### PR TITLE
docs: add TreeDB typed-storage naming scaffold

### DIFF
--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -1,0 +1,112 @@
+package collections
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func readTypedStorageNamingDoc(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join("..", "docs", "spec", "typed-storage-naming.md")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read typed-storage naming doc: %v", err)
+	}
+	return string(data)
+}
+
+func requireDocContains(t *testing.T, doc string, needles ...string) {
+	t.Helper()
+	for _, needle := range needles {
+		if !strings.Contains(doc, needle) {
+			t.Fatalf("typed-storage naming doc missing %q", needle)
+		}
+	}
+}
+
+func TestTypedStorageNamingVocabulary(t *testing.T) {
+	doc := readTypedStorageNamingDoc(t)
+
+	requireDocContains(t, doc,
+		"`typed storage` is the umbrella name",
+		"`typed storage`",
+		"`typed-row storage` / `typed_row_asset`",
+		"`typed-column storage` / `typed_column_part`",
+		"`retained document` / `document_payload`",
+		"`derived accelerator`",
+		"Do not use \"column store\" as the umbrella name",
+	)
+}
+
+func TestTypedStorageFieldOwnerVocabulary(t *testing.T) {
+	doc := readTypedStorageNamingDoc(t)
+
+	requireDocContains(t, doc,
+		"Authoritative field owners are only:",
+		"`retained_document` / `document_payload`",
+		"`typed_row_asset`",
+		"`typed_column_part`",
+	)
+
+	if strings.Contains(doc, "`derived_accelerator` is an authoritative") {
+		t.Fatalf("typed-storage naming doc must not describe derived_accelerator as authoritative")
+	}
+}
+
+func TestTypedStorageDerivedAcceleratorsAreNotAuthoritative(t *testing.T) {
+	doc := readTypedStorageNamingDoc(t)
+
+	requireDocContains(t, doc,
+		"`derived_accelerator` is a classification only",
+		"must not silently become a second source of truth",
+		"dictionary-code assets",
+		"int64-values assets",
+		"aggregate metadata",
+		"vector graph assets",
+		"read caches and decoded metadata caches",
+	)
+
+	for _, row := range []string{
+		"| dictionary-code assets | `derived_accelerator` |",
+		"| int64-values assets | `derived_accelerator` |",
+		"| aggregate metadata | `derived_accelerator` |",
+		"| vector graph assets | `derived_accelerator` |",
+		"| read caches and decoded metadata caches | `derived_accelerator` |",
+	} {
+		if !strings.Contains(doc, row) {
+			t.Fatalf("typed-storage naming doc missing derived accelerator row %q", row)
+		}
+	}
+}
+
+func TestTypedStorageLegacyNameInventoryTable(t *testing.T) {
+	doc := readTypedStorageNamingDoc(t)
+
+	requireDocContains(t, doc,
+		"## Legacy Name Inventory",
+		"rg -n \"ColumnStore|column store|column-store\" TreeDB experiments docs",
+		"| Path | Symbol/text | Current meaning | Classification | Action | Deferral reason |",
+		"`TreeDB/collections/api.go`",
+		"`ColumnStoreConfig`",
+		"`experiments/colgranule/**`",
+		"true typed-column terminology",
+		"compatibility-retained",
+		"deferred",
+	)
+}
+
+func TestTypedStoragePR0RuntimeBoundary(t *testing.T) {
+	doc := readTypedStorageNamingDoc(t)
+
+	requireDocContains(t, doc,
+		"## PR 0 Runtime Boundary",
+		"no durable typed-column part format",
+		"no `ColumnStoreConfig` removal",
+		"no public API break",
+		"no query planner change",
+		"no production data-path behavior change",
+		"no #1736 resource-manager behavior change",
+	)
+}

--- a/TreeDB/docs/spec/README.md
+++ b/TreeDB/docs/spec/README.md
@@ -153,6 +153,10 @@ Given pre-alpha status, this is a living spec that tracks implementation.
   - issue #1646 V0 inventory for rebuilding column-store-native vector graph
     search on generic column-store reader/cache APIs without carrying forward
     decoded full-graph behavior as the product path.
+- `TreeDB/docs/spec/typed-storage-naming.md`
+  - issue #1750 PR 0 naming scaffold establishing `typed storage` as the
+    umbrella for typed-row and typed-column physical storage, with legacy
+    `ColumnStore*` inventory and derived-accelerator classifications.
 
 ## Canonical Ownership
 
