### PR TITLE
collections: use direct adjacency views for column graph

### DIFF
--- a/TreeDB/collections/column_physical_asset.go
+++ b/TreeDB/collections/column_physical_asset.go
@@ -388,7 +388,9 @@ func encodeColumnPhysicalAsset(input columnPhysicalAssetEncodeInput) ([]byte, co
 					return nil, columnPhysicalAssetSummary{}, fmt.Errorf("collections: column physical asset row value column[%d] float32_vector: %w", colIdx, err)
 				}
 			case ColumnStoreValueAdjacencyList:
-				writeManifestUint32Slice(&b, value.AdjacencyList)
+				if err := writeManifestUint32SliceWithEncoding(&b, value.AdjacencyList, col.FixedWidthEncoding); err != nil {
+					return nil, columnPhysicalAssetSummary{}, fmt.Errorf("collections: column physical asset row value column[%d] adjacency_list: %w", colIdx, err)
+				}
 			default:
 				return nil, columnPhysicalAssetSummary{}, fmt.Errorf("collections: unsupported column physical value type %q", value.Type)
 			}
@@ -505,7 +507,7 @@ func decodeColumnPhysicalAsset(raw []byte) (columnPhysicalAsset, error) {
 							value.Float32Vector = cur.float32Slice()
 						}
 					case ColumnStoreValueAdjacencyList:
-						value.AdjacencyList = cur.uint32Slice()
+						value.AdjacencyList = cur.uint32SliceWithEncoding(asset.Columns[colIdx].FixedWidthEncoding)
 					default:
 						return columnPhysicalAsset{}, fmt.Errorf("collections: unsupported column physical value type %q", value.Type)
 					}
