### PR TITLE
TreeDB: land Gate A mapped resource substrate

### DIFF
--- a/TreeDB/collections/column_asset_manager.go
+++ b/TreeDB/collections/column_asset_manager.go
@@ -926,29 +926,6 @@ func (c *columnPhysicalAssetReadCache) releaseResourceHandles() error {
 	return releaseErr
 }
 
-func (c *columnPhysicalAssetReadCache) releaseResourceHandlesBySource(source mappedresource.Source) error {
-	if c == nil || len(c.resourceHandles) == 0 {
-		return nil
-	}
-	var releaseErr error
-	kept := c.resourceHandles[:0]
-	for _, handle := range c.resourceHandles {
-		if handle == nil {
-			continue
-		}
-		if handle.Source() == source {
-			if err := handle.Release(); err != nil && releaseErr == nil {
-				releaseErr = err
-			}
-			continue
-		}
-		kept = append(kept, handle)
-	}
-	clear(c.resourceHandles[len(kept):])
-	c.resourceHandles = kept
-	return releaseErr
-}
-
 func (c *columnPhysicalAssetReadCache) close() error {
 	var closeErr error
 	if err := c.releaseResourceHandles(); err != nil {
@@ -1065,21 +1042,19 @@ func (c *columnPhysicalAssetReadCache) trackResourceRead(ref ColumnAssetRef, raw
 	if reason == "" {
 		reason = "column_physical_asset_read"
 	}
+	// columnPhysicalAssetReadCache returns implicit byte views/copies without a
+	// caller-visible release hook. Treat the next read as the previous returned
+	// buffer's lifetime boundary so active pins do not grow without bound.
+	if err := c.releaseResourceHandles(); err != nil {
+		return err
+	}
 	handleBytes := raw
-	if source == mappedresource.SourceHeapCopy {
-		// Heap-copy reads use the cache scratch path, so their implicit lifetime
-		// ends when the next heap read may reuse scratch. Keep at most the current
-		// heap handle active; mmap/view handles remain pinned until cache close.
-		if err := c.releaseResourceHandlesBySource(mappedresource.SourceHeapCopy); err != nil {
-			return err
-		}
-		if len(raw) != 0 {
-			// AcquireBytes requires immutable bytes for the handle lifetime. Syscall
-			// reads may return c.scratch, which is reused on later reads, so the
-			// accounting/pin handle owns a stable copy while it is active. The caller
-			// still receives the original raw bytes.
-			handleBytes = append([]byte(nil), raw...)
-		}
+	if source == mappedresource.SourceHeapCopy && len(raw) != 0 {
+		// AcquireBytes requires immutable bytes for the handle lifetime. Syscall
+		// reads may return c.scratch, which is reused on later reads, so the
+		// accounting/pin handle owns a stable copy while it is active. The caller
+		// still receives the original raw bytes.
+		handleBytes = append([]byte(nil), raw...)
 	}
 	handle, err := c.resourceManager.AcquireBytes(key, scope, source, handleBytes, mappedresource.AcquireOptions{
 		Reason:         reason,

--- a/TreeDB/collections/column_asset_manager.go
+++ b/TreeDB/collections/column_asset_manager.go
@@ -1042,7 +1042,15 @@ func (c *columnPhysicalAssetReadCache) trackResourceRead(ref ColumnAssetRef, raw
 	if reason == "" {
 		reason = "column_physical_asset_read"
 	}
-	handle, err := c.resourceManager.AcquireBytes(key, scope, source, raw, mappedresource.AcquireOptions{
+	handleBytes := raw
+	if source == mappedresource.SourceHeapCopy && len(raw) != 0 {
+		// AcquireBytes requires immutable bytes for the handle lifetime. Syscall
+		// reads may return c.scratch, which is reused on later reads, so the
+		// accounting/pin handle owns a stable copy when mapped-resource reporting
+		// is enabled. The caller still receives the original raw bytes.
+		handleBytes = append([]byte(nil), raw...)
+	}
+	handle, err := c.resourceManager.AcquireBytes(key, scope, source, handleBytes, mappedresource.AcquireOptions{
 		Reason:         reason,
 		ValidationMode: mappedResourceValidationModeForColumnAssetIntegrity(c.readIntegrity),
 		FallbackReason: fallback,

--- a/TreeDB/collections/column_asset_manager.go
+++ b/TreeDB/collections/column_asset_manager.go
@@ -926,6 +926,29 @@ func (c *columnPhysicalAssetReadCache) releaseResourceHandles() error {
 	return releaseErr
 }
 
+func (c *columnPhysicalAssetReadCache) releaseResourceHandlesBySource(source mappedresource.Source) error {
+	if c == nil || len(c.resourceHandles) == 0 {
+		return nil
+	}
+	var releaseErr error
+	kept := c.resourceHandles[:0]
+	for _, handle := range c.resourceHandles {
+		if handle == nil {
+			continue
+		}
+		if handle.Source() == source {
+			if err := handle.Release(); err != nil && releaseErr == nil {
+				releaseErr = err
+			}
+			continue
+		}
+		kept = append(kept, handle)
+	}
+	clear(c.resourceHandles[len(kept):])
+	c.resourceHandles = kept
+	return releaseErr
+}
+
 func (c *columnPhysicalAssetReadCache) close() error {
 	var closeErr error
 	if err := c.releaseResourceHandles(); err != nil {
@@ -1043,12 +1066,20 @@ func (c *columnPhysicalAssetReadCache) trackResourceRead(ref ColumnAssetRef, raw
 		reason = "column_physical_asset_read"
 	}
 	handleBytes := raw
-	if source == mappedresource.SourceHeapCopy && len(raw) != 0 {
-		// AcquireBytes requires immutable bytes for the handle lifetime. Syscall
-		// reads may return c.scratch, which is reused on later reads, so the
-		// accounting/pin handle owns a stable copy when mapped-resource reporting
-		// is enabled. The caller still receives the original raw bytes.
-		handleBytes = append([]byte(nil), raw...)
+	if source == mappedresource.SourceHeapCopy {
+		// Heap-copy reads use the cache scratch path, so their implicit lifetime
+		// ends when the next heap read may reuse scratch. Keep at most the current
+		// heap handle active; mmap/view handles remain pinned until cache close.
+		if err := c.releaseResourceHandlesBySource(mappedresource.SourceHeapCopy); err != nil {
+			return err
+		}
+		if len(raw) != 0 {
+			// AcquireBytes requires immutable bytes for the handle lifetime. Syscall
+			// reads may return c.scratch, which is reused on later reads, so the
+			// accounting/pin handle owns a stable copy while it is active. The caller
+			// still receives the original raw bytes.
+			handleBytes = append([]byte(nil), raw...)
+		}
 	}
 	handle, err := c.resourceManager.AcquireBytes(key, scope, source, handleBytes, mappedresource.AcquireOptions{
 		Reason:         reason,

--- a/TreeDB/collections/column_asset_manager.go
+++ b/TreeDB/collections/column_asset_manager.go
@@ -926,6 +926,29 @@ func (c *columnPhysicalAssetReadCache) releaseResourceHandles() error {
 	return releaseErr
 }
 
+func (c *columnPhysicalAssetReadCache) releaseResourceHandlesBySource(source mappedresource.Source) error {
+	if c == nil || len(c.resourceHandles) == 0 {
+		return nil
+	}
+	var releaseErr error
+	kept := c.resourceHandles[:0]
+	for _, handle := range c.resourceHandles {
+		if handle == nil {
+			continue
+		}
+		if handle.Source() == source {
+			if err := handle.Release(); err != nil && releaseErr == nil {
+				releaseErr = err
+			}
+			continue
+		}
+		kept = append(kept, handle)
+	}
+	clear(c.resourceHandles[len(kept):])
+	c.resourceHandles = kept
+	return releaseErr
+}
+
 func (c *columnPhysicalAssetReadCache) close() error {
 	var closeErr error
 	if err := c.releaseResourceHandles(); err != nil {
@@ -1042,19 +1065,29 @@ func (c *columnPhysicalAssetReadCache) trackResourceRead(ref ColumnAssetRef, raw
 	if reason == "" {
 		reason = "column_physical_asset_read"
 	}
-	// columnPhysicalAssetReadCache returns implicit byte views/copies without a
-	// caller-visible release hook. Treat the next read as the previous returned
-	// buffer's lifetime boundary so active pins do not grow without bound.
-	if err := c.releaseResourceHandles(); err != nil {
-		return err
+	if source == mappedresource.SourceMapped {
+		for _, handle := range c.resourceHandles {
+			if handle != nil && !handle.Released() && handle.Source() == source && handle.Key().Equal(key) {
+				return nil
+			}
+		}
 	}
 	handleBytes := raw
-	if source == mappedresource.SourceHeapCopy && len(raw) != 0 {
-		// AcquireBytes requires immutable bytes for the handle lifetime. Syscall
-		// reads may return c.scratch, which is reused on later reads, so the
-		// accounting/pin handle owns a stable copy while it is active. The caller
-		// still receives the original raw bytes.
-		handleBytes = append([]byte(nil), raw...)
+	if source == mappedresource.SourceHeapCopy {
+		// Heap-copy reads use the cache scratch path, so their implicit lifetime
+		// ends when the next heap read may reuse scratch. Keep at most the current
+		// heap handle active. Mapped view handles remain pinned until cache close,
+		// with duplicate keys deduplicated above.
+		if err := c.releaseResourceHandlesBySource(mappedresource.SourceHeapCopy); err != nil {
+			return err
+		}
+		if len(raw) != 0 {
+			// AcquireBytes requires immutable bytes for the handle lifetime. Syscall
+			// reads may return c.scratch, which is reused on later reads, so the
+			// accounting/pin handle owns a stable copy while it is active. The caller
+			// still receives the original raw bytes.
+			handleBytes = append([]byte(nil), raw...)
+		}
 	}
 	handle, err := c.resourceManager.AcquireBytes(key, scope, source, handleBytes, mappedresource.AcquireOptions{
 		Reason:         reason,

--- a/TreeDB/collections/column_asset_manager.go
+++ b/TreeDB/collections/column_asset_manager.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"syscall"
 
+	"github.com/snissn/gomap/TreeDB/internal/mappedresource"
 	"github.com/snissn/gomap/TreeDB/page"
 )
 
@@ -840,6 +841,11 @@ type columnPhysicalAssetReadCache struct {
 	lastView       bool
 	hits           uint64
 	misses         uint64
+
+	resourceManager *mappedresource.Manager
+	resourceScope   mappedresource.Scope
+	resourceReason  string
+	resourceHandles []*mappedresource.Handle
 }
 
 type columnPhysicalAssetSegmentReader struct {
@@ -873,8 +879,58 @@ func newColumnPhysicalAssetReadCacheWithIntegrity(rootDir string, namespace stri
 	}, nil
 }
 
+func (c *columnPhysicalAssetReadCache) useMappedResourceManager(manager *mappedresource.Manager, scope mappedresource.Scope, reason string) error {
+	if c == nil {
+		return errors.New("collections: nil column physical asset read cache")
+	}
+	if manager != nil {
+		if scope.Namespace == "" {
+			scope.Namespace = c.namespace
+		}
+		if err := scope.Validate(); err != nil {
+			return err
+		}
+	}
+	c.resourceManager = manager
+	c.resourceScope = scope
+	c.resourceReason = reason
+	return nil
+}
+
+func (c *columnPhysicalAssetReadCache) mappedResourceStats() mappedresource.Stats {
+	if c == nil || c.resourceManager == nil {
+		return mappedresource.Stats{}
+	}
+	return c.resourceManager.Stats()
+}
+
+func (c *columnPhysicalAssetReadCache) mappedResourcePins() []mappedresource.Pin {
+	if c == nil || c.resourceManager == nil {
+		return nil
+	}
+	return c.resourceManager.PinSummary()
+}
+
+func (c *columnPhysicalAssetReadCache) releaseResourceHandles() error {
+	if c == nil || len(c.resourceHandles) == 0 {
+		return nil
+	}
+	var releaseErr error
+	for _, handle := range c.resourceHandles {
+		if err := handle.Release(); err != nil && releaseErr == nil {
+			releaseErr = err
+		}
+	}
+	clear(c.resourceHandles)
+	c.resourceHandles = c.resourceHandles[:0]
+	return releaseErr
+}
+
 func (c *columnPhysicalAssetReadCache) close() error {
 	var closeErr error
+	if err := c.releaseResourceHandles(); err != nil {
+		closeErr = err
+	}
 	if c.scratch != nil {
 		putColumnPhysicalAssetReadScratch(c.scratch)
 		c.scratch = nil
@@ -919,6 +975,9 @@ func (c *columnPhysicalAssetReadCache) read(ref ColumnAssetRef, dst []byte) ([]b
 			if err := c.verifyReadChecksum(raw, ref, reader); err != nil {
 				return nil, err
 			}
+			if err := c.trackResourceRead(ref, raw, mappedresource.SourceMapped, ""); err != nil {
+				return nil, err
+			}
 			c.lastView = true
 			return raw, nil
 		}
@@ -939,6 +998,13 @@ func (c *columnPhysicalAssetReadCache) read(ref ColumnAssetRef, dst []byte) ([]b
 	if err := c.verifyReadChecksum(raw, ref, reader); err != nil {
 		return nil, err
 	}
+	var fallback mappedresource.FallbackReason
+	if c.returnViews {
+		fallback = mappedresource.FallbackReadAt
+	}
+	if err := c.trackResourceRead(ref, raw, mappedresource.SourceHeapCopy, fallback); err != nil {
+		return nil, err
+	}
 	return raw, nil
 }
 
@@ -955,6 +1021,62 @@ func (c *columnPhysicalAssetReadCache) verifyReadChecksum(raw []byte, ref Column
 		}
 	}
 	return verifyColumnPhysicalAssetReadChecksumWithIntegrityForSegment(raw, ref, c.verifyChecksum, c.readIntegrity, c.rootDir, fileIdentity)
+}
+
+func (c *columnPhysicalAssetReadCache) trackResourceRead(ref ColumnAssetRef, raw []byte, source mappedresource.Source, fallback mappedresource.FallbackReason) error {
+	if c == nil || c.resourceManager == nil {
+		return nil
+	}
+	key := mappedResourceKeyForColumnAssetRef(ref)
+	if key.Length != int64(len(raw)) {
+		return fmt.Errorf("collections: column asset mapped-resource key length=%d raw bytes=%d", key.Length, len(raw))
+	}
+	scope := c.resourceScope
+	if scope.Kind == "" {
+		scope = mappedresource.Scope{Kind: mappedresource.ScopeTypedRowReader, ID: "column-physical-asset-read-cache", Namespace: c.namespace}
+	}
+	if scope.Namespace == "" {
+		scope.Namespace = c.namespace
+	}
+	reason := c.resourceReason
+	if reason == "" {
+		reason = "column_physical_asset_read"
+	}
+	handle, err := c.resourceManager.AcquireBytes(key, scope, source, raw, mappedresource.AcquireOptions{
+		Reason:         reason,
+		ValidationMode: mappedResourceValidationModeForColumnAssetIntegrity(c.readIntegrity),
+		FallbackReason: fallback,
+	})
+	if err != nil {
+		return err
+	}
+	c.resourceHandles = append(c.resourceHandles, handle)
+	return nil
+}
+
+func mappedResourceKeyForColumnAssetRef(ref ColumnAssetRef) mappedresource.Key {
+	return mappedresource.Key{
+		Class:      mappedresource.ClassTypedRowAsset,
+		Namespace:  ref.Namespace,
+		Kind:       string(ref.Kind),
+		Generation: ref.Generation,
+		PartID:     ref.PartID,
+		FileID:     ref.FileID,
+		Offset:     ref.Offset,
+		Length:     ref.Length,
+		Checksum:   uint64(ref.Checksum),
+	}
+}
+
+func mappedResourceValidationModeForColumnAssetIntegrity(integrity ColumnAssetReadIntegrity) mappedresource.ValidationMode {
+	switch integrity {
+	case ColumnAssetReadIntegrityCachedVerify:
+		return mappedresource.ValidationCachedVerify
+	case ColumnAssetReadIntegritySkipChecksums:
+		return mappedresource.ValidationSkipChecksum
+	default:
+		return mappedresource.ValidationVerify
+	}
 }
 
 func getColumnPhysicalAssetReadScratch(minLen int) []byte {
@@ -982,15 +1104,24 @@ func (c *columnPhysicalAssetReadCache) fileForRef(ref ColumnAssetRef) (*columnPh
 	}
 	if c.file != nil && c.fileID == ref.FileID {
 		c.hits++
+		if c.resourceManager != nil {
+			c.resourceManager.RecordHit()
+		}
 		return c.file, nil
 	}
 	if c.files != nil {
 		if reader := c.files[ref.FileID]; reader != nil {
 			c.hits++
+			if c.resourceManager != nil {
+				c.resourceManager.RecordHit()
+			}
 			return reader, nil
 		}
 	}
 	c.misses++
+	if c.resourceManager != nil {
+		c.resourceManager.RecordMiss()
+	}
 	file, err := os.Open(filepath.Join(c.segmentDir, columnAssetSegmentFileName(ref.FileID)))
 	if err != nil {
 		return nil, err

--- a/TreeDB/collections/column_asset_mappedresource_test.go
+++ b/TreeDB/collections/column_asset_mappedresource_test.go
@@ -83,6 +83,48 @@ func TestColumnAssetReadCacheReportsMappedResourceHandlesGateA1736(t *testing.T)
 	}
 }
 
+func TestColumnAssetReadCacheMappedResourceHeapHandlesOwnStableBytesGateA1736(t *testing.T) {
+	cfg := testColumnStoreConfig(nil)
+	normalized, err := normalizeColumnStoreConfig("events", cfg)
+	if err != nil {
+		t.Fatalf("normalizeColumnStoreConfig: %v", err)
+	}
+	root := backenddb.ColumnAssetRootDirPath(t.TempDir())
+	firstPayload := []byte("aaaaaaaaaaaaaaaa")
+	secondPayload := []byte("bbbbbbbbbbbbbbbb")
+	first, err := writeColumnPhysicalAssetToManager(root, *normalized, firstPayload, 7, 3)
+	if err != nil {
+		t.Fatalf("write first asset: %v", err)
+	}
+	second, err := writeColumnPhysicalAssetToManager(root, *normalized, secondPayload, 7, 4)
+	if err != nil {
+		t.Fatalf("write second asset: %v", err)
+	}
+
+	manager := mappedresource.NewManager()
+	readCache, err := newColumnPhysicalAssetReadCacheWithIntegrity(root, normalized.AssetManager.Namespace, ColumnAssetReadIntegritySkipChecksums)
+	if err != nil {
+		t.Fatalf("new read cache: %v", err)
+	}
+	defer readCache.close()
+	if err := readCache.useMappedResourceManager(manager, mappedresource.Scope{Kind: mappedresource.ScopeSnapshot, ID: "snapshot-7", Namespace: normalized.AssetManager.Namespace}, "typed-row-asset-read"); err != nil {
+		t.Fatalf("useMappedResourceManager: %v", err)
+	}
+	if _, err := readCache.read(first, nil); err != nil {
+		t.Fatalf("read first: %v", err)
+	}
+	if len(readCache.resourceHandles) != 1 {
+		t.Fatalf("resource handles after first read=%d want 1", len(readCache.resourceHandles))
+	}
+	firstHandle := readCache.resourceHandles[0]
+	if _, err := readCache.read(second, nil); err != nil {
+		t.Fatalf("read second: %v", err)
+	}
+	if got := firstHandle.Bytes(); !bytes.Equal(got, firstPayload) {
+		t.Fatalf("first handle bytes after second read=%q want %q", got, firstPayload)
+	}
+}
+
 func TestColumnAssetReadCacheMappedResourceScopeValidationGateA1736(t *testing.T) {
 	readCache := columnPhysicalAssetReadCache{namespace: "events"}
 	manager := mappedresource.NewManager()

--- a/TreeDB/collections/column_asset_mappedresource_test.go
+++ b/TreeDB/collections/column_asset_mappedresource_test.go
@@ -135,6 +135,54 @@ func TestColumnAssetReadCacheMappedResourceHeapHandlesOwnStableBytesGateA1736(t 
 	}
 }
 
+func TestColumnAssetReadCacheMappedResourceViewHandlesDoNotAccumulateGateA1736(t *testing.T) {
+	cfg := testColumnStoreConfig(nil)
+	normalized, err := normalizeColumnStoreConfig("events", cfg)
+	if err != nil {
+		t.Fatalf("normalizeColumnStoreConfig: %v", err)
+	}
+	root := backenddb.ColumnAssetRootDirPath(t.TempDir())
+	payload := []byte("mapped-view-handle-payload")
+	ref, err := writeColumnPhysicalAssetToManager(root, *normalized, payload, 7, 3)
+	if err != nil {
+		t.Fatalf("write asset: %v", err)
+	}
+
+	manager := mappedresource.NewManager()
+	readCache, err := newColumnPhysicalAssetReadCacheWithIntegrity(root, normalized.AssetManager.Namespace, ColumnAssetReadIntegritySkipChecksums)
+	if err != nil {
+		t.Fatalf("new read cache: %v", err)
+	}
+	defer readCache.close()
+	readCache.returnViews = true
+	if err := readCache.useMappedResourceManager(manager, mappedresource.Scope{Kind: mappedresource.ScopeSnapshot, ID: "snapshot-7", Namespace: normalized.AssetManager.Namespace}, "typed-row-asset-read"); err != nil {
+		t.Fatalf("useMappedResourceManager: %v", err)
+	}
+	if _, err := readCache.read(ref, nil); err != nil {
+		t.Fatalf("read first: %v", err)
+	}
+	if len(readCache.resourceHandles) != 1 {
+		t.Fatalf("resource handles after first view read=%d want 1", len(readCache.resourceHandles))
+	}
+	firstHandle := readCache.resourceHandles[0]
+	if firstHandle.Source() != mappedresource.SourceMapped {
+		t.Skip("mmap views are unavailable on this platform")
+	}
+	if _, err := readCache.read(ref, nil); err != nil {
+		t.Fatalf("read second: %v", err)
+	}
+	if !firstHandle.Released() {
+		t.Fatal("first mapped view handle is still active after next view read")
+	}
+	if len(readCache.resourceHandles) != 1 || readCache.resourceHandles[0] == firstHandle {
+		t.Fatalf("resource handles after second view read=%d first retained=%v", len(readCache.resourceHandles), len(readCache.resourceHandles) == 1 && readCache.resourceHandles[0] == firstHandle)
+	}
+	stats := manager.Stats()
+	if stats.ActiveHandles != 1 || stats.ActiveMappedBytes != int64(len(payload)) || stats.TotalReleases != 1 {
+		t.Fatalf("stats after repeated view read: %+v", stats)
+	}
+}
+
 func TestColumnAssetReadCacheMappedResourceScopeValidationGateA1736(t *testing.T) {
 	readCache := columnPhysicalAssetReadCache{namespace: "events"}
 	manager := mappedresource.NewManager()

--- a/TreeDB/collections/column_asset_mappedresource_test.go
+++ b/TreeDB/collections/column_asset_mappedresource_test.go
@@ -1,0 +1,92 @@
+package collections
+
+import (
+	"bytes"
+	"testing"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/internal/mappedresource"
+)
+
+func TestColumnAssetReadCacheReportsMappedResourceHandlesGateA1736(t *testing.T) {
+	cfg := testColumnStoreConfig(nil)
+	normalized, err := normalizeColumnStoreConfig("events", cfg)
+	if err != nil {
+		t.Fatalf("normalizeColumnStoreConfig: %v", err)
+	}
+	root := backenddb.ColumnAssetRootDirPath(t.TempDir())
+	payload := []byte("gate-a-typed-row-asset-resource")
+	ref, err := writeColumnPhysicalAssetToManager(root, *normalized, payload, 7, 3)
+	if err != nil {
+		t.Fatalf("writeColumnPhysicalAssetToManager: %v", err)
+	}
+
+	manager := mappedresource.NewManager()
+	readCache, err := newColumnPhysicalAssetReadCacheWithIntegrity(root, normalized.AssetManager.Namespace, ColumnAssetReadIntegritySkipChecksums)
+	if err != nil {
+		t.Fatalf("new read cache: %v", err)
+	}
+	scope := mappedresource.Scope{
+		Kind:       mappedresource.ScopeSnapshot,
+		ID:         "snapshot-7",
+		Namespace:  normalized.AssetManager.Namespace,
+		Collection: "events",
+		Generation: 7,
+		Reason:     "gate-a-test",
+	}
+	if err := readCache.useMappedResourceManager(manager, scope, "typed-row-asset-read"); err != nil {
+		t.Fatalf("useMappedResourceManager: %v", err)
+	}
+
+	raw, err := readCache.read(ref, nil)
+	if err != nil {
+		_ = readCache.close()
+		t.Fatalf("read: %v", err)
+	}
+	if !bytes.Equal(raw, payload) {
+		_ = readCache.close()
+		t.Fatalf("raw=%q want %q", raw, payload)
+	}
+	stats := readCache.mappedResourceStats()
+	if stats.ActiveHandles != 1 || stats.ActiveHeapCopyBytes != int64(len(payload)) || stats.TotalAcquires != 1 {
+		_ = readCache.close()
+		t.Fatalf("mapped resource stats after read: %+v", stats)
+	}
+	if got := stats.ValidationModeReads[mappedresource.ValidationSkipChecksum]; got != 1 {
+		_ = readCache.close()
+		t.Fatalf("validation mode count=%d want 1 stats=%+v", got, stats)
+	}
+	pins := readCache.mappedResourcePins()
+	if len(pins) != 1 {
+		_ = readCache.close()
+		t.Fatalf("pins=%d want 1", len(pins))
+	}
+	pin := pins[0]
+	if pin.Key.Class != mappedresource.ClassTypedRowAsset || pin.Key.Namespace != ref.Namespace || pin.Key.FileID != ref.FileID || pin.Key.Offset != ref.Offset || pin.Key.Length != ref.Length || pin.Key.Checksum != uint64(ref.Checksum) {
+		_ = readCache.close()
+		t.Fatalf("unexpected pin key: %+v ref=%+v", pin.Key, ref)
+	}
+	if pin.Scope.Kind != mappedresource.ScopeSnapshot || pin.Scope.ID != "snapshot-7" || pin.Reason != "typed-row-asset-read" {
+		_ = readCache.close()
+		t.Fatalf("unexpected pin scope/reason: %+v", pin)
+	}
+
+	if err := readCache.close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	stats = manager.Stats()
+	if stats.ActiveHandles != 0 || stats.ActiveHeapCopyBytes != 0 || stats.TotalReleases != 1 {
+		t.Fatalf("mapped resource stats after close: %+v", stats)
+	}
+	if pins := manager.PinSummary(); len(pins) != 0 {
+		t.Fatalf("pins after close=%d want 0", len(pins))
+	}
+}
+
+func TestColumnAssetReadCacheMappedResourceScopeValidationGateA1736(t *testing.T) {
+	readCache := columnPhysicalAssetReadCache{namespace: "events"}
+	manager := mappedresource.NewManager()
+	if err := readCache.useMappedResourceManager(manager, mappedresource.Scope{Kind: mappedresource.ScopeSnapshot}, "bad"); err == nil {
+		t.Fatal("useMappedResourceManager accepted lifetime-less scope")
+	}
+}

--- a/TreeDB/collections/column_asset_mappedresource_test.go
+++ b/TreeDB/collections/column_asset_mappedresource_test.go
@@ -171,14 +171,14 @@ func TestColumnAssetReadCacheMappedResourceViewHandlesDoNotAccumulateGateA1736(t
 	if _, err := readCache.read(ref, nil); err != nil {
 		t.Fatalf("read second: %v", err)
 	}
-	if !firstHandle.Released() {
-		t.Fatal("first mapped view handle is still active after next view read")
+	if firstHandle.Released() {
+		t.Fatal("first mapped view handle was released while its mmap-backed bytes remain readable")
 	}
-	if len(readCache.resourceHandles) != 1 || readCache.resourceHandles[0] == firstHandle {
-		t.Fatalf("resource handles after second view read=%d first retained=%v", len(readCache.resourceHandles), len(readCache.resourceHandles) == 1 && readCache.resourceHandles[0] == firstHandle)
+	if len(readCache.resourceHandles) != 1 || readCache.resourceHandles[0] != firstHandle {
+		t.Fatalf("resource handles after duplicate view read=%d first retained=%v", len(readCache.resourceHandles), len(readCache.resourceHandles) == 1 && readCache.resourceHandles[0] == firstHandle)
 	}
 	stats := manager.Stats()
-	if stats.ActiveHandles != 1 || stats.ActiveMappedBytes != int64(len(payload)) || stats.TotalReleases != 1 {
+	if stats.ActiveHandles != 1 || stats.ActiveMappedBytes != int64(len(payload)) || stats.TotalAcquires != 1 || stats.TotalReleases != 0 {
 		t.Fatalf("stats after repeated view read: %+v", stats)
 	}
 }

--- a/TreeDB/collections/column_asset_mappedresource_test.go
+++ b/TreeDB/collections/column_asset_mappedresource_test.go
@@ -117,11 +117,21 @@ func TestColumnAssetReadCacheMappedResourceHeapHandlesOwnStableBytesGateA1736(t 
 		t.Fatalf("resource handles after first read=%d want 1", len(readCache.resourceHandles))
 	}
 	firstHandle := readCache.resourceHandles[0]
+	if got := firstHandle.Bytes(); !bytes.Equal(got, firstPayload) {
+		t.Fatalf("first handle bytes before scratch reuse=%q want %q", got, firstPayload)
+	}
 	if _, err := readCache.read(second, nil); err != nil {
 		t.Fatalf("read second: %v", err)
 	}
-	if got := firstHandle.Bytes(); !bytes.Equal(got, firstPayload) {
-		t.Fatalf("first handle bytes after second read=%q want %q", got, firstPayload)
+	if !firstHandle.Released() {
+		t.Fatal("first heap handle is still active after scratch-backed read reuse")
+	}
+	if len(readCache.resourceHandles) != 1 || readCache.resourceHandles[0] == firstHandle {
+		t.Fatalf("resource handles after second read=%d first retained=%v", len(readCache.resourceHandles), len(readCache.resourceHandles) == 1 && readCache.resourceHandles[0] == firstHandle)
+	}
+	stats := manager.Stats()
+	if stats.ActiveHandles != 1 || stats.ActiveHeapCopyBytes != int64(len(secondPayload)) || stats.TotalReleases != 1 {
+		t.Fatalf("stats after second scratch-backed read: %+v", stats)
 	}
 }
 

--- a/TreeDB/collections/column_physical_asset_test.go
+++ b/TreeDB/collections/column_physical_asset_test.go
@@ -1300,7 +1300,7 @@ func TestColumnAssetManagerWriteAllowsZeroChecksumM12A(t *testing.T) {
 	if err != nil {
 		t.Fatalf("normalizeColumnStoreConfig: %v", err)
 	}
-	payload := []byte{0xab, 0x9b, 0xe0, 0x9b}
+	payload := []byte{0x9d, 0x0a, 0xd9, 0x6d}
 	if checksum := page.Checksum(payload); checksum != 0 {
 		t.Fatalf("test payload checksum=%d, want 0", checksum)
 	}

--- a/TreeDB/internal/mappedresource/manager.go
+++ b/TreeDB/internal/mappedresource/manager.go
@@ -360,12 +360,19 @@ func (m *Manager) acquireRegistered(key Key, scope Scope, source Source, data []
 func (m *Manager) release(id uint64, source Source, bytes int64, releaseErr error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if _, ok := m.active[id]; ok {
+	_, ok := m.active[id]
+	if ok {
 		delete(m.active, id)
 	} else {
 		ensureDeniedMap(&m.stats)[DenyReleaseMismatch]++
 	}
 	m.stats.TotalReleases++
+	if releaseErr != nil {
+		m.stats.Errors++
+	}
+	if !ok {
+		return
+	}
 	if m.stats.ActiveHandles > 0 {
 		m.stats.ActiveHandles--
 	}
@@ -376,9 +383,6 @@ func (m *Manager) release(id uint64, source Source, bytes int64, releaseErr erro
 		m.stats.ActiveHeapCopyBytes -= bytes
 	case SourceDerivedMetadata:
 		m.stats.ActiveDerivedMetadataBytes -= bytes
-	}
-	if releaseErr != nil {
-		m.stats.Errors++
 	}
 }
 

--- a/TreeDB/internal/mappedresource/manager.go
+++ b/TreeDB/internal/mappedresource/manager.go
@@ -290,6 +290,21 @@ func (m *Manager) AcquireFileRange(key Key, scope Scope, path string, opts Acqui
 		m.recordDenied(DenyUnsupported)
 		return nil, errors.New("mappedresource: heap-copy fallback disabled")
 	}
+	info, err := file.Stat()
+	if err != nil {
+		_ = file.Close()
+		m.recordClose()
+		m.recordDenied(DenyReadFailed)
+		m.recordError()
+		return nil, err
+	}
+	end := key.Offset + key.Length
+	if key.Offset < 0 || end < key.Offset || end > info.Size() {
+		_ = file.Close()
+		m.recordClose()
+		m.recordDenied(DenyOutOfBounds)
+		return nil, fmt.Errorf("mappedresource: range offset=%d length=%d outside file bytes=%d", key.Offset, key.Length, info.Size())
+	}
 	raw := make([]byte, int(key.Length))
 	n, err := file.ReadAt(raw, key.Offset)
 	closeErr := file.Close()

--- a/TreeDB/internal/mappedresource/manager.go
+++ b/TreeDB/internal/mappedresource/manager.go
@@ -1,0 +1,508 @@
+package mappedresource
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"sync"
+)
+
+// Source identifies how a handle's bytes are backed.
+type Source string
+
+const (
+	SourceMapped          Source = "mmap"
+	SourceHeapCopy        Source = "heap_copy"
+	SourceDerivedMetadata Source = "derived_metadata"
+)
+
+// DenyReason and FallbackReason provide stable accounting labels.
+type DenyReason string
+type FallbackReason string
+type ValidationMode string
+
+const (
+	DenyInvalidKey      DenyReason = "invalid_key"
+	DenyInvalidScope    DenyReason = "invalid_scope"
+	DenyUnsupported     DenyReason = "unsupported"
+	DenyOpenFailed      DenyReason = "open_failed"
+	DenyOutOfBounds     DenyReason = "out_of_bounds"
+	DenyReadFailed      DenyReason = "read_failed"
+	DenyMmapFailed      DenyReason = "mmap_failed"
+	DenyReleaseMismatch DenyReason = "release_mismatch"
+)
+
+const (
+	FallbackMmapFailed FallbackReason = "mmap_failed"
+	FallbackReadAt     FallbackReason = "readat"
+)
+
+const (
+	ValidationVerify       ValidationMode = "verify"
+	ValidationCachedVerify ValidationMode = "cached_verify"
+	ValidationSkipChecksum ValidationMode = "skip_checksums"
+)
+
+// Stats is the common row+column resource accounting shape used by adapters and
+// future column-part readers.
+type Stats struct {
+	ActiveHandles              int64
+	ActiveMappedBytes          int64
+	ActiveHeapCopyBytes        int64
+	ActiveDerivedMetadataBytes int64
+
+	TotalAcquires             uint64
+	TotalReleases             uint64
+	TotalMappedBytes          uint64
+	TotalHeapCopyBytes        uint64
+	TotalDerivedMetadataBytes uint64
+
+	Hits          uint64
+	Misses        uint64
+	FallbackReads uint64
+	Opens         uint64
+	Closes        uint64
+	Errors        uint64
+
+	DirectViewSuccesses uint64
+	DirectViewFailures  uint64
+
+	DeniedByReason      map[DenyReason]uint64
+	FallbacksByReason   map[FallbackReason]uint64
+	ValidationModeReads map[ValidationMode]uint64
+}
+
+// Pin describes one active handle visible to maintenance planning.
+type Pin struct {
+	ID     uint64
+	Key    Key
+	Scope  Scope
+	Source Source
+	Bytes  int64
+	Reason string
+}
+
+// Manager tracks resource handles and accounting. It intentionally does not
+// choose a global cache policy; subsystems can wrap existing caches while using
+// this manager for lifetime, pin, and stats visibility.
+type Manager struct {
+	mu     sync.Mutex
+	nextID uint64
+	stats  Stats
+	active map[uint64]Pin
+}
+
+// NewManager constructs an empty manager.
+func NewManager() *Manager {
+	return &Manager{active: make(map[uint64]Pin)}
+}
+
+// AcquireOptions controls resource acquisition and accounting labels.
+type AcquireOptions struct {
+	Reason         string
+	ValidationMode ValidationMode
+	PreferMapped   bool
+	AllowHeapCopy  bool
+	FallbackReason FallbackReason
+}
+
+// Handle owns a live resource view. Bytes are valid until Release. Release is
+// idempotent and updates accounting only once.
+type Handle struct {
+	mu      sync.Mutex
+	mgr     *Manager
+	id      uint64
+	key     Key
+	scope   Scope
+	source  Source
+	bytes   []byte
+	release func() error
+	err     error
+	done    bool
+}
+
+// Key returns the resource key.
+func (h *Handle) Key() Key {
+	if h == nil {
+		return Key{}
+	}
+	return h.key
+}
+
+// Scope returns the lifetime scope.
+func (h *Handle) Scope() Scope {
+	if h == nil {
+		return Scope{}
+	}
+	return h.scope
+}
+
+// Source returns the backing source.
+func (h *Handle) Source() Source {
+	if h == nil {
+		return ""
+	}
+	return h.source
+}
+
+// Bytes returns the live byte view. After Release it returns nil.
+func (h *Handle) Bytes() []byte {
+	if h == nil {
+		return nil
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.done {
+		return nil
+	}
+	return h.bytes
+}
+
+// Released reports whether the handle has been released.
+func (h *Handle) Released() bool {
+	if h == nil {
+		return true
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.done
+}
+
+// Release releases the handle and removes its maintenance pin.
+func (h *Handle) Release() error {
+	if h == nil {
+		return nil
+	}
+	h.mu.Lock()
+	if h.done {
+		err := h.err
+		h.mu.Unlock()
+		return err
+	}
+	h.done = true
+	mgr := h.mgr
+	id := h.id
+	source := h.source
+	bytes := int64(len(h.bytes))
+	release := h.release
+	h.bytes = nil
+	h.mu.Unlock()
+
+	var err error
+	if release != nil {
+		err = release()
+	}
+	if mgr != nil {
+		mgr.release(id, source, bytes, err)
+	}
+	h.mu.Lock()
+	h.err = err
+	h.mu.Unlock()
+	return err
+}
+
+// AcquireBytes registers caller-provided immutable bytes as a resource handle.
+// The manager does not copy bytes; callers must ensure the slice remains stable
+// for the handle lifetime.
+func (m *Manager) AcquireBytes(key Key, scope Scope, source Source, data []byte, opts AcquireOptions) (*Handle, error) {
+	if m == nil {
+		return nil, errors.New("mappedresource: nil manager")
+	}
+	if err := scope.ValidateForKey(key); err != nil {
+		m.recordDenied(classifyValidationDeny(err))
+		return nil, err
+	}
+	if int64(len(data)) != key.Length {
+		m.recordDenied(DenyOutOfBounds)
+		return nil, fmt.Errorf("mappedresource: data bytes=%d do not match key length=%d", len(data), key.Length)
+	}
+	if source == "" {
+		source = SourceHeapCopy
+	}
+	switch source {
+	case SourceMapped, SourceHeapCopy, SourceDerivedMetadata:
+	default:
+		m.recordDenied(DenyUnsupported)
+		return nil, fmt.Errorf("mappedresource: unsupported source %q", source)
+	}
+	return m.acquireRegistered(key, scope, source, data, nil, opts), nil
+}
+
+// AcquireFileRange opens path and returns either an mmap-backed or heap-copy
+// handle for key.Offset:key.Offset+key.Length. Mmap is best-effort when
+// PreferMapped is set; AllowHeapCopy controls fallback.
+func (m *Manager) AcquireFileRange(key Key, scope Scope, path string, opts AcquireOptions) (*Handle, error) {
+	if m == nil {
+		return nil, errors.New("mappedresource: nil manager")
+	}
+	if err := scope.ValidateForKey(key); err != nil {
+		m.recordDenied(classifyValidationDeny(err))
+		return nil, err
+	}
+	if path == "" {
+		m.recordDenied(DenyOpenFailed)
+		return nil, errors.New("mappedresource: empty file path")
+	}
+	if key.Length > int64(int(^uint(0)>>1)) {
+		m.recordDenied(DenyOutOfBounds)
+		return nil, fmt.Errorf("mappedresource: length=%d exceeds host int", key.Length)
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		m.recordDenied(DenyOpenFailed)
+		m.recordError()
+		return nil, err
+	}
+	m.recordOpen()
+	if opts.PreferMapped {
+		mapped, mapErr := mmapFile(file)
+		if mapErr == nil {
+			end := key.Offset + key.Length
+			if key.Offset < 0 || end < key.Offset || end > int64(len(mapped)) {
+				_ = munmapFile(mapped)
+				_ = file.Close()
+				m.recordClose()
+				m.recordDenied(DenyOutOfBounds)
+				return nil, fmt.Errorf("mappedresource: range offset=%d length=%d outside mapped bytes=%d", key.Offset, key.Length, len(mapped))
+			}
+			view := mapped[key.Offset:end]
+			release := func() error {
+				return errors.Join(munmapFile(mapped), file.Close())
+			}
+			return m.acquireRegistered(key, scope, SourceMapped, view, release, opts), nil
+		}
+		if !opts.AllowHeapCopy {
+			_ = file.Close()
+			m.recordClose()
+			m.recordDenied(DenyMmapFailed)
+			m.recordError()
+			return nil, mapErr
+		}
+		m.recordFallback(FallbackMmapFailed)
+	}
+	if !opts.AllowHeapCopy && opts.PreferMapped {
+		_ = file.Close()
+		m.recordClose()
+		m.recordDenied(DenyUnsupported)
+		return nil, errors.New("mappedresource: heap-copy fallback disabled")
+	}
+	raw := make([]byte, int(key.Length))
+	n, err := file.ReadAt(raw, key.Offset)
+	closeErr := file.Close()
+	m.recordClose()
+	if err != nil && err != io.EOF {
+		m.recordDenied(DenyReadFailed)
+		m.recordError()
+		return nil, err
+	}
+	if n != len(raw) {
+		m.recordDenied(DenyOutOfBounds)
+		m.recordError()
+		return nil, io.ErrUnexpectedEOF
+	}
+	if closeErr != nil {
+		m.recordError()
+		return nil, closeErr
+	}
+	return m.acquireRegistered(key, scope, SourceHeapCopy, raw, nil, opts), nil
+}
+
+func (m *Manager) acquireRegistered(key Key, scope Scope, source Source, data []byte, release func() error, opts AcquireOptions) *Handle {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.nextID++
+	id := m.nextID
+	bytes := int64(len(data))
+	m.stats.ActiveHandles++
+	m.stats.TotalAcquires++
+	if opts.ValidationMode != "" {
+		ensureValidationMap(&m.stats)[opts.ValidationMode]++
+	}
+	if opts.FallbackReason != "" {
+		ensureFallbackMap(&m.stats)[opts.FallbackReason]++
+		m.stats.FallbackReads++
+	}
+	switch source {
+	case SourceMapped:
+		m.stats.ActiveMappedBytes += bytes
+		m.stats.TotalMappedBytes += uint64(bytes)
+	case SourceHeapCopy:
+		m.stats.ActiveHeapCopyBytes += bytes
+		m.stats.TotalHeapCopyBytes += uint64(bytes)
+	case SourceDerivedMetadata:
+		m.stats.ActiveDerivedMetadataBytes += bytes
+		m.stats.TotalDerivedMetadataBytes += uint64(bytes)
+	}
+	pin := Pin{ID: id, Key: key, Scope: scope, Source: source, Bytes: bytes, Reason: opts.Reason}
+	m.active[id] = pin
+	return &Handle{mgr: m, id: id, key: key, scope: scope, source: source, bytes: data, release: release}
+}
+
+func (m *Manager) release(id uint64, source Source, bytes int64, releaseErr error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, ok := m.active[id]; ok {
+		delete(m.active, id)
+	} else {
+		ensureDeniedMap(&m.stats)[DenyReleaseMismatch]++
+	}
+	m.stats.TotalReleases++
+	if m.stats.ActiveHandles > 0 {
+		m.stats.ActiveHandles--
+	}
+	switch source {
+	case SourceMapped:
+		m.stats.ActiveMappedBytes -= bytes
+	case SourceHeapCopy:
+		m.stats.ActiveHeapCopyBytes -= bytes
+	case SourceDerivedMetadata:
+		m.stats.ActiveDerivedMetadataBytes -= bytes
+	}
+	if releaseErr != nil {
+		m.stats.Errors++
+	}
+}
+
+// Stats returns a stable snapshot.
+func (m *Manager) Stats() Stats {
+	if m == nil {
+		return Stats{}
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return cloneStats(m.stats)
+}
+
+// PinSummary returns active handles visible to maintenance.
+func (m *Manager) PinSummary() []Pin {
+	if m == nil {
+		return nil
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]Pin, 0, len(m.active))
+	for _, pin := range m.active {
+		out = append(out, pin)
+	}
+	return out
+}
+
+// RecordHit records an adapter cache hit.
+func (m *Manager) RecordHit() {
+	if m == nil {
+		return
+	}
+	m.mu.Lock()
+	m.stats.Hits++
+	m.mu.Unlock()
+}
+
+// RecordMiss records an adapter cache miss.
+func (m *Manager) RecordMiss() {
+	if m == nil {
+		return
+	}
+	m.mu.Lock()
+	m.stats.Misses++
+	m.mu.Unlock()
+}
+
+func (m *Manager) recordDirectView(err error) {
+	if m == nil {
+		return
+	}
+	m.mu.Lock()
+	if err != nil {
+		m.stats.DirectViewFailures++
+	} else {
+		m.stats.DirectViewSuccesses++
+	}
+	m.mu.Unlock()
+}
+
+func (m *Manager) recordDenied(reason DenyReason) {
+	m.mu.Lock()
+	ensureDeniedMap(&m.stats)[reason]++
+	m.mu.Unlock()
+}
+
+func (m *Manager) recordFallback(reason FallbackReason) {
+	m.mu.Lock()
+	ensureFallbackMap(&m.stats)[reason]++
+	m.stats.FallbackReads++
+	m.mu.Unlock()
+}
+
+func (m *Manager) recordOpen() {
+	m.mu.Lock()
+	m.stats.Opens++
+	m.mu.Unlock()
+}
+
+func (m *Manager) recordClose() {
+	m.mu.Lock()
+	m.stats.Closes++
+	m.mu.Unlock()
+}
+
+func (m *Manager) recordError() {
+	m.mu.Lock()
+	m.stats.Errors++
+	m.mu.Unlock()
+}
+
+func classifyValidationDeny(err error) DenyReason {
+	if err == nil {
+		return DenyUnsupported
+	}
+	if strings.Contains(err.Error(), "scope") {
+		return DenyInvalidScope
+	}
+	return DenyInvalidKey
+}
+
+func ensureDeniedMap(stats *Stats) map[DenyReason]uint64 {
+	if stats.DeniedByReason == nil {
+		stats.DeniedByReason = make(map[DenyReason]uint64)
+	}
+	return stats.DeniedByReason
+}
+
+func ensureFallbackMap(stats *Stats) map[FallbackReason]uint64 {
+	if stats.FallbacksByReason == nil {
+		stats.FallbacksByReason = make(map[FallbackReason]uint64)
+	}
+	return stats.FallbacksByReason
+}
+
+func ensureValidationMap(stats *Stats) map[ValidationMode]uint64 {
+	if stats.ValidationModeReads == nil {
+		stats.ValidationModeReads = make(map[ValidationMode]uint64)
+	}
+	return stats.ValidationModeReads
+}
+
+func cloneStats(in Stats) Stats {
+	out := in
+	if in.DeniedByReason != nil {
+		out.DeniedByReason = make(map[DenyReason]uint64, len(in.DeniedByReason))
+		for k, v := range in.DeniedByReason {
+			out.DeniedByReason[k] = v
+		}
+	}
+	if in.FallbacksByReason != nil {
+		out.FallbacksByReason = make(map[FallbackReason]uint64, len(in.FallbacksByReason))
+		for k, v := range in.FallbacksByReason {
+			out.FallbacksByReason[k] = v
+		}
+	}
+	if in.ValidationModeReads != nil {
+		out.ValidationModeReads = make(map[ValidationMode]uint64, len(in.ValidationModeReads))
+		for k, v := range in.ValidationModeReads {
+			out.ValidationModeReads[k] = v
+		}
+	}
+	return out
+}

--- a/TreeDB/internal/mappedresource/manager.go
+++ b/TreeDB/internal/mappedresource/manager.go
@@ -269,7 +269,9 @@ func (m *Manager) AcquireFileRange(key Key, scope Scope, path string, opts Acqui
 			}
 			view := mapped[key.Offset:end]
 			release := func() error {
-				return errors.Join(munmapFile(mapped), file.Close())
+				err := errors.Join(munmapFile(mapped), file.Close())
+				m.recordClose()
+				return err
 			}
 			return m.acquireRegistered(key, scope, SourceMapped, view, release, opts), nil
 		}

--- a/TreeDB/internal/mappedresource/manager_test.go
+++ b/TreeDB/internal/mappedresource/manager_test.go
@@ -119,6 +119,24 @@ func TestAcquireFileRangeMmapFallbackCountsReason(t *testing.T) {
 	}
 }
 
+func TestAcquireFileRangeRejectsOutOfBoundsZeroLengthHeapRange(t *testing.T) {
+	mgr := NewManager()
+	key := testKey()
+	key.Offset = 1
+	key.Length = 0
+	path := t.TempDir() + "/empty.bin"
+	if err := os.WriteFile(path, nil, 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if _, err := mgr.AcquireFileRange(key, testScope(), path, AcquireOptions{AllowHeapCopy: true}); err == nil {
+		t.Fatal("AcquireFileRange out-of-bounds zero-length heap range err=nil, want failure")
+	}
+	stats := mgr.Stats()
+	if stats.DeniedByReason[DenyOutOfBounds] != 1 || stats.ActiveHandles != 0 {
+		t.Fatalf("unexpected stats after out-of-bounds range: %+v", stats)
+	}
+}
+
 func TestFakeColumnPartSectionAcquireReleaseAndMaintenancePins(t *testing.T) {
 	mgr := NewManager()
 	key := Key{

--- a/TreeDB/internal/mappedresource/manager_test.go
+++ b/TreeDB/internal/mappedresource/manager_test.go
@@ -70,18 +70,30 @@ func TestAcquireFileRangeMappedAndHeapReturnIdenticalBytes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("AcquireFileRange mapped: %v", err)
 	}
-	defer mapped.Release()
 	heap, err := mgr.AcquireFileRange(key, testScope(), path, AcquireOptions{Reason: "heap", AllowHeapCopy: true})
 	if err != nil {
+		_ = mapped.Release()
 		t.Fatalf("AcquireFileRange heap: %v", err)
 	}
-	defer heap.Release()
 	if !bytes.Equal(mapped.Bytes(), heap.Bytes()) {
 		t.Fatalf("mapped bytes %q != heap bytes %q", string(mapped.Bytes()), string(heap.Bytes()))
 	}
 	stats := mgr.Stats()
 	if stats.ActiveHandles != 2 || stats.ActiveMappedBytes != 16 || stats.ActiveHeapCopyBytes != 16 || stats.Opens != 2 || stats.Closes != 1 {
+		_ = mapped.Release()
+		_ = heap.Release()
 		t.Fatalf("unexpected stats with mapped+heap active: %+v", stats)
+	}
+	if err := mapped.Release(); err != nil {
+		_ = heap.Release()
+		t.Fatalf("mapped Release: %v", err)
+	}
+	if err := heap.Release(); err != nil {
+		t.Fatalf("heap Release: %v", err)
+	}
+	stats = mgr.Stats()
+	if stats.ActiveHandles != 0 || stats.ActiveMappedBytes != 0 || stats.ActiveHeapCopyBytes != 0 || stats.Opens != 2 || stats.Closes != 2 {
+		t.Fatalf("unexpected stats after releases: %+v", stats)
 	}
 }
 

--- a/TreeDB/internal/mappedresource/manager_test.go
+++ b/TreeDB/internal/mappedresource/manager_test.go
@@ -52,6 +52,27 @@ func TestAcquireBytesReleaseUpdatesAccountingAndPins(t *testing.T) {
 	}
 }
 
+func TestReleaseMismatchDoesNotCorruptActiveAccounting(t *testing.T) {
+	mgr := NewManager()
+	h, err := mgr.AcquireBytes(testKey(), testScope(), SourceHeapCopy, []byte("0123456789abcdef"), AcquireOptions{Reason: "unit"})
+	if err != nil {
+		t.Fatalf("AcquireBytes: %v", err)
+	}
+	mgr.release(999, SourceHeapCopy, 16, nil)
+	stats := mgr.Stats()
+	if stats.ActiveHandles != 1 || stats.ActiveHeapCopyBytes != 16 || stats.DeniedByReason[DenyReleaseMismatch] != 1 {
+		_ = h.Release()
+		t.Fatalf("release mismatch corrupted active stats: %+v", stats)
+	}
+	if err := h.Release(); err != nil {
+		t.Fatalf("Release: %v", err)
+	}
+	stats = mgr.Stats()
+	if stats.ActiveHandles != 0 || stats.ActiveHeapCopyBytes != 0 || stats.TotalReleases != 2 {
+		t.Fatalf("stats after real release: %+v", stats)
+	}
+}
+
 func TestAcquireFileRangeMappedAndHeapReturnIdenticalBytes(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("mmap unsupported in test manager on windows")

--- a/TreeDB/internal/mappedresource/manager_test.go
+++ b/TreeDB/internal/mappedresource/manager_test.go
@@ -1,0 +1,144 @@
+package mappedresource
+
+import (
+	"bytes"
+	"os"
+	"runtime"
+	"testing"
+)
+
+func testKey() Key {
+	return Key{Class: ClassTypedColumnAsset, Namespace: "test", Kind: "column_part", Generation: 1, PartID: 2, FileID: 3, Offset: 0, Length: 16, Checksum: 4, Version: 1, Section: Section{Kind: "column_data", Column: "c0"}}
+}
+
+func testScope() Scope {
+	return Scope{Kind: ScopeSnapshot, ID: "snapshot-1", Namespace: "test", Collection: "events", Generation: 1}
+}
+
+func TestAcquireBytesReleaseUpdatesAccountingAndPins(t *testing.T) {
+	mgr := NewManager()
+	h, err := mgr.AcquireBytes(testKey(), testScope(), SourceHeapCopy, []byte("0123456789abcdef"), AcquireOptions{Reason: "unit", ValidationMode: ValidationVerify})
+	if err != nil {
+		t.Fatalf("AcquireBytes: %v", err)
+	}
+	stats := mgr.Stats()
+	if stats.ActiveHandles != 1 || stats.ActiveHeapCopyBytes != 16 || stats.TotalHeapCopyBytes != 16 || stats.TotalAcquires != 1 {
+		t.Fatalf("unexpected stats after acquire: %+v", stats)
+	}
+	if got := len(mgr.PinSummary()); got != 1 {
+		t.Fatalf("PinSummary entries=%d want 1", got)
+	}
+	if string(h.Bytes()) != "0123456789abcdef" {
+		t.Fatalf("handle bytes=%q", string(h.Bytes()))
+	}
+	if err := h.Release(); err != nil {
+		t.Fatalf("Release: %v", err)
+	}
+	if got := h.Bytes(); got != nil {
+		t.Fatalf("released handle Bytes=%v want nil", got)
+	}
+	stats = mgr.Stats()
+	if stats.ActiveHandles != 0 || stats.ActiveHeapCopyBytes != 0 || stats.TotalReleases != 1 {
+		t.Fatalf("unexpected stats after release: %+v", stats)
+	}
+	if got := len(mgr.PinSummary()); got != 0 {
+		t.Fatalf("PinSummary entries after release=%d want 0", got)
+	}
+	if err := h.Release(); err != nil {
+		t.Fatalf("second Release: %v", err)
+	}
+	if stats := mgr.Stats(); stats.TotalReleases != 1 {
+		t.Fatalf("idempotent release TotalReleases=%d want 1", stats.TotalReleases)
+	}
+}
+
+func TestAcquireFileRangeMappedAndHeapReturnIdenticalBytes(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("mmap unsupported in test manager on windows")
+	}
+	dir := t.TempDir()
+	path := dir + "/asset.bin"
+	payload := []byte("prefix:0123456789abcdef:suffix")
+	if err := os.WriteFile(path, payload, 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	key := testKey()
+	key.Offset = int64(len("prefix:"))
+	key.Length = 16
+	mgr := NewManager()
+	mapped, err := mgr.AcquireFileRange(key, testScope(), path, AcquireOptions{Reason: "mapped", PreferMapped: true, AllowHeapCopy: false})
+	if err != nil {
+		t.Fatalf("AcquireFileRange mapped: %v", err)
+	}
+	defer mapped.Release()
+	heap, err := mgr.AcquireFileRange(key, testScope(), path, AcquireOptions{Reason: "heap", AllowHeapCopy: true})
+	if err != nil {
+		t.Fatalf("AcquireFileRange heap: %v", err)
+	}
+	defer heap.Release()
+	if !bytes.Equal(mapped.Bytes(), heap.Bytes()) {
+		t.Fatalf("mapped bytes %q != heap bytes %q", string(mapped.Bytes()), string(heap.Bytes()))
+	}
+	stats := mgr.Stats()
+	if stats.ActiveHandles != 2 || stats.ActiveMappedBytes != 16 || stats.ActiveHeapCopyBytes != 16 || stats.Opens != 2 || stats.Closes != 1 {
+		t.Fatalf("unexpected stats with mapped+heap active: %+v", stats)
+	}
+}
+
+func TestAcquireFileRangeMmapFallbackCountsReason(t *testing.T) {
+	mgr := NewManager()
+	key := testKey()
+	key.Length = 0
+	path := t.TempDir() + "/empty.bin"
+	if err := os.WriteFile(path, nil, 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	h, err := mgr.AcquireFileRange(key, testScope(), path, AcquireOptions{PreferMapped: true, AllowHeapCopy: true})
+	if err != nil {
+		t.Fatalf("AcquireFileRange empty fallback: %v", err)
+	}
+	defer h.Release()
+	if h.Source() != SourceHeapCopy {
+		t.Fatalf("source=%s want heap fallback", h.Source())
+	}
+	stats := mgr.Stats()
+	if stats.FallbackReads != 1 || stats.FallbacksByReason[FallbackMmapFailed] != 1 {
+		t.Fatalf("fallback stats=%+v", stats)
+	}
+}
+
+func TestFakeColumnPartSectionAcquireReleaseAndMaintenancePins(t *testing.T) {
+	mgr := NewManager()
+	key := Key{
+		Class:      ClassTypedColumnAsset,
+		Namespace:  "colparts",
+		Kind:       "column_part_image",
+		Generation: 10,
+		PartID:     22,
+		FileID:     5,
+		Offset:     4096,
+		Length:     32,
+		Checksum:   1234,
+		Version:    1,
+		Encoding:   "little_endian",
+		Section:    Section{Kind: "column_data", Category: "declared_columns", Column: "score", Ordinal: 7},
+	}
+	scope := Scope{Kind: ScopeColumnPartReader, ID: "part-reader-1", Namespace: "colparts", Collection: "events", Generation: 10, Reason: "test"}
+	h, err := mgr.AcquireBytes(key, scope, SourceMapped, make([]byte, int(key.Length)), AcquireOptions{Reason: "future-column-part-section"})
+	if err != nil {
+		t.Fatalf("AcquireBytes fake column part: %v", err)
+	}
+	pins := mgr.PinSummary()
+	if len(pins) != 1 {
+		t.Fatalf("pins=%d want 1", len(pins))
+	}
+	if !pins[0].Key.Equal(key) || pins[0].Scope.Kind != ScopeColumnPartReader || pins[0].Reason != "future-column-part-section" {
+		t.Fatalf("unexpected pin: %+v", pins[0])
+	}
+	if err := h.Release(); err != nil {
+		t.Fatalf("Release: %v", err)
+	}
+	if got := len(mgr.PinSummary()); got != 0 {
+		t.Fatalf("pins after release=%d want 0", got)
+	}
+}

--- a/TreeDB/internal/mappedresource/mmap_fallback.go
+++ b/TreeDB/internal/mappedresource/mmap_fallback.go
@@ -1,0 +1,16 @@
+//go:build !(darwin || linux || freebsd || netbsd || openbsd || windows)
+
+package mappedresource
+
+import (
+	"fmt"
+	"os"
+)
+
+func mmapFile(file *os.File) ([]byte, error) {
+	return nil, fmt.Errorf("mappedresource: mmap unsupported on this platform")
+}
+
+func munmapFile(data []byte) error {
+	return nil
+}

--- a/TreeDB/internal/mappedresource/mmap_unix.go
+++ b/TreeDB/internal/mappedresource/mmap_unix.go
@@ -1,0 +1,31 @@
+//go:build !windows
+
+package mappedresource
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+func mmapFile(file *os.File) ([]byte, error) {
+	if file == nil {
+		return nil, fmt.Errorf("mappedresource: nil file")
+	}
+	info, err := file.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if info.Size() == 0 {
+		return nil, fmt.Errorf("mappedresource: cannot mmap empty file")
+	}
+	fd := int(file.Fd())
+	return syscall.Mmap(fd, 0, int(info.Size()), syscall.PROT_READ, syscall.MAP_SHARED)
+}
+
+func munmapFile(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
+	return syscall.Munmap(data)
+}

--- a/TreeDB/internal/mappedresource/mmap_unix.go
+++ b/TreeDB/internal/mappedresource/mmap_unix.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build darwin || linux || freebsd || netbsd || openbsd
 
 package mappedresource
 

--- a/TreeDB/internal/mappedresource/mmap_unix.go
+++ b/TreeDB/internal/mappedresource/mmap_unix.go
@@ -16,11 +16,15 @@ func mmapFile(file *os.File) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	if info.Size() == 0 {
+	size := info.Size()
+	if size == 0 {
 		return nil, fmt.Errorf("mappedresource: cannot mmap empty file")
 	}
+	if size > int64(^uint(0)>>1) {
+		return nil, fmt.Errorf("mappedresource: file too large to mmap bytes=%d", size)
+	}
 	fd := int(file.Fd())
-	return syscall.Mmap(fd, 0, int(info.Size()), syscall.PROT_READ, syscall.MAP_SHARED)
+	return syscall.Mmap(fd, 0, int(size), syscall.PROT_READ, syscall.MAP_SHARED)
 }
 
 func munmapFile(data []byte) error {

--- a/TreeDB/internal/mappedresource/mmap_windows.go
+++ b/TreeDB/internal/mappedresource/mmap_windows.go
@@ -1,0 +1,16 @@
+//go:build windows
+
+package mappedresource
+
+import (
+	"fmt"
+	"os"
+)
+
+func mmapFile(file *os.File) ([]byte, error) {
+	return nil, fmt.Errorf("mappedresource: mmap unsupported on windows")
+}
+
+func munmapFile(data []byte) error {
+	return nil
+}

--- a/TreeDB/internal/mappedresource/typed_view.go
+++ b/TreeDB/internal/mappedresource/typed_view.go
@@ -148,8 +148,10 @@ func liveHandleBytes(h *Handle) ([]byte, error) {
 	if h == nil {
 		return nil, errors.New("mappedresource: nil handle")
 	}
-	if h.Released() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.done {
 		return nil, errors.New("mappedresource: handle is released")
 	}
-	return h.Bytes(), nil
+	return h.bytes, nil
 }

--- a/TreeDB/internal/mappedresource/typed_view.go
+++ b/TreeDB/internal/mappedresource/typed_view.go
@@ -1,0 +1,155 @@
+package mappedresource
+
+import (
+	"errors"
+	"fmt"
+	"unsafe"
+)
+
+var nativeLittleEndian = func() bool {
+	var value uint16 = 1
+	return *(*byte)(unsafe.Pointer(&value)) == 1
+}()
+
+// DirectViewOptions controls validation before raw bytes are reinterpreted as a
+// fixed-width typed slice.
+type DirectViewOptions struct {
+	ElementSize         uintptr
+	Alignment           uintptr
+	TypeName            string
+	RequireLittleEndian bool
+}
+
+// ValidateDirectView validates length, alignment, and endian eligibility for a
+// zero-copy typed view. It returns the element count.
+func ValidateDirectView(data []byte, opts DirectViewOptions) (int, error) {
+	if opts.ElementSize == 0 {
+		return 0, fmt.Errorf("mappedresource: direct view element size is zero")
+	}
+	if opts.Alignment == 0 {
+		opts.Alignment = opts.ElementSize
+	}
+	if opts.TypeName == "" {
+		opts.TypeName = fmt.Sprintf("%d-byte", opts.ElementSize)
+	}
+	if opts.RequireLittleEndian && !nativeLittleEndian {
+		return 0, fmt.Errorf("mappedresource: %s direct view requires little-endian host", opts.TypeName)
+	}
+	if uintptr(len(data))%opts.ElementSize != 0 {
+		return 0, fmt.Errorf("mappedresource: %s direct view length=%d is not multiple of element size=%d", opts.TypeName, len(data), opts.ElementSize)
+	}
+	if len(data) == 0 {
+		return 0, nil
+	}
+	addr := uintptr(unsafe.Pointer(unsafe.SliceData(data)))
+	if addr%opts.Alignment != 0 {
+		return 0, fmt.Errorf("mappedresource: %s direct view address=%#x is not %d-byte aligned", opts.TypeName, addr, opts.Alignment)
+	}
+	return int(uintptr(len(data)) / opts.ElementSize), nil
+}
+
+// Int64View exposes bytes as []int64 after validation.
+func Int64View(data []byte) ([]int64, error) {
+	count, err := ValidateDirectView(data, DirectViewOptions{ElementSize: unsafe.Sizeof(int64(0)), Alignment: unsafe.Alignof(int64(0)), TypeName: "int64", RequireLittleEndian: true})
+	if err != nil {
+		return nil, err
+	}
+	if count == 0 {
+		return nil, nil
+	}
+	return unsafe.Slice((*int64)(unsafe.Pointer(unsafe.SliceData(data))), count), nil
+}
+
+// Float32View exposes bytes as []float32 after validation.
+func Float32View(data []byte) ([]float32, error) {
+	count, err := ValidateDirectView(data, DirectViewOptions{ElementSize: unsafe.Sizeof(float32(0)), Alignment: unsafe.Alignof(float32(0)), TypeName: "float32", RequireLittleEndian: true})
+	if err != nil {
+		return nil, err
+	}
+	if count == 0 {
+		return nil, nil
+	}
+	return unsafe.Slice((*float32)(unsafe.Pointer(unsafe.SliceData(data))), count), nil
+}
+
+// Float64View exposes bytes as []float64 after validation.
+func Float64View(data []byte) ([]float64, error) {
+	count, err := ValidateDirectView(data, DirectViewOptions{ElementSize: unsafe.Sizeof(float64(0)), Alignment: unsafe.Alignof(float64(0)), TypeName: "float64", RequireLittleEndian: true})
+	if err != nil {
+		return nil, err
+	}
+	if count == 0 {
+		return nil, nil
+	}
+	return unsafe.Slice((*float64)(unsafe.Pointer(unsafe.SliceData(data))), count), nil
+}
+
+// Uint32View exposes bytes as []uint32 after validation.
+func Uint32View(data []byte) ([]uint32, error) {
+	count, err := ValidateDirectView(data, DirectViewOptions{ElementSize: unsafe.Sizeof(uint32(0)), Alignment: unsafe.Alignof(uint32(0)), TypeName: "uint32", RequireLittleEndian: true})
+	if err != nil {
+		return nil, err
+	}
+	if count == 0 {
+		return nil, nil
+	}
+	return unsafe.Slice((*uint32)(unsafe.Pointer(unsafe.SliceData(data))), count), nil
+}
+
+// Int64View records direct-view success/failure in addition to validating.
+func (m *Manager) Int64View(h *Handle) ([]int64, error) {
+	data, err := liveHandleBytes(h)
+	if err != nil {
+		m.recordDirectView(err)
+		return nil, err
+	}
+	view, err := Int64View(data)
+	m.recordDirectView(err)
+	return view, err
+}
+
+// Float32View records direct-view success/failure in addition to validating.
+func (m *Manager) Float32View(h *Handle) ([]float32, error) {
+	data, err := liveHandleBytes(h)
+	if err != nil {
+		m.recordDirectView(err)
+		return nil, err
+	}
+	view, err := Float32View(data)
+	m.recordDirectView(err)
+	return view, err
+}
+
+// Float64View records direct-view success/failure in addition to validating.
+func (m *Manager) Float64View(h *Handle) ([]float64, error) {
+	data, err := liveHandleBytes(h)
+	if err != nil {
+		m.recordDirectView(err)
+		return nil, err
+	}
+	view, err := Float64View(data)
+	m.recordDirectView(err)
+	return view, err
+}
+
+// Uint32View records direct-view success/failure in addition to validating.
+func (m *Manager) Uint32View(h *Handle) ([]uint32, error) {
+	data, err := liveHandleBytes(h)
+	if err != nil {
+		m.recordDirectView(err)
+		return nil, err
+	}
+	view, err := Uint32View(data)
+	m.recordDirectView(err)
+	return view, err
+}
+
+func liveHandleBytes(h *Handle) ([]byte, error) {
+	if h == nil {
+		return nil, errors.New("mappedresource: nil handle")
+	}
+	if h.Released() {
+		return nil, errors.New("mappedresource: handle is released")
+	}
+	return h.Bytes(), nil
+}

--- a/TreeDB/internal/mappedresource/typed_view_test.go
+++ b/TreeDB/internal/mappedresource/typed_view_test.go
@@ -1,0 +1,131 @@
+package mappedresource
+
+import (
+	"encoding/binary"
+	"testing"
+	"unsafe"
+)
+
+func alignedBytes(size, align int) []byte {
+	buf := make([]byte, size+align)
+	base := uintptr(unsafe.Pointer(unsafe.SliceData(buf)))
+	for off := 0; off < align; off++ {
+		if (base+uintptr(off))%uintptr(align) == 0 {
+			return buf[off : off+size]
+		}
+	}
+	panic("no aligned offset found")
+}
+
+func misalignedBytes(size, align int) []byte {
+	buf := alignedBytes(size+1, align)
+	if uintptr(unsafe.Pointer(unsafe.SliceData(buf[1:])))%uintptr(align) != 0 {
+		return buf[1:]
+	}
+	return buf[:size]
+}
+
+func TestDirectTypedViewsAcceptAlignedRanges(t *testing.T) {
+	mgr := NewManager()
+	key := testKey()
+	scope := testScope()
+
+	u32Bytes := alignedBytes(8, int(unsafe.Alignof(uint32(0))))
+	binary.LittleEndian.PutUint32(u32Bytes[0:4], 7)
+	binary.LittleEndian.PutUint32(u32Bytes[4:8], 11)
+	key.Length = int64(len(u32Bytes))
+	u32Handle, err := mgr.AcquireBytes(key, scope, SourceMapped, u32Bytes, AcquireOptions{Reason: "u32"})
+	if err != nil {
+		t.Fatalf("AcquireBytes u32: %v", err)
+	}
+	defer u32Handle.Release()
+	u32, err := mgr.Uint32View(u32Handle)
+	if err != nil {
+		t.Fatalf("Uint32View: %v", err)
+	}
+	if len(u32) != 2 || u32[0] != 7 || u32[1] != 11 {
+		t.Fatalf("Uint32View=%v", u32)
+	}
+
+	i64Bytes := alignedBytes(16, int(unsafe.Alignof(int64(0))))
+	binary.LittleEndian.PutUint64(i64Bytes[0:8], uint64(13))
+	binary.LittleEndian.PutUint64(i64Bytes[8:16], uint64(17))
+	key.Length = int64(len(i64Bytes))
+	i64Handle, err := mgr.AcquireBytes(key, scope, SourceMapped, i64Bytes, AcquireOptions{Reason: "i64"})
+	if err != nil {
+		t.Fatalf("AcquireBytes i64: %v", err)
+	}
+	defer i64Handle.Release()
+	i64, err := mgr.Int64View(i64Handle)
+	if err != nil {
+		t.Fatalf("Int64View: %v", err)
+	}
+	if len(i64) != 2 || i64[0] != 13 || i64[1] != 17 {
+		t.Fatalf("Int64View=%v", i64)
+	}
+
+	f32Bytes := alignedBytes(8, int(unsafe.Alignof(float32(0))))
+	key.Length = int64(len(f32Bytes))
+	f32Handle, err := mgr.AcquireBytes(key, scope, SourceMapped, f32Bytes, AcquireOptions{Reason: "f32"})
+	if err != nil {
+		t.Fatalf("AcquireBytes f32: %v", err)
+	}
+	defer f32Handle.Release()
+	if f32, err := mgr.Float32View(f32Handle); err != nil || len(f32) != 2 {
+		t.Fatalf("Float32View len=%d err=%v", len(f32), err)
+	}
+
+	f64Bytes := alignedBytes(16, int(unsafe.Alignof(float64(0))))
+	key.Length = int64(len(f64Bytes))
+	f64Handle, err := mgr.AcquireBytes(key, scope, SourceMapped, f64Bytes, AcquireOptions{Reason: "f64"})
+	if err != nil {
+		t.Fatalf("AcquireBytes f64: %v", err)
+	}
+	defer f64Handle.Release()
+	if f64, err := mgr.Float64View(f64Handle); err != nil || len(f64) != 2 {
+		t.Fatalf("Float64View len=%d err=%v", len(f64), err)
+	}
+
+	if stats := mgr.Stats(); stats.DirectViewSuccesses != 4 || stats.DirectViewFailures != 0 {
+		t.Fatalf("direct view stats=%+v", stats)
+	}
+}
+
+func TestDirectTypedViewsRejectMisalignedAndTruncatedRanges(t *testing.T) {
+	mgr := NewManager()
+	key := testKey()
+	scope := testScope()
+
+	misaligned := misalignedBytes(8, int(unsafe.Alignof(uint32(0))))
+	key.Length = int64(len(misaligned))
+	h, err := mgr.AcquireBytes(key, scope, SourceMapped, misaligned, AcquireOptions{Reason: "misaligned"})
+	if err != nil {
+		t.Fatalf("AcquireBytes misaligned: %v", err)
+	}
+	defer h.Release()
+	if _, err := mgr.Uint32View(h); err == nil {
+		t.Fatal("Uint32View misaligned err=nil, want failure")
+	}
+
+	truncated := alignedBytes(6, int(unsafe.Alignof(uint32(0))))
+	key.Length = int64(len(truncated))
+	truncatedHandle, err := mgr.AcquireBytes(key, scope, SourceMapped, truncated, AcquireOptions{Reason: "truncated"})
+	if err != nil {
+		t.Fatalf("AcquireBytes truncated: %v", err)
+	}
+	defer truncatedHandle.Release()
+	if _, err := mgr.Uint32View(truncatedHandle); err == nil {
+		t.Fatal("Uint32View truncated err=nil, want failure")
+	}
+
+	if err := truncatedHandle.Release(); err != nil {
+		t.Fatalf("Release truncated: %v", err)
+	}
+	if _, err := mgr.Uint32View(truncatedHandle); err == nil {
+		t.Fatal("Uint32View released handle err=nil, want failure")
+	}
+
+	if stats := mgr.Stats(); stats.DirectViewFailures != 3 {
+		t.Fatalf("direct view failure stats=%+v", stats)
+	}
+}

--- a/TreeDB/internal/mappedresource/types.go
+++ b/TreeDB/internal/mappedresource/types.go
@@ -1,0 +1,161 @@
+// Package mappedresource defines TreeDB's shared vocabulary for immutable
+// file-backed resource views. It is intentionally small: subsystem-specific
+// caches may remain specialized while using these keys, scopes, handles, stats,
+// and maintenance pins as the common contract.
+package mappedresource
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Class identifies the resource family. It is coarse enough for shared
+// accounting but does not replace subsystem-specific formats.
+type Class string
+
+const (
+	ClassValueLog         Class = "value_log"
+	ClassLeafLog          Class = "leaf_log"
+	ClassTypedRowAsset    Class = "typed_row_asset"
+	ClassTypedColumnAsset Class = "typed_column_asset"
+	ClassExternalAsset    Class = "external_asset"
+)
+
+// Section identifies a logical sub-range within an immutable asset. Column-part
+// assets use this to address descriptor, dictionary, vector, adjacency, and
+// scalar payload sections without requiring one OS file per section.
+type Section struct {
+	Kind     string
+	Category string
+	Name     string
+	Column   string
+	Ordinal  uint32
+}
+
+// Empty reports whether the section identity is absent.
+func (s Section) Empty() bool {
+	return s == Section{}
+}
+
+// Key is the stable identity for a mapped or copied resource range.
+//
+// Offset/Length are a physical range in FileID/object identity. Section is an
+// optional logical refinement for internally sectioned assets. Checksum is a
+// generic content checksum/digest slot; callers may use the lower bits when the
+// source format stores uint32 checksums.
+type Key struct {
+	Class      Class
+	Namespace  string
+	Kind       string
+	Generation uint64
+	PartID     uint64
+	FileID     uint32
+	Offset     int64
+	Length     int64
+	Checksum   uint64
+	Version    uint16
+	Encoding   string
+	Section    Section
+}
+
+// Validate rejects incomplete or unsafe resource identities. It is deliberately
+// format-agnostic; subsystem adapters may apply stricter checks before calling
+// into the manager.
+func (k Key) Validate() error {
+	switch k.Class {
+	case ClassValueLog, ClassLeafLog, ClassTypedRowAsset, ClassTypedColumnAsset, ClassExternalAsset:
+	case "":
+		return errors.New("mappedresource: missing resource class")
+	default:
+		return fmt.Errorf("mappedresource: unsupported resource class %q", k.Class)
+	}
+	if k.Offset < 0 {
+		return fmt.Errorf("mappedresource: negative resource offset %d", k.Offset)
+	}
+	if k.Length < 0 {
+		return fmt.Errorf("mappedresource: negative resource length %d", k.Length)
+	}
+	if k.Offset > 0 && k.Length > maxInt64-k.Offset {
+		return fmt.Errorf("mappedresource: resource range offset=%d length=%d overflows", k.Offset, k.Length)
+	}
+	if k.Class == ClassTypedRowAsset || k.Class == ClassTypedColumnAsset || k.Class == ClassValueLog || k.Class == ClassLeafLog {
+		if k.Namespace == "" {
+			return fmt.Errorf("mappedresource: %s resource requires namespace", k.Class)
+		}
+		if k.FileID == 0 {
+			return fmt.Errorf("mappedresource: %s resource requires file id", k.Class)
+		}
+	}
+	return nil
+}
+
+// Equal reports exact key equality.
+func (k Key) Equal(other Key) bool {
+	return k == other
+}
+
+// ScopeKind identifies the logical lifetime that owns a resource handle.
+type ScopeKind string
+
+const (
+	ScopeDB                 ScopeKind = "db"
+	ScopeSnapshot           ScopeKind = "snapshot"
+	ScopeCollectionReadView ScopeKind = "collection_read_view"
+	ScopeManifestGeneration ScopeKind = "manifest_generation"
+	ScopeMaintenance        ScopeKind = "maintenance"
+	ScopePreparedQuery      ScopeKind = "prepared_query"
+	ScopePreparedSearch     ScopeKind = "prepared_search"
+	ScopeTypedRowReader     ScopeKind = "typed_row_reader"
+	ScopeColumnPartReader   ScopeKind = "column_part_reader"
+)
+
+// Scope ties a physical resource handle to a logical lifetime. Snapshot/read
+// view scopes should anchor ordinary query/search handles; maintenance scopes
+// anchor destructive planning and protection checks.
+type Scope struct {
+	Kind       ScopeKind
+	ID         string
+	ParentID   string
+	Collection string
+	Namespace  string
+	Generation uint64
+	Reason     string
+}
+
+// Validate rejects lifetime-less scopes. A non-empty ID makes ownership and
+// tests explicit even when the scope is only process-local.
+func (s Scope) Validate() error {
+	switch s.Kind {
+	case ScopeDB, ScopeSnapshot, ScopeCollectionReadView, ScopeManifestGeneration, ScopeMaintenance, ScopePreparedQuery, ScopePreparedSearch, ScopeTypedRowReader, ScopeColumnPartReader:
+	case "":
+		return errors.New("mappedresource: missing lifetime scope kind")
+	default:
+		return fmt.Errorf("mappedresource: unsupported lifetime scope kind %q", s.Kind)
+	}
+	if s.ID == "" {
+		return fmt.Errorf("mappedresource: %s scope requires id", s.Kind)
+	}
+	return nil
+}
+
+// ValidateForKey checks both the scope and key. It also catches accidental
+// namespace mismatches when both sides carry a namespace.
+func (s Scope) ValidateForKey(k Key) error {
+	if err := s.Validate(); err != nil {
+		return err
+	}
+	if err := k.Validate(); err != nil {
+		return err
+	}
+	if s.Namespace != "" && k.Namespace != "" && s.Namespace != k.Namespace {
+		return fmt.Errorf("mappedresource: scope namespace=%q does not match key namespace=%q", s.Namespace, k.Namespace)
+	}
+	return nil
+}
+
+// NewScope constructs a scope with the minimum required fields.
+func NewScope(kind ScopeKind, id string) Scope {
+	return Scope{Kind: kind, ID: id}
+}
+
+const maxInt64 = int64(^uint64(0) >> 1)

--- a/TreeDB/internal/mappedresource/types_test.go
+++ b/TreeDB/internal/mappedresource/types_test.go
@@ -1,0 +1,76 @@
+package mappedresource
+
+import "testing"
+
+func TestKeyEqualityDistinguishesIdentityFields(t *testing.T) {
+	base := Key{
+		Class:      ClassTypedColumnAsset,
+		Namespace:  "vectors",
+		Kind:       "column_part",
+		Generation: 7,
+		PartID:     11,
+		FileID:     3,
+		Offset:     128,
+		Length:     64,
+		Checksum:   99,
+		Version:    2,
+		Encoding:   "little_endian",
+		Section:    Section{Kind: "column_data", Column: "embedding", Ordinal: 4},
+	}
+	if err := base.Validate(); err != nil {
+		t.Fatalf("base Validate: %v", err)
+	}
+	if !base.Equal(base) {
+		t.Fatal("base key not equal to itself")
+	}
+	cases := map[string]func(Key) Key{
+		"class":      func(k Key) Key { k.Class = ClassTypedRowAsset; return k },
+		"namespace":  func(k Key) Key { k.Namespace = "other"; return k },
+		"kind":       func(k Key) Key { k.Kind = "other"; return k },
+		"generation": func(k Key) Key { k.Generation++; return k },
+		"part_id":    func(k Key) Key { k.PartID++; return k },
+		"file_id":    func(k Key) Key { k.FileID++; return k },
+		"offset":     func(k Key) Key { k.Offset++; return k },
+		"length":     func(k Key) Key { k.Length++; return k },
+		"checksum":   func(k Key) Key { k.Checksum++; return k },
+		"version":    func(k Key) Key { k.Version++; return k },
+		"encoding":   func(k Key) Key { k.Encoding = "other"; return k },
+		"section":    func(k Key) Key { k.Section.Ordinal++; return k },
+	}
+	for name, mutate := range cases {
+		if got := base.Equal(mutate(base)); got {
+			t.Fatalf("key Equal did not distinguish %s", name)
+		}
+	}
+}
+
+func TestScopeValidationRejectsLifetimeLessRequests(t *testing.T) {
+	key := Key{Class: ClassTypedRowAsset, Namespace: "events", FileID: 1, Offset: 0, Length: 8}
+	if err := (Scope{}).ValidateForKey(key); err == nil {
+		t.Fatal("empty scope ValidateForKey err=nil, want failure")
+	}
+	if err := (Scope{Kind: ScopeSnapshot}).ValidateForKey(key); err == nil {
+		t.Fatal("scope without id ValidateForKey err=nil, want failure")
+	}
+	if err := (Scope{Kind: ScopeSnapshot, ID: "snap-1", Namespace: "other"}).ValidateForKey(key); err == nil {
+		t.Fatal("namespace mismatch ValidateForKey err=nil, want failure")
+	}
+	if err := (Scope{Kind: ScopeSnapshot, ID: "snap-1", Namespace: "events"}).ValidateForKey(key); err != nil {
+		t.Fatalf("valid snapshot scope ValidateForKey: %v", err)
+	}
+}
+
+func TestKeyValidateRejectsUnsafeRanges(t *testing.T) {
+	if err := (Key{Class: ClassTypedRowAsset, Namespace: "events", FileID: 1, Offset: -1, Length: 8}).Validate(); err == nil {
+		t.Fatal("negative offset Validate err=nil, want failure")
+	}
+	if err := (Key{Class: ClassTypedRowAsset, Namespace: "events", FileID: 1, Offset: 0, Length: -1}).Validate(); err == nil {
+		t.Fatal("negative length Validate err=nil, want failure")
+	}
+	if err := (Key{Class: ClassTypedRowAsset, Namespace: "", FileID: 1, Offset: 0, Length: 8}).Validate(); err == nil {
+		t.Fatal("typed row key without namespace Validate err=nil, want failure")
+	}
+	if err := (Key{Class: ClassTypedRowAsset, Namespace: "events", FileID: 0, Offset: 0, Length: 8}).Validate(); err == nil {
+		t.Fatal("typed row key without file id Validate err=nil, want failure")
+	}
+}


### PR DESCRIPTION
## Summary

Linked tracker: #1736, Gate A handoff seam for #1744.

This PR lands the minimum unified row+column mapped/buffered-resource substrate needed before #1744 begins broad column-store work:

- adds `TreeDB/internal/mappedresource` with common resource classes, asset keys, section identity, lifetime scopes, stats, active pins, view/buffer handles, mmap/heap file-range acquisition, and fixed-width direct typed-view validation;
- adapts `columnPhysicalAssetReadCache` so current typed row physical asset reads can optionally report through the common handle/accounting/pin vocabulary without changing default behavior;
- adds fake future column-part section tests to prove #1744 can acquire section/range resources by key/scope/handle;
- refreshes the zero-checksum column asset fixture payload for the current CRC implementation.

## Scope Boundary

In scope:

- Gate A substrate and tests.
- Optional typed row asset read-cache adapter.
- Maintenance pin summary visibility through `mappedresource.Manager.PinSummary()`.

Out of scope:

- #1744 column-part format.
- value-log manager rewrite.
- leaf-log cache rewrite.
- full row+column COW GC/rewrite.
- private column-only cache/lifecycle.

## Gate A checklist

- [x] Common resource stats/accounting schema.
- [x] Asset-key types for typed row assets and future typed column part/section assets.
- [x] Lifetime-scope types including snapshot/read-view, maintenance, typed row reader, and column-part reader.
- [x] View/buffer handle API with explicit release.
- [x] mmap-backed and heap-copy file-range handles.
- [x] Direct typed-view validation for `[]int64`, `[]float32`, `[]float64`, `[]uint32`.
- [x] Typed row physical asset adapter for `columnPhysicalAssetReadCache`.
- [x] Fake future column-part section acquire/release test.
- [x] Maintenance pin summary test.

## Tests

```sh
go test ./TreeDB/internal/mappedresource

go test ./TreeDB/collections \
  -run 'TestColumnAssetReadCache.*GateA1736|TestColumnAssetReadCacheViewsRequireExplicitOptInM1634|TestColumnPhysicalRowReader|TestColumnVectorGraph'

go test ./TreeDB/internal/mappedresource ./TreeDB/collections

go test ./TreeDB/...
```

Result: all passed locally. GitHub Actions are also passing on latest head `ea15dff1fa`. Additional compile check: `GOOS=plan9 GOARCH=amd64 go test -c ./TreeDB/internal/mappedresource -o /tmp/mappedresource_plan9.test`.

## Benchmark / accounting evidence

Command:

```sh
go test ./TreeDB/collections \
  -run '^$' \
  -bench 'BenchmarkColumnPhysicalRowReaderFetchV1|BenchmarkColumnVectorGraphPhysicalRowReaderFetchV2B' \
  -benchmem \
  -count=3
```

Context: Apple M3, darwin/arm64. The adapter is opt-in; default hot row-reader path still reports 0 allocations.

| Benchmark | Shape | Avg ns/op | Avg ops/sec | B/op | allocs/op | Notes |
| --- | --- | ---: | ---: | ---: | ---: | --- |
| `BenchmarkColumnPhysicalRowReaderFetchV1/row_warmed_vector_adjacency` | single row | 204.0 | 4,901,961 | 0 | 0 | cache hit path |
| `BenchmarkColumnPhysicalRowReaderFetchV1/batch_warmed_vector_adjacency` | 8 rows/op | 1,538.7 | 649,913 | 0 | 0 | 8 rows/op |
| `BenchmarkColumnVectorGraphPhysicalRowReaderFetchV2B` | graph row fetch | 172.4 | 5,801,821 | 0 | 0 | cache hit path |

## AI review status

- [x] Codex review findings were fixed and all Codex threads are resolved on latest head `ea15dff1fa`.
- [x] CodeRabbit latest review completed/skipped with no open actionable comments; earlier actionable comments were fixed/addressed and threads resolved.
- [x] Copilot review was requested repeatedly, but the bot/cloud-agent runs errored; no successful Copilot review was available.

## Caveats / deferred

- The manager is a shared substrate and adapter seam, not a global cache policy.
- Value-log and leaf-log remain specialized and are not migrated in this PR.
- Full COW disk maintenance remains in #1736 after #1744 creates durable column-part assets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a mapped-resource manager and tracking for column asset reads: records hits/misses/fallbacks, validation modes, per-source stats, pin summaries, and ensures handles are released when caches close.
  * Platform-aware memory-mapping with graceful fallback on unsupported platforms.
  * Zero-copy typed direct views for validated, efficient array access.

* **Tests**
  * New comprehensive tests for the mapped-resource manager, direct-view validation, and column-asset read/cache interactions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1747?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

