### PR TITLE
Build shared typed-column row selection model

### DIFF
--- a/TreeDB/collections/typed_column_adapter.go
+++ b/TreeDB/collections/typed_column_adapter.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"math/bits"
 	"sort"
 
 	"github.com/snissn/gomap/TreeDB/internal/columnsemantics"
@@ -1731,8 +1732,11 @@ func scanTypedColumnInt64PredicateAggregatePartWithVisibility(part *typedcolumn.
 type typedColumnInt64PredicateAggregateScanScratch struct {
 	// GranuleReader only retains decode/decompression scratch and is safe to
 	// reuse across immutable typed-column parts within the session lifetime.
-	reader typedcolumn.GranuleReader
-	values []int64
+	reader         typedcolumn.GranuleReader
+	values         []int64
+	predicateRows  []int
+	visibilityRows []int
+	selection      typedcolumn.RowSelectionScratch
 }
 
 func scanTypedColumnInt64PredicateAggregatePartWithVisibilityAndScratch(part *typedcolumn.ColumnPart, valueColumn string, req TypedColumnInt64PredicateScanRequest, result *TypedColumnInt64PredicateAggregateResult, visibility *typedColumnLatestPhysicalPart, scratch *typedColumnInt64PredicateAggregateScanScratch) (bool, error) {
@@ -1756,6 +1760,11 @@ func scanTypedColumnInt64PredicateAggregatePartWithVisibilityAndScratch(part *ty
 		g := block.Granule
 		if g.HasMinMax && !typedColumnInt64PredicateMayMatch(req, g.Min, g.Max) {
 			result.Diagnostics.BlocksPruned++
+			selection, err := typedcolumn.NewEmptyRowSelection(block.Descriptor.RowCount)
+			if err != nil {
+				return false, err
+			}
+			recordTypedColumnSelectionDiagnostics(&result.Diagnostics, selection)
 			continue
 		}
 		values, err := scratch.reader.DecodeInt64Into(scratch.values[:0], g)
@@ -1770,21 +1779,163 @@ func scanTypedColumnInt64PredicateAggregatePartWithVisibilityAndScratch(part *ty
 		result.Diagnostics.BlocksDecoded++
 		result.Diagnostics.DecodedHeapCopyBytes += uint64(g.RawBytes)
 		result.Diagnostics.RowsScanned += len(values)
-		for i, v := range values {
-			rowIndex := block.Descriptor.FirstRow + i
-			if visibility != nil && !visibility.rowVisible(rowIndex) {
-				continue
-			}
-			if !typedColumnInt64PredicateMatches(req, v) {
-				continue
-			}
-			if err := addTypedColumnInt64PredicateAggregateValue(result, v); err != nil {
+
+		selection, err := typedColumnInt64PredicateAggregateBlockSelection(req, g, values, scratch)
+		if err != nil {
+			return false, err
+		}
+		if visibility != nil && !selection.IsEmpty() {
+			visibilitySelection, err := typedColumnInt64VisibilitySelectionForBlock(visibility, block.Descriptor.FirstRow, block.Descriptor.RowCount, scratch)
+			if err != nil {
 				return false, err
 			}
-			result.Diagnostics.RowsMatched++
+			selection, err = typedcolumn.ComposeRowSelectionsInto(block.Descriptor.RowCount, typedcolumn.RowSelectionComponents{Predicate: &selection, Visibility: &visibilitySelection}, &scratch.selection)
+			if err != nil {
+				return false, err
+			}
+			result.Diagnostics.SelectionCompositions++
+		}
+		recordTypedColumnSelectionDiagnostics(&result.Diagnostics, selection)
+		if selection.IsEmpty() {
+			continue
+		}
+		if err := addTypedColumnInt64AggregateSelectedValues(result, values, selection); err != nil {
+			return false, err
 		}
 	}
 	return !decodedAny && len(valueCol.Blocks) != 0, nil
+}
+
+func typedColumnInt64PredicateAggregateBlockSelection(req TypedColumnInt64PredicateScanRequest, g typedcolumn.EncodedGranule, values []int64, scratch *typedColumnInt64PredicateAggregateScanScratch) (typedcolumn.RowSelection, error) {
+	rows := len(values)
+	if rows == 0 {
+		return typedcolumn.NewEmptyRowSelection(0)
+	}
+	if typedColumnInt64PredicateCoversGranule(req, g) {
+		return typedcolumn.NewAllRowSelection(rows)
+	}
+	scratch.predicateRows = scratch.predicateRows[:0]
+	for i, v := range values {
+		if typedColumnInt64PredicateMatches(req, v) {
+			scratch.predicateRows = append(scratch.predicateRows, i)
+		}
+	}
+	return typedcolumn.NewSparseRowSelectionNoCopy(rows, scratch.predicateRows)
+}
+
+func typedColumnInt64PredicateCoversGranule(req TypedColumnInt64PredicateScanRequest, g typedcolumn.EncodedGranule) bool {
+	switch req.Kind {
+	case TypedColumnInt64PredicateAll:
+		return true
+	case TypedColumnInt64PredicateEqual:
+		return g.HasMinMax && g.Min == req.Value && g.Max == req.Value
+	case TypedColumnInt64PredicateRange:
+		return g.HasMinMax && req.Low <= g.Min && req.High >= g.Max
+	default:
+		return false
+	}
+}
+
+func typedColumnInt64VisibilitySelectionForBlock(visibility *typedColumnLatestPhysicalPart, firstRow int, rowCount int, scratch *typedColumnInt64PredicateAggregateScanScratch) (typedcolumn.RowSelection, error) {
+	if visibility == nil {
+		return typedcolumn.NewAllRowSelection(rowCount)
+	}
+	scratch.visibilityRows = scratch.visibilityRows[:0]
+	for offset := 0; offset < rowCount; offset++ {
+		if visibility.rowVisible(firstRow + offset) {
+			scratch.visibilityRows = append(scratch.visibilityRows, offset)
+		}
+	}
+	return typedcolumn.NewSparseRowSelectionNoCopy(rowCount, scratch.visibilityRows)
+}
+
+func addTypedColumnInt64AggregateSelectedValues(result *TypedColumnInt64PredicateAggregateResult, values []int64, selection typedcolumn.RowSelection) error {
+	switch selection.Kind() {
+	case typedcolumn.RowSelectionEmpty:
+		return nil
+	case typedcolumn.RowSelectionAll:
+		for _, v := range values {
+			if err := addTypedColumnInt64PredicateAggregateValue(result, v); err != nil {
+				return err
+			}
+			result.Diagnostics.RowsMatched++
+		}
+		return nil
+	case typedcolumn.RowSelectionRange:
+		start, end, ok := selection.SingleRange()
+		if !ok || start < 0 || end > len(values) {
+			return fmt.Errorf("typed-column int64 aggregate invalid range selection [%d,%d) values=%d", start, end, len(values))
+		}
+		for _, v := range values[start:end] {
+			if err := addTypedColumnInt64PredicateAggregateValue(result, v); err != nil {
+				return err
+			}
+			result.Diagnostics.RowsMatched++
+		}
+		return nil
+	case typedcolumn.RowSelectionRanges:
+		for _, r := range selection.Ranges() {
+			if r.Start < 0 || r.End < r.Start || r.End > len(values) {
+				return fmt.Errorf("typed-column int64 aggregate invalid ranges selection [%d,%d) values=%d", r.Start, r.End, len(values))
+			}
+			for _, v := range values[r.Start:r.End] {
+				if err := addTypedColumnInt64PredicateAggregateValue(result, v); err != nil {
+					return err
+				}
+				result.Diagnostics.RowsMatched++
+			}
+		}
+		return nil
+	case typedcolumn.RowSelectionSparse:
+		for _, row := range selection.SparseRows() {
+			if row < 0 || row >= len(values) {
+				return fmt.Errorf("typed-column int64 aggregate sparse row=%d values=%d", row, len(values))
+			}
+			if err := addTypedColumnInt64PredicateAggregateValue(result, values[row]); err != nil {
+				return err
+			}
+			result.Diagnostics.RowsMatched++
+		}
+		return nil
+	case typedcolumn.RowSelectionBitmap:
+		for wordIndex, word := range selection.BitmapWords() {
+			for word != 0 {
+				bit := bits.TrailingZeros64(word)
+				row := wordIndex*64 + bit
+				if row >= len(values) {
+					break
+				}
+				if err := addTypedColumnInt64PredicateAggregateValue(result, values[row]); err != nil {
+					return err
+				}
+				result.Diagnostics.RowsMatched++
+				word &^= uint64(1) << uint(bit)
+			}
+		}
+		return nil
+	default:
+		return fmt.Errorf("typed-column int64 aggregate unsupported selection shape %s", selection.Shape().Kind)
+	}
+}
+
+func recordTypedColumnSelectionDiagnostics(diag *TypedColumnInt64PredicateScanDiagnostics, selection typedcolumn.RowSelection) {
+	if diag == nil {
+		return
+	}
+	switch selection.Kind() {
+	case typedcolumn.RowSelectionEmpty:
+		diag.SelectionEmptyBlocks++
+	case typedcolumn.RowSelectionAll:
+		diag.SelectionAllBlocks++
+	case typedcolumn.RowSelectionRange:
+		diag.SelectionRangeBlocks++
+	case typedcolumn.RowSelectionRanges:
+		diag.SelectionRangesBlocks++
+	case typedcolumn.RowSelectionBitmap:
+		diag.SelectionBitmapBlocks++
+	case typedcolumn.RowSelectionSparse:
+		diag.SelectionSparseBlocks++
+	}
 }
 
 type typedColumnStringPredicateScanScratch struct {

--- a/TreeDB/collections/typed_column_conformance_test.go
+++ b/TreeDB/collections/typed_column_conformance_test.go
@@ -228,98 +228,69 @@ func TestTypedColumnAdapterSemanticConformanceSmallRows(t *testing.T) {
 	}
 }
 
-type typedColumnTestSelectionKind string
-
-const (
-	typedColumnTestSelectionEmpty  typedColumnTestSelectionKind = "empty"
-	typedColumnTestSelectionAll    typedColumnTestSelectionKind = "all"
-	typedColumnTestSelectionRange  typedColumnTestSelectionKind = "range"
-	typedColumnTestSelectionBitmap typedColumnTestSelectionKind = "bitmap"
-	typedColumnTestSelectionSparse typedColumnTestSelectionKind = "sparse"
-)
-
-type typedColumnTestSelection struct {
-	kind   typedColumnTestSelectionKind
-	rows   int
-	start  int
-	end    int
-	bitmap []bool
-	sparse []int
-}
-
-func typedColumnTestSelectionRows(sel typedColumnTestSelection, visible, nulls, defaults []bool) []int {
-	if sel.rows <= 0 {
-		return nil
+func TestTypedColumnSelectionMaskConformance(t *testing.T) {
+	visible := mustConformanceMaskSelection(t, []bool{true, true, false, true, true, true, true, false})
+	nulls := mustConformanceMaskSelection(t, []bool{false, true, false, false, false, false, true, false})
+	defaults := mustConformanceMaskSelection(t, []bool{false, false, false, false, true, false, false, false})
+	bitmapWords := []uint64{0}
+	for _, row := range []int{0, 1, 4, 5, 7} {
+		bitmapWords[0] |= uint64(1) << uint(row)
 	}
-	out := make([]int, 0, sel.rows)
-	appendIfLive := func(row int) {
-		if row < 0 || row >= sel.rows {
-			return
-		}
-		if len(visible) != 0 && !visible[row] {
-			return
-		}
-		if len(nulls) != 0 && nulls[row] {
-			return
-		}
-		if len(defaults) != 0 && defaults[row] {
-			return
-		}
-		out = append(out, row)
+	bitmapSel, err := typedcolumn.NewBitmapRowSelection(8, bitmapWords)
+	if err != nil {
+		t.Fatalf("NewBitmapRowSelection: %v", err)
 	}
-	switch sel.kind {
-	case typedColumnTestSelectionEmpty:
-		return nil
-	case typedColumnTestSelectionAll:
-		for row := 0; row < sel.rows; row++ {
-			appendIfLive(row)
-		}
-	case typedColumnTestSelectionRange:
-		start, end := sel.start, sel.end
-		if start < 0 {
-			start = 0
-		}
-		if end > sel.rows {
-			end = sel.rows
-		}
-		for row := start; row < end; row++ {
-			appendIfLive(row)
-		}
-	case typedColumnTestSelectionBitmap:
-		limit := min(sel.rows, len(sel.bitmap))
-		for row := 0; row < limit; row++ {
-			if sel.bitmap[row] {
-				appendIfLive(row)
-			}
-		}
-	case typedColumnTestSelectionSparse:
-		for _, row := range sel.sparse {
-			appendIfLive(row)
-		}
+	emptySel, err := typedcolumn.NewEmptyRowSelection(8)
+	if err != nil {
+		t.Fatalf("NewEmptyRowSelection: %v", err)
 	}
-	return out
-}
-
-func TestTypedColumnSelectionMaskConformancePlaceholder(t *testing.T) {
-	visible := []bool{true, true, false, true, true, true, true, false}
-	nulls := []bool{false, true, false, false, false, false, true, false}
-	defaults := []bool{false, false, false, false, true, false, false, false}
+	allSel, err := typedcolumn.NewAllRowSelection(8)
+	if err != nil {
+		t.Fatalf("NewAllRowSelection: %v", err)
+	}
+	rangeSel, err := typedcolumn.NewRangeRowSelection(8, 2, 7)
+	if err != nil {
+		t.Fatalf("NewRangeRowSelection: %v", err)
+	}
+	sparseSel, err := typedcolumn.NewSparseRowSelection(8, []int{0, 3, 6})
+	if err != nil {
+		t.Fatalf("NewSparseRowSelection: %v", err)
+	}
 	tests := []struct {
 		name string
-		sel  typedColumnTestSelection
+		sel  typedcolumn.RowSelection
 		want []int
 	}{
-		{name: "empty", sel: typedColumnTestSelection{kind: typedColumnTestSelectionEmpty, rows: 8}, want: nil},
-		{name: "all", sel: typedColumnTestSelection{kind: typedColumnTestSelectionAll, rows: 8}, want: []int{0, 3, 5}},
-		{name: "range", sel: typedColumnTestSelection{kind: typedColumnTestSelectionRange, rows: 8, start: 2, end: 7}, want: []int{3, 5}},
-		{name: "bitmap", sel: typedColumnTestSelection{kind: typedColumnTestSelectionBitmap, rows: 8, bitmap: []bool{true, true, false, false, true, true, false, true}}, want: []int{0, 5}},
-		{name: "sparse", sel: typedColumnTestSelection{kind: typedColumnTestSelectionSparse, rows: 8, sparse: []int{6, 3, 0}}, want: []int{3, 0}},
+		{name: "empty", sel: emptySel, want: nil},
+		{name: "all", sel: allSel, want: []int{0, 3, 5}},
+		{name: "range", sel: rangeSel, want: []int{3, 5}},
+		{name: "bitmap", sel: bitmapSel, want: []int{0, 5}},
+		{name: "sparse", sel: sparseSel, want: []int{0, 3}},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := typedColumnTestSelectionRows(tc.sel, visible, nulls, defaults); !slices.Equal(got, tc.want) {
-				t.Fatalf("selection rows=%v want %v", got, tc.want)
+			gotSel, err := typedcolumn.ComposeRowSelections(8, typedcolumn.RowSelectionComponents{Predicate: &tc.sel, Visibility: &visible, Nulls: &nulls, Defaults: &defaults})
+			if err != nil {
+				t.Fatalf("ComposeRowSelections: %v", err)
+			}
+			if got := gotSel.AppendRows(nil); !slices.Equal(got, tc.want) {
+				t.Fatalf("selection rows=%v want %v shape=%+v", got, tc.want, gotSel.Shape())
 			}
 		})
 	}
+}
+
+func mustConformanceMaskSelection(t *testing.T, mask []bool) typedcolumn.RowSelection {
+	t.Helper()
+	rows := make([]int, 0, len(mask))
+	for row, ok := range mask {
+		if ok {
+			rows = append(rows, row)
+		}
+	}
+	selection, err := typedcolumn.NewSparseRowSelection(len(mask), rows)
+	if err != nil {
+		t.Fatalf("NewSparseRowSelection mask: %v", err)
+	}
+	return selection
 }

--- a/TreeDB/collections/typed_column_int64_scan.go
+++ b/TreeDB/collections/typed_column_int64_scan.go
@@ -63,6 +63,14 @@ type TypedColumnInt64PredicateScanDiagnostics struct {
 	BlocksPruned     int
 	BlocksDecoded    int
 
+	SelectionEmptyBlocks  int
+	SelectionAllBlocks    int
+	SelectionRangeBlocks  int
+	SelectionRangesBlocks int
+	SelectionBitmapBlocks int
+	SelectionSparseBlocks int
+	SelectionCompositions int
+
 	DirectTypedColumnAssetReads int
 	FullAssetReads              int
 	FallbackReads               int
@@ -898,6 +906,13 @@ func addTypedColumnInt64PredicateAggregateDiagnostics(dst *TypedColumnInt64Predi
 	dst.BlocksConsidered += src.BlocksConsidered
 	dst.BlocksPruned += src.BlocksPruned
 	dst.BlocksDecoded += src.BlocksDecoded
+	dst.SelectionEmptyBlocks += src.SelectionEmptyBlocks
+	dst.SelectionAllBlocks += src.SelectionAllBlocks
+	dst.SelectionRangeBlocks += src.SelectionRangeBlocks
+	dst.SelectionRangesBlocks += src.SelectionRangesBlocks
+	dst.SelectionBitmapBlocks += src.SelectionBitmapBlocks
+	dst.SelectionSparseBlocks += src.SelectionSparseBlocks
+	dst.SelectionCompositions += src.SelectionCompositions
 	dst.DirectTypedColumnAssetReads += src.DirectTypedColumnAssetReads
 	dst.FullAssetReads += src.FullAssetReads
 	dst.FallbackReads += src.FallbackReads

--- a/TreeDB/collections/typed_column_int64_scan_test.go
+++ b/TreeDB/collections/typed_column_int64_scan_test.go
@@ -511,6 +511,34 @@ func TestTypedColumnInt64AggregateAllPrunedZero(t *testing.T) {
 	if result.Diagnostics.RowsScanned != 0 || result.Diagnostics.RowsMatched != 0 || result.Diagnostics.PartsPruned != 2 || result.Diagnostics.BlocksDecoded != 0 {
 		t.Fatalf("diagnostics=%+v want all pruned zero aggregate", result.Diagnostics)
 	}
+	if result.Diagnostics.SelectionEmptyBlocks == 0 || result.Diagnostics.SelectionAllBlocks != 0 || result.Diagnostics.SelectionSparseBlocks != 0 {
+		t.Fatalf("diagnostics=%+v want shared empty selection diagnostics for pruned blocks", result.Diagnostics)
+	}
+}
+
+func TestTypedColumnInt64AggregateSelectionShapes(t *testing.T) {
+	d, col := setupTypedColumnInt64ScanCollection(t)
+	defer func() { _ = d.Close() }()
+	insertTypedColumnInt64ScanRows(t, col, []int64{10, 20, 30, 20})
+
+	all, err := col.RunTypedColumnInt64PredicateAggregate(TypedColumnInt64PredicateAggregateRequest{Column: "time_us", Kind: TypedColumnInt64PredicateAll})
+	if err != nil {
+		t.Fatalf("RunTypedColumnInt64PredicateAggregate all: %v", err)
+	}
+	assertTypedColumnInt64Aggregate(t, all, 4, 80)
+	if all.Diagnostics.SelectionAllBlocks == 0 || all.Diagnostics.SelectionSparseBlocks != 0 || all.Diagnostics.SelectionEmptyBlocks != 0 {
+		t.Fatalf("all diagnostics=%+v want all-row selection shape", all.Diagnostics)
+	}
+
+	exact, err := col.RunTypedColumnInt64PredicateAggregate(TypedColumnInt64PredicateAggregateRequest{Column: "time_us", Kind: TypedColumnInt64PredicateEqual, Value: 20})
+	if err != nil {
+		t.Fatalf("RunTypedColumnInt64PredicateAggregate exact: %v", err)
+	}
+	assertTypedColumnInt64Aggregate(t, exact, 2, 40)
+	if exact.Diagnostics.SelectionSparseBlocks+exact.Diagnostics.SelectionRangeBlocks == 0 {
+		t.Fatalf("exact diagnostics=%+v want sparse/range predicate selection shape", exact.Diagnostics)
+	}
+	assertTypedColumnInt64AggregateNoMaterializationDiagnostics(t, exact.Diagnostics, "selection-shaped typed-column aggregate")
 }
 
 func TestTypedColumnInt64AggregateReopenDurable(t *testing.T) {
@@ -2155,6 +2183,13 @@ func reportTypedColumnInt64AggregateBenchMetrics(b *testing.B, totalRows int, di
 	b.ReportMetric(float64(diag.BlocksConsidered), "blocks_considered/op")
 	b.ReportMetric(float64(diag.BlocksPruned), "blocks_pruned/op")
 	b.ReportMetric(float64(diag.BlocksDecoded), "blocks_decoded/op")
+	b.ReportMetric(float64(diag.SelectionEmptyBlocks), "selection_empty_blocks/op")
+	b.ReportMetric(float64(diag.SelectionAllBlocks), "selection_all_blocks/op")
+	b.ReportMetric(float64(diag.SelectionRangeBlocks), "selection_range_blocks/op")
+	b.ReportMetric(float64(diag.SelectionRangesBlocks), "selection_ranges_blocks/op")
+	b.ReportMetric(float64(diag.SelectionBitmapBlocks), "selection_bitmap_blocks/op")
+	b.ReportMetric(float64(diag.SelectionSparseBlocks), "selection_sparse_blocks/op")
+	b.ReportMetric(float64(diag.SelectionCompositions), "selection_compositions/op")
 	b.ReportMetric(float64(diag.FullAssetReads), "full_asset_reads/op")
 	b.ReportMetric(float64(diag.FullAssetBytes), "full_asset_bytes/op")
 	b.ReportMetric(float64(diag.SectionBytesRead), "section_bytes_read/op")
@@ -2242,6 +2277,13 @@ func reportTypedColumnInt64ScanBenchMetrics(b *testing.B, diag TypedColumnInt64P
 	b.ReportMetric(float64(diag.RowsScanned), "rows_scanned/op")
 	b.ReportMetric(float64(diag.PartsPruned), "parts_pruned/op")
 	b.ReportMetric(float64(diag.BlocksPruned), "blocks_pruned/op")
+	b.ReportMetric(float64(diag.SelectionEmptyBlocks), "selection_empty_blocks/op")
+	b.ReportMetric(float64(diag.SelectionAllBlocks), "selection_all_blocks/op")
+	b.ReportMetric(float64(diag.SelectionRangeBlocks), "selection_range_blocks/op")
+	b.ReportMetric(float64(diag.SelectionRangesBlocks), "selection_ranges_blocks/op")
+	b.ReportMetric(float64(diag.SelectionBitmapBlocks), "selection_bitmap_blocks/op")
+	b.ReportMetric(float64(diag.SelectionSparseBlocks), "selection_sparse_blocks/op")
+	b.ReportMetric(float64(diag.SelectionCompositions), "selection_compositions/op")
 }
 
 type typedColumnInt64AggregateTestBlockRange struct {

--- a/TreeDB/docs/spec/typed-column-semantics.md
+++ b/TreeDB/docs/spec/typed-column-semantics.md
@@ -44,6 +44,33 @@ signed int64 logical values; bool counts return int64 false/true/null buckets;
 and dictionary group-by keys are dictionary string values bound to a stable
 dictionary identity.
 
+## Row selection and mask composition (#1844)
+
+Typed-column kernels consume block-local row selections from
+`TreeDB/internal/typedcolumn` rather than reimplementing mask semantics per type.
+The internal `RowSelection` model represents:
+
+- empty selections;
+- all rows;
+- one contiguous range;
+- multiple sorted ranges;
+- bitmap selections;
+- sparse row indexes.
+
+Selections expose count, iteration, range extraction, and shape diagnostics
+without forcing row-id materialization for all/range forms. Composition is
+fail-closed: predicate and visibility masks are intersected, while delete,
+null, and default masks exclude rows from value semantics. Mismatched row domains
+return an empty selection plus an error. Scratch-backed `Into` helpers make reuse
+explicit and avoid hidden global caches.
+
+Multi-column execution contracts are descriptors, not a planner. They bind
+predicate/measure/projection/visibility/null/default roles to row spans,
+optional immutable asset identity, and section dependency kinds such as values,
+dictionaries, offsets, null/default masks, visibility, stats, pruning metadata,
+vector payloads, and adjacency payloads. Row-span or asset-generation mismatches
+must fail closed before a hot loop consumes multiple columns.
+
 ## typedcolumn coverage
 
 The matrix covers every current `typedcolumn.ColumnType`:

--- a/TreeDB/internal/typedcolumn/row_execution.go
+++ b/TreeDB/internal/typedcolumn/row_execution.go
@@ -277,7 +277,7 @@ func validateColumnRowDescriptor(desc columnRowDescriptor) error {
 	return nil
 }
 
-func makeSectionDependency(role sectionDependencyRole, column string, columnType ColumnType, sectionKind ColumnPartImageSectionKind, span rowSpan, required bool) (sectionDependencyDescriptor, error) {
+func makeValuesSectionDependency(role sectionDependencyRole, column string, columnType ColumnType, sectionKind ColumnPartImageSectionKind, span rowSpan, required bool) (sectionDependencyDescriptor, error) {
 	return NewSectionDependency(role, column, columnType, SectionDependencyValues, sectionKind, span, required)
 }
 

--- a/TreeDB/internal/typedcolumn/row_execution.go
+++ b/TreeDB/internal/typedcolumn/row_execution.go
@@ -2,86 +2,80 @@ package typedcolumn
 
 import "fmt"
 
-type rowMaskRole uint8
+// RowMaskRole identifies how a mask participates in selection composition.
+type RowMaskRole uint8
+
+type rowMaskRole = RowMaskRole
 
 const (
-	rowMaskPredicate rowMaskRole = iota
+	rowMaskPredicate RowMaskRole = iota
 	rowMaskVisibility
 	rowMaskDelete
 	rowMaskNull
 	rowMaskDefault
 )
 
-type rowSelectionComponents struct {
-	Predicate  *rowSelection
-	Visibility *rowSelection
-	Deletes    *rowSelection
-	Nulls      *rowSelection
-	Defaults   *rowSelection
-}
-
-type rowSpan struct {
-	FirstRow int
-	RowCount int
-}
-
-type columnRowDescriptor struct {
-	Column string
-	Type   ColumnType
-	Span   rowSpan
-}
-
-type sectionDependencyRole uint8
-
 const (
-	sectionDependencyPredicate sectionDependencyRole = iota
-	sectionDependencyMeasure
-	sectionDependencyProjection
-	sectionDependencyVisibility
-	sectionDependencyNull
-	sectionDependencyDefault
+	RowMaskPredicate  RowMaskRole = rowMaskPredicate
+	RowMaskVisibility RowMaskRole = rowMaskVisibility
+	RowMaskDelete     RowMaskRole = rowMaskDelete
+	RowMaskNull       RowMaskRole = rowMaskNull
+	RowMaskDefault    RowMaskRole = rowMaskDefault
 )
 
-type sectionDependencyDescriptor struct {
-	Role        sectionDependencyRole
-	Column      string
-	Type        ColumnType
-	SectionKind ColumnPartImageSectionKind
-	Span        rowSpan
-	Required    bool
+// RowSelectionComponents centralizes block-local composition. Predicate and
+// visibility selections are included; delete/null/default selections name rows
+// that must be excluded from value semantics.
+type RowSelectionComponents struct {
+	Predicate  *RowSelection
+	Visibility *RowSelection
+	Deletes    *RowSelection
+	Nulls      *RowSelection
+	Defaults   *RowSelection
 }
 
-func composeRowSelections(rows int, components rowSelectionComponents) (rowSelection, error) {
+type rowSelectionComponents = RowSelectionComponents
+
+// ComposeRowSelections composes predicate, visibility/delete, and null/default
+// masks over a block-local row domain. Mismatched domains return an empty
+// fail-closed selection plus an error.
+func ComposeRowSelections(rows int, components RowSelectionComponents) (RowSelection, error) {
+	return ComposeRowSelectionsInto(rows, components, nil)
+}
+
+// ComposeRowSelectionsInto is the scratch-backed form of ComposeRowSelections.
+// Returned selections may alias scratch until scratch is reused.
+func ComposeRowSelectionsInto(rows int, components RowSelectionComponents, scratch *RowSelectionScratch) (RowSelection, error) {
 	current, err := makeAllRowSelection(rows)
 	if err != nil {
 		return current, err
 	}
 	if components.Predicate != nil {
-		current, err = includeSelection(current, *components.Predicate, rowMaskPredicate)
+		current, err = includeSelectionInto(current, *components.Predicate, rowMaskPredicate, scratch)
 		if err != nil {
 			return failClosedSelection(rows, components.Predicate.rows), err
 		}
 	}
 	if components.Visibility != nil {
-		current, err = includeSelection(current, *components.Visibility, rowMaskVisibility)
+		current, err = includeSelectionInto(current, *components.Visibility, rowMaskVisibility, scratch)
 		if err != nil {
 			return failClosedSelection(rows, components.Visibility.rows), err
 		}
 	}
 	if components.Deletes != nil {
-		current, err = excludeSelection(current, *components.Deletes, rowMaskDelete)
+		current, err = excludeSelectionInto(current, *components.Deletes, rowMaskDelete, scratch)
 		if err != nil {
 			return failClosedSelection(rows, components.Deletes.rows), err
 		}
 	}
 	if components.Nulls != nil {
-		current, err = excludeSelection(current, *components.Nulls, rowMaskNull)
+		current, err = excludeSelectionInto(current, *components.Nulls, rowMaskNull, scratch)
 		if err != nil {
 			return failClosedSelection(rows, components.Nulls.rows), err
 		}
 	}
 	if components.Defaults != nil {
-		current, err = excludeSelection(current, *components.Defaults, rowMaskDefault)
+		current, err = excludeSelectionInto(current, *components.Defaults, rowMaskDefault, scratch)
 		if err != nil {
 			return failClosedSelection(rows, components.Defaults.rows), err
 		}
@@ -89,28 +83,123 @@ func composeRowSelections(rows int, components rowSelectionComponents) (rowSelec
 	return current, nil
 }
 
+func composeRowSelections(rows int, components rowSelectionComponents) (rowSelection, error) {
+	return ComposeRowSelections(rows, components)
+}
+
 func includeSelection(current rowSelection, mask rowSelection, role rowMaskRole) (rowSelection, error) {
+	return includeSelectionInto(current, mask, role, nil)
+}
+
+func includeSelectionInto(current RowSelection, mask RowSelection, role RowMaskRole, scratch *RowSelectionScratch) (RowSelection, error) {
 	if err := validateSameSelectionRows(current, mask); err != nil {
 		return failClosedSelection(current.rows, mask.rows), fmt.Errorf("typedcolumn: %s mask row mismatch: %w", role, err)
 	}
-	return andRowSelections(current, mask)
+	return AndRowSelectionsInto(current, mask, scratch)
 }
 
 func excludeSelection(current rowSelection, mask rowSelection, role rowMaskRole) (rowSelection, error) {
+	return excludeSelectionInto(current, mask, role, nil)
+}
+
+func excludeSelectionInto(current RowSelection, mask RowSelection, role RowMaskRole, scratch *RowSelectionScratch) (RowSelection, error) {
 	if err := validateSameSelectionRows(current, mask); err != nil {
 		return failClosedSelection(current.rows, mask.rows), fmt.Errorf("typedcolumn: %s mask row mismatch: %w", role, err)
 	}
-	inverted, err := notRowSelection(mask)
+	inverted, err := NotRowSelectionInto(mask, scratch)
 	if err != nil {
 		return failClosedSelection(current.rows, mask.rows), fmt.Errorf("typedcolumn: invert %s mask: %w", role, err)
 	}
-	return andRowSelections(current, inverted)
+	return AndRowSelectionsInto(current, inverted, scratch)
 }
 
+// RowSpan is a half-open row span over a column section or block.
+type RowSpan struct {
+	FirstRow int
+	RowCount int
+}
+
+type rowSpan = RowSpan
+
+// ColumnExecutionRole classifies how a column participates in a future
+// multi-column execution plan. It is descriptive; it is not a planner.
+type ColumnExecutionRole uint8
+
+type sectionDependencyRole = ColumnExecutionRole
+
+const (
+	sectionDependencyPredicate ColumnExecutionRole = iota
+	sectionDependencyMeasure
+	sectionDependencyProjection
+	sectionDependencyVisibility
+	sectionDependencyNull
+	sectionDependencyDefault
+)
+
+const (
+	ColumnRolePredicate  ColumnExecutionRole = sectionDependencyPredicate
+	ColumnRoleMeasure    ColumnExecutionRole = sectionDependencyMeasure
+	ColumnRoleProjection ColumnExecutionRole = sectionDependencyProjection
+	ColumnRoleVisibility ColumnExecutionRole = sectionDependencyVisibility
+	ColumnRoleNull       ColumnExecutionRole = sectionDependencyNull
+	ColumnRoleDefault    ColumnExecutionRole = sectionDependencyDefault
+)
+
+// SectionDependencyKind names the logical section/payload class needed by an
+// operation. It intentionally covers future codecs without requiring a planner.
+type SectionDependencyKind string
+
+const (
+	SectionDependencyValues           SectionDependencyKind = "values"
+	SectionDependencyDictionaries     SectionDependencyKind = "dictionaries"
+	SectionDependencyOffsets          SectionDependencyKind = "offsets"
+	SectionDependencyNullMask         SectionDependencyKind = "null_mask"
+	SectionDependencyDefaultMask      SectionDependencyKind = "default_mask"
+	SectionDependencyVisibility       SectionDependencyKind = "visibility"
+	SectionDependencyStats            SectionDependencyKind = "stats"
+	SectionDependencyPruningMetadata  SectionDependencyKind = "pruning_metadata"
+	SectionDependencyVectorPayload    SectionDependencyKind = "vector_payload"
+	SectionDependencyAdjacencyPayload SectionDependencyKind = "adjacency_payload"
+)
+
+// ColumnRowDescriptor binds one column role to a row span and optional immutable
+// asset identity. Non-zero identity fields must align across descriptors.
+type ColumnRowDescriptor struct {
+	Column             string
+	Type               ColumnType
+	Span               RowSpan
+	SnapshotGeneration uint64
+	AssetGeneration    uint64
+	PartID             uint64
+	SchemaVersion      uint32
+	AlignmentKey       string
+}
+
+type columnRowDescriptor = ColumnRowDescriptor
+
+// SectionDependencyDescriptor describes a section read dependency for a column
+// role and row span. SectionKind identifies the tcs1 section class, while Kind
+// identifies the logical payload/metadata need.
+type SectionDependencyDescriptor struct {
+	Role        ColumnExecutionRole
+	Column      string
+	Type        ColumnType
+	Kind        SectionDependencyKind
+	SectionKind ColumnPartImageSectionKind
+	Span        RowSpan
+	Required    bool
+}
+
+type sectionDependencyDescriptor = SectionDependencyDescriptor
+
 func makeRowSpan(firstRow int, rowCount int) (rowSpan, error) {
-	span := rowSpan{FirstRow: firstRow, RowCount: rowCount}
+	return NewRowSpan(firstRow, rowCount)
+}
+
+func NewRowSpan(firstRow int, rowCount int) (RowSpan, error) {
+	span := RowSpan{FirstRow: firstRow, RowCount: rowCount}
 	if err := validateRowSpan(span); err != nil {
-		return rowSpan{}, err
+		return RowSpan{}, err
 	}
 	return span, nil
 }
@@ -118,6 +207,9 @@ func makeRowSpan(firstRow int, rowCount int) (rowSpan, error) {
 func (s rowSpan) endRow() int {
 	return s.FirstRow + s.RowCount
 }
+
+// EndRow returns the exclusive row end.
+func (s RowSpan) EndRow() int { return s.FirstRow + s.RowCount }
 
 func validateRowSpan(span rowSpan) error {
 	if span.FirstRow < 0 {
@@ -132,6 +224,12 @@ func validateRowSpan(span rowSpan) error {
 	return nil
 }
 
+// AlignColumnRowSpans validates that all columns share the same row span and
+// optional snapshot/asset/schema identity. It fails closed on any mismatch.
+func AlignColumnRowSpans(columns []ColumnRowDescriptor) (RowSpan, bool, error) {
+	return alignColumnRowSpans(columns)
+}
+
 func alignColumnRowSpans(columns []columnRowDescriptor) (rowSpan, bool, error) {
 	if len(columns) == 0 {
 		return rowSpan{}, false, fmt.Errorf("typedcolumn: no column row spans to align")
@@ -139,17 +237,35 @@ func alignColumnRowSpans(columns []columnRowDescriptor) (rowSpan, bool, error) {
 	if err := validateColumnRowDescriptor(columns[0]); err != nil {
 		return rowSpan{}, false, err
 	}
-	want := columns[0].Span
+	want := columns[0]
 	for i := 1; i < len(columns); i++ {
 		if err := validateColumnRowDescriptor(columns[i]); err != nil {
 			return rowSpan{}, false, err
 		}
-		if columns[i].Span != want {
-			return rowSpan{}, false, fmt.Errorf("typedcolumn: column %s span [%d,%d) mismatches [%d,%d)", columns[i].Column, columns[i].Span.FirstRow, columns[i].Span.endRow(), want.FirstRow, want.endRow())
+		if columns[i].Span != want.Span {
+			return rowSpan{}, false, fmt.Errorf("typedcolumn: column %s span [%d,%d) mismatches [%d,%d)", columns[i].Column, columns[i].Span.FirstRow, columns[i].Span.endRow(), want.Span.FirstRow, want.Span.endRow())
+		}
+		if mismatchIdentity(want.SnapshotGeneration, columns[i].SnapshotGeneration) {
+			return rowSpan{}, false, fmt.Errorf("typedcolumn: column %s snapshot generation %d mismatches %d", columns[i].Column, columns[i].SnapshotGeneration, want.SnapshotGeneration)
+		}
+		if mismatchIdentity(want.AssetGeneration, columns[i].AssetGeneration) {
+			return rowSpan{}, false, fmt.Errorf("typedcolumn: column %s asset generation %d mismatches %d", columns[i].Column, columns[i].AssetGeneration, want.AssetGeneration)
+		}
+		if mismatchIdentity(want.PartID, columns[i].PartID) {
+			return rowSpan{}, false, fmt.Errorf("typedcolumn: column %s part id %d mismatches %d", columns[i].Column, columns[i].PartID, want.PartID)
+		}
+		if mismatchIdentity32(want.SchemaVersion, columns[i].SchemaVersion) {
+			return rowSpan{}, false, fmt.Errorf("typedcolumn: column %s schema version %d mismatches %d", columns[i].Column, columns[i].SchemaVersion, want.SchemaVersion)
+		}
+		if want.AlignmentKey != "" && columns[i].AlignmentKey != "" && columns[i].AlignmentKey != want.AlignmentKey {
+			return rowSpan{}, false, fmt.Errorf("typedcolumn: column %s asset ref %q mismatches %q", columns[i].Column, columns[i].AlignmentKey, want.AlignmentKey)
 		}
 	}
-	return want, true, nil
+	return want.Span, true, nil
 }
+
+func mismatchIdentity(a, b uint64) bool   { return a != 0 && b != 0 && a != b }
+func mismatchIdentity32(a, b uint32) bool { return a != 0 && b != 0 && a != b }
 
 func validateColumnRowDescriptor(desc columnRowDescriptor) error {
 	if desc.Column == "" {
@@ -162,11 +278,21 @@ func validateColumnRowDescriptor(desc columnRowDescriptor) error {
 }
 
 func makeSectionDependency(role sectionDependencyRole, column string, columnType ColumnType, sectionKind ColumnPartImageSectionKind, span rowSpan, required bool) (sectionDependencyDescriptor, error) {
-	dep := sectionDependencyDescriptor{Role: role, Column: column, Type: columnType, SectionKind: sectionKind, Span: span, Required: required}
+	return NewSectionDependency(role, column, columnType, SectionDependencyValues, sectionKind, span, required)
+}
+
+func NewSectionDependency(role ColumnExecutionRole, column string, columnType ColumnType, kind SectionDependencyKind, sectionKind ColumnPartImageSectionKind, span RowSpan, required bool) (SectionDependencyDescriptor, error) {
+	dep := SectionDependencyDescriptor{Role: role, Column: column, Type: columnType, Kind: kind, SectionKind: sectionKind, Span: span, Required: required}
 	if err := validateSectionDependency(dep); err != nil {
-		return sectionDependencyDescriptor{}, err
+		return SectionDependencyDescriptor{}, err
 	}
 	return dep, nil
+}
+
+// ValidateSectionDependencies validates dependency descriptors and their row
+// alignment. It does not read any payloads.
+func ValidateSectionDependencies(deps []SectionDependencyDescriptor) (RowSpan, bool, error) {
+	return validateSectionDependencies(deps)
 }
 
 func validateSectionDependencies(deps []sectionDependencyDescriptor) (rowSpan, bool, error) {
@@ -190,6 +316,9 @@ func validateSectionDependency(dep sectionDependencyDescriptor) error {
 	if !dep.Role.valid() {
 		return fmt.Errorf("typedcolumn: invalid section dependency role %d", dep.Role)
 	}
+	if dep.Kind == "" {
+		return fmt.Errorf("typedcolumn: empty %s dependency kind", dep.Role)
+	}
 	if dep.SectionKind == ColumnPartImageSectionManifest {
 		return fmt.Errorf("typedcolumn: %s dependency cannot target manifest section", dep.Role)
 	}
@@ -197,6 +326,41 @@ func validateSectionDependency(dep sectionDependencyDescriptor) error {
 		return err
 	}
 	return nil
+}
+
+// PredicateColumnDependencies describes the ordinary sections needed to produce
+// a predicate selection for one column. Callers may add dictionary/vector/etc.
+// dependencies when the operation requires them.
+func PredicateColumnDependencies(column string, columnType ColumnType, span RowSpan, nullable bool) ([]SectionDependencyDescriptor, error) {
+	return standardColumnDependencies(ColumnRolePredicate, column, columnType, span, nullable, true)
+}
+
+func MeasureColumnDependencies(column string, columnType ColumnType, span RowSpan, nullable bool) ([]SectionDependencyDescriptor, error) {
+	return standardColumnDependencies(ColumnRoleMeasure, column, columnType, span, nullable, false)
+}
+
+func ProjectionColumnDependencies(column string, columnType ColumnType, span RowSpan, nullable bool) ([]SectionDependencyDescriptor, error) {
+	return standardColumnDependencies(ColumnRoleProjection, column, columnType, span, nullable, false)
+}
+
+func standardColumnDependencies(role ColumnExecutionRole, column string, columnType ColumnType, span RowSpan, nullable bool, pruning bool) ([]SectionDependencyDescriptor, error) {
+	kinds := []SectionDependencyKind{SectionDependencyValues}
+	if pruning {
+		kinds = append(kinds, SectionDependencyPruningMetadata)
+	}
+	if nullable {
+		kinds = append(kinds, SectionDependencyNullMask, SectionDependencyDefaultMask)
+	}
+	out := make([]SectionDependencyDescriptor, 0, len(kinds))
+	for _, kind := range kinds {
+		sectionKind := ColumnPartImageSectionColumnData
+		dep, err := NewSectionDependency(role, column, columnType, kind, sectionKind, span, true)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, dep)
+	}
+	return out, nil
 }
 
 func appendSelectedBools(dst []bool, values []bool, selection rowSelection) ([]bool, error) {
@@ -247,7 +411,7 @@ func appendSelectedUint32s(dst []uint32, values []uint32, selection rowSelection
 	return out, nil
 }
 
-func (r rowMaskRole) String() string {
+func (r RowMaskRole) String() string {
 	switch r {
 	case rowMaskPredicate:
 		return "predicate"
@@ -264,11 +428,11 @@ func (r rowMaskRole) String() string {
 	}
 }
 
-func (r sectionDependencyRole) valid() bool {
+func (r ColumnExecutionRole) valid() bool {
 	return r <= sectionDependencyDefault
 }
 
-func (r sectionDependencyRole) String() string {
+func (r ColumnExecutionRole) String() string {
 	switch r {
 	case sectionDependencyPredicate:
 		return "predicate"

--- a/TreeDB/internal/typedcolumn/row_execution.go
+++ b/TreeDB/internal/typedcolumn/row_execution.go
@@ -1,0 +1,288 @@
+package typedcolumn
+
+import "fmt"
+
+type rowMaskRole uint8
+
+const (
+	rowMaskPredicate rowMaskRole = iota
+	rowMaskVisibility
+	rowMaskDelete
+	rowMaskNull
+	rowMaskDefault
+)
+
+type rowSelectionComponents struct {
+	Predicate  *rowSelection
+	Visibility *rowSelection
+	Deletes    *rowSelection
+	Nulls      *rowSelection
+	Defaults   *rowSelection
+}
+
+type rowSpan struct {
+	FirstRow int
+	RowCount int
+}
+
+type columnRowDescriptor struct {
+	Column string
+	Type   ColumnType
+	Span   rowSpan
+}
+
+type sectionDependencyRole uint8
+
+const (
+	sectionDependencyPredicate sectionDependencyRole = iota
+	sectionDependencyMeasure
+	sectionDependencyProjection
+	sectionDependencyVisibility
+	sectionDependencyNull
+	sectionDependencyDefault
+)
+
+type sectionDependencyDescriptor struct {
+	Role        sectionDependencyRole
+	Column      string
+	Type        ColumnType
+	SectionKind ColumnPartImageSectionKind
+	Span        rowSpan
+	Required    bool
+}
+
+func composeRowSelections(rows int, components rowSelectionComponents) (rowSelection, error) {
+	current, err := makeAllRowSelection(rows)
+	if err != nil {
+		return current, err
+	}
+	if components.Predicate != nil {
+		current, err = includeSelection(current, *components.Predicate, rowMaskPredicate)
+		if err != nil {
+			return failClosedSelection(rows, components.Predicate.rows), err
+		}
+	}
+	if components.Visibility != nil {
+		current, err = includeSelection(current, *components.Visibility, rowMaskVisibility)
+		if err != nil {
+			return failClosedSelection(rows, components.Visibility.rows), err
+		}
+	}
+	if components.Deletes != nil {
+		current, err = excludeSelection(current, *components.Deletes, rowMaskDelete)
+		if err != nil {
+			return failClosedSelection(rows, components.Deletes.rows), err
+		}
+	}
+	if components.Nulls != nil {
+		current, err = excludeSelection(current, *components.Nulls, rowMaskNull)
+		if err != nil {
+			return failClosedSelection(rows, components.Nulls.rows), err
+		}
+	}
+	if components.Defaults != nil {
+		current, err = excludeSelection(current, *components.Defaults, rowMaskDefault)
+		if err != nil {
+			return failClosedSelection(rows, components.Defaults.rows), err
+		}
+	}
+	return current, nil
+}
+
+func includeSelection(current rowSelection, mask rowSelection, role rowMaskRole) (rowSelection, error) {
+	if err := validateSameSelectionRows(current, mask); err != nil {
+		return failClosedSelection(current.rows, mask.rows), fmt.Errorf("typedcolumn: %s mask row mismatch: %w", role, err)
+	}
+	return andRowSelections(current, mask)
+}
+
+func excludeSelection(current rowSelection, mask rowSelection, role rowMaskRole) (rowSelection, error) {
+	if err := validateSameSelectionRows(current, mask); err != nil {
+		return failClosedSelection(current.rows, mask.rows), fmt.Errorf("typedcolumn: %s mask row mismatch: %w", role, err)
+	}
+	inverted, err := notRowSelection(mask)
+	if err != nil {
+		return failClosedSelection(current.rows, mask.rows), fmt.Errorf("typedcolumn: invert %s mask: %w", role, err)
+	}
+	return andRowSelections(current, inverted)
+}
+
+func makeRowSpan(firstRow int, rowCount int) (rowSpan, error) {
+	span := rowSpan{FirstRow: firstRow, RowCount: rowCount}
+	if err := validateRowSpan(span); err != nil {
+		return rowSpan{}, err
+	}
+	return span, nil
+}
+
+func (s rowSpan) endRow() int {
+	return s.FirstRow + s.RowCount
+}
+
+func validateRowSpan(span rowSpan) error {
+	if span.FirstRow < 0 {
+		return fmt.Errorf("typedcolumn: negative row span first row %d", span.FirstRow)
+	}
+	if span.RowCount < 0 {
+		return fmt.Errorf("typedcolumn: negative row span count %d", span.RowCount)
+	}
+	if span.FirstRow > int(^uint(0)>>1)-span.RowCount {
+		return fmt.Errorf("typedcolumn: row span [%d,+%d) overflows int", span.FirstRow, span.RowCount)
+	}
+	return nil
+}
+
+func alignColumnRowSpans(columns []columnRowDescriptor) (rowSpan, bool, error) {
+	if len(columns) == 0 {
+		return rowSpan{}, false, fmt.Errorf("typedcolumn: no column row spans to align")
+	}
+	if err := validateColumnRowDescriptor(columns[0]); err != nil {
+		return rowSpan{}, false, err
+	}
+	want := columns[0].Span
+	for i := 1; i < len(columns); i++ {
+		if err := validateColumnRowDescriptor(columns[i]); err != nil {
+			return rowSpan{}, false, err
+		}
+		if columns[i].Span != want {
+			return rowSpan{}, false, fmt.Errorf("typedcolumn: column %s span [%d,%d) mismatches [%d,%d)", columns[i].Column, columns[i].Span.FirstRow, columns[i].Span.endRow(), want.FirstRow, want.endRow())
+		}
+	}
+	return want, true, nil
+}
+
+func validateColumnRowDescriptor(desc columnRowDescriptor) error {
+	if desc.Column == "" {
+		return fmt.Errorf("typedcolumn: empty column row descriptor column")
+	}
+	if err := validateRowSpan(desc.Span); err != nil {
+		return err
+	}
+	return nil
+}
+
+func makeSectionDependency(role sectionDependencyRole, column string, columnType ColumnType, sectionKind ColumnPartImageSectionKind, span rowSpan, required bool) (sectionDependencyDescriptor, error) {
+	dep := sectionDependencyDescriptor{Role: role, Column: column, Type: columnType, SectionKind: sectionKind, Span: span, Required: required}
+	if err := validateSectionDependency(dep); err != nil {
+		return sectionDependencyDescriptor{}, err
+	}
+	return dep, nil
+}
+
+func validateSectionDependencies(deps []sectionDependencyDescriptor) (rowSpan, bool, error) {
+	if len(deps) == 0 {
+		return rowSpan{}, false, fmt.Errorf("typedcolumn: no section dependencies")
+	}
+	columns := make([]columnRowDescriptor, 0, len(deps))
+	for _, dep := range deps {
+		if err := validateSectionDependency(dep); err != nil {
+			return rowSpan{}, false, err
+		}
+		columns = append(columns, columnRowDescriptor{Column: dep.Column, Type: dep.Type, Span: dep.Span})
+	}
+	return alignColumnRowSpans(columns)
+}
+
+func validateSectionDependency(dep sectionDependencyDescriptor) error {
+	if dep.Column == "" {
+		return fmt.Errorf("typedcolumn: empty %s dependency column", dep.Role)
+	}
+	if !dep.Role.valid() {
+		return fmt.Errorf("typedcolumn: invalid section dependency role %d", dep.Role)
+	}
+	if dep.SectionKind == ColumnPartImageSectionManifest {
+		return fmt.Errorf("typedcolumn: %s dependency cannot target manifest section", dep.Role)
+	}
+	if err := validateRowSpan(dep.Span); err != nil {
+		return err
+	}
+	return nil
+}
+
+func appendSelectedBools(dst []bool, values []bool, selection rowSelection) ([]bool, error) {
+	if len(values) != selection.rows {
+		return dst[:0], fmt.Errorf("typedcolumn: bool values rows=%d selection rows=%d", len(values), selection.rows)
+	}
+	out := dst[:0]
+	switch selection.kind {
+	case rowSelectionEmpty:
+		return out, nil
+	case rowSelectionAll:
+		return append(out, values...), nil
+	case rowSelectionRange:
+		return append(out, values[selection.start:selection.end]...), nil
+	case rowSelectionRanges:
+		for _, r := range selection.ranges {
+			out = append(out, values[r.Start:r.End]...)
+		}
+	case rowSelectionBitmap, rowSelectionSparse:
+		selection.forEach(func(row int) {
+			out = append(out, values[row])
+		})
+	}
+	return out, nil
+}
+
+func appendSelectedUint32s(dst []uint32, values []uint32, selection rowSelection) ([]uint32, error) {
+	if len(values) != selection.rows {
+		return dst[:0], fmt.Errorf("typedcolumn: uint32 values rows=%d selection rows=%d", len(values), selection.rows)
+	}
+	out := dst[:0]
+	switch selection.kind {
+	case rowSelectionEmpty:
+		return out, nil
+	case rowSelectionAll:
+		return append(out, values...), nil
+	case rowSelectionRange:
+		return append(out, values[selection.start:selection.end]...), nil
+	case rowSelectionRanges:
+		for _, r := range selection.ranges {
+			out = append(out, values[r.Start:r.End]...)
+		}
+	case rowSelectionBitmap, rowSelectionSparse:
+		selection.forEach(func(row int) {
+			out = append(out, values[row])
+		})
+	}
+	return out, nil
+}
+
+func (r rowMaskRole) String() string {
+	switch r {
+	case rowMaskPredicate:
+		return "predicate"
+	case rowMaskVisibility:
+		return "visibility"
+	case rowMaskDelete:
+		return "delete"
+	case rowMaskNull:
+		return "null"
+	case rowMaskDefault:
+		return "default"
+	default:
+		return "unknown"
+	}
+}
+
+func (r sectionDependencyRole) valid() bool {
+	return r <= sectionDependencyDefault
+}
+
+func (r sectionDependencyRole) String() string {
+	switch r {
+	case sectionDependencyPredicate:
+		return "predicate"
+	case sectionDependencyMeasure:
+		return "measure"
+	case sectionDependencyProjection:
+		return "projection"
+	case sectionDependencyVisibility:
+		return "visibility"
+	case sectionDependencyNull:
+		return "null"
+	case sectionDependencyDefault:
+		return "default"
+	default:
+		return "unknown"
+	}
+}

--- a/TreeDB/internal/typedcolumn/row_execution.go
+++ b/TreeDB/internal/typedcolumn/row_execution.go
@@ -106,11 +106,11 @@ func excludeSelectionInto(current RowSelection, mask RowSelection, role RowMaskR
 	if err := validateSameSelectionRows(current, mask); err != nil {
 		return failClosedSelection(current.rows, mask.rows), fmt.Errorf("typedcolumn: %s mask row mismatch: %w", role, err)
 	}
-	inverted, err := NotRowSelectionInto(mask, scratch)
+	out, err := SubtractRowSelectionsInto(current, mask, scratch)
 	if err != nil {
-		return failClosedSelection(current.rows, mask.rows), fmt.Errorf("typedcolumn: invert %s mask: %w", role, err)
+		return failClosedSelection(current.rows, mask.rows), fmt.Errorf("typedcolumn: exclude %s mask: %w", role, err)
 	}
-	return AndRowSelectionsInto(current, inverted, scratch)
+	return out, nil
 }
 
 // RowSpan is a half-open row span over a column section or block.

--- a/TreeDB/internal/typedcolumn/row_selection.go
+++ b/TreeDB/internal/typedcolumn/row_selection.go
@@ -1,0 +1,538 @@
+package typedcolumn
+
+import (
+	"errors"
+	"fmt"
+	"math/bits"
+)
+
+type rowSelectionKind uint8
+
+const (
+	rowSelectionEmpty rowSelectionKind = iota
+	rowSelectionAll
+	rowSelectionRange
+	rowSelectionRanges
+	rowSelectionBitmap
+	rowSelectionSparse
+)
+
+type rowRange struct {
+	Start int
+	End   int
+}
+
+type rowSelection struct {
+	rows   int
+	kind   rowSelectionKind
+	start  int
+	end    int
+	ranges []rowRange
+	bitmap []uint64
+	sparse []int
+	count  int
+}
+
+type rowSelectionShape struct {
+	Kind        string
+	Rows        int
+	Count       int
+	Ranges      int
+	BitmapWords int
+	SparseRows  int
+}
+
+func makeEmptyRowSelection(rows int) (rowSelection, error) {
+	if rows < 0 {
+		return rowSelection{}, fmt.Errorf("typedcolumn: negative row selection rows %d", rows)
+	}
+	return rowSelection{rows: rows, kind: rowSelectionEmpty}, nil
+}
+
+func makeAllRowSelection(rows int) (rowSelection, error) {
+	if rows < 0 {
+		return rowSelection{}, fmt.Errorf("typedcolumn: negative row selection rows %d", rows)
+	}
+	if rows == 0 {
+		return rowSelection{rows: rows, kind: rowSelectionEmpty}, nil
+	}
+	return rowSelection{rows: rows, kind: rowSelectionAll, count: rows}, nil
+}
+
+func makeRangeRowSelection(rows int, start int, end int) (rowSelection, error) {
+	if err := validateRowRange(rows, rowRange{Start: start, End: end}); err != nil {
+		return rowSelection{}, err
+	}
+	if start == end {
+		return makeEmptyRowSelection(rows)
+	}
+	if start == 0 && end == rows {
+		return makeAllRowSelection(rows)
+	}
+	return rowSelection{rows: rows, kind: rowSelectionRange, start: start, end: end, count: end - start}, nil
+}
+
+func makeRangesRowSelection(rows int, ranges []rowRange) (rowSelection, error) {
+	if rows < 0 {
+		return rowSelection{}, fmt.Errorf("typedcolumn: negative row selection rows %d", rows)
+	}
+	if len(ranges) == 0 {
+		return makeEmptyRowSelection(rows)
+	}
+	merged := make([]rowRange, 0, len(ranges))
+	for i, r := range ranges {
+		if err := validateRowRange(rows, r); err != nil {
+			return rowSelection{}, fmt.Errorf("typedcolumn: invalid row range %d: %w", i, err)
+		}
+		if r.Start == r.End {
+			continue
+		}
+		if len(merged) == 0 {
+			merged = append(merged, r)
+			continue
+		}
+		last := &merged[len(merged)-1]
+		if r.Start < last.End {
+			return rowSelection{}, fmt.Errorf("typedcolumn: row ranges overlap at %d", i)
+		}
+		if r.Start == last.End {
+			last.End = r.End
+			continue
+		}
+		merged = append(merged, r)
+	}
+	if len(merged) == 0 {
+		return makeEmptyRowSelection(rows)
+	}
+	count := 0
+	for _, r := range merged {
+		count += r.End - r.Start
+	}
+	if count == rows {
+		return makeAllRowSelection(rows)
+	}
+	if len(merged) == 1 {
+		return makeRangeRowSelection(rows, merged[0].Start, merged[0].End)
+	}
+	return rowSelection{rows: rows, kind: rowSelectionRanges, ranges: merged, count: count}, nil
+}
+
+func makeSparseRowSelection(rows int, sparse []int) (rowSelection, error) {
+	if rows < 0 {
+		return rowSelection{}, fmt.Errorf("typedcolumn: negative row selection rows %d", rows)
+	}
+	if len(sparse) == 0 {
+		return makeEmptyRowSelection(rows)
+	}
+	copySparse := make([]int, len(sparse))
+	for i, row := range sparse {
+		if row < 0 || row >= rows {
+			return rowSelection{}, fmt.Errorf("typedcolumn: sparse row %d=%d outside [0,%d)", i, row, rows)
+		}
+		if i > 0 && row <= sparse[i-1] {
+			return rowSelection{}, fmt.Errorf("typedcolumn: sparse rows not strictly increasing at %d", i)
+		}
+		copySparse[i] = row
+	}
+	if len(copySparse) == rows {
+		return makeAllRowSelection(rows)
+	}
+	if isContiguousSparse(copySparse) {
+		return makeRangeRowSelection(rows, copySparse[0], copySparse[len(copySparse)-1]+1)
+	}
+	return rowSelection{rows: rows, kind: rowSelectionSparse, sparse: copySparse, count: len(copySparse)}, nil
+}
+
+func makeBitmapRowSelection(rows int, bitmap []uint64) (rowSelection, error) {
+	if rows < 0 {
+		return rowSelection{}, fmt.Errorf("typedcolumn: negative row selection rows %d", rows)
+	}
+	wantWords := rowSelectionBitmapWords(rows)
+	if len(bitmap) != wantWords {
+		return rowSelection{}, fmt.Errorf("typedcolumn: bitmap words=%d want=%d", len(bitmap), wantWords)
+	}
+	if wantWords == 0 {
+		return makeEmptyRowSelection(rows)
+	}
+	copyBitmap := append([]uint64(nil), bitmap...)
+	if padding := rows % 64; padding != 0 {
+		valid := uint64(1<<uint(padding)) - 1
+		if copyBitmap[len(copyBitmap)-1]&^valid != 0 {
+			return rowSelection{}, errors.New("typedcolumn: row selection bitmap has non-zero padding bits")
+		}
+	}
+	count := 0
+	for _, word := range copyBitmap {
+		count += bits.OnesCount64(word)
+	}
+	if count == 0 {
+		return makeEmptyRowSelection(rows)
+	}
+	if count == rows {
+		return makeAllRowSelection(rows)
+	}
+	if start, end, ok := contiguousBitmapRange(rows, copyBitmap); ok {
+		return makeRangeRowSelection(rows, start, end)
+	}
+	return rowSelection{rows: rows, kind: rowSelectionBitmap, bitmap: copyBitmap, count: count}, nil
+}
+
+func (s rowSelection) rowsCount() int {
+	return s.rows
+}
+
+func (s rowSelection) countRows() int {
+	return s.count
+}
+
+func (s rowSelection) shape() rowSelectionShape {
+	shape := rowSelectionShape{Kind: s.kind.String(), Rows: s.rows, Count: s.count}
+	switch s.kind {
+	case rowSelectionRanges:
+		shape.Ranges = len(s.ranges)
+	case rowSelectionBitmap:
+		shape.BitmapWords = len(s.bitmap)
+	case rowSelectionSparse:
+		shape.SparseRows = len(s.sparse)
+	case rowSelectionRange:
+		shape.Ranges = 1
+	}
+	return shape
+}
+
+func (s rowSelection) contains(row int) bool {
+	if row < 0 || row >= s.rows {
+		return false
+	}
+	switch s.kind {
+	case rowSelectionEmpty:
+		return false
+	case rowSelectionAll:
+		return true
+	case rowSelectionRange:
+		return row >= s.start && row < s.end
+	case rowSelectionRanges:
+		for _, r := range s.ranges {
+			if row < r.Start {
+				return false
+			}
+			if row < r.End {
+				return true
+			}
+		}
+		return false
+	case rowSelectionBitmap:
+		return s.bitmap[row/64]&(uint64(1)<<uint(row%64)) != 0
+	case rowSelectionSparse:
+		lo, hi := 0, len(s.sparse)
+		for lo < hi {
+			mid := int(uint(lo+hi) >> 1)
+			if s.sparse[mid] < row {
+				lo = mid + 1
+			} else {
+				hi = mid
+			}
+		}
+		return lo < len(s.sparse) && s.sparse[lo] == row
+	default:
+		return false
+	}
+}
+
+func (s rowSelection) forEach(fn func(row int)) {
+	switch s.kind {
+	case rowSelectionEmpty:
+		return
+	case rowSelectionAll:
+		for row := 0; row < s.rows; row++ {
+			fn(row)
+		}
+	case rowSelectionRange:
+		for row := s.start; row < s.end; row++ {
+			fn(row)
+		}
+	case rowSelectionRanges:
+		for _, r := range s.ranges {
+			for row := r.Start; row < r.End; row++ {
+				fn(row)
+			}
+		}
+	case rowSelectionBitmap:
+		for wordIndex, word := range s.bitmap {
+			for word != 0 {
+				bit := bits.TrailingZeros64(word)
+				row := wordIndex*64 + bit
+				if row < s.rows {
+					fn(row)
+				}
+				word &^= uint64(1) << uint(bit)
+			}
+		}
+	case rowSelectionSparse:
+		for _, row := range s.sparse {
+			fn(row)
+		}
+	}
+}
+
+func (s rowSelection) appendRows(dst []int) []int {
+	switch s.kind {
+	case rowSelectionEmpty:
+		return dst
+	case rowSelectionAll:
+		for row := 0; row < s.rows; row++ {
+			dst = append(dst, row)
+		}
+	case rowSelectionRange:
+		for row := s.start; row < s.end; row++ {
+			dst = append(dst, row)
+		}
+	case rowSelectionRanges:
+		for _, r := range s.ranges {
+			for row := r.Start; row < r.End; row++ {
+				dst = append(dst, row)
+			}
+		}
+	case rowSelectionBitmap:
+		for wordIndex, word := range s.bitmap {
+			for word != 0 {
+				bit := bits.TrailingZeros64(word)
+				row := wordIndex*64 + bit
+				if row < s.rows {
+					dst = append(dst, row)
+				}
+				word &^= uint64(1) << uint(bit)
+			}
+		}
+	case rowSelectionSparse:
+		dst = append(dst, s.sparse...)
+	}
+	return dst
+}
+
+func (s rowSelection) appendRanges(dst []rowRange) []rowRange {
+	switch s.kind {
+	case rowSelectionEmpty:
+		return dst
+	case rowSelectionAll:
+		return append(dst, rowRange{Start: 0, End: s.rows})
+	case rowSelectionRange:
+		return append(dst, rowRange{Start: s.start, End: s.end})
+	case rowSelectionRanges:
+		return append(dst, s.ranges...)
+	case rowSelectionBitmap:
+		inRange := false
+		start := 0
+		for row := 0; row < s.rows; row++ {
+			set := s.bitmap[row/64]&(uint64(1)<<uint(row%64)) != 0
+			if set && !inRange {
+				start = row
+				inRange = true
+				continue
+			}
+			if !set && inRange {
+				dst = append(dst, rowRange{Start: start, End: row})
+				inRange = false
+			}
+		}
+		if inRange {
+			dst = append(dst, rowRange{Start: start, End: s.rows})
+		}
+	case rowSelectionSparse:
+		if len(s.sparse) == 0 {
+			return dst
+		}
+		start := s.sparse[0]
+		prev := start
+		for _, row := range s.sparse[1:] {
+			if row == prev+1 {
+				prev = row
+				continue
+			}
+			dst = append(dst, rowRange{Start: start, End: prev + 1})
+			start = row
+			prev = row
+		}
+		dst = append(dst, rowRange{Start: start, End: prev + 1})
+	}
+	return dst
+}
+
+func andRowSelections(a rowSelection, b rowSelection) (rowSelection, error) {
+	if err := validateSameSelectionRows(a, b); err != nil {
+		return failClosedSelection(a.rows, b.rows), err
+	}
+	if a.kind == rowSelectionEmpty || b.kind == rowSelectionEmpty {
+		return makeEmptyRowSelection(a.rows)
+	}
+	if a.kind == rowSelectionAll {
+		return b, nil
+	}
+	if b.kind == rowSelectionAll {
+		return a, nil
+	}
+	if a.kind == rowSelectionBitmap && b.kind == rowSelectionBitmap {
+		words := make([]uint64, len(a.bitmap))
+		for i := range words {
+			words[i] = a.bitmap[i] & b.bitmap[i]
+		}
+		return makeBitmapRowSelection(a.rows, words)
+	}
+	left := a.appendRanges(nil)
+	right := b.appendRanges(nil)
+	out := make([]rowRange, 0, min(len(left), len(right)))
+	i, j := 0, 0
+	for i < len(left) && j < len(right) {
+		start := max(left[i].Start, right[j].Start)
+		end := min(left[i].End, right[j].End)
+		if start < end {
+			out = append(out, rowRange{Start: start, End: end})
+		}
+		if left[i].End < right[j].End {
+			i++
+		} else {
+			j++
+		}
+	}
+	return makeRangesRowSelection(a.rows, out)
+}
+
+func orRowSelections(a rowSelection, b rowSelection) (rowSelection, error) {
+	if err := validateSameSelectionRows(a, b); err != nil {
+		return failClosedSelection(a.rows, b.rows), err
+	}
+	if a.kind == rowSelectionAll || b.kind == rowSelectionAll {
+		return makeAllRowSelection(a.rows)
+	}
+	if a.kind == rowSelectionEmpty {
+		return b, nil
+	}
+	if b.kind == rowSelectionEmpty {
+		return a, nil
+	}
+	if a.kind == rowSelectionBitmap && b.kind == rowSelectionBitmap {
+		words := make([]uint64, len(a.bitmap))
+		for i := range words {
+			words[i] = a.bitmap[i] | b.bitmap[i]
+		}
+		return makeBitmapRowSelection(a.rows, words)
+	}
+	merged := append(a.appendRanges(nil), b.appendRanges(nil)...)
+	insertionSortRanges(merged)
+	return makeRangesRowSelection(a.rows, merged)
+}
+
+func notRowSelection(s rowSelection) (rowSelection, error) {
+	switch s.kind {
+	case rowSelectionEmpty:
+		return makeAllRowSelection(s.rows)
+	case rowSelectionAll:
+		return makeEmptyRowSelection(s.rows)
+	}
+	ranges := s.appendRanges(nil)
+	out := make([]rowRange, 0, len(ranges)+1)
+	start := 0
+	for _, r := range ranges {
+		if start < r.Start {
+			out = append(out, rowRange{Start: start, End: r.Start})
+		}
+		start = r.End
+	}
+	if start < s.rows {
+		out = append(out, rowRange{Start: start, End: s.rows})
+	}
+	return makeRangesRowSelection(s.rows, out)
+}
+
+func (k rowSelectionKind) String() string {
+	switch k {
+	case rowSelectionEmpty:
+		return "empty"
+	case rowSelectionAll:
+		return "all"
+	case rowSelectionRange:
+		return "range"
+	case rowSelectionRanges:
+		return "ranges"
+	case rowSelectionBitmap:
+		return "bitmap"
+	case rowSelectionSparse:
+		return "sparse"
+	default:
+		return "unknown"
+	}
+}
+
+func validateRowRange(rows int, r rowRange) error {
+	if rows < 0 {
+		return fmt.Errorf("typedcolumn: negative row selection rows %d", rows)
+	}
+	if r.Start < 0 || r.End < r.Start || r.End > rows {
+		return fmt.Errorf("typedcolumn: row range [%d,%d) outside [0,%d)", r.Start, r.End, rows)
+	}
+	return nil
+}
+
+func rowSelectionBitmapWords(rows int) int {
+	return (rows + 63) / 64
+}
+
+func contiguousBitmapRange(rows int, bitmap []uint64) (int, int, bool) {
+	start := -1
+	end := -1
+	seenGap := false
+	for row := 0; row < rows; row++ {
+		set := bitmap[row/64]&(uint64(1)<<uint(row%64)) != 0
+		switch {
+		case set && start < 0:
+			start = row
+			end = row + 1
+		case set && !seenGap:
+			end = row + 1
+		case set && seenGap:
+			return 0, 0, false
+		case !set && start >= 0:
+			seenGap = true
+		}
+	}
+	return start, end, start >= 0
+}
+
+func isContiguousSparse(rows []int) bool {
+	for i := 1; i < len(rows); i++ {
+		if rows[i] != rows[i-1]+1 {
+			return false
+		}
+	}
+	return true
+}
+
+func validateSameSelectionRows(a rowSelection, b rowSelection) error {
+	if a.rows != b.rows {
+		return fmt.Errorf("typedcolumn: row selection rows mismatch %d != %d", a.rows, b.rows)
+	}
+	return nil
+}
+
+func failClosedSelection(aRows int, bRows int) rowSelection {
+	rows := aRows
+	if bRows > rows {
+		rows = bRows
+	}
+	if rows < 0 {
+		rows = 0
+	}
+	return rowSelection{rows: rows, kind: rowSelectionEmpty}
+}
+
+func insertionSortRanges(ranges []rowRange) {
+	for i := 1; i < len(ranges); i++ {
+		r := ranges[i]
+		j := i - 1
+		for j >= 0 && (ranges[j].Start > r.Start || (ranges[j].Start == r.Start && ranges[j].End > r.End)) {
+			ranges[j+1] = ranges[j]
+			j--
+		}
+		ranges[j+1] = r
+	}
+}

--- a/TreeDB/internal/typedcolumn/row_selection.go
+++ b/TreeDB/internal/typedcolumn/row_selection.go
@@ -726,6 +726,58 @@ func orRowSelections(a rowSelection, b rowSelection) (rowSelection, error) {
 	return makeRangesRowSelection(a.rows, merged)
 }
 
+// SubtractRowSelectionsInto returns a-b using caller-owned scratch. The returned
+// selection may alias scratch until scratch is reused.
+func SubtractRowSelectionsInto(a RowSelection, b RowSelection, scratch *RowSelectionScratch) (RowSelection, error) {
+	if scratch == nil {
+		var local RowSelectionScratch
+		scratch = &local
+	}
+	if err := validateSameSelectionRows(a, b); err != nil {
+		return failClosedSelection(a.rows, b.rows), err
+	}
+	if a.kind == rowSelectionEmpty || b.kind == rowSelectionAll {
+		return makeEmptyRowSelection(a.rows)
+	}
+	if b.kind == rowSelectionEmpty {
+		return a, nil
+	}
+	// Copy/decompose inputs into stable scratch slices before resetting outRanges:
+	// either input may itself alias scratch.outRanges from a previous operation.
+	scratch.leftRanges = a.appendRanges(scratch.leftRanges[:0])
+	scratch.rightRanges = b.appendRanges(scratch.rightRanges[:0])
+	scratch.outRanges = scratch.outRanges[:0]
+	rightIdx := 0
+	for _, left := range scratch.leftRanges {
+		cursor := left.Start
+		for rightIdx < len(scratch.rightRanges) && scratch.rightRanges[rightIdx].End <= left.Start {
+			rightIdx++
+		}
+		for idx := rightIdx; idx < len(scratch.rightRanges); idx++ {
+			right := scratch.rightRanges[idx]
+			if right.Start >= left.End {
+				break
+			}
+			if cursor < right.Start {
+				end := min(right.Start, left.End)
+				if cursor < end {
+					scratch.outRanges = append(scratch.outRanges, RowRange{Start: cursor, End: end})
+				}
+			}
+			if right.End > cursor {
+				cursor = right.End
+				if cursor >= left.End {
+					break
+				}
+			}
+		}
+		if cursor < left.End {
+			scratch.outRanges = append(scratch.outRanges, RowRange{Start: cursor, End: left.End})
+		}
+	}
+	return makeRangesRowSelectionNoCopy(a.rows, scratch.outRanges)
+}
+
 // OrRowSelections returns the union of a and b.
 func OrRowSelections(a RowSelection, b RowSelection) (RowSelection, error) {
 	return orRowSelections(a, b)

--- a/TreeDB/internal/typedcolumn/row_selection.go
+++ b/TreeDB/internal/typedcolumn/row_selection.go
@@ -6,10 +6,15 @@ import (
 	"math/bits"
 )
 
-type rowSelectionKind uint8
+// RowSelectionKind names the concrete representation used for a block-local
+// row selection. Callers should prefer all/range/ranges forms when possible;
+// bitmap and sparse forms are available for genuinely irregular selections.
+type RowSelectionKind uint8
+
+type rowSelectionKind = RowSelectionKind
 
 const (
-	rowSelectionEmpty rowSelectionKind = iota
+	rowSelectionEmpty RowSelectionKind = iota
 	rowSelectionAll
 	rowSelectionRange
 	rowSelectionRanges
@@ -17,29 +22,61 @@ const (
 	rowSelectionSparse
 )
 
-type rowRange struct {
+const (
+	RowSelectionEmpty  RowSelectionKind = rowSelectionEmpty
+	RowSelectionAll    RowSelectionKind = rowSelectionAll
+	RowSelectionRange  RowSelectionKind = rowSelectionRange
+	RowSelectionRanges RowSelectionKind = rowSelectionRanges
+	RowSelectionBitmap RowSelectionKind = rowSelectionBitmap
+	RowSelectionSparse RowSelectionKind = rowSelectionSparse
+)
+
+// RowRange is a half-open [Start, End) range over a block-local row domain.
+type RowRange struct {
 	Start int
 	End   int
 }
 
-type rowSelection struct {
+type rowRange = RowRange
+
+// RowSelection is an immutable block-local selection over rows [0, Rows()).
+// Slice-backed selections may alias caller-owned scratch when constructed by a
+// NoCopy/Into helper; callers must not mutate those slices until the selection
+// is no longer used. The type deliberately has no package-global cache.
+type RowSelection struct {
 	rows   int
-	kind   rowSelectionKind
+	kind   RowSelectionKind
 	start  int
 	end    int
-	ranges []rowRange
+	ranges []RowRange
 	bitmap []uint64
 	sparse []int
 	count  int
 }
 
-type rowSelectionShape struct {
+type rowSelection = RowSelection
+
+// RowSelectionShape is a cheap diagnostic summary that does not materialize row
+// IDs.
+type RowSelectionShape struct {
 	Kind        string
 	Rows        int
 	Count       int
 	Ranges      int
 	BitmapWords int
 	SparseRows  int
+}
+
+type rowSelectionShape = RowSelectionShape
+
+// RowSelectionScratch owns caller-scoped temporary storage for composition and
+// no-copy constructors. Returned selections may alias these slices until the
+// next operation using the same scratch.
+type RowSelectionScratch struct {
+	leftRanges  []RowRange
+	rightRanges []RowRange
+	outRanges   []RowRange
+	bitmap      []uint64
 }
 
 func makeEmptyRowSelection(rows int) (rowSelection, error) {
@@ -177,6 +214,111 @@ func makeBitmapRowSelection(rows int, bitmap []uint64) (rowSelection, error) {
 	return rowSelection{rows: rows, kind: rowSelectionBitmap, bitmap: copyBitmap, count: count}, nil
 }
 
+// NewEmptyRowSelection returns an empty selection over rows.
+func NewEmptyRowSelection(rows int) (RowSelection, error) { return makeEmptyRowSelection(rows) }
+
+// NewAllRowSelection returns a compact all-rows selection over rows.
+func NewAllRowSelection(rows int) (RowSelection, error) { return makeAllRowSelection(rows) }
+
+// NewRangeRowSelection returns a compact half-open range selection.
+func NewRangeRowSelection(rows int, start int, end int) (RowSelection, error) {
+	return makeRangeRowSelection(rows, start, end)
+}
+
+// NewRangesRowSelection returns a compact multi-range selection. Adjacent ranges
+// are coalesced and fully-covered domains collapse to all.
+func NewRangesRowSelection(rows int, ranges []RowRange) (RowSelection, error) {
+	return makeRangesRowSelection(rows, ranges)
+}
+
+// NewSparseRowSelection returns a sparse selection from strictly increasing row
+// indexes. The input slice is copied.
+func NewSparseRowSelection(rows int, sparse []int) (RowSelection, error) {
+	return makeSparseRowSelection(rows, sparse)
+}
+
+// NewSparseRowSelectionNoCopy returns a sparse selection that may alias sparse.
+// The input must be strictly increasing and must not be mutated while the
+// selection is in use.
+func NewSparseRowSelectionNoCopy(rows int, sparse []int) (RowSelection, error) {
+	return makeSparseRowSelectionNoCopy(rows, sparse)
+}
+
+// NewBitmapRowSelection returns a bitmap selection. The bitmap slice is copied
+// and must have exactly ceil(rows/64) words with zero padding bits.
+func NewBitmapRowSelection(rows int, bitmap []uint64) (RowSelection, error) {
+	return makeBitmapRowSelection(rows, bitmap)
+}
+
+func makeSparseRowSelectionNoCopy(rows int, sparse []int) (RowSelection, error) {
+	if rows < 0 {
+		return RowSelection{}, fmt.Errorf("typedcolumn: negative row selection rows %d", rows)
+	}
+	if len(sparse) == 0 {
+		return makeEmptyRowSelection(rows)
+	}
+	for i, row := range sparse {
+		if row < 0 || row >= rows {
+			return RowSelection{}, fmt.Errorf("typedcolumn: sparse row %d=%d outside [0,%d)", i, row, rows)
+		}
+		if i > 0 && row <= sparse[i-1] {
+			return RowSelection{}, fmt.Errorf("typedcolumn: sparse rows not strictly increasing at %d", i)
+		}
+	}
+	if len(sparse) == rows {
+		return makeAllRowSelection(rows)
+	}
+	if isContiguousSparse(sparse) {
+		return makeRangeRowSelection(rows, sparse[0], sparse[len(sparse)-1]+1)
+	}
+	return RowSelection{rows: rows, kind: rowSelectionSparse, sparse: sparse, count: len(sparse)}, nil
+}
+
+func makeRangesRowSelectionNoCopy(rows int, ranges []RowRange) (RowSelection, error) {
+	if rows < 0 {
+		return RowSelection{}, fmt.Errorf("typedcolumn: negative row selection rows %d", rows)
+	}
+	if len(ranges) == 0 {
+		return makeEmptyRowSelection(rows)
+	}
+	out := ranges[:0]
+	for i, r := range ranges {
+		if err := validateRowRange(rows, r); err != nil {
+			return RowSelection{}, fmt.Errorf("typedcolumn: invalid row range %d: %w", i, err)
+		}
+		if r.Start == r.End {
+			continue
+		}
+		if len(out) == 0 {
+			out = append(out, r)
+			continue
+		}
+		last := &out[len(out)-1]
+		if r.Start < last.End {
+			return RowSelection{}, fmt.Errorf("typedcolumn: row ranges overlap at %d", i)
+		}
+		if r.Start == last.End {
+			last.End = r.End
+			continue
+		}
+		out = append(out, r)
+	}
+	if len(out) == 0 {
+		return makeEmptyRowSelection(rows)
+	}
+	count := 0
+	for _, r := range out {
+		count += r.End - r.Start
+	}
+	if count == rows {
+		return makeAllRowSelection(rows)
+	}
+	if len(out) == 1 {
+		return makeRangeRowSelection(rows, out[0].Start, out[0].End)
+	}
+	return RowSelection{rows: rows, kind: rowSelectionRanges, ranges: out, count: count}, nil
+}
+
 func (s rowSelection) rowsCount() int {
 	return s.rows
 }
@@ -184,6 +326,79 @@ func (s rowSelection) rowsCount() int {
 func (s rowSelection) countRows() int {
 	return s.count
 }
+
+// Rows returns the row-domain size.
+func (s RowSelection) Rows() int { return s.rows }
+
+// Count returns the selected row count without materializing row IDs.
+func (s RowSelection) Count() int { return s.count }
+
+// Kind returns the compact representation shape.
+func (s RowSelection) Kind() RowSelectionKind { return s.kind }
+
+// IsEmpty reports whether no rows are selected.
+func (s RowSelection) IsEmpty() bool { return s.count == 0 || s.kind == rowSelectionEmpty }
+
+// IsAll reports whether the selection covers the whole row domain.
+func (s RowSelection) IsAll() bool { return s.kind == rowSelectionAll }
+
+// SingleRange exposes the half-open range for range selections.
+func (s RowSelection) SingleRange() (start int, end int, ok bool) {
+	if s.kind != rowSelectionRange {
+		return 0, 0, false
+	}
+	return s.start, s.end, true
+}
+
+// Ranges returns the internal range slice for range/ranges selections. Treat the
+// returned slice as read-only and copy it if it must outlive caller scratch.
+func (s RowSelection) Ranges() []RowRange {
+	switch s.kind {
+	case rowSelectionRange:
+		return []RowRange{{Start: s.start, End: s.end}}
+	case rowSelectionRanges:
+		return s.ranges
+	case rowSelectionAll:
+		return []RowRange{{Start: 0, End: s.rows}}
+	default:
+		return nil
+	}
+}
+
+// SparseRows returns the internal sparse row slice for sparse selections.
+// Treat the returned slice as read-only.
+func (s RowSelection) SparseRows() []int {
+	if s.kind != rowSelectionSparse {
+		return nil
+	}
+	return s.sparse
+}
+
+// BitmapWords returns the internal bitmap words for bitmap selections. Treat the
+// returned slice as read-only.
+func (s RowSelection) BitmapWords() []uint64 {
+	if s.kind != rowSelectionBitmap {
+		return nil
+	}
+	return s.bitmap
+}
+
+// Contains reports whether row is selected.
+func (s RowSelection) Contains(row int) bool { return s.contains(row) }
+
+// ForEach calls fn once for each selected row in ascending order. It does not
+// allocate, but performance-sensitive kernels should switch on Kind and use the
+// concrete accessors to avoid callback overhead in inner loops.
+func (s RowSelection) ForEach(fn func(row int)) { s.forEach(fn) }
+
+// AppendRows appends selected rows in ascending order to dst.
+func (s RowSelection) AppendRows(dst []int) []int { return s.appendRows(dst) }
+
+// AppendRanges appends a range decomposition to dst without materializing rows.
+func (s RowSelection) AppendRanges(dst []RowRange) []RowRange { return s.appendRanges(dst) }
+
+// Shape returns diagnostic metadata for the selection representation.
+func (s RowSelection) Shape() RowSelectionShape { return s.shape() }
 
 func (s rowSelection) shape() rowSelectionShape {
 	shape := rowSelectionShape{Kind: s.kind.String(), Rows: s.rows, Count: s.count}
@@ -397,6 +612,95 @@ func andRowSelections(a rowSelection, b rowSelection) (rowSelection, error) {
 	return makeRangesRowSelection(a.rows, out)
 }
 
+// AndRowSelections returns the intersection of a and b. Mixed-shape results are
+// range-normalized and may allocate; use AndRowSelectionsInto with caller scratch
+// on prepared/hot paths.
+func AndRowSelections(a RowSelection, b RowSelection) (RowSelection, error) {
+	return andRowSelections(a, b)
+}
+
+// AndRowSelectionsInto intersects a and b using caller-owned scratch for mixed
+// range results. The returned selection may alias scratch until the next scratch
+// use.
+func AndRowSelectionsInto(a RowSelection, b RowSelection, scratch *RowSelectionScratch) (RowSelection, error) {
+	if scratch == nil {
+		return andRowSelections(a, b)
+	}
+	if err := validateSameSelectionRows(a, b); err != nil {
+		return failClosedSelection(a.rows, b.rows), err
+	}
+	if a.kind == rowSelectionEmpty || b.kind == rowSelectionEmpty {
+		return makeEmptyRowSelection(a.rows)
+	}
+	if a.kind == rowSelectionAll {
+		return b, nil
+	}
+	if b.kind == rowSelectionAll {
+		return a, nil
+	}
+	if a.kind == rowSelectionBitmap && b.kind == rowSelectionBitmap {
+		words := rowSelectionBitmapWords(a.rows)
+		if cap(scratch.bitmap) < words {
+			scratch.bitmap = make([]uint64, words)
+		}
+		out := scratch.bitmap[:words]
+		for i := range out {
+			out[i] = a.bitmap[i] & b.bitmap[i]
+		}
+		return makeBitmapRowSelectionNoCopy(a.rows, out)
+	}
+	scratch.leftRanges = a.appendRanges(scratch.leftRanges[:0])
+	scratch.rightRanges = b.appendRanges(scratch.rightRanges[:0])
+	scratch.outRanges = scratch.outRanges[:0]
+	i, j := 0, 0
+	for i < len(scratch.leftRanges) && j < len(scratch.rightRanges) {
+		start := max(scratch.leftRanges[i].Start, scratch.rightRanges[j].Start)
+		end := min(scratch.leftRanges[i].End, scratch.rightRanges[j].End)
+		if start < end {
+			scratch.outRanges = append(scratch.outRanges, RowRange{Start: start, End: end})
+		}
+		if scratch.leftRanges[i].End < scratch.rightRanges[j].End {
+			i++
+		} else {
+			j++
+		}
+	}
+	return makeRangesRowSelectionNoCopy(a.rows, scratch.outRanges)
+}
+
+func makeBitmapRowSelectionNoCopy(rows int, bitmap []uint64) (RowSelection, error) {
+	if rows < 0 {
+		return RowSelection{}, fmt.Errorf("typedcolumn: negative row selection rows %d", rows)
+	}
+	wantWords := rowSelectionBitmapWords(rows)
+	if len(bitmap) != wantWords {
+		return RowSelection{}, fmt.Errorf("typedcolumn: bitmap words=%d want=%d", len(bitmap), wantWords)
+	}
+	if wantWords == 0 {
+		return makeEmptyRowSelection(rows)
+	}
+	if padding := rows % 64; padding != 0 {
+		valid := uint64(1<<uint(padding)) - 1
+		if bitmap[len(bitmap)-1]&^valid != 0 {
+			return RowSelection{}, errors.New("typedcolumn: row selection bitmap has non-zero padding bits")
+		}
+	}
+	count := 0
+	for _, word := range bitmap {
+		count += bits.OnesCount64(word)
+	}
+	if count == 0 {
+		return makeEmptyRowSelection(rows)
+	}
+	if count == rows {
+		return makeAllRowSelection(rows)
+	}
+	if start, end, ok := contiguousBitmapRange(rows, bitmap); ok {
+		return makeRangeRowSelection(rows, start, end)
+	}
+	return RowSelection{rows: rows, kind: rowSelectionBitmap, bitmap: bitmap, count: count}, nil
+}
+
 func orRowSelections(a rowSelection, b rowSelection) (rowSelection, error) {
 	if err := validateSameSelectionRows(a, b); err != nil {
 		return failClosedSelection(a.rows, b.rows), err
@@ -420,6 +724,43 @@ func orRowSelections(a rowSelection, b rowSelection) (rowSelection, error) {
 	merged := append(a.appendRanges(nil), b.appendRanges(nil)...)
 	insertionSortRanges(merged)
 	return makeRangesRowSelection(a.rows, merged)
+}
+
+// OrRowSelections returns the union of a and b.
+func OrRowSelections(a RowSelection, b RowSelection) (RowSelection, error) {
+	return orRowSelections(a, b)
+}
+
+// NotRowSelection returns the complement of s over its row domain.
+func NotRowSelection(s RowSelection) (RowSelection, error) {
+	return notRowSelection(s)
+}
+
+// NotRowSelectionInto returns the complement of s using caller scratch for range
+// decomposition. Returned selections may alias scratch.
+func NotRowSelectionInto(s RowSelection, scratch *RowSelectionScratch) (RowSelection, error) {
+	if scratch == nil {
+		return notRowSelection(s)
+	}
+	switch s.kind {
+	case rowSelectionEmpty:
+		return makeAllRowSelection(s.rows)
+	case rowSelectionAll:
+		return makeEmptyRowSelection(s.rows)
+	}
+	scratch.leftRanges = s.appendRanges(scratch.leftRanges[:0])
+	scratch.outRanges = scratch.outRanges[:0]
+	start := 0
+	for _, r := range scratch.leftRanges {
+		if start < r.Start {
+			scratch.outRanges = append(scratch.outRanges, RowRange{Start: start, End: r.Start})
+		}
+		start = r.End
+	}
+	if start < s.rows {
+		scratch.outRanges = append(scratch.outRanges, RowRange{Start: start, End: s.rows})
+	}
+	return makeRangesRowSelectionNoCopy(s.rows, scratch.outRanges)
 }
 
 func notRowSelection(s rowSelection) (rowSelection, error) {

--- a/TreeDB/internal/typedcolumn/row_selection.go
+++ b/TreeDB/internal/typedcolumn/row_selection.go
@@ -723,7 +723,38 @@ func orRowSelections(a rowSelection, b rowSelection) (rowSelection, error) {
 	}
 	merged := append(a.appendRanges(nil), b.appendRanges(nil)...)
 	insertionSortRanges(merged)
-	return makeRangesRowSelection(a.rows, merged)
+	return makeUnionRangesRowSelection(a.rows, merged)
+}
+
+func makeUnionRangesRowSelection(rows int, ranges []RowRange) (RowSelection, error) {
+	if rows < 0 {
+		return RowSelection{}, fmt.Errorf("typedcolumn: negative row selection rows %d", rows)
+	}
+	if len(ranges) == 0 {
+		return makeEmptyRowSelection(rows)
+	}
+	out := ranges[:0]
+	for i, r := range ranges {
+		if err := validateRowRange(rows, r); err != nil {
+			return RowSelection{}, fmt.Errorf("typedcolumn: invalid row range %d: %w", i, err)
+		}
+		if r.Start == r.End {
+			continue
+		}
+		if len(out) == 0 {
+			out = append(out, r)
+			continue
+		}
+		last := &out[len(out)-1]
+		if r.Start <= last.End {
+			if r.End > last.End {
+				last.End = r.End
+			}
+			continue
+		}
+		out = append(out, r)
+	}
+	return makeRangesRowSelectionNoCopy(rows, out)
 }
 
 // SubtractRowSelectionsInto returns a-b using caller-owned scratch. The returned

--- a/TreeDB/internal/typedcolumn/row_selection.go
+++ b/TreeDB/internal/typedcolumn/row_selection.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"math/bits"
+	"slices"
 )
 
 // RowSelectionKind names the concrete representation used for a block-local
@@ -128,7 +129,7 @@ func makeRangesRowSelection(rows int, ranges []rowRange) (rowSelection, error) {
 	if len(merged) == 0 {
 		return makeEmptyRowSelection(rows)
 	}
-	insertionSortRanges(merged)
+	sortRowRanges(merged)
 	return makeUnionRangesRowSelection(rows, merged)
 }
 
@@ -329,8 +330,10 @@ func (s RowSelection) SingleRange() (start int, end int, ok bool) {
 	return s.start, s.end, true
 }
 
-// Ranges returns the internal range slice for range/ranges selections. Treat the
-// returned slice as read-only and copy it if it must outlive caller scratch.
+// Ranges returns a range decomposition for range/ranges/all selections. Treat
+// the returned slice as read-only and copy it if it must outlive caller scratch.
+// For all/range shapes this returns a fresh one-element slice; hot paths should
+// prefer SingleRange or AppendRanges with caller-owned scratch.
 func (s RowSelection) Ranges() []RowRange {
 	switch s.kind {
 	case rowSelectionRange:
@@ -406,15 +409,16 @@ func (s rowSelection) contains(row int) bool {
 	case rowSelectionRange:
 		return row >= s.start && row < s.end
 	case rowSelectionRanges:
-		for _, r := range s.ranges {
-			if row < r.Start {
-				return false
-			}
-			if row < r.End {
-				return true
+		lo, hi := 0, len(s.ranges)
+		for lo < hi {
+			mid := int(uint(lo+hi) >> 1)
+			if s.ranges[mid].End <= row {
+				lo = mid + 1
+			} else {
+				hi = mid
 			}
 		}
-		return false
+		return lo < len(s.ranges) && row >= s.ranges[lo].Start
 	case rowSelectionBitmap:
 		return s.bitmap[row/64]&(uint64(1)<<uint(row%64)) != 0
 	case rowSelectionSparse:
@@ -701,7 +705,7 @@ func orRowSelections(a rowSelection, b rowSelection) (rowSelection, error) {
 		return makeBitmapRowSelection(a.rows, words)
 	}
 	merged := append(a.appendRanges(nil), b.appendRanges(nil)...)
-	insertionSortRanges(merged)
+	sortRowRanges(merged)
 	return makeUnionRangesRowSelection(a.rows, merged)
 }
 
@@ -926,14 +930,19 @@ func failClosedSelection(aRows int, bRows int) rowSelection {
 	return rowSelection{rows: rows, kind: rowSelectionEmpty}
 }
 
-func insertionSortRanges(ranges []rowRange) {
-	for i := 1; i < len(ranges); i++ {
-		r := ranges[i]
-		j := i - 1
-		for j >= 0 && (ranges[j].Start > r.Start || (ranges[j].Start == r.Start && ranges[j].End > r.End)) {
-			ranges[j+1] = ranges[j]
-			j--
+func sortRowRanges(ranges []rowRange) {
+	slices.SortFunc(ranges, func(a, b rowRange) int {
+		switch {
+		case a.Start < b.Start:
+			return -1
+		case a.Start > b.Start:
+			return 1
+		case a.End < b.End:
+			return -1
+		case a.End > b.End:
+			return 1
+		default:
+			return 0
 		}
-		ranges[j+1] = r
-	}
+	})
 }

--- a/TreeDB/internal/typedcolumn/row_selection.go
+++ b/TreeDB/internal/typedcolumn/row_selection.go
@@ -116,42 +116,20 @@ func makeRangesRowSelection(rows int, ranges []rowRange) (rowSelection, error) {
 	if len(ranges) == 0 {
 		return makeEmptyRowSelection(rows)
 	}
-	merged := make([]rowRange, 0, len(ranges))
+	merged := make([]RowRange, 0, len(ranges))
 	for i, r := range ranges {
 		if err := validateRowRange(rows, r); err != nil {
 			return rowSelection{}, fmt.Errorf("typedcolumn: invalid row range %d: %w", i, err)
 		}
-		if r.Start == r.End {
-			continue
-		}
-		if len(merged) == 0 {
+		if r.Start != r.End {
 			merged = append(merged, r)
-			continue
 		}
-		last := &merged[len(merged)-1]
-		if r.Start < last.End {
-			return rowSelection{}, fmt.Errorf("typedcolumn: row ranges overlap at %d", i)
-		}
-		if r.Start == last.End {
-			last.End = r.End
-			continue
-		}
-		merged = append(merged, r)
 	}
 	if len(merged) == 0 {
 		return makeEmptyRowSelection(rows)
 	}
-	count := 0
-	for _, r := range merged {
-		count += r.End - r.Start
-	}
-	if count == rows {
-		return makeAllRowSelection(rows)
-	}
-	if len(merged) == 1 {
-		return makeRangeRowSelection(rows, merged[0].Start, merged[0].End)
-	}
-	return rowSelection{rows: rows, kind: rowSelectionRanges, ranges: merged, count: count}, nil
+	insertionSortRanges(merged)
+	return makeUnionRangesRowSelection(rows, merged)
 }
 
 func makeSparseRowSelection(rows int, sparse []int) (rowSelection, error) {
@@ -225,8 +203,9 @@ func NewRangeRowSelection(rows int, start int, end int) (RowSelection, error) {
 	return makeRangeRowSelection(rows, start, end)
 }
 
-// NewRangesRowSelection returns a compact multi-range selection. Adjacent ranges
-// are coalesced and fully-covered domains collapse to all.
+// NewRangesRowSelection returns a compact multi-range selection. Ranges may be
+// unsorted; overlapping and adjacent ranges are coalesced, and fully-covered
+// domains collapse to all.
 func NewRangesRowSelection(rows int, ranges []RowRange) (RowSelection, error) {
 	return makeRangesRowSelection(rows, ranges)
 }
@@ -940,12 +919,10 @@ func validateSameSelectionRows(a rowSelection, b rowSelection) error {
 
 func failClosedSelection(aRows int, bRows int) rowSelection {
 	rows := aRows
-	if bRows > rows {
-		rows = bRows
-	}
 	if rows < 0 {
 		rows = 0
 	}
+	_ = bRows
 	return rowSelection{rows: rows, kind: rowSelectionEmpty}
 }
 

--- a/TreeDB/internal/typedcolumn/row_selection_test.go
+++ b/TreeDB/internal/typedcolumn/row_selection_test.go
@@ -194,6 +194,38 @@ func TestSectionDependencyDescriptorsCoverRolesAndAlign(t *testing.T) {
 	if err == nil || ok || got.RowCount != 0 {
 		t.Fatalf("validateSectionDependencies mismatch got=%+v ok=%v err=%v", got, ok, err)
 	}
+
+	predicateDeps, err := PredicateColumnDependencies("active", ColumnTypeBool, span, true)
+	if err != nil {
+		t.Fatalf("PredicateColumnDependencies: %v", err)
+	}
+	seenKinds := make(map[SectionDependencyKind]bool)
+	for _, dep := range predicateDeps {
+		seenKinds[dep.Kind] = true
+	}
+	for _, kind := range []SectionDependencyKind{SectionDependencyValues, SectionDependencyPruningMetadata, SectionDependencyNullMask, SectionDependencyDefaultMask} {
+		if !seenKinds[kind] {
+			t.Fatalf("predicate dependency kinds=%v missing %s", seenKinds, kind)
+		}
+	}
+}
+
+func TestColumnRowAlignmentRejectsAssetIdentityMismatches(t *testing.T) {
+	span := mustRowSpan(t, 0, 16)
+	_, ok, err := alignColumnRowSpans([]columnRowDescriptor{
+		{Column: "predicate", Type: ColumnTypeInt64, Span: span, SnapshotGeneration: 7, AssetGeneration: 10, PartID: 2, SchemaVersion: 99, AlignmentKey: "asset-a"},
+		{Column: "measure", Type: ColumnTypeInt64, Span: span, SnapshotGeneration: 7, AssetGeneration: 10, PartID: 2, SchemaVersion: 99, AlignmentKey: "asset-b"},
+	})
+	if err == nil || ok || !strings.Contains(err.Error(), "asset ref") {
+		t.Fatalf("asset mismatch ok=%v err=%v", ok, err)
+	}
+	_, ok, err = alignColumnRowSpans([]columnRowDescriptor{
+		{Column: "predicate", Type: ColumnTypeInt64, Span: span, SnapshotGeneration: 7, AssetGeneration: 10, PartID: 2, SchemaVersion: 99},
+		{Column: "measure", Type: ColumnTypeInt64, Span: span, SnapshotGeneration: 8, AssetGeneration: 10, PartID: 2, SchemaVersion: 99},
+	})
+	if err == nil || ok || !strings.Contains(err.Error(), "snapshot generation") {
+		t.Fatalf("snapshot mismatch ok=%v err=%v", ok, err)
+	}
 }
 
 func TestRowSelectionNonInt64SmokeConsumption(t *testing.T) {
@@ -224,6 +256,21 @@ func TestRowSelectionNonInt64SmokeConsumption(t *testing.T) {
 	}
 }
 
+func BenchmarkRowSelectionIterateAll(b *testing.B) {
+	selection := mustAllSelection(b, 4096)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		count := 0
+		selection.forEach(func(row int) {
+			count += row & 1
+		})
+		if count == -1 {
+			b.Fatal(count)
+		}
+	}
+}
+
 func BenchmarkRowSelectionIterateRange(b *testing.B) {
 	selection := mustRangeSelection(b, 4096, 256, 3840)
 	b.ReportAllocs()
@@ -234,6 +281,44 @@ func BenchmarkRowSelectionIterateRange(b *testing.B) {
 			count += row & 1
 		})
 		if count == -1 {
+			b.Fatal(count)
+		}
+	}
+}
+
+func BenchmarkRowSelectionIterateBitmap(b *testing.B) {
+	setRows := make([]int, 0, 512)
+	for row := 0; row < 4096; row += 8 {
+		setRows = append(setRows, row)
+	}
+	selection := mustBitmapSelection(b, 4096, setRows)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		count := 0
+		selection.forEach(func(row int) {
+			count += row & 1
+		})
+		if count != 0 {
+			b.Fatal(count)
+		}
+	}
+}
+
+func BenchmarkRowSelectionIterateSparse(b *testing.B) {
+	setRows := make([]int, 0, 512)
+	for row := 0; row < 4096; row += 8 {
+		setRows = append(setRows, row)
+	}
+	selection := mustSparseSelection(b, 4096, setRows)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		count := 0
+		selection.forEach(func(row int) {
+			count += row & 1
+		})
+		if count != 0 {
 			b.Fatal(count)
 		}
 	}
@@ -261,6 +346,26 @@ func BenchmarkRowSelectionAndRanges(b *testing.B) {
 		got, err := andRowSelections(left, right)
 		if err != nil || got.countRows() != 2048 {
 			b.Fatalf("got count=%d err=%v", got.countRows(), err)
+		}
+	}
+}
+
+func BenchmarkRowSelectionComposeScratchNoAlloc(b *testing.B) {
+	predicate := mustRangesSelection(b, 8192, []rowRange{{Start: 0, End: 4096}, {Start: 6144, End: 8192}})
+	visibility := mustRangesSelection(b, 8192, []rowRange{{Start: 1024, End: 7168}})
+	deletes := mustSparseSelection(b, 8192, []int{2048, 2049, 4096, 4097})
+	components := rowSelectionComponents{Predicate: &predicate, Visibility: &visibility, Deletes: &deletes}
+	var scratch RowSelectionScratch
+	warm, err := ComposeRowSelectionsInto(8192, components, &scratch)
+	if err != nil || warm.countRows() == 0 {
+		b.Fatalf("warm count=%d err=%v", warm.countRows(), err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		got, err := ComposeRowSelectionsInto(8192, components, &scratch)
+		if err != nil || got.countRows() != warm.countRows() {
+			b.Fatalf("got count=%d warm=%d err=%v", got.countRows(), warm.countRows(), err)
 		}
 	}
 }

--- a/TreeDB/internal/typedcolumn/row_selection_test.go
+++ b/TreeDB/internal/typedcolumn/row_selection_test.go
@@ -84,6 +84,30 @@ func TestRowSelectionSetOperationsAndComposition(t *testing.T) {
 	assertSelectionRows(t, composed, []int{2, 4, 9})
 }
 
+func TestRowSelectionScratchCompositionMatchesAllocatingComposition(t *testing.T) {
+	predicate := mustRangesSelection(t, 12, []rowRange{{Start: 0, End: 8}, {Start: 9, End: 12}})
+	visibility := mustRangesSelection(t, 12, []rowRange{{Start: 0, End: 12}})
+	deletes := mustSparseSelection(t, 12, []int{8})
+	nulls := mustRangeSelection(t, 12, 9, 10)
+	defaults := mustRangeSelection(t, 12, 10, 11)
+	components := rowSelectionComponents{Predicate: &predicate, Visibility: &visibility, Deletes: &deletes, Nulls: &nulls, Defaults: &defaults}
+	want, err := ComposeRowSelections(12, components)
+	if err != nil {
+		t.Fatalf("ComposeRowSelections: %v", err)
+	}
+	assertSelectionRows(t, want, []int{0, 1, 2, 3, 4, 5, 6, 7, 11})
+	var scratch RowSelectionScratch
+	for i := 0; i < 3; i++ {
+		got, err := ComposeRowSelectionsInto(12, components, &scratch)
+		if err != nil {
+			t.Fatalf("ComposeRowSelectionsInto iter %d: %v", i, err)
+		}
+		if !reflect.DeepEqual(got.appendRows(nil), want.appendRows(nil)) {
+			t.Fatalf("iter %d rows=%v want %v shape=%+v", i, got.appendRows(nil), want.appendRows(nil), got.shape())
+		}
+	}
+}
+
 func TestRowSelectionFailClosedOnMaskRowMismatch(t *testing.T) {
 	predicate := mustAllSelection(t, 5)
 	visibility := mustAllSelection(t, 6)

--- a/TreeDB/internal/typedcolumn/row_selection_test.go
+++ b/TreeDB/internal/typedcolumn/row_selection_test.go
@@ -29,6 +29,9 @@ func TestRowSelectionShapesCountIterateAndRanges(t *testing.T) {
 	if shape := ranges.shape(); shape.Kind != "ranges" || shape.Ranges != 3 || shape.Count != 5 {
 		t.Fatalf("ranges shape=%+v", shape)
 	}
+	coalesced := mustRangesSelection(t, 10, []rowRange{{Start: 6, End: 8}, {Start: 1, End: 4}, {Start: 3, End: 6}})
+	assertSelectionRows(t, coalesced, []int{1, 2, 3, 4, 5, 6, 7})
+	assertSelectionRanges(t, coalesced, []rowRange{{Start: 1, End: 8}})
 
 	bitmap := mustBitmapSelection(t, 130, []int{0, 2, 64, 129})
 	assertSelectionRows(t, bitmap, []int{0, 2, 64, 129})
@@ -123,7 +126,7 @@ func TestRowSelectionFailClosedOnMaskRowMismatch(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "visibility mask row mismatch") {
 		t.Fatalf("compose mismatch err=%v", err)
 	}
-	if got.countRows() != 0 || got.shape().Kind != "empty" {
+	if got.countRows() != 0 || got.shape().Kind != "empty" || got.rowsCount() != 5 {
 		t.Fatalf("fail-closed selection=%+v shape=%+v", got, got.shape())
 	}
 

--- a/TreeDB/internal/typedcolumn/row_selection_test.go
+++ b/TreeDB/internal/typedcolumn/row_selection_test.go
@@ -58,12 +58,20 @@ func TestRowSelectionSetOperationsAndComposition(t *testing.T) {
 
 	orSel, err := orRowSelections(mustRangeSelection(t, 12, 0, 2), mustRangeSelection(t, 12, 2, 4))
 	if err != nil {
-		t.Fatalf("orRowSelections: %v", err)
+		t.Fatalf("orRowSelections adjacent: %v", err)
 	}
 	if shape := orSel.shape(); shape.Kind != "range" {
 		t.Fatalf("adjacent OR shape=%+v want range", shape)
 	}
 	assertSelectionRows(t, orSel, []int{0, 1, 2, 3})
+	overlapOr, err := orRowSelections(mustRangeSelection(t, 12, 0, 6), mustRangeSelection(t, 12, 3, 9))
+	if err != nil {
+		t.Fatalf("orRowSelections overlap: %v", err)
+	}
+	if shape := overlapOr.shape(); shape.Kind != "range" {
+		t.Fatalf("overlap OR shape=%+v want range", shape)
+	}
+	assertSelectionRows(t, overlapOr, []int{0, 1, 2, 3, 4, 5, 6, 7, 8})
 
 	notSel, err := notRowSelection(mustRangesSelection(t, 8, []rowRange{{Start: 2, End: 4}, {Start: 6, End: 7}}))
 	if err != nil {

--- a/TreeDB/internal/typedcolumn/row_selection_test.go
+++ b/TreeDB/internal/typedcolumn/row_selection_test.go
@@ -1,0 +1,377 @@
+package typedcolumn
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestRowSelectionShapesCountIterateAndRanges(t *testing.T) {
+	all := mustAllSelection(t, 8)
+	assertSelectionRows(t, all, []int{0, 1, 2, 3, 4, 5, 6, 7})
+	if shape := all.shape(); shape.Kind != "all" || shape.Count != 8 || shape.BitmapWords != 0 {
+		t.Fatalf("all shape=%+v", shape)
+	}
+
+	empty := mustEmptySelection(t, 8)
+	assertSelectionRows(t, empty, nil)
+
+	rangeSel := mustRangeSelection(t, 8, 2, 6)
+	assertSelectionRows(t, rangeSel, []int{2, 3, 4, 5})
+	assertSelectionRanges(t, rangeSel, []rowRange{{Start: 2, End: 6}})
+	if shape := rangeSel.shape(); shape.Kind != "range" || shape.Ranges != 1 || shape.Count != 4 {
+		t.Fatalf("range shape=%+v", shape)
+	}
+
+	ranges := mustRangesSelection(t, 10, []rowRange{{Start: 1, End: 3}, {Start: 5, End: 7}, {Start: 8, End: 9}})
+	assertSelectionRows(t, ranges, []int{1, 2, 5, 6, 8})
+	assertSelectionRanges(t, ranges, []rowRange{{Start: 1, End: 3}, {Start: 5, End: 7}, {Start: 8, End: 9}})
+	if shape := ranges.shape(); shape.Kind != "ranges" || shape.Ranges != 3 || shape.Count != 5 {
+		t.Fatalf("ranges shape=%+v", shape)
+	}
+
+	bitmap := mustBitmapSelection(t, 130, []int{0, 2, 64, 129})
+	assertSelectionRows(t, bitmap, []int{0, 2, 64, 129})
+	if shape := bitmap.shape(); shape.Kind != "bitmap" || shape.BitmapWords != 3 || shape.Count != 4 {
+		t.Fatalf("bitmap shape=%+v", shape)
+	}
+
+	sparse := mustSparseSelection(t, 20, []int{1, 4, 9, 19})
+	assertSelectionRows(t, sparse, []int{1, 4, 9, 19})
+	if shape := sparse.shape(); shape.Kind != "sparse" || shape.SparseRows != 4 || shape.Count != 4 {
+		t.Fatalf("sparse shape=%+v", shape)
+	}
+}
+
+func TestRowSelectionSetOperationsAndComposition(t *testing.T) {
+	predicate := mustRangesSelection(t, 12, []rowRange{{Start: 2, End: 10}})
+	visibility := mustRangesSelection(t, 12, []rowRange{{Start: 0, End: 6}, {Start: 8, End: 12}})
+	deletes := mustSparseSelection(t, 12, []int{3, 8})
+	nulls := mustRangeSelection(t, 12, 5, 6)
+	defaults := mustEmptySelection(t, 12)
+
+	andSel, err := andRowSelections(predicate, visibility)
+	if err != nil {
+		t.Fatalf("andRowSelections: %v", err)
+	}
+	assertSelectionRows(t, andSel, []int{2, 3, 4, 5, 8, 9})
+
+	orSel, err := orRowSelections(mustRangeSelection(t, 12, 0, 2), mustRangeSelection(t, 12, 2, 4))
+	if err != nil {
+		t.Fatalf("orRowSelections: %v", err)
+	}
+	if shape := orSel.shape(); shape.Kind != "range" {
+		t.Fatalf("adjacent OR shape=%+v want range", shape)
+	}
+	assertSelectionRows(t, orSel, []int{0, 1, 2, 3})
+
+	notSel, err := notRowSelection(mustRangesSelection(t, 8, []rowRange{{Start: 2, End: 4}, {Start: 6, End: 7}}))
+	if err != nil {
+		t.Fatalf("notRowSelection: %v", err)
+	}
+	assertSelectionRows(t, notSel, []int{0, 1, 4, 5, 7})
+
+	composed, err := composeRowSelections(12, rowSelectionComponents{
+		Predicate:  &predicate,
+		Visibility: &visibility,
+		Deletes:    &deletes,
+		Nulls:      &nulls,
+		Defaults:   &defaults,
+	})
+	if err != nil {
+		t.Fatalf("composeRowSelections: %v", err)
+	}
+	assertSelectionRows(t, composed, []int{2, 4, 9})
+}
+
+func TestRowSelectionFailClosedOnMaskRowMismatch(t *testing.T) {
+	predicate := mustAllSelection(t, 5)
+	visibility := mustAllSelection(t, 6)
+	got, err := composeRowSelections(5, rowSelectionComponents{Predicate: &predicate, Visibility: &visibility})
+	if err == nil || !strings.Contains(err.Error(), "visibility mask row mismatch") {
+		t.Fatalf("compose mismatch err=%v", err)
+	}
+	if got.countRows() != 0 || got.shape().Kind != "empty" {
+		t.Fatalf("fail-closed selection=%+v shape=%+v", got, got.shape())
+	}
+
+	other := mustAllSelection(t, 4)
+	got, err = andRowSelections(predicate, other)
+	if err == nil || !strings.Contains(err.Error(), "rows mismatch") {
+		t.Fatalf("and mismatch err=%v", err)
+	}
+	if got.countRows() != 0 {
+		t.Fatalf("and fail-closed count=%d", got.countRows())
+	}
+}
+
+func TestRowSelectionDoesNotMaterializeBitmapForAllOrRange(t *testing.T) {
+	allWords := []uint64{^uint64(0), (uint64(1) << 6) - 1}
+	all, err := makeBitmapRowSelection(70, allWords)
+	if err != nil {
+		t.Fatalf("makeBitmapRowSelection all: %v", err)
+	}
+	if shape := all.shape(); shape.Kind != "all" || shape.BitmapWords != 0 {
+		t.Fatalf("all bitmap shape=%+v", shape)
+	}
+
+	words := bitmapWordsForRows(70, []int{10, 11, 12, 13})
+	rangeSel, err := makeBitmapRowSelection(70, words)
+	if err != nil {
+		t.Fatalf("makeBitmapRowSelection range: %v", err)
+	}
+	if shape := rangeSel.shape(); shape.Kind != "range" || shape.BitmapWords != 0 {
+		t.Fatalf("range bitmap shape=%+v", shape)
+	}
+}
+
+func TestRowSelectionIterationAllocationEvidence(t *testing.T) {
+	selection := mustRangeSelection(t, 1024, 128, 896)
+	var sum int
+	allocs := testing.AllocsPerRun(1000, func() {
+		sum = 0
+		selection.forEach(func(row int) {
+			sum += row
+		})
+	})
+	if allocs != 0 {
+		t.Fatalf("range iteration allocs/run=%v want 0", allocs)
+	}
+	if sum == 0 {
+		t.Fatalf("unexpected zero sum")
+	}
+
+	rows := make([]int, 0, selection.countRows())
+	allocs = testing.AllocsPerRun(1000, func() {
+		rows = selection.appendRows(rows[:0])
+	})
+	if allocs != 0 {
+		t.Fatalf("appendRows with preallocated dst allocs/run=%v want 0", allocs)
+	}
+	if len(rows) != selection.countRows() {
+		t.Fatalf("appendRows len=%d count=%d", len(rows), selection.countRows())
+	}
+}
+
+func TestColumnRowAlignmentMatchesAndMismatchesFailClosed(t *testing.T) {
+	span := mustRowSpan(t, 100, 50)
+	got, ok, err := alignColumnRowSpans([]columnRowDescriptor{
+		{Column: "predicate", Type: ColumnTypeBool, Span: span},
+		{Column: "measure", Type: ColumnTypeInt64, Span: span},
+		{Column: "projection", Type: ColumnTypeLowCardinalityCode, Span: span},
+	})
+	if err != nil || !ok || got != span {
+		t.Fatalf("align ok got=%+v ok=%v err=%v", got, ok, err)
+	}
+
+	mismatch := mustRowSpan(t, 101, 50)
+	got, ok, err = alignColumnRowSpans([]columnRowDescriptor{
+		{Column: "predicate", Type: ColumnTypeBool, Span: span},
+		{Column: "measure", Type: ColumnTypeInt64, Span: mismatch},
+	})
+	if err == nil || ok || got.RowCount != 0 {
+		t.Fatalf("align mismatch got=%+v ok=%v err=%v", got, ok, err)
+	}
+}
+
+func TestSectionDependencyDescriptorsCoverRolesAndAlign(t *testing.T) {
+	span := mustRowSpan(t, 0, 128)
+	deps := []sectionDependencyDescriptor{
+		mustSectionDependency(t, sectionDependencyPredicate, "active", ColumnTypeBool, span),
+		mustSectionDependency(t, sectionDependencyMeasure, "amount", ColumnTypeInt64, span),
+		mustSectionDependency(t, sectionDependencyProjection, "kind", ColumnTypeLowCardinalityCode, span),
+		mustSectionDependency(t, sectionDependencyVisibility, "visible", ColumnTypeBool, span),
+		mustSectionDependency(t, sectionDependencyNull, "amount.null", ColumnTypeBool, span),
+		mustSectionDependency(t, sectionDependencyDefault, "amount.default", ColumnTypeBool, span),
+	}
+	got, ok, err := validateSectionDependencies(deps)
+	if err != nil || !ok || got != span {
+		t.Fatalf("validateSectionDependencies got=%+v ok=%v err=%v", got, ok, err)
+	}
+
+	deps[2].Span = mustRowSpan(t, 1, 128)
+	got, ok, err = validateSectionDependencies(deps)
+	if err == nil || ok || got.RowCount != 0 {
+		t.Fatalf("validateSectionDependencies mismatch got=%+v ok=%v err=%v", got, ok, err)
+	}
+}
+
+func TestRowSelectionNonInt64SmokeConsumption(t *testing.T) {
+	selection := mustRangesSelection(t, 6, []rowRange{{Start: 1, End: 3}, {Start: 5, End: 6}})
+
+	bools, err := appendSelectedBools(nil, []bool{false, true, true, false, false, true}, selection)
+	if err != nil {
+		t.Fatalf("appendSelectedBools: %v", err)
+	}
+	if !reflect.DeepEqual(bools, []bool{true, true, true}) {
+		t.Fatalf("bools=%v", bools)
+	}
+
+	codes, err := appendSelectedUint32s(nil, []uint32{10, 11, 12, 13, 14, 15}, selection)
+	if err != nil {
+		t.Fatalf("appendSelectedUint32s: %v", err)
+	}
+	if !reflect.DeepEqual(codes, []uint32{11, 12, 15}) {
+		t.Fatalf("codes=%v", codes)
+	}
+
+	_, _, err = validateSectionDependencies([]sectionDependencyDescriptor{
+		mustSectionDependency(t, sectionDependencyProjection, "code", ColumnTypeLowCardinalityCode, mustRowSpan(t, 0, 6)),
+		mustSectionDependency(t, sectionDependencyPredicate, "flag", ColumnTypeBool, mustRowSpan(t, 0, 6)),
+	})
+	if err != nil {
+		t.Fatalf("non-int64 deps: %v", err)
+	}
+}
+
+func BenchmarkRowSelectionIterateRange(b *testing.B) {
+	selection := mustRangeSelection(b, 4096, 256, 3840)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		count := 0
+		selection.forEach(func(row int) {
+			count += row & 1
+		})
+		if count == -1 {
+			b.Fatal(count)
+		}
+	}
+}
+
+func BenchmarkRowSelectionAppendRowsPreallocated(b *testing.B) {
+	selection := mustRangesSelection(b, 4096, []rowRange{{Start: 10, End: 1024}, {Start: 2048, End: 3072}})
+	rows := make([]int, 0, selection.countRows())
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		rows = selection.appendRows(rows[:0])
+		if len(rows) != selection.countRows() {
+			b.Fatal(len(rows))
+		}
+	}
+}
+
+func BenchmarkRowSelectionAndRanges(b *testing.B) {
+	left := mustRangesSelection(b, 8192, []rowRange{{Start: 0, End: 2048}, {Start: 4096, End: 8192}})
+	right := mustRangesSelection(b, 8192, []rowRange{{Start: 1024, End: 3072}, {Start: 6144, End: 7168}})
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		got, err := andRowSelections(left, right)
+		if err != nil || got.countRows() != 2048 {
+			b.Fatalf("got count=%d err=%v", got.countRows(), err)
+		}
+	}
+}
+
+func assertSelectionRows(t testing.TB, selection rowSelection, want []int) {
+	t.Helper()
+	got := selection.appendRows(nil)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("rows=%v want %v shape=%+v", got, want, selection.shape())
+	}
+	if selection.countRows() != len(want) {
+		t.Fatalf("count=%d want %d", selection.countRows(), len(want))
+	}
+	for row := 0; row < selection.rowsCount(); row++ {
+		wantContains := false
+		for _, w := range want {
+			if w == row {
+				wantContains = true
+				break
+			}
+		}
+		if selection.contains(row) != wantContains {
+			t.Fatalf("contains(%d)=%v want %v", row, selection.contains(row), wantContains)
+		}
+	}
+}
+
+func assertSelectionRanges(t testing.TB, selection rowSelection, want []rowRange) {
+	t.Helper()
+	got := selection.appendRanges(nil)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ranges=%v want %v", got, want)
+	}
+}
+
+func mustEmptySelection(t testing.TB, rows int) rowSelection {
+	t.Helper()
+	sel, err := makeEmptyRowSelection(rows)
+	if err != nil {
+		t.Fatalf("makeEmptyRowSelection: %v", err)
+	}
+	return sel
+}
+
+func mustAllSelection(t testing.TB, rows int) rowSelection {
+	t.Helper()
+	sel, err := makeAllRowSelection(rows)
+	if err != nil {
+		t.Fatalf("makeAllRowSelection: %v", err)
+	}
+	return sel
+}
+
+func mustRangeSelection(t testing.TB, rows int, start int, end int) rowSelection {
+	t.Helper()
+	sel, err := makeRangeRowSelection(rows, start, end)
+	if err != nil {
+		t.Fatalf("makeRangeRowSelection: %v", err)
+	}
+	return sel
+}
+
+func mustRangesSelection(t testing.TB, rows int, ranges []rowRange) rowSelection {
+	t.Helper()
+	sel, err := makeRangesRowSelection(rows, ranges)
+	if err != nil {
+		t.Fatalf("makeRangesRowSelection: %v", err)
+	}
+	return sel
+}
+
+func mustSparseSelection(t testing.TB, rows int, sparse []int) rowSelection {
+	t.Helper()
+	sel, err := makeSparseRowSelection(rows, sparse)
+	if err != nil {
+		t.Fatalf("makeSparseRowSelection: %v", err)
+	}
+	return sel
+}
+
+func mustBitmapSelection(t testing.TB, rows int, setRows []int) rowSelection {
+	t.Helper()
+	sel, err := makeBitmapRowSelection(rows, bitmapWordsForRows(rows, setRows))
+	if err != nil {
+		t.Fatalf("makeBitmapRowSelection: %v", err)
+	}
+	return sel
+}
+
+func mustRowSpan(t testing.TB, firstRow int, rowCount int) rowSpan {
+	t.Helper()
+	span, err := makeRowSpan(firstRow, rowCount)
+	if err != nil {
+		t.Fatalf("makeRowSpan: %v", err)
+	}
+	return span
+}
+
+func mustSectionDependency(t testing.TB, role sectionDependencyRole, column string, columnType ColumnType, span rowSpan) sectionDependencyDescriptor {
+	t.Helper()
+	dep, err := makeSectionDependency(role, column, columnType, ColumnPartImageSectionColumnData, span, true)
+	if err != nil {
+		t.Fatalf("makeSectionDependency: %v", err)
+	}
+	return dep
+}
+
+func bitmapWordsForRows(rows int, setRows []int) []uint64 {
+	words := make([]uint64, rowSelectionBitmapWords(rows))
+	for _, row := range setRows {
+		words[row/64] |= uint64(1) << uint(row%64)
+	}
+	return words
+}

--- a/TreeDB/internal/typedcolumn/row_selection_test.go
+++ b/TreeDB/internal/typedcolumn/row_selection_test.go
@@ -501,9 +501,9 @@ func mustRowSpan(t testing.TB, firstRow int, rowCount int) rowSpan {
 
 func mustSectionDependency(t testing.TB, role sectionDependencyRole, column string, columnType ColumnType, span rowSpan) sectionDependencyDescriptor {
 	t.Helper()
-	dep, err := makeSectionDependency(role, column, columnType, ColumnPartImageSectionColumnData, span, true)
+	dep, err := makeValuesSectionDependency(role, column, columnType, ColumnPartImageSectionColumnData, span, true)
 	if err != nil {
-		t.Fatalf("makeSectionDependency: %v", err)
+		t.Fatalf("makeValuesSectionDependency: %v", err)
 	}
 	return dep
 }


### PR DESCRIPTION
## Linked issues

Closes #1844.
Parent tracker: #1836.

## Layer/type family changed

#1844 shared typed-column row selection/mask and multi-column execution substrate. First concrete consumer is the existing int64 predicate aggregate prepared-hot path.

## What changed

- Added internal `typedcolumn.RowSelection` for empty/all/range/ranges/bitmap/sparse shapes with count, iteration, range extraction, shape diagnostics, set operations, and explicit scratch-backed composition.
- Added row-span alignment and section-dependency descriptors for predicate/measure/projection/visibility/null/default roles and dependency kinds (values, dictionaries, offsets, null/default masks, visibility, stats, pruning metadata, vector/adjacency payloads).
- Replaced the conformance placeholder mask model with the shared selection composition model.
- Integrated int64 aggregate block scans with row selections for all-pruned, all/full-covered, exact/range, and visibility-composed blocks; no row/document materialization is introduced.
- Added non-int64 smoke coverage using bool and uint32/dictionary-code fake consumers.
- Documented selection/mask semantics in `TreeDB/docs/spec/typed-column-semantics.md`.
- Addressed AI review findings/nits: unsorted/overlapping range normalization, fail-closed mismatch domain, overlapping OR unions, value-dependency helper naming, range `Contains` binary search, and O(n log n) range sorting.

## Supported / fallback / unsupported notes

- Non-null int64 predicate aggregate remains supported through the #1843 semantic gate.
- Nullable int64 aggregate carrier semantics remain fail-closed/fallback per #1843; this PR centralizes null/default mask composition but does not admit nullable value aggregates.
- Bool/string/vector/adjacency optimized kernels are not added here; descriptors and fake/non-int64 tests prove the selection model is not int64-specific.
- No CRC/checksum substrate changes; #1851 behavior is untouched.

## Selection/null/default/visibility boundary

Predicate and visibility selections are intersected. Delete, null, and default masks are subtracted. Row-domain or alignment mismatches return an empty fail-closed selection plus an error. Scratch reuse is explicit via caller-owned `RowSelectionScratch`; there are no hidden global caches.

## Integrity/lifetime/concurrency boundary

Prepared int64 aggregate sessions keep the existing explicit single-session lifetime and cached-verify behavior. Selection scratch is session/local-call scoped, not global. No public value types were added; new types are internal to `TreeDB/internal/typedcolumn`.

## Tests

- `go test -count=1 ./TreeDB/docs ./TreeDB/internal/columnsemantics ./TreeDB/internal/typedcolumn ./TreeDB/collections`
- `go test -count=1 ./...`
- Coordinator latest-head rerun: `go test -count=1 ./TreeDB/docs ./TreeDB/internal/columnsemantics ./TreeDB/internal/typedcolumn ./TreeDB/collections`
- Coordinator latest-head focused row-selection rerun: `go test -count=1 ./TreeDB/internal/typedcolumn -run 'TestRowSelection|TestColumnRow|TestSectionDependency'`

## Benchmarks

Hardware: Apple M3 / darwin arm64. Dataset: 4,096 rows, clustered monotonic, typed_column_part, cached_verify, `-benchtime=100x` for int64 aggregate; `-benchtime=200x` for selection.

### Int64 prepared-hot before/after

Base: `e8c3a078daf2d0a1534324acb4d54aa94065e0f1`; head: this PR at `c986122cacd95671e4d5a049405ba6d8762aa6fa` (prepared-hot table from `-count=3`, median-ish representative run shown).

| shape | base ns/op | head ns/op | head ops/sec | B/op | allocs/op | rows scanned/op | rows matched/op | selection diagnostics |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| all_pruned_no_match | 2,971 | 950 | 1,052,166 | 2,640 | 11 | 0 | 0 | empty_blocks=1 |
| exact_value | 15,303 | 13,644 | 73,291 | 2,640 | 11 | 4,096 | 1 | range_blocks=1 |
| selective_range_1pct | 14,410 | 14,332 | 69,776 | 2,640 | 11 | 4,096 | 40 | range_blocks=1 |
| no_filter_full_aggregate | 18,845 | 15,603 | 64,091 | 2,640 | 11 | 4,096 | 4,096 | all_blocks=1 |

### Selection iteration/composition

| benchmark | ns/op | ops/sec | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: |
| IterateAll | 16,732 | 59,766 | 0 | 0 |
| IterateRange | 10,750 | 93,023 | 0 | 0 |
| IterateBitmap | 2,144 | 466,418 | 0 | 0 |
| IterateSparse | 1,584 | 631,313 | 0 | 0 |
| ComposeScratchNoAlloc | 330.4 | 3,026,634 | 0 | 0 |

Note: bitmap/sparse iteration benchmarks select fewer rows than all/range by design to exercise irregular shapes; the allocation evidence is the primary #1844 signal.

## AI/internal review status

Internal Orca subagents used:

- high implementation subagent for selection foundation (`1844-selection-foundation`), committed as `7d7739e`.
- xhigh review subagent (`1844-review`) found a scratch-alias composition bug; fixed in `5b2e091`; re-review PASS.

External AI review requests posted after PR creation, after the overlapping-union fix (`ca649ec2e`), and after coordinator review-nit fixes (`c986122c`). Latest-head status for `c986122cacd95671e4d5a049405ba6d8762aa6fa`:

- CI: all checks passing.
- Codex: latest review reports no major issues.
- Copilot: latest comment about `Ranges()` allocation documented/resolved; no unresolved threads remain.
- CodeRabbit: latest status passes/skips incremental review; earlier actionable nits were fixed or explicitly documented/resolved.


## Risks / deferrals

- This is a substrate and int64 aggregate integration slice, not a full planner or multi-column operator implementation.
- Existing prepared-hot int64 aggregate still has pre-existing per-run allocations; this PR avoids new selection-composition heap churn and preserves no row/document materialization.
- Type-family optimized kernels (#1845-#1848), prepared-state refactor (#1837), layout/direct-view/writer contracts (#1838/#1849/#1850), stats/pruning (#1840/#1841), and kernel dispatch (#1839) remain deferred.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Faster, batch-oriented predicate filtering for int64 aggregates with support for multiple row-selection shapes (empty/all/range/ranges/bitmap/sparse) and composition with visibility masks.
  * Aggregate diagnostics now report selection-shape metrics and composition counts to aid performance analysis.

* **Documentation**
  * Added detailed row-selection and mask-composition semantics.

* **Tests**
  * Broadened tests and benchmarks covering selection shapes, composition, alignment, diagnostics, and iteration/append performance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1855?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

