### PR TITLE
Add TreeDB collection and vector quickstart demos

### DIFF
--- a/cmd/treedb_collection_demo/README.md
+++ b/cmd/treedb_collection_demo/README.md
@@ -1,0 +1,25 @@
+# treedb_collection_demo
+
+Quickstart/profile harness for TreeDB collections. It creates a fresh DB, loads deterministic fixture documents with `InsertBatch`, optionally checkpoints/reopens, and runs a selected read workload.
+
+Examples:
+
+```sh
+go run ./cmd/treedb_collection_demo -mode document -rows 1000 -workload range-aggregate
+go run ./cmd/treedb_collection_demo -mode typed-column -rows 1000 -workload range-aggregate
+OUT=$(mktemp -d /tmp/treedb_collection_demo_profiles_XXXXXX)
+go run ./cmd/treedb_collection_demo -mode typed-column -rows 10000 -workload range-aggregate -profile-dir "$OUT"
+```
+
+Supported modes: `document`, `typed-row`, `typed-column`, `hybrid-document-row`, `hybrid-document-column`, `hybrid-row-column`.
+
+Supported workloads: `insert`, `point-get`, `range-filter`, `range-aggregate`, `full-aggregate`, `mixed-read`, `reopen-read`.
+
+Named presets: `document-app`, `event-analytics`, `schema-aware`, `hybrid-product`, `perf-engineer`. Explicit flags such as `-rows`, `-batch-size`, `-mode`, and `-workload` override preset defaults.
+
+When `-profile-dir` is set, the command writes:
+
+- `cpu.pprof`
+- `allocs.pprof`
+- `summary.json`
+- `summary.md`

--- a/cmd/treedb_collection_demo/README.md
+++ b/cmd/treedb_collection_demo/README.md
@@ -1,6 +1,6 @@
 # treedb_collection_demo
 
-Quickstart/profile harness for TreeDB collections. It creates a fresh DB, loads deterministic fixture documents with `InsertBatch`, optionally checkpoints/reopens, and runs a selected read workload.
+Quickstart/profile harness for TreeDB collections. It creates a fresh DB, loads deterministic fixture documents with `InsertBatch`, optionally checkpoints/reopens, and runs a selected read workload. Explicit `-dir` values must be absent or empty; temporary DBs are removed unless `-keep-dir` is set.
 
 Examples:
 

