### PR TITLE
collections: align column graph vector quality

### DIFF
--- a/TreeDB/collections/column_vector_graph_row_reader.go
+++ b/TreeDB/collections/column_vector_graph_row_reader.go
@@ -520,10 +520,8 @@ func (r *columnVectorGraphPhysicalRowReader) graphRowFromPhysicalRow(row columnP
 	if err != nil {
 		return columnVectorGraphPhysicalRow{}, err
 	}
-	for i, neighbor := range graphRow.Adjacency {
-		if err := validateColumnVectorGraphAdjacencyOrdinal(r.def.Name, row.Ordinal, i, neighbor, rowCount); err != nil {
-			return columnVectorGraphPhysicalRow{}, err
-		}
+	if err := validateColumnVectorGraphAdjacency(r.def.Name, row.Ordinal, graphRow.Adjacency, rowCount); err != nil {
+		return columnVectorGraphPhysicalRow{}, err
 	}
 	return graphRow, nil
 }
@@ -574,4 +572,83 @@ func validateColumnVectorGraphAdjacencyOrdinal(graphName string, ordinal int, ad
 		return fmt.Errorf("collections: column_graph %q ordinal=%d adjacency[%d]=%d outside row_count=%d: %w", graphName, ordinal, adjacencyIndex, neighbor, rowCount, errColumnVectorGraphAdjacencyOrdinalOutOfBounds)
 	}
 	return nil
+}
+
+func validateColumnVectorGraphAdjacency(graphName string, ordinal int, adjacency []uint32, rowCount int) error {
+	maxLayer, err := columnVectorGraphAdjacencyMaxLayer(adjacency)
+	if err != nil {
+		return fmt.Errorf("collections: column_graph %q ordinal=%d malformed adjacency: %w", graphName, ordinal, err)
+	}
+	for layer := 0; layer <= maxLayer; layer++ {
+		neighbors, err := columnVectorGraphAdjacencyLayer(adjacency, layer)
+		if err != nil {
+			return fmt.Errorf("collections: column_graph %q ordinal=%d malformed adjacency layer=%d: %w", graphName, ordinal, layer, err)
+		}
+		for i, neighbor := range neighbors {
+			if err := validateColumnVectorGraphAdjacencyOrdinal(graphName, ordinal, i, neighbor, rowCount); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func columnVectorGraphAdjacencyMaxLayer(adjacency []uint32) (int, error) {
+	if !columnVectorGraphAdjacencyIsLayered(adjacency) {
+		return 0, nil
+	}
+	maxLayer := int(adjacency[1])
+	pos := 2
+	for layer := 0; layer <= maxLayer; layer++ {
+		if pos >= len(adjacency) {
+			return 0, fmt.Errorf("layer=%d missing count", layer)
+		}
+		count := int(adjacency[pos])
+		pos++
+		if count < 0 || count > len(adjacency)-pos {
+			return 0, fmt.Errorf("layer=%d count=%d exceeds remaining=%d", layer, count, len(adjacency)-pos)
+		}
+		pos += count
+	}
+	if pos != len(adjacency) {
+		return 0, fmt.Errorf("trailing adjacency values=%d", len(adjacency)-pos)
+	}
+	return maxLayer, nil
+}
+
+func columnVectorGraphAdjacencyLayer(adjacency []uint32, wantLayer int) ([]uint32, error) {
+	if wantLayer < 0 {
+		return nil, fmt.Errorf("negative layer=%d", wantLayer)
+	}
+	if !columnVectorGraphAdjacencyIsLayered(adjacency) {
+		if wantLayer == 0 {
+			return adjacency, nil
+		}
+		return nil, nil
+	}
+	maxLayer := int(adjacency[1])
+	if wantLayer > maxLayer {
+		return nil, nil
+	}
+	pos := 2
+	for layer := 0; layer <= maxLayer; layer++ {
+		if pos >= len(adjacency) {
+			return nil, fmt.Errorf("layer=%d missing count", layer)
+		}
+		count := int(adjacency[pos])
+		pos++
+		if count < 0 || count > len(adjacency)-pos {
+			return nil, fmt.Errorf("layer=%d count=%d exceeds remaining=%d", layer, count, len(adjacency)-pos)
+		}
+		layerAdjacency := adjacency[pos : pos+count]
+		if layer == wantLayer {
+			return layerAdjacency, nil
+		}
+		pos += count
+	}
+	return nil, nil
+}
+
+func columnVectorGraphAdjacencyIsLayered(adjacency []uint32) bool {
+	return len(adjacency) >= 2 && adjacency[0] == columnVectorGraphLayeredAdjacencyMagic
 }

--- a/TreeDB/collections/column_vector_graph_row_reader_test.go
+++ b/TreeDB/collections/column_vector_graph_row_reader_test.go
@@ -43,6 +43,7 @@ func TestColumnVectorGraphPhysicalRowReaderFetchesPublishedGraphRowsV2B(t *testi
 	if got, want := reader.RowCount(), len(rows); got != want {
 		t.Fatalf("RowCount=%d want %d", got, want)
 	}
+	wantGraph := columnGraphRebuildNativeGraphLayoutV2A(t, def, rows)
 	scratch := columnPhysicalRowReaderScratch{
 		Values:        make([]columnDeclaredValue, 0, 3),
 		Float32Values: make([]float32, 0, def.Dimensions),
@@ -52,7 +53,8 @@ func TestColumnVectorGraphPhysicalRowReaderFetchesPublishedGraphRowsV2B(t *testi
 	if err != nil {
 		t.Fatalf("FetchRow(1): %v", err)
 	}
-	assertColumnVectorGraphPhysicalRowV2B(t, row, "doc-b", 1, 1, []float32{0, 1, 0}, 1, []uint32{0, 2})
+	wantInput := columnGraphRebuildInputByIDV2B(t, rows, wantGraph.ids[1])
+	assertColumnVectorGraphPhysicalRowV2B(t, row, wantGraph.ids[1], 1, 1, wantInput.vector, 1, wantGraph.adjacency[1])
 
 	var batchIDs []string
 	if err := reader.FetchBatch([]int{2, 0}, &scratch, func(row columnVectorGraphPhysicalRow) error {
@@ -61,13 +63,24 @@ func TestColumnVectorGraphPhysicalRowReaderFetchesPublishedGraphRowsV2B(t *testi
 	}); err != nil {
 		t.Fatalf("FetchBatch: %v", err)
 	}
-	if got, want := strings.Join(batchIDs, ","), "doc-c,doc-a"; got != want {
+	if got, want := strings.Join(batchIDs, ","), strings.Join([]string{wantGraph.ids[2], wantGraph.ids[0]}, ","); got != want {
 		t.Fatalf("batch IDs=%q want %q", got, want)
 	}
 	stats := reader.Stats()
 	if stats.RowFetches != 1 || stats.BatchFetches != 1 || stats.RowsFetched != 3 {
 		t.Fatalf("stats=%+v want one row fetch, one batch fetch, three fetched rows", stats)
 	}
+}
+
+func columnGraphRebuildInputByIDV2B(tb testing.TB, rows []columnGraphRebuildInputRowV2A, id string) columnGraphRebuildInputRowV2A {
+	tb.Helper()
+	for _, row := range rows {
+		if row.id == id {
+			return row
+		}
+	}
+	tb.Fatalf("missing input row id=%q", id)
+	return columnGraphRebuildInputRowV2A{}
 }
 
 func TestColumnVectorGraphPhysicalRowReaderOpensEmptyPublishedGraphV2B(t *testing.T) {

--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -251,10 +251,21 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 			return nil, stats, err
 		}
 	}
+	entryOrdinal := 0
+	maxLayer, err := r.maxAdjacencyLayer(plan, singleBlockView, entryOrdinal, scratch)
+	if err != nil {
+		return nil, stats, err
+	}
+	for layer := maxLayer; layer > 0; layer-- {
+		entryOrdinal, err = r.greedyNearestAtLayer(plan, singleBlockView, query, queryInvNorm, entryOrdinal, layer, scratch, &stats)
+		if err != nil {
+			return nil, stats, err
+		}
+	}
 	visitMarks := scratch.visitMarks
 	visitEpoch := scratch.visitEpoch
-	visitMarks[0] = visitEpoch
-	if err := r.scoreAndPushFrontierVisited(plan, singleBlockView, query, queryInvNorm, 0, topK, scratch, &stats); err != nil {
+	visitMarks[entryOrdinal] = visitEpoch
+	if err := r.scoreAndPushFrontierVisited(plan, singleBlockView, query, queryInvNorm, entryOrdinal, topK, scratch, &stats); err != nil {
 		return nil, stats, err
 	}
 	nextSeed := 0
@@ -273,7 +284,7 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 			}
 			continue
 		}
-		adjacency, err := r.expandCandidateAdjacency(plan, singleBlockView, candidate.ordinal, scratch, &stats)
+		adjacency, err := r.expandCandidateAdjacencyLayer(plan, singleBlockView, candidate.ordinal, 0, scratch, &stats)
 		if err != nil {
 			return nil, stats, err
 		}
@@ -303,6 +314,46 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 		return nil, stats, err
 	}
 	return scratch.results, stats, nil
+}
+
+func (r *columnVectorGraphPhysicalRowReader) maxAdjacencyLayer(plan *columnVectorGraphSearchPlan, singleBlockView *columnVectorGraphBlockView, ordinal int, scratch *columnVectorGraphNativeSearchScratch) (int, error) {
+	adjacency, err := r.rawCandidateAdjacency(plan, singleBlockView, ordinal, scratch)
+	if err != nil {
+		return 0, err
+	}
+	return columnVectorGraphAdjacencyMaxLayer(adjacency)
+}
+
+func (r *columnVectorGraphPhysicalRowReader) greedyNearestAtLayer(plan *columnVectorGraphSearchPlan, singleBlockView *columnVectorGraphBlockView, query []float32, queryInvNorm float32, entryOrdinal int, layer int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) (int, error) {
+	best := entryOrdinal
+	bestScore, err := r.scoreOrdinal(plan, singleBlockView, query, queryInvNorm, best, scratch, stats)
+	if err != nil {
+		return 0, err
+	}
+	changed := true
+	for changed {
+		changed = false
+		adjacency, err := r.expandCandidateAdjacencyLayer(plan, singleBlockView, best, layer, scratch, stats)
+		if err != nil {
+			return 0, err
+		}
+		for i, neighbor := range adjacency {
+			if uint64(neighbor) >= uint64(r.RowCount()) {
+				return 0, fmt.Errorf("collections: column_graph %q ordinal=%d adjacency[%d]=%d outside row_count=%d: %w", r.def.Name, best, i, neighbor, r.RowCount(), errColumnVectorGraphAdjacencyOrdinalOutOfBounds)
+			}
+			neighborOrdinal := int(neighbor)
+			score, err := r.scoreOrdinal(plan, singleBlockView, query, queryInvNorm, neighborOrdinal, scratch, stats)
+			if err != nil {
+				return 0, err
+			}
+			if score > bestScore || (score == bestScore && neighborOrdinal < best) {
+				best = neighborOrdinal
+				bestScore = score
+				changed = true
+			}
+		}
+	}
+	return best, nil
 }
 
 func (r *columnVectorGraphPhysicalRowReader) fetchTopSearchResults(plan *columnVectorGraphSearchPlan, singleBlockView *columnVectorGraphBlockView, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) error {
@@ -374,32 +425,9 @@ func sortColumnVectorGraphResultOrderByOrdinal(order []int, top []columnVectorGr
 }
 
 func (r *columnVectorGraphPhysicalRowReader) scoreAndPushFrontierVisited(plan *columnVectorGraphSearchPlan, singleBlockView *columnVectorGraphBlockView, query []float32, queryInvNorm float32, ordinal, topK int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) error {
-	view := singleBlockView
-	rowIndex := ordinal
-	if view == nil {
-		refView, ref, err := plan.blockViewForOrdinal(ordinal)
-		if err != nil {
-			return err
-		}
-		view = refView
-		rowIndex = ref.rowIndex
-	}
-	stats.ScoreBatches++
-	stats.OrdinalsGrouped++
-	stats.BlockViewHits = plan.hits
-	stats.BlockViewMisses = plan.misses
-	stats.BlockViewBuilds = plan.builds
-	scratch.scoreScratch.Float32Values = scratch.scoreScratch.Float32Values[:0]
-	vector, vectorScratch := view.vectorUnchecked(rowIndex, scratch.scoreScratch.Float32Values)
-	scratch.scoreScratch.Float32Values = vectorScratch
-	invNorm := view.invNormUnchecked(rowIndex)
-	stats.CandidateFetches++
-	score, err := columnVectorGraphNativeCosineScoreVector(query, queryInvNorm, ordinal, vector, invNorm)
+	score, err := r.scoreOrdinal(plan, singleBlockView, query, queryInvNorm, ordinal, scratch, stats)
 	if err != nil {
 		return err
-	}
-	if math.IsNaN(score) || math.IsInf(score, 0) {
-		return fmt.Errorf("collections: column_graph %q candidate ordinal=%d cosine score is not finite", r.def.Name, ordinal)
 	}
 	stats.Candidates++
 	candidate := columnVectorGraphSearchCandidate{
@@ -411,13 +439,77 @@ func (r *columnVectorGraphPhysicalRowReader) scoreAndPushFrontierVisited(plan *c
 	return nil
 }
 
-func (r *columnVectorGraphPhysicalRowReader) expandCandidateAdjacency(plan *columnVectorGraphSearchPlan, singleBlockView *columnVectorGraphBlockView, ordinal int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) ([]uint32, error) {
+func (r *columnVectorGraphPhysicalRowReader) scoreOrdinal(plan *columnVectorGraphSearchPlan, singleBlockView *columnVectorGraphBlockView, query []float32, queryInvNorm float32, ordinal int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) (float64, error) {
 	view := singleBlockView
 	rowIndex := ordinal
 	if view == nil {
 		refView, ref, err := plan.blockViewForOrdinal(ordinal)
 		if err != nil {
-			return nil, err
+			return 0, err
+		}
+		view = refView
+		rowIndex = ref.rowIndex
+	}
+	if stats != nil {
+		stats.ScoreBatches++
+		stats.OrdinalsGrouped++
+		stats.BlockViewHits = plan.hits
+		stats.BlockViewMisses = plan.misses
+		stats.BlockViewBuilds = plan.builds
+	}
+	scratch.scoreScratch.Float32Values = scratch.scoreScratch.Float32Values[:0]
+	vector, vectorScratch := view.vectorUnchecked(rowIndex, scratch.scoreScratch.Float32Values)
+	scratch.scoreScratch.Float32Values = vectorScratch
+	invNorm := view.invNormUnchecked(rowIndex)
+	if stats != nil {
+		stats.CandidateFetches++
+	}
+	score, err := columnVectorGraphNativeCosineScoreVector(query, queryInvNorm, ordinal, vector, invNorm)
+	if err != nil {
+		return 0, err
+	}
+	if math.IsNaN(score) || math.IsInf(score, 0) {
+		return 0, fmt.Errorf("collections: column_graph %q candidate ordinal=%d cosine score is not finite", r.def.Name, ordinal)
+	}
+	return score, nil
+}
+
+func (r *columnVectorGraphPhysicalRowReader) expandCandidateAdjacencyLayer(plan *columnVectorGraphSearchPlan, singleBlockView *columnVectorGraphBlockView, ordinal int, layer int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) ([]uint32, error) {
+	adjacency, direct, err := r.rawCandidateAdjacencyWithDirectView(plan, singleBlockView, ordinal, scratch)
+	if err != nil {
+		return nil, err
+	}
+	layerAdjacency, err := columnVectorGraphAdjacencyLayer(adjacency, layer)
+	if err != nil {
+		return nil, fmt.Errorf("collections: column_graph %q ordinal=%d malformed adjacency layer=%d: %w", r.def.Name, ordinal, layer, err)
+	}
+	if stats != nil {
+		stats.ExpansionFetches++
+		stats.AdjacencyExpansions++
+		if direct {
+			stats.AdjacencyDirectViews++
+		} else {
+			stats.AdjacencyScratchDecodes++
+		}
+		stats.BlockViewHits = plan.hits
+		stats.BlockViewMisses = plan.misses
+		stats.BlockViewBuilds = plan.builds
+	}
+	return layerAdjacency, nil
+}
+
+func (r *columnVectorGraphPhysicalRowReader) rawCandidateAdjacency(plan *columnVectorGraphSearchPlan, singleBlockView *columnVectorGraphBlockView, ordinal int, scratch *columnVectorGraphNativeSearchScratch) ([]uint32, error) {
+	adjacency, _, err := r.rawCandidateAdjacencyWithDirectView(plan, singleBlockView, ordinal, scratch)
+	return adjacency, err
+}
+
+func (r *columnVectorGraphPhysicalRowReader) rawCandidateAdjacencyWithDirectView(plan *columnVectorGraphSearchPlan, singleBlockView *columnVectorGraphBlockView, ordinal int, scratch *columnVectorGraphNativeSearchScratch) ([]uint32, bool, error) {
+	view := singleBlockView
+	rowIndex := ordinal
+	if view == nil {
+		refView, ref, err := plan.blockViewForOrdinal(ordinal)
+		if err != nil {
+			return nil, false, err
 		}
 		view = refView
 		rowIndex = ref.rowIndex
@@ -425,20 +517,10 @@ func (r *columnVectorGraphPhysicalRowReader) expandCandidateAdjacency(plan *colu
 	scratch.expandScratch.Uint32Values = scratch.expandScratch.Uint32Values[:0]
 	adjacency, adjacencyScratch, direct, err := view.adjacency(rowIndex, scratch.expandScratch.Uint32Values)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	scratch.expandScratch.Uint32Values = adjacencyScratch
-	stats.ExpansionFetches++
-	stats.AdjacencyExpansions++
-	if direct {
-		stats.AdjacencyDirectViews++
-	} else {
-		stats.AdjacencyScratchDecodes++
-	}
-	stats.BlockViewHits = plan.hits
-	stats.BlockViewMisses = plan.misses
-	stats.BlockViewBuilds = plan.builds
-	return adjacency, nil
+	return adjacency, direct, nil
 }
 
 func (s *columnVectorGraphNativeSearchScratch) markVisited(ordinal int) bool {

--- a/TreeDB/collections/column_vector_graph_search_test.go
+++ b/TreeDB/collections/column_vector_graph_search_test.go
@@ -80,7 +80,7 @@ func TestColumnVectorGraphNativeSearchCosineUsesPhysicalRowsV3(t *testing.T) {
 	if stats.Candidates != uint64(len(rows)) {
 		t.Fatalf("Candidates=%d want %d", stats.Candidates, len(rows))
 	}
-	if stats.Edges == 0 || stats.CandidateFetches != uint64(len(rows)) || stats.ScoreBatches != uint64(len(rows)) || stats.ExpansionFetches != stats.AdjacencyExpansions || stats.ResultFetches != uint64(len(got)) {
+	if stats.Edges == 0 || stats.CandidateFetches < uint64(len(rows)) || stats.ScoreBatches < uint64(len(rows)) || stats.ExpansionFetches != stats.AdjacencyExpansions || stats.ResultFetches != uint64(len(got)) {
 		t.Fatalf("stats=%+v want candidate/result fetches plus lazy adjacency expansion fetches", stats)
 	}
 	readerStats := reader.Stats()
@@ -958,7 +958,7 @@ func columnGraphNativeSearchResultsMismatchV3(got, want []columnVectorGraphNativ
 		return fmt.Sprintf("results len=%d want %d got=%+v want=%+v", len(got), len(want), got, want)
 	}
 	for i := range want {
-		if got[i].Ordinal != want[i].Ordinal || !bytes.Equal(got[i].ID, want[i].ID) || math.Abs(got[i].Score-want[i].Score) > 1e-6 {
+		if !bytes.Equal(got[i].ID, want[i].ID) || math.Abs(got[i].Score-want[i].Score) > 1e-6 {
 			return fmt.Sprintf("result[%d]=%s want %s", i, columnGraphNativeSearchResultStringV3(got[i]), columnGraphNativeSearchResultStringV3(want[i]))
 		}
 	}

--- a/TreeDB/collections/column_vector_graph_search_test.go
+++ b/TreeDB/collections/column_vector_graph_search_test.go
@@ -81,7 +81,7 @@ func TestColumnVectorGraphNativeSearchCosineUsesPhysicalRowsV3(t *testing.T) {
 		t.Fatalf("Candidates=%d want %d", stats.Candidates, len(rows))
 	}
 	if stats.Edges == 0 || stats.CandidateFetches < uint64(len(rows)) || stats.ScoreBatches < uint64(len(rows)) || stats.ExpansionFetches != stats.AdjacencyExpansions || stats.ResultFetches != uint64(len(got)) {
-		t.Fatalf("stats=%+v want candidate/result fetches plus lazy adjacency expansion fetches", stats)
+		t.Fatalf("stats=%+v want at least %d candidate/score batches, exact result fetches, and matching lazy expansion fetches", stats, len(rows))
 	}
 	readerStats := reader.Stats()
 	if readerStats.RowFetches != 0 || readerStats.BatchFetches != 0 || readerStats.RowsFetched != 0 {

--- a/TreeDB/collections/vector_index_rebuild.go
+++ b/TreeDB/collections/vector_index_rebuild.go
@@ -506,10 +506,8 @@ func columnVectorGraphNativeLocalityOrder(index *VectorIndex) []int {
 		visited[index.entry] = true
 		queue = append(queue, index.entry)
 	}
-	for len(queue) > 0 {
-		nodeID := queue[0]
-		copy(queue, queue[1:])
-		queue = queue[:len(queue)-1]
+	for head := 0; head < len(queue); head++ {
+		nodeID := queue[head]
 		order = append(order, nodeID)
 		node := &index.nodes[nodeID]
 		for layer := len(node.neighbors) - 1; layer >= 0; layer-- {

--- a/TreeDB/collections/vector_index_rebuild.go
+++ b/TreeDB/collections/vector_index_rebuild.go
@@ -14,6 +14,7 @@ import (
 const (
 	columnVectorGraphNeighborInsertionLimit = 32
 	maxColumnVectorGraphAdjacencyOrdinal    = uint64(^uint32(0))
+	columnVectorGraphLayeredAdjacencyMagic  = ^uint32(0)
 )
 
 var (
@@ -432,42 +433,148 @@ func buildColumnVectorGraphAdjacency(rows []columnVectorGraphAssetRow, def Vecto
 	if uint64(len(rows)) > maxColumnVectorGraphAdjacencyOrdinal {
 		return fmt.Errorf("collections: column vector graph row count=%d exceeds uint32 adjacency encoding", len(rows))
 	}
-	degree := def.M
-	if degree <= 0 {
-		degree = defaultVectorIndexM
-	}
-	maxDegree := len(rows) - 1
-	if maxDegree < 0 {
-		maxDegree = 0
-	}
-	if degree > maxDegree {
-		degree = maxDegree
-	}
 	for i := range rows {
 		if len(rows[i].Vector) != def.Dimensions {
 			return fmt.Errorf("collections: column vector graph row[%d] vector dims=%d want %d", i, len(rows[i].Vector), def.Dimensions)
 		}
 	}
+
+	index, err := newVectorIndex(nil, vectorIndexOptionsFromDefinition(def))
+	if err != nil {
+		return err
+	}
+	index.mu.Lock()
+	defer index.mu.Unlock()
 	for i := range rows {
-		if degree <= 0 {
-			rows[i].Adjacency = nil
-			continue
+		if err := index.insertVectorLocked(rows[i].ID, rows[i].Vector); err != nil {
+			return fmt.Errorf("collections: build column vector graph row[%d]: %w", i, err)
 		}
-		candidates, err := topColumnVectorGraphNeighbors(rows, i, degree)
+	}
+
+	inputOrdinalByNode := make([]int, len(index.nodes))
+	for i := range inputOrdinalByNode {
+		inputOrdinalByNode[i] = -1
+	}
+	for i := range rows {
+		nodeID, ok := index.currentNode[string(rows[i].ID)]
+		if !ok || nodeID < 0 || nodeID >= len(index.nodes) || index.nodes[nodeID].deleted {
+			return fmt.Errorf("collections: column vector graph row[%d] missing native graph node", i)
+		}
+		inputOrdinalByNode[nodeID] = i
+	}
+	order := columnVectorGraphNativeLocalityOrder(index)
+	if len(order) != len(rows) {
+		return fmt.Errorf("collections: column vector graph locality order rows=%d want %d", len(order), len(rows))
+	}
+	orderedRows := make([]columnVectorGraphAssetRow, len(rows))
+	nodeOrdinal := make([]int, len(index.nodes))
+	for i := range nodeOrdinal {
+		nodeOrdinal[i] = -1
+	}
+	for ordinal, nodeID := range order {
+		inputOrdinal := -1
+		if nodeID >= 0 && nodeID < len(inputOrdinalByNode) {
+			inputOrdinal = inputOrdinalByNode[nodeID]
+		}
+		if inputOrdinal < 0 {
+			return fmt.Errorf("collections: column vector graph locality node=%d missing input row", nodeID)
+		}
+		orderedRows[ordinal] = rows[inputOrdinal]
+		nodeOrdinal[nodeID] = ordinal
+	}
+	copy(rows, orderedRows)
+	nodeIDByOrdinal := order
+	for i := range rows {
+		nodeID := nodeIDByOrdinal[i]
+		adjacency, err := columnVectorGraphLayeredAdjacencyFromNativeNode(&index.nodes[nodeID], nodeOrdinal)
 		if err != nil {
 			return err
 		}
-		neighbors := make([]uint32, len(candidates))
-		for n := range candidates {
-			ordinal := candidates[n].ordinal
-			if ordinal < 0 || uint64(ordinal) > maxColumnVectorGraphAdjacencyOrdinal {
-				return fmt.Errorf("collections: column vector graph neighbor ordinal=%d exceeds uint32 adjacency encoding", ordinal)
-			}
-			neighbors[n] = uint32(ordinal)
-		}
-		rows[i].Adjacency = neighbors
+		rows[i].Adjacency = adjacency
 	}
 	return nil
+}
+
+func columnVectorGraphNativeLocalityOrder(index *VectorIndex) []int {
+	if index == nil || len(index.nodes) == 0 {
+		return nil
+	}
+	order := make([]int, 0, len(index.nodes))
+	visited := make([]bool, len(index.nodes))
+	queue := make([]int, 0, len(index.nodes))
+	if index.entry >= 0 && index.entry < len(index.nodes) && !index.nodes[index.entry].deleted {
+		visited[index.entry] = true
+		queue = append(queue, index.entry)
+	}
+	for len(queue) > 0 {
+		nodeID := queue[0]
+		copy(queue, queue[1:])
+		queue = queue[:len(queue)-1]
+		order = append(order, nodeID)
+		node := &index.nodes[nodeID]
+		for layer := len(node.neighbors) - 1; layer >= 0; layer-- {
+			for _, neighbor := range node.neighbors[layer] {
+				neighborID := neighbor.nodeID
+				if neighborID < 0 || neighborID >= len(index.nodes) || visited[neighborID] || index.nodes[neighborID].deleted {
+					continue
+				}
+				visited[neighborID] = true
+				queue = append(queue, neighborID)
+			}
+		}
+	}
+	for nodeID := range index.nodes {
+		if visited[nodeID] || index.nodes[nodeID].deleted {
+			continue
+		}
+		order = append(order, nodeID)
+	}
+	return order
+}
+
+func columnVectorGraphLayeredAdjacencyFromNativeNode(node *vectorIndexNode, nodeOrdinal []int) ([]uint32, error) {
+	if node == nil {
+		return nil, nil
+	}
+	maxLayer := len(node.neighbors) - 1
+	for maxLayer >= 0 && len(node.neighbors[maxLayer]) == 0 {
+		maxLayer--
+	}
+	if maxLayer < 0 {
+		return nil, nil
+	}
+	layers := make([][]uint32, maxLayer+1)
+	for layer := 0; layer <= maxLayer; layer++ {
+		if len(node.neighbors[layer]) == 0 {
+			continue
+		}
+		layers[layer] = make([]uint32, 0, len(node.neighbors[layer]))
+		for _, neighbor := range node.neighbors[layer] {
+			neighborID := neighbor.nodeID
+			if neighborID < 0 || neighborID >= len(nodeOrdinal) {
+				return nil, fmt.Errorf("collections: column vector graph neighbor node=%d out of range", neighborID)
+			}
+			ordinal := nodeOrdinal[neighborID]
+			if ordinal < 0 || uint64(ordinal) > maxColumnVectorGraphAdjacencyOrdinal {
+				return nil, fmt.Errorf("collections: column vector graph neighbor ordinal=%d exceeds uint32 adjacency encoding", ordinal)
+			}
+			layers[layer] = append(layers[layer], uint32(ordinal))
+		}
+	}
+	if maxLayer == 0 {
+		return layers[0], nil
+	}
+	total := 2
+	for layer := 0; layer <= maxLayer; layer++ {
+		total += 1 + len(layers[layer])
+	}
+	encoded := make([]uint32, 0, total)
+	encoded = append(encoded, columnVectorGraphLayeredAdjacencyMagic, uint32(maxLayer))
+	for layer := 0; layer <= maxLayer; layer++ {
+		encoded = append(encoded, uint32(len(layers[layer])))
+		encoded = append(encoded, layers[layer]...)
+	}
+	return encoded, nil
 }
 
 func topColumnVectorGraphNeighbors(rows []columnVectorGraphAssetRow, row, degree int) ([]columnVectorGraphNeighbor, error) {

--- a/TreeDB/collections/vector_index_rebuild_test.go
+++ b/TreeDB/collections/vector_index_rebuild_test.go
@@ -73,11 +73,10 @@ func TestColumnGraphRebuildVectorIndexPublishesPhysicalManifestV2A(t *testing.T)
 	if got := strings.Join(columnGraphRebuildScannedIDsV2A(scanned), ","); got != strings.Join(wantGraph.ids, ",") {
 		t.Fatalf("scanned graph ids=%s, want native locality order %s", got, strings.Join(wantGraph.ids, ","))
 	}
-	if got := scanned[0].adjacency; !uint32SlicesEqual(got, wantGraph.adjacency[0]) {
-		t.Fatalf("%s adjacency=%v, want native layered adjacency %v", wantGraph.ids[0], got, wantGraph.adjacency[0])
-	}
-	if got := scanned[1].adjacency; !uint32SlicesEqual(got, wantGraph.adjacency[1]) {
-		t.Fatalf("%s adjacency=%v, want native layered adjacency %v", wantGraph.ids[1], got, wantGraph.adjacency[1])
+	for i := range wantGraph.ids {
+		if got := scanned[i].adjacency; !uint32SlicesEqual(got, wantGraph.adjacency[i]) {
+			t.Fatalf("%s adjacency=%v, want native layered adjacency %v", wantGraph.ids[i], got, wantGraph.adjacency[i])
+		}
 	}
 
 	if err := d.Checkpoint(); err != nil {

--- a/TreeDB/collections/vector_index_rebuild_test.go
+++ b/TreeDB/collections/vector_index_rebuild_test.go
@@ -69,14 +69,15 @@ func TestColumnGraphRebuildVectorIndexPublishesPhysicalManifestV2A(t *testing.T)
 	if len(scanned) != len(rows) {
 		t.Fatalf("scanned graph rows=%d want %d", len(scanned), len(rows))
 	}
-	if got := strings.Join(columnGraphRebuildScannedIDsV2A(scanned), ","); got != "doc-a,doc-b,doc-c,doc-d" {
-		t.Fatalf("scanned graph ids=%s", got)
+	wantGraph := columnGraphRebuildNativeGraphLayoutV2A(t, def, rows)
+	if got := strings.Join(columnGraphRebuildScannedIDsV2A(scanned), ","); got != strings.Join(wantGraph.ids, ",") {
+		t.Fatalf("scanned graph ids=%s, want native locality order %s", got, strings.Join(wantGraph.ids, ","))
 	}
-	if got := scanned[0].adjacency; len(got) != 3 || got[0] != 1 || got[1] != 2 || got[2] != 3 {
-		t.Fatalf("doc-a adjacency=%v, want [1 2 3]", got)
+	if got := scanned[0].adjacency; !uint32SlicesEqual(got, wantGraph.adjacency[0]) {
+		t.Fatalf("%s adjacency=%v, want native layered adjacency %v", wantGraph.ids[0], got, wantGraph.adjacency[0])
 	}
-	if got := scanned[1].adjacency; len(got) != 3 || got[0] != 0 || got[1] != 2 || got[2] != 3 {
-		t.Fatalf("doc-b adjacency=%v, want [0 2 3]", got)
+	if got := scanned[1].adjacency; !uint32SlicesEqual(got, wantGraph.adjacency[1]) {
+		t.Fatalf("%s adjacency=%v, want native layered adjacency %v", wantGraph.ids[1], got, wantGraph.adjacency[1])
 	}
 
 	if err := d.Checkpoint(); err != nil {
@@ -342,7 +343,7 @@ func TestColumnGraphRebuildVectorIndexExpectedPartsUsesActiveGenerationV2A(t *te
 	}
 }
 
-func TestColumnGraphRebuildVectorIndexAdjacencyUsesBoundedTopKV2A(t *testing.T) {
+func TestColumnGraphRebuildVectorIndexAdjacencyUsesFlattenedNativeGraphV2A(t *testing.T) {
 	rows := []columnGraphRebuildInputRowV2A{
 		{id: "doc-a", vector: []float32{1, 0}},
 		{id: "doc-b", vector: []float32{0.99, 0.01}},
@@ -358,8 +359,14 @@ func TestColumnGraphRebuildVectorIndexAdjacencyUsesBoundedTopKV2A(t *testing.T) 
 	if graph.AssetRef.Namespace != col.Meta().Options.ColumnStore.AssetManager.Namespace {
 		t.Fatalf("graph namespace=%q want base namespace=%q", graph.AssetRef.Namespace, col.Meta().Options.ColumnStore.AssetManager.Namespace)
 	}
-	if got := scanned[0].adjacency; len(got) != 2 || got[0] != 1 || got[1] != 2 {
-		t.Fatalf("doc-a adjacency=%v, want bounded top-k [1 2]", got)
+	wantGraph := columnGraphRebuildNativeGraphLayoutV2A(t, def, rows)
+	for i := range rows {
+		if gotID := string(scanned[i].id); gotID != wantGraph.ids[i] {
+			t.Fatalf("scanned[%d] id=%q, want native locality order %q", i, gotID, wantGraph.ids[i])
+		}
+		if got := scanned[i].adjacency; !uint32SlicesEqual(got, wantGraph.adjacency[i]) {
+			t.Fatalf("%s adjacency=%v, want native layered adjacency %v", wantGraph.ids[i], got, wantGraph.adjacency[i])
+		}
 	}
 }
 
@@ -1016,6 +1023,71 @@ func columnGraphRebuildVectorIndexDefinitionV2A(dims, m int) VectorIndexDefiniti
 		panic(err)
 	}
 	return def
+}
+
+type columnGraphRebuildNativeGraphLayoutResultV2A struct {
+	ids       []string
+	adjacency [][]uint32
+}
+
+func columnGraphRebuildNativeGraphLayoutV2A(tb testing.TB, def VectorIndexDefinition, rows []columnGraphRebuildInputRowV2A) columnGraphRebuildNativeGraphLayoutResultV2A {
+	tb.Helper()
+	index, err := newVectorIndex(nil, vectorIndexOptionsFromDefinition(def))
+	if err != nil {
+		tb.Fatalf("newVectorIndex: %v", err)
+	}
+	index.mu.Lock()
+	defer index.mu.Unlock()
+	for i := range rows {
+		if err := index.insertVectorLocked([]byte(rows[i].id), rows[i].vector); err != nil {
+			tb.Fatalf("insertVectorLocked row %d: %v", i, err)
+		}
+	}
+	inputOrdinalByNode := make([]int, len(index.nodes))
+	for i := range inputOrdinalByNode {
+		inputOrdinalByNode[i] = -1
+	}
+	for i := range rows {
+		nodeID, ok := index.currentNode[rows[i].id]
+		if !ok {
+			tb.Fatalf("native graph missing row %q", rows[i].id)
+		}
+		inputOrdinalByNode[nodeID] = i
+	}
+	order := columnVectorGraphNativeLocalityOrder(index)
+	nodeOrdinal := make([]int, len(index.nodes))
+	for i := range nodeOrdinal {
+		nodeOrdinal[i] = -1
+	}
+	ids := make([]string, len(order))
+	for ordinal, nodeID := range order {
+		if nodeID < 0 || nodeID >= len(inputOrdinalByNode) || inputOrdinalByNode[nodeID] < 0 {
+			tb.Fatalf("native graph locality node %d missing input row", nodeID)
+		}
+		nodeOrdinal[nodeID] = ordinal
+		ids[ordinal] = rows[inputOrdinalByNode[nodeID]].id
+	}
+	adjacency := make([][]uint32, len(rows))
+	for ordinal, nodeID := range order {
+		encoded, err := columnVectorGraphLayeredAdjacencyFromNativeNode(&index.nodes[nodeID], nodeOrdinal)
+		if err != nil {
+			tb.Fatalf("columnVectorGraphLayeredAdjacencyFromNativeNode ordinal %d: %v", ordinal, err)
+		}
+		adjacency[ordinal] = encoded
+	}
+	return columnGraphRebuildNativeGraphLayoutResultV2A{ids: ids, adjacency: adjacency}
+}
+
+func uint32SlicesEqual(a, b []uint32) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func insertColumnGraphRebuildRowsV2A(tb testing.TB, col *Collection, rows []columnGraphRebuildInputRowV2A) {

--- a/TreeDB/collections/vector_index_search_test.go
+++ b/TreeDB/collections/vector_index_search_test.go
@@ -844,7 +844,7 @@ func assertVectorIndexSearchResultsV4(tb testing.TB, got []VectorIndexSearchResu
 		tb.Fatalf("results=%d want %d", len(got), len(want))
 	}
 	for i := range want {
-		if !bytes.Equal(got[i].ID, want[i].ID) || got[i].Ordinal != want[i].Ordinal || math.Abs(got[i].Score-want[i].Score) > 1e-6 {
+		if !bytes.Equal(got[i].ID, want[i].ID) || math.Abs(got[i].Score-want[i].Score) > 1e-6 {
 			tb.Fatalf("result[%d]=%+v want id=%q ordinal=%d score=%v", i, got[i], want[i].ID, want[i].Ordinal, want[i].Score)
 		}
 		if wantDocs && len(got[i].Document) == 0 {

--- a/cmd/treedb_column_graph_demo/main_test.go
+++ b/cmd/treedb_column_graph_demo/main_test.go
@@ -33,7 +33,7 @@ func TestColumnGraphDemoRunsCloseReopenNativeReaderPath(t *testing.T) {
 		"row_fetches=",
 		"decoded_blocks=",
 		"max_resident_B=",
-		"result[0] id=doc-000000 ordinal=0",
+		"result[0] id=doc-000000 ",
 	}
 	for _, needle := range required {
 		if !strings.Contains(out, needle) {

--- a/cmd/treedb_vector_search_demo/main_test.go
+++ b/cmd/treedb_vector_search_demo/main_test.go
@@ -12,6 +12,8 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/snissn/gomap/TreeDB/collections"
 )
 
 func TestExecuteSmokeCompactsReopensValidatesAndBenchmarks(t *testing.T) {
@@ -121,6 +123,79 @@ func TestExecuteConsumesDatasetDir(t *testing.T) {
 	}
 	if res.Search.Queries != 4 {
 		t.Fatalf("search queries=%d want 4", res.Search.Queries)
+	}
+}
+
+func TestExecuteColumnGraphSearchPath(t *testing.T) {
+	res, err := execute(context.Background(), config{
+		dir:                   t.TempDir(),
+		keepDir:               true,
+		docs:                  64,
+		dimensions:            8,
+		queries:               4,
+		searchConcurrency:     []int{2},
+		validateQueries:       2,
+		validateDocs:          2,
+		topK:                  3,
+		batchSize:             16,
+		m:                     4,
+		efConstruction:        32,
+		efSearch:              32,
+		valuePointerThreshold: defaultValuePointerThreshold,
+		leafGenerationTarget:  defaultLeafGenerationTarget,
+		minRecall:             0.5,
+		disableExactFallback:  true,
+		vectorIndexStrategy:   collections.VectorIndexStrategyColumnGraph,
+	})
+	if err != nil {
+		t.Fatalf("execute column_graph: %v", err)
+	}
+	if res.Backend != "treedb_column_graph" {
+		t.Fatalf("backend=%q want treedb_column_graph", res.Backend)
+	}
+	if res.VectorIndexStrategy != collections.VectorIndexStrategyColumnGraph {
+		t.Fatalf("strategy=%q want column_graph", res.VectorIndexStrategy)
+	}
+	if res.VectorIndexSearchPath != collections.VectorIndexSearchPathColumnGraphNativeReader {
+		t.Fatalf("search path=%q want %q", res.VectorIndexSearchPath, collections.VectorIndexSearchPathColumnGraphNativeReader)
+	}
+	if res.Validation.Recall < res.Validation.MinRecall {
+		t.Fatalf("recall=%f below min=%f", res.Validation.Recall, res.Validation.MinRecall)
+	}
+	if res.Search.Queries != 4 || res.Search.ExactFallbacks != 0 {
+		t.Fatalf("unexpected column_graph search result: %+v", res.Search)
+	}
+}
+
+func TestExecuteColumnGraphRecallBenchmarkShape(t *testing.T) {
+	res, err := execute(context.Background(), config{
+		dir:                   t.TempDir(),
+		keepDir:               true,
+		docs:                  1000,
+		dimensions:            64,
+		queries:               4,
+		searchConcurrency:     []int{2},
+		validateQueries:       32,
+		validateDocs:          2,
+		topK:                  10,
+		batchSize:             128,
+		m:                     16,
+		efConstruction:        128,
+		efSearch:              128,
+		valuePointerThreshold: defaultValuePointerThreshold,
+		leafGenerationTarget:  defaultLeafGenerationTarget,
+		minRecall:             0.95,
+		disableExactFallback:  true,
+		vectorIndexStrategy:   collections.VectorIndexStrategyColumnGraph,
+	})
+	if err != nil {
+		t.Fatalf("execute column_graph benchmark shape: %v", err)
+	}
+	if res.Validation.Recall < 0.95 {
+		t.Fatalf("recall=%f want >=0.95", res.Validation.Recall)
+	}
+	if res.Search.AvgCandidates != 128 {
+		t.Fatalf("avg candidates=%f want ef_search=128", res.Search.AvgCandidates)
 	}
 }
 


### PR DESCRIPTION
## Summary

- build column_graph adjacency from the native TreeDB HNSW graph construction
- persist layered adjacency so column-store search can perform upper-layer greedy descent before layer-0 search
- reorder physical graph rows by graph locality so direct neighbors are more likely to share row granules
- keep locality ordering linear-time and treat physical ordinals as graph-internal in tests
- add a benchmark-shape recall regression

Follow-up to #1742 for #1739.

## Root Cause

The column_graph rebuild path wrote a flat top-M graph, while the native TreeDB path uses deterministic logarithmic HNSW layers and upper-layer greedy descent. The flat graph passed tiny smoke shapes but failed the pgvector validation shape as corpus size increased.

## Validation

- `go test ./TreeDB/collections ./cmd/treedb_vector_search_demo ./cmd/treedb_column_graph_demo`
- `bash -n scripts/bench_vector_db_compare.sh`
- `python3 -m py_compile benchmarks/vector_db_compare/summarize.py`
- 5k comparison: `/tmp/gomap_vector_db_compare_1739_layered_5k_20260522_092015/comparison.md`
- 10k comparison: `/tmp/gomap_vector_db_compare_1739_layered_10k_20260522_092126/comparison.md`

## Notes

Base PR: #1742. This PR is not merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fail-closed, whole-adjacency validation to reject malformed adjacency encodings and prevent incorrect results.

* **New Features**
  * Layered adjacency encoding and native-locality ordering for graph storage and rebuilds.
  * Layer-aware adjacency extraction during search and candidate expansion.

* **Performance Improvements**
  * Layer-aware greedy traversal and consolidated scoring for more reliable and often faster nearest-neighbor search.

* **Tests / Demos**
  * Updated and added tests/demos to validate layered adjacency, native locality order, relaxed ordinal checks, and column-graph strategy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1743?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->