### PR TITLE
test: lock typed-storage naming contract

### DIFF
--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -1,18 +1,43 @@
 package collections
 
 import (
+	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
+	"regexp"
+	"runtime"
+	"sort"
 	"strings"
 	"testing"
+	"unicode/utf8"
 )
+
+func typedStorageRepoRoot(t *testing.T) string {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatalf("runtime.Caller failed")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(thisFile), "..", ".."))
+}
 
 func readTypedStorageNamingDoc(t *testing.T) string {
 	t.Helper()
-	path := filepath.Join("..", "docs", "spec", "typed-storage-naming.md")
+	path := filepath.Join(typedStorageRepoRoot(t), "TreeDB", "docs", "spec", "typed-storage-naming.md")
 	data, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("read typed-storage naming doc: %v", err)
+	}
+	return string(data)
+}
+
+func readTypedStorageSpecREADME(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(typedStorageRepoRoot(t), "TreeDB", "docs", "spec", "README.md")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read typed-storage spec README: %v", err)
 	}
 	return string(data)
 }
@@ -36,7 +61,7 @@ func TestTypedStorageNamingVocabulary(t *testing.T) {
 		"`typed-column storage` / `typed_column_part`",
 		"`retained document` / `document_payload`",
 		"`derived accelerator`",
-		"Do not use \"column store\" as the umbrella name",
+		"Do not use \"column "+"store\" as the umbrella name",
 	)
 }
 
@@ -52,6 +77,29 @@ func TestTypedStorageFieldOwnerVocabulary(t *testing.T) {
 
 	if strings.Contains(doc, "`derived_accelerator` is an authoritative") {
 		t.Fatalf("typed-storage naming doc must not describe derived_accelerator as authoritative")
+	}
+}
+
+func TestTypedStorageVocabularyMatchesConstants(t *testing.T) {
+	doc := readTypedStorageNamingDoc(t)
+	rows := []string{
+		fmt.Sprintf("| `%s` | `%s` |", "TypedStorageOwnerRetainedDocument", TypedStorageOwnerRetainedDocument),
+		"| `document_payload` alias | `document_payload` |",
+		fmt.Sprintf("| `%s` | `%s` |", "TypedStorageOwnerRowAsset", TypedStorageOwnerRowAsset),
+		fmt.Sprintf("| `%s` | `%s` |", "TypedStorageOwnerColumnPart", TypedStorageOwnerColumnPart),
+		fmt.Sprintf("| `%s` | `%s` |", "TypedStorageAssetClassDerivedAccelerator", TypedStorageAssetClassDerivedAccelerator),
+		fmt.Sprintf("| `%s` | `%s` |", "Column"+"StoreValueBool", ColumnStoreValueBool),
+		fmt.Sprintf("| `%s` | `%s` |", "Column"+"StoreValueInt64", ColumnStoreValueInt64),
+		fmt.Sprintf("| `%s` | `%s` |", "Column"+"StoreValueFloat32", ColumnStoreValueFloat32),
+		fmt.Sprintf("| `%s` | `%s` |", "Column"+"StoreValueDouble", ColumnStoreValueDouble),
+		fmt.Sprintf("| `%s` | `%s` |", "Column"+"StoreValueString", ColumnStoreValueString),
+		fmt.Sprintf("| `%s` | `%s` |", "Column"+"StoreValueFloat32Vector", ColumnStoreValueFloat32Vector),
+		fmt.Sprintf("| `%s` | `%s` |", "Column"+"StoreValueAdjacencyList", ColumnStoreValueAdjacencyList),
+	}
+	for _, want := range rows {
+		if !strings.Contains(doc, want) {
+			t.Fatalf("typed-storage naming doc missing code vocabulary row %q", want)
+		}
 	}
 }
 
@@ -86,18 +134,19 @@ func TestTypedStorageLegacyNameInventoryTable(t *testing.T) {
 
 	requireDocContains(t, doc,
 		"## Legacy Name Inventory",
-		"rg -n \"ColumnStore|column store|column-store\" TreeDB docs experiments",
+		"rg -n \""+typedStorageLegacyNamePatternText()+"\" TreeDB docs experiments",
 		"| Path | Symbol/text | Current meaning | Classification | Action | Deferral reason |",
 		"`TreeDB/collections/api.go`",
-		"`ColumnStoreConfig`",
+		"`Column"+"StoreConfig`",
 		"`experiments/colgranule/**`",
 		"true typed-column terminology",
 		"compatibility-retained",
 		"deferred",
+		"TestTypedStorageLegacyNameAllowlistIsComplete",
 	)
 }
 
