### PR TITLE
bench: add 768d vector dot kernel sweep

### DIFF
--- a/benchmarks/vector_distance_kernels/README.md
+++ b/benchmarks/vector_distance_kernels/README.md
@@ -79,6 +79,23 @@ cd benchmarks/vector_distance_kernels
 GOWORK=off go test -bench 'BenchmarkDotProduct(768|Batch768)' -benchmem -count=5 | tee /tmp/dot768_bench.txt
 ```
 
+The `snissn/simd` fork has a merged amd64 AVX512 cross-row batch4
+`f32.DotProductBatch` implementation (https://github.com/snissn/simd/pull/1).
+To validate TreeDB-shaped kernels against that fork before it is released or
+upstreamed, use a temporary module replacement from this benchmark module:
+
+```sh
+mkdir -p ~/dev/snissn
+git clone https://github.com/snissn/simd ~/dev/snissn/simd || git -C ~/dev/snissn/simd pull --ff-only
+cd benchmarks/vector_distance_kernels
+GOWORK=off go mod edit -replace github.com/tphakala/simd=$HOME/dev/snissn/simd
+GOWORK=off go test -bench 'BenchmarkDotProduct(768|Batch768)' -benchmem -count=5 | tee /tmp/dot768_snissn_simd.txt
+GOWORK=off go mod edit -dropreplace github.com/tphakala/simd
+```
+
+On the 11th Gen Intel i5-11400F test host, the fork's true 128x768 batch path
+measured about 22-23 ns/dot versus about 31 ns/dot for a per-row loop.
+
 As of this benchmark, `go get github.com/ashvardanian/simsimd/golang@latest`
 fails because the latest `github.com/ashvardanian/simsimd` module does not
 contain a `golang` package. If that package becomes available, add it beside the

--- a/benchmarks/vector_distance_kernels/README.md
+++ b/benchmarks/vector_distance_kernels/README.md
@@ -72,6 +72,13 @@ cd benchmarks/vector_distance_kernels
 GOWORK=off go test -bench 'BenchmarkTreeDBRerank' -benchmem -count=5 | tee /tmp/treedb_rerank_kernel.txt
 ```
 
+Focused 768-dimensional dot-product run, matching larger vector-search shapes:
+
+```sh
+cd benchmarks/vector_distance_kernels
+GOWORK=off go test -bench 'BenchmarkDotProduct(768|Batch768)' -benchmem -count=5 | tee /tmp/dot768_bench.txt
+```
+
 As of this benchmark, `go get github.com/ashvardanian/simsimd/golang@latest`
 fails because the latest `github.com/ashvardanian/simsimd` module does not
 contain a `golang` package. If that package becomes available, add it beside the

