### PR TITLE
M1: reuse typed-column aggregate asset lifecycle

### DIFF
--- a/TreeDB/collections/column_asset_manager.go
+++ b/TreeDB/collections/column_asset_manager.go
@@ -845,6 +845,11 @@ type columnPhysicalAssetReadCache struct {
 	lastView       bool
 	hits           uint64
 	misses         uint64
+	// trustCachedVerifyFileIdentity lets explicit prepared lifetimes reuse the
+	// identity captured when the segment reader was opened. Default read caches
+	// keep refreshing identity so existing fail-closed tests and non-prepared
+	// readers retain their stricter cached-verify behavior.
+	trustCachedVerifyFileIdentity bool
 
 	resourceManager *mappedresource.Manager
 	resourceScope   mappedresource.Scope
@@ -1049,7 +1054,7 @@ func (c *columnPhysicalAssetReadCache) verifyReadChecksum(raw []byte, ref Column
 	var fileIdentity columnAssetVerifiedChecksumFileIdentity
 	if reader != nil {
 		fileIdentity = reader.identity
-		if c.readIntegrity == ColumnAssetReadIntegrityCachedVerify {
+		if c.readIntegrity == ColumnAssetReadIntegrityCachedVerify && !c.trustCachedVerifyFileIdentity {
 			fileIdentity = columnAssetVerifiedChecksumFileIdentityFromFile(reader.file)
 			reader.identity = fileIdentity
 		}

--- a/TreeDB/collections/column_store.go
+++ b/TreeDB/collections/column_store.go
@@ -137,9 +137,10 @@ const (
 	ColumnAssetReadIntegrityVerify ColumnAssetReadIntegrity = "verify"
 	// ColumnAssetReadIntegrityCachedVerify verifies each immutable typed asset
 	// ref on first process read, then skips repeated hot-read CRC work for the
-	// same ref. It is a benchmark-relaxed mode: post-verification file
-	// corruption can be missed until the cache entry is evicted or the process
-	// restarts.
+	// same ref. Explicit prepared read sessions may also reuse the file identity
+	// captured when the segment reader was opened. It is a benchmark-relaxed mode:
+	// post-verification file corruption can be missed until the cache entry is
+	// evicted, the prepared session is closed, or the process restarts.
 	ColumnAssetReadIntegrityCachedVerify ColumnAssetReadIntegrity = "cached_verify"
 	// ColumnAssetReadIntegritySkipChecksums is an unsafe relaxed hot-read mode
 	// for benchmark/performance attribution. It skips per-read payload checksum

--- a/TreeDB/collections/typed_column_int64_scan.go
+++ b/TreeDB/collections/typed_column_int64_scan.go
@@ -98,6 +98,47 @@ type TypedColumnInt64PredicateAggregateResult struct {
 	Diagnostics TypedColumnInt64PredicateScanDiagnostics
 }
 
+// TypedColumnInt64PredicateAggregateSession owns an explicit prepared lifetime
+// for repeated typed-column int64 predicate aggregate scans over one immutable
+// snapshot. It keeps the column physical asset read cache and mappedresource
+// handles alive between Run calls, and releases them on Close.
+//
+// A session is not safe for concurrent Run and Close calls; callers that share a
+// session between goroutines must provide external synchronization.
+type TypedColumnInt64PredicateAggregateSession struct {
+	view               columnPhysicalScanSnapshotView
+	closeView          func()
+	req                TypedColumnInt64PredicateAggregateRequest
+	fields             []TypedStorageField
+	schemaHash         uint64
+	refsByGeneration   map[uint64]columnManifestAssetRefForScan
+	readCache          columnPhysicalAssetReadCache
+	resourceManager    *mappedresource.Manager
+	resolver           *typedColumnLatestRowResolver
+	prepareDiagnostics TypedColumnInt64PredicateScanDiagnostics
+	closed             bool
+}
+
+// TypedColumnInt64PredicateAggregateSessionDiagnostics reports scoped resource
+// state for a prepared aggregate session without exposing internal resource
+// manager types in the public API.
+type TypedColumnInt64PredicateAggregateSessionDiagnostics struct {
+	Closed                   bool
+	ColumnAssetReadIntegrity string
+	SegmentFileCacheHits     uint64
+	SegmentFileCacheMisses   uint64
+	ActiveResourceHandles    int64
+	ActiveMappedBytes        int64
+	ActiveHeapCopyBytes      int64
+	TotalResourceAcquires    uint64
+	TotalResourceReleases    uint64
+	TotalMappedBytes         uint64
+	TotalHeapCopyBytes       uint64
+	FallbackReads            uint64
+}
+
+var errTypedColumnInt64PredicateAggregateSessionClosed = errors.New("collections: typed-column int64 predicate aggregate session is closed")
+
 const (
 	typedColumnInt64PredicateAggregateMaxSum = int64(1<<63 - 1)
 	typedColumnInt64PredicateAggregateMinSum = -typedColumnInt64PredicateAggregateMaxSum - 1
@@ -216,6 +257,39 @@ func (c *Collection) RunTypedColumnInt64PredicateAggregate(req TypedColumnInt64P
 		return c.runTypedColumnInt64PredicateAggregateDocumentFallback(req, cfg, "typed_column_not_selected", start)
 	}
 	return c.runTypedColumnInt64PredicateAggregateDirect(view, req, cfg, start)
+}
+
+// PrepareTypedColumnInt64PredicateAggregate prepares a scoped typed-column int64
+// predicate aggregate session over the current recovery-authoritative snapshot.
+// The prepared path is intentionally direct typed-column only: unsupported
+// columns or unavailable typed-column assets fail closed instead of falling back
+// to document scans. In cached_verify mode, the session reuses the file identity
+// captured when a segment reader is opened; use verify mode for per-run checksum
+// validation during a long-lived session. Call Close when finished to release
+// mapped assets and the pinned snapshot.
+func (c *Collection) PrepareTypedColumnInt64PredicateAggregate(req TypedColumnInt64PredicateAggregateRequest) (*TypedColumnInt64PredicateAggregateSession, error) {
+	if err := validateTypedColumnInt64PredicateAggregateRequest(req); err != nil {
+		return nil, err
+	}
+	view, closeView, err := c.prepareColumnPhysicalScanSnapshotViewWithSidecars(columnManifestScanNoSidecars())
+	if err != nil {
+		if closeView != nil {
+			closeView()
+		}
+		return nil, err
+	}
+	release := true
+	defer func() {
+		if release && closeView != nil {
+			closeView()
+		}
+	}()
+	session, _, err := c.prepareTypedColumnInt64PredicateAggregateSessionFromView(view, closeView, req)
+	if err != nil {
+		return nil, err
+	}
+	release = false
+	return session, nil
 }
 
 func validateTypedColumnInt64PredicateAggregateRequest(req TypedColumnInt64PredicateAggregateRequest) error {
@@ -465,15 +539,87 @@ func (c *Collection) runTypedColumnInt64PredicateScanDirect(view columnPhysicalS
 	return result, nil
 }
 
-func (c *Collection) runTypedColumnInt64PredicateAggregateDirect(view columnPhysicalScanSnapshotView, req TypedColumnInt64PredicateAggregateRequest, cfg ColumnStoreConfig, start time.Time) (TypedColumnInt64PredicateAggregateResult, error) {
+func (c *Collection) runTypedColumnInt64PredicateAggregateDirect(view columnPhysicalScanSnapshotView, req TypedColumnInt64PredicateAggregateRequest, _ ColumnStoreConfig, start time.Time) (TypedColumnInt64PredicateAggregateResult, error) {
+	session, diag, err := c.prepareTypedColumnInt64PredicateAggregateSessionFromView(view, nil, req)
+	if err != nil {
+		return TypedColumnInt64PredicateAggregateResult{Diagnostics: diag}, err
+	}
+	defer func() { _ = session.Close() }()
+	return session.run(start, session.prepareDiagnostics)
+}
+
+func (c *Collection) prepareTypedColumnInt64PredicateAggregateSessionFromView(view columnPhysicalScanSnapshotView, closeView func(), req TypedColumnInt64PredicateAggregateRequest) (*TypedColumnInt64PredicateAggregateSession, TypedColumnInt64PredicateScanDiagnostics, error) {
 	diag := typedColumnInt64PredicateDiagnosticsFromView(view)
 	diag.ColumnAssetReadIntegrity = columnAssetReadIntegrityLabel(req.ColumnAssetReadIntegrity)
+	cfg := view.FullConfig
+	if !cfg.Enabled {
+		cfg = view.Config
+	}
 	fields := columnStoreTypedColumnPartFields(cfg)
 	if ok, err := typedColumnAdapterHasInt64PredicateColumn(fields, req.Column); err != nil {
-		return TypedColumnInt64PredicateAggregateResult{Diagnostics: diag}, err
+		return nil, diag, err
 	} else if !ok {
-		return TypedColumnInt64PredicateAggregateResult{Diagnostics: diag}, fmt.Errorf("collections: typed-column int64 predicate aggregate column %q is not owned by typed_column_part", req.Column)
+		return nil, diag, fmt.Errorf("collections: typed-column int64 predicate aggregate column %q is not owned by typed_column_part", req.Column)
 	}
+	refsByGeneration, err := typedColumnInt64PredicateAggregateRefsByGeneration(view)
+	if err != nil {
+		return nil, diag, err
+	}
+	if len(refsByGeneration) == 0 {
+		return nil, diag, errors.New("collections: missing typed_column_part assets for typed-column int64 predicate aggregate")
+	}
+	if view.MutationParts == 0 {
+		if _, err := validateTypedColumnPhysicalAssetPairing(refsByGeneration, view.AssetRefs); err != nil {
+			return nil, diag, typedColumnPhysicalAssetPairingAggregateError(err)
+		}
+	} else if err := validateTypedColumnMultipartAssetPairing(refsByGeneration, view.AssetRefs); err != nil {
+		return nil, diag, err
+	}
+
+	mgr := mappedresource.NewManager()
+	readCache, err := newColumnPhysicalAssetReadCacheWithIntegrity(view.ColumnAssetRootDir, view.AssetNamespace, req.ColumnAssetReadIntegrity)
+	if err != nil {
+		return nil, diag, err
+	}
+	readCache.returnViews = true
+	readCache.trustCachedVerifyFileIdentity = true
+	scope := mappedresource.Scope{Kind: mappedresource.ScopePreparedQuery, ID: "typed-column-int64-predicate-aggregate", Namespace: view.AssetNamespace, Collection: view.CollectionName, Generation: view.Diagnostics.ManifestGeneration, Reason: "typed-column int64 predicate aggregate session"}
+	if err := readCache.useMappedResourceManager(mgr, scope, "typed-column int64 predicate aggregate session"); err != nil {
+		_ = readCache.close()
+		return nil, diag, err
+	}
+
+	session := &TypedColumnInt64PredicateAggregateSession{
+		view:             view,
+		closeView:        closeView,
+		req:              req,
+		fields:           fields,
+		schemaHash:       cfg.SchemaHash,
+		refsByGeneration: refsByGeneration,
+		readCache:        readCache,
+		resourceManager:  mgr,
+	}
+	if view.MutationParts != 0 {
+		beforeStats := mgr.Stats()
+		beforeHits := session.readCache.hits
+		beforeMisses := session.readCache.misses
+		resolver, err := buildTypedColumnLatestRowResolver(view, &session.readCache, &session.prepareDiagnostics)
+		if err != nil {
+			_ = session.readCache.close()
+			return nil, diag, err
+		}
+		afterStats := mgr.Stats()
+		session.prepareDiagnostics.SegmentFileCacheHits = session.readCache.hits - beforeHits
+		session.prepareDiagnostics.SegmentFileCacheMisses = session.readCache.misses - beforeMisses
+		session.prepareDiagnostics.MappedBytes = afterStats.TotalMappedBytes - beforeStats.TotalMappedBytes
+		session.prepareDiagnostics.HeapCopyBytes = afterStats.TotalHeapCopyBytes - beforeStats.TotalHeapCopyBytes
+		session.prepareDiagnostics.FallbackReads = int(afterStats.FallbackReads - beforeStats.FallbackReads)
+		session.resolver = resolver
+	}
+	return session, diag, nil
+}
+
+func typedColumnInt64PredicateAggregateRefsByGeneration(view columnPhysicalScanSnapshotView) (map[uint64]columnManifestAssetRefForScan, error) {
 	refsByGeneration := make(map[uint64]columnManifestAssetRefForScan, len(view.TypedColumnPartRefs))
 	for _, ref := range view.TypedColumnPartRefs {
 		if ref.Ref.Kind != ColumnAssetKindTCS1TypedColumnPart {
@@ -483,74 +629,117 @@ func (c *Collection) runTypedColumnInt64PredicateAggregateDirect(view columnPhys
 			continue
 		}
 		if ref.Role == ColumnManifestPartRoleTombstone || ref.Reason == ColumnPublishOperationDelete {
-			return TypedColumnInt64PredicateAggregateResult{Diagnostics: diag}, fmt.Errorf("collections: typed-column int64 predicate aggregate got tombstone typed ref generation=%d", ref.Ref.Generation)
+			return nil, fmt.Errorf("collections: typed-column int64 predicate aggregate got tombstone typed ref generation=%d", ref.Ref.Generation)
 		}
 		if _, exists := refsByGeneration[ref.Ref.Generation]; exists {
-			return TypedColumnInt64PredicateAggregateResult{Diagnostics: diag}, fmt.Errorf("collections: duplicate typed_column_part ref for generation=%d", ref.Ref.Generation)
+			return nil, fmt.Errorf("collections: duplicate typed_column_part ref for generation=%d", ref.Ref.Generation)
 		}
 		refsByGeneration[ref.Ref.Generation] = ref
 	}
-	if len(refsByGeneration) == 0 {
-		return TypedColumnInt64PredicateAggregateResult{Diagnostics: diag}, errors.New("collections: missing typed_column_part assets for typed-column int64 predicate aggregate")
-	}
-	if view.MutationParts == 0 {
-		if _, err := validateTypedColumnPhysicalAssetPairing(refsByGeneration, view.AssetRefs); err != nil {
-			return TypedColumnInt64PredicateAggregateResult{Diagnostics: diag}, typedColumnPhysicalAssetPairingAggregateError(err)
-		}
-	} else if err := validateTypedColumnMultipartAssetPairing(refsByGeneration, view.AssetRefs); err != nil {
-		return TypedColumnInt64PredicateAggregateResult{Diagnostics: diag}, err
-	}
+	return refsByGeneration, nil
+}
 
-	mgr := mappedresource.NewManager()
-	readCache, err := newColumnPhysicalAssetReadCacheWithIntegrity(view.ColumnAssetRootDir, view.AssetNamespace, req.ColumnAssetReadIntegrity)
-	if err != nil {
-		return TypedColumnInt64PredicateAggregateResult{Diagnostics: diag}, err
+// Close releases mapped asset handles and the pinned snapshot owned by the
+// prepared aggregate session. It is safe to call multiple times.
+func (s *TypedColumnInt64PredicateAggregateSession) Close() error {
+	if s == nil || s.closed {
+		return nil
 	}
-	readCache.returnViews = true
-	if err := readCache.useMappedResourceManager(mgr, mappedresource.Scope{Kind: mappedresource.ScopeColumnPartReader, ID: "typed-column-int64-predicate-aggregate", Namespace: view.AssetNamespace, Generation: view.Diagnostics.ManifestGeneration, Reason: "typed-column int64 predicate aggregate"}, "typed-column int64 predicate aggregate"); err != nil {
-		_ = readCache.close()
-		return TypedColumnInt64PredicateAggregateResult{Diagnostics: diag}, err
+	s.closed = true
+	var closeErr error
+	if err := s.readCache.close(); err != nil {
+		closeErr = err
 	}
-	defer func() { _ = readCache.close() }()
+	if s.closeView != nil {
+		s.closeView()
+		s.closeView = nil
+	}
+	return closeErr
+}
 
+// Diagnostics returns current scoped resource state for the prepared session.
+func (s *TypedColumnInt64PredicateAggregateSession) Diagnostics() TypedColumnInt64PredicateAggregateSessionDiagnostics {
+	if s == nil {
+		return TypedColumnInt64PredicateAggregateSessionDiagnostics{Closed: true}
+	}
+	stats := mappedresource.Stats{}
+	if s.resourceManager != nil {
+		stats = s.resourceManager.Stats()
+	}
+	return TypedColumnInt64PredicateAggregateSessionDiagnostics{
+		Closed:                   s.closed,
+		ColumnAssetReadIntegrity: columnAssetReadIntegrityLabel(s.req.ColumnAssetReadIntegrity),
+		SegmentFileCacheHits:     s.readCache.hits,
+		SegmentFileCacheMisses:   s.readCache.misses,
+		ActiveResourceHandles:    stats.ActiveHandles,
+		ActiveMappedBytes:        stats.ActiveMappedBytes,
+		ActiveHeapCopyBytes:      stats.ActiveHeapCopyBytes,
+		TotalResourceAcquires:    stats.TotalAcquires,
+		TotalResourceReleases:    stats.TotalReleases,
+		TotalMappedBytes:         stats.TotalMappedBytes,
+		TotalHeapCopyBytes:       stats.TotalHeapCopyBytes,
+		FallbackReads:            stats.FallbackReads,
+	}
+}
+
+// Run executes one hot aggregate scan against the prepared snapshot. Setup and
+// warmup work done before Run is not included in the returned ScanNanos.
+func (s *TypedColumnInt64PredicateAggregateSession) Run() (TypedColumnInt64PredicateAggregateResult, error) {
+	return s.run(time.Now(), TypedColumnInt64PredicateScanDiagnostics{})
+}
+
+func (s *TypedColumnInt64PredicateAggregateSession) run(start time.Time, includeDiagnostics TypedColumnInt64PredicateScanDiagnostics) (TypedColumnInt64PredicateAggregateResult, error) {
+	if s == nil || s.closed {
+		return TypedColumnInt64PredicateAggregateResult{}, errTypedColumnInt64PredicateAggregateSessionClosed
+	}
+	diag := typedColumnInt64PredicateDiagnosticsFromView(s.view)
+	diag.ColumnAssetReadIntegrity = columnAssetReadIntegrityLabel(s.req.ColumnAssetReadIntegrity)
+	addTypedColumnInt64PredicateAggregateDiagnostics(&diag, includeDiagnostics)
 	result := TypedColumnInt64PredicateAggregateResult{Diagnostics: diag}
-	var resolver *typedColumnLatestRowResolver
-	if view.MutationParts != 0 {
-		resolver, err = buildTypedColumnLatestRowResolver(view, &readCache, &result.Diagnostics)
-		if err != nil {
-			return result, err
-		}
+	beforeStats := mappedresource.Stats{}
+	if s.resourceManager != nil {
+		beforeStats = s.resourceManager.Stats()
+	}
+	beforeHits := s.readCache.hits
+	beforeMisses := s.readCache.misses
+	updateCacheDeltas := func() {
+		result.Diagnostics.SegmentFileCacheHits = includeDiagnostics.SegmentFileCacheHits + s.readCache.hits - beforeHits
+		result.Diagnostics.SegmentFileCacheMisses = includeDiagnostics.SegmentFileCacheMisses + s.readCache.misses - beforeMisses
 	}
 	var rawScratch []byte
-	for _, physical := range view.AssetRefs {
+	for _, physical := range s.view.AssetRefs {
 		if physical.Role == ColumnManifestPartRoleTombstone || physical.Reason == ColumnPublishOperationDelete {
 			continue
 		}
-		typedRef := refsByGeneration[physical.Ref.Generation]
+		typedRef := s.refsByGeneration[physical.Ref.Generation]
 		result.Diagnostics.PartsConsidered++
-		raw, err := readCache.read(typedRef.Ref, rawScratch)
-		result.Diagnostics.SegmentFileCacheHits = readCache.hits
-		result.Diagnostics.SegmentFileCacheMisses = readCache.misses
+		raw, err := s.readCache.read(typedRef.Ref, rawScratch)
+		updateCacheDeltas()
 		if err != nil {
 			return result, fmt.Errorf("collections: typed-column int64 predicate aggregate read generation=%d part_id=%d: %w", typedRef.Ref.Generation, typedRef.Ref.PartID, err)
 		}
 		rawScratch = raw
+		if s.readCache.lastView {
+			result.Diagnostics.MappedBytes += uint64(len(raw))
+		} else {
+			result.Diagnostics.HeapCopyBytes += uint64(len(raw))
+		}
 		result.Diagnostics.DirectTypedColumnAssetReads++
 		result.Diagnostics.PhysicalBytesScanned += int64(len(raw))
-		adapterPart, adapterColumn, manifestBytes, err := typedColumnAdapterPrepareInt64PredicateAggregatePart(fields, raw, typedRef.Ref.PartID, typedRef.Rows, physical.Rows, cfg.SchemaHash, req.Column)
+		adapterPart, adapterColumn, manifestBytes, err := typedColumnAdapterPrepareInt64PredicateAggregatePart(s.fields, raw, typedRef.Ref.PartID, typedRef.Rows, physical.Rows, s.schemaHash, s.req.Column)
 		if err != nil {
 			return result, fmt.Errorf("collections: typed-column int64 predicate aggregate decode generation=%d part_id=%d: %w", typedRef.Ref.Generation, typedRef.Ref.PartID, err)
 		}
 		result.Diagnostics.DecodedMetadataBytes += uint64(manifestBytes)
 		var visibility *typedColumnLatestPhysicalPart
-		if resolver != nil {
+		if s.resolver != nil {
 			var ok bool
-			visibility, ok = resolver.partForGeneration(physical.Ref.Generation)
+			visibility, ok = s.resolver.partForGeneration(physical.Ref.Generation)
 			if !ok {
 				return result, fmt.Errorf("collections: typed-column int64 predicate aggregate missing latest-visible physical generation=%d", physical.Ref.Generation)
 			}
 		}
-		partPruned, err := scanTypedColumnInt64PredicateAggregatePartWithVisibility(adapterPart.Part, adapterColumn.Definition.Name, typedColumnInt64PredicateAggregateScanRequest(req), &result, visibility)
+		partPruned, err := scanTypedColumnInt64PredicateAggregatePartWithVisibility(adapterPart.Part, adapterColumn.Definition.Name, typedColumnInt64PredicateAggregateScanRequest(s.req), &result, visibility)
 		if err != nil {
 			return result, fmt.Errorf("collections: typed-column int64 predicate aggregate scan generation=%d part_id=%d: %w", typedRef.Ref.Generation, typedRef.Ref.PartID, err)
 		}
@@ -563,12 +752,44 @@ func (c *Collection) runTypedColumnInt64PredicateAggregateDirect(view columnPhys
 	if result.Count != 0 {
 		result.Avg = float64(result.Sum) / float64(result.Count)
 	}
-	stats := mgr.Stats()
-	result.Diagnostics.MappedBytes = stats.TotalMappedBytes
-	result.Diagnostics.HeapCopyBytes = stats.TotalHeapCopyBytes
-	result.Diagnostics.FallbackReads = int(stats.FallbackReads)
+	if s.resourceManager != nil {
+		afterStats := s.resourceManager.Stats()
+		result.Diagnostics.FallbackReads += int(afterStats.FallbackReads - beforeStats.FallbackReads)
+	}
+	updateCacheDeltas()
 	result.Diagnostics.ScanNanos = time.Since(start).Nanoseconds()
 	return result, nil
+}
+
+func addTypedColumnInt64PredicateAggregateDiagnostics(dst *TypedColumnInt64PredicateScanDiagnostics, src TypedColumnInt64PredicateScanDiagnostics) {
+	if dst == nil {
+		return
+	}
+	dst.RowsScanned += src.RowsScanned
+	dst.RowsMatched += src.RowsMatched
+	dst.PartsConsidered += src.PartsConsidered
+	dst.PartsPruned += src.PartsPruned
+	dst.PartsDecoded += src.PartsDecoded
+	dst.BlocksConsidered += src.BlocksConsidered
+	dst.BlocksPruned += src.BlocksPruned
+	dst.BlocksDecoded += src.BlocksDecoded
+	dst.DirectTypedColumnAssetReads += src.DirectTypedColumnAssetReads
+	dst.FallbackReads += src.FallbackReads
+	dst.CodesMatched += src.CodesMatched
+	dst.DictionaryBytesDecoded += src.DictionaryBytesDecoded
+	dst.MappedBytes += src.MappedBytes
+	dst.HeapCopyBytes += src.HeapCopyBytes
+	dst.DecodedMetadataBytes += src.DecodedMetadataBytes
+	dst.DecodedHeapCopyBytes += src.DecodedHeapCopyBytes
+	dst.PhysicalBytesScanned += src.PhysicalBytesScanned
+	dst.RowLocatorDecodes += src.RowLocatorDecodes
+	dst.PhysicalRowIDLookups += src.PhysicalRowIDLookups
+	dst.PhysicalRowAssetReads += src.PhysicalRowAssetReads
+	dst.RowMaterializations += src.RowMaterializations
+	dst.DocumentMaterializations += src.DocumentMaterializations
+	dst.DocumentReconstructions += src.DocumentReconstructions
+	dst.SegmentFileCacheHits += src.SegmentFileCacheHits
+	dst.SegmentFileCacheMisses += src.SegmentFileCacheMisses
 }
 
 func (c *Collection) typedColumnInt64PredicateCatalogColumn(column string) (ColumnStoreConfig, ColumnStoreColumn, bool, error) {

--- a/TreeDB/collections/typed_column_int64_scan_test.go
+++ b/TreeDB/collections/typed_column_int64_scan_test.go
@@ -849,12 +849,16 @@ func TestTypedColumnInt64AggregatePreparedSessionIntegrityFailClosed(t *testing.
 			corruptTypedColumnAssetPayload1755(t, d, typedRefs[0])
 			assetPath, err := columnAssetSegmentPath(d.ColumnAssetRootDir(), typedRefs[0])
 			if err != nil {
-				_ = session.Close()
+				if session != nil {
+					_ = session.Close()
+				}
 				t.Fatalf("columnAssetSegmentPath: %v", err)
 			}
 			changedModTime := time.Now().Add(2 * time.Hour).Round(0)
 			if err := os.Chtimes(assetPath, changedModTime, changedModTime); err != nil {
-				_ = session.Close()
+				if session != nil {
+					_ = session.Close()
+				}
 				t.Fatalf("Chtimes corrupt typed-column asset: %v", err)
 			}
 			if tc.integrity == ColumnAssetReadIntegrityCachedVerify {

--- a/TreeDB/collections/typed_column_int64_scan_test.go
+++ b/TreeDB/collections/typed_column_int64_scan_test.go
@@ -756,6 +756,122 @@ func TestTypedColumnInt64AggregateDirectDiagnosticsNoMaterialization(t *testing.
 	}
 }
 
+func TestTypedColumnInt64AggregatePreparedSessionLifecycle(t *testing.T) {
+	d, col := setupTypedColumnInt64ScanCollection(t)
+	defer func() { _ = d.Close() }()
+	insertTypedColumnInt64ScanRows(t, col, []int64{10, 20, 30, 20})
+
+	session, err := col.PrepareTypedColumnInt64PredicateAggregate(TypedColumnInt64PredicateAggregateRequest{Column: "time_us", Kind: TypedColumnInt64PredicateEqual, Value: 20, ColumnAssetReadIntegrity: ColumnAssetReadIntegrityCachedVerify})
+	if err != nil {
+		t.Fatalf("PrepareTypedColumnInt64PredicateAggregate: %v", err)
+	}
+	first, err := session.Run()
+	if err != nil {
+		_ = session.Close()
+		t.Fatalf("session first Run: %v", err)
+	}
+	assertTypedColumnInt64Aggregate(t, first, 2, 40)
+	if first.Diagnostics.Fallback || first.Diagnostics.DirectTypedColumnAssetReads == 0 || first.Diagnostics.SegmentFileCacheMisses == 0 || first.Diagnostics.ColumnAssetReadIntegrity != string(ColumnAssetReadIntegrityCachedVerify) {
+		_ = session.Close()
+		t.Fatalf("first diagnostics=%+v want direct cached-verify read with initial cache miss", first.Diagnostics)
+	}
+	firstSessionDiag := session.Diagnostics()
+	if firstSessionDiag.ActiveResourceHandles == 0 || firstSessionDiag.ActiveMappedBytes+firstSessionDiag.ActiveHeapCopyBytes == 0 || firstSessionDiag.TotalResourceAcquires == 0 {
+		_ = session.Close()
+		t.Fatalf("session diagnostics after first run=%+v want active resource handles", firstSessionDiag)
+	}
+
+	second, err := session.Run()
+	if err != nil {
+		_ = session.Close()
+		t.Fatalf("session second Run: %v", err)
+	}
+	assertTypedColumnInt64Aggregate(t, second, 2, 40)
+	if second.Diagnostics.SegmentFileCacheHits == 0 || second.Diagnostics.SegmentFileCacheMisses != 0 {
+		_ = session.Close()
+		t.Fatalf("second diagnostics=%+v want hot cache hits and no misses", second.Diagnostics)
+	}
+	secondSessionDiag := session.Diagnostics()
+	if firstSessionDiag.ActiveMappedBytes > 0 && secondSessionDiag.TotalResourceAcquires != firstSessionDiag.TotalResourceAcquires {
+		_ = session.Close()
+		t.Fatalf("session diagnostics after second run=%+v first=%+v want mapped handle reuse", secondSessionDiag, firstSessionDiag)
+	}
+
+	if err := session.Close(); err != nil {
+		t.Fatalf("session Close: %v", err)
+	}
+	closedDiag := session.Diagnostics()
+	if !closedDiag.Closed || closedDiag.ActiveResourceHandles != 0 || closedDiag.ActiveMappedBytes != 0 || closedDiag.ActiveHeapCopyBytes != 0 {
+		t.Fatalf("session diagnostics after close=%+v want no active handles or bytes", closedDiag)
+	}
+	if closedDiag.TotalResourceReleases != closedDiag.TotalResourceAcquires {
+		t.Fatalf("session diagnostics after close=%+v want releases to match acquires", closedDiag)
+	}
+	if _, err := session.Run(); !errors.Is(err, errTypedColumnInt64PredicateAggregateSessionClosed) {
+		t.Fatalf("session Run after Close err=%v want closed-session error", err)
+	}
+}
+
+func TestTypedColumnInt64AggregatePreparedSessionIntegrityFailClosed(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		integrity ColumnAssetReadIntegrity
+	}{
+		{name: "verify", integrity: ColumnAssetReadIntegrityVerify},
+		{name: "cached_verify", integrity: ColumnAssetReadIntegrityCachedVerify},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.integrity == ColumnAssetReadIntegrityCachedVerify {
+				resetColumnAssetVerifiedChecksumCacheForTest(t)
+			}
+			d, col := setupTypedColumnInt64ScanCollection(t)
+			defer func() { _ = d.Close() }()
+			insertTypedColumnInt64ScanRows(t, col, []int64{1, 2, 3})
+			typedRefs := typedColumnPartRefs1755(columnManifestAssetRefsForCollectionM12A(t, d, col))
+			if len(typedRefs) != 1 {
+				t.Fatalf("typed refs=%+v want one", typedRefs)
+			}
+
+			session, err := col.PrepareTypedColumnInt64PredicateAggregate(TypedColumnInt64PredicateAggregateRequest{Column: "time_us", Kind: TypedColumnInt64PredicateEqual, Value: 2, ColumnAssetReadIntegrity: tc.integrity})
+			if err != nil {
+				t.Fatalf("PrepareTypedColumnInt64PredicateAggregate: %v", err)
+			}
+			if _, err := session.Run(); err != nil {
+				_ = session.Close()
+				t.Fatalf("session warm Run: %v", err)
+			}
+			if tc.integrity == ColumnAssetReadIntegrityCachedVerify {
+				if err := session.Close(); err != nil {
+					t.Fatalf("cached-verify warm session Close: %v", err)
+				}
+				session = nil
+			}
+			corruptTypedColumnAssetPayload1755(t, d, typedRefs[0])
+			assetPath, err := columnAssetSegmentPath(d.ColumnAssetRootDir(), typedRefs[0])
+			if err != nil {
+				_ = session.Close()
+				t.Fatalf("columnAssetSegmentPath: %v", err)
+			}
+			changedModTime := time.Now().Add(2 * time.Hour).Round(0)
+			if err := os.Chtimes(assetPath, changedModTime, changedModTime); err != nil {
+				_ = session.Close()
+				t.Fatalf("Chtimes corrupt typed-column asset: %v", err)
+			}
+			if tc.integrity == ColumnAssetReadIntegrityCachedVerify {
+				session, err = col.PrepareTypedColumnInt64PredicateAggregate(TypedColumnInt64PredicateAggregateRequest{Column: "time_us", Kind: TypedColumnInt64PredicateEqual, Value: 2, ColumnAssetReadIntegrity: tc.integrity})
+				if err != nil {
+					t.Fatalf("PrepareTypedColumnInt64PredicateAggregate after corruption: %v", err)
+				}
+			}
+			_, err = session.Run()
+			_ = session.Close()
+			if err == nil || !strings.Contains(err.Error(), "checksum") {
+				t.Fatalf("session Run after corruption err=%v want checksum failure", err)
+			}
+		})
+	}
+}
+
 func TestTypedColumnInt64AggregateFallbackDiagnostics(t *testing.T) {
 	t.Run("row_asset_owner", func(t *testing.T) {
 		d := openTypedColumnInt64ScanDB(t)
@@ -944,6 +1060,10 @@ func TestTypedColumnInt64AggregateBenchParsers(t *testing.T) {
 		parallelUnsafe := typedColumnInt64AggregateBenchSubBenchmarkName(256, typedColumnInt64AggregateBenchDistributionByName("clustered_monotonic"), "typed_column_part", typedColumnInt64AggregateBenchShapeByName("range_1pct"), typedColumnInt64AggregateBenchReadIntegrityByName("skip_checksums"), typedColumnInt64AggregateBenchExecutionModeByName("parallel_contention"))
 		if !strings.Contains(parallelUnsafe, "/timed_one_shot_api/read_integrity_unsafe_skip_checksums_ceiling/execution_parallel_contention/") {
 			t.Fatalf("parallel unsafe sub-benchmark name=%q missing timed boundary/read integrity/execution labels", parallelUnsafe)
+		}
+		prepared := typedColumnInt64AggregateBenchSubBenchmarkName(256, typedColumnInt64AggregateBenchDistributionByName("clustered_monotonic"), "typed_column_part", typedColumnInt64AggregateBenchShapeByName("range_1pct"), typedColumnInt64AggregateBenchReadIntegrityByName("cached_verify"), typedColumnInt64AggregateBenchExecutionModeByName("prepared_session_serial"))
+		if !strings.Contains(prepared, "/timed_prepared_session_hot_scan/read_integrity_cached_verify/execution_serial/") {
+			t.Fatalf("prepared sub-benchmark name=%q missing prepared timed boundary", prepared)
 		}
 		fallback := typedColumnInt64AggregateBenchSubBenchmarkName(256, typedColumnInt64AggregateBenchDistributionByName("clustered_monotonic"), "document_full_scan_fallback", typedColumnInt64AggregateBenchShapeByName("range_1pct"), typedColumnInt64AggregateBenchReadIntegrityNotApplicable(), typedColumnInt64AggregateBenchExecutionModeByName("serial"))
 		if !strings.Contains(fallback, "/path_document_full_scan_fallback/") || !strings.Contains(fallback, "/read_integrity_not_applicable/") {
@@ -1191,11 +1311,10 @@ type typedColumnInt64AggregateBenchReadIntegrity struct {
 }
 
 type typedColumnInt64AggregateBenchExecutionMode struct {
-	name string
-	// runOneShotAPI intentionally measures the current public one-shot API only.
-	// Future prepared/session aggregate APIs should add a separate timed boundary
-	// instead of reusing this runner.
-	runOneShotAPI func(*testing.B, *Collection, TypedColumnInt64PredicateAggregateRequest, typedColumnInt64AggregateBenchExpected) (TypedColumnInt64PredicateAggregateResult, error)
+	name          string
+	timedBoundary string
+	typedPathOnly bool
+	run           func(*testing.B, *Collection, *TypedColumnInt64PredicateAggregateSession, TypedColumnInt64PredicateAggregateRequest, typedColumnInt64AggregateBenchExpected) (TypedColumnInt64PredicateAggregateResult, error)
 }
 
 const typedColumnInt64AggregateBenchBatchRows = 32768
@@ -1207,6 +1326,9 @@ func runTypedColumnInt64AggregateBenchPath(b *testing.B, rows int, dist typedCol
 	}
 	for _, execution := range typedColumnInt64AggregateBenchExecutionModes() {
 		execution := execution
+		if execution.typedPathOnly && !typedPath {
+			continue
+		}
 		b.Run(typedColumnInt64AggregateBenchSubBenchmarkName(rows, dist, pathName, shape, readIntegrity, execution), func(b *testing.B) {
 			setupStart := time.Now()
 			d, col := setupTypedColumnInt64AggregateBenchCollection(b, typedPath)
@@ -1218,12 +1340,34 @@ func runTypedColumnInt64AggregateBenchPath(b *testing.B, rows int, dist typedCol
 			req.Column = "time_us"
 			req.ColumnAssetReadIntegrity = readIntegrity.integrity
 			b.StopTimer()
+			var session *TypedColumnInt64PredicateAggregateSession
+			if execution.timedBoundary == "prepared_session_hot_scan" {
+				var err error
+				session, err = col.PrepareTypedColumnInt64PredicateAggregate(req)
+				if err != nil {
+					b.Fatalf("PrepareTypedColumnInt64PredicateAggregate: %v", err)
+				}
+				warmup, err := session.Run()
+				if err != nil {
+					_ = session.Close()
+					b.Fatalf("prepared warmup Run: %v", err)
+				}
+				if err := validateTypedColumnInt64AggregateBenchResult(warmup, expected); err != nil {
+					_ = session.Close()
+					b.Fatal(err)
+				}
+			}
 			b.ReportAllocs()
 			b.ResetTimer()
 			reportTypedColumnInt64AggregateBenchSetupMetrics(b, setupMetrics)
 			b.StartTimer()
-			result, runErr := execution.runOneShotAPI(b, col, req, expected)
+			result, runErr := execution.run(b, col, session, req, expected)
 			b.StopTimer()
+			if session != nil {
+				if err := session.Close(); err != nil {
+					b.Fatalf("prepared session Close: %v", err)
+				}
+			}
 			if runErr != nil {
 				b.Fatalf("RunTypedColumnInt64PredicateAggregate: %v", runErr)
 			}
@@ -1236,10 +1380,14 @@ func runTypedColumnInt64AggregateBenchPath(b *testing.B, rows int, dist typedCol
 }
 
 func typedColumnInt64AggregateBenchSubBenchmarkName(rows int, dist typedColumnInt64AggregateBenchDistribution, pathName string, shape typedColumnInt64AggregateBenchShape, readIntegrity typedColumnInt64AggregateBenchReadIntegrity, execution typedColumnInt64AggregateBenchExecutionMode) string {
-	return fmt.Sprintf("rows_%d/dist_%s/path_%s/shape_%s/timed_one_shot_api/read_integrity_%s/execution_%s/predicate_count_sum_avg", rows, dist.name, pathName, shape.name, readIntegrity.name, execution.name)
+	timedBoundary := execution.timedBoundary
+	if timedBoundary == "" {
+		timedBoundary = "one_shot_api"
+	}
+	return fmt.Sprintf("rows_%d/dist_%s/path_%s/shape_%s/timed_%s/read_integrity_%s/execution_%s/predicate_count_sum_avg", rows, dist.name, pathName, shape.name, timedBoundary, readIntegrity.name, execution.name)
 }
 
-func runTypedColumnInt64AggregateBenchOneShotSerial(b *testing.B, col *Collection, req TypedColumnInt64PredicateAggregateRequest, expected typedColumnInt64AggregateBenchExpected) (TypedColumnInt64PredicateAggregateResult, error) {
+func runTypedColumnInt64AggregateBenchOneShotSerial(b *testing.B, col *Collection, _ *TypedColumnInt64PredicateAggregateSession, req TypedColumnInt64PredicateAggregateRequest, expected typedColumnInt64AggregateBenchExpected) (TypedColumnInt64PredicateAggregateResult, error) {
 	b.Helper()
 	var result TypedColumnInt64PredicateAggregateResult
 	for i := 0; i < b.N; i++ {
@@ -1252,7 +1400,7 @@ func runTypedColumnInt64AggregateBenchOneShotSerial(b *testing.B, col *Collectio
 	return result, nil
 }
 
-func runTypedColumnInt64AggregateBenchOneShotParallel(b *testing.B, col *Collection, req TypedColumnInt64PredicateAggregateRequest, expected typedColumnInt64AggregateBenchExpected) (TypedColumnInt64PredicateAggregateResult, error) {
+func runTypedColumnInt64AggregateBenchOneShotParallel(b *testing.B, col *Collection, _ *TypedColumnInt64PredicateAggregateSession, req TypedColumnInt64PredicateAggregateRequest, expected typedColumnInt64AggregateBenchExpected) (TypedColumnInt64PredicateAggregateResult, error) {
 	b.Helper()
 	var firstResult TypedColumnInt64PredicateAggregateResult
 	var firstResultOnce sync.Once
@@ -1280,6 +1428,22 @@ func runTypedColumnInt64AggregateBenchOneShotParallel(b *testing.B, col *Collect
 		return firstResult, errValue.(error)
 	}
 	return firstResult, nil
+}
+
+func runTypedColumnInt64AggregateBenchPreparedSessionSerial(b *testing.B, _ *Collection, session *TypedColumnInt64PredicateAggregateSession, _ TypedColumnInt64PredicateAggregateRequest, _ typedColumnInt64AggregateBenchExpected) (TypedColumnInt64PredicateAggregateResult, error) {
+	b.Helper()
+	if session == nil {
+		return TypedColumnInt64PredicateAggregateResult{}, errors.New("missing prepared typed-column int64 aggregate session")
+	}
+	var result TypedColumnInt64PredicateAggregateResult
+	for i := 0; i < b.N; i++ {
+		var err error
+		result, err = session.Run()
+		if err != nil {
+			return result, err
+		}
+	}
+	return result, nil
 }
 
 func validateTypedColumnInt64AggregateBenchResult(result TypedColumnInt64PredicateAggregateResult, expected typedColumnInt64AggregateBenchExpected) error {
@@ -1462,15 +1626,18 @@ func typedColumnInt64AggregateBenchExecutionModes() []typedColumnInt64AggregateB
 	return []typedColumnInt64AggregateBenchExecutionMode{
 		typedColumnInt64AggregateBenchExecutionModeByName("serial"),
 		typedColumnInt64AggregateBenchExecutionModeByName("parallel_contention"),
+		typedColumnInt64AggregateBenchExecutionModeByName("prepared_session_serial"),
 	}
 }
 
 func typedColumnInt64AggregateBenchExecutionModeByName(name string) typedColumnInt64AggregateBenchExecutionMode {
 	switch strings.ToLower(strings.TrimSpace(name)) {
 	case "serial":
-		return typedColumnInt64AggregateBenchExecutionMode{name: "serial", runOneShotAPI: runTypedColumnInt64AggregateBenchOneShotSerial}
+		return typedColumnInt64AggregateBenchExecutionMode{name: "serial", timedBoundary: "one_shot_api", run: runTypedColumnInt64AggregateBenchOneShotSerial}
 	case "parallel", "parallel_contention", "runparallel":
-		return typedColumnInt64AggregateBenchExecutionMode{name: "parallel_contention", runOneShotAPI: runTypedColumnInt64AggregateBenchOneShotParallel}
+		return typedColumnInt64AggregateBenchExecutionMode{name: "parallel_contention", timedBoundary: "one_shot_api", run: runTypedColumnInt64AggregateBenchOneShotParallel}
+	case "prepared", "prepared_session", "prepared_session_serial", "session_serial":
+		return typedColumnInt64AggregateBenchExecutionMode{name: "serial", timedBoundary: "prepared_session_hot_scan", typedPathOnly: true, run: runTypedColumnInt64AggregateBenchPreparedSessionSerial}
 	default:
 		return typedColumnInt64AggregateBenchExecutionMode{}
 	}


### PR DESCRIPTION
## Summary

Closes #1824. Refs #1806.

- Adds `PrepareTypedColumnInt64PredicateAggregate` and `TypedColumnInt64PredicateAggregateSession`, an explicit scoped prepared lifetime for repeated typed-column int64 aggregate scans.
- Reuses the existing `columnPhysicalAssetReadCache` plus a scoped `mappedresource.Manager`; `Close` releases mappedresource handles, mmap/file readers, and the pinned snapshot.
- Keeps `RunTypedColumnInt64PredicateAggregate` semantics intact by routing the direct path through the same session runner while preserving document fallback and multipart/latest-visible diagnostics.
- Extends `BenchmarkTypedColumnInt64PredicateAggregate` with `timed_prepared_session_hot_scan` labels; setup + one warmup run happen outside the timer, and timed iterations call `session.Run()` only.

## Scope boundary

This is M1 only. It does **not** implement #1825 dictionary decode changes, #1826 targeted/range reads, #1827 int64 decode allocation removal, #1828 closeout guardrails, or M3 parsed metadata caching.

## Integrity/lifetime notes

- `verify` still validates checksums on each prepared-session read.
- `cached_verify` remains benchmark-relaxed. Prepared sessions reuse the file identity captured when a segment reader is opened, so hot scans avoid per-op `fstat`; use `verify` if per-run checksum validation during a long-lived session is required.
- Generic/non-prepared read caches keep their stricter cached-verify identity refresh behavior; existing cached-verify corruption/recreated-segment tests still pass.
- Session API is documented as not safe for concurrent `Run`/`Close`; no shared-session `RunParallel` support is claimed.

## Timed boundary

For `timed_prepared_session_hot_scan`:

1. Benchmark setup inserts rows.
2. `PrepareTypedColumnInt64PredicateAggregate` creates the snapshot/resource lifetime.
3. One warmup `Run` loads/verifies/maps asset handles outside the timer.
4. Timer starts; repeated `session.Run()` calls reuse the prepared lifetime.

## Tests

Local latest-head (`f9e954bf79db0ff39492fcfd2073f7fa377a0662`):

```sh
go test -count=1 ./TreeDB/collections -run 'TestTypedColumnInt64AggregatePreparedSession|TestColumnAssetReadCacheCachedVerifyRefreshesOpenFileIdentityM1634'
go test -count=1 ./TreeDB/collections -run 'TestTypedColumnInt64.*Aggregate|TestTypedColumnInt64Scan|TestColumnAssetReadIntegrity|TestColumnAssetReadCache'
go test -count=1 ./TreeDB/collections
go test -count=1 ./TreeDB/...
```

Reviewer also ran:

```sh
go test -count=1 ./TreeDB/collections -run 'TestTypedColumnInt64AggregatePreparedSession|TestTypedColumnInt64ScanMultipartLatestVisibleUpdatesDeletes|TestTypedColumnInt64AggregateBenchParsers|TestColumnAssetReadCacheCachedVerifyRefreshesOpenFileIdentityM1634'
```

## Benchmarks

Machine: Apple M3, darwin/arm64. Dataset: `rows=65536`, `dist_clustered_monotonic`, `shape_selective_range_1pct`, typed-column path only. Command:

```sh
TREEDB_TYPED_COLUMN_BENCH_ROWS=65536 \
TREEDB_TYPED_COLUMN_BENCH_SHAPES=range_1pct \
TREEDB_TYPED_COLUMN_BENCH_INCLUDE_FALLBACK=false \
go test -run '^$' -bench '^BenchmarkTypedColumnInt64PredicateAggregate$' \
  -benchmem -benchtime=100x -count=5 ./TreeDB/collections
```

| timed boundary | integrity | ns/op avg (range) | ops/sec avg | rows/sec avg | matches/sec avg | B/op | allocs/op | mapped_bytes/op | decoded_bytes/op | physical_bytes_scanned/op |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| one-shot API serial | cached_verify | 74,078 (73,115-76,716) | 13,504 | 884,984,329 | 8,844,982 | 98,744 | 210 | 2,691,374 | 8,194 | 2,691,374 |
| prepared session hot serial | cached_verify | 43,812 (41,579-47,622) | 22,893 | 1,500,314,755 | 14,994,906 | 89,872 | 167 | 2,691,374 | 8,194 | 2,691,374 |

Optional unsafe ceiling command:

```sh
TREEDB_TYPED_COLUMN_BENCH_ROWS=65536 \
TREEDB_TYPED_COLUMN_BENCH_SHAPES=range_1pct \
TREEDB_TYPED_COLUMN_BENCH_READ_INTEGRITY=all \
TREEDB_TYPED_COLUMN_BENCH_INCLUDE_FALLBACK=false \
go test -run '^$' -bench '^BenchmarkTypedColumnInt64PredicateAggregate$' \
  -benchmem -benchtime=50x -count=3 ./TreeDB/collections
```

Prepared hot `unsafe_skip_checksums_ceiling`: ~42,453 ns/op avg, ~23,563 ops/sec, 89,872 B/op, 167 allocs/op. Unsafe mode remains opt-in and is not the default.

## Profiles

Artifacts: `/tmp/issue1824_evidence/profiles2/`.

Commands:

```sh
TREEDB_TYPED_COLUMN_BENCH_ROWS=65536 \
TREEDB_TYPED_COLUMN_BENCH_SHAPES=range_1pct \
TREEDB_TYPED_COLUMN_BENCH_INCLUDE_FALLBACK=false \
go test -run '^$' \
  -bench '^BenchmarkTypedColumnInt64PredicateAggregate/rows_65536/dist_clustered_monotonic/path_typed_column_part/shape_selective_range_1pct/timed_prepared_session_hot_scan/read_integrity_cached_verify/execution_serial/predicate_count_sum_avg$' \
  -benchmem -benchtime=30000x -count=1 \
  -cpuprofile /tmp/issue1824_evidence/profiles2/prepared_session_cpu.pprof \
  -memprofile /tmp/issue1824_evidence/profiles2/prepared_session_mem.pprof \
  ./TreeDB/collections
```

Prepared hot result: `42395 ns/op`, `89872 B/op`, `167 allocs/op`.

CPU top (prepared hot):

| cost center | cum | note |
| --- | ---: | --- |
| `scanTypedColumnInt64PredicateAggregatePartWithVisibility` | 0.73s / 1.49s | actual scan/decode dominates |
| `typedcolumn.DecodeInt64Into` / `decodeDeltaVarint` | 0.41s | M5 deferred |
| `typedColumnAdapterPrepareInt64PredicateAggregatePart` | 0.24s | metadata/dictionary work deferred to later scoped issues |
| `columnPhysicalAssetReadCache.verifyReadChecksum` | 0.01s | cached verify hash lookup only |
| `os.Open` / `fileForRef` / `Fstat` / `mmap` / `munmap` / close | not present in hot Run top | lifecycle moved outside timed hot scan |

One-shot comparison profile (`one_shot_cpu.pprof`, same shape, 30000x) still shows per-op lifecycle costs: `fileForRef` 0.67s, `os.Open` 0.58s, `Close` 0.20s, `munmap` 0.19s, `mmapColumnPhysicalAssetFile` 0.07s, `Fstat` 0.06s.

Allocation top (prepared hot) is still dominated by later issues: `decodeDeltaVarint` (~1.9GB over 30000 ops), descriptor/metadata decode, and dictionary decode. This PR only removes session-lifecycle allocation/costs; M4/M5/M2 remain deferred.

## CI / AI / internal review status

- CI: latest-head GitHub Actions for `f9e954bf79db0ff39492fcfd2073f7fa377a0662` are green across PR checks (gofmt, TreeDB/root/unified-bench/HashDB/redisserver workflows, Linux race/perf/profiles, macOS, Windows, and read-snapshot guardrail).
- Internal Pi executor implemented an independent session patch and ran focused/full collection tests in a child worktree.
- Final Pi reviewer: PASS, no blocking findings, no non-blocking nits.
- Codex review: re-requested after latest-head fix; latest response reports no major issues.
- CodeRabbit: reported one test cleanup guard; fixed in `f9e954bf79db0ff39492fcfd2073f7fa377a0662`, re-requested, confirmed addressed, status check passing, review thread resolved.
- Copilot: requested/re-requested, but Copilot encountered a review/agent error; no latest-head Copilot signoff is claimed.

## Risks and deferrals

- `cached_verify` prepared sessions are intentionally benchmark-relaxed and reuse opened file identity for the session lifetime; use `verify` for per-run validation in long-lived sessions.
- Full-asset mapped/touched bytes are unchanged; #1826 owns targeted/range reads.
- Metadata/dictionary decode and int64 decode allocations remain visible; #1825/#1827 own those follow-ups.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added prepared (long-lived) session support for typed-column int64 aggregate queries to improve multi-run performance, diagnostics, and resource management.
  * Cache/verification behavior updated so cached-verify mode can preserve or refresh captured file identity based on configuration.

* **Tests**
  * Added tests and benchmarks covering prepared-session lifecycle, cache-warm behavior, resource release, and integrity failure scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1830?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
