### PR TITLE
Add typed-column int64 pruning metadata

### DIFF
--- a/TreeDB/collections/typed_column_int64_scan.go
+++ b/TreeDB/collections/typed_column_int64_scan.go
@@ -71,57 +71,63 @@ type TypedColumnInt64PredicateScanDiagnostics struct {
 	SelectionSparseBlocks int
 	SelectionCompositions int
 
-	DirectTypedColumnAssetReads  int
-	FullAssetReads               int
-	FallbackReads                int
-	CodesMatched                 int
-	DictionaryBytesDecoded       uint64
-	FullAssetBytes               uint64
-	SectionBytesRead             uint64
-	RangeBytesRead               uint64
-	MappedBytes                  uint64
-	HeapCopyBytes                uint64
-	DecodedMetadataBytes         uint64
-	DecodedHeapCopyBytes         uint64
-	MaterializedBytes            uint64
-	FastDecodeDirectViewPlans    int
-	FastDecodeStreamingPlans     int
-	FastDecodeMaterializePlans   int
-	FastDecodeUnsupportedPlans   int
-	DirectViewSuccesses          int
-	DirectViewFailures           int
-	KernelBlocks                 int
-	KernelFullCoveredBlocks      int
-	KernelSelectedBlocks         int
-	KernelCursorBlocks           int
-	KernelFallbackBlocks         int
-	StatsBlocks                  int
-	StatsFullCoveredBlocks       int
-	StatsFallbackBlocks          int
-	StatsRows                    int
-	StatsFallbackReason          string
-	StatsValidationFailures      int
-	StatsValidationFailureReason string
-	FastDecodeFallbackReason     string
-	DirectViewCertified          int
-	StreamingCertified           int
-	StatsCertified               int
-	PruningCertified             int
-	CertificationFailures        int
-	CertificationFailureReason   string
-	PhysicalBytesScanned         int64
-	RowLocatorDecodes            int
-	PhysicalRowIDLookups         int
-	PhysicalRowAssetReads        int
-	RowMaterializations          int
-	DocumentMaterializations     int
-	DocumentReconstructions      int
-	SegmentFileCacheHits         uint64
-	SegmentFileCacheMisses       uint64
-	ColumnAssetReadIntegrity     string
-	Fallback                     bool
-	FallbackReason               string
-	ScanNanos                    int64
+	DirectTypedColumnAssetReads    int
+	FullAssetReads                 int
+	FallbackReads                  int
+	CodesMatched                   int
+	DictionaryBytesDecoded         uint64
+	FullAssetBytes                 uint64
+	SectionBytesRead               uint64
+	RangeBytesRead                 uint64
+	MappedBytes                    uint64
+	HeapCopyBytes                  uint64
+	DecodedMetadataBytes           uint64
+	DecodedHeapCopyBytes           uint64
+	MaterializedBytes              uint64
+	FastDecodeDirectViewPlans      int
+	FastDecodeStreamingPlans       int
+	FastDecodeMaterializePlans     int
+	FastDecodeUnsupportedPlans     int
+	DirectViewSuccesses            int
+	DirectViewFailures             int
+	KernelBlocks                   int
+	KernelFullCoveredBlocks        int
+	KernelSelectedBlocks           int
+	KernelCursorBlocks             int
+	KernelFallbackBlocks           int
+	StatsBlocks                    int
+	StatsFullCoveredBlocks         int
+	StatsFallbackBlocks            int
+	StatsRows                      int
+	PruningBlocks                  int
+	PruningRows                    int
+	PruningFallbackBlocks          int
+	PruningFallbackReason          string
+	StatsFallbackReason            string
+	StatsValidationFailures        int
+	StatsValidationFailureReason   string
+	PruningValidationFailures      int
+	PruningValidationFailureReason string
+	FastDecodeFallbackReason       string
+	DirectViewCertified            int
+	StreamingCertified             int
+	StatsCertified                 int
+	PruningCertified               int
+	CertificationFailures          int
+	CertificationFailureReason     string
+	PhysicalBytesScanned           int64
+	RowLocatorDecodes              int
+	PhysicalRowIDLookups           int
+	PhysicalRowAssetReads          int
+	RowMaterializations            int
+	DocumentMaterializations       int
+	DocumentReconstructions        int
+	SegmentFileCacheHits           uint64
+	SegmentFileCacheMisses         uint64
+	ColumnAssetReadIntegrity       string
+	Fallback                       bool
+	FallbackReason                 string
+	ScanNanos                      int64
 }
 
 type TypedColumnInt64PredicateScanResult struct {
@@ -971,12 +977,22 @@ func addTypedColumnInt64PredicateAggregateDiagnostics(dst *TypedColumnInt64Predi
 	dst.StatsFullCoveredBlocks += src.StatsFullCoveredBlocks
 	dst.StatsFallbackBlocks += src.StatsFallbackBlocks
 	dst.StatsRows += src.StatsRows
+	dst.PruningBlocks += src.PruningBlocks
+	dst.PruningRows += src.PruningRows
+	dst.PruningFallbackBlocks += src.PruningFallbackBlocks
+	if src.PruningFallbackReason != "" {
+		dst.PruningFallbackReason = src.PruningFallbackReason
+	}
 	if src.StatsFallbackReason != "" {
 		dst.StatsFallbackReason = src.StatsFallbackReason
 	}
 	dst.StatsValidationFailures += src.StatsValidationFailures
 	if src.StatsValidationFailureReason != "" {
 		dst.StatsValidationFailureReason = src.StatsValidationFailureReason
+	}
+	dst.PruningValidationFailures += src.PruningValidationFailures
+	if src.PruningValidationFailureReason != "" {
+		dst.PruningValidationFailureReason = src.PruningValidationFailureReason
 	}
 	if src.FastDecodeFallbackReason != "" {
 		dst.FastDecodeFallbackReason = src.FastDecodeFallbackReason

--- a/TreeDB/collections/typed_column_int64_scan.go
+++ b/TreeDB/collections/typed_column_int64_scan.go
@@ -599,6 +599,8 @@ func (c *Collection) runTypedColumnInt64PredicateAggregateDirect(view columnPhys
 	includeDiagnostics := session.prepareDiagnostics
 	includeDiagnostics.PruningBlocks = 0
 	includeDiagnostics.PruningRows = 0
+	includeDiagnostics.PruningFallbackBlocks = 0
+	includeDiagnostics.PruningFallbackReason = ""
 	return session.run(start, includeDiagnostics)
 }
 

--- a/TreeDB/collections/typed_column_int64_scan.go
+++ b/TreeDB/collections/typed_column_int64_scan.go
@@ -596,7 +596,10 @@ func (c *Collection) runTypedColumnInt64PredicateAggregateDirect(view columnPhys
 		return TypedColumnInt64PredicateAggregateResult{Diagnostics: diag}, err
 	}
 	defer func() { _ = session.Close() }()
-	return session.run(start, session.prepareDiagnostics)
+	includeDiagnostics := session.prepareDiagnostics
+	includeDiagnostics.PruningBlocks = 0
+	includeDiagnostics.PruningRows = 0
+	return session.run(start, includeDiagnostics)
 }
 
 func (c *Collection) prepareTypedColumnInt64PredicateAggregateSessionFromView(view columnPhysicalScanSnapshotView, closeView func(), req TypedColumnInt64PredicateAggregateRequest) (*TypedColumnInt64PredicateAggregateSession, TypedColumnInt64PredicateScanDiagnostics, error) {

--- a/TreeDB/collections/typed_column_int64_scan_test.go
+++ b/TreeDB/collections/typed_column_int64_scan_test.go
@@ -611,6 +611,9 @@ func TestTypedColumnInt64PreparedUsesDurablePruningMetadata(t *testing.T) {
 		t.Fatalf("Run: %v", err)
 	}
 	assertTypedColumnInt64Aggregate(t, result, 2, 40)
+	if result.Diagnostics.PruningBlocks != 1 || result.Diagnostics.PruningRows != 2 {
+		t.Fatalf("run diagnostics=%+v want one pruned candidate block with two rows", result.Diagnostics)
+	}
 }
 
 func TestTypedColumnInt64RawLayoutRoundTripReopenQuery(t *testing.T) {

--- a/TreeDB/collections/typed_column_int64_scan_test.go
+++ b/TreeDB/collections/typed_column_int64_scan_test.go
@@ -601,8 +601,8 @@ func TestTypedColumnInt64PreparedUsesDurablePruningMetadata(t *testing.T) {
 		if block.CandidateSelection.IsEmpty() {
 			continue
 		}
-		if block.NeedsPredicate {
-			t.Fatalf("block %+v still requires predicate after exact pruning metadata", block)
+		if !block.NeedsPredicate {
+			t.Fatalf("block %+v must keep predicate verification after pruning metadata narrows rows", block)
 		}
 		matched += block.CandidateSelection.Count()
 	}

--- a/TreeDB/collections/typed_column_int64_scan_test.go
+++ b/TreeDB/collections/typed_column_int64_scan_test.go
@@ -570,6 +570,49 @@ func TestTypedColumnInt64AggregateSelectionShapes(t *testing.T) {
 	assertTypedColumnInt64AggregateNoMaterializationDiagnostics(t, exact.Diagnostics, "selection-shaped typed-column aggregate")
 }
 
+func TestTypedColumnInt64PreparedUsesDurablePruningMetadata(t *testing.T) {
+	d, col := setupTypedColumnInt64ScanCollection(t)
+	defer func() { _ = d.Close() }()
+	insertTypedColumnInt64ScanRows(t, col, []int64{10, 20, 30, 20})
+	session, err := col.PrepareTypedColumnInt64PredicateAggregate(TypedColumnInt64PredicateAggregateRequest{Column: "time_us", Kind: TypedColumnInt64PredicateEqual, Value: 20, ColumnAssetReadIntegrity: ColumnAssetReadIntegrityCachedVerify})
+	if err != nil {
+		t.Fatalf("PrepareTypedColumnInt64PredicateAggregate: %v", err)
+	}
+	defer func() { _ = session.Close() }()
+	if session.prepareDiagnostics.DecodedMetadataBytes == 0 || session.prepareDiagnostics.PruningCertified == 0 {
+		t.Fatalf("prepare diagnostics=%+v want pruning metadata decoded/certified", session.prepareDiagnostics)
+	}
+	var preparedColumn *typedColumnPreparedColumnState
+	for _, part := range session.preparedState.partsByRef {
+		preparedColumn = part.Columns[session.aggregateColumn.Definition.Name]
+		break
+	}
+	if preparedColumn == nil {
+		t.Fatalf("prepared pruning column missing")
+	}
+	if !preparedColumn.Int64PruningReady || preparedColumn.PruningFallbackReason != "" {
+		t.Fatalf("prepared pruning state=%+v fallback=%q", preparedColumn, preparedColumn.PruningFallbackReason)
+	}
+	matched := 0
+	for _, block := range preparedColumn.BlockPlans {
+		if block.CandidateSelection.IsEmpty() {
+			continue
+		}
+		if block.NeedsPredicate {
+			t.Fatalf("block %+v still requires predicate after exact pruning metadata", block)
+		}
+		matched += block.CandidateSelection.Count()
+	}
+	if matched != 2 {
+		t.Fatalf("pruning candidate rows=%d want 2", matched)
+	}
+	result, err := session.Run()
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	assertTypedColumnInt64Aggregate(t, result, 2, 40)
+}
+
 func TestTypedColumnInt64RawLayoutRoundTripReopenQuery(t *testing.T) {
 	dir := t.TempDir()
 	if err := backenddb.SaveFormatConfig(dir, backenddb.FormatConfig{RequiredFeatures: []string{backenddb.RequiredFeatureCommandWALV1}}); err != nil {
@@ -2365,7 +2408,11 @@ func runTypedColumnInt64AggregateBenchPath(b *testing.B, rows int, dist typedCol
 			if session != nil {
 				b.ReportMetric(float64(session.prepareDiagnostics.DirectViewCertified), "prepare_direct_view_certified/op")
 				b.ReportMetric(float64(session.prepareDiagnostics.StreamingCertified), "prepare_streaming_certified/op")
+				b.ReportMetric(float64(session.prepareDiagnostics.PruningCertified), "prepare_pruning_certified/op")
+				b.ReportMetric(float64(session.prepareDiagnostics.PruningBlocks), "prepare_pruning_blocks/op")
+				b.ReportMetric(float64(session.prepareDiagnostics.PruningRows), "prepare_pruning_rows/op")
 				b.ReportMetric(float64(session.prepareDiagnostics.CertificationFailures), "prepare_certification_failures/op")
+				b.ReportMetric(float64(session.prepareDiagnostics.PruningValidationFailures), "prepare_pruning_validation_failures/op")
 			}
 		})
 	}
@@ -3090,8 +3137,13 @@ func reportTypedColumnInt64AggregateBenchMetrics(b *testing.B, totalRows int, di
 	b.ReportMetric(float64(diag.StatsFallbackBlocks), "stats_fallback_blocks/op")
 	b.ReportMetric(float64(diag.StatsRows), "stats_rows/op")
 	b.ReportMetric(float64(diag.StatsValidationFailures), "stats_validation_failures/op")
+	b.ReportMetric(float64(diag.PruningBlocks), "pruning_blocks/op")
+	b.ReportMetric(float64(diag.PruningRows), "pruning_rows/op")
+	b.ReportMetric(float64(diag.PruningFallbackBlocks), "pruning_fallback_blocks/op")
+	b.ReportMetric(float64(diag.PruningValidationFailures), "pruning_validation_failures/op")
 	b.ReportMetric(float64(diag.DirectViewCertified), "direct_view_certified/op")
 	b.ReportMetric(float64(diag.StreamingCertified), "streaming_certified/op")
+	b.ReportMetric(float64(diag.PruningCertified), "pruning_certified/op")
 	b.ReportMetric(float64(diag.CertificationFailures), "certification_failures/op")
 	b.ReportMetric(float64(diag.PhysicalBytesScanned), "physical_bytes_scanned/op")
 	b.ReportMetric(float64(diag.RowLocatorDecodes), "row_locator_decodes/op")
@@ -3110,6 +3162,9 @@ func reportTypedColumnInt64AggregateBenchMetrics(b *testing.B, totalRows int, di
 	}
 	if diag.FastDecodeFallbackReason != "" {
 		b.ReportMetric(1, "fast_decode_fallback_reason_"+typedColumnInt64AggregateBenchMetricToken(diag.FastDecodeFallbackReason)+"_count")
+	}
+	if diag.PruningFallbackReason != "" {
+		b.ReportMetric(1, "pruning_fallback_reason_"+typedColumnInt64AggregateBenchMetricToken(diag.PruningFallbackReason)+"_count")
 	}
 }
 

--- a/TreeDB/collections/typed_column_int64_scan_test.go
+++ b/TreeDB/collections/typed_column_int64_scan_test.go
@@ -619,6 +619,31 @@ func TestTypedColumnInt64PreparedUsesDurablePruningMetadata(t *testing.T) {
 	}
 }
 
+func TestTypedColumnInt64PreparedAllPredicateSkipsPruningMetadata(t *testing.T) {
+	d, col := setupTypedColumnInt64ScanCollection(t)
+	defer func() { _ = d.Close() }()
+	insertTypedColumnInt64ScanRows(t, col, []int64{10, 20, 30, 20})
+	session, err := col.PrepareTypedColumnInt64PredicateAggregate(TypedColumnInt64PredicateAggregateRequest{Column: "time_us", Kind: TypedColumnInt64PredicateAll, ColumnAssetReadIntegrity: ColumnAssetReadIntegrityCachedVerify})
+	if err != nil {
+		t.Fatalf("PrepareTypedColumnInt64PredicateAggregate all: %v", err)
+	}
+	defer func() { _ = session.Close() }()
+	var preparedColumn *typedColumnPreparedColumnState
+	for _, part := range session.preparedState.partsByRef {
+		preparedColumn = part.Columns[session.aggregateColumn.Definition.Name]
+		break
+	}
+	if preparedColumn == nil {
+		t.Fatalf("prepared pruning column missing")
+	}
+	if preparedColumn.Int64PruningReady || preparedColumn.PruningFallbackReason != "" {
+		t.Fatalf("prepared all pruning state=%+v fallback=%q want pruning skipped", preparedColumn, preparedColumn.PruningFallbackReason)
+	}
+	if session.prepareDiagnostics.PruningBlocks != 0 || session.prepareDiagnostics.PruningRows != 0 || session.prepareDiagnostics.PruningFallbackBlocks != 0 {
+		t.Fatalf("prepare diagnostics=%+v want no all-predicate pruning work", session.prepareDiagnostics)
+	}
+}
+
 func TestTypedColumnInt64RawLayoutRoundTripReopenQuery(t *testing.T) {
 	dir := t.TempDir()
 	if err := backenddb.SaveFormatConfig(dir, backenddb.FormatConfig{RequiredFeatures: []string{backenddb.RequiredFeatureCommandWALV1}}); err != nil {

--- a/TreeDB/collections/typed_column_int64_scan_test.go
+++ b/TreeDB/collections/typed_column_int64_scan_test.go
@@ -582,6 +582,9 @@ func TestTypedColumnInt64PreparedUsesDurablePruningMetadata(t *testing.T) {
 	if session.prepareDiagnostics.DecodedMetadataBytes == 0 || session.prepareDiagnostics.PruningCertified == 0 {
 		t.Fatalf("prepare diagnostics=%+v want pruning metadata decoded/certified", session.prepareDiagnostics)
 	}
+	if session.prepareDiagnostics.PruningBlocks != 1 || session.prepareDiagnostics.PruningRows != 2 {
+		t.Fatalf("prepare diagnostics=%+v want one pruned candidate block with two rows", session.prepareDiagnostics)
+	}
 	var preparedColumn *typedColumnPreparedColumnState
 	for _, part := range session.preparedState.partsByRef {
 		preparedColumn = part.Columns[session.aggregateColumn.Definition.Name]

--- a/TreeDB/collections/typed_column_prepared_int64.go
+++ b/TreeDB/collections/typed_column_prepared_int64.go
@@ -645,6 +645,9 @@ func (s *TypedColumnInt64PredicateAggregateSession) scanPreparedAggregateColumnS
 	for blockIdx := range preparedColumn.BlockPlans {
 		block := &preparedColumn.BlockPlans[blockIdx]
 		result.Diagnostics.BlocksConsidered++
+		if preparedColumn.Int64PruningReady && !block.CandidateSelection.IsAll() {
+			recordTypedColumnInt64PruningBlock(&result.Diagnostics, block.CandidateSelection.Count())
+		}
 		if block.CandidateSelection.IsEmpty() {
 			result.Diagnostics.BlocksPruned++
 			recordTypedColumnSelectionDiagnostics(&result.Diagnostics, block.CandidateSelection)

--- a/TreeDB/collections/typed_column_prepared_int64.go
+++ b/TreeDB/collections/typed_column_prepared_int64.go
@@ -74,13 +74,14 @@ func (s *TypedColumnInt64PredicateAggregateSession) prepareTargetedAggregateStat
 	}
 	includeStats := s.req.ColumnAssetReadIntegrity != ColumnAssetReadIntegritySkipChecksums
 	pruningPredicate, pruningOK := typedColumnInt64PruningPredicate(typedColumnInt64PredicateAggregateScanRequest(s.req))
+	includePruning := pruningOK && pruningPredicate.Kind != typedcolumn.Int64PruningPredicateAll
 	requests := []typedColumnPreparedColumnRequest{
 		{
 			Field:                    s.aggregateColumn.Field,
 			Role:                     typedcolumn.ColumnRolePredicate,
 			Operation:                typedColumnInt64PredicateSemanticOperation(s.req.Kind),
-			IncludePruning:           true,
-			HasInt64PruningPredicate: pruningOK,
+			IncludePruning:           includePruning,
+			HasInt64PruningPredicate: includePruning,
 			Int64PruningPredicate:    pruningPredicate,
 		},
 		{

--- a/TreeDB/collections/typed_column_prepared_int64.go
+++ b/TreeDB/collections/typed_column_prepared_int64.go
@@ -37,6 +37,22 @@ func (s *TypedColumnInt64PredicateAggregateSession) validatePreparedInt64Aggrega
 	return nil
 }
 
+func typedColumnInt64PruningPredicate(req TypedColumnInt64PredicateScanRequest) (typedcolumn.Int64PruningPredicate, bool) {
+	switch req.Kind {
+	case TypedColumnInt64PredicateAll:
+		return typedcolumn.Int64PruningPredicate{Kind: typedcolumn.Int64PruningPredicateAll}, true
+	case TypedColumnInt64PredicateEqual:
+		return typedcolumn.Int64PruningPredicate{Kind: typedcolumn.Int64PruningPredicateEqual, Value: req.Value}, true
+	case TypedColumnInt64PredicateRange:
+		if req.Low > req.High {
+			return typedcolumn.Int64PruningPredicate{}, false
+		}
+		return typedcolumn.Int64PruningPredicate{Kind: typedcolumn.Int64PruningPredicateRange, Low: req.Low, High: req.High}, true
+	default:
+		return typedcolumn.Int64PruningPredicate{}, false
+	}
+}
+
 func (s *TypedColumnInt64PredicateAggregateSession) prepareTargetedAggregateState() error {
 	if s == nil {
 		return errors.New("collections: nil typed-column int64 predicate aggregate session")
@@ -57,12 +73,15 @@ func (s *TypedColumnInt64PredicateAggregateSession) prepareTargetedAggregateStat
 		prepareResult.Diagnostics.SegmentFileCacheMisses = s.readCache.misses - beforeMisses
 	}
 	includeStats := s.req.ColumnAssetReadIntegrity != ColumnAssetReadIntegritySkipChecksums
+	pruningPredicate, pruningOK := typedColumnInt64PruningPredicate(typedColumnInt64PredicateAggregateScanRequest(s.req))
 	requests := []typedColumnPreparedColumnRequest{
 		{
-			Field:          s.aggregateColumn.Field,
-			Role:           typedcolumn.ColumnRolePredicate,
-			Operation:      typedColumnInt64PredicateSemanticOperation(s.req.Kind),
-			IncludePruning: true,
+			Field:                    s.aggregateColumn.Field,
+			Role:                     typedcolumn.ColumnRolePredicate,
+			Operation:                typedColumnInt64PredicateSemanticOperation(s.req.Kind),
+			IncludePruning:           true,
+			HasInt64PruningPredicate: pruningOK,
+			Int64PruningPredicate:    pruningPredicate,
 		},
 		{
 			Field:        s.aggregateColumn.Field,
@@ -114,7 +133,7 @@ func (s *TypedColumnInt64PredicateAggregateSession) prepareTargetedAggregateStat
 		prepareResult.Diagnostics.FallbackReads += int(afterStats.FallbackReads - beforeStats.FallbackReads)
 	}
 	updateCacheDeltas()
-	prepareResult.Diagnostics.DecodedMetadataBytes += state.diagnostics.ManifestBytes + state.diagnostics.DescriptorBytes + state.diagnostics.ContractBytes
+	prepareResult.Diagnostics.DecodedMetadataBytes += state.diagnostics.ManifestBytes + state.diagnostics.DescriptorBytes + state.diagnostics.ContractBytes + state.diagnostics.DecodedMetadataBytes
 	prepareResult.Diagnostics.DirectViewCertified += state.diagnostics.DirectViewCertified
 	prepareResult.Diagnostics.StreamingCertified += state.diagnostics.StreamingCertified
 	prepareResult.Diagnostics.StatsCertified += state.diagnostics.StatsCertified
@@ -123,6 +142,12 @@ func (s *TypedColumnInt64PredicateAggregateSession) prepareTargetedAggregateStat
 	prepareResult.Diagnostics.CertificationFailureReason = state.diagnostics.CertificationFailureReason
 	prepareResult.Diagnostics.StatsValidationFailures += state.diagnostics.StatsValidationFailures
 	prepareResult.Diagnostics.StatsValidationFailureReason = state.diagnostics.StatsValidationFailureReason
+	prepareResult.Diagnostics.PruningBlocks += state.diagnostics.PruningBlocks
+	prepareResult.Diagnostics.PruningRows += state.diagnostics.PruningRows
+	prepareResult.Diagnostics.PruningFallbackBlocks += state.diagnostics.PruningFallbackBlocks
+	prepareResult.Diagnostics.PruningFallbackReason = state.diagnostics.PruningFallbackReason
+	prepareResult.Diagnostics.PruningValidationFailures += state.diagnostics.PruningValidationFailures
+	prepareResult.Diagnostics.PruningValidationFailureReason = state.diagnostics.PruningValidationFailureReason
 	addTypedColumnInt64PredicateAggregateDiagnostics(&s.prepareDiagnostics, prepareResult.Diagnostics)
 	s.preparedState = state
 	return nil
@@ -395,6 +420,24 @@ func recordTypedColumnInt64StatsFallbackBlock(diag *TypedColumnInt64PredicateSca
 	}
 }
 
+func recordTypedColumnInt64PruningBlock(diag *TypedColumnInt64PredicateScanDiagnostics, rows int) {
+	if diag == nil {
+		return
+	}
+	diag.PruningBlocks++
+	diag.PruningRows += rows
+}
+
+func recordTypedColumnInt64PruningFallbackBlock(diag *TypedColumnInt64PredicateScanDiagnostics, reason string) {
+	if diag == nil {
+		return
+	}
+	diag.PruningFallbackBlocks++
+	if reason != "" {
+		diag.PruningFallbackReason = reason
+	}
+}
+
 func recordTypedColumnInt64FastDecodePlan(diag *TypedColumnInt64PredicateScanDiagnostics, plan typeddecode.Plan) {
 	if diag == nil {
 		return
@@ -606,6 +649,9 @@ func (s *TypedColumnInt64PredicateAggregateSession) scanPreparedAggregateColumnS
 			result.Diagnostics.BlocksPruned++
 			recordTypedColumnSelectionDiagnostics(&result.Diagnostics, block.CandidateSelection)
 			continue
+		}
+		if preparedColumn.PruningFallbackReason != "" {
+			recordTypedColumnInt64PruningFallbackBlock(&result.Diagnostics, preparedColumn.PruningFallbackReason)
 		}
 		if visibility == nil && s.req.ColumnAssetReadIntegrity != ColumnAssetReadIntegritySkipChecksums {
 			usedStats, err := addTypedColumnInt64AggregateStatsBlock(result, preparedColumn, block)

--- a/TreeDB/collections/typed_column_prepared_int64.go
+++ b/TreeDB/collections/typed_column_prepared_int64.go
@@ -641,11 +641,12 @@ func (s *TypedColumnInt64PredicateAggregateSession) scanPreparedAggregateColumnS
 	payloadRead := false
 	columnPlan := typeddecode.Int64ReducerPlan(preparedColumn.Plan.Layout, preparedColumn.Certification)
 	recordTypedColumnInt64FastDecodePlan(&result.Diagnostics, columnPlan)
+	recordScanPruningDiagnostics := result.Diagnostics.PruningBlocks == 0 && result.Diagnostics.PruningRows == 0
 	var err error
 	for blockIdx := range preparedColumn.BlockPlans {
 		block := &preparedColumn.BlockPlans[blockIdx]
 		result.Diagnostics.BlocksConsidered++
-		if preparedColumn.Int64PruningReady && !block.CandidateSelection.IsAll() {
+		if recordScanPruningDiagnostics && preparedColumn.Int64PruningReady && !block.CandidateSelection.IsAll() {
 			recordTypedColumnInt64PruningBlock(&result.Diagnostics, block.CandidateSelection.Count())
 		}
 		if block.CandidateSelection.IsEmpty() {

--- a/TreeDB/collections/typed_column_prepared_int64.go
+++ b/TreeDB/collections/typed_column_prepared_int64.go
@@ -641,12 +641,11 @@ func (s *TypedColumnInt64PredicateAggregateSession) scanPreparedAggregateColumnS
 	payloadRead := false
 	columnPlan := typeddecode.Int64ReducerPlan(preparedColumn.Plan.Layout, preparedColumn.Certification)
 	recordTypedColumnInt64FastDecodePlan(&result.Diagnostics, columnPlan)
-	recordScanPruningDiagnostics := result.Diagnostics.PruningBlocks == 0 && result.Diagnostics.PruningRows == 0
 	var err error
 	for blockIdx := range preparedColumn.BlockPlans {
 		block := &preparedColumn.BlockPlans[blockIdx]
 		result.Diagnostics.BlocksConsidered++
-		if recordScanPruningDiagnostics && preparedColumn.Int64PruningReady && !block.CandidateSelection.IsAll() {
+		if preparedColumn.Int64PruningReady && !block.CandidateSelection.IsAll() {
 			recordTypedColumnInt64PruningBlock(&result.Diagnostics, block.CandidateSelection.Count())
 		}
 		if block.CandidateSelection.IsEmpty() {
@@ -709,9 +708,17 @@ func (s *TypedColumnInt64PredicateAggregateSession) scanPreparedAggregateColumnS
 					result.Diagnostics.RowsScanned += len(values)
 					selection := block.CandidateSelection
 					if block.NeedsPredicate {
-						selection, err = typedColumnInt64PredicateAggregateBlockSelection(typedColumnInt64PredicateAggregateScanRequest(s.req), granule, values, &s.aggregateScratch)
+						predicateSelection, err := typedColumnInt64PredicateAggregateBlockSelection(typedColumnInt64PredicateAggregateScanRequest(s.req), granule, values, &s.aggregateScratch)
 						if err != nil {
 							return false, err
+						}
+						selection = predicateSelection
+						if !block.CandidateSelection.IsAll() {
+							selection, err = typedcolumn.ComposeRowSelectionsInto(block.Descriptor.RowCount, typedcolumn.RowSelectionComponents{Predicate: &predicateSelection, Visibility: &block.CandidateSelection}, &s.aggregateScratch.selection)
+							if err != nil {
+								return false, err
+							}
+							result.Diagnostics.SelectionCompositions++
 						}
 					}
 					if visibility != nil && !selection.IsEmpty() {

--- a/TreeDB/collections/typed_column_prepared_state.go
+++ b/TreeDB/collections/typed_column_prepared_state.go
@@ -746,6 +746,10 @@ func typedColumnApplyPreparedInt64Pruning(part *typedColumnPreparedPartState, re
 		}
 		block.CandidateSelection = newSelection
 		block.NeedsPredicate = false
+		if diag != nil && !newSelection.IsAll() {
+			diag.PruningBlocks++
+			diag.PruningRows += newSelection.Count()
+		}
 		block.PruningExact = candidate.Exact
 		block.PruningExactCount = candidate.ExactCount
 		block.PruningExactSum = candidate.ExactSum

--- a/TreeDB/collections/typed_column_prepared_state.go
+++ b/TreeDB/collections/typed_column_prepared_state.go
@@ -745,7 +745,9 @@ func typedColumnApplyPreparedInt64Pruning(part *typedColumnPreparedPartState, re
 			newSelection = empty
 		}
 		block.CandidateSelection = newSelection
-		block.NeedsPredicate = false
+		if request.Int64PruningPredicate.Kind != typedcolumn.Int64PruningPredicateAll && !newSelection.IsAll() {
+			block.NeedsPredicate = true
+		}
 		if diag != nil && !newSelection.IsAll() {
 			diag.PruningBlocks++
 			diag.PruningRows += newSelection.Count()

--- a/TreeDB/collections/typed_column_prepared_state.go
+++ b/TreeDB/collections/typed_column_prepared_state.go
@@ -783,8 +783,8 @@ func typedColumnPreparedPruningFallback(column *typedColumnPreparedColumnState, 
 		column.PruningFallbackReason = reason
 	}
 	if diag != nil {
-		blocks := 1
-		if column != nil && len(column.BlockPlans) != 0 {
+		blocks := 0
+		if column != nil {
 			blocks = len(column.BlockPlans)
 		}
 		diag.PruningFallbackBlocks += blocks

--- a/TreeDB/collections/typed_column_prepared_state.go
+++ b/TreeDB/collections/typed_column_prepared_state.go
@@ -732,7 +732,10 @@ func typedColumnApplyPreparedInt64Pruning(part *typedColumnPreparedPartState, re
 			if err != nil {
 				return err
 			}
-			newSelection = composed
+			newSelection, err = typedColumnPreparedCloneRowSelection(composed)
+			if err != nil {
+				return err
+			}
 		}
 		if !oldNonEmpty {
 			empty, err := typedcolumn.NewEmptyRowSelection(block.Descriptor.RowCount)
@@ -743,10 +746,6 @@ func typedColumnApplyPreparedInt64Pruning(part *typedColumnPreparedPartState, re
 		}
 		block.CandidateSelection = newSelection
 		block.NeedsPredicate = false
-		if diag != nil && !newSelection.IsEmpty() {
-			diag.PruningBlocks++
-			diag.PruningRows += newSelection.Count()
-		}
 		block.PruningExact = candidate.Exact
 		block.PruningExactCount = candidate.ExactCount
 		block.PruningExactSum = candidate.ExactSum
@@ -754,6 +753,29 @@ func typedColumnApplyPreparedInt64Pruning(part *typedColumnPreparedPartState, re
 	column.PruningFallbackReason = ""
 	column.Int64PruningReady = true
 	return nil
+}
+
+func typedColumnPreparedCloneRowSelection(selection typedcolumn.RowSelection) (typedcolumn.RowSelection, error) {
+	switch selection.Kind() {
+	case typedcolumn.RowSelectionEmpty:
+		return typedcolumn.NewEmptyRowSelection(selection.Rows())
+	case typedcolumn.RowSelectionAll:
+		return typedcolumn.NewAllRowSelection(selection.Rows())
+	case typedcolumn.RowSelectionRange:
+		start, end, ok := selection.SingleRange()
+		if !ok {
+			return typedcolumn.RowSelection{}, fmt.Errorf("collections: typed-column prepared selection range shape missing range")
+		}
+		return typedcolumn.NewRangeRowSelection(selection.Rows(), start, end)
+	case typedcolumn.RowSelectionRanges:
+		return typedcolumn.NewRangesRowSelection(selection.Rows(), selection.Ranges())
+	case typedcolumn.RowSelectionBitmap:
+		return typedcolumn.NewBitmapRowSelection(selection.Rows(), selection.BitmapWords())
+	case typedcolumn.RowSelectionSparse:
+		return typedcolumn.NewSparseRowSelection(selection.Rows(), selection.SparseRows())
+	default:
+		return typedcolumn.RowSelection{}, fmt.Errorf("collections: typed-column prepared unsupported row selection shape %s", selection.Shape().Kind)
+	}
 }
 
 func typedColumnPreparedPruningFallback(column *typedColumnPreparedColumnState, diag *typedColumnPreparedStateDiagnostics, reason string) {

--- a/TreeDB/collections/typed_column_prepared_state.go
+++ b/TreeDB/collections/typed_column_prepared_state.go
@@ -21,15 +21,17 @@ type typedColumnPreparedRangeReader func(offset int, length int, section bool) (
 // physical definitions and from the concrete section dependencies selected by
 // the operation.
 type typedColumnPreparedColumnRequest struct {
-	Field                   TypedStorageField
-	Role                    typedcolumn.ColumnExecutionRole
-	Operation               columnsemantics.Operation
-	IncludeDictionaries     bool
-	IncludeVisibility       bool
-	IncludeStats            bool
-	IncludePruning          bool
-	IncludeVectorPayload    bool
-	IncludeAdjacencyPayload bool
+	Field                    TypedStorageField
+	Role                     typedcolumn.ColumnExecutionRole
+	Operation                columnsemantics.Operation
+	IncludeDictionaries      bool
+	IncludeVisibility        bool
+	IncludeStats             bool
+	IncludePruning           bool
+	HasInt64PruningPredicate bool
+	Int64PruningPredicate    typedcolumn.Int64PruningPredicate
+	IncludeVectorPayload     bool
+	IncludeAdjacencyPayload  bool
 }
 
 type typedColumnPreparedColumnPlan struct {
@@ -44,27 +46,34 @@ type typedColumnPreparedColumnPlan struct {
 }
 
 type typedColumnPreparedStateDiagnostics struct {
-	PartsPrepared                int
-	ColumnsPrepared              int
-	BlocksPrepared               int
-	CandidateBlocks              int
-	PrunedBlocks                 int
-	SectionDependencies          int
-	CandidateRanges              int
-	CandidateRangeBytes          uint64
-	ManifestBytes                uint64
-	DescriptorBytes              uint64
-	ContractBytes                uint64
-	DirectViewCertified          int
-	StreamingCertified           int
-	StatsCertified               int
-	PruningCertified             int
-	CertificationFailures        int
-	CertificationFailureReason   string
-	StatsValidationFailures      int
-	StatsValidationFailureReason string
-	Fallback                     bool
-	FallbackReason               string
+	PartsPrepared                  int
+	ColumnsPrepared                int
+	BlocksPrepared                 int
+	CandidateBlocks                int
+	PrunedBlocks                   int
+	SectionDependencies            int
+	CandidateRanges                int
+	CandidateRangeBytes            uint64
+	DecodedMetadataBytes           uint64
+	ManifestBytes                  uint64
+	DescriptorBytes                uint64
+	ContractBytes                  uint64
+	DirectViewCertified            int
+	StreamingCertified             int
+	StatsCertified                 int
+	PruningCertified               int
+	CertificationFailures          int
+	CertificationFailureReason     string
+	StatsValidationFailures        int
+	StatsValidationFailureReason   string
+	PruningBlocks                  int
+	PruningRows                    int
+	PruningFallbackBlocks          int
+	PruningFallbackReason          string
+	PruningValidationFailures      int
+	PruningValidationFailureReason string
+	Fallback                       bool
+	FallbackReason                 string
 }
 
 type typedColumnPreparedBlockPlan struct {
@@ -75,6 +84,9 @@ type typedColumnPreparedBlockPlan struct {
 	PayloadLength      int
 	CandidateSelection typedcolumn.RowSelection
 	NeedsPredicate     bool
+	PruningExact       bool
+	PruningExactCount  int64
+	PruningExactSum    int64
 }
 
 type typedColumnPreparedColumnState struct {
@@ -88,6 +100,8 @@ type typedColumnPreparedColumnState struct {
 	Int64Stats            typedcolumn.Int64ColumnStats
 	Int64StatsReady       bool
 	StatsFallbackReason   string
+	PruningFallbackReason string
+	Int64PruningReady     bool
 	Dictionaries          map[string]int64
 }
 
@@ -165,6 +179,8 @@ func (c *typedColumnPreparedColumnState) close() {
 	c.Int64Stats = typedcolumn.Int64ColumnStats{}
 	c.Int64StatsReady = false
 	c.StatsFallbackReason = ""
+	c.PruningFallbackReason = ""
+	c.Int64PruningReady = false
 	c.Dictionaries = nil
 }
 
@@ -246,7 +262,7 @@ func typedColumnPreparedDependenciesForRequest(req typedColumnPreparedColumnRequ
 	}
 	deps = append(deps, values)
 	if req.IncludePruning {
-		dep, err := typedcolumn.NewSectionDependency(req.Role, def.Name, def.Type, typedcolumn.SectionDependencyPruningMetadata, typedcolumn.ColumnPartImageSectionColumnData, span, true)
+		dep, err := typedcolumn.NewSectionDependency(req.Role, def.Name, def.Type, typedcolumn.SectionDependencyPruningMetadata, typedcolumn.ColumnPartImageSectionPruningMetadata, span, false)
 		if err != nil {
 			return nil, err
 		}
@@ -362,8 +378,20 @@ func typedColumnPreparePartStateFromRanges(ref ColumnAssetRef, physical ColumnAs
 		return nil, typedColumnPreparedStateDiagnostics{}, err
 	}
 	part, diag, err := typedColumnPreparePartStateFromParsed(ref, physical, typedRows, physicalRows, fields, schemaHash, image, desc, columns, manifestBytes, descriptorRaw, contractRaw, columnRequests, blockSelection)
-	if err != nil || part == nil || diag.Fallback || !typedColumnPreparedRequestsIncludeStats(columnRequests) {
+	if err != nil || part == nil || diag.Fallback {
 		return part, diag, err
+	}
+	if typedColumnPreparedRequestsIncludePruning(columnRequests) {
+		pruningDiag, err := typedColumnAttachPreparedPruning(part, image, readRange, columnRequests)
+		typedColumnPreparedStateDiagnosticsAdd(&diag, pruningDiag)
+		if err != nil {
+			diag.PruningValidationFailures++
+			diag.PruningValidationFailureReason = err.Error()
+			return nil, diag, fmt.Errorf("collections: typed_column_part pruning validation failed: %w", err)
+		}
+	}
+	if !typedColumnPreparedRequestsIncludeStats(columnRequests) {
+		return part, diag, nil
 	}
 	if err := typedColumnAttachPreparedStats(part, image, readRange); err != nil {
 		diag.StatsValidationFailures++
@@ -573,6 +601,175 @@ func typedColumnPreparedColumnWantsStats(column *typedColumnPreparedColumnState)
 	return false
 }
 
+func typedColumnPreparedRequestsIncludePruning(requests []typedColumnPreparedColumnRequest) bool {
+	for _, request := range requests {
+		if request.IncludePruning {
+			return true
+		}
+	}
+	return false
+}
+
+func typedColumnPreparedColumnWantsPruning(column *typedColumnPreparedColumnState) bool {
+	if column == nil {
+		return false
+	}
+	for _, dep := range column.Plan.Dependencies {
+		if dep.Kind == typedcolumn.SectionDependencyPruningMetadata {
+			return true
+		}
+	}
+	return false
+}
+
+func typedColumnAttachPreparedPruning(part *typedColumnPreparedPartState, image typedcolumn.ColumnPartImage, readRange typedColumnPreparedRangeReader, requests []typedColumnPreparedColumnRequest) (typedColumnPreparedStateDiagnostics, error) {
+	var diag typedColumnPreparedStateDiagnostics
+	if part == nil {
+		return diag, errors.New("collections: typed-column prepared pruning missing part")
+	}
+	section, ok, err := image.PruningMetadataSection()
+	if err != nil {
+		return diag, err
+	}
+	if !ok {
+		for _, column := range part.Columns {
+			if typedColumnPreparedColumnWantsPruning(column) {
+				typedColumnPreparedPruningFallback(column, &diag, typedcolumn.ColumnPruningReasonMissingMetadata)
+			}
+		}
+		return diag, nil
+	}
+	if readRange == nil {
+		return diag, errors.New("collections: typed-column prepared pruning requires range reader")
+	}
+	raw, err := readRange(section.Offset, section.Length, true)
+	if err != nil {
+		return diag, err
+	}
+	diag.DecodedMetadataBytes += uint64(len(raw))
+	pruning, err := typedcolumn.DecodeColumnPartPruningSection(raw)
+	if err != nil {
+		return diag, err
+	}
+	if err := typedcolumn.ValidateColumnPartPruning(pruning, part.Descriptor, part.PhysicalColumns); err != nil {
+		return diag, err
+	}
+	for _, request := range requests {
+		if !request.IncludePruning || !request.HasInt64PruningPredicate {
+			continue
+		}
+		if err := typedColumnApplyPreparedInt64Pruning(part, request, pruning, &diag); err != nil {
+			return diag, err
+		}
+	}
+	return diag, nil
+}
+
+func typedColumnApplyPreparedInt64Pruning(part *typedColumnPreparedPartState, request typedColumnPreparedColumnRequest, pruning typedcolumn.ColumnPartPruning, diag *typedColumnPreparedStateDiagnostics) error {
+	adapterColumn, err := typedColumnAdapterMapField(request.Field)
+	if err != nil {
+		return err
+	}
+	column := part.Columns[adapterColumn.Definition.Name]
+	if column == nil {
+		return fmt.Errorf("collections: typed-column prepared pruning missing column %q", adapterColumn.Definition.Name)
+	}
+	semOp := typedcolumn.ColumnPruningOpOrderedRange
+	if request.Int64PruningPredicate.Kind == typedcolumn.Int64PruningPredicateEqual {
+		semOp = typedcolumn.ColumnPruningOpEquality
+	}
+	semDesc := columnsemantics.Descriptor{Logical: column.Plan.Logical, Physical: column.Plan.Definition.Type, Encoding: column.Plan.Definition.Encoding, Nullable: column.Plan.Field.Nullable, DictionaryOrder: column.Plan.Layout.Descriptor.DictionaryOrder, DictionaryCollation: column.Plan.Layout.Descriptor.DictionaryCollation}
+	semanticsOp := columnsemantics.OpPruneOrderedRange
+	if semOp == typedcolumn.ColumnPruningOpEquality {
+		semanticsOp = columnsemantics.OpPruneEquality
+	}
+	if cap := columnsemantics.CapabilityFor(semDesc, semanticsOp); !cap.Supported() {
+		typedColumnPreparedPruningFallback(column, diag, cap.Error())
+		return nil
+	}
+	if cap := column.Plan.Layout.SupportsSemanticOperation(semanticsOp); !cap.Supported() {
+		typedColumnPreparedPruningFallback(column, diag, cap.Error())
+		return nil
+	}
+	if !column.Certification.PruningCertified {
+		typedColumnPreparedPruningFallback(column, diag, "layout_pruning_not_certified")
+		return nil
+	}
+	index, ok := pruning.Int64Column(adapterColumn.Definition.Name)
+	if !ok {
+		typedColumnPreparedPruningFallback(column, diag, typedcolumn.ColumnPruningReasonMissingMetadata)
+		return nil
+	}
+	plan, err := index.PlanInt64Predicate(request.Int64PruningPredicate)
+	if err != nil {
+		return err
+	}
+	if plan.Reason != "" && plan.Reason != typedcolumn.ColumnPruningReasonSupported {
+		typedColumnPreparedPruningFallback(column, diag, plan.Reason)
+		return nil
+	}
+	if len(plan.Blocks) != len(column.BlockPlans) {
+		return fmt.Errorf("collections: typed-column prepared pruning column %q block candidates=%d want %d", adapterColumn.Definition.Name, len(plan.Blocks), len(column.BlockPlans))
+	}
+	candidates := make(map[int]typedcolumn.ColumnPruningBlockCandidate, len(plan.Blocks))
+	for _, candidate := range plan.Blocks {
+		candidates[candidate.BlockIndex] = candidate
+	}
+	var scratch typedcolumn.RowSelectionScratch
+	for i := range column.BlockPlans {
+		block := &column.BlockPlans[i]
+		candidate, ok := candidates[block.Index]
+		if !ok {
+			return fmt.Errorf("collections: typed-column prepared pruning column %q missing block candidate %d", adapterColumn.Definition.Name, block.Index)
+		}
+		if candidate.FirstRow != block.Descriptor.FirstRow || candidate.RowCount != block.Descriptor.RowCount {
+			return fmt.Errorf("collections: typed-column prepared pruning column %q block %d identity mismatch", adapterColumn.Definition.Name, block.Index)
+		}
+		oldNonEmpty := !block.CandidateSelection.IsEmpty()
+		newSelection := candidate.Selection
+		if oldNonEmpty && !block.CandidateSelection.IsAll() {
+			composed, err := typedcolumn.ComposeRowSelectionsInto(block.Descriptor.RowCount, typedcolumn.RowSelectionComponents{Predicate: &newSelection, Visibility: &block.CandidateSelection}, &scratch)
+			if err != nil {
+				return err
+			}
+			newSelection = composed
+		}
+		if !oldNonEmpty {
+			empty, err := typedcolumn.NewEmptyRowSelection(block.Descriptor.RowCount)
+			if err != nil {
+				return err
+			}
+			newSelection = empty
+		}
+		block.CandidateSelection = newSelection
+		block.NeedsPredicate = false
+		if diag != nil && !newSelection.IsEmpty() {
+			diag.PruningBlocks++
+			diag.PruningRows += newSelection.Count()
+		}
+		block.PruningExact = candidate.Exact
+		block.PruningExactCount = candidate.ExactCount
+		block.PruningExactSum = candidate.ExactSum
+	}
+	column.PruningFallbackReason = ""
+	column.Int64PruningReady = true
+	return nil
+}
+
+func typedColumnPreparedPruningFallback(column *typedColumnPreparedColumnState, diag *typedColumnPreparedStateDiagnostics, reason string) {
+	if column != nil {
+		column.PruningFallbackReason = reason
+	}
+	if diag != nil {
+		blocks := 1
+		if column != nil && len(column.BlockPlans) != 0 {
+			blocks = len(column.BlockPlans)
+		}
+		diag.PruningFallbackBlocks += blocks
+		diag.PruningFallbackReason = reason
+	}
+}
+
 func typedColumnAttachPreparedStats(part *typedColumnPreparedPartState, image typedcolumn.ColumnPartImage, readRange typedColumnPreparedRangeReader) error {
 	if part == nil {
 		return errors.New("collections: typed-column prepared stats missing part")
@@ -695,6 +892,7 @@ func typedColumnPreparedStateDiagnosticsAdd(dst *typedColumnPreparedStateDiagnos
 	dst.SectionDependencies += src.SectionDependencies
 	dst.CandidateRanges += src.CandidateRanges
 	dst.CandidateRangeBytes += src.CandidateRangeBytes
+	dst.DecodedMetadataBytes += src.DecodedMetadataBytes
 	dst.ManifestBytes += src.ManifestBytes
 	dst.DescriptorBytes += src.DescriptorBytes
 	dst.ContractBytes += src.ContractBytes
@@ -709,6 +907,16 @@ func typedColumnPreparedStateDiagnosticsAdd(dst *typedColumnPreparedStateDiagnos
 	dst.StatsValidationFailures += src.StatsValidationFailures
 	if src.StatsValidationFailureReason != "" {
 		dst.StatsValidationFailureReason = src.StatsValidationFailureReason
+	}
+	dst.PruningBlocks += src.PruningBlocks
+	dst.PruningRows += src.PruningRows
+	dst.PruningFallbackBlocks += src.PruningFallbackBlocks
+	if src.PruningFallbackReason != "" {
+		dst.PruningFallbackReason = src.PruningFallbackReason
+	}
+	dst.PruningValidationFailures += src.PruningValidationFailures
+	if src.PruningValidationFailureReason != "" {
+		dst.PruningValidationFailureReason = src.PruningValidationFailureReason
 	}
 	if src.Fallback {
 		dst.Fallback = true

--- a/TreeDB/collections/typed_column_prepared_state_test.go
+++ b/TreeDB/collections/typed_column_prepared_state_test.go
@@ -279,6 +279,20 @@ func TestTypedColumnPreparedPruningComposedSelectionsDoNotAliasScratch(t *testin
 	}
 }
 
+func TestTypedColumnPreparedPruningFallbackDoesNotInflateEmptyBlockPlans(t *testing.T) {
+	var diag typedColumnPreparedStateDiagnostics
+	column := &typedColumnPreparedColumnState{}
+	typedColumnPreparedPruningFallback(column, &diag, "missing")
+	if diag.PruningFallbackBlocks != 0 || diag.PruningFallbackReason != "missing" || column.PruningFallbackReason != "missing" {
+		t.Fatalf("fallback diag=%+v column_reason=%q want zero blocks and reason", diag, column.PruningFallbackReason)
+	}
+	column.BlockPlans = []typedColumnPreparedBlockPlan{{}, {}}
+	typedColumnPreparedPruningFallback(column, &diag, "unsupported")
+	if diag.PruningFallbackBlocks != 2 || diag.PruningFallbackReason != "unsupported" || column.PruningFallbackReason != "unsupported" {
+		t.Fatalf("fallback diag=%+v column_reason=%q want two blocks and updated reason", diag, column.PruningFallbackReason)
+	}
+}
+
 func assertPreparedSelectionRows(t *testing.T, selection typedcolumn.RowSelection, want []int) {
 	t.Helper()
 	got := selection.AppendRows(nil)

--- a/TreeDB/collections/typed_column_prepared_state_test.go
+++ b/TreeDB/collections/typed_column_prepared_state_test.go
@@ -218,6 +218,80 @@ func TestTypedColumnPreparedStateMultiColumnMismatchFailsClosed(t *testing.T) {
 	}
 }
 
+func TestTypedColumnPreparedPruningComposedSelectionsDoNotAliasScratch(t *testing.T) {
+	field := TypedStorageField{Name: "score", Path: "score", Owner: TypedStorageOwnerColumnPart, ValueType: "int64"}
+	values := []int64{
+		0, 1, 1, 0, 0, 1, 1, 0, 1, 1,
+		1, 0, 0, 1, 1, 0, 0, 1, 1, 0,
+	}
+	rows := make([]typedColumnAdapterRow, len(values))
+	for i, value := range values {
+		rows[i] = typedColumnAdapterRow{PrimaryID: int64(i + 1), Values: map[string]columnDeclaredValue{
+			"score": {Type: field.ValueType, Present: true, Int64: value},
+		}}
+	}
+	adapterPart, err := buildTypedColumnAdapterPart(typedColumnAdapterOptions{PartID: 1841, RowsPerGranule: 10, Fields: []TypedStorageField{field}}, rows)
+	if err != nil {
+		t.Fatalf("buildTypedColumnAdapterPart: %v", err)
+	}
+	image, err := adapterPart.buildImage()
+	if err != nil {
+		t.Fatalf("buildImage: %v", err)
+	}
+	ref := ColumnAssetRef{Kind: ColumnAssetKindTCS1TypedColumnPart, Namespace: "test", Generation: 1, PartID: image.PartID, FileID: 1, Length: int64(len(image.Bytes))}
+	physical := ColumnAssetRef{Kind: ColumnAssetKindTCS1PartImage, Namespace: "test", Generation: 1, PartID: columnPhysicalRowAssetPartID, FileID: 1, Length: int64(len(image.Bytes))}
+	readRange := func(offset int, length int, section bool) ([]byte, error) {
+		if offset < 0 || length <= 0 || offset+length > len(image.Bytes) {
+			t.Fatalf("range offset=%d length=%d outside image bytes=%d", offset, length, len(image.Bytes))
+		}
+		return image.Bytes[offset : offset+length], nil
+	}
+	blockSelection := func(g typedcolumn.EncodedGranule, rows int) (typedcolumn.RowSelection, bool, error) {
+		selection, err := typedcolumn.NewRangesRowSelection(rows, []typedcolumn.RowRange{{Start: 0, End: 2}, {Start: 5, End: 6}, {Start: 8, End: 9}})
+		return selection, true, err
+	}
+	requests := []typedColumnPreparedColumnRequest{{
+		Field:                    field,
+		Role:                     typedcolumn.ColumnRolePredicate,
+		Operation:                columnsemantics.OpEquality,
+		IncludePruning:           true,
+		HasInt64PruningPredicate: true,
+		Int64PruningPredicate:    typedcolumn.Int64PruningPredicate{Kind: typedcolumn.Int64PruningPredicateEqual, Value: 1},
+	}}
+	part, diag, err := typedColumnPreparePartStateFromRanges(ref, physical, image.Rows, image.Rows, []TypedStorageField{field}, uint64(adapterPart.Part.Descriptor.SchemaVersion), requests, readRange, blockSelection)
+	if err != nil {
+		t.Fatalf("typedColumnPreparePartStateFromRanges: %v", err)
+	}
+	if diag.PruningValidationFailures != 0 || diag.PruningFallbackBlocks != 0 {
+		t.Fatalf("pruning diagnostics=%+v want no validation/fallback", diag)
+	}
+	column := part.Columns["score"]
+	if column == nil || !column.Int64PruningReady {
+		t.Fatalf("prepared column=%+v want pruning ready", column)
+	}
+	if len(column.BlockPlans) != 2 {
+		t.Fatalf("block plans=%d want 2", len(column.BlockPlans))
+	}
+	assertPreparedSelectionRows(t, column.BlockPlans[0].CandidateSelection, []int{1, 5, 8})
+	assertPreparedSelectionRows(t, column.BlockPlans[1].CandidateSelection, []int{0, 8})
+	if column.BlockPlans[0].NeedsPredicate || column.BlockPlans[1].NeedsPredicate {
+		t.Fatalf("block plans still require predicate after pruning: %+v", column.BlockPlans)
+	}
+}
+
+func assertPreparedSelectionRows(t *testing.T, selection typedcolumn.RowSelection, want []int) {
+	t.Helper()
+	got := selection.AppendRows(nil)
+	if len(got) != len(want) {
+		t.Fatalf("selection rows=%v want %v shape=%+v", got, want, selection.Shape())
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("selection rows=%v want %v shape=%+v", got, want, selection.Shape())
+		}
+	}
+}
+
 func assertPreparedPlanDependency(t *testing.T, plan typedColumnPreparedColumnPlan, kind typedcolumn.SectionDependencyKind) {
 	t.Helper()
 	for _, dep := range plan.Dependencies {

--- a/TreeDB/collections/typed_column_prepared_state_test.go
+++ b/TreeDB/collections/typed_column_prepared_state_test.go
@@ -265,6 +265,9 @@ func TestTypedColumnPreparedPruningComposedSelectionsDoNotAliasScratch(t *testin
 	if diag.PruningValidationFailures != 0 || diag.PruningFallbackBlocks != 0 {
 		t.Fatalf("pruning diagnostics=%+v want no validation/fallback", diag)
 	}
+	if diag.PruningBlocks != 2 || diag.PruningRows != 5 {
+		t.Fatalf("pruning diagnostics=%+v want two narrowed blocks and five candidate rows", diag)
+	}
 	column := part.Columns["score"]
 	if column == nil || !column.Int64PruningReady {
 		t.Fatalf("prepared column=%+v want pruning ready", column)

--- a/TreeDB/collections/typed_column_prepared_state_test.go
+++ b/TreeDB/collections/typed_column_prepared_state_test.go
@@ -277,8 +277,8 @@ func TestTypedColumnPreparedPruningComposedSelectionsDoNotAliasScratch(t *testin
 	}
 	assertPreparedSelectionRows(t, column.BlockPlans[0].CandidateSelection, []int{1, 5, 8})
 	assertPreparedSelectionRows(t, column.BlockPlans[1].CandidateSelection, []int{0, 8})
-	if column.BlockPlans[0].NeedsPredicate || column.BlockPlans[1].NeedsPredicate {
-		t.Fatalf("block plans still require predicate after pruning: %+v", column.BlockPlans)
+	if !column.BlockPlans[0].NeedsPredicate || !column.BlockPlans[1].NeedsPredicate {
+		t.Fatalf("block plans must keep predicate verification after pruning: %+v", column.BlockPlans)
 	}
 }
 

--- a/TreeDB/docs/spec/typed-column-layout-capabilities.md
+++ b/TreeDB/docs/spec/typed-column-layout-capabilities.md
@@ -5,7 +5,8 @@ operation support remains defined in `typed-column-semantics.md`; this document
 covers the physical layout/codec contract that decides whether a semantic
 operation may use a direct view, safe fixed-width reducer, streaming decoder,
 stats payload, or pruning metadata. The stats envelope and payload contract is
-specified in `typed-column-stats.md`.
+specified in `typed-column-stats.md`; durable pruning metadata is specified in
+`typed-column-pruning.md`.
 
 The implementation lives in `TreeDB/internal/columnlayout`. Capability keys are
 not just encodings. A key includes:
@@ -21,8 +22,8 @@ not just encodings. A key includes:
 
 | Logical type | Physical + encoding | Layout capability |
 | --- | --- | --- |
-| `int64` | `int64` + `delta_varint` | Variable-width streaming int64 reducer/range predicate. No direct view. |
-| `int64` | `int64` + `raw_int64` + `compression=none` | Optional explicit fixed-width little-endian layout. Safe byte-loop reducer/range predicate is allowed after row-count and length validation. Direct-view metadata is declared for future use, but #1849 owns zero-copy typed views. |
+| `int64` | `int64` + `delta_varint` | Variable-width streaming int64 reducer/range predicate plus value-row pruning metadata. No direct view. |
+| `int64` | `int64` + `raw_int64` + `compression=none` | Optional explicit fixed-width little-endian layout. Safe byte-loop reducer/range predicate and value-row pruning metadata are allowed after row-count and length validation. Direct-view metadata is declared for future use, but #1849 owns zero-copy typed views. |
 | `string` | `low_cardinality_code` + `low_cardinality_uint32` | Dictionary-code equality/group support. Lexical range/pruning is unsupported unless dictionary order and collation proof are present. |
 | `bool` | `bool` + `bool_bitpack_rle` | Bool-specific counts/equality; scalar range remains unsupported by semantics. |
 | `float32`/`double` | current `int64` + `raw_int64` bit-pattern carrier | Does not advertise int64 numeric aggregate/range/pruning. Native float layouts must define NaN, signed-zero, infinity, endian, width, and stats rules before enabling numeric fast paths. |
@@ -110,9 +111,10 @@ Prepared int64 diagnostics include `DirectViewCertified`, `StreamingCertified`,
 counters. When durable stats are consumed, block diagnostics distinguish
 `StatsBlocks`/`StatsFullCoveredBlocks`/`StatsRows` from `BlocksDecoded` and
 `Kernel*` counters; stats misses and unsupported selection shapes increment
-`StatsFallbackBlocks`. Benchmarks report these as `direct_view_certified/op`,
-`streaming_certified/op`, `stats_blocks/op`, `stats_fallback_blocks/op`, and
-`certification_failures/op`.
+`StatsFallbackBlocks`. Pruning metadata validation is prepare-time and emits
+explicit fallback/validation diagnostics in the int64 prepared state. Benchmarks
+report these as `direct_view_certified/op`, `streaming_certified/op`,
+`stats_blocks/op`, `stats_fallback_blocks/op`, and `certification_failures/op`.
 
 Stable layout fallback reason codes live in `TreeDB/internal/columnlayout`, for
 example `layout_variable_width_no_direct_view`,

--- a/TreeDB/docs/spec/typed-column-pruning.md
+++ b/TreeDB/docs/spec/typed-column-pruning.md
@@ -1,0 +1,81 @@
+# Typed-Column Pruning/Index Metadata (#1841)
+
+Status: pre-alpha internal contract for immutable `typed_column_part` pruning
+metadata. This is a generic envelope with type-specific payloads. The first
+payload is a non-null `int64` value-row index used by prepared int64 predicate
+aggregate planning.
+
+## Contract
+
+A `typed_column_part` may contain one `pruning_metadata` TCS1 section. The
+section is optional: missing metadata is an explicit fallback to existing
+min/max pruning and value decoding. Present metadata is validated before use and
+is bound to the same immutable part descriptor and writer-certified layout
+contract as column data.
+
+Each column payload is wrapped in a generic envelope containing:
+
+- envelope version;
+- part id;
+- column name, physical type, encoding, compression;
+- part row count and block count;
+- null/default counts;
+- payload kind;
+- advertised pruning operations;
+- payload length and checksum.
+
+Readers must fail closed on checksum, identity, row-count, block identity,
+null/default, ordering, or min/max mismatches. Unsupported or missing payloads
+fall back explicitly. Hot row loops consume concrete block-local `RowSelection`
+plans and must not call generic capability interfaces per row.
+
+## Initial payload: `int64_value_rows_v1`
+
+`int64_value_rows_v1` is emitted for non-null `int64` columns with uncompressed
+int64 encodings (`raw_int64`, `delta_varint`, or `double_delta_varint`). Nullable
+or defaultable carriers are deliberately not indexed by this payload.
+
+The payload stores:
+
+- a block map (`block index`, `first row`, `row count`, optional min/max);
+- one `(value, row)` entry for every part row, sorted by `(value, row)`.
+
+The payload advertises:
+
+- `pruning.equality`;
+- `pruning.ordered_range`.
+
+Prepared planning binary-searches entries for equality/range predicates and
+returns immutable block-local `RowSelection` candidates. These selections compose
+with #1844 visibility/delete/null/default masks. For current int64 aggregate
+execution they narrow or eliminate value decoding but do not bypass column-data
+read-integrity validation for matching blocks.
+
+## Capability gates
+
+Use requires all of the following:
+
+1. semantic capability support in `TreeDB/internal/columnsemantics` for the
+   logical operation (`pruning.equality` or `pruning.ordered_range`);
+2. layout capability support in `TreeDB/internal/columnlayout` for value-row
+   pruning;
+3. writer-certified `PruningCertified` layout contract flag;
+4. envelope/payload validation against the descriptor and decoded column block
+   metadata.
+
+Bool/string/float/vector/adjacency payloads are intentionally deferred. They
+must define type-native value semantics rather than reusing int64 carrier
+ordering or aggregates.
+
+## Diagnostics and fallback
+
+Prepared int64 sessions decode pruning metadata during prepare when requested.
+Diagnostics count decoded metadata bytes and preserve existing
+`PruningCertified` certification counters. Missing metadata records a fallback
+reason on prepared column state; corrupt/stale metadata returns a validation
+error rather than silently accepting unsafe candidates.
+
+## On-disk compatibility
+
+TreeDB is pre-alpha. Adding this section changes newly written TCS1 images; old
+images without pruning metadata remain readable and use fallback planning.

--- a/TreeDB/docs/spec/typed-column-semantics.md
+++ b/TreeDB/docs/spec/typed-column-semantics.md
@@ -18,7 +18,7 @@ The shared model lives in `TreeDB/internal/columnsemantics` and separates:
 | Logical type | Current typedcolumn type | Encoding/layout | Scalar range/aggregate stance |
 | --- | --- | --- | --- |
 | `bool` | `bool` | `bool_bitpack_rle` | equality/counts supported; broad scalar range is unsupported (`bool_range_unsupported`). |
-| `int64` | `int64` | `delta_varint` by default; explicit `fixed_width_encoding: "little_endian"` selects uncompressed `raw_int64`; double-delta remains a valid typedcolumn encoding but is not the adapter default | equality, ordered range, count rows/non-null, sum/avg/min/max, min/max stats, sum stats, and ordered-range pruning are supported for non-null int64 semantics. Durable sum/count stats are gated by the stats envelope in `typed-column-stats.md` and are usable only for advertised all/full-block selection shapes. Physical reducer/direct-view eligibility is additionally gated by `typed-column-layout-capabilities.md`. |
+| `int64` | `int64` | `delta_varint` by default; explicit `fixed_width_encoding: "little_endian"` selects uncompressed `raw_int64`; double-delta remains a valid typedcolumn encoding but is not the adapter default | equality, ordered range, count rows/non-null, sum/avg/min/max, min/max stats, sum stats, equality pruning, and ordered-range pruning are supported for non-null int64 semantics. Durable sum/count stats are gated by the stats envelope in `typed-column-stats.md`; durable value-row pruning metadata is gated by `typed-column-pruning.md`. Physical reducer/direct-view/pruning eligibility is additionally gated by `typed-column-layout-capabilities.md`. |
 | `float32` | `int64` | `raw_int64` carrying `math.Float32bits` | raw bit patterns do **not** provide int64 ordered range, sum, min/max, stats, pruning, or direct scalar value semantics (`float_raw_int64_bit_pattern`). Native float semantics require a future float layout and NaN/signed-zero/infinity rules. |
 | `double` | `int64` | `raw_int64` carrying `math.Float64bits` | same raw-bit restriction as `float32`. |
 | `string` | `low_cardinality_code` | `low_cardinality_uint32` plus dictionary metadata | dictionary equality/in-list/group-by are supported. Lexical range/prefix/pruning are unsupported unless dictionary order and collation identity are explicitly proven (`dictionary_order_unproven`, `dictionary_collation_unproven`). |
@@ -70,6 +70,16 @@ optional immutable asset identity, and section dependency kinds such as values,
 dictionaries, offsets, null/default masks, visibility, stats, pruning metadata,
 vector payloads, and adjacency payloads. Row-span or asset-generation mismatches
 must fail closed before a hot loop consumes multiple columns.
+
+## Durable pruning metadata (#1841)
+
+Typed-column pruning metadata is generic at the envelope layer and type-specific
+at the payload layer. The first payload is `int64_value_rows_v1`, a non-null
+int64 `(value,row)` index that advertises `pruning.equality` and
+`pruning.ordered_range`. Prepared planning validates the envelope and payload,
+then produces block-local `RowSelection` candidates that compose with visibility
+and null/default masks. Missing metadata is a safe fallback; corrupt or stale
+metadata fails closed. See `typed-column-pruning.md` for the payload contract.
 
 ## Durable stats envelope (#1840)
 

--- a/TreeDB/internal/columnlayout/layout.go
+++ b/TreeDB/internal/columnlayout/layout.go
@@ -19,6 +19,7 @@ const (
 	OpInt64NumericReducer    Operation = "reducer.int64_numeric"
 	OpInt64RangePredicate    Operation = "predicate.int64_range"
 	OpMinMaxPruning          Operation = "pruning.min_max"
+	OpValueRowPruning        Operation = "pruning.value_rows"
 	OpMinMaxStats            Operation = "stats.min_max"
 	OpSumStats               Operation = "stats.sum"
 	OpLexicalRangePredicate  Operation = "predicate.lexical_range"
@@ -64,6 +65,7 @@ const (
 	ReasonVectorScalarUnsupported     ReasonCode = "layout_vector_scalar_unsupported"
 	ReasonAdjacencyScalarUnsupported  ReasonCode = "layout_adjacency_scalar_unsupported"
 	ReasonStatsPayloadUnsupported     ReasonCode = "layout_stats_payload_unsupported"
+	ReasonPruningPayloadUnsupported   ReasonCode = "layout_pruning_payload_unsupported"
 	ReasonOperationUnsupported        ReasonCode = "layout_operation_unsupported"
 )
 
@@ -159,6 +161,7 @@ type StatsCapabilities struct {
 
 type PruningCapabilities struct {
 	OrderedMinMax     bool
+	ValueRows         bool
 	DictionaryCodes   bool
 	LexicalDictionary bool
 	VectorIndex       bool
@@ -240,6 +243,7 @@ func CapabilitiesFor(desc Descriptor) Capabilities {
 			caps.Stats.MinMax = true
 			caps.Stats.Sum = true
 			caps.Pruning.OrderedMinMax = true
+			caps.Pruning.ValueRows = true
 		}
 	case typedcolumn.EncodingDeltaVarint, typedcolumn.EncodingDoubleDeltaVarint:
 		caps.Layout.Kind = LayoutVariableWidth
@@ -252,6 +256,7 @@ func CapabilitiesFor(desc Descriptor) Capabilities {
 			caps.Stats.MinMax = true
 			caps.Stats.Sum = true
 			caps.Pruning.OrderedMinMax = true
+			caps.Pruning.ValueRows = true
 		}
 	case typedcolumn.EncodingNullableInt64:
 		caps.Layout.Kind = LayoutWrapper
@@ -342,7 +347,7 @@ func (c Capabilities) Supports(op Operation) Capability {
 	}
 	if c.Wrappers.Nullable {
 		switch op {
-		case OpDirectView, OpInt64NumericReducer, OpInt64RangePredicate, OpMinMaxPruning, OpMinMaxStats, OpSumStats, OpScalarNumericAggregate:
+		case OpDirectView, OpInt64NumericReducer, OpInt64RangePredicate, OpMinMaxPruning, OpValueRowPruning, OpMinMaxStats, OpSumStats, OpScalarNumericAggregate:
 			return Fallback(op, ReasonNullDefaultWrapperRequired, "nullable/default wrapper exposes null/default masks separately from carrier values")
 		}
 	}
@@ -350,25 +355,25 @@ func (c Capabilities) Supports(op Operation) Capability {
 		switch op {
 		case OpDirectView:
 			return Unsupported(op, ReasonCompressedDirectView, fmt.Sprintf("compression=%s", c.Descriptor.Compression))
-		case OpInt64NumericReducer, OpInt64RangePredicate, OpMinMaxPruning, OpMinMaxStats, OpSumStats, OpScalarNumericAggregate:
+		case OpInt64NumericReducer, OpInt64RangePredicate, OpMinMaxPruning, OpValueRowPruning, OpMinMaxStats, OpSumStats, OpScalarNumericAggregate:
 			return Unsupported(op, ReasonUnsupportedCompression, fmt.Sprintf("compression=%s", c.Descriptor.Compression))
 		}
 	}
 	if c.Descriptor.Logical == columnsemantics.LogicalFloat32 || c.Descriptor.Logical == columnsemantics.LogicalDouble {
 		switch op {
-		case OpInt64NumericReducer, OpInt64RangePredicate, OpMinMaxPruning, OpMinMaxStats, OpSumStats, OpScalarNumericAggregate:
+		case OpInt64NumericReducer, OpInt64RangePredicate, OpMinMaxPruning, OpValueRowPruning, OpMinMaxStats, OpSumStats, OpScalarNumericAggregate:
 			return Unsupported(op, ReasonFloatBitPatternNotNumeric, "float bit-pattern storage is not an int64 numeric layout")
 		}
 	}
 	if c.Descriptor.Logical == columnsemantics.LogicalFloat32Vector {
 		switch op {
-		case OpInt64NumericReducer, OpInt64RangePredicate, OpMinMaxPruning, OpMinMaxStats, OpSumStats, OpLexicalRangePredicate, OpScalarNumericAggregate:
+		case OpInt64NumericReducer, OpInt64RangePredicate, OpMinMaxPruning, OpValueRowPruning, OpMinMaxStats, OpSumStats, OpLexicalRangePredicate, OpScalarNumericAggregate:
 			return Unsupported(op, ReasonVectorScalarUnsupported, "vector layouts reject scalar aggregate/range shortcuts")
 		}
 	}
 	if c.Descriptor.Logical == columnsemantics.LogicalAdjacencyList {
 		switch op {
-		case OpInt64NumericReducer, OpInt64RangePredicate, OpMinMaxPruning, OpMinMaxStats, OpSumStats, OpLexicalRangePredicate, OpScalarNumericAggregate:
+		case OpInt64NumericReducer, OpInt64RangePredicate, OpMinMaxPruning, OpValueRowPruning, OpMinMaxStats, OpSumStats, OpLexicalRangePredicate, OpScalarNumericAggregate:
 			return Unsupported(op, ReasonAdjacencyScalarUnsupported, "adjacency layouts reject scalar aggregate/range shortcuts")
 		}
 	}
@@ -393,7 +398,12 @@ func (c Capabilities) Supports(op Operation) Capability {
 		if c.Pruning.OrderedMinMax {
 			return Supported(op)
 		}
-		return Unsupported(op, ReasonOperationUnsupported, "layout does not advertise ordered min/max pruning")
+		return Unsupported(op, ReasonPruningPayloadUnsupported, "layout does not advertise ordered min/max pruning")
+	case OpValueRowPruning:
+		if c.Pruning.ValueRows {
+			return Supported(op)
+		}
+		return Unsupported(op, ReasonPruningPayloadUnsupported, "layout does not advertise value-row pruning")
 	case OpMinMaxStats:
 		if c.Stats.MinMax {
 			return Supported(op)
@@ -446,8 +456,10 @@ func (c Capabilities) SupportsSemanticOperation(op columnsemantics.Operation) Ca
 		return c.Supports(OpMinMaxStats)
 	case columnsemantics.OpStatsSum:
 		return c.Supports(OpSumStats)
+	case columnsemantics.OpPruneEquality:
+		return c.Supports(OpValueRowPruning)
 	case columnsemantics.OpPruneOrderedRange:
-		return c.Supports(OpMinMaxPruning)
+		return c.Supports(OpValueRowPruning)
 	case columnsemantics.OpDirectScalarValueCarrier:
 		return c.supportsDirectScalarValueCarrier()
 	case columnsemantics.OpStringLexicalRange, columnsemantics.OpStringPrefix, columnsemantics.OpDictionaryRange:

--- a/TreeDB/internal/columnlayout/layout_test.go
+++ b/TreeDB/internal/columnlayout/layout_test.go
@@ -11,7 +11,7 @@ import (
 func TestInt64RawLayoutCapabilitiesAndValidation(t *testing.T) {
 	desc := Descriptor{Logical: columnsemantics.LogicalInt64, Physical: typedcolumn.ColumnTypeInt64, Encoding: typedcolumn.EncodingRawInt64, Compression: typedcolumn.CompressionNone}
 	caps := CapabilitiesFor(desc)
-	if !caps.Layout.FixedWidth || caps.Layout.ElementWidthBytes != 8 || caps.Layout.Endian != EndianLittle || !caps.DirectView.Eligible || !caps.Reducers.Int64FixedWidthRaw || !caps.Reducers.Int64NumericAggregate {
+	if !caps.Layout.FixedWidth || caps.Layout.ElementWidthBytes != 8 || caps.Layout.Endian != EndianLittle || !caps.DirectView.Eligible || !caps.Reducers.Int64FixedWidthRaw || !caps.Reducers.Int64NumericAggregate || !caps.Pruning.ValueRows {
 		t.Fatalf("raw int64 caps=%+v", caps)
 	}
 	if cap := caps.SupportsSemanticOperation(columnsemantics.OpDirectScalarValueCarrier); !cap.Supported() {
@@ -47,11 +47,14 @@ func TestInt64RawLayoutCapabilitiesAndValidation(t *testing.T) {
 func TestInt64DeltaLayoutStillSupportsStreamingReducer(t *testing.T) {
 	desc := Descriptor{Logical: columnsemantics.LogicalInt64, Physical: typedcolumn.ColumnTypeInt64, Encoding: typedcolumn.EncodingDeltaVarint, Compression: typedcolumn.CompressionNone}
 	caps := CapabilitiesFor(desc)
-	if !caps.Layout.VariableWidth || caps.DirectView.Eligible || !caps.Reducers.Int64Streaming || !caps.Reducers.Int64NumericAggregate {
+	if !caps.Layout.VariableWidth || caps.DirectView.Eligible || !caps.Reducers.Int64Streaming || !caps.Reducers.Int64NumericAggregate || !caps.Pruning.ValueRows {
 		t.Fatalf("delta caps=%+v", caps)
 	}
 	if cap := caps.SupportsSemanticOperation(columnsemantics.OpSum); !cap.Supported() {
 		t.Fatalf("delta sum cap=%+v", cap)
+	}
+	if cap := caps.SupportsSemanticOperation(columnsemantics.OpPruneEquality); !cap.Supported() {
+		t.Fatalf("delta equality pruning cap=%+v", cap)
 	}
 	if cap := caps.Supports(OpDirectView); cap.Supported() || cap.Reason != ReasonVariableWidthNoDirectView {
 		t.Fatalf("delta direct view cap=%+v want reason %s", cap, ReasonVariableWidthNoDirectView)

--- a/TreeDB/internal/columnsemantics/semantics.go
+++ b/TreeDB/internal/columnsemantics/semantics.go
@@ -51,6 +51,7 @@ const (
 	OpVectorMetrics            Operation = "aggregate.vector_metrics"
 	OpStatsMinMax              Operation = "stats.min_max"
 	OpStatsSum                 Operation = "stats.sum"
+	OpPruneEquality            Operation = "pruning.equality"
 	OpPruneOrderedRange        Operation = "pruning.ordered_range"
 	OpDirectScalarValueCarrier Operation = "direct.scalar_value_carrier"
 )
@@ -112,6 +113,7 @@ const (
 	ReasonAdjacencyCapabilityDeferred         ReasonCode = "adjacency_capability_deferred"
 	ReasonBoolRangeUnsupported                ReasonCode = "bool_range_unsupported"
 	ReasonStatsPayloadUnsupported             ReasonCode = "stats_payload_unsupported"
+	ReasonPruningPayloadUnsupported           ReasonCode = "pruning_payload_unsupported"
 )
 
 // Descriptor binds logical semantics to the current typedcolumn physical shape.
@@ -224,7 +226,7 @@ func CapabilityFor(desc Descriptor, op Operation) Capability {
 			return SupportedResult(op, ResultSemantics{ResultType: "int64", OverflowPolicy: "checked row count"})
 		case OpIsNull, OpIsNotNull:
 			return Supported(op)
-		case OpSum, OpAvg, OpMin, OpMax, OpStatsSum, OpStatsMinMax, OpPruneOrderedRange:
+		case OpSum, OpAvg, OpMin, OpMax, OpStatsSum, OpStatsMinMax, OpPruneEquality, OpPruneOrderedRange:
 			return Fallback(op, ReasonNullableCarrierAggregateSemantics, "nullable/default carrier requires explicit count/value aggregate semantics")
 		default:
 			return Fallback(op, ReasonNullableCarrierValueSemantics, "nullable/default carrier requires explicit null/default filtering before value operation")
@@ -287,7 +289,7 @@ func int64Capability(desc Descriptor, op Operation) Capability {
 		return Unsupported(op, ReasonLogicalPhysicalMismatch, "int64 semantics require typedcolumn int64 physical type")
 	}
 	switch op {
-	case OpAllRows, OpEquality, OpInequality, OpOrderedRange, OpInList, OpStatsMinMax, OpPruneOrderedRange, OpDirectScalarValueCarrier:
+	case OpAllRows, OpEquality, OpInequality, OpOrderedRange, OpInList, OpStatsMinMax, OpPruneEquality, OpPruneOrderedRange, OpDirectScalarValueCarrier:
 		return Supported(op)
 	case OpCountRows, OpCountNonNull:
 		return SupportedResult(op, ResultSemantics{ResultType: "int64", OverflowPolicy: "checked row count"})
@@ -313,6 +315,8 @@ func boolCapability(desc Descriptor, op Operation) Capability {
 	switch op {
 	case OpAllRows, OpEquality, OpInequality, OpInList, OpDirectScalarValueCarrier:
 		return Supported(op)
+	case OpPruneEquality:
+		return Fallback(op, ReasonPruningPayloadUnsupported, "bool pruning payload is deferred to the bool type-family slice")
 	case OpCountRows, OpCountNonNull:
 		return SupportedResult(op, ResultSemantics{ResultType: "int64", OverflowPolicy: "checked row count"})
 	case OpBoolCounts:
@@ -329,7 +333,7 @@ func boolCapability(desc Descriptor, op Operation) Capability {
 func floatCapability(desc Descriptor, op Operation) Capability {
 	if desc.Physical == typedcolumn.ColumnTypeInt64 && desc.Encoding == typedcolumn.EncodingRawInt64 {
 		switch op {
-		case OpOrderedRange, OpSum, OpAvg, OpMin, OpMax, OpStatsMinMax, OpStatsSum, OpPruneOrderedRange, OpDirectScalarValueCarrier:
+		case OpOrderedRange, OpSum, OpAvg, OpMin, OpMax, OpStatsMinMax, OpStatsSum, OpPruneEquality, OpPruneOrderedRange, OpDirectScalarValueCarrier:
 			return Unsupported(op, ReasonFloatRawInt64BitPattern, "raw int64 float bit patterns do not provide numeric float semantics")
 		case OpAllRows:
 			return Supported(op)
@@ -351,6 +355,8 @@ func stringCapability(desc Descriptor, op Operation) Capability {
 	switch op {
 	case OpAllRows, OpEquality, OpInequality, OpInList, OpDictionaryEquality:
 		return Supported(op)
+	case OpPruneEquality:
+		return Fallback(op, ReasonPruningPayloadUnsupported, "string pruning payload is deferred to the string type-family slice")
 	case OpCountRows, OpCountNonNull:
 		return SupportedResult(op, ResultSemantics{ResultType: "int64", OverflowPolicy: "checked row count"})
 	case OpDictionaryGroupBy:
@@ -381,7 +387,7 @@ func vectorCapability(desc Descriptor, op Operation) Capability {
 		return SupportedResult(op, ResultSemantics{ResultType: "int64", OverflowPolicy: "checked row count"})
 	case OpVectorSimilarity, OpVectorMetrics:
 		return Fallback(op, ReasonVectorCapabilityDeferred, "vector-specific kernels are deferred")
-	case OpEquality, OpInequality, OpOrderedRange, OpInList, OpSum, OpAvg, OpMin, OpMax, OpStatsMinMax, OpStatsSum, OpPruneOrderedRange, OpDirectScalarValueCarrier:
+	case OpEquality, OpInequality, OpOrderedRange, OpInList, OpSum, OpAvg, OpMin, OpMax, OpStatsMinMax, OpStatsSum, OpPruneEquality, OpPruneOrderedRange, OpDirectScalarValueCarrier:
 		return Unsupported(op, ReasonVectorScalarOperationUnsupported, "vector columns are not scalar comparable or scalar aggregate values")
 	default:
 		return Unsupported(op, ReasonOperationUnsupported, "operation is not a vector semantic capability")
@@ -399,7 +405,7 @@ func adjacencyCapability(desc Descriptor, op Operation) Capability {
 		return SupportedResult(op, ResultSemantics{ResultType: "int64", OverflowPolicy: "checked row count"})
 	case OpVectorSimilarity, OpVectorMetrics:
 		return Fallback(op, ReasonAdjacencyCapabilityDeferred, "graph/vector-specific adjacency capabilities are deferred")
-	case OpEquality, OpInequality, OpOrderedRange, OpInList, OpSum, OpAvg, OpMin, OpMax, OpStatsMinMax, OpStatsSum, OpPruneOrderedRange, OpDirectScalarValueCarrier:
+	case OpEquality, OpInequality, OpOrderedRange, OpInList, OpSum, OpAvg, OpMin, OpMax, OpStatsMinMax, OpStatsSum, OpPruneEquality, OpPruneOrderedRange, OpDirectScalarValueCarrier:
 		return Unsupported(op, ReasonAdjacencyScalarOperationUnsupported, "adjacency columns are not scalar comparable or scalar aggregate values")
 	default:
 		return Unsupported(op, ReasonOperationUnsupported, "operation is not an adjacency semantic capability")

--- a/TreeDB/internal/columnsemantics/semantics_test.go
+++ b/TreeDB/internal/columnsemantics/semantics_test.go
@@ -27,7 +27,7 @@ func TestSemanticMatrixCoversCurrentLogicalTypesColumnTypesAndEncodings(t *testi
 
 func TestCapabilityInt64SupportsPreparedPredicateAndAggregateSemantics(t *testing.T) {
 	desc := Descriptor{Logical: LogicalInt64, Physical: typedcolumn.ColumnTypeInt64, Encoding: typedcolumn.EncodingDeltaVarint}
-	for _, op := range []Operation{OpAllRows, OpEquality, OpOrderedRange, OpCountRows, OpCountNonNull, OpSum, OpAvg, OpMin, OpMax, OpStatsMinMax, OpStatsSum, OpPruneOrderedRange} {
+	for _, op := range []Operation{OpAllRows, OpEquality, OpOrderedRange, OpCountRows, OpCountNonNull, OpSum, OpAvg, OpMin, OpMax, OpStatsMinMax, OpStatsSum, OpPruneEquality, OpPruneOrderedRange} {
 		if cap := CapabilityFor(desc, op); cap.Status != StatusSupported || cap.Phase != PhasePrepare {
 			t.Fatalf("op %s status=%s reason=%s phase=%s", op, cap.Status, cap.Reason, cap.Phase)
 		}
@@ -72,7 +72,7 @@ func TestCapabilityBoolSupportsEqualityButRejectsRangeSemantics(t *testing.T) {
 func TestCapabilityFloatRawInt64DoesNotClaimInt64NumericSemantics(t *testing.T) {
 	for _, logical := range []LogicalType{LogicalFloat32, LogicalDouble} {
 		desc := Descriptor{Logical: logical, Physical: typedcolumn.ColumnTypeInt64, Encoding: typedcolumn.EncodingRawInt64}
-		for _, op := range []Operation{OpOrderedRange, OpSum, OpAvg, OpMin, OpMax, OpStatsMinMax, OpStatsSum, OpPruneOrderedRange, OpDirectScalarValueCarrier} {
+		for _, op := range []Operation{OpOrderedRange, OpSum, OpAvg, OpMin, OpMax, OpStatsMinMax, OpStatsSum, OpPruneEquality, OpPruneOrderedRange, OpDirectScalarValueCarrier} {
 			cap := CapabilityFor(desc, op)
 			if cap.Status != StatusUnsupported || cap.Reason != ReasonFloatRawInt64BitPattern {
 				t.Fatalf("%s %s status=%s reason=%s", logical, op, cap.Status, cap.Reason)
@@ -115,7 +115,7 @@ func TestCapabilityNullableCarrierDistinguishesCountAndValueAggregateSemantics(t
 			t.Fatalf("%s status=%s reason=%s", op, cap.Status, cap.Reason)
 		}
 	}
-	for _, op := range []Operation{OpSum, OpAvg, OpMin, OpMax, OpStatsMinMax, OpStatsSum, OpPruneOrderedRange} {
+	for _, op := range []Operation{OpSum, OpAvg, OpMin, OpMax, OpStatsMinMax, OpStatsSum, OpPruneEquality, OpPruneOrderedRange} {
 		cap := CapabilityFor(desc, op)
 		if cap.Status != StatusFallback || cap.Reason != ReasonNullableCarrierAggregateSemantics {
 			t.Fatalf("%s status=%s reason=%s", op, cap.Status, cap.Reason)
@@ -156,7 +156,7 @@ func TestCapabilityVectorAndAdjacencyRejectScalarShortcutSemantics(t *testing.T)
 				t.Fatalf("%s %s capability=%+v", tc.name, op, cap)
 			}
 		}
-		for _, op := range []Operation{OpEquality, OpOrderedRange, OpSum, OpAvg, OpMin, OpMax, OpStatsMinMax, OpPruneOrderedRange, OpDirectScalarValueCarrier} {
+		for _, op := range []Operation{OpEquality, OpOrderedRange, OpSum, OpAvg, OpMin, OpMax, OpStatsMinMax, OpPruneEquality, OpPruneOrderedRange, OpDirectScalarValueCarrier} {
 			cap := CapabilityFor(tc.desc, op)
 			if cap.Status != StatusUnsupported || cap.Reason != tc.reason {
 				t.Fatalf("%s %s status=%s reason=%s", tc.name, op, cap.Status, cap.Reason)
@@ -192,6 +192,7 @@ func TestCapabilityReasonCodesAreStable(t *testing.T) {
 		ReasonVectorScalarOperationUnsupported:    "vector_scalar_operation_unsupported",
 		ReasonAdjacencyScalarOperationUnsupported: "adjacency_scalar_operation_unsupported",
 		ReasonStatsPayloadUnsupported:             "stats_payload_unsupported",
+		ReasonPruningPayloadUnsupported:           "pruning_payload_unsupported",
 	}
 	for got, want := range checks {
 		if string(got) != want {

--- a/TreeDB/internal/typedcolumn/part.go
+++ b/TreeDB/internal/typedcolumn/part.go
@@ -105,6 +105,7 @@ type ColumnPart struct {
 	Locators          map[int64]RowLocator
 	AggregateMetadata map[string]AggregateMetadata
 	ColumnStats       ColumnPartStats
+	PruningMetadata   ColumnPartPruning
 }
 
 type ColumnPartDescriptor struct {
@@ -253,6 +254,11 @@ func (b *ColumnPartBuilder) Build(partID uint64, batch Batch) (*ColumnPart, erro
 		return nil, err
 	}
 	part.ColumnStats = stats
+	pruning, err := buildColumnPartPruning(part)
+	if err != nil {
+		return nil, err
+	}
+	part.PruningMetadata = pruning
 	return part, nil
 }
 

--- a/TreeDB/internal/typedcolumn/part_accounting.go
+++ b/TreeDB/internal/typedcolumn/part_accounting.go
@@ -33,6 +33,7 @@ type ColumnPartByteAccounting struct {
 	SortKeyMetadataBytes    int                                    `json:"sort_key_metadata_bytes"`
 	AggregateMetadataBytes  int                                    `json:"aggregate_metadata_bytes"`
 	ColumnStatsBytes        int                                    `json:"column_stats_bytes"`
+	PruningMetadataBytes    int                                    `json:"pruning_metadata_bytes"`
 	DescriptorBytes         int                                    `json:"descriptor_bytes"`
 	LayoutContractBytes     int                                    `json:"layout_contract_bytes"`
 	LocatorBytes            int                                    `json:"locator_bytes"`
@@ -174,6 +175,7 @@ func (p *ColumnPart) ByteAccounting() ColumnPartByteAccounting {
 	out.SortKeyMetadataBytes = estimateSortKeyMetadataBytes(p.Descriptor.SortKey)
 	out.AggregateMetadataBytes = aggregateMetadataStoredBytes(p.AggregateMetadata)
 	out.ColumnStatsBytes = columnStatsStoredBytes(p.ColumnStats)
+	out.PruningMetadataBytes = columnPruningStoredBytes(p.PruningMetadata)
 	out.DescriptorBytes = estimateColumnPartDescriptorBytes(p.Descriptor)
 	out.LocatorBytes = len(p.Locators) * rowLocatorBytes
 	for _, compression := range compressionByKey {
@@ -221,6 +223,7 @@ func (p *ColumnPart) ByteAccountingFromImage(image ColumnPartImage) ColumnPartBy
 	out.SortKeyMetadataBytes = image.CategoryBytes(ColumnPartImageCategorySortKeyMetadata)
 	out.AggregateMetadataBytes = image.CategoryBytes(ColumnPartImageCategoryAggregateMetadata)
 	out.ColumnStatsBytes = image.CategoryBytes(ColumnPartImageCategoryColumnStats)
+	out.PruningMetadataBytes = image.CategoryBytes(ColumnPartImageCategoryPruningMetadata)
 	out.DescriptorBytes = image.CategoryBytes(ColumnPartImageCategoryDescriptor)
 	out.LayoutContractBytes = image.CategoryBytes(ColumnPartImageCategoryLayoutContract)
 	out.LocatorBytes = image.CategoryBytes(ColumnPartImageCategoryLocators)
@@ -247,6 +250,7 @@ func (a ColumnPartByteAccounting) CategoryBytes() int {
 		a.SortKeyMetadataBytes +
 		a.AggregateMetadataBytes +
 		a.ColumnStatsBytes +
+		a.PruningMetadataBytes +
 		a.DescriptorBytes +
 		a.LayoutContractBytes +
 		a.LocatorBytes
@@ -304,6 +308,14 @@ func aggregateMetadataStoredBytes(metadata map[string]AggregateMetadata) int {
 
 func columnStatsStoredBytes(stats ColumnPartStats) int {
 	raw, err := encodeColumnPartStatsSection(stats)
+	if err != nil {
+		return 0
+	}
+	return len(raw)
+}
+
+func columnPruningStoredBytes(pruning ColumnPartPruning) int {
+	raw, err := encodeColumnPartPruningSection(pruning)
 	if err != nil {
 		return 0
 	}

--- a/TreeDB/internal/typedcolumn/part_image.go
+++ b/TreeDB/internal/typedcolumn/part_image.go
@@ -25,6 +25,7 @@ const (
 	ColumnPartImageSectionRowLocators       ColumnPartImageSectionKind = "row_locators"
 	ColumnPartImageSectionAggregateMetadata ColumnPartImageSectionKind = "aggregate_metadata"
 	ColumnPartImageSectionColumnStats       ColumnPartImageSectionKind = "column_stats"
+	ColumnPartImageSectionPruningMetadata   ColumnPartImageSectionKind = "pruning_metadata"
 	ColumnPartImageSectionDictionaries      ColumnPartImageSectionKind = "dictionaries"
 	ColumnPartImageSectionLayoutContract    ColumnPartImageSectionKind = "layout_contract"
 	ColumnPartImageSectionColumnData        ColumnPartImageSectionKind = "column_data"
@@ -41,6 +42,7 @@ const (
 	ColumnPartImageCategoryLocators          ColumnPartImageSectionCategory = "locators"
 	ColumnPartImageCategoryAggregateMetadata ColumnPartImageSectionCategory = "aggregate_metadata"
 	ColumnPartImageCategoryColumnStats       ColumnPartImageSectionCategory = "column_stats"
+	ColumnPartImageCategoryPruningMetadata   ColumnPartImageSectionCategory = "pruning_metadata"
 	ColumnPartImageCategoryDictionaries      ColumnPartImageSectionCategory = "dictionaries"
 	ColumnPartImageCategoryLayoutContract    ColumnPartImageSectionCategory = "layout_contract"
 	ColumnPartImageCategoryDeclaredColumns   ColumnPartImageSectionCategory = "declared_columns"
@@ -114,6 +116,7 @@ func (p *ColumnPart) WithImagePayloads(image ColumnPartImage) (*ColumnPart, erro
 	}
 	out := *p
 	out.ColumnStats = cloneColumnPartStats(p.ColumnStats)
+	out.PruningMetadata = cloneColumnPartPruning(p.PruningMetadata)
 	out.Columns = make(map[string]ColumnPartColumn, len(p.Columns))
 	for name, column := range p.Columns {
 		outColumn := column
@@ -331,6 +334,9 @@ func (b *columnPartImageBuilder) build() (ColumnPartImage, error) {
 		return ColumnPartImage{}, err
 	}
 	if err := b.addColumnStatsSection(); err != nil {
+		return ColumnPartImage{}, err
+	}
+	if err := b.addPruningMetadataSection(); err != nil {
 		return ColumnPartImage{}, err
 	}
 	if err := b.addDictionarySection(); err != nil {
@@ -649,6 +655,25 @@ func (b *columnPartImageBuilder) addColumnStatsSection() error {
 		Kind:     ColumnPartImageSectionColumnStats,
 		Category: ColumnPartImageCategoryColumnStats,
 		Name:     "column_stats",
+		Rows:     b.part.Descriptor.RowCount,
+		Granules: len(b.part.Descriptor.Granules),
+		Blocks:   countColumnBlocks(b.part.Descriptor),
+	}, data)
+	return nil
+}
+
+func (b *columnPartImageBuilder) addPruningMetadataSection() error {
+	data, err := encodeColumnPartPruningSection(b.part.PruningMetadata)
+	if err != nil {
+		return err
+	}
+	if len(data) == 0 {
+		return nil
+	}
+	b.appendSection(ColumnPartImageSection{
+		Kind:     ColumnPartImageSectionPruningMetadata,
+		Category: ColumnPartImageCategoryPruningMetadata,
+		Name:     "column_pruning",
 		Rows:     b.part.Descriptor.RowCount,
 		Granules: len(b.part.Descriptor.Granules),
 		Blocks:   countColumnBlocks(b.part.Descriptor),
@@ -998,6 +1023,7 @@ var columnPartImageSectionCodes = []columnPartImageSectionCode{
 	{kind: ColumnPartImageSectionManifest, kindCode: 8, category: ColumnPartImageCategoryManifest, categoryCode: 8},
 	{kind: ColumnPartImageSectionLayoutContract, kindCode: 9, category: ColumnPartImageCategoryLayoutContract, categoryCode: 9},
 	{kind: ColumnPartImageSectionColumnStats, kindCode: 10, category: ColumnPartImageCategoryColumnStats, categoryCode: 10},
+	{kind: ColumnPartImageSectionPruningMetadata, kindCode: 11, category: ColumnPartImageCategoryPruningMetadata, categoryCode: 11},
 }
 
 func columnPartImageSectionKindCode(kind ColumnPartImageSectionKind) (uint16, error) {

--- a/TreeDB/internal/typedcolumn/part_image_decode.go
+++ b/TreeDB/internal/typedcolumn/part_image_decode.go
@@ -233,6 +233,7 @@ type ColumnPartImageReadOptions struct {
 	ValidateRowLocators      bool
 	IncludeAggregateMetadata bool
 	IncludeColumnStats       bool
+	IncludePruningMetadata   bool
 }
 
 func ColumnPartFromImage(image ColumnPartImage) (*ColumnPart, error) {
@@ -241,6 +242,7 @@ func ColumnPartFromImage(image ColumnPartImage) (*ColumnPart, error) {
 		ValidateRowLocators:      true,
 		IncludeAggregateMetadata: true,
 		IncludeColumnStats:       true,
+		IncludePruningMetadata:   true,
 	})
 }
 
@@ -330,6 +332,13 @@ func ColumnPartFromImageWithOptions(image ColumnPartImage, opts ColumnPartImageR
 			return nil, err
 		}
 	}
+	var pruningMetadata ColumnPartPruning
+	if opts.IncludePruningMetadata {
+		pruningMetadata, err = decodeColumnPruningSectionFromImage(image, desc, columns)
+		if err != nil {
+			return nil, err
+		}
+	}
 	aggregateDefinitions := make([]AggregateMetadataDefinition, 0, len(aggregateMetadata))
 	for _, metadata := range aggregateMetadata {
 		aggregateDefinitions = append(aggregateDefinitions, metadata.Definition)
@@ -360,6 +369,7 @@ func ColumnPartFromImageWithOptions(image ColumnPartImage, opts ColumnPartImageR
 		Locators:          locators,
 		AggregateMetadata: aggregateMetadata,
 		ColumnStats:       columnStats,
+		PruningMetadata:   pruningMetadata,
 	}
 	return part, nil
 }
@@ -1962,6 +1972,7 @@ func validateImageSectionMultiplicity(sections []ColumnPartImageSection) error {
 		ColumnPartImageSectionDictionaries,
 		ColumnPartImageSectionLayoutContract,
 		ColumnPartImageSectionColumnStats,
+		ColumnPartImageSectionPruningMetadata,
 	} {
 		if counts[kind] > 1 {
 			return fmt.Errorf("typedcolumn: image has %d %s sections, want at most 1", counts[kind], kind)
@@ -1992,6 +2003,8 @@ func expectedImageSectionCategory(kind ColumnPartImageSectionKind) (ColumnPartIm
 		return ColumnPartImageCategoryAggregateMetadata, true
 	case ColumnPartImageSectionColumnStats:
 		return ColumnPartImageCategoryColumnStats, true
+	case ColumnPartImageSectionPruningMetadata:
+		return ColumnPartImageCategoryPruningMetadata, true
 	case ColumnPartImageSectionDictionaries:
 		return ColumnPartImageCategoryDictionaries, true
 	case ColumnPartImageSectionLayoutContract:

--- a/TreeDB/internal/typedcolumn/pruning.go
+++ b/TreeDB/internal/typedcolumn/pruning.go
@@ -177,6 +177,8 @@ func (idx Int64ValueRowIndex) PlanInt64Predicate(pred Int64PruningPredicate) (Co
 		if ok, reason := idx.CanPlan(op); !ok {
 			return ColumnPruningCandidatePlan{Rows: idx.Rows, Reason: reason}, nil
 		}
+	} else {
+		return idx.planAllInt64Predicate()
 	}
 	plan := ColumnPruningCandidatePlan{Rows: idx.Rows, Blocks: make([]ColumnPruningBlockCandidate, len(idx.Blocks)), Exact: true}
 	rowsByBlock := make([][]int, len(idx.Blocks))
@@ -228,6 +230,26 @@ func (idx Int64ValueRowIndex) PlanInt64Predicate(pred Int64PruningPredicate) (Co
 			return ColumnPruningCandidatePlan{}, fmt.Errorf("typedcolumn: pruning block %d selection: %w", i, err)
 		}
 		candidate := ColumnPruningBlockCandidate{BlockIndex: block.Index, FirstRow: block.FirstRow, RowCount: block.RowCount, Selection: selection, Exact: exactSumOKByBlock[i], ExactCount: exactCountByBlock[i], ExactSum: exactSumByBlock[i]}
+		plan.Blocks[i] = candidate
+		if selection.IsEmpty() {
+			plan.PrunedBlocks++
+			plan.PrunedRows += block.RowCount
+			continue
+		}
+		plan.CandidateBlocks++
+		plan.CandidateRows += selection.Count()
+	}
+	return plan, nil
+}
+
+func (idx Int64ValueRowIndex) planAllInt64Predicate() (ColumnPruningCandidatePlan, error) {
+	plan := ColumnPruningCandidatePlan{Rows: idx.Rows, Blocks: make([]ColumnPruningBlockCandidate, len(idx.Blocks)), Exact: false}
+	for i, block := range idx.Blocks {
+		selection, err := NewAllRowSelection(block.RowCount)
+		if err != nil {
+			return ColumnPruningCandidatePlan{}, err
+		}
+		candidate := ColumnPruningBlockCandidate{BlockIndex: block.Index, FirstRow: block.FirstRow, RowCount: block.RowCount, Selection: selection, Exact: false}
 		plan.Blocks[i] = candidate
 		if selection.IsEmpty() {
 			plan.PrunedBlocks++

--- a/TreeDB/internal/typedcolumn/pruning.go
+++ b/TreeDB/internal/typedcolumn/pruning.go
@@ -1,0 +1,930 @@
+package typedcolumn
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/snissn/gomap/TreeDB/internal/crc"
+)
+
+const (
+	columnPartPruningSectionMagic   = uint32(0x54435052) // TCPR
+	columnPartPruningSectionVersion = uint16(1)
+	ColumnPruningEnvelopeVersion    = uint16(1)
+	Int64PruningPayloadVersion      = uint16(1)
+)
+
+// ColumnPruningOperation is stored as the semantic predicate operation string
+// advertised by a pruning/index envelope. The values intentionally match
+// columnsemantics.Operation without importing that package into typedcolumn.
+type ColumnPruningOperation string
+
+const (
+	ColumnPruningOpEquality     ColumnPruningOperation = "pruning.equality"
+	ColumnPruningOpOrderedRange ColumnPruningOperation = "pruning.ordered_range"
+)
+
+type ColumnPruningPayloadKind string
+
+const (
+	ColumnPruningPayloadInt64ValueRowsV1 ColumnPruningPayloadKind = "int64_value_rows_v1"
+	ColumnPruningPayloadUnsupported      ColumnPruningPayloadKind = "unsupported"
+)
+
+const (
+	ColumnPruningReasonSupported            = "supported"
+	ColumnPruningReasonMissingMetadata      = "pruning_metadata_missing"
+	ColumnPruningReasonUnsupportedPayload   = "pruning_payload_unsupported"
+	ColumnPruningReasonOperationUnsupported = "pruning_operation_unsupported"
+	ColumnPruningReasonChecksumMismatch     = "pruning_checksum_mismatch"
+	ColumnPruningReasonIdentityMismatch     = "pruning_identity_mismatch"
+	ColumnPruningReasonRowCountMismatch     = "pruning_row_count_mismatch"
+	ColumnPruningReasonNullDefaultMismatch  = "pruning_null_default_mismatch"
+	ColumnPruningReasonEntryOrderMismatch   = "pruning_entry_order_mismatch"
+	ColumnPruningReasonEntryRowMismatch     = "pruning_entry_row_mismatch"
+	ColumnPruningReasonMinMaxMismatch       = "pruning_min_max_mismatch"
+	ColumnPruningReasonSumOverflow          = "pruning_sum_overflow"
+)
+
+type ColumnPruningEnvelope struct {
+	Version         uint16
+	PartID          uint64
+	ColumnName      string
+	ColumnType      ColumnType
+	Encoding        Encoding
+	Compression     Compression
+	Rows            int
+	Blocks          int
+	NullCount       int
+	DefaultCount    int
+	PayloadKind     ColumnPruningPayloadKind
+	Operations      []ColumnPruningOperation
+	PayloadLength   int
+	PayloadChecksum uint32
+}
+
+type Int64PruningBlock struct {
+	Index     int
+	FirstRow  int
+	RowCount  int
+	HasMinMax bool
+	Min       int64
+	Max       int64
+}
+
+type Int64PruningEntry struct {
+	Value int64
+	Row   int
+}
+
+type Int64ValueRowIndex struct {
+	Envelope     ColumnPruningEnvelope
+	Rows         int
+	NullCount    int
+	DefaultCount int
+	Blocks       []Int64PruningBlock
+	Entries      []Int64PruningEntry
+}
+
+type ColumnPartPruning struct {
+	Version uint16
+	PartID  uint64
+	Rows    int
+	Int64   map[string]Int64ValueRowIndex
+}
+
+func (p ColumnPartPruning) Empty() bool { return len(p.Int64) == 0 }
+
+func (p ColumnPartPruning) Int64Column(name string) (Int64ValueRowIndex, bool) {
+	if p.Int64 == nil {
+		return Int64ValueRowIndex{}, false
+	}
+	index, ok := p.Int64[name]
+	return index, ok
+}
+
+func (e ColumnPruningEnvelope) SupportsOperation(op ColumnPruningOperation) bool {
+	for _, advertised := range e.Operations {
+		if advertised == op {
+			return true
+		}
+	}
+	return false
+}
+
+func (idx Int64ValueRowIndex) CanPlan(op ColumnPruningOperation) (bool, string) {
+	if idx.Envelope.PayloadKind != ColumnPruningPayloadInt64ValueRowsV1 {
+		return false, ColumnPruningReasonUnsupportedPayload
+	}
+	if !idx.Envelope.SupportsOperation(op) {
+		return false, ColumnPruningReasonOperationUnsupported
+	}
+	return true, ColumnPruningReasonSupported
+}
+
+type Int64PruningPredicateKind string
+
+const (
+	Int64PruningPredicateAll   Int64PruningPredicateKind = "all"
+	Int64PruningPredicateEqual Int64PruningPredicateKind = "equal"
+	Int64PruningPredicateRange Int64PruningPredicateKind = "range"
+)
+
+type Int64PruningPredicate struct {
+	Kind  Int64PruningPredicateKind
+	Value int64
+	Low   int64
+	High  int64
+}
+
+type ColumnPruningBlockCandidate struct {
+	BlockIndex     int
+	FirstRow       int
+	RowCount       int
+	Selection      RowSelection
+	NeedsPredicate bool
+	Exact          bool
+	ExactCount     int64
+	ExactSum       int64
+}
+
+type ColumnPruningCandidatePlan struct {
+	Rows              int
+	Blocks            []ColumnPruningBlockCandidate
+	CandidateRows     int
+	PrunedRows        int
+	CandidateBlocks   int
+	PrunedBlocks      int
+	FalsePositiveRows int
+	Exact             bool
+	ExactCount        int64
+	ExactSum          int64
+	Reason            string
+}
+
+// PlanInt64Predicate turns a durable int64 value-row index into block-local
+// RowSelection candidates. The returned selections are immutable and own their
+// slice storage; callers may retain them for a prepared/session lifetime.
+func (idx Int64ValueRowIndex) PlanInt64Predicate(pred Int64PruningPredicate) (ColumnPruningCandidatePlan, error) {
+	if err := validateInt64PruningPredicate(pred); err != nil {
+		return ColumnPruningCandidatePlan{}, err
+	}
+	op := ColumnPruningOpOrderedRange
+	if pred.Kind == Int64PruningPredicateEqual {
+		op = ColumnPruningOpEquality
+	}
+	if pred.Kind != Int64PruningPredicateAll {
+		if ok, reason := idx.CanPlan(op); !ok {
+			return ColumnPruningCandidatePlan{Rows: idx.Rows, Reason: reason}, nil
+		}
+	}
+	plan := ColumnPruningCandidatePlan{Rows: idx.Rows, Blocks: make([]ColumnPruningBlockCandidate, len(idx.Blocks)), Exact: true}
+	rowsByBlock := make([][]int, len(idx.Blocks))
+	exactCountByBlock := make([]int64, len(idx.Blocks))
+	exactSumByBlock := make([]int64, len(idx.Blocks))
+	exactSumOK := true
+	exactSumOKByBlock := make([]bool, len(idx.Blocks))
+	for i := range exactSumOKByBlock {
+		exactSumOKByBlock[i] = true
+	}
+	entries := idx.entriesForPredicate(pred)
+	for _, entry := range entries {
+		blockIndex := idx.blockIndexForRow(entry.Row)
+		if blockIndex < 0 {
+			return ColumnPruningCandidatePlan{}, fmt.Errorf("typedcolumn: pruning entry row=%d outside block map: %s", entry.Row, ColumnPruningReasonEntryRowMismatch)
+		}
+		local := entry.Row - idx.Blocks[blockIndex].FirstRow
+		rowsByBlock[blockIndex] = append(rowsByBlock[blockIndex], local)
+		exactCountByBlock[blockIndex]++
+		if exactSumOKByBlock[blockIndex] {
+			updatedBlock, err := checkedInt64Add(exactSumByBlock[blockIndex], entry.Value)
+			if err != nil {
+				exactSumOKByBlock[blockIndex] = false
+				exactSumByBlock[blockIndex] = 0
+				exactSumOK = false
+				plan.Exact = false
+				plan.ExactSum = 0
+			} else {
+				exactSumByBlock[blockIndex] = updatedBlock
+			}
+		}
+		if exactSumOK {
+			updated, err := checkedInt64Add(plan.ExactSum, entry.Value)
+			if err != nil {
+				exactSumOK = false
+				plan.Exact = false
+				plan.ExactSum = 0
+			} else {
+				plan.ExactSum = updated
+			}
+		}
+		plan.ExactCount++
+	}
+	for i, block := range idx.Blocks {
+		rows := rowsByBlock[i]
+		sort.Ints(rows)
+		selection, err := pruningSelectionFromSortedRows(block.RowCount, rows)
+		if err != nil {
+			return ColumnPruningCandidatePlan{}, fmt.Errorf("typedcolumn: pruning block %d selection: %w", i, err)
+		}
+		candidate := ColumnPruningBlockCandidate{BlockIndex: block.Index, FirstRow: block.FirstRow, RowCount: block.RowCount, Selection: selection, Exact: exactSumOKByBlock[i], ExactCount: exactCountByBlock[i], ExactSum: exactSumByBlock[i]}
+		plan.Blocks[i] = candidate
+		if selection.IsEmpty() {
+			plan.PrunedBlocks++
+			plan.PrunedRows += block.RowCount
+			continue
+		}
+		plan.CandidateBlocks++
+		plan.CandidateRows += selection.Count()
+	}
+	return plan, nil
+}
+
+func validateInt64PruningPredicate(pred Int64PruningPredicate) error {
+	switch pred.Kind {
+	case Int64PruningPredicateAll, Int64PruningPredicateEqual:
+		return nil
+	case Int64PruningPredicateRange:
+		if pred.Low > pred.High {
+			return fmt.Errorf("typedcolumn: int64 pruning range low=%d high=%d", pred.Low, pred.High)
+		}
+		return nil
+	default:
+		return fmt.Errorf("typedcolumn: unsupported int64 pruning predicate %q", pred.Kind)
+	}
+}
+
+func (idx Int64ValueRowIndex) entriesForPredicate(pred Int64PruningPredicate) []Int64PruningEntry {
+	switch pred.Kind {
+	case Int64PruningPredicateAll:
+		return idx.Entries
+	case Int64PruningPredicateEqual:
+		start := sort.Search(len(idx.Entries), func(i int) bool { return idx.Entries[i].Value >= pred.Value })
+		end := sort.Search(len(idx.Entries), func(i int) bool { return idx.Entries[i].Value > pred.Value })
+		return idx.Entries[start:end]
+	case Int64PruningPredicateRange:
+		start := sort.Search(len(idx.Entries), func(i int) bool { return idx.Entries[i].Value >= pred.Low })
+		end := sort.Search(len(idx.Entries), func(i int) bool { return idx.Entries[i].Value > pred.High })
+		return idx.Entries[start:end]
+	default:
+		return nil
+	}
+}
+
+func (idx Int64ValueRowIndex) blockIndexForRow(row int) int {
+	if row < 0 || row >= idx.Rows || len(idx.Blocks) == 0 {
+		return -1
+	}
+	pos := sort.Search(len(idx.Blocks), func(i int) bool {
+		return idx.Blocks[i].FirstRow+idx.Blocks[i].RowCount > row
+	})
+	if pos >= len(idx.Blocks) {
+		return -1
+	}
+	block := idx.Blocks[pos]
+	if row < block.FirstRow || row >= block.FirstRow+block.RowCount {
+		return -1
+	}
+	return pos
+}
+
+func pruningSelectionFromSortedRows(rows int, selected []int) (RowSelection, error) {
+	if len(selected) == 0 {
+		return NewEmptyRowSelection(rows)
+	}
+	start, prev := selected[0], selected[0]
+	if start < 0 || start >= rows {
+		return RowSelection{}, fmt.Errorf("typedcolumn: selected row %d outside [0,%d)", start, rows)
+	}
+	ranges := make([]RowRange, 0, 4)
+	for _, row := range selected[1:] {
+		if row <= prev {
+			return RowSelection{}, fmt.Errorf("typedcolumn: selected rows not strictly increasing at %d", row)
+		}
+		if row >= rows {
+			return RowSelection{}, fmt.Errorf("typedcolumn: selected row %d outside [0,%d)", row, rows)
+		}
+		if row == prev+1 {
+			prev = row
+			continue
+		}
+		ranges = append(ranges, RowRange{Start: start, End: prev + 1})
+		start, prev = row, row
+	}
+	ranges = append(ranges, RowRange{Start: start, End: prev + 1})
+	if len(ranges) <= typedColumnPruningSelectionRangeLimit {
+		return NewRangesRowSelection(rows, ranges)
+	}
+	return NewSparseRowSelection(rows, selected)
+}
+
+const typedColumnPruningSelectionRangeLimit = 8
+
+func buildColumnPartPruning(part *ColumnPart) (ColumnPartPruning, error) {
+	if part == nil {
+		return ColumnPartPruning{}, fmt.Errorf("typedcolumn: nil part")
+	}
+	out := ColumnPartPruning{Version: columnPartPruningSectionVersion, PartID: part.Descriptor.PartID, Rows: part.Descriptor.RowCount}
+	for _, columnDesc := range part.Descriptor.Columns {
+		if columnDesc.Type != ColumnTypeInt64 {
+			continue
+		}
+		column, ok := part.Columns[columnDesc.Name]
+		if !ok {
+			return ColumnPartPruning{}, fmt.Errorf("typedcolumn: pruning missing column %s", columnDesc.Name)
+		}
+		index, ok, err := buildInt64ValueRowIndex(part.Descriptor, columnDesc, column)
+		if err != nil {
+			return ColumnPartPruning{}, err
+		}
+		if !ok {
+			continue
+		}
+		if out.Int64 == nil {
+			out.Int64 = make(map[string]Int64ValueRowIndex)
+		}
+		out.Int64[columnDesc.Name] = index
+	}
+	return out, nil
+}
+
+func buildInt64ValueRowIndex(desc ColumnPartDescriptor, columnDesc ColumnPartColumnDescriptor, column ColumnPartColumn) (Int64ValueRowIndex, bool, error) {
+	if column.Definition.Type != ColumnTypeInt64 || column.Definition.Encoding == EncodingNullableInt64 || column.Definition.Compression != CompressionNone {
+		return Int64ValueRowIndex{}, false, nil
+	}
+	index := Int64ValueRowIndex{
+		Envelope: ColumnPruningEnvelope{
+			Version:     ColumnPruningEnvelopeVersion,
+			PartID:      desc.PartID,
+			ColumnName:  columnDesc.Name,
+			ColumnType:  columnDesc.Type,
+			Encoding:    column.Definition.Encoding,
+			Compression: column.Definition.Compression,
+			Rows:        desc.RowCount,
+			Blocks:      len(column.Blocks),
+			PayloadKind: ColumnPruningPayloadInt64ValueRowsV1,
+			Operations:  []ColumnPruningOperation{ColumnPruningOpEquality, ColumnPruningOpOrderedRange},
+		},
+		Rows:    desc.RowCount,
+		Blocks:  make([]Int64PruningBlock, 0, len(column.Blocks)),
+		Entries: make([]Int64PruningEntry, 0, desc.RowCount),
+	}
+	var reader GranuleReader
+	for i, block := range column.Blocks {
+		if i >= len(columnDesc.Blocks) {
+			return Int64ValueRowIndex{}, false, fmt.Errorf("typedcolumn: pruning column %s block %d missing descriptor", columnDesc.Name, i)
+		}
+		if block.Descriptor != columnDesc.Blocks[i] {
+			return Int64ValueRowIndex{}, false, fmt.Errorf("typedcolumn: pruning column %s block %d descriptor mismatch", columnDesc.Name, i)
+		}
+		g := block.Granule
+		if g.NullCount != 0 || g.DefaultCount != 0 {
+			return Int64ValueRowIndex{}, false, nil
+		}
+		values, err := reader.DecodeInt64Into(nil, g)
+		if err != nil {
+			return Int64ValueRowIndex{}, false, fmt.Errorf("typedcolumn: pruning column %s block %d decode: %w", columnDesc.Name, i, err)
+		}
+		if len(values) != block.Descriptor.RowCount {
+			return Int64ValueRowIndex{}, false, fmt.Errorf("typedcolumn: pruning column %s block %d values=%d want rows=%d", columnDesc.Name, i, len(values), block.Descriptor.RowCount)
+		}
+		index.Blocks = append(index.Blocks, Int64PruningBlock{Index: i, FirstRow: block.Descriptor.FirstRow, RowCount: block.Descriptor.RowCount, HasMinMax: g.HasMinMax, Min: g.Min, Max: g.Max})
+		for row, value := range values {
+			index.Entries = append(index.Entries, Int64PruningEntry{Value: value, Row: block.Descriptor.FirstRow + row})
+		}
+	}
+	sort.Slice(index.Entries, func(i, j int) bool {
+		if index.Entries[i].Value != index.Entries[j].Value {
+			return index.Entries[i].Value < index.Entries[j].Value
+		}
+		return index.Entries[i].Row < index.Entries[j].Row
+	})
+	if err := ValidateInt64ValueRowIndex(index, desc, columnDesc, column); err != nil {
+		return Int64ValueRowIndex{}, false, err
+	}
+	return index, true, nil
+}
+
+func encodeColumnPartPruningSection(pruning ColumnPartPruning) ([]byte, error) {
+	if pruning.Empty() {
+		return nil, nil
+	}
+	var enc columnPartImageEncoder
+	enc.u32(columnPartPruningSectionMagic)
+	enc.u16(columnPartPruningSectionVersion)
+	enc.u16(0)
+	enc.u64(pruning.PartID)
+	enc.i64(int64(pruning.Rows))
+	names := make([]string, 0, len(pruning.Int64))
+	for name := range pruning.Int64 {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	enc.u32(uint32(len(names)))
+	for _, name := range names {
+		index := pruning.Int64[name]
+		payload, err := encodeInt64PruningPayload(index)
+		if err != nil {
+			return nil, err
+		}
+		envelope := index.Envelope
+		envelope.PayloadLength = len(payload)
+		envelope.PayloadChecksum = crc.Checksum(payload)
+		if err := encodeColumnPruningEnvelope(&enc, envelope); err != nil {
+			return nil, err
+		}
+		enc.buf = append(enc.buf, payload...)
+	}
+	return enc.bytes(), nil
+}
+
+func (i ColumnPartImage) PruningMetadataSection() (ColumnPartImageSection, bool, error) {
+	sections := i.sectionsByKind(ColumnPartImageSectionPruningMetadata)
+	if len(sections) == 0 {
+		return ColumnPartImageSection{}, false, nil
+	}
+	if len(sections) != 1 {
+		return ColumnPartImageSection{}, false, fmt.Errorf("typedcolumn: image has %d %s sections, want at most 1", len(sections), ColumnPartImageSectionPruningMetadata)
+	}
+	return sections[0], true, nil
+}
+
+func decodeColumnPruningSectionFromImage(image ColumnPartImage, desc ColumnPartDescriptor, columns map[string]ColumnPartColumn) (ColumnPartPruning, error) {
+	section, ok, err := image.PruningMetadataSection()
+	if err != nil || !ok {
+		return ColumnPartPruning{}, err
+	}
+	pruning, err := DecodeColumnPartPruningSection(image.sectionBytes(section))
+	if err != nil {
+		return ColumnPartPruning{}, err
+	}
+	if err := ValidateColumnPartPruning(pruning, desc, columns); err != nil {
+		return ColumnPartPruning{}, err
+	}
+	return pruning, nil
+}
+
+func DecodeColumnPartPruningSection(data []byte) (ColumnPartPruning, error) {
+	dec := columnPartImageDecoder{data: data}
+	magic, err := dec.u32()
+	if err != nil {
+		return ColumnPartPruning{}, err
+	}
+	if magic != columnPartPruningSectionMagic {
+		return ColumnPartPruning{}, fmt.Errorf("typedcolumn: bad column pruning section magic=0x%08x", magic)
+	}
+	version, err := dec.u16()
+	if err != nil {
+		return ColumnPartPruning{}, err
+	}
+	if version != columnPartPruningSectionVersion {
+		return ColumnPartPruning{}, fmt.Errorf("typedcolumn: unsupported column pruning section version=%d", version)
+	}
+	reserved, err := dec.u16()
+	if err != nil {
+		return ColumnPartPruning{}, err
+	}
+	if reserved != 0 {
+		return ColumnPartPruning{}, fmt.Errorf("typedcolumn: column pruning section reserved=%d want 0", reserved)
+	}
+	partID, err := dec.u64()
+	if err != nil {
+		return ColumnPartPruning{}, err
+	}
+	rows64, err := dec.i64()
+	if err != nil {
+		return ColumnPartPruning{}, err
+	}
+	rows, err := nonNegativeInt64ToInt(rows64, "column pruning rows")
+	if err != nil {
+		return ColumnPartPruning{}, err
+	}
+	columnCount, err := dec.u32()
+	if err != nil {
+		return ColumnPartPruning{}, err
+	}
+	columns, err := dec.boundedCount(columnCount, 64, "column pruning entries")
+	if err != nil {
+		return ColumnPartPruning{}, err
+	}
+	pruning := ColumnPartPruning{Version: version, PartID: partID, Rows: rows, Int64: make(map[string]Int64ValueRowIndex, columns)}
+	for i := 0; i < columns; i++ {
+		envelope, err := decodeColumnPruningEnvelope(&dec)
+		if err != nil {
+			return ColumnPartPruning{}, err
+		}
+		payload, err := dec.bytes(envelope.PayloadLength)
+		if err != nil {
+			return ColumnPartPruning{}, err
+		}
+		if got := crc.Checksum(payload); got != envelope.PayloadChecksum {
+			return ColumnPartPruning{}, fmt.Errorf("typedcolumn: column pruning %s payload checksum=%08x want=%08x: %s", envelope.ColumnName, got, envelope.PayloadChecksum, ColumnPruningReasonChecksumMismatch)
+		}
+		switch envelope.PayloadKind {
+		case ColumnPruningPayloadInt64ValueRowsV1:
+			index, err := decodeInt64PruningPayload(envelope, payload)
+			if err != nil {
+				return ColumnPartPruning{}, err
+			}
+			if _, exists := pruning.Int64[envelope.ColumnName]; exists {
+				return ColumnPartPruning{}, fmt.Errorf("typedcolumn: duplicate int64 pruning metadata for column %s", envelope.ColumnName)
+			}
+			pruning.Int64[envelope.ColumnName] = index
+		default:
+			return ColumnPartPruning{}, fmt.Errorf("typedcolumn: unsupported column pruning payload %q for column %s: %s", envelope.PayloadKind, envelope.ColumnName, ColumnPruningReasonUnsupportedPayload)
+		}
+	}
+	if err := dec.finish(); err != nil {
+		return ColumnPartPruning{}, err
+	}
+	return pruning, nil
+}
+
+func encodeColumnPruningEnvelope(enc *columnPartImageEncoder, envelope ColumnPruningEnvelope) error {
+	if envelope.Version == 0 {
+		envelope.Version = ColumnPruningEnvelopeVersion
+	}
+	if envelope.Version != ColumnPruningEnvelopeVersion {
+		return fmt.Errorf("typedcolumn: unsupported column pruning envelope version=%d", envelope.Version)
+	}
+	if envelope.ColumnName == "" {
+		return fmt.Errorf("typedcolumn: column pruning envelope requires column name")
+	}
+	columnType, err := columnTypeCode(envelope.ColumnType)
+	if err != nil {
+		return err
+	}
+	enc.u16(envelope.Version)
+	enc.u16(0)
+	enc.u64(envelope.PartID)
+	enc.str(envelope.ColumnName)
+	enc.u16(columnType)
+	enc.u16(uint16(envelope.Encoding))
+	enc.u16(uint16(envelope.Compression))
+	enc.u16(0)
+	enc.i64(int64(envelope.Rows))
+	enc.i64(int64(envelope.Blocks))
+	enc.i64(int64(envelope.NullCount))
+	enc.i64(int64(envelope.DefaultCount))
+	enc.str(string(envelope.PayloadKind))
+	operations := make([]string, len(envelope.Operations))
+	for i, op := range envelope.Operations {
+		operations[i] = string(op)
+	}
+	enc.stringSlice(operations)
+	enc.i64(int64(envelope.PayloadLength))
+	enc.u32(envelope.PayloadChecksum)
+	enc.u32(0)
+	return nil
+}
+
+func decodeColumnPruningEnvelope(dec *columnPartImageDecoder) (ColumnPruningEnvelope, error) {
+	version, err := dec.u16()
+	if err != nil {
+		return ColumnPruningEnvelope{}, err
+	}
+	if version != ColumnPruningEnvelopeVersion {
+		return ColumnPruningEnvelope{}, fmt.Errorf("typedcolumn: unsupported column pruning envelope version=%d", version)
+	}
+	reserved, err := dec.u16()
+	if err != nil {
+		return ColumnPruningEnvelope{}, err
+	}
+	if reserved != 0 {
+		return ColumnPruningEnvelope{}, fmt.Errorf("typedcolumn: column pruning envelope reserved=%d want 0", reserved)
+	}
+	partID, err := dec.u64()
+	if err != nil {
+		return ColumnPruningEnvelope{}, err
+	}
+	columnName, err := dec.str()
+	if err != nil {
+		return ColumnPruningEnvelope{}, err
+	}
+	columnTypeCode, err := dec.u16()
+	if err != nil {
+		return ColumnPruningEnvelope{}, err
+	}
+	columnType, err := columnTypeFromCode(columnTypeCode)
+	if err != nil {
+		return ColumnPruningEnvelope{}, err
+	}
+	encodingCode, err := dec.u16()
+	if err != nil {
+		return ColumnPruningEnvelope{}, err
+	}
+	encoding, err := decodeStatsEncoding(encodingCode)
+	if err != nil {
+		return ColumnPruningEnvelope{}, err
+	}
+	compressionCode, err := dec.u16()
+	if err != nil {
+		return ColumnPruningEnvelope{}, err
+	}
+	compression, err := decodeStatsCompression(compressionCode)
+	if err != nil {
+		return ColumnPruningEnvelope{}, err
+	}
+	reserved, err = dec.u16()
+	if err != nil {
+		return ColumnPruningEnvelope{}, err
+	}
+	if reserved != 0 {
+		return ColumnPruningEnvelope{}, fmt.Errorf("typedcolumn: column pruning envelope encoding reserved=%d want 0", reserved)
+	}
+	rows, err := decodeStatsInt(dec, "column pruning rows")
+	if err != nil {
+		return ColumnPruningEnvelope{}, err
+	}
+	blocks, err := decodeStatsInt(dec, "column pruning blocks")
+	if err != nil {
+		return ColumnPruningEnvelope{}, err
+	}
+	nullCount, err := decodeStatsInt(dec, "column pruning null count")
+	if err != nil {
+		return ColumnPruningEnvelope{}, err
+	}
+	defaultCount, err := decodeStatsInt(dec, "column pruning default count")
+	if err != nil {
+		return ColumnPruningEnvelope{}, err
+	}
+	payloadKind, err := dec.str()
+	if err != nil {
+		return ColumnPruningEnvelope{}, err
+	}
+	operationStrings, err := dec.stringSlice()
+	if err != nil {
+		return ColumnPruningEnvelope{}, err
+	}
+	operations := make([]ColumnPruningOperation, len(operationStrings))
+	for i, op := range operationStrings {
+		operations[i] = ColumnPruningOperation(op)
+	}
+	payloadLength, err := decodeStatsInt(dec, "column pruning payload length")
+	if err != nil {
+		return ColumnPruningEnvelope{}, err
+	}
+	payloadChecksum, err := dec.u32()
+	if err != nil {
+		return ColumnPruningEnvelope{}, err
+	}
+	reserved32, err := dec.u32()
+	if err != nil {
+		return ColumnPruningEnvelope{}, err
+	}
+	if reserved32 != 0 {
+		return ColumnPruningEnvelope{}, fmt.Errorf("typedcolumn: column pruning envelope trailer reserved=%d want 0", reserved32)
+	}
+	return ColumnPruningEnvelope{Version: version, PartID: partID, ColumnName: columnName, ColumnType: columnType, Encoding: encoding, Compression: compression, Rows: rows, Blocks: blocks, NullCount: nullCount, DefaultCount: defaultCount, PayloadKind: ColumnPruningPayloadKind(payloadKind), Operations: operations, PayloadLength: payloadLength, PayloadChecksum: payloadChecksum}, nil
+}
+
+func encodeInt64PruningPayload(index Int64ValueRowIndex) ([]byte, error) {
+	var enc columnPartImageEncoder
+	enc.u16(Int64PruningPayloadVersion)
+	enc.u16(0)
+	enc.i64(int64(index.Rows))
+	enc.i64(int64(index.NullCount))
+	enc.i64(int64(index.DefaultCount))
+	enc.u32(uint32(len(index.Blocks)))
+	for _, block := range index.Blocks {
+		enc.i64(int64(block.Index))
+		enc.i64(int64(block.FirstRow))
+		enc.i64(int64(block.RowCount))
+		enc.boolean(block.HasMinMax)
+		enc.i64(block.Min)
+		enc.i64(block.Max)
+	}
+	enc.u32(uint32(len(index.Entries)))
+	for _, entry := range index.Entries {
+		enc.i64(entry.Value)
+		enc.i64(int64(entry.Row))
+	}
+	return enc.bytes(), nil
+}
+
+func decodeInt64PruningPayload(envelope ColumnPruningEnvelope, payload []byte) (Int64ValueRowIndex, error) {
+	dec := columnPartImageDecoder{data: payload}
+	version, err := dec.u16()
+	if err != nil {
+		return Int64ValueRowIndex{}, err
+	}
+	if version != Int64PruningPayloadVersion {
+		return Int64ValueRowIndex{}, fmt.Errorf("typedcolumn: unsupported int64 pruning payload version=%d", version)
+	}
+	reserved, err := dec.u16()
+	if err != nil {
+		return Int64ValueRowIndex{}, err
+	}
+	if reserved != 0 {
+		return Int64ValueRowIndex{}, fmt.Errorf("typedcolumn: int64 pruning reserved=%d want 0", reserved)
+	}
+	rows, err := decodeStatsInt(&dec, "int64 pruning rows")
+	if err != nil {
+		return Int64ValueRowIndex{}, err
+	}
+	nullCount, err := decodeStatsInt(&dec, "int64 pruning null count")
+	if err != nil {
+		return Int64ValueRowIndex{}, err
+	}
+	defaultCount, err := decodeStatsInt(&dec, "int64 pruning default count")
+	if err != nil {
+		return Int64ValueRowIndex{}, err
+	}
+	blockCount, err := dec.u32()
+	if err != nil {
+		return Int64ValueRowIndex{}, err
+	}
+	blocksTotal, err := dec.boundedCount(blockCount, 48, "int64 pruning blocks")
+	if err != nil {
+		return Int64ValueRowIndex{}, err
+	}
+	index := Int64ValueRowIndex{Envelope: envelope, Rows: rows, NullCount: nullCount, DefaultCount: defaultCount, Blocks: make([]Int64PruningBlock, 0, blocksTotal)}
+	for i := 0; i < blocksTotal; i++ {
+		block, err := decodeInt64PruningBlock(&dec)
+		if err != nil {
+			return Int64ValueRowIndex{}, err
+		}
+		if block.Index != i {
+			return Int64ValueRowIndex{}, fmt.Errorf("typedcolumn: int64 pruning block index=%d want %d", block.Index, i)
+		}
+		index.Blocks = append(index.Blocks, block)
+	}
+	entryCount, err := dec.u32()
+	if err != nil {
+		return Int64ValueRowIndex{}, err
+	}
+	entriesTotal, err := dec.boundedCount(entryCount, 16, "int64 pruning entries")
+	if err != nil {
+		return Int64ValueRowIndex{}, err
+	}
+	index.Entries = make([]Int64PruningEntry, 0, entriesTotal)
+	for i := 0; i < entriesTotal; i++ {
+		value, err := dec.i64()
+		if err != nil {
+			return Int64ValueRowIndex{}, err
+		}
+		row64, err := dec.i64()
+		if err != nil {
+			return Int64ValueRowIndex{}, err
+		}
+		row, err := nonNegativeInt64ToInt(row64, "int64 pruning entry row")
+		if err != nil {
+			return Int64ValueRowIndex{}, err
+		}
+		index.Entries = append(index.Entries, Int64PruningEntry{Value: value, Row: row})
+	}
+	if err := dec.finish(); err != nil {
+		return Int64ValueRowIndex{}, err
+	}
+	return index, nil
+}
+
+func decodeInt64PruningBlock(dec *columnPartImageDecoder) (Int64PruningBlock, error) {
+	index, err := decodeStatsInt(dec, "int64 pruning block index")
+	if err != nil {
+		return Int64PruningBlock{}, err
+	}
+	firstRow, err := decodeStatsInt(dec, "int64 pruning block first row")
+	if err != nil {
+		return Int64PruningBlock{}, err
+	}
+	rowCount, err := decodeStatsInt(dec, "int64 pruning block row count")
+	if err != nil {
+		return Int64PruningBlock{}, err
+	}
+	hasMinMax, err := dec.boolean()
+	if err != nil {
+		return Int64PruningBlock{}, err
+	}
+	minValue, err := dec.i64()
+	if err != nil {
+		return Int64PruningBlock{}, err
+	}
+	maxValue, err := dec.i64()
+	if err != nil {
+		return Int64PruningBlock{}, err
+	}
+	return Int64PruningBlock{Index: index, FirstRow: firstRow, RowCount: rowCount, HasMinMax: hasMinMax, Min: minValue, Max: maxValue}, nil
+}
+
+func ValidateColumnPartPruning(pruning ColumnPartPruning, desc ColumnPartDescriptor, columns map[string]ColumnPartColumn) error {
+	if pruning.Version != columnPartPruningSectionVersion {
+		return fmt.Errorf("typedcolumn: column pruning version=%d want %d", pruning.Version, columnPartPruningSectionVersion)
+	}
+	if pruning.PartID != desc.PartID {
+		return fmt.Errorf("typedcolumn: column pruning part_id=%d want %d: %s", pruning.PartID, desc.PartID, ColumnPruningReasonIdentityMismatch)
+	}
+	if pruning.Rows != desc.RowCount {
+		return fmt.Errorf("typedcolumn: column pruning rows=%d want %d: %s", pruning.Rows, desc.RowCount, ColumnPruningReasonRowCountMismatch)
+	}
+	columnDescs := make(map[string]ColumnPartColumnDescriptor, len(desc.Columns))
+	for _, columnDesc := range desc.Columns {
+		columnDescs[columnDesc.Name] = columnDesc
+	}
+	for name, index := range pruning.Int64 {
+		columnDesc, ok := columnDescs[name]
+		if !ok {
+			return fmt.Errorf("typedcolumn: column pruning %s missing descriptor: %s", name, ColumnPruningReasonIdentityMismatch)
+		}
+		column, ok := columns[name]
+		if !ok {
+			return fmt.Errorf("typedcolumn: column pruning %s missing column: %s", name, ColumnPruningReasonIdentityMismatch)
+		}
+		if err := ValidateInt64ValueRowIndex(index, desc, columnDesc, column); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func ValidateInt64ValueRowIndex(index Int64ValueRowIndex, desc ColumnPartDescriptor, columnDesc ColumnPartColumnDescriptor, column ColumnPartColumn) error {
+	envelope := index.Envelope
+	if envelope.Version != ColumnPruningEnvelopeVersion {
+		return fmt.Errorf("typedcolumn: column pruning %s envelope version=%d want %d", envelope.ColumnName, envelope.Version, ColumnPruningEnvelopeVersion)
+	}
+	if envelope.PartID != desc.PartID {
+		return fmt.Errorf("typedcolumn: column pruning %s part_id=%d want %d: %s", envelope.ColumnName, envelope.PartID, desc.PartID, ColumnPruningReasonIdentityMismatch)
+	}
+	if envelope.ColumnName != columnDesc.Name || envelope.ColumnName != column.Definition.Name {
+		return fmt.Errorf("typedcolumn: column pruning name=%q descriptor=%q definition=%q: %s", envelope.ColumnName, columnDesc.Name, column.Definition.Name, ColumnPruningReasonIdentityMismatch)
+	}
+	if envelope.ColumnType != ColumnTypeInt64 || columnDesc.Type != ColumnTypeInt64 || column.Definition.Type != ColumnTypeInt64 || envelope.PayloadKind != ColumnPruningPayloadInt64ValueRowsV1 {
+		return fmt.Errorf("typedcolumn: column pruning %s int64 payload cannot apply to type envelope=%s descriptor=%s definition=%s payload=%s: %s", envelope.ColumnName, envelope.ColumnType, columnDesc.Type, column.Definition.Type, envelope.PayloadKind, ColumnPruningReasonUnsupportedPayload)
+	}
+	if envelope.Encoding != column.Definition.Encoding || envelope.Compression != column.Definition.Compression {
+		return fmt.Errorf("typedcolumn: column pruning %s encoding/compression=%s/%s want %s/%s: %s", envelope.ColumnName, envelope.Encoding, envelope.Compression, column.Definition.Encoding, column.Definition.Compression, ColumnPruningReasonIdentityMismatch)
+	}
+	if envelope.Rows != desc.RowCount || index.Rows != desc.RowCount {
+		return fmt.Errorf("typedcolumn: column pruning %s rows envelope=%d payload=%d want %d: %s", envelope.ColumnName, envelope.Rows, index.Rows, desc.RowCount, ColumnPruningReasonRowCountMismatch)
+	}
+	if envelope.Blocks != len(column.Blocks) || len(index.Blocks) != len(column.Blocks) || len(columnDesc.Blocks) != len(column.Blocks) {
+		return fmt.Errorf("typedcolumn: column pruning %s blocks envelope=%d payload=%d descriptor=%d column=%d: %s", envelope.ColumnName, envelope.Blocks, len(index.Blocks), len(columnDesc.Blocks), len(column.Blocks), ColumnPruningReasonRowCountMismatch)
+	}
+	if envelope.NullCount != index.NullCount || envelope.DefaultCount != index.DefaultCount || index.NullCount != 0 || index.DefaultCount != 0 {
+		return fmt.Errorf("typedcolumn: column pruning %s null/default counts envelope=%d/%d payload=%d/%d want 0/0: %s", envelope.ColumnName, envelope.NullCount, envelope.DefaultCount, index.NullCount, index.DefaultCount, ColumnPruningReasonNullDefaultMismatch)
+	}
+	if !envelope.SupportsOperation(ColumnPruningOpEquality) || !envelope.SupportsOperation(ColumnPruningOpOrderedRange) {
+		return fmt.Errorf("typedcolumn: column pruning %s does not advertise equality and ordered range: %s", envelope.ColumnName, ColumnPruningReasonOperationUnsupported)
+	}
+	rowTotal := 0
+	for i, blockIndex := range index.Blocks {
+		block := column.Blocks[i]
+		if blockIndex.Index != i || blockIndex.FirstRow != block.Descriptor.FirstRow || blockIndex.RowCount != block.Descriptor.RowCount {
+			return fmt.Errorf("typedcolumn: column pruning %s block %d row identity mismatch: %s", envelope.ColumnName, i, ColumnPruningReasonRowCountMismatch)
+		}
+		if blockIndex.HasMinMax != block.Granule.HasMinMax || (blockIndex.HasMinMax && (blockIndex.Min != block.Granule.Min || blockIndex.Max != block.Granule.Max || blockIndex.Min > blockIndex.Max)) {
+			return fmt.Errorf("typedcolumn: column pruning %s block %d min/max mismatch: %s", envelope.ColumnName, i, ColumnPruningReasonMinMaxMismatch)
+		}
+		rowTotal += blockIndex.RowCount
+	}
+	if rowTotal != desc.RowCount {
+		return fmt.Errorf("typedcolumn: column pruning %s block rows=%d want %d: %s", envelope.ColumnName, rowTotal, desc.RowCount, ColumnPruningReasonRowCountMismatch)
+	}
+	if len(index.Entries) != desc.RowCount {
+		return fmt.Errorf("typedcolumn: column pruning %s entries=%d want rows=%d: %s", envelope.ColumnName, len(index.Entries), desc.RowCount, ColumnPruningReasonRowCountMismatch)
+	}
+	seen := make([]bool, desc.RowCount)
+	for i, entry := range index.Entries {
+		if i > 0 {
+			prev := index.Entries[i-1]
+			if entry.Value < prev.Value || (entry.Value == prev.Value && entry.Row <= prev.Row) {
+				return fmt.Errorf("typedcolumn: column pruning %s entry %d order mismatch: %s", envelope.ColumnName, i, ColumnPruningReasonEntryOrderMismatch)
+			}
+		}
+		if entry.Row < 0 || entry.Row >= desc.RowCount {
+			return fmt.Errorf("typedcolumn: column pruning %s entry %d row=%d outside rows=%d: %s", envelope.ColumnName, i, entry.Row, desc.RowCount, ColumnPruningReasonEntryRowMismatch)
+		}
+		if seen[entry.Row] {
+			return fmt.Errorf("typedcolumn: column pruning %s duplicate row=%d: %s", envelope.ColumnName, entry.Row, ColumnPruningReasonEntryRowMismatch)
+		}
+		seen[entry.Row] = true
+		blockIndex := index.blockIndexForRow(entry.Row)
+		if blockIndex < 0 {
+			return fmt.Errorf("typedcolumn: column pruning %s entry %d row=%d outside blocks: %s", envelope.ColumnName, i, entry.Row, ColumnPruningReasonEntryRowMismatch)
+		}
+		block := index.Blocks[blockIndex]
+		if block.HasMinMax && (entry.Value < block.Min || entry.Value > block.Max) {
+			return fmt.Errorf("typedcolumn: column pruning %s entry %d value=%d outside block min/max [%d,%d]: %s", envelope.ColumnName, i, entry.Value, block.Min, block.Max, ColumnPruningReasonMinMaxMismatch)
+		}
+	}
+	return nil
+}
+
+func cloneColumnPartPruning(pruning ColumnPartPruning) ColumnPartPruning {
+	out := pruning
+	if pruning.Int64 != nil {
+		out.Int64 = make(map[string]Int64ValueRowIndex, len(pruning.Int64))
+		for name, index := range pruning.Int64 {
+			out.Int64[name] = cloneInt64ValueRowIndex(index)
+		}
+	}
+	return out
+}
+
+func cloneInt64ValueRowIndex(index Int64ValueRowIndex) Int64ValueRowIndex {
+	out := index
+	out.Envelope.Operations = append([]ColumnPruningOperation(nil), index.Envelope.Operations...)
+	out.Blocks = append([]Int64PruningBlock(nil), index.Blocks...)
+	out.Entries = append([]Int64PruningEntry(nil), index.Entries...)
+	return out
+}

--- a/TreeDB/internal/typedcolumn/pruning.go
+++ b/TreeDB/internal/typedcolumn/pruning.go
@@ -756,7 +756,7 @@ func decodeInt64PruningPayload(envelope ColumnPruningEnvelope, payload []byte) (
 	if err != nil {
 		return Int64ValueRowIndex{}, err
 	}
-	blocksTotal, err := dec.boundedCount(blockCount, 48, "int64 pruning blocks")
+	blocksTotal, err := dec.boundedCount(blockCount, int64PruningBlockEncodedBytes, "int64 pruning blocks")
 	if err != nil {
 		return Int64ValueRowIndex{}, err
 	}
@@ -800,6 +800,8 @@ func decodeInt64PruningPayload(envelope ColumnPruningEnvelope, payload []byte) (
 	}
 	return index, nil
 }
+
+const int64PruningBlockEncodedBytes = 42
 
 func decodeInt64PruningBlock(dec *columnPartImageDecoder) (Int64PruningBlock, error) {
 	index, err := decodeStatsInt(dec, "int64 pruning block index")

--- a/TreeDB/internal/typedcolumn/pruning.go
+++ b/TreeDB/internal/typedcolumn/pruning.go
@@ -371,7 +371,7 @@ func buildColumnPartPruning(part *ColumnPart) (ColumnPartPruning, error) {
 }
 
 func buildInt64ValueRowIndex(desc ColumnPartDescriptor, columnDesc ColumnPartColumnDescriptor, column ColumnPartColumn) (Int64ValueRowIndex, bool, error) {
-	if column.Definition.Type != ColumnTypeInt64 || column.Definition.Encoding == EncodingNullableInt64 || column.Definition.Compression != CompressionNone {
+	if column.Definition.StatsDisabled || column.Definition.Type != ColumnTypeInt64 || column.Definition.Encoding == EncodingNullableInt64 || column.Definition.Compression != CompressionNone {
 		return Int64ValueRowIndex{}, false, nil
 	}
 	index := Int64ValueRowIndex{
@@ -869,6 +869,9 @@ func ValidateInt64ValueRowIndex(index Int64ValueRowIndex, desc ColumnPartDescrip
 	}
 	if envelope.ColumnName != columnDesc.Name || envelope.ColumnName != column.Definition.Name {
 		return fmt.Errorf("typedcolumn: column pruning name=%q descriptor=%q definition=%q: %s", envelope.ColumnName, columnDesc.Name, column.Definition.Name, ColumnPruningReasonIdentityMismatch)
+	}
+	if column.Definition.StatsDisabled {
+		return fmt.Errorf("typedcolumn: column pruning %s disabled by definition: %s", envelope.ColumnName, ColumnPruningReasonUnsupportedPayload)
 	}
 	if envelope.ColumnType != ColumnTypeInt64 || columnDesc.Type != ColumnTypeInt64 || column.Definition.Type != ColumnTypeInt64 || envelope.PayloadKind != ColumnPruningPayloadInt64ValueRowsV1 {
 		return fmt.Errorf("typedcolumn: column pruning %s int64 payload cannot apply to type envelope=%s descriptor=%s definition=%s payload=%s: %s", envelope.ColumnName, envelope.ColumnType, columnDesc.Type, column.Definition.Type, envelope.PayloadKind, ColumnPruningReasonUnsupportedPayload)

--- a/TreeDB/internal/typedcolumn/pruning_test.go
+++ b/TreeDB/internal/typedcolumn/pruning_test.go
@@ -55,6 +55,27 @@ func TestColumnPruningInt64ValueRowsRoundTrip(t *testing.T) {
 	}
 }
 
+func TestColumnPruningAllPredicateDoesNotScanValueRows(t *testing.T) {
+	part := mustStatsTestPartWithBlockRows(t, []int64{3, 4, 5, 6}, EncodingRawInt64, 2)
+	index, ok := part.PruningMetadata.Int64Column("value")
+	if !ok {
+		t.Fatalf("missing int64 pruning metadata for value")
+	}
+	index.Entries = nil
+	plan, err := index.PlanInt64Predicate(Int64PruningPredicate{Kind: Int64PruningPredicateAll})
+	if err != nil {
+		t.Fatalf("PlanInt64Predicate all: %v", err)
+	}
+	if plan.Exact || plan.CandidateRows != 4 || plan.CandidateBlocks != 2 || plan.PrunedBlocks != 0 {
+		t.Fatalf("all plan=%+v want all rows/blocks without exact value scan", plan)
+	}
+	for _, block := range plan.Blocks {
+		if !block.Selection.IsAll() || block.NeedsPredicate || block.Exact {
+			t.Fatalf("all block candidate=%+v want all non-exact selection", block)
+		}
+	}
+}
+
 func TestColumnPruningPayloadChecksumFailsClosed(t *testing.T) {
 	part := mustStatsTestPartWithBlockRows(t, []int64{3, 4, 5, 6}, EncodingRawInt64, 2)
 	image, err := BuildColumnPartImage(part, ColumnPartImageOptions{LayoutLogicalTypes: map[string]string{"id": "int64", "value": "int64"}})

--- a/TreeDB/internal/typedcolumn/pruning_test.go
+++ b/TreeDB/internal/typedcolumn/pruning_test.go
@@ -1,0 +1,92 @@
+package typedcolumn
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestColumnPruningInt64ValueRowsRoundTrip(t *testing.T) {
+	part := mustStatsTestPartWithBlockRows(t, []int64{5, 1, 5, 9, 5, 2}, EncodingDeltaVarint, 3)
+	index, ok := part.PruningMetadata.Int64Column("value")
+	if !ok {
+		t.Fatalf("missing int64 pruning metadata for value")
+	}
+	if !index.Envelope.SupportsOperation(ColumnPruningOpEquality) || !index.Envelope.SupportsOperation(ColumnPruningOpOrderedRange) {
+		t.Fatalf("operations=%v", index.Envelope.Operations)
+	}
+	plan, err := index.PlanInt64Predicate(Int64PruningPredicate{Kind: Int64PruningPredicateEqual, Value: 5})
+	if err != nil {
+		t.Fatalf("PlanInt64Predicate: %v", err)
+	}
+	if got, want := plan.CandidateRows, 3; got != want {
+		t.Fatalf("candidate rows=%d want %d", got, want)
+	}
+	if got, want := plan.ExactCount, int64(3); got != want || plan.ExactSum != 15 {
+		t.Fatalf("exact count/sum=%d/%d want %d/%d", got, plan.ExactSum, want, int64(15))
+	}
+	assertPruningSelectionRows(t, plan.Blocks[0].Selection, []int{0, 2})
+	assertPruningSelectionRows(t, plan.Blocks[1].Selection, []int{1})
+
+	image, err := BuildColumnPartImage(part, ColumnPartImageOptions{LayoutLogicalTypes: map[string]string{"id": "int64", "value": "int64"}})
+	if err != nil {
+		t.Fatalf("BuildColumnPartImage: %v", err)
+	}
+	section, ok, err := image.PruningMetadataSection()
+	if err != nil || !ok {
+		t.Fatalf("PruningMetadataSection ok=%v err=%v", ok, err)
+	}
+	decoded, err := DecodeColumnPartPruningSection(image.sectionBytes(section))
+	if err != nil {
+		t.Fatalf("DecodeColumnPartPruningSection: %v", err)
+	}
+	if err := ValidateColumnPartPruning(decoded, part.Descriptor, part.Columns); err != nil {
+		t.Fatalf("ValidateColumnPartPruning: %v", err)
+	}
+	decodedIndex, ok := decoded.Int64Column("value")
+	if !ok {
+		t.Fatalf("decoded missing value index")
+	}
+	decodedPlan, err := decodedIndex.PlanInt64Predicate(Int64PruningPredicate{Kind: Int64PruningPredicateRange, Low: 2, High: 5})
+	if err != nil {
+		t.Fatalf("decoded range plan: %v", err)
+	}
+	if got, want := decodedPlan.CandidateRows, 4; got != want {
+		t.Fatalf("decoded candidate rows=%d want %d", got, want)
+	}
+}
+
+func TestColumnPruningPayloadChecksumFailsClosed(t *testing.T) {
+	part := mustStatsTestPartWithBlockRows(t, []int64{3, 4, 5, 6}, EncodingRawInt64, 2)
+	image, err := BuildColumnPartImage(part, ColumnPartImageOptions{LayoutLogicalTypes: map[string]string{"id": "int64", "value": "int64"}})
+	if err != nil {
+		t.Fatalf("BuildColumnPartImage: %v", err)
+	}
+	section, ok, err := image.PruningMetadataSection()
+	if err != nil || !ok {
+		t.Fatalf("PruningMetadataSection ok=%v err=%v", ok, err)
+	}
+	raw := append([]byte(nil), image.sectionBytes(section)...)
+	raw[len(raw)-1] ^= 0x80
+	_, err = DecodeColumnPartPruningSection(raw)
+	if err == nil || !strings.Contains(err.Error(), ColumnPruningReasonChecksumMismatch) {
+		t.Fatalf("DecodeColumnPartPruningSection err=%v want checksum mismatch", err)
+	}
+}
+
+func assertPruningSelectionRows(t testing.TB, selection RowSelection, want []int) {
+	t.Helper()
+	got := make([]int, 0, selection.Count())
+	for row := 0; row < selection.Rows(); row++ {
+		if selection.Contains(row) {
+			got = append(got, row)
+		}
+	}
+	if len(got) != len(want) {
+		t.Fatalf("selection rows=%v want %v shape=%+v", got, want, selection.Shape())
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("selection rows=%v want %v shape=%+v", got, want, selection.Shape())
+		}
+	}
+}

--- a/TreeDB/internal/typedcolumn/pruning_test.go
+++ b/TreeDB/internal/typedcolumn/pruning_test.go
@@ -76,6 +76,47 @@ func TestColumnPruningAllPredicateDoesNotScanValueRows(t *testing.T) {
 	}
 }
 
+func TestColumnPruningDisabledDefinitionSkipsInt64Payload(t *testing.T) {
+	part, err := BuildColumnPart(1, Options{
+		SchemaVersion: 1,
+		SchemaMode:    ColumnSchemaFixed,
+		Columns: []ColumnDefinition{
+			{Name: "id", Type: ColumnTypeInt64, Encoding: EncodingRawInt64, StatsDisabled: true},
+			{Name: "value", Type: ColumnTypeInt64, Encoding: EncodingDeltaVarint, StatsDisabled: true},
+			{Name: "raw_float_bits", Type: ColumnTypeInt64, Encoding: EncodingRawInt64, StatsDisabled: true},
+		},
+		LogicalPrimaryKey: LogicalPrimaryKey{Columns: []string{"id"}},
+		PartPolicy:        ColumnPartPolicy{RowsPerGranule: 4, DefaultCodecBlockRows: 4},
+	}, Batch{Rows: 3, Columns: map[string][]int64{"id": {1, 2, 3}, "value": {10, 20, 30}, "raw_float_bits": {0x3f800000, 0x40000000, 0x40400000}}})
+	if err != nil {
+		t.Fatalf("Build disabled pruning part: %v", err)
+	}
+	if !part.PruningMetadata.Empty() {
+		t.Fatalf("disabled int64 carriers emitted pruning metadata: %+v", part.PruningMetadata)
+	}
+
+	present := mustStatsTestPartWithBlockRows(t, []int64{1, 2, 3}, EncodingDeltaVarint, 3)
+	index, ok := present.PruningMetadata.Int64Column("value")
+	if !ok {
+		t.Fatalf("missing value pruning metadata")
+	}
+	column := present.Columns["value"]
+	column.Definition.StatsDisabled = true
+	columnDesc := ColumnPartColumnDescriptor{}
+	for _, desc := range present.Descriptor.Columns {
+		if desc.Name == "value" {
+			columnDesc = desc
+			break
+		}
+	}
+	if columnDesc.Name == "" {
+		t.Fatalf("missing value descriptor")
+	}
+	if err := ValidateInt64ValueRowIndex(index, present.Descriptor, columnDesc, column); err == nil || !strings.Contains(err.Error(), ColumnPruningReasonUnsupportedPayload) {
+		t.Fatalf("Validate disabled pruning err=%v want unsupported-payload fail-closed", err)
+	}
+}
+
 func TestColumnPruningPayloadChecksumFailsClosed(t *testing.T) {
 	part := mustStatsTestPartWithBlockRows(t, []int64{3, 4, 5, 6}, EncodingRawInt64, 2)
 	image, err := BuildColumnPartImage(part, ColumnPartImageOptions{LayoutLogicalTypes: map[string]string{"id": "int64", "value": "int64"}})

--- a/TreeDB/internal/typedcolumn/row_execution.go
+++ b/TreeDB/internal/typedcolumn/row_execution.go
@@ -354,6 +354,9 @@ func standardColumnDependencies(role ColumnExecutionRole, column string, columnT
 	out := make([]SectionDependencyDescriptor, 0, len(kinds))
 	for _, kind := range kinds {
 		sectionKind := ColumnPartImageSectionColumnData
+		if kind == SectionDependencyPruningMetadata {
+			sectionKind = ColumnPartImageSectionPruningMetadata
+		}
 		dep, err := NewSectionDependency(role, column, columnType, kind, sectionKind, span, true)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
## Summary

Closes #1841. Part of #1836.

Implements the int64 reference slice of the generic typed-column pruning/index substrate:

- adds a durable TCS1 `pruning_metadata` section with a generic envelope and checksum validation;
- adds `int64_value_rows_v1` payloads for semantic, non-null int64 `(value,row)` indexes with equality/range operation declarations;
- wires semantic/layout capability gates for `pruning.equality` and `pruning.ordered_range`;
- validates pruning metadata against descriptor/column/block identity and min/max metadata, failing closed on corrupt/stale metadata;
- honors disabled semantic carriers (`StatsDisabled`) so hidden/internal and float raw-bit physical int64 columns do not emit or accept int64 pruning payloads;
- consumes pruning metadata in prepared int64 aggregate planning to create block-local `RowSelection` candidates that compose with existing visibility selection;
- preserves matching-block payload reads/validation so existing column-data read-integrity/corruption behavior remains fail-closed;
- updates storage accounting, docs, diagnostics, and benchmarks to report pruning metadata/candidate counters.

Deferred intentionally: bool/string/float/vector/adjacency pruning payloads and any public `ColumnStoreValueType` additions.

## Validation

Latest head: `bd316aea4`.

- `git diff --check origin/main...HEAD` ✅
- `go test -count=1 ./TreeDB/internal/typedcolumn -run 'TestColumnPruning'` ✅
- `go test -count=1 ./TreeDB/collections -run 'TestTypedColumnInt64PreparedAllPredicateSkipsPruningMetadata|TestTypedColumnInt64PreparedPruningMetadataNarrowsCandidates'` ✅
- `go test -count=1 ./TreeDB/internal/typedcolumn ./TreeDB/collections` ✅
- `go test -count=1 ./TreeDB/internal/columnsemantics ./TreeDB/internal/columnlayout ./TreeDB/internal/typedkernel ./TreeDB/internal/typeddecode ./TreeDB/internal/typedcolumn ./TreeDB/collections ./TreeDB/docs` ✅
- `go test -count=1 ./TreeDB/...` ✅

## 1M benchmark/profile evidence

Local machine: Apple M3/darwin arm64. Commands used `GOWORK=off`, `TREEDB_TYPED_COLUMN_BENCH_ROWS=1048576`, `TREEDB_TYPED_COLUMN_BENCH_READ_INTEGRITY=cached_verify`, `TREEDB_TYPED_COLUMN_BENCH_LAYOUTS=delta_varint`, `TREEDB_TYPED_COLUMN_BENCH_INCLUDE_FALLBACK=false`, `-benchmem`, `-benchtime=1x`, `-count=1`, prepared-session hot-scan subbench only.

Head artifact bundle: `/tmp/treedb_1841_pruning_bench_20260525_125330`.

| distribution | shape | ns/op | rows matched | rows scanned | blocks decoded/pruned | pruning rows | asset bytes | allocs/op |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| clustered | no_filter | 18,917 | 1,048,576 | 0 | 0/0 | 0 | 128,022,520 | 4 |
| clustered | exact | 70,875 | 1 | 8,192 | 1/127 | 1 | 128,022,520 | 4 |
| clustered | tiny | 69,167 | 100 | 8,192 | 1/127 | 100 | 128,022,520 | 4 |
| clustered | range_1pct | 84,458 | 10,485 | 8,192 | 1/126 | 2,293 | 128,022,520 | 4 |
| clustered | range_10pct | 91,459 | 104,857 | 8,192 | 1/115 | 6,553 | 128,022,520 | 4 |
| clustered | tail | 76,833 | 10,485 | 8,192 | 1/126 | 2,293 | 128,022,520 | 4 |
| random | no_filter | 18,833 | 1,048,576 | 0 | 0/0 | 0 | 130,119,417 | 4 |
| random | exact | 73,667 | 1 | 8,192 | 1/127 | 1 | 130,119,417 | 4 |
| random | tiny | 5,980,500 | 100 | 819,200 | 100/28 | 100 | 130,119,417 | 4 |
| random | range_1pct | 15,509,542 | 10,485 | 1,048,576 | 128/0 | 10,485 | 130,119,417 | 4 |
| random | range_10pct | 19,730,208 | 104,857 | 1,048,576 | 128/0 | 104,857 | 130,119,417 | 4 |
| random | tail | 15,146,000 | 10,485 | 1,048,576 | 128/0 | 10,485 | 130,119,417 | 4 |
| hotspot | no_filter | 18,292 | 1,048,576 | 0 | 0/0 | 0 | 128,904,704 | 4 |
| hotspot | exact | 21,847,625 | 104,858 | 1,048,576 | 128/0 | 104,858 | 128,904,704 | 4 |
| hotspot | tiny | 36,888,333 | 419,450 | 1,048,576 | 128/0 | 419,450 | 128,904,704 | 4 |
| hotspot | range_1pct | 36,800,291 | 421,527 | 1,048,576 | 128/0 | 421,527 | 128,904,704 | 4 |
| hotspot | range_10pct | 38,404,584 | 440,402 | 1,048,576 | 128/0 | 440,402 | 128,904,704 | 4 |
| hotspot | tail | 430,791 | 2,097 | 16,384 | 2/126 | 2,097 | 128,904,704 | 4 |

Clustered base (`48c957fbb`, #1840) vs head, same command:

| shape | base ns/op | head ns/op | delta | base asset bytes | head asset bytes |
|---|---:|---:|---:|---:|---:|
| no_filter | 17,542 | 18,917 | +7.8% | 111,230,712 | 128,022,520 |
| exact | 80,792 | 70,875 | -12.3% | 111,230,712 | 128,022,520 |
| tiny | 81,500 | 69,167 | -15.1% | 111,230,712 | 128,022,520 |
| range_1pct | 92,792 | 84,458 | -9.0% | 111,230,712 | 128,022,520 |
| range_10pct | 95,208 | 91,459 | -3.9% | 111,230,712 | 128,022,520 |
| tail | 85,750 | 76,833 | -10.4% | 111,230,712 | 128,022,520 |

Storage/write envelope from the same run: clustered typed-column asset bytes increased by ~16.8 MB (+15.1%) for the value-row pruning payload; DB directory bytes increased from 191,764,026 to 208,555,834. Setup/write timing remained in the same 1x local noise band (`setup_ns` about 2.86-3.15s base vs 2.89-3.07s head across clustered shapes).

Hot profile: random exact, 1M rows, prepared hot, cached verify, `-benchtime=5000x`:

- `68,185 ns/op`, `1/128` block decoded, `127/128` pruned, `1` pruning row, `8,192` rows scanned, `515 B/op`, `4 allocs/op`.
- CPU top: `RowSelection.contains` 25.9%, `runtime.duffcopy` 22.2%, `binary.Uvarint` 18.5%, `int64Cursor.Next` 11.1%, `addTypedColumnInt64AggregateStreamingValues` 7.4%.
- Artifacts: `/tmp/treedb_1841_pruning_bench_20260525_125330/profile_random_exact_5000x/hot_query_cpu.pprof` and `hot_query_cpu_top.txt`.

## Notes

- Missing pruning metadata is explicit fallback.
- Corrupt/stale pruning metadata fails closed during decode/validation.
- All-predicate/no-filter prepared sessions skip value-row pruning work (`PruningBlocks`, `PruningRows`, and `PruningFallbackBlocks` remain zero) while retaining generic certification diagnostics.
- New TCS1 section is pre-alpha format evolution; no migration scaffolding added.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Durable value-row pruning for int64 columns to accelerate equality and ordered‑range predicate scans; prepared and direct aggregates now surface pruning diagnostics (pruned blocks/rows, fallback blocks, validation failures and human-readable reasons).

* **Documentation**
  * New/updated specs describing the pruning metadata contract, layout capabilities, validation, diagnostics and fail‑closed behavior.

* **Tests**
  * Expanded unit/integration tests and benchmarks covering pruning encode/decode, planning, prepared-run behavior, diagnostics, fallbacks, and benchmark counters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1864?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
