### PR TITLE
typedcolumn: add durable int64 stats

### DIFF
--- a/TreeDB/collections/typed_column_adapter.go
+++ b/TreeDB/collections/typed_column_adapter.go
@@ -163,6 +163,7 @@ func typedColumnAdapterMapField(field TypedStorageField) (typedColumnAdapterColu
 		Encoding:       mapping.Encoding,
 		Compression:    typedcolumn.CompressionNone,
 		CompressionSet: true,
+		StatsDisabled:  field.ValueType != ColumnStoreValueInt64,
 	}
 	switch field.ValueType {
 	case ColumnStoreValueFloat32Vector:
@@ -242,6 +243,7 @@ func buildTypedColumnAdapterPart(opts typedColumnAdapterOptions, rows []typedCol
 		Encoding:       typedcolumn.EncodingRawInt64,
 		Compression:    typedcolumn.CompressionNone,
 		CompressionSet: true,
+		StatsDisabled:  true,
 	})
 	for _, column := range columns {
 		defs = append(defs, column.Definition)

--- a/TreeDB/collections/typed_column_conformance_test.go
+++ b/TreeDB/collections/typed_column_conformance_test.go
@@ -45,7 +45,7 @@ func TestTypedColumnAdapterSemanticConformanceMatrix(t *testing.T) {
 			checks: []capabilityCheck{
 				{op: columnsemantics.OpOrderedRange, status: columnsemantics.StatusSupported, reason: columnsemantics.ReasonSupported},
 				{op: columnsemantics.OpSum, status: columnsemantics.StatusSupported, reason: columnsemantics.ReasonSupported},
-				{op: columnsemantics.OpStatsSum, status: columnsemantics.StatusUnsupported, reason: columnsemantics.ReasonStatsPayloadUnsupported},
+				{op: columnsemantics.OpStatsSum, status: columnsemantics.StatusSupported, reason: columnsemantics.ReasonSupported},
 			},
 		},
 		{
@@ -186,6 +186,14 @@ func TestTypedColumnAdapterSemanticConformanceSmallRows(t *testing.T) {
 	part, err := buildTypedColumnAdapterPart(typedColumnAdapterOptions{PartID: 1842, RowsPerGranule: 1, Fields: fields}, rows)
 	if err != nil {
 		t.Fatalf("buildTypedColumnAdapterPart: %v", err)
+	}
+	if _, ok := part.Part.ColumnStats.Int64Column("count"); !ok {
+		t.Fatalf("logical int64 column missing stats: %+v", part.Part.ColumnStats)
+	}
+	for _, name := range []string{"score32", "score64", typedColumnAdapterPrimaryIDColumn} {
+		if _, ok := part.Part.ColumnStats.Int64Column(name); ok {
+			t.Fatalf("column %q emitted int64 stats despite non-int64 semantics: %+v", name, part.Part.ColumnStats)
+		}
 	}
 	if got := part.Dictionary["kind"]; got["alpha"] != 0 || got["beta"] != 1 {
 		t.Fatalf("dictionary=%+v want sorted string codes", got)

--- a/TreeDB/collections/typed_column_int64_scan.go
+++ b/TreeDB/collections/typed_column_int64_scan.go
@@ -71,50 +71,57 @@ type TypedColumnInt64PredicateScanDiagnostics struct {
 	SelectionSparseBlocks int
 	SelectionCompositions int
 
-	DirectTypedColumnAssetReads int
-	FullAssetReads              int
-	FallbackReads               int
-	CodesMatched                int
-	DictionaryBytesDecoded      uint64
-	FullAssetBytes              uint64
-	SectionBytesRead            uint64
-	RangeBytesRead              uint64
-	MappedBytes                 uint64
-	HeapCopyBytes               uint64
-	DecodedMetadataBytes        uint64
-	DecodedHeapCopyBytes        uint64
-	MaterializedBytes           uint64
-	FastDecodeDirectViewPlans   int
-	FastDecodeStreamingPlans    int
-	FastDecodeMaterializePlans  int
-	FastDecodeUnsupportedPlans  int
-	DirectViewSuccesses         int
-	DirectViewFailures          int
-	KernelBlocks                int
-	KernelFullCoveredBlocks     int
-	KernelSelectedBlocks        int
-	KernelCursorBlocks          int
-	KernelFallbackBlocks        int
-	FastDecodeFallbackReason    string
-	DirectViewCertified         int
-	StreamingCertified          int
-	StatsCertified              int
-	PruningCertified            int
-	CertificationFailures       int
-	CertificationFailureReason  string
-	PhysicalBytesScanned        int64
-	RowLocatorDecodes           int
-	PhysicalRowIDLookups        int
-	PhysicalRowAssetReads       int
-	RowMaterializations         int
-	DocumentMaterializations    int
-	DocumentReconstructions     int
-	SegmentFileCacheHits        uint64
-	SegmentFileCacheMisses      uint64
-	ColumnAssetReadIntegrity    string
-	Fallback                    bool
-	FallbackReason              string
-	ScanNanos                   int64
+	DirectTypedColumnAssetReads  int
+	FullAssetReads               int
+	FallbackReads                int
+	CodesMatched                 int
+	DictionaryBytesDecoded       uint64
+	FullAssetBytes               uint64
+	SectionBytesRead             uint64
+	RangeBytesRead               uint64
+	MappedBytes                  uint64
+	HeapCopyBytes                uint64
+	DecodedMetadataBytes         uint64
+	DecodedHeapCopyBytes         uint64
+	MaterializedBytes            uint64
+	FastDecodeDirectViewPlans    int
+	FastDecodeStreamingPlans     int
+	FastDecodeMaterializePlans   int
+	FastDecodeUnsupportedPlans   int
+	DirectViewSuccesses          int
+	DirectViewFailures           int
+	KernelBlocks                 int
+	KernelFullCoveredBlocks      int
+	KernelSelectedBlocks         int
+	KernelCursorBlocks           int
+	KernelFallbackBlocks         int
+	StatsBlocks                  int
+	StatsFullCoveredBlocks       int
+	StatsFallbackBlocks          int
+	StatsRows                    int
+	StatsFallbackReason          string
+	StatsValidationFailures      int
+	StatsValidationFailureReason string
+	FastDecodeFallbackReason     string
+	DirectViewCertified          int
+	StreamingCertified           int
+	StatsCertified               int
+	PruningCertified             int
+	CertificationFailures        int
+	CertificationFailureReason   string
+	PhysicalBytesScanned         int64
+	RowLocatorDecodes            int
+	PhysicalRowIDLookups         int
+	PhysicalRowAssetReads        int
+	RowMaterializations          int
+	DocumentMaterializations     int
+	DocumentReconstructions      int
+	SegmentFileCacheHits         uint64
+	SegmentFileCacheMisses       uint64
+	ColumnAssetReadIntegrity     string
+	Fallback                     bool
+	FallbackReason               string
+	ScanNanos                    int64
 }
 
 type TypedColumnInt64PredicateScanResult struct {
@@ -960,6 +967,17 @@ func addTypedColumnInt64PredicateAggregateDiagnostics(dst *TypedColumnInt64Predi
 	dst.KernelSelectedBlocks += src.KernelSelectedBlocks
 	dst.KernelCursorBlocks += src.KernelCursorBlocks
 	dst.KernelFallbackBlocks += src.KernelFallbackBlocks
+	dst.StatsBlocks += src.StatsBlocks
+	dst.StatsFullCoveredBlocks += src.StatsFullCoveredBlocks
+	dst.StatsFallbackBlocks += src.StatsFallbackBlocks
+	dst.StatsRows += src.StatsRows
+	if src.StatsFallbackReason != "" {
+		dst.StatsFallbackReason = src.StatsFallbackReason
+	}
+	dst.StatsValidationFailures += src.StatsValidationFailures
+	if src.StatsValidationFailureReason != "" {
+		dst.StatsValidationFailureReason = src.StatsValidationFailureReason
+	}
 	if src.FastDecodeFallbackReason != "" {
 		dst.FastDecodeFallbackReason = src.FastDecodeFallbackReason
 	}

--- a/TreeDB/collections/typed_column_int64_scan_test.go
+++ b/TreeDB/collections/typed_column_int64_scan_test.go
@@ -696,6 +696,91 @@ func TestTypedColumnInt64PreparedCertificationDiagnosticsAndClose(t *testing.T) 
 	}
 }
 
+func TestTypedColumnInt64PreparedStatsRoundTripReopen(t *testing.T) {
+	dir := t.TempDir()
+	if err := backenddb.SaveFormatConfig(dir, backenddb.FormatConfig{RequiredFeatures: []string{backenddb.RequiredFeatureCommandWALV1}}); err != nil {
+		t.Fatalf("SaveFormatConfig: %v", err)
+	}
+	d := openCollectionCommandWALDB(t, dir)
+	col := createTypedColumnInt64ScanCollection(t, d)
+	insertTypedColumnInt64ScanRows(t, col, []int64{11, 12, 13, 14})
+	if err := d.Checkpoint(); err != nil {
+		_ = d.Close()
+		t.Fatalf("Checkpoint: %v", err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	reopened := openCollectionCommandWALDB(t, dir)
+	defer func() { _ = reopened.Close() }()
+	reopenedCol, err := NewCollectionManager(reopened).OpenCollection("events")
+	if err != nil {
+		t.Fatalf("OpenCollection: %v", err)
+	}
+	session, err := reopenedCol.PrepareTypedColumnInt64PredicateAggregate(TypedColumnInt64PredicateAggregateRequest{Column: "time_us", Kind: TypedColumnInt64PredicateAll, ColumnAssetReadIntegrity: ColumnAssetReadIntegrityCachedVerify})
+	if err != nil {
+		t.Fatalf("Prepare all stats: %v", err)
+	}
+	all, err := session.Run()
+	if closeErr := session.Close(); closeErr != nil {
+		t.Fatalf("Close all stats: %v", closeErr)
+	}
+	if err != nil {
+		t.Fatalf("Run all stats: %v", err)
+	}
+	assertTypedColumnInt64Aggregate(t, all, 4, 50)
+	if all.Diagnostics.StatsBlocks == 0 || all.Diagnostics.BlocksDecoded != 0 || all.Diagnostics.RowsScanned != 0 || all.Diagnostics.RangeBytesRead != 0 || all.Diagnostics.KernelBlocks != 0 {
+		t.Fatalf("all diagnostics=%+v want durable stats with no payload decode", all.Diagnostics)
+	}
+
+	rangeSession, err := reopenedCol.PrepareTypedColumnInt64PredicateAggregate(TypedColumnInt64PredicateAggregateRequest{Column: "time_us", Kind: TypedColumnInt64PredicateRange, Low: 10, High: 20, ColumnAssetReadIntegrity: ColumnAssetReadIntegrityCachedVerify})
+	if err != nil {
+		t.Fatalf("Prepare full-covered range stats: %v", err)
+	}
+	covered, err := rangeSession.Run()
+	if closeErr := rangeSession.Close(); closeErr != nil {
+		t.Fatalf("Close range stats: %v", closeErr)
+	}
+	if err != nil {
+		t.Fatalf("Run full-covered range stats: %v", err)
+	}
+	assertTypedColumnInt64Aggregate(t, covered, 4, 50)
+	if covered.Diagnostics.StatsBlocks == 0 || covered.Diagnostics.BlocksDecoded != 0 || covered.Diagnostics.StatsFallbackBlocks != 0 {
+		t.Fatalf("range diagnostics=%+v want full-covered durable stats", covered.Diagnostics)
+	}
+}
+
+func TestTypedColumnInt64PreparedStatsCorruptionFailsClosed(t *testing.T) {
+	d, col := setupTypedColumnInt64ScanCollection(t)
+	defer func() { _ = d.Close() }()
+	insertTypedColumnInt64ScanRows(t, col, []int64{1, 2, 3})
+	refs := typedColumnPartRefs1755(columnManifestAssetRefsForCollectionM12A(t, d, col))
+	if len(refs) != 1 {
+		t.Fatalf("typed-column refs=%+v want one", refs)
+	}
+	raw, err := readColumnPhysicalAssetFromManager(d.ColumnAssetRootDir(), refs[0])
+	if err != nil {
+		t.Fatalf("read typed-column asset: %v", err)
+	}
+	image, err := typedcolumn.ParseColumnPartImage(raw)
+	if err != nil {
+		t.Fatalf("ParseColumnPartImage: %v", err)
+	}
+	statsSection, ok, err := image.ColumnStatsSection()
+	if err != nil || !ok {
+		t.Fatalf("ColumnStatsSection ok=%v err=%v", ok, err)
+	}
+	corruptAt := int64(statsSection.Offset + statsSection.Length - 1)
+	var corrupt [1]byte
+	corrupt[0] = raw[corruptAt] ^ 0xff
+	writeColumnAssetBytesAtRelativeOffset(t, d, refs[0], corruptAt, corrupt[:])
+	_, err = col.PrepareTypedColumnInt64PredicateAggregate(TypedColumnInt64PredicateAggregateRequest{Column: "time_us", Kind: TypedColumnInt64PredicateAll, ColumnAssetReadIntegrity: ColumnAssetReadIntegritySkipChecksums})
+	if err == nil || !strings.Contains(err.Error(), "stats validation") || !strings.Contains(err.Error(), typedcolumn.ColumnStatsReasonChecksumMismatch) {
+		t.Fatalf("Prepare corrupt stats err=%v want fail-closed stats checksum", err)
+	}
+}
+
 func TestTypedColumnInt64PreparedDeltaUsesStreamingCursor(t *testing.T) {
 	d, col := setupTypedColumnInt64ScanCollection(t)
 	defer func() { _ = d.Close() }()
@@ -734,8 +819,8 @@ func TestTypedColumnInt64PreparedKernelOverflowAndNegativeValues(t *testing.T) {
 		t.Fatalf("Run negative values: %v", err)
 	}
 	assertTypedColumnInt64Aggregate(t, negative, 3, -25)
-	if negative.Diagnostics.KernelBlocks == 0 {
-		t.Fatalf("negative diagnostics=%+v want prepared kernel path", negative.Diagnostics)
+	if negative.Diagnostics.StatsBlocks == 0 || negative.Diagnostics.BlocksDecoded != 0 || negative.Diagnostics.KernelBlocks != 0 {
+		t.Fatalf("negative diagnostics=%+v want prepared durable stats path", negative.Diagnostics)
 	}
 
 	overflowDB, overflowCol := setupTypedColumnInt64ScanCollection(t)
@@ -771,8 +856,8 @@ func TestTypedColumnInt64PreparedDeltaKernelDiagnosticsFullPartialPruned(t *test
 		t.Fatalf("Run all: %v", err)
 	}
 	assertTypedColumnInt64Aggregate(t, all, 6, 21)
-	if all.Diagnostics.KernelBlocks == 0 || all.Diagnostics.KernelFullCoveredBlocks == 0 || all.Diagnostics.KernelFallbackBlocks != 0 {
-		t.Fatalf("all diagnostics=%+v want full-covered streaming kernel fast path", all.Diagnostics)
+	if all.Diagnostics.StatsBlocks == 0 || all.Diagnostics.StatsFullCoveredBlocks == 0 || all.Diagnostics.BlocksDecoded != 0 || all.Diagnostics.KernelBlocks != 0 || all.Diagnostics.KernelFallbackBlocks != 0 {
+		t.Fatalf("all diagnostics=%+v want full-covered durable stats fast path", all.Diagnostics)
 	}
 
 	partialSession, err := col.PrepareTypedColumnInt64PredicateAggregate(TypedColumnInt64PredicateAggregateRequest{Column: "time_us", Kind: TypedColumnInt64PredicateRange, Low: 3, High: 4, ColumnAssetReadIntegrity: ColumnAssetReadIntegrityCachedVerify})
@@ -787,8 +872,8 @@ func TestTypedColumnInt64PreparedDeltaKernelDiagnosticsFullPartialPruned(t *test
 		t.Fatalf("Run partial: %v", err)
 	}
 	assertTypedColumnInt64Aggregate(t, partial, 2, 7)
-	if partial.Diagnostics.KernelFallbackBlocks == 0 || partial.Diagnostics.KernelCursorBlocks != 0 {
-		t.Fatalf("partial diagnostics=%+v want explicit partial streaming fallback classification", partial.Diagnostics)
+	if partial.Diagnostics.StatsBlocks != 0 || partial.Diagnostics.StatsFallbackBlocks == 0 || partial.Diagnostics.KernelFallbackBlocks == 0 || partial.Diagnostics.KernelCursorBlocks != 0 {
+		t.Fatalf("partial diagnostics=%+v want stats fallback plus explicit partial streaming fallback classification", partial.Diagnostics)
 	}
 
 	prunedSession, err := col.PrepareTypedColumnInt64PredicateAggregate(TypedColumnInt64PredicateAggregateRequest{Column: "time_us", Kind: TypedColumnInt64PredicateEqual, Value: 99, ColumnAssetReadIntegrity: ColumnAssetReadIntegrityCachedVerify})
@@ -849,7 +934,11 @@ func TestTypedColumnInt64PreparedRawKernelSelectionShapes(t *testing.T) {
 				t.Fatalf("prepared Run: %v", err)
 			}
 			assertTypedColumnInt64Aggregate(t, prepared, direct.Count, direct.Sum)
-			if prepared.Diagnostics.KernelBlocks == 0 || prepared.Diagnostics.KernelSelectedBlocks+prepared.Diagnostics.KernelFullCoveredBlocks == 0 || prepared.Diagnostics.KernelFallbackBlocks != 0 {
+			if tc.wantShape == "all" {
+				if prepared.Diagnostics.StatsBlocks == 0 || prepared.Diagnostics.BlocksDecoded != 0 || prepared.Diagnostics.KernelBlocks != 0 {
+					t.Fatalf("prepared diagnostics=%+v want raw all-selection durable stats reducer", prepared.Diagnostics)
+				}
+			} else if prepared.Diagnostics.KernelBlocks == 0 || prepared.Diagnostics.KernelSelectedBlocks+prepared.Diagnostics.KernelFullCoveredBlocks == 0 || prepared.Diagnostics.KernelFallbackBlocks != 0 {
 				t.Fatalf("prepared diagnostics=%+v want raw direct-view typedkernel reducer", prepared.Diagnostics)
 			}
 			switch tc.wantShape {
@@ -1553,8 +1642,8 @@ func TestTypedColumnInt64PreparedSessionCachedVerifyVisibilityUsesKernelPath(t *
 		t.Fatalf("Run: %v", err)
 	}
 	assertTypedColumnInt64Aggregate(t, result, 2, 65)
-	if result.Diagnostics.MutationParts == 0 || result.Diagnostics.SelectionCompositions == 0 || result.Diagnostics.KernelBlocks == 0 || result.Diagnostics.KernelCursorBlocks == 0 {
-		t.Fatalf("diagnostics=%+v want cached-verify targeted kernel+visibility path", result.Diagnostics)
+	if result.Diagnostics.MutationParts == 0 || result.Diagnostics.SelectionCompositions == 0 || result.Diagnostics.KernelBlocks == 0 || result.Diagnostics.KernelCursorBlocks == 0 || result.Diagnostics.StatsBlocks != 0 || result.Diagnostics.StatsFallbackBlocks == 0 {
+		t.Fatalf("diagnostics=%+v want cached-verify targeted kernel+visibility path with stats fallback", result.Diagnostics)
 	}
 	if result.Diagnostics.FullAssetReads != 0 || result.Diagnostics.SectionBytesRead != 0 || result.Diagnostics.DecodedMetadataBytes != 0 || result.Diagnostics.DecodedHeapCopyBytes != 0 || result.Diagnostics.KernelFallbackBlocks != 0 {
 		t.Fatalf("diagnostics=%+v want hot targeted visibility run without full asset/materialized fallback", result.Diagnostics)
@@ -2980,6 +3069,11 @@ func reportTypedColumnInt64AggregateBenchMetrics(b *testing.B, totalRows int, di
 	b.ReportMetric(float64(diag.KernelSelectedBlocks), "kernel_selected_blocks/op")
 	b.ReportMetric(float64(diag.KernelCursorBlocks), "kernel_cursor_blocks/op")
 	b.ReportMetric(float64(diag.KernelFallbackBlocks), "kernel_fallback_blocks/op")
+	b.ReportMetric(float64(diag.StatsBlocks), "stats_blocks/op")
+	b.ReportMetric(float64(diag.StatsFullCoveredBlocks), "stats_full_covered_blocks/op")
+	b.ReportMetric(float64(diag.StatsFallbackBlocks), "stats_fallback_blocks/op")
+	b.ReportMetric(float64(diag.StatsRows), "stats_rows/op")
+	b.ReportMetric(float64(diag.StatsValidationFailures), "stats_validation_failures/op")
 	b.ReportMetric(float64(diag.DirectViewCertified), "direct_view_certified/op")
 	b.ReportMetric(float64(diag.StreamingCertified), "streaming_certified/op")
 	b.ReportMetric(float64(diag.CertificationFailures), "certification_failures/op")

--- a/TreeDB/collections/typed_column_int64_scan_test.go
+++ b/TreeDB/collections/typed_column_int64_scan_test.go
@@ -751,7 +751,7 @@ func TestTypedColumnInt64PreparedStatsRoundTripReopen(t *testing.T) {
 	}
 }
 
-func TestTypedColumnInt64PreparedStatsCorruptionFailsClosed(t *testing.T) {
+func TestTypedColumnInt64PreparedStatsCorruptionIntegrityPolicy(t *testing.T) {
 	d, col := setupTypedColumnInt64ScanCollection(t)
 	defer func() { _ = d.Close() }()
 	insertTypedColumnInt64ScanRows(t, col, []int64{1, 2, 3})
@@ -775,9 +775,25 @@ func TestTypedColumnInt64PreparedStatsCorruptionFailsClosed(t *testing.T) {
 	var corrupt [1]byte
 	corrupt[0] = raw[corruptAt] ^ 0xff
 	writeColumnAssetBytesAtRelativeOffset(t, d, refs[0], corruptAt, corrupt[:])
-	_, err = col.PrepareTypedColumnInt64PredicateAggregate(TypedColumnInt64PredicateAggregateRequest{Column: "time_us", Kind: TypedColumnInt64PredicateAll, ColumnAssetReadIntegrity: ColumnAssetReadIntegritySkipChecksums})
-	if err == nil || !strings.Contains(err.Error(), "stats validation") || !strings.Contains(err.Error(), typedcolumn.ColumnStatsReasonChecksumMismatch) {
-		t.Fatalf("Prepare corrupt stats err=%v want fail-closed stats checksum", err)
+	_, err = col.PrepareTypedColumnInt64PredicateAggregate(TypedColumnInt64PredicateAggregateRequest{Column: "time_us", Kind: TypedColumnInt64PredicateAll, ColumnAssetReadIntegrity: ColumnAssetReadIntegrityCachedVerify})
+	if err == nil || !strings.Contains(err.Error(), "checksum") {
+		t.Fatalf("Prepare corrupt stats err=%v want fail-closed checksum validation", err)
+	}
+
+	skipSession, err := col.PrepareTypedColumnInt64PredicateAggregate(TypedColumnInt64PredicateAggregateRequest{Column: "time_us", Kind: TypedColumnInt64PredicateAll, ColumnAssetReadIntegrity: ColumnAssetReadIntegritySkipChecksums})
+	if err != nil {
+		t.Fatalf("Prepare corrupt stats with skip-checksums: %v", err)
+	}
+	skipResult, err := skipSession.Run()
+	if closeErr := skipSession.Close(); closeErr != nil {
+		t.Fatalf("Close skip-checksums session: %v", closeErr)
+	}
+	if err != nil {
+		t.Fatalf("Run corrupt stats with skip-checksums: %v", err)
+	}
+	assertTypedColumnInt64Aggregate(t, skipResult, 3, 6)
+	if skipResult.Diagnostics.StatsBlocks != 0 || skipResult.Diagnostics.BlocksDecoded == 0 {
+		t.Fatalf("skip-checksums diagnostics=%+v want stats ignored and decode fallback", skipResult.Diagnostics)
 	}
 }
 

--- a/TreeDB/collections/typed_column_prepared_int64.go
+++ b/TreeDB/collections/typed_column_prepared_int64.go
@@ -64,9 +64,10 @@ func (s *TypedColumnInt64PredicateAggregateSession) prepareTargetedAggregateStat
 			IncludePruning: true,
 		},
 		{
-			Field:     s.aggregateColumn.Field,
-			Role:      typedcolumn.ColumnRoleMeasure,
-			Operation: columnsemantics.OpSum,
+			Field:        s.aggregateColumn.Field,
+			Role:         typedcolumn.ColumnRoleMeasure,
+			Operation:    columnsemantics.OpSum,
+			IncludeStats: true,
 		},
 	}
 	for _, physical := range s.view.AssetRefs {
@@ -119,6 +120,8 @@ func (s *TypedColumnInt64PredicateAggregateSession) prepareTargetedAggregateStat
 	prepareResult.Diagnostics.PruningCertified += state.diagnostics.PruningCertified
 	prepareResult.Diagnostics.CertificationFailures += state.diagnostics.CertificationFailures
 	prepareResult.Diagnostics.CertificationFailureReason = state.diagnostics.CertificationFailureReason
+	prepareResult.Diagnostics.StatsValidationFailures += state.diagnostics.StatsValidationFailures
+	prepareResult.Diagnostics.StatsValidationFailureReason = state.diagnostics.StatsValidationFailureReason
 	addTypedColumnInt64PredicateAggregateDiagnostics(&s.prepareDiagnostics, prepareResult.Diagnostics)
 	s.preparedState = state
 	return nil
@@ -372,6 +375,25 @@ func recordTypedColumnInt64KernelFallbackBlock(diag *TypedColumnInt64PredicateSc
 	diag.KernelFallbackBlocks++
 }
 
+func recordTypedColumnInt64StatsBlock(diag *TypedColumnInt64PredicateScanDiagnostics, rows int) {
+	if diag == nil {
+		return
+	}
+	diag.StatsBlocks++
+	diag.StatsFullCoveredBlocks++
+	diag.StatsRows += rows
+}
+
+func recordTypedColumnInt64StatsFallbackBlock(diag *TypedColumnInt64PredicateScanDiagnostics, reason string) {
+	if diag == nil {
+		return
+	}
+	diag.StatsFallbackBlocks++
+	if reason != "" {
+		diag.StatsFallbackReason = reason
+	}
+}
+
 func recordTypedColumnInt64FastDecodePlan(diag *TypedColumnInt64PredicateScanDiagnostics, plan typeddecode.Plan) {
 	if diag == nil {
 		return
@@ -524,6 +546,45 @@ func addTypedColumnInt64AggregateStreamingValues(result *TypedColumnInt64Predica
 	return nil
 }
 
+func addTypedColumnInt64AggregateStatsBlock(result *TypedColumnInt64PredicateAggregateResult, preparedColumn *typedColumnPreparedColumnState, block *typedColumnPreparedBlockPlan) (bool, error) {
+	if result == nil || preparedColumn == nil {
+		return false, nil
+	}
+	if !preparedColumn.Int64StatsReady {
+		if preparedColumn.StatsFallbackReason != "" {
+			recordTypedColumnInt64StatsFallbackBlock(&result.Diagnostics, preparedColumn.StatsFallbackReason)
+		}
+		return false, nil
+	}
+	if !block.CandidateSelection.IsAll() || block.NeedsPredicate {
+		recordTypedColumnInt64StatsFallbackBlock(&result.Diagnostics, typedcolumn.ColumnStatsReasonSelectionUnsupported)
+		return false, nil
+	}
+	ok, reason := preparedColumn.Int64Stats.CanAnswer(typedcolumn.ColumnStatsOpSum, typedcolumn.ColumnStatsSelectionFullBlock)
+	if !ok {
+		recordTypedColumnInt64StatsFallbackBlock(&result.Diagnostics, reason)
+		return false, nil
+	}
+	blockStats, ok := preparedColumn.Int64Stats.Block(block.Index)
+	if !ok {
+		return false, fmt.Errorf("collections: typed-column int64 stats missing block %d for column %q", block.Index, preparedColumn.Plan.Definition.Name)
+	}
+	if blockStats.FirstRow != block.Descriptor.FirstRow || blockStats.RowCount != block.Descriptor.RowCount || blockStats.ValueCount != block.Descriptor.RowCount {
+		return false, fmt.Errorf("collections: typed-column int64 stats block %d row identity mismatch", block.Index)
+	}
+	ok, reason = blockStats.CanAnswer(typedcolumn.ColumnStatsOpSum)
+	if !ok {
+		recordTypedColumnInt64StatsFallbackBlock(&result.Diagnostics, reason)
+		return false, nil
+	}
+	if err := addTypedColumnInt64AggregateKernelResult(result, typedkernel.AggregateResult{Op: preparedColumn.AggregateReducer.Operation(), NonNulls: int64(blockStats.ValueCount), Sum: blockStats.Sum, HasValue: true}); err != nil {
+		return false, err
+	}
+	recordTypedColumnSelectionDiagnostics(&result.Diagnostics, block.CandidateSelection)
+	recordTypedColumnInt64StatsBlock(&result.Diagnostics, blockStats.ValueCount)
+	return true, nil
+}
+
 func (s *TypedColumnInt64PredicateAggregateSession) scanPreparedAggregateColumnState(preparedColumn *typedColumnPreparedColumnState, ref ColumnAssetRef, visibility *typedColumnLatestPhysicalPart, result *TypedColumnInt64PredicateAggregateResult, updateCacheDeltas func()) (bool, error) {
 	if preparedColumn == nil {
 		return false, errors.New("collections: typed-column int64 predicate aggregate nil prepared column")
@@ -532,16 +593,34 @@ func (s *TypedColumnInt64PredicateAggregateSession) scanPreparedAggregateColumnS
 		return false, fmt.Errorf("collections: typed-column int64 predicate aggregate prepared column %q missing kernel reducer", preparedColumn.Plan.Definition.Name)
 	}
 	decodedAny := false
+	statsAny := false
 	payloadRead := false
 	columnPlan := typeddecode.Int64ReducerPlan(preparedColumn.Plan.Layout, preparedColumn.Certification)
 	recordTypedColumnInt64FastDecodePlan(&result.Diagnostics, columnPlan)
 	var err error
-	for _, block := range preparedColumn.BlockPlans {
+	for blockIdx := range preparedColumn.BlockPlans {
+		block := &preparedColumn.BlockPlans[blockIdx]
 		result.Diagnostics.BlocksConsidered++
 		if block.CandidateSelection.IsEmpty() {
 			result.Diagnostics.BlocksPruned++
 			recordTypedColumnSelectionDiagnostics(&result.Diagnostics, block.CandidateSelection)
 			continue
+		}
+		if visibility == nil && s.req.ColumnAssetReadIntegrity != ColumnAssetReadIntegritySkipChecksums {
+			usedStats, err := addTypedColumnInt64AggregateStatsBlock(result, preparedColumn, block)
+			if err != nil {
+				return false, err
+			}
+			if usedStats {
+				statsAny = true
+				continue
+			}
+		} else if s.req.ColumnAssetReadIntegrity == ColumnAssetReadIntegritySkipChecksums && preparedColumn.Int64StatsReady && block.CandidateSelection.IsAll() && !block.NeedsPredicate {
+			recordTypedColumnInt64StatsFallbackBlock(&result.Diagnostics, "skip_checksums")
+		} else if preparedColumn.Int64StatsReady && block.CandidateSelection.IsAll() && !block.NeedsPredicate {
+			recordTypedColumnInt64StatsFallbackBlock(&result.Diagnostics, "visibility_selection")
+		} else if !preparedColumn.Int64StatsReady && preparedColumn.StatsFallbackReason != "" {
+			recordTypedColumnInt64StatsFallbackBlock(&result.Diagnostics, preparedColumn.StatsFallbackReason)
 		}
 		var payload []byte
 		var handle *mappedresource.Handle
@@ -621,12 +700,12 @@ func (s *TypedColumnInt64PredicateAggregateSession) scanPreparedAggregateColumnS
 		}
 		decodedAny = true
 		result.Diagnostics.BlocksDecoded++
-		if err := addTypedColumnInt64AggregateStreamingValues(result, typedColumnInt64PredicateAggregateScanRequest(s.req), granule, block, preparedColumn.AggregateReducer, visibility, &s.aggregateScratch); err != nil {
+		if err := addTypedColumnInt64AggregateStreamingValues(result, typedColumnInt64PredicateAggregateScanRequest(s.req), granule, *block, preparedColumn.AggregateReducer, visibility, &s.aggregateScratch); err != nil {
 			return false, err
 		}
 	}
 	if payloadRead {
 		result.Diagnostics.DirectTypedColumnAssetReads++
 	}
-	return !decodedAny && len(preparedColumn.BlockPlans) != 0, nil
+	return !decodedAny && !statsAny && len(preparedColumn.BlockPlans) != 0, nil
 }

--- a/TreeDB/collections/typed_column_prepared_int64.go
+++ b/TreeDB/collections/typed_column_prepared_int64.go
@@ -56,6 +56,7 @@ func (s *TypedColumnInt64PredicateAggregateSession) prepareTargetedAggregateStat
 		prepareResult.Diagnostics.SegmentFileCacheHits = s.readCache.hits - beforeHits
 		prepareResult.Diagnostics.SegmentFileCacheMisses = s.readCache.misses - beforeMisses
 	}
+	includeStats := s.req.ColumnAssetReadIntegrity != ColumnAssetReadIntegritySkipChecksums
 	requests := []typedColumnPreparedColumnRequest{
 		{
 			Field:          s.aggregateColumn.Field,
@@ -67,7 +68,7 @@ func (s *TypedColumnInt64PredicateAggregateSession) prepareTargetedAggregateStat
 			Field:        s.aggregateColumn.Field,
 			Role:         typedcolumn.ColumnRoleMeasure,
 			Operation:    columnsemantics.OpSum,
-			IncludeStats: true,
+			IncludeStats: includeStats,
 		},
 	}
 	for _, physical := range s.view.AssetRefs {

--- a/TreeDB/collections/typed_column_prepared_state.go
+++ b/TreeDB/collections/typed_column_prepared_state.go
@@ -44,25 +44,27 @@ type typedColumnPreparedColumnPlan struct {
 }
 
 type typedColumnPreparedStateDiagnostics struct {
-	PartsPrepared              int
-	ColumnsPrepared            int
-	BlocksPrepared             int
-	CandidateBlocks            int
-	PrunedBlocks               int
-	SectionDependencies        int
-	CandidateRanges            int
-	CandidateRangeBytes        uint64
-	ManifestBytes              uint64
-	DescriptorBytes            uint64
-	ContractBytes              uint64
-	DirectViewCertified        int
-	StreamingCertified         int
-	StatsCertified             int
-	PruningCertified           int
-	CertificationFailures      int
-	CertificationFailureReason string
-	Fallback                   bool
-	FallbackReason             string
+	PartsPrepared                int
+	ColumnsPrepared              int
+	BlocksPrepared               int
+	CandidateBlocks              int
+	PrunedBlocks                 int
+	SectionDependencies          int
+	CandidateRanges              int
+	CandidateRangeBytes          uint64
+	ManifestBytes                uint64
+	DescriptorBytes              uint64
+	ContractBytes                uint64
+	DirectViewCertified          int
+	StreamingCertified           int
+	StatsCertified               int
+	PruningCertified             int
+	CertificationFailures        int
+	CertificationFailureReason   string
+	StatsValidationFailures      int
+	StatsValidationFailureReason string
+	Fallback                     bool
+	FallbackReason               string
 }
 
 type typedColumnPreparedBlockPlan struct {
@@ -83,6 +85,9 @@ type typedColumnPreparedColumnState struct {
 	Certification         typedcolumn.ColumnPartLayoutContractColumn
 	AggregateReducer      typedkernel.PreparedReducer
 	AggregateReducerReady bool
+	Int64Stats            typedcolumn.Int64ColumnStats
+	Int64StatsReady       bool
+	StatsFallbackReason   string
 	Dictionaries          map[string]int64
 }
 
@@ -157,6 +162,9 @@ func (c *typedColumnPreparedColumnState) close() {
 	c.Certification = typedcolumn.ColumnPartLayoutContractColumn{}
 	c.AggregateReducer = typedkernel.PreparedReducer{}
 	c.AggregateReducerReady = false
+	c.Int64Stats = typedcolumn.Int64ColumnStats{}
+	c.Int64StatsReady = false
+	c.StatsFallbackReason = ""
 	c.Dictionaries = nil
 }
 
@@ -268,7 +276,7 @@ func typedColumnPreparedDependenciesForRequest(req typedColumnPreparedColumnRequ
 		deps = append(deps, dep)
 	}
 	if req.IncludeStats {
-		dep, err := typedcolumn.NewSectionDependency(req.Role, def.Name, def.Type, typedcolumn.SectionDependencyStats, typedcolumn.ColumnPartImageSectionAggregateMetadata, span, false)
+		dep, err := typedcolumn.NewSectionDependency(req.Role, def.Name, def.Type, typedcolumn.SectionDependencyStats, typedcolumn.ColumnPartImageSectionColumnStats, span, false)
 		if err != nil {
 			return nil, err
 		}
@@ -353,7 +361,16 @@ func typedColumnPreparePartStateFromRanges(ref ColumnAssetRef, physical ColumnAs
 	if err != nil {
 		return nil, typedColumnPreparedStateDiagnostics{}, err
 	}
-	return typedColumnPreparePartStateFromParsed(ref, physical, typedRows, physicalRows, fields, schemaHash, image, desc, columns, manifestBytes, descriptorRaw, contractRaw, columnRequests, blockSelection)
+	part, diag, err := typedColumnPreparePartStateFromParsed(ref, physical, typedRows, physicalRows, fields, schemaHash, image, desc, columns, manifestBytes, descriptorRaw, contractRaw, columnRequests, blockSelection)
+	if err != nil || part == nil || diag.Fallback || !typedColumnPreparedRequestsIncludeStats(columnRequests) {
+		return part, diag, err
+	}
+	if err := typedColumnAttachPreparedStats(part, image, readRange); err != nil {
+		diag.StatsValidationFailures++
+		diag.StatsValidationFailureReason = err.Error()
+		return nil, diag, fmt.Errorf("collections: typed_column_part stats validation failed: %w", err)
+	}
+	return part, diag, nil
 }
 
 func typedColumnPreparePartStateFromParsed(ref ColumnAssetRef, physical ColumnAssetRef, typedRows int, physicalRows int, _ []TypedStorageField, schemaHash uint64, image typedcolumn.ColumnPartImage, desc typedcolumn.ColumnPartDescriptor, columns map[string]typedcolumn.ColumnPartColumn, manifestBytes int, descriptorRaw []byte, contractRaw []byte, columnRequests []typedColumnPreparedColumnRequest, blockSelection func(typedcolumn.EncodedGranule, int) (typedcolumn.RowSelection, bool, error)) (*typedColumnPreparedPartState, typedColumnPreparedStateDiagnostics, error) {
@@ -535,6 +552,92 @@ func buildTypedColumnPreparedColumnState(plan typedColumnPreparedColumnPlan, col
 	return state, diag, nil
 }
 
+func typedColumnPreparedRequestsIncludeStats(requests []typedColumnPreparedColumnRequest) bool {
+	for _, request := range requests {
+		if request.IncludeStats {
+			return true
+		}
+	}
+	return false
+}
+
+func typedColumnPreparedColumnWantsStats(column *typedColumnPreparedColumnState) bool {
+	if column == nil {
+		return false
+	}
+	for _, dep := range column.Plan.Dependencies {
+		if dep.Kind == typedcolumn.SectionDependencyStats {
+			return true
+		}
+	}
+	return false
+}
+
+func typedColumnAttachPreparedStats(part *typedColumnPreparedPartState, image typedcolumn.ColumnPartImage, readRange typedColumnPreparedRangeReader) error {
+	if part == nil {
+		return errors.New("collections: typed-column prepared stats missing part")
+	}
+	section, ok, err := image.ColumnStatsSection()
+	if err != nil {
+		return err
+	}
+	if !ok {
+		for _, column := range part.Columns {
+			if typedColumnPreparedColumnWantsStats(column) {
+				column.StatsFallbackReason = "missing_stats"
+			}
+		}
+		return nil
+	}
+	if readRange == nil {
+		return errors.New("collections: typed-column prepared stats requires range reader")
+	}
+	raw, err := readRange(section.Offset, section.Length, true)
+	if err != nil {
+		return err
+	}
+	stats, err := typedcolumn.DecodeColumnPartStatsSection(raw)
+	if err != nil {
+		return err
+	}
+	if err := typedcolumn.ValidateColumnPartStats(stats, part.Descriptor, part.PhysicalColumns); err != nil {
+		return err
+	}
+	for name, column := range part.Columns {
+		if !typedColumnPreparedColumnWantsStats(column) {
+			continue
+		}
+		int64Stats, ok := stats.Int64Column(name)
+		if !ok {
+			column.StatsFallbackReason = "missing_stats"
+			continue
+		}
+		semDesc := columnsemantics.Descriptor{
+			Logical:             column.Plan.Logical,
+			Physical:            column.Plan.Definition.Type,
+			Encoding:            column.Plan.Definition.Encoding,
+			Nullable:            column.Plan.Field.Nullable,
+			DictionaryOrder:     column.Plan.Layout.Descriptor.DictionaryOrder,
+			DictionaryCollation: column.Plan.Layout.Descriptor.DictionaryCollation,
+		}
+		if cap := columnsemantics.CapabilityFor(semDesc, columnsemantics.OpStatsSum); !cap.Supported() {
+			column.StatsFallbackReason = cap.Error()
+			continue
+		}
+		if cap := column.Plan.Layout.SupportsSemanticOperation(columnsemantics.OpStatsSum); !cap.Supported() {
+			column.StatsFallbackReason = cap.Error()
+			continue
+		}
+		if !column.Certification.StatsCertified {
+			column.StatsFallbackReason = "layout_stats_not_certified"
+			continue
+		}
+		column.Int64Stats = int64Stats
+		column.Int64StatsReady = true
+	}
+	return nil
+}
+
 func typedColumnPreparedValidateColumnDataSections(image typedcolumn.ColumnPartImage, desc typedcolumn.ColumnPartDescriptor, columns map[string]typedcolumn.ColumnPartColumn) error {
 	sectionsByColumn := make(map[string]typedcolumn.ColumnPartImageSection, len(columns))
 	for _, section := range image.Sections {
@@ -602,6 +705,10 @@ func typedColumnPreparedStateDiagnosticsAdd(dst *typedColumnPreparedStateDiagnos
 	dst.CertificationFailures += src.CertificationFailures
 	if src.CertificationFailureReason != "" {
 		dst.CertificationFailureReason = src.CertificationFailureReason
+	}
+	dst.StatsValidationFailures += src.StatsValidationFailures
+	if src.StatsValidationFailureReason != "" {
+		dst.StatsValidationFailureReason = src.StatsValidationFailureReason
 	}
 	if src.Fallback {
 		dst.Fallback = true

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -350,7 +350,7 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/column_vector_graph_typed_column.go", classification: typedStorageLegacyDerived, matchingLines: 6, occurrences: 6},
 	{path: "TreeDB/collections/column_vector_graph_typed_column_test.go", classification: typedStorageLegacyDerived, matchingLines: 21, occurrences: 24},
 	{path: "TreeDB/collections/command_wal_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 4, occurrences: 6},
-	{path: "TreeDB/collections/typed_column_adapter.go", classification: typedStorageLegacyCompatibility, matchingLines: 45, occurrences: 51},
+	{path: "TreeDB/collections/typed_column_adapter.go", classification: typedStorageLegacyCompatibility, matchingLines: 46, occurrences: 52},
 	{path: "TreeDB/collections/typed_column_adapter_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 204, occurrences: 212},
 	{path: "TreeDB/collections/typed_column_conformance_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 26, occurrences: 33},
 	{path: "TreeDB/collections/typed_column_int64_scan.go", classification: typedStorageLegacyCompatibility, matchingLines: 22, occurrences: 31},

--- a/TreeDB/docs/spec/typed-column-kernels.md
+++ b/TreeDB/docs/spec/typed-column-kernels.md
@@ -20,7 +20,9 @@ Reducers dispatch once outside the hot row loop. Concrete reducers switch on
 `typedcolumn.RowSelection.Kind()` for empty, all, range, ranges, bitmap, and
 sparse selections. The initial int64 reducer represents count rows, count
 non-null, sum, avg, min, and max separately, with checked int64 sum accumulation.
-Nullable value aggregates remain fallback/unsupported until a future kernel
-composes null/default masks explicitly. Direct/zero-copy access is not
-implemented here; future integration should obtain any direct views through
-`TreeDB/internal/typeddecode` before invoking a concrete kernel.
+#1840 durable int64 stats may answer all/full-block-covered count/sum/avg before
+payload decode; partial selections, visibility masks, or unsupported stats fall
+back to these typedkernel reducers. Nullable value aggregates remain
+fallback/unsupported until a future kernel composes null/default masks
+explicitly. Direct/zero-copy access is obtained through `TreeDB/internal/typeddecode`
+before invoking a concrete kernel.

--- a/TreeDB/docs/spec/typed-column-kernels.md
+++ b/TreeDB/docs/spec/typed-column-kernels.md
@@ -20,7 +20,7 @@ Reducers dispatch once outside the hot row loop. Concrete reducers switch on
 `typedcolumn.RowSelection.Kind()` for empty, all, range, ranges, bitmap, and
 sparse selections. The initial int64 reducer represents count rows, count
 non-null, sum, avg, min, and max separately, with checked int64 sum accumulation.
-#1840 durable int64 stats may answer all/full-block-covered count/sum/avg before
+Issue #1840 durable int64 stats may answer all/full-block-covered count/sum/avg before
 payload decode; partial selections, visibility masks, or unsupported stats fall
 back to these typedkernel reducers. Nullable value aggregates remain
 fallback/unsupported until a future kernel composes null/default masks

--- a/TreeDB/docs/spec/typed-column-layout-capabilities.md
+++ b/TreeDB/docs/spec/typed-column-layout-capabilities.md
@@ -4,7 +4,8 @@ Status: pre-alpha internal contract for typed-column prepare/read planning. Sema
 operation support remains defined in `typed-column-semantics.md`; this document
 covers the physical layout/codec contract that decides whether a semantic
 operation may use a direct view, safe fixed-width reducer, streaming decoder,
-stats payload, or pruning metadata.
+stats payload, or pruning metadata. The stats envelope and payload contract is
+specified in `typed-column-stats.md`.
 
 The implementation lives in `TreeDB/internal/columnlayout`. Capability keys are
 not just encodings. A key includes:
@@ -106,8 +107,12 @@ Current validation is at prepare plus payload-read boundaries:
 Prepared int64 diagnostics include `DirectViewCertified`, `StreamingCertified`,
 `StatsCertified`, `PruningCertified`, `CertificationFailures`, and
 `CertificationFailureReason`, alongside mapped/heap/decoded/materialized byte
-counters. Benchmarks report these as `direct_view_certified/op`,
-`streaming_certified/op`, and `certification_failures/op`.
+counters. When durable stats are consumed, block diagnostics distinguish
+`StatsBlocks`/`StatsFullCoveredBlocks`/`StatsRows` from `BlocksDecoded` and
+`Kernel*` counters; stats misses and unsupported selection shapes increment
+`StatsFallbackBlocks`. Benchmarks report these as `direct_view_certified/op`,
+`streaming_certified/op`, `stats_blocks/op`, `stats_fallback_blocks/op`, and
+`certification_failures/op`.
 
 Stable layout fallback reason codes live in `TreeDB/internal/columnlayout`, for
 example `layout_variable_width_no_direct_view`,

--- a/TreeDB/docs/spec/typed-column-semantics.md
+++ b/TreeDB/docs/spec/typed-column-semantics.md
@@ -18,7 +18,7 @@ The shared model lives in `TreeDB/internal/columnsemantics` and separates:
 | Logical type | Current typedcolumn type | Encoding/layout | Scalar range/aggregate stance |
 | --- | --- | --- | --- |
 | `bool` | `bool` | `bool_bitpack_rle` | equality/counts supported; broad scalar range is unsupported (`bool_range_unsupported`). |
-| `int64` | `int64` | `delta_varint` by default; explicit `fixed_width_encoding: "little_endian"` selects uncompressed `raw_int64`; double-delta remains a valid typedcolumn encoding but is not the adapter default | equality, ordered range, count rows/non-null, sum/avg/min/max, min/max stats, and ordered-range pruning are supported for non-null int64 semantics. Sum stats are currently unsupported because existing stats payloads do not store sums (`stats_payload_unsupported`). Physical reducer/direct-view eligibility is additionally gated by `typed-column-layout-capabilities.md`. |
+| `int64` | `int64` | `delta_varint` by default; explicit `fixed_width_encoding: "little_endian"` selects uncompressed `raw_int64`; double-delta remains a valid typedcolumn encoding but is not the adapter default | equality, ordered range, count rows/non-null, sum/avg/min/max, min/max stats, sum stats, and ordered-range pruning are supported for non-null int64 semantics. Durable sum/count stats are gated by the stats envelope in `typed-column-stats.md` and are usable only for advertised all/full-block selection shapes. Physical reducer/direct-view eligibility is additionally gated by `typed-column-layout-capabilities.md`. |
 | `float32` | `int64` | `raw_int64` carrying `math.Float32bits` | raw bit patterns do **not** provide int64 ordered range, sum, min/max, stats, pruning, or direct scalar value semantics (`float_raw_int64_bit_pattern`). Native float semantics require a future float layout and NaN/signed-zero/infinity rules. |
 | `double` | `int64` | `raw_int64` carrying `math.Float64bits` | same raw-bit restriction as `float32`. |
 | `string` | `low_cardinality_code` | `low_cardinality_uint32` plus dictionary metadata | dictionary equality/in-list/group-by are supported. Lexical range/prefix/pruning are unsupported unless dictionary order and collation identity are explicitly proven (`dictionary_order_unproven`, `dictionary_collation_unproven`). |
@@ -70,6 +70,30 @@ optional immutable asset identity, and section dependency kinds such as values,
 dictionaries, offsets, null/default masks, visibility, stats, pruning metadata,
 vector payloads, and adjacency payloads. Row-span or asset-generation mismatches
 must fail closed before a hot loop consumes multiple columns.
+
+## Durable stats envelope (#1840)
+
+Typed-column stats are generic at the envelope layer and type-specific at the
+payload layer. The envelope binds part id, column name, physical type, encoding,
+row count, block count, null/default/visible/value counts, advertised logical
+operations, advertised selection shapes, payload length, and payload checksum.
+A payload may be consumed only when both the semantic capability matrix and the
+layout contract support the requested operation and the envelope advertises the
+requested selection shape. Invalid present stats fail closed; absent stats are a
+safe fallback to decoding.
+
+The first payload is non-null `int64` block/part count+sum+min/max. It answers
+prepared count/sum/avg aggregate blocks only for all rows or full-covered blocks
+(no partial/random/sparse selection and no visibility mutation mask). Sum uses
+checked int64 overflow semantics; overflowing block sums are marked not
+stats-answerable and fall back to the checked reducer.
+
+Future bool, string/dictionary, float, vector, or adjacency stats must add their
+own payload semantics rather than reusing int64 carrier meanings. Dictionary and
+string range stats require dictionary-order plus collation proof. Float stats
+require native float layout plus NaN/signed-zero/infinity and precision rules.
+Vector/adjacency stats must be vector/graph-specific metadata, not scalar
+aggregate shortcuts.
 
 ## typedcolumn coverage
 

--- a/TreeDB/docs/spec/typed-column-stats.md
+++ b/TreeDB/docs/spec/typed-column-stats.md
@@ -42,7 +42,9 @@ Prepared int64 count/sum/avg scans use this payload only when a block is
 full-covered by the predicate and no visibility/mutation mask is required. This
 covers no-filter/all-match and clustered full-covered range blocks. Partial,
 random, sparse, hotspot, nullable/default, or mutation-visible blocks use the
-existing typedkernel/direct-view/streaming fallback path.
+existing typedkernel/direct-view/streaming fallback path. The envelope may still
+advertise the `all_rows` shape for exact count operations when part-level sum
+overflows; sum/avg additionally require `sum_valid`.
 
 Overflow behavior is explicit: if a block sum overflows int64 during stats
 construction, that block does not advertise a usable sum and selected scans fall

--- a/TreeDB/docs/spec/typed-column-stats.md
+++ b/TreeDB/docs/spec/typed-column-stats.md
@@ -1,0 +1,68 @@
+# Typed-Column Stats Framework (#1840)
+
+Status: internal pre-alpha format. New binaries may require rebuilding old test
+DBs when typed-column image formats change, but readers treat absent stats as a
+safe decode fallback.
+
+## Envelope
+
+Typed-column stats use a generic envelope and type-specific payloads.
+
+The envelope binds:
+
+- stats section/envelope version;
+- immutable typed-column part id and column name;
+- physical typedcolumn type, encoding, compression, row count, and block count;
+- row-count contracts: total rows, null rows, default rows, visible rows, and
+  value rows are distinct fields;
+- advertised logical operations, for example `aggregate.sum` and `stats.sum`;
+- advertised selection shapes, currently `full_block` and optionally `all_rows`;
+- payload kind, payload length, and payload CRC32/IEEE checksum.
+
+A prepared reader may consume stats only after normal asset integrity policy and
+writer layout certification have accepted the typed-column part. Present but
+invalid stats are corruption/staleness and fail closed. Missing stats are not
+corruption; optimized paths fall back to decoding.
+
+## Int64 payload v1
+
+The initial payload is `int64_count_sum_min_max_v1` for non-null logical `int64`
+columns with typedcolumn physical `int64`. Collection adapter columns whose
+physical carrier is `int64` but whose logical value type is not `int64` (for
+example float raw-bit carriers and the hidden primary-id carrier) disable this
+payload at build time and still require semantic/layout gates at read time. The
+payload records part-level and block-level:
+
+- row/value counts;
+- null/default/visible counts (zero/null-free for the current value payload);
+- checked int64 sum plus a `sum_valid` bit;
+- min/max copied from the validated block granule metadata.
+
+Prepared int64 count/sum/avg scans use this payload only when a block is
+full-covered by the predicate and no visibility/mutation mask is required. This
+covers no-filter/all-match and clustered full-covered range blocks. Partial,
+random, sparse, hotspot, nullable/default, or mutation-visible blocks use the
+existing typedkernel/direct-view/streaming fallback path.
+
+Overflow behavior is explicit: if a block sum overflows int64 during stats
+construction, that block does not advertise a usable sum and selected scans fall
+back to the checked reducer, which returns the existing overflow error. If a
+part-level sum overflows, block stats can still be used independently, and final
+result accumulation remains checked.
+
+## Future payload rules
+
+The envelope is type-neutral; payload semantics are not.
+
+- Bool payloads should expose true/false/null counts, not broad scalar range.
+- String/dictionary payloads may expose dictionary-id stats only under stable
+  dictionary identity. Lexical range stats require dictionary-order and collation
+  proof.
+- Float payloads require native float layout and explicit NaN, signed-zero,
+  infinity, precision, and sum/min/max rules. Raw int64 bit patterns must not use
+  int64 numeric stats.
+- Vector and adjacency payloads must be vector/graph-specific metadata or index
+  sketches and must reject scalar aggregate assumptions.
+
+Future payloads must declare their supported operations and selection shapes in
+the envelope and must be admitted through the semantic/layout capability gates.

--- a/TreeDB/internal/columnlayout/layout.go
+++ b/TreeDB/internal/columnlayout/layout.go
@@ -20,6 +20,7 @@ const (
 	OpInt64RangePredicate    Operation = "predicate.int64_range"
 	OpMinMaxPruning          Operation = "pruning.min_max"
 	OpMinMaxStats            Operation = "stats.min_max"
+	OpSumStats               Operation = "stats.sum"
 	OpLexicalRangePredicate  Operation = "predicate.lexical_range"
 	OpScalarNumericAggregate Operation = "aggregate.scalar_numeric"
 )
@@ -237,6 +238,7 @@ func CapabilitiesFor(desc Descriptor) Capabilities {
 			caps.Reducers.Int64FixedWidthRaw = true
 			caps.Reducers.Int64NumericAggregate = true
 			caps.Stats.MinMax = true
+			caps.Stats.Sum = true
 			caps.Pruning.OrderedMinMax = true
 		}
 	case typedcolumn.EncodingDeltaVarint, typedcolumn.EncodingDoubleDeltaVarint:
@@ -248,6 +250,7 @@ func CapabilitiesFor(desc Descriptor) Capabilities {
 			caps.Reducers.Int64Streaming = true
 			caps.Reducers.Int64NumericAggregate = true
 			caps.Stats.MinMax = true
+			caps.Stats.Sum = true
 			caps.Pruning.OrderedMinMax = true
 		}
 	case typedcolumn.EncodingNullableInt64:
@@ -339,7 +342,7 @@ func (c Capabilities) Supports(op Operation) Capability {
 	}
 	if c.Wrappers.Nullable {
 		switch op {
-		case OpDirectView, OpInt64NumericReducer, OpInt64RangePredicate, OpMinMaxPruning, OpScalarNumericAggregate:
+		case OpDirectView, OpInt64NumericReducer, OpInt64RangePredicate, OpMinMaxPruning, OpMinMaxStats, OpSumStats, OpScalarNumericAggregate:
 			return Fallback(op, ReasonNullDefaultWrapperRequired, "nullable/default wrapper exposes null/default masks separately from carrier values")
 		}
 	}
@@ -347,25 +350,25 @@ func (c Capabilities) Supports(op Operation) Capability {
 		switch op {
 		case OpDirectView:
 			return Unsupported(op, ReasonCompressedDirectView, fmt.Sprintf("compression=%s", c.Descriptor.Compression))
-		case OpInt64NumericReducer, OpInt64RangePredicate, OpMinMaxPruning, OpMinMaxStats, OpScalarNumericAggregate:
+		case OpInt64NumericReducer, OpInt64RangePredicate, OpMinMaxPruning, OpMinMaxStats, OpSumStats, OpScalarNumericAggregate:
 			return Unsupported(op, ReasonUnsupportedCompression, fmt.Sprintf("compression=%s", c.Descriptor.Compression))
 		}
 	}
 	if c.Descriptor.Logical == columnsemantics.LogicalFloat32 || c.Descriptor.Logical == columnsemantics.LogicalDouble {
 		switch op {
-		case OpInt64NumericReducer, OpInt64RangePredicate, OpMinMaxPruning, OpMinMaxStats, OpScalarNumericAggregate:
+		case OpInt64NumericReducer, OpInt64RangePredicate, OpMinMaxPruning, OpMinMaxStats, OpSumStats, OpScalarNumericAggregate:
 			return Unsupported(op, ReasonFloatBitPatternNotNumeric, "float bit-pattern storage is not an int64 numeric layout")
 		}
 	}
 	if c.Descriptor.Logical == columnsemantics.LogicalFloat32Vector {
 		switch op {
-		case OpInt64NumericReducer, OpInt64RangePredicate, OpMinMaxPruning, OpMinMaxStats, OpLexicalRangePredicate, OpScalarNumericAggregate:
+		case OpInt64NumericReducer, OpInt64RangePredicate, OpMinMaxPruning, OpMinMaxStats, OpSumStats, OpLexicalRangePredicate, OpScalarNumericAggregate:
 			return Unsupported(op, ReasonVectorScalarUnsupported, "vector layouts reject scalar aggregate/range shortcuts")
 		}
 	}
 	if c.Descriptor.Logical == columnsemantics.LogicalAdjacencyList {
 		switch op {
-		case OpInt64NumericReducer, OpInt64RangePredicate, OpMinMaxPruning, OpMinMaxStats, OpLexicalRangePredicate, OpScalarNumericAggregate:
+		case OpInt64NumericReducer, OpInt64RangePredicate, OpMinMaxPruning, OpMinMaxStats, OpSumStats, OpLexicalRangePredicate, OpScalarNumericAggregate:
 			return Unsupported(op, ReasonAdjacencyScalarUnsupported, "adjacency layouts reject scalar aggregate/range shortcuts")
 		}
 	}
@@ -396,6 +399,11 @@ func (c Capabilities) Supports(op Operation) Capability {
 			return Supported(op)
 		}
 		return Unsupported(op, ReasonStatsPayloadUnsupported, "layout does not advertise min/max stats")
+	case OpSumStats:
+		if c.Stats.Sum {
+			return Supported(op)
+		}
+		return Unsupported(op, ReasonStatsPayloadUnsupported, "layout does not advertise sum stats")
 	case OpLexicalRangePredicate:
 		if c.Pruning.LexicalDictionary {
 			return Supported(op)
@@ -436,6 +444,8 @@ func (c Capabilities) SupportsSemanticOperation(op columnsemantics.Operation) Ca
 		return c.Supports(OpInt64NumericReducer)
 	case columnsemantics.OpStatsMinMax:
 		return c.Supports(OpMinMaxStats)
+	case columnsemantics.OpStatsSum:
+		return c.Supports(OpSumStats)
 	case columnsemantics.OpPruneOrderedRange:
 		return c.Supports(OpMinMaxPruning)
 	case columnsemantics.OpDirectScalarValueCarrier:

--- a/TreeDB/internal/columnsemantics/semantics.go
+++ b/TreeDB/internal/columnsemantics/semantics.go
@@ -298,7 +298,7 @@ func int64Capability(desc Descriptor, op Operation) Capability {
 	case OpMin, OpMax:
 		return SupportedResult(op, ResultSemantics{ResultType: "int64", Comparison: "signed int64 logical order"})
 	case OpStatsSum:
-		return Unsupported(op, ReasonStatsPayloadUnsupported, "current typed-column stats payloads do not store int64 sums")
+		return SupportedResult(op, ResultSemantics{ResultType: "int64", Accumulator: "durable int64 block/part stats payload", OverflowPolicy: "checked"})
 	case OpIsNull, OpIsNotNull:
 		return Unsupported(op, ReasonNotNullable, "non-null int64 column")
 	default:

--- a/TreeDB/internal/columnsemantics/semantics_test.go
+++ b/TreeDB/internal/columnsemantics/semantics_test.go
@@ -27,13 +27,10 @@ func TestSemanticMatrixCoversCurrentLogicalTypesColumnTypesAndEncodings(t *testi
 
 func TestCapabilityInt64SupportsPreparedPredicateAndAggregateSemantics(t *testing.T) {
 	desc := Descriptor{Logical: LogicalInt64, Physical: typedcolumn.ColumnTypeInt64, Encoding: typedcolumn.EncodingDeltaVarint}
-	for _, op := range []Operation{OpAllRows, OpEquality, OpOrderedRange, OpCountRows, OpCountNonNull, OpSum, OpAvg, OpMin, OpMax, OpStatsMinMax, OpPruneOrderedRange} {
+	for _, op := range []Operation{OpAllRows, OpEquality, OpOrderedRange, OpCountRows, OpCountNonNull, OpSum, OpAvg, OpMin, OpMax, OpStatsMinMax, OpStatsSum, OpPruneOrderedRange} {
 		if cap := CapabilityFor(desc, op); cap.Status != StatusSupported || cap.Phase != PhasePrepare {
 			t.Fatalf("op %s status=%s reason=%s phase=%s", op, cap.Status, cap.Reason, cap.Phase)
 		}
-	}
-	if cap := CapabilityFor(desc, OpStatsSum); cap.Status != StatusUnsupported || cap.Reason != ReasonStatsPayloadUnsupported {
-		t.Fatalf("stats sum status=%s reason=%s", cap.Status, cap.Reason)
 	}
 }
 
@@ -46,6 +43,7 @@ func TestCapabilityInt64AggregateResultSemanticsAreExplicit(t *testing.T) {
 		OpAvg:          {ResultType: "float64", Accumulator: "checked int64 sum and int64 count", OverflowPolicy: "checked sum", Precision: "float64 quotient"},
 		OpMin:          {ResultType: "int64", Comparison: "signed int64 logical order"},
 		OpMax:          {ResultType: "int64", Comparison: "signed int64 logical order"},
+		OpStatsSum:     {ResultType: "int64", Accumulator: "durable int64 block/part stats payload", OverflowPolicy: "checked"},
 	}
 	for op, want := range checks {
 		cap := CapabilityFor(desc, op)
@@ -94,7 +92,7 @@ func TestCapabilityStringDictionaryCodesDoNotImplyLexicalRangeWithoutProof(t *te
 	if cap := CapabilityFor(desc, OpDictionaryEquality); cap.Status != StatusSupported {
 		t.Fatalf("dictionary equality status=%s reason=%s", cap.Status, cap.Reason)
 	}
-	for _, op := range []Operation{OpOrderedRange, OpDictionaryRange, OpStringPrefix, OpStringLexicalRange, OpPruneOrderedRange} {
+	for _, op := range []Operation{OpOrderedRange, OpDictionaryRange, OpStringPrefix, OpStringLexicalRange, OpStatsMinMax, OpPruneOrderedRange} {
 		cap := CapabilityFor(desc, op)
 		if cap.Status != StatusUnsupported || cap.Reason != ReasonDictionaryOrderUnproven {
 			t.Fatalf("%s status=%s reason=%s", op, cap.Status, cap.Reason)
@@ -117,7 +115,7 @@ func TestCapabilityNullableCarrierDistinguishesCountAndValueAggregateSemantics(t
 			t.Fatalf("%s status=%s reason=%s", op, cap.Status, cap.Reason)
 		}
 	}
-	for _, op := range []Operation{OpSum, OpAvg, OpMin, OpMax, OpStatsMinMax, OpPruneOrderedRange} {
+	for _, op := range []Operation{OpSum, OpAvg, OpMin, OpMax, OpStatsMinMax, OpStatsSum, OpPruneOrderedRange} {
 		cap := CapabilityFor(desc, op)
 		if cap.Status != StatusFallback || cap.Reason != ReasonNullableCarrierAggregateSemantics {
 			t.Fatalf("%s status=%s reason=%s", op, cap.Status, cap.Reason)

--- a/TreeDB/internal/typedcolumn/part.go
+++ b/TreeDB/internal/typedcolumn/part.go
@@ -84,6 +84,7 @@ type ColumnDefinition struct {
 	Cardinality        uint32
 	FixedWidthElements int
 	CodecBlockRows     int
+	StatsDisabled      bool
 }
 
 type Batch struct {
@@ -103,6 +104,7 @@ type ColumnPart struct {
 	Marks             []SortKeyMark
 	Locators          map[int64]RowLocator
 	AggregateMetadata map[string]AggregateMetadata
+	ColumnStats       ColumnPartStats
 }
 
 type ColumnPartDescriptor struct {
@@ -246,6 +248,11 @@ func (b *ColumnPartBuilder) Build(partID uint64, batch Batch) (*ColumnPart, erro
 	if err := b.buildAggregateMetadata(part, batch); err != nil {
 		return nil, err
 	}
+	stats, err := buildColumnPartStats(part)
+	if err != nil {
+		return nil, err
+	}
+	part.ColumnStats = stats
 	return part, nil
 }
 

--- a/TreeDB/internal/typedcolumn/part_accounting.go
+++ b/TreeDB/internal/typedcolumn/part_accounting.go
@@ -32,6 +32,7 @@ type ColumnPartByteAccounting struct {
 	MarkBytes               int                                    `json:"mark_bytes"`
 	SortKeyMetadataBytes    int                                    `json:"sort_key_metadata_bytes"`
 	AggregateMetadataBytes  int                                    `json:"aggregate_metadata_bytes"`
+	ColumnStatsBytes        int                                    `json:"column_stats_bytes"`
 	DescriptorBytes         int                                    `json:"descriptor_bytes"`
 	LayoutContractBytes     int                                    `json:"layout_contract_bytes"`
 	LocatorBytes            int                                    `json:"locator_bytes"`
@@ -172,6 +173,7 @@ func (p *ColumnPart) ByteAccounting() ColumnPartByteAccounting {
 	out.MarkBytes = estimateSortKeyMarkBytes(p.Marks)
 	out.SortKeyMetadataBytes = estimateSortKeyMetadataBytes(p.Descriptor.SortKey)
 	out.AggregateMetadataBytes = aggregateMetadataStoredBytes(p.AggregateMetadata)
+	out.ColumnStatsBytes = columnStatsStoredBytes(p.ColumnStats)
 	out.DescriptorBytes = estimateColumnPartDescriptorBytes(p.Descriptor)
 	out.LocatorBytes = len(p.Locators) * rowLocatorBytes
 	for _, compression := range compressionByKey {
@@ -218,6 +220,7 @@ func (p *ColumnPart) ByteAccountingFromImage(image ColumnPartImage) ColumnPartBy
 	out.MarkBytes = image.CategoryBytes(ColumnPartImageCategoryMarks)
 	out.SortKeyMetadataBytes = image.CategoryBytes(ColumnPartImageCategorySortKeyMetadata)
 	out.AggregateMetadataBytes = image.CategoryBytes(ColumnPartImageCategoryAggregateMetadata)
+	out.ColumnStatsBytes = image.CategoryBytes(ColumnPartImageCategoryColumnStats)
 	out.DescriptorBytes = image.CategoryBytes(ColumnPartImageCategoryDescriptor)
 	out.LayoutContractBytes = image.CategoryBytes(ColumnPartImageCategoryLayoutContract)
 	out.LocatorBytes = image.CategoryBytes(ColumnPartImageCategoryLocators)
@@ -243,6 +246,7 @@ func (a ColumnPartByteAccounting) CategoryBytes() int {
 		a.MarkBytes +
 		a.SortKeyMetadataBytes +
 		a.AggregateMetadataBytes +
+		a.ColumnStatsBytes +
 		a.DescriptorBytes +
 		a.LayoutContractBytes +
 		a.LocatorBytes
@@ -296,6 +300,14 @@ func aggregateMetadataStoredBytes(metadata map[string]AggregateMetadata) int {
 		}
 	}
 	return total
+}
+
+func columnStatsStoredBytes(stats ColumnPartStats) int {
+	raw, err := encodeColumnPartStatsSection(stats)
+	if err != nil {
+		return 0
+	}
+	return len(raw)
 }
 
 type columnCompressionKey struct {

--- a/TreeDB/internal/typedcolumn/part_image.go
+++ b/TreeDB/internal/typedcolumn/part_image.go
@@ -24,6 +24,7 @@ const (
 	ColumnPartImageSectionSortKeyMarks      ColumnPartImageSectionKind = "sort_key_marks"
 	ColumnPartImageSectionRowLocators       ColumnPartImageSectionKind = "row_locators"
 	ColumnPartImageSectionAggregateMetadata ColumnPartImageSectionKind = "aggregate_metadata"
+	ColumnPartImageSectionColumnStats       ColumnPartImageSectionKind = "column_stats"
 	ColumnPartImageSectionDictionaries      ColumnPartImageSectionKind = "dictionaries"
 	ColumnPartImageSectionLayoutContract    ColumnPartImageSectionKind = "layout_contract"
 	ColumnPartImageSectionColumnData        ColumnPartImageSectionKind = "column_data"
@@ -39,6 +40,7 @@ const (
 	ColumnPartImageCategoryMarks             ColumnPartImageSectionCategory = "marks"
 	ColumnPartImageCategoryLocators          ColumnPartImageSectionCategory = "locators"
 	ColumnPartImageCategoryAggregateMetadata ColumnPartImageSectionCategory = "aggregate_metadata"
+	ColumnPartImageCategoryColumnStats       ColumnPartImageSectionCategory = "column_stats"
 	ColumnPartImageCategoryDictionaries      ColumnPartImageSectionCategory = "dictionaries"
 	ColumnPartImageCategoryLayoutContract    ColumnPartImageSectionCategory = "layout_contract"
 	ColumnPartImageCategoryDeclaredColumns   ColumnPartImageSectionCategory = "declared_columns"
@@ -111,6 +113,7 @@ func (p *ColumnPart) WithImagePayloads(image ColumnPartImage) (*ColumnPart, erro
 		return nil, err
 	}
 	out := *p
+	out.ColumnStats = cloneColumnPartStats(p.ColumnStats)
 	out.Columns = make(map[string]ColumnPartColumn, len(p.Columns))
 	for name, column := range p.Columns {
 		outColumn := column
@@ -268,6 +271,7 @@ func comparablePartColumnDefinitionForImage(imageDefinition ColumnDefinition, pa
 func comparableColumnDefinition(def ColumnDefinition) ColumnDefinition {
 	def.CodecBlockRows = 0
 	def.Compression = 0
+	def.StatsDisabled = false
 	return def
 }
 
@@ -324,6 +328,9 @@ func (b *columnPartImageBuilder) build() (ColumnPartImage, error) {
 		return ColumnPartImage{}, err
 	}
 	if err := b.addAggregateMetadataSections(); err != nil {
+		return ColumnPartImage{}, err
+	}
+	if err := b.addColumnStatsSection(); err != nil {
 		return ColumnPartImage{}, err
 	}
 	if err := b.addDictionarySection(); err != nil {
@@ -627,6 +634,25 @@ func (b *columnPartImageBuilder) addAggregateMetadataSections() error {
 			Blocks:   metadata.Stats.Entries,
 		}, enc.bytes())
 	}
+	return nil
+}
+
+func (b *columnPartImageBuilder) addColumnStatsSection() error {
+	data, err := encodeColumnPartStatsSection(b.part.ColumnStats)
+	if err != nil {
+		return err
+	}
+	if len(data) == 0 {
+		return nil
+	}
+	b.appendSection(ColumnPartImageSection{
+		Kind:     ColumnPartImageSectionColumnStats,
+		Category: ColumnPartImageCategoryColumnStats,
+		Name:     "column_stats",
+		Rows:     b.part.Descriptor.RowCount,
+		Granules: len(b.part.Descriptor.Granules),
+		Blocks:   countColumnBlocks(b.part.Descriptor),
+	}, data)
 	return nil
 }
 
@@ -971,6 +997,7 @@ var columnPartImageSectionCodes = []columnPartImageSectionCode{
 	{kind: ColumnPartImageSectionColumnData, kindCode: 7, category: ColumnPartImageCategoryDeclaredColumns, categoryCode: 7},
 	{kind: ColumnPartImageSectionManifest, kindCode: 8, category: ColumnPartImageCategoryManifest, categoryCode: 8},
 	{kind: ColumnPartImageSectionLayoutContract, kindCode: 9, category: ColumnPartImageCategoryLayoutContract, categoryCode: 9},
+	{kind: ColumnPartImageSectionColumnStats, kindCode: 10, category: ColumnPartImageCategoryColumnStats, categoryCode: 10},
 }
 
 func columnPartImageSectionKindCode(kind ColumnPartImageSectionKind) (uint16, error) {

--- a/TreeDB/internal/typedcolumn/part_image_decode.go
+++ b/TreeDB/internal/typedcolumn/part_image_decode.go
@@ -232,6 +232,7 @@ type ColumnPartImageReadOptions struct {
 	IncludeRowLocators       bool
 	ValidateRowLocators      bool
 	IncludeAggregateMetadata bool
+	IncludeColumnStats       bool
 }
 
 func ColumnPartFromImage(image ColumnPartImage) (*ColumnPart, error) {
@@ -239,6 +240,7 @@ func ColumnPartFromImage(image ColumnPartImage) (*ColumnPart, error) {
 		IncludeRowLocators:       true,
 		ValidateRowLocators:      true,
 		IncludeAggregateMetadata: true,
+		IncludeColumnStats:       true,
 	})
 }
 
@@ -321,6 +323,13 @@ func ColumnPartFromImageWithOptions(image ColumnPartImage, opts ColumnPartImageR
 			return nil, err
 		}
 	}
+	var columnStats ColumnPartStats
+	if opts.IncludeColumnStats {
+		columnStats, err = decodeColumnStatsSectionFromImage(image, desc, columns)
+		if err != nil {
+			return nil, err
+		}
+	}
 	aggregateDefinitions := make([]AggregateMetadataDefinition, 0, len(aggregateMetadata))
 	for _, metadata := range aggregateMetadata {
 		aggregateDefinitions = append(aggregateDefinitions, metadata.Definition)
@@ -350,6 +359,7 @@ func ColumnPartFromImageWithOptions(image ColumnPartImage, opts ColumnPartImageR
 		Marks:             marks,
 		Locators:          locators,
 		AggregateMetadata: aggregateMetadata,
+		ColumnStats:       columnStats,
 	}
 	return part, nil
 }
@@ -1951,6 +1961,7 @@ func validateImageSectionMultiplicity(sections []ColumnPartImageSection) error {
 		ColumnPartImageSectionRowLocators,
 		ColumnPartImageSectionDictionaries,
 		ColumnPartImageSectionLayoutContract,
+		ColumnPartImageSectionColumnStats,
 	} {
 		if counts[kind] > 1 {
 			return fmt.Errorf("typedcolumn: image has %d %s sections, want at most 1", counts[kind], kind)
@@ -1979,6 +1990,8 @@ func expectedImageSectionCategory(kind ColumnPartImageSectionKind) (ColumnPartIm
 		return ColumnPartImageCategoryLocators, true
 	case ColumnPartImageSectionAggregateMetadata:
 		return ColumnPartImageCategoryAggregateMetadata, true
+	case ColumnPartImageSectionColumnStats:
+		return ColumnPartImageCategoryColumnStats, true
 	case ColumnPartImageSectionDictionaries:
 		return ColumnPartImageCategoryDictionaries, true
 	case ColumnPartImageSectionLayoutContract:

--- a/TreeDB/internal/typedcolumn/stats.go
+++ b/TreeDB/internal/typedcolumn/stats.go
@@ -1,0 +1,1006 @@
+package typedcolumn
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/snissn/gomap/TreeDB/internal/crc"
+)
+
+const (
+	columnPartStatsSectionMagic   = uint32(0x54435354) // TCST
+	columnPartStatsSectionVersion = uint16(1)
+	ColumnStatsEnvelopeVersion    = uint16(1)
+	Int64StatsPayloadVersion      = uint16(1)
+)
+
+// ColumnStatsOperation is stored as the semantic operation string advertised by
+// a stats envelope. The values intentionally match columnsemantics.Operation
+// without importing that package into typedcolumn.
+type ColumnStatsOperation string
+
+const (
+	ColumnStatsOpCountRows    ColumnStatsOperation = "aggregate.count_rows"
+	ColumnStatsOpCountNonNull ColumnStatsOperation = "aggregate.count_non_null"
+	ColumnStatsOpSum          ColumnStatsOperation = "aggregate.sum"
+	ColumnStatsOpAvg          ColumnStatsOperation = "aggregate.avg"
+	ColumnStatsOpMin          ColumnStatsOperation = "aggregate.min"
+	ColumnStatsOpMax          ColumnStatsOperation = "aggregate.max"
+	ColumnStatsOpStatsMinMax  ColumnStatsOperation = "stats.min_max"
+	ColumnStatsOpStatsSum     ColumnStatsOperation = "stats.sum"
+)
+
+// ColumnStatsSelectionShape records the row-selection domains an envelope can
+// answer without decoding values. Narrower/random selections must not use a
+// payload unless a future type-specific stats format advertises that shape.
+type ColumnStatsSelectionShape string
+
+const (
+	ColumnStatsSelectionAllRows   ColumnStatsSelectionShape = "all_rows"
+	ColumnStatsSelectionFullBlock ColumnStatsSelectionShape = "full_block"
+)
+
+type ColumnStatsPayloadKind string
+
+const (
+	ColumnStatsPayloadInt64V1      ColumnStatsPayloadKind = "int64_count_sum_min_max_v1"
+	ColumnStatsPayloadUnsupported  ColumnStatsPayloadKind = "unsupported"
+	ColumnStatsPayloadFuturePrefix ColumnStatsPayloadKind = "future"
+)
+
+const (
+	ColumnStatsReasonSupported            = "supported"
+	ColumnStatsReasonUnsupportedPayload   = "stats_payload_unsupported"
+	ColumnStatsReasonOperationUnsupported = "operation_unsupported"
+	ColumnStatsReasonSelectionUnsupported = "selection_shape_unsupported"
+	ColumnStatsReasonChecksumMismatch     = "checksum_mismatch"
+	ColumnStatsReasonIdentityMismatch     = "identity_mismatch"
+	ColumnStatsReasonRowCountMismatch     = "row_count_mismatch"
+	ColumnStatsReasonNullDefaultMismatch  = "null_default_count_mismatch"
+	ColumnStatsReasonVisibilityMismatch   = "visibility_count_mismatch"
+	ColumnStatsReasonMinMaxMismatch       = "min_max_mismatch"
+	ColumnStatsReasonSumOverflow          = "sum_overflow"
+)
+
+type ColumnStatsEnvelope struct {
+	Version         uint16
+	PartID          uint64
+	ColumnName      string
+	ColumnType      ColumnType
+	Encoding        Encoding
+	Compression     Compression
+	Rows            int
+	Blocks          int
+	NullCount       int
+	DefaultCount    int
+	VisibleCount    int
+	ValueCount      int
+	PayloadKind     ColumnStatsPayloadKind
+	Operations      []ColumnStatsOperation
+	SelectionShapes []ColumnStatsSelectionShape
+	PayloadLength   int
+	PayloadChecksum uint32
+}
+
+type Int64BlockStats struct {
+	Index        int
+	FirstRow     int
+	RowCount     int
+	NullCount    int
+	DefaultCount int
+	VisibleCount int
+	ValueCount   int
+	Sum          int64
+	SumValid     bool
+	HasMinMax    bool
+	Min          int64
+	Max          int64
+}
+
+type Int64ColumnStats struct {
+	Envelope     ColumnStatsEnvelope
+	Count        int
+	NullCount    int
+	DefaultCount int
+	VisibleCount int
+	ValueCount   int
+	Sum          int64
+	SumValid     bool
+	HasMinMax    bool
+	Min          int64
+	Max          int64
+	Blocks       []Int64BlockStats
+}
+
+type ColumnPartStats struct {
+	Version uint16
+	PartID  uint64
+	Rows    int
+	Int64   map[string]Int64ColumnStats
+}
+
+func (s ColumnPartStats) Empty() bool {
+	return len(s.Int64) == 0
+}
+
+func (s ColumnPartStats) Int64Column(name string) (Int64ColumnStats, bool) {
+	if s.Int64 == nil {
+		return Int64ColumnStats{}, false
+	}
+	stats, ok := s.Int64[name]
+	return stats, ok
+}
+
+func (s Int64ColumnStats) Block(index int) (Int64BlockStats, bool) {
+	if index < 0 || index >= len(s.Blocks) {
+		return Int64BlockStats{}, false
+	}
+	block := s.Blocks[index]
+	if block.Index != index {
+		return Int64BlockStats{}, false
+	}
+	return block, true
+}
+
+func (e ColumnStatsEnvelope) SupportsOperation(op ColumnStatsOperation) bool {
+	for _, advertised := range e.Operations {
+		if advertised == op {
+			return true
+		}
+	}
+	return false
+}
+
+func (e ColumnStatsEnvelope) SupportsSelectionShape(shape ColumnStatsSelectionShape) bool {
+	for _, advertised := range e.SelectionShapes {
+		if advertised == shape {
+			return true
+		}
+	}
+	return false
+}
+
+func (s Int64ColumnStats) CanAnswer(op ColumnStatsOperation, shape ColumnStatsSelectionShape) (bool, string) {
+	if s.Envelope.PayloadKind != ColumnStatsPayloadInt64V1 {
+		return false, ColumnStatsReasonUnsupportedPayload
+	}
+	if !s.Envelope.SupportsOperation(op) {
+		return false, ColumnStatsReasonOperationUnsupported
+	}
+	if !s.Envelope.SupportsSelectionShape(shape) {
+		return false, ColumnStatsReasonSelectionUnsupported
+	}
+	if (op == ColumnStatsOpSum || op == ColumnStatsOpAvg || op == ColumnStatsOpStatsSum) && shape == ColumnStatsSelectionAllRows && !s.SumValid {
+		return false, ColumnStatsReasonSumOverflow
+	}
+	return true, ColumnStatsReasonSupported
+}
+
+func (b Int64BlockStats) CanAnswer(op ColumnStatsOperation) (bool, string) {
+	switch op {
+	case ColumnStatsOpCountRows, ColumnStatsOpCountNonNull, ColumnStatsOpMin, ColumnStatsOpMax, ColumnStatsOpStatsMinMax:
+		return true, ColumnStatsReasonSupported
+	case ColumnStatsOpSum, ColumnStatsOpAvg, ColumnStatsOpStatsSum:
+		if !b.SumValid {
+			return false, ColumnStatsReasonSumOverflow
+		}
+		return true, ColumnStatsReasonSupported
+	default:
+		return false, ColumnStatsReasonOperationUnsupported
+	}
+}
+
+func buildColumnPartStats(part *ColumnPart) (ColumnPartStats, error) {
+	if part == nil {
+		return ColumnPartStats{}, fmt.Errorf("typedcolumn: nil part")
+	}
+	out := ColumnPartStats{Version: columnPartStatsSectionVersion, PartID: part.Descriptor.PartID, Rows: part.Descriptor.RowCount}
+	for _, columnDesc := range part.Descriptor.Columns {
+		if columnDesc.Type != ColumnTypeInt64 {
+			continue
+		}
+		column, ok := part.Columns[columnDesc.Name]
+		if !ok {
+			return ColumnPartStats{}, fmt.Errorf("typedcolumn: stats missing column %s", columnDesc.Name)
+		}
+		stats, ok, err := buildInt64ColumnStats(part.Descriptor, columnDesc, column)
+		if err != nil {
+			return ColumnPartStats{}, err
+		}
+		if !ok {
+			continue
+		}
+		if out.Int64 == nil {
+			out.Int64 = make(map[string]Int64ColumnStats)
+		}
+		out.Int64[columnDesc.Name] = stats
+	}
+	return out, nil
+}
+
+func buildInt64ColumnStats(desc ColumnPartDescriptor, columnDesc ColumnPartColumnDescriptor, column ColumnPartColumn) (Int64ColumnStats, bool, error) {
+	if column.Definition.StatsDisabled || column.Definition.Type != ColumnTypeInt64 || column.Definition.Encoding == EncodingNullableInt64 {
+		return Int64ColumnStats{}, false, nil
+	}
+	if column.Definition.Compression != CompressionNone {
+		// Current stats are still correct for compressed blocks, but the #1840
+		// prepared shortcut is intentionally scoped to writer-certified non-null
+		// int64 reducer layouts. Leave compressed values to the decode path.
+		return Int64ColumnStats{}, false, nil
+	}
+	stats := Int64ColumnStats{
+		Envelope: ColumnStatsEnvelope{
+			Version:     ColumnStatsEnvelopeVersion,
+			PartID:      desc.PartID,
+			ColumnName:  columnDesc.Name,
+			ColumnType:  columnDesc.Type,
+			Encoding:    column.Definition.Encoding,
+			Compression: column.Definition.Compression,
+			Rows:        desc.RowCount,
+			Blocks:      len(column.Blocks),
+			PayloadKind: ColumnStatsPayloadInt64V1,
+			Operations:  []ColumnStatsOperation{ColumnStatsOpCountRows, ColumnStatsOpCountNonNull, ColumnStatsOpMin, ColumnStatsOpMax, ColumnStatsOpStatsMinMax},
+			SelectionShapes: []ColumnStatsSelectionShape{
+				ColumnStatsSelectionFullBlock,
+			},
+		},
+		Blocks:   make([]Int64BlockStats, 0, len(column.Blocks)),
+		SumValid: true,
+	}
+	partHasMinMax := false
+	partMin, partMax := int64(0), int64(0)
+	var reader GranuleReader
+	for i, block := range column.Blocks {
+		if i >= len(columnDesc.Blocks) {
+			return Int64ColumnStats{}, false, fmt.Errorf("typedcolumn: stats column %s block %d missing descriptor", columnDesc.Name, i)
+		}
+		if block.Descriptor != columnDesc.Blocks[i] {
+			return Int64ColumnStats{}, false, fmt.Errorf("typedcolumn: stats column %s block %d descriptor mismatch", columnDesc.Name, i)
+		}
+		blockStats, err := buildInt64BlockStats(&reader, i, block)
+		if err != nil {
+			return Int64ColumnStats{}, false, fmt.Errorf("typedcolumn: stats column %s block %d: %w", columnDesc.Name, i, err)
+		}
+		stats.Blocks = append(stats.Blocks, blockStats)
+		stats.Count += blockStats.RowCount
+		stats.NullCount += blockStats.NullCount
+		stats.DefaultCount += blockStats.DefaultCount
+		stats.VisibleCount += blockStats.VisibleCount
+		stats.ValueCount += blockStats.ValueCount
+		if blockStats.HasMinMax {
+			partMin, partMax, partHasMinMax = updateOptionalMinMax(partMin, partMax, partHasMinMax, blockStats.Min)
+			partMin, partMax, partHasMinMax = updateOptionalMinMax(partMin, partMax, partHasMinMax, blockStats.Max)
+		}
+		if stats.SumValid && blockStats.SumValid {
+			updated, err := checkedInt64Add(stats.Sum, blockStats.Sum)
+			if err != nil {
+				stats.SumValid = false
+				stats.Sum = 0
+			} else {
+				stats.Sum = updated
+			}
+		} else {
+			stats.SumValid = false
+			stats.Sum = 0
+		}
+	}
+	if stats.Count != desc.RowCount {
+		return Int64ColumnStats{}, false, fmt.Errorf("typedcolumn: stats column %s row count=%d want part rows=%d", columnDesc.Name, stats.Count, desc.RowCount)
+	}
+	stats.HasMinMax = partHasMinMax
+	stats.Min = partMin
+	stats.Max = partMax
+	stats.Envelope.NullCount = stats.NullCount
+	stats.Envelope.DefaultCount = stats.DefaultCount
+	stats.Envelope.VisibleCount = stats.VisibleCount
+	stats.Envelope.ValueCount = stats.ValueCount
+	if anyInt64BlockSumValid(stats.Blocks) {
+		stats.Envelope.Operations = append(stats.Envelope.Operations, ColumnStatsOpSum, ColumnStatsOpAvg, ColumnStatsOpStatsSum)
+	}
+	if stats.SumValid {
+		stats.Envelope.SelectionShapes = append(stats.Envelope.SelectionShapes, ColumnStatsSelectionAllRows)
+	}
+	return stats, true, nil
+}
+
+func buildInt64BlockStats(reader *GranuleReader, index int, block ColumnBlock) (Int64BlockStats, error) {
+	g := block.Granule
+	if g.Rows != block.Descriptor.RowCount {
+		return Int64BlockStats{}, fmt.Errorf("granule rows=%d descriptor rows=%d", g.Rows, block.Descriptor.RowCount)
+	}
+	stats := Int64BlockStats{
+		Index:        index,
+		FirstRow:     block.Descriptor.FirstRow,
+		RowCount:     block.Descriptor.RowCount,
+		NullCount:    g.NullCount,
+		DefaultCount: g.DefaultCount,
+		VisibleCount: block.Descriptor.RowCount,
+		ValueCount:   block.Descriptor.RowCount - g.NullCount - g.DefaultCount,
+		SumValid:     true,
+		HasMinMax:    g.HasMinMax,
+		Min:          g.Min,
+		Max:          g.Max,
+	}
+	if stats.ValueCount < 0 {
+		return Int64BlockStats{}, fmt.Errorf("value count=%d from rows=%d nulls=%d defaults=%d", stats.ValueCount, stats.RowCount, g.NullCount, g.DefaultCount)
+	}
+	if g.NullCount != 0 || g.DefaultCount != 0 {
+		return Int64BlockStats{}, fmt.Errorf("non-null int64 stats got null/default counts %d/%d", g.NullCount, g.DefaultCount)
+	}
+	cursor, err := reader.Int64Cursor(g)
+	if err != nil {
+		return Int64BlockStats{}, err
+	}
+	for row := 0; row < g.Rows; row++ {
+		value, err := cursor.Next()
+		if err != nil {
+			return Int64BlockStats{}, err
+		}
+		if !stats.SumValid {
+			continue
+		}
+		updated, err := checkedInt64Add(stats.Sum, value)
+		if err != nil {
+			stats.SumValid = false
+			stats.Sum = 0
+			continue
+		}
+		stats.Sum = updated
+	}
+	if err := cursor.Finish(); err != nil {
+		return Int64BlockStats{}, err
+	}
+	return stats, nil
+}
+
+func anyInt64BlockSumValid(blocks []Int64BlockStats) bool {
+	for _, block := range blocks {
+		if block.SumValid {
+			return true
+		}
+	}
+	return false
+}
+
+func encodeColumnPartStatsSection(stats ColumnPartStats) ([]byte, error) {
+	if stats.Empty() {
+		return nil, nil
+	}
+	var enc columnPartImageEncoder
+	enc.u32(columnPartStatsSectionMagic)
+	enc.u16(columnPartStatsSectionVersion)
+	enc.u16(0)
+	enc.u64(stats.PartID)
+	enc.i64(int64(stats.Rows))
+	names := make([]string, 0, len(stats.Int64))
+	for name := range stats.Int64 {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	enc.u32(uint32(len(names)))
+	for _, name := range names {
+		columnStats := stats.Int64[name]
+		payload, err := encodeInt64StatsPayload(columnStats)
+		if err != nil {
+			return nil, err
+		}
+		envelope := columnStats.Envelope
+		envelope.PayloadLength = len(payload)
+		envelope.PayloadChecksum = crc.Checksum(payload)
+		if err := encodeColumnStatsEnvelope(&enc, envelope); err != nil {
+			return nil, err
+		}
+		enc.buf = append(enc.buf, payload...)
+	}
+	return enc.bytes(), nil
+}
+
+func (i ColumnPartImage) ColumnStatsSection() (ColumnPartImageSection, bool, error) {
+	sections := i.sectionsByKind(ColumnPartImageSectionColumnStats)
+	if len(sections) == 0 {
+		return ColumnPartImageSection{}, false, nil
+	}
+	if len(sections) != 1 {
+		return ColumnPartImageSection{}, false, fmt.Errorf("typedcolumn: image has %d %s sections, want at most 1", len(sections), ColumnPartImageSectionColumnStats)
+	}
+	return sections[0], true, nil
+}
+
+func decodeColumnStatsSectionFromImage(image ColumnPartImage, desc ColumnPartDescriptor, columns map[string]ColumnPartColumn) (ColumnPartStats, error) {
+	section, ok, err := image.ColumnStatsSection()
+	if err != nil || !ok {
+		return ColumnPartStats{}, err
+	}
+	stats, err := DecodeColumnPartStatsSection(image.sectionBytes(section))
+	if err != nil {
+		return ColumnPartStats{}, err
+	}
+	if err := ValidateColumnPartStats(stats, desc, columns); err != nil {
+		return ColumnPartStats{}, err
+	}
+	return stats, nil
+}
+
+func DecodeColumnPartStatsSection(data []byte) (ColumnPartStats, error) {
+	dec := columnPartImageDecoder{data: data}
+	magic, err := dec.u32()
+	if err != nil {
+		return ColumnPartStats{}, err
+	}
+	if magic != columnPartStatsSectionMagic {
+		return ColumnPartStats{}, fmt.Errorf("typedcolumn: bad column stats section magic=0x%08x", magic)
+	}
+	version, err := dec.u16()
+	if err != nil {
+		return ColumnPartStats{}, err
+	}
+	if version != columnPartStatsSectionVersion {
+		return ColumnPartStats{}, fmt.Errorf("typedcolumn: unsupported column stats section version=%d", version)
+	}
+	reserved, err := dec.u16()
+	if err != nil {
+		return ColumnPartStats{}, err
+	}
+	if reserved != 0 {
+		return ColumnPartStats{}, fmt.Errorf("typedcolumn: column stats section reserved=%d want 0", reserved)
+	}
+	partID, err := dec.u64()
+	if err != nil {
+		return ColumnPartStats{}, err
+	}
+	rows64, err := dec.i64()
+	if err != nil {
+		return ColumnPartStats{}, err
+	}
+	rows, err := nonNegativeInt64ToInt(rows64, "column stats rows")
+	if err != nil {
+		return ColumnPartStats{}, err
+	}
+	columnCount, err := dec.u32()
+	if err != nil {
+		return ColumnPartStats{}, err
+	}
+	columns, err := dec.boundedCount(columnCount, 96, "column stats entries")
+	if err != nil {
+		return ColumnPartStats{}, err
+	}
+	stats := ColumnPartStats{Version: version, PartID: partID, Rows: rows, Int64: make(map[string]Int64ColumnStats, columns)}
+	for i := 0; i < columns; i++ {
+		envelope, err := decodeColumnStatsEnvelope(&dec)
+		if err != nil {
+			return ColumnPartStats{}, err
+		}
+		payload, err := dec.bytes(envelope.PayloadLength)
+		if err != nil {
+			return ColumnPartStats{}, err
+		}
+		if got := crc.Checksum(payload); got != envelope.PayloadChecksum {
+			return ColumnPartStats{}, fmt.Errorf("typedcolumn: column stats %s payload checksum=%08x want=%08x: %s", envelope.ColumnName, got, envelope.PayloadChecksum, ColumnStatsReasonChecksumMismatch)
+		}
+		switch envelope.PayloadKind {
+		case ColumnStatsPayloadInt64V1:
+			columnStats, err := decodeInt64StatsPayload(envelope, payload)
+			if err != nil {
+				return ColumnPartStats{}, err
+			}
+			if _, exists := stats.Int64[envelope.ColumnName]; exists {
+				return ColumnPartStats{}, fmt.Errorf("typedcolumn: duplicate int64 stats for column %s", envelope.ColumnName)
+			}
+			stats.Int64[envelope.ColumnName] = columnStats
+		default:
+			return ColumnPartStats{}, fmt.Errorf("typedcolumn: unsupported column stats payload %q for column %s: %s", envelope.PayloadKind, envelope.ColumnName, ColumnStatsReasonUnsupportedPayload)
+		}
+	}
+	if err := dec.finish(); err != nil {
+		return ColumnPartStats{}, err
+	}
+	return stats, nil
+}
+
+func encodeColumnStatsEnvelope(enc *columnPartImageEncoder, envelope ColumnStatsEnvelope) error {
+	if envelope.Version == 0 {
+		envelope.Version = ColumnStatsEnvelopeVersion
+	}
+	if envelope.Version != ColumnStatsEnvelopeVersion {
+		return fmt.Errorf("typedcolumn: unsupported column stats envelope version=%d", envelope.Version)
+	}
+	if envelope.ColumnName == "" {
+		return fmt.Errorf("typedcolumn: column stats envelope requires column name")
+	}
+	columnType, err := columnTypeCode(envelope.ColumnType)
+	if err != nil {
+		return err
+	}
+	enc.u16(envelope.Version)
+	enc.u16(0)
+	enc.u64(envelope.PartID)
+	enc.str(envelope.ColumnName)
+	enc.u16(columnType)
+	enc.u16(uint16(envelope.Encoding))
+	enc.u16(uint16(envelope.Compression))
+	enc.u16(0)
+	enc.i64(int64(envelope.Rows))
+	enc.i64(int64(envelope.Blocks))
+	enc.i64(int64(envelope.NullCount))
+	enc.i64(int64(envelope.DefaultCount))
+	enc.i64(int64(envelope.VisibleCount))
+	enc.i64(int64(envelope.ValueCount))
+	enc.str(string(envelope.PayloadKind))
+	operations := make([]string, len(envelope.Operations))
+	for i, op := range envelope.Operations {
+		operations[i] = string(op)
+	}
+	enc.stringSlice(operations)
+	shapes := make([]string, len(envelope.SelectionShapes))
+	for i, shape := range envelope.SelectionShapes {
+		shapes[i] = string(shape)
+	}
+	enc.stringSlice(shapes)
+	enc.i64(int64(envelope.PayloadLength))
+	enc.u32(envelope.PayloadChecksum)
+	enc.u32(0)
+	return nil
+}
+
+func decodeColumnStatsEnvelope(dec *columnPartImageDecoder) (ColumnStatsEnvelope, error) {
+	version, err := dec.u16()
+	if err != nil {
+		return ColumnStatsEnvelope{}, err
+	}
+	if version != ColumnStatsEnvelopeVersion {
+		return ColumnStatsEnvelope{}, fmt.Errorf("typedcolumn: unsupported column stats envelope version=%d", version)
+	}
+	reserved, err := dec.u16()
+	if err != nil {
+		return ColumnStatsEnvelope{}, err
+	}
+	if reserved != 0 {
+		return ColumnStatsEnvelope{}, fmt.Errorf("typedcolumn: column stats envelope reserved=%d want 0", reserved)
+	}
+	partID, err := dec.u64()
+	if err != nil {
+		return ColumnStatsEnvelope{}, err
+	}
+	columnName, err := dec.str()
+	if err != nil {
+		return ColumnStatsEnvelope{}, err
+	}
+	columnTypeCode, err := dec.u16()
+	if err != nil {
+		return ColumnStatsEnvelope{}, err
+	}
+	columnType, err := columnTypeFromCode(columnTypeCode)
+	if err != nil {
+		return ColumnStatsEnvelope{}, err
+	}
+	encoding, err := dec.u16()
+	if err != nil {
+		return ColumnStatsEnvelope{}, err
+	}
+	compression, err := dec.u16()
+	if err != nil {
+		return ColumnStatsEnvelope{}, err
+	}
+	reserved, err = dec.u16()
+	if err != nil {
+		return ColumnStatsEnvelope{}, err
+	}
+	if reserved != 0 {
+		return ColumnStatsEnvelope{}, fmt.Errorf("typedcolumn: column stats envelope encoding reserved=%d want 0", reserved)
+	}
+	rows, err := decodeStatsInt(dec, "column stats rows")
+	if err != nil {
+		return ColumnStatsEnvelope{}, err
+	}
+	blocks, err := decodeStatsInt(dec, "column stats blocks")
+	if err != nil {
+		return ColumnStatsEnvelope{}, err
+	}
+	nullCount, err := decodeStatsInt(dec, "column stats null count")
+	if err != nil {
+		return ColumnStatsEnvelope{}, err
+	}
+	defaultCount, err := decodeStatsInt(dec, "column stats default count")
+	if err != nil {
+		return ColumnStatsEnvelope{}, err
+	}
+	visibleCount, err := decodeStatsInt(dec, "column stats visible count")
+	if err != nil {
+		return ColumnStatsEnvelope{}, err
+	}
+	valueCount, err := decodeStatsInt(dec, "column stats value count")
+	if err != nil {
+		return ColumnStatsEnvelope{}, err
+	}
+	payloadKind, err := dec.str()
+	if err != nil {
+		return ColumnStatsEnvelope{}, err
+	}
+	operationStrings, err := dec.stringSlice()
+	if err != nil {
+		return ColumnStatsEnvelope{}, err
+	}
+	operations := make([]ColumnStatsOperation, len(operationStrings))
+	for i, op := range operationStrings {
+		operations[i] = ColumnStatsOperation(op)
+	}
+	shapeStrings, err := dec.stringSlice()
+	if err != nil {
+		return ColumnStatsEnvelope{}, err
+	}
+	shapes := make([]ColumnStatsSelectionShape, len(shapeStrings))
+	for i, shape := range shapeStrings {
+		shapes[i] = ColumnStatsSelectionShape(shape)
+	}
+	payloadLength, err := decodeStatsInt(dec, "column stats payload length")
+	if err != nil {
+		return ColumnStatsEnvelope{}, err
+	}
+	payloadChecksum, err := dec.u32()
+	if err != nil {
+		return ColumnStatsEnvelope{}, err
+	}
+	reserved32, err := dec.u32()
+	if err != nil {
+		return ColumnStatsEnvelope{}, err
+	}
+	if reserved32 != 0 {
+		return ColumnStatsEnvelope{}, fmt.Errorf("typedcolumn: column stats envelope trailer reserved=%d want 0", reserved32)
+	}
+	return ColumnStatsEnvelope{
+		Version:         version,
+		PartID:          partID,
+		ColumnName:      columnName,
+		ColumnType:      columnType,
+		Encoding:        Encoding(encoding),
+		Compression:     Compression(compression),
+		Rows:            rows,
+		Blocks:          blocks,
+		NullCount:       nullCount,
+		DefaultCount:    defaultCount,
+		VisibleCount:    visibleCount,
+		ValueCount:      valueCount,
+		PayloadKind:     ColumnStatsPayloadKind(payloadKind),
+		Operations:      operations,
+		SelectionShapes: shapes,
+		PayloadLength:   payloadLength,
+		PayloadChecksum: payloadChecksum,
+	}, nil
+}
+
+func encodeInt64StatsPayload(stats Int64ColumnStats) ([]byte, error) {
+	var enc columnPartImageEncoder
+	enc.u16(Int64StatsPayloadVersion)
+	enc.u16(0)
+	enc.i64(int64(stats.Count))
+	enc.i64(int64(stats.NullCount))
+	enc.i64(int64(stats.DefaultCount))
+	enc.i64(int64(stats.VisibleCount))
+	enc.i64(int64(stats.ValueCount))
+	enc.boolean(stats.SumValid)
+	enc.i64(stats.Sum)
+	enc.boolean(stats.HasMinMax)
+	enc.i64(stats.Min)
+	enc.i64(stats.Max)
+	enc.u32(uint32(len(stats.Blocks)))
+	for _, block := range stats.Blocks {
+		enc.i64(int64(block.Index))
+		enc.i64(int64(block.FirstRow))
+		enc.i64(int64(block.RowCount))
+		enc.i64(int64(block.NullCount))
+		enc.i64(int64(block.DefaultCount))
+		enc.i64(int64(block.VisibleCount))
+		enc.i64(int64(block.ValueCount))
+		enc.boolean(block.SumValid)
+		enc.i64(block.Sum)
+		enc.boolean(block.HasMinMax)
+		enc.i64(block.Min)
+		enc.i64(block.Max)
+	}
+	return enc.bytes(), nil
+}
+
+func decodeInt64StatsPayload(envelope ColumnStatsEnvelope, payload []byte) (Int64ColumnStats, error) {
+	dec := columnPartImageDecoder{data: payload}
+	version, err := dec.u16()
+	if err != nil {
+		return Int64ColumnStats{}, err
+	}
+	if version != Int64StatsPayloadVersion {
+		return Int64ColumnStats{}, fmt.Errorf("typedcolumn: unsupported int64 stats payload version=%d", version)
+	}
+	reserved, err := dec.u16()
+	if err != nil {
+		return Int64ColumnStats{}, err
+	}
+	if reserved != 0 {
+		return Int64ColumnStats{}, fmt.Errorf("typedcolumn: int64 stats reserved=%d want 0", reserved)
+	}
+	count, err := decodeStatsInt(&dec, "int64 stats count")
+	if err != nil {
+		return Int64ColumnStats{}, err
+	}
+	nullCount, err := decodeStatsInt(&dec, "int64 stats null count")
+	if err != nil {
+		return Int64ColumnStats{}, err
+	}
+	defaultCount, err := decodeStatsInt(&dec, "int64 stats default count")
+	if err != nil {
+		return Int64ColumnStats{}, err
+	}
+	visibleCount, err := decodeStatsInt(&dec, "int64 stats visible count")
+	if err != nil {
+		return Int64ColumnStats{}, err
+	}
+	valueCount, err := decodeStatsInt(&dec, "int64 stats value count")
+	if err != nil {
+		return Int64ColumnStats{}, err
+	}
+	sumValid, err := dec.boolean()
+	if err != nil {
+		return Int64ColumnStats{}, err
+	}
+	sum, err := dec.i64()
+	if err != nil {
+		return Int64ColumnStats{}, err
+	}
+	hasMinMax, err := dec.boolean()
+	if err != nil {
+		return Int64ColumnStats{}, err
+	}
+	minValue, err := dec.i64()
+	if err != nil {
+		return Int64ColumnStats{}, err
+	}
+	maxValue, err := dec.i64()
+	if err != nil {
+		return Int64ColumnStats{}, err
+	}
+	blockCount, err := dec.u32()
+	if err != nil {
+		return Int64ColumnStats{}, err
+	}
+	blocks, err := dec.boundedCount(blockCount, 84, "int64 stats blocks")
+	if err != nil {
+		return Int64ColumnStats{}, err
+	}
+	stats := Int64ColumnStats{
+		Envelope:     envelope,
+		Count:        count,
+		NullCount:    nullCount,
+		DefaultCount: defaultCount,
+		VisibleCount: visibleCount,
+		ValueCount:   valueCount,
+		Sum:          sum,
+		SumValid:     sumValid,
+		HasMinMax:    hasMinMax,
+		Min:          minValue,
+		Max:          maxValue,
+		Blocks:       make([]Int64BlockStats, 0, blocks),
+	}
+	for i := 0; i < blocks; i++ {
+		block, err := decodeInt64BlockStats(&dec)
+		if err != nil {
+			return Int64ColumnStats{}, err
+		}
+		if block.Index != i {
+			return Int64ColumnStats{}, fmt.Errorf("typedcolumn: int64 stats block index=%d want %d", block.Index, i)
+		}
+		stats.Blocks = append(stats.Blocks, block)
+	}
+	if err := dec.finish(); err != nil {
+		return Int64ColumnStats{}, err
+	}
+	return stats, nil
+}
+
+func decodeInt64BlockStats(dec *columnPartImageDecoder) (Int64BlockStats, error) {
+	index, err := decodeStatsInt(dec, "int64 stats block index")
+	if err != nil {
+		return Int64BlockStats{}, err
+	}
+	firstRow, err := decodeStatsInt(dec, "int64 stats block first row")
+	if err != nil {
+		return Int64BlockStats{}, err
+	}
+	rowCount, err := decodeStatsInt(dec, "int64 stats block row count")
+	if err != nil {
+		return Int64BlockStats{}, err
+	}
+	nullCount, err := decodeStatsInt(dec, "int64 stats block null count")
+	if err != nil {
+		return Int64BlockStats{}, err
+	}
+	defaultCount, err := decodeStatsInt(dec, "int64 stats block default count")
+	if err != nil {
+		return Int64BlockStats{}, err
+	}
+	visibleCount, err := decodeStatsInt(dec, "int64 stats block visible count")
+	if err != nil {
+		return Int64BlockStats{}, err
+	}
+	valueCount, err := decodeStatsInt(dec, "int64 stats block value count")
+	if err != nil {
+		return Int64BlockStats{}, err
+	}
+	sumValid, err := dec.boolean()
+	if err != nil {
+		return Int64BlockStats{}, err
+	}
+	sum, err := dec.i64()
+	if err != nil {
+		return Int64BlockStats{}, err
+	}
+	hasMinMax, err := dec.boolean()
+	if err != nil {
+		return Int64BlockStats{}, err
+	}
+	minValue, err := dec.i64()
+	if err != nil {
+		return Int64BlockStats{}, err
+	}
+	maxValue, err := dec.i64()
+	if err != nil {
+		return Int64BlockStats{}, err
+	}
+	return Int64BlockStats{Index: index, FirstRow: firstRow, RowCount: rowCount, NullCount: nullCount, DefaultCount: defaultCount, VisibleCount: visibleCount, ValueCount: valueCount, Sum: sum, SumValid: sumValid, HasMinMax: hasMinMax, Min: minValue, Max: maxValue}, nil
+}
+
+func (d *columnPartImageDecoder) bytes(n int) ([]byte, error) {
+	if err := d.require(n); err != nil {
+		return nil, err
+	}
+	out := d.data[d.offset : d.offset+n]
+	d.offset += n
+	return out, nil
+}
+
+func decodeStatsInt(dec *columnPartImageDecoder, field string) (int, error) {
+	v, err := dec.i64()
+	if err != nil {
+		return 0, err
+	}
+	return nonNegativeInt64ToInt(v, field)
+}
+
+func ValidateColumnPartStats(stats ColumnPartStats, desc ColumnPartDescriptor, columns map[string]ColumnPartColumn) error {
+	if stats.Version != columnPartStatsSectionVersion {
+		return fmt.Errorf("typedcolumn: column stats version=%d want %d", stats.Version, columnPartStatsSectionVersion)
+	}
+	if stats.PartID != desc.PartID {
+		return fmt.Errorf("typedcolumn: column stats part_id=%d want %d: %s", stats.PartID, desc.PartID, ColumnStatsReasonIdentityMismatch)
+	}
+	if stats.Rows != desc.RowCount {
+		return fmt.Errorf("typedcolumn: column stats rows=%d want %d: %s", stats.Rows, desc.RowCount, ColumnStatsReasonRowCountMismatch)
+	}
+	columnDescs := make(map[string]ColumnPartColumnDescriptor, len(desc.Columns))
+	for _, columnDesc := range desc.Columns {
+		columnDescs[columnDesc.Name] = columnDesc
+	}
+	for name, int64Stats := range stats.Int64 {
+		columnDesc, ok := columnDescs[name]
+		if !ok {
+			return fmt.Errorf("typedcolumn: column stats %s missing descriptor: %s", name, ColumnStatsReasonIdentityMismatch)
+		}
+		column, ok := columns[name]
+		if !ok {
+			return fmt.Errorf("typedcolumn: column stats %s missing column: %s", name, ColumnStatsReasonIdentityMismatch)
+		}
+		if err := ValidateInt64ColumnStats(int64Stats, desc, columnDesc, column); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func ValidateInt64ColumnStats(stats Int64ColumnStats, desc ColumnPartDescriptor, columnDesc ColumnPartColumnDescriptor, column ColumnPartColumn) error {
+	envelope := stats.Envelope
+	if envelope.Version != ColumnStatsEnvelopeVersion {
+		return fmt.Errorf("typedcolumn: column stats %s envelope version=%d want %d", envelope.ColumnName, envelope.Version, ColumnStatsEnvelopeVersion)
+	}
+	if envelope.PartID != desc.PartID || envelope.PartID != stats.Envelope.PartID {
+		return fmt.Errorf("typedcolumn: column stats %s part_id=%d want %d: %s", envelope.ColumnName, envelope.PartID, desc.PartID, ColumnStatsReasonIdentityMismatch)
+	}
+	if envelope.ColumnName != columnDesc.Name || envelope.ColumnName != column.Definition.Name {
+		return fmt.Errorf("typedcolumn: column stats name=%q descriptor=%q definition=%q: %s", envelope.ColumnName, columnDesc.Name, column.Definition.Name, ColumnStatsReasonIdentityMismatch)
+	}
+	if envelope.ColumnType != ColumnTypeInt64 || columnDesc.Type != ColumnTypeInt64 || column.Definition.Type != ColumnTypeInt64 || envelope.PayloadKind != ColumnStatsPayloadInt64V1 {
+		return fmt.Errorf("typedcolumn: column stats %s int64 payload cannot apply to type envelope=%s descriptor=%s definition=%s payload=%s: %s", envelope.ColumnName, envelope.ColumnType, columnDesc.Type, column.Definition.Type, envelope.PayloadKind, ColumnStatsReasonUnsupportedPayload)
+	}
+	if envelope.Encoding != column.Definition.Encoding || envelope.Compression != column.Definition.Compression {
+		return fmt.Errorf("typedcolumn: column stats %s encoding/compression=%s/%s want %s/%s: %s", envelope.ColumnName, envelope.Encoding, envelope.Compression, column.Definition.Encoding, column.Definition.Compression, ColumnStatsReasonIdentityMismatch)
+	}
+	if envelope.Rows != desc.RowCount || stats.Count != desc.RowCount {
+		return fmt.Errorf("typedcolumn: column stats %s rows envelope=%d count=%d want %d: %s", envelope.ColumnName, envelope.Rows, stats.Count, desc.RowCount, ColumnStatsReasonRowCountMismatch)
+	}
+	if envelope.Blocks != len(column.Blocks) || len(stats.Blocks) != len(column.Blocks) || len(columnDesc.Blocks) != len(column.Blocks) {
+		return fmt.Errorf("typedcolumn: column stats %s blocks envelope=%d payload=%d descriptor=%d column=%d: %s", envelope.ColumnName, envelope.Blocks, len(stats.Blocks), len(columnDesc.Blocks), len(column.Blocks), ColumnStatsReasonRowCountMismatch)
+	}
+	if envelope.NullCount != stats.NullCount || envelope.DefaultCount != stats.DefaultCount || envelope.ValueCount != stats.ValueCount || envelope.VisibleCount != stats.VisibleCount {
+		return fmt.Errorf("typedcolumn: column stats %s envelope count mismatch null/default/visible/value: %s", envelope.ColumnName, ColumnStatsReasonNullDefaultMismatch)
+	}
+	if stats.NullCount != 0 || stats.DefaultCount != 0 {
+		return fmt.Errorf("typedcolumn: column stats %s null/default counts=%d/%d want 0/0: %s", envelope.ColumnName, stats.NullCount, stats.DefaultCount, ColumnStatsReasonNullDefaultMismatch)
+	}
+	if stats.VisibleCount != desc.VisibleRowCount || stats.ValueCount != desc.RowCount {
+		return fmt.Errorf("typedcolumn: column stats %s visible/value=%d/%d want %d/%d: %s", envelope.ColumnName, stats.VisibleCount, stats.ValueCount, desc.VisibleRowCount, desc.RowCount, ColumnStatsReasonVisibilityMismatch)
+	}
+	if stats.HasMinMax && stats.Min > stats.Max {
+		return fmt.Errorf("typedcolumn: column stats %s min=%d max=%d: %s", envelope.ColumnName, stats.Min, stats.Max, ColumnStatsReasonMinMaxMismatch)
+	}
+	rowTotal := 0
+	nullTotal := 0
+	defaultTotal := 0
+	visibleTotal := 0
+	valueTotal := 0
+	partMin, partMax, partHasMinMax := int64(0), int64(0), false
+	partSum, partSumValid := int64(0), true
+	for i, blockStats := range stats.Blocks {
+		block := column.Blocks[i]
+		if blockStats.Index != i || blockStats.FirstRow != block.Descriptor.FirstRow || blockStats.RowCount != block.Descriptor.RowCount {
+			return fmt.Errorf("typedcolumn: column stats %s block %d row identity mismatch stats=(%d,%d,%d) descriptor=(%d,%d): %s", envelope.ColumnName, i, blockStats.Index, blockStats.FirstRow, blockStats.RowCount, block.Descriptor.FirstRow, block.Descriptor.RowCount, ColumnStatsReasonRowCountMismatch)
+		}
+		if blockStats.NullCount != block.Granule.NullCount || blockStats.DefaultCount != block.Granule.DefaultCount {
+			return fmt.Errorf("typedcolumn: column stats %s block %d null/default=%d/%d want %d/%d: %s", envelope.ColumnName, i, blockStats.NullCount, blockStats.DefaultCount, block.Granule.NullCount, block.Granule.DefaultCount, ColumnStatsReasonNullDefaultMismatch)
+		}
+		if blockStats.VisibleCount != blockStats.RowCount {
+			return fmt.Errorf("typedcolumn: column stats %s block %d visible=%d want rows=%d: %s", envelope.ColumnName, i, blockStats.VisibleCount, blockStats.RowCount, ColumnStatsReasonVisibilityMismatch)
+		}
+		if blockStats.ValueCount != blockStats.RowCount-blockStats.NullCount-blockStats.DefaultCount {
+			return fmt.Errorf("typedcolumn: column stats %s block %d value_count=%d rows/null/default=%d/%d/%d: %s", envelope.ColumnName, i, blockStats.ValueCount, blockStats.RowCount, blockStats.NullCount, blockStats.DefaultCount, ColumnStatsReasonNullDefaultMismatch)
+		}
+		if blockStats.HasMinMax != block.Granule.HasMinMax || (blockStats.HasMinMax && (blockStats.Min != block.Granule.Min || blockStats.Max != block.Granule.Max || blockStats.Min > blockStats.Max)) {
+			return fmt.Errorf("typedcolumn: column stats %s block %d min/max mismatch stats=(has=%v min=%d max=%d) granule=(has=%v min=%d max=%d): %s", envelope.ColumnName, i, blockStats.HasMinMax, blockStats.Min, blockStats.Max, block.Granule.HasMinMax, block.Granule.Min, block.Granule.Max, ColumnStatsReasonMinMaxMismatch)
+		}
+		rowTotal += blockStats.RowCount
+		nullTotal += blockStats.NullCount
+		defaultTotal += blockStats.DefaultCount
+		visibleTotal += blockStats.VisibleCount
+		valueTotal += blockStats.ValueCount
+		if blockStats.HasMinMax {
+			partMin, partMax, partHasMinMax = updateOptionalMinMax(partMin, partMax, partHasMinMax, blockStats.Min)
+			partMin, partMax, partHasMinMax = updateOptionalMinMax(partMin, partMax, partHasMinMax, blockStats.Max)
+		}
+		if partSumValid && blockStats.SumValid {
+			updated, err := checkedInt64Add(partSum, blockStats.Sum)
+			if err != nil {
+				partSumValid = false
+				partSum = 0
+			} else {
+				partSum = updated
+			}
+		} else {
+			partSumValid = false
+			partSum = 0
+		}
+	}
+	if rowTotal != desc.RowCount || nullTotal != stats.NullCount || defaultTotal != stats.DefaultCount || visibleTotal != stats.VisibleCount || valueTotal != stats.ValueCount {
+		return fmt.Errorf("typedcolumn: column stats %s totals rows/null/default/visible/value=%d/%d/%d/%d/%d want %d/%d/%d/%d/%d: %s", envelope.ColumnName, rowTotal, nullTotal, defaultTotal, visibleTotal, valueTotal, desc.RowCount, stats.NullCount, stats.DefaultCount, stats.VisibleCount, stats.ValueCount, ColumnStatsReasonRowCountMismatch)
+	}
+	if stats.HasMinMax != partHasMinMax || (stats.HasMinMax && (stats.Min != partMin || stats.Max != partMax)) {
+		return fmt.Errorf("typedcolumn: column stats %s part min/max mismatch: %s", envelope.ColumnName, ColumnStatsReasonMinMaxMismatch)
+	}
+	if stats.SumValid != partSumValid || (stats.SumValid && stats.Sum != partSum) {
+		return fmt.Errorf("typedcolumn: column stats %s part sum mismatch: %s", envelope.ColumnName, ColumnStatsReasonSumOverflow)
+	}
+	return nil
+}
+
+func cloneColumnPartStats(stats ColumnPartStats) ColumnPartStats {
+	out := stats
+	if stats.Int64 != nil {
+		out.Int64 = make(map[string]Int64ColumnStats, len(stats.Int64))
+		for name, columnStats := range stats.Int64 {
+			out.Int64[name] = cloneInt64ColumnStats(columnStats)
+		}
+	}
+	return out
+}
+
+func cloneInt64ColumnStats(stats Int64ColumnStats) Int64ColumnStats {
+	out := stats
+	out.Envelope.Operations = append([]ColumnStatsOperation(nil), stats.Envelope.Operations...)
+	out.Envelope.SelectionShapes = append([]ColumnStatsSelectionShape(nil), stats.Envelope.SelectionShapes...)
+	out.Blocks = append([]Int64BlockStats(nil), stats.Blocks...)
+	return out
+}

--- a/TreeDB/internal/typedcolumn/stats.go
+++ b/TreeDB/internal/typedcolumn/stats.go
@@ -586,11 +586,19 @@ func decodeColumnStatsEnvelope(dec *columnPartImageDecoder) (ColumnStatsEnvelope
 	if err != nil {
 		return ColumnStatsEnvelope{}, err
 	}
-	encoding, err := dec.u16()
+	encodingCode, err := dec.u16()
 	if err != nil {
 		return ColumnStatsEnvelope{}, err
 	}
-	compression, err := dec.u16()
+	encoding, err := decodeStatsEncoding(encodingCode)
+	if err != nil {
+		return ColumnStatsEnvelope{}, err
+	}
+	compressionCode, err := dec.u16()
+	if err != nil {
+		return ColumnStatsEnvelope{}, err
+	}
+	compression, err := decodeStatsCompression(compressionCode)
 	if err != nil {
 		return ColumnStatsEnvelope{}, err
 	}
@@ -665,8 +673,8 @@ func decodeColumnStatsEnvelope(dec *columnPartImageDecoder) (ColumnStatsEnvelope
 		PartID:          partID,
 		ColumnName:      columnName,
 		ColumnType:      columnType,
-		Encoding:        Encoding(encoding),
-		Compression:     Compression(compression),
+		Encoding:        encoding,
+		Compression:     compression,
 		Rows:            rows,
 		Blocks:          blocks,
 		NullCount:       nullCount,
@@ -679,6 +687,32 @@ func decodeColumnStatsEnvelope(dec *columnPartImageDecoder) (ColumnStatsEnvelope
 		PayloadLength:   payloadLength,
 		PayloadChecksum: payloadChecksum,
 	}, nil
+}
+
+func decodeStatsEncoding(code uint16) (Encoding, error) {
+	if code > 0xff {
+		return 0, fmt.Errorf("typedcolumn: column stats envelope encoding=%d exceeds uint8", code)
+	}
+	encoding := Encoding(code)
+	switch encoding {
+	case EncodingRawInt64, EncodingDeltaVarint, EncodingDoubleDeltaVarint, EncodingNullableInt64, EncodingBoolBitpackRLE, EncodingLowCardinalityUint32, EncodingRawFloat32Vector, EncodingRawUint32Dense:
+		return encoding, nil
+	default:
+		return 0, fmt.Errorf("typedcolumn: unknown column stats envelope encoding=%d", code)
+	}
+}
+
+func decodeStatsCompression(code uint16) (Compression, error) {
+	if code > 0xff {
+		return 0, fmt.Errorf("typedcolumn: column stats envelope compression=%d exceeds uint8", code)
+	}
+	compression := Compression(code)
+	switch compression {
+	case CompressionNone, CompressionSnappy, CompressionLZ4, CompressionZSTD, CompressionZSTDDict:
+		return compression, nil
+	default:
+		return 0, fmt.Errorf("typedcolumn: unknown column stats envelope compression=%d", code)
+	}
 }
 
 func encodeInt64StatsPayload(stats Int64ColumnStats) ([]byte, error) {

--- a/TreeDB/internal/typedcolumn/stats.go
+++ b/TreeDB/internal/typedcolumn/stats.go
@@ -219,6 +219,9 @@ func buildColumnPartStats(part *ColumnPart) (ColumnPartStats, error) {
 }
 
 func buildInt64ColumnStats(desc ColumnPartDescriptor, columnDesc ColumnPartColumnDescriptor, column ColumnPartColumn) (Int64ColumnStats, bool, error) {
+	if desc.VisibleRowCount != desc.RowCount {
+		return Int64ColumnStats{}, false, nil
+	}
 	if column.Definition.StatsDisabled || column.Definition.Type != ColumnTypeInt64 || column.Definition.Encoding == EncodingNullableInt64 {
 		return Int64ColumnStats{}, false, nil
 	}
@@ -297,9 +300,7 @@ func buildInt64ColumnStats(desc ColumnPartDescriptor, columnDesc ColumnPartColum
 	if anyInt64BlockSumValid(stats.Blocks) {
 		stats.Envelope.Operations = append(stats.Envelope.Operations, ColumnStatsOpSum, ColumnStatsOpAvg, ColumnStatsOpStatsSum)
 	}
-	if stats.SumValid {
-		stats.Envelope.SelectionShapes = append(stats.Envelope.SelectionShapes, ColumnStatsSelectionAllRows)
-	}
+	stats.Envelope.SelectionShapes = append(stats.Envelope.SelectionShapes, ColumnStatsSelectionAllRows)
 	return stats, true, nil
 }
 

--- a/TreeDB/internal/typedcolumn/stats.go
+++ b/TreeDB/internal/typedcolumn/stats.go
@@ -219,7 +219,7 @@ func buildColumnPartStats(part *ColumnPart) (ColumnPartStats, error) {
 }
 
 func buildInt64ColumnStats(desc ColumnPartDescriptor, columnDesc ColumnPartColumnDescriptor, column ColumnPartColumn) (Int64ColumnStats, bool, error) {
-	if desc.VisibleRowCount != desc.RowCount {
+	if !columnStatsPartFullyVisible(desc) {
 		return Int64ColumnStats{}, false, nil
 	}
 	if column.Definition.StatsDisabled || column.Definition.Type != ColumnTypeInt64 || column.Definition.Encoding == EncodingNullableInt64 {
@@ -302,6 +302,18 @@ func buildInt64ColumnStats(desc ColumnPartDescriptor, columnDesc ColumnPartColum
 	}
 	stats.Envelope.SelectionShapes = append(stats.Envelope.SelectionShapes, ColumnStatsSelectionAllRows)
 	return stats, true, nil
+}
+
+func columnStatsPartFullyVisible(desc ColumnPartDescriptor) bool {
+	if desc.VisibleRowCount != desc.RowCount {
+		return false
+	}
+	for _, granule := range desc.Granules {
+		if granule.VisibleRows != granule.RowCount || granule.DeletedRows != 0 {
+			return false
+		}
+	}
+	return true
 }
 
 func buildInt64BlockStats(reader *GranuleReader, index int, block ColumnBlock) (Int64BlockStats, error) {

--- a/TreeDB/internal/typedcolumn/stats_test.go
+++ b/TreeDB/internal/typedcolumn/stats_test.go
@@ -1,0 +1,229 @@
+package typedcolumn
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestColumnStatsInt64RoundTripAndValidation(t *testing.T) {
+	part := mustStatsTestPart(t, []int64{1, 2, 3, 4, 5}, EncodingDeltaVarint)
+	image, err := BuildColumnPartImage(part, ColumnPartImageOptions{LayoutLogicalTypes: map[string]string{"id": "int64", "value": "int64"}})
+	if err != nil {
+		t.Fatalf("BuildColumnPartImage: %v", err)
+	}
+	decoded, err := ColumnPartFromImage(image)
+	if err != nil {
+		t.Fatalf("ColumnPartFromImage: %v", err)
+	}
+	stats, ok := decoded.ColumnStats.Int64Column("value")
+	if !ok {
+		t.Fatalf("missing int64 stats: %+v", decoded.ColumnStats)
+	}
+	if stats.Count != 5 || stats.ValueCount != 5 || stats.NullCount != 0 || stats.DefaultCount != 0 || !stats.SumValid || stats.Sum != 15 || !stats.HasMinMax || stats.Min != 1 || stats.Max != 5 {
+		t.Fatalf("stats=%+v want count/sum/min/max", stats)
+	}
+	if ok, reason := stats.CanAnswer(ColumnStatsOpSum, ColumnStatsSelectionFullBlock); !ok || reason != ColumnStatsReasonSupported {
+		t.Fatalf("CanAnswer sum/full_block ok=%v reason=%s", ok, reason)
+	}
+	if ok, reason := stats.CanAnswer(ColumnStatsOpSum, ColumnStatsSelectionShape("sparse")); ok || reason != ColumnStatsReasonSelectionUnsupported {
+		t.Fatalf("CanAnswer sparse ok=%v reason=%s", ok, reason)
+	}
+	if ok, reason := stats.CanAnswer(ColumnStatsOperation("predicate.equality"), ColumnStatsSelectionFullBlock); ok || reason != ColumnStatsReasonOperationUnsupported {
+		t.Fatalf("CanAnswer predicate ok=%v reason=%s", ok, reason)
+	}
+}
+
+func TestColumnStatsEnvelopeRejectsCorruptAndMismatchedMetadata(t *testing.T) {
+	part := mustStatsTestPart(t, []int64{10, 20, 30}, EncodingRawInt64)
+	image, err := BuildColumnPartImage(part, ColumnPartImageOptions{LayoutLogicalTypes: map[string]string{"id": "int64", "value": "int64"}})
+	if err != nil {
+		t.Fatalf("BuildColumnPartImage: %v", err)
+	}
+	section, ok, err := image.ColumnStatsSection()
+	if err != nil || !ok {
+		t.Fatalf("ColumnStatsSection ok=%v err=%v", ok, err)
+	}
+	raw := append([]byte(nil), image.sectionBytes(section)...)
+	if len(raw) < 6 {
+		t.Fatalf("stats raw too short: %d", len(raw))
+	}
+	badVersion := append([]byte(nil), raw...)
+	badVersion[4]++
+	if _, err := DecodeColumnPartStatsSection(badVersion); err == nil || !strings.Contains(err.Error(), "version") {
+		t.Fatalf("bad version err=%v", err)
+	}
+	truncated := raw[:len(raw)-1]
+	if _, err := DecodeColumnPartStatsSection(truncated); err == nil || !strings.Contains(err.Error(), "truncated") {
+		t.Fatalf("truncated err=%v", err)
+	}
+	badChecksum := append([]byte(nil), raw...)
+	badChecksum[len(badChecksum)-1] ^= 0x55
+	if _, err := DecodeColumnPartStatsSection(badChecksum); err == nil || !strings.Contains(err.Error(), ColumnStatsReasonChecksumMismatch) {
+		t.Fatalf("checksum err=%v", err)
+	}
+
+	stats, err := DecodeColumnPartStatsSection(raw)
+	if err != nil {
+		t.Fatalf("DecodeColumnPartStatsSection: %v", err)
+	}
+	if err := ValidateColumnPartStats(stats, part.Descriptor, part.Columns); err != nil {
+		t.Fatalf("ValidateColumnPartStats: %v", err)
+	}
+	wrongPart := stats
+	wrongPart.PartID++
+	if err := ValidateColumnPartStats(wrongPart, part.Descriptor, part.Columns); err == nil || !strings.Contains(err.Error(), ColumnStatsReasonIdentityMismatch) {
+		t.Fatalf("wrong part err=%v", err)
+	}
+	valueStats := stats.Int64["value"]
+	wrongName := cloneInt64ColumnStats(valueStats)
+	wrongName.Envelope.ColumnName = "other"
+	if err := ValidateInt64ColumnStats(wrongName, part.Descriptor, part.Descriptor.Columns[1], part.Columns["value"]); err == nil || !strings.Contains(err.Error(), ColumnStatsReasonIdentityMismatch) {
+		t.Fatalf("wrong name err=%v", err)
+	}
+	wrongRows := cloneInt64ColumnStats(valueStats)
+	wrongRows.Blocks[0].RowCount++
+	if err := ValidateInt64ColumnStats(wrongRows, part.Descriptor, part.Descriptor.Columns[1], part.Columns["value"]); err == nil || !strings.Contains(err.Error(), ColumnStatsReasonRowCountMismatch) {
+		t.Fatalf("wrong rows err=%v", err)
+	}
+	wrongMinMax := cloneInt64ColumnStats(valueStats)
+	wrongMinMax.Blocks[0].Min--
+	if err := ValidateInt64ColumnStats(wrongMinMax, part.Descriptor, part.Descriptor.Columns[1], part.Columns["value"]); err == nil || !strings.Contains(err.Error(), ColumnStatsReasonMinMaxMismatch) {
+		t.Fatalf("wrong min/max err=%v", err)
+	}
+	wrongCounts := cloneInt64ColumnStats(valueStats)
+	wrongCounts.Blocks[0].DefaultCount = 1
+	if err := ValidateInt64ColumnStats(wrongCounts, part.Descriptor, part.Descriptor.Columns[1], part.Columns["value"]); err == nil || !strings.Contains(err.Error(), ColumnStatsReasonNullDefaultMismatch) {
+		t.Fatalf("wrong null/default err=%v", err)
+	}
+	wrongType := cloneInt64ColumnStats(valueStats)
+	wrongType.Envelope.ColumnType = ColumnTypeBool
+	if err := ValidateInt64ColumnStats(wrongType, part.Descriptor, part.Descriptor.Columns[1], part.Columns["value"]); err == nil || !strings.Contains(err.Error(), ColumnStatsReasonUnsupportedPayload) {
+		t.Fatalf("wrong type err=%v", err)
+	}
+}
+
+func TestColumnStatsOverflowAndNullableSemantics(t *testing.T) {
+	overflowPart := mustStatsTestPart(t, []int64{1<<63 - 1, 1}, EncodingDeltaVarint)
+	stats, ok := overflowPart.ColumnStats.Int64Column("value")
+	if !ok {
+		t.Fatalf("missing overflow stats")
+	}
+	block, ok := stats.Block(0)
+	if !ok {
+		t.Fatalf("missing block stats")
+	}
+	if block.SumValid {
+		t.Fatalf("overflow block stats=%+v should not advertise valid sum", block)
+	}
+	if ok, reason := block.CanAnswer(ColumnStatsOpSum); ok || reason != ColumnStatsReasonSumOverflow {
+		t.Fatalf("overflow CanAnswer ok=%v reason=%s", ok, reason)
+	}
+	if stats.Envelope.SupportsOperation(ColumnStatsOpSum) {
+		t.Fatalf("single overflowing block stats should not advertise sum op: %+v", stats.Envelope.Operations)
+	}
+
+	partOverflowOnly := mustStatsTestPartWithBlockRows(t, []int64{1<<63 - 1, 1}, EncodingRawInt64, 1)
+	partOverflowStats, ok := partOverflowOnly.ColumnStats.Int64Column("value")
+	if !ok {
+		t.Fatalf("missing part-overflow stats")
+	}
+	if partOverflowStats.SumValid || partOverflowStats.Envelope.SupportsSelectionShape(ColumnStatsSelectionAllRows) {
+		t.Fatalf("part-overflow stats should not advertise all-rows sum: %+v", partOverflowStats)
+	}
+	if !partOverflowStats.Envelope.SupportsOperation(ColumnStatsOpSum) {
+		t.Fatalf("part-overflow stats should still advertise block sum op: %+v", partOverflowStats.Envelope.Operations)
+	}
+	for i := range partOverflowStats.Blocks {
+		if ok, reason := partOverflowStats.Blocks[i].CanAnswer(ColumnStatsOpSum); !ok || reason != ColumnStatsReasonSupported {
+			t.Fatalf("block %d CanAnswer sum ok=%v reason=%s stats=%+v", i, ok, reason, partOverflowStats.Blocks[i])
+		}
+	}
+
+	part, err := BuildColumnPart(1, Options{
+		SchemaVersion: 1,
+		SchemaMode:    ColumnSchemaFixed,
+		Columns: []ColumnDefinition{
+			{Name: "id", Type: ColumnTypeInt64, Encoding: EncodingRawInt64},
+			{Name: "maybe", Type: ColumnTypeInt64, Encoding: EncodingNullableInt64},
+		},
+		LogicalPrimaryKey: LogicalPrimaryKey{Columns: []string{"id"}},
+		PartPolicy:        ColumnPartPolicy{RowsPerGranule: 4, DefaultCodecBlockRows: 4},
+	}, Batch{
+		Rows:          3,
+		Columns:       map[string][]int64{"id": []int64{1, 2, 3}, "maybe": []int64{10, 20, 30}},
+		Nulls:         map[string][]bool{"maybe": []bool{false, true, false}},
+		Defaults:      map[string][]bool{"maybe": []bool{false, false, true}},
+		DefaultValues: map[string]int64{"maybe": 7},
+	})
+	if err != nil {
+		t.Fatalf("Build nullable part: %v", err)
+	}
+	if _, ok := part.ColumnStats.Int64Column("maybe"); ok {
+		t.Fatalf("nullable/default int64 carrier must not emit value sum stats: %+v", part.ColumnStats)
+	}
+}
+
+func TestColumnStatsDisabledDefinitionSkipsInt64Payload(t *testing.T) {
+	part, err := BuildColumnPart(1, Options{
+		SchemaVersion: 1,
+		SchemaMode:    ColumnSchemaFixed,
+		Columns: []ColumnDefinition{
+			{Name: "id", Type: ColumnTypeInt64, Encoding: EncodingRawInt64, StatsDisabled: true},
+			{Name: "raw_float_bits", Type: ColumnTypeInt64, Encoding: EncodingRawInt64, StatsDisabled: true},
+		},
+		LogicalPrimaryKey: LogicalPrimaryKey{Columns: []string{"id"}},
+		PartPolicy:        ColumnPartPolicy{RowsPerGranule: 4, DefaultCodecBlockRows: 4},
+	}, Batch{Rows: 3, Columns: map[string][]int64{"id": []int64{1, 2, 3}, "raw_float_bits": []int64{0, 1, 2}}})
+	if err != nil {
+		t.Fatalf("Build disabled stats part: %v", err)
+	}
+	if !part.ColumnStats.Empty() {
+		t.Fatalf("disabled int64 carriers emitted stats: %+v", part.ColumnStats)
+	}
+}
+
+func TestColumnPartImageWithoutStatsRemainsReadable(t *testing.T) {
+	part := mustStatsTestPart(t, []int64{1, 2, 3}, EncodingDeltaVarint)
+	part.ColumnStats = ColumnPartStats{}
+	image, err := BuildColumnPartImage(part, ColumnPartImageOptions{LayoutLogicalTypes: map[string]string{"id": "int64", "value": "int64"}})
+	if err != nil {
+		t.Fatalf("BuildColumnPartImage without stats: %v", err)
+	}
+	if _, ok, err := image.ColumnStatsSection(); err != nil || ok {
+		t.Fatalf("ColumnStatsSection ok=%v err=%v want absent", ok, err)
+	}
+	decoded, err := ColumnPartFromImage(image)
+	if err != nil {
+		t.Fatalf("ColumnPartFromImage without stats: %v", err)
+	}
+	if !decoded.ColumnStats.Empty() {
+		t.Fatalf("decoded stats=%+v want empty", decoded.ColumnStats)
+	}
+}
+
+func mustStatsTestPart(t *testing.T, values []int64, encoding Encoding) *ColumnPart {
+	t.Helper()
+	return mustStatsTestPartWithBlockRows(t, values, encoding, len(values))
+}
+
+func mustStatsTestPartWithBlockRows(t *testing.T, values []int64, encoding Encoding, blockRows int) *ColumnPart {
+	t.Helper()
+	ids := make([]int64, len(values))
+	for i := range ids {
+		ids[i] = int64(i + 1)
+	}
+	part, err := BuildColumnPart(1, Options{
+		SchemaVersion: 1,
+		SchemaMode:    ColumnSchemaFixed,
+		Columns: []ColumnDefinition{
+			{Name: "id", Type: ColumnTypeInt64, Encoding: EncodingRawInt64},
+			{Name: "value", Type: ColumnTypeInt64, Encoding: encoding},
+		},
+		LogicalPrimaryKey: LogicalPrimaryKey{Columns: []string{"id"}},
+		PartPolicy:        ColumnPartPolicy{RowsPerGranule: blockRows, DefaultCodecBlockRows: blockRows},
+	}, Batch{Rows: len(values), Columns: map[string][]int64{"id": ids, "value": values}})
+	if err != nil {
+		t.Fatalf("BuildColumnPart: %v", err)
+	}
+	return part
+}

--- a/TreeDB/internal/typedcolumn/stats_test.go
+++ b/TreeDB/internal/typedcolumn/stats_test.go
@@ -127,8 +127,17 @@ func TestColumnStatsOverflowAndNullableSemantics(t *testing.T) {
 	if !ok {
 		t.Fatalf("missing part-overflow stats")
 	}
-	if partOverflowStats.SumValid || partOverflowStats.Envelope.SupportsSelectionShape(ColumnStatsSelectionAllRows) {
-		t.Fatalf("part-overflow stats should not advertise all-rows sum: %+v", partOverflowStats)
+	if partOverflowStats.SumValid {
+		t.Fatalf("part-overflow stats should not have a valid part sum: %+v", partOverflowStats)
+	}
+	if !partOverflowStats.Envelope.SupportsSelectionShape(ColumnStatsSelectionAllRows) {
+		t.Fatalf("part-overflow stats should still advertise all-rows shape for count operations: %+v", partOverflowStats.Envelope.SelectionShapes)
+	}
+	if ok, reason := partOverflowStats.CanAnswer(ColumnStatsOpSum, ColumnStatsSelectionAllRows); ok || reason != ColumnStatsReasonSumOverflow {
+		t.Fatalf("part-overflow all-rows sum CanAnswer ok=%v reason=%s", ok, reason)
+	}
+	if ok, reason := partOverflowStats.CanAnswer(ColumnStatsOpCountRows, ColumnStatsSelectionAllRows); !ok || reason != ColumnStatsReasonSupported {
+		t.Fatalf("part-overflow all-rows count CanAnswer ok=%v reason=%s", ok, reason)
 	}
 	if !partOverflowStats.Envelope.SupportsOperation(ColumnStatsOpSum) {
 		t.Fatalf("part-overflow stats should still advertise block sum op: %+v", partOverflowStats.Envelope.Operations)
@@ -160,6 +169,18 @@ func TestColumnStatsOverflowAndNullableSemantics(t *testing.T) {
 	}
 	if _, ok := part.ColumnStats.Int64Column("maybe"); ok {
 		t.Fatalf("nullable/default int64 carrier must not emit value sum stats: %+v", part.ColumnStats)
+	}
+}
+
+func TestColumnStatsSkipsNonFullyVisiblePart(t *testing.T) {
+	part := mustStatsTestPart(t, []int64{1, 2, 3}, EncodingDeltaVarint)
+	part.Descriptor.VisibleRowCount = part.Descriptor.RowCount - 1
+	stats, err := buildColumnPartStats(part)
+	if err != nil {
+		t.Fatalf("buildColumnPartStats non-visible: %v", err)
+	}
+	if !stats.Empty() {
+		t.Fatalf("non-fully-visible part emitted stats: %+v", stats)
 	}
 }
 

--- a/TreeDB/internal/typedcolumn/stats_test.go
+++ b/TreeDB/internal/typedcolumn/stats_test.go
@@ -173,14 +173,39 @@ func TestColumnStatsOverflowAndNullableSemantics(t *testing.T) {
 }
 
 func TestColumnStatsSkipsNonFullyVisiblePart(t *testing.T) {
-	part := mustStatsTestPart(t, []int64{1, 2, 3}, EncodingDeltaVarint)
-	part.Descriptor.VisibleRowCount = part.Descriptor.RowCount - 1
-	stats, err := buildColumnPartStats(part)
-	if err != nil {
-		t.Fatalf("buildColumnPartStats non-visible: %v", err)
+	tests := []struct {
+		name   string
+		mutate func(*testing.T, *ColumnPart)
+	}{
+		{
+			name: "part visible row count",
+			mutate: func(t *testing.T, part *ColumnPart) {
+				part.Descriptor.VisibleRowCount = part.Descriptor.RowCount - 1
+			},
+		},
+		{
+			name: "granule visibility",
+			mutate: func(t *testing.T, part *ColumnPart) {
+				if len(part.Descriptor.Granules) == 0 {
+					t.Fatalf("test part has no granules")
+				}
+				part.Descriptor.Granules[0].VisibleRows = part.Descriptor.Granules[0].RowCount - 1
+				part.Descriptor.Granules[0].DeletedRows = 1
+			},
+		},
 	}
-	if !stats.Empty() {
-		t.Fatalf("non-fully-visible part emitted stats: %+v", stats)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			part := mustStatsTestPart(t, []int64{1, 2, 3}, EncodingDeltaVarint)
+			tt.mutate(t, part)
+			stats, err := buildColumnPartStats(part)
+			if err != nil {
+				t.Fatalf("buildColumnPartStats non-visible: %v", err)
+			}
+			if !stats.Empty() {
+				t.Fatalf("non-fully-visible part emitted stats: %+v", stats)
+			}
+		})
 	}
 }
 

--- a/TreeDB/internal/typedcolumn/stats_test.go
+++ b/TreeDB/internal/typedcolumn/stats_test.go
@@ -1,6 +1,7 @@
 package typedcolumn
 
 import (
+	"encoding/binary"
 	"strings"
 	"testing"
 )
@@ -61,6 +62,27 @@ func TestColumnStatsEnvelopeRejectsCorruptAndMismatchedMetadata(t *testing.T) {
 	if _, err := DecodeColumnPartStatsSection(badChecksum); err == nil || !strings.Contains(err.Error(), ColumnStatsReasonChecksumMismatch) {
 		t.Fatalf("checksum err=%v", err)
 	}
+	encodingOffset, compressionOffset := firstStatsEnvelopeEncodingOffsets(t, raw)
+	badEncodingOverflow := append([]byte(nil), raw...)
+	binary.LittleEndian.PutUint16(badEncodingOverflow[encodingOffset:], 0x0101)
+	if _, err := DecodeColumnPartStatsSection(badEncodingOverflow); err == nil || !strings.Contains(err.Error(), "encoding") || !strings.Contains(err.Error(), "exceeds uint8") {
+		t.Fatalf("encoding overflow err=%v", err)
+	}
+	badEncodingUnknown := append([]byte(nil), raw...)
+	binary.LittleEndian.PutUint16(badEncodingUnknown[encodingOffset:], 200)
+	if _, err := DecodeColumnPartStatsSection(badEncodingUnknown); err == nil || !strings.Contains(err.Error(), "unknown column stats envelope encoding") {
+		t.Fatalf("encoding unknown err=%v", err)
+	}
+	badCompressionOverflow := append([]byte(nil), raw...)
+	binary.LittleEndian.PutUint16(badCompressionOverflow[compressionOffset:], 0x0101)
+	if _, err := DecodeColumnPartStatsSection(badCompressionOverflow); err == nil || !strings.Contains(err.Error(), "compression") || !strings.Contains(err.Error(), "exceeds uint8") {
+		t.Fatalf("compression overflow err=%v", err)
+	}
+	badCompressionUnknown := append([]byte(nil), raw...)
+	binary.LittleEndian.PutUint16(badCompressionUnknown[compressionOffset:], 200)
+	if _, err := DecodeColumnPartStatsSection(badCompressionUnknown); err == nil || !strings.Contains(err.Error(), "unknown column stats envelope compression") {
+		t.Fatalf("compression unknown err=%v", err)
+	}
 
 	stats, err := DecodeColumnPartStatsSection(raw)
 	if err != nil {
@@ -100,6 +122,53 @@ func TestColumnStatsEnvelopeRejectsCorruptAndMismatchedMetadata(t *testing.T) {
 	if err := ValidateInt64ColumnStats(wrongType, part.Descriptor, part.Descriptor.Columns[1], part.Columns["value"]); err == nil || !strings.Contains(err.Error(), ColumnStatsReasonUnsupportedPayload) {
 		t.Fatalf("wrong type err=%v", err)
 	}
+}
+
+func firstStatsEnvelopeEncodingOffsets(t *testing.T, data []byte) (int, int) {
+	t.Helper()
+	dec := columnPartImageDecoder{data: data}
+	if _, err := dec.u32(); err != nil {
+		t.Fatalf("stats magic: %v", err)
+	}
+	if _, err := dec.u16(); err != nil {
+		t.Fatalf("stats version: %v", err)
+	}
+	if _, err := dec.u16(); err != nil {
+		t.Fatalf("stats reserved: %v", err)
+	}
+	if _, err := dec.u64(); err != nil {
+		t.Fatalf("stats part id: %v", err)
+	}
+	if _, err := dec.i64(); err != nil {
+		t.Fatalf("stats rows: %v", err)
+	}
+	if _, err := dec.u32(); err != nil {
+		t.Fatalf("stats column count: %v", err)
+	}
+	if _, err := dec.u16(); err != nil {
+		t.Fatalf("envelope version: %v", err)
+	}
+	if _, err := dec.u16(); err != nil {
+		t.Fatalf("envelope reserved: %v", err)
+	}
+	if _, err := dec.u64(); err != nil {
+		t.Fatalf("envelope part id: %v", err)
+	}
+	if _, err := dec.str(); err != nil {
+		t.Fatalf("envelope column name: %v", err)
+	}
+	if _, err := dec.u16(); err != nil {
+		t.Fatalf("envelope column type: %v", err)
+	}
+	encodingOffset := dec.offset
+	if _, err := dec.u16(); err != nil {
+		t.Fatalf("envelope encoding: %v", err)
+	}
+	compressionOffset := dec.offset
+	if _, err := dec.u16(); err != nil {
+		t.Fatalf("envelope compression: %v", err)
+	}
+	return encodingOffset, compressionOffset
 }
 
 func TestColumnStatsOverflowAndNullableSemantics(t *testing.T) {


### PR DESCRIPTION
## Summary

Closes #1840. Part of #1836.

- Adds a durable typed-column `column_stats` image section with a versioned generic envelope and CRC-checked int64 count/sum/min/max payload.
- Builds stats for eligible non-null logical int64 columns only; nullable/default wrappers, float raw-bit carriers, vector/adjacency columns, hidden primary-id carriers, and non-fully-visible parts stay gated/fallback.
- Wires prepared int64 count/sum/avg aggregate scans to consume stats for all/full-block-covered selections, with fail-closed validation and decode/kernel fallback for partial, random, visibility, skip-checksum, or overflow cases.
- Updates semantics/layout docs and diagnostics/bench metrics for stats usage and fallback counters.

## Tests

Latest local head: `94b225b33518c9a8b2c7bb7893f30d1d2185627c`

- `git diff --check origin/main...HEAD`
- `go test -count=1 ./TreeDB/internal/typedcolumn ./TreeDB/internal/columnsemantics ./TreeDB/internal/columnlayout ./TreeDB/collections ./TreeDB/docs`
- `go test -count=1 ./TreeDB/collections`
- `go test -count=1 ./TreeDB/...`

## Benchmarks

Host: Apple M3 / darwin arm64. Dataset: 1,048,576 rows, delta-varint `typed_column_part`, cached-verify integrity, prepared-session hot scan, `-benchtime=10x -count=3`.

| Shape/distribution | Base ns/op | Head ns/op | Change | Stats blocks | Fallback blocks | Rows scanned |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| clustered no-filter | 4,315,646 | 14,117 | -99.67% | 128 | 0 | 0 (base 1,048,576) |
| clustered all-match | 4,317,812 | 14,121 | -99.67% | 128 | 0 | 0 (base 1,048,576) |
| clustered 1% range | 112,746 | 80,154 | -28.91% | 1 | 1 | 8,192 (base 16,384) |
| partially-clustered 1% range | 112,967 | 80,575 | -28.67% | 1 | 1 | 8,192 (base 16,384) |
| random 1% range | 9,216,275 | 9,304,733 | +0.96% | 0 | 128 | 1,048,576 (unchanged) |
| hotspot 1% range | 10,453,112 | 10,374,083 | -0.76% | 0 | 128 | 1,048,576 (unchanged) |

Hot-path allocations stayed flat at 512 B/op and 4 allocs/op. Stats storage increased typed-column asset bytes by about +0.02% and DB directory bytes by about +0.01% on the 1M-row datasets. Setup/write time was within run noise (roughly -2% to +2%). CPU/allocation profiles were captured locally under `artifacts/1840/benchmarks/`.

## Review / scope

- Latest-head CI is green across required Linux/macOS/Windows/race/profile/bench suites.
- Codex latest-head review: no major issues.
- Copilot latest-head review: no blocking issues; earlier findings addressed/outdated.
- CodeRabbit latest-head review/check: pass/skipped with no new actionable comments; coordinator verified 0 unresolved review threads after fixing the non-fully-visible stats emission gate and validating stats envelope encoding/compression enums.
- Non-goals intentionally deferred: #1841 pruning/index strategy and type-family payload optimizations #1845–#1848 beyond generic envelope extension points and negative tests.
