### PR TITLE
collections: trim native vector search hot-path overhead

### DIFF
--- a/TreeDB/collections/column_vector_graph_block_view.go
+++ b/TreeDB/collections/column_vector_graph_block_view.go
@@ -152,14 +152,14 @@ func (p *columnVectorGraphSearchPlan) blockViewForAssetOrdinal(assetOrdinal int)
 		}
 		p.physicalReader = reader
 	}
+	if reader.closed {
+		return nil, errors.New("collections: physical column row reader is closed")
+	}
 	if len(reader.ranges) == 1 && assetOrdinal == 0 {
 		if p.singleBlockView != nil {
 			p.hits++
 			return p.singleBlockView, nil
 		}
-	}
-	if reader.closed {
-		return nil, errors.New("collections: physical column row reader is closed")
 	}
 	if assetOrdinal < 0 || assetOrdinal >= len(reader.ranges) {
 		return nil, fmt.Errorf("collections: column_graph block view asset ordinal=%d outside ranges=%d", assetOrdinal, len(reader.ranges))

--- a/TreeDB/collections/column_vector_graph_block_view.go
+++ b/TreeDB/collections/column_vector_graph_block_view.go
@@ -32,11 +32,13 @@ type columnVectorGraphAdjacencySpan struct {
 }
 
 type columnVectorGraphSearchPlan struct {
-	reader     *columnVectorGraphPhysicalRowReader
-	blockViews map[int]*columnVectorGraphBlockView
-	hits       uint64
-	misses     uint64
-	builds     uint64
+	reader          *columnVectorGraphPhysicalRowReader
+	physicalReader  *columnPhysicalRowReader
+	blockViews      map[int]*columnVectorGraphBlockView
+	singleBlockView *columnVectorGraphBlockView
+	hits            uint64
+	misses          uint64
+	builds          uint64
 }
 
 func (s *columnVectorGraphNativeSearchScratch) prepareSearchPlan(reader *columnVectorGraphPhysicalRowReader) (*columnVectorGraphSearchPlan, error) {
@@ -46,7 +48,8 @@ func (s *columnVectorGraphNativeSearchScratch) prepareSearchPlan(reader *columnV
 	if reader == nil {
 		return nil, errNilColumnVectorGraphPhysicalRowReader
 	}
-	if _, err := reader.rowReader(); err != nil {
+	physicalReader, err := reader.rowReader()
+	if err != nil {
 		return nil, err
 	}
 	plan := &s.searchPlan
@@ -55,7 +58,9 @@ func (s *columnVectorGraphNativeSearchScratch) prepareSearchPlan(reader *columnV
 			delete(plan.blockViews, k)
 		}
 		plan.reader = reader
+		plan.singleBlockView = nil
 	}
+	plan.physicalReader = physicalReader
 	plan.hits = 0
 	plan.misses = 0
 	plan.builds = 0
@@ -76,19 +81,31 @@ func newColumnVectorGraphSearchPlan(reader *columnVectorGraphPhysicalRowReader) 
 	if reader == nil {
 		return nil, errNilColumnVectorGraphPhysicalRowReader
 	}
-	if _, err := reader.rowReader(); err != nil {
+	physicalReader, err := reader.rowReader()
+	if err != nil {
 		return nil, err
 	}
-	return &columnVectorGraphSearchPlan{reader: reader}, nil
+	return &columnVectorGraphSearchPlan{reader: reader, physicalReader: physicalReader}, nil
 }
 
 func (p *columnVectorGraphSearchPlan) ordinalRef(ordinal int) (columnVectorGraphOrdinalRef, error) {
 	if p == nil || p.reader == nil {
 		return columnVectorGraphOrdinalRef{}, errNilColumnVectorGraphPhysicalRowReader
 	}
-	reader, err := p.reader.rowReader()
-	if err != nil {
-		return columnVectorGraphOrdinalRef{}, err
+	reader := p.physicalReader
+	if reader == nil {
+		var err error
+		reader, err = p.reader.rowReader()
+		if err != nil {
+			return columnVectorGraphOrdinalRef{}, err
+		}
+		p.physicalReader = reader
+	}
+	if len(reader.ranges) == 1 {
+		if uint64(ordinal) >= uint64(reader.totalRows) {
+			return columnVectorGraphOrdinalRef{}, fmt.Errorf("collections: physical column row ordinal=%d outside row_count=%d: %w", ordinal, reader.totalRows, errColumnPhysicalRowOrdinalOutOfBounds)
+		}
+		return columnVectorGraphOrdinalRef{assetOrdinal: 0, rowIndex: ordinal}, nil
 	}
 	rangeIdx := reader.rangeIndexForOrdinal(ordinal)
 	if rangeIdx < 0 {
@@ -102,6 +119,16 @@ func (p *columnVectorGraphSearchPlan) ordinalRef(ordinal int) (columnVectorGraph
 }
 
 func (p *columnVectorGraphSearchPlan) blockViewForOrdinal(ordinal int) (*columnVectorGraphBlockView, columnVectorGraphOrdinalRef, error) {
+	if p != nil && p.physicalReader != nil && len(p.physicalReader.ranges) == 1 {
+		if uint64(ordinal) >= uint64(p.physicalReader.totalRows) {
+			return nil, columnVectorGraphOrdinalRef{}, fmt.Errorf("collections: physical column row ordinal=%d outside row_count=%d: %w", ordinal, p.physicalReader.totalRows, errColumnPhysicalRowOrdinalOutOfBounds)
+		}
+		view, err := p.blockViewForAssetOrdinal(0)
+		if err != nil {
+			return nil, columnVectorGraphOrdinalRef{}, err
+		}
+		return view, columnVectorGraphOrdinalRef{assetOrdinal: 0, rowIndex: ordinal}, nil
+	}
 	ref, err := p.ordinalRef(ordinal)
 	if err != nil {
 		return nil, columnVectorGraphOrdinalRef{}, err
@@ -117,9 +144,20 @@ func (p *columnVectorGraphSearchPlan) blockViewForAssetOrdinal(assetOrdinal int)
 	if p == nil || p.reader == nil {
 		return nil, errNilColumnVectorGraphPhysicalRowReader
 	}
-	reader, err := p.reader.rowReader()
-	if err != nil {
-		return nil, err
+	reader := p.physicalReader
+	if reader == nil {
+		var err error
+		reader, err = p.reader.rowReader()
+		if err != nil {
+			return nil, err
+		}
+		p.physicalReader = reader
+	}
+	if len(reader.ranges) == 1 && assetOrdinal == 0 {
+		if p.singleBlockView != nil {
+			p.hits++
+			return p.singleBlockView, nil
+		}
 	}
 	if assetOrdinal < 0 || assetOrdinal >= len(reader.ranges) {
 		return nil, fmt.Errorf("collections: column_graph block view asset ordinal=%d outside ranges=%d", assetOrdinal, len(reader.ranges))
@@ -140,16 +178,20 @@ func (p *columnVectorGraphSearchPlan) blockViewForAssetOrdinal(assetOrdinal int)
 		return nil, err
 	}
 	p.builds++
-	if p.blockViews == nil {
-		p.blockViews = make(map[int]*columnVectorGraphBlockView, reader.maxBlocks)
-	}
-	if reader.maxBlocks > 0 && len(p.blockViews) >= reader.maxBlocks {
-		for existing := range p.blockViews {
-			delete(p.blockViews, existing)
-			break
+	if len(reader.ranges) == 1 && assetOrdinal == 0 {
+		p.singleBlockView = view
+	} else {
+		if p.blockViews == nil {
+			p.blockViews = make(map[int]*columnVectorGraphBlockView, reader.maxBlocks)
 		}
+		if reader.maxBlocks > 0 && len(p.blockViews) >= reader.maxBlocks {
+			for existing := range p.blockViews {
+				delete(p.blockViews, existing)
+				break
+			}
+		}
+		p.blockViews[assetOrdinal] = view
 	}
-	p.blockViews[assetOrdinal] = view
 	return view, nil
 }
 

--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -56,9 +56,8 @@ type columnVectorGraphNativeSearchResult struct {
 }
 
 type columnVectorGraphSearchCandidate struct {
-	ordinal   int
-	score     float64
-	adjacency []uint32
+	ordinal int
+	score   float64
 }
 
 // columnVectorGraphNativeSearchScratch is caller-owned mutable search state.
@@ -76,7 +75,6 @@ type columnVectorGraphNativeSearchScratch struct {
 	idBuffers      [][]byte
 	resultOrder    []int
 	resultOrdinals []int
-	adjacencyBuf   []uint32
 	searchPlan     columnVectorGraphSearchPlan
 }
 
@@ -103,20 +101,12 @@ func (s *columnVectorGraphNativeSearchScratch) prepare(rowCount, dimensions, deg
 	if frontierCap < topK {
 		frontierCap = topK
 	}
-	adjacencyCap := 0
-	if frontierCap > 0 && degree > 0 {
-		if frontierCap > math.MaxInt/degree {
-			return fmt.Errorf("collections: column_graph native search adjacency scratch overflows: frontierCap=%d degree=%d", frontierCap, degree)
-		}
-		adjacencyCap = frontierCap * degree
-	}
 	s.frontier = resizeColumnVectorGraphNativeCandidateScratch(s.frontier, frontierCap)
 	s.top = resizeColumnVectorGraphNativeCandidateScratch(s.top, topK)
 	s.results = resizeColumnVectorGraphNativeResultScratch(s.results, topK)
 	s.idBuffers = resizeColumnVectorGraphNativeIDBuffersScratch(s.idBuffers, topK)
 	s.resultOrder = resizeColumnVectorGraphNativeIntScratch(s.resultOrder, topK)
 	s.resultOrdinals = resizeColumnVectorGraphNativeIntScratch(s.resultOrdinals, topK)
-	s.adjacencyBuf = resizeColumnVectorGraphNativeUint32Scratch(s.adjacencyBuf, adjacencyCap)
 	return nil
 }
 
@@ -140,19 +130,10 @@ func prepareColumnVectorGraphNativeRowScratch(s *columnPhysicalRowReaderScratch,
 }
 
 func resizeColumnVectorGraphNativeCandidateScratch(dst []columnVectorGraphSearchCandidate, target int) []columnVectorGraphSearchCandidate {
-	if len(dst) > 0 {
-		clearColumnVectorGraphNativeCandidateAdjacencyRefs(dst)
-	}
 	if cap(dst) < target || columnVectorGraphNativeScratchCapOversized(cap(dst), target) {
 		return make([]columnVectorGraphSearchCandidate, 0, target)
 	}
 	return dst[:0]
-}
-
-func clearColumnVectorGraphNativeCandidateAdjacencyRefs(candidates []columnVectorGraphSearchCandidate) {
-	for i := range candidates {
-		candidates[i].adjacency = nil
-	}
 }
 
 func resizeColumnVectorGraphNativeResultScratch(dst []columnVectorGraphNativeSearchResult, target int) []columnVectorGraphNativeSearchResult {
@@ -178,13 +159,6 @@ func resizeColumnVectorGraphNativeUint64Scratch(dst []uint64, target int) []uint
 		return make([]uint64, target)
 	}
 	return dst[:target]
-}
-
-func resizeColumnVectorGraphNativeUint32Scratch(dst []uint32, target int) []uint32 {
-	if cap(dst) < target || columnVectorGraphNativeScratchCapOversized(cap(dst), target) {
-		return make([]uint32, 0, target)
-	}
-	return dst[:0]
 }
 
 func resizeColumnVectorGraphNativeIDBuffersScratch(dst [][]byte, target int) [][]byte {
@@ -456,7 +430,6 @@ func (s *columnVectorGraphNativeSearchScratch) popFrontier() (columnVectorGraphS
 	lastIdx := len(s.frontier) - 1
 	best := s.frontier[0]
 	last := s.frontier[lastIdx]
-	s.frontier[lastIdx].adjacency = nil
 	s.frontier = s.frontier[:lastIdx]
 	if len(s.frontier) > 0 {
 		s.frontier[0] = last

--- a/TreeDB/collections/column_vector_graph_search_test.go
+++ b/TreeDB/collections/column_vector_graph_search_test.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"unsafe"
 )
 
 const columnVectorGraphNativeSearchParallelBenchMaxWorkersV3 = 8
@@ -146,46 +147,10 @@ func TestColumnVectorGraphNativeSearchKeepsExpansionAdjacencyStableV3(t *testing
 	}
 }
 
-func TestColumnVectorGraphNativeSearchScratchClearsCandidateAdjacencyRefsV3(t *testing.T) {
-	var scratch columnVectorGraphNativeSearchScratch
-	scratch.frontier = append(scratch.frontier, columnVectorGraphSearchCandidate{
-		ordinal:   1,
-		score:     1,
-		adjacency: []uint32{1, 2},
-	})
-	scratch.top = append(scratch.top, columnVectorGraphSearchCandidate{
-		ordinal:   2,
-		score:     2,
-		adjacency: []uint32{3, 4},
-	})
-	if err := scratch.prepare(4, 3, 2, 1, 2); err != nil {
-		t.Fatalf("prepare: %v", err)
-	}
-	assertColumnVectorGraphCandidateScratchNoAdjacencyRefsV3(t, "frontier after prepare", scratch.frontier)
-	assertColumnVectorGraphCandidateScratchNoAdjacencyRefsV3(t, "top after prepare", scratch.top)
-
-	scratch.frontier = append(scratch.frontier,
-		columnVectorGraphSearchCandidate{ordinal: 1, score: 1, adjacency: []uint32{1}},
-		columnVectorGraphSearchCandidate{ordinal: 2, score: 2, adjacency: []uint32{2}},
-	)
-	if _, ok := scratch.popFrontier(); !ok {
-		t.Fatalf("popFrontier returned ok=false")
-	}
-	backing := scratch.frontier[:cap(scratch.frontier)]
-	for i := len(scratch.frontier); i < len(backing); i++ {
-		if backing[i].adjacency != nil {
-			t.Fatalf("frontier backing slot %d retained adjacency %v after pop", i, backing[i].adjacency)
-		}
-	}
-}
-
-func assertColumnVectorGraphCandidateScratchNoAdjacencyRefsV3(t *testing.T, label string, candidates []columnVectorGraphSearchCandidate) {
-	t.Helper()
-	backing := candidates[:cap(candidates)]
-	for i, candidate := range backing {
-		if candidate.adjacency != nil {
-			t.Fatalf("%s backing slot %d retained adjacency %v", label, i, candidate.adjacency)
-		}
+func TestColumnVectorGraphNativeSearchCandidateCarriesNoAdjacencyV3(t *testing.T) {
+	candidate := columnVectorGraphSearchCandidate{ordinal: 1, score: 1}
+	if got, want := unsafe.Sizeof(candidate), uintptr(16); got != want {
+		t.Fatalf("candidate size=%d want compact ordinal+score size=%d", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary

Follow-on to #1723. This PR trims native vector search hot-path overhead identified in the clean #1723 profile.

Scope:

- Remove obsolete `adjacency []uint32` from `columnVectorGraphSearchCandidate`.
- Remove obsolete adjacency scratch/copy helper state from native search scratch.
- Add single-range/single-block fast paths in `columnVectorGraphSearchPlan`.
- Keep search behavior, lazy adjacency, and block-view top-k materialization unchanged.

## What Changed

- `columnVectorGraphSearchCandidate` is now compact ordinal+score only.
- Frontier/top-k swaps no longer copy a stale slice header.
- `prepare` no longer computes or reserves eager adjacency scratch capacity.
- `columnVectorGraphSearchPlan` caches the physical reader and single block view.
- Single-range graph assets bypass repeated `rangeIndexForOrdinal` and map lookups.

## Validation

```sh
go test ./TreeDB/collections
# ok github.com/snissn/gomap/TreeDB/collections 19.290s
```

Benchmark smoke on Apple M3, darwin/arm64:

```sh
go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnVectorGraphNativeSearchCosineProduction8192V3$' -benchtime=100x -count=1
# 8019 ns/op, 0 B/op, 0 allocs/op

go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnVectorGraphNativeSearchCosineParallelProduction8192V3$' -benchtime=100x -count=1
# 2329 ns/op, 50 B/op, 0 allocs/op
```

## Profile Evidence

Fresh profile artifacts:

```text
/tmp/pr1724_hotpath_profile_20260521_210633
```

Key files:

```text
serial/bench.txt
serial/cpu.pprof
serial/cpu_top.txt
serial/list_hot.txt
parallel/bench.txt
parallel/cpu.pprof
parallel/cpu_top.txt
parallel/list_hot.txt
```

Profile benchmark run:

| Benchmark | ns/op | ops/sec | B/op | allocs/op | candidates/search | edges/search | decoded_blocks/search | physical_B/search |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Serial production 8192 | 8,291 | 120,613 | 0 | 0 | 128 | 612 | 0 | 0 |
| Parallel production 8192 | 1,938 | 515,996 | 0 | 0 | 128 | 612 | 0 | 0 |

Profile cleanliness check: CPU top does not show generic row materialization/build contamination:

- `fetchRowUnchecked`
- `fetchRow`
- `decodeRowFromBlock`
- `readColumnPhysicalRowValuesIntoScratch`
- `readSelectedColumnPhysicalValueIntoScratch`
- `RebuildVectorIndex`
- `InsertBatch`
- `buildColumnVectorGraphAdjacency`

## Before / After Evidence

Against #1723 profile run on the same Apple M3 machine:

| Benchmark | #1723 profile ns/op | This PR profile ns/op | ops/sec after | delta |
| --- | ---: | ---: | ---: | ---: |
| Serial production 8192 | 12,805 | 8,291 | 120,613 | -35.3% |
| Parallel production 8192 | 2,821 | 1,938 | 515,996 | -31.3% |

Against the original clean post-SIMD baseline from `/tmp/pr1713_native_hot_profile_20260521_172315`:

| Benchmark | baseline ns/op | This PR profile ns/op | ops/sec after | delta |
| --- | ---: | ---: | ---: | ---: |
| Serial production 8192 | 30,035 | 8,291 | 120,613 | -72.4% |
| Parallel production 8192 | 7,072 | 1,938 | 515,996 | -72.6% |

## Hotspot Movement

The targeted bottlenecks moved as expected:

| Area | #1723 serial evidence | This PR serial evidence |
| --- | ---: | ---: |
| `blockViewForOrdinal` | 16.64% cum | 3.95% cum |
| `ordinalRef` | 10.68% cum | no longer in top output |
| `rangeIndexForOrdinal` | 4.90% cum | no longer in top output |
| `duffcopy` | 5.95% flat | no longer in top output |
| `frontierSiftUp` | 10.33% cum | 5.57% cum |
| `insertTop` | 5.78% cum | 2.15% cum |

Current leading expected costs are now vector math, adjacency decode/validation, and remaining frontier/top-k mechanics.

## Stack

- Depends on #1723.
- No PRs merged.
