### PR TITLE
treedb: add typed-column adapter seam

### DIFF
--- a/TreeDB/collections/typed_column_adapter.go
+++ b/TreeDB/collections/typed_column_adapter.go
@@ -1,0 +1,456 @@
+package collections
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"math"
+	"sort"
+
+	"github.com/snissn/gomap/TreeDB/internal/mappedresource"
+	"github.com/snissn/gomap/TreeDB/internal/typedcolumn"
+)
+
+var errTypedColumnAdapterUnsupportedType = errors.New("collections: typed-column adapter unsupported type")
+
+const typedColumnAdapterPrimaryIDColumn = "__treedb_primary_id"
+
+type typedColumnAdapterTypeStatus string
+
+const (
+	typedColumnAdapterRepresented typedColumnAdapterTypeStatus = "represented"
+	typedColumnAdapterFailClosed  typedColumnAdapterTypeStatus = "fail_closed"
+)
+
+type typedColumnAdapterTypeMapping struct {
+	ValueType  ColumnStoreValueType
+	Status     typedColumnAdapterTypeStatus
+	Reason     string
+	ColumnType typedcolumn.ColumnType
+	Encoding   typedcolumn.Encoding
+}
+
+type typedColumnAdapterColumn struct {
+	Field              TypedStorageField
+	Definition         typedcolumn.ColumnDefinition
+	Dictionary         map[string]int64
+	ReverseDictionary  map[int64]string
+	FixedWidthEncoding ColumnFixedWidthEncoding
+}
+
+type typedColumnAdapterOptions struct {
+	Collection     string
+	Namespace      string
+	SchemaVersion  uint32
+	PartID         uint64
+	RowsPerGranule int
+	Fields         []TypedStorageField
+}
+
+type typedColumnAdapterRow struct {
+	PrimaryID int64
+	Values    map[string]columnDeclaredValue
+}
+
+type typedColumnAdapterPart struct {
+	Options    typedColumnAdapterOptions
+	Columns    []typedColumnAdapterColumn
+	Part       *typedcolumn.ColumnPart
+	Dictionary map[string]map[string]int64
+}
+
+type typedColumnAdapterResourceReader struct {
+	Manager       *mappedresource.Manager
+	Image         typedcolumn.ColumnPartImage
+	Path          string
+	Namespace     string
+	Generation    uint64
+	PartID        uint64
+	FileID        uint32
+	Scope         mappedresource.Scope
+	PreferMapped  bool
+	AllowHeapCopy bool
+}
+
+func typedColumnAdapterTypeMatrix() []typedColumnAdapterTypeMapping {
+	return []typedColumnAdapterTypeMapping{
+		{ValueType: ColumnStoreValueBool, Status: typedColumnAdapterRepresented, ColumnType: typedcolumn.ColumnTypeBool, Encoding: typedcolumn.EncodingBoolBitpackRLE},
+		{ValueType: ColumnStoreValueInt64, Status: typedColumnAdapterRepresented, ColumnType: typedcolumn.ColumnTypeInt64, Encoding: typedcolumn.EncodingDeltaVarint},
+		{ValueType: ColumnStoreValueFloat32, Status: typedColumnAdapterRepresented, ColumnType: typedcolumn.ColumnTypeInt64, Encoding: typedcolumn.EncodingRawInt64, Reason: "stored as raw int64 float32 bit patterns until native float sections land"},
+		{ValueType: ColumnStoreValueDouble, Status: typedColumnAdapterRepresented, ColumnType: typedcolumn.ColumnTypeInt64, Encoding: typedcolumn.EncodingRawInt64, Reason: "stored as raw int64 float64 bit patterns until native float sections land"},
+		{ValueType: ColumnStoreValueString, Status: typedColumnAdapterRepresented, ColumnType: typedcolumn.ColumnTypeLowCardinalityCode, Encoding: typedcolumn.EncodingLowCardinalityUint32, Reason: "stored as dictionary codes with dictionary section metadata"},
+		{ValueType: ColumnStoreValueFloat32Vector, Status: typedColumnAdapterFailClosed, Reason: "dense vector typed-column sections are staged to #1756"},
+		{ValueType: ColumnStoreValueAdjacencyList, Status: typedColumnAdapterFailClosed, Reason: "adjacency typed-column sections are staged to #1756"},
+	}
+}
+
+func typedColumnAdapterMappingForValueType(valueType ColumnStoreValueType) (typedColumnAdapterTypeMapping, error) {
+	for _, mapping := range typedColumnAdapterTypeMatrix() {
+		if mapping.ValueType == valueType {
+			if mapping.Status != typedColumnAdapterRepresented {
+				return mapping, fmt.Errorf("%w: %s: %s", errTypedColumnAdapterUnsupportedType, valueType, mapping.Reason)
+			}
+			return mapping, nil
+		}
+	}
+	return typedColumnAdapterTypeMapping{ValueType: valueType, Status: typedColumnAdapterFailClosed, Reason: "unknown declared value type"}, fmt.Errorf("%w: %s", errTypedColumnAdapterUnsupportedType, valueType)
+}
+
+func typedColumnAdapterMapField(field TypedStorageField) (typedColumnAdapterColumn, error) {
+	if field.Owner != TypedStorageOwnerColumnPart {
+		return typedColumnAdapterColumn{}, fmt.Errorf("collections: typed-column adapter field %q owner=%q want %q", field.Path, field.Owner, TypedStorageOwnerColumnPart)
+	}
+	mapping, err := typedColumnAdapterMappingForValueType(field.ValueType)
+	if err != nil {
+		return typedColumnAdapterColumn{}, err
+	}
+	name := field.Name
+	if name == "" {
+		name = field.Path
+	}
+	if name == "" {
+		return typedColumnAdapterColumn{}, errors.New("collections: typed-column adapter field requires name or path")
+	}
+	def := typedcolumn.ColumnDefinition{
+		Name:           name,
+		Type:           mapping.ColumnType,
+		Encoding:       mapping.Encoding,
+		Compression:    typedcolumn.CompressionNone,
+		CompressionSet: true,
+	}
+	return typedColumnAdapterColumn{Field: field, Definition: def, FixedWidthEncoding: field.FixedWidthEncoding}, nil
+}
+
+func buildTypedColumnAdapterPart(opts typedColumnAdapterOptions, rows []typedColumnAdapterRow) (*typedColumnAdapterPart, error) {
+	if opts.PartID == 0 {
+		opts.PartID = 1
+	}
+	columns := make([]typedColumnAdapterColumn, 0, len(opts.Fields))
+	for _, field := range opts.Fields {
+		column, err := typedColumnAdapterMapField(field)
+		if err != nil {
+			return nil, err
+		}
+		columns = append(columns, column)
+	}
+	for i := range columns {
+		if columns[i].Field.ValueType == ColumnStoreValueString {
+			dict := buildTypedColumnAdapterStringDictionary(columns[i], rows)
+			columns[i].Dictionary = dict
+			columns[i].ReverseDictionary = reverseTypedColumnAdapterDictionary(dict)
+			columns[i].Definition.Cardinality = uint32(len(dict))
+		}
+	}
+
+	defs := make([]typedcolumn.ColumnDefinition, 0, len(columns)+1)
+	defs = append(defs, typedcolumn.ColumnDefinition{
+		Name:           typedColumnAdapterPrimaryIDColumn,
+		Type:           typedcolumn.ColumnTypeInt64,
+		Encoding:       typedcolumn.EncodingRawInt64,
+		Compression:    typedcolumn.CompressionNone,
+		CompressionSet: true,
+	})
+	for _, column := range columns {
+		defs = append(defs, column.Definition)
+	}
+	batch := typedcolumn.Batch{Rows: len(rows), Columns: make(map[string][]int64, len(defs))}
+	batch.Columns[typedColumnAdapterPrimaryIDColumn] = make([]int64, len(rows))
+	for _, column := range columns {
+		batch.Columns[column.Definition.Name] = make([]int64, len(rows))
+	}
+	for rowIdx, row := range rows {
+		batch.Columns[typedColumnAdapterPrimaryIDColumn][rowIdx] = row.PrimaryID
+		for _, column := range columns {
+			value, ok := row.Values[column.Field.Path]
+			if !ok && column.Field.Name != "" {
+				value, ok = row.Values[column.Field.Name]
+			}
+			if !ok {
+				return nil, fmt.Errorf("collections: typed-column adapter row %d missing field %q", rowIdx, column.Field.Path)
+			}
+			encoded, err := encodeTypedColumnAdapterValue(column, value)
+			if err != nil {
+				return nil, fmt.Errorf("collections: typed-column adapter row %d field %q: %w", rowIdx, column.Field.Path, err)
+			}
+			batch.Columns[column.Definition.Name][rowIdx] = encoded
+		}
+	}
+	rowsPerGranule := opts.RowsPerGranule
+	if rowsPerGranule == 0 {
+		rowsPerGranule = typedcolumn.DefaultRowsPerGranule
+	}
+	partOpts := typedcolumn.Options{
+		SchemaVersion: opts.SchemaVersion,
+		SchemaMode:    typedcolumn.ColumnSchemaFixed,
+		Columns:       defs,
+		LogicalPrimaryKey: typedcolumn.LogicalPrimaryKey{
+			Columns: []string{typedColumnAdapterPrimaryIDColumn},
+		},
+		SortKey:     typedcolumn.SortKey{Columns: []typedcolumn.SortKeyColumn{{Column: typedColumnAdapterPrimaryIDColumn}}},
+		PartPolicy:  typedcolumn.ColumnPartPolicy{RowsPerGranule: rowsPerGranule},
+		Compression: typedcolumn.ColumnCompressionPolicy{Default: typedcolumn.CompressionNone},
+	}
+	part, err := typedcolumn.BuildColumnPart(opts.PartID, partOpts, batch)
+	if err != nil {
+		return nil, err
+	}
+	return &typedColumnAdapterPart{Options: opts, Columns: columns, Part: part, Dictionary: typedColumnAdapterDictionaries(columns)}, nil
+}
+
+func typedColumnAdapterPartFromImage(opts typedColumnAdapterOptions, image typedcolumn.ColumnPartImage) (*typedColumnAdapterPart, error) {
+	part, err := typedcolumn.ColumnPartFromImage(image)
+	if err != nil {
+		return nil, err
+	}
+	columns := make([]typedColumnAdapterColumn, 0, len(opts.Fields))
+	for _, field := range opts.Fields {
+		column, err := typedColumnAdapterMapField(field)
+		if err != nil {
+			return nil, err
+		}
+		columns = append(columns, column)
+	}
+	dictionaries, err := image.Dictionaries()
+	if err != nil {
+		return nil, err
+	}
+	for i := range columns {
+		if columns[i].Field.ValueType == ColumnStoreValueString {
+			dict := dictionaries[columns[i].Definition.Name]
+			if len(dict) == 0 {
+				return nil, fmt.Errorf("collections: typed-column adapter image missing dictionary for %q", columns[i].Definition.Name)
+			}
+			columns[i].Dictionary = dict
+			columns[i].ReverseDictionary = reverseTypedColumnAdapterDictionary(dict)
+		}
+	}
+	return &typedColumnAdapterPart{Options: opts, Columns: columns, Part: part, Dictionary: dictionaries}, nil
+}
+
+func (p *typedColumnAdapterPart) buildImage() (typedcolumn.ColumnPartImage, error) {
+	if p == nil || p.Part == nil {
+		return typedcolumn.ColumnPartImage{}, errors.New("collections: nil typed-column adapter part")
+	}
+	return typedcolumn.BuildColumnPartImage(p.Part, typedcolumn.ColumnPartImageOptions{Dictionaries: p.Dictionary})
+}
+
+func (p *typedColumnAdapterPart) scanColumnValues(columnName string) ([]columnDeclaredValue, error) {
+	if p == nil || p.Part == nil {
+		return nil, errors.New("collections: nil typed-column adapter part")
+	}
+	column, ok := p.columnByName(columnName)
+	if !ok {
+		return nil, fmt.Errorf("collections: typed-column adapter missing column %q", columnName)
+	}
+	scan, err := p.Part.NewScanner().ScanProjected([]string{column.Definition.Name})
+	if err != nil {
+		return nil, err
+	}
+	encoded := scan.Columns[column.Definition.Name]
+	out := make([]columnDeclaredValue, len(encoded))
+	for i, raw := range encoded {
+		value, err := decodeTypedColumnAdapterValue(column, raw)
+		if err != nil {
+			return nil, fmt.Errorf("collections: typed-column adapter row %d column %q: %w", i, columnName, err)
+		}
+		out[i] = value
+	}
+	return out, nil
+}
+
+func (p *typedColumnAdapterPart) columnByName(name string) (typedColumnAdapterColumn, bool) {
+	for _, column := range p.Columns {
+		if column.Field.Name == name || column.Field.Path == name || column.Definition.Name == name {
+			return column, true
+		}
+	}
+	return typedColumnAdapterColumn{}, false
+}
+
+func encodeTypedColumnAdapterValue(column typedColumnAdapterColumn, value columnDeclaredValue) (int64, error) {
+	if value.Type != "" && value.Type != column.Field.ValueType {
+		return 0, fmt.Errorf("value type=%q want %q", value.Type, column.Field.ValueType)
+	}
+	if !value.Present || value.Null {
+		return 0, fmt.Errorf("null or missing values are not represented by the #1754 typed-column adapter")
+	}
+	switch column.Field.ValueType {
+	case ColumnStoreValueBool:
+		if value.Bool {
+			return 1, nil
+		}
+		return 0, nil
+	case ColumnStoreValueInt64:
+		return value.Int64, nil
+	case ColumnStoreValueFloat32:
+		return int64(math.Float32bits(value.Float32)), nil
+	case ColumnStoreValueDouble:
+		return int64(math.Float64bits(value.Double)), nil
+	case ColumnStoreValueString:
+		code, ok := column.Dictionary[value.String]
+		if !ok {
+			return 0, fmt.Errorf("string value %q missing dictionary code", value.String)
+		}
+		return code, nil
+	default:
+		return 0, fmt.Errorf("%w: %s", errTypedColumnAdapterUnsupportedType, column.Field.ValueType)
+	}
+}
+
+func decodeTypedColumnAdapterValue(column typedColumnAdapterColumn, raw int64) (columnDeclaredValue, error) {
+	value := columnDeclaredValue{Type: column.Field.ValueType, Present: true}
+	switch column.Field.ValueType {
+	case ColumnStoreValueBool:
+		value.Bool = raw != 0
+	case ColumnStoreValueInt64:
+		value.Int64 = raw
+	case ColumnStoreValueFloat32:
+		value.Float32 = math.Float32frombits(uint32(raw))
+	case ColumnStoreValueDouble:
+		value.Double = math.Float64frombits(uint64(raw))
+	case ColumnStoreValueString:
+		text, ok := column.ReverseDictionary[raw]
+		if !ok {
+			return columnDeclaredValue{}, fmt.Errorf("missing dictionary value for code %d", raw)
+		}
+		value.String = text
+	default:
+		return columnDeclaredValue{}, fmt.Errorf("%w: %s", errTypedColumnAdapterUnsupportedType, column.Field.ValueType)
+	}
+	return value, nil
+}
+
+func buildTypedColumnAdapterStringDictionary(column typedColumnAdapterColumn, rows []typedColumnAdapterRow) map[string]int64 {
+	seen := make(map[string]struct{})
+	for _, row := range rows {
+		value, ok := row.Values[column.Field.Path]
+		if !ok && column.Field.Name != "" {
+			value, ok = row.Values[column.Field.Name]
+		}
+		if ok && value.Present && !value.Null {
+			seen[value.String] = struct{}{}
+		}
+	}
+	values := make([]string, 0, len(seen))
+	for value := range seen {
+		values = append(values, value)
+	}
+	sort.Strings(values)
+	dict := make(map[string]int64, len(values))
+	for i, value := range values {
+		dict[value] = int64(i)
+	}
+	return dict
+}
+
+func reverseTypedColumnAdapterDictionary(dict map[string]int64) map[int64]string {
+	reverse := make(map[int64]string, len(dict))
+	for value, code := range dict {
+		reverse[code] = value
+	}
+	return reverse
+}
+
+func typedColumnAdapterDictionaries(columns []typedColumnAdapterColumn) map[string]map[string]int64 {
+	out := make(map[string]map[string]int64)
+	for _, column := range columns {
+		if len(column.Dictionary) != 0 {
+			out[column.Definition.Name] = column.Dictionary
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func typedColumnAdapterRetainedPayloadSplitRestore(cfg ColumnStoreConfig, document []byte, values []columnDeclaredValue) ([]byte, []byte, error) {
+	retained, err := columnRetainedPayloadFromJSONDocument(cfg, document)
+	if err != nil {
+		return nil, nil, err
+	}
+	restored, err := reconstructColumnJSONDocument(cfg, retained, values)
+	if err != nil {
+		return nil, nil, err
+	}
+	return retained, restored, nil
+}
+
+func (r typedColumnAdapterResourceReader) ReadSection(section typedcolumn.ColumnPartImageSection) ([]byte, error) {
+	h, err := r.AcquireSection(section)
+	if err != nil {
+		return nil, err
+	}
+	defer h.Release()
+	return bytes.Clone(h.Bytes()), nil
+}
+
+func (r typedColumnAdapterResourceReader) AcquireSection(section typedcolumn.ColumnPartImageSection) (*mappedresource.Handle, error) {
+	mgr := r.Manager
+	if mgr == nil {
+		return nil, errors.New("collections: typed-column adapter resource reader requires manager")
+	}
+	namespace := r.Namespace
+	if namespace == "" {
+		namespace = "typed-column-adapter"
+	}
+	fileID := r.FileID
+	if fileID == 0 {
+		fileID = 1
+	}
+	partID := r.PartID
+	if partID == 0 {
+		partID = r.Image.PartID
+	}
+	key := mappedresource.Key{
+		Class:      mappedresource.ClassTypedColumnAsset,
+		Namespace:  namespace,
+		Kind:       string(section.Kind),
+		Generation: r.Generation,
+		PartID:     partID,
+		FileID:     fileID,
+		Offset:     int64(section.Offset),
+		Length:     int64(section.Length),
+		Version:    r.Image.Version,
+		Encoding:   section.Encoding.String(),
+		Section: mappedresource.Section{
+			Kind:     string(section.Kind),
+			Category: string(section.Category),
+			Name:     section.Name,
+			Column:   section.Column,
+		},
+	}
+	scope := r.Scope
+	if scope == (mappedresource.Scope{}) {
+		scope = mappedresource.Scope{Kind: mappedresource.ScopeColumnPartReader, ID: "typed-column-adapter", Namespace: namespace, Generation: r.Generation, Reason: "typed-column adapter section read"}
+	}
+	if r.Path != "" {
+		return mgr.AcquireFileRange(key, scope, r.Path, mappedresource.AcquireOptions{
+			Reason:         "typed-column adapter section read",
+			ValidationMode: mappedresource.ValidationVerify,
+			PreferMapped:   r.PreferMapped,
+			AllowHeapCopy:  r.AllowHeapCopy,
+		})
+	}
+	data, err := r.Image.SectionBytes(section)
+	if err != nil {
+		return nil, err
+	}
+	return mgr.AcquireBytes(key, scope, mappedresource.SourceHeapCopy, data, mappedresource.AcquireOptions{Reason: "typed-column adapter heap section read", ValidationMode: mappedresource.ValidationVerify})
+}
+
+func typedColumnAdapterInt64View(mgr *mappedresource.Manager, h *mappedresource.Handle) ([]int64, error) {
+	return mgr.Int64View(h)
+}
+
+func typedColumnAdapterFloat32View(mgr *mappedresource.Manager, h *mappedresource.Handle) ([]float32, error) {
+	return mgr.Float32View(h)
+}
+
+func typedColumnAdapterFloat64View(mgr *mappedresource.Manager, h *mappedresource.Handle) ([]float64, error) {
+	return mgr.Float64View(h)
+}
+
+func typedColumnAdapterUint32View(mgr *mappedresource.Manager, h *mappedresource.Handle) ([]uint32, error) {
+	return mgr.Uint32View(h)
+}

--- a/TreeDB/collections/typed_column_adapter.go
+++ b/TreeDB/collections/typed_column_adapter.go
@@ -13,7 +13,11 @@ import (
 
 var errTypedColumnAdapterUnsupportedType = errors.New("collections: typed-column adapter unsupported type")
 
-const typedColumnAdapterPrimaryIDColumn = "__treedb_primary_id"
+const (
+	typedColumnAdapterPrimaryIDColumn       = "__treedb_primary_id"
+	typedColumnAdapterMetadataDictionary    = "__treedb_adapter_metadata"
+	typedColumnAdapterMetadataValueTypeMark = "value_type"
+)
 
 type typedColumnAdapterTypeStatus string
 
@@ -113,6 +117,9 @@ func typedColumnAdapterMapField(field TypedStorageField) (typedColumnAdapterColu
 	}
 	if name == typedColumnAdapterPrimaryIDColumn || field.Path == typedColumnAdapterPrimaryIDColumn {
 		return typedColumnAdapterColumn{}, fmt.Errorf("collections: typed-column adapter field %q uses reserved primary-id column %q", field.Path, typedColumnAdapterPrimaryIDColumn)
+	}
+	if name == typedColumnAdapterMetadataDictionary || field.Path == typedColumnAdapterMetadataDictionary {
+		return typedColumnAdapterColumn{}, fmt.Errorf("collections: typed-column adapter field %q uses reserved metadata dictionary %q", field.Path, typedColumnAdapterMetadataDictionary)
 	}
 	def := typedcolumn.ColumnDefinition{
 		Name:           name,
@@ -249,6 +256,9 @@ func typedColumnAdapterPartFromImage(opts typedColumnAdapterOptions, image typed
 	}
 	dictionaries, err := image.Dictionaries()
 	if err != nil {
+		return nil, err
+	}
+	if err := validateTypedColumnAdapterMetadata(dictionaries, columns); err != nil {
 		return nil, err
 	}
 	for i := range columns {
@@ -429,12 +439,37 @@ func reverseTypedColumnAdapterDictionary(dict map[string]int64) map[int64]string
 	return reverse
 }
 
+func typedColumnAdapterMetadataKey(column typedColumnAdapterColumn) string {
+	return column.Definition.Name + "\x00" + typedColumnAdapterMetadataValueTypeMark + "\x00" + string(column.Field.ValueType)
+}
+
+func validateTypedColumnAdapterMetadata(dictionaries map[string]map[string]int64, columns []typedColumnAdapterColumn) error {
+	if len(columns) == 0 {
+		return nil
+	}
+	metadata := dictionaries[typedColumnAdapterMetadataDictionary]
+	if len(metadata) == 0 {
+		return fmt.Errorf("collections: typed-column adapter image missing metadata dictionary %q", typedColumnAdapterMetadataDictionary)
+	}
+	for _, column := range columns {
+		if _, ok := metadata[typedColumnAdapterMetadataKey(column)]; !ok {
+			return fmt.Errorf("collections: typed-column adapter image value type metadata mismatch for column %q", column.Definition.Name)
+		}
+	}
+	return nil
+}
+
 func typedColumnAdapterDictionaries(columns []typedColumnAdapterColumn) map[string]map[string]int64 {
 	out := make(map[string]map[string]int64)
-	for _, column := range columns {
+	metadata := make(map[string]int64, len(columns))
+	for i, column := range columns {
+		metadata[typedColumnAdapterMetadataKey(column)] = int64(i + 1)
 		if len(column.Dictionary) != 0 {
 			out[column.Definition.Name] = column.Dictionary
 		}
+	}
+	if len(metadata) != 0 {
+		out[typedColumnAdapterMetadataDictionary] = metadata
 	}
 	if len(out) == 0 {
 		return nil

--- a/TreeDB/collections/typed_column_adapter.go
+++ b/TreeDB/collections/typed_column_adapter.go
@@ -138,6 +138,9 @@ func typedColumnAdapterColumnsForFields(fields []TypedStorageField) ([]typedColu
 			return nil, fmt.Errorf("collections: typed-column adapter duplicate column %q", column.Definition.Name)
 		}
 		if field.Path != "" {
+			if owner, exists := seenPaths[field.Path]; exists {
+				return nil, fmt.Errorf("collections: typed-column adapter duplicate field path %q for columns %q and %q", field.Path, owner, column.Definition.Name)
+			}
 			if owner, exists := seenNames[field.Path]; exists {
 				return nil, fmt.Errorf("collections: typed-column adapter ambiguous field path %q collides with field name %q", field.Path, owner)
 			}
@@ -241,6 +244,9 @@ func typedColumnAdapterPartFromImage(opts typedColumnAdapterOptions, image typed
 	if err != nil {
 		return nil, err
 	}
+	if err := validateTypedColumnAdapterImageSchema(part, columns); err != nil {
+		return nil, err
+	}
 	dictionaries, err := image.Dictionaries()
 	if err != nil {
 		return nil, err
@@ -256,6 +262,29 @@ func typedColumnAdapterPartFromImage(opts typedColumnAdapterOptions, image typed
 		}
 	}
 	return &typedColumnAdapterPart{Options: opts, Columns: columns, Part: part, Dictionary: dictionaries}, nil
+}
+
+func validateTypedColumnAdapterImageSchema(part *typedcolumn.ColumnPart, columns []typedColumnAdapterColumn) error {
+	if part == nil {
+		return errors.New("collections: typed-column adapter nil image part")
+	}
+	primary, ok := part.Columns[typedColumnAdapterPrimaryIDColumn]
+	if !ok {
+		return fmt.Errorf("collections: typed-column adapter image missing primary-id column %q", typedColumnAdapterPrimaryIDColumn)
+	}
+	if primary.Definition.Type != typedcolumn.ColumnTypeInt64 || primary.Definition.Encoding != typedcolumn.EncodingRawInt64 {
+		return fmt.Errorf("collections: typed-column adapter image primary-id column %q type/encoding mismatch", typedColumnAdapterPrimaryIDColumn)
+	}
+	for _, column := range columns {
+		got, ok := part.Columns[column.Definition.Name]
+		if !ok {
+			return fmt.Errorf("collections: typed-column adapter image missing column %q", column.Definition.Name)
+		}
+		if got.Definition.Type != column.Definition.Type || got.Definition.Encoding != column.Definition.Encoding || got.Definition.Compression != column.Definition.Compression {
+			return fmt.Errorf("collections: typed-column adapter image column %q schema mismatch: got type=%s encoding=%s compression=%s want type=%s encoding=%s compression=%s", column.Definition.Name, got.Definition.Type, got.Definition.Encoding, got.Definition.Compression, column.Definition.Type, column.Definition.Encoding, column.Definition.Compression)
+		}
+	}
+	return nil
 }
 
 func (p *typedColumnAdapterPart) buildImage() (typedcolumn.ColumnPartImage, error) {

--- a/TreeDB/collections/typed_column_adapter.go
+++ b/TreeDB/collections/typed_column_adapter.go
@@ -111,6 +111,9 @@ func typedColumnAdapterMapField(field TypedStorageField) (typedColumnAdapterColu
 	if name == "" {
 		return typedColumnAdapterColumn{}, errors.New("collections: typed-column adapter field requires name or path")
 	}
+	if name == typedColumnAdapterPrimaryIDColumn || field.Path == typedColumnAdapterPrimaryIDColumn {
+		return typedColumnAdapterColumn{}, fmt.Errorf("collections: typed-column adapter field %q uses reserved primary-id column %q", field.Path, typedColumnAdapterPrimaryIDColumn)
+	}
 	def := typedcolumn.ColumnDefinition{
 		Name:           name,
 		Type:           mapping.ColumnType,

--- a/TreeDB/collections/typed_column_adapter.go
+++ b/TreeDB/collections/typed_column_adapter.go
@@ -124,21 +124,53 @@ func typedColumnAdapterMapField(field TypedStorageField) (typedColumnAdapterColu
 	return typedColumnAdapterColumn{Field: field, Definition: def, FixedWidthEncoding: field.FixedWidthEncoding}, nil
 }
 
-func buildTypedColumnAdapterPart(opts typedColumnAdapterOptions, rows []typedColumnAdapterRow) (*typedColumnAdapterPart, error) {
-	if opts.PartID == 0 {
-		opts.PartID = 1
-	}
-	columns := make([]typedColumnAdapterColumn, 0, len(opts.Fields))
-	for _, field := range opts.Fields {
+func typedColumnAdapterColumnsForFields(fields []TypedStorageField) ([]typedColumnAdapterColumn, error) {
+	columns := make([]typedColumnAdapterColumn, 0, len(fields))
+	seenColumns := map[string]struct{}{typedColumnAdapterPrimaryIDColumn: {}}
+	seenNames := make(map[string]string, len(fields))
+	seenPaths := make(map[string]string, len(fields))
+	for _, field := range fields {
 		column, err := typedColumnAdapterMapField(field)
 		if err != nil {
 			return nil, err
 		}
+		if _, exists := seenColumns[column.Definition.Name]; exists {
+			return nil, fmt.Errorf("collections: typed-column adapter duplicate column %q", column.Definition.Name)
+		}
+		if field.Path != "" {
+			if owner, exists := seenNames[field.Path]; exists {
+				return nil, fmt.Errorf("collections: typed-column adapter ambiguous field path %q collides with field name %q", field.Path, owner)
+			}
+		}
+		if field.Name != "" {
+			if owner, exists := seenPaths[field.Name]; exists {
+				return nil, fmt.Errorf("collections: typed-column adapter ambiguous field name %q collides with field path %q", field.Name, owner)
+			}
+			seenNames[field.Name] = column.Definition.Name
+		}
+		seenColumns[column.Definition.Name] = struct{}{}
+		if field.Path != "" {
+			seenPaths[field.Path] = column.Definition.Name
+		}
 		columns = append(columns, column)
+	}
+	return columns, nil
+}
+
+func buildTypedColumnAdapterPart(opts typedColumnAdapterOptions, rows []typedColumnAdapterRow) (*typedColumnAdapterPart, error) {
+	if opts.PartID == 0 {
+		opts.PartID = 1
+	}
+	columns, err := typedColumnAdapterColumnsForFields(opts.Fields)
+	if err != nil {
+		return nil, err
 	}
 	for i := range columns {
 		if columns[i].Field.ValueType == ColumnStoreValueString {
-			dict := buildTypedColumnAdapterStringDictionary(columns[i], rows)
+			dict, err := buildTypedColumnAdapterStringDictionary(columns[i], rows)
+			if err != nil {
+				return nil, err
+			}
 			columns[i].Dictionary = dict
 			columns[i].ReverseDictionary = reverseTypedColumnAdapterDictionary(dict)
 			columns[i].Definition.Cardinality = uint32(len(dict))
@@ -164,9 +196,9 @@ func buildTypedColumnAdapterPart(opts typedColumnAdapterOptions, rows []typedCol
 	for rowIdx, row := range rows {
 		batch.Columns[typedColumnAdapterPrimaryIDColumn][rowIdx] = row.PrimaryID
 		for _, column := range columns {
-			value, ok := row.Values[column.Field.Path]
-			if !ok && column.Field.Name != "" {
-				value, ok = row.Values[column.Field.Name]
+			value, ok, err := typedColumnAdapterRowValue(row, column)
+			if err != nil {
+				return nil, fmt.Errorf("collections: typed-column adapter row %d field %q: %w", rowIdx, column.Field.Path, err)
 			}
 			if !ok {
 				return nil, fmt.Errorf("collections: typed-column adapter row %d missing field %q", rowIdx, column.Field.Path)
@@ -205,13 +237,9 @@ func typedColumnAdapterPartFromImage(opts typedColumnAdapterOptions, image typed
 	if err != nil {
 		return nil, err
 	}
-	columns := make([]typedColumnAdapterColumn, 0, len(opts.Fields))
-	for _, field := range opts.Fields {
-		column, err := typedColumnAdapterMapField(field)
-		if err != nil {
-			return nil, err
-		}
-		columns = append(columns, column)
+	columns, err := typedColumnAdapterColumnsForFields(opts.Fields)
+	if err != nil {
+		return nil, err
 	}
 	dictionaries, err := image.Dictionaries()
 	if err != nil {
@@ -271,7 +299,10 @@ func (p *typedColumnAdapterPart) columnByName(name string) (typedColumnAdapterCo
 }
 
 func encodeTypedColumnAdapterValue(column typedColumnAdapterColumn, value columnDeclaredValue) (int64, error) {
-	if value.Type != "" && value.Type != column.Field.ValueType {
+	if value.Type == "" {
+		return 0, errors.New("declared type required")
+	}
+	if value.Type != column.Field.ValueType {
 		return 0, fmt.Errorf("value type=%q want %q", value.Type, column.Field.ValueType)
 	}
 	if !value.Present || value.Null {
@@ -323,12 +354,27 @@ func decodeTypedColumnAdapterValue(column typedColumnAdapterColumn, raw int64) (
 	return value, nil
 }
 
-func buildTypedColumnAdapterStringDictionary(column typedColumnAdapterColumn, rows []typedColumnAdapterRow) map[string]int64 {
+func typedColumnAdapterRowValue(row typedColumnAdapterRow, column typedColumnAdapterColumn) (columnDeclaredValue, bool, error) {
+	pathValue, pathOK := row.Values[column.Field.Path]
+	if column.Field.Name == "" || column.Field.Name == column.Field.Path {
+		return pathValue, pathOK, nil
+	}
+	nameValue, nameOK := row.Values[column.Field.Name]
+	if pathOK && nameOK {
+		return columnDeclaredValue{}, false, fmt.Errorf("ambiguous field keys %q and %q", column.Field.Path, column.Field.Name)
+	}
+	if pathOK {
+		return pathValue, true, nil
+	}
+	return nameValue, nameOK, nil
+}
+
+func buildTypedColumnAdapterStringDictionary(column typedColumnAdapterColumn, rows []typedColumnAdapterRow) (map[string]int64, error) {
 	seen := make(map[string]struct{})
-	for _, row := range rows {
-		value, ok := row.Values[column.Field.Path]
-		if !ok && column.Field.Name != "" {
-			value, ok = row.Values[column.Field.Name]
+	for rowIdx, row := range rows {
+		value, ok, err := typedColumnAdapterRowValue(row, column)
+		if err != nil {
+			return nil, fmt.Errorf("collections: typed-column adapter row %d field %q: %w", rowIdx, column.Field.Path, err)
 		}
 		if ok && value.Present && !value.Null {
 			seen[value.String] = struct{}{}
@@ -343,7 +389,7 @@ func buildTypedColumnAdapterStringDictionary(column typedColumnAdapterColumn, ro
 	for i, value := range values {
 		dict[value] = int64(i)
 	}
-	return dict
+	return dict, nil
 }
 
 func reverseTypedColumnAdapterDictionary(dict map[string]int64) map[int64]string {

--- a/TreeDB/collections/typed_column_adapter_test.go
+++ b/TreeDB/collections/typed_column_adapter_test.go
@@ -1,0 +1,364 @@
+package collections
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"math"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"unsafe"
+
+	"github.com/snissn/gomap/TreeDB/internal/mappedresource"
+	"github.com/snissn/gomap/TreeDB/internal/typedcolumn"
+)
+
+func TestTypedColumnAdapterMapsTreeDBDeclaredTypes(t *testing.T) {
+	want := map[ColumnStoreValueType]typedColumnAdapterTypeStatus{
+		ColumnStoreValueBool:          typedColumnAdapterRepresented,
+		ColumnStoreValueInt64:         typedColumnAdapterRepresented,
+		ColumnStoreValueFloat32:       typedColumnAdapterRepresented,
+		ColumnStoreValueDouble:        typedColumnAdapterRepresented,
+		ColumnStoreValueString:        typedColumnAdapterRepresented,
+		ColumnStoreValueFloat32Vector: typedColumnAdapterFailClosed,
+		ColumnStoreValueAdjacencyList: typedColumnAdapterFailClosed,
+	}
+	got := make(map[ColumnStoreValueType]typedColumnAdapterTypeStatus)
+	for _, mapping := range typedColumnAdapterTypeMatrix() {
+		got[mapping.ValueType] = mapping.Status
+	}
+	for valueType, status := range want {
+		if got[valueType] != status {
+			t.Fatalf("value type %s status=%s want %s matrix=%+v", valueType, got[valueType], status, got)
+		}
+	}
+	field := typedColumnAdapterField("score", ColumnStoreValueFloat32)
+	column, err := typedColumnAdapterMapField(field)
+	if err != nil {
+		t.Fatalf("typedColumnAdapterMapField(float32): %v", err)
+	}
+	if column.Definition.Type != typedcolumn.ColumnTypeInt64 || column.Definition.Encoding != typedcolumn.EncodingRawInt64 {
+		t.Fatalf("float32 mapping definition=%+v", column.Definition)
+	}
+}
+
+func TestTypedColumnAdapterRoundTripBool(t *testing.T) {
+	got := typedColumnAdapterRoundTrip(t, typedColumnAdapterField("flag", ColumnStoreValueBool), []columnDeclaredValue{
+		{Type: ColumnStoreValueBool, Present: true, Bool: true},
+		{Type: ColumnStoreValueBool, Present: true, Bool: false},
+		{Type: ColumnStoreValueBool, Present: true, Bool: true},
+	})
+	if !got[0].Bool || got[1].Bool || !got[2].Bool {
+		t.Fatalf("bool round trip=%+v", got)
+	}
+}
+
+func TestTypedColumnAdapterRoundTripInt64(t *testing.T) {
+	want := []int64{-7, 0, 99}
+	values := make([]columnDeclaredValue, len(want))
+	for i, v := range want {
+		values[i] = columnDeclaredValue{Type: ColumnStoreValueInt64, Present: true, Int64: v}
+	}
+	got := typedColumnAdapterRoundTrip(t, typedColumnAdapterField("count", ColumnStoreValueInt64), values)
+	for i := range want {
+		if got[i].Int64 != want[i] {
+			t.Fatalf("int64[%d]=%d want %d all=%+v", i, got[i].Int64, want[i], got)
+		}
+	}
+}
+
+func TestTypedColumnAdapterRoundTripFloat32(t *testing.T) {
+	want := []float32{-1.25, 0, 3.5}
+	values := make([]columnDeclaredValue, len(want))
+	for i, v := range want {
+		values[i] = columnDeclaredValue{Type: ColumnStoreValueFloat32, Present: true, Float32: v}
+	}
+	got := typedColumnAdapterRoundTrip(t, typedColumnAdapterField("score", ColumnStoreValueFloat32), values)
+	for i := range want {
+		if math.Float32bits(got[i].Float32) != math.Float32bits(want[i]) {
+			t.Fatalf("float32[%d]=%v want %v all=%+v", i, got[i].Float32, want[i], got)
+		}
+	}
+}
+
+func TestTypedColumnAdapterRoundTripFloat64(t *testing.T) {
+	want := []float64{-1.25, 0, 3.5}
+	values := make([]columnDeclaredValue, len(want))
+	for i, v := range want {
+		values[i] = columnDeclaredValue{Type: ColumnStoreValueDouble, Present: true, Double: v}
+	}
+	got := typedColumnAdapterRoundTrip(t, typedColumnAdapterField("ratio", ColumnStoreValueDouble), values)
+	for i := range want {
+		if math.Float64bits(got[i].Double) != math.Float64bits(want[i]) {
+			t.Fatalf("float64[%d]=%v want %v all=%+v", i, got[i].Double, want[i], got)
+		}
+	}
+}
+
+func TestTypedColumnAdapterRoundTripString(t *testing.T) {
+	want := []string{"beta", "alpha", "beta"}
+	values := make([]columnDeclaredValue, len(want))
+	for i, v := range want {
+		values[i] = columnDeclaredValue{Type: ColumnStoreValueString, Present: true, String: v}
+	}
+	field := typedColumnAdapterField("kind", ColumnStoreValueString)
+	part := typedColumnAdapterBuildPart(t, field, values)
+	if got := part.Dictionary["kind"]; got["alpha"] != 0 || got["beta"] != 1 {
+		t.Fatalf("dictionary=%+v want sorted stable codes", got)
+	}
+	image, err := part.buildImage()
+	if err != nil {
+		t.Fatalf("buildImage: %v", err)
+	}
+	parsed, err := typedColumnAdapterPartFromImage(part.Options, image)
+	if err != nil {
+		t.Fatalf("typedColumnAdapterPartFromImage: %v", err)
+	}
+	got, err := parsed.scanColumnValues("kind")
+	if err != nil {
+		t.Fatalf("scanColumnValues(kind): %v", err)
+	}
+	for i := range want {
+		if got[i].String != want[i] {
+			t.Fatalf("string[%d]=%q want %q all=%+v", i, got[i].String, want[i], got)
+		}
+	}
+}
+
+func TestTypedColumnAdapterVectorAndAdjacencyRepresentedOrFailClosed(t *testing.T) {
+	for _, valueType := range []ColumnStoreValueType{ColumnStoreValueFloat32Vector, ColumnStoreValueAdjacencyList} {
+		mapping, err := typedColumnAdapterMappingForValueType(valueType)
+		if !errors.Is(err, errTypedColumnAdapterUnsupportedType) {
+			t.Fatalf("%s err=%v want errTypedColumnAdapterUnsupportedType", valueType, err)
+		}
+		if mapping.Status != typedColumnAdapterFailClosed || mapping.Reason == "" {
+			t.Fatalf("%s mapping=%+v want fail-closed reason", valueType, mapping)
+		}
+	}
+}
+
+func TestTypedColumnAdapterExistingConfigStaysTypedRow(t *testing.T) {
+	layout, err := ResolveTypedStorageLayout(CollectionMeta{
+		Name: "typed_column_adapter_existing_config",
+		Options: CollectionOptions{ColumnStore: &ColumnStoreConfig{
+			Enabled: true,
+			Columns: []ColumnStoreColumn{{Name: "count", Path: "count", ValueType: ColumnStoreValueInt64}},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("ResolveTypedStorageLayout: %v", err)
+	}
+	owner, ok := layout.OwnerForPath("count")
+	if !ok || owner != TypedStorageOwnerRowAsset {
+		t.Fatalf("owner=%s ok=%v want typed_row_asset layout=%+v", owner, ok, layout)
+	}
+	if layout.HasTypedColumnPartOwners() {
+		t.Fatalf("existing config unexpectedly has typed-column owner: %+v", layout)
+	}
+	if err := layout.EnsureReadSupported(); err != nil {
+		t.Fatalf("EnsureReadSupported existing config: %v", err)
+	}
+}
+
+func TestTypedColumnAdapterRetainedPayloadSplitRestore(t *testing.T) {
+	cfg := ColumnStoreConfig{
+		Enabled:         true,
+		RetainedPayload: ColumnRetainedPayloadNonColumn,
+		Reconstruction:  ColumnReconstructionRetainedPayloadAndColumns,
+		Columns: []ColumnStoreColumn{
+			{Name: "count", Path: "count", ValueType: ColumnStoreValueInt64},
+			{Name: "flag", Path: "nested.flag", ValueType: ColumnStoreValueBool},
+		},
+	}
+	doc := []byte(`{"count":7,"keep":"yes","nested":{"flag":true,"other":9}}`)
+	values := []columnDeclaredValue{
+		{Type: ColumnStoreValueInt64, Present: true, Int64: 7},
+		{Type: ColumnStoreValueBool, Present: true, Bool: true},
+	}
+	retained, restored, err := typedColumnAdapterRetainedPayloadSplitRestore(cfg, doc, values)
+	if err != nil {
+		t.Fatalf("typedColumnAdapterRetainedPayloadSplitRestore: %v", err)
+	}
+	if strings.Contains(string(retained), "count") || strings.Contains(string(retained), "flag") {
+		t.Fatalf("retained payload still contains declared fields: %s", retained)
+	}
+	var restoredObj map[string]any
+	if err := json.Unmarshal(restored, &restoredObj); err != nil {
+		t.Fatalf("unmarshal restored: %v", err)
+	}
+	if restoredObj["keep"] != "yes" || restoredObj["count"].(float64) != 7 {
+		t.Fatalf("restored top-level=%s", restored)
+	}
+	nested := restoredObj["nested"].(map[string]any)
+	if nested["flag"] != true || nested["other"].(float64) != 9 {
+		t.Fatalf("restored nested=%s", restored)
+	}
+}
+
+func TestTypedColumnAdapterMappedResourceMmapHeapParity(t *testing.T) {
+	field := typedColumnAdapterField("count", ColumnStoreValueInt64)
+	part := typedColumnAdapterBuildPart(t, field, []columnDeclaredValue{
+		{Type: ColumnStoreValueInt64, Present: true, Int64: 1},
+		{Type: ColumnStoreValueInt64, Present: true, Int64: 2},
+	})
+	image, err := part.buildImage()
+	if err != nil {
+		t.Fatalf("buildImage: %v", err)
+	}
+	section := typedColumnAdapterFindColumnSection(t, image, "count")
+	path := filepath.Join(t.TempDir(), "part.tcs1")
+	if err := os.WriteFile(path, image.Bytes, 0o600); err != nil {
+		t.Fatalf("write image: %v", err)
+	}
+	mgr := mappedresource.NewManager()
+	mappedReader := typedColumnAdapterResourceReader{Manager: mgr, Image: image, Path: path, Namespace: "typed-column-adapter-test", PartID: image.PartID, PreferMapped: true, AllowHeapCopy: true}
+	heapReader := typedColumnAdapterResourceReader{Manager: mgr, Image: image, Path: path, Namespace: "typed-column-adapter-test", PartID: image.PartID, AllowHeapCopy: true}
+	mappedBytes, err := mappedReader.ReadSection(section)
+	if err != nil {
+		t.Fatalf("mapped ReadSection: %v", err)
+	}
+	heapBytes, err := heapReader.ReadSection(section)
+	if err != nil {
+		t.Fatalf("heap ReadSection: %v", err)
+	}
+	want, err := image.SectionBytes(section)
+	if err != nil {
+		t.Fatalf("image.SectionBytes: %v", err)
+	}
+	if !slices.Equal(mappedBytes, want) || !slices.Equal(heapBytes, want) {
+		t.Fatalf("section parity mapped=%x heap=%x want=%x", mappedBytes, heapBytes, want)
+	}
+}
+
+func TestTypedColumnAdapterTypedViewsValidateFixedWidth(t *testing.T) {
+	mgr := mappedresource.NewManager()
+	scope := mappedresource.Scope{Kind: mappedresource.ScopeColumnPartReader, ID: "typed-column-adapter-views", Namespace: "typed-column-adapter-test"}
+
+	i64 := typedColumnAdapterAlignedBytes(16, int(unsafe.Alignof(int64(0))))
+	binary.LittleEndian.PutUint64(i64[0:8], 7)
+	binary.LittleEndian.PutUint64(i64[8:16], 11)
+	i64Handle := typedColumnAdapterAcquireBytes(t, mgr, scope, i64, "i64")
+	defer i64Handle.Release()
+	if got, err := typedColumnAdapterInt64View(mgr, i64Handle); err != nil || !slices.Equal(got, []int64{7, 11}) {
+		t.Fatalf("Int64View=%v err=%v", got, err)
+	}
+
+	f32Bytes := typedColumnAdapterAlignedBytes(8, int(unsafe.Alignof(float32(0))))
+	binary.LittleEndian.PutUint32(f32Bytes[0:4], math.Float32bits(1.5))
+	binary.LittleEndian.PutUint32(f32Bytes[4:8], math.Float32bits(2.5))
+	f32Handle := typedColumnAdapterAcquireBytes(t, mgr, scope, f32Bytes, "f32")
+	defer f32Handle.Release()
+	if got, err := typedColumnAdapterFloat32View(mgr, f32Handle); err != nil || len(got) != 2 || got[0] != 1.5 || got[1] != 2.5 {
+		t.Fatalf("Float32View=%v err=%v", got, err)
+	}
+
+	f64Bytes := typedColumnAdapterAlignedBytes(16, int(unsafe.Alignof(float64(0))))
+	binary.LittleEndian.PutUint64(f64Bytes[0:8], math.Float64bits(1.5))
+	binary.LittleEndian.PutUint64(f64Bytes[8:16], math.Float64bits(2.5))
+	f64Handle := typedColumnAdapterAcquireBytes(t, mgr, scope, f64Bytes, "f64")
+	defer f64Handle.Release()
+	if got, err := typedColumnAdapterFloat64View(mgr, f64Handle); err != nil || len(got) != 2 || got[0] != 1.5 || got[1] != 2.5 {
+		t.Fatalf("Float64View=%v err=%v", got, err)
+	}
+
+	u32Bytes := typedColumnAdapterAlignedBytes(8, int(unsafe.Alignof(uint32(0))))
+	binary.LittleEndian.PutUint32(u32Bytes[0:4], 3)
+	binary.LittleEndian.PutUint32(u32Bytes[4:8], 5)
+	u32Handle := typedColumnAdapterAcquireBytes(t, mgr, scope, u32Bytes, "u32")
+	defer u32Handle.Release()
+	if got, err := typedColumnAdapterUint32View(mgr, u32Handle); err != nil || !slices.Equal(got, []uint32{3, 5}) {
+		t.Fatalf("Uint32View=%v err=%v", got, err)
+	}
+
+	truncated := typedColumnAdapterAlignedBytes(6, int(unsafe.Alignof(uint32(0))))
+	truncatedHandle := typedColumnAdapterAcquireBytes(t, mgr, scope, truncated, "truncated")
+	defer truncatedHandle.Release()
+	if _, err := typedColumnAdapterUint32View(mgr, truncatedHandle); err == nil {
+		t.Fatalf("Uint32View truncated err=nil, want failure")
+	}
+	if stats := mgr.Stats(); stats.DirectViewSuccesses != 4 || stats.DirectViewFailures != 1 {
+		t.Fatalf("direct view stats=%+v", stats)
+	}
+}
+
+func TestTypedColumnAdapterUnsupportedTypeFailsClosed(t *testing.T) {
+	field := typedColumnAdapterField("future", ColumnStoreValueType("decimal128"))
+	if _, err := buildTypedColumnAdapterPart(typedColumnAdapterOptions{PartID: 1, Fields: []TypedStorageField{field}}, nil); !errors.Is(err, errTypedColumnAdapterUnsupportedType) {
+		t.Fatalf("build unsupported err=%v want errTypedColumnAdapterUnsupportedType", err)
+	}
+	missing := typedColumnAdapterField("missing", ColumnStoreValueInt64)
+	_, err := buildTypedColumnAdapterPart(typedColumnAdapterOptions{PartID: 1, Fields: []TypedStorageField{missing}}, []typedColumnAdapterRow{{PrimaryID: 1, Values: nil}})
+	if err == nil || !strings.Contains(err.Error(), "missing field") {
+		t.Fatalf("build missing field err=%v want missing field", err)
+	}
+}
+
+func typedColumnAdapterField(name string, valueType ColumnStoreValueType) TypedStorageField {
+	return TypedStorageField{Name: name, Path: name, Owner: TypedStorageOwnerColumnPart, ValueType: valueType}
+}
+
+func typedColumnAdapterRoundTrip(t *testing.T, field TypedStorageField, values []columnDeclaredValue) []columnDeclaredValue {
+	t.Helper()
+	part := typedColumnAdapterBuildPart(t, field, values)
+	image, err := part.buildImage()
+	if err != nil {
+		t.Fatalf("buildImage: %v", err)
+	}
+	parsed, err := typedColumnAdapterPartFromImage(part.Options, image)
+	if err != nil {
+		t.Fatalf("typedColumnAdapterPartFromImage: %v", err)
+	}
+	got, err := parsed.scanColumnValues(field.Name)
+	if err != nil {
+		t.Fatalf("scanColumnValues(%s): %v", field.Name, err)
+	}
+	return got
+}
+
+func typedColumnAdapterBuildPart(t *testing.T, field TypedStorageField, values []columnDeclaredValue) *typedColumnAdapterPart {
+	t.Helper()
+	rows := make([]typedColumnAdapterRow, len(values))
+	for i, value := range values {
+		rows[i] = typedColumnAdapterRow{PrimaryID: int64(i + 1), Values: map[string]columnDeclaredValue{field.Path: value}}
+	}
+	part, err := buildTypedColumnAdapterPart(typedColumnAdapterOptions{PartID: 42, RowsPerGranule: 2, Fields: []TypedStorageField{field}}, rows)
+	if err != nil {
+		t.Fatalf("buildTypedColumnAdapterPart: %v", err)
+	}
+	return part
+}
+
+func typedColumnAdapterFindColumnSection(t *testing.T, image typedcolumn.ColumnPartImage, column string) typedcolumn.ColumnPartImageSection {
+	t.Helper()
+	for _, section := range image.Sections {
+		if section.Kind == typedcolumn.ColumnPartImageSectionColumnData && section.Column == column {
+			return section
+		}
+	}
+	t.Fatalf("missing column data section %q in %+v", column, image.Sections)
+	return typedcolumn.ColumnPartImageSection{}
+}
+
+func typedColumnAdapterAcquireBytes(t *testing.T, mgr *mappedresource.Manager, scope mappedresource.Scope, data []byte, kind string) *mappedresource.Handle {
+	t.Helper()
+	key := mappedresource.Key{Class: mappedresource.ClassTypedColumnAsset, Namespace: scope.Namespace, Kind: kind, FileID: 1, Length: int64(len(data))}
+	h, err := mgr.AcquireBytes(key, scope, mappedresource.SourceMapped, data, mappedresource.AcquireOptions{Reason: kind, ValidationMode: mappedresource.ValidationVerify})
+	if err != nil {
+		t.Fatalf("AcquireBytes(%s): %v", kind, err)
+	}
+	return h
+}
+
+func typedColumnAdapterAlignedBytes(size int, align int) []byte {
+	buf := make([]byte, size+align)
+	base := uintptr(unsafe.Pointer(unsafe.SliceData(buf)))
+	for off := 0; off < align; off++ {
+		if (base+uintptr(off))%uintptr(align) == 0 {
+			return buf[off : off+size]
+		}
+	}
+	panic("no aligned offset found")
+}

--- a/TreeDB/collections/typed_column_adapter_test.go
+++ b/TreeDB/collections/typed_column_adapter_test.go
@@ -284,6 +284,18 @@ func TestTypedColumnAdapterTypedViewsValidateFixedWidth(t *testing.T) {
 	}
 }
 
+func TestTypedColumnAdapterReservedPrimaryIDFailsClosed(t *testing.T) {
+	for _, field := range []TypedStorageField{
+		typedColumnAdapterField(typedColumnAdapterPrimaryIDColumn, ColumnStoreValueInt64),
+		{Name: "user_id", Path: typedColumnAdapterPrimaryIDColumn, Owner: TypedStorageOwnerColumnPart, ValueType: ColumnStoreValueInt64},
+	} {
+		_, err := buildTypedColumnAdapterPart(typedColumnAdapterOptions{PartID: 1, Fields: []TypedStorageField{field}}, nil)
+		if err == nil || !strings.Contains(err.Error(), "reserved primary-id column") {
+			t.Fatalf("build reserved field %+v err=%v want reserved primary-id column", field, err)
+		}
+	}
+}
+
 func TestTypedColumnAdapterUnsupportedTypeFailsClosed(t *testing.T) {
 	field := typedColumnAdapterField("future", ColumnStoreValueType("decimal128"))
 	if _, err := buildTypedColumnAdapterPart(typedColumnAdapterOptions{PartID: 1, Fields: []TypedStorageField{field}}, nil); !errors.Is(err, errTypedColumnAdapterUnsupportedType) {

--- a/TreeDB/collections/typed_column_adapter_test.go
+++ b/TreeDB/collections/typed_column_adapter_test.go
@@ -294,6 +294,11 @@ func TestTypedColumnAdapterReservedPrimaryIDFailsClosed(t *testing.T) {
 			t.Fatalf("build reserved field %+v err=%v want reserved primary-id column", field, err)
 		}
 	}
+	metadata := typedColumnAdapterField(typedColumnAdapterMetadataDictionary, ColumnStoreValueString)
+	_, err := buildTypedColumnAdapterPart(typedColumnAdapterOptions{PartID: 1, Fields: []TypedStorageField{metadata}}, nil)
+	if err == nil || !strings.Contains(err.Error(), "reserved metadata dictionary") {
+		t.Fatalf("build metadata-reserved field err=%v want reserved metadata dictionary", err)
+	}
 }
 
 func TestTypedColumnAdapterDuplicateOrAmbiguousFieldsFailClosed(t *testing.T) {
@@ -332,6 +337,19 @@ func TestTypedColumnAdapterImageSchemaMismatchFailsClosed(t *testing.T) {
 	mismatch := typedColumnAdapterField("count", ColumnStoreValueBool)
 	if _, err := typedColumnAdapterPartFromImage(typedColumnAdapterOptions{PartID: 1, Fields: []TypedStorageField{mismatch}}, image); err == nil || !strings.Contains(err.Error(), "schema mismatch") {
 		t.Fatalf("partFromImage schema mismatch err=%v want schema mismatch", err)
+	}
+}
+
+func TestTypedColumnAdapterImageValueTypeMetadataMismatchFailsClosed(t *testing.T) {
+	field := typedColumnAdapterField("score", ColumnStoreValueDouble)
+	part := typedColumnAdapterBuildPart(t, field, []columnDeclaredValue{{Type: ColumnStoreValueDouble, Present: true, Double: 42.5}})
+	image, err := part.buildImage()
+	if err != nil {
+		t.Fatalf("buildImage: %v", err)
+	}
+	mismatch := typedColumnAdapterField("score", ColumnStoreValueFloat32)
+	if _, err := typedColumnAdapterPartFromImage(typedColumnAdapterOptions{PartID: 1, Fields: []TypedStorageField{mismatch}}, image); err == nil || !strings.Contains(err.Error(), "value type metadata mismatch") {
+		t.Fatalf("partFromImage value-type mismatch err=%v want value type metadata mismatch", err)
 	}
 }
 

--- a/TreeDB/collections/typed_column_adapter_test.go
+++ b/TreeDB/collections/typed_column_adapter_test.go
@@ -305,12 +305,33 @@ func TestTypedColumnAdapterDuplicateOrAmbiguousFieldsFailClosed(t *testing.T) {
 		t.Fatalf("build duplicate fields err=%v want duplicate column", err)
 	}
 
+	duplicatePath := []TypedStorageField{
+		{Name: "left", Path: "same", Owner: TypedStorageOwnerColumnPart, ValueType: ColumnStoreValueInt64},
+		{Name: "right", Path: "same", Owner: TypedStorageOwnerColumnPart, ValueType: ColumnStoreValueInt64},
+	}
+	if _, err := buildTypedColumnAdapterPart(typedColumnAdapterOptions{PartID: 1, Fields: duplicatePath}, nil); err == nil || !strings.Contains(err.Error(), "duplicate field path") {
+		t.Fatalf("build duplicate path fields err=%v want duplicate field path", err)
+	}
+
 	crossCollision := []TypedStorageField{
 		{Name: "left", Path: "right", Owner: TypedStorageOwnerColumnPart, ValueType: ColumnStoreValueInt64},
 		{Name: "right", Path: "other", Owner: TypedStorageOwnerColumnPart, ValueType: ColumnStoreValueInt64},
 	}
 	if _, err := buildTypedColumnAdapterPart(typedColumnAdapterOptions{PartID: 1, Fields: crossCollision}, nil); err == nil || !strings.Contains(err.Error(), "ambiguous field name") {
 		t.Fatalf("build cross-collision fields err=%v want ambiguous field name", err)
+	}
+}
+
+func TestTypedColumnAdapterImageSchemaMismatchFailsClosed(t *testing.T) {
+	field := typedColumnAdapterField("count", ColumnStoreValueInt64)
+	part := typedColumnAdapterBuildPart(t, field, []columnDeclaredValue{{Type: ColumnStoreValueInt64, Present: true, Int64: 10}})
+	image, err := part.buildImage()
+	if err != nil {
+		t.Fatalf("buildImage: %v", err)
+	}
+	mismatch := typedColumnAdapterField("count", ColumnStoreValueBool)
+	if _, err := typedColumnAdapterPartFromImage(typedColumnAdapterOptions{PartID: 1, Fields: []TypedStorageField{mismatch}}, image); err == nil || !strings.Contains(err.Error(), "schema mismatch") {
+		t.Fatalf("partFromImage schema mismatch err=%v want schema mismatch", err)
 	}
 }
 

--- a/TreeDB/collections/typed_column_adapter_test.go
+++ b/TreeDB/collections/typed_column_adapter_test.go
@@ -296,6 +296,45 @@ func TestTypedColumnAdapterReservedPrimaryIDFailsClosed(t *testing.T) {
 	}
 }
 
+func TestTypedColumnAdapterDuplicateOrAmbiguousFieldsFailClosed(t *testing.T) {
+	duplicate := []TypedStorageField{
+		{Name: "dup", Path: "left", Owner: TypedStorageOwnerColumnPart, ValueType: ColumnStoreValueInt64},
+		{Name: "dup", Path: "right", Owner: TypedStorageOwnerColumnPart, ValueType: ColumnStoreValueInt64},
+	}
+	if _, err := buildTypedColumnAdapterPart(typedColumnAdapterOptions{PartID: 1, Fields: duplicate}, nil); err == nil || !strings.Contains(err.Error(), "duplicate column") {
+		t.Fatalf("build duplicate fields err=%v want duplicate column", err)
+	}
+
+	crossCollision := []TypedStorageField{
+		{Name: "left", Path: "right", Owner: TypedStorageOwnerColumnPart, ValueType: ColumnStoreValueInt64},
+		{Name: "right", Path: "other", Owner: TypedStorageOwnerColumnPart, ValueType: ColumnStoreValueInt64},
+	}
+	if _, err := buildTypedColumnAdapterPart(typedColumnAdapterOptions{PartID: 1, Fields: crossCollision}, nil); err == nil || !strings.Contains(err.Error(), "ambiguous field name") {
+		t.Fatalf("build cross-collision fields err=%v want ambiguous field name", err)
+	}
+}
+
+func TestTypedColumnAdapterAmbiguousRowKeysFailClosed(t *testing.T) {
+	field := TypedStorageField{Name: "count", Path: "metrics.count", Owner: TypedStorageOwnerColumnPart, ValueType: ColumnStoreValueInt64}
+	rows := []typedColumnAdapterRow{{PrimaryID: 1, Values: map[string]columnDeclaredValue{
+		"count":         {Type: ColumnStoreValueInt64, Present: true, Int64: 10},
+		"metrics.count": {Type: ColumnStoreValueInt64, Present: true, Int64: 20},
+	}}}
+	if _, err := buildTypedColumnAdapterPart(typedColumnAdapterOptions{PartID: 1, Fields: []TypedStorageField{field}}, rows); err == nil || !strings.Contains(err.Error(), "ambiguous field keys") {
+		t.Fatalf("build ambiguous row err=%v want ambiguous field keys", err)
+	}
+}
+
+func TestTypedColumnAdapterMissingDeclaredValueTypeFailsClosed(t *testing.T) {
+	field := typedColumnAdapterField("count", ColumnStoreValueInt64)
+	rows := []typedColumnAdapterRow{{PrimaryID: 1, Values: map[string]columnDeclaredValue{
+		"count": {Present: true, Int64: 10},
+	}}}
+	if _, err := buildTypedColumnAdapterPart(typedColumnAdapterOptions{PartID: 1, Fields: []TypedStorageField{field}}, rows); err == nil || !strings.Contains(err.Error(), "declared type required") {
+		t.Fatalf("build missing declared type err=%v want declared type required", err)
+	}
+}
+
 func TestTypedColumnAdapterUnsupportedTypeFailsClosed(t *testing.T) {
 	field := typedColumnAdapterField("future", ColumnStoreValueType("decimal128"))
 	if _, err := buildTypedColumnAdapterPart(typedColumnAdapterOptions{PartID: 1, Fields: []TypedStorageField{field}}, nil); !errors.Is(err, errTypedColumnAdapterUnsupportedType) {

--- a/TreeDB/docs/spec/README.md
+++ b/TreeDB/docs/spec/README.md
@@ -161,6 +161,10 @@ Given pre-alpha status, this is a living spec that tracks implementation.
   - issue #1753 implementation note for the non-authoritative
     `TreeDB/internal/typedcolumn` data-plane transplant from
     `experiments/colgranule`.
+- `TreeDB/docs/spec/typed-column-adapter.md`
+  - issue #1754 implementation note for the non-authoritative adapter from
+    TreeDB typed-storage field metadata and #1736 mapped resources to the
+    transplanted typed-column data plane.
 
 ## Canonical Ownership
 
@@ -187,7 +191,8 @@ Typed physical storage vocabulary (`typed storage`, `typed-row storage`,
 `typed-column storage`, `typed_row_asset`, `typed_column_part`,
 `retained_document`, `document_payload`, and `derived_accelerator`) is owned by
 `typed-storage-naming.md`; the #1753 non-authoritative typed-column transplant
-scope is recorded in `typed-column-transplant.md`. User-command WAL lifecycle terms
+scope is recorded in `typed-column-transplant.md`, and the #1754 adapter seam is
+recorded in `typed-column-adapter.md`. User-command WAL lifecycle terms
 (`CommandEnvelope`, `LSN`, `AppliedLSN`, `WAL-supported`, `WAL-rejected`,
 `WAL-off-only`) are owned by `user-command-wal.md`. Deprecated collection root-delta WAL terms
 (`CollectionSeq`, `WALLSN`, `root group`, `applied watermark`) remain defined in
@@ -204,8 +209,8 @@ blocking questions live:
 - Raft sequencing and local recoverability questions:
   `native-query-raft-roadmap.md`.
 - Typed-storage persistence and historical roadmap questions:
-  `typed-storage-naming.md`, `typed-column-transplant.md`, and
-  `GOMAP_TREEDB_COLUMN_STORE_RFC.md`.
+  `typed-storage-naming.md`, `typed-column-transplant.md`,
+  `typed-column-adapter.md`, and `GOMAP_TREEDB_COLUMN_STORE_RFC.md`.
 
 A blocking implementation question must be listed in this index and in its
 owner document. Non-blocking future-extension questions must be labeled as

--- a/TreeDB/docs/spec/typed-column-adapter.md
+++ b/TreeDB/docs/spec/typed-column-adapter.md
@@ -40,8 +40,8 @@ and `[]uint32` buffers.
 
 ## Retained Payload Seam
 
-`typedColumnAdapterRetainedPayloadSplitRestore` reuses the production retained
-payload split/restore helpers as an internal test seam. It does not alter
+`typedColumnAdapterRetainedPayloadSplitRestore` reuses the production
+retained-payload split/restore helpers as an internal test seam. It does not alter
 production retained-payload behavior.
 
 ## Boundary

--- a/TreeDB/docs/spec/typed-column-adapter.md
+++ b/TreeDB/docs/spec/typed-column-adapter.md
@@ -1,0 +1,52 @@
+# Typed-Column Adapter (#1754)
+
+Status: current implementation note for issue #1754 under parent tracker #1744.
+
+`TreeDB/collections/typed_column_adapter.go` adapts the transplanted
+`TreeDB/internal/typedcolumn` data plane to TreeDB typed-storage field metadata,
+legacy `ColumnStoreValueType` compatibility names, retained-payload test seams,
+and #1736 `mappedresource` section access.
+
+This adapter is **non-authoritative**. It does not publish collection manifests,
+write recovery metadata, replay WAL state, switch query planning, or enable
+`typed_column_part` ownership in production. Existing `ColumnStoreConfig`
+metadata still resolves to `typed_row_asset` unless tests construct explicit
+`TypedStorageOwnerColumnPart` fields for this adapter seam.
+
+## Type Matrix
+
+| TreeDB declared type | #1754 adapter status | Representation |
+| --- | --- | --- |
+| `bool` | represented | `typedcolumn.ColumnTypeBool` bitpack/RLE encoding. |
+| `int64` | represented | `typedcolumn.ColumnTypeInt64` delta-varint encoding. |
+| `float32` | represented | Raw int64 column carrying `math.Float32bits` in the low 32 bits until native float sections land. |
+| `double` / `float64` | represented | Raw int64 column carrying `math.Float64bits`. |
+| `string` | represented | Low-cardinality uint32 codes plus typed-column dictionary section metadata. |
+| `float32_vector` | fail closed | Dense vector typed-column sections are staged to #1756. |
+| `adjacency_list` | fail closed | Adjacency typed-column sections are staged to #1756. |
+
+Nullable/missing adapter values fail closed in #1754 because the transplanted
+part builder does not yet have a TreeDB nullable typed-column representation.
+Publication/reopen work in #1755 and vector/adjacency work in #1756 may extend
+this matrix without changing the existing typed-row compatibility path.
+
+## Resource Seam
+
+`typedColumnAdapterResourceReader` acquires typed-column image sections through
+issue #1736 `mappedresource.Manager` handles. Tests cover file-backed mmap-or-heap
+reads and heap reads for the same section bytes. Fixed-width adapter reads use
+mappedresource typed-view validation for `[]int64`, `[]float32`, `[]float64`,
+and `[]uint32` buffers.
+
+## Retained Payload Seam
+
+`typedColumnAdapterRetainedPayloadSplitRestore` reuses the production retained
+payload split/restore helpers as an internal test seam. It does not alter
+production retained-payload behavior.
+
+## Boundary
+
+The only production `TreeDB/collections` file that imports
+`TreeDB/internal/typedcolumn` in issue #1754 should be the adapter seam. Later
+PRs must keep publication/reopen/recovery wiring in #1755 and query/vector
+integration in #1756/#1757 rather than hiding those changes in the adapter.

--- a/TreeDB/docs/spec/typed-column-transplant.md
+++ b/TreeDB/docs/spec/typed-column-transplant.md
@@ -56,8 +56,8 @@ typed-row physical asset format.
 
 ## Boundary
 
-`TreeDB/internal/typedcolumn` must remain a data-plane package until the adapter
-PRs land. In issue `#1753`, it must not be imported by
-`TreeDB/collections` production files, and it must not change
-`ResolveTypedStorageLayout` fail-closed behavior for authoritative
-`typed_column_part` ownership.
+`TreeDB/internal/typedcolumn` remains a data-plane package. Issue `#1753`
+forbade production `TreeDB/collections` imports; issue `#1754` adds the narrow
+`typed_column_adapter.go` seam for metadata/resource adaptation. The adapter seam
+still must not publish manifests or change `ResolveTypedStorageLayout`
+fail-closed behavior for authoritative `typed_column_part` ownership.

--- a/TreeDB/docs/spec/typed-storage-naming.md
+++ b/TreeDB/docs/spec/typed-storage-naming.md
@@ -86,6 +86,16 @@ make `typed_column_part` an authoritative owner yet. The transplant deliberately
 uses package-local `Options`/`Batch` names instead of adding new public or
 internal `ColumnStore*` umbrella names.
 
+## PR 4 Typed-Column Adapter
+
+Issue #1754 introduces `TreeDB/collections/typed_column_adapter.go` as a
+non-authoritative adapter seam from TreeDB typed-storage metadata and #1736
+resource handles to `TreeDB/internal/typedcolumn`. It may use
+`ColumnStoreValueType` as compatibility input, but existing `ColumnStoreConfig`
+metadata still resolves to `typed_row_asset` unless tests construct explicit
+`typed_column_part` fields. This adapter must not publish production manifests,
+change query planning, or enable authoritative `typed_column_part` reads.
+
 ## Current Derived Accelerator Classifications
 
 These existing assets are derived accelerators unless a future format explicitly

--- a/TreeDB/internal/typedcolumn/transplant_test.go
+++ b/TreeDB/internal/typedcolumn/transplant_test.go
@@ -394,9 +394,13 @@ func TestTypedColumnTransplantNoProductionPublication(t *testing.T) {
 			t.Fatalf("parse %s: %v", path, err)
 		}
 		for _, imp := range file.Imports {
-			if strings.Trim(imp.Path.Value, "\"") == "github.com/snissn/gomap/TreeDB/internal/typedcolumn" {
-				t.Fatalf("production collections import typedcolumn in %s; #1753 must not publish/control-plane integrate it", path)
+			if strings.Trim(imp.Path.Value, "\"") != "github.com/snissn/gomap/TreeDB/internal/typedcolumn" {
+				continue
 			}
+			if filepath.Base(path) == "typed_column_adapter.go" {
+				continue
+			}
+			t.Fatalf("production collections import typedcolumn in %s; typed-column data-plane imports must stay in the #1754 adapter seam", path)
 		}
 		return nil
 	})

--- a/TreeDB/internal/typedcolumn/transplant_test.go
+++ b/TreeDB/internal/typedcolumn/transplant_test.go
@@ -381,6 +381,7 @@ func TestTypedColumnTransplantNoProductionPublication(t *testing.T) {
 	}
 	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(file), "..", "..", ".."))
 	collectionsDir := filepath.Join(repoRoot, "TreeDB", "collections")
+	allowedAdapter := filepath.Clean(filepath.Join(collectionsDir, "typed_column_adapter.go"))
 	fset := token.NewFileSet()
 	err := filepath.WalkDir(collectionsDir, func(path string, d fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
@@ -397,7 +398,7 @@ func TestTypedColumnTransplantNoProductionPublication(t *testing.T) {
 			if strings.Trim(imp.Path.Value, "\"") != "github.com/snissn/gomap/TreeDB/internal/typedcolumn" {
 				continue
 			}
-			if filepath.Base(path) == "typed_column_adapter.go" {
+			if filepath.Clean(path) == allowedAdapter {
 				continue
 			}
 			t.Fatalf("production collections import typedcolumn in %s; typed-column data-plane imports must stay in the #1754 adapter seam", path)


### PR DESCRIPTION
## Summary

Adds the #1754 non-authoritative adapter seam from TreeDB typed-storage metadata to the transplanted `TreeDB/internal/typedcolumn` data plane.

Parent tracker: #1744  
Child issue: #1754  
Dependency status: #1753 / PR #1763 is merged via `605ffd62b868d19f41cf5dae73e037a2f6311486`; #1736 Gate A mappedresource APIs are available and used for section reads/typed-view validation.

This PR does **not** make typed-column parts authoritative production storage.

## What Changed

- Added `TreeDB/collections/typed_column_adapter.go`:
  - maps `TypedStorageField` + compatibility `ColumnStoreValueType` metadata to `typedcolumn` descriptors/codecs;
  - builds non-authoritative typed-column parts from caller-provided test/adapter rows;
  - round-trips through typed-column part images and dictionary metadata;
  - adapts retained-payload split/restore helpers as an internal seam;
  - adds a #1736 `mappedresource.Manager` section reader and typed-view wrappers for fixed-width buffers.
- Added adapter tests for the required #1754 matrix and resource seams.
- Updated docs/spec notes for the #1754 adapter boundary and type matrix.
- Updated the #1753 no-production-publication guard to allow only the #1754 adapter seam to import `TreeDB/internal/typedcolumn` from `TreeDB/collections`.

## Scope Boundary / Non-Goals

In scope:

- Non-authoritative adapter/seam code.
- Adapter-level round trips for supported scalar declared types.
- Fail-closed vector/adjacency representation until #1756.
- #1736 mappedresource acquisition and fixed-width typed-view validation.
- Existing typed-row compatibility checks.

Out of scope:

- No authoritative typed-column publication.
- No production collection manifest/recovery integration.
- No query planner or product scan/vector path switch.
- No #1736 COW maintenance implementation.
- No `ColumnStoreConfig` compatibility API removal.
- No rewrite of the transplanted colgranule internals into typed-row asset shape.

## Type Matrix

| TreeDB declared type | #1754 status | Representation / reason |
| --- | --- | --- |
| `bool` | represented | `typedcolumn.ColumnTypeBool` bitpack/RLE. |
| `int64` | represented | `typedcolumn.ColumnTypeInt64` delta-varint. |
| `float32` | represented | raw int64 column carrying `math.Float32bits` until native float sections land. |
| `double` / `float64` | represented | raw int64 column carrying `math.Float64bits`. |
| `string` | represented | low-cardinality uint32 codes plus typed-column dictionary section metadata. |
| `float32_vector` | fail closed | dense vector typed-column sections are staged to #1756. |
| `adjacency_list` | fail closed | adjacency typed-column sections are staged to #1756. |

Nullable/missing adapter values fail closed in this PR because #1754 does not introduce a nullable typed-column representation.

## #1736 Resource / Seam Status

- `typedColumnAdapterResourceReader` acquires typed-column image sections via `mappedresource.Manager`.
- Tests cover file-backed mmap-or-heap reads and heap reads over the same section bytes.
- Tests validate fixed-width typed views for `[]int64`, `[]float32`, `[]float64`, and `[]uint32` through mappedresource wrappers.
- No private production mmap/cache/lifecycle is introduced.

## Naming Impact

- No public `ColumnStore*` API is added, removed, or renamed.
- `ColumnStoreValueType` remains compatibility input to the adapter matrix.
- New code uses typed-column/typed-storage adapter terminology, not “column store” as an umbrella.
- Existing `ColumnStoreConfig` metadata still resolves to `typed_row_asset` unless tests construct explicit `typed_column_part` fields.

## Required Test Mapping

| Required #1754 item | Actual test |
| --- | --- |
| Maps TreeDB declared types | `TestTypedColumnAdapterMapsTreeDBDeclaredTypes` |
| Bool round trip | `TestTypedColumnAdapterRoundTripBool` |
| Int64 round trip | `TestTypedColumnAdapterRoundTripInt64` |
| Float32 round trip | `TestTypedColumnAdapterRoundTripFloat32` |
| Float64 round trip | `TestTypedColumnAdapterRoundTripFloat64` |
| String round trip | `TestTypedColumnAdapterRoundTripString` |
| Vector/adjacency represented or fail closed | `TestTypedColumnAdapterVectorAndAdjacencyRepresentedOrFailClosed` |
| Existing config stays typed-row | `TestTypedColumnAdapterExistingConfigStaysTypedRow` |
| Retained payload split/restore | `TestTypedColumnAdapterRetainedPayloadSplitRestore` |
| Mappedresource mmap/heap parity | `TestTypedColumnAdapterMappedResourceMmapHeapParity` |
| Typed views validate fixed width | `TestTypedColumnAdapterTypedViewsValidateFixedWidth` |
| Reserved adapter names fail closed | `TestTypedColumnAdapterReservedPrimaryIDFailsClosed` |
| Duplicate/ambiguous field descriptors fail closed | `TestTypedColumnAdapterDuplicateOrAmbiguousFieldsFailClosed` |
| Image schema mismatch fails closed | `TestTypedColumnAdapterImageSchemaMismatchFailsClosed` |
| Image value-type metadata drift fails closed | `TestTypedColumnAdapterImageValueTypeMetadataMismatchFailsClosed` |
| Ambiguous row keys fail closed | `TestTypedColumnAdapterAmbiguousRowKeysFailClosed` |
| Missing declared value type fails closed | `TestTypedColumnAdapterMissingDeclaredValueTypeFailsClosed` |
| Unsupported type fails closed | `TestTypedColumnAdapterUnsupportedTypeFailsClosed` |

## Tests Run

```sh
go test -count=1 ./TreeDB/collections -run TestTypedColumnAdapter -v
go test -count=1 ./TreeDB/internal/typedcolumn -run TestTypedColumnTransplantNoProductionPublication -v
go test -count=1 ./TreeDB/internal/typedcolumn ./TreeDB/collections
go test -count=1 ./TreeDB/docs ./TreeDB/internal/typedcolumn ./TreeDB/collections
go test -count=1 ./TreeDB/...
rg -n "ColumnStore|column store|column-store" TreeDB docs experiments
git grep -n -E "ColumnStore|column store|column-store" origin/main -- TreeDB docs experiments
```

Legacy-name audit:

- `origin/main`: 1850 lines
- branch: 1931 lines
- Increase is from #1754 adapter tests/docs and compatibility-name input references; public `ColumnStore*` APIs are unchanged.

## Benchmark / Performance Evidence

No benchmarks run. This PR adds an internal non-authoritative adapter seam and tests/docs; it does not switch production hot paths, query planning, publication, or vector scans.

## CI / Review Status

- Latest-head CI: passing on `41d719c25890510978f764e6c7d1b09803dd1929`.
- Merge state: `CLEAN`.
- Review threads: 0 unresolved.
- Codex review: latest-head review found no major issues. Earlier valid findings were fixed.
- CodeRabbit review: completed/skipped on latest head; earlier valid findings were fixed.
- Copilot review: repeatedly failed with `Copilot encountered an error and was unable to review this pull request.`

## Follow-Ups

- #1755 owns durable publication/reopen/reconstruction integration.
- #1756 owns vector dense sections / adjacency representation.
- #1757 owns production predicate scan integration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a typed-column adapter supporting bool, int64, float32, float64 and string with deterministic string dictionaries, synthetic primary-id column, strict fail-closed behavior for null/missing/unsupported types (including vectors/adjacency), duplicate/ambiguous field detection, retained-JSON split/restore, and support for mmap or heap-backed reads and fixed-width typed views.

* **Tests**
  * Comprehensive suite for mapping, encode/decode round-trips, retained-payload restore, fixed-width view validation, mmap/heap parity, and fail-closed scenarios.

* **Documentation**
  * New and updated spec pages describing adapter semantics, type matrix, resource/read constraints, and integration boundaries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1766?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