@@ -165,7 +169,7 @@ Given pre-alpha status, this is a living spec that tracks implementation.
 | Current recovery algorithm | `recovery.md` | `storage-format.md`, `verification.md`. |
 | Durable bytes and file names | `storage-format.md` | `recovery.md`, `architecture.md`, `backup-restore.md`. |
 | Value-log and split leaf-log lifecycle | `value-log-lifecycle.md` | `storage-format.md`, `user-command-wal.md`, `collection-wal-durability-plan.md` for historical external-ref context. |
-| Command-WAL external refs and side files | `user-command-wal.md` | `value-log-lifecycle.md`, future column-store docs. |
+| Command-WAL external refs and side files | `user-command-wal.md` | `value-log-lifecycle.md`, future typed-storage docs. |
 | Public API semantics | `contracts.md` | `write-path-and-durability.md`, `collections-write-domain.md`. |
 | Native-wire ack policies | `native-wire-protocol.md` | `user-command-wal.md`, `native-query-raft-roadmap.md`. |
 | Raft/local apply layering | `native-query-raft-roadmap.md` | `native-wire-protocol.md`, `user-command-wal.md`. |
@@ -175,9 +179,12 @@ Given pre-alpha status, this is a living spec that tracks implementation.
 
 TreeDB-wide storage terms (`value log`, `leaf log`, `commit log`,
 `ValuePtr`) are owned by `storage-format.md` and `value-log-lifecycle.md`.
-User-command WAL lifecycle terms (`CommandEnvelope`, `LSN`, `AppliedLSN`,
-`WAL-supported`, `WAL-rejected`, `WAL-off-only`) are owned by
-`user-command-wal.md`. Deprecated collection root-delta WAL terms
+Typed physical storage vocabulary (`typed storage`, `typed-row storage`,
+`typed-column storage`, `typed_row_asset`, `typed_column_part`,
+`retained_document`, `document_payload`, and `derived_accelerator`) is owned by
+`typed-storage-naming.md`. User-command WAL lifecycle terms
+(`CommandEnvelope`, `LSN`, `AppliedLSN`, `WAL-supported`, `WAL-rejected`,
+`WAL-off-only`) are owned by `user-command-wal.md`. Deprecated collection root-delta WAL terms
 (`CollectionSeq`, `WALLSN`, `root group`, `applied watermark`) remain defined in
 `collection-wal-durability-plan.md` for historical design context only.
 

