### PR TITLE
Define typed-column schema evolution policy

### DIFF
--- a/TreeDB/collections/typed_column_adapter.go
+++ b/TreeDB/collections/typed_column_adapter.go
@@ -342,7 +342,7 @@ func typedColumnAdapterPartFromDecodedImage(opts typedColumnAdapterOptions, imag
 	if err != nil {
 		return nil, err
 	}
-	if err := validateTypedColumnAdapterImageSchema(part, columns); err != nil {
+	if err := validateTypedColumnAdapterImageSchema(part, columns, opts.SchemaVersion); err != nil {
 		return nil, err
 	}
 	dictionaries, err := image.Dictionaries()
@@ -369,9 +369,12 @@ func typedColumnAdapterPartFromDecodedImage(opts typedColumnAdapterOptions, imag
 	return &typedColumnAdapterPart{Options: opts, Columns: columns, Part: part, Dictionary: dictionaries}, nil
 }
 
-func validateTypedColumnAdapterImageSchema(part *typedcolumn.ColumnPart, columns []typedColumnAdapterColumn) error {
+func validateTypedColumnAdapterImageSchema(part *typedcolumn.ColumnPart, columns []typedColumnAdapterColumn, schemaVersion uint32) error {
 	if part == nil {
 		return errors.New("collections: typed-column adapter nil image part")
+	}
+	if schemaVersion != 0 && part.Descriptor.SchemaVersion != schemaVersion {
+		return fmt.Errorf("collections: typed-column adapter image schema_version=%d want %d", part.Descriptor.SchemaVersion, schemaVersion)
 	}
 	primary, ok := part.Columns[typedColumnAdapterPrimaryIDColumn]
 	if !ok {
@@ -951,7 +954,7 @@ func typedColumnAdapterPrepareInt64PredicatePart(fields []TypedStorageField, raw
 	if image.PartID != refPartID || image.Rows != typedRows || image.Rows != physicalRows {
 		return nil, typedColumnAdapterColumn{}, 0, fmt.Errorf("collections: typed_column_part %s image/ref mismatch image_part=%d ref_part=%d image_rows=%d typed_manifest_rows=%d physical_rows=%d", operation, image.PartID, refPartID, image.Rows, typedRows, physicalRows)
 	}
-	adapterPart, err := decode(typedColumnAdapterOptions{Fields: fields}, image)
+	adapterPart, err := decode(typedColumnAdapterOptions{Fields: fields, SchemaVersion: uint32(schemaHash)}, image)
 	if err != nil {
 		return nil, typedColumnAdapterColumn{}, 0, err
 	}

--- a/TreeDB/collections/typed_column_adapter_test.go
+++ b/TreeDB/collections/typed_column_adapter_test.go
@@ -991,6 +991,40 @@ func TestTypedColumnAdapterDuplicateOrAmbiguousFieldsFailClosed(t *testing.T) {
 	}
 }
 
+func TestTypedColumnAdapterImageDescriptorVersionFailsClosed(t *testing.T) {
+	field := typedColumnAdapterField("count", ColumnStoreValueInt64)
+	part := typedColumnAdapterBuildPart(t, field, []columnDeclaredValue{{Type: ColumnStoreValueInt64, Present: true, Int64: 10}})
+	image, err := part.buildImage()
+	if err != nil {
+		t.Fatalf("buildImage: %v", err)
+	}
+	corrupt := image
+	corrupt.Bytes = bytes.Clone(image.Bytes)
+	corrupt.Sections = slices.Clone(image.Sections)
+	descriptor := typedColumnAdapterFindSection(t, corrupt, typedcolumn.ColumnPartImageSectionDescriptor)
+	binary.LittleEndian.PutUint16(corrupt.Bytes[descriptor.Offset:descriptor.Offset+2], 99)
+
+	if _, err := typedColumnAdapterPartFromImage(part.Options, corrupt); err == nil || !strings.Contains(err.Error(), "unsupported descriptor version") {
+		t.Fatalf("partFromImage descriptor version err=%v want unsupported descriptor version", err)
+	}
+}
+
+func TestTypedColumnAdapterImageSchemaVersionMismatchFailsClosed(t *testing.T) {
+	field := typedColumnAdapterField("count", ColumnStoreValueInt64)
+	rows := []typedColumnAdapterRow{{PrimaryID: 1, Values: map[string]columnDeclaredValue{"count": {Type: ColumnStoreValueInt64, Present: true, Int64: 10}}}}
+	part, err := buildTypedColumnAdapterPart(typedColumnAdapterOptions{PartID: 1, SchemaVersion: 77, Fields: []TypedStorageField{field}}, rows)
+	if err != nil {
+		t.Fatalf("buildTypedColumnAdapterPart: %v", err)
+	}
+	image, err := part.buildImage()
+	if err != nil {
+		t.Fatalf("buildImage: %v", err)
+	}
+	if _, err := typedColumnAdapterPartFromImage(typedColumnAdapterOptions{PartID: 1, SchemaVersion: 78, Fields: []TypedStorageField{field}}, image); err == nil || !strings.Contains(err.Error(), "schema_version=77 want 78") {
+		t.Fatalf("partFromImage schema version mismatch err=%v want schema_version mismatch", err)
+	}
+}
+
 func TestTypedColumnAdapterImageSchemaMismatchFailsClosed(t *testing.T) {
 	field := typedColumnAdapterField("count", ColumnStoreValueInt64)
 	part := typedColumnAdapterBuildPart(t, field, []columnDeclaredValue{{Type: ColumnStoreValueInt64, Present: true, Int64: 10}})
@@ -1004,6 +1038,20 @@ func TestTypedColumnAdapterImageSchemaMismatchFailsClosed(t *testing.T) {
 	}
 }
 
+func TestTypedColumnAdapterImageOwnerMismatchFailsClosed(t *testing.T) {
+	field := typedColumnAdapterField("count", ColumnStoreValueInt64)
+	part := typedColumnAdapterBuildPart(t, field, []columnDeclaredValue{{Type: ColumnStoreValueInt64, Present: true, Int64: 10}})
+	image, err := part.buildImage()
+	if err != nil {
+		t.Fatalf("buildImage: %v", err)
+	}
+	mismatch := typedColumnAdapterField("count", ColumnStoreValueInt64)
+	mismatch.Owner = TypedStorageOwnerRowAsset
+	if _, err := typedColumnAdapterPartFromImage(typedColumnAdapterOptions{PartID: 1, Fields: []TypedStorageField{mismatch}}, image); err == nil || !strings.Contains(err.Error(), "owner=\"typed_row_asset\" want \"typed_column_part\"") {
+		t.Fatalf("partFromImage owner mismatch err=%v want owner mismatch", err)
+	}
+}
+
 func TestTypedColumnAdapterImageValueTypeMetadataMismatchFailsClosed(t *testing.T) {
 	field := typedColumnAdapterField("score", ColumnStoreValueDouble)
 	part := typedColumnAdapterBuildPart(t, field, []columnDeclaredValue{{Type: ColumnStoreValueDouble, Present: true, Double: 42.5}})
@@ -1014,6 +1062,37 @@ func TestTypedColumnAdapterImageValueTypeMetadataMismatchFailsClosed(t *testing.
 	mismatch := typedColumnAdapterField("score", ColumnStoreValueFloat32)
 	if _, err := typedColumnAdapterPartFromImage(typedColumnAdapterOptions{PartID: 1, Fields: []TypedStorageField{mismatch}}, image); err == nil || !strings.Contains(err.Error(), "value type metadata mismatch") {
 		t.Fatalf("partFromImage value-type mismatch err=%v want value type metadata mismatch", err)
+	}
+}
+
+func TestTypedColumnAdapterImageVectorDimsMismatchFailsClosed(t *testing.T) {
+	field := typedColumnAdapterField("embedding", ColumnStoreValueFloat32Vector)
+	field.VectorDims = 3
+	part := typedColumnAdapterBuildPart(t, field, []columnDeclaredValue{
+		{Type: ColumnStoreValueFloat32Vector, Present: true, Float32Vector: []float32{1, 2, 3}},
+		{Type: ColumnStoreValueFloat32Vector, Present: true, Float32Vector: []float32{4, 5, 6}},
+	})
+	image, err := part.buildImage()
+	if err != nil {
+		t.Fatalf("buildImage: %v", err)
+	}
+	mismatch := field
+	mismatch.VectorDims = 4
+	if _, err := typedColumnAdapterPartFromImage(typedColumnAdapterOptions{PartID: 1, Fields: []TypedStorageField{mismatch}}, image); err == nil || !strings.Contains(err.Error(), "fixed_width_elements=3 want") {
+		t.Fatalf("partFromImage vector_dims mismatch err=%v want fixed_width_elements schema mismatch", err)
+	}
+}
+
+func TestTypedColumnAdapterPrepareInt64SchemaHashMismatchFailsBeforeScan(t *testing.T) {
+	field := typedColumnAdapterField("count", ColumnStoreValueInt64)
+	part := typedColumnAdapterBuildPart(t, field, []columnDeclaredValue{{Type: ColumnStoreValueInt64, Present: true, Int64: 10}})
+	image, err := part.buildImage()
+	if err != nil {
+		t.Fatalf("buildImage: %v", err)
+	}
+	_, _, _, err = typedColumnAdapterPrepareInt64PredicateScanPart([]TypedStorageField{field}, image.Bytes, image.PartID, image.Rows, image.Rows, uint64(part.Part.Descriptor.SchemaVersion+1), "count")
+	if err == nil || !strings.Contains(err.Error(), "schema_version") {
+		t.Fatalf("prepare int64 predicate schema hash mismatch err=%v want schema_version failure before scan", err)
 	}
 }
 
@@ -1161,6 +1240,17 @@ func typedColumnAdapterFindColumnSection(t *testing.T, image typedcolumn.ColumnP
 		}
 	}
 	t.Fatalf("missing column data section %q in %+v", column, image.Sections)
+	return typedcolumn.ColumnPartImageSection{}
+}
+
+func typedColumnAdapterFindSection(t *testing.T, image typedcolumn.ColumnPartImage, kind typedcolumn.ColumnPartImageSectionKind) typedcolumn.ColumnPartImageSection {
+	t.Helper()
+	for _, section := range image.Sections {
+		if section.Kind == kind {
+			return section
+		}
+	}
+	t.Fatalf("missing section %q in %+v", kind, image.Sections)
 	return typedcolumn.ColumnPartImageSection{}
 }
 

--- a/TreeDB/collections/typed_column_publication.go
+++ b/TreeDB/collections/typed_column_publication.go
@@ -295,7 +295,7 @@ func (c *Collection) typedColumnPartValuesForVisibleRowAtSnapshotIntoWithCache(s
 		if cache != nil {
 			cache.PartLoads++
 		}
-		part, err := typedColumnAdapterPartFromBytesForReconstruction(typedColumnAdapterOptions{Fields: fields}, raw)
+		part, err := typedColumnAdapterPartFromBytesForReconstruction(typedColumnAdapterOptions{Fields: fields, SchemaVersion: uint32(cfg.SchemaHash)}, raw)
 		if err != nil {
 			if closeErr := readCache.close(); closeErr != nil {
 				err = errors.Join(err, closeErr)

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -349,7 +349,7 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/column_vector_graph_typed_column_test.go", classification: typedStorageLegacyDerived, matchingLines: 21, occurrences: 24},
 	{path: "TreeDB/collections/command_wal_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 4, occurrences: 6},
 	{path: "TreeDB/collections/typed_column_adapter.go", classification: typedStorageLegacyCompatibility, matchingLines: 30, occurrences: 35},
-	{path: "TreeDB/collections/typed_column_adapter_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 152, occurrences: 155},
+	{path: "TreeDB/collections/typed_column_adapter_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 164, occurrences: 167},
 	{path: "TreeDB/collections/typed_column_int64_scan.go", classification: typedStorageLegacyCompatibility, matchingLines: 22, occurrences: 31},
 	{path: "TreeDB/collections/typed_column_int64_scan_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 29, occurrences: 36},
 	{path: "TreeDB/collections/typed_column_publication.go", classification: typedStorageLegacyCompatibility, matchingLines: 17, occurrences: 19},

--- a/TreeDB/docs/spec/README.md
+++ b/TreeDB/docs/spec/README.md
@@ -186,6 +186,11 @@ Given pre-alpha status, this is a living spec that tracks implementation.
 - `TreeDB/docs/spec/typed-asset-maintenance-1788.md`
   - issue #1788 implementation contract for typed-row plus typed-column COW
     reachability, active mappedresource pin protection, GC, and rewrite.
+- `TreeDB/docs/spec/typed-column-schema-evolution.md`
+  - issue #1789 pre-alpha policy for typed-column image/descriptor/manifest
+    schema evolution, fail-closed mismatch handling, rebuild-vs-migrate
+    decisions, future migration tooling requirements, and allocation/performance
+    evidence for format changes.
 
 ## Canonical Ownership
 
@@ -216,9 +221,10 @@ in `typed-column-transplant.md`, the #1754/#1755 adapter/publication seam is
 recorded in `typed-column-adapter.md`, the #1758 closeout evidence/handoff is
 recorded in `typed-storage-closeout-1758.md`, and current typed-row plus
 typed-column maintenance behavior is recorded in
-`typed-asset-maintenance-1788.md`. User-command WAL lifecycle terms
-(`CommandEnvelope`, `LSN`, `AppliedLSN`, `WAL-supported`, `WAL-rejected`,
-`WAL-off-only`) are owned by `user-command-wal.md`. Deprecated collection root-delta WAL terms
+`typed-asset-maintenance-1788.md`, and typed-column schema/version evolution
+policy is owned by `typed-column-schema-evolution.md`. User-command WAL
+lifecycle terms (`CommandEnvelope`, `LSN`, `AppliedLSN`, `WAL-supported`,
+`WAL-rejected`, `WAL-off-only`) are owned by `user-command-wal.md`. Deprecated collection root-delta WAL terms
 (`CollectionSeq`, `WALLSN`, `root group`, `applied watermark`) remain defined in
 `collection-wal-durability-plan.md` for historical design context only.
 
@@ -235,7 +241,8 @@ blocking questions live:
 - Typed-storage persistence and historical roadmap questions:
   `typed-storage-naming.md`, `typed-column-transplant.md`,
   `typed-column-adapter.md`, `typed-storage-closeout-1758.md`,
-  `typed-asset-maintenance-1788.md`, and `GOMAP_TREEDB_COLUMN_STORE_RFC.md`.
+  `typed-asset-maintenance-1788.md`, `typed-column-schema-evolution.md`, and
+  `GOMAP_TREEDB_COLUMN_STORE_RFC.md`.
 
 A blocking implementation question must be listed in this index and in its
 owner document. Non-blocking future-extension questions must be labeled as
@@ -252,6 +259,7 @@ Docs lint treats this list as a manifest:
 - `TreeDB/docs/spec/write-path-and-durability.md`
 - `TreeDB/docs/spec/recovery.md`
 - `TreeDB/docs/spec/verification.md`
+- `TreeDB/docs/spec/typed-column-schema-evolution.md`
 
 ## Relationship to Existing Docs
 

--- a/TreeDB/docs/spec/storage-format.md
+++ b/TreeDB/docs/spec/storage-format.md
@@ -8,7 +8,9 @@ TreeDB is pre-alpha; format compatibility between versions is not guaranteed.
 That disclaimer does not permit fail-open handling of acknowledged durable
 writes. Once a directory advertises a required storage feature such as
 `command_wal_v1`, unsupported binaries must fail closed instead of serving,
-cleaning, compacting, or rewriting the directory.
+cleaning, compacting, or rewriting the directory. Typed-column image,
+descriptor, manifest, and schema evolution follows the fail-closed policy in
+`typed-column-schema-evolution.md`.
 
 ## 1. Top-Level Storage Objects
 
@@ -796,6 +798,17 @@ Readers must fail closed for a column-enabled collection when:
 - the recovery-authoritative applied command LSN is zero while an active manifest
   is present, or
 - a durable-only column collection is opened under a relaxed durability mode.
+
+For typed-column parts specifically, readers and maintenance planners must reject
+unsupported image versions, descriptor versions, manifest identity versions,
+schema-hash drift, field-owner/value-type mismatches, `vector_dims` and
+fixed-width layout mismatches, and kind/generation/part/checksum/range mismatches
+from headers, descriptors, manifest identities, or refs whenever possible. They
+must fail closed before full payload decode or per-row allocation when those
+compact records already prove the format unsupported. Rebuild benchmark and
+experiment directories rather than relying on implicit migrations during the
+pre-alpha period; future migration tooling requirements are owned by
+`typed-column-schema-evolution.md`.
 
 `CollectionInsertBatchByIDV1` payload:
 

--- a/TreeDB/docs/spec/typed-column-adapter.md
+++ b/TreeDB/docs/spec/typed-column-adapter.md
@@ -1,6 +1,8 @@
 # Typed-Column Adapter and Durable Vector Publication (#1754/#1755/#1756)
 
 Status: current implementation note for issues #1754, #1755, and #1756 under parent tracker #1744.
+Typed-column schema/version evolution and migration policy is defined in
+`typed-column-schema-evolution.md`.
 
 `TreeDB/collections/typed_column_adapter.go` adapts the transplanted
 `TreeDB/internal/typedcolumn` data plane to TreeDB typed-storage field metadata,
@@ -44,7 +46,11 @@ Adapter input rows are keyed by `TypedStorageField.Path`, not by display `Name`.
 When `Name != Path`, the physical column name may use `Name`, but decoded rows
 are restored under `Path`; display-name-only input fails closed. Adapter images
 are fixed-schema: reads fail closed if the image contains unexpected columns or
-is missing any expected field column/primary-id column.
+is missing any expected field column/primary-id column. The adapter must reject
+schema hash, field ownership, value type, `vector_dims`, fixed-width metadata,
+image/descriptor version, and manifest ref mismatches from adapter descriptors,
+manifest identities, or refs before row materialization whenever those compact
+records are sufficient.
 
 ## Durable Publication / Reconstruction Seam (#1755)
 
@@ -119,8 +125,10 @@ allocations in touched functions, the PR must fix them or explicitly call out wh
 they are out of scope with a linked follow-up recommendation. Any remaining
 hot-path allocation requires baseline-versus-final `B/op`/`allocs/op` evidence
 and an allocation profile/top that names and justifies the source or defers it
-with rationale. These allocation targets do not relax checksum, lifetime, schema,
-or fail-closed validation.
+with rationale. Future typed-column format/schema changes must state whether
+they preserve 0-alloc/near-0-alloc decode and scan paths or introduce an explicit
+benchmarked fallback. These allocation targets do not relax checksum, lifetime,
+schema, or fail-closed validation.
 
 ## Boundary
 

--- a/TreeDB/docs/spec/typed-column-schema-evolution.md
+++ b/TreeDB/docs/spec/typed-column-schema-evolution.md
@@ -1,0 +1,131 @@
+# Typed-Column Schema Evolution and Migration Policy (#1789)
+
+Status: current pre-alpha policy for typed-column image, descriptor, manifest,
+and schema changes. This document is normative for typed-column storage changes;
+it does not introduce migration scaffolding or a backwards-compatibility promise.
+
+## Pre-alpha compatibility policy
+
+TreeDB is pre-alpha. Typed-column part images, descriptors, manifest records,
+and collection metadata fields may change between commits or releases. A DB
+directory created by one binary is not guaranteed to open with another binary,
+and a newer binary is allowed to reject older typed-column directories rather
+than migrate them.
+
+The required safety rule is fail closed: when typed-column metadata or bytes are
+unsupported, stale, incomplete, or inconsistent, TreeDB must reject the open,
+scan, reconstruction, maintenance, GC, or rewrite operation before serving data
+or mutating typed assets. Unsupported typed-column formats must not be treated as
+best-effort data, silently cleaned up, or rewritten into a guessed shape.
+
+For benchmark and experiment directories, the preferred current answer is
+rebuild rather than migrate. Recreate fixture DB directories with the binary and
+schema being measured. Migration tooling is deferred until a separate issue
+commits to a stable compatibility target.
+
+## Fail-closed detection points
+
+Typed-column validation should reject mismatches from small headers,
+descriptors, manifest identity records, and manifest refs whenever possible. A
+reader or maintenance planner should not decode a full typed-column payload, scan
+all rows, or allocate per-row state merely to discover an unsupported version or
+schema mismatch.
+
+Current and future typed-column code must fail closed on at least these classes:
+
+- **Schema identity:** collection `schema_hash` and typed asset `SchemaHash`
+  must match the normalized schema/config that selected the reader. Schema hash
+  drift means caches and typed-column payloads are stale.
+- **Field ownership:** each logical field has one authoritative owner for a
+  generation. A field expected to be `typed_column_part` must not be read from a
+  typed-row asset, retained document payload, or derived accelerator as a silent
+  substitute, and overlapping authoritative owners must be rejected.
+- **Value type:** declared `ColumnStoreValueType` / typed-storage value type must
+  match the typed-column column descriptor. Unsupported value types such as
+  authoritative `adjacency_list` remain fail-closed until their format is
+  specified.
+- **Vector dimensions:** `float32_vector` fields must have positive
+  `vector_dims`, and descriptor fixed-width element counts must match the
+  declared dimensions. Nullable/missing vector and adjacency payloads remain
+  staged and fail-closed.
+- **Fixed-width metadata and layout:** fixed-width column descriptors must match
+  type, encoding, compression, element width/count, byte length, row count,
+  endian mode, section range, and alignment before exposing direct typed views.
+  Truncated, overlapping, out-of-bounds, or misaligned sections must fail closed
+  or use only an explicitly documented safe fallback that preserves semantics.
+- **Image version:** typed-column part-image magic/version values are required
+  gates. Unknown image versions must fail closed before section payload decode.
+- **Descriptor version:** column, dictionary, aggregate, locator, nullable, and
+  future section descriptors must reject unsupported descriptor versions/kinds
+  from descriptor bytes before row-level decode.
+- **Manifest identity:** active manifest identity and recovery-authoritative
+  identity must have supported format/version values, matching generation and
+  checksum, and the collection metadata must name the expected manifest root and
+  storage policy. Missing or conflicting identity state fails closed.
+- **Manifest refs:** every accepted typed-column ref must match expected kind,
+  namespace, generation, part id, segment file id, offset, length, checksum,
+  lifecycle role, and row/range metadata. Kind/generation/part/checksum/range
+  mismatches, non-canonical segments, missing segments, and out-of-bounds ranges
+  fail closed.
+
+These checks apply both to online reads and to maintenance. A GC or rewrite plan
+with incomplete classification, unsupported typed-column formats, corrupt refs,
+or unconvertible active pins must not delete or rewrite typed-column bytes.
+
+## Rebuild versus migrate
+
+Until TreeDB declares a stable typed-column compatibility window:
+
+- benchmark and experiment DB directories should be rebuilt after typed-column
+  image, descriptor, manifest, or schema semantics change;
+- public docs and benchmark notes should identify the commit/schema used to
+  create reusable fixtures;
+- tooling may report why a directory is unsupported, but it must not perform an
+  implicit migration during open, scan, GC, rewrite, or compaction; and
+- tests may assert fail-closed behavior for old/unsupported versions instead of
+  requiring cross-version reads.
+
+## Future migration tooling requirements
+
+A future migration tool must be explicitly scoped before implementation. At a
+minimum it must:
+
+1. open the source directory read-only and validate typed-column image,
+   descriptor, manifest, checksum, and range closure before copying bytes;
+2. identify source and target format/schema versions, including descriptor and
+   manifest identity versions;
+3. produce a new directory or copy-on-write generation rather than mutating the
+   only durable copy in place;
+4. preserve row identity, generation ordering, tombstone semantics, schema hash
+   provenance, field ownership, value types, vector dimensions, nullable/missing
+   semantics, and fixed-width layout invariants;
+5. recompute and publish manifest identity checksums only after all target refs
+   are durable and verified;
+6. keep typed-row, typed-column, and derived-accelerator refs tied to their
+   authoritative owner/generation;
+7. provide an audit/verification report that operators can run read-only; and
+8. include reopen, corruption, interruption, and rollback tests plus benchmark
+   evidence for any migrated hot path.
+
+This issue deliberately does not build that scaffolding.
+
+## Performance compatibility policy
+
+Typed-column decode, direct-view, scan, and reconstruction merge paths are
+allocation-budgeted hot paths. A future change to typed-column image,
+descriptor, schema, or manifest semantics must state whether it preserves the
+current 0-alloc or near-0-alloc decode/scan path after setup. If it cannot, the
+change must define an explicit, benchmarked fallback and explain why the fallback
+is acceptable.
+
+PRs that touch typed-column or column-store hot paths must report baseline versus
+final `B/op` and `allocs/op` for the affected benchmark(s). If a profile exposes
+new hot-path allocation, the PR must remove it or document a bounded follow-up
+with allocation profile/top evidence. Policy or migration work must not bless
+full-document reconstruction on direct typed-column scan paths, per-row heap
+wrappers, maps, interface boxes, closures, or string/byte conversions in inner
+loops.
+
+Fail-closed validation is not optional for performance. Unsupported-version and
+schema-mismatch checks should be header/descriptor-level and allocation-bounded,
+not skipped or delayed until row materialization.

--- a/TreeDB/docs/spec/typed-column-schema-evolution.md
+++ b/TreeDB/docs/spec/typed-column-schema-evolution.md
@@ -40,8 +40,8 @@ Current and future typed-column code must fail closed on at least these classes:
   generation. A field expected to be `typed_column_part` must not be read from a
   typed-row asset, retained document payload, or derived accelerator as a silent
   substitute, and overlapping authoritative owners must be rejected.
-- **Value type:** declared `ColumnStoreValueType` / typed-storage value type must
-  match the typed-column column descriptor. Unsupported value types such as
+- **Value type:** declared typed-storage value type must match the typed-column
+  column descriptor. Unsupported value types such as
   authoritative `adjacency_list` remain fail-closed until their format is
   specified.
 - **Vector dimensions:** `float32_vector` fields must have positive
@@ -118,9 +118,9 @@ current 0-alloc or near-0-alloc decode/scan path after setup. If it cannot, the
 change must define an explicit, benchmarked fallback and explain why the fallback
 is acceptable.
 
-PRs that touch typed-column or column-store hot paths must report baseline versus
-final `B/op` and `allocs/op` for the affected benchmark(s). If a profile exposes
-new hot-path allocation, the PR must remove it or document a bounded follow-up
+PRs that touch typed-column or typed-storage hot paths must report baseline
+versus final `B/op` and `allocs/op` for the affected benchmark(s). If a profile
+exposes new hot-path allocation, the PR must remove it or document a bounded follow-up
 with allocation profile/top evidence. Policy or migration work must not bless
 full-document reconstruction on direct typed-column scan paths, per-row heap
 wrappers, maps, interface boxes, closures, or string/byte conversions in inner

--- a/TreeDB/docs/spec/typed-storage-closeout-1758.md
+++ b/TreeDB/docs/spec/typed-storage-closeout-1758.md
@@ -392,6 +392,19 @@ Remaining COW maintenance work for #1736/#1788:
   aggregate query integration, multipart lifecycle/compaction, and full row+column
   COW cleanup as explicit follow-ups, not implied #1744 completions.
 
+## Post-closeout #1789 schema evolution policy
+
+Issue #1789 adds the current typed-column schema evolution and migration policy
+in `TreeDB/docs/spec/typed-column-schema-evolution.md`. The closeout facts above
+remain the implementation baseline, but typed-column image, descriptor, manifest,
+and schema formats are still pre-alpha: unsupported versions and schema/layout
+mismatches must fail closed rather than trigger implicit migration, cleanup, or
+rewrite. Benchmark and experiment directories should be rebuilt after typed-column
+format/schema changes until explicitly scoped migration tooling exists. Future
+hot-path format changes must report baseline-versus-final `B/op` and `allocs/op`
+and preserve 0-alloc/near-0-alloc direct decode/scan paths or document a
+benchmarked fallback.
+
 ## Post-closeout #1788 maintenance update
 
 Issue #1788 adds the current row+column typed-asset maintenance contract in

--- a/TreeDB/docs/spec/verification.md
+++ b/TreeDB/docs/spec/verification.md
@@ -781,6 +781,27 @@ Coverage:
   - `BenchmarkCollectionOverheadPlanIndexedTemplateV1`
   - `BenchmarkCollectionOverheadIndexStateTemplateV1Extraction`
 
+## 12.5 Typed-Column Schema Evolution and Migration Policy
+
+Invariant:
+- During pre-alpha, typed-column image, descriptor, manifest, and schema changes
+  may reject existing DB directories rather than migrate them.
+- Unsupported typed-column versions and schema/layout mismatches fail closed from
+  headers, descriptors, manifest identities, or refs where possible before full
+  payload decode or per-row allocation.
+- Hot typed-column format/schema changes report baseline-versus-final `B/op` and
+  `allocs/op` evidence or explicitly document a benchmarked fallback.
+
+Coverage:
+- Policy owner: `TreeDB/docs/spec/typed-column-schema-evolution.md`.
+- Existing fail-closed coverage is distributed across typed-column adapter,
+  publication, vector dense-section, int64 scan, and typed-asset maintenance
+  tests in `TreeDB/collections` and `TreeDB/internal/typedcolumn`.
+- Future format-version or schema-semantic changes must add targeted negative
+  tests for unsupported image/descriptor versions, schema-hash mismatch,
+  owner/value-type/vector-dim/fixed-width metadata mismatch, and manifest
+  identity/ref mismatch in the package that owns the changed decoder.
+
 ## 13. Native Wire Protocol
 
 Invariant:

--- a/TreeDB/internal/typedcolumn/tcs1.go
+++ b/TreeDB/internal/typedcolumn/tcs1.go
@@ -153,6 +153,9 @@ func DecodeTCS1ColumnPartHeader(header []byte, totalBytes int64) (TCS1PartRecord
 		return TCS1PartRecord{}, fmt.Errorf("typedcolumn: TCS1 rows=%d exceeds host int", rows64)
 	}
 	imageVersion := binary.LittleEndian.Uint16(header[tcs1ImageVersionOffset:tcs1ReservedOffset])
+	if imageVersion != columnPartImageVersion {
+		return TCS1PartRecord{}, fmt.Errorf("typedcolumn: unsupported part image version %d", imageVersion)
+	}
 	if reserved := binary.LittleEndian.Uint16(header[tcs1ReservedOffset:tcs1PayloadCRC32Offset]); reserved != 0 {
 		return TCS1PartRecord{}, fmt.Errorf("typedcolumn: TCS1 reserved=%d want 0", reserved)
 	}
@@ -207,6 +210,9 @@ func decodeTCS1Header(data []byte) (TCS1PartRecord, []byte, error) {
 	}
 	rows := int(rows64)
 	imageVersion := binary.LittleEndian.Uint16(data[tcs1ImageVersionOffset:tcs1ReservedOffset])
+	if imageVersion != columnPartImageVersion {
+		return TCS1PartRecord{}, nil, fmt.Errorf("typedcolumn: unsupported part image version %d", imageVersion)
+	}
 	if reserved := binary.LittleEndian.Uint16(data[tcs1ReservedOffset:tcs1PayloadCRC32Offset]); reserved != 0 {
 		return TCS1PartRecord{}, nil, fmt.Errorf("typedcolumn: TCS1 reserved=%d want 0", reserved)
 	}

--- a/TreeDB/internal/typedcolumn/validation_test.go
+++ b/TreeDB/internal/typedcolumn/validation_test.go
@@ -1,0 +1,181 @@
+package typedcolumn
+
+import (
+	"encoding/binary"
+	"strings"
+	"testing"
+)
+
+func TestTypedColumnValidationUnsupportedImageVersionFailsClosed(t *testing.T) {
+	image := mustTransplantImage(t, mustTransplantPart(t, 178901, transplantTestOptions([]SortKeyColumn{{Column: "id"}}), transplantTestBatch()))
+
+	badImage := append([]byte(nil), image.Bytes...)
+	binary.LittleEndian.PutUint16(badImage[4:6], columnPartImageVersion+1)
+	if _, err := ParseColumnPartImage(badImage); err == nil || !strings.Contains(err.Error(), "unsupported part image version") {
+		t.Fatalf("ParseColumnPartImage unsupported image version err=%v want unsupported part image version", err)
+	}
+
+	tcs1, _, err := EncodeTCS1ColumnPartImage(image)
+	if err != nil {
+		t.Fatalf("EncodeTCS1ColumnPartImage: %v", err)
+	}
+	badTCS1 := append([]byte(nil), tcs1...)
+	binary.LittleEndian.PutUint16(badTCS1[tcs1ImageVersionOffset:tcs1ReservedOffset], columnPartImageVersion+1)
+	badTCS1[tcs1PayloadOffset] ^= 0xff // Must fail on the header image version before payload checksum/parse.
+	if _, err := DecodeTCS1ColumnPartHeader(badTCS1[:tcs1HeaderBytes], int64(len(badTCS1))); err == nil || !strings.Contains(err.Error(), "unsupported part image version") {
+		t.Fatalf("DecodeTCS1ColumnPartHeader unsupported image version err=%v want unsupported part image version", err)
+	}
+	if _, _, err := DecodeTCS1ColumnPartImage(badTCS1); err == nil || !strings.Contains(err.Error(), "unsupported part image version") || strings.Contains(err.Error(), "checksum") {
+		t.Fatalf("DecodeTCS1ColumnPartImage unsupported image version err=%v want header version failure before checksum", err)
+	}
+}
+
+func TestTypedColumnValidationUnsupportedDescriptorVersionFailsClosed(t *testing.T) {
+	image := mustTransplantImage(t, mustTransplantPart(t, 178902, transplantTestOptions([]SortKeyColumn{{Column: "id"}}), transplantTestBatch()))
+	corrupt := cloneColumnPartImageBytes(image)
+	descriptor := mustValidationSection(t, corrupt, ColumnPartImageSectionDescriptor)
+	binary.LittleEndian.PutUint16(corrupt.Bytes[descriptor.Offset:descriptor.Offset+2], columnPartDescriptorVersion+1)
+
+	if _, err := ColumnPartFromImage(corrupt); err == nil || !strings.Contains(err.Error(), "unsupported descriptor version") {
+		t.Fatalf("ColumnPartFromImage unsupported descriptor version err=%v want unsupported descriptor version", err)
+	}
+}
+
+func TestTypedColumnValidationDescriptorSchemaVersionMismatchFailsClosed(t *testing.T) {
+	part := mustTransplantPart(t, 178903, transplantTestOptions([]SortKeyColumn{{Column: "id"}}), transplantTestBatch())
+	image := mustTransplantImage(t, part)
+	corrupt := cloneColumnPartImageBytes(image)
+	descriptor := mustValidationSection(t, corrupt, ColumnPartImageSectionDescriptor)
+	binary.LittleEndian.PutUint32(corrupt.Bytes[descriptor.Offset+10:descriptor.Offset+14], part.Descriptor.SchemaVersion+1)
+
+	if _, err := part.WithImagePayloads(corrupt); err == nil || !strings.Contains(err.Error(), "image descriptor does not match part descriptor") {
+		t.Fatalf("WithImagePayloads schema version mismatch err=%v want descriptor mismatch", err)
+	}
+}
+
+func TestTypedColumnValidationFixedWidthLayoutMismatchFailsClosed(t *testing.T) {
+	part := mustValidationVectorPart(t, 178904)
+	image, err := BuildColumnPartImage(part, ColumnPartImageOptions{})
+	if err != nil {
+		t.Fatalf("BuildColumnPartImage: %v", err)
+	}
+	corrupt := cloneColumnPartImageBytes(image)
+	fixedWidthOffset := mustValidationDescriptorFixedWidthOffset(t, corrupt, "embedding")
+	binary.LittleEndian.PutUint32(corrupt.Bytes[fixedWidthOffset:fixedWidthOffset+4], 2)
+
+	if _, err := ColumnPartFromImage(corrupt); err == nil || !(strings.Contains(err.Error(), "raw bytes") || strings.Contains(err.Error(), "fixed-width elements")) {
+		t.Fatalf("ColumnPartFromImage fixed-width layout mismatch err=%v want descriptor layout failure", err)
+	}
+}
+
+func cloneColumnPartImageBytes(image ColumnPartImage) ColumnPartImage {
+	clone := image
+	clone.Bytes = append([]byte(nil), image.Bytes...)
+	clone.Sections = append([]ColumnPartImageSection(nil), image.Sections...)
+	return clone
+}
+
+func mustValidationSection(t *testing.T, image ColumnPartImage, kind ColumnPartImageSectionKind) ColumnPartImageSection {
+	t.Helper()
+	section, err := image.singleSection(kind)
+	if err != nil {
+		t.Fatalf("singleSection(%s): %v", kind, err)
+	}
+	return section
+}
+
+func mustValidationVectorPart(t *testing.T, partID uint64) *ColumnPart {
+	t.Helper()
+	part, err := BuildColumnPart(partID, Options{
+		SchemaVersion: 1,
+		SchemaMode:    ColumnSchemaFixed,
+		Columns: []ColumnDefinition{
+			{Name: "id", Type: ColumnTypeInt64, Encoding: EncodingRawInt64, Compression: CompressionNone},
+			{Name: "embedding", Type: ColumnTypeFloat32Vector, Encoding: EncodingRawFloat32Vector, Compression: CompressionNone, CompressionSet: true, FixedWidthElements: 3},
+		},
+		LogicalPrimaryKey: LogicalPrimaryKey{Columns: []string{"id"}},
+		SortKey:           SortKey{Columns: []SortKeyColumn{{Column: "id"}}},
+		PartPolicy:        ColumnPartPolicy{RowsPerGranule: 2},
+		Compression:       ColumnCompressionPolicy{Default: CompressionNone},
+	}, Batch{
+		Rows:           2,
+		Columns:        map[string][]int64{"id": {2, 1}},
+		Float32Vectors: map[string][]float32{"embedding": {1, 2, 3, 4, 5, 6}},
+	})
+	if err != nil {
+		t.Fatalf("BuildColumnPart(vector): %v", err)
+	}
+	return part
+}
+
+func mustValidationDescriptorFixedWidthOffset(t *testing.T, image ColumnPartImage, column string) int {
+	t.Helper()
+	section := mustValidationSection(t, image, ColumnPartImageSectionDescriptor)
+	dec := columnPartImageDecoder{data: image.sectionBytes(section)}
+	mustValidationSkipU16(t, &dec)
+	mustValidationSkipU64(t, &dec)
+	mustValidationReadU32(t, &dec)
+	mustValidationSkipI64(t, &dec)
+	mustValidationSkipI64(t, &dec)
+	if _, err := dec.stringSlice(); err != nil {
+		t.Fatalf("decode logical primary key: %v", err)
+	}
+	granuleCount := mustValidationReadU32(t, &dec)
+	granuleBytes := int(granuleCount) * 64
+	if err := dec.require(granuleBytes); err != nil {
+		t.Fatalf("skip descriptor granules: %v", err)
+	}
+	dec.offset += granuleBytes
+	columnCount := mustValidationReadU32(t, &dec)
+	for i := 0; i < int(columnCount); i++ {
+		name, err := dec.str()
+		if err != nil {
+			t.Fatalf("decode descriptor column name: %v", err)
+		}
+		mustValidationSkipU16(t, &dec)
+		mustValidationReadU32(t, &dec)
+		fixedWidthOffset := dec.offset
+		mustValidationReadU32(t, &dec)
+		blockCount := mustValidationReadU32(t, &dec)
+		if name == column {
+			return section.Offset + fixedWidthOffset
+		}
+		blockBytes := int(blockCount) * 94
+		if err := dec.require(blockBytes); err != nil {
+			t.Fatalf("skip descriptor column %q blocks: %v", name, err)
+		}
+		dec.offset += blockBytes
+	}
+	t.Fatalf("descriptor column %q not found", column)
+	return 0
+}
+
+func mustValidationSkipU16(t *testing.T, dec *columnPartImageDecoder) {
+	t.Helper()
+	if _, err := dec.u16(); err != nil {
+		t.Fatalf("decode descriptor: %v", err)
+	}
+}
+
+func mustValidationReadU32(t *testing.T, dec *columnPartImageDecoder) uint32 {
+	t.Helper()
+	v, err := dec.u32()
+	if err != nil {
+		t.Fatalf("decode descriptor: %v", err)
+	}
+	return v
+}
+
+func mustValidationSkipU64(t *testing.T, dec *columnPartImageDecoder) {
+	t.Helper()
+	if _, err := dec.u64(); err != nil {
+		t.Fatalf("decode descriptor: %v", err)
+	}
+}
+
+func mustValidationSkipI64(t *testing.T, dec *columnPartImageDecoder) {
+	t.Helper()
+	if _, err := dec.i64(); err != nil {
+		t.Fatalf("decode descriptor: %v", err)
+	}
+}


### PR DESCRIPTION
Closes #1789.

## Summary

- Adds `typed-column-schema-evolution.md` as the pre-alpha typed-column image/descriptor/manifest/schema policy.
- Documents fail-closed handling for schema identity, field ownership, value type, vector dims, fixed-width metadata/layout, manifest identity, refs, and unsupported versions.
- Documents rebuild-vs-migrate as the current benchmark/experiment policy and lists future migration tooling requirements without adding migration scaffolding.
- Adds fail-closed validation/tests for unsupported image/descriptor versions and typed-column schema/layout mismatches.

## Scope boundaries

- No public API stability or backwards-compatibility promise for pre-alpha DB directories.
- No migration scaffolding.
- No #1785/#1786/#1783/#1790 product/query expansion.
- Persistent value-log architecture unchanged; no TreeDB slabs.

## Tests

```sh
go test -count=1 ./TreeDB/internal/typedcolumn ./TreeDB/collections ./TreeDB/docs
go test -count=1 ./TreeDB/...
go test -count=1 ./... -p=1
```

All passed locally.

## Allocation / performance note

This PR touches docs, tests, and setup/header/descriptor validation only. It does not change typed-column scan/decode inner loops or column-store hot loops. Benchmark `B/op`/`allocs/op` evidence is therefore not applicable for this issue; the new policy requires future hot-path format/schema changes to report baseline-vs-final allocation evidence.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced schema version validation for typed columns to detect and reject unsupported versions and metadata mismatches early, preventing errors during decode or scanning operations.

* **Documentation**
  * Added comprehensive documentation on typed-column schema evolution and migration policies, including pre-alpha compatibility guidance, fail-closed validation requirements, and rebuild recommendations for test databases instead of implicit migration during schema changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1818?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->