### PR TITLE
bench: allow dataset exact vector validation

### DIFF
--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -287,7 +287,7 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 			}
 			continue
 		}
-		if len(scratch.top) >= efSearch && columnVectorGraphSearchCandidateWorse(candidate, scratch.top[len(scratch.top)-1]) {
+		if len(scratch.top) >= efSearch && candidate.score < scratch.top[len(scratch.top)-1].score {
 			break
 		}
 		adjacency, err := r.expandCandidateAdjacencyLayer(plan, singleBlockView, candidate.ordinal, 0, scratch, &stats)
@@ -440,8 +440,18 @@ func (r *columnVectorGraphPhysicalRowReader) scoreAndPushFrontierVisited(plan *c
 		ordinal: ordinal,
 		score:   score,
 	}
-	if len(scratch.top) < candidateLimit || columnVectorGraphSearchCandidateBetter(candidate, scratch.top[len(scratch.top)-1]) {
+	if len(scratch.top) < candidateLimit {
 		scratch.insertTop(candidateLimit, candidate)
+		scratch.pushFrontier(candidate)
+		return nil
+	}
+	worstRetained := scratch.top[len(scratch.top)-1]
+	if columnVectorGraphSearchCandidateBetter(candidate, worstRetained) {
+		scratch.insertTop(candidateLimit, candidate)
+		scratch.pushFrontier(candidate)
+		return nil
+	}
+	if candidate.score >= worstRetained.score {
 		scratch.pushFrontier(candidate)
 	}
 	return nil
@@ -611,10 +621,6 @@ func columnVectorGraphSearchCandidateBetter(left, right columnVectorGraphSearchC
 		return left.ordinal < right.ordinal
 	}
 	return left.score > right.score
-}
-
-func columnVectorGraphSearchCandidateWorse(left, right columnVectorGraphSearchCandidate) bool {
-	return columnVectorGraphSearchCandidateBetter(right, left)
 }
 
 func columnVectorGraphNativeCosineScore(query []float32, queryInvNorm float32, row columnVectorGraphPhysicalRow) (float64, error) {

--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -102,7 +102,7 @@ func (s *columnVectorGraphNativeSearchScratch) prepare(rowCount, dimensions, deg
 		frontierCap = topK
 	}
 	s.frontier = resizeColumnVectorGraphNativeCandidateScratch(s.frontier, frontierCap)
-	s.top = resizeColumnVectorGraphNativeCandidateScratch(s.top, topK)
+	s.top = resizeColumnVectorGraphNativeCandidateScratch(s.top, frontierCap)
 	s.results = resizeColumnVectorGraphNativeResultScratch(s.results, topK)
 	s.idBuffers = resizeColumnVectorGraphNativeIDBuffersScratch(s.idBuffers, topK)
 	s.resultOrder = resizeColumnVectorGraphNativeIntScratch(s.resultOrder, topK)
@@ -265,13 +265,16 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 	visitMarks := scratch.visitMarks
 	visitEpoch := scratch.visitEpoch
 	visitMarks[entryOrdinal] = visitEpoch
-	if err := r.scoreAndPushFrontierVisited(plan, singleBlockView, query, queryInvNorm, entryOrdinal, topK, scratch, &stats); err != nil {
+	if err := r.scoreAndPushFrontierVisited(plan, singleBlockView, query, queryInvNorm, entryOrdinal, efSearch, scratch, &stats); err != nil {
 		return nil, stats, err
 	}
 	nextSeed := 0
-	for stats.Candidates < uint64(efSearch) {
+	for {
 		candidate, ok := scratch.popFrontier()
 		if !ok {
+			if len(scratch.top) >= efSearch {
+				break
+			}
 			for nextSeed < rowCount && scratch.visitMarks[nextSeed] == scratch.visitEpoch {
 				nextSeed++
 			}
@@ -279,19 +282,19 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 				break
 			}
 			visitMarks[nextSeed] = visitEpoch
-			if err := r.scoreAndPushFrontierVisited(plan, singleBlockView, query, queryInvNorm, nextSeed, topK, scratch, &stats); err != nil {
+			if err := r.scoreAndPushFrontierVisited(plan, singleBlockView, query, queryInvNorm, nextSeed, efSearch, scratch, &stats); err != nil {
 				return nil, stats, err
 			}
 			continue
+		}
+		if len(scratch.top) >= efSearch && columnVectorGraphSearchCandidateWorse(candidate, scratch.top[len(scratch.top)-1]) {
+			break
 		}
 		adjacency, err := r.expandCandidateAdjacencyLayer(plan, singleBlockView, candidate.ordinal, 0, scratch, &stats)
 		if err != nil {
 			return nil, stats, err
 		}
 		for i, neighbor := range adjacency {
-			if stats.Candidates >= uint64(efSearch) {
-				break
-			}
 			stats.Edges++
 			if uint64(neighbor) >= uint64(rowCount) {
 				return nil, stats, fmt.Errorf("collections: column_graph %q ordinal=%d adjacency[%d]=%d outside row_count=%d: %w", r.def.Name, candidate.ordinal, i, neighbor, rowCount, errColumnVectorGraphAdjacencyOrdinalOutOfBounds)
@@ -301,7 +304,7 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 				continue
 			}
 			visitMarks[neighborOrdinal] = visitEpoch
-			if err := r.scoreAndPushFrontierVisited(plan, singleBlockView, query, queryInvNorm, neighborOrdinal, topK, scratch, &stats); err != nil {
+			if err := r.scoreAndPushFrontierVisited(plan, singleBlockView, query, queryInvNorm, neighborOrdinal, efSearch, scratch, &stats); err != nil {
 				return nil, stats, err
 			}
 		}
@@ -310,7 +313,7 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 	if len(scratch.top) == 0 {
 		return scratch.results, stats, nil
 	}
-	if err := r.fetchTopSearchResults(plan, singleBlockView, scratch, &stats); err != nil {
+	if err := r.fetchTopSearchResults(plan, singleBlockView, scratch, topK, &stats); err != nil {
 		return nil, stats, err
 	}
 	return scratch.results, stats, nil
@@ -356,8 +359,11 @@ func (r *columnVectorGraphPhysicalRowReader) greedyNearestAtLayer(plan *columnVe
 	return best, nil
 }
 
-func (r *columnVectorGraphPhysicalRowReader) fetchTopSearchResults(plan *columnVectorGraphSearchPlan, singleBlockView *columnVectorGraphBlockView, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) error {
+func (r *columnVectorGraphPhysicalRowReader) fetchTopSearchResults(plan *columnVectorGraphSearchPlan, singleBlockView *columnVectorGraphBlockView, scratch *columnVectorGraphNativeSearchScratch, topK int, stats *columnVectorGraphNativeSearchStats) error {
 	n := len(scratch.top)
+	if n > topK {
+		n = topK
+	}
 	scratch.resultOrder = scratch.resultOrder[:n]
 	scratch.resultOrdinals = scratch.resultOrdinals[:n]
 	for i := 0; i < n; i++ {
@@ -395,7 +401,7 @@ func (r *columnVectorGraphPhysicalRowReader) fetchTopSearchResults(plan *columnV
 	stats.BlockViewHits = plan.hits
 	stats.BlockViewMisses = plan.misses
 	stats.BlockViewBuilds = plan.builds
-	for i, candidate := range scratch.top {
+	for i, candidate := range scratch.top[:n] {
 		scratch.results = append(scratch.results, columnVectorGraphNativeSearchResult{
 			Ordinal: candidate.ordinal,
 			ID:      scratch.idBuffers[i],
@@ -424,7 +430,7 @@ func sortColumnVectorGraphResultOrderByOrdinal(order []int, top []columnVectorGr
 	})
 }
 
-func (r *columnVectorGraphPhysicalRowReader) scoreAndPushFrontierVisited(plan *columnVectorGraphSearchPlan, singleBlockView *columnVectorGraphBlockView, query []float32, queryInvNorm float32, ordinal, topK int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) error {
+func (r *columnVectorGraphPhysicalRowReader) scoreAndPushFrontierVisited(plan *columnVectorGraphSearchPlan, singleBlockView *columnVectorGraphBlockView, query []float32, queryInvNorm float32, ordinal, candidateLimit int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) error {
 	score, err := r.scoreOrdinal(plan, singleBlockView, query, queryInvNorm, ordinal, scratch, stats)
 	if err != nil {
 		return err
@@ -434,8 +440,10 @@ func (r *columnVectorGraphPhysicalRowReader) scoreAndPushFrontierVisited(plan *c
 		ordinal: ordinal,
 		score:   score,
 	}
-	scratch.insertTop(topK, candidate)
-	scratch.pushFrontier(candidate)
+	if len(scratch.top) < candidateLimit || columnVectorGraphSearchCandidateBetter(candidate, scratch.top[len(scratch.top)-1]) {
+		scratch.insertTop(candidateLimit, candidate)
+		scratch.pushFrontier(candidate)
+	}
 	return nil
 }
 
@@ -603,6 +611,10 @@ func columnVectorGraphSearchCandidateBetter(left, right columnVectorGraphSearchC
 		return left.ordinal < right.ordinal
 	}
 	return left.score > right.score
+}
+
+func columnVectorGraphSearchCandidateWorse(left, right columnVectorGraphSearchCandidate) bool {
+	return columnVectorGraphSearchCandidateBetter(right, left)
 }
 
 func columnVectorGraphNativeCosineScore(query []float32, queryInvNorm float32, row columnVectorGraphPhysicalRow) (float64, error) {

--- a/TreeDB/collections/column_vector_graph_search_test.go
+++ b/TreeDB/collections/column_vector_graph_search_test.go
@@ -147,6 +147,31 @@ func TestColumnVectorGraphNativeSearchDoesNotStopBeforePromisingFrontierV6(t *te
 	}
 }
 
+func TestColumnVectorGraphNativeSearchExpandsEqualScoreFrontierV6(t *testing.T) {
+	rows := []columnVectorGraphAssetRow{
+		{ID: []byte("doc-start"), Vector: []float32{0, 1, 0}, InvNorm: 1, Adjacency: []uint32{1, 2}},
+		{ID: []byte("doc-tie-low-ordinal"), Vector: []float32{0, 1, 0}, InvNorm: 1},
+		{ID: []byte("doc-tie-bridge"), Vector: []float32{0, 1, 0}, InvNorm: 1, Adjacency: []uint32{3}},
+		{ID: []byte("doc-best"), Vector: []float32{1, 0, 0}, InvNorm: 1},
+	}
+	d, col, def := publishColumnVectorGraphPhysicalReaderTestAssetV2B(t, rows)
+	defer func() { _ = d.Close() }()
+	reader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("openColumnVectorGraphPhysicalRowReader: %v", err)
+	}
+	defer reader.Close()
+
+	var scratch columnVectorGraphNativeSearchScratch
+	got, stats, err := reader.SearchCosine([]float32{1, 0, 0}, columnVectorGraphNativeSearchOptions{TopK: 1, EfSearch: 2}, &scratch)
+	if err != nil {
+		t.Fatalf("SearchCosine: %v", err)
+	}
+	if len(got) != 1 || got[0].Ordinal != 3 || string(got[0].ID) != "doc-best" {
+		t.Fatalf("results=%+v stats=%+v want equal-score frontier expansion to reach doc-best", got, stats)
+	}
+}
+
 func TestColumnVectorGraphNativeSearchKeepsExpansionAdjacencyStableV3(t *testing.T) {
 	rows := []columnVectorGraphAssetRow{
 		{ID: []byte("doc-start"), Vector: []float32{0, 1, 0}, InvNorm: 1, Adjacency: []uint32{1, 2}},

--- a/TreeDB/collections/column_vector_graph_search_test.go
+++ b/TreeDB/collections/column_vector_graph_search_test.go
@@ -113,11 +113,37 @@ func TestColumnVectorGraphNativeSearchUsesBestFirstFrontierV3(t *testing.T) {
 	if len(got) != 1 || got[0].Ordinal != 4 || string(got[0].ID) != "doc-best" {
 		t.Fatalf("results=%+v want best-first traversal to reach doc-best before lower-score branch", got)
 	}
-	if stats.Candidates != 4 || stats.CandidateFetches != 4 || stats.ScoreBatches != 4 || stats.ExpansionFetches != stats.AdjacencyExpansions {
-		t.Fatalf("stats=%+v want four scored candidates plus lazy adjacency expansion fetches", stats)
+	if stats.Candidates < 4 || stats.Candidates > uint64(len(rows)) || stats.CandidateFetches != stats.Candidates || stats.ScoreBatches != stats.Candidates || stats.ExpansionFetches != stats.AdjacencyExpansions {
+		t.Fatalf("stats=%+v want bounded best-first scored candidates plus lazy adjacency expansion fetches", stats)
 	}
 	if readerStats := reader.Stats(); readerStats.RowFetches != 0 || readerStats.BatchFetches != 0 || readerStats.RowsFetched != 0 {
 		t.Fatalf("reader stats=%+v want no generic row fetches for scoring or result IDs stats=%+v", readerStats, stats)
+	}
+}
+
+func TestColumnVectorGraphNativeSearchDoesNotStopBeforePromisingFrontierV6(t *testing.T) {
+	rows := []columnVectorGraphAssetRow{
+		{ID: []byte("doc-start"), Vector: []float32{0, 1, 0}, InvNorm: 1, Adjacency: []uint32{1, 2, 3}},
+		{ID: []byte("doc-low-a"), Vector: []float32{-1, 0, 0}, InvNorm: 1},
+		{ID: []byte("doc-low-b"), Vector: []float32{-0.8, 0.6, 0}, InvNorm: 1},
+		{ID: []byte("doc-bridge"), Vector: []float32{0.5, 0.8660254, 0}, InvNorm: 1, Adjacency: []uint32{4}},
+		{ID: []byte("doc-best"), Vector: []float32{1, 0, 0}, InvNorm: 1},
+	}
+	d, col, def := publishColumnVectorGraphPhysicalReaderTestAssetV2B(t, rows)
+	defer func() { _ = d.Close() }()
+	reader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("openColumnVectorGraphPhysicalRowReader: %v", err)
+	}
+	defer reader.Close()
+
+	var scratch columnVectorGraphNativeSearchScratch
+	got, stats, err := reader.SearchCosine([]float32{1, 0, 0}, columnVectorGraphNativeSearchOptions{TopK: 1, EfSearch: 3}, &scratch)
+	if err != nil {
+		t.Fatalf("SearchCosine: %v", err)
+	}
+	if len(got) != 1 || got[0].Ordinal != 4 || string(got[0].ID) != "doc-best" {
+		t.Fatalf("results=%+v stats=%+v want bounded HNSW frontier to continue through bridge to doc-best", got, stats)
 	}
 }
 

--- a/TreeDB/collections/vector_index.go
+++ b/TreeDB/collections/vector_index.go
@@ -168,6 +168,9 @@ type VectorIndexSearchOptions struct {
 	IndexRangeFilter     *VectorIndexRangeFilter
 	ExactFilterMaxDocs   int
 	DisableExactFallback bool
+	// SkipDocumentFetch leaves native runtime vector search results with IDs and distances only.
+	// Historical native runtime search behavior fetches result documents by default.
+	SkipDocumentFetch bool
 	// IncludeDocuments materializes full documents after column_graph top-k selection.
 	IncludeDocuments bool
 	// MaxDecodedBlocks bounds the physical column row reader cache for column_graph search.
@@ -1501,7 +1504,11 @@ func (idx *VectorIndex) Search(query []float32, opts VectorIndexSearchOptions) (
 	idx.mu.RUnlock()
 
 	if fastRerank && err == nil {
-		results, err = idx.attachVectorSearchResultDocuments(results, resultNodeIDs, opts.TopK)
+		if opts.SkipDocumentFetch {
+			cloneVectorSearchResultDocumentIDs(results)
+		} else {
+			results, err = idx.attachVectorSearchResultDocuments(results, resultNodeIDs, opts.TopK)
+		}
 	} else if !fastRerank {
 		results, err = idx.rerankCandidates(query, candidateIDs, filter, opts.TopK, &trace)
 	}

--- a/TreeDB/collections/vector_index_test.go
+++ b/TreeDB/collections/vector_index_test.go
@@ -96,6 +96,14 @@ func TestCollectionVectorIndexSearchDocumentsAreOwned(t *testing.T) {
 			if !bytes.Equal(results[0].Document, docA) || !bytes.Equal(results[1].Document, docB) {
 				t.Fatalf("unexpected documents: %q %q", results[0].Document, results[1].Document)
 			}
+			idOnly, _, err := index.Search([]float32{1, 0}, VectorIndexSearchOptions{TopK: 2, DisableExactFallback: true, SkipDocumentFetch: true})
+			if err != nil {
+				t.Fatalf("id-only search vector index: %v", err)
+			}
+			requireVectorResultIDs(t, idOnly, "a", "b")
+			if len(idOnly[0].Document) != 0 || len(idOnly[1].Document) != 0 {
+				t.Fatalf("id-only documents: %q %q, want empty", idOnly[0].Document, idOnly[1].Document)
+			}
 			for i, result := range results {
 				if cap(result.DocumentID) != len(result.DocumentID) {
 					t.Fatalf("result %d document id cap=%d len=%d, want exact cap", i, cap(result.DocumentID), len(result.DocumentID))

--- a/cmd/treedb_vector_search_demo/README.md
+++ b/cmd/treedb_vector_search_demo/README.md
@@ -94,6 +94,8 @@ Useful flags:
   run.
 - `-disable-exact-fallback=false`: allow exact fallback during benchmark
   searches.
+- `-native-search-documents=false`: for native runtime vector indexes, report
+  pure ANN ID/distance search without fetching/materializing result documents.
 - `-validate-queries N` and `-min-recall R`: run recall validation for `N`
   queries; set `-min-recall=0` when disabling validation with
   `-validate-queries=0`.

--- a/cmd/treedb_vector_search_demo/README.md
+++ b/cmd/treedb_vector_search_demo/README.md
@@ -97,4 +97,8 @@ Useful flags:
 - `-validate-queries N` and `-min-recall R`: run recall validation for `N`
   queries; set `-min-recall=0` when disabling validation with
   `-validate-queries=0`.
+- `-validation-exact-source=dataset`: in `-dataset-dir` mode, compute the exact
+  recall baseline from exported `documents.f32` instead of TreeDB document
+  materialization. `validate-docs` still samples TreeDB document reads
+  separately.
 - `-json`: emit the full result object for scripts.

--- a/cmd/treedb_vector_search_demo/main.go
+++ b/cmd/treedb_vector_search_demo/main.go
@@ -45,6 +45,7 @@ const (
 type config struct {
 	dir                   string
 	datasetDir            string
+	validationExactSource string
 	keepDir               bool
 	matrix                bool
 	profile               treedb.Profile
@@ -89,6 +90,7 @@ type result struct {
 	SearchConcurrency     []int                             `json:"search_concurrency"`
 	ValidateQueries       int                               `json:"validate_queries"`
 	ValidateDocs          int                               `json:"validate_docs"`
+	ValidationExactSource string                            `json:"validation_exact_source"`
 	TopK                  int                               `json:"top_k"`
 	M                     int                               `json:"m"`
 	EfConstruction        int                               `json:"ef_construction"`
@@ -145,6 +147,7 @@ type phaseResult struct {
 }
 
 type validationResult struct {
+	ExactSource      string  `json:"exact_source"`
 	DocumentsChecked int     `json:"documents_checked"`
 	QueriesChecked   int     `json:"queries_checked"`
 	ExactTotal       int     `json:"exact_total"`
@@ -268,6 +271,7 @@ func parseConfig(args []string) (config, error) {
 		queries:               defaultQueries,
 		validateQueries:       32,
 		validateDocs:          16,
+		validationExactSource: "treedb",
 		topK:                  defaultTopK,
 		batchSize:             defaultBatchSize,
 		m:                     defaultM,
@@ -290,6 +294,7 @@ func parseConfig(args []string) (config, error) {
 	fs.SetOutput(io.Discard)
 	fs.StringVar(&cfg.dir, "dir", "", "TreeDB directory to create; empty uses a temporary directory; explicit directories are kept")
 	fs.StringVar(&cfg.datasetDir, "dataset-dir", "", "Optional exported vector dataset directory to load documents and queries from")
+	fs.StringVar(&cfg.validationExactSource, "validation-exact-source", cfg.validationExactSource, "Exact recall baseline source: treedb or dataset (dataset requires -dataset-dir and avoids TreeDB document materialization)")
 	fs.BoolVar(&cfg.keepDir, "keep-dir", false, "Keep the DB directory after the run")
 	fs.BoolVar(&cfg.matrix, "matrix", cfg.matrix, "Run the storage/search benchmark matrix instead of a single storage case")
 	fs.StringVar(&profileRaw, "profile", profileRaw, "TreeDB profile: durable, fast, wal_on_fast, or bench")
@@ -378,6 +383,9 @@ func parseConfig(args []string) (config, error) {
 	if cfg.datasetDir != "" {
 		cfg.datasetDir = filepath.Clean(cfg.datasetDir)
 	}
+	if err := normalizeValidationExactSource(&cfg); err != nil {
+		return config{}, err
+	}
 	if cfg.datasetDir == "" && cfg.validateQueries > cfg.docs {
 		return config{}, errors.New("-validate-queries cannot exceed -docs")
 	}
@@ -445,7 +453,24 @@ func parseSearchConcurrency(raw string) ([]int, error) {
 	return out, nil
 }
 
+func normalizeValidationExactSource(cfg *config) error {
+	switch cfg.validationExactSource {
+	case "", "treedb":
+		cfg.validationExactSource = "treedb"
+	case "dataset":
+		if cfg.datasetDir == "" {
+			return errors.New("-validation-exact-source=dataset requires -dataset-dir")
+		}
+	default:
+		return fmt.Errorf("unsupported -validation-exact-source %q (want treedb or dataset)", cfg.validationExactSource)
+	}
+	return nil
+}
+
 func applySearchBenchmarkDefaults(cfg *config) error {
+	if err := normalizeValidationExactSource(cfg); err != nil {
+		return err
+	}
 	if len(cfg.searchConcurrency) == 0 {
 		concurrency, err := parseSearchConcurrency(defaultSearchConcurrency)
 		if err != nil {
@@ -663,6 +688,7 @@ func execute(ctx context.Context, cfg config) (result, error) {
 		SearchConcurrency:     append([]int(nil), cfg.searchConcurrency...),
 		ValidateQueries:       cfg.validateQueries,
 		ValidateDocs:          cfg.validateDocs,
+		ValidationExactSource: cfg.validationExactSource,
 		TopK:                  cfg.topK,
 		M:                     cfg.m,
 		EfConstruction:        cfg.efConstruction,
@@ -1245,6 +1271,7 @@ func validateCompactedData(col *collections.Collection, idx *collections.VectorI
 		out.Seconds = elapsed.Seconds
 	}()
 	out = validationResult{
+		ExactSource:      cfg.validationExactSource,
 		DocumentsChecked: cfg.validateDocs,
 		QueriesChecked:   cfg.validateQueries,
 		MinRecall:        cfg.minRecall,
@@ -1271,6 +1298,9 @@ func validateCompactedData(col *collections.Collection, idx *collections.VectorI
 	queries, err := loadQueries(cfg.validateQueries, cfg, work, 0)
 	if err != nil {
 		return out, err
+	}
+	if cfg.validationExactSource == "dataset" {
+		return validateNativeRuntimeWithDatasetExact(idx, cfg, work, queries, out)
 	}
 	// Recall validation disables exact fallback on the ANN side so it measures
 	// the graph result against the exact baseline computed inside CheckRecall.
@@ -1300,6 +1330,7 @@ func validateCompactedColumnGraphData(col *collections.Collection, indexName str
 		out.Seconds = elapsed.Seconds
 	}()
 	out = validationResult{
+		ExactSource:      cfg.validationExactSource,
 		DocumentsChecked: cfg.validateDocs,
 		QueriesChecked:   cfg.validateQueries,
 		MinRecall:        cfg.minRecall,
@@ -1334,6 +1365,9 @@ func validateCompactedColumnGraphData(col *collections.Collection, indexName str
 			err = closeErr
 		}
 	}()
+	if cfg.validationExactSource == "dataset" {
+		return validateColumnGraphWithDatasetExact(searcher, cfg, work, queries, out)
+	}
 	for _, query := range queries {
 		exact, err := col.SearchVectorsExact(query, collections.VectorSearchOptions{
 			Field:  "embedding",
@@ -1373,6 +1407,205 @@ func validateCompactedColumnGraphData(col *collections.Collection, indexName str
 		return out, fmt.Errorf("recall %.4f below minimum %.4f", out.Recall, cfg.minRecall)
 	}
 	return out, nil
+}
+
+func validateNativeRuntimeWithDatasetExact(idx *collections.VectorIndex, cfg config, work workload, queries [][]float32, out validationResult) (validationResult, error) {
+	docs, invNorms, ids, err := loadDatasetDocumentVectorsWithInvNorms(cfg, work)
+	if err != nil {
+		return out, err
+	}
+	for _, query := range queries {
+		exactIDs, err := datasetExactTopKIDs(query, docs, invNorms, ids, cfg.topK)
+		if err != nil {
+			return out, err
+		}
+		results, _, err := idx.Search(query, collections.VectorIndexSearchOptions{TopK: cfg.topK, EfSearch: cfg.efSearch, DisableExactFallback: true})
+		if err != nil {
+			return out, err
+		}
+		exactSet := stringSet(exactIDs)
+		out.ExactTotal += len(exactIDs)
+		out.ANNTotal += len(results)
+		for _, result := range results {
+			if _, ok := exactSet[string(result.DocumentID)]; ok {
+				out.Overlap++
+			}
+		}
+	}
+	return finishValidationRecall(out, cfg.minRecall)
+}
+
+func validateColumnGraphWithDatasetExact(searcher *collections.VectorIndexSearcher, cfg config, work workload, queries [][]float32, out validationResult) (validationResult, error) {
+	docs, invNorms, ids, err := loadDatasetDocumentVectorsWithInvNorms(cfg, work)
+	if err != nil {
+		return out, err
+	}
+	for _, query := range queries {
+		exactIDs, err := datasetExactTopKIDs(query, docs, invNorms, ids, cfg.topK)
+		if err != nil {
+			return out, err
+		}
+		response, err := searcher.Search(collections.VectorIndexSearcherSearchOptions{Query: query, TopK: cfg.topK, EfSearch: cfg.efSearch})
+		if err != nil {
+			return out, err
+		}
+		if response.Path != collections.VectorIndexSearchPathColumnGraphNativeReader {
+			return out, fmt.Errorf("unexpected column_graph validation path %q", response.Path)
+		}
+		exactSet := stringSet(exactIDs)
+		out.ExactTotal += len(exactIDs)
+		out.ANNTotal += len(response.Results)
+		for _, result := range response.Results {
+			if _, ok := exactSet[string(result.ID)]; ok {
+				out.Overlap++
+			}
+		}
+	}
+	return finishValidationRecall(out, cfg.minRecall)
+}
+
+func finishValidationRecall(out validationResult, minRecall float64) (validationResult, error) {
+	if out.ExactTotal > 0 {
+		out.Recall = float64(out.Overlap) / float64(out.ExactTotal)
+	}
+	if out.Recall < minRecall {
+		return out, fmt.Errorf("recall %.4f below minimum %.4f", out.Recall, minRecall)
+	}
+	return out, nil
+}
+
+func stringSet(ids [][]byte) map[string]struct{} {
+	out := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		out[string(id)] = struct{}{}
+	}
+	return out
+}
+
+func loadDatasetDocumentVectorsWithInvNorms(cfg config, work workload) ([][]float32, []float32, [][]byte, error) {
+	if work.datasetDir == "" {
+		return nil, nil, nil, errors.New("dataset exact validation requires -dataset-dir")
+	}
+	docs, err := readFloat32Vectors(datasetPath(work, work.manifest.DocumentVectorsFile, "documents.f32"), cfg.docs, cfg.dimensions)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	ids, err := loadDatasetDocumentIDs(cfg, work)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	invNorms := make([]float32, len(docs))
+	for i, doc := range docs {
+		invNorm, err := vectorInvNorm(doc)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("dataset document vector %d norm: %w", i, err)
+		}
+		invNorms[i] = invNorm
+	}
+	return docs, invNorms, ids, nil
+}
+
+func loadDatasetDocumentIDs(cfg config, work workload) ([][]byte, error) {
+	f, err := os.Open(datasetPath(work, work.manifest.DocumentsJSONLFile, "documents.jsonl"))
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 64*1024*1024)
+	ids := make([][]byte, 0, cfg.docs)
+	for i := 0; scanner.Scan(); i++ {
+		if i >= cfg.docs {
+			return nil, fmt.Errorf("dataset documents file has more than %d rows", cfg.docs)
+		}
+		var header datasetDocumentHeader
+		if err := json.Unmarshal(scanner.Bytes(), &header); err != nil {
+			return nil, fmt.Errorf("decode dataset document %d: %w", i, err)
+		}
+		if header.Index != i {
+			return nil, fmt.Errorf("dataset document index=%d at row %d", header.Index, i)
+		}
+		if header.ID == "" {
+			return nil, fmt.Errorf("dataset document %d has empty id", i)
+		}
+		ids = append(ids, []byte(header.ID))
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	if len(ids) != cfg.docs {
+		return nil, fmt.Errorf("dataset documents rows=%d, want %d", len(ids), cfg.docs)
+	}
+	return ids, nil
+}
+
+func vectorInvNorm(v []float32) (float32, error) {
+	var norm float64
+	for _, value := range v {
+		if math.IsNaN(float64(value)) || math.IsInf(float64(value), 0) {
+			return 0, errors.New("vector contains non-finite value")
+		}
+		norm += float64(value) * float64(value)
+	}
+	if norm == 0 || math.IsNaN(norm) || math.IsInf(norm, 0) {
+		return 0, errors.New("vector has invalid norm")
+	}
+	return float32(1 / math.Sqrt(norm)), nil
+}
+
+type datasetExactCandidate struct {
+	index int
+	score float64
+}
+
+func datasetExactTopKIDs(query []float32, docs [][]float32, invNorms []float32, ids [][]byte, topK int) ([][]byte, error) {
+	if topK <= 0 {
+		return nil, errors.New("dataset exact topK must be positive")
+	}
+	queryInvNorm, err := vectorInvNorm(query)
+	if err != nil {
+		return nil, fmt.Errorf("query norm: %w", err)
+	}
+	limit := topK
+	if limit > len(docs) {
+		limit = len(docs)
+	}
+	top := make([]datasetExactCandidate, 0, limit)
+	for i, doc := range docs {
+		if len(doc) != len(query) {
+			return nil, fmt.Errorf("dataset document vector %d dims=%d want %d", i, len(doc), len(query))
+		}
+		var dot float64
+		for j, value := range query {
+			dot += float64(value) * float64(doc[j])
+		}
+		score := dot * float64(queryInvNorm) * float64(invNorms[i])
+		candidate := datasetExactCandidate{index: i, score: score}
+		pos := len(top)
+		for pos > 0 && datasetExactCandidateBetter(candidate, top[pos-1]) {
+			pos--
+		}
+		if pos >= limit {
+			continue
+		}
+		if len(top) < limit {
+			top = append(top, datasetExactCandidate{})
+		}
+		copy(top[pos+1:], top[pos:len(top)-1])
+		top[pos] = candidate
+	}
+	out := make([][]byte, len(top))
+	for i, candidate := range top {
+		out[i] = bytes.Clone(ids[candidate.index])
+	}
+	return out, nil
+}
+
+func datasetExactCandidateBetter(left, right datasetExactCandidate) bool {
+	if left.score == right.score {
+		return left.index < right.index
+	}
+	return left.score > right.score
 }
 
 func jsonDocumentsEqual(a, b []byte) bool {
@@ -2033,8 +2266,8 @@ func printText(w io.Writer, res result) {
 	}
 	fmt.Fprintf(w, "reopen_and_load_vector_index path=%s: %.3fs\n", resultSearchPath(res), res.ReopenLoad.Seconds)
 	fmt.Fprintf(w, "\nValidation\n")
-	fmt.Fprintf(w, "documents_checked=%d queries_checked=%d recall_at_%d=%.4f overlap=%d/%d\n",
-		res.Validation.DocumentsChecked, res.Validation.QueriesChecked, res.TopK, res.Validation.Recall, res.Validation.Overlap, res.Validation.ExactTotal)
+	fmt.Fprintf(w, "exact_source=%s documents_checked=%d queries_checked=%d recall_at_%d=%.4f overlap=%d/%d\n",
+		res.Validation.ExactSource, res.Validation.DocumentsChecked, res.Validation.QueriesChecked, res.TopK, res.Validation.Recall, res.Validation.Overlap, res.Validation.ExactTotal)
 	fmt.Fprintf(w, "\nSearch Benchmark\n")
 	fmt.Fprintf(w, "avg=%.2fus p50=%.2fus p95=%.2fus p99=%.2fus ops/sec=%.1f exact_fallbacks=%d\n",
 		res.Search.AvgMicros,

--- a/cmd/treedb_vector_search_demo/main.go
+++ b/cmd/treedb_vector_search_demo/main.go
@@ -67,6 +67,7 @@ type config struct {
 	compactSyncEachPhase  bool
 	vacuumIndex           bool
 	disableExactFallback  bool
+	nativeSearchDocuments bool
 	requireValueLogBytes  bool
 	requireLeafVLogBytes  bool
 	jsonOut               bool
@@ -101,6 +102,7 @@ type result struct {
 	Compact               bool                              `json:"compact"`
 	CompactSyncEachPhase  bool                              `json:"compact_sync_each_phase"`
 	DisableExactFallback  bool                              `json:"disable_exact_fallback"`
+	NativeSearchDocuments bool                              `json:"native_search_documents"`
 	Insert                phaseResult                       `json:"insert"`
 	Rebuild               phaseResult                       `json:"rebuild"`
 	CompactPhase          phaseResult                       `json:"compact_phase"`
@@ -284,6 +286,7 @@ func parseConfig(args []string) (config, error) {
 		compact:               false,
 		vacuumIndex:           true,
 		disableExactFallback:  true,
+		nativeSearchDocuments: true,
 		profile:               treedb.ProfileBench,
 		vectorIndexStrategy:   collections.VectorIndexStrategyNativeRuntime,
 	}
@@ -317,6 +320,7 @@ func parseConfig(args []string) (config, error) {
 	fs.BoolVar(&cfg.compactSyncEachPhase, "compact-sync-each-phase", false, "Ask CompactStorage to fsync each rewrite/pack phase")
 	fs.BoolVar(&cfg.vacuumIndex, "vacuum-index", cfg.vacuumIndex, "Run offline index.db vacuum after close before final storage/reopen")
 	fs.BoolVar(&cfg.disableExactFallback, "disable-exact-fallback", cfg.disableExactFallback, "Disable exact fallback during ANN benchmark queries")
+	fs.BoolVar(&cfg.nativeSearchDocuments, "native-search-documents", cfg.nativeSearchDocuments, "Fetch/materialize result documents during native runtime search benchmarks")
 	fs.BoolVar(&cfg.requireValueLogBytes, "require-value-log-bytes", false, "Fail if compacted storage has no value-log bytes")
 	fs.BoolVar(&cfg.requireLeafVLogBytes, "require-leaf-vlog-bytes", false, "Fail if compacted storage has no leaf value-log bytes")
 	fs.BoolVar(&cfg.jsonOut, "json", false, "Emit JSON instead of text")
@@ -699,6 +703,7 @@ func execute(ctx context.Context, cfg config) (result, error) {
 		Compact:               cfg.compact,
 		CompactSyncEachPhase:  cfg.compactSyncEachPhase,
 		DisableExactFallback:  cfg.disableExactFallback,
+		NativeSearchDocuments: cfg.nativeSearchDocuments,
 	}
 
 	if def.Strategy == collections.VectorIndexStrategyColumnGraph {
@@ -1800,6 +1805,7 @@ func benchmarkSearchLoadedConcurrent(idx *collections.VectorIndex, cfg config, q
 				TopK:                 cfg.topK,
 				EfSearch:             cfg.efSearch,
 				DisableExactFallback: cfg.disableExactFallback,
+				SkipDocumentFetch:    !cfg.nativeSearchDocuments,
 			})
 			if err != nil {
 				setErr(err)
@@ -2245,8 +2251,8 @@ func percentile(sorted []int64, p float64) int64 {
 
 func printText(w io.Writer, res result) {
 	fmt.Fprintf(w, "TreeDB vector search demo\n")
-	fmt.Fprintf(w, "dir=%s kept=%t profile=%s backend=%s vector_index_strategy=%s vector_index_search_path=%s docs=%d dims=%d queries=%d top_k=%d m=%d ef_construction=%d ef_search=%d value_pointer_threshold=%d leaf_generation_segment_target=%d\n",
-		res.Dir, res.KeptDir, res.Profile, resultBackend(res), resultStrategy(res), resultSearchPath(res), res.Docs, res.Dimensions, res.Queries, res.TopK, res.M, res.EfConstruction, res.EfSearch, res.ValuePointerThreshold, res.LeafGenerationTarget)
+	fmt.Fprintf(w, "dir=%s kept=%t profile=%s backend=%s vector_index_strategy=%s vector_index_search_path=%s native_search_documents=%t docs=%d dims=%d queries=%d top_k=%d m=%d ef_construction=%d ef_search=%d value_pointer_threshold=%d leaf_generation_segment_target=%d\n",
+		res.Dir, res.KeptDir, res.Profile, resultBackend(res), resultStrategy(res), resultSearchPath(res), res.NativeSearchDocuments, res.Docs, res.Dimensions, res.Queries, res.TopK, res.M, res.EfConstruction, res.EfSearch, res.ValuePointerThreshold, res.LeafGenerationTarget)
 	fmt.Fprintf(w, "\nPhases\n")
 	fmt.Fprintf(w, "insert: %.3fs\n", res.Insert.Seconds)
 	fmt.Fprintf(w, "rebuild_vector_index strategy=%s: %.3fs native_root_bytes=%d\n", resultStrategy(res), res.Rebuild.Seconds, res.NativeRootBytes)

--- a/cmd/treedb_vector_search_demo/main_test.go
+++ b/cmd/treedb_vector_search_demo/main_test.go
@@ -847,6 +847,7 @@ func TestRunTextOutput(t *testing.T) {
 		"backend=treedb",
 		"vector_index_strategy=native_runtime",
 		"vector_index_search_path=native_runtime_snapshot",
+		"native_search_documents=true",
 		"value_pointer_threshold=1024",
 		"leaf_generation_segment_target=4194304",
 		"Storage",

--- a/cmd/treedb_vector_search_demo/main_test.go
+++ b/cmd/treedb_vector_search_demo/main_test.go
@@ -242,6 +242,41 @@ func TestExecuteDatasetDirClampsValidateQueries(t *testing.T) {
 	}
 }
 
+func TestExecuteDatasetExactValidationSource(t *testing.T) {
+	datasetDir := writeDemoDataset(t, 96, 8, 4, 3)
+	res, err := execute(context.Background(), config{
+		dir:                   t.TempDir(),
+		datasetDir:            datasetDir,
+		validationExactSource: "dataset",
+		keepDir:               true,
+		docs:                  96,
+		dimensions:            8,
+		queries:               2,
+		searchConcurrency:     []int{2},
+		validateQueries:       4,
+		validateDocs:          2,
+		topK:                  3,
+		batchSize:             16,
+		m:                     4,
+		efConstruction:        32,
+		efSearch:              32,
+		valuePointerThreshold: defaultValuePointerThreshold,
+		leafGenerationTarget:  defaultLeafGenerationTarget,
+		minRecall:             0.5,
+		disableExactFallback:  true,
+		vectorIndexStrategy:   collections.VectorIndexStrategyColumnGraph,
+	})
+	if err != nil {
+		t.Fatalf("execute with dataset exact validation: %v", err)
+	}
+	if res.ValidationExactSource != "dataset" || res.Validation.ExactSource != "dataset" {
+		t.Fatalf("validation exact source result=%q validation=%q, want dataset", res.ValidationExactSource, res.Validation.ExactSource)
+	}
+	if res.Validation.QueriesChecked != 4 || res.Validation.ExactTotal != 12 || res.Validation.ANNTotal != 12 || res.Validation.Recall < 0.5 {
+		t.Fatalf("unexpected dataset exact validation: %+v", res.Validation)
+	}
+}
+
 func TestRunJSONOutput(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
@@ -631,6 +666,16 @@ func TestParseConfigRejectsInvalidValidationCombinations(t *testing.T) {
 			args: []string{"-validate-docs", "-1"},
 			want: "-validate-docs cannot be negative",
 		},
+		{
+			name: "dataset exact source requires dataset dir",
+			args: []string{"-validation-exact-source", "dataset"},
+			want: "requires -dataset-dir",
+		},
+		{
+			name: "unsupported exact source",
+			args: []string{"-validation-exact-source", "other"},
+			want: "unsupported -validation-exact-source",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			_, err := parseConfig(tc.args)
@@ -808,6 +853,7 @@ func TestRunTextOutput(t *testing.T) {
 		"format index_outer_leaves_in_vlog=",
 		"storage_domains index_db=",
 		"Memory",
+		"exact_source=treedb",
 		"avg=",
 		"Parallel Search Benchmark",
 	} {

--- a/cmd/treedb_vector_search_demo/main_test.go
+++ b/cmd/treedb_vector_search_demo/main_test.go
@@ -207,8 +207,8 @@ func TestExecuteColumnGraphRecallBenchmarkShape(t *testing.T) {
 	if res.Validation.Recall < 0.95 {
 		t.Fatalf("recall=%f want >=0.95", res.Validation.Recall)
 	}
-	if res.Search.AvgCandidates != 128 {
-		t.Fatalf("avg candidates=%f want ef_search=128", res.Search.AvgCandidates)
+	if res.Search.AvgCandidates < 128 {
+		t.Fatalf("avg candidates=%f want at least ef_search=128 scored candidates", res.Search.AvgCandidates)
 	}
 }
 

--- a/scripts/bench_vector_db_compare.sh
+++ b/scripts/bench_vector_db_compare.sh
@@ -14,6 +14,7 @@ QUERIES="${QUERIES:-10000}"
 VALIDATE_QUERIES="${VALIDATE_QUERIES:-64}"
 VALIDATE_DOCS="${VALIDATE_DOCS:-16}"
 TREEDB_VALIDATION_EXACT_SOURCE="${TREEDB_VALIDATION_EXACT_SOURCE:-treedb}"
+TREEDB_NATIVE_SEARCH_DOCUMENTS="${TREEDB_NATIVE_SEARCH_DOCUMENTS:-true}"
 TOP_K="${TOP_K:-10}"
 SEARCH_CONCURRENCY="${SEARCH_CONCURRENCY:-2,4,8,16,32,64,128}"
 M="${M:-16}"
@@ -159,6 +160,7 @@ cat >"$RUN_DIR/README.md" <<EOF
 - validate queries: \`$VALIDATE_QUERIES\`
 - validate docs: \`$VALIDATE_DOCS\`
 - TreeDB validation exact source: \`$TREEDB_VALIDATION_EXACT_SOURCE\`
+- TreeDB native search documents: \`$TREEDB_NATIVE_SEARCH_DOCUMENTS\`
 - top_k: \`$TOP_K\`
 - concurrency: \`$SEARCH_CONCURRENCY\`
 - M / efConstruction / efSearch: \`$M / $EF_CONSTRUCTION / $EF_SEARCH\`
@@ -226,6 +228,7 @@ if contains_backend treedb; then
 		-validate-queries "$VALIDATE_QUERIES" \
 		-validate-docs "$VALIDATE_DOCS" \
 		-validation-exact-source "$TREEDB_VALIDATION_EXACT_SOURCE" \
+		-native-search-documents "$TREEDB_NATIVE_SEARCH_DOCUMENTS" \
 		-top-k "$TOP_K" \
 		-m "$M" \
 		-ef-construction "$EF_CONSTRUCTION" \

--- a/scripts/bench_vector_db_compare.sh
+++ b/scripts/bench_vector_db_compare.sh
@@ -12,6 +12,8 @@ DOCS="${DOCS:-10000}"
 DIMS="${DIMS:-64}"
 QUERIES="${QUERIES:-10000}"
 VALIDATE_QUERIES="${VALIDATE_QUERIES:-64}"
+VALIDATE_DOCS="${VALIDATE_DOCS:-16}"
+TREEDB_VALIDATION_EXACT_SOURCE="${TREEDB_VALIDATION_EXACT_SOURCE:-treedb}"
 TOP_K="${TOP_K:-10}"
 SEARCH_CONCURRENCY="${SEARCH_CONCURRENCY:-2,4,8,16,32,64,128}"
 M="${M:-16}"
@@ -155,6 +157,8 @@ cat >"$RUN_DIR/README.md" <<EOF
 - dims: \`$DIMS\`
 - queries: \`$QUERIES\`
 - validate queries: \`$VALIDATE_QUERIES\`
+- validate docs: \`$VALIDATE_DOCS\`
+- TreeDB validation exact source: \`$TREEDB_VALIDATION_EXACT_SOURCE\`
 - top_k: \`$TOP_K\`
 - concurrency: \`$SEARCH_CONCURRENCY\`
 - M / efConstruction / efSearch: \`$M / $EF_CONSTRUCTION / $EF_SEARCH\`
@@ -220,7 +224,8 @@ if contains_backend treedb; then
 		-queries "$QUERIES" \
 		-search-concurrency "$SEARCH_CONCURRENCY" \
 		-validate-queries "$VALIDATE_QUERIES" \
-		-validate-docs 16 \
+		-validate-docs "$VALIDATE_DOCS" \
+		-validation-exact-source "$TREEDB_VALIDATION_EXACT_SOURCE" \
 		-top-k "$TOP_K" \
 		-m "$M" \
 		-ef-construction "$EF_CONSTRUCTION" \
@@ -243,7 +248,8 @@ if contains_backend treedb_column_graph; then
 		-queries "$QUERIES" \
 		-search-concurrency "$SEARCH_CONCURRENCY" \
 		-validate-queries "$VALIDATE_QUERIES" \
-		-validate-docs 16 \
+		-validate-docs "$VALIDATE_DOCS" \
+		-validation-exact-source "$TREEDB_VALIDATION_EXACT_SOURCE" \
 		-top-k "$TOP_K" \
 		-m "$M" \
 		-ef-construction "$EF_CONSTRUCTION" \


### PR DESCRIPTION
## Summary
- add `-validation-exact-source` to `treedb_vector_search_demo` with `treedb` (default) and `dataset` modes
- compute dataset-mode exact recall from exported `documents.f32`/`queries.f32`, avoiding TreeDB document materialization during recall validation
- expose `TREEDB_VALIDATION_EXACT_SOURCE` and `VALIDATE_DOCS` in the vector DB comparator script

## Tests
- `bash -n scripts/bench_vector_db_compare.sh`
- `go test ./cmd/treedb_vector_search_demo ./cmd/treedb_vector_dataset_export`
- `go test ./TreeDB/collections -run 'TestColumnVectorGraphNativeSearch|TestSearchVectorIndexColumnGraph'`\n- smoke: `BACKENDS=treedb_column_graph DOCS=500 DIMS=64 QUERIES=100 VALIDATE_QUERIES=20 VALIDATE_DOCS=4 TREEDB_VALIDATION_EXACT_SOURCE=dataset MIN_RECALL=0.90 scripts/bench_vector_db_compare.sh`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable validation source for exact recall (`-validation-exact-source`) and an option to run native searches without fetching documents (`-native-search-documents` / ID-only mode).

* **Bug Fixes**
  * Improved vector search frontier/candidate handling to yield more reliable nearest‑neighbor traversal and scoring.

* **Tests**
  * Added tests for tied-score expansion and traversal through promising frontier branches.

* **Chores**
  * Updated benchmark/demo docs and runner to expose validation settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1761?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->