### PR TITLE
treedb: add int64 typed-column predicate scan

### DIFF
--- a/TreeDB/collections/column_physical_scan.go
+++ b/TreeDB/collections/column_physical_scan.go
@@ -202,6 +202,7 @@ type columnPhysicalScanSnapshotView struct {
 	CollectionName      string
 	Catalog             *collectionCatalog
 	Config              ColumnStoreConfig
+	FullConfig          ColumnStoreConfig
 	ColumnStoreEnabled  bool
 	CommitSeq           uint64
 	AssetRefs           []columnManifestAssetRefForScan
@@ -376,6 +377,7 @@ func (c *Collection) prepareColumnPhysicalScanSnapshotViewAtSnapshotWithSidecars
 		CollectionName:     collectionName,
 		Catalog:            catalog,
 		Config:             rowAssetConfig,
+		FullConfig:         cfg,
 		ColumnStoreEnabled: columnStoreEnabled,
 		CommitSeq:          snapshotState.CommitSeq,
 		Diagnostics:        diag,

--- a/TreeDB/collections/typed_column_adapter.go
+++ b/TreeDB/collections/typed_column_adapter.go
@@ -667,6 +667,125 @@ func (r typedColumnAdapterResourceReader) AcquireSection(section typedcolumn.Col
 	return mgr.AcquireBytes(key, scope, mappedresource.SourceHeapCopy, data, mappedresource.AcquireOptions{Reason: "typed-column adapter heap section read", ValidationMode: mappedresource.ValidationVerify})
 }
 
+func typedColumnAdapterHasInt64PredicateColumn(fields []TypedStorageField, column string) (bool, error) {
+	adapterColumn, ok, err := typedColumnInt64PredicateAdapterColumn(fields, column)
+	if err != nil || !ok {
+		return ok, err
+	}
+	if adapterColumn.Field.ValueType != ColumnStoreValueInt64 || adapterColumn.Definition.Type != typedcolumn.ColumnTypeInt64 {
+		return false, fmt.Errorf("%w: typed-column int64 predicate column %q is not encoded as int64", ErrColumnQueryPlanUnsupported, column)
+	}
+	return true, nil
+}
+
+func typedColumnAdapterPrepareInt64PredicateScanPart(fields []TypedStorageField, raw []byte, refPartID uint64, typedRows int, physicalRows int, schemaHash uint64, column string) (*typedColumnAdapterPart, typedColumnAdapterColumn, int, error) {
+	adapterColumn, ok, err := typedColumnInt64PredicateAdapterColumn(fields, column)
+	if err != nil {
+		return nil, typedColumnAdapterColumn{}, 0, err
+	}
+	if !ok {
+		return nil, typedColumnAdapterColumn{}, 0, fmt.Errorf("collections: typed-column int64 predicate column %q is not owned by typed_column_part", column)
+	}
+	if adapterColumn.Field.ValueType != ColumnStoreValueInt64 || adapterColumn.Definition.Type != typedcolumn.ColumnTypeInt64 {
+		return nil, typedColumnAdapterColumn{}, 0, fmt.Errorf("%w: typed-column int64 predicate column %q is not encoded as int64", ErrColumnQueryPlanUnsupported, column)
+	}
+	image, err := typedcolumn.ParseColumnPartImage(raw)
+	if err != nil {
+		return nil, typedColumnAdapterColumn{}, 0, err
+	}
+	if image.PartID != refPartID || image.Rows != typedRows || image.Rows != physicalRows {
+		return nil, typedColumnAdapterColumn{}, 0, fmt.Errorf("collections: typed_column_part image/ref mismatch image_part=%d ref_part=%d image_rows=%d typed_manifest_rows=%d physical_rows=%d", image.PartID, refPartID, image.Rows, typedRows, physicalRows)
+	}
+	adapterPart, err := typedColumnAdapterPartFromImage(typedColumnAdapterOptions{Fields: fields}, image)
+	if err != nil {
+		return nil, typedColumnAdapterColumn{}, 0, err
+	}
+	if adapterPart.Part.Descriptor.SchemaVersion != uint32(schemaHash) {
+		return nil, typedColumnAdapterColumn{}, 0, fmt.Errorf("collections: typed_column_part schema_version=%d want %d", adapterPart.Part.Descriptor.SchemaVersion, uint32(schemaHash))
+	}
+	return adapterPart, adapterColumn, image.ManifestBytes, nil
+}
+
+func typedColumnInt64PredicateAdapterColumn(fields []TypedStorageField, column string) (typedColumnAdapterColumn, bool, error) {
+	columns, err := typedColumnAdapterColumnsForFields(fields)
+	if err != nil {
+		return typedColumnAdapterColumn{}, false, err
+	}
+	for _, adapterColumn := range columns {
+		if adapterColumn.Field.Name == column || adapterColumn.Field.Path == column || adapterColumn.Definition.Name == column {
+			return adapterColumn, true, nil
+		}
+	}
+	return typedColumnAdapterColumn{}, false, nil
+}
+
+func scanTypedColumnInt64PredicatePart(part *typedcolumn.ColumnPart, valueColumn string, req TypedColumnInt64PredicateScanRequest, generation uint64, partID uint64, result *TypedColumnInt64PredicateScanResult) (bool, error) {
+	if part == nil {
+		return false, errors.New("nil typed-column part")
+	}
+	valueCol, ok := part.Columns[valueColumn]
+	if !ok {
+		return false, fmt.Errorf("missing value column %q", valueColumn)
+	}
+	idCol, ok := part.Columns[typedColumnAdapterPrimaryIDColumn]
+	if !ok {
+		return false, fmt.Errorf("missing primary id column %q", typedColumnAdapterPrimaryIDColumn)
+	}
+	if valueCol.Definition.Type != typedcolumn.ColumnTypeInt64 || idCol.Definition.Type != typedcolumn.ColumnTypeInt64 {
+		return false, fmt.Errorf("value or primary id column is not int64")
+	}
+	var reader typedcolumn.GranuleReader
+	var valueScratch []int64
+	var idScratch []int64
+	decodedAny := false
+	for _, block := range valueCol.Blocks {
+		result.Diagnostics.BlocksConsidered++
+		g := block.Granule
+		if g.HasMinMax && !typedColumnInt64PredicateMayMatch(req, g.Min, g.Max) {
+			result.Diagnostics.BlocksPruned++
+			continue
+		}
+		idBlock, ok := typedColumnFindAlignedBlock(idCol.Blocks, block.Descriptor.FirstRow, block.Descriptor.RowCount)
+		if !ok {
+			return false, fmt.Errorf("missing aligned primary-id block first_row=%d rows=%d", block.Descriptor.FirstRow, block.Descriptor.RowCount)
+		}
+		values, err := reader.DecodeInt64Into(valueScratch[:0], g)
+		if err != nil {
+			return false, err
+		}
+		valueScratch = values
+		ids, err := reader.DecodeInt64Into(idScratch[:0], idBlock.Granule)
+		if err != nil {
+			return false, err
+		}
+		idScratch = ids
+		if len(values) != block.Descriptor.RowCount || len(ids) != block.Descriptor.RowCount {
+			return false, fmt.Errorf("decoded rows value=%d ids=%d want %d", len(values), len(ids), block.Descriptor.RowCount)
+		}
+		decodedAny = true
+		result.Diagnostics.BlocksDecoded++
+		result.Diagnostics.DecodedHeapCopyBytes += uint64(g.RawBytes + idBlock.Granule.RawBytes)
+		result.Diagnostics.RowsScanned += len(values)
+		for i, v := range values {
+			if !typedColumnInt64PredicateMatches(req, v) {
+				continue
+			}
+			result.Rows = append(result.Rows, TypedColumnInt64PredicateScanRow{Generation: generation, PartID: partID, RowIndex: block.Descriptor.FirstRow + i, PrimaryID: ids[i], Value: v})
+			result.Diagnostics.RowsMatched++
+		}
+	}
+	return !decodedAny && len(valueCol.Blocks) != 0, nil
+}
+
+func typedColumnFindAlignedBlock(blocks []typedcolumn.ColumnBlock, firstRow, rows int) (typedcolumn.ColumnBlock, bool) {
+	for _, block := range blocks {
+		if block.Descriptor.FirstRow == firstRow && block.Descriptor.RowCount == rows {
+			return block, true
+		}
+	}
+	return typedcolumn.ColumnBlock{}, false
+}
+
 func typedColumnAdapterInt64View(mgr *mappedresource.Manager, h *mappedresource.Handle) ([]int64, error) {
 	return mgr.Int64View(h)
 }

--- a/TreeDB/collections/typed_column_adapter.go
+++ b/TreeDB/collections/typed_column_adapter.go
@@ -734,6 +734,7 @@ func scanTypedColumnInt64PredicatePart(part *typedcolumn.ColumnPart, valueColumn
 	if valueCol.Definition.Type != typedcolumn.ColumnTypeInt64 || idCol.Definition.Type != typedcolumn.ColumnTypeInt64 {
 		return false, fmt.Errorf("value or primary id column is not int64")
 	}
+	idBlocksByRange := typedColumnBlocksByRange(idCol.Blocks)
 	var reader typedcolumn.GranuleReader
 	var valueScratch []int64
 	var idScratch []int64
@@ -745,7 +746,7 @@ func scanTypedColumnInt64PredicatePart(part *typedcolumn.ColumnPart, valueColumn
 			result.Diagnostics.BlocksPruned++
 			continue
 		}
-		idBlock, ok := typedColumnFindAlignedBlock(idCol.Blocks, block.Descriptor.FirstRow, block.Descriptor.RowCount)
+		idBlock, ok := idBlocksByRange[typedColumnBlockRange{FirstRow: block.Descriptor.FirstRow, RowCount: block.Descriptor.RowCount}]
 		if !ok {
 			return false, fmt.Errorf("missing aligned primary-id block first_row=%d rows=%d", block.Descriptor.FirstRow, block.Descriptor.RowCount)
 		}
@@ -777,13 +778,17 @@ func scanTypedColumnInt64PredicatePart(part *typedcolumn.ColumnPart, valueColumn
 	return !decodedAny && len(valueCol.Blocks) != 0, nil
 }
 
-func typedColumnFindAlignedBlock(blocks []typedcolumn.ColumnBlock, firstRow, rows int) (typedcolumn.ColumnBlock, bool) {
+type typedColumnBlockRange struct {
+	FirstRow int
+	RowCount int
+}
+
+func typedColumnBlocksByRange(blocks []typedcolumn.ColumnBlock) map[typedColumnBlockRange]typedcolumn.ColumnBlock {
+	out := make(map[typedColumnBlockRange]typedcolumn.ColumnBlock, len(blocks))
 	for _, block := range blocks {
-		if block.Descriptor.FirstRow == firstRow && block.Descriptor.RowCount == rows {
-			return block, true
-		}
+		out[typedColumnBlockRange{FirstRow: block.Descriptor.FirstRow, RowCount: block.Descriptor.RowCount}] = block
 	}
-	return typedcolumn.ColumnBlock{}, false
+	return out
 }
 
 func typedColumnAdapterInt64View(mgr *mappedresource.Manager, h *mappedresource.Handle) ([]int64, error) {

--- a/TreeDB/collections/typed_column_int64_scan.go
+++ b/TreeDB/collections/typed_column_int64_scan.go
@@ -85,12 +85,20 @@ func (c *Collection) RunTypedColumnInt64PredicateScan(req TypedColumnInt64Predic
 		return TypedColumnInt64PredicateScanResult{}, err
 	}
 	start := time.Now()
+	hintCfg, hintColumn, hintDeclared, hintErr := c.typedColumnInt64PredicateCatalogColumn(req.Column)
+	if hintErr != nil {
+		return TypedColumnInt64PredicateScanResult{}, hintErr
+	}
+	hintTypedColumnOwner := hintDeclared && hintColumn.ValueType == ColumnStoreValueInt64 && !hintColumn.Nullable && columnStoreColumnIsTypedColumnPart(hintColumn)
 	view, closeView, err := c.prepareColumnPhysicalScanSnapshotViewWithSidecars(columnManifestScanNoSidecars())
 	if closeView != nil {
 		defer closeView()
 	}
 	if err != nil {
-		return c.runTypedColumnInt64PredicateScanDocumentFallback(req, ColumnStoreConfig{}, "column_store_unavailable", start)
+		if hintTypedColumnOwner {
+			return TypedColumnInt64PredicateScanResult{}, err
+		}
+		return c.runTypedColumnInt64PredicateScanDocumentFallback(req, hintCfg, "column_store_unavailable", start)
 	}
 	cfg := view.FullConfig
 	if !cfg.Enabled {
@@ -190,6 +198,7 @@ func (c *Collection) runTypedColumnInt64PredicateScanDirect(view columnPhysicalS
 			return result, fmt.Errorf("collections: typed-column int64 predicate decode generation=%d part_id=%d: %w", typedRef.Ref.Generation, typedRef.Ref.PartID, err)
 		}
 		result.Diagnostics.DecodedMetadataBytes += uint64(manifestBytes)
+		matchedStart := len(result.Rows)
 		partPruned, err := scanTypedColumnInt64PredicatePart(adapterPart.Part, adapterColumn.Definition.Name, req, typedRef.Ref.Generation, typedRef.Ref.PartID, &result)
 		if err != nil {
 			return result, fmt.Errorf("collections: typed-column int64 predicate scan generation=%d part_id=%d: %w", typedRef.Ref.Generation, typedRef.Ref.PartID, err)
@@ -199,6 +208,30 @@ func (c *Collection) runTypedColumnInt64PredicateScanDirect(view columnPhysicalS
 		} else {
 			result.Diagnostics.PartsDecoded++
 		}
+		if len(result.Rows) > matchedStart {
+			physicalRaw, err := readCache.read(physical.Ref, rawScratch)
+			result.Diagnostics.SegmentFileCacheHits = readCache.hits
+			result.Diagnostics.SegmentFileCacheMisses = readCache.misses
+			if err != nil {
+				return result, fmt.Errorf("collections: typed-column int64 predicate physical id read generation=%d part_id=%d: %w", physical.Ref.Generation, physical.Ref.PartID, err)
+			}
+			rawScratch = physicalRaw
+			result.Diagnostics.PhysicalBytesScanned += int64(len(physicalRaw))
+			ids, err := typedColumnInt64PredicatePhysicalRowIDs(physicalRaw, physical.Ref, view.CollectionName, view.Config, result.Rows[matchedStart:])
+			if err != nil {
+				return result, fmt.Errorf("collections: typed-column int64 predicate physical id decode generation=%d part_id=%d: %w", physical.Ref.Generation, physical.Ref.PartID, err)
+			}
+			for rowIdx := matchedStart; rowIdx < len(result.Rows); rowIdx++ {
+				matched := &result.Rows[rowIdx]
+				documentID, ok := ids[matched.RowIndex]
+				if !ok {
+					return result, fmt.Errorf("collections: typed-column int64 predicate missing physical document id for row_index=%d", matched.RowIndex)
+				}
+				matched.Generation = physical.Ref.Generation
+				matched.PartID = physical.Ref.PartID
+				matched.DocumentID = documentID
+			}
+		}
 	}
 	stats := mgr.Stats()
 	result.Diagnostics.MappedBytes = stats.TotalMappedBytes
@@ -207,6 +240,57 @@ func (c *Collection) runTypedColumnInt64PredicateScanDirect(view columnPhysicalS
 	result.Diagnostics.DecodedHeapCopyBytes += stats.TotalHeapCopyBytes
 	result.Diagnostics.ScanNanos = time.Since(start).Nanoseconds()
 	return result, nil
+}
+
+func (c *Collection) typedColumnInt64PredicateCatalogColumn(column string) (ColumnStoreConfig, ColumnStoreColumn, bool, error) {
+	if c == nil {
+		return ColumnStoreConfig{}, ColumnStoreColumn{}, false, errCollectionNil
+	}
+	if c.db == nil {
+		return ColumnStoreConfig{}, ColumnStoreColumn{}, false, errCollectionDBNil
+	}
+	c.catalogMu.RLock()
+	defer c.catalogMu.RUnlock()
+	catalog := c.catalog
+	if catalog == nil || catalog.meta.Options.ColumnStore == nil || !catalog.meta.Options.ColumnStore.Enabled {
+		return ColumnStoreConfig{}, ColumnStoreColumn{}, false, nil
+	}
+	cfg := catalog.meta.Options.ColumnStore.copy()
+	col, _, ok := columnPhysicalQueryDeclaredColumn(cfg, column)
+	return cfg, col, ok, nil
+}
+
+func typedColumnInt64PredicatePhysicalRowIDs(raw []byte, ref ColumnAssetRef, collection string, cfg ColumnStoreConfig, matchedRows []TypedColumnInt64PredicateScanRow) (map[int][]byte, error) {
+	projection := columnPhysicalScanProjection{outputByColumn: make([]int, len(cfg.Columns))}
+	for i := range projection.outputByColumn {
+		projection.outputByColumn[i] = -1
+	}
+	wanted := make(map[int]struct{}, len(matchedRows))
+	for _, row := range matchedRows {
+		if row.RowIndex < 0 {
+			return nil, fmt.Errorf("matched row_index=%d is negative", row.RowIndex)
+		}
+		wanted[row.RowIndex] = struct{}{}
+	}
+	ids := make(map[int][]byte, len(wanted))
+	_, err := scanColumnPhysicalAssetRowsWithManifestOperation(raw, ref, collection, &cfg, projection, ColumnPublishOperationInsert, func(row columnPhysicalScanRowView) error {
+		if row.Deleted {
+			return fmt.Errorf("physical row[%d] is deleted", row.RowIndex)
+		}
+		if _, ok := wanted[row.RowIndex]; ok {
+			ids[row.RowIndex] = bytes.Clone(row.ID)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	for rowIndex := range wanted {
+		if ids[rowIndex] == nil {
+			return nil, fmt.Errorf("missing physical document id for row_index=%d", rowIndex)
+		}
+	}
+	return ids, nil
 }
 
 func typedColumnInt64PredicateMayMatch(req TypedColumnInt64PredicateScanRequest, minValue, maxValue int64) bool {

--- a/TreeDB/collections/typed_column_int64_scan.go
+++ b/TreeDB/collections/typed_column_int64_scan.go
@@ -153,6 +153,13 @@ func (c *Collection) runTypedColumnInt64PredicateScanDirect(view columnPhysicalS
 		if ref.Ref.Kind != ColumnAssetKindTCS1TypedColumnPart {
 			continue
 		}
+		if ref.Reason != ColumnPublishOperationInsert {
+			return TypedColumnInt64PredicateScanResult{Diagnostics: diag}, fmt.Errorf("collections: typed-column int64 predicate scan requires insert-only typed refs, got %s", ref.Reason)
+		}
+		// Current durable typed-column publication emits one typed_column_part
+		// locator per generation (part_id=2) paired with that generation's
+		// physical row locator part (part_id=1). Duplicate generations are a
+		// manifest invariant violation and fail closed here.
 		if _, exists := refsByGeneration[ref.Ref.Generation]; exists {
 			return TypedColumnInt64PredicateScanResult{Diagnostics: diag}, fmt.Errorf("collections: duplicate typed_column_part ref for generation=%d", ref.Ref.Generation)
 		}

--- a/TreeDB/collections/typed_column_int64_scan.go
+++ b/TreeDB/collections/typed_column_int64_scan.go
@@ -112,6 +112,9 @@ func (c *Collection) RunTypedColumnInt64PredicateScan(req TypedColumnInt64Predic
 		return TypedColumnInt64PredicateScanResult{}, fmt.Errorf("%w: typed-column int64 predicate column %q has type=%q nullable=%v", ErrColumnQueryPlanUnsupported, req.Column, col.ValueType, col.Nullable)
 	}
 	if !columnStoreColumnIsTypedColumnPart(col) {
+		if view.MutationParts != 0 {
+			return c.runTypedColumnInt64PredicateScanDocumentFallback(req, cfg, "mutation_visibility_requires_document_reconstruction", start)
+		}
 		return c.runTypedColumnInt64PredicateScanPhysicalFallback(view, req, cfg, "typed_column_not_selected", start)
 	}
 	if view.MutationParts != 0 {
@@ -237,7 +240,6 @@ func (c *Collection) runTypedColumnInt64PredicateScanDirect(view columnPhysicalS
 	result.Diagnostics.MappedBytes = stats.TotalMappedBytes
 	result.Diagnostics.HeapCopyBytes = stats.TotalHeapCopyBytes
 	result.Diagnostics.FallbackReads = int(stats.FallbackReads)
-	result.Diagnostics.DecodedHeapCopyBytes += stats.TotalHeapCopyBytes
 	result.Diagnostics.ScanNanos = time.Since(start).Nanoseconds()
 	return result, nil
 }
@@ -319,28 +321,33 @@ func (c *Collection) runTypedColumnInt64PredicateScanPhysicalFallback(view colum
 	result := TypedColumnInt64PredicateScanResult{Diagnostics: typedColumnInt64PredicateDiagnosticsFromView(view)}
 	result.Diagnostics.Fallback = true
 	result.Diagnostics.FallbackReason = reason
-	visible, err := c.scanColumnPhysicalVisibleRowsWithReadIntegrity([]string{req.Column}, req.ColumnAssetReadIntegrity)
+	scanDiag, err := c.scanColumnPhysicalRowsInSnapshotView(view, columnPhysicalScanRequest{
+		ProjectedColumns:  []string{req.Column},
+		RequireInsertOnly: true,
+		ReadIntegrity:     req.ColumnAssetReadIntegrity,
+		Visitor: func(row columnPhysicalScanRowView) error {
+			if row.Deleted || len(row.Values) == 0 {
+				return nil
+			}
+			value, err := columnPhysicalQueryInt64Value(row.Values[0])
+			if err != nil {
+				return err
+			}
+			result.Diagnostics.RowsScanned++
+			if typedColumnInt64PredicateMatches(req, value) {
+				result.Rows = append(result.Rows, TypedColumnInt64PredicateScanRow{Generation: row.Generation, PartID: row.PartID, RowIndex: row.RowIndex, DocumentID: bytes.Clone(row.ID), Value: value})
+				result.Diagnostics.RowsMatched++
+			}
+			return nil
+		},
+	})
 	result.Diagnostics.ColumnAssetReadIntegrity = columnAssetReadIntegrityLabel(req.ColumnAssetReadIntegrity)
-	result.Diagnostics.FallbackReads = visible.Diagnostics.DecodedBlocks
-	result.Diagnostics.PhysicalBytesScanned = visible.Diagnostics.PhysicalBytesScanned
-	result.Diagnostics.SegmentFileCacheHits = visible.Diagnostics.SegmentFileCacheHits
-	result.Diagnostics.SegmentFileCacheMisses = visible.Diagnostics.SegmentFileCacheMisses
+	result.Diagnostics.FallbackReads = scanDiag.DecodedBlocks
+	result.Diagnostics.PhysicalBytesScanned = scanDiag.PhysicalBytesScanned
+	result.Diagnostics.SegmentFileCacheHits = scanDiag.SegmentFileCacheHits
+	result.Diagnostics.SegmentFileCacheMisses = scanDiag.SegmentFileCacheMisses
 	if err != nil {
 		return result, err
-	}
-	for _, row := range visible.Rows {
-		if row.Deleted || len(row.Values) == 0 {
-			continue
-		}
-		value, err := columnPhysicalQueryInt64Value(row.Values[0])
-		if err != nil {
-			return result, err
-		}
-		result.Diagnostics.RowsScanned++
-		if typedColumnInt64PredicateMatches(req, value) {
-			result.Rows = append(result.Rows, TypedColumnInt64PredicateScanRow{Generation: row.Generation, PartID: row.PartID, RowIndex: row.RowIndex, DocumentID: bytes.Clone(row.ID), Value: value})
-			result.Diagnostics.RowsMatched++
-		}
 	}
 	result.Diagnostics.ScanNanos = time.Since(start).Nanoseconds()
 	_ = cfg

--- a/TreeDB/collections/typed_column_int64_scan.go
+++ b/TreeDB/collections/typed_column_int64_scan.go
@@ -342,7 +342,7 @@ func (c *Collection) runTypedColumnInt64PredicateScanPhysicalFallback(view colum
 			}
 			result.Diagnostics.RowsScanned++
 			if typedColumnInt64PredicateMatches(req, value) {
-				result.Rows = append(result.Rows, TypedColumnInt64PredicateScanRow{Generation: row.Generation, PartID: row.PartID, RowIndex: row.RowIndex, DocumentID: bytes.Clone(row.ID), Value: value})
+				result.Rows = append(result.Rows, TypedColumnInt64PredicateScanRow{Generation: row.Generation, PartID: row.PartID, RowIndex: row.RowIndex, PrimaryID: int64(row.RowIndex), DocumentID: bytes.Clone(row.ID), Value: value})
 				result.Diagnostics.RowsMatched++
 			}
 			return nil

--- a/TreeDB/collections/typed_column_int64_scan.go
+++ b/TreeDB/collections/typed_column_int64_scan.go
@@ -1,0 +1,311 @@
+package collections
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/snissn/gomap/TreeDB/internal/mappedresource"
+)
+
+type TypedColumnInt64PredicateScanKind string
+
+const (
+	TypedColumnInt64PredicateEqual TypedColumnInt64PredicateScanKind = "equal"
+	TypedColumnInt64PredicateRange TypedColumnInt64PredicateScanKind = "range"
+)
+
+type TypedColumnInt64PredicateScanRequest struct {
+	Column                   string
+	Kind                     TypedColumnInt64PredicateScanKind
+	Value                    int64
+	Low                      int64
+	High                     int64
+	ColumnAssetReadIntegrity ColumnAssetReadIntegrity
+}
+
+type TypedColumnInt64PredicateScanRow struct {
+	Generation uint64
+	PartID     uint64
+	RowIndex   int
+	PrimaryID  int64
+	DocumentID []byte
+	Value      int64
+}
+
+type TypedColumnInt64PredicateScanDiagnostics struct {
+	ManifestRoot               uint64
+	ManifestGeneration         uint64
+	RecoveryManifestGeneration uint64
+	AppliedCommandLSN          uint64
+	ManifestRecords            int
+	AssetRefs                  int
+	MutationParts              int
+
+	RowsScanned int
+	RowsMatched int
+
+	PartsConsidered  int
+	PartsPruned      int
+	PartsDecoded     int
+	BlocksConsidered int
+	BlocksPruned     int
+	BlocksDecoded    int
+
+	DirectTypedColumnAssetReads int
+	FallbackReads               int
+	MappedBytes                 uint64
+	HeapCopyBytes               uint64
+	DecodedMetadataBytes        uint64
+	DecodedHeapCopyBytes        uint64
+	PhysicalBytesScanned        int64
+	RowMaterializations         int
+	SegmentFileCacheHits        uint64
+	SegmentFileCacheMisses      uint64
+	ColumnAssetReadIntegrity    string
+	Fallback                    bool
+	FallbackReason              string
+	ScanNanos                   int64
+}
+
+type TypedColumnInt64PredicateScanResult struct {
+	Rows        []TypedColumnInt64PredicateScanRow
+	Diagnostics TypedColumnInt64PredicateScanDiagnostics
+}
+
+// RunTypedColumnInt64PredicateScan executes the scoped #1757 scalar predicate MVP.
+// When the requested int64 field is owned by typed_column_part, the predicate is
+// evaluated directly over durable typed_column_part assets and fails closed if
+// those assets are unavailable or inconsistent. Non typed-column ownership keeps
+// the existing typed-row/document fallback behavior and is identified in
+// Diagnostics.Fallback.
+func (c *Collection) RunTypedColumnInt64PredicateScan(req TypedColumnInt64PredicateScanRequest) (TypedColumnInt64PredicateScanResult, error) {
+	if err := validateTypedColumnInt64PredicateScanRequest(req); err != nil {
+		return TypedColumnInt64PredicateScanResult{}, err
+	}
+	start := time.Now()
+	view, closeView, err := c.prepareColumnPhysicalScanSnapshotViewWithSidecars(columnManifestScanNoSidecars())
+	if closeView != nil {
+		defer closeView()
+	}
+	if err != nil {
+		return c.runTypedColumnInt64PredicateScanDocumentFallback(req, ColumnStoreConfig{}, "column_store_unavailable", start)
+	}
+	cfg := view.FullConfig
+	if !cfg.Enabled {
+		cfg = view.Config
+	}
+	col, _, ok := columnPhysicalQueryDeclaredColumn(cfg, req.Column)
+	if !ok {
+		return c.runTypedColumnInt64PredicateScanDocumentFallback(req, cfg, "undeclared_column", start)
+	}
+	if col.ValueType != ColumnStoreValueInt64 || col.Nullable {
+		return TypedColumnInt64PredicateScanResult{}, fmt.Errorf("%w: typed-column int64 predicate column %q has type=%q nullable=%v", ErrColumnQueryPlanUnsupported, req.Column, col.ValueType, col.Nullable)
+	}
+	if !columnStoreColumnIsTypedColumnPart(col) {
+		return c.runTypedColumnInt64PredicateScanPhysicalFallback(view, req, cfg, "typed_column_not_selected", start)
+	}
+	if view.MutationParts != 0 {
+		return c.runTypedColumnInt64PredicateScanDocumentFallback(req, cfg, "mutation_visibility_requires_document_reconstruction", start)
+	}
+	return c.runTypedColumnInt64PredicateScanDirect(view, req, cfg, start)
+}
+
+func validateTypedColumnInt64PredicateScanRequest(req TypedColumnInt64PredicateScanRequest) error {
+	if req.Column == "" {
+		return errors.New("collections: typed-column int64 predicate scan requires column")
+	}
+	switch req.Kind {
+	case TypedColumnInt64PredicateEqual:
+	case TypedColumnInt64PredicateRange:
+		if req.Low > req.High {
+			return errors.New("collections: typed-column int64 predicate range low is greater than high")
+		}
+	default:
+		return fmt.Errorf("%w: unsupported typed-column int64 predicate kind %q", ErrColumnQueryPlanUnsupported, req.Kind)
+	}
+	return nil
+}
+
+func (c *Collection) runTypedColumnInt64PredicateScanDirect(view columnPhysicalScanSnapshotView, req TypedColumnInt64PredicateScanRequest, cfg ColumnStoreConfig, start time.Time) (TypedColumnInt64PredicateScanResult, error) {
+	diag := typedColumnInt64PredicateDiagnosticsFromView(view)
+	diag.ColumnAssetReadIntegrity = columnAssetReadIntegrityLabel(req.ColumnAssetReadIntegrity)
+	fields := columnStoreTypedColumnPartFields(cfg)
+	if ok, err := typedColumnAdapterHasInt64PredicateColumn(fields, req.Column); err != nil {
+		return TypedColumnInt64PredicateScanResult{Diagnostics: diag}, err
+	} else if !ok {
+		return TypedColumnInt64PredicateScanResult{Diagnostics: diag}, fmt.Errorf("collections: typed-column int64 predicate column %q is not owned by typed_column_part", req.Column)
+	}
+	refsByGeneration := make(map[uint64]columnManifestAssetRefForScan, len(view.TypedColumnPartRefs))
+	for _, ref := range view.TypedColumnPartRefs {
+		if ref.Ref.Kind != ColumnAssetKindTCS1TypedColumnPart {
+			continue
+		}
+		if _, exists := refsByGeneration[ref.Ref.Generation]; exists {
+			return TypedColumnInt64PredicateScanResult{Diagnostics: diag}, fmt.Errorf("collections: duplicate typed_column_part ref for generation=%d", ref.Ref.Generation)
+		}
+		refsByGeneration[ref.Ref.Generation] = ref
+	}
+	if len(refsByGeneration) == 0 {
+		return TypedColumnInt64PredicateScanResult{Diagnostics: diag}, errors.New("collections: missing typed_column_part assets for typed-column int64 predicate scan")
+	}
+	for _, physical := range view.AssetRefs {
+		if physical.Reason != ColumnPublishOperationInsert {
+			return TypedColumnInt64PredicateScanResult{Diagnostics: diag}, fmt.Errorf("collections: typed-column int64 predicate scan requires insert-only physical refs, got %s", physical.Reason)
+		}
+		if _, ok := refsByGeneration[physical.Ref.Generation]; !ok {
+			return TypedColumnInt64PredicateScanResult{Diagnostics: diag}, fmt.Errorf("collections: missing typed_column_part asset for generation=%d", physical.Ref.Generation)
+		}
+	}
+
+	mgr := mappedresource.NewManager()
+	readCache, err := newColumnPhysicalAssetReadCacheWithIntegrity(view.ColumnAssetRootDir, view.AssetNamespace, req.ColumnAssetReadIntegrity)
+	if err != nil {
+		return TypedColumnInt64PredicateScanResult{Diagnostics: diag}, err
+	}
+	readCache.returnViews = true
+	if err := readCache.useMappedResourceManager(mgr, mappedresource.Scope{Kind: mappedresource.ScopeColumnPartReader, ID: "typed-column-int64-predicate-scan", Namespace: view.AssetNamespace, Generation: view.Diagnostics.ManifestGeneration, Reason: "typed-column int64 predicate scan"}, "typed-column int64 predicate scan"); err != nil {
+		_ = readCache.close()
+		return TypedColumnInt64PredicateScanResult{Diagnostics: diag}, err
+	}
+	defer func() { _ = readCache.close() }()
+
+	result := TypedColumnInt64PredicateScanResult{Diagnostics: diag}
+	var rawScratch []byte
+	for _, physical := range view.AssetRefs {
+		typedRef := refsByGeneration[physical.Ref.Generation]
+		result.Diagnostics.PartsConsidered++
+		raw, err := readCache.read(typedRef.Ref, rawScratch)
+		result.Diagnostics.SegmentFileCacheHits = readCache.hits
+		result.Diagnostics.SegmentFileCacheMisses = readCache.misses
+		if err != nil {
+			return result, fmt.Errorf("collections: typed-column int64 predicate read generation=%d part_id=%d: %w", typedRef.Ref.Generation, typedRef.Ref.PartID, err)
+		}
+		rawScratch = raw
+		result.Diagnostics.DirectTypedColumnAssetReads++
+		result.Diagnostics.PhysicalBytesScanned += int64(len(raw))
+		adapterPart, adapterColumn, manifestBytes, err := typedColumnAdapterPrepareInt64PredicateScanPart(fields, raw, typedRef.Ref.PartID, typedRef.Rows, physical.Rows, cfg.SchemaHash, req.Column)
+		if err != nil {
+			return result, fmt.Errorf("collections: typed-column int64 predicate decode generation=%d part_id=%d: %w", typedRef.Ref.Generation, typedRef.Ref.PartID, err)
+		}
+		result.Diagnostics.DecodedMetadataBytes += uint64(manifestBytes)
+		partPruned, err := scanTypedColumnInt64PredicatePart(adapterPart.Part, adapterColumn.Definition.Name, req, typedRef.Ref.Generation, typedRef.Ref.PartID, &result)
+		if err != nil {
+			return result, fmt.Errorf("collections: typed-column int64 predicate scan generation=%d part_id=%d: %w", typedRef.Ref.Generation, typedRef.Ref.PartID, err)
+		}
+		if partPruned {
+			result.Diagnostics.PartsPruned++
+		} else {
+			result.Diagnostics.PartsDecoded++
+		}
+	}
+	stats := mgr.Stats()
+	result.Diagnostics.MappedBytes = stats.TotalMappedBytes
+	result.Diagnostics.HeapCopyBytes = stats.TotalHeapCopyBytes
+	result.Diagnostics.FallbackReads = int(stats.FallbackReads)
+	result.Diagnostics.DecodedHeapCopyBytes += stats.TotalHeapCopyBytes
+	result.Diagnostics.ScanNanos = time.Since(start).Nanoseconds()
+	return result, nil
+}
+
+func typedColumnInt64PredicateMayMatch(req TypedColumnInt64PredicateScanRequest, minValue, maxValue int64) bool {
+	switch req.Kind {
+	case TypedColumnInt64PredicateEqual:
+		return req.Value >= minValue && req.Value <= maxValue
+	case TypedColumnInt64PredicateRange:
+		return req.High >= minValue && req.Low <= maxValue
+	default:
+		return false
+	}
+}
+
+func typedColumnInt64PredicateMatches(req TypedColumnInt64PredicateScanRequest, value int64) bool {
+	switch req.Kind {
+	case TypedColumnInt64PredicateEqual:
+		return value == req.Value
+	case TypedColumnInt64PredicateRange:
+		return value >= req.Low && value <= req.High
+	default:
+		return false
+	}
+}
+
+func (c *Collection) runTypedColumnInt64PredicateScanPhysicalFallback(view columnPhysicalScanSnapshotView, req TypedColumnInt64PredicateScanRequest, cfg ColumnStoreConfig, reason string, start time.Time) (TypedColumnInt64PredicateScanResult, error) {
+	result := TypedColumnInt64PredicateScanResult{Diagnostics: typedColumnInt64PredicateDiagnosticsFromView(view)}
+	result.Diagnostics.Fallback = true
+	result.Diagnostics.FallbackReason = reason
+	visible, err := c.scanColumnPhysicalVisibleRowsWithReadIntegrity([]string{req.Column}, req.ColumnAssetReadIntegrity)
+	result.Diagnostics.ColumnAssetReadIntegrity = columnAssetReadIntegrityLabel(req.ColumnAssetReadIntegrity)
+	result.Diagnostics.FallbackReads = visible.Diagnostics.DecodedBlocks
+	result.Diagnostics.PhysicalBytesScanned = visible.Diagnostics.PhysicalBytesScanned
+	result.Diagnostics.SegmentFileCacheHits = visible.Diagnostics.SegmentFileCacheHits
+	result.Diagnostics.SegmentFileCacheMisses = visible.Diagnostics.SegmentFileCacheMisses
+	if err != nil {
+		return result, err
+	}
+	for _, row := range visible.Rows {
+		if row.Deleted || len(row.Values) == 0 {
+			continue
+		}
+		value, err := columnPhysicalQueryInt64Value(row.Values[0])
+		if err != nil {
+			return result, err
+		}
+		result.Diagnostics.RowsScanned++
+		if typedColumnInt64PredicateMatches(req, value) {
+			result.Rows = append(result.Rows, TypedColumnInt64PredicateScanRow{Generation: row.Generation, PartID: row.PartID, RowIndex: row.RowIndex, DocumentID: bytes.Clone(row.ID), Value: value})
+			result.Diagnostics.RowsMatched++
+		}
+	}
+	result.Diagnostics.ScanNanos = time.Since(start).Nanoseconds()
+	_ = cfg
+	return result, nil
+}
+
+func (c *Collection) runTypedColumnInt64PredicateScanDocumentFallback(req TypedColumnInt64PredicateScanRequest, cfg ColumnStoreConfig, reason string, start time.Time) (TypedColumnInt64PredicateScanResult, error) {
+	result := TypedColumnInt64PredicateScanResult{}
+	result.Diagnostics.Fallback = true
+	result.Diagnostics.FallbackReason = reason
+	result.Diagnostics.ColumnAssetReadIntegrity = columnAssetReadIntegrityLabel(req.ColumnAssetReadIntegrity)
+	path := req.Column
+	if col, _, ok := columnPhysicalQueryDeclaredColumn(cfg, req.Column); ok {
+		path = col.Path
+	}
+	fallbackCfg := ColumnStoreConfig{Columns: []ColumnStoreColumn{{Name: req.Column, Path: path, ValueType: ColumnStoreValueInt64}}}
+	_, err := c.ScanDocumentsFunc(maxCollectionInt, func(record DocumentRecord) (bool, error) {
+		result.Diagnostics.RowMaterializations++
+		result.Diagnostics.FallbackReads++
+		rows, err := extractColumnDeclaredRowsFromJSONDocuments(fallbackCfg, []columnWriteDocument{{ID: record.ID, Document: record.Document}})
+		if err != nil {
+			return false, err
+		}
+		if len(rows) != 1 || len(rows[0].Values) != 1 {
+			return false, errors.New("collections: document fallback failed to extract int64 predicate column")
+		}
+		value, err := columnPhysicalQueryInt64Value(rows[0].Values[0])
+		if err != nil {
+			return false, err
+		}
+		result.Diagnostics.RowsScanned++
+		if typedColumnInt64PredicateMatches(req, value) {
+			result.Rows = append(result.Rows, TypedColumnInt64PredicateScanRow{DocumentID: bytes.Clone(record.ID), Value: value})
+			result.Diagnostics.RowsMatched++
+		}
+		return true, nil
+	})
+	result.Diagnostics.ScanNanos = time.Since(start).Nanoseconds()
+	return result, err
+}
+
+func typedColumnInt64PredicateDiagnosticsFromView(view columnPhysicalScanSnapshotView) TypedColumnInt64PredicateScanDiagnostics {
+	return TypedColumnInt64PredicateScanDiagnostics{
+		ManifestRoot:               view.Diagnostics.ManifestRoot,
+		ManifestGeneration:         view.Diagnostics.ManifestGeneration,
+		RecoveryManifestGeneration: view.Diagnostics.RecoveryManifestGeneration,
+		AppliedCommandLSN:          view.Diagnostics.AppliedCommandLSN,
+		ManifestRecords:            view.Diagnostics.ManifestRecords,
+		AssetRefs:                  view.Diagnostics.AssetRefs,
+		MutationParts:              view.Diagnostics.MutationParts,
+	}
+}

--- a/TreeDB/collections/typed_column_int64_scan_test.go
+++ b/TreeDB/collections/typed_column_int64_scan_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sort"
 	"testing"
+	"time"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 )
@@ -78,6 +79,54 @@ func TestTypedColumnInt64ScanAllPrunedNoMatch(t *testing.T) {
 	}
 }
 
+func TestTypedColumnInt64ScanDirectIdentityMatchesPhysicalFallback(t *testing.T) {
+	directDB, directCol := setupTypedColumnInt64ScanCollection(t)
+	defer func() { _ = directDB.Close() }()
+	insertTypedColumnInt64ScanRows(t, directCol, []int64{10, 20, 30, 20})
+	direct, err := directCol.RunTypedColumnInt64PredicateScan(TypedColumnInt64PredicateScanRequest{Column: "time_us", Kind: TypedColumnInt64PredicateEqual, Value: 20})
+	if err != nil {
+		t.Fatalf("direct scan: %v", err)
+	}
+
+	fallbackDB := openTypedColumnInt64ScanDB(t)
+	defer func() { _ = fallbackDB.Close() }()
+	cfg := testColumnStoreConfig(nil)
+	cfg.Columns = []ColumnStoreColumn{{Name: "time_us", Path: "time_us", ValueType: ColumnStoreValueInt64, Owner: TypedStorageOwnerRowAsset}}
+	cfg.SortKey = nil
+	cfg.AggregateMetadata = nil
+	mgr := NewCollectionManager(fallbackDB)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "events", Options: CollectionOptions{ColumnStore: cfg}}); err != nil {
+		t.Fatalf("CreateCollection fallback: %v", err)
+	}
+	fallbackCol, err := mgr.OpenCollection("events")
+	if err != nil {
+		t.Fatalf("OpenCollection fallback: %v", err)
+	}
+	insertTypedColumnInt64ScanRows(t, fallbackCol, []int64{10, 20, 30, 20})
+	fallback, err := fallbackCol.RunTypedColumnInt64PredicateScan(TypedColumnInt64PredicateScanRequest{Column: "time_us", Kind: TypedColumnInt64PredicateEqual, Value: 20})
+	if err != nil {
+		t.Fatalf("fallback scan: %v", err)
+	}
+	if !fallback.Diagnostics.Fallback || direct.Diagnostics.Fallback {
+		t.Fatalf("direct fallback=%v fallback fallback=%v", direct.Diagnostics.Fallback, fallback.Diagnostics.Fallback)
+	}
+	got := typedColumnInt64ScanIdentityStrings(direct)
+	want := typedColumnInt64ScanIdentityStrings(fallback)
+	if len(got) != len(want) {
+		t.Fatalf("direct identities=%v fallback identities=%v", got, want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("direct identities=%v fallback identities=%v", got, want)
+		}
+	}
+	for _, row := range direct.Rows {
+		if len(row.DocumentID) == 0 || row.PartID != columnPhysicalRowAssetPartID {
+			t.Fatalf("direct row=%+v want physical row asset identity and document id", row)
+		}
+	}
+}
+
 func TestTypedColumnInt64ScanFallbackWhenTypedColumnUnsupported(t *testing.T) {
 	d := openTypedColumnInt64ScanDB(t)
 	defer func() { _ = d.Close() }()
@@ -120,6 +169,22 @@ func TestTypedColumnInt64ScanStaleMetadataFailsClosed(t *testing.T) {
 	}
 }
 
+func TestTypedColumnInt64ScanManifestSetupMismatchFailsClosed(t *testing.T) {
+	d, col := setupTypedColumnInt64ScanCollection(t)
+	defer func() { _ = d.Close() }()
+	insertTypedColumnInt64ScanRows(t, col, []int64{1, 2, 3})
+	col.catalogMu.Lock()
+	if col.catalog == nil || col.catalog.meta.Options.ColumnStore == nil || col.catalog.meta.Options.ColumnStore.RecoveryAuthoritativeManifest == nil {
+		col.catalogMu.Unlock()
+		t.Fatalf("missing cached recovery-authoritative manifest")
+	}
+	col.catalog.meta.Options.ColumnStore.RecoveryAuthoritativeManifest.Checksum++
+	col.catalogMu.Unlock()
+	if _, err := col.RunTypedColumnInt64PredicateScan(TypedColumnInt64PredicateScanRequest{Column: "time_us", Kind: TypedColumnInt64PredicateEqual, Value: 2}); err == nil {
+		t.Fatalf("RunTypedColumnInt64PredicateScan err=nil want fail-closed manifest setup mismatch")
+	}
+}
+
 func TestTypedColumnInt64ScanReopen(t *testing.T) {
 	dir := t.TempDir()
 	if err := backenddb.SaveFormatConfig(dir, backenddb.FormatConfig{RequiredFeatures: []string{backenddb.RequiredFeatureCommandWALV1}}); err != nil {
@@ -154,23 +219,27 @@ func TestTypedColumnInt64ScanReopen(t *testing.T) {
 
 func BenchmarkTypedColumnInt64PredicateScan(b *testing.B) {
 	const rows = 4096
-	values := make([]int64, rows)
-	for i := range values {
-		values[i] = int64(i % 1024)
+	valuesHot := make([]int64, rows)
+	valuesCold := make([]int64, rows)
+	for i := range valuesHot {
+		valuesHot[i] = int64(i)
+		valuesCold[i] = int64(10000 + i)
 	}
 	b.Run("typed_column_part", func(b *testing.B) {
 		d, col := setupTypedColumnInt64ScanCollection(b)
 		defer func() { _ = d.Close() }()
-		insertTypedColumnInt64ScanRows(b, col, values)
+		insertTypedColumnInt64ScanRows(b, col, valuesHot)
+		insertTypedColumnInt64ScanRows(b, col, valuesCold)
 		b.ReportAllocs()
 		b.ResetTimer()
+		benchStart := time.Now()
 		for i := 0; i < b.N; i++ {
 			result, err := col.RunTypedColumnInt64PredicateScan(TypedColumnInt64PredicateScanRequest{Column: "time_us", Kind: TypedColumnInt64PredicateRange, Low: 100, High: 199, ColumnAssetReadIntegrity: ColumnAssetReadIntegrityCachedVerify})
 			if err != nil {
 				b.Fatalf("RunTypedColumnInt64PredicateScan: %v", err)
 			}
 			if i == b.N-1 {
-				reportTypedColumnInt64ScanBenchMetrics(b, result.Diagnostics)
+				reportTypedColumnInt64ScanBenchMetrics(b, result.Diagnostics, time.Since(benchStart), b.N)
 			}
 		}
 	})
@@ -185,25 +254,27 @@ func BenchmarkTypedColumnInt64PredicateScan(b *testing.B) {
 		if err != nil {
 			b.Fatalf("OpenCollection: %v", err)
 		}
-		insertTypedColumnInt64ScanRows(b, col, values)
+		insertTypedColumnInt64ScanRows(b, col, valuesHot)
+		insertTypedColumnInt64ScanRows(b, col, valuesCold)
 		b.ReportAllocs()
 		b.ResetTimer()
+		benchStart := time.Now()
 		for i := 0; i < b.N; i++ {
 			result, err := col.RunTypedColumnInt64PredicateScan(TypedColumnInt64PredicateScanRequest{Column: "time_us", Kind: TypedColumnInt64PredicateRange, Low: 100, High: 199})
 			if err != nil {
 				b.Fatalf("RunTypedColumnInt64PredicateScan fallback: %v", err)
 			}
 			if i == b.N-1 {
-				reportTypedColumnInt64ScanBenchMetrics(b, result.Diagnostics)
+				reportTypedColumnInt64ScanBenchMetrics(b, result.Diagnostics, time.Since(benchStart), b.N)
 			}
 		}
 	})
 }
 
-func reportTypedColumnInt64ScanBenchMetrics(b *testing.B, diag TypedColumnInt64PredicateScanDiagnostics) {
+func reportTypedColumnInt64ScanBenchMetrics(b *testing.B, diag TypedColumnInt64PredicateScanDiagnostics, elapsed time.Duration, iterations int) {
 	b.Helper()
-	if diag.ScanNanos > 0 {
-		b.ReportMetric(float64(1_000_000_000)/float64(diag.ScanNanos), "ops/sec")
+	if elapsed > 0 && iterations > 0 {
+		b.ReportMetric(float64(iterations)/elapsed.Seconds(), "ops/sec")
 	}
 	b.ReportMetric(float64(diag.MappedBytes), "mapped_bytes/op")
 	b.ReportMetric(float64(diag.HeapCopyBytes), "heap_copy_bytes/op")
@@ -259,6 +330,15 @@ func insertTypedColumnInt64ScanRows(tb testing.TB, col *Collection, values []int
 	if _, err := col.InsertBatch(ids, docs); err != nil {
 		tb.Fatalf("InsertBatch: %v", err)
 	}
+}
+
+func typedColumnInt64ScanIdentityStrings(result TypedColumnInt64PredicateScanResult) []string {
+	out := make([]string, len(result.Rows))
+	for i, row := range result.Rows {
+		out[i] = fmt.Sprintf("%s/%d/%d/%d/%d", string(row.DocumentID), row.Generation, row.PartID, row.RowIndex, row.Value)
+	}
+	sort.Strings(out)
+	return out
 }
 
 func assertTypedColumnInt64ScanValues(t *testing.T, result TypedColumnInt64PredicateScanResult, want []int64) {

--- a/TreeDB/collections/typed_column_int64_scan_test.go
+++ b/TreeDB/collections/typed_column_int64_scan_test.go
@@ -1,0 +1,281 @@
+package collections
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+)
+
+func TestTypedColumnInt64ScanEqualityPredicate(t *testing.T) {
+	d, col := setupTypedColumnInt64ScanCollection(t)
+	defer func() { _ = d.Close() }()
+	insertTypedColumnInt64ScanRows(t, col, []int64{10, 20, 30, 20})
+
+	result, err := col.RunTypedColumnInt64PredicateScan(TypedColumnInt64PredicateScanRequest{Column: "time_us", Kind: TypedColumnInt64PredicateEqual, Value: 20})
+	if err != nil {
+		t.Fatalf("RunTypedColumnInt64PredicateScan: %v", err)
+	}
+	assertTypedColumnInt64ScanValues(t, result, []int64{20, 20})
+	if result.Diagnostics.Fallback || result.Diagnostics.DirectTypedColumnAssetReads == 0 || result.Diagnostics.RowMaterializations != 0 {
+		t.Fatalf("diagnostics=%+v want direct typed-column path without reconstruction", result.Diagnostics)
+	}
+	if result.Diagnostics.RowsScanned != 4 || result.Diagnostics.RowsMatched != 2 {
+		t.Fatalf("diagnostics=%+v want rows scanned=4 matched=2", result.Diagnostics)
+	}
+}
+
+func TestTypedColumnInt64ScanRangePredicate(t *testing.T) {
+	d, col := setupTypedColumnInt64ScanCollection(t)
+	defer func() { _ = d.Close() }()
+	insertTypedColumnInt64ScanRows(t, col, []int64{5, 10, 15, 20, 25})
+
+	result, err := col.RunTypedColumnInt64PredicateScan(TypedColumnInt64PredicateScanRequest{Column: "time_us", Kind: TypedColumnInt64PredicateRange, Low: 10, High: 20})
+	if err != nil {
+		t.Fatalf("RunTypedColumnInt64PredicateScan: %v", err)
+	}
+	assertTypedColumnInt64ScanValues(t, result, []int64{10, 15, 20})
+	if result.Diagnostics.BlocksDecoded == 0 || result.Diagnostics.DecodedHeapCopyBytes == 0 || result.Diagnostics.DecodedMetadataBytes == 0 {
+		t.Fatalf("diagnostics=%+v want decoded block and metadata bytes", result.Diagnostics)
+	}
+}
+
+func TestTypedColumnInt64ScanPrunesWithMinMaxMetadata(t *testing.T) {
+	d, col := setupTypedColumnInt64ScanCollection(t)
+	defer func() { _ = d.Close() }()
+	insertTypedColumnInt64ScanRows(t, col, []int64{1, 2, 3})
+	insertTypedColumnInt64ScanRows(t, col, []int64{100, 101, 102})
+
+	result, err := col.RunTypedColumnInt64PredicateScan(TypedColumnInt64PredicateScanRequest{Column: "time_us", Kind: TypedColumnInt64PredicateRange, Low: 100, High: 102})
+	if err != nil {
+		t.Fatalf("RunTypedColumnInt64PredicateScan: %v", err)
+	}
+	assertTypedColumnInt64ScanValues(t, result, []int64{100, 101, 102})
+	if result.Diagnostics.PartsPruned == 0 || result.Diagnostics.BlocksPruned == 0 || result.Diagnostics.PartsDecoded == 0 {
+		t.Fatalf("diagnostics=%+v want min/max pruning and decoded matching part", result.Diagnostics)
+	}
+	if result.Diagnostics.RowsScanned >= 6 {
+		t.Fatalf("rows_scanned=%d want pruned below full row count diagnostics=%+v", result.Diagnostics.RowsScanned, result.Diagnostics)
+	}
+}
+
+func TestTypedColumnInt64ScanAllPrunedNoMatch(t *testing.T) {
+	d, col := setupTypedColumnInt64ScanCollection(t)
+	defer func() { _ = d.Close() }()
+	insertTypedColumnInt64ScanRows(t, col, []int64{1, 2, 3})
+	insertTypedColumnInt64ScanRows(t, col, []int64{10, 11, 12})
+
+	result, err := col.RunTypedColumnInt64PredicateScan(TypedColumnInt64PredicateScanRequest{Column: "time_us", Kind: TypedColumnInt64PredicateEqual, Value: 99})
+	if err != nil {
+		t.Fatalf("RunTypedColumnInt64PredicateScan: %v", err)
+	}
+	if len(result.Rows) != 0 || result.Diagnostics.RowsMatched != 0 || result.Diagnostics.RowsScanned != 0 {
+		t.Fatalf("result=%+v diagnostics=%+v want all pruned no match", result.Rows, result.Diagnostics)
+	}
+	if result.Diagnostics.PartsPruned != 2 || result.Diagnostics.BlocksPruned == 0 || result.Diagnostics.BlocksDecoded != 0 {
+		t.Fatalf("diagnostics=%+v want all parts/blocks pruned and no decoded blocks", result.Diagnostics)
+	}
+}
+
+func TestTypedColumnInt64ScanFallbackWhenTypedColumnUnsupported(t *testing.T) {
+	d := openTypedColumnInt64ScanDB(t)
+	defer func() { _ = d.Close() }()
+	cfg := testColumnStoreConfig(nil)
+	cfg.Columns = []ColumnStoreColumn{{Name: "time_us", Path: "time_us", ValueType: ColumnStoreValueInt64, Owner: TypedStorageOwnerRowAsset}}
+	cfg.SortKey = nil
+	cfg.AggregateMetadata = nil
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "events", Options: CollectionOptions{ColumnStore: cfg}}); err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	col, err := mgr.OpenCollection("events")
+	if err != nil {
+		t.Fatalf("OpenCollection: %v", err)
+	}
+	insertTypedColumnInt64ScanRows(t, col, []int64{7, 8, 9})
+
+	result, err := col.RunTypedColumnInt64PredicateScan(TypedColumnInt64PredicateScanRequest{Column: "time_us", Kind: TypedColumnInt64PredicateRange, Low: 8, High: 9})
+	if err != nil {
+		t.Fatalf("RunTypedColumnInt64PredicateScan fallback: %v", err)
+	}
+	assertTypedColumnInt64ScanValues(t, result, []int64{8, 9})
+	if !result.Diagnostics.Fallback || result.Diagnostics.FallbackReason != "typed_column_not_selected" || result.Diagnostics.DirectTypedColumnAssetReads != 0 {
+		t.Fatalf("diagnostics=%+v want typed-row fallback", result.Diagnostics)
+	}
+}
+
+func TestTypedColumnInt64ScanStaleMetadataFailsClosed(t *testing.T) {
+	d, col := setupTypedColumnInt64ScanCollection(t)
+	defer func() { _ = d.Close() }()
+	insertTypedColumnInt64ScanRows(t, col, []int64{1, 2, 3})
+	typedRefs := typedColumnPartRefs1755(columnManifestAssetRefsForCollectionM12A(t, d, col))
+	if len(typedRefs) != 1 {
+		t.Fatalf("typed refs=%+v want one", typedRefs)
+	}
+	corruptTypedColumnAssetPayload1755(t, d, typedRefs[0])
+
+	if _, err := col.RunTypedColumnInt64PredicateScan(TypedColumnInt64PredicateScanRequest{Column: "time_us", Kind: TypedColumnInt64PredicateEqual, Value: 2}); err == nil {
+		t.Fatalf("RunTypedColumnInt64PredicateScan err=nil want fail-closed corrupt ref/checksum metadata")
+	}
+}
+
+func TestTypedColumnInt64ScanReopen(t *testing.T) {
+	dir := t.TempDir()
+	if err := backenddb.SaveFormatConfig(dir, backenddb.FormatConfig{RequiredFeatures: []string{backenddb.RequiredFeatureCommandWALV1}}); err != nil {
+		t.Fatalf("SaveFormatConfig: %v", err)
+	}
+	d := openCollectionCommandWALDB(t, dir)
+	col := createTypedColumnInt64ScanCollection(t, d)
+	insertTypedColumnInt64ScanRows(t, col, []int64{11, 12, 13})
+	if err := d.Checkpoint(); err != nil {
+		_ = d.Close()
+		t.Fatalf("Checkpoint: %v", err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	reopened := openCollectionCommandWALDB(t, dir)
+	defer func() { _ = reopened.Close() }()
+	reopenedCol, err := NewCollectionManager(reopened).OpenCollection("events")
+	if err != nil {
+		t.Fatalf("OpenCollection: %v", err)
+	}
+	result, err := reopenedCol.RunTypedColumnInt64PredicateScan(TypedColumnInt64PredicateScanRequest{Column: "time_us", Kind: TypedColumnInt64PredicateRange, Low: 12, High: 13})
+	if err != nil {
+		t.Fatalf("RunTypedColumnInt64PredicateScan reopened: %v", err)
+	}
+	assertTypedColumnInt64ScanValues(t, result, []int64{12, 13})
+	if result.Diagnostics.DirectTypedColumnAssetReads == 0 || result.Diagnostics.MappedBytes+result.Diagnostics.HeapCopyBytes == 0 {
+		t.Fatalf("diagnostics=%+v want durable typed_column_part asset reads after reopen", result.Diagnostics)
+	}
+}
+
+func BenchmarkTypedColumnInt64PredicateScan(b *testing.B) {
+	const rows = 4096
+	values := make([]int64, rows)
+	for i := range values {
+		values[i] = int64(i % 1024)
+	}
+	b.Run("typed_column_part", func(b *testing.B) {
+		d, col := setupTypedColumnInt64ScanCollection(b)
+		defer func() { _ = d.Close() }()
+		insertTypedColumnInt64ScanRows(b, col, values)
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			result, err := col.RunTypedColumnInt64PredicateScan(TypedColumnInt64PredicateScanRequest{Column: "time_us", Kind: TypedColumnInt64PredicateRange, Low: 100, High: 199, ColumnAssetReadIntegrity: ColumnAssetReadIntegrityCachedVerify})
+			if err != nil {
+				b.Fatalf("RunTypedColumnInt64PredicateScan: %v", err)
+			}
+			if i == b.N-1 {
+				reportTypedColumnInt64ScanBenchMetrics(b, result.Diagnostics)
+			}
+		}
+	})
+	b.Run("document_full_scan_fallback", func(b *testing.B) {
+		d := openTypedColumnInt64ScanDB(b)
+		defer func() { _ = d.Close() }()
+		mgr := NewCollectionManager(d)
+		if _, err := mgr.CreateCollection(&CollectionMeta{Name: "events"}); err != nil {
+			b.Fatalf("CreateCollection: %v", err)
+		}
+		col, err := mgr.OpenCollection("events")
+		if err != nil {
+			b.Fatalf("OpenCollection: %v", err)
+		}
+		insertTypedColumnInt64ScanRows(b, col, values)
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			result, err := col.RunTypedColumnInt64PredicateScan(TypedColumnInt64PredicateScanRequest{Column: "time_us", Kind: TypedColumnInt64PredicateRange, Low: 100, High: 199})
+			if err != nil {
+				b.Fatalf("RunTypedColumnInt64PredicateScan fallback: %v", err)
+			}
+			if i == b.N-1 {
+				reportTypedColumnInt64ScanBenchMetrics(b, result.Diagnostics)
+			}
+		}
+	})
+}
+
+func reportTypedColumnInt64ScanBenchMetrics(b *testing.B, diag TypedColumnInt64PredicateScanDiagnostics) {
+	b.Helper()
+	if diag.ScanNanos > 0 {
+		b.ReportMetric(float64(1_000_000_000)/float64(diag.ScanNanos), "ops/sec")
+	}
+	b.ReportMetric(float64(diag.MappedBytes), "mapped_bytes/op")
+	b.ReportMetric(float64(diag.HeapCopyBytes), "heap_copy_bytes/op")
+	b.ReportMetric(float64(diag.DecodedHeapCopyBytes), "decoded_bytes/op")
+	b.ReportMetric(float64(diag.RowsScanned), "rows_scanned/op")
+	b.ReportMetric(float64(diag.PartsPruned), "parts_pruned/op")
+	b.ReportMetric(float64(diag.BlocksPruned), "blocks_pruned/op")
+}
+
+func setupTypedColumnInt64ScanCollection(tb testing.TB) (*backenddb.DB, *Collection) {
+	tb.Helper()
+	d := openTypedColumnInt64ScanDB(tb)
+	return d, createTypedColumnInt64ScanCollection(tb, d)
+}
+
+func openTypedColumnInt64ScanDB(tb testing.TB) *backenddb.DB {
+	tb.Helper()
+	dir := tb.TempDir()
+	if err := backenddb.SaveFormatConfig(dir, backenddb.FormatConfig{RequiredFeatures: []string{backenddb.RequiredFeatureCommandWALV1}}); err != nil {
+		tb.Fatalf("SaveFormatConfig: %v", err)
+	}
+	return openCollectionCommandWALDB(tb, dir)
+}
+
+func createTypedColumnInt64ScanCollection(tb testing.TB, d *backenddb.DB) *Collection {
+	tb.Helper()
+	cfg := testColumnStoreConfig(nil)
+	cfg.Columns = []ColumnStoreColumn{
+		{Name: "time_us", Path: "time_us", ValueType: ColumnStoreValueInt64, Owner: TypedStorageOwnerColumnPart},
+		{Name: "kind", Path: "kind", ValueType: ColumnStoreValueString, Owner: TypedStorageOwnerRowAsset, Dictionary: true},
+	}
+	cfg.SortKey = nil
+	cfg.AggregateMetadata = nil
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "events", Options: CollectionOptions{ColumnStore: cfg}}); err != nil {
+		tb.Fatalf("CreateCollection: %v", err)
+	}
+	col, err := mgr.OpenCollection("events")
+	if err != nil {
+		tb.Fatalf("OpenCollection: %v", err)
+	}
+	return col
+}
+
+func insertTypedColumnInt64ScanRows(tb testing.TB, col *Collection, values []int64) {
+	tb.Helper()
+	ids := make([][]byte, len(values))
+	docs := make([][]byte, len(values))
+	for i, value := range values {
+		ids[i] = []byte(fmt.Sprintf("e%06d_%d", value, i))
+		docs[i] = []byte(fmt.Sprintf(`{"time_us":%d,"kind":"k%d"}`, value, value%8))
+	}
+	if _, err := col.InsertBatch(ids, docs); err != nil {
+		tb.Fatalf("InsertBatch: %v", err)
+	}
+}
+
+func assertTypedColumnInt64ScanValues(t *testing.T, result TypedColumnInt64PredicateScanResult, want []int64) {
+	t.Helper()
+	got := make([]int64, len(result.Rows))
+	for i, row := range result.Rows {
+		got[i] = row.Value
+	}
+	sort.Slice(got, func(i, j int) bool { return got[i] < got[j] })
+	want = append([]int64(nil), want...)
+	sort.Slice(want, func(i, j int) bool { return want[i] < want[j] })
+	if len(got) != len(want) {
+		t.Fatalf("values=%v want %v diagnostics=%+v", got, want, result.Diagnostics)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("values=%v want %v diagnostics=%+v", got, want, result.Diagnostics)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Closes #1757. Parent tracker: #1744. Depends on #1736/#1755/#1781; current base includes #1781 via PR #1792 merge commit `849b3b10e22b39827a44e32de185b02e870b540d`.

This PR lands the scoped scalar typed-column predicate MVP:

- adds an explicit `RunTypedColumnInt64PredicateScan` path for `int64` equality/range predicates;
- when the requested field owner is `typed_column_part`, evaluates predicates directly over durable `typed_column_part` assets and min/max block metadata;
- returns physical row identity (`DocumentID`, generation, physical row part, row index) by reading row-asset locator bytes only, not by reconstructing full documents;
- preserves typed-row/document fallback when typed-column storage is not selected/unsupported;
- fails closed on corrupt/missing/stale authoritative typed-column assets or manifest setup mismatch;
- reports counters for rows scanned/matched, parts/blocks considered/pruned/decoded, direct typed-column reads, fallback reads, mapped bytes, heap-copy/decoded bytes, and scan timing.

## Scope boundary / non-goals

- No vector dense-section/native graph switch (#1782).
- No string/dictionary production predicate query MVP (#1785 follow-up remains separate).
- No aggregate query MVP (#1786 follow-up remains separate).
- No broad optimizer rewrite; this is an explicit scoped API, not automatic planner routing.
- No private metadata cache or new authoritative sidecar ownership.
- Dictionary and aggregate data-plane hooks remain intact.

## Start gate / dependency status

- This reads authoritative durable `typed_column_part` assets when the field owner is `typed_column_part`.
- #1781 guardrails are merged in the base via PR #1792 / merge commit `849b3b10e22b39827a44e32de185b02e870b540d`.
- #1736 mappedresource/accounting surface is used through the existing column asset read cache + `mappedresource.Manager` handle path.
- Dictionary-query and aggregate-query integration are explicitly excluded from this PR.

## Naming impact

- New public-ish TreeDB collection API/types use `TypedColumnInt64PredicateScan*` and are scoped to true typed-column predicate scan behavior.
- Existing `ColumnStore*` compatibility/config names are unchanged.
- `typed_column_part` remains the authoritative owner name for durable column-major assets.
- `typed-row`/retained-document fallback behavior remains compatibility behavior, not renamed here.

## Tests

Latest local head: `fec34fd7c0da6cf345ebb6438c531959cb60e37f` (`darwin/arm64`, Apple M3, Go `go1.25.5`).

```sh
go test -count=1 ./TreeDB/collections -run 'TestTypedColumnInt64Scan'
go test -count=1 ./TreeDB/collections ./TreeDB/internal/typedcolumn
go test -count=1 ./TreeDB/...
go test -count=1 ./...
```

All passed locally.

Required #1757 mapping:

| Required item | Test / evidence |
| --- | --- |
| Equality predicate | `TestTypedColumnInt64ScanEqualityPredicate` |
| Range predicate | `TestTypedColumnInt64ScanRangePredicate` |
| Min/max pruning | `TestTypedColumnInt64ScanPrunesWithMinMaxMetadata` |
| All-pruned no-match | `TestTypedColumnInt64ScanAllPrunedNoMatch` |
| Fallback unsupported/not selected | `TestTypedColumnInt64ScanFallbackWhenTypedColumnUnsupported` |
| Stale/fail-closed metadata/assets | `TestTypedColumnInt64ScanStaleMetadataFailsClosed`, `TestTypedColumnInt64ScanManifestSetupMismatchFailsClosed` |
| Reopen durable assets | `TestTypedColumnInt64ScanReopen` |
| Row identity without reconstruction | `TestTypedColumnInt64ScanDirectIdentityMatchesPhysicalFallback` plus direct diagnostics assert `RowMaterializations == 0` |

## Benchmarks

Command:

```sh
go test -run '^$' -bench 'BenchmarkTypedColumnInt64PredicateScan' -benchmem -benchtime=100x -count=1 ./TreeDB/collections
```

Hardware/context: Apple M3, `darwin/arm64`, Go `go1.25.5`; branch `snissn/1757-manager`; commit `fec34fd7c0da6cf345ebb6438c531959cb60e37f`.

Dataset/timing boundary: two 4096-row insert batches. The typed-column sub-benchmark queries a range that matches one part and prunes one part by typed-column min/max metadata; setup/build/publish occurs before the timer. The fallback sub-benchmark uses the current document full-scan/reconstruction-style path over the same 8192 logical rows. The typed-column path still includes per-call typed-column image parse/setup plus physical row-ID locator read for matches; the hot predicate evaluation itself avoids full document reconstruction.

| Benchmark | ns/op | ops/sec | B/op | allocs/op | mapped bytes/op | heap-copy bytes/op | decoded bytes/op | rows scanned/op | parts pruned/op | blocks pruned/op |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| `BenchmarkTypedColumnInt64PredicateScan/typed_column_part-8` | 512,787 | 1,965 | 1,101,902 | 297 | 529,722 | 0 | 36,864 | 4,096 | 1.000 | 1.000 |
| `BenchmarkTypedColumnInt64PredicateScan/document_full_scan_fallback-8` | 5,646,920 | 177.2 | 13,066,670 | 163,941 | 0 | 0 | 0 | 8,192 | 0 | 0 |

## AI review / CI status

- Latest-head CI: green on `fec34fd7c0da6cf345ebb6438c531959cb60e37f` (all required checks passed, including TreeDB shards and race checks).
- Mergeability: GitHub reports `MERGEABLE` / `CLEAN`.
- Codex: latest re-review reported no major issues; earlier findings addressed in `c3b61b80d`.
- Copilot: requested multiple times; GitHub/Copilot returned tool/cloud-agent errors and no actionable review.
- CodeRabbit: latest status successful; actionable comments addressed/dispositioned in `0eae9fe38` and `fec34fd7c`.
- Unresolved review threads: none.

## Risks / caveats

- The direct scan is intentionally insert-only for typed-column parts. Mutation-bearing manifests fall back to document reconstruction for correctness until latest-visible multipart predicate execution is scoped separately.
- The typed-column benchmark includes per-call image parse/setup and physical row-ID locator read, so allocations are bounded and reported rather than claimed zero-allocation end-to-end.
- Automatic planner routing is deferred; callers opt into this MVP API explicitly.
