### PR TITLE
M0: lock typed-column aggregate baselines and contention guardrails

### DIFF
--- a/TreeDB/collections/typed_column_int64_scan_test.go
+++ b/TreeDB/collections/typed_column_int64_scan_test.go
@@ -930,6 +930,9 @@ func TestTypedColumnInt64AggregateBenchParsers(t *testing.T) {
 		if _, err := parseTypedColumnInt64AggregateBenchReadIntegrities("verify"); err == nil || !strings.Contains(err.Error(), "invalid read integrity") {
 			t.Fatalf("invalid read integrity err=%v", err)
 		}
+		if _, err := parseTypedColumnInt64AggregateBenchReadIntegrities("not_applicable"); err == nil || !strings.Contains(err.Error(), "invalid read integrity") {
+			t.Fatalf("not_applicable should be reserved for fallback labels, err=%v", err)
+		}
 	})
 
 	t.Run("sub_benchmark_names", func(t *testing.T) {
@@ -941,6 +944,10 @@ func TestTypedColumnInt64AggregateBenchParsers(t *testing.T) {
 		parallelUnsafe := typedColumnInt64AggregateBenchSubBenchmarkName(256, typedColumnInt64AggregateBenchDistributionByName("clustered_monotonic"), "typed_column_part", typedColumnInt64AggregateBenchShapeByName("range_1pct"), typedColumnInt64AggregateBenchReadIntegrityByName("skip_checksums"), typedColumnInt64AggregateBenchExecutionModeByName("parallel_contention"))
 		if !strings.Contains(parallelUnsafe, "/timed_one_shot_api/read_integrity_unsafe_skip_checksums_ceiling/execution_parallel_contention/") {
 			t.Fatalf("parallel unsafe sub-benchmark name=%q missing timed boundary/read integrity/execution labels", parallelUnsafe)
+		}
+		fallback := typedColumnInt64AggregateBenchSubBenchmarkName(256, typedColumnInt64AggregateBenchDistributionByName("clustered_monotonic"), "document_full_scan_fallback", typedColumnInt64AggregateBenchShapeByName("range_1pct"), typedColumnInt64AggregateBenchReadIntegrityNotApplicable(), typedColumnInt64AggregateBenchExecutionModeByName("serial"))
+		if !strings.Contains(fallback, "/path_document_full_scan_fallback/") || !strings.Contains(fallback, "/read_integrity_not_applicable/") {
+			t.Fatalf("fallback sub-benchmark name=%q missing fallback/not-applicable labels", fallback)
 		}
 	})
 }
@@ -1155,7 +1162,7 @@ func BenchmarkTypedColumnInt64PredicateAggregate(b *testing.B) {
 					runTypedColumnInt64AggregateBenchPath(b, rows, dist, shape, req, expected, true, readIntegrity)
 				}
 				if typedColumnInt64AggregateBenchIncludeFallback(includeFallbackEnv, rows) {
-					runTypedColumnInt64AggregateBenchPath(b, rows, dist, shape, req, expected, false, typedColumnInt64AggregateBenchReadIntegrityByName("cached_verify"))
+					runTypedColumnInt64AggregateBenchPath(b, rows, dist, shape, req, expected, false, typedColumnInt64AggregateBenchReadIntegrityNotApplicable())
 				}
 			}
 		}
@@ -1220,6 +1227,9 @@ func runTypedColumnInt64AggregateBenchPath(b *testing.B, rows int, dist typedCol
 			if runErr != nil {
 				b.Fatalf("RunTypedColumnInt64PredicateAggregate: %v", runErr)
 			}
+			if err := validateTypedColumnInt64AggregateBenchResult(result, expected); err != nil {
+				b.Fatal(err)
+			}
 			reportTypedColumnInt64AggregateBenchMetrics(b, rows, result.Diagnostics, b.Elapsed(), b.N)
 		})
 	}
@@ -1238,9 +1248,6 @@ func runTypedColumnInt64AggregateBenchOneShotSerial(b *testing.B, col *Collectio
 		if err != nil {
 			return result, err
 		}
-		if err := validateTypedColumnInt64AggregateBenchResult(result, expected); err != nil {
-			return result, err
-		}
 	}
 	return result, nil
 }
@@ -1257,9 +1264,6 @@ func runTypedColumnInt64AggregateBenchOneShotParallel(b *testing.B, col *Collect
 				continue
 			}
 			result, err := col.RunTypedColumnInt64PredicateAggregate(req)
