### PR TITLE
treedb: add typed-column durability safety tests

### DIFF
--- a/TreeDB/collections/typed_column_publication_test.go
+++ b/TreeDB/collections/typed_column_publication_test.go
@@ -1,6 +1,7 @@
 package collections
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"os"
@@ -103,6 +104,64 @@ func TestTypedColumnPublicationCheckpointReopen(t *testing.T) {
 	}
 }
 
+func TestTypedColumnPublicationCommandWALReopenWithoutCheckpoint(t *testing.T) {
+	dir := t.TempDir()
+	if err := backenddb.SaveFormatConfig(dir, backenddb.FormatConfig{RequiredFeatures: []string{backenddb.RequiredFeatureCommandWALV1}}); err != nil {
+		t.Fatalf("SaveFormatConfig: %v", err)
+	}
+	d := openCollectionCommandWALDB(t, dir)
+	col := createTypedColumnPartCollection1755(t, d)
+	if err := d.Checkpoint(); err != nil {
+		_ = d.Close()
+		t.Fatalf("Checkpoint baseline collection: %v", err)
+	}
+
+	if _, err := col.InsertBatch([][]byte{[]byte("e1"), []byte("e2")}, [][]byte{
+		[]byte(`{"time_us":1,"kind":"like","score":2.5,"flag":true,"payload":"alpha"}`),
+		[]byte(`{"time_us":2,"kind":"post","score":3.5,"flag":false,"payload":"beta"}`),
+	}); err != nil {
+		_ = d.Close()
+		t.Fatalf("InsertBatch: %v", err)
+	}
+	if _, changed, err := col.Update([]byte("e1"), func(current []byte) ([]byte, bool, error) {
+		assertJSONEqualM13C(t, current, []byte(`{"time_us":1,"kind":"like","score":2.5,"flag":true,"payload":"alpha"}`))
+		return []byte(`{"time_us":3,"kind":"share","score":6.5,"flag":false,"payload":"alpha2"}`), true, nil
+	}); err != nil || !changed {
+		_ = d.Close()
+		t.Fatalf("Update changed=%v err=%v", changed, err)
+	}
+	assertTypedColumnManifestShape1755(t, d, col, 2, 2)
+	preCloseRefs := typedColumnPartRefs1755(columnManifestAssetRefsForCollectionM12A(t, d, col))
+	if len(preCloseRefs) != 2 {
+		_ = d.Close()
+		t.Fatalf("pre-close typed refs=%+v want two", preCloseRefs)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("Close without checkpoint: %v", err)
+	}
+	d = nil
+
+	reopened := openCollectionCommandWALDB(t, dir)
+	defer func() { _ = reopened.Close() }()
+	reopenedCol, err := NewCollectionManager(reopened).OpenCollection("events")
+	if err != nil {
+		t.Fatalf("OpenCollection reopened: %v", err)
+	}
+	assertTypedColumnManifestShape1755(t, reopened, reopenedCol, 2, 2)
+	got, err := reopenedCol.Get([]byte("e1"))
+	if err != nil {
+		t.Fatalf("reopened Get e1: %v", err)
+	}
+	assertJSONEqualM13C(t, got, []byte(`{"time_us":3,"kind":"share","score":6.5,"flag":false,"payload":"alpha2"}`))
+	got, err = reopenedCol.Get([]byte("e2"))
+	if err != nil {
+		t.Fatalf("reopened Get e2: %v", err)
+	}
+	assertJSONEqualM13C(t, got, []byte(`{"time_us":2,"kind":"post","score":3.5,"flag":false,"payload":"beta"}`))
+	reopenedRefs := typedColumnPartRefs1755(columnManifestAssetRefsForCollectionM12A(t, reopened, reopenedCol))
+	assertColumnAssetRefsEqual1755(t, preCloseRefs, reopenedRefs)
+}
+
 func TestTypedColumnReconstructionHybridOwners(t *testing.T) {
 	dir := t.TempDir()
 	if err := backenddb.SaveFormatConfig(dir, backenddb.FormatConfig{RequiredFeatures: []string{backenddb.RequiredFeatureCommandWALV1}}); err != nil {
@@ -188,6 +247,52 @@ func TestTypedColumnPublicationCorruptAssetFailsClosed(t *testing.T) {
 	corruptTypedColumnAssetPayload1755(t, d, typedRef)
 	if got, err := col.Get([]byte("e1")); err == nil || got != nil || !strings.Contains(err.Error(), "typed-column reconstruction") {
 		t.Fatalf("Get with corrupt typed-column asset got=%s err=%v, want typed-column fail-closed error", got, err)
+	}
+}
+
+func TestTypedColumnFailedExtractionLeavesDocumentAndManifestUnchanged(t *testing.T) {
+	d, col, _ := setupSingleTypedColumnPart1755(t)
+	defer func() { _ = d.Close() }()
+	beforeIdentity, ok := col.ColumnStoreCacheIdentity()
+	if !ok || beforeIdentity.ManifestRoot == 0 {
+		t.Fatalf("ColumnStoreCacheIdentity=%+v ok=%v want manifest", beforeIdentity, ok)
+	}
+	beforeRefs := columnManifestAssetRefsForCollectionM12A(t, d, col)
+	beforeDoc, err := col.Get([]byte("e1"))
+	if err != nil {
+		t.Fatalf("Get before: %v", err)
+	}
+	assertJSONEqualM13C(t, beforeDoc, []byte(`{"time_us":1,"kind":"like","score":2.5,"flag":true}`))
+
+	cases := []struct {
+		name string
+		doc  []byte
+	}{
+		{name: "missing typed string", doc: []byte(`{"time_us":2,"score":4.5,"flag":false}`)},
+		{name: "null typed double", doc: []byte(`{"time_us":2,"kind":"bad","score":null,"flag":false}`)},
+		{name: "typed bool mismatch", doc: []byte(`{"time_us":2,"kind":"bad","score":4.5,"flag":"false"}`)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, err := col.Update([]byte("e1"), func(current []byte) ([]byte, bool, error) {
+				assertJSONEqualM13C(t, current, beforeDoc)
+				return tc.doc, true, nil
+			})
+			if !errors.Is(err, ErrColumnDeclaredValueUnsupported) {
+				t.Fatalf("Update err=%v want ErrColumnDeclaredValueUnsupported", err)
+			}
+			afterIdentity, ok := col.ColumnStoreCacheIdentity()
+			if !ok || afterIdentity != beforeIdentity {
+				t.Fatalf("identity after failed update=%+v ok=%v want %+v", afterIdentity, ok, beforeIdentity)
+			}
+			afterRefs := columnManifestAssetRefsForCollectionM12A(t, d, col)
+			assertColumnAssetRefsEqual1755(t, beforeRefs, afterRefs)
+			afterDoc, err := col.Get([]byte("e1"))
+			if err != nil {
+				t.Fatalf("Get after failed update: %v", err)
+			}
+			assertJSONEqualM13C(t, afterDoc, beforeDoc)
+		})
 	}
 }
 
@@ -298,6 +403,202 @@ func TestTypedColumnReachabilityRefsExposedForMaintenance(t *testing.T) {
 		}
 	}
 	t.Fatalf("typed ref %+v not exposed in reachability entries=%+v", typedRef, plan.Entries)
