### PR TITLE
Land snapshot-bound typed-storage document materializer

### DIFF
--- a/TreeDB/collections/document_materializer.go
+++ b/TreeDB/collections/document_materializer.go
@@ -1,0 +1,445 @@
+package collections
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"time"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+)
+
+// DocumentFetchOptions configures snapshot-bound document materialization.
+// Projection and row-locator point-fetch options are intentionally deferred to
+// later materializer milestones; the zero value preserves Collection.Get-style
+// full-document output and verified column-asset reads.
+type DocumentFetchOptions struct {
+	// ColumnAssetReadIntegrity controls typed-row/physical row asset reads used
+	// to find the visible row for a document. Typed-column part reconstruction
+	// continues to use the default verified read path until the prepared asset
+	// lifecycle lands.
+	ColumnAssetReadIntegrity ColumnAssetReadIntegrity
+}
+
+// DocumentRowRef identifies a document row in a snapshot-bound typed-storage
+// materialization request. #1872 keeps the row-ref API seam but still resolves
+// documents through the batched document-ID scan; direct O(topK) row-locator
+// point fetch is deferred to #1874.
+type DocumentRowRef struct {
+	DocumentID        []byte
+	Generation        uint64
+	PartID            uint64
+	RowIndex          int
+	AppliedCommandLSN uint64
+}
+
+// DocumentFetchResult is one materialized document result. ID and Document are
+// response-owned slices. Missing documents have Found=false and Document=nil.
+type DocumentFetchResult struct {
+	ID       []byte
+	Document []byte
+	Found    bool
+	RowRef   DocumentRowRef
+}
+
+// DocumentMaterializationStats attributes the work performed by a
+// CollectionReadView fetch. Counters describe the fetch call, not the lifetime
+// of the read view.
+type DocumentMaterializationStats struct {
+	DocumentsRequested uint64
+	DocumentsFetched   uint64
+	DocumentsMissing   uint64
+	DocumentBytes      uint64
+
+	RetainedPayloadFetches uint64
+	RetainedPayloadBytes   uint64
+
+	VisibilityScans         uint64
+	VisibilityRowsScanned   uint64
+	VisibilityRows          uint64
+	VisibilityPhysicalBytes int64
+	VisibilityNanos         int64
+
+	TypedColumnRows        uint64
+	TypedColumnCacheHits   uint64
+	TypedColumnCacheMisses uint64
+	TypedColumnPartLoads   uint64
+	TypedColumnPartDecodes uint64
+	TypedColumnNanos       int64
+
+	JSONReconstructionRows  uint64
+	JSONReconstructionNanos int64
+
+	RowRefFallbackScans uint64
+}
+
+// DocumentFetchResponse contains ordered materialization results and per-call
+// diagnostics.
+type DocumentFetchResponse struct {
+	Results []DocumentFetchResult
+	Stats   DocumentMaterializationStats
+}
+
+// CollectionReadView is a closeable snapshot-bound document materializer for a
+// collection. It preserves the catalog/root visibility that existed when the
+// view was opened. Returned documents are owned by the fetch response. The view
+// is not concurrency-safe; callers that fetch concurrently should open one view
+// per worker or synchronize externally.
+type CollectionReadView struct {
+	collection *Collection
+	snapshot   *backenddb.Snapshot
+	catalog    *collectionCatalog
+	ownsSnap   bool
+	closed     bool
+}
+
+// OpenCollectionReadView opens a snapshot-bound document materializer. Buffered
+// writes are flushed before the snapshot is acquired so the view matches normal
+// Collection.Get visibility at open time; later writes are not visible through
+// the view.
+func (c *Collection) OpenCollectionReadView() (*CollectionReadView, error) {
+	if c == nil {
+		return nil, errCollectionNil
+	}
+	if c.db == nil {
+		return nil, errCollectionDBNil
+	}
+	if err := c.flushBufferedWrites(); err != nil {
+		return nil, err
+	}
+	snap := c.db.AcquireSnapshot()
+	if snap == nil {
+		return nil, backenddb.ErrClosed
+	}
+	closeOnErr := true
+	defer func() {
+		if closeOnErr {
+			_ = snap.Close()
+		}
+	}()
+	catalog, err := c.catalogForSnapshot(snap)
+	if err != nil {
+		return nil, err
+	}
+	if catalog == nil {
+		return nil, errCollectionNotFound
+	}
+	view := newCollectionReadViewAtSnapshot(c, snap, catalog, true)
+	closeOnErr = false
+	return view, nil
+}
+
+func newCollectionReadViewAtSnapshot(c *Collection, snap *backenddb.Snapshot, catalog *collectionCatalog, ownsSnap bool) *CollectionReadView {
+	return &CollectionReadView{collection: c, snapshot: snap, catalog: catalog, ownsSnap: ownsSnap}
+}
+
+// Close releases the snapshot owned by the read view. Views that are bound to a
+// caller-owned snapshot still become closed, but leave snapshot release to the
+// owner.
+func (v *CollectionReadView) Close() error {
+	if v == nil || v.closed {
+		return nil
+	}
+	v.closed = true
+	if v.ownsSnap && v.snapshot != nil {
+		err := v.snapshot.Close()
+		v.snapshot = nil
+		return err
+	}
+	return nil
+}
+
+// FetchDocumentsByID materializes full documents for ids in input order. Missing
+// documents produce Found=false results without failing the whole fetch.
+func (v *CollectionReadView) FetchDocumentsByID(ids [][]byte, opts DocumentFetchOptions) (DocumentFetchResponse, error) {
+	return v.fetchDocumentsByID(ids, nil, opts)
+}
+
+func (v *CollectionReadView) validateOpen() error {
+	if v == nil || v.collection == nil {
+		return errors.New("collections: nil collection read view")
+	}
+	if v.closed {
+		return errors.New("collections: collection read view is closed")
+	}
+	if v.snapshot == nil || v.catalog == nil {
+		return errors.New("collections: nil collection read view")
+	}
+	return nil
+}
+
+// FetchDocumentsByRowRef materializes full documents for row refs in input
+// order. The current implementation validates the row ref against the visible
+// row discovered by a batched document-ID scan; direct row-locator fetch is
+// intentionally deferred to #1874.
+func (v *CollectionReadView) FetchDocumentsByRowRef(refs []DocumentRowRef, opts DocumentFetchOptions) (DocumentFetchResponse, error) {
+	if err := v.validateOpen(); err != nil {
+		return DocumentFetchResponse{}, err
+	}
+	if len(refs) == 0 {
+		return DocumentFetchResponse{}, nil
+	}
+	ids := make([][]byte, len(refs))
+	expected := make([]*DocumentRowRef, len(refs))
+	for i := range refs {
+		if len(refs[i].DocumentID) == 0 {
+			return DocumentFetchResponse{}, fmt.Errorf("collections: document row ref %d missing document id", i)
+		}
+		if refs[i].RowIndex < 0 {
+			return DocumentFetchResponse{}, fmt.Errorf("collections: document row ref %d has negative row index", i)
+		}
+		ids[i] = refs[i].DocumentID
+		expected[i] = &refs[i]
+	}
+	response, err := v.fetchDocumentsByID(ids, expected, opts)
+	response.Stats.RowRefFallbackScans++
+	return response, err
+}
+
+func (v *CollectionReadView) fetchDocumentsByID(ids [][]byte, expected []*DocumentRowRef, opts DocumentFetchOptions) (DocumentFetchResponse, error) {
+	if err := v.validateOpen(); err != nil {
+		return DocumentFetchResponse{}, err
+	}
+	if expected != nil && len(expected) != len(ids) {
+		return DocumentFetchResponse{}, errors.New("collections: document row ref count does not match ids")
+	}
+	if len(ids) == 0 {
+		return DocumentFetchResponse{}, nil
+	}
+	response := DocumentFetchResponse{
+		Results: make([]DocumentFetchResult, len(ids)),
+		Stats: DocumentMaterializationStats{
+			DocumentsRequested: uint64(len(ids)),
+		},
+	}
+	var idArena []byte
+	retained := make([][]byte, len(ids))
+	foundIDs := make([][]byte, 0, len(ids))
+	for i, id := range ids {
+		if len(id) == 0 {
+			return response, fmt.Errorf("collections: document id at position %d cannot be empty", i)
+		}
+		idStart := len(idArena)
+		idArena = append(idArena, id...)
+		ownedID := idArena[idStart:len(idArena):len(idArena)]
+		response.Results[i].ID = ownedID
+		value, found, err := collectionGetAppendAtCatalogRoot(v.snapshot, v.catalog, collectionPrimaryRootName(v.catalog.meta.Name), id, nil)
+		if err != nil {
+			return response, err
+		}
+		if !found {
+			response.Stats.DocumentsMissing++
+			continue
+		}
+		response.Results[i].Found = true
+		retained[i] = value
+		foundIDs = append(foundIDs, id)
+		response.Stats.RetainedPayloadFetches++
+		response.Stats.RetainedPayloadBytes += uint64(len(value))
+	}
+	if len(foundIDs) == 0 {
+		return response, nil
+	}
+	if !columnStoreCanReconstructDocument(v.catalog.meta) {
+		var documentArena []byte
+		for i := range response.Results {
+			if !response.Results[i].Found {
+				continue
+			}
+			documentArena = appendDocumentFetchOwnedBytes(documentArena, retained[i], &response.Results[i])
+			response.Stats.DocumentsFetched++
+			response.Stats.DocumentBytes += uint64(len(response.Results[i].Document))
+		}
+		return response, nil
+	}
+	return v.fetchColumnStoreDocumentsByID(response, ids, retained, expected, opts)
+}
+
+func (v *CollectionReadView) fetchColumnStoreDocumentsByID(response DocumentFetchResponse, ids [][]byte, retained [][]byte, expected []*DocumentRowRef, opts DocumentFetchOptions) (DocumentFetchResponse, error) {
+	cfg := v.catalog.meta.Options.ColumnStore.copy()
+	readIntegrity := opts.ColumnAssetReadIntegrity
+	if readIntegrity == "" {
+		readIntegrity = ColumnAssetReadIntegrityVerify
+	}
+	visibleStart := time.Now()
+	visible, err := v.collection.scanColumnPhysicalVisibleRowsAtSnapshotForTargetsWithReadIntegrity(
+		v.snapshot,
+		v.catalog,
+		v.catalog.meta.Name,
+		v.catalog.rootID(collectionColumnManifestRootName(v.catalog.meta.Name)),
+		cfg,
+		true,
+		newColumnPhysicalVisibilityTargetIDs(ids),
+		nil,
+		readIntegrity,
+	)
+	response.Stats.VisibilityNanos = time.Since(visibleStart).Nanoseconds()
+	response.Stats.VisibilityScans++
+	response.Stats.VisibilityRowsScanned = uint64(visible.Diagnostics.RowsScanned)
+	response.Stats.VisibilityRows = uint64(len(visible.Rows))
+	response.Stats.VisibilityPhysicalBytes = visible.Diagnostics.PhysicalBytesScanned
+	if err != nil {
+		return response, err
+	}
+	visibleByID := make(map[string]columnPhysicalVisibleRow, len(visible.Rows))
+	for _, row := range visible.Rows {
+		visibleByID[string(row.ID)] = row
+	}
+	var typedColumnCache *typedColumnPartReconstructionCache
+	if columnStoreHasTypedColumnPartOwners(cfg) {
+		typedColumnCache = &typedColumnPartReconstructionCache{Parts: make(map[uint64]typedColumnPartDecodedValues)}
+	}
+	manifestRootID := v.catalog.rootID(collectionColumnManifestRootName(v.catalog.meta.Name))
+	typedScratch := make([]columnDeclaredValue, 0, len(columnStoreTypedColumnPartFields(cfg)))
+	mergeScratch := make([]columnDeclaredValue, 0, len(cfg.Columns))
+	var documentArena []byte
+	for i := range response.Results {
+		if !response.Results[i].Found {
+			continue
+		}
+		row, ok := visibleByID[string(response.Results[i].ID)]
+		if !ok {
+			return response, fmt.Errorf("collections: column reconstruction missing visible physical row for id %q", string(response.Results[i].ID))
+		}
+		if row.Deleted {
+			return response, fmt.Errorf("collections: column reconstruction latest physical row is deleted for id %q", string(response.Results[i].ID))
+		}
+		rowRef := documentRowRefFromVisibleRow(row)
+		if expected != nil && expected[i] != nil {
+			if err := validateDocumentRowRefMatchesVisibleRow(*expected[i], row); err != nil {
+				return response, err
+			}
+			rowRef.DocumentID = append(rowRef.DocumentID[:0], expected[i].DocumentID...)
+		}
+		response.Results[i].RowRef = rowRef
+
+		beforeCacheHits, beforeCacheMisses, beforePartLoads, beforePartDecodes := typedColumnCacheCounters(typedColumnCache)
+		typedStart := time.Now()
+		typedValues, err := v.collection.typedColumnPartValuesForVisibleRowAtSnapshotIntoWithCache(v.snapshot, manifestRootID, cfg, row, typedColumnCache, typedScratch)
+		typedElapsed := time.Since(typedStart)
+		if err != nil {
+			return response, err
+		}
+		if len(typedValues.Values) > 0 || columnStoreHasTypedColumnPartOwners(cfg) {
+			response.Stats.TypedColumnRows++
+		}
+		afterCacheHits, afterCacheMisses, afterPartLoads, afterPartDecodes := typedColumnCacheCounters(typedColumnCache)
+		response.Stats.TypedColumnCacheHits += deltaUint64(beforeCacheHits, afterCacheHits)
+		response.Stats.TypedColumnCacheMisses += deltaUint64(beforeCacheMisses, afterCacheMisses)
+		response.Stats.TypedColumnPartLoads += deltaUint64(beforePartLoads, afterPartLoads)
+		response.Stats.TypedColumnPartDecodes += deltaUint64(beforePartDecodes, afterPartDecodes)
+		response.Stats.TypedColumnNanos += typedElapsed.Nanoseconds()
+
+		reconstructStart := time.Now()
+		fullValues, err := mergeColumnReconstructionValuesInto(cfg, row.Values, typedValues.Values, mergeScratch)
+		if err != nil {
+			return response, err
+		}
+		reconstructed, err := reconstructColumnDocumentFromVisibleRowValues(cfg, retained[i], row, fullValues)
+		if err != nil {
+			return response, err
+		}
+		response.Stats.JSONReconstructionNanos += time.Since(reconstructStart).Nanoseconds()
+		response.Stats.JSONReconstructionRows++
+		documentArena = appendDocumentFetchOwnedBytes(documentArena, reconstructed, &response.Results[i])
+		response.Stats.DocumentsFetched++
+		response.Stats.DocumentBytes += uint64(len(response.Results[i].Document))
+	}
+	return response, nil
+}
+
+func appendDocumentFetchOwnedBytes(arena []byte, src []byte, result *DocumentFetchResult) []byte {
+	if result == nil {
+		return arena
+	}
+	start := len(arena)
+	arena = append(arena, src...)
+	result.Document = arena[start:len(arena):len(arena)]
+	return arena
+}
+
+func documentRowRefFromVisibleRow(row columnPhysicalVisibleRow) DocumentRowRef {
+	return DocumentRowRef{
+		DocumentID:        bytes.Clone(row.ID),
+		Generation:        row.Generation,
+		PartID:            row.PartID,
+		RowIndex:          row.RowIndex,
+		AppliedCommandLSN: row.AppliedCommandLSN,
+	}
+}
+
+func validateDocumentRowRefMatchesVisibleRow(ref DocumentRowRef, row columnPhysicalVisibleRow) error {
+	if len(ref.DocumentID) == 0 {
+		return errors.New("collections: document row ref missing document id")
+	}
+	if !bytes.Equal(ref.DocumentID, row.ID) {
+		return fmt.Errorf("collections: document row ref id %q does not match visible row id %q", string(ref.DocumentID), string(row.ID))
+	}
+	if ref.RowIndex < 0 {
+		return fmt.Errorf("collections: document row ref for id %q has negative row index", string(ref.DocumentID))
+	}
+	if ref.RowIndex != row.RowIndex {
+		return fmt.Errorf("collections: document row ref for id %q row_index=%d does not match visible row_index=%d", string(ref.DocumentID), ref.RowIndex, row.RowIndex)
+	}
+	if ref.Generation != 0 && ref.Generation != row.Generation {
+		return fmt.Errorf("collections: document row ref for id %q generation=%d does not match visible generation=%d", string(ref.DocumentID), ref.Generation, row.Generation)
+	}
+	if ref.PartID != 0 && ref.PartID != row.PartID {
+		return fmt.Errorf("collections: document row ref for id %q part_id=%d does not match visible part_id=%d", string(ref.DocumentID), ref.PartID, row.PartID)
+	}
+	if ref.AppliedCommandLSN != 0 && ref.AppliedCommandLSN != row.AppliedCommandLSN {
+		return fmt.Errorf("collections: document row ref for id %q applied_command_lsn=%d does not match visible applied_command_lsn=%d", string(ref.DocumentID), ref.AppliedCommandLSN, row.AppliedCommandLSN)
+	}
+	return nil
+}
+
+func typedColumnCacheCounters(cache *typedColumnPartReconstructionCache) (hits, misses, loads, decodes uint64) {
+	if cache == nil {
+		return 0, 0, 0, 0
+	}
+	return cache.CacheHits, cache.CacheMisses, cache.PartLoads, cache.TypedPartDecodes
+}
+
+func addDocumentMaterializationStatsToVectorStats(dst *VectorIndexSearchStats, src DocumentMaterializationStats) error {
+	if dst == nil {
+		return nil
+	}
+	dst.DocumentsFetched += src.DocumentsFetched
+	dst.DocumentsMissing += src.DocumentsMissing
+	dst.DocumentBytes += src.DocumentBytes
+	dst.DocumentRetainedFetches += src.RetainedPayloadFetches
+	dst.DocumentRetainedBytes += src.RetainedPayloadBytes
+	dst.DocumentVisibilityScans += src.VisibilityScans
+	dst.DocumentVisibilityRowsScanned += src.VisibilityRowsScanned
+	dst.DocumentVisibilityRows += src.VisibilityRows
+	visibilityBytes, err := addInt64ToUint64Metric(dst.DocumentVisibilityPhysicalBytes, src.VisibilityPhysicalBytes, "document visibility physical bytes")
+	if err != nil {
+		return err
+	}
+	dst.DocumentVisibilityPhysicalBytes = visibilityBytes
+	dst.DocumentVisibilityNanos += uint64(maxInt64ForMetric(src.VisibilityNanos, 0))
+	dst.DocumentTypedColumnRows += src.TypedColumnRows
+	dst.DocumentTypedColumnCacheHits += src.TypedColumnCacheHits
+	dst.DocumentTypedColumnCacheMisses += src.TypedColumnCacheMisses
+	dst.DocumentTypedColumnPartLoads += src.TypedColumnPartLoads
+	dst.DocumentTypedColumnPartDecodes += src.TypedColumnPartDecodes
+	dst.DocumentTypedColumnNanos += uint64(maxInt64ForMetric(src.TypedColumnNanos, 0))
+	dst.DocumentJSONReconstructionRows += src.JSONReconstructionRows
+	dst.DocumentJSONReconstructionNanos += uint64(maxInt64ForMetric(src.JSONReconstructionNanos, 0))
+	dst.DocumentRowRefFallbackScans += src.RowRefFallbackScans
+	return nil
+}
+
+func addInt64ToUint64Metric(total uint64, n int64, label string) (uint64, error) {
+	if n < 0 || uint64(n) > ^uint64(0)-total {
+		return 0, fmt.Errorf("collections: %s overflow", label)
+	}
+	return total + uint64(n), nil
+}
+
+func maxInt64ForMetric(n, floor int64) int64 {
+	if n < floor {
+		return floor
+	}
+	return n
+}

