### PR TITLE
Avoid eager row-locator decode in int64 typed-column scans

### DIFF
--- a/TreeDB/collections/typed_column_adapter.go
+++ b/TreeDB/collections/typed_column_adapter.go
@@ -280,6 +280,22 @@ func typedColumnAdapterPartFromImage(opts typedColumnAdapterOptions, image typed
 	if err != nil {
 		return nil, err
 	}
+	return typedColumnAdapterPartFromDecodedImage(opts, image, part)
+}
+
+func typedColumnAdapterPartFromImageForInt64PredicateScan(opts typedColumnAdapterOptions, image typedcolumn.ColumnPartImage) (*typedColumnAdapterPart, error) {
+	part, err := typedcolumn.ColumnPartFromImageWithOptions(image, typedcolumn.ColumnPartImageReadOptions{
+		IncludeRowLocators:       false,
+		ValidateRowLocators:      false,
+		IncludeAggregateMetadata: false,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return typedColumnAdapterPartFromDecodedImage(opts, image, part)
+}
+
+func typedColumnAdapterPartFromDecodedImage(opts typedColumnAdapterOptions, image typedcolumn.ColumnPartImage, part *typedcolumn.ColumnPart) (*typedColumnAdapterPart, error) {
 	columns, err := typedColumnAdapterColumnsForFields(opts.Fields)
 	if err != nil {
 		return nil, err
@@ -739,7 +755,7 @@ func typedColumnAdapterPrepareInt64PredicateScanPart(fields []TypedStorageField,
 	if image.PartID != refPartID || image.Rows != typedRows || image.Rows != physicalRows {
 		return nil, typedColumnAdapterColumn{}, 0, fmt.Errorf("collections: typed_column_part image/ref mismatch image_part=%d ref_part=%d image_rows=%d typed_manifest_rows=%d physical_rows=%d", image.PartID, refPartID, image.Rows, typedRows, physicalRows)
 	}
-	adapterPart, err := typedColumnAdapterPartFromImage(typedColumnAdapterOptions{Fields: fields}, image)
+	adapterPart, err := typedColumnAdapterPartFromImageForInt64PredicateScan(typedColumnAdapterOptions{Fields: fields}, image)
 	if err != nil {
 		return nil, typedColumnAdapterColumn{}, 0, err
 	}

--- a/TreeDB/collections/typed_column_int64_scan_test.go
+++ b/TreeDB/collections/typed_column_int64_scan_test.go
@@ -27,6 +27,55 @@ func TestTypedColumnInt64ScanEqualityPredicate(t *testing.T) {
 	}
 }
 
+func TestTypedColumnInt64ScanEqualityPredicateSkipsRowLocators(t *testing.T) {
+	d, col := setupTypedColumnInt64ScanCollection(t)
+	defer func() { _ = d.Close() }()
+	values := []int64{10, 20, 30, 20}
+	insertTypedColumnInt64ScanRows(t, col, values)
+
+	runResult, err := col.RunTypedColumnInt64PredicateScan(TypedColumnInt64PredicateScanRequest{Column: "time_us", Kind: TypedColumnInt64PredicateEqual, Value: 20})
+	if err != nil {
+		t.Fatalf("RunTypedColumnInt64PredicateScan: %v", err)
+	}
+	assertTypedColumnInt64ScanValues(t, runResult, []int64{20, 20})
+	if runResult.Diagnostics.Fallback {
+		t.Fatalf("diagnostics=%+v want direct typed-column path", runResult.Diagnostics)
+	}
+
+	typedRefs := typedColumnPartRefs1755(columnManifestAssetRefsForCollectionM12A(t, d, col))
+	if len(typedRefs) != 1 {
+		t.Fatalf("typed refs=%+v want one", typedRefs)
+	}
+	raw, err := readColumnPhysicalAssetFromManager(d.ColumnAssetRootDir(), typedRefs[0])
+	if err != nil {
+		t.Fatalf("read typed-column part: %v", err)
+	}
+	fields := []TypedStorageField{{Name: "time_us", Path: "time_us", ValueType: "int64", Owner: TypedStorageOwnerColumnPart}}
+	generic, err := typedColumnAdapterPartFromBytes(typedColumnAdapterOptions{Fields: fields}, raw)
+	if err != nil {
+		t.Fatalf("typedColumnAdapterPartFromBytes: %v", err)
+	}
+	if got := len(generic.Part.Locators); got != len(values) {
+		t.Fatalf("generic locator count=%d want %d", got, len(values))
+	}
+	prepared, adapterColumn, _, err := typedColumnAdapterPrepareInt64PredicateScanPart(fields, raw, typedRefs[0].PartID, len(values), len(values), uint64(generic.Part.Descriptor.SchemaVersion), "time_us")
+	if err != nil {
+		t.Fatalf("typedColumnAdapterPrepareInt64PredicateScanPart: %v", err)
+	}
+	if prepared.Part.Locators != nil {
+		t.Fatalf("int64 predicate scan locators loaded: len=%d want nil", len(prepared.Part.Locators))
+	}
+	var scanResult TypedColumnInt64PredicateScanResult
+	partPruned, err := scanTypedColumnInt64PredicatePart(prepared.Part, adapterColumn.Definition.Name, TypedColumnInt64PredicateScanRequest{Column: "time_us", Kind: TypedColumnInt64PredicateEqual, Value: 20}, typedRefs[0].Generation, typedRefs[0].PartID, &scanResult)
+	if err != nil {
+		t.Fatalf("scanTypedColumnInt64PredicatePart: %v", err)
+	}
+	if partPruned {
+		t.Fatalf("partPruned=true want decoded matches")
+	}
+	assertTypedColumnInt64ScanValues(t, scanResult, []int64{20, 20})
+}
+
 func TestTypedColumnInt64ScanRangePredicate(t *testing.T) {
 	d, col := setupTypedColumnInt64ScanCollection(t)
 	defer func() { _ = d.Close() }()


### PR DESCRIPTION
## Linked tracker issue and scope boundary

Closes #1802. Parent tracker: #1791.

This PR keeps the typed-column on-disk format and write/publication paths unchanged. It only adds a narrow `RunTypedColumnInt64PredicateScan` decode path that parses typed-column parts without eager row-locator or aggregate-metadata materialization. Generic `typedColumnAdapterPartFromImage` still uses the default locator-validating decode for callers that need full reconstruction/publication validation.

## Start-phase test plan

- Focused existing int64 predicate scan correctness/fail-closed tests.
- Package-level `./TreeDB/collections` after implementation.
- Broader `./TreeDB/...` before closeout.

## Start-phase performance/profile plan

- Baseline `BenchmarkTypedColumnInt64PredicateScan/typed_column_part` on `origin/main` with `-benchmem -benchtime=3000x -count=5`.
- Closeout benchmark with the same command on this PR head.
- CPU and allocation profile with the required profile command, checking that `decodeRowLocatorsSection` is removed from the direct scan hot path.

## What changed

- Added `typedColumnAdapterPartFromImageForInt64PredicateScan`, using `typedcolumn.ColumnPartFromImageWithOptions` with row locators and aggregate metadata excluded.
- Wired only `typedColumnAdapterPrepareInt64PredicateScanPart` / direct int64 predicate scan to that helper.
- Added `TestTypedColumnInt64ScanEqualityPredicateSkipsRowLocators` to prove the generic path still loads locators while the scan-specific prepare/scan path leaves `Part.Locators` nil and still matches rows.

## Close-phase test evidence

```sh
go test -count=1 ./TreeDB/collections -run 'TestTypedColumnInt64Scan(EqualityPredicate|RangePredicate|PrunesWithMinMaxMetadata|AllPrunedNoMatch|StaleMetadataFailsClosed|ManifestSetupMismatchFailsClosed|Reopen)'
go test -count=1 ./TreeDB/collections
go test -count=1 ./TreeDB/...
```

All passed locally on Apple M3 / darwin arm64.

## Close-phase benchmark evidence

Command:

```sh
go test -run '^$' -bench '^BenchmarkTypedColumnInt64PredicateScan/typed_column_part$' -benchmem -benchtime=3000x -count=5 ./TreeDB/collections
```

| Version | ns/op avg (min..max) | ops/sec avg | B/op avg | allocs/op | rows_scanned/op | parts_pruned/op | blocks_pruned/op | decoded_bytes/op | mapped_bytes/op |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| `origin/main` baseline | 479,406 (476,541..482,327) | 2,087 | 1,105,602 | 323 | 4096 | 1 | 1 | 36,864 | 529,722 |
| PR head | 188,221 (182,756..195,857) | 5,321 | 113,547 | 283 | 4096 | 1 | 1 | 36,864 | 529,722 |

Profile-run sample on PR head:

```text
BenchmarkTypedColumnInt64PredicateScan/typed_column_part-8  3000  197100 ns/op  5077 ops/sec  113544 B/op  283 allocs/op
```

## CPU profile summary

Profile command:

```sh
go test -run '^$' -bench '^BenchmarkTypedColumnInt64PredicateScan/typed_column_part$' -benchmem -benchtime=3000x -count=1 -cpuprofile /tmp/typedscan_lazy_locator_cpu.pprof -memprofile /tmp/typedscan_lazy_locator_mem.pprof ./TreeDB/collections
```

Baseline profile artifact from the pre-change path showed:

- `decodeRowLocatorsSection`: 0.41s cumulative CPU.
- `typedColumnAdapterPrepareInt64PredicateScanPart`: 0.67s cumulative CPU.

PR-head profile showed:

- `decodeRowLocatorsSection` no longer appears in CPU top output.
- `typedColumnAdapterPrepareInt64PredicateScanPart`: 70ms cumulative CPU in the profile run.
- Remaining direct-scan costs are mostly physical row-id lookup, manifest/cache/checksum/open-close work, and int64 payload decode.

## Allocation profile summary

Baseline allocation profile showed:

- `decodeRowLocatorsSection`: 2,653.93MB allocated over the profile run (77.25%).
- `typedColumnAdapterPrepareInt64PredicateScanPart`: 2,884.50MB cumulative allocation.

PR-head allocation profile showed:

- `decodeRowLocatorsSection` no longer appears in allocation top output.
- `typedColumnAdapterPrepareInt64PredicateScanPart`: 29.51MB cumulative allocation.
- Remaining allocations are dominated by int64 payload decode, benchmark setup/opening, and physical-row/result work.

## Latest-head CI

Latest pushed head: `0fd0c44975f67608f9834420c4e9fe2eaaf1df79`. GitHub checks are green on latest head, including TreeDB vet+test, root vet+test, unified bench gates, read-snapshot guardrail, HashDB Windows, redisserver protocol bench, and format.

## AI review status and unresolved thread summary

- Codex: requested with `@codex review`; result: no major issues.
- CodeRabbit: auto-review plus `@coderabbitai review`; result: no actionable comments / check passed (review skipped after no new actionable incremental findings).
- Copilot: requested twice with `@copilot review` and via GitHub reviewer request; Copilot returned an infrastructure error (`Copilot encountered an error and was unable to review this pull request`) and did not provide actionable findings.
- Review threads: GraphQL review-thread inventory returned zero review threads.

## Risks / deferred work

- This intentionally does not remove row locators from written typed-column assets.
- This does not change generic typed-column reconstruction/publication validation.
- Deferred follow-ups remain cached scan handles, unsafe/direct int64 views, mmap/cache reuse, count-only APIs, string/dictionary/aggregate/vector graph work, and #1788 row+column COW maintenance.