--- a/cmd/treedb_collection_demo/main.go
+++ b/cmd/treedb_collection_demo/main.go
@@ -1,0 +1,785 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"runtime"
+	"runtime/pprof"
+	"sort"
+	"strings"
+	"time"
+
+	treedb "github.com/snissn/gomap/TreeDB"
+	"github.com/snissn/gomap/TreeDB/collections"
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+)
+
+const (
+	modeDocument             = "document"
+	modeTypedRow             = "typed-row"
+	modeTypedColumn          = "typed-column"
+	modeHybridDocumentRow    = "hybrid-document-row"
+	modeHybridDocumentCol    = "hybrid-document-column"
+	modeHybridRowColumn      = "hybrid-row-column"
+	workloadInsert           = "insert"
+	workloadPointGet         = "point-get"
+	workloadRangeFilter      = "range-filter"
+	workloadRangeAggregate   = "range-aggregate"
+	workloadFullAggregate    = "full-aggregate"
+	workloadMixedRead        = "mixed-read"
+	workloadReopenRead       = "reopen-read"
+	collectionName           = "demo_events"
+	indexTimeUS              = "time_us"
+	defaultRows              = 1000
+	defaultBatchSize         = 1000
+	defaultPayloadBytes      = 128
+	defaultStringCardinality = 16
+	defaultExtraFields       = 2
+	defaultSeed              = int64(1)
+)
+
+type config struct {
+	Mode              string
+	Workload          string
+	Rows              int
+	BatchSize         int
+	PayloadBytes      int
+	Int64Distribution string
+	StringCardinality int
+	ExtraFields       int
+	Dir               string
+	KeepDir           bool
+	Seed              int64
+	ReadIntegrity     string
+	Checkpoint        bool
+	Reopen            bool
+	ProfileDir        string
+	Preset            string
+}
+
+type fixtureRow struct {
+	ID      []byte
+	Doc     []byte
+	TimeUS  int64
+	Amount  int64
+	Kind    string
+	Payload string
+}
+
+type storedDoc struct {
+	TimeUS int64  `json:"time_us"`
+	Amount int64  `json:"amount"`
+	Kind   string `json:"kind"`
+}
+
+type aggregate struct {
+	Count int64   `json:"count"`
+	Sum   int64   `json:"sum"`
+	Avg   float64 `json:"avg"`
+}
+
+type materializationSummary struct {
+	DocumentMaterializations int `json:"document_materializations"`
+	RowMaterializations      int `json:"row_materializations"`
+}
+
+type diagnosticSummary struct {
+	Fallback             bool   `json:"fallback,omitempty"`
+	FallbackReason       string `json:"fallback_reason,omitempty"`
+	RowsScanned          int    `json:"rows_scanned,omitempty"`
+	RowsMatched          int    `json:"rows_matched,omitempty"`
+	PartsConsidered      int    `json:"parts_considered,omitempty"`
+	PartsPruned          int    `json:"parts_pruned,omitempty"`
+	BlocksDecoded        int    `json:"blocks_decoded,omitempty"`
+	MappedBytes          uint64 `json:"mapped_bytes,omitempty"`
+	DecodedBytes         uint64 `json:"decoded_bytes,omitempty"`
+	HeapCopyBytes        uint64 `json:"heap_copy_bytes,omitempty"`
+	DecodedMetadataBytes uint64 `json:"decoded_metadata_bytes,omitempty"`
+	ReadIntegrity        string `json:"read_integrity,omitempty"`
+}
+
+type summary struct {
+	Mode              string                 `json:"mode"`
+	Workload          string                 `json:"workload"`
+	Rows              int                    `json:"rows"`
+	BatchSize         int                    `json:"batch_size"`
+	PayloadBytes      int                    `json:"payload_bytes"`
+	Int64Distribution string                 `json:"int64_distribution"`
+	StringCardinality int                    `json:"string_cardinality"`
+	ExtraFields       int                    `json:"extra_fields"`
+	SetupMS           float64                `json:"setup_ms"`
+	QueryMS           float64                `json:"query_ms"`
+	Ops               int64                  `json:"ops"`
+	OpsSec            float64                `json:"ops_sec"`
+	RowsSec           float64                `json:"rows_sec"`
+	Matches           int64                  `json:"matches"`
+	Aggregate         aggregate              `json:"aggregate"`
+	Materialization   materializationSummary `json:"materialization"`
+	Diagnostics       diagnosticSummary      `json:"diagnostics"`
+	DBDir             string                 `json:"db_dir"`
+	ProfileDir        string                 `json:"profile_dir,omitempty"`
+	KeptDir           bool                   `json:"kept_dir"`
+}
+
+func defaultConfig() config {
+	return config{
+		Mode:              modeDocument,
+		Workload:          workloadRangeAggregate,
+		Rows:              defaultRows,
+		BatchSize:         defaultBatchSize,
+		PayloadBytes:      defaultPayloadBytes,
+		Int64Distribution: "linear",
+		StringCardinality: defaultStringCardinality,
+		ExtraFields:       defaultExtraFields,
+		Seed:              defaultSeed,
+		ReadIntegrity:     string(collections.ColumnAssetReadIntegrityVerify),
+	}
+}
+
+func main() {
+	cfg, err := parseConfig(os.Args[1:])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(2)
+	}
+	out, err := runDemo(cfg)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	printSummary(os.Stdout, out)
+}
+
+func parseConfig(args []string) (config, error) {
+	defs := defaultConfig()
+	var parsed config
+	parsed = defs
+	fs := flag.NewFlagSet("treedb_collection_demo", flag.ContinueOnError)
+	fs.SetOutput(new(bytes.Buffer))
+	fs.StringVar(&parsed.Mode, "mode", defs.Mode, "storage mode: document|typed-row|typed-column|hybrid-document-row|hybrid-document-column|hybrid-row-column")
+	fs.StringVar(&parsed.Workload, "workload", defs.Workload, "workload: insert|point-get|range-filter|range-aggregate|full-aggregate|mixed-read|reopen-read")
+	fs.IntVar(&parsed.Rows, "rows", defs.Rows, "fixture row count")
+	fs.IntVar(&parsed.BatchSize, "batch-size", defs.BatchSize, "InsertBatch size")
+	fs.IntVar(&parsed.PayloadBytes, "payload-bytes", defs.PayloadBytes, "bytes in retained payload string")
+	fs.StringVar(&parsed.Int64Distribution, "int64-distribution", defs.Int64Distribution, "linear|modulo|random|descending")
+	fs.IntVar(&parsed.StringCardinality, "string-cardinality", defs.StringCardinality, "distinct kind strings")
+	fs.IntVar(&parsed.ExtraFields, "extra-fields", defs.ExtraFields, "extra retained JSON fields")
+	fs.StringVar(&parsed.Dir, "dir", defs.Dir, "database directory; a temp dir is used when empty")
+	fs.BoolVar(&parsed.KeepDir, "keep-dir", defs.KeepDir, "keep database directory after exit")
+	fs.Int64Var(&parsed.Seed, "seed", defs.Seed, "deterministic fixture seed")
+	fs.StringVar(&parsed.ReadIntegrity, "read-integrity", defs.ReadIntegrity, "typed-column read integrity: verify|cached_verify|skip_checksums")
+	fs.BoolVar(&parsed.Checkpoint, "checkpoint", defs.Checkpoint, "checkpoint after setup before query")
+	fs.BoolVar(&parsed.Reopen, "reopen", defs.Reopen, "checkpoint, close, and reopen before query")
+	fs.StringVar(&parsed.ProfileDir, "profile-dir", defs.ProfileDir, "emit cpu.pprof, allocs.pprof, summary.json, summary.md")
+	fs.StringVar(&parsed.Preset, "preset", defs.Preset, "preset: document-app|event-analytics|schema-aware|hybrid-product|perf-engineer")
+	if err := fs.Parse(args); err != nil {
+		return config{}, err
+	}
+	visited := map[string]bool{}
+	fs.Visit(func(f *flag.Flag) { visited[f.Name] = true })
+
+	cfg := defs
+	if parsed.Preset != "" {
+		var err error
+		cfg, err = configWithPreset(cfg, parsed.Preset)
+		if err != nil {
+			return config{}, err
+		}
+	}
+	if visited["mode"] {
+		cfg.Mode = parsed.Mode
+	}
+	if visited["workload"] {
+		cfg.Workload = parsed.Workload
+	}
+	if visited["rows"] {
+		cfg.Rows = parsed.Rows
+	}
+	if visited["batch-size"] {
+		cfg.BatchSize = parsed.BatchSize
+	}
+	if visited["payload-bytes"] {
+		cfg.PayloadBytes = parsed.PayloadBytes
+	}
+	if visited["int64-distribution"] {
+		cfg.Int64Distribution = parsed.Int64Distribution
+	}
+	if visited["string-cardinality"] {
+		cfg.StringCardinality = parsed.StringCardinality
+	}
+	if visited["extra-fields"] {
+		cfg.ExtraFields = parsed.ExtraFields
+	}
+	if visited["dir"] {
+		cfg.Dir = parsed.Dir
+	}
+	if visited["keep-dir"] {
+		cfg.KeepDir = parsed.KeepDir
+	}
+	if visited["seed"] {
+		cfg.Seed = parsed.Seed
+	}
+	if visited["read-integrity"] {
+		cfg.ReadIntegrity = parsed.ReadIntegrity
+	}
+	if visited["checkpoint"] {
+		cfg.Checkpoint = parsed.Checkpoint
+	}
+	if visited["reopen"] {
+		cfg.Reopen = parsed.Reopen
+	}
+	if visited["profile-dir"] {
+		cfg.ProfileDir = parsed.ProfileDir
+	}
+	cfg.Preset = parsed.Preset
+	return validateConfig(cfg)
+}
+
+func configWithPreset(cfg config, preset string) (config, error) {
+	switch preset {
+	case "document-app":
+		cfg.Mode = modeDocument
+		cfg.Workload = workloadPointGet
+		cfg.Rows = 5000
+		cfg.PayloadBytes = 512
+		cfg.ExtraFields = 4
+	case "event-analytics":
+		cfg.Mode = modeTypedColumn
+		cfg.Workload = workloadRangeAggregate
+		cfg.Rows = 10000
+		cfg.PayloadBytes = 64
+		cfg.ExtraFields = 1
+	case "schema-aware":
+		cfg.Mode = modeTypedRow
+		cfg.Workload = workloadPointGet
+		cfg.Rows = 5000
+		cfg.PayloadBytes = 128
+	case "hybrid-product":
+		cfg.Mode = modeHybridDocumentCol
+		cfg.Workload = workloadMixedRead
+		cfg.Rows = 5000
+		cfg.PayloadBytes = 512
+		cfg.ExtraFields = 6
+	case "perf-engineer":
+		cfg.Mode = modeTypedColumn
+		cfg.Workload = workloadRangeAggregate
+		cfg.Rows = 50000
+		cfg.BatchSize = 5000
+		cfg.PayloadBytes = 32
+	case "":
+	default:
+		return cfg, fmt.Errorf("unknown preset %q", preset)
+	}
+	return cfg, nil
+}
+
+func validateConfig(cfg config) (config, error) {
+	switch cfg.Mode {
+	case modeDocument, modeTypedRow, modeTypedColumn, modeHybridDocumentRow, modeHybridDocumentCol, modeHybridRowColumn:
+	default:
+		return cfg, fmt.Errorf("unknown mode %q", cfg.Mode)
+	}
+	switch cfg.Workload {
+	case workloadInsert, workloadPointGet, workloadRangeFilter, workloadRangeAggregate, workloadFullAggregate, workloadMixedRead, workloadReopenRead:
+	default:
+		return cfg, fmt.Errorf("unknown workload %q", cfg.Workload)
+	}
+	if cfg.Rows <= 0 {
+		return cfg, errors.New("rows must be positive")
+	}
+	if cfg.BatchSize <= 0 {
+		return cfg, errors.New("batch-size must be positive")
+	}
+	if cfg.PayloadBytes < 0 {
+		return cfg, errors.New("payload-bytes cannot be negative")
+	}
+	if cfg.StringCardinality <= 0 {
+		return cfg, errors.New("string-cardinality must be positive")
+	}
+	if cfg.ExtraFields < 0 {
+		return cfg, errors.New("extra-fields cannot be negative")
+	}
+	switch cfg.Int64Distribution {
+	case "linear", "modulo", "random", "descending":
+	default:
+		return cfg, fmt.Errorf("unknown int64-distribution %q", cfg.Int64Distribution)
+	}
+	switch cfg.ReadIntegrity {
+	case string(collections.ColumnAssetReadIntegrityVerify), string(collections.ColumnAssetReadIntegrityCachedVerify), string(collections.ColumnAssetReadIntegritySkipChecksums):
+	default:
+		return cfg, fmt.Errorf("unknown read-integrity %q", cfg.ReadIntegrity)
+	}
+	return cfg, nil
+}
+
+func runDemo(cfg config) (summary, error) {
+	var err error
+	if cfg.Dir == "" {
+		cfg.Dir, err = os.MkdirTemp("", "treedb_collection_demo_")
+		if err != nil {
+			return summary{}, err
+		}
+	} else {
+		cfg.Dir, err = filepath.Abs(cfg.Dir)
+		if err != nil {
+			return summary{}, err
+		}
+		if err := os.RemoveAll(cfg.Dir); err != nil {
+			return summary{}, err
+		}
+		if err := os.MkdirAll(cfg.Dir, 0o755); err != nil {
+			return summary{}, err
+		}
+	}
+	if !cfg.KeepDir {
+		defer os.RemoveAll(cfg.Dir)
+	}
+
+	prof, err := startProfiles(cfg.ProfileDir)
+	if err != nil {
+		return summary{}, err
+	}
+	defer prof.stop()
+
+	rows := generateFixtureRows(cfg)
+	backend, cleanup, err := openDemoBackend(cfg.Dir)
+	if err != nil {
+		return summary{}, err
+	}
+	cleanupCalled := false
+	closeBackend := func() error {
+		if cleanupCalled {
+			return nil
+		}
+		cleanupCalled = true
+		return cleanup()
+	}
+	defer closeBackend()
+
+	mgr := collections.NewCollectionManager(backend)
+	if _, err := mgr.CreateCollection(collectionMetaForMode(cfg.Mode)); err != nil {
+		return summary{}, err
+	}
+	col, err := mgr.OpenCollection(collectionName)
+	if err != nil {
+		return summary{}, err
+	}
+
+	setupStart := time.Now()
+	if err := insertRows(col, rows, cfg.BatchSize); err != nil {
+		return summary{}, err
+	}
+	if err := mgr.FlushAll(); err != nil {
+		return summary{}, err
+	}
+	setupDur := time.Since(setupStart)
+
+	needReopen := cfg.Reopen || cfg.Workload == workloadReopenRead
+	if cfg.Checkpoint || needReopen {
+		if err := backend.Checkpoint(); err != nil {
+			return summary{}, err
+		}
+	}
+	if needReopen {
+		if err := closeBackend(); err != nil {
+			return summary{}, err
+		}
+		backend, cleanup, err = openDemoBackend(cfg.Dir)
+		if err != nil {
+			return summary{}, err
+		}
+		cleanupCalled = false
+		mgr = collections.NewCollectionManager(backend)
+		col, err = mgr.OpenCollection(collectionName)
+		if err != nil {
+			return summary{}, err
+		}
+	}
+
+	queryStart := time.Now()
+	result, err := executeWorkload(col, rows, cfg)
+	if err != nil {
+		return summary{}, err
+	}
+	queryDur := time.Since(queryStart)
+
+	out := summary{
+		Mode: cfg.Mode, Workload: cfg.Workload, Rows: cfg.Rows, BatchSize: cfg.BatchSize,
+		PayloadBytes: cfg.PayloadBytes, Int64Distribution: cfg.Int64Distribution,
+		StringCardinality: cfg.StringCardinality, ExtraFields: cfg.ExtraFields,
+		SetupMS: durationMS(setupDur), QueryMS: durationMS(queryDur), Ops: result.Ops,
+		Matches: result.Matches, Aggregate: result.Aggregate, Materialization: result.Materialization,
+		Diagnostics: result.Diagnostics, DBDir: cfg.Dir, ProfileDir: cfg.ProfileDir, KeptDir: cfg.KeepDir,
+	}
+	if queryDur > 0 && result.Ops > 0 {
+		out.OpsSec = float64(result.Ops) / queryDur.Seconds()
+	}
+	if queryDur > 0 {
+		out.RowsSec = float64(cfg.Rows) / queryDur.Seconds()
+	}
+	if cfg.Workload == workloadInsert && setupDur > 0 {
+		out.RowsSec = float64(cfg.Rows) / setupDur.Seconds()
+	}
+	if err := prof.writeSummary(out); err != nil {
+		return summary{}, err
+	}
+	return out, nil
+}
+
+type profileRun struct {
+	dir string
+	cpu *os.File
+}
+
+func startProfiles(dir string) (*profileRun, error) {
+	p := &profileRun{dir: dir}
+	if dir == "" {
+		return p, nil
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, err
+	}
+	f, err := os.Create(filepath.Join(dir, "cpu.pprof"))
+	if err != nil {
+		return nil, err
+	}
+	if err := pprof.StartCPUProfile(f); err != nil {
+		_ = f.Close()
+		return nil, err
+	}
+	p.cpu = f
+	return p, nil
+}
+
+func (p *profileRun) stop() {
+	if p == nil || p.cpu == nil {
+		return
+	}
+	pprof.StopCPUProfile()
+	_ = p.cpu.Close()
+	p.cpu = nil
+}
+
+func (p *profileRun) writeSummary(out summary) error {
+	if p == nil || p.dir == "" {
+		return nil
+	}
+	p.stop()
+	runtime.GC()
+	allocs, err := os.Create(filepath.Join(p.dir, "allocs.pprof"))
+	if err != nil {
+		return err
+	}
+	if err := pprof.Lookup("allocs").WriteTo(allocs, 0); err != nil {
+		_ = allocs.Close()
+		return err
+	}
+	if err := allocs.Close(); err != nil {
+		return err
+	}
+	jsonBytes, err := json.MarshalIndent(out, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(p.dir, "summary.json"), append(jsonBytes, '\n'), 0o644); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(p.dir, "summary.md"), []byte(markdownSummary(out)), 0o644)
+}
+
+func openDemoBackend(dir string) (*backenddb.DB, func() error, error) {
+	mainDir := filepath.Join(dir, "maindb")
+	if err := os.MkdirAll(mainDir, 0o755); err != nil {
+		return nil, nil, err
+	}
+	if err := backenddb.SaveFormatConfig(mainDir, backenddb.FormatConfig{RequiredFeatures: []string{backenddb.RequiredFeatureCommandWALV1}}); err != nil {
+		return nil, nil, err
+	}
+	return treedb.OpenBackendWithCachedLeafLog(treedb.Options{Dir: dir, CommandWAL: true, DisableBackgroundPrune: true})
+}
+
+func collectionMetaForMode(mode string) *collections.CollectionMeta {
+	meta := &collections.CollectionMeta{Name: collectionName}
+	if mode == modeDocument {
+		meta.Indexes = []collections.IndexDefinition{{Name: indexTimeUS, Field: "time_us", ValueType: collections.IndexValueInt64}}
+	}
+	cfg := &collections.ColumnStoreConfig{Enabled: true}
+	column := func(name, path string, vt collections.ColumnStoreValueType, owner collections.TypedStorageFieldOwner, dict bool) collections.ColumnStoreColumn {
+		return collections.ColumnStoreColumn{Name: name, Path: path, ValueType: vt, Owner: owner, Dictionary: dict}
+	}
+	switch mode {
+	case modeDocument:
+		return meta
+	case modeTypedRow:
+		cfg.Columns = []collections.ColumnStoreColumn{
+			column("time_us", "time_us", collections.ColumnStoreValueInt64, collections.TypedStorageOwnerRowAsset, false),
+			column("amount", "amount", collections.ColumnStoreValueInt64, collections.TypedStorageOwnerRowAsset, false),
+			column("kind", "kind", collections.ColumnStoreValueString, collections.TypedStorageOwnerRowAsset, true),
+		}
+	case modeTypedColumn:
+		cfg.Columns = []collections.ColumnStoreColumn{
+			column("time_us", "time_us", collections.ColumnStoreValueInt64, collections.TypedStorageOwnerColumnPart, false),
+			column("amount", "amount", collections.ColumnStoreValueInt64, collections.TypedStorageOwnerColumnPart, false),
+			column("kind", "kind", collections.ColumnStoreValueString, collections.TypedStorageOwnerRowAsset, true),
+		}
+	case modeHybridDocumentRow:
+		cfg.RetainedPayload = collections.ColumnRetainedPayloadFull
+		cfg.Columns = []collections.ColumnStoreColumn{
+			column("time_us", "time_us", collections.ColumnStoreValueInt64, collections.TypedStorageOwnerRowAsset, false),
+			column("amount", "amount", collections.ColumnStoreValueInt64, collections.TypedStorageOwnerRowAsset, false),
+			column("kind", "kind", collections.ColumnStoreValueString, collections.TypedStorageOwnerRowAsset, true),
+		}
+	case modeHybridDocumentCol:
+		cfg.RetainedPayload = collections.ColumnRetainedPayloadFull
+		cfg.Columns = []collections.ColumnStoreColumn{
+			column("time_us", "time_us", collections.ColumnStoreValueInt64, collections.TypedStorageOwnerColumnPart, false),
+			column("amount", "amount", collections.ColumnStoreValueInt64, collections.TypedStorageOwnerColumnPart, false),
+			column("kind", "kind", collections.ColumnStoreValueString, collections.TypedStorageOwnerRowAsset, true),
+		}
+	case modeHybridRowColumn:
+		cfg.Columns = []collections.ColumnStoreColumn{
+			column("time_us", "time_us", collections.ColumnStoreValueInt64, collections.TypedStorageOwnerColumnPart, false),
+			column("amount", "amount", collections.ColumnStoreValueInt64, collections.TypedStorageOwnerRowAsset, false),
+			column("kind", "kind", collections.ColumnStoreValueString, collections.TypedStorageOwnerRowAsset, true),
+		}
+	}
+	cfg.SortKey = []collections.ColumnSortKey{{Column: "time_us"}}
+	cfg.AggregateMetadata = []collections.ColumnAggregateMetadata{{Name: "rows", Kind: collections.ColumnAggregateCount}}
+	meta.Options.ColumnStore = cfg
+	return meta
+}
+
+func generateFixtureRows(cfg config) []fixtureRow {
+	rng := rand.New(rand.NewSource(cfg.Seed))
+	rows := make([]fixtureRow, cfg.Rows)
+	for i := range rows {
+		timeUS := int64(i)
+		switch cfg.Int64Distribution {
+		case "modulo":
+			timeUS = int64(i % max(1, cfg.Rows/10))
+		case "random":
+			timeUS = rng.Int63n(int64(max(1, cfg.Rows*2)))
+		case "descending":
+			timeUS = int64(cfg.Rows - i - 1)
+		}
+		amount := int64((i*17)%1000) - 100
+		kind := fmt.Sprintf("k%03d", i%cfg.StringCardinality)
+		payload := deterministicPayload(cfg.PayloadBytes, cfg.Seed, i)
+		id := []byte(fmt.Sprintf("doc%012d", i))
+		rows[i] = fixtureRow{ID: id, TimeUS: timeUS, Amount: amount, Kind: kind, Payload: payload}
+		rows[i].Doc = encodeFixtureDoc(rows[i], cfg.ExtraFields)
+	}
+	return rows
+}
+
+func deterministicPayload(n int, seed int64, row int) string {
+	if n <= 0 {
+		return ""
+	}
+	alphabet := "abcdefghijklmnopqrstuvwxyz0123456789"
+	var b strings.Builder
+	b.Grow(n)
+	start := int((seed + int64(row*13)) % int64(len(alphabet)))
+	for b.Len() < n {
+		b.WriteByte(alphabet[(start+b.Len())%len(alphabet)])
+	}
+	return b.String()
+}
+
+func encodeFixtureDoc(row fixtureRow, extraFields int) []byte {
+	var b bytes.Buffer
+	fmt.Fprintf(&b, `{"time_us":%d,"amount":%d,"kind":%q,"payload":%q`, row.TimeUS, row.Amount, row.Kind, row.Payload)
+	for i := 0; i < extraFields; i++ {
+		fmt.Fprintf(&b, `,"extra_%d":%d`, i, row.TimeUS+int64(i))
+	}
+	b.WriteByte('}')
+	return b.Bytes()
+}
+
+func insertRows(col *collections.Collection, rows []fixtureRow, batchSize int) error {
+	for start := 0; start < len(rows); start += batchSize {
+		end := start + batchSize
+		if end > len(rows) {
+			end = len(rows)
+		}
+		ids := make([][]byte, end-start)
+		docs := make([][]byte, end-start)
+		for i := start; i < end; i++ {
+			ids[i-start] = rows[i].ID
+			docs[i-start] = rows[i].Doc
+		}
+		if _, err := col.InsertBatch(ids, docs); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type workloadResult struct {
+	Ops             int64
+	Matches         int64
+	Aggregate       aggregate
+	Materialization materializationSummary
+	Diagnostics     diagnosticSummary
+}
+
+func executeWorkload(col *collections.Collection, rows []fixtureRow, cfg config) (workloadResult, error) {
+	switch cfg.Workload {
+	case workloadInsert:
+		return workloadResult{Ops: int64(len(rows))}, nil
+	case workloadPointGet:
+		return runPointGet(col, rows)
+	case workloadRangeFilter:
+		return runRangeFilter(col, rows, cfg)
+	case workloadRangeAggregate:
+		return runRangeAggregate(col, rows, cfg, false)
+	case workloadFullAggregate:
+		return runRangeAggregate(col, rows, cfg, true)
+	case workloadMixedRead:
+		pg, err := runPointGet(col, rows[:min(len(rows), 128)])
+		if err != nil {
+			return workloadResult{}, err
+		}
+		agg, err := runRangeAggregate(col, rows, cfg, false)
+		if err != nil {
+			return workloadResult{}, err
+		}
+		agg.Ops += pg.Ops
+		agg.Materialization.DocumentMaterializations += pg.Materialization.DocumentMaterializations
+		return agg, nil
+	case workloadReopenRead:
+		return runRangeAggregate(col, rows, cfg, false)
+	default:
+		return workloadResult{}, fmt.Errorf("unknown workload %q", cfg.Workload)
+	}
+}
+
+func runPointGet(col *collections.Collection, rows []fixtureRow) (workloadResult, error) {
+	var out workloadResult
+	for _, row := range rows {
+		doc, err := col.Get(row.ID)
+		if err != nil {
+			return out, err
+		}
+		if doc == nil {
+			return out, fmt.Errorf("missing document %s", row.ID)
+		}
+		out.Ops++
+		out.Matches++
+		out.Materialization.DocumentMaterializations++
+	}
+	return out, nil
+}
+
+func runRangeFilter(col *collections.Collection, rows []fixtureRow, cfg config) (workloadResult, error) {
+	low, high := queryRange(rows, false)
+	if modeHasTypedStorage(cfg.Mode) {
+		res, err := col.RunTypedColumnInt64PredicateScan(collections.TypedColumnInt64PredicateScanRequest{Column: "time_us", Kind: collections.TypedColumnInt64PredicateRange, Low: low, High: high, ColumnAssetReadIntegrity: collections.ColumnAssetReadIntegrity(cfg.ReadIntegrity)})
+		if err != nil {
+			return workloadResult{}, err
+		}
+		return workloadResult{Ops: 1, Matches: int64(len(res.Rows)), Diagnostics: diagnosticsFrom(res.Diagnostics), Materialization: materializationFrom(res.Diagnostics)}, nil
+	}
+	ids, _, err := col.FindByIndexRange(indexTimeUS, collections.IndexRangeOptions{Lower: collections.IndexRangeBound{Value: low, Inclusive: true}, Upper: collections.IndexRangeBound{Value: high, Inclusive: true}, Limit: len(rows) + 1})
+	if err != nil {
+		return workloadResult{}, err
+	}
+	return workloadResult{Ops: 1, Matches: int64(len(ids))}, nil
+}
+
+func runRangeAggregate(col *collections.Collection, rows []fixtureRow, cfg config, full bool) (workloadResult, error) {
+	low, high := queryRange(rows, full)
+	if modeHasTypedStorage(cfg.Mode) {
+		res, err := col.RunTypedColumnInt64PredicateAggregate(collections.TypedColumnInt64PredicateAggregateRequest{Column: "time_us", Kind: collections.TypedColumnInt64PredicateRange, Low: low, High: high, ColumnAssetReadIntegrity: collections.ColumnAssetReadIntegrity(cfg.ReadIntegrity)})
+		if err != nil {
+			return workloadResult{}, err
+		}
+		diag := diagnosticsFrom(res.Diagnostics)
+		return workloadResult{Ops: 1, Matches: res.Count, Aggregate: aggregate{Count: res.Count, Sum: res.Sum, Avg: res.Avg}, Diagnostics: diag, Materialization: materializationFrom(res.Diagnostics)}, nil
+	}
+	return scanDocumentAggregate(col, len(rows), low, high)
+}
+
+func scanDocumentAggregate(col *collections.Collection, maxDocs int, low, high int64) (workloadResult, error) {
+	var out workloadResult
+	_, err := col.ScanDocumentsFunc(maxDocs, func(record collections.DocumentRecord) (bool, error) {
+		out.Materialization.DocumentMaterializations++
+		var doc storedDoc
+		if err := json.Unmarshal(record.Document, &doc); err != nil {
+			return false, err
+		}
+		if doc.TimeUS >= low && doc.TimeUS <= high {
+			out.Matches++
+			out.Aggregate.Count++
+			out.Aggregate.Sum += doc.TimeUS
+		}
+		return true, nil
+	})
+	if err != nil {
+		return out, err
+	}
+	out.Ops = 1
+	if out.Aggregate.Count > 0 {
+		out.Aggregate.Avg = float64(out.Aggregate.Sum) / float64(out.Aggregate.Count)
+	}
+	return out, nil
+}
+
+func queryRange(rows []fixtureRow, full bool) (int64, int64) {
+	if full {
+		return math.MinInt64, math.MaxInt64
+	}
+	vals := make([]int64, len(rows))
+	for i := range rows {
+		vals[i] = rows[i].TimeUS
+	}
+	sort.Slice(vals, func(i, j int) bool { return vals[i] < vals[j] })
+	return vals[len(vals)/4], vals[(len(vals)*3)/4]
+}
+
+func modeHasTypedStorage(mode string) bool { return mode != modeDocument }
+
+func diagnosticsFrom(d collections.TypedColumnInt64PredicateScanDiagnostics) diagnosticSummary {
+	return diagnosticSummary{Fallback: d.Fallback, FallbackReason: d.FallbackReason, RowsScanned: d.RowsScanned, RowsMatched: d.RowsMatched, PartsConsidered: d.PartsConsidered, PartsPruned: d.PartsPruned, BlocksDecoded: d.BlocksDecoded, MappedBytes: d.MappedBytes, DecodedBytes: d.DecodedHeapCopyBytes, HeapCopyBytes: d.HeapCopyBytes, DecodedMetadataBytes: d.DecodedMetadataBytes, ReadIntegrity: d.ColumnAssetReadIntegrity}
+}
+
+func materializationFrom(d collections.TypedColumnInt64PredicateScanDiagnostics) materializationSummary {
+	return materializationSummary{DocumentMaterializations: d.DocumentMaterializations, RowMaterializations: d.RowMaterializations}
+}
+
+func durationMS(d time.Duration) float64 { return float64(d.Microseconds()) / 1000 }
+
+func printSummary(w interface{ Write([]byte) (int, error) }, s summary) {
+	fmt.Fprintf(w, "mode=%s workload=%s rows=%d\n", s.Mode, s.Workload, s.Rows)
+	fmt.Fprintf(w, "setup_ms=%.3f query_ms=%.3f ops_sec=%.2f rows_sec=%.2f\n", s.SetupMS, s.QueryMS, s.OpsSec, s.RowsSec)
+	fmt.Fprintf(w, "matches=%d count=%d sum=%d avg=%.3f\n", s.Matches, s.Aggregate.Count, s.Aggregate.Sum, s.Aggregate.Avg)
+	fmt.Fprintf(w, "document_materializations=%d row_materializations=%d mapped_bytes=%d decoded_bytes=%d\n", s.Materialization.DocumentMaterializations, s.Materialization.RowMaterializations, s.Diagnostics.MappedBytes, s.Diagnostics.DecodedBytes)
+	fmt.Fprintf(w, "db_dir=%s\n", s.DBDir)
+	if s.ProfileDir != "" {
+		fmt.Fprintf(w, "profile_dir=%s\n", s.ProfileDir)
+	}
+}
+
+func markdownSummary(s summary) string {
+	return fmt.Sprintf("# TreeDB collection demo\n\n- mode: `%s`\n- workload: `%s`\n- rows: `%d`\n- setup_ms: `%.3f`\n- query_ms: `%.3f`\n- matches: `%d`\n- count/sum/avg: `%d` / `%d` / `%.3f`\n- db_dir: `%s`\n", s.Mode, s.Workload, s.Rows, s.SetupMS, s.QueryMS, s.Matches, s.Aggregate.Count, s.Aggregate.Sum, s.Aggregate.Avg, s.DBDir)
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/cmd/treedb_collection_demo/main.go
+++ b/cmd/treedb_collection_demo/main.go
@@ -320,27 +320,12 @@ func validateConfig(cfg config) (config, error) {
 }
 
 func runDemo(cfg config) (summary, error) {
-	var err error
-	if cfg.Dir == "" {
-		cfg.Dir, err = os.MkdirTemp("", "treedb_collection_demo_")
-		if err != nil {
-			return summary{}, err
-		}
-	} else {
-		cfg.Dir, err = filepath.Abs(cfg.Dir)
-		if err != nil {
-			return summary{}, err
-		}
-		if err := os.RemoveAll(cfg.Dir); err != nil {
-			return summary{}, err
-		}
-		if err := os.MkdirAll(cfg.Dir, 0o755); err != nil {
-			return summary{}, err
-		}
+	dir, kept, dirCleanup, err := prepareDemoDir(cfg.Dir, cfg.KeepDir)
+	if err != nil {
+		return summary{}, err
 	}
-	if !cfg.KeepDir {
-		defer os.RemoveAll(cfg.Dir)
-	}
+	cfg.Dir = dir
+	defer dirCleanup()
 
 	prof, err := startProfiles(cfg.ProfileDir)
 	if err != nil {
@@ -349,7 +334,7 @@ func runDemo(cfg config) (summary, error) {
 	defer prof.stop()
 
 	rows := generateFixtureRows(cfg)
-	backend, cleanup, err := openDemoBackend(cfg.Dir)
+	backend, backendCleanup, err := openDemoBackend(cfg.Dir)
 	if err != nil {
 		return summary{}, err
 	}
@@ -359,7 +344,7 @@ func runDemo(cfg config) (summary, error) {
 			return nil
 		}
 		cleanupCalled = true
-		return cleanup()
+		return backendCleanup()
 	}
 	defer closeBackend()
 
@@ -391,7 +376,7 @@ func runDemo(cfg config) (summary, error) {
 		if err := closeBackend(); err != nil {
 			return summary{}, err
 		}
-		backend, cleanup, err = openDemoBackend(cfg.Dir)
+		backend, backendCleanup, err = openDemoBackend(cfg.Dir)
 		if err != nil {
 			return summary{}, err
 		}
@@ -416,7 +401,7 @@ func runDemo(cfg config) (summary, error) {
 		StringCardinality: cfg.StringCardinality, ExtraFields: cfg.ExtraFields,
 		SetupMS: durationMS(setupDur), QueryMS: durationMS(queryDur), Ops: result.Ops,
 		Matches: result.Matches, Aggregate: result.Aggregate, Materialization: result.Materialization,
-		Diagnostics: result.Diagnostics, DBDir: cfg.Dir, ProfileDir: cfg.ProfileDir, KeptDir: cfg.KeepDir,
+		Diagnostics: result.Diagnostics, DBDir: cfg.Dir, ProfileDir: cfg.ProfileDir, KeptDir: kept,
 	}
 	if queryDur > 0 && result.Ops > 0 {
 		out.OpsSec = float64(result.Ops) / queryDur.Seconds()
@@ -492,6 +477,74 @@ func (p *profileRun) writeSummary(out summary) error {
 		return err
 	}
 	return os.WriteFile(filepath.Join(p.dir, "summary.md"), []byte(markdownSummary(out)), 0o644)
+}
+
+func prepareDemoDir(dir string, keep bool) (string, bool, func(), error) {
+	if strings.TrimSpace(dir) == "" {
+		tmp, err := os.MkdirTemp("", "treedb_collection_demo_")
+		if err != nil {
+			return "", false, nil, err
+		}
+		if keep {
+			return tmp, true, func() {}, nil
+		}
+		return tmp, false, func() { _ = os.RemoveAll(tmp) }, nil
+	}
+	abs, err := validateFreshDemoDir(dir)
+	if err != nil {
+		return "", false, nil, err
+	}
+	if err := ensureFreshDemoDir(abs); err != nil {
+		return "", false, nil, err
+	}
+	return abs, true, func() {}, nil
+}
+
+func validateFreshDemoDir(dir string) (string, error) {
+	cleanInput := filepath.Clean(strings.TrimSpace(dir))
+	if cleanInput == "" || cleanInput == "." || cleanInput == ".." || demoDirHasParentTraversal(cleanInput) {
+		return "", fmt.Errorf("refusing unsafe demo directory %q", dir)
+	}
+	abs, err := filepath.Abs(cleanInput)
+	if err != nil {
+		return "", err
+	}
+	abs = filepath.Clean(abs)
+	root := filepath.VolumeName(abs) + string(os.PathSeparator)
+	if abs == root || len(abs) < 8 || abs == filepath.Clean(os.TempDir()) {
+		return "", fmt.Errorf("refusing unsafe demo directory %q", dir)
+	}
+	return abs, nil
+}
+
+func demoDirHasParentTraversal(path string) bool {
+	for _, part := range strings.FieldsFunc(path, func(r rune) bool { return r == '/' || r == '\\' }) {
+		if part == ".." {
+			return true
+		}
+	}
+	return false
+}
+
+func ensureFreshDemoDir(abs string) error {
+	info, err := os.Stat(abs)
+	if err == nil {
+		if !info.IsDir() {
+			return fmt.Errorf("-dir %q exists and is not a directory", abs)
+		}
+		entries, err := os.ReadDir(abs)
+		if err != nil {
+			return err
+		}
+		if len(entries) > 0 {
+			return fmt.Errorf("-dir %q already exists and is not empty; choose a fresh directory", abs)
+		}
+		return nil
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		return os.MkdirAll(abs, 0o755)
+	}
+	return err
 }
 
 func openDemoBackend(dir string) (*backenddb.DB, func() error, error) {

--- a/cmd/treedb_collection_demo/main.go
+++ b/cmd/treedb_collection_demo/main.go
@@ -644,11 +644,22 @@ func deterministicPayload(n int, seed int64, row int) string {
 	alphabet := "abcdefghijklmnopqrstuvwxyz0123456789"
 	var b strings.Builder
 	b.Grow(n)
-	start := int((seed + int64(row*13)) % int64(len(alphabet)))
+	start := positiveModulo(seed+int64(row*13), len(alphabet))
 	for b.Len() < n {
 		b.WriteByte(alphabet[(start+b.Len())%len(alphabet)])
 	}
 	return b.String()
+}
+
+func positiveModulo(value int64, mod int) int {
+	if mod <= 0 {
+		return 0
+	}
+	out := value % int64(mod)
+	if out < 0 {
+		out += int64(mod)
+	}
+	return int(out)
 }
 
 func encodeFixtureDoc(row fixtureRow, extraFields int) []byte {

--- a/cmd/treedb_collection_demo/main.go
+++ b/cmd/treedb_collection_demo/main.go
@@ -508,8 +508,12 @@ func prepareDemoDir(dir string, keep bool) (string, bool, func(), error) {
 }
 
 func validateFreshDemoDir(dir string) (string, error) {
-	cleanInput := filepath.Clean(strings.TrimSpace(dir))
-	if cleanInput == "" || cleanInput == "." || cleanInput == ".." || demoDirHasParentTraversal(cleanInput) {
+	rawInput := strings.TrimSpace(dir)
+	if rawInput == "" || demoDirHasParentTraversal(rawInput) {
+		return "", fmt.Errorf("refusing unsafe demo directory %q", dir)
+	}
+	cleanInput := filepath.Clean(rawInput)
+	if cleanInput == "." || cleanInput == ".." {
 		return "", fmt.Errorf("refusing unsafe demo directory %q", dir)
 	}
 	abs, err := filepath.Abs(cleanInput)

--- a/cmd/treedb_collection_demo/main.go
+++ b/cmd/treedb_collection_demo/main.go
@@ -43,6 +43,7 @@ const (
 	defaultStringCardinality = 16
 	defaultExtraFields       = 2
 	defaultSeed              = int64(1)
+	minFreshDemoDirBytes     = 8
 )
 
 type config struct {
@@ -515,7 +516,7 @@ func validateFreshDemoDir(dir string) (string, error) {
 	}
 	abs = filepath.Clean(abs)
 	root := filepath.VolumeName(abs) + string(os.PathSeparator)
-	if abs == root || len(abs) < 8 || abs == filepath.Clean(os.TempDir()) {
+	if abs == root || len(abs) < minFreshDemoDirBytes || abs == filepath.Clean(os.TempDir()) {
 		return "", fmt.Errorf("refusing unsafe demo directory %q", dir)
 	}
 	return abs, nil
@@ -651,13 +652,20 @@ func deterministicPayload(n int, seed int64, row int) string {
 }
 
 func encodeFixtureDoc(row fixtureRow, extraFields int) []byte {
-	var b bytes.Buffer
-	fmt.Fprintf(&b, `{"time_us":%d,"amount":%d,"kind":%q,"payload":%q`, row.TimeUS, row.Amount, row.Kind, row.Payload)
-	for i := 0; i < extraFields; i++ {
-		fmt.Fprintf(&b, `,"extra_%d":%d`, i, row.TimeUS+int64(i))
+	doc := map[string]any{
+		"time_us": row.TimeUS,
+		"amount":  row.Amount,
+		"kind":    row.Kind,
+		"payload": row.Payload,
 	}
-	b.WriteByte('}')
-	return b.Bytes()
+	for i := 0; i < extraFields; i++ {
+		doc[fmt.Sprintf("extra_%d", i)] = row.TimeUS + int64(i)
+	}
+	encoded, err := json.Marshal(doc)
+	if err != nil {
+		panic(fmt.Sprintf("encode deterministic fixture document: %v", err))
+	}
+	return encoded
 }
 
 func insertRows(col *collections.Collection, rows []fixtureRow, batchSize int) error {
@@ -804,7 +812,7 @@ func queryRange(rows []fixtureRow, full bool) (int64, int64) {
 func modeHasTypedStorage(mode string) bool { return mode != modeDocument }
 
 func diagnosticsFrom(d collections.TypedColumnInt64PredicateScanDiagnostics) diagnosticSummary {
-	return diagnosticSummary{Fallback: d.Fallback, FallbackReason: d.FallbackReason, RowsScanned: d.RowsScanned, RowsMatched: d.RowsMatched, PartsConsidered: d.PartsConsidered, PartsPruned: d.PartsPruned, BlocksDecoded: d.BlocksDecoded, MappedBytes: d.MappedBytes, DecodedBytes: d.DecodedHeapCopyBytes, HeapCopyBytes: d.HeapCopyBytes, DecodedMetadataBytes: d.DecodedMetadataBytes, ReadIntegrity: d.ColumnAssetReadIntegrity}
+	return diagnosticSummary{Fallback: d.Fallback, FallbackReason: d.FallbackReason, RowsScanned: d.RowsScanned, RowsMatched: d.RowsMatched, PartsConsidered: d.PartsConsidered, PartsPruned: d.PartsPruned, BlocksDecoded: d.BlocksDecoded, MappedBytes: d.MappedBytes, DecodedBytes: d.DecodedMetadataBytes + d.DecodedHeapCopyBytes, HeapCopyBytes: d.HeapCopyBytes, DecodedMetadataBytes: d.DecodedMetadataBytes, ReadIntegrity: d.ColumnAssetReadIntegrity}
 }
 
 func materializationFrom(d collections.TypedColumnInt64PredicateScanDiagnostics) materializationSummary {
@@ -826,17 +834,4 @@ func printSummary(w interface{ Write([]byte) (int, error) }, s summary) {
 
 func markdownSummary(s summary) string {
 	return fmt.Sprintf("# TreeDB collection demo\n\n- mode: `%s`\n- workload: `%s`\n- rows: `%d`\n- setup_ms: `%.3f`\n- query_ms: `%.3f`\n- matches: `%d`\n- count/sum/avg: `%d` / `%d` / `%.3f`\n- db_dir: `%s`\n", s.Mode, s.Workload, s.Rows, s.SetupMS, s.QueryMS, s.Matches, s.Aggregate.Count, s.Aggregate.Sum, s.Aggregate.Avg, s.DBDir)
-}
-
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-func max(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
 }

--- a/cmd/treedb_collection_demo/main.go
+++ b/cmd/treedb_collection_demo/main.go
@@ -183,6 +183,9 @@ func parseConfig(args []string) (config, error) {
 	if err := fs.Parse(args); err != nil {
 		return config{}, err
 	}
+	if fs.NArg() != 0 {
+		return config{}, fmt.Errorf("unexpected positional arguments: %s", strings.Join(fs.Args(), " "))
+	}
 	visited := map[string]bool{}
 	fs.Visit(func(f *flag.Flag) { visited[f.Name] = true })
 
@@ -823,7 +826,23 @@ func queryRange(rows []fixtureRow, full bool) (int64, int64) {
 func modeHasTypedStorage(mode string) bool { return mode != modeDocument }
 
 func diagnosticsFrom(d collections.TypedColumnInt64PredicateScanDiagnostics) diagnosticSummary {
-	return diagnosticSummary{Fallback: d.Fallback, FallbackReason: d.FallbackReason, RowsScanned: d.RowsScanned, RowsMatched: d.RowsMatched, PartsConsidered: d.PartsConsidered, PartsPruned: d.PartsPruned, BlocksDecoded: d.BlocksDecoded, MappedBytes: d.MappedBytes, DecodedBytes: d.DecodedMetadataBytes + d.DecodedHeapCopyBytes, HeapCopyBytes: d.HeapCopyBytes, DecodedMetadataBytes: d.DecodedMetadataBytes, ReadIntegrity: d.ColumnAssetReadIntegrity}
+	// TypedColumnInt64PredicateScanDiagnostics exposes decoded metadata and decoded
+	// candidate payload bytes separately. The demo's decoded_bytes output is the
+	// total decoded byte budget for the query.
+	return diagnosticSummary{
+		Fallback:             d.Fallback,
+		FallbackReason:       d.FallbackReason,
+		RowsScanned:          d.RowsScanned,
+		RowsMatched:          d.RowsMatched,
+		PartsConsidered:      d.PartsConsidered,
+		PartsPruned:          d.PartsPruned,
+		BlocksDecoded:        d.BlocksDecoded,
+		MappedBytes:          d.MappedBytes,
+		DecodedBytes:         d.DecodedMetadataBytes + d.DecodedHeapCopyBytes,
+		HeapCopyBytes:        d.HeapCopyBytes,
+		DecodedMetadataBytes: d.DecodedMetadataBytes,
+		ReadIntegrity:        d.ColumnAssetReadIntegrity,
+	}
 }
 
 func materializationFrom(d collections.TypedColumnInt64PredicateScanDiagnostics) materializationSummary {

--- a/cmd/treedb_collection_demo/main.go
+++ b/cmd/treedb_collection_demo/main.go
@@ -43,7 +43,6 @@ const (
 	defaultStringCardinality = 16
 	defaultExtraFields       = 2
 	defaultSeed              = int64(1)
-	minFreshDemoDirBytes     = 8
 )
 
 type config struct {
@@ -519,7 +518,7 @@ func validateFreshDemoDir(dir string) (string, error) {
 	}
 	abs = filepath.Clean(abs)
 	root := filepath.VolumeName(abs) + string(os.PathSeparator)
-	if abs == root || len(abs) < minFreshDemoDirBytes || abs == filepath.Clean(os.TempDir()) {
+	if abs == root || abs == filepath.Clean(os.TempDir()) {
 		return "", fmt.Errorf("refusing unsafe demo directory %q", dir)
 	}
 	return abs, nil

--- a/cmd/treedb_collection_demo/main.go
+++ b/cmd/treedb_collection_demo/main.go
@@ -403,14 +403,18 @@ func runDemo(cfg config) (summary, error) {
 		Matches: result.Matches, Aggregate: result.Aggregate, Materialization: result.Materialization,
 		Diagnostics: result.Diagnostics, DBDir: cfg.Dir, ProfileDir: cfg.ProfileDir, KeptDir: kept,
 	}
-	if queryDur > 0 && result.Ops > 0 {
-		out.OpsSec = float64(result.Ops) / queryDur.Seconds()
-	}
-	if queryDur > 0 {
-		out.RowsSec = float64(cfg.Rows) / queryDur.Seconds()
-	}
-	if cfg.Workload == workloadInsert && setupDur > 0 {
-		out.RowsSec = float64(cfg.Rows) / setupDur.Seconds()
+	if cfg.Workload == workloadInsert {
+		if setupDur > 0 {
+			out.OpsSec = float64(result.Ops) / setupDur.Seconds()
+			out.RowsSec = float64(cfg.Rows) / setupDur.Seconds()
+		}
+	} else {
+		if queryDur > 0 && result.Ops > 0 {
+			out.OpsSec = float64(result.Ops) / queryDur.Seconds()
+		}
+		if queryDur > 0 {
+			out.RowsSec = float64(cfg.Rows) / queryDur.Seconds()
+		}
 	}
 	if err := prof.writeSummary(out); err != nil {
 		return summary{}, err

--- a/cmd/treedb_collection_demo/main_test.go
+++ b/cmd/treedb_collection_demo/main_test.go
@@ -137,6 +137,12 @@ func TestExplicitDirMustBeFresh(t *testing.T) {
 	}
 }
 
+func TestValidateFreshDemoDirRejectsRawParentTraversal(t *testing.T) {
+	if _, err := validateFreshDemoDir("safe/../other"); err == nil {
+		t.Fatal("validateFreshDemoDir accepted raw parent traversal")
+	}
+}
+
 func TestValidateFreshDemoDirAllowsShortExplicitPath(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("absolute /tmp/db shape is Unix-specific")

--- a/cmd/treedb_collection_demo/main_test.go
+++ b/cmd/treedb_collection_demo/main_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -133,6 +134,19 @@ func TestExplicitDirMustBeFresh(t *testing.T) {
 	}
 	if got, err := os.ReadFile(filepath.Join(dir, "keep.txt")); err != nil || string(got) != "keep" {
 		t.Fatalf("sentinel changed: got=%q err=%v", got, err)
+	}
+}
+
+func TestValidateFreshDemoDirAllowsShortExplicitPath(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("absolute /tmp/db shape is Unix-specific")
+	}
+	got, err := validateFreshDemoDir("/tmp/db")
+	if err != nil {
+		t.Fatalf("validateFreshDemoDir rejected short explicit path: %v", err)
+	}
+	if got != "/tmp/db" {
+		t.Fatalf("path=%q want /tmp/db", got)
 	}
 }
 

--- a/cmd/treedb_collection_demo/main_test.go
+++ b/cmd/treedb_collection_demo/main_test.go
@@ -4,8 +4,16 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
+
+func TestParseConfigRejectsPositionals(t *testing.T) {
+	_, err := parseConfig([]string{"unexpected"})
+	if err == nil || !strings.Contains(err.Error(), "unexpected positional arguments") {
+		t.Fatalf("err=%v want unexpected positional rejection", err)
+	}
+}
 
 func TestParseConfigPresetOverride(t *testing.T) {
 	cfg, err := parseConfig([]string{"-preset", "event-analytics", "-rows", "123", "-batch-size", "7", "-mode", "document"})

--- a/cmd/treedb_collection_demo/main_test.go
+++ b/cmd/treedb_collection_demo/main_test.go
@@ -40,6 +40,16 @@ func TestGenerateFixtureRowsDeterministic(t *testing.T) {
 	}
 }
 
+func TestDeterministicPayloadHandlesNegativeSeed(t *testing.T) {
+	got := deterministicPayload(64, -99, 3)
+	if len(got) != 64 {
+		t.Fatalf("payload len=%d want 64", len(got))
+	}
+	if got != deterministicPayload(64, -99, 3) {
+		t.Fatalf("negative-seed payload is not deterministic")
+	}
+}
+
 func TestAggregateParityAcrossModes(t *testing.T) {
 	modes := []string{modeDocument, modeTypedRow, modeTypedColumn, modeHybridDocumentRow, modeHybridDocumentCol, modeHybridRowColumn}
 	var wantCount, wantSum int64

--- a/cmd/treedb_collection_demo/main_test.go
+++ b/cmd/treedb_collection_demo/main_test.go
@@ -82,6 +82,26 @@ func TestReopenReadSmoke(t *testing.T) {
 	}
 }
 
+func TestInsertWorkloadReportsSetupThroughput(t *testing.T) {
+	cfg := defaultConfig()
+	cfg.Mode = modeTypedColumn
+	cfg.Workload = workloadInsert
+	cfg.Rows = 32
+	cfg.BatchSize = 16
+	cfg.PayloadBytes = 8
+	cfg.Dir = filepath.Join(t.TempDir(), "db")
+	got, err := runDemo(cfg)
+	if err != nil {
+		t.Fatalf("runDemo insert: %v", err)
+	}
+	if got.Ops != int64(cfg.Rows) || got.OpsSec <= 0 || got.RowsSec <= 0 {
+		t.Fatalf("insert counters not populated from setup timing: %+v", got)
+	}
+	if got.QueryMS < 0 {
+		t.Fatalf("query_ms should not be negative: %+v", got)
+	}
+}
+
 func TestExplicitDirMustBeFresh(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "keep.txt"), []byte("keep"), 0o600); err != nil {

--- a/cmd/treedb_collection_demo/main_test.go
+++ b/cmd/treedb_collection_demo/main_test.go
@@ -82,6 +82,22 @@ func TestReopenReadSmoke(t *testing.T) {
 	}
 }
 
+func TestExplicitDirMustBeFresh(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "keep.txt"), []byte("keep"), 0o600); err != nil {
+		t.Fatalf("write sentinel: %v", err)
+	}
+	cfg := defaultConfig()
+	cfg.Rows = 8
+	cfg.Dir = dir
+	if _, err := runDemo(cfg); err == nil {
+		t.Fatal("runDemo accepted non-empty explicit dir")
+	}
+	if got, err := os.ReadFile(filepath.Join(dir, "keep.txt")); err != nil || string(got) != "keep" {
+		t.Fatalf("sentinel changed: got=%q err=%v", got, err)
+	}
+}
+
 func TestProfileArtifactsCreated(t *testing.T) {
 	profileDir := t.TempDir()
 	cfg := defaultConfig()

--- a/cmd/treedb_collection_demo/main_test.go
+++ b/cmd/treedb_collection_demo/main_test.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseConfigPresetOverride(t *testing.T) {
+	cfg, err := parseConfig([]string{"-preset", "event-analytics", "-rows", "123", "-batch-size", "7", "-mode", "document"})
+	if err != nil {
+		t.Fatalf("parseConfig: %v", err)
+	}
+	if cfg.Preset != "event-analytics" || cfg.Workload != workloadRangeAggregate {
+		t.Fatalf("preset not applied: %+v", cfg)
+	}
+	if cfg.Rows != 123 || cfg.BatchSize != 7 || cfg.Mode != modeDocument {
+		t.Fatalf("explicit flags did not override preset: %+v", cfg)
+	}
+}
+
+func TestGenerateFixtureRowsDeterministic(t *testing.T) {
+	cfg := defaultConfig()
+	cfg.Rows = 8
+	cfg.PayloadBytes = 17
+	cfg.ExtraFields = 3
+	cfg.Int64Distribution = "random"
+	cfg.Seed = 99
+
+	first := generateFixtureRows(cfg)
+	second := generateFixtureRows(cfg)
+	if len(first) != len(second) {
+		t.Fatalf("length mismatch")
+	}
+	for i := range first {
+		if !bytes.Equal(first[i].ID, second[i].ID) || !bytes.Equal(first[i].Doc, second[i].Doc) || first[i].TimeUS != second[i].TimeUS {
+			t.Fatalf("row %d differs:\n%+v\n%+v", i, first[i], second[i])
+		}
+	}
+}
+
+func TestAggregateParityAcrossModes(t *testing.T) {
+	modes := []string{modeDocument, modeTypedRow, modeTypedColumn, modeHybridDocumentRow, modeHybridDocumentCol, modeHybridRowColumn}
+	var wantCount, wantSum int64
+	for i, mode := range modes {
+		cfg := defaultConfig()
+		cfg.Mode = mode
+		cfg.Rows = 48
+		cfg.BatchSize = 16
+		cfg.PayloadBytes = 8
+		cfg.ExtraFields = 1
+		cfg.Dir = filepath.Join(t.TempDir(), "db")
+		got, err := runDemo(cfg)
+		if err != nil {
+			t.Fatalf("runDemo mode=%s: %v", mode, err)
+		}
+		if i == 0 {
+			wantCount, wantSum = got.Aggregate.Count, got.Aggregate.Sum
+			continue
+		}
+		if got.Aggregate.Count != wantCount || got.Aggregate.Sum != wantSum {
+			t.Fatalf("mode=%s aggregate count=%d sum=%d want count=%d sum=%d", mode, got.Aggregate.Count, got.Aggregate.Sum, wantCount, wantSum)
+		}
+	}
+}
+
+func TestReopenReadSmoke(t *testing.T) {
+	cfg := defaultConfig()
+	cfg.Mode = modeTypedColumn
+	cfg.Workload = workloadReopenRead
+	cfg.Rows = 64
+	cfg.BatchSize = 32
+	cfg.PayloadBytes = 8
+	cfg.Dir = filepath.Join(t.TempDir(), "db")
+	got, err := runDemo(cfg)
+	if err != nil {
+		t.Fatalf("runDemo reopen-read: %v", err)
+	}
+	if got.Matches == 0 || got.Aggregate.Count == 0 {
+		t.Fatalf("unexpected reopen-read result: %+v", got)
+	}
+}
+
+func TestProfileArtifactsCreated(t *testing.T) {
+	profileDir := t.TempDir()
+	cfg := defaultConfig()
+	cfg.Mode = modeTypedColumn
+	cfg.Rows = 128
+	cfg.BatchSize = 64
+	cfg.PayloadBytes = 8
+	cfg.Dir = filepath.Join(t.TempDir(), "db")
+	cfg.ProfileDir = profileDir
+	if _, err := runDemo(cfg); err != nil {
+		t.Fatalf("runDemo profile: %v", err)
+	}
+	for _, name := range []string{"cpu.pprof", "allocs.pprof", "summary.json", "summary.md"} {
+		path := filepath.Join(profileDir, name)
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("missing profile artifact %s: %v", name, err)
+		}
+		if info.Size() == 0 {
+			t.Fatalf("profile artifact %s is empty", name)
+		}
+	}
+}

--- a/cmd/treedb_vector_demo/README.md
+++ b/cmd/treedb_vector_demo/README.md
@@ -1,0 +1,38 @@
+# treedb_vector_demo
+
+Quickstart/profile harness for TreeDB vector/RAG collection layouts. It creates a
+fresh DB (explicit `-dir` values must be absent or empty), publishes deterministic embeddings as typed-column dense
+`float32_vector` sections, rebuilds a `column_graph` vector index, reopens the DB,
+and runs vector query smoke tests.
+
+Example:
+
+```sh
+go run ./cmd/treedb_vector_demo \
+  -rows 1000 \
+  -dims 128 \
+  -vectors typed-column \
+  -metadata typed-row \
+  -queries 10
+```
+
+Metadata can be stored in retained documents (`-metadata document`) or typed-row
+fields (`-metadata typed-row`). The pre-alpha demo currently requires
+`-vectors typed-column`; unsupported vector storage modes fail clearly instead
+of silently using a different path.
+
+Use `-final-fetch` to time full-document fetch after top-k selection. Use
+`-metadata-filter` for a deterministic tenant filter smoke; this uses exact
+scoring while still publishing typed-column vector assets because public
+`column_graph` metadata predicates are not wired yet.
+
+When `-profile-dir` is set, the command writes:
+
+- `vector_demo_cpu.pprof`
+- `vector_demo_allocs.pprof`
+- `vector_demo_summary.json`
+- `vector_demo_summary.md`
+
+Useful presets: `vector-rag` and `perf-engineer`. Explicit flags such as
+`-rows`, `-dims`, `-queries`, `-top-k`, `-batch-size`, and `-profile-dir`
+override preset defaults.

--- a/cmd/treedb_vector_demo/main.go
+++ b/cmd/treedb_vector_demo/main.go
@@ -587,10 +587,7 @@ func prepareFreshDir(dir string, keep bool) (string, bool, func(), error) {
 	if err != nil {
 		return "", false, nil, err
 	}
-	if err := os.RemoveAll(abs); err != nil {
-		return "", false, nil, err
-	}
-	if err := os.MkdirAll(abs, 0o755); err != nil {
+	if err := ensureFreshDemoDir(abs); err != nil {
 		return "", false, nil, err
 	}
 	return abs, true, func() {}, nil
@@ -598,7 +595,7 @@ func prepareFreshDir(dir string, keep bool) (string, bool, func(), error) {
 
 func validateFreshDemoDir(dir string) (string, error) {
 	cleanInput := filepath.Clean(strings.TrimSpace(dir))
-	if cleanInput == "" || cleanInput == "." || cleanInput == ".." || strings.Contains(cleanInput, ".."+string(os.PathSeparator)) {
+	if cleanInput == "" || cleanInput == "." || cleanInput == ".." || demoDirHasParentTraversal(cleanInput) {
 		return "", fmt.Errorf("refusing unsafe demo directory %q", dir)
 	}
 	abs, err := filepath.Abs(cleanInput)
@@ -611,6 +608,36 @@ func validateFreshDemoDir(dir string) (string, error) {
 		return "", fmt.Errorf("refusing unsafe demo directory %q", dir)
 	}
 	return abs, nil
+}
+
+func demoDirHasParentTraversal(path string) bool {
+	for _, part := range strings.FieldsFunc(path, func(r rune) bool { return r == '/' || r == '\\' }) {
+		if part == ".." {
+			return true
+		}
+	}
+	return false
+}
+
+func ensureFreshDemoDir(abs string) error {
+	info, err := os.Stat(abs)
+	if err == nil {
+		if !info.IsDir() {
+			return fmt.Errorf("-dir %q exists and is not a directory", abs)
+		}
+		entries, err := os.ReadDir(abs)
+		if err != nil {
+			return err
+		}
+		if len(entries) > 0 {
+			return fmt.Errorf("-dir %q already exists and is not empty; choose a fresh directory", abs)
+		}
+		return nil
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		return os.MkdirAll(abs, 0o755)
+	}
+	return err
 }
 
 func writeProfileArtifacts(dir string, res *result) error {

--- a/cmd/treedb_vector_demo/main.go
+++ b/cmd/treedb_vector_demo/main.go
@@ -550,6 +550,7 @@ func runExactFilteredQueries(col *collections.Collection, rows []vectorRow, quer
 		if len(hits) == 0 {
 			return fmt.Errorf("query %s returned no exact filtered results", q.Name)
 		}
+		res.Candidates += uint64(filteredRows)
 		res.ScoredVectors += uint64(filteredRows)
 		if i == 0 {
 			res.FirstResults = hits
@@ -569,6 +570,7 @@ func runExactFilteredQueries(col *collections.Collection, rows []vectorRow, quer
 	}
 	searchElapsed := time.Since(searchStart) - fetchElapsed
 	setSearchTiming(res, cfg.Queries, searchElapsed, fetchElapsed)
+	res.CandidatesPerSearch = float64(res.Candidates) / float64(cfg.Queries)
 	return nil
 }
 

--- a/cmd/treedb_vector_demo/main.go
+++ b/cmd/treedb_vector_demo/main.go
@@ -1,0 +1,688 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"math"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"runtime"
+	"runtime/pprof"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/snissn/gomap/TreeDB/collections"
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+)
+
+const (
+	vectorIndexName      = "embedding_graph"
+	collectionName       = "docs"
+	defaultPreset        = "vector-rag"
+	defaultFilterTenant  = "tenant-00"
+	minFreshDemoDirBytes = 8
+)
+
+type config struct {
+	Rows           int
+	Dims           int
+	VectorMode     string
+	MetadataMode   string
+	Queries        int
+	TopK           int
+	MetadataFilter bool
+	FinalFetch     bool
+	Dir            string
+	KeepDir        bool
+	Seed           int64
+	ProfileDir     string
+	Preset         string
+	EfSearch       int
+	MaxDecoded     int
+}
+
+type vectorRow struct {
+	ID       string
+	Tenant   string
+	Title    string
+	TimeUS   int64
+	Category string
+	Vector   []float32
+}
+
+type queryFixture struct {
+	Name   string
+	Vector []float32
+}
+
+type searchHit struct {
+	ID      string  `json:"id"`
+	Ordinal int     `json:"ordinal"`
+	Score   float64 `json:"score"`
+}
+
+type result struct {
+	Preset                    string      `json:"preset"`
+	Dir                       string      `json:"dir"`
+	KeptDir                   bool        `json:"kept_dir"`
+	Rows                      int         `json:"rows"`
+	Dims                      int         `json:"dims"`
+	Queries                   int         `json:"queries"`
+	TopK                      int         `json:"top_k"`
+	VectorMode                string      `json:"vector_mode"`
+	MetadataMode              string      `json:"metadata_mode"`
+	MetadataFilter            bool        `json:"metadata_filter"`
+	MetadataFilterDescription string      `json:"metadata_filter_description,omitempty"`
+	FinalFetch                bool        `json:"final_fetch"`
+	SearchPath                string      `json:"search_path"`
+	SetupMillis               float64     `json:"setup_ms"`
+	SearchMillis              float64     `json:"search_ms"`
+	FetchMillis               float64     `json:"fetch_ms"`
+	OpsPerSecond              float64     `json:"ops_sec"`
+	Candidates                uint64      `json:"candidates"`
+	CandidatesPerSearch       float64     `json:"candidates_per_search"`
+	ScoredVectors             uint64      `json:"scored_vectors"`
+	DocsFetched               uint64      `json:"docs_fetched"`
+	DocumentBytes             uint64      `json:"document_bytes"`
+	MappedBytes               uint64      `json:"mapped_bytes"`
+	HeapCopyBytes             uint64      `json:"heap_copy_bytes"`
+	DecodedBytes              uint64      `json:"decoded_bytes"`
+	PhysicalBytesRead         int64       `json:"physical_bytes_read"`
+	VectorDirectViews         uint64      `json:"vector_direct_views"`
+	VectorScratchDecodes      uint64      `json:"vector_scratch_decodes"`
+	TypedColumnFallbacks      uint64      `json:"typed_column_fallbacks"`
+	ProfileDir                string      `json:"profile_dir,omitempty"`
+	CPUProfile                string      `json:"cpu_profile,omitempty"`
+	AllocsProfile             string      `json:"allocs_profile,omitempty"`
+	SummaryJSON               string      `json:"summary_json,omitempty"`
+	SummaryMarkdown           string      `json:"summary_markdown,omitempty"`
+	FirstResults              []searchHit `json:"first_results,omitempty"`
+}
+
+func main() {
+	if err := run(os.Args[1:], os.Stdout, os.Stderr); err != nil {
+		fmt.Fprintf(os.Stderr, "treedb_vector_demo: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(args []string, stdout, stderr io.Writer) error {
+	cfg, err := parseConfig(args)
+	if err != nil {
+		return err
+	}
+	var cpuFile *os.File
+	if cfg.ProfileDir != "" {
+		if err := os.MkdirAll(cfg.ProfileDir, 0o755); err != nil {
+			return err
+		}
+		path := filepath.Join(cfg.ProfileDir, "vector_demo_cpu.pprof")
+		cpuFile, err = os.Create(path)
+		if err != nil {
+			return err
+		}
+		if err := pprof.StartCPUProfile(cpuFile); err != nil {
+			_ = cpuFile.Close()
+			return err
+		}
+	}
+	res, execErr := execute(context.Background(), cfg)
+	if cpuFile != nil {
+		pprof.StopCPUProfile()
+		if err := cpuFile.Close(); execErr == nil && err != nil {
+			execErr = err
+		}
+	}
+	if execErr != nil {
+		return execErr
+	}
+	if cfg.ProfileDir != "" {
+		if err := writeProfileArtifacts(cfg.ProfileDir, &res); err != nil {
+			return err
+		}
+	}
+	printText(stdout, res)
+	if !res.KeptDir {
+		fmt.Fprintln(stderr, "temporary db removed; rerun with -keep-dir to inspect files")
+	}
+	return nil
+}
+
+func parseConfig(args []string) (config, error) {
+	preset, err := scanPreset(args)
+	if err != nil {
+		return config{}, err
+	}
+	cfg, err := presetConfig(preset)
+	if err != nil {
+		return config{}, err
+	}
+	fs := flag.NewFlagSet("treedb_vector_demo", flag.ContinueOnError)
+	fs.IntVar(&cfg.Rows, "rows", cfg.Rows, "number of deterministic documents/vectors to load")
+	fs.IntVar(&cfg.Dims, "dims", cfg.Dims, "embedding dimensions")
+	fs.StringVar(&cfg.VectorMode, "vectors", cfg.VectorMode, "vector storage mode: document, typed-row, typed-column")
+	fs.StringVar(&cfg.MetadataMode, "metadata", cfg.MetadataMode, "metadata storage mode: document, typed-row, typed-column")
+	fs.IntVar(&cfg.Queries, "queries", cfg.Queries, "number of vector queries to run")
+	fs.IntVar(&cfg.TopK, "top-k", cfg.TopK, "nearest neighbors per query")
+	fs.BoolVar(&cfg.MetadataFilter, "metadata-filter", cfg.MetadataFilter, "restrict scoring/search output to a deterministic tenant filter when supported")
+	fs.BoolVar(&cfg.FinalFetch, "final-fetch", cfg.FinalFetch, "fetch full documents after top-k selection and time that separately")
+	fs.StringVar(&cfg.Dir, "dir", cfg.Dir, "TreeDB directory; empty uses a temporary directory")
+	fs.BoolVar(&cfg.KeepDir, "keep-dir", cfg.KeepDir, "keep an automatically-created temporary DB directory after the run")
+	fs.Int64Var(&cfg.Seed, "seed", cfg.Seed, "deterministic fixture seed")
+	fs.StringVar(&cfg.ProfileDir, "profile-dir", cfg.ProfileDir, "optional directory for vector_demo_cpu.pprof, vector_demo_allocs.pprof, and summaries")
+	fs.StringVar(&cfg.Preset, "preset", cfg.Preset, "persona preset: vector-rag or perf-engineer")
+	fs.IntVar(&cfg.EfSearch, "ef-search", cfg.EfSearch, "column_graph graph exploration bound; 0 uses index default")
+	fs.IntVar(&cfg.MaxDecoded, "max-decoded-blocks", cfg.MaxDecoded, "bounded physical column decoded-block cache size")
+	if err := fs.Parse(args); err != nil {
+		return cfg, err
+	}
+	if fs.NArg() != 0 {
+		return cfg, fmt.Errorf("unexpected positional arguments: %s", strings.Join(fs.Args(), " "))
+	}
+	return cfg, validateConfig(cfg)
+}
+
+func scanPreset(args []string) (string, error) {
+	preset := defaultPreset
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if arg == "-preset" {
+			if i+1 >= len(args) {
+				return "", errors.New("missing value for -preset")
+			}
+			preset = args[i+1]
+			i++
+			continue
+		}
+		if strings.HasPrefix(arg, "-preset=") {
+			preset = strings.TrimPrefix(arg, "-preset=")
+		}
+	}
+	return preset, nil
+}
+
+func presetConfig(preset string) (config, error) {
+	switch preset {
+	case "", "vector-rag":
+		return config{Rows: 1000, Dims: 128, VectorMode: "typed-column", MetadataMode: "typed-row", Queries: 10, TopK: 10, Seed: 1, Preset: "vector-rag", EfSearch: 128, MaxDecoded: 4}, nil
+	case "perf-engineer":
+		return config{Rows: 10000, Dims: 128, VectorMode: "typed-column", MetadataMode: "typed-row", Queries: 100, TopK: 10, Seed: 1, Preset: "perf-engineer", EfSearch: 128, MaxDecoded: 8}, nil
+	default:
+		return config{}, fmt.Errorf("unsupported preset %q (supported: vector-rag, perf-engineer)", preset)
+	}
+}
+
+func validateConfig(cfg config) error {
+	if cfg.Rows <= 0 {
+		return errors.New("rows must be positive")
+	}
+	if cfg.Dims <= 0 {
+		return errors.New("dims must be positive")
+	}
+	if cfg.Queries <= 0 {
+		return errors.New("queries must be positive")
+	}
+	if cfg.TopK <= 0 {
+		return errors.New("top-k must be positive")
+	}
+	if cfg.TopK > cfg.Rows {
+		return errors.New("top-k cannot exceed rows")
+	}
+	if cfg.EfSearch < 0 || cfg.MaxDecoded < 0 {
+		return errors.New("ef-search and max-decoded-blocks must be non-negative")
+	}
+	if cfg.VectorMode != "typed-column" {
+		return fmt.Errorf("unsupported -vectors %q: this pre-alpha demo currently publishes/searches typed-column dense vector sections only", cfg.VectorMode)
+	}
+	switch cfg.MetadataMode {
+	case "document", "typed-row":
+		return nil
+	case "typed-column":
+		return errors.New("unsupported -metadata typed-column: scalar typed-column metadata filtering is not wired into public vector search yet; use document or typed-row")
+	default:
+		return fmt.Errorf("unsupported -metadata %q (supported: document, typed-row)", cfg.MetadataMode)
+	}
+}
+
+func execute(ctx context.Context, cfg config) (result, error) {
+	if err := ctx.Err(); err != nil {
+		return result{}, err
+	}
+	dir, kept, cleanup, err := prepareFreshDir(cfg.Dir, cfg.KeepDir)
+	if err != nil {
+		return result{}, err
+	}
+	defer cleanup()
+	cfg.Dir = dir
+
+	setupStart := time.Now()
+	rows := generateRows(cfg.Rows, cfg.Dims, cfg.Seed)
+	queries := generateQueries(rows, cfg.Queries, cfg.Seed+7919)
+	if err := backenddb.SaveFormatConfig(cfg.Dir, backenddb.FormatConfig{RequiredFeatures: []string{backenddb.RequiredFeatureCommandWALV1}}); err != nil {
+		return result{}, err
+	}
+	db, err := backenddb.Open(backenddb.Options{Dir: cfg.Dir, DisableBackgroundPrune: true})
+	if err != nil {
+		return result{}, err
+	}
+	manager := collections.NewCollectionManager(db)
+	if _, err := manager.CreateCollection(collectionMeta(cfg)); err != nil {
+		_ = db.Close()
+		return result{}, err
+	}
+	col, err := manager.OpenCollection(collectionName)
+	if err != nil {
+		_ = db.Close()
+		return result{}, err
+	}
+	if err := insertRows(col, rows); err != nil {
+		_ = db.Close()
+		return result{}, err
+	}
+	if status, err := col.RebuildVectorIndex(vectorIndexName); err != nil {
+		_ = db.Close()
+		return result{}, err
+	} else if !status.Loaded {
+		_ = db.Close()
+		return result{}, fmt.Errorf("vector index rebuild did not load column_graph: state=%s reason=%s", status.State, status.Reason)
+	}
+	if err := db.Checkpoint(); err != nil {
+		_ = db.Close()
+		return result{}, err
+	}
+	if err := db.Close(); err != nil {
+		return result{}, err
+	}
+
+	reopened, err := backenddb.Open(backenddb.Options{Dir: cfg.Dir, DisableBackgroundPrune: true})
+	if err != nil {
+		return result{}, err
+	}
+	defer func() { _ = reopened.Close() }()
+	reopenedCol, err := collections.NewCollectionManager(reopened).OpenCollection(collectionName)
+	if err != nil {
+		return result{}, err
+	}
+	setupElapsed := time.Since(setupStart)
+
+	res := result{
+		Preset:                    cfg.Preset,
+		Dir:                       cfg.Dir,
+		KeptDir:                   kept,
+		Rows:                      cfg.Rows,
+		Dims:                      cfg.Dims,
+		Queries:                   cfg.Queries,
+		TopK:                      cfg.TopK,
+		VectorMode:                cfg.VectorMode,
+		MetadataMode:              cfg.MetadataMode,
+		MetadataFilter:            cfg.MetadataFilter,
+		MetadataFilterDescription: metadataFilterDescription(cfg),
+		FinalFetch:                cfg.FinalFetch,
+		SetupMillis:               millis(setupElapsed),
+		ProfileDir:                cfg.ProfileDir,
+	}
+	if cfg.MetadataFilter {
+		if err := runExactFilteredQueries(reopenedCol, rows, queries, cfg, &res); err != nil {
+			return result{}, err
+		}
+	} else {
+		if err := runColumnGraphQueries(reopenedCol, queries, cfg, &res); err != nil {
+			return result{}, err
+		}
+	}
+	return res, nil
+}
+
+func collectionMeta(cfg config) *collections.CollectionMeta {
+	columns := []collections.ColumnStoreColumn{
+		{Name: "embedding", Path: "embedding", Owner: collections.TypedStorageOwnerColumnPart, ValueType: collections.ColumnStoreValueFloat32Vector, VectorDims: cfg.Dims},
+	}
+	var sortKey []collections.ColumnSortKey
+	if cfg.MetadataMode == "typed-row" {
+		columns = append([]collections.ColumnStoreColumn{
+			{Name: "time_us", Path: "time_us", Owner: collections.TypedStorageOwnerRowAsset, ValueType: collections.ColumnStoreValueInt64},
+			{Name: "tenant", Path: "tenant", Owner: collections.TypedStorageOwnerRowAsset, ValueType: collections.ColumnStoreValueString, Dictionary: true},
+			{Name: "category", Path: "category", Owner: collections.TypedStorageOwnerRowAsset, ValueType: collections.ColumnStoreValueString, Dictionary: true},
+			{Name: "title", Path: "title", Owner: collections.TypedStorageOwnerRowAsset, ValueType: collections.ColumnStoreValueString, Dictionary: true},
+		}, columns...)
+		sortKey = []collections.ColumnSortKey{{Column: "time_us"}}
+	}
+	return &collections.CollectionMeta{
+		Name: collectionName,
+		Options: collections.CollectionOptions{
+			DocumentFormat: collections.DocumentFormatJSON,
+			ColumnStore: &collections.ColumnStoreConfig{
+				Enabled: true,
+				Columns: columns,
+				SortKey: sortKey,
+			},
+		},
+		VectorIndexes: []collections.VectorIndexDefinition{{
+			Name:           vectorIndexName,
+			Field:          "embedding",
+			Metric:         collections.VectorMetricCosine,
+			Dimensions:     cfg.Dims,
+			M:              16,
+			EfConstruction: 128,
+			EfSearch:       cfg.EfSearch,
+			Encoding:       collections.VectorIndexEncodingFloat32,
+			Strategy:       collections.VectorIndexStrategyColumnGraph,
+		}},
+	}
+}
+
+func generateRows(n, dims int, seed int64) []vectorRow {
+	rng := rand.New(rand.NewSource(seed))
+	rows := make([]vectorRow, n)
+	for i := range rows {
+		v := make([]float32, dims)
+		cluster := i % 16
+		for d := range v {
+			base := math.Sin(float64((cluster+1)*(d+3))) + math.Cos(float64((i+1)*(d+1)%29))
+			noise := (rng.Float64() - 0.5) * 0.025
+			v[d] = float32(base + noise)
+		}
+		normalize(v)
+		rows[i] = vectorRow{
+			ID:       fmt.Sprintf("doc-%06d", i),
+			Tenant:   fmt.Sprintf("tenant-%02d", i%8),
+			Title:    fmt.Sprintf("deterministic document %06d", i),
+			TimeUS:   int64(1_700_000_000_000_000 + i*1000),
+			Category: fmt.Sprintf("topic-%02d", cluster),
+			Vector:   v,
+		}
+	}
+	return rows
+}
+
+func generateQueries(rows []vectorRow, n int, seed int64) []queryFixture {
+	rng := rand.New(rand.NewSource(seed))
+	queries := make([]queryFixture, n)
+	for i := range queries {
+		base := rows[(i*37+11)%len(rows)].Vector
+		v := append([]float32(nil), base...)
+		for d := range v {
+			v[d] += float32((rng.Float64() - 0.5) * 0.01)
+		}
+		normalize(v)
+		queries[i] = queryFixture{Name: fmt.Sprintf("query-%04d", i), Vector: v}
+	}
+	return queries
+}
+
+func normalize(v []float32) {
+	var sum float64
+	for _, x := range v {
+		sum += float64(x) * float64(x)
+	}
+	if sum == 0 {
+		return
+	}
+	inv := float32(1 / math.Sqrt(sum))
+	for i := range v {
+		v[i] *= inv
+	}
+}
+
+func insertRows(col *collections.Collection, rows []vectorRow) error {
+	ids := make([][]byte, len(rows))
+	docs := make([][]byte, len(rows))
+	for i, row := range rows {
+		raw, err := json.Marshal(map[string]any{
+			"did":       row.ID,
+			"tenant":    row.Tenant,
+			"title":     row.Title,
+			"time_us":   row.TimeUS,
+			"category":  row.Category,
+			"body":      fmt.Sprintf("RAG fixture body for %s in %s", row.ID, row.Category),
+			"embedding": row.Vector,
+		})
+		if err != nil {
+			return err
+		}
+		ids[i] = []byte(row.ID)
+		docs[i] = raw
+	}
+	_, err := col.InsertBatch(ids, docs)
+	return err
+}
+
+func runColumnGraphQueries(col *collections.Collection, queries []queryFixture, cfg config, res *result) error {
+	searcher, err := col.OpenVectorIndexSearcher(collections.VectorIndexSearcherOptions{IndexName: vectorIndexName, MaxDecodedBlocks: cfg.MaxDecoded})
+	if err != nil {
+		return err
+	}
+	defer func() { _ = searcher.Close() }()
+	res.SearchPath = string(collections.VectorIndexSearchPathColumnGraphNativeReader)
+	var fetchElapsed time.Duration
+	searchStart := time.Now()
+	for i, q := range queries {
+		got, err := searcher.Search(collections.VectorIndexSearcherSearchOptions{Query: q.Vector, TopK: cfg.TopK, EfSearch: cfg.EfSearch, IncludeDocuments: false})
+		if err != nil {
+			return err
+		}
+		if len(got.Results) == 0 {
+			return fmt.Errorf("query %s returned no results", q.Name)
+		}
+		res.Candidates += got.Stats.Candidates
+		res.ScoredVectors += got.Stats.CandidateFetches
+		res.PhysicalBytesRead += got.Stats.PhysicalBytesRead
+		res.VectorDirectViews += got.Stats.VectorDirectViews
+		res.VectorScratchDecodes += got.Stats.VectorScratchDecodes
+		res.TypedColumnFallbacks += got.Stats.TypedColumnFallbacks
+		res.MappedBytes = maxUint64(res.MappedBytes, got.Stats.TypedColumnMappedBytes)
+		res.HeapCopyBytes = maxUint64(res.HeapCopyBytes, got.Stats.TypedColumnHeapCopyBytes)
+		res.DecodedBytes = maxUint64(res.DecodedBytes, got.Stats.TypedColumnDecodedBytes)
+		if i == 0 {
+			res.FirstResults = hitsFromSearchResults(got.Results)
+		}
+		if cfg.FinalFetch {
+			start := time.Now()
+			for _, hit := range got.Results {
+				doc, err := col.Get(hit.ID)
+				if err != nil {
+					return err
+				}
+				res.DocsFetched++
+				res.DocumentBytes += uint64(len(doc))
+			}
+			fetchElapsed += time.Since(start)
+		}
+	}
+	searchElapsed := time.Since(searchStart) - fetchElapsed
+	res.SearchMillis = millis(searchElapsed)
+	res.FetchMillis = millis(fetchElapsed)
+	res.OpsPerSecond = float64(cfg.Queries) / searchElapsed.Seconds()
+	res.CandidatesPerSearch = float64(res.Candidates) / float64(cfg.Queries)
+	return nil
+}
+
+func runExactFilteredQueries(col *collections.Collection, rows []vectorRow, queries []queryFixture, cfg config, res *result) error {
+	res.SearchPath = "exact_scoring_metadata_filter"
+	var fetchElapsed time.Duration
+	searchStart := time.Now()
+	for i, q := range queries {
+		hits := exactTopK(rows, q.Vector, cfg.TopK, func(row vectorRow) bool { return row.Tenant == defaultFilterTenant })
+		if len(hits) == 0 {
+			return fmt.Errorf("query %s returned no exact filtered results", q.Name)
+		}
+		res.ScoredVectors += uint64(len(rows))
+		if i == 0 {
+			res.FirstResults = hits
+		}
+		if cfg.FinalFetch {
+			start := time.Now()
+			for _, hit := range hits {
+				doc, err := col.Get([]byte(hit.ID))
+				if err != nil {
+					return err
+				}
+				res.DocsFetched++
+				res.DocumentBytes += uint64(len(doc))
+			}
+			fetchElapsed += time.Since(start)
+		}
+	}
+	searchElapsed := time.Since(searchStart) - fetchElapsed
+	res.SearchMillis = millis(searchElapsed)
+	res.FetchMillis = millis(fetchElapsed)
+	res.OpsPerSecond = float64(cfg.Queries) / searchElapsed.Seconds()
+	return nil
+}
+
+func exactTopK(rows []vectorRow, query []float32, topK int, filter func(vectorRow) bool) []searchHit {
+	hits := make([]searchHit, 0, len(rows))
+	for i, row := range rows {
+		if filter != nil && !filter(row) {
+			continue
+		}
+		hits = append(hits, searchHit{ID: row.ID, Ordinal: i, Score: dot(row.Vector, query)})
+	}
+	sort.Slice(hits, func(i, j int) bool {
+		if hits[i].Score == hits[j].Score {
+			return hits[i].ID < hits[j].ID
+		}
+		return hits[i].Score > hits[j].Score
+	})
+	if len(hits) > topK {
+		hits = hits[:topK]
+	}
+	return hits
+}
+
+func dot(a, b []float32) float64 {
+	var sum float64
+	for i := range a {
+		sum += float64(a[i]) * float64(b[i])
+	}
+	return sum
+}
+
+func hitsFromSearchResults(results []collections.VectorIndexSearchResult) []searchHit {
+	hits := make([]searchHit, len(results))
+	for i, r := range results {
+		hits[i] = searchHit{ID: string(r.ID), Ordinal: r.Ordinal, Score: r.Score}
+	}
+	return hits
+}
+
+func prepareFreshDir(dir string, keep bool) (string, bool, func(), error) {
+	if strings.TrimSpace(dir) == "" {
+		tmp, err := os.MkdirTemp("", "treedb-vector-demo-*")
+		if err != nil {
+			return "", false, nil, err
+		}
+		if !keep {
+			return tmp, false, func() { _ = os.RemoveAll(tmp) }, nil
+		}
+		return tmp, true, func() {}, nil
+	}
+	abs, err := validateFreshDemoDir(dir)
+	if err != nil {
+		return "", false, nil, err
+	}
+	if err := os.RemoveAll(abs); err != nil {
+		return "", false, nil, err
+	}
+	if err := os.MkdirAll(abs, 0o755); err != nil {
+		return "", false, nil, err
+	}
+	return abs, true, func() {}, nil
+}
+
+func validateFreshDemoDir(dir string) (string, error) {
+	cleanInput := filepath.Clean(strings.TrimSpace(dir))
+	if cleanInput == "" || cleanInput == "." || cleanInput == ".." || strings.Contains(cleanInput, ".."+string(os.PathSeparator)) {
+		return "", fmt.Errorf("refusing unsafe demo directory %q", dir)
+	}
+	abs, err := filepath.Abs(cleanInput)
+	if err != nil {
+		return "", err
+	}
+	abs = filepath.Clean(abs)
+	root := filepath.VolumeName(abs) + string(os.PathSeparator)
+	if abs == root || len(abs) < minFreshDemoDirBytes || abs == filepath.Clean(os.TempDir()) {
+		return "", fmt.Errorf("refusing unsafe demo directory %q", dir)
+	}
+	return abs, nil
+}
+
+func writeProfileArtifacts(dir string, res *result) error {
+	res.ProfileDir = dir
+	res.CPUProfile = filepath.Join(dir, "vector_demo_cpu.pprof")
+	res.AllocsProfile = filepath.Join(dir, "vector_demo_allocs.pprof")
+	res.SummaryJSON = filepath.Join(dir, "vector_demo_summary.json")
+	res.SummaryMarkdown = filepath.Join(dir, "vector_demo_summary.md")
+	runtime.GC()
+	allocs, err := os.Create(res.AllocsProfile)
+	if err != nil {
+		return err
+	}
+	if err := pprof.Lookup("allocs").WriteTo(allocs, 0); err != nil {
+		_ = allocs.Close()
+		return err
+	}
+	if err := allocs.Close(); err != nil {
+		return err
+	}
+	jsonBytes, err := json.MarshalIndent(res, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(res.SummaryJSON, append(jsonBytes, '\n'), 0o644); err != nil {
+		return err
+	}
+	return os.WriteFile(res.SummaryMarkdown, []byte(summaryMarkdown(*res)), 0o644)
+}
+
+func summaryMarkdown(res result) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "# TreeDB vector demo summary\n\n")
+	fmt.Fprintf(&b, "- preset: `%s`\n- vectors: `%s`\n- metadata: `%s`\n- rows: `%d`\n- dims: `%d`\n- queries: `%d`\n- top_k: `%d`\n- search_path: `%s`\n- setup_ms: `%.3f`\n- search_ms: `%.3f`\n- fetch_ms: `%.3f`\n- ops_sec: `%.2f`\n- docs_fetched: `%d`\n- mapped_bytes: `%d`\n- decoded_bytes: `%d`\n", res.Preset, res.VectorMode, res.MetadataMode, res.Rows, res.Dims, res.Queries, res.TopK, res.SearchPath, res.SetupMillis, res.SearchMillis, res.FetchMillis, res.OpsPerSecond, res.DocsFetched, res.MappedBytes+res.HeapCopyBytes, res.DecodedBytes)
+	fmt.Fprintf(&b, "\nArtifacts: `vector_demo_cpu.pprof`, `vector_demo_allocs.pprof`, `vector_demo_summary.json`, `vector_demo_summary.md`.\n")
+	return b.String()
+}
+
+func printText(w io.Writer, res result) {
+	fmt.Fprintf(w, "TreeDB vector/RAG demo (pre-alpha collections)\n")
+	fmt.Fprintf(w, "preset=%s vectors=%s metadata=%s metadata_filter=%t final_fetch=%t\n", res.Preset, res.VectorMode, res.MetadataMode, res.MetadataFilter, res.FinalFetch)
+	fmt.Fprintf(w, "db_dir=%s rows=%d dims=%d queries=%d top_k=%d search_path=%s\n", res.Dir, res.Rows, res.Dims, res.Queries, res.TopK, res.SearchPath)
+	fmt.Fprintf(w, "setup_ms=%.3f search_ms=%.3f fetch_ms=%.3f ops_sec=%.2f\n", res.SetupMillis, res.SearchMillis, res.FetchMillis, res.OpsPerSecond)
+	fmt.Fprintf(w, "candidates=%d candidates_per_search=%.2f scored_vectors=%d docs_fetched=%d document_bytes=%d\n", res.Candidates, res.CandidatesPerSearch, res.ScoredVectors, res.DocsFetched, res.DocumentBytes)
+	fmt.Fprintf(w, "mapped_bytes=%d heap_copy_bytes=%d decoded_bytes=%d physical_bytes_read=%d vector_direct_views=%d vector_scratch_decodes=%d typed_column_fallbacks=%d\n", res.MappedBytes, res.HeapCopyBytes, res.DecodedBytes, res.PhysicalBytesRead, res.VectorDirectViews, res.VectorScratchDecodes, res.TypedColumnFallbacks)
+	if res.MetadataFilterDescription != "" {
+		fmt.Fprintf(w, "metadata_filter_description=%s\n", res.MetadataFilterDescription)
+	}
+	if res.ProfileDir != "" {
+		fmt.Fprintf(w, "profile_dir=%s\n", res.ProfileDir)
+		fmt.Fprintf(w, "profile_artifacts=vector_demo_cpu.pprof,vector_demo_allocs.pprof,vector_demo_summary.json,vector_demo_summary.md\n")
+	}
+	for i, hit := range res.FirstResults {
+		if i >= 5 {
+			break
+		}
+		fmt.Fprintf(w, "result[%d] id=%s ordinal=%d score=%.6f\n", i, hit.ID, hit.Ordinal, hit.Score)
+	}
+}
+
+func metadataFilterDescription(cfg config) string {
+	if !cfg.MetadataFilter {
+		return ""
+	}
+	return "tenant=" + defaultFilterTenant + "; exact_scoring is used because public column_graph search does not yet expose metadata predicates"
+}
+
+func millis(d time.Duration) float64 { return float64(d) / float64(time.Millisecond) }
+
+func maxUint64(a, b uint64) uint64 {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/cmd/treedb_vector_demo/main.go
+++ b/cmd/treedb_vector_demo/main.go
@@ -27,7 +27,6 @@ const (
 	defaultPreset          = "vector-rag"
 	defaultFilterTenant    = "tenant-00"
 	defaultVectorBatchSize = 512
-	minFreshDemoDirBytes   = 8
 )
 
 type config struct {
@@ -653,7 +652,7 @@ func validateFreshDemoDir(dir string) (string, error) {
 	}
 	abs = filepath.Clean(abs)
 	root := filepath.VolumeName(abs) + string(os.PathSeparator)
-	if abs == root || len(abs) < minFreshDemoDirBytes || abs == filepath.Clean(os.TempDir()) {
+	if abs == root || abs == filepath.Clean(os.TempDir()) {
 		return "", fmt.Errorf("refusing unsafe demo directory %q", dir)
 	}
 	return abs, nil

--- a/cmd/treedb_vector_demo/main.go
+++ b/cmd/treedb_vector_demo/main.go
@@ -530,15 +530,19 @@ func runColumnGraphQueries(col *collections.Collection, queries []queryFixture, 
 		}
 	}
 	searchElapsed := time.Since(searchStart) - fetchElapsed
-	res.SearchMillis = millis(searchElapsed)
-	res.FetchMillis = millis(fetchElapsed)
-	res.OpsPerSecond = float64(cfg.Queries) / searchElapsed.Seconds()
+	setSearchTiming(res, cfg.Queries, searchElapsed, fetchElapsed)
 	res.CandidatesPerSearch = float64(res.Candidates) / float64(cfg.Queries)
 	return nil
 }
 
 func runExactFilteredQueries(col *collections.Collection, rows []vectorRow, queries []queryFixture, cfg config, res *result) error {
 	res.SearchPath = "exact_scoring_metadata_filter"
+	filteredRows := 0
+	for _, row := range rows {
+		if row.Tenant == defaultFilterTenant {
+			filteredRows++
+		}
+	}
 	var fetchElapsed time.Duration
 	searchStart := time.Now()
 	for i, q := range queries {
@@ -546,7 +550,7 @@ func runExactFilteredQueries(col *collections.Collection, rows []vectorRow, quer
 		if len(hits) == 0 {
 			return fmt.Errorf("query %s returned no exact filtered results", q.Name)
 		}
-		res.ScoredVectors += uint64(len(rows))
+		res.ScoredVectors += uint64(filteredRows)
 		if i == 0 {
 			res.FirstResults = hits
 		}
@@ -564,10 +568,19 @@ func runExactFilteredQueries(col *collections.Collection, rows []vectorRow, quer
 		}
 	}
 	searchElapsed := time.Since(searchStart) - fetchElapsed
+	setSearchTiming(res, cfg.Queries, searchElapsed, fetchElapsed)
+	return nil
+}
+
+func setSearchTiming(res *result, queries int, searchElapsed, fetchElapsed time.Duration) {
+	if searchElapsed <= 0 {
+		searchElapsed = time.Nanosecond
+	}
 	res.SearchMillis = millis(searchElapsed)
 	res.FetchMillis = millis(fetchElapsed)
-	res.OpsPerSecond = float64(cfg.Queries) / searchElapsed.Seconds()
-	return nil
+	if queries > 0 {
+		res.OpsPerSecond = float64(queries) / searchElapsed.Seconds()
+	}
 }
 
 func exactTopK(rows []vectorRow, query []float32, topK int, filter func(vectorRow) bool) []searchHit {

--- a/cmd/treedb_vector_demo/main.go
+++ b/cmd/treedb_vector_demo/main.go
@@ -22,11 +22,12 @@ import (
 )
 
 const (
-	vectorIndexName      = "embedding_graph"
-	collectionName       = "docs"
-	defaultPreset        = "vector-rag"
-	defaultFilterTenant  = "tenant-00"
-	minFreshDemoDirBytes = 8
+	vectorIndexName        = "embedding_graph"
+	collectionName         = "docs"
+	defaultPreset          = "vector-rag"
+	defaultFilterTenant    = "tenant-00"
+	defaultVectorBatchSize = 512
+	minFreshDemoDirBytes   = 8
 )
 
 type config struct {
@@ -36,6 +37,7 @@ type config struct {
 	MetadataMode   string
 	Queries        int
 	TopK           int
+	BatchSize      int
 	MetadataFilter bool
 	FinalFetch     bool
 	Dir            string
@@ -75,6 +77,7 @@ type result struct {
 	Dims                      int         `json:"dims"`
 	Queries                   int         `json:"queries"`
 	TopK                      int         `json:"top_k"`
+	BatchSize                 int         `json:"batch_size"`
 	VectorMode                string      `json:"vector_mode"`
 	MetadataMode              string      `json:"metadata_mode"`
 	MetadataFilter            bool        `json:"metadata_filter"`
@@ -90,9 +93,9 @@ type result struct {
 	ScoredVectors             uint64      `json:"scored_vectors"`
 	DocsFetched               uint64      `json:"docs_fetched"`
 	DocumentBytes             uint64      `json:"document_bytes"`
-	MappedBytes               uint64      `json:"mapped_bytes"`
-	HeapCopyBytes             uint64      `json:"heap_copy_bytes"`
-	DecodedBytes              uint64      `json:"decoded_bytes"`
+	MappedBytesPeak           uint64      `json:"mapped_bytes_peak"`
+	HeapCopyBytesPeak         uint64      `json:"heap_copy_bytes_peak"`
+	DecodedBytesPeak          uint64      `json:"decoded_bytes_peak"`
 	PhysicalBytesRead         int64       `json:"physical_bytes_read"`
 	VectorDirectViews         uint64      `json:"vector_direct_views"`
 	VectorScratchDecodes      uint64      `json:"vector_scratch_decodes"`
@@ -170,6 +173,7 @@ func parseConfig(args []string) (config, error) {
 	fs.StringVar(&cfg.MetadataMode, "metadata", cfg.MetadataMode, "metadata storage mode: document, typed-row, typed-column")
 	fs.IntVar(&cfg.Queries, "queries", cfg.Queries, "number of vector queries to run")
 	fs.IntVar(&cfg.TopK, "top-k", cfg.TopK, "nearest neighbors per query")
+	fs.IntVar(&cfg.BatchSize, "batch-size", cfg.BatchSize, "documents per InsertBatch call")
 	fs.BoolVar(&cfg.MetadataFilter, "metadata-filter", cfg.MetadataFilter, "restrict scoring/search output to a deterministic tenant filter when supported")
 	fs.BoolVar(&cfg.FinalFetch, "final-fetch", cfg.FinalFetch, "fetch full documents after top-k selection and time that separately")
 	fs.StringVar(&cfg.Dir, "dir", cfg.Dir, "TreeDB directory; empty uses a temporary directory")
@@ -200,8 +204,19 @@ func scanPreset(args []string) (string, error) {
 			i++
 			continue
 		}
+		if arg == "--preset" {
+			if i+1 >= len(args) {
+				return "", errors.New("missing value for --preset")
+			}
+			preset = args[i+1]
+			i++
+			continue
+		}
 		if strings.HasPrefix(arg, "-preset=") {
 			preset = strings.TrimPrefix(arg, "-preset=")
+		}
+		if strings.HasPrefix(arg, "--preset=") {
+			preset = strings.TrimPrefix(arg, "--preset=")
 		}
 	}
 	return preset, nil
@@ -210,9 +225,9 @@ func scanPreset(args []string) (string, error) {
 func presetConfig(preset string) (config, error) {
 	switch preset {
 	case "", "vector-rag":
-		return config{Rows: 1000, Dims: 128, VectorMode: "typed-column", MetadataMode: "typed-row", Queries: 10, TopK: 10, Seed: 1, Preset: "vector-rag", EfSearch: 128, MaxDecoded: 4}, nil
+		return config{Rows: 1000, Dims: 128, VectorMode: "typed-column", MetadataMode: "typed-row", Queries: 10, TopK: 10, BatchSize: defaultVectorBatchSize, Seed: 1, Preset: "vector-rag", EfSearch: 128, MaxDecoded: 4}, nil
 	case "perf-engineer":
-		return config{Rows: 10000, Dims: 128, VectorMode: "typed-column", MetadataMode: "typed-row", Queries: 100, TopK: 10, Seed: 1, Preset: "perf-engineer", EfSearch: 128, MaxDecoded: 8}, nil
+		return config{Rows: 10000, Dims: 128, VectorMode: "typed-column", MetadataMode: "typed-row", Queries: 100, TopK: 10, BatchSize: defaultVectorBatchSize, Seed: 1, Preset: "perf-engineer", EfSearch: 128, MaxDecoded: 8}, nil
 	default:
 		return config{}, fmt.Errorf("unsupported preset %q (supported: vector-rag, perf-engineer)", preset)
 	}
@@ -234,6 +249,9 @@ func validateConfig(cfg config) error {
 	if cfg.TopK > cfg.Rows {
 		return errors.New("top-k cannot exceed rows")
 	}
+	if cfg.BatchSize <= 0 {
+		return errors.New("batch-size must be positive")
+	}
 	if cfg.EfSearch < 0 || cfg.MaxDecoded < 0 {
 		return errors.New("ef-search and max-decoded-blocks must be non-negative")
 	}
@@ -253,6 +271,9 @@ func validateConfig(cfg config) error {
 func execute(ctx context.Context, cfg config) (result, error) {
 	if err := ctx.Err(); err != nil {
 		return result{}, err
+	}
+	if cfg.BatchSize <= 0 {
+		cfg.BatchSize = defaultVectorBatchSize
 	}
 	dir, kept, cleanup, err := prepareFreshDir(cfg.Dir, cfg.KeepDir)
 	if err != nil {
@@ -281,7 +302,7 @@ func execute(ctx context.Context, cfg config) (result, error) {
 		_ = db.Close()
 		return result{}, err
 	}
-	if err := insertRows(col, rows); err != nil {
+	if err := insertRows(col, rows, cfg.BatchSize); err != nil {
 		_ = db.Close()
 		return result{}, err
 	}
@@ -319,6 +340,7 @@ func execute(ctx context.Context, cfg config) (result, error) {
 		Dims:                      cfg.Dims,
 		Queries:                   cfg.Queries,
 		TopK:                      cfg.TopK,
+		BatchSize:                 cfg.BatchSize,
 		VectorMode:                cfg.VectorMode,
 		MetadataMode:              cfg.MetadataMode,
 		MetadataFilter:            cfg.MetadataFilter,
@@ -430,27 +452,39 @@ func normalize(v []float32) {
 	}
 }
 
-func insertRows(col *collections.Collection, rows []vectorRow) error {
-	ids := make([][]byte, len(rows))
-	docs := make([][]byte, len(rows))
-	for i, row := range rows {
-		raw, err := json.Marshal(map[string]any{
-			"did":       row.ID,
-			"tenant":    row.Tenant,
-			"title":     row.Title,
-			"time_us":   row.TimeUS,
-			"category":  row.Category,
-			"body":      fmt.Sprintf("RAG fixture body for %s in %s", row.ID, row.Category),
-			"embedding": row.Vector,
-		})
-		if err != nil {
+func insertRows(col *collections.Collection, rows []vectorRow, batchSize int) error {
+	if batchSize <= 0 {
+		batchSize = defaultVectorBatchSize
+	}
+	for start := 0; start < len(rows); start += batchSize {
+		end := start + batchSize
+		if end > len(rows) {
+			end = len(rows)
+		}
+		ids := make([][]byte, end-start)
+		docs := make([][]byte, end-start)
+		for i := start; i < end; i++ {
+			row := rows[i]
+			raw, err := json.Marshal(map[string]any{
+				"did":       row.ID,
+				"tenant":    row.Tenant,
+				"title":     row.Title,
+				"time_us":   row.TimeUS,
+				"category":  row.Category,
+				"body":      fmt.Sprintf("RAG fixture body for %s in %s", row.ID, row.Category),
+				"embedding": row.Vector,
+			})
+			if err != nil {
+				return err
+			}
+			ids[i-start] = []byte(row.ID)
+			docs[i-start] = raw
+		}
+		if _, err := col.InsertBatch(ids, docs); err != nil {
 			return err
 		}
-		ids[i] = []byte(row.ID)
-		docs[i] = raw
 	}
-	_, err := col.InsertBatch(ids, docs)
-	return err
+	return nil
 }
 
 func runColumnGraphQueries(col *collections.Collection, queries []queryFixture, cfg config, res *result) error {
@@ -476,9 +510,9 @@ func runColumnGraphQueries(col *collections.Collection, queries []queryFixture, 
 		res.VectorDirectViews += got.Stats.VectorDirectViews
 		res.VectorScratchDecodes += got.Stats.VectorScratchDecodes
 		res.TypedColumnFallbacks += got.Stats.TypedColumnFallbacks
-		res.MappedBytes = maxUint64(res.MappedBytes, got.Stats.TypedColumnMappedBytes)
-		res.HeapCopyBytes = maxUint64(res.HeapCopyBytes, got.Stats.TypedColumnHeapCopyBytes)
-		res.DecodedBytes = maxUint64(res.DecodedBytes, got.Stats.TypedColumnDecodedBytes)
+		res.MappedBytesPeak = max(res.MappedBytesPeak, got.Stats.TypedColumnMappedBytes)
+		res.HeapCopyBytesPeak = max(res.HeapCopyBytesPeak, got.Stats.TypedColumnHeapCopyBytes)
+		res.DecodedBytesPeak = max(res.DecodedBytesPeak, got.Stats.TypedColumnDecodedBytes)
 		if i == 0 {
 			res.FirstResults = hitsFromSearchResults(got.Results)
 		}
@@ -671,7 +705,7 @@ func writeProfileArtifacts(dir string, res *result) error {
 func summaryMarkdown(res result) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "# TreeDB vector demo summary\n\n")
-	fmt.Fprintf(&b, "- preset: `%s`\n- vectors: `%s`\n- metadata: `%s`\n- rows: `%d`\n- dims: `%d`\n- queries: `%d`\n- top_k: `%d`\n- search_path: `%s`\n- setup_ms: `%.3f`\n- search_ms: `%.3f`\n- fetch_ms: `%.3f`\n- ops_sec: `%.2f`\n- docs_fetched: `%d`\n- mapped_bytes: `%d`\n- decoded_bytes: `%d`\n", res.Preset, res.VectorMode, res.MetadataMode, res.Rows, res.Dims, res.Queries, res.TopK, res.SearchPath, res.SetupMillis, res.SearchMillis, res.FetchMillis, res.OpsPerSecond, res.DocsFetched, res.MappedBytes+res.HeapCopyBytes, res.DecodedBytes)
+	fmt.Fprintf(&b, "- preset: `%s`\n- vectors: `%s`\n- metadata: `%s`\n- rows: `%d`\n- dims: `%d`\n- queries: `%d`\n- top_k: `%d`\n- batch_size: `%d`\n- search_path: `%s`\n- setup_ms: `%.3f`\n- search_ms: `%.3f`\n- fetch_ms: `%.3f`\n- ops_sec: `%.2f`\n- docs_fetched: `%d`\n- mapped_bytes_peak: `%d`\n- heap_copy_bytes_peak: `%d`\n- decoded_bytes_peak: `%d`\n", res.Preset, res.VectorMode, res.MetadataMode, res.Rows, res.Dims, res.Queries, res.TopK, res.BatchSize, res.SearchPath, res.SetupMillis, res.SearchMillis, res.FetchMillis, res.OpsPerSecond, res.DocsFetched, res.MappedBytesPeak, res.HeapCopyBytesPeak, res.DecodedBytesPeak)
 	fmt.Fprintf(&b, "\nArtifacts: `vector_demo_cpu.pprof`, `vector_demo_allocs.pprof`, `vector_demo_summary.json`, `vector_demo_summary.md`.\n")
 	return b.String()
 }
@@ -679,10 +713,10 @@ func summaryMarkdown(res result) string {
 func printText(w io.Writer, res result) {
 	fmt.Fprintf(w, "TreeDB vector/RAG demo (pre-alpha collections)\n")
 	fmt.Fprintf(w, "preset=%s vectors=%s metadata=%s metadata_filter=%t final_fetch=%t\n", res.Preset, res.VectorMode, res.MetadataMode, res.MetadataFilter, res.FinalFetch)
-	fmt.Fprintf(w, "db_dir=%s rows=%d dims=%d queries=%d top_k=%d search_path=%s\n", res.Dir, res.Rows, res.Dims, res.Queries, res.TopK, res.SearchPath)
+	fmt.Fprintf(w, "db_dir=%s rows=%d dims=%d queries=%d top_k=%d batch_size=%d search_path=%s\n", res.Dir, res.Rows, res.Dims, res.Queries, res.TopK, res.BatchSize, res.SearchPath)
 	fmt.Fprintf(w, "setup_ms=%.3f search_ms=%.3f fetch_ms=%.3f ops_sec=%.2f\n", res.SetupMillis, res.SearchMillis, res.FetchMillis, res.OpsPerSecond)
 	fmt.Fprintf(w, "candidates=%d candidates_per_search=%.2f scored_vectors=%d docs_fetched=%d document_bytes=%d\n", res.Candidates, res.CandidatesPerSearch, res.ScoredVectors, res.DocsFetched, res.DocumentBytes)
-	fmt.Fprintf(w, "mapped_bytes=%d heap_copy_bytes=%d decoded_bytes=%d physical_bytes_read=%d vector_direct_views=%d vector_scratch_decodes=%d typed_column_fallbacks=%d\n", res.MappedBytes, res.HeapCopyBytes, res.DecodedBytes, res.PhysicalBytesRead, res.VectorDirectViews, res.VectorScratchDecodes, res.TypedColumnFallbacks)
+	fmt.Fprintf(w, "mapped_bytes_peak=%d heap_copy_bytes_peak=%d decoded_bytes_peak=%d physical_bytes_read=%d vector_direct_views=%d vector_scratch_decodes=%d typed_column_fallbacks=%d\n", res.MappedBytesPeak, res.HeapCopyBytesPeak, res.DecodedBytesPeak, res.PhysicalBytesRead, res.VectorDirectViews, res.VectorScratchDecodes, res.TypedColumnFallbacks)
 	if res.MetadataFilterDescription != "" {
 		fmt.Fprintf(w, "metadata_filter_description=%s\n", res.MetadataFilterDescription)
 	}
@@ -706,10 +740,3 @@ func metadataFilterDescription(cfg config) string {
 }
 
 func millis(d time.Duration) float64 { return float64(d) / float64(time.Millisecond) }
-
-func maxUint64(a, b uint64) uint64 {
-	if a > b {
-		return a
-	}
-	return b
-}

--- a/cmd/treedb_vector_demo/main.go
+++ b/cmd/treedb_vector_demo/main.go
@@ -642,8 +642,12 @@ func prepareFreshDir(dir string, keep bool) (string, bool, func(), error) {
 }
 
 func validateFreshDemoDir(dir string) (string, error) {
-	cleanInput := filepath.Clean(strings.TrimSpace(dir))
-	if cleanInput == "" || cleanInput == "." || cleanInput == ".." || demoDirHasParentTraversal(cleanInput) {
+	rawInput := strings.TrimSpace(dir)
+	if rawInput == "" || demoDirHasParentTraversal(rawInput) {
+		return "", fmt.Errorf("refusing unsafe demo directory %q", dir)
+	}
+	cleanInput := filepath.Clean(rawInput)
+	if cleanInput == "." || cleanInput == ".." {
 		return "", fmt.Errorf("refusing unsafe demo directory %q", dir)
 	}
 	abs, err := filepath.Abs(cleanInput)

--- a/cmd/treedb_vector_demo/main_test.go
+++ b/cmd/treedb_vector_demo/main_test.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParseConfigPresetAndOverrides(t *testing.T) {
+	cfg, err := parseConfig([]string{
+		"-preset", "perf-engineer",
+		"-rows", "123",
+		"-dims", "12",
+		"-vectors", "typed-column",
+		"-metadata", "document",
+		"-queries", "4",
+		"-top-k", "3",
+		"-metadata-filter",
+		"-final-fetch",
+	})
+	if err != nil {
+		t.Fatalf("parseConfig: %v", err)
+	}
+	if cfg.Preset != "perf-engineer" || cfg.Rows != 123 || cfg.Dims != 12 || cfg.MetadataMode != "document" || cfg.Queries != 4 || cfg.TopK != 3 || !cfg.MetadataFilter || !cfg.FinalFetch {
+		t.Fatalf("unexpected cfg: %+v", cfg)
+	}
+}
+
+func TestParseConfigRejectsUnsupportedVectorMode(t *testing.T) {
+	_, err := parseConfig([]string{"-vectors", "document"})
+	if err == nil || !strings.Contains(err.Error(), "typed-column dense vector sections only") {
+		t.Fatalf("err=%v, want clear typed-column-only error", err)
+	}
+}
+
+func TestDeterministicVectorFixture(t *testing.T) {
+	a := generateRows(8, 6, 99)
+	b := generateRows(8, 6, 99)
+	c := generateRows(8, 6, 100)
+	if len(a) != len(b) || len(a[0].Vector) != 6 {
+		t.Fatalf("bad fixture shape: %d dims=%d", len(a), len(a[0].Vector))
+	}
+	for i := range a {
+		if a[i].ID != b[i].ID || a[i].Tenant != b[i].Tenant {
+			t.Fatalf("row metadata not deterministic: %+v vs %+v", a[i], b[i])
+		}
+		for d := range a[i].Vector {
+			if a[i].Vector[d] != b[i].Vector[d] {
+				t.Fatalf("vector[%d][%d] not deterministic: %v vs %v", i, d, a[i].Vector[d], b[i].Vector[d])
+			}
+		}
+	}
+	if a[0].Vector[0] == c[0].Vector[0] {
+		t.Fatalf("different seeds produced identical first component: %v", a[0].Vector[0])
+	}
+	queries := generateQueries(a, 3, 7)
+	if len(queries) != 3 || len(queries[0].Vector) != 6 || queries[0].Name != "query-0000" {
+		t.Fatalf("bad query fixture: %+v", queries)
+	}
+}
+
+func TestExactTopKShape(t *testing.T) {
+	rows := generateRows(32, 8, 1)
+	query := append([]float32(nil), rows[0].Vector...)
+	hits := exactTopK(rows, query, 5, nil)
+	if len(hits) != 5 {
+		t.Fatalf("len(hits)=%d want 5", len(hits))
+	}
+	for i := 1; i < len(hits); i++ {
+		if hits[i-1].Score < hits[i].Score {
+			t.Fatalf("hits not sorted: %+v", hits)
+		}
+	}
+	filtered := exactTopK(rows, query, 4, func(row vectorRow) bool { return row.Tenant == defaultFilterTenant })
+	if len(filtered) != 4 {
+		t.Fatalf("filtered len=%d want 4", len(filtered))
+	}
+	for _, hit := range filtered {
+		idx := -1
+		_, _ = idx, hit
+		for i := range rows {
+			if rows[i].ID == hit.ID {
+				idx = i
+				break
+			}
+		}
+		if idx < 0 || rows[idx].Tenant != defaultFilterTenant {
+			t.Fatalf("filtered hit %+v not in tenant %s", hit, defaultFilterTenant)
+		}
+	}
+}
+
+func TestExecuteColumnGraphTopKSmoke(t *testing.T) {
+	res, err := execute(t.Context(), config{
+		Rows:         64,
+		Dims:         8,
+		VectorMode:   "typed-column",
+		MetadataMode: "typed-row",
+		Queries:      2,
+		TopK:         3,
+		Dir:          filepath.Join(t.TempDir(), "db"),
+		Seed:         1,
+		Preset:       "vector-rag",
+		EfSearch:     32,
+		MaxDecoded:   1,
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if res.SearchPath != "column_graph_native_reader" || len(res.FirstResults) != 3 || res.Rows != 64 || res.Dims != 8 || res.Queries != 2 {
+		t.Fatalf("unexpected result: %+v", res)
+	}
+	if res.VectorDirectViews == 0 || res.TypedColumnFallbacks != 0 {
+		t.Fatalf("typed-column vector counters missing/fallback: %+v", res)
+	}
+}
+
+func TestRunProfileArtifacts(t *testing.T) {
+	profileDir := filepath.Join(t.TempDir(), "profiles")
+	var stdout, stderr bytes.Buffer
+	err := run([]string{
+		"-rows", "32",
+		"-dims", "8",
+		"-queries", "1",
+		"-top-k", "2",
+		"-profile-dir", profileDir,
+	}, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("run: %v\nstdout:\n%s\nstderr:\n%s", err, stdout.String(), stderr.String())
+	}
+	for _, name := range []string{"vector_demo_cpu.pprof", "vector_demo_allocs.pprof", "vector_demo_summary.json", "vector_demo_summary.md"} {
+		path := filepath.Join(profileDir, name)
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("missing profile artifact %s: %v", name, err)
+		}
+		if info.Size() == 0 {
+			t.Fatalf("profile artifact %s is empty", name)
+		}
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "profile_artifacts=vector_demo_cpu.pprof,vector_demo_allocs.pprof,vector_demo_summary.json,vector_demo_summary.md") {
+		t.Fatalf("stdout missing artifact names:\n%s", out)
+	}
+}

--- a/cmd/treedb_vector_demo/main_test.go
+++ b/cmd/treedb_vector_demo/main_test.go
@@ -170,6 +170,12 @@ func TestExecuteMetadataFilterCountsFilteredVectors(t *testing.T) {
 	if res.ScoredVectors != wantScored {
 		t.Fatalf("scored_vectors=%d want %d", res.ScoredVectors, wantScored)
 	}
+	if res.Candidates != wantScored {
+		t.Fatalf("candidates=%d want %d", res.Candidates, wantScored)
+	}
+	if res.CandidatesPerSearch != float64(64/8) {
+		t.Fatalf("candidates_per_search=%f want %f", res.CandidatesPerSearch, float64(64/8))
+	}
 }
 
 func TestExplicitDirMustBeFresh(t *testing.T) {

--- a/cmd/treedb_vector_demo/main_test.go
+++ b/cmd/treedb_vector_demo/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -79,6 +80,14 @@ func TestDeterministicVectorFixture(t *testing.T) {
 	}
 }
 
+func TestSetSearchTimingAvoidsNonFiniteOps(t *testing.T) {
+	var res result
+	setSearchTiming(&res, 2, 0, 0)
+	if res.OpsPerSecond <= 0 || math.IsInf(res.OpsPerSecond, 0) || math.IsNaN(res.OpsPerSecond) {
+		t.Fatalf("ops/sec=%v want finite positive", res.OpsPerSecond)
+	}
+}
+
 func TestExactTopKShape(t *testing.T) {
 	rows := generateRows(32, 8, 1)
 	query := append([]float32(nil), rows[0].Vector...)
@@ -135,6 +144,31 @@ func TestExecuteColumnGraphTopKSmoke(t *testing.T) {
 	}
 	if res.VectorDirectViews == 0 || res.TypedColumnFallbacks != 0 {
 		t.Fatalf("typed-column vector counters missing/fallback: %+v", res)
+	}
+}
+
+func TestExecuteMetadataFilterCountsFilteredVectors(t *testing.T) {
+	res, err := execute(context.Background(), config{
+		Rows:           64,
+		Dims:           8,
+		VectorMode:     "typed-column",
+		MetadataMode:   "typed-row",
+		Queries:        2,
+		TopK:           3,
+		MetadataFilter: true,
+		Dir:            filepath.Join(t.TempDir(), "db"),
+		Seed:           1,
+		Preset:         "vector-rag",
+		EfSearch:       32,
+		MaxDecoded:     1,
+	})
+	if err != nil {
+		t.Fatalf("execute metadata filter: %v", err)
+	}
+	// The fixture has eight tenants, so tenant-00 appears rows/8 times.
+	wantScored := uint64((64 / 8) * 2)
+	if res.ScoredVectors != wantScored {
+		t.Fatalf("scored_vectors=%d want %d", res.ScoredVectors, wantScored)
 	}
 }
 

--- a/cmd/treedb_vector_demo/main_test.go
+++ b/cmd/treedb_vector_demo/main_test.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -189,6 +190,19 @@ func TestExplicitDirMustBeFresh(t *testing.T) {
 	}
 	if got, err := os.ReadFile(filepath.Join(dir, "keep.txt")); err != nil || string(got) != "keep" {
 		t.Fatalf("sentinel changed: got=%q err=%v", got, err)
+	}
+}
+
+func TestValidateFreshDemoDirAllowsShortExplicitPath(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("absolute /tmp/db shape is Unix-specific")
+	}
+	got, err := validateFreshDemoDir("/tmp/db")
+	if err != nil {
+		t.Fatalf("validateFreshDemoDir rejected short explicit path: %v", err)
+	}
+	if got != "/tmp/db" {
+		t.Fatalf("path=%q want /tmp/db", got)
 	}
 }
 

--- a/cmd/treedb_vector_demo/main_test.go
+++ b/cmd/treedb_vector_demo/main_test.go
@@ -193,6 +193,12 @@ func TestExplicitDirMustBeFresh(t *testing.T) {
 	}
 }
 
+func TestValidateFreshDemoDirRejectsRawParentTraversal(t *testing.T) {
+	if _, err := validateFreshDemoDir("safe/../other"); err == nil {
+		t.Fatal("validateFreshDemoDir accepted raw parent traversal")
+	}
+}
+
 func TestValidateFreshDemoDirAllowsShortExplicitPath(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("absolute /tmp/db shape is Unix-specific")

--- a/cmd/treedb_vector_demo/main_test.go
+++ b/cmd/treedb_vector_demo/main_test.go
@@ -117,6 +117,20 @@ func TestExecuteColumnGraphTopKSmoke(t *testing.T) {
 	}
 }
 
+func TestExplicitDirMustBeFresh(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "keep.txt"), []byte("keep"), 0o600); err != nil {
+		t.Fatalf("write sentinel: %v", err)
+	}
+	_, _, _, err := prepareFreshDir(dir, false)
+	if err == nil {
+		t.Fatal("prepareFreshDir accepted non-empty explicit dir")
+	}
+	if got, err := os.ReadFile(filepath.Join(dir, "keep.txt")); err != nil || string(got) != "keep" {
+		t.Fatalf("sentinel changed: got=%q err=%v", got, err)
+	}
+}
+
 func TestRunProfileArtifacts(t *testing.T) {
 	profileDir := filepath.Join(t.TempDir(), "profiles")
 	var stdout, stderr bytes.Buffer

--- a/cmd/treedb_vector_demo/main_test.go
+++ b/cmd/treedb_vector_demo/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -25,6 +26,23 @@ func TestParseConfigPresetAndOverrides(t *testing.T) {
 	}
 	if cfg.Preset != "perf-engineer" || cfg.Rows != 123 || cfg.Dims != 12 || cfg.MetadataMode != "document" || cfg.Queries != 4 || cfg.TopK != 3 || !cfg.MetadataFilter || !cfg.FinalFetch {
 		t.Fatalf("unexpected cfg: %+v", cfg)
+	}
+}
+
+func TestParseConfigDoubleDashPresetDefaults(t *testing.T) {
+	cfg, err := parseConfig([]string{"--preset", "perf-engineer"})
+	if err != nil {
+		t.Fatalf("parseConfig --preset: %v", err)
+	}
+	if cfg.Preset != "perf-engineer" || cfg.Rows != 10000 || cfg.Queries != 100 {
+		t.Fatalf("--preset did not apply perf-engineer defaults: %+v", cfg)
+	}
+	cfg, err = parseConfig([]string{"--preset=vector-rag"})
+	if err != nil {
+		t.Fatalf("parseConfig --preset=: %v", err)
+	}
+	if cfg.Preset != "vector-rag" || cfg.Rows != 1000 || cfg.Queries != 10 {
+		t.Fatalf("--preset= did not apply vector-rag defaults: %+v", cfg)
 	}
 }
 
@@ -93,7 +111,7 @@ func TestExactTopKShape(t *testing.T) {
 }
 
 func TestExecuteColumnGraphTopKSmoke(t *testing.T) {
-	res, err := execute(t.Context(), config{
+	res, err := execute(context.Background(), config{
 		Rows:         64,
 		Dims:         8,
 		VectorMode:   "typed-column",
@@ -111,6 +129,9 @@ func TestExecuteColumnGraphTopKSmoke(t *testing.T) {
 	}
 	if res.SearchPath != "column_graph_native_reader" || len(res.FirstResults) != 3 || res.Rows != 64 || res.Dims != 8 || res.Queries != 2 {
 		t.Fatalf("unexpected result: %+v", res)
+	}
+	if res.BatchSize != defaultVectorBatchSize {
+		t.Fatalf("batch_size=%d want default %d", res.BatchSize, defaultVectorBatchSize)
 	}
 	if res.VectorDirectViews == 0 || res.TypedColumnFallbacks != 0 {
 		t.Fatalf("typed-column vector counters missing/fallback: %+v", res)

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -113,3 +113,14 @@ Profile + analyze (recommended):
 See:
 - `cmd/unified_bench/README.md`
 - `cmd/benchprof/README.md`
+
+## TreeDB Collection Demos
+
+For collection quickstarts, persona/use-case guidance, and vector/RAG smoke
+commands, see `docs/TREEDB_COLLECTION_QUICKSTART.md`.
+
+Fast vector/RAG smoke:
+
+```sh
+go run ./cmd/treedb_vector_demo -rows 1000 -dims 128 -vectors typed-column -metadata typed-row -queries 10
+```

--- a/docs/TREEDB_COLLECTION_QUICKSTART.md
+++ b/docs/TREEDB_COLLECTION_QUICKSTART.md
@@ -8,12 +8,65 @@ runs unless a command explicitly documents reuse.
 
 | Persona | Use case | Recommended demo/layout today |
 | --- | --- | --- |
-| Document application developer | Flexible JSON documents, point gets, simple scans | Use retained JSON document collections; collection demo coverage is being added under issue #1811. |
-| Operational/event analytics developer | Timestamp filters and count/sum/avg over declared scalar fields | Use typed-column scalar fields for optimized int64 predicate/aggregate shapes; see TreeDB collection benchmark docs while the standalone collection demo lands. |
+| Document application developer | Flexible JSON documents, point gets, simple scans | `cmd/treedb_collection_demo -mode document`; retained JSON payload is the primary model. |
+| Operational/event analytics developer | Timestamp filters and count/sum/avg over declared scalar fields | `cmd/treedb_collection_demo -mode typed-column -workload range-aggregate`; typed-column scalar fields exercise the optimized int64 predicate/aggregate shape. |
 | Schema-aware application developer | Declared scalar fields plus predictable point reads | Use typed-row assets with retained payloads for flexible fields. |
 | Hybrid product workload | Retained JSON payload plus typed metadata/metrics; separate final document fetch from scan/search | Use retained document + typed-row metadata + typed-column metrics/vectors, and time final fetch separately. |
 | Vector search/RAG-style developer | Embeddings with metadata and optional final document fetch | `cmd/treedb_vector_demo` with `-vectors typed-column -metadata typed-row` or `-metadata document`. |
 | Operations/performance engineer | Reproducible smoke/profile runs with counters and pprof artifacts | `cmd/treedb_vector_demo -preset perf-engineer -profile-dir ...` and the benchmark harnesses in `cmd/unified_bench`. |
+
+## Collection storage quickstart
+
+`cmd/treedb_collection_demo` creates a fresh TreeDB directory, declares a
+collection layout, loads deterministic JSON fixtures with `InsertBatch`, and
+runs one workload with setup time reported separately from query time.
+
+Document aggregate smoke:
+
+```sh
+go run ./cmd/treedb_collection_demo \
+  -mode document \
+  -rows 1000 \
+  -workload range-aggregate
+```
+
+Typed-column aggregate smoke:
+
+```sh
+go run ./cmd/treedb_collection_demo \
+  -mode typed-column \
+  -rows 1000 \
+  -workload range-aggregate
+```
+
+Profile smoke:
+
+```sh
+OUT=$(mktemp -d /tmp/treedb_collection_demo_profiles_XXXXXX)
+go run ./cmd/treedb_collection_demo \
+  -mode typed-column \
+  -rows 10000 \
+  -workload range-aggregate \
+  -profile-dir "$OUT"
+```
+
+Profile artifacts:
+
+- `cpu.pprof`
+- `allocs.pprof`
+- `summary.json`
+- `summary.md`
+
+Modes: `document`, `typed-row`, `typed-column`, `hybrid-document-row`,
+`hybrid-document-column`, and `hybrid-row-column`. Workloads: `insert`,
+`point-get`, `range-filter`, `range-aggregate`, `full-aggregate`, `mixed-read`,
+and `reopen-read`. Presets: `document-app`, `event-analytics`, `schema-aware`,
+`hybrid-product`, and `perf-engineer`.
+
+The typed-column aggregate path reports diagnostics such as materialization
+counts, mapped bytes, decoded bytes, pruning counters, and read-integrity mode.
+If the requested layout is not the direct typed-column shape, fallback counters
+make that visible instead of implying the optimized path was used.
 
 ## Vector/RAG quickstart
 

--- a/docs/TREEDB_COLLECTION_QUICKSTART.md
+++ b/docs/TREEDB_COLLECTION_QUICKSTART.md
@@ -70,6 +70,8 @@ make that visible instead of implying the optimized path was used.
 
 ## Vector/RAG quickstart
 
+See also `cmd/treedb_vector_demo/README.md`.
+
 `cmd/treedb_vector_demo` creates a fresh TreeDB directory, declares a collection,
 loads deterministic JSON fixtures, publishes embeddings as typed-column dense
 `float32_vector` sections, rebuilds a `column_graph` vector index, closes and
@@ -136,7 +138,7 @@ Profile artifacts:
 - `vector_demo_summary.md`
 
 The command prints setup timing separately from vector search timing and optional
-final document fetch timing. Counters include rows, dimensions, queries, top-k,
-ops/sec, candidate/scored-vector counts, documents fetched, typed-column mapped
-or heap-copy bytes, decoded bytes, and typed-column fallback counters where the
+final document fetch timing. Counters include rows, dimensions, queries, top-k, batch size, ops/sec,
+candidate/scored-vector counts, documents fetched, typed-column mapped/heap-copy
+byte peaks, decoded byte peaks, and typed-column fallback counters where the
 public search API exposes them.

--- a/docs/TREEDB_COLLECTION_QUICKSTART.md
+++ b/docs/TREEDB_COLLECTION_QUICKSTART.md
@@ -1,0 +1,89 @@
+# TreeDB Collection Quickstart Demos
+
+TreeDB collections are **pre-alpha**: on-disk formats, command names, and public
+collection APIs may change before stabilization. Rebuild demo directories between
+runs unless a command explicitly documents reuse.
+
+## Persona/use-case map
+
+| Persona | Use case | Recommended demo/layout today |
+| --- | --- | --- |
+| Document application developer | Flexible JSON documents, point gets, simple scans | Use retained JSON document collections; collection demo coverage is being added under issue #1811. |
+| Operational/event analytics developer | Timestamp filters and count/sum/avg over declared scalar fields | Use typed-column scalar fields for optimized int64 predicate/aggregate shapes; see TreeDB collection benchmark docs while the standalone collection demo lands. |
+| Schema-aware application developer | Declared scalar fields plus predictable point reads | Use typed-row assets with retained payloads for flexible fields. |
+| Hybrid product workload | Retained JSON payload plus typed metadata/metrics; separate final document fetch from scan/search | Use retained document + typed-row metadata + typed-column metrics/vectors, and time final fetch separately. |
+| Vector search/RAG-style developer | Embeddings with metadata and optional final document fetch | `cmd/treedb_vector_demo` with `-vectors typed-column -metadata typed-row` or `-metadata document`. |
+| Operations/performance engineer | Reproducible smoke/profile runs with counters and pprof artifacts | `cmd/treedb_vector_demo -preset perf-engineer -profile-dir ...` and the benchmark harnesses in `cmd/unified_bench`. |
+
+## Vector/RAG quickstart
+
+`cmd/treedb_vector_demo` creates a fresh TreeDB directory, declares a collection,
+loads deterministic JSON fixtures, publishes embeddings as typed-column dense
+`float32_vector` sections, rebuilds a `column_graph` vector index, closes and
+reopens the DB, and then runs query smoke searches. Metadata can live in the
+retained document or in typed-row fields.
+
+Current optimized vector query shape: typed-column vectors + `column_graph`
+native reader via `OpenVectorIndexSearcher`. Public metadata predicates are not
+yet wired into the `column_graph` search API; `-metadata-filter` therefore uses
+honest deterministic `exact_scoring_metadata_filter` while still publishing the
+typed-column vector assets.
+
+Smoke run:
+
+```sh
+go run ./cmd/treedb_vector_demo \
+  -rows 1000 \
+  -dims 128 \
+  -vectors typed-column \
+  -metadata typed-row \
+  -queries 10
+```
+
+Document metadata mode:
+
+```sh
+go run ./cmd/treedb_vector_demo \
+  -rows 1000 \
+  -dims 128 \
+  -vectors typed-column \
+  -metadata document \
+  -queries 10 \
+  -final-fetch
+```
+
+Metadata-filter smoke (exact scoring, not ANN graph search):
+
+```sh
+go run ./cmd/treedb_vector_demo \
+  -rows 1000 \
+  -dims 128 \
+  -vectors typed-column \
+  -metadata typed-row \
+  -metadata-filter \
+  -queries 10
+```
+
+Profile run:
+
+```sh
+OUT=$(mktemp -d /tmp/treedb_vector_demo_profiles_XXXXXX)
+go run ./cmd/treedb_vector_demo \
+  -preset perf-engineer \
+  -rows 10000 \
+  -queries 100 \
+  -profile-dir "$OUT"
+```
+
+Profile artifacts:
+
+- `vector_demo_cpu.pprof`
+- `vector_demo_allocs.pprof`
+- `vector_demo_summary.json`
+- `vector_demo_summary.md`
+
+The command prints setup timing separately from vector search timing and optional
+final document fetch timing. Counters include rows, dimensions, queries, top-k,
+ops/sec, candidate/scored-vector counts, documents fetched, typed-column mapped
+or heap-copy bytes, decoded bytes, and typed-column fallback counters where the
+public search API exposes them.


### PR DESCRIPTION
## Summary

Closes #1811. Parent tracker: #1791.

Adds standalone TreeDB collection/vector quickstart/profile programs for pre-alpha typed-storage demos:

- `cmd/treedb_collection_demo` covers document, typed-row, typed-column, and hybrid collection layouts with deterministic fixtures, realistic scalar workloads, checkpoint/reopen, read-integrity flags, and pprof/profile summaries.
- `cmd/treedb_vector_demo` covers vector/RAG smoke with typed-column dense `float32_vector` storage, document or typed-row metadata, `column_graph` native reader searches, optional final fetch timing, chunked `InsertBatch`, and profile summaries.
- `docs/TREEDB_COLLECTION_QUICKSTART.md` links persona/use-case commands, profile artifacts, caveats, and current optimized-vs-deferred paths; `docs/GETTING_STARTED.md` links the guide.

## Linked tracker issue and milestone

- Tracker: #1811
- Parent: #1791
- Milestones covered in this PR: M0 fixture/flags/output shape, M1 collection MVP, M2 hybrid layouts/workloads, M3 profile artifacts, M4 vector demo, M5 docs integration, M6 persona presets for the supported demo scope.
- Explicitly not included: production storage optimizations, HTML reports, unified-bench replacement, 10M/50M presets, or private lifecycle/cache APIs.

## Commands added

- `go run ./cmd/treedb_collection_demo ...`
- `go run ./cmd/treedb_vector_demo ...`

## Example command output

Collection typed-column aggregate excerpt:

```text
mode=typed-column workload=range-aggregate rows=1000
setup_ms=35.713 query_ms=0.184 ops_sec=5410.29 rows_sec=5410289.29
matches=501 count=501 sum=250500 avg=500.000
document_materializations=0 row_materializations=0 mapped_bytes=43377 decoded_bytes=1585
```

Vector/RAG excerpt:

```text
TreeDB vector/RAG demo (pre-alpha collections)
preset=vector-rag vectors=typed-column metadata=typed-row metadata_filter=false final_fetch=false
db_dir=... rows=1000 dims=128 queries=10 top_k=10 batch_size=512 search_path=column_graph_native_reader
setup_ms=303.736 search_ms=0.154 fetch_ms=0.000 ops_sec=64777.33
candidates=1280 candidates_per_search=128.00 scored_vectors=1686 docs_fetched=0 document_bytes=0
mapped_bytes_peak=249856 heap_copy_bytes_peak=262144 decoded_bytes_peak=1050 physical_bytes_read=0 vector_direct_views=1686 vector_scratch_decodes=0 typed_column_fallbacks=0
```

## Workload/layout matrix supported

Collection demo modes:

| Mode | Intended persona/use case |
| --- | --- |
| `document` | retained JSON document app developer |
| `typed-row` | schema-aware scalar fields in typed-row assets |
| `typed-column` | event analytics scalar column aggregate/filter path |
| `hybrid-document-row` | retained document + typed-row metadata |
| `hybrid-document-column` | retained document + typed-column metrics |
| `hybrid-row-column` | typed-row metadata + typed-column metrics |

Collection workloads: `insert`, `point-get`, `range-filter`, `range-aggregate`, `full-aggregate`, `mixed-read`, `reopen-read`.

Collection presets: `document-app`, `event-analytics`, `schema-aware`, `hybrid-product`, `perf-engineer`.

Vector demo supports typed-column dense vector storage with `-metadata document|typed-row`; unsupported `-vectors document|typed-row` and `-metadata typed-column` fail clearly. `-metadata-filter` is intentionally documented as exact scoring until public graph+metadata predicates exist.

## Profile artifact behavior

Collection `-profile-dir` emits:

- `cpu.pprof`
- `allocs.pprof`
- `summary.json`
- `summary.md`

Vector `-profile-dir` emits:

- `vector_demo_cpu.pprof`
- `vector_demo_allocs.pprof`
- `vector_demo_summary.json`
- `vector_demo_summary.md`

These artifacts are intentionally simple demo/profile outputs, not a replacement for unified-bench/benchprof.

## Start-phase test plan

- Focused command package tests for flag/preset parsing, deterministic fixtures, profile artifact creation, fresh-dir safety, collection aggregate parity, collection reopen-read, vector top-k smoke.
- Docs package smoke/lint via `go test ./TreeDB/docs`.
- Required end-to-end smoke commands from #1811 for collection document/typed-column aggregate, collection profile dir, and vector typed-column demo.

## Close-phase test evidence

Latest local head: `3d2585821`.

```sh
go test ./cmd/treedb_collection_demo ./cmd/treedb_vector_demo ./TreeDB/docs
# ok github.com/snissn/gomap/cmd/treedb_collection_demo
# ok github.com/snissn/gomap/cmd/treedb_vector_demo
# ok github.com/snissn/gomap/TreeDB/docs
```

Internal Orca review: high-thinking review agent passed after one blocking finding was fixed (`insert` workload throughput now derives from setup/insert duration rather than no-op query duration).

## Smoke run evidence with command lines

```sh
go run ./cmd/treedb_collection_demo -mode document -rows 1000 -workload range-aggregate
```

Result excerpt: `matches=501 count=501 sum=250500 avg=500.000`, `document_materializations=1000`.

```sh
go run ./cmd/treedb_collection_demo -mode typed-column -rows 1000 -workload range-aggregate
```

Result excerpt: `matches=501 count=501 sum=250500 avg=500.000`, `document_materializations=0`, `mapped_bytes=43377`, `decoded_bytes=1585`.

```sh
OUT=$(mktemp -d /tmp/treedb_collection_demo_profiles_XXXXXX)
go run ./cmd/treedb_collection_demo -mode typed-column -rows 10000 -workload range-aggregate -profile-dir "$OUT"
find "$OUT" -maxdepth 1 -type f | sed 's#.*/##' | sort
```

Artifacts observed: `allocs.pprof`, `cpu.pprof`, `summary.json`, `summary.md`.

```sh
go run ./cmd/treedb_vector_demo -rows 1000 -dims 128 -vectors typed-column -metadata typed-row -queries 10
```

Result excerpt: `search_path=column_graph_native_reader`, `batch_size=512`, `vector_direct_views=1686`, `typed_column_fallbacks=0`.

Additional vector profile smoke:

```sh
OUT=$(mktemp -d /tmp/treedb_vector_demo_profiles_XXXXXX)
go run ./cmd/treedb_vector_demo -rows 128 -dims 32 -queries 2 -top-k 3 -profile-dir "$OUT"
find "$OUT" -maxdepth 1 -type f | sed 's#.*/##' | sort
```

Artifacts observed: `vector_demo_allocs.pprof`, `vector_demo_cpu.pprof`, `vector_demo_summary.json`, `vector_demo_summary.md`.

## AI review status and unresolved thread summary

- Codex: latest-head review on `3d2585821` reported no major issues; earlier path-validation findings were fixed in `d3053981a` and `3d2585821`.
- Copilot: requested repeatedly; latest attempt on `3d2585821` errored/unavailable, so no Copilot findings are pending.
- CodeRabbit: latest-head review completed/skipped with status success; prior findings were fixed in `9ff9f0cb8`, `956a0e935`, `ccd128f8a`, `98bbccee7`, `d3053981a`, and `3d2585821`.
- Unresolved review threads: none; Codex and CodeRabbit threads resolved after fixes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two CLI demos: a collection demo (multiple storage modes, workloads, named presets with CLI overrides, deterministic fixtures, safe directory handling, optional checkpoint/reopen) and a vector/RAG demo (configurable embeddings, index rebuild + top‑k search, optional metadata filtering/final fetch). Both emit timing, throughput, aggregate/search diagnostics and optional profiling artifacts.

* **Documentation**
  * New quickstarts and README entries; Getting Started updated.

* **Tests**
  * Expanded tests for CLI parsing, preset overrides, determinism, safety checks, end‑to‑end smoke runs, and profiling artifact validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1815?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
