### PR TITLE
collections: call same-length vector dot product in native search

### DIFF
--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -531,7 +531,7 @@ func columnVectorGraphNativeCosineScoreVector(query []float32, queryInvNorm floa
 	if len(vector) != len(query) {
 		return 0, fmt.Errorf("collections: column_graph candidate ordinal=%d vector dims=%d want %d: %w", ordinal, len(vector), len(query), errColumnVectorGraphNativeSearchCandidateDimensionMismatch)
 	}
-	dot := float64(vectorDotProductFloat32(query, vector))
+	dot := float64(vectorDotProductFloat32SameLen(query, vector))
 	if !math.IsInf(dot, 0) && !math.IsNaN(dot) {
 		return dot * float64(queryInvNorm) * float64(invNorm), nil
 	}

--- a/TreeDB/collections/vector_dot_amd64.go
+++ b/TreeDB/collections/vector_dot_amd64.go
@@ -12,5 +12,12 @@ func vectorDotProductFloat32(left, right []float32) float32 {
 	if n == 0 {
 		return 0
 	}
-	return simdf32.DotProduct(left[:n], right[:n])
+	return vectorDotProductFloat32SameLen(left[:n], right[:n])
+}
+
+func vectorDotProductFloat32SameLen(left, right []float32) float32 {
+	if len(left) == 0 {
+		return 0
+	}
+	return simdf32.DotProduct(left, right)
 }

--- a/TreeDB/collections/vector_dot_arm64.go
+++ b/TreeDB/collections/vector_dot_arm64.go
@@ -2,7 +2,13 @@
 
 package collections
 
-import axiomsimd "github.com/axiomhq/simd-go"
+import (
+	_ "github.com/axiomhq/simd-go"
+	_ "unsafe"
+)
+
+//go:linkname axiomsimdDotProductFloat32Impl github.com/axiomhq/simd-go.dotProductFloat32Impl
+func axiomsimdDotProductFloat32Impl(left, right []float32) float32
 
 func vectorDotProductFloat32(left, right []float32) float32 {
 	// Axiom provides its SIMD dot-product dispatch on arm64.
@@ -13,5 +19,12 @@ func vectorDotProductFloat32(left, right []float32) float32 {
 	if n == 0 {
 		return 0
 	}
-	return axiomsimd.DotProductFloat32(left[:n], right[:n])
+	return vectorDotProductFloat32SameLen(left[:n], right[:n])
+}
+
+func vectorDotProductFloat32SameLen(left, right []float32) float32 {
+	if len(left) == 0 {
+		return 0
+	}
+	return axiomsimdDotProductFloat32Impl(left, right)
 }

--- a/TreeDB/collections/vector_dot_default.go
+++ b/TreeDB/collections/vector_dot_default.go
@@ -12,8 +12,16 @@ func vectorDotProductFloat32(left, right []float32) float32 {
 	if n == 0 {
 		return 0
 	}
+	return vectorDotProductFloat32SameLen(left[:n], right[:n])
+}
+
+func vectorDotProductFloat32SameLen(left, right []float32) float32 {
+	n := len(left)
+	if n == 0 {
+		return 0
+	}
 	return blas32.Dot(
-		blas32.Vector{N: n, Inc: 1, Data: left[:n]},
-		blas32.Vector{N: n, Inc: 1, Data: right[:n]},
+		blas32.Vector{N: n, Inc: 1, Data: left},
+		blas32.Vector{N: n, Inc: 1, Data: right},
 	)
 }


### PR DESCRIPTION
## Summary

Follow-on to #1728. This PR removes duplicate min-length/slicing work from the native vector search dot-product hot path.

Scope:

- Adds `vectorDotProductFloat32SameLen` with the precondition that caller already checked equal lengths.
- Updates native cosine scoring to call the same-length helper after its existing dimension check.
- Keeps the existing `vectorDotProductFloat32` min-length wrapper for any future general-purpose callers.
- On arm64, calls the axiomhq/simd-go implementation entry directly via `go:linkname` so the hot path skips the exported `DotProductFloat32` wrapper's repeated min-length logic.

## Validation

```sh
go test ./TreeDB/collections
# ok github.com/snissn/gomap/TreeDB/collections 15.612s
```

Smoke benchmarks on Apple M3, darwin/arm64:

```sh
go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnVectorGraphNativeSearchCosineProduction8192V3$' -benchtime=100x -count=1
# 4648 ns/op, 0 B/op, 0 allocs/op

go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnVectorGraphNativeSearchCosineParallelProduction8192V3$' -benchtime=100x -count=1
# 1510 ns/op, 18 B/op, 0 allocs/op
```

## Profile Evidence

Fresh profile artifacts:

```text
/tmp/pr1729_dotproduct_samelen_profile_20260522_051915
```

Key files:

```text
serial/bench.txt
serial/cpu.pprof
serial/cpu_top.txt
parallel/bench.txt
parallel/cpu.pprof
parallel/cpu_top.txt
```

Profile benchmark run:

| Benchmark | ns/op | ops/sec | B/op | allocs/op | candidates/search | edges/search | decoded_blocks/search | physical_B/search |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Serial production 8192 | 4,551 | 219,732 | 0 | 0 | 128 | 612 | 0 | 0 |
| Parallel production 8192 | 1,168 | 856,164 | 0 | 0 | 128 | 612 | 0 | 0 |

## Before / After Evidence

Against #1728 profile run on the same Apple M3 machine:

| Benchmark | #1728 profile ns/op | This PR profile ns/op | ops/sec after | delta |
| --- | ---: | ---: | ---: | ---: |
| Serial production 8192 | 4,733 | 4,551 | 219,732 | -3.8% |
| Parallel production 8192 | 1,159 | 1,168 | 856,164 | +0.8% |

Against original clean post-SIMD baseline:

| Benchmark | baseline ns/op | This PR profile ns/op | ops/sec after | delta |
| --- | ---: | ---: | ---: | ---: |
| Serial production 8192 | 30,035 | 4,551 | 219,732 | -84.8% |
| Parallel production 8192 | 7,072 | 1,168 | 856,164 | -83.5% |

## Hotspot Notes

The exported `axiomsimd.DotProductFloat32` wrapper no longer appears in the profile top. The hot path now goes straight to `dotProductFloat32Impl` / `dotProductFloat32NEON` through the same-length helper.

Remaining dominant work is expected vector math:

- Serial: `dotProductFloat32NEON` 20.02% flat, `dotProductFloat32Impl` 23.96% cum.
- Parallel remains dominated by NEON dot product and frontier mechanics.

## Risk Notes

The arm64 fast path uses `go:linkname` to call an unexported implementation symbol in `github.com/axiomhq/simd-go`. This is intentionally isolated to `vector_dot_arm64.go`. If we want to avoid this coupling, the safer alternative is to upstream a public `DotProductFloat32SameLen` / `DotProductFloat32N` API to axiomhq/simd-go and switch to it when available.

## Stack

- Depends on #1728.
- No PRs merged.



## Current normalized benchmark rerun

To compare the open stack apples-to-apples, I reran the same production 8192 serial and parallel benchmarks on the current PR head (`a7a1d84e53353bef353d3d6cd826d8daa9501e20`) on Apple M3, darwin/arm64. These numbers are the current normalized local comparison; the older profile artifact table below is retained as historical profile evidence from that capture run.

```sh
go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnVectorGraphNativeSearchCosine(Parallel)?Production8192V3$' -benchtime=100x -benchmem -count=3
```

| Benchmark | ns/op runs | avg ns/op | avg ops/sec | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: | ---: |
| Serial production 8192 | 6563 / 6330 / 6284 | 6392 | 156,437 | 0 | 0 |
| Parallel production 8192 | 1963 / 1922 / 1919 | 1935 | 516,885 | 8-27 | 0 |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized vector dot-product computation on multiple processor architectures (AMD64, ARM64, default) for improved efficiency in vector search operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1731?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