--- a/benchmarks/vector_distance_kernels/vector_dot_768_bench_test.go
+++ b/benchmarks/vector_distance_kernels/vector_dot_768_bench_test.go
@@ -1,0 +1,108 @@
+package vectordistancekernels
+
+import (
+	"testing"
+
+	axiomsimd "github.com/axiomhq/simd-go"
+	dahvrisimd "github.com/ic-timon/da-hvri/simd"
+	simdf32 "github.com/tphakala/simd/f32"
+	"github.com/viterin/vek/vek32"
+	"gonum.org/v1/gonum/blas/blas32"
+)
+
+func BenchmarkDotProduct768(b *testing.B) {
+	const dims = 768
+	query, _ := benchVector(17, dims)
+	candidate, _ := benchVector(23, dims)
+	b.Run("axiomhq", func(b *testing.B) {
+		var s float32
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			s += axiomsimd.DotProductFloat32(query, candidate)
+		}
+		sinkDistance32 = s
+	})
+	b.Run("vek32", func(b *testing.B) {
+		var s float32
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			s += vek32.Dot(query, candidate)
+		}
+		sinkDistance32 = s
+	})
+	b.Run("tphakala", func(b *testing.B) {
+		var s float32
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			s += simdf32.DotProduct(query, candidate)
+		}
+		sinkDistance32 = s
+	})
+	b.Run("tphakala_unsafe", func(b *testing.B) {
+		var s float32
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			s += simdf32.DotProductUnsafe(query, candidate)
+		}
+		sinkDistance32 = s
+	})
+	b.Run("da_hvri", func(b *testing.B) {
+		var s float64
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			s += dahvrisimd.DotProduct(query, candidate)
+		}
+		sinkDistance64 = s
+	})
+	b.Run("gonum_blas32", func(b *testing.B) {
+		var s float32
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			s += blas32.Dot(blas32.Vector{N: dims, Inc: 1, Data: query}, blas32.Vector{N: dims, Inc: 1, Data: candidate})
+		}
+		sinkDistance32 = s
+	})
+}
+
+func BenchmarkDotProductBatch768x128(b *testing.B) {
+	const dims = 768
+	const candidatesN = 128
+	query, _ := benchVector(17, dims)
+	flat, _ := benchCandidateMatrix(candidatesN, dims)
+	rows := candidateRows(flat, candidatesN, dims)
+	dots := make([]float32, candidatesN)
+	b.Run("tphakala_batch", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			simdf32.DotProductBatch(dots, rows, query)
+		}
+		sinkDistanceBuf = dots
+	})
+	b.Run("tphakala_loop", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			for j := 0; j < candidatesN; j++ {
+				dots[j] = simdf32.DotProduct(query, rows[j])
+			}
+		}
+		sinkDistanceBuf = dots
+	})
+	b.Run("vek32_loop", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			for j := 0; j < candidatesN; j++ {
+				dots[j] = vek32.Dot(query, rows[j])
+			}
+		}
+		sinkDistanceBuf = dots
+	})
+	b.Run("axiomhq_loop", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			for j := 0; j < candidatesN; j++ {
+				dots[j] = axiomsimd.DotProductFloat32(query, rows[j])
+			}
+		}
+		sinkDistanceBuf = dots
+	})
+}


### PR DESCRIPTION
## Summary
- add focused 768-dimensional dot-product microbenchmarks for the vector kernel module
- include single-vector and 128-candidate batch/loop shapes matching larger TreeDB vector-search runs
- document the focused benchmark command
- document the merged `snissn/simd` AVX512 batch4 fork and temporary `go mod edit -replace` validation flow so future vector-search iterations can find it

## Local result on this host
`GOWORK=off go test -run '^$' -bench 'BenchmarkDotProduct(768|Batch768)' -benchmem -count=1`\n\nKey result with current dependency: `github.com/tphakala/simd/f32` remains fastest for 768d single-dot on this i5-11400F (~20-21 ns/op), with `vek32` second (~28-29 ns/op). Current upstream `DotProductBatch` and per-row loop are similar for 128x768 because upstream batch loops per row.\n\nMerged fork validation: https://github.com/snissn/simd/pull/1 adds a true amd64 AVX512 cross-row batch4 `DotProductBatch`. With a temporary replace to `~/dev/snissn/simd`, the focused 128x768 batch measured ~3329 ns/op (~26 ns/dot in the gomap harness) vs loop ~4538 ns/op (~35 ns/dot). The standalone fork benchmark measured ~22-23 ns/dot vs ~31 ns/dot.\n\n## Tests\n- `cd benchmarks/vector_distance_kernels && GOWORK=off go test -run '^$' -bench 'BenchmarkDotProduct(768|Batch768)' -benchmem -count=1`\n- `cd benchmarks/vector_distance_kernels && GOWORK=off go mod edit -replace github.com/tphakala/simd=$HOME/dev/snissn/simd && GOWORK=off go test -run '^$' -bench 'BenchmarkDotProductBatch768x128/(tphakala_batch|tphakala_loop)' -benchmem -count=1 && GOWORK=off go mod edit -dropreplace github.com/tphakala/simd`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added benchmarks for 768-dimensional dot-product performance
  * Added batched dot-product benchmark for 768 × 128 workloads

* **Documentation**
  * Added instructions to run 768-dimensional benchmarks with output logging
  * Added guidance to validate an alternative local implementation (swap to a local fork, run benchmarks, collect results)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1765?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->