-			if err == nil {
-				err = validateTypedColumnInt64AggregateBenchResult(result, expected)
-			}
 			if err != nil {
 				if stop.CompareAndSwap(false, true) {
 					firstErr.Store(err)
@@ -1437,6 +1441,10 @@ func typedColumnInt64AggregateBenchReadIntegrityByName(name string) typedColumnI
 	default:
 		return typedColumnInt64AggregateBenchReadIntegrity{}
 	}
+}
+
+func typedColumnInt64AggregateBenchReadIntegrityNotApplicable() typedColumnInt64AggregateBenchReadIntegrity {
+	return typedColumnInt64AggregateBenchReadIntegrity{name: "not_applicable"}
 }
 
 func typedColumnInt64AggregateBenchReadIntegrityNames(readIntegrities []typedColumnInt64AggregateBenchReadIntegrity) []string {

--- a/TreeDB/collections/typed_column_int64_scan_test.go
+++ b/TreeDB/collections/typed_column_int64_scan_test.go
@@ -1264,6 +1264,9 @@ func runTypedColumnInt64AggregateBenchOneShotParallel(b *testing.B, col *Collect
 				continue
 			}
 			result, err := col.RunTypedColumnInt64PredicateAggregate(req)
+			if err == nil {
+				err = validateTypedColumnInt64AggregateBenchResult(result, expected)
+			}
 			if err != nil {
 				if stop.CompareAndSwap(false, true) {
 					firstErr.Store(err)

--- a/TreeDB/collections/typed_column_int64_scan_test.go
+++ b/TreeDB/collections/typed_column_int64_scan_test.go
@@ -8,6 +8,8 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -733,8 +735,24 @@ func TestTypedColumnInt64AggregateDirectDiagnosticsNoMaterialization(t *testing.
 	}
 	assertTypedColumnInt64Aggregate(t, result, 2, 40)
 	diag := result.Diagnostics
-	if diag.Fallback || diag.DirectTypedColumnAssetReads == 0 || diag.RowLocatorDecodes != 0 || diag.PhysicalRowIDLookups != 0 || diag.PhysicalRowAssetReads != 0 || diag.RowMaterializations != 0 || diag.DocumentMaterializations != 0 || diag.DocumentReconstructions != 0 {
-		t.Fatalf("diagnostics=%+v want direct aggregate with zero row/document materialization", diag)
+	if diag.Fallback {
+		t.Fatalf("diagnostics=%+v want direct aggregate path", diag)
+	}
+	if diag.DirectTypedColumnAssetReads == 0 {
+		t.Fatalf("diagnostics=%+v want typed-column asset reads", diag)
+	}
+	zeroDiagnostics := map[string]int{
+		"document_materializations": diag.DocumentMaterializations,
+		"document_reconstructions":  diag.DocumentReconstructions,
+		"row_materializations":      diag.RowMaterializations,
+		"row_locator_decodes":       diag.RowLocatorDecodes,
+		"physical_row_asset_reads":  diag.PhysicalRowAssetReads,
+		"physical_row_id_lookups":   diag.PhysicalRowIDLookups,
+	}
+	for name, got := range zeroDiagnostics {
+		if got != 0 {
+			t.Fatalf("diagnostics=%+v %s=%d want 0 for insert-only typed-column aggregate path", diag, name, got)
+		}
 	}
 }
 
@@ -891,6 +909,38 @@ func TestTypedColumnInt64AggregateBenchParsers(t *testing.T) {
 		}
 		if !typedColumnInt64AggregateBenchIncludeFallback("true", 1048576) || typedColumnInt64AggregateBenchIncludeFallback("false", 4096) {
 			t.Fatalf("fallback explicit override failed")
+		}
+	})
+
+	t.Run("read_integrity", func(t *testing.T) {
+		got, err := parseTypedColumnInt64AggregateBenchReadIntegrities("")
+		if err != nil {
+			t.Fatalf("default read integrity: %v", err)
+		}
+		if gotNames := typedColumnInt64AggregateBenchReadIntegrityNames(got); fmt.Sprint(gotNames) != fmt.Sprint([]string{"cached_verify"}) {
+			t.Fatalf("default read integrity=%v", gotNames)
+		}
+		got, err = parseTypedColumnInt64AggregateBenchReadIntegrities("cached_verify,skip_checksums")
+		if err != nil {
+			t.Fatalf("explicit read integrity: %v", err)
+		}
+		if gotNames := typedColumnInt64AggregateBenchReadIntegrityNames(got); fmt.Sprint(gotNames) != fmt.Sprint([]string{"cached_verify", "unsafe_skip_checksums_ceiling"}) {
+			t.Fatalf("explicit read integrity=%v", gotNames)
+		}
+		if _, err := parseTypedColumnInt64AggregateBenchReadIntegrities("verify"); err == nil || !strings.Contains(err.Error(), "invalid read integrity") {
+			t.Fatalf("invalid read integrity err=%v", err)
+		}
+	})
+
+	t.Run("sub_benchmark_names", func(t *testing.T) {
+		name := typedColumnInt64AggregateBenchSubBenchmarkName(256, typedColumnInt64AggregateBenchDistributionByName("clustered_monotonic"), "typed_column_part", typedColumnInt64AggregateBenchShapeByName("range_1pct"), typedColumnInt64AggregateBenchReadIntegrityByName("cached_verify"), typedColumnInt64AggregateBenchExecutionModeByName("serial"))
+		want := "rows_256/dist_clustered_monotonic/path_typed_column_part/shape_selective_range_1pct/timed_one_shot_api/read_integrity_cached_verify/execution_serial/predicate_count_sum_avg"
+		if name != want {
+			t.Fatalf("serial sub-benchmark name=%q want %q", name, want)
+		}
+		parallelUnsafe := typedColumnInt64AggregateBenchSubBenchmarkName(256, typedColumnInt64AggregateBenchDistributionByName("clustered_monotonic"), "typed_column_part", typedColumnInt64AggregateBenchShapeByName("range_1pct"), typedColumnInt64AggregateBenchReadIntegrityByName("skip_checksums"), typedColumnInt64AggregateBenchExecutionModeByName("parallel_contention"))
+		if !strings.Contains(parallelUnsafe, "/timed_one_shot_api/read_integrity_unsafe_skip_checksums_ceiling/execution_parallel_contention/") {
+			t.Fatalf("parallel unsafe sub-benchmark name=%q missing timed boundary/read integrity/execution labels", parallelUnsafe)
 		}
 	})
 }
