### PR TITLE
Standardize TreeDB CRC32 on go-crc32-asm wrapper

### DIFF
--- a/TreeDB/collections/crc_bench_test.go
+++ b/TreeDB/collections/crc_bench_test.go
@@ -1,0 +1,55 @@
+package collections
+
+import (
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+var benchmarkColumnAssetCRCSink uint32
+var benchmarkColumnAssetBoolSink bool
+
+func BenchmarkColumnPhysicalAssetChecksumVerify(b *testing.B) {
+	raw := deterministicColumnAssetCRCBuf(4 << 20)
+	ref := ColumnAssetRef{
+		Kind:       ColumnAssetKindTCS1TypedColumnPart,
+		Namespace:  "crc-bench",
+		Generation: 1,
+		PartID:     1851,
+		FileID:     1,
+		Length:     int64(len(raw)),
+		Checksum:   page.Checksum(raw),
+	}
+	if ref.Checksum == 0 {
+		b.Fatal("unexpected zero checksum for deterministic asset payload")
+	}
+
+	b.SetBytes(int64(len(raw)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	var sum uint32
+	var ok bool
+	for i := 0; i < b.N; i++ {
+		got := page.Checksum(raw)
+		ok = got == ref.Checksum
+		if !ok {
+			b.Fatalf("column physical asset checksum=%d want %d", got, ref.Checksum)
+		}
+		sum ^= got
+	}
+	benchmarkColumnAssetCRCSink = sum
+	benchmarkColumnAssetBoolSink = ok
+}
+
+func deterministicColumnAssetCRCBuf(size int) []byte {
+	buf := make([]byte, size)
+	var x uint32 = 0x51ed1851
+	for i := range buf {
+		x += 0x9e3779b9
+		x ^= x >> 16
+		x *= 0x85ebca6b
+		x ^= x >> 13
+		buf[i] = byte(x >> 8)
+	}
+	return buf
+}

--- a/TreeDB/collections/crc_bench_test.go
+++ b/TreeDB/collections/crc_bench_test.go
@@ -24,21 +24,38 @@ func BenchmarkColumnPhysicalAssetChecksumVerify(b *testing.B) {
 		b.Fatal("unexpected zero checksum for deterministic asset payload")
 	}
 
-	b.SetBytes(int64(len(raw)))
-	b.ReportAllocs()
-	b.ResetTimer()
-	var sum uint32
-	var ok bool
-	for i := 0; i < b.N; i++ {
-		got := page.Checksum(raw)
-		ok = got == ref.Checksum
-		if !ok {
-			b.Fatalf("column physical asset checksum=%d want %d", got, ref.Checksum)
+	b.Run("strict_verify", func(b *testing.B) {
+		b.SetBytes(int64(len(raw)))
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if err := verifyColumnPhysicalAssetReadChecksumWithIntegrityForSegment(raw, ref, true, ColumnAssetReadIntegrityVerify, "", columnAssetVerifiedChecksumFileIdentity{}); err != nil {
+				b.Fatal(err)
+			}
 		}
-		sum ^= got
-	}
-	benchmarkColumnAssetCRCSink = sum
-	benchmarkColumnAssetBoolSink = ok
+		benchmarkColumnAssetCRCSink = ref.Checksum
+		benchmarkColumnAssetBoolSink = true
+	})
+
+	b.Run("cached_verify_prepare_miss", func(b *testing.B) {
+		b.SetBytes(int64(len(raw)))
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			identity := columnAssetVerifiedChecksumFileIdentity{
+				dev:             1,
+				ino:             2,
+				size:            int64(len(raw)),
+				modTimeUnixNano: int64(i + 1),
+				valid:           true,
+			}
+			if err := verifyColumnPhysicalAssetReadChecksumWithIntegrityForSegment(raw, ref, true, ColumnAssetReadIntegrityCachedVerify, "crc-bench-root", identity); err != nil {
+				b.Fatal(err)
+			}
+		}
+		benchmarkColumnAssetCRCSink = ref.Checksum
+		benchmarkColumnAssetBoolSink = true
+	})
 }
 
 func deterministicColumnAssetCRCBuf(size int) []byte {

--- a/TreeDB/compact_storage_cached_internal_test.go
+++ b/TreeDB/compact_storage_cached_internal_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
-	crc32 "github.com/snissn/go-crc32-asm"
 	"os"
 	"path/filepath"
 	"sort"
@@ -13,6 +12,7 @@ import (
 	"testing"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/internal/crc"
 	"github.com/snissn/gomap/TreeDB/internal/valuelog"
 	"github.com/snissn/gomap/TreeDB/page"
 )
@@ -363,7 +363,7 @@ func TestCompactStorageClearsPublicRewriteSourceGCBehindActiveWriters(t *testing
 	for i := 0; i < rows; i++ {
 		key := cachedRewriteReclaimKey(i)
 		value := cachedRewriteReclaimValue(i)
-		expected[string(key)] = expectedValue{size: len(value), sum: crc32.ChecksumIEEE(value)}
+		expected[string(key)] = expectedValue{size: len(value), sum: crc.Checksum(value)}
 		if err := batch.Set(key, value); err != nil {
 			t.Fatalf("batch set %d: %v", i, err)
 		}
@@ -448,9 +448,9 @@ func TestCompactStorageClearsPublicRewriteSourceGCBehindActiveWriters(t *testing
 			_ = reopened.Close()
 			t.Fatalf("get %x after CompactStorage: %v", []byte(key), err)
 		}
-		if len(got) != want.size || crc32.ChecksumIEEE(got) != want.sum {
+		if len(got) != want.size || crc.Checksum(got) != want.sum {
 			_ = reopened.Close()
-			t.Fatalf("value mismatch for %x: got len=%d crc=%08x want len=%d crc=%08x", []byte(key), len(got), crc32.ChecksumIEEE(got), want.size, want.sum)
+			t.Fatalf("value mismatch for %x: got len=%d crc=%08x want len=%d crc=%08x", []byte(key), len(got), crc.Checksum(got), want.size, want.sum)
 		}
 	}
 	if err := reopened.Close(); err != nil {

--- a/TreeDB/db/vlog_gc_incremental.go
+++ b/TreeDB/db/vlog_gc_incremental.go
@@ -5,7 +5,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	crc32 "github.com/snissn/go-crc32-asm"
 	"os"
 	"path/filepath"
 	"sort"
@@ -13,6 +12,7 @@ import (
 
 	batchpkg "github.com/snissn/gomap/TreeDB/batch"
 	"github.com/snissn/gomap/TreeDB/internal/atomicfile"
+	"github.com/snissn/gomap/TreeDB/internal/crc"
 	"github.com/snissn/gomap/TreeDB/internal/iterator"
 	"github.com/snissn/gomap/TreeDB/internal/valuelog"
 	"github.com/snissn/gomap/TreeDB/node"
@@ -585,8 +585,8 @@ func encodeValueLogRefCounts(commitSeq uint64, counts map[uint32]uint64) ([]byte
 		binary.LittleEndian.PutUint64(tmp8[:], counts[fileID])
 		buf = append(buf, tmp8[:]...)
 	}
-	crc := crc32.ChecksumIEEE(buf)
-	binary.LittleEndian.PutUint32(tmp4[:], crc)
+	checksum := crc.Checksum(buf)
+	binary.LittleEndian.PutUint32(tmp4[:], checksum)
 	buf = append(buf, tmp4[:]...)
 	return buf, nil
 }
@@ -604,7 +604,7 @@ func decodeValueLogRefCounts(data []byte) (valueLogRefCountsDisk, error) {
 	}
 	payload := data[:len(data)-4]
 	gotCRC := binary.LittleEndian.Uint32(data[len(data)-4:])
-	if crc32.ChecksumIEEE(payload) != gotCRC {
+	if crc.Checksum(payload) != gotCRC {
 		return valueLogRefCountsDisk{}, errValueLogRefCorrupt
 	}
 	off := len(valueLogRefCountsMagic)

--- a/TreeDB/db/vlog_rewrite_test.go
+++ b/TreeDB/db/vlog_rewrite_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	crc32 "github.com/snissn/go-crc32-asm"
 	"io"
 	"os"
 	"path/filepath"
@@ -21,6 +20,7 @@ import (
 	batchpkg "github.com/snissn/gomap/TreeDB/batch"
 	"github.com/snissn/gomap/TreeDB/internal/commitlog"
 	"github.com/snissn/gomap/TreeDB/internal/compression"
+	"github.com/snissn/gomap/TreeDB/internal/crc"
 	"github.com/snissn/gomap/TreeDB/internal/iterator"
 	"github.com/snissn/gomap/TreeDB/internal/memtable"
 	"github.com/snissn/gomap/TreeDB/internal/valuelog"
@@ -1615,7 +1615,7 @@ func TestNextRewriteRIDStartFromSet_ErrorsOnCorruptMidFileRecord(t *testing.T) {
 	binary.LittleEndian.PutUint64(rawRecord[ridStart:ridEnd], 20)
 	binary.LittleEndian.PutUint32(rawRecord[bodyLenStart:bodyLenEnd], 1)
 	rawRecord[valuelog.HeaderSize] = 0xff
-	binary.LittleEndian.PutUint32(rawRecord[crcStart:versionOff], crc32.ChecksumIEEE(rawRecord[versionOff:]))
+	binary.LittleEndian.PutUint32(rawRecord[crcStart:versionOff], crc.Checksum(rawRecord[versionOff:]))
 	if _, err := w.AppendRawRecord(rawRecord, uint32(len(rawRecord)-versionOff)); err != nil {
 		t.Fatalf("AppendRawRecord(corrupt grouped): %v", err)
 	}
@@ -3105,7 +3105,7 @@ func TestScanValueLogSegmentPreferredDictID_SkipsNonGroupedRecords(t *testing.T)
 	binary.LittleEndian.PutUint64(rawRecord[8:16], 1)
 	binary.LittleEndian.PutUint32(rawRecord[16:20], uint32(len(rawPayload)))
 	copy(rawRecord[valuelog.HeaderSize:], rawPayload)
-	binary.LittleEndian.PutUint32(rawRecord[0:4], crc32.ChecksumIEEE(rawRecord[4:]))
+	binary.LittleEndian.PutUint32(rawRecord[0:4], crc.Checksum(rawRecord[4:]))
 	if _, err := w.AppendRawRecord(rawRecord, uint32(len(rawRecord)-4)); err != nil {
 		t.Fatalf("AppendRawRecord: %v", err)
 	}
@@ -3152,7 +3152,7 @@ func TestScanValueLogSegmentPreferredDictID_IgnoresInvalidRecordVersion(t *testi
 	binary.LittleEndian.PutUint64(rawRecord[8:16], 1)
 	binary.LittleEndian.PutUint32(rawRecord[16:20], uint32(len(payload)))
 	copy(rawRecord[valuelog.HeaderSize:], payload)
-	binary.LittleEndian.PutUint32(rawRecord[0:4], crc32.ChecksumIEEE(rawRecord[4:]))
+	binary.LittleEndian.PutUint32(rawRecord[0:4], crc.Checksum(rawRecord[4:]))
 	if _, err := w.AppendRawRecord(rawRecord, uint32(len(rawRecord)-4)); err != nil {
 		t.Fatalf("AppendRawRecord: %v", err)
 	}

--- a/TreeDB/internal/crc/crc.go
+++ b/TreeDB/internal/crc/crc.go
@@ -1,7 +1,14 @@
 // Package crc is TreeDB's audited CRC-32 facade.
 //
 // All functions use the CRC-32/IEEE polynomial and preserve the byte-for-byte
-// values produced by github.com/snissn/go-crc32-asm.
+// values produced by hash/crc32.ChecksumIEEE and hash/crc32.Update. TreeDB
+// stores these checksum bytes on disk, so this package centralizes routing
+// through github.com/snissn/go-crc32-asm without changing the polynomial or
+// verification semantics.
+//
+// go-crc32-asm selects architecture-specific acceleration where available and
+// uses its bit-compatible fallback on unsupported architectures; callers must
+// treat either path as the same fail-closed verification primitive.
 package crc
 
 import crc32 "github.com/snissn/go-crc32-asm"

--- a/TreeDB/internal/crc/crc.go
+++ b/TreeDB/internal/crc/crc.go
@@ -1,13 +1,19 @@
+// Package crc is TreeDB's audited CRC-32 facade.
+//
+// All functions use the CRC-32/IEEE polynomial and preserve the byte-for-byte
+// values produced by github.com/snissn/go-crc32-asm.
 package crc
 
 import crc32 "github.com/snissn/go-crc32-asm"
 
 var table = crc32.MakeTable(crc32.IEEE)
 
+// Checksum returns the CRC-32/IEEE checksum of data.
 func Checksum(data []byte) uint32 {
 	return crc32.Checksum(data, table)
 }
 
+// ChecksumParts returns the CRC-32/IEEE checksum over the concatenation of parts.
 func ChecksumParts(parts ...[]byte) uint32 {
 	sum := uint32(0)
 	for _, p := range parts {
@@ -19,6 +25,7 @@ func ChecksumParts(parts ...[]byte) uint32 {
 	return sum
 }
 
+// Update extends sum with data using the CRC-32/IEEE polynomial.
 func Update(sum uint32, data []byte) uint32 {
 	if len(data) == 0 {
 		return sum

--- a/TreeDB/internal/crc/crc_bench_test.go
+++ b/TreeDB/internal/crc/crc_bench_test.go
@@ -1,0 +1,86 @@
+package crc
+
+import (
+	"fmt"
+	"testing"
+)
+
+var benchmarkCRCSink uint32
+
+func BenchmarkCRCChecksumSizes(b *testing.B) {
+	for _, size := range []int{
+		64,
+		256,
+		4 << 10,
+		16 << 10,
+		64 << 10,
+		1 << 20,
+		4 << 20,
+	} {
+		b.Run(formatCRCSize(size), func(b *testing.B) {
+			buf := deterministicCRCBuf(size)
+			b.SetBytes(int64(len(buf)))
+			b.ReportAllocs()
+			b.ResetTimer()
+			var sum uint32
+			for i := 0; i < b.N; i++ {
+				sum ^= Checksum(buf)
+			}
+			benchmarkCRCSink = sum
+		})
+	}
+}
+
+func BenchmarkCRCUpdateChunked(b *testing.B) {
+	buf := deterministicCRCBuf(4 << 20)
+	const chunk = 16 << 10
+	b.SetBytes(int64(len(buf)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	var sum uint32
+	for i := 0; i < b.N; i++ {
+		var crc uint32
+		for off := 0; off < len(buf); off += chunk {
+			end := off + chunk
+			if end > len(buf) {
+				end = len(buf)
+			}
+			crc = Update(crc, buf[off:end])
+		}
+		sum ^= crc
+	}
+	benchmarkCRCSink = sum
+}
+
+func BenchmarkCRCChecksumParts(b *testing.B) {
+	header := deterministicCRCBuf(16)
+	payload := deterministicCRCBuf(64 << 10)
+	b.SetBytes(int64(len(header) + len(payload)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	var sum uint32
+	for i := 0; i < b.N; i++ {
+		sum ^= ChecksumParts(header, payload)
+	}
+	benchmarkCRCSink = sum
+}
+
+func deterministicCRCBuf(size int) []byte {
+	buf := make([]byte, size)
+	var x uint32 = 0x1851cafe
+	for i := range buf {
+		x = x*1664525 + 1013904223
+		buf[i] = byte(x >> 24)
+	}
+	return buf
+}
+
+func formatCRCSize(size int) string {
+	if size >= 1<<20 && size%(1<<20) == 0 {
+		return fmt.Sprintf("%dMiB", size>>20)
+	}
+	if size >= 1<<10 && size%(1<<10) == 0 {
+		return fmt.Sprintf("%dKiB", size>>10)
+	}
+	return fmt.Sprintf("%dB", size)
+}

--- a/TreeDB/internal/crc/crc_test.go
+++ b/TreeDB/internal/crc/crc_test.go
@@ -1,0 +1,99 @@
+package crc
+
+import (
+	"bytes"
+	stdcrc32 "hash/crc32"
+	"math/rand"
+	"testing"
+)
+
+func TestChecksumIEEEKnownVectors(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		data []byte
+		want uint32
+	}{
+		{name: "empty", data: nil, want: 0x00000000},
+		{name: "digits", data: []byte("123456789"), want: 0xcbf43926},
+		{name: "hello_world", data: []byte("hello world"), want: 0x0d4a1185},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := Checksum(tc.data); got != tc.want {
+				t.Fatalf("Checksum(%q)=0x%08x want 0x%08x", tc.data, got, tc.want)
+			}
+			if got := ChecksumParts(tc.data); got != tc.want {
+				t.Fatalf("ChecksumParts(%q)=0x%08x want 0x%08x", tc.data, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestChecksumIEEERandomizedCompatibility(t *testing.T) {
+	t.Parallel()
+
+	rng := rand.New(rand.NewSource(0x1851c0de))
+	lengths := []int{0, 1, 2, 3, 4, 7, 8, 15, 16, 31, 32, 63, 64, 127, 128, 255, 256, 1024, 4096, 65536}
+	for caseNum := 0; caseNum < 200; caseNum++ {
+		lengths = append(lengths, rng.Intn(128*1024))
+	}
+
+	for _, n := range lengths {
+		data := make([]byte, n)
+		if _, err := rng.Read(data); err != nil {
+			t.Fatalf("rng.Read(%d): %v", n, err)
+		}
+		want := stdcrc32.ChecksumIEEE(data)
+		if got := Checksum(data); got != want {
+			t.Fatalf("Checksum len=%d got=0x%08x want stdlib=0x%08x", n, got, want)
+		}
+	}
+}
+
+func TestUpdateAndChecksumPartsStreamingCompatibility(t *testing.T) {
+	t.Parallel()
+
+	rng := rand.New(rand.NewSource(0x18515ea1))
+	data := make([]byte, 256*1024+333)
+	if _, err := rng.Read(data); err != nil {
+		t.Fatalf("rng.Read: %v", err)
+	}
+	table := stdcrc32.MakeTable(stdcrc32.IEEE)
+
+	for _, chunks := range [][]int{
+		{len(data)},
+		{0, 1, 0, 2, 3, 5, 8, 13, 21, 34, 55, 89},
+		{64, 256, 4096, 16 * 1024, 64 * 1024, 1 << 20},
+	} {
+		var gotUpdate uint32
+		var wantUpdate uint32
+		parts := make([][]byte, 0, len(chunks)+1)
+		off := 0
+		for off < len(data) {
+			for _, chunk := range chunks {
+				end := off + chunk
+				if end > len(data) {
+					end = len(data)
+				}
+				part := data[off:end]
+				parts = append(parts, part)
+				gotUpdate = Update(gotUpdate, part)
+				wantUpdate = stdcrc32.Update(wantUpdate, table, part)
+				off = end
+				if off == len(data) {
+					break
+				}
+			}
+		}
+		if gotUpdate != wantUpdate {
+			t.Fatalf("Update chunks=%v got=0x%08x want stdlib=0x%08x", chunks, gotUpdate, wantUpdate)
+		}
+		if gotParts := ChecksumParts(parts...); gotParts != wantUpdate {
+			t.Fatalf("ChecksumParts chunks=%v got=0x%08x want stdlib=0x%08x", chunks, gotParts, wantUpdate)
+		}
+		if gotWhole := Checksum(bytes.Join(parts, nil)); gotWhole != wantUpdate {
+			t.Fatalf("Checksum joined chunks=%v got=0x%08x want stdlib=0x%08x", chunks, gotWhole, wantUpdate)
+		}
+	}
+}

--- a/TreeDB/internal/typedcolumn/tcs1.go
+++ b/TreeDB/internal/typedcolumn/tcs1.go
@@ -3,7 +3,8 @@ package typedcolumn
 import (
 	"encoding/binary"
 	"fmt"
-	crc32 "github.com/snissn/go-crc32-asm"
+
+	"github.com/snissn/gomap/TreeDB/internal/crc"
 )
 
 const (
@@ -74,7 +75,7 @@ func EncodeTCS1ColumnPartImage(image ColumnPartImage) ([]byte, TCS1PartRecord, e
 	binary.LittleEndian.PutUint64(out[tcs1RowsOffset:tcs1ImageVersionOffset], uint64(image.Rows))
 	binary.LittleEndian.PutUint16(out[tcs1ImageVersionOffset:tcs1ReservedOffset], image.Version)
 	binary.LittleEndian.PutUint16(out[tcs1ReservedOffset:tcs1PayloadCRC32Offset], 0)
-	checksum := crc32.ChecksumIEEE(image.Bytes)
+	checksum := crc.Checksum(image.Bytes)
 	binary.LittleEndian.PutUint32(out[tcs1PayloadCRC32Offset:tcs1PayloadOffset], checksum)
 	copy(out[tcs1PayloadOffset:], image.Bytes)
 	return out, TCS1PartRecord{
@@ -218,7 +219,7 @@ func decodeTCS1Header(data []byte) (TCS1PartRecord, []byte, error) {
 	}
 	wantChecksum := binary.LittleEndian.Uint32(data[tcs1PayloadCRC32Offset:tcs1PayloadOffset])
 	payload := data[tcs1PayloadOffset:]
-	if checksum := crc32.ChecksumIEEE(payload); checksum != wantChecksum {
+	if checksum := crc.Checksum(payload); checksum != wantChecksum {
 		return TCS1PartRecord{}, nil, fmt.Errorf("typedcolumn: TCS1 payload checksum=%08x want %08x", checksum, wantChecksum)
 	}
 	return TCS1PartRecord{

--- a/TreeDB/internal/typedcolumn/tcs1_crc_bench_test.go
+++ b/TreeDB/internal/typedcolumn/tcs1_crc_bench_test.go
@@ -1,0 +1,75 @@
+package typedcolumn
+
+import "testing"
+
+var benchmarkTCS1RowsSink int
+var benchmarkTCS1CRCSink uint32
+
+func BenchmarkTCS1DecodeChecksum(b *testing.B) {
+	const (
+		rows = 8192
+		dims = 128
+	)
+	image := benchmarkTCS1ColumnPartImage(b, rows, dims)
+	tcs1, record, err := EncodeTCS1ColumnPartImage(image)
+	if err != nil {
+		b.Fatalf("EncodeTCS1ColumnPartImage: %v", err)
+	}
+	if record.PayloadBytes == 0 || record.PayloadCRC32 == 0 {
+		b.Fatalf("unexpected TCS1 record: %+v", record)
+	}
+
+	b.SetBytes(int64(len(tcs1)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	var rowSum int
+	var crcSum uint32
+	for i := 0; i < b.N; i++ {
+		decodedImage, decodedRecord, err := DecodeTCS1ColumnPartImage(tcs1)
+		if err != nil {
+			b.Fatalf("DecodeTCS1ColumnPartImage: %v", err)
+		}
+		rowSum += decodedImage.Rows
+		crcSum ^= decodedRecord.PayloadCRC32
+	}
+	b.StopTimer()
+	benchmarkTCS1RowsSink = rowSum
+	benchmarkTCS1CRCSink = crcSum
+	b.ReportMetric(float64(b.N*rows)/b.Elapsed().Seconds(), "rows/s")
+}
+
+func benchmarkTCS1ColumnPartImage(tb testing.TB, rows, dims int) ColumnPartImage {
+	tb.Helper()
+	ids := make([]int64, rows)
+	values := make([]float32, rows*dims)
+	for row := 0; row < rows; row++ {
+		ids[row] = int64(row)
+		for dim := 0; dim < dims; dim++ {
+			values[row*dims+dim] = float32((row+1)*(dim+3)%997) / 997
+		}
+	}
+	part, err := BuildColumnPart(1851, Options{
+		SchemaVersion: 1,
+		SchemaMode:    ColumnSchemaFixed,
+		Columns: []ColumnDefinition{
+			{Name: "id", Type: ColumnTypeInt64, Encoding: EncodingRawInt64, Compression: CompressionNone, CompressionSet: true},
+			{Name: "embedding", Type: ColumnTypeFloat32Vector, Encoding: EncodingRawFloat32Vector, Compression: CompressionNone, CompressionSet: true, FixedWidthElements: dims},
+		},
+		LogicalPrimaryKey: LogicalPrimaryKey{Columns: []string{"id"}},
+		SortKey:           SortKey{Columns: []SortKeyColumn{{Column: "id"}}},
+		PartPolicy:        ColumnPartPolicy{RowsPerGranule: rows},
+		Compression:       ColumnCompressionPolicy{Default: CompressionNone},
+	}, Batch{Rows: rows, Columns: map[string][]int64{"id": ids}, Float32Vectors: map[string][]float32{"embedding": values}})
+	if err != nil {
+		tb.Fatalf("BuildColumnPart: %v", err)
+	}
+	image, err := BuildColumnPartImage(part, ColumnPartImageOptions{})
+	if err != nil {
+		tb.Fatalf("BuildColumnPartImage: %v", err)
+	}
+	parsed, err := ParseColumnPartImage(image.Bytes)
+	if err != nil {
+		tb.Fatalf("ParseColumnPartImage: %v", err)
+	}
+	return parsed
+}

--- a/TreeDB/internal/valuelog/crc_bench_test.go
+++ b/TreeDB/internal/valuelog/crc_bench_test.go
@@ -1,0 +1,42 @@
+package valuelog
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/internal/crc"
+)
+
+var benchmarkValueLogCRCSink uint32
+
+func BenchmarkValueLogRecordChecksumParts(b *testing.B) {
+	var header [HeaderSize]byte
+	payload := deterministicValueLogCRCBuf(64 << 10)
+	header[4] = Version
+	binary.LittleEndian.PutUint64(header[8:16], 0x1851)
+	binary.LittleEndian.PutUint32(header[16:20], uint32(len(payload)))
+	want := crc.ChecksumParts(header[4:], payload)
+
+	b.SetBytes(int64(len(header[4:]) + len(payload)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	var sum uint32
+	for i := 0; i < b.N; i++ {
+		got := crc.ChecksumParts(header[4:], payload)
+		if got != want {
+			b.Fatalf("checksum=0x%08x want 0x%08x", got, want)
+		}
+		sum ^= got
+	}
+	benchmarkValueLogCRCSink = sum
+}
+
+func deterministicValueLogCRCBuf(size int) []byte {
+	buf := make([]byte, size)
+	var x uint64 = 0x1851f00d12345678
+	for i := range buf {
+		x = x*2862933555777941757 + 3037000493
+		buf[i] = byte(x >> 56)
+	}
+	return buf
+}

--- a/TreeDB/page/crc_bench_test.go
+++ b/TreeDB/page/crc_bench_test.go
@@ -16,11 +16,11 @@ func BenchmarkPageChecksumUpdateVerify(b *testing.B) {
 		buf[16] = byte(i)
 		sum ^= UpdateChecksum(buf)
 		ok = VerifyChecksumNonMutating(buf)
+		if !ok {
+			b.Fatal("checksum verification failed")
+		}
 	}
 	b.StopTimer()
-	if !ok {
-		b.Fatal("checksum verification failed")
-	}
 	benchmarkPageCRCSink = sum
 	benchmarkPageBoolSink = ok
 }
@@ -34,11 +34,11 @@ func BenchmarkPageChecksumVerifyOnly(b *testing.B) {
 	var ok bool
 	for i := 0; i < b.N; i++ {
 		ok = VerifyChecksumNonMutating(buf)
+		if !ok {
+			b.Fatal("checksum verification failed")
+		}
 	}
 	b.StopTimer()
-	if !ok {
-		b.Fatal("checksum verification failed")
-	}
 	benchmarkPageBoolSink = ok
 }
 

--- a/TreeDB/page/crc_bench_test.go
+++ b/TreeDB/page/crc_bench_test.go
@@ -1,0 +1,55 @@
+package page
+
+import "testing"
+
+var benchmarkPageCRCSink uint32
+var benchmarkPageBoolSink bool
+
+func BenchmarkPageChecksumUpdateVerify(b *testing.B) {
+	buf := deterministicPageCRCBuf(PageSize)
+	b.SetBytes(int64(len(buf)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	var sum uint32
+	var ok bool
+	for i := 0; i < b.N; i++ {
+		buf[16] = byte(i)
+		sum ^= UpdateChecksum(buf)
+		ok = VerifyChecksumNonMutating(buf)
+	}
+	b.StopTimer()
+	if !ok {
+		b.Fatal("checksum verification failed")
+	}
+	benchmarkPageCRCSink = sum
+	benchmarkPageBoolSink = ok
+}
+
+func BenchmarkPageChecksumVerifyOnly(b *testing.B) {
+	buf := deterministicPageCRCBuf(PageSize)
+	UpdateChecksum(buf)
+	b.SetBytes(int64(len(buf)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	var ok bool
+	for i := 0; i < b.N; i++ {
+		ok = VerifyChecksumNonMutating(buf)
+	}
+	b.StopTimer()
+	if !ok {
+		b.Fatal("checksum verification failed")
+	}
+	benchmarkPageBoolSink = ok
+}
+
+func deterministicPageCRCBuf(size int) []byte {
+	buf := make([]byte, size)
+	var x uint32 = 0x9e3779b9
+	for i := range buf {
+		x ^= x << 13
+		x ^= x >> 17
+		x ^= x << 5
+		buf[i] = byte(x)
+	}
+	return buf
+}

--- a/TreeDB/page/page.go
+++ b/TreeDB/page/page.go
@@ -3,8 +3,9 @@ package page
 import (
 	"encoding/binary"
 	"errors"
-	crc32 "github.com/snissn/go-crc32-asm"
 	"unsafe"
+
+	"github.com/snissn/gomap/TreeDB/internal/crc"
 )
 
 var ErrInvalidPageType = errors.New("invalid page type")
@@ -66,14 +67,12 @@ type ValuePtr struct {
 	FileID uint32
 }
 
-// CRC-32/IEEE table.
-var crcTable = crc32.MakeTable(crc32.IEEE)
 var checksumZeroField = [4]byte{}
 var checksumZeroBlock = [1024]byte{}
 
 // Checksum returns the CRC-32/IEEE checksum of data.
 func Checksum(data []byte) uint32 {
-	return crc32.Checksum(data, crcTable)
+	return crc.Checksum(data)
 }
 
 // CalculateChecksum computes the checksum of the page data,
@@ -83,9 +82,9 @@ func CalculateChecksum(data []byte) uint32 {
 		return 0
 	}
 	// CRC over bytes 0-7, then the zeroed checksum field (bytes 8-11), then the rest.
-	sum := crc32.Update(0, crcTable, data[0:8])
-	sum = crc32.Update(sum, crcTable, checksumZeroField[:])
-	sum = crc32.Update(sum, crcTable, data[12:])
+	sum := crc.Update(0, data[0:8])
+	sum = crc.Update(sum, checksumZeroField[:])
+	sum = crc.Update(sum, data[12:])
 	return sum
 }
 
@@ -99,12 +98,12 @@ func CalculateChecksumWithZeroGap(prefix []byte, gapLen int, suffix []byte) uint
 	if gapLen < 0 {
 		panic("page: checksum zero-gap length is negative")
 	}
-	sum := crc32.Update(0, crcTable, prefix[0:8])
-	sum = crc32.Update(sum, crcTable, checksumZeroField[:])
-	sum = crc32.Update(sum, crcTable, prefix[12:])
+	sum := crc.Update(0, prefix[0:8])
+	sum = crc.Update(sum, checksumZeroField[:])
+	sum = crc.Update(sum, prefix[12:])
 	sum = updateChecksumZeroes(sum, gapLen)
 	if len(suffix) > 0 {
-		sum = crc32.Update(sum, crcTable, suffix)
+		sum = crc.Update(sum, suffix)
 	}
 	return sum
 }
@@ -115,7 +114,7 @@ func updateChecksumZeroes(sum uint32, count int) uint32 {
 		if n > len(checksumZeroBlock) {
 			n = len(checksumZeroBlock)
 		}
-		sum = crc32.Update(sum, crcTable, checksumZeroBlock[:n])
+		sum = crc.Update(sum, checksumZeroBlock[:n])
 		count -= n
 	}
 	return sum
@@ -133,7 +132,7 @@ func UpdateChecksum(data []byte) uint32 {
 	data[9] = 0
 	data[10] = 0
 	data[11] = 0
-	sum := crc32.Checksum(data, crcTable)
+	sum := crc.Checksum(data)
 	binary.LittleEndian.PutUint32(data[8:12], sum)
 	return sum
 }

--- a/TreeDB/template/def.go
+++ b/TreeDB/template/def.go
@@ -3,8 +3,8 @@ package template
 import (
 	"encoding/binary"
 	"errors"
-	crc32 "github.com/snissn/go-crc32-asm"
 
+	"github.com/snissn/gomap/TreeDB/internal/crc"
 	"github.com/zeebo/xxh3"
 )
 
@@ -17,8 +17,6 @@ const (
 var (
 	ErrCorruptTemplateDef = errors.New("template: corrupt template def")
 )
-
-var crcTable = crc32.MakeTable(crc32.IEEE)
 
 // EncodeTemplateDef serializes anchors into the TemplateDefBytes format.
 func EncodeTemplateDef(def TemplateDef, cfg Config) ([]byte, error) {
@@ -54,8 +52,8 @@ func EncodeTemplateDef(def TemplateDef, cfg Config) ([]byte, error) {
 			copy(buf[off:], a)
 			off += len(a)
 		}
-		crc := crc32.Checksum(buf[:off], crcTable)
-		binary.LittleEndian.PutUint32(buf[off:], crc)
+		checksum := crc.Checksum(buf[:off])
+		binary.LittleEndian.PutUint32(buf[off:], checksum)
 		off += 4
 		if off != len(buf) {
 			return nil, ErrCorruptTemplateDef
@@ -109,8 +107,8 @@ func EncodeTemplateDef(def TemplateDef, cfg Config) ([]byte, error) {
 	}
 	copy(buf[off:], def.Base)
 	off += len(def.Base)
-	crc := crc32.Checksum(buf[:off], crcTable)
-	binary.LittleEndian.PutUint32(buf[off:], crc)
+	checksum := crc.Checksum(buf[:off])
+	binary.LittleEndian.PutUint32(buf[off:], checksum)
 	off += 4
 	if off != len(buf) {
 		return nil, ErrCorruptTemplateDef
@@ -128,7 +126,7 @@ func DecodeTemplateDef(buf []byte) (TemplateDef, error) {
 	}
 	payloadLen := len(buf) - 4
 	crcWant := binary.LittleEndian.Uint32(buf[payloadLen:])
-	crcGot := crc32.Checksum(buf[:payloadLen], crcTable)
+	crcGot := crc.Checksum(buf[:payloadLen])
 	if crcGot != crcWant {
 		return TemplateDef{}, ErrCorruptTemplateDef
 	}


### PR DESCRIPTION
## Summary

Closes #1851. Part of tracker #1836 layer 1b.

- Centralizes TreeDB CRC-32/IEEE computation through `TreeDB/internal/crc`, backed by `github.com/snissn/go-crc32-asm`.
- Routes production TreeDB checksum sites that directly imported `go-crc32-asm` through the wrapper: page checksums, typed-column TCS1 payload checksums, template definition checksums, value-log ref-count metadata checksums, and TreeDB test helpers.
- Adds wrapper compatibility tests and representative checksum benchmarks for raw CRC sizes, page update/verify, value-log record checksum parts, TCS1 typed-column decode/checksum, and column physical asset verification.

## Scope / non-goals

No on-disk checksum bytes, polynomial, little-endian storage, read-integrity modes, query/storage semantics, or fail-closed behavior are changed. This does not implement #1844, #1837, #1850, #1849, or any new public `ColumnStoreValueType`.

## Call-site inventory

Production TreeDB CRC32 paths now route through the wrapper/facade:

- `TreeDB/internal/crc`: sole direct production import of `github.com/snissn/go-crc32-asm`; exposes `Checksum`, `ChecksumParts`, and `Update` using CRC-32/IEEE.
- `TreeDB/page`: page/data checksum APIs and page checksum-zero-field helpers use `internal/crc`.
- `TreeDB/internal/commitlog`: already used `internal/crc`; rerun tests cover WAL/commitlog checksum paths.
- `TreeDB/internal/valuelog`: already used `internal/crc`; new benchmark covers record `ChecksumParts` shape.
- `TreeDB/internal/typedcolumn`: TCS1 payload checksums now use `internal/crc`.
- `TreeDB/template`: template definition checksums now use `internal/crc`.
- `TreeDB/db/vlog_gc_incremental.go`: value-log ref-count metadata checksum now uses `internal/crc`.
- `TreeDB/collections`: column/typed asset checksum paths route via `page.Checksum` -> `internal/crc`; benchmark covers strict and cached-verify prepare-miss asset verification.

Justified exceptions:

- `TreeDB/internal/crc/crc_test.go` imports stdlib `hash/crc32` only as the compatibility reference.
- `experiments/*` still imports `go-crc32-asm` directly; these are outside `TreeDB/internal` visibility and are non-production experiments / hash tournament coverage.

## Compatibility and fallback

`internal/crc` documents that the wrapper remains bit-compatible with `hash/crc32.ChecksumIEEE`/`Update`. The go-crc32-asm dependency selects architecture acceleration when available and otherwise uses a bit-compatible fallback; either path remains a fail-closed verification primitive.

New tests cover:

- Known IEEE vectors: empty, `123456789` = `0xcbf43926`, `hello world` = `0x0d4a1185`.
- Randomized compatibility against stdlib `hash/crc32.ChecksumIEEE`.
- Streaming/chunked `Update` and `ChecksumParts` compatibility against stdlib `Update`.

## Fail-closed evidence

Rerun tests include existing corruption/integrity coverage:

- Page checksum update/verify: `TreeDB/page` tests.
- Commitlog/WAL corruption: `TreeDB/internal/commitlog` and DB command-WAL corruption tests via `./TreeDB/db`.
- Value-log corruption: `TreeDB/internal/valuelog` and `./TreeDB/db` tests.
- Column physical asset corruption and read-integrity modes: `TreeDB/collections` tests.
- Typed-column/TCS1/manifest fail-closed corruption: `TreeDB/internal/typedcolumn` and `TreeDB/collections` tests.

## Tests run

- `go test ./TreeDB/internal/crc ./TreeDB/page ./TreeDB/internal/typedcolumn ./TreeDB/template ./TreeDB/internal/commitlog ./TreeDB/internal/valuelog ./TreeDB/collections`
- `go test ./TreeDB/db`
- `go test ./TreeDB/internal/crc ./TreeDB/page ./TreeDB/internal/typedcolumn ./TreeDB/template ./TreeDB/internal/commitlog ./TreeDB/internal/valuelog ./TreeDB/collections ./TreeDB/db`
- `go test ./TreeDB/...`
- `go test -run '^$' -bench 'BenchmarkCRC|BenchmarkPageChecksum|BenchmarkValueLogRecordChecksumParts|BenchmarkTCS1DecodeChecksum|BenchmarkColumnPhysicalAssetChecksumVerify' -benchmem -benchtime=1s -count=1 ./TreeDB/internal/crc ./TreeDB/page ./TreeDB/internal/valuelog ./TreeDB/internal/typedcolumn ./TreeDB/collections`

## Benchmark environment

- CPU/arch: Apple M3, `darwin/arm64`
- Go: `go1.25.5 darwin/arm64`
- go-crc32-asm: `github.com/snissn/go-crc32-asm v0.0.0-20260522204125-08945951423a`
- Evidence type: current-wrapper evidence; old direct production imports already used the same go-crc32-asm dependency, so this PR verifies wrapper routing and no-allocation hot-path throughput rather than claiming a semantic before/after format change.

## Benchmarks

| Benchmark | ns/op | Throughput | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: |
| `BenchmarkCRCChecksumSizes/64B-8` | 8.195 | 7,809.18 MB/s | 0 | 0 |
| `BenchmarkCRCChecksumSizes/256B-8` | 17.02 | 15,043.08 MB/s | 0 | 0 |
| `BenchmarkCRCChecksumSizes/4KiB-8` | 112.6 | 36,384.80 MB/s | 0 | 0 |
| `BenchmarkCRCChecksumSizes/16KiB-8` | 312.3 | 52,462.17 MB/s | 0 | 0 |
| `BenchmarkCRCChecksumSizes/64KiB-8` | 1,136 | 57,687.03 MB/s | 0 | 0 |
| `BenchmarkCRCChecksumSizes/1MiB-8` | 17,495 | 59,935.28 MB/s | 0 | 0 |
| `BenchmarkCRCChecksumSizes/4MiB-8` | 70,185 | 59,761.00 MB/s | 0 | 0 |
| `BenchmarkCRCUpdateChunked-8` | 99,834 | 42,012.62 MB/s | 0 | 0 |
| `BenchmarkCRCChecksumParts-8` | 1,183 | 55,410.06 MB/s | 0 | 0 |
| `BenchmarkPageChecksumUpdateVerify-8` | 337.4 | 12,139.49 MB/s | 0 | 0 |
| `BenchmarkPageChecksumVerifyOnly-8` | 163.7 | 25,027.75 MB/s | 0 | 0 |
| `BenchmarkValueLogRecordChecksumParts-8` | 1,193 | 54,968.50 MB/s | 0 | 0 |
| `BenchmarkTCS1DecodeChecksum-8` | 76,048 | 59,474.53 MB/s; 107,721,221 rows/s | 792 | 7 |
| `BenchmarkColumnPhysicalAssetChecksumVerify/strict_verify-8` | 69,640 | 60,228.58 MB/s | 0 | 0 |
| `BenchmarkColumnPhysicalAssetChecksumVerify/cached_verify_prepare_miss-8` | 67,815 | 61,849.14 MB/s | 0 | 0 |

## Review status

- Internal Orca xhigh review: PASS, no blocking findings.
- Codex: requested with `@codex review`; result: "Didn't find any major issues."
- Copilot: requested with `@copilot review`; reviewed 13/13 files and generated no comments.
- CodeRabbit: requested with `@coderabbitai review`; no actionable comments generated. Its docstring-coverage pre-merge warning is repo-wide informational and not a finding against this PR's exported wrapper APIs, which are documented.
- Latest-head CI for `484ddfa69f772037addb4ce2491c6cb4d08f4a13`: all checks passing.
