### PR TITLE
treedb: transplant typed-column data plane

### DIFF
--- a/TreeDB/docs/spec/README.md
+++ b/TreeDB/docs/spec/README.md
@@ -157,6 +157,10 @@ Given pre-alpha status, this is a living spec that tracks implementation.
   - issue #1750 PR 0 naming scaffold establishing `typed storage` as the
     umbrella for typed-row and typed-column physical storage, with legacy
     compatibility-name inventory and derived-accelerator classifications.
+- `TreeDB/docs/spec/typed-column-transplant.md`
+  - issue #1753 implementation note for the non-authoritative
+    `TreeDB/internal/typedcolumn` data-plane transplant from
+    `experiments/colgranule`.
 
 ## Canonical Ownership
 
@@ -182,7 +186,8 @@ TreeDB-wide storage terms (`value log`, `leaf log`, `commit log`,
 Typed physical storage vocabulary (`typed storage`, `typed-row storage`,
 `typed-column storage`, `typed_row_asset`, `typed_column_part`,
 `retained_document`, `document_payload`, and `derived_accelerator`) is owned by
-`typed-storage-naming.md`. User-command WAL lifecycle terms
+`typed-storage-naming.md`; the #1753 non-authoritative typed-column transplant
+scope is recorded in `typed-column-transplant.md`. User-command WAL lifecycle terms
 (`CommandEnvelope`, `LSN`, `AppliedLSN`, `WAL-supported`, `WAL-rejected`,
 `WAL-off-only`) are owned by `user-command-wal.md`. Deprecated collection root-delta WAL terms
 (`CollectionSeq`, `WALLSN`, `root group`, `applied watermark`) remain defined in
@@ -199,7 +204,8 @@ blocking questions live:
 - Raft sequencing and local recoverability questions:
   `native-query-raft-roadmap.md`.
 - Typed-storage persistence and historical roadmap questions:
-  `typed-storage-naming.md` and `GOMAP_TREEDB_COLUMN_STORE_RFC.md`.
+  `typed-storage-naming.md`, `typed-column-transplant.md`, and
+  `GOMAP_TREEDB_COLUMN_STORE_RFC.md`.
 
 A blocking implementation question must be listed in this index and in its
 owner document. Non-blocking future-extension questions must be labeled as

--- a/TreeDB/docs/spec/storage-format.md
+++ b/TreeDB/docs/spec/storage-format.md
@@ -710,6 +710,12 @@ control-plane state, not a sidecar hint. Current normalized fields are:
   cache identity invalidation. Manifest generation and recovery LSN are not
   schema-hash inputs.
 
+Issue #1753 also adds `TreeDB/internal/typedcolumn` as a non-authoritative
+transplant of the `experiments/colgranule` typed-column data plane. Its part
+image/TCS1 bytes are not registered as production collection metadata in this
+PR, do not change the `options.column_store` contract above, and are documented
+in `typed-column-transplant.md` until #1754/#1755 add control-plane adapters.
+
 Readers must fail closed for a column-enabled collection when:
 
 - active manifest metadata is missing required recovery-authoritative metadata,

--- a/TreeDB/docs/spec/typed-column-transplant.md
+++ b/TreeDB/docs/spec/typed-column-transplant.md
@@ -1,0 +1,61 @@
+# Typed-Column Data-Plane Transplant (#1753)
+
+Status: current implementation note for issue #1753 under parent tracker #1744.
+
+`TreeDB/internal/typedcolumn` is a copy/adapt transplant of the coherent
+`experiments/colgranule` typed-column data plane. It is intentionally
+**non-authoritative**: it can build, encode, decode, and scan typed-column part
+artifacts, but it does not publish production collection assets, register
+collection manifests, participate in WAL/recovery, change query planning, or
+make `typed_column_part` an authoritative field owner.
+
+The package preserves the colgranule data-plane shape:
+
+- versioned part images and TCS1 memory headers;
+- section directories with aligned section offsets;
+- granules, typed descriptors, codecs, and compression choices;
+- row locators;
+- sort-key mark and predicate/pruning metadata;
+- dictionary descriptors;
+- aggregate metadata descriptors and payloads;
+- latest-visible base/delta/tombstone part-set logic over caller-owned parts.
+
+Production control-plane adaptation is deferred to #1754/#1755. Any future byte
+access backed by production files should adapt this package to the #1736
+mapped-resource handles rather than reshaping this data plane into the existing
+typed-row physical asset format.
+
+## Copy / Adapt / Defer Table
+
+| Source | Destination / action | Semantic delta | Reason | Tests |
+| --- | --- | --- | --- | --- |
+| `experiments/colgranule/typed.go` | copied to `TreeDB/internal/typedcolumn/typed.go` | package and error prefix renamed | preserve typed codecs | `TestTypedColumnTransplantPartImageRoundTrip` |
+| `experiments/colgranule/granule.go` | copied to `TreeDB/internal/typedcolumn/granule.go` | package and error prefix renamed | preserve granule encodings/compression | `TestTypedColumnTransplantPartImageRoundTrip`, `TestTypedColumnTransplantPredicateMetadataRoundTrip` |
+| `experiments/colgranule/part.go` | copied/adapted to `TreeDB/internal/typedcolumn/part.go` | `ColumnStoreOptions` -> package-local `Options`; `ColumnBatch` -> `Batch`; error prefix renamed | avoid adding new `ColumnStore*` names while preserving part descriptors/build/scan | `TestTypedColumnTransplantPartImageRoundTrip`, `TestTypedColumnTransplantRowLocatorRoundTrip` |
+| `experiments/colgranule/part_image.go` | copied/adapted to `TreeDB/internal/typedcolumn/part_image.go` | package/error prefix renamed; section offsets aligned; padding accounting added | preserve sectioned image model and satisfy fixed-width alignment | `TestTypedColumnTransplantSectionDirectoryRoundTrip`, `TestTypedColumnTransplantFixedWidthSectionsAreAligned` |
+| `experiments/colgranule/part_image_decode.go` | copied/adapted to `TreeDB/internal/typedcolumn/part_image_decode.go` | package/error prefix renamed; validates aligned sections and permits explicit padding gaps | preserve decode/bounds checks for aligned section directories | `TestTypedColumnTransplantRejectsInvalidMagicOrVersion`, `TestTypedColumnTransplantRejectsTruncatedOrOutOfBoundsSection` |
+| `experiments/colgranule/predicate.go` | copied to `TreeDB/internal/typedcolumn/predicate.go` | package/error prefix renamed | preserve sort-key mark and predicate/pruning metadata | `TestTypedColumnTransplantPredicateMetadataRoundTrip` |
+| `experiments/colgranule/aggregate_metadata.go` | copied to `TreeDB/internal/typedcolumn/aggregate_metadata.go` | package/error prefix renamed | preserve aggregate metadata descriptors/payloads | `TestTypedColumnTransplantDictionaryAggregateDescriptorsRoundTrip` |
+| `experiments/colgranule/aggregate.go` | copied to `TreeDB/internal/typedcolumn/aggregate.go` | package/error prefix renamed | preserve aggregate arena helpers used by metadata build | `TestTypedColumnTransplantDictionaryAggregateDescriptorsRoundTrip` |
+| `experiments/colgranule/adaptive_mark.go` | copied to `TreeDB/internal/typedcolumn/adaptive_mark.go` | package/error prefix renamed | preserve adaptive mark sizing hooks | covered by package compile and part builder coverage |
+| `experiments/colgranule/part_accounting.go` | copied/adapted to `TreeDB/internal/typedcolumn/part_accounting.go` | JSONBench-only helper deferred; padding bytes added | keep part/granule/accounting concepts without benchmark fixture dependency | `TestTypedColumnTransplantPartImageRoundTrip` |
+| `experiments/colgranule/tcs1.go` | copied/adapted to `TreeDB/internal/typedcolumn/tcs1.go` | in-memory encode/decode/header validation retained; asset-store helpers deferred | preserve versioned header/checksum identity without adding production publication/storage | `TestTypedColumnTransplantPartImageRoundTrip`, `TestTypedColumnTransplantRejectsInvalidMagicOrVersion` |
+| `experiments/colgranule/part_set.go` | copied/adapted subset to `TreeDB/internal/typedcolumn/part_set.go` | latest-visible base/delta/tombstone data-plane logic retained over caller-owned parts; workspace/manifest/compaction deferred | keep coherent part-set semantics without production control-plane integration | `TestTypedColumnTransplantPartSetLatestVisibleRows` |
+| `experiments/colgranule/asset_store.go`, `asset_manager.go`, `workspace.go`, `lifecycle*.go`, `collection_manifest.go`, `control_plane_binary.go`, `mutation_adapter.go` | deferred | no production/internal copy in #1753 | control-plane, workspace, publication, recovery, or benchmark/lifecycle ownership belongs to #1754/#1755 and #1736 integration | `TestTypedColumnTransplantNoProductionPublication` |
+| `experiments/colgranule/jsonbench*`, benchmark reports, local-data benchmarks | deferred / remain in experiments | none | benchmark harnesses and JSONBench fixtures are not required for the non-authoritative data-plane transplant | not hot-path integrated in #1753 |
+
+## Naming Impact
+
+- No public `ColumnStore*` API is added or removed.
+- Internal package names use `typedcolumn` and package-local `Options`/`Batch`
+  instead of adding new `ColumnStoreOptions` or `ColumnBatch` symbols.
+- `ColumnPart*`, `ColumnPartImage*`, and section names are retained as true
+  typed-column terminology.
+- Current production `ColumnStoreConfig` and typed-row assets are unchanged.
+
+## Boundary
+
+`TreeDB/internal/typedcolumn` must remain a data-plane package until the adapter
+PRs land. It must not be imported by `TreeDB/collections` production files in
+#1753, and it must not change `ResolveTypedStorageLayout` fail-closed behavior
+for authoritative `typed_column_part` ownership.

--- a/TreeDB/docs/spec/typed-column-transplant.md
+++ b/TreeDB/docs/spec/typed-column-transplant.md
@@ -18,10 +18,11 @@ The package preserves the colgranule data-plane shape:
 - sort-key mark and predicate/pruning metadata;
 - dictionary descriptors;
 - aggregate metadata descriptors and payloads;
-- latest-visible base/delta/tombstone part-set logic over caller-owned parts.
+- latest-visible base/delta/tombstone part-set logic over caller-owned parts;
+- a narrow `SectionReader` seam for #1754 mappedresource-backed byte access.
 
 Production control-plane adaptation is deferred to #1754/#1755. Any future byte
-access backed by production files should adapt this package to the #1736
+access backed by production files should adapt `SectionReader` to the #1736
 mapped-resource handles rather than reshaping this data plane into the existing
 typed-row physical asset format.
 
@@ -33,7 +34,7 @@ typed-row physical asset format.
 | `experiments/colgranule/granule.go` | copied to `TreeDB/internal/typedcolumn/granule.go` | package and error prefix renamed | preserve granule encodings/compression | `TestTypedColumnTransplantPartImageRoundTrip`, `TestTypedColumnTransplantPredicateMetadataRoundTrip` |
 | `experiments/colgranule/part.go` | copied/adapted to `TreeDB/internal/typedcolumn/part.go` | `ColumnStoreOptions` -> package-local `Options`; `ColumnBatch` -> `Batch`; error prefix renamed | avoid adding new `ColumnStore*` names while preserving part descriptors/build/scan | `TestTypedColumnTransplantPartImageRoundTrip`, `TestTypedColumnTransplantRowLocatorRoundTrip` |
 | `experiments/colgranule/part_image.go` | copied/adapted to `TreeDB/internal/typedcolumn/part_image.go` | package/error prefix renamed; section offsets aligned; padding accounting added | preserve sectioned image model and satisfy fixed-width alignment | `TestTypedColumnTransplantSectionDirectoryRoundTrip`, `TestTypedColumnTransplantFixedWidthSectionsAreAligned` |
-| `experiments/colgranule/part_image_decode.go` | copied/adapted to `TreeDB/internal/typedcolumn/part_image_decode.go` | package/error prefix renamed; validates aligned sections and permits explicit padding gaps | preserve decode/bounds checks for aligned section directories | `TestTypedColumnTransplantRejectsInvalidMagicOrVersion`, `TestTypedColumnTransplantRejectsTruncatedOrOutOfBoundsSection` |
+| `experiments/colgranule/part_image_decode.go` | copied/adapted to `TreeDB/internal/typedcolumn/part_image_decode.go` plus `section_reader.go` seam | package/error prefix renamed; validates aligned sections and permits explicit padding gaps; exposes `SectionReader` for future mappedresource adapters | preserve decode/bounds checks for aligned section directories while deferring #1736-backed IO to #1754 | `TestTypedColumnTransplantRejectsInvalidMagicOrVersion`, `TestTypedColumnTransplantRejectsTruncatedOrOutOfBoundsSection`, `TestTypedColumnTransplantSectionDirectoryRoundTrip` |
 | `experiments/colgranule/predicate.go` | copied to `TreeDB/internal/typedcolumn/predicate.go` | package/error prefix renamed | preserve sort-key mark and predicate/pruning metadata | `TestTypedColumnTransplantPredicateMetadataRoundTrip` |
 | `experiments/colgranule/aggregate_metadata.go` | copied to `TreeDB/internal/typedcolumn/aggregate_metadata.go` | package/error prefix renamed | preserve aggregate metadata descriptors/payloads | `TestTypedColumnTransplantDictionaryAggregateDescriptorsRoundTrip` |
 | `experiments/colgranule/aggregate.go` | copied to `TreeDB/internal/typedcolumn/aggregate.go` | package/error prefix renamed | preserve aggregate arena helpers used by metadata build | `TestTypedColumnTransplantDictionaryAggregateDescriptorsRoundTrip` |

--- a/TreeDB/docs/spec/typed-column-transplant.md
+++ b/TreeDB/docs/spec/typed-column-transplant.md
@@ -57,6 +57,7 @@ typed-row physical asset format.
 ## Boundary
 
 `TreeDB/internal/typedcolumn` must remain a data-plane package until the adapter
-PRs land. It must not be imported by `TreeDB/collections` production files in
-#1753, and it must not change `ResolveTypedStorageLayout` fail-closed behavior
-for authoritative `typed_column_part` ownership.
+PRs land. In issue `#1753`, it must not be imported by
+`TreeDB/collections` production files, and it must not change
+`ResolveTypedStorageLayout` fail-closed behavior for authoritative
+`typed_column_part` ownership.

--- a/TreeDB/docs/spec/typed-storage-naming.md
+++ b/TreeDB/docs/spec/typed-storage-naming.md
@@ -77,6 +77,15 @@ Remaining legacy names must fall into one of these classes:
 | true typed-column terminology | `experiments/colgranule` and future sectioned, column-major `typed_column_part` data-plane terms. | Preserve the coherent typed-column data plane for #1753 transplant work. |
 | deferred | Historical RFCs, vector-search reconstruction notes, and large implementation files deferred to #1752 follow-ups. | Avoid broad mechanical churn or format claims before typed-column publication exists. |
 
+## PR 3 Typed-Column Data-Plane Transplant
+
+Issue #1753 introduces `TreeDB/internal/typedcolumn` as an internal,
+non-authoritative transplant of the `experiments/colgranule` data plane. This is
+true typed-column terminology, but it is not production publication and does not
+make `typed_column_part` an authoritative owner yet. The transplant deliberately
+uses package-local `Options`/`Batch` names instead of adding new public or
+internal `ColumnStore*` umbrella names.
+
 ## Current Derived Accelerator Classifications
 
 These existing assets are derived accelerators unless a future format explicitly

--- a/TreeDB/internal/typedcolumn/adaptive_mark.go
+++ b/TreeDB/internal/typedcolumn/adaptive_mark.go
@@ -1,0 +1,124 @@
+package typedcolumn
+
+import "fmt"
+
+const (
+	DefaultAdaptiveMarkTargetBytes = 1 << 20
+	DefaultAdaptiveMarkMinRows     = 512
+)
+
+type ColumnAdaptiveMarkSizing struct {
+	Enabled     bool `json:"enabled,omitempty"`
+	TargetBytes int  `json:"target_bytes,omitempty"`
+	MinRows     int  `json:"min_rows,omitempty"`
+	MaxRows     int  `json:"max_rows,omitempty"`
+}
+
+type ColumnAdaptiveMarkEstimate struct {
+	Rows           int     `json:"rows"`
+	RawBytes       int     `json:"raw_bytes"`
+	RawBytesPerRow float64 `json:"raw_bytes_per_row"`
+	TargetBytes    int     `json:"target_bytes"`
+	MinRows        int     `json:"min_rows"`
+	MaxRows        int     `json:"max_rows"`
+	RowsPerMark    int     `json:"rows_per_mark"`
+	Marks          int     `json:"marks"`
+	ClampedByMin   bool    `json:"clamped_by_min,omitempty"`
+	ClampedByMax   bool    `json:"clamped_by_max,omitempty"`
+}
+
+func NormalizeColumnAdaptiveMarkSizing(cfg ColumnAdaptiveMarkSizing, rowsPerGranule int) (ColumnAdaptiveMarkSizing, error) {
+	if !cfg.Enabled {
+		return cfg, nil
+	}
+	if cfg.TargetBytes == 0 {
+		cfg.TargetBytes = DefaultAdaptiveMarkTargetBytes
+	}
+	if cfg.TargetBytes < 0 {
+		return ColumnAdaptiveMarkSizing{}, fmt.Errorf("typedcolumn: invalid adaptive mark target bytes %d", cfg.TargetBytes)
+	}
+	if cfg.MinRows == 0 {
+		cfg.MinRows = DefaultAdaptiveMarkMinRows
+	}
+	if cfg.MinRows <= 0 {
+		return ColumnAdaptiveMarkSizing{}, fmt.Errorf("typedcolumn: invalid adaptive mark min rows %d", cfg.MinRows)
+	}
+	if cfg.MaxRows == 0 {
+		if rowsPerGranule > 0 {
+			cfg.MaxRows = rowsPerGranule
+		} else {
+			cfg.MaxRows = DefaultRowsPerGranule
+		}
+	}
+	if cfg.MaxRows <= 0 {
+		return ColumnAdaptiveMarkSizing{}, fmt.Errorf("typedcolumn: invalid adaptive mark max rows %d", cfg.MaxRows)
+	}
+	if cfg.MinRows > cfg.MaxRows {
+		return ColumnAdaptiveMarkSizing{}, fmt.Errorf("typedcolumn: adaptive mark min rows %d exceeds max rows %d", cfg.MinRows, cfg.MaxRows)
+	}
+	return cfg, nil
+}
+
+func EstimateAdaptiveRowsPerMark(rows int, rawBytes int, cfg ColumnAdaptiveMarkSizing) (ColumnAdaptiveMarkEstimate, error) {
+	cfg, err := NormalizeColumnAdaptiveMarkSizing(cfg, 0)
+	if err != nil {
+		return ColumnAdaptiveMarkEstimate{}, err
+	}
+	if !cfg.Enabled {
+		return ColumnAdaptiveMarkEstimate{}, fmt.Errorf("typedcolumn: adaptive mark sizing is disabled")
+	}
+	if rows <= 0 {
+		return ColumnAdaptiveMarkEstimate{}, fmt.Errorf("typedcolumn: invalid adaptive mark rows %d", rows)
+	}
+	if rawBytes < 0 {
+		return ColumnAdaptiveMarkEstimate{}, fmt.Errorf("typedcolumn: invalid adaptive mark raw bytes %d", rawBytes)
+	}
+	bytesPerRow := 1
+	if rawBytes > 0 {
+		bytesPerRow = (rawBytes + rows - 1) / rows
+	}
+	rowsPerMark := cfg.TargetBytes / bytesPerRow
+	if rowsPerMark == 0 {
+		rowsPerMark = 1
+	}
+	estimate := ColumnAdaptiveMarkEstimate{
+		Rows:           rows,
+		RawBytes:       rawBytes,
+		RawBytesPerRow: float64(rawBytes) / float64(rows),
+		TargetBytes:    cfg.TargetBytes,
+		MinRows:        cfg.MinRows,
+		MaxRows:        cfg.MaxRows,
+		RowsPerMark:    rowsPerMark,
+	}
+	if estimate.RowsPerMark < cfg.MinRows {
+		estimate.RowsPerMark = cfg.MinRows
+		estimate.ClampedByMin = true
+	}
+	if estimate.RowsPerMark > cfg.MaxRows {
+		estimate.RowsPerMark = cfg.MaxRows
+		estimate.ClampedByMax = true
+	}
+	estimate.Marks = (rows + estimate.RowsPerMark - 1) / estimate.RowsPerMark
+	return estimate, nil
+}
+
+func EstimateBatchUncompressedBytes(batch Batch, defs []ColumnDefinition) (int, error) {
+	rows, err := validateBatch(batch, defs)
+	if err != nil {
+		return 0, err
+	}
+	total := 0
+	for _, def := range defs {
+		switch def.Type {
+		case ColumnTypeInt64:
+			total += rows * 8
+		case ColumnTypeLowCardinalityCode:
+			total += rows * 4
+		case ColumnTypeBool:
+			total += rows
+		default:
+			return 0, fmt.Errorf("typedcolumn: unsupported column type %s for adaptive mark sizing", def.Type)
+		}
+	}
+	return total, nil
+}

--- a/TreeDB/internal/typedcolumn/aggregate.go
+++ b/TreeDB/internal/typedcolumn/aggregate.go
@@ -1,0 +1,393 @@
+package typedcolumn
+
+import (
+	"errors"
+	"fmt"
+)
+
+const maxAggregateCells = 1 << 20
+
+type AggregateArena struct {
+	reader       GranuleReader
+	counts       []uint64
+	bucketCounts []uint64
+	codeBits     []uint64
+	seenInt64    map[int64]struct{}
+}
+
+func (a *AggregateArena) Reset() {
+	a.counts = a.counts[:0]
+	a.bucketCounts = a.bucketCounts[:0]
+	a.codeBits = a.codeBits[:0]
+	clear(a.seenInt64)
+}
+
+// GroupedCountCodes returns arena-owned count storage. The returned slice is
+// valid only until the next AggregateArena operation or Reset.
+func (a *AggregateArena) GroupedCountCodes(granules []EncodedGranule, cardinality uint32) ([]uint64, error) {
+	counts, err := a.prepareCounts(granules, cardinality)
+	if err != nil {
+		return nil, err
+	}
+	clear(counts)
+	for _, g := range granules {
+		if err := a.forEachCode(g, func(code uint32) error {
+			if int(code) >= len(counts) {
+				return fmt.Errorf("typedcolumn: code %d outside counts", code)
+			}
+			counts[code]++
+			return nil
+		}); err != nil {
+			return nil, err
+		}
+	}
+	a.counts = counts
+	return counts, nil
+}
+
+// FilteredGroupedCountCodes returns arena-owned count storage. The returned
+// slice is valid only until the next AggregateArena operation or Reset.
+func (a *AggregateArena) FilteredGroupedCountCodes(codeGranules []EncodedGranule, filterGranules []EncodedGranule, filter Int64RangePredicate, cardinality uint32) ([]uint64, PredicateDiagnostics, error) {
+	var diagnostics PredicateDiagnostics
+	if len(codeGranules) != len(filterGranules) {
+		return nil, diagnostics, fmt.Errorf("typedcolumn: code granules=%d filter granules=%d", len(codeGranules), len(filterGranules))
+	}
+	counts, err := a.prepareCounts(codeGranules, cardinality)
+	if err != nil {
+		return nil, diagnostics, err
+	}
+	clear(counts)
+	if filter.Empty() {
+		a.counts = counts
+		return counts, diagnostics, nil
+	}
+	for i, codeGranule := range codeGranules {
+		filterGranule := filterGranules[i]
+		diagnostics.Considered++
+		if filterGranule.Rows != codeGranule.Rows {
+			return nil, diagnostics, errors.New("typedcolumn: filter/code row mismatch")
+		}
+		if filterGranule.HasMinMax && (filter.High < filterGranule.Min || filter.Low > filterGranule.Max) {
+			diagnostics.SkippedByMinMax++
+			continue
+		}
+		filterValues, err := a.reader.DecodeInt64(filterGranule)
+		if err != nil {
+			return nil, diagnostics, err
+		}
+		if len(filterValues) != codeGranule.Rows {
+			return nil, diagnostics, errors.New("typedcolumn: filter/code row mismatch")
+		}
+		codeRaw, err := a.reader.decompressPayload(codeGranule)
+		if err != nil {
+			return nil, diagnostics, err
+		}
+		header, err := parseUint32CodesHeader(codeRaw, codeGranule.Rows)
+		if err != nil {
+			return nil, diagnostics, err
+		}
+		diagnostics.Decoded++
+		for row, value := range filterValues {
+			if value < filter.Low || value > filter.High {
+				continue
+			}
+			code := readUint32Code(header.data, header.width, row)
+			if code >= header.cardinality || int(code) >= len(counts) {
+				return nil, diagnostics, fmt.Errorf("typedcolumn: code %d outside counts", code)
+			}
+			counts[code]++
+			diagnostics.Matched++
+		}
+	}
+	a.counts = counts
+	return counts, diagnostics, nil
+}
+
+func (a *AggregateArena) MinMaxInt64(granules []EncodedGranule, filter *Int64RangePredicate) (int64, int64, bool, error) {
+	has := false
+	min, max := int64(0), int64(0)
+	for _, g := range granules {
+		if filter == nil && g.HasMinMax {
+			min, max, has = updateOptionalMinMax(min, max, has, g.Min)
+			min, max, has = updateOptionalMinMax(min, max, has, g.Max)
+			continue
+		}
+		values, err := a.reader.DecodeInt64(g)
+		if err != nil {
+			return 0, 0, false, err
+		}
+		for _, v := range values {
+			if filter != nil && (v < filter.Low || v > filter.High) {
+				continue
+			}
+			min, max, has = updateOptionalMinMax(min, max, has, v)
+		}
+	}
+	return min, max, has, nil
+}
+
+func (a *AggregateArena) ExactDistinctCodes(granules []EncodedGranule, cardinality uint32) (int, error) {
+	cardinality, err := inferCodeCardinality(granules, cardinality)
+	if err != nil {
+		return 0, err
+	}
+	words := (int(cardinality) + 63) / 64
+	if words > maxAggregateCells {
+		return 0, fmt.Errorf("typedcolumn: code distinct words=%d exceeds cap %d", words, maxAggregateCells)
+	}
+	if cap(a.codeBits) < words {
+		a.codeBits = make([]uint64, words)
+	} else {
+		a.codeBits = a.codeBits[:words]
+	}
+	clear(a.codeBits)
+	for _, g := range granules {
+		if err := a.forEachCode(g, func(code uint32) error {
+			if code >= cardinality {
+				return fmt.Errorf("typedcolumn: code %d outside cardinality %d", code, cardinality)
+			}
+			if int(code/64) >= len(a.codeBits) {
+				return fmt.Errorf("typedcolumn: code %d outside cardinality %d", code, cardinality)
+			}
+			a.codeBits[code/64] |= 1 << uint(code%64)
+			return nil
+		}); err != nil {
+			return 0, err
+		}
+	}
+	distinct := 0
+	for _, word := range a.codeBits {
+		distinct += popcount64(word)
+	}
+	return distinct, nil
+}
+
+func (a *AggregateArena) ExactDistinctInt64(granules []EncodedGranule) (int, error) {
+	if a.seenInt64 == nil {
+		a.seenInt64 = make(map[int64]struct{})
+	} else {
+		clear(a.seenInt64)
+	}
+	for _, g := range granules {
+		values, err := a.reader.DecodeInt64(g)
+		if err != nil {
+			return 0, err
+		}
+		for _, v := range values {
+			a.seenInt64[v] = struct{}{}
+		}
+	}
+	return len(a.seenInt64), nil
+}
+
+type TimeBucketedCounts struct {
+	BucketWidth int64
+	MinBucket   int64
+	Buckets     int
+	Cardinality uint32
+	Counts      []uint64
+}
+
+func (c TimeBucketedCounts) Count(bucket int64, code uint32) uint64 {
+	if c.BucketWidth <= 0 || code >= c.Cardinality {
+		return 0
+	}
+	bucketOffset := bucket - c.MinBucket
+	if bucketOffset < 0 || bucketOffset >= int64(c.Buckets) {
+		return 0
+	}
+	cell, err := bucketCellIndex(int(bucketOffset), c.Buckets, code, c.Cardinality, len(c.Counts))
+	if err != nil {
+		return 0
+	}
+	return c.Counts[cell]
+}
+
+// TimeBucketedCountCodes returns a result whose Counts slice is arena-owned.
+// Counts is valid only until the next AggregateArena operation or Reset.
+func (a *AggregateArena) TimeBucketedCountCodes(codeGranules []EncodedGranule, timeGranules []EncodedGranule, bucketWidth int64, cardinality uint32) (TimeBucketedCounts, error) {
+	if len(codeGranules) != len(timeGranules) {
+		return TimeBucketedCounts{}, fmt.Errorf("typedcolumn: code granules=%d time granules=%d", len(codeGranules), len(timeGranules))
+	}
+	if bucketWidth <= 0 {
+		return TimeBucketedCounts{}, fmt.Errorf("typedcolumn: invalid bucket width %d", bucketWidth)
+	}
+	cardinality, err := inferCodeCardinality(codeGranules, cardinality)
+	if err != nil {
+		return TimeBucketedCounts{}, err
+	}
+	minTime, maxTime, ok, err := a.MinMaxInt64(timeGranules, nil)
+	if err != nil {
+		return TimeBucketedCounts{}, err
+	}
+	if !ok {
+		return TimeBucketedCounts{BucketWidth: bucketWidth, Cardinality: cardinality}, nil
+	}
+	minBucket := floorDiv(minTime, bucketWidth)
+	maxBucket := floorDiv(maxTime, bucketWidth)
+	buckets, cells, err := boundedBucketCells(minBucket, maxBucket, cardinality)
+	if err != nil {
+		return TimeBucketedCounts{}, err
+	}
+	if cap(a.bucketCounts) < cells {
+		a.bucketCounts = make([]uint64, cells)
+	} else {
+		a.bucketCounts = a.bucketCounts[:cells]
+	}
+	clear(a.bucketCounts)
+	for i, codeGranule := range codeGranules {
+		times, err := a.reader.DecodeInt64(timeGranules[i])
+		if err != nil {
+			return TimeBucketedCounts{}, err
+		}
+		codeRaw, err := a.reader.decompressPayload(codeGranule)
+		if err != nil {
+			return TimeBucketedCounts{}, err
+		}
+		header, err := parseUint32CodesHeader(codeRaw, codeGranule.Rows)
+		if err != nil {
+			return TimeBucketedCounts{}, err
+		}
+		if len(times) != codeGranule.Rows {
+			return TimeBucketedCounts{}, errors.New("typedcolumn: time/code row mismatch")
+		}
+		for row, timestamp := range times {
+			code := readUint32Code(header.data, header.width, row)
+			if code >= header.cardinality || code >= cardinality {
+				return TimeBucketedCounts{}, fmt.Errorf("typedcolumn: code %d outside cardinality %d", code, cardinality)
+			}
+			bucketIndex64 := floorDiv(timestamp, bucketWidth) - minBucket
+			if bucketIndex64 < 0 || bucketIndex64 >= int64(buckets) {
+				return TimeBucketedCounts{}, fmt.Errorf("typedcolumn: timestamp %d outside bucket range [%d,%d]", timestamp, minBucket, maxBucket)
+			}
+			bucketIndex := int(bucketIndex64)
+			cell, err := bucketCellIndex(bucketIndex, buckets, code, cardinality, len(a.bucketCounts))
+			if err != nil {
+				return TimeBucketedCounts{}, err
+			}
+			a.bucketCounts[cell]++
+		}
+	}
+	return TimeBucketedCounts{
+		BucketWidth: bucketWidth,
+		MinBucket:   minBucket,
+		Buckets:     buckets,
+		Cardinality: cardinality,
+		Counts:      a.bucketCounts,
+	}, nil
+}
+
+func (a *AggregateArena) prepareCounts(granules []EncodedGranule, cardinality uint32) ([]uint64, error) {
+	cardinality, err := inferCodeCardinality(granules, cardinality)
+	if err != nil {
+		return nil, err
+	}
+	if cardinality > maxAggregateCells {
+		return nil, fmt.Errorf("typedcolumn: cardinality %d exceeds cap %d", cardinality, maxAggregateCells)
+	}
+	if cap(a.counts) < int(cardinality) {
+		a.counts = make([]uint64, cardinality)
+	} else {
+		a.counts = a.counts[:cardinality]
+	}
+	return a.counts, nil
+}
+
+func (a *AggregateArena) forEachCode(g EncodedGranule, fn func(uint32) error) error {
+	raw, err := a.reader.decompressPayload(g)
+	if err != nil {
+		return err
+	}
+	header, err := parseUint32CodesHeader(raw, g.Rows)
+	if err != nil {
+		return err
+	}
+	for row := 0; row < g.Rows; row++ {
+		code := readUint32Code(header.data, header.width, row)
+		if code >= header.cardinality {
+			return fmt.Errorf("typedcolumn: code %d outside cardinality %d", code, header.cardinality)
+		}
+		if err := fn(code); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func inferCodeCardinality(granules []EncodedGranule, cardinality uint32) (uint32, error) {
+	if cardinality > maxCodeCardinality {
+		return 0, fmt.Errorf("typedcolumn: cardinality %d exceeds cap %d", cardinality, maxCodeCardinality)
+	}
+	if cardinality != 0 {
+		return cardinality, nil
+	}
+	maxCardinality := cardinality
+	var reader GranuleReader
+	for _, g := range granules {
+		raw, err := reader.decompressPayload(g)
+		if err != nil {
+			return 0, err
+		}
+		header, err := parseUint32CodesHeader(raw, g.Rows)
+		if err != nil {
+			return 0, err
+		}
+		if maxCardinality == 0 || header.cardinality > maxCardinality {
+			maxCardinality = header.cardinality
+		}
+	}
+	if maxCardinality == 0 {
+		return 0, errors.New("typedcolumn: empty code cardinality")
+	}
+	return maxCardinality, nil
+}
+
+func boundedBucketCells(minBucket int64, maxBucket int64, cardinality uint32) (int, int, error) {
+	if maxBucket < minBucket {
+		return 0, 0, fmt.Errorf("typedcolumn: invalid bucket range [%d,%d]", minBucket, maxBucket)
+	}
+	if cardinality == 0 {
+		return 0, 0, errors.New("typedcolumn: empty code cardinality")
+	}
+	maxBuckets := maxAggregateCells / int(cardinality)
+	if maxBuckets == 0 {
+		return 0, 0, fmt.Errorf("typedcolumn: aggregate cardinality=%d exceeds cell cap %d", cardinality, maxAggregateCells)
+	}
+	maxSpan := int64(maxBuckets - 1)
+	const minInt64 = -1 << 63
+	if maxBucket >= minInt64+maxSpan && maxBucket-maxSpan > minBucket {
+		return 0, 0, fmt.Errorf("typedcolumn: aggregate buckets exceed cap %d", maxBuckets)
+	}
+	buckets := int(maxBucket - minBucket + 1)
+	cells := buckets * int(cardinality)
+	return buckets, cells, nil
+}
+
+func bucketCellIndex(bucketIndex int, buckets int, code uint32, cardinality uint32, cells int) (int, error) {
+	if bucketIndex < 0 || bucketIndex >= buckets {
+		return 0, fmt.Errorf("typedcolumn: bucket index %d outside bucket count %d", bucketIndex, buckets)
+	}
+	if code >= cardinality {
+		return 0, fmt.Errorf("typedcolumn: code %d outside cardinality %d", code, cardinality)
+	}
+	cell := bucketIndex*int(cardinality) + int(code)
+	if cell < 0 || cell >= cells {
+		return 0, fmt.Errorf("typedcolumn: bucket cell %d outside counts length %d", cell, cells)
+	}
+	return cell, nil
+}
+
+func floorDiv(v int64, width int64) int64 {
+	q := v / width
+	r := v % width
+	if r != 0 && ((r < 0) != (width < 0)) {
+		q--
+	}
+	return q
+}
+
+func popcount64(v uint64) int {
+	v = v - ((v >> 1) & 0x5555555555555555)
+	v = (v & 0x3333333333333333) + ((v >> 2) & 0x3333333333333333)
+	return int((((v + (v >> 4)) & 0x0f0f0f0f0f0f0f0f) * 0x0101010101010101) >> 56)
+}

--- a/TreeDB/internal/typedcolumn/aggregate_metadata.go
+++ b/TreeDB/internal/typedcolumn/aggregate_metadata.go
@@ -1,0 +1,352 @@
+package typedcolumn
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"sort"
+	"time"
+)
+
+const aggregateMetadataGroupMinMaxEntryBytes = 24
+
+type AggregateMetadataKind string
+
+const (
+	AggregateMetadataGroupMinMax AggregateMetadataKind = "group_min_max"
+)
+
+const AggregateMetadataDefinitionVersion uint16 = 1
+
+type AggregateMetadataScope string
+
+const (
+	AggregateMetadataScopeGranule AggregateMetadataScope = "granule"
+)
+
+type AggregateMetadataMeasureOp string
+
+const (
+	AggregateMetadataMeasureCount AggregateMetadataMeasureOp = "count"
+	AggregateMetadataMeasureMin   AggregateMetadataMeasureOp = "min"
+	AggregateMetadataMeasureMax   AggregateMetadataMeasureOp = "max"
+)
+
+type AggregateMetadataPredicateOp string
+
+const (
+	AggregateMetadataPredicateEq AggregateMetadataPredicateOp = "eq"
+)
+
+type AggregateMetadataMeasure struct {
+	Op     AggregateMetadataMeasureOp `json:"op"`
+	Column string                     `json:"column,omitempty"`
+}
+
+type AggregateMetadataPredicate struct {
+	Column string                       `json:"column"`
+	Op     AggregateMetadataPredicateOp `json:"op"`
+	Value  int64                        `json:"value"`
+}
+
+type AggregateMetadataDefinition struct {
+	Name           string                       `json:"name"`
+	Version        uint16                       `json:"version"`
+	Kind           AggregateMetadataKind        `json:"kind"`
+	Scope          AggregateMetadataScope       `json:"scope"`
+	GroupKeys      []string                     `json:"group_keys"`
+	Measures       []AggregateMetadataMeasure   `json:"measures"`
+	Predicates     []AggregateMetadataPredicate `json:"predicates,omitempty"`
+	MaxBytesPerRow float64                      `json:"max_bytes_per_row"`
+}
+
+type AggregateMetadata struct {
+	Definition AggregateMetadataDefinition `json:"definition"`
+	Granules   []AggregateMetadataGranule  `json:"granules,omitempty"`
+	Stats      AggregateMetadataStats      `json:"stats"`
+}
+
+type AggregateMetadataStats struct {
+	Admitted            bool          `json:"admitted"`
+	RejectedReason      string        `json:"rejected_reason,omitempty"`
+	BuildDuration       time.Duration `json:"build_duration"`
+	Granules            int           `json:"granules"`
+	GranulesWithRows    int           `json:"granules_with_rows"`
+	RowsMatched         int           `json:"rows_matched"`
+	Entries             int           `json:"entries"`
+	ValueBytes          int           `json:"value_bytes"`
+	DescriptorBytes     int           `json:"estimated_descriptor_bytes"`
+	TotalBytes          int           `json:"estimated_total_bytes"`
+	BytesPerPartRow     float64       `json:"bytes_per_part_row"`
+	BytesPerMatchedRow  float64       `json:"bytes_per_matched_row"`
+	Compression         string        `json:"compression"`
+	AdmissionMaxBytes   float64       `json:"admission_max_bytes_per_row"`
+	AdmissionMeasuredBy string        `json:"admission_measured_by"`
+}
+
+type AggregateMetadataGranule struct {
+	GranuleOrdinal int                      `json:"granule_ordinal"`
+	FirstRow       int                      `json:"first_row"`
+	RowCount       int                      `json:"row_count"`
+	MatchedRows    int                      `json:"matched_rows"`
+	Entries        []AggregateMetadataEntry `json:"entries,omitempty"`
+}
+
+type AggregateMetadataEntry struct {
+	Group uint32 `json:"group"`
+	Count uint32 `json:"count"`
+	Min   int64  `json:"min"`
+	Max   int64  `json:"max"`
+}
+
+func (p *ColumnPart) AggregateMetadataByName(name string) (AggregateMetadata, bool) {
+	if p == nil || p.AggregateMetadata == nil {
+		return AggregateMetadata{}, false
+	}
+	metadata, ok := p.AggregateMetadata[name]
+	return metadata, ok
+}
+
+func normalizeAggregateMetadataDefinition(def AggregateMetadataDefinition, columns map[string]ColumnDefinition) (AggregateMetadataDefinition, error) {
+	if def.Name == "" {
+		return AggregateMetadataDefinition{}, errors.New("typedcolumn: aggregate metadata name is empty")
+	}
+	if def.Version == 0 {
+		def.Version = AggregateMetadataDefinitionVersion
+	}
+	if def.Version != AggregateMetadataDefinitionVersion {
+		return AggregateMetadataDefinition{}, fmt.Errorf("typedcolumn: unsupported aggregate metadata %s version %d", def.Name, def.Version)
+	}
+	if def.Kind == "" {
+		def.Kind = AggregateMetadataGroupMinMax
+	}
+	if def.Kind != AggregateMetadataGroupMinMax {
+		return AggregateMetadataDefinition{}, fmt.Errorf("typedcolumn: unsupported aggregate metadata kind %s", def.Kind)
+	}
+	if def.Scope == "" {
+		def.Scope = AggregateMetadataScopeGranule
+	}
+	if def.Scope != AggregateMetadataScopeGranule {
+		return AggregateMetadataDefinition{}, fmt.Errorf("typedcolumn: unsupported aggregate metadata %s scope %s", def.Name, def.Scope)
+	}
+	if len(def.GroupKeys) != 1 {
+		return AggregateMetadataDefinition{}, fmt.Errorf("typedcolumn: aggregate metadata %s supports exactly one group key, got %d", def.Name, len(def.GroupKeys))
+	}
+	groupColumn := def.GroupKeys[0]
+	if groupColumn == "" {
+		return AggregateMetadataDefinition{}, fmt.Errorf("typedcolumn: aggregate metadata %s has empty group key", def.Name)
+	}
+	groupDef, ok := columns[groupColumn]
+	if !ok {
+		return AggregateMetadataDefinition{}, fmt.Errorf("typedcolumn: aggregate metadata %s group column %s is not declared", def.Name, groupColumn)
+	}
+	if groupDef.Type != ColumnTypeLowCardinalityCode {
+		return AggregateMetadataDefinition{}, fmt.Errorf("typedcolumn: aggregate metadata %s group column %s type=%s want %s", def.Name, groupColumn, groupDef.Type, ColumnTypeLowCardinalityCode)
+	}
+
+	valueColumn, err := aggregateMetadataGroupMinMaxValueColumn(def)
+	if err != nil {
+		return AggregateMetadataDefinition{}, err
+	}
+	valueDef, ok := columns[valueColumn]
+	if !ok {
+		return AggregateMetadataDefinition{}, fmt.Errorf("typedcolumn: aggregate metadata %s value column %s is not declared", def.Name, valueColumn)
+	}
+	if valueDef.Type != ColumnTypeInt64 {
+		return AggregateMetadataDefinition{}, fmt.Errorf("typedcolumn: aggregate metadata %s value column %s type=%s want %s", def.Name, valueColumn, valueDef.Type, ColumnTypeInt64)
+	}
+
+	seenPredicates := make(map[string]struct{}, len(def.Predicates))
+	for i, predicate := range def.Predicates {
+		if predicate.Column == "" {
+			return AggregateMetadataDefinition{}, fmt.Errorf("typedcolumn: aggregate metadata %s predicate %d has empty column", def.Name, i)
+		}
+		if predicate.Op != AggregateMetadataPredicateEq {
+			return AggregateMetadataDefinition{}, fmt.Errorf("typedcolumn: aggregate metadata %s predicate %d op %s is unsupported", def.Name, i, predicate.Op)
+		}
+		if _, ok := columns[predicate.Column]; !ok {
+			return AggregateMetadataDefinition{}, fmt.Errorf("typedcolumn: aggregate metadata %s predicate column %s is not declared", def.Name, predicate.Column)
+		}
+		if _, ok := seenPredicates[predicate.Column]; ok {
+			return AggregateMetadataDefinition{}, fmt.Errorf("typedcolumn: aggregate metadata %s duplicate predicate column %s", def.Name, predicate.Column)
+		}
+		seenPredicates[predicate.Column] = struct{}{}
+	}
+	if math.IsNaN(def.MaxBytesPerRow) || math.IsInf(def.MaxBytesPerRow, 0) {
+		return AggregateMetadataDefinition{}, fmt.Errorf("typedcolumn: aggregate metadata %s max bytes per row %.3f is not finite", def.Name, def.MaxBytesPerRow)
+	}
+	if def.MaxBytesPerRow < 0 {
+		return AggregateMetadataDefinition{}, fmt.Errorf("typedcolumn: aggregate metadata %s max bytes per row %.3f is negative", def.Name, def.MaxBytesPerRow)
+	}
+	def.GroupKeys = append([]string(nil), def.GroupKeys...)
+	def.Measures = append([]AggregateMetadataMeasure(nil), def.Measures...)
+	def.Predicates = append([]AggregateMetadataPredicate(nil), def.Predicates...)
+	return def, nil
+}
+
+func aggregateMetadataGroupMinMaxValueColumn(def AggregateMetadataDefinition) (string, error) {
+	if len(def.Measures) != 3 {
+		return "", fmt.Errorf("typedcolumn: aggregate metadata %s supports exactly count/min/max measures, got %d", def.Name, len(def.Measures))
+	}
+	var hasCount bool
+	var minColumn string
+	var maxColumn string
+	for i, measure := range def.Measures {
+		switch measure.Op {
+		case AggregateMetadataMeasureCount:
+			if hasCount {
+				return "", fmt.Errorf("typedcolumn: aggregate metadata %s has duplicate count measure", def.Name)
+			}
+			if measure.Column != "" {
+				return "", fmt.Errorf("typedcolumn: aggregate metadata %s count measure must not bind column %s", def.Name, measure.Column)
+			}
+			hasCount = true
+		case AggregateMetadataMeasureMin:
+			if minColumn != "" {
+				return "", fmt.Errorf("typedcolumn: aggregate metadata %s has duplicate min measure", def.Name)
+			}
+			minColumn = measure.Column
+		case AggregateMetadataMeasureMax:
+			if maxColumn != "" {
+				return "", fmt.Errorf("typedcolumn: aggregate metadata %s has duplicate max measure", def.Name)
+			}
+			maxColumn = measure.Column
+		default:
+			return "", fmt.Errorf("typedcolumn: aggregate metadata %s measure %d op %s is unsupported", def.Name, i, measure.Op)
+		}
+	}
+	if !hasCount || minColumn == "" || maxColumn == "" {
+		return "", fmt.Errorf("typedcolumn: aggregate metadata %s requires count, min, and max measures", def.Name)
+	}
+	if minColumn != maxColumn {
+		return "", fmt.Errorf("typedcolumn: aggregate metadata %s min column %s differs from max column %s", def.Name, minColumn, maxColumn)
+	}
+	return minColumn, nil
+}
+
+func (b *ColumnPartBuilder) buildAggregateMetadata(part *ColumnPart, batch Batch) error {
+	if len(b.opts.AggregateMetadata) == 0 {
+		return nil
+	}
+	part.AggregateMetadata = make(map[string]AggregateMetadata, len(b.opts.AggregateMetadata))
+	for _, def := range b.opts.AggregateMetadata {
+		metadata, err := b.buildGroupMinMaxMetadata(part, batch, def)
+		if err != nil {
+			return err
+		}
+		part.AggregateMetadata[def.Name] = metadata
+	}
+	return nil
+}
+
+func (b *ColumnPartBuilder) buildGroupMinMaxMetadata(part *ColumnPart, batch Batch, def AggregateMetadataDefinition) (AggregateMetadata, error) {
+	start := time.Now()
+	groupColumn := def.GroupKeys[0]
+	valueColumn, err := aggregateMetadataGroupMinMaxValueColumn(def)
+	if err != nil {
+		return AggregateMetadata{}, err
+	}
+	groupValues := batch.Columns[groupColumn]
+	valueValues := batch.Columns[valueColumn]
+	predicateValues := make([][]int64, len(def.Predicates))
+	for i, predicate := range def.Predicates {
+		predicateValues[i] = batch.Columns[predicate.Column]
+	}
+
+	metadata := AggregateMetadata{
+		Definition: cloneAggregateMetadataDefinition(def),
+		Granules:   make([]AggregateMetadataGranule, 0, len(part.Descriptor.Granules)),
+	}
+	groupIndex := make(map[uint32]int)
+	for _, granule := range part.Descriptor.Granules {
+		clear(groupIndex)
+		outGranule := AggregateMetadataGranule{
+			GranuleOrdinal: granule.Ordinal,
+			FirstRow:       granule.FirstRow,
+			RowCount:       granule.RowCount,
+		}
+		for partRow := granule.FirstRow; partRow < granule.FirstRow+granule.RowCount; partRow++ {
+			sourceRow := b.order[partRow]
+			if !aggregateMetadataPredicatesMatch(predicateValues, def.Predicates, sourceRow) {
+				continue
+			}
+			group64 := groupValues[sourceRow]
+			if group64 < 0 || group64 > math.MaxUint32 {
+				return AggregateMetadata{}, fmt.Errorf("typedcolumn: aggregate metadata %s group value %d outside uint32", def.Name, group64)
+			}
+			group := uint32(group64)
+			value := valueValues[sourceRow]
+			outGranule.MatchedRows++
+			if index, ok := groupIndex[group]; ok {
+				entry := &outGranule.Entries[index]
+				if entry.Count == math.MaxUint32 {
+					return AggregateMetadata{}, fmt.Errorf("typedcolumn: aggregate metadata %s granule %d group %d count exceeds uint32", def.Name, granule.Ordinal, group)
+				}
+				entry.Count++
+				if value < entry.Min {
+					entry.Min = value
+				}
+				if value > entry.Max {
+					entry.Max = value
+				}
+				continue
+			}
+			if outGranule.MatchedRows > math.MaxUint32 {
+				return AggregateMetadata{}, fmt.Errorf("typedcolumn: aggregate metadata %s granule %d matched rows exceed uint32", def.Name, granule.Ordinal)
+			}
+			groupIndex[group] = len(outGranule.Entries)
+			outGranule.Entries = append(outGranule.Entries, AggregateMetadataEntry{
+				Group: group,
+				Count: 1,
+				Min:   value,
+				Max:   value,
+			})
+		}
+		sort.Slice(outGranule.Entries, func(i, j int) bool {
+			return outGranule.Entries[i].Group < outGranule.Entries[j].Group
+		})
+		if outGranule.MatchedRows > 0 {
+			metadata.Stats.GranulesWithRows++
+		}
+		metadata.Stats.RowsMatched += outGranule.MatchedRows
+		metadata.Stats.Entries += len(outGranule.Entries)
+		metadata.Granules = append(metadata.Granules, outGranule)
+	}
+	metadata.Stats.BuildDuration = time.Since(start)
+	metadata.Stats.Granules = len(part.Descriptor.Granules)
+	metadata.Stats.ValueBytes = metadata.Stats.Entries * aggregateMetadataGroupMinMaxEntryBytes
+	metadata.Stats.DescriptorBytes = len(part.Descriptor.Granules)*32 + len(def.Predicates)*24 + len(def.Measures)*16 + len(def.GroupKeys)*16 + 72
+	metadata.Stats.TotalBytes = metadata.Stats.ValueBytes + metadata.Stats.DescriptorBytes
+	metadata.Stats.Compression = "none_prototype"
+	metadata.Stats.AdmissionMaxBytes = def.MaxBytesPerRow
+	metadata.Stats.AdmissionMeasuredBy = "estimated_total_metadata_bytes / part_rows"
+	if part.Descriptor.RowCount > 0 {
+		metadata.Stats.BytesPerPartRow = float64(metadata.Stats.TotalBytes) / float64(part.Descriptor.RowCount)
+	}
+	if metadata.Stats.RowsMatched > 0 {
+		metadata.Stats.BytesPerMatchedRow = float64(metadata.Stats.TotalBytes) / float64(metadata.Stats.RowsMatched)
+	}
+	metadata.Stats.Admitted = true
+	if def.MaxBytesPerRow > 0 && metadata.Stats.BytesPerPartRow > def.MaxBytesPerRow {
+		metadata.Stats.Admitted = false
+		metadata.Stats.RejectedReason = fmt.Sprintf("bytes_per_part_row %.6f exceeds max %.6f", metadata.Stats.BytesPerPartRow, def.MaxBytesPerRow)
+		metadata.Granules = nil
+	}
+	return metadata, nil
+}
+
+func cloneAggregateMetadataDefinition(def AggregateMetadataDefinition) AggregateMetadataDefinition {
+	def.GroupKeys = append([]string(nil), def.GroupKeys...)
+	def.Measures = append([]AggregateMetadataMeasure(nil), def.Measures...)
+	def.Predicates = append([]AggregateMetadataPredicate(nil), def.Predicates...)
+	return def
+}
+
+func aggregateMetadataPredicatesMatch(predicateValues [][]int64, predicates []AggregateMetadataPredicate, row int) bool {
+	for i, predicate := range predicates {
+		if predicateValues[i][row] != predicate.Value {
+			return false
+		}
+	}
+	return true
+}

--- a/TreeDB/internal/typedcolumn/aggregate_metadata.go
+++ b/TreeDB/internal/typedcolumn/aggregate_metadata.go
@@ -104,7 +104,23 @@ func (p *ColumnPart) AggregateMetadataByName(name string) (AggregateMetadata, bo
 		return AggregateMetadata{}, false
 	}
 	metadata, ok := p.AggregateMetadata[name]
-	return metadata, ok
+	if !ok {
+		return AggregateMetadata{}, false
+	}
+	return cloneAggregateMetadata(metadata), true
+}
+
+func cloneAggregateMetadata(metadata AggregateMetadata) AggregateMetadata {
+	metadata.Definition = cloneAggregateMetadataDefinition(metadata.Definition)
+	if len(metadata.Granules) != 0 {
+		granules := make([]AggregateMetadataGranule, len(metadata.Granules))
+		for i, granule := range metadata.Granules {
+			granules[i] = granule
+			granules[i].Entries = append([]AggregateMetadataEntry(nil), granule.Entries...)
+		}
+		metadata.Granules = granules
+	}
+	return metadata
 }
 
 func normalizeAggregateMetadataDefinition(def AggregateMetadataDefinition, columns map[string]ColumnDefinition) (AggregateMetadataDefinition, error) {

--- a/TreeDB/internal/typedcolumn/doc.go
+++ b/TreeDB/internal/typedcolumn/doc.go
@@ -1,0 +1,11 @@
+// Package typedcolumn contains the transplanted experiments/colgranule
+// typed-column data plane for TreeDB.
+//
+// The package is intentionally non-authoritative in this PR: it can build,
+// encode, decode, and read typed-column part artifacts, but it does not publish
+// production collection assets, register manifest/recovery state, participate in
+// WAL replay, or own logical fields through typed_storage_layout. Later TreeDB
+// integration layers are expected to adapt this package to #1736 mappedresource
+// handles and the production control plane without reshaping the sectioned
+// column-major part-image model into the existing typed-row asset format.
+package typedcolumn

--- a/TreeDB/internal/typedcolumn/granule.go
+++ b/TreeDB/internal/typedcolumn/granule.go
@@ -1,0 +1,801 @@
+package typedcolumn
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/golang/snappy"
+	"github.com/pierrec/lz4/v4"
+)
+
+const (
+	DefaultRowsPerGranule = 8192
+	maxGranuleDecodeRows  = 1 << 20
+)
+
+type Encoding uint8
+
+const (
+	EncodingRawInt64 Encoding = iota + 1
+	EncodingDeltaVarint
+	EncodingDoubleDeltaVarint
+	EncodingNullableInt64
+	EncodingBoolBitpackRLE
+	EncodingLowCardinalityUint32
+)
+
+func (e Encoding) String() string {
+	switch e {
+	case EncodingRawInt64:
+		return "raw_int64"
+	case EncodingDeltaVarint:
+		return "delta_varint"
+	case EncodingDoubleDeltaVarint:
+		return "double_delta_varint"
+	case EncodingNullableInt64:
+		return "nullable_int64"
+	case EncodingBoolBitpackRLE:
+		return "bool_bitpack_rle"
+	case EncodingLowCardinalityUint32:
+		return "low_cardinality_uint32"
+	default:
+		return fmt.Sprintf("encoding_%d", e)
+	}
+}
+
+type Compression uint8
+
+const (
+	CompressionNone Compression = iota
+	CompressionSnappy
+	CompressionLZ4
+	CompressionZSTD
+	CompressionZSTDDict
+)
+
+func (c Compression) String() string {
+	switch c {
+	case CompressionNone:
+		return "none"
+	case CompressionSnappy:
+		return "snappy"
+	case CompressionLZ4:
+		return "lz4"
+	case CompressionZSTD:
+		return "zstd"
+	case CompressionZSTDDict:
+		return "zstd_dict"
+	default:
+		return fmt.Sprintf("compression_%d", c)
+	}
+}
+
+type Config struct {
+	Encoding    Encoding
+	Compression Compression
+}
+
+type PayloadRefKind uint8
+
+const (
+	PayloadRefInline PayloadRefKind = iota + 1
+)
+
+func (k PayloadRefKind) String() string {
+	switch k {
+	case PayloadRefInline:
+		return "inline"
+	default:
+		return fmt.Sprintf("payload_ref_%d", k)
+	}
+}
+
+type PayloadRef struct {
+	Kind   PayloadRefKind
+	Offset int64
+	Length int
+}
+
+type CodecReport struct {
+	Encoding                  Encoding
+	RequestedCompression      Compression
+	ActualCompression         Compression
+	CompressionAttempted      bool
+	CompressionKept           bool
+	CompressionFallbackReason string
+	RawBytes                  int
+	StoredBytes               int
+	CompressionNanos          int64
+}
+
+type EncodedGranule struct {
+	Rows         int
+	NullCount    int
+	DefaultCount int
+	HasMinMax    bool
+	Min          int64
+	Max          int64
+	Encoding     Encoding
+	Compression  Compression
+	RawBytes     int
+	StoredBytes  int
+	PayloadRef   PayloadRef
+	CodecReport  CodecReport
+	Payload      []byte
+}
+
+type GranuleBuilder struct {
+	cfg        Config
+	raw        []byte
+	encoded    []byte
+	compressed []byte
+	values64   []int64
+}
+
+func NewGranuleBuilder(cfg Config) *GranuleBuilder {
+	return &GranuleBuilder{cfg: cfg}
+}
+
+func (b *GranuleBuilder) Reset(cfg Config) {
+	b.cfg = cfg
+	b.raw = b.raw[:0]
+	b.compressed = b.compressed[:0]
+}
+
+// BuildInt64 returns a granule whose payload aliases builder-owned scratch until
+// the next BuildInt64 or Reset call.
+func (b *GranuleBuilder) BuildInt64(values []int64) (EncodedGranule, error) {
+	if len(values) == 0 {
+		return EncodedGranule{}, errors.New("typedcolumn: empty granule")
+	}
+	if err := validateGranuleDecodeRows(len(values)); err != nil {
+		return EncodedGranule{}, err
+	}
+	min, max := minMax(values)
+	raw, err := encodeInt64Payload(b.raw[:0], values, b.cfg.Encoding)
+	if err != nil {
+		return EncodedGranule{}, err
+	}
+	b.raw = raw
+	selection, err := admitCompressionInto(b.compressed[:0], raw, b.cfg.Encoding, b.cfg.Compression)
+	if err != nil {
+		return EncodedGranule{}, err
+	}
+	b.compressed = selection.Scratch
+	return newEncodedGranule(len(values), min, max, true, b.cfg.Encoding, selection), nil
+}
+
+type GranuleReader struct {
+	raw      []byte
+	values   []int64
+	stored64 []int64
+	bools    []bool
+	nulls    []bool
+	defaults []bool
+	codes    []uint32
+}
+
+func (r *GranuleReader) DecodeInt64(g EncodedGranule) ([]int64, error) {
+	values, err := r.DecodeInt64Into(r.values[:0], g)
+	if err != nil {
+		return nil, err
+	}
+	r.values = values
+	return values, nil
+}
+
+func (r *GranuleReader) DecodeInt64Into(dst []int64, g EncodedGranule) ([]int64, error) {
+	raw, err := r.decompressPayload(g)
+	if err != nil {
+		return nil, err
+	}
+	return decodeInt64Payload(dst, raw, g)
+}
+
+func (r *GranuleReader) int64Cursor(g EncodedGranule) (int64Cursor, error) {
+	raw, err := r.decompressPayload(g)
+	if err != nil {
+		return int64Cursor{}, err
+	}
+	cursor := int64Cursor{
+		encoding: g.Encoding,
+		raw:      raw,
+		rows:     g.Rows,
+	}
+	switch g.Encoding {
+	case EncodingRawInt64:
+		if len(raw)%8 != 0 || len(raw)/8 != g.Rows {
+			return int64Cursor{}, fmt.Errorf("typedcolumn: raw int64 length=%d rows=%d", len(raw), g.Rows)
+		}
+	case EncodingDeltaVarint, EncodingDoubleDeltaVarint:
+	default:
+		return int64Cursor{}, fmt.Errorf("typedcolumn: unsupported encoding %d", g.Encoding)
+	}
+	return cursor, nil
+}
+
+func (r *GranuleReader) RangeScanCountInt64(g EncodedGranule, low, high int64) (int, error) {
+	if low > high || (g.HasMinMax && (high < g.Min || low > g.Max)) {
+		r.values = r.values[:0]
+		return 0, nil
+	}
+	values, err := r.DecodeInt64(g)
+	if err != nil {
+		return 0, err
+	}
+	count := 0
+	for _, v := range values {
+		if v >= low && v <= high {
+			count++
+		}
+	}
+	return count, nil
+}
+
+func EncodeInt64(dst []byte, values []int64, cfg Config) (EncodedGranule, error) {
+	if len(values) == 0 {
+		return EncodedGranule{}, errors.New("typedcolumn: empty granule")
+	}
+	if err := validateGranuleDecodeRows(len(values)); err != nil {
+		return EncodedGranule{}, err
+	}
+	min, max := minMax(values)
+	raw, err := encodeInt64Payload(dst[:0], values, cfg.Encoding)
+	if err != nil {
+		return EncodedGranule{}, err
+	}
+	selection, err := compressPayload(raw, cfg.Encoding, cfg.Compression)
+	if err != nil {
+		return EncodedGranule{}, err
+	}
+	return newEncodedGranule(len(values), min, max, true, cfg.Encoding, selection), nil
+}
+
+func DecodeInt64(dst []int64, g EncodedGranule) ([]int64, error) {
+	var reader GranuleReader
+	return reader.DecodeInt64Into(dst, g)
+}
+
+func decodeInt64Payload(dst []int64, raw []byte, g EncodedGranule) ([]int64, error) {
+	out := dst[:0]
+	switch g.Encoding {
+	case EncodingRawInt64:
+		if len(raw)%8 != 0 || len(raw)/8 != g.Rows {
+			return nil, fmt.Errorf("typedcolumn: raw int64 length=%d rows=%d", len(raw), g.Rows)
+		}
+		if cap(out) < g.Rows {
+			out = make([]int64, g.Rows)
+		} else {
+			out = out[:g.Rows]
+		}
+		for i := range out {
+			out[i] = int64(binary.LittleEndian.Uint64(raw[i*8:]))
+		}
+	case EncodingDeltaVarint:
+		var err error
+		out, err = decodeDeltaVarint(out, raw, g.Rows)
+		if err != nil {
+			return nil, err
+		}
+	case EncodingDoubleDeltaVarint:
+		var err error
+		out, err = decodeDoubleDeltaVarint(out, raw, g.Rows)
+		if err != nil {
+			return nil, err
+		}
+	default:
+		return nil, fmt.Errorf("typedcolumn: unsupported encoding %d", g.Encoding)
+	}
+	return out, nil
+}
+
+func RangeScanCount(g EncodedGranule, low, high int64, scratch []int64) (int, []int64, error) {
+	if low > high || (g.HasMinMax && (high < g.Min || low > g.Max)) {
+		return 0, scratch[:0], nil
+	}
+	var reader GranuleReader
+	values, err := reader.DecodeInt64Into(scratch, g)
+	if err != nil {
+		return 0, scratch, err
+	}
+	count := 0
+	for _, v := range values {
+		if v >= low && v <= high {
+			count++
+		}
+	}
+	return count, values, nil
+}
+
+func newEncodedGranule(rows int, min int64, max int64, hasMinMax bool, encoding Encoding, selection CompressionSelection) EncodedGranule {
+	report := selection.Report
+	report.Encoding = encoding
+	report.ActualCompression = selection.Actual
+	report.StoredBytes = len(selection.Payload)
+	return EncodedGranule{
+		Rows:        rows,
+		HasMinMax:   hasMinMax,
+		Min:         min,
+		Max:         max,
+		Encoding:    encoding,
+		Compression: selection.Actual,
+		RawBytes:    report.RawBytes,
+		StoredBytes: len(selection.Payload),
+		PayloadRef: PayloadRef{
+			Kind:   PayloadRefInline,
+			Length: len(selection.Payload),
+		},
+		CodecReport: report,
+		Payload:     selection.Payload,
+	}
+}
+
+func encodeInt64Payload(dst []byte, values []int64, encoding Encoding) ([]byte, error) {
+	switch encoding {
+	case EncodingRawInt64:
+		need := len(values) * 8
+		if cap(dst) < need {
+			dst = make([]byte, need)
+		} else {
+			dst = dst[:need]
+		}
+		for i, v := range values {
+			binary.LittleEndian.PutUint64(dst[i*8:], uint64(v))
+		}
+		return dst, nil
+	case EncodingDeltaVarint:
+		if cap(dst) < len(values)*2 {
+			dst = make([]byte, 0, len(values)*2)
+		}
+		var buf [binary.MaxVarintLen64]byte
+		prev := int64(0)
+		for i, v := range values {
+			delta := v
+			if i > 0 {
+				delta = v - prev
+			}
+			n := binary.PutUvarint(buf[:], zigzag(delta))
+			dst = append(dst, buf[:n]...)
+			prev = v
+		}
+		return dst, nil
+	case EncodingDoubleDeltaVarint:
+		if cap(dst) < len(values)*2 {
+			dst = make([]byte, 0, len(values)*2)
+		}
+		var buf [binary.MaxVarintLen64]byte
+		prev := int64(0)
+		prevDelta := int64(0)
+		for i, v := range values {
+			var encoded int64
+			switch i {
+			case 0:
+				encoded = v
+			case 1:
+				encoded = v - prev
+				prevDelta = encoded
+			default:
+				delta := v - prev
+				encoded = delta - prevDelta
+				prevDelta = delta
+			}
+			n := binary.PutUvarint(buf[:], zigzag(encoded))
+			dst = append(dst, buf[:n]...)
+			prev = v
+		}
+		return dst, nil
+	default:
+		return nil, fmt.Errorf("typedcolumn: unsupported encoding %d", encoding)
+	}
+}
+
+func decodeDeltaVarint(dst []int64, raw []byte, rows int) ([]int64, error) {
+	if err := validateGranuleDecodeRows(rows); err != nil {
+		return nil, err
+	}
+	if rows > len(raw) {
+		return nil, fmt.Errorf("typedcolumn: delta rows=%d exceed payload bytes=%d", rows, len(raw))
+	}
+	out := dst[:0]
+	if cap(out) < rows {
+		out = make([]int64, 0, rows)
+	}
+	prev := int64(0)
+	for len(raw) > 0 && len(out) < rows {
+		u, n := binary.Uvarint(raw)
+		if n <= 0 {
+			return nil, errors.New("typedcolumn: malformed delta varint")
+		}
+		delta := unzigzag(u)
+		v := delta
+		if len(out) > 0 {
+			v = prev + delta
+		}
+		out = append(out, v)
+		prev = v
+		raw = raw[n:]
+	}
+	if len(out) != rows {
+		return nil, fmt.Errorf("typedcolumn: decoded rows=%d want=%d", len(out), rows)
+	}
+	if len(raw) != 0 {
+		return nil, errors.New("typedcolumn: trailing delta bytes")
+	}
+	return out, nil
+}
+
+func decodeDoubleDeltaVarint(dst []int64, raw []byte, rows int) ([]int64, error) {
+	if err := validateGranuleDecodeRows(rows); err != nil {
+		return nil, err
+	}
+	if rows > len(raw) {
+		return nil, fmt.Errorf("typedcolumn: double-delta rows=%d exceed payload bytes=%d", rows, len(raw))
+	}
+	out := dst[:0]
+	if cap(out) < rows {
+		out = make([]int64, 0, rows)
+	}
+	prev := int64(0)
+	prevDelta := int64(0)
+	for len(raw) > 0 && len(out) < rows {
+		u, n := binary.Uvarint(raw)
+		if n <= 0 {
+			return nil, errors.New("typedcolumn: malformed double-delta varint")
+		}
+		encoded := unzigzag(u)
+		var v int64
+		switch len(out) {
+		case 0:
+			v = encoded
+		case 1:
+			prevDelta = encoded
+			v = prev + encoded
+		default:
+			delta := prevDelta + encoded
+			v = prev + delta
+			prevDelta = delta
+		}
+		out = append(out, v)
+		prev = v
+		raw = raw[n:]
+	}
+	if len(out) != rows {
+		return nil, fmt.Errorf("typedcolumn: decoded rows=%d want=%d", len(out), rows)
+	}
+	if len(raw) != 0 {
+		return nil, errors.New("typedcolumn: trailing double-delta bytes")
+	}
+	return out, nil
+}
+
+type int64Cursor struct {
+	encoding  Encoding
+	raw       []byte
+	rows      int
+	row       int
+	offset    int
+	prev      int64
+	prevDelta int64
+}
+
+func (c *int64Cursor) Next() (int64, error) {
+	if c.row >= c.rows {
+		return 0, fmt.Errorf("typedcolumn: int64 cursor row=%d exceeds rows=%d", c.row, c.rows)
+	}
+	switch c.encoding {
+	case EncodingRawInt64:
+		v := int64(binary.LittleEndian.Uint64(c.raw[c.row*8:]))
+		c.row++
+		c.offset = c.row * 8
+		return v, nil
+	case EncodingDeltaVarint:
+		u, n := binary.Uvarint(c.raw[c.offset:])
+		if n <= 0 {
+			return 0, errors.New("typedcolumn: malformed delta varint")
+		}
+		delta := unzigzag(u)
+		v := delta
+		if c.row > 0 {
+			v = c.prev + delta
+		}
+		c.row++
+		c.offset += n
+		c.prev = v
+		return v, nil
+	case EncodingDoubleDeltaVarint:
+		u, n := binary.Uvarint(c.raw[c.offset:])
+		if n <= 0 {
+			return 0, errors.New("typedcolumn: malformed double-delta varint")
+		}
+		encoded := unzigzag(u)
+		var v int64
+		switch c.row {
+		case 0:
+			v = encoded
+		case 1:
+			c.prevDelta = encoded
+			v = c.prev + encoded
+		default:
+			delta := c.prevDelta + encoded
+			v = c.prev + delta
+			c.prevDelta = delta
+		}
+		c.row++
+		c.offset += n
+		c.prev = v
+		return v, nil
+	default:
+		return 0, fmt.Errorf("typedcolumn: unsupported encoding %d", c.encoding)
+	}
+}
+
+func (c *int64Cursor) Finish() error {
+	if c.row != c.rows {
+		return fmt.Errorf("typedcolumn: decoded rows=%d want=%d", c.row, c.rows)
+	}
+	if c.encoding != EncodingRawInt64 && c.offset != len(c.raw) {
+		return fmt.Errorf("typedcolumn: trailing %s bytes", c.encoding)
+	}
+	return nil
+}
+
+func validateGranuleDecodeRows(rows int) error {
+	if rows < 0 {
+		return fmt.Errorf("typedcolumn: negative rows=%d", rows)
+	}
+	if rows > maxGranuleDecodeRows {
+		return fmt.Errorf("typedcolumn: rows=%d exceed cap %d", rows, maxGranuleDecodeRows)
+	}
+	return nil
+}
+
+func (c *int64Cursor) RawBytesRead() int {
+	return c.offset
+}
+
+type CompressionSelection struct {
+	Payload []byte
+	Actual  Compression
+	Scratch []byte
+	Report  CodecReport
+}
+
+func admitCompressionInto(dst []byte, raw []byte, encoding Encoding, compression Compression) (CompressionSelection, error) {
+	report := CodecReport{
+		Encoding:             encoding,
+		RequestedCompression: compression,
+		ActualCompression:    compression,
+		RawBytes:             len(raw),
+	}
+	switch compression {
+	case CompressionNone:
+		report.ActualCompression = CompressionNone
+		report.CompressionKept = true
+		report.StoredBytes = len(raw)
+		return CompressionSelection{Payload: raw, Actual: CompressionNone, Scratch: dst[:0], Report: report}, nil
+	case CompressionSnappy:
+		need := snappy.MaxEncodedLen(len(raw))
+		if cap(dst) < need {
+			dst = make([]byte, 0, need)
+		} else {
+			dst = dst[:0]
+		}
+		start := time.Now()
+		out := snappy.Encode(dst, raw)
+		report.CompressionNanos = time.Since(start).Nanoseconds()
+		report.CompressionAttempted = true
+		if len(out) >= len(raw) {
+			report.ActualCompression = CompressionNone
+			report.CompressionFallbackReason = "not_smaller"
+			report.StoredBytes = len(raw)
+			return CompressionSelection{Payload: raw, Actual: CompressionNone, Scratch: dst[:0], Report: report}, nil
+		}
+		report.ActualCompression = CompressionSnappy
+		report.CompressionKept = true
+		report.StoredBytes = len(out)
+		return CompressionSelection{Payload: out, Actual: CompressionSnappy, Scratch: out, Report: report}, nil
+	case CompressionLZ4:
+		need := lz4.CompressBlockBound(len(raw))
+		if cap(dst) < need {
+			dst = make([]byte, need)
+		} else {
+			dst = dst[:need]
+		}
+		start := time.Now()
+		n, err := lz4.CompressBlock(raw, dst, nil)
+		report.CompressionNanos = time.Since(start).Nanoseconds()
+		if err != nil {
+			return CompressionSelection{}, err
+		}
+		report.CompressionAttempted = true
+		if n == 0 || n >= len(raw) {
+			report.ActualCompression = CompressionNone
+			report.CompressionFallbackReason = "not_smaller"
+			report.StoredBytes = len(raw)
+			return CompressionSelection{Payload: raw, Actual: CompressionNone, Scratch: dst[:0], Report: report}, nil
+		}
+		out := dst[:n]
+		report.ActualCompression = CompressionLZ4
+		report.CompressionKept = true
+		report.StoredBytes = len(out)
+		return CompressionSelection{Payload: out, Actual: CompressionLZ4, Scratch: out, Report: report}, nil
+	default:
+		return CompressionSelection{}, fmt.Errorf("typedcolumn: unsupported compression %d", compression)
+	}
+}
+
+func compressPayload(raw []byte, encoding Encoding, compression Compression) (CompressionSelection, error) {
+	selection, err := admitCompressionInto(nil, raw, encoding, compression)
+	if err != nil {
+		return CompressionSelection{}, err
+	}
+	payload := append([]byte(nil), selection.Payload...)
+	selection.Payload = payload
+	selection.Report.StoredBytes = len(payload)
+	return selection, nil
+}
+
+func decompressPayload(g EncodedGranule) ([]byte, error) {
+	var reader GranuleReader
+	return reader.decompressPayload(g)
+}
+
+func (r *GranuleReader) decompressPayload(g EncodedGranule) ([]byte, error) {
+	if err := validateGranule(g); err != nil {
+		return nil, err
+	}
+	switch g.Compression {
+	case CompressionNone:
+		if len(g.Payload) != g.RawBytes {
+			return nil, fmt.Errorf("typedcolumn: raw payload length=%d want=%d", len(g.Payload), g.RawBytes)
+		}
+		return g.Payload, nil
+	case CompressionSnappy:
+		decodedLen, err := snappy.DecodedLen(g.Payload)
+		if err != nil {
+			return nil, err
+		}
+		if decodedLen != g.RawBytes {
+			return nil, fmt.Errorf("typedcolumn: snappy decoded length=%d want=%d", decodedLen, g.RawBytes)
+		}
+		if cap(r.raw) < decodedLen {
+			r.raw = make([]byte, decodedLen)
+		} else {
+			r.raw = r.raw[:decodedLen]
+		}
+		out, err := snappy.Decode(r.raw, g.Payload)
+		if err != nil {
+			return nil, err
+		}
+		if len(out) != g.RawBytes {
+			return nil, fmt.Errorf("typedcolumn: snappy decoded length=%d want=%d", len(out), g.RawBytes)
+		}
+		r.raw = out
+		return out, nil
+	case CompressionLZ4:
+		if cap(r.raw) < g.RawBytes {
+			r.raw = make([]byte, g.RawBytes)
+		} else {
+			r.raw = r.raw[:g.RawBytes]
+		}
+		out := r.raw
+		n, err := lz4.UncompressBlock(g.Payload, out)
+		if err != nil {
+			return nil, err
+		}
+		if n != g.RawBytes {
+			return nil, fmt.Errorf("typedcolumn: lz4 decoded length=%d want=%d", n, g.RawBytes)
+		}
+		return out, nil
+	default:
+		return nil, fmt.Errorf("typedcolumn: unsupported compression %d", g.Compression)
+	}
+}
+
+func validateGranule(g EncodedGranule) error {
+	if g.Rows <= 0 {
+		return fmt.Errorf("typedcolumn: invalid row count %d", g.Rows)
+	}
+	if err := validateGranuleDecodeRows(g.Rows); err != nil {
+		return err
+	}
+	if g.NullCount < 0 {
+		return fmt.Errorf("typedcolumn: negative null count %d", g.NullCount)
+	}
+	if g.DefaultCount < 0 {
+		return fmt.Errorf("typedcolumn: negative default count %d", g.DefaultCount)
+	}
+	if g.NullCount > g.Rows || g.DefaultCount > g.Rows-g.NullCount {
+		return errors.New("typedcolumn: null/default count exceeds rows")
+	}
+	if g.RawBytes < 0 {
+		return fmt.Errorf("typedcolumn: negative raw payload length %d", g.RawBytes)
+	}
+	if g.StoredBytes < 0 {
+		return fmt.Errorf("typedcolumn: negative stored payload length %d", g.StoredBytes)
+	}
+	maxRaw := maxGranuleRawPayloadBytes(g.Encoding, g.Rows)
+	if maxRaw < 0 {
+		return fmt.Errorf("typedcolumn: unsupported encoding %d", g.Encoding)
+	}
+	if g.RawBytes > maxRaw {
+		return fmt.Errorf("typedcolumn: raw payload length=%d exceeds max=%d", g.RawBytes, maxRaw)
+	}
+	maxStored, err := maxGranuleStoredPayloadBytes(g.Compression, maxRaw)
+	if err != nil {
+		return err
+	}
+	if g.StoredBytes > maxStored {
+		return fmt.Errorf("typedcolumn: stored payload length=%d exceeds max=%d", g.StoredBytes, maxStored)
+	}
+	if len(g.Payload) > maxStored {
+		return fmt.Errorf("typedcolumn: payload length=%d exceeds max=%d", len(g.Payload), maxStored)
+	}
+	if g.PayloadRef.Kind != PayloadRefInline {
+		return fmt.Errorf("typedcolumn: unsupported payload ref kind %d", g.PayloadRef.Kind)
+	}
+	if g.PayloadRef.Offset != 0 {
+		return fmt.Errorf("typedcolumn: inline payload offset=%d want=0", g.PayloadRef.Offset)
+	}
+	if g.StoredBytes != len(g.Payload) {
+		return fmt.Errorf("typedcolumn: stored payload length=%d want=%d", len(g.Payload), g.StoredBytes)
+	}
+	if g.PayloadRef.Length != len(g.Payload) {
+		return fmt.Errorf("typedcolumn: payload ref length=%d want=%d", g.PayloadRef.Length, len(g.Payload))
+	}
+	return nil
+}
+
+func maxGranuleRawPayloadBytes(encoding Encoding, rows int) int {
+	switch encoding {
+	case EncodingRawInt64:
+		return rows * 8
+	case EncodingDeltaVarint, EncodingDoubleDeltaVarint:
+		return rows * binary.MaxVarintLen64
+	case EncodingNullableInt64:
+		return nullableInt64HeaderBytes + 2*bitmapBytes(rows) + rows*binary.MaxVarintLen64
+	case EncodingBoolBitpackRLE:
+		return 2 + rows*binary.MaxVarintLen64
+	case EncodingLowCardinalityUint32:
+		return 1 + binary.MaxVarintLen64 + rows*4
+	default:
+		return -1
+	}
+}
+
+func maxGranuleStoredPayloadBytes(compression Compression, maxRaw int) (int, error) {
+	switch compression {
+	case CompressionNone:
+		return maxRaw, nil
+	case CompressionSnappy:
+		return snappy.MaxEncodedLen(maxRaw), nil
+	case CompressionLZ4:
+		return lz4.CompressBlockBound(maxRaw), nil
+	default:
+		return 0, fmt.Errorf("typedcolumn: unsupported compression %d", compression)
+	}
+}
+
+func minMax(values []int64) (int64, int64) {
+	min, max := int64(math.MaxInt64), int64(math.MinInt64)
+	for _, v := range values {
+		if v < min {
+			min = v
+		}
+		if v > max {
+			max = v
+		}
+	}
+	return min, max
+}
+
+func zigzag(v int64) uint64 {
+	return uint64(v<<1) ^ uint64(v>>63)
+}
+
+func unzigzag(v uint64) int64 {
+	return int64(v>>1) ^ -int64(v&1)
+}

--- a/TreeDB/internal/typedcolumn/granule.go
+++ b/TreeDB/internal/typedcolumn/granule.go
@@ -349,6 +349,8 @@ func encodeInt64Payload(dst []byte, values []int64, encoding Encoding) ([]byte, 
 	case EncodingDeltaVarint:
 		if cap(dst) < len(values)*2 {
 			dst = make([]byte, 0, len(values)*2)
+		} else {
+			dst = dst[:0]
 		}
 		var buf [binary.MaxVarintLen64]byte
 		prev := int64(0)
@@ -365,6 +367,8 @@ func encodeInt64Payload(dst []byte, values []int64, encoding Encoding) ([]byte, 
 	case EncodingDoubleDeltaVarint:
 		if cap(dst) < len(values)*2 {
 			dst = make([]byte, 0, len(values)*2)
+		} else {
+			dst = dst[:0]
 		}
 		var buf [binary.MaxVarintLen64]byte
 		prev := int64(0)

--- a/TreeDB/internal/typedcolumn/part.go
+++ b/TreeDB/internal/typedcolumn/part.go
@@ -1,0 +1,853 @@
+package typedcolumn
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"sort"
+)
+
+const columnPartDescriptorVersion = 1
+
+type ColumnSchemaMode string
+
+const (
+	ColumnSchemaFixed ColumnSchemaMode = "fixed"
+)
+
+type ColumnType string
+
+const (
+	ColumnTypeInt64              ColumnType = "int64"
+	ColumnTypeLowCardinalityCode ColumnType = "low_cardinality_code"
+	ColumnTypeBool               ColumnType = "bool"
+)
+
+type SortKeyDirection string
+
+const (
+	SortKeyAsc  SortKeyDirection = "asc"
+	SortKeyDesc SortKeyDirection = "desc"
+)
+
+type SortKeyNullOrder string
+
+const (
+	SortKeyNullsDefault SortKeyNullOrder = ""
+	SortKeyNullsFirst   SortKeyNullOrder = "first"
+	SortKeyNullsLast    SortKeyNullOrder = "last"
+)
+
+type LogicalPrimaryKey struct {
+	Columns []string
+}
+
+type SortKey struct {
+	Columns []SortKeyColumn
+}
+
+type SortKeyColumn struct {
+	Column    string
+	Direction SortKeyDirection
+	Nulls     SortKeyNullOrder
+}
+
+type Options struct {
+	SchemaVersion     uint32
+	SchemaMode        ColumnSchemaMode
+	Columns           []ColumnDefinition
+	LogicalPrimaryKey LogicalPrimaryKey
+	SortKey           SortKey
+	PartPolicy        ColumnPartPolicy
+	Compression       ColumnCompressionPolicy
+	AggregateMetadata []AggregateMetadataDefinition
+}
+
+type ColumnPartPolicy struct {
+	RowsPerGranule        int
+	DefaultCodecBlockRows int
+	AdaptiveMarkSizing    ColumnAdaptiveMarkSizing
+}
+
+type ColumnCompressionPolicy struct {
+	Default Compression
+}
+
+type ColumnDefinition struct {
+	Name           string
+	Type           ColumnType
+	Encoding       Encoding
+	Compression    Compression
+	CompressionSet bool
+	Cardinality    uint32
+	CodecBlockRows int
+}
+
+type Batch struct {
+	Rows    int
+	Columns map[string][]int64
+}
+
+type ColumnPart struct {
+	Options           Options
+	Descriptor        ColumnPartDescriptor
+	Columns           map[string]ColumnPartColumn
+	Marks             []SortKeyMark
+	Locators          map[int64]RowLocator
+	AggregateMetadata map[string]AggregateMetadata
+}
+
+type ColumnPartDescriptor struct {
+	Version           uint8
+	PartID            uint64
+	SchemaVersion     uint32
+	RowCount          int
+	VisibleRowCount   int
+	LogicalPrimaryKey []string
+	SortKey           []SortKeyColumn
+	Granules          []GranuleDescriptor
+	Columns           []ColumnPartColumnDescriptor
+}
+
+type GranuleDescriptor struct {
+	Ordinal          int
+	FirstRow         int
+	RowCount         int
+	VisibleRows      int
+	DeletedRows      int
+	IDLower          int64
+	IDUpperExclusive int64
+	MarkOrdinal      int
+}
+
+type ColumnPartColumnDescriptor struct {
+	Name   string
+	Type   ColumnType
+	Blocks []ColumnBlockDescriptor
+}
+
+type ColumnBlockDescriptor struct {
+	FirstRow          int
+	RowCount          int
+	FirstGranule      int
+	LastGranule       int
+	Encoding          Encoding
+	Compression       Compression
+	RawBytes          int
+	StoredBytes       int
+	CodecBlockOrdinal int
+}
+
+type ColumnPartColumn struct {
+	Definition ColumnDefinition
+	Blocks     []ColumnBlock
+}
+
+type ColumnBlock struct {
+	Descriptor ColumnBlockDescriptor
+	Granule    EncodedGranule
+}
+
+type RowLocator struct {
+	PrimaryID      int64
+	PartID         uint64
+	PartRow        int
+	GranuleOrdinal int
+	RowInGranule   int
+}
+
+type ColumnPartBuilder struct {
+	opts     Options
+	order    []int
+	values64 []int64
+	codes32  []uint32
+	bools    []bool
+	builder  *GranuleBuilder
+}
+
+func NewColumnPartBuilder(opts Options) (*ColumnPartBuilder, error) {
+	normalized, err := normalizeOptions(opts)
+	if err != nil {
+		return nil, err
+	}
+	return &ColumnPartBuilder{opts: normalized, builder: NewGranuleBuilder(Config{})}, nil
+}
+
+func BuildColumnPart(partID uint64, opts Options, batch Batch) (*ColumnPart, error) {
+	builder, err := NewColumnPartBuilder(opts)
+	if err != nil {
+		return nil, err
+	}
+	return builder.Build(partID, batch)
+}
+
+func (b *ColumnPartBuilder) Build(partID uint64, batch Batch) (*ColumnPart, error) {
+	rows, err := validateBatch(batch, b.opts.Columns)
+	if err != nil {
+		return nil, err
+	}
+	if b.opts.PartPolicy.AdaptiveMarkSizing.Enabled {
+		rawBytes, err := EstimateBatchUncompressedBytes(batch, b.opts.Columns)
+		if err != nil {
+			return nil, err
+		}
+		estimate, err := EstimateAdaptiveRowsPerMark(rows, rawBytes, b.opts.PartPolicy.AdaptiveMarkSizing)
+		if err != nil {
+			return nil, err
+		}
+		b.opts.PartPolicy.RowsPerGranule = estimate.RowsPerMark
+	}
+	pkColumn := b.opts.LogicalPrimaryKey.Columns[0]
+	order, err := b.sortedOrder(batch, rows, pkColumn)
+	if err != nil {
+		return nil, err
+	}
+	b.order = order
+
+	part := &ColumnPart{
+		Options: b.opts,
+		Descriptor: ColumnPartDescriptor{
+			Version:           columnPartDescriptorVersion,
+			PartID:            partID,
+			SchemaVersion:     b.opts.SchemaVersion,
+			RowCount:          rows,
+			VisibleRowCount:   rows,
+			LogicalPrimaryKey: append([]string(nil), b.opts.LogicalPrimaryKey.Columns...),
+			SortKey:           append([]SortKeyColumn(nil), b.opts.SortKey.Columns...),
+		},
+		Columns:  make(map[string]ColumnPartColumn, len(b.opts.Columns)),
+		Locators: make(map[int64]RowLocator, rows),
+	}
+
+	if err := b.buildGranulesAndLocators(part, batch, pkColumn); err != nil {
+		return nil, err
+	}
+	for _, def := range b.opts.Columns {
+		column, descriptor, err := b.buildColumn(batch, def)
+		if err != nil {
+			return nil, err
+		}
+		part.Columns[def.Name] = column
+		part.Descriptor.Columns = append(part.Descriptor.Columns, descriptor)
+	}
+	if err := b.buildAggregateMetadata(part, batch); err != nil {
+		return nil, err
+	}
+	return part, nil
+}
+
+func (p *ColumnPart) LocatePrimaryID(primaryID int64) (RowLocator, bool) {
+	locator, ok := p.Locators[primaryID]
+	return locator, ok
+}
+
+func (p *ColumnPart) EncodedColumnBlocks(name string) ([]EncodedGranule, error) {
+	column, ok := p.Columns[name]
+	if !ok {
+		return nil, fmt.Errorf("typedcolumn: missing column %s", name)
+	}
+	out := make([]EncodedGranule, len(column.Blocks))
+	for i, block := range column.Blocks {
+		out[i] = block.Granule
+	}
+	return out, nil
+}
+
+func (p *ColumnPart) NewScanner() *ColumnPartScanner {
+	return &ColumnPartScanner{part: p}
+}
+
+type ColumnPartScanner struct {
+	part    *ColumnPart
+	reader  GranuleReader
+	values  []int64
+	codes   []uint32
+	bools   []bool
+	scratch []int64
+}
+
+type ProjectedScanResult struct {
+	Rows        int
+	Columns     map[string][]int64
+	Diagnostics PartScanDiagnostics
+}
+
+type PartScanDiagnostics struct {
+	RowsScanned        int
+	ColumnsProjected   int
+	GranulesConsidered int
+	GranulesDecoded    int
+	BlocksDecoded      int
+	BytesDecoded       int
+}
+
+func (s *ColumnPartScanner) ScanProjected(columns []string) (ProjectedScanResult, error) {
+	return s.ScanProjectedInto(make(map[string][]int64, len(columns)), columns)
+}
+
+func (s *ColumnPartScanner) ScanProjectedInto(dst map[string][]int64, columns []string) (ProjectedScanResult, error) {
+	if s.part == nil {
+		return ProjectedScanResult{}, errors.New("typedcolumn: nil part scanner")
+	}
+	projection, err := s.validateProjection(columns)
+	if err != nil {
+		return ProjectedScanResult{}, err
+	}
+	if dst == nil {
+		dst = make(map[string][]int64, len(projection))
+	}
+	out := ProjectedScanResult{
+		Rows:    s.part.Descriptor.RowCount,
+		Columns: dst,
+		Diagnostics: PartScanDiagnostics{
+			RowsScanned:        s.part.Descriptor.RowCount,
+			ColumnsProjected:   len(projection),
+			GranulesConsidered: len(s.part.Descriptor.Granules),
+		},
+	}
+	next := make(map[string][]int64, len(projection))
+	for _, name := range projection {
+		values, diagnostics, err := s.scanColumnInto(name, dst[name])
+		if err != nil {
+			return ProjectedScanResult{}, err
+		}
+		next[name] = values
+		if diagnostics.GranulesDecoded > out.Diagnostics.GranulesDecoded {
+			out.Diagnostics.GranulesDecoded = diagnostics.GranulesDecoded
+		}
+		out.Diagnostics.BlocksDecoded += diagnostics.BlocksDecoded
+		out.Diagnostics.BytesDecoded += diagnostics.BytesDecoded
+	}
+	for name := range dst {
+		if _, ok := next[name]; !ok {
+			delete(dst, name)
+		}
+	}
+	for name, values := range next {
+		dst[name] = values
+	}
+	return out, nil
+}
+
+func (s *ColumnPartScanner) validateProjection(columns []string) ([]string, error) {
+	if len(columns) == 0 {
+		return nil, errors.New("typedcolumn: empty projection")
+	}
+	seen := make(map[string]struct{}, len(columns))
+	for _, name := range columns {
+		if name == "" {
+			return nil, errors.New("typedcolumn: empty projection column")
+		}
+		if _, ok := seen[name]; ok {
+			return nil, fmt.Errorf("typedcolumn: duplicate projection column %s", name)
+		}
+		if _, ok := s.part.Columns[name]; !ok {
+			return nil, fmt.Errorf("typedcolumn: missing column %s", name)
+		}
+		seen[name] = struct{}{}
+	}
+	return columns, nil
+}
+
+func (s *ColumnPartScanner) ValueAt(locator RowLocator, columnName string) (int64, error) {
+	if s.part == nil {
+		return 0, errors.New("typedcolumn: nil part scanner")
+	}
+	if locator.PartID != s.part.Descriptor.PartID {
+		return 0, fmt.Errorf("typedcolumn: locator part=%d want %d", locator.PartID, s.part.Descriptor.PartID)
+	}
+	column, ok := s.part.Columns[columnName]
+	if !ok {
+		return 0, fmt.Errorf("typedcolumn: missing column %s", columnName)
+	}
+	for _, block := range column.Blocks {
+		if locator.PartRow < block.Descriptor.FirstRow || locator.PartRow >= block.Descriptor.FirstRow+block.Descriptor.RowCount {
+			continue
+		}
+		values, err := s.decodeBlock(column.Definition.Type, block.Granule)
+		if err != nil {
+			return 0, err
+		}
+		return values[locator.PartRow-block.Descriptor.FirstRow], nil
+	}
+	return 0, fmt.Errorf("typedcolumn: locator row %d outside column %s", locator.PartRow, columnName)
+}
+
+func (s *ColumnPartScanner) scanColumn(name string) ([]int64, PartScanDiagnostics, error) {
+	return s.scanColumnInto(name, nil)
+}
+
+func (s *ColumnPartScanner) scanColumnInto(name string, dst []int64) ([]int64, PartScanDiagnostics, error) {
+	column, ok := s.part.Columns[name]
+	if !ok {
+		return nil, PartScanDiagnostics{}, fmt.Errorf("typedcolumn: missing column %s", name)
+	}
+	out := ensureInt64Len(dst[:0], s.part.Descriptor.RowCount)
+	var diagnostics PartScanDiagnostics
+	granulesDecoded, err := countGranulesCoveredByBlocks(column.Blocks)
+	if err != nil {
+		return nil, diagnostics, fmt.Errorf("typedcolumn: column %s: %w", name, err)
+	}
+	diagnostics.GranulesDecoded = granulesDecoded
+	for _, block := range column.Blocks {
+		values, err := s.decodeBlock(column.Definition.Type, block.Granule)
+		if err != nil {
+			return nil, diagnostics, err
+		}
+		if len(values) != block.Descriptor.RowCount {
+			return nil, diagnostics, fmt.Errorf("typedcolumn: block rows=%d decoded=%d", block.Descriptor.RowCount, len(values))
+		}
+		copy(out[block.Descriptor.FirstRow:block.Descriptor.FirstRow+block.Descriptor.RowCount], values)
+		diagnostics.BlocksDecoded++
+		diagnostics.BytesDecoded += block.Granule.RawBytes
+	}
+	return out, diagnostics, nil
+}
+
+func (s *ColumnPartScanner) scanColumnRowsInto(name string, dst []int64, rows []int) ([]int64, PartScanDiagnostics, error) {
+	column, ok := s.part.Columns[name]
+	if !ok {
+		return nil, PartScanDiagnostics{}, fmt.Errorf("typedcolumn: missing column %s", name)
+	}
+	if len(rows) == 0 {
+		return dst[:0], PartScanDiagnostics{}, nil
+	}
+	if rows[0] < 0 || rows[len(rows)-1] >= s.part.Descriptor.RowCount {
+		return nil, PartScanDiagnostics{}, fmt.Errorf("typedcolumn: visible row range [%d,%d] outside part rows=%d", rows[0], rows[len(rows)-1], s.part.Descriptor.RowCount)
+	}
+	out := dst
+	var diagnostics PartScanDiagnostics
+	rowIndex := 0
+	for _, block := range column.Blocks {
+		first := block.Descriptor.FirstRow
+		limit := first + block.Descriptor.RowCount
+		for rowIndex < len(rows) && rows[rowIndex] < first {
+			return nil, diagnostics, fmt.Errorf("typedcolumn: visible row %d before block %d first row %d", rows[rowIndex], block.Descriptor.CodecBlockOrdinal, first)
+		}
+		start := rowIndex
+		for rowIndex < len(rows) && rows[rowIndex] < limit {
+			rowIndex++
+		}
+		if start == rowIndex {
+			continue
+		}
+		values, err := s.decodeBlock(column.Definition.Type, block.Granule)
+		if err != nil {
+			return nil, diagnostics, err
+		}
+		if len(values) != block.Descriptor.RowCount {
+			return nil, diagnostics, fmt.Errorf("typedcolumn: block rows=%d decoded=%d", block.Descriptor.RowCount, len(values))
+		}
+		for _, row := range rows[start:rowIndex] {
+			out = append(out, values[row-first])
+		}
+		diagnostics.BlocksDecoded++
+		diagnostics.BytesDecoded += block.Granule.RawBytes
+	}
+	if rowIndex != len(rows) {
+		return nil, diagnostics, fmt.Errorf("typedcolumn: %d visible rows outside column %s blocks", len(rows)-rowIndex, name)
+	}
+	diagnostics.RowsScanned = len(rows)
+	return out, diagnostics, nil
+}
+
+func countGranulesCoveredByBlocks(blocks []ColumnBlock) (int, error) {
+	total := 0
+	coveredStart := -1
+	coveredEnd := -1
+	prevFirst := -1
+	for _, block := range blocks {
+		first := block.Descriptor.FirstGranule
+		last := block.Descriptor.LastGranule
+		if first < 0 || last < first {
+			return 0, fmt.Errorf("invalid granule range %d..%d", first, last)
+		}
+		if prevFirst >= 0 && first < prevFirst {
+			return 0, fmt.Errorf("granule ranges out of order: %d after %d", first, prevFirst)
+		}
+		prevFirst = first
+		if coveredStart < 0 {
+			coveredStart = first
+			coveredEnd = last
+			continue
+		}
+		if first <= coveredEnd+1 {
+			if last > coveredEnd {
+				coveredEnd = last
+			}
+			continue
+		}
+		total += coveredEnd - coveredStart + 1
+		coveredStart = first
+		coveredEnd = last
+	}
+	if coveredStart >= 0 {
+		total += coveredEnd - coveredStart + 1
+	}
+	return total, nil
+}
+
+func (s *ColumnPartScanner) decodeBlock(columnType ColumnType, g EncodedGranule) ([]int64, error) {
+	switch columnType {
+	case ColumnTypeInt64:
+		values, err := s.reader.DecodeInt64Into(s.values[:0], g)
+		if err != nil {
+			return nil, err
+		}
+		s.values = values
+		return values, nil
+	case ColumnTypeLowCardinalityCode:
+		codes, err := s.reader.DecodeUint32CodesInto(s.codes[:0], g)
+		if err != nil {
+			return nil, err
+		}
+		s.codes = codes
+		s.scratch = ensureInt64Len(s.scratch[:0], len(codes))
+		for i, code := range codes {
+			s.scratch[i] = int64(code)
+		}
+		return s.scratch, nil
+	case ColumnTypeBool:
+		values, err := s.reader.DecodeBoolInto(s.bools[:0], g)
+		if err != nil {
+			return nil, err
+		}
+		s.bools = values
+		s.scratch = ensureInt64Len(s.scratch[:0], len(values))
+		for i, v := range values {
+			if v {
+				s.scratch[i] = 1
+			} else {
+				s.scratch[i] = 0
+			}
+		}
+		return s.scratch, nil
+	default:
+		return nil, fmt.Errorf("typedcolumn: unsupported column type %s", columnType)
+	}
+}
+
+func normalizeOptions(opts Options) (Options, error) {
+	opts.Columns = append([]ColumnDefinition(nil), opts.Columns...)
+	opts.LogicalPrimaryKey.Columns = append([]string(nil), opts.LogicalPrimaryKey.Columns...)
+	opts.SortKey.Columns = append([]SortKeyColumn(nil), opts.SortKey.Columns...)
+	if opts.SchemaVersion == 0 {
+		opts.SchemaVersion = 1
+	}
+	if opts.SchemaMode == "" {
+		opts.SchemaMode = ColumnSchemaFixed
+	}
+	if opts.SchemaMode != ColumnSchemaFixed {
+		return Options{}, fmt.Errorf("typedcolumn: unsupported schema mode %s", opts.SchemaMode)
+	}
+	var err error
+	if opts.PartPolicy.AdaptiveMarkSizing.Enabled {
+		opts.PartPolicy.AdaptiveMarkSizing, err = NormalizeColumnAdaptiveMarkSizing(opts.PartPolicy.AdaptiveMarkSizing, opts.PartPolicy.RowsPerGranule)
+		if err != nil {
+			return Options{}, err
+		}
+		opts.PartPolicy.RowsPerGranule = opts.PartPolicy.AdaptiveMarkSizing.MaxRows
+	} else {
+		if opts.PartPolicy.RowsPerGranule == 0 {
+			opts.PartPolicy.RowsPerGranule = DefaultRowsPerGranule
+		}
+		if opts.PartPolicy.RowsPerGranule <= 0 {
+			return Options{}, fmt.Errorf("typedcolumn: invalid rows per granule %d", opts.PartPolicy.RowsPerGranule)
+		}
+	}
+	if opts.PartPolicy.DefaultCodecBlockRows < 0 {
+		return Options{}, fmt.Errorf("typedcolumn: invalid default codec block rows %d", opts.PartPolicy.DefaultCodecBlockRows)
+	}
+	if err := validateCompression(opts.Compression.Default); err != nil {
+		return Options{}, fmt.Errorf("typedcolumn: unsupported default compression %s", opts.Compression.Default)
+	}
+	if len(opts.LogicalPrimaryKey.Columns) != 1 {
+		return Options{}, fmt.Errorf("typedcolumn: engine requires exactly one logical primary key column, got %d", len(opts.LogicalPrimaryKey.Columns))
+	}
+	if len(opts.SortKey.Columns) == 0 {
+		opts.SortKey.Columns = []SortKeyColumn{{Column: opts.LogicalPrimaryKey.Columns[0]}}
+	}
+	if len(opts.Columns) == 0 {
+		return Options{}, errors.New("typedcolumn: no declared columns")
+	}
+	seen := make(map[string]struct{}, len(opts.Columns))
+	columnsByName := make(map[string]ColumnDefinition, len(opts.Columns))
+	for i := range opts.Columns {
+		def, err := normalizeColumnDefinition(opts.Columns[i], opts.Compression.Default)
+		if err != nil {
+			return Options{}, err
+		}
+		if _, ok := seen[def.Name]; ok {
+			return Options{}, fmt.Errorf("typedcolumn: duplicate column %s", def.Name)
+		}
+		seen[def.Name] = struct{}{}
+		columnsByName[def.Name] = def
+		opts.Columns[i] = def
+	}
+	if _, ok := seen[opts.LogicalPrimaryKey.Columns[0]]; !ok {
+		return Options{}, fmt.Errorf("typedcolumn: logical primary key column %s is not declared", opts.LogicalPrimaryKey.Columns[0])
+	}
+	for i := range opts.SortKey.Columns {
+		c := &opts.SortKey.Columns[i]
+		if c.Column == "" {
+			return Options{}, fmt.Errorf("typedcolumn: empty sort key column at %d", i)
+		}
+		if _, ok := seen[c.Column]; !ok {
+			return Options{}, fmt.Errorf("typedcolumn: sort key column %s is not declared", c.Column)
+		}
+		if c.Direction == "" {
+			c.Direction = SortKeyAsc
+		}
+		if c.Direction != SortKeyAsc && c.Direction != SortKeyDesc {
+			return Options{}, fmt.Errorf("typedcolumn: unsupported sort direction %s", c.Direction)
+		}
+		if c.Direction == SortKeyDesc {
+			return Options{}, errors.New("typedcolumn: descending sort keys are not supported by transplant marks yet")
+		}
+		if c.Nulls != SortKeyNullsDefault && c.Nulls != SortKeyNullsFirst && c.Nulls != SortKeyNullsLast {
+			return Options{}, fmt.Errorf("typedcolumn: unsupported null order %s", c.Nulls)
+		}
+	}
+	seenMetadata := make(map[string]struct{}, len(opts.AggregateMetadata))
+	for i := range opts.AggregateMetadata {
+		def, err := normalizeAggregateMetadataDefinition(opts.AggregateMetadata[i], columnsByName)
+		if err != nil {
+			return Options{}, err
+		}
+		if _, ok := seenMetadata[def.Name]; ok {
+			return Options{}, fmt.Errorf("typedcolumn: duplicate aggregate metadata %s", def.Name)
+		}
+		seenMetadata[def.Name] = struct{}{}
+		opts.AggregateMetadata[i] = def
+	}
+	return opts, nil
+}
+
+func normalizeColumnDefinition(def ColumnDefinition, defaultCompression Compression) (ColumnDefinition, error) {
+	if def.Name == "" {
+		return ColumnDefinition{}, errors.New("typedcolumn: empty column name")
+	}
+	if def.Type == "" {
+		def.Type = ColumnTypeInt64
+	}
+	if def.CodecBlockRows < 0 {
+		return ColumnDefinition{}, fmt.Errorf("typedcolumn: invalid codec block rows %d for %s", def.CodecBlockRows, def.Name)
+	}
+	if !def.CompressionSet && def.Compression == CompressionNone && defaultCompression != CompressionNone {
+		def.Compression = defaultCompression
+	}
+	if err := validateCompression(def.Compression); err != nil {
+		return ColumnDefinition{}, fmt.Errorf("typedcolumn: unsupported compression %s for %s", def.Compression, def.Name)
+	}
+	switch def.Type {
+	case ColumnTypeInt64:
+		if def.Encoding == 0 {
+			def.Encoding = EncodingDeltaVarint
+		}
+		if def.Encoding != EncodingRawInt64 && def.Encoding != EncodingDeltaVarint && def.Encoding != EncodingDoubleDeltaVarint {
+			return ColumnDefinition{}, fmt.Errorf("typedcolumn: unsupported int64 encoding %s for %s", def.Encoding, def.Name)
+		}
+	case ColumnTypeLowCardinalityCode:
+		def.Encoding = EncodingLowCardinalityUint32
+	case ColumnTypeBool:
+		def.Encoding = EncodingBoolBitpackRLE
+	default:
+		return ColumnDefinition{}, fmt.Errorf("typedcolumn: unsupported column type %s for %s", def.Type, def.Name)
+	}
+	return def, nil
+}
+
+func validateCompression(compression Compression) error {
+	switch compression {
+	case CompressionNone, CompressionSnappy, CompressionLZ4:
+		return nil
+	default:
+		return fmt.Errorf("typedcolumn: unsupported compression %s", compression)
+	}
+}
+
+func validateBatch(batch Batch, defs []ColumnDefinition) (int, error) {
+	if batch.Columns == nil {
+		return 0, errors.New("typedcolumn: nil column batch")
+	}
+	rows := batch.Rows
+	for _, def := range defs {
+		values, ok := batch.Columns[def.Name]
+		if !ok {
+			return 0, fmt.Errorf("typedcolumn: missing column %s", def.Name)
+		}
+		if rows == 0 {
+			rows = len(values)
+		}
+		if len(values) != rows {
+			return 0, fmt.Errorf("typedcolumn: column %s rows=%d want=%d", def.Name, len(values), rows)
+		}
+	}
+	if rows <= 0 {
+		return 0, fmt.Errorf("typedcolumn: invalid part rows %d", rows)
+	}
+	return rows, nil
+}
+
+func (b *ColumnPartBuilder) sortedOrder(batch Batch, rows int, pkColumn string) ([]int, error) {
+	if cap(b.order) < rows {
+		b.order = make([]int, rows)
+	} else {
+		b.order = b.order[:rows]
+	}
+	for i := range b.order {
+		b.order[i] = i
+	}
+	sort.Slice(b.order, func(i, j int) bool {
+		left := b.order[i]
+		right := b.order[j]
+		for _, c := range b.opts.SortKey.Columns {
+			values := batch.Columns[c.Column]
+			if values[left] == values[right] {
+				continue
+			}
+			if c.Direction == SortKeyDesc {
+				return values[left] > values[right]
+			}
+			return values[left] < values[right]
+		}
+		pk := batch.Columns[pkColumn]
+		if pk[left] != pk[right] {
+			return pk[left] < pk[right]
+		}
+		return left < right
+	})
+	return b.order, nil
+}
+
+func (b *ColumnPartBuilder) buildGranulesAndLocators(part *ColumnPart, batch Batch, pkColumn string) error {
+	rowsPerGranule := b.opts.PartPolicy.RowsPerGranule
+	pkValues := batch.Columns[pkColumn]
+	for start := 0; start < len(b.order); start += rowsPerGranule {
+		end := min(start+rowsPerGranule, len(b.order))
+		ordinal := len(part.Descriptor.Granules)
+		idLower, idUpper := int64(math.MaxInt64), int64(math.MinInt64)
+		for partRow := start; partRow < end; partRow++ {
+			primaryID := pkValues[b.order[partRow]]
+			if primaryID == math.MaxInt64 {
+				return fmt.Errorf("typedcolumn: primary id %d cannot form exclusive upper bound", primaryID)
+			}
+			if _, exists := part.Locators[primaryID]; exists {
+				return fmt.Errorf("typedcolumn: duplicate primary id %d", primaryID)
+			}
+			if primaryID < idLower {
+				idLower = primaryID
+			}
+			if primaryID > idUpper {
+				idUpper = primaryID
+			}
+			part.Locators[primaryID] = RowLocator{
+				PrimaryID:      primaryID,
+				PartID:         part.Descriptor.PartID,
+				PartRow:        partRow,
+				GranuleOrdinal: ordinal,
+				RowInGranule:   partRow - start,
+			}
+		}
+		markColumns := make([]SortKeyColumnValues, len(b.opts.SortKey.Columns))
+		for i, sortColumn := range b.opts.SortKey.Columns {
+			values := make([]int64, end-start)
+			sourceValues := batch.Columns[sortColumn.Column]
+			for row := start; row < end; row++ {
+				values[row-start] = sourceValues[b.order[row]]
+			}
+			markColumns[i] = SortKeyColumnValues{Name: sortColumn.Column, Values: values}
+		}
+		mark, err := buildOwnedSortKeyMark(markColumns)
+		if err != nil {
+			return err
+		}
+		part.Marks = append(part.Marks, mark)
+		part.Descriptor.Granules = append(part.Descriptor.Granules, GranuleDescriptor{
+			Ordinal:          ordinal,
+			FirstRow:         start,
+			RowCount:         end - start,
+			VisibleRows:      end - start,
+			IDLower:          idLower,
+			IDUpperExclusive: exclusiveInt64Upper(idUpper),
+			MarkOrdinal:      len(part.Marks) - 1,
+		})
+	}
+	return nil
+}
+
+func (b *ColumnPartBuilder) buildColumn(batch Batch, def ColumnDefinition) (ColumnPartColumn, ColumnPartColumnDescriptor, error) {
+	blockRows := def.CodecBlockRows
+	if blockRows == 0 {
+		blockRows = b.opts.PartPolicy.DefaultCodecBlockRows
+	}
+	if blockRows == 0 {
+		blockRows = b.opts.PartPolicy.RowsPerGranule
+	}
+	column := ColumnPartColumn{Definition: def}
+	descriptor := ColumnPartColumnDescriptor{Name: def.Name, Type: def.Type}
+	sourceValues := batch.Columns[def.Name]
+	for start := 0; start < len(b.order); start += blockRows {
+		end := min(start+blockRows, len(b.order))
+		g, err := b.buildColumnBlockGranule(sourceValues, def, start, end)
+		if err != nil {
+			return ColumnPartColumn{}, ColumnPartColumnDescriptor{}, err
+		}
+		owned := g
+		owned.Payload = append([]byte(nil), g.Payload...)
+		desc := ColumnBlockDescriptor{
+			FirstRow:          start,
+			RowCount:          end - start,
+			FirstGranule:      start / b.opts.PartPolicy.RowsPerGranule,
+			LastGranule:       (end - 1) / b.opts.PartPolicy.RowsPerGranule,
+			Encoding:          owned.Encoding,
+			Compression:       owned.Compression,
+			RawBytes:          owned.RawBytes,
+			StoredBytes:       owned.StoredBytes,
+			CodecBlockOrdinal: len(column.Blocks),
+		}
+		column.Blocks = append(column.Blocks, ColumnBlock{Descriptor: desc, Granule: owned})
+		descriptor.Blocks = append(descriptor.Blocks, desc)
+	}
+	return column, descriptor, nil
+}
+
+func (b *ColumnPartBuilder) buildColumnBlockGranule(sourceValues []int64, def ColumnDefinition, start int, end int) (EncodedGranule, error) {
+	b.values64 = ensureInt64Len(b.values64[:0], end-start)
+	for row := start; row < end; row++ {
+		b.values64[row-start] = sourceValues[b.order[row]]
+	}
+	cfg := Config{Encoding: def.Encoding, Compression: def.Compression}
+	b.builder.Reset(cfg)
+	switch def.Type {
+	case ColumnTypeInt64:
+		return b.builder.BuildInt64(b.values64)
+	case ColumnTypeLowCardinalityCode:
+		b.codes32 = ensureUint32Len(b.codes32[:0], len(b.values64))
+		for i, v := range b.values64 {
+			if v < 0 || v > math.MaxUint32 {
+				return EncodedGranule{}, fmt.Errorf("typedcolumn: code value %d outside uint32 for %s", v, def.Name)
+			}
+			b.codes32[i] = uint32(v)
+		}
+		return b.builder.BuildUint32Codes(b.codes32, def.Cardinality)
+	case ColumnTypeBool:
+		b.bools = ensureBoolLen(b.bools[:0], len(b.values64))
+		for i, v := range b.values64 {
+			if v != 0 && v != 1 {
+				return EncodedGranule{}, fmt.Errorf("typedcolumn: bool value %d outside 0/1 for %s", v, def.Name)
+			}
+			b.bools[i] = v == 1
+		}
+		return b.builder.BuildBool(b.bools)
+	default:
+		return EncodedGranule{}, fmt.Errorf("typedcolumn: unsupported column type %s", def.Type)
+	}
+}
+
+func exclusiveInt64Upper(v int64) int64 {
+	if v == math.MaxInt64 {
+		return math.MaxInt64
+	}
+	return v + 1
+}

--- a/TreeDB/internal/typedcolumn/part.go
+++ b/TreeDB/internal/typedcolumn/part.go
@@ -415,7 +415,10 @@ func (s *ColumnPartScanner) scanColumnRowsInto(name string, dst []int64, rows []
 	if rows[0] < 0 || rows[len(rows)-1] >= s.part.Descriptor.RowCount {
 		return nil, PartScanDiagnostics{}, fmt.Errorf("typedcolumn: visible row range [%d,%d] outside part rows=%d", rows[0], rows[len(rows)-1], s.part.Descriptor.RowCount)
 	}
-	out := dst
+	out := dst[:0]
+	if cap(out) < len(rows) {
+		out = make([]int64, 0, len(rows))
+	}
 	var diagnostics PartScanDiagnostics
 	rowIndex := 0
 	for _, block := range column.Blocks {
@@ -670,8 +673,10 @@ func validateBatch(batch Batch, defs []ColumnDefinition) (int, error) {
 	if batch.Columns == nil {
 		return 0, errors.New("typedcolumn: nil column batch")
 	}
+	declared := make(map[string]struct{}, len(defs))
 	rows := batch.Rows
 	for _, def := range defs {
+		declared[def.Name] = struct{}{}
 		values, ok := batch.Columns[def.Name]
 		if !ok {
 			return 0, fmt.Errorf("typedcolumn: missing column %s", def.Name)
@@ -681,6 +686,11 @@ func validateBatch(batch Batch, defs []ColumnDefinition) (int, error) {
 		}
 		if len(values) != rows {
 			return 0, fmt.Errorf("typedcolumn: column %s rows=%d want=%d", def.Name, len(values), rows)
+		}
+	}
+	for name := range batch.Columns {
+		if _, ok := declared[name]; !ok {
+			return 0, fmt.Errorf("typedcolumn: undeclared column %s", name)
 		}
 	}
 	if rows <= 0 {

--- a/TreeDB/internal/typedcolumn/part_accounting.go
+++ b/TreeDB/internal/typedcolumn/part_accounting.go
@@ -1,0 +1,303 @@
+package typedcolumn
+
+import "sort"
+
+const (
+	columnPartDescriptorBaseBytes = 96
+	granuleDescriptorBytes        = 64
+	columnDescriptorBytes         = 32
+	columnBlockDescriptorBytes    = 64
+	sortKeyColumnDescriptorBytes  = 32
+	sortKeyMarkBaseBytes          = 16
+	sortKeyPrefixBaseBytes        = 16
+	sortKeyBoundInt64Bytes        = 8
+	rowLocatorBytes               = 32
+	dictionaryHeaderBytes         = 32
+	dictionaryEntryOverheadBytes  = 12
+)
+
+type ColumnPartByteAccounting struct {
+	Rows                    int                                    `json:"rows"`
+	Columns                 int                                    `json:"columns"`
+	Granules                int                                    `json:"granules"`
+	CodecBlocks             int                                    `json:"codec_blocks"`
+	PhysicalFiles           int                                    `json:"physical_files"`
+	SerializedImageBytes    int                                    `json:"serialized_image_bytes,omitempty"`
+	SerializedManifestBytes int                                    `json:"serialized_manifest_bytes,omitempty"`
+	SerializedPaddingBytes  int                                    `json:"serialized_padding_bytes,omitempty"`
+	LogicalValueBytes       int                                    `json:"logical_value_bytes"`
+	EncodedRawBytes         int                                    `json:"encoded_raw_bytes"`
+	DeclaredColumnBytes     int                                    `json:"declared_column_bytes"`
+	DictionaryBytes         int                                    `json:"dictionary_bytes"`
+	MarkBytes               int                                    `json:"mark_bytes"`
+	SortKeyMetadataBytes    int                                    `json:"sort_key_metadata_bytes"`
+	AggregateMetadataBytes  int                                    `json:"aggregate_metadata_bytes"`
+	DescriptorBytes         int                                    `json:"descriptor_bytes"`
+	LocatorBytes            int                                    `json:"locator_bytes"`
+	TotalStoredBytes        int                                    `json:"total_stored_bytes"`
+	BytesPerRow             float64                                `json:"bytes_per_row"`
+	RetainedJSONPayload     string                                 `json:"retained_json_payload"`
+	ColumnsDetail           []ColumnPartColumnByteAccounting       `json:"columns_detail"`
+	CompressionDetail       []ColumnPartCompressionByteAccounting  `json:"compression_detail"`
+	SerializedSections      []ColumnPartImageSectionByteAccounting `json:"serialized_sections,omitempty"`
+}
+
+type ColumnPartColumnByteAccounting struct {
+	Column               string         `json:"column"`
+	Type                 ColumnType     `json:"type"`
+	Rows                 int            `json:"rows"`
+	Blocks               int            `json:"blocks"`
+	LogicalValueBytes    int            `json:"logical_value_bytes"`
+	EncodedRawBytes      int            `json:"encoded_raw_bytes"`
+	StoredBytes          int            `json:"stored_bytes"`
+	Encoding             Encoding       `json:"encoding"`
+	RequestedCompression Compression    `json:"requested_compression"`
+	ActualCompressionMix map[string]int `json:"actual_compression_mix"`
+	CompressionAttempted int            `json:"compression_attempted"`
+	CompressionKept      int            `json:"compression_kept"`
+	CompressionRejected  int            `json:"compression_rejected"`
+	FallbackReasons      map[string]int `json:"fallback_reasons,omitempty"`
+	CompressionNanos     int64          `json:"compression_nanos"`
+}
+
+type ColumnPartCompressionByteAccounting struct {
+	Column                 string      `json:"column"`
+	Substream              string      `json:"substream"`
+	Encoding               Encoding    `json:"encoding"`
+	RequestedCompression   Compression `json:"requested_compression"`
+	ActualCompression      Compression `json:"actual_compression"`
+	Blocks                 int         `json:"blocks"`
+	CompressionAttempted   int         `json:"compression_attempted"`
+	CompressionKept        int         `json:"compression_kept"`
+	CompressionRejected    int         `json:"compression_rejected"`
+	FallbackReason         string      `json:"fallback_reason,omitempty"`
+	EncodedRawBytes        int         `json:"encoded_raw_bytes"`
+	StoredBytes            int         `json:"stored_bytes"`
+	CompressionNanos       int64       `json:"compression_nanos"`
+	StoredToEncodedRawRate float64     `json:"stored_to_encoded_raw_rate"`
+}
+
+func (p *ColumnPart) ByteAccounting() ColumnPartByteAccounting {
+	if p == nil {
+		return ColumnPartByteAccounting{}
+	}
+	out := ColumnPartByteAccounting{
+		Rows:                p.Descriptor.RowCount,
+		Granules:            len(p.Descriptor.Granules),
+		PhysicalFiles:       0,
+		RetainedJSONPayload: "absent_declared_columns_only",
+	}
+	compressionByKey := make(map[columnCompressionKey]*ColumnPartCompressionByteAccounting)
+	for _, columnDescriptor := range p.Descriptor.Columns {
+		column, ok := p.Columns[columnDescriptor.Name]
+		if !ok {
+			continue
+		}
+		detail := ColumnPartColumnByteAccounting{
+			Column:               columnDescriptor.Name,
+			Type:                 column.Definition.Type,
+			Encoding:             column.Definition.Encoding,
+			RequestedCompression: column.Definition.Compression,
+			ActualCompressionMix: make(map[string]int),
+			FallbackReasons:      make(map[string]int),
+		}
+		for _, block := range column.Blocks {
+			report := block.Granule.CodecReport
+			out.CodecBlocks++
+			valueBytes := logicalColumnValueBytes(column.Definition.Type, block.Descriptor.RowCount)
+			detail.Rows += block.Descriptor.RowCount
+			detail.Blocks++
+			detail.LogicalValueBytes += valueBytes
+			detail.EncodedRawBytes += block.Descriptor.RawBytes
+			detail.StoredBytes += block.Descriptor.StoredBytes
+			detail.ActualCompressionMix[block.Descriptor.Compression.String()]++
+			if report.CompressionAttempted {
+				detail.CompressionAttempted++
+			}
+			if report.CompressionKept {
+				detail.CompressionKept++
+			}
+			if report.CompressionAttempted && !report.CompressionKept {
+				detail.CompressionRejected++
+			}
+			if report.CompressionFallbackReason != "" {
+				detail.FallbackReasons[report.CompressionFallbackReason]++
+			}
+			detail.CompressionNanos += report.CompressionNanos
+
+			key := columnCompressionKey{
+				column:               columnDescriptor.Name,
+				substream:            "values",
+				encoding:             block.Descriptor.Encoding,
+				requestedCompression: column.Definition.Compression,
+				actualCompression:    block.Descriptor.Compression,
+				fallbackReason:       report.CompressionFallbackReason,
+			}
+			compression := compressionByKey[key]
+			if compression == nil {
+				compression = &ColumnPartCompressionByteAccounting{
+					Column:               key.column,
+					Substream:            key.substream,
+					Encoding:             key.encoding,
+					RequestedCompression: key.requestedCompression,
+					ActualCompression:    key.actualCompression,
+					FallbackReason:       key.fallbackReason,
+				}
+				compressionByKey[key] = compression
+			}
+			compression.Blocks++
+			if report.CompressionAttempted {
+				compression.CompressionAttempted++
+			}
+			if report.CompressionKept {
+				compression.CompressionKept++
+			}
+			if report.CompressionAttempted && !report.CompressionKept {
+				compression.CompressionRejected++
+			}
+			compression.EncodedRawBytes += block.Descriptor.RawBytes
+			compression.StoredBytes += block.Descriptor.StoredBytes
+			compression.CompressionNanos += report.CompressionNanos
+		}
+		if len(detail.FallbackReasons) == 0 {
+			detail.FallbackReasons = nil
+		}
+		out.LogicalValueBytes += detail.LogicalValueBytes
+		out.EncodedRawBytes += detail.EncodedRawBytes
+		out.DeclaredColumnBytes += detail.StoredBytes
+		out.ColumnsDetail = append(out.ColumnsDetail, detail)
+	}
+	out.Columns = len(out.ColumnsDetail)
+	out.MarkBytes = estimateSortKeyMarkBytes(p.Marks)
+	out.SortKeyMetadataBytes = estimateSortKeyMetadataBytes(p.Descriptor.SortKey)
+	out.AggregateMetadataBytes = aggregateMetadataStoredBytes(p.AggregateMetadata)
+	out.DescriptorBytes = estimateColumnPartDescriptorBytes(p.Descriptor)
+	out.LocatorBytes = len(p.Locators) * rowLocatorBytes
+	for _, compression := range compressionByKey {
+		if compression.EncodedRawBytes > 0 {
+			compression.StoredToEncodedRawRate = float64(compression.StoredBytes) / float64(compression.EncodedRawBytes)
+		}
+		out.CompressionDetail = append(out.CompressionDetail, *compression)
+	}
+	sort.Slice(out.CompressionDetail, func(i, j int) bool {
+		left := out.CompressionDetail[i]
+		right := out.CompressionDetail[j]
+		if left.Column != right.Column {
+			return left.Column < right.Column
+		}
+		if left.Substream != right.Substream {
+			return left.Substream < right.Substream
+		}
+		if left.Encoding != right.Encoding {
+			return left.Encoding < right.Encoding
+		}
+		if left.RequestedCompression != right.RequestedCompression {
+			return left.RequestedCompression < right.RequestedCompression
+		}
+		if left.ActualCompression != right.ActualCompression {
+			return left.ActualCompression < right.ActualCompression
+		}
+		return left.FallbackReason < right.FallbackReason
+	})
+	out.RecomputeTotals()
+	return out
+}
+
+func (p *ColumnPart) ByteAccountingFromImage(image ColumnPartImage) ColumnPartByteAccounting {
+	out := p.ByteAccounting()
+	if image.TotalBytes() == 0 {
+		return out
+	}
+	out.PhysicalFiles = 0
+	out.SerializedImageBytes = image.TotalBytes()
+	out.SerializedManifestBytes = image.ManifestBytes
+	out.SerializedPaddingBytes = image.PaddingBytes()
+	out.DeclaredColumnBytes = image.CategoryBytes(ColumnPartImageCategoryDeclaredColumns)
+	out.DictionaryBytes = image.CategoryBytes(ColumnPartImageCategoryDictionaries)
+	out.MarkBytes = image.CategoryBytes(ColumnPartImageCategoryMarks)
+	out.SortKeyMetadataBytes = image.CategoryBytes(ColumnPartImageCategorySortKeyMetadata)
+	out.AggregateMetadataBytes = image.CategoryBytes(ColumnPartImageCategoryAggregateMetadata)
+	out.DescriptorBytes = image.CategoryBytes(ColumnPartImageCategoryDescriptor)
+	out.LocatorBytes = image.CategoryBytes(ColumnPartImageCategoryLocators)
+	out.SerializedSections = image.SectionByteAccounting()
+	out.RecomputeTotals()
+	return out
+}
+
+func (a *ColumnPartByteAccounting) RecomputeTotals() {
+	a.TotalStoredBytes = a.CategoryBytes()
+	if a.Rows > 0 {
+		a.BytesPerRow = float64(a.TotalStoredBytes) / float64(a.Rows)
+	} else {
+		a.BytesPerRow = 0
+	}
+}
+
+func (a ColumnPartByteAccounting) CategoryBytes() int {
+	return a.SerializedManifestBytes +
+		a.SerializedPaddingBytes +
+		a.DeclaredColumnBytes +
+		a.DictionaryBytes +
+		a.MarkBytes +
+		a.SortKeyMetadataBytes +
+		a.AggregateMetadataBytes +
+		a.DescriptorBytes +
+		a.LocatorBytes
+}
+
+func logicalColumnValueBytes(columnType ColumnType, rows int) int {
+	switch columnType {
+	case ColumnTypeBool:
+		return rows
+	case ColumnTypeLowCardinalityCode:
+		return rows * 4
+	default:
+		return rows * 8
+	}
+}
+
+func estimateColumnPartDescriptorBytes(desc ColumnPartDescriptor) int {
+	total := columnPartDescriptorBaseBytes
+	total += len(desc.Granules) * granuleDescriptorBytes
+	for _, column := range desc.Columns {
+		total += columnDescriptorBytes
+		total += len(column.Blocks) * columnBlockDescriptorBytes
+	}
+	return total
+}
+
+func estimateSortKeyMetadataBytes(columns []SortKeyColumn) int {
+	return len(columns) * sortKeyColumnDescriptorBytes
+}
+
+func estimateSortKeyMarkBytes(marks []SortKeyMark) int {
+	total := 0
+	for _, mark := range marks {
+		total += sortKeyMarkBaseBytes
+		for _, prefix := range mark.Prefixes {
+			total += sortKeyPrefixBaseBytes
+			total += len(prefix.Lower.Values) * sortKeyBoundInt64Bytes
+			total += len(prefix.UpperExclusive.Values) * sortKeyBoundInt64Bytes
+		}
+	}
+	return total
+}
+
+func aggregateMetadataStoredBytes(metadata map[string]AggregateMetadata) int {
+	total := 0
+	for _, m := range metadata {
+		if m.Stats.Admitted {
+			total += m.Stats.TotalBytes
+		}
+	}
+	return total
+}
+
+type columnCompressionKey struct {
+	column               string
+	substream            string
+	encoding             Encoding
+	requestedCompression Compression
+	actualCompression    Compression
+	fallbackReason       string
+}

--- a/TreeDB/internal/typedcolumn/part_image.go
+++ b/TreeDB/internal/typedcolumn/part_image.go
@@ -518,6 +518,9 @@ func (b *columnPartImageBuilder) addSortKeyMarksSection() error {
 }
 
 func (b *columnPartImageBuilder) addRowLocatorsSection() error {
+	if err := validateDecodedRowLocators(b.part.Descriptor, b.part.Descriptor.PartID, b.part.Locators); err != nil {
+		return err
+	}
 	primaryIDs := make([]int64, 0, len(b.part.Locators))
 	for primaryID := range b.part.Locators {
 		primaryIDs = append(primaryIDs, primaryID)
@@ -538,7 +541,7 @@ func (b *columnPartImageBuilder) addRowLocatorsSection() error {
 	enc.u32(uint32(len(primaryIDs)))
 	for _, primaryID := range primaryIDs {
 		locator := b.part.Locators[primaryID]
-		enc.i64(locator.PrimaryID)
+		enc.i64(primaryID)
 		enc.u64(locator.PartID)
 		enc.u32(uint32(locator.PartRow))
 		enc.u32(uint32(locator.GranuleOrdinal))

--- a/TreeDB/internal/typedcolumn/part_image.go
+++ b/TreeDB/internal/typedcolumn/part_image.go
@@ -1,0 +1,922 @@
+package typedcolumn
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math"
+	"reflect"
+	"sort"
+	"time"
+)
+
+const columnPartImageVersion uint16 = 1
+
+const columnPartImageMagic uint32 = 0x4d494354 // "TCIM", little-endian on disk.
+
+const columnPartImageSectionAlignment = 8
+
+type ColumnPartImageSectionKind string
+
+const (
+	ColumnPartImageSectionManifest          ColumnPartImageSectionKind = "manifest"
+	ColumnPartImageSectionDescriptor        ColumnPartImageSectionKind = "descriptor"
+	ColumnPartImageSectionSortKeyMetadata   ColumnPartImageSectionKind = "sort_key_metadata"
+	ColumnPartImageSectionSortKeyMarks      ColumnPartImageSectionKind = "sort_key_marks"
+	ColumnPartImageSectionRowLocators       ColumnPartImageSectionKind = "row_locators"
+	ColumnPartImageSectionAggregateMetadata ColumnPartImageSectionKind = "aggregate_metadata"
+	ColumnPartImageSectionDictionaries      ColumnPartImageSectionKind = "dictionaries"
+	ColumnPartImageSectionColumnData        ColumnPartImageSectionKind = "column_data"
+	ColumnPartImageSectionPadding           ColumnPartImageSectionKind = "padding"
+)
+
+type ColumnPartImageSectionCategory string
+
+const (
+	ColumnPartImageCategoryManifest          ColumnPartImageSectionCategory = "manifest"
+	ColumnPartImageCategoryDescriptor        ColumnPartImageSectionCategory = "descriptor"
+	ColumnPartImageCategorySortKeyMetadata   ColumnPartImageSectionCategory = "sort_key_metadata"
+	ColumnPartImageCategoryMarks             ColumnPartImageSectionCategory = "marks"
+	ColumnPartImageCategoryLocators          ColumnPartImageSectionCategory = "locators"
+	ColumnPartImageCategoryAggregateMetadata ColumnPartImageSectionCategory = "aggregate_metadata"
+	ColumnPartImageCategoryDictionaries      ColumnPartImageSectionCategory = "dictionaries"
+	ColumnPartImageCategoryDeclaredColumns   ColumnPartImageSectionCategory = "declared_columns"
+	ColumnPartImageCategoryPadding           ColumnPartImageSectionCategory = "padding"
+)
+
+type ColumnPartImageOptions struct {
+	Dictionaries map[string]map[string]int64
+}
+
+type ColumnPartImage struct {
+	Version       uint16                   `json:"version"`
+	PartID        uint64                   `json:"part_id"`
+	Rows          int                      `json:"rows"`
+	ManifestBytes int                      `json:"manifest_bytes"`
+	Sections      []ColumnPartImageSection `json:"sections"`
+	Bytes         []byte                   `json:"-"`
+}
+
+type ColumnPartImageSection struct {
+	Kind        ColumnPartImageSectionKind     `json:"kind"`
+	Category    ColumnPartImageSectionCategory `json:"category"`
+	Name        string                         `json:"name,omitempty"`
+	Column      string                         `json:"column,omitempty"`
+	Offset      int                            `json:"offset"`
+	Length      int                            `json:"length"`
+	Rows        int                            `json:"rows,omitempty"`
+	Granules    int                            `json:"granules,omitempty"`
+	Blocks      int                            `json:"blocks,omitempty"`
+	Encoding    Encoding                       `json:"encoding,omitempty"`
+	Compression Compression                    `json:"compression,omitempty"`
+}
+
+type ColumnPartImageSectionByteAccounting struct {
+	Kind     ColumnPartImageSectionKind     `json:"kind"`
+	Category ColumnPartImageSectionCategory `json:"category"`
+	Name     string                         `json:"name,omitempty"`
+	Column   string                         `json:"column,omitempty"`
+	Bytes    int                            `json:"bytes"`
+}
+
+func BuildColumnPartImage(part *ColumnPart, opts ColumnPartImageOptions) (ColumnPartImage, error) {
+	if part == nil {
+		return ColumnPartImage{}, fmt.Errorf("typedcolumn: nil part")
+	}
+	builder := columnPartImageBuilder{part: part, opts: opts}
+	return builder.build()
+}
+
+func (p *ColumnPart) WithImagePayloads(image ColumnPartImage) (*ColumnPart, error) {
+	if p == nil {
+		return nil, fmt.Errorf("typedcolumn: nil part")
+	}
+	if image.TotalBytes() == 0 {
+		return nil, fmt.Errorf("typedcolumn: empty part image")
+	}
+	if err := image.validateForRead(); err != nil {
+		return nil, err
+	}
+	if image.PartID != p.Descriptor.PartID {
+		return nil, fmt.Errorf("typedcolumn: image part id=%d does not match part id=%d", image.PartID, p.Descriptor.PartID)
+	}
+	if image.Rows != p.Descriptor.RowCount {
+		return nil, fmt.Errorf("typedcolumn: image rows=%d does not match part rows=%d", image.Rows, p.Descriptor.RowCount)
+	}
+	if err := validateImageDescriptorMatchesPart(image, p); err != nil {
+		return nil, err
+	}
+	out := *p
+	out.Columns = make(map[string]ColumnPartColumn, len(p.Columns))
+	for name, column := range p.Columns {
+		outColumn := column
+		outColumn.Blocks = append([]ColumnBlock(nil), column.Blocks...)
+		out.Columns[name] = outColumn
+	}
+	if err := attachColumnPayloadsFromImage(image, out.Columns); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (i ColumnPartImage) TotalBytes() int {
+	return len(i.Bytes)
+}
+
+func (i ColumnPartImage) CategoryBytes(category ColumnPartImageSectionCategory) int {
+	switch category {
+	case ColumnPartImageCategoryManifest:
+		return i.ManifestBytes
+	case ColumnPartImageCategoryPadding:
+		return i.PaddingBytes()
+	}
+	total := 0
+	for _, section := range i.Sections {
+		if section.Category == category {
+			total += section.Length
+		}
+	}
+	return total
+}
+
+func (i ColumnPartImage) PaddingBytes() int {
+	cursor := i.ManifestBytes
+	padding := 0
+	for _, section := range i.Sections {
+		if section.Offset > cursor {
+			padding += section.Offset - cursor
+		}
+		if end := section.Offset + section.Length; end > cursor {
+			cursor = end
+		}
+	}
+	if len(i.Bytes) > cursor {
+		padding += len(i.Bytes) - cursor
+	}
+	return padding
+}
+
+func (i ColumnPartImage) SectionByteAccounting() []ColumnPartImageSectionByteAccounting {
+	out := make([]ColumnPartImageSectionByteAccounting, 0, len(i.Sections)+1)
+	if i.ManifestBytes > 0 {
+		out = append(out, ColumnPartImageSectionByteAccounting{
+			Kind:     ColumnPartImageSectionManifest,
+			Category: ColumnPartImageCategoryManifest,
+			Bytes:    i.ManifestBytes,
+		})
+	}
+	if padding := i.PaddingBytes(); padding > 0 {
+		out = append(out, ColumnPartImageSectionByteAccounting{
+			Kind:     ColumnPartImageSectionPadding,
+			Category: ColumnPartImageCategoryPadding,
+			Bytes:    padding,
+		})
+	}
+	for _, section := range i.Sections {
+		out = append(out, ColumnPartImageSectionByteAccounting{
+			Kind:     section.Kind,
+			Category: section.Category,
+			Name:     section.Name,
+			Column:   section.Column,
+			Bytes:    section.Length,
+		})
+	}
+	return out
+}
+
+func (i ColumnPartImage) columnDataSection(column string) (ColumnPartImageSection, bool) {
+	for _, section := range i.Sections {
+		if section.Kind == ColumnPartImageSectionColumnData && section.Column == column {
+			return section, true
+		}
+	}
+	return ColumnPartImageSection{}, false
+}
+
+func validateImageDescriptorMatchesPart(image ColumnPartImage, part *ColumnPart) error {
+	descriptorSection, err := image.singleSection(ColumnPartImageSectionDescriptor)
+	if err != nil {
+		return err
+	}
+	imageDesc, imageColumns, err := decodeColumnPartDescriptorSection(image.sectionBytes(descriptorSection))
+	if err != nil {
+		return err
+	}
+	partDesc := part.Descriptor
+	imageDesc.SortKey = nil
+	partDesc.SortKey = nil
+	if !reflect.DeepEqual(imageDesc, partDesc) {
+		return fmt.Errorf("typedcolumn: image descriptor does not match part descriptor")
+	}
+	sortKey, err := decodeSortKeyMetadataSection(image)
+	if err != nil {
+		return err
+	}
+	if !reflect.DeepEqual(sortKey, part.Descriptor.SortKey) {
+		return fmt.Errorf("typedcolumn: image sort key does not match part sort key")
+	}
+	if len(imageColumns) != len(part.Columns) {
+		return fmt.Errorf("typedcolumn: image has %d columns, part has %d", len(imageColumns), len(part.Columns))
+	}
+	for name, imageColumn := range imageColumns {
+		partColumn, ok := part.Columns[name]
+		if !ok {
+			return fmt.Errorf("typedcolumn: image descriptor has unknown column %s", name)
+		}
+		partDefinition, err := comparablePartColumnDefinitionForImage(imageColumn.Definition, partColumn)
+		if err != nil {
+			return err
+		}
+		if comparableColumnDefinition(imageColumn.Definition) != partDefinition {
+			return fmt.Errorf("typedcolumn: image descriptor column %s definition does not match part", name)
+		}
+		if len(imageColumn.Blocks) != len(partColumn.Blocks) {
+			return fmt.Errorf("typedcolumn: image descriptor column %s blocks=%d part blocks=%d", name, len(imageColumn.Blocks), len(partColumn.Blocks))
+		}
+		for i := range imageColumn.Blocks {
+			if imageColumn.Blocks[i].Descriptor != partColumn.Blocks[i].Descriptor {
+				return fmt.Errorf("typedcolumn: image descriptor column %s block %d descriptor does not match part", name, i)
+			}
+			if comparableGranuleMetadata(imageColumn.Blocks[i].Granule) != comparableGranuleMetadata(partColumn.Blocks[i].Granule) {
+				return fmt.Errorf("typedcolumn: image descriptor column %s block %d granule metadata does not match part", name, i)
+			}
+		}
+	}
+	return nil
+}
+
+func comparablePartColumnDefinitionForImage(imageDefinition ColumnDefinition, partColumn ColumnPartColumn) (ColumnDefinition, error) {
+	definition := comparableColumnDefinition(partColumn.Definition)
+	if imageDefinition.Type != ColumnTypeLowCardinalityCode || definition.Cardinality != 0 {
+		return definition, nil
+	}
+	cardinality, err := imageColumnCardinalityForDescriptor(ColumnPartColumnDescriptor{
+		Name: imageDefinition.Name,
+		Type: imageDefinition.Type,
+	}, partColumn)
+	if err != nil {
+		return ColumnDefinition{}, err
+	}
+	definition.Cardinality = cardinality
+	return definition, nil
+}
+
+func comparableColumnDefinition(def ColumnDefinition) ColumnDefinition {
+	def.CodecBlockRows = 0
+	def.Compression = 0
+	return def
+}
+
+type comparableEncodedGranuleMetadata struct {
+	Rows         int
+	NullCount    int
+	DefaultCount int
+	HasMinMax    bool
+	Min          int64
+	Max          int64
+	Encoding     Encoding
+	Compression  Compression
+	RawBytes     int
+	StoredBytes  int
+}
+
+func comparableGranuleMetadata(granule EncodedGranule) comparableEncodedGranuleMetadata {
+	return comparableEncodedGranuleMetadata{
+		Rows:         granule.Rows,
+		NullCount:    granule.NullCount,
+		DefaultCount: granule.DefaultCount,
+		HasMinMax:    granule.HasMinMax,
+		Min:          granule.Min,
+		Max:          granule.Max,
+		Encoding:     granule.Encoding,
+		Compression:  granule.Compression,
+		RawBytes:     granule.RawBytes,
+		StoredBytes:  granule.StoredBytes,
+	}
+}
+
+type columnPartImageBuilder struct {
+	part     *ColumnPart
+	opts     ColumnPartImageOptions
+	sections []columnPartImageSectionData
+}
+
+type columnPartImageSectionData struct {
+	section ColumnPartImageSection
+	data    []byte
+}
+
+func (b *columnPartImageBuilder) build() (ColumnPartImage, error) {
+	if err := b.addDescriptorSection(); err != nil {
+		return ColumnPartImage{}, err
+	}
+	if err := b.addSortKeyMetadataSection(); err != nil {
+		return ColumnPartImage{}, err
+	}
+	if err := b.addSortKeyMarksSection(); err != nil {
+		return ColumnPartImage{}, err
+	}
+	if err := b.addRowLocatorsSection(); err != nil {
+		return ColumnPartImage{}, err
+	}
+	if err := b.addAggregateMetadataSections(); err != nil {
+		return ColumnPartImage{}, err
+	}
+	if err := b.addDictionarySection(); err != nil {
+		return ColumnPartImage{}, err
+	}
+	if err := b.addColumnDataSections(); err != nil {
+		return ColumnPartImage{}, err
+	}
+
+	sections, manifest, err := b.layoutManifestAndSections()
+	if err != nil {
+		return ColumnPartImage{}, err
+	}
+	out := make([]byte, 0, len(manifest)+sumImageSectionDataBytes(b.sections))
+	out = append(out, manifest...)
+	for _, section := range b.sections {
+		if section.section.Offset < len(out) {
+			return ColumnPartImage{}, fmt.Errorf("typedcolumn: section %s offset=%d overlaps image bytes=%d", section.section.Kind, section.section.Offset, len(out))
+		}
+		out = append(out, make([]byte, section.section.Offset-len(out))...)
+		out = append(out, section.data...)
+	}
+	return ColumnPartImage{
+		Version:       columnPartImageVersion,
+		PartID:        b.part.Descriptor.PartID,
+		Rows:          b.part.Descriptor.RowCount,
+		ManifestBytes: len(manifest),
+		Sections:      sections,
+		Bytes:         out,
+	}, nil
+}
+
+func (b *columnPartImageBuilder) layoutManifestAndSections() ([]ColumnPartImageSection, []byte, error) {
+	sections := make([]ColumnPartImageSection, len(b.sections))
+	for i := range b.sections {
+		sections[i] = b.sections[i].section
+	}
+	manifestBytes := 0
+	for attempt := 0; attempt < 8; attempt++ {
+		manifest, err := encodeColumnPartImageManifest(b.part, sections, manifestBytes)
+		if err != nil {
+			return nil, nil, err
+		}
+		offset := alignColumnPartImageOffset(len(manifest))
+		for i := range b.sections {
+			offset = alignColumnPartImageOffset(offset)
+			b.sections[i].section.Offset = offset
+			b.sections[i].section.Length = len(b.sections[i].data)
+			sections[i] = b.sections[i].section
+			offset += len(b.sections[i].data)
+		}
+		finalManifest, err := encodeColumnPartImageManifest(b.part, sections, len(manifest))
+		if err != nil {
+			return nil, nil, err
+		}
+		if len(finalManifest) == len(manifest) {
+			return sections, finalManifest, nil
+		}
+		manifestBytes = len(finalManifest)
+	}
+	return nil, nil, fmt.Errorf("typedcolumn: part image manifest length did not stabilize")
+}
+
+func (b *columnPartImageBuilder) addDescriptorSection() error {
+	var enc columnPartImageEncoder
+	desc := b.part.Descriptor
+	enc.u16(uint16(desc.Version))
+	enc.u64(desc.PartID)
+	enc.u32(desc.SchemaVersion)
+	enc.i64(int64(desc.RowCount))
+	enc.i64(int64(desc.VisibleRowCount))
+	enc.stringSlice(desc.LogicalPrimaryKey)
+	enc.u32(uint32(len(desc.Granules)))
+	for _, granule := range desc.Granules {
+		enc.i64(int64(granule.Ordinal))
+		enc.i64(int64(granule.FirstRow))
+		enc.i64(int64(granule.RowCount))
+		enc.i64(int64(granule.VisibleRows))
+		enc.i64(int64(granule.DeletedRows))
+		enc.i64(granule.IDLower)
+		enc.i64(granule.IDUpperExclusive)
+		enc.i64(int64(granule.MarkOrdinal))
+	}
+	enc.u32(uint32(len(desc.Columns)))
+	for _, column := range desc.Columns {
+		partColumn, ok := b.part.Columns[column.Name]
+		if !ok {
+			return fmt.Errorf("typedcolumn: missing column %s", column.Name)
+		}
+		enc.str(column.Name)
+		columnType, err := columnTypeCode(column.Type)
+		if err != nil {
+			return err
+		}
+		enc.u16(columnType)
+		cardinality, err := imageColumnCardinalityForDescriptor(column, partColumn)
+		if err != nil {
+			return err
+		}
+		enc.u32(cardinality)
+		enc.u32(uint32(len(column.Blocks)))
+		for i, block := range column.Blocks {
+			if i >= len(partColumn.Blocks) {
+				return fmt.Errorf("typedcolumn: descriptor column %s block %d missing payload block", column.Name, i)
+			}
+			granule := partColumn.Blocks[i].Granule
+			enc.i64(int64(block.FirstRow))
+			enc.i64(int64(block.RowCount))
+			enc.i64(int64(block.FirstGranule))
+			enc.i64(int64(block.LastGranule))
+			enc.u16(uint16(block.Encoding))
+			enc.u16(uint16(block.Compression))
+			enc.i64(int64(block.RawBytes))
+			enc.i64(int64(block.StoredBytes))
+			enc.i64(int64(block.CodecBlockOrdinal))
+			enc.i64(int64(granule.NullCount))
+			enc.i64(int64(granule.DefaultCount))
+			enc.boolean(granule.HasMinMax)
+			enc.i64(granule.Min)
+			enc.i64(granule.Max)
+		}
+	}
+	b.appendSection(ColumnPartImageSection{
+		Kind:     ColumnPartImageSectionDescriptor,
+		Category: ColumnPartImageCategoryDescriptor,
+		Name:     "part_descriptor",
+		Rows:     desc.RowCount,
+		Granules: len(desc.Granules),
+		Blocks:   countColumnBlocks(desc),
+	}, enc.bytes())
+	return nil
+}
+
+func imageColumnCardinalityForDescriptor(column ColumnPartColumnDescriptor, partColumn ColumnPartColumn) (uint32, error) {
+	cardinality := partColumn.Definition.Cardinality
+	if column.Type != ColumnTypeLowCardinalityCode {
+		return cardinality, nil
+	}
+	for i, block := range partColumn.Blocks {
+		if !block.Granule.HasMinMax {
+			continue
+		}
+		if block.Granule.Min < 0 || block.Granule.Max < 0 {
+			return 0, fmt.Errorf("typedcolumn: descriptor column %s block %d has negative low-cardinality min/max", column.Name, i)
+		}
+		needed := uint64(block.Granule.Max) + 1
+		if needed > maxCodeCardinality {
+			return 0, fmt.Errorf("typedcolumn: descriptor column %s block %d inferred cardinality %d exceeds cap %d", column.Name, i, needed, maxCodeCardinality)
+		}
+		if uint32(needed) > cardinality {
+			cardinality = uint32(needed)
+		}
+	}
+	if cardinality == 0 {
+		return 0, fmt.Errorf("typedcolumn: descriptor column %s has zero low-cardinality cardinality", column.Name)
+	}
+	return cardinality, nil
+}
+
+func (b *columnPartImageBuilder) addSortKeyMetadataSection() error {
+	var enc columnPartImageEncoder
+	enc.u32(uint32(len(b.part.Descriptor.SortKey)))
+	for _, column := range b.part.Descriptor.SortKey {
+		enc.str(column.Column)
+		enc.str(string(column.Direction))
+		enc.str(string(column.Nulls))
+	}
+	b.appendSection(ColumnPartImageSection{
+		Kind:     ColumnPartImageSectionSortKeyMetadata,
+		Category: ColumnPartImageCategorySortKeyMetadata,
+		Name:     "sort_key",
+	}, enc.bytes())
+	return nil
+}
+
+func (b *columnPartImageBuilder) addSortKeyMarksSection() error {
+	var enc columnPartImageEncoder
+	enc.u32(uint32(len(b.part.Marks)))
+	for _, mark := range b.part.Marks {
+		enc.i64(int64(mark.Rows))
+		enc.stringSlice(mark.Columns)
+		enc.u32(uint32(len(mark.Prefixes)))
+		for _, prefix := range mark.Prefixes {
+			enc.stringSlice(prefix.Columns)
+			encodeSortKeyBound(&enc, prefix.Lower)
+			encodeSortKeyBound(&enc, prefix.UpperExclusive)
+		}
+	}
+	b.appendSection(ColumnPartImageSection{
+		Kind:     ColumnPartImageSectionSortKeyMarks,
+		Category: ColumnPartImageCategoryMarks,
+		Name:     "sort_key_marks",
+		Rows:     b.part.Descriptor.RowCount,
+		Granules: len(b.part.Marks),
+	}, enc.bytes())
+	return nil
+}
+
+func (b *columnPartImageBuilder) addRowLocatorsSection() error {
+	primaryIDs := make([]int64, 0, len(b.part.Locators))
+	for primaryID := range b.part.Locators {
+		primaryIDs = append(primaryIDs, primaryID)
+	}
+	sort.Slice(primaryIDs, func(i, j int) bool { return primaryIDs[i] < primaryIDs[j] })
+	if uint64(len(primaryIDs)) > uint64(^uint32(0)) {
+		return fmt.Errorf("typedcolumn: row locator count=%d exceeds uint32", len(primaryIDs))
+	}
+	recordBytes, err := checkedMulInt(len(primaryIDs), rowLocatorBytes, "row locator section bytes")
+	if err != nil {
+		return err
+	}
+	payloadBytes, err := checkedAddInt(4, recordBytes, "row locator section bytes")
+	if err != nil {
+		return err
+	}
+	enc := columnPartImageEncoder{buf: make([]byte, 0, payloadBytes)}
+	enc.u32(uint32(len(primaryIDs)))
+	for _, primaryID := range primaryIDs {
+		locator := b.part.Locators[primaryID]
+		enc.i64(locator.PrimaryID)
+		enc.u64(locator.PartID)
+		enc.u32(uint32(locator.PartRow))
+		enc.u32(uint32(locator.GranuleOrdinal))
+		enc.u32(uint32(locator.RowInGranule))
+		enc.u32(0)
+	}
+	b.appendSection(ColumnPartImageSection{
+		Kind:     ColumnPartImageSectionRowLocators,
+		Category: ColumnPartImageCategoryLocators,
+		Name:     "primary_id_locators",
+		Rows:     len(primaryIDs),
+	}, enc.bytes())
+	return nil
+}
+
+func (b *columnPartImageBuilder) addAggregateMetadataSections() error {
+	if len(b.part.AggregateMetadata) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(b.part.AggregateMetadata))
+	for name := range b.part.AggregateMetadata {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		metadata := b.part.AggregateMetadata[name]
+		var enc columnPartImageEncoder
+		if err := encodeAggregateMetadataDefinition(&enc, metadata.Definition); err != nil {
+			return err
+		}
+		if err := encodeAggregateMetadataStats(&enc, metadata.Stats); err != nil {
+			return err
+		}
+		enc.u32(uint32(len(metadata.Granules)))
+		for _, granule := range metadata.Granules {
+			enc.i64(int64(granule.GranuleOrdinal))
+			enc.i64(int64(granule.FirstRow))
+			enc.i64(int64(granule.RowCount))
+			enc.i64(int64(granule.MatchedRows))
+			enc.u32(uint32(len(granule.Entries)))
+			for _, entry := range granule.Entries {
+				enc.u32(entry.Group)
+				enc.u32(entry.Count)
+				enc.i64(entry.Min)
+				enc.i64(entry.Max)
+			}
+		}
+		b.appendSection(ColumnPartImageSection{
+			Kind:     ColumnPartImageSectionAggregateMetadata,
+			Category: ColumnPartImageCategoryAggregateMetadata,
+			Name:     name,
+			Rows:     metadata.Stats.RowsMatched,
+			Granules: metadata.Stats.Granules,
+			Blocks:   metadata.Stats.Entries,
+		}, enc.bytes())
+	}
+	return nil
+}
+
+func (b *columnPartImageBuilder) addDictionarySection() error {
+	if len(b.opts.Dictionaries) == 0 {
+		return nil
+	}
+	var enc columnPartImageEncoder
+	names := make([]string, 0, len(b.opts.Dictionaries))
+	for name := range b.opts.Dictionaries {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	enc.u32(uint32(len(names)))
+	for _, name := range names {
+		values := b.opts.Dictionaries[name]
+		entries := make([]dictionaryImageEntry, 0, len(values))
+		for value, code := range values {
+			entries = append(entries, dictionaryImageEntry{Value: value, Code: code})
+		}
+		sort.Slice(entries, func(i, j int) bool {
+			if entries[i].Code != entries[j].Code {
+				return entries[i].Code < entries[j].Code
+			}
+			return entries[i].Value < entries[j].Value
+		})
+		enc.str(name)
+		enc.u32(uint32(len(entries)))
+		for _, entry := range entries {
+			enc.i64(entry.Code)
+			enc.str(entry.Value)
+		}
+	}
+	b.appendSection(ColumnPartImageSection{
+		Kind:     ColumnPartImageSectionDictionaries,
+		Category: ColumnPartImageCategoryDictionaries,
+		Name:     "part_dictionaries",
+	}, enc.bytes())
+	return nil
+}
+
+func (b *columnPartImageBuilder) addColumnDataSections() error {
+	for _, columnDescriptor := range b.part.Descriptor.Columns {
+		column, ok := b.part.Columns[columnDescriptor.Name]
+		if !ok {
+			return fmt.Errorf("typedcolumn: missing column %s", columnDescriptor.Name)
+		}
+		totalPayloadBytes := 0
+		for i, block := range column.Blocks {
+			if len(block.Granule.Payload) != block.Descriptor.StoredBytes {
+				return fmt.Errorf("typedcolumn: column %s block %d payload bytes=%d descriptor stored bytes=%d", columnDescriptor.Name, i, len(block.Granule.Payload), block.Descriptor.StoredBytes)
+			}
+			totalPayloadBytes += block.Descriptor.StoredBytes
+		}
+		data := make([]byte, 0, totalPayloadBytes)
+		for _, block := range column.Blocks {
+			data = append(data, block.Granule.Payload...)
+		}
+		b.appendSection(ColumnPartImageSection{
+			Kind:        ColumnPartImageSectionColumnData,
+			Category:    ColumnPartImageCategoryDeclaredColumns,
+			Column:      columnDescriptor.Name,
+			Rows:        b.part.Descriptor.RowCount,
+			Granules:    len(b.part.Descriptor.Granules),
+			Blocks:      len(column.Blocks),
+			Encoding:    column.Definition.Encoding,
+			Compression: column.Definition.Compression,
+		}, data)
+	}
+	return nil
+}
+
+func (b *columnPartImageBuilder) appendSection(section ColumnPartImageSection, data []byte) {
+	section.Length = len(data)
+	b.sections = append(b.sections, columnPartImageSectionData{
+		section: section,
+		data:    data,
+	})
+}
+
+type dictionaryImageEntry struct {
+	Value string
+	Code  int64
+}
+
+type columnPartImageEncoder struct {
+	buf []byte
+}
+
+func (e *columnPartImageEncoder) bytes() []byte {
+	return e.buf
+}
+
+func (e *columnPartImageEncoder) u16(v uint16) {
+	e.buf = binary.LittleEndian.AppendUint16(e.buf, v)
+}
+
+func (e *columnPartImageEncoder) u32(v uint32) {
+	e.buf = binary.LittleEndian.AppendUint32(e.buf, v)
+}
+
+func (e *columnPartImageEncoder) u64(v uint64) {
+	e.buf = binary.LittleEndian.AppendUint64(e.buf, v)
+}
+
+func (e *columnPartImageEncoder) i64(v int64) {
+	e.u64(uint64(v))
+}
+
+func (e *columnPartImageEncoder) boolean(v bool) {
+	if v {
+		e.u16(1)
+		return
+	}
+	e.u16(0)
+}
+
+func (e *columnPartImageEncoder) str(v string) {
+	e.u32(uint32(len(v)))
+	e.buf = append(e.buf, v...)
+}
+
+func (e *columnPartImageEncoder) stringSlice(values []string) {
+	e.u32(uint32(len(values)))
+	for _, value := range values {
+		e.str(value)
+	}
+}
+
+func encodeColumnPartImageManifest(part *ColumnPart, sections []ColumnPartImageSection, manifestBytes int) ([]byte, error) {
+	var enc columnPartImageEncoder
+	enc.u32(columnPartImageMagic)
+	enc.u16(columnPartImageVersion)
+	enc.u16(0)
+	enc.u64(part.Descriptor.PartID)
+	enc.i64(int64(part.Descriptor.RowCount))
+	enc.u32(uint32(manifestBytes))
+	enc.u32(uint32(len(sections)))
+	for _, section := range sections {
+		kindCode, err := columnPartImageSectionKindCode(section.Kind)
+		if err != nil {
+			return nil, err
+		}
+		categoryCode, err := columnPartImageSectionCategoryCode(section.Category)
+		if err != nil {
+			return nil, err
+		}
+		enc.u16(kindCode)
+		enc.u16(categoryCode)
+		enc.u64(uint64(section.Offset))
+		enc.u64(uint64(section.Length))
+		enc.i64(int64(section.Rows))
+		enc.i64(int64(section.Granules))
+		enc.i64(int64(section.Blocks))
+		enc.u16(uint16(section.Encoding))
+		enc.u16(uint16(section.Compression))
+		enc.str(section.Name)
+		enc.str(section.Column)
+	}
+	return enc.bytes(), nil
+}
+
+func encodeSortKeyBound(enc *columnPartImageEncoder, bound SortKeyBound) {
+	enc.boolean(bound.Exclusive)
+	enc.boolean(bound.Unbounded)
+	enc.u32(uint32(len(bound.Values)))
+	for _, value := range bound.Values {
+		enc.i64(value)
+	}
+}
+
+func encodeAggregateMetadataDefinition(enc *columnPartImageEncoder, def AggregateMetadataDefinition) error {
+	enc.str(def.Name)
+	enc.u16(def.Version)
+	enc.str(string(def.Kind))
+	enc.str(string(def.Scope))
+	enc.stringSlice(def.GroupKeys)
+	enc.u32(uint32(len(def.Measures)))
+	for _, measure := range def.Measures {
+		enc.str(string(measure.Op))
+		enc.str(measure.Column)
+	}
+	enc.u32(uint32(len(def.Predicates)))
+	for _, predicate := range def.Predicates {
+		enc.str(predicate.Column)
+		enc.str(string(predicate.Op))
+		enc.i64(predicate.Value)
+	}
+	if err := encodeNonNegativeScaledFloat(enc, fmt.Sprintf("aggregate metadata %s max bytes per row", def.Name), def.MaxBytesPerRow); err != nil {
+		return err
+	}
+	return nil
+}
+
+func encodeAggregateMetadataStats(enc *columnPartImageEncoder, stats AggregateMetadataStats) error {
+	enc.boolean(stats.Admitted)
+	enc.str(stats.RejectedReason)
+	enc.i64(durationNanos(stats.BuildDuration))
+	enc.i64(int64(stats.Granules))
+	enc.i64(int64(stats.GranulesWithRows))
+	enc.i64(int64(stats.RowsMatched))
+	enc.i64(int64(stats.Entries))
+	enc.i64(int64(stats.ValueBytes))
+	enc.i64(int64(stats.DescriptorBytes))
+	enc.i64(int64(stats.TotalBytes))
+	if err := encodeNonNegativeScaledFloat(enc, "aggregate metadata bytes per part row", stats.BytesPerPartRow); err != nil {
+		return err
+	}
+	if err := encodeNonNegativeScaledFloat(enc, "aggregate metadata bytes per matched row", stats.BytesPerMatchedRow); err != nil {
+		return err
+	}
+	enc.str(stats.Compression)
+	if err := encodeNonNegativeScaledFloat(enc, "aggregate metadata admission max bytes", stats.AdmissionMaxBytes); err != nil {
+		return err
+	}
+	enc.str(stats.AdmissionMeasuredBy)
+	return nil
+}
+
+func encodeNonNegativeScaledFloat(enc *columnPartImageEncoder, field string, value float64) error {
+	if math.IsNaN(value) || math.IsInf(value, 0) {
+		return fmt.Errorf("typedcolumn: %s must be finite, got %v", field, value)
+	}
+	if value < 0 {
+		return fmt.Errorf("typedcolumn: %s %.6f is negative", field, value)
+	}
+	scaled := math.Round(value * 1_000_000)
+	if scaled > math.MaxInt64 {
+		return fmt.Errorf("typedcolumn: %s %.6f exceeds scaled int64", field, value)
+	}
+	enc.i64(int64(scaled))
+	return nil
+}
+
+func countColumnBlocks(desc ColumnPartDescriptor) int {
+	total := 0
+	for _, column := range desc.Columns {
+		total += len(column.Blocks)
+	}
+	return total
+}
+
+func sumImageSectionDataBytes(sections []columnPartImageSectionData) int {
+	total := 0
+	for _, section := range sections {
+		total += len(section.data)
+	}
+	return total
+}
+
+func alignColumnPartImageOffset(offset int) int {
+	mask := columnPartImageSectionAlignment - 1
+	return (offset + mask) &^ mask
+}
+
+func durationNanos(d time.Duration) int64 {
+	return int64(d)
+}
+
+func columnTypeCode(t ColumnType) (uint16, error) {
+	switch t {
+	case ColumnTypeInt64:
+		return 1, nil
+	case ColumnTypeLowCardinalityCode:
+		return 2, nil
+	case ColumnTypeBool:
+		return 3, nil
+	default:
+		return 0, fmt.Errorf("typedcolumn: unsupported column type %s", t)
+	}
+}
+
+type columnPartImageSectionCode struct {
+	kind         ColumnPartImageSectionKind
+	kindCode     uint16
+	category     ColumnPartImageSectionCategory
+	categoryCode uint16
+}
+
+var columnPartImageSectionCodes = []columnPartImageSectionCode{
+	{kind: ColumnPartImageSectionDescriptor, kindCode: 1, category: ColumnPartImageCategoryDescriptor, categoryCode: 1},
+	{kind: ColumnPartImageSectionSortKeyMetadata, kindCode: 2, category: ColumnPartImageCategorySortKeyMetadata, categoryCode: 2},
+	{kind: ColumnPartImageSectionSortKeyMarks, kindCode: 3, category: ColumnPartImageCategoryMarks, categoryCode: 3},
+	{kind: ColumnPartImageSectionRowLocators, kindCode: 4, category: ColumnPartImageCategoryLocators, categoryCode: 4},
+	{kind: ColumnPartImageSectionAggregateMetadata, kindCode: 5, category: ColumnPartImageCategoryAggregateMetadata, categoryCode: 5},
+	{kind: ColumnPartImageSectionDictionaries, kindCode: 6, category: ColumnPartImageCategoryDictionaries, categoryCode: 6},
+	{kind: ColumnPartImageSectionColumnData, kindCode: 7, category: ColumnPartImageCategoryDeclaredColumns, categoryCode: 7},
+	{kind: ColumnPartImageSectionManifest, kindCode: 8, category: ColumnPartImageCategoryManifest, categoryCode: 8},
+}
+
+func columnPartImageSectionKindCode(kind ColumnPartImageSectionKind) (uint16, error) {
+	for _, code := range columnPartImageSectionCodes {
+		if code.kind == kind {
+			return code.kindCode, nil
+		}
+	}
+	return 0, fmt.Errorf("typedcolumn: unknown image section kind %s", kind)
+}
+
+func columnPartImageSectionKindFromCode(code uint16) (ColumnPartImageSectionKind, error) {
+	for _, entry := range columnPartImageSectionCodes {
+		if entry.kindCode == code {
+			return entry.kind, nil
+		}
+	}
+	return "", fmt.Errorf("typedcolumn: unknown image section kind code %d", code)
+}
+
+func columnPartImageSectionCategoryCode(category ColumnPartImageSectionCategory) (uint16, error) {
+	for _, code := range columnPartImageSectionCodes {
+		if code.category == category {
+			return code.categoryCode, nil
+		}
+	}
+	return 0, fmt.Errorf("typedcolumn: unknown image section category %s", category)
+}
+
+func columnPartImageSectionCategoryFromCode(code uint16) (ColumnPartImageSectionCategory, error) {
+	for _, entry := range columnPartImageSectionCodes {
+		if entry.categoryCode == code {
+			return entry.category, nil
+		}
+	}
+	return "", fmt.Errorf("typedcolumn: unknown image section category code %d", code)
+}

--- a/TreeDB/internal/typedcolumn/part_image_decode.go
+++ b/TreeDB/internal/typedcolumn/part_image_decode.go
@@ -1,0 +1,1985 @@
+package typedcolumn
+
+import (
+	"encoding/binary"
+	"fmt"
+	"sort"
+	"time"
+)
+
+const maxColumnPartImageStringBytes = 1 << 20
+
+func ParseColumnPartImage(data []byte) (ColumnPartImage, error) {
+	dec := columnPartImageDecoder{data: data}
+	magic, err := dec.u32()
+	if err != nil {
+		return ColumnPartImage{}, err
+	}
+	if magic != columnPartImageMagic {
+		return ColumnPartImage{}, fmt.Errorf("typedcolumn: invalid part image magic 0x%x", magic)
+	}
+	version, err := dec.u16()
+	if err != nil {
+		return ColumnPartImage{}, err
+	}
+	if version != columnPartImageVersion {
+		return ColumnPartImage{}, fmt.Errorf("typedcolumn: unsupported part image version %d", version)
+	}
+	if _, err := dec.u16(); err != nil {
+		return ColumnPartImage{}, err
+	}
+	partID, err := dec.u64()
+	if err != nil {
+		return ColumnPartImage{}, err
+	}
+	rows, err := dec.i64()
+	if err != nil {
+		return ColumnPartImage{}, err
+	}
+	if rows < 0 {
+		return ColumnPartImage{}, fmt.Errorf("typedcolumn: negative image row count %d", rows)
+	}
+	imageRows, err := nonNegativeInt64ToInt(rows, "image rows")
+	if err != nil {
+		return ColumnPartImage{}, err
+	}
+	manifestBytes, err := dec.u32()
+	if err != nil {
+		return ColumnPartImage{}, err
+	}
+	if uint64(int(manifestBytes)) != uint64(manifestBytes) {
+		return ColumnPartImage{}, fmt.Errorf("typedcolumn: manifest bytes=%d exceed host int", manifestBytes)
+	}
+	manifestLength := int(manifestBytes)
+	if manifestLength > len(data) {
+		return ColumnPartImage{}, fmt.Errorf("typedcolumn: manifest bytes=%d exceed image bytes=%d", manifestBytes, len(data))
+	}
+	sectionCount, err := dec.u32()
+	if err != nil {
+		return ColumnPartImage{}, err
+	}
+	if uint64(int(sectionCount)) != uint64(sectionCount) {
+		return ColumnPartImage{}, fmt.Errorf("typedcolumn: section count=%d exceed host int", sectionCount)
+	}
+	if err := validateImageSectionCount(sectionCount, manifestLength, dec.offset); err != nil {
+		return ColumnPartImage{}, err
+	}
+	sections := make([]ColumnPartImageSection, 0, int(sectionCount))
+	for i := 0; i < int(sectionCount); i++ {
+		kindCode, err := dec.u16()
+		if err != nil {
+			return ColumnPartImage{}, err
+		}
+		categoryCode, err := dec.u16()
+		if err != nil {
+			return ColumnPartImage{}, err
+		}
+		offset, err := dec.u64()
+		if err != nil {
+			return ColumnPartImage{}, err
+		}
+		length, err := dec.u64()
+		if err != nil {
+			return ColumnPartImage{}, err
+		}
+		sectionRows, err := dec.i64()
+		if err != nil {
+			return ColumnPartImage{}, err
+		}
+		granules, err := dec.i64()
+		if err != nil {
+			return ColumnPartImage{}, err
+		}
+		blocks, err := dec.i64()
+		if err != nil {
+			return ColumnPartImage{}, err
+		}
+		encoding, err := dec.u16()
+		if err != nil {
+			return ColumnPartImage{}, err
+		}
+		compression, err := dec.u16()
+		if err != nil {
+			return ColumnPartImage{}, err
+		}
+		name, err := dec.str()
+		if err != nil {
+			return ColumnPartImage{}, err
+		}
+		column, err := dec.str()
+		if err != nil {
+			return ColumnPartImage{}, err
+		}
+		kind, err := columnPartImageSectionKindFromCode(kindCode)
+		if err != nil {
+			return ColumnPartImage{}, err
+		}
+		category, err := columnPartImageSectionCategoryFromCode(categoryCode)
+		if err != nil {
+			return ColumnPartImage{}, err
+		}
+		if kind == ColumnPartImageSectionManifest {
+			return ColumnPartImage{}, fmt.Errorf("typedcolumn: manifest is not a directory section")
+		}
+		if err := validateImageSectionCategory(kind, category); err != nil {
+			return ColumnPartImage{}, err
+		}
+		if sectionRows < 0 || granules < 0 || blocks < 0 {
+			return ColumnPartImage{}, fmt.Errorf("typedcolumn: section %s has negative rows/granules/blocks (%d,%d,%d)", kind, sectionRows, granules, blocks)
+		}
+		if int64(int(sectionRows)) != sectionRows || int64(int(granules)) != granules || int64(int(blocks)) != blocks {
+			return ColumnPartImage{}, fmt.Errorf("typedcolumn: section %s rows/granules/blocks exceed host int (%d,%d,%d)", kind, sectionRows, granules, blocks)
+		}
+		if uint64(int(offset)) != offset || uint64(int(length)) != length {
+			return ColumnPartImage{}, fmt.Errorf("typedcolumn: section %s offset=%d length=%d exceed host int", kind, offset, length)
+		}
+		section := ColumnPartImageSection{
+			Kind:        kind,
+			Category:    category,
+			Name:        name,
+			Column:      column,
+			Offset:      int(offset),
+			Length:      int(length),
+			Rows:        int(sectionRows),
+			Granules:    int(granules),
+			Blocks:      int(blocks),
+			Encoding:    Encoding(encoding),
+			Compression: Compression(compression),
+		}
+		if err := validateImageSectionBounds(section, int(manifestBytes), len(data)); err != nil {
+			return ColumnPartImage{}, err
+		}
+		sections = append(sections, section)
+	}
+	if dec.offset != manifestLength {
+		return ColumnPartImage{}, fmt.Errorf("typedcolumn: manifest bytes=%d decoded=%d", manifestBytes, dec.offset)
+	}
+	if err := validateImageSectionLayout(sections, manifestLength, len(data)); err != nil {
+		return ColumnPartImage{}, err
+	}
+	if err := validateImageSectionMultiplicity(sections); err != nil {
+		return ColumnPartImage{}, err
+	}
+	return ColumnPartImage{
+		Version:       version,
+		PartID:        partID,
+		Rows:          imageRows,
+		ManifestBytes: int(manifestBytes),
+		Sections:      sections,
+		Bytes:         data,
+	}, nil
+}
+
+type ColumnPartImageReadOptions struct {
+	IncludeRowLocators       bool
+	ValidateRowLocators      bool
+	IncludeAggregateMetadata bool
+}
+
+func ColumnPartFromImage(image ColumnPartImage) (*ColumnPart, error) {
+	return ColumnPartFromImageWithOptions(image, ColumnPartImageReadOptions{
+		IncludeRowLocators:       true,
+		ValidateRowLocators:      true,
+		IncludeAggregateMetadata: true,
+	})
+}
+
+func ColumnPartFromImageWithOptions(image ColumnPartImage, opts ColumnPartImageReadOptions) (*ColumnPart, error) {
+	if image.TotalBytes() == 0 {
+		return nil, fmt.Errorf("typedcolumn: empty part image")
+	}
+	if opts.ValidateRowLocators {
+		opts.IncludeRowLocators = true
+	}
+	if err := image.validateForRead(); err != nil {
+		return nil, err
+	}
+	descriptorSection, err := image.singleSection(ColumnPartImageSectionDescriptor)
+	if err != nil {
+		return nil, err
+	}
+	desc, columns, err := decodeColumnPartDescriptorSection(image.sectionBytes(descriptorSection))
+	if err != nil {
+		return nil, err
+	}
+	if desc.PartID != image.PartID {
+		return nil, fmt.Errorf("typedcolumn: descriptor part id=%d manifest part id=%d", desc.PartID, image.PartID)
+	}
+	if desc.RowCount != image.Rows {
+		return nil, fmt.Errorf("typedcolumn: descriptor rows=%d manifest rows=%d", desc.RowCount, image.Rows)
+	}
+	sortKey, err := decodeSortKeyMetadataSection(image)
+	if err != nil {
+		return nil, err
+	}
+	desc.SortKey = sortKey
+	marks, err := decodeSortKeyMarksSection(image)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateDecodedSortKeyMarks(desc, marks); err != nil {
+		return nil, err
+	}
+	var locators map[int64]RowLocator
+	if opts.IncludeRowLocators {
+		locators, err = decodeRowLocatorsSection(image)
+		if err != nil {
+			return nil, err
+		}
+		if opts.ValidateRowLocators {
+			if err := validateDecodedRowLocators(desc, image.PartID, locators); err != nil {
+				return nil, err
+			}
+		}
+	}
+	if err := attachColumnPayloadsFromImage(image, columns); err != nil {
+		return nil, err
+	}
+	if opts.ValidateRowLocators {
+		if err := validateDecodedRowLocatorsPrimaryKey(desc, columns, locators); err != nil {
+			return nil, err
+		}
+	}
+	optionsColumns := make([]ColumnDefinition, 0, len(desc.Columns))
+	for _, columnDescriptor := range desc.Columns {
+		column, ok := columns[columnDescriptor.Name]
+		if !ok {
+			return nil, fmt.Errorf("typedcolumn: descriptor column %s missing decoded column", columnDescriptor.Name)
+		}
+		def := column.Definition
+		if def.Type == ColumnTypeLowCardinalityCode {
+			if def.Cardinality == 0 || def.Cardinality > maxCodeCardinality {
+				return nil, fmt.Errorf("typedcolumn: invalid low-cardinality cardinality %d for %s", def.Cardinality, def.Name)
+			}
+			column.Definition = def
+			columns[columnDescriptor.Name] = column
+		}
+		optionsColumns = append(optionsColumns, def)
+	}
+	var aggregateMetadata map[string]AggregateMetadata
+	if opts.IncludeAggregateMetadata {
+		aggregateMetadata, err = decodeAggregateMetadataSections(image)
+		if err != nil {
+			return nil, err
+		}
+	}
+	aggregateDefinitions := make([]AggregateMetadataDefinition, 0, len(aggregateMetadata))
+	for _, metadata := range aggregateMetadata {
+		aggregateDefinitions = append(aggregateDefinitions, metadata.Definition)
+	}
+	sort.Slice(aggregateDefinitions, func(i, j int) bool {
+		return aggregateDefinitions[i].Name < aggregateDefinitions[j].Name
+	})
+	part := &ColumnPart{
+		Options: Options{
+			SchemaVersion: desc.SchemaVersion,
+			SchemaMode:    ColumnSchemaFixed,
+			Columns:       optionsColumns,
+			LogicalPrimaryKey: LogicalPrimaryKey{
+				Columns: append([]string(nil), desc.LogicalPrimaryKey...),
+			},
+			SortKey: SortKey{
+				Columns: append([]SortKeyColumn(nil), sortKey...),
+			},
+			PartPolicy: ColumnPartPolicy{
+				RowsPerGranule:        inferredRowsPerGranule(desc.Granules),
+				DefaultCodecBlockRows: inferredDefaultCodecBlockRows(desc.Columns),
+			},
+			AggregateMetadata: aggregateDefinitions,
+		},
+		Descriptor:        desc,
+		Columns:           columns,
+		Marks:             marks,
+		Locators:          locators,
+		AggregateMetadata: aggregateMetadata,
+	}
+	return part, nil
+}
+
+func decodeColumnPartDescriptorSection(data []byte) (ColumnPartDescriptor, map[string]ColumnPartColumn, error) {
+	dec := columnPartImageDecoder{data: data}
+	version, err := dec.u16()
+	if err != nil {
+		return ColumnPartDescriptor{}, nil, err
+	}
+	if version != columnPartDescriptorVersion {
+		return ColumnPartDescriptor{}, nil, fmt.Errorf("typedcolumn: unsupported descriptor version %d", version)
+	}
+	partID, err := dec.u64()
+	if err != nil {
+		return ColumnPartDescriptor{}, nil, err
+	}
+	schemaVersion, err := dec.u32()
+	if err != nil {
+		return ColumnPartDescriptor{}, nil, err
+	}
+	rowCount, err := dec.i64()
+	if err != nil {
+		return ColumnPartDescriptor{}, nil, err
+	}
+	rowCountInt, err := nonNegativeInt64ToInt(rowCount, "descriptor row count")
+	if err != nil {
+		return ColumnPartDescriptor{}, nil, err
+	}
+	visibleRows, err := dec.i64()
+	if err != nil {
+		return ColumnPartDescriptor{}, nil, err
+	}
+	visibleRowsInt, err := nonNegativeInt64ToInt(visibleRows, "descriptor visible rows")
+	if err != nil {
+		return ColumnPartDescriptor{}, nil, err
+	}
+	logicalPrimaryKey, err := dec.stringSlice()
+	if err != nil {
+		return ColumnPartDescriptor{}, nil, err
+	}
+	granuleCount, err := dec.u32()
+	if err != nil {
+		return ColumnPartDescriptor{}, nil, err
+	}
+	granules, err := dec.boundedCount(granuleCount, 64, "descriptor granules")
+	if err != nil {
+		return ColumnPartDescriptor{}, nil, err
+	}
+	desc := ColumnPartDescriptor{
+		Version:           uint8(version),
+		PartID:            partID,
+		SchemaVersion:     schemaVersion,
+		RowCount:          rowCountInt,
+		VisibleRowCount:   visibleRowsInt,
+		LogicalPrimaryKey: logicalPrimaryKey,
+		Granules:          make([]GranuleDescriptor, 0, granules),
+	}
+	for i := 0; i < granules; i++ {
+		granule, err := decodeGranuleDescriptor(&dec)
+		if err != nil {
+			return ColumnPartDescriptor{}, nil, err
+		}
+		desc.Granules = append(desc.Granules, granule)
+	}
+	if err := validateDecodedGranuleDescriptors(desc); err != nil {
+		return ColumnPartDescriptor{}, nil, err
+	}
+	columnCount, err := dec.u32()
+	if err != nil {
+		return ColumnPartDescriptor{}, nil, err
+	}
+	columnTotal, err := dec.boundedCount(columnCount, 14, "descriptor columns")
+	if err != nil {
+		return ColumnPartDescriptor{}, nil, err
+	}
+	columns := make(map[string]ColumnPartColumn, columnTotal)
+	for i := 0; i < columnTotal; i++ {
+		name, err := dec.str()
+		if err != nil {
+			return ColumnPartDescriptor{}, nil, err
+		}
+		if _, exists := columns[name]; exists {
+			return ColumnPartDescriptor{}, nil, fmt.Errorf("typedcolumn: duplicate descriptor column %s", name)
+		}
+		columnTypeCode, err := dec.u16()
+		if err != nil {
+			return ColumnPartDescriptor{}, nil, err
+		}
+		columnType, err := columnTypeFromCode(columnTypeCode)
+		if err != nil {
+			return ColumnPartDescriptor{}, nil, err
+		}
+		cardinality, err := dec.u32()
+		if err != nil {
+			return ColumnPartDescriptor{}, nil, err
+		}
+		if columnType == ColumnTypeLowCardinalityCode {
+			if cardinality == 0 || cardinality > maxCodeCardinality {
+				return ColumnPartDescriptor{}, nil, fmt.Errorf("typedcolumn: invalid low-cardinality cardinality %d for %s", cardinality, name)
+			}
+		} else if cardinality != 0 {
+			return ColumnPartDescriptor{}, nil, fmt.Errorf("typedcolumn: column %s type=%s has cardinality %d", name, columnType, cardinality)
+		}
+		blockCount, err := dec.u32()
+		if err != nil {
+			return ColumnPartDescriptor{}, nil, err
+		}
+		blocks, err := dec.boundedCount(blockCount, 94, "descriptor column blocks")
+		if err != nil {
+			return ColumnPartDescriptor{}, nil, err
+		}
+		columnDesc := ColumnPartColumnDescriptor{Name: name, Type: columnType, Blocks: make([]ColumnBlockDescriptor, 0, blocks)}
+		column := ColumnPartColumn{
+			Definition: ColumnDefinition{
+				Name:        name,
+				Type:        columnType,
+				Cardinality: cardinality,
+			},
+			Blocks: make([]ColumnBlock, 0, blocks),
+		}
+		expectedFirstRow := 0
+		for j := 0; j < blocks; j++ {
+			blockDesc, granule, err := decodeColumnBlockDescriptorAndGranule(&dec)
+			if err != nil {
+				return ColumnPartDescriptor{}, nil, err
+			}
+			if err := validateDecodedColumnBlockDescriptor(desc, name, columnType, cardinality, j, blockDesc); err != nil {
+				return ColumnPartDescriptor{}, nil, err
+			}
+			if err := validateDecodedColumnBlockGranuleMetadata(name, j, granule); err != nil {
+				return ColumnPartDescriptor{}, nil, err
+			}
+			if blockDesc.FirstRow != expectedFirstRow {
+				return ColumnPartDescriptor{}, nil, fmt.Errorf("typedcolumn: descriptor column %s block %d first row=%d want contiguous first row=%d", name, j, blockDesc.FirstRow, expectedFirstRow)
+			}
+			expectedFirstRow += blockDesc.RowCount
+			if j == 0 {
+				column.Definition.Encoding = blockDesc.Encoding
+				column.Definition.Compression = blockDesc.Compression
+			}
+			columnDesc.Blocks = append(columnDesc.Blocks, blockDesc)
+			column.Blocks = append(column.Blocks, ColumnBlock{Descriptor: blockDesc, Granule: granule})
+		}
+		if expectedFirstRow != desc.RowCount {
+			return ColumnPartDescriptor{}, nil, fmt.Errorf("typedcolumn: descriptor column %s covers %d rows, want %d", name, expectedFirstRow, desc.RowCount)
+		}
+		desc.Columns = append(desc.Columns, columnDesc)
+		columns[name] = column
+	}
+	if err := dec.finish(); err != nil {
+		return ColumnPartDescriptor{}, nil, err
+	}
+	return desc, columns, nil
+}
+
+func validateDecodedGranuleDescriptors(desc ColumnPartDescriptor) error {
+	if desc.RowCount > 0 && len(desc.Granules) == 0 {
+		return fmt.Errorf("typedcolumn: descriptor rows=%d has no granules", desc.RowCount)
+	}
+	expectedFirstRow := 0
+	for i, granule := range desc.Granules {
+		if granule.Ordinal != i {
+			return fmt.Errorf("typedcolumn: granule %d has ordinal=%d", i, granule.Ordinal)
+		}
+		if granule.RowCount <= 0 {
+			return fmt.Errorf("typedcolumn: granule %d has invalid row count %d", i, granule.RowCount)
+		}
+		if granule.FirstRow != expectedFirstRow {
+			return fmt.Errorf("typedcolumn: granule %d first row=%d want %d", i, granule.FirstRow, expectedFirstRow)
+		}
+		if granule.VisibleRows > granule.RowCount {
+			return fmt.Errorf("typedcolumn: granule %d visible rows=%d exceed row count=%d", i, granule.VisibleRows, granule.RowCount)
+		}
+		if granule.DeletedRows > granule.RowCount {
+			return fmt.Errorf("typedcolumn: granule %d deleted rows=%d exceed row count=%d", i, granule.DeletedRows, granule.RowCount)
+		}
+		if granule.VisibleRows+granule.DeletedRows > granule.RowCount {
+			return fmt.Errorf("typedcolumn: granule %d visible+deleted rows=%d exceed row count=%d", i, granule.VisibleRows+granule.DeletedRows, granule.RowCount)
+		}
+		expectedFirstRow += granule.RowCount
+	}
+	if expectedFirstRow != desc.RowCount {
+		return fmt.Errorf("typedcolumn: descriptor granules cover %d rows, want %d", expectedFirstRow, desc.RowCount)
+	}
+	return nil
+}
+
+func validateDecodedColumnBlockDescriptor(desc ColumnPartDescriptor, column string, columnType ColumnType, cardinality uint32, blockIndex int, block ColumnBlockDescriptor) error {
+	if block.RowCount <= 0 {
+		return fmt.Errorf("typedcolumn: descriptor column %s block %d has invalid row count %d", column, blockIndex, block.RowCount)
+	}
+	if block.FirstRow > desc.RowCount || block.RowCount > desc.RowCount-block.FirstRow {
+		return fmt.Errorf("typedcolumn: descriptor column %s block %d first row=%d row count=%d outside part rows=%d", column, blockIndex, block.FirstRow, block.RowCount, desc.RowCount)
+	}
+	if block.FirstGranule > block.LastGranule {
+		return fmt.Errorf("typedcolumn: descriptor column %s block %d granule range [%d,%d] is inverted", column, blockIndex, block.FirstGranule, block.LastGranule)
+	}
+	if len(desc.Granules) > 0 && block.LastGranule >= len(desc.Granules) {
+		return fmt.Errorf("typedcolumn: descriptor column %s block %d last granule=%d outside granules=%d", column, blockIndex, block.LastGranule, len(desc.Granules))
+	}
+	firstGranule, lastGranule, err := decodedBlockGranuleRange(desc.Granules, block.FirstRow, block.RowCount)
+	if err != nil {
+		return fmt.Errorf("typedcolumn: descriptor column %s block %d: %w", column, blockIndex, err)
+	}
+	if block.FirstGranule != firstGranule || block.LastGranule != lastGranule {
+		return fmt.Errorf("typedcolumn: descriptor column %s block %d granule range [%d,%d] want [%d,%d] for rows [%d,%d)", column, blockIndex, block.FirstGranule, block.LastGranule, firstGranule, lastGranule, block.FirstRow, block.FirstRow+block.RowCount)
+	}
+	maxRawBytes, err := maxDecodedBlockRawBytes(columnType, cardinality, block.Encoding, block.RowCount)
+	if err != nil {
+		return fmt.Errorf("typedcolumn: descriptor column %s block %d: %w", column, blockIndex, err)
+	}
+	if block.RawBytes > maxRawBytes {
+		return fmt.Errorf("typedcolumn: descriptor column %s block %d raw bytes=%d exceed max=%d for %d rows", column, blockIndex, block.RawBytes, maxRawBytes, block.RowCount)
+	}
+	if block.Compression == CompressionNone && block.StoredBytes != block.RawBytes {
+		return fmt.Errorf("typedcolumn: descriptor column %s block %d uncompressed stored bytes=%d raw bytes=%d", column, blockIndex, block.StoredBytes, block.RawBytes)
+	}
+	if block.Compression != CompressionNone && block.StoredBytes > block.RawBytes {
+		return fmt.Errorf("typedcolumn: descriptor column %s block %d compressed stored bytes=%d exceed raw bytes=%d", column, blockIndex, block.StoredBytes, block.RawBytes)
+	}
+	return nil
+}
+
+func validateDecodedColumnBlockGranuleMetadata(column string, blockIndex int, granule EncodedGranule) error {
+	if granule.Rows <= 0 {
+		return fmt.Errorf("typedcolumn: descriptor column %s block %d granule has invalid row count %d", column, blockIndex, granule.Rows)
+	}
+	if granule.NullCount < 0 {
+		return fmt.Errorf("typedcolumn: descriptor column %s block %d granule has negative null count %d", column, blockIndex, granule.NullCount)
+	}
+	if granule.DefaultCount < 0 {
+		return fmt.Errorf("typedcolumn: descriptor column %s block %d granule has negative default count %d", column, blockIndex, granule.DefaultCount)
+	}
+	if granule.NullCount > granule.Rows || granule.DefaultCount > granule.Rows-granule.NullCount {
+		return fmt.Errorf("typedcolumn: descriptor column %s block %d granule null/default count exceeds rows", column, blockIndex)
+	}
+	if granule.HasMinMax && granule.Min > granule.Max {
+		return fmt.Errorf("typedcolumn: descriptor column %s block %d granule min=%d exceeds max=%d", column, blockIndex, granule.Min, granule.Max)
+	}
+	return nil
+}
+
+func decodedBlockGranuleRange(granules []GranuleDescriptor, firstRow int, rowCount int) (int, int, error) {
+	if rowCount <= 0 {
+		return 0, 0, fmt.Errorf("invalid block row count %d", rowCount)
+	}
+	firstGranule, ok := decodedGranuleIndexForRow(granules, firstRow)
+	if !ok {
+		return 0, 0, fmt.Errorf("first row=%d is not covered by descriptor granules", firstRow)
+	}
+	lastRow := firstRow + rowCount - 1
+	lastGranule, ok := decodedGranuleIndexForRow(granules, lastRow)
+	if !ok {
+		return 0, 0, fmt.Errorf("last row=%d is not covered by descriptor granules", lastRow)
+	}
+	return firstGranule, lastGranule, nil
+}
+
+func decodedGranuleIndexForRow(granules []GranuleDescriptor, row int) (int, bool) {
+	i := sort.Search(len(granules), func(i int) bool {
+		granule := granules[i]
+		return granule.FirstRow+granule.RowCount > row
+	})
+	if i < len(granules) {
+		granule := granules[i]
+		if row >= granule.FirstRow && row < granule.FirstRow+granule.RowCount {
+			return i, true
+		}
+	}
+	return 0, false
+}
+
+func maxDecodedBlockRawBytes(columnType ColumnType, cardinality uint32, encoding Encoding, rows int) (int, error) {
+	switch columnType {
+	case ColumnTypeInt64:
+		switch encoding {
+		case EncodingRawInt64:
+			return checkedMulInt(rows, 8, "raw int64 bytes")
+		case EncodingDeltaVarint, EncodingDoubleDeltaVarint:
+			return checkedMulInt(rows, binary.MaxVarintLen64, "varint bytes")
+		default:
+			return 0, fmt.Errorf("unsupported int64 encoding %d", encoding)
+		}
+	case ColumnTypeLowCardinalityCode:
+		if encoding != EncodingLowCardinalityUint32 {
+			return 0, fmt.Errorf("unsupported low-cardinality encoding %d", encoding)
+		}
+		if cardinality == 0 || cardinality > maxCodeCardinality {
+			return 0, fmt.Errorf("invalid low-cardinality cardinality %d", cardinality)
+		}
+		codeBytes, err := checkedMulInt(rows, 4, "low-cardinality code bytes")
+		if err != nil {
+			return 0, err
+		}
+		return checkedAddInt(1+binary.MaxVarintLen64, codeBytes, "low-cardinality raw bytes")
+	case ColumnTypeBool:
+		if encoding != EncodingBoolBitpackRLE {
+			return 0, fmt.Errorf("unsupported bool encoding %d", encoding)
+		}
+		rleBytes, err := checkedMulInt(rows, binary.MaxVarintLen64, "bool rle bytes")
+		if err != nil {
+			return 0, err
+		}
+		return checkedAddInt(2, rleBytes, "bool raw bytes")
+	default:
+		return 0, fmt.Errorf("unsupported column type %s", columnType)
+	}
+}
+
+func checkedMulInt(a int, b int, field string) (int, error) {
+	if a < 0 || b < 0 {
+		return 0, fmt.Errorf("%s has negative operand %d*%d", field, a, b)
+	}
+	if b != 0 && a > int(^uint(0)>>1)/b {
+		return 0, fmt.Errorf("%s overflow %d*%d", field, a, b)
+	}
+	return a * b, nil
+}
+
+func checkedAddInt(a int, b int, field string) (int, error) {
+	if a < 0 || b < 0 {
+		return 0, fmt.Errorf("%s has negative operand %d+%d", field, a, b)
+	}
+	if a > int(^uint(0)>>1)-b {
+		return 0, fmt.Errorf("%s overflow %d+%d", field, a, b)
+	}
+	return a + b, nil
+}
+
+func uint32ToInt(v uint32, field string) (int, error) {
+	if uint64(int(v)) != uint64(v) {
+		return 0, fmt.Errorf("typedcolumn: %s=%d exceeds host int", field, v)
+	}
+	return int(v), nil
+}
+
+func decodeGranuleDescriptor(dec *columnPartImageDecoder) (GranuleDescriptor, error) {
+	ordinal, err := dec.i64()
+	if err != nil {
+		return GranuleDescriptor{}, err
+	}
+	firstRow, err := dec.i64()
+	if err != nil {
+		return GranuleDescriptor{}, err
+	}
+	rowCount, err := dec.i64()
+	if err != nil {
+		return GranuleDescriptor{}, err
+	}
+	visibleRows, err := dec.i64()
+	if err != nil {
+		return GranuleDescriptor{}, err
+	}
+	deletedRows, err := dec.i64()
+	if err != nil {
+		return GranuleDescriptor{}, err
+	}
+	idLower, err := dec.i64()
+	if err != nil {
+		return GranuleDescriptor{}, err
+	}
+	idUpper, err := dec.i64()
+	if err != nil {
+		return GranuleDescriptor{}, err
+	}
+	markOrdinal, err := dec.i64()
+	if err != nil {
+		return GranuleDescriptor{}, err
+	}
+	ordinalInt, err := nonNegativeInt64ToInt(ordinal, "granule ordinal")
+	if err != nil {
+		return GranuleDescriptor{}, err
+	}
+	firstRowInt, err := nonNegativeInt64ToInt(firstRow, "granule first row")
+	if err != nil {
+		return GranuleDescriptor{}, err
+	}
+	rowCountInt, err := nonNegativeInt64ToInt(rowCount, "granule row count")
+	if err != nil {
+		return GranuleDescriptor{}, err
+	}
+	visibleRowsInt, err := nonNegativeInt64ToInt(visibleRows, "granule visible rows")
+	if err != nil {
+		return GranuleDescriptor{}, err
+	}
+	deletedRowsInt, err := nonNegativeInt64ToInt(deletedRows, "granule deleted rows")
+	if err != nil {
+		return GranuleDescriptor{}, err
+	}
+	markOrdinalInt, err := nonNegativeInt64ToInt(markOrdinal, "granule mark ordinal")
+	if err != nil {
+		return GranuleDescriptor{}, err
+	}
+	return GranuleDescriptor{
+		Ordinal:          ordinalInt,
+		FirstRow:         firstRowInt,
+		RowCount:         rowCountInt,
+		VisibleRows:      visibleRowsInt,
+		DeletedRows:      deletedRowsInt,
+		IDLower:          idLower,
+		IDUpperExclusive: idUpper,
+		MarkOrdinal:      markOrdinalInt,
+	}, nil
+}
+
+func decodeColumnBlockDescriptorAndGranule(dec *columnPartImageDecoder) (ColumnBlockDescriptor, EncodedGranule, error) {
+	firstRow, err := dec.i64()
+	if err != nil {
+		return ColumnBlockDescriptor{}, EncodedGranule{}, err
+	}
+	rowCount, err := dec.i64()
+	if err != nil {
+		return ColumnBlockDescriptor{}, EncodedGranule{}, err
+	}
+	firstGranule, err := dec.i64()
+	if err != nil {
+		return ColumnBlockDescriptor{}, EncodedGranule{}, err
+	}
+	lastGranule, err := dec.i64()
+	if err != nil {
+		return ColumnBlockDescriptor{}, EncodedGranule{}, err
+	}
+	encodingCode, err := dec.u16()
+	if err != nil {
+		return ColumnBlockDescriptor{}, EncodedGranule{}, err
+	}
+	compressionCode, err := dec.u16()
+	if err != nil {
+		return ColumnBlockDescriptor{}, EncodedGranule{}, err
+	}
+	rawBytes, err := dec.i64()
+	if err != nil {
+		return ColumnBlockDescriptor{}, EncodedGranule{}, err
+	}
+	storedBytes, err := dec.i64()
+	if err != nil {
+		return ColumnBlockDescriptor{}, EncodedGranule{}, err
+	}
+	ordinal, err := dec.i64()
+	if err != nil {
+		return ColumnBlockDescriptor{}, EncodedGranule{}, err
+	}
+	nullCount, err := dec.i64()
+	if err != nil {
+		return ColumnBlockDescriptor{}, EncodedGranule{}, err
+	}
+	defaultCount, err := dec.i64()
+	if err != nil {
+		return ColumnBlockDescriptor{}, EncodedGranule{}, err
+	}
+	hasMinMax, err := dec.boolean()
+	if err != nil {
+		return ColumnBlockDescriptor{}, EncodedGranule{}, err
+	}
+	minValue, err := dec.i64()
+	if err != nil {
+		return ColumnBlockDescriptor{}, EncodedGranule{}, err
+	}
+	maxValue, err := dec.i64()
+	if err != nil {
+		return ColumnBlockDescriptor{}, EncodedGranule{}, err
+	}
+	firstRowInt, err := nonNegativeInt64ToInt(firstRow, "column block first row")
+	if err != nil {
+		return ColumnBlockDescriptor{}, EncodedGranule{}, err
+	}
+	rowCountInt, err := nonNegativeInt64ToInt(rowCount, "column block row count")
+	if err != nil {
+		return ColumnBlockDescriptor{}, EncodedGranule{}, err
+	}
+	firstGranuleInt, err := nonNegativeInt64ToInt(firstGranule, "column block first granule")
+	if err != nil {
+		return ColumnBlockDescriptor{}, EncodedGranule{}, err
+	}
+	lastGranuleInt, err := nonNegativeInt64ToInt(lastGranule, "column block last granule")
+	if err != nil {
+		return ColumnBlockDescriptor{}, EncodedGranule{}, err
+	}
+	rawBytesInt, err := nonNegativeInt64ToInt(rawBytes, "column block raw bytes")
+	if err != nil {
+		return ColumnBlockDescriptor{}, EncodedGranule{}, err
+	}
+	storedBytesInt, err := nonNegativeInt64ToInt(storedBytes, "column block stored bytes")
+	if err != nil {
+		return ColumnBlockDescriptor{}, EncodedGranule{}, err
+	}
+	ordinalInt, err := nonNegativeInt64ToInt(ordinal, "column block ordinal")
+	if err != nil {
+		return ColumnBlockDescriptor{}, EncodedGranule{}, err
+	}
+	nullCountInt, err := nonNegativeInt64ToInt(nullCount, "granule null count")
+	if err != nil {
+		return ColumnBlockDescriptor{}, EncodedGranule{}, err
+	}
+	defaultCountInt, err := nonNegativeInt64ToInt(defaultCount, "granule default count")
+	if err != nil {
+		return ColumnBlockDescriptor{}, EncodedGranule{}, err
+	}
+	encoding := Encoding(encodingCode)
+	compression := Compression(compressionCode)
+	desc := ColumnBlockDescriptor{
+		FirstRow:          firstRowInt,
+		RowCount:          rowCountInt,
+		FirstGranule:      firstGranuleInt,
+		LastGranule:       lastGranuleInt,
+		Encoding:          encoding,
+		Compression:       compression,
+		RawBytes:          rawBytesInt,
+		StoredBytes:       storedBytesInt,
+		CodecBlockOrdinal: ordinalInt,
+	}
+	granule := EncodedGranule{
+		Rows:         rowCountInt,
+		NullCount:    nullCountInt,
+		DefaultCount: defaultCountInt,
+		HasMinMax:    hasMinMax,
+		Min:          minValue,
+		Max:          maxValue,
+		Encoding:     encoding,
+		Compression:  compression,
+		RawBytes:     rawBytesInt,
+		StoredBytes:  storedBytesInt,
+		PayloadRef: PayloadRef{
+			Kind:   PayloadRefInline,
+			Length: storedBytesInt,
+		},
+		CodecReport: CodecReport{
+			Encoding:             encoding,
+			ActualCompression:    compression,
+			RequestedCompression: compression,
+			RawBytes:             rawBytesInt,
+			StoredBytes:          storedBytesInt,
+		},
+	}
+	return desc, granule, nil
+}
+
+func decodeSortKeyMetadataSection(image ColumnPartImage) ([]SortKeyColumn, error) {
+	section, err := image.singleSection(ColumnPartImageSectionSortKeyMetadata)
+	if err != nil {
+		return nil, err
+	}
+	dec := columnPartImageDecoder{data: image.sectionBytes(section)}
+	count, err := dec.u32()
+	if err != nil {
+		return nil, err
+	}
+	total, err := dec.boundedCount(count, 12, "sort key columns")
+	if err != nil {
+		return nil, err
+	}
+	out := make([]SortKeyColumn, 0, total)
+	for i := 0; i < total; i++ {
+		column, err := dec.str()
+		if err != nil {
+			return nil, err
+		}
+		direction, err := dec.str()
+		if err != nil {
+			return nil, err
+		}
+		nulls, err := dec.str()
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, SortKeyColumn{Column: column, Direction: SortKeyDirection(direction), Nulls: SortKeyNullOrder(nulls)})
+	}
+	if err := dec.finish(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func decodeSortKeyMarksSection(image ColumnPartImage) ([]SortKeyMark, error) {
+	section, err := image.singleSection(ColumnPartImageSectionSortKeyMarks)
+	if err != nil {
+		return nil, err
+	}
+	dec := columnPartImageDecoder{data: image.sectionBytes(section)}
+	count, err := dec.u32()
+	if err != nil {
+		return nil, err
+	}
+	total, err := dec.boundedCount(count, 16, "sort key marks")
+	if err != nil {
+		return nil, err
+	}
+	out := make([]SortKeyMark, 0, total)
+	for i := 0; i < total; i++ {
+		rows, err := dec.i64()
+		if err != nil {
+			return nil, err
+		}
+		rowsInt, err := nonNegativeInt64ToInt(rows, "sort key mark rows")
+		if err != nil {
+			return nil, err
+		}
+		columns, err := dec.stringSlice()
+		if err != nil {
+			return nil, err
+		}
+		prefixCount, err := dec.u32()
+		if err != nil {
+			return nil, err
+		}
+		prefixes, err := dec.boundedCount(prefixCount, 20, "sort key mark prefixes")
+		if err != nil {
+			return nil, err
+		}
+		mark := SortKeyMark{Rows: rowsInt, Columns: columns, Prefixes: make([]SortKeyPrefixSummary, 0, prefixes)}
+		for j := 0; j < prefixes; j++ {
+			prefixColumns, err := dec.stringSlice()
+			if err != nil {
+				return nil, err
+			}
+			lower, err := decodeSortKeyBound(&dec)
+			if err != nil {
+				return nil, err
+			}
+			upper, err := decodeSortKeyBound(&dec)
+			if err != nil {
+				return nil, err
+			}
+			mark.Prefixes = append(mark.Prefixes, SortKeyPrefixSummary{
+				Columns:        prefixColumns,
+				Lower:          lower,
+				UpperExclusive: upper,
+			})
+		}
+		if err := validateDecodedSortKeyMark(mark, i); err != nil {
+			return nil, err
+		}
+		out = append(out, mark)
+	}
+	if err := dec.finish(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func validateDecodedSortKeyMark(mark SortKeyMark, index int) error {
+	if mark.Rows <= 0 {
+		return fmt.Errorf("typedcolumn: sort key mark %d has invalid row count %d", index, mark.Rows)
+	}
+	if len(mark.Columns) == 0 {
+		return fmt.Errorf("typedcolumn: sort key mark %d has no columns", index)
+	}
+	if len(mark.Columns) > maxSortKeyColumns {
+		return fmt.Errorf("typedcolumn: sort key mark %d columns=%d exceeds cap %d", index, len(mark.Columns), maxSortKeyColumns)
+	}
+	for columnIndex, column := range mark.Columns {
+		if column == "" {
+			return fmt.Errorf("typedcolumn: sort key mark %d has empty column name at %d", index, columnIndex)
+		}
+	}
+	if len(mark.Prefixes) != len(mark.Columns) {
+		return fmt.Errorf("typedcolumn: sort key mark %d prefixes=%d want columns=%d", index, len(mark.Prefixes), len(mark.Columns))
+	}
+	for prefixIndex, prefix := range mark.Prefixes {
+		prefixLen := prefixIndex + 1
+		if !sameStringSlice(prefix.Columns, mark.Columns[:prefixLen]) {
+			return fmt.Errorf("typedcolumn: sort key mark %d prefix %d columns=%v want %v", index, prefixIndex, prefix.Columns, mark.Columns[:prefixLen])
+		}
+		if prefix.Lower.Exclusive {
+			return fmt.Errorf("typedcolumn: sort key mark %d prefix %d lower bound is exclusive", index, prefixIndex)
+		}
+		if prefix.Lower.Unbounded {
+			return fmt.Errorf("typedcolumn: sort key mark %d prefix %d lower bound is unbounded", index, prefixIndex)
+		}
+		if len(prefix.Lower.Values) != prefixLen {
+			return fmt.Errorf("typedcolumn: sort key mark %d prefix %d lower values=%d want %d", index, prefixIndex, len(prefix.Lower.Values), prefixLen)
+		}
+		if !prefix.UpperExclusive.Exclusive {
+			return fmt.Errorf("typedcolumn: sort key mark %d prefix %d upper bound is not exclusive", index, prefixIndex)
+		}
+		if prefix.UpperExclusive.Unbounded {
+			if len(prefix.UpperExclusive.Values) != 0 {
+				return fmt.Errorf("typedcolumn: sort key mark %d prefix %d unbounded upper has %d values", index, prefixIndex, len(prefix.UpperExclusive.Values))
+			}
+			continue
+		}
+		if len(prefix.UpperExclusive.Values) != prefixLen {
+			return fmt.Errorf("typedcolumn: sort key mark %d prefix %d upper values=%d want %d", index, prefixIndex, len(prefix.UpperExclusive.Values), prefixLen)
+		}
+		if compareInt64Tuple(prefix.UpperExclusive.Values, prefix.Lower.Values) <= 0 {
+			return fmt.Errorf("typedcolumn: sort key mark %d prefix %d upper bound %v is not greater than lower bound %v", index, prefixIndex, prefix.UpperExclusive.Values, prefix.Lower.Values)
+		}
+	}
+	return nil
+}
+
+func validateDecodedSortKeyMarks(desc ColumnPartDescriptor, marks []SortKeyMark) error {
+	if len(desc.SortKey) == 0 {
+		return fmt.Errorf("typedcolumn: descriptor has no sort key")
+	}
+	if len(marks) != len(desc.Granules) {
+		return fmt.Errorf("typedcolumn: sort key marks=%d granules=%d", len(marks), len(desc.Granules))
+	}
+	expectedColumns := make([]string, len(desc.SortKey))
+	for i, column := range desc.SortKey {
+		if column.Column == "" {
+			return fmt.Errorf("typedcolumn: descriptor sort key has empty column at %d", i)
+		}
+		expectedColumns[i] = column.Column
+	}
+	for i, mark := range marks {
+		if !sameStringSlice(mark.Columns, expectedColumns) {
+			return fmt.Errorf("typedcolumn: sort key mark %d columns=%v want descriptor sort key %v", i, mark.Columns, expectedColumns)
+		}
+	}
+	for i, granule := range desc.Granules {
+		if granule.MarkOrdinal != i {
+			return fmt.Errorf("typedcolumn: granule %d mark ordinal=%d want %d", i, granule.MarkOrdinal, i)
+		}
+		if granule.MarkOrdinal >= len(marks) {
+			return fmt.Errorf("typedcolumn: granule %d mark ordinal=%d outside marks=%d", i, granule.MarkOrdinal, len(marks))
+		}
+		if marks[i].Rows != granule.RowCount {
+			return fmt.Errorf("typedcolumn: granule %d rows=%d mark rows=%d", i, granule.RowCount, marks[i].Rows)
+		}
+	}
+	return nil
+}
+
+func decodeSortKeyBound(dec *columnPartImageDecoder) (SortKeyBound, error) {
+	exclusive, err := dec.boolean()
+	if err != nil {
+		return SortKeyBound{}, err
+	}
+	unbounded, err := dec.boolean()
+	if err != nil {
+		return SortKeyBound{}, err
+	}
+	values, err := dec.int64Slice()
+	if err != nil {
+		return SortKeyBound{}, err
+	}
+	return SortKeyBound{Values: values, Exclusive: exclusive, Unbounded: unbounded}, nil
+}
+
+func decodeRowLocatorsSection(image ColumnPartImage) (map[int64]RowLocator, error) {
+	section, err := image.singleSection(ColumnPartImageSectionRowLocators)
+	if err != nil {
+		return nil, err
+	}
+	data := image.sectionBytes(section)
+	if len(data) < 4 {
+		return nil, fmt.Errorf("typedcolumn: truncated row locators section bytes=%d", len(data))
+	}
+	count := binary.LittleEndian.Uint32(data[:4])
+	maxLocators := (len(data) - 4) / rowLocatorBytes
+	if uint64(count) > uint64(maxLocators) {
+		return nil, fmt.Errorf("typedcolumn: row locators count=%d exceeds section capacity=%d", count, maxLocators)
+	}
+	total, err := uint32ToInt(count, "row locators count")
+	if err != nil {
+		return nil, err
+	}
+	recordBytes, err := checkedMulInt(total, rowLocatorBytes, "row locator section bytes")
+	if err != nil {
+		return nil, err
+	}
+	wantBytes, err := checkedAddInt(4, recordBytes, "row locator section bytes")
+	if err != nil {
+		return nil, err
+	}
+	if len(data) != wantBytes {
+		return nil, fmt.Errorf("typedcolumn: row locators section bytes=%d want %d", len(data), wantBytes)
+	}
+	out := make(map[int64]RowLocator, total)
+	offset := 4
+	for i := 0; i < total; i++ {
+		primaryID := int64(binary.LittleEndian.Uint64(data[offset:]))
+		offset += 8
+		partID := binary.LittleEndian.Uint64(data[offset:])
+		offset += 8
+		partRow := binary.LittleEndian.Uint32(data[offset:])
+		offset += 4
+		granuleOrdinal := binary.LittleEndian.Uint32(data[offset:])
+		offset += 4
+		rowInGranule := binary.LittleEndian.Uint32(data[offset:])
+		offset += 4
+		reserved := binary.LittleEndian.Uint32(data[offset:])
+		offset += 4
+		if reserved != 0 {
+			return nil, fmt.Errorf("typedcolumn: row locator primary id %d reserved=%d want 0", primaryID, reserved)
+		}
+		partRowInt, err := uint32ToInt(partRow, "row locator part row")
+		if err != nil {
+			return nil, err
+		}
+		granuleOrdinalInt, err := uint32ToInt(granuleOrdinal, "row locator granule ordinal")
+		if err != nil {
+			return nil, err
+		}
+		rowInGranuleInt, err := uint32ToInt(rowInGranule, "row locator row in granule")
+		if err != nil {
+			return nil, err
+		}
+		if _, exists := out[primaryID]; exists {
+			return nil, fmt.Errorf("typedcolumn: duplicate row locator primary id %d", primaryID)
+		}
+		out[primaryID] = RowLocator{
+			PrimaryID:      primaryID,
+			PartID:         partID,
+			PartRow:        partRowInt,
+			GranuleOrdinal: granuleOrdinalInt,
+			RowInGranule:   rowInGranuleInt,
+		}
+	}
+	return out, nil
+}
+
+func validateDecodedRowLocators(desc ColumnPartDescriptor, partID uint64, locators map[int64]RowLocator) error {
+	if len(locators) != desc.RowCount {
+		return fmt.Errorf("typedcolumn: row locator count=%d want part rows=%d", len(locators), desc.RowCount)
+	}
+	seenRows := make([]bool, desc.RowCount)
+	for primaryID, locator := range locators {
+		if locator.PrimaryID != primaryID {
+			return fmt.Errorf("typedcolumn: row locator key %d has primary id %d", primaryID, locator.PrimaryID)
+		}
+		if locator.PartID != partID {
+			return fmt.Errorf("typedcolumn: row locator primary id %d part id=%d want %d", primaryID, locator.PartID, partID)
+		}
+		if locator.PartRow < 0 || locator.PartRow >= desc.RowCount {
+			return fmt.Errorf("typedcolumn: row locator primary id %d part row=%d outside part rows=%d", primaryID, locator.PartRow, desc.RowCount)
+		}
+		if locator.GranuleOrdinal < 0 || locator.GranuleOrdinal >= len(desc.Granules) {
+			return fmt.Errorf("typedcolumn: row locator primary id %d granule ordinal=%d outside granules=%d", primaryID, locator.GranuleOrdinal, len(desc.Granules))
+		}
+		granule := desc.Granules[locator.GranuleOrdinal]
+		if locator.RowInGranule < 0 || locator.RowInGranule >= granule.RowCount {
+			return fmt.Errorf("typedcolumn: row locator primary id %d row in granule=%d outside granule rows=%d", primaryID, locator.RowInGranule, granule.RowCount)
+		}
+		partRow := granule.FirstRow + locator.RowInGranule
+		if locator.PartRow != partRow {
+			return fmt.Errorf("typedcolumn: row locator primary id %d part row=%d want %d from granule %d", primaryID, locator.PartRow, partRow, locator.GranuleOrdinal)
+		}
+		if seenRows[locator.PartRow] {
+			return fmt.Errorf("typedcolumn: duplicate row locator part row %d", locator.PartRow)
+		}
+		seenRows[locator.PartRow] = true
+	}
+	return nil
+}
+
+func validateDecodedRowLocatorsPrimaryKey(desc ColumnPartDescriptor, columns map[string]ColumnPartColumn, locators map[int64]RowLocator) error {
+	if len(desc.LogicalPrimaryKey) != 1 {
+		return fmt.Errorf("typedcolumn: row locator validation requires one logical primary key column, got %d", len(desc.LogicalPrimaryKey))
+	}
+	primaryColumnName := desc.LogicalPrimaryKey[0]
+	column, ok := columns[primaryColumnName]
+	if !ok {
+		return fmt.Errorf("typedcolumn: row locator validation missing primary key column %s", primaryColumnName)
+	}
+	if column.Definition.Type != ColumnTypeInt64 {
+		return fmt.Errorf("typedcolumn: row locator validation primary key column %s type=%s want int64", primaryColumnName, column.Definition.Type)
+	}
+	var reader GranuleReader
+	var scratch []int64
+	for blockIndex, block := range column.Blocks {
+		values, err := reader.DecodeInt64Into(scratch[:0], block.Granule)
+		if err != nil {
+			return fmt.Errorf("typedcolumn: decode primary key column %s block %d: %w", primaryColumnName, blockIndex, err)
+		}
+		scratch = values
+		if len(values) != block.Descriptor.RowCount {
+			return fmt.Errorf("typedcolumn: primary key column %s block %d decoded rows=%d want %d", primaryColumnName, blockIndex, len(values), block.Descriptor.RowCount)
+		}
+		for rowOffset, primaryID := range values {
+			partRow := block.Descriptor.FirstRow + rowOffset
+			locator, ok := locators[primaryID]
+			if !ok {
+				return fmt.Errorf("typedcolumn: row locator missing primary id %d for part row %d", primaryID, partRow)
+			}
+			if locator.PartRow != partRow {
+				return fmt.Errorf("typedcolumn: row locator primary id %d points to part row %d want %d", primaryID, locator.PartRow, partRow)
+			}
+		}
+	}
+	return nil
+}
+
+func attachColumnPayloadsFromImage(image ColumnPartImage, columns map[string]ColumnPartColumn) error {
+	if err := validateColumnDataSectionsForColumns(image, columns); err != nil {
+		return err
+	}
+	for name, column := range columns {
+		section, ok := image.columnDataSection(name)
+		if !ok {
+			return fmt.Errorf("typedcolumn: image missing column data section %s", name)
+		}
+		offset := section.Offset
+		sectionEnd := section.Offset + section.Length
+		for i := range column.Blocks {
+			block := &column.Blocks[i]
+			length := block.Descriptor.StoredBytes
+			if length < 0 || offset > sectionEnd || length > sectionEnd-offset {
+				return fmt.Errorf("typedcolumn: image column %s block %d length=%d outside section", name, i, length)
+			}
+			block.Granule.Payload = image.Bytes[offset : offset+length]
+			// The payload slice is already narrowed to the block bytes; keep inline refs normalized for granule validation.
+			block.Granule.PayloadRef = PayloadRef{Kind: PayloadRefInline, Length: length}
+			offset += length
+		}
+		if offset != sectionEnd {
+			return fmt.Errorf("typedcolumn: image column %s consumed=%d section=%d", name, offset-section.Offset, section.Length)
+		}
+		columns[name] = column
+	}
+	return nil
+}
+
+func validateColumnDataSectionsForColumns(image ColumnPartImage, columns map[string]ColumnPartColumn) error {
+	required := make(map[string]struct{}, len(columns))
+	for name := range columns {
+		required[name] = struct{}{}
+	}
+	seen := make(map[string]ColumnPartImageSection, len(columns))
+	for _, section := range image.Sections {
+		if section.Kind != ColumnPartImageSectionColumnData {
+			continue
+		}
+		if section.Column == "" {
+			return fmt.Errorf("typedcolumn: image column data section at offset=%d has empty column", section.Offset)
+		}
+		if _, ok := required[section.Column]; !ok {
+			return fmt.Errorf("typedcolumn: image has column data section for unknown column %s at offset=%d", section.Column, section.Offset)
+		}
+		previous, exists := seen[section.Column]
+		if exists {
+			return fmt.Errorf("typedcolumn: duplicate column data section %s at offset=%d previous_offset=%d", section.Column, section.Offset, previous.Offset)
+		}
+		seen[section.Column] = section
+	}
+	for name := range required {
+		if _, ok := seen[name]; !ok {
+			return fmt.Errorf("typedcolumn: image missing column data section %s", name)
+		}
+	}
+	return nil
+}
+
+func (i ColumnPartImage) Dictionaries() (map[string]map[string]int64, error) {
+	if err := i.validateForRead(); err != nil {
+		return nil, err
+	}
+	sections := i.sectionsByKind(ColumnPartImageSectionDictionaries)
+	if len(sections) == 0 {
+		return nil, nil
+	}
+	if len(sections) != 1 {
+		return nil, fmt.Errorf("typedcolumn: image has %d dictionary sections, want 1", len(sections))
+	}
+	dec := columnPartImageDecoder{data: i.sectionBytes(sections[0])}
+	count, err := dec.u32()
+	if err != nil {
+		return nil, err
+	}
+	total, err := dec.boundedCount(count, 8, "dictionaries")
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string]map[string]int64, total)
+	for idx := 0; idx < total; idx++ {
+		name, err := dec.str()
+		if err != nil {
+			return nil, err
+		}
+		if _, exists := out[name]; exists {
+			return nil, fmt.Errorf("typedcolumn: duplicate dictionary %s", name)
+		}
+		entryCount, err := dec.u32()
+		if err != nil {
+			return nil, err
+		}
+		entries, err := dec.boundedCount(entryCount, 12, "dictionary entries")
+		if err != nil {
+			return nil, err
+		}
+		values := make(map[string]int64, entries)
+		codes := make(map[int64]string, entries)
+		for j := 0; j < entries; j++ {
+			code, err := dec.i64()
+			if err != nil {
+				return nil, err
+			}
+			value, err := dec.str()
+			if err != nil {
+				return nil, err
+			}
+			if _, exists := values[value]; exists {
+				return nil, fmt.Errorf("typedcolumn: duplicate dictionary value %s in %s", value, name)
+			}
+			if previous, exists := codes[code]; exists {
+				return nil, fmt.Errorf("typedcolumn: duplicate dictionary code %d in %s for %q and %q", code, name, previous, value)
+			}
+			values[value] = code
+			codes[code] = value
+		}
+		out[name] = values
+	}
+	if err := dec.finish(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func decodeAggregateMetadataSections(image ColumnPartImage) (map[string]AggregateMetadata, error) {
+	sections := image.sectionsByKind(ColumnPartImageSectionAggregateMetadata)
+	if len(sections) == 0 {
+		return nil, nil
+	}
+	out := make(map[string]AggregateMetadata, len(sections))
+	for _, section := range sections {
+		dec := columnPartImageDecoder{data: image.sectionBytes(section)}
+		def, err := decodeAggregateMetadataDefinition(&dec)
+		if err != nil {
+			return nil, err
+		}
+		stats, err := decodeAggregateMetadataStats(&dec)
+		if err != nil {
+			return nil, err
+		}
+		granuleCount, err := dec.u32()
+		if err != nil {
+			return nil, err
+		}
+		granules, err := dec.boundedCount(granuleCount, 36, "aggregate metadata granules")
+		if err != nil {
+			return nil, err
+		}
+		metadata := AggregateMetadata{
+			Definition: def,
+			Stats:      stats,
+			Granules:   make([]AggregateMetadataGranule, 0, granules),
+		}
+		totalMatchedRows := 0
+		for i := 0; i < granules; i++ {
+			granuleOrdinal, err := dec.i64()
+			if err != nil {
+				return nil, err
+			}
+			firstRow, err := dec.i64()
+			if err != nil {
+				return nil, err
+			}
+			rowCount, err := dec.i64()
+			if err != nil {
+				return nil, err
+			}
+			matchedRows, err := dec.i64()
+			if err != nil {
+				return nil, err
+			}
+			entryCount, err := dec.u32()
+			if err != nil {
+				return nil, err
+			}
+			entries, err := dec.boundedCount(entryCount, 24, "aggregate metadata entries")
+			if err != nil {
+				return nil, err
+			}
+			granuleOrdinalInt, err := nonNegativeInt64ToInt(granuleOrdinal, "aggregate metadata granule ordinal")
+			if err != nil {
+				return nil, err
+			}
+			firstRowInt, err := nonNegativeInt64ToInt(firstRow, "aggregate metadata first row")
+			if err != nil {
+				return nil, err
+			}
+			rowCountInt, err := nonNegativeInt64ToInt(rowCount, "aggregate metadata row count")
+			if err != nil {
+				return nil, err
+			}
+			matchedRowsInt, err := nonNegativeInt64ToInt(matchedRows, "aggregate metadata matched rows")
+			if err != nil {
+				return nil, err
+			}
+			granule := AggregateMetadataGranule{
+				GranuleOrdinal: granuleOrdinalInt,
+				FirstRow:       firstRowInt,
+				RowCount:       rowCountInt,
+				MatchedRows:    matchedRowsInt,
+				Entries:        make([]AggregateMetadataEntry, 0, entries),
+			}
+			entryRows := 0
+			for j := 0; j < entries; j++ {
+				group, err := dec.u32()
+				if err != nil {
+					return nil, err
+				}
+				count, err := dec.u32()
+				if err != nil {
+					return nil, err
+				}
+				if count == 0 {
+					return nil, fmt.Errorf("typedcolumn: aggregate metadata %s granule %d entry %d has zero count", metadata.Definition.Name, granuleOrdinalInt, j)
+				}
+				minValue, err := dec.i64()
+				if err != nil {
+					return nil, err
+				}
+				maxValue, err := dec.i64()
+				if err != nil {
+					return nil, err
+				}
+				if minValue > maxValue {
+					return nil, fmt.Errorf("typedcolumn: aggregate metadata %s granule %d entry %d min=%d exceeds max=%d", metadata.Definition.Name, granuleOrdinalInt, j, minValue, maxValue)
+				}
+				granule.Entries = append(granule.Entries, AggregateMetadataEntry{Group: group, Count: count, Min: minValue, Max: maxValue})
+				entryRows += int(count)
+			}
+			if entryRows != granule.MatchedRows {
+				return nil, fmt.Errorf("typedcolumn: aggregate metadata %s granule %d entry rows=%d matched rows=%d", metadata.Definition.Name, granule.GranuleOrdinal, entryRows, granule.MatchedRows)
+			}
+			metadata.Granules = append(metadata.Granules, granule)
+			totalMatchedRows += granule.MatchedRows
+		}
+		if metadata.Stats.Admitted && totalMatchedRows != metadata.Stats.RowsMatched {
+			return nil, fmt.Errorf("typedcolumn: aggregate metadata %s granule matched rows=%d stats matched rows=%d", metadata.Definition.Name, totalMatchedRows, metadata.Stats.RowsMatched)
+		}
+		if !metadata.Stats.Admitted && len(metadata.Granules) != 0 {
+			return nil, fmt.Errorf("typedcolumn: aggregate metadata %s is rejected but has %d granules", metadata.Definition.Name, len(metadata.Granules))
+		}
+		if err := dec.finish(); err != nil {
+			return nil, err
+		}
+		if _, exists := out[metadata.Definition.Name]; exists {
+			return nil, fmt.Errorf("typedcolumn: duplicate aggregate metadata %s at section %s offset=%d", metadata.Definition.Name, section.Name, section.Offset)
+		}
+		out[metadata.Definition.Name] = metadata
+	}
+	return out, nil
+}
+
+func decodeAggregateMetadataDefinition(dec *columnPartImageDecoder) (AggregateMetadataDefinition, error) {
+	name, err := dec.str()
+	if err != nil {
+		return AggregateMetadataDefinition{}, err
+	}
+	version, err := dec.u16()
+	if err != nil {
+		return AggregateMetadataDefinition{}, err
+	}
+	kind, err := dec.str()
+	if err != nil {
+		return AggregateMetadataDefinition{}, err
+	}
+	scope, err := dec.str()
+	if err != nil {
+		return AggregateMetadataDefinition{}, err
+	}
+	groupKeys, err := dec.stringSlice()
+	if err != nil {
+		return AggregateMetadataDefinition{}, err
+	}
+	measureCount, err := dec.u32()
+	if err != nil {
+		return AggregateMetadataDefinition{}, err
+	}
+	measureTotal, err := dec.boundedCount(measureCount, 8, "aggregate metadata measures")
+	if err != nil {
+		return AggregateMetadataDefinition{}, err
+	}
+	measures := make([]AggregateMetadataMeasure, 0, measureTotal)
+	for i := 0; i < measureTotal; i++ {
+		op, err := dec.str()
+		if err != nil {
+			return AggregateMetadataDefinition{}, err
+		}
+		column, err := dec.str()
+		if err != nil {
+			return AggregateMetadataDefinition{}, err
+		}
+		measures = append(measures, AggregateMetadataMeasure{Op: AggregateMetadataMeasureOp(op), Column: column})
+	}
+	predicateCount, err := dec.u32()
+	if err != nil {
+		return AggregateMetadataDefinition{}, err
+	}
+	predicateTotal, err := dec.boundedCount(predicateCount, 16, "aggregate metadata predicates")
+	if err != nil {
+		return AggregateMetadataDefinition{}, err
+	}
+	predicates := make([]AggregateMetadataPredicate, 0, predicateTotal)
+	for i := 0; i < predicateTotal; i++ {
+		column, err := dec.str()
+		if err != nil {
+			return AggregateMetadataDefinition{}, err
+		}
+		op, err := dec.str()
+		if err != nil {
+			return AggregateMetadataDefinition{}, err
+		}
+		value, err := dec.i64()
+		if err != nil {
+			return AggregateMetadataDefinition{}, err
+		}
+		predicates = append(predicates, AggregateMetadataPredicate{Column: column, Op: AggregateMetadataPredicateOp(op), Value: value})
+	}
+	maxBytesPerRow, err := dec.i64()
+	if err != nil {
+		return AggregateMetadataDefinition{}, err
+	}
+	maxBytesPerRowFloat, err := nonNegativeScaledInt64ToFloat64(maxBytesPerRow, "aggregate metadata max bytes per row")
+	if err != nil {
+		return AggregateMetadataDefinition{}, err
+	}
+	return AggregateMetadataDefinition{
+		Name:           name,
+		Version:        version,
+		Kind:           AggregateMetadataKind(kind),
+		Scope:          AggregateMetadataScope(scope),
+		GroupKeys:      groupKeys,
+		Measures:       measures,
+		Predicates:     predicates,
+		MaxBytesPerRow: maxBytesPerRowFloat,
+	}, nil
+}
+
+func decodeAggregateMetadataStats(dec *columnPartImageDecoder) (AggregateMetadataStats, error) {
+	admitted, err := dec.boolean()
+	if err != nil {
+		return AggregateMetadataStats{}, err
+	}
+	rejectedReason, err := dec.str()
+	if err != nil {
+		return AggregateMetadataStats{}, err
+	}
+	buildNanos, err := dec.i64()
+	if err != nil {
+		return AggregateMetadataStats{}, err
+	}
+	granules, err := dec.i64()
+	if err != nil {
+		return AggregateMetadataStats{}, err
+	}
+	granulesWithRows, err := dec.i64()
+	if err != nil {
+		return AggregateMetadataStats{}, err
+	}
+	rowsMatched, err := dec.i64()
+	if err != nil {
+		return AggregateMetadataStats{}, err
+	}
+	entries, err := dec.i64()
+	if err != nil {
+		return AggregateMetadataStats{}, err
+	}
+	valueBytes, err := dec.i64()
+	if err != nil {
+		return AggregateMetadataStats{}, err
+	}
+	descriptorBytes, err := dec.i64()
+	if err != nil {
+		return AggregateMetadataStats{}, err
+	}
+	totalBytes, err := dec.i64()
+	if err != nil {
+		return AggregateMetadataStats{}, err
+	}
+	bytesPerPartRow, err := dec.i64()
+	if err != nil {
+		return AggregateMetadataStats{}, err
+	}
+	bytesPerMatchedRow, err := dec.i64()
+	if err != nil {
+		return AggregateMetadataStats{}, err
+	}
+	compression, err := dec.str()
+	if err != nil {
+		return AggregateMetadataStats{}, err
+	}
+	admissionMaxBytes, err := dec.i64()
+	if err != nil {
+		return AggregateMetadataStats{}, err
+	}
+	admissionMeasuredBy, err := dec.str()
+	if err != nil {
+		return AggregateMetadataStats{}, err
+	}
+	if buildNanos < 0 {
+		return AggregateMetadataStats{}, fmt.Errorf("typedcolumn: negative aggregate metadata build duration %d", buildNanos)
+	}
+	granulesInt, err := nonNegativeInt64ToInt(granules, "aggregate metadata granules")
+	if err != nil {
+		return AggregateMetadataStats{}, err
+	}
+	granulesWithRowsInt, err := nonNegativeInt64ToInt(granulesWithRows, "aggregate metadata granules with rows")
+	if err != nil {
+		return AggregateMetadataStats{}, err
+	}
+	rowsMatchedInt, err := nonNegativeInt64ToInt(rowsMatched, "aggregate metadata rows matched")
+	if err != nil {
+		return AggregateMetadataStats{}, err
+	}
+	entriesInt, err := nonNegativeInt64ToInt(entries, "aggregate metadata entries")
+	if err != nil {
+		return AggregateMetadataStats{}, err
+	}
+	valueBytesInt, err := nonNegativeInt64ToInt(valueBytes, "aggregate metadata value bytes")
+	if err != nil {
+		return AggregateMetadataStats{}, err
+	}
+	descriptorBytesInt, err := nonNegativeInt64ToInt(descriptorBytes, "aggregate metadata descriptor bytes")
+	if err != nil {
+		return AggregateMetadataStats{}, err
+	}
+	totalBytesInt, err := nonNegativeInt64ToInt(totalBytes, "aggregate metadata total bytes")
+	if err != nil {
+		return AggregateMetadataStats{}, err
+	}
+	bytesPerPartRowFloat, err := nonNegativeScaledInt64ToFloat64(bytesPerPartRow, "aggregate metadata bytes per part row")
+	if err != nil {
+		return AggregateMetadataStats{}, err
+	}
+	bytesPerMatchedRowFloat, err := nonNegativeScaledInt64ToFloat64(bytesPerMatchedRow, "aggregate metadata bytes per matched row")
+	if err != nil {
+		return AggregateMetadataStats{}, err
+	}
+	admissionMaxBytesFloat, err := nonNegativeScaledInt64ToFloat64(admissionMaxBytes, "aggregate metadata admission max bytes")
+	if err != nil {
+		return AggregateMetadataStats{}, err
+	}
+	return AggregateMetadataStats{
+		Admitted:            admitted,
+		RejectedReason:      rejectedReason,
+		BuildDuration:       time.Duration(buildNanos),
+		Granules:            granulesInt,
+		GranulesWithRows:    granulesWithRowsInt,
+		RowsMatched:         rowsMatchedInt,
+		Entries:             entriesInt,
+		ValueBytes:          valueBytesInt,
+		DescriptorBytes:     descriptorBytesInt,
+		TotalBytes:          totalBytesInt,
+		BytesPerPartRow:     bytesPerPartRowFloat,
+		BytesPerMatchedRow:  bytesPerMatchedRowFloat,
+		Compression:         compression,
+		AdmissionMaxBytes:   admissionMaxBytesFloat,
+		AdmissionMeasuredBy: admissionMeasuredBy,
+	}, nil
+}
+
+func nonNegativeScaledInt64ToFloat64(v int64, field string) (float64, error) {
+	if v < 0 {
+		return 0, fmt.Errorf("typedcolumn: negative %s %d", field, v)
+	}
+	return float64(v) / 1_000_000, nil
+}
+
+func (i ColumnPartImage) singleSection(kind ColumnPartImageSectionKind) (ColumnPartImageSection, error) {
+	sections := i.sectionsByKind(kind)
+	if len(sections) != 1 {
+		return ColumnPartImageSection{}, fmt.Errorf("typedcolumn: image has %d %s sections, want 1", len(sections), kind)
+	}
+	return sections[0], nil
+}
+
+func (i ColumnPartImage) sectionsByKind(kind ColumnPartImageSectionKind) []ColumnPartImageSection {
+	out := make([]ColumnPartImageSection, 0, 1)
+	for _, section := range i.Sections {
+		if section.Kind == kind {
+			out = append(out, section)
+		}
+	}
+	return out
+}
+
+func (i ColumnPartImage) sectionBytes(section ColumnPartImageSection) []byte {
+	return i.Bytes[section.Offset : section.Offset+section.Length]
+}
+
+func (i ColumnPartImage) validateForRead() error {
+	if i.TotalBytes() == 0 {
+		return fmt.Errorf("typedcolumn: empty part image")
+	}
+	if i.Version != columnPartImageVersion {
+		return fmt.Errorf("typedcolumn: unsupported part image version %d", i.Version)
+	}
+	if i.Rows < 0 {
+		return fmt.Errorf("typedcolumn: negative image row count %d", i.Rows)
+	}
+	if i.ManifestBytes <= 0 || i.ManifestBytes > len(i.Bytes) {
+		return fmt.Errorf("typedcolumn: manifest bytes=%d exceed image bytes=%d", i.ManifestBytes, len(i.Bytes))
+	}
+	for _, section := range i.Sections {
+		if section.Kind == ColumnPartImageSectionManifest {
+			return fmt.Errorf("typedcolumn: manifest is not a directory section")
+		}
+		if err := validateImageSectionCategory(section.Kind, section.Category); err != nil {
+			return err
+		}
+		if err := validateImageSectionBounds(section, i.ManifestBytes, len(i.Bytes)); err != nil {
+			return err
+		}
+	}
+	if err := validateImageSectionLayout(i.Sections, i.ManifestBytes, len(i.Bytes)); err != nil {
+		return err
+	}
+	if err := validateImageSectionMultiplicity(i.Sections); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateImageSectionBounds(section ColumnPartImageSection, manifestBytes int, totalBytes int) error {
+	if section.Offset < 0 {
+		return fmt.Errorf("typedcolumn: section %s has negative offset %d", section.Kind, section.Offset)
+	}
+	if section.Offset < manifestBytes {
+		return fmt.Errorf("typedcolumn: section %s offset=%d before manifest=%d", section.Kind, section.Offset, manifestBytes)
+	}
+	if section.Offset%columnPartImageSectionAlignment != 0 {
+		return fmt.Errorf("typedcolumn: section %s offset=%d is not %d-byte aligned", section.Kind, section.Offset, columnPartImageSectionAlignment)
+	}
+	if section.Length < 0 {
+		return fmt.Errorf("typedcolumn: section %s has negative length %d", section.Kind, section.Length)
+	}
+	if section.Length > totalBytes || section.Offset > totalBytes-section.Length {
+		return fmt.Errorf("typedcolumn: section %s offset=%d length=%d exceeds image bytes=%d", section.Kind, section.Offset, section.Length, totalBytes)
+	}
+	return nil
+}
+
+func validateImageSectionCount(sectionCount uint32, manifestBytes int, decodedManifestBytes int) error {
+	const minSectionDirectoryEntryBytes = 56
+	remainingManifestBytes := manifestBytes - decodedManifestBytes
+	if remainingManifestBytes < 0 {
+		return fmt.Errorf("typedcolumn: decoded manifest bytes=%d exceed manifest bytes=%d", decodedManifestBytes, manifestBytes)
+	}
+	maxSections := remainingManifestBytes / minSectionDirectoryEntryBytes
+	if int(sectionCount) > maxSections {
+		return fmt.Errorf("typedcolumn: section count=%d exceeds manifest capacity=%d", sectionCount, maxSections)
+	}
+	return nil
+}
+
+func validateImageSectionLayout(sections []ColumnPartImageSection, manifestBytes int, totalBytes int) error {
+	cursor := manifestBytes
+	for _, section := range sections {
+		if section.Offset < cursor {
+			return fmt.Errorf("typedcolumn: section %s offset=%d overlaps previous end=%d", section.Kind, section.Offset, cursor)
+		}
+		cursor = section.Offset + section.Length
+	}
+	if cursor != totalBytes {
+		return fmt.Errorf("typedcolumn: image sections cover %d bytes, image has %d", cursor, totalBytes)
+	}
+	return nil
+}
+
+func validateImageSectionMultiplicity(sections []ColumnPartImageSection) error {
+	counts := make(map[ColumnPartImageSectionKind]int, len(sections))
+	for _, section := range sections {
+		counts[section.Kind]++
+	}
+	for _, kind := range []ColumnPartImageSectionKind{
+		ColumnPartImageSectionDescriptor,
+		ColumnPartImageSectionSortKeyMetadata,
+		ColumnPartImageSectionSortKeyMarks,
+		ColumnPartImageSectionRowLocators,
+		ColumnPartImageSectionDictionaries,
+	} {
+		if counts[kind] > 1 {
+			return fmt.Errorf("typedcolumn: image has %d %s sections, want at most 1", counts[kind], kind)
+		}
+	}
+	return nil
+}
+
+func validateImageSectionCategory(kind ColumnPartImageSectionKind, category ColumnPartImageSectionCategory) error {
+	expected, ok := expectedImageSectionCategory(kind)
+	if ok && category != expected {
+		return fmt.Errorf("typedcolumn: section %s category=%s want %s", kind, category, expected)
+	}
+	return nil
+}
+
+func expectedImageSectionCategory(kind ColumnPartImageSectionKind) (ColumnPartImageSectionCategory, bool) {
+	switch kind {
+	case ColumnPartImageSectionDescriptor:
+		return ColumnPartImageCategoryDescriptor, true
+	case ColumnPartImageSectionSortKeyMetadata:
+		return ColumnPartImageCategorySortKeyMetadata, true
+	case ColumnPartImageSectionSortKeyMarks:
+		return ColumnPartImageCategoryMarks, true
+	case ColumnPartImageSectionRowLocators:
+		return ColumnPartImageCategoryLocators, true
+	case ColumnPartImageSectionAggregateMetadata:
+		return ColumnPartImageCategoryAggregateMetadata, true
+	case ColumnPartImageSectionDictionaries:
+		return ColumnPartImageCategoryDictionaries, true
+	case ColumnPartImageSectionColumnData:
+		return ColumnPartImageCategoryDeclaredColumns, true
+	case ColumnPartImageSectionManifest:
+		return ColumnPartImageCategoryManifest, true
+	default:
+		return "", false
+	}
+}
+
+func inferredRowsPerGranule(granules []GranuleDescriptor) int {
+	if len(granules) == 0 {
+		return 0
+	}
+	return granules[0].RowCount
+}
+
+func inferredDefaultCodecBlockRows(columns []ColumnPartColumnDescriptor) int {
+	for _, column := range columns {
+		if len(column.Blocks) > 0 {
+			return column.Blocks[0].RowCount
+		}
+	}
+	return 0
+}
+
+type columnPartImageDecoder struct {
+	data   []byte
+	offset int
+}
+
+func (d *columnPartImageDecoder) u16() (uint16, error) {
+	if err := d.require(2); err != nil {
+		return 0, err
+	}
+	v := binary.LittleEndian.Uint16(d.data[d.offset:])
+	d.offset += 2
+	return v, nil
+}
+
+func (d *columnPartImageDecoder) u32() (uint32, error) {
+	if err := d.require(4); err != nil {
+		return 0, err
+	}
+	v := binary.LittleEndian.Uint32(d.data[d.offset:])
+	d.offset += 4
+	return v, nil
+}
+
+func (d *columnPartImageDecoder) u64() (uint64, error) {
+	if err := d.require(8); err != nil {
+		return 0, err
+	}
+	v := binary.LittleEndian.Uint64(d.data[d.offset:])
+	d.offset += 8
+	return v, nil
+}
+
+func (d *columnPartImageDecoder) i64() (int64, error) {
+	v, err := d.u64()
+	return int64(v), err
+}
+
+func (d *columnPartImageDecoder) boolean() (bool, error) {
+	v, err := d.u16()
+	if err != nil {
+		return false, err
+	}
+	switch v {
+	case 0:
+		return false, nil
+	case 1:
+		return true, nil
+	default:
+		return false, fmt.Errorf("typedcolumn: invalid boolean value %d", v)
+	}
+}
+
+func (d *columnPartImageDecoder) str() (string, error) {
+	length, err := d.u32()
+	if err != nil {
+		return "", err
+	}
+	lengthInt, err := d.countToInt(length, "string bytes")
+	if err != nil {
+		return "", err
+	}
+	if lengthInt > maxColumnPartImageStringBytes {
+		return "", fmt.Errorf("typedcolumn: string bytes=%d exceeds max=%d", lengthInt, maxColumnPartImageStringBytes)
+	}
+	if err := d.require(lengthInt); err != nil {
+		return "", err
+	}
+	v := string(d.data[d.offset : d.offset+lengthInt])
+	d.offset += lengthInt
+	return v, nil
+}
+
+func (d *columnPartImageDecoder) stringSlice() ([]string, error) {
+	count, err := d.u32()
+	if err != nil {
+		return nil, err
+	}
+	total, err := d.boundedCount(count, 4, "string slice values")
+	if err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, total)
+	for i := 0; i < total; i++ {
+		value, err := d.str()
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, value)
+	}
+	return out, nil
+}
+
+func (d *columnPartImageDecoder) int64Slice() ([]int64, error) {
+	count, err := d.u32()
+	if err != nil {
+		return nil, err
+	}
+	total, err := d.boundedCount(count, 8, "int64 slice values")
+	if err != nil {
+		return nil, err
+	}
+	out := make([]int64, 0, total)
+	for i := 0; i < total; i++ {
+		value, err := d.i64()
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, value)
+	}
+	return out, nil
+}
+
+func (d *columnPartImageDecoder) require(n int) error {
+	if n < 0 || n > len(d.data)-d.offset {
+		return fmt.Errorf("typedcolumn: truncated part image at offset %d need %d bytes have %d", d.offset, n, len(d.data)-d.offset)
+	}
+	return nil
+}
+
+func (d *columnPartImageDecoder) boundedCount(count uint32, minItemBytes int, label string) (int, error) {
+	total, err := d.countToInt(count, label)
+	if err != nil {
+		return 0, err
+	}
+	if minItemBytes < 0 {
+		return 0, fmt.Errorf("typedcolumn: invalid minimum item bytes %d for %s", minItemBytes, label)
+	}
+	if minItemBytes > 0 && total > (len(d.data)-d.offset)/minItemBytes {
+		return 0, fmt.Errorf("typedcolumn: %s count=%d exceeds section capacity=%d", label, count, (len(d.data)-d.offset)/minItemBytes)
+	}
+	return total, nil
+}
+
+func (d *columnPartImageDecoder) countToInt(count uint32, label string) (int, error) {
+	total := int(count)
+	if uint64(total) != uint64(count) {
+		return 0, fmt.Errorf("typedcolumn: %s count=%d exceeds host int", label, count)
+	}
+	return total, nil
+}
+
+func nonNegativeInt64ToInt(value int64, label string) (int, error) {
+	if value < 0 {
+		return 0, fmt.Errorf("typedcolumn: negative %s %d", label, value)
+	}
+	out := int(value)
+	if int64(out) != value {
+		return 0, fmt.Errorf("typedcolumn: %s=%d exceeds host int", label, value)
+	}
+	return out, nil
+}
+
+func (d *columnPartImageDecoder) finish() error {
+	if d.offset != len(d.data) {
+		return fmt.Errorf("typedcolumn: trailing part image section bytes=%d", len(d.data)-d.offset)
+	}
+	return nil
+}
+
+func columnTypeFromCode(code uint16) (ColumnType, error) {
+	switch code {
+	case 1:
+		return ColumnTypeInt64, nil
+	case 2:
+		return ColumnTypeLowCardinalityCode, nil
+	case 3:
+		return ColumnTypeBool, nil
+	default:
+		return "", fmt.Errorf("typedcolumn: unknown column type code %d", code)
+	}
+}

--- a/TreeDB/internal/typedcolumn/part_set.go
+++ b/TreeDB/internal/typedcolumn/part_set.go
@@ -167,6 +167,9 @@ func (r *PartSetReader) buildVisibility(tombstones []Tombstone) error {
 			stats.DeltaParts++
 		}
 		stats.InputRows += loaded.Part.Descriptor.RowCount
+		if err := validateDecodedRowLocators(loaded.Part.Descriptor, loaded.Part.Descriptor.PartID, loaded.Part.Locators); err != nil {
+			return fmt.Errorf("typedcolumn: part set part %d locators: %w", loaded.Part.Descriptor.PartID, err)
+		}
 		for primaryID, locator := range loaded.Part.Locators {
 			if locator.PartID != loaded.Part.Descriptor.PartID {
 				return fmt.Errorf("typedcolumn: part set locator part=%d want %d", locator.PartID, loaded.Part.Descriptor.PartID)

--- a/TreeDB/internal/typedcolumn/part_set.go
+++ b/TreeDB/internal/typedcolumn/part_set.go
@@ -121,6 +121,10 @@ func (r *PartSetReader) LatestLocator(primaryID int64) (RowLocator, bool) {
 	return ref.Locator, true
 }
 
+// ScanLatestLocator recomputes latest-visible selection from the caller-owned
+// parts instead of reading the cached index. It is retained as a data-plane
+// cross-check and adapter seam for future lazy/mappedresource-backed readers;
+// immutable in-memory parts should match LatestLocator.
 func (r *PartSetReader) ScanLatestLocator(primaryID int64) (RowLocator, bool) {
 	ref, ok := r.scanLatestRowRef(primaryID)
 	if !ok {

--- a/TreeDB/internal/typedcolumn/part_set.go
+++ b/TreeDB/internal/typedcolumn/part_set.go
@@ -1,0 +1,277 @@
+package typedcolumn
+
+import (
+	"fmt"
+	"sort"
+)
+
+// PartRole records whether a typed-column part participates as a base or delta
+// in a logical part set. Publication/control-plane ownership is intentionally
+// outside this package; callers provide already-open non-authoritative parts.
+type PartRole string
+
+const (
+	PartRoleBase  PartRole = "base"
+	PartRoleDelta PartRole = "delta"
+)
+
+// PartRef is the data-plane identity needed to evaluate latest-visible rows
+// across base and delta parts. It deliberately excludes collection manifest,
+// WAL, recovery, and asset publication references.
+type PartRef struct {
+	Role         PartRole
+	GenerationID uint64
+	Part         *ColumnPart
+}
+
+// Tombstone removes a primary ID at or below the tombstone generation.
+type Tombstone struct {
+	PrimaryID    int64
+	GenerationID uint64
+}
+
+type PartSetReader struct {
+	parts          []partSetLoadedPart
+	latest         map[int64]partSetRowRef
+	visibleRows    map[int]map[int]struct{}
+	visibleRowList []partSetVisibleRows
+	tombstoneByID  map[int64]uint64
+	visibilityStat PartSetVisibilityStats
+}
+
+type partSetLoadedPart struct {
+	Ref     PartRef
+	Part    *ColumnPart
+	Ordinal int
+}
+
+type partSetRowRef struct {
+	PrimaryID    int64
+	PartIndex    int
+	PartRow      int
+	GenerationID uint64
+	Ordinal      int
+	Locator      RowLocator
+}
+
+type partSetVisibleRows struct {
+	Rows []int
+	All  bool
+}
+
+type PartSetVisibilityStats struct {
+	Parts          int `json:"parts"`
+	BaseParts      int `json:"base_parts"`
+	DeltaParts     int `json:"delta_parts"`
+	InputRows      int `json:"input_rows"`
+	VisibleRows    int `json:"visible_rows"`
+	SupersededRows int `json:"superseded_rows"`
+	DeletedRows    int `json:"deleted_rows"`
+	Tombstones     int `json:"tombstones"`
+}
+
+// NewPartSetReader builds a non-authoritative latest-visible row index over
+// caller-owned parts. The algorithm is copied/adapted from experiments/colgranule
+// ColumnPartSetReader.buildVisibility without workspace or collection-manifest
+// publication plumbing.
+func NewPartSetReader(refs []PartRef, tombstones []Tombstone) (*PartSetReader, error) {
+	reader := &PartSetReader{
+		latest:        make(map[int64]partSetRowRef),
+		visibleRows:   make(map[int]map[int]struct{}),
+		tombstoneByID: make(map[int64]uint64, len(tombstones)),
+	}
+	for i, ref := range refs {
+		if ref.Part == nil {
+			return nil, fmt.Errorf("typedcolumn: nil part set part at index %d", i)
+		}
+		switch ref.Role {
+		case PartRoleBase, PartRoleDelta:
+		case "":
+			return nil, fmt.Errorf("typedcolumn: empty part set role at index %d", i)
+		default:
+			return nil, fmt.Errorf("typedcolumn: unsupported part set role %q", ref.Role)
+		}
+		reader.parts = append(reader.parts, partSetLoadedPart{
+			Ref:     ref,
+			Part:    ref.Part,
+			Ordinal: len(reader.parts),
+		})
+	}
+	if err := reader.buildVisibility(tombstones); err != nil {
+		return nil, err
+	}
+	return reader, nil
+}
+
+func (r *PartSetReader) VisibilityStats() PartSetVisibilityStats {
+	if r == nil {
+		return PartSetVisibilityStats{}
+	}
+	return r.visibilityStat
+}
+
+func (r *PartSetReader) LatestLocator(primaryID int64) (RowLocator, bool) {
+	if r == nil {
+		return RowLocator{}, false
+	}
+	ref, ok := r.latest[primaryID]
+	if !ok {
+		return RowLocator{}, false
+	}
+	return ref.Locator, true
+}
+
+func (r *PartSetReader) ScanLatestLocator(primaryID int64) (RowLocator, bool) {
+	ref, ok := r.scanLatestRowRef(primaryID)
+	if !ok {
+		return RowLocator{}, false
+	}
+	return ref.Locator, true
+}
+
+func (r *PartSetReader) ValueAtLatest(primaryID int64, columnName string) (int64, bool, error) {
+	if r == nil {
+		return 0, false, nil
+	}
+	ref, ok := r.latest[primaryID]
+	if !ok {
+		return 0, false, nil
+	}
+	value, err := r.valueAtRowRef(ref, columnName)
+	if err != nil {
+		return 0, false, err
+	}
+	return value, true, nil
+}
+
+func (r *PartSetReader) VisibleRowsForPart(partIndex int) ([]int, bool) {
+	visible := r.visibleRowsForPart(partIndex)
+	return append([]int(nil), visible.Rows...), visible.All
+}
+
+func (r *PartSetReader) buildVisibility(tombstones []Tombstone) error {
+	for _, tombstone := range tombstones {
+		if prev, ok := r.tombstoneByID[tombstone.PrimaryID]; !ok || tombstone.GenerationID > prev {
+			r.tombstoneByID[tombstone.PrimaryID] = tombstone.GenerationID
+		}
+	}
+	stats := PartSetVisibilityStats{
+		Parts:      len(r.parts),
+		Tombstones: len(tombstones),
+	}
+	for partIndex, loaded := range r.parts {
+		switch loaded.Ref.Role {
+		case PartRoleBase:
+			stats.BaseParts++
+		case PartRoleDelta:
+			stats.DeltaParts++
+		}
+		stats.InputRows += loaded.Part.Descriptor.RowCount
+		for primaryID, locator := range loaded.Part.Locators {
+			if locator.PartID != loaded.Part.Descriptor.PartID {
+				return fmt.Errorf("typedcolumn: part set locator part=%d want %d", locator.PartID, loaded.Part.Descriptor.PartID)
+			}
+			if locator.PartRow < 0 || locator.PartRow >= loaded.Part.Descriptor.RowCount {
+				return fmt.Errorf("typedcolumn: part set locator row=%d outside part %d rows=%d", locator.PartRow, loaded.Part.Descriptor.PartID, loaded.Part.Descriptor.RowCount)
+			}
+			row := partSetRowRef{
+				PrimaryID:    primaryID,
+				PartIndex:    partIndex,
+				PartRow:      locator.PartRow,
+				GenerationID: loaded.Ref.GenerationID,
+				Ordinal:      loaded.Ordinal,
+				Locator:      locator,
+			}
+			if tombstoneGeneration, ok := r.tombstoneByID[primaryID]; ok && tombstoneGeneration >= row.GenerationID {
+				stats.DeletedRows++
+				continue
+			}
+			prev, ok := r.latest[primaryID]
+			if !ok || row.newerThan(prev) {
+				if ok {
+					stats.SupersededRows++
+				}
+				r.latest[primaryID] = row
+				continue
+			}
+			stats.SupersededRows++
+		}
+	}
+	for _, row := range r.latest {
+		if r.visibleRows[row.PartIndex] == nil {
+			r.visibleRows[row.PartIndex] = make(map[int]struct{})
+		}
+		r.visibleRows[row.PartIndex][row.PartRow] = struct{}{}
+	}
+	r.visibleRowList = make([]partSetVisibleRows, len(r.parts))
+	for partIndex, rows := range r.visibleRows {
+		list := make([]int, 0, len(rows))
+		for row := range rows {
+			list = append(list, row)
+		}
+		sort.Ints(list)
+		r.visibleRowList[partIndex] = partSetVisibleRows{
+			Rows: list,
+			All:  len(list) == r.parts[partIndex].Part.Descriptor.RowCount,
+		}
+	}
+	stats.VisibleRows = len(r.latest)
+	r.visibilityStat = stats
+	return nil
+}
+
+func (r *PartSetReader) visibleRowsForPart(partIndex int) partSetVisibleRows {
+	if r == nil || partIndex < 0 || partIndex >= len(r.visibleRowList) {
+		return partSetVisibleRows{}
+	}
+	return r.visibleRowList[partIndex]
+}
+
+func (r *PartSetReader) scanLatestRowRef(primaryID int64) (partSetRowRef, bool) {
+	if r == nil {
+		return partSetRowRef{}, false
+	}
+	var best partSetRowRef
+	var found bool
+	tombstoneGeneration, tombstoned := r.tombstoneByID[primaryID]
+	for partIndex, loaded := range r.parts {
+		locator, ok := loaded.Part.LocatePrimaryID(primaryID)
+		if !ok {
+			continue
+		}
+		row := partSetRowRef{
+			PrimaryID:    primaryID,
+			PartIndex:    partIndex,
+			PartRow:      locator.PartRow,
+			GenerationID: loaded.Ref.GenerationID,
+			Ordinal:      loaded.Ordinal,
+			Locator:      locator,
+		}
+		if tombstoned && tombstoneGeneration >= row.GenerationID {
+			continue
+		}
+		if !found || row.newerThan(best) {
+			best = row
+			found = true
+		}
+	}
+	return best, found
+}
+
+func (r *PartSetReader) valueAtRowRef(ref partSetRowRef, columnName string) (int64, error) {
+	if r == nil {
+		return 0, fmt.Errorf("typedcolumn: nil part set reader")
+	}
+	if ref.PartIndex < 0 || ref.PartIndex >= len(r.parts) {
+		return 0, fmt.Errorf("typedcolumn: row ref part index %d outside %d parts", ref.PartIndex, len(r.parts))
+	}
+	scanner := ColumnPartScanner{part: r.parts[ref.PartIndex].Part}
+	return scanner.ValueAt(ref.Locator, columnName)
+}
+
+func (r partSetRowRef) newerThan(other partSetRowRef) bool {
+	if r.GenerationID != other.GenerationID {
+		return r.GenerationID > other.GenerationID
+	}
+	return r.Ordinal > other.Ordinal
+}

--- a/TreeDB/internal/typedcolumn/predicate.go
+++ b/TreeDB/internal/typedcolumn/predicate.go
@@ -1,0 +1,476 @@
+package typedcolumn
+
+import (
+	"errors"
+	"fmt"
+	"math"
+)
+
+const maxSortKeyColumns = 8
+
+type Int64RangePredicate struct {
+	Column string
+	Low    int64
+	High   int64
+}
+
+func (p Int64RangePredicate) Empty() bool {
+	return p.Low > p.High
+}
+
+type PredicatePlan struct {
+	Filter        Int64RangePredicate
+	SortKeyRanges []Int64RangePredicate
+}
+
+type PredicateDiagnostics struct {
+	Considered      int
+	SkippedByMark   int
+	SkippedByMinMax int
+	Decoded         int
+	Matched         int
+}
+
+type SortKeyColumnValues struct {
+	Name   string
+	Values []int64
+}
+
+type SortKeyBound struct {
+	Values    []int64
+	Exclusive bool
+	Unbounded bool
+}
+
+type SortKeyPrefixSummary struct {
+	Columns        []string
+	Lower          SortKeyBound
+	UpperExclusive SortKeyBound
+}
+
+type SortKeyMark struct {
+	Rows         int
+	Columns      []string
+	ColumnValues [][]int64
+	Prefixes     []SortKeyPrefixSummary
+}
+
+type sortKeyRangePlan struct {
+	prefixLen int
+	lower     [maxSortKeyColumns]int64
+	upper     [maxSortKeyColumns]int64
+	hasUpper  bool
+	empty     bool
+}
+
+type compiledRowSortKeyRange struct {
+	Column string
+	Values []int64
+	Low    int64
+	High   int64
+}
+
+type compiledRowSortKeyRanges struct {
+	ranges [maxSortKeyColumns]compiledRowSortKeyRange
+	count  int
+}
+
+func BuildSortKeyMark(columns []SortKeyColumnValues) (SortKeyMark, error) {
+	return buildSortKeyMark(columns, true)
+}
+
+func buildOwnedSortKeyMark(columns []SortKeyColumnValues) (SortKeyMark, error) {
+	return buildSortKeyMark(columns, false)
+}
+
+func buildSortKeyMark(columns []SortKeyColumnValues, copyValues bool) (SortKeyMark, error) {
+	if len(columns) == 0 {
+		return SortKeyMark{}, errors.New("typedcolumn: empty sort key")
+	}
+	if len(columns) > maxSortKeyColumns {
+		return SortKeyMark{}, fmt.Errorf("typedcolumn: sort key columns=%d exceeds cap %d", len(columns), maxSortKeyColumns)
+	}
+	rows := len(columns[0].Values)
+	if rows == 0 {
+		return SortKeyMark{}, errors.New("typedcolumn: empty sort-key mark")
+	}
+	mark := SortKeyMark{
+		Rows:         rows,
+		Columns:      make([]string, len(columns)),
+		ColumnValues: make([][]int64, len(columns)),
+		Prefixes:     make([]SortKeyPrefixSummary, len(columns)),
+	}
+	lower := make([]int64, len(columns))
+	last := make([]int64, len(columns))
+	for i, c := range columns {
+		if c.Name == "" {
+			return SortKeyMark{}, fmt.Errorf("typedcolumn: empty sort key column name at %d", i)
+		}
+		for j := 0; j < i; j++ {
+			if columns[j].Name == c.Name {
+				return SortKeyMark{}, fmt.Errorf("typedcolumn: duplicate sort key column %q", c.Name)
+			}
+		}
+		if len(c.Values) != rows {
+			return SortKeyMark{}, fmt.Errorf("typedcolumn: sort key column %s rows=%d want=%d", c.Name, len(c.Values), rows)
+		}
+		mark.Columns[i] = c.Name
+		if copyValues {
+			mark.ColumnValues[i] = append([]int64(nil), c.Values...)
+		} else {
+			mark.ColumnValues[i] = c.Values
+		}
+		lower[i] = c.Values[0]
+		last[i] = c.Values[rows-1]
+	}
+	for row := 1; row < rows; row++ {
+		if compareSortKeyRows(columns, row-1, row) > 0 {
+			return SortKeyMark{}, fmt.Errorf("typedcolumn: sort key rows out of order at row %d", row)
+		}
+	}
+	for prefixLen := 1; prefixLen <= len(columns); prefixLen++ {
+		prefixColumns := append([]string(nil), mark.Columns[:prefixLen]...)
+		prefixLower := append([]int64(nil), lower[:prefixLen]...)
+		upper, hasUpper := exclusiveUpperBound(last[:prefixLen])
+		mark.Prefixes[prefixLen-1] = SortKeyPrefixSummary{
+			Columns: prefixColumns,
+			Lower: SortKeyBound{
+				Values: prefixLower,
+			},
+			UpperExclusive: SortKeyBound{
+				Values:    upper,
+				Exclusive: true,
+				Unbounded: !hasUpper,
+			},
+		}
+	}
+	return mark, nil
+}
+
+func (m SortKeyMark) MayContainRanges(ranges []Int64RangePredicate) (bool, bool, error) {
+	plan, err := compileSortKeyRangePlan(m.Columns, ranges)
+	if err != nil {
+		return false, false, err
+	}
+	return m.mayContainCompiled(plan)
+}
+
+func (r *GranuleReader) CountInt64RangeWithDiagnostics(granules []EncodedGranule, marks []SortKeyMark, plan PredicatePlan) (int, PredicateDiagnostics, error) {
+	var diagnostics PredicateDiagnostics
+	if plan.Filter.Empty() {
+		return 0, diagnostics, nil
+	}
+	if plan.Filter.Column == "" {
+		return 0, diagnostics, errors.New("typedcolumn: empty filter column")
+	}
+	if len(marks) != 0 && len(marks) != len(granules) {
+		return 0, diagnostics, fmt.Errorf("typedcolumn: marks=%d granules=%d", len(marks), len(granules))
+	}
+	if len(marks) == 0 && len(plan.SortKeyRanges) != 0 {
+		return 0, diagnostics, errors.New("typedcolumn: sort key ranges require marks")
+	}
+	var sortPlan sortKeyRangePlan
+	var err error
+	if len(marks) != 0 {
+		sortPlan, err = compileSortKeyRangePlan(marks[0].Columns, plan.SortKeyRanges)
+		if err != nil {
+			return 0, diagnostics, err
+		}
+	}
+	total := 0
+	for i, g := range granules {
+		diagnostics.Considered++
+		if len(marks) != 0 {
+			if !sameStringSlice(marks[0].Columns, marks[i].Columns) {
+				return total, diagnostics, errors.New("typedcolumn: inconsistent sort key mark columns")
+			}
+			if marks[i].Rows != g.Rows {
+				return total, diagnostics, fmt.Errorf("typedcolumn: mark rows=%d granule rows=%d at granule %d", marks[i].Rows, g.Rows, i)
+			}
+			mayContain, constrained, err := marks[i].mayContainCompiled(sortPlan)
+			if err != nil {
+				return total, diagnostics, err
+			}
+			if constrained && !mayContain {
+				diagnostics.SkippedByMark++
+				continue
+			}
+		}
+		if g.HasMinMax && (plan.Filter.High < g.Min || plan.Filter.Low > g.Max) {
+			diagnostics.SkippedByMinMax++
+			continue
+		}
+		values, err := r.DecodeInt64(g)
+		if err != nil {
+			return total, diagnostics, err
+		}
+		diagnostics.Decoded++
+		count := 0
+		if len(marks) != 0 && len(plan.SortKeyRanges) != 0 {
+			count, err = marks[i].countMatchingRows(values, plan)
+			if err != nil {
+				return total, diagnostics, err
+			}
+		} else {
+			for _, v := range values {
+				if v >= plan.Filter.Low && v <= plan.Filter.High {
+					count++
+				}
+			}
+		}
+		diagnostics.Matched += count
+		total += count
+	}
+	return total, diagnostics, nil
+}
+
+func compileSortKeyRangePlan(columns []string, ranges []Int64RangePredicate) (sortKeyRangePlan, error) {
+	var plan sortKeyRangePlan
+	if len(ranges) == 0 {
+		return plan, nil
+	}
+	if len(columns) == 0 {
+		return plan, errors.New("typedcolumn: sort key ranges require mark columns")
+	}
+	if len(columns) > maxSortKeyColumns {
+		return plan, fmt.Errorf("typedcolumn: sort key columns=%d exceeds cap %d", len(columns), maxSortKeyColumns)
+	}
+	if err := validateSortKeyColumnNames(columns); err != nil {
+		return plan, err
+	}
+	if err := validateRangePredicates(columns, ranges); err != nil {
+		return plan, err
+	}
+	var upperInclusive [maxSortKeyColumns]int64
+	for _, column := range columns {
+		predicate, ok := findRangePredicate(ranges, column)
+		if !ok {
+			break
+		}
+		if predicate.Empty() {
+			plan.empty = true
+			return plan, nil
+		}
+		plan.lower[plan.prefixLen] = predicate.Low
+		upperInclusive[plan.prefixLen] = predicate.High
+		plan.prefixLen++
+	}
+	if plan.prefixLen == 0 {
+		return plan, nil
+	}
+	plan.hasUpper = exclusiveUpperBoundArray(upperInclusive[:plan.prefixLen], &plan.upper)
+	return plan, nil
+}
+
+func (m SortKeyMark) mayContainCompiled(plan sortKeyRangePlan) (bool, bool, error) {
+	if plan.empty {
+		return false, true, nil
+	}
+	if plan.prefixLen == 0 {
+		return true, false, nil
+	}
+	if plan.prefixLen > len(m.Prefixes) {
+		return false, true, errors.New("typedcolumn: missing sort key prefix summary")
+	}
+	prefix := m.Prefixes[plan.prefixLen-1]
+	if plan.hasUpper && compareInt64Tuple(plan.upper[:plan.prefixLen], prefix.Lower.Values) <= 0 {
+		return false, true, nil
+	}
+	if !prefix.UpperExclusive.Unbounded && compareInt64Tuple(prefix.UpperExclusive.Values, plan.lower[:plan.prefixLen]) <= 0 {
+		return false, true, nil
+	}
+	return true, true, nil
+}
+
+func (m SortKeyMark) countMatchingRows(values []int64, plan PredicatePlan) (int, error) {
+	if len(values) != m.Rows {
+		return 0, fmt.Errorf("typedcolumn: decoded rows=%d mark rows=%d", len(values), m.Rows)
+	}
+	compiledRanges, err := m.compileRowSortKeyRanges(plan.SortKeyRanges)
+	if err != nil {
+		return 0, err
+	}
+	count := 0
+	for row, v := range values {
+		if v < plan.Filter.Low || v > plan.Filter.High {
+			continue
+		}
+		if compiledRanges.rowMatches(row) {
+			count++
+		}
+	}
+	return count, nil
+}
+
+func (m SortKeyMark) compileRowSortKeyRanges(ranges []Int64RangePredicate) (compiledRowSortKeyRanges, error) {
+	if len(m.ColumnValues) != len(m.Columns) {
+		return compiledRowSortKeyRanges{}, errors.New("typedcolumn: sort key mark row values missing")
+	}
+	if err := validateRangePredicates(m.Columns, ranges); err != nil {
+		return compiledRowSortKeyRanges{}, err
+	}
+	var compiled compiledRowSortKeyRanges
+	for _, predicate := range ranges {
+		columnIndex := indexString(m.Columns, predicate.Column)
+		values := m.ColumnValues[columnIndex]
+		if len(values) != m.Rows {
+			return compiledRowSortKeyRanges{}, fmt.Errorf("typedcolumn: sort key column %q rows=%d want=%d", predicate.Column, len(values), m.Rows)
+		}
+		compiled.ranges[compiled.count] = compiledRowSortKeyRange{
+			Column: predicate.Column,
+			Values: values,
+			Low:    predicate.Low,
+			High:   predicate.High,
+		}
+		compiled.count++
+	}
+	return compiled, nil
+}
+
+func (r compiledRowSortKeyRanges) rowMatches(row int) bool {
+	for i := 0; i < r.count; i++ {
+		predicate := r.ranges[i]
+		value := predicate.Values[row]
+		if value < predicate.Low || value > predicate.High {
+			return false
+		}
+	}
+	return true
+}
+
+func findRangePredicate(ranges []Int64RangePredicate, column string) (Int64RangePredicate, bool) {
+	for _, p := range ranges {
+		if p.Column == column {
+			return p, true
+		}
+	}
+	return Int64RangePredicate{}, false
+}
+
+func validateSortKeyColumnNames(columns []string) error {
+	for i, column := range columns {
+		if column == "" {
+			return fmt.Errorf("typedcolumn: empty sort key column name at %d", i)
+		}
+		for j := 0; j < i; j++ {
+			if columns[j] == column {
+				return fmt.Errorf("typedcolumn: duplicate sort key column %q", column)
+			}
+		}
+	}
+	return nil
+}
+
+func validateRangePredicates(columns []string, ranges []Int64RangePredicate) error {
+	if len(ranges) > maxSortKeyColumns {
+		return fmt.Errorf("typedcolumn: sort key ranges=%d exceeds cap %d", len(ranges), maxSortKeyColumns)
+	}
+	for i, predicate := range ranges {
+		if predicate.Column == "" {
+			return fmt.Errorf("typedcolumn: empty sort key range column at %d", i)
+		}
+		if !containsString(columns, predicate.Column) {
+			return fmt.Errorf("typedcolumn: sort key range column %q not present in mark", predicate.Column)
+		}
+		for j := 0; j < i; j++ {
+			if ranges[j].Column == predicate.Column {
+				return fmt.Errorf("typedcolumn: duplicate sort key range column %q", predicate.Column)
+			}
+		}
+	}
+	return nil
+}
+
+func compareSortKeyRows(columns []SortKeyColumnValues, left int, right int) int {
+	for _, column := range columns {
+		lv := column.Values[left]
+		rv := column.Values[right]
+		if lv < rv {
+			return -1
+		}
+		if lv > rv {
+			return 1
+		}
+	}
+	return 0
+}
+
+func containsString(values []string, want string) bool {
+	return indexString(values, want) >= 0
+}
+
+func indexString(values []string, want string) int {
+	for i, value := range values {
+		if value == want {
+			return i
+		}
+	}
+	return -1
+}
+
+func exclusiveUpperBound(values []int64) ([]int64, bool) {
+	out := append([]int64(nil), values...)
+	for i := len(out) - 1; i >= 0; i-- {
+		if out[i] == math.MaxInt64 {
+			continue
+		}
+		out[i]++
+		for j := i + 1; j < len(out); j++ {
+			out[j] = math.MinInt64
+		}
+		return out, true
+	}
+	return nil, false
+}
+
+func exclusiveUpperBoundArray(values []int64, out *[maxSortKeyColumns]int64) bool {
+	for i, v := range values {
+		out[i] = v
+	}
+	for i := len(values) - 1; i >= 0; i-- {
+		if out[i] == math.MaxInt64 {
+			continue
+		}
+		out[i]++
+		for j := i + 1; j < len(values); j++ {
+			out[j] = math.MinInt64
+		}
+		return true
+	}
+	return false
+}
+
+func compareInt64Tuple(a []int64, b []int64) int {
+	n := len(a)
+	if len(b) < n {
+		n = len(b)
+	}
+	for i := 0; i < n; i++ {
+		if a[i] < b[i] {
+			return -1
+		}
+		if a[i] > b[i] {
+			return 1
+		}
+	}
+	switch {
+	case len(a) < len(b):
+		return -1
+	case len(a) > len(b):
+		return 1
+	default:
+		return 0
+	}
+}
+
+func sameStringSlice(a []string, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/TreeDB/internal/typedcolumn/section_reader.go
+++ b/TreeDB/internal/typedcolumn/section_reader.go
@@ -1,0 +1,28 @@
+package typedcolumn
+
+// SectionReader is the narrow byte-access seam that #1754 can adapt to #1736
+// mappedresource-backed handles without changing the typed-column data-plane
+// section directory or codecs.
+type SectionReader interface {
+	ReadSection(section ColumnPartImageSection) ([]byte, error)
+}
+
+// ImageSectionReader reads sections from an in-memory part image.
+type ImageSectionReader struct {
+	Image ColumnPartImage
+}
+
+func NewImageSectionReader(image ColumnPartImage) ImageSectionReader {
+	return ImageSectionReader{Image: image}
+}
+
+func (r ImageSectionReader) ReadSection(section ColumnPartImageSection) ([]byte, error) {
+	return r.Image.SectionBytes(section)
+}
+
+func (i ColumnPartImage) SectionBytes(section ColumnPartImageSection) ([]byte, error) {
+	if err := validateImageSectionBounds(section, i.ManifestBytes, len(i.Bytes)); err != nil {
+		return nil, err
+	}
+	return i.sectionBytes(section), nil
+}

--- a/TreeDB/internal/typedcolumn/tcs1.go
+++ b/TreeDB/internal/typedcolumn/tcs1.go
@@ -59,7 +59,10 @@ func EncodeTCS1ColumnPartImage(image ColumnPartImage) ([]byte, TCS1PartRecord, e
 		return nil, TCS1PartRecord{}, fmt.Errorf("typedcolumn: TCS1 encode image version=%d parsed image version=%d", image.Version, parsed.Version)
 	}
 	payloadBytes := len(image.Bytes)
-	totalBytes := tcs1HeaderBytes + payloadBytes
+	totalBytes, err := checkedAddInt(tcs1HeaderBytes, payloadBytes, "typedcolumn: TCS1 total bytes")
+	if err != nil {
+		return nil, TCS1PartRecord{}, err
+	}
 	out := make([]byte, totalBytes)
 	binary.LittleEndian.PutUint32(out[tcs1MagicOffset:tcs1VersionOffset], tcs1Magic)
 	binary.LittleEndian.PutUint16(out[tcs1VersionOffset:tcs1KindOffset], tcs1Version)

--- a/TreeDB/internal/typedcolumn/tcs1.go
+++ b/TreeDB/internal/typedcolumn/tcs1.go
@@ -1,0 +1,226 @@
+package typedcolumn
+
+import (
+	"encoding/binary"
+	"fmt"
+	crc32 "github.com/snissn/go-crc32-asm"
+)
+
+const (
+	tcs1Magic              uint32 = 0x31534354 // "TCS1", little-endian on disk.
+	tcs1Version            uint16 = 1
+	tcs1PartImageKind      uint16 = 1
+	tcs1SupportedFlags     uint32 = 0
+	tcs1MagicOffset               = 0
+	tcs1VersionOffset             = tcs1MagicOffset + 4
+	tcs1KindOffset                = tcs1VersionOffset + 2
+	tcs1FlagsOffset               = tcs1KindOffset + 2
+	tcs1HeaderBytesOffset         = tcs1FlagsOffset + 4
+	tcs1PayloadBytesOffset        = tcs1HeaderBytesOffset + 4
+	tcs1PartIDOffset              = tcs1PayloadBytesOffset + 8
+	tcs1RowsOffset                = tcs1PartIDOffset + 8
+	tcs1ImageVersionOffset        = tcs1RowsOffset + 8
+	tcs1ReservedOffset            = tcs1ImageVersionOffset + 2
+	tcs1PayloadCRC32Offset        = tcs1ReservedOffset + 2
+	tcs1HeaderBytes               = tcs1PayloadCRC32Offset + 4
+	tcs1PayloadOffset             = tcs1HeaderBytes
+)
+
+type TCS1PartRecord struct {
+	Version      uint16 `json:"version"`
+	Kind         uint16 `json:"kind"`
+	Flags        uint32 `json:"flags"`
+	PartID       uint64 `json:"part_id"`
+	Rows         int    `json:"rows"`
+	ImageVersion uint16 `json:"image_version"`
+	PayloadBytes int    `json:"payload_bytes"`
+	TotalBytes   int    `json:"total_bytes"`
+	PayloadCRC32 uint32 `json:"payload_crc32"`
+}
+
+func EncodeTCS1ColumnPartImage(image ColumnPartImage) ([]byte, TCS1PartRecord, error) {
+	if image.TotalBytes() == 0 {
+		return nil, TCS1PartRecord{}, fmt.Errorf("typedcolumn: empty column part image")
+	}
+	if image.Rows < 0 {
+		return nil, TCS1PartRecord{}, fmt.Errorf("typedcolumn: negative image rows %d", image.Rows)
+	}
+	parsed, err := ParseColumnPartImage(image.Bytes)
+	if err != nil {
+		return nil, TCS1PartRecord{}, fmt.Errorf("typedcolumn: validate image before TCS1 encode: %w", err)
+	}
+	if parsed.PartID != image.PartID {
+		return nil, TCS1PartRecord{}, fmt.Errorf("typedcolumn: TCS1 encode part id=%d parsed image part id=%d", image.PartID, parsed.PartID)
+	}
+	if parsed.Rows != image.Rows {
+		return nil, TCS1PartRecord{}, fmt.Errorf("typedcolumn: TCS1 encode rows=%d parsed image rows=%d", image.Rows, parsed.Rows)
+	}
+	if parsed.Version != image.Version {
+		return nil, TCS1PartRecord{}, fmt.Errorf("typedcolumn: TCS1 encode image version=%d parsed image version=%d", image.Version, parsed.Version)
+	}
+	payloadBytes := len(image.Bytes)
+	totalBytes := tcs1HeaderBytes + payloadBytes
+	out := make([]byte, totalBytes)
+	binary.LittleEndian.PutUint32(out[tcs1MagicOffset:tcs1VersionOffset], tcs1Magic)
+	binary.LittleEndian.PutUint16(out[tcs1VersionOffset:tcs1KindOffset], tcs1Version)
+	binary.LittleEndian.PutUint16(out[tcs1KindOffset:tcs1FlagsOffset], tcs1PartImageKind)
+	binary.LittleEndian.PutUint32(out[tcs1FlagsOffset:tcs1HeaderBytesOffset], 0)
+	binary.LittleEndian.PutUint32(out[tcs1HeaderBytesOffset:tcs1PayloadBytesOffset], tcs1HeaderBytes)
+	binary.LittleEndian.PutUint64(out[tcs1PayloadBytesOffset:tcs1PartIDOffset], uint64(payloadBytes))
+	binary.LittleEndian.PutUint64(out[tcs1PartIDOffset:tcs1RowsOffset], image.PartID)
+	binary.LittleEndian.PutUint64(out[tcs1RowsOffset:tcs1ImageVersionOffset], uint64(image.Rows))
+	binary.LittleEndian.PutUint16(out[tcs1ImageVersionOffset:tcs1ReservedOffset], image.Version)
+	binary.LittleEndian.PutUint16(out[tcs1ReservedOffset:tcs1PayloadCRC32Offset], 0)
+	checksum := crc32.ChecksumIEEE(image.Bytes)
+	binary.LittleEndian.PutUint32(out[tcs1PayloadCRC32Offset:tcs1PayloadOffset], checksum)
+	copy(out[tcs1PayloadOffset:], image.Bytes)
+	return out, TCS1PartRecord{
+		Version:      tcs1Version,
+		Kind:         tcs1PartImageKind,
+		PartID:       image.PartID,
+		Rows:         image.Rows,
+		ImageVersion: image.Version,
+		PayloadBytes: payloadBytes,
+		TotalBytes:   totalBytes,
+		PayloadCRC32: checksum,
+	}, nil
+}
+
+func DecodeTCS1ColumnPartImage(data []byte) (ColumnPartImage, TCS1PartRecord, error) {
+	record, payload, err := decodeTCS1Header(data)
+	if err != nil {
+		return ColumnPartImage{}, TCS1PartRecord{}, err
+	}
+	image, err := ParseColumnPartImage(payload)
+	if err != nil {
+		return ColumnPartImage{}, TCS1PartRecord{}, fmt.Errorf("typedcolumn: parse TCS1 column part image: %w", err)
+	}
+	if image.PartID != record.PartID {
+		return ColumnPartImage{}, TCS1PartRecord{}, fmt.Errorf("typedcolumn: TCS1 part id=%d image part id=%d", record.PartID, image.PartID)
+	}
+	if image.Rows != record.Rows {
+		return ColumnPartImage{}, TCS1PartRecord{}, fmt.Errorf("typedcolumn: TCS1 rows=%d image rows=%d", record.Rows, image.Rows)
+	}
+	if image.Version != record.ImageVersion {
+		return ColumnPartImage{}, TCS1PartRecord{}, fmt.Errorf("typedcolumn: TCS1 image version=%d parsed image version=%d", record.ImageVersion, image.Version)
+	}
+	return image, record, nil
+}
+
+func DecodeTCS1ColumnPartHeader(header []byte, totalBytes int64) (TCS1PartRecord, error) {
+	if len(header) < tcs1HeaderBytes {
+		return TCS1PartRecord{}, fmt.Errorf("typedcolumn: truncated TCS1 header bytes=%d", len(header))
+	}
+	if totalBytes < tcs1HeaderBytes {
+		return TCS1PartRecord{}, fmt.Errorf("typedcolumn: TCS1 total bytes=%d below header bytes=%d", totalBytes, tcs1HeaderBytes)
+	}
+	if totalBytes > int64(^uint(0)>>1) {
+		return TCS1PartRecord{}, fmt.Errorf("typedcolumn: TCS1 total bytes=%d exceeds host int", totalBytes)
+	}
+	magic := binary.LittleEndian.Uint32(header[tcs1MagicOffset:tcs1VersionOffset])
+	if magic != tcs1Magic {
+		return TCS1PartRecord{}, fmt.Errorf("typedcolumn: invalid TCS1 magic 0x%x", magic)
+	}
+	version := binary.LittleEndian.Uint16(header[tcs1VersionOffset:tcs1KindOffset])
+	if version != tcs1Version {
+		return TCS1PartRecord{}, fmt.Errorf("typedcolumn: unsupported TCS1 version %d", version)
+	}
+	kind := binary.LittleEndian.Uint16(header[tcs1KindOffset:tcs1FlagsOffset])
+	if kind != tcs1PartImageKind {
+		return TCS1PartRecord{}, fmt.Errorf("typedcolumn: unsupported TCS1 kind %d", kind)
+	}
+	flags := binary.LittleEndian.Uint32(header[tcs1FlagsOffset:tcs1HeaderBytesOffset])
+	if flags&^tcs1SupportedFlags != 0 {
+		return TCS1PartRecord{}, fmt.Errorf("typedcolumn: unsupported TCS1 flags 0x%x", flags)
+	}
+	headerBytes := binary.LittleEndian.Uint32(header[tcs1HeaderBytesOffset:tcs1PayloadBytesOffset])
+	if headerBytes != tcs1HeaderBytes {
+		return TCS1PartRecord{}, fmt.Errorf("typedcolumn: TCS1 header bytes=%d want %d", headerBytes, tcs1HeaderBytes)
+	}
+	payloadBytes := binary.LittleEndian.Uint64(header[tcs1PayloadBytesOffset:tcs1PartIDOffset])
+	if payloadBytes > uint64(totalBytes-int64(tcs1PayloadOffset)) {
+		return TCS1PartRecord{}, fmt.Errorf("typedcolumn: TCS1 payload bytes=%d exceed available=%d", payloadBytes, totalBytes-int64(tcs1PayloadOffset))
+	}
+	if payloadBytes != uint64(totalBytes-int64(tcs1PayloadOffset)) {
+		return TCS1PartRecord{}, fmt.Errorf("typedcolumn: TCS1 payload bytes=%d want payload bytes=%d", payloadBytes, totalBytes-int64(tcs1PayloadOffset))
+	}
+	partID := binary.LittleEndian.Uint64(header[tcs1PartIDOffset:tcs1RowsOffset])
+	rows64 := binary.LittleEndian.Uint64(header[tcs1RowsOffset:tcs1ImageVersionOffset])
+	if rows64 > uint64(^uint(0)>>1) {
+		return TCS1PartRecord{}, fmt.Errorf("typedcolumn: TCS1 rows=%d exceeds host int", rows64)
+	}
+	imageVersion := binary.LittleEndian.Uint16(header[tcs1ImageVersionOffset:tcs1ReservedOffset])
+	if reserved := binary.LittleEndian.Uint16(header[tcs1ReservedOffset:tcs1PayloadCRC32Offset]); reserved != 0 {
+		return TCS1PartRecord{}, fmt.Errorf("typedcolumn: TCS1 reserved=%d want 0", reserved)
+	}
+	return TCS1PartRecord{
+		Version:      version,
+		Kind:         kind,
+		Flags:        flags,
+		PartID:       partID,
+		Rows:         int(rows64),
+		ImageVersion: imageVersion,
+		PayloadBytes: int(payloadBytes),
+		TotalBytes:   int(totalBytes),
+		PayloadCRC32: binary.LittleEndian.Uint32(header[tcs1PayloadCRC32Offset:tcs1PayloadOffset]),
+	}, nil
+}
+
+func decodeTCS1Header(data []byte) (TCS1PartRecord, []byte, error) {
+	if len(data) < tcs1HeaderBytes {
+		return TCS1PartRecord{}, nil, fmt.Errorf("typedcolumn: truncated TCS1 header bytes=%d", len(data))
+	}
+	magic := binary.LittleEndian.Uint32(data[tcs1MagicOffset:tcs1VersionOffset])
+	if magic != tcs1Magic {
+		return TCS1PartRecord{}, nil, fmt.Errorf("typedcolumn: invalid TCS1 magic 0x%x", magic)
+	}
+	version := binary.LittleEndian.Uint16(data[tcs1VersionOffset:tcs1KindOffset])
+	if version != tcs1Version {
+		return TCS1PartRecord{}, nil, fmt.Errorf("typedcolumn: unsupported TCS1 version %d", version)
+	}
+	kind := binary.LittleEndian.Uint16(data[tcs1KindOffset:tcs1FlagsOffset])
+	if kind != tcs1PartImageKind {
+		return TCS1PartRecord{}, nil, fmt.Errorf("typedcolumn: unsupported TCS1 kind %d", kind)
+	}
+	flags := binary.LittleEndian.Uint32(data[tcs1FlagsOffset:tcs1HeaderBytesOffset])
+	if flags&^tcs1SupportedFlags != 0 {
+		return TCS1PartRecord{}, nil, fmt.Errorf("typedcolumn: unsupported TCS1 flags 0x%x", flags)
+	}
+	headerBytes := binary.LittleEndian.Uint32(data[tcs1HeaderBytesOffset:tcs1PayloadBytesOffset])
+	if headerBytes != tcs1HeaderBytes {
+		return TCS1PartRecord{}, nil, fmt.Errorf("typedcolumn: TCS1 header bytes=%d want %d", headerBytes, tcs1HeaderBytes)
+	}
+	payloadBytes := binary.LittleEndian.Uint64(data[tcs1PayloadBytesOffset:tcs1PartIDOffset])
+	if payloadBytes > uint64(len(data)-tcs1PayloadOffset) {
+		return TCS1PartRecord{}, nil, fmt.Errorf("typedcolumn: TCS1 payload bytes=%d exceed available=%d", payloadBytes, len(data)-tcs1PayloadOffset)
+	}
+	if payloadBytes != uint64(len(data)-tcs1PayloadOffset) {
+		return TCS1PartRecord{}, nil, fmt.Errorf("typedcolumn: TCS1 payload bytes=%d want payload bytes=%d", payloadBytes, len(data)-tcs1PayloadOffset)
+	}
+	partID := binary.LittleEndian.Uint64(data[tcs1PartIDOffset:tcs1RowsOffset])
+	rows64 := binary.LittleEndian.Uint64(data[tcs1RowsOffset:tcs1ImageVersionOffset])
+	if rows64 > uint64(^uint(0)>>1) {
+		return TCS1PartRecord{}, nil, fmt.Errorf("typedcolumn: TCS1 rows=%d exceeds host int", rows64)
+	}
+	rows := int(rows64)
+	imageVersion := binary.LittleEndian.Uint16(data[tcs1ImageVersionOffset:tcs1ReservedOffset])
+	if reserved := binary.LittleEndian.Uint16(data[tcs1ReservedOffset:tcs1PayloadCRC32Offset]); reserved != 0 {
+		return TCS1PartRecord{}, nil, fmt.Errorf("typedcolumn: TCS1 reserved=%d want 0", reserved)
+	}
+	wantChecksum := binary.LittleEndian.Uint32(data[tcs1PayloadCRC32Offset:tcs1PayloadOffset])
+	payload := data[tcs1PayloadOffset:]
+	if checksum := crc32.ChecksumIEEE(payload); checksum != wantChecksum {
+		return TCS1PartRecord{}, nil, fmt.Errorf("typedcolumn: TCS1 payload checksum=%08x want %08x", checksum, wantChecksum)
+	}
+	return TCS1PartRecord{
+		Version:      version,
+		Kind:         kind,
+		Flags:        flags,
+		PartID:       partID,
+		Rows:         rows,
+		ImageVersion: imageVersion,
+		PayloadBytes: int(payloadBytes),
+		TotalBytes:   len(data),
+		PayloadCRC32: wantChecksum,
+	}, payload, nil
+}

--- a/TreeDB/internal/typedcolumn/transplant_test.go
+++ b/TreeDB/internal/typedcolumn/transplant_test.go
@@ -1,0 +1,374 @@
+package typedcolumn
+
+import (
+	"encoding/binary"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestTypedColumnTransplantPartImageRoundTrip(t *testing.T) {
+	part := mustTransplantPart(t, 101, transplantTestOptions([]SortKeyColumn{{Column: "id"}}), transplantTestBatch())
+	image := mustTransplantImage(t, part)
+
+	parsed, err := ParseColumnPartImage(image.Bytes)
+	if err != nil {
+		t.Fatalf("ParseColumnPartImage: %v", err)
+	}
+	if parsed.PartID != image.PartID || parsed.Rows != image.Rows || parsed.Version != image.Version {
+		t.Fatalf("parsed identity=%d/%d/%d want %d/%d/%d", parsed.PartID, parsed.Rows, parsed.Version, image.PartID, image.Rows, image.Version)
+	}
+	if parsed.TotalBytes() != image.TotalBytes() || parsed.ManifestBytes != image.ManifestBytes {
+		t.Fatalf("parsed bytes total=%d/%d manifest=%d/%d", parsed.TotalBytes(), image.TotalBytes(), parsed.ManifestBytes, image.ManifestBytes)
+	}
+	if accounting := part.ByteAccountingFromImage(parsed); accounting.TotalStoredBytes != parsed.TotalBytes() || accounting.CategoryBytes() != parsed.TotalBytes() {
+		t.Fatalf("accounting total/category=(%d,%d) image=%d accounting=%+v", accounting.TotalStoredBytes, accounting.CategoryBytes(), parsed.TotalBytes(), accounting)
+	}
+
+	reconstructed, err := ColumnPartFromImage(parsed)
+	if err != nil {
+		t.Fatalf("ColumnPartFromImage: %v", err)
+	}
+	scan, err := reconstructed.NewScanner().ScanProjected([]string{"id", "time_us", "value", "kind_code", "has_reply"})
+	if err != nil {
+		t.Fatalf("ScanProjected: %v", err)
+	}
+	assertTransplantInt64s(t, "id", scan.Columns["id"], []int64{1, 2, 3, 4, 5, 6})
+	assertTransplantInt64s(t, "value", scan.Columns["value"], []int64{100, 200, 300, 400, 500, 600})
+
+	tcs1, record, err := EncodeTCS1ColumnPartImage(parsed)
+	if err != nil {
+		t.Fatalf("EncodeTCS1ColumnPartImage: %v", err)
+	}
+	decodedImage, decodedRecord, err := DecodeTCS1ColumnPartImage(tcs1)
+	if err != nil {
+		t.Fatalf("DecodeTCS1ColumnPartImage: %v", err)
+	}
+	if decodedImage.TotalBytes() != parsed.TotalBytes() || decodedRecord.PayloadCRC32 != record.PayloadCRC32 {
+		t.Fatalf("decoded TCS1 image bytes/checksum=(%d,%08x) want (%d,%08x)", decodedImage.TotalBytes(), decodedRecord.PayloadCRC32, parsed.TotalBytes(), record.PayloadCRC32)
+	}
+}
+
+func TestTypedColumnTransplantSectionDirectoryRoundTrip(t *testing.T) {
+	part := mustTransplantPart(t, 102, transplantTestOptions([]SortKeyColumn{{Column: "kind_code"}, {Column: "time_us"}}), transplantTestBatch())
+	image := mustTransplantImage(t, part)
+	parsed, err := ParseColumnPartImage(image.Bytes)
+	if err != nil {
+		t.Fatalf("ParseColumnPartImage: %v", err)
+	}
+	if len(parsed.Sections) != len(image.Sections) {
+		t.Fatalf("sections=%d want %d", len(parsed.Sections), len(image.Sections))
+	}
+	for idx := range image.Sections {
+		want := image.Sections[idx]
+		got := parsed.Sections[idx]
+		if got.Kind != want.Kind || got.Category != want.Category || got.Name != want.Name || got.Column != want.Column || got.Offset != want.Offset || got.Length != want.Length {
+			t.Fatalf("section[%d]=%+v want %+v", idx, got, want)
+		}
+		assertTransplantBytes(t, got.Kind, parsed.sectionBytes(got), image.sectionBytes(want))
+	}
+	if parsed.PaddingBytes() == 0 {
+		t.Fatalf("expected aligned section directory to carry padding bytes")
+	}
+}
+
+func TestTypedColumnTransplantRejectsInvalidMagicOrVersion(t *testing.T) {
+	image := mustTransplantImage(t, mustTransplantPart(t, 103, transplantTestOptions([]SortKeyColumn{{Column: "id"}}), transplantTestBatch()))
+
+	badMagic := append([]byte(nil), image.Bytes...)
+	binary.LittleEndian.PutUint32(badMagic[:4], columnPartImageMagic+1)
+	if _, err := ParseColumnPartImage(badMagic); err == nil || !strings.Contains(err.Error(), "invalid part image magic") {
+		t.Fatalf("bad image magic err=%v want invalid magic", err)
+	}
+	badVersion := append([]byte(nil), image.Bytes...)
+	binary.LittleEndian.PutUint16(badVersion[4:6], columnPartImageVersion+1)
+	if _, err := ParseColumnPartImage(badVersion); err == nil || !strings.Contains(err.Error(), "unsupported part image version") {
+		t.Fatalf("bad image version err=%v want unsupported version", err)
+	}
+
+	tcs1, _, err := EncodeTCS1ColumnPartImage(image)
+	if err != nil {
+		t.Fatalf("EncodeTCS1ColumnPartImage: %v", err)
+	}
+	badTCS1Magic := append([]byte(nil), tcs1...)
+	binary.LittleEndian.PutUint32(badTCS1Magic[tcs1MagicOffset:tcs1VersionOffset], tcs1Magic+1)
+	if _, _, err := DecodeTCS1ColumnPartImage(badTCS1Magic); err == nil || !strings.Contains(err.Error(), "invalid TCS1 magic") {
+		t.Fatalf("bad TCS1 magic err=%v want invalid magic", err)
+	}
+	badTCS1Version := append([]byte(nil), tcs1...)
+	binary.LittleEndian.PutUint16(badTCS1Version[tcs1VersionOffset:tcs1KindOffset], tcs1Version+1)
+	if _, _, err := DecodeTCS1ColumnPartImage(badTCS1Version); err == nil || !strings.Contains(err.Error(), "unsupported TCS1 version") {
+		t.Fatalf("bad TCS1 version err=%v want unsupported version", err)
+	}
+}
+
+func TestTypedColumnTransplantRejectsTruncatedOrOutOfBoundsSection(t *testing.T) {
+	part := mustTransplantPart(t, 104, transplantTestOptions([]SortKeyColumn{{Column: "id"}}), transplantTestBatch())
+	image := mustTransplantImage(t, part)
+	if _, err := ParseColumnPartImage(image.Bytes[:len(image.Bytes)-1]); err == nil {
+		t.Fatalf("truncated image parsed successfully")
+	}
+
+	corrupt := image
+	corrupt.Bytes = append([]byte(nil), image.Bytes...)
+	corrupt.Sections = append([]ColumnPartImageSection(nil), image.Sections...)
+	corrupt.Sections[0].Offset = alignColumnPartImageOffset(len(corrupt.Bytes) + 8)
+	if _, err := ColumnPartFromImage(corrupt); err == nil || !strings.Contains(err.Error(), "exceeds image bytes") {
+		t.Fatalf("out-of-bounds section err=%v want exceeds image bytes", err)
+	}
+
+	unaligned := image
+	unaligned.Bytes = append([]byte(nil), image.Bytes...)
+	unaligned.Sections = append([]ColumnPartImageSection(nil), image.Sections...)
+	unaligned.Sections[0].Offset++
+	if _, err := ColumnPartFromImage(unaligned); err == nil || !strings.Contains(err.Error(), "aligned") {
+		t.Fatalf("unaligned section err=%v want aligned", err)
+	}
+}
+
+func TestTypedColumnTransplantRowLocatorRoundTrip(t *testing.T) {
+	part := mustTransplantPart(t, 105, transplantTestOptions([]SortKeyColumn{{Column: "time_us"}}), transplantTestBatch())
+	image := mustTransplantImage(t, part)
+	reconstructed, err := ColumnPartFromImage(image)
+	if err != nil {
+		t.Fatalf("ColumnPartFromImage: %v", err)
+	}
+	locator, ok := reconstructed.LocatePrimaryID(6)
+	if !ok {
+		t.Fatalf("missing row locator for primary id 6")
+	}
+	if locator.PartID != 105 || locator.PrimaryID != 6 || locator.PartRow < 0 || locator.GranuleOrdinal < 0 {
+		t.Fatalf("bad locator: %+v", locator)
+	}
+	value, err := reconstructed.NewScanner().ValueAt(locator, "value")
+	if err != nil {
+		t.Fatalf("ValueAt(locator): %v", err)
+	}
+	if value != 600 {
+		t.Fatalf("locator value=%d want 600", value)
+	}
+}
+
+func TestTypedColumnTransplantPartSetLatestVisibleRows(t *testing.T) {
+	opts := transplantTestOptions([]SortKeyColumn{{Column: "id"}})
+	base := mustTransplantPart(t, 201, opts, Batch{Columns: map[string][]int64{
+		"id":        {1, 2, 3},
+		"time_us":   {10, 20, 30},
+		"value":     {100, 200, 300},
+		"kind_code": {0, 1, 2},
+		"has_reply": {1, 0, 1},
+	}})
+	delta := mustTransplantPart(t, 202, opts, Batch{Columns: map[string][]int64{
+		"id":        {2, 4},
+		"time_us":   {25, 40},
+		"value":     {250, 400},
+		"kind_code": {1, 0},
+		"has_reply": {1, 0},
+	}})
+	reader, err := NewPartSetReader([]PartRef{
+		{Role: PartRoleBase, GenerationID: 1, Part: base},
+		{Role: PartRoleDelta, GenerationID: 2, Part: delta},
+	}, []Tombstone{{PrimaryID: 3, GenerationID: 2}})
+	if err != nil {
+		t.Fatalf("NewPartSetReader: %v", err)
+	}
+	stats := reader.VisibilityStats()
+	if stats.Parts != 2 || stats.BaseParts != 1 || stats.DeltaParts != 1 || stats.InputRows != 5 || stats.VisibleRows != 3 || stats.SupersededRows != 1 || stats.DeletedRows != 1 {
+		t.Fatalf("visibility stats=%+v", stats)
+	}
+	value, ok, err := reader.ValueAtLatest(2, "value")
+	if err != nil || !ok || value != 250 {
+		t.Fatalf("latest id=2 value/ok/err=(%d,%v,%v) want 250,true,nil", value, ok, err)
+	}
+	if _, ok := reader.LatestLocator(3); ok {
+		t.Fatalf("deleted primary id 3 remained visible")
+	}
+	if locator, ok := reader.ScanLatestLocator(4); !ok || locator.PartID != 202 {
+		t.Fatalf("scan latest id=4 locator=%+v ok=%v want part 202", locator, ok)
+	}
+	baseRows, baseAll := reader.VisibleRowsForPart(0)
+	deltaRows, deltaAll := reader.VisibleRowsForPart(1)
+	if !slices.Equal(baseRows, []int{0}) || baseAll || !slices.Equal(deltaRows, []int{0, 1}) || !deltaAll {
+		t.Fatalf("visible rows base=%v all=%v delta=%v all=%v", baseRows, baseAll, deltaRows, deltaAll)
+	}
+}
+
+func TestTypedColumnTransplantPredicateMetadataRoundTrip(t *testing.T) {
+	part := mustTransplantPart(t, 106, transplantTestOptions([]SortKeyColumn{{Column: "kind_code"}, {Column: "time_us"}}), transplantTestBatch())
+	image := mustTransplantImage(t, part)
+	reconstructed, err := ColumnPartFromImage(image)
+	if err != nil {
+		t.Fatalf("ColumnPartFromImage: %v", err)
+	}
+	if len(reconstructed.Marks) != len(part.Marks) || len(reconstructed.Marks) == 0 {
+		t.Fatalf("marks=%d want %d", len(reconstructed.Marks), len(part.Marks))
+	}
+	mayContain, constrained, err := reconstructed.Marks[0].MayContainRanges([]Int64RangePredicate{{Column: "kind_code", Low: 2, High: 2}})
+	if err != nil {
+		t.Fatalf("MayContainRanges: %v", err)
+	}
+	if mayContain || !constrained {
+		t.Fatalf("mark predicate mayContain/constrained=(%v,%v) want false,true", mayContain, constrained)
+	}
+	mayContain, constrained, err = reconstructed.Marks[len(reconstructed.Marks)-1].MayContainRanges([]Int64RangePredicate{{Column: "kind_code", Low: 0, High: 0}})
+	if err != nil {
+		t.Fatalf("MayContainRanges(last mark): %v", err)
+	}
+	if mayContain || !constrained {
+		t.Fatalf("last mark predicate mayContain/constrained=(%v,%v) want false,true", mayContain, constrained)
+	}
+}
+
+func TestTypedColumnTransplantDictionaryAggregateDescriptorsRoundTrip(t *testing.T) {
+	opts := transplantTestOptions([]SortKeyColumn{{Column: "id"}})
+	opts.AggregateMetadata = []AggregateMetadataDefinition{transplantAggregateMetadataDefinition()}
+	part := mustTransplantPart(t, 107, opts, transplantTestBatch())
+	image := mustTransplantImage(t, part)
+	parsed, err := ParseColumnPartImage(image.Bytes)
+	if err != nil {
+		t.Fatalf("ParseColumnPartImage: %v", err)
+	}
+	dictionaries, err := parsed.Dictionaries()
+	if err != nil {
+		t.Fatalf("Dictionaries: %v", err)
+	}
+	if dictionaries["kind_code"]["reply"] != 1 || dictionaries["kind_code"]["system"] != 2 {
+		t.Fatalf("dictionary round trip: %+v", dictionaries)
+	}
+	reconstructed, err := ColumnPartFromImage(parsed)
+	if err != nil {
+		t.Fatalf("ColumnPartFromImage: %v", err)
+	}
+	metadata, ok := reconstructed.AggregateMetadataByName("kind_time")
+	if !ok {
+		t.Fatalf("missing aggregate metadata")
+	}
+	if metadata.Definition.Kind != AggregateMetadataGroupMinMax || metadata.Definition.Scope != AggregateMetadataScopeGranule || len(metadata.Definition.Predicates) != 1 {
+		t.Fatalf("aggregate definition=%+v", metadata.Definition)
+	}
+	if !metadata.Stats.Admitted || metadata.Stats.RowsMatched == 0 || len(metadata.Granules) == 0 {
+		t.Fatalf("aggregate stats=%+v granules=%d", metadata.Stats, len(metadata.Granules))
+	}
+}
+
+func TestTypedColumnTransplantFixedWidthSectionsAreAligned(t *testing.T) {
+	image := mustTransplantImage(t, mustTransplantPart(t, 108, transplantTestOptions([]SortKeyColumn{{Column: "id"}}), transplantTestBatch()))
+	for _, section := range image.Sections {
+		if section.Offset%columnPartImageSectionAlignment != 0 {
+			t.Fatalf("section %s offset=%d is not %d-byte aligned", section.Kind, section.Offset, columnPartImageSectionAlignment)
+		}
+	}
+	if _, err := ParseColumnPartImage(image.Bytes); err != nil {
+		t.Fatalf("ParseColumnPartImage aligned image: %v", err)
+	}
+}
+
+func TestTypedColumnTransplantNoProductionPublication(t *testing.T) {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(file), "..", "..", ".."))
+	collectionsDir := filepath.Join(repoRoot, "TreeDB", "collections")
+	matches, err := filepath.Glob(filepath.Join(collectionsDir, "*.go"))
+	if err != nil {
+		t.Fatalf("glob collections: %v", err)
+	}
+	fset := token.NewFileSet()
+	for _, path := range matches {
+		if strings.HasSuffix(path, "_test.go") {
+			continue
+		}
+		file, err := parser.ParseFile(fset, path, nil, parser.ImportsOnly)
+		if err != nil {
+			t.Fatalf("parse %s: %v", path, err)
+		}
+		for _, imp := range file.Imports {
+			if strings.Trim(imp.Path.Value, "\"") == "github.com/snissn/gomap/TreeDB/internal/typedcolumn" {
+				t.Fatalf("production collections import typedcolumn in %s; #1753 must not publish/control-plane integrate it", path)
+			}
+		}
+	}
+}
+
+func transplantTestOptions(sortKey []SortKeyColumn) Options {
+	return Options{
+		SchemaVersion: 1,
+		SchemaMode:    ColumnSchemaFixed,
+		Columns: []ColumnDefinition{
+			{Name: "id", Type: ColumnTypeInt64, Encoding: EncodingRawInt64, Compression: CompressionNone},
+			{Name: "time_us", Type: ColumnTypeInt64, Encoding: EncodingDeltaVarint, Compression: CompressionNone},
+			{Name: "value", Type: ColumnTypeInt64, Encoding: EncodingDeltaVarint, Compression: CompressionNone},
+			{Name: "kind_code", Type: ColumnTypeLowCardinalityCode, Compression: CompressionNone, Cardinality: 3},
+			{Name: "has_reply", Type: ColumnTypeBool, Compression: CompressionNone},
+		},
+		LogicalPrimaryKey: LogicalPrimaryKey{Columns: []string{"id"}},
+		SortKey:           SortKey{Columns: sortKey},
+		PartPolicy:        ColumnPartPolicy{RowsPerGranule: 2},
+	}
+}
+
+func transplantTestBatch() Batch {
+	return Batch{Columns: map[string][]int64{
+		"id":        {3, 1, 2, 6, 4, 5},
+		"time_us":   {30, 10, 20, 60, 40, 50},
+		"value":     {300, 100, 200, 600, 400, 500},
+		"kind_code": {1, 0, 0, 2, 1, 1},
+		"has_reply": {1, 1, 0, 1, 0, 1},
+	}}
+}
+
+func transplantAggregateMetadataDefinition() AggregateMetadataDefinition {
+	return AggregateMetadataDefinition{
+		Name:      "kind_time",
+		Version:   AggregateMetadataDefinitionVersion,
+		Kind:      AggregateMetadataGroupMinMax,
+		Scope:     AggregateMetadataScopeGranule,
+		GroupKeys: []string{"kind_code"},
+		Measures: []AggregateMetadataMeasure{
+			{Op: AggregateMetadataMeasureCount},
+			{Op: AggregateMetadataMeasureMin, Column: "time_us"},
+			{Op: AggregateMetadataMeasureMax, Column: "time_us"},
+		},
+		Predicates:     []AggregateMetadataPredicate{{Column: "has_reply", Op: AggregateMetadataPredicateEq, Value: 1}},
+		MaxBytesPerRow: 256,
+	}
+}
+
+func mustTransplantPart(t *testing.T, partID uint64, opts Options, batch Batch) *ColumnPart {
+	t.Helper()
+	part, err := BuildColumnPart(partID, opts, batch)
+	if err != nil {
+		t.Fatalf("BuildColumnPart: %v", err)
+	}
+	return part
+}
+
+func mustTransplantImage(t *testing.T, part *ColumnPart) ColumnPartImage {
+	t.Helper()
+	image, err := BuildColumnPartImage(part, ColumnPartImageOptions{Dictionaries: map[string]map[string]int64{
+		"kind_code": {"user": 0, "reply": 1, "system": 2},
+	}})
+	if err != nil {
+		t.Fatalf("BuildColumnPartImage: %v", err)
+	}
+	return image
+}
+
+func assertTransplantInt64s(t *testing.T, name string, got []int64, want []int64) {
+	t.Helper()
+	if !slices.Equal(got, want) {
+		t.Fatalf("%s=%v want %v", name, got, want)
+	}
+}
+
+func assertTransplantBytes(t *testing.T, kind ColumnPartImageSectionKind, got []byte, want []byte) {
+	t.Helper()
+	if !slices.Equal(got, want) {
+		t.Fatalf("section %s bytes differ: got %d bytes want %d bytes", kind, len(got), len(want))
+	}
+}

--- a/TreeDB/internal/typedcolumn/transplant_test.go
+++ b/TreeDB/internal/typedcolumn/transplant_test.go
@@ -63,13 +63,23 @@ func TestTypedColumnTransplantSectionDirectoryRoundTrip(t *testing.T) {
 	if len(parsed.Sections) != len(image.Sections) {
 		t.Fatalf("sections=%d want %d", len(parsed.Sections), len(image.Sections))
 	}
+	parsedReader := NewImageSectionReader(parsed)
+	imageReader := NewImageSectionReader(image)
 	for idx := range image.Sections {
 		want := image.Sections[idx]
 		got := parsed.Sections[idx]
 		if got.Kind != want.Kind || got.Category != want.Category || got.Name != want.Name || got.Column != want.Column || got.Offset != want.Offset || got.Length != want.Length {
 			t.Fatalf("section[%d]=%+v want %+v", idx, got, want)
 		}
-		assertTransplantBytes(t, got.Kind, parsed.sectionBytes(got), image.sectionBytes(want))
+		gotBytes, err := parsedReader.ReadSection(got)
+		if err != nil {
+			t.Fatalf("ReadSection(parsed %s): %v", got.Kind, err)
+		}
+		wantBytes, err := imageReader.ReadSection(want)
+		if err != nil {
+			t.Fatalf("ReadSection(image %s): %v", want.Kind, err)
+		}
+		assertTransplantBytes(t, got.Kind, gotBytes, wantBytes)
 	}
 	if parsed.PaddingBytes() == 0 {
 		t.Fatalf("expected aligned section directory to carry padding bytes")

--- a/TreeDB/internal/typedcolumn/transplant_test.go
+++ b/TreeDB/internal/typedcolumn/transplant_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"go/parser"
 	"go/token"
+	"io/fs"
 	"path/filepath"
 	"runtime"
 	"slices"
@@ -267,6 +268,48 @@ func TestTypedColumnTransplantPredicateMetadataRoundTrip(t *testing.T) {
 	}
 }
 
+func TestTypedColumnTransplantBuildRejectsUndeclaredBatchColumn(t *testing.T) {
+	batch := transplantTestBatch()
+	batch.Columns["extra"] = []int64{1, 2, 3, 4, 5, 6}
+	_, err := BuildColumnPart(204, transplantTestOptions([]SortKeyColumn{{Column: "id"}}), batch)
+	if err == nil || !strings.Contains(err.Error(), "undeclared column extra") {
+		t.Fatalf("BuildColumnPart undeclared err=%v want undeclared column", err)
+	}
+}
+
+func TestTypedColumnTransplantEncodeInt64PayloadResetsDestination(t *testing.T) {
+	for _, encoding := range []Encoding{EncodingDeltaVarint, EncodingDoubleDeltaVarint} {
+		got, err := encodeInt64Payload([]byte{0xff, 0xff, 0xff}, []int64{1, 2, 3}, encoding)
+		if err != nil {
+			t.Fatalf("encodeInt64Payload(%s): %v", encoding, err)
+		}
+		if len(got) == 0 || got[0] == 0xff {
+			t.Fatalf("encodeInt64Payload(%s) kept stale destination prefix: %v", encoding, got)
+		}
+	}
+}
+
+func TestTypedColumnTransplantScanColumnRowsIntoResetsDestination(t *testing.T) {
+	part := mustTransplantPart(t, 205, transplantTestOptions([]SortKeyColumn{{Column: "id"}}), transplantTestBatch())
+	scanner := part.NewScanner()
+	got, _, err := scanner.scanColumnRowsInto("value", []int64{999, 888}, []int{0, 2})
+	if err != nil {
+		t.Fatalf("scanColumnRowsInto: %v", err)
+	}
+	assertTransplantInt64s(t, "selected values", got, []int64{100, 300})
+}
+
+func TestTypedColumnTransplantBuildImageRejectsLocatorKeyMismatch(t *testing.T) {
+	part := clonePartWithLocators(mustTransplantPart(t, 206, transplantTestOptions([]SortKeyColumn{{Column: "id"}}), transplantTestBatch()))
+	locator := part.Locators[1]
+	locator.PrimaryID = 999
+	part.Locators[1] = locator
+	_, err := BuildColumnPartImage(part, ColumnPartImageOptions{})
+	if err == nil || !strings.Contains(err.Error(), "row locator key 1 has primary id 999") {
+		t.Fatalf("BuildColumnPartImage locator mismatch err=%v want primary id mismatch", err)
+	}
+}
+
 func TestTypedColumnTransplantDictionaryAggregateDescriptorsRoundTrip(t *testing.T) {
 	opts := transplantTestOptions([]SortKeyColumn{{Column: "id"}})
 	opts.AggregateMetadata = []AggregateMetadataDefinition{transplantAggregateMetadataDefinition()}
@@ -299,6 +342,26 @@ func TestTypedColumnTransplantDictionaryAggregateDescriptorsRoundTrip(t *testing
 	}
 }
 
+func TestTypedColumnTransplantAggregateMetadataByNameReturnsDeepCopy(t *testing.T) {
+	opts := transplantTestOptions([]SortKeyColumn{{Column: "id"}})
+	opts.AggregateMetadata = []AggregateMetadataDefinition{transplantAggregateMetadataDefinition()}
+	part := mustTransplantPart(t, 109, opts, transplantTestBatch())
+	metadata, ok := part.AggregateMetadataByName("kind_time")
+	if !ok || len(metadata.Definition.GroupKeys) == 0 || len(metadata.Granules) == 0 || len(metadata.Granules[0].Entries) == 0 {
+		t.Fatalf("missing aggregate metadata shape: ok=%v metadata=%+v", ok, metadata)
+	}
+	metadata.Definition.GroupKeys[0] = "mutated"
+	metadata.Granules[0].Entries[0].Count = 999
+
+	again, ok := part.AggregateMetadataByName("kind_time")
+	if !ok {
+		t.Fatalf("missing aggregate metadata after mutation")
+	}
+	if again.Definition.GroupKeys[0] == "mutated" || again.Granules[0].Entries[0].Count == 999 {
+		t.Fatalf("AggregateMetadataByName returned mutable internals: %+v", again)
+	}
+}
+
 func TestTypedColumnTransplantFixedWidthSectionsAreAligned(t *testing.T) {
 	image := mustTransplantImage(t, mustTransplantPart(t, 108, transplantTestOptions([]SortKeyColumn{{Column: "id"}}), transplantTestBatch()))
 	for _, section := range image.Sections {
@@ -318,14 +381,13 @@ func TestTypedColumnTransplantNoProductionPublication(t *testing.T) {
 	}
 	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(file), "..", "..", ".."))
 	collectionsDir := filepath.Join(repoRoot, "TreeDB", "collections")
-	matches, err := filepath.Glob(filepath.Join(collectionsDir, "*.go"))
-	if err != nil {
-		t.Fatalf("glob collections: %v", err)
-	}
 	fset := token.NewFileSet()
-	for _, path := range matches {
-		if strings.HasSuffix(path, "_test.go") {
-			continue
+	err := filepath.WalkDir(collectionsDir, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
 		}
 		file, err := parser.ParseFile(fset, path, nil, parser.ImportsOnly)
 		if err != nil {
@@ -336,6 +398,10 @@ func TestTypedColumnTransplantNoProductionPublication(t *testing.T) {
 				t.Fatalf("production collections import typedcolumn in %s; #1753 must not publish/control-plane integrate it", path)
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk collections: %v", err)
 	}
 }
 

--- a/TreeDB/internal/typedcolumn/transplant_test.go
+++ b/TreeDB/internal/typedcolumn/transplant_test.go
@@ -207,6 +207,40 @@ func TestTypedColumnTransplantPartSetLatestVisibleRows(t *testing.T) {
 	}
 }
 
+func TestTypedColumnTransplantPartSetRejectsMissingLocators(t *testing.T) {
+	part := mustTransplantPart(t, 203, transplantTestOptions([]SortKeyColumn{{Column: "id"}}), transplantTestBatch())
+	image := mustTransplantImage(t, part)
+	scanOnlyPart, err := ColumnPartFromImageWithOptions(image, ColumnPartImageReadOptions{})
+	if err != nil {
+		t.Fatalf("ColumnPartFromImageWithOptions(scan-only): %v", err)
+	}
+	if _, err := NewPartSetReader([]PartRef{{Role: PartRoleBase, GenerationID: 1, Part: scanOnlyPart}}, nil); err == nil || !strings.Contains(err.Error(), "row locator count=0") {
+		t.Fatalf("scan-only part set err=%v want missing row locator count", err)
+	}
+
+	partial := clonePartWithLocators(part)
+	delete(partial.Locators, int64(1))
+	if _, err := NewPartSetReader([]PartRef{{Role: PartRoleBase, GenerationID: 1, Part: partial}}, nil); err == nil || !strings.Contains(err.Error(), "row locator count=5") {
+		t.Fatalf("partial locator part set err=%v want partial row locator count", err)
+	}
+
+	duplicate := clonePartWithLocators(part)
+	first, ok := duplicate.LocatePrimaryID(1)
+	if !ok {
+		t.Fatalf("missing locator for id 1")
+	}
+	duplicate.Locators[2] = RowLocator{
+		PrimaryID:      2,
+		PartID:         first.PartID,
+		PartRow:        first.PartRow,
+		GranuleOrdinal: first.GranuleOrdinal,
+		RowInGranule:   first.RowInGranule,
+	}
+	if _, err := NewPartSetReader([]PartRef{{Role: PartRoleBase, GenerationID: 1, Part: duplicate}}, nil); err == nil || !strings.Contains(err.Error(), "duplicate row locator part row") {
+		t.Fatalf("duplicate locator part set err=%v want duplicate row locator", err)
+	}
+}
+
 func TestTypedColumnTransplantPredicateMetadataRoundTrip(t *testing.T) {
 	part := mustTransplantPart(t, 106, transplantTestOptions([]SortKeyColumn{{Column: "kind_code"}, {Column: "time_us"}}), transplantTestBatch())
 	image := mustTransplantImage(t, part)
@@ -367,6 +401,15 @@ func mustTransplantImage(t *testing.T, part *ColumnPart) ColumnPartImage {
 		t.Fatalf("BuildColumnPartImage: %v", err)
 	}
 	return image
+}
+
+func clonePartWithLocators(part *ColumnPart) *ColumnPart {
+	clone := *part
+	clone.Locators = make(map[int64]RowLocator, len(part.Locators))
+	for primaryID, locator := range part.Locators {
+		clone.Locators[primaryID] = locator
+	}
+	return &clone
 }
 
 func assertTransplantInt64s(t *testing.T, name string, got []int64, want []int64) {

--- a/TreeDB/internal/typedcolumn/typed.go
+++ b/TreeDB/internal/typedcolumn/typed.go
@@ -1,0 +1,754 @@
+package typedcolumn
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"math/bits"
+)
+
+const (
+	boolPayloadBitpack byte = 1
+	boolPayloadRLE     byte = 2
+
+	nullableInt64HeaderBytes = 21
+	maxCodeCardinality       = 1 << 20
+)
+
+// BuildBool returns a granule whose payload aliases builder-owned scratch until
+// the next builder Build* or Reset call.
+func (b *GranuleBuilder) BuildBool(values []bool) (EncodedGranule, error) {
+	if len(values) == 0 {
+		return EncodedGranule{}, errors.New("typedcolumn: empty granule")
+	}
+	if err := validateGranuleDecodeRows(len(values)); err != nil {
+		return EncodedGranule{}, err
+	}
+	raw := encodeBoolPayload(b.raw[:0], values)
+	b.raw = raw
+	selection, err := admitCompressionInto(b.compressed[:0], raw, EncodingBoolBitpackRLE, b.cfg.Compression)
+	if err != nil {
+		return EncodedGranule{}, err
+	}
+	b.compressed = selection.Scratch
+	min, max := boolMinMax(values)
+	return newEncodedGranule(len(values), min, max, true, EncodingBoolBitpackRLE, selection), nil
+}
+
+func (r *GranuleReader) DecodeBool(g EncodedGranule) ([]bool, error) {
+	values, err := r.DecodeBoolInto(r.bools[:0], g)
+	if err != nil {
+		return nil, err
+	}
+	r.bools = values
+	return values, nil
+}
+
+func (r *GranuleReader) DecodeBoolInto(dst []bool, g EncodedGranule) ([]bool, error) {
+	if g.Encoding != EncodingBoolBitpackRLE {
+		return nil, fmt.Errorf("typedcolumn: bool decode got encoding %d", g.Encoding)
+	}
+	raw, err := r.decompressPayload(g)
+	if err != nil {
+		return nil, err
+	}
+	return decodeBoolPayload(dst, raw, g.Rows)
+}
+
+func (r *GranuleReader) CountTrueBool(g EncodedGranule) (int, error) {
+	if g.Encoding != EncodingBoolBitpackRLE {
+		return 0, fmt.Errorf("typedcolumn: bool count got encoding %d", g.Encoding)
+	}
+	raw, err := r.decompressPayload(g)
+	if err != nil {
+		return 0, err
+	}
+	return countTrueBoolPayload(raw, g.Rows)
+}
+
+// BuildNullableInt64 returns a granule whose payload aliases builder-owned
+// scratch until the next builder Build* or Reset call.
+func (b *GranuleBuilder) BuildNullableInt64(values []int64, nulls []bool, defaults []bool, defaultValue int64) (EncodedGranule, error) {
+	if len(values) == 0 {
+		return EncodedGranule{}, errors.New("typedcolumn: empty granule")
+	}
+	if err := validateGranuleDecodeRows(len(values)); err != nil {
+		return EncodedGranule{}, err
+	}
+	valueEncoding, err := nullableValueEncoding(b.cfg.Encoding)
+	if err != nil {
+		return EncodedGranule{}, err
+	}
+	if err := validateOptionalBoolRows("nulls", len(values), nulls); err != nil {
+		return EncodedGranule{}, err
+	}
+	if err := validateOptionalBoolRows("defaults", len(values), defaults); err != nil {
+		return EncodedGranule{}, err
+	}
+
+	b.values64 = b.values64[:0]
+	nullCount := 0
+	defaultCount := 0
+	hasMinMax := false
+	min, max := int64(0), int64(0)
+	for i, v := range values {
+		isNull := boolAt(nulls, i)
+		isDefault := boolAt(defaults, i)
+		if isNull && isDefault {
+			return EncodedGranule{}, fmt.Errorf("typedcolumn: row %d is both null and default", i)
+		}
+		switch {
+		case isNull:
+			nullCount++
+		case isDefault:
+			defaultCount++
+			min, max, hasMinMax = updateOptionalMinMax(min, max, hasMinMax, defaultValue)
+		default:
+			b.values64 = append(b.values64, v)
+			min, max, hasMinMax = updateOptionalMinMax(min, max, hasMinMax, v)
+		}
+	}
+
+	encodedValues, err := encodeInt64Payload(b.encoded[:0], b.values64, valueEncoding)
+	if err != nil {
+		return EncodedGranule{}, err
+	}
+	b.encoded = encodedValues
+
+	nullMaskLen := bitmapBytes(len(values))
+	defaultMaskLen := bitmapBytes(len(values))
+	raw := b.raw[:0]
+	raw = append(raw, make([]byte, nullableInt64HeaderBytes)...)
+	raw[0] = byte(valueEncoding)
+	binary.LittleEndian.PutUint64(raw[1:9], uint64(defaultValue))
+	binary.LittleEndian.PutUint32(raw[9:13], uint32(len(b.values64)))
+	binary.LittleEndian.PutUint32(raw[13:17], uint32(nullMaskLen))
+	binary.LittleEndian.PutUint32(raw[17:21], uint32(defaultMaskLen))
+	raw = appendBitmap(raw, len(values), nulls)
+	raw = appendBitmap(raw, len(values), defaults)
+	raw = append(raw, encodedValues...)
+	b.raw = raw
+
+	selection, err := admitCompressionInto(b.compressed[:0], raw, EncodingNullableInt64, b.cfg.Compression)
+	if err != nil {
+		return EncodedGranule{}, err
+	}
+	b.compressed = selection.Scratch
+	g := newEncodedGranule(len(values), min, max, hasMinMax, EncodingNullableInt64, selection)
+	g.NullCount = nullCount
+	g.DefaultCount = defaultCount
+	return g, nil
+}
+
+func (r *GranuleReader) DecodeNullableInt64(g EncodedGranule) ([]int64, []bool, []bool, error) {
+	values, nulls, defaults, err := r.DecodeNullableInt64Into(r.values[:0], r.nulls[:0], r.defaults[:0], g)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	r.values = values
+	r.nulls = nulls
+	r.defaults = defaults
+	return values, nulls, defaults, nil
+}
+
+func (r *GranuleReader) DecodeNullableInt64Into(dst []int64, nulls []bool, defaults []bool, g EncodedGranule) ([]int64, []bool, []bool, error) {
+	if g.Encoding != EncodingNullableInt64 {
+		return nil, nil, nil, fmt.Errorf("typedcolumn: nullable int64 decode got encoding %d", g.Encoding)
+	}
+	raw, err := r.decompressPayload(g)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	header, err := parseNullableInt64Header(raw, g.Rows)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	storedGranule := EncodedGranule{
+		Rows:        header.storedRows,
+		HasMinMax:   false,
+		Encoding:    header.valueEncoding,
+		Compression: CompressionNone,
+		RawBytes:    len(header.encodedValues),
+		StoredBytes: len(header.encodedValues),
+		PayloadRef:  PayloadRef{Kind: PayloadRefInline, Length: len(header.encodedValues)},
+		Payload:     header.encodedValues,
+	}
+	stored, err := decodeInt64Payload(r.stored64[:0], header.encodedValues, storedGranule)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	r.stored64 = stored
+
+	out := ensureInt64Len(dst, g.Rows)
+	nullOut := ensureBoolLen(nulls, g.Rows)
+	defaultOut := ensureBoolLen(defaults, g.Rows)
+	storedIndex := 0
+	for i := 0; i < g.Rows; i++ {
+		isNull := bitmapBit(header.nullMask, i)
+		isDefault := bitmapBit(header.defaultMask, i)
+		if isNull && isDefault {
+			return nil, nil, nil, fmt.Errorf("typedcolumn: nullable int64 row %d is both null and default", i)
+		}
+		nullOut[i] = isNull
+		defaultOut[i] = isDefault
+		switch {
+		case isNull:
+			out[i] = 0
+		case isDefault:
+			out[i] = header.defaultValue
+		default:
+			if storedIndex >= len(stored) {
+				return nil, nil, nil, errors.New("typedcolumn: nullable int64 stored values underflow")
+			}
+			out[i] = stored[storedIndex]
+			storedIndex++
+		}
+	}
+	if storedIndex != len(stored) {
+		return nil, nil, nil, errors.New("typedcolumn: nullable int64 stored values overflow")
+	}
+	return out, nullOut, defaultOut, nil
+}
+
+// BuildUint32Codes returns a granule whose payload aliases builder-owned
+// scratch until the next builder Build* or Reset call.
+func (b *GranuleBuilder) BuildUint32Codes(codes []uint32, cardinality uint32) (EncodedGranule, error) {
+	if len(codes) == 0 {
+		return EncodedGranule{}, errors.New("typedcolumn: empty granule")
+	}
+	if err := validateGranuleDecodeRows(len(codes)); err != nil {
+		return EncodedGranule{}, err
+	}
+	minCode, maxCode := minMaxUint32(codes)
+	if cardinality == 0 {
+		if maxCode == ^uint32(0) {
+			return EncodedGranule{}, errors.New("typedcolumn: inferred cardinality overflows uint32")
+		}
+		cardinality = maxCode + 1
+	}
+	if cardinality > maxCodeCardinality {
+		return EncodedGranule{}, fmt.Errorf("typedcolumn: cardinality %d exceeds cap %d", cardinality, maxCodeCardinality)
+	}
+	if maxCode >= cardinality {
+		return EncodedGranule{}, fmt.Errorf("typedcolumn: code %d outside cardinality %d", maxCode, cardinality)
+	}
+	raw := encodeUint32CodesPayload(b.raw[:0], codes, cardinality, maxCode)
+	b.raw = raw
+	selection, err := admitCompressionInto(b.compressed[:0], raw, EncodingLowCardinalityUint32, b.cfg.Compression)
+	if err != nil {
+		return EncodedGranule{}, err
+	}
+	b.compressed = selection.Scratch
+	return newEncodedGranule(len(codes), int64(minCode), int64(maxCode), true, EncodingLowCardinalityUint32, selection), nil
+}
+
+func (r *GranuleReader) DecodeUint32Codes(g EncodedGranule) ([]uint32, error) {
+	codes, err := r.DecodeUint32CodesInto(r.codes[:0], g)
+	if err != nil {
+		return nil, err
+	}
+	r.codes = codes
+	return codes, nil
+}
+
+func (r *GranuleReader) DecodeUint32CodesInto(dst []uint32, g EncodedGranule) ([]uint32, error) {
+	if g.Encoding != EncodingLowCardinalityUint32 {
+		return nil, fmt.Errorf("typedcolumn: code decode got encoding %d", g.Encoding)
+	}
+	raw, err := r.decompressPayload(g)
+	if err != nil {
+		return nil, err
+	}
+	header, err := parseUint32CodesHeader(raw, g.Rows)
+	if err != nil {
+		return nil, err
+	}
+	out := ensureUint32Len(dst, g.Rows)
+	for i := 0; i < g.Rows; i++ {
+		code := readUint32Code(header.data, header.width, i)
+		if code >= header.cardinality {
+			return nil, fmt.Errorf("typedcolumn: code %d outside cardinality %d", code, header.cardinality)
+		}
+		out[i] = code
+	}
+	return out, nil
+}
+
+func (r *GranuleReader) CountUint32Codes(g EncodedGranule, counts []int) ([]int, error) {
+	if g.Encoding != EncodingLowCardinalityUint32 {
+		return nil, fmt.Errorf("typedcolumn: code count got encoding %d", g.Encoding)
+	}
+	raw, err := r.decompressPayload(g)
+	if err != nil {
+		return nil, err
+	}
+	header, err := parseUint32CodesHeader(raw, g.Rows)
+	if err != nil {
+		return nil, err
+	}
+	out := ensureIntLen(counts, int(header.cardinality))
+	clear(out)
+	for i := 0; i < g.Rows; i++ {
+		code := readUint32Code(header.data, header.width, i)
+		if code >= header.cardinality {
+			return nil, fmt.Errorf("typedcolumn: code %d outside cardinality %d", code, header.cardinality)
+		}
+		out[code]++
+	}
+	return out, nil
+}
+
+func encodeBoolPayload(dst []byte, values []bool) []byte {
+	bitpackLen := 1 + bitmapBytes(len(values))
+	rleLen := boolRLEPayloadLen(values)
+	if rleLen < bitpackLen {
+		dst = appendBoolRLE(dst[:0], values)
+		return dst
+	}
+	dst = append(dst[:0], boolPayloadBitpack)
+	return appendBitmap(dst, len(values), values)
+}
+
+func decodeBoolPayload(dst []bool, raw []byte, rows int) ([]bool, error) {
+	if err := validateGranuleDecodeRows(rows); err != nil {
+		return nil, err
+	}
+	if len(raw) == 0 {
+		return nil, errors.New("typedcolumn: missing bool payload mode")
+	}
+	switch raw[0] {
+	case boolPayloadBitpack:
+		mask := raw[1:]
+		need, err := bitmapBytesChecked(rows)
+		if err != nil {
+			return nil, err
+		}
+		if len(mask) != need {
+			return nil, fmt.Errorf("typedcolumn: bool bitpack bytes=%d want=%d", len(mask), need)
+		}
+		out := ensureBoolLen(dst, rows)
+		for i := 0; i < rows; i++ {
+			out[i] = bitmapBit(mask, i)
+		}
+		return out, nil
+	case boolPayloadRLE:
+		value, data, err := parseBoolRLEHeader(raw)
+		if err != nil {
+			return nil, err
+		}
+		if err := validateBoolRLERuns(data, rows); err != nil {
+			return nil, err
+		}
+		out := ensureBoolLen(dst, rows)
+		row := 0
+		for len(data) > 0 && row < rows {
+			run, n := binary.Uvarint(data)
+			for i := 0; i < int(run); i++ {
+				out[row+i] = value
+			}
+			row += int(run)
+			value = !value
+			data = data[n:]
+		}
+		return out, nil
+	default:
+		return nil, fmt.Errorf("typedcolumn: unsupported bool payload mode %d", raw[0])
+	}
+}
+
+func countTrueBoolPayload(raw []byte, rows int) (int, error) {
+	if err := validateGranuleDecodeRows(rows); err != nil {
+		return 0, err
+	}
+	if len(raw) == 0 {
+		return 0, errors.New("typedcolumn: missing bool payload mode")
+	}
+	switch raw[0] {
+	case boolPayloadBitpack:
+		mask := raw[1:]
+		need, err := bitmapBytesChecked(rows)
+		if err != nil {
+			return 0, err
+		}
+		if len(mask) != need {
+			return 0, fmt.Errorf("typedcolumn: bool bitpack bytes=%d want=%d", len(mask), need)
+		}
+		count := 0
+		fullBytes := rows / 8
+		for _, b := range mask[:fullBytes] {
+			count += bits.OnesCount8(b)
+		}
+		if rows%8 != 0 {
+			last := mask[fullBytes] & byte((1<<uint(rows%8))-1)
+			count += bits.OnesCount8(last)
+		}
+		return count, nil
+	case boolPayloadRLE:
+		value, data, err := parseBoolRLEHeader(raw)
+		if err != nil {
+			return 0, err
+		}
+		row := 0
+		count := 0
+		for len(data) > 0 && row < rows {
+			run, n := binary.Uvarint(data)
+			if n <= 0 {
+				return 0, errors.New("typedcolumn: malformed bool rle run")
+			}
+			if run == 0 || run > uint64(rows-row) {
+				return 0, errors.New("typedcolumn: invalid bool rle run")
+			}
+			if value {
+				count += int(run)
+			}
+			row += int(run)
+			value = !value
+			data = data[n:]
+		}
+		if row != rows {
+			return 0, fmt.Errorf("typedcolumn: bool rle rows=%d want=%d", row, rows)
+		}
+		if len(data) != 0 {
+			return 0, errors.New("typedcolumn: trailing bool rle bytes")
+		}
+		return count, nil
+	default:
+		return 0, fmt.Errorf("typedcolumn: unsupported bool payload mode %d", raw[0])
+	}
+}
+
+func boolRLEPayloadLen(values []bool) int {
+	if len(values) == 0 {
+		return 0
+	}
+	var buf [binary.MaxVarintLen64]byte
+	n := 2
+	run := uint64(1)
+	prev := values[0]
+	for _, v := range values[1:] {
+		if v == prev {
+			run++
+			continue
+		}
+		n += binary.PutUvarint(buf[:], run)
+		run = 1
+		prev = v
+	}
+	n += binary.PutUvarint(buf[:], run)
+	return n
+}
+
+func appendBoolRLE(dst []byte, values []bool) []byte {
+	dst = append(dst, boolPayloadRLE)
+	if values[0] {
+		dst = append(dst, 1)
+	} else {
+		dst = append(dst, 0)
+	}
+	var buf [binary.MaxVarintLen64]byte
+	run := uint64(1)
+	prev := values[0]
+	for _, v := range values[1:] {
+		if v == prev {
+			run++
+			continue
+		}
+		n := binary.PutUvarint(buf[:], run)
+		dst = append(dst, buf[:n]...)
+		run = 1
+		prev = v
+	}
+	n := binary.PutUvarint(buf[:], run)
+	return append(dst, buf[:n]...)
+}
+
+func encodeUint32CodesPayload(dst []byte, codes []uint32, cardinality uint32, maxCode uint32) []byte {
+	width := uint32CodeWidth(maxCode)
+	dst = append(dst[:0], width)
+	var buf [binary.MaxVarintLen64]byte
+	n := binary.PutUvarint(buf[:], uint64(cardinality))
+	dst = append(dst, buf[:n]...)
+	switch width {
+	case 1:
+		for _, code := range codes {
+			dst = append(dst, byte(code))
+		}
+	case 2:
+		oldLen := len(dst)
+		dst = append(dst, make([]byte, len(codes)*2)...)
+		for i, code := range codes {
+			binary.LittleEndian.PutUint16(dst[oldLen+i*2:], uint16(code))
+		}
+	case 4:
+		oldLen := len(dst)
+		dst = append(dst, make([]byte, len(codes)*4)...)
+		for i, code := range codes {
+			binary.LittleEndian.PutUint32(dst[oldLen+i*4:], code)
+		}
+	}
+	return dst
+}
+
+type uint32CodesHeader struct {
+	width       byte
+	cardinality uint32
+	data        []byte
+}
+
+func parseUint32CodesHeader(raw []byte, rows int) (uint32CodesHeader, error) {
+	if err := validateGranuleDecodeRows(rows); err != nil {
+		return uint32CodesHeader{}, err
+	}
+	if len(raw) < 2 {
+		return uint32CodesHeader{}, errors.New("typedcolumn: truncated code header")
+	}
+	width := raw[0]
+	if width != 1 && width != 2 && width != 4 {
+		return uint32CodesHeader{}, fmt.Errorf("typedcolumn: unsupported code width %d", width)
+	}
+	cardinality64, n := binary.Uvarint(raw[1:])
+	if n <= 0 {
+		return uint32CodesHeader{}, errors.New("typedcolumn: malformed code cardinality")
+	}
+	if cardinality64 == 0 || cardinality64 > maxCodeCardinality {
+		return uint32CodesHeader{}, fmt.Errorf("typedcolumn: invalid code cardinality %d", cardinality64)
+	}
+	data := raw[1+n:]
+	if rows > int(^uint(0)>>1)/int(width) {
+		return uint32CodesHeader{}, fmt.Errorf("typedcolumn: code rows=%d width=%d overflow", rows, width)
+	}
+	need := rows * int(width)
+	if len(data) != need {
+		return uint32CodesHeader{}, fmt.Errorf("typedcolumn: code data bytes=%d want=%d", len(data), need)
+	}
+	return uint32CodesHeader{width: width, cardinality: uint32(cardinality64), data: data}, nil
+}
+
+func readUint32Code(data []byte, width byte, row int) uint32 {
+	switch width {
+	case 1:
+		return uint32(data[row])
+	case 2:
+		return uint32(binary.LittleEndian.Uint16(data[row*2:]))
+	default:
+		return binary.LittleEndian.Uint32(data[row*4:])
+	}
+}
+
+type nullableInt64Header struct {
+	valueEncoding Encoding
+	defaultValue  int64
+	storedRows    int
+	nullMask      []byte
+	defaultMask   []byte
+	encodedValues []byte
+}
+
+func parseNullableInt64Header(raw []byte, rows int) (nullableInt64Header, error) {
+	if err := validateGranuleDecodeRows(rows); err != nil {
+		return nullableInt64Header{}, err
+	}
+	if len(raw) < nullableInt64HeaderBytes {
+		return nullableInt64Header{}, errors.New("typedcolumn: truncated nullable int64 header")
+	}
+	valueEncoding := Encoding(raw[0])
+	if _, err := nullableValueEncoding(valueEncoding); err != nil {
+		return nullableInt64Header{}, err
+	}
+	defaultValue := int64(binary.LittleEndian.Uint64(raw[1:9]))
+	storedRows := int(binary.LittleEndian.Uint32(raw[9:13]))
+	if storedRows > rows {
+		return nullableInt64Header{}, fmt.Errorf("typedcolumn: nullable stored rows=%d exceeds rows=%d", storedRows, rows)
+	}
+	nullMaskLen := int(binary.LittleEndian.Uint32(raw[13:17]))
+	defaultMaskLen := int(binary.LittleEndian.Uint32(raw[17:21]))
+	wantMaskLen, err := bitmapBytesChecked(rows)
+	if err != nil {
+		return nullableInt64Header{}, err
+	}
+	if nullMaskLen != wantMaskLen {
+		return nullableInt64Header{}, fmt.Errorf("typedcolumn: null mask bytes=%d want=%d", nullMaskLen, wantMaskLen)
+	}
+	if defaultMaskLen != wantMaskLen {
+		return nullableInt64Header{}, fmt.Errorf("typedcolumn: default mask bytes=%d want=%d", defaultMaskLen, wantMaskLen)
+	}
+	need := nullableInt64HeaderBytes + nullMaskLen + defaultMaskLen
+	if need > len(raw) {
+		return nullableInt64Header{}, errors.New("typedcolumn: truncated nullable int64 masks")
+	}
+	return nullableInt64Header{
+		valueEncoding: valueEncoding,
+		defaultValue:  defaultValue,
+		storedRows:    storedRows,
+		nullMask:      raw[nullableInt64HeaderBytes : nullableInt64HeaderBytes+nullMaskLen],
+		defaultMask:   raw[nullableInt64HeaderBytes+nullMaskLen : need],
+		encodedValues: raw[need:],
+	}, nil
+}
+
+func nullableValueEncoding(encoding Encoding) (Encoding, error) {
+	switch encoding {
+	case EncodingRawInt64, EncodingDeltaVarint, EncodingDoubleDeltaVarint:
+		return encoding, nil
+	default:
+		return 0, fmt.Errorf("typedcolumn: unsupported nullable int64 value encoding %d", encoding)
+	}
+}
+
+func appendBitmap(dst []byte, rows int, values []bool) []byte {
+	start := len(dst)
+	dst = append(dst, make([]byte, bitmapBytes(rows))...)
+	for i := 0; i < rows; i++ {
+		if boolAt(values, i) {
+			dst[start+i/8] |= 1 << uint(i%8)
+		}
+	}
+	return dst
+}
+
+func bitmapBytes(rows int) int {
+	return (rows + 7) / 8
+}
+
+func bitmapBytesChecked(rows int) (int, error) {
+	if err := validateGranuleDecodeRows(rows); err != nil {
+		return 0, err
+	}
+	return bitmapBytes(rows), nil
+}
+
+func parseBoolRLEHeader(raw []byte) (bool, []byte, error) {
+	if len(raw) < 2 {
+		return false, nil, errors.New("typedcolumn: truncated bool rle header")
+	}
+	switch raw[1] {
+	case 0:
+		return false, raw[2:], nil
+	case 1:
+		return true, raw[2:], nil
+	default:
+		return false, nil, fmt.Errorf("typedcolumn: invalid bool rle start value %d", raw[1])
+	}
+}
+
+func validateBoolRLERuns(data []byte, rows int) error {
+	row := 0
+	for len(data) > 0 && row < rows {
+		run, n := binary.Uvarint(data)
+		if n <= 0 {
+			return errors.New("typedcolumn: malformed bool rle run")
+		}
+		if run == 0 || run > uint64(rows-row) {
+			return errors.New("typedcolumn: invalid bool rle run")
+		}
+		row += int(run)
+		data = data[n:]
+	}
+	if row != rows {
+		return fmt.Errorf("typedcolumn: bool rle rows=%d want=%d", row, rows)
+	}
+	if len(data) != 0 {
+		return errors.New("typedcolumn: trailing bool rle bytes")
+	}
+	return nil
+}
+
+func bitmapBit(mask []byte, row int) bool {
+	return mask[row/8]&(1<<uint(row%8)) != 0
+}
+
+func boolAt(values []bool, i int) bool {
+	return i >= 0 && i < len(values) && values[i]
+}
+
+func validateOptionalBoolRows(name string, rows int, values []bool) error {
+	if len(values) != 0 && len(values) != rows {
+		return fmt.Errorf("typedcolumn: %s rows=%d want 0 or %d", name, len(values), rows)
+	}
+	return nil
+}
+
+func updateOptionalMinMax(min int64, max int64, has bool, v int64) (int64, int64, bool) {
+	if !has {
+		return v, v, true
+	}
+	if v < min {
+		min = v
+	}
+	if v > max {
+		max = v
+	}
+	return min, max, true
+}
+
+func boolMinMax(values []bool) (int64, int64) {
+	seenFalse := false
+	seenTrue := false
+	for _, v := range values {
+		if v {
+			seenTrue = true
+		} else {
+			seenFalse = true
+		}
+	}
+	switch {
+	case seenFalse && seenTrue:
+		return 0, 1
+	case seenTrue:
+		return 1, 1
+	default:
+		return 0, 0
+	}
+}
+
+func minMaxUint32(values []uint32) (uint32, uint32) {
+	min, max := values[0], values[0]
+	for _, v := range values[1:] {
+		if v < min {
+			min = v
+		}
+		if v > max {
+			max = v
+		}
+	}
+	return min, max
+}
+
+func uint32CodeWidth(maxCode uint32) byte {
+	switch {
+	case maxCode <= 0xff:
+		return 1
+	case maxCode <= 0xffff:
+		return 2
+	default:
+		return 4
+	}
+}
+
+func ensureInt64Len(dst []int64, n int) []int64 {
+	if cap(dst) < n {
+		return make([]int64, n)
+	}
+	return dst[:n]
+}
+
+func ensureBoolLen(dst []bool, n int) []bool {
+	if cap(dst) < n {
+		return make([]bool, n)
+	}
+	return dst[:n]
+}
+
+func ensureUint32Len(dst []uint32, n int) []uint32 {
+	if cap(dst) < n {
+		return make([]uint32, n)
+	}
+	return dst[:n]
+}
+
+func ensureIntLen(dst []int, n int) []int {
+	if cap(dst) < n {
+		return make([]int, n)
+	}
+	return dst[:n]
+}


### PR DESCRIPTION
## Summary

Transplants the coherent `experiments/colgranule` typed-column data plane into `TreeDB/internal/typedcolumn` as a **non-authoritative typed-column engine** for #1753.

This is a copy/adapt transplant, not a clean-room rewrite and not a typed-row-shaped serializer. The new internal package can build, encode, decode, validate, and scan its own typed-column part artifacts, but it is not wired into production collection publication or query planning.

Parent tracker: #1744  
Child issue: #1753  
Dependency status: #1750/#1751/#1752 are merged on `main`; #1736 Gate A is merged and broader #1736 resource/lifetime integration remains deferred.

## Scope Boundary / Non-Goals

In scope:

- `TreeDB/internal/typedcolumn` data-plane package.
- Versioned part images and TCS1 in-memory header/checksum identity.
- Section directory encode/decode with aligned section offsets.
- Granules, typed descriptors, codecs, compression, parts, row locators.
- Sort-key marks and predicate/pruning metadata.
- Dictionary descriptors and aggregate metadata descriptors/payloads.
- Latest-visible base/delta/tombstone part-set logic over caller-owned parts.
- Narrow `SectionReader` seam for #1754 mappedresource-backed byte access.
- Spec note: `TreeDB/docs/spec/typed-column-transplant.md`.

Out of scope / intentionally deferred:

- No production collection manifest publication.
- No command-WAL/recovery integration.
- No authoritative `typed_column_part` field ownership.
- No query planner, production scan, or vector path switch.
- No attempt to force this engine into the existing typed-row physical asset format.
- No private production mmap/cache/lifecycle; #1754 should adapt this package to #1736 mappedresource/control-plane seams.

## Copy / Adapt / Defer Table

| Source | Destination / action | Semantic delta | Reason | Tests |
| --- | --- | --- | --- | --- |
| `experiments/colgranule/typed.go` | copied to `TreeDB/internal/typedcolumn/typed.go` | package and error prefix renamed | preserve typed codecs | `TestTypedColumnTransplantPartImageRoundTrip` |
| `experiments/colgranule/granule.go` | copied to `TreeDB/internal/typedcolumn/granule.go` | package and error prefix renamed | preserve granule encodings/compression | `TestTypedColumnTransplantPartImageRoundTrip`, `TestTypedColumnTransplantPredicateMetadataRoundTrip` |
| `experiments/colgranule/part.go` | copied/adapted to `TreeDB/internal/typedcolumn/part.go` | `ColumnStoreOptions` -> package-local `Options`; `ColumnBatch` -> `Batch`; error prefix renamed | avoid adding new `ColumnStore*` names while preserving part descriptors/build/scan | `TestTypedColumnTransplantPartImageRoundTrip`, `TestTypedColumnTransplantRowLocatorRoundTrip` |
| `experiments/colgranule/part_image.go` | copied/adapted to `TreeDB/internal/typedcolumn/part_image.go` | package/error prefix renamed; section offsets aligned; padding accounting added | preserve sectioned image model and satisfy fixed-width alignment | `TestTypedColumnTransplantSectionDirectoryRoundTrip`, `TestTypedColumnTransplantFixedWidthSectionsAreAligned` |
| `experiments/colgranule/part_image_decode.go` | copied/adapted to `TreeDB/internal/typedcolumn/part_image_decode.go` plus `section_reader.go` seam | package/error prefix renamed; validates aligned sections and permits explicit padding gaps; exposes `SectionReader` for future mappedresource adapters | preserve decode/bounds checks for aligned section directories while deferring #1736-backed IO to #1754 | `TestTypedColumnTransplantRejectsInvalidMagicOrVersion`, `TestTypedColumnTransplantRejectsTruncatedOrOutOfBoundsSection`, `TestTypedColumnTransplantSectionDirectoryRoundTrip` |
| `experiments/colgranule/predicate.go` | copied to `TreeDB/internal/typedcolumn/predicate.go` | package/error prefix renamed | preserve sort-key mark and predicate/pruning metadata | `TestTypedColumnTransplantPredicateMetadataRoundTrip` |
| `experiments/colgranule/aggregate_metadata.go` | copied to `TreeDB/internal/typedcolumn/aggregate_metadata.go` | package/error prefix renamed | preserve aggregate metadata descriptors/payloads | `TestTypedColumnTransplantDictionaryAggregateDescriptorsRoundTrip` |
| `experiments/colgranule/aggregate.go` | copied to `TreeDB/internal/typedcolumn/aggregate.go` | package/error prefix renamed | preserve aggregate arena helpers used by metadata build | `TestTypedColumnTransplantDictionaryAggregateDescriptorsRoundTrip` |
| `experiments/colgranule/adaptive_mark.go` | copied to `TreeDB/internal/typedcolumn/adaptive_mark.go` | package/error prefix renamed | preserve adaptive mark sizing hooks | package compile and part builder coverage |
| `experiments/colgranule/part_accounting.go` | copied/adapted to `TreeDB/internal/typedcolumn/part_accounting.go` | JSONBench-only helper deferred; padding bytes added | keep part/granule/accounting concepts without benchmark fixture dependency | `TestTypedColumnTransplantPartImageRoundTrip` |
| `experiments/colgranule/tcs1.go` | copied/adapted to `TreeDB/internal/typedcolumn/tcs1.go` | in-memory encode/decode/header validation retained; asset-store helpers deferred | preserve versioned header/checksum identity without adding production publication/storage | `TestTypedColumnTransplantPartImageRoundTrip`, `TestTypedColumnTransplantRejectsInvalidMagicOrVersion` |
| `experiments/colgranule/part_set.go` | copied/adapted subset to `TreeDB/internal/typedcolumn/part_set.go` | latest-visible base/delta/tombstone data-plane logic retained over caller-owned parts; workspace/manifest/compaction deferred | keep coherent part-set semantics without production control-plane integration | `TestTypedColumnTransplantPartSetLatestVisibleRows` |
| `experiments/colgranule/asset_store.go`, `asset_manager.go`, `workspace.go`, `lifecycle*.go`, `collection_manifest.go`, `control_plane_binary.go`, `mutation_adapter.go` | deferred | no production/internal copy in #1753 | control-plane, workspace, publication, recovery, or benchmark/lifecycle ownership belongs to #1754/#1755 and #1736 integration | `TestTypedColumnTransplantNoProductionPublication` |
| `experiments/colgranule/jsonbench*`, benchmark reports, local-data benchmarks | deferred / remain in experiments | none | benchmark harnesses and JSONBench fixtures are not required for the non-authoritative data-plane transplant | not hot-path integrated in #1753 |

## Required Test Mapping

| Required item from #1753 | Actual test |
| --- | --- |
| Part image round trip | `TestTypedColumnTransplantPartImageRoundTrip` |
| Section directory round trip | `TestTypedColumnTransplantSectionDirectoryRoundTrip` |
| Invalid magic/version | `TestTypedColumnTransplantRejectsInvalidMagicOrVersion` |
| Truncated/out-of-bounds section | `TestTypedColumnTransplantRejectsTruncatedOrOutOfBoundsSection` |
| Row locator round trip | `TestTypedColumnTransplantRowLocatorRoundTrip` |
| Part-set latest-visible rows | `TestTypedColumnTransplantPartSetLatestVisibleRows` |
| Part-set rejects missing/incomplete/duplicate locators | `TestTypedColumnTransplantPartSetRejectsMissingLocators` |
| Predicate metadata round trip | `TestTypedColumnTransplantPredicateMetadataRoundTrip` |
| Dictionary/aggregate descriptors round trip | `TestTypedColumnTransplantDictionaryAggregateDescriptorsRoundTrip` |
| Fixed-width section alignment | `TestTypedColumnTransplantFixedWidthSectionsAreAligned` |
| No production publication | `TestTypedColumnTransplantNoProductionPublication` |

## Naming Impact

- No public `ColumnStore*` API is added, removed, or renamed.
- The internal transplant package uses `typedcolumn` and package-local `Options`/`Batch` instead of adding new `ColumnStoreOptions`/`ColumnBatch` symbols.
- `ColumnPart*` / `ColumnPartImage*` names are retained as true typed-column terminology.
- Current production `ColumnStoreConfig`, typed-row assets, and compatibility metadata remain unchanged.
- `typed-storage-naming.md` now records #1753 as a non-authoritative typed-column data-plane transplant.

## Tests Run

- `go test -count=1 ./TreeDB/internal/typedcolumn -run TestTypedColumnTransplant -v`
- `go test -count=1 ./TreeDB/internal/typedcolumn ./TreeDB/collections`
- `go test -count=1 ./TreeDB/...`
- `rg -n "ColumnStore|column store|column-store" TreeDB docs experiments`


Additional hardening coverage added after review:

- `TestTypedColumnTransplantPartSetRejectsMissingLocators`
- `TestTypedColumnTransplantBuildRejectsUndeclaredBatchColumn`
- `TestTypedColumnTransplantEncodeInt64PayloadResetsDestination`
- `TestTypedColumnTransplantScanColumnRowsIntoResetsDestination`
- `TestTypedColumnTransplantBuildImageRejectsLocatorKeyMismatch`
- `TestTypedColumnTransplantAggregateMetadataByNameReturnsDeepCopy`

## Benchmark / Performance Evidence

No benchmarks run. This PR adds an internal, non-authoritative data-plane package and tests/docs only; it is not wired into production hot paths, query planning, publication, or vector scans.

## CI / Review Status

- Latest-head CI: passing on head `e37d0e818`.
- Review threads: 0 unresolved.
- Codex review: latest-head re-review reported no major issues.
- CodeRabbit review: latest-head status passed after hardening fixes.
- Copilot review: requested on latest head; bot/cloud-agent errored again (`Copilot encountered an error and was unable to review this pull request`).

## Notes For Follow-Ups

- #1754 should adapt `TreeDB/internal/typedcolumn` to TreeDB typed-storage resources/control-plane and #1736 mappedresource handles.
- #1755 owns durable publication/reopen/reconstruction.
- #1756/#1757 own vector dense sections and predicate scan MVP integration.
