### PR TITLE
treedb: expand typed-column aggregate benchmark matrix

### DIFF
--- a/TreeDB/collections/typed_column_int64_scan.go
+++ b/TreeDB/collections/typed_column_int64_scan.go
@@ -12,6 +12,7 @@ import (
 type TypedColumnInt64PredicateScanKind string
 
 const (
+	TypedColumnInt64PredicateAll   TypedColumnInt64PredicateScanKind = "all"
 	TypedColumnInt64PredicateEqual TypedColumnInt64PredicateScanKind = "equal"
 	TypedColumnInt64PredicateRange TypedColumnInt64PredicateScanKind = "range"
 )
@@ -237,6 +238,7 @@ func validateTypedColumnInt64PredicateScanRequest(req TypedColumnInt64PredicateS
 		return errors.New("collections: typed-column int64 predicate scan requires column")
 	}
 	switch req.Kind {
+	case TypedColumnInt64PredicateAll:
 	case TypedColumnInt64PredicateEqual:
 	case TypedColumnInt64PredicateRange:
 		if req.Low > req.High {
@@ -537,6 +539,8 @@ func typedColumnInt64PredicatePhysicalRowIDs(raw []byte, ref ColumnAssetRef, col
 
 func typedColumnInt64PredicateMayMatch(req TypedColumnInt64PredicateScanRequest, minValue, maxValue int64) bool {
 	switch req.Kind {
+	case TypedColumnInt64PredicateAll:
+		return true
 	case TypedColumnInt64PredicateEqual:
 		return req.Value >= minValue && req.Value <= maxValue
 	case TypedColumnInt64PredicateRange:
@@ -548,6 +552,8 @@ func typedColumnInt64PredicateMayMatch(req TypedColumnInt64PredicateScanRequest,
 
 func typedColumnInt64PredicateMatches(req TypedColumnInt64PredicateScanRequest, value int64) bool {
 	switch req.Kind {
+	case TypedColumnInt64PredicateAll:
+		return true
 	case TypedColumnInt64PredicateEqual:
 		return value == req.Value
 	case TypedColumnInt64PredicateRange:

--- a/TreeDB/collections/typed_column_int64_scan_test.go
+++ b/TreeDB/collections/typed_column_int64_scan_test.go
@@ -95,6 +95,22 @@ func TestTypedColumnInt64ScanRangePredicate(t *testing.T) {
 	}
 }
 
+func TestTypedColumnInt64ScanAllPredicate(t *testing.T) {
+	d, col := setupTypedColumnInt64ScanCollection(t)
+	defer func() { _ = d.Close() }()
+	insertTypedColumnInt64ScanRows(t, col, []int64{5, 10, 15})
+	insertTypedColumnInt64ScanRows(t, col, []int64{20, 25})
+
+	result, err := col.RunTypedColumnInt64PredicateScan(TypedColumnInt64PredicateScanRequest{Column: "time_us", Kind: TypedColumnInt64PredicateAll})
+	if err != nil {
+		t.Fatalf("RunTypedColumnInt64PredicateScan all: %v", err)
+	}
+	assertTypedColumnInt64ScanValues(t, result, []int64{5, 10, 15, 20, 25})
+	if result.Diagnostics.RowsScanned != 5 || result.Diagnostics.RowsMatched != 5 || result.Diagnostics.PartsPruned != 0 {
+		t.Fatalf("diagnostics=%+v want full scan over all rows", result.Diagnostics)
+	}
+}
+
 func TestTypedColumnInt64ScanPrunesWithMinMaxMetadata(t *testing.T) {
 	d, col := setupTypedColumnInt64ScanCollection(t)
 	defer func() { _ = d.Close() }()
@@ -880,23 +896,24 @@ func runTypedColumnInt64AggregateBenchPath(b *testing.B, rows int, dist typedCol
 		if typedPath {
 			req.ColumnAssetReadIntegrity = ColumnAssetReadIntegrityCachedVerify
 		}
+		b.StopTimer()
 		b.ReportAllocs()
 		b.ResetTimer()
 		reportTypedColumnInt64AggregateBenchSetupMetrics(b, setupMetrics)
-		benchStart := time.Now()
+		b.StartTimer()
+		var result TypedColumnInt64PredicateAggregateResult
+		var runErr error
 		for i := 0; i < b.N; i++ {
-			result, err := col.RunTypedColumnInt64PredicateAggregate(req)
-			if err != nil {
-				b.Fatalf("RunTypedColumnInt64PredicateAggregate: %v", err)
-			}
-			if result.Count != expected.count || result.Sum != expected.sum || result.Avg != expected.avg {
-				b.Fatalf("aggregate count=%d sum=%d avg=%f want count=%d sum=%d avg=%f diagnostics=%+v", result.Count, result.Sum, result.Avg, expected.count, expected.sum, expected.avg, result.Diagnostics)
-			}
-			if i == b.N-1 {
-				reportTypedColumnInt64AggregateBenchMetrics(b, rows, result.Diagnostics, time.Since(benchStart), b.N)
-			}
+			result, runErr = col.RunTypedColumnInt64PredicateAggregate(req)
 		}
 		b.StopTimer()
+		if runErr != nil {
+			b.Fatalf("RunTypedColumnInt64PredicateAggregate: %v", runErr)
+		}
+		if result.Count != expected.count || result.Sum != expected.sum || result.Avg != expected.avg {
+			b.Fatalf("aggregate count=%d sum=%d avg=%f want count=%d sum=%d avg=%f diagnostics=%+v", result.Count, result.Sum, result.Avg, expected.count, expected.sum, expected.avg, result.Diagnostics)
+		}
+		reportTypedColumnInt64AggregateBenchMetrics(b, rows, result.Diagnostics, b.Elapsed(), b.N)
 	})
 }
 

--- a/TreeDB/collections/typed_column_int64_scan_test.go
+++ b/TreeDB/collections/typed_column_int64_scan_test.go
@@ -733,6 +733,30 @@ func TestTypedColumnInt64AggregateBenchDistributionDeterminism(t *testing.T) {
 	}
 }
 
+func TestTypedColumnInt64AggregateBenchRandomUniformScattersPowerOfTwoRows(t *testing.T) {
+	const rows = 1024
+	values := typedColumnInt64AggregateBenchValues(rows, typedColumnInt64AggregateBenchDistributionByName("random_uniform"))
+	seen := make(map[int64]struct{}, rows)
+	for _, value := range values {
+		seen[value] = struct{}{}
+	}
+	if len(seen) != rows {
+		t.Fatalf("random_uniform produced %d unique values, want permutation of %d rows", len(seen), rows)
+	}
+	minValue, maxValue := values[0], values[0]
+	for _, value := range values[:32] {
+		if value < minValue {
+			minValue = value
+		}
+		if value > maxValue {
+			maxValue = value
+		}
+	}
+	if maxValue-minValue < int64(rows/2) {
+		t.Fatalf("first random_uniform window min=%d max=%d does not scatter enough for pruning benchmark", minValue, maxValue)
+	}
+}
+
 func TestTypedColumnInt64AggregateBenchShapeExpectedAggregates(t *testing.T) {
 	const rows = 1000
 	values := typedColumnInt64AggregateBenchValues(rows, typedColumnInt64AggregateBenchDistributionByName("clustered_monotonic"))

--- a/TreeDB/collections/typed_column_int64_scan_test.go
+++ b/TreeDB/collections/typed_column_int64_scan_test.go
@@ -3,6 +3,7 @@ package collections
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -293,6 +294,22 @@ func TestTypedColumnInt64AggregateRangePredicate(t *testing.T) {
 	assertTypedColumnInt64Aggregate(t, result, 3, 45)
 	if result.Diagnostics.BlocksDecoded == 0 || result.Diagnostics.DecodedHeapCopyBytes == 0 || result.Diagnostics.DecodedMetadataBytes == 0 {
 		t.Fatalf("diagnostics=%+v want decoded block and metadata bytes", result.Diagnostics)
+	}
+}
+
+func TestTypedColumnInt64AggregateAllPredicate(t *testing.T) {
+	d, col := setupTypedColumnInt64ScanCollection(t)
+	defer func() { _ = d.Close() }()
+	insertTypedColumnInt64ScanRows(t, col, []int64{5, 10, 15})
+	insertTypedColumnInt64ScanRows(t, col, []int64{20, 25})
+
+	result, err := col.RunTypedColumnInt64PredicateAggregate(TypedColumnInt64PredicateAggregateRequest{Column: "time_us", Kind: TypedColumnInt64PredicateAll})
+	if err != nil {
+		t.Fatalf("RunTypedColumnInt64PredicateAggregate all: %v", err)
+	}
+	assertTypedColumnInt64Aggregate(t, result, 5, 75)
+	if result.Diagnostics.RowsScanned != 5 || result.Diagnostics.RowsMatched != 5 || result.Diagnostics.PartsPruned != 0 {
+		t.Fatalf("diagnostics=%+v want full aggregate over all rows", result.Diagnostics)
 	}
 }
 
@@ -592,114 +609,309 @@ func TestTypedColumnInt64AggregateFallbackDiagnostics(t *testing.T) {
 	})
 }
 
-func TestTypedColumnInt64AggregateBenchRowCountParser(t *testing.T) {
-	for _, tc := range []struct {
-		name    string
-		input   string
-		want    []int
-		wantErr bool
-	}{
-		{name: "empty_defaults", input: "", want: []int{4096, 65536}},
-		{name: "list", input: "16, 32,64", want: []int{16, 32, 64}},
-		{name: "bad", input: "16,nope", wantErr: true},
-		{name: "non_positive", input: "0", wantErr: true},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			got, err := parseTypedColumnInt64AggregateBenchRows(tc.input)
-			if tc.wantErr {
-				if err == nil {
-					t.Fatalf("parseTypedColumnInt64AggregateBenchRows(%q) err=nil", tc.input)
+func TestTypedColumnInt64AggregateBenchParsers(t *testing.T) {
+	t.Run("rows", func(t *testing.T) {
+		for _, tc := range []struct {
+			name    string
+			input   string
+			large   bool
+			want    []int
+			wantErr string
+		}{
+			{name: "empty_defaults", input: "", want: []int{4096, 65536}},
+			{name: "list", input: "16, 32,64", want: []int{16, 32, 64}},
+			{name: "bad", input: "16,nope", wantErr: "invalid row count"},
+			{name: "non_positive", input: "0", wantErr: "must be positive"},
+			{name: "large_blocked", input: "10000000", wantErr: "TREEDB_TYPED_COLUMN_BENCH_LARGE=true"},
+			{name: "large_allowed", input: "10000000,50000000", large: true, want: []int{10000000, 50000000}},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				got, err := parseTypedColumnInt64AggregateBenchRows(tc.input, tc.large)
+				if tc.wantErr != "" {
+					if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+						t.Fatalf("parseTypedColumnInt64AggregateBenchRows(%q) err=%v want %q", tc.input, err, tc.wantErr)
+					}
+					return
 				}
-				return
+				if err != nil {
+					t.Fatalf("parseTypedColumnInt64AggregateBenchRows(%q): %v", tc.input, err)
+				}
+				if fmt.Sprint(got) != fmt.Sprint(tc.want) {
+					t.Fatalf("rows=%v want %v", got, tc.want)
+				}
+			})
+		}
+	})
+
+	t.Run("shapes", func(t *testing.T) {
+		got, err := parseTypedColumnInt64AggregateBenchShapes("")
+		if err != nil {
+			t.Fatalf("default shapes: %v", err)
+		}
+		if gotNames := typedColumnInt64AggregateBenchShapeNames(got); fmt.Sprint(gotNames) != fmt.Sprint([]string{"selective_range_1pct", "all_pruned_no_match", "all_match"}) {
+			t.Fatalf("default shapes=%v", gotNames)
+		}
+		got, err = parseTypedColumnInt64AggregateBenchShapes("no_filter_full_aggregate, exact_value,tail_range")
+		if err != nil {
+			t.Fatalf("explicit shapes: %v", err)
+		}
+		if gotNames := typedColumnInt64AggregateBenchShapeNames(got); fmt.Sprint(gotNames) != fmt.Sprint([]string{"no_filter_full_aggregate", "exact_value", "tail_range"}) {
+			t.Fatalf("explicit shapes=%v", gotNames)
+		}
+		if _, err := parseTypedColumnInt64AggregateBenchShapes("selective_range_1pct,nope"); err == nil || !strings.Contains(err.Error(), "invalid shape") {
+			t.Fatalf("invalid shape err=%v", err)
+		}
+	})
+
+	t.Run("distributions", func(t *testing.T) {
+		got, err := parseTypedColumnInt64AggregateBenchDistributions("")
+		if err != nil {
+			t.Fatalf("default dists: %v", err)
+		}
+		if gotNames := typedColumnInt64AggregateBenchDistributionNames(got); fmt.Sprint(gotNames) != fmt.Sprint([]string{"clustered_monotonic"}) {
+			t.Fatalf("default dists=%v", gotNames)
+		}
+		got, err = parseTypedColumnInt64AggregateBenchDistributions("reverse_monotonic,random_uniform,hotspot_skewed")
+		if err != nil {
+			t.Fatalf("explicit dists: %v", err)
+		}
+		if gotNames := typedColumnInt64AggregateBenchDistributionNames(got); fmt.Sprint(gotNames) != fmt.Sprint([]string{"reverse_monotonic", "random_uniform", "hotspot_skewed"}) {
+			t.Fatalf("explicit dists=%v", gotNames)
+		}
+		if _, err := parseTypedColumnInt64AggregateBenchDistributions("clustered_monotonic,nope"); err == nil || !strings.Contains(err.Error(), "invalid distribution") {
+			t.Fatalf("invalid dist err=%v", err)
+		}
+	})
+
+	t.Run("booleans_and_fallback_default", func(t *testing.T) {
+		for _, tc := range []struct {
+			input   string
+			def     bool
+			want    bool
+			wantErr bool
+		}{
+			{input: "", def: true, want: true},
+			{input: "false", def: true, want: false},
+			{input: "true", want: true},
+			{input: "not-bool", wantErr: true},
+		} {
+			got, err := parseTypedColumnInt64AggregateBenchBool("TEST_BOOL", tc.input, tc.def)
+			if tc.wantErr {
+				if err == nil || !strings.Contains(err.Error(), "TEST_BOOL") {
+					t.Fatalf("parse bool input=%q err=%v", tc.input, err)
+				}
+				continue
 			}
-			if err != nil {
-				t.Fatalf("parseTypedColumnInt64AggregateBenchRows(%q): %v", tc.input, err)
+			if err != nil || got != tc.want {
+				t.Fatalf("parse bool input=%q got=%v err=%v want=%v", tc.input, got, err, tc.want)
 			}
-			if fmt.Sprint(got) != fmt.Sprint(tc.want) {
-				t.Fatalf("rows=%v want %v", got, tc.want)
+		}
+		if !typedColumnInt64AggregateBenchIncludeFallback("", 4096) || !typedColumnInt64AggregateBenchIncludeFallback("", 65536) || typedColumnInt64AggregateBenchIncludeFallback("", 1048576) {
+			t.Fatalf("fallback default should include only default rows")
+		}
+		if !typedColumnInt64AggregateBenchIncludeFallback("true", 1048576) || typedColumnInt64AggregateBenchIncludeFallback("false", 4096) {
+			t.Fatalf("fallback explicit override failed")
+		}
+	})
+}
+
+func TestTypedColumnInt64AggregateBenchDistributionDeterminism(t *testing.T) {
+	const rows = 257
+	for _, dist := range typedColumnInt64AggregateBenchAllDistributions() {
+		t.Run(dist.name, func(t *testing.T) {
+			first := typedColumnInt64AggregateBenchValues(rows, dist)
+			second := typedColumnInt64AggregateBenchValues(rows, dist)
+			if fmt.Sprint(first) != fmt.Sprint(second) {
+				t.Fatalf("distribution is not deterministic")
+			}
+			for i, value := range first {
+				if value < 0 || value >= rows {
+					t.Fatalf("value[%d]=%d outside [0,%d)", i, value, rows)
+				}
 			}
 		})
+	}
+}
+
+func TestTypedColumnInt64AggregateBenchShapeExpectedAggregates(t *testing.T) {
+	const rows = 1000
+	values := typedColumnInt64AggregateBenchValues(rows, typedColumnInt64AggregateBenchDistributionByName("clustered_monotonic"))
+	for _, tc := range []struct {
+		shape     string
+		wantCount int64
+		wantSum   int64
+	}{
+		{shape: "no_filter_full_aggregate", wantCount: 1000, wantSum: 499500},
+		{shape: "exact_value", wantCount: 1, wantSum: 250},
+		{shape: "tiny_range", wantCount: 10, wantSum: 2545},
+		{shape: "selective_range_1pct", wantCount: 10, wantSum: 2545},
+		{shape: "wide_range_10pct", wantCount: 100, wantSum: 29950},
+		{shape: "all_pruned_no_match", wantCount: 0, wantSum: 0},
+		{shape: "all_match", wantCount: 1000, wantSum: 499500},
+		{shape: "tail_range", wantCount: 10, wantSum: 9945},
+	} {
+		t.Run(tc.shape, func(t *testing.T) {
+			shape := typedColumnInt64AggregateBenchShapeByName(tc.shape)
+			req := shape.request(rows)
+			got := expectedTypedColumnInt64AggregateBenchResult(values, req)
+			if got.count != tc.wantCount || got.sum != tc.wantSum {
+				t.Fatalf("expected count=%d sum=%d want count=%d sum=%d req=%+v", got.count, got.sum, tc.wantCount, tc.wantSum, req)
+			}
+		})
+	}
+
+	for _, dist := range typedColumnInt64AggregateBenchAllDistributions() {
+		values := typedColumnInt64AggregateBenchValues(rows, dist)
+		for _, shape := range typedColumnInt64AggregateBenchAllShapes() {
+			req := shape.request(rows)
+			expected := expectedTypedColumnInt64AggregateBenchResult(values, req)
+			var manual typedColumnInt64AggregateBenchExpected
+			for _, value := range values {
+				if typedColumnInt64PredicateMatches(typedColumnInt64PredicateAggregateScanRequest(req), value) {
+					manual.count++
+					manual.sum += value
+				}
+			}
+			manual.finish()
+			if expected != manual {
+				t.Fatalf("dist=%s shape=%s expected=%+v manual=%+v", dist.name, shape.name, expected, manual)
+			}
+		}
 	}
 }
 
 func BenchmarkTypedColumnInt64PredicateAggregate(b *testing.B) {
-	rowCounts, err := parseTypedColumnInt64AggregateBenchRows(os.Getenv("TREEDB_TYPED_COLUMN_BENCH_ROWS"))
+	large, err := parseTypedColumnInt64AggregateBenchBool("TREEDB_TYPED_COLUMN_BENCH_LARGE", os.Getenv("TREEDB_TYPED_COLUMN_BENCH_LARGE"), false)
+	if err != nil {
+		b.Fatal(err)
+	}
+	rowCounts, err := parseTypedColumnInt64AggregateBenchRows(os.Getenv("TREEDB_TYPED_COLUMN_BENCH_ROWS"), large)
 	if err != nil {
 		b.Fatalf("TREEDB_TYPED_COLUMN_BENCH_ROWS: %v", err)
 	}
+	shapes, err := parseTypedColumnInt64AggregateBenchShapes(os.Getenv("TREEDB_TYPED_COLUMN_BENCH_SHAPES"))
+	if err != nil {
+		b.Fatalf("TREEDB_TYPED_COLUMN_BENCH_SHAPES: %v", err)
+	}
+	dists, err := parseTypedColumnInt64AggregateBenchDistributions(os.Getenv("TREEDB_TYPED_COLUMN_BENCH_DISTS"))
+	if err != nil {
+		b.Fatalf("TREEDB_TYPED_COLUMN_BENCH_DISTS: %v", err)
+	}
+	includeFallbackEnv := os.Getenv("TREEDB_TYPED_COLUMN_BENCH_INCLUDE_FALLBACK")
+	if strings.TrimSpace(includeFallbackEnv) != "" {
+		if _, err := parseTypedColumnInt64AggregateBenchBool("TREEDB_TYPED_COLUMN_BENCH_INCLUDE_FALLBACK", includeFallbackEnv, false); err != nil {
+			b.Fatal(err)
+		}
+	}
+
 	for _, rows := range rowCounts {
 		rows := rows
-		values := make([]int64, rows)
-		for i := range values {
-			values[i] = int64(i)
+		for _, dist := range dists {
+			dist := dist
+			for _, shape := range shapes {
+				shape := shape
+				req := shape.request(rows)
+				expected := expectedTypedColumnInt64AggregateBenchResultForDistribution(rows, dist, req)
+				runTypedColumnInt64AggregateBenchPath(b, rows, dist, shape, req, expected, true)
+				if typedColumnInt64AggregateBenchIncludeFallback(includeFallbackEnv, rows) {
+					runTypedColumnInt64AggregateBenchPath(b, rows, dist, shape, req, expected, false)
+				}
+			}
 		}
-		low := rows / 4
-		matchCount := maxIntForTypedColumnInt64AggregateBench(1, rows/100)
-		high := low + matchCount - 1
-		if high >= rows {
-			high = rows - 1
-			matchCount = high - low + 1
-		}
-		wantCount := int64(matchCount)
-		wantSum := int64(low+high) * wantCount / 2
-		b.Run(fmt.Sprintf("rows_%d/typed_column_part/predicate_count_sum_avg", rows), func(b *testing.B) {
-			d, col := setupTypedColumnInt64ScanCollection(b)
-			defer func() { _ = d.Close() }()
-			mid := rows / 2
-			insertTypedColumnInt64ScanRows(b, col, values[:mid])
-			insertTypedColumnInt64ScanRows(b, col, values[mid:])
-			b.ReportAllocs()
-			b.ResetTimer()
-			benchStart := time.Now()
-			for i := 0; i < b.N; i++ {
-				result, err := col.RunTypedColumnInt64PredicateAggregate(TypedColumnInt64PredicateAggregateRequest{Column: "time_us", Kind: TypedColumnInt64PredicateRange, Low: int64(low), High: int64(high), ColumnAssetReadIntegrity: ColumnAssetReadIntegrityCachedVerify})
-				if err != nil {
-					b.Fatalf("RunTypedColumnInt64PredicateAggregate: %v", err)
-				}
-				if result.Count != wantCount || result.Sum != wantSum {
-					b.Fatalf("aggregate count=%d sum=%d want count=%d sum=%d diagnostics=%+v", result.Count, result.Sum, wantCount, wantSum, result.Diagnostics)
-				}
-				if i == b.N-1 {
-					reportTypedColumnInt64AggregateBenchMetrics(b, rows, result.Diagnostics, time.Since(benchStart), b.N)
-				}
-			}
-			b.StopTimer()
-		})
-		b.Run(fmt.Sprintf("rows_%d/document_full_scan_fallback/predicate_count_sum_avg", rows), func(b *testing.B) {
-			d := openTypedColumnInt64ScanDB(b)
-			defer func() { _ = d.Close() }()
-			mgr := NewCollectionManager(d)
-			if _, err := mgr.CreateCollection(&CollectionMeta{Name: "events"}); err != nil {
-				b.Fatalf("CreateCollection: %v", err)
-			}
-			col, err := mgr.OpenCollection("events")
-			if err != nil {
-				b.Fatalf("OpenCollection: %v", err)
-			}
-			mid := rows / 2
-			insertTypedColumnInt64ScanRows(b, col, values[:mid])
-			insertTypedColumnInt64ScanRows(b, col, values[mid:])
-			b.ReportAllocs()
-			b.ResetTimer()
-			benchStart := time.Now()
-			for i := 0; i < b.N; i++ {
-				result, err := col.RunTypedColumnInt64PredicateAggregate(TypedColumnInt64PredicateAggregateRequest{Column: "time_us", Kind: TypedColumnInt64PredicateRange, Low: int64(low), High: int64(high)})
-				if err != nil {
-					b.Fatalf("RunTypedColumnInt64PredicateAggregate fallback: %v", err)
-				}
-				if result.Count != wantCount || result.Sum != wantSum {
-					b.Fatalf("aggregate count=%d sum=%d want count=%d sum=%d diagnostics=%+v", result.Count, result.Sum, wantCount, wantSum, result.Diagnostics)
-				}
-				if i == b.N-1 {
-					reportTypedColumnInt64AggregateBenchMetrics(b, rows, result.Diagnostics, time.Since(benchStart), b.N)
-				}
-			}
-			b.StopTimer()
-		})
 	}
 }
 
-func parseTypedColumnInt64AggregateBenchRows(env string) ([]int, error) {
+type typedColumnInt64AggregateBenchDistribution struct {
+	name    string
+	valueAt func(row, rows int) int64
+}
+
+type typedColumnInt64AggregateBenchShape struct {
+	name    string
+	request func(rows int) TypedColumnInt64PredicateAggregateRequest
+}
+
+type typedColumnInt64AggregateBenchExpected struct {
+	count int64
+	sum   int64
+	avg   float64
+}
+
+const typedColumnInt64AggregateBenchBatchRows = 32768
+
+func runTypedColumnInt64AggregateBenchPath(b *testing.B, rows int, dist typedColumnInt64AggregateBenchDistribution, shape typedColumnInt64AggregateBenchShape, req TypedColumnInt64PredicateAggregateRequest, expected typedColumnInt64AggregateBenchExpected, typedPath bool) {
+	pathName := "document_full_scan_fallback"
+	if typedPath {
+		pathName = "typed_column_part"
+	}
+	b.Run(fmt.Sprintf("rows_%d/dist_%s/path_%s/shape_%s/predicate_count_sum_avg", rows, dist.name, pathName, shape.name), func(b *testing.B) {
+		setupStart := time.Now()
+		d, col := setupTypedColumnInt64AggregateBenchCollection(b, typedPath)
+		defer func() { _ = d.Close() }()
+		batches := insertTypedColumnInt64AggregateBenchRows(b, col, rows, dist)
+		setupDuration := time.Since(setupStart)
+		setupMetrics := collectTypedColumnInt64AggregateBenchSetupMetrics(rows, batches, d, typedPath, setupDuration)
+
+		req.Column = "time_us"
+		if typedPath {
+			req.ColumnAssetReadIntegrity = ColumnAssetReadIntegrityCachedVerify
+		}
+		b.ReportAllocs()
+		b.ResetTimer()
+		reportTypedColumnInt64AggregateBenchSetupMetrics(b, setupMetrics)
+		benchStart := time.Now()
+		for i := 0; i < b.N; i++ {
+			result, err := col.RunTypedColumnInt64PredicateAggregate(req)
+			if err != nil {
+				b.Fatalf("RunTypedColumnInt64PredicateAggregate: %v", err)
+			}
+			if result.Count != expected.count || result.Sum != expected.sum || result.Avg != expected.avg {
+				b.Fatalf("aggregate count=%d sum=%d avg=%f want count=%d sum=%d avg=%f diagnostics=%+v", result.Count, result.Sum, result.Avg, expected.count, expected.sum, expected.avg, result.Diagnostics)
+			}
+			if i == b.N-1 {
+				reportTypedColumnInt64AggregateBenchMetrics(b, rows, result.Diagnostics, time.Since(benchStart), b.N)
+			}
+		}
+		b.StopTimer()
+	})
+}
+
+func setupTypedColumnInt64AggregateBenchCollection(tb testing.TB, typedPath bool) (*backenddb.DB, *Collection) {
+	tb.Helper()
+	if typedPath {
+		return setupTypedColumnInt64ScanCollection(tb)
+	}
+	d := openTypedColumnInt64ScanDB(tb)
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "events"}); err != nil {
+		tb.Fatalf("CreateCollection: %v", err)
+	}
+	col, err := mgr.OpenCollection("events")
+	if err != nil {
+		tb.Fatalf("OpenCollection: %v", err)
+	}
+	return d, col
+}
+
+func insertTypedColumnInt64AggregateBenchRows(tb testing.TB, col *Collection, rows int, dist typedColumnInt64AggregateBenchDistribution) int {
+	tb.Helper()
+	batches := 0
+	for start := 0; start < rows; start += typedColumnInt64AggregateBenchBatchRows {
+		end := start + typedColumnInt64AggregateBenchBatchRows
+		if end > rows {
+			end = rows
+		}
+		values := make([]int64, end-start)
+		for i := range values {
+			values[i] = dist.valueAt(start+i, rows)
+		}
+		insertTypedColumnInt64AggregateBenchRowsBatch(tb, col, start, values)
+		batches++
+	}
+	return batches
+}
+
+func parseTypedColumnInt64AggregateBenchRows(env string, large bool) ([]int, error) {
 	if strings.TrimSpace(env) == "" {
 		return []int{4096, 65536}, nil
 	}
@@ -717,9 +929,259 @@ func parseTypedColumnInt64AggregateBenchRows(env string) ([]int, error) {
 		if rows <= 0 {
 			return nil, fmt.Errorf("row count %d must be positive", rows)
 		}
+		if rows >= 10000000 && !large {
+			return nil, fmt.Errorf("row count %d requires TREEDB_TYPED_COLUMN_BENCH_LARGE=true", rows)
+		}
 		out = append(out, rows)
 	}
 	return out, nil
+}
+
+func parseTypedColumnInt64AggregateBenchShapes(env string) ([]typedColumnInt64AggregateBenchShape, error) {
+	if strings.TrimSpace(env) == "" {
+		return []typedColumnInt64AggregateBenchShape{
+			typedColumnInt64AggregateBenchShapeByName("selective_range_1pct"),
+			typedColumnInt64AggregateBenchShapeByName("all_pruned_no_match"),
+			typedColumnInt64AggregateBenchShapeByName("all_match"),
+		}, nil
+	}
+	parts := strings.Split(env, ",")
+	out := make([]typedColumnInt64AggregateBenchShape, 0, len(parts))
+	for _, part := range parts {
+		name := strings.TrimSpace(part)
+		if name == "" {
+			return nil, fmt.Errorf("empty shape")
+		}
+		shape := typedColumnInt64AggregateBenchShapeByName(name)
+		if shape.name == "" {
+			return nil, fmt.Errorf("invalid shape %q (available: %s)", name, strings.Join(typedColumnInt64AggregateBenchShapeNames(typedColumnInt64AggregateBenchAllShapes()), ","))
+		}
+		out = append(out, shape)
+	}
+	return out, nil
+}
+
+func parseTypedColumnInt64AggregateBenchDistributions(env string) ([]typedColumnInt64AggregateBenchDistribution, error) {
+	if strings.TrimSpace(env) == "" {
+		return []typedColumnInt64AggregateBenchDistribution{typedColumnInt64AggregateBenchDistributionByName("clustered_monotonic")}, nil
+	}
+	parts := strings.Split(env, ",")
+	out := make([]typedColumnInt64AggregateBenchDistribution, 0, len(parts))
+	for _, part := range parts {
+		name := strings.TrimSpace(part)
+		if name == "" {
+			return nil, fmt.Errorf("empty distribution")
+		}
+		dist := typedColumnInt64AggregateBenchDistributionByName(name)
+		if dist.name == "" {
+			return nil, fmt.Errorf("invalid distribution %q (available: %s)", name, strings.Join(typedColumnInt64AggregateBenchDistributionNames(typedColumnInt64AggregateBenchAllDistributions()), ","))
+		}
+		out = append(out, dist)
+	}
+	return out, nil
+}
+
+func parseTypedColumnInt64AggregateBenchBool(name, env string, def bool) (bool, error) {
+	if strings.TrimSpace(env) == "" {
+		return def, nil
+	}
+	switch strings.ToLower(strings.TrimSpace(env)) {
+	case "1", "t", "true", "yes", "y", "on":
+		return true, nil
+	case "0", "f", "false", "no", "n", "off":
+		return false, nil
+	default:
+		return false, fmt.Errorf("%s: invalid boolean %q", name, env)
+	}
+}
+
+func typedColumnInt64AggregateBenchIncludeFallback(env string, rows int) bool {
+	include, err := parseTypedColumnInt64AggregateBenchBool("TREEDB_TYPED_COLUMN_BENCH_INCLUDE_FALLBACK", env, rows == 4096 || rows == 65536)
+	return err == nil && include
+}
+
+func typedColumnInt64AggregateBenchAllShapes() []typedColumnInt64AggregateBenchShape {
+	return []typedColumnInt64AggregateBenchShape{
+		{name: "no_filter_full_aggregate", request: func(rows int) TypedColumnInt64PredicateAggregateRequest {
+			return TypedColumnInt64PredicateAggregateRequest{Column: "time_us", Kind: TypedColumnInt64PredicateAll}
+		}},
+		{name: "exact_value", request: func(rows int) TypedColumnInt64PredicateAggregateRequest {
+			return TypedColumnInt64PredicateAggregateRequest{Column: "time_us", Kind: TypedColumnInt64PredicateEqual, Value: int64(rows / 4)}
+		}},
+		{name: "tiny_range", request: func(rows int) TypedColumnInt64PredicateAggregateRequest {
+			low := rows / 4
+			width := clampIntForTypedColumnInt64AggregateBench(rows/1000, 10, 100)
+			if width > rows-low {
+				width = rows - low
+			}
+			if width < 1 {
+				width = 1
+			}
+			return TypedColumnInt64PredicateAggregateRequest{Column: "time_us", Kind: TypedColumnInt64PredicateRange, Low: int64(low), High: int64(low + width - 1)}
+		}},
+		{name: "selective_range_1pct", request: func(rows int) TypedColumnInt64PredicateAggregateRequest {
+			low := rows / 4
+			width := maxIntForTypedColumnInt64AggregateBench(1, rows/100)
+			if width > rows-low {
+				width = rows - low
+			}
+			return TypedColumnInt64PredicateAggregateRequest{Column: "time_us", Kind: TypedColumnInt64PredicateRange, Low: int64(low), High: int64(low + width - 1)}
+		}},
+		{name: "wide_range_10pct", request: func(rows int) TypedColumnInt64PredicateAggregateRequest {
+			low := rows / 4
+			width := maxIntForTypedColumnInt64AggregateBench(1, rows/10)
+			if width > rows-low {
+				width = rows - low
+			}
+			return TypedColumnInt64PredicateAggregateRequest{Column: "time_us", Kind: TypedColumnInt64PredicateRange, Low: int64(low), High: int64(low + width - 1)}
+		}},
+		{name: "all_pruned_no_match", request: func(rows int) TypedColumnInt64PredicateAggregateRequest {
+			return TypedColumnInt64PredicateAggregateRequest{Column: "time_us", Kind: TypedColumnInt64PredicateEqual, Value: int64(rows)}
+		}},
+		{name: "all_match", request: func(rows int) TypedColumnInt64PredicateAggregateRequest {
+			return TypedColumnInt64PredicateAggregateRequest{Column: "time_us", Kind: TypedColumnInt64PredicateRange, Low: 0, High: int64(rows - 1)}
+		}},
+		{name: "tail_range", request: func(rows int) TypedColumnInt64PredicateAggregateRequest {
+			width := maxIntForTypedColumnInt64AggregateBench(1, rows/100)
+			if width > rows {
+				width = rows
+			}
+			return TypedColumnInt64PredicateAggregateRequest{Column: "time_us", Kind: TypedColumnInt64PredicateRange, Low: int64(rows - width), High: int64(rows - 1)}
+		}},
+	}
+}
+
+func typedColumnInt64AggregateBenchShapeByName(name string) typedColumnInt64AggregateBenchShape {
+	name = strings.TrimSpace(name)
+	for _, shape := range typedColumnInt64AggregateBenchAllShapes() {
+		if shape.name == name {
+			return shape
+		}
+	}
+	return typedColumnInt64AggregateBenchShape{}
+}
+
+func typedColumnInt64AggregateBenchAllDistributions() []typedColumnInt64AggregateBenchDistribution {
+	return []typedColumnInt64AggregateBenchDistribution{
+		{name: "clustered_monotonic", valueAt: func(row, rows int) int64 { return int64(row) }},
+		{name: "reverse_monotonic", valueAt: func(row, rows int) int64 { return int64(rows - row - 1) }},
+		{name: "partially_clustered", valueAt: func(row, rows int) int64 {
+			const chunk = 256
+			start := row / chunk * chunk
+			end := start + chunk
+			if end > rows {
+				end = rows
+			}
+			return int64(start + (end - start - 1 - (row - start)))
+		}},
+		{name: "random_uniform", valueAt: func(row, rows int) int64 {
+			if rows <= 1 {
+				return 0
+			}
+			mul := randomUniformMultiplierForTypedColumnInt64AggregateBench(rows)
+			offset := rows/3 + 17
+			return int64((row*mul + offset) % rows)
+		}},
+		{name: "hotspot_skewed", valueAt: func(row, rows int) int64 {
+			if rows <= 1 {
+				return 0
+			}
+			span := minIntForTypedColumnInt64AggregateBench(8, rows)
+			base := rows/2 - span/2
+			if row%5 == 0 {
+				return int64(row)
+			}
+			return int64(base + row%span)
+		}},
+	}
+}
+
+func typedColumnInt64AggregateBenchDistributionByName(name string) typedColumnInt64AggregateBenchDistribution {
+	name = strings.TrimSpace(name)
+	for _, dist := range typedColumnInt64AggregateBenchAllDistributions() {
+		if dist.name == name {
+			return dist
+		}
+	}
+	return typedColumnInt64AggregateBenchDistribution{}
+}
+
+func typedColumnInt64AggregateBenchShapeNames(shapes []typedColumnInt64AggregateBenchShape) []string {
+	out := make([]string, len(shapes))
+	for i, shape := range shapes {
+		out[i] = shape.name
+	}
+	return out
+}
+
+func typedColumnInt64AggregateBenchDistributionNames(dists []typedColumnInt64AggregateBenchDistribution) []string {
+	out := make([]string, len(dists))
+	for i, dist := range dists {
+		out[i] = dist.name
+	}
+	return out
+}
+
+func typedColumnInt64AggregateBenchValues(rows int, dist typedColumnInt64AggregateBenchDistribution) []int64 {
+	values := make([]int64, rows)
+	for i := range values {
+		values[i] = dist.valueAt(i, rows)
+	}
+	return values
+}
+
+func expectedTypedColumnInt64AggregateBenchResult(values []int64, req TypedColumnInt64PredicateAggregateRequest) typedColumnInt64AggregateBenchExpected {
+	var out typedColumnInt64AggregateBenchExpected
+	scanReq := typedColumnInt64PredicateAggregateScanRequest(req)
+	for _, value := range values {
+		if typedColumnInt64PredicateMatches(scanReq, value) {
+			out.count++
+			out.sum += value
+		}
+	}
+	out.finish()
+	return out
+}
+
+func expectedTypedColumnInt64AggregateBenchResultForDistribution(rows int, dist typedColumnInt64AggregateBenchDistribution, req TypedColumnInt64PredicateAggregateRequest) typedColumnInt64AggregateBenchExpected {
+	var out typedColumnInt64AggregateBenchExpected
+	scanReq := typedColumnInt64PredicateAggregateScanRequest(req)
+	for row := 0; row < rows; row++ {
+		value := dist.valueAt(row, rows)
+		if typedColumnInt64PredicateMatches(scanReq, value) {
+			out.count++
+			out.sum += value
+		}
+	}
+	out.finish()
+	return out
+}
+
+func (e *typedColumnInt64AggregateBenchExpected) finish() {
+	if e.count != 0 {
+		e.avg = float64(e.sum) / float64(e.count)
+	}
+}
+
+func randomUniformMultiplierForTypedColumnInt64AggregateBench(rows int) int {
+	mul := rows/2*2 + 1
+	for gcdIntForTypedColumnInt64AggregateBench(mul, rows) != 1 {
+		mul += 2
+	}
+	return mul
+}
+
+func gcdIntForTypedColumnInt64AggregateBench(a, b int) int {
+	if a < 0 {
+		a = -a
+	}
+	if b < 0 {
+		b = -b
+	}
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
 }
 
 func maxIntForTypedColumnInt64AggregateBench(a, b int) int {
@@ -727,6 +1189,71 @@ func maxIntForTypedColumnInt64AggregateBench(a, b int) int {
 		return a
 	}
 	return b
+}
+
+func minIntForTypedColumnInt64AggregateBench(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func clampIntForTypedColumnInt64AggregateBench(v, low, high int) int {
+	if v < low {
+		return low
+	}
+	if v > high {
+		return high
+	}
+	return v
+}
+
+type typedColumnInt64AggregateBenchSetupMetrics struct {
+	rows                  int
+	batches               int
+	setupNanos            int64
+	typedColumnAssetBytes int64
+	dbDirBytes            int64
+}
+
+func collectTypedColumnInt64AggregateBenchSetupMetrics(rows, batches int, d *backenddb.DB, typedPath bool, setupDuration time.Duration) typedColumnInt64AggregateBenchSetupMetrics {
+	metrics := typedColumnInt64AggregateBenchSetupMetrics{
+		rows:       rows,
+		batches:    batches,
+		setupNanos: setupDuration.Nanoseconds(),
+		dbDirBytes: directorySizeForTypedColumnInt64AggregateBench(d.Dir()),
+	}
+	if typedPath {
+		metrics.typedColumnAssetBytes = directorySizeForTypedColumnInt64AggregateBench(d.ColumnAssetRootDir())
+	}
+	return metrics
+}
+
+func reportTypedColumnInt64AggregateBenchSetupMetrics(b *testing.B, metrics typedColumnInt64AggregateBenchSetupMetrics) {
+	b.Helper()
+	b.ReportMetric(float64(metrics.rows), "dataset_rows")
+	b.ReportMetric(float64(metrics.batches), "setup_batches")
+	b.ReportMetric(float64(metrics.setupNanos), "setup_ns")
+	if metrics.typedColumnAssetBytes != 0 {
+		b.ReportMetric(float64(metrics.typedColumnAssetBytes), "typed_column_asset_bytes")
+	}
+	b.ReportMetric(float64(metrics.dbDirBytes), "db_dir_bytes")
+}
+
+func directorySizeForTypedColumnInt64AggregateBench(root string) int64 {
+	var total int64
+	_ = filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+		if err != nil || entry == nil || entry.IsDir() {
+			return nil
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return nil
+		}
+		total += info.Size()
+		return nil
+	})
+	return total
 }
 
 func BenchmarkTypedColumnInt64PredicateScan(b *testing.B) {
@@ -864,6 +1391,20 @@ func insertTypedColumnInt64ScanRows(tb testing.TB, col *Collection, values []int
 	docs := make([][]byte, len(values))
 	for i, value := range values {
 		ids[i] = []byte(fmt.Sprintf("e%06d_%d", value, i))
+		docs[i] = []byte(fmt.Sprintf(`{"time_us":%d,"kind":"k%d"}`, value, value%8))
+	}
+	if _, err := col.InsertBatch(ids, docs); err != nil {
+		tb.Fatalf("InsertBatch: %v", err)
+	}
+}
+
+func insertTypedColumnInt64AggregateBenchRowsBatch(tb testing.TB, col *Collection, globalStart int, values []int64) {
+	tb.Helper()
+	ids := make([][]byte, len(values))
+	docs := make([][]byte, len(values))
+	for i, value := range values {
+		row := globalStart + i
+		ids[i] = []byte(fmt.Sprintf("bench_e%012d_%d", row, value))
 		docs[i] = []byte(fmt.Sprintf(`{"time_us":%d,"kind":"k%d"}`, value, value%8))
 	}
 	if _, err := col.InsertBatch(ids, docs); err != nil {

--- a/TreeDB/collections/typed_column_int64_scan_test.go
+++ b/TreeDB/collections/typed_column_int64_scan_test.go
@@ -1198,9 +1198,21 @@ func (e *typedColumnInt64AggregateBenchExpected) finish() {
 }
 
 func randomUniformMultiplierForTypedColumnInt64AggregateBench(rows int) int {
-	mul := rows/2*2 + 1
+	if rows <= 2 {
+		return 1
+	}
+	mul := int(uint64(6364136223846793005) % uint64(rows))
+	if mul == 0 {
+		mul = 1
+	}
+	if mul%2 == 0 {
+		mul++
+	}
 	for gcdIntForTypedColumnInt64AggregateBench(mul, rows) != 1 {
 		mul += 2
+		if mul >= rows {
+			mul = 1
+		}
 	}
 	return mul
 }

--- a/TreeDB/collections/typed_column_int64_scan_test.go
+++ b/TreeDB/collections/typed_column_int64_scan_test.go
@@ -651,11 +651,11 @@ func TestTypedColumnInt64AggregateBenchParsers(t *testing.T) {
 		if gotNames := typedColumnInt64AggregateBenchShapeNames(got); fmt.Sprint(gotNames) != fmt.Sprint([]string{"selective_range_1pct", "all_pruned_no_match", "all_match"}) {
 			t.Fatalf("default shapes=%v", gotNames)
 		}
-		got, err = parseTypedColumnInt64AggregateBenchShapes("no_filter_full_aggregate, exact_value,tail_range")
+		got, err = parseTypedColumnInt64AggregateBenchShapes("no_filter, exact,range_1pct,range_10pct,all_pruned,tail")
 		if err != nil {
 			t.Fatalf("explicit shapes: %v", err)
 		}
-		if gotNames := typedColumnInt64AggregateBenchShapeNames(got); fmt.Sprint(gotNames) != fmt.Sprint([]string{"no_filter_full_aggregate", "exact_value", "tail_range"}) {
+		if gotNames := typedColumnInt64AggregateBenchShapeNames(got); fmt.Sprint(gotNames) != fmt.Sprint([]string{"no_filter_full_aggregate", "exact_value", "selective_range_1pct", "wide_range_10pct", "all_pruned_no_match", "tail_range"}) {
 			t.Fatalf("explicit shapes=%v", gotNames)
 		}
 		if _, err := parseTypedColumnInt64AggregateBenchShapes("selective_range_1pct,nope"); err == nil || !strings.Contains(err.Error(), "invalid shape") {
@@ -671,11 +671,11 @@ func TestTypedColumnInt64AggregateBenchParsers(t *testing.T) {
 		if gotNames := typedColumnInt64AggregateBenchDistributionNames(got); fmt.Sprint(gotNames) != fmt.Sprint([]string{"clustered_monotonic"}) {
 			t.Fatalf("default dists=%v", gotNames)
 		}
-		got, err = parseTypedColumnInt64AggregateBenchDistributions("reverse_monotonic,random_uniform,hotspot_skewed")
+		got, err = parseTypedColumnInt64AggregateBenchDistributions("clustered,reverse,partial_random,random,hotspot")
 		if err != nil {
 			t.Fatalf("explicit dists: %v", err)
 		}
-		if gotNames := typedColumnInt64AggregateBenchDistributionNames(got); fmt.Sprint(gotNames) != fmt.Sprint([]string{"reverse_monotonic", "random_uniform", "hotspot_skewed"}) {
+		if gotNames := typedColumnInt64AggregateBenchDistributionNames(got); fmt.Sprint(gotNames) != fmt.Sprint([]string{"clustered_monotonic", "reverse_monotonic", "partially_clustered", "random_uniform", "hotspot_skewed"}) {
 			t.Fatalf("explicit dists=%v", gotNames)
 		}
 		if _, err := parseTypedColumnInt64AggregateBenchDistributions("clustered_monotonic,nope"); err == nil || !strings.Contains(err.Error(), "invalid distribution") {
@@ -1052,7 +1052,23 @@ func typedColumnInt64AggregateBenchAllShapes() []typedColumnInt64AggregateBenchS
 }
 
 func typedColumnInt64AggregateBenchShapeByName(name string) typedColumnInt64AggregateBenchShape {
-	name = strings.TrimSpace(name)
+	name = strings.ToLower(strings.TrimSpace(name))
+	switch name {
+	case "no_filter":
+		name = "no_filter_full_aggregate"
+	case "exact", "equality", "equal":
+		name = "exact_value"
+	case "tiny":
+		name = "tiny_range"
+	case "range_1pct", "selective_1pct":
+		name = "selective_range_1pct"
+	case "range_10pct", "wide_10pct":
+		name = "wide_range_10pct"
+	case "all_pruned", "no_match":
+		name = "all_pruned_no_match"
+	case "tail", "latest_window":
+		name = "tail_range"
+	}
 	for _, shape := range typedColumnInt64AggregateBenchAllShapes() {
 		if shape.name == name {
 			return shape
@@ -1087,7 +1103,13 @@ func typedColumnInt64AggregateBenchAllDistributions() []typedColumnInt64Aggregat
 				return 0
 			}
 			span := minIntForTypedColumnInt64AggregateBench(8, rows)
-			base := rows/2 - span/2
+			base := rows/4 - span/2
+			if base < 0 {
+				base = 0
+			}
+			if base+span > rows {
+				base = rows - span
+			}
 			if row%5 == 0 {
 				return int64(row)
 			}
@@ -1097,7 +1119,19 @@ func typedColumnInt64AggregateBenchAllDistributions() []typedColumnInt64Aggregat
 }
 
 func typedColumnInt64AggregateBenchDistributionByName(name string) typedColumnInt64AggregateBenchDistribution {
-	name = strings.TrimSpace(name)
+	name = strings.ToLower(strings.TrimSpace(name))
+	switch name {
+	case "clustered":
+		name = "clustered_monotonic"
+	case "reverse":
+		name = "reverse_monotonic"
+	case "partial_random", "partially_random", "partial_clustered":
+		name = "partially_clustered"
+	case "random":
+		name = "random_uniform"
+	case "hotspot", "skew", "skewed":
+		name = "hotspot_skewed"
+	}
 	for _, dist := range typedColumnInt64AggregateBenchAllDistributions() {
 		if dist.name == name {
 			return dist


### PR DESCRIPTION
## Summary

Closes #1808. Parent tracker: #1791. Related/context only: #1803/#1805, #1806, #1757, #1781, #1786.

This PR expands the typed-column int64 aggregate benchmark matrix without taking on #1806 bottleneck removal:

- adds a no-filter aggregate predicate kind (`TypedColumnInt64PredicateAll`) so `no_filter_full_aggregate` is measured distinctly from bounded all-match ranges;
- adds env-configured benchmark rows, query shapes, data distributions, fallback inclusion, and large-row opt-in gating;
- adds deterministic clustered/reverse/partially-clustered/random-uniform/hotspot-skewed generators and expected aggregate checks outside timed loops;
- keeps setup, setup metric reporting, correctness checks, and final benchmark metric emission outside the timed benchmark loop so the timed loop only executes `RunTypedColumnInt64PredicateAggregate`.

## Matrix implemented

Rows:

- default: `4096,65536`
- medium optional: `1048576`
- large optional: `10000000,50000000` and any row count `>=10000000` requires `TREEDB_TYPED_COLUMN_BENCH_LARGE=true`

Shapes:

- `no_filter_full_aggregate` (alias `no_filter`)
- `exact_value` (aliases `exact`, `equal`, `equality`)
- `tiny_range` (alias `tiny`)
- `selective_range_1pct` (aliases `range_1pct`, `selective_1pct`)
- `wide_range_10pct` (aliases `range_10pct`, `wide_10pct`)
- `all_pruned_no_match` (aliases `all_pruned`, `no_match`)
- `all_match`
- `tail_range` (aliases `tail`, `latest_window`)

Distributions:

- `clustered_monotonic` (alias `clustered`)
- `reverse_monotonic` (alias `reverse`)
- `partially_clustered` (aliases `partial_random`, `partially_random`, `partial_clustered`)
- `random_uniform` (alias `random`)
- `hotspot_skewed` (aliases `hotspot`, `skew`, `skewed`)

Default matrix remains local/CI-safe: rows `4096,65536`, shapes `selective_range_1pct,all_pruned_no_match,all_match`, dist `clustered_monotonic`; fallback is included by default only for default rows. Medium/large fallback requires `TREEDB_TYPED_COLUMN_BENCH_INCLUDE_FALLBACK=true`.

## Commands

Default run:

```sh
go test -run '^$' \
  -bench '^BenchmarkTypedColumnInt64PredicateAggregate$' \
  -benchmem \
  -benchtime=1x \
  -count=1 \
  ./TreeDB/collections
```

1M optional run used for evidence:

```sh
TREEDB_TYPED_COLUMN_BENCH_ROWS=1048576 \
TREEDB_TYPED_COLUMN_BENCH_SHAPES=range_1pct \
TREEDB_TYPED_COLUMN_BENCH_DISTS=clustered,random_uniform \
TREEDB_TYPED_COLUMN_BENCH_INCLUDE_FALLBACK=false \
go test -run '^$' \
  -bench '^BenchmarkTypedColumnInt64PredicateAggregate$' \
  -benchmem \
  -benchtime=3x \
  -count=1 \
  ./TreeDB/collections
```

10M opt-in example (not run in PR evidence):

```sh
TREEDB_TYPED_COLUMN_BENCH_LARGE=true \
TREEDB_TYPED_COLUMN_BENCH_ROWS=10000000 \
TREEDB_TYPED_COLUMN_BENCH_SHAPES=no_filter,range_1pct,range_10pct,all_pruned,tail \
TREEDB_TYPED_COLUMN_BENCH_DISTS=clustered,random_uniform \
TREEDB_TYPED_COLUMN_BENCH_INCLUDE_FALLBACK=false \
go test -run '^$' \
  -bench '^BenchmarkTypedColumnInt64PredicateAggregate$' \
  -benchmem \
  -benchtime=5x \
  -count=1 \
  ./TreeDB/collections
```

50M opt-in example (not run in PR evidence):

```sh
TREEDB_TYPED_COLUMN_BENCH_LARGE=true \
TREEDB_TYPED_COLUMN_BENCH_ROWS=50000000 \
TREEDB_TYPED_COLUMN_BENCH_SHAPES=no_filter,range_1pct,all_pruned \
TREEDB_TYPED_COLUMN_BENCH_DISTS=clustered \
TREEDB_TYPED_COLUMN_BENCH_INCLUDE_FALLBACK=false \
go test -run '^$' \
  -bench '^BenchmarkTypedColumnInt64PredicateAggregate$' \
  -benchmem \
  -benchtime=1x \
  -count=1 \
  ./TreeDB/collections
```

10M/50M are opt-in only; without `TREEDB_TYPED_COLUMN_BENCH_LARGE=true`, row counts `>=10000000` fail during benchmark config parsing.

## Default runtime impact

On Apple M3 / darwin arm64, latest head `fc16c90449ff30f244b9a751716dccdf546d8e26` default benchmark command above completed in `real 3.90s` with `-benchtime=1x`; normal `go test` is unaffected because benchmarks are not run by default.

## Benchmark evidence

Latest head: `fc16c90449ff30f244b9a751716dccdf546d8e26`.

Default rows, clustered distribution (`-benchtime=1x -count=1`; artifact `/tmp/issue1808_default_bench_head_fc16c9044.txt`):

| rows | path | shape | ns/op | ops/sec | rows/sec | B/op | allocs/op | rows_scanned/op | rows_matched/op | blocks_decoded/op | blocks_pruned/op | mapped_bytes/op | decoded_bytes/op |
| ---: | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 4096 | typed_column_part | selective_range_1pct | 214,209 | 4,668 | 19,121,512 | 44,296 | 100 | 4,096 | 40 | 1 | 0 | 169,080 | 4,096 |
| 4096 | document_full_scan_fallback | selective_range_1pct | 5,051,583 | 198.0 | 810,835 | 6,590,936 | 81,918 | 4,096 | 40 | 0 | 0 | 0 | 0 |
| 4096 | typed_column_part | all_pruned_no_match | 123,792 | 8,078 | 33,087,760 | 11,240 | 98 | 0 | 0 | 0 | 1 | 169,080 | 0 |
| 4096 | document_full_scan_fallback | all_pruned_no_match | 3,045,209 | 328.4 | 1,345,064 | 6,590,936 | 81,918 | 4,096 | 0 | 0 | 0 | 0 | 0 |
| 4096 | typed_column_part | all_match | 129,292 | 7,734 | 31,680,228 | 44,008 | 99 | 4,096 | 4,096 | 1 | 0 | 169,080 | 4,096 |
| 4096 | document_full_scan_fallback | all_match | 2,943,708 | 339.7 | 1,391,442 | 6,590,936 | 81,918 | 4,096 | 4,096 | 0 | 0 | 0 | 0 |
| 65536 | typed_column_part | selective_range_1pct | 574,708 | 1,740 | 114,033,561 | 94,776 | 205 | 8,192 | 655 | 1 | 7 | 2,691,374 | 8,194 |
| 65536 | document_full_scan_fallback | selective_range_1pct | 53,331,000 | 18.75 | 1,228,854 | 106,274,248 | 1,310,721 | 65,536 | 655 | 0 | 0 | 0 | 0 |
| 65536 | typed_column_part | all_pruned_no_match | 445,208 | 2,246 | 147,203,105 | 36,920 | 206 | 0 | 0 | 0 | 8 | 2,691,374 | 0 |
| 65536 | document_full_scan_fallback | all_pruned_no_match | 53,886,917 | 18.56 | 1,216,176 | 106,274,264 | 1,310,721 | 65,536 | 0 | 0 | 0 | 0 | 0 |
| 65536 | typed_column_part | all_match | 730,000 | 1,370 | 89,775,342 | 160,312 | 206 | 65,536 | 65,536 | 8 | 0 | 2,691,374 | 65,550 |
| 65536 | document_full_scan_fallback | all_match | 55,202,083 | 18.12 | 1,187,202 | 106,275,968 | 1,310,717 | 65,536 | 65,536 | 0 | 0 | 0 | 0 |

Medium optional 1M row run (`range_1pct`, clustered vs random_uniform, fallback off; artifact `/tmp/issue1808_medium_1m_bench_3x_head_fc16c9044.txt`):

| rows | distribution | path | shape | ns/op | ops/sec | rows/sec | B/op | allocs/op | rows_scanned/op | rows_matched/op | blocks_decoded/op | blocks_pruned/op | mapped_bytes/op | decoded_bytes/op |
| ---: | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 1,048,576 | clustered_monotonic | typed_column_part | selective_range_1pct | 2,217,514 | 451.0 | 472,861,122 | 504,664 | 2,726 | 16,384 | 10,485 | 2 | 126 | 43,062,014 | 16,388 |
| 1,048,576 | random_uniform | typed_column_part | selective_range_1pct | 7,601,208 | 131.6 | 137,948,594 | 2,536,280 | 2,757 | 1,048,576 | 10,485 | 128 | 0 | 45,158,911 | 3,145,727 |

Random-uniform demonstrates the intended poor-pruning/worst-case shape: all 128 blocks decode for the 1% range, versus 2 decoded / 126 pruned for clustered data. This is evidence for #1806 prioritization; this PR intentionally does not remove those bottlenecks.

## Tests

```sh
go test -count=1 ./TreeDB/collections -run 'TestTypedColumnInt64.*Aggregate|TestTypedColumnInt64Scan'
# ok github.com/snissn/gomap/TreeDB/collections 1.524s

env TREEDB_TYPED_COLUMN_BENCH_ROWS=1024 \
  TREEDB_TYPED_COLUMN_BENCH_INCLUDE_FALLBACK=false \
  TREEDB_TYPED_COLUMN_BENCH_SHAPES=range_1pct \
  TREEDB_TYPED_COLUMN_BENCH_DISTS=random_uniform \
  go test -run '^$' -bench '^BenchmarkTypedColumnInt64PredicateAggregate$' -benchmem -benchtime=1x -count=1 ./TreeDB/collections
# ok github.com/snissn/gomap/TreeDB/collections 0.481s

go test -count=1 ./TreeDB/collections
# ok github.com/snissn/gomap/TreeDB/collections 31.229s
```

Subagent review:

- Executor: `1808-bench-matrix` high-thinking implementation chunk, commit integrated.
- Reviewer: `1808-bench-review` high-thinking review passed head `0d40952782319f9f29fd5b14189775fbe10356b2`; manager applied/fixed coordinator review blockers in latest head `fc16c90449ff30f244b9a751716dccdf546d8e26`.

## CI / AI review / unresolved threads

Latest pushed head: `fc16c90449ff30f244b9a751716dccdf546d8e26`.

Latest-head GitHub Actions are green. `gh pr checks 1809 --repo snissn/gomap` reports all check runs passing, including Format, TreeDB vet/test across Ubuntu/macOS/Windows/race/perf-smoke, Root vet/test, unified_bench gates, HashDB Windows, redisserver bench, read-snapshot guardrail, and CodeRabbit status.

AI review status:

- Codex: latest-head re-review reported no major issues; prior P2 timed-loop thread was replied to and resolved.
- CodeRabbit: latest-head re-review verified setup metrics/timed loop cleanup and scan-path coverage; reported "PR is good to merge". CodeRabbit inline threads are resolved.
- Copilot: review was requested/re-requested, but Copilot returned an external reviewer error on the earlier head and did not produce a successful latest-head review. No Copilot code findings are open.

All review threads returned by the GitHub review-thread API are resolved.

## Scope boundary / deferrals

- Does not optimize the typed-column aggregate engine (#1806 owns bottleneck removal).
- Does not make 10M/50M defaults.
- Does not persist benchmark datasets or integrate with unified benchmark/report tooling.
- 10M and 50M commands are documented opt-in examples but were not run for this PR evidence.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Support for an "all" int64 predicate so scans and aggregates can include every row (no pruning), across both optimized and fallback query paths.

* **Tests**
  * Added tests verifying "all" predicate semantics and aggregate correctness.
  * Expanded benchmarking and test helpers for multi-shape/distribution scenarios, deterministic generators, parsers, and dataset/metric reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1809?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
