### PR TITLE
Optimize bool typed-column kernels

### DIFF
--- a/TreeDB/collections/typed_column_adapter.go
+++ b/TreeDB/collections/typed_column_adapter.go
@@ -1778,6 +1778,7 @@ type typedColumnInt64PredicateAggregateScanScratch struct {
 	predicateBitmap []uint64
 	visibilityRows  []int
 	selection       typedcolumn.RowSelectionScratch
+	boolSelection   typedcolumn.BoolSelectionScratch
 	kernel          typedkernel.Scratch
 }
 

--- a/TreeDB/collections/typed_column_bool_scan.go
+++ b/TreeDB/collections/typed_column_bool_scan.go
@@ -68,13 +68,17 @@ func (c *Collection) RunTypedColumnBoolPredicateAggregate(req TypedColumnBoolPre
 	if hintDeclared && columnStoreColumnIsTypedColumnPart(hintColumn) && (hintColumn.ValueType != ColumnStoreValueBool || hintColumn.Nullable) {
 		return TypedColumnBoolPredicateAggregateResult{}, typedColumnBoolPredicateUnsupportedColumnError(req.Column, hintColumn)
 	}
+	hintTypedColumnOwner := hintDeclared && hintColumn.ValueType == ColumnStoreValueBool && columnStoreColumnIsTypedColumnPart(hintColumn)
 	view, closeView, err := c.prepareColumnPhysicalScanSnapshotViewWithSidecars(columnManifestScanNoSidecars())
 	if closeView != nil {
 		defer closeView()
 	}
 	if err != nil {
+		if hintTypedColumnOwner {
+			return TypedColumnBoolPredicateAggregateResult{}, err
+		}
 		_ = hintCfg
-		return TypedColumnBoolPredicateAggregateResult{}, err
+		return TypedColumnBoolPredicateAggregateResult{}, fmt.Errorf("%w: typed-column bool predicate aggregate requires enabled typed_column_part column store", ErrColumnQueryPlanUnsupported)
 	}
 	cfg := view.FullConfig
 	if !cfg.Enabled {
@@ -555,8 +559,8 @@ func (s *TypedColumnBoolPredicateAggregateSession) runFullAssetAggregatePart(typ
 	if err != nil {
 		return rawScratch, fmt.Errorf("collections: typed-column bool predicate aggregate decode generation=%d part_id=%d: %w", typedRef.Ref.Generation, typedRef.Ref.PartID, err)
 	}
-	if adapterPart.Part.Descriptor.SchemaVersion != uint32(s.schemaHash) || adapterPart.Part.Descriptor.RowCount != typedRef.Rows || adapterPart.Part.Descriptor.RowCount != physical.Rows {
-		return rawScratch, fmt.Errorf("collections: typed_column_part bool aggregate image/ref mismatch rows=%d typed_manifest_rows=%d physical_rows=%d schema=%d want %d", adapterPart.Part.Descriptor.RowCount, typedRef.Rows, physical.Rows, adapterPart.Part.Descriptor.SchemaVersion, uint32(s.schemaHash))
+	if adapterPart.Part.Descriptor.PartID != typedRef.Ref.PartID || adapterPart.Part.Descriptor.SchemaVersion != uint32(s.schemaHash) || adapterPart.Part.Descriptor.RowCount != typedRef.Rows || adapterPart.Part.Descriptor.RowCount != physical.Rows {
+		return rawScratch, fmt.Errorf("collections: typed_column_part bool aggregate image/ref mismatch part_id=%d typed_ref_part_id=%d rows=%d typed_manifest_rows=%d physical_rows=%d schema=%d want %d", adapterPart.Part.Descriptor.PartID, typedRef.Ref.PartID, adapterPart.Part.Descriptor.RowCount, typedRef.Rows, physical.Rows, adapterPart.Part.Descriptor.SchemaVersion, uint32(s.schemaHash))
 	}
 	return rawScratch, s.scanFullAggregatePart(typedRef, physical, adapterPart.Part, result)
 }

--- a/TreeDB/collections/typed_column_bool_scan.go
+++ b/TreeDB/collections/typed_column_bool_scan.go
@@ -1,0 +1,866 @@
+package collections
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/snissn/gomap/TreeDB/internal/columnsemantics"
+	"github.com/snissn/gomap/TreeDB/internal/mappedresource"
+	"github.com/snissn/gomap/TreeDB/internal/typedcolumn"
+	"github.com/snissn/gomap/TreeDB/internal/typedkernel"
+)
+
+type TypedColumnBoolPredicateScanKind string
+
+const (
+	TypedColumnBoolPredicateAll   TypedColumnBoolPredicateScanKind = "all"
+	TypedColumnBoolPredicateEqual TypedColumnBoolPredicateScanKind = "equal"
+	TypedColumnBoolPredicateRange TypedColumnBoolPredicateScanKind = "range"
+)
+
+type TypedColumnBoolPredicateAggregateRequest struct {
+	Column                   string
+	Kind                     TypedColumnBoolPredicateScanKind
+	Value                    bool
+	ColumnAssetReadIntegrity ColumnAssetReadIntegrity
+}
+
+type TypedColumnBoolPredicateAggregateResult struct {
+	Rows        int64
+	NonNulls    int64
+	TrueCount   int64
+	FalseCount  int64
+	Diagnostics TypedColumnInt64PredicateScanDiagnostics
+}
+
+type TypedColumnBoolPredicateAggregateSession struct {
+	view               columnPhysicalScanSnapshotView
+	closeView          func()
+	req                TypedColumnBoolPredicateAggregateRequest
+	fields             []TypedStorageField
+	aggregateColumn    typedColumnAdapterColumn
+	schemaHash         uint64
+	refsByGeneration   map[uint64]columnManifestAssetRefForScan
+	validatedRefs      map[ColumnAssetRef]struct{}
+	preparedState      *typedColumnPreparedScanState
+	aggregateScratch   typedColumnInt64PredicateAggregateScanScratch
+	readCache          columnPhysicalAssetReadCache
+	resourceManager    *mappedresource.Manager
+	resolver           *typedColumnLatestRowResolver
+	prepareDiagnostics TypedColumnInt64PredicateScanDiagnostics
+	closed             bool
+}
+
+type TypedColumnBoolPredicateAggregateSessionDiagnostics = TypedColumnInt64PredicateAggregateSessionDiagnostics
+
+var errTypedColumnBoolPredicateAggregateSessionClosed = errors.New("collections: typed-column bool predicate aggregate session is closed")
+
+func (c *Collection) RunTypedColumnBoolPredicateAggregate(req TypedColumnBoolPredicateAggregateRequest) (TypedColumnBoolPredicateAggregateResult, error) {
+	if err := validateTypedColumnBoolPredicateAggregateRequest(req); err != nil {
+		return TypedColumnBoolPredicateAggregateResult{}, err
+	}
+	start := time.Now()
+	hintCfg, hintColumn, hintDeclared, hintErr := c.typedColumnBoolPredicateCatalogColumn(req.Column)
+	if hintErr != nil {
+		return TypedColumnBoolPredicateAggregateResult{}, hintErr
+	}
+	if hintDeclared && columnStoreColumnIsTypedColumnPart(hintColumn) && (hintColumn.ValueType != ColumnStoreValueBool || hintColumn.Nullable) {
+		return TypedColumnBoolPredicateAggregateResult{}, typedColumnBoolPredicateUnsupportedColumnError(req.Column, hintColumn)
+	}
+	view, closeView, err := c.prepareColumnPhysicalScanSnapshotViewWithSidecars(columnManifestScanNoSidecars())
+	if closeView != nil {
+		defer closeView()
+	}
+	if err != nil {
+		_ = hintCfg
+		return TypedColumnBoolPredicateAggregateResult{}, err
+	}
+	cfg := view.FullConfig
+	if !cfg.Enabled {
+		cfg = view.Config
+	}
+	col, _, ok := columnPhysicalQueryDeclaredColumn(cfg, req.Column)
+	if !ok {
+		return TypedColumnBoolPredicateAggregateResult{Diagnostics: typedColumnInt64PredicateDiagnosticsFromView(view)}, fmt.Errorf("%w: typed-column bool predicate aggregate column %q is undeclared", ErrColumnQueryPlanUnsupported, req.Column)
+	}
+	if col.ValueType != ColumnStoreValueBool || col.Nullable {
+		return TypedColumnBoolPredicateAggregateResult{Diagnostics: typedColumnInt64PredicateDiagnosticsFromView(view)}, typedColumnBoolPredicateUnsupportedColumnError(req.Column, col)
+	}
+	if !columnStoreColumnIsTypedColumnPart(col) {
+		return TypedColumnBoolPredicateAggregateResult{Diagnostics: typedColumnInt64PredicateDiagnosticsFromView(view)}, fmt.Errorf("%w: typed-column bool predicate aggregate column %q is not owned by typed_column_part", ErrColumnQueryPlanUnsupported, req.Column)
+	}
+	session, diag, err := c.prepareTypedColumnBoolPredicateAggregateSessionFromView(view, nil, req)
+	if err != nil {
+		return TypedColumnBoolPredicateAggregateResult{Diagnostics: diag}, err
+	}
+	defer func() { _ = session.Close() }()
+	includeDiagnostics := session.prepareDiagnostics
+	includeDiagnostics.PruningBlocks = 0
+	includeDiagnostics.PruningRows = 0
+	includeDiagnostics.PruningFallbackBlocks = 0
+	includeDiagnostics.PruningFallbackReason = ""
+	return session.run(start, includeDiagnostics)
+}
+
+func (c *Collection) PrepareTypedColumnBoolPredicateAggregate(req TypedColumnBoolPredicateAggregateRequest) (*TypedColumnBoolPredicateAggregateSession, error) {
+	if err := validateTypedColumnBoolPredicateAggregateRequest(req); err != nil {
+		return nil, err
+	}
+	view, closeView, err := c.prepareColumnPhysicalScanSnapshotViewWithSidecars(columnManifestScanNoSidecars())
+	if err != nil {
+		if closeView != nil {
+			closeView()
+		}
+		return nil, err
+	}
+	release := true
+	defer func() {
+		if release && closeView != nil {
+			closeView()
+		}
+	}()
+	session, _, err := c.prepareTypedColumnBoolPredicateAggregateSessionFromView(view, closeView, req)
+	if err != nil {
+		return nil, err
+	}
+	release = false
+	return session, nil
+}
+
+func validateTypedColumnBoolPredicateAggregateRequest(req TypedColumnBoolPredicateAggregateRequest) error {
+	if req.Column == "" {
+		return errors.New("collections: typed-column bool predicate aggregate requires column")
+	}
+	switch req.Kind {
+	case TypedColumnBoolPredicateAll, TypedColumnBoolPredicateEqual:
+		return nil
+	case TypedColumnBoolPredicateRange:
+		return fmt.Errorf("%w: typed-column bool predicate aggregate does not support range predicates: %s", ErrColumnQueryPlanUnsupported, columnsemantics.ReasonBoolRangeUnsupported)
+	default:
+		return fmt.Errorf("%w: unsupported typed-column bool predicate kind %q", ErrColumnQueryPlanUnsupported, req.Kind)
+	}
+}
+
+func typedColumnBoolPredicateSemanticOperation(kind TypedColumnBoolPredicateScanKind) columnsemantics.Operation {
+	switch kind {
+	case TypedColumnBoolPredicateAll:
+		return columnsemantics.OpAllRows
+	case TypedColumnBoolPredicateEqual:
+		return columnsemantics.OpEquality
+	case TypedColumnBoolPredicateRange:
+		return columnsemantics.OpOrderedRange
+	default:
+		return columnsemantics.OpUnknownPredicateKind
+	}
+}
+
+func (c *Collection) typedColumnBoolPredicateCatalogColumn(column string) (ColumnStoreConfig, ColumnStoreColumn, bool, error) {
+	if c == nil {
+		return ColumnStoreConfig{}, ColumnStoreColumn{}, false, errCollectionNil
+	}
+	if c.db == nil {
+		return ColumnStoreConfig{}, ColumnStoreColumn{}, false, errCollectionDBNil
+	}
+	c.catalogMu.RLock()
+	defer c.catalogMu.RUnlock()
+	catalog := c.catalog
+	if catalog == nil || catalog.meta.Options.ColumnStore == nil || !catalog.meta.Options.ColumnStore.Enabled {
+		return ColumnStoreConfig{}, ColumnStoreColumn{}, false, nil
+	}
+	cfg := catalog.meta.Options.ColumnStore.copy()
+	col, _, ok := columnPhysicalQueryDeclaredColumn(cfg, column)
+	return cfg, col, ok, nil
+}
+
+func typedColumnBoolPredicateUnsupportedColumnError(column string, col ColumnStoreColumn) error {
+	return fmt.Errorf("%w: typed-column bool predicate aggregate column %q has type=%q nullable=%v", ErrColumnQueryPlanUnsupported, column, col.ValueType, col.Nullable)
+}
+
+func typedColumnAdapterHasBoolPredicateColumn(fields []TypedStorageField, column string) (bool, error) {
+	adapterColumn, ok, err := typedColumnInt64PredicateAdapterColumn(fields, column)
+	if err != nil || !ok {
+		return ok, err
+	}
+	if adapterColumn.Field.ValueType != ColumnStoreValueBool || adapterColumn.Field.Nullable || adapterColumn.Definition.Type != typedcolumn.ColumnTypeBool || adapterColumn.Definition.Encoding != typedcolumn.EncodingBoolBitpackRLE {
+		return false, fmt.Errorf("%w: typed-column bool predicate aggregate column %q is not a non-null bool bitpack/RLE typed-column (type=%q nullable=%v physical=%s encoding=%s)", ErrColumnQueryPlanUnsupported, column, adapterColumn.Field.ValueType, adapterColumn.Field.Nullable, adapterColumn.Definition.Type, adapterColumn.Definition.Encoding)
+	}
+	if err := requireTypedColumnAdapterCapability(adapterColumn, columnsemantics.OpEquality, fmt.Sprintf("typed-column bool predicate aggregate column %q", column)); err != nil {
+		return false, err
+	}
+	if err := requireTypedColumnAdapterCapability(adapterColumn, columnsemantics.OpBoolCounts, fmt.Sprintf("typed-column bool predicate aggregate column %q", column)); err != nil {
+		return false, err
+	}
+	if err := requireTypedColumnLayoutCapability(adapterColumn, columnsemantics.OpEquality, fmt.Sprintf("typed-column bool predicate aggregate column %q", column)); err != nil {
+		return false, err
+	}
+	if err := requireTypedColumnLayoutCapability(adapterColumn, columnsemantics.OpBoolCounts, fmt.Sprintf("typed-column bool predicate aggregate column %q", column)); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func (c *Collection) prepareTypedColumnBoolPredicateAggregateSessionFromView(view columnPhysicalScanSnapshotView, closeView func(), req TypedColumnBoolPredicateAggregateRequest) (*TypedColumnBoolPredicateAggregateSession, TypedColumnInt64PredicateScanDiagnostics, error) {
+	diag := typedColumnInt64PredicateDiagnosticsFromView(view)
+	diag.ColumnAssetReadIntegrity = columnAssetReadIntegrityLabel(req.ColumnAssetReadIntegrity)
+	cfg := view.FullConfig
+	if !cfg.Enabled {
+		cfg = view.Config
+	}
+	fields := columnStoreTypedColumnPartFields(cfg)
+	if ok, err := typedColumnAdapterHasBoolPredicateColumn(fields, req.Column); err != nil {
+		return nil, diag, err
+	} else if !ok {
+		return nil, diag, fmt.Errorf("collections: typed-column bool predicate aggregate column %q is not owned by typed_column_part", req.Column)
+	}
+	aggregateColumn, ok, err := typedColumnInt64PredicateAdapterColumn(fields, req.Column)
+	if err != nil {
+		return nil, diag, err
+	}
+	if !ok {
+		return nil, diag, fmt.Errorf("collections: typed-column bool predicate aggregate column %q is not owned by typed_column_part", req.Column)
+	}
+	refsByGeneration, err := typedColumnInt64PredicateAggregateRefsByGeneration(view)
+	if err != nil {
+		return nil, diag, err
+	}
+	if len(refsByGeneration) == 0 {
+		return nil, diag, errors.New("collections: missing typed_column_part assets for typed-column bool predicate aggregate")
+	}
+	if view.MutationParts == 0 {
+		if _, err := validateTypedColumnPhysicalAssetPairing(refsByGeneration, view.AssetRefs); err != nil {
+			return nil, diag, typedColumnPhysicalAssetPairingAggregateError(err)
+		}
+	} else if err := validateTypedColumnMultipartAssetPairing(refsByGeneration, view.AssetRefs); err != nil {
+		return nil, diag, err
+	}
+
+	mgr := mappedresource.NewManager()
+	readCache, err := newColumnPhysicalAssetReadCacheWithIntegrity(view.ColumnAssetRootDir, view.AssetNamespace, req.ColumnAssetReadIntegrity)
+	if err != nil {
+		return nil, diag, err
+	}
+	readCache.returnViews = true
+	readCache.trustCachedVerifyFileIdentity = true
+	scope := mappedresource.Scope{Kind: mappedresource.ScopePreparedQuery, ID: "typed-column-bool-predicate-aggregate", Namespace: view.AssetNamespace, Collection: view.CollectionName, Generation: view.Diagnostics.ManifestGeneration, Reason: "typed-column bool predicate aggregate session"}
+	if err := readCache.useMappedResourceManager(mgr, scope, "typed-column bool predicate aggregate session"); err != nil {
+		_ = readCache.close()
+		return nil, diag, err
+	}
+
+	session := &TypedColumnBoolPredicateAggregateSession{view: view, closeView: closeView, req: req, fields: fields, aggregateColumn: aggregateColumn, schemaHash: cfg.SchemaHash, refsByGeneration: refsByGeneration, validatedRefs: make(map[ColumnAssetRef]struct{}, len(refsByGeneration)), readCache: readCache, resourceManager: mgr}
+	if session.useTargetedAggregateRanges() {
+		if err := session.prepareTargetedAggregateState(); err != nil {
+			if session.preparedState != nil {
+				session.preparedState.close()
+			}
+			_ = session.readCache.close()
+			return nil, diag, err
+		}
+	}
+	if view.MutationParts != 0 {
+		beforeStats := mgr.Stats()
+		beforeHits := session.readCache.hits
+		beforeMisses := session.readCache.misses
+		var resolverDiagnostics TypedColumnInt64PredicateScanDiagnostics
+		resolver, err := buildTypedColumnLatestRowResolver(view, &session.readCache, &resolverDiagnostics)
+		if err != nil {
+			if session.preparedState != nil {
+				session.preparedState.close()
+			}
+			_ = session.readCache.close()
+			return nil, diag, err
+		}
+		afterStats := mgr.Stats()
+		resolverDiagnostics.SegmentFileCacheHits = session.readCache.hits - beforeHits
+		resolverDiagnostics.SegmentFileCacheMisses = session.readCache.misses - beforeMisses
+		resolverDiagnostics.MappedBytes = afterStats.TotalMappedBytes - beforeStats.TotalMappedBytes
+		resolverDiagnostics.HeapCopyBytes = afterStats.TotalHeapCopyBytes - beforeStats.TotalHeapCopyBytes
+		resolverDiagnostics.FallbackReads = int(afterStats.FallbackReads - beforeStats.FallbackReads)
+		addTypedColumnInt64PredicateAggregateDiagnostics(&session.prepareDiagnostics, resolverDiagnostics)
+		session.resolver = resolver
+	}
+	return session, diag, nil
+}
+
+func (s *TypedColumnBoolPredicateAggregateSession) validatePreparedBoolAggregateColumn() error {
+	if s == nil {
+		return errors.New("collections: nil typed-column bool predicate aggregate session")
+	}
+	column := s.aggregateColumn
+	if column.Field.ValueType != ColumnStoreValueBool || column.Field.Nullable || column.Definition.Type != typedcolumn.ColumnTypeBool || column.Definition.Encoding != typedcolumn.EncodingBoolBitpackRLE {
+		return fmt.Errorf("%w: typed-column bool predicate aggregate column %q is not a non-null bool bitpack/RLE typed-column (type=%q nullable=%v physical=%s encoding=%s)", ErrColumnQueryPlanUnsupported, s.req.Column, column.Field.ValueType, column.Field.Nullable, column.Definition.Type, column.Definition.Encoding)
+	}
+	for _, op := range []columnsemantics.Operation{typedColumnBoolPredicateSemanticOperation(s.req.Kind), columnsemantics.OpBoolCounts} {
+		if err := requireTypedColumnAdapterCapability(column, op, fmt.Sprintf("typed-column bool predicate aggregate column %q", s.req.Column)); err != nil {
+			return err
+		}
+		if err := requireTypedColumnLayoutCapability(column, op, fmt.Sprintf("typed-column bool predicate aggregate column %q", s.req.Column)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *TypedColumnBoolPredicateAggregateSession) prepareTargetedAggregateState() error {
+	if s == nil {
+		return errors.New("collections: nil typed-column bool predicate aggregate session")
+	}
+	if err := s.validatePreparedBoolAggregateColumn(); err != nil {
+		return err
+	}
+	state := &typedColumnPreparedScanState{partsByRef: make(map[ColumnAssetRef]*typedColumnPreparedPartState, len(s.refsByGeneration))}
+	prepareResult := &TypedColumnInt64PredicateAggregateResult{}
+	beforeStats := mappedresource.Stats{}
+	if s.resourceManager != nil {
+		beforeStats = s.resourceManager.Stats()
+	}
+	beforeHits := s.readCache.hits
+	beforeMisses := s.readCache.misses
+	updateCacheDeltas := func() {
+		prepareResult.Diagnostics.SegmentFileCacheHits = s.readCache.hits - beforeHits
+		prepareResult.Diagnostics.SegmentFileCacheMisses = s.readCache.misses - beforeMisses
+	}
+	requests := []typedColumnPreparedColumnRequest{
+		{Field: s.aggregateColumn.Field, Role: typedcolumn.ColumnRolePredicate, Operation: typedColumnBoolPredicateSemanticOperation(s.req.Kind)},
+		{Field: s.aggregateColumn.Field, Role: typedcolumn.ColumnRoleMeasure, Operation: columnsemantics.OpBoolCounts, IncludeStats: true},
+	}
+	for _, physical := range s.view.AssetRefs {
+		if physical.Role == ColumnManifestPartRoleTombstone || physical.Reason == ColumnPublishOperationDelete {
+			continue
+		}
+		typedRef, ok := s.refsByGeneration[physical.Ref.Generation]
+		if !ok {
+			return fmt.Errorf("collections: typed-column bool predicate aggregate missing typed ref for physical generation=%d", physical.Ref.Generation)
+		}
+		if err := s.ensureCachedVerifyFullAssetValidated(typedRef.Ref, prepareResult, updateCacheDeltas); err != nil {
+			return fmt.Errorf("collections: typed-column bool predicate aggregate validate generation=%d part_id=%d: %w", typedRef.Ref.Generation, typedRef.Ref.PartID, err)
+		}
+		readRange := func(offset int, length int, section bool) ([]byte, error) {
+			return s.readTypedColumnRange(typedRef.Ref, offset, length, section, prepareResult, updateCacheDeltas)
+		}
+		blockSelection := func(g typedcolumn.EncodedGranule, rows int) (typedcolumn.RowSelection, bool, error) {
+			if s.req.Kind == TypedColumnBoolPredicateEqual {
+				want := int64(0)
+				if s.req.Value {
+					want = 1
+				}
+				if g.HasMinMax && (want < g.Min || want > g.Max) {
+					selection, err := typedcolumn.NewEmptyRowSelection(rows)
+					return selection, false, err
+				}
+				selection, err := typedcolumn.NewAllRowSelection(rows)
+				if err != nil {
+					return typedcolumn.RowSelection{}, false, err
+				}
+				return selection, !(g.HasMinMax && g.Min == want && g.Max == want), nil
+			}
+			selection, err := typedcolumn.NewAllRowSelection(rows)
+			return selection, false, err
+		}
+		part, partDiag, err := typedColumnPreparePartStateFromRanges(typedRef.Ref, physical.Ref, typedRef.Rows, physical.Rows, s.fields, s.schemaHash, requests, readRange, blockSelection)
+		if err != nil {
+			return fmt.Errorf("collections: typed-column bool predicate aggregate prepare generation=%d part_id=%d: %w", typedRef.Ref.Generation, typedRef.Ref.PartID, err)
+		}
+		if partDiag.Fallback {
+			return fmt.Errorf("%w: %s", ErrColumnQueryPlanUnsupported, partDiag.FallbackReason)
+		}
+		if err := validateTypedColumnPreparedBoolAggregatePart(part, s.aggregateColumn, s.req); err != nil {
+			return fmt.Errorf("collections: typed-column bool predicate aggregate prepare generation=%d part_id=%d: %w", typedRef.Ref.Generation, typedRef.Ref.PartID, err)
+		}
+		state.partsByRef[typedRef.Ref] = part
+		typedColumnPreparedStateDiagnosticsAdd(&state.diagnostics, partDiag)
+	}
+	if s.resourceManager != nil {
+		afterStats := s.resourceManager.Stats()
+		prepareResult.Diagnostics.FallbackReads += int(afterStats.FallbackReads - beforeStats.FallbackReads)
+	}
+	updateCacheDeltas()
+	prepareResult.Diagnostics.DecodedMetadataBytes += state.diagnostics.ManifestBytes + state.diagnostics.DescriptorBytes + state.diagnostics.ContractBytes + state.diagnostics.DecodedMetadataBytes
+	prepareResult.Diagnostics.DirectViewCertified += state.diagnostics.DirectViewCertified
+	prepareResult.Diagnostics.StreamingCertified += state.diagnostics.StreamingCertified
+	prepareResult.Diagnostics.StatsCertified += state.diagnostics.StatsCertified
+	prepareResult.Diagnostics.PruningCertified += state.diagnostics.PruningCertified
+	prepareResult.Diagnostics.CertificationFailures += state.diagnostics.CertificationFailures
+	prepareResult.Diagnostics.CertificationFailureReason = state.diagnostics.CertificationFailureReason
+	prepareResult.Diagnostics.StatsValidationFailures += state.diagnostics.StatsValidationFailures
+	prepareResult.Diagnostics.StatsValidationFailureReason = state.diagnostics.StatsValidationFailureReason
+	prepareResult.Diagnostics.PruningFallbackBlocks += state.diagnostics.PruningFallbackBlocks
+	prepareResult.Diagnostics.PruningFallbackReason = state.diagnostics.PruningFallbackReason
+	addTypedColumnInt64PredicateAggregateDiagnostics(&s.prepareDiagnostics, prepareResult.Diagnostics)
+	s.preparedState = state
+	return nil
+}
+
+func validateTypedColumnPreparedBoolAggregatePart(part *typedColumnPreparedPartState, adapterColumn typedColumnAdapterColumn, req TypedColumnBoolPredicateAggregateRequest) error {
+	if part == nil {
+		return errors.New("collections: typed-column bool aggregate prepared state is missing")
+	}
+	preparedColumn, ok := part.Columns[adapterColumn.Definition.Name]
+	if !ok || preparedColumn == nil {
+		return fmt.Errorf("collections: typed-column bool aggregate prepared state missing column %q", adapterColumn.Definition.Name)
+	}
+	if preparedColumn.Plan.Definition.Type != typedcolumn.ColumnTypeBool || preparedColumn.Plan.Definition.Encoding != typedcolumn.EncodingBoolBitpackRLE {
+		return fmt.Errorf("collections: typed-column bool aggregate prepared column %q type=%s encoding=%s", adapterColumn.Definition.Name, preparedColumn.Plan.Definition.Type, preparedColumn.Plan.Definition.Encoding)
+	}
+	if cap := preparedColumn.Plan.Layout.SupportsSemanticOperation(columnsemantics.OpBoolCounts); !cap.Supported() {
+		return fmt.Errorf("collections: typed-column bool aggregate prepared column %q layout capability %s", adapterColumn.Definition.Name, cap.Error())
+	}
+	reducer, err := typedColumnPreparedBoolAggregateReducer(preparedColumn)
+	if err != nil {
+		return err
+	}
+	preparedColumn.AggregateReducer = reducer
+	preparedColumn.AggregateReducerReady = true
+	preparedColumn.StatsFallbackReason = typedcolumn.ColumnStatsReasonUnsupportedPayload
+	if req.Kind == TypedColumnBoolPredicateEqual {
+		preparedColumn.PruningFallbackReason = string(columnsemantics.ReasonPruningPayloadUnsupported)
+	}
+	return nil
+}
+
+func typedColumnPreparedBoolAggregateReducer(preparedColumn *typedColumnPreparedColumnState) (typedkernel.PreparedReducer, error) {
+	if preparedColumn == nil {
+		return typedkernel.PreparedReducer{}, errors.New("collections: typed-column bool aggregate prepared reducer missing column state")
+	}
+	desc := columnsemantics.Descriptor{Logical: preparedColumn.Plan.Logical, Physical: preparedColumn.Plan.Definition.Type, Encoding: preparedColumn.Plan.Definition.Encoding, Nullable: preparedColumn.Plan.Field.Nullable, DictionaryOrder: preparedColumn.Plan.Layout.Descriptor.DictionaryOrder, DictionaryCollation: preparedColumn.Plan.Layout.Descriptor.DictionaryCollation}
+	reducer, err := typedkernel.DefaultRegistry().Dispatch(typedkernel.DispatchRequest{Operation: columnsemantics.OpBoolCounts, Semantic: desc, Layout: preparedColumn.Plan.Layout})
+	if err != nil {
+		return typedkernel.PreparedReducer{}, fmt.Errorf("collections: typed-column bool aggregate prepared column %q kernel dispatch: %w", preparedColumn.Plan.Definition.Name, err)
+	}
+	return reducer, nil
+}
+
+func (s *TypedColumnBoolPredicateAggregateSession) Close() error {
+	if s == nil || s.closed {
+		return nil
+	}
+	s.closed = true
+	s.aggregateScratch = typedColumnInt64PredicateAggregateScanScratch{}
+	if s.preparedState != nil {
+		s.preparedState.close()
+	}
+	s.refsByGeneration = nil
+	s.validatedRefs = nil
+	s.resolver = nil
+	s.view = columnPhysicalScanSnapshotView{}
+	var closeErr error
+	if err := s.readCache.close(); err != nil {
+		closeErr = err
+	}
+	if s.closeView != nil {
+		s.closeView()
+		s.closeView = nil
+	}
+	return closeErr
+}
+
+func (s *TypedColumnBoolPredicateAggregateSession) Diagnostics() TypedColumnBoolPredicateAggregateSessionDiagnostics {
+	if s == nil {
+		return TypedColumnBoolPredicateAggregateSessionDiagnostics{Closed: true}
+	}
+	stats := mappedresource.Stats{}
+	if s.resourceManager != nil {
+		stats = s.resourceManager.Stats()
+	}
+	return TypedColumnBoolPredicateAggregateSessionDiagnostics{Closed: s.closed, ColumnAssetReadIntegrity: columnAssetReadIntegrityLabel(s.req.ColumnAssetReadIntegrity), SegmentFileCacheHits: s.readCache.hits, SegmentFileCacheMisses: s.readCache.misses, ActiveResourceHandles: stats.ActiveHandles, ActiveMappedBytes: stats.ActiveMappedBytes, ActiveHeapCopyBytes: stats.ActiveHeapCopyBytes, TotalResourceAcquires: stats.TotalAcquires, TotalResourceReleases: stats.TotalReleases, TotalMappedBytes: stats.TotalMappedBytes, TotalHeapCopyBytes: stats.TotalHeapCopyBytes, FallbackReads: stats.FallbackReads}
+}
+
+func (s *TypedColumnBoolPredicateAggregateSession) Run() (TypedColumnBoolPredicateAggregateResult, error) {
+	return s.run(time.Now(), TypedColumnInt64PredicateScanDiagnostics{})
+}
+
+func (s *TypedColumnBoolPredicateAggregateSession) run(start time.Time, includeDiagnostics TypedColumnInt64PredicateScanDiagnostics) (TypedColumnBoolPredicateAggregateResult, error) {
+	if s == nil || s.closed {
+		return TypedColumnBoolPredicateAggregateResult{}, errTypedColumnBoolPredicateAggregateSessionClosed
+	}
+	diag := typedColumnInt64PredicateDiagnosticsFromView(s.view)
+	diag.ColumnAssetReadIntegrity = columnAssetReadIntegrityLabel(s.req.ColumnAssetReadIntegrity)
+	addTypedColumnInt64PredicateAggregateDiagnostics(&diag, includeDiagnostics)
+	result := TypedColumnBoolPredicateAggregateResult{Diagnostics: diag}
+	beforeStats := mappedresource.Stats{}
+	if s.resourceManager != nil {
+		beforeStats = s.resourceManager.Stats()
+	}
+	beforeHits := s.readCache.hits
+	beforeMisses := s.readCache.misses
+	updateCacheDeltas := func() {
+		result.Diagnostics.SegmentFileCacheHits = includeDiagnostics.SegmentFileCacheHits + s.readCache.hits - beforeHits
+		result.Diagnostics.SegmentFileCacheMisses = includeDiagnostics.SegmentFileCacheMisses + s.readCache.misses - beforeMisses
+	}
+	var rawScratch []byte
+	useTargetedRanges := s.useTargetedAggregateRanges()
+	for _, physical := range s.view.AssetRefs {
+		if physical.Role == ColumnManifestPartRoleTombstone || physical.Reason == ColumnPublishOperationDelete {
+			continue
+		}
+		typedRef := s.refsByGeneration[physical.Ref.Generation]
+		result.Diagnostics.PartsConsidered++
+		var err error
+		if useTargetedRanges {
+			err = s.runTargetedAggregatePart(typedRef, physical, &result, updateCacheDeltas)
+		} else {
+			rawScratch, err = s.runFullAssetAggregatePart(typedRef, physical, rawScratch, &result, updateCacheDeltas)
+		}
+		if err != nil {
+			return result, err
+		}
+	}
+	if s.resourceManager != nil {
+		afterStats := s.resourceManager.Stats()
+		result.Diagnostics.FallbackReads += int(afterStats.FallbackReads - beforeStats.FallbackReads)
+	}
+	updateCacheDeltas()
+	result.Diagnostics.ScanNanos = time.Since(start).Nanoseconds()
+	return result, nil
+}
+
+func (s *TypedColumnBoolPredicateAggregateSession) useTargetedAggregateRanges() bool {
+	if s == nil {
+		return false
+	}
+	switch s.req.ColumnAssetReadIntegrity {
+	case ColumnAssetReadIntegrityCachedVerify, ColumnAssetReadIntegritySkipChecksums:
+		return true
+	default:
+		return false
+	}
+}
+
+func (s *TypedColumnBoolPredicateAggregateSession) runTargetedAggregatePart(typedRef columnManifestAssetRefForScan, physical columnManifestAssetRefForScan, result *TypedColumnBoolPredicateAggregateResult, updateCacheDeltas func()) error {
+	preparedPart, ok := typedColumnPreparedStatePart(s.preparedState, typedRef.Ref)
+	if !ok || preparedPart == nil {
+		return fmt.Errorf("collections: typed-column bool predicate aggregate missing prepared state generation=%d part_id=%d", typedRef.Ref.Generation, typedRef.Ref.PartID)
+	}
+	return s.scanPreparedAggregateStatePart(typedRef, physical, preparedPart, result, updateCacheDeltas)
+}
+
+func (s *TypedColumnBoolPredicateAggregateSession) runFullAssetAggregatePart(typedRef columnManifestAssetRefForScan, physical columnManifestAssetRefForScan, rawScratch []byte, result *TypedColumnBoolPredicateAggregateResult, updateCacheDeltas func()) ([]byte, error) {
+	raw, err := s.readCache.read(typedRef.Ref, rawScratch)
+	updateCacheDeltas()
+	if err != nil {
+		return rawScratch, fmt.Errorf("collections: typed-column bool predicate aggregate read generation=%d part_id=%d: %w", typedRef.Ref.Generation, typedRef.Ref.PartID, err)
+	}
+	rawScratch = raw
+	if s.readCache.lastView {
+		result.Diagnostics.MappedBytes += uint64(len(raw))
+	} else {
+		result.Diagnostics.HeapCopyBytes += uint64(len(raw))
+	}
+	result.Diagnostics.DirectTypedColumnAssetReads++
+	result.Diagnostics.FullAssetReads++
+	result.Diagnostics.FullAssetBytes += uint64(len(raw))
+	result.Diagnostics.PhysicalBytesScanned += int64(len(raw))
+	adapterPart, err := typedColumnAdapterPartFromBytes(typedColumnAdapterOptions{Fields: s.fields, SchemaVersion: uint32(s.schemaHash)}, raw)
+	if err != nil {
+		return rawScratch, fmt.Errorf("collections: typed-column bool predicate aggregate decode generation=%d part_id=%d: %w", typedRef.Ref.Generation, typedRef.Ref.PartID, err)
+	}
+	if adapterPart.Part.Descriptor.SchemaVersion != uint32(s.schemaHash) || adapterPart.Part.Descriptor.RowCount != typedRef.Rows || adapterPart.Part.Descriptor.RowCount != physical.Rows {
+		return rawScratch, fmt.Errorf("collections: typed_column_part bool aggregate image/ref mismatch rows=%d typed_manifest_rows=%d physical_rows=%d schema=%d want %d", adapterPart.Part.Descriptor.RowCount, typedRef.Rows, physical.Rows, adapterPart.Part.Descriptor.SchemaVersion, uint32(s.schemaHash))
+	}
+	return rawScratch, s.scanFullAggregatePart(typedRef, physical, adapterPart.Part, result)
+}
+
+func (s *TypedColumnBoolPredicateAggregateSession) scanFullAggregatePart(typedRef columnManifestAssetRefForScan, physical columnManifestAssetRefForScan, part *typedcolumn.ColumnPart, result *TypedColumnBoolPredicateAggregateResult) error {
+	var visibility *typedColumnLatestPhysicalPart
+	if s.resolver != nil {
+		var ok bool
+		visibility, ok = s.resolver.partForGeneration(physical.Ref.Generation)
+		if !ok {
+			return fmt.Errorf("collections: typed-column bool predicate aggregate missing latest-visible physical generation=%d", physical.Ref.Generation)
+		}
+	}
+	partPruned, err := scanTypedColumnBoolPredicateAggregatePartWithVisibilityAndScratch(part, s.aggregateColumn.Definition.Name, s.req, result, visibility, &s.aggregateScratch)
+	if err != nil {
+		return fmt.Errorf("collections: typed-column bool predicate aggregate scan generation=%d part_id=%d: %w", typedRef.Ref.Generation, typedRef.Ref.PartID, err)
+	}
+	if partPruned {
+		result.Diagnostics.PartsPruned++
+	} else {
+		result.Diagnostics.PartsDecoded++
+	}
+	return nil
+}
+
+func (s *TypedColumnBoolPredicateAggregateSession) ensureCachedVerifyFullAssetValidated(ref ColumnAssetRef, result *TypedColumnInt64PredicateAggregateResult, updateCacheDeltas func()) error {
+	if s.req.ColumnAssetReadIntegrity != ColumnAssetReadIntegrityCachedVerify {
+		return nil
+	}
+	if _, ok := s.validatedRefs[ref]; ok {
+		return nil
+	}
+	n, err := s.readCache.validateFullRef(ref)
+	updateCacheDeltas()
+	if err != nil {
+		return err
+	}
+	s.validatedRefs[ref] = struct{}{}
+	result.Diagnostics.FullAssetReads++
+	result.Diagnostics.FullAssetBytes += uint64(n)
+	result.Diagnostics.PhysicalBytesScanned += int64(n)
+	return nil
+}
+
+func (s *TypedColumnBoolPredicateAggregateSession) readTypedColumnRange(ref ColumnAssetRef, offset int, length int, section bool, result *TypedColumnInt64PredicateAggregateResult, updateCacheDeltas func()) ([]byte, error) {
+	raw, _, err := s.readTypedColumnRangeHandle(ref, offset, length, section, result, updateCacheDeltas)
+	return raw, err
+}
+
+func (s *TypedColumnBoolPredicateAggregateSession) readTypedColumnRangeHandle(ref ColumnAssetRef, offset int, length int, section bool, result *TypedColumnInt64PredicateAggregateResult, updateCacheDeltas func()) ([]byte, *mappedresource.Handle, error) {
+	if offset < 0 || length <= 0 {
+		return nil, nil, fmt.Errorf("collections: typed-column range offset=%d length=%d is invalid", offset, length)
+	}
+	raw, handle, err := s.readCache.readRangeHandle(ref, int64(offset), int64(length))
+	updateCacheDeltas()
+	if err != nil {
+		return nil, nil, err
+	}
+	if s.readCache.lastView {
+		result.Diagnostics.MappedBytes += uint64(len(raw))
+	} else {
+		result.Diagnostics.HeapCopyBytes += uint64(len(raw))
+	}
+	if section {
+		result.Diagnostics.SectionBytesRead += uint64(len(raw))
+	} else {
+		result.Diagnostics.RangeBytesRead += uint64(len(raw))
+	}
+	result.Diagnostics.PhysicalBytesScanned += int64(len(raw))
+	return raw, handle, nil
+}
+
+func (s *TypedColumnBoolPredicateAggregateSession) readBoolTypedColumnRangeHandle(ref ColumnAssetRef, offset int, length int, section bool, result *TypedColumnBoolPredicateAggregateResult, updateCacheDeltas func()) ([]byte, *mappedresource.Handle, error) {
+	if offset < 0 || length <= 0 {
+		return nil, nil, fmt.Errorf("collections: typed-column range offset=%d length=%d is invalid", offset, length)
+	}
+	raw, handle, err := s.readCache.readRangeHandle(ref, int64(offset), int64(length))
+	updateCacheDeltas()
+	if err != nil {
+		return nil, nil, err
+	}
+	if s.readCache.lastView {
+		result.Diagnostics.MappedBytes += uint64(len(raw))
+	} else {
+		result.Diagnostics.HeapCopyBytes += uint64(len(raw))
+	}
+	if section {
+		result.Diagnostics.SectionBytesRead += uint64(len(raw))
+	} else {
+		result.Diagnostics.RangeBytesRead += uint64(len(raw))
+	}
+	result.Diagnostics.PhysicalBytesScanned += int64(len(raw))
+	return raw, handle, nil
+}
+
+func (s *TypedColumnBoolPredicateAggregateSession) scanPreparedAggregateStatePart(typedRef columnManifestAssetRefForScan, physical columnManifestAssetRefForScan, preparedPart *typedColumnPreparedPartState, result *TypedColumnBoolPredicateAggregateResult, updateCacheDeltas func()) error {
+	preparedColumn, ok := preparedPart.Columns[s.aggregateColumn.Definition.Name]
+	if !ok || preparedColumn == nil {
+		return fmt.Errorf("collections: typed-column bool predicate aggregate prepared state missing column %q", s.aggregateColumn.Definition.Name)
+	}
+	var visibility *typedColumnLatestPhysicalPart
+	if s.resolver != nil {
+		var ok bool
+		visibility, ok = s.resolver.partForGeneration(physical.Ref.Generation)
+		if !ok {
+			return fmt.Errorf("collections: typed-column bool predicate aggregate missing latest-visible physical generation=%d", physical.Ref.Generation)
+		}
+	}
+	partPruned, err := s.scanPreparedAggregateColumnState(preparedColumn, typedRef.Ref, visibility, result, updateCacheDeltas)
+	if err != nil {
+		return fmt.Errorf("collections: typed-column bool predicate aggregate scan generation=%d part_id=%d: %w", typedRef.Ref.Generation, typedRef.Ref.PartID, err)
+	}
+	if partPruned {
+		result.Diagnostics.PartsPruned++
+	} else {
+		result.Diagnostics.PartsDecoded++
+	}
+	return nil
+}
+
+func (s *TypedColumnBoolPredicateAggregateSession) scanPreparedAggregateColumnState(preparedColumn *typedColumnPreparedColumnState, ref ColumnAssetRef, visibility *typedColumnLatestPhysicalPart, result *TypedColumnBoolPredicateAggregateResult, updateCacheDeltas func()) (bool, error) {
+	if preparedColumn == nil {
+		return false, errors.New("collections: typed-column bool predicate aggregate nil prepared column")
+	}
+	if !preparedColumn.AggregateReducerReady {
+		return false, fmt.Errorf("collections: typed-column bool predicate aggregate prepared column %q missing kernel reducer", preparedColumn.Plan.Definition.Name)
+	}
+	decodedAny := false
+	payloadRead := false
+	result.Diagnostics.FastDecodeStreamingPlans++
+	for blockIdx := range preparedColumn.BlockPlans {
+		block := &preparedColumn.BlockPlans[blockIdx]
+		result.Diagnostics.BlocksConsidered++
+		if block.CandidateSelection.IsEmpty() {
+			result.Diagnostics.BlocksPruned++
+			recordTypedColumnSelectionDiagnostics(&result.Diagnostics, block.CandidateSelection)
+			continue
+		}
+		if preparedColumn.StatsFallbackReason != "" {
+			recordTypedColumnInt64StatsFallbackBlock(&result.Diagnostics, preparedColumn.StatsFallbackReason)
+		}
+		if preparedColumn.PruningFallbackReason != "" {
+			recordTypedColumnInt64PruningFallbackBlock(&result.Diagnostics, preparedColumn.PruningFallbackReason)
+		}
+		payload, _, err := s.readBoolTypedColumnRangeHandle(ref, block.PayloadOffset, block.PayloadLength, false, result, updateCacheDeltas)
+		if err != nil {
+			return false, fmt.Errorf("read column %q block %d payload: %w", preparedColumn.Plan.Definition.Name, block.Index, err)
+		}
+		payloadRead = true
+		if len(payload) != block.PayloadLength {
+			return false, fmt.Errorf("typed-column bool aggregate column %q block %d payload bytes=%d want %d", preparedColumn.Plan.Definition.Name, block.Index, len(payload), block.PayloadLength)
+		}
+		granule := block.Granule
+		granule.Payload = payload
+		granule.PayloadRef = typedcolumn.PayloadRef{Kind: typedcolumn.PayloadRefInline, Length: block.PayloadLength}
+		if err := preparedColumn.Plan.Layout.ValidateGranulePayload(granule, payload); err != nil {
+			return false, err
+		}
+		decodedAny = true
+		result.Diagnostics.BlocksDecoded++
+		result.Diagnostics.RowsScanned += granule.Rows
+		selection := block.CandidateSelection
+		if block.NeedsPredicate {
+			predicateSelection, err := s.aggregateScratch.reader.SelectBool(granule, selection, s.req.Value, &s.aggregateScratch.boolSelection)
+			if err != nil {
+				return false, err
+			}
+			selection = predicateSelection
+		}
+		if visibility != nil && !selection.IsEmpty() {
+			visibilitySelection, err := typedColumnInt64VisibilitySelectionForBlock(visibility, block.Descriptor.FirstRow, block.Descriptor.RowCount, &s.aggregateScratch)
+			if err != nil {
+				return false, err
+			}
+			selection, err = typedcolumn.ComposeRowSelectionsInto(block.Descriptor.RowCount, typedcolumn.RowSelectionComponents{Predicate: &selection, Visibility: &visibilitySelection}, &s.aggregateScratch.selection)
+			if err != nil {
+				return false, err
+			}
+			result.Diagnostics.SelectionCompositions++
+		}
+		recordTypedColumnSelectionDiagnostics(&result.Diagnostics, selection)
+		if selection.IsEmpty() {
+			continue
+		}
+		if err := addTypedColumnBoolAggregateKernelGranule(result, preparedColumn.AggregateReducer, &granule, &s.aggregateScratch.reader, selection, &s.aggregateScratch.kernel); err != nil {
+			return false, err
+		}
+		recordTypedColumnInt64KernelBlock(&result.Diagnostics, !block.NeedsPredicate && visibility == nil && selection.IsAll(), false)
+	}
+	if payloadRead {
+		result.Diagnostics.DirectTypedColumnAssetReads++
+	}
+	return !decodedAny && len(preparedColumn.BlockPlans) != 0, nil
+}
+
+func scanTypedColumnBoolPredicateAggregatePartWithVisibilityAndScratch(part *typedcolumn.ColumnPart, valueColumn string, req TypedColumnBoolPredicateAggregateRequest, result *TypedColumnBoolPredicateAggregateResult, visibility *typedColumnLatestPhysicalPart, scratch *typedColumnInt64PredicateAggregateScanScratch) (bool, error) {
+	if part == nil {
+		return false, errors.New("nil typed-column part")
+	}
+	valueCol, ok := part.Columns[valueColumn]
+	if !ok {
+		return false, fmt.Errorf("missing value column %q", valueColumn)
+	}
+	if valueCol.Definition.Type != typedcolumn.ColumnTypeBool || valueCol.Definition.Encoding != typedcolumn.EncodingBoolBitpackRLE {
+		return false, fmt.Errorf("value column %q is not bool bitpack/RLE", valueColumn)
+	}
+	if scratch == nil {
+		var localScratch typedColumnInt64PredicateAggregateScanScratch
+		scratch = &localScratch
+	}
+	desc := columnsemantics.Descriptor{Logical: columnsemantics.LogicalBool, Physical: typedcolumn.ColumnTypeBool, Encoding: typedcolumn.EncodingBoolBitpackRLE}
+	layout := typedColumnLayoutCapabilitiesForAdapterColumn(typedColumnAdapterColumn{Field: TypedStorageField{Name: valueColumn, Path: valueColumn, ValueType: ColumnStoreValueBool, Owner: TypedStorageOwnerColumnPart}, Definition: valueCol.Definition})
+	reducer, err := typedkernel.DefaultRegistry().Dispatch(typedkernel.DispatchRequest{Operation: columnsemantics.OpBoolCounts, Semantic: desc, Layout: layout})
+	if err != nil {
+		return false, err
+	}
+	decodedAny := false
+	for _, block := range valueCol.Blocks {
+		result.Diagnostics.BlocksConsidered++
+		g := block.Granule
+		selection, needsPredicate, err := typedColumnBoolBlockSelection(req, g, block.Descriptor.RowCount)
+		if err != nil {
+			return false, err
+		}
+		if selection.IsEmpty() {
+			result.Diagnostics.BlocksPruned++
+			recordTypedColumnSelectionDiagnostics(&result.Diagnostics, selection)
+			continue
+		}
+		decodedAny = true
+		result.Diagnostics.BlocksDecoded++
+		result.Diagnostics.DecodedHeapCopyBytes += uint64(g.RawBytes)
+		result.Diagnostics.RowsScanned += g.Rows
+		if needsPredicate {
+			selection, err = scratch.reader.SelectBool(g, selection, req.Value, &scratch.boolSelection)
+			if err != nil {
+				return false, err
+			}
+		}
+		if visibility != nil && !selection.IsEmpty() {
+			visibilitySelection, err := typedColumnInt64VisibilitySelectionForBlock(visibility, block.Descriptor.FirstRow, block.Descriptor.RowCount, scratch)
+			if err != nil {
+				return false, err
+			}
+			selection, err = typedcolumn.ComposeRowSelectionsInto(block.Descriptor.RowCount, typedcolumn.RowSelectionComponents{Predicate: &selection, Visibility: &visibilitySelection}, &scratch.selection)
+			if err != nil {
+				return false, err
+			}
+			result.Diagnostics.SelectionCompositions++
+		}
+		recordTypedColumnSelectionDiagnostics(&result.Diagnostics, selection)
+		if selection.IsEmpty() {
+			continue
+		}
+		if err := addTypedColumnBoolAggregateKernelGranule(result, reducer, &g, &scratch.reader, selection, &scratch.kernel); err != nil {
+			return false, err
+		}
+		recordTypedColumnInt64KernelBlock(&result.Diagnostics, !needsPredicate && visibility == nil && selection.IsAll(), false)
+	}
+	return !decodedAny && len(valueCol.Blocks) != 0, nil
+}
+
+func typedColumnBoolBlockSelection(req TypedColumnBoolPredicateAggregateRequest, g typedcolumn.EncodedGranule, rows int) (typedcolumn.RowSelection, bool, error) {
+	if req.Kind == TypedColumnBoolPredicateEqual {
+		want := int64(0)
+		if req.Value {
+			want = 1
+		}
+		if g.HasMinMax && (want < g.Min || want > g.Max) {
+			selection, err := typedcolumn.NewEmptyRowSelection(rows)
+			return selection, false, err
+		}
+		selection, err := typedcolumn.NewAllRowSelection(rows)
+		if err != nil {
+			return typedcolumn.RowSelection{}, false, err
+		}
+		return selection, !(g.HasMinMax && g.Min == want && g.Max == want), nil
+	}
+	selection, err := typedcolumn.NewAllRowSelection(rows)
+	return selection, false, err
+}
+
+func addTypedColumnBoolAggregateKernelGranule(result *TypedColumnBoolPredicateAggregateResult, reducer typedkernel.PreparedReducer, granule *typedcolumn.EncodedGranule, reader *typedcolumn.GranuleReader, selection typedcolumn.RowSelection, scratch *typedkernel.Scratch) error {
+	out, err := reducer.Reduce(typedkernel.ReduceRequest{Rows: granule.Rows, Selection: selection, BoolGranule: *granule, HasBoolGranule: true, BoolReader: reader}, scratch)
+	if err != nil {
+		return err
+	}
+	return addTypedColumnBoolAggregateKernelResult(result, out)
+}
+
+func addTypedColumnBoolAggregateKernelResult(result *TypedColumnBoolPredicateAggregateResult, out typedkernel.AggregateResult) error {
+	if result == nil {
+		return errors.New("collections: nil typed-column bool aggregate result")
+	}
+	if out.Rows < 0 || out.NonNulls < 0 || out.TrueCount < 0 || out.FalseCount < 0 {
+		return fmt.Errorf("collections: typed-column bool aggregate invalid negative kernel counts: %+v", out)
+	}
+	if out.TrueCount+out.FalseCount != out.NonNulls || out.Rows != out.NonNulls {
+		return fmt.Errorf("collections: typed-column bool aggregate inconsistent kernel counts: %+v", out)
+	}
+	result.Rows += out.Rows
+	result.NonNulls += out.NonNulls
+	result.TrueCount += out.TrueCount
+	result.FalseCount += out.FalseCount
+	result.Diagnostics.RowsMatched += int(out.Rows)
+	return nil
+}

--- a/TreeDB/collections/typed_column_bool_scan_test.go
+++ b/TreeDB/collections/typed_column_bool_scan_test.go
@@ -1,0 +1,326 @@
+package collections
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/internal/columnsemantics"
+)
+
+func TestTypedColumnBoolPreparedCountsAndDiagnostics(t *testing.T) {
+	d, col := setupTypedColumnBoolScanCollection(t, false)
+	defer func() { _ = d.Close() }()
+	insertTypedColumnBoolScanRows(t, col, []bool{true, false, true, true, false})
+
+	tests := []struct {
+		name       string
+		req        TypedColumnBoolPredicateAggregateRequest
+		rows       int64
+		trueCount  int64
+		falseCount int64
+	}{
+		{name: "all", req: TypedColumnBoolPredicateAggregateRequest{Column: "flag", Kind: TypedColumnBoolPredicateAll, ColumnAssetReadIntegrity: ColumnAssetReadIntegrityCachedVerify}, rows: 5, trueCount: 3, falseCount: 2},
+		{name: "equal_true", req: TypedColumnBoolPredicateAggregateRequest{Column: "flag", Kind: TypedColumnBoolPredicateEqual, Value: true, ColumnAssetReadIntegrity: ColumnAssetReadIntegrityCachedVerify}, rows: 3, trueCount: 3, falseCount: 0},
+		{name: "equal_false", req: TypedColumnBoolPredicateAggregateRequest{Column: "flag", Kind: TypedColumnBoolPredicateEqual, Value: false, ColumnAssetReadIntegrity: ColumnAssetReadIntegrityCachedVerify}, rows: 2, trueCount: 0, falseCount: 2},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			session, err := col.PrepareTypedColumnBoolPredicateAggregate(tc.req)
+			if err != nil {
+				t.Fatalf("PrepareTypedColumnBoolPredicateAggregate: %v", err)
+			}
+			defer func() { _ = session.Close() }()
+			result, err := session.Run()
+			if err != nil {
+				t.Fatalf("Run: %v", err)
+			}
+			assertTypedColumnBoolAggregate(t, result, tc.rows, tc.trueCount, tc.falseCount)
+			if result.Diagnostics.Fallback || result.Diagnostics.KernelBlocks == 0 || result.Diagnostics.BlocksDecoded == 0 || result.Diagnostics.RowMaterializations != 0 {
+				t.Fatalf("diagnostics=%+v want prepared kernel path without document materialization", result.Diagnostics)
+			}
+			if result.Diagnostics.StatsFallbackBlocks == 0 || result.Diagnostics.StatsFallbackReason != "stats_payload_unsupported" {
+				t.Fatalf("diagnostics=%+v want explicit bool stats fallback", result.Diagnostics)
+			}
+			if tc.req.Kind == TypedColumnBoolPredicateEqual && (result.Diagnostics.PruningFallbackBlocks == 0 || !strings.Contains(result.Diagnostics.PruningFallbackReason, string(columnsemantics.ReasonPruningPayloadUnsupported))) {
+				t.Fatalf("diagnostics=%+v want explicit bool pruning fallback", result.Diagnostics)
+			}
+		})
+	}
+}
+
+func TestTypedColumnBoolOneShotVerifyUsesBoolKernel(t *testing.T) {
+	d, col := setupTypedColumnBoolScanCollection(t, false)
+	defer func() { _ = d.Close() }()
+	insertTypedColumnBoolScanRows(t, col, []bool{true, false, true, false})
+
+	result, err := col.RunTypedColumnBoolPredicateAggregate(TypedColumnBoolPredicateAggregateRequest{Column: "flag", Kind: TypedColumnBoolPredicateAll})
+	if err != nil {
+		t.Fatalf("RunTypedColumnBoolPredicateAggregate: %v", err)
+	}
+	assertTypedColumnBoolAggregate(t, result, 4, 2, 2)
+	if result.Diagnostics.Fallback || result.Diagnostics.KernelBlocks == 0 || result.Diagnostics.ColumnAssetReadIntegrity != string(ColumnAssetReadIntegrityVerify) {
+		t.Fatalf("diagnostics=%+v want one-shot verify bool kernel path", result.Diagnostics)
+	}
+}
+
+func TestTypedColumnBoolPreparedAllPrunedRLE(t *testing.T) {
+	d, col := setupTypedColumnBoolScanCollection(t, false)
+	defer func() { _ = d.Close() }()
+	insertTypedColumnBoolScanRows(t, col, []bool{true, true, true, true, true, true})
+
+	session, err := col.PrepareTypedColumnBoolPredicateAggregate(TypedColumnBoolPredicateAggregateRequest{Column: "flag", Kind: TypedColumnBoolPredicateEqual, Value: false, ColumnAssetReadIntegrity: ColumnAssetReadIntegrityCachedVerify})
+	if err != nil {
+		t.Fatalf("PrepareTypedColumnBoolPredicateAggregate: %v", err)
+	}
+	defer func() { _ = session.Close() }()
+	result, err := session.Run()
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	assertTypedColumnBoolAggregate(t, result, 0, 0, 0)
+	if result.Diagnostics.BlocksPruned == 0 || result.Diagnostics.BlocksDecoded != 0 || result.Diagnostics.RowsScanned != 0 {
+		t.Fatalf("diagnostics=%+v want min/max all-pruned bool block", result.Diagnostics)
+	}
+}
+
+func TestTypedColumnBoolVisibilityDeleteComposition(t *testing.T) {
+	d, col := setupTypedColumnBoolScanCollection(t, false)
+	defer func() { _ = d.Close() }()
+	ids := insertTypedColumnBoolScanRows(t, col, []bool{true, true, false, true})
+	if err := col.Delete(ids[1]); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	session, err := col.PrepareTypedColumnBoolPredicateAggregate(TypedColumnBoolPredicateAggregateRequest{Column: "flag", Kind: TypedColumnBoolPredicateEqual, Value: true, ColumnAssetReadIntegrity: ColumnAssetReadIntegrityCachedVerify})
+	if err != nil {
+		t.Fatalf("PrepareTypedColumnBoolPredicateAggregate: %v", err)
+	}
+	defer func() { _ = session.Close() }()
+	result, err := session.Run()
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	assertTypedColumnBoolAggregate(t, result, 2, 2, 0)
+	if result.Diagnostics.SelectionCompositions == 0 || result.Diagnostics.MutationParts == 0 {
+		t.Fatalf("diagnostics=%+v want visibility/delete composition", result.Diagnostics)
+	}
+}
+
+func TestTypedColumnBoolNullableMissingAndUnsupportedOperationsFailClosed(t *testing.T) {
+	d, col := setupTypedColumnBoolScanCollection(t, true)
+	defer func() { _ = d.Close() }()
+	ids := [][]byte{[]byte("b-null-1"), []byte("b-null-2"), []byte("b-null-3")}
+	docs := [][]byte{[]byte(`{"flag":true}`), []byte(`{"flag":false}`), []byte(`{"flag":null}`)}
+	if _, err := col.InsertBatch(ids, docs); err != nil {
+		t.Fatalf("InsertBatch nullable: %v", err)
+	}
+	_, err := col.PrepareTypedColumnBoolPredicateAggregate(TypedColumnBoolPredicateAggregateRequest{Column: "flag", Kind: TypedColumnBoolPredicateEqual, Value: false, ColumnAssetReadIntegrity: ColumnAssetReadIntegrityCachedVerify})
+	if !errors.Is(err, ErrColumnQueryPlanUnsupported) || !strings.Contains(err.Error(), "nullable") {
+		t.Fatalf("nullable prepare err=%v want fail-closed nullable diagnostic", err)
+	}
+
+	d2, col2 := setupTypedColumnBoolScanCollection(t, false)
+	defer func() { _ = d2.Close() }()
+	_, err = col2.InsertBatch([][]byte{[]byte("b-missing-1"), []byte("b-missing-2")}, [][]byte{[]byte(`{"flag":true}`), []byte(`{}`)})
+	if err == nil || !strings.Contains(err.Error(), "missing non-null declared value") {
+		t.Fatalf("InsertBatch missing non-null bool err=%v want fail-closed missing diagnostic", err)
+	}
+
+	d3, col3 := setupTypedColumnBoolScanCollection(t, false)
+	defer func() { _ = d3.Close() }()
+	insertTypedColumnBoolScanRows(t, col3, []bool{true, false})
+	_, err = col3.PrepareTypedColumnBoolPredicateAggregate(TypedColumnBoolPredicateAggregateRequest{Column: "flag", Kind: TypedColumnBoolPredicateRange, ColumnAssetReadIntegrity: ColumnAssetReadIntegrityCachedVerify})
+	if !errors.Is(err, ErrColumnQueryPlanUnsupported) || !strings.Contains(err.Error(), string(columnsemantics.ReasonBoolRangeUnsupported)) {
+		t.Fatalf("range prepare err=%v want bool range unsupported", err)
+	}
+}
+
+func BenchmarkTypedColumnBoolPredicateAggregate(b *testing.B) {
+	rows := 65536
+	if raw := strings.TrimSpace(os.Getenv("TREEDB_TYPED_COLUMN_BOOL_BENCH_ROWS")); raw != "" {
+		parsed, err := strconv.Atoi(raw)
+		if err != nil || parsed <= 0 {
+			b.Fatalf("TREEDB_TYPED_COLUMN_BOOL_BENCH_ROWS=%q", raw)
+		}
+		rows = parsed
+	}
+	shapes := []typedColumnBoolBenchShape{
+		{name: "all_mixed_counts", valueAt: func(row, rows int) bool { return row%3 == 0 || row%17 == 0 }, req: TypedColumnBoolPredicateAggregateRequest{Column: "flag", Kind: TypedColumnBoolPredicateAll}},
+		{name: "equal_true_selective", valueAt: func(row, rows int) bool { return row%100 == 0 }, req: TypedColumnBoolPredicateAggregateRequest{Column: "flag", Kind: TypedColumnBoolPredicateEqual, Value: true}},
+		{name: "equal_true_all_match_rle", valueAt: func(row, rows int) bool { return true }, req: TypedColumnBoolPredicateAggregateRequest{Column: "flag", Kind: TypedColumnBoolPredicateEqual, Value: true}},
+		{name: "equal_true_all_pruned_rle", valueAt: func(row, rows int) bool { return false }, req: TypedColumnBoolPredicateAggregateRequest{Column: "flag", Kind: TypedColumnBoolPredicateEqual, Value: true}},
+	}
+	for _, shape := range shapes {
+		shape := shape
+		b.Run(fmt.Sprintf("rows_%d/shape_%s/timed_prepared_session_hot_scan/read_integrity_cached_verify", rows, shape.name), func(b *testing.B) {
+			d, col := setupTypedColumnBoolScanCollection(b, false)
+			defer func() { _ = d.Close() }()
+			values := make([]bool, rows)
+			for i := range values {
+				values[i] = shape.valueAt(i, rows)
+			}
+			insertTypedColumnBoolScanRowsBatched(b, col, values)
+			expectedRows, expectedTrue, expectedFalse := expectedTypedColumnBoolBenchCounts(values, shape.req)
+			req := shape.req
+			req.ColumnAssetReadIntegrity = ColumnAssetReadIntegrityCachedVerify
+			session, err := col.PrepareTypedColumnBoolPredicateAggregate(req)
+			if err != nil {
+				b.Fatalf("PrepareTypedColumnBoolPredicateAggregate: %v", err)
+			}
+			warmup, err := session.Run()
+			if err != nil {
+				_ = session.Close()
+				b.Fatalf("warmup Run: %v", err)
+			}
+			if err := validateTypedColumnBoolBenchResult(warmup, expectedRows, expectedTrue, expectedFalse); err != nil {
+				_ = session.Close()
+				b.Fatal(err)
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			stopHotCPUProfile := startTypedColumnInt64AggregateBenchHotCPUProfile(b)
+			start := time.Now()
+			var result TypedColumnBoolPredicateAggregateResult
+			for i := 0; i < b.N; i++ {
+				result, err = session.Run()
+				if err != nil {
+					b.Fatalf("Run: %v", err)
+				}
+			}
+			elapsed := time.Since(start)
+			b.StopTimer()
+			if stopHotCPUProfile != nil {
+				stopHotCPUProfile()
+			}
+			if err := session.Close(); err != nil {
+				b.Fatalf("Close: %v", err)
+			}
+			if err := validateTypedColumnBoolBenchResult(result, expectedRows, expectedTrue, expectedFalse); err != nil {
+				b.Fatal(err)
+			}
+			reportTypedColumnBoolBenchMetrics(b, rows, result, elapsed)
+		})
+	}
+}
+
+type typedColumnBoolBenchShape struct {
+	name    string
+	valueAt func(row, rows int) bool
+	req     TypedColumnBoolPredicateAggregateRequest
+}
+
+func setupTypedColumnBoolScanCollection(tb testing.TB, nullable bool) (*backenddb.DB, *Collection) {
+	tb.Helper()
+	d := openTypedColumnInt64ScanDB(tb)
+	cfg := testColumnStoreConfig(nil)
+	cfg.Columns = []ColumnStoreColumn{{Name: "flag", Path: "flag", ValueType: ColumnStoreValueBool, Owner: TypedStorageOwnerColumnPart, Nullable: nullable}}
+	cfg.SortKey = nil
+	cfg.AggregateMetadata = nil
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "bools", Options: CollectionOptions{ColumnStore: cfg}}); err != nil {
+		tb.Fatalf("CreateCollection: %v", err)
+	}
+	col, err := mgr.OpenCollection("bools")
+	if err != nil {
+		tb.Fatalf("OpenCollection: %v", err)
+	}
+	return d, col
+}
+
+func insertTypedColumnBoolScanRows(tb testing.TB, col *Collection, values []bool) [][]byte {
+	tb.Helper()
+	ids := make([][]byte, len(values))
+	docs := make([][]byte, len(values))
+	for i, value := range values {
+		ids[i] = []byte(fmt.Sprintf("b%06d", i))
+		docs[i] = []byte(fmt.Sprintf(`{"flag":%t}`, value))
+	}
+	if _, err := col.InsertBatch(ids, docs); err != nil {
+		tb.Fatalf("InsertBatch: %v", err)
+	}
+	return ids
+}
+
+func insertTypedColumnBoolScanRowsBatched(tb testing.TB, col *Collection, values []bool) {
+	tb.Helper()
+	const batchRows = 32768
+	for start := 0; start < len(values); start += batchRows {
+		end := start + batchRows
+		if end > len(values) {
+			end = len(values)
+		}
+		ids := make([][]byte, end-start)
+		docs := make([][]byte, end-start)
+		for i, value := range values[start:end] {
+			row := start + i
+			ids[i] = []byte(fmt.Sprintf("bench_b%012d", row))
+			docs[i] = []byte(fmt.Sprintf(`{"flag":%t}`, value))
+		}
+		if _, err := col.InsertBatch(ids, docs); err != nil {
+			tb.Fatalf("InsertBatch batch %d:%d: %v", start, end, err)
+		}
+	}
+}
+
+func assertTypedColumnBoolAggregate(t *testing.T, result TypedColumnBoolPredicateAggregateResult, rows int64, trueCount int64, falseCount int64) {
+	t.Helper()
+	if result.Rows != rows || result.NonNulls != rows || result.TrueCount != trueCount || result.FalseCount != falseCount {
+		t.Fatalf("bool aggregate rows=%d non_nulls=%d true=%d false=%d want rows=%d true=%d false=%d diagnostics=%+v", result.Rows, result.NonNulls, result.TrueCount, result.FalseCount, rows, trueCount, falseCount, result.Diagnostics)
+	}
+}
+
+func expectedTypedColumnBoolBenchCounts(values []bool, req TypedColumnBoolPredicateAggregateRequest) (int64, int64, int64) {
+	var rows, trueCount, falseCount int64
+	for _, value := range values {
+		if req.Kind == TypedColumnBoolPredicateEqual && value != req.Value {
+			continue
+		}
+		rows++
+		if value {
+			trueCount++
+		} else {
+			falseCount++
+		}
+	}
+	return rows, trueCount, falseCount
+}
+
+func validateTypedColumnBoolBenchResult(result TypedColumnBoolPredicateAggregateResult, rows int64, trueCount int64, falseCount int64) error {
+	if result.Rows != rows || result.NonNulls != rows || result.TrueCount != trueCount || result.FalseCount != falseCount {
+		return fmt.Errorf("bool aggregate rows=%d non_nulls=%d true=%d false=%d want rows=%d true=%d false=%d diagnostics=%+v", result.Rows, result.NonNulls, result.TrueCount, result.FalseCount, rows, trueCount, falseCount, result.Diagnostics)
+	}
+	return nil
+}
+
+func reportTypedColumnBoolBenchMetrics(b *testing.B, rows int, result TypedColumnBoolPredicateAggregateResult, elapsed time.Duration) {
+	b.Helper()
+	seconds := elapsed.Seconds()
+	if seconds <= 0 {
+		return
+	}
+	ops := float64(b.N) / seconds
+	b.ReportMetric(ops, "ops/sec")
+	b.ReportMetric(float64(rows*b.N)/seconds, "rows/sec")
+	b.ReportMetric(float64(result.Rows*int64(b.N))/seconds, "matches/sec")
+	diag := result.Diagnostics
+	b.ReportMetric(float64(diag.PhysicalBytesScanned), "physical_bytes_scanned/op")
+	b.ReportMetric(float64(diag.MappedBytes), "mapped_bytes/op")
+	b.ReportMetric(float64(diag.DecodedHeapCopyBytes+diag.MaterializedBytes), "decoded_bytes/op")
+	b.ReportMetric(float64(diag.SelectionAllBlocks), "selection_all_blocks/op")
+	b.ReportMetric(float64(diag.SelectionEmptyBlocks), "selection_empty_blocks/op")
+	b.ReportMetric(float64(diag.SelectionRangeBlocks+diag.SelectionRangesBlocks), "selection_range_blocks/op")
+	b.ReportMetric(float64(diag.SelectionBitmapBlocks), "selection_bitmap_blocks/op")
+	b.ReportMetric(float64(diag.SelectionSparseBlocks), "selection_sparse_blocks/op")
+	b.ReportMetric(float64(diag.KernelBlocks), "kernel_blocks/op")
+	b.ReportMetric(float64(diag.KernelFullCoveredBlocks), "kernel_full_blocks/op")
+	b.ReportMetric(float64(diag.KernelSelectedBlocks), "kernel_selected_blocks/op")
+	b.ReportMetric(float64(diag.StatsFallbackBlocks), "stats_fallback_blocks/op")
+	b.ReportMetric(float64(diag.PruningFallbackBlocks), "pruning_fallback_blocks/op")
+	b.ReportMetric(float64(diag.BlocksPruned), "blocks_pruned/op")
+}

--- a/TreeDB/collections/typed_column_conformance_test.go
+++ b/TreeDB/collections/typed_column_conformance_test.go
@@ -32,8 +32,12 @@ func TestTypedColumnAdapterSemanticConformanceMatrix(t *testing.T) {
 			encoding: typedcolumn.EncodingBoolBitpackRLE,
 			checks: []capabilityCheck{
 				{op: columnsemantics.OpEquality, status: columnsemantics.StatusSupported, reason: columnsemantics.ReasonSupported},
+				{op: columnsemantics.OpCountRows, status: columnsemantics.StatusSupported, reason: columnsemantics.ReasonSupported},
+				{op: columnsemantics.OpCountNonNull, status: columnsemantics.StatusSupported, reason: columnsemantics.ReasonSupported},
 				{op: columnsemantics.OpBoolCounts, status: columnsemantics.StatusSupported, reason: columnsemantics.ReasonSupported},
 				{op: columnsemantics.OpOrderedRange, status: columnsemantics.StatusUnsupported, reason: columnsemantics.ReasonBoolRangeUnsupported},
+				{op: columnsemantics.OpSum, status: columnsemantics.StatusUnsupported, reason: columnsemantics.ReasonOperationUnsupported},
+				{op: columnsemantics.OpAvg, status: columnsemantics.StatusUnsupported, reason: columnsemantics.ReasonOperationUnsupported},
 			},
 		},
 		{

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -352,6 +352,8 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/command_wal_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 4, occurrences: 6},
 	{path: "TreeDB/collections/typed_column_adapter.go", classification: typedStorageLegacyCompatibility, matchingLines: 46, occurrences: 52},
 	{path: "TreeDB/collections/typed_column_adapter_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 204, occurrences: 212},
+	{path: "TreeDB/collections/typed_column_bool_scan.go", classification: typedStorageLegacyCompatibility, matchingLines: 12, occurrences: 17},
+	{path: "TreeDB/collections/typed_column_bool_scan_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 3, occurrences: 4},
 	{path: "TreeDB/collections/typed_column_conformance_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 26, occurrences: 33},
 	{path: "TreeDB/collections/typed_column_int64_scan.go", classification: typedStorageLegacyCompatibility, matchingLines: 22, occurrences: 31},
 	{path: "TreeDB/collections/typed_column_int64_scan_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 32, occurrences: 40},

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -352,7 +352,7 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/command_wal_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 4, occurrences: 6},
 	{path: "TreeDB/collections/typed_column_adapter.go", classification: typedStorageLegacyCompatibility, matchingLines: 46, occurrences: 52},
 	{path: "TreeDB/collections/typed_column_adapter_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 204, occurrences: 212},
-	{path: "TreeDB/collections/typed_column_bool_scan.go", classification: typedStorageLegacyCompatibility, matchingLines: 12, occurrences: 17},
+	{path: "TreeDB/collections/typed_column_bool_scan.go", classification: typedStorageLegacyCompatibility, matchingLines: 14, occurrences: 19},
 	{path: "TreeDB/collections/typed_column_bool_scan_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 3, occurrences: 4},
 	{path: "TreeDB/collections/typed_column_conformance_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 26, occurrences: 33},
 	{path: "TreeDB/collections/typed_column_int64_scan.go", classification: typedStorageLegacyCompatibility, matchingLines: 22, occurrences: 31},

--- a/TreeDB/internal/columnsemantics/semantics_test.go
+++ b/TreeDB/internal/columnsemantics/semantics_test.go
@@ -55,7 +55,7 @@ func TestCapabilityInt64AggregateResultSemanticsAreExplicit(t *testing.T) {
 
 func TestCapabilityBoolSupportsEqualityButRejectsRangeSemantics(t *testing.T) {
 	desc := Descriptor{Logical: LogicalBool, Physical: typedcolumn.ColumnTypeBool, Encoding: typedcolumn.EncodingBoolBitpackRLE}
-	for _, op := range []Operation{OpAllRows, OpEquality, OpInequality, OpInList, OpBoolCounts, OpDirectScalarValueCarrier} {
+	for _, op := range []Operation{OpAllRows, OpEquality, OpInequality, OpInList, OpCountRows, OpCountNonNull, OpBoolCounts, OpDirectScalarValueCarrier} {
 		cap := CapabilityFor(desc, op)
 		if cap.Status != StatusSupported || cap.Reason != ReasonSupported || cap.Phase != PhasePrepare {
 			t.Fatalf("%s capability=%+v", op, cap)
@@ -66,6 +66,18 @@ func TestCapabilityBoolSupportsEqualityButRejectsRangeSemantics(t *testing.T) {
 		if cap.Status != StatusUnsupported || cap.Reason != ReasonBoolRangeUnsupported {
 			t.Fatalf("%s status=%s reason=%s", op, cap.Status, cap.Reason)
 		}
+	}
+	for _, op := range []Operation{OpSum, OpAvg} {
+		cap := CapabilityFor(desc, op)
+		if cap.Status != StatusUnsupported || cap.Reason != ReasonOperationUnsupported {
+			t.Fatalf("%s status=%s reason=%s", op, cap.Status, cap.Reason)
+		}
+	}
+	if cap := CapabilityFor(desc, OpPruneEquality); cap.Status != StatusFallback || cap.Reason != ReasonPruningPayloadUnsupported {
+		t.Fatalf("%s capability=%+v", OpPruneEquality, cap)
+	}
+	if cap := CapabilityFor(desc, OpStatsSum); cap.Status != StatusUnsupported || cap.Reason != ReasonOperationUnsupported {
+		t.Fatalf("%s capability=%+v", OpStatsSum, cap)
 	}
 }
 

--- a/TreeDB/internal/typedcolumn/bool_kernel_test.go
+++ b/TreeDB/internal/typedcolumn/bool_kernel_test.go
@@ -1,0 +1,117 @@
+package typedcolumn
+
+import "testing"
+
+func TestBoolCountAndSelectBitpackSelectionParity(t *testing.T) {
+	values := make([]bool, 130)
+	for i := range values {
+		values[i] = i%3 == 0 || i%11 == 0
+	}
+	granule := mustBuildBoolGranule(t, values)
+	if len(granule.Payload) == 0 || granule.Payload[0] != boolPayloadBitpack {
+		t.Fatalf("payload mode=%v want bitpack", granule.Payload)
+	}
+	assertBoolCountSelectParity(t, granule, values)
+}
+
+func TestBoolCountAndSelectRLESelectionParity(t *testing.T) {
+	values := make([]bool, 160)
+	for i := range values {
+		switch {
+		case i < 40:
+			values[i] = true
+		case i < 75:
+			values[i] = false
+		case i < 140:
+			values[i] = true
+		default:
+			values[i] = false
+		}
+	}
+	granule := mustBuildBoolGranule(t, values)
+	if len(granule.Payload) == 0 || granule.Payload[0] != boolPayloadRLE {
+		t.Fatalf("payload mode=%v want rle", granule.Payload)
+	}
+	assertBoolCountSelectParity(t, granule, values)
+}
+
+func assertBoolCountSelectParity(t *testing.T, granule EncodedGranule, values []bool) {
+	t.Helper()
+	rows := len(values)
+	bitmap := make([]uint64, rowSelectionBitmapWords(rows))
+	for _, row := range []int{0, 2, 3, 5, 8, 13, 21, 34, 55, 89, 129} {
+		if row < rows {
+			bitmap[row/64] |= uint64(1) << uint(row%64)
+		}
+	}
+	selections := map[string]RowSelection{
+		"all":    mustBoolSelection(NewAllRowSelection(rows)),
+		"empty":  mustBoolSelection(NewEmptyRowSelection(rows)),
+		"range":  mustBoolSelection(NewRangeRowSelection(rows, 7, 97)),
+		"ranges": mustBoolSelection(NewRangesRowSelection(rows, []RowRange{{Start: 1, End: 9}, {Start: 32, End: 47}, {Start: 90, End: rows}})),
+		"bitmap": mustBoolSelection(NewBitmapRowSelection(rows, bitmap)),
+		"sparse": mustBoolSelection(NewSparseRowSelection(rows, []int{1, 4, 7, 31, 64, 65, 88, 127})),
+	}
+	var reader GranuleReader
+	var scratch BoolSelectionScratch
+	for name, selection := range selections {
+		for _, wantValue := range []bool{false, true} {
+			wantRows := expectedBoolRows(values, selection, wantValue)
+			gotCount, err := reader.CountBool(granule, selection, wantValue)
+			if err != nil {
+				t.Fatalf("%s CountBool(%v): %v", name, wantValue, err)
+			}
+			if gotCount != len(wantRows) {
+				t.Fatalf("%s CountBool(%v)=%d want %d rows=%v", name, wantValue, gotCount, len(wantRows), wantRows)
+			}
+			gotSelection, err := reader.SelectBool(granule, selection, wantValue, &scratch)
+			if err != nil {
+				t.Fatalf("%s SelectBool(%v): %v", name, wantValue, err)
+			}
+			gotRows := gotSelection.AppendRows(nil)
+			if !equalIntSlices(gotRows, wantRows) {
+				t.Fatalf("%s SelectBool(%v) rows=%v want %v shape=%+v", name, wantValue, gotRows, wantRows, gotSelection.Shape())
+			}
+		}
+	}
+}
+
+func mustBuildBoolGranule(t *testing.T, values []bool) EncodedGranule {
+	t.Helper()
+	builder := NewGranuleBuilder(Config{Encoding: EncodingBoolBitpackRLE, Compression: CompressionNone})
+	granule, err := builder.BuildBool(values)
+	if err != nil {
+		t.Fatalf("BuildBool: %v", err)
+	}
+	return granule
+}
+
+func expectedBoolRows(values []bool, selection RowSelection, want bool) []int {
+	rows := selection.AppendRows(nil)
+	out := rows[:0]
+	for _, row := range rows {
+		if values[row] == want {
+			out = append(out, row)
+		}
+	}
+	return out
+}
+
+func mustBoolSelection(selection RowSelection, err error) RowSelection {
+	if err != nil {
+		panic(err)
+	}
+	return selection
+}
+
+func equalIntSlices(left, right []int) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/TreeDB/internal/typedcolumn/transplant_test.go
+++ b/TreeDB/internal/typedcolumn/transplant_test.go
@@ -387,6 +387,9 @@ func TestTypedColumnTransplantNoProductionPublication(t *testing.T) {
 		// shared by concrete collection hot paths.
 		filepath.Clean(filepath.Join(collectionsDir, "typed_column_prepared_state.go")): {},
 		filepath.Clean(filepath.Join(collectionsDir, "typed_column_prepared_int64.go")): {},
+		// #1845 is the scoped bool typed-column predicate/count slice using the
+		// same prepared-state and row-selection substrate.
+		filepath.Clean(filepath.Join(collectionsDir, "typed_column_bool_scan.go")): {},
 		// #1782 is the scoped production vector graph reader that consumes
 		// validated typed-column dense vector sections through mappedresource.
 		filepath.Clean(filepath.Join(collectionsDir, "column_vector_graph_typed_column.go")): {},

--- a/TreeDB/internal/typedcolumn/typed.go
+++ b/TreeDB/internal/typedcolumn/typed.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math/bits"
+	"sort"
 )
 
 const (
@@ -64,6 +65,57 @@ func (r *GranuleReader) CountTrueBool(g EncodedGranule) (int, error) {
 		return 0, err
 	}
 	return countTrueBoolPayload(raw, g.Rows)
+}
+
+// BoolSelectionScratch owns caller/session-scoped temporary storage for bool
+// predicate selections. Returned selections from SelectBool may alias this
+// scratch until the next use.
+type BoolSelectionScratch struct {
+	Rows   []int
+	Ranges []RowRange
+	Bitmap []uint64
+}
+
+// CountBool counts rows in selection whose bool payload equals value. Bitpack
+// payloads use popcount over selected bit ranges/words; RLE payloads aggregate
+// matching runs without materializing []bool.
+func (r *GranuleReader) CountBool(g EncodedGranule, selection RowSelection, value bool) (int, error) {
+	if g.Encoding != EncodingBoolBitpackRLE {
+		return 0, fmt.Errorf("typedcolumn: bool count got encoding %d", g.Encoding)
+	}
+	if err := validateBoolSelectionRows(g.Rows, selection); err != nil {
+		return 0, err
+	}
+	if selection.IsEmpty() {
+		return 0, nil
+	}
+	raw, err := r.decompressPayload(g)
+	if err != nil {
+		return 0, err
+	}
+	return countBoolPayloadSelection(raw, g.Rows, selection, value)
+}
+
+// SelectBool returns the subset of selection whose bool payload equals value.
+// The returned selection may alias scratch when scratch is non-nil.
+func (r *GranuleReader) SelectBool(g EncodedGranule, selection RowSelection, value bool, scratch *BoolSelectionScratch) (RowSelection, error) {
+	if g.Encoding != EncodingBoolBitpackRLE {
+		return RowSelection{}, fmt.Errorf("typedcolumn: bool select got encoding %d", g.Encoding)
+	}
+	if err := validateBoolSelectionRows(g.Rows, selection); err != nil {
+		return RowSelection{}, err
+	}
+	if selection.IsEmpty() {
+		return NewEmptyRowSelection(g.Rows)
+	}
+	if scratch == nil {
+		scratch = &BoolSelectionScratch{}
+	}
+	raw, err := r.decompressPayload(g)
+	if err != nil {
+		return RowSelection{}, err
+	}
+	return selectBoolPayload(raw, g.Rows, selection, value, scratch)
 }
 
 // BuildNullableInt64 returns a granule whose payload aliases builder-owned
@@ -390,16 +442,7 @@ func countTrueBoolPayload(raw []byte, rows int) (int, error) {
 		if len(mask) != need {
 			return 0, fmt.Errorf("typedcolumn: bool bitpack bytes=%d want=%d", len(mask), need)
 		}
-		count := 0
-		fullBytes := rows / 8
-		for _, b := range mask[:fullBytes] {
-			count += bits.OnesCount8(b)
-		}
-		if rows%8 != 0 {
-			last := mask[fullBytes] & byte((1<<uint(rows%8))-1)
-			count += bits.OnesCount8(last)
-		}
-		return count, nil
+		return countBoolBitpackRange(mask, 0, rows), nil
 	case boolPayloadRLE:
 		value, data, err := parseBoolRLEHeader(raw)
 		if err != nil {
@@ -432,6 +475,491 @@ func countTrueBoolPayload(raw []byte, rows int) (int, error) {
 	default:
 		return 0, fmt.Errorf("typedcolumn: unsupported bool payload mode %d", raw[0])
 	}
+}
+
+func validateBoolSelectionRows(rows int, selection RowSelection) error {
+	if err := validateGranuleDecodeRows(rows); err != nil {
+		return err
+	}
+	if selection.Rows() != rows {
+		return fmt.Errorf("typedcolumn: bool selection rows=%d want %d", selection.Rows(), rows)
+	}
+	return nil
+}
+
+func countBoolPayloadSelection(raw []byte, rows int, selection RowSelection, value bool) (int, error) {
+	if len(raw) == 0 {
+		return 0, errors.New("typedcolumn: missing bool payload mode")
+	}
+	switch raw[0] {
+	case boolPayloadBitpack:
+		mask := raw[1:]
+		need, err := bitmapBytesChecked(rows)
+		if err != nil {
+			return 0, err
+		}
+		if len(mask) != need {
+			return 0, fmt.Errorf("typedcolumn: bool bitpack bytes=%d want=%d", len(mask), need)
+		}
+		trueCount := countBoolBitpackSelection(mask, rows, selection)
+		if value {
+			return trueCount, nil
+		}
+		return selection.Count() - trueCount, nil
+	case boolPayloadRLE:
+		return countBoolRLESelection(raw, rows, selection, value)
+	default:
+		return 0, fmt.Errorf("typedcolumn: unsupported bool payload mode %d", raw[0])
+	}
+}
+
+func countBoolBitpackSelection(mask []byte, rows int, selection RowSelection) int {
+	switch selection.Kind() {
+	case RowSelectionEmpty:
+		return 0
+	case RowSelectionAll:
+		return countBoolBitpackRange(mask, 0, rows)
+	case RowSelectionRange:
+		start, end, _ := selection.SingleRange()
+		return countBoolBitpackRange(mask, start, end)
+	case RowSelectionRanges:
+		count := 0
+		for _, r := range selection.Ranges() {
+			count += countBoolBitpackRange(mask, r.Start, r.End)
+		}
+		return count
+	case RowSelectionBitmap:
+		count := 0
+		for wordIndex, selected := range selection.BitmapWords() {
+			if selected == 0 {
+				continue
+			}
+			word := boolBitpackWord(mask, wordIndex, rows)
+			count += bits.OnesCount64(word & selected)
+		}
+		return count
+	case RowSelectionSparse:
+		count := 0
+		for _, row := range selection.SparseRows() {
+			if bitmapBit(mask, row) {
+				count++
+			}
+		}
+		return count
+	default:
+		return 0
+	}
+}
+
+func countBoolBitpackRange(mask []byte, start int, end int) int {
+	if start < 0 || end < start {
+		return 0
+	}
+	count := 0
+	for start < end && start%8 != 0 {
+		if bitmapBit(mask, start) {
+			count++
+		}
+		start++
+	}
+	for start+8 <= end {
+		count += bits.OnesCount8(mask[start/8])
+		start += 8
+	}
+	for start < end {
+		if bitmapBit(mask, start) {
+			count++
+		}
+		start++
+	}
+	return count
+}
+
+func boolBitpackWord(mask []byte, wordIndex int, rows int) uint64 {
+	byteStart := wordIndex * 8
+	if byteStart >= len(mask) {
+		return 0
+	}
+	byteEnd := min(byteStart+8, len(mask))
+	var word uint64
+	for i, b := range mask[byteStart:byteEnd] {
+		word |= uint64(b) << uint(i*8)
+	}
+	if padding := rows % 64; padding != 0 && wordIndex == rowSelectionBitmapWords(rows)-1 {
+		word &= uint64(1<<uint(padding)) - 1
+	}
+	return word
+}
+
+func countBoolRLESelection(raw []byte, rows int, selection RowSelection, want bool) (int, error) {
+	value, data, err := parseBoolRLEHeader(raw)
+	if err != nil {
+		return 0, err
+	}
+	row := 0
+	count := 0
+	for len(data) > 0 && row < rows {
+		run, n := binary.Uvarint(data)
+		if n <= 0 {
+			return 0, errors.New("typedcolumn: malformed bool rle run")
+		}
+		if run == 0 || run > uint64(rows-row) {
+			return 0, errors.New("typedcolumn: invalid bool rle run")
+		}
+		runStart := row
+		runEnd := row + int(run)
+		if value == want {
+			count += countSelectionInRange(selection, runStart, runEnd)
+		}
+		row = runEnd
+		value = !value
+		data = data[n:]
+	}
+	if row != rows {
+		return 0, fmt.Errorf("typedcolumn: bool rle rows=%d want=%d", row, rows)
+	}
+	if len(data) != 0 {
+		return 0, errors.New("typedcolumn: trailing bool rle bytes")
+	}
+	return count, nil
+}
+
+func countSelectionInRange(selection RowSelection, start int, end int) int {
+	if end <= start || selection.IsEmpty() {
+		return 0
+	}
+	switch selection.Kind() {
+	case RowSelectionAll:
+		return end - start
+	case RowSelectionRange:
+		selStart, selEnd, _ := selection.SingleRange()
+		return max(0, min(end, selEnd)-max(start, selStart))
+	case RowSelectionRanges:
+		count := 0
+		for _, r := range selection.Ranges() {
+			if r.End <= start {
+				continue
+			}
+			if r.Start >= end {
+				break
+			}
+			count += max(0, min(end, r.End)-max(start, r.Start))
+		}
+		return count
+	case RowSelectionBitmap:
+		return countBitmapSelectionRange(selection.BitmapWords(), start, end)
+	case RowSelectionSparse:
+		sparse := selection.SparseRows()
+		lo := sort.SearchInts(sparse, start)
+		hi := sort.SearchInts(sparse, end)
+		return hi - lo
+	default:
+		return 0
+	}
+}
+
+func countBitmapSelectionRange(words []uint64, start int, end int) int {
+	if end <= start {
+		return 0
+	}
+	count := 0
+	for start < end && start%64 != 0 {
+		if words[start/64]&(uint64(1)<<uint(start%64)) != 0 {
+			count++
+		}
+		start++
+	}
+	for start+64 <= end {
+		count += bits.OnesCount64(words[start/64])
+		start += 64
+	}
+	for start < end {
+		if words[start/64]&(uint64(1)<<uint(start%64)) != 0 {
+			count++
+		}
+		start++
+	}
+	return count
+}
+
+func selectBoolPayload(raw []byte, rows int, selection RowSelection, value bool, scratch *BoolSelectionScratch) (RowSelection, error) {
+	if len(raw) == 0 {
+		return RowSelection{}, errors.New("typedcolumn: missing bool payload mode")
+	}
+	switch raw[0] {
+	case boolPayloadBitpack:
+		mask := raw[1:]
+		need, err := bitmapBytesChecked(rows)
+		if err != nil {
+			return RowSelection{}, err
+		}
+		if len(mask) != need {
+			return RowSelection{}, fmt.Errorf("typedcolumn: bool bitpack bytes=%d want=%d", len(mask), need)
+		}
+		return selectBoolBitpack(mask, rows, selection, value, scratch)
+	case boolPayloadRLE:
+		return selectBoolRLE(raw, rows, selection, value, scratch)
+	default:
+		return RowSelection{}, fmt.Errorf("typedcolumn: unsupported bool payload mode %d", raw[0])
+	}
+}
+
+func selectBoolBitpack(mask []byte, rows int, selection RowSelection, value bool, scratch *BoolSelectionScratch) (RowSelection, error) {
+	switch selection.Kind() {
+	case RowSelectionEmpty:
+		return NewEmptyRowSelection(rows)
+	case RowSelectionSparse:
+		scratch.Rows = scratch.Rows[:0]
+		for _, row := range selection.SparseRows() {
+			if bitmapBit(mask, row) == value {
+				scratch.Rows = append(scratch.Rows, row)
+			}
+		}
+		return boolRowsSelection(rows, scratch)
+	default:
+		words := rowSelectionBitmapWords(rows)
+		if cap(scratch.Bitmap) < words {
+			scratch.Bitmap = make([]uint64, words)
+		} else {
+			scratch.Bitmap = scratch.Bitmap[:words]
+			for i := range scratch.Bitmap {
+				scratch.Bitmap[i] = 0
+			}
+		}
+		applyBoolBitpackSelection(mask, rows, selection, value, scratch.Bitmap)
+		return NewBitmapRowSelectionNoCopy(rows, scratch.Bitmap)
+	}
+}
+
+func applyBoolBitpackSelection(mask []byte, rows int, selection RowSelection, value bool, out []uint64) {
+	applyRange := func(start, end int) {
+		for row := start; row < end; row++ {
+			if bitmapBit(mask, row) == value {
+				out[row/64] |= uint64(1) << uint(row%64)
+			}
+		}
+	}
+	switch selection.Kind() {
+	case RowSelectionAll:
+		applyRange(0, rows)
+	case RowSelectionRange:
+		start, end, _ := selection.SingleRange()
+		applyRange(start, end)
+	case RowSelectionRanges:
+		for _, r := range selection.Ranges() {
+			applyRange(r.Start, r.End)
+		}
+	case RowSelectionBitmap:
+		for wordIndex, selected := range selection.BitmapWords() {
+			if selected == 0 {
+				continue
+			}
+			word := boolBitpackWord(mask, wordIndex, rows)
+			if !value {
+				word = ^word
+				if padding := rows % 64; padding != 0 && wordIndex == rowSelectionBitmapWords(rows)-1 {
+					word &= uint64(1<<uint(padding)) - 1
+				}
+			}
+			out[wordIndex] = selected & word
+		}
+	}
+}
+
+func selectBoolRLE(raw []byte, rows int, selection RowSelection, want bool, scratch *BoolSelectionScratch) (RowSelection, error) {
+	value, data, err := parseBoolRLEHeader(raw)
+	if err != nil {
+		return RowSelection{}, err
+	}
+	if selection.Kind() == RowSelectionBitmap || selection.Kind() == RowSelectionSparse {
+		return selectBoolRLEByRows(value, data, rows, selection, want, scratch)
+	}
+	scratch.Ranges = scratch.Ranges[:0]
+	row := 0
+	for len(data) > 0 && row < rows {
+		run, n := binary.Uvarint(data)
+		if n <= 0 {
+			return RowSelection{}, errors.New("typedcolumn: malformed bool rle run")
+		}
+		if run == 0 || run > uint64(rows-row) {
+			return RowSelection{}, errors.New("typedcolumn: invalid bool rle run")
+		}
+		runStart := row
+		runEnd := row + int(run)
+		if value == want {
+			appendSelectionRangeIntersections(selection, runStart, runEnd, scratch)
+		}
+		row = runEnd
+		value = !value
+		data = data[n:]
+	}
+	if row != rows {
+		return RowSelection{}, fmt.Errorf("typedcolumn: bool rle rows=%d want=%d", row, rows)
+	}
+	if len(data) != 0 {
+		return RowSelection{}, errors.New("typedcolumn: trailing bool rle bytes")
+	}
+	return NewRangesRowSelectionNoCopy(rows, scratch.Ranges)
+}
+
+func appendSelectionRangeIntersections(selection RowSelection, start int, end int, scratch *BoolSelectionScratch) {
+	appendRange := func(a, b int) {
+		if a < b {
+			scratch.Ranges = append(scratch.Ranges, RowRange{Start: a, End: b})
+		}
+	}
+	switch selection.Kind() {
+	case RowSelectionAll:
+		appendRange(start, end)
+	case RowSelectionRange:
+		selStart, selEnd, _ := selection.SingleRange()
+		appendRange(max(start, selStart), min(end, selEnd))
+	case RowSelectionRanges:
+		for _, r := range selection.Ranges() {
+			if r.End <= start {
+				continue
+			}
+			if r.Start >= end {
+				break
+			}
+			appendRange(max(start, r.Start), min(end, r.End))
+		}
+	}
+}
+
+func selectBoolRLEByRows(value bool, data []byte, rows int, selection RowSelection, want bool, scratch *BoolSelectionScratch) (RowSelection, error) {
+	if selection.Kind() == RowSelectionBitmap {
+		words := rowSelectionBitmapWords(rows)
+		if cap(scratch.Bitmap) < words {
+			scratch.Bitmap = make([]uint64, words)
+		} else {
+			scratch.Bitmap = scratch.Bitmap[:words]
+			for i := range scratch.Bitmap {
+				scratch.Bitmap[i] = 0
+			}
+		}
+		row := 0
+		for len(data) > 0 && row < rows {
+			run, n := binary.Uvarint(data)
+			if n <= 0 {
+				return RowSelection{}, errors.New("typedcolumn: malformed bool rle run")
+			}
+			if run == 0 || run > uint64(rows-row) {
+				return RowSelection{}, errors.New("typedcolumn: invalid bool rle run")
+			}
+			runEnd := row + int(run)
+			if value == want {
+				copyBitmapRangeIntersection(scratch.Bitmap, selection.BitmapWords(), row, runEnd)
+			}
+			row = runEnd
+			value = !value
+			data = data[n:]
+		}
+		if row != rows {
+			return RowSelection{}, fmt.Errorf("typedcolumn: bool rle rows=%d want=%d", row, rows)
+		}
+		if len(data) != 0 {
+			return RowSelection{}, errors.New("typedcolumn: trailing bool rle bytes")
+		}
+		return NewBitmapRowSelectionNoCopy(rows, scratch.Bitmap)
+	}
+	scratch.Rows = scratch.Rows[:0]
+	row := 0
+	sparse := selection.SparseRows()
+	sparseIndex := 0
+	for len(data) > 0 && row < rows {
+		run, n := binary.Uvarint(data)
+		if n <= 0 {
+			return RowSelection{}, errors.New("typedcolumn: malformed bool rle run")
+		}
+		if run == 0 || run > uint64(rows-row) {
+			return RowSelection{}, errors.New("typedcolumn: invalid bool rle run")
+		}
+		runEnd := row + int(run)
+		for sparseIndex < len(sparse) && sparse[sparseIndex] < row {
+			sparseIndex++
+		}
+		if value == want {
+			for sparseIndex < len(sparse) && sparse[sparseIndex] < runEnd {
+				scratch.Rows = append(scratch.Rows, sparse[sparseIndex])
+				sparseIndex++
+			}
+		}
+		row = runEnd
+		value = !value
+		data = data[n:]
+	}
+	if row != rows {
+		return RowSelection{}, fmt.Errorf("typedcolumn: bool rle rows=%d want=%d", row, rows)
+	}
+	if len(data) != 0 {
+		return RowSelection{}, errors.New("typedcolumn: trailing bool rle bytes")
+	}
+	return boolRowsSelection(rows, scratch)
+}
+
+func copyBitmapRangeIntersection(dst []uint64, src []uint64, start int, end int) {
+	for row := start; row < end; row++ {
+		word := row / 64
+		bit := uint(row % 64)
+		if src[word]&(uint64(1)<<bit) != 0 {
+			dst[word] |= uint64(1) << bit
+		}
+	}
+}
+
+const boolSelectionRangeLimit = 8
+
+func boolRowsSelection(rows int, scratch *BoolSelectionScratch) (RowSelection, error) {
+	selected := scratch.Rows
+	if len(selected) == 0 {
+		return NewEmptyRowSelection(rows)
+	}
+	if len(selected) == rows {
+		return NewAllRowSelection(rows)
+	}
+	if isContiguousBoolRows(selected) {
+		return NewRangeRowSelection(rows, selected[0], selected[len(selected)-1]+1)
+	}
+	scratch.Ranges = scratch.Ranges[:0]
+	start, prev := selected[0], selected[0]
+	for _, row := range selected[1:] {
+		if row == prev+1 {
+			prev = row
+			continue
+		}
+		scratch.Ranges = append(scratch.Ranges, RowRange{Start: start, End: prev + 1})
+		start, prev = row, row
+	}
+	scratch.Ranges = append(scratch.Ranges, RowRange{Start: start, End: prev + 1})
+	if len(scratch.Ranges) <= boolSelectionRangeLimit {
+		return NewRangesRowSelectionNoCopy(rows, scratch.Ranges)
+	}
+	if len(selected) >= 64 && len(selected)*4 >= rows*3 {
+		words := rowSelectionBitmapWords(rows)
+		if cap(scratch.Bitmap) < words {
+			scratch.Bitmap = make([]uint64, words)
+		} else {
+			scratch.Bitmap = scratch.Bitmap[:words]
+			for i := range scratch.Bitmap {
+				scratch.Bitmap[i] = 0
+			}
+		}
+		for _, row := range selected {
+			scratch.Bitmap[row/64] |= uint64(1) << uint(row%64)
+		}
+		return NewBitmapRowSelectionNoCopy(rows, scratch.Bitmap)
+	}
+	return NewSparseRowSelectionNoCopy(rows, selected)
+}
+
+func isContiguousBoolRows(rows []int) bool {
+	for i := 1; i < len(rows); i++ {
+		if rows[i] != rows[i-1]+1 {
+			return false
+		}
+	}
+	return len(rows) != 0
 }
 
 func boolRLEPayloadLen(values []bool) int {

--- a/TreeDB/internal/typedkernel/bool.go
+++ b/TreeDB/internal/typedkernel/bool.go
@@ -1,0 +1,47 @@
+package typedkernel
+
+import (
+	"fmt"
+
+	"github.com/snissn/gomap/TreeDB/internal/typedcolumn"
+)
+
+func reduceBoolCounts(op AggregateOp, req ReduceRequest, _ *Scratch) (AggregateResult, error) {
+	rows, err := validateSelectionRows(req)
+	if err != nil {
+		return AggregateResult{}, err
+	}
+	if len(req.Int64Values) != 0 || req.Int64Cursor != nil {
+		return AggregateResult{}, fmt.Errorf("typedkernel: bool reducer got int64 inputs")
+	}
+	switch op {
+	case OpCountNonNull:
+		return AggregateResult{Op: op, NonNulls: int64(req.Selection.Count()), HasValue: true}, nil
+	case OpBoolCounts:
+		if !req.HasBoolGranule {
+			if req.Selection.IsEmpty() {
+				return AggregateResult{Op: op, Rows: 0, NonNulls: 0, HasValue: true}, nil
+			}
+			return AggregateResult{}, fmt.Errorf("typedkernel: bool counts reducer requires bool granule")
+		}
+		if req.BoolGranule.Rows != rows {
+			return AggregateResult{}, fmt.Errorf("typedkernel: bool granule rows=%d want %d", req.BoolGranule.Rows, rows)
+		}
+		reader := req.BoolReader
+		if reader == nil {
+			reader = &typedcolumn.GranuleReader{}
+		}
+		trueCount, err := reader.CountBool(req.BoolGranule, req.Selection, true)
+		if err != nil {
+			return AggregateResult{}, err
+		}
+		selected := req.Selection.Count()
+		if trueCount < 0 || trueCount > selected {
+			return AggregateResult{}, fmt.Errorf("typedkernel: bool true count=%d outside selected=%d", trueCount, selected)
+		}
+		falseCount := selected - trueCount
+		return AggregateResult{Op: op, Rows: int64(selected), NonNulls: int64(selected), TrueCount: int64(trueCount), FalseCount: int64(falseCount), HasValue: true}, nil
+	default:
+		return AggregateResult{}, fmt.Errorf("typedkernel: bool reducer got op=%s", op)
+	}
+}

--- a/TreeDB/internal/typedkernel/registry.go
+++ b/TreeDB/internal/typedkernel/registry.go
@@ -26,8 +26,10 @@ const (
 
 // AggregateResult keeps row-count and value-count semantics distinct. For
 // CountRows, Rows is the row count. For CountNonNull and value aggregates,
-// NonNulls is the number of values included in the aggregate. HasValue is false
-// for empty min/max/avg inputs.
+// NonNulls is the number of values included in the aggregate. For OpBoolCounts,
+// Rows and NonNulls are the selected non-null bool rows while TrueCount and
+// FalseCount partition those rows. HasValue is false for empty min/max/avg
+// inputs.
 type AggregateResult struct {
 	Op         AggregateOp
 	Rows       int64

--- a/TreeDB/internal/typedkernel/registry.go
+++ b/TreeDB/internal/typedkernel/registry.go
@@ -21,6 +21,7 @@ const (
 	OpAvg          AggregateOp = columnsemantics.OpAvg
 	OpMin          AggregateOp = columnsemantics.OpMin
 	OpMax          AggregateOp = columnsemantics.OpMax
+	OpBoolCounts   AggregateOp = columnsemantics.OpBoolCounts
 )
 
 // AggregateResult keeps row-count and value-count semantics distinct. For
@@ -28,14 +29,16 @@ const (
 // NonNulls is the number of values included in the aggregate. HasValue is false
 // for empty min/max/avg inputs.
 type AggregateResult struct {
-	Op       AggregateOp
-	Rows     int64
-	NonNulls int64
-	Sum      int64
-	Avg      float64
-	Min      int64
-	Max      int64
-	HasValue bool
+	Op         AggregateOp
+	Rows       int64
+	NonNulls   int64
+	TrueCount  int64
+	FalseCount int64
+	Sum        int64
+	Avg        float64
+	Min        int64
+	Max        int64
+	HasValue   bool
 }
 
 // ReduceRequest is the concrete hot-loop input for one selected block. Rows is
@@ -44,10 +47,13 @@ type AggregateResult struct {
 // empty selections. Int64Cursor is used by streaming int64 kernels; callers
 // provide either Int64Values or Int64Cursor for value aggregates, not both.
 type ReduceRequest struct {
-	Rows        int
-	Selection   typedcolumn.RowSelection
-	Int64Values []int64
-	Int64Cursor *typedcolumn.Int64Cursor
+	Rows           int
+	Selection      typedcolumn.RowSelection
+	Int64Values    []int64
+	Int64Cursor    *typedcolumn.Int64Cursor
+	BoolGranule    typedcolumn.EncodedGranule
+	HasBoolGranule bool
+	BoolReader     *typedcolumn.GranuleReader
 }
 
 // Scratch is caller/session-owned reusable storage for future kernels. It is
@@ -55,6 +61,7 @@ type ReduceRequest struct {
 type Scratch struct {
 	Selection typedcolumn.RowSelectionScratch
 	Int64     []int64
+	Bool      typedcolumn.BoolSelectionScratch
 }
 
 // ReduceFunc runs a concrete reducer after registry dispatch. Implementations
@@ -96,6 +103,13 @@ var defaultEntries = [...]KernelSpec{
 		Physical: typedcolumn.ColumnTypeInt64,
 		Ops:      []AggregateOp{OpCountNonNull, OpSum, OpAvg, OpMin, OpMax},
 		Reduce:   reduceInt64Aggregate,
+	},
+	{
+		Name:     "bool.counts.v1",
+		Logical:  columnsemantics.LogicalBool,
+		Physical: typedcolumn.ColumnTypeBool,
+		Ops:      []AggregateOp{OpCountNonNull, OpBoolCounts},
+		Reduce:   reduceBoolCounts,
 	},
 }
 
@@ -233,7 +247,7 @@ func (entry KernelSpec) matches(op AggregateOp, desc columnsemantics.Descriptor,
 
 func isAggregateOp(op AggregateOp) bool {
 	switch op {
-	case OpCountRows, OpCountNonNull, OpSum, OpAvg, OpMin, OpMax:
+	case OpCountRows, OpCountNonNull, OpSum, OpAvg, OpMin, OpMax, OpBoolCounts:
 		return true
 	default:
 		return false

--- a/TreeDB/internal/typedkernel/registry_test.go
+++ b/TreeDB/internal/typedkernel/registry_test.go
@@ -326,6 +326,58 @@ func TestGenericCountRowsDispatchesForNonInt64(t *testing.T) {
 	}
 }
 
+func TestBoolCountsKernelSelectionParity(t *testing.T) {
+	values := []bool{true, false, true, true, false, false, true, false, true, false}
+	builder := typedcolumn.NewGranuleBuilder(typedcolumn.Config{Encoding: typedcolumn.EncodingBoolBitpackRLE, Compression: typedcolumn.CompressionNone})
+	granule, err := builder.BuildBool(values)
+	if err != nil {
+		t.Fatalf("BuildBool: %v", err)
+	}
+	selections := map[string]typedcolumn.RowSelection{
+		"all":    mustSelection(typedcolumn.NewAllRowSelection(len(values))),
+		"empty":  mustSelection(typedcolumn.NewEmptyRowSelection(len(values))),
+		"range":  mustSelection(typedcolumn.NewRangeRowSelection(len(values), 2, 8)),
+		"ranges": mustSelection(typedcolumn.NewRangesRowSelection(len(values), []typedcolumn.RowRange{{Start: 0, End: 2}, {Start: 5, End: 9}})),
+		"bitmap": mustSelection(typedcolumn.NewBitmapRowSelection(len(values), []uint64{(1 << 0) | (1 << 3) | (1 << 4) | (1 << 9)})),
+		"sparse": mustSelection(typedcolumn.NewSparseRowSelection(len(values), []int{1, 2, 7, 8})),
+	}
+	prepared, err := typedkernel.DefaultRegistry().Dispatch(typedkernel.DispatchRequest{Operation: typedkernel.OpBoolCounts, Semantic: boolSemantic(), Layout: boolLayout()})
+	if err != nil {
+		t.Fatalf("dispatch bool counts: %v", err)
+	}
+	if prepared.KernelName() != "bool.counts.v1" {
+		t.Fatalf("kernel=%q want bool.counts.v1", prepared.KernelName())
+	}
+	var reader typedcolumn.GranuleReader
+	for shape, selection := range selections {
+		t.Run(shape, func(t *testing.T) {
+			wantTrue, wantFalse := expectedBoolCounts(values, selection)
+			got, err := prepared.Reduce(typedkernel.ReduceRequest{Rows: len(values), Selection: selection, BoolGranule: granule, HasBoolGranule: true, BoolReader: &reader}, nil)
+			if err != nil {
+				t.Fatalf("reduce bool counts: %v", err)
+			}
+			if got.Rows != int64(selection.Count()) || got.NonNulls != int64(selection.Count()) || got.TrueCount != int64(wantTrue) || got.FalseCount != int64(wantFalse) || !got.HasValue {
+				t.Fatalf("result=%+v want rows/non_null=%d true=%d false=%d", got, selection.Count(), wantTrue, wantFalse)
+			}
+		})
+	}
+}
+
+func TestBoolCountNonNullKernel(t *testing.T) {
+	selection := mustSelection(typedcolumn.NewSparseRowSelection(8, []int{1, 4, 7}))
+	prepared, err := typedkernel.DefaultRegistry().Dispatch(typedkernel.DispatchRequest{Operation: typedkernel.OpCountNonNull, Semantic: boolSemantic(), Layout: boolLayout()})
+	if err != nil {
+		t.Fatalf("dispatch bool count non-null: %v", err)
+	}
+	got, err := prepared.Reduce(typedkernel.ReduceRequest{Rows: 8, Selection: selection}, nil)
+	if err != nil {
+		t.Fatalf("reduce bool count non-null: %v", err)
+	}
+	if prepared.KernelName() != "bool.counts.v1" || got.NonNulls != 3 || got.Rows != 0 {
+		t.Fatalf("kernel=%q result=%+v", prepared.KernelName(), got)
+	}
+}
+
 func TestCallerOwnedFakeNonInt64KernelDispatch(t *testing.T) {
 	reg, err := typedkernel.NewRegistry(nil)
 	if err != nil {
@@ -440,4 +492,17 @@ func boolSemantic() columnsemantics.Descriptor {
 
 func boolLayout() columnlayout.Capabilities {
 	return columnlayout.CapabilitiesFor(columnlayout.Descriptor{Logical: columnsemantics.LogicalBool, Physical: typedcolumn.ColumnTypeBool, Encoding: typedcolumn.EncodingBoolBitpackRLE, Compression: typedcolumn.CompressionNone})
+}
+
+func expectedBoolCounts(values []bool, selection typedcolumn.RowSelection) (int, int) {
+	trueCount := 0
+	falseCount := 0
+	for _, row := range selection.AppendRows(nil) {
+		if values[row] {
+			trueCount++
+		} else {
+			falseCount++
+		}
+	}
+	return trueCount, falseCount
 }


### PR DESCRIPTION
## Summary

Closes #1845. Part of #1836.

Implements the bool typed-column reference slice through the shared substrate:

- adds bool bitpack/RLE `GranuleReader` count/select helpers with RowSelection all/empty/range/ranges/bitmap/sparse support;
- adds `typedkernel` bool count reducers (`aggregate.bool_counts`, `count_non_null`) dispatched through the existing immutable registry;
- adds prepared/session bool predicate aggregate APIs using shared prepared-state, layout capability, kernel dispatch, selection/visibility composition, and read-integrity paths;
- keeps bool range/sum/avg unsupported/fail-closed; nullable bool stays an explicit unsupported/fallback path rather than treating null/default as false;
- reports explicit bool stats/pruning fallback diagnostics rather than tunneling bool through int64 stats/pruning payloads;
- adds bool benchmark/profile coverage for prepared-hot all/selective/all-match/all-pruned shapes.

Deferred intentionally: durable bool stats/pruning payloads, nullable bool optimized kernels, and string/float/vector type-family work (#1846-#1848).

## Validation

Latest head: `981e26b12`.

- `git diff --check origin/main...HEAD` ✅
- `go test -count=1 ./TreeDB/collections -run 'TestTypedColumnBool|TestTypedStorageLegacyNameAllowlistIsComplete'` ✅
- `go test -count=1 ./TreeDB/internal/typedkernel ./TreeDB/collections` ✅
- `go test -count=1 ./TreeDB/internal/typedcolumn ./TreeDB/internal/typedkernel ./TreeDB/internal/columnsemantics ./TreeDB/internal/columnlayout ./TreeDB/collections` ✅
- `go test -count=1 ./TreeDB/...` ⚠️ one unrelated flaky `TreeDB/caching` failure in `TestCheckpoint_KicksVlogGenerationRewriteDespiteRecentForegroundActivity`; immediate focused rerun passed:
  - `go test -count=1 ./TreeDB/caching -run TestCheckpoint_KicksVlogGenerationRewriteDespiteRecentForegroundActivity` ✅

## Benchmark/profile evidence

Local machine: Apple M3/darwin arm64. Prepared-session hot scan, cached_verify, setup excluded.

1,048,576-row bool benchmark (`TREEDB_TYPED_COLUMN_BOOL_BENCH_ROWS=1048576`, `-benchtime=100x`, `-benchmem`):

| shape | ns/op | ops/sec | rows/sec | matches/sec | mapped bytes | physical bytes | blocks pruned | kernel blocks | B/op | allocs/op |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| all_mixed_counts | 486,206 | 2,057 | 2.16B | 2.16B | 131,200 | 131,200 | 0 | 128 | 512 | 4 |
| equal_true_selective | 767,109 | 1,304 | 1.37B | 13.7M | 21,350 | 21,350 | 0 | 128 | 512 | 4 |
| equal_true_all_match_rle | 408,376 | 2,449 | 2.57B | 2.57B | 512 | 512 | 0 | 128 | 512 | 4 |
| equal_true_all_pruned_rle | 3,804 | 265,223 | 278B | 0 | 0 | 0 | 128 | 0 | 512 | 4 |

Additional profile artifacts: `/tmp/treedb_1845_bool_bench/profile_all_mixed_1m/`.

- CPU profile (`-benchtime=1000x`) shows the bool hot path in `typedcolumn.countBoolBitpackRange`, `typedcolumn.CountBool`, and `typedkernel.reduceBoolCounts`; `trackResourceRead`/mapped handle accounting is also visible.
- Non-profile benchmark remains the allocation signal: 512 B/op and 4 allocs/op across 1M shapes.

Manager artifacts also captured under `artifacts/1845/` in the worktree, including 262k smoke/profile outputs and the subtask plan.

## Semantics / boundaries

- Bool equality and all-row counting are supported; bool range predicates return `ErrColumnQueryPlanUnsupported` with `bool_range_unsupported`.
- Bool stats and pruning currently report explicit fallback diagnostics (`stats_payload_unsupported`, `pruning_payload_unsupported`) rather than unsafe payload reuse.
- Nullable/default bool remains fail-closed for this slice; missing non-null bool values fail during insert and nullable bool aggregate prepare rejects the plan.
- Prepared state owns scratch/resources; no hidden global mutable caches are added.
- Hot row loops use concrete bool helpers/kernels, not reflection or per-row interface dispatch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added boolean column predicate scanning with aggregate counting capabilities, supporting operations to count total rows, non-null values, true values, and false values.
  * Enabled prepared session execution mode for repeated scans with cached state.

* **Tests**
  * Added comprehensive test suite for boolean predicate aggregates, including benchmark for performance measurement and validation across multiple execution paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1865?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->