### PR TITLE
treedb: add dense vector typed-column sections

### DIFF
--- a/TreeDB/collections/typed_column_adapter.go
+++ b/TreeDB/collections/typed_column_adapter.go
@@ -83,8 +83,8 @@ func typedColumnAdapterTypeMatrix() []typedColumnAdapterTypeMapping {
 		{ValueType: ColumnStoreValueFloat32, Status: typedColumnAdapterRepresented, ColumnType: typedcolumn.ColumnTypeInt64, Encoding: typedcolumn.EncodingRawInt64, Reason: "stored as raw int64 float32 bit patterns until native float sections land"},
 		{ValueType: ColumnStoreValueDouble, Status: typedColumnAdapterRepresented, ColumnType: typedcolumn.ColumnTypeInt64, Encoding: typedcolumn.EncodingRawInt64, Reason: "stored as raw int64 float64 bit patterns until native float sections land"},
 		{ValueType: ColumnStoreValueString, Status: typedColumnAdapterRepresented, ColumnType: typedcolumn.ColumnTypeLowCardinalityCode, Encoding: typedcolumn.EncodingLowCardinalityUint32, Reason: "stored as dictionary codes with dictionary section metadata"},
-		{ValueType: ColumnStoreValueFloat32Vector, Status: typedColumnAdapterFailClosed, Reason: "dense vector typed-column sections are staged to #1756"},
-		{ValueType: ColumnStoreValueAdjacencyList, Status: typedColumnAdapterFailClosed, Reason: "adjacency typed-column sections are staged to #1756"},
+		{ValueType: ColumnStoreValueFloat32Vector, Status: typedColumnAdapterRepresented, ColumnType: typedcolumn.ColumnTypeFloat32Vector, Encoding: typedcolumn.EncodingRawFloat32Vector, Reason: "stored as fixed-dim dense little-endian float32 sections"},
+		{ValueType: ColumnStoreValueAdjacencyList, Status: typedColumnAdapterFailClosed, Reason: "adjacency_list typed-column publication still lacks fixed-degree schema metadata"},
 	}
 }
 
@@ -127,6 +127,12 @@ func typedColumnAdapterMapField(field TypedStorageField) (typedColumnAdapterColu
 		Encoding:       mapping.Encoding,
 		Compression:    typedcolumn.CompressionNone,
 		CompressionSet: true,
+	}
+	if field.ValueType == ColumnStoreValueFloat32Vector {
+		if field.VectorDims <= 0 {
+			return typedColumnAdapterColumn{}, fmt.Errorf("collections: typed-column adapter field %q float32_vector requires positive vector_dims", field.Path)
+		}
+		def.FixedWidthElements = field.VectorDims
 	}
 	return typedColumnAdapterColumn{Field: field, Definition: def, FixedWidthEncoding: field.FixedWidthEncoding}, nil
 }
