### PR TITLE
bench: report vacuumed TreeDB vector storage

### DIFF
--- a/TreeDB/db/command_wal_feature_gate_test.go
+++ b/TreeDB/db/command_wal_feature_gate_test.go
@@ -264,16 +264,10 @@ func TestCommandWALRequiredFeatureEnablesBackendCommandWAL(t *testing.T) {
 	}
 }
 
-func TestCommandWALRequiredFeatureFailsClosedForOfflineMaintenance(t *testing.T) {
+func TestCommandWALRequiredFeatureRejectsOfflineValueLogRewrite(t *testing.T) {
 	dir := t.TempDir()
 	if err := SaveFormatConfig(dir, FormatConfig{RequiredFeatures: []string{RequiredFeatureCommandWALV1}}); err != nil {
 		t.Fatalf("SaveFormatConfig: %v", err)
-	}
-	if err := VacuumIndexOffline(Options{Dir: dir}); !errors.Is(err, ErrCommandWALUnsupported) {
-		t.Fatalf("VacuumIndexOffline error=%v, want ErrCommandWALUnsupported", err)
-	}
-	if err := VacuumIndexOffline(Options{Dir: dir, IgnoreFormatConfig: true}); !errors.Is(err, ErrCommandWALUnsupported) {
-		t.Fatalf("VacuumIndexOffline IgnoreFormatConfig error=%v, want ErrCommandWALUnsupported", err)
 	}
 	if _, err := ValueLogRewriteOffline(Options{Dir: dir}); !errors.Is(err, ErrCommandWALUnsupported) {
 		t.Fatalf("ValueLogRewriteOffline error=%v, want ErrCommandWALUnsupported", err)

--- a/TreeDB/db/format_config.go
+++ b/TreeDB/db/format_config.go
@@ -408,6 +408,10 @@ func parseValueLogAutoPolicy(raw string) (ValueLogAutoPolicy, bool) {
 }
 
 func applyFormatConfigForMaintenance(opts *Options) error {
+	return applyFormatConfigForMaintenanceWithOptions(opts, false)
+}
+
+func applyFormatConfigForMaintenanceWithOptions(opts *Options, allowCommandWAL bool) error {
 	if opts == nil {
 		return nil
 	}
@@ -416,9 +420,10 @@ func applyFormatConfigForMaintenance(opts *Options) error {
 		if err != nil {
 			return err
 		}
-		if requiresCommandWAL {
+		if requiresCommandWAL && !allowCommandWAL {
 			return ErrCommandWALUnsupported
 		}
+		opts.CommandWAL = opts.CommandWAL || requiresCommandWAL
 		return nil
 	}
 	cfg, ok, err := LoadFormatConfig(opts.Dir)
@@ -428,9 +433,11 @@ func applyFormatConfigForMaintenance(opts *Options) error {
 	if !ok {
 		return nil
 	}
-	if cfg.RequiresCommandWALV1() {
+	requiresCommandWAL := cfg.RequiresCommandWALV1()
+	if requiresCommandWAL && !allowCommandWAL {
 		return ErrCommandWALUnsupported
 	}
+	opts.CommandWAL = opts.CommandWAL || requiresCommandWAL
 	cfg.ApplyToOptions(opts)
 	return nil
 }

--- a/TreeDB/db/vacuum_offline.go
+++ b/TreeDB/db/vacuum_offline.go
@@ -41,7 +41,7 @@ func vacuumIndexOffline(opts Options, fail vacuumFailpoint) error {
 	if opts.Dir == "" {
 		return errors.New("db dir required")
 	}
-	if err := applyFormatConfigForMaintenance(&opts); err != nil {
+	if err := applyFormatConfigForMaintenanceWithOptions(&opts, true); err != nil {
 		return err
 	}
 	if opts.ChunkSize == 0 {

--- a/TreeDB/db/vacuum_offline_test.go
+++ b/TreeDB/db/vacuum_offline_test.go
@@ -81,6 +81,75 @@ func TestVacuumIndexOffline_PreservesDataAndShrinksFile(t *testing.T) {
 	}
 }
 
+func TestVacuumIndexOffline_CommandWALPreservesDataAndShrinksFile(t *testing.T) {
+	dir := t.TempDir()
+	chunkSize := int64(4 * 1024 * 1024)
+
+	d, err := Open(Options{
+		Dir:                    dir,
+		ChunkSize:              chunkSize,
+		KeepRecent:             1,
+		CommandWAL:             true,
+		DisableBackgroundPrune: true,
+		PreferAppendAlloc:      true,
+	})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	value := bytes.Repeat([]byte("v"), 200)
+	for i := 0; i < 128; i++ {
+		b := d.NewBatch()
+		k := []byte(fmt.Sprintf("k%06d", i))
+		if err := b.Set(k, value); err != nil {
+			t.Fatalf("set: %v", err)
+		}
+		if err := b.Write(); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		_ = b.Close()
+	}
+	if err := d.Checkpoint(); err != nil {
+		t.Fatalf("checkpoint: %v", err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	indexPath := filepath.Join(dir, indexFileName)
+	beforeInfo, err := os.Stat(indexPath)
+	if err != nil {
+		t.Fatalf("stat before: %v", err)
+	}
+	if beforeInfo.Size() != chunkSize {
+		t.Fatalf("index.db before=%d want chunk floor %d", beforeInfo.Size(), chunkSize)
+	}
+
+	if err := VacuumIndexOffline(Options{Dir: dir, KeepRecent: 1}); err != nil {
+		t.Fatalf("vacuum: %v", err)
+	}
+
+	afterInfo, err := os.Stat(indexPath)
+	if err != nil {
+		t.Fatalf("stat after: %v", err)
+	}
+	if afterInfo.Size() >= beforeInfo.Size() {
+		t.Fatalf("expected command-WAL vacuum to shrink index.db: before=%d after=%d", beforeInfo.Size(), afterInfo.Size())
+	}
+
+	verify, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open after: %v", err)
+	}
+	defer func() { _ = verify.Close() }()
+	got, err := verify.Get([]byte("k000010"))
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if !bytes.Equal(got, value) {
+		t.Fatalf("value mismatch")
+	}
+}
+
 func TestVacuumIndexOffline_OuterLeavesInValueLog_PreservesLeafRefs(t *testing.T) {
 	dir := t.TempDir()
 	opts := Options{

--- a/TreeDB/offline_maintenance_format_config_test.go
+++ b/TreeDB/offline_maintenance_format_config_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	treedb "github.com/snissn/gomap/TreeDB"
@@ -46,7 +47,7 @@ func leafFlagsInIndex(t *testing.T, indexPath string) uint16 {
 	return 0
 }
 
-func TestOfflineMaintenanceRejectsCommandWALBeforeSideStoreOpen(t *testing.T) {
+func TestOfflineMaintenanceCommandWALGateBeforeSideStoreOpen(t *testing.T) {
 	root := t.TempDir()
 	mainDir := filepath.Join(root, "maindb")
 	if err := os.MkdirAll(mainDir, 0o755); err != nil {
@@ -56,15 +57,17 @@ func TestOfflineMaintenanceRejectsCommandWALBeforeSideStoreOpen(t *testing.T) {
 		t.Fatalf("SaveFormatConfig: %v", err)
 	}
 	// If public offline maintenance reaches side-store wiring, this malformed
-	// dictdb path returns a different error. command_wal_v1 must fail first even
-	// when IgnoreFormatConfig is set.
+	// dictdb path returns a different error. Index vacuum supports command-WAL
+	// DBs and should reach that validation; value-log rewrite must reject
+	// command-WAL before side-store wiring, even when IgnoreFormatConfig is set.
 	if err := os.MkdirAll(filepath.Join(root, "dictdb", "index.db"), 0o755); err != nil {
 		t.Fatalf("mkdir malformed dictdb index: %v", err)
 	}
 
 	for _, ignoreFormatConfig := range []bool{false, true} {
-		if err := treedb.VacuumIndexOffline(treedb.Options{Dir: root, IgnoreFormatConfig: ignoreFormatConfig}); !errors.Is(err, treedb.ErrCommandWALUnsupported) {
-			t.Fatalf("VacuumIndexOffline IgnoreFormatConfig=%v error=%v, want ErrCommandWALUnsupported", ignoreFormatConfig, err)
+		err := treedb.VacuumIndexOffline(treedb.Options{Dir: root, IgnoreFormatConfig: ignoreFormatConfig})
+		if err == nil || errors.Is(err, treedb.ErrCommandWALUnsupported) || !strings.Contains(err.Error(), "dictdb index path is a directory") {
+			t.Fatalf("VacuumIndexOffline IgnoreFormatConfig=%v error=%v, want malformed dictdb error", ignoreFormatConfig, err)
 		}
 		if _, err := treedb.ValueLogRewriteOffline(treedb.Options{Dir: root, IgnoreFormatConfig: ignoreFormatConfig}); !errors.Is(err, treedb.ErrCommandWALUnsupported) {
 			t.Fatalf("ValueLogRewriteOffline IgnoreFormatConfig=%v error=%v, want ErrCommandWALUnsupported", ignoreFormatConfig, err)

--- a/TreeDB/public.go
+++ b/TreeDB/public.go
@@ -1869,16 +1869,12 @@ func VacuumIndexOffline(opts Options) error {
 		if err != nil {
 			return err
 		}
-		if requiresCommandWAL {
-			return db.ErrCommandWALUnsupported
-		}
+		opts.CommandWAL = opts.CommandWAL || requiresCommandWAL
 	} else {
 		if cfg, ok, err := db.LoadFormatConfig(layout.mainDir); err != nil {
 			return err
 		} else if ok {
-			if cfg.RequiresCommandWALV1() {
-				return db.ErrCommandWALUnsupported
-			}
+			opts.CommandWAL = opts.CommandWAL || cfg.RequiresCommandWALV1()
 			cfg.ApplyToOptions(&opts)
 		}
 	}

--- a/benchmarks/vector_db_compare/summarize.py
+++ b/benchmarks/vector_db_compare/summarize.py
@@ -34,6 +34,10 @@ def bytes_human(value: float) -> str:
 def storage_record(result: dict[str, Any]) -> dict[str, Any]:
     if "storage_after_build" in result:
         return result["storage_after_build"]
+    if "storage_after_index_vacuum" in result:
+        return result["storage_after_index_vacuum"]
+    if "storage_after_close" in result:
+        return result["storage_after_close"]
     if "storage_after_compact" in result:
         return result["storage_after_compact"]
     if "storage" in result:
@@ -169,7 +173,7 @@ def render(results: list[dict[str, Any]]) -> str:
     lines.append("- PostgreSQL+pgvector storage uses the benchmark table's `pg_total_relation_size`, including its HNSW index.")
     lines.append("- MongoDB is included only when run against a MongoDB Vector Search deployment, such as Atlas or local Atlas with `mongot`; plain `mongod` is not a vector-search comparator.")
     lines.append("- MongoDB storage marked with `*` uses `collStats` collection storage and ordinary index bytes; MongoDB Vector Search index bytes are not exposed by this harness.")
-    lines.append("- TreeDB storage is the reopened benchmark datastore reported by `treedb_vector_search_demo`.")
+    lines.append("- TreeDB storage uses the post-close, post-index-vacuum retained datastore when reported by `treedb_vector_search_demo`; raw pre-close and pre-vacuum storage fields remain in the JSON.")
     lines.append("- Memory columns are intentionally separated: TreeDB reports native vector-index memory when available, while Python-backed comparator harnesses report whole benchmark process max RSS.")
     lines.append("")
     return "\n".join(lines)

--- a/cmd/treedb_vector_search_demo/main.go
+++ b/cmd/treedb_vector_search_demo/main.go
@@ -63,6 +63,7 @@ type config struct {
 	minRecall             float64
 	compact               bool
 	compactSyncEachPhase  bool
+	vacuumIndex           bool
 	disableExactFallback  bool
 	requireValueLogBytes  bool
 	requireLeafVLogBytes  bool
@@ -100,12 +101,15 @@ type result struct {
 	Insert                phaseResult                       `json:"insert"`
 	Rebuild               phaseResult                       `json:"rebuild"`
 	CompactPhase          phaseResult                       `json:"compact_phase"`
+	IndexVacuum           phaseResult                       `json:"index_vacuum"`
 	ReopenLoad            phaseResult                       `json:"reopen_load"`
 	Validation            validationResult                  `json:"validation"`
 	Search                searchBenchmarkResult             `json:"search"`
 	SearchBenchmarks      []searchBenchmarkResult           `json:"search_benchmarks"`
 	StorageBeforeCompact  storageReport                     `json:"storage_before_compact"`
 	StorageAfterCompact   storageReport                     `json:"storage_after_compact"`
+	StorageAfterClose     storageReport                     `json:"storage_after_close"`
+	StorageAfterVacuum    storageReport                     `json:"storage_after_index_vacuum"`
 	IndexStatsBefore      collections.VectorIndexStats      `json:"index_stats_before_compact"`
 	IndexStatsLoaded      collections.VectorIndexStats      `json:"index_stats_loaded"`
 	NativeRootBytes       int64                             `json:"native_root_bytes"`
@@ -273,6 +277,7 @@ func parseConfig(args []string) (config, error) {
 		minRecall:             0.95,
 		matrix:                true,
 		compact:               false,
+		vacuumIndex:           true,
 		disableExactFallback:  true,
 		profile:               treedb.ProfileBench,
 		vectorIndexStrategy:   collections.VectorIndexStrategyNativeRuntime,
@@ -304,6 +309,7 @@ func parseConfig(args []string) (config, error) {
 	fs.Float64Var(&cfg.minRecall, "min-recall", cfg.minRecall, "Minimum validation recall@topK")
 	fs.BoolVar(&cfg.compact, "compact", cfg.compact, "Run CompactStorageFull after insert/index build and before reopen/validation/search")
 	fs.BoolVar(&cfg.compactSyncEachPhase, "compact-sync-each-phase", false, "Ask CompactStorage to fsync each rewrite/pack phase")
+	fs.BoolVar(&cfg.vacuumIndex, "vacuum-index", cfg.vacuumIndex, "Run offline index.db vacuum after close before final storage/reopen")
 	fs.BoolVar(&cfg.disableExactFallback, "disable-exact-fallback", cfg.disableExactFallback, "Disable exact fallback during ANN benchmark queries")
 	fs.BoolVar(&cfg.requireValueLogBytes, "require-value-log-bytes", false, "Fail if compacted storage has no value-log bytes")
 	fs.BoolVar(&cfg.requireLeafVLogBytes, "require-leaf-vlog-bytes", false, "Fail if compacted storage has no leaf value-log bytes")
@@ -735,6 +741,23 @@ func execute(ctx context.Context, cfg config) (result, error) {
 	}
 	cleanupBackend = nil
 	d = nil
+	res.StorageAfterClose, err = storageUsage(dir, cfg.docs)
+	if err != nil {
+		return result{}, err
+	}
+	if cfg.vacuumIndex {
+		vacuumStart := time.Now()
+		if err := treedb.VacuumIndexOffline(treedb.Options{Dir: dir, KeepRecent: 1}); err != nil {
+			return result{}, fmt.Errorf("index vacuum: %w", err)
+		}
+		res.IndexVacuum = phaseSince(vacuumStart)
+		res.StorageAfterVacuum, err = storageUsage(dir, cfg.docs)
+		if err != nil {
+			return result{}, err
+		}
+	} else {
+		res.StorageAfterVacuum = res.StorageAfterClose
+	}
 	runtime.GC()
 
 	reopenStart := time.Now()
@@ -1932,6 +1955,11 @@ func printText(w io.Writer, res result) {
 	} else {
 		fmt.Fprintf(w, "compact_storage_full: skipped\n")
 	}
+	if res.IndexVacuum.DurationNanos > 0 {
+		fmt.Fprintf(w, "index_vacuum: %.3fs\n", res.IndexVacuum.Seconds)
+	} else {
+		fmt.Fprintf(w, "index_vacuum: skipped\n")
+	}
 	fmt.Fprintf(w, "reopen_and_load_native_index: %.3fs\n", res.ReopenLoad.Seconds)
 	fmt.Fprintf(w, "\nValidation\n")
 	fmt.Fprintf(w, "documents_checked=%d queries_checked=%d recall_at_%d=%.4f overlap=%d/%d\n",
@@ -1950,6 +1978,12 @@ func printText(w io.Writer, res result) {
 	fmt.Fprintf(w, "\nStorage\n")
 	fmt.Fprintf(w, "before_compact_total=%d bytes (%.1f/doc)\n", res.StorageBeforeCompact.TotalBytes, res.StorageBeforeCompact.BytesPerDoc)
 	fmt.Fprintf(w, "after_compact_total=%d bytes (%.1f/doc)\n", res.StorageAfterCompact.TotalBytes, res.StorageAfterCompact.BytesPerDoc)
+	if res.StorageAfterClose.TotalBytes > 0 {
+		fmt.Fprintf(w, "after_close_total=%d bytes (%.1f/doc)\n", res.StorageAfterClose.TotalBytes, res.StorageAfterClose.BytesPerDoc)
+	}
+	if res.StorageAfterVacuum.TotalBytes > 0 {
+		fmt.Fprintf(w, "after_index_vacuum_total=%d bytes (%.1f/doc)\n", res.StorageAfterVacuum.TotalBytes, res.StorageAfterVacuum.BytesPerDoc)
+	}
 	if res.FormatConfig != nil {
 		fmt.Fprintf(w, "format index_outer_leaves_in_vlog=%t leaf_prefix_compression=%t vlog_compression=%s\n",
 			res.FormatConfig.IndexOuterLeavesInValueLog,
@@ -1976,6 +2010,11 @@ func printMatrixText(w io.Writer, res matrixResult) {
 		fmt.Fprintf(w, "storage_after_compact_total=%d bytes (%.1f/doc)\n",
 			testCase.Result.StorageAfterCompact.TotalBytes,
 			testCase.Result.StorageAfterCompact.BytesPerDoc)
+		if testCase.Result.StorageAfterVacuum.TotalBytes > 0 {
+			fmt.Fprintf(w, "storage_after_index_vacuum_total=%d bytes (%.1f/doc)\n",
+				testCase.Result.StorageAfterVacuum.TotalBytes,
+				testCase.Result.StorageAfterVacuum.BytesPerDoc)
+		}
 		fmt.Fprintf(w, "storage_domains index_db=%d value_vlog=%d leaf_vlog=%d\n",
 			testCase.Result.StorageExpectation.IndexBytes,
 			testCase.Result.StorageExpectation.ValueLogBytes,


### PR DESCRIPTION
## Summary

- allow offline index vacuum on clean command-WAL TreeDB directories while keeping offline value-log rewrite rejected
- report post-close and post-index-vacuum storage from `treedb_vector_search_demo`
- make the vector DB comparison summary prefer the vacuumed retained TreeDB footprint when present

## Why

The column_graph benchmark was comparing pgvector retained relation bytes against TreeDB pre-close/pre-vacuum bytes. Command WAL disappears after close, and the benchmark profile leaves a 4 MiB `index.db` allocation floor that can be safely reclaimed with index vacuum.

## Validation

- `go test ./cmd/treedb_vector_search_demo ./TreeDB/db ./TreeDB -run 'TestDemoCommandWALFormatConfigPreservesProfileKnobs|TestRunTextOutput|TestVacuumIndexOffline|TestCommandWALRequiredFeatureRejectsOfflineValueLogRewrite|TestSideStoreChunkSize|TestVacuum'`\n- `go test ./TreeDB/db -run '^(TestVacuumIndexOffline|TestCommandWALRequiredFeatureRejectsOfflineValueLogRewrite)'`\n- `go test ./TreeDB -run '^(TestSideStoreChunkSize|TestVacuum)'`\n- `go test ./cmd/treedb_vector_search_demo`\n- `python3 -m py_compile benchmarks/vector_db_compare/summarize.py`\n- small column_graph smoke run: recall 1.0, `storage_after_index_vacuum` reported\n\n## Benchmark Note\n\nOn the existing 10k artifact copy, index vacuum reduced TreeDB retained files to 8,567,747 bytes (856.8 B/doc), versus pgvector table+indexes at 9,330,688 bytes (933.1 B/doc).\n\n## Notes\n\nBase PR: #1743. This PR is not merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Demo app adds optional offline index vacuum flag (enabled by default); results now record storage after index vacuum.

* **Tests**
  * Updated command‑WAL feature tests and renamed test to assert gating before side‑store wiring; added offline index‑vacuum test that verifies data preservation and file shrinkage; widened assertions to accept expected error patterns.

* **Refactor**
  * Offline maintenance now enforces command‑WAL gating earlier and enables command‑WAL when allowed instead of outright rejecting.

* **Benchmarks**
  * Benchmark output now prefers post‑vacuum storage snapshots and updated notes accordingly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1745?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->