@@ -704,12 +706,28 @@ func writeManifestFloat32SliceWithEncoding(b *bytes.Buffer, values []float32, en
 }
 
 func writeManifestUint32Slice(b *bytes.Buffer, values []uint32) {
+	_ = writeManifestUint32SliceWithEncoding(b, values, ColumnFixedWidthEncodingDefault)
+}
+
+func writeManifestUint32SliceWithEncoding(b *bytes.Buffer, values []uint32, encoding ColumnFixedWidthEncoding) error {
+	littleEndian, err := columnFixedWidthEncodingIsLittleEndian(encoding)
+	if err != nil {
+		return err
+	}
 	writeManifestUint64(b, uint64(len(values)))
 	var buf [4]byte
+	if littleEndian {
+		for _, value := range values {
+			binary.LittleEndian.PutUint32(buf[:], value)
+			_, _ = b.Write(buf[:])
+		}
+		return nil
+	}
 	for _, value := range values {
 		binary.BigEndian.PutUint32(buf[:], value)
 		_, _ = b.Write(buf[:])
 	}
+	return nil
 }
 
 func (c *manifestCursor) bool() bool {
@@ -806,6 +824,10 @@ func (c *manifestCursor) float32SliceAfterLengthWithEncoding(n uint64, encoding 
 }
 
 func (c *manifestCursor) uint32Slice() []uint32 {
+	return c.uint32SliceWithEncoding(ColumnFixedWidthEncodingDefault)
+}
+
+func (c *manifestCursor) uint32SliceWithEncoding(encoding ColumnFixedWidthEncoding) []uint32 {
 	n := c.u64()
 	if c.err != nil {
 		return nil
@@ -814,9 +836,18 @@ func (c *manifestCursor) uint32Slice() []uint32 {
 	if !ok {
 		return nil
 	}
+	littleEndian, err := columnFixedWidthEncodingIsLittleEndian(encoding)
+	if err != nil {
+		c.err = fmt.Errorf("collections: unsupported fixed_width_encoding %q", encoding)
+		return nil
+	}
 	out := make([]uint32, int(n))
 	for i := range out {
-		out[i] = binary.BigEndian.Uint32(c.raw[c.pos:])
+		if littleEndian {
+			out[i] = binary.LittleEndian.Uint32(c.raw[c.pos:])
+		} else {
+			out[i] = binary.BigEndian.Uint32(c.raw[c.pos:])
+		}
 		c.pos += 4
 	}
 	return out

--- a/TreeDB/collections/column_physical_row_reader.go
+++ b/TreeDB/collections/column_physical_row_reader.go
@@ -693,7 +693,7 @@ func readSelectedColumnPhysicalValueIntoScratch(cur *manifestCursor, col ColumnS
 	case ColumnStoreValueAdjacencyList:
 		start := len(scratch.Uint32Values)
 		var err error
-		scratch.Uint32Values, err = cur.appendUint32Slice(scratch.Uint32Values)
+		scratch.Uint32Values, err = cur.appendUint32SliceWithEncoding(scratch.Uint32Values, col.FixedWidthEncoding)
 		if err != nil {
 			return err
 		}
@@ -796,12 +796,21 @@ func columnPhysicalCopyLittleEndianFloat32Bytes(dst []float32, raw []byte) {
 }
 
 func (c *manifestCursor) appendUint32Slice(dst []uint32) ([]uint32, error) {
+	return c.appendUint32SliceWithEncoding(dst, ColumnFixedWidthEncodingDefault)
+}
+
+func (c *manifestCursor) appendUint32SliceWithEncoding(dst []uint32, encoding ColumnFixedWidthEncoding) ([]uint32, error) {
 	n := c.u64()
 	if c.err != nil {
 		return dst, c.err
 	}
 	byteLen, ok := c.fixedWidthSliceByteLen(n, 4, "uint32 slice")
 	if !ok {
+		return dst, c.err
+	}
+	littleEndian, err := columnFixedWidthEncodingIsLittleEndian(encoding)
+	if err != nil {
+		c.err = fmt.Errorf("collections: unsupported fixed_width_encoding %q", encoding)
 		return dst, c.err
 	}
 	base := len(dst)
@@ -813,26 +822,37 @@ func (c *manifestCursor) appendUint32Slice(dst []uint32) ([]uint32, error) {
 	} else {
 		dst = dst[:need]
 	}
-	// Keep cursor state out of the per-element loop; vector search decodes
-	// these fixed-width slices for every candidate row fetch.
 	pos := c.pos
 	end := pos + int(byteLen)
 	raw := c.raw
 	if pos < end {
-		_ = raw[end-1] // BCE: prove the full [pos, end) range before the loop.
+		_ = raw[end-1]
+	}
+	if littleEndian && columnPhysicalNativeLittleEndian {
+		dstBytes := unsafe.Slice((*byte)(unsafe.Pointer(unsafe.SliceData(dst[base:need]))), int(byteLen))
+		copy(dstBytes, raw[pos:end])
+		c.pos = end
+		return dst, nil
 	}
 	i := base
-	for ; i+4 <= need; i += 4 {
-		_ = raw[pos+15] // BCE: each unrolled iteration reads exactly 16 bytes.
-		dst[i] = uint32(raw[pos])<<24 | uint32(raw[pos+1])<<16 | uint32(raw[pos+2])<<8 | uint32(raw[pos+3])
-		dst[i+1] = uint32(raw[pos+4])<<24 | uint32(raw[pos+5])<<16 | uint32(raw[pos+6])<<8 | uint32(raw[pos+7])
-		dst[i+2] = uint32(raw[pos+8])<<24 | uint32(raw[pos+9])<<16 | uint32(raw[pos+10])<<8 | uint32(raw[pos+11])
-		dst[i+3] = uint32(raw[pos+12])<<24 | uint32(raw[pos+13])<<16 | uint32(raw[pos+14])<<8 | uint32(raw[pos+15])
-		pos += 16
-	}
-	for ; i < need; i++ {
-		dst[i] = uint32(raw[pos])<<24 | uint32(raw[pos+1])<<16 | uint32(raw[pos+2])<<8 | uint32(raw[pos+3])
-		pos += 4
+	if littleEndian {
+		for ; i < need; i++ {
+			dst[i] = uint32(raw[pos]) | uint32(raw[pos+1])<<8 | uint32(raw[pos+2])<<16 | uint32(raw[pos+3])<<24
+			pos += 4
+		}
+	} else {
+		for ; i+4 <= need; i += 4 {
+			_ = raw[pos+15]
+			dst[i] = uint32(raw[pos])<<24 | uint32(raw[pos+1])<<16 | uint32(raw[pos+2])<<8 | uint32(raw[pos+3])
+			dst[i+1] = uint32(raw[pos+4])<<24 | uint32(raw[pos+5])<<16 | uint32(raw[pos+6])<<8 | uint32(raw[pos+7])
+			dst[i+2] = uint32(raw[pos+8])<<24 | uint32(raw[pos+9])<<16 | uint32(raw[pos+10])<<8 | uint32(raw[pos+11])
+			dst[i+3] = uint32(raw[pos+12])<<24 | uint32(raw[pos+13])<<16 | uint32(raw[pos+14])<<8 | uint32(raw[pos+15])
+			pos += 16
+		}
+		for ; i < need; i++ {
+			dst[i] = uint32(raw[pos])<<24 | uint32(raw[pos+1])<<16 | uint32(raw[pos+2])<<8 | uint32(raw[pos+3])
+			pos += 4
+		}
 	}
 	c.pos = end
 	return dst, nil

--- a/TreeDB/collections/column_physical_scan.go
+++ b/TreeDB/collections/column_physical_scan.go
@@ -2039,7 +2039,7 @@ func scanColumnPhysicalRowValues(cur *manifestCursor, version uint16, cfg *Colum
 			}
 		case ColumnStoreValueAdjacencyList:
 			if selected {
-				rowValues[outputIdx].AdjacencyList = cur.uint32Slice()
+				rowValues[outputIdx].AdjacencyList = cur.uint32SliceWithEncoding(col.FixedWidthEncoding)
 				if cur.err != nil {
 					return cur.err
 				}

--- a/TreeDB/collections/column_store.go
+++ b/TreeDB/collections/column_store.go
@@ -602,7 +602,7 @@ func columnFixedWidthEncodingIsLittleEndian(encoding ColumnFixedWidthEncoding) (
 
 func columnStoreValueTypeSupportsFixedWidthEncoding(valueType ColumnStoreValueType) bool {
 	switch valueType {
-	case ColumnStoreValueFloat32Vector:
+	case ColumnStoreValueFloat32Vector, ColumnStoreValueAdjacencyList:
 		return true
 	default:
 		return false

--- a/TreeDB/collections/column_store_test.go
+++ b/TreeDB/collections/column_store_test.go
@@ -432,14 +432,6 @@ func TestColumnStoreMetadataValidation(t *testing.T) {
 			want: "fixed_width_encoding",
 		},
 		{
-			name: "adjacency fixed width encoding rejected",
-			cfg: &ColumnStoreConfig{
-				Enabled: true,
-				Columns: []ColumnStoreColumn{{Name: "neighbors", Path: "neighbors", ValueType: ColumnStoreValueAdjacencyList, FixedWidthEncoding: ColumnFixedWidthEncodingLittleEndian}},
-			},
-			want: "fixed_width_encoding",
-		},
-		{
 			name: "unsupported locator",
 			cfg: &ColumnStoreConfig{
 				Enabled: true,
@@ -565,6 +557,20 @@ func TestColumnStoreMetadataValidation(t *testing.T) {
 				t.Fatalf("normalizeCollectionMeta err=%v want %q", err, tt.want)
 			}
 		})
+	}
+}
+
+func TestColumnStoreAdjacencyFixedWidthEncodingNormalizes(t *testing.T) {
+	cfg := testColumnStoreConfig(nil)
+	cfg.Columns = []ColumnStoreColumn{{Name: "neighbors", Path: "neighbors", ValueType: ColumnStoreValueAdjacencyList, FixedWidthEncoding: ColumnFixedWidthEncodingLittleEndian}}
+	cfg.SortKey = nil
+	cfg.AggregateMetadata = nil
+	meta, err := normalizeCollectionMeta(CollectionMeta{Name: "events", Options: CollectionOptions{ColumnStore: cfg}})
+	if err != nil {
+		t.Fatalf("normalizeCollectionMeta: %v", err)
+	}
+	if got := meta.Options.ColumnStore.Columns[0].FixedWidthEncoding; got != ColumnFixedWidthEncodingLittleEndian {
+		t.Fatalf("adjacency fixed_width_encoding=%q want %q", got, ColumnFixedWidthEncodingLittleEndian)
 	}
 }
 

--- a/TreeDB/collections/column_vector_graph_block_view.go
+++ b/TreeDB/collections/column_vector_graph_block_view.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"unsafe"
 )
 
 var errColumnVectorGraphBlockViewRowOutOfBounds = errors.New("column_graph block view row outside block")
@@ -421,10 +422,11 @@ func (v *columnVectorGraphBlockView) adjacency(rowIndex int, scratch []uint32) (
 	if span.count == 0 {
 		return nil, scratch, true, nil
 	}
-	if v.adjacencyLittleEndian() && columnPhysicalNativeLittleEndian {
-		raw := v.block.raw[span.start:span.end]
-		adjacency := unsafe.Slice((*uint32)(unsafe.Pointer(unsafe.SliceData(raw))), span.count)
-		return adjacency, scratch, true, nil
+	if v.adjacencyLittleEndian() {
+		adjacency, ok := columnVectorGraphLittleEndianUint32DirectView(v.block.raw[span.start:span.end], span.count)
+		if ok {
+			return adjacency, scratch, true, nil
+		}
 	}
 	base := len(scratch)
 	need := base + span.count
@@ -448,6 +450,17 @@ func (v *columnVectorGraphBlockView) adjacency(rowIndex int, scratch []uint32) (
 		pos += 4
 	}
 	return scratch[base:], scratch, false, nil
+}
+
+func columnVectorGraphLittleEndianUint32DirectView(raw []byte, count int) ([]uint32, bool) {
+	if !columnPhysicalNativeLittleEndian || count <= 0 || len(raw) != count*4 {
+		return nil, false
+	}
+	ptr := unsafe.Pointer(unsafe.SliceData(raw))
+	if uintptr(ptr)%unsafe.Alignof(uint32(0)) != 0 {
+		return nil, false
+	}
+	return unsafe.Slice((*uint32)(ptr), count), true
 }
 
 func (v *columnVectorGraphBlockView) adjacencyLittleEndian() bool {

--- a/TreeDB/collections/column_vector_graph_block_view.go
+++ b/TreeDB/collections/column_vector_graph_block_view.go
@@ -412,11 +412,19 @@ func (v *columnVectorGraphBlockView) invNorm(rowIndex int) (float32, error) {
 	return v.invNorms[rowIndex], nil
 }
 
-func (v *columnVectorGraphBlockView) adjacency(rowIndex int, scratch []uint32) ([]uint32, []uint32, error) {
+func (v *columnVectorGraphBlockView) adjacency(rowIndex int, scratch []uint32) ([]uint32, []uint32, bool, error) {
 	if err := v.checkRowIndex(rowIndex); err != nil {
-		return nil, scratch, err
+		return nil, scratch, false, err
 	}
 	span := v.adjSpans[rowIndex]
+	if span.count == 0 {
+		return nil, scratch, true, nil
+	}
+	if v.adjacencyLittleEndian() && columnPhysicalNativeLittleEndian {
+		raw := v.block.raw[span.start:span.end]
+		adjacency := unsafe.Slice((*uint32)(unsafe.Pointer(unsafe.SliceData(raw))), span.count)
+		return adjacency, scratch, true, nil
+	}
 	base := len(scratch)
 	need := base + span.count
 	if cap(scratch) < need {
@@ -427,11 +435,29 @@ func (v *columnVectorGraphBlockView) adjacency(rowIndex int, scratch []uint32) (
 		scratch = scratch[:need]
 	}
 	pos := span.start
+	if v.adjacencyLittleEndian() {
+		for i := base; i < need; i++ {
+			scratch[i] = uint32(v.block.raw[pos]) | uint32(v.block.raw[pos+1])<<8 | uint32(v.block.raw[pos+2])<<16 | uint32(v.block.raw[pos+3])<<24
+			pos += 4
+		}
+		return scratch[base:], scratch, false, nil
+	}
 	for i := base; i < need; i++ {
 		scratch[i] = uint32(v.block.raw[pos])<<24 | uint32(v.block.raw[pos+1])<<16 | uint32(v.block.raw[pos+2])<<8 | uint32(v.block.raw[pos+3])
 		pos += 4
 	}
-	return scratch[base:], scratch, nil
+	return scratch[base:], scratch, false, nil
+}
+
+func (v *columnVectorGraphBlockView) adjacencyLittleEndian() bool {
+	if v == nil || v.reader == nil || v.reader.reader == nil {
+		return false
+	}
+	cols := v.reader.reader.view.Config.Columns
+	if len(cols) <= columnVectorGraphPhysicalRowValueAdjacency {
+		return false
+	}
+	return cols[columnVectorGraphPhysicalRowValueAdjacency].FixedWidthEncoding == ColumnFixedWidthEncodingLittleEndian
 }
 
 func columnVectorGraphReadBytesSpan(cur *manifestCursor) (int, int, error) {

--- a/TreeDB/collections/column_vector_graph_block_view_test.go
+++ b/TreeDB/collections/column_vector_graph_block_view_test.go
@@ -82,12 +82,19 @@ func TestColumnVectorGraphBlockViewAccessorsV1(t *testing.T) {
 	if math.Abs(float64(invNorm-1)) > 1e-6 {
 		t.Fatalf("invNorm=%v want 1", invNorm)
 	}
-	adjacency, adjacencyScratch, err := view.adjacency(ref.rowIndex, nil)
+	adjacency, adjacencyScratch, direct, err := view.adjacency(ref.rowIndex, nil)
 	if err != nil {
 		t.Fatalf("adjacency: %v", err)
 	}
-	if !slices.Equal(adjacency, []uint32{0}) || !slices.Equal(adjacencyScratch, []uint32{0}) {
-		t.Fatalf("adjacency=%v scratch=%v want [0]", adjacency, adjacencyScratch)
+	if !slices.Equal(adjacency, []uint32{0}) {
+		t.Fatalf("adjacency=%v want [0]", adjacency)
+	}
+	if columnPhysicalNativeLittleEndian {
+		if !direct || len(adjacencyScratch) != 0 {
+			t.Fatalf("direct=%t scratch=%v want direct adjacency view with no scratch", direct, adjacencyScratch)
+		}
+	} else if direct || !slices.Equal(adjacencyScratch, []uint32{0}) {
+		t.Fatalf("direct=%t scratch=%v want scratch adjacency decode", direct, adjacencyScratch)
 	}
 	stats := reader.Stats()
 	if stats.RowFetches != 0 || stats.RowsFetched != 0 {

--- a/TreeDB/collections/column_vector_graph_block_view_test.go
+++ b/TreeDB/collections/column_vector_graph_block_view_test.go
@@ -90,8 +90,11 @@ func TestColumnVectorGraphBlockViewAccessorsV1(t *testing.T) {
 		t.Fatalf("adjacency=%v want [0]", adjacency)
 	}
 	if columnPhysicalNativeLittleEndian {
-		if !direct || len(adjacencyScratch) != 0 {
-			t.Fatalf("direct=%t scratch=%v want direct adjacency view with no scratch", direct, adjacencyScratch)
+		if direct && len(adjacencyScratch) != 0 {
+			t.Fatalf("direct adjacency view used scratch=%v", adjacencyScratch)
+		}
+		if !direct && !slices.Equal(adjacencyScratch, []uint32{0}) {
+			t.Fatalf("scratch adjacency=%v want [0] when direct view is unaligned", adjacencyScratch)
 		}
 	} else if direct || !slices.Equal(adjacencyScratch, []uint32{0}) {
 		t.Fatalf("direct=%t scratch=%v want scratch adjacency decode", direct, adjacencyScratch)

--- a/TreeDB/collections/column_vector_graph_manifest.go
+++ b/TreeDB/collections/column_vector_graph_manifest.go
@@ -237,7 +237,7 @@ func columnVectorGraphPhysicalColumnStoreConfig(collection string, base ColumnSt
 		Columns: []ColumnStoreColumn{
 			{Name: columnVectorGraphVectorColumnName, Path: normalizedDef.Field, ValueType: ColumnStoreValueFloat32Vector, VectorDims: normalizedDef.Dimensions, FixedWidthEncoding: ColumnFixedWidthEncodingLittleEndian},
 			{Name: columnVectorGraphInvNormColumnName, Path: normalizedDef.Field + "_inv_norm", ValueType: ColumnStoreValueFloat32},
-			{Name: columnVectorGraphAdjacencyColumnName, Path: normalizedDef.Field + "_neighbors", ValueType: ColumnStoreValueAdjacencyList},
+			{Name: columnVectorGraphAdjacencyColumnName, Path: normalizedDef.Field + "_neighbors", ValueType: ColumnStoreValueAdjacencyList, FixedWidthEncoding: ColumnFixedWidthEncodingLittleEndian},
 		},
 		RetainedPayload: ColumnRetainedPayloadNone,
 		Reconstruction:  ColumnReconstructionRetainedPayloadAndColumns,

--- a/TreeDB/collections/column_vector_graph_manifest_test.go
+++ b/TreeDB/collections/column_vector_graph_manifest_test.go
@@ -90,8 +90,8 @@ func TestColumnVectorGraphPhysicalConfigUsesLittleEndianVectorOnlyM1C(t *testing
 		t.Fatalf("inv_norm fixed_width_encoding=%q want default", got)
 	}
 	adjacencyCol := columnVectorGraphPhysicalColumnForTestM1C(t, graphCfg.Columns, columnVectorGraphAdjacencyColumnName)
-	if got := adjacencyCol.FixedWidthEncoding; got != ColumnFixedWidthEncodingDefault {
-		t.Fatalf("adjacency fixed_width_encoding=%q want default", got)
+	if got := adjacencyCol.FixedWidthEncoding; got != ColumnFixedWidthEncodingLittleEndian {
+		t.Fatalf("adjacency fixed_width_encoding=%q want %q", got, ColumnFixedWidthEncodingLittleEndian)
 	}
 }
 
@@ -226,8 +226,8 @@ func TestColumnVectorGraphPhysicalAssetRoundTripV2A(t *testing.T) {
 		t.Fatalf("decoded inv_norm fixed_width_encoding=%q want default", got)
 	}
 	decodedAdjacencyCol := columnVectorGraphPhysicalColumnForTestM1C(t, decoded.Columns, columnVectorGraphAdjacencyColumnName)
-	if got := decodedAdjacencyCol.FixedWidthEncoding; got != ColumnFixedWidthEncodingDefault {
-		t.Fatalf("decoded adjacency fixed_width_encoding=%q want default", got)
+	if got := decodedAdjacencyCol.FixedWidthEncoding; got != ColumnFixedWidthEncodingLittleEndian {
+		t.Fatalf("decoded adjacency fixed_width_encoding=%q want %q", got, ColumnFixedWidthEncodingLittleEndian)
 	}
 	projection, err := newColumnPhysicalScanProjection(prepared.Config, []string{
 		columnVectorGraphVectorColumnName,

--- a/TreeDB/collections/column_vector_graph_row_reader.go
+++ b/TreeDB/collections/column_vector_graph_row_reader.go
@@ -477,7 +477,11 @@ func (r *columnVectorGraphPhysicalRowReader) readNativeGraphAdjacency(cur *manif
 	}
 	start := len(scratch.Uint32Values)
 	var err error
-	scratch.Uint32Values, err = cur.appendUint32Slice(scratch.Uint32Values)
+	encoding := ColumnFixedWidthEncodingDefault
+	if r.reader != nil && len(r.reader.view.Config.Columns) > columnVectorGraphPhysicalRowValueAdjacency {
+		encoding = r.reader.view.Config.Columns[columnVectorGraphPhysicalRowValueAdjacency].FixedWidthEncoding
+	}
+	scratch.Uint32Values, err = cur.appendUint32SliceWithEncoding(scratch.Uint32Values, encoding)
 	if err != nil {
 		return nil, err
 	}

--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -397,13 +397,17 @@ func (r *columnVectorGraphPhysicalRowReader) expandCandidateAdjacency(plan *colu
 		return nil, err
 	}
 	scratch.expandScratch.Uint32Values = scratch.expandScratch.Uint32Values[:0]
-	adjacency, adjacencyScratch, err := view.adjacency(ref.rowIndex, scratch.expandScratch.Uint32Values)
+	adjacency, adjacencyScratch, direct, err := view.adjacency(ref.rowIndex, scratch.expandScratch.Uint32Values)
 	if err != nil {
 		return nil, err
 	}
 	scratch.expandScratch.Uint32Values = adjacencyScratch
 	stats.AdjacencyExpansions++
-	stats.AdjacencyScratchDecodes++
+	if direct {
+		stats.AdjacencyDirectViews++
+	} else {
+		stats.AdjacencyScratchDecodes++
+	}
 	stats.BlockViewHits = plan.hits
 	stats.BlockViewMisses = plan.misses
 	stats.BlockViewBuilds = plan.builds


### PR DESCRIPTION
## Summary

Follow-on to #1724. This PR adds little-endian fixed-width adjacency-list encoding for column graph physical assets and uses direct adjacency views in the native block-view search path.

Scope:

- Allows `fixed_width_encoding: little_endian` for `adjacency_list` columns.
- Writes/reads adjacency payloads with the configured fixed-width encoding.
- Updates column_graph physical config so graph adjacency uses little-endian encoding.
- `columnVectorGraphBlockView.adjacency` returns direct `[]uint32` views on little-endian hosts.
- Generic row/scanner decode paths remain compatible through encoding-aware decode.

TreeDB is pre-alpha, so this intentionally changes the column_graph physical graph asset encoding without migration scaffolding.

## What Changed

- Added `writeManifestUint32SliceWithEncoding` and `uint32SliceWithEncoding`.
- Added `appendUint32SliceWithEncoding` for row-reader scratch decode fallback.
- Updated physical scan/asset decode paths for adjacency fixed-width encoding.
- Updated graph physical column config/tests to use little-endian adjacency.
- Updated native block-view adjacency accounting:
  - `adjacency_direct_views/search` is now 39.
  - `adjacency_scratch_decodes/search` is now 0.

## Validation

```sh
go test ./TreeDB/collections
# ok github.com/snissn/gomap/TreeDB/collections 16.155s
```

## Profile Evidence

Fresh profile artifacts:

```text
/tmp/pr1725_adj_direct_profile_20260521_211809
```

Key files:

```text
serial/bench.txt
serial/cpu.pprof
serial/cpu_top.txt
parallel/bench.txt
parallel/cpu.pprof
parallel/cpu_top.txt
```

Profile benchmark run on Apple M3, darwin/arm64:

| Benchmark | ns/op | ops/sec | B/op | allocs/op | adjacency_direct_views/search | adjacency_scratch_decodes/search | decoded_blocks/search | physical_B/search |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Serial production 8192 | 8,592 | 116,387 | 0 | 0 | 39 | 0 | 0 | 0 |
| Parallel production 8192 | 1,933 | 517,331 | 0 | 0 | 39 | 0 | 0 | 0 |

## Before / After Evidence

Against #1724 profile run on the same Apple M3 machine:

| Benchmark | #1724 profile ns/op | This PR profile ns/op | ops/sec after | delta |
| --- | ---: | ---: | ---: | ---: |
| Serial production 8192 | 8,291 | 8,592 | 116,387 | +3.6% |
| Parallel production 8192 | 1,938 | 1,933 | 517,331 | -0.3% |

## Notes

This PR achieves the intended path transition from scratch-decoded adjacency to direct adjacency views. The throughput impact is neutral/slightly mixed in this short profile because adjacency is now a smaller fraction of total search cost after #1724. It is still useful as an architectural foundation for keeping graph traversal aligned with typed physical block views.

## Stack

- Depends on #1724.
- Next planned PR: direct cosine helper to remove the temporary `columnVectorGraphPhysicalRow` wrapper in scoring.