@@ -201,7 +207,19 @@ func buildTypedColumnAdapterPart(opts typedColumnAdapterOptions, rows []typedCol
 	batch := typedcolumn.Batch{Rows: len(rows), Columns: make(map[string][]int64, len(defs))}
 	batch.Columns[typedColumnAdapterPrimaryIDColumn] = make([]int64, len(rows))
 	for _, column := range columns {
-		batch.Columns[column.Definition.Name] = make([]int64, len(rows))
+		switch column.Field.ValueType {
+		case ColumnStoreValueFloat32Vector:
+			if batch.Float32Vectors == nil {
+				batch.Float32Vectors = make(map[string][]float32)
+			}
+			elements, err := typedColumnAdapterDenseElements(len(rows), column.Definition.FixedWidthElements)
+			if err != nil {
+				return nil, err
+			}
+			batch.Float32Vectors[column.Definition.Name] = make([]float32, elements)
+		default:
+			batch.Columns[column.Definition.Name] = make([]int64, len(rows))
+		}
 	}
 	for rowIdx, row := range rows {
 		batch.Columns[typedColumnAdapterPrimaryIDColumn][rowIdx] = row.PrimaryID
@@ -213,11 +231,18 @@ func buildTypedColumnAdapterPart(opts typedColumnAdapterOptions, rows []typedCol
 			if !ok {
 				return nil, fmt.Errorf("collections: typed-column adapter row %d missing field %q", rowIdx, column.Field.Path)
 			}
-			encoded, err := encodeTypedColumnAdapterValue(column, value)
-			if err != nil {
-				return nil, fmt.Errorf("collections: typed-column adapter row %d field %q: %w", rowIdx, column.Field.Path, err)
+			switch column.Field.ValueType {
+			case ColumnStoreValueFloat32Vector:
+				if err := encodeTypedColumnAdapterFloat32VectorValue(batch.Float32Vectors[column.Definition.Name], rowIdx, column, value); err != nil {
+					return nil, fmt.Errorf("collections: typed-column adapter row %d field %q: %w", rowIdx, column.Field.Path, err)
+				}
+			default:
+				encoded, err := encodeTypedColumnAdapterValue(column, value)
+				if err != nil {
+					return nil, fmt.Errorf("collections: typed-column adapter row %d field %q: %w", rowIdx, column.Field.Path, err)
+				}
+				batch.Columns[column.Definition.Name][rowIdx] = encoded
 			}
-			batch.Columns[column.Definition.Name][rowIdx] = encoded
 		}
 	}
 	rowsPerGranule := opts.RowsPerGranule
@@ -298,8 +323,8 @@ func validateTypedColumnAdapterImageSchema(part *typedcolumn.ColumnPart, columns
 		if !ok {
 			return fmt.Errorf("collections: typed-column adapter image missing column %q", column.Definition.Name)
 		}
-		if got.Definition.Type != column.Definition.Type || got.Definition.Encoding != column.Definition.Encoding || got.Definition.Compression != column.Definition.Compression {
-			return fmt.Errorf("collections: typed-column adapter image column %q schema mismatch: got type=%s encoding=%s compression=%s want type=%s encoding=%s compression=%s", column.Definition.Name, got.Definition.Type, got.Definition.Encoding, got.Definition.Compression, column.Definition.Type, column.Definition.Encoding, column.Definition.Compression)
+		if got.Definition.Type != column.Definition.Type || got.Definition.Encoding != column.Definition.Encoding || got.Definition.Compression != column.Definition.Compression || got.Definition.FixedWidthElements != column.Definition.FixedWidthElements {
+			return fmt.Errorf("collections: typed-column adapter image column %q schema mismatch: got type=%s encoding=%s compression=%s fixed_width_elements=%d want type=%s encoding=%s compression=%s fixed_width_elements=%d", column.Definition.Name, got.Definition.Type, got.Definition.Encoding, got.Definition.Compression, got.Definition.FixedWidthElements, column.Definition.Type, column.Definition.Encoding, column.Definition.Compression, column.Definition.FixedWidthElements)
 		}
 	}
 	return nil
@@ -319,6 +344,18 @@ func (p *typedColumnAdapterPart) scanColumnValues(columnName string) ([]columnDe
 	column, ok := p.columnByName(columnName)
 	if !ok {
 		return nil, fmt.Errorf("collections: typed-column adapter missing column %q", columnName)
+	}
+	if column.Field.ValueType == ColumnStoreValueFloat32Vector {
+		matrix, err := p.Part.DenseFloat32VectorColumn(column.Definition.Name, nil)
+		if err != nil {
+			return nil, err
+		}
+		out := make([]columnDeclaredValue, matrix.Rows)
+		for i := 0; i < matrix.Rows; i++ {
+			start := i * matrix.ElementsPerRow
+			out[i] = columnDeclaredValue{Type: column.Field.ValueType, Present: true, Float32Vector: append([]float32(nil), matrix.Values[start:start+matrix.ElementsPerRow]...)}
+		}
+		return out, nil
 	}
 	scan, err := p.Part.NewScanner().ScanProjected([]string{column.Definition.Name})
 	if err != nil {
@@ -340,29 +377,27 @@ func (p *typedColumnAdapterPart) scanRows() ([]typedColumnAdapterRow, error) {
 	if p == nil || p.Part == nil {
 		return nil, errors.New("collections: nil typed-column adapter part")
 	}
-	projected := make([]string, 0, len(p.Columns)+1)
-	projected = append(projected, typedColumnAdapterPrimaryIDColumn)
-	for _, column := range p.Columns {
-		projected = append(projected, column.Definition.Name)
-	}
-	scan, err := p.Part.NewScanner().ScanProjected(projected)
+	scan, err := p.Part.NewScanner().ScanProjected([]string{typedColumnAdapterPrimaryIDColumn})
 	if err != nil {
 		return nil, err
 	}
 	ids := scan.Columns[typedColumnAdapterPrimaryIDColumn]
+	columnValues := make(map[string][]columnDeclaredValue, len(p.Columns))
+	for _, column := range p.Columns {
+		values, err := p.scanColumnValues(column.Definition.Name)
+		if err != nil {
+			return nil, err
+		}
+		if len(values) != len(ids) {
+			return nil, fmt.Errorf("collections: typed-column adapter column %q rows=%d want %d", column.Definition.Name, len(values), len(ids))
+		}
+		columnValues[column.Definition.Name] = values
+	}
 	rows := make([]typedColumnAdapterRow, len(ids))
 	for rowIdx, id := range ids {
 		values := make(map[string]columnDeclaredValue, len(p.Columns))
 		for _, column := range p.Columns {
-			encoded := scan.Columns[column.Definition.Name]
-			if len(encoded) != len(ids) {
-				return nil, fmt.Errorf("collections: typed-column adapter column %q rows=%d want %d", column.Definition.Name, len(encoded), len(ids))
-			}
-			value, err := decodeTypedColumnAdapterValue(column, encoded[rowIdx])
-			if err != nil {
-				return nil, fmt.Errorf("collections: typed-column adapter row %d column %q: %w", rowIdx, column.Definition.Name, err)
-			}
-			values[column.Field.Path] = value
+			values[column.Field.Path] = columnValues[column.Definition.Name][rowIdx]
 		}
 		rows[rowIdx] = typedColumnAdapterRow{PrimaryID: id, Values: values}
 	}
@@ -379,14 +414,8 @@ func (p *typedColumnAdapterPart) columnByName(name string) (typedColumnAdapterCo
 }
 
 func encodeTypedColumnAdapterValue(column typedColumnAdapterColumn, value columnDeclaredValue) (int64, error) {
-	if value.Type == "" {
-		return 0, errors.New("declared type required")
-	}
-	if value.Type != column.Field.ValueType {
-		return 0, fmt.Errorf("value type=%q want %q", value.Type, column.Field.ValueType)
-	}
-	if !value.Present || value.Null {
-		return 0, fmt.Errorf("null or missing values are not represented by the #1754 typed-column adapter")
+	if err := validateTypedColumnAdapterDeclaredValue(column, value); err != nil {
+		return 0, err
 	}
 	switch column.Field.ValueType {
 	case ColumnStoreValueBool:
@@ -409,6 +438,51 @@ func encodeTypedColumnAdapterValue(column typedColumnAdapterColumn, value column
 	default:
 		return 0, fmt.Errorf("%w: %s", errTypedColumnAdapterUnsupportedType, column.Field.ValueType)
 	}
+}
+
+func encodeTypedColumnAdapterFloat32VectorValue(dst []float32, rowIdx int, column typedColumnAdapterColumn, value columnDeclaredValue) error {
+	if err := validateTypedColumnAdapterDeclaredValue(column, value); err != nil {
+		return err
+	}
+	dims := column.Definition.FixedWidthElements
+	if dims <= 0 {
+		return fmt.Errorf("float32_vector fixed-width elements=%d", dims)
+	}
+	if len(value.Float32Vector) != dims {
+		return fmt.Errorf("float32_vector length=%d want vector_dims=%d", len(value.Float32Vector), dims)
+	}
+	start, err := typedColumnAdapterDenseElements(rowIdx, dims)
+	if err != nil {
+		return err
+	}
+	if start > len(dst)-dims {
+		return fmt.Errorf("float32_vector row %d outside destination", rowIdx)
+	}
+	copy(dst[start:start+dims], value.Float32Vector)
+	return nil
+}
+
+func typedColumnAdapterDenseElements(rows int, elementsPerRow int) (int, error) {
+	if rows < 0 || elementsPerRow < 0 {
+		return 0, fmt.Errorf("dense elements negative operands rows=%d elements_per_row=%d", rows, elementsPerRow)
+	}
+	if elementsPerRow != 0 && rows > int(^uint(0)>>1)/elementsPerRow {
+		return 0, fmt.Errorf("dense elements overflow rows=%d elements_per_row=%d", rows, elementsPerRow)
+	}
+	return rows * elementsPerRow, nil
+}
+
+func validateTypedColumnAdapterDeclaredValue(column typedColumnAdapterColumn, value columnDeclaredValue) error {
+	if value.Type == "" {
+		return errors.New("declared type required")
+	}
+	if value.Type != column.Field.ValueType {
+		return fmt.Errorf("value type=%q want %q", value.Type, column.Field.ValueType)
+	}
+	if !value.Present || value.Null {
+		return fmt.Errorf("null or missing values are not represented by the typed-column adapter")
+	}
+	return nil
 }
 
 func decodeTypedColumnAdapterValue(column typedColumnAdapterColumn, raw int64) (columnDeclaredValue, error) {

--- a/TreeDB/collections/typed_column_adapter_test.go
+++ b/TreeDB/collections/typed_column_adapter_test.go
@@ -23,7 +23,7 @@ func TestTypedColumnAdapterMapsTreeDBDeclaredTypes(t *testing.T) {
 		ColumnStoreValueFloat32:       typedColumnAdapterRepresented,
 		ColumnStoreValueDouble:        typedColumnAdapterRepresented,
 		ColumnStoreValueString:        typedColumnAdapterRepresented,
-		ColumnStoreValueFloat32Vector: typedColumnAdapterFailClosed,
+		ColumnStoreValueFloat32Vector: typedColumnAdapterRepresented,
 		ColumnStoreValueAdjacencyList: typedColumnAdapterFailClosed,
 	}
 	got := make(map[ColumnStoreValueType]typedColumnAdapterTypeStatus)
@@ -98,6 +98,22 @@ func TestTypedColumnAdapterRoundTripFloat64(t *testing.T) {
 	}
 }
 
+func TestTypedColumnAdapterRoundTripFloat32Vector(t *testing.T) {
+	want := [][]float32{{1, 0.5, -0.25}, {2, 3, 4}}
+	values := make([]columnDeclaredValue, len(want))
+	for i, v := range want {
+		values[i] = columnDeclaredValue{Type: ColumnStoreValueFloat32Vector, Present: true, Float32Vector: v}
+	}
+	field := typedColumnAdapterField("embedding", ColumnStoreValueFloat32Vector)
+	field.VectorDims = 3
+	got := typedColumnAdapterRoundTrip(t, field, values)
+	for i := range want {
+		if !slices.Equal(got[i].Float32Vector, want[i]) {
+			t.Fatalf("vector[%d]=%v want %v all=%+v", i, got[i].Float32Vector, want[i], got)
+		}
+	}
+}
+
 func TestTypedColumnAdapterRoundTripString(t *testing.T) {
 	want := []string{"beta", "alpha", "beta"}
 	values := make([]columnDeclaredValue, len(want))
@@ -128,15 +144,21 @@ func TestTypedColumnAdapterRoundTripString(t *testing.T) {
 	}
 }
 
-func TestTypedColumnAdapterVectorAndAdjacencyRepresentedOrFailClosed(t *testing.T) {
-	for _, valueType := range []ColumnStoreValueType{ColumnStoreValueFloat32Vector, ColumnStoreValueAdjacencyList} {
-		mapping, err := typedColumnAdapterMappingForValueType(valueType)
-		if !errors.Is(err, errTypedColumnAdapterUnsupportedType) {
-			t.Fatalf("%s err=%v want errTypedColumnAdapterUnsupportedType", valueType, err)
-		}
-		if mapping.Status != typedColumnAdapterFailClosed || mapping.Reason == "" {
-			t.Fatalf("%s mapping=%+v want fail-closed reason", valueType, mapping)
-		}
+func TestTypedColumnAdapterVectorRepresentedAdjacencyFailsClosed(t *testing.T) {
+	mapping, err := typedColumnAdapterMappingForValueType(ColumnStoreValueFloat32Vector)
+	if err != nil {
+		t.Fatalf("float32_vector mapping err=%v", err)
+	}
+	if mapping.Status != typedColumnAdapterRepresented || mapping.ColumnType != typedcolumn.ColumnTypeFloat32Vector || mapping.Encoding != typedcolumn.EncodingRawFloat32Vector {
+		t.Fatalf("float32_vector mapping=%+v want dense represented", mapping)
+	}
+
+	mapping, err = typedColumnAdapterMappingForValueType(ColumnStoreValueAdjacencyList)
+	if !errors.Is(err, errTypedColumnAdapterUnsupportedType) {
+		t.Fatalf("adjacency_list err=%v want errTypedColumnAdapterUnsupportedType", err)
+	}
+	if mapping.Status != typedColumnAdapterFailClosed || mapping.Reason == "" {
+		t.Fatalf("adjacency_list mapping=%+v want fail-closed reason", mapping)
 	}
 }
 

--- a/TreeDB/collections/typed_column_publication_test.go
+++ b/TreeDB/collections/typed_column_publication_test.go
@@ -103,6 +103,48 @@ func TestTypedColumnPublicationCheckpointReopen(t *testing.T) {
 	}
 }
 
+func TestTypedColumnVectorDensePublicationCheckpointReopen1756(t *testing.T) {
+	dir := t.TempDir()
+	if err := backenddb.SaveFormatConfig(dir, backenddb.FormatConfig{RequiredFeatures: []string{backenddb.RequiredFeatureCommandWALV1}}); err != nil {
+		t.Fatalf("SaveFormatConfig: %v", err)
+	}
+	d := openCollectionCommandWALDB(t, dir)
+	col := createTypedColumnVectorPartCollection1756(t, d)
+	if _, err := col.InsertBatch([][]byte{[]byte("v1"), []byte("v2")}, [][]byte{
+		[]byte(`{"embedding":[1,0.5,-0.25],"payload":"alpha"}`),
+		[]byte(`{"embedding":[2,3,4],"payload":"beta"}`),
+	}); err != nil {
+		_ = d.Close()
+		t.Fatalf("InsertBatch: %v", err)
+	}
+	assertTypedColumnManifestShape1755(t, d, col, 1, 1)
+	got, err := col.Get([]byte("v1"))
+	if err != nil {
+		_ = d.Close()
+		t.Fatalf("Get v1: %v", err)
+	}
+	assertJSONEqualM13C(t, got, []byte(`{"embedding":[1,0.5,-0.25],"payload":"alpha"}`))
+	if err := d.Checkpoint(); err != nil {
+		_ = d.Close()
+		t.Fatalf("Checkpoint: %v", err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	reopened := openCollectionCommandWALDB(t, dir)
+	defer func() { _ = reopened.Close() }()
+	reopenedCol, err := NewCollectionManager(reopened).OpenCollection("vectors")
+	if err != nil {
+		t.Fatalf("OpenCollection reopened: %v", err)
+	}
+	assertTypedColumnManifestShape1755(t, reopened, reopenedCol, 1, 1)
+	reopenedGot, err := reopenedCol.Get([]byte("v2"))
+	if err != nil {
+		t.Fatalf("reopened Get v2: %v", err)
+	}
+	assertJSONEqualM13C(t, reopenedGot, []byte(`{"embedding":[2,3,4],"payload":"beta"}`))
+}
+
 func TestTypedColumnReconstructionHybridOwners(t *testing.T) {
 	dir := t.TempDir()
 	if err := backenddb.SaveFormatConfig(dir, backenddb.FormatConfig{RequiredFeatures: []string{backenddb.RequiredFeatureCommandWALV1}}); err != nil {
@@ -396,11 +438,10 @@ func TestTypedColumnPublicationUnsupportedValueFailsClosed(t *testing.T) {
 	defer func() { _ = d.Close() }()
 	cfg := testColumnStoreConfig(nil)
 	cfg.Columns = []ColumnStoreColumn{{
-		Name:       "embedding",
-		Path:       "embedding",
-		ValueType:  ColumnStoreValueFloat32Vector,
-		Owner:      TypedStorageOwnerColumnPart,
-		VectorDims: 3,
+		Name:      "embedding_neighbors",
+		Path:      "embedding_neighbors",
+		ValueType: ColumnStoreValueAdjacencyList,
+		Owner:     TypedStorageOwnerColumnPart,
 	}}
 	cfg.SortKey = nil
 	cfg.AggregateMetadata = nil
@@ -412,7 +453,7 @@ func TestTypedColumnPublicationUnsupportedValueFailsClosed(t *testing.T) {
 	if err != nil {
 		t.Fatalf("OpenCollection: %v", err)
 	}
-	_, err = col.InsertBatch([][]byte{[]byte("e1")}, [][]byte{[]byte(`{"embedding":[1,2,3]}`)})
+	_, err = col.InsertBatch([][]byte{[]byte("e1")}, [][]byte{[]byte(`{"embedding_neighbors":[1,2,3]}`)})
 	if !errors.Is(err, backenddb.ErrCommandWALRejected) {
 		t.Fatalf("InsertBatch error=%v want ErrCommandWALRejected", err)
 	}
@@ -501,6 +542,23 @@ func createTypedColumnPartCollection1755(t testing.TB, d *backenddb.DB) *Collect
 		t.Fatalf("CreateCollection: %v", err)
 	}
 	col, err := mgr.OpenCollection("events")
+	if err != nil {
+		t.Fatalf("OpenCollection: %v", err)
+	}
+	return col
+}
+
+func createTypedColumnVectorPartCollection1756(t testing.TB, d *backenddb.DB) *Collection {
+	t.Helper()
+	cfg := testColumnStoreConfig(nil)
+	cfg.Columns = []ColumnStoreColumn{{Name: "embedding", Path: "embedding", ValueType: ColumnStoreValueFloat32Vector, Owner: TypedStorageOwnerColumnPart, VectorDims: 3}}
+	cfg.SortKey = nil
+	cfg.AggregateMetadata = nil
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "vectors", Options: CollectionOptions{ColumnStore: cfg}}); err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	col, err := mgr.OpenCollection("vectors")
 	if err != nil {
 		t.Fatalf("OpenCollection: %v", err)
 	}

--- a/TreeDB/collections/typed_column_publication_test.go
+++ b/TreeDB/collections/typed_column_publication_test.go
@@ -143,6 +143,11 @@ func TestTypedColumnVectorDensePublicationCheckpointReopen1756(t *testing.T) {
 		t.Fatalf("reopened Get v2: %v", err)
 	}
 	assertJSONEqualM13C(t, reopenedGot, []byte(`{"embedding":[2,3,4],"payload":"beta"}`))
+	reopenedGot, err = reopenedCol.Get([]byte("v1"))
+	if err != nil {
+		t.Fatalf("reopened Get v1: %v", err)
+	}
+	assertJSONEqualM13C(t, reopenedGot, []byte(`{"embedding":[1,0.5,-0.25],"payload":"alpha"}`))
 }
 
 func TestTypedColumnReconstructionHybridOwners(t *testing.T) {

--- a/TreeDB/collections/typed_storage_layout.go
+++ b/TreeDB/collections/typed_storage_layout.go
@@ -415,14 +415,13 @@ func (l TypedStorageLayout) HasTypedColumnPartOwners() bool {
 }
 
 // EnsureReadSupported fails closed for typed_column_part owners whose value
-// types are not represented by the current durable typed-column scalar path.
+// types are not represented by the current durable typed-column path.
 func (l TypedStorageLayout) EnsureReadSupported() error {
 	return l.ensureTypedColumnPartSupported()
 }
 
 // EnsurePublicationSupported fails closed for typed_column_part owners whose
-// value types are not represented by the current durable typed-column scalar
-// path.
+// value types are not represented by the current durable typed-column path.
 func (l TypedStorageLayout) EnsurePublicationSupported() error {
 	return l.ensureTypedColumnPartSupported()
 }
@@ -437,8 +436,15 @@ func (l TypedStorageLayout) ensureTypedColumnPartSupported() error {
 			if field.Nullable {
 				return fmt.Errorf("%w: nullable field %q", ErrTypedStorageColumnPartUnsupported, field.Path)
 			}
-		case ColumnStoreValueFloat32Vector, ColumnStoreValueAdjacencyList:
-			return fmt.Errorf("%w: value_type %q for field %q is deferred", ErrTypedStorageColumnPartUnsupported, field.ValueType, field.Path)
+		case ColumnStoreValueFloat32Vector:
+			if field.Nullable {
+				return fmt.Errorf("%w: nullable field %q", ErrTypedStorageColumnPartUnsupported, field.Path)
+			}
+			if field.VectorDims <= 0 {
+				return fmt.Errorf("%w: float32_vector field %q requires vector_dims", ErrTypedStorageColumnPartUnsupported, field.Path)
+			}
+		case ColumnStoreValueAdjacencyList:
+			return fmt.Errorf("%w: value_type %q for field %q is deferred until fixed-degree adjacency metadata exists", ErrTypedStorageColumnPartUnsupported, field.ValueType, field.Path)
 		default:
 			return fmt.Errorf("%w: value_type %q for field %q", ErrTypedStorageColumnPartUnsupported, field.ValueType, field.Path)
 		}

--- a/TreeDB/collections/typed_storage_layout_test.go
+++ b/TreeDB/collections/typed_storage_layout_test.go
@@ -108,7 +108,7 @@ func TestTypedStorageLayoutTypedColumnScalarSupported(t *testing.T) {
 	}
 }
 
-func TestTypedStorageLayoutTypedColumnUnsupportedValueFailsClosed(t *testing.T) {
+func TestTypedStorageLayoutTypedColumnVectorSupported(t *testing.T) {
 	layout, err := NormalizeTypedStorageLayout(TypedStorageLayout{
 		Collection: "events",
 		Fields: []TypedStorageField{{
@@ -117,6 +117,27 @@ func TestTypedStorageLayoutTypedColumnUnsupportedValueFailsClosed(t *testing.T) 
 			Owner:      TypedStorageOwnerColumnPart,
 			ValueType:  ColumnStoreValueFloat32Vector,
 			VectorDims: 3,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("NormalizeTypedStorageLayout: %v", err)
+	}
+	if err := layout.EnsureReadSupported(); err != nil {
+		t.Fatalf("EnsureReadSupported: %v", err)
+	}
+	if err := layout.EnsurePublicationSupported(); err != nil {
+		t.Fatalf("EnsurePublicationSupported: %v", err)
+	}
+}
+
+func TestTypedStorageLayoutTypedColumnUnsupportedValueFailsClosed(t *testing.T) {
+	layout, err := NormalizeTypedStorageLayout(TypedStorageLayout{
+		Collection: "events",
+		Fields: []TypedStorageField{{
+			Name:      "embedding_neighbors",
+			Path:      "embedding_neighbors",
+			Owner:     TypedStorageOwnerColumnPart,
+			ValueType: ColumnStoreValueAdjacencyList,
 		}},
 	})
 	if err != nil {

--- a/TreeDB/docs/spec/README.md
+++ b/TreeDB/docs/spec/README.md
@@ -162,10 +162,10 @@ Given pre-alpha status, this is a living spec that tracks implementation.
     `TreeDB/internal/typedcolumn` data-plane transplant from
     `experiments/colgranule`.
 - `TreeDB/docs/spec/typed-column-adapter.md`
-  - issues #1754/#1755 implementation note for the adapter from TreeDB
+  - issues #1754/#1755/#1756 implementation note for the adapter from TreeDB
     typed-storage field metadata and #1736 mapped resources to the transplanted
-    typed-column data plane, including opt-in durable scalar publication and
-    reconstruction.
+    typed-column data plane, including opt-in durable scalar and fixed-dimension
+    vector publication and reconstruction.
 
 ## Canonical Ownership
 

--- a/TreeDB/docs/spec/storage-format.md
+++ b/TreeDB/docs/spec/storage-format.md
@@ -727,12 +727,12 @@ control-plane state, not a sidecar hint. Current normalized fields are:
   cache identity invalidation. Manifest generation and recovery LSN are not
   schema-hash inputs.
 
-Issue #1753 added `TreeDB/internal/typedcolumn` as the transplanted
-`experiments/colgranule` typed-column data plane. Issues #1754/#1755 connect it
-to production collection metadata for opt-in scalar `typed_column_part` owners;
-#1756 adds fixed-dimension `float32_vector` dense sections. The transplant and
-adapter boundaries are documented in `typed-column-transplant.md` and
-`typed-column-adapter.md`.
+Issue `#1753` added `TreeDB/internal/typedcolumn` as the transplanted
+`experiments/colgranule` typed-column data plane. Issues `#1754`/`#1755` connect
+it to production collection metadata for opt-in scalar `typed_column_part`
+owners; issue `#1756` adds fixed-dimension `float32_vector` dense sections. The
+transplant and adapter boundaries are documented in `typed-column-transplant.md`
+and `typed-column-adapter.md`.
 
 Readers must fail closed for a column-enabled collection when:
 

--- a/TreeDB/docs/spec/storage-format.md
+++ b/TreeDB/docs/spec/storage-format.md
@@ -480,9 +480,10 @@ Insert/update rows must have `Deleted=false` and exactly one value per declared
 `Deleted=true` and zero column values. For layouts with `typed_column_part`
 owners, a `TCPA` row asset is still published for row IDs/tombstones and any
 row-owned fields; the matching `tcs1_typed_column_part` for the same generation
-contains authoritative scalar typed-column values keyed by row index. Readers
-validate namespace, generation, part id, schema hash, declared column
-descriptors, length, and checksum before accepting an asset ref.
+contains authoritative scalar and fixed-dimension `float32_vector` typed-column
+values keyed by row index. Readers validate namespace, generation, part id,
+schema hash, declared column descriptors, length, and checksum before accepting
+an asset ref.
 
 Version 1 row payloads omitted the `Deleted` flag and represented only live
 insert/update rows:
@@ -497,9 +498,13 @@ Writers emit version 2.
 
 Sectioned typed-column part payloads are `TreeDB/internal/typedcolumn` part
 images referenced by `ColumnAssetRef.Kind = tcs1_typed_column_part`. The durable
-Issue `#1755` scalar path represents bool, int64, float32, double/float64, and string
-fields; nullable/missing values, vector sections, and adjacency sections fail
-closed until later typed-storage issues extend the format.
+Issue `#1755` scalar path represents bool, int64, float32, double/float64, and
+string fields. Issue `#1756` adds fixed-dimension `float32_vector` fields as
+uncompressed row-major little-endian dense `float32` sections whose element count
+per row is `vector_dims`. Nullable/missing values and production
+`adjacency_list` publication fail closed until later typed-storage issues extend
+the format; internal dense `uint32` adjacency sections are validated for the
+future vector graph path but are not authoritative collection fields yet.
 
 ## 8. Commit-Log Segment Format
 
@@ -722,11 +727,12 @@ control-plane state, not a sidecar hint. Current normalized fields are:
   cache identity invalidation. Manifest generation and recovery LSN are not
   schema-hash inputs.
 
-Issue #1753 also adds `TreeDB/internal/typedcolumn` as a non-authoritative
-transplant of the `experiments/colgranule` typed-column data plane. Its part
-image/TCS1 bytes are not registered as production collection metadata in this
-PR, do not change the `options.column_store` contract above, and are documented
-in `typed-column-transplant.md` until #1754/#1755 add control-plane adapters.
+Issue #1753 added `TreeDB/internal/typedcolumn` as the transplanted
+`experiments/colgranule` typed-column data plane. Issues #1754/#1755 connect it
+to production collection metadata for opt-in scalar `typed_column_part` owners;
+#1756 adds fixed-dimension `float32_vector` dense sections. The transplant and
+adapter boundaries are documented in `typed-column-transplant.md` and
+`typed-column-adapter.md`.
 
 Readers must fail closed for a column-enabled collection when:
 

--- a/TreeDB/docs/spec/typed-column-adapter.md
+++ b/TreeDB/docs/spec/typed-column-adapter.md
@@ -83,6 +83,6 @@ views; misaligned direct views fall back to heap/scratch decode or fail closed.
 The only production `TreeDB/collections` file that imports
 `TreeDB/internal/typedcolumn` is the adapter seam. Publication/reopen logic calls
 through that seam. Query/vector search integration remains deferred to later
-#1756/#1757 work; this PR publishes fixed-dimension `float32_vector` values but
-does not switch native vector graph search to typed-column parts. Adjacency list
-publication remains fail-closed.
+issues `#1756`/`#1757`; this PR publishes fixed-dimension `float32_vector`
+values but does not switch native vector graph search to typed-column parts.
+Adjacency list publication remains fail-closed.

--- a/TreeDB/docs/spec/typed-column-adapter.md
+++ b/TreeDB/docs/spec/typed-column-adapter.md
@@ -1,6 +1,6 @@
-# Typed-Column Adapter and Durable Scalar Publication (#1754/#1755)
+# Typed-Column Adapter and Durable Vector Publication (#1754/#1755/#1756)
 
-Status: current implementation note for issues #1754 and #1755 under parent tracker #1744.
+Status: current implementation note for issues #1754, #1755, and #1756 under parent tracker #1744.
 
 `TreeDB/collections/typed_column_adapter.go` adapts the transplanted
 `TreeDB/internal/typedcolumn` data plane to TreeDB typed-storage field metadata,
@@ -15,9 +15,10 @@ locator/typed-row asset. Existing `ColumnStoreConfig` metadata still resolves to
 `typed_row_asset` unless a column explicitly sets `Owner:
 typed_column_part`.
 
-Issue `#1755` remains scoped: it does not switch query planning or physical predicate
-scans to typed-column sections, does not publish vector/adjacency sections, and
-does not make derived accelerators authoritative.
+Issue `#1756` extends that path with fixed-dimension `float32_vector` dense
+sections. It still does not switch query planning or physical predicate scans to
+typed-column sections, does not publish adjacency sections, and does not make
+derived accelerators authoritative.
 
 ## Type Matrix
 
@@ -28,21 +29,23 @@ does not make derived accelerators authoritative.
 | `float32` | represented | Raw int64 column carrying `math.Float32bits` in the low 32 bits until native float sections land. |
 | `double` / `float64` | represented | Raw int64 column carrying `math.Float64bits`. |
 | `string` | represented | Low-cardinality uint32 codes plus typed-column dictionary section metadata. |
-| `float32_vector` | fail closed | Dense vector typed-column sections are staged to #1756. |
-| `adjacency_list` | fail closed | Adjacency typed-column sections are staged to #1756. |
+| `float32_vector` | represented | Fixed-dimension row-major dense little-endian `float32` sections with `vector_dims` as elements per row. |
+| `adjacency_list` | fail closed | Internal dense `uint32` sections exist for #1756 validation, but production publication remains closed until fixed-degree adjacency schema metadata exists. |
 
 Nullable/missing adapter values still fail closed because the transplanted part
-builder does not yet have a TreeDB nullable typed-column representation. Vector
-and adjacency work remains staged to #1756.
+builder does not yet have a TreeDB nullable typed-column representation.
+Adjacency publication remains staged after #1756.
 
 ## Durable Publication / Reconstruction Seam (#1755)
 
-For inserts and updates with scalar `typed_column_part` owners, TreeDB writes:
+For inserts and updates with scalar or fixed-dimension vector
+`typed_column_part` owners, TreeDB writes:
 
 - a compatibility `tcs1_part_image`/`TCPA` typed-row asset containing row IDs,
   tombstones, and any `typed_row_asset` owned fields;
-- a `tcs1_typed_column_part` asset containing the authoritative scalar
-  `typed_column_part` values for the same generation.
+- a `tcs1_typed_column_part` asset containing the authoritative scalar and
+  fixed-dimension `float32_vector` `typed_column_part` values for the same
+  generation.
 
 Deletes publish only a typed-row tombstone asset. Retained-payload
 reconstruction finds the latest visible typed-row locator for a document ID and,
@@ -66,10 +69,20 @@ cache with `mappedresource.ClassTypedColumnAsset` when a manager is supplied.
 retained-payload split/restore helpers as an internal test seam. It does not alter
 production retained-payload behavior.
 
+## Dense Section Safety (#1756)
+
+`float32_vector` typed-column data is stored as uncompressed raw little-endian
+`float32` payloads. The `typedcolumn` image builder keeps all sections aligned to
+8-byte boundaries, which is sufficient for `float32` and `uint32` mappedresource
+direct views. Readers must validate lifetime, range, length, endian mode, and
+alignment through #1736 `mappedresource` handles before exposing direct typed
+views; misaligned direct views fall back to heap/scratch decode or fail closed.
+
 ## Boundary
 
 The only production `TreeDB/collections` file that imports
 `TreeDB/internal/typedcolumn` is the adapter seam. Publication/reopen logic calls
-through that seam. Query/vector integration remains deferred to #1756/#1757, and
-`typed_column_part` supports only the scalar matrix above until those issues
-land.
+through that seam. Query/vector search integration remains deferred to later
+#1756/#1757 work; this PR publishes fixed-dimension `float32_vector` values but
+does not switch native vector graph search to typed-column parts. Adjacency list
+publication remains fail-closed.

--- a/TreeDB/docs/spec/typed-column-transplant.md
+++ b/TreeDB/docs/spec/typed-column-transplant.md
@@ -32,8 +32,8 @@ this data plane into the existing typed-row physical asset format.
 | Source | Destination / action | Semantic delta | Reason | Tests |
 | --- | --- | --- | --- | --- |
 | `experiments/colgranule/typed.go` | copied to `TreeDB/internal/typedcolumn/typed.go` | package and error prefix renamed | preserve typed codecs | `TestTypedColumnTransplantPartImageRoundTrip` |
-| `experiments/colgranule/granule.go` | copied to `TreeDB/internal/typedcolumn/granule.go` | package and error prefix renamed | preserve granule encodings/compression | `TestTypedColumnTransplantPartImageRoundTrip`, `TestTypedColumnTransplantPredicateMetadataRoundTrip` |
-| `experiments/colgranule/part.go` | copied/adapted to `TreeDB/internal/typedcolumn/part.go` | `ColumnStoreOptions` -> package-local `Options`; `ColumnBatch` -> `Batch`; error prefix renamed | avoid adding new `ColumnStore*` names while preserving part descriptors/build/scan | `TestTypedColumnTransplantPartImageRoundTrip`, `TestTypedColumnTransplantRowLocatorRoundTrip` |
+| `experiments/colgranule/granule.go` | copied to `TreeDB/internal/typedcolumn/granule.go` | package and error prefix renamed; #1756 adds raw dense `float32_vector` and `uint32` encodings | preserve granule encodings/compression | `TestTypedColumnTransplantPartImageRoundTrip`, `TestTypedColumnTransplantPredicateMetadataRoundTrip`, `TestTypedColumnVectorDenseDirectViewAligned` |
+| `experiments/colgranule/part.go` | copied/adapted to `TreeDB/internal/typedcolumn/part.go` plus #1756 `dense.go` | `ColumnStoreOptions` -> package-local `Options`; `ColumnBatch` -> `Batch`; error prefix renamed; #1756 adds fixed-width dense vector/adjacency batches | avoid adding new `ColumnStore*` names while preserving part descriptors/build/scan | `TestTypedColumnTransplantPartImageRoundTrip`, `TestTypedColumnTransplantRowLocatorRoundTrip`, `TestTypedColumnAdjacencyDirectViewAligned` |
 | `experiments/colgranule/part_image.go` | copied/adapted to `TreeDB/internal/typedcolumn/part_image.go` | package/error prefix renamed; section offsets aligned; padding accounting added | preserve sectioned image model and satisfy fixed-width alignment | `TestTypedColumnTransplantSectionDirectoryRoundTrip`, `TestTypedColumnTransplantFixedWidthSectionsAreAligned` |
 | `experiments/colgranule/part_image_decode.go` | copied/adapted to `TreeDB/internal/typedcolumn/part_image_decode.go` plus `section_reader.go` seam | package/error prefix renamed; validates aligned sections and permits explicit padding gaps; exposes `SectionReader` for future mappedresource adapters | preserve decode/bounds checks for aligned section directories while deferring #1736-backed IO to #1754 | `TestTypedColumnTransplantRejectsInvalidMagicOrVersion`, `TestTypedColumnTransplantRejectsTruncatedOrOutOfBoundsSection`, `TestTypedColumnTransplantSectionDirectoryRoundTrip` |
 | `experiments/colgranule/predicate.go` | copied to `TreeDB/internal/typedcolumn/predicate.go` | package/error prefix renamed | preserve sort-key mark and predicate/pruning metadata | `TestTypedColumnTransplantPredicateMetadataRoundTrip` |
@@ -59,6 +59,8 @@ this data plane into the existing typed-row physical asset format.
 
 `TreeDB/internal/typedcolumn` remains a data-plane package. Issue `#1754` added
 the narrow `typed_column_adapter.go` seam for metadata/resource adaptation, and
-Issue `#1755` routes scalar durable publication/reconstruction through that seam. Query
-planning, vector/adjacency sections, and predicate scan integration remain owned
-by later #1744 children.
+Issue `#1755` routes scalar durable publication/reconstruction through that seam.
+Issue `#1756` adds aligned fixed-width dense `float32_vector` sections and
+internal dense `uint32` adjacency validation. Query planning, native vector graph
+switching, production adjacency publication, and predicate scan integration remain
+owned by later #1744 children.

--- a/TreeDB/docs/spec/typed-storage-naming.md
+++ b/TreeDB/docs/spec/typed-storage-naming.md
@@ -17,7 +17,7 @@ Required vocabulary:
 | --- | --- |
 | `typed storage` | Umbrella subsystem for typed-row storage and typed-column storage. |
 | `typed-row storage` / `typed_row_asset` | Current row-record physical asset path for declared typed values. |
-| `typed-column storage` / `typed_column_part` | Opt-in true sectioned, column-major part assets transplanted from `experiments/colgranule` (scalar durable publication starts in #1755). |
+| `typed-column storage` / `typed_column_part` | Opt-in true sectioned, column-major part assets transplanted from `experiments/colgranule` (scalar durable publication starts in #1755; fixed-dimension vector sections start in #1756). |
 | `retained document` / `document_payload` | Flexible document owner or retained residual payload used for reconstruction. |
 | `derived accelerator` | Non-authoritative duplicate, index, cache, or metadata derived from an authoritative owner. |
 
@@ -51,9 +51,10 @@ declared columns with no explicit typed-storage owner resolve to
 `typed_row_asset`. `ColumnRetainedPayloadFull` is compatibility duplication in
 `document_payload`; it does not make the retained document a second
 authoritative owner for declared typed fields. `typed_column_part` ownership may
-be represented in metadata; after #1755, scalar bool/int64/float32/double/string
-owners have opt-in durable publication and reconstruction, while unsupported
-value types still fail closed.
+be represented in metadata; after #1755/#1756, scalar
+bool/int64/float32/double/string and fixed-dimension `float32_vector` owners have
+opt-in durable publication and reconstruction, while unsupported value types
+still fail closed.
 
 The resolver is pure metadata only: it must not perform filesystem IO, mmap,
 section decode, DB mutation, asset open, publication, query planning, or durable
@@ -97,17 +98,17 @@ compatibility input, but existing `ColumnStoreConfig` metadata still resolves to
 
 ## PR 5 Durable Scalar Typed-Column Publication
 
-Issue #1755 lets explicit scalar `typed_column_part` owners publish durable
-`tcs1_typed_column_part` assets and reconstruct retained-payload documents after
-reopen. A compatibility `typed_row_asset`/`TCPA` asset remains present per
-mutation generation as the row-ID/tombstone locator and owner of any
-`typed_row_asset` fields. The invariant remains one authoritative owner per
-logical field per generation: retained document, typed-row asset, or typed-column
-part.
+Issues #1755/#1756 let explicit scalar and fixed-dimension `float32_vector`
+`typed_column_part` owners publish durable `tcs1_typed_column_part` assets and
+reconstruct retained-payload documents after reopen. A compatibility
+`typed_row_asset`/`TCPA` asset remains present per mutation generation as the
+row-ID/tombstone locator and owner of any `typed_row_asset` fields. The invariant
+remains one authoritative owner per logical field per generation: retained
+document, typed-row asset, or typed-column part.
 
-The #1755 path is intentionally not the query/vector switch. Vector and
-adjacency section representation remains #1756, and production predicate scan /
-query integration remains #1757.
+The #1756 path is intentionally not the native vector graph/query switch.
+Production adjacency publication and predicate scan / query integration remain
+later #1744 children (#1757 for the scalar predicate MVP).
 
 ## Current Derived Accelerator Classifications
 

--- a/TreeDB/internal/typedcolumn/adaptive_mark.go
+++ b/TreeDB/internal/typedcolumn/adaptive_mark.go
@@ -116,6 +116,16 @@ func EstimateBatchUncompressedBytes(batch Batch, defs []ColumnDefinition) (int, 
 			total += rows * 4
 		case ColumnTypeBool:
 			total += rows
+		case ColumnTypeFloat32Vector, ColumnTypeAdjacencyList:
+			rowBytes, err := checkedMulInt(def.FixedWidthElements, 4, "dense column row bytes")
+			if err != nil {
+				return 0, err
+			}
+			bytes, err := checkedMulInt(rows, rowBytes, "dense column uncompressed bytes")
+			if err != nil {
+				return 0, err
+			}
+			total += bytes
 		default:
 			return 0, fmt.Errorf("typedcolumn: unsupported column type %s for adaptive mark sizing", def.Type)
 		}

--- a/TreeDB/internal/typedcolumn/aggregate_metadata.go
+++ b/TreeDB/internal/typedcolumn/aggregate_metadata.go
@@ -180,8 +180,12 @@ func normalizeAggregateMetadataDefinition(def AggregateMetadataDefinition, colum
 		if predicate.Op != AggregateMetadataPredicateEq {
 			return AggregateMetadataDefinition{}, fmt.Errorf("typedcolumn: aggregate metadata %s predicate %d op %s is unsupported", def.Name, i, predicate.Op)
 		}
-		if _, ok := columns[predicate.Column]; !ok {
+		predicateDef, ok := columns[predicate.Column]
+		if !ok {
 			return AggregateMetadataDefinition{}, fmt.Errorf("typedcolumn: aggregate metadata %s predicate column %s is not declared", def.Name, predicate.Column)
+		}
+		if predicateDef.Type == ColumnTypeFloat32Vector || predicateDef.Type == ColumnTypeAdjacencyList {
+			return AggregateMetadataDefinition{}, fmt.Errorf("typedcolumn: aggregate metadata %s predicate column %s type=%s is not scalar", def.Name, predicate.Column, predicateDef.Type)
 		}
 		if _, ok := seenPredicates[predicate.Column]; ok {
 			return AggregateMetadataDefinition{}, fmt.Errorf("typedcolumn: aggregate metadata %s duplicate predicate column %s", def.Name, predicate.Column)

--- a/TreeDB/internal/typedcolumn/dense.go
+++ b/TreeDB/internal/typedcolumn/dense.go
@@ -30,9 +30,6 @@ func denseRowsForValues(values int, elementsPerRow int, name string) (int, error
 		return 0, fmt.Errorf("typedcolumn: dense column %s values=%d not divisible by fixed-width elements=%d", name, values, elementsPerRow)
 	}
 	rows := values / elementsPerRow
-	if err := validateGranuleDecodeRows(rows); err != nil {
-		return 0, err
-	}
 	return rows, nil
 }
 

--- a/TreeDB/internal/typedcolumn/dense.go
+++ b/TreeDB/internal/typedcolumn/dense.go
@@ -1,0 +1,405 @@
+package typedcolumn
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math"
+)
+
+// DenseFloat32Column is a row-major fixed-width float32 matrix section.
+type DenseFloat32Column struct {
+	Rows           int
+	ElementsPerRow int
+	Values         []float32
+	Direct         bool
+}
+
+// DenseUint32Column is a row-major fixed-width uint32 matrix section.
+type DenseUint32Column struct {
+	Rows           int
+	ElementsPerRow int
+	Values         []uint32
+	Direct         bool
+}
+
+func denseRowsForValues(values int, elementsPerRow int, name string) (int, error) {
+	if elementsPerRow <= 0 {
+		return 0, fmt.Errorf("typedcolumn: dense column %s requires positive fixed-width elements", name)
+	}
+	if values%elementsPerRow != 0 {
+		return 0, fmt.Errorf("typedcolumn: dense column %s values=%d not divisible by fixed-width elements=%d", name, values, elementsPerRow)
+	}
+	rows := values / elementsPerRow
+	if err := validateGranuleDecodeRows(rows); err != nil {
+		return 0, err
+	}
+	return rows, nil
+}
+
+func (b *ColumnPartBuilder) gatherFloat32Dense(source []float32, elementsPerRow int, start int, end int) ([]float32, error) {
+	count, err := checkedMulInt(end-start, elementsPerRow, "float32_vector block elements")
+	if err != nil {
+		return nil, err
+	}
+	b.float32s = ensureFloat32Len(b.float32s[:0], count)
+	for row := start; row < end; row++ {
+		sourceRow := b.order[row]
+		sourceStart, err := checkedMulInt(sourceRow, elementsPerRow, "float32_vector source offset")
+		if err != nil {
+			return nil, err
+		}
+		if sourceStart > len(source)-elementsPerRow {
+			return nil, fmt.Errorf("typedcolumn: float32_vector row %d outside source elements=%d", sourceRow, len(source))
+		}
+		copy(b.float32s[(row-start)*elementsPerRow:], source[sourceStart:sourceStart+elementsPerRow])
+	}
+	return b.float32s, nil
+}
+
+func (b *ColumnPartBuilder) gatherUint32Dense(source []uint32, elementsPerRow int, start int, end int) ([]uint32, error) {
+	count, err := checkedMulInt(end-start, elementsPerRow, "uint32 dense block elements")
+	if err != nil {
+		return nil, err
+	}
+	b.u32dense = ensureUint32Len(b.u32dense[:0], count)
+	for row := start; row < end; row++ {
+		sourceRow := b.order[row]
+		sourceStart, err := checkedMulInt(sourceRow, elementsPerRow, "uint32 dense source offset")
+		if err != nil {
+			return nil, err
+		}
+		if sourceStart > len(source)-elementsPerRow {
+			return nil, fmt.Errorf("typedcolumn: uint32 dense row %d outside source elements=%d", sourceRow, len(source))
+		}
+		copy(b.u32dense[(row-start)*elementsPerRow:], source[sourceStart:sourceStart+elementsPerRow])
+	}
+	return b.u32dense, nil
+}
+
+func (b *GranuleBuilder) BuildFloat32Vector(values []float32, rows int, elementsPerRow int) (EncodedGranule, error) {
+	if b.cfg.Encoding != 0 && b.cfg.Encoding != EncodingRawFloat32Vector {
+		return EncodedGranule{}, fmt.Errorf("typedcolumn: float32_vector encoding=%s want %s", b.cfg.Encoding, EncodingRawFloat32Vector)
+	}
+	if b.cfg.Compression != CompressionNone {
+		return EncodedGranule{}, fmt.Errorf("typedcolumn: float32_vector dense sections require compression=none, got %s", b.cfg.Compression)
+	}
+	if rows <= 0 {
+		return EncodedGranule{}, fmt.Errorf("typedcolumn: invalid float32_vector rows %d", rows)
+	}
+	if err := validateDenseElementCount(len(values), rows, elementsPerRow, "float32_vector"); err != nil {
+		return EncodedGranule{}, err
+	}
+	raw, err := encodeFloat32DensePayload(b.raw[:0], values)
+	if err != nil {
+		return EncodedGranule{}, err
+	}
+	b.raw = raw
+	selection, err := admitCompressionInto(b.compressed[:0], raw, EncodingRawFloat32Vector, b.cfg.Compression)
+	if err != nil {
+		return EncodedGranule{}, err
+	}
+	b.compressed = selection.Scratch
+	return newEncodedGranule(rows, 0, 0, false, EncodingRawFloat32Vector, selection), nil
+}
+
+func (b *GranuleBuilder) BuildUint32Dense(values []uint32, rows int, elementsPerRow int) (EncodedGranule, error) {
+	if b.cfg.Encoding != 0 && b.cfg.Encoding != EncodingRawUint32Dense {
+		return EncodedGranule{}, fmt.Errorf("typedcolumn: uint32 dense encoding=%s want %s", b.cfg.Encoding, EncodingRawUint32Dense)
+	}
+	if b.cfg.Compression != CompressionNone {
+		return EncodedGranule{}, fmt.Errorf("typedcolumn: uint32 dense sections require compression=none, got %s", b.cfg.Compression)
+	}
+	if rows <= 0 {
+		return EncodedGranule{}, fmt.Errorf("typedcolumn: invalid uint32 dense rows %d", rows)
+	}
+	if err := validateDenseElementCount(len(values), rows, elementsPerRow, "uint32 dense"); err != nil {
+		return EncodedGranule{}, err
+	}
+	raw, err := encodeUint32DensePayload(b.raw[:0], values)
+	if err != nil {
+		return EncodedGranule{}, err
+	}
+	b.raw = raw
+	selection, err := admitCompressionInto(b.compressed[:0], raw, EncodingRawUint32Dense, b.cfg.Compression)
+	if err != nil {
+		return EncodedGranule{}, err
+	}
+	b.compressed = selection.Scratch
+	return newEncodedGranule(rows, 0, 0, false, EncodingRawUint32Dense, selection), nil
+}
+
+func validateDenseElementCount(values int, rows int, elementsPerRow int, name string) error {
+	if elementsPerRow <= 0 {
+		return fmt.Errorf("typedcolumn: %s requires positive fixed-width elements", name)
+	}
+	if err := validateGranuleDecodeRows(rows); err != nil {
+		return err
+	}
+	want, err := checkedMulInt(rows, elementsPerRow, name+" elements")
+	if err != nil {
+		return err
+	}
+	if values != want {
+		return fmt.Errorf("typedcolumn: %s elements=%d want rows=%d*elements=%d", name, values, rows, elementsPerRow)
+	}
+	return nil
+}
+
+func encodeFloat32DensePayload(dst []byte, values []float32) ([]byte, error) {
+	need, err := checkedMulInt(len(values), 4, "float32_vector raw bytes")
+	if err != nil {
+		return nil, err
+	}
+	if cap(dst) < need {
+		dst = make([]byte, need)
+	} else {
+		dst = dst[:need]
+	}
+	for i, value := range values {
+		binary.LittleEndian.PutUint32(dst[i*4:], math.Float32bits(value))
+	}
+	return dst, nil
+}
+
+func encodeUint32DensePayload(dst []byte, values []uint32) ([]byte, error) {
+	need, err := checkedMulInt(len(values), 4, "uint32 dense raw bytes")
+	if err != nil {
+		return nil, err
+	}
+	if cap(dst) < need {
+		dst = make([]byte, need)
+	} else {
+		dst = dst[:need]
+	}
+	for i, value := range values {
+		binary.LittleEndian.PutUint32(dst[i*4:], value)
+	}
+	return dst, nil
+}
+
+func DecodeRawFloat32VectorPayload(dst []float32, raw []byte, rows int, elementsPerRow int) ([]float32, error) {
+	if err := validateDensePayloadBytes(len(raw), rows, elementsPerRow, 4, "float32_vector"); err != nil {
+		return nil, err
+	}
+	elements, err := checkedMulInt(rows, elementsPerRow, "float32_vector elements")
+	if err != nil {
+		return nil, err
+	}
+	out := dst[:0]
+	if cap(out) < elements {
+		out = make([]float32, elements)
+	} else {
+		out = out[:elements]
+	}
+	for i := range out {
+		out[i] = math.Float32frombits(binary.LittleEndian.Uint32(raw[i*4:]))
+	}
+	return out, nil
+}
+
+func DecodeRawUint32DensePayload(dst []uint32, raw []byte, rows int, elementsPerRow int) ([]uint32, error) {
+	if err := validateDensePayloadBytes(len(raw), rows, elementsPerRow, 4, "uint32 dense"); err != nil {
+		return nil, err
+	}
+	elements, err := checkedMulInt(rows, elementsPerRow, "uint32 dense elements")
+	if err != nil {
+		return nil, err
+	}
+	out := dst[:0]
+	if cap(out) < elements {
+		out = make([]uint32, elements)
+	} else {
+		out = out[:elements]
+	}
+	for i := range out {
+		out[i] = binary.LittleEndian.Uint32(raw[i*4:])
+	}
+	return out, nil
+}
+
+func validateDensePayloadBytes(rawBytes int, rows int, elementsPerRow int, elementBytes int, name string) error {
+	if rawBytes < 0 {
+		return fmt.Errorf("typedcolumn: %s raw bytes=%d", name, rawBytes)
+	}
+	if rows <= 0 {
+		return fmt.Errorf("typedcolumn: invalid %s rows %d", name, rows)
+	}
+	if elementsPerRow <= 0 {
+		return fmt.Errorf("typedcolumn: %s requires positive fixed-width elements", name)
+	}
+	if err := validateGranuleDecodeRows(rows); err != nil {
+		return err
+	}
+	elements, err := checkedMulInt(rows, elementsPerRow, name+" elements")
+	if err != nil {
+		return err
+	}
+	wantBytes, err := checkedMulInt(elements, elementBytes, name+" raw bytes")
+	if err != nil {
+		return err
+	}
+	if rawBytes != wantBytes {
+		return fmt.Errorf("typedcolumn: %s raw bytes=%d want=%d", name, rawBytes, wantBytes)
+	}
+	return nil
+}
+
+func (r *GranuleReader) DecodeFloat32VectorInto(dst []float32, g EncodedGranule, elementsPerRow int) ([]float32, error) {
+	if g.Encoding != EncodingRawFloat32Vector {
+		return nil, fmt.Errorf("typedcolumn: float32_vector encoding=%s want %s", g.Encoding, EncodingRawFloat32Vector)
+	}
+	raw, err := r.decompressDensePayload(g, elementsPerRow, 4, "float32_vector")
+	if err != nil {
+		return nil, err
+	}
+	return DecodeRawFloat32VectorPayload(dst, raw, g.Rows, elementsPerRow)
+}
+
+func (r *GranuleReader) DecodeUint32DenseInto(dst []uint32, g EncodedGranule, elementsPerRow int) ([]uint32, error) {
+	if g.Encoding != EncodingRawUint32Dense {
+		return nil, fmt.Errorf("typedcolumn: uint32 dense encoding=%s want %s", g.Encoding, EncodingRawUint32Dense)
+	}
+	raw, err := r.decompressDensePayload(g, elementsPerRow, 4, "uint32 dense")
+	if err != nil {
+		return nil, err
+	}
+	return DecodeRawUint32DensePayload(dst, raw, g.Rows, elementsPerRow)
+}
+
+func (r *GranuleReader) decompressDensePayload(g EncodedGranule, elementsPerRow int, elementBytes int, name string) ([]byte, error) {
+	if err := validateDenseGranule(g, elementsPerRow, elementBytes, name); err != nil {
+		return nil, err
+	}
+	return g.Payload, nil
+}
+
+func validateDenseGranule(g EncodedGranule, elementsPerRow int, elementBytes int, name string) error {
+	if g.Compression != CompressionNone {
+		return fmt.Errorf("typedcolumn: %s dense direct section requires compression=none, got %s", name, g.Compression)
+	}
+	if g.NullCount != 0 || g.DefaultCount != 0 {
+		return fmt.Errorf("typedcolumn: %s dense section has null/default counts", name)
+	}
+	if g.HasMinMax {
+		return fmt.Errorf("typedcolumn: %s dense section unexpectedly has min/max", name)
+	}
+	if err := validateDensePayloadBytes(g.RawBytes, g.Rows, elementsPerRow, elementBytes, name); err != nil {
+		return err
+	}
+	if g.StoredBytes != g.RawBytes || len(g.Payload) != g.RawBytes {
+		return fmt.Errorf("typedcolumn: %s stored bytes=%d payload=%d raw=%d", name, g.StoredBytes, len(g.Payload), g.RawBytes)
+	}
+	if g.PayloadRef.Kind != PayloadRefInline || g.PayloadRef.Offset != 0 || g.PayloadRef.Length != len(g.Payload) {
+		return fmt.Errorf("typedcolumn: %s payload ref kind=%s offset=%d length=%d payload=%d", name, g.PayloadRef.Kind, g.PayloadRef.Offset, g.PayloadRef.Length, len(g.Payload))
+	}
+	return nil
+}
+
+func (p *ColumnPart) DenseFloat32VectorColumn(name string, dst []float32) (DenseFloat32Column, error) {
+	column, ok := p.Columns[name]
+	if !ok {
+		return DenseFloat32Column{}, fmt.Errorf("typedcolumn: missing column %s", name)
+	}
+	if column.Definition.Type != ColumnTypeFloat32Vector {
+		return DenseFloat32Column{}, fmt.Errorf("typedcolumn: column %s type=%s is not float32_vector", name, column.Definition.Type)
+	}
+	out, err := denseFloat32ColumnInto(dst, p.Descriptor.RowCount, column)
+	if err != nil {
+		return DenseFloat32Column{}, err
+	}
+	return DenseFloat32Column{Rows: p.Descriptor.RowCount, ElementsPerRow: column.Definition.FixedWidthElements, Values: out}, nil
+}
+
+func (p *ColumnPart) DenseUint32Column(name string, dst []uint32) (DenseUint32Column, error) {
+	column, ok := p.Columns[name]
+	if !ok {
+		return DenseUint32Column{}, fmt.Errorf("typedcolumn: missing column %s", name)
+	}
+	if column.Definition.Type != ColumnTypeAdjacencyList {
+		return DenseUint32Column{}, fmt.Errorf("typedcolumn: column %s type=%s is not adjacency_list", name, column.Definition.Type)
+	}
+	out, err := denseUint32ColumnInto(dst, p.Descriptor.RowCount, column)
+	if err != nil {
+		return DenseUint32Column{}, err
+	}
+	return DenseUint32Column{Rows: p.Descriptor.RowCount, ElementsPerRow: column.Definition.FixedWidthElements, Values: out}, nil
+}
+
+func denseFloat32ColumnInto(dst []float32, rows int, column ColumnPartColumn) ([]float32, error) {
+	elements, err := checkedMulInt(rows, column.Definition.FixedWidthElements, "float32_vector column elements")
+	if err != nil {
+		return nil, err
+	}
+	out := dst[:0]
+	if cap(out) < elements {
+		out = make([]float32, elements)
+	} else {
+		out = out[:elements]
+	}
+	var reader GranuleReader
+	for _, block := range column.Blocks {
+		values, err := reader.DecodeFloat32VectorInto(nil, block.Granule, column.Definition.FixedWidthElements)
+		if err != nil {
+			return nil, err
+		}
+		wantElements, err := checkedMulInt(block.Descriptor.RowCount, column.Definition.FixedWidthElements, "float32_vector block elements")
+		if err != nil {
+			return nil, err
+		}
+		if len(values) != wantElements {
+			return nil, fmt.Errorf("typedcolumn: block rows=%d decoded elements=%d", block.Descriptor.RowCount, len(values))
+		}
+		start, err := checkedMulInt(block.Descriptor.FirstRow, column.Definition.FixedWidthElements, "float32_vector block offset")
+		if err != nil {
+			return nil, err
+		}
+		if start > len(out)-len(values) {
+			return nil, fmt.Errorf("typedcolumn: float32_vector block first_row=%d elements=%d outside column elements=%d", block.Descriptor.FirstRow, len(values), len(out))
+		}
+		copy(out[start:start+len(values)], values)
+	}
+	return out, nil
+}
+
+func denseUint32ColumnInto(dst []uint32, rows int, column ColumnPartColumn) ([]uint32, error) {
+	elements, err := checkedMulInt(rows, column.Definition.FixedWidthElements, "uint32 dense column elements")
+	if err != nil {
+		return nil, err
+	}
+	out := dst[:0]
+	if cap(out) < elements {
+		out = make([]uint32, elements)
+	} else {
+		out = out[:elements]
+	}
+	var reader GranuleReader
+	for _, block := range column.Blocks {
+		values, err := reader.DecodeUint32DenseInto(nil, block.Granule, column.Definition.FixedWidthElements)
+		if err != nil {
+			return nil, err
+		}
+		wantElements, err := checkedMulInt(block.Descriptor.RowCount, column.Definition.FixedWidthElements, "uint32 dense block elements")
+		if err != nil {
+			return nil, err
+		}
+		if len(values) != wantElements {
+			return nil, fmt.Errorf("typedcolumn: block rows=%d decoded elements=%d", block.Descriptor.RowCount, len(values))
+		}
+		start, err := checkedMulInt(block.Descriptor.FirstRow, column.Definition.FixedWidthElements, "uint32 dense block offset")
+		if err != nil {
+			return nil, err
+		}
+		if start > len(out)-len(values) {
+			return nil, fmt.Errorf("typedcolumn: uint32 dense block first_row=%d elements=%d outside column elements=%d", block.Descriptor.FirstRow, len(values), len(out))
+		}
+		copy(out[start:start+len(values)], values)
+	}
+	return out, nil
+}
+
+func ensureFloat32Len(dst []float32, n int) []float32 {
+	if cap(dst) < n {
+		return make([]float32, n)
+	}
+	return dst[:n]
+}

--- a/TreeDB/internal/typedcolumn/dense_test.go
+++ b/TreeDB/internal/typedcolumn/dense_test.go
@@ -1,0 +1,307 @@
+package typedcolumn
+
+import (
+	"math"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/internal/mappedresource"
+)
+
+func TestTypedColumnVectorDenseDirectViewAligned(t *testing.T) {
+	image := mustDenseVectorAdjacencyImage1756(t)
+	section := mustColumnDataSection1756(t, image, "embedding")
+	mgr := mappedresource.NewManager()
+	h := mustAcquireImageSectionBytes1756(t, mgr, image, section, image.SectionBytesMust1756(t, section))
+	defer h.Release()
+	view, err := mgr.Float32View(h)
+	if err != nil {
+		t.Fatalf("Float32View aligned: %v", err)
+	}
+	if len(view) != 6 || view[0] != 1 || view[5] != 4 {
+		t.Fatalf("view=%v want dense vector values", view)
+	}
+	if stats := mgr.Stats(); stats.DirectViewSuccesses != 1 || stats.DirectViewFailures != 0 {
+		t.Fatalf("direct view stats=%+v", stats)
+	}
+}
+
+func TestTypedColumnVectorDenseMisalignedFallsBackOrFailsClosed(t *testing.T) {
+	image := mustDenseVectorAdjacencyImage1756(t)
+	section := mustColumnDataSection1756(t, image, "embedding")
+	raw := image.SectionBytesMust1756(t, section)
+	misalignedBacking := append([]byte{0}, raw...)
+	misaligned := misalignedBacking[1:]
+	mgr := mappedresource.NewManager()
+	h := mustAcquireImageSectionBytes1756(t, mgr, image, section, misaligned)
+	defer h.Release()
+	if _, err := mgr.Float32View(h); err == nil {
+		t.Fatalf("Float32View misaligned err=nil, want validation failure")
+	}
+	values, err := DecodeRawFloat32VectorPayload(nil, h.Bytes(), 2, 3)
+	if err != nil {
+		t.Fatalf("fallback DecodeRawFloat32VectorPayload: %v", err)
+	}
+	if len(values) != 6 || values[1] != 0.5 || values[2] != -0.25 {
+		t.Fatalf("fallback values=%v", values)
+	}
+}
+
+func TestTypedColumnAdjacencyDirectViewAligned(t *testing.T) {
+	image := mustDenseVectorAdjacencyImage1756(t)
+	section := mustColumnDataSection1756(t, image, "neighbors")
+	mgr := mappedresource.NewManager()
+	h := mustAcquireImageSectionBytes1756(t, mgr, image, section, image.SectionBytesMust1756(t, section))
+	defer h.Release()
+	view, err := mgr.Uint32View(h)
+	if err != nil {
+		t.Fatalf("Uint32View aligned: %v", err)
+	}
+	if !slices.Equal(view, []uint32{1, 2, 0, 2}) {
+		t.Fatalf("adjacency view=%v", view)
+	}
+}
+
+func TestTypedColumnAdjacencyMisalignedFallsBackOrFailsClosed(t *testing.T) {
+	image := mustDenseVectorAdjacencyImage1756(t)
+	section := mustColumnDataSection1756(t, image, "neighbors")
+	raw := image.SectionBytesMust1756(t, section)
+	misalignedBacking := append([]byte{0}, raw...)
+	misaligned := misalignedBacking[1:]
+	mgr := mappedresource.NewManager()
+	h := mustAcquireImageSectionBytes1756(t, mgr, image, section, misaligned)
+	defer h.Release()
+	if _, err := mgr.Uint32View(h); err == nil {
+		t.Fatalf("Uint32View misaligned err=nil, want validation failure")
+	}
+	values, err := DecodeRawUint32DensePayload(nil, h.Bytes(), 2, 2)
+	if err != nil {
+		t.Fatalf("fallback DecodeRawUint32DensePayload: %v", err)
+	}
+	if !slices.Equal(values, []uint32{1, 2, 0, 2}) {
+		t.Fatalf("fallback adjacency=%v", values)
+	}
+}
+
+func TestTypedColumnVectorCountersDirectViewsAndScratchDecodes(t *testing.T) {
+	image := mustDenseVectorAdjacencyImage1756(t)
+	section := mustColumnDataSection1756(t, image, "embedding")
+	raw := image.SectionBytesMust1756(t, section)
+	mgr := mappedresource.NewManager()
+	aligned := mustAcquireImageSectionBytes1756(t, mgr, image, section, raw)
+	if _, err := mgr.Float32View(aligned); err != nil {
+		t.Fatalf("aligned Float32View: %v", err)
+	}
+	if err := aligned.Release(); err != nil {
+		t.Fatalf("aligned release: %v", err)
+	}
+	misalignedBacking := append([]byte{0}, raw...)
+	misaligned := mustAcquireImageSectionBytes1756(t, mgr, image, section, misalignedBacking[1:])
+	if _, err := mgr.Float32View(misaligned); err == nil {
+		t.Fatalf("misaligned Float32View err=nil")
+	}
+	if _, err := DecodeRawFloat32VectorPayload(nil, misaligned.Bytes(), 2, 3); err != nil {
+		t.Fatalf("fallback decode: %v", err)
+	}
+	if err := misaligned.Release(); err != nil {
+		t.Fatalf("misaligned release: %v", err)
+	}
+	stats := mgr.Stats()
+	if stats.DirectViewSuccesses != 1 || stats.DirectViewFailures != 1 || stats.TotalHeapCopyBytes != uint64(len(raw)*2) {
+		t.Fatalf("stats=%+v want one direct view, one scratch decode, heap bytes", stats)
+	}
+}
+
+func TestTypedColumnDenseMmapHeapParity1756(t *testing.T) {
+	image := mustDenseVectorAdjacencyImage1756(t)
+	section := mustColumnDataSection1756(t, image, "embedding")
+	path := filepath.Join(t.TempDir(), "part.tcim")
+	if err := os.WriteFile(path, image.Bytes, 0o600); err != nil {
+		t.Fatalf("write image: %v", err)
+	}
+	mgr := mappedresource.NewManager()
+	scope := mappedresource.Scope{Kind: mappedresource.ScopeColumnPartReader, ID: "dense-parity", Namespace: "typedcolumn-test"}
+	key := mappedresource.Key{Class: mappedresource.ClassTypedColumnAsset, Namespace: scope.Namespace, Kind: string(section.Kind), PartID: image.PartID, FileID: 1, Offset: int64(section.Offset), Length: int64(section.Length), Version: image.Version}
+	mappedHandle, err := mgr.AcquireFileRange(key, scope, path, mappedresource.AcquireOptions{Reason: "mapped dense vector", ValidationMode: mappedresource.ValidationVerify, PreferMapped: true, AllowHeapCopy: true})
+	if err != nil {
+		t.Fatalf("AcquireFileRange mapped: %v", err)
+	}
+	defer mappedHandle.Release()
+	heapHandle, err := mgr.AcquireFileRange(key, scope, path, mappedresource.AcquireOptions{Reason: "heap dense vector", ValidationMode: mappedresource.ValidationVerify, AllowHeapCopy: true})
+	if err != nil {
+		t.Fatalf("AcquireFileRange heap: %v", err)
+	}
+	defer heapHandle.Release()
+	mappedValues, err := mgr.Float32View(mappedHandle)
+	if err != nil {
+		t.Fatalf("mapped Float32View: %v", err)
+	}
+	heapValues, err := mgr.Float32View(heapHandle)
+	if err != nil {
+		t.Fatalf("heap Float32View: %v", err)
+	}
+	if !slices.Equal(mappedValues, heapValues) || len(mappedValues) != 6 || math.Float32bits(mappedValues[2]) != math.Float32bits(-0.25) {
+		t.Fatalf("mapped=%v heap=%v", mappedValues, heapValues)
+	}
+}
+
+func BenchmarkTypedColumnVectorDenseDirectViewScan(b *testing.B) {
+	const rows = 1024
+	const dims = 16
+	part := mustDenseVectorPart1756(b, rows, dims)
+	image, err := BuildColumnPartImage(part, ColumnPartImageOptions{})
+	if err != nil {
+		b.Fatalf("BuildColumnPartImage: %v", err)
+	}
+	section := mustColumnDataSection1756(b, image, "embedding")
+	mgr := mappedresource.NewManager()
+	h := mustAcquireImageSectionBytes1756(b, mgr, image, section, image.SectionBytesMust1756(b, section))
+	defer h.Release()
+	b.ReportAllocs()
+	b.ResetTimer()
+	var sum float32
+	for i := 0; i < b.N; i++ {
+		view, err := mgr.Float32View(h)
+		if err != nil {
+			b.Fatalf("Float32View: %v", err)
+		}
+		for _, value := range view {
+			sum += value
+		}
+	}
+	b.StopTimer()
+	if sum == 0 {
+		b.Fatalf("sum=0")
+	}
+	b.ReportMetric(float64(b.N*rows)/b.Elapsed().Seconds(), "rows/s")
+	b.ReportMetric(float64(b.N*rows*dims)/b.Elapsed().Seconds(), "elements/s")
+	stats := mgr.Stats()
+	b.ReportMetric(float64(stats.DirectViewSuccesses)/float64(b.N), "direct_views/op")
+	b.ReportMetric(float64(stats.DirectViewFailures)/float64(b.N), "scratch_decodes/op")
+}
+
+func BenchmarkTypedColumnVectorDenseSectionScan(b *testing.B) {
+	const rows = 1024
+	const dims = 16
+	part := mustDenseVectorPart1756(b, rows, dims)
+	b.ReportAllocs()
+	b.ResetTimer()
+	var sum float32
+	for i := 0; i < b.N; i++ {
+		matrix, err := part.DenseFloat32VectorColumn("embedding", nil)
+		if err != nil {
+			b.Fatalf("DenseFloat32VectorColumn: %v", err)
+		}
+		for _, value := range matrix.Values {
+			sum += value
+		}
+	}
+	b.StopTimer()
+	if sum == 0 {
+		b.Fatalf("sum=0")
+	}
+	b.ReportMetric(float64(b.N*rows)/b.Elapsed().Seconds(), "rows/s")
+	b.ReportMetric(float64(b.N*rows*dims)/b.Elapsed().Seconds(), "elements/s")
+}
+
+func mustDenseVectorAdjacencyImage1756(t testing.TB) ColumnPartImage {
+	t.Helper()
+	part := mustDenseVectorAdjacencyPart1756(t)
+	image, err := BuildColumnPartImage(part, ColumnPartImageOptions{})
+	if err != nil {
+		t.Fatalf("BuildColumnPartImage: %v", err)
+	}
+	parsed, err := ParseColumnPartImage(image.Bytes)
+	if err != nil {
+		t.Fatalf("ParseColumnPartImage: %v", err)
+	}
+	return parsed
+}
+
+func mustDenseVectorAdjacencyPart1756(t testing.TB) *ColumnPart {
+	t.Helper()
+	opts := Options{
+		SchemaVersion: 1,
+		SchemaMode:    ColumnSchemaFixed,
+		Columns: []ColumnDefinition{
+			{Name: "id", Type: ColumnTypeInt64, Encoding: EncodingRawInt64, Compression: CompressionNone, CompressionSet: true},
+			{Name: "embedding", Type: ColumnTypeFloat32Vector, Encoding: EncodingRawFloat32Vector, Compression: CompressionNone, CompressionSet: true, FixedWidthElements: 3},
+			{Name: "neighbors", Type: ColumnTypeAdjacencyList, Encoding: EncodingRawUint32Dense, Compression: CompressionNone, CompressionSet: true, FixedWidthElements: 2},
+		},
+		LogicalPrimaryKey: LogicalPrimaryKey{Columns: []string{"id"}},
+		SortKey:           SortKey{Columns: []SortKeyColumn{{Column: "id"}}},
+		PartPolicy:        ColumnPartPolicy{RowsPerGranule: 2},
+		Compression:       ColumnCompressionPolicy{Default: CompressionNone},
+	}
+	part, err := BuildColumnPart(7, opts, Batch{
+		Rows:           2,
+		Columns:        map[string][]int64{"id": []int64{10, 11}},
+		Float32Vectors: map[string][]float32{"embedding": []float32{1, 0.5, -0.25, 2, 3, 4}},
+		Uint32Vectors:  map[string][]uint32{"neighbors": []uint32{1, 2, 0, 2}},
+	})
+	if err != nil {
+		t.Fatalf("BuildColumnPart: %v", err)
+	}
+	return part
+}
+
+func mustDenseVectorPart1756(t testing.TB, rows int, dims int) *ColumnPart {
+	t.Helper()
+	ids := make([]int64, rows)
+	values := make([]float32, rows*dims)
+	for row := 0; row < rows; row++ {
+		ids[row] = int64(row)
+		for dim := 0; dim < dims; dim++ {
+			values[row*dims+dim] = float32(row+dim) / 10
+		}
+	}
+	part, err := BuildColumnPart(8, Options{
+		SchemaVersion: 1,
+		SchemaMode:    ColumnSchemaFixed,
+		Columns: []ColumnDefinition{
+			{Name: "id", Type: ColumnTypeInt64, Encoding: EncodingRawInt64, Compression: CompressionNone, CompressionSet: true},
+			{Name: "embedding", Type: ColumnTypeFloat32Vector, Encoding: EncodingRawFloat32Vector, Compression: CompressionNone, CompressionSet: true, FixedWidthElements: dims},
+		},
+		LogicalPrimaryKey: LogicalPrimaryKey{Columns: []string{"id"}},
+		SortKey:           SortKey{Columns: []SortKeyColumn{{Column: "id"}}},
+		PartPolicy:        ColumnPartPolicy{RowsPerGranule: rows},
+		Compression:       ColumnCompressionPolicy{Default: CompressionNone},
+	}, Batch{Rows: rows, Columns: map[string][]int64{"id": ids}, Float32Vectors: map[string][]float32{"embedding": values}})
+	if err != nil {
+		t.Fatalf("BuildColumnPart: %v", err)
+	}
+	return part
+}
+
+func mustColumnDataSection1756(t testing.TB, image ColumnPartImage, column string) ColumnPartImageSection {
+	t.Helper()
+	for _, section := range image.Sections {
+		if section.Kind == ColumnPartImageSectionColumnData && section.Column == column {
+			return section
+		}
+	}
+	t.Fatalf("missing column section %q in %+v", column, image.Sections)
+	return ColumnPartImageSection{}
+}
+
+func mustAcquireImageSectionBytes1756(t testing.TB, mgr *mappedresource.Manager, image ColumnPartImage, section ColumnPartImageSection, data []byte) *mappedresource.Handle {
+	t.Helper()
+	scope := mappedresource.Scope{Kind: mappedresource.ScopeColumnPartReader, ID: "dense-test", Namespace: "typedcolumn-test"}
+	key := mappedresource.Key{Class: mappedresource.ClassTypedColumnAsset, Namespace: scope.Namespace, Kind: string(section.Kind), PartID: image.PartID, FileID: 1, Offset: int64(section.Offset), Length: int64(len(data)), Version: image.Version, Encoding: section.Encoding.String()}
+	h, err := mgr.AcquireBytes(key, scope, mappedresource.SourceHeapCopy, data, mappedresource.AcquireOptions{Reason: "dense section", ValidationMode: mappedresource.ValidationVerify})
+	if err != nil {
+		t.Fatalf("AcquireBytes: %v", err)
+	}
+	return h
+}
+
+func (i ColumnPartImage) SectionBytesMust1756(t testing.TB, section ColumnPartImageSection) []byte {
+	t.Helper()
+	data, err := i.SectionBytes(section)
+	if err != nil {
+		t.Fatalf("SectionBytes(%s): %v", section.Column, err)
+	}
+	return data
+}

--- a/TreeDB/internal/typedcolumn/dense_test.go
+++ b/TreeDB/internal/typedcolumn/dense_test.go
@@ -86,6 +86,49 @@ func TestTypedColumnAdjacencyMisalignedFallsBackOrFailsClosed(t *testing.T) {
 	}
 }
 
+func TestTypedColumnDenseDescriptorRejectsTruncatedRawBytes1756(t *testing.T) {
+	part := mustDenseVectorAdjacencyPart1756(t)
+	for _, tc := range []struct {
+		name               string
+		columnType         ColumnType
+		fixedWidthElements int
+	}{
+		{name: "embedding", columnType: ColumnTypeFloat32Vector, fixedWidthElements: 3},
+		{name: "neighbors", columnType: ColumnTypeAdjacencyList, fixedWidthElements: 2},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			block := part.Columns[tc.name].Blocks[0].Descriptor
+			block.RawBytes -= 4
+			block.StoredBytes -= 4
+			err := validateDecodedColumnBlockDescriptor(part.Descriptor, tc.name, tc.columnType, 0, tc.fixedWidthElements, 0, block)
+			if err == nil || !strings.Contains(err.Error(), "dense raw bytes") {
+				t.Fatalf("validate truncated dense descriptor err=%v, want dense raw-bytes failure", err)
+			}
+		})
+	}
+}
+
+func TestTypedColumnDenseDescriptorRejectsCompressedBlocks1756(t *testing.T) {
+	part := mustDenseVectorAdjacencyPart1756(t)
+	for _, tc := range []struct {
+		name               string
+		columnType         ColumnType
+		fixedWidthElements int
+	}{
+		{name: "embedding", columnType: ColumnTypeFloat32Vector, fixedWidthElements: 3},
+		{name: "neighbors", columnType: ColumnTypeAdjacencyList, fixedWidthElements: 2},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			block := part.Columns[tc.name].Blocks[0].Descriptor
+			block.Compression = CompressionSnappy
+			err := validateDecodedColumnBlockDescriptor(part.Descriptor, tc.name, tc.columnType, 0, tc.fixedWidthElements, 0, block)
+			if err == nil || !strings.Contains(err.Error(), "dense compression") {
+				t.Fatalf("validate compressed dense descriptor err=%v, want dense compression failure", err)
+			}
+		})
+	}
+}
+
 func TestTypedColumnVectorLogicalPrimaryKeyFailsClosed1756(t *testing.T) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -113,6 +156,56 @@ func TestTypedColumnVectorLogicalPrimaryKeyFailsClosed1756(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "logical primary key column embedding type=float32_vector is not scalar") {
 		t.Fatalf("BuildColumnPart err=%v, want vector logical primary key fail-closed", err)
+	}
+}
+
+func TestTypedColumnAggregateMetadataVectorPredicateFailsClosed1756(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("BuildColumnPart panicked for vector aggregate predicate: %v", r)
+		}
+	}()
+	_, err := BuildColumnPart(10, Options{
+		SchemaVersion: 1,
+		SchemaMode:    ColumnSchemaFixed,
+		Columns: []ColumnDefinition{
+			{Name: "id", Type: ColumnTypeInt64, Encoding: EncodingRawInt64, Compression: CompressionNone, CompressionSet: true},
+			{Name: "time_us", Type: ColumnTypeInt64, Encoding: EncodingRawInt64, Compression: CompressionNone, CompressionSet: true},
+			{Name: "kind_code", Type: ColumnTypeLowCardinalityCode, Encoding: EncodingLowCardinalityUint32, Compression: CompressionNone, CompressionSet: true, Cardinality: 3},
+			{Name: "embedding", Type: ColumnTypeFloat32Vector, Encoding: EncodingRawFloat32Vector, Compression: CompressionNone, CompressionSet: true, FixedWidthElements: 3},
+		},
+		LogicalPrimaryKey: LogicalPrimaryKey{Columns: []string{"id"}},
+		SortKey:           SortKey{Columns: []SortKeyColumn{{Column: "id"}}},
+		PartPolicy:        ColumnPartPolicy{RowsPerGranule: 2},
+		Compression:       ColumnCompressionPolicy{Default: CompressionNone},
+		AggregateMetadata: []AggregateMetadataDefinition{{
+			Name:      "kind_time",
+			Version:   AggregateMetadataDefinitionVersion,
+			Kind:      AggregateMetadataGroupMinMax,
+			Scope:     AggregateMetadataScopeGranule,
+			GroupKeys: []string{"kind_code"},
+			Measures: []AggregateMetadataMeasure{
+				{Op: AggregateMetadataMeasureCount},
+				{Op: AggregateMetadataMeasureMin, Column: "time_us"},
+				{Op: AggregateMetadataMeasureMax, Column: "time_us"},
+			},
+			Predicates:     []AggregateMetadataPredicate{{Column: "embedding", Op: AggregateMetadataPredicateEq, Value: 1}},
+			MaxBytesPerRow: 256,
+		}},
+	}, Batch{
+		Rows: 2,
+		Columns: map[string][]int64{
+			"id":        {10, 11},
+			"time_us":   {100, 200},
+			"kind_code": {1, 2},
+		},
+		Float32Vectors: map[string][]float32{"embedding": {1, 0.5, -0.25, 2, 3, 4}},
+	})
+	if err == nil {
+		t.Fatalf("BuildColumnPart err=nil for vector aggregate predicate")
+	}
+	if !strings.Contains(err.Error(), "aggregate metadata kind_time predicate column embedding type=float32_vector is not scalar") {
+		t.Fatalf("BuildColumnPart err=%v, want vector aggregate predicate fail-closed", err)
 	}
 }
 

--- a/TreeDB/internal/typedcolumn/dense_test.go
+++ b/TreeDB/internal/typedcolumn/dense_test.go
@@ -209,6 +209,68 @@ func TestTypedColumnAggregateMetadataVectorPredicateFailsClosed1756(t *testing.T
 	}
 }
 
+func TestTypedColumnAggregateMetadataAdjacencyListPredicateFailsClosed1756(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("BuildColumnPart panicked for adjacency aggregate predicate: %v", r)
+		}
+	}()
+	_, err := BuildColumnPart(11, Options{
+		SchemaVersion: 1,
+		SchemaMode:    ColumnSchemaFixed,
+		Columns: []ColumnDefinition{
+			{Name: "id", Type: ColumnTypeInt64, Encoding: EncodingRawInt64, Compression: CompressionNone, CompressionSet: true},
+			{Name: "time_us", Type: ColumnTypeInt64, Encoding: EncodingRawInt64, Compression: CompressionNone, CompressionSet: true},
+			{Name: "kind_code", Type: ColumnTypeLowCardinalityCode, Encoding: EncodingLowCardinalityUint32, Compression: CompressionNone, CompressionSet: true, Cardinality: 3},
+			{Name: "neighbors", Type: ColumnTypeAdjacencyList, Encoding: EncodingRawUint32Dense, Compression: CompressionNone, CompressionSet: true, FixedWidthElements: 2},
+		},
+		LogicalPrimaryKey: LogicalPrimaryKey{Columns: []string{"id"}},
+		SortKey:           SortKey{Columns: []SortKeyColumn{{Column: "id"}}},
+		PartPolicy:        ColumnPartPolicy{RowsPerGranule: 2},
+		Compression:       ColumnCompressionPolicy{Default: CompressionNone},
+		AggregateMetadata: []AggregateMetadataDefinition{{
+			Name:      "kind_time",
+			Version:   AggregateMetadataDefinitionVersion,
+			Kind:      AggregateMetadataGroupMinMax,
+			Scope:     AggregateMetadataScopeGranule,
+			GroupKeys: []string{"kind_code"},
+			Measures: []AggregateMetadataMeasure{
+				{Op: AggregateMetadataMeasureCount},
+				{Op: AggregateMetadataMeasureMin, Column: "time_us"},
+				{Op: AggregateMetadataMeasureMax, Column: "time_us"},
+			},
+			Predicates:     []AggregateMetadataPredicate{{Column: "neighbors", Op: AggregateMetadataPredicateEq, Value: 1}},
+			MaxBytesPerRow: 256,
+		}},
+	}, Batch{
+		Rows: 2,
+		Columns: map[string][]int64{
+			"id":        {10, 11},
+			"time_us":   {100, 200},
+			"kind_code": {1, 2},
+		},
+		Uint32Vectors: map[string][]uint32{"neighbors": {1, 2, 0, 2}},
+	})
+	if err == nil {
+		t.Fatalf("BuildColumnPart err=nil for adjacency aggregate predicate")
+	}
+	if !strings.Contains(err.Error(), "aggregate metadata kind_time predicate column neighbors type=adjacency_list is not scalar") {
+		t.Fatalf("BuildColumnPart err=%v, want adjacency aggregate predicate fail-closed", err)
+	}
+}
+
+func TestTypedColumnDescriptorAccountingIncludesFixedWidthElements1756(t *testing.T) {
+	part := mustDenseVectorAdjacencyPart1756(t)
+	blocks := 0
+	for _, column := range part.Descriptor.Columns {
+		blocks += len(column.Blocks)
+	}
+	want := columnPartDescriptorBaseBytes + len(part.Descriptor.Granules)*granuleDescriptorBytes + len(part.Descriptor.Columns)*36 + blocks*columnBlockDescriptorBytes
+	if got := estimateColumnPartDescriptorBytes(part.Descriptor); got != want {
+		t.Fatalf("estimateColumnPartDescriptorBytes=%d want %d including 4-byte fixed-width field per column", got, want)
+	}
+}
+
 func TestTypedColumnVectorCountersDirectViewsAndScratchDecodes(t *testing.T) {
 	image := mustDenseVectorAdjacencyImage1756(t)
 	section := mustColumnDataSection1756(t, image, "embedding")

--- a/TreeDB/internal/typedcolumn/dense_test.go
+++ b/TreeDB/internal/typedcolumn/dense_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/snissn/gomap/TreeDB/internal/mappedresource"
@@ -82,6 +83,36 @@ func TestTypedColumnAdjacencyMisalignedFallsBackOrFailsClosed(t *testing.T) {
 	}
 	if !slices.Equal(values, []uint32{1, 2, 0, 2}) {
 		t.Fatalf("fallback adjacency=%v", values)
+	}
+}
+
+func TestTypedColumnVectorLogicalPrimaryKeyFailsClosed1756(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("BuildColumnPart panicked for vector logical primary key: %v", r)
+		}
+	}()
+	_, err := BuildColumnPart(9, Options{
+		SchemaVersion: 1,
+		SchemaMode:    ColumnSchemaFixed,
+		Columns: []ColumnDefinition{
+			{Name: "id", Type: ColumnTypeInt64, Encoding: EncodingRawInt64, Compression: CompressionNone, CompressionSet: true},
+			{Name: "embedding", Type: ColumnTypeFloat32Vector, Encoding: EncodingRawFloat32Vector, Compression: CompressionNone, CompressionSet: true, FixedWidthElements: 3},
+		},
+		LogicalPrimaryKey: LogicalPrimaryKey{Columns: []string{"embedding"}},
+		SortKey:           SortKey{Columns: []SortKeyColumn{{Column: "id"}}},
+		PartPolicy:        ColumnPartPolicy{RowsPerGranule: 2},
+		Compression:       ColumnCompressionPolicy{Default: CompressionNone},
+	}, Batch{
+		Rows:           2,
+		Columns:        map[string][]int64{"id": {10, 11}},
+		Float32Vectors: map[string][]float32{"embedding": {1, 0.5, -0.25, 2, 3, 4}},
+	})
+	if err == nil {
+		t.Fatalf("BuildColumnPart err=nil for vector logical primary key")
+	}
+	if !strings.Contains(err.Error(), "logical primary key column embedding type=float32_vector is not scalar") {
+		t.Fatalf("BuildColumnPart err=%v, want vector logical primary key fail-closed", err)
 	}
 }
 

--- a/TreeDB/internal/typedcolumn/granule.go
+++ b/TreeDB/internal/typedcolumn/granule.go
@@ -25,6 +25,8 @@ const (
 	EncodingNullableInt64
 	EncodingBoolBitpackRLE
 	EncodingLowCardinalityUint32
+	EncodingRawFloat32Vector
+	EncodingRawUint32Dense
 )
 
 func (e Encoding) String() string {
@@ -41,6 +43,10 @@ func (e Encoding) String() string {
 		return "bool_bitpack_rle"
 	case EncodingLowCardinalityUint32:
 		return "low_cardinality_uint32"
+	case EncodingRawFloat32Vector:
+		return "raw_float32_vector"
+	case EncodingRawUint32Dense:
+		return "raw_uint32_dense"
 	default:
 		return fmt.Sprintf("encoding_%d", e)
 	}

--- a/TreeDB/internal/typedcolumn/part.go
+++ b/TreeDB/internal/typedcolumn/part.go
@@ -595,8 +595,12 @@ func normalizeOptions(opts Options) (Options, error) {
 		columnsByName[def.Name] = def
 		opts.Columns[i] = def
 	}
-	if _, ok := seen[opts.LogicalPrimaryKey.Columns[0]]; !ok {
+	primaryKeyDefinition, ok := columnsByName[opts.LogicalPrimaryKey.Columns[0]]
+	if !ok {
 		return Options{}, fmt.Errorf("typedcolumn: logical primary key column %s is not declared", opts.LogicalPrimaryKey.Columns[0])
+	}
+	if primaryKeyDefinition.Type == ColumnTypeFloat32Vector || primaryKeyDefinition.Type == ColumnTypeAdjacencyList {
+		return Options{}, fmt.Errorf("typedcolumn: logical primary key column %s type=%s is not scalar", opts.LogicalPrimaryKey.Columns[0], primaryKeyDefinition.Type)
 	}
 	for i := range opts.SortKey.Columns {
 		c := &opts.SortKey.Columns[i]

--- a/TreeDB/internal/typedcolumn/part.go
+++ b/TreeDB/internal/typedcolumn/part.go
@@ -7,7 +7,7 @@ import (
 	"sort"
 )
 
-const columnPartDescriptorVersion = 1
+const columnPartDescriptorVersion = 2
 
 type ColumnSchemaMode string
 
@@ -21,6 +21,8 @@ const (
 	ColumnTypeInt64              ColumnType = "int64"
 	ColumnTypeLowCardinalityCode ColumnType = "low_cardinality_code"
 	ColumnTypeBool               ColumnType = "bool"
+	ColumnTypeFloat32Vector      ColumnType = "float32_vector"
+	ColumnTypeAdjacencyList      ColumnType = "adjacency_list"
 )
 
 type SortKeyDirection string
@@ -74,18 +76,21 @@ type ColumnCompressionPolicy struct {
 }
 
 type ColumnDefinition struct {
-	Name           string
-	Type           ColumnType
-	Encoding       Encoding
-	Compression    Compression
-	CompressionSet bool
-	Cardinality    uint32
-	CodecBlockRows int
+	Name               string
+	Type               ColumnType
+	Encoding           Encoding
+	Compression        Compression
+	CompressionSet     bool
+	Cardinality        uint32
+	FixedWidthElements int
+	CodecBlockRows     int
 }
 
 type Batch struct {
-	Rows    int
-	Columns map[string][]int64
+	Rows           int
+	Columns        map[string][]int64
+	Float32Vectors map[string][]float32
+	Uint32Vectors  map[string][]uint32
 }
 
 type ColumnPart struct {
@@ -121,9 +126,10 @@ type GranuleDescriptor struct {
 }
 
 type ColumnPartColumnDescriptor struct {
-	Name   string
-	Type   ColumnType
-	Blocks []ColumnBlockDescriptor
+	Name               string
+	Type               ColumnType
+	FixedWidthElements int
+	Blocks             []ColumnBlockDescriptor
 }
 
 type ColumnBlockDescriptor struct {
@@ -162,6 +168,8 @@ type ColumnPartBuilder struct {
 	values64 []int64
 	codes32  []uint32
 	bools    []bool
+	float32s []float32
+	u32dense []uint32
 	builder  *GranuleBuilder
 }
 
@@ -595,8 +603,12 @@ func normalizeOptions(opts Options) (Options, error) {
 		if c.Column == "" {
 			return Options{}, fmt.Errorf("typedcolumn: empty sort key column at %d", i)
 		}
-		if _, ok := seen[c.Column]; !ok {
+		def, ok := columnsByName[c.Column]
+		if !ok {
 			return Options{}, fmt.Errorf("typedcolumn: sort key column %s is not declared", c.Column)
+		}
+		if def.Type == ColumnTypeFloat32Vector || def.Type == ColumnTypeAdjacencyList {
+			return Options{}, fmt.Errorf("typedcolumn: sort key column %s type=%s is not scalar", c.Column, def.Type)
 		}
 		if c.Direction == "" {
 			c.Direction = SortKeyAsc
@@ -654,8 +666,37 @@ func normalizeColumnDefinition(def ColumnDefinition, defaultCompression Compress
 		def.Encoding = EncodingLowCardinalityUint32
 	case ColumnTypeBool:
 		def.Encoding = EncodingBoolBitpackRLE
+	case ColumnTypeFloat32Vector:
+		if def.FixedWidthElements <= 0 {
+			return ColumnDefinition{}, fmt.Errorf("typedcolumn: float32_vector column %s requires positive fixed-width elements", def.Name)
+		}
+		if def.Encoding == 0 {
+			def.Encoding = EncodingRawFloat32Vector
+		}
+		if def.Encoding != EncodingRawFloat32Vector {
+			return ColumnDefinition{}, fmt.Errorf("typedcolumn: unsupported float32_vector encoding %s for %s", def.Encoding, def.Name)
+		}
+		if def.Compression != CompressionNone {
+			return ColumnDefinition{}, fmt.Errorf("typedcolumn: float32_vector column %s requires uncompressed dense sections", def.Name)
+		}
+	case ColumnTypeAdjacencyList:
+		if def.FixedWidthElements <= 0 {
+			return ColumnDefinition{}, fmt.Errorf("typedcolumn: adjacency_list column %s requires positive fixed-width elements", def.Name)
+		}
+		if def.Encoding == 0 {
+			def.Encoding = EncodingRawUint32Dense
+		}
+		if def.Encoding != EncodingRawUint32Dense {
+			return ColumnDefinition{}, fmt.Errorf("typedcolumn: unsupported adjacency_list encoding %s for %s", def.Encoding, def.Name)
+		}
+		if def.Compression != CompressionNone {
+			return ColumnDefinition{}, fmt.Errorf("typedcolumn: adjacency_list column %s requires uncompressed dense sections", def.Name)
+		}
 	default:
 		return ColumnDefinition{}, fmt.Errorf("typedcolumn: unsupported column type %s for %s", def.Type, def.Name)
+	}
+	if def.Type != ColumnTypeFloat32Vector && def.Type != ColumnTypeAdjacencyList && def.FixedWidthElements != 0 {
+		return ColumnDefinition{}, fmt.Errorf("typedcolumn: scalar column %s has fixed-width elements=%d", def.Name, def.FixedWidthElements)
 	}
 	return def, nil
 }
@@ -670,27 +711,67 @@ func validateCompression(compression Compression) error {
 }
 
 func validateBatch(batch Batch, defs []ColumnDefinition) (int, error) {
-	if batch.Columns == nil {
-		return 0, errors.New("typedcolumn: nil column batch")
-	}
 	declared := make(map[string]struct{}, len(defs))
 	rows := batch.Rows
 	for _, def := range defs {
 		declared[def.Name] = struct{}{}
-		values, ok := batch.Columns[def.Name]
-		if !ok {
-			return 0, fmt.Errorf("typedcolumn: missing column %s", def.Name)
-		}
-		if rows == 0 {
-			rows = len(values)
-		}
-		if len(values) != rows {
-			return 0, fmt.Errorf("typedcolumn: column %s rows=%d want=%d", def.Name, len(values), rows)
+		switch def.Type {
+		case ColumnTypeFloat32Vector:
+			values, ok := batch.Float32Vectors[def.Name]
+			if !ok {
+				return 0, fmt.Errorf("typedcolumn: missing float32_vector column %s", def.Name)
+			}
+			columnRows, err := denseRowsForValues(len(values), def.FixedWidthElements, def.Name)
+			if err != nil {
+				return 0, err
+			}
+			if rows == 0 {
+				rows = columnRows
+			}
+			if columnRows != rows {
+				return 0, fmt.Errorf("typedcolumn: column %s rows=%d want=%d", def.Name, columnRows, rows)
+			}
+		case ColumnTypeAdjacencyList:
+			values, ok := batch.Uint32Vectors[def.Name]
+			if !ok {
+				return 0, fmt.Errorf("typedcolumn: missing adjacency_list column %s", def.Name)
+			}
+			columnRows, err := denseRowsForValues(len(values), def.FixedWidthElements, def.Name)
+			if err != nil {
+				return 0, err
+			}
+			if rows == 0 {
+				rows = columnRows
+			}
+			if columnRows != rows {
+				return 0, fmt.Errorf("typedcolumn: column %s rows=%d want=%d", def.Name, columnRows, rows)
+			}
+		default:
+			values, ok := batch.Columns[def.Name]
+			if !ok {
+				return 0, fmt.Errorf("typedcolumn: missing column %s", def.Name)
+			}
+			if rows == 0 {
+				rows = len(values)
+			}
+			if len(values) != rows {
+				return 0, fmt.Errorf("typedcolumn: column %s rows=%d want=%d", def.Name, len(values), rows)
+			}
 		}
 	}
 	for name := range batch.Columns {
 		if _, ok := declared[name]; !ok {
 			return 0, fmt.Errorf("typedcolumn: undeclared column %s", name)
+		}
+	}
+	for name := range batch.Float32Vectors {
+		if _, ok := declared[name]; !ok {
+			return 0, fmt.Errorf("typedcolumn: undeclared float32_vector column %s", name)
+		}
+	}
+	for name := range batch.Uint32Vectors {
+		if _, ok := declared[name]; !ok {
+			return 0, fmt.Errorf("typedcolumn: undeclared adjacency_list column %s", name)
 		}
 	}
 	if rows <= 0 {
@@ -795,11 +876,10 @@ func (b *ColumnPartBuilder) buildColumn(batch Batch, def ColumnDefinition) (Colu
 		blockRows = b.opts.PartPolicy.RowsPerGranule
 	}
 	column := ColumnPartColumn{Definition: def}
-	descriptor := ColumnPartColumnDescriptor{Name: def.Name, Type: def.Type}
-	sourceValues := batch.Columns[def.Name]
+	descriptor := ColumnPartColumnDescriptor{Name: def.Name, Type: def.Type, FixedWidthElements: def.FixedWidthElements}
 	for start := 0; start < len(b.order); start += blockRows {
 		end := min(start+blockRows, len(b.order))
-		g, err := b.buildColumnBlockGranule(sourceValues, def, start, end)
+		g, err := b.buildColumnBlockGranule(batch, def, start, end)
 		if err != nil {
 			return ColumnPartColumn{}, ColumnPartColumnDescriptor{}, err
 		}
@@ -822,13 +902,31 @@ func (b *ColumnPartBuilder) buildColumn(batch Batch, def ColumnDefinition) (Colu
 	return column, descriptor, nil
 }
 
-func (b *ColumnPartBuilder) buildColumnBlockGranule(sourceValues []int64, def ColumnDefinition, start int, end int) (EncodedGranule, error) {
+func (b *ColumnPartBuilder) buildColumnBlockGranule(batch Batch, def ColumnDefinition, start int, end int) (EncodedGranule, error) {
+	cfg := Config{Encoding: def.Encoding, Compression: def.Compression}
+	b.builder.Reset(cfg)
+	switch def.Type {
+	case ColumnTypeFloat32Vector:
+		sourceValues := batch.Float32Vectors[def.Name]
+		values, err := b.gatherFloat32Dense(sourceValues, def.FixedWidthElements, start, end)
+		if err != nil {
+			return EncodedGranule{}, err
+		}
+		return b.builder.BuildFloat32Vector(values, end-start, def.FixedWidthElements)
+	case ColumnTypeAdjacencyList:
+		sourceValues := batch.Uint32Vectors[def.Name]
+		values, err := b.gatherUint32Dense(sourceValues, def.FixedWidthElements, start, end)
+		if err != nil {
+			return EncodedGranule{}, err
+		}
+		return b.builder.BuildUint32Dense(values, end-start, def.FixedWidthElements)
+	}
+
+	sourceValues := batch.Columns[def.Name]
 	b.values64 = ensureInt64Len(b.values64[:0], end-start)
 	for row := start; row < end; row++ {
 		b.values64[row-start] = sourceValues[b.order[row]]
 	}
-	cfg := Config{Encoding: def.Encoding, Compression: def.Compression}
-	b.builder.Reset(cfg)
 	switch def.Type {
 	case ColumnTypeInt64:
 		return b.builder.BuildInt64(b.values64)

--- a/TreeDB/internal/typedcolumn/part_accounting.go
+++ b/TreeDB/internal/typedcolumn/part_accounting.go
@@ -5,7 +5,7 @@ import "sort"
 const (
 	columnPartDescriptorBaseBytes = 96
 	granuleDescriptorBytes        = 64
-	columnDescriptorBytes         = 32
+	columnDescriptorBytes         = 36
 	columnBlockDescriptorBytes    = 64
 	sortKeyColumnDescriptorBytes  = 32
 	sortKeyMarkBaseBytes          = 16

--- a/TreeDB/internal/typedcolumn/part_accounting.go
+++ b/TreeDB/internal/typedcolumn/part_accounting.go
@@ -104,7 +104,7 @@ func (p *ColumnPart) ByteAccounting() ColumnPartByteAccounting {
 		for _, block := range column.Blocks {
 			report := block.Granule.CodecReport
 			out.CodecBlocks++
-			valueBytes := logicalColumnValueBytes(column.Definition.Type, block.Descriptor.RowCount)
+			valueBytes := logicalColumnValueBytes(column.Definition, block.Descriptor.RowCount)
 			detail.Rows += block.Descriptor.RowCount
 			detail.Blocks++
 			detail.LogicalValueBytes += valueBytes
@@ -245,12 +245,14 @@ func (a ColumnPartByteAccounting) CategoryBytes() int {
 		a.LocatorBytes
 }
 
-func logicalColumnValueBytes(columnType ColumnType, rows int) int {
-	switch columnType {
+func logicalColumnValueBytes(def ColumnDefinition, rows int) int {
+	switch def.Type {
 	case ColumnTypeBool:
 		return rows
 	case ColumnTypeLowCardinalityCode:
 		return rows * 4
+	case ColumnTypeFloat32Vector, ColumnTypeAdjacencyList:
+		return rows * def.FixedWidthElements * 4
 	default:
 		return rows * 8
 	}

--- a/TreeDB/internal/typedcolumn/part_image.go
+++ b/TreeDB/internal/typedcolumn/part_image.go
@@ -9,7 +9,7 @@ import (
 	"time"
 )
 
-const columnPartImageVersion uint16 = 1
+const columnPartImageVersion uint16 = 2
 
 const columnPartImageMagic uint32 = 0x4d494354 // "TCIM", little-endian on disk.
 
@@ -419,6 +419,10 @@ func (b *columnPartImageBuilder) addDescriptorSection() error {
 			return err
 		}
 		enc.u32(cardinality)
+		if column.FixedWidthElements < 0 || uint64(column.FixedWidthElements) > uint64(^uint32(0)) {
+			return fmt.Errorf("typedcolumn: descriptor column %s fixed-width elements=%d", column.Name, column.FixedWidthElements)
+		}
+		enc.u32(uint32(column.FixedWidthElements))
 		enc.u32(uint32(len(column.Blocks)))
 		for i, block := range column.Blocks {
 			if i >= len(partColumn.Blocks) {
@@ -865,6 +869,10 @@ func columnTypeCode(t ColumnType) (uint16, error) {
 		return 2, nil
 	case ColumnTypeBool:
 		return 3, nil
+	case ColumnTypeFloat32Vector:
+		return 4, nil
+	case ColumnTypeAdjacencyList:
+		return 5, nil
 	default:
 		return 0, fmt.Errorf("typedcolumn: unsupported column type %s", t)
 	}

--- a/TreeDB/internal/typedcolumn/part_image.go
+++ b/TreeDB/internal/typedcolumn/part_image.go
@@ -422,6 +422,16 @@ func (b *columnPartImageBuilder) addDescriptorSection() error {
 		if column.FixedWidthElements < 0 || uint64(column.FixedWidthElements) > uint64(^uint32(0)) {
 			return fmt.Errorf("typedcolumn: descriptor column %s fixed-width elements=%d", column.Name, column.FixedWidthElements)
 		}
+		switch column.Type {
+		case ColumnTypeFloat32Vector, ColumnTypeAdjacencyList:
+			if column.FixedWidthElements <= 0 {
+				return fmt.Errorf("typedcolumn: descriptor column %s type=%s requires positive fixed-width elements", column.Name, column.Type)
+			}
+		default:
+			if column.FixedWidthElements != 0 {
+				return fmt.Errorf("typedcolumn: descriptor column %s type=%s has fixed-width elements=%d", column.Name, column.Type, column.FixedWidthElements)
+			}
+		}
 		enc.u32(uint32(column.FixedWidthElements))
 		enc.u32(uint32(len(column.Blocks)))
 		for i, block := range column.Blocks {

--- a/TreeDB/internal/typedcolumn/part_image_decode.go
+++ b/TreeDB/internal/typedcolumn/part_image_decode.go
@@ -526,6 +526,14 @@ func validateDecodedColumnBlockDescriptor(desc ColumnPartDescriptor, column stri
 	if block.RawBytes > maxRawBytes {
 		return fmt.Errorf("typedcolumn: descriptor column %s block %d raw bytes=%d exceed max=%d for %d rows", column, blockIndex, block.RawBytes, maxRawBytes, block.RowCount)
 	}
+	if columnType == ColumnTypeFloat32Vector || columnType == ColumnTypeAdjacencyList {
+		if block.Compression != CompressionNone {
+			return fmt.Errorf("typedcolumn: descriptor column %s block %d dense compression=%s want %s", column, blockIndex, block.Compression, CompressionNone)
+		}
+		if block.RawBytes != maxRawBytes {
+			return fmt.Errorf("typedcolumn: descriptor column %s block %d dense raw bytes=%d want %d for %d rows", column, blockIndex, block.RawBytes, maxRawBytes, block.RowCount)
+		}
+	}
 	if block.Compression == CompressionNone && block.StoredBytes != block.RawBytes {
 		return fmt.Errorf("typedcolumn: descriptor column %s block %d uncompressed stored bytes=%d raw bytes=%d", column, blockIndex, block.StoredBytes, block.RawBytes)
 	}

--- a/TreeDB/internal/typedcolumn/part_image_decode.go
+++ b/TreeDB/internal/typedcolumn/part_image_decode.go
@@ -364,7 +364,7 @@ func decodeColumnPartDescriptorSection(data []byte) (ColumnPartDescriptor, map[s
 	if err != nil {
 		return ColumnPartDescriptor{}, nil, err
 	}
-	columnTotal, err := dec.boundedCount(columnCount, 14, "descriptor columns")
+	columnTotal, err := dec.boundedCount(columnCount, 18, "descriptor columns")
 	if err != nil {
 		return ColumnPartDescriptor{}, nil, err
 	}

--- a/TreeDB/internal/typedcolumn/part_image_decode.go
+++ b/TreeDB/internal/typedcolumn/part_image_decode.go
@@ -396,6 +396,24 @@ func decodeColumnPartDescriptorSection(data []byte) (ColumnPartDescriptor, map[s
 		} else if cardinality != 0 {
 			return ColumnPartDescriptor{}, nil, fmt.Errorf("typedcolumn: column %s type=%s has cardinality %d", name, columnType, cardinality)
 		}
+		fixedWidthElements32, err := dec.u32()
+		if err != nil {
+			return ColumnPartDescriptor{}, nil, err
+		}
+		fixedWidthElements, err := uint32ToInt(fixedWidthElements32, "descriptor fixed-width elements")
+		if err != nil {
+			return ColumnPartDescriptor{}, nil, err
+		}
+		switch columnType {
+		case ColumnTypeFloat32Vector, ColumnTypeAdjacencyList:
+			if fixedWidthElements <= 0 {
+				return ColumnPartDescriptor{}, nil, fmt.Errorf("typedcolumn: column %s type=%s requires positive fixed-width elements", name, columnType)
+			}
+		default:
+			if fixedWidthElements != 0 {
+				return ColumnPartDescriptor{}, nil, fmt.Errorf("typedcolumn: column %s type=%s has fixed-width elements %d", name, columnType, fixedWidthElements)
+			}
+		}
 		blockCount, err := dec.u32()
 		if err != nil {
 			return ColumnPartDescriptor{}, nil, err
@@ -404,12 +422,13 @@ func decodeColumnPartDescriptorSection(data []byte) (ColumnPartDescriptor, map[s
 		if err != nil {
 			return ColumnPartDescriptor{}, nil, err
 		}
-		columnDesc := ColumnPartColumnDescriptor{Name: name, Type: columnType, Blocks: make([]ColumnBlockDescriptor, 0, blocks)}
+		columnDesc := ColumnPartColumnDescriptor{Name: name, Type: columnType, FixedWidthElements: fixedWidthElements, Blocks: make([]ColumnBlockDescriptor, 0, blocks)}
 		column := ColumnPartColumn{
 			Definition: ColumnDefinition{
-				Name:        name,
-				Type:        columnType,
-				Cardinality: cardinality,
+				Name:               name,
+				Type:               columnType,
+				Cardinality:        cardinality,
+				FixedWidthElements: fixedWidthElements,
 			},
 			Blocks: make([]ColumnBlock, 0, blocks),
 		}
@@ -419,7 +438,7 @@ func decodeColumnPartDescriptorSection(data []byte) (ColumnPartDescriptor, map[s
 			if err != nil {
 				return ColumnPartDescriptor{}, nil, err
 			}
-			if err := validateDecodedColumnBlockDescriptor(desc, name, columnType, cardinality, j, blockDesc); err != nil {
+			if err := validateDecodedColumnBlockDescriptor(desc, name, columnType, cardinality, fixedWidthElements, j, blockDesc); err != nil {
 				return ColumnPartDescriptor{}, nil, err
 			}
 			if err := validateDecodedColumnBlockGranuleMetadata(name, j, granule); err != nil {
@@ -480,7 +499,7 @@ func validateDecodedGranuleDescriptors(desc ColumnPartDescriptor) error {
 	return nil
 }
 
-func validateDecodedColumnBlockDescriptor(desc ColumnPartDescriptor, column string, columnType ColumnType, cardinality uint32, blockIndex int, block ColumnBlockDescriptor) error {
+func validateDecodedColumnBlockDescriptor(desc ColumnPartDescriptor, column string, columnType ColumnType, cardinality uint32, fixedWidthElements int, blockIndex int, block ColumnBlockDescriptor) error {
 	if block.RowCount <= 0 {
 		return fmt.Errorf("typedcolumn: descriptor column %s block %d has invalid row count %d", column, blockIndex, block.RowCount)
 	}
@@ -500,7 +519,7 @@ func validateDecodedColumnBlockDescriptor(desc ColumnPartDescriptor, column stri
 	if block.FirstGranule != firstGranule || block.LastGranule != lastGranule {
 		return fmt.Errorf("typedcolumn: descriptor column %s block %d granule range [%d,%d] want [%d,%d] for rows [%d,%d)", column, blockIndex, block.FirstGranule, block.LastGranule, firstGranule, lastGranule, block.FirstRow, block.FirstRow+block.RowCount)
 	}
-	maxRawBytes, err := maxDecodedBlockRawBytes(columnType, cardinality, block.Encoding, block.RowCount)
+	maxRawBytes, err := maxDecodedBlockRawBytes(columnType, cardinality, fixedWidthElements, block.Encoding, block.RowCount)
 	if err != nil {
 		return fmt.Errorf("typedcolumn: descriptor column %s block %d: %w", column, blockIndex, err)
 	}
@@ -565,7 +584,7 @@ func decodedGranuleIndexForRow(granules []GranuleDescriptor, row int) (int, bool
 	return 0, false
 }
 
-func maxDecodedBlockRawBytes(columnType ColumnType, cardinality uint32, encoding Encoding, rows int) (int, error) {
+func maxDecodedBlockRawBytes(columnType ColumnType, cardinality uint32, fixedWidthElements int, encoding Encoding, rows int) (int, error) {
 	switch columnType {
 	case ColumnTypeInt64:
 		switch encoding {
@@ -597,6 +616,24 @@ func maxDecodedBlockRawBytes(columnType ColumnType, cardinality uint32, encoding
 			return 0, err
 		}
 		return checkedAddInt(2, rleBytes, "bool raw bytes")
+	case ColumnTypeFloat32Vector:
+		if encoding != EncodingRawFloat32Vector {
+			return 0, fmt.Errorf("unsupported float32_vector encoding %d", encoding)
+		}
+		elements, err := checkedMulInt(rows, fixedWidthElements, "float32_vector elements")
+		if err != nil {
+			return 0, err
+		}
+		return checkedMulInt(elements, 4, "float32_vector raw bytes")
+	case ColumnTypeAdjacencyList:
+		if encoding != EncodingRawUint32Dense {
+			return 0, fmt.Errorf("unsupported adjacency_list encoding %d", encoding)
+		}
+		elements, err := checkedMulInt(rows, fixedWidthElements, "adjacency_list elements")
+		if err != nil {
+			return 0, err
+		}
+		return checkedMulInt(elements, 4, "adjacency_list raw bytes")
 	default:
 		return 0, fmt.Errorf("unsupported column type %s", columnType)
 	}
@@ -1979,6 +2016,10 @@ func columnTypeFromCode(code uint16) (ColumnType, error) {
 		return ColumnTypeLowCardinalityCode, nil
 	case 3:
 		return ColumnTypeBool, nil
+	case 4:
+		return ColumnTypeFloat32Vector, nil
+	case 5:
+		return ColumnTypeAdjacencyList, nil
 	default:
 		return "", fmt.Errorf("typedcolumn: unknown column type code %d", code)
 	}

--- a/docs/TREEDB_STORAGE_FORMAT.md
+++ b/docs/TREEDB_STORAGE_FORMAT.md
@@ -22,7 +22,7 @@ Operator-facing behavior is covered by:
   - `Dir/dictdb/`: dictionary store (for value-log compression)
 - Large values can be stored out-of-line in `Dir/maindb/value_vlog/` and referenced by `page.ValuePtr` pointers stored in the B+Tree.
 - The value log is **persistent storage**: pointers are valid long-term; segments are deleted only when unreachable (GC) or after rewrite/compaction.
-- Typed-storage physical assets are **value-log-shaped typed assets**, not generic row `value_vlog` payloads. Production typed-row assets and opt-in scalar typed-column parts live under the isolated typed asset manager namespace.
+- Typed-storage physical assets are **value-log-shaped typed assets**, not generic row `value_vlog` payloads. Production typed-row assets and opt-in scalar/vector typed-column parts live under the isolated typed asset manager namespace.
 
 ## Directory layout
 
@@ -64,8 +64,8 @@ Column manifest records stored in B-tree/root metadata hold durable
 `ColumnAssetRef` values: kind, namespace, generation, part id, segment file id,
 offset, length, and checksum. `tcs1_part_image` refs identify compatibility
 `TCPA` typed-row assets; `tcs1_typed_column_part` refs identify sectioned
-scalar typed-column parts. GC/rewrite must enumerate those refs from
-manifest/control roots, not by scanning row documents.
+scalar and fixed-dimension vector typed-column parts. GC/rewrite must enumerate
+those refs from manifest/control roots, not by scanning row documents.
 
 The typed-row physical part payload uses the `TCPA` envelope, version 3:
 
@@ -93,9 +93,10 @@ lossless. Delete/tombstone rows must have `deleted=true` and no column values.
 For layouts with `typed_column_part` owners, a `TCPA` row asset is still
 published for row IDs/tombstones and row-owned fields; the matching
 `tcs1_typed_column_part` for the same generation contains authoritative scalar
-typed-column values keyed by row index. The current scalar typed-column matrix is
-bool, int64, float32, double/float64, and string; nullable/missing values,
-vectors, and adjacency sections fail closed until later typed-storage issues.
+and fixed-dimension `float32_vector` typed-column values keyed by row index. The
+current typed-column publication matrix is bool, int64, float32, double/float64,
+string, and fixed-dimension float32 vectors; nullable/missing values and
+production adjacency sections fail closed until later typed-storage issues.
 Readers validate namespace, generation, part id, schema hash, column
 descriptors, length, and checksum before accepting an asset ref.
 


### PR DESCRIPTION
## Summary

Parent tracker: #1744. Child gate: closes/advances #1756.

This PR adds aligned/dense typed-column sections for vector-oriented data without weakening the existing unsafe-alignment guards:

- extends `TreeDB/internal/typedcolumn` with fixed-width dense raw sections:
  - `float32_vector` as row-major little-endian `[]float32` with `FixedWidthElements` / `vector_dims` elements per row;
  - internal `adjacency_list` dense `[]uint32` sections for #1756 validation;
- adapts the TreeDB typed-column adapter so explicit fixed-dimension `float32_vector` `typed_column_part` owners can publish durable `tcs1_typed_column_part` assets and reconstruct after reopen;
- keeps `adjacency_list` collection publication fail-closed until fixed-degree schema metadata exists;
- uses #1736 `mappedresource` handles/typed views for direct-view validation tests and counters;
- updates typed-storage docs/specs for the new vector-dense publication boundary.

## Scope boundary / non-goals

- Typed storage remains the umbrella term; typed-row storage remains the compatibility path.
- One logical field has one authoritative owner per generation: retained document, typed-row asset, or typed-column part.
- Derived/index/cache/vector graph copies remain non-authoritative `derived_accelerator`s.
- This PR does **not** switch native vector graph search to typed-column parts.
- This PR does **not** implement #1757 int64 predicate scan MVP.
- `adjacency_list` production publication remains fail-closed; the new internal dense `uint32` section support is validation groundwork for the later vector graph path.
- Nullable/missing typed-column values remain fail-closed.

## Naming impact

- Existing exported `ColumnStore*` compatibility names are retained.
- New internal typed-column names use `typedcolumn`, `ColumnTypeFloat32Vector`, `ColumnTypeAdjacencyList`, and dense section terminology.
- `typed_column_part` remains the authoritative typed-column owner name.
- Vector graph assets are still derived accelerators and are not promoted to authoritative owners.

## Safety / resource model

- Dense sections are uncompressed raw little-endian fixed-width payloads.
- `ColumnPartImage` sections remain 8-byte aligned; this is sufficient for `float32` and `uint32` direct views.
- Direct typed views are only exposed after #1736 `mappedresource` lifetime, length, endian, and alignment validation.
- Misaligned direct views fall back to safe heap/scratch decode in tests; truncated/unsupported sections fail closed.

## Tests

Local validation on Apple M3:

```sh
go test -count=1 ./TreeDB/docs ./TreeDB/internal/typedcolumn ./TreeDB/collections
go test -count=1 ./TreeDB/...
```

Required #1756 coverage mapping:

- `TestTypedColumnVectorDenseDirectViewAligned`
- `TestTypedColumnVectorDenseMisalignedFallsBackOrFailsClosed`
- `TestTypedColumnAdjacencyDirectViewAligned`
- `TestTypedColumnAdjacencyMisalignedFallsBackOrFailsClosed`
- `TestTypedColumnVectorCountersDirectViewsAndScratchDecodes`
- `TestTypedColumnDenseMmapHeapParity1756`
- `TestTypedColumnAdapterRoundTripFloat32Vector`
- `TestTypedColumnVectorDensePublicationCheckpointReopen1756`
- `TestTypedStorageLayoutTypedColumnVectorSupported`
- `TestTypedStorageLayoutTypedColumnUnsupportedValueFailsClosed` keeps adjacency fail-closed

## Benchmark smoke

Command:

```sh
go test -run '^$' -bench 'BenchmarkTypedColumnVectorDense(DirectView|Section)Scan' -benchmem -benchtime=100x -count=1 ./TreeDB/internal/typedcolumn
```

Hardware/context: Apple M3 (`darwin/arm64`), branch `codex/typed-column-vector-dense-1756`, commit `982ea1ee2`. Shape: 1024 rows x 16 float32 dims; benchmark scans all elements. Setup/build is outside the timed loop.

| Benchmark | ns/op | ops/sec | rows/s | elements/s | direct views/op | scratch decodes/op | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| `BenchmarkTypedColumnVectorDenseDirectViewScan-8` | 21,870 | 45,725 | 46,821,253 | 749,140,048 | 1.000 | 0 | 0 | 0 |
| `BenchmarkTypedColumnVectorDenseSectionScan-8` | 66,167 | 15,113 | 15,476,070 | 247,617,116 | n/a | n/a | 131,170 | 6 |

## AI review / CI status

- Latest head: `982ea1ee2` (`mergeStateStatus=CLEAN`, PR open, not draft).
- Latest-head CI: all checks passing, including CodeRabbit status, append-only guardrail, bench, gofmt, macOS/Ubuntu/Windows matrices, perf-smoke, profiles, race checks, and suites.
- Review threads: 0 unresolved.
- Codex: latest review after `982ea1ee2` found no major issues.
- CodeRabbit: latest status passed/skipped after findings were addressed through `982ea1ee2`.
- Copilot: repeatedly unavailable due to bot/cloud-agent errors after review requests; documented as unavailable, not passing.

## Caveats / follow-ups

- Native vector graph search remains on the current typed-row/derived graph path until a later #1756/#1744 PR switches it with parity and performance evidence.
- `adjacency_list` publication needs fixed-degree/CSR schema metadata before it can become an authoritative collection field.
- #1757 owns scalar predicate/query integration.
