### PR TITLE
[codex] Add vector graph native search benchmark sweeps

### DIFF
--- a/TreeDB/collections/column_physical_asset_test.go
+++ b/TreeDB/collections/column_physical_asset_test.go
@@ -1300,7 +1300,7 @@ func TestColumnAssetManagerWriteAllowsZeroChecksumM12A(t *testing.T) {
 	if err != nil {
 		t.Fatalf("normalizeColumnStoreConfig: %v", err)
 	}
-	payload := []byte{0xab, 0x9b, 0xe0, 0x9b}
+	payload := []byte{0x9d, 0x0a, 0xd9, 0x6d}
 	if checksum := page.Checksum(payload); checksum != 0 {
 		t.Fatalf("test payload checksum=%d, want 0", checksum)
 	}

--- a/TreeDB/collections/column_vector_graph_search_test.go
+++ b/TreeDB/collections/column_vector_graph_search_test.go
@@ -50,7 +50,7 @@ func columnVectorGraphNativeSearchProduction8192BenchShapeV3() columnVectorGraph
 }
 
 func columnVectorGraphNativeSearchProductionSweepBenchShapesV3() []columnVectorGraphNativeSearchBenchShapeV3 {
-	dims := []int{128, 384, 768, 1536}
+	dims := []int{128, 384, 768, 1024, 1536}
 	shapes := make([]columnVectorGraphNativeSearchBenchShapeV3, 0, len(dims)+1)
 	shapes = append(shapes, columnVectorGraphNativeSearchBenchShapeV3{
 		rows:                1024,

--- a/TreeDB/collections/column_vector_graph_search_test.go
+++ b/TreeDB/collections/column_vector_graph_search_test.go
@@ -49,6 +49,36 @@ func columnVectorGraphNativeSearchProduction8192BenchShapeV3() columnVectorGraph
 	}
 }
 
+func columnVectorGraphNativeSearchProductionSweepBenchShapesV3() []columnVectorGraphNativeSearchBenchShapeV3 {
+	dims := []int{128, 384, 768, 1536}
+	shapes := make([]columnVectorGraphNativeSearchBenchShapeV3, 0, len(dims)+1)
+	shapes = append(shapes, columnVectorGraphNativeSearchBenchShapeV3{
+		rows:                1024,
+		dims:                128,
+		m:                   16,
+		topK:                10,
+		efSearch:            128,
+		queryOrdinal:        512,
+		directPhysicalAsset: true,
+	})
+	for _, dim := range dims {
+		shapes = append(shapes, columnVectorGraphNativeSearchBenchShapeV3{
+			rows:                8192,
+			dims:                dim,
+			m:                   16,
+			topK:                10,
+			efSearch:            128,
+			queryOrdinal:        4096,
+			directPhysicalAsset: true,
+		})
+	}
+	return shapes
+}
+
+func columnVectorGraphNativeSearchBenchShapeNameV3(shape columnVectorGraphNativeSearchBenchShapeV3) string {
+	return fmt.Sprintf("rows=%d/dims=%d/degree=%d/topK=%d/efSearch=%d", shape.rows, shape.dims, shape.m, shape.topK, shape.efSearch)
+}
+
 func TestColumnVectorGraphNativeSearchCosineUsesPhysicalRowsV3(t *testing.T) {
 	rows := []columnGraphRebuildInputRowV2A{
 		{id: "doc-a", vector: []float32{1, 0, 0}},
@@ -624,6 +654,15 @@ func BenchmarkColumnVectorGraphNativeSearchCosineProduction8192V3(b *testing.B) 
 	benchmarkColumnVectorGraphNativeSearchCosineV3(b, columnVectorGraphNativeSearchProduction8192BenchShapeV3())
 }
 
+func BenchmarkColumnVectorGraphNativeSearchCosineProductionSweepV3(b *testing.B) {
+	for _, shape := range columnVectorGraphNativeSearchProductionSweepBenchShapesV3() {
+		shape := shape
+		b.Run(columnVectorGraphNativeSearchBenchShapeNameV3(shape), func(b *testing.B) {
+			benchmarkColumnVectorGraphNativeSearchCosineV3(b, shape)
+		})
+	}
+}
+
 func benchmarkColumnVectorGraphNativeSearchCosineV3(b *testing.B, shape columnVectorGraphNativeSearchBenchShapeV3) {
 	b.Helper()
 	closeFn, col, def, query := openColumnVectorGraphNativeSearchBenchFixtureV3(b, shape)
@@ -677,6 +716,15 @@ func BenchmarkColumnVectorGraphNativeSearchCosineParallelV3(b *testing.B) {
 
 func BenchmarkColumnVectorGraphNativeSearchCosineParallelProduction8192V3(b *testing.B) {
 	benchmarkColumnVectorGraphNativeSearchCosineParallelV3(b, columnVectorGraphNativeSearchProduction8192BenchShapeV3())
+}
+
+func BenchmarkColumnVectorGraphNativeSearchCosineParallelProductionSweepV3(b *testing.B) {
+	for _, shape := range columnVectorGraphNativeSearchProductionSweepBenchShapesV3() {
+		shape := shape
+		b.Run(columnVectorGraphNativeSearchBenchShapeNameV3(shape), func(b *testing.B) {
+			benchmarkColumnVectorGraphNativeSearchCosineParallelV3(b, shape)
+		})
+	}
 }
 
 func benchmarkColumnVectorGraphNativeSearchCosineParallelV3(b *testing.B, shape columnVectorGraphNativeSearchBenchShapeV3) {


### PR DESCRIPTION
## Summary

- Adds production sweep benchmark entry points for native cosine graph search.
- Keeps the existing 8192x128 serial and parallel benchmark names intact.
- Sweeps common embedding dimensions at the production 8192-row shape: 128, 384, 768, 1024, and 1536, plus a 1024x128 small control.
- Refreshes the zero-checksum column asset test fixture for the current CRC implementation.

## Benchmark results

User-provided reference results from the request:

```text
BenchmarkColumnVectorGraphNativeSearchCosineProduction8192V3: 4648 ns/op, 0 B/op, 0 allocs/op
BenchmarkColumnVectorGraphNativeSearchCosineParallelProduction8192V3: 1510 ns/op, 18 B/op, 0 allocs/op
```

Current local validation on `11th Gen Intel(R) Core(TM) i5-11400F @ 2.60GHz` with `GOWORK=off`, `-benchtime=100x`, `-count=1`:

```text
BenchmarkColumnVectorGraphNativeSearchCosineProduction8192V3-12           7924 ns/op   0 B/op   0 allocs/op
BenchmarkColumnVectorGraphNativeSearchCosineParallelProduction8192V3-12  2202 ns/op  40 B/op   0 allocs/op
```

New sweep results after adding `8192x1024`:

| Benchmark | ns/op | ops/sec | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: |
| serial rows=1024 dims=128 | 8524 | 117,316 | 0 | 0 |
| serial rows=8192 dims=128 | 7122 | 140,410 | 0 | 0 |
| serial rows=8192 dims=384 | 10257 | 97,494 | 0 | 0 |
| serial rows=8192 dims=768 | 25240 | 39,620 | 0 | 0 |
| serial rows=8192 dims=1024 | 31065 | 32,191 | 0 | 0 |
| serial rows=8192 dims=1536 | 40372 | 24,770 | 0 | 0 |
| parallel rows=1024 dims=128 | 2812 | 355,619 | 8 | 0 |
| parallel rows=8192 dims=128 | 2893 | 345,662 | 57 | 0 |
| parallel rows=8192 dims=384 | 3385 | 295,421 | 8 | 0 |
| parallel rows=8192 dims=768 | 6372 | 156,937 | 8 | 0 |
| parallel rows=8192 dims=1024 | 7686 | 130,107 | 8 | 0 |
| parallel rows=8192 dims=1536 | 11910 | 83,963 | 14 | 0 |

## CI fix

The first CI run failed in `TestColumnAssetManagerWriteAllowsZeroChecksumM12A` because the hardcoded nonempty zero-CRC payload no longer had checksum `0` under the current CRC implementation. The fixture payload was replaced with `9d0ad96d`, which preserves the test intent and has `page.Checksum(payload) == 0`.

## Review fixes

- Addressed CodeRabbit's finding by adding the missing `8192x1024` benchmark shape.

## Validation

```sh
GOWORK=off go test ./TreeDB/collections -run '^TestColumnAssetManagerWriteAllowsZeroChecksumM12A$' -count=1
GOWORK=off go test ./TreeDB/collections -count=1
GOWORK=off go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnVectorGraphNativeSearchCosineProduction8192V3$' -benchtime=100x -count=1
GOWORK=off go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnVectorGraphNativeSearchCosineParallelProduction8192V3$' -benchtime=100x -count=1
GOWORK=off go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnVectorGraphNativeSearchCosine.*ProductionSweepV3$' -benchtime=100x -count=1
git diff --check
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved checksum validation test to ensure zero-checksum payloads are preserved when written and read.
  * Added benchmark-only sweep and helpers for native vector graph search, with serial and parallel production-style benchmarks across multiple dimensional settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1748?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->