--- a/TreeDB/collections/document_materializer.go
+++ b/TreeDB/collections/document_materializer.go
@@ -35,6 +35,8 @@ type DocumentRowRef struct {
 
 // DocumentFetchResult is one materialized document result. ID and Document are
 // response-owned slices. Missing documents have Found=false and Document=nil.
+// RowRef is populated only when typed-storage reconstruction found a visible
+// physical row; it is zero for retained-payload-only results.
 type DocumentFetchResult struct {
 	ID       []byte
 	Document []byte
@@ -214,7 +216,7 @@ func (v *CollectionReadView) fetchDocumentsByID(ids [][]byte, expected []*Docume
 	}
 	var idArena []byte
 	retained := make([][]byte, len(ids))
-	foundIDs := make([][]byte, 0, len(ids))
+	foundCount := 0
 	for i, id := range ids {
 		if len(id) == 0 {
 			return response, fmt.Errorf("collections: document id at position %d cannot be empty", i)
@@ -233,12 +235,15 @@ func (v *CollectionReadView) fetchDocumentsByID(ids [][]byte, expected []*Docume
 		}
 		response.Results[i].Found = true
 		retained[i] = value
-		foundIDs = append(foundIDs, id)
+		foundCount++
 		response.Stats.RetainedPayloadFetches++
 		response.Stats.RetainedPayloadBytes += uint64(len(value))
 	}
-	if len(foundIDs) == 0 {
+	if foundCount == 0 {
 		return response, nil
+	}
+	if expected != nil && !columnStoreCanReconstructDocument(v.catalog.meta) {
+		return response, errors.New("collections: document row ref materialization requires typed-storage reconstruction support")
 	}
 	if !columnStoreCanReconstructDocument(v.catalog.meta) {
 		var documentArena []byte
@@ -350,6 +355,10 @@ func (v *CollectionReadView) fetchColumnStoreDocumentsByID(response DocumentFetc
 
 func appendDocumentFetchOwnedBytes(arena []byte, src []byte, result *DocumentFetchResult) []byte {
 	if result == nil {
+		return arena
+	}
+	if len(src) == 0 {
+		result.Document = []byte{}
 		return arena
 	}
 	start := len(arena)

--- a/TreeDB/collections/document_materializer_test.go
+++ b/TreeDB/collections/document_materializer_test.go
@@ -1,0 +1,249 @@
+package collections
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+)
+
+func TestCollectionReadViewFetchDocumentsByIDColumnReconstructionParity(t *testing.T) {
+	d, col := newDocumentMaterializerTestCollection(t)
+	defer func() { _ = d.Close() }()
+	ids := [][]byte{[]byte("e1"), []byte("e2")}
+	docs := [][]byte{
+		[]byte(`{"row_id":1,"kind":"alpha","score":1.5,"payload":"retained-a"}`),
+		[]byte(`{"row_id":2,"kind":"beta","score":2.5,"payload":"retained-b"}`),
+	}
+	if _, err := col.InsertBatch(ids, docs); err != nil {
+		t.Fatalf("InsertBatch: %v", err)
+	}
+	wantE1, err := col.Get([]byte("e1"))
+	if err != nil {
+		t.Fatalf("Get e1: %v", err)
+	}
+	wantE2, err := col.Get([]byte("e2"))
+	if err != nil {
+		t.Fatalf("Get e2: %v", err)
+	}
+
+	view, err := col.OpenCollectionReadView()
+	if err != nil {
+		t.Fatalf("OpenCollectionReadView: %v", err)
+	}
+	defer func() { _ = view.Close() }()
+	got, err := view.FetchDocumentsByID([][]byte{[]byte("e2"), []byte("missing"), []byte("e1"), []byte("e1")}, DocumentFetchOptions{})
+	if err != nil {
+		t.Fatalf("FetchDocumentsByID: %v", err)
+	}
+	if len(got.Results) != 4 {
+		t.Fatalf("results=%d want 4", len(got.Results))
+	}
+	if !got.Results[0].Found || !bytes.Equal(got.Results[0].Document, wantE2) {
+		t.Fatalf("e2 found=%t doc=%s want %s", got.Results[0].Found, got.Results[0].Document, wantE2)
+	}
+	if got.Results[1].Found || got.Results[1].Document != nil {
+		t.Fatalf("missing result=%+v want not found", got.Results[1])
+	}
+	if !got.Results[2].Found || !bytes.Equal(got.Results[2].Document, wantE1) || !got.Results[3].Found || !bytes.Equal(got.Results[3].Document, wantE1) {
+		t.Fatalf("e1 duplicate docs=%s/%s want %s", got.Results[2].Document, got.Results[3].Document, wantE1)
+	}
+	if got.Stats.DocumentsRequested != 4 || got.Stats.DocumentsFetched != 3 || got.Stats.DocumentsMissing != 1 {
+		t.Fatalf("stats=%+v want requested=4 fetched=3 missing=1", got.Stats)
+	}
+	if got.Stats.RetainedPayloadFetches != 3 || got.Stats.VisibilityScans != 1 || got.Stats.VisibilityRowsScanned != 2 || got.Stats.VisibilityRows != 2 || got.Stats.JSONReconstructionRows != 3 {
+		t.Fatalf("stats=%+v want retained fetches, one visibility scan over two row-asset rows, three reconstructions", got.Stats)
+	}
+	if got.Stats.TypedColumnRows != 3 || got.Stats.TypedColumnPartLoads == 0 || got.Stats.TypedColumnPartDecodes == 0 {
+		t.Fatalf("stats=%+v want typed_column_part reconstruction counters", got.Stats)
+	}
+
+	rowRefFetch, err := view.FetchDocumentsByRowRef([]DocumentRowRef{got.Results[0].RowRef}, DocumentFetchOptions{})
+	if err != nil {
+		t.Fatalf("FetchDocumentsByRowRef: %v", err)
+	}
+	if len(rowRefFetch.Results) != 1 || !rowRefFetch.Results[0].Found || !bytes.Equal(rowRefFetch.Results[0].Document, wantE2) {
+		t.Fatalf("row ref fetch=%+v want e2", rowRefFetch.Results)
+	}
+	badRef := got.Results[0].RowRef
+	badRef.RowIndex++
+	if _, err := view.FetchDocumentsByRowRef([]DocumentRowRef{badRef}, DocumentFetchOptions{}); err == nil || !strings.Contains(err.Error(), "row_index") {
+		t.Fatalf("bad row ref err=%v want row_index mismatch", err)
+	}
+}
+
+func TestCollectionReadViewClosedAndNilFailClosed(t *testing.T) {
+	var nilView *CollectionReadView
+	if _, err := nilView.FetchDocumentsByID([][]byte{[]byte("e1")}, DocumentFetchOptions{}); err == nil || !strings.Contains(err.Error(), "nil collection read view") {
+		t.Fatalf("nil FetchDocumentsByID err=%v want fail closed", err)
+	}
+	if _, err := nilView.FetchDocumentsByRowRef([]DocumentRowRef{{DocumentID: []byte("e1"), RowIndex: 0}}, DocumentFetchOptions{}); err == nil || !strings.Contains(err.Error(), "nil collection read view") {
+		t.Fatalf("nil FetchDocumentsByRowRef err=%v want fail closed", err)
+	}
+
+	d, col := newDocumentMaterializerTestCollection(t)
+	defer func() { _ = d.Close() }()
+	view, err := col.OpenCollectionReadView()
+	if err != nil {
+		t.Fatalf("OpenCollectionReadView: %v", err)
+	}
+	if err := view.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if _, err := view.FetchDocumentsByID([][]byte{[]byte("e1")}, DocumentFetchOptions{}); err == nil || !strings.Contains(err.Error(), "closed") {
+		t.Fatalf("closed FetchDocumentsByID err=%v want fail closed", err)
+	}
+}
+
+func TestCollectionReadViewMissingAndDeletedMatchCollectionGet(t *testing.T) {
+	d, col := newDocumentMaterializerTestCollection(t)
+	defer func() { _ = d.Close() }()
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("e1"), []byte("e2")},
+		[][]byte{
+			[]byte(`{"row_id":1,"kind":"alpha","score":1,"payload":"live"}`),
+			[]byte(`{"row_id":2,"kind":"beta","score":2,"payload":"deleted"}`),
+		},
+	); err != nil {
+		t.Fatalf("InsertBatch: %v", err)
+	}
+	if err := col.Delete([]byte("e2")); err != nil {
+		t.Fatalf("Delete e2: %v", err)
+	}
+	if got, err := col.Get([]byte("e2")); err != nil || got != nil {
+		t.Fatalf("Get deleted=%s err=%v want missing", got, err)
+	}
+	view, err := col.OpenCollectionReadView()
+	if err != nil {
+		t.Fatalf("OpenCollectionReadView: %v", err)
+	}
+	defer func() { _ = view.Close() }()
+	got, err := view.FetchDocumentsByID([][]byte{[]byte("e1"), []byte("e2"), []byte("missing")}, DocumentFetchOptions{})
+	if err != nil {
+		t.Fatalf("FetchDocumentsByID: %v", err)
+	}
+	if !got.Results[0].Found || got.Results[1].Found || got.Results[2].Found {
+		t.Fatalf("results=%+v want only e1 found", got.Results)
+	}
+	if got.Stats.DocumentsFetched != 1 || got.Stats.DocumentsMissing != 2 {
+		t.Fatalf("stats=%+v want one fetched and two missing", got.Stats)
+	}
+}
+
+func TestCollectionReadViewBoundSnapshotIgnoresLaterWrites(t *testing.T) {
+	d, col := newDocumentMaterializerTestCollection(t)
+	defer func() { _ = d.Close() }()
+	oldDoc := []byte(`{"row_id":1,"kind":"old","score":1,"payload":"before"}`)
+	if _, err := col.Insert([]byte("e1"), oldDoc); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+	view, err := col.OpenCollectionReadView()
+	if err != nil {
+		t.Fatalf("OpenCollectionReadView: %v", err)
+	}
+	defer func() { _ = view.Close() }()
+	if err := col.Delete([]byte("e1")); err != nil {
+		t.Fatalf("Delete after read-view open: %v", err)
+	}
+	if live, err := col.Get([]byte("e1")); err != nil || live != nil {
+		t.Fatalf("live Get after delete=%s err=%v want missing", live, err)
+	}
+	got, err := view.FetchDocumentsByID([][]byte{[]byte("e1")}, DocumentFetchOptions{})
+	if err != nil {
+		t.Fatalf("FetchDocumentsByID: %v", err)
+	}
+	if len(got.Results) != 1 || !got.Results[0].Found {
+		t.Fatalf("results=%+v want old snapshot document", got.Results)
+	}
+	want, err := reconstructDocumentMaterializerFixtureDoc(oldDoc)
+	if err != nil {
+		t.Fatalf("reconstruct old fixture: %v", err)
+	}
+	if !bytes.Equal(got.Results[0].Document, want) {
+		t.Fatalf("snapshot document=%s want %s", got.Results[0].Document, want)
+	}
+}
+
+func TestCollectionReadViewResponseDocumentsAreOwned(t *testing.T) {
+	d, col := newDocumentMaterializerTestCollection(t)
+	defer func() { _ = d.Close() }()
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("e1"), []byte("e2")},
+		[][]byte{
+			[]byte(`{"row_id":1,"kind":"alpha","score":1,"payload":"first"}`),
+			[]byte(`{"row_id":2,"kind":"beta","score":2,"payload":"second"}`),
+		},
+	); err != nil {
+		t.Fatalf("InsertBatch: %v", err)
+	}
+	view, err := col.OpenCollectionReadView()
+	if err != nil {
+		t.Fatalf("OpenCollectionReadView: %v", err)
+	}
+	defer func() { _ = view.Close() }()
+	got, err := view.FetchDocumentsByID([][]byte{[]byte("e1"), []byte("e2")}, DocumentFetchOptions{})
+	if err != nil {
+		t.Fatalf("FetchDocumentsByID: %v", err)
+	}
+	secondBefore := append([]byte(nil), got.Results[1].Document...)
+	_ = append(got.Results[0].Document, '!')
+	if !bytes.Equal(got.Results[1].Document, secondBefore) {
+		t.Fatalf("second document changed after appending to first: got %s want %s", got.Results[1].Document, secondBefore)
+	}
+	got.Results[0].Document[0] = 'X'
+	fresh, err := col.Get([]byte("e1"))
+	if err != nil {
+		t.Fatalf("Get e1 after mutating response: %v", err)
+	}
+	if len(fresh) == 0 || fresh[0] == 'X' {
+		t.Fatalf("mutating response document affected stored document: %s", fresh)
+	}
+}
+
+func newDocumentMaterializerTestCollection(t testing.TB) (*backenddb.DB, *Collection) {
+	t.Helper()
+	dir := t.TempDir()
+	if err := backenddb.SaveFormatConfig(dir, backenddb.FormatConfig{RequiredFeatures: []string{backenddb.RequiredFeatureCommandWALV1}}); err != nil {
+		t.Fatalf("SaveFormatConfig: %v", err)
+	}
+	d := openCollectionCommandWALDB(t, dir)
+	cfg := testColumnStoreConfig(nil)
+	cfg.Columns = []ColumnStoreColumn{
+		{Name: "row_id", Path: "row_id", ValueType: ColumnStoreValueInt64, Owner: TypedStorageOwnerRowAsset},
+		{Name: "kind", Path: "kind", ValueType: ColumnStoreValueString, Owner: TypedStorageOwnerColumnPart, Dictionary: true},
+		{Name: "score", Path: "score", ValueType: ColumnStoreValueDouble, Owner: TypedStorageOwnerColumnPart},
+	}
+	cfg.SortKey = nil
+	cfg.AggregateMetadata = nil
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "docs", Options: CollectionOptions{DocumentFormat: DocumentFormatJSON, ColumnStore: cfg}}); err != nil {
+		_ = d.Close()
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	col, err := mgr.OpenCollection("docs")
+	if err != nil {
+		_ = d.Close()
+		t.Fatalf("OpenCollection: %v", err)
+	}
+	return d, col
+}
+
+func reconstructDocumentMaterializerFixtureDoc(doc []byte) ([]byte, error) {
+	cfg := testColumnStoreConfig(nil)
+	cfg.Columns = []ColumnStoreColumn{
+		{Name: "row_id", Path: "row_id", ValueType: ColumnStoreValueInt64, Owner: TypedStorageOwnerRowAsset},
+		{Name: "kind", Path: "kind", ValueType: ColumnStoreValueString, Owner: TypedStorageOwnerColumnPart, Dictionary: true},
+		{Name: "score", Path: "score", ValueType: ColumnStoreValueDouble, Owner: TypedStorageOwnerColumnPart},
+	}
+	cfg.RetainedPayload = ColumnRetainedPayloadNonColumn
+	retained, err := columnRetainedPayloadFromJSONDocument(*cfg, doc)
+	if err != nil {
+		return nil, err
+	}
+	return reconstructColumnJSONDocument(*cfg, retained, []columnDeclaredValue{
+		{Type: ColumnStoreValueInt64, Int64: 1, Present: true},
+		{Type: ColumnStoreValueString, String: "old", Present: true},
+		{Type: ColumnStoreValueDouble, Double: 1, Present: true},
+	})
+}

--- a/TreeDB/collections/document_materializer_test.go
+++ b/TreeDB/collections/document_materializer_test.go
@@ -73,6 +73,35 @@ func TestCollectionReadViewFetchDocumentsByIDColumnReconstructionParity(t *testi
 	}
 }
 
