### PR TITLE
treedb: add aggregate metadata top-k shaping

### DIFF
--- a/TreeDB/collections/column_aggregate_metadata_query.go
+++ b/TreeDB/collections/column_aggregate_metadata_query.go
@@ -24,7 +24,9 @@ type columnAggregateMetadataRunner struct {
 	scheduledGranules        int
 	groupKeys                []string
 	entries                  []columnAggregateMetadataRunnerEntry
-	present                  []bool
+	seenGeneration           []uint32
+	runGeneration            uint32
+	touchedCodes             []int
 	mins                     []int64
 	maxs                     []int64
 	resultGroups             []ColumnPhysicalQueryGroup
@@ -89,10 +91,15 @@ func prepareColumnAggregateMetadataRunner(view columnPhysicalScanSnapshotView, r
 		}
 	}
 	groupCount := len(runner.groupKeys)
-	runner.present = make([]bool, groupCount)
+	runner.seenGeneration = make([]uint32, groupCount)
+	runner.touchedCodes = make([]int, 0, groupCount)
 	runner.mins = make([]int64, groupCount)
 	runner.maxs = make([]int64, groupCount)
-	runner.resultGroups = make([]ColumnPhysicalQueryGroup, 0, groupCount)
+	resultCap := groupCount
+	if req.TopK > 0 && req.TopK < resultCap {
+		resultCap = req.TopK
+	}
+	runner.resultGroups = make([]ColumnPhysicalQueryGroup, 0, resultCap)
 	stats := readCache.mappedResourceStats()
 	runner.mappedBytes = stats.TotalMappedBytes
 	runner.heapCopyBytes = stats.TotalHeapCopyBytes
