### PR TITLE
TreeDB typed-column kernel dispatch and int64 reducers

### DIFF
--- a/TreeDB/collections/typed_column_adapter.go
+++ b/TreeDB/collections/typed_column_adapter.go
@@ -11,6 +11,7 @@ import (
 	"github.com/snissn/gomap/TreeDB/internal/columnsemantics"
 	"github.com/snissn/gomap/TreeDB/internal/mappedresource"
 	"github.com/snissn/gomap/TreeDB/internal/typedcolumn"
+	"github.com/snissn/gomap/TreeDB/internal/typedkernel"
 )
 
 var errTypedColumnAdapterUnsupportedType = errors.New("collections: typed-column adapter unsupported type")
@@ -1775,6 +1776,7 @@ type typedColumnInt64PredicateAggregateScanScratch struct {
 	predicateBitmap []uint64
 	visibilityRows  []int
 	selection       typedcolumn.RowSelectionScratch
+	kernel          typedkernel.Scratch
 }
 
 func scanTypedColumnInt64PredicateAggregatePartWithVisibilityAndScratch(part *typedcolumn.ColumnPart, valueColumn string, req TypedColumnInt64PredicateScanRequest, result *TypedColumnInt64PredicateAggregateResult, visibility *typedColumnLatestPhysicalPart, scratch *typedColumnInt64PredicateAggregateScanScratch) (bool, error) {

--- a/TreeDB/collections/typed_column_int64_scan.go
+++ b/TreeDB/collections/typed_column_int64_scan.go
@@ -90,6 +90,11 @@ type TypedColumnInt64PredicateScanDiagnostics struct {
 	FastDecodeUnsupportedPlans  int
 	DirectViewSuccesses         int
 	DirectViewFailures          int
+	KernelBlocks                int
+	KernelFullCoveredBlocks     int
+	KernelSelectedBlocks        int
+	KernelCursorBlocks          int
+	KernelFallbackBlocks        int
 	FastDecodeFallbackReason    string
 	DirectViewCertified         int
 	StreamingCertified          int
@@ -950,6 +955,11 @@ func addTypedColumnInt64PredicateAggregateDiagnostics(dst *TypedColumnInt64Predi
 	dst.FastDecodeUnsupportedPlans += src.FastDecodeUnsupportedPlans
 	dst.DirectViewSuccesses += src.DirectViewSuccesses
 	dst.DirectViewFailures += src.DirectViewFailures
+	dst.KernelBlocks += src.KernelBlocks
+	dst.KernelFullCoveredBlocks += src.KernelFullCoveredBlocks
+	dst.KernelSelectedBlocks += src.KernelSelectedBlocks
+	dst.KernelCursorBlocks += src.KernelCursorBlocks
+	dst.KernelFallbackBlocks += src.KernelFallbackBlocks
 	if src.FastDecodeFallbackReason != "" {
 		dst.FastDecodeFallbackReason = src.FastDecodeFallbackReason
 	}

--- a/TreeDB/collections/typed_column_int64_scan_test.go
+++ b/TreeDB/collections/typed_column_int64_scan_test.go
@@ -771,8 +771,8 @@ func TestTypedColumnInt64PreparedDeltaKernelDiagnosticsFullPartialPruned(t *test
 		t.Fatalf("Run all: %v", err)
 	}
 	assertTypedColumnInt64Aggregate(t, all, 6, 21)
-	if all.Diagnostics.KernelBlocks == 0 || all.Diagnostics.KernelCursorBlocks == 0 || all.Diagnostics.KernelFullCoveredBlocks == 0 || all.Diagnostics.KernelFallbackBlocks != 0 {
-		t.Fatalf("all diagnostics=%+v want full-covered streaming cursor kernel", all.Diagnostics)
+	if all.Diagnostics.KernelBlocks == 0 || all.Diagnostics.KernelFullCoveredBlocks == 0 || all.Diagnostics.KernelFallbackBlocks != 0 {
+		t.Fatalf("all diagnostics=%+v want full-covered streaming kernel fast path", all.Diagnostics)
 	}
 
 	partialSession, err := col.PrepareTypedColumnInt64PredicateAggregate(TypedColumnInt64PredicateAggregateRequest{Column: "time_us", Kind: TypedColumnInt64PredicateRange, Low: 3, High: 4, ColumnAssetReadIntegrity: ColumnAssetReadIntegrityCachedVerify})
@@ -1515,6 +1515,50 @@ func TestTypedColumnInt64AggregatePreparedSessionSnapshotPinnedAcrossMutation(t 
 		t.Fatalf("new session Run: %v", err)
 	}
 	assertTypedColumnInt64Aggregate(t, fresh, 4, 160)
+}
+
+func TestTypedColumnInt64PreparedSessionCachedVerifyVisibilityUsesKernelPath(t *testing.T) {
+	d, col := setupTypedColumnInt64ScanCollection(t)
+	defer func() { _ = d.Close() }()
+	if _, err := col.InsertBatch([][]byte{[]byte("e1"), []byte("e2"), []byte("e3")}, [][]byte{
+		[]byte(`{"time_us":10,"kind":"k1"}`),
+		[]byte(`{"time_us":20,"kind":"k2"}`),
+		[]byte(`{"time_us":30,"kind":"k3"}`),
+	}); err != nil {
+		t.Fatalf("InsertBatch: %v", err)
+	}
+	if _, changed, err := col.Update([]byte("e1"), func(current []byte) ([]byte, bool, error) {
+		return []byte(`{"time_us":25,"kind":"k1b"}`), true, nil
+	}); err != nil || !changed {
+		t.Fatalf("Update e1 changed=%v err=%v", changed, err)
+	}
+	if _, changed, err := col.Update([]byte("e2"), func(current []byte) ([]byte, bool, error) {
+		return []byte(`{"time_us":40,"kind":"k2b"}`), true, nil
+	}); err != nil || !changed {
+		t.Fatalf("Update e2 changed=%v err=%v", changed, err)
+	}
+	if deleted, err := col.DeleteDocument([]byte("e3")); err != nil || !deleted {
+		t.Fatalf("DeleteDocument e3 deleted=%v err=%v", deleted, err)
+	}
+
+	session, err := col.PrepareTypedColumnInt64PredicateAggregate(TypedColumnInt64PredicateAggregateRequest{Column: "time_us", Kind: TypedColumnInt64PredicateAll, ColumnAssetReadIntegrity: ColumnAssetReadIntegrityCachedVerify})
+	if err != nil {
+		t.Fatalf("PrepareTypedColumnInt64PredicateAggregate: %v", err)
+	}
+	result, err := session.Run()
+	if closeErr := session.Close(); closeErr != nil {
+		t.Fatalf("Close: %v", closeErr)
+	}
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	assertTypedColumnInt64Aggregate(t, result, 2, 65)
+	if result.Diagnostics.MutationParts == 0 || result.Diagnostics.SelectionCompositions == 0 || result.Diagnostics.KernelBlocks == 0 || result.Diagnostics.KernelCursorBlocks == 0 {
+		t.Fatalf("diagnostics=%+v want cached-verify targeted kernel+visibility path", result.Diagnostics)
+	}
+	if result.Diagnostics.FullAssetReads != 0 || result.Diagnostics.SectionBytesRead != 0 || result.Diagnostics.DecodedMetadataBytes != 0 || result.Diagnostics.DecodedHeapCopyBytes != 0 || result.Diagnostics.KernelFallbackBlocks != 0 {
+		t.Fatalf("diagnostics=%+v want hot targeted visibility run without full asset/materialized fallback", result.Diagnostics)
+	}
 }
 
 func TestTypedColumnInt64AggregatePreparedSessionStreamsDeltaWithoutDecodeScratch(t *testing.T) {
@@ -2931,6 +2975,11 @@ func reportTypedColumnInt64AggregateBenchMetrics(b *testing.B, totalRows int, di
 	b.ReportMetric(float64(diag.FastDecodeUnsupportedPlans), "fast_decode_unsupported_plans/op")
 	b.ReportMetric(float64(diag.DirectViewSuccesses), "direct_view_successes/op")
 	b.ReportMetric(float64(diag.DirectViewFailures), "direct_view_failures/op")
+	b.ReportMetric(float64(diag.KernelBlocks), "kernel_blocks/op")
+	b.ReportMetric(float64(diag.KernelFullCoveredBlocks), "kernel_full_covered_blocks/op")
+	b.ReportMetric(float64(diag.KernelSelectedBlocks), "kernel_selected_blocks/op")
+	b.ReportMetric(float64(diag.KernelCursorBlocks), "kernel_cursor_blocks/op")
+	b.ReportMetric(float64(diag.KernelFallbackBlocks), "kernel_fallback_blocks/op")
 	b.ReportMetric(float64(diag.DirectViewCertified), "direct_view_certified/op")
 	b.ReportMetric(float64(diag.StreamingCertified), "streaming_certified/op")
 	b.ReportMetric(float64(diag.CertificationFailures), "certification_failures/op")

--- a/TreeDB/collections/typed_column_int64_scan_test.go
+++ b/TreeDB/collections/typed_column_int64_scan_test.go
@@ -298,6 +298,13 @@ func TestTypedColumnInt64AggregateNullableTypedColumnUnsupportedFailsClosed(t *t
 	if result.Diagnostics.Fallback || result.Diagnostics.RowMaterializations != 0 || result.Diagnostics.FallbackReads != 0 || result.Count != 0 || result.Sum != 0 {
 		t.Fatalf("result=%+v want fail-closed without document fallback/materialization", result)
 	}
+	insertTypedColumnInt64ScanRows(t, col, []int64{0})
+	if session, err := col.PrepareTypedColumnInt64PredicateAggregate(TypedColumnInt64PredicateAggregateRequest{Column: "time_us", Kind: TypedColumnInt64PredicateAll, ColumnAssetReadIntegrity: ColumnAssetReadIntegrityCachedVerify}); err == nil {
+		_ = session.Close()
+		t.Fatalf("PrepareTypedColumnInt64PredicateAggregate nullable err=nil want fail-closed nullable typed-column int64")
+	} else if !errors.Is(err, ErrColumnQueryPlanUnsupported) {
+		t.Fatalf("PrepareTypedColumnInt64PredicateAggregate nullable err=%v want unsupported nullable typed-column int64", err)
+	}
 }
 
 func TestTypedColumnInt64ScanStaleMetadataFailsClosed(t *testing.T) {
@@ -709,6 +716,166 @@ func TestTypedColumnInt64PreparedDeltaUsesStreamingCursor(t *testing.T) {
 	if result.Diagnostics.FastDecodeStreamingPlans == 0 || result.Diagnostics.FastDecodeDirectViewPlans != 0 || result.Diagnostics.DirectViewSuccesses != 0 || result.Diagnostics.DecodedHeapCopyBytes != 0 {
 		t.Fatalf("diagnostics=%+v want delta-varint streaming cursor without direct view or []int64 materialization", result.Diagnostics)
 	}
+}
+
+func TestTypedColumnInt64PreparedKernelOverflowAndNegativeValues(t *testing.T) {
+	d, col := setupTypedColumnInt64ScanCollection(t)
+	defer func() { _ = d.Close() }()
+	insertTypedColumnInt64ScanRows(t, col, []int64{-10, -20, 5})
+	session, err := col.PrepareTypedColumnInt64PredicateAggregate(TypedColumnInt64PredicateAggregateRequest{Column: "time_us", Kind: TypedColumnInt64PredicateAll, ColumnAssetReadIntegrity: ColumnAssetReadIntegrityCachedVerify})
+	if err != nil {
+		t.Fatalf("Prepare negative values: %v", err)
+	}
+	negative, err := session.Run()
+	if closeErr := session.Close(); closeErr != nil {
+		t.Fatalf("Close negative session: %v", closeErr)
+	}
+	if err != nil {
+		t.Fatalf("Run negative values: %v", err)
+	}
+	assertTypedColumnInt64Aggregate(t, negative, 3, -25)
+	if negative.Diagnostics.KernelBlocks == 0 {
+		t.Fatalf("negative diagnostics=%+v want prepared kernel path", negative.Diagnostics)
+	}
+
+	overflowDB, overflowCol := setupTypedColumnInt64ScanCollection(t)
+	defer func() { _ = overflowDB.Close() }()
+	insertTypedColumnInt64ScanRows(t, overflowCol, []int64{typedColumnInt64PredicateAggregateMaxSum, 1})
+	overflowSession, err := overflowCol.PrepareTypedColumnInt64PredicateAggregate(TypedColumnInt64PredicateAggregateRequest{Column: "time_us", Kind: TypedColumnInt64PredicateAll, ColumnAssetReadIntegrity: ColumnAssetReadIntegrityCachedVerify})
+	if err != nil {
+		t.Fatalf("Prepare overflow values: %v", err)
+	}
+	_, err = overflowSession.Run()
+	if closeErr := overflowSession.Close(); closeErr != nil {
+		t.Fatalf("Close overflow session: %v", closeErr)
+	}
+	if err == nil || !strings.Contains(err.Error(), "sum overflow") {
+		t.Fatalf("Run overflow err=%v want sum overflow through prepared kernel path", err)
+	}
+}
+
+func TestTypedColumnInt64PreparedDeltaKernelDiagnosticsFullPartialPruned(t *testing.T) {
+	d, col := setupTypedColumnInt64ScanCollection(t)
+	defer func() { _ = d.Close() }()
+	insertTypedColumnInt64ScanRows(t, col, []int64{1, 2, 3, 4, 5, 6})
+
+	allSession, err := col.PrepareTypedColumnInt64PredicateAggregate(TypedColumnInt64PredicateAggregateRequest{Column: "time_us", Kind: TypedColumnInt64PredicateAll, ColumnAssetReadIntegrity: ColumnAssetReadIntegrityCachedVerify})
+	if err != nil {
+		t.Fatalf("Prepare all: %v", err)
+	}
+	all, err := allSession.Run()
+	if closeErr := allSession.Close(); closeErr != nil {
+		t.Fatalf("Close all: %v", closeErr)
+	}
+	if err != nil {
+		t.Fatalf("Run all: %v", err)
+	}
+	assertTypedColumnInt64Aggregate(t, all, 6, 21)
+	if all.Diagnostics.KernelBlocks == 0 || all.Diagnostics.KernelCursorBlocks == 0 || all.Diagnostics.KernelFullCoveredBlocks == 0 || all.Diagnostics.KernelFallbackBlocks != 0 {
+		t.Fatalf("all diagnostics=%+v want full-covered streaming cursor kernel", all.Diagnostics)
+	}
+
+	partialSession, err := col.PrepareTypedColumnInt64PredicateAggregate(TypedColumnInt64PredicateAggregateRequest{Column: "time_us", Kind: TypedColumnInt64PredicateRange, Low: 3, High: 4, ColumnAssetReadIntegrity: ColumnAssetReadIntegrityCachedVerify})
+	if err != nil {
+		t.Fatalf("Prepare partial: %v", err)
+	}
+	partial, err := partialSession.Run()
+	if closeErr := partialSession.Close(); closeErr != nil {
+		t.Fatalf("Close partial: %v", closeErr)
+	}
+	if err != nil {
+		t.Fatalf("Run partial: %v", err)
+	}
+	assertTypedColumnInt64Aggregate(t, partial, 2, 7)
+	if partial.Diagnostics.KernelFallbackBlocks == 0 || partial.Diagnostics.KernelCursorBlocks != 0 {
+		t.Fatalf("partial diagnostics=%+v want explicit partial streaming fallback classification", partial.Diagnostics)
+	}
+
+	prunedSession, err := col.PrepareTypedColumnInt64PredicateAggregate(TypedColumnInt64PredicateAggregateRequest{Column: "time_us", Kind: TypedColumnInt64PredicateEqual, Value: 99, ColumnAssetReadIntegrity: ColumnAssetReadIntegrityCachedVerify})
+	if err != nil {
+		t.Fatalf("Prepare pruned: %v", err)
+	}
+	pruned, err := prunedSession.Run()
+	if closeErr := prunedSession.Close(); closeErr != nil {
+		t.Fatalf("Close pruned: %v", closeErr)
+	}
+	if err != nil {
+		t.Fatalf("Run pruned: %v", err)
+	}
+	assertTypedColumnInt64Aggregate(t, pruned, 0, 0)
+	if pruned.Diagnostics.BlocksPruned == 0 || pruned.Diagnostics.RangeBytesRead != 0 || pruned.Diagnostics.KernelBlocks != 0 || pruned.Diagnostics.KernelFallbackBlocks != 0 {
+		t.Fatalf("pruned diagnostics=%+v want payload-free prune without kernel/fallback blocks", pruned.Diagnostics)
+	}
+}
+
+func TestTypedColumnInt64PreparedRawKernelSelectionShapes(t *testing.T) {
+	if !typedColumnInt64DirectViewSupportedForTest() {
+		t.Skip("raw selected-value kernel path requires direct-view support")
+	}
+	tests := []struct {
+		name      string
+		values    []int64
+		req       TypedColumnInt64PredicateAggregateRequest
+		wantCount int64
+		wantSum   int64
+		wantShape string
+	}{
+		{name: "all", values: []int64{1, 2, 3, 4}, req: TypedColumnInt64PredicateAggregateRequest{Column: "time_us", Kind: TypedColumnInt64PredicateAll}, wantCount: 4, wantSum: 10, wantShape: "all"},
+		{name: "range", values: []int64{0, 1, 2, 3, 4, 5}, req: TypedColumnInt64PredicateAggregateRequest{Column: "time_us", Kind: TypedColumnInt64PredicateRange, Low: 2, High: 4}, wantCount: 3, wantSum: 9, wantShape: "range"},
+		{name: "sparse_parity", values: repeatedInt64SelectionValuesForTest(40, func(i int) bool { return i%2 == 0 }, 7), req: TypedColumnInt64PredicateAggregateRequest{Column: "time_us", Kind: TypedColumnInt64PredicateEqual, Value: 7}, wantCount: 20, wantSum: 140},
+		{name: "bitmap_parity", values: repeatedInt64SelectionValuesForTest(128, func(i int) bool { return i%4 != 0 }, 7), req: TypedColumnInt64PredicateAggregateRequest{Column: "time_us", Kind: TypedColumnInt64PredicateEqual, Value: 7}, wantCount: 96, wantSum: 672},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			d, col := setupTypedColumnInt64RawScanCollection(t)
+			defer func() { _ = d.Close() }()
+			insertTypedColumnInt64ScanRows(t, col, tc.values)
+			direct, err := col.RunTypedColumnInt64PredicateAggregate(tc.req)
+			if err != nil {
+				t.Fatalf("direct aggregate: %v", err)
+			}
+			assertTypedColumnInt64Aggregate(t, direct, tc.wantCount, tc.wantSum)
+			req := tc.req
+			req.ColumnAssetReadIntegrity = ColumnAssetReadIntegrityCachedVerify
+			session, err := col.PrepareTypedColumnInt64PredicateAggregate(req)
+			if err != nil {
+				t.Fatalf("Prepare: %v", err)
+			}
+			prepared, err := session.Run()
+			if closeErr := session.Close(); closeErr != nil {
+				t.Fatalf("Close: %v", closeErr)
+			}
+			if err != nil {
+				t.Fatalf("prepared Run: %v", err)
+			}
+			assertTypedColumnInt64Aggregate(t, prepared, direct.Count, direct.Sum)
+			if prepared.Diagnostics.KernelBlocks == 0 || prepared.Diagnostics.KernelSelectedBlocks+prepared.Diagnostics.KernelFullCoveredBlocks == 0 || prepared.Diagnostics.KernelFallbackBlocks != 0 {
+				t.Fatalf("prepared diagnostics=%+v want raw direct-view typedkernel reducer", prepared.Diagnostics)
+			}
+			switch tc.wantShape {
+			case "all":
+				if prepared.Diagnostics.SelectionAllBlocks == 0 {
+					t.Fatalf("diagnostics=%+v want all selection", prepared.Diagnostics)
+				}
+			case "range":
+				if prepared.Diagnostics.SelectionRangeBlocks == 0 {
+					t.Fatalf("diagnostics=%+v want range selection", prepared.Diagnostics)
+				}
+			}
+		})
+	}
+}
+
+func repeatedInt64SelectionValuesForTest(rows int, selected func(int) bool, selectedValue int64) []int64 {
+	values := make([]int64, rows)
+	for i := range values {
+		if selected(i) {
+			values[i] = selectedValue
+		} else {
+			values[i] = selectedValue + 1
+		}
+	}
+	return values
 }
 
 func TestTypedColumnInt64PreparedLayoutContractCorruptionFailsClosed(t *testing.T) {

--- a/TreeDB/collections/typed_column_prepared_int64.go
+++ b/TreeDB/collections/typed_column_prepared_int64.go
@@ -434,6 +434,21 @@ func addTypedColumnInt64AggregateStreamingValues(result *TypedColumnInt64Predica
 	}
 	result.Diagnostics.RowsScanned += rows
 	selection := block.CandidateSelection
+	if selection.IsAll() && !block.NeedsPredicate && visibility == nil {
+		count, sum, err := scratch.reader.CountSumInt64(granule)
+		if err != nil {
+			return err
+		}
+		if count != rows {
+			return fmt.Errorf("typed-column int64 streaming count=%d want rows=%d", count, rows)
+		}
+		if err := addTypedColumnInt64AggregateKernelResult(result, typedkernel.AggregateResult{Op: reducer.Operation(), NonNulls: int64(count), Sum: sum, HasValue: true}); err != nil {
+			return err
+		}
+		recordTypedColumnSelectionDiagnostics(&result.Diagnostics, selection)
+		recordTypedColumnInt64KernelBlock(&result.Diagnostics, true, false)
+		return nil
+	}
 	if selection.IsAll() && !block.NeedsPredicate {
 		if visibility != nil {
 			visibilitySelection, err := typedColumnInt64VisibilitySelectionForBlock(visibility, block.Descriptor.FirstRow, block.Descriptor.RowCount, scratch)

--- a/TreeDB/collections/typed_column_prepared_int64.go
+++ b/TreeDB/collections/typed_column_prepared_int64.go
@@ -11,6 +11,7 @@ import (
 	"github.com/snissn/gomap/TreeDB/internal/mappedresource"
 	"github.com/snissn/gomap/TreeDB/internal/typedcolumn"
 	"github.com/snissn/gomap/TreeDB/internal/typeddecode"
+	"github.com/snissn/gomap/TreeDB/internal/typedkernel"
 )
 
 func (s *TypedColumnInt64PredicateAggregateSession) validatePreparedInt64AggregateColumn() error {
@@ -151,7 +152,32 @@ func validateTypedColumnPreparedInt64AggregatePart(part *typedColumnPreparedPart
 	if preparedColumn.Plan.Layout.Reducers.Int64Streaming && !preparedColumn.Certification.StreamingCertified {
 		return fmt.Errorf("collections: typed-column int64 aggregate prepared column %q lacks certified streaming contract", adapterColumn.Definition.Name)
 	}
+	reducer, err := typedColumnPreparedInt64AggregateReducer(preparedColumn)
+	if err != nil {
+		return err
+	}
+	preparedColumn.AggregateReducer = reducer
+	preparedColumn.AggregateReducerReady = true
 	return nil
+}
+
+func typedColumnPreparedInt64AggregateReducer(preparedColumn *typedColumnPreparedColumnState) (typedkernel.PreparedReducer, error) {
+	if preparedColumn == nil {
+		return typedkernel.PreparedReducer{}, errors.New("collections: typed-column int64 aggregate prepared reducer missing column state")
+	}
+	desc := columnsemantics.Descriptor{
+		Logical:             preparedColumn.Plan.Logical,
+		Physical:            preparedColumn.Plan.Definition.Type,
+		Encoding:            preparedColumn.Plan.Definition.Encoding,
+		Nullable:            preparedColumn.Plan.Field.Nullable,
+		DictionaryOrder:     preparedColumn.Plan.Layout.Descriptor.DictionaryOrder,
+		DictionaryCollation: preparedColumn.Plan.Layout.Descriptor.DictionaryCollation,
+	}
+	reducer, err := typedkernel.DefaultRegistry().Dispatch(typedkernel.DispatchRequest{Operation: columnsemantics.OpSum, Semantic: desc, Layout: preparedColumn.Plan.Layout})
+	if err != nil {
+		return typedkernel.PreparedReducer{}, fmt.Errorf("collections: typed-column int64 aggregate prepared column %q kernel dispatch: %w", preparedColumn.Plan.Definition.Name, err)
+	}
+	return reducer, nil
 }
 
 func (s *TypedColumnInt64PredicateAggregateSession) scanPreparedAggregateStatePart(typedRef columnManifestAssetRefForScan, physical columnManifestAssetRefForScan, preparedPart *typedColumnPreparedPartState, result *TypedColumnInt64PredicateAggregateResult, updateCacheDeltas func()) error {
@@ -289,6 +315,63 @@ func addTypedColumnInt64AggregateSelectedRawValues(result *TypedColumnInt64Predi
 	}
 }
 
+func addTypedColumnInt64AggregateKernelResult(result *TypedColumnInt64PredicateAggregateResult, out typedkernel.AggregateResult) error {
+	if result == nil {
+		return errors.New("collections: nil typed-column int64 aggregate result")
+	}
+	if out.NonNulls < 0 || out.NonNulls > int64(maxCollectionInt) {
+		return fmt.Errorf("collections: typed-column int64 predicate aggregate invalid kernel count=%d", out.NonNulls)
+	}
+	if out.Sum > 0 && result.Sum > typedColumnInt64PredicateAggregateMaxSum-out.Sum {
+		return fmt.Errorf("collections: typed-column int64 predicate aggregate sum overflow current=%d value=%d", result.Sum, out.Sum)
+	}
+	if out.Sum < 0 && result.Sum < typedColumnInt64PredicateAggregateMinSum-out.Sum {
+		return fmt.Errorf("collections: typed-column int64 predicate aggregate sum overflow current=%d value=%d", result.Sum, out.Sum)
+	}
+	result.Count += out.NonNulls
+	result.Sum += out.Sum
+	result.Diagnostics.RowsMatched += int(out.NonNulls)
+	return nil
+}
+
+func addTypedColumnInt64AggregateKernelValues(result *TypedColumnInt64PredicateAggregateResult, reducer typedkernel.PreparedReducer, values []int64, selection typedcolumn.RowSelection, scratch *typedkernel.Scratch) error {
+	out, err := reducer.Reduce(typedkernel.ReduceRequest{Rows: len(values), Selection: selection, Int64Values: values}, scratch)
+	if err != nil {
+		return err
+	}
+	return addTypedColumnInt64AggregateKernelResult(result, out)
+}
+
+func addTypedColumnInt64AggregateKernelCursor(result *TypedColumnInt64PredicateAggregateResult, reducer typedkernel.PreparedReducer, cursor *typedcolumn.Int64Cursor, rows int, selection typedcolumn.RowSelection, scratch *typedkernel.Scratch) error {
+	out, err := reducer.Reduce(typedkernel.ReduceRequest{Rows: rows, Selection: selection, Int64Cursor: cursor}, scratch)
+	if err != nil {
+		return err
+	}
+	return addTypedColumnInt64AggregateKernelResult(result, out)
+}
+
+func recordTypedColumnInt64KernelBlock(diag *TypedColumnInt64PredicateScanDiagnostics, fullCovered bool, cursor bool) {
+	if diag == nil {
+		return
+	}
+	diag.KernelBlocks++
+	if fullCovered {
+		diag.KernelFullCoveredBlocks++
+	} else {
+		diag.KernelSelectedBlocks++
+	}
+	if cursor {
+		diag.KernelCursorBlocks++
+	}
+}
+
+func recordTypedColumnInt64KernelFallbackBlock(diag *TypedColumnInt64PredicateScanDiagnostics) {
+	if diag == nil {
+		return
+	}
+	diag.KernelFallbackBlocks++
+}
+
 func recordTypedColumnInt64FastDecodePlan(diag *TypedColumnInt64PredicateScanDiagnostics, plan typeddecode.Plan) {
 	if diag == nil {
 		return
@@ -337,7 +420,7 @@ func typedColumnInt64DirectViewFallbackAllowed(status typeddecode.Status) bool {
 	}
 }
 
-func addTypedColumnInt64AggregateStreamingValues(result *TypedColumnInt64PredicateAggregateResult, req TypedColumnInt64PredicateScanRequest, granule typedcolumn.EncodedGranule, block typedColumnPreparedBlockPlan, visibility *typedColumnLatestPhysicalPart, scratch *typedColumnInt64PredicateAggregateScanScratch) error {
+func addTypedColumnInt64AggregateStreamingValues(result *TypedColumnInt64PredicateAggregateResult, req TypedColumnInt64PredicateScanRequest, granule typedcolumn.EncodedGranule, block typedColumnPreparedBlockPlan, reducer typedkernel.PreparedReducer, visibility *typedColumnLatestPhysicalPart, scratch *typedColumnInt64PredicateAggregateScanScratch) error {
 	if result == nil {
 		return errors.New("collections: nil typed-column int64 aggregate result")
 	}
@@ -351,26 +434,33 @@ func addTypedColumnInt64AggregateStreamingValues(result *TypedColumnInt64Predica
 	}
 	result.Diagnostics.RowsScanned += rows
 	selection := block.CandidateSelection
-	if selection.IsAll() && !block.NeedsPredicate && visibility == nil {
-		count, sum, err := scratch.reader.CountSumInt64(granule)
+	if selection.IsAll() && !block.NeedsPredicate {
+		if visibility != nil {
+			visibilitySelection, err := typedColumnInt64VisibilitySelectionForBlock(visibility, block.Descriptor.FirstRow, block.Descriptor.RowCount, scratch)
+			if err != nil {
+				return err
+			}
+			selection, err = typedcolumn.ComposeRowSelectionsInto(block.Descriptor.RowCount, typedcolumn.RowSelectionComponents{Predicate: &selection, Visibility: &visibilitySelection}, &scratch.selection)
+			if err != nil {
+				return err
+			}
+			result.Diagnostics.SelectionCompositions++
+		}
+		recordTypedColumnSelectionDiagnostics(&result.Diagnostics, selection)
+		if selection.IsEmpty() {
+			return nil
+		}
+		cursor, err := scratch.reader.Int64Cursor(granule)
 		if err != nil {
 			return err
 		}
-		if count != rows {
-			return fmt.Errorf("typed-column int64 streaming count=%d want rows=%d", count, rows)
+		if err := addTypedColumnInt64AggregateKernelCursor(result, reducer, &cursor, rows, selection, &scratch.kernel); err != nil {
+			return err
 		}
-		if sum > 0 && result.Sum > typedColumnInt64PredicateAggregateMaxSum-sum {
-			return fmt.Errorf("collections: typed-column int64 predicate aggregate sum overflow current=%d value=%d", result.Sum, sum)
-		}
-		if sum < 0 && result.Sum < typedColumnInt64PredicateAggregateMinSum-sum {
-			return fmt.Errorf("collections: typed-column int64 predicate aggregate sum overflow current=%d value=%d", result.Sum, sum)
-		}
-		result.Count += int64(count)
-		result.Sum += sum
-		result.Diagnostics.RowsMatched += count
-		recordTypedColumnSelectionDiagnostics(&result.Diagnostics, selection)
+		recordTypedColumnInt64KernelBlock(&result.Diagnostics, visibility == nil && selection.IsAll(), true)
 		return nil
 	}
+	recordTypedColumnInt64KernelFallbackBlock(&result.Diagnostics)
 	cursor, err := scratch.reader.Int64Cursor(granule)
 	if err != nil {
 		return err
@@ -422,6 +512,9 @@ func addTypedColumnInt64AggregateStreamingValues(result *TypedColumnInt64Predica
 func (s *TypedColumnInt64PredicateAggregateSession) scanPreparedAggregateColumnState(preparedColumn *typedColumnPreparedColumnState, ref ColumnAssetRef, visibility *typedColumnLatestPhysicalPart, result *TypedColumnInt64PredicateAggregateResult, updateCacheDeltas func()) (bool, error) {
 	if preparedColumn == nil {
 		return false, errors.New("collections: typed-column int64 predicate aggregate nil prepared column")
+	}
+	if !preparedColumn.AggregateReducerReady {
+		return false, fmt.Errorf("collections: typed-column int64 predicate aggregate prepared column %q missing kernel reducer", preparedColumn.Plan.Definition.Name)
 	}
 	decodedAny := false
 	payloadRead := false
@@ -491,9 +584,10 @@ func (s *TypedColumnInt64PredicateAggregateSession) scanPreparedAggregateColumnS
 					if selection.IsEmpty() {
 						continue
 					}
-					if err := addTypedColumnInt64AggregateSelectedValues(result, values, selection); err != nil {
+					if err := addTypedColumnInt64AggregateKernelValues(result, preparedColumn.AggregateReducer, values, selection, &s.aggregateScratch.kernel); err != nil {
 						return false, err
 					}
+					recordTypedColumnInt64KernelBlock(&result.Diagnostics, !block.NeedsPredicate && visibility == nil && selection.IsAll(), false)
 					continue
 				}
 				if !typedColumnInt64DirectViewFallbackAllowed(viewStatus) {
@@ -512,7 +606,7 @@ func (s *TypedColumnInt64PredicateAggregateSession) scanPreparedAggregateColumnS
 		}
 		decodedAny = true
 		result.Diagnostics.BlocksDecoded++
-		if err := addTypedColumnInt64AggregateStreamingValues(result, typedColumnInt64PredicateAggregateScanRequest(s.req), granule, block, visibility, &s.aggregateScratch); err != nil {
+		if err := addTypedColumnInt64AggregateStreamingValues(result, typedColumnInt64PredicateAggregateScanRequest(s.req), granule, block, preparedColumn.AggregateReducer, visibility, &s.aggregateScratch); err != nil {
 			return false, err
 		}
 	}

--- a/TreeDB/collections/typed_column_prepared_int64.go
+++ b/TreeDB/collections/typed_column_prepared_int64.go
@@ -173,7 +173,7 @@ func typedColumnPreparedInt64AggregateReducer(preparedColumn *typedColumnPrepare
 		DictionaryOrder:     preparedColumn.Plan.Layout.Descriptor.DictionaryOrder,
 		DictionaryCollation: preparedColumn.Plan.Layout.Descriptor.DictionaryCollation,
 	}
-	reducer, err := typedkernel.DefaultRegistry().Dispatch(typedkernel.DispatchRequest{Operation: columnsemantics.OpSum, Semantic: desc, Layout: preparedColumn.Plan.Layout})
+	reducer, err := typedkernel.DefaultRegistry().Dispatch(typedkernel.DispatchRequest{Operation: preparedColumn.Plan.Operation, Semantic: desc, Layout: preparedColumn.Plan.Layout})
 	if err != nil {
 		return typedkernel.PreparedReducer{}, fmt.Errorf("collections: typed-column int64 aggregate prepared column %q kernel dispatch: %w", preparedColumn.Plan.Definition.Name, err)
 	}

--- a/TreeDB/collections/typed_column_prepared_state.go
+++ b/TreeDB/collections/typed_column_prepared_state.go
@@ -7,6 +7,7 @@ import (
 	"github.com/snissn/gomap/TreeDB/internal/columnlayout"
 	"github.com/snissn/gomap/TreeDB/internal/columnsemantics"
 	"github.com/snissn/gomap/TreeDB/internal/typedcolumn"
+	"github.com/snissn/gomap/TreeDB/internal/typedkernel"
 )
 
 // typedColumnPreparedRangeReader is the caller-owned byte access boundary used
@@ -34,6 +35,7 @@ type typedColumnPreparedColumnRequest struct {
 type typedColumnPreparedColumnPlan struct {
 	Field            TypedStorageField
 	Logical          columnsemantics.LogicalType
+	Operation        columnsemantics.Operation
 	Definition       typedcolumn.ColumnDefinition
 	Capability       columnsemantics.Capability
 	Layout           columnlayout.Capabilities
@@ -74,12 +76,14 @@ type typedColumnPreparedBlockPlan struct {
 }
 
 type typedColumnPreparedColumnState struct {
-	Plan          typedColumnPreparedColumnPlan
-	Column        typedcolumn.ColumnPartColumn
-	Section       typedcolumn.ColumnPartImageSection
-	BlockPlans    []typedColumnPreparedBlockPlan
-	Certification typedcolumn.ColumnPartLayoutContractColumn
-	Dictionaries  map[string]int64
+	Plan                  typedColumnPreparedColumnPlan
+	Column                typedcolumn.ColumnPartColumn
+	Section               typedcolumn.ColumnPartImageSection
+	BlockPlans            []typedColumnPreparedBlockPlan
+	Certification         typedcolumn.ColumnPartLayoutContractColumn
+	AggregateReducer      typedkernel.PreparedReducer
+	AggregateReducerReady bool
+	Dictionaries          map[string]int64
 }
 
 type typedColumnPreparedPartState struct {
@@ -204,6 +208,7 @@ func typedColumnDescribePreparedColumn(req typedColumnPreparedColumnRequest, spa
 	plan := typedColumnPreparedColumnPlan{
 		Field:            req.Field,
 		Logical:          logical,
+		Operation:        req.Operation,
 		Definition:       adapterColumn.Definition,
 		Capability:       capability,
 		Layout:           layout,

--- a/TreeDB/collections/typed_column_prepared_state.go
+++ b/TreeDB/collections/typed_column_prepared_state.go
@@ -422,6 +422,15 @@ func typedColumnPreparePartStateFromParsed(ref ColumnAssetRef, physical ColumnAs
 			return part, diag, nil
 		}
 		if existing := part.Columns[plan.Definition.Name]; existing != nil {
+			if request.Role == typedcolumn.ColumnRoleMeasure {
+				// A column can be requested once as a predicate and again as a
+				// measure. Keep the prepared reducer operation aligned with the
+				// measure request while preserving the union of section
+				// dependencies needed by both roles.
+				existing.Plan.Operation = plan.Operation
+				existing.Plan.Capability = plan.Capability
+				existing.Plan.LayoutCapability = plan.LayoutCapability
+			}
 			existing.Plan.Dependencies = append(existing.Plan.Dependencies, plan.Dependencies...)
 			part.Dependencies = append(part.Dependencies, plan.Dependencies...)
 			diag.SectionDependencies += len(plan.Dependencies)

--- a/TreeDB/collections/typed_column_prepared_state.go
+++ b/TreeDB/collections/typed_column_prepared_state.go
@@ -155,6 +155,8 @@ func (c *typedColumnPreparedColumnState) close() {
 	c.Section = typedcolumn.ColumnPartImageSection{}
 	c.BlockPlans = nil
 	c.Certification = typedcolumn.ColumnPartLayoutContractColumn{}
+	c.AggregateReducer = typedkernel.PreparedReducer{}
+	c.AggregateReducerReady = false
 	c.Dictionaries = nil
 }
 

--- a/TreeDB/collections/typed_column_prepared_state_test.go
+++ b/TreeDB/collections/typed_column_prepared_state_test.go
@@ -179,6 +179,17 @@ func TestTypedColumnPreparedStateMultiColumnMismatchFailsClosed(t *testing.T) {
 		}
 		return image.Bytes[offset : offset+length], nil
 	}
+	duplicateRequests := []typedColumnPreparedColumnRequest{
+		{Field: countField, Role: typedcolumn.ColumnRolePredicate, Operation: columnsemantics.OpAllRows, IncludePruning: true},
+		{Field: countField, Role: typedcolumn.ColumnRoleMeasure, Operation: columnsemantics.OpSum},
+	}
+	part, _, err := typedColumnPreparePartStateFromRanges(ref, physical, image.Rows, image.Rows, fields, uint64(adapterPart.Part.Descriptor.SchemaVersion), duplicateRequests, readRange, nil)
+	if err != nil {
+		t.Fatalf("prepare duplicate predicate/measure column: %v", err)
+	}
+	if got := part.Columns["count"].Plan.Operation; got != columnsemantics.OpSum {
+		t.Fatalf("duplicate column prepared operation=%s want measure operation %s", got, columnsemantics.OpSum)
+	}
 	request := []typedColumnPreparedColumnRequest{{Field: countField, Role: typedcolumn.ColumnRoleMeasure, Operation: columnsemantics.OpSum}}
 	_, _, err = typedColumnPreparePartStateFromRanges(ref, physical, 0, image.Rows, fields, uint64(adapterPart.Part.Descriptor.SchemaVersion), request, readRange, nil)
 	if err == nil || !strings.Contains(err.Error(), "image/ref mismatch") {

--- a/TreeDB/docs/spec/typed-column-kernels.md
+++ b/TreeDB/docs/spec/typed-column-kernels.md
@@ -1,0 +1,26 @@
+# Typed-Column Kernel Dispatch Framework (#1839 K1)
+
+Status: internal pre-alpha contract. Implementation lives in
+`TreeDB/internal/typedkernel` and is not a public API.
+
+Kernel dispatch is a prepare/block-planning boundary decision. Callers provide
+both the semantic descriptor from `columnsemantics` (#1843) and the layout
+capabilities from `columnlayout` (#1838). Dispatch fails closed unless both gates
+report `supported`; fallback or unsupported statuses are returned before a
+physical reducer is selected. Matching is therefore based on logical semantics
+and layout capability, not physical encoding alone.
+
+The registry is immutable/caller-owned. `DefaultRegistry` returns a static table
+with int64 count-rows and non-null int64 aggregate reducers. Tests and future
+planners can build their own registry with extra kernels; there is no mutable
+process-wide cache. Scratch/reuse is likewise explicit through caller/session
+owned values.
+
+Reducers dispatch once outside the hot row loop. Concrete reducers switch on
+`typedcolumn.RowSelection.Kind()` for empty, all, range, ranges, bitmap, and
+sparse selections. The initial int64 reducer represents count rows, count
+non-null, sum, avg, min, and max separately, with checked int64 sum accumulation.
+Nullable value aggregates remain fallback/unsupported until a future kernel
+composes null/default masks explicitly. Direct/zero-copy access is not
+implemented here; future integration should obtain any direct views through
+`TreeDB/internal/typeddecode` before invoking a concrete kernel.

--- a/TreeDB/internal/typedkernel/doc.go
+++ b/TreeDB/internal/typedkernel/doc.go
@@ -1,0 +1,12 @@
+// Package typedkernel contains internal typed-column aggregate kernel dispatch.
+//
+// Dispatch is a prepare/block-planning boundary operation: callers provide both
+// the #1843 semantic descriptor and the #1838 layout capabilities, and the
+// registry only returns a concrete reducer after both gates report support.
+// Reducers then run over a typedcolumn.RowSelection without consulting generic
+// capability tables in per-row hot loops.
+//
+// The package has no public API surface and no process-wide mutable caches.
+// DefaultRegistry returns an immutable static table; tests and future planners
+// can build caller-owned registries with additional kernels.
+package typedkernel

--- a/TreeDB/internal/typedkernel/int64.go
+++ b/TreeDB/internal/typedkernel/int64.go
@@ -1,0 +1,142 @@
+package typedkernel
+
+import (
+	"fmt"
+	"math"
+	"math/bits"
+
+	"github.com/snissn/gomap/TreeDB/internal/typedcolumn"
+)
+
+type int64Accum struct {
+	count int64
+	sum   int64
+	min   int64
+	max   int64
+	has   bool
+}
+
+func reduceInt64Aggregate(op AggregateOp, req ReduceRequest, _ *Scratch) (AggregateResult, error) {
+	rows, err := validateSelectionRows(req)
+	if err != nil {
+		return AggregateResult{}, err
+	}
+	if op == OpCountNonNull && req.Int64Values == nil {
+		return AggregateResult{Op: op, NonNulls: int64(req.Selection.Count()), HasValue: true}, nil
+	}
+	if len(req.Int64Values) != rows {
+		return AggregateResult{}, fmt.Errorf("typedkernel: int64 values rows=%d want %d", len(req.Int64Values), rows)
+	}
+	if op == OpCountNonNull {
+		return AggregateResult{Op: op, NonNulls: int64(req.Selection.Count()), HasValue: true}, nil
+	}
+	var acc int64Accum
+	switch req.Selection.Kind() {
+	case typedcolumn.RowSelectionEmpty:
+		return int64Result(op, acc)
+	case typedcolumn.RowSelectionAll:
+		for row := 0; row < rows; row++ {
+			if err := acc.add(req.Int64Values[row]); err != nil {
+				return AggregateResult{}, err
+			}
+		}
+	case typedcolumn.RowSelectionRange:
+		start, end, ok := req.Selection.SingleRange()
+		if !ok || start < 0 || end < start || end > rows {
+			return AggregateResult{}, fmt.Errorf("typedkernel: invalid int64 range selection [%d,%d) rows=%d", start, end, rows)
+		}
+		for row := start; row < end; row++ {
+			if err := acc.add(req.Int64Values[row]); err != nil {
+				return AggregateResult{}, err
+			}
+		}
+	case typedcolumn.RowSelectionRanges:
+		for _, r := range req.Selection.Ranges() {
+			if r.Start < 0 || r.End < r.Start || r.End > rows {
+				return AggregateResult{}, fmt.Errorf("typedkernel: invalid int64 ranges selection [%d,%d) rows=%d", r.Start, r.End, rows)
+			}
+			for row := r.Start; row < r.End; row++ {
+				if err := acc.add(req.Int64Values[row]); err != nil {
+					return AggregateResult{}, err
+				}
+			}
+		}
+	case typedcolumn.RowSelectionBitmap:
+		for wordIndex, word := range req.Selection.BitmapWords() {
+			for word != 0 {
+				bit := bits.TrailingZeros64(word)
+				row := wordIndex*64 + bit
+				if row >= rows {
+					break
+				}
+				if err := acc.add(req.Int64Values[row]); err != nil {
+					return AggregateResult{}, err
+				}
+				word &^= uint64(1) << uint(bit)
+			}
+		}
+	case typedcolumn.RowSelectionSparse:
+		for _, row := range req.Selection.SparseRows() {
+			if row < 0 || row >= rows {
+				return AggregateResult{}, fmt.Errorf("typedkernel: invalid int64 sparse row=%d rows=%d", row, rows)
+			}
+			if err := acc.add(req.Int64Values[row]); err != nil {
+				return AggregateResult{}, err
+			}
+		}
+	default:
+		return AggregateResult{}, fmt.Errorf("typedkernel: unsupported int64 row selection shape %s", req.Selection.Shape().Kind)
+	}
+	return int64Result(op, acc)
+}
+
+func (a *int64Accum) add(value int64) error {
+	if value > 0 && a.sum > math.MaxInt64-value {
+		return fmt.Errorf("typedkernel: int64 sum overflow current=%d value=%d", a.sum, value)
+	}
+	if value < 0 && a.sum < math.MinInt64-value {
+		return fmt.Errorf("typedkernel: int64 sum overflow current=%d value=%d", a.sum, value)
+	}
+	a.sum += value
+	a.count++
+	if !a.has {
+		a.min = value
+		a.max = value
+		a.has = true
+		return nil
+	}
+	if value < a.min {
+		a.min = value
+	}
+	if value > a.max {
+		a.max = value
+	}
+	return nil
+}
+
+func int64Result(op AggregateOp, acc int64Accum) (AggregateResult, error) {
+	out := AggregateResult{Op: op, NonNulls: acc.count, HasValue: acc.has}
+	switch op {
+	case OpSum:
+		out.Sum = acc.sum
+		// Sum over an empty selection is the additive identity and still a
+		// well-formed aggregate result.
+		out.HasValue = true
+	case OpAvg:
+		out.Sum = acc.sum
+		if acc.count != 0 {
+			out.Avg = float64(acc.sum) / float64(acc.count)
+		}
+	case OpMin:
+		if acc.has {
+			out.Min = acc.min
+		}
+	case OpMax:
+		if acc.has {
+			out.Max = acc.max
+		}
+	default:
+		return AggregateResult{}, fmt.Errorf("typedkernel: int64 reducer got op=%s", op)
+	}
+	return out, nil
+}

--- a/TreeDB/internal/typedkernel/int64.go
+++ b/TreeDB/internal/typedkernel/int64.go
@@ -21,22 +21,22 @@ func reduceInt64Aggregate(op AggregateOp, req ReduceRequest, _ *Scratch) (Aggreg
 	if err != nil {
 		return AggregateResult{}, err
 	}
-	if op == OpCountNonNull && req.Int64Values == nil {
-		return AggregateResult{Op: op, NonNulls: int64(req.Selection.Count()), HasValue: true}, nil
-	}
-	if len(req.Int64Values) != rows {
-		return AggregateResult{}, fmt.Errorf("typedkernel: int64 values rows=%d want %d", len(req.Int64Values), rows)
-	}
 	if op == OpCountNonNull {
 		return AggregateResult{Op: op, NonNulls: int64(req.Selection.Count()), HasValue: true}, nil
 	}
 	var acc int64Accum
+	if req.Selection.Kind() == typedcolumn.RowSelectionEmpty {
+		return int64Result(op, acc)
+	}
+	if len(req.Int64Values) != rows {
+		return AggregateResult{}, fmt.Errorf("typedkernel: int64 values rows=%d want %d", len(req.Int64Values), rows)
+	}
 	switch req.Selection.Kind() {
 	case typedcolumn.RowSelectionEmpty:
 		return int64Result(op, acc)
 	case typedcolumn.RowSelectionAll:
 		for row := 0; row < rows; row++ {
-			if err := acc.add(req.Int64Values[row]); err != nil {
+			if err := acc.add(op, req.Int64Values[row]); err != nil {
 				return AggregateResult{}, err
 			}
 		}
@@ -46,7 +46,7 @@ func reduceInt64Aggregate(op AggregateOp, req ReduceRequest, _ *Scratch) (Aggreg
 			return AggregateResult{}, fmt.Errorf("typedkernel: invalid int64 range selection [%d,%d) rows=%d", start, end, rows)
 		}
 		for row := start; row < end; row++ {
-			if err := acc.add(req.Int64Values[row]); err != nil {
+			if err := acc.add(op, req.Int64Values[row]); err != nil {
 				return AggregateResult{}, err
 			}
 		}
@@ -56,7 +56,7 @@ func reduceInt64Aggregate(op AggregateOp, req ReduceRequest, _ *Scratch) (Aggreg
 				return AggregateResult{}, fmt.Errorf("typedkernel: invalid int64 ranges selection [%d,%d) rows=%d", r.Start, r.End, rows)
 			}
 			for row := r.Start; row < r.End; row++ {
-				if err := acc.add(req.Int64Values[row]); err != nil {
+				if err := acc.add(op, req.Int64Values[row]); err != nil {
 					return AggregateResult{}, err
 				}
 			}
@@ -69,7 +69,7 @@ func reduceInt64Aggregate(op AggregateOp, req ReduceRequest, _ *Scratch) (Aggreg
 				if row >= rows {
 					break
 				}
-				if err := acc.add(req.Int64Values[row]); err != nil {
+				if err := acc.add(op, req.Int64Values[row]); err != nil {
 					return AggregateResult{}, err
 				}
 				word &^= uint64(1) << uint(bit)
@@ -80,7 +80,7 @@ func reduceInt64Aggregate(op AggregateOp, req ReduceRequest, _ *Scratch) (Aggreg
 			if row < 0 || row >= rows {
 				return AggregateResult{}, fmt.Errorf("typedkernel: invalid int64 sparse row=%d rows=%d", row, rows)
 			}
-			if err := acc.add(req.Int64Values[row]); err != nil {
+			if err := acc.add(op, req.Int64Values[row]); err != nil {
 				return AggregateResult{}, err
 			}
 		}
@@ -90,14 +90,16 @@ func reduceInt64Aggregate(op AggregateOp, req ReduceRequest, _ *Scratch) (Aggreg
 	return int64Result(op, acc)
 }
 
-func (a *int64Accum) add(value int64) error {
-	if value > 0 && a.sum > math.MaxInt64-value {
-		return fmt.Errorf("typedkernel: int64 sum overflow current=%d value=%d", a.sum, value)
+func (a *int64Accum) add(op AggregateOp, value int64) error {
+	if op == OpSum || op == OpAvg {
+		if value > 0 && a.sum > math.MaxInt64-value {
+			return fmt.Errorf("typedkernel: int64 sum overflow current=%d value=%d", a.sum, value)
+		}
+		if value < 0 && a.sum < math.MinInt64-value {
+			return fmt.Errorf("typedkernel: int64 sum overflow current=%d value=%d", a.sum, value)
+		}
+		a.sum += value
 	}
-	if value < 0 && a.sum < math.MinInt64-value {
-		return fmt.Errorf("typedkernel: int64 sum overflow current=%d value=%d", a.sum, value)
-	}
-	a.sum += value
 	a.count++
 	if !a.has {
 		a.min = value

--- a/TreeDB/internal/typedkernel/int64.go
+++ b/TreeDB/internal/typedkernel/int64.go
@@ -22,6 +22,9 @@ func reduceInt64Aggregate(op AggregateOp, req ReduceRequest, _ *Scratch) (Aggreg
 		return AggregateResult{}, err
 	}
 	if op == OpCountNonNull {
+		if req.Int64Cursor != nil {
+			return AggregateResult{}, fmt.Errorf("typedkernel: count non-null reducer does not accept int64 cursor")
+		}
 		return AggregateResult{Op: op, NonNulls: int64(req.Selection.Count()), HasValue: true}, nil
 	}
 	var acc int64Accum

--- a/TreeDB/internal/typedkernel/int64.go
+++ b/TreeDB/internal/typedkernel/int64.go
@@ -28,13 +28,21 @@ func reduceInt64Aggregate(op AggregateOp, req ReduceRequest, _ *Scratch) (Aggreg
 		return AggregateResult{Op: op, NonNulls: int64(req.Selection.Count()), HasValue: true}, nil
 	}
 	var acc int64Accum
+	if req.Int64Cursor != nil && len(req.Int64Values) != 0 {
+		return AggregateResult{}, fmt.Errorf("typedkernel: int64 reducer got both values and cursor")
+	}
 	if req.Selection.Kind() == typedcolumn.RowSelectionEmpty {
+		if req.Int64Cursor != nil {
+			if err := req.Int64Cursor.Finish(); err != nil {
+				return AggregateResult{}, err
+			}
+		}
+		if len(req.Int64Values) != 0 && len(req.Int64Values) != rows {
+			return AggregateResult{}, fmt.Errorf("typedkernel: int64 values rows=%d want %d", len(req.Int64Values), rows)
+		}
 		return int64Result(op, acc)
 	}
 	if req.Int64Cursor != nil {
-		if len(req.Int64Values) != 0 {
-			return AggregateResult{}, fmt.Errorf("typedkernel: int64 reducer got both values and cursor")
-		}
 		return reduceInt64AggregateCursor(op, req, rows)
 	}
 	if len(req.Int64Values) != rows {

--- a/TreeDB/internal/typedkernel/int64.go
+++ b/TreeDB/internal/typedkernel/int64.go
@@ -33,6 +33,9 @@ func reduceInt64Aggregate(op AggregateOp, req ReduceRequest, _ *Scratch) (Aggreg
 	}
 	if req.Selection.Kind() == typedcolumn.RowSelectionEmpty {
 		if req.Int64Cursor != nil {
+			if req.Int64Cursor.Rows() != rows {
+				return AggregateResult{}, fmt.Errorf("typedkernel: int64 cursor rows=%d want %d", req.Int64Cursor.Rows(), rows)
+			}
 			if err := req.Int64Cursor.Finish(); err != nil {
 				return AggregateResult{}, err
 			}

--- a/TreeDB/internal/typedkernel/int64.go
+++ b/TreeDB/internal/typedkernel/int64.go
@@ -28,6 +28,12 @@ func reduceInt64Aggregate(op AggregateOp, req ReduceRequest, _ *Scratch) (Aggreg
 	if req.Selection.Kind() == typedcolumn.RowSelectionEmpty {
 		return int64Result(op, acc)
 	}
+	if req.Int64Cursor != nil {
+		if len(req.Int64Values) != 0 {
+			return AggregateResult{}, fmt.Errorf("typedkernel: int64 reducer got both values and cursor")
+		}
+		return reduceInt64AggregateCursor(op, req, rows)
+	}
 	if len(req.Int64Values) != rows {
 		return AggregateResult{}, fmt.Errorf("typedkernel: int64 values rows=%d want %d", len(req.Int64Values), rows)
 	}
@@ -86,6 +92,104 @@ func reduceInt64Aggregate(op AggregateOp, req ReduceRequest, _ *Scratch) (Aggreg
 		}
 	default:
 		return AggregateResult{}, fmt.Errorf("typedkernel: unsupported int64 row selection shape %s", req.Selection.Shape().Kind)
+	}
+	return int64Result(op, acc)
+}
+
+func reduceInt64AggregateCursor(op AggregateOp, req ReduceRequest, rows int) (AggregateResult, error) {
+	cursor := req.Int64Cursor
+	if cursor.Rows() != rows {
+		return AggregateResult{}, fmt.Errorf("typedkernel: int64 cursor rows=%d want %d", cursor.Rows(), rows)
+	}
+	var acc int64Accum
+	switch req.Selection.Kind() {
+	case typedcolumn.RowSelectionAll:
+		for row := 0; row < rows; row++ {
+			value, err := cursor.Next()
+			if err != nil {
+				return AggregateResult{}, err
+			}
+			if err := acc.add(op, value); err != nil {
+				return AggregateResult{}, err
+			}
+		}
+	case typedcolumn.RowSelectionRange:
+		start, end, ok := req.Selection.SingleRange()
+		if !ok || start < 0 || end < start || end > rows {
+			return AggregateResult{}, fmt.Errorf("typedkernel: invalid int64 cursor range selection [%d,%d) rows=%d", start, end, rows)
+		}
+		for row := 0; row < rows; row++ {
+			value, err := cursor.Next()
+			if err != nil {
+				return AggregateResult{}, err
+			}
+			if row >= start && row < end {
+				if err := acc.add(op, value); err != nil {
+					return AggregateResult{}, err
+				}
+			}
+		}
+	case typedcolumn.RowSelectionRanges:
+		ranges := req.Selection.Ranges()
+		for _, r := range ranges {
+			if r.Start < 0 || r.End < r.Start || r.End > rows {
+				return AggregateResult{}, fmt.Errorf("typedkernel: invalid int64 cursor ranges selection [%d,%d) rows=%d", r.Start, r.End, rows)
+			}
+		}
+		rangeIndex := 0
+		for row := 0; row < rows; row++ {
+			value, err := cursor.Next()
+			if err != nil {
+				return AggregateResult{}, err
+			}
+			for rangeIndex < len(ranges) && row >= ranges[rangeIndex].End {
+				rangeIndex++
+			}
+			if rangeIndex < len(ranges) && row >= ranges[rangeIndex].Start {
+				if err := acc.add(op, value); err != nil {
+					return AggregateResult{}, err
+				}
+			}
+		}
+	case typedcolumn.RowSelectionBitmap:
+		words := req.Selection.BitmapWords()
+		for row := 0; row < rows; row++ {
+			value, err := cursor.Next()
+			if err != nil {
+				return AggregateResult{}, err
+			}
+			wordIndex := row / 64
+			if wordIndex < len(words) && words[wordIndex]&(uint64(1)<<uint(row%64)) != 0 {
+				if err := acc.add(op, value); err != nil {
+					return AggregateResult{}, err
+				}
+			}
+		}
+	case typedcolumn.RowSelectionSparse:
+		sparse := req.Selection.SparseRows()
+		for _, row := range sparse {
+			if row < 0 || row >= rows {
+				return AggregateResult{}, fmt.Errorf("typedkernel: invalid int64 cursor sparse row=%d rows=%d", row, rows)
+			}
+		}
+		sparseIndex := 0
+		for row := 0; row < rows; row++ {
+			value, err := cursor.Next()
+			if err != nil {
+				return AggregateResult{}, err
+			}
+			if sparseIndex < len(sparse) && row == sparse[sparseIndex] {
+				if err := acc.add(op, value); err != nil {
+					return AggregateResult{}, err
+				}
+				sparseIndex++
+			}
+		}
+	default:
+		return AggregateResult{}, fmt.Errorf("typedkernel: unsupported int64 cursor row selection shape %s", req.Selection.Shape().Kind)
+	}
+	if err := cursor.Finish(); err != nil {
+		return AggregateResult{}, err
 	}
 	return int64Result(op, acc)
 }

--- a/TreeDB/internal/typedkernel/registry.go
+++ b/TreeDB/internal/typedkernel/registry.go
@@ -83,13 +83,11 @@ type Registry struct {
 
 var defaultEntries = [...]KernelSpec{
 	{
-		Name:     "int64.count_rows.v1",
-		Logical:  columnsemantics.LogicalInt64,
-		Physical: typedcolumn.ColumnTypeInt64,
-		Ops:      []AggregateOp{OpCountRows},
-		Reduce:   reduceCountRows,
+		Name:   "generic.count_rows.v1",
+		Ops:    []AggregateOp{OpCountRows},
+		Reduce: reduceCountRows,
 		// Counting rows does not consume carrier values and is safe for nullable
-		// int64 wrappers once semantics/layout have accepted the operation.
+		// wrappers once semantics/layout have accepted the operation.
 		AllowNullable: true,
 	},
 	{

--- a/TreeDB/internal/typedkernel/registry.go
+++ b/TreeDB/internal/typedkernel/registry.go
@@ -1,0 +1,277 @@
+package typedkernel
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/snissn/gomap/TreeDB/internal/columnlayout"
+	"github.com/snissn/gomap/TreeDB/internal/columnsemantics"
+	"github.com/snissn/gomap/TreeDB/internal/typedcolumn"
+)
+
+// AggregateOp names the aggregate semantics accepted by this package. The
+// values intentionally alias columnsemantics.Operation so callers can carry the
+// #1843 decision through prepare without an additional translation layer.
+type AggregateOp = columnsemantics.Operation
+
+const (
+	OpCountRows    AggregateOp = columnsemantics.OpCountRows
+	OpCountNonNull AggregateOp = columnsemantics.OpCountNonNull
+	OpSum          AggregateOp = columnsemantics.OpSum
+	OpAvg          AggregateOp = columnsemantics.OpAvg
+	OpMin          AggregateOp = columnsemantics.OpMin
+	OpMax          AggregateOp = columnsemantics.OpMax
+)
+
+// AggregateResult keeps row-count and value-count semantics distinct. For
+// CountRows, Rows is the row count. For CountNonNull and value aggregates,
+// NonNulls is the number of values included in the aggregate. HasValue is false
+// for empty min/max/avg inputs.
+type AggregateResult struct {
+	Op       AggregateOp
+	Rows     int64
+	NonNulls int64
+	Sum      int64
+	Avg      float64
+	Min      int64
+	Max      int64
+	HasValue bool
+}
+
+// ReduceRequest is the concrete hot-loop input for one selected block. Rows is
+// the block-local row domain. Int64Values is used by int64 value kernels and may
+// be nil for count-row kernels.
+type ReduceRequest struct {
+	Rows        int
+	Selection   typedcolumn.RowSelection
+	Int64Values []int64
+}
+
+// Scratch is caller/session-owned reusable storage for future kernels. It is
+// deliberately explicit even though the initial int64 reducers do not need it.
+type Scratch struct {
+	Selection typedcolumn.RowSelectionScratch
+	Int64     []int64
+}
+
+// ReduceFunc runs a concrete reducer after registry dispatch. Implementations
+// must switch on RowSelection.Kind and must not use reflection or per-row
+// interface/callback dispatch.
+type ReduceFunc func(op AggregateOp, req ReduceRequest, scratch *Scratch) (AggregateResult, error)
+
+// KernelSpec is an immutable registry entry. Empty Logical/Physical fields are
+// wildcards, intended for generic kernels such as count rows. Value kernels
+// should bind logical and physical types and rely on Dispatch to enforce the
+// semantic and layout gates before matching.
+type KernelSpec struct {
+	Name          string
+	Logical       columnsemantics.LogicalType
+	Physical      typedcolumn.ColumnType
+	Ops           []AggregateOp
+	AllowNullable bool
+	Reduce        ReduceFunc
+}
+
+// Registry is an immutable/caller-owned dispatch table. Methods that add a
+// kernel return a new Registry and never mutate the receiver.
+type Registry struct {
+	entries []KernelSpec
+}
+
+var defaultEntries = [...]KernelSpec{
+	{
+		Name:     "int64.count_rows.v1",
+		Logical:  columnsemantics.LogicalInt64,
+		Physical: typedcolumn.ColumnTypeInt64,
+		Ops:      []AggregateOp{OpCountRows},
+		Reduce:   reduceCountRows,
+		// Counting rows does not consume carrier values and is safe for nullable
+		// int64 wrappers once semantics/layout have accepted the operation.
+		AllowNullable: true,
+	},
+	{
+		Name:     "int64.aggregate.v1",
+		Logical:  columnsemantics.LogicalInt64,
+		Physical: typedcolumn.ColumnTypeInt64,
+		Ops:      []AggregateOp{OpCountNonNull, OpSum, OpAvg, OpMin, OpMax},
+		Reduce:   reduceInt64Aggregate,
+	},
+}
+
+// DefaultRegistry returns the package's static immutable kernel table.
+func DefaultRegistry() Registry {
+	entries := make([]KernelSpec, len(defaultEntries))
+	for i, entry := range defaultEntries {
+		entries[i] = cloneKernelSpec(entry)
+	}
+	return Registry{entries: entries}
+}
+
+// NewRegistry returns a caller-owned registry containing the provided entries.
+func NewRegistry(entries []KernelSpec) (Registry, error) {
+	out := Registry{entries: make([]KernelSpec, len(entries))}
+	for i, entry := range entries {
+		if err := validateKernelSpec(entry); err != nil {
+			return Registry{}, fmt.Errorf("typedkernel: kernel %d: %w", i, err)
+		}
+		out.entries[i] = cloneKernelSpec(entry)
+	}
+	return out, nil
+}
+
+// WithKernel returns a new caller-owned registry with entry appended.
+func (r Registry) WithKernel(entry KernelSpec) (Registry, error) {
+	if err := validateKernelSpec(entry); err != nil {
+		return Registry{}, err
+	}
+	out := Registry{entries: make([]KernelSpec, 0, len(r.entries)+1)}
+	for _, existing := range r.entries {
+		out.entries = append(out.entries, cloneKernelSpec(existing))
+	}
+	out.entries = append(out.entries, cloneKernelSpec(entry))
+	return out, nil
+}
+
+// DispatchRequest is resolved at prepare/block-planning boundaries. Semantic
+// and layout descriptors must describe the same logical/physical column.
+type DispatchRequest struct {
+	Operation AggregateOp
+	Semantic  columnsemantics.Descriptor
+	Layout    columnlayout.Capabilities
+}
+
+// PreparedReducer is the concrete reducer selected by Dispatch. It is safe to
+// reuse for blocks with the same prepared semantic/layout decision.
+type PreparedReducer struct {
+	op           AggregateOp
+	kernel       KernelSpec
+	semanticCap  columnsemantics.Capability
+	layoutCap    columnlayout.Capability
+	layout       columnlayout.Capabilities
+	semanticDesc columnsemantics.Descriptor
+}
+
+func (p PreparedReducer) Operation() AggregateOp { return p.op }
+func (p PreparedReducer) KernelName() string     { return p.kernel.Name }
+func (p PreparedReducer) SemanticCapability() columnsemantics.Capability {
+	return p.semanticCap
+}
+func (p PreparedReducer) LayoutCapability() columnlayout.Capability { return p.layoutCap }
+
+// Reduce executes the selected concrete reducer. The function-table dispatch is
+// outside row loops; reducers own their RowSelection.Kind switch.
+func (p PreparedReducer) Reduce(req ReduceRequest, scratch *Scratch) (AggregateResult, error) {
+	if p.kernel.Reduce == nil {
+		return AggregateResult{}, fmt.Errorf("typedkernel: uninitialized reducer for %s", p.op)
+	}
+	return p.kernel.Reduce(p.op, req, scratch)
+}
+
+// Dispatch validates #1843 semantics and #1838 layout capabilities, then picks
+// the first matching registry entry. Unsupported/fallback capabilities fail
+// closed before any physical kernel is selected.
+func (r Registry) Dispatch(req DispatchRequest) (PreparedReducer, error) {
+	if !isAggregateOp(req.Operation) {
+		return PreparedReducer{}, fmt.Errorf("typedkernel: unsupported aggregate operation %q", req.Operation)
+	}
+	if err := validateDescriptorPair(req.Semantic, req.Layout.Descriptor); err != nil {
+		return PreparedReducer{}, err
+	}
+	semCap := columnsemantics.CapabilityFor(req.Semantic, req.Operation)
+	if !semCap.Supported() {
+		return PreparedReducer{}, fmt.Errorf("typedkernel: semantic capability %s status=%s reason=%s", req.Operation, semCap.Status, semCap.Error())
+	}
+	layoutCap := req.Layout.SupportsSemanticOperation(req.Operation)
+	if !layoutCap.Supported() {
+		return PreparedReducer{}, fmt.Errorf("typedkernel: layout capability %s status=%s reason=%s", req.Operation, layoutCap.Status, layoutCap.Error())
+	}
+	for _, entry := range r.entries {
+		if entry.matches(req.Operation, req.Semantic, req.Layout) {
+			return PreparedReducer{op: req.Operation, kernel: cloneKernelSpec(entry), semanticCap: semCap, layoutCap: layoutCap, layout: req.Layout, semanticDesc: req.Semantic}, nil
+		}
+	}
+	return PreparedReducer{}, fmt.Errorf("typedkernel: no kernel registered for op=%s logical=%s physical=%s encoding=%s nullable=%v", req.Operation, req.Semantic.Logical, req.Semantic.Physical, req.Semantic.Encoding, nullableDescriptor(req.Semantic, req.Layout))
+}
+
+func validateKernelSpec(entry KernelSpec) error {
+	if entry.Name == "" {
+		return fmt.Errorf("missing kernel name")
+	}
+	if entry.Reduce == nil {
+		return fmt.Errorf("kernel %q missing reducer", entry.Name)
+	}
+	if len(entry.Ops) == 0 {
+		return fmt.Errorf("kernel %q missing operations", entry.Name)
+	}
+	for _, op := range entry.Ops {
+		if !isAggregateOp(op) {
+			return fmt.Errorf("kernel %q unsupported aggregate operation %q", entry.Name, op)
+		}
+	}
+	return nil
+}
+
+func cloneKernelSpec(entry KernelSpec) KernelSpec {
+	entry.Ops = slices.Clone(entry.Ops)
+	return entry
+}
+
+func (entry KernelSpec) matches(op AggregateOp, desc columnsemantics.Descriptor, layout columnlayout.Capabilities) bool {
+	if !slices.Contains(entry.Ops, op) {
+		return false
+	}
+	if entry.Logical != "" && entry.Logical != desc.Logical {
+		return false
+	}
+	if entry.Physical != "" && entry.Physical != desc.Physical {
+		return false
+	}
+	if nullableDescriptor(desc, layout) && !entry.AllowNullable {
+		return false
+	}
+	return true
+}
+
+func isAggregateOp(op AggregateOp) bool {
+	switch op {
+	case OpCountRows, OpCountNonNull, OpSum, OpAvg, OpMin, OpMax:
+		return true
+	default:
+		return false
+	}
+}
+
+func validateDescriptorPair(sem columnsemantics.Descriptor, layout columnlayout.Descriptor) error {
+	if sem.Logical != layout.Logical || sem.Physical != layout.Physical || sem.Encoding != layout.Encoding || sem.Nullable != layout.Nullable || sem.DictionaryOrder != layout.DictionaryOrder || sem.DictionaryCollation != layout.DictionaryCollation {
+		return fmt.Errorf("typedkernel: semantic/layout descriptor mismatch semantic=(logical=%s physical=%s encoding=%s nullable=%v dictionary_order=%v collation=%q) layout=(logical=%s physical=%s encoding=%s nullable=%v dictionary_order=%v collation=%q)", sem.Logical, sem.Physical, sem.Encoding, sem.Nullable, sem.DictionaryOrder, sem.DictionaryCollation, layout.Logical, layout.Physical, layout.Encoding, layout.Nullable, layout.DictionaryOrder, layout.DictionaryCollation)
+	}
+	return nil
+}
+
+func nullableDescriptor(desc columnsemantics.Descriptor, layout columnlayout.Capabilities) bool {
+	return desc.Nullable || desc.Encoding == typedcolumn.EncodingNullableInt64 || layout.Wrappers.Nullable
+}
+
+func validateSelectionRows(req ReduceRequest) (int, error) {
+	rows := req.Rows
+	if rows == 0 && req.Selection.Rows() != 0 {
+		rows = req.Selection.Rows()
+	}
+	if rows < 0 {
+		return 0, fmt.Errorf("typedkernel: negative row domain %d", rows)
+	}
+	if req.Selection.Rows() != rows {
+		return 0, fmt.Errorf("typedkernel: selection rows=%d want %d", req.Selection.Rows(), rows)
+	}
+	return rows, nil
+}
+
+func reduceCountRows(op AggregateOp, req ReduceRequest, _ *Scratch) (AggregateResult, error) {
+	if op != OpCountRows {
+		return AggregateResult{}, fmt.Errorf("typedkernel: count rows reducer got op=%s", op)
+	}
+	if _, err := validateSelectionRows(req); err != nil {
+		return AggregateResult{}, err
+	}
+	return AggregateResult{Op: op, Rows: int64(req.Selection.Count()), HasValue: true}, nil
+}

--- a/TreeDB/internal/typedkernel/registry.go
+++ b/TreeDB/internal/typedkernel/registry.go
@@ -40,7 +40,7 @@ type AggregateResult struct {
 
 // ReduceRequest is the concrete hot-loop input for one selected block. Rows is
 // the block-local row domain. Int64Values is used by int64 value kernels and may
-// be nil for count-row kernels.
+// be nil for count-row/count-non-null reducers and empty selections.
 type ReduceRequest struct {
 	Rows        int
 	Selection   typedcolumn.RowSelection
@@ -143,12 +143,10 @@ type DispatchRequest struct {
 // PreparedReducer is the concrete reducer selected by Dispatch. It is safe to
 // reuse for blocks with the same prepared semantic/layout decision.
 type PreparedReducer struct {
-	op           AggregateOp
-	kernel       KernelSpec
-	semanticCap  columnsemantics.Capability
-	layoutCap    columnlayout.Capability
-	layout       columnlayout.Capabilities
-	semanticDesc columnsemantics.Descriptor
+	op          AggregateOp
+	kernel      KernelSpec
+	semanticCap columnsemantics.Capability
+	layoutCap   columnlayout.Capability
 }
 
 func (p PreparedReducer) Operation() AggregateOp { return p.op }
@@ -187,7 +185,7 @@ func (r Registry) Dispatch(req DispatchRequest) (PreparedReducer, error) {
 	}
 	for _, entry := range r.entries {
 		if entry.matches(req.Operation, req.Semantic, req.Layout) {
-			return PreparedReducer{op: req.Operation, kernel: cloneKernelSpec(entry), semanticCap: semCap, layoutCap: layoutCap, layout: req.Layout, semanticDesc: req.Semantic}, nil
+			return PreparedReducer{op: req.Operation, kernel: cloneKernelSpec(entry), semanticCap: semCap, layoutCap: layoutCap}, nil
 		}
 	}
 	return PreparedReducer{}, fmt.Errorf("typedkernel: no kernel registered for op=%s logical=%s physical=%s encoding=%s nullable=%v", req.Operation, req.Semantic.Logical, req.Semantic.Physical, req.Semantic.Encoding, nullableDescriptor(req.Semantic, req.Layout))

--- a/TreeDB/internal/typedkernel/registry.go
+++ b/TreeDB/internal/typedkernel/registry.go
@@ -39,12 +39,15 @@ type AggregateResult struct {
 }
 
 // ReduceRequest is the concrete hot-loop input for one selected block. Rows is
-// the block-local row domain. Int64Values is used by int64 value kernels and may
-// be nil for count-row/count-non-null reducers and empty selections.
+// the block-local row domain. Int64Values is used by materialized/direct-view
+// int64 value kernels and may be nil for count-row/count-non-null reducers and
+// empty selections. Int64Cursor is used by streaming int64 kernels; callers
+// provide either Int64Values or Int64Cursor for value aggregates, not both.
 type ReduceRequest struct {
 	Rows        int
 	Selection   typedcolumn.RowSelection
 	Int64Values []int64
+	Int64Cursor *typedcolumn.Int64Cursor
 }
 
 // Scratch is caller/session-owned reusable storage for future kernels. It is

--- a/TreeDB/internal/typedkernel/registry_test.go
+++ b/TreeDB/internal/typedkernel/registry_test.go
@@ -1,0 +1,254 @@
+package typedkernel_test
+
+import (
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/internal/columnlayout"
+	"github.com/snissn/gomap/TreeDB/internal/columnsemantics"
+	"github.com/snissn/gomap/TreeDB/internal/typedcolumn"
+	"github.com/snissn/gomap/TreeDB/internal/typedkernel"
+)
+
+func TestInt64AggregateParityRowSelectionShapes(t *testing.T) {
+	values := []int64{-7, 2, 0, 5, -3, 11, 4, -9, 8, 6}
+	selections := map[string]typedcolumn.RowSelection{
+		"all":    mustSelection(typedcolumn.NewAllRowSelection(len(values))),
+		"range":  mustSelection(typedcolumn.NewRangeRowSelection(len(values), 2, 8)),
+		"ranges": mustSelection(typedcolumn.NewRangesRowSelection(len(values), []typedcolumn.RowRange{{Start: 1, End: 3}, {Start: 5, End: 8}})),
+		"bitmap": mustSelection(typedcolumn.NewBitmapRowSelection(len(values), []uint64{(1 << 0) | (1 << 2) | (1 << 5) | (1 << 9)})),
+		"sparse": mustSelection(typedcolumn.NewSparseRowSelection(len(values), []int{0, 3, 4, 9})),
+		"empty":  mustSelection(typedcolumn.NewEmptyRowSelection(len(values))),
+	}
+	ops := []typedkernel.AggregateOp{typedkernel.OpCountRows, typedkernel.OpCountNonNull, typedkernel.OpSum, typedkernel.OpAvg, typedkernel.OpMin, typedkernel.OpMax}
+	reg := typedkernel.DefaultRegistry()
+	for shape, selection := range selections {
+		want := expectedInt64(values, selection)
+		for _, op := range ops {
+			t.Run(shape+"/"+string(op), func(t *testing.T) {
+				prepared, err := reg.Dispatch(typedkernel.DispatchRequest{Operation: op, Semantic: int64Semantic(false, typedcolumn.EncodingRawInt64), Layout: int64Layout(false, typedcolumn.EncodingRawInt64, typedcolumn.CompressionNone)})
+				if err != nil {
+					t.Fatalf("dispatch: %v", err)
+				}
+				got, err := prepared.Reduce(typedkernel.ReduceRequest{Rows: len(values), Selection: selection, Int64Values: values}, nil)
+				if err != nil {
+					t.Fatalf("reduce: %v", err)
+				}
+				assertInt64Aggregate(t, op, got, want)
+			})
+		}
+	}
+}
+
+func TestInt64AggregateOverflow(t *testing.T) {
+	reg := typedkernel.DefaultRegistry()
+	prepared, err := reg.Dispatch(typedkernel.DispatchRequest{Operation: typedkernel.OpSum, Semantic: int64Semantic(false, typedcolumn.EncodingRawInt64), Layout: int64Layout(false, typedcolumn.EncodingRawInt64, typedcolumn.CompressionNone)})
+	if err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	selection := mustSelection(typedcolumn.NewAllRowSelection(2))
+	for name, values := range map[string][]int64{
+		"positive": {math.MaxInt64, 1},
+		"negative": {math.MinInt64, -1},
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := prepared.Reduce(typedkernel.ReduceRequest{Rows: len(values), Selection: selection, Int64Values: values}, nil)
+			if err == nil || !strings.Contains(err.Error(), "overflow") {
+				t.Fatalf("expected overflow error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestDispatchSemanticAndLayoutGates(t *testing.T) {
+	reg := typedkernel.DefaultRegistry()
+	tests := []struct {
+		name    string
+		op      typedkernel.AggregateOp
+		sem     columnsemantics.Descriptor
+		layout  columnlayout.Capabilities
+		wantErr string
+	}{
+		{
+			name:    "bool sum fails semantic gate",
+			op:      typedkernel.OpSum,
+			sem:     boolSemantic(),
+			layout:  boolLayout(),
+			wantErr: "semantic capability",
+		},
+		{
+			name:    "compressed int64 sum fails layout gate",
+			op:      typedkernel.OpSum,
+			sem:     int64Semantic(false, typedcolumn.EncodingRawInt64),
+			layout:  int64Layout(false, typedcolumn.EncodingRawInt64, typedcolumn.CompressionSnappy),
+			wantErr: "layout capability",
+		},
+		{
+			name:    "nullable int64 value aggregate remains fallback",
+			op:      typedkernel.OpSum,
+			sem:     int64Semantic(true, typedcolumn.EncodingNullableInt64),
+			layout:  int64Layout(true, typedcolumn.EncodingNullableInt64, typedcolumn.CompressionNone),
+			wantErr: "status=fallback",
+		},
+		{
+			name:    "nullable count non-null has no value-mask kernel yet",
+			op:      typedkernel.OpCountNonNull,
+			sem:     int64Semantic(true, typedcolumn.EncodingNullableInt64),
+			layout:  int64Layout(true, typedcolumn.EncodingNullableInt64, typedcolumn.CompressionNone),
+			wantErr: "no kernel registered",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := reg.Dispatch(typedkernel.DispatchRequest{Operation: tc.op, Semantic: tc.sem, Layout: tc.layout})
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("Dispatch error=%v, want containing %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestCountRowsAndCountNonNullDistinct(t *testing.T) {
+	reg := typedkernel.DefaultRegistry()
+	selection := mustSelection(typedcolumn.NewRangeRowSelection(10, 2, 7))
+	countRows, err := reg.Dispatch(typedkernel.DispatchRequest{Operation: typedkernel.OpCountRows, Semantic: int64Semantic(true, typedcolumn.EncodingNullableInt64), Layout: int64Layout(true, typedcolumn.EncodingNullableInt64, typedcolumn.CompressionNone)})
+	if err != nil {
+		t.Fatalf("count rows dispatch: %v", err)
+	}
+	rows, err := countRows.Reduce(typedkernel.ReduceRequest{Rows: 10, Selection: selection}, nil)
+	if err != nil {
+		t.Fatalf("count rows reduce: %v", err)
+	}
+	if rows.Rows != 5 || rows.NonNulls != 0 || rows.Op != typedkernel.OpCountRows {
+		t.Fatalf("count rows result=%+v", rows)
+	}
+
+	countNonNull, err := reg.Dispatch(typedkernel.DispatchRequest{Operation: typedkernel.OpCountNonNull, Semantic: int64Semantic(false, typedcolumn.EncodingRawInt64), Layout: int64Layout(false, typedcolumn.EncodingRawInt64, typedcolumn.CompressionNone)})
+	if err != nil {
+		t.Fatalf("count non-null dispatch: %v", err)
+	}
+	nonNull, err := countNonNull.Reduce(typedkernel.ReduceRequest{Rows: 10, Selection: selection, Int64Values: make([]int64, 10)}, nil)
+	if err != nil {
+		t.Fatalf("count non-null reduce: %v", err)
+	}
+	if nonNull.NonNulls != 5 || nonNull.Rows != 0 || nonNull.Op != typedkernel.OpCountNonNull {
+		t.Fatalf("count non-null result=%+v", nonNull)
+	}
+}
+
+func TestCallerOwnedFakeNonInt64KernelDispatch(t *testing.T) {
+	reg, err := typedkernel.NewRegistry(nil)
+	if err != nil {
+		t.Fatalf("new registry: %v", err)
+	}
+	reg, err = reg.WithKernel(typedkernel.KernelSpec{
+		Name:     "test.bool.count_non_null.fake",
+		Logical:  columnsemantics.LogicalBool,
+		Physical: typedcolumn.ColumnTypeBool,
+		Ops:      []typedkernel.AggregateOp{typedkernel.OpCountNonNull},
+		Reduce: func(op typedkernel.AggregateOp, req typedkernel.ReduceRequest, _ *typedkernel.Scratch) (typedkernel.AggregateResult, error) {
+			return typedkernel.AggregateResult{Op: op, NonNulls: int64(req.Selection.Count()) + 1000, HasValue: true}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("with fake kernel: %v", err)
+	}
+	prepared, err := reg.Dispatch(typedkernel.DispatchRequest{Operation: typedkernel.OpCountNonNull, Semantic: boolSemantic(), Layout: boolLayout()})
+	if err != nil {
+		t.Fatalf("dispatch fake bool kernel: %v", err)
+	}
+	selection := mustSelection(typedcolumn.NewSparseRowSelection(8, []int{1, 4, 7}))
+	got, err := prepared.Reduce(typedkernel.ReduceRequest{Rows: 8, Selection: selection}, nil)
+	if err != nil {
+		t.Fatalf("reduce fake bool kernel: %v", err)
+	}
+	if prepared.KernelName() != "test.bool.count_non_null.fake" || got.NonNulls != 1003 {
+		t.Fatalf("fake kernel name=%q result=%+v", prepared.KernelName(), got)
+	}
+}
+
+type expectedAggregate struct {
+	count int64
+	sum   int64
+	avg   float64
+	min   int64
+	max   int64
+	has   bool
+}
+
+func expectedInt64(values []int64, selection typedcolumn.RowSelection) expectedAggregate {
+	rows := selection.AppendRows(nil)
+	out := expectedAggregate{count: int64(len(rows))}
+	for _, row := range rows {
+		v := values[row]
+		out.sum += v
+		if !out.has || v < out.min {
+			out.min = v
+		}
+		if !out.has || v > out.max {
+			out.max = v
+		}
+		out.has = true
+	}
+	if out.count != 0 {
+		out.avg = float64(out.sum) / float64(out.count)
+	}
+	return out
+}
+
+func assertInt64Aggregate(t *testing.T, op typedkernel.AggregateOp, got typedkernel.AggregateResult, want expectedAggregate) {
+	t.Helper()
+	if got.Op != op {
+		t.Fatalf("op=%s want %s", got.Op, op)
+	}
+	switch op {
+	case typedkernel.OpCountRows:
+		if got.Rows != want.count || got.NonNulls != 0 {
+			t.Fatalf("count rows got=%+v want count=%d", got, want.count)
+		}
+	case typedkernel.OpCountNonNull:
+		if got.NonNulls != want.count || got.Rows != 0 {
+			t.Fatalf("count non-null got=%+v want count=%d", got, want.count)
+		}
+	case typedkernel.OpSum:
+		if got.Sum != want.sum || got.NonNulls != want.count || !got.HasValue {
+			t.Fatalf("sum got=%+v want sum=%d count=%d", got, want.sum, want.count)
+		}
+	case typedkernel.OpAvg:
+		if got.Sum != want.sum || got.NonNulls != want.count || got.Avg != want.avg || got.HasValue != want.has {
+			t.Fatalf("avg got=%+v want sum=%d count=%d avg=%f has=%v", got, want.sum, want.count, want.avg, want.has)
+		}
+	case typedkernel.OpMin:
+		if got.Min != want.min || got.NonNulls != want.count || got.HasValue != want.has {
+			t.Fatalf("min got=%+v want min=%d count=%d has=%v", got, want.min, want.count, want.has)
+		}
+	case typedkernel.OpMax:
+		if got.Max != want.max || got.NonNulls != want.count || got.HasValue != want.has {
+			t.Fatalf("max got=%+v want max=%d count=%d has=%v", got, want.max, want.count, want.has)
+		}
+	}
+}
+
+func mustSelection(selection typedcolumn.RowSelection, err error) typedcolumn.RowSelection {
+	if err != nil {
+		panic(err)
+	}
+	return selection
+}
+
+func int64Semantic(nullable bool, encoding typedcolumn.Encoding) columnsemantics.Descriptor {
+	return columnsemantics.Descriptor{Logical: columnsemantics.LogicalInt64, Physical: typedcolumn.ColumnTypeInt64, Encoding: encoding, Nullable: nullable}
+}
+
+func int64Layout(nullable bool, encoding typedcolumn.Encoding, compression typedcolumn.Compression) columnlayout.Capabilities {
+	return columnlayout.CapabilitiesFor(columnlayout.Descriptor{Logical: columnsemantics.LogicalInt64, Physical: typedcolumn.ColumnTypeInt64, Encoding: encoding, Compression: compression, Nullable: nullable, Defaultable: nullable})
+}
+
+func boolSemantic() columnsemantics.Descriptor {
+	return columnsemantics.Descriptor{Logical: columnsemantics.LogicalBool, Physical: typedcolumn.ColumnTypeBool, Encoding: typedcolumn.EncodingBoolBitpackRLE}
+}
+
+func boolLayout() columnlayout.Capabilities {
+	return columnlayout.CapabilitiesFor(columnlayout.Descriptor{Logical: columnsemantics.LogicalBool, Physical: typedcolumn.ColumnTypeBool, Encoding: typedcolumn.EncodingBoolBitpackRLE, Compression: typedcolumn.CompressionNone})
+}

--- a/TreeDB/internal/typedkernel/registry_test.go
+++ b/TreeDB/internal/typedkernel/registry_test.go
@@ -141,6 +141,33 @@ func TestInt64MinMaxDoNotAccumulateOverflowingSum(t *testing.T) {
 	}
 }
 
+func TestInt64CountNonNullRejectsCursorWithoutConsuming(t *testing.T) {
+	values := []int64{1, 2, 3}
+	builder := typedcolumn.NewGranuleBuilder(typedcolumn.Config{Encoding: typedcolumn.EncodingDeltaVarint, Compression: typedcolumn.CompressionNone})
+	granule, err := builder.BuildInt64(values)
+	if err != nil {
+		t.Fatalf("BuildInt64: %v", err)
+	}
+	granule.Payload = append(append([]byte(nil), granule.Payload...), 0)
+	granule.RawBytes = len(granule.Payload)
+	granule.StoredBytes = len(granule.Payload)
+	granule.PayloadRef.Length = len(granule.Payload)
+	var reader typedcolumn.GranuleReader
+	cursor, err := reader.Int64Cursor(granule)
+	if err != nil {
+		t.Fatalf("Int64Cursor with trailing bytes should be constructed before Finish: %v", err)
+	}
+	prepared, err := typedkernel.DefaultRegistry().Dispatch(typedkernel.DispatchRequest{Operation: typedkernel.OpCountNonNull, Semantic: int64Semantic(false, typedcolumn.EncodingDeltaVarint), Layout: int64Layout(false, typedcolumn.EncodingDeltaVarint, typedcolumn.CompressionNone)})
+	if err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	selection := mustSelection(typedcolumn.NewAllRowSelection(len(values)))
+	_, err = prepared.Reduce(typedkernel.ReduceRequest{Rows: len(values), Selection: selection, Int64Cursor: &cursor}, nil)
+	if err == nil || !strings.Contains(err.Error(), "does not accept int64 cursor") {
+		t.Fatalf("count non-null cursor err=%v want explicit cursor rejection", err)
+	}
+}
+
 func TestInt64EmptySelectionDoesNotRequireValues(t *testing.T) {
 	reg := typedkernel.DefaultRegistry()
 	selection := mustSelection(typedcolumn.NewEmptyRowSelection(10))

--- a/TreeDB/internal/typedkernel/registry_test.go
+++ b/TreeDB/internal/typedkernel/registry_test.go
@@ -61,6 +61,69 @@ func TestInt64AggregateOverflow(t *testing.T) {
 	}
 }
 
+func TestInt64MinMaxDoNotAccumulateOverflowingSum(t *testing.T) {
+	reg := typedkernel.DefaultRegistry()
+	selection := mustSelection(typedcolumn.NewAllRowSelection(2))
+	tests := []struct {
+		name string
+		op   typedkernel.AggregateOp
+		vals []int64
+		want int64
+	}{
+		{name: "min positive sum overflow", op: typedkernel.OpMin, vals: []int64{math.MaxInt64, 1}, want: 1},
+		{name: "max positive sum overflow", op: typedkernel.OpMax, vals: []int64{math.MaxInt64, 1}, want: math.MaxInt64},
+		{name: "min negative sum overflow", op: typedkernel.OpMin, vals: []int64{math.MinInt64, -1}, want: math.MinInt64},
+		{name: "max negative sum overflow", op: typedkernel.OpMax, vals: []int64{math.MinInt64, -1}, want: -1},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			prepared, err := reg.Dispatch(typedkernel.DispatchRequest{Operation: tc.op, Semantic: int64Semantic(false, typedcolumn.EncodingRawInt64), Layout: int64Layout(false, typedcolumn.EncodingRawInt64, typedcolumn.CompressionNone)})
+			if err != nil {
+				t.Fatalf("dispatch: %v", err)
+			}
+			got, err := prepared.Reduce(typedkernel.ReduceRequest{Rows: len(tc.vals), Selection: selection, Int64Values: tc.vals}, nil)
+			if err != nil {
+				t.Fatalf("reduce: %v", err)
+			}
+			if !got.HasValue || got.NonNulls != 2 {
+				t.Fatalf("result metadata=%+v", got)
+			}
+			if tc.op == typedkernel.OpMin && got.Min != tc.want {
+				t.Fatalf("min=%d want %d", got.Min, tc.want)
+			}
+			if tc.op == typedkernel.OpMax && got.Max != tc.want {
+				t.Fatalf("max=%d want %d", got.Max, tc.want)
+			}
+		})
+	}
+}
+
+func TestInt64EmptySelectionDoesNotRequireValues(t *testing.T) {
+	reg := typedkernel.DefaultRegistry()
+	selection := mustSelection(typedcolumn.NewEmptyRowSelection(10))
+	for _, op := range []typedkernel.AggregateOp{typedkernel.OpSum, typedkernel.OpAvg, typedkernel.OpMin, typedkernel.OpMax} {
+		t.Run(string(op), func(t *testing.T) {
+			prepared, err := reg.Dispatch(typedkernel.DispatchRequest{Operation: op, Semantic: int64Semantic(false, typedcolumn.EncodingRawInt64), Layout: int64Layout(false, typedcolumn.EncodingRawInt64, typedcolumn.CompressionNone)})
+			if err != nil {
+				t.Fatalf("dispatch: %v", err)
+			}
+			got, err := prepared.Reduce(typedkernel.ReduceRequest{Rows: 10, Selection: selection}, nil)
+			if err != nil {
+				t.Fatalf("reduce with nil values: %v", err)
+			}
+			if got.NonNulls != 0 {
+				t.Fatalf("non-nulls=%d want 0", got.NonNulls)
+			}
+			if op == typedkernel.OpSum && !got.HasValue {
+				t.Fatalf("empty sum should be additive identity: %+v", got)
+			}
+			if op != typedkernel.OpSum && got.HasValue {
+				t.Fatalf("empty %s should not have a value: %+v", op, got)
+			}
+		})
+	}
+}
+
 func TestDispatchSemanticAndLayoutGates(t *testing.T) {
 	reg := typedkernel.DefaultRegistry()
 	tests := []struct {
@@ -70,6 +133,13 @@ func TestDispatchSemanticAndLayoutGates(t *testing.T) {
 		layout  columnlayout.Capabilities
 		wantErr string
 	}{
+		{
+			name:    "semantic layout descriptor mismatch fails closed",
+			op:      typedkernel.OpCountRows,
+			sem:     int64Semantic(false, typedcolumn.EncodingRawInt64),
+			layout:  boolLayout(),
+			wantErr: "descriptor mismatch",
+		},
 		{
 			name:    "bool sum fails semantic gate",
 			op:      typedkernel.OpSum,

--- a/TreeDB/internal/typedkernel/registry_test.go
+++ b/TreeDB/internal/typedkernel/registry_test.go
@@ -214,6 +214,18 @@ func TestInt64EmptySelectionValidatesCursorRequests(t *testing.T) {
 	if _, err := prepared.Reduce(typedkernel.ReduceRequest{Rows: len(values), Selection: selection, Int64Cursor: &cursor}, nil); err == nil || !strings.Contains(err.Error(), "decoded rows=0 want=3") {
 		t.Fatalf("empty cursor reduce err=%v want cursor validation failure", err)
 	}
+
+	shortGranule, err := builder.BuildInt64([]int64{99})
+	if err != nil {
+		t.Fatalf("BuildInt64 short: %v", err)
+	}
+	shortCursor, err := reader.Int64Cursor(shortGranule)
+	if err != nil {
+		t.Fatalf("short Int64Cursor: %v", err)
+	}
+	if _, err := prepared.Reduce(typedkernel.ReduceRequest{Rows: len(values), Selection: selection, Int64Cursor: &shortCursor}, nil); err == nil || !strings.Contains(err.Error(), "int64 cursor rows=1 want 3") {
+		t.Fatalf("empty short-cursor reduce err=%v want cursor row-domain mismatch", err)
+	}
 }
 
 func TestDispatchSemanticAndLayoutGates(t *testing.T) {

--- a/TreeDB/internal/typedkernel/registry_test.go
+++ b/TreeDB/internal/typedkernel/registry_test.go
@@ -194,6 +194,28 @@ func TestInt64EmptySelectionDoesNotRequireValues(t *testing.T) {
 	}
 }
 
+func TestInt64EmptySelectionValidatesCursorRequests(t *testing.T) {
+	values := []int64{1, 2, 3}
+	builder := typedcolumn.NewGranuleBuilder(typedcolumn.Config{Encoding: typedcolumn.EncodingDeltaVarint, Compression: typedcolumn.CompressionNone})
+	granule, err := builder.BuildInt64(values)
+	if err != nil {
+		t.Fatalf("BuildInt64: %v", err)
+	}
+	var reader typedcolumn.GranuleReader
+	cursor, err := reader.Int64Cursor(granule)
+	if err != nil {
+		t.Fatalf("Int64Cursor: %v", err)
+	}
+	prepared, err := typedkernel.DefaultRegistry().Dispatch(typedkernel.DispatchRequest{Operation: typedkernel.OpSum, Semantic: int64Semantic(false, typedcolumn.EncodingDeltaVarint), Layout: int64Layout(false, typedcolumn.EncodingDeltaVarint, typedcolumn.CompressionNone)})
+	if err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	selection := mustSelection(typedcolumn.NewEmptyRowSelection(len(values)))
+	if _, err := prepared.Reduce(typedkernel.ReduceRequest{Rows: len(values), Selection: selection, Int64Cursor: &cursor}, nil); err == nil || !strings.Contains(err.Error(), "decoded rows=0 want=3") {
+		t.Fatalf("empty cursor reduce err=%v want cursor validation failure", err)
+	}
+}
+
 func TestDispatchSemanticAndLayoutGates(t *testing.T) {
 	reg := typedkernel.DefaultRegistry()
 	tests := []struct {
@@ -274,6 +296,21 @@ func TestCountRowsAndCountNonNullDistinct(t *testing.T) {
 	}
 	if nonNull.NonNulls != 5 || nonNull.Rows != 0 || nonNull.Op != typedkernel.OpCountNonNull {
 		t.Fatalf("count non-null result=%+v", nonNull)
+	}
+}
+
+func TestGenericCountRowsDispatchesForNonInt64(t *testing.T) {
+	prepared, err := typedkernel.DefaultRegistry().Dispatch(typedkernel.DispatchRequest{Operation: typedkernel.OpCountRows, Semantic: boolSemantic(), Layout: boolLayout()})
+	if err != nil {
+		t.Fatalf("dispatch bool count rows: %v", err)
+	}
+	selection := mustSelection(typedcolumn.NewRangeRowSelection(8, 1, 6))
+	got, err := prepared.Reduce(typedkernel.ReduceRequest{Rows: 8, Selection: selection}, nil)
+	if err != nil {
+		t.Fatalf("reduce bool count rows: %v", err)
+	}
+	if prepared.KernelName() != "generic.count_rows.v1" || got.Rows != 5 || got.NonNulls != 0 {
+		t.Fatalf("kernel=%q result=%+v want generic count rows", prepared.KernelName(), got)
 	}
 }
 

--- a/TreeDB/internal/typedkernel/registry_test.go
+++ b/TreeDB/internal/typedkernel/registry_test.go
@@ -41,6 +41,49 @@ func TestInt64AggregateParityRowSelectionShapes(t *testing.T) {
 	}
 }
 
+func TestInt64AggregateCursorParityRowSelectionShapes(t *testing.T) {
+	values := []int64{-7, 2, 0, 5, -3, 11, 4, -9, 8, 6}
+	selections := map[string]typedcolumn.RowSelection{
+		"all":    mustSelection(typedcolumn.NewAllRowSelection(len(values))),
+		"range":  mustSelection(typedcolumn.NewRangeRowSelection(len(values), 2, 8)),
+		"ranges": mustSelection(typedcolumn.NewRangesRowSelection(len(values), []typedcolumn.RowRange{{Start: 1, End: 3}, {Start: 5, End: 8}})),
+		"bitmap": mustSelection(typedcolumn.NewBitmapRowSelection(len(values), []uint64{(1 << 0) | (1 << 2) | (1 << 5) | (1 << 9)})),
+		"sparse": mustSelection(typedcolumn.NewSparseRowSelection(len(values), []int{0, 3, 4, 9})),
+	}
+	reg := typedkernel.DefaultRegistry()
+	for _, enc := range []typedcolumn.Encoding{typedcolumn.EncodingRawInt64, typedcolumn.EncodingDeltaVarint, typedcolumn.EncodingDoubleDeltaVarint} {
+		enc := enc
+		t.Run(enc.String(), func(t *testing.T) {
+			builder := typedcolumn.NewGranuleBuilder(typedcolumn.Config{Encoding: enc, Compression: typedcolumn.CompressionNone})
+			granule, err := builder.BuildInt64(values)
+			if err != nil {
+				t.Fatalf("BuildInt64: %v", err)
+			}
+			for shape, selection := range selections {
+				shape := shape
+				selection := selection
+				t.Run(shape, func(t *testing.T) {
+					prepared, err := reg.Dispatch(typedkernel.DispatchRequest{Operation: typedkernel.OpSum, Semantic: int64Semantic(false, enc), Layout: int64Layout(false, enc, typedcolumn.CompressionNone)})
+					if err != nil {
+						t.Fatalf("dispatch: %v", err)
+					}
+					var reader typedcolumn.GranuleReader
+					cursor, err := reader.Int64Cursor(granule)
+					if err != nil {
+						t.Fatalf("Int64Cursor: %v", err)
+					}
+					got, err := prepared.Reduce(typedkernel.ReduceRequest{Rows: len(values), Selection: selection, Int64Cursor: &cursor}, nil)
+					if err != nil {
+						t.Fatalf("reduce cursor: %v", err)
+					}
+					want := expectedInt64(values, selection)
+					assertInt64Aggregate(t, typedkernel.OpSum, got, want)
+				})
+			}
+		})
+	}
+}
+
 func TestInt64AggregateOverflow(t *testing.T) {
 	reg := typedkernel.DefaultRegistry()
 	prepared, err := reg.Dispatch(typedkernel.DispatchRequest{Operation: typedkernel.OpSum, Semantic: int64Semantic(false, typedcolumn.EncodingRawInt64), Layout: int64Layout(false, typedcolumn.EncodingRawInt64, typedcolumn.CompressionNone)})


### PR DESCRIPTION
Closes #1839.

## Summary

- Adds `TreeDB/internal/typedkernel`, a shared typed-column aggregate dispatch/reducer framework with immutable/caller-owned registries, semantic+layout capability gates, and a test-only extension path for non-int64 kernels.
- Wires prepared int64 predicate aggregates to a prepared `typedkernel.PreparedReducer` selected outside hot row loops.
- Adds kernel diagnostics for full-covered, selected, cursor, and fallback blocks, including benchmark metric reporting.
- Keeps #1849 direct-view/fast-decode as the only direct-view boundary; raw direct-view paths call typedkernel reducers over validated views, and delta/double-delta full-covered paths retain the existing streaming reducer fast path.
- Adds tests for selection shapes, overflow/negative values, nullable count semantics, unsupported gates, mutation/visibility, and all-pruned zero-payload behavior.

## Scope / non-goals

- No #1840 persisted stats/block sums.
- No #1841 generic pruning/index strategy.
- No production bool/string/float/vector kernels (#1845-#1848); only a test fake verifies extensibility.
- No new public column-store value types.
- No hidden global mutable cache; `DefaultRegistry` returns an immutable copy and callers can own explicit registries/scratch.

## Validation

- `git diff --check origin/main...HEAD`
- `go test -count=1 ./TreeDB/internal/typedkernel ./TreeDB/collections -run 'TestInt64Aggregate|TestDispatchSemanticAndLayoutGates|TestCountRowsAndCountNonNullDistinct|TestCallerOwnedFakeNonInt64KernelDispatch|TestTypedColumnInt64PreparedKernelOverflowAndNegativeValues|TestTypedColumnInt64PreparedDeltaKernelDiagnosticsFullPartialPruned|TestTypedColumnInt64PreparedRawKernelSelectionShapes|TestTypedColumnInt64PreparedSessionCachedVerifyVisibilityUsesKernelPath|TestTypedColumnInt64PreparedDeltaUsesStreamingCursor|TestTypedColumnInt64RawLayoutRoundTripReopenQuery'`
- `go test -count=1 ./TreeDB/internal/typedkernel ./TreeDB/internal/typeddecode ./TreeDB/internal/typedcolumn ./TreeDB/collections`
- `go test -count=1 ./TreeDB/docs`
- `go test -count=1 ./TreeDB/internal/typedkernel ./TreeDB/collections -run 'TestInt64EmptySelectionValidatesCursorRequests|TestGenericCountRowsDispatchesForNonInt64|TestTypedColumnPreparedStateMultiColumnMismatchFailsClosed|TestTypedColumnInt64PreparedKernelOverflowAndNegativeValues|TestTypedColumnInt64PreparedDeltaKernelDiagnosticsFullPartialPruned|TestTypedColumnInt64PreparedSessionCachedVerifyVisibilityUsesKernelPath'`
- `go test -count=1 ./TreeDB/...`

## Benchmark / profile evidence

Artifacts were captured under `artifacts/1839/` in the manager worktree.

Prepared-hot 1,048,576-row delta layout, cached_verify, Apple M3/darwin arm64:

| dist | shape | base ns/op | head ns/op | note |
| --- | ---: | ---: | ---: | --- |
| clustered | no_filter | 4,315,062 | 4,335,108 | equivalent; 128 full-covered kernel blocks |
| clustered | all_match | 4,307,458 | 4,322,585 | equivalent; 128 full-covered kernel blocks |
| clustered | all_pruned | 6,342 | 6,351 | payload-free prune; 0 kernel blocks |
| clustered | exact | 73,994 | 76,142 | equivalent; 1 explicit fallback block |
| clustered | range_1pct | 111,023 | 111,277 | equivalent; 1 full-covered kernel + 1 fallback block |
| clustered | wide_10pct | 482,749 | 479,757 | slight improvement; 12 full-covered kernel blocks |
| random | range_1pct | 9,218,721 | 9,212,232 | equivalent; partial blocks classified fallback |
| hotspot | range_1pct | 10,283,427 | 11,027,735 | noisy partial fallback case; min run +~1.7%, no alloc regression |

Hot prepared scans remain `512 B/op` and `4 allocs/op`. CPU profiles show all-match hot scans dominated by `typedcolumn.CountSumInt64`/uvarint decode; predicate/materialization overhead remains absent because #1849 already installed the full-covered streaming fast path. #1839 therefore lands the shared dispatch/reducer substrate and diagnostics without claiming a new full-covered throughput step beyond that prior optimization.

## Review notes

- K1 framework and K2 integration were reviewed by xhigh subagents; blocking K2 findings were fixed before integration.
- Final coordinator review reran focused tests plus full `./TreeDB/...`.
- AI reviews requested after PR open.

Current head: `f48cbf1e692631f393cc09cd23fda5f76cf33252`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Kernel dispatch framework for optimized int64 aggregates and prepared kernel-based aggregation execution.

* **Diagnostics**
  * Aggregate diagnostics now include kernel block metrics (full/selected/cursor/fallback counts).

* **Documentation**
  * Added spec describing kernel dispatch contract, registry model, and supported int64 aggregates.

* **Tests**
  * Expanded tests for kernel dispatch, int64 aggregate parity, overflow handling, selection shapes, prepared-kernel behaviors, and visibility paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->