@@ -1081,6 +1131,10 @@ func BenchmarkTypedColumnInt64PredicateAggregate(b *testing.B) {
 	if err != nil {
 		b.Fatalf("TREEDB_TYPED_COLUMN_BENCH_DISTS: %v", err)
 	}
+	readIntegrities, err := parseTypedColumnInt64AggregateBenchReadIntegrities(os.Getenv("TREEDB_TYPED_COLUMN_BENCH_READ_INTEGRITY"))
+	if err != nil {
+		b.Fatalf("TREEDB_TYPED_COLUMN_BENCH_READ_INTEGRITY: %v", err)
+	}
 	includeFallbackEnv := os.Getenv("TREEDB_TYPED_COLUMN_BENCH_INCLUDE_FALLBACK")
 	if strings.TrimSpace(includeFallbackEnv) != "" {
 		if _, err := parseTypedColumnInt64AggregateBenchBool("TREEDB_TYPED_COLUMN_BENCH_INCLUDE_FALLBACK", includeFallbackEnv, false); err != nil {
@@ -1096,9 +1150,12 @@ func BenchmarkTypedColumnInt64PredicateAggregate(b *testing.B) {
 				shape := shape
 				req := shape.request(rows)
 				expected := expectedTypedColumnInt64AggregateBenchResultForDistribution(rows, dist, req)
-				runTypedColumnInt64AggregateBenchPath(b, rows, dist, shape, req, expected, true)
+				for _, readIntegrity := range readIntegrities {
+					readIntegrity := readIntegrity
+					runTypedColumnInt64AggregateBenchPath(b, rows, dist, shape, req, expected, true, readIntegrity)
+				}
 				if typedColumnInt64AggregateBenchIncludeFallback(includeFallbackEnv, rows) {
-					runTypedColumnInt64AggregateBenchPath(b, rows, dist, shape, req, expected, false)
+					runTypedColumnInt64AggregateBenchPath(b, rows, dist, shape, req, expected, false, typedColumnInt64AggregateBenchReadIntegrityByName("cached_verify"))
 				}
 			}
 		}
@@ -1121,44 +1178,108 @@ type typedColumnInt64AggregateBenchExpected struct {
 	avg   float64
 }
 
+type typedColumnInt64AggregateBenchReadIntegrity struct {
+	name      string
+	integrity ColumnAssetReadIntegrity
+}
+
+type typedColumnInt64AggregateBenchExecutionMode struct {
+	name string
+	// runOneShotAPI intentionally measures the current public one-shot API only.
+	// Future prepared/session aggregate APIs should add a separate timed boundary
+	// instead of reusing this runner.
+	runOneShotAPI func(*testing.B, *Collection, TypedColumnInt64PredicateAggregateRequest, typedColumnInt64AggregateBenchExpected) (TypedColumnInt64PredicateAggregateResult, error)
+}
+
 const typedColumnInt64AggregateBenchBatchRows = 32768
 
-func runTypedColumnInt64AggregateBenchPath(b *testing.B, rows int, dist typedColumnInt64AggregateBenchDistribution, shape typedColumnInt64AggregateBenchShape, req TypedColumnInt64PredicateAggregateRequest, expected typedColumnInt64AggregateBenchExpected, typedPath bool) {
+func runTypedColumnInt64AggregateBenchPath(b *testing.B, rows int, dist typedColumnInt64AggregateBenchDistribution, shape typedColumnInt64AggregateBenchShape, req TypedColumnInt64PredicateAggregateRequest, expected typedColumnInt64AggregateBenchExpected, typedPath bool, readIntegrity typedColumnInt64AggregateBenchReadIntegrity) {
 	pathName := "document_full_scan_fallback"
 	if typedPath {
 		pathName = "typed_column_part"
 	}
-	b.Run(fmt.Sprintf("rows_%d/dist_%s/path_%s/shape_%s/predicate_count_sum_avg", rows, dist.name, pathName, shape.name), func(b *testing.B) {
-		setupStart := time.Now()
-		d, col := setupTypedColumnInt64AggregateBenchCollection(b, typedPath)
-		defer func() { _ = d.Close() }()
-		batches := insertTypedColumnInt64AggregateBenchRows(b, col, rows, dist)
-		setupDuration := time.Since(setupStart)
-		setupMetrics := collectTypedColumnInt64AggregateBenchSetupMetrics(rows, batches, d, typedPath, setupDuration)
+	for _, execution := range typedColumnInt64AggregateBenchExecutionModes() {
+		execution := execution
+		b.Run(typedColumnInt64AggregateBenchSubBenchmarkName(rows, dist, pathName, shape, readIntegrity, execution), func(b *testing.B) {
+			setupStart := time.Now()
+			d, col := setupTypedColumnInt64AggregateBenchCollection(b, typedPath)
+			defer func() { _ = d.Close() }()
+			batches := insertTypedColumnInt64AggregateBenchRows(b, col, rows, dist)
+			setupDuration := time.Since(setupStart)
+			setupMetrics := collectTypedColumnInt64AggregateBenchSetupMetrics(rows, batches, d, typedPath, setupDuration)
 
-		req.Column = "time_us"
-		if typedPath {
-			req.ColumnAssetReadIntegrity = ColumnAssetReadIntegrityCachedVerify
+			req.Column = "time_us"
+			req.ColumnAssetReadIntegrity = readIntegrity.integrity
+			b.StopTimer()
+			b.ReportAllocs()
+			b.ResetTimer()
+			reportTypedColumnInt64AggregateBenchSetupMetrics(b, setupMetrics)
+			b.StartTimer()
+			result, runErr := execution.runOneShotAPI(b, col, req, expected)
+			b.StopTimer()
+			if runErr != nil {
+				b.Fatalf("RunTypedColumnInt64PredicateAggregate: %v", runErr)
+			}
+			reportTypedColumnInt64AggregateBenchMetrics(b, rows, result.Diagnostics, b.Elapsed(), b.N)
+		})
+	}
+}
+
+func typedColumnInt64AggregateBenchSubBenchmarkName(rows int, dist typedColumnInt64AggregateBenchDistribution, pathName string, shape typedColumnInt64AggregateBenchShape, readIntegrity typedColumnInt64AggregateBenchReadIntegrity, execution typedColumnInt64AggregateBenchExecutionMode) string {
+	return fmt.Sprintf("rows_%d/dist_%s/path_%s/shape_%s/timed_one_shot_api/read_integrity_%s/execution_%s/predicate_count_sum_avg", rows, dist.name, pathName, shape.name, readIntegrity.name, execution.name)
+}
+
+func runTypedColumnInt64AggregateBenchOneShotSerial(b *testing.B, col *Collection, req TypedColumnInt64PredicateAggregateRequest, expected typedColumnInt64AggregateBenchExpected) (TypedColumnInt64PredicateAggregateResult, error) {
+	b.Helper()
+	var result TypedColumnInt64PredicateAggregateResult
+	for i := 0; i < b.N; i++ {
+		var err error
+		result, err = col.RunTypedColumnInt64PredicateAggregate(req)
+		if err != nil {
+			return result, err
 		}
-		b.StopTimer()
-		b.ReportAllocs()
-		b.ResetTimer()
-		reportTypedColumnInt64AggregateBenchSetupMetrics(b, setupMetrics)
-		b.StartTimer()
-		var result TypedColumnInt64PredicateAggregateResult
-		var runErr error
-		for i := 0; i < b.N; i++ {
-			result, runErr = col.RunTypedColumnInt64PredicateAggregate(req)
+		if err := validateTypedColumnInt64AggregateBenchResult(result, expected); err != nil {
+			return result, err
 		}
-		b.StopTimer()
-		if runErr != nil {
-			b.Fatalf("RunTypedColumnInt64PredicateAggregate: %v", runErr)
+	}
+	return result, nil
+}
+
+func runTypedColumnInt64AggregateBenchOneShotParallel(b *testing.B, col *Collection, req TypedColumnInt64PredicateAggregateRequest, expected typedColumnInt64AggregateBenchExpected) (TypedColumnInt64PredicateAggregateResult, error) {
+	b.Helper()
+	var firstResult TypedColumnInt64PredicateAggregateResult
+	var firstResultOnce sync.Once
+	var firstErr atomic.Value
+	var stop atomic.Bool
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			if stop.Load() {
+				continue
+			}
+			result, err := col.RunTypedColumnInt64PredicateAggregate(req)
+			if err == nil {
+				err = validateTypedColumnInt64AggregateBenchResult(result, expected)
+			}
+			if err != nil {
+				if stop.CompareAndSwap(false, true) {
+					firstErr.Store(err)
+				}
+				continue
+			}
+			firstResultOnce.Do(func() { firstResult = result })
 		}
-		if result.Count != expected.count || result.Sum != expected.sum || result.Avg != expected.avg {
-			b.Fatalf("aggregate count=%d sum=%d avg=%f want count=%d sum=%d avg=%f diagnostics=%+v", result.Count, result.Sum, result.Avg, expected.count, expected.sum, expected.avg, result.Diagnostics)
-		}
-		reportTypedColumnInt64AggregateBenchMetrics(b, rows, result.Diagnostics, b.Elapsed(), b.N)
 	})
+	if errValue := firstErr.Load(); errValue != nil {
+		return firstResult, errValue.(error)
+	}
+	return firstResult, nil
+}
+
+func validateTypedColumnInt64AggregateBenchResult(result TypedColumnInt64PredicateAggregateResult, expected typedColumnInt64AggregateBenchExpected) error {
+	if result.Count != expected.count || result.Sum != expected.sum || result.Avg != expected.avg {
+		return fmt.Errorf("aggregate count=%d sum=%d avg=%f want count=%d sum=%d avg=%f diagnostics=%+v", result.Count, result.Sum, result.Avg, expected.count, expected.sum, expected.avg, result.Diagnostics)
+	}
+	return nil
 }
 
 func setupTypedColumnInt64AggregateBenchCollection(tb testing.TB, typedPath bool) (*backenddb.DB, *Collection) {
@@ -1277,6 +1398,70 @@ func parseTypedColumnInt64AggregateBenchBool(name, env string, def bool) (bool, 
 		return false, nil
 	default:
 		return false, fmt.Errorf("%s: invalid boolean %q", name, env)
+	}
+}
+
+func parseTypedColumnInt64AggregateBenchReadIntegrities(env string) ([]typedColumnInt64AggregateBenchReadIntegrity, error) {
+	if strings.TrimSpace(env) == "" {
+		return []typedColumnInt64AggregateBenchReadIntegrity{typedColumnInt64AggregateBenchReadIntegrityByName("cached_verify")}, nil
+	}
+	parts := strings.Split(env, ",")
+	out := make([]typedColumnInt64AggregateBenchReadIntegrity, 0, len(parts))
+	for _, part := range parts {
+		name := strings.TrimSpace(part)
+		if name == "" {
+			return nil, fmt.Errorf("empty read integrity")
+		}
+		if strings.EqualFold(name, "all") {
+			out = append(out, typedColumnInt64AggregateBenchReadIntegrityByName("cached_verify"), typedColumnInt64AggregateBenchReadIntegrityByName("skip_checksums"))
+			continue
+		}
+		readIntegrity := typedColumnInt64AggregateBenchReadIntegrityByName(name)
+		if readIntegrity.name == "" {
+			return nil, fmt.Errorf("invalid read integrity %q (available: cached_verify,skip_checksums,all)", name)
+		}
+		out = append(out, readIntegrity)
+	}
+	return out, nil
+}
+
+func typedColumnInt64AggregateBenchReadIntegrityByName(name string) typedColumnInt64AggregateBenchReadIntegrity {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "cached", "cached_verify":
+		return typedColumnInt64AggregateBenchReadIntegrity{name: "cached_verify", integrity: ColumnAssetReadIntegrityCachedVerify}
+	case "skip", "skip_checksums", "unsafe_skip_checksums", "unsafe_skip_checksums_ceiling":
+		// Unsafe checksum-skipping is benchmark-only ceiling coverage. It is not
+		// the default and must be explicitly requested with
+		// TREEDB_TYPED_COLUMN_BENCH_READ_INTEGRITY.
+		return typedColumnInt64AggregateBenchReadIntegrity{name: "unsafe_skip_checksums_ceiling", integrity: ColumnAssetReadIntegritySkipChecksums}
+	default:
+		return typedColumnInt64AggregateBenchReadIntegrity{}
+	}
+}
+
+func typedColumnInt64AggregateBenchReadIntegrityNames(readIntegrities []typedColumnInt64AggregateBenchReadIntegrity) []string {
+	names := make([]string, len(readIntegrities))
+	for i, readIntegrity := range readIntegrities {
+		names[i] = readIntegrity.name
+	}
+	return names
+}
+
+func typedColumnInt64AggregateBenchExecutionModes() []typedColumnInt64AggregateBenchExecutionMode {
+	return []typedColumnInt64AggregateBenchExecutionMode{
+		typedColumnInt64AggregateBenchExecutionModeByName("serial"),
+		typedColumnInt64AggregateBenchExecutionModeByName("parallel_contention"),
+	}
+}
+
+func typedColumnInt64AggregateBenchExecutionModeByName(name string) typedColumnInt64AggregateBenchExecutionMode {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "serial":
+		return typedColumnInt64AggregateBenchExecutionMode{name: "serial", runOneShotAPI: runTypedColumnInt64AggregateBenchOneShotSerial}
+	case "parallel", "parallel_contention", "runparallel":
+		return typedColumnInt64AggregateBenchExecutionMode{name: "parallel_contention", runOneShotAPI: runTypedColumnInt64AggregateBenchOneShotParallel}
+	default:
+		return typedColumnInt64AggregateBenchExecutionMode{}
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #1823. Refs parent tracker #1806.

This is measurement/harness and guardrails only:

- makes typed-column int64 aggregate benchmark subtest names explicit about the timed boundary (`timed_one_shot_api`), read-integrity mode, and execution mode;
- adds opt-in `TREEDB_TYPED_COLUMN_BENCH_READ_INTEGRITY=skip_checksums|all` coverage, labeled as `unsafe_skip_checksums_ceiling`; default remains `cached_verify`;
- adds serial and `RunParallel` contention-oriented one-shot benchmark execution scaffolding without introducing/faking a prepared/session API;
- tightens aggregate diagnostics tests to assert zero document materialization, document reconstruction, row materialization, row-locator decode, physical row asset reads, and physical row ID lookups on the insert-only direct typed-column aggregate path;
- fixes the review finding by validating every successful parallel aggregate iteration, not only the first captured result.

## Scope boundary / timed boundary

Current benchmark timing still measures the public one-shot API call:

```go
Collection.RunTypedColumnInt64PredicateAggregate(req)
```

Sub-benchmarks now include:

```text
.../timed_one_shot_api/read_integrity_<mode>/execution_<serial|parallel_contention>/predicate_count_sum_avg
```

Future #1824 prepared/session hot-scan work should add a separate timed boundary and runner. This PR does not add lifecycle reuse, session/cache state, dictionary-decode changes, targeted reads, int64 decode allocation changes, parsed metadata caches, or M3 cache work.

## Latest-head benchmark / profile commands run

Latest-head artifacts from commit `609dacd56ae05518ce549d33a36fbc83d729d598` are under `/tmp/issue1823_evidence_head609/`.

```sh
go test -run '^$' -bench '^BenchmarkTypedColumnInt64PredicateAggregate$' -benchmem -benchtime=100x -count=5 ./TreeDB/collections \
  | tee /tmp/issue1823_evidence_head609/default_bench.txt

TREEDB_TYPED_COLUMN_BENCH_ROWS=65536,1048576 \
go test -run '^$' -bench '^BenchmarkTypedColumnInt64PredicateAggregate$' -benchmem -benchtime=20x -count=3 ./TreeDB/collections \
  | tee /tmp/issue1823_evidence_head609/large_bench.txt

TREEDB_TYPED_COLUMN_BENCH_ROWS=65536 TREEDB_TYPED_COLUMN_BENCH_SHAPES=range_1pct \
TREEDB_TYPED_COLUMN_BENCH_DISTS=clustered TREEDB_TYPED_COLUMN_BENCH_INCLUDE_FALLBACK=false \
TREEDB_TYPED_COLUMN_BENCH_READ_INTEGRITY=all \
go test -run '^$' \
  -bench '^BenchmarkTypedColumnInt64PredicateAggregate/rows_65536/dist_clustered_monotonic/path_typed_column_part/shape_selective_range_1pct/timed_one_shot_api/read_integrity_(cached_verify|unsafe_skip_checksums_ceiling)/execution_serial/predicate_count_sum_avg$' \
  -benchmem -benchtime=100x -count=5 ./TreeDB/collections \
  | tee /tmp/issue1823_evidence_head609/integrity_ceiling_65k_serial.txt

TREEDB_TYPED_COLUMN_BENCH_ROWS=65536 TREEDB_TYPED_COLUMN_BENCH_SHAPES=range_1pct \
TREEDB_TYPED_COLUMN_BENCH_DISTS=clustered TREEDB_TYPED_COLUMN_BENCH_INCLUDE_FALLBACK=false \
go test -run '^$' \
  -bench '^BenchmarkTypedColumnInt64PredicateAggregate/rows_65536/dist_clustered_monotonic/path_typed_column_part/shape_selective_range_1pct/timed_one_shot_api/read_integrity_cached_verify/execution_serial/predicate_count_sum_avg$' \
  -benchmem -benchtime=30000x -count=1 \
  -cpuprofile /tmp/issue1823_evidence_head609/typedscan_aggregate_cpu_65k_one_shot_cached_verify.pprof \
  -memprofile /tmp/issue1823_evidence_head609/typedscan_aggregate_mem_65k_one_shot_cached_verify.pprof \
  ./TreeDB/collections \
  | tee /tmp/issue1823_evidence_head609/profile_bench_65k_cached_verify.txt

TREEDB_TYPED_COLUMN_BENCH_ROWS=65536 TREEDB_TYPED_COLUMN_BENCH_SHAPES=range_1pct \
TREEDB_TYPED_COLUMN_BENCH_DISTS=clustered TREEDB_TYPED_COLUMN_BENCH_INCLUDE_FALLBACK=false \
go test -run '^$' \
  -bench '^BenchmarkTypedColumnInt64PredicateAggregate/rows_65536/dist_clustered_monotonic/path_typed_column_part/shape_selective_range_1pct/timed_one_shot_api/read_integrity_cached_verify/execution_parallel_contention/predicate_count_sum_avg$' \
  -benchmem -benchtime=1000x -count=1 \
  -blockprofile /tmp/issue1823_evidence_head609/typedscan_aggregate_block_65k_parallel_cached_verify.pprof \
  -mutexprofile /tmp/issue1823_evidence_head609/typedscan_aggregate_mutex_65k_parallel_cached_verify.pprof \
  ./TreeDB/collections \
  | tee /tmp/issue1823_evidence_head609/block_mutex_bench_65k_parallel_cached_verify.txt
```

## Selected benchmark baselines

Machine: Apple M3, darwin/arm64. Values are medians from the latest-head local runs unless otherwise stated.

| rows | shape | integrity | execution | ns/op | ops/sec | rows/sec | matches/sec | B/op | allocs/op | mapped_bytes/op | decoded_bytes/op | physical_bytes_scanned/op |
| ---: | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 4,096 | selective_range_1pct | cached_verify | serial | 52,157 | 19,173 | 78,532,004 | 766,914 | 44,528 | 100 | 169,080 | 4,096 | 169,080 |
| 4,096 | selective_range_1pct | cached_verify | parallel_contention | 16,357 | 61,136 | 250,411,290 | 2,445,423 | 45,083 | 100 | 169,080 | 4,096 | 169,080 |
| 65,536 | selective_range_1pct | cached_verify | serial | 74,094 | 13,496 | 884,513,202 | 8,840,273 | 95,752 | 207 | 2,691,374 | 8,194 | 2,691,374 |
| 65,536 | selective_range_1pct | cached_verify | parallel_contention | 28,464 | 35,132 | 2,302,404,146 | 23,011,394 | 96,298 | 207 | 2,691,374 | 8,194 | 2,691,374 |
| 65,536 | selective_range_1pct | unsafe_skip_checksums_ceiling | serial | 70,061 | 14,273 | 935,415,562 | 9,349,017 | 95,752 | 207 | 2,691,374 | 8,194 | 2,691,374 |
| 1,048,576 | selective_range_1pct | cached_verify | serial | 660,421 | 1,514 | 1,587,739,091 | 15,876,240 | 523,528 | 2,760 | 43,062,014 | 16,388 | 43,062,014 |
| 1,048,576 | selective_range_1pct | cached_verify | parallel_contention | 600,810 | 1,664 | 1,745,269,244 | 17,451,427 | 526,557 | 2,763 | 43,062,014 | 16,388 | 43,062,014 |

Selected cached-verify direct typed-column rows report zero document materializations, document reconstructions, row materializations, row-locator decodes, physical row asset reads, and physical row ID lookups. Example 65k selective serial counters: `rows_scanned/op=8192`, `rows_matched/op=655`, parts `2 considered / 1 pruned / 1 decoded`, blocks `8 considered / 7 pruned / 1 decoded`.

## Profile summaries

65k one-shot cached-verify profile benchmark result:

```text
71556 ns/op, 13975 ops/sec, 915866763 rows/sec, 9153637 matches/sec,
95763 B/op, 207 allocs/op, mapped_bytes/op=2691374,
decoded_bytes/op=8194, physical_bytes_scanned/op=2691374
```

CPU top highlights (`go tool pprof -top`): direct aggregate path 2.01s cumulative; `columnPhysicalAssetReadCache.read` 1.32s; checksum verification 0.75s; file identity / `Fstat` 0.76s / 0.80s; `os.Open` 0.45s; typed-column aggregate prepare 0.42s; aggregate scan / int64 decode 0.07s.

Allocation top highlights (`go tool pprof -top -alloc_space`): `decodeDeltaVarint` / `decodeInt64Payload` 1841.97 MB; direct aggregate path 2645.91 MB cumulative; typed-column aggregate prepare 663.40 MB; adapter aggregate image decode 595.85 MB; `ColumnPartFromImageWithOptions` 334.18 MB; `ColumnPartImage.Dictionaries` 246.66 MB.

Block/mutex profile notes for the 65k parallel-contention smoke: block delay was dominated by benchmark/runtime/background waits (`runtime.selectgo`, `runtime.chanrecv1`); aggregate-path `Mutex.Lock` accounted for ~0.03s of 2.40s. Mutex delay was ~37.62ms total, primarily one-shot read-cache close/munmap paths. This is baseline contention evidence only; no reusable session/cache state exists in this PR.

## Tests

Latest-head local validation:

```sh
go test -count=1 ./TreeDB/collections -run 'TestTypedColumnInt64.*Aggregate|TestTypedColumnInt64Scan'

go test -count=1 ./TreeDB/collections

go test -count=1 ./TreeDB/...

TREEDB_TYPED_COLUMN_BENCH_ROWS=256 TREEDB_TYPED_COLUMN_BENCH_SHAPES=range_1pct \
TREEDB_TYPED_COLUMN_BENCH_DISTS=clustered TREEDB_TYPED_COLUMN_BENCH_INCLUDE_FALLBACK=true \
TREEDB_TYPED_COLUMN_BENCH_READ_INTEGRITY=all \
go test -count=1 ./TreeDB/collections -run '^$' -bench '^BenchmarkTypedColumnInt64PredicateAggregate$' -benchtime=1x
```

## CI / AI review status

- Latest PR head: `609dacd56ae05518ce549d33a36fbc83d729d598`.
- CI: all latest-head GitHub checks pass (`gofmt`, Root/TreeDB/unified_bench/HashDB/read-snapshot/redisserver workflows, including TreeDB race/perf-smoke and Windows/macOS/Linux jobs).
- CodeRabbit: latest-head status `SUCCESS`, review completed with no actionable findings.
- Codex: initial P2 finding fixed in `609dacd56`; review thread replied/resolved; re-review comment says no major issues.
- Copilot: requested/re-requested; Copilot reviewer/cloud-agent errored and was unable to review, so there is no actionable Copilot feedback to resolve.
- Internal Orca reviews: harness review and final review passed; follow-up review after `609dacd56` reported `PASS no blocking findings`.

## Risks / deferrals

- Default benchmark output now includes both serial and `parallel_contention` execution modes, increasing benchmark output/runtime.
- `parallel_contention` measures the real current one-shot API only; #1824 must add a distinct prepared/session timed boundary if/when reusable state exists.
- Optimization work is explicitly deferred to #1824, #1825, #1826, #1827, and #1828.
- This PR is not merged.
