### PR TITLE
collections: skip cold top-k inserts in native vector search

### DIFF
--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -500,17 +500,22 @@ func (s *columnVectorGraphNativeSearchScratch) insertTop(limit int, candidate co
 	if limit <= 0 {
 		return
 	}
-	pos := len(s.top)
+	topLen := len(s.top)
+	if topLen == limit && !columnVectorGraphSearchCandidateBetter(candidate, s.top[topLen-1]) {
+		return
+	}
+	pos := topLen
 	for pos > 0 && columnVectorGraphSearchCandidateBetter(candidate, s.top[pos-1]) {
 		pos--
 	}
 	if pos >= limit {
 		return
 	}
-	if len(s.top) < limit {
+	if topLen < limit {
 		s.top = append(s.top, columnVectorGraphSearchCandidate{})
+		topLen++
 	}
-	copy(s.top[pos+1:], s.top[pos:len(s.top)-1])
+	copy(s.top[pos+1:], s.top[pos:topLen-1])
 	s.top[pos] = candidate
 }
 


### PR DESCRIPTION
## Summary

Follow-on to #1732. This PR adds a cheap top-k threshold fast-reject path for native vector search.

Scope:

- Keeps the existing sorted top-k representation and final result ordering.
- When top-k is full, checks the current worst top-k candidate before scanning/inserting.
- Skips insertion work for candidates that cannot enter the top-k.

## Validation

```sh
go test ./TreeDB/collections
# ok github.com/snissn/gomap/TreeDB/collections 17.817s
```

## Profile Evidence

Fresh profile artifacts:

```text
/tmp/pr1733_topk_threshold_profile_20260522_053523
```

Profile benchmark run on Apple M3, darwin/arm64:

| Benchmark | ns/op | ops/sec | B/op | allocs/op | candidates/search | edges/search | decoded_blocks/search | physical_B/search |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Serial production 8192 | 6,348 | 157,530 | 0 | 0 | 128 | 612 | 0 | 0 |
| Parallel production 8192 | 1,446 | 691,563 | 0 | 0 | 128 | 612 | 0 | 0 |

## Before / After Evidence

Against #1732 profile run on the same Apple M3 machine:

| Benchmark | #1732 profile ns/op | This PR profile ns/op | ops/sec after | delta |
| --- | ---: | ---: | ---: | ---: |
| Serial production 8192 | 6,472 | 6,348 | 157,530 | -1.9% |
| Parallel production 8192 | 1,658 | 1,446 | 691,563 | -12.8% |

## Hotspot Notes

`insertTop` remains visible but the threshold check avoids unnecessary insertion scans/copies once top-k is full and the candidate cannot beat the current worst top-k entry.

## Stack

- Depends on #1732.
- No PRs merged.



## Current normalized benchmark rerun

To compare the open stack apples-to-apples, I reran the same production 8192 serial and parallel benchmarks on the current PR head (`11013a853774b9d6d39ab39c69c7ad53214661b5`) on Apple M3, darwin/arm64. These supersede the earlier profile numbers for latest-head comparison; the profile table below is retained as historical profile evidence from that capture run.

```sh
go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnVectorGraphNativeSearchCosine(Parallel)?Production8192V3$' -benchtime=100x -benchmem -count=3
```

| Benchmark | ns/op runs | avg ns/op | avg ops/sec | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: | ---: |
| Serial production 8192 | 6306 / 6523 / 6384 | 6404 | 156,144 | 0 | 0 |
| Parallel production 8192 | 1867 / 1921 / 1918 | 1902 | 525,762 | 26-52 | 0 |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal vector-search candidate handling to reduce unnecessary work and memory churn during search operations.
  * Enhances runtime efficiency and memory behavior for searches, resulting in lower resource use and faster backend processing.
  * No changes to search results, ranking quality, or user-facing behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1733?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
