### PR TITLE
docs: clean up typed-storage umbrella naming

### DIFF
--- a/TreeDB/collections/typed_storage_layout.go
+++ b/TreeDB/collections/typed_storage_layout.go
@@ -128,7 +128,7 @@ func ResolveTypedStorageLayout(meta CollectionMeta) (TypedStorageLayout, error) 
 		Enabled:             cfg.Enabled,
 		Fields:              fields,
 		RetainedPayload:     cfg.RetainedPayload,
-		DerivedAccelerators: derivedAcceleratorsFromColumnStoreConfig(*cfg),
+		DerivedAccelerators: derivedAcceleratorsFromTypedStorageCompatibilityConfig(*cfg),
 	}
 	applyRetainedPayloadToTypedStorageLayout(&layout)
 	return NormalizeTypedStorageLayout(layout)
@@ -340,7 +340,7 @@ func normalizeTypedStorageFieldOwner(owner TypedStorageFieldOwner) (TypedStorage
 	}
 }
 
-func derivedAcceleratorsFromColumnStoreConfig(cfg ColumnStoreConfig) []TypedStorageDerivedAccelerator {
+func derivedAcceleratorsFromTypedStorageCompatibilityConfig(cfg ColumnStoreConfig) []TypedStorageDerivedAccelerator {
 	var out []TypedStorageDerivedAccelerator
 	for _, col := range cfg.Columns {
 		if col.Dictionary {
@@ -366,7 +366,7 @@ func derivedAcceleratorsFromColumnStoreConfig(cfg ColumnStoreConfig) []TypedStor
 			Class: TypedStorageAssetClassDerivedAccelerator,
 		}
 		if aggregate.Column != "" {
-			if col, ok := columnStoreColumnByName(cfg.Columns, aggregate.Column); ok {
+			if col, ok := typedStorageCompatibilityColumnByName(cfg.Columns, aggregate.Column); ok {
 				accel.SourceFieldPath = col.Path
 				accel.SourceOwner = TypedStorageOwnerRowAsset
 			}
@@ -376,7 +376,7 @@ func derivedAcceleratorsFromColumnStoreConfig(cfg ColumnStoreConfig) []TypedStor
 	return out
 }
 
-func columnStoreColumnByName(columns []ColumnStoreColumn, name string) (ColumnStoreColumn, bool) {
+func typedStorageCompatibilityColumnByName(columns []ColumnStoreColumn, name string) (ColumnStoreColumn, bool) {
 	for _, col := range columns {
 		if col.Name == name {
 			return col, true

--- a/TreeDB/collections/typed_storage_layout_test.go
+++ b/TreeDB/collections/typed_storage_layout_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func testTypedStorageColumnStoreConfig(policy ColumnRetainedPayloadPolicy) *ColumnStoreConfig {
+func testTypedStorageCompatibilityConfig(policy ColumnRetainedPayloadPolicy) *ColumnStoreConfig {
 	return &ColumnStoreConfig{
 		Enabled:         true,
 		RetainedPayload: policy,
@@ -58,13 +58,13 @@ func TestTypedStorageLayoutNormalizeDocumentOnly(t *testing.T) {
 func TestTypedStorageLayoutNormalizeExistingColumnStoreConfigUsesTypedRowAsset(t *testing.T) {
 	layout, err := ResolveTypedStorageLayout(CollectionMeta{
 		Name:    "events",
-		Options: CollectionOptions{ColumnStore: testTypedStorageColumnStoreConfig(ColumnRetainedPayloadNonColumn)},
+		Options: CollectionOptions{ColumnStore: testTypedStorageCompatibilityConfig(ColumnRetainedPayloadNonColumn)},
 	})
 	if err != nil {
 		t.Fatalf("ResolveTypedStorageLayout: %v", err)
 	}
 	if !layout.Enabled {
-		t.Fatalf("column-store compatibility layout enabled=false")
+		t.Fatalf("typed-storage compatibility layout enabled=false")
 	}
 	requireTypedStorageOwner(t, layout, "time_us", TypedStorageOwnerRowAsset)
 	requireTypedStorageOwner(t, layout, "tag", TypedStorageOwnerRowAsset)
@@ -157,7 +157,7 @@ func TestTypedStorageLayoutRejectsOverlappingAuthoritativeOwners(t *testing.T) {
 func TestTypedStorageLayoutColumnRetainedPayloadFullCompatibility(t *testing.T) {
 	layout, err := ResolveTypedStorageLayout(CollectionMeta{
 		Name:    "events",
-		Options: CollectionOptions{ColumnStore: testTypedStorageColumnStoreConfig(ColumnRetainedPayloadFull)},
+		Options: CollectionOptions{ColumnStore: testTypedStorageCompatibilityConfig(ColumnRetainedPayloadFull)},
 	})
 	if err != nil {
 		t.Fatalf("ResolveTypedStorageLayout: %v", err)
@@ -236,6 +236,55 @@ func TestTypedStorageDerivedAcceleratorNotAuthoritative(t *testing.T) {
 	}
 	if got := layout.DerivedAccelerators[0].SourceOwner; got != TypedStorageOwnerRowAsset {
 		t.Fatalf("derived source owner=%q want %q", got, TypedStorageOwnerRowAsset)
+	}
+}
+
+func TestTypedStorageCompatibilityAliases(t *testing.T) {
+	var cfg ColumnStoreConfig
+	cfg.Enabled = true
+	cfg.Columns = []ColumnStoreColumn{{
+		Name:      "compat_field",
+		Path:      "compat_field",
+		ValueType: ColumnStoreValueString,
+	}}
+
+	layout, err := ResolveTypedStorageLayout(CollectionMeta{
+		Name:    "events",
+		Options: CollectionOptions{ColumnStore: &cfg},
+	})
+	if err != nil {
+		t.Fatalf("ResolveTypedStorageLayout with public compatibility config: %v", err)
+	}
+	requireTypedStorageOwner(t, layout, "compat_field", TypedStorageOwnerRowAsset)
+}
+
+func TestTypedStorageStatusVocabulary(t *testing.T) {
+	layout, err := NormalizeTypedStorageLayout(TypedStorageLayout{
+		Collection:      "events",
+		RetainedPayload: ColumnRetainedPayloadFull,
+		Fields: []TypedStorageField{
+			{Name: "time_us", Path: "time_us", Owner: TypedStorageOwnerRowAsset, ValueType: ColumnStoreValueInt64},
+			{Name: "embedding", Path: "embedding", Owner: TypedStorageOwnerColumnPart, ValueType: ColumnStoreValueFloat32Vector, VectorDims: 3},
+		},
+	})
+	if err != nil {
+		t.Fatalf("NormalizeTypedStorageLayout: %v", err)
+	}
+	rows := strings.Join(layout.FieldOwnerDebugRows(), "\n")
+	for _, want := range []string{
+		"time_us -> typed_row_asset",
+		"embedding -> typed_column_part",
+		"* -> retained_document(remainder)",
+		"document_payload -> compatibility_duplicate",
+	} {
+		if !strings.Contains(rows, want) {
+			t.Fatalf("status/debug rows missing %q in:\n%s", want, rows)
+		}
+	}
+	for _, legacyUmbrella := range []string{"column " + "store", "column-" + "store", "Column" + "Store"} {
+		if strings.Contains(rows, legacyUmbrella) {
+			t.Fatalf("status/debug rows contain legacy umbrella %q in:\n%s", legacyUmbrella, rows)
+		}
 	}
 }
 

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -86,7 +86,7 @@ func TestTypedStorageLegacyNameInventoryTable(t *testing.T) {
 
 	requireDocContains(t, doc,
 		"## Legacy Name Inventory",
-		"rg -n \"ColumnStore|column store|column-store\" TreeDB experiments docs",
+		"rg -n \"ColumnStore|column store|column-store\" TreeDB docs experiments",
 		"| Path | Symbol/text | Current meaning | Classification | Action | Deferral reason |",
 		"`TreeDB/collections/api.go`",
 		"`ColumnStoreConfig`",
@@ -95,6 +95,27 @@ func TestTypedStorageLegacyNameInventoryTable(t *testing.T) {
 		"compatibility-retained",
 		"deferred",
 	)
+}
+
+func TestTypedStorageLegacyColumnStoreNamesRemainClassified(t *testing.T) {
+	doc := readTypedStorageNamingDoc(t)
+
+	requireDocContains(t, doc,
+		"## PR 2 Umbrella Rename Cleanup",
+		"Issue #1752 is a naming cleanup only",
+		"Public/exported `Column"+"Store*` names remain compatibility-retained",
+		"Remaining legacy names must fall into one of these classes:",
+		"| compatibility-retained |",
+		"| true typed-column terminology |",
+		"| deferred |",
+		"Public API compatibility; do not remove in PR 2",
+	)
+
+	for _, class := range []string{"compatibility-retained", "true typed-column terminology", "deferred"} {
+		if !strings.Contains(doc, class) {
+			t.Fatalf("typed-storage naming doc missing legacy class %q", class)
+		}
+	}
 }
 
 func TestTypedStoragePR0RuntimeBoundary(t *testing.T) {

--- a/TreeDB/docs/spec/README.md
+++ b/TreeDB/docs/spec/README.md
@@ -150,13 +150,13 @@ Given pre-alpha status, this is a living spec that tracks implementation.
     fixtures, canonical validation, digest stability, benchmarks, and deferred
     Raft apply work.
 - `TreeDB/docs/spec/column-graph-native-reconstruction-inventory.md`
-  - issue #1646 V0 inventory for rebuilding column-store-native vector graph
-    search on generic column-store reader/cache APIs without carrying forward
-    decoded full-graph behavior as the product path.
+  - issue #1646 V0 inventory for rebuilding legacy native vector graph search
+    on typed-storage reader/cache APIs without carrying forward decoded
+    full-graph behavior as the product path.
 - `TreeDB/docs/spec/typed-storage-naming.md`
   - issue #1750 PR 0 naming scaffold establishing `typed storage` as the
     umbrella for typed-row and typed-column physical storage, with legacy
-    `ColumnStore*` inventory and derived-accelerator classifications.
+    compatibility-name inventory and derived-accelerator classifications.
 
 ## Canonical Ownership
 
@@ -198,8 +198,8 @@ blocking questions live:
 - Native-wire protocol questions: `native-wire-protocol.md`.
 - Raft sequencing and local recoverability questions:
   `native-query-raft-roadmap.md`.
-- Column-store persistence questions:
-  `GOMAP_TREEDB_COLUMN_STORE_RFC.md`.
+- Typed-storage persistence and historical roadmap questions:
+  `typed-storage-naming.md` and `GOMAP_TREEDB_COLUMN_STORE_RFC.md`.
 
 A blocking implementation question must be listed in this index and in its
 owner document. Non-blocking future-extension questions must be labeled as

--- a/TreeDB/docs/spec/storage-format.md
+++ b/TreeDB/docs/spec/storage-format.md
@@ -21,9 +21,10 @@ A TreeDB deployment uses:
 - value-log segments under `value_vlog/value-l*.log`,
 - optional split outer-leaf value-log segments under `leaf_vlog/value-l*.log`
   when `IndexOuterLeavesInValueLog` is enabled,
-- typed column asset manager segments under
+- typed asset manager segments under
   `column_assets/<namespace>/assets/segments/segment-*.tca` for production
-  column-store physical assets,
+  typed-storage physical assets (`column_assets` remains the compatibility
+  directory name),
 - optional side-store DBs (`dictdb`, `templatedb`) using their own `index.db` files.
 
 The old collection root-delta WAL storage class (`wal/collection-l*.log`,
@@ -419,14 +420,15 @@ Encoding rules:
 - if compact encoding is not smaller than the raw page, TreeDB stores the raw
   page payload instead.
 
-### 7.3 Column Asset Manager and TCPA Physical Assets
+### 7.3 Typed Asset Manager and TCPA Typed-Row Physical Assets
 
-Production column-store physical data is stored in typed column asset manager
-segments. These assets are value-log-shaped durable payloads, but they are not
-ordinary row `value_vlog` values and they are not split-leaf `leaf_vlog`
-records. Manifest/control roots can live in B-tree/root metadata; analytical
-column payloads, tombstones, marks, dictionaries, locators, and aggregate
-metadata belong under the isolated column asset manager namespace.
+Production typed-storage physical data is stored in typed asset manager segments
+under the compatibility `column_assets` directory. These assets are
+value-log-shaped durable payloads, but they are not ordinary row `value_vlog`
+values and they are not split-leaf `leaf_vlog` records. Manifest/control roots
+can live in B-tree/root metadata; typed-row payloads and derived accelerator
+payloads such as marks, dictionaries, locators, and aggregate metadata belong
+under the isolated typed asset manager namespace.
 
 A collection namespace such as `events/column-assets` maps to:
 

--- a/TreeDB/docs/spec/typed-storage-naming.md
+++ b/TreeDB/docs/spec/typed-storage-naming.md
@@ -58,6 +58,25 @@ The resolver is pure metadata only: it must not perform filesystem IO, mmap,
 section decode, DB mutation, asset open, publication, query planning, or durable
 typed-column format work.
 
+## PR 2 Umbrella Rename Cleanup
+
+Issue #1752 is a naming cleanup only. It must not start the colgranule
+transplant, durable typed-column part format, query-planner rewrite, production
+storage behavior change, or #1736 resource-manager work.
+
+After PR 2, new umbrella docs, comments, tests, status labels, and debug output
+should use `typed storage`, `TypedStorage*`, `typed-row`, or `typed-column`
+terminology. Public/exported `ColumnStore*` names remain compatibility-retained
+unless a future PR adds wrappers/aliases and a deprecation plan.
+
+Remaining legacy names must fall into one of these classes:
+
+| Class | Allowed occurrences | Reason |
+| --- | --- | --- |
+| compatibility-retained | Public API/config names such as `ColumnStoreConfig`, durable manifest/config fields, and compatibility tests that prove existing users still compile. | Avoid public API and metadata breakage while typed-storage names are introduced internally. |
+| true typed-column terminology | `experiments/colgranule` and future sectioned, column-major `typed_column_part` data-plane terms. | Preserve the coherent typed-column data plane for #1753 transplant work. |
+| deferred | Historical RFCs, vector-search reconstruction notes, and large implementation files deferred to #1752 follow-ups. | Avoid broad mechanical churn or format claims before typed-column publication exists. |
+
 ## Current Derived Accelerator Classifications
 
 These existing assets are derived accelerators unless a future format explicitly
@@ -76,7 +95,7 @@ promotes them and updates the typed-storage ownership contract:
 Audit command used for the initial inventory:
 
 ```sh
-rg -n "ColumnStore|column store|column-store" TreeDB experiments docs
+rg -n "ColumnStore|column store|column-store" TreeDB docs experiments
 ```
 
 The repository currently has many legacy `ColumnStore*`, "column store", and
@@ -86,9 +105,9 @@ occurrence in its PR inventory.
 
 | Path | Symbol/text | Current meaning | Classification | Action | Deferral reason |
 | --- | --- | --- | --- | --- | --- |
-| `TreeDB/collections/api.go` | `ColumnStoreConfig`, `ColumnStoreColumn`, `ColumnStoreValueType`, retained-payload options | Public compatibility configuration for declared typed fields and retained payload behavior. | compatibility-retained | Keep as compatibility input; #1751 should normalize it through typed-storage layout names. | Public API compatibility; do not remove in PR 0. |
-| `TreeDB/collections/column_store.go` and related publish/reconstruction files | `ColumnStore*` implementation names and comments | Production declared-field extraction, retained-payload handling, reconstruction, and publication control plane currently attached to typed-row assets. | compatibility-retained | Document as typed-storage/typed-row behavior; rename/wrap later under #1751/#1752. | Avoid behavior or public API change in PR 0. |
-| `TreeDB/collections/column_physical_asset.go`, `column_physical_*.go`, `column_physical_row_reader.go` | column physical asset / `TCPA` wording | Current row-record physical asset for declared typed values. | rename-now when touched as typed-row terminology | Treat as `typed_row_asset`; broad rename deferred to #1752. | Current PR is naming scaffold only. |
+| `TreeDB/collections/api.go` | `ColumnStoreConfig`, `ColumnStoreColumn`, `ColumnStoreValueType`, retained-payload options | Public compatibility configuration for declared typed fields and retained payload behavior. | compatibility-retained | Keep as compatibility input normalized by the typed-storage layout resolver. | Public API compatibility; do not remove in PR 2. |
+| `TreeDB/collections/column_store.go` and related publish/reconstruction files | `ColumnStore*` implementation names and comments | Production declared-field extraction, retained-payload handling, reconstruction, and publication control plane currently attached to typed-row assets. | compatibility-retained | Document as typed-storage/typed-row behavior; rename/wrap incrementally after the public compatibility seam is stable. | Avoid behavior or public API change in PR 2. |
+| `TreeDB/collections/column_physical_asset.go`, `column_physical_*.go`, `column_physical_row_reader.go` | column physical asset / `TCPA` wording | Current row-record physical asset for declared typed values. | deferred | Treat as `typed_row_asset`; broad file/symbol rename remains deferred until it can be split without obscuring behavior changes. | Large implementation surface; PR 2 only cleans safe umbrella names. |
 | `TreeDB/collections/column_asset_manager.go`, `column_asset_reachability.go`, `column_asset_gc.go`, `column_asset_rewrite.go` | column asset manager / reachability / GC / rewrite wording | Typed physical asset manager rooted in current typed-row assets and future typed-column refs. | compatibility-retained | Keep behavior; align terminology as typed-storage resource management in follow-ups. | #1736/#1755 own deeper resource and maintenance integration. |
 | `TreeDB/collections/column_dictionary_codes_asset.go` | dictionary-code asset names | Derived code sidecar for declared values. | derived accelerator | Keep as non-authoritative sidecar; require owner/generation association in later work. | Query integration and metadata rules belong to later #1744 children. |
 | `TreeDB/collections/column_int64_values_asset.go` | int64-values asset names | Derived values sidecar for declared values. | derived accelerator | Keep as non-authoritative sidecar; require owner/generation association in later work. | Query integration and metadata rules belong to later #1744 children. |
@@ -96,7 +115,7 @@ occurrence in its PR inventory.
 | `experiments/colgranule/**` | `ColumnStoreOptions`, `ColumnPart*`, column/granule descriptors | Coherent experimental typed-column data plane to transplant. | true typed-column terminology | Preserve for #1753 transplant; do not rename in PR 0. | Avoid thrashing the experiment before transplant. |
 | `TreeDB/docs/spec/GOMAP_TREEDB_COLUMN_STORE_RFC.md` | broad "column-store" roadmap wording | Historical/pre-typed-storage RFC that predates the umbrella rename. | deferred | Keep as historical supporting material until a dedicated docs rewrite. | Large historical document; changing it here would obscure PR 0. |
 | `TreeDB/docs/spec/column-graph-native-*.md` | column-store-native vector wording | Historical/vector tracker docs for rebuilding native vector search. | deferred | Keep historical references; future vector typed-column docs belong to #1756. | Do not change vector path in PR 0. |
-| `TreeDB/docs/spec/storage-format.md`, `docs/TREEDB_STORAGE_FORMAT.md`, backup/recovery/verification docs | future/physical column-store asset wording | Storage-format and recovery docs describing existing/future typed physical assets. | deferred | Update after typed-storage layout/publication work clarifies exact durable terms. | Avoid changing format claims before #1753/#1755. |
+| `TreeDB/docs/spec/storage-format.md`, `docs/TREEDB_STORAGE_FORMAT.md`, backup/recovery/verification docs | typed asset manager and `column_assets` compatibility directory wording | Storage-format and recovery docs describing existing/future typed physical assets. | compatibility-retained | Keep the on-disk directory name; use typed-storage wording around it. | Directory and manifest names are durable compatibility metadata. |
 
 ## PR 0 Runtime Boundary
 

--- a/docs/TREEDB_STORAGE_FORMAT.md
+++ b/docs/TREEDB_STORAGE_FORMAT.md
@@ -22,7 +22,7 @@ Operator-facing behavior is covered by:
   - `Dir/dictdb/`: dictionary store (for value-log compression)
 - Large values can be stored out-of-line in `Dir/maindb/value_vlog/` and referenced by `page.ValuePtr` pointers stored in the B+Tree.
 - The value log is **persistent storage**: pointers are valid long-term; segments are deleted only when unreachable (GC) or after rewrite/compaction.
-- Column-store physical assets are **value-log-shaped column assets**, not generic row `value_vlog` payloads. They live under the isolated typed column asset manager namespace.
+- Typed-storage physical assets are **value-log-shaped typed assets**, not generic row `value_vlog` payloads. Current production typed-row assets live under the isolated typed asset manager namespace; future typed-column parts will use the same typed-storage lifecycle.
 
 ## Directory layout
 
@@ -34,7 +34,7 @@ TreeDB creates/manages two sub-databases under the root directory:
 - `Dir/maindb/wal/`: redo journal segments named `commit-l<lane>-<seq>.log`.
 - `Dir/maindb/value_vlog/`: persistent large-value segments named `value-l<lane>-<seq>.log`.
 - `Dir/maindb/leaf_vlog/`: optional persistent outer-leaf generation segments named `value-l<lane>-<seq>.log`.
-- `Dir/maindb/column_assets/`: isolated typed column asset manager root for column-store physical assets.
+- `Dir/maindb/column_assets/`: compatibility directory name for the isolated typed asset manager root used by typed-storage physical assets.
 - `Dir/maindb/LOCK`: cross-process exclusive-open lock for the main DB.
 
 ### Dictionary store (`Dir/dictdb/`)
@@ -45,11 +45,11 @@ TreeDB creates/manages two sub-databases under the root directory:
 The dictionary store is used to persist trained dictionary bytes so value-log
 compressed frames can be decoded after restart.
 
-### Column assets (`column_assets/`)
+### Typed-storage assets (`column_assets/`)
 
-Column-store assets use an isolated value-log-shaped manager instead of ordinary
-row value-log entries. A collection namespace such as `events/column-assets`
-maps to:
+Typed-storage assets use an isolated value-log-shaped manager instead of ordinary
+row value-log entries. The `column_assets` directory name is compatibility
+metadata. A collection namespace such as `events/column-assets` maps to:
 
 ```text
 Dir/maindb/column_assets/events/column-assets/


### PR DESCRIPTION
## Parent / child trackers

Parent tracker: #1744.

Closes #1752.

This is PR 2: typed-storage umbrella rename cleanup.

Prerequisites complete:

- #1750 via #1759 (`8595ce673a2ccb27a25ce673ebf6419f1bcb7a7b`).
- #1751 via #1760 (`8f12d8e69bb95c5f36638ca7f649e61bca1eea7f`).
- #1736 Gate A is available; this PR does not touch resource-manager behavior.

## Summary

Cleans up safe typed-storage umbrella naming without changing runtime behavior:

- Renames new internal resolver helper/test naming from old umbrella wording to typed-storage compatibility wording.
- Updates typed-storage status/debug-output tests so emitted rows use `typed_row_asset`, `typed_column_part`, `retained_document`, and `document_payload` vocabulary.
- Updates storage docs to describe typed-storage/typed-row assets while preserving `column_assets` as the compatibility directory name.
- Extends `typed-storage-naming.md` with the PR 2 cleanup contract and remaining legacy-name classification classes.

## Naming impact

Public/exported API names touched: none renamed or removed.

Compatibility-retained:

- `ColumnStoreConfig`, `ColumnStoreColumn`, `ColumnStoreValueType`, and `CollectionOptions.ColumnStore` remain public compatibility input.
- `column_assets` remains the durable/compatibility directory name.

Renamed internally in this PR:

- `derivedAcceleratorsFromColumnStoreConfig` -> `derivedAcceleratorsFromTypedStorageCompatibilityConfig`.
- `columnStoreColumnByName` -> `typedStorageCompatibilityColumnByName`.
- `testTypedStorageColumnStoreConfig` -> `testTypedStorageCompatibilityConfig`.
- status/debug failure text now says typed-storage compatibility instead of column-store compatibility.

No true typed-column data-plane work is included. No colgranule transplant is included.

## Scope boundary and non-goals

This PR is naming cleanup only:

- no public API break;
- no `ColumnStoreConfig` removal;
- no durable typed-column part format;
- no query-planner behavior change;
- no production storage behavior change;
- no #1736 resource-manager changes;
- no unrelated cleanup outside typed-storage naming boundaries.

## Legacy-name audit

Audit command:

```sh
rg -n "ColumnStore|column store|column-store" TreeDB docs experiments
```

Before-change audit on latest `main` (`8f12d8e69`): 1845 matching lines.

After-change audit on this PR head (`448eff770`): 1845 matching lines.

The count is unchanged, but the touched docs/code replace safe umbrella wording with typed-storage terminology and add explicit PR 2 classification tests/docs. Remaining legacy names are classified in `TreeDB/docs/spec/typed-storage-naming.md` as:

| Classification | Remaining examples | Reason |
| --- | --- | --- |
| compatibility-retained | public `ColumnStore*` API/config names, manifest/config fields, `column_assets` directory name, compatibility tests | preserve public API and durable metadata compatibility |
| true typed-column terminology | `experiments/colgranule/**`, `ColumnPart*`/column-major experiment terms | preserve coherent data plane for #1753 transplant |
| deferred | historical RFCs, vector-search reconstruction docs, broad `column_*` implementation surfaces | avoid broad mechanical churn and format claims before #1753/#1755 |

## Tests

```sh
go test -count=1 ./TreeDB/collections -run 'TestTypedStorage'
go test -count=1 ./TreeDB/collections
rg -n "ColumnStore|column store|column-store" TreeDB docs experiments
```

The full collections package run covers existing collection API, typed-row asset, and vector graph tests.

## Benchmarks / performance

No benchmarks run. This PR changes docs, tests, comments/status vocabulary, and private helper names only; it does not touch runtime hot paths, query planning, publication, IO, mmap, codecs, or storage behavior.

## AI review / CI status

- Codex: requested after PR open; no major issues reported.
- Copilot: requested after PR open; reviewer/cloud-agent errored/unavailable and produced no findings.
- CodeRabbit: requested after PR open; no actionable comments generated.
- Review threads: 0 unresolved.
- Latest-head CI: passing on head `448eff770d4354e0fc845d3ccdf948b8cbd59120`.
