### PR TITLE
treedb: fuse dictionary count distinct reducer

### DIFF
--- a/TreeDB/collections/column_dictionary_query.go
+++ b/TreeDB/collections/column_dictionary_query.go
@@ -652,7 +652,9 @@ func columnDictionaryCodeSnapshotBytes(view columnPhysicalScanSnapshotView, byPa
 func (r *columnDictionaryCodeGroupCountDistinctRunner) run(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest) ColumnPhysicalQueryResult {
 	start := time.Now()
 	clear(r.groupCounts)
-	clear(r.groupDistinctCounts)
+	if r.combined {
+		clear(r.groupDistinctCounts)
+	}
 	clear(r.seen)
 	rows := 0
 	matched := 0

--- a/TreeDB/collections/column_dictionary_query.go
+++ b/TreeDB/collections/column_dictionary_query.go
@@ -31,8 +31,10 @@ type columnDictionaryCodeGroupCountRunner struct {
 type columnDictionaryCodeGroupCountDistinctRunner struct {
 	groupColumn          string
 	distinctColumn       string
+	combined             bool
 	groupDict            []string
 	groupCounts          []int
+	groupDistinctCounts  []int
 	seen                 []uint64
 	wordsPerGroup        int
 	assets               []columnDictionaryCodeGroupCountDistinctAsset
@@ -365,7 +367,7 @@ func runColumnDictionaryCodeGroupCountOneShot(view columnPhysicalScanSnapshotVie
 }
 
 func prepareColumnDictionaryCodeGroupCountDistinctRunner(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest, readCache *columnPhysicalAssetReadCache) (*columnDictionaryCodeGroupCountDistinctRunner, error) {
-	if req.Kind != ColumnPhysicalQueryGroupCountDistinct || req.GroupColumn == "" || req.DistinctColumn == "" || view.MutationParts != 0 {
+	if (req.Kind != ColumnPhysicalQueryGroupCountDistinct && req.Kind != ColumnPhysicalQueryGroupCountAndDistinct) || req.GroupColumn == "" || req.DistinctColumn == "" || view.MutationParts != 0 {
 		return nil, nil
 	}
 	if req.GroupColumn == req.DistinctColumn {
@@ -397,6 +399,7 @@ func prepareColumnDictionaryCodeGroupCountDistinctRunner(view columnPhysicalScan
 	runner := &columnDictionaryCodeGroupCountDistinctRunner{
 		groupColumn:    req.GroupColumn,
 		distinctColumn: req.DistinctColumn,
+		combined:       req.Kind == ColumnPhysicalQueryGroupCountAndDistinct,
 		assets:         make([]columnDictionaryCodeGroupCountDistinctAsset, 0, len(view.AssetRefs)),
 	}
 	predicateAssets, predicateBytes, err := prepareColumnDictionaryPredicateAssets(view, req, readCache)
@@ -570,6 +573,9 @@ func prepareColumnDictionaryCodeGroupCountDistinctRunner(view columnPhysicalScan
 	}
 	runner.wordsPerGroup = wordsPerGroup
 	runner.groupCounts = make([]int, len(runner.groupDict))
+	if runner.combined {
+		runner.groupDistinctCounts = make([]int, len(runner.groupDict))
+	}
 	runner.seen = make([]uint64, totalWords)
 	runner.resultGroups = make([]ColumnPhysicalQueryGroup, 0, len(runner.groupDict))
 	return runner, nil
@@ -646,6 +652,7 @@ func columnDictionaryCodeSnapshotBytes(view columnPhysicalScanSnapshotView, byPa
 func (r *columnDictionaryCodeGroupCountDistinctRunner) run(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest) ColumnPhysicalQueryResult {
 	start := time.Now()
 	clear(r.groupCounts)
+	clear(r.groupDistinctCounts)
 	clear(r.seen)
 	rows := 0
 	matched := 0
@@ -659,12 +666,19 @@ func (r *columnDictionaryCodeGroupCountDistinctRunner) run(view columnPhysicalSc
 			if predicates != nil && !predicates.matches(rowIdx) {
 				continue
 			}
+			if r.combined {
+				r.groupCounts[groupCode]++
+			}
 			distinctCode := asset.distinctCodes[rowIdx]
 			seenIdx := int(groupCode)*r.wordsPerGroup + int(distinctCode/64)
 			mask := uint64(1) << (distinctCode & 63)
 			if r.seen[seenIdx]&mask == 0 {
 				r.seen[seenIdx] |= mask
-				r.groupCounts[groupCode]++
+				if r.combined {
+					r.groupDistinctCounts[groupCode]++
+				} else {
+					r.groupCounts[groupCode]++
+				}
 			}
 			matched++
 		}
@@ -677,10 +691,11 @@ func (r *columnDictionaryCodeGroupCountDistinctRunner) run(view columnPhysicalSc
 		if count == 0 {
 			continue
 		}
-		r.resultGroups = append(r.resultGroups, ColumnPhysicalQueryGroup{
-			Key:   r.groupDict[code],
-			Count: count,
-		})
+		group := ColumnPhysicalQueryGroup{Key: r.groupDict[code], Count: count}
+		if r.combined {
+			group.DistinctCount = r.groupDistinctCounts[code]
+		}
+		r.resultGroups = append(r.resultGroups, group)
 	}
 	sortColumnPhysicalQueryGroupsByKey(r.resultGroups)
 	diag := columnPhysicalQueryDiagnosticsFromScan(view.Diagnostics)

--- a/TreeDB/collections/column_physical_query.go
+++ b/TreeDB/collections/column_physical_query.go
@@ -229,6 +229,11 @@ func (c *Collection) PrepareColumnPhysicalQuery(req ColumnPhysicalQueryRequest) 
 			return nil, fmt.Errorf("%w: prepared aggregate metadata query requires metadata assets", ErrColumnQueryPlanUnsupported)
 		}
 	} else if !columnPhysicalQueryHasPredicates(req) && req.Kind != ColumnPhysicalQueryGroupCountAndDistinct {
+		// ColumnPhysicalQueryGroupCountAndDistinct intentionally skips the
+		// columnPhysicalQueryHasPredicates/no-predicate direct executor path:
+		// newColumnPhysicalQueryExecutor does not implement fused q2 semantics, so
+		// prepared execution must use the dictionary sidecar runner unless direct
+		// fused support is added and validated here.
 		exec, err = newColumnPhysicalQueryExecutor(view.Config, req)
 		if err != nil {
 			_ = readCache.close()

--- a/TreeDB/collections/column_physical_query.go
+++ b/TreeDB/collections/column_physical_query.go
@@ -44,8 +44,10 @@ type ColumnPhysicalQueryRequest struct {
 	ColumnAssetReadIntegrity ColumnAssetReadIntegrity
 }
 
-// ColumnPhysicalQueryGroup is one reduced result row. Count is populated for
-// count-style queries; Int64 is populated for min/max/span-style queries.
+// ColumnPhysicalQueryGroup is one reduced result row. Key is the group key.
+// Count is populated for count-style queries and remains the distinct count for
+// group_count_distinct. DistinctCount is populated by group_count_and_distinct;
+// Int64 is populated for min/max/span-style queries.
 type ColumnPhysicalQueryGroup struct {
 	Key           string
 	Count         int
@@ -226,7 +228,7 @@ func (c *Collection) PrepareColumnPhysicalQuery(req ColumnPhysicalQueryRequest) 
 			_ = readCache.close()
 			return nil, fmt.Errorf("%w: prepared aggregate metadata query requires metadata assets", ErrColumnQueryPlanUnsupported)
 		}
-	} else if !columnPhysicalQueryHasPredicates(req) {
+	} else if !columnPhysicalQueryHasPredicates(req) && req.Kind != ColumnPhysicalQueryGroupCountAndDistinct {
 		exec, err = newColumnPhysicalQueryExecutor(view.Config, req)
 		if err != nil {
 			_ = readCache.close()
@@ -259,6 +261,10 @@ func (c *Collection) PrepareColumnPhysicalQuery(req ColumnPhysicalQueryRequest) 
 	if err != nil {
 		_ = readCache.close()
 		return nil, err
+	}
+	if req.Kind == ColumnPhysicalQueryGroupCountAndDistinct && dictDistinct == nil {
+		_ = readCache.close()
+		return nil, fmt.Errorf("%w: fused count-distinct physical query requires dictionary sidecar reducers", ErrColumnQueryPlanUnsupported)
 	}
 	if columnPhysicalQueryHasPredicates(req) && dictCount == nil && dictDistinct == nil && dictInt64 == nil {
 		_ = readCache.close()

--- a/TreeDB/collections/column_physical_query.go
+++ b/TreeDB/collections/column_physical_query.go
@@ -135,11 +135,30 @@ type ColumnPhysicalQueryRunner struct {
 
 var errColumnPhysicalScanCancelled = errors.New("collections: physical column scan cancelled")
 
+func validateColumnPhysicalGroupCountAndDistinctRequest(req ColumnPhysicalQueryRequest) error {
+	if req.Kind != ColumnPhysicalQueryGroupCountAndDistinct {
+		return nil
+	}
+	if req.GroupColumn == "" {
+		return fmt.Errorf("%w: physical column query group column is required", ErrColumnQueryPlanUnsupported)
+	}
+	if req.DistinctColumn == "" {
+		return fmt.Errorf("%w: physical column query distinct column is required", ErrColumnQueryPlanUnsupported)
+	}
+	if req.GroupColumn == req.DistinctColumn {
+		return fmt.Errorf("%w: physical column query group and distinct columns must differ", ErrColumnQueryPlanUnsupported)
+	}
+	return nil
+}
+
 // RunColumnPhysicalQuery executes an explicit serial physical column query over
 // the recovery-authoritative manifest. Insert-only manifests use the direct
 // scanner path; mutation-bearing manifests fall back to the M13C visibility
 // overlay before reducing.
 func (c *Collection) RunColumnPhysicalQuery(req ColumnPhysicalQueryRequest) (ColumnPhysicalQueryResult, error) {
+	if err := validateColumnPhysicalGroupCountAndDistinctRequest(req); err != nil {
+		return ColumnPhysicalQueryResult{}, err
+	}
 	mutationParts, err := c.columnPhysicalQueryMutationPartsHint()
 	if err != nil {
 		return ColumnPhysicalQueryResult{}, err
@@ -187,6 +206,9 @@ func (c *Collection) RunColumnPhysicalQuery(req ColumnPhysicalQueryRequest) (Col
 // until Close and fail-closes for mutation-bearing manifests or unsupported
 // query shapes rather than silently changing semantics.
 func (c *Collection) PrepareColumnPhysicalQuery(req ColumnPhysicalQueryRequest) (*ColumnPhysicalQueryRunner, error) {
+	if err := validateColumnPhysicalGroupCountAndDistinctRequest(req); err != nil {
+		return nil, err
+	}
 	view, closeView, err := c.prepareColumnPhysicalScanSnapshotViewWithSidecars(columnManifestScanSidecarsForPhysicalQuery(req))
 	if err != nil {
 		if closeView != nil {
@@ -536,6 +558,9 @@ func (c *Collection) scanColumnPhysicalQueryDirectInSnapshotViewWithReadCache(
 // Mutation-bearing manifests stay fail-closed until partitioned visibility
 // reconstruction is available.
 func (c *Collection) RunColumnPhysicalQueryParallel(req ColumnPhysicalQueryRequest, maxWorkers int) (ColumnPhysicalQueryResult, error) {
+	if err := validateColumnPhysicalGroupCountAndDistinctRequest(req); err != nil {
+		return ColumnPhysicalQueryResult{}, err
+	}
 	if columnPhysicalQueryHasPredicates(req) {
 		return ColumnPhysicalQueryResult{}, fmt.Errorf("%w: parallel physical predicates require partitioned dictionary sidecar execution", ErrColumnQueryPlanUnsupported)
 	}

--- a/TreeDB/collections/column_physical_query.go
+++ b/TreeDB/collections/column_physical_query.go
@@ -16,12 +16,13 @@ type ColumnPhysicalQueryKind string
 
 const (
 	// ColumnPhysicalQueryGroupCount counts rows by a string group column.
-	ColumnPhysicalQueryGroupCount         ColumnPhysicalQueryKind = "group_count"
-	ColumnPhysicalQueryGroupCountDistinct ColumnPhysicalQueryKind = "group_count_distinct"
-	ColumnPhysicalQueryHourCount          ColumnPhysicalQueryKind = "hour_count"
-	ColumnPhysicalQueryGroupMinInt64      ColumnPhysicalQueryKind = "group_min_int64"
-	ColumnPhysicalQueryGroupMaxInt64      ColumnPhysicalQueryKind = "group_max_int64"
-	ColumnPhysicalQueryGroupInt64Span     ColumnPhysicalQueryKind = "group_int64_span"
+	ColumnPhysicalQueryGroupCount            ColumnPhysicalQueryKind = "group_count"
+	ColumnPhysicalQueryGroupCountDistinct    ColumnPhysicalQueryKind = "group_count_distinct"
+	ColumnPhysicalQueryGroupCountAndDistinct ColumnPhysicalQueryKind = "group_count_and_distinct"
+	ColumnPhysicalQueryHourCount             ColumnPhysicalQueryKind = "hour_count"
+	ColumnPhysicalQueryGroupMinInt64         ColumnPhysicalQueryKind = "group_min_int64"
+	ColumnPhysicalQueryGroupMaxInt64         ColumnPhysicalQueryKind = "group_max_int64"
+	ColumnPhysicalQueryGroupInt64Span        ColumnPhysicalQueryKind = "group_int64_span"
 )
 
 const (
@@ -46,9 +47,10 @@ type ColumnPhysicalQueryRequest struct {
 // ColumnPhysicalQueryGroup is one reduced result row. Count is populated for
 // count-style queries; Int64 is populated for min/max/span-style queries.
 type ColumnPhysicalQueryGroup struct {
-	Key   string
-	Count int
-	Int64 int64
+	Key           string
+	Count         int
+	DistinctCount int
+	Int64         int64
 }
 
 // ColumnPhysicalQueryDiagnostics reports scan and reduce work for a physical
@@ -645,7 +647,7 @@ func columnManifestScanSidecarsForPhysicalQuery(req ColumnPhysicalQueryRequest) 
 		switch req.Kind {
 		case ColumnPhysicalQueryGroupCount:
 			return columnManifestScanSidecarFilter{DictionaryCodes: true, DictionaryColumn: req.GroupColumn}
-		case ColumnPhysicalQueryGroupCountDistinct:
+		case ColumnPhysicalQueryGroupCountDistinct, ColumnPhysicalQueryGroupCountAndDistinct:
 			return columnManifestScanSidecarFilter{DictionaryCodes: true, DictionaryColumn: req.GroupColumn, DictionaryColumn2: req.DistinctColumn}
 		case ColumnPhysicalQueryHourCount:
 			return columnManifestScanSidecarFilter{Int64Values: true, Int64Column: req.ValueColumn}
@@ -674,7 +676,7 @@ func columnManifestScanSidecarsForPhysicalQuery(req ColumnPhysicalQueryRequest) 
 	switch req.Kind {
 	case ColumnPhysicalQueryGroupCount:
 		addDictionaryColumn(req.GroupColumn)
-	case ColumnPhysicalQueryGroupCountDistinct:
+	case ColumnPhysicalQueryGroupCountDistinct, ColumnPhysicalQueryGroupCountAndDistinct:
 		addDictionaryColumn(req.GroupColumn)
 		addDictionaryColumn(req.DistinctColumn)
 	case ColumnPhysicalQueryHourCount:
@@ -741,7 +743,7 @@ func (c *Collection) runColumnPhysicalQueryInSnapshotView(view columnPhysicalSca
 
 func (c *Collection) runColumnPhysicalQueryDictionaryCodesInSnapshotView(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest) (ColumnPhysicalQueryResult, bool, error) {
 	if req.AggregateMetadataName != "" || view.MutationParts != 0 ||
-		(req.Kind != ColumnPhysicalQueryGroupCount && req.Kind != ColumnPhysicalQueryGroupCountDistinct) {
+		(req.Kind != ColumnPhysicalQueryGroupCount && req.Kind != ColumnPhysicalQueryGroupCountDistinct && req.Kind != ColumnPhysicalQueryGroupCountAndDistinct) {
 		return ColumnPhysicalQueryResult{}, false, nil
 	}
 	readCache, err := newColumnPhysicalAssetReadCacheWithIntegrity(view.ColumnAssetRootDir, view.AssetNamespace, req.ColumnAssetReadIntegrity)

--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -2071,6 +2071,26 @@ func TestColumnPhysicalQueryGroupCountAndDistinctFused1870(t *testing.T) {
 			t.Fatalf("RunColumnPhysicalQueryParallel fused q2 err=%v want ErrColumnQueryPlanUnsupported", err)
 		}
 	})
+	t.Run("invalid requests fail with precise validation", func(t *testing.T) {
+		for _, tc := range []struct {
+			name string
+			req  ColumnPhysicalQueryRequest
+			want string
+		}{
+			{name: "missing group", req: ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCountAndDistinct, DistinctColumn: "did"}, want: "group column is required"},
+			{name: "missing distinct", req: ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCountAndDistinct, GroupColumn: "event"}, want: "distinct column is required"},
+			{name: "same columns", req: ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCountAndDistinct, GroupColumn: "event", DistinctColumn: "event"}, want: "group and distinct columns must differ"},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				if _, err := collection.PrepareColumnPhysicalQuery(tc.req); !errors.Is(err, ErrColumnQueryPlanUnsupported) || !strings.Contains(err.Error(), tc.want) {
+					t.Fatalf("PrepareColumnPhysicalQuery err=%v want ErrColumnQueryPlanUnsupported containing %q", err, tc.want)
+				}
+				if _, err := collection.RunColumnPhysicalQuery(tc.req); !errors.Is(err, ErrColumnQueryPlanUnsupported) || !strings.Contains(err.Error(), tc.want) {
+					t.Fatalf("RunColumnPhysicalQuery err=%v want ErrColumnQueryPlanUnsupported containing %q", err, tc.want)
+				}
+			})
+		}
+	})
 	t.Run("prepared", func(t *testing.T) {
 		runner, err := collection.PrepareColumnPhysicalQuery(req)
 		if err != nil {

--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -2020,6 +2020,63 @@ func TestColumnPhysicalQueryDictionaryPredicatesJSONBenchShapes1869(t *testing.T
 	}
 }
 
+func TestColumnPhysicalQueryGroupCountAndDistinctFused1870(t *testing.T) {
+	events := []columnPhysicalPredicateEvent1869{
+		{ID: "e1", Kind: "commit", Operation: "create", Event: "post", Did: "did_a", TimeUS: 1},
+		{ID: "e2", Kind: "commit", Operation: "create", Event: "post", Did: "did_a", TimeUS: 2},
+		{ID: "e3", Kind: "commit", Operation: "create", Event: "post", Did: "did_b", TimeUS: 3},
+		{ID: "e4", Kind: "commit", Operation: "create", Event: "like", Did: "did_a", TimeUS: 4},
+		{ID: "e5", Kind: "identity", Operation: "create", Event: "post", Did: "did_c", TimeUS: 5},
+	}
+	collection, closeFn := openColumnPhysicalPredicateFixture1869(t, events)
+	defer closeFn()
+
+	req := ColumnPhysicalQueryRequest{
+		Kind:           ColumnPhysicalQueryGroupCountAndDistinct,
+		GroupColumn:    "event",
+		DistinctColumn: "did",
+		Predicates: []ColumnPhysicalQueryPredicate{
+			{Column: "kind", Value: "commit"},
+			{Column: "operation", Value: "create"},
+		},
+	}
+	wantCounts := map[string]int{"like": 1, "post": 3}
+	wantDistinct := map[string]int{"like": 1, "post": 2}
+	for _, run := range []struct {
+		name string
+		fn   func() (ColumnPhysicalQueryResult, error)
+	}{
+		{name: "one-shot", fn: func() (ColumnPhysicalQueryResult, error) { return collection.RunColumnPhysicalQuery(req) }},
+		{name: "prepared", fn: func() (ColumnPhysicalQueryResult, error) {
+			runner, err := collection.PrepareColumnPhysicalQuery(req)
+			if err != nil {
+				return ColumnPhysicalQueryResult{}, err
+			}
+			defer func() { _ = runner.Close() }()
+			return runner.Run()
+		}},
+	} {
+		t.Run(run.name, func(t *testing.T) {
+			result, err := run.fn()
+			if err != nil {
+				t.Fatalf("%s fused q2: %v", run.name, err)
+			}
+			gotCounts := make(map[string]int, len(result.Groups))
+			gotDistinct := make(map[string]int, len(result.Groups))
+			for _, group := range result.Groups {
+				gotCounts[group.Key] = group.Count
+				gotDistinct[group.Key] = group.DistinctCount
+			}
+			if !reflect.DeepEqual(gotCounts, wantCounts) || !reflect.DeepEqual(gotDistinct, wantDistinct) {
+				t.Fatalf("fused groups counts=%v distinct=%v want counts=%v distinct=%v full=%+v", gotCounts, gotDistinct, wantCounts, wantDistinct, result.Groups)
+			}
+			if result.Diagnostics.RowsScanned != len(events) || result.Diagnostics.RowsMatched != 4 || result.Diagnostics.ReduceRows != 4 {
+				t.Fatalf("diagnostics=%+v want scanned=%d matched/reduced=4", result.Diagnostics, len(events))
+			}
+		})
+	}
+}
+
 func TestColumnPhysicalQueryDictionaryPredicatesAbsentLiteralEmpty1869(t *testing.T) {
 	events := []columnPhysicalPredicateEvent1869{
 		{ID: "e1", Kind: "commit", Operation: "create", Event: "app.bsky.feed.post", Did: "did_a", TimeUS: 1},
@@ -2119,6 +2176,7 @@ func BenchmarkColumnPhysicalQueryDictionaryPredicates1869(b *testing.B) {
 	}{
 		{name: "q2_count", req: ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount, GroupColumn: "event", Predicates: commitCreate}},
 		{name: "q2_distinct", req: ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCountDistinct, GroupColumn: "event", DistinctColumn: "did", Predicates: commitCreate}},
+		{name: "q2_fused_count_distinct", req: ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCountAndDistinct, GroupColumn: "event", DistinctColumn: "did", Predicates: commitCreate}},
 		{name: "q4_min", req: ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupMinInt64, GroupColumn: "did", ValueColumn: "time_us", Predicates: postCreate}},
 		{name: "q5_span", req: ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupInt64Span, GroupColumn: "did", ValueColumn: "time_us", Predicates: postCreate}},
 	}

--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -2065,6 +2065,12 @@ func TestColumnPhysicalQueryGroupCountAndDistinctFused1870(t *testing.T) {
 		}
 		assertFused(t, result)
 	})
+	t.Run("parallel fail closed", func(t *testing.T) {
+		_, err := collection.RunColumnPhysicalQueryParallel(req, 4)
+		if !errors.Is(err, ErrColumnQueryPlanUnsupported) {
+			t.Fatalf("RunColumnPhysicalQueryParallel fused q2 err=%v want ErrColumnQueryPlanUnsupported", err)
+		}
+	})
 	t.Run("prepared", func(t *testing.T) {
 		runner, err := collection.PrepareColumnPhysicalQuery(req)
 		if err != nil {

--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -2042,39 +2042,68 @@ func TestColumnPhysicalQueryGroupCountAndDistinctFused1870(t *testing.T) {
 	}
 	wantCounts := map[string]int{"like": 1, "post": 3}
 	wantDistinct := map[string]int{"like": 1, "post": 2}
-	for _, run := range []struct {
-		name string
-		fn   func() (ColumnPhysicalQueryResult, error)
-	}{
-		{name: "one-shot", fn: func() (ColumnPhysicalQueryResult, error) { return collection.RunColumnPhysicalQuery(req) }},
-		{name: "prepared", fn: func() (ColumnPhysicalQueryResult, error) {
-			runner, err := collection.PrepareColumnPhysicalQuery(req)
-			if err != nil {
-				return ColumnPhysicalQueryResult{}, err
-			}
-			defer func() { _ = runner.Close() }()
-			return runner.Run()
-		}},
-	} {
-		t.Run(run.name, func(t *testing.T) {
-			result, err := run.fn()
-			if err != nil {
-				t.Fatalf("%s fused q2: %v", run.name, err)
-			}
-			gotCounts := make(map[string]int, len(result.Groups))
-			gotDistinct := make(map[string]int, len(result.Groups))
-			for _, group := range result.Groups {
-				gotCounts[group.Key] = group.Count
-				gotDistinct[group.Key] = group.DistinctCount
-			}
-			if !reflect.DeepEqual(gotCounts, wantCounts) || !reflect.DeepEqual(gotDistinct, wantDistinct) {
-				t.Fatalf("fused groups counts=%v distinct=%v want counts=%v distinct=%v full=%+v", gotCounts, gotDistinct, wantCounts, wantDistinct, result.Groups)
-			}
-			if result.Diagnostics.RowsScanned != len(events) || result.Diagnostics.RowsMatched != 4 || result.Diagnostics.ReduceRows != 4 {
-				t.Fatalf("diagnostics=%+v want scanned=%d matched/reduced=4", result.Diagnostics, len(events))
-			}
-		})
+	assertFused := func(t *testing.T, result ColumnPhysicalQueryResult) {
+		t.Helper()
+		gotCounts := make(map[string]int, len(result.Groups))
+		gotDistinct := make(map[string]int, len(result.Groups))
+		for _, group := range result.Groups {
+			gotCounts[group.Key] = group.Count
+			gotDistinct[group.Key] = group.DistinctCount
+		}
+		if !reflect.DeepEqual(gotCounts, wantCounts) || !reflect.DeepEqual(gotDistinct, wantDistinct) {
+			t.Fatalf("fused groups counts=%v distinct=%v want counts=%v distinct=%v full=%+v", gotCounts, gotDistinct, wantCounts, wantDistinct, result.Groups)
+		}
+		if result.Diagnostics.RowsScanned != len(events) || result.Diagnostics.RowsMatched != 4 || result.Diagnostics.ReduceRows != 4 {
+			t.Fatalf("diagnostics=%+v want scanned=%d matched/reduced=4", result.Diagnostics, len(events))
+		}
 	}
+
+	t.Run("one-shot", func(t *testing.T) {
+		result, err := collection.RunColumnPhysicalQuery(req)
+		if err != nil {
+			t.Fatalf("one-shot fused q2: %v", err)
+		}
+		assertFused(t, result)
+	})
+	t.Run("prepared", func(t *testing.T) {
+		runner, err := collection.PrepareColumnPhysicalQuery(req)
+		if err != nil {
+			t.Fatalf("PrepareColumnPhysicalQuery fused q2: %v", err)
+		}
+		defer func() { _ = runner.Close() }()
+		for i := 0; i < 2; i++ {
+			result, err := runner.Run()
+			if err != nil {
+				t.Fatalf("prepared fused q2 run %d: %v", i, err)
+			}
+			assertFused(t, result)
+		}
+	})
+	t.Run("prepared no predicates", func(t *testing.T) {
+		noPredicateReq := req
+		noPredicateReq.Predicates = nil
+		runner, err := collection.PrepareColumnPhysicalQuery(noPredicateReq)
+		if err != nil {
+			t.Fatalf("PrepareColumnPhysicalQuery no-predicate fused q2: %v", err)
+		}
+		defer func() { _ = runner.Close() }()
+		result, err := runner.Run()
+		if err != nil {
+			t.Fatalf("prepared no-predicate fused q2: %v", err)
+		}
+		gotCounts := make(map[string]int, len(result.Groups))
+		gotDistinct := make(map[string]int, len(result.Groups))
+		for _, group := range result.Groups {
+			gotCounts[group.Key] = group.Count
+			gotDistinct[group.Key] = group.DistinctCount
+		}
+		if wantCounts := map[string]int{"like": 1, "post": 4}; !reflect.DeepEqual(gotCounts, wantCounts) {
+			t.Fatalf("no-predicate counts=%v want %v full=%+v", gotCounts, wantCounts, result.Groups)
+		}
+		if wantDistinct := map[string]int{"like": 1, "post": 3}; !reflect.DeepEqual(gotDistinct, wantDistinct) {
+			t.Fatalf("no-predicate distinct=%v want %v full=%+v", gotDistinct, wantDistinct, result.Groups)
+		}
+	})
 }
 
 func TestColumnPhysicalQueryDictionaryPredicatesAbsentLiteralEmpty1869(t *testing.T) {


### PR DESCRIPTION
Closes #1870.

## Summary

Adds a fused dictionary grouped count+distinct physical reducer for q2-shaped column-store work:

- adds `ColumnPhysicalQueryGroupCountAndDistinct`;
- extends `ColumnPhysicalQueryGroup` with documented `DistinctCount` for the fused result;
- reuses the prepared dictionary sidecar count-distinct runner and computes total row count plus distinct count in the same scan;
- supports both no-predicate prepared execution and the predicate seam from #1869;
- keeps existing `group_count` and `group_count_distinct` behavior unchanged.

## Scope boundaries

- This is the q1/q2 reducer lane only; no q3 native reducer (#1858) and no q4/q5 metadata optimization (#1871).
- This does not wire JSONBench app cells yet; the gomap API/test/benchmark seam is present for the harness to consume.
- Direct row-asset fallback for the new fused kind is intentionally unsupported; the optimized path is dictionary sidecar execution.

## Tests

```sh
go test ./TreeDB/collections -run 'TestColumnPhysicalQueryGroupCountAndDistinctFused1870|TestColumnPhysicalQueryDictionaryPredicate'
go test ./TreeDB/collections
go test ./TreeDB/...
```

All passed locally on Apple M3 / darwin arm64.

## Benchmark

```sh
go test ./TreeDB/collections -run '^$' \
  -bench '^BenchmarkColumnPhysicalQueryDictionaryPredicates1869$' \
  -benchmem -benchtime=10x -count=1
```

| case | ns/op | scanned rows/s | matched rows/op | scanned rows/op | B/op | allocs/op |
|---|---:|---:|---:|---:|---:|---:|
| q2_count | 32,767 | 254.3M | 6,874 | 8,192 | 0 | 0 |
| q2_distinct | 39,800 | 208.4M | 6,874 | 8,192 | 0 | 0 |
| q2_fused_count_distinct | 40,992 | 201.7M | 6,874 | 8,192 | 0 | 0 |
| q4_min | 52,388 | 157.4M | 2,291 | 8,192 | 0 | 0 |
| q5_span | 52,858 | 156.0M | 2,291 | 8,192 | 0 | 0 |

The fused q2 path returns both total count and distinct count from one scan; compare against q2_count + q2_distinct as separate scans.

## Review / CI

Coordinator used the Orca issue-list workflow. AI review requested for latest head.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for combined group count + distinct-count queries; per-group results now include both totals.

* **Validation**
  * Requests for fused group+distinct queries are now validated and will be rejected if malformed (missing or identical group/distinct fields) or not supported by the execution path.

* **Tests**
  * Added unit test and benchmark covering fused group-count-and-distinct behavior and prepared-query variants.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1880?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->