+}
+
+func TestTypedColumnSnapshotReadsOldRefsAndReachabilityPinsCandidates(t *testing.T) {
+	d, col, firstRef := setupSingleTypedColumnPart1755(t)
+	defer func() { _ = d.Close() }()
+	oldSnap := d.AcquireSnapshot()
+	if oldSnap == nil {
+		t.Fatalf("AcquireSnapshot returned nil")
+	}
+	defer func() { _ = oldSnap.Close() }()
+	oldDoc, found := typedColumnDocumentAtSnapshot1755(t, col, oldSnap, []byte("e1"))
+	if !found {
+		t.Fatalf("old snapshot did not find e1")
+	}
+	assertJSONEqualM13C(t, oldDoc, []byte(`{"time_us":1,"kind":"like","score":2.5,"flag":true}`))
+
+	if _, changed, err := col.Update([]byte("e1"), func(current []byte) ([]byte, bool, error) {
+		assertJSONEqualM13C(t, current, oldDoc)
+		return []byte(`{"time_us":5,"kind":"share","score":7.5,"flag":false}`), true, nil
+	}); err != nil || !changed {
+		t.Fatalf("Update changed=%v err=%v", changed, err)
+	}
+	currentDoc, err := col.Get([]byte("e1"))
+	if err != nil {
+		t.Fatalf("current Get e1: %v", err)
+	}
+	assertJSONEqualM13C(t, currentDoc, []byte(`{"time_us":5,"kind":"share","score":7.5,"flag":false}`))
+	oldDocAgain, found := typedColumnDocumentAtSnapshot1755(t, col, oldSnap, []byte("e1"))
+	if !found {
+		t.Fatalf("old snapshot lost e1 after update")
+	}
+	assertJSONEqualM13C(t, oldDocAgain, []byte(`{"time_us":1,"kind":"like","score":2.5,"flag":true}`))
+
+	candidate := writeTypedColumnAssetCandidate1755(t, d, col, 3, 99)
+	rewrite, err := col.ColumnAssetRewrite(context.Background(), ColumnAssetRewriteOptions{
+		CandidateRefs: []ColumnAssetRef{candidate},
+	})
+	if err != nil {
+		t.Fatalf("ColumnAssetRewrite with pinned old snapshot: %v", err)
+	}
+	if rewrite.RefsRemapped == 0 || len(rewrite.SupersededRefs) == 0 {
+		t.Fatalf("rewrite stats=%+v want remapped/superseded refs", rewrite)
+	}
+	oldDocAfterRewrite, found := typedColumnDocumentAtSnapshot1755(t, col, oldSnap, []byte("e1"))
+	if !found {
+		t.Fatalf("old snapshot lost e1 after rewrite")
+	}
+	assertJSONEqualM13C(t, oldDocAfterRewrite, []byte(`{"time_us":1,"kind":"like","score":2.5,"flag":true}`))
+	if !columnAssetRefsContain1755(rewrite.SupersededRefs, firstRef) {
+		t.Fatalf("superseded refs=%+v want initial typed ref %+v", rewrite.SupersededRefs, firstRef)
+	}
+
+	unpinned, err := col.PlanColumnAssetReachability(context.Background(), ColumnAssetReachabilityOptions{
+		Detailed:      true,
+		CandidateRefs: rewrite.SupersededRefs,
+	})
+	if err != nil {
+		t.Fatalf("PlanColumnAssetReachability unpinned superseded: %v", err)
+	}
+	assertColumnAssetReachabilityEntry1755(t, unpinned, firstRef, ColumnAssetReachabilityReclaimable, false)
+
+	pinned, err := col.PlanColumnAssetReachability(context.Background(), ColumnAssetReachabilityOptions{
+		Detailed:                              true,
+		ProtectCandidateRefsForOlderSnapshots: true,
+		CandidateRefs:                         rewrite.SupersededRefs,
+	})
+	if err != nil {
+		t.Fatalf("PlanColumnAssetReachability pinned superseded: %v", err)
+	}
+	assertColumnAssetReachabilityEntry1755(t, pinned, firstRef, ColumnAssetReachabilityProtected, true)
+}
+
+func TestTypedColumnSnapshotReadsOldRefsAfterDelete(t *testing.T) {
+	d, col, _ := setupSingleTypedColumnPart1755(t)
+	defer func() { _ = d.Close() }()
+	oldSnap := d.AcquireSnapshot()
+	if oldSnap == nil {
+		t.Fatalf("AcquireSnapshot returned nil")
+	}
+	defer func() { _ = oldSnap.Close() }()
+
+	deleted, err := col.DeleteDocument([]byte("e1"))
+	if err != nil || !deleted {
+		t.Fatalf("DeleteDocument deleted=%v err=%v", deleted, err)
+	}
+	if got, err := col.Get([]byte("e1")); err != nil || got != nil {
+		t.Fatalf("current Get after delete got=%s err=%v want missing", got, err)
+	}
+	oldDoc, found := typedColumnDocumentAtSnapshot1755(t, col, oldSnap, []byte("e1"))
+	if !found {
+		t.Fatalf("old snapshot lost e1 after delete")
+	}
+	assertJSONEqualM13C(t, oldDoc, []byte(`{"time_us":1,"kind":"like","score":2.5,"flag":true}`))
+}
+
+func TestTypedColumnColumnAssetRewriteRoundTripMixedRefs(t *testing.T) {
+	d, col, _ := setupSingleTypedColumnPart1755(t)
+	dir := d.Dir()
+	dClosed := false
+	defer func() {
+		if !dClosed {
+			_ = d.Close()
+		}
+	}()
+	beforeRefs := columnManifestAssetRefsForCollectionM12A(t, d, col)
+	beforePhysical := columnManifestPhysicalAssetRefsForTestM1634(beforeRefs)
+	beforeTyped := typedColumnPartRefs1755(beforeRefs)
+	if len(beforePhysical) != 1 || len(beforeTyped) != 1 {
+		t.Fatalf("before physical=%+v typed=%+v want one each all=%+v", beforePhysical, beforeTyped, beforeRefs)
+	}
+	candidate := writeTypedColumnAssetCandidate1755(t, d, col, 2, 99)
+	if candidate.FileID != beforeRefs[0].FileID {
+		t.Fatalf("candidate file_id=%d live file_id=%d, test requires mixed segment", candidate.FileID, beforeRefs[0].FileID)
+	}
+	oldSegmentPath, err := columnAssetSegmentPath(d.ColumnAssetRootDir(), candidate)
+	if err != nil {
+		t.Fatalf("columnAssetSegmentPath: %v", err)
+	}
+
+	rewrite, err := col.ColumnAssetRewrite(context.Background(), ColumnAssetRewriteOptions{
+		Detailed:      true,
+		CandidateRefs: []ColumnAssetRef{candidate},
+	})
+	if err != nil {
+		t.Fatalf("ColumnAssetRewrite: %v", err)
+	}
+	if rewrite.SegmentsRewritten != 1 || rewrite.RefsRemapped != len(beforeRefs) {
+		t.Fatalf("rewrite stats=%+v want one rewritten segment and %d remapped refs", rewrite, len(beforeRefs))
+	}
+	afterRefs := columnManifestAssetRefsForCollectionM12A(t, d, col)
+	if afterPhysical := columnManifestPhysicalAssetRefsForTestM1634(afterRefs); len(afterPhysical) != 1 || afterPhysical[0] == beforePhysical[0] {
+		t.Fatalf("after physical=%+v before=%+v want remapped physical ref", afterPhysical, beforePhysical)
+	}
+	if afterTyped := typedColumnPartRefs1755(afterRefs); len(afterTyped) != 1 || afterTyped[0] == beforeTyped[0] {
+		t.Fatalf("after typed=%+v before=%+v want remapped typed ref", afterTyped, beforeTyped)
+	}
+	got, err := col.Get([]byte("e1"))
+	if err != nil {
+		t.Fatalf("Get after rewrite: %v", err)
+	}
+	assertJSONEqualM13C(t, got, []byte(`{"time_us":1,"kind":"like","score":2.5,"flag":true}`))
+	if err := d.Close(); err != nil {
+		t.Fatalf("Close after rewrite: %v", err)
+	}
+	dClosed = true
+
+	reopened := openCollectionCommandWALDB(t, dir)
+	defer func() { _ = reopened.Close() }()
+	reopenedCol, err := NewCollectionManager(reopened).OpenCollection("events")
+	if err != nil {
+		t.Fatalf("OpenCollection reopened: %v", err)
+	}
+	reopenedGot, err := reopenedCol.Get([]byte("e1"))
+	if err != nil {
+		t.Fatalf("reopened Get e1 after rewrite: %v", err)
+	}
+	assertJSONEqualM13C(t, reopenedGot, []byte(`{"time_us":1,"kind":"like","score":2.5,"flag":true}`))
+	gcStats, err := reopenedCol.ColumnAssetGC(context.Background(), ColumnAssetGCOptions{
+		CandidateRefs: append(append([]ColumnAssetRef(nil), rewrite.SupersededRefs...), candidate),
+	})
+	if err != nil {
+		t.Fatalf("ColumnAssetGC: %v", err)
+	}
+	if gcStats.SegmentsDeleted != 1 || gcStats.BytesDeleted == 0 {
+		t.Fatalf("gc stats=%+v want old mixed segment deleted", gcStats)
+	}
+	if _, err := os.Stat(oldSegmentPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("old mixed segment stat err=%v want not exist", err)
+	}
+	afterGC, err := reopenedCol.Get([]byte("e1"))
+	if err != nil {
+		t.Fatalf("Get after GC: %v", err)
+	}
+	assertJSONEqualM13C(t, afterGC, []byte(`{"time_us":1,"kind":"like","score":2.5,"flag":true}`))
+}
+
+func TestTypedColumnPhysicalQueryFailsClosedForColumnPartFields(t *testing.T) {
+	d, col, _ := setupSingleTypedColumnPart1755(t)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RunColumnPhysicalQuery(ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount, GroupColumn: "kind"}); !errors.Is(err, ErrColumnQueryPlanUnsupported) {
+		t.Fatalf("RunColumnPhysicalQuery typed-column group err=%v want ErrColumnQueryPlanUnsupported", err)
+	}
+	result, err := col.RunColumnPhysicalQuery(ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryHourCount, ValueColumn: "time_us"})
+	if err != nil {
+		t.Fatalf("RunColumnPhysicalQuery row-owned time_us: %v", err)
+	}
+	if result.Diagnostics.ReduceRows != 1 || result.Diagnostics.RowMaterializations != 0 || result.Diagnostics.ReconstructionRows != 0 {
+		t.Fatalf("row-owned query diagnostics=%+v want one direct physical row and no reconstruction", result.Diagnostics)
+	}
+	count := 0
+	for _, group := range result.Groups {
+		count += group.Count
+	}
+	if count != 1 {
+		t.Fatalf("row-owned query total count=%d groups=%+v want 1", count, result.Groups)
+	}
 }
 
 func TestTypedColumnPublicationExistingTypedRowCompatibility(t *testing.T) {
@@ -415,6 +716,96 @@ func TestTypedColumnPublicationUnsupportedValueFailsClosed(t *testing.T) {
 	_, err = col.InsertBatch([][]byte{[]byte("e1")}, [][]byte{[]byte(`{"embedding":[1,2,3]}`)})
 	if !errors.Is(err, backenddb.ErrCommandWALRejected) {
 		t.Fatalf("InsertBatch error=%v want ErrCommandWALRejected", err)
+	}
+}
+
+func typedColumnDocumentAtSnapshot1755(t testing.TB, col *Collection, snap *backenddb.Snapshot, id []byte) ([]byte, bool) {
+	t.Helper()
+	catalog, err := col.catalogForSnapshot(snap)
+	if err != nil {
+		t.Fatalf("catalogForSnapshot: %v", err)
+	}
+	if catalog == nil {
+		t.Fatalf("catalogForSnapshot returned nil")
+	}
+	retained, found, err := collectionGetAppendAtCatalogRoot(snap, catalog, collectionPrimaryRootName(catalog.meta.Name), id, nil)
+	if err != nil {
+		t.Fatalf("collectionGetAppendAtCatalogRoot(%q): %v", string(id), err)
+	}
+	if !found {
+		return nil, false
+	}
+	if !columnStoreCanReconstructDocument(catalog.meta) {
+		return bytes.Clone(retained), true
+	}
+	reconstructed, err := col.reconstructColumnDocumentAtSnapshot(snap, catalog, id, retained)
+	if err != nil {
+		t.Fatalf("reconstructColumnDocumentAtSnapshot(%q): %v", string(id), err)
+	}
+	return reconstructed, true
+}
+
+func assertColumnAssetReachabilityEntry1755(t testing.TB, plan ColumnAssetReachabilityPlan, ref ColumnAssetRef, status ColumnAssetReachabilityStatus, wantPinned bool) {
+	t.Helper()
+	for _, entry := range plan.Entries {
+		if entry.Ref != ref {
+			continue
+		}
+		if entry.Status != status {
+			t.Fatalf("entry %+v status=%s want %s plan=%+v", entry.Ref, entry.Status, status, plan)
+		}
+		if wantPinned && !columnAssetReachabilitySourcesContain1755(entry.Sources, ColumnAssetReachabilitySourcePinnedSnapshot) {
+			t.Fatalf("entry %+v sources=%v want pinned_snapshot", entry.Ref, entry.Sources)
+		}
+		return
+	}
+	t.Fatalf("ref %+v not found in reachability entries=%+v", ref, plan.Entries)
+}
+
+func columnAssetReachabilitySourcesContain1755(sources []ColumnAssetReachabilitySource, want ColumnAssetReachabilitySource) bool {
+	for _, source := range sources {
+		if source == want {
+			return true
+		}
+	}
+	return false
+}
+
+func writeTypedColumnAssetCandidate1755(t testing.TB, d *backenddb.DB, col *Collection, generation, partID uint64) ColumnAssetRef {
+	t.Helper()
+	cfg := col.Meta().Options.ColumnStore
+	if cfg == nil || cfg.AssetManager == nil {
+		t.Fatalf("missing column store config: %+v", cfg)
+	}
+	payload := []byte("typed-column-candidate-1755")
+	ref, err := writeColumnAssetToManager(d.ColumnAssetRootDir(), *cfg, payload, ColumnAssetKindTCS1TypedColumnPart, generation, partID)
+	if err != nil {
+		t.Fatalf("writeColumnAssetToManager candidate: %v", err)
+	}
+	if ref.Length != int64(len(payload)) {
+		t.Fatalf("candidate ref length=%d want %d", ref.Length, len(payload))
+	}
+	return ref
+}
+
+func columnAssetRefsContain1755(refs []ColumnAssetRef, want ColumnAssetRef) bool {
+	for _, ref := range refs {
+		if ref == want {
+			return true
+		}
+	}
+	return false
+}
+
+func assertColumnAssetRefsEqual1755(t testing.TB, want, got []ColumnAssetRef) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("refs=%+v want %+v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("refs[%d]=%+v want %+v (all got %+v)", i, got[i], want[i], got)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds P0 typed-column correctness coverage for #1771 / #1744 in `TreeDB/collections/typed_column_publication_test.go`.
- Covers command-WAL reopen without an explicit post-write checkpoint, failed typed-column extraction atomicity, old snapshot typed-column visibility, pinned-snapshot reachability protection, mixed typed-row + typed-column asset rewrite/GC roundtrip, and fail-closed physical query behavior for `typed_column_part` fields.
- No production hot-path code changed; this PR is correctness-test-only.

## Linked tracker issues

- Closes #1771
- Parent tracker: #1744

## Start-phase test plan

- Review existing #1769 typed-column publication helpers and extend them with snapshot/reachability/rewrite fixtures.
- Add recovery and atomicity tests first.
- Add snapshot and maintenance safety tests next.
- Add physical query fail-closed coverage last.

## Start-phase performance plan

Correctness-only PR. No production hot path or cache behavior changes; benchmarks are not required.

## Close-phase test evidence

- `go test -count=1 ./TreeDB/collections -run 'TestTypedColumn|TestColumnAsset'` — pass
- `go test -count=1 ./TreeDB/...` — pass

## Benchmark evidence

Not run; no production code or performance-sensitive path changed.

## AI review status

- Codex: requested; no major issues found.
- CodeRabbit: requested; no actionable comments, status green. Non-blocking docstring-coverage warning applies to new test helpers only.
- Copilot: requested twice; Copilot returned a service error and did not complete a review.
- Review threads: none open.

## CI status

Latest head `b999f7d981798332154981996b3171da4df5aad8` is green across GitHub checks.

## Caveats / deferred work

- #1757 still owns typed-column predicate/physical scan/query integration. This PR asserts current fail-closed behavior instead of implementing that integration.
- PR is not merged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for typed-column publication scenarios, including database recovery, failure handling, snapshot consistency, and query planning validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1779?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->