### PR TITLE
treedb: add mappedresource Gate A correctness tests

### DIFF
--- a/TreeDB/collections/column_asset_manager.go
+++ b/TreeDB/collections/column_asset_manager.go
@@ -915,6 +915,13 @@ func (c *columnPhysicalAssetReadCache) mappedResourcePins() []mappedresource.Pin
 	return c.resourceManager.PinSummary()
 }
 
+func (c *columnPhysicalAssetReadCache) mappedResourcePinnedRefs() []ColumnAssetRef {
+	if c == nil {
+		return nil
+	}
+	return columnAssetRefsForMappedResourcePins(c.mappedResourcePins(), c.namespace)
+}
+
 func (c *columnPhysicalAssetReadCache) releaseResourceHandles() error {
 	if c == nil || len(c.resourceHandles) == 0 {
 		return nil
@@ -1121,6 +1128,49 @@ func mappedResourceKeyForColumnAssetRef(ref ColumnAssetRef) mappedresource.Key {
 		Length:     ref.Length,
 		Checksum:   uint64(ref.Checksum),
 	}
+}
+
+func columnAssetRefsForMappedResourcePins(pins []mappedresource.Pin, namespace string) []ColumnAssetRef {
+	if len(pins) == 0 {
+		return nil
+	}
+	refs := make([]ColumnAssetRef, 0, len(pins))
+	for _, pin := range pins {
+		ref, ok := columnAssetRefForMappedResourceKey(pin.Key)
+		if !ok {
+			continue
+		}
+		if namespace != "" && ref.Namespace != namespace {
+			continue
+		}
+		refs = append(refs, ref)
+	}
+	return refs
+}
+
+func columnAssetRefForMappedResourceKey(key mappedresource.Key) (ColumnAssetRef, bool) {
+	switch key.Class {
+	case mappedresource.ClassTypedRowAsset, mappedresource.ClassTypedColumnAsset:
+	default:
+		return ColumnAssetRef{}, false
+	}
+	if key.Checksum != uint64(uint32(key.Checksum)) {
+		return ColumnAssetRef{}, false
+	}
+	ref := ColumnAssetRef{
+		Kind:       ColumnAssetKind(key.Kind),
+		Namespace:  key.Namespace,
+		Generation: key.Generation,
+		PartID:     key.PartID,
+		FileID:     key.FileID,
+		Offset:     key.Offset,
+		Length:     key.Length,
+		Checksum:   uint32(key.Checksum),
+	}
+	if err := validateColumnAssetRefForPlan(ref); err != nil {
+		return ColumnAssetRef{}, false
+	}
+	return ref, true
 }
 
 func mappedResourceValidationModeForColumnAssetIntegrity(integrity ColumnAssetReadIntegrity) mappedresource.ValidationMode {

--- a/TreeDB/collections/column_asset_mappedresource_test.go
+++ b/TreeDB/collections/column_asset_mappedresource_test.go
@@ -183,6 +183,70 @@ func TestColumnAssetReadCacheMappedResourceViewHandlesDoNotAccumulateGateA1736(t
 	}
 }
 
+func TestColumnAssetReadCacheIntegrityModesReportMappedResourceValidation(t *testing.T) {
+	cfg := testColumnStoreConfig(nil)
+	normalized, err := normalizeColumnStoreConfig("events", cfg)
+	if err != nil {
+		t.Fatalf("normalizeColumnStoreConfig: %v", err)
+	}
+	root := backenddb.ColumnAssetRootDirPath(t.TempDir())
+	payload := []byte("mapped-resource-integrity-mode-payload")
+	ref, err := writeColumnPhysicalAssetToManager(root, *normalized, payload, 7, 3)
+	if err != nil {
+		t.Fatalf("writeColumnPhysicalAssetToManager: %v", err)
+	}
+
+	tests := []struct {
+		name      string
+		integrity ColumnAssetReadIntegrity
+		wantMode  mappedresource.ValidationMode
+	}{
+		{name: "verify", integrity: ColumnAssetReadIntegrityVerify, wantMode: mappedresource.ValidationVerify},
+		{name: "cached_verify", integrity: ColumnAssetReadIntegrityCachedVerify, wantMode: mappedresource.ValidationCachedVerify},
+		{name: "skip_checksums", integrity: ColumnAssetReadIntegritySkipChecksums, wantMode: mappedresource.ValidationSkipChecksum},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manager := mappedresource.NewManager()
+			readCache, err := newColumnPhysicalAssetReadCacheWithIntegrity(root, normalized.AssetManager.Namespace, tt.integrity)
+			if err != nil {
+				t.Fatalf("new read cache: %v", err)
+			}
+			if err := readCache.useMappedResourceManager(manager, mappedresource.Scope{Kind: mappedresource.ScopeSnapshot, ID: "snapshot-" + tt.name, Namespace: normalized.AssetManager.Namespace}, "integrity-mode-read"); err != nil {
+				t.Fatalf("useMappedResourceManager: %v", err)
+			}
+			raw, err := readCache.read(ref, nil)
+			if err != nil {
+				_ = readCache.close()
+				t.Fatalf("read: %v", err)
+			}
+			if !bytes.Equal(raw, payload) {
+				_ = readCache.close()
+				t.Fatalf("raw=%q want %q", raw, payload)
+			}
+			stats := readCache.mappedResourceStats()
+			if got := stats.ValidationModeReads[tt.wantMode]; got != 1 {
+				_ = readCache.close()
+				t.Fatalf("validation mode %q count=%d want 1 stats=%+v", tt.wantMode, got, stats)
+			}
+			if len(stats.ValidationModeReads) != 1 {
+				_ = readCache.close()
+				t.Fatalf("validation mode map=%+v want only %q", stats.ValidationModeReads, tt.wantMode)
+			}
+			if got := columnAssetReadIntegrityLabel(tt.integrity); got != string(tt.wantMode) {
+				_ = readCache.close()
+				t.Fatalf("integrity label=%q want mappedresource validation label %q", got, tt.wantMode)
+			}
+			if err := readCache.close(); err != nil {
+				t.Fatalf("close: %v", err)
+			}
+			if stats := manager.Stats(); stats.ActiveHandles != 0 || stats.ActiveHeapCopyBytes != 0 || stats.TotalReleases != 1 {
+				t.Fatalf("mapped resource stats after close: %+v", stats)
+			}
+		})
+	}
+}
+
 func TestColumnAssetReadCacheMappedResourceScopeValidationGateA1736(t *testing.T) {
 	readCache := columnPhysicalAssetReadCache{namespace: "events"}
 	manager := mappedresource.NewManager()

--- a/TreeDB/collections/column_asset_reachability_test.go
+++ b/TreeDB/collections/column_asset_reachability_test.go
@@ -7,9 +7,11 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"testing"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/internal/mappedresource"
 	"github.com/snissn/gomap/TreeDB/page"
 )
 