@@ -101,41 +108,19 @@ func prepareColumnAggregateMetadataRunner(view columnPhysicalScanSnapshotView, r
 
 func (r *columnAggregateMetadataRunner) run(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest) ColumnPhysicalQueryResult {
 	start := time.Now()
-	for i := range r.present {
-		r.present[i] = false
-	}
-	for _, entry := range r.entries {
-		code := entry.groupCode
-		if !r.present[code] {
-			r.present[code] = true
-			r.mins[code] = entry.min
-			r.maxs[code] = entry.max
-			continue
-		}
-		if entry.min < r.mins[code] {
-			r.mins[code] = entry.min
-		}
-		if entry.max > r.maxs[code] {
-			r.maxs[code] = entry.max
-		}
-	}
+	reduceStart := start
+	r.reduceEntries()
+	reduceNanos := time.Since(reduceStart).Nanoseconds()
+
+	shapeStart := time.Now()
 	r.resultGroups = r.resultGroups[:0]
-	for code, key := range r.groupKeys {
-		if !r.present[code] {
-			continue
-		}
-		group := ColumnPhysicalQueryGroup{Key: key}
-		switch r.kind {
-		case ColumnPhysicalQueryGroupMinInt64:
-			group.Int64 = r.mins[code]
-		case ColumnPhysicalQueryGroupMaxInt64:
-			group.Int64 = r.maxs[code]
-		case ColumnPhysicalQueryGroupInt64Span:
-			group.Int64 = r.maxs[code] - r.mins[code]
-		}
-		r.resultGroups = append(r.resultGroups, group)
+	if req.TopK > 0 {
+		r.appendTopKGroups(req)
+	} else {
+		r.appendAllGroups()
 	}
-	sortColumnPhysicalQueryGroupsByKey(r.resultGroups)
+	shapeNanos := time.Since(shapeStart).Nanoseconds()
+
 	diag := columnPhysicalQueryDiagnosticsFromScan(view.Diagnostics)
 	diag.WorkerCount = 1
 	diag.ProjectedColumns = 2
@@ -147,7 +132,121 @@ func (r *columnAggregateMetadataRunner) run(view columnPhysicalScanSnapshotView,
 	diag.HeapCopyBytes = r.heapCopyBytes
 	diag.ReduceRows = r.rows
 	diag.ResultGroups = len(r.resultGroups)
+	diag.TopKLimit = req.TopK
+	diag.TopKCandidates = columnPhysicalTopKCandidates(req, r.touchedCodes, r.groupKeys)
+	diag.TopKOrder = string(req.TopKOrder)
 	diag.ColumnAssetReadIntegrity = r.columnAssetReadIntegrity
 	diag.ScanNanos = time.Since(start).Nanoseconds()
+	diag.ReduceNanos = reduceNanos
+	diag.ResultShapeNanos = shapeNanos
 	return ColumnPhysicalQueryResult{Groups: r.resultGroups, Diagnostics: diag}
+}
+
+func (r *columnAggregateMetadataRunner) reduceEntries() {
+	generation := r.nextGeneration()
+	r.touchedCodes = r.touchedCodes[:0]
+	for _, entry := range r.entries {
+		code := entry.groupCode
+		if r.seenGeneration[code] != generation {
+			r.seenGeneration[code] = generation
+			r.touchedCodes = append(r.touchedCodes, code)
+			r.mins[code] = entry.min
+			r.maxs[code] = entry.max
+			continue
+		}
+		if entry.min < r.mins[code] {
+			r.mins[code] = entry.min
+		}
+		if entry.max > r.maxs[code] {
+			r.maxs[code] = entry.max
+		}
+	}
+}
+
+func (r *columnAggregateMetadataRunner) nextGeneration() uint32 {
+	r.runGeneration++
+	if r.runGeneration == 0 {
+		clear(r.seenGeneration)
+		r.runGeneration = 1
+	}
+	return r.runGeneration
+}
+
+func (r *columnAggregateMetadataRunner) appendAllGroups() {
+	for _, code := range r.touchedCodes {
+		r.resultGroups = append(r.resultGroups, r.groupForCode(code))
+	}
+	sortColumnPhysicalQueryGroupsByKey(r.resultGroups)
+}
+
+func (r *columnAggregateMetadataRunner) appendTopKGroups(req ColumnPhysicalQueryRequest) {
+	for _, code := range r.touchedCodes {
+		key := r.groupKeys[code]
+		if req.SkipEmptyGroupKey && key == "" {
+			continue
+		}
+		insertColumnPhysicalTopKGroup(&r.resultGroups, r.groupForCode(code), req.TopK, req.TopKOrder)
+	}
+}
+
+func (r *columnAggregateMetadataRunner) groupForCode(code int) ColumnPhysicalQueryGroup {
+	group := ColumnPhysicalQueryGroup{Key: r.groupKeys[code]}
+	switch r.kind {
+	case ColumnPhysicalQueryGroupMinInt64:
+		group.Int64 = r.mins[code]
+	case ColumnPhysicalQueryGroupMaxInt64:
+		group.Int64 = r.maxs[code]
+	case ColumnPhysicalQueryGroupInt64Span:
+		group.Int64 = r.maxs[code] - r.mins[code]
+	}
+	return group
+}
+
+func columnPhysicalTopKCandidates(req ColumnPhysicalQueryRequest, touched []int, groupKeys []string) int {
+	if req.TopK <= 0 {
+		return 0
+	}
+	if !req.SkipEmptyGroupKey {
+		return len(touched)
+	}
+	candidates := 0
+	for _, code := range touched {
+		if groupKeys[code] != "" {
+			candidates++
+		}
+	}
+	return candidates
+}
+
+func insertColumnPhysicalTopKGroup(groups *[]ColumnPhysicalQueryGroup, group ColumnPhysicalQueryGroup, limit int, order ColumnPhysicalQueryTopKOrder) {
+	if limit <= 0 {
+		return
+	}
+	out := *groups
+	if len(out) < limit {
+		out = append(out, group)
+		for i := len(out) - 1; i > 0 && columnPhysicalTopKLess(order, out[i], out[i-1]); i-- {
+			out[i], out[i-1] = out[i-1], out[i]
+		}
+		*groups = out
+		return
+	}
+	if !columnPhysicalTopKLess(order, group, out[len(out)-1]) {
+		return
+	}
+	out[len(out)-1] = group
+	for i := len(out) - 1; i > 0 && columnPhysicalTopKLess(order, out[i], out[i-1]); i-- {
+		out[i], out[i-1] = out[i-1], out[i]
+	}
+	*groups = out
+}
+
+func columnPhysicalTopKLess(order ColumnPhysicalQueryTopKOrder, a, b ColumnPhysicalQueryGroup) bool {
+	if a.Int64 != b.Int64 {
+		if order == ColumnPhysicalQueryTopKInt64Desc {
+			return a.Int64 > b.Int64
+		}
+		return a.Int64 < b.Int64
+	}
+	return a.Key < b.Key
 }

--- a/TreeDB/collections/column_aggregate_metadata_typed_column_test.go
+++ b/TreeDB/collections/column_aggregate_metadata_typed_column_test.go
@@ -184,6 +184,123 @@ func TestAggregateMetadataTypedColumnPartPreparedRunnerAllocation1786(t *testing
 	}
 }
 
+func TestAggregateMetadataPreparedTopK1871(t *testing.T) {
+	events := []columnPhysicalQueryEventM13B{
+		{ID: "e00", Did: "", TimeUS: 0, Kind: "post"},
+		{ID: "e01", Did: "", TimeUS: 100, Kind: "post"},
+		{ID: "e02", Did: "did:a", TimeUS: 10, Kind: "post"},
+		{ID: "e03", Did: "did:a", TimeUS: 20, Kind: "post"},
+		{ID: "e04", Did: "did:b", TimeUS: 5, Kind: "post"},
+		{ID: "e05", Did: "did:b", TimeUS: 15, Kind: "post"},
+		{ID: "e06", Did: "did:c", TimeUS: 5, Kind: "post"},
+		{ID: "e07", Did: "did:c", TimeUS: 13, Kind: "post"},
+		{ID: "e08", Did: "did:d", TimeUS: 1, Kind: "post"},
+		{ID: "e09", Did: "did:d", TimeUS: 10, Kind: "post"},
+		{ID: "e10", Did: "did:e", TimeUS: 7, Kind: "post"},
+		{ID: "e11", Did: "did:e", TimeUS: 14, Kind: "post"},
+	}
+	d, col := openAggregateMetadataTypedColumnPartFixture1786(t, events)
+	defer func() { _ = d.Close() }()
+
+	tests := []struct {
+		name  string
+		req   ColumnPhysicalQueryRequest
+		want  []ColumnPhysicalQueryGroup
+		order ColumnPhysicalQueryTopKOrder
+	}{
+		{
+			name:  "q4 asc min skips empty",
+			req:   ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupMinInt64, GroupColumn: "did", ValueColumn: "time_us", AggregateMetadataName: "min_time_us", TopK: 3, TopKOrder: ColumnPhysicalQueryTopKInt64Asc, SkipEmptyGroupKey: true},
+			want:  []ColumnPhysicalQueryGroup{{Key: "did:d", Int64: 1}, {Key: "did:b", Int64: 5}, {Key: "did:c", Int64: 5}},
+			order: ColumnPhysicalQueryTopKInt64Asc,
+		},
+		{
+			name:  "q5 desc span skips empty",
+			req:   ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupInt64Span, GroupColumn: "did", ValueColumn: "time_us", AggregateMetadataName: "min_time_us", TopK: 3, TopKOrder: ColumnPhysicalQueryTopKInt64Desc, SkipEmptyGroupKey: true},
+			want:  []ColumnPhysicalQueryGroup{{Key: "did:a", Int64: 10}, {Key: "did:b", Int64: 10}, {Key: "did:d", Int64: 9}},
+			order: ColumnPhysicalQueryTopKInt64Desc,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			oneShot, err := col.RunColumnPhysicalQuery(tc.req)
+			if err != nil {
+				t.Fatalf("RunColumnPhysicalQuery: %v", err)
+			}
+			if !equalColumnPhysicalGroups1871(oneShot.Groups, tc.want) {
+				t.Fatalf("one-shot groups=%+v want %+v", oneShot.Groups, tc.want)
+			}
+			runner, err := col.PrepareColumnPhysicalQuery(tc.req)
+			if err != nil {
+				t.Fatalf("PrepareColumnPhysicalQuery: %v", err)
+			}
+			defer func() { _ = runner.Close() }()
+			for i := 0; i < 2; i++ {
+				result, err := runner.Run()
+				if err != nil {
+					t.Fatalf("runner Run %d: %v", i, err)
+				}
+				if !equalColumnPhysicalGroups1871(result.Groups, tc.want) {
+					t.Fatalf("groups=%+v want %+v", result.Groups, tc.want)
+				}
+				if result.Diagnostics.RowsScanned != 0 || result.Diagnostics.ReduceRows != len(events) {
+					t.Fatalf("diagnostics=%+v want zero scanned and reduce rows=%d", result.Diagnostics, len(events))
+				}
+				if result.Diagnostics.TopKLimit != 3 || result.Diagnostics.TopKOrder != string(tc.order) || result.Diagnostics.TopKCandidates != 5 || result.Diagnostics.ResultGroups != 3 || result.Diagnostics.ResultShapeNanos <= 0 {
+					t.Fatalf("top-K diagnostics=%+v", result.Diagnostics)
+				}
+			}
+		})
+	}
+
+	allReq := ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupMinInt64, GroupColumn: "did", ValueColumn: "time_us", AggregateMetadataName: "min_time_us"}
+	all, err := col.RunColumnPhysicalQuery(allReq)
+	if err != nil {
+		t.Fatalf("RunColumnPhysicalQuery all groups: %v", err)
+	}
+	if len(all.Groups) != 6 || all.Groups[0].Key != "" || all.Diagnostics.TopKLimit != 0 {
+		t.Fatalf("all-groups result=%+v diagnostics=%+v", all.Groups, all.Diagnostics)
+	}
+}
+
+func TestAggregateMetadataTopKValidation1871(t *testing.T) {
+	d, col := openAggregateMetadataTypedColumnPartFixture1786(t, columnPhysicalQueryFixtureEventsM13B(16))
+	defer func() { _ = d.Close() }()
+	tests := []struct {
+		name string
+		req  ColumnPhysicalQueryRequest
+		want string
+	}{
+		{name: "negative", req: ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupMinInt64, GroupColumn: "did", ValueColumn: "time_us", AggregateMetadataName: "min_time_us", TopK: -1}, want: "non-negative"},
+		{name: "missing metadata", req: ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupMinInt64, GroupColumn: "did", ValueColumn: "time_us", TopK: 3, TopKOrder: ColumnPhysicalQueryTopKInt64Asc}, want: "requires aggregate metadata"},
+		{name: "missing order", req: ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupMinInt64, GroupColumn: "did", ValueColumn: "time_us", AggregateMetadataName: "min_time_us", TopK: 3}, want: "order is required"},
+		{name: "order without limit", req: ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupMinInt64, GroupColumn: "did", ValueColumn: "time_us", AggregateMetadataName: "min_time_us", TopKOrder: ColumnPhysicalQueryTopKInt64Asc}, want: "requires a positive limit"},
+		{name: "unsupported kind", req: ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount, GroupColumn: "did", ValueColumn: "time_us", AggregateMetadataName: "min_time_us", TopK: 3, TopKOrder: ColumnPhysicalQueryTopKInt64Asc}, want: "requires an int64 aggregate kind"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := col.PrepareColumnPhysicalQuery(tc.req); !errors.Is(err, ErrColumnQueryPlanUnsupported) || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("PrepareColumnPhysicalQuery err=%v want ErrColumnQueryPlanUnsupported containing %q", err, tc.want)
+			}
+		})
+	}
+	if _, err := col.RunColumnPhysicalQueryParallel(ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupMinInt64, GroupColumn: "did", ValueColumn: "time_us", AggregateMetadataName: "min_time_us"}, 4); !errors.Is(err, ErrColumnQueryPlanUnsupported) || !strings.Contains(err.Error(), "parallel aggregate metadata") {
+		t.Fatalf("RunColumnPhysicalQueryParallel aggregate metadata err=%v want fail-closed", err)
+	}
+}
+
+func equalColumnPhysicalGroups1871(a, b []ColumnPhysicalQueryGroup) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
 func openAggregateMetadataTypedColumnPartFixture1786(tb testing.TB, events []columnPhysicalQueryEventM13B) (*backenddb.DB, *Collection) {
 	tb.Helper()
 	d := openTypedColumnInt64ScanDB(tb)
@@ -247,6 +364,10 @@ func BenchmarkAggregateMetadataTypedColumnPart1786(b *testing.B) {
 	const rows = 4096
 	events := columnPhysicalQueryFixtureEventsM13B(rows)
 	reqMetadata := ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupInt64Span, GroupColumn: "did", ValueColumn: "time_us", AggregateMetadataName: "min_time_us", ColumnAssetReadIntegrity: ColumnAssetReadIntegrityCachedVerify}
+	reqMetadataTopK := reqMetadata
+	reqMetadataTopK.TopK = 3
+	reqMetadataTopK.TopKOrder = ColumnPhysicalQueryTopKInt64Desc
+	reqMetadataTopK.SkipEmptyGroupKey = true
 	reqScan := ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupInt64Span, GroupColumn: "did", ValueColumn: "time_us", ColumnAssetReadIntegrity: ColumnAssetReadIntegrityCachedVerify}
 
 	b.Run("typed_column_metadata", func(b *testing.B) {
@@ -289,6 +410,34 @@ func BenchmarkAggregateMetadataTypedColumnPart1786(b *testing.B) {
 			result, err := runner.Run()
 			if err != nil {
 				b.Fatalf("runner Run metadata: %v", err)
+			}
+			last = result.Diagnostics
+		}
+		reportAggregateMetadataPhysicalQueryBench1786(b, last, rows)
+	})
+	b.Run("typed_column_metadata_prepared_topk", func(b *testing.B) {
+		d, col := openAggregateMetadataTypedColumnPartFixture1786(b, events)
+		defer func() { _ = d.Close() }()
+		runner, err := col.PrepareColumnPhysicalQuery(reqMetadataTopK)
+		if err != nil {
+			b.Fatalf("PrepareColumnPhysicalQuery top-K metadata: %v", err)
+		}
+		defer func() { _ = runner.Close() }()
+		preview, err := runner.Run()
+		if err != nil {
+			b.Fatalf("preview prepared top-K metadata: %v", err)
+		}
+		if got, want := len(preview.Groups), 3; got != want {
+			b.Fatalf("preview top-K groups=%d want %d", got, want)
+		}
+		b.SetBytes(preview.Diagnostics.PhysicalBytesScanned)
+		b.ReportAllocs()
+		b.ResetTimer()
+		var last ColumnPhysicalQueryDiagnostics
+		for i := 0; i < b.N; i++ {
+			result, err := runner.Run()
+			if err != nil {
+				b.Fatalf("runner Run top-K metadata: %v", err)
 			}
 			last = result.Diagnostics
 		}
@@ -431,6 +580,9 @@ func reportAggregateMetadataPhysicalQueryBench1786(b *testing.B, diag ColumnPhys
 	b.ReportMetric(float64(diag.RowMaterializations), "row_materializations/op")
 	b.ReportMetric(float64(diag.DocumentMaterializations), "document_materializations/op")
 	b.ReportMetric(float64(diag.ReconstructionRows), "reconstruction_rows/op")
+	b.ReportMetric(float64(diag.TopKLimit), "topk_limit/op")
+	b.ReportMetric(float64(diag.TopKCandidates), "topk_candidates/op")
+	b.ReportMetric(float64(diag.ResultShapeNanos), "result_shape_ns/op")
 }
 
 func assertAggregateMetadataTypedColumnDiagnostics1786(t testing.TB, diag ColumnPhysicalQueryDiagnostics, wantRows int) {

--- a/TreeDB/collections/column_aggregate_metadata_typed_column_test.go
+++ b/TreeDB/collections/column_aggregate_metadata_typed_column_test.go
@@ -246,7 +246,7 @@ func TestAggregateMetadataPreparedTopK1871(t *testing.T) {
 				if result.Diagnostics.RowsScanned != 0 || result.Diagnostics.ReduceRows != len(events) {
 					t.Fatalf("diagnostics=%+v want zero scanned and reduce rows=%d", result.Diagnostics, len(events))
 				}
-				if result.Diagnostics.TopKLimit != 3 || result.Diagnostics.TopKOrder != string(tc.order) || result.Diagnostics.TopKCandidates != 5 || result.Diagnostics.ResultGroups != 3 || result.Diagnostics.ResultShapeNanos <= 0 {
+				if result.Diagnostics.TopKLimit != 3 || result.Diagnostics.TopKOrder != string(tc.order) || result.Diagnostics.TopKCandidates != 5 || result.Diagnostics.ResultGroups != 3 || result.Diagnostics.ResultShapeNanos < 0 {
 					t.Fatalf("top-K diagnostics=%+v", result.Diagnostics)
 				}
 			}

--- a/TreeDB/collections/column_physical_query.go
+++ b/TreeDB/collections/column_physical_query.go
@@ -14,6 +14,19 @@ import (
 // shapes supported directly by the column asset scanner.
 type ColumnPhysicalQueryKind string
 
+// ColumnPhysicalQueryTopKOrder selects ordering for optional Top-K int64
+// physical query result shaping.
+type ColumnPhysicalQueryTopKOrder string
+
+const (
+	// ColumnPhysicalQueryTopKInt64Asc keeps the smallest Int64 groups first,
+	// using Key as the deterministic tie-break.
+	ColumnPhysicalQueryTopKInt64Asc ColumnPhysicalQueryTopKOrder = "int64_asc"
+	// ColumnPhysicalQueryTopKInt64Desc keeps the largest Int64 groups first,
+	// using Key as the deterministic tie-break.
+	ColumnPhysicalQueryTopKInt64Desc ColumnPhysicalQueryTopKOrder = "int64_desc"
+)
+
 const (
 	// ColumnPhysicalQueryGroupCount counts rows by a string group column.
 	ColumnPhysicalQueryGroupCount            ColumnPhysicalQueryKind = "group_count"
@@ -34,12 +47,18 @@ const (
 // does not invoke planner routing; M14 owns forced/automatic route selection.
 // Predicates are an AND-list of dictionary string equality/IN filters for the
 // insert-only physical sidecar path; unsupported predicate shapes fail closed.
+// TopK is optional and currently supported by aggregate-metadata int64 reducers
+// only. When TopK is set, TopKOrder chooses value order and Key is the tie-break;
+// SkipEmptyGroupKey omits empty-string group keys before applying the limit.
 type ColumnPhysicalQueryRequest struct {
 	Kind                     ColumnPhysicalQueryKind
 	GroupColumn              string
 	ValueColumn              string
 	DistinctColumn           string
 	AggregateMetadataName    string
+	TopK                     int
+	TopKOrder                ColumnPhysicalQueryTopKOrder
+	SkipEmptyGroupKey        bool
 	Predicates               []ColumnPhysicalQueryPredicate
 	ColumnAssetReadIntegrity ColumnAssetReadIntegrity
 }
@@ -90,6 +109,9 @@ type ColumnPhysicalQueryDiagnostics struct {
 	MappedBytes                 uint64
 	HeapCopyBytes               uint64
 	ReduceRows                  int
+	TopKLimit                   int
+	TopKCandidates              int
+	TopKOrder                   string
 	VisibilityRows              int
 	ReconstructionRows          int
 	ResultGroups                int
@@ -100,6 +122,7 @@ type ColumnPhysicalQueryDiagnostics struct {
 	ScanNanos                   int64
 	VisibilityNanos             int64
 	ReduceNanos                 int64
+	ResultShapeNanos            int64
 	ReconstructionNanos         int64
 }
 
@@ -135,6 +158,13 @@ type ColumnPhysicalQueryRunner struct {
 
 var errColumnPhysicalScanCancelled = errors.New("collections: physical column scan cancelled")
 
+func validateColumnPhysicalQueryRequest(req ColumnPhysicalQueryRequest) error {
+	if err := validateColumnPhysicalGroupCountAndDistinctRequest(req); err != nil {
+		return err
+	}
+	return validateColumnPhysicalTopKRequest(req)
+}
+
 func validateColumnPhysicalGroupCountAndDistinctRequest(req ColumnPhysicalQueryRequest) error {
 	if req.Kind != ColumnPhysicalQueryGroupCountAndDistinct {
 		return nil
@@ -151,12 +181,43 @@ func validateColumnPhysicalGroupCountAndDistinctRequest(req ColumnPhysicalQueryR
 	return nil
 }
 
+func validateColumnPhysicalTopKRequest(req ColumnPhysicalQueryRequest) error {
+	if req.TopK < 0 {
+		return fmt.Errorf("%w: physical column query top-K limit must be non-negative", ErrColumnQueryPlanUnsupported)
+	}
+	if req.TopK == 0 {
+		if req.TopKOrder != "" {
+			return fmt.Errorf("%w: physical column query top-K order requires a positive limit", ErrColumnQueryPlanUnsupported)
+		}
+		if req.SkipEmptyGroupKey {
+			return fmt.Errorf("%w: physical column query skip-empty group key requires a positive top-K limit", ErrColumnQueryPlanUnsupported)
+		}
+		return nil
+	}
+	if req.AggregateMetadataName == "" {
+		return fmt.Errorf("%w: physical column query top-K requires aggregate metadata", ErrColumnQueryPlanUnsupported)
+	}
+	switch req.Kind {
+	case ColumnPhysicalQueryGroupMinInt64, ColumnPhysicalQueryGroupMaxInt64, ColumnPhysicalQueryGroupInt64Span:
+	default:
+		return fmt.Errorf("%w: physical column query top-K requires an int64 aggregate kind", ErrColumnQueryPlanUnsupported)
+	}
+	switch req.TopKOrder {
+	case ColumnPhysicalQueryTopKInt64Asc, ColumnPhysicalQueryTopKInt64Desc:
+		return nil
+	case "":
+		return fmt.Errorf("%w: physical column query top-K order is required", ErrColumnQueryPlanUnsupported)
+	default:
+		return fmt.Errorf("%w: unsupported physical column query top-K order %q", ErrColumnQueryPlanUnsupported, req.TopKOrder)
+	}
+}
+
 // RunColumnPhysicalQuery executes an explicit serial physical column query over
 // the recovery-authoritative manifest. Insert-only manifests use the direct
 // scanner path; mutation-bearing manifests fall back to the M13C visibility
 // overlay before reducing.
 func (c *Collection) RunColumnPhysicalQuery(req ColumnPhysicalQueryRequest) (ColumnPhysicalQueryResult, error) {
-	if err := validateColumnPhysicalGroupCountAndDistinctRequest(req); err != nil {
+	if err := validateColumnPhysicalQueryRequest(req); err != nil {
 		return ColumnPhysicalQueryResult{}, err
 	}
 	mutationParts, err := c.columnPhysicalQueryMutationPartsHint()
@@ -206,7 +267,7 @@ func (c *Collection) RunColumnPhysicalQuery(req ColumnPhysicalQueryRequest) (Col
 // until Close and fail-closes for mutation-bearing manifests or unsupported
 // query shapes rather than silently changing semantics.
 func (c *Collection) PrepareColumnPhysicalQuery(req ColumnPhysicalQueryRequest) (*ColumnPhysicalQueryRunner, error) {
-	if err := validateColumnPhysicalGroupCountAndDistinctRequest(req); err != nil {
+	if err := validateColumnPhysicalQueryRequest(req); err != nil {
 		return nil, err
 	}
 	view, closeView, err := c.prepareColumnPhysicalScanSnapshotViewWithSidecars(columnManifestScanSidecarsForPhysicalQuery(req))
@@ -432,10 +493,16 @@ func (c *Collection) runColumnPhysicalQueryAggregateMetadataInSnapshotView(view 
 	}
 	diag.ScanNanos = time.Since(start).Nanoseconds()
 	diag.ReduceRows = acc.rows
-	diag.ResultGroups = acc.groupCount()
+	shapeStart := time.Now()
+	groups := acc.groups(req)
+	diag.ResultShapeNanos = time.Since(shapeStart).Nanoseconds()
+	diag.ResultGroups = len(groups)
+	diag.TopKLimit = req.TopK
+	diag.TopKOrder = string(req.TopKOrder)
+	diag.TopKCandidates = acc.topKCandidates(req)
 	diag.SegmentFileCacheHits = readCache.hits
 	diag.SegmentFileCacheMisses = readCache.misses
-	return ColumnPhysicalQueryResult{Groups: acc.groups(), Diagnostics: diag}, nil
+	return ColumnPhysicalQueryResult{Groups: groups, Diagnostics: diag}, nil
 }
 
 func (c *Collection) runColumnPhysicalQueryDirectInSnapshotView(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest, refModulo, refRemainder int, shouldCancel func() bool) (ColumnPhysicalQueryResult, bool, error) {
@@ -558,8 +625,11 @@ func (c *Collection) scanColumnPhysicalQueryDirectInSnapshotViewWithReadCache(
 // Mutation-bearing manifests stay fail-closed until partitioned visibility
 // reconstruction is available.
 func (c *Collection) RunColumnPhysicalQueryParallel(req ColumnPhysicalQueryRequest, maxWorkers int) (ColumnPhysicalQueryResult, error) {
-	if err := validateColumnPhysicalGroupCountAndDistinctRequest(req); err != nil {
+	if err := validateColumnPhysicalQueryRequest(req); err != nil {
 		return ColumnPhysicalQueryResult{}, err
+	}
+	if req.AggregateMetadataName != "" {
+		return ColumnPhysicalQueryResult{}, fmt.Errorf("%w: parallel aggregate metadata physical queries are not supported", ErrColumnQueryPlanUnsupported)
 	}
 	if columnPhysicalQueryHasPredicates(req) {
 		return ColumnPhysicalQueryResult{}, fmt.Errorf("%w: parallel physical predicates require partitioned dictionary sidecar execution", ErrColumnQueryPlanUnsupported)
@@ -1041,6 +1111,14 @@ func mergeColumnPhysicalQueryDiagnostics(left, right ColumnPhysicalQueryDiagnost
 	left.MappedBytes += right.MappedBytes
 	left.HeapCopyBytes += right.HeapCopyBytes
 	left.ReduceRows += right.ReduceRows
+	left.TopKCandidates += right.TopKCandidates
+	if right.TopKLimit > left.TopKLimit {
+		left.TopKLimit = right.TopKLimit
+	}
+	if left.TopKOrder == "" {
+		left.TopKOrder = right.TopKOrder
+	}
+	left.ResultShapeNanos += right.ResultShapeNanos
 	left.VisibilityRows += right.VisibilityRows
 	left.ReconstructionRows += right.ReconstructionRows
 	left.SegmentFileCacheHits += right.SegmentFileCacheHits
@@ -1724,20 +1802,60 @@ func (a *columnPhysicalQueryMetadataAccumulator) groupCount() int {
 	return len(a.int64Values)
 }
 
-func (a *columnPhysicalQueryMetadataAccumulator) groups() []ColumnPhysicalQueryGroup {
-	out := make([]ColumnPhysicalQueryGroup, 0, a.groupCount())
+func (a *columnPhysicalQueryMetadataAccumulator) groups(req ColumnPhysicalQueryRequest) []ColumnPhysicalQueryGroup {
+	capacity := a.groupCount()
+	if req.TopK > 0 && req.TopK < capacity {
+		capacity = req.TopK
+	}
+	out := make([]ColumnPhysicalQueryGroup, 0, capacity)
+	add := func(group ColumnPhysicalQueryGroup) {
+		if req.SkipEmptyGroupKey && group.Key == "" {
+			return
+		}
+		if req.TopK > 0 {
+			insertColumnPhysicalTopKGroup(&out, group, req.TopK, req.TopKOrder)
+			return
+		}
+		out = append(out, group)
+	}
 	switch a.kind {
 	case ColumnPhysicalQueryGroupMinInt64, ColumnPhysicalQueryGroupMaxInt64:
 		for key, value := range a.int64Values {
-			out = append(out, ColumnPhysicalQueryGroup{Key: key, Int64: value})
+			add(ColumnPhysicalQueryGroup{Key: key, Int64: value})
 		}
 	case ColumnPhysicalQueryGroupInt64Span:
 		for key, span := range a.spans {
-			out = append(out, ColumnPhysicalQueryGroup{Key: key, Int64: span.max - span.min})
+			add(ColumnPhysicalQueryGroup{Key: key, Int64: span.max - span.min})
 		}
 	}
-	sortColumnPhysicalQueryGroupsByKey(out)
+	if req.TopK == 0 {
+		sortColumnPhysicalQueryGroupsByKey(out)
+	}
 	return out
+}
+
+func (a *columnPhysicalQueryMetadataAccumulator) topKCandidates(req ColumnPhysicalQueryRequest) int {
+	if req.TopK <= 0 {
+		return 0
+	}
+	if !req.SkipEmptyGroupKey {
+		return a.groupCount()
+	}
+	candidates := 0
+	if a.spans != nil {
+		for key := range a.spans {
+			if key != "" {
+				candidates++
+			}
+		}
+		return candidates
+	}
+	for key := range a.int64Values {
+		if key != "" {
+			candidates++
+		}
+	}
+	return candidates
 }
 
 func (e *columnPhysicalQueryExecutor) mergeFrom(other *columnPhysicalQueryExecutor) error {

--- a/TreeDB/docs/guides/typed-storage-performance.md
+++ b/TreeDB/docs/guides/typed-storage-performance.md
@@ -110,8 +110,11 @@ go test ./TreeDB/collections \
 
 Key counters: `metadata_hits/op`, `metadata_decoded_bytes/op`,
 `mapped_bytes/op`, `heap_copy_bytes/op`, `rows_scanned/op`,
-`row_materializations/op`, `document_materializations/op`, and
-`reconstruction_rows/op`.
+`row_materializations/op`, `document_materializations/op`,
+`reconstruction_rows/op`, `topk_limit/op`, `topk_candidates/op`, and
+`result_shape_ns/op`. Prepared aggregate metadata queries may request explicit
+Top-K result shaping for int64 min/max/span results; this keeps all-groups
+semantics unchanged unless callers set `TopK` and `TopKOrder`.
 
 ### Selecting #1808 matrix shapes and distributions
 

--- a/experiments/colgranule/README.md
+++ b/experiments/colgranule/README.md
@@ -317,7 +317,11 @@ GOWORK=off go test ./experiments/colgranule -run '^$' \
 The known q4 caveat is sort order, not row materialization: M2's single-part
 baseline can early-stop on a globally time-ordered part, while the correct M4
 multipart path currently scans visible rows. A future k-way sort-key/mark merge
-across parts is needed before multipart q4 can early-stop safely.
+across parts is needed before multipart q4 can early-stop safely. The TreeDB
+comparison also includes explicit aggregate-metadata Top-K q4/q5 variants that
+report `topk_limit/op`, `topk_candidates/op`, and `result_shape_ns/op`; these
+use logical rows/sec with `rows_scanned/op=0` and should not be confused with
+full data-row scans or pruning metadata.
 
 ## M1D Gates Before Value-Log-Backed M2
 

--- a/experiments/colgranule/jsonbench_treedb_columnstore_bench_test.go
+++ b/experiments/colgranule/jsonbench_treedb_columnstore_bench_test.go
@@ -114,7 +114,9 @@ func benchmarkJSONBenchColumnStoreCompareTreeDB(b *testing.B, ds JSONBenchDatase
 		{name: "q4_min_by_user", req: collections.ColumnPhysicalQueryRequest{Kind: collections.ColumnPhysicalQueryGroupMinInt64, GroupColumn: "did", ValueColumn: "time_us"}},
 		{name: "q5_span_by_user", req: collections.ColumnPhysicalQueryRequest{Kind: collections.ColumnPhysicalQueryGroupInt64Span, GroupColumn: "did", ValueColumn: "time_us"}},
 		{name: "q4_metadata_min_by_user", req: collections.ColumnPhysicalQueryRequest{Kind: collections.ColumnPhysicalQueryGroupMinInt64, GroupColumn: "did", ValueColumn: "time_us", AggregateMetadataName: "min_time_us"}},
+		{name: "q4_metadata_top3_min_by_user", req: collections.ColumnPhysicalQueryRequest{Kind: collections.ColumnPhysicalQueryGroupMinInt64, GroupColumn: "did", ValueColumn: "time_us", AggregateMetadataName: "min_time_us", TopK: 3, TopKOrder: collections.ColumnPhysicalQueryTopKInt64Asc, SkipEmptyGroupKey: true}},
 		{name: "q5_metadata_span_by_user", req: collections.ColumnPhysicalQueryRequest{Kind: collections.ColumnPhysicalQueryGroupInt64Span, GroupColumn: "did", ValueColumn: "time_us", AggregateMetadataName: "min_time_us"}},
+		{name: "q5_metadata_top3_span_by_user", req: collections.ColumnPhysicalQueryRequest{Kind: collections.ColumnPhysicalQueryGroupInt64Span, GroupColumn: "did", ValueColumn: "time_us", AggregateMetadataName: "min_time_us", TopK: 3, TopKOrder: collections.ColumnPhysicalQueryTopKInt64Desc, SkipEmptyGroupKey: true}},
 	}
 	for _, q := range queries {
 		q := q
@@ -384,6 +386,9 @@ func reportTreeDBJSONBenchColumnStoreCompareMetrics(b *testing.B, reducedRows in
 	b.ReportMetric(float64(diag.DecodedMetadataBytes), "decoded_metadata_bytes/op")
 	b.ReportMetric(float64(diag.RowMaterializations), "row_materializations/op")
 	b.ReportMetric(float64(diag.DocumentMaterializations), "document_materializations/op")
+	b.ReportMetric(float64(diag.TopKLimit), "topk_limit/op")
+	b.ReportMetric(float64(diag.TopKCandidates), "topk_candidates/op")
+	b.ReportMetric(float64(diag.ResultShapeNanos), "result_shape_ns/op")
 }
 
 func jsonBenchCompareDirSize(root string) int64 {


### PR DESCRIPTION
Closes #1871.

## Summary

Adds an explicit prepared aggregate-metadata Top-K/result-shaping path for q4/q5-shaped int64 reducers.

- Adds `ColumnPhysicalQueryRequest.TopK`, `TopKOrder`, and `SkipEmptyGroupKey` for explicit opt-in Top-K semantics.
- Keeps all-groups semantics unchanged when `TopK == 0`.
- Supports aggregate-metadata one-shot and prepared min/max/span results with deterministic Key tie-breaks.
- Reworks prepared aggregate metadata hot runs to use generation-stamped touched group codes instead of clearing/scanning the full presence bitmap.
- Adds Top-K diagnostics: limit, candidate count, order, and result-shaping nanos.
- Keeps parallel aggregate-metadata execution fail-closed instead of silently ignoring aggregate metadata in the parallel direct-scan path.
- Adds low-level JSONBench comparison Top-K q4/q5 metadata benchmark variants and docs notes.

## Scope / milestone

Implements the M1 hot-run/result-shaping milestone for #1871. This does not change the aggregate metadata on-disk format (M2) and does not wire JSONBench's separate repo to request Top-K yet; the gomap physical query API and low-level benchmark seam are present.

## Start-phase baseline

Baseline on `origin/main` after #1870 (`e5c7390e4`), Apple M3/darwin arm64:

```sh
go test ./experiments/colgranule -run '^$' \
  -bench '^BenchmarkJSONBenchColumnStoreCompare/rows_819200/treedb_column_store_prepared/q[45]_metadata' \
  -benchmem -benchtime=3x -count=1
```

Artifact: `/tmp/treedb_1871_baseline_20260525_232741.txt`

| path | ns/op | logical rows/sec | rows_scanned/op | metadata bytes/op | result groups | B/op | allocs/op |
|---|---:|---:|---:|---:|---:|---:|---:|
| q4 metadata all groups | 5,970,819 | 139.3M | 0 | 30,169,697 | 65,536 | 389 | 0 |
| q5 metadata all groups | 6,402,806 | 130.0M | 0 | 30,169,697 | 65,536 | 389 | 0 |

## Close-phase tests

```sh
go test ./TreeDB/collections -run 'TestAggregateMetadata(PreparedTopK1871|TopKValidation1871|TypedColumnPartPreparedRunnerAllocation1786)'
go test ./TreeDB/collections
go test ./TreeDB/...
go test ./experiments/colgranule
```

All passed locally.

## Close-phase benchmark evidence

```sh
go test ./experiments/colgranule -run '^$' \
  -bench '^BenchmarkJSONBenchColumnStoreCompare/rows_819200/treedb_column_store_prepared/q[45]_metadata' \
  -benchmem -benchtime=5x -count=1
```

Artifact: `/tmp/treedb_1871_after_20260525_233728_5x.txt`

| path | ns/op | logical rows/sec | rows_scanned/op | metadata bytes/op | result groups | topk candidates | result_shape_ns/op | B/op | allocs/op |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| q4 metadata all groups | 6,245,125 | 132.6M | 0 | 30,169,697 | 65,536 | 0 | 5,257,333 | 233 | 0 |
| q4 metadata Top-3 | 1,380,892 | 616.7M | 0 | 30,169,697 | 3 | 65,536 | 407,916 | 233 | 0 |
| q5 metadata all groups | 6,416,533 | 128.9M | 0 | 30,169,697 | 65,536 | 0 | 5,416,875 | 233 | 0 |
| q5 metadata Top-3 | 1,379,475 | 616.5M | 0 | 30,169,697 | 3 | 65,536 | 410,500 | 233 | 0 |

Timing boundary: benchmark setup/load and metadata build are outside `b.ResetTimer`; `PrepareColumnPhysicalQuery` runs before the timer for prepared cells; hot `Run()` covers metadata reduction + result shaping. Rows/sec uses logical dataset rows; `rows_scanned/op=0` and `decoded_metadata_bytes/op` reports metadata bytes processed.

Focused small-fixture aggregate metadata bench:

```sh
go test ./TreeDB/collections -run '^$' \
  -bench '^BenchmarkAggregateMetadataTypedColumnPart1786/(typed_column_metadata_prepared|typed_column_metadata_prepared_topk)$' \
  -benchmem -benchtime=10x -count=1
```

Prepared Top-K remains zero-alloc and reports Top-K diagnostics. On the tiny 12-group fixture it is intentionally not faster than all-groups; the low-level JSONBench-shaped 65,536-group fixture shows the target result-shaping win.

## Review / CI

Coordinator used the Orca issue-list workflow. AI review requested after PR creation; latest-head CI and review findings will be resolved before merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Top-K result shaping for aggregate metadata queries on int64 aggregates (min/max/span).
  * New request options: TopK limit, TopK order (asc/desc), and skip-empty-group-key.
  * New diagnostics: TopKLimit, TopKCandidates, TopKOrder, ResultShapeNanos.

* **Tests & Benchmarks**
  * Added TopK-focused unit tests and benchmark variants; benchmarks now report TopK diagnostics and result-shape timing.

* **Documentation**
  * Clarified Top-K semantics and measurement guidance in performance docs and READMEs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1881?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->