### PR TITLE
bench: add GPU dot product tournament

### DIFF
--- a/benchmarks/gpu_dot_tournament/README.md
+++ b/benchmarks/gpu_dot_tournament/README.md
@@ -63,25 +63,33 @@ rows=8192:   ~0.91-0.98 ms   (~8-9M dots/sec)
 rows=65536:  ~7.9-8.1 ms     (~8M dots/sec)
 ```
 
-That host has an RTX 3060 Ti installed, but the local NVIDIA driver/runtime was
-mismatched while this benchmark was written, so CUDA cases skipped with:
+On the same host, using an RTX 3060 Ti with matching user-space driver
+libraries, the CUDA/cuBLAS candidates measured:
 
 ```text
-cudaGetDeviceCount: forward compatibility was attempted on non supported HW
+rows=128:    device-resident SGEMV ~3.4-3.5 us/op   (~36-38M dots/sec)
+             upload-query SGEMV    ~20 us/op        (~6M dots/sec)
+             device-resident SGEMM ~3.4-3.5 us/op   (~36-38M dots/sec)
+rows=1024:   device-resident SGEMV ~10.2-10.3 us/op (~99-100M dots/sec)
+             upload-query SGEMV    ~22 us/op        (~46M dots/sec)
+             device-resident SGEMM ~10.3 us/op      (~99M dots/sec)
+rows=8192:   device-resident SGEMV ~65 us/op        (~125M dots/sec)
+             upload-query SGEMV    ~86 us/op        (~95M dots/sec)
+             device-resident SGEMM ~65 us/op        (~125M dots/sec)
+rows=65536:  device-resident SGEMV ~0.50 ms/op      (~128-131M dots/sec)
+             upload-query SGEMV    ~0.55 ms/op      (~119M dots/sec)
+             device-resident SGEMM ~0.50 ms/op      (~131M dots/sec)
 ```
 
-The roofline for a device-resident GPU path is nevertheless useful. A 3060 Ti is
-roughly a 448 GB/s memory-bandwidth device. Scoring one query against 65,536
-rows of 768 float32s reads about 201 MB of row data, so a bandwidth-limited
-ideal is about 2.2k such tournaments/sec, or about 145M 768d dots/sec. That is
-roughly an 18x raw dot-throughput ceiling over the local CPU baseline for the
-large-row case. The CUDA/cuBLAS tournament exists to replace this roofline with
-measured numbers on a working CUDA host.
+The GPU win is clearest for large, device-resident batches. At 65,536 rows, the
+CUDA path is about 16x faster than the local CPU baseline (~0.50 ms vs ~8 ms).
+At 128 rows, launch/library overhead dominates and the device-resident GPU case
+is only modestly faster; uploading/downloading per query is slower than CPU.
 
 For native in-memory HNSW at `100k docs / 768 dims / ef_search=128`, prior
 single-thread no-document search measured about `0.83-0.92 ms/search`, or about
 `1.1k-1.2k searches/sec`, with roughly 63% of CPU samples in dot products. If a
 future GPU path can batch the graph scoring work into device-resident row groups
-and approach ~145M 768d dots/sec, the dot stage for a search that scores ~2k
-vectors would be around 14 us. End-to-end search would then be dominated by CPU
+at ~125-131M 768d dots/sec, the dot stage for a search that scores ~2k vectors
+would be around 15-16 us. End-to-end search would then be dominated by CPU
 frontier traversal and GPU scheduling/transfer unless those are also batched.

--- a/benchmarks/gpu_dot_tournament/README.md
+++ b/benchmarks/gpu_dot_tournament/README.md
@@ -1,0 +1,87 @@
+# GPU Dot-Product Tournament
+
+This standalone benchmark module compares CPU and CUDA/cuBLAS approaches for
+TreeDB-shaped vector scoring:
+
+```text
+out[i] = dot(query[768], matrix[row_i][768])
+```
+
+The default package builds without CUDA and includes a CPU baseline. CUDA cases
+are behind the `cuda` build tag so normal repository CI does not require an
+NVIDIA driver/toolkit.
+
+## Candidates
+
+- `cpu_tphakala_loop`: current Go SIMD baseline, looping over rows with
+  `github.com/tphakala/simd/f32.DotProduct`.
+- `cuda_cublas_sgemv_device_resident`: matrix, query, and output are already on
+  the GPU; measures the cuBLAS SGEMV compute path.
+- `cuda_cublas_sgemv_upload_query`: matrix stays resident on GPU, but each
+  operation uploads the query and downloads the output.
+- `cuda_cublas_sgemm_device_resident`: same math expressed as a skinny SGEMM.
+
+The device-resident cases are the relevant optimistic model for a future TreeDB
+GPU path where vector blocks and query batches are staged on device. The
+upload/download case shows PCIe overhead when only one query is evaluated at a
+time.
+
+## Run
+
+CPU only:
+
+```sh
+cd benchmarks/gpu_dot_tournament
+GOWORK=off go test -run '^$' -bench . -benchmem -count=3
+```
+
+CUDA tournament:
+
+```sh
+cd benchmarks/gpu_dot_tournament
+GOWORK=off go test -tags cuda -run '^$' -bench . -benchmem -count=3
+```
+
+The CUDA benchmark uses CUDA runtime and cuBLAS via cgo:
+
+```text
+-lcudart -lcublas
+```
+
+If the NVIDIA driver/toolkit is unavailable or mismatched, CUDA cases skip with
+the runtime error.
+
+## Local CPU baseline and GPU roofline
+
+On the 11th Gen Intel i5-11400F host used while adding this benchmark, the CPU
+baseline measured:
+
+```text
+rows=128:    ~4.2-4.5 us/op  (~28-30M dots/sec)
+rows=1024:   ~44-50 us/op    (~21-23M dots/sec)
+rows=8192:   ~0.91-0.98 ms   (~8-9M dots/sec)
+rows=65536:  ~7.9-8.1 ms     (~8M dots/sec)
+```
+
+That host has an RTX 3060 Ti installed, but the local NVIDIA driver/runtime was
+mismatched while this benchmark was written, so CUDA cases skipped with:
+
+```text
+cudaGetDeviceCount: forward compatibility was attempted on non supported HW
+```
+
+The roofline for a device-resident GPU path is nevertheless useful. A 3060 Ti is
+roughly a 448 GB/s memory-bandwidth device. Scoring one query against 65,536
+rows of 768 float32s reads about 201 MB of row data, so a bandwidth-limited
+ideal is about 2.2k such tournaments/sec, or about 145M 768d dots/sec. That is
+roughly an 18x raw dot-throughput ceiling over the local CPU baseline for the
+large-row case. The CUDA/cuBLAS tournament exists to replace this roofline with
+measured numbers on a working CUDA host.
+
+For native in-memory HNSW at `100k docs / 768 dims / ef_search=128`, prior
+single-thread no-document search measured about `0.83-0.92 ms/search`, or about
+`1.1k-1.2k searches/sec`, with roughly 63% of CPU samples in dot products. If a
+future GPU path can batch the graph scoring work into device-resident row groups
+and approach ~145M 768d dots/sec, the dot stage for a search that scores ~2k
+vectors would be around 14 us. End-to-end search would then be dominated by CPU
+frontier traversal and GPU scheduling/transfer unless those are also batched.

--- a/benchmarks/gpu_dot_tournament/cpu_bench_test.go
+++ b/benchmarks/gpu_dot_tournament/cpu_bench_test.go
@@ -1,0 +1,55 @@
+package gpudottournament
+
+import (
+	"fmt"
+	"testing"
+
+	simdf32 "github.com/tphakala/simd/f32"
+)
+
+const (
+	benchDim = 768
+)
+
+var sinkDots []float32
+
+func BenchmarkDotTournamentCPU(b *testing.B) {
+	for _, rows := range []int{128, 1024, 8192, 65536} {
+		b.Run(fmt.Sprintf("cpu_tphakala_loop_rows_%d", rows), func(b *testing.B) {
+			query := deterministicVector(17, benchDim)
+			matrix := deterministicMatrix(rows, benchDim)
+			out := make([]float32, rows)
+			b.ReportAllocs()
+			b.ReportMetric(float64(rows), "dots/op")
+			b.SetBytes(int64(rows * benchDim * 4))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				for row := 0; row < rows; row++ {
+					base := row * benchDim
+					out[row] = simdf32.DotProduct(query, matrix[base:base+benchDim])
+				}
+			}
+			sinkDots = out
+		})
+	}
+}
+
+func deterministicVector(seed, n int) []float32 {
+	out := make([]float32, n)
+	x := uint32(seed)*747796405 + 2891336453
+	for i := range out {
+		x = x*1664525 + 1013904223
+		out[i] = float32(int32(x>>9)%2000-1000) / 1000
+	}
+	return out
+}
+
+func deterministicMatrix(rows, dim int) []float32 {
+	out := make([]float32, rows*dim)
+	x := uint32(rows*dim)*747796405 + 2891336453
+	for i := range out {
+		x = x*1664525 + 1013904223
+		out[i] = float32(int32(x>>9)%2000-1000) / 1000
+	}
+	return out
+}

--- a/benchmarks/gpu_dot_tournament/cuda_bench_test.go
+++ b/benchmarks/gpu_dot_tournament/cuda_bench_test.go
@@ -1,0 +1,163 @@
+//go:build cuda
+
+package gpudottournament
+
+import (
+	"fmt"
+	"testing"
+	"unsafe"
+)
+
+func BenchmarkDotTournamentCUDA(b *testing.B) {
+	if err := requireCUDA(); err != nil {
+		b.Skip(err)
+	}
+	for _, rows := range []int{128, 1024, 8192, 65536} {
+		b.Run(fmt.Sprintf("cuda_cublas_sgemv_device_resident_rows_%d", rows), func(b *testing.B) {
+			benchmarkCUDADot(b, rows, cudaCandidateSGEMVResident)
+		})
+		b.Run(fmt.Sprintf("cuda_cublas_sgemv_upload_query_rows_%d", rows), func(b *testing.B) {
+			benchmarkCUDADot(b, rows, cudaCandidateSGEMVUploadQuery)
+		})
+		b.Run(fmt.Sprintf("cuda_cublas_sgemm_device_resident_rows_%d", rows), func(b *testing.B) {
+			benchmarkCUDADot(b, rows, cudaCandidateSGEMMResident)
+		})
+	}
+}
+
+type cudaCandidate int
+
+const (
+	cudaCandidateSGEMVResident cudaCandidate = iota
+	cudaCandidateSGEMVUploadQuery
+	cudaCandidateSGEMMResident
+)
+
+func benchmarkCUDADot(b *testing.B, rows int, candidate cudaCandidate) {
+	query := deterministicVector(17, benchDim)
+	matrix := deterministicMatrix(rows, benchDim)
+	out := make([]float32, rows)
+	ctx := newCUDAContext(b, matrix, query, out)
+	defer ctx.close(b)
+	b.ReportAllocs()
+	b.ReportMetric(float64(rows), "dots/op")
+	b.SetBytes(int64(rows * benchDim * 4))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		switch candidate {
+		case cudaCandidateSGEMVResident:
+			ctx.sgemv(b)
+		case cudaCandidateSGEMVUploadQuery:
+			ctx.uploadQuery(b, query)
+			ctx.sgemv(b)
+			ctx.downloadOut(b, out)
+		case cudaCandidateSGEMMResident:
+			ctx.sgemm(b)
+		}
+	}
+	ctx.sync(b)
+	sinkDots = out
+}
+
+type cudaContext struct {
+	handle  cudaHandle
+	dMatrix unsafe.Pointer
+	dQuery  unsafe.Pointer
+	dOut    unsafe.Pointer
+	rows    int
+}
+
+func newCUDAContext(tb testing.TB, matrix, query, out []float32) *cudaContext {
+	tb.Helper()
+	ctx := &cudaContext{rows: len(out)}
+	var err error
+	ctx.handle, err = cudaCreate()
+	if err != nil {
+		tb.Fatal(err)
+	}
+	ctx.dMatrix = mustCUDAMalloc(tb, len(matrix)*4)
+	ctx.dQuery = mustCUDAMalloc(tb, len(query)*4)
+	ctx.dOut = mustCUDAMalloc(tb, len(out)*4)
+	if err := cudaH2DRaw(ctx.dMatrix, matrix); err != nil {
+		tb.Fatal(err)
+	}
+	if err := cudaH2DRaw(ctx.dQuery, query); err != nil {
+		tb.Fatal(err)
+	}
+	return ctx
+}
+
+func (c *cudaContext) close(tb testing.TB) {
+	tb.Helper()
+	if c.dMatrix != nil {
+		if err := cudaFreeRaw(c.dMatrix); err != nil {
+			tb.Fatal(err)
+		}
+	}
+	if c.dQuery != nil {
+		if err := cudaFreeRaw(c.dQuery); err != nil {
+			tb.Fatal(err)
+		}
+	}
+	if c.dOut != nil {
+		if err := cudaFreeRaw(c.dOut); err != nil {
+			tb.Fatal(err)
+		}
+	}
+	if c.handle != nil {
+		if err := cudaDestroy(c.handle); err != nil {
+			tb.Fatal(err)
+		}
+	}
+}
+
+func (c *cudaContext) sgemv(tb testing.TB) {
+	tb.Helper()
+	if err := cudaSgemvT(c.handle, benchDim, c.rows, c.dMatrix, c.dQuery, c.dOut); err != nil {
+		tb.Fatal(err)
+	}
+}
+func (c *cudaContext) sgemm(tb testing.TB) {
+	tb.Helper()
+	if err := cudaSgemmT(c.handle, benchDim, c.rows, c.dMatrix, c.dQuery, c.dOut); err != nil {
+		tb.Fatal(err)
+	}
+}
+func (c *cudaContext) uploadQuery(tb testing.TB, query []float32) {
+	tb.Helper()
+	if err := cudaH2DRaw(c.dQuery, query); err != nil {
+		tb.Fatal(err)
+	}
+}
+func (c *cudaContext) downloadOut(tb testing.TB, out []float32) {
+	tb.Helper()
+	if err := cudaD2HRaw(out, c.dOut); err != nil {
+		tb.Fatal(err)
+	}
+}
+func (c *cudaContext) sync(tb testing.TB) {
+	tb.Helper()
+	if err := cudaSyncRaw(); err != nil {
+		tb.Fatal(err)
+	}
+}
+
+func requireCUDA() error {
+	n, err := cudaDeviceCount()
+	if err != nil {
+		return err
+	}
+	if n <= 0 {
+		return fmt.Errorf("no CUDA devices")
+	}
+	return nil
+}
+
+func mustCUDAMalloc(tb testing.TB, bytes int) unsafe.Pointer {
+	tb.Helper()
+	p, err := cudaMallocRaw(bytes)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	return p
+}

--- a/benchmarks/gpu_dot_tournament/cuda_cgo.go
+++ b/benchmarks/gpu_dot_tournament/cuda_cgo.go
@@ -1,0 +1,132 @@
+//go:build cuda
+
+package gpudottournament
+
+/*
+#cgo LDFLAGS: -lcudart -lcublas
+#include <stdlib.h>
+#include <cuda_runtime.h>
+#include <cublas_v2.h>
+
+static const char* gd_cuda_err(cudaError_t err) { return cudaGetErrorString(err); }
+static const char* gd_cublas_err(cublasStatus_t st) {
+    switch (st) {
+    case CUBLAS_STATUS_SUCCESS: return "CUBLAS_STATUS_SUCCESS";
+    case CUBLAS_STATUS_NOT_INITIALIZED: return "CUBLAS_STATUS_NOT_INITIALIZED";
+    case CUBLAS_STATUS_ALLOC_FAILED: return "CUBLAS_STATUS_ALLOC_FAILED";
+    case CUBLAS_STATUS_INVALID_VALUE: return "CUBLAS_STATUS_INVALID_VALUE";
+    case CUBLAS_STATUS_ARCH_MISMATCH: return "CUBLAS_STATUS_ARCH_MISMATCH";
+    case CUBLAS_STATUS_MAPPING_ERROR: return "CUBLAS_STATUS_MAPPING_ERROR";
+    case CUBLAS_STATUS_EXECUTION_FAILED: return "CUBLAS_STATUS_EXECUTION_FAILED";
+    case CUBLAS_STATUS_INTERNAL_ERROR: return "CUBLAS_STATUS_INTERNAL_ERROR";
+    case CUBLAS_STATUS_NOT_SUPPORTED: return "CUBLAS_STATUS_NOT_SUPPORTED";
+    case CUBLAS_STATUS_LICENSE_ERROR: return "CUBLAS_STATUS_LICENSE_ERROR";
+    default: return "CUBLAS_STATUS_UNKNOWN";
+    }
+}
+static cudaError_t gd_malloc(void **p, size_t n) { return cudaMalloc(p, n); }
+static cudaError_t gd_free(void *p) { return cudaFree(p); }
+static cudaError_t gd_h2d(void *dst, const void *src, size_t n) { return cudaMemcpy(dst, src, n, cudaMemcpyHostToDevice); }
+static cudaError_t gd_d2h(void *dst, const void *src, size_t n) { return cudaMemcpy(dst, src, n, cudaMemcpyDeviceToHost); }
+static cudaError_t gd_device_count(int *n) { return cudaGetDeviceCount(n); }
+static cudaError_t gd_sync() { return cudaDeviceSynchronize(); }
+static cublasStatus_t gd_create(cublasHandle_t *h) { return cublasCreate(h); }
+static cublasStatus_t gd_destroy(cublasHandle_t h) { return cublasDestroy(h); }
+static cublasStatus_t gd_sgemv_t(cublasHandle_t h, int dim, int rows, const float *matrix, const float *query, float *out) {
+    const float alpha = 1.0f;
+    const float beta = 0.0f;
+    return cublasSgemv(h, CUBLAS_OP_T, dim, rows, &alpha, matrix, dim, query, 1, &beta, out, 1);
+}
+static cublasStatus_t gd_sgemm_t(cublasHandle_t h, int dim, int rows, const float *matrix, const float *query, float *out) {
+    const float alpha = 1.0f;
+    const float beta = 0.0f;
+    return cublasSgemm(h, CUBLAS_OP_T, CUBLAS_OP_N, 1, rows, dim, &alpha, query, dim, matrix, dim, &beta, out, 1);
+}
+*/
+import "C"
+
+import (
+	"fmt"
+	"unsafe"
+)
+
+type cudaHandle = C.cublasHandle_t
+
+func cudaDeviceCount() (int, error) {
+	var n C.int
+	if err := C.gd_device_count(&n); err != C.cudaSuccess {
+		return 0, fmt.Errorf("cudaGetDeviceCount: %s", C.GoString(C.gd_cuda_err(err)))
+	}
+	return int(n), nil
+}
+
+func cudaCreate() (cudaHandle, error) {
+	var h C.cublasHandle_t
+	if st := C.gd_create(&h); st != C.CUBLAS_STATUS_SUCCESS {
+		return nil, fmt.Errorf("cublasCreate: %s", C.GoString(C.gd_cublas_err(st)))
+	}
+	return h, nil
+}
+
+func cudaDestroy(h cudaHandle) error {
+	if st := C.gd_destroy(h); st != C.CUBLAS_STATUS_SUCCESS {
+		return fmt.Errorf("cublasDestroy: %s", C.GoString(C.gd_cublas_err(st)))
+	}
+	return nil
+}
+
+func cudaMallocRaw(bytes int) (unsafe.Pointer, error) {
+	var p unsafe.Pointer
+	if err := C.gd_malloc(&p, C.size_t(bytes)); err != C.cudaSuccess {
+		return nil, fmt.Errorf("cudaMalloc(%d): %s", bytes, C.GoString(C.gd_cuda_err(err)))
+	}
+	return p, nil
+}
+
+func cudaFreeRaw(p unsafe.Pointer) error {
+	if err := C.gd_free(p); err != C.cudaSuccess {
+		return fmt.Errorf("cudaFree: %s", C.GoString(C.gd_cuda_err(err)))
+	}
+	return nil
+}
+
+func cudaH2DRaw(dst unsafe.Pointer, src []float32) error {
+	if len(src) == 0 {
+		return nil
+	}
+	if err := C.gd_h2d(dst, unsafe.Pointer(&src[0]), C.size_t(len(src)*4)); err != C.cudaSuccess {
+		return fmt.Errorf("cudaMemcpy H2D: %s", C.GoString(C.gd_cuda_err(err)))
+	}
+	return nil
+}
+
+func cudaD2HRaw(dst []float32, src unsafe.Pointer) error {
+	if len(dst) == 0 {
+		return nil
+	}
+	if err := C.gd_d2h(unsafe.Pointer(&dst[0]), src, C.size_t(len(dst)*4)); err != C.cudaSuccess {
+		return fmt.Errorf("cudaMemcpy D2H: %s", C.GoString(C.gd_cuda_err(err)))
+	}
+	return nil
+}
+
+func cudaSyncRaw() error {
+	if err := C.gd_sync(); err != C.cudaSuccess {
+		return fmt.Errorf("cudaDeviceSynchronize: %s", C.GoString(C.gd_cuda_err(err)))
+	}
+	return nil
+}
+
+func cudaSgemvT(h cudaHandle, dim, rows int, matrix, query, out unsafe.Pointer) error {
+	if st := C.gd_sgemv_t(h, C.int(dim), C.int(rows), (*C.float)(matrix), (*C.float)(query), (*C.float)(out)); st != C.CUBLAS_STATUS_SUCCESS {
+		return fmt.Errorf("cublasSgemv: %s", C.GoString(C.gd_cublas_err(st)))
+	}
+	return nil
+}
+
+func cudaSgemmT(h cudaHandle, dim, rows int, matrix, query, out unsafe.Pointer) error {
+	if st := C.gd_sgemm_t(h, C.int(dim), C.int(rows), (*C.float)(matrix), (*C.float)(query), (*C.float)(out)); st != C.CUBLAS_STATUS_SUCCESS {
+		return fmt.Errorf("cublasSgemm: %s", C.GoString(C.gd_cublas_err(st)))
+	}
+	return nil
+}

--- a/benchmarks/gpu_dot_tournament/go.mod
+++ b/benchmarks/gpu_dot_tournament/go.mod
@@ -1,0 +1,7 @@
+module github.com/snissn/gomap/benchmarks/gpu_dot_tournament
+
+go 1.25
+
+require github.com/tphakala/simd v1.0.22
+
+require golang.org/x/sys v0.38.0 // indirect

--- a/benchmarks/gpu_dot_tournament/go.sum
+++ b/benchmarks/gpu_dot_tournament/go.sum
@@ -1,0 +1,12 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/tphakala/simd v1.0.22 h1:3wHL91t4yvhCB0ycyTznvucTHax+QGpYkvOhqfraTYw=
+github.com/tphakala/simd v1.0.22/go.mod h1:8xsPUbOTnNI4WUdPlXVlWXt85Y8RCm3xqGAo8PLxYyA=
+golang.org/x/sys v0.38.0 h1:3yZWxaJjBmCWXqhN1qh02AkOnCQ1poK6oF+a7xWL6Gc=
+golang.org/x/sys v0.38.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
## Summary
- add standalone `benchmarks/gpu_dot_tournament` module for TreeDB-shaped 768d dot-product tournaments
- include CPU `tphakala/simd` baseline plus CUDA/cuBLAS candidates behind a `cuda` build tag
- CUDA candidates cover device-resident SGEMV, query-upload SGEMV, and skinny SGEMM
- document local CPU and CUDA performance evidence plus TreeDB native graph estimates

## Local CUDA note
The system libraries were mismatched (`nvidia-smi` saw 535.309 user-space vs 535.288 kernel module). I extracted matching 535.288 user-space libs under `/tmp/nvidia_535_288_libs` and ran CUDA with:

```sh
LD_LIBRARY_PATH=/tmp/nvidia_535_288_libs/extract/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH
```

## Performance evidence
Local host: 11th Gen Intel i5-11400F + RTX 3060 Ti.

CPU baseline:

```text
rows=128:    ~4.0 us/op      (~31M dots/sec)
rows=1024:   ~45-52 us/op    (~20-23M dots/sec)
rows=8192:   ~0.93-1.01 ms   (~8-9M dots/sec)
rows=65536:  ~8.1-8.2 ms     (~8M dots/sec)
```

CUDA/cuBLAS:

```text
rows=128:    device-resident SGEMV/GEMM ~3.4-3.5 us/op   (~36-38M dots/sec)
             upload-query SGEMV         ~20 us/op        (~6M dots/sec)