--- a/TreeDB/docs/spec/typed-storage-naming.md
+++ b/TreeDB/docs/spec/typed-storage-naming.md
@@ -1,0 +1,82 @@
+# TreeDB Typed Storage Naming
+
+This document is the PR 0 naming scaffold for issue #1750 under the
+#1744 typed-storage tracker. It is intentionally a vocabulary and inventory
+contract only. It does not define a new durable on-disk format, remove legacy
+public APIs, alter query planning, or change runtime behavior.
+
+## Naming Contract
+
+`typed storage` is the umbrella name for TreeDB's non-document physical storage
+for schema-declared typed fields. Do not use "column store" as the umbrella name
+for that superset.
+
+Required vocabulary:
+
+| Term | Meaning |
+| --- | --- |
+| `typed storage` | Umbrella subsystem for typed-row storage and typed-column storage. |
+| `typed-row storage` / `typed_row_asset` | Current row-record physical asset path for declared typed values. |
+| `typed-column storage` / `typed_column_part` | Future true sectioned, column-major part assets transplanted from `experiments/colgranule`. |
+| `retained document` / `document_payload` | Flexible document owner or retained residual payload used for reconstruction. |
+| `derived accelerator` | Non-authoritative duplicate, index, cache, or metadata derived from an authoritative owner. |
+
+Authoritative field owners are only:
+
+- `retained_document` / `document_payload`;
+- `typed_row_asset`;
+- `typed_column_part`.
+
+`derived_accelerator` is a classification only. It is not an authoritative field
+owner and must not silently become a second source of truth for a logical field.
+
+## Current Derived Accelerator Classifications
+
+These existing assets are derived accelerators unless a future format explicitly
+promotes them and updates the typed-storage ownership contract:
+
+| Asset family | Classification | Authoritative owner relationship |
+| --- | --- | --- |
+| dictionary-code assets | `derived_accelerator` | Derived from a typed-row or typed-column authoritative value owner. |
+| int64-values assets | `derived_accelerator` | Derived from a typed-row or typed-column authoritative value owner. |
+| aggregate metadata | `derived_accelerator` | Derived metadata tied to an authoritative owner/generation. |
+| vector graph assets | `derived_accelerator` | Derived graph/search structure tied to vector field ownership. |
+| read caches and decoded metadata caches | `derived_accelerator` | Runtime acceleration over authoritative storage. |
+
+## Legacy Name Inventory
+
+Audit command used for the initial inventory:
+
+```sh
+rg -n "ColumnStore|column store|column-store" TreeDB experiments docs
+```
+
+The repository currently has many legacy `ColumnStore*`, "column store", and
+"column-store" references. This table classifies the major current groups. A PR
+that touches a specific legacy occurrence must include the exact touched
+occurrence in its PR inventory.
+
+| Path | Symbol/text | Current meaning | Classification | Action | Deferral reason |
+| --- | --- | --- | --- | --- | --- |
+| `TreeDB/collections/api.go` | `ColumnStoreConfig`, `ColumnStoreColumn`, `ColumnStoreValueType`, retained-payload options | Public compatibility configuration for declared typed fields and retained payload behavior. | compatibility-retained | Keep as compatibility input; #1751 should normalize it through typed-storage layout names. | Public API compatibility; do not remove in PR 0. |
+| `TreeDB/collections/column_store.go` and related publish/reconstruction files | `ColumnStore*` implementation names and comments | Production declared-field extraction, retained-payload handling, reconstruction, and publication control plane currently attached to typed-row assets. | compatibility-retained | Document as typed-storage/typed-row behavior; rename/wrap later under #1751/#1752. | Avoid behavior or public API change in PR 0. |
+| `TreeDB/collections/column_physical_asset.go`, `column_physical_*.go`, `column_physical_row_reader.go` | column physical asset / `TCPA` wording | Current row-record physical asset for declared typed values. | rename-now when touched as typed-row terminology | Treat as `typed_row_asset`; broad rename deferred to #1752. | Current PR is naming scaffold only. |
+| `TreeDB/collections/column_asset_manager.go`, `column_asset_reachability.go`, `column_asset_gc.go`, `column_asset_rewrite.go` | column asset manager / reachability / GC / rewrite wording | Typed physical asset manager rooted in current typed-row assets and future typed-column refs. | compatibility-retained | Keep behavior; align terminology as typed-storage resource management in follow-ups. | #1736/#1755 own deeper resource and maintenance integration. |
+| `TreeDB/collections/column_dictionary_codes_asset.go` | dictionary-code asset names | Derived code sidecar for declared values. | derived accelerator | Keep as non-authoritative sidecar; require owner/generation association in later work. | Query integration and metadata rules belong to later #1744 children. |
+| `TreeDB/collections/column_int64_values_asset.go` | int64-values asset names | Derived values sidecar for declared values. | derived accelerator | Keep as non-authoritative sidecar; require owner/generation association in later work. | Query integration and metadata rules belong to later #1744 children. |
+| `TreeDB/collections/column_vector_graph_*.go`, `vector_index*.go` | vector graph / native column wording | Derived vector graph/search structures and row readers over current assets. | derived accelerator | Keep as non-authoritative accelerator; future dense typed-column sections are #1756. | Do not change vector product path in PR 0. |
+| `experiments/colgranule/**` | `ColumnStoreOptions`, `ColumnPart*`, column/granule descriptors | Coherent experimental typed-column data plane to transplant. | true typed-column terminology | Preserve for #1753 transplant; do not rename in PR 0. | Avoid thrashing the experiment before transplant. |
+| `TreeDB/docs/spec/GOMAP_TREEDB_COLUMN_STORE_RFC.md` | broad "column-store" roadmap wording | Historical/pre-typed-storage RFC that predates the umbrella rename. | deferred | Keep as historical supporting material until a dedicated docs rewrite. | Large historical document; changing it here would obscure PR 0. |
+| `TreeDB/docs/spec/column-graph-native-*.md` | column-store-native vector wording | Historical/vector tracker docs for rebuilding native vector search. | deferred | Keep historical references; future vector typed-column docs belong to #1756. | Do not change vector path in PR 0. |
+| `TreeDB/docs/spec/storage-format.md`, `docs/TREEDB_STORAGE_FORMAT.md`, backup/recovery/verification docs | future/physical column-store asset wording | Storage-format and recovery docs describing existing/future typed physical assets. | deferred | Update after typed-storage layout/publication work clarifies exact durable terms. | Avoid changing format claims before #1753/#1755. |
+
+## PR 0 Runtime Boundary
+
+This naming scaffold must preserve existing runtime behavior:
+
+- no durable typed-column part format;
+- no `ColumnStoreConfig` removal;
+- no public API break;
+- no query planner change;
+- no production data-path behavior change;
+- no #1736 resource-manager behavior change.

