### PR TITLE
TreeDB typed-column fast decode and direct views

### DIFF
--- a/TreeDB/collections/column_asset_manager.go
+++ b/TreeDB/collections/column_asset_manager.go
@@ -480,8 +480,9 @@ func newNextColumnPhysicalAssetSegmentAppender(rootDir string, cfg ColumnStoreCo
 
 func nextColumnAssetSegmentFileIDCached(namespace columnAssetManagerNamespace, cleanSegmentDir string, cache *columnAssetSegmentAllocationCache) (uint32, error) {
 	if cache != nil && cache.valid && cache.segmentDir == cleanSegmentDir {
-		if cache.nextFileID == 0 {
-			return 0, errors.New("collections: column asset segment file_id exhausted")
+		if cache.nextFileID == 0 || cache.nextFileID >= columnAssetDirectViewSegmentFileIDBase {
+			cache.nextFileID = 0
+			return 0, errors.New("collections: column asset segment file_id exhausted before direct-view reserved band")
 		}
 		return cache.nextFileID, nil
 	}
@@ -511,7 +512,7 @@ func advanceColumnAssetSegmentFileIDCache(cleanSegmentDir string, cache *columnA
 	}
 	cache.segmentDir = cleanSegmentDir
 	cache.valid = true
-	if allocatedFileID == ^uint32(0) {
+	if allocatedFileID >= columnAssetDirectViewSegmentFileIDBase-1 {
 		cache.nextFileID = 0
 		return
 	}

--- a/TreeDB/collections/column_asset_manager.go
+++ b/TreeDB/collections/column_asset_manager.go
@@ -276,7 +276,41 @@ func writeColumnPhysicalAssetToManager(rootDir string, cfg ColumnStoreConfig, pa
 }
 
 func writeTypedColumnPartAssetToManager(rootDir string, cfg ColumnStoreConfig, payload []byte, generation, partID uint64) (ColumnAssetRef, error) {
+	if columnStoreConfigHasDirectViewFixedWidthColumn(cfg) {
+		fileID, err := directViewTypedColumnSegmentFileID(generation)
+		if err != nil {
+			return ColumnAssetRef{}, err
+		}
+		return writeColumnAssetToManagerSegment(rootDir, cfg, payload, ColumnAssetKindTCS1TypedColumnPart, generation, partID, fileID)
+	}
 	return writeColumnAssetToManager(rootDir, cfg, payload, ColumnAssetKindTCS1TypedColumnPart, generation, partID)
+}
+
+func columnStoreConfigHasDirectViewFixedWidthColumn(cfg ColumnStoreConfig) bool {
+	for _, column := range cfg.Columns {
+		if !columnStoreColumnIsTypedColumnPart(column) || column.Nullable {
+			continue
+		}
+		switch column.ValueType {
+		case ColumnStoreValueInt64:
+			if column.FixedWidthEncoding == ColumnFixedWidthEncodingLittleEndian {
+				return true
+			}
+		case ColumnStoreValueFloat32Vector, ColumnStoreValueAdjacencyList:
+			if column.VectorDims > 0 || column.ValueType == ColumnStoreValueAdjacencyList {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func directViewTypedColumnSegmentFileID(generation uint64) (uint32, error) {
+	const base uint64 = 1 << 20
+	if generation == 0 || generation > uint64(^uint32(0))-base {
+		return 0, fmt.Errorf("collections: typed-column direct-view generation=%d cannot form segment file id", generation)
+	}
+	return uint32(base + generation), nil
 }
 
 func writeColumnAggregateMetadataAssetToManager(rootDir string, cfg ColumnStoreConfig, payload []byte, generation, partID uint64) (ColumnAssetRef, error) {
@@ -1014,7 +1048,7 @@ func (c *columnPhysicalAssetReadCache) read(ref ColumnAssetRef, dst []byte) ([]b
 			if err := c.verifyReadChecksum(raw, ref, reader); err != nil {
 				return nil, err
 			}
-			if err := c.trackResourceRead(ref, raw, mappedresource.SourceMapped, ""); err != nil {
+			if _, err := c.trackResourceRead(ref, raw, mappedresource.SourceMapped, ""); err != nil {
 				return nil, err
 			}
 			c.lastView = true
@@ -1041,7 +1075,7 @@ func (c *columnPhysicalAssetReadCache) read(ref ColumnAssetRef, dst []byte) ([]b
 	if c.returnViews {
 		fallback = mappedresource.FallbackReadAt
 	}
-	if err := c.trackResourceRead(ref, raw, mappedresource.SourceHeapCopy, fallback); err != nil {
+	if _, err := c.trackResourceRead(ref, raw, mappedresource.SourceHeapCopy, fallback); err != nil {
 		return nil, err
 	}
 	return raw, nil
@@ -1079,61 +1113,68 @@ func (c *columnPhysicalAssetReadCache) validateFullRef(ref ColumnAssetRef) (int,
 }
 
 func (c *columnPhysicalAssetReadCache) readRange(ref ColumnAssetRef, relativeOffset int64, length int64) ([]byte, error) {
+	raw, _, err := c.readRangeHandle(ref, relativeOffset, length)
+	return raw, err
+}
+
+func (c *columnPhysicalAssetReadCache) readRangeHandle(ref ColumnAssetRef, relativeOffset int64, length int64) ([]byte, *mappedresource.Handle, error) {
 	if c == nil {
-		return nil, errors.New("collections: nil column physical asset read cache")
+		return nil, nil, errors.New("collections: nil column physical asset read cache")
 	}
 	if err := validateColumnAssetRefForPlan(ref); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if ref.Namespace != c.namespace {
-		return nil, fmt.Errorf("collections: column physical asset ref namespace=%q want %q", ref.Namespace, c.namespace)
+		return nil, nil, fmt.Errorf("collections: column physical asset ref namespace=%q want %q", ref.Namespace, c.namespace)
 	}
 	if relativeOffset < 0 || length <= 0 {
-		return nil, fmt.Errorf("collections: column physical asset range offset=%d length=%d is invalid", relativeOffset, length)
+		return nil, nil, fmt.Errorf("collections: column physical asset range offset=%d length=%d is invalid", relativeOffset, length)
 	}
 	end := relativeOffset + length
 	if end < relativeOffset || end > ref.Length {
-		return nil, fmt.Errorf("collections: column physical asset range offset=%d length=%d outside ref length=%d", relativeOffset, length, ref.Length)
+		return nil, nil, fmt.Errorf("collections: column physical asset range offset=%d length=%d outside ref length=%d", relativeOffset, length, ref.Length)
 	}
 	if ref.Offset > int64(^uint64(0)>>1)-relativeOffset {
-		return nil, fmt.Errorf("collections: column physical asset range base offset=%d relative=%d overflows", ref.Offset, relativeOffset)
+		return nil, nil, fmt.Errorf("collections: column physical asset range base offset=%d relative=%d overflows", ref.Offset, relativeOffset)
 	}
 	rangeRef := ref
 	rangeRef.Offset = ref.Offset + relativeOffset
 	rangeRef.Length = length
 	reader, err := c.fileForRef(ref)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if c.lastView {
 		c.lastView = false
 	}
 	if c.returnViews {
 		if raw, ok, err := reader.readView(rangeRef); err != nil {
-			return nil, err
+			return nil, nil, err
 		} else if ok {
-			if err := c.trackResourceRead(rangeRef, raw, mappedresource.SourceMapped, ""); err != nil {
-				return nil, err
+			handle, err := c.trackResourceRead(rangeRef, raw, mappedresource.SourceMapped, "")
+			if err != nil {
+				return nil, nil, err
 			}
 			c.lastView = true
-			return raw, nil
+			return raw, handle, nil
 		}
 	}
 	if length > int64(maxCollectionInt) {
-		return nil, fmt.Errorf("collections: column physical asset range length=%d overflows int", length)
+		return nil, nil, fmt.Errorf("collections: column physical asset range length=%d overflows int", length)
 	}
 	raw, err := readColumnPhysicalAssetFromFileWithChecksum(reader.file, rangeRef, make([]byte, int(length)), false)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	var fallback mappedresource.FallbackReason
 	if c.returnViews {
 		fallback = mappedresource.FallbackReadAt
 	}
-	if err := c.trackResourceRead(rangeRef, raw, mappedresource.SourceHeapCopy, fallback); err != nil {
-		return nil, err
+	handle, err := c.trackResourceRead(rangeRef, raw, mappedresource.SourceHeapCopy, fallback)
+	if err != nil {
+		return nil, nil, err
 	}
-	return raw, nil
+	return raw, handle, nil
 }
 
 func (c *columnPhysicalAssetReadCache) verifyReadChecksum(raw []byte, ref ColumnAssetRef, reader *columnPhysicalAssetSegmentReader) error {
@@ -1151,13 +1192,13 @@ func (c *columnPhysicalAssetReadCache) verifyReadChecksum(raw []byte, ref Column
 	return verifyColumnPhysicalAssetReadChecksumWithIntegrityForSegment(raw, ref, c.verifyChecksum, c.readIntegrity, c.rootDir, fileIdentity)
 }
 
-func (c *columnPhysicalAssetReadCache) trackResourceRead(ref ColumnAssetRef, raw []byte, source mappedresource.Source, fallback mappedresource.FallbackReason) error {
+func (c *columnPhysicalAssetReadCache) trackResourceRead(ref ColumnAssetRef, raw []byte, source mappedresource.Source, fallback mappedresource.FallbackReason) (*mappedresource.Handle, error) {
 	if c == nil || c.resourceManager == nil {
-		return nil
+		return nil, nil
 	}
 	key := mappedResourceKeyForColumnAssetRef(ref)
 	if key.Length != int64(len(raw)) {
-		return fmt.Errorf("collections: column asset mapped-resource key length=%d raw bytes=%d", key.Length, len(raw))
+		return nil, fmt.Errorf("collections: column asset mapped-resource key length=%d raw bytes=%d", key.Length, len(raw))
 	}
 	scope := c.resourceScope
 	if scope.Kind == "" {
@@ -1173,7 +1214,7 @@ func (c *columnPhysicalAssetReadCache) trackResourceRead(ref ColumnAssetRef, raw
 	if source == mappedresource.SourceMapped {
 		for _, handle := range c.resourceHandles {
 			if handle != nil && !handle.Released() && handle.Source() == source && handle.Key().Equal(key) {
-				return nil
+				return handle, nil
 			}
 		}
 	}
@@ -1184,7 +1225,7 @@ func (c *columnPhysicalAssetReadCache) trackResourceRead(ref ColumnAssetRef, raw
 		// heap handle active. Mapped view handles remain pinned until cache close,
 		// with duplicate keys deduplicated above.
 		if err := c.releaseResourceHandlesBySource(mappedresource.SourceHeapCopy); err != nil {
-			return err
+			return nil, err
 		}
 		if len(raw) != 0 {
 			// AcquireBytes requires immutable bytes for the handle lifetime. Syscall
@@ -1201,10 +1242,10 @@ func (c *columnPhysicalAssetReadCache) trackResourceRead(ref ColumnAssetRef, raw
 		ResourceRoot:   c.rootDir,
 	})
 	if err != nil {
-		return err
+		return nil, err
 	}
 	c.resourceHandles = append(c.resourceHandles, handle)
-	return nil
+	return handle, nil
 }
 
 func mappedResourceKeyForColumnAssetRef(ref ColumnAssetRef) mappedresource.Key {

--- a/TreeDB/collections/column_asset_manager.go
+++ b/TreeDB/collections/column_asset_manager.go
@@ -18,15 +18,16 @@ import (
 )
 
 const (
-	columnAssetManagerAssetsDirName     = "assets"
-	columnAssetManagerSegmentsDirName   = "segments"
-	columnAssetManagerIndexesDirName    = "indexes"
-	columnAssetManagerPreparedDirName   = "prepared"
-	columnAssetManagerQuarantineDirName = "quarantine"
-	columnAssetManagerTempDirName       = "tmp"
-	columnAssetSegmentFilePrefix        = "segment-"
-	columnAssetSegmentFileSuffix        = ".tca"
-	columnAssetM12ASegmentFileID        = uint32(1)
+	columnAssetManagerAssetsDirName        = "assets"
+	columnAssetManagerSegmentsDirName      = "segments"
+	columnAssetManagerIndexesDirName       = "indexes"
+	columnAssetManagerPreparedDirName      = "prepared"
+	columnAssetManagerQuarantineDirName    = "quarantine"
+	columnAssetManagerTempDirName          = "tmp"
+	columnAssetSegmentFilePrefix           = "segment-"
+	columnAssetSegmentFileSuffix           = ".tca"
+	columnAssetM12ASegmentFileID           = uint32(1)
+	columnAssetDirectViewSegmentFileIDBase = uint32(1 << 20)
 )
 
 const columnAssetSegmentWriteLockStripes = 64
@@ -306,7 +307,7 @@ func columnStoreConfigHasDirectViewFixedWidthColumn(cfg ColumnStoreConfig) bool 
 }
 
 func directViewTypedColumnSegmentFileID(generation uint64) (uint32, error) {
-	const base uint64 = 1 << 20
+	base := uint64(columnAssetDirectViewSegmentFileIDBase)
 	if generation == 0 || generation > uint64(^uint32(0))-base {
 		return 0, fmt.Errorf("collections: typed-column direct-view generation=%d cannot form segment file id", generation)
 	}
@@ -418,6 +419,9 @@ func nextColumnAssetSegmentFileID(namespace columnAssetManagerNamespace) (uint32
 	}
 	maxFileID := uint32(0)
 	for _, segment := range segments {
+		if segment.fileID >= columnAssetDirectViewSegmentFileIDBase {
+			continue
+		}
 		if segment.fileID > maxFileID {
 			maxFileID = segment.fileID
 		}
@@ -425,8 +429,8 @@ func nextColumnAssetSegmentFileID(namespace columnAssetManagerNamespace) (uint32
 	if maxFileID < columnAssetM12ASegmentFileID {
 		maxFileID = columnAssetM12ASegmentFileID
 	}
-	if maxFileID == ^uint32(0) {
-		return 0, errors.New("collections: column asset segment file_id exhausted")
+	if maxFileID >= columnAssetDirectViewSegmentFileIDBase-1 {
+		return 0, errors.New("collections: column asset segment file_id exhausted before direct-view reserved band")
 	}
 	return maxFileID + 1, nil
 }

--- a/TreeDB/collections/column_physical_asset_test.go
+++ b/TreeDB/collections/column_physical_asset_test.go
@@ -1588,6 +1588,41 @@ func TestColumnAssetSegmentAllocationCacheRescansOnConflictM15C(t *testing.T) {
 	}
 }
 
+func TestColumnAssetSegmentAllocationSkipsDirectViewReservedBandM1849(t *testing.T) {
+	cfg := testColumnStoreConfig(nil)
+	normalized, err := normalizeColumnStoreConfig("events", cfg)
+	if err != nil {
+		t.Fatalf("normalizeColumnStoreConfig: %v", err)
+	}
+	root := backenddb.ColumnAssetRootDirPath(t.TempDir())
+	namespace, err := columnAssetManagerNamespaceForRoot(root, normalized.AssetManager.Namespace)
+	if err != nil {
+		t.Fatalf("columnAssetManagerNamespaceForRoot: %v", err)
+	}
+	if err := ensureColumnAssetManagerNamespace(namespace); err != nil {
+		t.Fatalf("ensureColumnAssetManagerNamespace: %v", err)
+	}
+	directViewFileID, err := directViewTypedColumnSegmentFileID(7)
+	if err != nil {
+		t.Fatalf("directViewTypedColumnSegmentFileID: %v", err)
+	}
+	directViewPath, err := columnAssetSegmentPath(root, ColumnAssetRef{Namespace: normalized.AssetManager.Namespace, FileID: directViewFileID})
+	if err != nil {
+		t.Fatalf("columnAssetSegmentPath direct-view: %v", err)
+	}
+	if err := os.WriteFile(directViewPath, []byte("reserved-direct-view"), 0o600); err != nil {
+		t.Fatalf("write direct-view segment: %v", err)
+	}
+	appender, err := newNextColumnPhysicalAssetSegmentAppender(root, *normalized)
+	if err != nil {
+		t.Fatalf("newNextColumnPhysicalAssetSegmentAppender: %v", err)
+	}
+	defer func() { _ = appender.abort() }()
+	if appender.fileID >= columnAssetDirectViewSegmentFileIDBase || appender.fileID == directViewFileID {
+		t.Fatalf("appender file_id=%d collided with direct-view reserved file_id=%d base=%d", appender.fileID, directViewFileID, columnAssetDirectViewSegmentFileIDBase)
+	}
+}
+
 func TestColumnAssetSegmentAppenderFailedCloseRemovesSegmentM15C(t *testing.T) {
 	cfg := testColumnStoreConfig(nil)
 	normalized, err := normalizeColumnStoreConfig("events", cfg)

--- a/TreeDB/collections/column_physical_asset_test.go
+++ b/TreeDB/collections/column_physical_asset_test.go
@@ -1623,6 +1623,29 @@ func TestColumnAssetSegmentAllocationSkipsDirectViewReservedBandM1849(t *testing
 	}
 }
 
+func TestColumnAssetSegmentAllocationCacheStopsBeforeDirectViewReservedBandM1849(t *testing.T) {
+	cleanSegmentDir := filepath.Clean(t.TempDir())
+	cache := &columnAssetSegmentAllocationCache{segmentDir: cleanSegmentDir, nextFileID: columnAssetDirectViewSegmentFileIDBase - 1, valid: true}
+	namespace := columnAssetManagerNamespace{SegmentDir: cleanSegmentDir}
+	fileID, err := nextColumnAssetSegmentFileIDCached(namespace, cleanSegmentDir, cache)
+	if err != nil || fileID != columnAssetDirectViewSegmentFileIDBase-1 {
+		t.Fatalf("cached file_id=%d err=%v want last regular id", fileID, err)
+	}
+	advanceColumnAssetSegmentFileIDCache(cleanSegmentDir, cache, fileID)
+	if cache.nextFileID != 0 {
+		t.Fatalf("advanced cached next_file_id=%d want exhausted before direct-view band", cache.nextFileID)
+	}
+	if _, err := nextColumnAssetSegmentFileIDCached(namespace, cleanSegmentDir, cache); err == nil {
+		t.Fatal("nextColumnAssetSegmentFileIDCached err=nil want exhausted before direct-view band")
+	}
+
+	cache.nextFileID = columnAssetDirectViewSegmentFileIDBase
+	cache.valid = true
+	if _, err := nextColumnAssetSegmentFileIDCached(namespace, cleanSegmentDir, cache); err == nil {
+		t.Fatal("nextColumnAssetSegmentFileIDCached accepted reserved direct-view file id")
+	}
+}
+
 func TestColumnAssetSegmentAppenderFailedCloseRemovesSegmentM15C(t *testing.T) {
 	cfg := testColumnStoreConfig(nil)
 	normalized, err := normalizeColumnStoreConfig("events", cfg)

--- a/TreeDB/collections/typed_column_int64_scan.go
+++ b/TreeDB/collections/typed_column_int64_scan.go
@@ -84,6 +84,13 @@ type TypedColumnInt64PredicateScanDiagnostics struct {
 	DecodedMetadataBytes        uint64
 	DecodedHeapCopyBytes        uint64
 	MaterializedBytes           uint64
+	FastDecodeDirectViewPlans   int
+	FastDecodeStreamingPlans    int
+	FastDecodeMaterializePlans  int
+	FastDecodeUnsupportedPlans  int
+	DirectViewSuccesses         int
+	DirectViewFailures          int
+	FastDecodeFallbackReason    string
 	DirectViewCertified         int
 	StreamingCertified          int
 	StatsCertified              int
@@ -857,13 +864,18 @@ func (s *TypedColumnInt64PredicateAggregateSession) ensureCachedVerifyFullAssetV
 }
 
 func (s *TypedColumnInt64PredicateAggregateSession) readTypedColumnRange(ref ColumnAssetRef, offset int, length int, section bool, result *TypedColumnInt64PredicateAggregateResult, updateCacheDeltas func()) ([]byte, error) {
+	raw, _, err := s.readTypedColumnRangeHandle(ref, offset, length, section, result, updateCacheDeltas)
+	return raw, err
+}
+
+func (s *TypedColumnInt64PredicateAggregateSession) readTypedColumnRangeHandle(ref ColumnAssetRef, offset int, length int, section bool, result *TypedColumnInt64PredicateAggregateResult, updateCacheDeltas func()) ([]byte, *mappedresource.Handle, error) {
 	if offset < 0 || length <= 0 {
-		return nil, fmt.Errorf("collections: typed-column range offset=%d length=%d is invalid", offset, length)
+		return nil, nil, fmt.Errorf("collections: typed-column range offset=%d length=%d is invalid", offset, length)
 	}
-	raw, err := s.readCache.readRange(ref, int64(offset), int64(length))
+	raw, handle, err := s.readCache.readRangeHandle(ref, int64(offset), int64(length))
 	updateCacheDeltas()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if s.readCache.lastView {
 		result.Diagnostics.MappedBytes += uint64(len(raw))
@@ -876,7 +888,7 @@ func (s *TypedColumnInt64PredicateAggregateSession) readTypedColumnRange(ref Col
 		result.Diagnostics.RangeBytesRead += uint64(len(raw))
 	}
 	result.Diagnostics.PhysicalBytesScanned += int64(len(raw))
-	return raw, nil
+	return raw, handle, nil
 }
 
 func (s *TypedColumnInt64PredicateAggregateSession) scanPreparedAggregatePart(typedRef columnManifestAssetRefForScan, physical columnManifestAssetRefForScan, adapterPart *typedColumnAdapterPart, adapterColumn typedColumnAdapterColumn, result *TypedColumnInt64PredicateAggregateResult) error {
@@ -932,6 +944,15 @@ func addTypedColumnInt64PredicateAggregateDiagnostics(dst *TypedColumnInt64Predi
 	dst.DecodedMetadataBytes += src.DecodedMetadataBytes
 	dst.DecodedHeapCopyBytes += src.DecodedHeapCopyBytes
 	dst.MaterializedBytes += src.MaterializedBytes
+	dst.FastDecodeDirectViewPlans += src.FastDecodeDirectViewPlans
+	dst.FastDecodeStreamingPlans += src.FastDecodeStreamingPlans
+	dst.FastDecodeMaterializePlans += src.FastDecodeMaterializePlans
+	dst.FastDecodeUnsupportedPlans += src.FastDecodeUnsupportedPlans
+	dst.DirectViewSuccesses += src.DirectViewSuccesses
+	dst.DirectViewFailures += src.DirectViewFailures
+	if src.FastDecodeFallbackReason != "" {
+		dst.FastDecodeFallbackReason = src.FastDecodeFallbackReason
+	}
 	dst.DirectViewCertified += src.DirectViewCertified
 	dst.StreamingCertified += src.StreamingCertified
 	dst.StatsCertified += src.StatsCertified

--- a/TreeDB/collections/typed_column_int64_scan_test.go
+++ b/TreeDB/collections/typed_column_int64_scan_test.go
@@ -1,6 +1,7 @@
 package collections
 
 import (
+	"context"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -554,6 +555,13 @@ func TestTypedColumnInt64RawLayoutRoundTripReopenQuery(t *testing.T) {
 	if len(refs) != 1 {
 		t.Fatalf("typed-column refs=%+v want one", refs)
 	}
+	if refs[0].Offset != 0 || refs[0].FileID == columnAssetM12ASegmentFileID {
+		t.Fatalf("raw direct-view typed-column ref=%+v want deterministic direct-view segment at offset 0", refs[0])
+	}
+	reachability, err := col.PlanColumnAssetReachability(context.Background(), ColumnAssetReachabilityOptions{Detailed: true})
+	if err != nil || !reachability.Complete || reachability.Segments.Unknown != 0 || reachability.Segments.Missing != 0 {
+		t.Fatalf("raw direct-view reachability plan=%+v err=%v want complete with no unknown/missing segments", reachability, err)
+	}
 	if got := typedColumnInt64ColumnEncodingForTest(t, d, refs[0], "time_us"); got != typedcolumn.EncodingRawInt64 {
 		t.Fatalf("time_us encoding=%s want %s", got, typedcolumn.EncodingRawInt64)
 	}
@@ -572,15 +580,21 @@ func TestTypedColumnInt64RawLayoutRoundTripReopenQuery(t *testing.T) {
 		t.Fatalf("PrepareTypedColumnInt64PredicateAggregate raw: %v", err)
 	}
 	prepared, err := session.Run()
-	if closeErr := session.Close(); closeErr != nil {
-		t.Fatalf("Close prepared raw: %v", closeErr)
-	}
 	if err != nil {
 		t.Fatalf("prepared raw Run: %v", err)
 	}
+	if diag := session.Diagnostics(); diag.ActiveResourceHandles == 0 || diag.ActiveMappedBytes+diag.ActiveHeapCopyBytes == 0 {
+		t.Fatalf("session diagnostics before close=%+v want pinned direct-view resources", diag)
+	}
+	if closeErr := session.Close(); closeErr != nil {
+		t.Fatalf("Close prepared raw: %v", closeErr)
+	}
+	if _, err := session.Run(); !errors.Is(err, errTypedColumnInt64PredicateAggregateSessionClosed) {
+		t.Fatalf("Run after Close err=%v want session closed before exposing stale direct view", err)
+	}
 	assertTypedColumnInt64Aggregate(t, prepared, 3, 45)
-	if prepared.Diagnostics.DecodedHeapCopyBytes != 0 {
-		t.Fatalf("prepared raw diagnostics=%+v want safe raw reducer without decoded heap copy", prepared.Diagnostics)
+	if prepared.Diagnostics.DecodedHeapCopyBytes != 0 || prepared.Diagnostics.FastDecodeDirectViewPlans == 0 || prepared.Diagnostics.DirectViewSuccesses == 0 {
+		t.Fatalf("prepared raw diagnostics=%+v want direct-view reducer without decoded heap copy", prepared.Diagnostics)
 	}
 	if session.prepareDiagnostics.DirectViewCertified == 0 || session.prepareDiagnostics.CertificationFailures != 0 {
 		t.Fatalf("prepare diagnostics=%+v want certified direct-view layout with no failures", session.prepareDiagnostics)
@@ -630,14 +644,36 @@ func TestTypedColumnInt64PreparedCertificationDiagnosticsAndClose(t *testing.T) 
 	}
 	assertTypedColumnInt64Aggregate(t, first, 3, 9)
 	assertTypedColumnInt64Aggregate(t, second, 3, 9)
-	if first.Diagnostics.DecodedMetadataBytes != 0 || second.Diagnostics.DecodedMetadataBytes != 0 || first.Diagnostics.DecodedHeapCopyBytes != 0 || second.Diagnostics.DecodedHeapCopyBytes != 0 {
-		t.Fatalf("hot diagnostics first=%+v second=%+v want no per-run metadata or heap decode", first.Diagnostics, second.Diagnostics)
+	if first.Diagnostics.DecodedMetadataBytes != 0 || second.Diagnostics.DecodedMetadataBytes != 0 || first.Diagnostics.DecodedHeapCopyBytes != 0 || second.Diagnostics.DecodedHeapCopyBytes != 0 || first.Diagnostics.DirectViewSuccesses == 0 || second.Diagnostics.DirectViewSuccesses == 0 {
+		t.Fatalf("hot diagnostics first=%+v second=%+v want direct-view runs with no per-run metadata or heap decode", first.Diagnostics, second.Diagnostics)
 	}
 	if err := session.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
 	}
 	if diag := session.Diagnostics(); !diag.Closed || diag.ActiveResourceHandles != 0 || diag.ActiveMappedBytes != 0 || diag.ActiveHeapCopyBytes != 0 {
 		t.Fatalf("session diagnostics after close=%+v want resources released", diag)
+	}
+}
+
+func TestTypedColumnInt64PreparedDeltaUsesStreamingCursor(t *testing.T) {
+	d, col := setupTypedColumnInt64ScanCollection(t)
+	defer func() { _ = d.Close() }()
+	insertTypedColumnInt64ScanRows(t, col, []int64{1, 3, 6, 10, 15, 21})
+	session, err := col.PrepareTypedColumnInt64PredicateAggregate(TypedColumnInt64PredicateAggregateRequest{Column: "time_us", Kind: TypedColumnInt64PredicateRange, Low: 3, High: 15, ColumnAssetReadIntegrity: ColumnAssetReadIntegrityCachedVerify})
+	if err != nil {
+		t.Fatalf("PrepareTypedColumnInt64PredicateAggregate: %v", err)
+	}
+	defer func() { _ = session.Close() }()
+	if session.prepareDiagnostics.StreamingCertified == 0 {
+		t.Fatalf("prepare diagnostics=%+v want streaming-certified delta layout", session.prepareDiagnostics)
+	}
+	result, err := session.Run()
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	assertTypedColumnInt64Aggregate(t, result, 4, 34)
+	if result.Diagnostics.FastDecodeStreamingPlans == 0 || result.Diagnostics.FastDecodeDirectViewPlans != 0 || result.Diagnostics.DirectViewSuccesses != 0 || result.Diagnostics.DecodedHeapCopyBytes != 0 {
+		t.Fatalf("diagnostics=%+v want delta-varint streaming cursor without direct view or []int64 materialization", result.Diagnostics)
 	}
 }
 
@@ -1280,7 +1316,7 @@ func TestTypedColumnInt64AggregatePreparedSessionSnapshotPinnedAcrossMutation(t 
 	assertTypedColumnInt64Aggregate(t, fresh, 4, 160)
 }
 
-func TestTypedColumnInt64AggregatePreparedSessionReusesDecodeScratch(t *testing.T) {
+func TestTypedColumnInt64AggregatePreparedSessionStreamsDeltaWithoutDecodeScratch(t *testing.T) {
 	const rows = 65536
 	d, col := setupTypedColumnInt64ScanCollection(t)
 	defer func() { _ = d.Close() }()
@@ -1302,11 +1338,9 @@ func TestTypedColumnInt64AggregatePreparedSessionReusesDecodeScratch(t *testing.
 	if err := validateTypedColumnInt64AggregateBenchResult(first, expected); err != nil {
 		t.Fatal(err)
 	}
-	if len(session.aggregateScratch.values) == 0 {
-		t.Fatalf("first diagnostics=%+v left empty aggregate decode scratch", first.Diagnostics)
+	if first.Diagnostics.FastDecodeStreamingPlans == 0 || first.Diagnostics.DecodedHeapCopyBytes != 0 || len(session.aggregateScratch.values) != 0 {
+		t.Fatalf("first diagnostics=%+v scratch_values=%d want delta streaming cursor without decode scratch", first.Diagnostics, len(session.aggregateScratch.values))
 	}
-	firstPtr := &session.aggregateScratch.values[0]
-	firstCap := cap(session.aggregateScratch.values)
 
 	second, err := session.Run()
 	if err != nil {
@@ -1315,11 +1349,8 @@ func TestTypedColumnInt64AggregatePreparedSessionReusesDecodeScratch(t *testing.
 	if err := validateTypedColumnInt64AggregateBenchResult(second, expected); err != nil {
 		t.Fatal(err)
 	}
-	if len(session.aggregateScratch.values) == 0 {
-		t.Fatalf("second diagnostics=%+v left empty aggregate decode scratch", second.Diagnostics)
-	}
-	if got := &session.aggregateScratch.values[0]; got != firstPtr || cap(session.aggregateScratch.values) != firstCap {
-		t.Fatalf("aggregate decode scratch reallocated between hot runs: ptr %p -> %p cap %d -> %d", firstPtr, got, firstCap, cap(session.aggregateScratch.values))
+	if second.Diagnostics.FastDecodeStreamingPlans == 0 || second.Diagnostics.DecodedHeapCopyBytes != 0 || len(session.aggregateScratch.values) != 0 {
+		t.Fatalf("second diagnostics=%+v scratch_values=%d want delta streaming cursor without decode scratch", second.Diagnostics, len(session.aggregateScratch.values))
 	}
 	if err := session.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
@@ -2693,6 +2724,12 @@ func reportTypedColumnInt64AggregateBenchMetrics(b *testing.B, totalRows int, di
 	b.ReportMetric(float64(diag.HeapCopyBytes), "heap_copy_bytes/op")
 	b.ReportMetric(float64(diag.DecodedHeapCopyBytes), "decoded_bytes/op")
 	b.ReportMetric(float64(diag.MaterializedBytes), "materialized_bytes/op")
+	b.ReportMetric(float64(diag.FastDecodeDirectViewPlans), "fast_decode_direct_view_plans/op")
+	b.ReportMetric(float64(diag.FastDecodeStreamingPlans), "fast_decode_streaming_plans/op")
+	b.ReportMetric(float64(diag.FastDecodeMaterializePlans), "fast_decode_materialize_plans/op")
+	b.ReportMetric(float64(diag.FastDecodeUnsupportedPlans), "fast_decode_unsupported_plans/op")
+	b.ReportMetric(float64(diag.DirectViewSuccesses), "direct_view_successes/op")
+	b.ReportMetric(float64(diag.DirectViewFailures), "direct_view_failures/op")
 	b.ReportMetric(float64(diag.DirectViewCertified), "direct_view_certified/op")
 	b.ReportMetric(float64(diag.StreamingCertified), "streaming_certified/op")
 	b.ReportMetric(float64(diag.CertificationFailures), "certification_failures/op")
@@ -2710,6 +2747,9 @@ func reportTypedColumnInt64AggregateBenchMetrics(b *testing.B, totalRows int, di
 	b.ReportMetric(float64(fallbackCount), "fallback_count")
 	if diag.FallbackReason != "" {
 		b.ReportMetric(1, "fallback_reason_"+typedColumnInt64AggregateBenchMetricToken(diag.FallbackReason)+"_count")
+	}
+	if diag.FastDecodeFallbackReason != "" {
+		b.ReportMetric(1, "fast_decode_fallback_reason_"+typedColumnInt64AggregateBenchMetricToken(diag.FastDecodeFallbackReason)+"_count")
 	}
 }
 

--- a/TreeDB/collections/typed_column_int64_scan_test.go
+++ b/TreeDB/collections/typed_column_int64_scan_test.go
@@ -16,6 +16,7 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+	"unsafe"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 	"github.com/snissn/gomap/TreeDB/internal/typedcolumn"
@@ -23,12 +24,20 @@ import (
 )
 
 func typedColumnInt64DirectViewSupportedForTest() bool {
+	if !typedColumnInt64HostLittleEndianForTest() {
+		return false
+	}
 	switch runtime.GOOS {
 	case "darwin", "linux", "freebsd", "netbsd", "openbsd":
 		return true
 	default:
 		return false
 	}
+}
+
+func typedColumnInt64HostLittleEndianForTest() bool {
+	var value uint16 = 1
+	return *(*byte)(unsafe.Pointer(&value)) == 1
 }
 
 func TestTypedColumnInt64ScanEqualityPredicate(t *testing.T) {

--- a/TreeDB/collections/typed_column_int64_scan_test.go
+++ b/TreeDB/collections/typed_column_int64_scan_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"runtime/pprof"
 	"sort"
 	"strconv"
@@ -18,7 +19,17 @@ import (
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 	"github.com/snissn/gomap/TreeDB/internal/typedcolumn"
+	"github.com/snissn/gomap/TreeDB/internal/typeddecode"
 )
+
+func typedColumnInt64DirectViewSupportedForTest() bool {
+	switch runtime.GOOS {
+	case "darwin", "linux", "freebsd", "netbsd", "openbsd":
+		return true
+	default:
+		return false
+	}
+}
 
 func TestTypedColumnInt64ScanEqualityPredicate(t *testing.T) {
 	d, col := setupTypedColumnInt64ScanCollection(t)
@@ -593,8 +604,15 @@ func TestTypedColumnInt64RawLayoutRoundTripReopenQuery(t *testing.T) {
 		t.Fatalf("Run after Close err=%v want session closed before exposing stale direct view", err)
 	}
 	assertTypedColumnInt64Aggregate(t, prepared, 3, 45)
-	if prepared.Diagnostics.DecodedHeapCopyBytes != 0 || prepared.Diagnostics.FastDecodeDirectViewPlans == 0 || prepared.Diagnostics.DirectViewSuccesses == 0 {
-		t.Fatalf("prepared raw diagnostics=%+v want direct-view reducer without decoded heap copy", prepared.Diagnostics)
+	if prepared.Diagnostics.DecodedHeapCopyBytes != 0 || prepared.Diagnostics.FastDecodeDirectViewPlans == 0 {
+		t.Fatalf("prepared raw diagnostics=%+v want fast raw reducer without decoded heap copy", prepared.Diagnostics)
+	}
+	if typedColumnInt64DirectViewSupportedForTest() {
+		if prepared.Diagnostics.DirectViewSuccesses == 0 || prepared.Diagnostics.HeapCopyBytes != 0 {
+			t.Fatalf("prepared raw diagnostics=%+v want mmap direct-view reducer", prepared.Diagnostics)
+		}
+	} else if prepared.Diagnostics.DirectViewFailures == 0 || prepared.Diagnostics.FastDecodeFallbackReason != string(typeddecode.ReasonHandleSourceUnsupported) {
+		t.Fatalf("prepared raw diagnostics=%+v want platform heap fallback without materialization", prepared.Diagnostics)
 	}
 	if session.prepareDiagnostics.DirectViewCertified == 0 || session.prepareDiagnostics.CertificationFailures != 0 {
 		t.Fatalf("prepare diagnostics=%+v want certified direct-view layout with no failures", session.prepareDiagnostics)
@@ -644,8 +662,15 @@ func TestTypedColumnInt64PreparedCertificationDiagnosticsAndClose(t *testing.T) 
 	}
 	assertTypedColumnInt64Aggregate(t, first, 3, 9)
 	assertTypedColumnInt64Aggregate(t, second, 3, 9)
-	if first.Diagnostics.DecodedMetadataBytes != 0 || second.Diagnostics.DecodedMetadataBytes != 0 || first.Diagnostics.DecodedHeapCopyBytes != 0 || second.Diagnostics.DecodedHeapCopyBytes != 0 || first.Diagnostics.DirectViewSuccesses == 0 || second.Diagnostics.DirectViewSuccesses == 0 {
-		t.Fatalf("hot diagnostics first=%+v second=%+v want direct-view runs with no per-run metadata or heap decode", first.Diagnostics, second.Diagnostics)
+	if first.Diagnostics.DecodedMetadataBytes != 0 || second.Diagnostics.DecodedMetadataBytes != 0 || first.Diagnostics.DecodedHeapCopyBytes != 0 || second.Diagnostics.DecodedHeapCopyBytes != 0 {
+		t.Fatalf("hot diagnostics first=%+v second=%+v want no per-run metadata or heap decode", first.Diagnostics, second.Diagnostics)
+	}
+	if typedColumnInt64DirectViewSupportedForTest() {
+		if first.Diagnostics.DirectViewSuccesses == 0 || second.Diagnostics.DirectViewSuccesses == 0 || first.Diagnostics.HeapCopyBytes != 0 || second.Diagnostics.HeapCopyBytes != 0 {
+			t.Fatalf("hot diagnostics first=%+v second=%+v want mmap direct-view runs", first.Diagnostics, second.Diagnostics)
+		}
+	} else if first.Diagnostics.DirectViewFailures == 0 || second.Diagnostics.DirectViewFailures == 0 || first.Diagnostics.FastDecodeFallbackReason != string(typeddecode.ReasonHandleSourceUnsupported) || second.Diagnostics.FastDecodeFallbackReason != string(typeddecode.ReasonHandleSourceUnsupported) {
+		t.Fatalf("hot diagnostics first=%+v second=%+v want platform heap fallback without materialization", first.Diagnostics, second.Diagnostics)
 	}
 	if err := session.Close(); err != nil {
 		t.Fatalf("Close: %v", err)

--- a/TreeDB/collections/typed_column_prepared_int64.go
+++ b/TreeDB/collections/typed_column_prepared_int64.go
@@ -10,6 +10,7 @@ import (
 	"github.com/snissn/gomap/TreeDB/internal/columnsemantics"
 	"github.com/snissn/gomap/TreeDB/internal/mappedresource"
 	"github.com/snissn/gomap/TreeDB/internal/typedcolumn"
+	"github.com/snissn/gomap/TreeDB/internal/typeddecode"
 )
 
 func (s *TypedColumnInt64PredicateAggregateSession) validatePreparedInt64AggregateColumn() error {
@@ -288,12 +289,123 @@ func addTypedColumnInt64AggregateSelectedRawValues(result *TypedColumnInt64Predi
 	}
 }
 
+func recordTypedColumnInt64FastDecodePlan(diag *TypedColumnInt64PredicateScanDiagnostics, plan typeddecode.Plan) {
+	if diag == nil {
+		return
+	}
+	switch plan.Path {
+	case typeddecode.PathDirectView:
+		diag.FastDecodeDirectViewPlans++
+	case typeddecode.PathStreaming:
+		diag.FastDecodeStreamingPlans++
+	case typeddecode.PathMaterialize:
+		diag.FastDecodeMaterializePlans++
+	case typeddecode.PathUnsupported:
+		diag.FastDecodeUnsupportedPlans++
+	}
+	if plan.Reason != "" && plan.Reason != typeddecode.ReasonSupported {
+		diag.FastDecodeFallbackReason = string(plan.Reason)
+	}
+}
+
+func recordTypedColumnInt64DirectViewStatus(diag *TypedColumnInt64PredicateScanDiagnostics, status typeddecode.Status) {
+	if diag == nil {
+		return
+	}
+	if status.Direct() {
+		diag.DirectViewSuccesses++
+		return
+	}
+	diag.DirectViewFailures++
+	if status.Reason != "" && status.Reason != typeddecode.ReasonSupported {
+		diag.FastDecodeFallbackReason = string(status.Reason)
+	}
+}
+
+func typedColumnInt64DirectViewFallbackAllowed(status typeddecode.Status) bool {
+	if status.Direct() {
+		return false
+	}
+	if status.Path != typeddecode.PathStreaming {
+		return false
+	}
+	switch status.Reason {
+	case typeddecode.ReasonUnaligned, typeddecode.ReasonHandleSourceUnsupported, typeddecode.ReasonWrongEndian, typeddecode.ReasonNotWriterCertified:
+		return true
+	default:
+		return false
+	}
+}
+
+func addTypedColumnInt64AggregateStreamingValues(result *TypedColumnInt64PredicateAggregateResult, req TypedColumnInt64PredicateScanRequest, granule typedcolumn.EncodedGranule, block typedColumnPreparedBlockPlan, visibility *typedColumnLatestPhysicalPart, scratch *typedColumnInt64PredicateAggregateScanScratch) error {
+	if result == nil {
+		return errors.New("collections: nil typed-column int64 aggregate result")
+	}
+	if scratch == nil {
+		var local typedColumnInt64PredicateAggregateScanScratch
+		scratch = &local
+	}
+	cursor, err := scratch.reader.Int64Cursor(granule)
+	if err != nil {
+		return err
+	}
+	rows := granule.Rows
+	if rows != block.Descriptor.RowCount {
+		return fmt.Errorf("typed-column int64 streaming rows=%d want block rows=%d", rows, block.Descriptor.RowCount)
+	}
+	result.Diagnostics.RowsScanned += rows
+	selection := block.CandidateSelection
+	needFinalSelection := block.NeedsPredicate || visibility != nil || !selection.IsAll()
+	if needFinalSelection {
+		scratch.predicateRows = scratch.predicateRows[:0]
+	}
+	for row := 0; row < rows; row++ {
+		value, err := cursor.Next()
+		if err != nil {
+			return err
+		}
+		if !selection.Contains(row) {
+			continue
+		}
+		if block.NeedsPredicate && !typedColumnInt64PredicateMatches(req, value) {
+			continue
+		}
+		if visibility != nil && !visibility.rowVisible(block.Descriptor.FirstRow+row) {
+			continue
+		}
+		if err := addTypedColumnInt64PredicateAggregateValue(result, value); err != nil {
+			return err
+		}
+		result.Diagnostics.RowsMatched++
+		if needFinalSelection {
+			scratch.predicateRows = append(scratch.predicateRows, row)
+		}
+	}
+	if err := cursor.Finish(); err != nil {
+		return err
+	}
+	if needFinalSelection {
+		finalSelection, err := typedColumnInt64PredicateRowsSelection(rows, scratch)
+		if err != nil {
+			return err
+		}
+		if visibility != nil {
+			result.Diagnostics.SelectionCompositions++
+		}
+		recordTypedColumnSelectionDiagnostics(&result.Diagnostics, finalSelection)
+		return nil
+	}
+	recordTypedColumnSelectionDiagnostics(&result.Diagnostics, selection)
+	return nil
+}
+
 func (s *TypedColumnInt64PredicateAggregateSession) scanPreparedAggregateColumnState(preparedColumn *typedColumnPreparedColumnState, ref ColumnAssetRef, visibility *typedColumnLatestPhysicalPart, result *TypedColumnInt64PredicateAggregateResult, updateCacheDeltas func()) (bool, error) {
 	if preparedColumn == nil {
 		return false, errors.New("collections: typed-column int64 predicate aggregate nil prepared column")
 	}
 	decodedAny := false
 	payloadRead := false
+	columnPlan := typeddecode.Int64ReducerPlan(preparedColumn.Plan.Layout, preparedColumn.Certification)
 	var err error
 	for _, block := range preparedColumn.BlockPlans {
 		result.Diagnostics.BlocksConsidered++
@@ -303,8 +415,9 @@ func (s *TypedColumnInt64PredicateAggregateSession) scanPreparedAggregateColumnS
 			continue
 		}
 		var payload []byte
+		var handle *mappedresource.Handle
 		if block.PayloadLength > 0 {
-			payload, err = s.readTypedColumnRange(ref, block.PayloadOffset, block.PayloadLength, false, result, updateCacheDeltas)
+			payload, handle, err = s.readTypedColumnRangeHandle(ref, block.PayloadOffset, block.PayloadLength, false, result, updateCacheDeltas)
 			if err != nil {
 				if preparedColumn.Plan.Layout.Reducers.Int64FixedWidthRaw {
 					return false, fmt.Errorf("raw layout read column %q block %d payload: %w", preparedColumn.Plan.Definition.Name, block.Index, err)
@@ -319,79 +432,67 @@ func (s *TypedColumnInt64PredicateAggregateSession) scanPreparedAggregateColumnS
 		granule := block.Granule
 		granule.Payload = payload
 		granule.PayloadRef = typedcolumn.PayloadRef{Kind: typedcolumn.PayloadRefInline, Length: block.PayloadLength}
-		if preparedColumn.Plan.Layout.Reducers.Int64FixedWidthRaw {
-			if !preparedColumn.Certification.DirectViewCertified {
-				if err := preparedColumn.Plan.Layout.ValidateGranulePayload(granule, payload); err != nil {
-					return false, err
-				}
-			}
-			decodedAny = true
-			result.Diagnostics.BlocksDecoded++
-			result.Diagnostics.RowsScanned += granule.Rows
 
-			selection := block.CandidateSelection
-			if block.NeedsPredicate {
-				selection, err = typedColumnInt64RawPredicateSelection(typedColumnInt64PredicateAggregateScanRequest(s.req), granule, payload, &s.aggregateScratch)
-				if err != nil {
-					return false, err
-				}
-			}
-			if visibility != nil && !selection.IsEmpty() {
-				visibilitySelection, err := typedColumnInt64VisibilitySelectionForBlock(visibility, block.Descriptor.FirstRow, block.Descriptor.RowCount, &s.aggregateScratch)
-				if err != nil {
-					return false, err
-				}
-				selection, err = typedcolumn.ComposeRowSelectionsInto(block.Descriptor.RowCount, typedcolumn.RowSelectionComponents{Predicate: &selection, Visibility: &visibilitySelection}, &s.aggregateScratch.selection)
-				if err != nil {
-					return false, err
-				}
-				result.Diagnostics.SelectionCompositions++
-			}
-			recordTypedColumnSelectionDiagnostics(&result.Diagnostics, selection)
-			if selection.IsEmpty() {
-				continue
-			}
-			if err := addTypedColumnInt64AggregateSelectedRawValues(result, payload, granule.Rows, selection); err != nil {
-				return false, err
-			}
-			continue
+		recordTypedColumnInt64FastDecodePlan(&result.Diagnostics, columnPlan)
+		if columnPlan.Path == typeddecode.PathUnsupported {
+			return false, fmt.Errorf("collections: typed-column int64 aggregate fast decode unsupported for column %q: %s", preparedColumn.Plan.Definition.Name, columnPlan.Status().Error())
 		}
-		values, err := s.aggregateScratch.reader.DecodeInt64Into(s.aggregateScratch.values[:0], granule)
-		if err != nil {
+		if columnPlan.DirectCandidate() {
+			if block.Index < 0 || block.Index >= len(preparedColumn.Certification.Blocks) {
+				return false, fmt.Errorf("collections: typed-column int64 aggregate direct-view block index=%d outside certification blocks=%d", block.Index, len(preparedColumn.Certification.Blocks))
+			}
+			blockStatus := typeddecode.ValidateDirectViewBlock(typeddecode.DirectViewBlockRequest{Plan: columnPlan, Certification: preparedColumn.Certification, Block: preparedColumn.Certification.Blocks[block.Index], Rows: granule.Rows, PayloadBytes: len(payload)})
+			if blockStatus.Direct() {
+				values, viewStatus := typeddecode.Int64View(s.resourceManager, handle, typeddecode.ResourceViewOptions{ExpectedElements: granule.Rows, RequireMapped: true})
+				recordTypedColumnInt64DirectViewStatus(&result.Diagnostics, viewStatus)
+				if viewStatus.Direct() {
+					decodedAny = true
+					result.Diagnostics.BlocksDecoded++
+					result.Diagnostics.RowsScanned += len(values)
+					selection := block.CandidateSelection
+					if block.NeedsPredicate {
+						selection, err = typedColumnInt64PredicateAggregateBlockSelection(typedColumnInt64PredicateAggregateScanRequest(s.req), granule, values, &s.aggregateScratch)
+						if err != nil {
+							return false, err
+						}
+					}
+					if visibility != nil && !selection.IsEmpty() {
+						visibilitySelection, err := typedColumnInt64VisibilitySelectionForBlock(visibility, block.Descriptor.FirstRow, block.Descriptor.RowCount, &s.aggregateScratch)
+						if err != nil {
+							return false, err
+						}
+						selection, err = typedcolumn.ComposeRowSelectionsInto(block.Descriptor.RowCount, typedcolumn.RowSelectionComponents{Predicate: &selection, Visibility: &visibilitySelection}, &s.aggregateScratch.selection)
+						if err != nil {
+							return false, err
+						}
+						result.Diagnostics.SelectionCompositions++
+					}
+					recordTypedColumnSelectionDiagnostics(&result.Diagnostics, selection)
+					if selection.IsEmpty() {
+						continue
+					}
+					if err := addTypedColumnInt64AggregateSelectedValues(result, values, selection); err != nil {
+						return false, err
+					}
+					continue
+				}
+				if !typedColumnInt64DirectViewFallbackAllowed(viewStatus) {
+					return false, fmt.Errorf("collections: typed-column int64 aggregate direct view failed closed for column %q block %d: %s", preparedColumn.Plan.Definition.Name, block.Index, viewStatus.Error())
+				}
+			} else if !typedColumnInt64DirectViewFallbackAllowed(blockStatus) {
+				recordTypedColumnInt64DirectViewStatus(&result.Diagnostics, blockStatus)
+				return false, fmt.Errorf("collections: typed-column int64 aggregate direct-view contract failed for column %q block %d: %s", preparedColumn.Plan.Definition.Name, block.Index, blockStatus.Error())
+			} else {
+				recordTypedColumnInt64DirectViewStatus(&result.Diagnostics, blockStatus)
+			}
+		}
+
+		if err := preparedColumn.Plan.Layout.ValidateGranulePayload(granule, payload); err != nil {
 			return false, err
-		}
-		s.aggregateScratch.values = values
-		if len(values) != block.Descriptor.RowCount {
-			return false, fmt.Errorf("decoded rows value=%d want %d", len(values), block.Descriptor.RowCount)
 		}
 		decodedAny = true
 		result.Diagnostics.BlocksDecoded++
-		result.Diagnostics.DecodedHeapCopyBytes += uint64(granule.RawBytes)
-		result.Diagnostics.RowsScanned += len(values)
-
-		selection := block.CandidateSelection
-		if block.NeedsPredicate {
-			selection, err = typedColumnInt64PredicateAggregateBlockSelection(typedColumnInt64PredicateAggregateScanRequest(s.req), granule, values, &s.aggregateScratch)
-			if err != nil {
-				return false, err
-			}
-		}
-		if visibility != nil && !selection.IsEmpty() {
-			visibilitySelection, err := typedColumnInt64VisibilitySelectionForBlock(visibility, block.Descriptor.FirstRow, block.Descriptor.RowCount, &s.aggregateScratch)
-			if err != nil {
-				return false, err
-			}
-			selection, err = typedcolumn.ComposeRowSelectionsInto(block.Descriptor.RowCount, typedcolumn.RowSelectionComponents{Predicate: &selection, Visibility: &visibilitySelection}, &s.aggregateScratch.selection)
-			if err != nil {
-				return false, err
-			}
-			result.Diagnostics.SelectionCompositions++
-		}
-		recordTypedColumnSelectionDiagnostics(&result.Diagnostics, selection)
-		if selection.IsEmpty() {
-			continue
-		}
-		if err := addTypedColumnInt64AggregateSelectedValues(result, values, selection); err != nil {
+		if err := addTypedColumnInt64AggregateStreamingValues(result, typedColumnInt64PredicateAggregateScanRequest(s.req), granule, block, visibility, &s.aggregateScratch); err != nil {
 			return false, err
 		}
 	}

--- a/TreeDB/collections/typed_column_prepared_int64.go
+++ b/TreeDB/collections/typed_column_prepared_int64.go
@@ -345,16 +345,36 @@ func addTypedColumnInt64AggregateStreamingValues(result *TypedColumnInt64Predica
 		var local typedColumnInt64PredicateAggregateScanScratch
 		scratch = &local
 	}
-	cursor, err := scratch.reader.Int64Cursor(granule)
-	if err != nil {
-		return err
-	}
 	rows := granule.Rows
 	if rows != block.Descriptor.RowCount {
 		return fmt.Errorf("typed-column int64 streaming rows=%d want block rows=%d", rows, block.Descriptor.RowCount)
 	}
 	result.Diagnostics.RowsScanned += rows
 	selection := block.CandidateSelection
+	if selection.IsAll() && !block.NeedsPredicate && visibility == nil {
+		count, sum, err := scratch.reader.CountSumInt64(granule)
+		if err != nil {
+			return err
+		}
+		if count != rows {
+			return fmt.Errorf("typed-column int64 streaming count=%d want rows=%d", count, rows)
+		}
+		if sum > 0 && result.Sum > typedColumnInt64PredicateAggregateMaxSum-sum {
+			return fmt.Errorf("collections: typed-column int64 predicate aggregate sum overflow current=%d value=%d", result.Sum, sum)
+		}
+		if sum < 0 && result.Sum < typedColumnInt64PredicateAggregateMinSum-sum {
+			return fmt.Errorf("collections: typed-column int64 predicate aggregate sum overflow current=%d value=%d", result.Sum, sum)
+		}
+		result.Count += int64(count)
+		result.Sum += sum
+		result.Diagnostics.RowsMatched += count
+		recordTypedColumnSelectionDiagnostics(&result.Diagnostics, selection)
+		return nil
+	}
+	cursor, err := scratch.reader.Int64Cursor(granule)
+	if err != nil {
+		return err
+	}
 	needFinalSelection := block.NeedsPredicate || visibility != nil || !selection.IsAll()
 	if needFinalSelection {
 		scratch.predicateRows = scratch.predicateRows[:0]

--- a/TreeDB/collections/typed_column_prepared_int64.go
+++ b/TreeDB/collections/typed_column_prepared_int64.go
@@ -455,7 +455,7 @@ func (s *TypedColumnInt64PredicateAggregateSession) scanPreparedAggregateColumnS
 		granule.PayloadRef = typedcolumn.PayloadRef{Kind: typedcolumn.PayloadRefInline, Length: block.PayloadLength}
 
 		if columnPlan.Path == typeddecode.PathUnsupported {
-			return false, fmt.Errorf("collections: typed-column int64 aggregate fast decode unsupported for column %q: %s", preparedColumn.Plan.Definition.Name, columnPlan.Status().Error())
+			return false, fmt.Errorf("collections: typed-column int64 aggregate fast decode unsupported for column %q: %s", preparedColumn.Plan.Definition.Name, columnPlan.Status().String())
 		}
 		if columnPlan.DirectCandidate() {
 			if block.Index < 0 || block.Index >= len(preparedColumn.Certification.Blocks) {
@@ -497,11 +497,11 @@ func (s *TypedColumnInt64PredicateAggregateSession) scanPreparedAggregateColumnS
 					continue
 				}
 				if !typedColumnInt64DirectViewFallbackAllowed(viewStatus) {
-					return false, fmt.Errorf("collections: typed-column int64 aggregate direct view failed closed for column %q block %d: %s", preparedColumn.Plan.Definition.Name, block.Index, viewStatus.Error())
+					return false, fmt.Errorf("collections: typed-column int64 aggregate direct view failed closed for column %q block %d: %s", preparedColumn.Plan.Definition.Name, block.Index, viewStatus.String())
 				}
 			} else if !typedColumnInt64DirectViewFallbackAllowed(blockStatus) {
 				recordTypedColumnInt64DirectViewStatus(&result.Diagnostics, blockStatus)
-				return false, fmt.Errorf("collections: typed-column int64 aggregate direct-view contract failed for column %q block %d: %s", preparedColumn.Plan.Definition.Name, block.Index, blockStatus.Error())
+				return false, fmt.Errorf("collections: typed-column int64 aggregate direct-view contract failed for column %q block %d: %s", preparedColumn.Plan.Definition.Name, block.Index, blockStatus.String())
 			} else {
 				recordTypedColumnInt64DirectViewStatus(&result.Diagnostics, blockStatus)
 			}

--- a/TreeDB/collections/typed_column_prepared_int64.go
+++ b/TreeDB/collections/typed_column_prepared_int64.go
@@ -426,6 +426,7 @@ func (s *TypedColumnInt64PredicateAggregateSession) scanPreparedAggregateColumnS
 	decodedAny := false
 	payloadRead := false
 	columnPlan := typeddecode.Int64ReducerPlan(preparedColumn.Plan.Layout, preparedColumn.Certification)
+	recordTypedColumnInt64FastDecodePlan(&result.Diagnostics, columnPlan)
 	var err error
 	for _, block := range preparedColumn.BlockPlans {
 		result.Diagnostics.BlocksConsidered++
@@ -453,7 +454,6 @@ func (s *TypedColumnInt64PredicateAggregateSession) scanPreparedAggregateColumnS
 		granule.Payload = payload
 		granule.PayloadRef = typedcolumn.PayloadRef{Kind: typedcolumn.PayloadRefInline, Length: block.PayloadLength}
 
-		recordTypedColumnInt64FastDecodePlan(&result.Diagnostics, columnPlan)
 		if columnPlan.Path == typeddecode.PathUnsupported {
 			return false, fmt.Errorf("collections: typed-column int64 aggregate fast decode unsupported for column %q: %s", preparedColumn.Plan.Definition.Name, columnPlan.Status().Error())
 		}

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -321,7 +321,7 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/column_int64_values_asset.go", classification: typedStorageLegacyDerived, matchingLines: 8, occurrences: 8},
 	{path: "TreeDB/collections/column_manifest_format.go", classification: typedStorageLegacyCompatibility, matchingLines: 2, occurrences: 2},
 	{path: "TreeDB/collections/column_physical_asset.go", classification: typedStorageLegacyDeferred, matchingLines: 36, occurrences: 36},
-	{path: "TreeDB/collections/column_physical_asset_test.go", classification: typedStorageLegacyDeferred, matchingLines: 156, occurrences: 160},
+	{path: "TreeDB/collections/column_physical_asset_test.go", classification: typedStorageLegacyDeferred, matchingLines: 159, occurrences: 163},
 	{path: "TreeDB/collections/column_physical_query.go", classification: typedStorageLegacyDeferred, matchingLines: 36, occurrences: 38},
 	{path: "TreeDB/collections/column_physical_query_test.go", classification: typedStorageLegacyDeferred, matchingLines: 128, occurrences: 139},
 	{path: "TreeDB/collections/column_physical_row_reader.go", classification: typedStorageLegacyDeferred, matchingLines: 21, occurrences: 21},

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -309,7 +309,7 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/column_aggregate_metadata_asset.go", classification: typedStorageLegacyDerived, matchingLines: 7, occurrences: 8},
 	{path: "TreeDB/collections/column_aggregate_metadata_typed_column_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 13, occurrences: 15},
 	{path: "TreeDB/collections/column_asset_gc_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 33, occurrences: 35},
-	{path: "TreeDB/collections/column_asset_manager.go", classification: typedStorageLegacyCompatibility, matchingLines: 11, occurrences: 11},
+	{path: "TreeDB/collections/column_asset_manager.go", classification: typedStorageLegacyCompatibility, matchingLines: 15, occurrences: 16},
 	{path: "TreeDB/collections/column_asset_mappedresource_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 12, occurrences: 12},
 	{path: "TreeDB/collections/column_asset_reachability_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 28, occurrences: 29},
 	{path: "TreeDB/collections/column_asset_rewrite.go", classification: typedStorageLegacyCompatibility, matchingLines: 8, occurrences: 10},

--- a/TreeDB/internal/mappedresource/typed_view.go
+++ b/TreeDB/internal/mappedresource/typed_view.go
@@ -11,6 +11,14 @@ var nativeLittleEndian = func() bool {
 	return *(*byte)(unsafe.Pointer(&value)) == 1
 }()
 
+var (
+	ErrDirectViewNilHandle      = errors.New("mappedresource: nil handle")
+	ErrDirectViewReleasedHandle = errors.New("mappedresource: handle is released")
+	ErrDirectViewWrongEndian    = errors.New("mappedresource: direct view wrong endian")
+	ErrDirectViewLengthMultiple = errors.New("mappedresource: direct view length multiple mismatch")
+	ErrDirectViewUnaligned      = errors.New("mappedresource: direct view unaligned")
+)
+
 // DirectViewOptions controls validation before raw bytes are reinterpreted as a
 // fixed-width typed slice.
 type DirectViewOptions struct {
@@ -33,17 +41,17 @@ func ValidateDirectView(data []byte, opts DirectViewOptions) (int, error) {
 		opts.TypeName = fmt.Sprintf("%d-byte", opts.ElementSize)
 	}
 	if opts.RequireLittleEndian && !nativeLittleEndian {
-		return 0, fmt.Errorf("mappedresource: %s direct view requires little-endian host", opts.TypeName)
+		return 0, fmt.Errorf("%w: %s direct view requires little-endian host", ErrDirectViewWrongEndian, opts.TypeName)
 	}
 	if uintptr(len(data))%opts.ElementSize != 0 {
-		return 0, fmt.Errorf("mappedresource: %s direct view length=%d is not multiple of element size=%d", opts.TypeName, len(data), opts.ElementSize)
+		return 0, fmt.Errorf("%w: %s direct view length=%d is not multiple of element size=%d", ErrDirectViewLengthMultiple, opts.TypeName, len(data), opts.ElementSize)
 	}
 	if len(data) == 0 {
 		return 0, nil
 	}
 	addr := uintptr(unsafe.Pointer(unsafe.SliceData(data)))
 	if addr%opts.Alignment != 0 {
-		return 0, fmt.Errorf("mappedresource: %s direct view address=%#x is not %d-byte aligned", opts.TypeName, addr, opts.Alignment)
+		return 0, fmt.Errorf("%w: %s direct view address=%#x is not %d-byte aligned", ErrDirectViewUnaligned, opts.TypeName, addr, opts.Alignment)
 	}
 	return int(uintptr(len(data)) / opts.ElementSize), nil
 }
@@ -146,12 +154,12 @@ func (m *Manager) Uint32View(h *Handle) ([]uint32, error) {
 
 func liveHandleBytes(h *Handle) ([]byte, error) {
 	if h == nil {
-		return nil, errors.New("mappedresource: nil handle")
+		return nil, ErrDirectViewNilHandle
 	}
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	if h.done {
-		return nil, errors.New("mappedresource: handle is released")
+		return nil, ErrDirectViewReleasedHandle
 	}
 	return h.bytes, nil
 }

--- a/TreeDB/internal/typedcolumn/granule.go
+++ b/TreeDB/internal/typedcolumn/granule.go
@@ -259,6 +259,98 @@ func (c *Int64Cursor) Rows() int { return c.cursor.rows }
 // RawBytesRead returns the payload byte offset consumed by the cursor.
 func (c *Int64Cursor) RawBytesRead() int { return c.cursor.RawBytesRead() }
 
+// CountSumInt64 streams all int64 values in the granule and returns count+sum
+// without materializing a []int64. It is intended for full-block reducers on
+// certified prepared paths where predicate/visibility/selection do not require
+// per-row branching in the caller.
+func (r *GranuleReader) CountSumInt64(g EncodedGranule) (int, int64, error) {
+	raw, err := r.decompressPayload(g)
+	if err != nil {
+		return 0, 0, err
+	}
+	if err := validateGranuleDecodeRows(g.Rows); err != nil {
+		return 0, 0, err
+	}
+	var sum int64
+	switch g.Encoding {
+	case EncodingRawInt64:
+		if len(raw)%8 != 0 || len(raw)/8 != g.Rows {
+			return 0, 0, fmt.Errorf("typedcolumn: raw int64 length=%d rows=%d", len(raw), g.Rows)
+		}
+		for row := 0; row < g.Rows; row++ {
+			v := int64(binary.LittleEndian.Uint64(raw[row*8:]))
+			if err := addCountSumInt64(&sum, v); err != nil {
+				return 0, 0, err
+			}
+		}
+	case EncodingDeltaVarint:
+		prev := int64(0)
+		for row := 0; row < g.Rows; row++ {
+			u, n := binary.Uvarint(raw)
+			if n <= 0 {
+				return 0, 0, errors.New("typedcolumn: malformed delta varint")
+			}
+			delta := unzigzag(u)
+			v := delta
+			if row > 0 {
+				v = prev + delta
+			}
+			if err := addCountSumInt64(&sum, v); err != nil {
+				return 0, 0, err
+			}
+			prev = v
+			raw = raw[n:]
+		}
+		if len(raw) != 0 {
+			return 0, 0, errors.New("typedcolumn: trailing delta bytes")
+		}
+	case EncodingDoubleDeltaVarint:
+		prev := int64(0)
+		prevDelta := int64(0)
+		for row := 0; row < g.Rows; row++ {
+			u, n := binary.Uvarint(raw)
+			if n <= 0 {
+				return 0, 0, errors.New("typedcolumn: malformed double-delta varint")
+			}
+			encoded := unzigzag(u)
+			var v int64
+			switch row {
+			case 0:
+				v = encoded
+			case 1:
+				prevDelta = encoded
+				v = prev + encoded
+			default:
+				delta := prevDelta + encoded
+				v = prev + delta
+				prevDelta = delta
+			}
+			if err := addCountSumInt64(&sum, v); err != nil {
+				return 0, 0, err
+			}
+			prev = v
+			raw = raw[n:]
+		}
+		if len(raw) != 0 {
+			return 0, 0, errors.New("typedcolumn: trailing double-delta bytes")
+		}
+	default:
+		return 0, 0, fmt.Errorf("typedcolumn: unsupported encoding %d", g.Encoding)
+	}
+	return g.Rows, sum, nil
+}
+
+func addCountSumInt64(sum *int64, value int64) error {
+	if value > 0 && *sum > math.MaxInt64-value {
+		return fmt.Errorf("typedcolumn: int64 sum overflow current=%d value=%d", *sum, value)
+	}
+	if value < 0 && *sum < math.MinInt64-value {
+		return fmt.Errorf("typedcolumn: int64 sum overflow current=%d value=%d", *sum, value)
+	}
+	*sum += value
+	return nil
+}
+
 func (r *GranuleReader) RangeScanCountInt64(g EncodedGranule, low, high int64) (int, error) {
 	if low > high || (g.HasMinMax && (high < g.Min || low > g.Max)) {
 		r.values = r.values[:0]

--- a/TreeDB/internal/typedcolumn/granule.go
+++ b/TreeDB/internal/typedcolumn/granule.go
@@ -223,6 +223,42 @@ func (r *GranuleReader) int64Cursor(g EncodedGranule) (int64Cursor, error) {
 	return cursor, nil
 }
 
+// Int64Cursor streams int64 values from a granule without materializing a full
+// []int64. It is intended for reducers and predicate cursors that have already
+// selected a concrete typed-column path during prepare.
+type Int64Cursor struct {
+	cursor int64Cursor
+}
+
+// Int64Cursor returns a cursor over raw, delta-varint, or double-delta int64
+// payloads after payload decompression/validation. The cursor aliases reader
+// scratch for compressed payloads and is valid until the next GranuleReader
+// operation.
+func (r *GranuleReader) Int64Cursor(g EncodedGranule) (Int64Cursor, error) {
+	cursor, err := r.int64Cursor(g)
+	if err != nil {
+		return Int64Cursor{}, err
+	}
+	return Int64Cursor{cursor: cursor}, nil
+}
+
+// Next returns the next value. Call Finish after consuming Rows values to catch
+// truncated or trailing variable-width payload bytes.
+func (c *Int64Cursor) Next() (int64, error) { return c.cursor.Next() }
+
+// Finish validates that exactly the declared rows were consumed and that
+// variable-width encodings have no trailing bytes.
+func (c *Int64Cursor) Finish() error { return c.cursor.Finish() }
+
+// Row returns the next row index to be decoded.
+func (c *Int64Cursor) Row() int { return c.cursor.row }
+
+// Rows returns the declared row count.
+func (c *Int64Cursor) Rows() int { return c.cursor.rows }
+
+// RawBytesRead returns the payload byte offset consumed by the cursor.
+func (c *Int64Cursor) RawBytesRead() int { return c.cursor.RawBytesRead() }
+
 func (r *GranuleReader) RangeScanCountInt64(g EncodedGranule, low, high int64) (int, error) {
 	if low > high || (g.HasMinMax && (high < g.Min || low > g.Max)) {
 		r.values = r.values[:0]

--- a/TreeDB/internal/typedcolumn/granule.go
+++ b/TreeDB/internal/typedcolumn/granule.go
@@ -293,7 +293,11 @@ func (r *GranuleReader) CountSumInt64(g EncodedGranule) (int, int64, error) {
 			delta := unzigzag(u)
 			v := delta
 			if row > 0 {
-				v = prev + delta
+				var addErr error
+				v, addErr = checkedInt64Add(prev, delta)
+				if addErr != nil {
+					return 0, 0, fmt.Errorf("typedcolumn: delta int64 overflow: %w", addErr)
+				}
 			}
 			if err := addCountSumInt64(&sum, v); err != nil {
 				return 0, 0, err
@@ -318,11 +322,21 @@ func (r *GranuleReader) CountSumInt64(g EncodedGranule) (int, int64, error) {
 			case 0:
 				v = encoded
 			case 1:
+				var addErr error
 				prevDelta = encoded
-				v = prev + encoded
+				v, addErr = checkedInt64Add(prev, encoded)
+				if addErr != nil {
+					return 0, 0, fmt.Errorf("typedcolumn: double-delta int64 overflow: %w", addErr)
+				}
 			default:
-				delta := prevDelta + encoded
-				v = prev + delta
+				delta, addErr := checkedInt64Add(prevDelta, encoded)
+				if addErr != nil {
+					return 0, 0, fmt.Errorf("typedcolumn: double-delta delta overflow: %w", addErr)
+				}
+				v, addErr = checkedInt64Add(prev, delta)
+				if addErr != nil {
+					return 0, 0, fmt.Errorf("typedcolumn: double-delta int64 overflow: %w", addErr)
+				}
 				prevDelta = delta
 			}
 			if err := addCountSumInt64(&sum, v); err != nil {
@@ -341,14 +355,22 @@ func (r *GranuleReader) CountSumInt64(g EncodedGranule) (int, int64, error) {
 }
 
 func addCountSumInt64(sum *int64, value int64) error {
-	if value > 0 && *sum > math.MaxInt64-value {
-		return fmt.Errorf("typedcolumn: int64 sum overflow current=%d value=%d", *sum, value)
+	updated, err := checkedInt64Add(*sum, value)
+	if err != nil {
+		return fmt.Errorf("typedcolumn: int64 sum overflow: %w", err)
 	}
-	if value < 0 && *sum < math.MinInt64-value {
-		return fmt.Errorf("typedcolumn: int64 sum overflow current=%d value=%d", *sum, value)
-	}
-	*sum += value
+	*sum = updated
 	return nil
+}
+
+func checkedInt64Add(current, value int64) (int64, error) {
+	if value > 0 && current > math.MaxInt64-value {
+		return 0, fmt.Errorf("current=%d value=%d", current, value)
+	}
+	if value < 0 && current < math.MinInt64-value {
+		return 0, fmt.Errorf("current=%d value=%d", current, value)
+	}
+	return current + value, nil
 }
 
 func (r *GranuleReader) RangeScanCountInt64(g EncodedGranule, low, high int64) (int, error) {
@@ -637,7 +659,11 @@ func (c *int64Cursor) Next() (int64, error) {
 		delta := unzigzag(u)
 		v := delta
 		if c.row > 0 {
-			v = c.prev + delta
+			var err error
+			v, err = checkedInt64Add(c.prev, delta)
+			if err != nil {
+				return 0, fmt.Errorf("typedcolumn: delta int64 overflow: %w", err)
+			}
 		}
 		c.row++
 		c.offset += n
@@ -654,11 +680,21 @@ func (c *int64Cursor) Next() (int64, error) {
 		case 0:
 			v = encoded
 		case 1:
+			var err error
 			c.prevDelta = encoded
-			v = c.prev + encoded
+			v, err = checkedInt64Add(c.prev, encoded)
+			if err != nil {
+				return 0, fmt.Errorf("typedcolumn: double-delta int64 overflow: %w", err)
+			}
 		default:
-			delta := c.prevDelta + encoded
-			v = c.prev + delta
+			delta, err := checkedInt64Add(c.prevDelta, encoded)
+			if err != nil {
+				return 0, fmt.Errorf("typedcolumn: double-delta delta overflow: %w", err)
+			}
+			v, err = checkedInt64Add(c.prev, delta)
+			if err != nil {
+				return 0, fmt.Errorf("typedcolumn: double-delta int64 overflow: %w", err)
+			}
 			c.prevDelta = delta
 		}
 		c.row++

--- a/TreeDB/internal/typedcolumn/granule.go
+++ b/TreeDB/internal/typedcolumn/granule.go
@@ -293,11 +293,7 @@ func (r *GranuleReader) CountSumInt64(g EncodedGranule) (int, int64, error) {
 			delta := unzigzag(u)
 			v := delta
 			if row > 0 {
-				var addErr error
-				v, addErr = checkedInt64Add(prev, delta)
-				if addErr != nil {
-					return 0, 0, fmt.Errorf("typedcolumn: delta int64 overflow: %w", addErr)
-				}
+				v = prev + delta
 			}
 			if err := addCountSumInt64(&sum, v); err != nil {
 				return 0, 0, err
@@ -322,21 +318,11 @@ func (r *GranuleReader) CountSumInt64(g EncodedGranule) (int, int64, error) {
 			case 0:
 				v = encoded
 			case 1:
-				var addErr error
 				prevDelta = encoded
-				v, addErr = checkedInt64Add(prev, encoded)
-				if addErr != nil {
-					return 0, 0, fmt.Errorf("typedcolumn: double-delta int64 overflow: %w", addErr)
-				}
+				v = prev + encoded
 			default:
-				delta, addErr := checkedInt64Add(prevDelta, encoded)
-				if addErr != nil {
-					return 0, 0, fmt.Errorf("typedcolumn: double-delta delta overflow: %w", addErr)
-				}
-				v, addErr = checkedInt64Add(prev, delta)
-				if addErr != nil {
-					return 0, 0, fmt.Errorf("typedcolumn: double-delta int64 overflow: %w", addErr)
-				}
+				delta := prevDelta + encoded
+				v = prev + delta
 				prevDelta = delta
 			}
 			if err := addCountSumInt64(&sum, v); err != nil {
@@ -659,11 +645,7 @@ func (c *int64Cursor) Next() (int64, error) {
 		delta := unzigzag(u)
 		v := delta
 		if c.row > 0 {
-			var err error
-			v, err = checkedInt64Add(c.prev, delta)
-			if err != nil {
-				return 0, fmt.Errorf("typedcolumn: delta int64 overflow: %w", err)
-			}
+			v = c.prev + delta
 		}
 		c.row++
 		c.offset += n
@@ -680,21 +662,11 @@ func (c *int64Cursor) Next() (int64, error) {
 		case 0:
 			v = encoded
 		case 1:
-			var err error
 			c.prevDelta = encoded
-			v, err = checkedInt64Add(c.prev, encoded)
-			if err != nil {
-				return 0, fmt.Errorf("typedcolumn: double-delta int64 overflow: %w", err)
-			}
+			v = c.prev + encoded
 		default:
-			delta, err := checkedInt64Add(c.prevDelta, encoded)
-			if err != nil {
-				return 0, fmt.Errorf("typedcolumn: double-delta delta overflow: %w", err)
-			}
-			v, err = checkedInt64Add(c.prev, delta)
-			if err != nil {
-				return 0, fmt.Errorf("typedcolumn: double-delta int64 overflow: %w", err)
-			}
+			delta := c.prevDelta + encoded
+			v = c.prev + delta
 			c.prevDelta = delta
 		}
 		c.row++

--- a/TreeDB/internal/typedcolumn/int64_cursor_test.go
+++ b/TreeDB/internal/typedcolumn/int64_cursor_test.go
@@ -28,6 +28,13 @@ func TestGranuleReaderInt64CursorDeltaAndDoubleDelta(t *testing.T) {
 			if err := cursor.Finish(); err != nil {
 				t.Fatalf("Finish: %v", err)
 			}
+			count, sum, err := reader.CountSumInt64(g)
+			if err != nil {
+				t.Fatalf("CountSumInt64: %v", err)
+			}
+			if count != len(values) || sum != 153 {
+				t.Fatalf("CountSumInt64 count=%d sum=%d want count=%d sum=153", count, sum, len(values))
+			}
 		})
 	}
 }
@@ -86,6 +93,27 @@ func BenchmarkGranuleReaderInt64DeltaCursorVsDecode(b *testing.B) {
 		}
 		if sum == 42 {
 			b.Fatal(sum)
+		}
+	})
+	b.Run("streaming_count_sum", func(b *testing.B) {
+		var reader GranuleReader
+		b.ReportAllocs()
+		b.SetBytes(int64(g.RawBytes))
+		b.ReportMetric(float64(len(values)), "values/op")
+		b.ResetTimer()
+		var total int64
+		for i := 0; i < b.N; i++ {
+			count, sum, err := reader.CountSumInt64(g)
+			if err != nil {
+				b.Fatalf("CountSumInt64: %v", err)
+			}
+			if count != len(values) {
+				b.Fatalf("CountSumInt64 count=%d want %d", count, len(values))
+			}
+			total += sum
+		}
+		if total == 42 {
+			b.Fatal(total)
 		}
 	})
 	b.Run("decode_into_scratch", func(b *testing.B) {

--- a/TreeDB/internal/typedcolumn/int64_cursor_test.go
+++ b/TreeDB/internal/typedcolumn/int64_cursor_test.go
@@ -1,6 +1,10 @@
 package typedcolumn
 
-import "testing"
+import (
+	"encoding/binary"
+	"math"
+	"testing"
+)
 
 func TestGranuleReaderInt64CursorDeltaAndDoubleDelta(t *testing.T) {
 	values := []int64{10, 12, 17, 17, -3, 100}
@@ -34,6 +38,30 @@ func TestGranuleReaderInt64CursorDeltaAndDoubleDelta(t *testing.T) {
 			}
 			if count != len(values) || sum != 153 {
 				t.Fatalf("CountSumInt64 count=%d sum=%d want count=%d sum=153", count, sum, len(values))
+			}
+		})
+	}
+}
+
+func TestGranuleReaderInt64CursorFailsClosedOnDecodeOverflow(t *testing.T) {
+	for _, enc := range []Encoding{EncodingDeltaVarint, EncodingDoubleDeltaVarint} {
+		t.Run(enc.String(), func(t *testing.T) {
+			payload := binary.AppendUvarint(nil, zigzag(math.MaxInt64))
+			payload = binary.AppendUvarint(payload, zigzag(1))
+			g := EncodedGranule{Rows: 2, Encoding: enc, Compression: CompressionNone, RawBytes: len(payload), StoredBytes: len(payload), PayloadRef: PayloadRef{Kind: PayloadRefInline, Length: len(payload)}, Payload: payload}
+			var reader GranuleReader
+			cursor, err := reader.Int64Cursor(g)
+			if err != nil {
+				t.Fatalf("Int64Cursor: %v", err)
+			}
+			if got, err := cursor.Next(); err != nil || got != math.MaxInt64 {
+				t.Fatalf("first Next got=%d err=%v want MaxInt64", got, err)
+			}
+			if _, err := cursor.Next(); err == nil {
+				t.Fatal("second Next err=nil want overflow")
+			}
+			if _, _, err := reader.CountSumInt64(g); err == nil {
+				t.Fatal("CountSumInt64 err=nil want overflow")
 			}
 		})
 	}

--- a/TreeDB/internal/typedcolumn/int64_cursor_test.go
+++ b/TreeDB/internal/typedcolumn/int64_cursor_test.go
@@ -1,0 +1,112 @@
+package typedcolumn
+
+import "testing"
+
+func TestGranuleReaderInt64CursorDeltaAndDoubleDelta(t *testing.T) {
+	values := []int64{10, 12, 17, 17, -3, 100}
+	for _, enc := range []Encoding{EncodingDeltaVarint, EncodingDoubleDeltaVarint, EncodingRawInt64} {
+		t.Run(enc.String(), func(t *testing.T) {
+			builder := NewGranuleBuilder(Config{Encoding: enc, Compression: CompressionNone})
+			g, err := builder.BuildInt64(values)
+			if err != nil {
+				t.Fatalf("BuildInt64: %v", err)
+			}
+			var reader GranuleReader
+			cursor, err := reader.Int64Cursor(g)
+			if err != nil {
+				t.Fatalf("Int64Cursor: %v", err)
+			}
+			for i, want := range values {
+				got, err := cursor.Next()
+				if err != nil {
+					t.Fatalf("Next[%d]: %v", i, err)
+				}
+				if got != want {
+					t.Fatalf("Next[%d]=%d want %d", i, got, want)
+				}
+			}
+			if err := cursor.Finish(); err != nil {
+				t.Fatalf("Finish: %v", err)
+			}
+		})
+	}
+}
+
+func TestGranuleReaderInt64CursorFinishDetectsShortRead(t *testing.T) {
+	builder := NewGranuleBuilder(Config{Encoding: EncodingDeltaVarint, Compression: CompressionNone})
+	g, err := builder.BuildInt64([]int64{1, 2, 3})
+	if err != nil {
+		t.Fatalf("BuildInt64: %v", err)
+	}
+	var reader GranuleReader
+	cursor, err := reader.Int64Cursor(g)
+	if err != nil {
+		t.Fatalf("Int64Cursor: %v", err)
+	}
+	if _, err := cursor.Next(); err != nil {
+		t.Fatalf("Next: %v", err)
+	}
+	if err := cursor.Finish(); err == nil {
+		t.Fatal("Finish err=nil want short-read failure")
+	}
+}
+
+func BenchmarkGranuleReaderInt64DeltaCursorVsDecode(b *testing.B) {
+	values := make([]int64, 4096)
+	for i := range values {
+		values[i] = int64(i*i/7 - i/3)
+	}
+	builder := NewGranuleBuilder(Config{Encoding: EncodingDeltaVarint, Compression: CompressionNone})
+	g, err := builder.BuildInt64(values)
+	if err != nil {
+		b.Fatalf("BuildInt64: %v", err)
+	}
+	b.Run("streaming_cursor", func(b *testing.B) {
+		var reader GranuleReader
+		b.ReportAllocs()
+		b.SetBytes(int64(g.RawBytes))
+		b.ReportMetric(float64(len(values)), "values/op")
+		b.ResetTimer()
+		var sum int64
+		for i := 0; i < b.N; i++ {
+			cursor, err := reader.Int64Cursor(g)
+			if err != nil {
+				b.Fatalf("Int64Cursor: %v", err)
+			}
+			for row := 0; row < cursor.Rows(); row++ {
+				v, err := cursor.Next()
+				if err != nil {
+					b.Fatalf("Next: %v", err)
+				}
+				sum += v
+			}
+			if err := cursor.Finish(); err != nil {
+				b.Fatalf("Finish: %v", err)
+			}
+		}
+		if sum == 42 {
+			b.Fatal(sum)
+		}
+	})
+	b.Run("decode_into_scratch", func(b *testing.B) {
+		var reader GranuleReader
+		scratch := make([]int64, 0, len(values))
+		b.ReportAllocs()
+		b.SetBytes(int64(g.RawBytes))
+		b.ReportMetric(float64(len(values)), "values/op")
+		b.ResetTimer()
+		var sum int64
+		for i := 0; i < b.N; i++ {
+			out, err := reader.DecodeInt64Into(scratch[:0], g)
+			if err != nil {
+				b.Fatalf("DecodeInt64Into: %v", err)
+			}
+			for _, v := range out {
+				sum += v
+			}
+		}
+		if sum == 42 {
+			b.Fatal(sum)
+		}
+	})
+}

--- a/TreeDB/internal/typedcolumn/int64_cursor_test.go
+++ b/TreeDB/internal/typedcolumn/int64_cursor_test.go
@@ -1,7 +1,6 @@
 package typedcolumn
 
 import (
-	"encoding/binary"
 	"math"
 	"testing"
 )
@@ -43,25 +42,38 @@ func TestGranuleReaderInt64CursorDeltaAndDoubleDelta(t *testing.T) {
 	}
 }
 
-func TestGranuleReaderInt64CursorFailsClosedOnDecodeOverflow(t *testing.T) {
+func TestGranuleReaderInt64CursorPreservesEncoderWraparound(t *testing.T) {
+	values := []int64{math.MaxInt64, math.MinInt64}
 	for _, enc := range []Encoding{EncodingDeltaVarint, EncodingDoubleDeltaVarint} {
 		t.Run(enc.String(), func(t *testing.T) {
-			payload := binary.AppendUvarint(nil, zigzag(math.MaxInt64))
-			payload = binary.AppendUvarint(payload, zigzag(1))
-			g := EncodedGranule{Rows: 2, Encoding: enc, Compression: CompressionNone, RawBytes: len(payload), StoredBytes: len(payload), PayloadRef: PayloadRef{Kind: PayloadRefInline, Length: len(payload)}, Payload: payload}
+			builder := NewGranuleBuilder(Config{Encoding: enc, Compression: CompressionNone})
+			g, err := builder.BuildInt64(values)
+			if err != nil {
+				t.Fatalf("BuildInt64: %v", err)
+			}
 			var reader GranuleReader
 			cursor, err := reader.Int64Cursor(g)
 			if err != nil {
 				t.Fatalf("Int64Cursor: %v", err)
 			}
-			if got, err := cursor.Next(); err != nil || got != math.MaxInt64 {
-				t.Fatalf("first Next got=%d err=%v want MaxInt64", got, err)
+			for i, want := range values {
+				got, err := cursor.Next()
+				if err != nil {
+					t.Fatalf("Next[%d]: %v", i, err)
+				}
+				if got != want {
+					t.Fatalf("Next[%d]=%d want %d", i, got, want)
+				}
 			}
-			if _, err := cursor.Next(); err == nil {
-				t.Fatal("second Next err=nil want overflow")
+			if err := cursor.Finish(); err != nil {
+				t.Fatalf("Finish: %v", err)
 			}
-			if _, _, err := reader.CountSumInt64(g); err == nil {
-				t.Fatal("CountSumInt64 err=nil want overflow")
+			count, sum, err := reader.CountSumInt64(g)
+			if err != nil {
+				t.Fatalf("CountSumInt64: %v", err)
+			}
+			if count != len(values) || sum != -1 {
+				t.Fatalf("CountSumInt64 count=%d sum=%d want count=%d sum=-1", count, sum, len(values))
 			}
 		})
 	}

--- a/TreeDB/internal/typeddecode/plan.go
+++ b/TreeDB/internal/typeddecode/plan.go
@@ -298,6 +298,8 @@ func checkedMul3(a, b, c int) (int, bool) {
 
 // ResourceViewOptions controls handle-level direct-view validation.
 type ResourceViewOptions struct {
+	// ExpectedElements validates the view length. Use a negative value to skip
+	// length validation; zero intentionally means an empty view is expected.
 	ExpectedElements int
 	RequireMapped    bool
 }

--- a/TreeDB/internal/typeddecode/plan.go
+++ b/TreeDB/internal/typeddecode/plan.go
@@ -1,0 +1,404 @@
+// Package typeddecode contains shared typed-column fast-decode planning and
+// validated direct-view helpers. It deliberately keeps unsafe byte
+// reinterpretation inside TreeDB/internal/mappedresource and only returns direct
+// views after semantic, layout, writer-certification, row-count, endian,
+// alignment, and lifetime checks have all succeeded.
+package typeddecode
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/snissn/gomap/TreeDB/internal/columnlayout"
+	"github.com/snissn/gomap/TreeDB/internal/mappedresource"
+	"github.com/snissn/gomap/TreeDB/internal/typedcolumn"
+)
+
+// Path is the explicit fast-decode path selected for one column/operator/block.
+type Path string
+
+const (
+	PathDirectView  Path = "direct_view"
+	PathStreaming   Path = "streaming"
+	PathMaterialize Path = "materialize"
+	PathUnsupported Path = "unsupported"
+)
+
+// Reason is a stable planning/fallback diagnostic token. Add new values rather
+// than changing strings; tests and PR benchmark output may key on them.
+type Reason string
+
+const (
+	ReasonSupported                  Reason = "supported"
+	ReasonUnsupportedOperation       Reason = "unsupported_operation"
+	ReasonLayoutCapability           Reason = "layout_capability"
+	ReasonNotWriterCertified         Reason = "writer_certification_missing"
+	ReasonCompressed                 Reason = "compressed"
+	ReasonVariableWidth              Reason = "variable_width"
+	ReasonNullableWrapper            Reason = "nullable_default_wrapper"
+	ReasonWrongEndian                Reason = "wrong_endian"
+	ReasonLengthMultipleMismatch     Reason = "length_multiple_mismatch"
+	ReasonPayloadLengthMismatch      Reason = "payload_length_mismatch"
+	ReasonRowCountMismatch           Reason = "row_count_mismatch"
+	ReasonDimensionMismatch          Reason = "dimension_mismatch"
+	ReasonUnaligned                  Reason = "unaligned"
+	ReasonNilHandle                  Reason = "nil_handle"
+	ReasonStaleHandle                Reason = "stale_handle"
+	ReasonHandleSourceUnsupported    Reason = "handle_source_unsupported"
+	ReasonDictionarySemanticsMissing Reason = "dictionary_semantics_missing"
+	ReasonMaterializationRequired    Reason = "materialization_required"
+	ReasonValidationFailed           Reason = "validation_failed"
+)
+
+// Status describes the outcome of planning or validating a fast-decode path.
+type Status struct {
+	Path    Path
+	Reason  Reason
+	Message string
+	Err     error
+}
+
+func DirectStatus() Status { return Status{Path: PathDirectView, Reason: ReasonSupported} }
+func StreamingStatus(reason Reason, msg string) Status {
+	return Status{Path: PathStreaming, Reason: reason, Message: msg}
+}
+func MaterializeStatus(reason Reason, msg string) Status {
+	return Status{Path: PathMaterialize, Reason: reason, Message: msg}
+}
+func UnsupportedStatus(reason Reason, msg string) Status {
+	return Status{Path: PathUnsupported, Reason: reason, Message: msg}
+}
+
+func (s Status) Direct() bool {
+	return s.Path == PathDirectView && s.Reason == ReasonSupported && s.Err == nil
+}
+func (s Status) Streaming() bool   { return s.Path == PathStreaming }
+func (s Status) Unsupported() bool { return s.Path == PathUnsupported }
+
+func (s Status) Error() string {
+	if s.Err != nil {
+		return s.Err.Error()
+	}
+	if s.Message != "" {
+		return fmt.Sprintf("%s: %s", s.Reason, s.Message)
+	}
+	return string(s.Reason)
+}
+
+// Plan is a reusable per-column/operator decision. Per-block and per-handle
+// validation still has to run before exposing a direct-view slice.
+type Plan struct {
+	Path           Path
+	Reason         Reason
+	Message        string
+	ElementSize    int
+	ElementsPerRow int
+	Alignment      int
+	Rows           int
+}
+
+func (p Plan) Status() Status        { return Status{Path: p.Path, Reason: p.Reason, Message: p.Message} }
+func (p Plan) DirectCandidate() bool { return p.Path == PathDirectView && p.Reason == ReasonSupported }
+
+// Counters is a small shared accounting shape for prepared scans and future
+// kernels. It is caller-owned; there is no package-global cache.
+type Counters struct {
+	DirectViewPlans     uint64
+	StreamingPlans      uint64
+	MaterializePlans    uint64
+	UnsupportedPlans    uint64
+	DirectViewSuccesses uint64
+	DirectViewFailures  uint64
+	FallbackReasons     map[Reason]uint64
+}
+
+func (c *Counters) ObservePlan(p Plan)     { c.observe(p.Path, p.Reason) }
+func (c *Counters) ObserveStatus(s Status) { c.observe(s.Path, s.Reason) }
+func (c *Counters) ObserveDirectViewStatus(s Status) {
+	if c == nil {
+		return
+	}
+	if s.Direct() {
+		c.DirectViewSuccesses++
+		return
+	}
+	c.DirectViewFailures++
+	c.observe(s.Path, s.Reason)
+}
+
+func (c *Counters) observe(path Path, reason Reason) {
+	if c == nil {
+		return
+	}
+	switch path {
+	case PathDirectView:
+		c.DirectViewPlans++
+	case PathStreaming:
+		c.StreamingPlans++
+	case PathMaterialize:
+		c.MaterializePlans++
+	case PathUnsupported:
+		c.UnsupportedPlans++
+	}
+	if reason != "" && reason != ReasonSupported {
+		if c.FallbackReasons == nil {
+			c.FallbackReasons = make(map[Reason]uint64, 1)
+		}
+		c.FallbackReasons[reason]++
+	}
+}
+
+// Int64ReducerPlan chooses direct_view for certified raw int64 layouts and
+// streaming for certified delta/double-delta or raw layouts that cannot direct
+// view. Materialization is intentionally not selected by the shared int64
+// aggregate planner.
+func Int64ReducerPlan(layout columnlayout.Capabilities, cert typedcolumn.ColumnPartLayoutContractColumn) Plan {
+	if cap := layout.Supports(columnlayout.OpInt64NumericReducer); !cap.Supported() {
+		return Plan{Path: PathUnsupported, Reason: ReasonLayoutCapability, Message: cap.Error()}
+	}
+	if layout.Reducers.Int64FixedWidthRaw {
+		base := Plan{Path: PathDirectView, Reason: ReasonSupported, ElementSize: 8, ElementsPerRow: 1, Alignment: 8, Rows: cert.Rows}
+		if status := validateDirectViewCertification(layout, cert, 8, 1); !status.Direct() {
+			if status.Unsupported() {
+				return Plan{Path: PathUnsupported, Reason: status.Reason, Message: status.Message, ElementSize: 8, ElementsPerRow: 1, Alignment: 8, Rows: cert.Rows}
+			}
+			// Raw fixed-width int64 can still be safely streamed with explicit
+			// little-endian loads when a direct view is not certified.
+			return Plan{Path: PathStreaming, Reason: status.Reason, Message: status.Message, ElementSize: 8, ElementsPerRow: 1, Alignment: 8, Rows: cert.Rows}
+		}
+		return base
+	}
+	if layout.Reducers.Int64Streaming {
+		if !cert.StreamingCertified {
+			return Plan{Path: PathUnsupported, Reason: ReasonNotWriterCertified, Message: "int64 streaming layout is not writer-certified"}
+		}
+		if cert.Compression != typedcolumn.CompressionNone {
+			return Plan{Path: PathUnsupported, Reason: ReasonCompressed, Message: fmt.Sprintf("compression=%s", cert.Compression)}
+		}
+		if cert.NullMaskPresent || cert.DefaultMaskPresent || cert.NullCount != 0 || cert.DefaultCount != 0 {
+			return Plan{Path: PathUnsupported, Reason: ReasonNullableWrapper, Message: "null/default masks must be applied outside scalar int64 reducer"}
+		}
+		return Plan{Path: PathStreaming, Reason: ReasonVariableWidth, Message: "certified variable-width int64 streaming reducer", ElementSize: 8, ElementsPerRow: 1, Rows: cert.Rows}
+	}
+	return Plan{Path: PathUnsupported, Reason: ReasonUnsupportedOperation, Message: "layout does not advertise int64 reducer"}
+}
+
+func validateDirectViewCertification(layout columnlayout.Capabilities, cert typedcolumn.ColumnPartLayoutContractColumn, elementSize int, elementsPerRow int) Status {
+	if cap := layout.Supports(columnlayout.OpDirectView); !cap.Supported() {
+		return statusFromLayoutCapability(cap)
+	}
+	return validateDirectViewCertificationFields(cert, elementSize, elementsPerRow)
+}
+
+func validateDirectViewCertificationFields(cert typedcolumn.ColumnPartLayoutContractColumn, elementSize int, elementsPerRow int) Status {
+	if !cert.DirectViewCertified {
+		return StreamingStatus(ReasonNotWriterCertified, "column lacks writer-certified direct-view contract")
+	}
+	if cert.Compression != typedcolumn.CompressionNone {
+		return UnsupportedStatus(ReasonCompressed, fmt.Sprintf("compression=%s", cert.Compression))
+	}
+	if cert.NullMaskPresent || cert.DefaultMaskPresent || cert.NullCount != 0 || cert.DefaultCount != 0 {
+		return UnsupportedStatus(ReasonNullableWrapper, "null/default masks must be separate from value direct view")
+	}
+	if cert.Endian != typedcolumn.ColumnPartLayoutEndianLittle {
+		return StreamingStatus(ReasonWrongEndian, fmt.Sprintf("endian=%s", cert.Endian))
+	}
+	if cert.ElementSize != elementSize {
+		return StreamingStatus(ReasonLengthMultipleMismatch, fmt.Sprintf("element_size=%d want %d", cert.ElementSize, elementSize))
+	}
+	if cert.FixedWidthElements != 0 && cert.FixedWidthElements != elementsPerRow {
+		return StreamingStatus(ReasonDimensionMismatch, fmt.Sprintf("elements_per_row=%d want %d", cert.FixedWidthElements, elementsPerRow))
+	}
+	if cert.Alignment <= 0 || cert.Alignment < elementSize || cert.LengthMultiple <= 0 || cert.LengthMultiple%elementSize != 0 {
+		return StreamingStatus(ReasonLengthMultipleMismatch, fmt.Sprintf("alignment=%d length_multiple=%d element_size=%d", cert.Alignment, cert.LengthMultiple, elementSize))
+	}
+	return DirectStatus()
+}
+
+func statusFromLayoutCapability(cap columnlayout.Capability) Status {
+	reason := ReasonLayoutCapability
+	switch cap.Reason {
+	case columnlayout.ReasonCompressedDirectView, columnlayout.ReasonUnsupportedCompression:
+		reason = ReasonCompressed
+	case columnlayout.ReasonVariableWidthNoDirectView:
+		reason = ReasonVariableWidth
+	case columnlayout.ReasonNullDefaultWrapperRequired:
+		reason = ReasonNullableWrapper
+	case columnlayout.ReasonOperationUnsupported:
+		reason = ReasonUnsupportedOperation
+	}
+	if string(cap.Status) == "fallback" {
+		return StreamingStatus(reason, cap.Error())
+	}
+	return UnsupportedStatus(reason, cap.Error())
+}
+
+// DirectViewBlockRequest validates one payload/block against a direct-view plan.
+type DirectViewBlockRequest struct {
+	Plan          Plan
+	Certification typedcolumn.ColumnPartLayoutContractColumn
+	Block         typedcolumn.ColumnPartLayoutContractBlock
+	Rows          int
+	PayloadBytes  int
+}
+
+func ValidateDirectViewBlock(req DirectViewBlockRequest) Status {
+	if !req.Plan.DirectCandidate() {
+		return req.Plan.Status()
+	}
+	cert := req.Certification
+	block := req.Block
+	if status := validateDirectViewCertificationFields(cert, req.Plan.ElementSize, max(1, req.Plan.ElementsPerRow)); !status.Direct() {
+		return status
+	}
+	if req.Rows < 0 || block.RowCount != req.Rows {
+		return StreamingStatus(ReasonRowCountMismatch, fmt.Sprintf("block_rows=%d request_rows=%d", block.RowCount, req.Rows))
+	}
+	if block.Encoding != cert.Encoding || block.Compression != cert.Compression {
+		return UnsupportedStatus(ReasonValidationFailed, fmt.Sprintf("block encoding/compression=(%s,%s) cert=(%s,%s)", block.Encoding, block.Compression, cert.Encoding, cert.Compression))
+	}
+	if block.NullCount != 0 || block.DefaultCount != 0 {
+		return UnsupportedStatus(ReasonNullableWrapper, fmt.Sprintf("block null/default=(%d,%d)", block.NullCount, block.DefaultCount))
+	}
+	if req.PayloadBytes != block.PayloadLength {
+		return UnsupportedStatus(ReasonPayloadLengthMismatch, fmt.Sprintf("payload_bytes=%d block_length=%d", req.PayloadBytes, block.PayloadLength))
+	}
+	if cert.LengthMultiple <= 0 || block.PayloadLength%cert.LengthMultiple != 0 || block.RawBytes%cert.LengthMultiple != 0 {
+		return StreamingStatus(ReasonLengthMultipleMismatch, fmt.Sprintf("payload=%d raw=%d multiple=%d", block.PayloadLength, block.RawBytes, cert.LengthMultiple))
+	}
+	elementsPerRow := req.Plan.ElementsPerRow
+	if elementsPerRow <= 0 {
+		elementsPerRow = 1
+	}
+	want, ok := checkedMul3(req.Rows, elementsPerRow, req.Plan.ElementSize)
+	if !ok {
+		return UnsupportedStatus(ReasonPayloadLengthMismatch, "fixed-width byte count overflow")
+	}
+	if block.PayloadLength != want || block.RawBytes != want || block.StoredBytes != want {
+		return UnsupportedStatus(ReasonRowCountMismatch, fmt.Sprintf("payload/raw/stored=(%d,%d,%d) want rows=%d*elements=%d*width=%d=%d", block.PayloadLength, block.RawBytes, block.StoredBytes, req.Rows, elementsPerRow, req.Plan.ElementSize, want))
+	}
+	return DirectStatus()
+}
+
+func checkedMul3(a, b, c int) (int, bool) {
+	if a < 0 || b < 0 || c < 0 {
+		return 0, false
+	}
+	maxInt := int(^uint(0) >> 1)
+	if b != 0 && a > maxInt/b {
+		return 0, false
+	}
+	ab := a * b
+	if c != 0 && ab > maxInt/c {
+		return 0, false
+	}
+	return ab * c, true
+}
+
+// ResourceViewOptions controls handle-level direct-view validation.
+type ResourceViewOptions struct {
+	ExpectedElements int
+	RequireMapped    bool
+}
+
+func Int64View(mgr *mappedresource.Manager, h *mappedresource.Handle, opts ResourceViewOptions) ([]int64, Status) {
+	status := validateHandle(h, mappedresource.SourceMapped, opts.RequireMapped)
+	if !status.Direct() {
+		return nil, status
+	}
+	var view []int64
+	var err error
+	if mgr != nil {
+		view, err = mgr.Int64View(h)
+	} else {
+		view, err = mappedresource.Int64View(h.Bytes())
+	}
+	return validateViewLen(view, opts.ExpectedElements, err)
+}
+
+func Float32View(mgr *mappedresource.Manager, h *mappedresource.Handle, opts ResourceViewOptions) ([]float32, Status) {
+	status := validateHandle(h, mappedresource.SourceMapped, opts.RequireMapped)
+	if !status.Direct() {
+		return nil, status
+	}
+	var view []float32
+	var err error
+	if mgr != nil {
+		view, err = mgr.Float32View(h)
+	} else {
+		view, err = mappedresource.Float32View(h.Bytes())
+	}
+	return validateViewLen(view, opts.ExpectedElements, err)
+}
+
+func Float64View(mgr *mappedresource.Manager, h *mappedresource.Handle, opts ResourceViewOptions) ([]float64, Status) {
+	status := validateHandle(h, mappedresource.SourceMapped, opts.RequireMapped)
+	if !status.Direct() {
+		return nil, status
+	}
+	var view []float64
+	var err error
+	if mgr != nil {
+		view, err = mgr.Float64View(h)
+	} else {
+		view, err = mappedresource.Float64View(h.Bytes())
+	}
+	return validateViewLen(view, opts.ExpectedElements, err)
+}
+
+func Uint32View(mgr *mappedresource.Manager, h *mappedresource.Handle, opts ResourceViewOptions) ([]uint32, Status) {
+	status := validateHandle(h, mappedresource.SourceMapped, opts.RequireMapped)
+	if !status.Direct() {
+		return nil, status
+	}
+	var view []uint32
+	var err error
+	if mgr != nil {
+		view, err = mgr.Uint32View(h)
+	} else {
+		view, err = mappedresource.Uint32View(h.Bytes())
+	}
+	return validateViewLen(view, opts.ExpectedElements, err)
+}
+
+func validateHandle(h *mappedresource.Handle, required mappedresource.Source, requireSource bool) Status {
+	if h == nil {
+		return StreamingStatus(ReasonNilHandle, "nil mappedresource handle")
+	}
+	if h.Released() {
+		return UnsupportedStatus(ReasonStaleHandle, "mappedresource handle is released")
+	}
+	if requireSource && h.Source() != required {
+		return StreamingStatus(ReasonHandleSourceUnsupported, fmt.Sprintf("source=%s want %s", h.Source(), required))
+	}
+	return DirectStatus()
+}
+
+func validateViewLen[T any](view []T, expected int, err error) ([]T, Status) {
+	if err != nil {
+		return nil, classifyViewError(err)
+	}
+	if expected >= 0 && len(view) != expected {
+		return nil, UnsupportedStatus(ReasonRowCountMismatch, fmt.Sprintf("view elements=%d want %d", len(view), expected))
+	}
+	return view, DirectStatus()
+}
+
+func classifyViewError(err error) Status {
+	msg := err.Error()
+	lower := strings.ToLower(msg)
+	switch {
+	case strings.Contains(lower, "nil handle"):
+		return StreamingStatus(ReasonNilHandle, msg)
+	case strings.Contains(lower, "released"):
+		return UnsupportedStatus(ReasonStaleHandle, msg)
+	case strings.Contains(lower, "aligned"):
+		return StreamingStatus(ReasonUnaligned, msg)
+	case strings.Contains(lower, "little-endian"):
+		return StreamingStatus(ReasonWrongEndian, msg)
+	case strings.Contains(lower, "multiple"):
+		return UnsupportedStatus(ReasonLengthMultipleMismatch, msg)
+	default:
+		return UnsupportedStatus(ReasonValidationFailed, msg)
+	}
+}

--- a/TreeDB/internal/typeddecode/plan.go
+++ b/TreeDB/internal/typeddecode/plan.go
@@ -6,10 +6,11 @@
 package typeddecode
 
 import (
+	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/snissn/gomap/TreeDB/internal/columnlayout"
+	"github.com/snissn/gomap/TreeDB/internal/columnsemantics"
 	"github.com/snissn/gomap/TreeDB/internal/mappedresource"
 	"github.com/snissn/gomap/TreeDB/internal/typedcolumn"
 )
@@ -227,7 +228,7 @@ func statusFromLayoutCapability(cap columnlayout.Capability) Status {
 	case columnlayout.ReasonOperationUnsupported:
 		reason = ReasonUnsupportedOperation
 	}
-	if string(cap.Status) == "fallback" {
+	if cap.Status == columnsemantics.StatusFallback {
 		return StreamingStatus(reason, cap.Error())
 	}
 	return UnsupportedStatus(reason, cap.Error())
@@ -275,7 +276,7 @@ func ValidateDirectViewBlock(req DirectViewBlockRequest) Status {
 		return UnsupportedStatus(ReasonPayloadLengthMismatch, "fixed-width byte count overflow")
 	}
 	if block.PayloadLength != want || block.RawBytes != want || block.StoredBytes != want {
-		return UnsupportedStatus(ReasonRowCountMismatch, fmt.Sprintf("payload/raw/stored=(%d,%d,%d) want rows=%d*elements=%d*width=%d=%d", block.PayloadLength, block.RawBytes, block.StoredBytes, req.Rows, elementsPerRow, req.Plan.ElementSize, want))
+		return UnsupportedStatus(ReasonPayloadLengthMismatch, fmt.Sprintf("payload/raw/stored=(%d,%d,%d) want rows=%d*elements=%d*width=%d=%d", block.PayloadLength, block.RawBytes, block.StoredBytes, req.Rows, elementsPerRow, req.Plan.ElementSize, want))
 	}
 	return DirectStatus()
 }
@@ -386,17 +387,16 @@ func validateViewLen[T any](view []T, expected int, err error) ([]T, Status) {
 
 func classifyViewError(err error) Status {
 	msg := err.Error()
-	lower := strings.ToLower(msg)
 	switch {
-	case strings.Contains(lower, "nil handle"):
+	case errors.Is(err, mappedresource.ErrDirectViewNilHandle):
 		return StreamingStatus(ReasonNilHandle, msg)
-	case strings.Contains(lower, "released"):
+	case errors.Is(err, mappedresource.ErrDirectViewReleasedHandle):
 		return UnsupportedStatus(ReasonStaleHandle, msg)
-	case strings.Contains(lower, "aligned"):
+	case errors.Is(err, mappedresource.ErrDirectViewUnaligned):
 		return StreamingStatus(ReasonUnaligned, msg)
-	case strings.Contains(lower, "little-endian"):
+	case errors.Is(err, mappedresource.ErrDirectViewWrongEndian):
 		return StreamingStatus(ReasonWrongEndian, msg)
-	case strings.Contains(lower, "multiple"):
+	case errors.Is(err, mappedresource.ErrDirectViewLengthMultiple):
 		return UnsupportedStatus(ReasonLengthMultipleMismatch, msg)
 	default:
 		return UnsupportedStatus(ReasonValidationFailed, msg)

--- a/TreeDB/internal/typeddecode/plan.go
+++ b/TreeDB/internal/typeddecode/plan.go
@@ -76,7 +76,7 @@ func (s Status) Direct() bool {
 func (s Status) Streaming() bool   { return s.Path == PathStreaming }
 func (s Status) Unsupported() bool { return s.Path == PathUnsupported }
 
-func (s Status) Error() string {
+func (s Status) String() string {
 	if s.Err != nil {
 		return s.Err.Error()
 	}

--- a/TreeDB/internal/typeddecode/plan_test.go
+++ b/TreeDB/internal/typeddecode/plan_test.go
@@ -65,6 +65,11 @@ func TestDirectViewValidationFailsClosedForLengthRowEndianAndNullable(t *testing
 	if status := ValidateDirectViewBlock(DirectViewBlockRequest{Plan: plan, Certification: cert, Block: wrongRows, Rows: 2, PayloadBytes: 16}); status.Reason != ReasonRowCountMismatch {
 		t.Fatalf("row status=%+v want %s", status, ReasonRowCountMismatch)
 	}
+	wrongBytes := cert.Blocks[0]
+	wrongBytes.StoredBytes = 8
+	if status := ValidateDirectViewBlock(DirectViewBlockRequest{Plan: plan, Certification: cert, Block: wrongBytes, Rows: 2, PayloadBytes: 16}); status.Reason != ReasonPayloadLengthMismatch {
+		t.Fatalf("byte contract status=%+v want %s", status, ReasonPayloadLengthMismatch)
+	}
 
 	wrongEndian := cert
 	wrongEndian.Endian = typedcolumn.ColumnPartLayoutEndianCodecDefined
@@ -83,6 +88,25 @@ func TestDirectViewValidationFailsClosedForLengthRowEndianAndNullable(t *testing
 	compressed.Compression = typedcolumn.CompressionSnappy
 	if status := ValidateDirectViewBlock(DirectViewBlockRequest{Plan: plan, Certification: compressed, Block: cert.Blocks[0], Rows: 2, PayloadBytes: 16}); status.Reason != ReasonCompressed {
 		t.Fatalf("compressed status=%+v want %s", status, ReasonCompressed)
+	}
+}
+
+func TestStatusFromLayoutCapabilityUsesTypedStatus(t *testing.T) {
+	stream := statusFromLayoutCapability(columnlayout.Capability{
+		Status:  columnsemantics.StatusFallback,
+		Reason:  columnlayout.ReasonVariableWidthNoDirectView,
+		Message: "no direct view",
+	})
+	if !stream.Streaming() || stream.Reason != ReasonVariableWidth {
+		t.Fatalf("stream status=%+v", stream)
+	}
+	unsupported := statusFromLayoutCapability(columnlayout.Capability{
+		Status:  columnsemantics.StatusUnsupported,
+		Reason:  columnlayout.ReasonVariableWidthNoDirectView,
+		Message: "no direct view",
+	})
+	if !unsupported.Unsupported() || unsupported.Reason != ReasonVariableWidth {
+		t.Fatalf("unsupported status=%+v", unsupported)
 	}
 }
 

--- a/TreeDB/internal/typeddecode/plan_test.go
+++ b/TreeDB/internal/typeddecode/plan_test.go
@@ -91,6 +91,15 @@ func TestDirectViewValidationFailsClosedForLengthRowEndianAndNullable(t *testing
 	}
 }
 
+func TestStatusDoesNotImplementError(t *testing.T) {
+	if _, ok := any(DirectStatus()).(error); ok {
+		t.Fatal("Status must not implement error; successful statuses would become non-nil errors")
+	}
+	if got := UnsupportedStatus(ReasonUnsupportedOperation, "nope").String(); got == "" {
+		t.Fatal("Status.String returned empty diagnostic")
+	}
+}
+
 func TestStatusFromLayoutCapabilityUsesTypedStatus(t *testing.T) {
 	stream := statusFromLayoutCapability(columnlayout.Capability{
 		Status:  columnsemantics.StatusFallback,

--- a/TreeDB/internal/typeddecode/plan_test.go
+++ b/TreeDB/internal/typeddecode/plan_test.go
@@ -1,0 +1,166 @@
+package typeddecode
+
+import (
+	"encoding/binary"
+	"testing"
+	"unsafe"
+
+	"github.com/snissn/gomap/TreeDB/internal/columnlayout"
+	"github.com/snissn/gomap/TreeDB/internal/columnsemantics"
+	"github.com/snissn/gomap/TreeDB/internal/mappedresource"
+	"github.com/snissn/gomap/TreeDB/internal/typedcolumn"
+)
+
+func TestInt64DirectViewPlanAndHandleValidation(t *testing.T) {
+	rows := 3
+	caps := columnlayout.CapabilitiesFor(columnlayout.Descriptor{Logical: columnsemantics.LogicalInt64, Physical: typedcolumn.ColumnTypeInt64, Encoding: typedcolumn.EncodingRawInt64, Compression: typedcolumn.CompressionNone})
+	cert := testInt64DirectCert(rows)
+	plan := Int64ReducerPlan(caps, cert)
+	if !plan.DirectCandidate() {
+		t.Fatalf("plan=%+v want direct candidate", plan)
+	}
+	blockStatus := ValidateDirectViewBlock(DirectViewBlockRequest{Plan: plan, Certification: cert, Block: cert.Blocks[0], Rows: rows, PayloadBytes: rows * 8})
+	if !blockStatus.Direct() {
+		t.Fatalf("block status=%+v want direct", blockStatus)
+	}
+
+	raw := alignedBytes(8, rows*8)
+	for i := 0; i < rows; i++ {
+		binary.LittleEndian.PutUint64(raw[i*8:], uint64(i+10))
+	}
+	mgr := mappedresource.NewManager()
+	h, err := mgr.AcquireBytes(testKey(int64(len(raw))), testScope(), mappedresource.SourceMapped, raw, mappedresource.AcquireOptions{Reason: "typeddecode test"})
+	if err != nil {
+		t.Fatalf("AcquireBytes: %v", err)
+	}
+	view, viewStatus := Int64View(mgr, h, ResourceViewOptions{ExpectedElements: rows, RequireMapped: true})
+	if !viewStatus.Direct() {
+		t.Fatalf("view status=%+v want direct", viewStatus)
+	}
+	if len(view) != rows || view[0] != 10 || view[2] != 12 {
+		t.Fatalf("view=%v", view)
+	}
+	if err := h.Release(); err != nil {
+		t.Fatalf("Release: %v", err)
+	}
+	if stats := mgr.Stats(); stats.DirectViewSuccesses != 1 || stats.DirectViewFailures != 0 {
+		t.Fatalf("stats=%+v want one direct-view success", stats)
+	}
+}
+
+func TestDirectViewValidationFailsClosedForLengthRowEndianAndNullable(t *testing.T) {
+	cert := testInt64DirectCert(2)
+	plan := Plan{Path: PathDirectView, Reason: ReasonSupported, ElementSize: 8, ElementsPerRow: 1, Alignment: 8, Rows: 2}
+
+	truncated := cert.Blocks[0]
+	truncated.PayloadLength = 15
+	truncated.RawBytes = 15
+	truncated.StoredBytes = 15
+	if status := ValidateDirectViewBlock(DirectViewBlockRequest{Plan: plan, Certification: cert, Block: truncated, Rows: 2, PayloadBytes: 15}); status.Reason != ReasonLengthMultipleMismatch {
+		t.Fatalf("truncated status=%+v want %s", status, ReasonLengthMultipleMismatch)
+	}
+
+	wrongRows := cert.Blocks[0]
+	wrongRows.RowCount = 3
+	if status := ValidateDirectViewBlock(DirectViewBlockRequest{Plan: plan, Certification: cert, Block: wrongRows, Rows: 2, PayloadBytes: 16}); status.Reason != ReasonRowCountMismatch {
+		t.Fatalf("row status=%+v want %s", status, ReasonRowCountMismatch)
+	}
+
+	wrongEndian := cert
+	wrongEndian.Endian = typedcolumn.ColumnPartLayoutEndianCodecDefined
+	if status := ValidateDirectViewBlock(DirectViewBlockRequest{Plan: plan, Certification: wrongEndian, Block: cert.Blocks[0], Rows: 2, PayloadBytes: 16}); status.Reason != ReasonWrongEndian {
+		t.Fatalf("endian status=%+v want %s", status, ReasonWrongEndian)
+	}
+
+	nullable := cert
+	nullable.NullMaskPresent = true
+	nullable.NullCount = 1
+	if status := ValidateDirectViewBlock(DirectViewBlockRequest{Plan: plan, Certification: nullable, Block: cert.Blocks[0], Rows: 2, PayloadBytes: 16}); status.Reason != ReasonNullableWrapper {
+		t.Fatalf("nullable status=%+v want %s", status, ReasonNullableWrapper)
+	}
+
+	compressed := cert
+	compressed.Compression = typedcolumn.CompressionSnappy
+	if status := ValidateDirectViewBlock(DirectViewBlockRequest{Plan: plan, Certification: compressed, Block: cert.Blocks[0], Rows: 2, PayloadBytes: 16}); status.Reason != ReasonCompressed {
+		t.Fatalf("compressed status=%+v want %s", status, ReasonCompressed)
+	}
+}
+
+func TestDirectViewHandleRejectsUnalignedHeapAndStale(t *testing.T) {
+	raw := alignedBytes(8, 17)
+	misaligned := raw[1:17]
+	mgr := mappedresource.NewManager()
+	h, err := mgr.AcquireBytes(testKey(int64(len(misaligned))), testScope(), mappedresource.SourceMapped, misaligned, mappedresource.AcquireOptions{Reason: "typeddecode unaligned"})
+	if err != nil {
+		t.Fatalf("AcquireBytes mapped: %v", err)
+	}
+	if _, status := Int64View(mgr, h, ResourceViewOptions{ExpectedElements: 2, RequireMapped: true}); status.Reason != ReasonUnaligned {
+		t.Fatalf("unaligned status=%+v want %s", status, ReasonUnaligned)
+	}
+	_ = h.Release()
+	if _, status := Int64View(mgr, h, ResourceViewOptions{ExpectedElements: 2, RequireMapped: true}); status.Reason != ReasonStaleHandle {
+		t.Fatalf("stale status=%+v want %s", status, ReasonStaleHandle)
+	}
+
+	heapRaw := alignedBytes(8, 16)
+	heap, err := mgr.AcquireBytes(testKeyWithPart(2, int64(len(heapRaw))), testScope(), mappedresource.SourceHeapCopy, heapRaw, mappedresource.AcquireOptions{Reason: "typeddecode heap"})
+	if err != nil {
+		t.Fatalf("AcquireBytes heap: %v", err)
+	}
+	defer func() { _ = heap.Release() }()
+	if _, status := Int64View(mgr, heap, ResourceViewOptions{ExpectedElements: 2, RequireMapped: true}); status.Reason != ReasonHandleSourceUnsupported {
+		t.Fatalf("heap status=%+v want %s", status, ReasonHandleSourceUnsupported)
+	}
+}
+
+func TestInt64DeltaPlanUsesStreamingNotDirectView(t *testing.T) {
+	caps := columnlayout.CapabilitiesFor(columnlayout.Descriptor{Logical: columnsemantics.LogicalInt64, Physical: typedcolumn.ColumnTypeInt64, Encoding: typedcolumn.EncodingDeltaVarint, Compression: typedcolumn.CompressionNone})
+	cert := typedcolumn.ColumnPartLayoutContractColumn{Name: "v", LogicalType: "int64", Type: typedcolumn.ColumnTypeInt64, Encoding: typedcolumn.EncodingDeltaVarint, Compression: typedcolumn.CompressionNone, Rows: 4, Endian: typedcolumn.ColumnPartLayoutEndianCodecDefined, StreamingCertified: true}
+	plan := Int64ReducerPlan(caps, cert)
+	if plan.Path != PathStreaming || plan.Reason != ReasonVariableWidth {
+		t.Fatalf("plan=%+v want variable-width streaming", plan)
+	}
+}
+
+func TestDenseDirectViewBlockValidatesDimensionsAndLength(t *testing.T) {
+	cert := typedcolumn.ColumnPartLayoutContractColumn{
+		Name: "vec", LogicalType: "float32_vector", Type: typedcolumn.ColumnTypeFloat32Vector, Encoding: typedcolumn.EncodingRawFloat32Vector, Compression: typedcolumn.CompressionNone,
+		Rows: 2, FixedWidthElements: 4, ElementSize: 4, Alignment: 4, Endian: typedcolumn.ColumnPartLayoutEndianLittle, LengthMultiple: 4, DirectViewCertified: true,
+	}
+	cert.Blocks = []typedcolumn.ColumnPartLayoutContractBlock{{RowCount: 2, Encoding: cert.Encoding, Compression: cert.Compression, RawBytes: 32, StoredBytes: 32, PayloadLength: 32}}
+	plan := Plan{Path: PathDirectView, Reason: ReasonSupported, ElementSize: 4, ElementsPerRow: 4, Alignment: 4, Rows: 2}
+	if status := ValidateDirectViewBlock(DirectViewBlockRequest{Plan: plan, Certification: cert, Block: cert.Blocks[0], Rows: 2, PayloadBytes: 32}); !status.Direct() {
+		t.Fatalf("dense status=%+v want direct", status)
+	}
+	wrongDims := plan
+	wrongDims.ElementsPerRow = 3
+	if status := ValidateDirectViewBlock(DirectViewBlockRequest{Plan: wrongDims, Certification: cert, Block: cert.Blocks[0], Rows: 2, PayloadBytes: 32}); status.Reason != ReasonDimensionMismatch {
+		t.Fatalf("dimension status=%+v want %s", status, ReasonDimensionMismatch)
+	}
+}
+
+func testInt64DirectCert(rows int) typedcolumn.ColumnPartLayoutContractColumn {
+	bytes := rows * 8
+	return typedcolumn.ColumnPartLayoutContractColumn{
+		Name: "v", LogicalType: "int64", Type: typedcolumn.ColumnTypeInt64, Encoding: typedcolumn.EncodingRawInt64, Compression: typedcolumn.CompressionNone,
+		Rows: rows, ElementSize: 8, Alignment: 8, Endian: typedcolumn.ColumnPartLayoutEndianLittle, LengthMultiple: 8, DirectViewCertified: true,
+		Blocks: []typedcolumn.ColumnPartLayoutContractBlock{{RowCount: rows, Encoding: typedcolumn.EncodingRawInt64, Compression: typedcolumn.CompressionNone, RawBytes: bytes, StoredBytes: bytes, PayloadLength: bytes}},
+	}
+}
+
+func alignedBytes(align int, n int) []byte {
+	buf := make([]byte, n+align)
+	addr := uintptr(unsafe.Pointer(&buf[0]))
+	off := int((uintptr(align) - addr%uintptr(align)) % uintptr(align))
+	return buf[off : off+n]
+}
+
+func testKey(length int64) mappedresource.Key { return testKeyWithPart(1, length) }
+
+func testKeyWithPart(partID uint64, length int64) mappedresource.Key {
+	return mappedresource.Key{Class: mappedresource.ClassTypedColumnAsset, Namespace: "typeddecode-test", Kind: "section", Generation: 1, PartID: partID, FileID: 1, Length: length}
+}
+
+func testScope() mappedresource.Scope {
+	return mappedresource.Scope{Kind: mappedresource.ScopePreparedQuery, ID: "typeddecode-test", Namespace: "typeddecode-test"}
+}


### PR DESCRIPTION
## Summary
- add `TreeDB/internal/typeddecode`, a shared fast-decode/direct-view planning layer with explicit `direct_view`, `streaming`, `materialize`, and `unsupported` statuses plus stable fallback reasons/counters; statuses format diagnostics without implementing `error`
- add mappedresource-backed typed direct-view helpers with sentinel errors, and integrate prepared int64 aggregates so raw fixed-width int64 can scan through pinned zero-copy views while delta/double-delta stream without decode scratch
- add `GranuleReader.Int64Cursor` plus `CountSumInt64` for full-block streaming reducers without materializing `[]int64`, preserving existing delta/double-delta wraparound decode semantics while still fail-closing on aggregate sum overflow
- place direct-view-eligible fixed-width typed-column parts in deterministic generation-specific segment files at offset 0, reserve that segment-id band from both scanned and cached generic allocators, and cover reachability/GC accounting expectations without synthetic padding
- extend diagnostics, tests, and benchmarks for direct-view success/failure, platform heap fallback on non-mmap or non-little-endian targets, streaming fallback reasons, close/lifetime behavior, certification failures, direct-view segment allocation, and typed-column cursor behavior

Closes #1849

## Tests
Latest local validation on head `9ed7f55fe`:
- `go test ./TreeDB/internal/mappedresource ./TreeDB/internal/columnlayout ./TreeDB/internal/typedcolumn ./TreeDB/internal/typeddecode ./TreeDB/collections -count=1`
- `go test ./TreeDB/internal/typeddecode ./TreeDB/internal/mappedresource ./TreeDB/internal/typedcolumn ./TreeDB/collections -count=1`
- `go test ./TreeDB/internal/typedcolumn ./TreeDB/internal/typeddecode ./TreeDB/collections -count=1`
- `go test ./TreeDB/collections -run 'TestTypedStorageLegacyNameAllowlistIsComplete|TestColumnAssetSegmentAllocationSkipsDirectViewReservedBandM1849|TestTypedColumnInt64RawLayoutRoundTripReopenQuery' -count=1`
- `go test ./TreeDB/caching -run 'TestCheckpoint_KicksVlogGenerationRewriteDespiteRecentForegroundActivity' -count=1`
- `go test ./TreeDB/... -count=1`

## Benchmarks / Diagnostics
Latest local benchmark context: Apple M3 / darwin arm64 / head `9ed7f55fe`.

`go test ./TreeDB/internal/typedcolumn -run '^$' -bench 'BenchmarkGranuleReaderInt64DeltaCursorVsDecode' -benchmem -benchtime=100x -count=1`

| case | ns/op | B/op | allocs/op |
| --- | ---: | ---: | ---: |
| streaming_cursor | 15,128 | 0 | 0 |
| streaming_count_sum | 24,353 | 0 | 0 |
| decode_into_scratch | 14,500 | 0 | 0 |

`TREEDB_TYPED_COLUMN_BENCH_ROWS=4096 TREEDB_TYPED_COLUMN_BENCH_SHAPES=range_1pct TREEDB_TYPED_COLUMN_BENCH_LAYOUTS=all TREEDB_TYPED_COLUMN_BENCH_INCLUDE_FALLBACK=true TREEDB_TYPED_COLUMN_BENCH_DISTS=clustered_monotonic go test ./TreeDB/collections -run '^$' -bench 'BenchmarkTypedColumnInt64PredicateAggregate' -benchmem -benchtime=20x -count=1`

| path / timing | ns/op | ops/sec | rows/sec | B/op | allocs/op | key diagnostics |
| --- | ---: | ---: | ---: | ---: | ---: | --- |
| delta/default prepared hot scan | 34,212 | 29,229 | 119,722,324 | 512 | 4 | `fast_decode_streaming_plans=1`, variable-width fallback reason, `decoded_bytes=0` |
| raw fixed-width prepared hot scan | 6,802 | 147,015 | 602,171,404 | 512 | 4 | `fast_decode_direct_view_plans=1`, `direct_view_successes=1`, `decoded_bytes=0`, `mapped_bytes=32768` |
| document fallback serial | 2,950,212 | 339.0 | 1,388,375 | 6,599,369 | 81,915 | full document materialization baseline |

## Review / CI
- Latest-head CI for `9ed7f55fe` is green (all required/check-rollup jobs passing; merge state clean).
- Orca xhigh reviewer re-reviewed manager implementation and reported no blocking findings.
- Copilot review findings were fixed or explicitly resolved; all review threads are resolved.
- CodeRabbit actionable findings were fixed; all review threads are resolved.
- Codex review reported no major issues on an earlier head; re-requested after subsequent pushes.
