### PR TITLE
treedb: publish scalar typed-column parts

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -18495,6 +18495,11 @@ func (c *Collection) scanDocumentsFuncWithColumnReconstruction(
 	}
 	visibleRows := visible.Rows
 	visiblePos := 0
+	var typedColumnCache map[uint64][]typedColumnAdapterRow
+	if columnStoreHasTypedColumnPartOwners(columnStoreConfig) {
+		typedColumnCache = make(map[uint64][]typedColumnAdapterRow)
+	}
+	manifestRootID := catalog.rootID(collectionColumnManifestRootName(catalog.meta.Name))
 	for _, record := range records {
 		for visiblePos < len(visibleRows) && bytes.Compare(visibleRows[visiblePos].ID, record.ID) < 0 {
 			visiblePos++
@@ -18502,7 +18507,15 @@ func (c *Collection) scanDocumentsFuncWithColumnReconstruction(
 		if visiblePos >= len(visibleRows) || !bytes.Equal(visibleRows[visiblePos].ID, record.ID) {
 			return false, fmt.Errorf("collections: column reconstruction missing visible physical row for id %q", string(record.ID))
 		}
-		reconstructed, err := reconstructColumnDocumentFromVisibleRow(columnStoreConfig, record.Document, visibleRows[visiblePos])
+		typedValues, err := c.typedColumnPartValuesForVisibleRowAtSnapshotWithCache(snap, manifestRootID, columnStoreConfig, visibleRows[visiblePos], typedColumnCache)
+		if err != nil {
+			return false, err
+		}
+		fullValues, err := mergeColumnReconstructionValues(columnStoreConfig, visibleRows[visiblePos].Values, typedValues.Values)
+		if err != nil {
+			return false, err
+		}
+		reconstructed, err := reconstructColumnDocumentFromVisibleRowValues(columnStoreConfig, record.Document, visibleRows[visiblePos], fullValues)
 		if err != nil {
 			return false, err
 		}

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -18495,9 +18495,9 @@ func (c *Collection) scanDocumentsFuncWithColumnReconstruction(
 	}
 	visibleRows := visible.Rows
 	visiblePos := 0
-	var typedColumnCache map[uint64][]typedColumnAdapterRow
+	var typedColumnCache *typedColumnPartReconstructionCache
 	if columnStoreHasTypedColumnPartOwners(columnStoreConfig) {
-		typedColumnCache = make(map[uint64][]typedColumnAdapterRow)
+		typedColumnCache = &typedColumnPartReconstructionCache{Rows: make(map[uint64][]typedColumnAdapterRow)}
 	}
 	manifestRootID := catalog.rootID(collectionColumnManifestRootName(catalog.meta.Name))
 	for _, record := range records {

--- a/TreeDB/collections/column_asset_manager.go
+++ b/TreeDB/collections/column_asset_manager.go
@@ -275,6 +275,10 @@ func writeColumnPhysicalAssetToManager(rootDir string, cfg ColumnStoreConfig, pa
 	return writeColumnAssetToManager(rootDir, cfg, payload, ColumnAssetKindTCS1PartImage, generation, partID)
 }
 
+func writeTypedColumnPartAssetToManager(rootDir string, cfg ColumnStoreConfig, payload []byte, generation, partID uint64) (ColumnAssetRef, error) {
+	return writeColumnAssetToManager(rootDir, cfg, payload, ColumnAssetKindTCS1TypedColumnPart, generation, partID)
+}
+
 func writeColumnAggregateMetadataAssetToManager(rootDir string, cfg ColumnStoreConfig, payload []byte, generation, partID uint64) (ColumnAssetRef, error) {
 	return writeColumnAssetToManager(rootDir, cfg, payload, ColumnAssetKindTCS1AggregateMetadata, generation, partID)
 }
@@ -1102,8 +1106,12 @@ func (c *columnPhysicalAssetReadCache) trackResourceRead(ref ColumnAssetRef, raw
 }
 
 func mappedResourceKeyForColumnAssetRef(ref ColumnAssetRef) mappedresource.Key {
+	class := mappedresource.ClassTypedRowAsset
+	if ref.Kind == ColumnAssetKindTCS1TypedColumnPart {
+		class = mappedresource.ClassTypedColumnAsset
+	}
 	return mappedresource.Key{
-		Class:      mappedresource.ClassTypedRowAsset,
+		Class:      class,
 		Namespace:  ref.Namespace,
 		Kind:       string(ref.Kind),
 		Generation: ref.Generation,

--- a/TreeDB/collections/column_asset_reachability.go
+++ b/TreeDB/collections/column_asset_reachability.go
@@ -1021,7 +1021,7 @@ func columnAssetReachabilitySegmentPath(segmentDir, name string) string {
 }
 
 func columnAssetReachabilityRefCanContributeRange(ref ColumnAssetRef, namespace string) bool {
-	return (ref.Kind == ColumnAssetKindTCS1PartImage || ref.Kind == ColumnAssetKindTCS1AggregateMetadata || ref.Kind == ColumnAssetKindTCS1DictionaryCodes || ref.Kind == ColumnAssetKindTCS1Int64Values) &&
+	return (ref.Kind == ColumnAssetKindTCS1PartImage || ref.Kind == ColumnAssetKindTCS1TypedColumnPart || ref.Kind == ColumnAssetKindTCS1AggregateMetadata || ref.Kind == ColumnAssetKindTCS1DictionaryCodes || ref.Kind == ColumnAssetKindTCS1Int64Values) &&
 		ref.Namespace == namespace &&
 		ref.Generation != 0 &&
 		ref.PartID != 0 &&

--- a/TreeDB/collections/column_asset_reachability.go
+++ b/TreeDB/collections/column_asset_reachability.go
@@ -271,6 +271,19 @@ func (c *Collection) planColumnAssetReachability(ctx context.Context, opts colum
 			input.recoveryRefs++
 		}
 	}
+	for i, typedPartRef := range view.TypedColumnPartRefs {
+		if i%columnAssetReachabilityContextCheckInterval == 0 {
+			if err := ctx.Err(); err != nil {
+				return columnAssetReachabilityPlanIdentity(input), input.refs, err
+			}
+		}
+		if input.addRef(typedPartRef.Ref, ColumnAssetReachabilitySourceActiveManifest) {
+			input.activeRefs++
+		}
+		if input.addRef(typedPartRef.Ref, ColumnAssetReachabilitySourceRecoveryManifest) {
+			input.recoveryRefs++
+		}
+	}
 	for i, metadataRef := range view.AggregateMetadata {
 		if i%columnAssetReachabilityContextCheckInterval == 0 {
 			if err := ctx.Err(); err != nil {
@@ -355,7 +368,7 @@ func (c *Collection) columnAssetReachabilityOlderSnapshotPinned(planCommitSeq ui
 }
 
 func columnAssetReachabilityInputFromSnapshotView(view columnPhysicalScanSnapshotView, opts columnAssetReachabilityOptionsInternal) columnAssetReachabilityInput {
-	expectedRefs := len(view.AssetRefs) + len(view.AggregateMetadata) + len(view.DictionaryCodes) + len(view.Int64Values) + len(view.GraphAssetRefs) + len(opts.CandidateRefs) + len(opts.PendingRefs) + len(opts.PreparedRefs) + len(opts.PinnedRefs)
+	expectedRefs := len(view.AssetRefs) + len(view.TypedColumnPartRefs) + len(view.AggregateMetadata) + len(view.DictionaryCodes) + len(view.Int64Values) + len(view.GraphAssetRefs) + len(opts.CandidateRefs) + len(opts.PendingRefs) + len(opts.PreparedRefs) + len(opts.PinnedRefs)
 	input := columnAssetReachabilityInput{
 		rootDir:        view.ColumnAssetRootDir,
 		collection:     view.CollectionName,

--- a/TreeDB/collections/column_asset_rewrite.go
+++ b/TreeDB/collections/column_asset_rewrite.go
@@ -444,8 +444,8 @@ func cleanupColumnAssetRewriteCopiedSegment(rootDir string, remap columnAssetRew
 
 func validateColumnAssetRewriteRefKinds(refs []ColumnAssetRef) error {
 	for idx, ref := range refs {
-		if ref.Kind != ColumnAssetKindTCS1PartImage && ref.Kind != ColumnAssetKindTCS1AggregateMetadata && ref.Kind != ColumnAssetKindTCS1DictionaryCodes && ref.Kind != ColumnAssetKindTCS1Int64Values {
-			return fmt.Errorf("collections: column asset rewrite supports only physical part, aggregate metadata, dictionary code, or int64 value refs: ref %d kind %q", idx, ref.Kind)
+		if ref.Kind != ColumnAssetKindTCS1PartImage && ref.Kind != ColumnAssetKindTCS1TypedColumnPart && ref.Kind != ColumnAssetKindTCS1AggregateMetadata && ref.Kind != ColumnAssetKindTCS1DictionaryCodes && ref.Kind != ColumnAssetKindTCS1Int64Values {
+			return fmt.Errorf("collections: column asset rewrite supports only physical part, typed-column part, aggregate metadata, dictionary code, or int64 value refs: ref %d kind %q", idx, ref.Kind)
 		}
 	}
 	return nil
@@ -603,7 +603,7 @@ func columnAssetRewriteManifestPartRefForPatch(raw []byte, expectedNamespace str
 		return ColumnAssetRef{}, columnAssetRewriteManifestPartPatchOffsets{}, errors.New("collections: trailing bytes in column manifest part record")
 	}
 	kind := ColumnAssetKind(string(kindBytes))
-	if kind != ColumnAssetKindTCS1PartImage && kind != ColumnAssetKindTCS1AggregateMetadata && kind != ColumnAssetKindTCS1DictionaryCodes && kind != ColumnAssetKindTCS1Int64Values {
+	if kind != ColumnAssetKindTCS1PartImage && kind != ColumnAssetKindTCS1TypedColumnPart && kind != ColumnAssetKindTCS1AggregateMetadata && kind != ColumnAssetKindTCS1DictionaryCodes && kind != ColumnAssetKindTCS1Int64Values {
 		return ColumnAssetRef{}, columnAssetRewriteManifestPartPatchOffsets{}, fmt.Errorf("collections: unsupported column manifest part asset kind %q", string(kindBytes))
 	}
 	if !columnPhysicalBytesEqualString(namespaceBytes, expectedNamespace) {

--- a/TreeDB/collections/column_manifest_format.go
+++ b/TreeDB/collections/column_manifest_format.go
@@ -329,7 +329,7 @@ func encodeColumnManifestHeaderRecord(input ColumnPublishManifestEncodeInput, ge
 func columnManifestPreparedPartCount(assets []ColumnPreparedAsset) int {
 	count := 0
 	for _, asset := range assets {
-		if asset.Ref.Kind == ColumnAssetKindTCS1PartImage {
+		if asset.Ref.Kind == ColumnAssetKindTCS1PartImage || asset.Ref.Kind == ColumnAssetKindTCS1TypedColumnPart {
 			count++
 		}
 	}

--- a/TreeDB/collections/column_physical_asset.go
+++ b/TreeDB/collections/column_physical_asset.go
@@ -529,6 +529,7 @@ func decodeColumnPhysicalAsset(raw []byte) (columnPhysicalAsset, error) {
 }
 
 func validateColumnPhysicalAssetForManifest(raw []byte, ref ColumnAssetRef, cfg ColumnStoreConfig) error {
+	cfg = columnStoreRowAssetConfig(cfg)
 	if err := validateColumnAssetRefForPlan(ref); err != nil {
 		return err
 	}

--- a/TreeDB/collections/column_physical_asset.go
+++ b/TreeDB/collections/column_physical_asset.go
@@ -528,6 +528,27 @@ func decodeColumnPhysicalAsset(raw []byte) (columnPhysicalAsset, error) {
 	return asset, nil
 }
 
+func columnPhysicalAssetColumnMatchesManifestConfig(got, want ColumnStoreColumn) (bool, error) {
+	gotOwner, err := columnStoreColumnOwner(got)
+	if err != nil {
+		return false, fmt.Errorf("decoded owner: %w", err)
+	}
+	wantOwner, err := columnStoreColumnOwner(want)
+	if err != nil {
+		return false, fmt.Errorf("manifest owner: %w", err)
+	}
+	if gotOwner != TypedStorageOwnerRowAsset || wantOwner != TypedStorageOwnerRowAsset {
+		return false, nil
+	}
+	// TCPA row assets predate typed-storage owner metadata and do not encode an
+	// owner field. Treat the legacy zero owner and explicit typed_row_asset owner
+	// as the same physical schema while still requiring all encoded fields to
+	// match exactly.
+	got.Owner = ""
+	want.Owner = ""
+	return got == want, nil
+}
+
 func validateColumnPhysicalAssetForManifest(raw []byte, ref ColumnAssetRef, cfg ColumnStoreConfig) error {
 	cfg = columnStoreRowAssetConfig(cfg)
 	if err := validateColumnAssetRefForPlan(ref); err != nil {
@@ -562,7 +583,11 @@ func validateColumnPhysicalAssetForManifest(raw []byte, ref ColumnAssetRef, cfg 
 		return fmt.Errorf("collections: column physical asset columns=%d want %d", len(asset.Columns), len(cfg.Columns))
 	}
 	for i := range cfg.Columns {
-		if asset.Columns[i] != cfg.Columns[i] {
+		match, err := columnPhysicalAssetColumnMatchesManifestConfig(asset.Columns[i], cfg.Columns[i])
+		if err != nil {
+			return fmt.Errorf("collections: column physical asset column[%d]: %w", i, err)
+		}
+		if !match {
 			return fmt.Errorf("collections: column physical asset column[%d]=%+v want %+v", i, asset.Columns[i], cfg.Columns[i])
 		}
 	}

--- a/TreeDB/collections/column_physical_asset_test.go
+++ b/TreeDB/collections/column_physical_asset_test.go
@@ -141,6 +141,14 @@ func TestColumnPhysicalAssetCodecRoundTripM12A(t *testing.T) {
 	if err := validateColumnPhysicalAssetForManifest(encoded, ref, *normalized); err != nil {
 		t.Fatalf("validateColumnPhysicalAssetForManifest: %v", err)
 	}
+	explicitRowOwner := *normalized
+	explicitRowOwner.Columns = append([]ColumnStoreColumn(nil), normalized.Columns...)
+	for i := range explicitRowOwner.Columns {
+		explicitRowOwner.Columns[i].Owner = TypedStorageOwnerRowAsset
+	}
+	if err := validateColumnPhysicalAssetForManifest(encoded, ref, explicitRowOwner); err != nil {
+		t.Fatalf("validateColumnPhysicalAssetForManifest explicit typed_row_asset owner: %v", err)
+	}
 	wrongSchema := *normalized
 	wrongSchema.Columns = append([]ColumnStoreColumn(nil), normalized.Columns...)
 	wrongSchema.Columns[0].Path = "wrong_time_us"

--- a/TreeDB/collections/column_physical_scan.go
+++ b/TreeDB/collections/column_physical_scan.go
@@ -1308,7 +1308,7 @@ func decodeColumnManifestSnapshotViewForScan(records []columnManifestRecord, exp
 		if err != nil {
 			return columnManifestSnapshot{}, nil, 0, err
 		}
-		if ref.Kind != ColumnAssetKindTCS1PartImage {
+		if ref.Kind != ColumnAssetKindTCS1PartImage && ref.Kind != ColumnAssetKindTCS1TypedColumnPart {
 			return columnManifestSnapshot{}, nil, 0, fmt.Errorf("collections: unsupported column manifest part asset kind %q", ref.Kind)
 		}
 		if ref.Generation != keyGeneration {
@@ -1321,13 +1321,15 @@ func decodeColumnManifestSnapshotViewForScan(records []columnManifestRecord, exp
 		if !ok {
 			return columnManifestSnapshot{}, nil, 0, fmt.Errorf("collections: unsupported column manifest part reason %q", string(reason))
 		}
-		livePartRows.add(ref.Generation, ref.PartID, rows)
-		refs = append(refs, columnManifestAssetRefForScan{Ref: ref, Reason: operation, Rows: rows})
+		if ref.Kind == ColumnAssetKindTCS1PartImage {
+			livePartRows.add(ref.Generation, ref.PartID, rows)
+			refs = append(refs, columnManifestAssetRefForScan{Ref: ref, Reason: operation, Rows: rows})
+			if operation != ColumnPublishOperationInsert {
+				mutationParts++
+			}
+		}
 		if ref.Generation == snapshot.Generation {
 			activeParts++
-		}
-		if operation != ColumnPublishOperationInsert {
-			mutationParts++
 		}
 	}
 	for _, record := range records {

--- a/TreeDB/collections/column_physical_scan.go
+++ b/TreeDB/collections/column_physical_scan.go
@@ -199,20 +199,21 @@ func columnManifestScanPartPreallocCapacity(expectedParts uint64) int {
 }
 
 type columnPhysicalScanSnapshotView struct {
-	CollectionName     string
-	Catalog            *collectionCatalog
-	Config             ColumnStoreConfig
-	ColumnStoreEnabled bool
-	CommitSeq          uint64
-	AssetRefs          []columnManifestAssetRefForScan
-	AggregateMetadata  []columnManifestAggregateMetadataSnapshot
-	DictionaryCodes    []columnManifestDictionaryCodesSnapshot
-	Int64Values        []columnManifestInt64ValuesSnapshot
-	GraphAssetRefs     []ColumnAssetRef
-	MutationParts      int
-	Diagnostics        columnPhysicalScanDiagnostics
-	ColumnAssetRootDir string
-	AssetNamespace     string
+	CollectionName      string
+	Catalog             *collectionCatalog
+	Config              ColumnStoreConfig
+	ColumnStoreEnabled  bool
+	CommitSeq           uint64
+	AssetRefs           []columnManifestAssetRefForScan
+	TypedColumnPartRefs []columnManifestAssetRefForScan
+	AggregateMetadata   []columnManifestAggregateMetadataSnapshot
+	DictionaryCodes     []columnManifestDictionaryCodesSnapshot
+	Int64Values         []columnManifestInt64ValuesSnapshot
+	GraphAssetRefs      []ColumnAssetRef
+	MutationParts       int
+	Diagnostics         columnPhysicalScanDiagnostics
+	ColumnAssetRootDir  string
+	AssetNamespace      string
 }
 
 var errColumnPhysicalAssetManifestOperationMismatch = errors.New("collections: column physical asset operation does not match manifest reason")
@@ -386,7 +387,7 @@ func (c *Collection) prepareColumnPhysicalScanSnapshotViewAtSnapshotWithSidecars
 		view.Diagnostics = diag
 		return view, err
 	}
-	manifest, refs, graphRefs, mutationParts, manifestRecords, err := loadColumnManifestSnapshotViewForScanFromRootWithSidecars(snap, rootID, rowAssetConfig, *cfg.ActiveManifest, collectionName, filter, true, catalog.meta.VectorIndexes)
+	manifest, refs, typedColumnPartRefs, graphRefs, mutationParts, manifestRecords, err := loadColumnManifestSnapshotViewForScanFromRootWithSidecars(snap, rootID, rowAssetConfig, *cfg.ActiveManifest, collectionName, filter, true, catalog.meta.VectorIndexes)
 	if err != nil {
 		diag.ManifestRecords = manifestRecords
 		view.Diagnostics = diag
@@ -396,6 +397,7 @@ func (c *Collection) prepareColumnPhysicalScanSnapshotViewAtSnapshotWithSidecars
 	diag.AssetRefs = len(refs)
 	diag.MutationParts = mutationParts
 	view.AssetRefs = refs
+	view.TypedColumnPartRefs = typedColumnPartRefs
 	view.AggregateMetadata = manifest.AggregateMetadata
 	view.DictionaryCodes = manifest.DictionaryCodes
 	view.Int64Values = manifest.Int64Values
@@ -583,13 +585,14 @@ func loadColumnManifestRecordsFromRoot(snap *backenddb.Snapshot, rootID uint64) 
 }
 
 func loadColumnManifestSnapshotViewForScanFromRoot(snap *backenddb.Snapshot, rootID uint64, cfg ColumnStoreConfig, identity ColumnManifestIdentity, collection string, activeVectorIndexesKnown bool, activeVectorIndexes []VectorIndexDefinition) (columnManifestSnapshot, []columnManifestAssetRefForScan, []ColumnAssetRef, int, int, error) {
-	return loadColumnManifestSnapshotViewForScanFromRootWithSidecars(snap, rootID, cfg, identity, collection, columnManifestScanAllSidecars(), activeVectorIndexesKnown, activeVectorIndexes)
+	manifest, refs, _, graphRefs, mutationParts, manifestRecords, err := loadColumnManifestSnapshotViewForScanFromRootWithSidecars(snap, rootID, cfg, identity, collection, columnManifestScanAllSidecars(), activeVectorIndexesKnown, activeVectorIndexes)
+	return manifest, refs, graphRefs, mutationParts, manifestRecords, err
 }
 
-func loadColumnManifestSnapshotViewForScanFromRootWithSidecars(snap *backenddb.Snapshot, rootID uint64, cfg ColumnStoreConfig, identity ColumnManifestIdentity, collection string, filter columnManifestScanSidecarFilter, activeVectorIndexesKnown bool, activeVectorIndexes []VectorIndexDefinition) (columnManifestSnapshot, []columnManifestAssetRefForScan, []ColumnAssetRef, int, int, error) {
+func loadColumnManifestSnapshotViewForScanFromRootWithSidecars(snap *backenddb.Snapshot, rootID uint64, cfg ColumnStoreConfig, identity ColumnManifestIdentity, collection string, filter columnManifestScanSidecarFilter, activeVectorIndexesKnown bool, activeVectorIndexes []VectorIndexDefinition) (columnManifestSnapshot, []columnManifestAssetRefForScan, []columnManifestAssetRefForScan, []ColumnAssetRef, int, int, error) {
 	iter, err := snap.IteratorAtRoot(rootID, columnManifestHeaderRecordKeyBytes, nil)
 	if err != nil {
-		return columnManifestSnapshot{}, nil, nil, 0, 0, fmt.Errorf("collections: column manifest root %d unreadable: %w", rootID, err)
+		return columnManifestSnapshot{}, nil, nil, nil, 0, 0, fmt.Errorf("collections: column manifest root %d unreadable: %w", rootID, err)
 	}
 	defer func() { _ = iter.Close() }()
 
@@ -601,6 +604,7 @@ func loadColumnManifestSnapshotViewForScanFromRootWithSidecars(snap *backenddb.S
 	manifestRecords := 0
 	mutationParts := 0
 	var refs []columnManifestAssetRefForScan
+	var typedColumnPartRefs []columnManifestAssetRefForScan
 	var graphRefs []ColumnAssetRef
 	var livePartRows columnManifestLivePartRowsForScan
 	for iter.Valid() {
@@ -614,21 +618,21 @@ func loadColumnManifestSnapshotViewForScanFromRootWithSidecars(snap *backenddb.S
 		}
 		value, _, flags := iter.UnsafeEntry()
 		if flags&node.FlagPointer != 0 {
-			return columnManifestSnapshot{}, nil, nil, 0, manifestRecords, fmt.Errorf("collections: column manifest record %q must be inline", key)
+			return columnManifestSnapshot{}, nil, nil, nil, 0, manifestRecords, fmt.Errorf("collections: column manifest record %q must be inline", key)
 		}
 		manifestRecords++
 
 		switch {
 		case bytes.Equal(key, columnManifestHeaderRecordKeyBytes):
 			if sawHeader {
-				return columnManifestSnapshot{}, nil, nil, 0, manifestRecords, errors.New("collections: duplicate column manifest binary header record")
+				return columnManifestSnapshot{}, nil, nil, nil, 0, manifestRecords, errors.New("collections: duplicate column manifest binary header record")
 			}
 			header, err := decodeColumnManifestHeaderRecordForScan(value)
 			if err != nil {
-				return columnManifestSnapshot{}, nil, nil, 0, manifestRecords, err
+				return columnManifestSnapshot{}, nil, nil, nil, 0, manifestRecords, err
 			}
 			if err := validateColumnManifestHeaderRecordForScan(header, cfg, identity, collection); err != nil {
-				return columnManifestSnapshot{}, nil, nil, 0, manifestRecords, err
+				return columnManifestSnapshot{}, nil, nil, nil, 0, manifestRecords, err
 			}
 			operation, _ := columnPhysicalScanOperationFromBytes(header.operation)
 			snapshot = columnManifestSnapshot{
@@ -677,27 +681,27 @@ func loadColumnManifestSnapshotViewForScanFromRootWithSidecars(snap *backenddb.S
 			}
 			keyGeneration, keyPartID, err := columnManifestPartKeyFromRecordKeyForScan(key)
 			if err != nil {
-				return columnManifestSnapshot{}, nil, nil, 0, manifestRecords, err
+				return columnManifestSnapshot{}, nil, nil, nil, 0, manifestRecords, err
 			}
 			if keyGeneration > snapshot.Generation {
-				return columnManifestSnapshot{}, nil, nil, 0, manifestRecords, fmt.Errorf("collections: column manifest part generation=%d is newer than header generation=%d", keyGeneration, snapshot.Generation)
+				return columnManifestSnapshot{}, nil, nil, nil, 0, manifestRecords, fmt.Errorf("collections: column manifest part generation=%d is newer than header generation=%d", keyGeneration, snapshot.Generation)
 			}
 			ref, rows, _, _, _, reason, err := decodeColumnManifestPartFieldsForScan(value, cfg.AssetManager.Namespace)
 			if err != nil {
-				return columnManifestSnapshot{}, nil, nil, 0, manifestRecords, err
+				return columnManifestSnapshot{}, nil, nil, nil, 0, manifestRecords, err
 			}
 			if ref.Kind != ColumnAssetKindTCS1PartImage && ref.Kind != ColumnAssetKindTCS1TypedColumnPart {
-				return columnManifestSnapshot{}, nil, nil, 0, manifestRecords, fmt.Errorf("collections: unsupported column manifest part asset kind %q", ref.Kind)
+				return columnManifestSnapshot{}, nil, nil, nil, 0, manifestRecords, fmt.Errorf("collections: unsupported column manifest part asset kind %q", ref.Kind)
 			}
 			if ref.Generation != keyGeneration {
-				return columnManifestSnapshot{}, nil, nil, 0, manifestRecords, fmt.Errorf("collections: column manifest part key generation=%d does not match ref generation=%d", keyGeneration, ref.Generation)
+				return columnManifestSnapshot{}, nil, nil, nil, 0, manifestRecords, fmt.Errorf("collections: column manifest part key generation=%d does not match ref generation=%d", keyGeneration, ref.Generation)
 			}
 			if ref.PartID != keyPartID {
-				return columnManifestSnapshot{}, nil, nil, 0, manifestRecords, fmt.Errorf("collections: column manifest part key part_id=%d does not match ref part_id=%d", keyPartID, ref.PartID)
+				return columnManifestSnapshot{}, nil, nil, nil, 0, manifestRecords, fmt.Errorf("collections: column manifest part key part_id=%d does not match ref part_id=%d", keyPartID, ref.PartID)
 			}
 			operation, ok := columnPhysicalScanOperationFromBytes(reason)
 			if !ok {
-				return columnManifestSnapshot{}, nil, nil, 0, manifestRecords, fmt.Errorf("collections: unsupported column manifest part reason %q", string(reason))
+				return columnManifestSnapshot{}, nil, nil, nil, 0, manifestRecords, fmt.Errorf("collections: unsupported column manifest part reason %q", string(reason))
 			}
 			if ref.Kind == ColumnAssetKindTCS1PartImage {
 				livePartRows.add(ref.Generation, ref.PartID, rows)
@@ -705,6 +709,8 @@ func loadColumnManifestSnapshotViewForScanFromRootWithSidecars(snap *backenddb.S
 				if operation != ColumnPublishOperationInsert {
 					mutationParts++
 				}
+			} else {
+				typedColumnPartRefs = append(typedColumnPartRefs, columnManifestAssetRefForScan{Ref: ref, Reason: operation, Rows: rows})
 			}
 			if ref.Generation == snapshot.Generation {
 				activeParts++
@@ -718,12 +724,12 @@ func loadColumnManifestSnapshotViewForScanFromRootWithSidecars(snap *backenddb.S
 			}
 			_, _, name, err := columnManifestAggregateMetadataKeyPartsFromRecordKey(key)
 			if err != nil {
-				return columnManifestSnapshot{}, nil, nil, 0, manifestRecords, err
+				return columnManifestSnapshot{}, nil, nil, nil, 0, manifestRecords, err
 			}
 			preferredName, include := filter.aggregateMetadataNameForScan(name)
 			if !include {
 				if err := validateColumnManifestAggregateMetadataRecordForScan(key, value, cfg.AssetManager.Namespace, snapshot.Generation, &livePartRows); err != nil {
-					return columnManifestSnapshot{}, nil, nil, 0, manifestRecords, err
+					return columnManifestSnapshot{}, nil, nil, nil, 0, manifestRecords, err
 				}
 				writeHashBytes(&d, key)
 				writeHashBytes(&d, value)
@@ -731,7 +737,7 @@ func loadColumnManifestSnapshotViewForScanFromRootWithSidecars(snap *backenddb.S
 			}
 			aggregate, err := decodeColumnManifestAggregateMetadataRecordForScan(key, value, cfg.AssetManager.Namespace, snapshot.Generation, &livePartRows, preferredName)
 			if err != nil {
-				return columnManifestSnapshot{}, nil, nil, 0, manifestRecords, err
+				return columnManifestSnapshot{}, nil, nil, nil, 0, manifestRecords, err
 			}
 			snapshot.AggregateMetadata = append(snapshot.AggregateMetadata, aggregate)
 			writeHashBytes(&d, key)
@@ -743,12 +749,12 @@ func loadColumnManifestSnapshotViewForScanFromRootWithSidecars(snap *backenddb.S
 			}
 			_, _, columnName, err := columnManifestDictionaryCodesKeyPartsFromRecordKey(key)
 			if err != nil {
-				return columnManifestSnapshot{}, nil, nil, 0, manifestRecords, err
+				return columnManifestSnapshot{}, nil, nil, nil, 0, manifestRecords, err
 			}
 			preferredColumnName, include := filter.dictionaryColumnNameForScan(columnName)
 			if !include {
 				if err := validateColumnManifestDictionaryCodesRecordForScan(key, value, cfg.AssetManager.Namespace, snapshot.Generation, &livePartRows); err != nil {
-					return columnManifestSnapshot{}, nil, nil, 0, manifestRecords, err
+					return columnManifestSnapshot{}, nil, nil, nil, 0, manifestRecords, err
 				}
 				writeHashBytes(&d, key)
 				writeHashBytes(&d, value)
@@ -756,7 +762,7 @@ func loadColumnManifestSnapshotViewForScanFromRootWithSidecars(snap *backenddb.S
 			}
 			dictionary, err := decodeColumnManifestDictionaryCodesRecordForScan(key, value, cfg.AssetManager.Namespace, snapshot.Generation, &livePartRows, preferredColumnName)
 			if err != nil {
-				return columnManifestSnapshot{}, nil, nil, 0, manifestRecords, err
+				return columnManifestSnapshot{}, nil, nil, nil, 0, manifestRecords, err
 			}
 			snapshot.DictionaryCodes = append(snapshot.DictionaryCodes, dictionary)
 			writeHashBytes(&d, key)
@@ -768,12 +774,12 @@ func loadColumnManifestSnapshotViewForScanFromRootWithSidecars(snap *backenddb.S
 			}
 			_, _, columnName, err := columnManifestInt64ValuesKeyPartsFromRecordKey(key)
 			if err != nil {
-				return columnManifestSnapshot{}, nil, nil, 0, manifestRecords, err
+				return columnManifestSnapshot{}, nil, nil, nil, 0, manifestRecords, err
 			}
 			preferredColumnName, include := filter.int64ColumnNameForScan(columnName)
 			if !include {
 				if err := validateColumnManifestInt64ValuesRecordForScan(key, value, cfg.AssetManager.Namespace, snapshot.Generation, &livePartRows); err != nil {
-					return columnManifestSnapshot{}, nil, nil, 0, manifestRecords, err
+					return columnManifestSnapshot{}, nil, nil, nil, 0, manifestRecords, err
 				}
 				writeHashBytes(&d, key)
 				writeHashBytes(&d, value)
@@ -781,7 +787,7 @@ func loadColumnManifestSnapshotViewForScanFromRootWithSidecars(snap *backenddb.S
 			}
 			values, err := decodeColumnManifestInt64ValuesRecordForScan(key, value, cfg.AssetManager.Namespace, snapshot.Generation, &livePartRows, preferredColumnName)
 			if err != nil {
-				return columnManifestSnapshot{}, nil, nil, 0, manifestRecords, err
+				return columnManifestSnapshot{}, nil, nil, nil, 0, manifestRecords, err
 			}
 			snapshot.Int64Values = append(snapshot.Int64Values, values)
 			writeHashBytes(&d, key)
@@ -794,22 +800,22 @@ func loadColumnManifestSnapshotViewForScanFromRootWithSidecars(snap *backenddb.S
 			if retainColumnManifestVectorGraphRecordForWrite(key, activeVectorIndexesKnown, activeVectorIndexes) {
 				graph, err := decodeColumnVectorGraphManifestRecord(value)
 				if err != nil {
-					return columnManifestSnapshot{}, nil, nil, 0, manifestRecords, err
+					return columnManifestSnapshot{}, nil, nil, nil, 0, manifestRecords, err
 				}
 				if graph.AssetRef.Generation > snapshot.Generation {
-					return columnManifestSnapshot{}, nil, nil, 0, manifestRecords, fmt.Errorf("collections: column vector graph asset generation=%d is newer than active manifest generation=%d", graph.AssetRef.Generation, snapshot.Generation)
+					return columnManifestSnapshot{}, nil, nil, nil, 0, manifestRecords, fmt.Errorf("collections: column vector graph asset generation=%d is newer than active manifest generation=%d", graph.AssetRef.Generation, snapshot.Generation)
 				}
 				if graph.BaseManifestGeneration != graph.AssetRef.Generation {
-					return columnManifestSnapshot{}, nil, nil, 0, manifestRecords, fmt.Errorf("collections: column vector graph base manifest generation=%d does not match asset generation=%d", graph.BaseManifestGeneration, graph.AssetRef.Generation)
+					return columnManifestSnapshot{}, nil, nil, nil, 0, manifestRecords, fmt.Errorf("collections: column vector graph base manifest generation=%d does not match asset generation=%d", graph.BaseManifestGeneration, graph.AssetRef.Generation)
 				}
 				if graph.AssetRef.Kind != ColumnAssetKindTCS1PartImage {
-					return columnManifestSnapshot{}, nil, nil, 0, manifestRecords, fmt.Errorf("collections: column vector graph asset kind=%q want %q", graph.AssetRef.Kind, ColumnAssetKindTCS1PartImage)
+					return columnManifestSnapshot{}, nil, nil, nil, 0, manifestRecords, fmt.Errorf("collections: column vector graph asset kind=%q want %q", graph.AssetRef.Kind, ColumnAssetKindTCS1PartImage)
 				}
 				if graph.AssetRef.Namespace != cfg.AssetManager.Namespace {
-					return columnManifestSnapshot{}, nil, nil, 0, manifestRecords, fmt.Errorf("collections: column vector graph asset namespace=%q want %q", graph.AssetRef.Namespace, cfg.AssetManager.Namespace)
+					return columnManifestSnapshot{}, nil, nil, nil, 0, manifestRecords, fmt.Errorf("collections: column vector graph asset namespace=%q want %q", graph.AssetRef.Namespace, cfg.AssetManager.Namespace)
 				}
 				if err := validateColumnAssetRefForPlan(graph.AssetRef); err != nil {
-					return columnManifestSnapshot{}, nil, nil, 0, manifestRecords, err
+					return columnManifestSnapshot{}, nil, nil, nil, 0, manifestRecords, err
 				}
 				graphRefs = append(graphRefs, graph.AssetRef)
 			}
@@ -819,22 +825,22 @@ func loadColumnManifestSnapshotViewForScanFromRootWithSidecars(snap *backenddb.S
 		iter.Next()
 	}
 	if err := iter.Error(); err != nil {
-		return columnManifestSnapshot{}, nil, nil, 0, manifestRecords, err
+		return columnManifestSnapshot{}, nil, nil, nil, 0, manifestRecords, err
 	}
 	if !sawHeader {
-		return columnManifestSnapshot{}, nil, nil, 0, manifestRecords, errors.New("collections: column manifest missing binary header record")
+		return columnManifestSnapshot{}, nil, nil, nil, 0, manifestRecords, errors.New("collections: column manifest missing binary header record")
 	}
 	if activeParts != snapshot.ExpectedParts {
-		return columnManifestSnapshot{}, nil, nil, 0, manifestRecords, fmt.Errorf("collections: invalid column manifest part count=%d want %d", activeParts, snapshot.ExpectedParts)
+		return columnManifestSnapshot{}, nil, nil, nil, 0, manifestRecords, fmt.Errorf("collections: invalid column manifest part count=%d want %d", activeParts, snapshot.ExpectedParts)
 	}
 	checksum := d.Sum64()
 	if checksum == 0 {
 		checksum = 1
 	}
 	if checksum != identity.Checksum {
-		return columnManifestSnapshot{}, nil, nil, 0, manifestRecords, fmt.Errorf("collections: physical column scan manifest checksum=%d want active identity checksum=%d", checksum, identity.Checksum)
+		return columnManifestSnapshot{}, nil, nil, nil, 0, manifestRecords, fmt.Errorf("collections: physical column scan manifest checksum=%d want active identity checksum=%d", checksum, identity.Checksum)
 	}
-	return snapshot, refs, graphRefs, mutationParts, manifestRecords, nil
+	return snapshot, refs, typedColumnPartRefs, graphRefs, mutationParts, manifestRecords, nil
 }
 
 func validateColumnManifestSnapshot(snapshot columnManifestSnapshot, records []columnManifestRecord, cfg ColumnStoreConfig, identity ColumnManifestIdentity, collection string, context string) error {

--- a/TreeDB/collections/column_physical_scan.go
+++ b/TreeDB/collections/column_physical_scan.go
@@ -960,7 +960,7 @@ func loadColumnManifestPlannerCapabilitiesForScan(snap *backenddb.Snapshot, root
 			if err != nil {
 				return columnManifestPlannerCapabilitiesForScan{}, err
 			}
-			if ref.Kind != ColumnAssetKindTCS1PartImage {
+			if ref.Kind != ColumnAssetKindTCS1PartImage && ref.Kind != ColumnAssetKindTCS1TypedColumnPart {
 				return columnManifestPlannerCapabilitiesForScan{}, fmt.Errorf("collections: unsupported column manifest part asset kind %q", ref.Kind)
 			}
 			if ref.Generation != keyGeneration {
@@ -973,23 +973,25 @@ func loadColumnManifestPlannerCapabilitiesForScan(snap *backenddb.Snapshot, root
 			if !ok {
 				return columnManifestPlannerCapabilitiesForScan{}, fmt.Errorf("collections: unsupported column manifest part reason %q", string(reason))
 			}
-			// Capability counts describe the refs a physical scan would read:
-			// all reachable lineage through the active generation. The header
-			// expected-parts check below is generation-local and intentionally
-			// only counts current-generation records.
-			if caps.PhysicalAssetCount == maxCollectionInt {
-				return columnManifestPlannerCapabilitiesForScan{}, errors.New("collections: column manifest physical asset count overflows int")
-			}
-			caps.PhysicalAssetCount++
-			if operation != ColumnPublishOperationInsert {
-				if caps.MutationParts == maxCollectionInt {
-					return columnManifestPlannerCapabilitiesForScan{}, errors.New("collections: column manifest mutation part count overflows int")
+			if ref.Kind == ColumnAssetKindTCS1PartImage {
+				// Capability counts describe the refs a physical scan would read:
+				// all reachable lineage through the active generation. The header
+				// expected-parts check below is generation-local and counts typed-row
+				// locator parts plus typed-column part records.
+				if caps.PhysicalAssetCount == maxCollectionInt {
+					return columnManifestPlannerCapabilitiesForScan{}, errors.New("collections: column manifest physical asset count overflows int")
 				}
-				caps.MutationParts++
+				caps.PhysicalAssetCount++
+				if operation != ColumnPublishOperationInsert {
+					if caps.MutationParts == maxCollectionInt {
+						return columnManifestPlannerCapabilitiesForScan{}, errors.New("collections: column manifest mutation part count overflows int")
+					}
+					caps.MutationParts++
+				}
+				livePartRows.add(ref.Generation, ref.PartID, rows)
 			}
 			writeHashBytes(&d, key)
 			writeHashBytes(&d, value)
-			livePartRows.add(ref.Generation, ref.PartID, rows)
 			if keyGeneration == header.generation {
 				activeParts++
 			}

--- a/TreeDB/collections/column_physical_scan.go
+++ b/TreeDB/collections/column_physical_scan.go
@@ -370,10 +370,11 @@ func (c *Collection) prepareColumnPhysicalScanSnapshotViewAtSnapshotWithSidecars
 		RecoveryManifestGeneration: cfg.RecoveryAuthoritativeManifest.Generation,
 		AppliedCommandLSN:          cfg.RecoveryAuthoritativeAppliedCommandLSN,
 	}
+	rowAssetConfig := columnStoreRowAssetConfig(cfg)
 	view := columnPhysicalScanSnapshotView{
 		CollectionName:     collectionName,
 		Catalog:            catalog,
-		Config:             cfg,
+		Config:             rowAssetConfig,
 		ColumnStoreEnabled: columnStoreEnabled,
 		CommitSeq:          snapshotState.CommitSeq,
 		Diagnostics:        diag,
@@ -385,7 +386,7 @@ func (c *Collection) prepareColumnPhysicalScanSnapshotViewAtSnapshotWithSidecars
 		view.Diagnostics = diag
 		return view, err
 	}
-	manifest, refs, graphRefs, mutationParts, manifestRecords, err := loadColumnManifestSnapshotViewForScanFromRootWithSidecars(snap, rootID, cfg, *cfg.ActiveManifest, collectionName, filter, true, catalog.meta.VectorIndexes)
+	manifest, refs, graphRefs, mutationParts, manifestRecords, err := loadColumnManifestSnapshotViewForScanFromRootWithSidecars(snap, rootID, rowAssetConfig, *cfg.ActiveManifest, collectionName, filter, true, catalog.meta.VectorIndexes)
 	if err != nil {
 		diag.ManifestRecords = manifestRecords
 		view.Diagnostics = diag
@@ -685,7 +686,7 @@ func loadColumnManifestSnapshotViewForScanFromRootWithSidecars(snap *backenddb.S
 			if err != nil {
 				return columnManifestSnapshot{}, nil, nil, 0, manifestRecords, err
 			}
-			if ref.Kind != ColumnAssetKindTCS1PartImage {
+			if ref.Kind != ColumnAssetKindTCS1PartImage && ref.Kind != ColumnAssetKindTCS1TypedColumnPart {
 				return columnManifestSnapshot{}, nil, nil, 0, manifestRecords, fmt.Errorf("collections: unsupported column manifest part asset kind %q", ref.Kind)
 			}
 			if ref.Generation != keyGeneration {
@@ -698,13 +699,15 @@ func loadColumnManifestSnapshotViewForScanFromRootWithSidecars(snap *backenddb.S
 			if !ok {
 				return columnManifestSnapshot{}, nil, nil, 0, manifestRecords, fmt.Errorf("collections: unsupported column manifest part reason %q", string(reason))
 			}
-			livePartRows.add(ref.Generation, ref.PartID, rows)
-			refs = append(refs, columnManifestAssetRefForScan{Ref: ref, Reason: operation, Rows: rows})
+			if ref.Kind == ColumnAssetKindTCS1PartImage {
+				livePartRows.add(ref.Generation, ref.PartID, rows)
+				refs = append(refs, columnManifestAssetRefForScan{Ref: ref, Reason: operation, Rows: rows})
+				if operation != ColumnPublishOperationInsert {
+					mutationParts++
+				}
+			}
 			if ref.Generation == snapshot.Generation {
 				activeParts++
-			}
-			if operation != ColumnPublishOperationInsert {
-				mutationParts++
 			}
 			writeHashBytes(&d, key)
 			writeHashBytes(&d, value)
@@ -1625,6 +1628,9 @@ func columnManifestAssetRefsFromRecordsForScan(records []columnManifestRecord, a
 		if err != nil {
 			return nil, 0, err
 		}
+		if ref.Kind == ColumnAssetKindTCS1TypedColumnPart {
+			continue
+		}
 		if ref.Kind != ColumnAssetKindTCS1PartImage {
 			return nil, 0, fmt.Errorf("collections: unsupported column manifest part asset kind %q", ref.Kind)
 		}
@@ -1733,6 +1739,8 @@ func columnAssetKindFromBytesForScan(raw []byte) (ColumnAssetKind, bool) {
 	switch {
 	case columnPhysicalBytesEqualString(raw, string(ColumnAssetKindTCS1PartImage)):
 		return ColumnAssetKindTCS1PartImage, true
+	case columnPhysicalBytesEqualString(raw, string(ColumnAssetKindTCS1TypedColumnPart)):
+		return ColumnAssetKindTCS1TypedColumnPart, true
 	case columnPhysicalBytesEqualString(raw, string(ColumnAssetKindTCS1AggregateMetadata)):
 		return ColumnAssetKindTCS1AggregateMetadata, true
 	case columnPhysicalBytesEqualString(raw, string(ColumnAssetKindTCS1DictionaryCodes)):

--- a/TreeDB/collections/column_physical_scan_test.go
+++ b/TreeDB/collections/column_physical_scan_test.go
@@ -879,7 +879,7 @@ func TestColumnManifestSnapshotSidecarFilterStillValidatesSkippedRecordsM1634(t 
 	}
 	defer func() { _ = snap.Close() }()
 
-	_, _, _, _, _, err = loadColumnManifestSnapshotViewForScanFromRootWithSidecars(
+	_, _, _, _, _, _, err = loadColumnManifestSnapshotViewForScanFromRootWithSidecars(
 		snap,
 		rootID,
 		*cfg,
@@ -972,7 +972,7 @@ func TestColumnManifestScanRejectsHugeExpectedPartsWithoutPreallocM1634(t *testi
 	if err == nil || !strings.Contains(err.Error(), "invalid column manifest part count=1 want 18446744073709551615") {
 		t.Fatalf("loadColumnManifestPlannerCapabilitiesForScan err=%v want huge part-count mismatch", err)
 	}
-	_, _, _, _, _, err = loadColumnManifestSnapshotViewForScanFromRootWithSidecars(
+	_, _, _, _, _, _, err = loadColumnManifestSnapshotViewForScanFromRootWithSidecars(
 		snap,
 		rootID,
 		*cfg,

--- a/TreeDB/collections/column_publish_plan.go
+++ b/TreeDB/collections/column_publish_plan.go
@@ -38,8 +38,12 @@ const (
 type ColumnAssetKind string
 
 const (
-	// ColumnAssetKindTCS1PartImage references an immutable TCS1 part image.
+	// ColumnAssetKindTCS1PartImage references an immutable typed-row TCS1/TCPA
+	// part image retained for compatibility.
 	ColumnAssetKindTCS1PartImage ColumnAssetKind = "tcs1_part_image"
+	// ColumnAssetKindTCS1TypedColumnPart references an immutable sectioned
+	// typed-column TCS1 part image.
+	ColumnAssetKindTCS1TypedColumnPart ColumnAssetKind = "tcs1_typed_column_part"
 	// ColumnAssetKindTCS1AggregateMetadata references grouped aggregate metadata
 	// stored as a typed column asset beside physical part images.
 	ColumnAssetKindTCS1AggregateMetadata ColumnAssetKind = "tcs1_aggregate_metadata"
@@ -916,7 +920,7 @@ func validateColumnPreparedAssetForPlan(asset ColumnPreparedAsset) error {
 
 func validateColumnAssetRefForPlan(ref ColumnAssetRef) error {
 	switch ref.Kind {
-	case ColumnAssetKindTCS1PartImage, ColumnAssetKindTCS1AggregateMetadata, ColumnAssetKindTCS1DictionaryCodes, ColumnAssetKindTCS1Int64Values:
+	case ColumnAssetKindTCS1PartImage, ColumnAssetKindTCS1TypedColumnPart, ColumnAssetKindTCS1AggregateMetadata, ColumnAssetKindTCS1DictionaryCodes, ColumnAssetKindTCS1Int64Values:
 	default:
 		if ref.Kind == "" {
 			return errors.New("collections: column asset ref kind is required")

--- a/TreeDB/collections/column_publish_write.go
+++ b/TreeDB/collections/column_publish_write.go
@@ -86,7 +86,7 @@ func requireColumnStoreWriteOperationSupported(meta CollectionMeta, operation Co
 	}
 	layout, err := ResolveTypedStorageLayout(meta)
 	if err != nil {
-		return err
+		return fmt.Errorf("%w: column-store write collection=%q operation=%q: %v", backenddb.ErrCommandWALRejected, meta.Name, operation, err)
 	}
 	if err := layout.EnsurePublicationSupported(); err != nil {
 		return fmt.Errorf("%w: column-store write collection=%q operation=%q: %v", backenddb.ErrCommandWALRejected, meta.Name, operation, err)

--- a/TreeDB/collections/column_publish_write.go
+++ b/TreeDB/collections/column_publish_write.go
@@ -84,6 +84,13 @@ func requireColumnStoreWriteOperationSupported(meta CollectionMeta, operation Co
 			meta.Options.DocumentFormat,
 		)
 	}
+	layout, err := ResolveTypedStorageLayout(meta)
+	if err != nil {
+		return err
+	}
+	if err := layout.EnsurePublicationSupported(); err != nil {
+		return fmt.Errorf("%w: column-store write collection=%q operation=%q: %v", backenddb.ErrCommandWALRejected, meta.Name, operation, err)
+	}
 	switch operation {
 	case ColumnPublishOperationInsert, ColumnPublishOperationUpdate, ColumnPublishOperationDelete:
 		return nil
@@ -496,26 +503,30 @@ func (c *Collection) prepareColumnPhysicalAssetRowsForCommand(prepared ColumnPub
 	if hookInput.CurrentManifest != nil {
 		generation = hookInput.CurrentManifest.Generation + 1
 	}
-	const partID = uint64(1)
+	rowAssetConfig := columnStoreRowAssetConfig(hookInput.ColumnStore)
+	rowAssetRows, err := projectColumnDeclaredRowsForColumns(hookInput.ColumnStore.Columns, rowAssetConfig.Columns, rows)
+	if err != nil {
+		return ColumnPublishPreparedAssets{}, err
+	}
 	encoded, summary, err := encodeColumnPhysicalAsset(columnPhysicalAssetEncodeInput{
 		Collection:        hookInput.Collection,
 		Namespace:         hookInput.ColumnStore.AssetManager.Namespace,
 		Generation:        generation,
-		PartID:            partID,
+		PartID:            columnPhysicalRowAssetPartID,
 		AppliedCommandLSN: hookInput.AppliedCommandLSN,
 		Operation:         hookInput.Operation,
 		SchemaHash:        hookInput.ColumnStore.SchemaHash,
-		Columns:           hookInput.ColumnStore.Columns,
-		Rows:              rows,
+		Columns:           rowAssetConfig.Columns,
+		Rows:              rowAssetRows,
 	})
 	if err != nil {
 		return ColumnPublishPreparedAssets{}, err
 	}
-	ref, err := writeColumnPhysicalAssetToManager(c.db.ColumnAssetRootDir(), hookInput.ColumnStore, encoded, generation, partID)
+	ref, err := writeColumnPhysicalAssetToManager(c.db.ColumnAssetRootDir(), hookInput.ColumnStore, encoded, generation, columnPhysicalRowAssetPartID)
 	if err != nil {
 		return ColumnPublishPreparedAssets{}, err
 	}
-	if err := validateColumnPhysicalAssetPreparedRefForManifest(ref, hookInput.ColumnStore, generation, partID, len(encoded)); err != nil {
+	if err := validateColumnPhysicalAssetPreparedRefForManifest(ref, rowAssetConfig, generation, columnPhysicalRowAssetPartID, len(encoded)); err != nil {
 		return ColumnPublishPreparedAssets{}, err
 	}
 	if prepared.CommandBytes == 0 {
@@ -531,8 +542,33 @@ func (c *Collection) prepareColumnPhysicalAssetRowsForCommand(prepared ColumnPub
 		GenerationID: generation,
 		Reason:       string(input.operation),
 	}}
+	if hookInput.Operation == ColumnPublishOperationInsert || hookInput.Operation == ColumnPublishOperationUpdate {
+		typedColumnImage, typedColumnRows, err := buildTypedColumnPartImageForDeclaredRows(hookInput.ColumnStore, generation, typedColumnPartAssetPartID, rows)
+		if err != nil {
+			return ColumnPublishPreparedAssets{}, err
+		}
+		if len(typedColumnImage) != 0 {
+			typedColumnRef, err := writeTypedColumnPartAssetToManager(c.db.ColumnAssetRootDir(), hookInput.ColumnStore, typedColumnImage, generation, typedColumnPartAssetPartID)
+			if err != nil {
+				return ColumnPublishPreparedAssets{}, err
+			}
+			if typedColumnRef.Namespace != hookInput.ColumnStore.AssetManager.Namespace || typedColumnRef.Kind != ColumnAssetKindTCS1TypedColumnPart ||
+				typedColumnRef.Generation != generation || typedColumnRef.PartID != typedColumnPartAssetPartID || typedColumnRef.Length != int64(len(typedColumnImage)) {
+				return ColumnPublishPreparedAssets{}, fmt.Errorf("collections: invalid typed-column part asset ref %+v", typedColumnRef)
+			}
+			prepped := ColumnPreparedAsset{
+				Ref:          typedColumnRef,
+				Rows:         typedColumnRows,
+				Bytes:        typedColumnRef.Length,
+				PublishID:    hookInput.AppliedCommandLSN,
+				GenerationID: generation,
+				Reason:       string(input.operation),
+			}
+			prepared.Assets = append(prepared.Assets, prepped)
+		}
+	}
 	if hookInput.Operation == ColumnPublishOperationInsert {
-		dictionaryAssets, err := buildColumnDictionaryCodesAssets(hookInput.ColumnStore, rows, hookInput.Collection, hookInput.ColumnStore.AssetManager.Namespace, generation, partID, hookInput.AppliedCommandLSN)
+		dictionaryAssets, err := buildColumnDictionaryCodesAssets(rowAssetConfig, rowAssetRows, hookInput.Collection, hookInput.ColumnStore.AssetManager.Namespace, generation, columnPhysicalRowAssetPartID, hookInput.AppliedCommandLSN)
 		if err != nil {
 			return ColumnPublishPreparedAssets{}, err
 		}
@@ -541,12 +577,12 @@ func (c *Collection) prepareColumnPhysicalAssetRowsForCommand(prepared ColumnPub
 			if err != nil {
 				return ColumnPublishPreparedAssets{}, err
 			}
-			dictionaryRef, err := writeColumnDictionaryCodesAssetToManager(c.db.ColumnAssetRootDir(), hookInput.ColumnStore, encodedDictionary, generation, partID)
+			dictionaryRef, err := writeColumnDictionaryCodesAssetToManager(c.db.ColumnAssetRootDir(), hookInput.ColumnStore, encodedDictionary, generation, columnPhysicalRowAssetPartID)
 			if err != nil {
 				return ColumnPublishPreparedAssets{}, err
 			}
 			if dictionaryRef.Namespace != hookInput.ColumnStore.AssetManager.Namespace || dictionaryRef.Kind != ColumnAssetKindTCS1DictionaryCodes ||
-				dictionaryRef.Generation != generation || dictionaryRef.PartID != partID || dictionaryRef.Length != int64(len(encodedDictionary)) {
+				dictionaryRef.Generation != generation || dictionaryRef.PartID != columnPhysicalRowAssetPartID || dictionaryRef.Length != int64(len(encodedDictionary)) {
 				return ColumnPublishPreparedAssets{}, fmt.Errorf("collections: invalid dictionary codes asset ref %+v", dictionaryRef)
 			}
 			prepared.Assets = append(prepared.Assets, ColumnPreparedAsset{
@@ -558,7 +594,7 @@ func (c *Collection) prepareColumnPhysicalAssetRowsForCommand(prepared ColumnPub
 				Reason:       dictionary.ColumnName,
 			})
 		}
-		int64Assets, err := buildColumnInt64ValuesAssets(hookInput.ColumnStore, rows, hookInput.Collection, hookInput.ColumnStore.AssetManager.Namespace, generation, partID, hookInput.AppliedCommandLSN)
+		int64Assets, err := buildColumnInt64ValuesAssets(rowAssetConfig, rowAssetRows, hookInput.Collection, hookInput.ColumnStore.AssetManager.Namespace, generation, columnPhysicalRowAssetPartID, hookInput.AppliedCommandLSN)
 		if err != nil {
 			return ColumnPublishPreparedAssets{}, err
 		}
@@ -567,12 +603,12 @@ func (c *Collection) prepareColumnPhysicalAssetRowsForCommand(prepared ColumnPub
 			if err != nil {
 				return ColumnPublishPreparedAssets{}, err
 			}
-			valuesRef, err := writeColumnInt64ValuesAssetToManager(c.db.ColumnAssetRootDir(), hookInput.ColumnStore, encodedValues, generation, partID)
+			valuesRef, err := writeColumnInt64ValuesAssetToManager(c.db.ColumnAssetRootDir(), hookInput.ColumnStore, encodedValues, generation, columnPhysicalRowAssetPartID)
 			if err != nil {
 				return ColumnPublishPreparedAssets{}, err
 			}
 			if valuesRef.Namespace != hookInput.ColumnStore.AssetManager.Namespace || valuesRef.Kind != ColumnAssetKindTCS1Int64Values ||
-				valuesRef.Generation != generation || valuesRef.PartID != partID || valuesRef.Length != int64(len(encodedValues)) {
+				valuesRef.Generation != generation || valuesRef.PartID != columnPhysicalRowAssetPartID || valuesRef.Length != int64(len(encodedValues)) {
 				return ColumnPublishPreparedAssets{}, fmt.Errorf("collections: invalid int64 values asset ref %+v", valuesRef)
 			}
 			prepared.Assets = append(prepared.Assets, ColumnPreparedAsset{
@@ -584,8 +620,8 @@ func (c *Collection) prepareColumnPhysicalAssetRowsForCommand(prepared ColumnPub
 				Reason:       values.ColumnName,
 			})
 		}
-		for _, aggregate := range hookInput.ColumnStore.AggregateMetadata {
-			metadata, ok, err := buildColumnAggregateMetadataAsset(hookInput.ColumnStore, rows, aggregate, hookInput.Collection, hookInput.ColumnStore.AssetManager.Namespace, generation, partID, hookInput.AppliedCommandLSN)
+		for _, aggregate := range rowAssetConfig.AggregateMetadata {
+			metadata, ok, err := buildColumnAggregateMetadataAsset(rowAssetConfig, rowAssetRows, aggregate, hookInput.Collection, hookInput.ColumnStore.AssetManager.Namespace, generation, columnPhysicalRowAssetPartID, hookInput.AppliedCommandLSN)
 			if err != nil {
 				return ColumnPublishPreparedAssets{}, err
 			}
@@ -596,12 +632,12 @@ func (c *Collection) prepareColumnPhysicalAssetRowsForCommand(prepared ColumnPub
 			if err != nil {
 				return ColumnPublishPreparedAssets{}, err
 			}
-			metadataRef, err := writeColumnAggregateMetadataAssetToManager(c.db.ColumnAssetRootDir(), hookInput.ColumnStore, encodedMetadata, generation, partID)
+			metadataRef, err := writeColumnAggregateMetadataAssetToManager(c.db.ColumnAssetRootDir(), hookInput.ColumnStore, encodedMetadata, generation, columnPhysicalRowAssetPartID)
 			if err != nil {
 				return ColumnPublishPreparedAssets{}, err
 			}
 			if metadataRef.Namespace != hookInput.ColumnStore.AssetManager.Namespace || metadataRef.Kind != ColumnAssetKindTCS1AggregateMetadata ||
-				metadataRef.Generation != generation || metadataRef.PartID != partID || metadataRef.Length != int64(len(encodedMetadata)) {
+				metadataRef.Generation != generation || metadataRef.PartID != columnPhysicalRowAssetPartID || metadataRef.Length != int64(len(encodedMetadata)) {
 				return ColumnPublishPreparedAssets{}, fmt.Errorf("collections: invalid aggregate metadata asset ref %+v", metadataRef)
 			}
 			prepared.Assets = append(prepared.Assets, ColumnPreparedAsset{

--- a/TreeDB/collections/column_reconstruction.go
+++ b/TreeDB/collections/column_reconstruction.go
@@ -85,6 +85,13 @@ func (c *Collection) reconstructColumnDocumentAtSnapshotWithDiagnostics(snap *ba
 	if cfg.Reconstruction != ColumnReconstructionRetainedPayloadAndColumns {
 		return nil, diag, fmt.Errorf("collections: unsupported column reconstruction policy %q", cfg.Reconstruction)
 	}
+	layout, err := ResolveTypedStorageLayout(catalog.meta)
+	if err != nil {
+		return nil, diag, err
+	}
+	if err := layout.EnsureReadSupported(); err != nil {
+		return nil, diag, err
+	}
 	visibilityStart := time.Now()
 	row, scanDiag, found, err := c.latestColumnPhysicalVisibleRowAtSnapshot(snap, catalog, documentID, nil)
 	diag.VisibilityNanos = time.Since(visibilityStart).Nanoseconds()
@@ -100,7 +107,16 @@ func (c *Collection) reconstructColumnDocumentAtSnapshotWithDiagnostics(snap *ba
 		return nil, diag, fmt.Errorf("collections: column reconstruction latest physical row is deleted for id %q", string(documentID))
 	}
 	reconstructionStart := time.Now()
-	out, err := reconstructColumnDocumentFromVisibleRow(cfg, retained, row)
+	manifestRootID := catalog.rootID(collectionColumnManifestRootName(catalog.meta.Name))
+	typedValues, err := c.typedColumnPartValuesForVisibleRowAtSnapshot(snap, manifestRootID, cfg, row)
+	if err != nil {
+		return nil, diag, err
+	}
+	fullValues, err := mergeColumnReconstructionValues(cfg, row.Values, typedValues.Values)
+	if err != nil {
+		return nil, diag, err
+	}
+	out, err := reconstructColumnDocumentFromVisibleRowValues(cfg, retained, row, fullValues)
 	if err != nil {
 		return nil, diag, err
 	}
@@ -113,7 +129,49 @@ func reconstructColumnDocumentFromVisibleRow(cfg ColumnStoreConfig, retained []b
 	if row.Deleted {
 		return nil, errors.New("collections: column reconstruction latest physical row is deleted")
 	}
-	return reconstructColumnJSONDocument(cfg, retained, row.Values)
+	values, err := mergeColumnReconstructionValues(cfg, row.Values, nil)
+	if err != nil {
+		return nil, err
+	}
+	return reconstructColumnJSONDocument(cfg, retained, values)
+}
+
+func reconstructColumnDocumentFromVisibleRowValues(cfg ColumnStoreConfig, retained []byte, row columnPhysicalVisibleRow, values []columnDeclaredValue) ([]byte, error) {
+	if row.Deleted {
+		return nil, errors.New("collections: column reconstruction latest physical row is deleted")
+	}
+	return reconstructColumnJSONDocument(cfg, retained, values)
+}
+
+func mergeColumnReconstructionValues(cfg ColumnStoreConfig, rowValues, typedColumnValues []columnDeclaredValue) ([]columnDeclaredValue, error) {
+	values := make([]columnDeclaredValue, len(cfg.Columns))
+	rowIdx := 0
+	typedIdx := 0
+	for i, col := range cfg.Columns {
+		switch columnStoreColumnOwnerOrRowAsset(col) {
+		case TypedStorageOwnerRowAsset:
+			if rowIdx >= len(rowValues) {
+				return nil, fmt.Errorf("collections: column reconstruction missing typed_row_asset value for column %q", col.Name)
+			}
+			values[i] = rowValues[rowIdx]
+			rowIdx++
+		case TypedStorageOwnerColumnPart:
+			if typedIdx >= len(typedColumnValues) {
+				return nil, fmt.Errorf("collections: column reconstruction missing typed_column_part value for column %q", col.Name)
+			}
+			values[i] = typedColumnValues[typedIdx]
+			typedIdx++
+		default:
+			return nil, fmt.Errorf("collections: column reconstruction unsupported owner %q for column %q", col.Owner, col.Name)
+		}
+	}
+	if rowIdx != len(rowValues) {
+		return nil, fmt.Errorf("collections: column reconstruction unused typed_row_asset values=%d", len(rowValues)-rowIdx)
+	}
+	if typedIdx != len(typedColumnValues) {
+		return nil, fmt.Errorf("collections: column reconstruction unused typed_column_part values=%d", len(typedColumnValues)-typedIdx)
+	}
+	return values, nil
 }
 
 func reconstructColumnJSONDocument(cfg ColumnStoreConfig, retained []byte, values []columnDeclaredValue) ([]byte, error) {

--- a/TreeDB/collections/column_store.go
+++ b/TreeDB/collections/column_store.go
@@ -168,9 +168,12 @@ type ColumnStoreConfig struct {
 }
 
 type ColumnStoreColumn struct {
-	Name               string                   `json:"name"`
-	Path               string                   `json:"path"`
-	ValueType          ColumnStoreValueType     `json:"value_type"`
+	Name      string               `json:"name"`
+	Path      string               `json:"path"`
+	ValueType ColumnStoreValueType `json:"value_type"`
+	// Owner is typed-storage metadata. The zero value preserves compatibility and
+	// resolves to typed_row_asset; typed_column_part is opt-in/experimental.
+	Owner              TypedStorageFieldOwner   `json:"owner,omitempty"`
 	Nullable           bool                     `json:"nullable,omitempty"`
 	Dictionary         bool                     `json:"dictionary,omitempty"`
 	VectorDims         int                      `json:"vector_dims,omitempty"`
@@ -426,6 +429,13 @@ func validateColumnStoreConfig(collection string, cfg ColumnStoreConfig) error {
 		if err != nil {
 			return fmt.Errorf("collections: invalid column %q value_type: %w", col.Name, err)
 		}
+		owner, err := columnStoreColumnOwner(col)
+		if err != nil {
+			return fmt.Errorf("collections: invalid column %q owner: %w", col.Name, err)
+		}
+		if owner != TypedStorageOwnerRowAsset && owner != TypedStorageOwnerColumnPart {
+			return fmt.Errorf("collections: invalid column %q owner: %s is not a typed asset owner", col.Name, owner)
+		}
 		fixedWidthEncoding, err := normalizeColumnFixedWidthEncoding(col.FixedWidthEncoding)
 		if err != nil {
 			return fmt.Errorf("collections: invalid column %q fixed_width_encoding: %w", col.Name, err)
@@ -595,6 +605,26 @@ func columnFixedWidthEncodingIsLittleEndian(encoding ColumnFixedWidthEncoding) (
 		return false, err
 	}
 	return normalized == ColumnFixedWidthEncodingLittleEndian, nil
+}
+
+func columnStoreColumnOwner(col ColumnStoreColumn) (TypedStorageFieldOwner, error) {
+	return normalizeTypedStorageFieldOwner(col.Owner)
+}
+
+func columnStoreColumnOwnerOrRowAsset(col ColumnStoreColumn) TypedStorageFieldOwner {
+	owner, err := columnStoreColumnOwner(col)
+	if err != nil || owner == "" {
+		return TypedStorageOwnerRowAsset
+	}
+	return owner
+}
+
+func columnStoreColumnIsTypedColumnPart(col ColumnStoreColumn) bool {
+	return columnStoreColumnOwnerOrRowAsset(col) == TypedStorageOwnerColumnPart
+}
+
+func columnStoreColumnIsTypedRowAsset(col ColumnStoreColumn) bool {
+	return columnStoreColumnOwnerOrRowAsset(col) == TypedStorageOwnerRowAsset
 }
 
 func columnStoreValueTypeSupportsFixedWidthEncoding(valueType ColumnStoreValueType) bool {
@@ -960,6 +990,7 @@ func hashColumnStoreSchema(cfg *ColumnStoreConfig) uint64 {
 		writeHashString(&d, col.Name)
 		writeHashString(&d, col.Path)
 		writeHashString(&d, string(col.ValueType))
+		writeHashString(&d, string(columnStoreColumnOwnerOrRowAsset(col)))
 		writeHashUint64(&d, uint64(col.VectorDims))
 		writeHashBool(&d, col.Nullable)
 		writeHashBool(&d, col.Dictionary)

--- a/TreeDB/collections/typed_column_adapter.go
+++ b/TreeDB/collections/typed_column_adapter.go
@@ -242,6 +242,14 @@ func buildTypedColumnAdapterPart(opts typedColumnAdapterOptions, rows []typedCol
 	return &typedColumnAdapterPart{Options: opts, Columns: columns, Part: part, Dictionary: typedColumnAdapterDictionaries(columns)}, nil
 }
 
+func typedColumnAdapterPartFromBytes(opts typedColumnAdapterOptions, raw []byte) (*typedColumnAdapterPart, error) {
+	image, err := typedcolumn.ParseColumnPartImage(raw)
+	if err != nil {
+		return nil, err
+	}
+	return typedColumnAdapterPartFromImage(opts, image)
+}
+
 func typedColumnAdapterPartFromImage(opts typedColumnAdapterOptions, image typedcolumn.ColumnPartImage) (*typedColumnAdapterPart, error) {
 	part, err := typedcolumn.ColumnPartFromImage(image)
 	if err != nil {
@@ -326,6 +334,39 @@ func (p *typedColumnAdapterPart) scanColumnValues(columnName string) ([]columnDe
 		out[i] = value
 	}
 	return out, nil
+}
+
+func (p *typedColumnAdapterPart) scanRows() ([]typedColumnAdapterRow, error) {
+	if p == nil || p.Part == nil {
+		return nil, errors.New("collections: nil typed-column adapter part")
+	}
+	projected := make([]string, 0, len(p.Columns)+1)
+	projected = append(projected, typedColumnAdapterPrimaryIDColumn)
+	for _, column := range p.Columns {
+		projected = append(projected, column.Definition.Name)
+	}
+	scan, err := p.Part.NewScanner().ScanProjected(projected)
+	if err != nil {
+		return nil, err
+	}
+	ids := scan.Columns[typedColumnAdapterPrimaryIDColumn]
+	rows := make([]typedColumnAdapterRow, len(ids))
+	for rowIdx, id := range ids {
+		values := make(map[string]columnDeclaredValue, len(p.Columns))
+		for _, column := range p.Columns {
+			encoded := scan.Columns[column.Definition.Name]
+			if len(encoded) != len(ids) {
+				return nil, fmt.Errorf("collections: typed-column adapter column %q rows=%d want %d", column.Definition.Name, len(encoded), len(ids))
+			}
+			value, err := decodeTypedColumnAdapterValue(column, encoded[rowIdx])
+			if err != nil {
+				return nil, fmt.Errorf("collections: typed-column adapter row %d column %q: %w", rowIdx, column.Definition.Name, err)
+			}
+			values[column.Field.Path] = value
+		}
+		rows[rowIdx] = typedColumnAdapterRow{PrimaryID: id, Values: values}
+	}
+	return rows, nil
 }
 
 func (p *typedColumnAdapterPart) columnByName(name string) (typedColumnAdapterColumn, bool) {

--- a/TreeDB/collections/typed_column_publication.go
+++ b/TreeDB/collections/typed_column_publication.go
@@ -178,6 +178,9 @@ func typedColumnAdapterRowsFromDeclaredRows(allColumns []ColumnStoreColumn, fiel
 }
 
 func buildTypedColumnPartImageForDeclaredRows(cfg ColumnStoreConfig, generation, partID uint64, rows []columnDeclaredRow) ([]byte, int, error) {
+	if !columnStoreHasTypedColumnPartOwners(cfg) {
+		return nil, 0, nil
+	}
 	fields := columnStoreTypedColumnPartFields(cfg)
 	if len(fields) == 0 {
 		return nil, 0, nil
@@ -208,6 +211,13 @@ type typedColumnPartVisibleValues struct {
 }
 
 func (c *Collection) typedColumnPartValuesForVisibleRowAtSnapshot(snap *backenddb.Snapshot, manifestRootID uint64, cfg ColumnStoreConfig, physicalRow columnPhysicalVisibleRow) (typedColumnPartVisibleValues, error) {
+	return c.typedColumnPartValuesForVisibleRowAtSnapshotWithCache(snap, manifestRootID, cfg, physicalRow, nil)
+}
+
+func (c *Collection) typedColumnPartValuesForVisibleRowAtSnapshotWithCache(snap *backenddb.Snapshot, manifestRootID uint64, cfg ColumnStoreConfig, physicalRow columnPhysicalVisibleRow, cache map[uint64][]typedColumnAdapterRow) (typedColumnPartVisibleValues, error) {
+	if !columnStoreHasTypedColumnPartOwners(cfg) {
+		return typedColumnPartVisibleValues{}, nil
+	}
 	fields := columnStoreTypedColumnPartFields(cfg)
 	if len(fields) == 0 {
 		return typedColumnPartVisibleValues{}, nil
@@ -215,29 +225,38 @@ func (c *Collection) typedColumnPartValuesForVisibleRowAtSnapshot(snap *backendd
 	if physicalRow.Deleted {
 		return typedColumnPartVisibleValues{}, nil
 	}
-	ref, ok, err := c.typedColumnPartRefForGeneration(snap, manifestRootID, cfg, physicalRow.Generation)
-	if err != nil {
-		return typedColumnPartVisibleValues{}, err
-	}
+	rows, ok := cache[physicalRow.Generation]
 	if !ok {
-		return typedColumnPartVisibleValues{}, fmt.Errorf("collections: typed-column reconstruction missing typed_column_part asset for generation=%d", physicalRow.Generation)
-	}
-	readCache, err := newColumnPhysicalAssetReadCacheWithIntegrity(c.db.ColumnAssetRootDir(), cfg.AssetManager.Namespace, ColumnAssetReadIntegrityVerify)
-	if err != nil {
-		return typedColumnPartVisibleValues{}, err
-	}
-	defer func() { _ = readCache.close() }()
-	raw, err := readCache.read(ref.Ref, nil)
-	if err != nil {
-		return typedColumnPartVisibleValues{}, fmt.Errorf("collections: typed-column reconstruction read generation=%d part_id=%d: %w", ref.Ref.Generation, ref.Ref.PartID, err)
-	}
-	part, err := typedColumnAdapterPartFromBytes(typedColumnAdapterOptions{Fields: fields}, raw)
-	if err != nil {
-		return typedColumnPartVisibleValues{}, fmt.Errorf("collections: typed-column reconstruction decode generation=%d part_id=%d: %w", ref.Ref.Generation, ref.Ref.PartID, err)
-	}
-	rows, err := part.scanRows()
-	if err != nil {
-		return typedColumnPartVisibleValues{}, err
+		ref, found, err := c.typedColumnPartRefForGeneration(snap, manifestRootID, cfg, physicalRow.Generation)
+		if err != nil {
+			return typedColumnPartVisibleValues{}, err
+		}
+		if !found {
+			return typedColumnPartVisibleValues{}, fmt.Errorf("collections: typed-column reconstruction missing typed_column_part asset for generation=%d", physicalRow.Generation)
+		}
+		readCache, err := newColumnPhysicalAssetReadCacheWithIntegrity(c.db.ColumnAssetRootDir(), cfg.AssetManager.Namespace, ColumnAssetReadIntegrityVerify)
+		if err != nil {
+			return typedColumnPartVisibleValues{}, err
+		}
+		raw, readErr := readCache.read(ref.Ref, nil)
+		closeErr := readCache.close()
+		if readErr != nil {
+			return typedColumnPartVisibleValues{}, fmt.Errorf("collections: typed-column reconstruction read generation=%d part_id=%d: %w", ref.Ref.Generation, ref.Ref.PartID, readErr)
+		}
+		if closeErr != nil {
+			return typedColumnPartVisibleValues{}, closeErr
+		}
+		part, err := typedColumnAdapterPartFromBytes(typedColumnAdapterOptions{Fields: fields}, raw)
+		if err != nil {
+			return typedColumnPartVisibleValues{}, fmt.Errorf("collections: typed-column reconstruction decode generation=%d part_id=%d: %w", ref.Ref.Generation, ref.Ref.PartID, err)
+		}
+		rows, err = part.scanRows()
+		if err != nil {
+			return typedColumnPartVisibleValues{}, err
+		}
+		if cache != nil {
+			cache[physicalRow.Generation] = rows
+		}
 	}
 	if physicalRow.RowIndex < 0 || physicalRow.RowIndex >= len(rows) {
 		return typedColumnPartVisibleValues{}, fmt.Errorf("collections: typed-column reconstruction row_index=%d outside typed_column_part rows=%d", physicalRow.RowIndex, len(rows))

--- a/TreeDB/collections/typed_column_publication.go
+++ b/TreeDB/collections/typed_column_publication.go
@@ -210,11 +210,17 @@ type typedColumnPartVisibleValues struct {
 	Values []columnDeclaredValue
 }
 
+type typedColumnPartReconstructionCache struct {
+	Rows       map[uint64][]typedColumnAdapterRow
+	Refs       map[uint64]columnManifestAssetRefForScan
+	RefsLoaded bool
+}
+
 func (c *Collection) typedColumnPartValuesForVisibleRowAtSnapshot(snap *backenddb.Snapshot, manifestRootID uint64, cfg ColumnStoreConfig, physicalRow columnPhysicalVisibleRow) (typedColumnPartVisibleValues, error) {
 	return c.typedColumnPartValuesForVisibleRowAtSnapshotWithCache(snap, manifestRootID, cfg, physicalRow, nil)
 }
 
-func (c *Collection) typedColumnPartValuesForVisibleRowAtSnapshotWithCache(snap *backenddb.Snapshot, manifestRootID uint64, cfg ColumnStoreConfig, physicalRow columnPhysicalVisibleRow, cache map[uint64][]typedColumnAdapterRow) (typedColumnPartVisibleValues, error) {
+func (c *Collection) typedColumnPartValuesForVisibleRowAtSnapshotWithCache(snap *backenddb.Snapshot, manifestRootID uint64, cfg ColumnStoreConfig, physicalRow columnPhysicalVisibleRow, cache *typedColumnPartReconstructionCache) (typedColumnPartVisibleValues, error) {
 	if !columnStoreHasTypedColumnPartOwners(cfg) {
 		return typedColumnPartVisibleValues{}, nil
 	}
@@ -225,9 +231,13 @@ func (c *Collection) typedColumnPartValuesForVisibleRowAtSnapshotWithCache(snap 
 	if physicalRow.Deleted {
 		return typedColumnPartVisibleValues{}, nil
 	}
-	rows, ok := cache[physicalRow.Generation]
+	var rows []typedColumnAdapterRow
+	var ok bool
+	if cache != nil && cache.Rows != nil {
+		rows, ok = cache.Rows[physicalRow.Generation]
+	}
 	if !ok {
-		ref, found, err := c.typedColumnPartRefForGeneration(snap, manifestRootID, cfg, physicalRow.Generation)
+		ref, found, err := c.typedColumnPartRefForGenerationWithCache(snap, manifestRootID, cfg, physicalRow.Generation, cache)
 		if err != nil {
 			return typedColumnPartVisibleValues{}, err
 		}
@@ -264,7 +274,10 @@ func (c *Collection) typedColumnPartValuesForVisibleRowAtSnapshotWithCache(snap 
 			return typedColumnPartVisibleValues{}, closeErr
 		}
 		if cache != nil {
-			cache[physicalRow.Generation] = rows
+			if cache.Rows == nil {
+				cache.Rows = make(map[uint64][]typedColumnAdapterRow)
+			}
+			cache.Rows[physicalRow.Generation] = rows
 		}
 	}
 	if physicalRow.RowIndex < 0 || physicalRow.RowIndex >= len(rows) {
@@ -286,39 +299,74 @@ func (c *Collection) typedColumnPartValuesForVisibleRowAtSnapshotWithCache(snap 
 }
 
 func (c *Collection) typedColumnPartRefForGeneration(snap *backenddb.Snapshot, rootID uint64, cfg ColumnStoreConfig, generation uint64) (columnManifestAssetRefForScan, bool, error) {
-	if rootID == 0 {
-		return columnManifestAssetRefForScan{}, false, errors.New("collections: typed-column reconstruction missing manifest root")
+	return c.typedColumnPartRefForGenerationWithCache(snap, rootID, cfg, generation, nil)
+}
+
+func (c *Collection) typedColumnPartRefForGenerationWithCache(snap *backenddb.Snapshot, rootID uint64, cfg ColumnStoreConfig, generation uint64, cache *typedColumnPartReconstructionCache) (columnManifestAssetRefForScan, bool, error) {
+	if cache != nil && cache.RefsLoaded {
+		ref, found := cache.Refs[generation]
+		return ref, found, nil
 	}
-	if snap == nil {
-		return columnManifestAssetRefForScan{}, false, errCollectionDBNil
-	}
-	records, err := loadColumnManifestRecordsFromRoot(snap, rootID)
+	refs, err := c.typedColumnPartRefsByGeneration(snap, rootID, cfg)
 	if err != nil {
 		return columnManifestAssetRefForScan{}, false, err
 	}
+	if cache != nil {
+		cache.Refs = refs
+		cache.RefsLoaded = true
+	}
+	ref, found := refs[generation]
+	return ref, found, nil
+}
+
+func (c *Collection) typedColumnPartRefsByGeneration(snap *backenddb.Snapshot, rootID uint64, cfg ColumnStoreConfig) (map[uint64]columnManifestAssetRefForScan, error) {
+	if rootID == 0 {
+		return nil, errors.New("collections: typed-column reconstruction missing manifest root")
+	}
+	if snap == nil {
+		return nil, errCollectionDBNil
+	}
+	if cfg.AssetManager == nil {
+		return nil, errors.New("collections: typed-column reconstruction requires column asset manager metadata")
+	}
+	records, err := loadColumnManifestRecordsFromRoot(snap, rootID)
+	if err != nil {
+		return nil, err
+	}
+	return typedColumnPartRefsByGenerationFromManifestRecords(records, cfg.AssetManager.Namespace)
+}
+
+func typedColumnPartRefsByGenerationFromManifestRecords(records []columnManifestRecord, expectedNamespace string) (map[uint64]columnManifestAssetRefForScan, error) {
+	refs := make(map[uint64]columnManifestAssetRefForScan)
 	for _, record := range records {
 		if !bytes.HasPrefix(record.key, columnManifestPartRecordPrefixBytes) {
 			continue
 		}
 		keyGeneration, keyPartID, err := columnManifestPartKeyFromRecordKeyForScan(record.key)
 		if err != nil {
-			return columnManifestAssetRefForScan{}, false, err
+			return nil, err
 		}
-		ref, rows, _, _, _, reason, err := decodeColumnManifestPartFieldsForScan(record.value, cfg.AssetManager.Namespace)
+		ref, rows, _, _, _, reason, err := decodeColumnManifestPartFieldsForScan(record.value, expectedNamespace)
 		if err != nil {
-			return columnManifestAssetRefForScan{}, false, err
+			return nil, err
 		}
-		if ref.Kind != ColumnAssetKindTCS1TypedColumnPart || ref.Generation != generation {
+		if ref.Kind != ColumnAssetKindTCS1TypedColumnPart {
 			continue
 		}
 		if ref.Generation != keyGeneration || ref.PartID != keyPartID {
-			return columnManifestAssetRefForScan{}, false, fmt.Errorf("collections: typed-column manifest key generation/part mismatch")
+			return nil, fmt.Errorf("collections: typed-column manifest key generation/part mismatch")
+		}
+		if ref.PartID != typedColumnPartAssetPartID {
+			return nil, fmt.Errorf("collections: typed-column manifest unexpected part_id=%d", ref.PartID)
 		}
 		operation, ok := columnPhysicalScanOperationFromBytes(reason)
 		if !ok {
-			return columnManifestAssetRefForScan{}, false, fmt.Errorf("collections: unsupported typed-column manifest reason %q", string(reason))
+			return nil, fmt.Errorf("collections: unsupported typed-column manifest reason %q", string(reason))
 		}
-		return columnManifestAssetRefForScan{Ref: ref, Reason: operation, Rows: rows}, true, nil
+		if _, exists := refs[ref.Generation]; exists {
+			return nil, fmt.Errorf("collections: duplicate typed-column manifest ref for generation=%d", ref.Generation)
+		}
+		refs[ref.Generation] = columnManifestAssetRefForScan{Ref: ref, Reason: operation, Rows: rows}
 	}
-	return columnManifestAssetRefForScan{}, false, nil
+	return refs, nil
 }

--- a/TreeDB/collections/typed_column_publication.go
+++ b/TreeDB/collections/typed_column_publication.go
@@ -1,0 +1,296 @@
+package collections
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+)
+
+const (
+	columnPhysicalRowAssetPartID = uint64(1)
+	typedColumnPartAssetPartID   = uint64(2)
+)
+
+func columnStoreHasTypedColumnPartOwners(cfg ColumnStoreConfig) bool {
+	for _, col := range cfg.Columns {
+		if columnStoreColumnIsTypedColumnPart(col) {
+			return true
+		}
+	}
+	return false
+}
+
+func columnStoreRowAssetColumns(cfg ColumnStoreConfig) []ColumnStoreColumn {
+	columns := make([]ColumnStoreColumn, 0, len(cfg.Columns))
+	for _, col := range cfg.Columns {
+		if columnStoreColumnIsTypedRowAsset(col) {
+			columns = append(columns, col)
+		}
+	}
+	return columns
+}
+
+func columnStoreTypedColumnPartFields(cfg ColumnStoreConfig) []TypedStorageField {
+	fields := make([]TypedStorageField, 0, len(cfg.Columns))
+	for _, col := range cfg.Columns {
+		if !columnStoreColumnIsTypedColumnPart(col) {
+			continue
+		}
+		fields = append(fields, TypedStorageField{
+			Name:               col.Name,
+			Path:               col.Path,
+			Owner:              TypedStorageOwnerColumnPart,
+			ValueType:          col.ValueType,
+			Nullable:           col.Nullable,
+			Dictionary:         col.Dictionary,
+			VectorDims:         col.VectorDims,
+			FixedWidthEncoding: col.FixedWidthEncoding,
+		})
+	}
+	return fields
+}
+
+func columnStoreRowAssetConfig(cfg ColumnStoreConfig) ColumnStoreConfig {
+	if !columnStoreHasTypedColumnPartOwners(cfg) {
+		return cfg
+	}
+	out := cfg.copy()
+	out.Columns = columnStoreRowAssetColumns(cfg)
+	out.SortKey = filterColumnSortKeysForColumns(cfg.SortKey, out.Columns)
+	out.AggregateMetadata = filterColumnAggregateMetadataForColumns(cfg.AggregateMetadata, out.Columns)
+	// The manifest/schema identity remains the full typed-storage layout hash.
+	// Row assets only carry typed_row_asset-owned fields plus row locators.
+	out.SchemaHash = cfg.SchemaHash
+	return out
+}
+
+func filterColumnSortKeysForColumns(sortKeys []ColumnSortKey, columns []ColumnStoreColumn) []ColumnSortKey {
+	if len(sortKeys) == 0 {
+		return nil
+	}
+	present := columnStoreColumnNameSet(columns)
+	out := make([]ColumnSortKey, 0, len(sortKeys))
+	for _, sortKey := range sortKeys {
+		if _, ok := present[sortKey.Column]; ok {
+			out = append(out, sortKey)
+		}
+	}
+	return out
+}
+
+func filterColumnAggregateMetadataForColumns(aggregates []ColumnAggregateMetadata, columns []ColumnStoreColumn) []ColumnAggregateMetadata {
+	if len(aggregates) == 0 {
+		return nil
+	}
+	present := columnStoreColumnNameSet(columns)
+	out := make([]ColumnAggregateMetadata, 0, len(aggregates))
+	for _, aggregate := range aggregates {
+		if aggregate.Column != "" {
+			if _, ok := present[aggregate.Column]; !ok {
+				continue
+			}
+		}
+		if aggregate.GroupColumn != "" {
+			if _, ok := present[aggregate.GroupColumn]; !ok {
+				continue
+			}
+		}
+		out = append(out, aggregate)
+	}
+	return out
+}
+
+func columnStoreColumnNameSet(columns []ColumnStoreColumn) map[string]struct{} {
+	present := make(map[string]struct{}, len(columns))
+	for _, col := range columns {
+		present[col.Name] = struct{}{}
+	}
+	return present
+}
+
+func projectColumnDeclaredRowsForColumns(allColumns, selected []ColumnStoreColumn, rows []columnDeclaredRow) ([]columnDeclaredRow, error) {
+	if len(selected) == len(allColumns) {
+		all := true
+		for i := range selected {
+			if selected[i].Name != allColumns[i].Name || selected[i].Path != allColumns[i].Path {
+				all = false
+				break
+			}
+		}
+		if all {
+			return rows, nil
+		}
+	}
+	indexByName := make(map[string]int, len(allColumns))
+	for i, col := range allColumns {
+		indexByName[col.Name] = i
+	}
+	out := make([]columnDeclaredRow, len(rows))
+	for rowIdx, row := range rows {
+		out[rowIdx] = columnDeclaredRow{ID: bytes.Clone(row.ID), Deleted: row.Deleted}
+		if row.Deleted {
+			continue
+		}
+		if len(row.Values) != len(allColumns) {
+			return nil, fmt.Errorf("collections: typed-storage row[%d] values=%d columns=%d", rowIdx, len(row.Values), len(allColumns))
+		}
+		out[rowIdx].Values = make([]columnDeclaredValue, len(selected))
+		for selectedIdx, col := range selected {
+			allIdx, ok := indexByName[col.Name]
+			if !ok {
+				return nil, fmt.Errorf("collections: typed-storage selected column %q not found", col.Name)
+			}
+			out[rowIdx].Values[selectedIdx] = row.Values[allIdx]
+		}
+	}
+	return out, nil
+}
+
+func typedColumnAdapterRowsFromDeclaredRows(allColumns []ColumnStoreColumn, fields []TypedStorageField, rows []columnDeclaredRow) ([]typedColumnAdapterRow, error) {
+	if len(fields) == 0 {
+		return nil, nil
+	}
+	indexByPath := make(map[string]int, len(allColumns))
+	for i, col := range allColumns {
+		indexByPath[col.Path] = i
+	}
+	out := make([]typedColumnAdapterRow, len(rows))
+	for rowIdx, row := range rows {
+		if row.Deleted {
+			return nil, fmt.Errorf("collections: typed-column part row[%d] is deleted", rowIdx)
+		}
+		if len(row.Values) != len(allColumns) {
+			return nil, fmt.Errorf("collections: typed-column part row[%d] values=%d columns=%d", rowIdx, len(row.Values), len(allColumns))
+		}
+		values := make(map[string]columnDeclaredValue, len(fields))
+		for _, field := range fields {
+			allIdx, ok := indexByPath[field.Path]
+			if !ok {
+				return nil, fmt.Errorf("collections: typed-column part field %q not found", field.Path)
+			}
+			values[field.Path] = row.Values[allIdx]
+		}
+		out[rowIdx] = typedColumnAdapterRow{PrimaryID: int64(rowIdx), Values: values}
+	}
+	return out, nil
+}
+
+func buildTypedColumnPartImageForDeclaredRows(cfg ColumnStoreConfig, generation, partID uint64, rows []columnDeclaredRow) ([]byte, int, error) {
+	fields := columnStoreTypedColumnPartFields(cfg)
+	if len(fields) == 0 {
+		return nil, 0, nil
+	}
+	adapterRows, err := typedColumnAdapterRowsFromDeclaredRows(cfg.Columns, fields, rows)
+	if err != nil {
+		return nil, 0, err
+	}
+	part, err := buildTypedColumnAdapterPart(typedColumnAdapterOptions{
+		Collection:    "",
+		Namespace:     cfg.AssetManager.Namespace,
+		SchemaVersion: uint32(cfg.SchemaHash),
+		PartID:        partID,
+		Fields:        fields,
+	}, adapterRows)
+	if err != nil {
+		return nil, 0, err
+	}
+	image, err := part.buildImage()
+	if err != nil {
+		return nil, 0, err
+	}
+	return image.Bytes, image.Rows, nil
+}
+
+type typedColumnPartVisibleValues struct {
+	Values []columnDeclaredValue
+}
+
+func (c *Collection) typedColumnPartValuesForVisibleRowAtSnapshot(snap *backenddb.Snapshot, manifestRootID uint64, cfg ColumnStoreConfig, physicalRow columnPhysicalVisibleRow) (typedColumnPartVisibleValues, error) {
+	fields := columnStoreTypedColumnPartFields(cfg)
+	if len(fields) == 0 {
+		return typedColumnPartVisibleValues{}, nil
+	}
+	if physicalRow.Deleted {
+		return typedColumnPartVisibleValues{}, nil
+	}
+	ref, ok, err := c.typedColumnPartRefForGeneration(snap, manifestRootID, cfg, physicalRow.Generation)
+	if err != nil {
+		return typedColumnPartVisibleValues{}, err
+	}
+	if !ok {
+		return typedColumnPartVisibleValues{}, fmt.Errorf("collections: typed-column reconstruction missing typed_column_part asset for generation=%d", physicalRow.Generation)
+	}
+	readCache, err := newColumnPhysicalAssetReadCacheWithIntegrity(c.db.ColumnAssetRootDir(), cfg.AssetManager.Namespace, ColumnAssetReadIntegrityVerify)
+	if err != nil {
+		return typedColumnPartVisibleValues{}, err
+	}
+	defer func() { _ = readCache.close() }()
+	raw, err := readCache.read(ref.Ref, nil)
+	if err != nil {
+		return typedColumnPartVisibleValues{}, fmt.Errorf("collections: typed-column reconstruction read generation=%d part_id=%d: %w", ref.Ref.Generation, ref.Ref.PartID, err)
+	}
+	part, err := typedColumnAdapterPartFromBytes(typedColumnAdapterOptions{Fields: fields}, raw)
+	if err != nil {
+		return typedColumnPartVisibleValues{}, fmt.Errorf("collections: typed-column reconstruction decode generation=%d part_id=%d: %w", ref.Ref.Generation, ref.Ref.PartID, err)
+	}
+	rows, err := part.scanRows()
+	if err != nil {
+		return typedColumnPartVisibleValues{}, err
+	}
+	if physicalRow.RowIndex < 0 || physicalRow.RowIndex >= len(rows) {
+		return typedColumnPartVisibleValues{}, fmt.Errorf("collections: typed-column reconstruction row_index=%d outside typed_column_part rows=%d", physicalRow.RowIndex, len(rows))
+	}
+	row := rows[physicalRow.RowIndex]
+	if row.PrimaryID != int64(physicalRow.RowIndex) {
+		return typedColumnPartVisibleValues{}, fmt.Errorf("collections: typed-column reconstruction locator=%d want row_index=%d", row.PrimaryID, physicalRow.RowIndex)
+	}
+	values := make([]columnDeclaredValue, len(fields))
+	for i, field := range fields {
+		value, ok := row.Values[field.Path]
+		if !ok {
+			return typedColumnPartVisibleValues{}, fmt.Errorf("collections: typed-column reconstruction missing field %q", field.Path)
+		}
+		values[i] = value
+	}
+	return typedColumnPartVisibleValues{Values: values}, nil
+}
+
+func (c *Collection) typedColumnPartRefForGeneration(snap *backenddb.Snapshot, rootID uint64, cfg ColumnStoreConfig, generation uint64) (columnManifestAssetRefForScan, bool, error) {
+	if rootID == 0 {
+		return columnManifestAssetRefForScan{}, false, errors.New("collections: typed-column reconstruction missing manifest root")
+	}
+	if snap == nil {
+		return columnManifestAssetRefForScan{}, false, errCollectionDBNil
+	}
+	records, err := loadColumnManifestRecordsFromRoot(snap, rootID)
+	if err != nil {
+		return columnManifestAssetRefForScan{}, false, err
+	}
+	for _, record := range records {
+		if !bytes.HasPrefix(record.key, columnManifestPartRecordPrefixBytes) {
+			continue
+		}
+		keyGeneration, keyPartID, err := columnManifestPartKeyFromRecordKeyForScan(record.key)
+		if err != nil {
+			return columnManifestAssetRefForScan{}, false, err
+		}
+		ref, rows, _, _, _, reason, err := decodeColumnManifestPartFieldsForScan(record.value, cfg.AssetManager.Namespace)
+		if err != nil {
+			return columnManifestAssetRefForScan{}, false, err
+		}
+		if ref.Kind != ColumnAssetKindTCS1TypedColumnPart || ref.Generation != generation {
+			continue
+		}
+		if ref.Generation != keyGeneration || ref.PartID != keyPartID {
+			return columnManifestAssetRefForScan{}, false, fmt.Errorf("collections: typed-column manifest key generation/part mismatch")
+		}
+		operation, ok := columnPhysicalScanOperationFromBytes(reason)
+		if !ok {
+			return columnManifestAssetRefForScan{}, false, fmt.Errorf("collections: unsupported typed-column manifest reason %q", string(reason))
+		}
+		return columnManifestAssetRefForScan{Ref: ref, Reason: operation, Rows: rows}, true, nil
+	}
+	return columnManifestAssetRefForScan{}, false, nil
+}

--- a/TreeDB/collections/typed_column_publication.go
+++ b/TreeDB/collections/typed_column_publication.go
@@ -239,20 +239,29 @@ func (c *Collection) typedColumnPartValuesForVisibleRowAtSnapshotWithCache(snap 
 			return typedColumnPartVisibleValues{}, err
 		}
 		raw, readErr := readCache.read(ref.Ref, nil)
-		closeErr := readCache.close()
 		if readErr != nil {
+			if closeErr := readCache.close(); closeErr != nil {
+				readErr = errors.Join(readErr, closeErr)
+			}
 			return typedColumnPartVisibleValues{}, fmt.Errorf("collections: typed-column reconstruction read generation=%d part_id=%d: %w", ref.Ref.Generation, ref.Ref.PartID, readErr)
-		}
-		if closeErr != nil {
-			return typedColumnPartVisibleValues{}, closeErr
 		}
 		part, err := typedColumnAdapterPartFromBytes(typedColumnAdapterOptions{Fields: fields}, raw)
 		if err != nil {
+			if closeErr := readCache.close(); closeErr != nil {
+				err = errors.Join(err, closeErr)
+			}
 			return typedColumnPartVisibleValues{}, fmt.Errorf("collections: typed-column reconstruction decode generation=%d part_id=%d: %w", ref.Ref.Generation, ref.Ref.PartID, err)
 		}
 		rows, err = part.scanRows()
+		closeErr := readCache.close()
 		if err != nil {
+			if closeErr != nil {
+				err = errors.Join(err, closeErr)
+			}
 			return typedColumnPartVisibleValues{}, err
+		}
+		if closeErr != nil {
+			return typedColumnPartVisibleValues{}, closeErr
 		}
 		if cache != nil {
 			cache[physicalRow.Generation] = rows

--- a/TreeDB/collections/typed_column_publication_test.go
+++ b/TreeDB/collections/typed_column_publication_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"strings"
 	"testing"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
@@ -121,6 +122,44 @@ func TestTypedColumnReconstructionHybridOwners(t *testing.T) {
 	assertTypedColumnManifestShape1755(t, d, col, 1, 1)
 }
 
+func TestTypedColumnReconstructionScanHybridOwners(t *testing.T) {
+	dir := t.TempDir()
+	if err := backenddb.SaveFormatConfig(dir, backenddb.FormatConfig{RequiredFeatures: []string{backenddb.RequiredFeatureCommandWALV1}}); err != nil {
+		t.Fatalf("SaveFormatConfig: %v", err)
+	}
+	d := openCollectionCommandWALDB(t, dir)
+	col := createTypedColumnPartCollection1755(t, d)
+	if _, err := col.InsertBatch([][]byte{[]byte("e1"), []byte("e2")}, [][]byte{
+		[]byte(`{"time_us":1,"kind":"like","score":2.5,"flag":true,"payload":"alpha"}`),
+		[]byte(`{"time_us":2,"kind":"post","score":3.5,"flag":false,"payload":"beta"}`),
+	}); err != nil {
+		_ = d.Close()
+		t.Fatalf("InsertBatch: %v", err)
+	}
+	if err := d.Checkpoint(); err != nil {
+		_ = d.Close()
+		t.Fatalf("Checkpoint: %v", err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	reopened := openCollectionCommandWALDB(t, dir)
+	defer func() { _ = reopened.Close() }()
+	reopenedCol, err := NewCollectionManager(reopened).OpenCollection("events")
+	if err != nil {
+		t.Fatalf("OpenCollection reopened: %v", err)
+	}
+	records, truncated, err := reopenedCol.ScanDocuments(10)
+	if err != nil {
+		t.Fatalf("ScanDocuments: %v", err)
+	}
+	if truncated || len(records) != 2 {
+		t.Fatalf("ScanDocuments truncated=%v records=%d want 2", truncated, len(records))
+	}
+	assertJSONEqualM13C(t, records[0].Document, []byte(`{"time_us":1,"kind":"like","score":2.5,"flag":true,"payload":"alpha"}`))
+	assertJSONEqualM13C(t, records[1].Document, []byte(`{"time_us":2,"kind":"post","score":3.5,"flag":false,"payload":"beta"}`))
+}
+
 func TestTypedColumnPublicationRejectsOverlappingOwners(t *testing.T) {
 	_, err := NormalizeTypedStorageLayout(TypedStorageLayout{
 		Collection: "events",
@@ -129,8 +168,8 @@ func TestTypedColumnPublicationRejectsOverlappingOwners(t *testing.T) {
 			{Name: "score_column", Path: "score", Owner: TypedStorageOwnerColumnPart, ValueType: ColumnStoreValueDouble},
 		},
 	})
-	if err == nil {
-		t.Fatal("NormalizeTypedStorageLayout accepted overlapping authoritative owners")
+	if err == nil || !strings.Contains(err.Error(), "overlapping authoritative typed-storage owners") {
+		t.Fatalf("NormalizeTypedStorageLayout error=%v want overlapping owners rejection", err)
 	}
 }
 
@@ -138,8 +177,8 @@ func TestTypedColumnPublicationMissingAssetFailsClosed(t *testing.T) {
 	d, col, typedRef := setupSingleTypedColumnPart1755(t)
 	defer func() { _ = d.Close() }()
 	removeTypedColumnAssetPayload1755(t, d, col, typedRef)
-	if got, err := col.Get([]byte("e1")); err == nil || got != nil {
-		t.Fatalf("Get with missing typed-column asset got=%s err=%v, want fail-closed error", got, err)
+	if got, err := col.Get([]byte("e1")); err == nil || got != nil || !strings.Contains(err.Error(), "typed-column reconstruction") {
+		t.Fatalf("Get with missing typed-column asset got=%s err=%v, want typed-column fail-closed error", got, err)
 	}
 }
 
@@ -147,8 +186,8 @@ func TestTypedColumnPublicationCorruptAssetFailsClosed(t *testing.T) {
 	d, col, typedRef := setupSingleTypedColumnPart1755(t)
 	defer func() { _ = d.Close() }()
 	corruptTypedColumnAssetPayload1755(t, d, typedRef)
-	if got, err := col.Get([]byte("e1")); err == nil || got != nil {
-		t.Fatalf("Get with corrupt typed-column asset got=%s err=%v, want fail-closed error", got, err)
+	if got, err := col.Get([]byte("e1")); err == nil || got != nil || !strings.Contains(err.Error(), "typed-column reconstruction") {
+		t.Fatalf("Get with corrupt typed-column asset got=%s err=%v, want typed-column fail-closed error", got, err)
 	}
 }
 
@@ -163,7 +202,12 @@ func TestTypedColumnManifestRecoveryRefsSurviveReopen(t *testing.T) {
 		_ = d.Close()
 		t.Fatalf("InsertBatch: %v", err)
 	}
-	wantRef := typedColumnPartRefs1755(columnManifestAssetRefsForCollectionM12A(t, d, col))[0]
+	typedRefs := typedColumnPartRefs1755(columnManifestAssetRefsForCollectionM12A(t, d, col))
+	if len(typedRefs) != 1 {
+		_ = d.Close()
+		t.Fatalf("typed refs=%+v want one", typedRefs)
+	}
+	wantRef := typedRefs[0]
 	if err := d.Checkpoint(); err != nil {
 		_ = d.Close()
 		t.Fatalf("Checkpoint: %v", err)
@@ -177,9 +221,9 @@ func TestTypedColumnManifestRecoveryRefsSurviveReopen(t *testing.T) {
 	if err != nil {
 		t.Fatalf("OpenCollection reopened: %v", err)
 	}
-	typedRefs := typedColumnPartRefs1755(columnManifestAssetRefsForCollectionM12A(t, reopened, reopenedCol))
-	if len(typedRefs) != 1 || typedRefs[0] != wantRef {
-		t.Fatalf("reopened typed refs=%+v want [%+v]", typedRefs, wantRef)
+	reopenedTypedRefs := typedColumnPartRefs1755(columnManifestAssetRefsForCollectionM12A(t, reopened, reopenedCol))
+	if len(reopenedTypedRefs) != 1 || reopenedTypedRefs[0] != wantRef {
+		t.Fatalf("reopened typed refs=%+v want [%+v]", reopenedTypedRefs, wantRef)
 	}
 }
 
@@ -244,7 +288,11 @@ func TestTypedColumnPartMappedResourceReadUsesColumnPartClass1755(t *testing.T) 
 	if _, err := col.InsertBatch([][]byte{[]byte("e1")}, [][]byte{[]byte(`{"time_us":1,"kind":"like","score":2.5,"flag":true}`)}); err != nil {
 		t.Fatalf("InsertBatch: %v", err)
 	}
-	typedRef := typedColumnPartRefs1755(columnManifestAssetRefsForCollectionM12A(t, d, col))[0]
+	typedRefs := typedColumnPartRefs1755(columnManifestAssetRefsForCollectionM12A(t, d, col))
+	if len(typedRefs) != 1 {
+		t.Fatalf("typed refs=%+v want one", typedRefs)
+	}
+	typedRef := typedRefs[0]
 	manager := mappedresource.NewManager()
 	readCache, err := newColumnPhysicalAssetReadCacheWithIntegrity(d.ColumnAssetRootDir(), col.Meta().Options.ColumnStore.AssetManager.Namespace, ColumnAssetReadIntegrityVerify)
 	if err != nil {

--- a/TreeDB/collections/typed_column_publication_test.go
+++ b/TreeDB/collections/typed_column_publication_test.go
@@ -227,6 +227,31 @@ func TestTypedColumnManifestRecoveryRefsSurviveReopen(t *testing.T) {
 	}
 }
 
+func TestTypedColumnManifestSnapshotViewAcceptsTypedPartRefs1755(t *testing.T) {
+	d, col, _ := setupSingleTypedColumnPart1755(t)
+	defer func() { _ = d.Close() }()
+	id, ok := col.ColumnStoreCacheIdentity()
+	if !ok || id.ManifestRoot == 0 {
+		t.Fatalf("ColumnStoreCacheIdentity=%+v ok=%v want manifest root", id, ok)
+	}
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatalf("AcquireSnapshot returned nil")
+	}
+	defer func() { _ = snap.Close() }()
+	records, err := loadColumnManifestRecordsFromRoot(snap, id.ManifestRoot)
+	if err != nil {
+		t.Fatalf("loadColumnManifestRecordsFromRoot: %v", err)
+	}
+	snapshot, refs, mutationParts, err := decodeColumnManifestSnapshotViewForScan(records, col.Meta().Options.ColumnStore.AssetManager.Namespace)
+	if err != nil {
+		t.Fatalf("decodeColumnManifestSnapshotViewForScan: %v", err)
+	}
+	if snapshot.ExpectedParts != 2 || len(refs) != 1 || refs[0].Ref.Kind != ColumnAssetKindTCS1PartImage || mutationParts != 0 {
+		t.Fatalf("snapshot expected_parts=%d refs=%+v mutationParts=%d; want one physical ref and typed part counted", snapshot.ExpectedParts, refs, mutationParts)
+	}
+}
+
 func TestTypedColumnReachabilityRefsExposedForMaintenance(t *testing.T) {
 	d, col, typedRef := setupSingleTypedColumnPart1755(t)
 	defer func() { _ = d.Close() }()

--- a/TreeDB/collections/typed_column_publication_test.go
+++ b/TreeDB/collections/typed_column_publication_test.go
@@ -1,0 +1,281 @@
+package collections
+
+import (
+	"errors"
+	"testing"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/internal/mappedresource"
+)
+
+func TestTypedColumnPartDurablePublicationReopenAndReconstruction1755(t *testing.T) {
+	dir := t.TempDir()
+	if err := backenddb.SaveFormatConfig(dir, backenddb.FormatConfig{RequiredFeatures: []string{backenddb.RequiredFeatureCommandWALV1}}); err != nil {
+		t.Fatalf("SaveFormatConfig: %v", err)
+	}
+	d := openCollectionCommandWALDB(t, dir)
+	col := createTypedColumnPartCollection1755(t, d)
+
+	if _, err := col.InsertBatch([][]byte{[]byte("e1"), []byte("e2")}, [][]byte{
+		[]byte(`{"time_us":1,"kind":"like","score":2.5,"flag":true,"payload":"alpha"}`),
+		[]byte(`{"time_us":2,"kind":"post","score":3.5,"flag":false,"payload":"beta"}`),
+	}); err != nil {
+		_ = d.Close()
+		t.Fatalf("InsertBatch: %v", err)
+	}
+	assertTypedColumnManifestShape1755(t, d, col, 1, 1)
+	assertTypedColumnLatestRows1755(t, d, col, 1, []typedColumnExpectedRow1755{
+		{PrimaryID: 0, Kind: "like", Score: 2.5, Flag: true},
+		{PrimaryID: 1, Kind: "post", Score: 3.5, Flag: false},
+	})
+	got, err := col.Get([]byte("e1"))
+	if err != nil {
+		_ = d.Close()
+		t.Fatalf("Get e1: %v", err)
+	}
+	assertJSONEqualM13C(t, got, []byte(`{"time_us":1,"kind":"like","score":2.5,"flag":true,"payload":"alpha"}`))
+
+	updated, changed, err := col.Update([]byte("e1"), func(current []byte) ([]byte, bool, error) {
+		assertJSONEqualM13C(t, current, []byte(`{"time_us":1,"kind":"like","score":2.5,"flag":true,"payload":"alpha"}`))
+		return []byte(`{"time_us":3,"kind":"share","score":6.5,"flag":false,"payload":"alpha2"}`), true, nil
+	})
+	if err != nil || !updated || !changed {
+		_ = d.Close()
+		t.Fatalf("Update e1 updated=%v changed=%v err=%v", updated, changed, err)
+	}
+	assertTypedColumnManifestShape1755(t, d, col, 2, 2)
+	got, err = col.Get([]byte("e1"))
+	if err != nil {
+		_ = d.Close()
+		t.Fatalf("Get updated e1: %v", err)
+	}
+	assertJSONEqualM13C(t, got, []byte(`{"time_us":3,"kind":"share","score":6.5,"flag":false,"payload":"alpha2"}`))
+	got, err = col.Get([]byte("e2"))
+	if err != nil {
+		_ = d.Close()
+		t.Fatalf("Get e2: %v", err)
+	}
+	assertJSONEqualM13C(t, got, []byte(`{"time_us":2,"kind":"post","score":3.5,"flag":false,"payload":"beta"}`))
+
+	deleted, err := col.DeleteDocument([]byte("e2"))
+	if err != nil || !deleted {
+		_ = d.Close()
+		t.Fatalf("DeleteDocument e2 deleted=%v err=%v", deleted, err)
+	}
+	if got, err := col.Get([]byte("e2")); err != nil || got != nil {
+		_ = d.Close()
+		t.Fatalf("Get deleted e2 got=%s err=%v, want missing", got, err)
+	}
+	assertTypedColumnManifestShape1755(t, d, col, 3, 2)
+	got, err = col.Get([]byte("e1"))
+	if err != nil {
+		_ = d.Close()
+		t.Fatalf("Get e1 after delete: %v", err)
+	}
+	assertJSONEqualM13C(t, got, []byte(`{"time_us":3,"kind":"share","score":6.5,"flag":false,"payload":"alpha2"}`))
+
+	if err := d.Checkpoint(); err != nil {
+		_ = d.Close()
+		t.Fatalf("Checkpoint: %v", err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	d = nil
+
+	reopened := openCollectionCommandWALDB(t, dir)
+	defer func() { _ = reopened.Close() }()
+	reopenedCol, err := NewCollectionManager(reopened).OpenCollection("events")
+	if err != nil {
+		t.Fatalf("OpenCollection reopened: %v", err)
+	}
+	assertTypedColumnManifestShape1755(t, reopened, reopenedCol, 3, 2)
+	reopenedGot, err := reopenedCol.Get([]byte("e1"))
+	if err != nil {
+		t.Fatalf("reopened Get e1: %v", err)
+	}
+	assertJSONEqualM13C(t, reopenedGot, []byte(`{"time_us":3,"kind":"share","score":6.5,"flag":false,"payload":"alpha2"}`))
+	if reopenedGot, err := reopenedCol.Get([]byte("e2")); err != nil || reopenedGot != nil {
+		t.Fatalf("reopened Get deleted e2 got=%s err=%v, want missing", reopenedGot, err)
+	}
+}
+
+func TestTypedColumnPartMappedResourceReadUsesColumnPartClass1755(t *testing.T) {
+	dir := t.TempDir()
+	if err := backenddb.SaveFormatConfig(dir, backenddb.FormatConfig{RequiredFeatures: []string{backenddb.RequiredFeatureCommandWALV1}}); err != nil {
+		t.Fatalf("SaveFormatConfig: %v", err)
+	}
+	d := openCollectionCommandWALDB(t, dir)
+	defer func() { _ = d.Close() }()
+	col := createTypedColumnPartCollection1755(t, d)
+	if _, err := col.InsertBatch([][]byte{[]byte("e1")}, [][]byte{[]byte(`{"time_us":1,"kind":"like","score":2.5,"flag":true}`)}); err != nil {
+		t.Fatalf("InsertBatch: %v", err)
+	}
+	typedRef := typedColumnPartRefs1755(columnManifestAssetRefsForCollectionM12A(t, d, col))[0]
+	manager := mappedresource.NewManager()
+	readCache, err := newColumnPhysicalAssetReadCacheWithIntegrity(d.ColumnAssetRootDir(), col.Meta().Options.ColumnStore.AssetManager.Namespace, ColumnAssetReadIntegrityVerify)
+	if err != nil {
+		t.Fatalf("new read cache: %v", err)
+	}
+	scope := mappedresource.Scope{
+		Kind:       mappedresource.ScopeColumnPartReader,
+		ID:         "typed-column-part-1755",
+		Namespace:  typedRef.Namespace,
+		Collection: "events",
+		Generation: typedRef.Generation,
+		Reason:     "typed-column-publication-test",
+	}
+	if err := readCache.useMappedResourceManager(manager, scope, "typed-column-part-read"); err != nil {
+		_ = readCache.close()
+		t.Fatalf("useMappedResourceManager: %v", err)
+	}
+	if _, err := readCache.read(typedRef, nil); err != nil {
+		_ = readCache.close()
+		t.Fatalf("read typed part: %v", err)
+	}
+	pins := readCache.mappedResourcePins()
+	if len(pins) != 1 {
+		_ = readCache.close()
+		t.Fatalf("pins=%d want 1", len(pins))
+	}
+	pin := pins[0]
+	if pin.Key.Class != mappedresource.ClassTypedColumnAsset || pin.Scope.Kind != mappedresource.ScopeColumnPartReader || pin.Reason != "typed-column-part-read" {
+		_ = readCache.close()
+		t.Fatalf("unexpected mappedresource pin: %+v", pin)
+	}
+	if err := readCache.close(); err != nil {
+		t.Fatalf("close read cache: %v", err)
+	}
+	if pins := manager.PinSummary(); len(pins) != 0 {
+		t.Fatalf("pins after close=%d want 0", len(pins))
+	}
+}
+
+func TestTypedColumnPartUnsupportedValueFailsClosed1755(t *testing.T) {
+	dir := t.TempDir()
+	if err := backenddb.SaveFormatConfig(dir, backenddb.FormatConfig{RequiredFeatures: []string{backenddb.RequiredFeatureCommandWALV1}}); err != nil {
+		t.Fatalf("SaveFormatConfig: %v", err)
+	}
+	d := openCollectionCommandWALDB(t, dir)
+	defer func() { _ = d.Close() }()
+	cfg := testColumnStoreConfig(nil)
+	cfg.Columns = []ColumnStoreColumn{{
+		Name:       "embedding",
+		Path:       "embedding",
+		ValueType:  ColumnStoreValueFloat32Vector,
+		Owner:      TypedStorageOwnerColumnPart,
+		VectorDims: 3,
+	}}
+	cfg.SortKey = nil
+	cfg.AggregateMetadata = nil
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "events", Options: CollectionOptions{ColumnStore: cfg}}); err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	col, err := mgr.OpenCollection("events")
+	if err != nil {
+		t.Fatalf("OpenCollection: %v", err)
+	}
+	_, err = col.InsertBatch([][]byte{[]byte("e1")}, [][]byte{[]byte(`{"embedding":[1,2,3]}`)})
+	if !errors.Is(err, backenddb.ErrCommandWALRejected) {
+		t.Fatalf("InsertBatch error=%v want ErrCommandWALRejected", err)
+	}
+}
+
+type typedColumnExpectedRow1755 struct {
+	PrimaryID int64
+	Kind      string
+	Score     float64
+	Flag      bool
+}
+
+func createTypedColumnPartCollection1755(t testing.TB, d *backenddb.DB) *Collection {
+	t.Helper()
+	cfg := testColumnStoreConfig(nil)
+	cfg.Columns = []ColumnStoreColumn{
+		{Name: "time_us", Path: "time_us", ValueType: ColumnStoreValueInt64, Owner: TypedStorageOwnerRowAsset},
+		{Name: "kind", Path: "kind", ValueType: ColumnStoreValueString, Owner: TypedStorageOwnerColumnPart},
+		{Name: "score", Path: "score", ValueType: ColumnStoreValueDouble, Owner: TypedStorageOwnerColumnPart},
+		{Name: "flag", Path: "flag", ValueType: ColumnStoreValueBool, Owner: TypedStorageOwnerColumnPart},
+	}
+	cfg.SortKey = nil
+	cfg.AggregateMetadata = nil
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "events", Options: CollectionOptions{ColumnStore: cfg}}); err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	col, err := mgr.OpenCollection("events")
+	if err != nil {
+		t.Fatalf("OpenCollection: %v", err)
+	}
+	return col
+}
+
+func assertTypedColumnManifestShape1755(t testing.TB, d *backenddb.DB, col *Collection, wantGeneration uint64, wantTypedParts int) {
+	t.Helper()
+	id, ok := col.ColumnStoreCacheIdentity()
+	if !ok || id.ManifestRoot == 0 || id.ManifestGeneration != wantGeneration {
+		t.Fatalf("ColumnStoreCacheIdentity=%+v ok=%v want generation=%d manifest root", id, ok, wantGeneration)
+	}
+	refs := columnManifestAssetRefsForCollectionM12A(t, d, col)
+	physicalRefs := columnManifestPhysicalAssetRefsForTestM1634(refs)
+	typedRefs := typedColumnPartRefs1755(refs)
+	if len(physicalRefs) != int(wantGeneration) {
+		t.Fatalf("physical refs=%+v want %d", physicalRefs, wantGeneration)
+	}
+	if len(typedRefs) != wantTypedParts {
+		t.Fatalf("typed refs=%+v want %d all refs=%+v", typedRefs, wantTypedParts, refs)
+	}
+}
+
+func assertTypedColumnLatestRows1755(t testing.TB, d *backenddb.DB, col *Collection, generation uint64, want []typedColumnExpectedRow1755) {
+	t.Helper()
+	var ref ColumnAssetRef
+	found := false
+	for _, candidate := range typedColumnPartRefs1755(columnManifestAssetRefsForCollectionM12A(t, d, col)) {
+		if candidate.Generation == generation {
+			ref = candidate
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("missing typed-column part for generation=%d", generation)
+	}
+	raw, err := readColumnPhysicalAssetFromManager(d.ColumnAssetRootDir(), ref)
+	if err != nil {
+		t.Fatalf("read typed-column part: %v", err)
+	}
+	part, err := typedColumnAdapterPartFromBytes(typedColumnAdapterOptions{Fields: columnStoreTypedColumnPartFields(*col.Meta().Options.ColumnStore)}, raw)
+	if err != nil {
+		t.Fatalf("typedColumnAdapterPartFromBytes: %v", err)
+	}
+	rows, err := part.scanRows()
+	if err != nil {
+		t.Fatalf("scanRows: %v", err)
+	}
+	if len(rows) != len(want) {
+		t.Fatalf("typed rows=%d want %d", len(rows), len(want))
+	}
+	for i, row := range rows {
+		if row.PrimaryID != want[i].PrimaryID {
+			t.Fatalf("row[%d] primary_id=%d want %d", i, row.PrimaryID, want[i].PrimaryID)
+		}
+		kind := row.Values["kind"]
+		score := row.Values["score"]
+		flag := row.Values["flag"]
+		if kind.String != want[i].Kind || score.Double != want[i].Score || flag.Bool != want[i].Flag {
+			t.Fatalf("row[%d] values kind=%+v score=%+v flag=%+v want %+v", i, kind, score, flag, want[i])
+		}
+	}
+}
+
+func typedColumnPartRefs1755(refs []ColumnAssetRef) []ColumnAssetRef {
+	out := make([]ColumnAssetRef, 0, len(refs))
+	for _, ref := range refs {
+		if ref.Kind == ColumnAssetKindTCS1TypedColumnPart {
+			out = append(out, ref)
+		}
+	}
+	return out
+}

--- a/TreeDB/collections/typed_column_publication_test.go
+++ b/TreeDB/collections/typed_column_publication_test.go
@@ -227,6 +227,36 @@ func TestTypedColumnManifestRecoveryRefsSurviveReopen(t *testing.T) {
 	}
 }
 
+func TestTypedColumnManifestRejectsUnexpectedTypedPartID1755(t *testing.T) {
+	asset := ColumnPreparedAsset{
+		Ref: ColumnAssetRef{
+			Kind:       ColumnAssetKindTCS1TypedColumnPart,
+			Namespace:  "events/column-assets",
+			Generation: 1,
+			PartID:     99,
+			FileID:     1,
+			Length:     64,
+			Checksum:   7,
+		},
+		Rows:         1,
+		Bytes:        64,
+		PublishID:    1,
+		GenerationID: 1,
+		Reason:       string(ColumnPublishOperationInsert),
+	}
+	raw, err := encodeColumnManifestPartRecord(asset)
+	if err != nil {
+		t.Fatalf("encodeColumnManifestPartRecord: %v", err)
+	}
+	_, err = typedColumnPartRefsByGenerationFromManifestRecords([]columnManifestRecord{{
+		key:   columnManifestPartRecordKey(asset.Ref.Generation, asset.Ref.PartID),
+		value: raw,
+	}}, asset.Ref.Namespace)
+	if err == nil || !strings.Contains(err.Error(), "unexpected part_id=99") {
+		t.Fatalf("typedColumnPartRefsByGenerationFromManifestRecords err=%v want unexpected part_id", err)
+	}
+}
+
 func TestTypedColumnManifestSnapshotViewAcceptsTypedPartRefs1755(t *testing.T) {
 	d, col, _ := setupSingleTypedColumnPart1755(t)
 	defer func() { _ = d.Close() }()

--- a/TreeDB/collections/typed_column_publication_test.go
+++ b/TreeDB/collections/typed_column_publication_test.go
@@ -1,14 +1,16 @@
 package collections
 
 import (
+	"context"
 	"errors"
+	"os"
 	"testing"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 	"github.com/snissn/gomap/TreeDB/internal/mappedresource"
 )
 
-func TestTypedColumnPartDurablePublicationReopenAndReconstruction1755(t *testing.T) {
+func TestTypedColumnPublicationCheckpointReopen(t *testing.T) {
 	dir := t.TempDir()
 	if err := backenddb.SaveFormatConfig(dir, backenddb.FormatConfig{RequiredFeatures: []string{backenddb.RequiredFeatureCommandWALV1}}); err != nil {
 		t.Fatalf("SaveFormatConfig: %v", err)
@@ -100,6 +102,137 @@ func TestTypedColumnPartDurablePublicationReopenAndReconstruction1755(t *testing
 	}
 }
 
+func TestTypedColumnReconstructionHybridOwners(t *testing.T) {
+	dir := t.TempDir()
+	if err := backenddb.SaveFormatConfig(dir, backenddb.FormatConfig{RequiredFeatures: []string{backenddb.RequiredFeatureCommandWALV1}}); err != nil {
+		t.Fatalf("SaveFormatConfig: %v", err)
+	}
+	d := openCollectionCommandWALDB(t, dir)
+	defer func() { _ = d.Close() }()
+	col := createTypedColumnPartCollection1755(t, d)
+	if _, err := col.InsertBatch([][]byte{[]byte("e1")}, [][]byte{[]byte(`{"time_us":7,"kind":"like","score":9.25,"flag":true,"payload":"hybrid"}`)}); err != nil {
+		t.Fatalf("InsertBatch: %v", err)
+	}
+	got, err := col.Get([]byte("e1"))
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	assertJSONEqualM13C(t, got, []byte(`{"time_us":7,"kind":"like","score":9.25,"flag":true,"payload":"hybrid"}`))
+	assertTypedColumnManifestShape1755(t, d, col, 1, 1)
+}
+
+func TestTypedColumnPublicationRejectsOverlappingOwners(t *testing.T) {
+	_, err := NormalizeTypedStorageLayout(TypedStorageLayout{
+		Collection: "events",
+		Fields: []TypedStorageField{
+			{Name: "score_row", Path: "score", Owner: TypedStorageOwnerRowAsset, ValueType: ColumnStoreValueDouble},
+			{Name: "score_column", Path: "score", Owner: TypedStorageOwnerColumnPart, ValueType: ColumnStoreValueDouble},
+		},
+	})
+	if err == nil {
+		t.Fatal("NormalizeTypedStorageLayout accepted overlapping authoritative owners")
+	}
+}
+
+func TestTypedColumnPublicationMissingAssetFailsClosed(t *testing.T) {
+	d, col, typedRef := setupSingleTypedColumnPart1755(t)
+	defer func() { _ = d.Close() }()
+	removeTypedColumnAssetPayload1755(t, d, col, typedRef)
+	if got, err := col.Get([]byte("e1")); err == nil || got != nil {
+		t.Fatalf("Get with missing typed-column asset got=%s err=%v, want fail-closed error", got, err)
+	}
+}
+
+func TestTypedColumnPublicationCorruptAssetFailsClosed(t *testing.T) {
+	d, col, typedRef := setupSingleTypedColumnPart1755(t)
+	defer func() { _ = d.Close() }()
+	corruptTypedColumnAssetPayload1755(t, d, typedRef)
+	if got, err := col.Get([]byte("e1")); err == nil || got != nil {
+		t.Fatalf("Get with corrupt typed-column asset got=%s err=%v, want fail-closed error", got, err)
+	}
+}
+
+func TestTypedColumnManifestRecoveryRefsSurviveReopen(t *testing.T) {
+	dir := t.TempDir()
+	if err := backenddb.SaveFormatConfig(dir, backenddb.FormatConfig{RequiredFeatures: []string{backenddb.RequiredFeatureCommandWALV1}}); err != nil {
+		t.Fatalf("SaveFormatConfig: %v", err)
+	}
+	d := openCollectionCommandWALDB(t, dir)
+	col := createTypedColumnPartCollection1755(t, d)
+	if _, err := col.InsertBatch([][]byte{[]byte("e1")}, [][]byte{[]byte(`{"time_us":1,"kind":"like","score":2.5,"flag":true}`)}); err != nil {
+		_ = d.Close()
+		t.Fatalf("InsertBatch: %v", err)
+	}
+	wantRef := typedColumnPartRefs1755(columnManifestAssetRefsForCollectionM12A(t, d, col))[0]
+	if err := d.Checkpoint(); err != nil {
+		_ = d.Close()
+		t.Fatalf("Checkpoint: %v", err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	reopened := openCollectionCommandWALDB(t, dir)
+	defer func() { _ = reopened.Close() }()
+	reopenedCol, err := NewCollectionManager(reopened).OpenCollection("events")
+	if err != nil {
+		t.Fatalf("OpenCollection reopened: %v", err)
+	}
+	typedRefs := typedColumnPartRefs1755(columnManifestAssetRefsForCollectionM12A(t, reopened, reopenedCol))
+	if len(typedRefs) != 1 || typedRefs[0] != wantRef {
+		t.Fatalf("reopened typed refs=%+v want [%+v]", typedRefs, wantRef)
+	}
+}
+
+func TestTypedColumnReachabilityRefsExposedForMaintenance(t *testing.T) {
+	d, col, typedRef := setupSingleTypedColumnPart1755(t)
+	defer func() { _ = d.Close() }()
+	plan, err := col.PlanColumnAssetReachability(context.Background(), ColumnAssetReachabilityOptions{Detailed: true})
+	if err != nil {
+		t.Fatalf("PlanColumnAssetReachability: %v", err)
+	}
+	for _, entry := range plan.Entries {
+		if entry.Ref == typedRef {
+			if entry.Status != ColumnAssetReachabilityProtected {
+				t.Fatalf("typed ref reachability status=%s want protected entry=%+v", entry.Status, entry)
+			}
+			return
+		}
+	}
+	t.Fatalf("typed ref %+v not exposed in reachability entries=%+v", typedRef, plan.Entries)
+}
+
+func TestTypedColumnPublicationExistingTypedRowCompatibility(t *testing.T) {
+	dir := t.TempDir()
+	if err := backenddb.SaveFormatConfig(dir, backenddb.FormatConfig{RequiredFeatures: []string{backenddb.RequiredFeatureCommandWALV1}}); err != nil {
+		t.Fatalf("SaveFormatConfig: %v", err)
+	}
+	d := openCollectionCommandWALDB(t, dir)
+	defer func() { _ = d.Close() }()
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "events", Options: CollectionOptions{ColumnStore: testColumnStoreConfig(nil)}}); err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	col, err := mgr.OpenCollection("events")
+	if err != nil {
+		t.Fatalf("OpenCollection: %v", err)
+	}
+	if _, err := col.InsertBatch([][]byte{[]byte("e1")}, [][]byte{[]byte(`{"time_us":1,"kind":"like","did":"d1","payload":"row"}`)}); err != nil {
+		t.Fatalf("InsertBatch: %v", err)
+	}
+	refs := columnManifestAssetRefsForCollectionM12A(t, d, col)
+	if typedRefs := typedColumnPartRefs1755(refs); len(typedRefs) != 0 {
+		t.Fatalf("existing typed-row config published typed-column refs=%+v", typedRefs)
+	}
+	if physicalRefs := columnManifestPhysicalAssetRefsForTestM1634(refs); len(physicalRefs) != 1 {
+		t.Fatalf("physical refs=%+v want one", physicalRefs)
+	}
+	got, err := col.Get([]byte("e1"))
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	assertJSONEqualM13C(t, got, []byte(`{"time_us":1,"kind":"like","did":"d1","payload":"row"}`))
+}
+
 func TestTypedColumnPartMappedResourceReadUsesColumnPartClass1755(t *testing.T) {
 	dir := t.TempDir()
 	if err := backenddb.SaveFormatConfig(dir, backenddb.FormatConfig{RequiredFeatures: []string{backenddb.RequiredFeatureCommandWALV1}}); err != nil {
@@ -151,7 +284,7 @@ func TestTypedColumnPartMappedResourceReadUsesColumnPartClass1755(t *testing.T) 
 	}
 }
 
-func TestTypedColumnPartUnsupportedValueFailsClosed1755(t *testing.T) {
+func TestTypedColumnPublicationUnsupportedValueFailsClosed(t *testing.T) {
 	dir := t.TempDir()
 	if err := backenddb.SaveFormatConfig(dir, backenddb.FormatConfig{RequiredFeatures: []string{backenddb.RequiredFeatureCommandWALV1}}); err != nil {
 		t.Fatalf("SaveFormatConfig: %v", err)
@@ -179,6 +312,66 @@ func TestTypedColumnPartUnsupportedValueFailsClosed1755(t *testing.T) {
 	_, err = col.InsertBatch([][]byte{[]byte("e1")}, [][]byte{[]byte(`{"embedding":[1,2,3]}`)})
 	if !errors.Is(err, backenddb.ErrCommandWALRejected) {
 		t.Fatalf("InsertBatch error=%v want ErrCommandWALRejected", err)
+	}
+}
+
+func setupSingleTypedColumnPart1755(t testing.TB) (*backenddb.DB, *Collection, ColumnAssetRef) {
+	t.Helper()
+	dir := t.TempDir()
+	if err := backenddb.SaveFormatConfig(dir, backenddb.FormatConfig{RequiredFeatures: []string{backenddb.RequiredFeatureCommandWALV1}}); err != nil {
+		t.Fatalf("SaveFormatConfig: %v", err)
+	}
+	d := openCollectionCommandWALDB(t, dir)
+	col := createTypedColumnPartCollection1755(t, d)
+	if _, err := col.InsertBatch([][]byte{[]byte("e1")}, [][]byte{[]byte(`{"time_us":1,"kind":"like","score":2.5,"flag":true}`)}); err != nil {
+		_ = d.Close()
+		t.Fatalf("InsertBatch: %v", err)
+	}
+	typedRefs := typedColumnPartRefs1755(columnManifestAssetRefsForCollectionM12A(t, d, col))
+	if len(typedRefs) != 1 {
+		_ = d.Close()
+		t.Fatalf("typed refs=%+v want one", typedRefs)
+	}
+	return d, col, typedRefs[0]
+}
+
+func removeTypedColumnAssetPayload1755(t testing.TB, d *backenddb.DB, col *Collection, typedRef ColumnAssetRef) {
+	t.Helper()
+	path, err := columnAssetSegmentPath(d.ColumnAssetRootDir(), typedRef)
+	if err != nil {
+		t.Fatalf("columnAssetSegmentPath: %v", err)
+	}
+	for _, physicalRef := range columnManifestPhysicalAssetRefsForTestM1634(columnManifestAssetRefsForCollectionM12A(t, d, col)) {
+		if physicalRef.FileID == typedRef.FileID && physicalRef.Offset+physicalRef.Length > typedRef.Offset {
+			t.Fatalf("cannot remove typed payload without damaging physical row asset: physical=%+v typed=%+v", physicalRef, typedRef)
+		}
+	}
+	if err := os.Truncate(path, typedRef.Offset); err != nil {
+		t.Fatalf("truncate typed-column asset payload: %v", err)
+	}
+}
+
+func corruptTypedColumnAssetPayload1755(t testing.TB, d *backenddb.DB, typedRef ColumnAssetRef) {
+	t.Helper()
+	path, err := columnAssetSegmentPath(d.ColumnAssetRootDir(), typedRef)
+	if err != nil {
+		t.Fatalf("columnAssetSegmentPath: %v", err)
+	}
+	f, err := os.OpenFile(path, os.O_RDWR, 0)
+	if err != nil {
+		t.Fatalf("open typed-column asset segment: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+	buf := []byte{0}
+	if _, err := f.ReadAt(buf, typedRef.Offset); err != nil {
+		t.Fatalf("read typed-column asset byte: %v", err)
+	}
+	buf[0] ^= 0xff
+	if _, err := f.WriteAt(buf, typedRef.Offset); err != nil {
+		t.Fatalf("corrupt typed-column asset byte: %v", err)
+	}
+	if err := f.Sync(); err != nil {
+		t.Fatalf("sync corrupt typed-column asset: %v", err)
 	}
 }
 

--- a/TreeDB/collections/typed_storage_layout.go
+++ b/TreeDB/collections/typed_storage_layout.go
@@ -7,10 +7,9 @@ import (
 )
 
 // ErrTypedStorageColumnPartUnsupported is returned by fail-closed guards when a
-// normalized layout contains authoritative typed-column ownership. PR #1751 only
-// introduces the pure-metadata resolver; durable typed-column reads and
-// publication land in later #1744 children.
-var ErrTypedStorageColumnPartUnsupported = errors.New("collections: typed_column_part ownership is not supported yet")
+// normalized layout contains a typed_column_part owner/value-type combination
+// that the current durable typed-column publication path cannot represent.
+var ErrTypedStorageColumnPartUnsupported = errors.New("collections: typed_column_part ownership is unsupported for this field")
 
 // TypedStorageFieldOwner names the authoritative physical owner for one logical
 // field in a normalized typed-storage layout.
@@ -112,10 +111,14 @@ func ResolveTypedStorageLayout(meta CollectionMeta) (TypedStorageLayout, error) 
 	}
 	fields := make([]TypedStorageField, 0, len(cfg.Columns))
 	for _, col := range cfg.Columns {
+		owner, err := columnStoreColumnOwner(col)
+		if err != nil {
+			return TypedStorageLayout{}, fmt.Errorf("collections: invalid column %q owner: %w", col.Name, err)
+		}
 		fields = append(fields, TypedStorageField{
 			Name:               col.Name,
 			Path:               col.Path,
-			Owner:              TypedStorageOwnerRowAsset,
+			Owner:              owner,
 			ValueType:          col.ValueType,
 			Nullable:           col.Nullable,
 			Dictionary:         col.Dictionary,
@@ -343,12 +346,13 @@ func normalizeTypedStorageFieldOwner(owner TypedStorageFieldOwner) (TypedStorage
 func derivedAcceleratorsFromTypedStorageCompatibilityConfig(cfg ColumnStoreConfig) []TypedStorageDerivedAccelerator {
 	var out []TypedStorageDerivedAccelerator
 	for _, col := range cfg.Columns {
+		owner := columnStoreColumnOwnerOrRowAsset(col)
 		if col.Dictionary {
 			out = append(out, TypedStorageDerivedAccelerator{
 				Name:            col.Name + ":dictionary",
 				Class:           TypedStorageAssetClassDerivedAccelerator,
 				SourceFieldPath: col.Path,
-				SourceOwner:     TypedStorageOwnerRowAsset,
+				SourceOwner:     owner,
 			})
 		}
 		if col.ValueType == ColumnStoreValueInt64 && !col.Nullable {
@@ -356,7 +360,7 @@ func derivedAcceleratorsFromTypedStorageCompatibilityConfig(cfg ColumnStoreConfi
 				Name:            col.Name + ":int64_values",
 				Class:           TypedStorageAssetClassDerivedAccelerator,
 				SourceFieldPath: col.Path,
-				SourceOwner:     TypedStorageOwnerRowAsset,
+				SourceOwner:     owner,
 			})
 		}
 	}
@@ -368,7 +372,7 @@ func derivedAcceleratorsFromTypedStorageCompatibilityConfig(cfg ColumnStoreConfi
 		if aggregate.Column != "" {
 			if col, ok := typedStorageCompatibilityColumnByName(cfg.Columns, aggregate.Column); ok {
 				accel.SourceFieldPath = col.Path
-				accel.SourceOwner = TypedStorageOwnerRowAsset
+				accel.SourceOwner = columnStoreColumnOwnerOrRowAsset(col)
 			}
 		}
 		out = append(out, accel)
@@ -410,21 +414,34 @@ func (l TypedStorageLayout) HasTypedColumnPartOwners() bool {
 	return false
 }
 
-// EnsureReadSupported fails closed for layouts that mention typed_column_part
-// ownership before the production typed-column read path exists.
+// EnsureReadSupported fails closed for typed_column_part owners whose value
+// types are not represented by the current durable typed-column scalar path.
 func (l TypedStorageLayout) EnsureReadSupported() error {
-	if l.HasTypedColumnPartOwners() {
-		return ErrTypedStorageColumnPartUnsupported
-	}
-	return nil
+	return l.ensureTypedColumnPartSupported()
 }
 
-// EnsurePublicationSupported fails closed for layouts that mention
-// typed_column_part ownership before the production typed-column publication
-// path exists.
+// EnsurePublicationSupported fails closed for typed_column_part owners whose
+// value types are not represented by the current durable typed-column scalar
+// path.
 func (l TypedStorageLayout) EnsurePublicationSupported() error {
-	if l.HasTypedColumnPartOwners() {
-		return ErrTypedStorageColumnPartUnsupported
+	return l.ensureTypedColumnPartSupported()
+}
+
+func (l TypedStorageLayout) ensureTypedColumnPartSupported() error {
+	for _, field := range l.Fields {
+		if field.Owner != TypedStorageOwnerColumnPart {
+			continue
+		}
+		switch field.ValueType {
+		case ColumnStoreValueBool, ColumnStoreValueInt64, ColumnStoreValueFloat32, ColumnStoreValueDouble, ColumnStoreValueString:
+			if field.Nullable {
+				return fmt.Errorf("%w: nullable field %q", ErrTypedStorageColumnPartUnsupported, field.Path)
+			}
+		case ColumnStoreValueFloat32Vector, ColumnStoreValueAdjacencyList:
+			return fmt.Errorf("%w: value_type %q for field %q is deferred", ErrTypedStorageColumnPartUnsupported, field.ValueType, field.Path)
+		default:
+			return fmt.Errorf("%w: value_type %q for field %q", ErrTypedStorageColumnPartUnsupported, field.ValueType, field.Path)
+		}
 	}
 	return nil
 }

--- a/TreeDB/collections/typed_storage_layout_test.go
+++ b/TreeDB/collections/typed_storage_layout_test.go
@@ -301,6 +301,9 @@ func TestTypedStorageCompatibilityConfigCanOptIntoColumnPartOwner(t *testing.T) 
 	if err := layout.EnsureReadSupported(); err != nil {
 		t.Fatalf("EnsureReadSupported: %v", err)
 	}
+	if err := layout.EnsurePublicationSupported(); err != nil {
+		t.Fatalf("EnsurePublicationSupported: %v", err)
+	}
 }
 
 func TestTypedStorageStatusVocabulary(t *testing.T) {

--- a/TreeDB/collections/typed_storage_layout_test.go
+++ b/TreeDB/collections/typed_storage_layout_test.go
@@ -83,7 +83,7 @@ func TestTypedStorageLayoutNormalizeExistingColumnStoreConfigUsesTypedRowAsset(t
 	}
 }
 
-func TestTypedStorageLayoutTypedColumnPlaceholderFailsClosed(t *testing.T) {
+func TestTypedStorageLayoutTypedColumnScalarSupported(t *testing.T) {
 	layout, err := NormalizeTypedStorageLayout(TypedStorageLayout{
 		Collection: "events",
 		Fields: []TypedStorageField{{
@@ -98,7 +98,29 @@ func TestTypedStorageLayoutTypedColumnPlaceholderFailsClosed(t *testing.T) {
 	}
 	requireTypedStorageOwner(t, layout, "score", TypedStorageOwnerColumnPart)
 	if !layout.HasTypedColumnPartOwners() {
-		t.Fatalf("typed-column placeholder not detected")
+		t.Fatalf("typed-column part owner not detected")
+	}
+	if err := layout.EnsureReadSupported(); err != nil {
+		t.Fatalf("EnsureReadSupported: %v", err)
+	}
+	if err := layout.EnsurePublicationSupported(); err != nil {
+		t.Fatalf("EnsurePublicationSupported: %v", err)
+	}
+}
+
+func TestTypedStorageLayoutTypedColumnUnsupportedValueFailsClosed(t *testing.T) {
+	layout, err := NormalizeTypedStorageLayout(TypedStorageLayout{
+		Collection: "events",
+		Fields: []TypedStorageField{{
+			Name:       "embedding",
+			Path:       "embedding",
+			Owner:      TypedStorageOwnerColumnPart,
+			ValueType:  ColumnStoreValueFloat32Vector,
+			VectorDims: 3,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("NormalizeTypedStorageLayout: %v", err)
 	}
 	if err := layout.EnsureReadSupported(); !errors.Is(err, ErrTypedStorageColumnPartUnsupported) {
 		t.Fatalf("EnsureReadSupported error=%v want %v", err, ErrTypedStorageColumnPartUnsupported)
@@ -256,6 +278,29 @@ func TestTypedStorageCompatibilityAliases(t *testing.T) {
 		t.Fatalf("ResolveTypedStorageLayout with public compatibility config: %v", err)
 	}
 	requireTypedStorageOwner(t, layout, "compat_field", TypedStorageOwnerRowAsset)
+}
+
+func TestTypedStorageCompatibilityConfigCanOptIntoColumnPartOwner(t *testing.T) {
+	cfg := ColumnStoreConfig{
+		Enabled: true,
+		Columns: []ColumnStoreColumn{{
+			Name:      "score",
+			Path:      "score",
+			ValueType: ColumnStoreValueDouble,
+			Owner:     TypedStorageOwnerColumnPart,
+		}},
+	}
+	layout, err := ResolveTypedStorageLayout(CollectionMeta{
+		Name:    "events",
+		Options: CollectionOptions{ColumnStore: &cfg},
+	})
+	if err != nil {
+		t.Fatalf("ResolveTypedStorageLayout with typed-column owner: %v", err)
+	}
+	requireTypedStorageOwner(t, layout, "score", TypedStorageOwnerColumnPart)
+	if err := layout.EnsureReadSupported(); err != nil {
+		t.Fatalf("EnsureReadSupported: %v", err)
+	}
 }
 
 func TestTypedStorageStatusVocabulary(t *testing.T) {

--- a/TreeDB/docs/spec/README.md
+++ b/TreeDB/docs/spec/README.md
@@ -162,9 +162,10 @@ Given pre-alpha status, this is a living spec that tracks implementation.
     `TreeDB/internal/typedcolumn` data-plane transplant from
     `experiments/colgranule`.
 - `TreeDB/docs/spec/typed-column-adapter.md`
-  - issue #1754 implementation note for the non-authoritative adapter from
-    TreeDB typed-storage field metadata and #1736 mapped resources to the
-    transplanted typed-column data plane.
+  - issues #1754/#1755 implementation note for the adapter from TreeDB
+    typed-storage field metadata and #1736 mapped resources to the transplanted
+    typed-column data plane, including opt-in durable scalar publication and
+    reconstruction.
 
 ## Canonical Ownership
 
@@ -190,8 +191,8 @@ TreeDB-wide storage terms (`value log`, `leaf log`, `commit log`,
 Typed physical storage vocabulary (`typed storage`, `typed-row storage`,
 `typed-column storage`, `typed_row_asset`, `typed_column_part`,
 `retained_document`, `document_payload`, and `derived_accelerator`) is owned by
-`typed-storage-naming.md`; the #1753 non-authoritative typed-column transplant
-scope is recorded in `typed-column-transplant.md`, and the #1754 adapter seam is
+`typed-storage-naming.md`; the #1753 typed-column transplant scope is recorded
+in `typed-column-transplant.md`, and the #1754/#1755 adapter/publication seam is
 recorded in `typed-column-adapter.md`. User-command WAL lifecycle terms
 (`CommandEnvelope`, `LSN`, `AppliedLSN`, `WAL-supported`, `WAL-rejected`,
 `WAL-off-only`) are owned by `user-command-wal.md`. Deprecated collection root-delta WAL terms

--- a/TreeDB/docs/spec/storage-format.md
+++ b/TreeDB/docs/spec/storage-format.md
@@ -497,7 +497,7 @@ Writers emit version 2.
 
 Sectioned typed-column part payloads are `TreeDB/internal/typedcolumn` part
 images referenced by `ColumnAssetRef.Kind = tcs1_typed_column_part`. The durable
-#1755 scalar path represents bool, int64, float32, double/float64, and string
+Issue `#1755` scalar path represents bool, int64, float32, double/float64, and string
 fields; nullable/missing values, vector sections, and adjacency sections fail
 closed until later typed-storage issues extend the format.
 

--- a/TreeDB/docs/spec/storage-format.md
+++ b/TreeDB/docs/spec/storage-format.md
@@ -420,15 +420,15 @@ Encoding rules:
 - if compact encoding is not smaller than the raw page, TreeDB stores the raw
   page payload instead.
 
-### 7.3 Typed Asset Manager and TCPA Typed-Row Physical Assets
+### 7.3 Typed Asset Manager, TCPA Typed-Row Assets, and Typed-Column Parts
 
 Production typed-storage physical data is stored in typed asset manager segments
 under the compatibility `column_assets` directory. These assets are
 value-log-shaped durable payloads, but they are not ordinary row `value_vlog`
 values and they are not split-leaf `leaf_vlog` records. Manifest/control roots
-can live in B-tree/root metadata; typed-row payloads and derived accelerator
-payloads such as marks, dictionaries, locators, and aggregate metadata belong
-under the isolated typed asset manager namespace.
+can live in B-tree/root metadata; typed-row payloads, typed-column part payloads,
+and derived accelerator payloads such as marks, dictionaries, locators, and
+aggregate metadata belong under the isolated typed asset manager namespace.
 
 A collection namespace such as `events/column-assets` maps to:
 
@@ -443,11 +443,13 @@ Dir/maindb/column_assets/events/column-assets/
 
 Segment file names use `segment-%06d.tca`. Durable manifest records store
 typed `ColumnAssetRef` values containing kind, namespace, generation, part id,
-segment file id, offset, length, and checksum. GC/rewrite must enumerate these
-refs from manifest/control roots and snapshots; it must not scan row documents
-to discover column assets.
+segment file id, offset, length, and checksum. Current part refs may use
+`tcs1_part_image` for compatibility typed-row/TCPA assets or
+`tcs1_typed_column_part` for sectioned scalar typed-column parts. GC/rewrite
+must enumerate these refs from manifest/control roots and snapshots; it must not
+scan row documents to discover typed-storage assets.
 
-Current physical part payloads use the `TCPA` envelope:
+Compatibility typed-row physical part payloads use the `TCPA` envelope:
 
 ```text
 u32      Magic = "TCPA"
@@ -474,8 +476,12 @@ values   declared column values when Deleted=false
 ```
 
 Insert/update rows must have `Deleted=false` and exactly one value per declared
-column. Delete/tombstone rows must have `Deleted=true` and zero column values.
-Readers validate namespace, generation, part id, schema hash, declared column
+`typed_row_asset` column in the row asset. Delete/tombstone rows must have
+`Deleted=true` and zero column values. For layouts with `typed_column_part`
+owners, a `TCPA` row asset is still published for row IDs/tombstones and any
+row-owned fields; the matching `tcs1_typed_column_part` for the same generation
+contains authoritative scalar typed-column values keyed by row index. Readers
+validate namespace, generation, part id, schema hash, declared column
 descriptors, length, and checksum before accepting an asset ref.
 
 Version 1 row payloads omitted the `Deleted` flag and represented only live
@@ -488,6 +494,12 @@ values   declared column values
 
 M12C and later decoders may read version 1 as `Deleted=false` for pre-v2 assets.
 Writers emit version 2.
+
+Sectioned typed-column part payloads are `TreeDB/internal/typedcolumn` part
+images referenced by `ColumnAssetRef.Kind = tcs1_typed_column_part`. The durable
+#1755 scalar path represents bool, int64, float32, double/float64, and string
+fields; nullable/missing values, vector sections, and adjacency sections fail
+closed until later typed-storage issues extend the format.
 
 ## 8. Commit-Log Segment Format
 

--- a/TreeDB/docs/spec/typed-column-adapter.md
+++ b/TreeDB/docs/spec/typed-column-adapter.md
@@ -15,7 +15,7 @@ locator/typed-row asset. Existing `ColumnStoreConfig` metadata still resolves to
 `typed_row_asset` unless a column explicitly sets `Owner:
 typed_column_part`.
 
-#1755 remains scoped: it does not switch query planning or physical predicate
+Issue `#1755` remains scoped: it does not switch query planning or physical predicate
 scans to typed-column sections, does not publish vector/adjacency sections, and
 does not make derived accelerators authoritative.
 

--- a/TreeDB/docs/spec/typed-column-adapter.md
+++ b/TreeDB/docs/spec/typed-column-adapter.md
@@ -1,21 +1,27 @@
-# Typed-Column Adapter (#1754)
+# Typed-Column Adapter and Durable Scalar Publication (#1754/#1755)
 
-Status: current implementation note for issue #1754 under parent tracker #1744.
+Status: current implementation note for issues #1754 and #1755 under parent tracker #1744.
 
 `TreeDB/collections/typed_column_adapter.go` adapts the transplanted
 `TreeDB/internal/typedcolumn` data plane to TreeDB typed-storage field metadata,
 legacy `ColumnStoreValueType` compatibility names, retained-payload test seams,
 and #1736 `mappedresource` section access.
 
-This adapter is **non-authoritative**. It does not publish collection manifests,
-write recovery metadata, replay WAL state, switch query planning, or enable
-`typed_column_part` ownership in production. Existing `ColumnStoreConfig`
-metadata still resolves to `typed_row_asset` unless tests construct explicit
-`TypedStorageOwnerColumnPart` fields for this adapter seam.
+The #1754 adapter seam maps TreeDB metadata to `typedcolumn` parts. Issue #1755
+adds an opt-in durable scalar publication path for explicit
+`typed_column_part` owners: collection manifests can now reference immutable
+`tcs1_typed_column_part` assets beside the compatibility typed-row `TCPA` row
+locator/typed-row asset. Existing `ColumnStoreConfig` metadata still resolves to
+`typed_row_asset` unless a column explicitly sets `Owner:
+typed_column_part`.
+
+#1755 remains scoped: it does not switch query planning or physical predicate
+scans to typed-column sections, does not publish vector/adjacency sections, and
+does not make derived accelerators authoritative.
 
 ## Type Matrix
 
-| TreeDB declared type | #1754 adapter status | Representation |
+| TreeDB declared type | adapter / #1755 publication status | Representation |
 | --- | --- | --- |
 | `bool` | represented | `typedcolumn.ColumnTypeBool` bitpack/RLE encoding. |
 | `int64` | represented | `typedcolumn.ColumnTypeInt64` delta-varint encoding. |
@@ -25,10 +31,25 @@ metadata still resolves to `typed_row_asset` unless tests construct explicit
 | `float32_vector` | fail closed | Dense vector typed-column sections are staged to #1756. |
 | `adjacency_list` | fail closed | Adjacency typed-column sections are staged to #1756. |
 
-Nullable/missing adapter values fail closed in #1754 because the transplanted
-part builder does not yet have a TreeDB nullable typed-column representation.
-Publication/reopen work in #1755 and vector/adjacency work in #1756 may extend
-this matrix without changing the existing typed-row compatibility path.
+Nullable/missing adapter values still fail closed because the transplanted part
+builder does not yet have a TreeDB nullable typed-column representation. Vector
+and adjacency work remains staged to #1756.
+
+## Durable Publication / Reconstruction Seam (#1755)
+
+For inserts and updates with scalar `typed_column_part` owners, TreeDB writes:
+
+- a compatibility `tcs1_part_image`/`TCPA` typed-row asset containing row IDs,
+  tombstones, and any `typed_row_asset` owned fields;
+- a `tcs1_typed_column_part` asset containing the authoritative scalar
+  `typed_column_part` values for the same generation.
+
+Deletes publish only a typed-row tombstone asset. Retained-payload
+reconstruction finds the latest visible typed-row locator for a document ID and,
+when that locator's generation has typed-column fields, reads the matching
+`typed_column_part` by row index. Reopen/recovery uses the manifest refs and
+existing typed asset manager paths; typed-column refs participate in reachability
+and rewrite/GC eligibility as durable typed-storage assets.
 
 ## Resource Seam
 
@@ -36,7 +57,8 @@ this matrix without changing the existing typed-row compatibility path.
 issue #1736 `mappedresource.Manager` handles. Tests cover file-backed mmap-or-heap
 reads and heap reads for the same section bytes. Fixed-width adapter reads use
 mappedresource typed-view validation for `[]int64`, `[]float32`, `[]float64`,
-and `[]uint32` buffers.
+and `[]uint32` buffers. Durable typed-column asset reads use the typed asset read
+cache with `mappedresource.ClassTypedColumnAsset` when a manager is supplied.
 
 ## Retained Payload Seam
 
@@ -47,6 +69,7 @@ production retained-payload behavior.
 ## Boundary
 
 The only production `TreeDB/collections` file that imports
-`TreeDB/internal/typedcolumn` in issue #1754 should be the adapter seam. Later
-PRs must keep publication/reopen/recovery wiring in #1755 and query/vector
-integration in #1756/#1757 rather than hiding those changes in the adapter.
+`TreeDB/internal/typedcolumn` is the adapter seam. Publication/reopen logic calls
+through that seam. Query/vector integration remains deferred to #1756/#1757, and
+`typed_column_part` supports only the scalar matrix above until those issues
+land.

--- a/TreeDB/docs/spec/typed-column-transplant.md
+++ b/TreeDB/docs/spec/typed-column-transplant.md
@@ -59,6 +59,6 @@ this data plane into the existing typed-row physical asset format.
 
 `TreeDB/internal/typedcolumn` remains a data-plane package. Issue `#1754` added
 the narrow `typed_column_adapter.go` seam for metadata/resource adaptation, and
-#1755 routes scalar durable publication/reconstruction through that seam. Query
+Issue `#1755` routes scalar durable publication/reconstruction through that seam. Query
 planning, vector/adjacency sections, and predicate scan integration remain owned
 by later #1744 children.

--- a/TreeDB/docs/spec/typed-column-transplant.md
+++ b/TreeDB/docs/spec/typed-column-transplant.md
@@ -3,11 +3,12 @@
 Status: current implementation note for issue #1753 under parent tracker #1744.
 
 `TreeDB/internal/typedcolumn` is a copy/adapt transplant of the coherent
-`experiments/colgranule` typed-column data plane. It is intentionally
-**non-authoritative**: it can build, encode, decode, and scan typed-column part
-artifacts, but it does not publish production collection assets, register
-collection manifests, participate in WAL/recovery, change query planning, or
-make `typed_column_part` an authoritative field owner.
+`experiments/colgranule` typed-column data plane. Issue #1753 kept the package
+non-authoritative: it could build, encode, decode, and scan typed-column part
+artifacts without publishing production collection assets. Issue #1755 now uses
+that data plane through the `TreeDB/collections` adapter for opt-in durable
+scalar `typed_column_part` publication/reconstruction; the internal package
+itself remains a data-plane package, not a manifest/WAL/query owner.
 
 The package preserves the colgranule data-plane shape:
 
@@ -21,10 +22,10 @@ The package preserves the colgranule data-plane shape:
 - latest-visible base/delta/tombstone part-set logic over caller-owned parts;
 - a narrow `SectionReader` seam for #1754 mappedresource-backed byte access.
 
-Production control-plane adaptation is deferred to #1754/#1755. Any future byte
-access backed by production files should adapt `SectionReader` to the #1736
-mapped-resource handles rather than reshaping this data plane into the existing
-typed-row physical asset format.
+Production control-plane adaptation begins in #1755 for scalar publication and
+reconstruction. Future byte access backed by production files should continue to
+adapt `SectionReader` to the #1736 mapped-resource handles rather than reshaping
+this data plane into the existing typed-row physical asset format.
 
 ## Copy / Adapt / Defer Table
 
@@ -56,8 +57,8 @@ typed-row physical asset format.
 
 ## Boundary
 
-`TreeDB/internal/typedcolumn` remains a data-plane package. Issue `#1753`
-forbade production `TreeDB/collections` imports; issue `#1754` adds the narrow
-`typed_column_adapter.go` seam for metadata/resource adaptation. The adapter seam
-still must not publish manifests or change `ResolveTypedStorageLayout`
-fail-closed behavior for authoritative `typed_column_part` ownership.
+`TreeDB/internal/typedcolumn` remains a data-plane package. Issue `#1754` added
+the narrow `typed_column_adapter.go` seam for metadata/resource adaptation, and
+#1755 routes scalar durable publication/reconstruction through that seam. Query
+planning, vector/adjacency sections, and predicate scan integration remain owned
+by later #1744 children.

--- a/TreeDB/docs/spec/typed-storage-naming.md
+++ b/TreeDB/docs/spec/typed-storage-naming.md
@@ -17,7 +17,7 @@ Required vocabulary:
 | --- | --- |
 | `typed storage` | Umbrella subsystem for typed-row storage and typed-column storage. |
 | `typed-row storage` / `typed_row_asset` | Current row-record physical asset path for declared typed values. |
-| `typed-column storage` / `typed_column_part` | Future true sectioned, column-major part assets transplanted from `experiments/colgranule`. |
+| `typed-column storage` / `typed_column_part` | Opt-in true sectioned, column-major part assets transplanted from `experiments/colgranule` (scalar durable publication starts in #1755). |
 | `retained document` / `document_payload` | Flexible document owner or retained residual payload used for reconstruction. |
 | `derived accelerator` | Non-authoritative duplicate, index, cache, or metadata derived from an authoritative owner. |
 
@@ -51,8 +51,9 @@ declared columns with no explicit typed-storage owner resolve to
 `typed_row_asset`. `ColumnRetainedPayloadFull` is compatibility duplication in
 `document_payload`; it does not make the retained document a second
 authoritative owner for declared typed fields. `typed_column_part` ownership may
-be represented as a placeholder, but reads and publication must fail closed until
-the typed-column format/publication work lands.
+be represented in metadata; after #1755, scalar bool/int64/float32/double/string
+owners have opt-in durable publication and reconstruction, while unsupported
+value types still fail closed.
 
 The resolver is pure metadata only: it must not perform filesystem IO, mmap,
 section decode, DB mutation, asset open, publication, query planning, or durable
@@ -88,13 +89,25 @@ internal `ColumnStore*` umbrella names.
 
 ## PR 4 Typed-Column Adapter
 
-Issue #1754 introduces `TreeDB/collections/typed_column_adapter.go` as a
-non-authoritative adapter seam from TreeDB typed-storage metadata and #1736
-resource handles to `TreeDB/internal/typedcolumn`. It may use
-`ColumnStoreValueType` as compatibility input, but existing `ColumnStoreConfig`
-metadata still resolves to `typed_row_asset` unless tests construct explicit
-`typed_column_part` fields. This adapter must not publish production manifests,
-change query planning, or enable authoritative `typed_column_part` reads.
+Issue #1754 introduces `TreeDB/collections/typed_column_adapter.go` as an
+adapter seam from TreeDB typed-storage metadata and #1736 resource handles to
+`TreeDB/internal/typedcolumn`. It may use `ColumnStoreValueType` as
+compatibility input, but existing `ColumnStoreConfig` metadata still resolves to
+`typed_row_asset` unless a column explicitly selects `typed_column_part`.
+
+## PR 5 Durable Scalar Typed-Column Publication
+
+Issue #1755 lets explicit scalar `typed_column_part` owners publish durable
+`tcs1_typed_column_part` assets and reconstruct retained-payload documents after
+reopen. A compatibility `typed_row_asset`/`TCPA` asset remains present per
+mutation generation as the row-ID/tombstone locator and owner of any
+`typed_row_asset` fields. The invariant remains one authoritative owner per
+logical field per generation: retained document, typed-row asset, or typed-column
+part.
+
+The #1755 path is intentionally not the query/vector switch. Vector and
+adjacency section representation remains #1756, and production predicate scan /
+query integration remains #1757.
 
 ## Current Derived Accelerator Classifications
 

--- a/docs/TREEDB_STORAGE_FORMAT.md
+++ b/docs/TREEDB_STORAGE_FORMAT.md
@@ -22,7 +22,7 @@ Operator-facing behavior is covered by:
   - `Dir/dictdb/`: dictionary store (for value-log compression)
 - Large values can be stored out-of-line in `Dir/maindb/value_vlog/` and referenced by `page.ValuePtr` pointers stored in the B+Tree.
 - The value log is **persistent storage**: pointers are valid long-term; segments are deleted only when unreachable (GC) or after rewrite/compaction.
-- Typed-storage physical assets are **value-log-shaped typed assets**, not generic row `value_vlog` payloads. Current production typed-row assets live under the isolated typed asset manager namespace; future typed-column parts will use the same typed-storage lifecycle.
+- Typed-storage physical assets are **value-log-shaped typed assets**, not generic row `value_vlog` payloads. Production typed-row assets and opt-in scalar typed-column parts live under the isolated typed asset manager namespace.
 
 ## Directory layout
 
@@ -62,10 +62,12 @@ Dir/maindb/column_assets/events/column-assets/
 
 Column manifest records stored in B-tree/root metadata hold durable
 `ColumnAssetRef` values: kind, namespace, generation, part id, segment file id,
-offset, length, and checksum. GC/rewrite must enumerate those refs from
+offset, length, and checksum. `tcs1_part_image` refs identify compatibility
+`TCPA` typed-row assets; `tcs1_typed_column_part` refs identify sectioned
+scalar typed-column parts. GC/rewrite must enumerate those refs from
 manifest/control roots, not by scanning row documents.
 
-The current physical part payload uses the `TCPA` envelope, version 3:
+The typed-row physical part payload uses the `TCPA` envelope, version 3:
 
 ```text
 u32      Magic = "TCPA"
@@ -84,10 +86,16 @@ rows     row id + deleted flag + optional declared column values
 ```
 
 Insert and update rows must have `deleted=false` and one declared value per
-column. Each declared value stores its type, null bit, and present bit; the
-present bit distinguishes an omitted nullable JSON path from an explicit JSON
-`null` so retained-payload reconstruction remains lossless. Delete/tombstone
-rows must have `deleted=true` and no column values.
+`typed_row_asset` column in the row asset. Each declared value stores its type,
+null bit, and present bit; the present bit distinguishes an omitted nullable JSON
+path from an explicit JSON `null` so retained-payload reconstruction remains
+lossless. Delete/tombstone rows must have `deleted=true` and no column values.
+For layouts with `typed_column_part` owners, a `TCPA` row asset is still
+published for row IDs/tombstones and row-owned fields; the matching
+`tcs1_typed_column_part` for the same generation contains authoritative scalar
+typed-column values keyed by row index. The current scalar typed-column matrix is
+bool, int64, float32, double/float64, and string; nullable/missing values,
+vectors, and adjacency sections fail closed until later typed-storage issues.
 Readers validate namespace, generation, part id, schema hash, column
 descriptors, length, and checksum before accepting an asset ref.
 


### PR DESCRIPTION
## Parent / rollout

Parent tracker: #1744. Implements #1755 on top of merged #1751, #1753, and #1754; #1736 Gate A mappedresource seams are present.

Rollout mode: opt-in / experimental. Existing `ColumnStoreConfig` columns with zero owner still resolve to `typed_row_asset`; scalar typed-column publication only starts when a column explicitly sets `Owner: typed_column_part`. No old-DB migration promise is made.

## What changed

- Added compatibility metadata `ColumnStoreColumn.Owner` and wired `ResolveTypedStorageLayout` so declared columns can opt into `typed_column_part` ownership.
- Added durable scalar typed-column publication:
  - `tcs1_part_image` / TCPA remains the per-generation typed-row row-ID/tombstone locator and owner for any `typed_row_asset` fields.
  - New `ColumnAssetKindTCS1TypedColumnPart = "tcs1_typed_column_part"` stores authoritative scalar `typed_column_part` values.
  - Current scalar matrix: bool, int64, float32, double/float64, string.
- Reconstructs retained-payload JSON from retained document + typed-row owners + typed-column owners after checkpoint/reopen.
- Exposes typed-column refs to manifest scan/reopen, reachability, and rewrite/GC range accounting; physical scans ignore typed-column refs until #1757.
- Keeps unsupported nullable/missing, vector, and adjacency typed-column values fail-closed.

## Manifest / recovery / #1736 maintenance refs

New durable manifest refs:

- `tcs1_part_image`: compatibility TCPA row-locator / typed-row asset, currently part id `1` for the publication generation.
- `tcs1_typed_column_part`: sectioned typed-column part image, currently part id `2` for the same publication generation.

Files touched for manifest/recovery/reconstruction/maintenance visibility include:

- `TreeDB/collections/column_publish_write.go`
- `TreeDB/collections/column_manifest_format.go`
- `TreeDB/collections/column_physical_scan.go`
- `TreeDB/collections/column_reconstruction.go`
- `TreeDB/collections/column_asset_reachability.go`
- `TreeDB/collections/column_asset_rewrite.go`
- `TreeDB/collections/typed_column_publication.go`

## Naming impact

- `ColumnStoreColumn.Owner` is a compatibility-retained public config field that carries canonical `TypedStorageFieldOwner` values.
- New asset kind name is typed-column-specific: `tcs1_typed_column_part`.
- Existing public/exported `ColumnStore*` names remain compatibility-retained.
- Docs continue to use `typed storage` as the umbrella; `typed_row_asset`, `typed_column_part`, and `derived_accelerator` retain their canonical meanings.

## Scope boundary / non-goals

- No full #1736 COW GC/rewrite/delete-policy closeout.
- No production predicate scan or query planner switch to typed-column sections (#1757).
- No vector dense sections or adjacency representation (#1756).
- No private lifecycle system or alternate asset store.
- No overlapping authoritative owners for a logical field.

## Required test mapping

- `TestTypedColumnPublicationCheckpointReopen` → checkpoint/reopen with typed-column owners and reconstruction.
- `TestTypedColumnPublicationWriteSyncReopen` → not separate: this collection path is command-WAL/checkpoint based and has no distinct typed-column WriteSync API in this PR.
- `TestTypedColumnReconstructionHybridOwners` → retained + typed-row + typed-column point reconstruction.
- `TestTypedColumnReconstructionScanHybridOwners` → scan/iteration reconstruction for typed-column owners.
- `TestTypedColumnPublicationRejectsOverlappingOwners` → overlapping authoritative owners fail closed.
- `TestTypedColumnPublicationMissingAssetFailsClosed` → missing typed-column asset bytes fail closed.
- `TestTypedColumnPublicationCorruptAssetFailsClosed` → corrupt typed-column asset bytes fail closed.
- `TestTypedColumnManifestRecoveryRefsSurviveReopen` → typed-column manifest refs survive reopen.
- `TestTypedColumnReachabilityRefsExposedForMaintenance` → #1736 reachability sees typed-column refs.
- `TestTypedColumnPublicationExistingTypedRowCompatibility` → existing typed-row configs publish/read as before.

## Validation

- `go test -count=1 ./TreeDB/docs ./TreeDB/internal/typedcolumn ./TreeDB/collections`
- `go test -count=1 ./TreeDB/...`

Focused point-read/reconstruction benchmark smoke (existing typed-row path, because reconstruction hot path was touched):

- `go test -run '^$' -bench BenchmarkColumnStoreGetReconstructionM13C/rows_1024 -benchtime=100x -count=1 ./TreeDB/collections`
- Result on Apple M3: `462986 ns/op`, `166706 B/op`, `120 allocs/op`.

## AI review / CI status

- Codex: requested; latest response after ddf38bf94 found no major issues.
- CodeRabbit: requested; latest status/check is passing after ddf38bf94.
- Copilot: requested twice; bot/cloud agent reported review errors, treated as unavailable.
- Latest-head CI: all required checks pass after ddf38bf94; mergeStateStatus=CLEAN.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Opt-in typed-column-part storage for scalar fields with durable publication, manifest refs, and merged reconstruction with row data; per-scan caching for performance; per-column ownership metadata supported.

* **Bug Fixes**
  * Improved validation, manifest/ref mapping, reachability/planning, scan/load, and write/read checks for typed-column-part and hybrid ownership layouts.

* **Documentation**
  * Expanded specs detailing typed-column-part storage, discovery, validation, and fail-closed rules.

* **Tests**
  * New end-to-end and negative tests for publication, reconstruction, recovery, compatibility, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->