--- a/TreeDB/docs/spec/typed-storage-naming.md
+++ b/TreeDB/docs/spec/typed-storage-naming.md
@@ -1,9 +1,9 @@
 # TreeDB Typed Storage Naming
 
-This document is the PR 0 naming scaffold for issue #1750 under the
-#1744 typed-storage tracker. It is intentionally a vocabulary and inventory
-contract only. It does not define a new durable on-disk format, remove legacy
-public APIs, alter query planning, or change runtime behavior.
+This document is the PR 0 naming scaffold for issue #1750 under the #1744
+typed-storage tracker. It is intentionally a vocabulary and inventory contract
+only. It does not define a new durable on-disk format, remove legacy public
+APIs, alter query planning, or change runtime behavior.
 
 ## Naming Contract
 


### PR DESCRIPTION
## Summary

PR 0 for #1744 / #1750: establish TreeDB `typed storage` naming and ownership scaffolding without changing runtime behavior.

Changes:

- adds `TreeDB/docs/spec/typed-storage-naming.md` as the typed-storage naming contract;
- registers the doc in `TreeDB/docs/spec/README.md` terminology ownership;
- adds tests that lock the required vocabulary, field-owner set, derived-accelerator classification, legacy-name inventory table, and PR 0 runtime boundary.

## Trackers

- Parent tracker: #1744
- Child tracker: Closes #1750
- This is #1744 PR 0 / naming scaffold.

## Naming impact

`typed storage` is established as the umbrella name for non-document/schema-declared typed physical storage.

Required vocabulary documented and tested:

- `typed storage`
- `typed-row storage` / `typed_row_asset`
- `typed-column storage` / `typed_column_part`
- `retained document` / `document_payload`
- `derived accelerator`

Authoritative field owners documented and tested:

- `retained_document` / `document_payload`
- `typed_row_asset`
- `typed_column_part`

`derived_accelerator` is documented/tested as a classification only, not an authoritative owner.

## Legacy-name inventory

Audit command:

```sh
rg -n "ColumnStore|column store|column-store" TreeDB experiments docs
```

Audit counts from this branch:

- before PR scaffold: 1798 matching lines
- after PR scaffold: 1813 matching lines
- increase is limited to the new naming scaffold doc/tests and README registration; no production umbrella `ColumnStore*` concept was added.

Required inventory table:

| Path | Symbol/text | Current meaning | Classification | Action | Deferral reason |
| --- | --- | --- | --- | --- | --- |
| `TreeDB/collections/api.go` | `ColumnStoreConfig`, `ColumnStoreColumn`, `ColumnStoreValueType`, retained-payload options | Public compatibility configuration for declared typed fields and retained payload behavior. | compatibility-retained | Keep as compatibility input; #1751 should normalize it through typed-storage layout names. | Public API compatibility; do not remove in PR 0. |
| `TreeDB/collections/column_store.go` and related publish/reconstruction files | `ColumnStore*` implementation names and comments | Production declared-field extraction, retained-payload handling, reconstruction, and publication control plane currently attached to typed-row assets. | compatibility-retained | Document as typed-storage/typed-row behavior; rename/wrap later under #1751/#1752. | Avoid behavior or public API change in PR 0. |
| `TreeDB/collections/column_physical_asset.go`, `column_physical_*.go`, `column_physical_row_reader.go` | column physical asset / `TCPA` wording | Current row-record physical asset for declared typed values. | rename-now when touched as typed-row terminology | Treat as `typed_row_asset`; broad rename deferred to #1752. | Current PR is naming scaffold only. |
| `TreeDB/collections/column_asset_manager.go`, `column_asset_reachability.go`, `column_asset_gc.go`, `column_asset_rewrite.go` | column asset manager / reachability / GC / rewrite wording | Typed physical asset manager rooted in current typed-row assets and future typed-column refs. | compatibility-retained | Keep behavior; align terminology as typed-storage resource management in follow-ups. | #1736/#1755 own deeper resource and maintenance integration. |
| `TreeDB/collections/column_dictionary_codes_asset.go` | dictionary-code asset names | Derived code sidecar for declared values. | derived accelerator | Keep as non-authoritative sidecar; require owner/generation association in later work. | Query integration and metadata rules belong to later #1744 children. |
| `TreeDB/collections/column_int64_values_asset.go` | int64-values asset names | Derived values sidecar for declared values. | derived accelerator | Keep as non-authoritative sidecar; require owner/generation association in later work. | Query integration and metadata rules belong to later #1744 children. |
| `TreeDB/collections/column_vector_graph_*.go`, `vector_index*.go` | vector graph / native column wording | Derived vector graph/search structures and row readers over current assets. | derived accelerator | Keep as non-authoritative accelerator; future dense typed-column sections are #1756. | Do not change vector product path in PR 0. |
| `experiments/colgranule/**` | `ColumnStoreOptions`, `ColumnPart*`, column/granule descriptors | Coherent experimental typed-column data plane to transplant. | true typed-column terminology | Preserve for #1753 transplant; do not rename in PR 0. | Avoid thrashing the experiment before transplant. |
| `TreeDB/docs/spec/GOMAP_TREEDB_COLUMN_STORE_RFC.md` | broad "column-store" roadmap wording | Historical/pre-typed-storage RFC that predates the umbrella rename. | deferred | Keep as historical supporting material until a dedicated docs rewrite. | Large historical document; changing it here would obscure PR 0. |
| `TreeDB/docs/spec/column-graph-native-*.md` | column-store-native vector wording | Historical/vector tracker docs for rebuilding native vector search. | deferred | Keep historical references; future vector typed-column docs belong to #1756. | Do not change vector path in PR 0. |
| `TreeDB/docs/spec/storage-format.md`, `docs/TREEDB_STORAGE_FORMAT.md`, backup/recovery/verification docs | future/physical column-store asset wording | Storage-format and recovery docs describing existing/future typed physical assets. | deferred | Update after typed-storage layout/publication work clarifies exact durable terms. | Avoid changing format claims before #1753/#1755. |

Changed-file audit:

```text
TreeDB/docs/spec/README.md: legacy #1646 wording retained; new `ColumnStore*` mention is inventory text only.
TreeDB/docs/spec/typed-storage-naming.md: legacy-name inventory/classification only.
TreeDB/collections/typed_storage_naming_test.go: validates naming contract, inventory text, and runtime boundary only.
```

## No-runtime-behavior-change confirmation

This PR only adds documentation and tests. It does not:

- add a durable typed-column part format;
- remove or rename `ColumnStoreConfig`;
- break public APIs;
- change query planning;
- change production data-path behavior;
- change #1736 resource-manager behavior.

## Tests / audits run

```sh
go test ./TreeDB/collections -run TestTypedStorage
go test ./TreeDB/collections
rg -n "ColumnStore|column store|column-store" TreeDB experiments docs
```

Required tests added/mapped:

- `TestTypedStorageNamingVocabulary`
- `TestTypedStorageFieldOwnerVocabulary`
- `TestTypedStorageDerivedAcceleratorsAreNotAuthoritative`
- `TestTypedStorageLegacyNameInventoryTable`
- `TestTypedStoragePR0RuntimeBoundary`

Vector graph files/status/docs were not modified, so no focused vector graph row-reader test was required beyond `go test ./TreeDB/collections`.

## Benchmarks

Not run. This PR is docs/tests only and does not touch hot-path runtime code.

## AI review / CI status

Latest head: `c86ac7dc2008aac0ef137d67f2d5eea19d834d3f`.

- Codex: requested after latest head; reported no major issues.
- Copilot: requested after latest head; Copilot cloud agent errored/unavailable, so no actionable Copilot review was produced.
- CodeRabbit: requested after latest head; one markdownlint finding was fixed in `c86ac7d`, review thread is resolved, and latest CodeRabbit check reports pass/review skipped.
- CI: latest-head GitHub checks are passing; the separate Copilot cloud-agent run failed non-blockingly while attempting to address/review the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new typed storage naming spec documenting vocabulary, authority rules, an inventory of existing usages, and a PR-0 runtime boundary checklist.
  * Updated the spec index/README to reference the new typed storage document and adjusted related ownership entries.

* **Tests**
  * Added validation tests that verify the typed storage documentation contains required vocabulary, authority statements, inventory entries, and runtime-boundary constraints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1759?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->