-func TestTypedStorageLegacyColumnStoreNamesRemainClassified(t *testing.T) {
+func TestTypedStorageLegacyNamesRemainClassified(t *testing.T) {
 	doc := readTypedStorageNamingDoc(t)
 
 	requireDocContains(t, doc,
@@ -118,16 +167,333 @@ func TestTypedStorageLegacyColumnStoreNamesRemainClassified(t *testing.T) {
 	}
 }
 
+func TestTypedStorageLegacyNameAllowlistIsComplete(t *testing.T) {
+	actual := scanTypedStorageLegacyNameUsage(t)
+	expected := make(map[string]typedStorageLegacyNameAllowlistEntry, len(typedStorageLegacyNameAllowlist))
+	var problems []string
+	for _, entry := range typedStorageLegacyNameAllowlist {
+		if entry.path == "" || entry.classification == "" {
+			problems = append(problems, fmt.Sprintf("invalid empty allowlist entry: %+v", entry))
+			continue
+		}
+		if _, ok := typedStorageLegacyNameClassifications[entry.classification]; !ok {
+			problems = append(problems, fmt.Sprintf("%s uses unknown classification %q", entry.path, entry.classification))
+		}
+		if prior, ok := expected[entry.path]; ok {
+			problems = append(problems, fmt.Sprintf("duplicate allowlist entry for %s: %+v and %+v", entry.path, prior, entry))
+			continue
+		}
+		expected[entry.path] = entry
+	}
+
+	for path, usage := range actual {
+		entry, ok := expected[path]
+		if !ok {
+			problems = append(problems, fmt.Sprintf("unclassified legacy-name usage in %s: %d matching lines, %d occurrences", path, usage.matchingLines, usage.occurrences))
+			continue
+		}
+		if usage.matchingLines != entry.matchingLines || usage.occurrences != entry.occurrences {
+			problems = append(problems, fmt.Sprintf("legacy-name usage drift in %s (%s): got %d matching lines/%d occurrences, want %d/%d", path, entry.classification, usage.matchingLines, usage.occurrences, entry.matchingLines, entry.occurrences))
+		}
+	}
+	for path, entry := range expected {
+		if _, ok := actual[path]; !ok {
+			problems = append(problems, fmt.Sprintf("allowlist entry %s (%s) has no current matches", path, entry.classification))
+		}
+	}
+	if len(problems) > 0 {
+		sort.Strings(problems)
+		t.Fatalf("typed-storage legacy-name allowlist is stale:\n%s\nRun `rg -n %q TreeDB docs experiments`, then classify each changed match before updating this allowlist.", strings.Join(problems, "\n"), typedStorageLegacyNamePatternText())
+	}
+}
+
+func TestTypedStorageSpecLinksResolve(t *testing.T) {
+	repoRoot := typedStorageRepoRoot(t)
+	specDir := filepath.Join(repoRoot, "TreeDB", "docs", "spec")
+	docs := []string{
+		filepath.Join(specDir, "typed-storage-naming.md"),
+		filepath.Join(specDir, "README.md"),
+	}
+	var problems []string
+	for _, docPath := range docs {
+		data, err := os.ReadFile(docPath)
+		if err != nil {
+			t.Fatalf("read %s: %v", docPath, err)
+		}
+		refs := typedStorageMarkdownReferences(string(data))
+		if len(refs) == 0 {
+			problems = append(problems, fmt.Sprintf("%s has no markdown/spec references to validate", filepath.ToSlash(docPath)))
+			continue
+		}
+		for _, ref := range refs {
+			if ok := typedStorageMarkdownReferenceResolves(repoRoot, filepath.Dir(docPath), ref); !ok {
+				problems = append(problems, fmt.Sprintf("%s references missing markdown path %q", filepath.ToSlash(docPath), ref))
+			}
+		}
+	}
+	readme := readTypedStorageSpecREADME(t)
+	requireDocContains(t, readme,
+		"`TreeDB/docs/spec/typed-storage-naming.md`",
+		"Typed physical storage vocabulary",
+		"`typed-storage-naming.md`; the #1753 typed-column transplant scope is recorded",
+	)
+	if len(problems) > 0 {
+		sort.Strings(problems)
+		t.Fatalf("typed-storage spec link validation failed:\n%s", strings.Join(problems, "\n"))
+	}
+}
+
 func TestTypedStoragePR0RuntimeBoundary(t *testing.T) {
 	doc := readTypedStorageNamingDoc(t)
 
 	requireDocContains(t, doc,
 		"## PR 0 Runtime Boundary",
 		"no durable typed-column part format",
-		"no `ColumnStoreConfig` removal",
+		"no `Column"+"StoreConfig` removal",
 		"no public API break",
 		"no query planner change",
 		"no production data-path behavior change",
 		"no #1736 resource-manager behavior change",
 	)
+}
+
+func TestTypedStorageNamingRuntimeBoundary(t *testing.T) {
+	doc := readTypedStorageNamingDoc(t)
+
+	requireDocContains(t, doc,
+		"## Naming Regression Test Boundary",
+		"Issue #1773 adds regression coverage for this naming contract only",
+		"limited to docs, tests, and process evidence",
+		"repo-scan allowlist updates",
+		"spec link checks",
+		"code-vocabulary alignment checks",
+		"must move to a separate implementation tracker",
+	)
+}
+
+type typedStorageLegacyNameClassification string
+
+const (
+	typedStorageLegacyCompatibility typedStorageLegacyNameClassification = "compatibility-retained"
+	typedStorageLegacyDerived       typedStorageLegacyNameClassification = "derived accelerator"
+	typedStorageLegacyDeferred      typedStorageLegacyNameClassification = "deferred"
+	typedStorageLegacyTrueColumn    typedStorageLegacyNameClassification = "true typed-column terminology"
+)
+
+var typedStorageLegacyNameClassifications = map[typedStorageLegacyNameClassification]struct{}{
+	typedStorageLegacyCompatibility: {},
+	typedStorageLegacyDerived:       {},
+	typedStorageLegacyDeferred:      {},
+	typedStorageLegacyTrueColumn:    {},
+}
+
+type typedStorageLegacyNameAllowlistEntry struct {
+	path           string
+	classification typedStorageLegacyNameClassification
+	matchingLines  int
+	occurrences    int
+}
+
+var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
+	{path: "TreeDB/collections/api.go", classification: typedStorageLegacyCompatibility, matchingLines: 45, occurrences: 51},
+	{path: "TreeDB/collections/column_aggregate_metadata_asset.go", classification: typedStorageLegacyDerived, matchingLines: 7, occurrences: 8},
+	{path: "TreeDB/collections/column_asset_gc_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 32, occurrences: 34},
+	{path: "TreeDB/collections/column_asset_manager.go", classification: typedStorageLegacyCompatibility, matchingLines: 11, occurrences: 11},
+	{path: "TreeDB/collections/column_asset_mappedresource_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 12, occurrences: 12},
+	{path: "TreeDB/collections/column_asset_reachability_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 22, occurrences: 23},
+	{path: "TreeDB/collections/column_asset_rewrite.go", classification: typedStorageLegacyCompatibility, matchingLines: 8, occurrences: 10},
+	{path: "TreeDB/collections/column_asset_rewrite_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 18, occurrences: 18},
+	{path: "TreeDB/collections/column_dict_int64_query.go", classification: typedStorageLegacyDerived, matchingLines: 2, occurrences: 2},
+	{path: "TreeDB/collections/column_dictionary_codes_asset.go", classification: typedStorageLegacyDerived, matchingLines: 10, occurrences: 10},
+	{path: "TreeDB/collections/column_dictionary_query.go", classification: typedStorageLegacyDerived, matchingLines: 6, occurrences: 6},
+	{path: "TreeDB/collections/column_int64_query.go", classification: typedStorageLegacyDerived, matchingLines: 2, occurrences: 2},
+	{path: "TreeDB/collections/column_int64_values_asset.go", classification: typedStorageLegacyDerived, matchingLines: 8, occurrences: 8},
+	{path: "TreeDB/collections/column_manifest_format.go", classification: typedStorageLegacyCompatibility, matchingLines: 2, occurrences: 2},
+	{path: "TreeDB/collections/column_physical_asset.go", classification: typedStorageLegacyDeferred, matchingLines: 35, occurrences: 35},
+	{path: "TreeDB/collections/column_physical_asset_test.go", classification: typedStorageLegacyDeferred, matchingLines: 156, occurrences: 160},
+	{path: "TreeDB/collections/column_physical_query.go", classification: typedStorageLegacyDeferred, matchingLines: 36, occurrences: 38},
+	{path: "TreeDB/collections/column_physical_query_test.go", classification: typedStorageLegacyDeferred, matchingLines: 128, occurrences: 139},
+	{path: "TreeDB/collections/column_physical_row_reader.go", classification: typedStorageLegacyDeferred, matchingLines: 21, occurrences: 21},
+	{path: "TreeDB/collections/column_physical_row_reader_test.go", classification: typedStorageLegacyDeferred, matchingLines: 19, occurrences: 20},
+	{path: "TreeDB/collections/column_physical_scan.go", classification: typedStorageLegacyDeferred, matchingLines: 34, occurrences: 34},
+	{path: "TreeDB/collections/column_physical_scan_test.go", classification: typedStorageLegacyDeferred, matchingLines: 36, occurrences: 43},
+	{path: "TreeDB/collections/column_physical_visibility.go", classification: typedStorageLegacyDeferred, matchingLines: 8, occurrences: 8},
+	{path: "TreeDB/collections/column_publish_plan.go", classification: typedStorageLegacyCompatibility, matchingLines: 46, occurrences: 59},
+	{path: "TreeDB/collections/column_publish_plan_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 69, occurrences: 90},
+	{path: "TreeDB/collections/column_publish_write.go", classification: typedStorageLegacyCompatibility, matchingLines: 56, occurrences: 60},
+	{path: "TreeDB/collections/column_publish_write_bench_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 35, occurrences: 37},
+	{path: "TreeDB/collections/column_publish_write_path_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 163, occurrences: 183},
+	{path: "TreeDB/collections/column_query_plan.go", classification: typedStorageLegacyCompatibility, matchingLines: 43, occurrences: 43},
+	{path: "TreeDB/collections/column_query_plan_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 56, occurrences: 68},
+	{path: "TreeDB/collections/column_reconstruction.go", classification: typedStorageLegacyCompatibility, matchingLines: 19, occurrences: 20},
+	{path: "TreeDB/collections/column_store.go", classification: typedStorageLegacyCompatibility, matchingLines: 72, occurrences: 113},
+	{path: "TreeDB/collections/column_store_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 167, occurrences: 213},
+	{path: "TreeDB/collections/column_vector_graph_block_view.go", classification: typedStorageLegacyDerived, matchingLines: 4, occurrences: 4},
+	{path: "TreeDB/collections/column_vector_graph_manifest.go", classification: typedStorageLegacyDerived, matchingLines: 26, occurrences: 31},
+	{path: "TreeDB/collections/column_vector_graph_manifest_test.go", classification: typedStorageLegacyDerived, matchingLines: 56, occurrences: 76},
+	{path: "TreeDB/collections/column_vector_graph_row_reader.go", classification: typedStorageLegacyDerived, matchingLines: 8, occurrences: 10},
+	{path: "TreeDB/collections/column_vector_graph_row_reader_test.go", classification: typedStorageLegacyDerived, matchingLines: 15, occurrences: 16},
+	{path: "TreeDB/collections/column_vector_graph_search_test.go", classification: typedStorageLegacyDerived, matchingLines: 1, occurrences: 1},
+	{path: "TreeDB/collections/command_wal_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 4, occurrences: 6},
+	{path: "TreeDB/collections/typed_column_adapter.go", classification: typedStorageLegacyCompatibility, matchingLines: 26, occurrences: 26},
+	{path: "TreeDB/collections/typed_column_adapter_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 59, occurrences: 61},
+	{path: "TreeDB/collections/typed_column_publication.go", classification: typedStorageLegacyCompatibility, matchingLines: 16, occurrences: 18},
+	{path: "TreeDB/collections/typed_column_publication_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 31, occurrences: 33},
+	{path: "TreeDB/collections/typed_storage_layout.go", classification: typedStorageLegacyCompatibility, matchingLines: 14, occurrences: 20},
+	{path: "TreeDB/collections/typed_storage_layout_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 30, occurrences: 30},
+	{path: "TreeDB/collections/typed_storage_naming_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 7, occurrences: 7},
+	{path: "TreeDB/collections/vector_index.go", classification: typedStorageLegacyDerived, matchingLines: 1, occurrences: 1},
+	{path: "TreeDB/collections/vector_index_metadata_test.go", classification: typedStorageLegacyDerived, matchingLines: 9, occurrences: 11},
+	{path: "TreeDB/collections/vector_index_rebuild.go", classification: typedStorageLegacyDerived, matchingLines: 16, occurrences: 18},
+	{path: "TreeDB/collections/vector_index_rebuild_test.go", classification: typedStorageLegacyDerived, matchingLines: 32, occurrences: 38},
+	{path: "TreeDB/docs/spec/COMPRESSION_TECHNOLOGY_SPEC.md", classification: typedStorageLegacyDeferred, matchingLines: 5, occurrences: 5},
+	{path: "TreeDB/docs/spec/GOMAP_TREEDB_COLUMN_STORE_RFC.md", classification: typedStorageLegacyDeferred, matchingLines: 108, occurrences: 112},
+	{path: "TreeDB/docs/spec/backup-restore.md", classification: typedStorageLegacyDeferred, matchingLines: 1, occurrences: 1},
+	{path: "TreeDB/docs/spec/collection-wal-durability-plan.md", classification: typedStorageLegacyDeferred, matchingLines: 42, occurrences: 42},
+	{path: "TreeDB/docs/spec/column-graph-native-block-planner.md", classification: typedStorageLegacyDeferred, matchingLines: 1, occurrences: 1},
+	{path: "TreeDB/docs/spec/column-graph-native-reconstruction-inventory.md", classification: typedStorageLegacyDeferred, matchingLines: 14, occurrences: 14},
+	{path: "TreeDB/docs/spec/column-graph-native-vector-search.md", classification: typedStorageLegacyDeferred, matchingLines: 7, occurrences: 8},
+	{path: "TreeDB/docs/spec/typed-column-adapter.md", classification: typedStorageLegacyCompatibility, matchingLines: 2, occurrences: 2},
+	{path: "TreeDB/docs/spec/typed-column-transplant.md", classification: typedStorageLegacyCompatibility, matchingLines: 4, occurrences: 5},
+	{path: "TreeDB/docs/spec/typed-storage-naming.md", classification: typedStorageLegacyCompatibility, matchingLines: 23, occurrences: 28},
+	{path: "TreeDB/docs/spec/user-command-wal.md", classification: typedStorageLegacyDeferred, matchingLines: 1, occurrences: 1},
+	{path: "TreeDB/docs/spec/verification.md", classification: typedStorageLegacyDeferred, matchingLines: 2, occurrences: 2},
+	{path: "experiments/colgranule/DEFERRED_ISSUES.md", classification: typedStorageLegacyTrueColumn, matchingLines: 1, occurrences: 1},
+	{path: "experiments/colgranule/README.md", classification: typedStorageLegacyTrueColumn, matchingLines: 1, occurrences: 1},
+	{path: "experiments/colgranule/cmd/jsonbench_compare/main.go", classification: typedStorageLegacyTrueColumn, matchingLines: 1, occurrences: 1},
+	{path: "experiments/colgranule/collection_manifest.go", classification: typedStorageLegacyTrueColumn, matchingLines: 4, occurrences: 5},
+	{path: "experiments/colgranule/collection_manifest_test.go", classification: typedStorageLegacyTrueColumn, matchingLines: 1, occurrences: 1},
+	{path: "experiments/colgranule/granule_bench_test.go", classification: typedStorageLegacyTrueColumn, matchingLines: 2, occurrences: 2},
+	{path: "experiments/colgranule/jsonbench_bench_test.go", classification: typedStorageLegacyTrueColumn, matchingLines: 1, occurrences: 1},
+	{path: "experiments/colgranule/jsonbench_part_build_report.go", classification: typedStorageLegacyTrueColumn, matchingLines: 2, occurrences: 3},
+	{path: "experiments/colgranule/jsonbench_part_queries.go", classification: typedStorageLegacyTrueColumn, matchingLines: 9, occurrences: 9},
+	{path: "experiments/colgranule/jsonbench_test.go", classification: typedStorageLegacyTrueColumn, matchingLines: 2, occurrences: 4},
+	{path: "experiments/colgranule/mutation_adapter.go", classification: typedStorageLegacyTrueColumn, matchingLines: 3, occurrences: 3},
+	{path: "experiments/colgranule/mutation_adapter_test.go", classification: typedStorageLegacyTrueColumn, matchingLines: 5, occurrences: 5},
+	{path: "experiments/colgranule/part.go", classification: typedStorageLegacyTrueColumn, matchingLines: 24, occurrences: 26},
+	{path: "experiments/colgranule/part_accounting.go", classification: typedStorageLegacyTrueColumn, matchingLines: 4, occurrences: 4},
+	{path: "experiments/colgranule/part_accounting_test.go", classification: typedStorageLegacyTrueColumn, matchingLines: 1, occurrences: 1},
+	{path: "experiments/colgranule/part_image_decode.go", classification: typedStorageLegacyTrueColumn, matchingLines: 1, occurrences: 1},
+	{path: "experiments/colgranule/part_image_test.go", classification: typedStorageLegacyTrueColumn, matchingLines: 1, occurrences: 1},
+	{path: "experiments/colgranule/part_set.go", classification: typedStorageLegacyTrueColumn, matchingLines: 3, occurrences: 3},
+	{path: "experiments/colgranule/part_set_test.go", classification: typedStorageLegacyTrueColumn, matchingLines: 5, occurrences: 5},
+	{path: "experiments/colgranule/part_test.go", classification: typedStorageLegacyTrueColumn, matchingLines: 2, occurrences: 2},
+}
+
+type typedStorageLegacyNameUsage struct {
+	matchingLines int
+	occurrences   int
+}
+
+func typedStorageLegacyNamePatternText() string {
+	return "Column" + "Store|column " + "store|column-" + "store"
+}
+
+var typedStorageLegacyNamePattern = regexp.MustCompile(typedStorageLegacyNamePatternText())
+
+func scanTypedStorageLegacyNameUsage(t *testing.T) map[string]typedStorageLegacyNameUsage {
+	t.Helper()
+	repoRoot := typedStorageRepoRoot(t)
+	roots := []string{"TreeDB", "docs", "experiments"}
+	usage := make(map[string]typedStorageLegacyNameUsage)
+	for _, root := range roots {
+		rootPath := filepath.Join(repoRoot, root)
+		if _, err := os.Stat(rootPath); err != nil {
+			t.Fatalf("stat legacy-name scan root %s: %v", rootPath, err)
+		}
+		err := filepath.WalkDir(rootPath, func(path string, d fs.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
+			}
+			if d.IsDir() {
+				switch d.Name() {
+				case ".git", "node_modules", "vendor":
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			data, err := os.ReadFile(path)
+			if err != nil {
+				return err
+			}
+			if !utf8.Valid(data) {
+				return nil
+			}
+			rel, err := filepath.Rel(repoRoot, path)
+			if err != nil {
+				return err
+			}
+			var current typedStorageLegacyNameUsage
+			for _, line := range strings.Split(string(data), "\n") {
+				matches := typedStorageLegacyNamePattern.FindAllStringIndex(line, -1)
+				if len(matches) == 0 {
+					continue
+				}
+				current.matchingLines++
+				current.occurrences += len(matches)
+			}
+			if current.matchingLines > 0 {
+				usage[filepath.ToSlash(rel)] = current
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("walk legacy-name scan root %s: %v", rootPath, err)
+		}
+	}
+	return usage
+}
+
+var typedStorageMarkdownReferencePatterns = []*regexp.Regexp{
+	regexp.MustCompile(`\[[^\]]+\]\(([^)\s#?]+\.md)(?:#[^)]*)?\)`),
+	regexp.MustCompile("`([^`\\s]+\\.md)`"),
+}
+
+func typedStorageMarkdownReferences(content string) []string {
+	seen := make(map[string]struct{})
+	var refs []string
+	for _, pattern := range typedStorageMarkdownReferencePatterns {
+		for _, match := range pattern.FindAllStringSubmatch(content, -1) {
+			if len(match) < 2 {
+				continue
+			}
+			ref := strings.TrimSpace(match[1])
+			if ref == "" {
+				continue
+			}
+			if _, ok := seen[ref]; ok {
+				continue
+			}
+			seen[ref] = struct{}{}
+			refs = append(refs, ref)
+		}
+	}
+	sort.Strings(refs)
+	return refs
+}
+
+func typedStorageMarkdownReferenceResolves(repoRoot, baseDir, ref string) bool {
+	ref = strings.TrimSpace(ref)
+	ref = strings.TrimSuffix(ref, ".")
+	ref = strings.TrimSuffix(ref, ",")
+	ref = strings.TrimSuffix(ref, ";")
+	ref = strings.TrimPrefix(ref, "./")
+	if idx := strings.IndexByte(ref, '#'); idx >= 0 {
+		ref = ref[:idx]
+	}
+	var candidate string
+	slashRef := filepath.FromSlash(ref)
+	if filepath.IsAbs(slashRef) {
+		candidate = slashRef
+	} else if strings.HasPrefix(ref, "TreeDB/") || strings.HasPrefix(ref, "docs/") || strings.HasPrefix(ref, "experiments/") {
+		candidate = filepath.Join(repoRoot, slashRef)
+	} else {
+		candidate = filepath.Join(baseDir, slashRef)
+	}
+	if strings.ContainsAny(candidate, "*?[") {
+		matches, err := filepath.Glob(candidate)
+		return err == nil && len(matches) > 0
+	}
+	info, err := os.Stat(candidate)
+	return err == nil && !info.IsDir()
 }

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -412,16 +412,20 @@ func scanTypedStorageLegacyNameUsage(t *testing.T) map[string]typedStorageLegacy
 				}
 				return nil
 			}
+			rel, err := filepath.Rel(repoRoot, path)
+			if err != nil {
+				return err
+			}
+			rel = filepath.ToSlash(rel)
+			if typedStorageLegacyNameScanSkipsGeneratedArtifact(rel) {
+				return nil
+			}
 			data, err := os.ReadFile(path)
 			if err != nil {
 				return err
 			}
 			if !utf8.Valid(data) {
 				return nil
-			}
-			rel, err := filepath.Rel(repoRoot, path)
-			if err != nil {
-				return err
 			}
 			var current typedStorageLegacyNameUsage
 			for _, line := range strings.Split(string(data), "\n") {
@@ -433,7 +437,7 @@ func scanTypedStorageLegacyNameUsage(t *testing.T) map[string]typedStorageLegacy
 				current.occurrences += len(matches)
 			}
 			if current.matchingLines > 0 {
-				usage[filepath.ToSlash(rel)] = current
+				usage[rel] = current
 			}
 			return nil
 		})
@@ -442,6 +446,13 @@ func scanTypedStorageLegacyNameUsage(t *testing.T) map[string]typedStorageLegacy
 		}
 	}
 	return usage
+}
+
+func typedStorageLegacyNameScanSkipsGeneratedArtifact(rel string) bool {
+	// CI test/race jobs write transient JSONL output under TreeDB before package
+	// tests run. The contract is over repository sources matched by the audit
+	// command in a clean checkout, not generated run logs.
+	return strings.HasPrefix(rel, "TreeDB/treedb-") && strings.HasSuffix(rel, ".jsonl")
 }
 
 var typedStorageMarkdownReferencePatterns = []*regexp.Regexp{

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
-	"runtime"
 	"sort"
 	"strings"
 	"testing"
@@ -15,11 +15,21 @@ import (
 
 func typedStorageRepoRoot(t *testing.T) string {
 	t.Helper()
-	_, thisFile, _, ok := runtime.Caller(0)
-	if !ok {
-		t.Fatalf("runtime.Caller failed")
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get working directory: %v", err)
 	}
-	return filepath.Clean(filepath.Join(filepath.Dir(thisFile), "..", ".."))
+	for dir := filepath.Clean(wd); ; dir = filepath.Dir(dir) {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			if _, err := os.Stat(filepath.Join(dir, "TreeDB", "docs", "spec", "typed-storage-naming.md")); err == nil {
+				return dir
+			}
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("find repo root from %s: go.mod with typed-storage spec not found", wd)
+		}
+	}
 }
 
 func readTypedStorageNamingDoc(t *testing.T) string {
@@ -396,6 +406,55 @@ func scanTypedStorageLegacyNameUsage(t *testing.T) map[string]typedStorageLegacy
 	repoRoot := typedStorageRepoRoot(t)
 	roots := []string{"TreeDB", "docs", "experiments"}
 	usage := make(map[string]typedStorageLegacyNameUsage)
+	for _, rel := range typedStorageLegacyNameScanFiles(t, repoRoot, roots) {
+		if typedStorageLegacyNameScanSkipsGeneratedArtifact(rel) {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(repoRoot, filepath.FromSlash(rel)))
+		if err != nil {
+			t.Fatalf("read legacy-name scan file %s: %v", rel, err)
+		}
+		if !utf8.Valid(data) {
+			continue
+		}
+		var current typedStorageLegacyNameUsage
+		for _, line := range strings.Split(string(data), "\n") {
+			matches := typedStorageLegacyNamePattern.FindAllStringIndex(line, -1)
+			if len(matches) == 0 {
+				continue
+			}
+			current.matchingLines++
+			current.occurrences += len(matches)
+		}
+		if current.matchingLines > 0 {
+			usage[rel] = current
+		}
+	}
+	return usage
+}
+
+func typedStorageLegacyNameScanFiles(t *testing.T, repoRoot string, roots []string) []string {
+	t.Helper()
+	args := append([]string{"-C", repoRoot, "ls-files", "-z", "--"}, roots...)
+	out, err := exec.Command("git", args...).Output()
+	if err == nil && len(out) > 0 {
+		parts := strings.Split(string(out), "\x00")
+		files := make([]string, 0, len(parts))
+		for _, part := range parts {
+			if part == "" {
+				continue
+			}
+			files = append(files, filepath.ToSlash(part))
+		}
+		sort.Strings(files)
+		return files
+	}
+	return typedStorageLegacyNameWalkFiles(t, repoRoot, roots)
+}
+
+func typedStorageLegacyNameWalkFiles(t *testing.T, repoRoot string, roots []string) []string {
+	t.Helper()
+	var files []string
 	for _, root := range roots {
 		rootPath := filepath.Join(repoRoot, root)
 		if _, err := os.Stat(rootPath); err != nil {
@@ -410,42 +469,27 @@ func scanTypedStorageLegacyNameUsage(t *testing.T) map[string]typedStorageLegacy
 				case ".git", "node_modules", "vendor":
 					return filepath.SkipDir
 				}
+				if strings.HasPrefix(d.Name(), ".") {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			if strings.HasPrefix(d.Name(), ".") {
 				return nil
 			}
 			rel, err := filepath.Rel(repoRoot, path)
 			if err != nil {
 				return err
 			}
-			rel = filepath.ToSlash(rel)
-			if typedStorageLegacyNameScanSkipsGeneratedArtifact(rel) {
-				return nil
-			}
-			data, err := os.ReadFile(path)
-			if err != nil {
-				return err
-			}
-			if !utf8.Valid(data) {
-				return nil
-			}
-			var current typedStorageLegacyNameUsage
-			for _, line := range strings.Split(string(data), "\n") {
-				matches := typedStorageLegacyNamePattern.FindAllStringIndex(line, -1)
-				if len(matches) == 0 {
-					continue
-				}
-				current.matchingLines++
-				current.occurrences += len(matches)
-			}
-			if current.matchingLines > 0 {
-				usage[rel] = current
-			}
+			files = append(files, filepath.ToSlash(rel))
 			return nil
 		})
 		if err != nil {
 			t.Fatalf("walk legacy-name scan root %s: %v", rootPath, err)
 		}
 	}
-	return usage
+	sort.Strings(files)
+	return files
 }
 
 func typedStorageLegacyNameScanSkipsGeneratedArtifact(rel string) bool {

--- a/TreeDB/docs/spec/typed-storage-naming.md
+++ b/TreeDB/docs/spec/typed-storage-naming.md
@@ -30,6 +30,26 @@ Authoritative field owners are only:
 `derived_accelerator` is a classification only. It is not an authoritative field
 owner and must not silently become a second source of truth for a logical field.
 
+## Code Vocabulary Contract
+
+The naming regression tests compare this table to Go constants so docs cannot
+drift from the runtime vocabulary strings.
+
+| Go symbol or alias | Documented string | Scope |
+| --- | --- | --- |
+| `TypedStorageOwnerRetainedDocument` | `retained_document` | Authoritative retained-document owner. |
+| `document_payload` alias | `document_payload` | Retained-payload/document-owner wording. |
+| `TypedStorageOwnerRowAsset` | `typed_row_asset` | Authoritative typed-row asset owner. |
+| `TypedStorageOwnerColumnPart` | `typed_column_part` | Authoritative typed-column part owner. |
+| `TypedStorageAssetClassDerivedAccelerator` | `derived_accelerator` | Non-authoritative sidecar classification. |
+| `ColumnStoreValueBool` | `bool` | Legacy public declared-type compatibility name. |
+| `ColumnStoreValueInt64` | `int64` | Legacy public declared-type compatibility name. |
+| `ColumnStoreValueFloat32` | `float32` | Legacy public declared-type compatibility name. |
+| `ColumnStoreValueDouble` | `double` | Legacy public declared-type compatibility name; docs may also say `float64`. |
+| `ColumnStoreValueString` | `string` | Legacy public declared-type compatibility name. |
+| `ColumnStoreValueFloat32Vector` | `float32_vector` | Legacy public declared-type compatibility name. |
+| `ColumnStoreValueAdjacencyList` | `adjacency_list` | Legacy public declared-type compatibility name. |
+
 ## PR 1 Layout Resolver Contract
 
 Issue #1751 adds the pure-metadata resolver surface that turns collection
@@ -136,6 +156,11 @@ The repository currently has many legacy `ColumnStore*`, "column store", and
 that touches a specific legacy occurrence must include the exact touched
 occurrence in its PR inventory.
 
+`TestTypedStorageLegacyNameAllowlistIsComplete` is the executable inventory for
+this contract: every match from the audit command must map to one of the
+classifications below, and line/occurrence count drift must update the
+classification explanation in the PR.
+
 | Path | Symbol/text | Current meaning | Classification | Action | Deferral reason |
 | --- | --- | --- | --- | --- | --- |
 | `TreeDB/collections/api.go` | `ColumnStoreConfig`, `ColumnStoreColumn`, `ColumnStoreValueType`, retained-payload options | Public compatibility configuration for declared typed fields and retained payload behavior. | compatibility-retained | Keep as compatibility input normalized by the typed-storage layout resolver. | Public API compatibility; do not remove in PR 2. |
@@ -160,3 +185,12 @@ This naming scaffold must preserve existing runtime behavior:
 - no query planner change;
 - no production data-path behavior change;
 - no #1736 resource-manager behavior change.
+
+## Naming Regression Test Boundary
+
+Issue #1773 adds regression coverage for this naming contract only. It is
+limited to docs, tests, and process evidence: repo-scan allowlist updates,
+spec link checks, and code-vocabulary alignment checks. A future exception that
+needs production behavior, public API, storage format, query planning, or
+publication changes must move to a separate implementation tracker and document
+why this naming guard is insufficient.


### PR DESCRIPTION
## Summary

Lands the #1773 typed-storage naming contract regression tests.

Changes:
- adds an executable legacy-name allowlist for every current `ColumnStore|column store|column-store` match under tracked `TreeDB`, `docs`, and `experiments` sources;
- adds spec/README markdown reference validation for the typed-storage naming docs;
- ties documented typed-storage vocabulary to Go constants, including owner strings, derived-accelerator class, and declared value-type compatibility constants;
- documents and tests the #1773 docs/tests/process-only boundary.

## Linked trackers

- Resolves #1773
- Parent tracker: #1744

## Scope boundary

Docs/tests only. No production behavior, public API removal, on-disk format, query planner, publication, typed-column adapter, layout resolver, fuzz/corruption, or durability behavior changes.

## Start-phase audit command

```sh
rg -n "ColumnStore|column store|column-store" TreeDB docs experiments
```

I reviewed the current matches before implementation and kept the change limited to the naming spec plus its regression tests.

## Legacy-name allowlist explanation

`TestTypedStorageLegacyNameAllowlistIsComplete` is the exact executable inventory. Each entry records a path, classification, matching-line count, and occurrence count so new or changed legacy-name matches fail until classified. The test scans tracked repository sources, matching the clean-checkout audit contract and avoiding generated CI/test logs.

Classification rationale for the new allowlist entries:

- `compatibility-retained`: existing public/config names, current typed-row control-plane names, command-WAL/publish/query compatibility tests, adapter/publication seams that still consume legacy public metadata, and the naming spec/test itself.
- `derived accelerator`: dictionary-code, int64-values, aggregate metadata, vector graph, vector index metadata/rebuild, and related query/reader files that are non-authoritative sidecars over typed-storage owners.
- `deferred`: current `column_physical_*` typed-row implementation names and historical/planning docs whose broad wording is intentionally deferred to later cleanup/rewrite work.
- `true typed-column terminology`: `experiments/colgranule/**`, which remains the coherent experimental typed-column data-plane source terminology.

## Close-phase audit/test evidence

Latest head: `6c8f73edbcfe789213f7e3bfc5b1f51de0becab6`.

```sh
rg -n "ColumnStore|column store|column-store" TreeDB docs experiments >/tmp/typed_storage_legacy_audit.txt && wc -l /tmp/typed_storage_legacy_audit.txt
# 2022 /tmp/typed_storage_legacy_audit.txt

git diff --check

go test -count=1 -trimpath ./TreeDB/collections -run TestTypedStorage

printf 'ColumnStore synthetic generated log\n' > TreeDB/treedb-test.jsonl
go test -count=1 ./TreeDB/collections -run TestTypedStorageLegacyNameAllowlistIsComplete
rm -f TreeDB/treedb-test.jsonl

go test -count=1 ./TreeDB/collections -run TestTypedStorage

go test -count=1 ./TreeDB/docs ./TreeDB/collections
```

Latest local results: all commands pass.

## CI status

Latest-head GitHub checks for `6c8f73edbcfe789213f7e3bfc5b1f51de0becab6` are green, and `mergeStateStatus=CLEAN`.

## Benchmarks

Not run; this is docs/tests-only with no production hot-path changes.

## AI review status

- Codex: latest re-review on `6c8f73edbcfe789213f7e3bfc5b1f51de0becab6` found no major issues. Two earlier Codex findings were fixed and their threads are resolved.
- CodeRabbit: latest status is passing / no actionable comments. Its docstring pre-merge warning is non-blocking for unexported test helpers.
- Copilot: re-requested after latest head; Copilot reviewer encountered an error again and is treated as unavailable.

## Unresolved threads / risks / deferrals

- Unresolved threads: none.
- Risks: allowlist count drift is intentionally strict; future legitimate removals/additions must update the classification entry and PR explanation.
- Deferrals: public API wrapper/deprecation plan, umbrella naming compatibility expansion (#1775), layout resolver matrix (#1774), typed-column data-plane fuzz/corruption (#1776), adapter edge/corruption tests (#1777), and durable scalar publication correctness (#1778).

Not merged by this PR author/manager.