@@ -115,6 +117,96 @@ func TestColumnAssetReachabilityPlanClassifiesCandidateRefsAndPinsM15A(t *testin
 	}
 	if pinned.RewriteDebtBytes != 0 {
 		t.Fatalf("pinned rewrite debt=%d want 0", pinned.RewriteDebtBytes)
+	}
+}
+
+func TestMappedResourcePinnedRefsProtectColumnAssetReachability(t *testing.T) {
+	dir := prepareColumnAssetReachabilityCommandWALDirM15A(t)
+	d := openCollectionCommandWALDB(t, dir)
+	defer func() { _ = d.Close() }()
+	col := openColumnStoreCollectionM10B(t, d)
+
+	if _, err := col.Insert([]byte("e1"), []byte(`{"time_us":1,"kind":"like","did":"d1"}`)); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+	candidate := writeColumnAssetReachabilityCandidateM15A(t, d, col, 2, 99)
+	basePlan, err := col.PlanColumnAssetReachability(context.Background(), ColumnAssetReachabilityOptions{
+		Detailed:      true,
+		CandidateRefs: []ColumnAssetRef{candidate},
+	})
+	if err != nil {
+		t.Fatalf("PlanColumnAssetReachability unpinned: %v", err)
+	}
+	if basePlan.Refs.Reclaimable != 1 {
+		t.Fatalf("unpinned ref stats=%+v want one reclaimable candidate", basePlan.Refs)
+	}
+
+	cfg := col.Meta().Options.ColumnStore
+	manager := mappedresource.NewManager()
+	readCache, err := newColumnPhysicalAssetReadCacheWithIntegrity(d.ColumnAssetRootDir(), cfg.AssetManager.Namespace, ColumnAssetReadIntegrityVerify)
+	if err != nil {
+		t.Fatalf("new read cache: %v", err)
+	}
+	scope := mappedresource.Scope{
+		Kind:       mappedresource.ScopeSnapshot,
+		ID:         "snapshot-reachability-pin",
+		Namespace:  cfg.AssetManager.Namespace,
+		Collection: "events",
+		Generation: candidate.Generation,
+		Reason:     "reachability-test",
+	}
+	if err := readCache.useMappedResourceManager(manager, scope, "reachability-pinned-read"); err != nil {
+		_ = readCache.close()
+		t.Fatalf("useMappedResourceManager: %v", err)
+	}
+	raw, err := readCache.read(candidate, nil)
+	if err != nil {
+		_ = readCache.close()
+		t.Fatalf("read candidate: %v", err)
+	}
+	if int64(len(raw)) != candidate.Length {
+		_ = readCache.close()
+		t.Fatalf("candidate read bytes=%d want %d", len(raw), candidate.Length)
+	}
+	pinnedRefs := readCache.mappedResourcePinnedRefs()
+	if len(pinnedRefs) != 1 || pinnedRefs[0] != candidate {
+		_ = readCache.close()
+		t.Fatalf("mappedresource pinned refs=%+v want candidate %+v", pinnedRefs, candidate)
+	}
+
+	pinnedPlan, err := col.PlanColumnAssetReachability(context.Background(), ColumnAssetReachabilityOptions{
+		Detailed:      true,
+		CandidateRefs: []ColumnAssetRef{candidate},
+		PinnedRefs:    pinnedRefs,
+	})
+	if err != nil {
+		_ = readCache.close()
+		t.Fatalf("PlanColumnAssetReachability pinned: %v", err)
+	}
+	if pinnedPlan.Sources.PinnedRefs != 1 || pinnedPlan.Refs.Reclaimable != 0 || pinnedPlan.RewriteDebtBytes != 0 {
+		_ = readCache.close()
+		t.Fatalf("pinned plan stats=%+v sources=%+v rewriteDebt=%d", pinnedPlan.Refs, pinnedPlan.Sources, pinnedPlan.RewriteDebtBytes)
+	}
+	foundPinnedCandidate := false
+	for _, entry := range pinnedPlan.Entries {
+		if entry.Ref != candidate {
+			continue
+		}
+		foundPinnedCandidate = true
+		if entry.Status != ColumnAssetReachabilityProtected || !slices.Contains(entry.Sources, ColumnAssetReachabilitySourcePinnedSnapshot) {
+			_ = readCache.close()
+			t.Fatalf("pinned candidate entry=%+v want protected with pinned source", entry)
+		}
+	}
+	if !foundPinnedCandidate {
+		_ = readCache.close()
+		t.Fatal("missing pinned candidate entry")
+	}
+	if err := readCache.close(); err != nil {
+		t.Fatalf("close read cache: %v", err)
+	}
+	if pins := manager.PinSummary(); len(pins) != 0 {
+		t.Fatalf("pins after close=%d want 0", len(pins))
 	}
 }
 

