### PR TITLE
Add typed-column benchmark/profile conformance guardrails

### DIFF
--- a/TreeDB/collections/column_semantics.go
+++ b/TreeDB/collections/column_semantics.go
@@ -1,6 +1,7 @@
 package collections
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/snissn/gomap/TreeDB/internal/columnsemantics"
@@ -48,10 +49,45 @@ func typedColumnAdapterCapability(column typedColumnAdapterColumn, op columnsema
 	return columnsemantics.CapabilityFor(desc, op), nil
 }
 
+type typedColumnSemanticCapabilityError struct {
+	context   string
+	operation columnsemantics.Operation
+	status    columnsemantics.Status
+	reason    columnsemantics.ReasonCode
+	detail    string
+	cause     error
+}
+
+func (e *typedColumnSemanticCapabilityError) Error() string {
+	if e == nil {
+		return "typed-column semantic capability error"
+	}
+	if e.detail != "" {
+		return fmt.Sprintf("%s semantic capability %s status=%s reason=%s detail=%s", e.context, e.operation, e.status, e.reason, e.detail)
+	}
+	return fmt.Sprintf("%s semantic capability %s status=%s reason=%s", e.context, e.operation, e.status, e.reason)
+}
+
+func (e *typedColumnSemanticCapabilityError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.cause
+}
+
+func typedColumnSemanticCapabilityReason(err error) (columnsemantics.ReasonCode, bool) {
+	var semanticErr *typedColumnSemanticCapabilityError
+	if errors.As(err, &semanticErr) && semanticErr != nil {
+		return semanticErr.reason, true
+	}
+	return "", false
+}
+
 func requireTypedColumnAdapterCapability(column typedColumnAdapterColumn, op columnsemantics.Operation, context string) error {
 	capability, err := typedColumnAdapterCapability(column, op)
 	if err != nil {
-		return fmt.Errorf("%w: %s semantic capability %s reason=%s: %v", ErrColumnQueryPlanUnsupported, context, op, capability.Reason, err)
+		semanticErr := &typedColumnSemanticCapabilityError{context: context, operation: op, status: capability.Status, reason: capability.Reason, detail: err.Error(), cause: err}
+		return fmt.Errorf("%w: %w", ErrColumnQueryPlanUnsupported, semanticErr)
 	}
 	if capability.Supported() {
 		return nil
@@ -60,5 +96,6 @@ func requireTypedColumnAdapterCapability(column typedColumnAdapterColumn, op col
 	if capabilityDetail == "" {
 		capabilityDetail = string(capability.Reason)
 	}
-	return fmt.Errorf("%w: %s semantic capability %s status=%s reason=%s detail=%s", ErrColumnQueryPlanUnsupported, context, op, capability.Status, capability.Reason, capabilityDetail)
+	semanticErr := &typedColumnSemanticCapabilityError{context: context, operation: op, status: capability.Status, reason: capability.Reason, detail: capabilityDetail}
+	return fmt.Errorf("%w: %w", ErrColumnQueryPlanUnsupported, semanticErr)
 }

--- a/TreeDB/collections/typed_column_conformance_test.go
+++ b/TreeDB/collections/typed_column_conformance_test.go
@@ -1,0 +1,325 @@
+package collections
+
+import (
+	"errors"
+	"math"
+	"slices"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/internal/columnsemantics"
+	"github.com/snissn/gomap/TreeDB/internal/typedcolumn"
+)
+
+func TestTypedColumnAdapterSemanticConformanceMatrix(t *testing.T) {
+	type capabilityCheck struct {
+		op     columnsemantics.Operation
+		status columnsemantics.Status
+		reason columnsemantics.ReasonCode
+	}
+	tests := []struct {
+		name     string
+		field    TypedStorageField
+		logical  columnsemantics.LogicalType
+		physical typedcolumn.ColumnType
+		encoding typedcolumn.Encoding
+		checks   []capabilityCheck
+	}{
+		{
+			name:     "bool",
+			field:    semanticField("flag", ColumnStoreValueBool),
+			logical:  columnsemantics.LogicalBool,
+			physical: typedcolumn.ColumnTypeBool,
+			encoding: typedcolumn.EncodingBoolBitpackRLE,
+			checks: []capabilityCheck{
+				{op: columnsemantics.OpEquality, status: columnsemantics.StatusSupported, reason: columnsemantics.ReasonSupported},
+				{op: columnsemantics.OpBoolCounts, status: columnsemantics.StatusSupported, reason: columnsemantics.ReasonSupported},
+				{op: columnsemantics.OpOrderedRange, status: columnsemantics.StatusUnsupported, reason: columnsemantics.ReasonBoolRangeUnsupported},
+			},
+		},
+		{
+			name:     "int64",
+			field:    semanticField("count", ColumnStoreValueInt64),
+			logical:  columnsemantics.LogicalInt64,
+			physical: typedcolumn.ColumnTypeInt64,
+			encoding: typedcolumn.EncodingDeltaVarint,
+			checks: []capabilityCheck{
+				{op: columnsemantics.OpOrderedRange, status: columnsemantics.StatusSupported, reason: columnsemantics.ReasonSupported},
+				{op: columnsemantics.OpSum, status: columnsemantics.StatusSupported, reason: columnsemantics.ReasonSupported},
+				{op: columnsemantics.OpStatsSum, status: columnsemantics.StatusUnsupported, reason: columnsemantics.ReasonStatsPayloadUnsupported},
+			},
+		},
+		{
+			name:     "float32_raw_bits",
+			field:    semanticField("score32", ColumnStoreValueFloat32),
+			logical:  columnsemantics.LogicalFloat32,
+			physical: typedcolumn.ColumnTypeInt64,
+			encoding: typedcolumn.EncodingRawInt64,
+			checks: []capabilityCheck{
+				{op: columnsemantics.OpOrderedRange, status: columnsemantics.StatusUnsupported, reason: columnsemantics.ReasonFloatRawInt64BitPattern},
+				{op: columnsemantics.OpDirectScalarValueCarrier, status: columnsemantics.StatusUnsupported, reason: columnsemantics.ReasonFloatRawInt64BitPattern},
+				{op: columnsemantics.OpEquality, status: columnsemantics.StatusFallback, reason: columnsemantics.ReasonNativeFloatLayoutMissing},
+			},
+		},
+		{
+			name:     "double_raw_bits",
+			field:    semanticField("score64", ColumnStoreValueDouble),
+			logical:  columnsemantics.LogicalDouble,
+			physical: typedcolumn.ColumnTypeInt64,
+			encoding: typedcolumn.EncodingRawInt64,
+			checks: []capabilityCheck{
+				{op: columnsemantics.OpOrderedRange, status: columnsemantics.StatusUnsupported, reason: columnsemantics.ReasonFloatRawInt64BitPattern},
+				{op: columnsemantics.OpMin, status: columnsemantics.StatusUnsupported, reason: columnsemantics.ReasonFloatRawInt64BitPattern},
+				{op: columnsemantics.OpInList, status: columnsemantics.StatusFallback, reason: columnsemantics.ReasonNativeFloatLayoutMissing},
+			},
+		},
+		{
+			name:     "string_dictionary",
+			field:    semanticField("kind", ColumnStoreValueString),
+			logical:  columnsemantics.LogicalString,
+			physical: typedcolumn.ColumnTypeLowCardinalityCode,
+			encoding: typedcolumn.EncodingLowCardinalityUint32,
+			checks: []capabilityCheck{
+				{op: columnsemantics.OpDictionaryEquality, status: columnsemantics.StatusSupported, reason: columnsemantics.ReasonSupported},
+				{op: columnsemantics.OpDictionaryGroupBy, status: columnsemantics.StatusSupported, reason: columnsemantics.ReasonSupported},
+				{op: columnsemantics.OpStringPrefix, status: columnsemantics.StatusUnsupported, reason: columnsemantics.ReasonDictionaryOrderUnproven},
+			},
+		},
+		{
+			name:     "float32_vector",
+			field:    semanticVectorField("embedding"),
+			logical:  columnsemantics.LogicalFloat32Vector,
+			physical: typedcolumn.ColumnTypeFloat32Vector,
+			encoding: typedcolumn.EncodingRawFloat32Vector,
+			checks: []capabilityCheck{
+				{op: columnsemantics.OpCountRows, status: columnsemantics.StatusSupported, reason: columnsemantics.ReasonSupported},
+				{op: columnsemantics.OpEquality, status: columnsemantics.StatusUnsupported, reason: columnsemantics.ReasonVectorScalarOperationUnsupported},
+				{op: columnsemantics.OpVectorSimilarity, status: columnsemantics.StatusFallback, reason: columnsemantics.ReasonVectorCapabilityDeferred},
+			},
+		},
+		{
+			name:     "adjacency_list",
+			field:    semanticAdjacencyField("neighbors"),
+			logical:  columnsemantics.LogicalAdjacencyList,
+			physical: typedcolumn.ColumnTypeAdjacencyList,
+			encoding: typedcolumn.EncodingRawUint32Dense,
+			checks: []capabilityCheck{
+				{op: columnsemantics.OpCountRows, status: columnsemantics.StatusSupported, reason: columnsemantics.ReasonSupported},
+				{op: columnsemantics.OpOrderedRange, status: columnsemantics.StatusUnsupported, reason: columnsemantics.ReasonAdjacencyScalarOperationUnsupported},
+				{op: columnsemantics.OpVectorMetrics, status: columnsemantics.StatusFallback, reason: columnsemantics.ReasonAdjacencyCapabilityDeferred},
+			},
+		},
+	}
+
+	seen := make(map[ColumnStoreValueType]bool, len(tests))
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			seen[tc.field.ValueType] = true
+			column, err := typedColumnAdapterMapField(tc.field)
+			if err != nil {
+				t.Fatalf("typedColumnAdapterMapField: %v", err)
+			}
+			desc, err := typedColumnAdapterSemanticDescriptor(column)
+			if err != nil {
+				t.Fatalf("typedColumnAdapterSemanticDescriptor: %v", err)
+			}
+			if desc.Logical != tc.logical || desc.Physical != tc.physical || desc.Encoding != tc.encoding {
+				t.Fatalf("descriptor=%+v want logical=%s physical=%s encoding=%s", desc, tc.logical, tc.physical, tc.encoding)
+			}
+			for _, check := range tc.checks {
+				cap, err := typedColumnAdapterCapability(column, check.op)
+				if err != nil {
+					t.Fatalf("typedColumnAdapterCapability(%s): %v", check.op, err)
+				}
+				if cap.Status != check.status || cap.Reason != check.reason || cap.Phase != columnsemantics.PhasePrepare {
+					t.Fatalf("%s capability=%+v want status=%s reason=%s phase=%s", check.op, cap, check.status, check.reason, columnsemantics.PhasePrepare)
+				}
+				if check.status != columnsemantics.StatusSupported {
+					err := requireTypedColumnAdapterCapability(column, check.op, "conformance "+tc.name)
+					if !errors.Is(err, ErrColumnQueryPlanUnsupported) {
+						t.Fatalf("requireTypedColumnAdapterCapability(%s) err=%v want ErrColumnQueryPlanUnsupported", check.op, err)
+					}
+					gotReason, ok := typedColumnSemanticCapabilityReason(err)
+					if !ok || gotReason != check.reason {
+						t.Fatalf("semantic reason=%s ok=%v want %s err=%v", gotReason, ok, check.reason, err)
+					}
+				}
+			}
+		})
+	}
+	for _, valueType := range []ColumnStoreValueType{ColumnStoreValueBool, ColumnStoreValueInt64, ColumnStoreValueFloat32, ColumnStoreValueDouble, ColumnStoreValueString, ColumnStoreValueFloat32Vector, ColumnStoreValueAdjacencyList} {
+		if !seen[valueType] {
+			t.Fatalf("value type %s missing from semantic conformance matrix", valueType)
+		}
+	}
+}
+
+func TestTypedColumnAdapterSemanticConformanceSmallRows(t *testing.T) {
+	fields := []TypedStorageField{
+		semanticField("flag", ColumnStoreValueBool),
+		semanticField("count", ColumnStoreValueInt64),
+		semanticField("score32", ColumnStoreValueFloat32),
+		semanticField("score64", ColumnStoreValueDouble),
+		semanticField("kind", ColumnStoreValueString),
+		semanticVectorField("embedding"),
+		semanticAdjacencyField("neighbors"),
+	}
+	rows := []typedColumnAdapterRow{
+		{PrimaryID: 10, Values: map[string]columnDeclaredValue{
+			"flag":      {Type: ColumnStoreValueBool, Present: true, Bool: true},
+			"count":     {Type: ColumnStoreValueInt64, Present: true, Int64: math.MinInt64},
+			"score32":   {Type: ColumnStoreValueFloat32, Present: true, Float32: math.Float32frombits(0x80000000)},
+			"score64":   {Type: ColumnStoreValueDouble, Present: true, Double: math.Float64frombits(0x7ff8000000001234)},
+			"kind":      {Type: ColumnStoreValueString, Present: true, String: "beta"},
+			"embedding": {Type: ColumnStoreValueFloat32Vector, Present: true, Float32Vector: []float32{1, 2, 3}},
+			"neighbors": {Type: ColumnStoreValueAdjacencyList, Present: true, AdjacencyList: []uint32{4, 5}},
+		}},
+		{PrimaryID: 11, Values: map[string]columnDeclaredValue{
+			"flag":      {Type: ColumnStoreValueBool, Present: true, Bool: false},
+			"count":     {Type: ColumnStoreValueInt64, Present: true, Int64: math.MaxInt64},
+			"score32":   {Type: ColumnStoreValueFloat32, Present: true, Float32: math.Float32frombits(0x7fc01234)},
+			"score64":   {Type: ColumnStoreValueDouble, Present: true, Double: math.Float64frombits(0x8000000000000000)},
+			"kind":      {Type: ColumnStoreValueString, Present: true, String: "alpha"},
+			"embedding": {Type: ColumnStoreValueFloat32Vector, Present: true, Float32Vector: []float32{-1, -2, -3}},
+			"neighbors": {Type: ColumnStoreValueAdjacencyList, Present: true, AdjacencyList: []uint32{6, 7}},
+		}},
+	}
+	part, err := buildTypedColumnAdapterPart(typedColumnAdapterOptions{PartID: 1842, RowsPerGranule: 1, Fields: fields}, rows)
+	if err != nil {
+		t.Fatalf("buildTypedColumnAdapterPart: %v", err)
+	}
+	if got := part.Dictionary["kind"]; got["alpha"] != 0 || got["beta"] != 1 {
+		t.Fatalf("dictionary=%+v want sorted string codes", got)
+	}
+	image, err := part.buildImage()
+	if err != nil {
+		t.Fatalf("buildImage: %v", err)
+	}
+	parsed, err := typedColumnAdapterPartFromImage(part.Options, image)
+	if err != nil {
+		t.Fatalf("typedColumnAdapterPartFromImage: %v", err)
+	}
+	gotRows, err := parsed.scanRows()
+	if err != nil {
+		t.Fatalf("scanRows: %v", err)
+	}
+	if len(gotRows) != len(rows) {
+		t.Fatalf("rows=%d want %d", len(gotRows), len(rows))
+	}
+	if !gotRows[0].Values["flag"].Bool || gotRows[1].Values["flag"].Bool {
+		t.Fatalf("bool rows=%+v", gotRows)
+	}
+	if gotRows[0].Values["count"].Int64 != math.MinInt64 || gotRows[1].Values["count"].Int64 != math.MaxInt64 {
+		t.Fatalf("int64 rows=%+v", gotRows)
+	}
+	if math.Float32bits(gotRows[0].Values["score32"].Float32) != 0x80000000 || math.Float32bits(gotRows[1].Values["score32"].Float32) != 0x7fc01234 {
+		t.Fatalf("float32 bit rows=%+v", gotRows)
+	}
+	if math.Float64bits(gotRows[0].Values["score64"].Double) != 0x7ff8000000001234 || math.Float64bits(gotRows[1].Values["score64"].Double) != 0x8000000000000000 {
+		t.Fatalf("double bit rows=%+v", gotRows)
+	}
+	if gotRows[0].Values["kind"].String != "beta" || gotRows[1].Values["kind"].String != "alpha" {
+		t.Fatalf("string rows=%+v", gotRows)
+	}
+	if !slices.Equal(gotRows[0].Values["embedding"].Float32Vector, []float32{1, 2, 3}) || !slices.Equal(gotRows[1].Values["embedding"].Float32Vector, []float32{-1, -2, -3}) {
+		t.Fatalf("vector rows=%+v", gotRows)
+	}
+	if !slices.Equal(gotRows[0].Values["neighbors"].AdjacencyList, []uint32{4, 5}) || !slices.Equal(gotRows[1].Values["neighbors"].AdjacencyList, []uint32{6, 7}) {
+		t.Fatalf("adjacency rows=%+v", gotRows)
+	}
+}
+
+type typedColumnTestSelectionKind string
+
+const (
+	typedColumnTestSelectionEmpty  typedColumnTestSelectionKind = "empty"
+	typedColumnTestSelectionAll    typedColumnTestSelectionKind = "all"
+	typedColumnTestSelectionRange  typedColumnTestSelectionKind = "range"
+	typedColumnTestSelectionBitmap typedColumnTestSelectionKind = "bitmap"
+	typedColumnTestSelectionSparse typedColumnTestSelectionKind = "sparse"
+)
+
+type typedColumnTestSelection struct {
+	kind   typedColumnTestSelectionKind
+	rows   int
+	start  int
+	end    int
+	bitmap []bool
+	sparse []int
+}
+
+func typedColumnTestSelectionRows(sel typedColumnTestSelection, visible, nulls, defaults []bool) []int {
+	if sel.rows <= 0 {
+		return nil
+	}
+	out := make([]int, 0, sel.rows)
+	appendIfLive := func(row int) {
+		if row < 0 || row >= sel.rows {
+			return
+		}
+		if len(visible) != 0 && !visible[row] {
+			return
+		}
+		if len(nulls) != 0 && nulls[row] {
+			return
+		}
+		if len(defaults) != 0 && defaults[row] {
+			return
+		}
+		out = append(out, row)
+	}
+	switch sel.kind {
+	case typedColumnTestSelectionEmpty:
+		return nil
+	case typedColumnTestSelectionAll:
+		for row := 0; row < sel.rows; row++ {
+			appendIfLive(row)
+		}
+	case typedColumnTestSelectionRange:
+		start, end := sel.start, sel.end
+		if start < 0 {
+			start = 0
+		}
+		if end > sel.rows {
+			end = sel.rows
+		}
+		for row := start; row < end; row++ {
+			appendIfLive(row)
+		}
+	case typedColumnTestSelectionBitmap:
+		limit := min(sel.rows, len(sel.bitmap))
+		for row := 0; row < limit; row++ {
+			if sel.bitmap[row] {
+				appendIfLive(row)
+			}
+		}
+	case typedColumnTestSelectionSparse:
+		for _, row := range sel.sparse {
+			appendIfLive(row)
+		}
+	}
+	return out
+}
+
+func TestTypedColumnSelectionMaskConformancePlaceholder(t *testing.T) {
+	visible := []bool{true, true, false, true, true, true, true, false}
+	nulls := []bool{false, true, false, false, false, false, true, false}
+	defaults := []bool{false, false, false, false, true, false, false, false}
+	tests := []struct {
+		name string
+		sel  typedColumnTestSelection
+		want []int
+	}{
+		{name: "empty", sel: typedColumnTestSelection{kind: typedColumnTestSelectionEmpty, rows: 8}, want: nil},
+		{name: "all", sel: typedColumnTestSelection{kind: typedColumnTestSelectionAll, rows: 8}, want: []int{0, 3, 5}},
+		{name: "range", sel: typedColumnTestSelection{kind: typedColumnTestSelectionRange, rows: 8, start: 2, end: 7}, want: []int{3, 5}},
+		{name: "bitmap", sel: typedColumnTestSelection{kind: typedColumnTestSelectionBitmap, rows: 8, bitmap: []bool{true, true, false, false, true, true, false, true}}, want: []int{0, 5}},
+		{name: "sparse", sel: typedColumnTestSelection{kind: typedColumnTestSelectionSparse, rows: 8, sparse: []int{6, 3, 0}}, want: []int{3, 0}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := typedColumnTestSelectionRows(tc.sel, visible, nulls, defaults); !slices.Equal(got, tc.want) {
+				t.Fatalf("selection rows=%v want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/TreeDB/collections/typed_column_int64_scan_test.go
+++ b/TreeDB/collections/typed_column_int64_scan_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime/pprof"
 	"sort"
 	"strconv"
 	"strings"
@@ -1167,6 +1168,21 @@ func TestTypedColumnInt64AggregateBenchParsers(t *testing.T) {
 		}
 	})
 
+	t.Run("fallback_reason_metric_tokens", func(t *testing.T) {
+		for _, tc := range []struct {
+			input string
+			want  string
+		}{
+			{input: "typed_column_not_selected", want: "typed_column_not_selected"},
+			{input: "Capability: nullable carrier aggregate semantics", want: "capability_nullable_carrier_aggregate_semantics"},
+			{input: "!!!", want: "unknown"},
+		} {
+			if got := typedColumnInt64AggregateBenchMetricToken(tc.input); got != tc.want {
+				t.Fatalf("metric token %q=%q want %q", tc.input, got, tc.want)
+			}
+		}
+	})
+
 	t.Run("sub_benchmark_names", func(t *testing.T) {
 		name := typedColumnInt64AggregateBenchSubBenchmarkName(256, typedColumnInt64AggregateBenchDistributionByName("clustered_monotonic"), "typed_column_part", typedColumnInt64AggregateBenchShapeByName("range_1pct"), typedColumnInt64AggregateBenchReadIntegrityByName("cached_verify"), typedColumnInt64AggregateBenchExecutionModeByName("serial"))
 		want := "rows_256/dist_clustered_monotonic/path_typed_column_part/shape_selective_range_1pct/timed_one_shot_api/read_integrity_cached_verify/execution_serial/predicate_count_sum_avg"
@@ -1476,9 +1492,13 @@ func runTypedColumnInt64AggregateBenchPath(b *testing.B, rows int, dist typedCol
 			b.ReportAllocs()
 			b.ResetTimer()
 			reportTypedColumnInt64AggregateBenchSetupMetrics(b, setupMetrics)
+			stopHotCPUProfile := startTypedColumnInt64AggregateBenchHotCPUProfile(b)
 			b.StartTimer()
 			result, runErr := execution.run(b, col, session, req, expected)
 			b.StopTimer()
+			if stopHotCPUProfile != nil {
+				stopHotCPUProfile()
+			}
 			if session != nil {
 				if err := session.Close(); err != nil {
 					b.Fatalf("prepared session Close: %v", err)
@@ -2149,6 +2169,62 @@ func reportTypedColumnInt64AggregateBenchMetrics(b *testing.B, totalRows int, di
 	b.ReportMetric(float64(diag.RowMaterializations), "row_materializations/op")
 	b.ReportMetric(float64(diag.DocumentMaterializations), "document_materializations/op")
 	b.ReportMetric(float64(diag.DocumentReconstructions), "document_reconstructions/op")
+	fallbackCount := 0
+	if diag.Fallback {
+		fallbackCount = 1
+	}
+	b.ReportMetric(float64(fallbackCount), "fallback_count")
+	if diag.FallbackReason != "" {
+		b.ReportMetric(1, "fallback_reason_"+typedColumnInt64AggregateBenchMetricToken(diag.FallbackReason)+"_count")
+	}
+}
+
+func startTypedColumnInt64AggregateBenchHotCPUProfile(b *testing.B) func() {
+	b.Helper()
+	profilePath := strings.TrimSpace(os.Getenv("TREEDB_TYPED_COLUMN_BENCH_HOT_CPU_PROFILE"))
+	if profilePath == "" {
+		return nil
+	}
+	if dir := filepath.Dir(profilePath); dir != "." {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			b.Fatalf("create hot CPU profile dir %q: %v", dir, err)
+		}
+	}
+	file, err := os.Create(profilePath)
+	if err != nil {
+		b.Fatalf("create hot CPU profile %q: %v", profilePath, err)
+	}
+	if err := pprof.StartCPUProfile(file); err != nil {
+		_ = file.Close()
+		b.Fatalf("start hot CPU profile %q: %v", profilePath, err)
+	}
+	return func() {
+		pprof.StopCPUProfile()
+		if err := file.Close(); err != nil {
+			b.Fatalf("close hot CPU profile %q: %v", profilePath, err)
+		}
+	}
+}
+
+func typedColumnInt64AggregateBenchMetricToken(reason string) string {
+	var builder strings.Builder
+	lastUnderscore := false
+	for _, r := range strings.ToLower(reason) {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			builder.WriteRune(r)
+			lastUnderscore = false
+			continue
+		}
+		if !lastUnderscore && builder.Len() != 0 {
+			builder.WriteByte('_')
+			lastUnderscore = true
+		}
+	}
+	out := strings.Trim(builder.String(), "_")
+	if out == "" {
+		return "unknown"
+	}
+	return out
 }
 
 func reportTypedColumnInt64ScanBenchMetrics(b *testing.B, diag TypedColumnInt64PredicateScanDiagnostics, elapsed time.Duration, iterations int) {

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -352,6 +352,7 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/command_wal_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 4, occurrences: 6},
 	{path: "TreeDB/collections/typed_column_adapter.go", classification: typedStorageLegacyCompatibility, matchingLines: 43, occurrences: 48},
 	{path: "TreeDB/collections/typed_column_adapter_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 201, occurrences: 209},
+	{path: "TreeDB/collections/typed_column_conformance_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 26, occurrences: 33},
 	{path: "TreeDB/collections/typed_column_int64_scan.go", classification: typedStorageLegacyCompatibility, matchingLines: 22, occurrences: 31},
 	{path: "TreeDB/collections/typed_column_int64_scan_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 29, occurrences: 36},
 	{path: "TreeDB/collections/typed_column_string_predicate_validation_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 7, occurrences: 8},

--- a/TreeDB/docs/guides/typed-storage-performance.md
+++ b/TreeDB/docs/guides/typed-storage-performance.md
@@ -83,8 +83,8 @@ go test -run '^$' \
 Expected output shape:
 
 ```text
-BenchmarkTypedColumnInt64PredicateAggregate/rows_4096/dist_clustered_monotonic/path_typed_column_part/shape_selective_range_1pct/predicate_count_sum_avg-8 ... dataset_rows ... setup_ns ... ns/op ... rows_scanned/op ... rows_matched/op ... blocks_pruned/op ... mapped_bytes/op ... decoded_bytes/op ... document_materializations/op ... B/op ... allocs/op
-BenchmarkTypedColumnInt64PredicateAggregate/rows_4096/dist_clustered_monotonic/path_document_full_scan_fallback/shape_selective_range_1pct/predicate_count_sum_avg-8 ... document_materializations/op ... row_materializations/op ... B/op ... allocs/op
+BenchmarkTypedColumnInt64PredicateAggregate/rows_4096/dist_clustered_monotonic/path_typed_column_part/shape_selective_range_1pct/timed_one_shot_api/read_integrity_cached_verify/execution_serial/predicate_count_sum_avg-8 ... dataset_rows ... setup_ns ... ns/op ... rows_scanned/op ... rows_matched/op ... blocks_pruned/op ... mapped_bytes/op ... decoded_bytes/op ... document_materializations/op ... fallback_count ... B/op ... allocs/op
+BenchmarkTypedColumnInt64PredicateAggregate/rows_4096/dist_clustered_monotonic/path_document_full_scan_fallback/shape_selective_range_1pct/timed_one_shot_api/read_integrity_not_applicable/execution_serial/predicate_count_sum_avg-8 ... document_materializations/op ... row_materializations/op ... fallback_count ... fallback_reason_column_store_unavailable_count ... B/op ... allocs/op
 ```
 
 Read the typed-column row and fallback row separately. The direct typed-column
@@ -154,6 +154,63 @@ go test -run '^$' \
   ./TreeDB/collections
 ```
 
+### Repeatable script runbook
+
+The repo-local wrapper below writes stable artifact names under `RUN_DIR` and is
+safe for quick validation. It uses `GOWORK=off` by default.
+
+Small smoke (direct typed-column path plus the small document fallback sample for
+reason counters):
+
+```sh
+RUN_DIR=/tmp/treedb_typed_column_smoke_$(date +%Y%m%d_%H%M%S) \
+ROWS=4096 BENCHTIME=1x COUNT=1 RUN_1M=false \
+scripts/treedb_typed_column_bench_profile.sh
+```
+
+Primary smoke artifacts:
+
+```text
+$RUN_DIR/README.md
+$RUN_DIR/smoke/typed_column_int64_aggregate_bench.txt
+$RUN_DIR/hot_query_profile/hot_query_bench.txt
+$RUN_DIR/hot_query_profile/hot_query_cpu.pprof
+$RUN_DIR/hot_query_profile/hot_query_cpu_top.txt
+$RUN_DIR/hot_query_profile/process_allocs.pprof
+$RUN_DIR/hot_query_profile/process_allocs_top.txt
+```
+
+1M int64 matrix (all current shapes and distributions, direct typed-column path,
+three execution labels, cached-verify read integrity, fallback disabled to keep
+runtime bounded):
+
+```sh
+RUN_DIR=/tmp/treedb_typed_column_1m_$(date +%Y%m%d_%H%M%S) \
+RUN_SMOKE=false RUN_1M=true RUN_HOT_PROFILE=false \
+BENCHTIME_1M=3x COUNT_1M=1 \
+scripts/treedb_typed_column_bench_profile.sh
+```
+
+Primary 1M artifact:
+
+```text
+$RUN_DIR/matrix_1m/typed_column_int64_aggregate_bench.txt
+```
+
+Optional 1M matrix expansions:
+
+```sh
+# Include unsafe checksum-skipping ceiling rows next to cached-verify rows.
+RUN_DIR=/tmp/treedb_typed_column_1m_read_integrity_$(date +%Y%m%d_%H%M%S) \
+RUN_SMOKE=false RUN_1M=true RUN_HOT_PROFILE=false READ_INTEGRITY_1M=all \
+scripts/treedb_typed_column_bench_profile.sh
+
+# Include document fallback rows at 1M only when you explicitly want the cost.
+RUN_DIR=/tmp/treedb_typed_column_1m_fallback_$(date +%Y%m%d_%H%M%S) \
+RUN_SMOKE=false RUN_1M=true RUN_HOT_PROFILE=false INCLUDE_FALLBACK_1M=true \
+scripts/treedb_typed_column_bench_profile.sh
+```
+
 ### Medium 1M-row selective aggregate
 
 ```sh
@@ -162,7 +219,7 @@ TREEDB_TYPED_COLUMN_BENCH_SHAPES=selective_range_1pct \
 TREEDB_TYPED_COLUMN_BENCH_DISTS=clustered_monotonic \
 TREEDB_TYPED_COLUMN_BENCH_INCLUDE_FALLBACK=false \
 go test -run '^$' \
-  -bench 'BenchmarkTypedColumnInt64PredicateAggregate/rows_1048576/dist_clustered_monotonic/path_typed_column_part/shape_selective_range_1pct/predicate_count_sum_avg$' \
+  -bench 'BenchmarkTypedColumnInt64PredicateAggregate/rows_1048576/dist_clustered_monotonic/path_typed_column_part/shape_selective_range_1pct/timed_one_shot_api/read_integrity_cached_verify/execution_serial/predicate_count_sum_avg$' \
   -benchmem \
   -benchtime=20x \
   -count=3 \
@@ -186,37 +243,54 @@ especially `no_filter_full_aggregate`, `all_match`, `random_uniform`, and
 
 ### Focused aggregate CPU and allocation profile
 
-This command profiles the current aggregate path with setup outside the timed
-loop but includes the per-operation read/validation work that the benchmark is
-measuring.
+Prefer the script's prepared-session hot-query CPU profile when investigating the
+scan loop boundary:
+
+```sh
+RUN_DIR=/tmp/treedb_typed_column_hot_$(date +%Y%m%d_%H%M%S) \
+RUN_SMOKE=false RUN_1M=false RUN_HOT_PROFILE=true \
+PROFILE_ROWS=65536 PROFILE_BENCHTIME=30000x PROFILE_COUNT=1 \
+scripts/treedb_typed_column_bench_profile.sh
+```
+
+Inspect profiles:
+
+```sh
+go tool pprof -top $RUN_DIR/hot_query_profile/hot_query_cpu.pprof
+go tool pprof -top -sample_index=alloc_space $RUN_DIR/hot_query_profile/process_allocs.pprof
+```
+
+The CPU profile uses the benchmark-owned
+`TREEDB_TYPED_COLUMN_BENCH_HOT_CPU_PROFILE` boundary around the prepared-session
+`Run` loop after setup, prepare, and warmup. Set it only with an exact single
+sub-benchmark regex, as repeated matching sub-benchmarks would overwrite the same
+profile path. The allocation profile is still Go
+test process-wide (`-memprofile` cannot be scoped to only the hot loop here), so
+use benchmark `B/op` and `allocs/op` as the hot-loop allocation signal and treat
+`process_allocs.pprof` as attribution context. A fully hot-only allocation
+profile remains follow-up work.
+
+Manual equivalent for the hot CPU profile:
 
 ```sh
 TREEDB_TYPED_COLUMN_BENCH_ROWS=65536 \
 TREEDB_TYPED_COLUMN_BENCH_SHAPES=selective_range_1pct \
 TREEDB_TYPED_COLUMN_BENCH_DISTS=clustered_monotonic \
 TREEDB_TYPED_COLUMN_BENCH_INCLUDE_FALLBACK=false \
+TREEDB_TYPED_COLUMN_BENCH_HOT_CPU_PROFILE=/tmp/typedscan_hot_cpu.pprof \
 go test -run '^$' \
-  -bench 'BenchmarkTypedColumnInt64PredicateAggregate/rows_65536/dist_clustered_monotonic/path_typed_column_part/shape_selective_range_1pct/predicate_count_sum_avg$' \
+  -bench 'BenchmarkTypedColumnInt64PredicateAggregate/rows_65536/dist_clustered_monotonic/path_typed_column_part/shape_selective_range_1pct/timed_prepared_session_hot_scan/read_integrity_cached_verify/execution_serial/predicate_count_sum_avg$' \
   -benchmem \
   -benchtime=30000x \
   -count=1 \
-  -cpuprofile /tmp/typedscan_aggregate_cpu.pprof \
-  -memprofile /tmp/typedscan_aggregate_mem.pprof \
   ./TreeDB/collections
 ```
 
-Inspect profiles:
-
-```sh
-go tool pprof -top /tmp/typedscan_aggregate_cpu.pprof
-go tool pprof -top -sample_index=alloc_space /tmp/typedscan_aggregate_mem.pprof
-```
-
-Expected current profile themes are per-scan asset read/open/fstat/checksum,
-metadata/dictionary decode, and int64 decode allocation. If a profile instead
-shows document materialization dominating the direct typed-column row, re-check
-that you are running the `path_typed_column_part` sub-benchmark and not the
-fallback.
+Expected current profile themes are targeted section/range reads, metadata decode
+that remains inside the prepared-session hot loop, and int64 decode/aggregate
+work. If a profile instead shows document materialization dominating the direct
+typed-column row, re-check that you are running the `path_typed_column_part` and
+`timed_prepared_session_hot_scan` sub-benchmark, not fallback or one-shot setup.
 
 ### Dense vector typed-column smoke
 
@@ -324,6 +398,21 @@ $OUT/insights.html
 | `physical_row_asset_reads/op` | Typed-row physical asset reads. | Should be zero for direct typed-column aggregate paths. |
 | `physical_row_id_lookups/op` | Row-ID lookup work. | Aggregate path should avoid it; point/document fetch may need it. |
 | `row_locator_decodes/op` | Row locator decode work. | Should be zero for the direct aggregate path; locator work is tracked separately from column payload scans. |
+| `fallback_count` | Numeric 0/1 indicator for whether the measured aggregate result used a fallback path. | Direct typed-column aggregate rows should report 0. Fallback rows report 1 and should be read as a separate baseline, not mixed with direct rows. |
+| `fallback_reason_<reason>_count` | Reason-specific 0/1 fallback marker derived from `Diagnostics.FallbackReason`, for example `fallback_reason_column_store_unavailable_count` or `fallback_reason_typed_column_not_selected_count`. | Present only when a fallback reason is available in the result. Current int64 aggregate benchmark exposes fallback reasons, but semantic capability failures generally fail closed with an error instead of producing fallback rows. |
+
+### Fallback and capability reason limits
+
+For the int64 aggregate benchmark, small document fallback rows report
+`fallback_count=1` plus a sanitized `fallback_reason_<reason>_count` metric when
+`TREEDB_TYPED_COLUMN_BENCH_INCLUDE_FALLBACK=true`. Direct typed-column rows report
+`fallback_count=0`.
+
+Typed-column semantic capability reasons (for example nullable aggregate carrier
+semantics or unsupported scalar operations) are not counted as benchmark fallback
+reasons today because these paths fail closed before producing a timed fallback
+row. Treat those as correctness/planner diagnostics from tests and errors, not as
+performance fallback counters, until broader selection-engine integration lands.
 
 ### Mapped bytes vs decoded bytes
 

--- a/TreeDB/internal/columnsemantics/semantics_test.go
+++ b/TreeDB/internal/columnsemantics/semantics_test.go
@@ -55,6 +55,22 @@ func TestCapabilityInt64AggregateResultSemanticsAreExplicit(t *testing.T) {
 	}
 }
 
+func TestCapabilityBoolSupportsEqualityButRejectsRangeSemantics(t *testing.T) {
+	desc := Descriptor{Logical: LogicalBool, Physical: typedcolumn.ColumnTypeBool, Encoding: typedcolumn.EncodingBoolBitpackRLE}
+	for _, op := range []Operation{OpAllRows, OpEquality, OpInequality, OpInList, OpBoolCounts, OpDirectScalarValueCarrier} {
+		cap := CapabilityFor(desc, op)
+		if cap.Status != StatusSupported || cap.Reason != ReasonSupported || cap.Phase != PhasePrepare {
+			t.Fatalf("%s capability=%+v", op, cap)
+		}
+	}
+	for _, op := range []Operation{OpOrderedRange, OpPruneOrderedRange, OpMin, OpMax, OpStatsMinMax} {
+		cap := CapabilityFor(desc, op)
+		if cap.Status != StatusUnsupported || cap.Reason != ReasonBoolRangeUnsupported {
+			t.Fatalf("%s status=%s reason=%s", op, cap.Status, cap.Reason)
+		}
+	}
+}
+
 func TestCapabilityFloatRawInt64DoesNotClaimInt64NumericSemantics(t *testing.T) {
 	for _, logical := range []LogicalType{LogicalFloat32, LogicalDouble} {
 		desc := Descriptor{Logical: logical, Physical: typedcolumn.ColumnTypeInt64, Encoding: typedcolumn.EncodingRawInt64}
@@ -146,6 +162,25 @@ func TestCapabilityVectorAndAdjacencyRejectScalarShortcutSemantics(t *testing.T)
 			cap := CapabilityFor(tc.desc, op)
 			if cap.Status != StatusUnsupported || cap.Reason != tc.reason {
 				t.Fatalf("%s %s status=%s reason=%s", tc.name, op, cap.Status, cap.Reason)
+			}
+		}
+	}
+}
+
+func TestCapabilityVectorAndAdjacencySpecificOperationsAreExplicitFallbacks(t *testing.T) {
+	checks := []struct {
+		name   string
+		desc   Descriptor
+		reason ReasonCode
+	}{
+		{"vector", Descriptor{Logical: LogicalFloat32Vector, Physical: typedcolumn.ColumnTypeFloat32Vector, Encoding: typedcolumn.EncodingRawFloat32Vector}, ReasonVectorCapabilityDeferred},
+		{"adjacency", Descriptor{Logical: LogicalAdjacencyList, Physical: typedcolumn.ColumnTypeAdjacencyList, Encoding: typedcolumn.EncodingRawUint32Dense}, ReasonAdjacencyCapabilityDeferred},
+	}
+	for _, tc := range checks {
+		for _, op := range []Operation{OpVectorSimilarity, OpVectorMetrics} {
+			cap := CapabilityFor(tc.desc, op)
+			if cap.Status != StatusFallback || cap.Reason != tc.reason || cap.Phase != PhasePrepare {
+				t.Fatalf("%s %s capability=%+v", tc.name, op, cap)
 			}
 		}
 	}

--- a/scripts/treedb_typed_column_bench_profile.sh
+++ b/scripts/treedb_typed_column_bench_profile.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+cd "$ROOT"
+
+RUN_DIR="${RUN_DIR:-/tmp/treedb_typed_column_bench_profile_$(date +%Y%m%d_%H%M%S)}"
+RUN_SMOKE="${RUN_SMOKE:-true}"
+RUN_1M="${RUN_1M:-false}"
+RUN_HOT_PROFILE="${RUN_HOT_PROFILE:-true}"
+RUN_ALLOC_PROFILE="${RUN_ALLOC_PROFILE:-true}"
+
+ROWS="${ROWS:-4096}"
+SMOKE_SHAPES="${SMOKE_SHAPES:-selective_range_1pct}"
+SMOKE_DISTS="${SMOKE_DISTS:-clustered_monotonic}"
+SMOKE_READ_INTEGRITY="${SMOKE_READ_INTEGRITY:-cached_verify}"
+SMOKE_INCLUDE_FALLBACK="${SMOKE_INCLUDE_FALLBACK:-true}"
+BENCHTIME="${BENCHTIME:-1x}"
+COUNT="${COUNT:-1}"
+
+ROWS_1M="${ROWS_1M:-1048576}"
+SHAPES_1M="${SHAPES_1M:-no_filter,exact,tiny,range_1pct,range_10pct,all_pruned,all_match,tail}"
+DISTS_1M="${DISTS_1M:-clustered,reverse,partial_clustered,random,hotspot}"
+READ_INTEGRITY_1M="${READ_INTEGRITY_1M:-cached_verify}"
+INCLUDE_FALLBACK_1M="${INCLUDE_FALLBACK_1M:-false}"
+BENCHTIME_1M="${BENCHTIME_1M:-3x}"
+COUNT_1M="${COUNT_1M:-1}"
+
+PROFILE_ROWS="${PROFILE_ROWS:-$ROWS}"
+PROFILE_SHAPE="${PROFILE_SHAPE:-selective_range_1pct}"
+PROFILE_DIST="${PROFILE_DIST:-clustered_monotonic}"
+PROFILE_READ_INTEGRITY="${PROFILE_READ_INTEGRITY:-cached_verify}"
+PROFILE_BENCHTIME="${PROFILE_BENCHTIME:-$BENCHTIME}"
+PROFILE_COUNT="${PROFILE_COUNT:-1}"
+
+mkdir -p "$RUN_DIR"
+
+is_true() {
+	case "$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')" in
+		1|true|yes|y|on) return 0 ;;
+		*) return 1 ;;
+	esac
+}
+
+canonical_shape() {
+	case "$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')" in
+		no_filter) printf '%s' "no_filter_full_aggregate" ;;
+		exact|equality|equal) printf '%s' "exact_value" ;;
+		tiny) printf '%s' "tiny_range" ;;
+		range_1pct|selective_1pct) printf '%s' "selective_range_1pct" ;;
+		range_10pct|wide_10pct) printf '%s' "wide_range_10pct" ;;
+		all_pruned|no_match) printf '%s' "all_pruned_no_match" ;;
+		tail|latest_window) printf '%s' "tail_range" ;;
+		*) printf '%s' "$1" ;;
+	esac
+}
+
+canonical_dist() {
+	case "$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')" in
+		clustered) printf '%s' "clustered_monotonic" ;;
+		reverse) printf '%s' "reverse_monotonic" ;;
+		partial_random|partially_random|partial_clustered) printf '%s' "partially_clustered" ;;
+		random) printf '%s' "random_uniform" ;;
+		hotspot|skew|skewed) printf '%s' "hotspot_skewed" ;;
+		*) printf '%s' "$1" ;;
+	esac
+}
+
+canonical_read_integrity() {
+	case "$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')" in
+		cached|cached_verify) printf '%s' "cached_verify" ;;
+		skip|skip_checksums|unsafe_skip_checksums|unsafe_skip_checksums_ceiling) printf '%s' "unsafe_skip_checksums_ceiling" ;;
+		*) printf '%s' "$1" ;;
+	esac
+}
+
+run_bench() {
+	local name=$1
+	local rows=$2
+	local shapes=$3
+	local dists=$4
+	local read_integrity=$5
+	local include_fallback=$6
+	local benchtime=$7
+	local count=$8
+	local bench_regex=$9
+	local dir="$RUN_DIR/$name"
+	mkdir -p "$dir"
+	cat >"$dir/env.txt" <<EOF
+TREEDB_TYPED_COLUMN_BENCH_ROWS=$rows
+TREEDB_TYPED_COLUMN_BENCH_SHAPES=$shapes
+TREEDB_TYPED_COLUMN_BENCH_DISTS=$dists
+TREEDB_TYPED_COLUMN_BENCH_READ_INTEGRITY=$read_integrity
+TREEDB_TYPED_COLUMN_BENCH_INCLUDE_FALLBACK=$include_fallback
+BENCHTIME=$benchtime
+COUNT=$count
+BENCH_REGEX=$bench_regex
+EOF
+	echo "running typed-column int64 aggregate $name into: $dir"
+	(
+		export GOWORK="${GOWORK:-off}"
+		export TREEDB_TYPED_COLUMN_BENCH_ROWS="$rows"
+		export TREEDB_TYPED_COLUMN_BENCH_SHAPES="$shapes"
+		export TREEDB_TYPED_COLUMN_BENCH_DISTS="$dists"
+		export TREEDB_TYPED_COLUMN_BENCH_READ_INTEGRITY="$read_integrity"
+		export TREEDB_TYPED_COLUMN_BENCH_INCLUDE_FALLBACK="$include_fallback"
+		go test -run '^$' \
+			-bench "$bench_regex" \
+			-benchmem \
+			-benchtime="$benchtime" \
+			-count="$count" \
+			./TreeDB/collections
+	) 2>&1 | tee "$dir/typed_column_int64_aggregate_bench.txt"
+}
+
+run_hot_profile() {
+	local dir="$RUN_DIR/hot_query_profile"
+	mkdir -p "$dir"
+	local shape dist read_integrity bench_regex cpu_profile alloc_profile
+	shape=$(canonical_shape "$PROFILE_SHAPE")
+	dist=$(canonical_dist "$PROFILE_DIST")
+	read_integrity=$(canonical_read_integrity "$PROFILE_READ_INTEGRITY")
+	bench_regex="^BenchmarkTypedColumnInt64PredicateAggregate/rows_${PROFILE_ROWS}/dist_${dist}/path_typed_column_part/shape_${shape}/timed_prepared_session_hot_scan/read_integrity_${read_integrity}/execution_serial/predicate_count_sum_avg$"
+	cpu_profile="$dir/hot_query_cpu.pprof"
+	alloc_profile="$dir/process_allocs.pprof"
+	cat >"$dir/env.txt" <<EOF
+TREEDB_TYPED_COLUMN_BENCH_ROWS=$PROFILE_ROWS
+TREEDB_TYPED_COLUMN_BENCH_SHAPES=$shape
+TREEDB_TYPED_COLUMN_BENCH_DISTS=$dist
+TREEDB_TYPED_COLUMN_BENCH_READ_INTEGRITY=$PROFILE_READ_INTEGRITY
+TREEDB_TYPED_COLUMN_BENCH_INCLUDE_FALLBACK=false
+TREEDB_TYPED_COLUMN_BENCH_HOT_CPU_PROFILE=$cpu_profile
+BENCHTIME=$PROFILE_BENCHTIME
+COUNT=$PROFILE_COUNT
+BENCH_REGEX=$bench_regex
+EOF
+	echo "running prepared-session hot-query CPU profile into: $dir"
+	local args=(go test -run '^$' -bench "$bench_regex" -benchmem -benchtime="$PROFILE_BENCHTIME" -count="$PROFILE_COUNT")
+	if is_true "$RUN_ALLOC_PROFILE"; then
+		args+=(-memprofile "$alloc_profile")
+	fi
+	args+=(./TreeDB/collections)
+	(
+		export GOWORK="${GOWORK:-off}"
+		export TREEDB_TYPED_COLUMN_BENCH_ROWS="$PROFILE_ROWS"
+		export TREEDB_TYPED_COLUMN_BENCH_SHAPES="$shape"
+		export TREEDB_TYPED_COLUMN_BENCH_DISTS="$dist"
+		export TREEDB_TYPED_COLUMN_BENCH_READ_INTEGRITY="$PROFILE_READ_INTEGRITY"
+		export TREEDB_TYPED_COLUMN_BENCH_INCLUDE_FALLBACK=false
+		export TREEDB_TYPED_COLUMN_BENCH_HOT_CPU_PROFILE="$cpu_profile"
+		"${args[@]}"
+	) 2>&1 | tee "$dir/hot_query_bench.txt"
+	if [[ -s "$cpu_profile" ]]; then
+		go tool pprof -top "$cpu_profile" >"$dir/hot_query_cpu_top.txt"
+	fi
+	if is_true "$RUN_ALLOC_PROFILE" && [[ -s "$alloc_profile" ]]; then
+		go tool pprof -top -sample_index=alloc_space "$alloc_profile" >"$dir/process_allocs_top.txt"
+	fi
+}
+
+cat >"$RUN_DIR/README.md" <<EOF
+# TreeDB typed-column int64 benchmark/profile bundle
+
+- worktree: \`$ROOT\`
+- branch: \`$(git rev-parse --abbrev-ref HEAD)\`
+- commit: \`$(git rev-parse --short HEAD)\`
+- smoke enabled: \`$RUN_SMOKE\`
+- 1M matrix enabled: \`$RUN_1M\`
+- hot prepared-session CPU profile enabled: \`$RUN_HOT_PROFILE\`
+
+Primary artifacts:
+
+- \`smoke/typed_column_int64_aggregate_bench.txt\` when smoke is enabled
+- \`matrix_1m/typed_column_int64_aggregate_bench.txt\` when 1M matrix is enabled
+- \`hot_query_profile/hot_query_cpu.pprof\`
+- \`hot_query_profile/hot_query_cpu_top.txt\`
+- \`hot_query_profile/process_allocs.pprof\` when allocation profiling is enabled
+- \`hot_query_profile/process_allocs_top.txt\` when allocation profiling is enabled
+
+The hot CPU profile uses the benchmark-owned
+\`TREEDB_TYPED_COLUMN_BENCH_HOT_CPU_PROFILE\` boundary around the prepared-session
+\`Run\` loop. The allocation profile is Go test process-wide; use benchmark
+\`B/op\` and \`allocs/op\` as the hot-loop allocation signal.
+EOF
+
+if is_true "$RUN_SMOKE"; then
+	run_bench "smoke" "$ROWS" "$SMOKE_SHAPES" "$SMOKE_DISTS" "$SMOKE_READ_INTEGRITY" "$SMOKE_INCLUDE_FALLBACK" "$BENCHTIME" "$COUNT" '^BenchmarkTypedColumnInt64PredicateAggregate$'
+fi
+
+if is_true "$RUN_1M"; then
+	run_bench "matrix_1m" "$ROWS_1M" "$SHAPES_1M" "$DISTS_1M" "$READ_INTEGRITY_1M" "$INCLUDE_FALLBACK_1M" "$BENCHTIME_1M" "$COUNT_1M" '^BenchmarkTypedColumnInt64PredicateAggregate$'
+fi
+
+if is_true "$RUN_HOT_PROFILE"; then
+	run_hot_profile
+fi
+
+echo "typed-column int64 benchmark/profile bundle: $RUN_DIR"
+echo "bundle index: $RUN_DIR/README.md"


### PR DESCRIPTION
Closes #1842
Parent tracker: #1836
Depends on merged #1843 / PR #1852 (base merge commit 31c3dbe50cf469d16fd29ac24162690a8059ee7c).

## Layer / scope

- Adds typed-column benchmark/profile guardrails and semantic conformance coverage.
- Preserves the #1843 semantic capability/admission gate; no new public value types.
- Does not implement #1851 CRC work or the #1844 selection engine. Selection/mask coverage here is a pure test placeholder for future #1844 integration.

## What changed

- Added small-row typed-column semantic conformance tests covering current public type families: bool, int64, float32, double, string/dictionary, float32_vector, adjacency_list.
- Added structured typed-column semantic capability errors so tests can assert stable reason codes while preserving `errors.Is(err, ErrColumnQueryPlanUnsupported)`.
- Added test-only selection/mask placeholder coverage for empty/all/range/bitmap/sparse plus visibility/null/default composition.
- Added int64 aggregate benchmark fallback counters: `fallback_count` and `fallback_reason_<reason>_count` where diagnostics expose a fallback reason.
- Added `scripts/treedb_typed_column_bench_profile.sh` and updated `TreeDB/docs/guides/typed-storage-performance.md` with smoke, 1M matrix, and hot-query profile workflows.

## Supported / unsupported / fallback notes

- Bool: equality/bool counts supported; scalar range/min/max pruning semantics fail closed with `bool_range_unsupported`.
- Int64: existing aggregate/range path remains the performance reference; stats-sum stays unsupported.
- Float32/double: current raw-int64 bit-pattern carriers do not claim int64 range/sum/min/max semantics (`float_raw_int64_bit_pattern`); equality/in-list remains explicit fallback until native float semantics/layouts land.
- String/dictionary: dictionary equality/group-by smoke is covered; lexical prefix/range remains fail-closed unless ordering/collation is proven.
- Vector/adjacency: scalar predicates/aggregates fail closed; vector/graph-specific operations are explicit fallbacks/deferred.

## Selection/null/default/visibility boundary

The new conformance placeholder proves expected composition for empty/all/range/bitmap/sparse selections with visibility, null, and default masks. It is test-only and intentionally does not add production #1844 APIs.

## Tests run

```sh
GOWORK=off go test -count=1 ./TreeDB/internal/columnsemantics ./TreeDB/collections -run 'Semantic|Conformance|Selection|TypedColumnAdapter'
GOWORK=off go test -count=1 ./TreeDB/collections -run 'TypedColumn.*(Semantic|Conformance|Selection|Adapter|String|Bool)'
GOWORK=off go test -count=1 ./TreeDB/collections -run TestTypedColumnInt64AggregateBenchParsers
GOWORK=off go test -count=1 ./TreeDB/internal/columnsemantics ./TreeDB/collections
GOWORK=off go test -count=1 ./TreeDB/internal/typedcolumn ./TreeDB/internal/columnsemantics ./TreeDB/collections
```

## Benchmarks / profiles

Smoke + hot profile script:

```sh
RUN_DIR=/tmp/treedb_typed_column_smoke_1842_manager ROWS=4096 BENCHTIME=1x COUNT=1 RUN_1M=false scripts/treedb_typed_column_bench_profile.sh
```

1M subset evidence (full 1M matrix remains scripted/runbooked):

```sh
RUN_DIR=/tmp/treedb_typed_column_1m_subset_1842_manager RUN_SMOKE=false RUN_1M=true RUN_HOT_PROFILE=false ROWS_1M=1048576 SHAPES_1M=range_1pct DISTS_1M=clustered BENCHTIME_1M=1x COUNT_1M=1 INCLUDE_FALLBACK_1M=false scripts/treedb_typed_column_bench_profile.sh
```

Hot-query-only CPU profile:

```sh
RUN_DIR=/tmp/treedb_typed_column_hot_1842_manager RUN_SMOKE=false RUN_1M=false RUN_HOT_PROFILE=true RUN_ALLOC_PROFILE=true PROFILE_ROWS=65536 PROFILE_BENCHTIME=30000x PROFILE_COUNT=1 scripts/treedb_typed_column_bench_profile.sh
```

Key rows from local Apple M3 evidence:

| Shape | Boundary | Rows | ns/op | ops/sec | rows/sec | matches/sec | B/op | allocs/op | mapped bytes/op | decoded bytes/op | physical bytes/op | fallback |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| 1M clustered range_1pct | one-shot | 1,048,576 | 4,389,709 | 227.8 | 238,871,415 | 2,388,541 | 592,480 | 1,676 | 69,444 | 16,388 | 43,131,458 | 0 |
| 1M clustered range_1pct | prepared hot scan | 1,048,576 | 107,833 | 9,274 | 9,724,073,336 | 97,233,685 | 118,784 | 228 | 16,388 | 16,388 | 16,388 | 0 |
| 65,536 clustered range_1pct | prepared hot profile | 65,536 | 29,635 | 33,744 | 2,211,465,088 | 22,102,503 | 7,904 | 18 | 8,194 | 8,194 | 8,194 | 0 |
| 4,096 fallback smoke | document fallback | 4,096 | 2,967,125 | 337.0 | 1,380,461 | 13,481 | 6,591,264 | 81,921 | 0 | 0 | 0 | `column_store_unavailable` |

Profile artifacts:

- `/tmp/treedb_typed_column_hot_1842_manager/hot_query_profile/hot_query_cpu.pprof`
- `/tmp/treedb_typed_column_hot_1842_manager/hot_query_profile/hot_query_cpu_top.txt`
- `/tmp/treedb_typed_column_hot_1842_manager/hot_query_profile/process_allocs.pprof`
- `/tmp/treedb_typed_column_hot_1842_manager/hot_query_profile/process_allocs_top.txt`

The CPU profile is started after fixture construction, session prepare, and warmup, and stopped before session close. Allocation pprof remains Go-test process-wide; the runbook documents this boundary and uses benchmark `B/op`/`allocs/op` as the hot-loop allocation signal.

## Integrity / lifetime / concurrency boundary

- No checksum/integrity semantics are weakened. `skip_checksums` remains explicitly labeled unsafe ceiling-only in docs/script options.
- No hidden global caches are introduced.
- Semantic checks remain prepare-time/planning guardrails; no per-row generic/reflection dispatch added.

## AI review / CI

- Latest-head CI: green.
- Codex latest-head review: no major issues.
- Copilot latest-head review: no additional blocking issues.
- CodeRabbit latest-head review: commented with docstring-coverage warning only; no blocking findings.
- Internal xhigh review passed with no blocking findings; remaining caveat is the documented allocation-profile boundary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added benchmarking script for typed-column int64 aggregate performance testing with configurable parameters.
  * Introduced fallback counter metrics to track and report query execution behavior.

* **Documentation**
  * Updated typed-storage performance guide with new benchmarking runbook, profiling instructions, and fallback counter documentation.

* **Tests**
  * Expanded test coverage for typed column adapter semantic conformance and data round-tripping.
  * Added profiling capabilities to benchmark execution for performance analysis.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1853?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