+func TestCollectionReadViewFetchDocumentsByRowRefRequiresTypedStorage(t *testing.T) {
+	dir := t.TempDir()
+	if err := backenddb.SaveFormatConfig(dir, backenddb.FormatConfig{RequiredFeatures: []string{backenddb.RequiredFeatureCommandWALV1}}); err != nil {
+		t.Fatalf("SaveFormatConfig: %v", err)
+	}
+	d := openCollectionCommandWALDB(t, dir)
+	defer func() { _ = d.Close() }()
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "plain", Options: CollectionOptions{DocumentFormat: DocumentFormatJSON}}); err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	col, err := mgr.OpenCollection("plain")
+	if err != nil {
+		t.Fatalf("OpenCollection: %v", err)
+	}
+	if _, err := col.Insert([]byte("e1"), []byte(`{"name":"plain"}`)); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+	view, err := col.OpenCollectionReadView()
+	if err != nil {
+		t.Fatalf("OpenCollectionReadView: %v", err)
+	}
+	defer func() { _ = view.Close() }()
+	_, err = view.FetchDocumentsByRowRef([]DocumentRowRef{{DocumentID: []byte("e1"), RowIndex: 0}}, DocumentFetchOptions{})
+	if err == nil || !strings.Contains(err.Error(), "typed-storage reconstruction") {
+		t.Fatalf("FetchDocumentsByRowRef err=%v want typed-storage reconstruction error", err)
+	}
+}
+
 func TestCollectionReadViewClosedAndNilFailClosed(t *testing.T) {
 	var nilView *CollectionReadView
 	if _, err := nilView.FetchDocumentsByID([][]byte{[]byte("e1")}, DocumentFetchOptions{}); err == nil || !strings.Contains(err.Error(), "nil collection read view") {

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -338,6 +338,8 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/column_query_plan_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 56, occurrences: 68},
 	{path: "TreeDB/collections/column_reconstruction.go", classification: typedStorageLegacyCompatibility, matchingLines: 20, occurrences: 21},
 	{path: "TreeDB/collections/column_semantics.go", classification: typedStorageLegacyCompatibility, matchingLines: 8, occurrences: 8},
+	{path: "TreeDB/collections/document_materializer.go", classification: typedStorageLegacyCompatibility, matchingLines: 3, occurrences: 3},
+	{path: "TreeDB/collections/document_materializer_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 14, occurrences: 14},
 	{path: "TreeDB/collections/column_store.go", classification: typedStorageLegacyCompatibility, matchingLines: 74, occurrences: 116},
 	{path: "TreeDB/collections/column_store_compatibility_api_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 7, occurrences: 9},
 	{path: "TreeDB/collections/column_store_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 173, occurrences: 222},

--- a/TreeDB/collections/vector_index_search.go
+++ b/TreeDB/collections/vector_index_search.go
@@ -85,6 +85,42 @@ type VectorIndexSearchStats struct {
 	ResultFetches uint64 `json:"result_fetches,omitempty"`
 	// DocumentsFetched is the post-top-k document materialization count.
 	DocumentsFetched uint64 `json:"documents_fetched,omitempty"`
+	// DocumentsMissing is the post-top-k materialization miss count.
+	DocumentsMissing uint64 `json:"documents_missing,omitempty"`
+	// DocumentBytes is the materialized response document byte count.
+	DocumentBytes uint64 `json:"document_bytes,omitempty"`
+	// DocumentRetainedFetches counts primary retained-payload fetches for document materialization.
+	DocumentRetainedFetches uint64 `json:"document_retained_fetches,omitempty"`
+	// DocumentRetainedBytes counts retained-payload bytes read for document materialization.
+	DocumentRetainedBytes uint64 `json:"document_retained_bytes,omitempty"`
+	// DocumentVisibilityScans counts batched typed-row visibility scans used by materialization.
+	DocumentVisibilityScans uint64 `json:"document_visibility_scans,omitempty"`
+	// DocumentVisibilityRowsScanned counts typed-row asset rows scanned for materialization.
+	DocumentVisibilityRowsScanned uint64 `json:"document_visibility_rows_scanned,omitempty"`
+	// DocumentVisibilityRows counts visible typed rows found by materialization scans.
+	DocumentVisibilityRows uint64 `json:"document_visibility_rows,omitempty"`
+	// DocumentVisibilityPhysicalBytes counts typed-row physical bytes scanned for materialization.
+	DocumentVisibilityPhysicalBytes uint64 `json:"document_visibility_physical_bytes,omitempty"`
+	// DocumentVisibilityNanos attributes typed-row visibility scan time.
+	DocumentVisibilityNanos uint64 `json:"document_visibility_nanos,omitempty"`
+	// DocumentTypedColumnRows counts materialized rows that consulted typed_column_part storage.
+	DocumentTypedColumnRows uint64 `json:"document_typed_column_rows,omitempty"`
+	// DocumentTypedColumnCacheHits counts typed-column reconstruction cache hits.
+	DocumentTypedColumnCacheHits uint64 `json:"document_typed_column_cache_hits,omitempty"`
+	// DocumentTypedColumnCacheMisses counts typed-column reconstruction cache misses.
+	DocumentTypedColumnCacheMisses uint64 `json:"document_typed_column_cache_misses,omitempty"`
+	// DocumentTypedColumnPartLoads counts typed_column_part asset loads.
+	DocumentTypedColumnPartLoads uint64 `json:"document_typed_column_part_loads,omitempty"`
+	// DocumentTypedColumnPartDecodes counts typed_column_part decodes.
+	DocumentTypedColumnPartDecodes uint64 `json:"document_typed_column_part_decodes,omitempty"`
+	// DocumentTypedColumnNanos attributes typed-column value fetch/decode time.
+	DocumentTypedColumnNanos uint64 `json:"document_typed_column_nanos,omitempty"`
+	// DocumentJSONReconstructionRows counts rows serialized through JSON reconstruction.
+	DocumentJSONReconstructionRows uint64 `json:"document_json_reconstruction_rows,omitempty"`
+	// DocumentJSONReconstructionNanos attributes JSON merge/serialization time.
+	DocumentJSONReconstructionNanos uint64 `json:"document_json_reconstruction_nanos,omitempty"`
+	// DocumentRowRefFallbackScans counts row-ref requests served by the interim target-ID scan path.
+	DocumentRowRefFallbackScans uint64 `json:"document_row_ref_fallback_scans,omitempty"`
 
 	// RowFetches is the per-search count of physical row-reader fetch calls.
 	RowFetches uint64 `json:"row_fetches,omitempty"`
@@ -153,17 +189,18 @@ type VectorIndexSearchResponse struct {
 // searchers. Close and reopen the searcher after writes/rebuilds when callers
 // need the newest column_graph generation.
 type VectorIndexSearcher struct {
-	collection *Collection
-	indexName  string
-	strategy   VectorIndexStrategy
-	path       VectorIndexSearchPath
-	status     VectorIndexStatus
-	snapshot   *backenddb.Snapshot
-	catalog    *collectionCatalog
-	reader     *columnVectorGraphPhysicalRowReader
-	scratch    columnVectorGraphNativeSearchScratch
-	readerLast columnPhysicalRowReaderStats
-	closed     bool
+	collection   *Collection
+	indexName    string
+	strategy     VectorIndexStrategy
+	path         VectorIndexSearchPath
+	status       VectorIndexStatus
+	snapshot     *backenddb.Snapshot
+	catalog      *collectionCatalog
+	reader       *columnVectorGraphPhysicalRowReader
+	documentView *CollectionReadView
+	scratch      columnVectorGraphNativeSearchScratch
+	readerLast   columnPhysicalRowReaderStats
+	closed       bool
 }
 
 // SearchVectorIndex searches a collection vector index through the public
@@ -367,7 +404,6 @@ func (s *VectorIndexSearcher) Search(opts VectorIndexSearcherSearchOptions) (Vec
 	}
 	idBytes := make([]byte, idByteCount)
 	idOffset := 0
-	var documentBytes []byte
 	for i, result := range results {
 		if len(result.ID) > len(idBytes)-idOffset {
 			return response, errors.New("collections: vector index search result id byte accounting mismatch")
@@ -381,26 +417,30 @@ func (s *VectorIndexSearcher) Search(opts VectorIndexSearcherSearchOptions) (Vec
 			Ordinal: result.Ordinal,
 			Score:   result.Score,
 		}
-		if opts.IncludeDocuments {
-			doc, found, err := s.getDocumentAtBoundSnapshot(result.ID)
-			if err != nil {
-				return response, err
+	}
+	if opts.IncludeDocuments {
+		if s.documentView == nil {
+			s.documentView = newCollectionReadViewAtSnapshot(s.collection, s.snapshot, s.catalog, false)
+		}
+		ids := make([][]byte, len(results))
+		for i := range results {
+			ids[i] = results[i].ID
+		}
+		documents, err := s.documentView.FetchDocumentsByID(ids, DocumentFetchOptions{})
+		if err != nil {
+			return response, err
+		}
+		if len(documents.Results) != len(response.Results) {
+			return response, errors.New("collections: vector index document materializer result count mismatch")
+		}
+		for i := range documents.Results {
+			if !documents.Results[i].Found {
+				return response, fmt.Errorf("collections: vector index %q result document %q not found", s.indexName, results[i].ID)
 			}
-			if !found {
-				return response, fmt.Errorf("collections: vector index %q result document %q not found", s.indexName, result.ID)
-			}
-			if documentBytes == nil {
-				capHint, err := multiplyVectorIndexSearchByteTotal(len(doc), len(results), math.MaxInt, "document")
-				if err != nil {
-					return response, err
-				}
-				documentBytes = make([]byte, 0, capHint)
-			}
-			docOffset := len(documentBytes)
-			documentBytes = append(documentBytes, doc...)
-			responseDoc := documentBytes[docOffset:len(documentBytes):len(documentBytes)]
-			response.Results[i].Document = responseDoc
-			response.Stats.DocumentsFetched++
+			response.Results[i].Document = documents.Results[i].Document
+		}
+		if err := addDocumentMaterializationStatsToVectorStats(&response.Stats, documents.Stats); err != nil {
+			return response, err
 		}
 	}
 	return response, nil
@@ -414,27 +454,6 @@ func validateVectorIndexSearchRequest(topK, efSearch int) error {
 		return errors.New("collections: vector index search ef_search cannot be negative")
 	}
 	return nil
-}
-
-// getDocumentAtBoundSnapshot returns snapshot-bound document bytes for immediate
-// use by Search. Search copies them into response-owned storage before exposing
-// documents to callers, matching Collection.Get retention semantics.
-func (s *VectorIndexSearcher) getDocumentAtBoundSnapshot(documentID []byte) ([]byte, bool, error) {
-	if s == nil || s.snapshot == nil || s.catalog == nil || s.collection == nil {
-		return nil, false, errors.New("collections: nil vector index searcher snapshot")
-	}
-	value, found, err := collectionGetAppendAtCatalogRoot(s.snapshot, s.catalog, collectionPrimaryRootName(s.collection.meta.Name), documentID, nil)
-	if err != nil || !found {
-		return nil, found, err
-	}
-	if !columnStoreCanReconstructDocument(s.catalog.meta) {
-		return value, true, nil
-	}
-	reconstructed, err := s.collection.reconstructColumnDocumentAtSnapshot(s.snapshot, s.catalog, documentID, value)
-	if err != nil {
-		return nil, false, err
-	}
-	return reconstructed, true, nil
 }
 
 func vectorIndexSearchResultIDBytes(results []columnVectorGraphNativeSearchResult) (int, error) {
@@ -477,14 +496,22 @@ func (s *VectorIndexSearcher) Close() error {
 	}
 	s.closed = true
 	var closeErr error
+	if s.documentView != nil {
+		if err := s.documentView.Close(); err != nil {
+			closeErr = err
+		}
+		s.documentView = nil
+	}
 	if s.reader == nil {
 		if s.snapshot != nil {
-			closeErr = s.snapshot.Close()
+			if err := s.snapshot.Close(); closeErr == nil && err != nil {
+				closeErr = err
+			}
 			s.snapshot = nil
 		}
 		return closeErr
 	}
-	if err := s.reader.Close(); err != nil {
+	if err := s.reader.Close(); closeErr == nil && err != nil {
 		closeErr = err
 	}
 	if s.snapshot != nil {

--- a/TreeDB/collections/vector_index_search_test.go
+++ b/TreeDB/collections/vector_index_search_test.go
@@ -1130,6 +1130,20 @@ func reportVectorIndexSearchBenchMetricsV4(b *testing.B, n int, stats VectorInde
 		b.ReportMetric(float64(stats.OpenPhysicalBytesRead), "max_open_physical_B")
 	}
 	b.ReportMetric(float64(stats.DocumentsFetched), "docs_fetched/search")
+	b.ReportMetric(float64(stats.DocumentsMissing), "docs_missing/search")
+	b.ReportMetric(float64(stats.DocumentBytes), "doc_B/search")
+	b.ReportMetric(float64(stats.DocumentRetainedFetches), "doc_retained_fetches/search")
+	b.ReportMetric(float64(stats.DocumentRetainedBytes), "doc_retained_B/search")
+	b.ReportMetric(float64(stats.DocumentVisibilityScans), "doc_visibility_scans/search")
+	b.ReportMetric(float64(stats.DocumentVisibilityRowsScanned), "doc_visibility_rows_scanned/search")
+	b.ReportMetric(float64(stats.DocumentVisibilityRows), "doc_visibility_rows/search")
+	b.ReportMetric(float64(stats.DocumentVisibilityPhysicalBytes), "doc_visibility_physical_B/search")
+	b.ReportMetric(float64(stats.DocumentTypedColumnRows), "doc_typed_column_rows/search")
+	b.ReportMetric(float64(stats.DocumentTypedColumnCacheHits), "doc_typed_column_cache_hits/search")
+	b.ReportMetric(float64(stats.DocumentTypedColumnCacheMisses), "doc_typed_column_cache_misses/search")
+	b.ReportMetric(float64(stats.DocumentTypedColumnPartLoads), "doc_typed_column_part_loads/search")
+	b.ReportMetric(float64(stats.DocumentTypedColumnPartDecodes), "doc_typed_column_part_decodes/search")
+	b.ReportMetric(float64(stats.DocumentJSONReconstructionRows), "doc_json_reconstruction_rows/search")
 }
 
 var vectorSearchBenchSinkOrdinalV4 int


### PR DESCRIPTION
## Objective

Closes #1872 by adding a generic, closeable, snapshot-bound typed-storage document materializer/read-view and routing column_graph vector `IncludeDocuments` through it.

## Scope / non-goals

Includes:
- `CollectionReadView` with `FetchDocumentsByID` and `FetchDocumentsByRowRef` API seam.
- Snapshot/catalog-bound retained payload + typed_row_asset + typed_column_part reconstruction.
- Response-owned materialized document bytes, including present-but-empty documents.
- Vector final document fetch through the generic materializer.
- Materialization counters for retained fetch, typed-row visibility scan, typed-column part fetch/decode/cache, and JSON reconstruction.

Excludes/deferred:
- #1873 mmap-backed materializer asset lifecycle.
- #1874 true row-locator O(topK) point fetch. `FetchDocumentsByRowRef` validates refs and uses the interim batched target-ID scan path.
- #1875 projection-aware fetch.
- #1876 retained-payload-full policy evaluation.
- Graph traversal/scoring changes.

## Design

- `OpenCollectionReadView` flushes current buffered writes, acquires one DB snapshot, and binds the collection catalog/root visibility for the view lifetime.
- Vector searchers create/use a read view bound to the same snapshot they already hold, so prepared searchers keep old-snapshot document visibility after later writes.
- `FetchDocumentsByID` preserves input order and duplicates, returns `Found=false` for missing/deleted documents, and batch-scans target IDs once for typed-storage reconstruction.
- `FetchDocumentsByRowRef` is a product seam for later row-locator work; this PR validates row refs against the visible row discovered by ID scan. If typed-storage reconstruction is unavailable, row-ref materialization fails closed instead of returning unvalidated retained payloads.
- Returned IDs/documents are cap-isolated response-owned slices. `RowRef` is populated only when typed-storage reconstruction found a visible physical row; it remains zero for retained-payload-only results.

## Copied/Adapted From Old Stack

- Copied: none.
- Adapted: existing `ScanDocumentsFunc` batched target-ID reconstruction pattern and existing column reconstruction helpers.
- Oracle/comparator only: existing vector IncludeDocuments tests/benchmarks.
- Quarantined/not copied: no vector-specific document cache, no mmap lifecycle, no row-locator point fetch.

## Path Identity

- Native reader: unchanged `column_graph_native_reader` graph search; docs are fetched only after top-k.
- Decoded comparator: unchanged/not used by this PR.
- Legacy/native vector index: unchanged fail-closed behavior for non-column_graph public native-reader search.
- Unsupported/fail-closed: nil/closed read views fail closed; stale/mismatched row refs fail closed; row-ref requests without typed-storage reconstruction fail closed.

## Base And Dependency State

- Base branch: `origin/main`
- Base commit: `46187ba4ce510f6e17e6e8f5ec9acc1e4acec23f`
- Latest PR head tested: `46ac8d8e2d1113b1d2ccd5b1679c3482a08d5c4c`
- Dependency sequence: first PR in #1872 -> #1873 -> #1874 -> #1875 -> #1876; no predecessor merged.

## Test Plan Start

Planned before implementation:
- Add read-view tests for nil/closed, missing/deleted, snapshot binding, typed row + typed column reconstruction parity, and response ownership.
- Preserve existing vector IncludeDocuments tests and snapshot-bound searcher document behavior.
- Update typed-storage naming allowlist for new compatibility references.

## Test Plan Close

Commands run on latest head:

```sh
GOWORK=off go test ./TreeDB/collections -run 'TestCollectionReadView|Test.*VectorIndex.*Documents|TestOpenVectorIndexSearcherFetchesDocumentsFromBoundSnapshotV4|TestTypedColumnPublicationRetainedPayloadPolicyMatrix|TestTypedStorageLegacyNameAllowlistIsComplete' -count=1
GOWORK=off go test ./TreeDB/collections -count=1
GOWORK=off go vet ./TreeDB/collections
./scripts/check_read_snapshot_guardrail.sh
```

All passed locally on Apple M3 / darwin arm64. Latest-head CI is expected to be the source of truth for mergeability.

## Performance Plan Start

Baseline command, before implementation, on clean base commit `46187ba4ce510f6e17e6e8f5ec9acc1e4acec23f`:

```sh
GOWORK=off go test ./TreeDB/collections -run '^$' \
  -bench 'BenchmarkSearchVectorIndexColumnGraphNativeReader(V4|WithDocumentsV4)$|BenchmarkOpenVectorIndexSearcherColumnGraphNativeReaderV4$' \
  -benchmem -count=3
```

Fixture: existing 1024-row / 128-dim / topK=10 column_graph benchmark fixture. Setup/open/decode remains in the public one-shot benchmarks; prepared searcher benchmark times steady-state graph search.

## Performance Plan Close

Candidate command (same shape/hardware/fixture) on `46ac8d8e2d1113b1d2ccd5b1679c3482a08d5c4c`:

```sh
GOWORK=off go test ./TreeDB/collections -run '^$' \
  -bench 'BenchmarkSearchVectorIndexColumnGraphNativeReader(V4|WithDocumentsV4)$|BenchmarkOpenVectorIndexSearcherColumnGraphNativeReaderV4$' \
  -benchmem -count=3
```

Artifacts:
- baseline: `/tmp/1872_baseline_20260525_205423/vector_doc_baseline.txt`
- candidate: `/tmp/1872_candidate_reviewfix_20260525_214358/vector_doc_candidate.txt`
- baseline profile: `/tmp/1872_profiles_baseline_20260525_211741/{cpu,mem}_top.txt`
- candidate profile: `/tmp/1872_profiles_candidate_reviewfix_20260525_214434/{cpu,mem}_top.txt`

Median of 3 local runs:

| Benchmark | Branch/commit | ns/op | ops/sec | B/op | allocs/op | docs/search | materializer counters | Notes |
| --- | --- | ---: | ---: | ---: | ---: | ---: | --- | --- |
| `BenchmarkSearchVectorIndexColumnGraphNativeReaderV4` | base `46187ba` | 299,910 | 3,334 | 894,423 | 334 | 0 | n/a | public one-shot graph-only |
| same | PR `46ac8d8` | 286,994 | 3,484 | 884,832 | 334 | 0 | all doc counters 0 | graph-only allocation unchanged |
| `BenchmarkOpenVectorIndexSearcherColumnGraphNativeReaderV4` | base `46187ba` | 26,320 | 37,994 | 9,688 | 214 | 0 | n/a | prepared graph-only hot loop |
| same | PR `46ac8d8` | 25,734 | 38,859 | 9,688 | 214 | 0 | all doc counters 0 | hot loop unchanged |
| `BenchmarkSearchVectorIndexColumnGraphNativeReaderWithDocumentsV4` | base `46187ba` | 2,843,249 | 352 | 6,496,151 | 11,548 | 10 | old path had no materializer counters | per-result reconstruction scans |
| same | PR `46ac8d8` | 645,941 | 1,548 | 2,380,819 | 1,756 | 10 | `doc_visibility_scans=1`, `doc_visibility_rows_scanned=1024`, `doc_visibility_rows=10`, `doc_visibility_physical_B=661823`, `doc_json_reconstruction_rows=10`, `doc_B=13636` | one batched target-ID scan; row-locator point fetch deferred to #1874 |

Profile summary:
- Baseline CPU: dominated by syscall/open/read/close (`syscall.syscall` 69.7% flat, `syscall.syscall6` 9.5% flat) from repeated per-result reconstruction scans.
- Candidate CPU remains syscall-heavy, consistent with #1873 mmap/lifecycle being deferred, but total op time is much lower because document reconstruction is batched.
- Baseline allocation profile: largest flat allocator was repeated full-row vector decode (`manifestCursor.float32SliceAfterLengthWithEncoding`, 77.4%).
- Candidate allocation profile: largest materializer-specific allocators are the one visibility index over target rows and response document arena.

## AI Review Loop

- Internal xhigh Pi review: PASS on implementation head; no blocking findings.
- Copilot: reviewed latest diff and left two comments; both addressed in `46ac8d8` (remove unnecessary `foundIDs`, document `RowRef` population semantics). Re-requested after the review-fix push.
- CodeRabbit: reviewed and left two actionable comments; both addressed in `46ac8d8` (fail closed when row-ref validation cannot run, preserve present-but-empty non-nil documents). Re-requested after the review-fix push.
- Codex: initial review said no major issues; re-requested after the review-fix push.
- Unresolved threads: none at body update time.

## Risks / follow-ups

- The interim #1872 implementation still scans the typed-row asset once per fetch call (`doc_visibility_rows_scanned=1024` in the benchmark). #1874 owns true row-locator O(topK) fetch.
- Remaining syscall/open/read/close profile is expected and deferred to #1873 mmap-backed materializer asset lifecycle.
- Projection and retained-payload policy tradeoffs intentionally remain in #1875/#1876.
