### PR TITLE
M5: reuse typed-column aggregate int64 decode scratch

### DIFF
--- a/TreeDB/collections/typed_column_adapter.go
+++ b/TreeDB/collections/typed_column_adapter.go
@@ -1690,7 +1690,8 @@ func scanTypedColumnInt64PredicateAggregatePartWithVisibilityAndScratch(part *ty
 		return false, fmt.Errorf("value column is not int64")
 	}
 	if scratch == nil {
-		scratch = &typedColumnInt64PredicateAggregateScanScratch{}
+		var localScratch typedColumnInt64PredicateAggregateScanScratch
+		scratch = &localScratch
 	}
 	decodedAny := false
 	for _, block := range valueCol.Blocks {

--- a/TreeDB/collections/typed_column_adapter.go
+++ b/TreeDB/collections/typed_column_adapter.go
@@ -1674,6 +1674,8 @@ func scanTypedColumnInt64PredicateAggregatePartWithVisibility(part *typedcolumn.
 }
 
 type typedColumnInt64PredicateAggregateScanScratch struct {
+	// GranuleReader only retains decode/decompression scratch and is safe to
+	// reuse across immutable typed-column parts within the session lifetime.
 	reader typedcolumn.GranuleReader
 	values []int64
 }

--- a/TreeDB/collections/typed_column_adapter.go
+++ b/TreeDB/collections/typed_column_adapter.go
@@ -1670,6 +1670,15 @@ func scanTypedColumnInt64PredicateAggregatePart(part *typedcolumn.ColumnPart, va
 }
 
 func scanTypedColumnInt64PredicateAggregatePartWithVisibility(part *typedcolumn.ColumnPart, valueColumn string, req TypedColumnInt64PredicateScanRequest, result *TypedColumnInt64PredicateAggregateResult, visibility *typedColumnLatestPhysicalPart) (bool, error) {
+	return scanTypedColumnInt64PredicateAggregatePartWithVisibilityAndScratch(part, valueColumn, req, result, visibility, nil)
+}
+
+type typedColumnInt64PredicateAggregateScanScratch struct {
+	reader typedcolumn.GranuleReader
+	values []int64
+}
+
+func scanTypedColumnInt64PredicateAggregatePartWithVisibilityAndScratch(part *typedcolumn.ColumnPart, valueColumn string, req TypedColumnInt64PredicateScanRequest, result *TypedColumnInt64PredicateAggregateResult, visibility *typedColumnLatestPhysicalPart, scratch *typedColumnInt64PredicateAggregateScanScratch) (bool, error) {
 	if part == nil {
 		return false, errors.New("nil typed-column part")
 	}
@@ -1680,8 +1689,9 @@ func scanTypedColumnInt64PredicateAggregatePartWithVisibility(part *typedcolumn.
 	if valueCol.Definition.Type != typedcolumn.ColumnTypeInt64 {
 		return false, fmt.Errorf("value column is not int64")
 	}
-	var reader typedcolumn.GranuleReader
-	var valueScratch []int64
+	if scratch == nil {
+		scratch = &typedColumnInt64PredicateAggregateScanScratch{}
+	}
 	decodedAny := false
 	for _, block := range valueCol.Blocks {
 		result.Diagnostics.BlocksConsidered++
@@ -1690,11 +1700,11 @@ func scanTypedColumnInt64PredicateAggregatePartWithVisibility(part *typedcolumn.
 			result.Diagnostics.BlocksPruned++
 			continue
 		}
-		values, err := reader.DecodeInt64Into(valueScratch[:0], g)
+		values, err := scratch.reader.DecodeInt64Into(scratch.values[:0], g)
 		if err != nil {
 			return false, err
 		}
-		valueScratch = values
+		scratch.values = values
 		if len(values) != block.Descriptor.RowCount {
 			return false, fmt.Errorf("decoded rows value=%d want %d", len(values), block.Descriptor.RowCount)
 		}

--- a/TreeDB/collections/typed_column_adapter_test.go
+++ b/TreeDB/collections/typed_column_adapter_test.go
@@ -1285,7 +1285,7 @@ func TestTypedColumnAdapterInt64AggregateScratchReusedAcrossScans(t *testing.T) 
 	if len(scratch.values) == 0 {
 		t.Fatal("first scan left empty scratch values")
 	}
-	firstPtr := unsafe.Pointer(unsafe.SliceData(scratch.values))
+	firstPtr := &scratch.values[0]
 	firstCap := cap(scratch.values)
 
 	var second TypedColumnInt64PredicateAggregateResult
@@ -1296,7 +1296,7 @@ func TestTypedColumnAdapterInt64AggregateScratchReusedAcrossScans(t *testing.T) 
 	if partPruned || second.Count != first.Count || second.Sum != first.Sum || second.Diagnostics.BlocksDecoded != first.Diagnostics.BlocksDecoded {
 		t.Fatalf("second partPruned=%v result=%+v diagnostics=%+v want first=%+v", partPruned, second, second.Diagnostics, first)
 	}
-	if got := unsafe.Pointer(unsafe.SliceData(scratch.values)); got != firstPtr || cap(scratch.values) != firstCap {
+	if got := &scratch.values[0]; got != firstPtr || cap(scratch.values) != firstCap {
 		t.Fatalf("scratch reallocated: ptr %p -> %p cap %d -> %d", firstPtr, got, firstCap, cap(scratch.values))
 	}
 }

--- a/TreeDB/collections/typed_column_adapter_test.go
+++ b/TreeDB/collections/typed_column_adapter_test.go
@@ -1260,6 +1260,47 @@ func TestTypedColumnAdapterPrepareInt64AggregateSkipsDictionaryDecode(t *testing
 	}
 }
 
+func TestTypedColumnAdapterInt64AggregateScratchReusedAcrossScans(t *testing.T) {
+	field := typedColumnAdapterField("count", ColumnStoreValueInt64)
+	rows := []typedColumnAdapterRow{
+		{PrimaryID: 1, Values: map[string]columnDeclaredValue{"count": {Type: ColumnStoreValueInt64, Present: true, Int64: 1}}},
+		{PrimaryID: 2, Values: map[string]columnDeclaredValue{"count": {Type: ColumnStoreValueInt64, Present: true, Int64: 2}}},
+		{PrimaryID: 3, Values: map[string]columnDeclaredValue{"count": {Type: ColumnStoreValueInt64, Present: true, Int64: 3}}},
+		{PrimaryID: 4, Values: map[string]columnDeclaredValue{"count": {Type: ColumnStoreValueInt64, Present: true, Int64: 4}}},
+	}
+	part, err := buildTypedColumnAdapterPart(typedColumnAdapterOptions{PartID: 78, RowsPerGranule: 2, Fields: []TypedStorageField{field}}, rows)
+	if err != nil {
+		t.Fatalf("buildTypedColumnAdapterPart: %v", err)
+	}
+	var scratch typedColumnInt64PredicateAggregateScanScratch
+	req := TypedColumnInt64PredicateScanRequest{Kind: TypedColumnInt64PredicateAll}
+	var first TypedColumnInt64PredicateAggregateResult
+	partPruned, err := scanTypedColumnInt64PredicateAggregatePartWithVisibilityAndScratch(part.Part, "count", req, &first, nil, &scratch)
+	if err != nil {
+		t.Fatalf("first scan: %v", err)
+	}
+	if partPruned || first.Count != 4 || first.Sum != 10 || first.Diagnostics.BlocksDecoded != 2 {
+		t.Fatalf("first partPruned=%v result=%+v diagnostics=%+v", partPruned, first, first.Diagnostics)
+	}
+	if len(scratch.values) == 0 {
+		t.Fatal("first scan left empty scratch values")
+	}
+	firstPtr := unsafe.Pointer(unsafe.SliceData(scratch.values))
+	firstCap := cap(scratch.values)
+
+	var second TypedColumnInt64PredicateAggregateResult
+	partPruned, err = scanTypedColumnInt64PredicateAggregatePartWithVisibilityAndScratch(part.Part, "count", req, &second, nil, &scratch)
+	if err != nil {
+		t.Fatalf("second scan: %v", err)
+	}
+	if partPruned || second.Count != first.Count || second.Sum != first.Sum || second.Diagnostics.BlocksDecoded != first.Diagnostics.BlocksDecoded {
+		t.Fatalf("second partPruned=%v result=%+v diagnostics=%+v want first=%+v", partPruned, second, second.Diagnostics, first)
+	}
+	if got := unsafe.Pointer(unsafe.SliceData(scratch.values)); got != firstPtr || cap(scratch.values) != firstCap {
+		t.Fatalf("scratch reallocated: ptr %p -> %p cap %d -> %d", firstPtr, got, firstCap, cap(scratch.values))
+	}
+}
+
 func TestTypedColumnAdapterPrepareInt64AggregateValidationFailsClosed(t *testing.T) {
 	field := typedColumnAdapterField("count", ColumnStoreValueInt64)
 	part := typedColumnAdapterBuildPart(t, field, []columnDeclaredValue{{Type: ColumnStoreValueInt64, Present: true, Int64: 10}})

--- a/TreeDB/collections/typed_column_int64_scan.go
+++ b/TreeDB/collections/typed_column_int64_scan.go
@@ -118,6 +118,7 @@ type TypedColumnInt64PredicateAggregateSession struct {
 	refsByGeneration   map[uint64]columnManifestAssetRefForScan
 	validatedRefs      map[ColumnAssetRef]struct{}
 	targetedPartCache  map[ColumnAssetRef]*typedColumnInt64AggregateTargetedPart
+	aggregateScratch   typedColumnInt64PredicateAggregateScanScratch
 	readCache          columnPhysicalAssetReadCache
 	resourceManager    *mappedresource.Manager
 	resolver           *typedColumnLatestRowResolver
@@ -657,6 +658,7 @@ func (s *TypedColumnInt64PredicateAggregateSession) Close() error {
 		return nil
 	}
 	s.closed = true
+	s.aggregateScratch = typedColumnInt64PredicateAggregateScanScratch{}
 	var closeErr error
 	if err := s.readCache.close(); err != nil {
 		closeErr = err
@@ -872,7 +874,7 @@ func (s *TypedColumnInt64PredicateAggregateSession) scanPreparedAggregatePart(ty
 			return fmt.Errorf("collections: typed-column int64 predicate aggregate missing latest-visible physical generation=%d", physical.Ref.Generation)
 		}
 	}
-	partPruned, err := scanTypedColumnInt64PredicateAggregatePartWithVisibility(adapterPart.Part, adapterColumn.Definition.Name, typedColumnInt64PredicateAggregateScanRequest(s.req), result, visibility)
+	partPruned, err := scanTypedColumnInt64PredicateAggregatePartWithVisibilityAndScratch(adapterPart.Part, adapterColumn.Definition.Name, typedColumnInt64PredicateAggregateScanRequest(s.req), result, visibility, &s.aggregateScratch)
 	if err != nil {
 		return fmt.Errorf("collections: typed-column int64 predicate aggregate scan generation=%d part_id=%d: %w", typedRef.Ref.Generation, typedRef.Ref.PartID, err)
 	}

--- a/TreeDB/collections/typed_column_int64_scan_test.go
+++ b/TreeDB/collections/typed_column_int64_scan_test.go
@@ -869,6 +869,55 @@ func TestTypedColumnInt64AggregatePreparedSessionHotScanUsesTargetedRanges(t *te
 	}
 }
 
+func TestTypedColumnInt64AggregatePreparedSessionReusesDecodeScratch(t *testing.T) {
+	const rows = 65536
+	d, col := setupTypedColumnInt64ScanCollection(t)
+	defer func() { _ = d.Close() }()
+	dist := typedColumnInt64AggregateBenchDistributionByName("clustered")
+	insertTypedColumnInt64AggregateBenchRows(t, col, rows, dist)
+	req := typedColumnInt64AggregateBenchShapeByName("range_1pct").request(rows)
+	req.ColumnAssetReadIntegrity = ColumnAssetReadIntegritySkipChecksums
+	expected := expectedTypedColumnInt64AggregateBenchResultForDistribution(rows, dist, req)
+
+	session, err := col.PrepareTypedColumnInt64PredicateAggregate(req)
+	if err != nil {
+		t.Fatalf("PrepareTypedColumnInt64PredicateAggregate: %v", err)
+	}
+	defer func() { _ = session.Close() }()
+	first, err := session.Run()
+	if err != nil {
+		t.Fatalf("first Run: %v", err)
+	}
+	if err := validateTypedColumnInt64AggregateBenchResult(first, expected); err != nil {
+		t.Fatal(err)
+	}
+	if len(session.aggregateScratch.values) == 0 {
+		t.Fatalf("first diagnostics=%+v left empty aggregate decode scratch", first.Diagnostics)
+	}
+	firstPtr := &session.aggregateScratch.values[0]
+	firstCap := cap(session.aggregateScratch.values)
+
+	second, err := session.Run()
+	if err != nil {
+		t.Fatalf("second Run: %v", err)
+	}
+	if err := validateTypedColumnInt64AggregateBenchResult(second, expected); err != nil {
+		t.Fatal(err)
+	}
+	if len(session.aggregateScratch.values) == 0 {
+		t.Fatalf("second diagnostics=%+v left empty aggregate decode scratch", second.Diagnostics)
+	}
+	if got := &session.aggregateScratch.values[0]; got != firstPtr || cap(session.aggregateScratch.values) != firstCap {
+		t.Fatalf("aggregate decode scratch reallocated between hot runs: ptr %p -> %p cap %d -> %d", firstPtr, got, firstCap, cap(session.aggregateScratch.values))
+	}
+	if err := session.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if session.aggregateScratch.values != nil {
+		t.Fatalf("Close retained aggregate decode scratch len=%d cap=%d", len(session.aggregateScratch.values), cap(session.aggregateScratch.values))
+	}
+}
+
 func TestTypedColumnInt64AggregatePreparedSessionIntegrityFailClosed(t *testing.T) {
 	for _, tc := range []struct {
 		name      string

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -350,7 +350,7 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/column_vector_graph_typed_column_test.go", classification: typedStorageLegacyDerived, matchingLines: 21, occurrences: 24},
 	{path: "TreeDB/collections/command_wal_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 4, occurrences: 6},
 	{path: "TreeDB/collections/typed_column_adapter.go", classification: typedStorageLegacyCompatibility, matchingLines: 39, occurrences: 44},
-	{path: "TreeDB/collections/typed_column_adapter_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 196, occurrences: 204},
+	{path: "TreeDB/collections/typed_column_adapter_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 201, occurrences: 209},
 	{path: "TreeDB/collections/typed_column_int64_scan.go", classification: typedStorageLegacyCompatibility, matchingLines: 22, occurrences: 31},
 	{path: "TreeDB/collections/typed_column_int64_scan_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 29, occurrences: 36},
 	{path: "TreeDB/collections/typed_column_string_predicate_validation_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 7, occurrences: 8},


### PR DESCRIPTION
## Summary

Closes #1827. Refs parent tracker #1806.

- Adds session-scoped `typedColumnInt64PredicateAggregateScanScratch` for the typed-column int64 aggregate path.
- Reuses the aggregate `GranuleReader` and decoded `[]int64` scratch across hot `TypedColumnInt64PredicateAggregateSession.Run()` calls.
- Clears the scratch on `Close()` so a closed prepared session does not intentionally retain the decode buffer.
- Keeps all encodings on the existing safe decode path; no direct raw views or mapped-view lifetime changes are introduced.

## Safety / lifetime boundary

The scratch is owned by the prepared aggregate session, and `Run`/`Close` are already documented as not concurrency-safe without external synchronization. Decoded values do not escape the scan call. `Close()` drops the scratch. Because no direct views were added, there are no new alignment/endian/compression/lifetime guards beyond the existing typed-column decode validation.

## Tests

Latest local head: `f7bf50d5ad0d04a54a749ccaf4c502e1bd1e9e11`.

```sh
go test -count=1 ./TreeDB/collections -run 'TestTypedColumnAdapterInt64AggregateScratchReusedAcrossScans|TestTypedColumnInt64AggregatePreparedSessionReusesDecodeScratch|TestTypedColumnInt64AggregatePreparedSessionHotScanUsesTargetedRanges'
go test -count=1 ./TreeDB/collections -run 'TestTypedStorageLegacyNameAllowlist|TestTypedColumnAdapterInt64AggregateScratchReusedAcrossScans|TestTypedColumnInt64AggregatePreparedSessionReusesDecodeScratch'
go test -count=1 ./TreeDB/collections ./TreeDB/internal/typedcolumn
git diff --check
go test -count=1 ./TreeDB/...
```

## Benchmarks

Artifacts:

- Base after #1826: `/tmp/issue1827_bench_base_8a73_20260524_122158/prepared_hot_range1pct_65k_1m_cached_skip.txt`
- Head: `/tmp/issue1827_bench_head_8a73edaed_20260524_122257/prepared_hot_range1pct_65k_1m_cached_skip.txt`
- Benchstat: `/tmp/issue1827_bench_head_8a73edaed_20260524_122257/benchstat_base_vs_head.txt`

Command shape:

```sh
BENCH='^BenchmarkTypedColumnInt64PredicateAggregate/rows_(65536|1048576)/dist_clustered_monotonic/path_typed_column_part/shape_selective_range_1pct/timed_prepared_session_hot_scan/read_integrity_(cached_verify|unsafe_skip_checksums_ceiling)/execution_serial/predicate_count_sum_avg$'
TREEDB_TYPED_COLUMN_BENCH_ROWS=65536,1048576 \
TREEDB_TYPED_COLUMN_BENCH_SHAPES=range_1pct \
TREEDB_TYPED_COLUMN_BENCH_DISTS=clustered \
TREEDB_TYPED_COLUMN_BENCH_READ_INTEGRITY=all \
TREEDB_TYPED_COLUMN_BENCH_INCLUDE_FALLBACK=false \
go test -run '^$' -bench "$BENCH" -benchmem -benchtime=20x -count=3 ./TreeDB/collections
```

Median before → after:

| rows | integrity | ns/op | ops/sec | rows/sec | matches/sec | B/op | allocs/op | mapped_bytes/op | decoded_bytes/op | physical_bytes_scanned/op |
| ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 65,536 | cached_verify | 31,523 → 29,675 (-5.9%) | 31,723 → 33,698 (+6.2%) | 2.079G → 2.208G | 20.78M → 22.07M | 73,440 → 7,904 (-89.2%) | 19 → 18 | 8,194 → 8,194 | 8,194 → 8,194 | 8,194 → 8,194 |
| 65,536 | skip ceiling | 31,502 → 29,267 (-7.1%) | 31,744 → 34,169 (+7.6%) | 2.080G → 2.239G | 20.79M → 22.38M | 73,440 → 7,904 (-89.2%) | 19 → 18 | 8,194 → 8,194 | 8,194 → 8,194 | 8,194 → 8,194 |
| 1,048,576 | cached_verify | 91,783 → 88,635 (-3.4%) | 10,895 → 11,282 (+3.6%) | 11.424G → 11.830G | 114.24M → 118.29M | 184,320 → 118,784 (-35.6%) | 229 → 228 | 16,388 → 16,388 | 16,388 → 16,388 | 16,388 → 16,388 |
| 1,048,576 | skip ceiling | 90,777 → 85,696 (-5.6%) | 11,016 → 11,669 (+5.9%) | 11.551G → 12.236G | 115.50M → 122.35M | 184,320 → 118,784 (-35.6%) | 229 → 228 | 16,388 → 16,388 | 16,388 → 16,388 | 16,388 → 16,388 |

## Profiles

Profile command used the 1M cached-verify hot-scan benchmark with `-benchtime=30000x`:

```sh
BENCH='^BenchmarkTypedColumnInt64PredicateAggregate/rows_1048576/dist_clustered_monotonic/path_typed_column_part/shape_selective_range_1pct/timed_prepared_session_hot_scan/read_integrity_cached_verify/execution_serial/predicate_count_sum_avg$'
TREEDB_TYPED_COLUMN_BENCH_ROWS=1048576 \
TREEDB_TYPED_COLUMN_BENCH_SHAPES=range_1pct \
TREEDB_TYPED_COLUMN_BENCH_DISTS=clustered \
TREEDB_TYPED_COLUMN_BENCH_READ_INTEGRITY=cached_verify \
TREEDB_TYPED_COLUMN_BENCH_INCLUDE_FALLBACK=false \
go test -run '^$' -bench "$BENCH" -benchmem -benchtime=30000x -count=1 \
  -cpuprofile cpu.pprof -memprofile mem.pprof ./TreeDB/collections
```

Artifacts: `/tmp/issue1827_profiles_20260524_122407/`

Allocation highlights (`alloc_space`):

| cost center | base | head |
| --- | ---: | ---: |
| total profile alloc_space | 15,464 MB | 13,475 MB |
| hot `Run` cumulative | 5,318 MB / 34.39% | 3,419 MB / 25.37% |
| `decodeDeltaVarint` | 1,887 MB / 12.20% | absent from top table |
| `scanTypedColumnInt64PredicateAggregate...` cumulative | 1,887 MB / 12.20% | absent from alloc top table |
| targeted instantiate | 3,416 MB / 22.09% | 3,398 MB / 25.22% |

CPU highlights:

| cost center | base | head |
| --- | ---: | ---: |
| benchmark ns/op | 90,536 | 86,401 |
| aggregate scan cumulative | 1.85s / 25.66% | 1.60s / 22.89% |
| `decodeDeltaVarint` cumulative | 0.81s / 11.23% | 0.69s / 9.87% |
| `mallocgc` cumulative | 1.26s / 17.48% | 1.04s / 14.88% |

Remaining hot allocations are concentrated in targeted part instantiation; this PR intentionally does not broaden scope into a parsed metadata cache or direct raw views.

## Direct-view guard summary

No direct raw-int64 views were added, so no new alignment, length, endian, compression, or mapped-view lifetime behavior is introduced.

## CI / AI review status

- CI: green on latest head.
- Internal coordinator review: PASS after local tests/benchmarks/profiles.
- Codex: PASS.
- CodeRabbit: latest status SUCCESS; final comment says all prior findings addressed / PR ready.
- Copilot: reviewer errored despite re-request; documented before merge.

## Deferrals

- #1828 final guardrails/closeout remains deferred.
- M3 parsed metadata cache remains deferred.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized memory allocation in column scanning operations by reusing scratch buffers across consecutive scans instead of allocating new ones per iteration.

* **Tests**
  * Added tests to verify scratch buffer reuse across multiple scan operations and session runs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1834?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
