### PR TITLE
collections: add typed-storage layout resolver

### DIFF
--- a/TreeDB/collections/typed_storage_layout.go
+++ b/TreeDB/collections/typed_storage_layout.go
@@ -1,0 +1,430 @@
+package collections
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+)
+
+// ErrTypedStorageColumnPartUnsupported is returned by fail-closed guards when a
+// normalized layout contains authoritative typed-column ownership. PR #1751 only
+// introduces the pure-metadata resolver; durable typed-column reads and
+// publication land in later #1744 children.
+var ErrTypedStorageColumnPartUnsupported = errors.New("collections: typed_column_part ownership is not supported yet")
+
+// TypedStorageFieldOwner names the authoritative physical owner for one logical
+// field in a normalized typed-storage layout.
+type TypedStorageFieldOwner string
+
+const (
+	// TypedStorageOwnerRetainedDocument means the field is authoritatively owned
+	// by the retained document/document_payload path.
+	TypedStorageOwnerRetainedDocument TypedStorageFieldOwner = "retained_document"
+	// TypedStorageOwnerRowAsset means the field is authoritatively owned by the
+	// current typed-row physical asset path.
+	TypedStorageOwnerRowAsset TypedStorageFieldOwner = "typed_row_asset"
+	// TypedStorageOwnerColumnPart is a future typed-column owner placeholder. It
+	// may be represented by the resolver, but read/publication support fails
+	// closed until the typed-column format and publication path land.
+	TypedStorageOwnerColumnPart TypedStorageFieldOwner = "typed_column_part"
+)
+
+// TypedStorageAssetClass classifies non-authoritative assets associated with a
+// typed-storage owner/generation.
+type TypedStorageAssetClass string
+
+const (
+	// TypedStorageAssetClassDerivedAccelerator marks dictionaries, int64 values,
+	// aggregate metadata, vector graphs, and caches as derived sidecars. It is not
+	// an authoritative field owner.
+	TypedStorageAssetClassDerivedAccelerator TypedStorageAssetClass = "derived_accelerator"
+)
+
+// TypedStorageField describes one explicitly resolved logical field owner. The
+// zero Owner is normalized to TypedStorageOwnerRowAsset for compatibility with
+// existing ColumnStoreConfig declared typed fields.
+type TypedStorageField struct {
+	Name               string                   `json:"name,omitempty"`
+	Path               string                   `json:"path"`
+	Owner              TypedStorageFieldOwner   `json:"owner"`
+	ValueType          ColumnStoreValueType     `json:"value_type,omitempty"`
+	Nullable           bool                     `json:"nullable,omitempty"`
+	Dictionary         bool                     `json:"dictionary,omitempty"`
+	VectorDims         int                      `json:"vector_dims,omitempty"`
+	FixedWidthEncoding ColumnFixedWidthEncoding `json:"fixed_width_encoding,omitempty"`
+}
+
+// TypedStorageDerivedAccelerator describes a non-authoritative sidecar tied to
+// an authoritative owner and optional generation.
+type TypedStorageDerivedAccelerator struct {
+	Name            string                 `json:"name"`
+	Class           TypedStorageAssetClass `json:"class"`
+	SourceFieldPath string                 `json:"source_field_path,omitempty"`
+	SourceOwner     TypedStorageFieldOwner `json:"source_owner,omitempty"`
+	Generation      uint64                 `json:"generation,omitempty"`
+}
+
+// TypedStorageLayout is the pure-metadata resolved ownership view for a
+// collection generation. It does not open assets, read sections, mutate DB
+// state, publish roots, or acquire mmap/resource handles.
+type TypedStorageLayout struct {
+	Collection string `json:"collection,omitempty"`
+	Enabled    bool   `json:"enabled,omitempty"`
+
+	// Fields contains explicit authoritative owners for declared/logical fields.
+	// Unknown document fields are represented by RetainedDocumentOwnsRemainder.
+	Fields []TypedStorageField `json:"fields,omitempty"`
+
+	// RetainedPayload records the compatibility retained-payload policy that
+	// produced the document_payload behavior below.
+	RetainedPayload ColumnRetainedPayloadPolicy `json:"retained_payload,omitempty"`
+	// RetainedDocumentOwnsRemainder means document_payload remains the
+	// authoritative owner for fields not listed in Fields.
+	RetainedDocumentOwnsRemainder bool `json:"retained_document_owns_remainder,omitempty"`
+	// RetainedDocumentCompatibilityDuplicate means document_payload may contain
+	// bytes for fields whose authoritative owner is a typed asset. This models
+	// ColumnRetainedPayloadFull compatibility duplication without creating
+	// overlapping authoritative owners.
+	RetainedDocumentCompatibilityDuplicate bool `json:"retained_document_compatibility_duplicate,omitempty"`
+
+	DerivedAccelerators []TypedStorageDerivedAccelerator `json:"derived_accelerators,omitempty"`
+}
+
+// ResolveTypedStorageLayout maps collection metadata to a normalized
+// typed-storage ownership layout. Existing ColumnStoreConfig metadata is kept as
+// compatibility input: declared columns resolve to typed_row_asset ownership.
+func ResolveTypedStorageLayout(meta CollectionMeta) (TypedStorageLayout, error) {
+	if err := ValidateCollectionName(meta.Name); err != nil {
+		return TypedStorageLayout{}, err
+	}
+	cfg, err := normalizeColumnStoreConfig(meta.Name, meta.Options.ColumnStore)
+	if err != nil {
+		return TypedStorageLayout{}, err
+	}
+	if cfg == nil {
+		return NormalizeTypedStorageLayout(TypedStorageLayout{
+			Collection:                             meta.Name,
+			Enabled:                                false,
+			RetainedPayload:                        ColumnRetainedPayloadFull,
+			RetainedDocumentOwnsRemainder:          true,
+			RetainedDocumentCompatibilityDuplicate: false,
+		})
+	}
+	fields := make([]TypedStorageField, 0, len(cfg.Columns))
+	for _, col := range cfg.Columns {
+		fields = append(fields, TypedStorageField{
+			Name:               col.Name,
+			Path:               col.Path,
+			Owner:              TypedStorageOwnerRowAsset,
+			ValueType:          col.ValueType,
+			Nullable:           col.Nullable,
+			Dictionary:         col.Dictionary,
+			VectorDims:         col.VectorDims,
+			FixedWidthEncoding: col.FixedWidthEncoding,
+		})
+	}
+	layout := TypedStorageLayout{
+		Collection:          meta.Name,
+		Enabled:             cfg.Enabled,
+		Fields:              fields,
+		RetainedPayload:     cfg.RetainedPayload,
+		DerivedAccelerators: derivedAcceleratorsFromColumnStoreConfig(*cfg),
+	}
+	applyRetainedPayloadToTypedStorageLayout(&layout)
+	return NormalizeTypedStorageLayout(layout)
+}
+
+// NormalizeTypedStorageLayout normalizes and validates an explicit
+// pure-metadata typed-storage layout. It accepts typed_column_part placeholders
+// so future metadata can be represented, while fail-closed read/publication
+// guards below prevent accidental use as a supported data path.
+func NormalizeTypedStorageLayout(in TypedStorageLayout) (TypedStorageLayout, error) {
+	out := in.copy()
+	if out.Collection != "" {
+		if err := ValidateCollectionName(out.Collection); err != nil {
+			return TypedStorageLayout{}, err
+		}
+	}
+	if out.RetainedPayload == "" {
+		if len(out.Fields) == 0 {
+			out.RetainedPayload = ColumnRetainedPayloadFull
+		} else {
+			out.RetainedPayload = ColumnRetainedPayloadNonColumn
+		}
+	}
+	if err := validateTypedStorageRetainedPayload(out.RetainedPayload); err != nil {
+		return TypedStorageLayout{}, err
+	}
+	applyRetainedPayloadToTypedStorageLayout(&out)
+	seenPaths := make(map[string]TypedStorageFieldOwner, len(out.Fields))
+	for i := range out.Fields {
+		field := &out.Fields[i]
+		if field.Owner == "" {
+			field.Owner = TypedStorageOwnerRowAsset
+		}
+		owner, err := normalizeTypedStorageFieldOwner(field.Owner)
+		if err != nil {
+			name := field.Name
+			if name == "" {
+				name = field.Path
+			}
+			return TypedStorageLayout{}, fmt.Errorf("collections: invalid typed-storage field %q owner: %w", name, err)
+		}
+		field.Owner = owner
+		if field.Name != "" {
+			if err := ValidateIndexName(field.Name); err != nil {
+				return TypedStorageLayout{}, fmt.Errorf("collections: invalid typed-storage field %q name: %w", field.Name, err)
+			}
+		}
+		if err := ValidateIndexPath(field.Path); err != nil {
+			name := field.Name
+			if name == "" {
+				name = field.Path
+			}
+			return TypedStorageLayout{}, fmt.Errorf("collections: invalid typed-storage field %q path: %w", name, err)
+		}
+		if field.ValueType != "" {
+			valueType, err := normalizeColumnStoreValueType(field.ValueType)
+			if err != nil {
+				name := field.Name
+				if name == "" {
+					name = field.Path
+				}
+				return TypedStorageLayout{}, fmt.Errorf("collections: invalid typed-storage field %q value_type: %w", name, err)
+			}
+			field.ValueType = valueType
+			if valueType == ColumnStoreValueFloat32Vector {
+				if field.VectorDims <= 0 {
+					name := field.Name
+					if name == "" {
+						name = field.Path
+					}
+					return TypedStorageLayout{}, fmt.Errorf("collections: invalid typed-storage field %q vector_dims: must be positive", name)
+				}
+			} else if field.VectorDims != 0 {
+				name := field.Name
+				if name == "" {
+					name = field.Path
+				}
+				return TypedStorageLayout{}, fmt.Errorf("collections: invalid typed-storage field %q vector_dims: only float32_vector fields may set vector_dims", name)
+			}
+			if field.Dictionary && valueType != ColumnStoreValueString {
+				name := field.Name
+				if name == "" {
+					name = field.Path
+				}
+				return TypedStorageLayout{}, fmt.Errorf("collections: invalid typed-storage field %q dictionary: unsupported for value_type %q", name, valueType)
+			}
+		}
+		fixedWidthEncoding, err := normalizeColumnFixedWidthEncoding(field.FixedWidthEncoding)
+		if err != nil {
+			name := field.Name
+			if name == "" {
+				name = field.Path
+			}
+			return TypedStorageLayout{}, fmt.Errorf("collections: invalid typed-storage field %q fixed_width_encoding: %w", name, err)
+		}
+		field.FixedWidthEncoding = fixedWidthEncoding
+		if field.FixedWidthEncoding != ColumnFixedWidthEncodingDefault && !columnStoreValueTypeSupportsFixedWidthEncoding(field.ValueType) {
+			name := field.Name
+			if name == "" {
+				name = field.Path
+			}
+			return TypedStorageLayout{}, fmt.Errorf("collections: invalid typed-storage field %q fixed_width_encoding: unsupported for value_type %q", name, field.ValueType)
+		}
+		if prior, ok := seenPaths[field.Path]; ok {
+			return TypedStorageLayout{}, fmt.Errorf("collections: overlapping authoritative typed-storage owners for field path %q: %s and %s", field.Path, prior, field.Owner)
+		}
+		seenPaths[field.Path] = field.Owner
+	}
+	for i := range out.DerivedAccelerators {
+		accel := &out.DerivedAccelerators[i]
+		if accel.Class == "" {
+			accel.Class = TypedStorageAssetClassDerivedAccelerator
+		}
+		if accel.Class != TypedStorageAssetClassDerivedAccelerator {
+			return TypedStorageLayout{}, fmt.Errorf("collections: unsupported typed-storage asset class %q", accel.Class)
+		}
+		if accel.Name == "" {
+			return TypedStorageLayout{}, errors.New("collections: typed-storage derived accelerator requires name")
+		}
+		if accel.SourceFieldPath != "" {
+			if err := ValidateIndexPath(accel.SourceFieldPath); err != nil {
+				return TypedStorageLayout{}, fmt.Errorf("collections: invalid typed-storage derived accelerator %q source path: %w", accel.Name, err)
+			}
+			owner, ok := seenPaths[accel.SourceFieldPath]
+			if !ok {
+				return TypedStorageLayout{}, fmt.Errorf("collections: typed-storage derived accelerator %q references unknown authoritative field path %q", accel.Name, accel.SourceFieldPath)
+			}
+			if accel.SourceOwner == "" {
+				accel.SourceOwner = owner
+			}
+		}
+		if accel.SourceOwner != "" {
+			owner, err := normalizeTypedStorageFieldOwner(accel.SourceOwner)
+			if err != nil {
+				return TypedStorageLayout{}, fmt.Errorf("collections: invalid typed-storage derived accelerator %q source owner: %w", accel.Name, err)
+			}
+			accel.SourceOwner = owner
+			if accel.SourceFieldPath != "" && seenPaths[accel.SourceFieldPath] != owner {
+				return TypedStorageLayout{}, fmt.Errorf("collections: typed-storage derived accelerator %q source owner %q does not match authoritative owner %q for field path %q", accel.Name, owner, seenPaths[accel.SourceFieldPath], accel.SourceFieldPath)
+			}
+		}
+	}
+	out.Enabled = out.Enabled || len(out.Fields) > 0 || len(out.DerivedAccelerators) > 0 || out.RetainedPayload != ColumnRetainedPayloadFull || !out.RetainedDocumentOwnsRemainder
+	return out, nil
+}
+
+func (l TypedStorageLayout) copy() TypedStorageLayout {
+	out := l
+	out.Fields = append([]TypedStorageField(nil), l.Fields...)
+	out.DerivedAccelerators = append([]TypedStorageDerivedAccelerator(nil), l.DerivedAccelerators...)
+	return out
+}
+
+func validateTypedStorageRetainedPayload(policy ColumnRetainedPayloadPolicy) error {
+	switch policy {
+	case ColumnRetainedPayloadNonColumn, ColumnRetainedPayloadFull, ColumnRetainedPayloadNone:
+		return nil
+	default:
+		return fmt.Errorf("collections: unsupported retained payload policy %q", policy)
+	}
+}
+
+func applyRetainedPayloadToTypedStorageLayout(layout *TypedStorageLayout) {
+	if layout == nil {
+		return
+	}
+	switch layout.RetainedPayload {
+	case ColumnRetainedPayloadFull:
+		layout.RetainedDocumentOwnsRemainder = true
+		layout.RetainedDocumentCompatibilityDuplicate = len(layout.Fields) > 0
+	case ColumnRetainedPayloadNonColumn:
+		layout.RetainedDocumentOwnsRemainder = true
+		layout.RetainedDocumentCompatibilityDuplicate = false
+	case ColumnRetainedPayloadNone:
+		layout.RetainedDocumentOwnsRemainder = false
+		layout.RetainedDocumentCompatibilityDuplicate = false
+	}
+}
+
+func normalizeTypedStorageFieldOwner(owner TypedStorageFieldOwner) (TypedStorageFieldOwner, error) {
+	switch owner {
+	case TypedStorageOwnerRetainedDocument, TypedStorageOwnerRowAsset, TypedStorageOwnerColumnPart:
+		return owner, nil
+	case "document_payload":
+		return TypedStorageOwnerRetainedDocument, nil
+	case TypedStorageFieldOwner(TypedStorageAssetClassDerivedAccelerator):
+		return "", errors.New("derived_accelerator is not an authoritative field owner")
+	case "":
+		return TypedStorageOwnerRowAsset, nil
+	default:
+		return "", fmt.Errorf("unsupported typed-storage field owner %q", owner)
+	}
+}
+
+func derivedAcceleratorsFromColumnStoreConfig(cfg ColumnStoreConfig) []TypedStorageDerivedAccelerator {
+	var out []TypedStorageDerivedAccelerator
+	for _, col := range cfg.Columns {
+		if col.Dictionary {
+			out = append(out, TypedStorageDerivedAccelerator{
+				Name:            col.Name + ":dictionary",
+				Class:           TypedStorageAssetClassDerivedAccelerator,
+				SourceFieldPath: col.Path,
+				SourceOwner:     TypedStorageOwnerRowAsset,
+			})
+		}
+		if col.ValueType == ColumnStoreValueInt64 && !col.Nullable {
+			out = append(out, TypedStorageDerivedAccelerator{
+				Name:            col.Name + ":int64_values",
+				Class:           TypedStorageAssetClassDerivedAccelerator,
+				SourceFieldPath: col.Path,
+				SourceOwner:     TypedStorageOwnerRowAsset,
+			})
+		}
+	}
+	for _, aggregate := range cfg.AggregateMetadata {
+		accel := TypedStorageDerivedAccelerator{
+			Name:  aggregate.Name,
+			Class: TypedStorageAssetClassDerivedAccelerator,
+		}
+		if aggregate.Column != "" {
+			if col, ok := columnStoreColumnByName(cfg.Columns, aggregate.Column); ok {
+				accel.SourceFieldPath = col.Path
+				accel.SourceOwner = TypedStorageOwnerRowAsset
+			}
+		}
+		out = append(out, accel)
+	}
+	return out
+}
+
+func columnStoreColumnByName(columns []ColumnStoreColumn, name string) (ColumnStoreColumn, bool) {
+	for _, col := range columns {
+		if col.Name == name {
+			return col, true
+		}
+	}
+	return ColumnStoreColumn{}, false
+}
+
+// OwnerForPath returns the authoritative owner for a logical field path when it
+// is explicitly declared or is covered by the retained document remainder.
+func (l TypedStorageLayout) OwnerForPath(path string) (TypedStorageFieldOwner, bool) {
+	for _, field := range l.Fields {
+		if field.Path == path {
+			return field.Owner, true
+		}
+	}
+	if l.RetainedDocumentOwnsRemainder {
+		return TypedStorageOwnerRetainedDocument, true
+	}
+	return "", false
+}
+
+// HasTypedColumnPartOwners reports whether the layout contains future
+// typed-column authoritative owners.
+func (l TypedStorageLayout) HasTypedColumnPartOwners() bool {
+	for _, field := range l.Fields {
+		if field.Owner == TypedStorageOwnerColumnPart {
+			return true
+		}
+	}
+	return false
+}
+
+// EnsureReadSupported fails closed for layouts that mention typed_column_part
+// ownership before the production typed-column read path exists.
+func (l TypedStorageLayout) EnsureReadSupported() error {
+	if l.HasTypedColumnPartOwners() {
+		return ErrTypedStorageColumnPartUnsupported
+	}
+	return nil
+}
+
+// EnsurePublicationSupported fails closed for layouts that mention
+// typed_column_part ownership before the production typed-column publication
+// path exists.
+func (l TypedStorageLayout) EnsurePublicationSupported() error {
+	if l.HasTypedColumnPartOwners() {
+		return ErrTypedStorageColumnPartUnsupported
+	}
+	return nil
+}
+
+// FieldOwnerDebugRows returns deterministic status/debug rows for tests and PR
+// evidence without touching DB files or opening assets.
+func (l TypedStorageLayout) FieldOwnerDebugRows() []string {
+	rows := make([]string, 0, len(l.Fields)+1)
+	if l.RetainedDocumentOwnsRemainder {
+		rows = append(rows, "* -> retained_document(remainder)")
+	}
+	for _, field := range l.Fields {
+		rows = append(rows, fmt.Sprintf("%s -> %s", field.Path, field.Owner))
+	}
+	if l.RetainedDocumentCompatibilityDuplicate {
+		rows = append(rows, "document_payload -> compatibility_duplicate")
+	}
+	sort.Strings(rows)
+	return rows
+}

