### PR TITLE
collections: align column graph search frontier with HNSW

### DIFF
--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -287,7 +287,7 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 			}
 			continue
 		}
-		if len(scratch.top) >= efSearch && columnVectorGraphSearchCandidateWorse(candidate, scratch.top[len(scratch.top)-1]) {
+		if len(scratch.top) >= efSearch && candidate.score < scratch.top[len(scratch.top)-1].score {
 			break
 		}
 		adjacency, err := r.expandCandidateAdjacencyLayer(plan, singleBlockView, candidate.ordinal, 0, scratch, &stats)
@@ -440,8 +440,18 @@ func (r *columnVectorGraphPhysicalRowReader) scoreAndPushFrontierVisited(plan *c
 		ordinal: ordinal,
 		score:   score,
 	}
-	if len(scratch.top) < candidateLimit || columnVectorGraphSearchCandidateBetter(candidate, scratch.top[len(scratch.top)-1]) {
+	if len(scratch.top) < candidateLimit {
 		scratch.insertTop(candidateLimit, candidate)
+		scratch.pushFrontier(candidate)
+		return nil
+	}
+	worstRetained := scratch.top[len(scratch.top)-1]
+	if columnVectorGraphSearchCandidateBetter(candidate, worstRetained) {
+		scratch.insertTop(candidateLimit, candidate)
+		scratch.pushFrontier(candidate)
+		return nil
+	}
+	if candidate.score >= worstRetained.score {
 		scratch.pushFrontier(candidate)
 	}
 	return nil
@@ -611,10 +621,6 @@ func columnVectorGraphSearchCandidateBetter(left, right columnVectorGraphSearchC
 		return left.ordinal < right.ordinal
 	}
 	return left.score > right.score
-}
-
-func columnVectorGraphSearchCandidateWorse(left, right columnVectorGraphSearchCandidate) bool {
-	return columnVectorGraphSearchCandidateBetter(right, left)
 }
 
 func columnVectorGraphNativeCosineScore(query []float32, queryInvNorm float32, row columnVectorGraphPhysicalRow) (float64, error) {

--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -102,7 +102,7 @@ func (s *columnVectorGraphNativeSearchScratch) prepare(rowCount, dimensions, deg
 		frontierCap = topK
 	}
 	s.frontier = resizeColumnVectorGraphNativeCandidateScratch(s.frontier, frontierCap)
-	s.top = resizeColumnVectorGraphNativeCandidateScratch(s.top, topK)
+	s.top = resizeColumnVectorGraphNativeCandidateScratch(s.top, frontierCap)
 	s.results = resizeColumnVectorGraphNativeResultScratch(s.results, topK)
 	s.idBuffers = resizeColumnVectorGraphNativeIDBuffersScratch(s.idBuffers, topK)
 	s.resultOrder = resizeColumnVectorGraphNativeIntScratch(s.resultOrder, topK)
@@ -265,13 +265,16 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 	visitMarks := scratch.visitMarks
 	visitEpoch := scratch.visitEpoch
 	visitMarks[entryOrdinal] = visitEpoch
-	if err := r.scoreAndPushFrontierVisited(plan, singleBlockView, query, queryInvNorm, entryOrdinal, topK, scratch, &stats); err != nil {
+	if err := r.scoreAndPushFrontierVisited(plan, singleBlockView, query, queryInvNorm, entryOrdinal, efSearch, scratch, &stats); err != nil {
 		return nil, stats, err
 	}
 	nextSeed := 0
-	for stats.Candidates < uint64(efSearch) {
+	for {
 		candidate, ok := scratch.popFrontier()
 		if !ok {
+			if len(scratch.top) >= efSearch {
+				break
+			}
 			for nextSeed < rowCount && scratch.visitMarks[nextSeed] == scratch.visitEpoch {
 				nextSeed++
 			}
@@ -279,19 +282,19 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 				break
 			}
 			visitMarks[nextSeed] = visitEpoch
-			if err := r.scoreAndPushFrontierVisited(plan, singleBlockView, query, queryInvNorm, nextSeed, topK, scratch, &stats); err != nil {
+			if err := r.scoreAndPushFrontierVisited(plan, singleBlockView, query, queryInvNorm, nextSeed, efSearch, scratch, &stats); err != nil {
 				return nil, stats, err
 			}
 			continue
+		}
+		if len(scratch.top) >= efSearch && columnVectorGraphSearchCandidateWorse(candidate, scratch.top[len(scratch.top)-1]) {
+			break
 		}
 		adjacency, err := r.expandCandidateAdjacencyLayer(plan, singleBlockView, candidate.ordinal, 0, scratch, &stats)
 		if err != nil {
 			return nil, stats, err
 		}
 		for i, neighbor := range adjacency {
-			if stats.Candidates >= uint64(efSearch) {
-				break
-			}
 			stats.Edges++
 			if uint64(neighbor) >= uint64(rowCount) {
 				return nil, stats, fmt.Errorf("collections: column_graph %q ordinal=%d adjacency[%d]=%d outside row_count=%d: %w", r.def.Name, candidate.ordinal, i, neighbor, rowCount, errColumnVectorGraphAdjacencyOrdinalOutOfBounds)
@@ -301,7 +304,7 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 				continue
 			}
 			visitMarks[neighborOrdinal] = visitEpoch
-			if err := r.scoreAndPushFrontierVisited(plan, singleBlockView, query, queryInvNorm, neighborOrdinal, topK, scratch, &stats); err != nil {
+			if err := r.scoreAndPushFrontierVisited(plan, singleBlockView, query, queryInvNorm, neighborOrdinal, efSearch, scratch, &stats); err != nil {
 				return nil, stats, err
 			}
 		}
@@ -310,7 +313,7 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 	if len(scratch.top) == 0 {
 		return scratch.results, stats, nil
 	}
-	if err := r.fetchTopSearchResults(plan, singleBlockView, scratch, &stats); err != nil {
+	if err := r.fetchTopSearchResults(plan, singleBlockView, scratch, topK, &stats); err != nil {
 		return nil, stats, err
 	}
 	return scratch.results, stats, nil
@@ -356,8 +359,11 @@ func (r *columnVectorGraphPhysicalRowReader) greedyNearestAtLayer(plan *columnVe
 	return best, nil
 }
 
-func (r *columnVectorGraphPhysicalRowReader) fetchTopSearchResults(plan *columnVectorGraphSearchPlan, singleBlockView *columnVectorGraphBlockView, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) error {
+func (r *columnVectorGraphPhysicalRowReader) fetchTopSearchResults(plan *columnVectorGraphSearchPlan, singleBlockView *columnVectorGraphBlockView, scratch *columnVectorGraphNativeSearchScratch, topK int, stats *columnVectorGraphNativeSearchStats) error {
 	n := len(scratch.top)
+	if n > topK {
+		n = topK
+	}
 	scratch.resultOrder = scratch.resultOrder[:n]
 	scratch.resultOrdinals = scratch.resultOrdinals[:n]
 	for i := 0; i < n; i++ {
@@ -395,7 +401,7 @@ func (r *columnVectorGraphPhysicalRowReader) fetchTopSearchResults(plan *columnV
 	stats.BlockViewHits = plan.hits
 	stats.BlockViewMisses = plan.misses
 	stats.BlockViewBuilds = plan.builds
-	for i, candidate := range scratch.top {
+	for i, candidate := range scratch.top[:n] {
 		scratch.results = append(scratch.results, columnVectorGraphNativeSearchResult{
 			Ordinal: candidate.ordinal,
 			ID:      scratch.idBuffers[i],
@@ -424,7 +430,7 @@ func sortColumnVectorGraphResultOrderByOrdinal(order []int, top []columnVectorGr
 	})
 }
 
-func (r *columnVectorGraphPhysicalRowReader) scoreAndPushFrontierVisited(plan *columnVectorGraphSearchPlan, singleBlockView *columnVectorGraphBlockView, query []float32, queryInvNorm float32, ordinal, topK int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) error {
+func (r *columnVectorGraphPhysicalRowReader) scoreAndPushFrontierVisited(plan *columnVectorGraphSearchPlan, singleBlockView *columnVectorGraphBlockView, query []float32, queryInvNorm float32, ordinal, candidateLimit int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) error {
 	score, err := r.scoreOrdinal(plan, singleBlockView, query, queryInvNorm, ordinal, scratch, stats)
 	if err != nil {
 		return err
@@ -434,8 +440,10 @@ func (r *columnVectorGraphPhysicalRowReader) scoreAndPushFrontierVisited(plan *c
 		ordinal: ordinal,
 		score:   score,
 	}
-	scratch.insertTop(topK, candidate)
-	scratch.pushFrontier(candidate)
+	if len(scratch.top) < candidateLimit || columnVectorGraphSearchCandidateBetter(candidate, scratch.top[len(scratch.top)-1]) {
+		scratch.insertTop(candidateLimit, candidate)
+		scratch.pushFrontier(candidate)
+	}
 	return nil
 }
 
@@ -603,6 +611,10 @@ func columnVectorGraphSearchCandidateBetter(left, right columnVectorGraphSearchC
 		return left.ordinal < right.ordinal
 	}
 	return left.score > right.score
+}
+
+func columnVectorGraphSearchCandidateWorse(left, right columnVectorGraphSearchCandidate) bool {
+	return columnVectorGraphSearchCandidateBetter(right, left)
 }
 
 func columnVectorGraphNativeCosineScore(query []float32, queryInvNorm float32, row columnVectorGraphPhysicalRow) (float64, error) {

--- a/TreeDB/collections/column_vector_graph_search_test.go
+++ b/TreeDB/collections/column_vector_graph_search_test.go
@@ -147,6 +147,31 @@ func TestColumnVectorGraphNativeSearchDoesNotStopBeforePromisingFrontierV6(t *te
 	}
 }
 
+func TestColumnVectorGraphNativeSearchExpandsEqualScoreFrontierV6(t *testing.T) {
+	rows := []columnVectorGraphAssetRow{
+		{ID: []byte("doc-start"), Vector: []float32{0, 1, 0}, InvNorm: 1, Adjacency: []uint32{1, 2}},
+		{ID: []byte("doc-tie-low-ordinal"), Vector: []float32{0, 1, 0}, InvNorm: 1},
+		{ID: []byte("doc-tie-bridge"), Vector: []float32{0, 1, 0}, InvNorm: 1, Adjacency: []uint32{3}},
+		{ID: []byte("doc-best"), Vector: []float32{1, 0, 0}, InvNorm: 1},
+	}
+	d, col, def := publishColumnVectorGraphPhysicalReaderTestAssetV2B(t, rows)
+	defer func() { _ = d.Close() }()
+	reader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("openColumnVectorGraphPhysicalRowReader: %v", err)
+	}
+	defer reader.Close()
+
+	var scratch columnVectorGraphNativeSearchScratch
+	got, stats, err := reader.SearchCosine([]float32{1, 0, 0}, columnVectorGraphNativeSearchOptions{TopK: 1, EfSearch: 2}, &scratch)
+	if err != nil {
+		t.Fatalf("SearchCosine: %v", err)
+	}
+	if len(got) != 1 || got[0].Ordinal != 3 || string(got[0].ID) != "doc-best" {
+		t.Fatalf("results=%+v stats=%+v want equal-score frontier expansion to reach doc-best", got, stats)
+	}
+}
+
 func TestColumnVectorGraphNativeSearchKeepsExpansionAdjacencyStableV3(t *testing.T) {
 	rows := []columnVectorGraphAssetRow{
 		{ID: []byte("doc-start"), Vector: []float32{0, 1, 0}, InvNorm: 1, Adjacency: []uint32{1, 2}},

--- a/TreeDB/collections/column_vector_graph_search_test.go
+++ b/TreeDB/collections/column_vector_graph_search_test.go
@@ -113,11 +113,37 @@ func TestColumnVectorGraphNativeSearchUsesBestFirstFrontierV3(t *testing.T) {
 	if len(got) != 1 || got[0].Ordinal != 4 || string(got[0].ID) != "doc-best" {
 		t.Fatalf("results=%+v want best-first traversal to reach doc-best before lower-score branch", got)
 	}
-	if stats.Candidates != 4 || stats.CandidateFetches != 4 || stats.ScoreBatches != 4 || stats.ExpansionFetches != stats.AdjacencyExpansions {
-		t.Fatalf("stats=%+v want four scored candidates plus lazy adjacency expansion fetches", stats)
+	if stats.Candidates < 4 || stats.Candidates > uint64(len(rows)) || stats.CandidateFetches != stats.Candidates || stats.ScoreBatches != stats.Candidates || stats.ExpansionFetches != stats.AdjacencyExpansions {
+		t.Fatalf("stats=%+v want bounded best-first scored candidates plus lazy adjacency expansion fetches", stats)
 	}
 	if readerStats := reader.Stats(); readerStats.RowFetches != 0 || readerStats.BatchFetches != 0 || readerStats.RowsFetched != 0 {
 		t.Fatalf("reader stats=%+v want no generic row fetches for scoring or result IDs stats=%+v", readerStats, stats)
+	}
+}
+
+func TestColumnVectorGraphNativeSearchDoesNotStopBeforePromisingFrontierV6(t *testing.T) {
+	rows := []columnVectorGraphAssetRow{
+		{ID: []byte("doc-start"), Vector: []float32{0, 1, 0}, InvNorm: 1, Adjacency: []uint32{1, 2, 3}},
+		{ID: []byte("doc-low-a"), Vector: []float32{-1, 0, 0}, InvNorm: 1},
+		{ID: []byte("doc-low-b"), Vector: []float32{-0.8, 0.6, 0}, InvNorm: 1},
+		{ID: []byte("doc-bridge"), Vector: []float32{0.5, 0.8660254, 0}, InvNorm: 1, Adjacency: []uint32{4}},
+		{ID: []byte("doc-best"), Vector: []float32{1, 0, 0}, InvNorm: 1},
+	}
+	d, col, def := publishColumnVectorGraphPhysicalReaderTestAssetV2B(t, rows)
+	defer func() { _ = d.Close() }()
+	reader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("openColumnVectorGraphPhysicalRowReader: %v", err)
+	}
+	defer reader.Close()
+
+	var scratch columnVectorGraphNativeSearchScratch
+	got, stats, err := reader.SearchCosine([]float32{1, 0, 0}, columnVectorGraphNativeSearchOptions{TopK: 1, EfSearch: 3}, &scratch)
+	if err != nil {
+		t.Fatalf("SearchCosine: %v", err)
+	}
+	if len(got) != 1 || got[0].Ordinal != 4 || string(got[0].ID) != "doc-best" {
+		t.Fatalf("results=%+v stats=%+v want bounded HNSW frontier to continue through bridge to doc-best", got, stats)
 	}
 }
 

--- a/cmd/treedb_vector_search_demo/main_test.go
+++ b/cmd/treedb_vector_search_demo/main_test.go
@@ -207,8 +207,8 @@ func TestExecuteColumnGraphRecallBenchmarkShape(t *testing.T) {
 	if res.Validation.Recall < 0.95 {
 		t.Fatalf("recall=%f want >=0.95", res.Validation.Recall)
 	}
-	if res.Search.AvgCandidates != 128 {
-		t.Fatalf("avg candidates=%f want ef_search=128", res.Search.AvgCandidates)
+	if res.Search.AvgCandidates < 128 {
+		t.Fatalf("avg candidates=%f want at least ef_search=128 scored candidates", res.Search.AvgCandidates)
 	}
 }
 


### PR DESCRIPTION
Follow-up to #1745 and the column_graph vector comparator parity work.

Base/stack:
- Base branch: `codex/issue-1739-vacuumed-vector-storage` (#1745)
- This PR is not merged.

## Root cause

- The persisted `column_graph` search loop stopped after scoring `ef_search` candidates and only kept `top_k` candidates in its bounded best set.
- Native TreeDB HNSW and pgvector continue best-first expansion while the frontier can still improve the bounded `ef_search` candidate set.
- On 384-dimensional data with M=16/efSearch=128 this made `column_graph` recall trail both TreeDB native and pgvector significantly.

## Fix

- Keep an `ef_search`-sized bounded candidate set during `column_graph` native-reader search.
- Continue popping the best frontier candidate until its score is strictly below the current worst retained score, matching HNSW search-layer semantics without using ordinal tie-breaks as a stop condition.
- Still expand equal-score frontier candidates because they can be bridges to better neighbors.
- Only materialize the final topK results after search.
- Add regression tests for:
  - stopping before a promising frontier bridge;
  - equal-score frontier expansion.

## Tests

Latest local validation:

```sh
go test ./TreeDB/collections ./cmd/treedb_vector_search_demo ./cmd/treedb_vector_dataset_export
```

Result: pass.

Focused validation also run during development:

```sh
go test ./TreeDB/collections -run 'TestColumnVectorGraphNativeSearch|TestSearchVectorIndexColumnGraph'
go test ./cmd/treedb_vector_search_demo ./cmd/treedb_vector_dataset_export
```

Result: pass.

## Benchmark / parity evidence

Shape: 10k docs / 384 dims / topK=10 / M=16 / efConstruction=128 / efSearch=128, same exported dataset, pgvector as control.

| State | TreeDB native recall@10 | TreeDB column_graph recall@10 | pgvector recall@10 |
| --- | ---: | ---: | ---: |
| Before fix | 0.9516 | 0.8109 | 0.9531 |
| After fix | 0.9516 | 0.9516 | 0.9500 |

After-fix artifact:

```text
/tmp/gomap_vector_fix_pg_control_dim384_m16_ef128_20260522_144200/comparison.md
```

## CI / reviews

- CI: latest-head GitHub Actions for `100527672` are green.
- Codex: initial finding fixed; thread resolved with score-only termination and equal-score regression test. Latest Codex re-review: "Didn't find any major issues."
- CodeRabbit: re-review completed with no actionable comments; status green. Its docstring-coverage warning is a generic non-blocking warning and not specific to this PR.
- Copilot: review re-requested after latest push; previous attempt errored and no actionable latest-head Copilot feedback was available.

## Caveats

- This is a correctness/parity change and intentionally increases scored candidates/search for `column_graph` to match HNSW semantics; latency increases versus the previous under-searching behavior.
