### PR TITLE
treedb: add typed-column vector perf guardrails

### DIFF
--- a/TreeDB/collections/typed_column_publication.go
+++ b/TreeDB/collections/typed_column_publication.go
@@ -214,6 +214,11 @@ type typedColumnPartReconstructionCache struct {
 	Rows       map[uint64][]typedColumnAdapterRow
 	Refs       map[uint64]columnManifestAssetRefForScan
 	RefsLoaded bool
+
+	CacheHits        uint64
+	CacheMisses      uint64
+	PartLoads        uint64
+	TypedPartDecodes uint64
 }
 
 func (c *Collection) typedColumnPartValuesForVisibleRowAtSnapshot(snap *backenddb.Snapshot, manifestRootID uint64, cfg ColumnStoreConfig, physicalRow columnPhysicalVisibleRow) (typedColumnPartVisibleValues, error) {
@@ -236,7 +241,12 @@ func (c *Collection) typedColumnPartValuesForVisibleRowAtSnapshotWithCache(snap 
 	if cache != nil && cache.Rows != nil {
 		rows, ok = cache.Rows[physicalRow.Generation]
 	}
-	if !ok {
+	if ok {
+		cache.CacheHits++
+	} else {
+		if cache != nil {
+			cache.CacheMisses++
+		}
 		ref, found, err := c.typedColumnPartRefForGenerationWithCache(snap, manifestRootID, cfg, physicalRow.Generation, cache)
 		if err != nil {
 			return typedColumnPartVisibleValues{}, err
@@ -255,6 +265,9 @@ func (c *Collection) typedColumnPartValuesForVisibleRowAtSnapshotWithCache(snap 
 			}
 			return typedColumnPartVisibleValues{}, fmt.Errorf("collections: typed-column reconstruction read generation=%d part_id=%d: %w", ref.Ref.Generation, ref.Ref.PartID, readErr)
 		}
+		if cache != nil {
+			cache.PartLoads++
+		}
 		part, err := typedColumnAdapterPartFromBytes(typedColumnAdapterOptions{Fields: fields}, raw)
 		if err != nil {
 			if closeErr := readCache.close(); closeErr != nil {
@@ -272,6 +285,9 @@ func (c *Collection) typedColumnPartValuesForVisibleRowAtSnapshotWithCache(snap 
 		}
 		if closeErr != nil {
 			return typedColumnPartVisibleValues{}, closeErr
+		}
+		if cache != nil {
+			cache.TypedPartDecodes++
 		}
 		if cache != nil {
 			if cache.Rows == nil {

--- a/TreeDB/collections/typed_column_publication_test.go
+++ b/TreeDB/collections/typed_column_publication_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -264,6 +265,69 @@ func TestTypedColumnReconstructionScanHybridOwners(t *testing.T) {
 	}
 	assertJSONEqualM13C(t, records[0].Document, []byte(`{"time_us":1,"kind":"like","score":2.5,"flag":true,"payload":"alpha"}`))
 	assertJSONEqualM13C(t, records[1].Document, []byte(`{"time_us":2,"kind":"post","score":3.5,"flag":false,"payload":"beta"}`))
+}
+
+func TestTypedColumnReconstructionCacheDecodesOncePerGeneration1781(t *testing.T) {
+	const rows = 8
+	col, snap, visibleRows, cfg, manifestRootID := typedColumnReconstructionCacheFixture1781(t, rows)
+	cache := &typedColumnPartReconstructionCache{Rows: make(map[uint64][]typedColumnAdapterRow, 1)}
+	for _, row := range visibleRows {
+		typedValues, err := col.typedColumnPartValuesForVisibleRowAtSnapshotWithCache(snap, manifestRootID, cfg, row, cache)
+		if err != nil {
+			t.Fatalf("typedColumnPartValuesForVisibleRowAtSnapshotWithCache: %v", err)
+		}
+		fullValues, err := mergeColumnReconstructionValues(cfg, row.Values, typedValues.Values)
+		if err != nil {
+			t.Fatalf("mergeColumnReconstructionValues: %v", err)
+		}
+		if len(fullValues) != len(cfg.Columns) {
+			t.Fatalf("full values=%d want columns=%d", len(fullValues), len(cfg.Columns))
+		}
+	}
+	if cache.PartLoads != 1 || cache.TypedPartDecodes != 1 || cache.CacheMisses != 1 || cache.CacheHits != rows-1 {
+		t.Fatalf("cache counters loads=%d decodes=%d hits=%d misses=%d want one load/decode/miss and %d hits", cache.PartLoads, cache.TypedPartDecodes, cache.CacheHits, cache.CacheMisses, rows-1)
+	}
+}
+
+func BenchmarkTypedColumnReconstructionCache1781(b *testing.B) {
+	const rows = 128
+	col, snap, visibleRows, cfg, manifestRootID := typedColumnReconstructionCacheFixture1781(b, rows)
+	b.ReportAllocs()
+	b.ResetTimer()
+	var reconstructedRows int64
+	var partLoads, typedPartDecodes, cacheHits, cacheMisses uint64
+	for i := 0; i < b.N; i++ {
+		cache := &typedColumnPartReconstructionCache{Rows: make(map[uint64][]typedColumnAdapterRow, 1)}
+		for _, row := range visibleRows {
+			typedValues, err := col.typedColumnPartValuesForVisibleRowAtSnapshotWithCache(snap, manifestRootID, cfg, row, cache)
+			if err != nil {
+				b.Fatalf("typedColumnPartValuesForVisibleRowAtSnapshotWithCache: %v", err)
+			}
+			fullValues, err := mergeColumnReconstructionValues(cfg, row.Values, typedValues.Values)
+			if err != nil {
+				b.Fatalf("mergeColumnReconstructionValues: %v", err)
+			}
+			if len(fullValues) == 0 {
+				b.Fatal("empty reconstruction values")
+			}
+			reconstructedRows++
+		}
+		partLoads += cache.PartLoads
+		typedPartDecodes += cache.TypedPartDecodes
+		cacheHits += cache.CacheHits
+		cacheMisses += cache.CacheMisses
+	}
+	b.StopTimer()
+	if typedPartDecodes != uint64(b.N) || partLoads != uint64(b.N) {
+		b.Fatalf("typed-column part decodes=%d loads=%d want one per benchmark op (%d), not per row", typedPartDecodes, partLoads, b.N)
+	}
+	elapsed := b.Elapsed()
+	b.ReportMetric(float64(reconstructedRows)/elapsed.Seconds(), "rows/s")
+	b.ReportMetric(float64(reconstructedRows)/float64(b.N), "rows/op")
+	b.ReportMetric(float64(partLoads)/float64(b.N), "part_loads/op")
+	b.ReportMetric(float64(typedPartDecodes)/float64(b.N), "typed_part_decodes/op")
+	b.ReportMetric(float64(cacheHits)/float64(b.N), "cache_hits/op")
+	b.ReportMetric(float64(cacheMisses)/float64(b.N), "cache_misses/op")
 }
 
 func TestTypedColumnPublicationRejectsOverlappingOwners(t *testing.T) {
@@ -763,6 +827,48 @@ func TestTypedColumnPublicationUnsupportedValueFailsClosed(t *testing.T) {
 	if !errors.Is(err, backenddb.ErrCommandWALRejected) {
 		t.Fatalf("InsertBatch error=%v want ErrCommandWALRejected", err)
 	}
+}
+
+func typedColumnReconstructionCacheFixture1781(t testing.TB, rows int) (*Collection, *backenddb.Snapshot, []columnPhysicalVisibleRow, ColumnStoreConfig, uint64) {
+	t.Helper()
+	dir := t.TempDir()
+	if err := backenddb.SaveFormatConfig(dir, backenddb.FormatConfig{RequiredFeatures: []string{backenddb.RequiredFeatureCommandWALV1}}); err != nil {
+		t.Fatalf("SaveFormatConfig: %v", err)
+	}
+	d := openCollectionCommandWALDB(t, dir)
+	t.Cleanup(func() { _ = d.Close() })
+	col := createTypedColumnPartCollection1755(t, d)
+	ids := make([][]byte, rows)
+	docs := make([][]byte, rows)
+	for i := 0; i < rows; i++ {
+		ids[i] = []byte(fmt.Sprintf("e%06d", i))
+		docs[i] = []byte(fmt.Sprintf(`{"time_us":%d,"kind":"kind-%02d","score":%.2f,"flag":%t,"payload":"payload-%d"}`, i+1, i%7, float64(i)+0.25, i%2 == 0, i))
+	}
+	if _, err := col.InsertBatch(ids, docs); err != nil {
+		t.Fatalf("InsertBatch: %v", err)
+	}
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatalf("AcquireSnapshot returned nil")
+	}
+	t.Cleanup(func() { _ = snap.Close() })
+	catalog, err := col.catalogForSnapshot(snap)
+	if err != nil {
+		t.Fatalf("catalogForSnapshot: %v", err)
+	}
+	if catalog == nil {
+		t.Fatalf("catalogForSnapshot returned nil")
+	}
+	cfg := catalog.meta.Options.ColumnStore.copy()
+	manifestRootID := catalog.rootID(collectionColumnManifestRootName(catalog.meta.Name))
+	visible, err := col.scanColumnPhysicalVisibleRowsAtSnapshot(snap, catalog, catalog.meta.Name, manifestRootID, cfg, true, nil)
+	if err != nil {
+		t.Fatalf("scanColumnPhysicalVisibleRowsAtSnapshot: %v", err)
+	}
+	if len(visible.Rows) != rows {
+		t.Fatalf("visible rows=%d want %d", len(visible.Rows), rows)
+	}
+	return col, snap, visible.Rows, cfg, manifestRootID
 }
 
 func typedColumnDocumentAtSnapshot1755(t testing.TB, col *Collection, snap *backenddb.Snapshot, id []byte) ([]byte, bool) {

--- a/TreeDB/internal/typedcolumn/dense_test.go
+++ b/TreeDB/internal/typedcolumn/dense_test.go
@@ -333,6 +333,41 @@ func TestTypedColumnDenseMmapHeapParity1756(t *testing.T) {
 	}
 }
 
+func TestTypedColumnVectorDenseDirectViewKernelZeroAllocs1781(t *testing.T) {
+	const rows = 1024
+	const dims = 16
+	part := mustDenseVectorPart1756(t, rows, dims)
+	image, err := BuildColumnPartImage(part, ColumnPartImageOptions{})
+	if err != nil {
+		t.Fatalf("BuildColumnPartImage: %v", err)
+	}
+	parsed, err := ParseColumnPartImage(image.Bytes)
+	if err != nil {
+		t.Fatalf("ParseColumnPartImage: %v", err)
+	}
+	section := mustColumnDataSection1756(t, parsed, "embedding")
+	mgr := mappedresource.NewManager()
+	h := mustAcquireImageSectionBytes1756(t, mgr, parsed, section, parsed.SectionBytesMust1756(t, section))
+	defer h.Release()
+	view, err := mgr.Float32View(h)
+	if err != nil {
+		t.Fatalf("Float32View setup: %v", err)
+	}
+	if len(view) != rows*dims {
+		t.Fatalf("view elements=%d want %d", len(view), rows*dims)
+	}
+	var sum float32
+	allocs := testing.AllocsPerRun(1000, func() {
+		sum += denseFloat32KernelSum1781(view)
+	})
+	if allocs != 0 {
+		t.Fatalf("direct-view dense float32 kernel allocs/run=%v want 0", allocs)
+	}
+	if sum == 0 {
+		t.Fatalf("sum=0")
+	}
+}
+
 func BenchmarkTypedColumnVectorDenseDirectViewScan(b *testing.B) {
 	const rows = 1024
 	const dims = 16
@@ -366,6 +401,71 @@ func BenchmarkTypedColumnVectorDenseDirectViewScan(b *testing.B) {
 	stats := mgr.Stats()
 	b.ReportMetric(float64(stats.DirectViewSuccesses)/float64(b.N), "direct_views/op")
 	b.ReportMetric(float64(stats.DirectViewFailures)/float64(b.N), "scratch_decodes/op")
+	b.ReportMetric(float64(stats.TotalMappedBytes), "mapped_B")
+	b.ReportMetric(float64(stats.TotalHeapCopyBytes), "heap_copy_B")
+}
+
+func BenchmarkTypedColumnVectorDenseMmapHeapDirectViewScan(b *testing.B) {
+	const rows = 1024
+	const dims = 16
+	part := mustDenseVectorPart1756(b, rows, dims)
+	image, err := BuildColumnPartImage(part, ColumnPartImageOptions{})
+	if err != nil {
+		b.Fatalf("BuildColumnPartImage: %v", err)
+	}
+	parsed, err := ParseColumnPartImage(image.Bytes)
+	if err != nil {
+		b.Fatalf("ParseColumnPartImage: %v", err)
+	}
+	section := mustColumnDataSection1756(b, parsed, "embedding")
+	path := filepath.Join(b.TempDir(), "part.tcim")
+	if err := os.WriteFile(path, parsed.Bytes, 0o600); err != nil {
+		b.Fatalf("write image: %v", err)
+	}
+	scope := mappedresource.Scope{Kind: mappedresource.ScopeColumnPartReader, ID: "dense-mmap-heap-bench", Namespace: "typedcolumn-test"}
+	key := mappedresource.Key{Class: mappedresource.ClassTypedColumnAsset, Namespace: scope.Namespace, Kind: string(section.Kind), PartID: parsed.PartID, FileID: 1, Offset: int64(section.Offset), Length: int64(section.Length), Version: parsed.Version, Encoding: section.Encoding.String()}
+	for _, tc := range []struct {
+		name string
+		opts mappedresource.AcquireOptions
+	}{
+		{name: "mapped", opts: mappedresource.AcquireOptions{Reason: "mapped dense vector benchmark", ValidationMode: mappedresource.ValidationVerify, PreferMapped: true, AllowHeapCopy: true}},
+		{name: "heap", opts: mappedresource.AcquireOptions{Reason: "heap dense vector benchmark", ValidationMode: mappedresource.ValidationVerify, AllowHeapCopy: true}},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			mgr := mappedresource.NewManager()
+			h, err := mgr.AcquireFileRange(key, scope, path, tc.opts)
+			if err != nil {
+				b.Fatalf("AcquireFileRange: %v", err)
+			}
+			defer h.Release()
+			if _, err := mgr.Float32View(h); err != nil {
+				b.Fatalf("Float32View setup: %v", err)
+			}
+			baseStats := mgr.Stats()
+			b.ReportAllocs()
+			b.ResetTimer()
+			var sum float32
+			for i := 0; i < b.N; i++ {
+				view, err := mgr.Float32View(h)
+				if err != nil {
+					b.Fatalf("Float32View: %v", err)
+				}
+				sum += denseFloat32KernelSum1781(view)
+			}
+			b.StopTimer()
+			if sum == 0 {
+				b.Fatalf("sum=0")
+			}
+			elapsed := b.Elapsed()
+			stats := mgr.Stats()
+			b.ReportMetric(float64(b.N*rows)/elapsed.Seconds(), "rows/s")
+			b.ReportMetric(float64(b.N*rows*dims)/elapsed.Seconds(), "elements/s")
+			b.ReportMetric(float64(stats.DirectViewSuccesses-baseStats.DirectViewSuccesses)/float64(b.N), "direct_views/op")
+			b.ReportMetric(float64(stats.DirectViewFailures-baseStats.DirectViewFailures)/float64(b.N), "scratch_decodes/op")
+			b.ReportMetric(float64(stats.TotalMappedBytes), "mapped_B")
+			b.ReportMetric(float64(stats.TotalHeapCopyBytes), "heap_copy_B")
+		})
+	}
 }
 
 func BenchmarkTypedColumnVectorDenseSectionScan(b *testing.B) {
@@ -390,6 +490,14 @@ func BenchmarkTypedColumnVectorDenseSectionScan(b *testing.B) {
 	}
 	b.ReportMetric(float64(b.N*rows)/b.Elapsed().Seconds(), "rows/s")
 	b.ReportMetric(float64(b.N*rows*dims)/b.Elapsed().Seconds(), "elements/s")
+}
+
+func denseFloat32KernelSum1781(values []float32) float32 {
+	var sum float32
+	for _, value := range values {
+		sum += value
+	}
+	return sum
 }
 
 func mustDenseVectorAdjacencyImage1756(t testing.TB) ColumnPartImage {


### PR DESCRIPTION
## Summary

Closes #1781. Parent tracker: #1744.

This PR lands focused typed-column/vector performance guardrails before #1757 predicate scans:

- adds a zero-allocation direct dense `float32_vector` kernel guardrail after setup;
- extends dense vector direct-view benchmarks with rows/s, elements/s, direct-view/scratch counters, and mapped/heap byte counters;
- adds a light mmap-vs-heap direct-view benchmark smoke next to the existing parity test;
- adds typed-column reconstruction generation-cache counters plus a test/benchmark showing typed-column part load/decode happens once per generation/op, not once per row.

## Scope boundary / non-goals

- Does **not** implement #1757 int64 predicate scan.
- Does **not** switch native vector graph/search to typed-column parts (#1782).
- Does **not** make `adjacency_list` authoritative.
- Does **not** add SIMD requirements.
- Does **not** weaken validation, checksum/integrity, mappedresource lifetime, alignment, endian, length, or range checks.

## Start-phase test / benchmark plan

- Focused packages: `./TreeDB/internal/typedcolumn ./TreeDB/collections`.
- Guardrail tests for direct dense vector allocation and reconstruction-cache decode/load counts.
- Benchmarks for dense vector direct-view scans, mapped-vs-heap direct-view scans, section decode baseline, and typed-column reconstruction-cache reuse.

## Close-phase test evidence

Branch/commit: `snissn/1781-manager` @ `36371c8b36ccd6475a81402f7eef81bbe414a029`.

```sh
go test -count=1 ./TreeDB/internal/typedcolumn ./TreeDB/collections
go test -count=1 ./TreeDB/...
```

Results: both passed locally on Apple M3 (`darwin/arm64`, Go `go1.25.5`).

## Close-phase benchmark evidence

Command:

```sh
go test -run '^$' -bench 'BenchmarkTypedColumnVectorDense|BenchmarkTypedColumnReconstruction' -benchmem -benchtime=100x -count=1 ./TreeDB/internal/typedcolumn ./TreeDB/collections
```

Hardware/context: Apple M3, `darwin/arm64`, Go `go1.25.5`; branch `snissn/1781-manager`; commit `36371c8b36ccd6475a81402f7eef81bbe414a029`.

Timing boundary:

- Dense direct-view benchmarks build/parse/acquire the typed-column image before the timer; timed loop validates/exposes direct view and scans the already-acquired section.
- Mmap/heap benchmark acquires the resource handle before the timer; timed loop does direct-view validation plus scan.
- Section scan baseline times full dense column decode plus scan.
- Reconstruction cache benchmark builds the DB fixture and visible-row set before the timer; each timed op creates one generation cache and reconstructs 128 visible rows through the cache.

| Benchmark | Shape | ns/op | ops/sec | rows/s | elements/s | direct views/op | scratch decodes/op | mapped bytes | heap-copy bytes | B/op | allocs/op |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| `BenchmarkTypedColumnVectorDenseDirectViewScan-8` | 1024 rows x 16 dims | 12,451 | 80,315 | 82,240,739 | 1,315,851,822 | 1.000 | 0 | 0 | 65,536 | 0 | 0 |
| `BenchmarkTypedColumnVectorDenseMmapHeapDirectViewScan/mapped-8` | 1024 rows x 16 dims | 12,192 | 82,021 | 83,991,775 | 1,343,868,395 | 1.000 | 0 | 65,536 | 0 | 0 | 0 |
| `BenchmarkTypedColumnVectorDenseMmapHeapDirectViewScan/heap-8` | 1024 rows x 16 dims | 12,117 | 82,529 | 84,511,669 | 1,352,186,698 | 1.000 | 0 | 0 | 65,536 | 0 | 0 |
| `BenchmarkTypedColumnVectorDenseSectionScan-8` | 1024 rows x 16 dims | 29,259 | 34,178 | 34,998,077 | 559,969,240 | n/a | n/a | n/a | n/a | 131,168 | 6 |

| Benchmark | Shape | ns/op | ops/sec | rows/s | rows/op | part loads/op | typed part decodes/op | cache hits/op | cache misses/op | B/op | allocs/op |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| `BenchmarkTypedColumnReconstructionCache1781-8` | 128 rows, 1 generation | 156,789 | 6,378 | 816,385 | 128.0 | 1.000 | 1.000 | 127.0 | 1.000 | 364,742 | 1,142 |

## AI review / CI status

Latest head: `36371c8b36ccd6475a81402f7eef81bbe414a029` (`mergeStateStatus=CLEAN`, PR open, not draft).

- Latest-head CI: green. Passing checks include CodeRabbit status, append-only guardrail, bench, gofmt, macOS/Ubuntu/Windows matrices, perf-smoke, profiles, race checks, and suites.
- Codex: requested after PR creation; latest review found no major issues.
- CodeRabbit: requested after PR creation; no actionable comments; status passed/review skipped. CodeRabbit's generated docstring-coverage item is a non-blocking generic warning for test/helper code.
- Copilot: requested twice; returned bot/cloud-agent review error and is documented as unavailable, not passing.
- Unresolved review threads: 0.

## Risks / caveats

- Reconstruction cache benchmark is intentionally a guardrail for the current one-generation scan/reconstruction path; multi-generation cache accounting can be added later if #1757 needs it.
- Existing reconstruction still allocates for JSON/value materialization; this PR only guards against typed-column part reload/decode per row.