rows=1024:   device-resident SGEMV/GEMM ~10.2-10.3 us/op (~99-100M dots/sec)
             upload-query SGEMV         ~22 us/op        (~46M dots/sec)
rows=8192:   device-resident SGEMV/GEMM ~65 us/op        (~125M dots/sec)
             upload-query SGEMV         ~86 us/op        (~95M dots/sec)
rows=65536:  device-resident SGEMV/GEMM ~0.50 ms/op      (~128-131M dots/sec)
             upload-query SGEMV         ~0.55 ms/op      (~119M dots/sec)
```

Clear GPU win: large device-resident batches. At 65,536 rows, CUDA is ~16x faster than CPU (~0.50ms vs ~8ms). Small batches are launch/library-overhead dominated; per-query upload/download can lose to CPU.

## TreeDB in-memory graph estimate
Prior native in-memory no-doc HNSW at 100k docs / 768 dims / ef_search=128 measured ~0.83-0.92 ms/search (~1.1k-1.2k searches/sec), with ~63% CPU in dot products. If graph scoring can be batched into device-resident row groups and approach ~125-131M 768d dots/sec, a ~2k-dot search has a ~15-16 us dot-stage ceiling; end-to-end will then be dominated by CPU frontier traversal and GPU scheduling/transfers unless those are batched too.

## Tests
- `cd benchmarks/gpu_dot_tournament && GOWORK=off go test ./...`
- `cd benchmarks/gpu_dot_tournament && GOWORK=off go test -run '^$' -bench 'BenchmarkDotTournamentCPU' -benchmem -count=3`\n- `cd benchmarks/gpu_dot_tournament && LD_LIBRARY_PATH=/tmp/nvidia_535_288_libs/extract/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH GOWORK=off go test -tags cuda -run '^$' -bench 'BenchmarkDotTournament(CPU|CUDA)' -benchmem -count=3`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation describing CPU vs GPU dot-product benchmarks with performance baselines and guidance on when each approach performs best.

* **Tests**
  * Added CPU benchmark for dot-product operations across multiple data sizes.
  * Added GPU benchmark with multiple kernel variants for performance comparison.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1767?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->