--- a/TreeDB/internal/mappedresource/manager.go
+++ b/TreeDB/internal/mappedresource/manager.go
@@ -176,10 +176,9 @@ func (h *Handle) Release() error {
 		return nil
 	}
 	h.mu.Lock()
+	defer h.mu.Unlock()
 	if h.done {
-		err := h.err
-		h.mu.Unlock()
-		return err
+		return h.err
 	}
 	h.done = true
 	mgr := h.mgr
@@ -188,7 +187,6 @@ func (h *Handle) Release() error {
 	bytes := int64(len(h.bytes))
 	release := h.release
 	h.bytes = nil
-	h.mu.Unlock()
 
 	var err error
 	if release != nil {
@@ -197,9 +195,7 @@ func (h *Handle) Release() error {
 	if mgr != nil {
 		mgr.release(id, source, bytes, err)
 	}
-	h.mu.Lock()
 	h.err = err
-	h.mu.Unlock()
 	return err
 }
 

--- a/TreeDB/internal/mappedresource/manager_test.go
+++ b/TreeDB/internal/mappedresource/manager_test.go
@@ -2,9 +2,14 @@ package mappedresource
 
 import (
 	"bytes"
+	"errors"
+	"fmt"
 	"os"
 	"runtime"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 func testKey() Key {
@@ -49,6 +54,47 @@ func TestAcquireBytesReleaseUpdatesAccountingAndPins(t *testing.T) {
 	}
 	if stats := mgr.Stats(); stats.TotalReleases != 1 {
 		t.Fatalf("idempotent release TotalReleases=%d want 1", stats.TotalReleases)
+	}
+}
+
+func TestMappedResourceStatsSnapshotIsDeepCopy(t *testing.T) {
+	mgr := NewManager()
+	h, err := mgr.AcquireBytes(testKey(), testScope(), SourceHeapCopy, []byte("0123456789abcdef"), AcquireOptions{
+		Reason:         "snapshot",
+		ValidationMode: ValidationCachedVerify,
+		FallbackReason: FallbackReadAt,
+	})
+	if err != nil {
+		t.Fatalf("AcquireBytes: %v", err)
+	}
+	defer h.Release()
+
+	badKey := testKey()
+	badKey.FileID = 0
+	if _, err := mgr.AcquireBytes(badKey, testScope(), SourceHeapCopy, []byte("0123456789abcdef"), AcquireOptions{}); err == nil {
+		t.Fatal("AcquireBytes with invalid key err=nil, want failure")
+	}
+
+	snapshot := mgr.Stats()
+	if snapshot.DeniedByReason[DenyInvalidKey] != 1 || snapshot.FallbacksByReason[FallbackReadAt] != 1 || snapshot.ValidationModeReads[ValidationCachedVerify] != 1 {
+		t.Fatalf("stats snapshot missing expected map counts: %+v", snapshot)
+	}
+	snapshot.DeniedByReason[DenyInvalidKey] = 99
+	snapshot.DeniedByReason[DenyUnsupported] = 99
+	snapshot.FallbacksByReason[FallbackReadAt] = 99
+	snapshot.FallbacksByReason[FallbackMmapFailed] = 99
+	snapshot.ValidationModeReads[ValidationCachedVerify] = 99
+	snapshot.ValidationModeReads[ValidationSkipChecksum] = 99
+
+	fresh := mgr.Stats()
+	if fresh.DeniedByReason[DenyInvalidKey] != 1 || fresh.DeniedByReason[DenyUnsupported] != 0 {
+		t.Fatalf("DeniedByReason was not deep-copied: %+v", fresh.DeniedByReason)
+	}
+	if fresh.FallbacksByReason[FallbackReadAt] != 1 || fresh.FallbacksByReason[FallbackMmapFailed] != 0 {
+		t.Fatalf("FallbacksByReason was not deep-copied: %+v", fresh.FallbacksByReason)
+	}
+	if fresh.ValidationModeReads[ValidationCachedVerify] != 1 || fresh.ValidationModeReads[ValidationSkipChecksum] != 0 {
+		t.Fatalf("ValidationModeReads was not deep-copied: %+v", fresh.ValidationModeReads)
 	}
 }
 
@@ -155,6 +201,188 @@ func TestAcquireFileRangeRejectsOutOfBoundsZeroLengthHeapRange(t *testing.T) {
 	stats := mgr.Stats()
 	if stats.DeniedByReason[DenyOutOfBounds] != 1 || stats.ActiveHandles != 0 {
 		t.Fatalf("unexpected stats after out-of-bounds range: %+v", stats)
+	}
+}
+
+func TestAcquireFileRangeBoundaryMatrix(t *testing.T) {
+	dir := t.TempDir()
+	path := dir + "/asset.bin"
+	payload := []byte("0123456789abcdef")
+	if err := os.WriteFile(path, payload, 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	tests := []struct {
+		name      string
+		offset    int64
+		length    int64
+		wantBytes []byte
+		wantErr   bool
+	}{
+		{name: "full range", offset: 0, length: int64(len(payload)), wantBytes: payload},
+		{name: "middle range", offset: 3, length: 5, wantBytes: payload[3:8]},
+		{name: "zero length at eof", offset: int64(len(payload)), length: 0, wantBytes: []byte{}},
+		{name: "negative offset", offset: -1, length: 1, wantErr: true},
+		{name: "negative length", offset: 0, length: -1, wantErr: true},
+		{name: "overflowing range", offset: maxInt64 - 1, length: 2, wantErr: true},
+		{name: "zero length past eof", offset: int64(len(payload)) + 1, length: 0, wantErr: true},
+		{name: "length past eof", offset: int64(len(payload)) - 1, length: 2, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mgr := NewManager()
+			key := testKey()
+			key.Offset = tt.offset
+			key.Length = tt.length
+			h, err := mgr.AcquireFileRange(key, testScope(), path, AcquireOptions{Reason: tt.name, AllowHeapCopy: true})
+			if tt.wantErr {
+				if err == nil {
+					if h != nil {
+						_ = h.Release()
+					}
+					t.Fatal("AcquireFileRange err=nil, want failure")
+				}
+				assertMappedResourceNoActive(t, mgr)
+				stats := mgr.Stats()
+				if stats.TotalAcquires != 0 || stats.Opens != stats.Closes {
+					t.Fatalf("failure leaked acquisition/open accounting: %+v", stats)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("AcquireFileRange: %v", err)
+			}
+			if got := h.Bytes(); !bytes.Equal(got, tt.wantBytes) {
+				_ = h.Release()
+				t.Fatalf("bytes=%q want %q", got, tt.wantBytes)
+			}
+			if stats := mgr.Stats(); stats.ActiveHandles != 1 || stats.TotalAcquires != 1 {
+				_ = h.Release()
+				t.Fatalf("unexpected active stats after success: %+v", stats)
+			}
+			if err := h.Release(); err != nil {
+				t.Fatalf("Release: %v", err)
+			}
+			assertMappedResourceNoActive(t, mgr)
+		})
+	}
+}
+
+func TestMappedResourceConcurrentAcquireReleasePinSummaryRace(t *testing.T) {
+	mgr := NewManager()
+	const workers = 8
+	const iters = 128
+	payload := []byte("0123456789abcdef")
+
+	var done atomic.Bool
+	var observer sync.WaitGroup
+	observer.Add(1)
+	go func() {
+		defer observer.Done()
+		for !done.Load() {
+			_ = mgr.Stats()
+			_ = mgr.PinSummary()
+			runtime.Gosched()
+		}
+	}()
+
+	errs := make(chan error, workers*iters)
+	var wg sync.WaitGroup
+	for worker := 0; worker < workers; worker++ {
+		worker := worker
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for iter := 0; iter < iters; iter++ {
+				key := testKey()
+				key.FileID = uint32(worker + 1)
+				key.PartID = uint64(iter + 1)
+				key.Checksum = uint64(worker*iters + iter + 1)
+				scope := testScope()
+				scope.ID = fmt.Sprintf("snapshot-%d-%d", worker, iter)
+				source := SourceHeapCopy
+				if iter%2 == 0 {
+					source = SourceMapped
+				}
+				h, err := mgr.AcquireBytes(key, scope, source, payload, AcquireOptions{Reason: "concurrent", ValidationMode: ValidationVerify})
+				if err != nil {
+					errs <- fmt.Errorf("AcquireBytes worker=%d iter=%d: %w", worker, iter, err)
+					continue
+				}
+				_ = mgr.Stats()
+				_ = mgr.PinSummary()
+				if got := h.Bytes(); len(got) != len(payload) {
+					errs <- fmt.Errorf("handle bytes len=%d want %d", len(got), len(payload))
+				}
+				if err := h.Release(); err != nil {
+					errs <- fmt.Errorf("Release worker=%d iter=%d: %w", worker, iter, err)
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	done.Store(true)
+	observer.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Error(err)
+		}
+	}
+	stats := mgr.Stats()
+	want := uint64(workers * iters)
+	if stats.TotalAcquires != want || stats.TotalReleases != want || stats.ActiveHandles != 0 || stats.ActiveMappedBytes != 0 || stats.ActiveHeapCopyBytes != 0 {
+		t.Fatalf("stats after concurrent acquire/release: %+v want acquires/releases=%d and no active bytes", stats, want)
+	}
+	if pins := mgr.PinSummary(); len(pins) != 0 {
+		t.Fatalf("pins after concurrent acquire/release=%d want 0", len(pins))
+	}
+}
+
+func TestMappedResourceReleaseConcurrentIdempotent(t *testing.T) {
+	mgr := NewManager()
+	releaseErr := errors.New("release failed")
+	releaseEntered := make(chan struct{})
+	releaseProceed := make(chan struct{})
+	h := mgr.acquireRegistered(testKey(), testScope(), SourceHeapCopy, []byte("0123456789abcdef"), func() error {
+		close(releaseEntered)
+		<-releaseProceed
+		return releaseErr
+	}, AcquireOptions{Reason: "concurrent-release"})
+
+	const callers = 16
+	errs := make(chan error, callers)
+	go func() { errs <- h.Release() }()
+	<-releaseEntered
+	for i := 1; i < callers; i++ {
+		go func() { errs <- h.Release() }()
+	}
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		close(releaseProceed)
+	}()
+	for i := 0; i < callers; i++ {
+		if err := <-errs; !errors.Is(err, releaseErr) {
+			t.Fatalf("Release caller %d error=%v want %v", i, err, releaseErr)
+		}
+	}
+	stats := mgr.Stats()
+	if stats.TotalReleases != 1 || stats.Errors != 1 || stats.ActiveHandles != 0 || stats.ActiveHeapCopyBytes != 0 || stats.DeniedByReason[DenyReleaseMismatch] != 0 {
+		t.Fatalf("stats after concurrent idempotent release: %+v", stats)
+	}
+	if pins := mgr.PinSummary(); len(pins) != 0 {
+		t.Fatalf("pins after concurrent release=%d want 0", len(pins))
+	}
+}
+
+func assertMappedResourceNoActive(t testing.TB, mgr *Manager) {
+	t.Helper()
+	stats := mgr.Stats()
+	if stats.ActiveHandles != 0 || stats.ActiveMappedBytes != 0 || stats.ActiveHeapCopyBytes != 0 || stats.ActiveDerivedMetadataBytes != 0 {
+		t.Fatalf("mappedresource active accounting leaked: %+v", stats)
+	}
+	if pins := mgr.PinSummary(); len(pins) != 0 {
+		t.Fatalf("mappedresource pins leaked=%d: %+v", len(pins), pins)
 	}
 }
 

--- a/TreeDB/internal/mappedresource/manager_test.go
+++ b/TreeDB/internal/mappedresource/manager_test.go
@@ -67,7 +67,7 @@ func TestMappedResourceStatsSnapshotIsDeepCopy(t *testing.T) {
 	if err != nil {
 		t.Fatalf("AcquireBytes: %v", err)
 	}
-	defer h.Release()
+	defer func() { _ = h.Release() }()
 
 	badKey := testKey()
 	badKey.FileID = 0


### PR DESCRIPTION
## Summary

- Adds mappedresource manager coverage for stats snapshot immutability, file-range boundary failures, concurrent acquire/release/pin-summary access, and concurrent idempotent release error propagation.
- Adds column asset read-cache coverage for `verify`, `cached_verify`, and `skip_checksums` mappedresource validation labels.
- Bridges active mappedresource pins back to `ColumnAssetRef` pinned refs and tests that reachability planning protects a pinned column asset candidate.

## Linked tracker issue

Closes #1772.
Related trackers: #1744, #1736.

## Start-phase test plan

- Review current `TreeDB/internal/mappedresource` tests and column asset read-cache/reachability tests.
- Add deterministic boundary/accounting tests first.
- Add concurrency/race coverage for acquire/release/stats/pin summary.
- Add read-cache integrity-label and pinned-ref reachability bridge tests.

## Start-phase performance plan

Correctness-only. This PR adds tests and a small release idempotence fix; it does not change hot-path read-cache behavior. No benchmarks required.

## Close-phase focused test evidence

Latest local head tested: `1a90f685b076d2c26e287bc79eac7e6f48c2d1fe`.

```sh
go test -count=1 ./TreeDB/internal/mappedresource ./TreeDB/collections -run 'TestMappedResource|TestColumnAssetReadCache|TestColumnAssetReachability|TestAcquireFileRangeBoundaryMatrix'
# ok github.com/snissn/gomap/TreeDB/internal/mappedresource 0.495s
# ok github.com/snissn/gomap/TreeDB/collections 1.202s
```

```sh
go test -count=1 ./TreeDB/...
# ok github.com/snissn/gomap/TreeDB/... (all packages)
```

## Race-test evidence

```sh
go test -race -count=1 ./TreeDB/internal/mappedresource
# ok github.com/snissn/gomap/TreeDB/internal/mappedresource 1.409s
```

## Benchmark evidence

Not run; correctness-only change with no read-cache hot-path behavior change.

## AI review status and unresolved thread summary

- Codex: no major issues on latest head.
- CodeRabbit: prior nit fixed in `1a90f68`; latest review has no actionable comments.
- Copilot: requested twice via `@copilot review` and reviewer request, but Copilot cloud agent errored both times; treated as bot unavailable/non-blocking.
- Unresolved review threads: none.

## CI status

Latest-head CI is green for `1a90f685b076d2c26e287bc79eac7e6f48c2d1fe`. One earlier `race-check (linux)-2` flake was retried successfully before the final push; final-head TreeDB race checks passed.

## Caveats

PR is prepared for review but not merged.
