### PR TITLE
collections: trust finite column graph scoring after block validation

### DIFF
--- a/TreeDB/collections/column_vector_graph_block_view.go
+++ b/TreeDB/collections/column_vector_graph_block_view.go
@@ -68,14 +68,15 @@ func (s *columnVectorGraphNativeSearchScratch) prepareSearchPlan(reader *columnV
 }
 
 type columnVectorGraphBlockView struct {
-	reader              *columnVectorGraphPhysicalRowReader
-	block               *columnPhysicalRowReaderBlock
-	idSpans             []columnVectorGraphByteSpan
-	vectorSpans         []columnVectorGraphVectorSpan
-	invNorms            []float32
-	adjSpans            []columnVectorGraphAdjacencySpan
-	rowValidated        []bool
-	adjacencyDirectView bool
+	reader               *columnVectorGraphPhysicalRowReader
+	block                *columnPhysicalRowReaderBlock
+	idSpans              []columnVectorGraphByteSpan
+	vectorSpans          []columnVectorGraphVectorSpan
+	invNorms             []float32
+	adjSpans             []columnVectorGraphAdjacencySpan
+	rowValidated         []bool
+	adjacencyDirectView  bool
+	trustedFiniteScoring bool
 }
 
 func newColumnVectorGraphSearchPlan(reader *columnVectorGraphPhysicalRowReader) (*columnVectorGraphSearchPlan, error) {
@@ -208,14 +209,15 @@ func newColumnVectorGraphBlockView(reader *columnVectorGraphPhysicalRowReader, b
 	}
 	rows := len(block.rowOffsets)
 	view := &columnVectorGraphBlockView{
-		reader:              reader,
-		block:               block,
-		idSpans:             make([]columnVectorGraphByteSpan, rows),
-		vectorSpans:         make([]columnVectorGraphVectorSpan, rows),
-		invNorms:            make([]float32, rows),
-		adjSpans:            make([]columnVectorGraphAdjacencySpan, rows),
-		rowValidated:        make([]bool, rows),
-		adjacencyDirectView: columnVectorGraphBlockViewAdjacencyDirectView(reader),
+		reader:               reader,
+		block:                block,
+		idSpans:              make([]columnVectorGraphByteSpan, rows),
+		vectorSpans:          make([]columnVectorGraphVectorSpan, rows),
+		invNorms:             make([]float32, rows),
+		adjSpans:             make([]columnVectorGraphAdjacencySpan, rows),
+		rowValidated:         make([]bool, rows),
+		adjacencyDirectView:  columnVectorGraphBlockViewAdjacencyDirectView(reader),
+		trustedFiniteScoring: true,
 	}
 	for rowIndex := 0; rowIndex < rows; rowIndex++ {
 		if err := view.indexRow(rowIndex); err != nil {
@@ -302,8 +304,39 @@ func (v *columnVectorGraphBlockView) indexVector(cur *manifestCursor, ordinal in
 		return columnVectorGraphVectorSpan{}, cur.err
 	}
 	start := cur.pos
-	cur.pos += int(byteLen)
+	end := cur.pos + int(byteLen)
+	if err := v.validateFiniteVectorPayload(start, end, int(n), ordinal); err != nil {
+		return columnVectorGraphVectorSpan{}, err
+	}
+	cur.pos = end
 	return columnVectorGraphVectorSpan{start: start, end: cur.pos, dims: int(n)}, nil
+}
+
+func (v *columnVectorGraphBlockView) validateFiniteVectorPayload(start, end, dims, ordinal int) error {
+	if dims == 0 {
+		return nil
+	}
+	raw := v.block.raw[start:end]
+	if columnPhysicalNativeLittleEndian {
+		vector := unsafe.Slice((*float32)(unsafe.Pointer(unsafe.SliceData(raw))), dims)
+		for i, value := range vector {
+			if math.IsNaN(float64(value)) || math.IsInf(float64(value), 0) {
+				v.trustedFiniteScoring = false
+				return fmt.Errorf("collections: column_graph %q ordinal=%d vector[%d] is not finite", v.reader.def.Name, ordinal, i)
+			}
+		}
+		return nil
+	}
+	pos := start
+	for i := 0; i < dims; i++ {
+		value := math.Float32frombits(uint32(v.block.raw[pos]) | uint32(v.block.raw[pos+1])<<8 | uint32(v.block.raw[pos+2])<<16 | uint32(v.block.raw[pos+3])<<24)
+		if math.IsNaN(float64(value)) || math.IsInf(float64(value), 0) {
+			v.trustedFiniteScoring = false
+			return fmt.Errorf("collections: column_graph %q ordinal=%d vector[%d] is not finite", v.reader.def.Name, ordinal, i)
+		}
+		pos += 4
+	}
+	return nil
 }
 
 func (v *columnVectorGraphBlockView) indexInvNorm(cur *manifestCursor, ordinal int) (float32, error) {

--- a/TreeDB/collections/column_vector_graph_block_view.go
+++ b/TreeDB/collections/column_vector_graph_block_view.go
@@ -318,14 +318,17 @@ func (v *columnVectorGraphBlockView) validateFiniteVectorPayload(start, end, dim
 	}
 	raw := v.block.raw[start:end]
 	if columnPhysicalNativeLittleEndian {
-		vector := unsafe.Slice((*float32)(unsafe.Pointer(unsafe.SliceData(raw))), dims)
-		for i, value := range vector {
-			if math.IsNaN(float64(value)) || math.IsInf(float64(value), 0) {
-				v.trustedFiniteScoring = false
-				return fmt.Errorf("collections: column_graph %q ordinal=%d vector[%d] is not finite", v.reader.def.Name, ordinal, i)
+		ptr := unsafe.Pointer(unsafe.SliceData(raw))
+		if uintptr(ptr)%unsafe.Alignof(float32(0)) == 0 {
+			vector := unsafe.Slice((*float32)(ptr), dims)
+			for i, value := range vector {
+				if math.IsNaN(float64(value)) || math.IsInf(float64(value), 0) {
+					v.trustedFiniteScoring = false
+					return fmt.Errorf("collections: column_graph %q ordinal=%d vector[%d] is not finite", v.reader.def.Name, ordinal, i)
+				}
 			}
+			return nil
 		}
-		return nil
 	}
 	pos := start
 	for i := 0; i < dims; i++ {

--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -535,16 +535,13 @@ func columnVectorGraphNativeCosineScoreVectorTrusted(query []float32, queryInvNo
 	}
 	dot := float64(vectorDotProductFloat32SameLen(query, vector))
 	score := dot * float64(queryInvNorm) * float64(invNorm)
-	if trustedFinite {
-		return score, nil
-	}
 	if !math.IsInf(score, 0) && !math.IsNaN(score) {
 		return score, nil
 	}
 	dot = columnVectorGraphNativeDotProductFloat64(query, vector)
 	score = dot * float64(queryInvNorm) * float64(invNorm)
 	if math.IsInf(score, 0) || math.IsNaN(score) {
-		return 0, fmt.Errorf("collections: column_graph %q candidate ordinal=%d cosine score is not finite", "", ordinal)
+		return 0, fmt.Errorf("collections: column_graph candidate ordinal=%d cosine score is not finite", ordinal)
 	}
 	return score, nil
 }

--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -251,10 +251,11 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 			return nil, stats, err
 		}
 	}
+	trustedFiniteScoring := singleBlockView != nil && singleBlockView.trustedFiniteScoring
 	visitMarks := scratch.visitMarks
 	visitEpoch := scratch.visitEpoch
 	visitMarks[0] = visitEpoch
-	if err := r.scoreAndPushFrontierVisited(plan, singleBlockView, query, queryInvNorm, 0, topK, scratch, &stats); err != nil {
+	if err := r.scoreAndPushFrontierVisited(plan, singleBlockView, trustedFiniteScoring, query, queryInvNorm, 0, topK, scratch, &stats); err != nil {
 		return nil, stats, err
 	}
 	nextSeed := 0
@@ -268,7 +269,7 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 				break
 			}
 			visitMarks[nextSeed] = visitEpoch
-			if err := r.scoreAndPushFrontierVisited(plan, singleBlockView, query, queryInvNorm, nextSeed, topK, scratch, &stats); err != nil {
+			if err := r.scoreAndPushFrontierVisited(plan, singleBlockView, trustedFiniteScoring, query, queryInvNorm, nextSeed, topK, scratch, &stats); err != nil {
 				return nil, stats, err
 			}
 			continue
@@ -290,7 +291,7 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 				continue
 			}
 			visitMarks[neighborOrdinal] = visitEpoch
-			if err := r.scoreAndPushFrontierVisited(plan, singleBlockView, query, queryInvNorm, neighborOrdinal, topK, scratch, &stats); err != nil {
+			if err := r.scoreAndPushFrontierVisited(plan, singleBlockView, trustedFiniteScoring, query, queryInvNorm, neighborOrdinal, topK, scratch, &stats); err != nil {
 				return nil, stats, err
 			}
 		}
@@ -373,7 +374,7 @@ func sortColumnVectorGraphResultOrderByOrdinal(order []int, top []columnVectorGr
 	})
 }
 
-func (r *columnVectorGraphPhysicalRowReader) scoreAndPushFrontierVisited(plan *columnVectorGraphSearchPlan, singleBlockView *columnVectorGraphBlockView, query []float32, queryInvNorm float32, ordinal, topK int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) error {
+func (r *columnVectorGraphPhysicalRowReader) scoreAndPushFrontierVisited(plan *columnVectorGraphSearchPlan, singleBlockView *columnVectorGraphBlockView, trustedFiniteScoring bool, query []float32, queryInvNorm float32, ordinal, topK int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) error {
 	view := singleBlockView
 	rowIndex := ordinal
 	if view == nil {
@@ -394,12 +395,9 @@ func (r *columnVectorGraphPhysicalRowReader) scoreAndPushFrontierVisited(plan *c
 	scratch.scoreScratch.Float32Values = vectorScratch
 	invNorm := view.invNormUnchecked(rowIndex)
 	stats.CandidateFetches++
-	score, err := columnVectorGraphNativeCosineScoreVector(query, queryInvNorm, ordinal, vector, invNorm)
+	score, err := columnVectorGraphNativeCosineScoreVectorTrusted(query, queryInvNorm, ordinal, vector, invNorm, trustedFiniteScoring)
 	if err != nil {
 		return err
-	}
-	if math.IsNaN(score) || math.IsInf(score, 0) {
-		return fmt.Errorf("collections: column_graph %q candidate ordinal=%d cosine score is not finite", r.def.Name, ordinal)
 	}
 	stats.Candidates++
 	candidate := columnVectorGraphSearchCandidate{
@@ -528,15 +526,27 @@ func columnVectorGraphNativeCosineScore(query []float32, queryInvNorm float32, r
 }
 
 func columnVectorGraphNativeCosineScoreVector(query []float32, queryInvNorm float32, ordinal int, vector []float32, invNorm float32) (float64, error) {
+	return columnVectorGraphNativeCosineScoreVectorTrusted(query, queryInvNorm, ordinal, vector, invNorm, false)
+}
+
+func columnVectorGraphNativeCosineScoreVectorTrusted(query []float32, queryInvNorm float32, ordinal int, vector []float32, invNorm float32, trustedFinite bool) (float64, error) {
 	if len(vector) != len(query) {
 		return 0, fmt.Errorf("collections: column_graph candidate ordinal=%d vector dims=%d want %d: %w", ordinal, len(vector), len(query), errColumnVectorGraphNativeSearchCandidateDimensionMismatch)
 	}
 	dot := float64(vectorDotProductFloat32SameLen(query, vector))
-	if !math.IsInf(dot, 0) && !math.IsNaN(dot) {
-		return dot * float64(queryInvNorm) * float64(invNorm), nil
+	score := dot * float64(queryInvNorm) * float64(invNorm)
+	if trustedFinite {
+		return score, nil
+	}
+	if !math.IsInf(score, 0) && !math.IsNaN(score) {
+		return score, nil
 	}
 	dot = columnVectorGraphNativeDotProductFloat64(query, vector)
-	return dot * float64(queryInvNorm) * float64(invNorm), nil
+	score = dot * float64(queryInvNorm) * float64(invNorm)
+	if math.IsInf(score, 0) || math.IsNaN(score) {
+		return 0, fmt.Errorf("collections: column_graph %q candidate ordinal=%d cosine score is not finite", "", ordinal)
+	}
+	return score, nil
 }
 
 func columnVectorGraphNativeDotProductFloat64(left, right []float32) float64 {

--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -535,7 +535,11 @@ func columnVectorGraphNativeCosineScoreVectorTrusted(query []float32, queryInvNo
 	}
 	dot := float64(vectorDotProductFloat32SameLen(query, vector))
 	score := dot * float64(queryInvNorm) * float64(invNorm)
-	if !math.IsInf(score, 0) && !math.IsNaN(score) {
+	if trustedFinite {
+		if score >= -math.MaxFloat64 && score <= math.MaxFloat64 {
+			return score, nil
+		}
+	} else if !math.IsInf(score, 0) && !math.IsNaN(score) {
 		return score, nil
 	}
 	dot = columnVectorGraphNativeDotProductFloat64(query, vector)

--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -385,6 +385,10 @@ func (r *columnVectorGraphPhysicalRowReader) scoreAndPushFrontierVisited(plan *c
 		view = refView
 		rowIndex = ref.rowIndex
 	}
+	localTrustedFiniteScoring := trustedFiniteScoring
+	if singleBlockView == nil {
+		localTrustedFiniteScoring = view.trustedFiniteScoring
+	}
 	stats.ScoreBatches++
 	stats.OrdinalsGrouped++
 	stats.BlockViewHits = plan.hits
@@ -395,7 +399,7 @@ func (r *columnVectorGraphPhysicalRowReader) scoreAndPushFrontierVisited(plan *c
 	scratch.scoreScratch.Float32Values = vectorScratch
 	invNorm := view.invNormUnchecked(rowIndex)
 	stats.CandidateFetches++
-	score, err := columnVectorGraphNativeCosineScoreVectorTrusted(query, queryInvNorm, ordinal, vector, invNorm, trustedFiniteScoring)
+	score, err := columnVectorGraphNativeCosineScoreVectorTrusted(query, queryInvNorm, ordinal, vector, invNorm, localTrustedFiniteScoring)
 	if err != nil {
 		return err
 	}

--- a/TreeDB/collections/column_vector_graph_search_test.go
+++ b/TreeDB/collections/column_vector_graph_search_test.go
@@ -273,6 +273,22 @@ func TestColumnVectorGraphNativeCosineScoreKeepsFiniteFloat32ZeroV3(t *testing.T
 	}
 }
 
+func TestColumnVectorGraphNativeCosineScoreTrustedFallbackOnFloat32OverflowV3(t *testing.T) {
+	got, err := columnVectorGraphNativeCosineScoreVectorTrusted(
+		[]float32{math.MaxFloat32}, 1,
+		7,
+		[]float32{math.MaxFloat32}, 1,
+		true,
+	)
+	if err != nil {
+		t.Fatalf("columnVectorGraphNativeCosineScoreVectorTrusted: %v", err)
+	}
+	want := float64(math.MaxFloat32) * float64(math.MaxFloat32)
+	if math.IsInf(got, 0) || math.IsNaN(got) || got != want {
+		t.Fatalf("columnVectorGraphNativeCosineScoreVectorTrusted=%g want finite float64 fallback %g", got, want)
+	}
+}
+
 func TestColumnVectorGraphNativeSearchEmptyAndTopKClampV3(t *testing.T) {
 	_, d, col, def := openColumnGraphRebuildTestCollectionV2A(t, 3, 2, nil)
 	defer func() { _ = d.Close() }()


### PR DESCRIPTION
## Summary

Follow-on to #1731. This PR adds an internal trusted-finite scoring invariant for column_graph block views.

Scope:

- Validates vector payload components once while building the bounded block view.
- Records `trustedFiniteScoring` on the block view when vector payloads and invNorms have been validated.
- Uses a trusted scoring path in native search to skip repeated finite checks in the hot candidate scoring loop.
- Keeps the non-trusted scoring helper path for malformed/fallback callers.

This is the metadata/invariant form of the optimization: finite validation is moved to block-view construction, and hot scoring can trust the validated graph asset.

## Validation

```sh
go test ./TreeDB/collections
# ok github.com/snissn/gomap/TreeDB/collections 19.115s
```

## Profile Evidence

Fresh profile artifacts:

```text
/tmp/pr1732_trusted_finite_profile_20260522_053255
```

Profile benchmark run on Apple M3, darwin/arm64:

| Benchmark | ns/op | ops/sec | B/op | allocs/op | candidates/search | edges/search | decoded_blocks/search | physical_B/search |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Serial production 8192 | 6,472 | 154,512 | 0 | 0 | 128 | 612 | 0 | 0 |
| Parallel production 8192 | 1,658 | 603,136 | 0 | 0 | 128 | 612 | 0 | 0 |

## Notes

This PR establishes the finite-validation/trust hook for graph assets. In this profile, `math.IsInf` drops to a small residual cost from fallback/non-search setup paths; the search hot path uses the trusted scoring helper after single-block view validation.

## Stack

- Depends on #1731.
- Next planned PR: top-k threshold optimization.



## Current normalized benchmark rerun

To compare the open stack apples-to-apples, I reran the same production 8192 serial and parallel benchmarks on the current PR head (`5e8f5a43ab29434076e339729122fccc80950a15`) on Apple M3, darwin/arm64. These supersede the earlier profile numbers for latest-head comparison; the profile table below is retained as historical profile evidence from that capture run.

```sh
go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnVectorGraphNativeSearchCosine(Parallel)?Production8192V3$' -benchtime=100x -benchmem -count=3
```

| Benchmark | ns/op runs | avg ns/op | avg ops/sec | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: | ---: |
| Serial production 8192 | 6345 / 6318 / 6503 | 6389 | 156,527 | 0 | 0 |
| Parallel production 8192 | 1921 / 1960 / 1913 | 1931 | 517,777 | 17-31 | 0 |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Indexing now validates every vector element and reports non-finite values (NaN, Infinity) with clear context (graph, vector ordinal, element index).
  * Scoring uses optimized fast paths with reliable fallbacks to avoid overflow/NaN/Inf affecting results; scoring trusts validated vectors for performance.

* **Tests**
  * Added test ensuring correct handling of float32 overflow in vector scoring.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1732?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