--- a/TreeDB/collections/typed_storage_layout.go
+++ b/TreeDB/collections/typed_storage_layout.go
@@ -313,11 +313,13 @@ func typedStorageLayoutHasTypedAssetOwnedFields(layout *TypedStorageLayout) bool
 		return false
 	}
 	for _, field := range layout.Fields {
-		switch field.Owner {
-		case "", TypedStorageOwnerRowAsset, TypedStorageOwnerColumnPart:
-			return true
-		case TypedStorageOwnerRetainedDocument, "document_payload":
+		owner, err := normalizeTypedStorageFieldOwner(field.Owner)
+		if err != nil {
 			continue
+		}
+		switch owner {
+		case TypedStorageOwnerRowAsset, TypedStorageOwnerColumnPart:
+			return true
 		}
 	}
 	return false

--- a/TreeDB/collections/typed_storage_layout.go
+++ b/TreeDB/collections/typed_storage_layout.go
@@ -298,7 +298,7 @@ func applyRetainedPayloadToTypedStorageLayout(layout *TypedStorageLayout) {
 	switch layout.RetainedPayload {
 	case ColumnRetainedPayloadFull:
 		layout.RetainedDocumentOwnsRemainder = true
-		layout.RetainedDocumentCompatibilityDuplicate = len(layout.Fields) > 0
+		layout.RetainedDocumentCompatibilityDuplicate = typedStorageLayoutHasTypedAssetOwnedFields(layout)
 	case ColumnRetainedPayloadNonColumn:
 		layout.RetainedDocumentOwnsRemainder = true
 		layout.RetainedDocumentCompatibilityDuplicate = false
@@ -306,6 +306,21 @@ func applyRetainedPayloadToTypedStorageLayout(layout *TypedStorageLayout) {
 		layout.RetainedDocumentOwnsRemainder = false
 		layout.RetainedDocumentCompatibilityDuplicate = false
 	}
+}
+
+func typedStorageLayoutHasTypedAssetOwnedFields(layout *TypedStorageLayout) bool {
+	if layout == nil {
+		return false
+	}
+	for _, field := range layout.Fields {
+		switch field.Owner {
+		case "", TypedStorageOwnerRowAsset, TypedStorageOwnerColumnPart:
+			return true
+		case TypedStorageOwnerRetainedDocument, "document_payload":
+			continue
+		}
+	}
+	return false
 }
 
 func normalizeTypedStorageFieldOwner(owner TypedStorageFieldOwner) (TypedStorageFieldOwner, error) {

--- a/TreeDB/collections/typed_storage_layout_test.go
+++ b/TreeDB/collections/typed_storage_layout_test.go
@@ -1,0 +1,247 @@
+package collections
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func testTypedStorageColumnStoreConfig(policy ColumnRetainedPayloadPolicy) *ColumnStoreConfig {
+	return &ColumnStoreConfig{
+		Enabled:         true,
+		RetainedPayload: policy,
+		Columns: []ColumnStoreColumn{
+			{Name: "time_us", Path: "time_us", ValueType: ColumnStoreValueInt64},
+			{Name: "tag", Path: "tag", ValueType: ColumnStoreValueString, Dictionary: true},
+		},
+		AggregateMetadata: []ColumnAggregateMetadata{
+			{Name: "time_count", Column: "time_us", Kind: ColumnAggregateCount},
+		},
+	}
+}
+
+func requireTypedStorageOwner(t *testing.T, layout TypedStorageLayout, path string, want TypedStorageFieldOwner) {
+	t.Helper()
+	got, ok := layout.OwnerForPath(path)
+	if !ok {
+		t.Fatalf("OwnerForPath(%q) missing; layout rows=%v", path, layout.FieldOwnerDebugRows())
+	}
+	if got != want {
+		t.Fatalf("OwnerForPath(%q)=%q want %q; layout rows=%v", path, got, want, layout.FieldOwnerDebugRows())
+	}
+}
+
+func TestTypedStorageLayoutNormalizeDocumentOnly(t *testing.T) {
+	layout, err := ResolveTypedStorageLayout(CollectionMeta{Name: "docs"})
+	if err != nil {
+		t.Fatalf("ResolveTypedStorageLayout: %v", err)
+	}
+	if layout.Enabled {
+		t.Fatalf("document-only layout enabled=%v want false", layout.Enabled)
+	}
+	if len(layout.Fields) != 0 {
+		t.Fatalf("document-only layout fields=%v want none", layout.Fields)
+	}
+	requireTypedStorageOwner(t, layout, "anything", TypedStorageOwnerRetainedDocument)
+	if !layout.RetainedDocumentOwnsRemainder {
+		t.Fatalf("document-only layout should retain document ownership for the remainder")
+	}
+	if layout.RetainedDocumentCompatibilityDuplicate {
+		t.Fatalf("document-only layout should not mark compatibility duplication")
+	}
+	if rows := layout.FieldOwnerDebugRows(); !reflect.DeepEqual(rows, []string{"* -> retained_document(remainder)"}) {
+		t.Fatalf("debug rows=%v", rows)
+	}
+}
+
+func TestTypedStorageLayoutNormalizeExistingColumnStoreConfigUsesTypedRowAsset(t *testing.T) {
+	layout, err := ResolveTypedStorageLayout(CollectionMeta{
+		Name:    "events",
+		Options: CollectionOptions{ColumnStore: testTypedStorageColumnStoreConfig(ColumnRetainedPayloadNonColumn)},
+	})
+	if err != nil {
+		t.Fatalf("ResolveTypedStorageLayout: %v", err)
+	}
+	if !layout.Enabled {
+		t.Fatalf("column-store compatibility layout enabled=false")
+	}
+	requireTypedStorageOwner(t, layout, "time_us", TypedStorageOwnerRowAsset)
+	requireTypedStorageOwner(t, layout, "tag", TypedStorageOwnerRowAsset)
+	requireTypedStorageOwner(t, layout, "payload", TypedStorageOwnerRetainedDocument)
+	if layout.RetainedPayload != ColumnRetainedPayloadNonColumn {
+		t.Fatalf("retained payload=%q want %q", layout.RetainedPayload, ColumnRetainedPayloadNonColumn)
+	}
+	if layout.RetainedDocumentCompatibilityDuplicate {
+		t.Fatalf("non-column retained payload must not mark compatibility duplication")
+	}
+	if err := layout.EnsureReadSupported(); err != nil {
+		t.Fatalf("typed-row layout read support: %v", err)
+	}
+	if err := layout.EnsurePublicationSupported(); err != nil {
+		t.Fatalf("typed-row layout publication support: %v", err)
+	}
+}
+
+func TestTypedStorageLayoutTypedColumnPlaceholderFailsClosed(t *testing.T) {
+	layout, err := NormalizeTypedStorageLayout(TypedStorageLayout{
+		Collection: "events",
+		Fields: []TypedStorageField{{
+			Name:      "score",
+			Path:      "score",
+			Owner:     TypedStorageOwnerColumnPart,
+			ValueType: ColumnStoreValueDouble,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("NormalizeTypedStorageLayout: %v", err)
+	}
+	requireTypedStorageOwner(t, layout, "score", TypedStorageOwnerColumnPart)
+	if !layout.HasTypedColumnPartOwners() {
+		t.Fatalf("typed-column placeholder not detected")
+	}
+	if err := layout.EnsureReadSupported(); !errors.Is(err, ErrTypedStorageColumnPartUnsupported) {
+		t.Fatalf("EnsureReadSupported error=%v want %v", err, ErrTypedStorageColumnPartUnsupported)
+	}
+	if err := layout.EnsurePublicationSupported(); !errors.Is(err, ErrTypedStorageColumnPartUnsupported) {
+		t.Fatalf("EnsurePublicationSupported error=%v want %v", err, ErrTypedStorageColumnPartUnsupported)
+	}
+}
+
+func TestTypedStorageLayoutHybridOwners(t *testing.T) {
+	layout, err := NormalizeTypedStorageLayout(TypedStorageLayout{
+		Collection:      "events",
+		RetainedPayload: ColumnRetainedPayloadNonColumn,
+		Fields: []TypedStorageField{
+			{Name: "profile_name", Path: "profile.name", Owner: TypedStorageOwnerRetainedDocument},
+			{Name: "time_us", Path: "time_us", Owner: TypedStorageOwnerRowAsset, ValueType: ColumnStoreValueInt64},
+			{Name: "embedding", Path: "embedding", Owner: TypedStorageOwnerColumnPart, ValueType: ColumnStoreValueFloat32Vector, VectorDims: 3},
+		},
+	})
+	if err != nil {
+		t.Fatalf("NormalizeTypedStorageLayout: %v", err)
+	}
+	requireTypedStorageOwner(t, layout, "profile.name", TypedStorageOwnerRetainedDocument)
+	requireTypedStorageOwner(t, layout, "time_us", TypedStorageOwnerRowAsset)
+	requireTypedStorageOwner(t, layout, "embedding", TypedStorageOwnerColumnPart)
+	requireTypedStorageOwner(t, layout, "unmodeled", TypedStorageOwnerRetainedDocument)
+	rows := strings.Join(layout.FieldOwnerDebugRows(), "\n")
+	for _, want := range []string{
+		"profile.name -> retained_document",
+		"time_us -> typed_row_asset",
+		"embedding -> typed_column_part",
+		"* -> retained_document(remainder)",
+	} {
+		if !strings.Contains(rows, want) {
+			t.Fatalf("debug rows missing %q in:\n%s", want, rows)
+		}
+	}
+}
+
+func TestTypedStorageLayoutRejectsOverlappingAuthoritativeOwners(t *testing.T) {
+	_, err := NormalizeTypedStorageLayout(TypedStorageLayout{
+		Collection: "events",
+		Fields: []TypedStorageField{
+			{Name: "time_row", Path: "time_us", Owner: TypedStorageOwnerRowAsset, ValueType: ColumnStoreValueInt64},
+			{Name: "time_column", Path: "time_us", Owner: TypedStorageOwnerColumnPart, ValueType: ColumnStoreValueInt64},
+		},
+	})
+	if err == nil {
+		t.Fatalf("expected overlapping owner error")
+	}
+	if !strings.Contains(err.Error(), "overlapping authoritative typed-storage owners") {
+		t.Fatalf("error=%v", err)
+	}
+}
+
+func TestTypedStorageLayoutColumnRetainedPayloadFullCompatibility(t *testing.T) {
+	layout, err := ResolveTypedStorageLayout(CollectionMeta{
+		Name:    "events",
+		Options: CollectionOptions{ColumnStore: testTypedStorageColumnStoreConfig(ColumnRetainedPayloadFull)},
+	})
+	if err != nil {
+		t.Fatalf("ResolveTypedStorageLayout: %v", err)
+	}
+	requireTypedStorageOwner(t, layout, "time_us", TypedStorageOwnerRowAsset)
+	requireTypedStorageOwner(t, layout, "undeclared", TypedStorageOwnerRetainedDocument)
+	if !layout.RetainedDocumentOwnsRemainder {
+		t.Fatalf("ColumnRetainedPayloadFull should keep retained document remainder ownership")
+	}
+	if !layout.RetainedDocumentCompatibilityDuplicate {
+		t.Fatalf("ColumnRetainedPayloadFull should mark compatibility duplication")
+	}
+	for _, row := range layout.FieldOwnerDebugRows() {
+		if row == "time_us -> retained_document" {
+			t.Fatalf("declared field was treated as overlapping retained ownership: %v", layout.FieldOwnerDebugRows())
+		}
+	}
+}
+
+func TestTypedStorageDerivedAcceleratorNotAuthoritative(t *testing.T) {
+	_, err := NormalizeTypedStorageLayout(TypedStorageLayout{
+		Collection: "events",
+		Fields: []TypedStorageField{{
+			Name:  "bad",
+			Path:  "bad",
+			Owner: TypedStorageFieldOwner(TypedStorageAssetClassDerivedAccelerator),
+		}},
+	})
+	if err == nil {
+		t.Fatalf("expected derived-accelerator owner rejection")
+	}
+	if !strings.Contains(err.Error(), "derived_accelerator is not an authoritative field owner") {
+		t.Fatalf("error=%v", err)
+	}
+
+	layout, err := NormalizeTypedStorageLayout(TypedStorageLayout{
+		Collection: "events",
+		Fields: []TypedStorageField{{
+			Name:      "time_us",
+			Path:      "time_us",
+			Owner:     TypedStorageOwnerRowAsset,
+			ValueType: ColumnStoreValueInt64,
+		}},
+		DerivedAccelerators: []TypedStorageDerivedAccelerator{{
+			Name:            "time_us:int64_values",
+			Class:           TypedStorageAssetClassDerivedAccelerator,
+			SourceFieldPath: "time_us",
+			Generation:      7,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("NormalizeTypedStorageLayout with derived accelerator: %v", err)
+	}
+	requireTypedStorageOwner(t, layout, "time_us", TypedStorageOwnerRowAsset)
+	if got := layout.DerivedAccelerators[0].Class; got != TypedStorageAssetClassDerivedAccelerator {
+		t.Fatalf("derived class=%q want %q", got, TypedStorageAssetClassDerivedAccelerator)
+	}
+	if got := layout.DerivedAccelerators[0].SourceOwner; got != TypedStorageOwnerRowAsset {
+		t.Fatalf("derived source owner=%q want %q", got, TypedStorageOwnerRowAsset)
+	}
+}
+
+func TestTypedStorageLayoutResolverIsPureMetadata(t *testing.T) {
+	cfg := &ColumnStoreConfig{
+		Enabled: true,
+		Columns: []ColumnStoreColumn{{
+			Name:      "time_us",
+			Path:      "time_us",
+			ValueType: ColumnStoreValueInt64,
+		}},
+		AssetManager: &ColumnAssetManagerConfig{
+			Kind:      ColumnAssetManagerValueLogShaped,
+			Namespace: "does/not/exist/on/disk",
+		},
+	}
+	layout, err := ResolveTypedStorageLayout(CollectionMeta{
+		Name:    "events",
+		Options: CollectionOptions{ColumnStore: cfg},
+	})
+	if err != nil {
+		t.Fatalf("ResolveTypedStorageLayout should validate metadata only without opening asset namespace: %v", err)
+	}
+	requireTypedStorageOwner(t, layout, "time_us", TypedStorageOwnerRowAsset)
+	if rows := layout.FieldOwnerDebugRows(); len(rows) == 0 {
+		t.Fatalf("expected debug rows from pure metadata resolver")
+	}
+}

--- a/TreeDB/collections/typed_storage_layout_test.go
+++ b/TreeDB/collections/typed_storage_layout_test.go
@@ -175,6 +175,22 @@ func TestTypedStorageLayoutColumnRetainedPayloadFullCompatibility(t *testing.T) 
 			t.Fatalf("declared field was treated as overlapping retained ownership: %v", layout.FieldOwnerDebugRows())
 		}
 	}
+
+	retainedOnly, err := NormalizeTypedStorageLayout(TypedStorageLayout{
+		Collection:      "events",
+		RetainedPayload: ColumnRetainedPayloadFull,
+		Fields: []TypedStorageField{{
+			Name:  "profile_name",
+			Path:  "profile.name",
+			Owner: TypedStorageOwnerRetainedDocument,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("NormalizeTypedStorageLayout retained-only full payload: %v", err)
+	}
+	if retainedOnly.RetainedDocumentCompatibilityDuplicate {
+		t.Fatalf("retained-only full payload should not mark typed-field compatibility duplication")
+	}
 }
 
 func TestTypedStorageDerivedAcceleratorNotAuthoritative(t *testing.T) {
@@ -212,6 +228,9 @@ func TestTypedStorageDerivedAcceleratorNotAuthoritative(t *testing.T) {
 		t.Fatalf("NormalizeTypedStorageLayout with derived accelerator: %v", err)
 	}
 	requireTypedStorageOwner(t, layout, "time_us", TypedStorageOwnerRowAsset)
+	if got := len(layout.DerivedAccelerators); got != 1 {
+		t.Fatalf("derived accelerators=%d want 1; layout=%v", got, layout.FieldOwnerDebugRows())
+	}
 	if got := layout.DerivedAccelerators[0].Class; got != TypedStorageAssetClassDerivedAccelerator {
 		t.Fatalf("derived class=%q want %q", got, TypedStorageAssetClassDerivedAccelerator)
 	}

--- a/TreeDB/docs/spec/typed-storage-naming.md
+++ b/TreeDB/docs/spec/typed-storage-naming.md
@@ -30,6 +30,34 @@ Authoritative field owners are only:
 `derived_accelerator` is a classification only. It is not an authoritative field
 owner and must not silently become a second source of truth for a logical field.
 
+## PR 1 Layout Resolver Contract
+
+Issue #1751 adds the pure-metadata resolver surface that turns collection
+metadata into explicit typed-storage ownership rows. The implementation names are
+canonical for this seam:
+
+- `TypedStorageLayout`
+- `TypedStorageFieldOwner`
+- `TypedStorageOwnerRetainedDocument`
+- `TypedStorageOwnerRowAsset`
+- `TypedStorageOwnerColumnPart`
+- `TypedStorageAssetClass`
+- `TypedStorageAssetClassDerivedAccelerator`
+- `ResolveTypedStorageLayout`
+- `NormalizeTypedStorageLayout`
+
+Compatibility normalization keeps `ColumnStoreConfig` as input metadata. Existing
+declared columns with no explicit typed-storage owner resolve to
+`typed_row_asset`. `ColumnRetainedPayloadFull` is compatibility duplication in
+`document_payload`; it does not make the retained document a second
+authoritative owner for declared typed fields. `typed_column_part` ownership may
+be represented as a placeholder, but reads and publication must fail closed until
+the typed-column format/publication work lands.
+
+The resolver is pure metadata only: it must not perform filesystem IO, mmap,
+section decode, DB mutation, asset open, publication, query planning, or durable
+typed-column format work.
+
 ## Current Derived Accelerator Classifications
 
 These existing assets are derived accelerators unless a future format explicitly


### PR DESCRIPTION
## Parent / dependency status

Parent tracker: #1744.

Closes #1751.

Prerequisite #1750 is complete via merged PR #1759 (`8595ce673a2ccb27a25ce673ebf6419f1bcb7a7b`). #1736 Gate A is available via merged PR #1747; this PR does not acquire resource-manager handles because the resolver is pure metadata only.

## Summary

Adds PR 1's typed-storage ownership resolver and compatibility normalization:

- `ResolveTypedStorageLayout(CollectionMeta)` maps current collection metadata to explicit typed-storage ownership rows.
- `NormalizeTypedStorageLayout(TypedStorageLayout)` normalizes/validates explicit pure-metadata layouts, including future `typed_column_part` placeholders.
- Existing `ColumnStoreConfig` remains the compatibility input; declared columns resolve to `typed_row_asset` ownership.
- Retained payload policy is represented in the resolved layout:
  - `ColumnRetainedPayloadNonColumn`: retained document owns the remainder.
  - `ColumnRetainedPayloadFull`: document payload is a compatibility duplicate for declared typed fields, not a second authoritative owner.
  - `ColumnRetainedPayloadNone`: no retained-document remainder owner.
- `typed_column_part` placeholders can be represented but `EnsureReadSupported` and `EnsurePublicationSupported` fail closed with `ErrTypedStorageColumnPartUnsupported` until later #1753/#1755 support exists.
- Derived accelerators are owner/generation-associated metadata, not authoritative field owners.

## Naming impact

Implemented the requested names directly; no alternate-name mapping is needed:

- `TypedStorageLayout`
- `TypedStorageFieldOwner`
- `TypedStorageOwnerRetainedDocument`
- `TypedStorageOwnerRowAsset`
- `TypedStorageOwnerColumnPart`
- `TypedStorageAssetClass`
- `TypedStorageAssetClassDerivedAccelerator`
- `ResolveTypedStorageLayout`
- `NormalizeTypedStorageLayout`

Compatibility-retained names:

- `ColumnStoreConfig` remains public compatibility metadata.
- `ColumnStoreColumn` values become `typed_row_asset` owners in the resolved layout.
- No `ColumnStore*` removal or public API break.

## Scope boundary and non-goals

The resolver is pure metadata only. This PR does not perform filesystem IO, mmap, section decode, DB mutation, asset open, publication, query planner changes, durable typed-column format work, or colgranule transplant work.

Non-goals held:

- no durable typed-column part format;
- no authoritative typed-column publication;
- no broad mechanical rename cleanup;
- no query planner rewrite;
- no `ColumnStoreConfig` removal.

## Test mapping

Required #1751 test item -> actual test:

- `TestTypedStorageLayoutNormalizeDocumentOnly` -> same name.
- `TestTypedStorageLayoutNormalizeExistingColumnStoreConfigUsesTypedRowAsset` -> same name.
- `TestTypedStorageLayoutTypedColumnPlaceholderFailsClosed` -> same name.
- `TestTypedStorageLayoutHybridOwners` -> same name.
- `TestTypedStorageLayoutRejectsOverlappingAuthoritativeOwners` -> same name.
- `TestTypedStorageLayoutColumnRetainedPayloadFullCompatibility` -> same name.
- `TestTypedStorageDerivedAcceleratorNotAuthoritative` -> same name.
- `TestTypedStorageLayoutResolverIsPureMetadata` -> same name.

## Test evidence

```sh
go test -count=1 ./TreeDB/collections -run TestTypedStorage
go test -count=1 ./TreeDB/collections
```

Both pass locally on head `f30d9f303`.

## Benchmark / performance evidence

No benchmark run. This PR adds a pure metadata resolver and tests/docs only; it is not on a runtime hot path and does not change query, publication, IO, mmap, or codec paths.

## AI review / CI status

- Codex: requested after latest fixes; no major issues reported.
- Copilot: requested twice; reviewer errored/unavailable and did not provide findings.
- CodeRabbit: actionable findings fixed in follow-up commits; latest incremental review has no actionable findings / skipped.
- Review threads: 0 unresolved.
- Latest-head CI: passing on head `f30d9f303cae210dfda6693cc83c62946b9f9e8f`.
