### PR TITLE
M6: add final typed-column aggregate guardrails

### DIFF
--- a/TreeDB/collections/typed_column_int64_scan_test.go
+++ b/TreeDB/collections/typed_column_int64_scan_test.go
@@ -742,6 +742,11 @@ func TestTypedColumnInt64AggregateDirectDiagnosticsNoMaterialization(t *testing.
 	if diag.DirectTypedColumnAssetReads == 0 {
 		t.Fatalf("diagnostics=%+v want typed-column asset reads", diag)
 	}
+	assertTypedColumnInt64AggregateNoMaterializationDiagnostics(t, diag, "insert-only typed-column aggregate path")
+}
+
+func assertTypedColumnInt64AggregateNoMaterializationDiagnostics(t *testing.T, diag TypedColumnInt64PredicateScanDiagnostics, context string) {
+	t.Helper()
 	zeroDiagnostics := map[string]int{
 		"document_materializations": diag.DocumentMaterializations,
 		"document_reconstructions":  diag.DocumentReconstructions,
@@ -752,7 +757,7 @@ func TestTypedColumnInt64AggregateDirectDiagnosticsNoMaterialization(t *testing.
 	}
 	for name, got := range zeroDiagnostics {
 		if got != 0 {
-			t.Fatalf("diagnostics=%+v %s=%d want 0 for insert-only typed-column aggregate path", diag, name, got)
+			t.Fatalf("diagnostics=%+v %s=%d want 0 for %s", diag, name, got, context)
 		}
 	}
 }
@@ -847,6 +852,7 @@ func TestTypedColumnInt64AggregatePreparedSessionHotScanUsesTargetedRanges(t *te
 		t.Fatal(err)
 	}
 	diag := hot.Diagnostics
+	assertTypedColumnInt64AggregateNoMaterializationDiagnostics(t, diag, "prepared typed-column aggregate hot scan")
 	if diag.FullAssetBytes != 0 || diag.FullAssetReads != 0 {
 		t.Fatalf("hot diagnostics=%+v want no per-run full-asset validation bytes after cached-verify session boundary", diag)
 	}


### PR DESCRIPTION
## Summary

Closes #1828. Final closeout for parent tracker #1806.

- Adds a shared typed-column int64 aggregate diagnostic guardrail helper.
- Extends the prepared-session targeted hot-scan test to assert zero document materialization, document reconstruction, row materialization, row-locator decode, physical row asset reads, and physical row ID lookups.
- Records final benchmark/profile evidence for the current #1806 runlist.
- Explicitly leaves M3 parsed metadata cache deferred.

## Child issue / PR summary

| child | PR | status | main contribution |
| --- | --- | --- | --- |
| #1823 M0 | #1829 | merged | measurement/guardrails; explicit benchmark timed-boundary labels and diagnostics |
| #1824 M1 | #1830 | merged | explicit prepared aggregate session and scoped asset lifecycle reuse |
| #1825 M4 | #1831 | merged | int64 aggregate prepare skips dictionary decode while generic/string paths stay fail-closed |
| #1826 M2 | #1833 | merged | targeted manifest/descriptor/payload range reads for selective prepared hot scans |
| #1827 M5 | #1834 | merged | session-scoped int64 decode scratch reuse |
| #1828 M6 | this PR | open | final diagnostics guardrails and closeout evidence |

## Final benchmark evidence

Artifacts:

- Final default aggregate matrix: `/tmp/issue1828_final_bench_default_20260524_125108/default_aggregate_matrix.txt`
- Final 65k/1M prepared hot matrix: `/tmp/issue1828_final_bench_65k_1m_20260524_125146/prepared_hot_range1pct_65k_1m_cached_skip.txt`
- Final focused profiles: `/tmp/issue1828_final_profiles_20260524_125235/`

Baseline reference is #1823's post-measurement one-shot serial baseline from PR #1829. Final rows are the optimized prepared-session hot-scan boundary; this is intentional and not an apples-to-apples claim about one-shot API setup cost.

| rows | integrity | boundary | ns/op | ops/sec | rows/sec | matches/sec | B/op | allocs/op | mapped_bytes/op | decoded_bytes/op | physical_bytes_scanned/op | full_asset_bytes/op | section_bytes_read/op | range_bytes_read/op |
| ---: | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 65,536 | cached_verify | #1823 one-shot serial → final prepared hot | 74,094 → 30,008 (-59.5%) | 13,496 → 33,324 (+146.9%) | 0.885G → 2.184G | 8.84M → 21.83M | 95,752 → 7,904 (-91.7%) | 207 → 18 (-91.3%) | 2,691,374 → 8,194 | 8,194 → 8,194 | 2,691,374 → 8,194 | 0 | 0 | 8,194 |
| 1,048,576 | cached_verify | #1823 one-shot serial → final prepared hot | 660,421 → 89,788 (-86.4%) | 1,514 → 11,137 (+635.6%) | 1.588G → 11.678G | 15.88M → 116.78M | 523,528 → 118,784 (-77.3%) | 2,760 → 228 (-91.7%) | 43,062,014 → 16,388 | 16,388 → 16,388 | 43,062,014 → 16,388 | 0 | 0 | 16,388 |

Final prepared hot unsafe ceiling rows from the final 65k/1M matrix:

| rows | integrity | ns/op | ops/sec | rows/sec | matches/sec | B/op | allocs/op | mapped_bytes/op | decoded_bytes/op | physical_bytes_scanned/op |
| ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 65,536 | unsafe_skip_checksums_ceiling | 29,856 | 33,494 | 2.195G | 21.94M | 7,904 | 18 | 8,194 | 8,194 | 8,194 |
| 1,048,576 | unsafe_skip_checksums_ceiling | 87,565 | 11,420 | 11.975G | 119.74M | 118,784 | 228 | 16,388 | 16,388 | 16,388 |

`unsafe_skip_checksums_ceiling` is only an attribution ceiling. `cached_verify` still validates immutable whole refs once per prepared session; the final hot rows above are after that scoped validation boundary.

## Final profile evidence

Focused profile command:

```sh
BENCH='^BenchmarkTypedColumnInt64PredicateAggregate/rows_1048576/dist_clustered_monotonic/path_typed_column_part/shape_selective_range_1pct/timed_prepared_session_hot_scan/read_integrity_cached_verify/execution_serial/predicate_count_sum_avg$'
TREEDB_TYPED_COLUMN_BENCH_ROWS=1048576 \
TREEDB_TYPED_COLUMN_BENCH_SHAPES=range_1pct \
TREEDB_TYPED_COLUMN_BENCH_DISTS=clustered \
TREEDB_TYPED_COLUMN_BENCH_READ_INTEGRITY=cached_verify \
TREEDB_TYPED_COLUMN_BENCH_INCLUDE_FALLBACK=false \
go test -run '^$' -bench "$BENCH" -benchmem -benchtime=30000x -count=1 \
  -cpuprofile cpu.pprof -memprofile mem.pprof ./TreeDB/collections
```

Final focused benchmark row: `90,019 ns/op`, `11,109 ops/sec`, `11.648G rows/sec`, `116.47M matches/sec`, `118,784 B/op`, `228 allocs/op`, `mapped_bytes/op=16,388`, `decoded_bytes/op=16,388`, `physical_bytes_scanned/op=16,388`.

CPU top highlights (`/tmp/issue1828_final_profiles_20260524_125235/cpu_top.txt`):

| cost center | final |
| --- | ---: |
| aggregate scan with session scratch | 1.49s / 21.07% cumulative |
| delta-varint decode CPU | 0.48s / 6.79% cumulative |
| `mallocgc` | 1.35s / 19.09% cumulative |
| targeted range/metadata setup from hot path | not present as repeated full-image decode |

Allocation top highlights (`/tmp/issue1828_final_profiles_20260524_125235/mem_top.txt`):

| cost center | final |
| --- | ---: |
| total profile alloc_space | 13.28 GB |
| hot `Run` cumulative | 3.35 GB / 25.21% |
| targeted part instantiate | 3.33 GB / 25.10% |
| `decodeDeltaVarint` decode buffer allocation | absent from top table |

The remaining optimized-hot allocations are not zero; they are dominated by targeted part instantiation. This closeout does not overclaim zero allocation.

## M3 parsed metadata cache deferred

M3 parsed metadata cache remains deferred from #1806. The current run deliberately used explicit prepared-session scoped state rather than a hidden/global cache. If future work reopens M3, it should be a separate issue with cache-off/on evidence, cold/warm hit benchmarks, `RunParallel` contention, block/mutex profiles, hit/miss/retained-byte metrics, race/close/lifetime tests, generation invalidation, and corrupt/stale/mismatched asset fail-closed tests.

## Tests

Latest local head: `6dbeb96a42328b8a77125ce66824e89194c14e8c`.

```sh
go test -count=1 ./TreeDB/collections -run 'TestTypedColumnInt64AggregateDirectDiagnosticsNoMaterialization|TestTypedColumnInt64AggregatePreparedSessionHotScanUsesTargetedRanges|TestTypedColumnInt64AggregatePreparedSessionReusesDecodeScratch|TestTypedColumnInt64AggregatePreparedSessionIntegrityFailClosed'
go test -count=1 ./TreeDB/collections ./TreeDB/internal/typedcolumn
git diff --check
go test -count=1 ./TreeDB/...
```

Note: an earlier full `go test -count=1 ./TreeDB/...` run hit a transient existing caching test failure (`TestCheckpoint_KicksVlogGenerationRewriteDespiteRecentForegroundActivity`); the targeted test and package rerun passed, and the final full rerun passed.

## CI / AI review status

- CI: green on latest head.
- Internal coordinator review: PASS after local tests/benchmarks/profiles.
- Codex: PASS.
- CodeRabbit: SUCCESS; no actionable comments in latest review.
- Copilot: reviewer errored despite request; documented before merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored test infrastructure for improved maintainability and consistency in diagnostic validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1835?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
