### PR TITLE
Land typed-storage row-locator document point fetch

### DIFF
--- a/TreeDB/collections/document_materializer.go
+++ b/TreeDB/collections/document_materializer.go
@@ -11,21 +11,20 @@ import (
 	"github.com/snissn/gomap/TreeDB/internal/mappedresource"
 )
 
-// DocumentFetchOptions configures snapshot-bound document materialization.
-// Projection and row-locator point-fetch options are intentionally deferred to
-// later materializer milestones; the zero value preserves Collection.Get-style
-// full-document output and verified column-asset reads.
+// DocumentFetchOptions configures snapshot-bound document materialization. The
+// zero value preserves Collection.Get-style full-document output and verified
+// column-asset reads.
 type DocumentFetchOptions struct {
 	// ColumnAssetReadIntegrity controls typed-row/physical row asset reads used
-	// to find the visible row for a document. Typed-column part reconstruction
-	// uses the prepared read-view cache with verified reads.
+	// to locate or point-fetch the visible row for a document. Typed-column part
+	// reconstruction uses the prepared read-view cache with verified reads.
 	ColumnAssetReadIntegrity ColumnAssetReadIntegrity
 }
 
 // DocumentRowRef identifies a document row in a snapshot-bound typed-storage
-// materialization request. #1872 keeps the row-ref API seam but still resolves
-// documents through the batched document-ID scan; direct O(topK) row-locator
-// point fetch is deferred to #1874.
+// materialization request. Refs are produced by typed-storage locator lookups or
+// by FetchDocumentsByID scan reconstruction and are validated against the
+// decoded physical row before materialization.
 type DocumentRowRef struct {
 	DocumentID        []byte
 	Generation        uint64
@@ -74,7 +73,19 @@ type DocumentMaterializationStats struct {
 	JSONReconstructionRows  uint64
 	JSONReconstructionNanos int64
 
-	RowRefFallbackScans uint64
+	RowLocatorBuilds        uint64
+	RowLocatorLookups       uint64
+	RowLocatorMisses        uint64
+	RowLocatorRowsScanned   uint64
+	RowLocatorPhysicalBytes int64
+	RowLocatorNanos         int64
+
+	PointRowFetches uint64
+	PointRowDecodes uint64
+
+	RowRefFallbackScans      uint64
+	RowRefUnsupported        uint64
+	RowRefValidationFailures uint64
 
 	AssetMmapHits        uint64
 	AssetReadAtFallbacks uint64
@@ -90,7 +101,36 @@ type DocumentFetchResponse struct {
 	Stats   DocumentMaterializationStats
 }
 
+// DocumentRowRefLookupResult is one ordered document-row locator lookup result.
+// Missing or deleted documents have Found=false and a zero RowRef.
+type DocumentRowRefLookupResult struct {
+	ID     []byte
+	RowRef DocumentRowRef
+	Found  bool
+}
+
+// DocumentRowRefLookupResponse contains ordered row-ref lookup results and
+// diagnostics for the snapshot-derived locator work.
+type DocumentRowRefLookupResponse struct {
+	Results []DocumentRowRefLookupResult
+	Stats   DocumentMaterializationStats
+}
+
 var collectionReadViewScopeSeq atomic.Uint64
+
+type documentRowPartKey struct {
+	Generation uint64
+	PartID     uint64
+}
+
+type documentRowLocator struct {
+	byID map[string]DocumentRowRef
+}
+
+type documentRowLocatorCandidate struct {
+	ref     DocumentRowRef
+	deleted bool
+}
 
 // CollectionReadView is a closeable snapshot-bound document materializer for a
 // collection. It preserves the catalog/root visibility that existed when the
@@ -111,6 +151,12 @@ type CollectionReadView struct {
 	rowAssetReadCache               *columnPhysicalAssetReadCache
 	rowAssetReadIntegrity           ColumnAssetReadIntegrity
 	typedColumnAssetReadCache       *columnPhysicalAssetReadCache
+	typedColumnReconstructionCache  *typedColumnPartReconstructionCache
+	columnSnapshotView              *columnPhysicalScanSnapshotView
+	rowLocator                      *documentRowLocator
+	pointRowRefs                    map[documentRowPartKey]columnManifestAssetRefForScan
+	pointRowBlocks                  map[documentRowPartKey]*columnPhysicalRowReaderBlock
+	pointRowProjection              *columnPhysicalScanProjection
 	forceAssetReadAtFallbackForTest bool
 }
 
@@ -231,6 +277,7 @@ func (v *CollectionReadView) ensureAssetReadCaches(cfg ColumnStoreConfig, rowInt
 	namespace := cfg.AssetManager.Namespace
 	if v.rowAssetReadCache == nil || v.rowAssetReadIntegrity != rowIntegrity || v.rowAssetReadCache.namespace != namespace {
 		if v.rowAssetReadCache != nil {
+			v.clearPointRowBlockCache()
 			if err := v.rowAssetReadCache.close(); err != nil {
 				return err
 			}
@@ -253,6 +300,7 @@ func (v *CollectionReadView) ensureAssetReadCaches(cfg ColumnStoreConfig, rowInt
 	}
 	if v.typedColumnAssetReadCache == nil || v.typedColumnAssetReadCache.namespace != namespace {
 		if v.typedColumnAssetReadCache != nil {
+			v.typedColumnReconstructionCache = nil
 			if err := v.typedColumnAssetReadCache.close(); err != nil {
 				return err
 			}
@@ -367,6 +415,7 @@ func (v *CollectionReadView) closeAssetReadCaches() error {
 	if v == nil {
 		return nil
 	}
+	v.clearPointRowBlockCache()
 	var closeErr error
 	if v.rowAssetReadCache != nil {
 		closeErr = errors.Join(closeErr, v.rowAssetReadCache.close())
@@ -378,37 +427,343 @@ func (v *CollectionReadView) closeAssetReadCaches() error {
 		v.assetClosedCounters.addReadCache(v.typedColumnAssetReadCache)
 		v.typedColumnAssetReadCache = nil
 	}
+	v.typedColumnReconstructionCache = nil
 	return closeErr
 }
 
+func (v *CollectionReadView) clearPointRowBlockCache() {
+	if v == nil {
+		return
+	}
+	for key := range v.pointRowBlocks {
+		delete(v.pointRowBlocks, key)
+	}
+}
+
+// LookupDocumentRowRefsByID resolves document IDs to snapshot-visible typed-row
+// refs in input order. It builds or reuses a generic materializer row-locator
+// map for the read view; missing or deleted documents return Found=false.
+func (v *CollectionReadView) LookupDocumentRowRefsByID(ids [][]byte, opts DocumentFetchOptions) (DocumentRowRefLookupResponse, error) {
+	start := time.Now()
+	response, err := v.lookupDocumentRowRefsByID(ids, opts)
+	response.Stats.FetchNanos = time.Since(start).Nanoseconds()
+	return response, err
+}
+
+func (v *CollectionReadView) lookupDocumentRowRefsByID(ids [][]byte, opts DocumentFetchOptions) (DocumentRowRefLookupResponse, error) {
+	if err := v.validateOpen(); err != nil {
+		return DocumentRowRefLookupResponse{}, err
+	}
+	if len(ids) == 0 {
+		return DocumentRowRefLookupResponse{}, nil
+	}
+	response := DocumentRowRefLookupResponse{
+		Results: make([]DocumentRowRefLookupResult, len(ids)),
+		Stats: DocumentMaterializationStats{
+			DocumentsRequested: uint64(len(ids)),
+		},
+	}
+	if !columnStoreCanReconstructDocument(v.catalog.meta) {
+		response.Stats.RowRefUnsupported++
+		return response, errors.New("collections: document row ref lookup requires typed-storage reconstruction support")
+	}
+	cfg := v.catalog.meta.Options.ColumnStore.copy()
+	readIntegrity := opts.ColumnAssetReadIntegrity
+	if readIntegrity == "" {
+		readIntegrity = ColumnAssetReadIntegrityVerify
+	}
+	if err := v.ensureAssetReadCaches(cfg, readIntegrity); err != nil {
+		response.Stats.RowRefUnsupported++
+		return response, err
+	}
+	assetCountersBefore := v.assetCounters()
+	defer func() {
+		addDocumentMaterializerAssetCounterDeltas(&response.Stats, assetCountersBefore, v.assetCounters())
+	}()
+	if err := v.ensureDocumentRowLocator(cfg, readIntegrity, &response.Stats); err != nil {
+		response.Stats.RowRefUnsupported++
+		return response, err
+	}
+	var idArena []byte
+	for i, id := range ids {
+		if len(id) == 0 {
+			return response, fmt.Errorf("collections: document id at position %d cannot be empty", i)
+		}
+		idStart := len(idArena)
+		idArena = append(idArena, id...)
+		ownedID := idArena[idStart:len(idArena):len(idArena)]
+		response.Results[i].ID = ownedID
+		response.Stats.RowLocatorLookups++
+		rowRef, ok := v.rowLocator.byID[string(id)]
+		if !ok {
+			response.Stats.RowLocatorMisses++
+			continue
+		}
+		rowRef.DocumentID = ownedID
+		response.Results[i].RowRef = rowRef
+		response.Results[i].Found = true
+	}
+	return response, nil
+}
+
+func (v *CollectionReadView) materializerColumnSnapshotView(cfg ColumnStoreConfig) (columnPhysicalScanSnapshotView, error) {
+	if v == nil || v.collection == nil || v.catalog == nil || v.snapshot == nil {
+		return columnPhysicalScanSnapshotView{}, errors.New("collections: nil collection read view")
+	}
+	if v.columnSnapshotView != nil {
+		return *v.columnSnapshotView, nil
+	}
+	collectionName := v.catalog.meta.Name
+	rootID := v.catalog.rootID(collectionColumnManifestRootName(collectionName))
+	view, err := v.collection.prepareColumnPhysicalScanSnapshotViewAtSnapshotWithSidecars(v.snapshot, v.catalog, collectionName, rootID, cfg, true, columnManifestScanNoSidecars())
+	if err != nil {
+		return columnPhysicalScanSnapshotView{}, err
+	}
+	v.columnSnapshotView = &view
+	return view, nil
+}
+
+func (v *CollectionReadView) ensureDocumentRowLocator(cfg ColumnStoreConfig, readIntegrity ColumnAssetReadIntegrity, stats *DocumentMaterializationStats) error {
+	if v == nil {
+		return errors.New("collections: nil collection read view")
+	}
+	if v.rowLocator != nil {
+		return nil
+	}
+	if err := v.ensureAssetReadCaches(cfg, readIntegrity); err != nil {
+		return err
+	}
+	view, err := v.materializerColumnSnapshotView(cfg)
+	if err != nil {
+		return err
+	}
+	projection := noColumnPhysicalScanProjection(view.Config)
+	latest := make(map[string]documentRowLocatorCandidate, max(len(view.AssetRefs), 1))
+	var rawScratch []byte
+	buildStart := time.Now()
+	if stats != nil {
+		stats.RowLocatorBuilds++
+	}
+	for _, assetRef := range view.AssetRefs {
+		if assetRef.Ref.Kind != ColumnAssetKindTCS1PartImage {
+			return fmt.Errorf("collections: document row locator unsupported asset kind %q", assetRef.Ref.Kind)
+		}
+		raw, err := v.rowAssetReadCache.read(assetRef.Ref, rawScratch)
+		if err != nil {
+			return fmt.Errorf("collections: document row locator read generation=%d part_id=%d: %w", assetRef.Ref.Generation, assetRef.Ref.PartID, err)
+		}
+		rawScratch = raw
+		if stats != nil {
+			stats.RowLocatorPhysicalBytes += int64(len(raw))
+		}
+		summary, err := scanColumnPhysicalAssetRowsWithManifestOperation(raw, assetRef.Ref, view.CollectionName, &view.Config, projection, assetRef.Reason, func(row columnPhysicalScanRowView) error {
+			key := string(row.ID)
+			candidate := documentRowLocatorCandidate{ref: documentRowRefFromScanRowView(row), deleted: row.Deleted}
+			if existing, ok := latest[key]; !ok || documentRowRefNewer(candidate.ref, existing.ref) {
+				latest[key] = candidate
+			}
+			return nil
+		})
+		if err != nil {
+			return fmt.Errorf("collections: document row locator decode generation=%d part_id=%d: %w", assetRef.Ref.Generation, assetRef.Ref.PartID, err)
+		}
+		if stats != nil {
+			stats.RowLocatorRowsScanned += uint64(summary.rows)
+		}
+	}
+	locator := &documentRowLocator{byID: make(map[string]DocumentRowRef, len(latest))}
+	for key, candidate := range latest {
+		if candidate.deleted {
+			continue
+		}
+		locator.byID[key] = candidate.ref
+	}
+	v.rowLocator = locator
+	if stats != nil {
+		stats.RowLocatorNanos += time.Since(buildStart).Nanoseconds()
+	}
+	return nil
+}
+
+func noColumnPhysicalScanProjection(cfg ColumnStoreConfig) columnPhysicalScanProjection {
+	projection := columnPhysicalScanProjection{outputByColumn: make([]int, len(cfg.Columns))}
+	for i := range projection.outputByColumn {
+		projection.outputByColumn[i] = -1
+	}
+	return projection
+}
+
+func (v *CollectionReadView) validateDocumentRowRefLatest(ref DocumentRowRef, stats *DocumentMaterializationStats) error {
+	if v == nil || v.rowLocator == nil {
+		return nil
+	}
+	if stats != nil {
+		stats.RowLocatorLookups++
+	}
+	latest, ok := v.rowLocator.byID[string(ref.DocumentID)]
+	if !ok {
+		if stats != nil {
+			stats.RowLocatorMisses++
+			stats.RowRefValidationFailures++
+		}
+		return fmt.Errorf("collections: document row ref for id %q is not latest-visible in snapshot", string(ref.DocumentID))
+	}
+	if err := validateDocumentRowRefMatchesRowRef(ref, latest); err != nil {
+		if stats != nil {
+			stats.RowRefValidationFailures++
+		}
+		return err
+	}
+	return nil
+}
+
+func (v *CollectionReadView) fetchDocumentPointRow(view columnPhysicalScanSnapshotView, ref DocumentRowRef, scratch *columnPhysicalRowReaderScratch, stats *DocumentMaterializationStats) (columnPhysicalVisibleRow, error) {
+	if stats != nil {
+		stats.PointRowFetches++
+	}
+	assetRef, err := v.pointRowAssetRef(view, ref)
+	if err != nil {
+		return columnPhysicalVisibleRow{}, err
+	}
+	block, err := v.loadPointRowBlock(view, assetRef)
+	if err != nil {
+		return columnPhysicalVisibleRow{}, err
+	}
+	if ref.RowIndex < 0 || ref.RowIndex >= len(block.rowOffsets) {
+		return columnPhysicalVisibleRow{}, fmt.Errorf("collections: document row ref for id %q row_index=%d outside physical rows=%d", string(ref.DocumentID), ref.RowIndex, len(block.rowOffsets))
+	}
+	projection, err := v.pointRowScanProjection(view)
+	if err != nil {
+		return columnPhysicalVisibleRow{}, err
+	}
+	reader := &columnPhysicalRowReader{view: view, projection: projection}
+	row, err := reader.decodeRowFromBlock(block, ref.RowIndex, ref.RowIndex, scratch)
+	if err != nil {
+		return columnPhysicalVisibleRow{}, err
+	}
+	if stats != nil {
+		stats.PointRowDecodes++
+	}
+	if err := validateDocumentRowRefMatchesPointRow(ref, row); err != nil {
+		return columnPhysicalVisibleRow{}, err
+	}
+	return columnPhysicalVisibleRowFromReaderRow(row), nil
+}
+
+func (v *CollectionReadView) pointRowAssetRef(view columnPhysicalScanSnapshotView, ref DocumentRowRef) (columnManifestAssetRefForScan, error) {
+	if v.pointRowRefs == nil {
+		v.pointRowRefs = make(map[documentRowPartKey]columnManifestAssetRefForScan, len(view.AssetRefs))
+		for _, assetRef := range view.AssetRefs {
+			if assetRef.Ref.Kind != ColumnAssetKindTCS1PartImage {
+				return columnManifestAssetRefForScan{}, fmt.Errorf("collections: document row ref unsupported asset kind %q", assetRef.Ref.Kind)
+			}
+			key := documentRowPartKey{Generation: assetRef.Ref.Generation, PartID: assetRef.Ref.PartID}
+			if _, exists := v.pointRowRefs[key]; exists {
+				return columnManifestAssetRefForScan{}, fmt.Errorf("collections: duplicate document row ref asset generation=%d part_id=%d", key.Generation, key.PartID)
+			}
+			v.pointRowRefs[key] = assetRef
+		}
+	}
+	key := documentRowPartKey{Generation: ref.Generation, PartID: ref.PartID}
+	assetRef, ok := v.pointRowRefs[key]
+	if !ok {
+		return columnManifestAssetRefForScan{}, fmt.Errorf("collections: document row ref for id %q generation=%d part_id=%d is not present in snapshot", string(ref.DocumentID), ref.Generation, ref.PartID)
+	}
+	return assetRef, nil
+}
+
+func (v *CollectionReadView) loadPointRowBlock(view columnPhysicalScanSnapshotView, assetRef columnManifestAssetRefForScan) (*columnPhysicalRowReaderBlock, error) {
+	key := documentRowPartKey{Generation: assetRef.Ref.Generation, PartID: assetRef.Ref.PartID}
+	if block := v.pointRowBlocks[key]; block != nil {
+		return block, nil
+	}
+	if v.rowAssetReadCache == nil {
+		return nil, errors.New("collections: document row point fetch requires row asset read cache")
+	}
+	raw, err := v.rowAssetReadCache.read(assetRef.Ref, nil)
+	if err != nil {
+		return nil, fmt.Errorf("collections: document row point fetch read generation=%d part_id=%d: %w", assetRef.Ref.Generation, assetRef.Ref.PartID, err)
+	}
+	if !v.rowAssetReadCache.lastView {
+		raw = bytes.Clone(raw)
+	}
+	header, version, rowsOffset, err := parseColumnPhysicalAssetScanHeader(raw, assetRef.Ref, view.CollectionName, &view.Config, assetRef.Reason)
+	if err != nil {
+		return nil, fmt.Errorf("collections: document row point fetch header generation=%d part_id=%d: %w", assetRef.Ref.Generation, assetRef.Ref.PartID, err)
+	}
+	header = cloneColumnPhysicalAssetScanHeader(header)
+	rowOffsets, err := indexColumnPhysicalAssetReaderRows(raw, version, rowsOffset, header, &view.Config)
+	if err != nil {
+		return nil, fmt.Errorf("collections: document row point fetch index generation=%d part_id=%d: %w", assetRef.Ref.Generation, assetRef.Ref.PartID, err)
+	}
+	block := &columnPhysicalRowReaderBlock{
+		assetOrdinal:  -1,
+		raw:           raw,
+		version:       version,
+		header:        header,
+		rowOffsets:    rowOffsets,
+		residentBytes: int64(len(raw)),
+	}
+	if v.pointRowBlocks == nil {
+		v.pointRowBlocks = make(map[documentRowPartKey]*columnPhysicalRowReaderBlock)
+	}
+	v.pointRowBlocks[key] = block
+	return block, nil
+}
+
+func (v *CollectionReadView) pointRowScanProjection(view columnPhysicalScanSnapshotView) (columnPhysicalScanProjection, error) {
+	if v.pointRowProjection != nil {
+		return *v.pointRowProjection, nil
+	}
+	projection, err := newColumnPhysicalScanProjection(view.Config, nil)
+	if err != nil {
+		return columnPhysicalScanProjection{}, err
+	}
+	v.pointRowProjection = &projection
+	return projection, nil
+}
+
 // FetchDocumentsByRowRef materializes full documents for row refs in input
-// order. The current implementation validates the row ref against the visible
-// row discovered by a batched document-ID scan; direct row-locator fetch is
-// intentionally deferred to #1874.
+// order. Supported typed-row refs are point-fetched by generation/part/row_index
+// and validated against the decoded physical row before reconstruction.
 func (v *CollectionReadView) FetchDocumentsByRowRef(refs []DocumentRowRef, opts DocumentFetchOptions) (DocumentFetchResponse, error) {
+	start := time.Now()
+	response, err := v.fetchDocumentsByRowRef(refs, opts)
+	response.Stats.FetchNanos = time.Since(start).Nanoseconds()
+	return response, err
+}
+
+func (v *CollectionReadView) fetchDocumentsByRowRef(refs []DocumentRowRef, opts DocumentFetchOptions) (DocumentFetchResponse, error) {
 	if err := v.validateOpen(); err != nil {
 		return DocumentFetchResponse{}, err
 	}
 	if len(refs) == 0 {
 		return DocumentFetchResponse{}, nil
 	}
+	if !columnStoreCanReconstructDocument(v.catalog.meta) {
+		response := DocumentFetchResponse{Stats: DocumentMaterializationStats{DocumentsRequested: uint64(len(refs)), RowRefUnsupported: 1}}
+		return response, errors.New("collections: document row ref materialization requires typed-storage reconstruction support")
+	}
 	ids := make([][]byte, len(refs))
-	expected := make([]*DocumentRowRef, len(refs))
 	for i := range refs {
-		if len(refs[i].DocumentID) == 0 {
-			return DocumentFetchResponse{}, fmt.Errorf("collections: document row ref %d missing document id", i)
-		}
-		if refs[i].RowIndex < 0 {
-			return DocumentFetchResponse{}, fmt.Errorf("collections: document row ref %d has negative row index", i)
+		if err := validateDocumentRowRefForPointFetch(i, refs[i]); err != nil {
+			return DocumentFetchResponse{}, err
 		}
 		ids[i] = refs[i].DocumentID
-		expected[i] = &refs[i]
 	}
-	start := time.Now()
-	response, err := v.fetchDocumentsByID(ids, expected, opts)
-	response.Stats.FetchNanos = time.Since(start).Nanoseconds()
-	response.Stats.RowRefFallbackScans++
-	return response, err
+	response, retained, foundCount, err := v.fetchRetainedPayloadsByID(ids)
+	if err != nil {
+		return response, err
+	}
+	if foundCount != len(refs) {
+		for i := range response.Results {
+			if !response.Results[i].Found {
+				response.Stats.RowRefValidationFailures++
+				return response, fmt.Errorf("collections: document row ref for id %q is not visible in primary root", string(response.Results[i].ID))
+			}
+		}
+	}
+	return v.fetchColumnStoreDocumentsByRowRef(response, refs, retained, opts)
 }
 
 func (v *CollectionReadView) fetchDocumentsByID(ids [][]byte, expected []*DocumentRowRef, opts DocumentFetchOptions) (DocumentFetchResponse, error) {
@@ -421,36 +776,9 @@ func (v *CollectionReadView) fetchDocumentsByID(ids [][]byte, expected []*Docume
 	if len(ids) == 0 {
 		return DocumentFetchResponse{}, nil
 	}
-	response := DocumentFetchResponse{
-		Results: make([]DocumentFetchResult, len(ids)),
-		Stats: DocumentMaterializationStats{
-			DocumentsRequested: uint64(len(ids)),
-		},
-	}
-	var idArena []byte
-	retained := make([][]byte, len(ids))
-	foundCount := 0
-	for i, id := range ids {
-		if len(id) == 0 {
-			return response, fmt.Errorf("collections: document id at position %d cannot be empty", i)
-		}
-		idStart := len(idArena)
-		idArena = append(idArena, id...)
-		ownedID := idArena[idStart:len(idArena):len(idArena)]
-		response.Results[i].ID = ownedID
-		value, found, err := collectionGetAppendAtCatalogRoot(v.snapshot, v.catalog, collectionPrimaryRootName(v.catalog.meta.Name), id, nil)
-		if err != nil {
-			return response, err
-		}
-		if !found {
-			response.Stats.DocumentsMissing++
-			continue
-		}
-		response.Results[i].Found = true
-		retained[i] = value
-		foundCount++
-		response.Stats.RetainedPayloadFetches++
-		response.Stats.RetainedPayloadBytes += uint64(len(value))
+	response, retained, foundCount, err := v.fetchRetainedPayloadsByID(ids)
+	if err != nil {
+		return response, err
 	}
 	if foundCount == 0 {
 		return response, nil
@@ -471,6 +799,131 @@ func (v *CollectionReadView) fetchDocumentsByID(ids [][]byte, expected []*Docume
 		return response, nil
 	}
 	return v.fetchColumnStoreDocumentsByID(response, ids, retained, expected, opts)
+}
+
+func (v *CollectionReadView) fetchRetainedPayloadsByID(ids [][]byte) (DocumentFetchResponse, [][]byte, int, error) {
+	response := DocumentFetchResponse{
+		Results: make([]DocumentFetchResult, len(ids)),
+		Stats: DocumentMaterializationStats{
+			DocumentsRequested: uint64(len(ids)),
+		},
+	}
+	var idArena []byte
+	retained := make([][]byte, len(ids))
+	foundCount := 0
+	for i, id := range ids {
+		if len(id) == 0 {
+			return response, retained, foundCount, fmt.Errorf("collections: document id at position %d cannot be empty", i)
+		}
+		idStart := len(idArena)
+		idArena = append(idArena, id...)
+		ownedID := idArena[idStart:len(idArena):len(idArena)]
+		response.Results[i].ID = ownedID
+		value, found, err := collectionGetAppendAtCatalogRoot(v.snapshot, v.catalog, collectionPrimaryRootName(v.catalog.meta.Name), id, nil)
+		if err != nil {
+			return response, retained, foundCount, err
+		}
+		if !found {
+			response.Stats.DocumentsMissing++
+			continue
+		}
+		response.Results[i].Found = true
+		retained[i] = value
+		foundCount++
+		response.Stats.RetainedPayloadFetches++
+		response.Stats.RetainedPayloadBytes += uint64(len(value))
+	}
+	return response, retained, foundCount, nil
+}
+
+func (v *CollectionReadView) fetchColumnStoreDocumentsByRowRef(response DocumentFetchResponse, refs []DocumentRowRef, retained [][]byte, opts DocumentFetchOptions) (out DocumentFetchResponse, err error) {
+	out = response
+	cfg := v.catalog.meta.Options.ColumnStore.copy()
+	readIntegrity := opts.ColumnAssetReadIntegrity
+	if readIntegrity == "" {
+		readIntegrity = ColumnAssetReadIntegrityVerify
+	}
+	if err := v.ensureAssetReadCaches(cfg, readIntegrity); err != nil {
+		out.Stats.RowRefUnsupported++
+		return out, err
+	}
+	assetCountersBefore := v.assetCounters()
+	defer func() {
+		addDocumentMaterializerAssetCounterDeltas(&out.Stats, assetCountersBefore, v.assetCounters())
+	}()
+	view, err := v.materializerColumnSnapshotView(cfg)
+	if err != nil {
+		out.Stats.RowRefUnsupported++
+		return out, err
+	}
+	if view.MutationParts != 0 {
+		if err := v.ensureDocumentRowLocator(cfg, readIntegrity, &out.Stats); err != nil {
+			out.Stats.RowRefUnsupported++
+			return out, err
+		}
+	}
+	typedColumnCache := v.typedColumnReconstructionCacheForConfig(cfg)
+	manifestRootID := v.catalog.rootID(collectionColumnManifestRootName(v.catalog.meta.Name))
+	typedScratch := make([]columnDeclaredValue, 0, len(columnStoreTypedColumnPartFields(cfg)))
+	mergeScratch := make([]columnDeclaredValue, 0, len(cfg.Columns))
+	var rowScratch columnPhysicalRowReaderScratch
+	var documentArena []byte
+	for i := range out.Results {
+		if !out.Results[i].Found {
+			out.Stats.RowRefValidationFailures++
+			return out, fmt.Errorf("collections: document row ref for id %q is not visible in primary root", string(out.Results[i].ID))
+		}
+		if view.MutationParts != 0 {
+			if err := v.validateDocumentRowRefLatest(refs[i], &out.Stats); err != nil {
+				return out, err
+			}
+		}
+		row, err := v.fetchDocumentPointRow(view, refs[i], &rowScratch, &out.Stats)
+		if err != nil {
+			out.Stats.RowRefValidationFailures++
+			return out, err
+		}
+		if row.Deleted {
+			out.Stats.RowRefValidationFailures++
+			return out, fmt.Errorf("collections: document row ref for id %q points at deleted row", string(refs[i].DocumentID))
+		}
+		rowRef := documentRowRefFromVisibleRow(row)
+		rowRef.DocumentID = out.Results[i].ID
+		out.Results[i].RowRef = rowRef
+
+		beforeCacheHits, beforeCacheMisses, beforePartLoads, beforePartDecodes := typedColumnCacheCounters(typedColumnCache)
+		typedStart := time.Now()
+		typedValues, err := v.collection.typedColumnPartValuesForVisibleRowAtSnapshotIntoWithCache(v.snapshot, manifestRootID, cfg, row, typedColumnCache, typedScratch)
+		typedElapsed := time.Since(typedStart)
+		if err != nil {
+			return out, err
+		}
+		if len(typedValues.Values) > 0 || columnStoreHasTypedColumnPartOwners(cfg) {
+			out.Stats.TypedColumnRows++
+		}
+		afterCacheHits, afterCacheMisses, afterPartLoads, afterPartDecodes := typedColumnCacheCounters(typedColumnCache)
+		out.Stats.TypedColumnCacheHits += deltaUint64(beforeCacheHits, afterCacheHits)
+		out.Stats.TypedColumnCacheMisses += deltaUint64(beforeCacheMisses, afterCacheMisses)
+		out.Stats.TypedColumnPartLoads += deltaUint64(beforePartLoads, afterPartLoads)
+		out.Stats.TypedColumnPartDecodes += deltaUint64(beforePartDecodes, afterPartDecodes)
+		out.Stats.TypedColumnNanos += typedElapsed.Nanoseconds()
+
+		reconstructStart := time.Now()
+		fullValues, err := mergeColumnReconstructionValuesInto(cfg, row.Values, typedValues.Values, mergeScratch)
+		if err != nil {
+			return out, err
+		}
+		reconstructed, err := reconstructColumnDocumentFromVisibleRowValues(cfg, retained[i], row, fullValues)
+		if err != nil {
+			return out, err
+		}
+		out.Stats.JSONReconstructionNanos += time.Since(reconstructStart).Nanoseconds()
+		out.Stats.JSONReconstructionRows++
+		documentArena = appendDocumentFetchOwnedBytes(documentArena, reconstructed, &out.Results[i])
+		out.Stats.DocumentsFetched++
+		out.Stats.DocumentBytes += uint64(len(out.Results[i].Document))
+	}
+	return out, nil
 }
 
 func (v *CollectionReadView) fetchColumnStoreDocumentsByID(response DocumentFetchResponse, ids [][]byte, retained [][]byte, expected []*DocumentRowRef, opts DocumentFetchOptions) (out DocumentFetchResponse, err error) {
@@ -512,10 +965,7 @@ func (v *CollectionReadView) fetchColumnStoreDocumentsByID(response DocumentFetc
 	for _, row := range visible.Rows {
 		visibleByID[string(row.ID)] = row
 	}
-	var typedColumnCache *typedColumnPartReconstructionCache
-	if columnStoreHasTypedColumnPartOwners(cfg) {
-		typedColumnCache = &typedColumnPartReconstructionCache{Parts: make(map[uint64]typedColumnPartDecodedValues), ReadCache: v.typedColumnAssetReadCache}
-	}
+	typedColumnCache := v.typedColumnReconstructionCacheForConfig(cfg)
 	manifestRootID := v.catalog.rootID(collectionColumnManifestRootName(v.catalog.meta.Name))
 	typedScratch := make([]columnDeclaredValue, 0, len(columnStoreTypedColumnPartFields(cfg)))
 	mergeScratch := make([]columnDeclaredValue, 0, len(cfg.Columns))
@@ -599,6 +1049,110 @@ func documentRowRefFromVisibleRow(row columnPhysicalVisibleRow) DocumentRowRef {
 	}
 }
 
+func documentRowRefFromScanRowView(row columnPhysicalScanRowView) DocumentRowRef {
+	// Row locators are keyed by document ID, so the stored ref only needs the
+	// physical row coordinates. Lookup callers attach an owned DocumentID to the
+	// response row ref; avoiding a per-row ID clone keeps locator builds cheap.
+	return DocumentRowRef{
+		Generation:        row.Generation,
+		PartID:            row.PartID,
+		RowIndex:          row.RowIndex,
+		AppliedCommandLSN: row.AppliedCommandLSN,
+	}
+}
+
+func documentRowRefNewer(a, b DocumentRowRef) bool {
+	if a.AppliedCommandLSN != b.AppliedCommandLSN {
+		return a.AppliedCommandLSN > b.AppliedCommandLSN
+	}
+	if a.Generation != b.Generation {
+		return a.Generation > b.Generation
+	}
+	if a.PartID != b.PartID {
+		return a.PartID > b.PartID
+	}
+	return a.RowIndex > b.RowIndex
+}
+
+func columnPhysicalVisibleRowFromReaderRow(row columnPhysicalRowReaderRow) columnPhysicalVisibleRow {
+	return columnPhysicalVisibleRow{
+		Generation:        row.Generation,
+		PartID:            row.PartID,
+		AppliedCommandLSN: row.AppliedCommandLSN,
+		Operation:         row.Operation,
+		RowIndex:          row.RowIndex,
+		ID:                row.ID,
+		Values:            row.Values,
+		Deleted:           row.Deleted,
+	}
+}
+
+func validateDocumentRowRefForPointFetch(pos int, ref DocumentRowRef) error {
+	if len(ref.DocumentID) == 0 {
+		return fmt.Errorf("collections: document row ref %d missing document id", pos)
+	}
+	if ref.Generation == 0 {
+		return fmt.Errorf("collections: document row ref %d missing generation", pos)
+	}
+	if ref.PartID == 0 {
+		return fmt.Errorf("collections: document row ref %d missing part_id", pos)
+	}
+	if ref.RowIndex < 0 {
+		return fmt.Errorf("collections: document row ref %d has negative row_index", pos)
+	}
+	if ref.AppliedCommandLSN == 0 {
+		return fmt.Errorf("collections: document row ref %d missing applied_command_lsn", pos)
+	}
+	return nil
+}
+
+func validateDocumentRowRefMatchesPointRow(ref DocumentRowRef, row columnPhysicalRowReaderRow) error {
+	if len(ref.DocumentID) == 0 {
+		return errors.New("collections: document row ref missing document id")
+	}
+	if !bytes.Equal(ref.DocumentID, row.ID) {
+		return fmt.Errorf("collections: document row ref id %q does not match physical row id %q", string(ref.DocumentID), string(row.ID))
+	}
+	if ref.Generation != row.Generation {
+		return fmt.Errorf("collections: document row ref for id %q generation=%d does not match physical generation=%d", string(ref.DocumentID), ref.Generation, row.Generation)
+	}
+	if ref.PartID != row.PartID {
+		return fmt.Errorf("collections: document row ref for id %q part_id=%d does not match physical part_id=%d", string(ref.DocumentID), ref.PartID, row.PartID)
+	}
+	if ref.RowIndex != row.RowIndex {
+		return fmt.Errorf("collections: document row ref for id %q row_index=%d does not match physical row_index=%d", string(ref.DocumentID), ref.RowIndex, row.RowIndex)
+	}
+	if ref.AppliedCommandLSN != row.AppliedCommandLSN {
+		return fmt.Errorf("collections: document row ref for id %q applied_command_lsn=%d does not match physical applied_command_lsn=%d", string(ref.DocumentID), ref.AppliedCommandLSN, row.AppliedCommandLSN)
+	}
+	if row.Deleted {
+		return fmt.Errorf("collections: document row ref for id %q points at deleted physical row", string(ref.DocumentID))
+	}
+	return nil
+}
+
+func validateDocumentRowRefMatchesRowRef(ref DocumentRowRef, latest DocumentRowRef) error {
+	if len(ref.DocumentID) == 0 {
+		return errors.New("collections: document row ref missing document id")
+	}
+	if len(latest.DocumentID) != 0 && !bytes.Equal(ref.DocumentID, latest.DocumentID) {
+		return fmt.Errorf("collections: document row ref id %q does not match latest-visible id %q", string(ref.DocumentID), string(latest.DocumentID))
+	}
+	if ref.Generation != latest.Generation {
+		return fmt.Errorf("collections: document row ref for id %q generation=%d does not match latest-visible generation=%d", string(ref.DocumentID), ref.Generation, latest.Generation)
+	}
+	if ref.PartID != latest.PartID {
+		return fmt.Errorf("collections: document row ref for id %q part_id=%d does not match latest-visible part_id=%d", string(ref.DocumentID), ref.PartID, latest.PartID)
+	}
+	if ref.RowIndex != latest.RowIndex {
+		return fmt.Errorf("collections: document row ref for id %q row_index=%d does not match latest-visible row_index=%d", string(ref.DocumentID), ref.RowIndex, latest.RowIndex)
+	}
+	if ref.AppliedCommandLSN != latest.AppliedCommandLSN {
+		return fmt.Errorf("collections: document row ref for id %q applied_command_lsn=%d does not match latest-visible applied_command_lsn=%d", string(ref.DocumentID), ref.AppliedCommandLSN, latest.AppliedCommandLSN)
+	}
+	return nil
+}
+
 func validateDocumentRowRefMatchesVisibleRow(ref DocumentRowRef, row columnPhysicalVisibleRow) error {
 	if len(ref.DocumentID) == 0 {
 		return errors.New("collections: document row ref missing document id")
@@ -622,6 +1176,19 @@ func validateDocumentRowRefMatchesVisibleRow(ref DocumentRowRef, row columnPhysi
 		return fmt.Errorf("collections: document row ref for id %q applied_command_lsn=%d does not match visible applied_command_lsn=%d", string(ref.DocumentID), ref.AppliedCommandLSN, row.AppliedCommandLSN)
 	}
 	return nil
+}
+
+func (v *CollectionReadView) typedColumnReconstructionCacheForConfig(cfg ColumnStoreConfig) *typedColumnPartReconstructionCache {
+	if v == nil || !columnStoreHasTypedColumnPartOwners(cfg) {
+		return nil
+	}
+	if v.typedColumnReconstructionCache == nil || v.typedColumnReconstructionCache.ReadCache != v.typedColumnAssetReadCache {
+		v.typedColumnReconstructionCache = &typedColumnPartReconstructionCache{
+			Parts:     make(map[uint64]typedColumnPartDecodedValues),
+			ReadCache: v.typedColumnAssetReadCache,
+		}
+	}
+	return v.typedColumnReconstructionCache
 }
 
 func typedColumnCacheCounters(cache *typedColumnPartReconstructionCache) (hits, misses, loads, decodes uint64) {
@@ -658,7 +1225,21 @@ func addDocumentMaterializationStatsToVectorStats(dst *VectorIndexSearchStats, s
 	dst.DocumentTypedColumnNanos += uint64(maxInt64ForMetric(src.TypedColumnNanos, 0))
 	dst.DocumentJSONReconstructionRows += src.JSONReconstructionRows
 	dst.DocumentJSONReconstructionNanos += uint64(maxInt64ForMetric(src.JSONReconstructionNanos, 0))
+	dst.DocumentRowLocatorBuilds += src.RowLocatorBuilds
+	dst.DocumentRowLocatorLookups += src.RowLocatorLookups
+	dst.DocumentRowLocatorMisses += src.RowLocatorMisses
+	dst.DocumentRowLocatorRowsScanned += src.RowLocatorRowsScanned
+	locatorBytes, err := addInt64ToUint64Metric(dst.DocumentRowLocatorPhysicalBytes, src.RowLocatorPhysicalBytes, "document row locator physical bytes")
+	if err != nil {
+		return err
+	}
+	dst.DocumentRowLocatorPhysicalBytes = locatorBytes
+	dst.DocumentRowLocatorNanos += uint64(maxInt64ForMetric(src.RowLocatorNanos, 0))
+	dst.DocumentPointRowFetches += src.PointRowFetches
+	dst.DocumentPointRowDecodes += src.PointRowDecodes
 	dst.DocumentRowRefFallbackScans += src.RowRefFallbackScans
+	dst.DocumentRowRefUnsupported += src.RowRefUnsupported
+	dst.DocumentRowRefValidationFailures += src.RowRefValidationFailures
 	dst.DocumentAssetMmapHits += src.AssetMmapHits
 	dst.DocumentAssetReadAtFallbacks += src.AssetReadAtFallbacks
 	dst.DocumentAssetFileOpens += src.AssetFileOpens

--- a/TreeDB/collections/document_materializer.go
+++ b/TreeDB/collections/document_materializer.go
@@ -477,7 +477,6 @@ func (v *CollectionReadView) lookupDocumentRowRefsByID(ids [][]byte, opts Docume
 		readIntegrity = ColumnAssetReadIntegrityVerify
 	}
 	if err := v.ensureAssetReadCaches(cfg, readIntegrity); err != nil {
-		response.Stats.RowRefUnsupported++
 		return response, err
 	}
 	assetCountersBefore := v.assetCounters()
@@ -485,7 +484,6 @@ func (v *CollectionReadView) lookupDocumentRowRefsByID(ids [][]byte, opts Docume
 		addDocumentMaterializerAssetCounterDeltas(&response.Stats, assetCountersBefore, v.assetCounters())
 	}()
 	if err := v.ensureDocumentRowLocator(cfg, readIntegrity, &response.Stats); err != nil {
-		response.Stats.RowRefUnsupported++
 		return response, err
 	}
 	var idArena []byte
@@ -850,7 +848,6 @@ func (v *CollectionReadView) fetchColumnStoreDocumentsByRowRef(response Document
 		readIntegrity = ColumnAssetReadIntegrityVerify
 	}
 	if err := v.ensureAssetReadCaches(cfg, readIntegrity); err != nil {
-		out.Stats.RowRefUnsupported++
 		return out, err
 	}
 	assetCountersBefore := v.assetCounters()
@@ -859,12 +856,10 @@ func (v *CollectionReadView) fetchColumnStoreDocumentsByRowRef(response Document
 	}()
 	view, err := v.materializerColumnSnapshotView(cfg)
 	if err != nil {
-		out.Stats.RowRefUnsupported++
 		return out, err
 	}
 	if view.MutationParts != 0 {
 		if err := v.ensureDocumentRowLocator(cfg, readIntegrity, &out.Stats); err != nil {
-			out.Stats.RowRefUnsupported++
 			return out, err
 		}
 	}

--- a/TreeDB/collections/document_materializer.go
+++ b/TreeDB/collections/document_materializer.go
@@ -436,9 +436,6 @@ func (v *CollectionReadView) clearDerivedRowFetchCaches() {
 	if v == nil {
 		return
 	}
-	for key := range v.pointRowBlocks {
-		delete(v.pointRowBlocks, key)
-	}
 	v.pointRowBlocks = nil
 	v.rowLocator = nil
 	v.columnSnapshotView = nil
@@ -886,7 +883,7 @@ func (v *CollectionReadView) fetchColumnStoreDocumentsByRowRef(response Document
 			out.Stats.RowRefValidationFailures++
 			return out, err
 		}
-		rowRef := documentRowRefFromVisibleRow(row)
+		rowRef := documentRowRefCoordinatesFromVisibleRow(row)
 		rowRef.DocumentID = out.Results[i].ID
 		out.Results[i].RowRef = rowRef
 
@@ -1039,8 +1036,13 @@ func appendDocumentFetchOwnedBytes(arena []byte, src []byte, result *DocumentFet
 }
 
 func documentRowRefFromVisibleRow(row columnPhysicalVisibleRow) DocumentRowRef {
+	ref := documentRowRefCoordinatesFromVisibleRow(row)
+	ref.DocumentID = bytes.Clone(row.ID)
+	return ref
+}
+
+func documentRowRefCoordinatesFromVisibleRow(row columnPhysicalVisibleRow) DocumentRowRef {
 	return DocumentRowRef{
-		DocumentID:        bytes.Clone(row.ID),
 		Generation:        row.Generation,
 		PartID:            row.PartID,
 		RowIndex:          row.RowIndex,

--- a/TreeDB/collections/document_materializer.go
+++ b/TreeDB/collections/document_materializer.go
@@ -729,7 +729,9 @@ func (v *CollectionReadView) pointRowScanProjection(view columnPhysicalScanSnaps
 
 // FetchDocumentsByRowRef materializes full documents for row refs in input
 // order. Supported typed-row refs are point-fetched by generation/part/row_index
-// and validated against the decoded physical row before reconstruction.
+// and validated against the decoded physical row before reconstruction. Row-ref
+// fetches are strict: a missing primary-root document, stale ref, or physical
+// mismatch fails the request instead of silently returning a partial batch.
 func (v *CollectionReadView) FetchDocumentsByRowRef(refs []DocumentRowRef, opts DocumentFetchOptions) (DocumentFetchResponse, error) {
 	start := time.Now()
 	response, err := v.fetchDocumentsByRowRef(refs, opts)

--- a/TreeDB/collections/document_materializer.go
+++ b/TreeDB/collections/document_materializer.go
@@ -281,6 +281,7 @@ func (v *CollectionReadView) ensureAssetReadCaches(cfg ColumnStoreConfig, rowInt
 			v.rowLocator = nil
 			v.columnSnapshotView = nil
 			v.pointRowRefs = nil
+			v.pointRowProjection = nil
 			if err := v.rowAssetReadCache.close(); err != nil {
 				return err
 			}

--- a/TreeDB/collections/document_materializer.go
+++ b/TreeDB/collections/document_materializer.go
@@ -278,6 +278,9 @@ func (v *CollectionReadView) ensureAssetReadCaches(cfg ColumnStoreConfig, rowInt
 	if v.rowAssetReadCache == nil || v.rowAssetReadIntegrity != rowIntegrity || v.rowAssetReadCache.namespace != namespace {
 		if v.rowAssetReadCache != nil {
 			v.clearPointRowBlockCache()
+			v.rowLocator = nil
+			v.columnSnapshotView = nil
+			v.pointRowRefs = nil
 			if err := v.rowAssetReadCache.close(); err != nil {
 				return err
 			}

--- a/TreeDB/collections/document_materializer.go
+++ b/TreeDB/collections/document_materializer.go
@@ -887,10 +887,6 @@ func (v *CollectionReadView) fetchColumnStoreDocumentsByRowRef(response Document
 			out.Stats.RowRefValidationFailures++
 			return out, err
 		}
-		if row.Deleted {
-			out.Stats.RowRefValidationFailures++
-			return out, fmt.Errorf("collections: document row ref for id %q points at deleted row", string(refs[i].DocumentID))
-		}
 		rowRef := documentRowRefFromVisibleRow(row)
 		rowRef.DocumentID = out.Results[i].ID
 		out.Results[i].RowRef = rowRef

--- a/TreeDB/collections/document_materializer.go
+++ b/TreeDB/collections/document_materializer.go
@@ -129,6 +129,7 @@ type documentRowLocator struct {
 
 type documentRowLocatorCandidate struct {
 	ref     DocumentRowRef
+	ordinal int
 	deleted bool
 }
 
@@ -277,11 +278,7 @@ func (v *CollectionReadView) ensureAssetReadCaches(cfg ColumnStoreConfig, rowInt
 	namespace := cfg.AssetManager.Namespace
 	if v.rowAssetReadCache == nil || v.rowAssetReadIntegrity != rowIntegrity || v.rowAssetReadCache.namespace != namespace {
 		if v.rowAssetReadCache != nil {
-			v.clearPointRowBlockCache()
-			v.rowLocator = nil
-			v.columnSnapshotView = nil
-			v.pointRowRefs = nil
-			v.pointRowProjection = nil
+			v.clearDerivedRowFetchCaches()
 			if err := v.rowAssetReadCache.close(); err != nil {
 				return err
 			}
@@ -419,7 +416,7 @@ func (v *CollectionReadView) closeAssetReadCaches() error {
 	if v == nil {
 		return nil
 	}
-	v.clearPointRowBlockCache()
+	v.clearDerivedRowFetchCaches()
 	var closeErr error
 	if v.rowAssetReadCache != nil {
 		closeErr = errors.Join(closeErr, v.rowAssetReadCache.close())
@@ -435,13 +432,18 @@ func (v *CollectionReadView) closeAssetReadCaches() error {
 	return closeErr
 }
 
-func (v *CollectionReadView) clearPointRowBlockCache() {
+func (v *CollectionReadView) clearDerivedRowFetchCaches() {
 	if v == nil {
 		return
 	}
 	for key := range v.pointRowBlocks {
 		delete(v.pointRowBlocks, key)
 	}
+	v.pointRowBlocks = nil
+	v.rowLocator = nil
+	v.columnSnapshotView = nil
+	v.pointRowRefs = nil
+	v.pointRowProjection = nil
 }
 
 // LookupDocumentRowRefsByID resolves document IDs to snapshot-visible typed-row
@@ -546,7 +548,7 @@ func (v *CollectionReadView) ensureDocumentRowLocator(cfg ColumnStoreConfig, rea
 	if stats != nil {
 		stats.RowLocatorBuilds++
 	}
-	for _, assetRef := range view.AssetRefs {
+	for ordinal, assetRef := range view.AssetRefs {
 		if assetRef.Ref.Kind != ColumnAssetKindTCS1PartImage {
 			return fmt.Errorf("collections: document row locator unsupported asset kind %q", assetRef.Ref.Kind)
 		}
@@ -560,8 +562,8 @@ func (v *CollectionReadView) ensureDocumentRowLocator(cfg ColumnStoreConfig, rea
 		}
 		summary, err := scanColumnPhysicalAssetRowsWithManifestOperation(raw, assetRef.Ref, view.CollectionName, &view.Config, projection, assetRef.Reason, func(row columnPhysicalScanRowView) error {
 			key := string(row.ID)
-			candidate := documentRowLocatorCandidate{ref: documentRowRefFromScanRowView(row), deleted: row.Deleted}
-			if existing, ok := latest[key]; !ok || documentRowRefNewer(candidate.ref, existing.ref) {
+			candidate := documentRowLocatorCandidate{ref: documentRowRefFromScanRowView(row), ordinal: ordinal, deleted: row.Deleted}
+			if existing, ok := latest[key]; !ok || documentRowLocatorCandidateNewer(candidate, existing) {
 				latest[key] = candidate
 			}
 			return nil
@@ -1058,17 +1060,20 @@ func documentRowRefFromScanRowView(row columnPhysicalScanRowView) DocumentRowRef
 	}
 }
 
-func documentRowRefNewer(a, b DocumentRowRef) bool {
-	if a.AppliedCommandLSN != b.AppliedCommandLSN {
-		return a.AppliedCommandLSN > b.AppliedCommandLSN
+func documentRowLocatorCandidateNewer(a, b documentRowLocatorCandidate) bool {
+	if a.ref.AppliedCommandLSN != b.ref.AppliedCommandLSN {
+		return a.ref.AppliedCommandLSN > b.ref.AppliedCommandLSN
 	}
-	if a.Generation != b.Generation {
-		return a.Generation > b.Generation
+	if a.ref.Generation != b.ref.Generation {
+		return a.ref.Generation > b.ref.Generation
 	}
-	if a.PartID != b.PartID {
-		return a.PartID > b.PartID
+	if a.ref.PartID != b.ref.PartID {
+		return a.ref.PartID > b.ref.PartID
 	}
-	return a.RowIndex > b.RowIndex
+	if a.ref.RowIndex != b.ref.RowIndex {
+		return a.ref.RowIndex > b.ref.RowIndex
+	}
+	return a.ordinal > b.ordinal
 }
 
 func columnPhysicalVisibleRowFromReaderRow(row columnPhysicalRowReaderRow) columnPhysicalVisibleRow {

--- a/TreeDB/collections/document_materializer_test.go
+++ b/TreeDB/collections/document_materializer_test.go
@@ -659,7 +659,7 @@ func TestCollectionReadViewEnsureAssetReadCachesInvalidatesDerivedRowCaches1874(
 	if _, err := view.FetchDocumentsByRowRef([]DocumentRowRef{lookup.Results[0].RowRef}, DocumentFetchOptions{}); err != nil {
 		t.Fatalf("FetchDocumentsByRowRef: %v", err)
 	}
-	if view.rowLocator == nil || view.columnSnapshotView == nil || len(view.pointRowRefs) == 0 || len(view.pointRowBlocks) == 0 {
+	if view.rowLocator == nil || view.columnSnapshotView == nil || len(view.pointRowRefs) == 0 || len(view.pointRowBlocks) == 0 || view.pointRowProjection == nil {
 		t.Fatalf("expected derived caches to be populated before integrity change")
 	}
 	cfg := view.columnSnapshotView.Config

--- a/TreeDB/collections/document_materializer_test.go
+++ b/TreeDB/collections/document_materializer_test.go
@@ -681,6 +681,34 @@ func TestCollectionReadViewEnsureAssetReadCachesInvalidatesDerivedRowCaches1874(
 	if len(view.pointRowBlocks) != 0 {
 		t.Fatalf("pointRowBlocks=%d want empty after row asset cache rebuild", len(view.pointRowBlocks))
 	}
+	lookup, err = view.LookupDocumentRowRefsByID([][]byte{[]byte("e1"), []byte("e2")}, DocumentFetchOptions{})
+	if err != nil {
+		t.Fatalf("LookupDocumentRowRefsByID after rebuild: %v", err)
+	}
+	if _, err := view.FetchDocumentsByRowRef([]DocumentRowRef{lookup.Results[0].RowRef}, DocumentFetchOptions{}); err != nil {
+		t.Fatalf("FetchDocumentsByRowRef after rebuild: %v", err)
+	}
+	if view.rowLocator == nil || view.columnSnapshotView == nil || len(view.pointRowRefs) == 0 || len(view.pointRowBlocks) == 0 || view.pointRowProjection == nil {
+		t.Fatalf("expected derived caches to be repopulated before close")
+	}
+	if err := view.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if view.rowLocator != nil || view.columnSnapshotView != nil || view.pointRowRefs != nil || view.pointRowProjection != nil || view.pointRowBlocks != nil {
+		t.Fatalf("derived caches retained after Close: rowLocator=%v columnSnapshotView=%v pointRowRefs=%v pointRowProjection=%v pointRowBlocks=%v", view.rowLocator, view.columnSnapshotView, view.pointRowRefs, view.pointRowProjection, view.pointRowBlocks)
+	}
+}
+
+func TestDocumentRowLocatorCandidateNewerUsesOrdinalTieBreaker1874(t *testing.T) {
+	base := DocumentRowRef{Generation: 2, PartID: 7, RowIndex: 11, AppliedCommandLSN: 42}
+	older := documentRowLocatorCandidate{ref: base, ordinal: 3}
+	newer := documentRowLocatorCandidate{ref: base, ordinal: 4}
+	if !documentRowLocatorCandidateNewer(newer, older) {
+		t.Fatalf("higher ordinal should win exact row-ref ties")
+	}
+	if documentRowLocatorCandidateNewer(older, newer) {
+		t.Fatalf("lower ordinal should not win exact row-ref ties")
+	}
 }
 
 func BenchmarkCollectionReadViewFetchDocumentsByIDMaterializer(b *testing.B) {

--- a/TreeDB/collections/document_materializer_test.go
+++ b/TreeDB/collections/document_materializer_test.go
@@ -675,6 +675,9 @@ func TestCollectionReadViewEnsureAssetReadCachesInvalidatesDerivedRowCaches1874(
 	if view.pointRowRefs != nil {
 		t.Fatalf("pointRowRefs=%v want nil after row asset cache rebuild", view.pointRowRefs)
 	}
+	if view.pointRowProjection != nil {
+		t.Fatalf("pointRowProjection=%v want nil after row asset cache rebuild", view.pointRowProjection)
+	}
 	if len(view.pointRowBlocks) != 0 {
 		t.Fatalf("pointRowBlocks=%d want empty after row asset cache rebuild", len(view.pointRowBlocks))
 	}

--- a/TreeDB/collections/document_materializer_test.go
+++ b/TreeDB/collections/document_materializer_test.go
@@ -412,6 +412,229 @@ func TestCollectionReadViewResponseDocumentsAreOwned(t *testing.T) {
 	}
 }
 
+func TestCollectionReadViewFetchDocumentsByRowRefPointFetchInsertOnly1874(t *testing.T) {
+	d, col := newDocumentMaterializerTestCollection(t)
+	defer func() { _ = d.Close() }()
+	ids := [][]byte{[]byte("e1"), []byte("e2"), []byte("e3")}
+	docs := [][]byte{
+		[]byte(`{"row_id":1,"kind":"alpha","score":1,"payload":"first"}`),
+		[]byte(`{"row_id":2,"kind":"beta","score":2,"payload":"second"}`),
+		[]byte(`{"row_id":3,"kind":"gamma","score":3,"payload":"third"}`),
+	}
+	if _, err := col.InsertBatch(ids, docs); err != nil {
+		t.Fatalf("InsertBatch: %v", err)
+	}
+	want := make(map[string][]byte, len(ids))
+	for _, id := range ids {
+		doc, err := col.Get(id)
+		if err != nil {
+			t.Fatalf("Get %q: %v", id, err)
+		}
+		want[string(id)] = doc
+	}
+	view, err := col.OpenCollectionReadView()
+	if err != nil {
+		t.Fatalf("OpenCollectionReadView: %v", err)
+	}
+	defer func() { _ = view.Close() }()
+	resolved, err := view.FetchDocumentsByID(ids, DocumentFetchOptions{})
+	if err != nil {
+		t.Fatalf("FetchDocumentsByID: %v", err)
+	}
+	refsByID := make(map[string]DocumentRowRef, len(resolved.Results))
+	for i := range resolved.Results {
+		if !resolved.Results[i].Found {
+			t.Fatalf("resolved[%d] missing", i)
+		}
+		refsByID[string(resolved.Results[i].ID)] = resolved.Results[i].RowRef
+	}
+	orderedRefs := []DocumentRowRef{refsByID["e3"], refsByID["e1"], refsByID["e3"], refsByID["e2"]}
+	got, err := view.FetchDocumentsByRowRef(orderedRefs, DocumentFetchOptions{})
+	if err != nil {
+		t.Fatalf("FetchDocumentsByRowRef: %v", err)
+	}
+	wantIDs := []string{"e3", "e1", "e3", "e2"}
+	if len(got.Results) != len(wantIDs) {
+		t.Fatalf("results=%d want %d", len(got.Results), len(wantIDs))
+	}
+	for i, wantID := range wantIDs {
+		if !got.Results[i].Found || !bytes.Equal(got.Results[i].ID, []byte(wantID)) || !bytes.Equal(got.Results[i].Document, want[wantID]) {
+			t.Fatalf("result[%d]=%+v doc=%s want id=%s doc=%s", i, got.Results[i], got.Results[i].Document, wantID, want[wantID])
+		}
+	}
+	if got.Stats.PointRowFetches != uint64(len(orderedRefs)) || got.Stats.PointRowDecodes != uint64(len(orderedRefs)) {
+		t.Fatalf("stats=%+v want one point fetch/decode per ref", got.Stats)
+	}
+	if got.Stats.RowRefFallbackScans != 0 || got.Stats.VisibilityScans != 0 || got.Stats.VisibilityRowsScanned != 0 {
+		t.Fatalf("stats=%+v want direct row-ref point fetch without visibility scan fallback", got.Stats)
+	}
+}
+
+func TestCollectionReadViewFetchDocumentsByRowRefMutationLatestVisible1874(t *testing.T) {
+	d, col := newDocumentMaterializerTestCollection(t)
+	defer func() { _ = d.Close() }()
+	oldE1Doc := []byte(`{"row_id":1,"kind":"old","score":1,"payload":"before"}`)
+	oldE2Doc := []byte(`{"row_id":2,"kind":"keep","score":2,"payload":"delete-me"}`)
+	if _, err := col.InsertBatch([][]byte{[]byte("e1"), []byte("e2")}, [][]byte{oldE1Doc, oldE2Doc}); err != nil {
+		t.Fatalf("InsertBatch: %v", err)
+	}
+	oldE1, err := col.Get([]byte("e1"))
+	if err != nil {
+		t.Fatalf("Get old e1: %v", err)
+	}
+	oldE2, err := col.Get([]byte("e2"))
+	if err != nil {
+		t.Fatalf("Get old e2: %v", err)
+	}
+	oldView, err := col.OpenCollectionReadView()
+	if err != nil {
+		t.Fatalf("Open old read view: %v", err)
+	}
+	defer func() { _ = oldView.Close() }()
+	oldResolved, err := oldView.FetchDocumentsByID([][]byte{[]byte("e1"), []byte("e2")}, DocumentFetchOptions{})
+	if err != nil {
+		t.Fatalf("old FetchDocumentsByID: %v", err)
+	}
+	oldE1Ref := oldResolved.Results[0].RowRef
+	oldE2Ref := oldResolved.Results[1].RowRef
+
+	newE1Doc := []byte(`{"row_id":1,"kind":"new","score":11,"payload":"after"}`)
+	matched, modified, err := col.Update([]byte("e1"), func([]byte) ([]byte, bool, error) { return newE1Doc, true, nil })
+	if err != nil || !matched || !modified {
+		t.Fatalf("Update e1 matched=%t modified=%t err=%v", matched, modified, err)
+	}
+	if err := col.Delete([]byte("e2")); err != nil {
+		t.Fatalf("Delete e2: %v", err)
+	}
+	newE1, err := col.Get([]byte("e1"))
+	if err != nil {
+		t.Fatalf("Get new e1: %v", err)
+	}
+	if liveE2, err := col.Get([]byte("e2")); err != nil || liveE2 != nil {
+		t.Fatalf("Get deleted e2=%s err=%v want missing", liveE2, err)
+	}
+
+	currentView, err := col.OpenCollectionReadView()
+	if err != nil {
+		t.Fatalf("Open current read view: %v", err)
+	}
+	defer func() { _ = currentView.Close() }()
+	lookup, err := currentView.LookupDocumentRowRefsByID([][]byte{[]byte("e1"), []byte("e2")}, DocumentFetchOptions{})
+	if err != nil {
+		t.Fatalf("LookupDocumentRowRefsByID: %v", err)
+	}
+	if !lookup.Results[0].Found || lookup.Results[1].Found || lookup.Stats.RowLocatorLookups != 2 || lookup.Stats.RowLocatorMisses != 1 || lookup.Stats.RowLocatorBuilds != 1 {
+		t.Fatalf("lookup=%+v stats=%+v want updated e1 ref and deleted e2 miss", lookup.Results, lookup.Stats)
+	}
+	current, err := currentView.FetchDocumentsByRowRef([]DocumentRowRef{lookup.Results[0].RowRef}, DocumentFetchOptions{})
+	if err != nil {
+		t.Fatalf("current FetchDocumentsByRowRef: %v", err)
+	}
+	if len(current.Results) != 1 || !current.Results[0].Found || !bytes.Equal(current.Results[0].Document, newE1) {
+		t.Fatalf("current row-ref doc=%s want %s", current.Results[0].Document, newE1)
+	}
+	if current.Stats.RowRefFallbackScans != 0 || current.Stats.PointRowFetches != 1 || current.Stats.PointRowDecodes != 1 {
+		t.Fatalf("current stats=%+v want direct point fetch", current.Stats)
+	}
+	if _, err := currentView.FetchDocumentsByRowRef([]DocumentRowRef{oldE1Ref}, DocumentFetchOptions{}); err == nil || !strings.Contains(err.Error(), "latest-visible") {
+		t.Fatalf("old e1 ref on current view err=%v want latest-visible fail closed", err)
+	}
+	if _, err := currentView.FetchDocumentsByRowRef([]DocumentRowRef{oldE2Ref}, DocumentFetchOptions{}); err == nil || !strings.Contains(err.Error(), "not visible") {
+		t.Fatalf("old e2 ref on current view err=%v want deleted/missing fail closed", err)
+	}
+
+	stale, err := oldView.FetchDocumentsByRowRef([]DocumentRowRef{oldE1Ref, oldE2Ref}, DocumentFetchOptions{})
+	if err != nil {
+		t.Fatalf("old snapshot FetchDocumentsByRowRef after later writes: %v", err)
+	}
+	if len(stale.Results) != 2 || !bytes.Equal(stale.Results[0].Document, oldE1) || !bytes.Equal(stale.Results[1].Document, oldE2) {
+		t.Fatalf("stale docs=%s/%s want old %s/%s", stale.Results[0].Document, stale.Results[1].Document, oldE1, oldE2)
+	}
+}
+
+func TestCollectionReadViewFetchDocumentsByRowRefMismatchFailsClosed1874(t *testing.T) {
+	d, col := newDocumentMaterializerTestCollection(t)
+	defer func() { _ = d.Close() }()
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("e1"), []byte("e2")},
+		[][]byte{
+			[]byte(`{"row_id":1,"kind":"alpha","score":1,"payload":"first"}`),
+			[]byte(`{"row_id":2,"kind":"beta","score":2,"payload":"second"}`),
+		},
+	); err != nil {
+		t.Fatalf("InsertBatch: %v", err)
+	}
+	view, err := col.OpenCollectionReadView()
+	if err != nil {
+		t.Fatalf("OpenCollectionReadView: %v", err)
+	}
+	defer func() { _ = view.Close() }()
+	resolved, err := view.FetchDocumentsByID([][]byte{[]byte("e1")}, DocumentFetchOptions{})
+	if err != nil {
+		t.Fatalf("FetchDocumentsByID: %v", err)
+	}
+	ref := resolved.Results[0].RowRef
+	tests := []struct {
+		name string
+		mut  func(DocumentRowRef) DocumentRowRef
+		want string
+	}{
+		{name: "row_index", mut: func(r DocumentRowRef) DocumentRowRef { r.RowIndex = 99; return r }, want: "row_index"},
+		{name: "generation", mut: func(r DocumentRowRef) DocumentRowRef { r.Generation += 100; return r }, want: "generation"},
+		{name: "part", mut: func(r DocumentRowRef) DocumentRowRef { r.PartID += 100; return r }, want: "part_id"},
+		{name: "lsn", mut: func(r DocumentRowRef) DocumentRowRef { r.AppliedCommandLSN++; return r }, want: "applied_command_lsn"},
+		{name: "document_id", mut: func(r DocumentRowRef) DocumentRowRef { r.DocumentID = []byte("e2"); return r }, want: "id"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := view.FetchDocumentsByRowRef([]DocumentRowRef{tt.mut(ref)}, DocumentFetchOptions{})
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("FetchDocumentsByRowRef err=%v want %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestCollectionReadViewFetchDocumentsByRowRefResponseDocumentsAreOwned1874(t *testing.T) {
+	d, col := newDocumentMaterializerTestCollection(t)
+	defer func() { _ = d.Close() }()
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("e1"), []byte("e2")},
+		[][]byte{
+			[]byte(`{"row_id":1,"kind":"alpha","score":1,"payload":"first"}`),
+			[]byte(`{"row_id":2,"kind":"beta","score":2,"payload":"second"}`),
+		},
+	); err != nil {
+		t.Fatalf("InsertBatch: %v", err)
+	}
+	view, err := col.OpenCollectionReadView()
+	if err != nil {
+		t.Fatalf("OpenCollectionReadView: %v", err)
+	}
+	defer func() { _ = view.Close() }()
+	resolved, err := view.FetchDocumentsByID([][]byte{[]byte("e1"), []byte("e2")}, DocumentFetchOptions{})
+	if err != nil {
+		t.Fatalf("FetchDocumentsByID: %v", err)
+	}
+	got, err := view.FetchDocumentsByRowRef([]DocumentRowRef{resolved.Results[0].RowRef, resolved.Results[1].RowRef}, DocumentFetchOptions{})
+	if err != nil {
+		t.Fatalf("FetchDocumentsByRowRef: %v", err)
+	}
+	secondBefore := append([]byte(nil), got.Results[1].Document...)
+	_ = append(got.Results[0].Document, '!')
+	if !bytes.Equal(got.Results[1].Document, secondBefore) {
+		t.Fatalf("second document changed after appending to first: got %s want %s", got.Results[1].Document, secondBefore)
+	}
+	got.Results[0].Document[0] = 'X'
+	fresh, err := col.Get([]byte("e1"))
+	if err != nil {
+		t.Fatalf("Get e1 after mutating response: %v", err)
+	}
+	if len(fresh) == 0 || fresh[0] == 'X' {
+		t.Fatalf("mutating row-ref response document affected stored document: %s", fresh)
+	}
+}
+
 func BenchmarkCollectionReadViewFetchDocumentsByIDMaterializer(b *testing.B) {
 	benchmarkCollectionReadViewFetchDocumentsByIDMaterializer(b, false)
 }
@@ -479,6 +702,17 @@ func reportDocumentMaterializerBenchMetrics(b *testing.B, stats DocumentMaterial
 	b.ReportMetric(float64(stats.TypedColumnNanos), "typed_column_ns/fetch")
 	b.ReportMetric(float64(stats.JSONReconstructionRows), "json_reconstruction_rows/fetch")
 	b.ReportMetric(float64(stats.JSONReconstructionNanos), "json_reconstruction_ns/fetch")
+	b.ReportMetric(float64(stats.RowLocatorBuilds), "row_locator_builds/fetch")
+	b.ReportMetric(float64(stats.RowLocatorLookups), "row_locator_lookups/fetch")
+	b.ReportMetric(float64(stats.RowLocatorMisses), "row_locator_misses/fetch")
+	b.ReportMetric(float64(stats.RowLocatorRowsScanned), "row_locator_rows_scanned/fetch")
+	b.ReportMetric(float64(stats.RowLocatorPhysicalBytes), "row_locator_physical_B/fetch")
+	b.ReportMetric(float64(stats.RowLocatorNanos), "row_locator_ns/fetch")
+	b.ReportMetric(float64(stats.PointRowFetches), "point_row_fetches/fetch")
+	b.ReportMetric(float64(stats.PointRowDecodes), "point_row_decodes/fetch")
+	b.ReportMetric(float64(stats.RowRefFallbackScans), "row_ref_fallback_scans/fetch")
+	b.ReportMetric(float64(stats.RowRefUnsupported), "row_ref_unsupported/fetch")
+	b.ReportMetric(float64(stats.RowRefValidationFailures), "row_ref_validation_failures/fetch")
 	b.ReportMetric(float64(stats.AssetMmapHits), "asset_mmap_hits/fetch")
 	b.ReportMetric(float64(stats.AssetReadAtFallbacks), "asset_readat_fallbacks/fetch")
 	b.ReportMetric(float64(stats.AssetFileOpens), "asset_file_opens/fetch")

--- a/TreeDB/collections/document_materializer_test.go
+++ b/TreeDB/collections/document_materializer_test.go
@@ -635,6 +635,51 @@ func TestCollectionReadViewFetchDocumentsByRowRefResponseDocumentsAreOwned1874(t
 	}
 }
 
+func TestCollectionReadViewEnsureAssetReadCachesInvalidatesDerivedRowCaches1874(t *testing.T) {
+	d, col := newDocumentMaterializerTestCollection(t)
+	defer func() { _ = d.Close() }()
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("e1"), []byte("e2")},
+		[][]byte{
+			[]byte(`{"row_id":1,"kind":"alpha","score":1,"payload":"first"}`),
+			[]byte(`{"row_id":2,"kind":"beta","score":2,"payload":"second"}`),
+		},
+	); err != nil {
+		t.Fatalf("InsertBatch: %v", err)
+	}
+	view, err := col.OpenCollectionReadView()
+	if err != nil {
+		t.Fatalf("OpenCollectionReadView: %v", err)
+	}
+	defer func() { _ = view.Close() }()
+	lookup, err := view.LookupDocumentRowRefsByID([][]byte{[]byte("e1"), []byte("e2")}, DocumentFetchOptions{})
+	if err != nil {
+		t.Fatalf("LookupDocumentRowRefsByID: %v", err)
+	}
+	if _, err := view.FetchDocumentsByRowRef([]DocumentRowRef{lookup.Results[0].RowRef}, DocumentFetchOptions{}); err != nil {
+		t.Fatalf("FetchDocumentsByRowRef: %v", err)
+	}
+	if view.rowLocator == nil || view.columnSnapshotView == nil || len(view.pointRowRefs) == 0 || len(view.pointRowBlocks) == 0 {
+		t.Fatalf("expected derived caches to be populated before integrity change")
+	}
+	cfg := view.columnSnapshotView.Config
+	if err := view.ensureAssetReadCaches(cfg, ColumnAssetReadIntegritySkipChecksums); err != nil {
+		t.Fatalf("ensureAssetReadCaches: %v", err)
+	}
+	if view.rowLocator != nil {
+		t.Fatalf("rowLocator=%v want nil after row asset cache rebuild", view.rowLocator)
+	}
+	if view.columnSnapshotView != nil {
+		t.Fatalf("columnSnapshotView=%v want nil after row asset cache rebuild", view.columnSnapshotView)
+	}
+	if view.pointRowRefs != nil {
+		t.Fatalf("pointRowRefs=%v want nil after row asset cache rebuild", view.pointRowRefs)
+	}
+	if len(view.pointRowBlocks) != 0 {
+		t.Fatalf("pointRowBlocks=%d want empty after row asset cache rebuild", len(view.pointRowBlocks))
+	}
+}
+
 func BenchmarkCollectionReadViewFetchDocumentsByIDMaterializer(b *testing.B) {
 	benchmarkCollectionReadViewFetchDocumentsByIDMaterializer(b, false)
 }

--- a/TreeDB/collections/document_row_locator_bench_test.go
+++ b/TreeDB/collections/document_row_locator_bench_test.go
@@ -56,6 +56,9 @@ func benchmarkCollectionReadViewFetchDocumentsByRowRefMaterializerRows1874(b *te
 		if err != nil {
 			b.Fatalf("FetchDocumentsByRowRef: %v", err)
 		}
+		if len(got.Results) == 0 {
+			b.Fatalf("FetchDocumentsByRowRef returned 0 results")
+		}
 		vectorSearchBenchSinkOrdinalV4 += len(got.Results[0].Document)
 	}
 	b.StopTimer()
@@ -118,6 +121,9 @@ func benchmarkSearchVectorIndexColumnGraphNativeReaderWithDocumentsRows1874(b *t
 		if err != nil {
 			b.Fatalf("SearchVectorIndex: %v", err)
 		}
+		if len(got.Results) == 0 {
+			b.Fatalf("SearchVectorIndex returned 0 results")
+		}
 		vectorSearchBenchSinkOrdinalV4 += len(got.Results[0].Document)
 	}
 	b.StopTimer()
@@ -176,6 +182,9 @@ func benchmarkOpenVectorIndexSearcherColumnGraphNativeReaderWithDocumentsRows187
 		got, err := searcher.Search(opts)
 		if err != nil {
 			b.Fatalf("Search: %v", err)
+		}
+		if len(got.Results) == 0 {
+			b.Fatalf("Search returned 0 results")
 		}
 		vectorSearchBenchSinkOrdinalV4 += len(got.Results[0].Document)
 	}

--- a/TreeDB/collections/document_row_locator_bench_test.go
+++ b/TreeDB/collections/document_row_locator_bench_test.go
@@ -1,0 +1,184 @@
+package collections
+
+import (
+	"fmt"
+	"testing"
+)
+
+func BenchmarkCollectionReadViewFetchDocumentsByRowRefMaterializerRows1874(b *testing.B) {
+	for _, rows := range []int{1024, 8192} {
+		rows := rows
+		b.Run(fmt.Sprintf("rows_%d", rows), func(b *testing.B) {
+			benchmarkCollectionReadViewFetchDocumentsByRowRefMaterializerRows1874(b, rows)
+		})
+	}
+}
+
+func benchmarkCollectionReadViewFetchDocumentsByRowRefMaterializerRows1874(b *testing.B, rows int) {
+	b.Helper()
+	d, col := newDocumentMaterializerTestCollection(b)
+	defer func() { _ = d.Close() }()
+	ids := make([][]byte, rows)
+	docs := make([][]byte, rows)
+	for i := 0; i < rows; i++ {
+		ids[i] = []byte(fmt.Sprintf("e%05d", i))
+		docs[i] = []byte(fmt.Sprintf(`{"row_id":%d,"kind":"kind-%d","score":%0.1f,"payload":"retained-%d"}`, i, i%8, float64(i)+0.5, i))
+	}
+	if _, err := col.InsertBatch(ids, docs); err != nil {
+		b.Fatalf("InsertBatch: %v", err)
+	}
+	view, err := col.OpenCollectionReadView()
+	if err != nil {
+		b.Fatalf("OpenCollectionReadView: %v", err)
+	}
+	defer func() { _ = view.Close() }()
+	fetchIDs := documentRowLocatorBenchmarkFetchIDs1874(ids)
+	resolved, err := view.FetchDocumentsByID(fetchIDs, DocumentFetchOptions{})
+	if err != nil {
+		b.Fatalf("resolve row refs: %v", err)
+	}
+	refs := make([]DocumentRowRef, len(resolved.Results))
+	for i := range resolved.Results {
+		if !resolved.Results[i].Found {
+			b.Fatalf("resolve row refs result[%d] missing", i)
+		}
+		refs[i] = resolved.Results[i].RowRef
+	}
+	measured, err := view.FetchDocumentsByRowRef(refs, DocumentFetchOptions{})
+	if err != nil {
+		b.Fatalf("measure FetchDocumentsByRowRef: %v", err)
+	}
+	stats := measured.Stats
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		got, err := view.FetchDocumentsByRowRef(refs, DocumentFetchOptions{})
+		if err != nil {
+			b.Fatalf("FetchDocumentsByRowRef: %v", err)
+		}
+		vectorSearchBenchSinkOrdinalV4 += len(got.Results[0].Document)
+	}
+	b.StopTimer()
+	reportDocumentMaterializerBenchMetrics(b, stats)
+}
+
+func documentRowLocatorBenchmarkFetchIDs1874(ids [][]byte) [][]byte {
+	if len(ids) == 0 {
+		return nil
+	}
+	positions := []int{37, 128, 255, 512, 700, 900, 1000, 3, 44, 88}
+	out := make([][]byte, len(positions))
+	for i, pos := range positions {
+		out[i] = ids[pos%len(ids)]
+	}
+	return out
+}
+
+func BenchmarkSearchVectorIndexColumnGraphNativeReaderWithDocumentsRows1874(b *testing.B) {
+	for _, rows := range []int{1024, 8192} {
+		rows := rows
+		b.Run(fmt.Sprintf("rows_%d", rows), func(b *testing.B) {
+			benchmarkSearchVectorIndexColumnGraphNativeReaderWithDocumentsRows1874(b, rows)
+		})
+	}
+}
+
+func benchmarkSearchVectorIndexColumnGraphNativeReaderWithDocumentsRows1874(b *testing.B, rows int) {
+	b.Helper()
+	const (
+		dims     = 128
+		m        = 16
+		topK     = 10
+		efSearch = 128
+	)
+	input := columnGraphRebuildSyntheticRowsV2A(rows, dims)
+	_, d, col, def := openColumnGraphRebuildTestCollectionV2A(b, dims, m, input)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		b.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	query := append([]float32(nil), input[37%len(input)].vector...)
+	opts := VectorIndexSearchOptions{
+		IndexName:        def.Name,
+		Query:            query,
+		TopK:             topK,
+		EfSearch:         efSearch,
+		IncludeDocuments: true,
+		MaxDecodedBlocks: 1,
+	}
+	warm, err := col.SearchVectorIndex(opts)
+	if err != nil {
+		b.Fatalf("warm SearchVectorIndex: %v", err)
+	}
+	stats := warm.Stats
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		got, err := col.SearchVectorIndex(opts)
+		if err != nil {
+			b.Fatalf("SearchVectorIndex: %v", err)
+		}
+		vectorSearchBenchSinkOrdinalV4 += len(got.Results[0].Document)
+	}
+	b.StopTimer()
+	reportVectorIndexSearchBenchMetricsV4(b, b.N, stats, true)
+}
+
+func BenchmarkOpenVectorIndexSearcherColumnGraphNativeReaderWithDocumentsRows1874(b *testing.B) {
+	for _, rows := range []int{1024, 8192} {
+		rows := rows
+		b.Run(fmt.Sprintf("rows_%d", rows), func(b *testing.B) {
+			benchmarkOpenVectorIndexSearcherColumnGraphNativeReaderWithDocumentsRows1874(b, rows)
+		})
+	}
+}
+
+func benchmarkOpenVectorIndexSearcherColumnGraphNativeReaderWithDocumentsRows1874(b *testing.B, rows int) {
+	b.Helper()
+	const (
+		dims     = 128
+		m        = 16
+		topK     = 10
+		efSearch = 128
+	)
+	input := columnGraphRebuildSyntheticRowsV2A(rows, dims)
+	_, d, col, def := openColumnGraphRebuildTestCollectionV2A(b, dims, m, input)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		b.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	searcher, err := col.OpenVectorIndexSearcher(VectorIndexSearcherOptions{
+		IndexName:        def.Name,
+		MaxDecodedBlocks: 1,
+	})
+	if err != nil {
+		b.Fatalf("OpenVectorIndexSearcher: %v", err)
+	}
+	defer func() { _ = searcher.Close() }()
+	query := append([]float32(nil), input[37%len(input)].vector...)
+	opts := VectorIndexSearcherSearchOptions{
+		Query:            query,
+		TopK:             topK,
+		EfSearch:         efSearch,
+		IncludeDocuments: true,
+	}
+	if _, err := searcher.Search(opts); err != nil {
+		b.Fatalf("warm Search: %v", err)
+	}
+	measured, err := searcher.Search(opts)
+	if err != nil {
+		b.Fatalf("measure Search stats: %v", err)
+	}
+	stats := measured.Stats
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		got, err := searcher.Search(opts)
+		if err != nil {
+			b.Fatalf("Search: %v", err)
+		}
+		vectorSearchBenchSinkOrdinalV4 += len(got.Results[0].Document)
+	}
+	b.StopTimer()
+	reportVectorIndexSearchBenchMetricsV4(b, b.N, stats, false)
+}

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -339,7 +339,7 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/column_query_plan_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 56, occurrences: 68},
 	{path: "TreeDB/collections/column_reconstruction.go", classification: typedStorageLegacyCompatibility, matchingLines: 20, occurrences: 21},
 	{path: "TreeDB/collections/column_semantics.go", classification: typedStorageLegacyCompatibility, matchingLines: 8, occurrences: 8},
-	{path: "TreeDB/collections/document_materializer.go", classification: typedStorageLegacyCompatibility, matchingLines: 5, occurrences: 5},
+	{path: "TreeDB/collections/document_materializer.go", classification: typedStorageLegacyCompatibility, matchingLines: 13, occurrences: 13},
 	{path: "TreeDB/collections/document_materializer_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 17, occurrences: 17},
 	{path: "TreeDB/collections/column_store.go", classification: typedStorageLegacyCompatibility, matchingLines: 74, occurrences: 116},
 	{path: "TreeDB/collections/column_store_compatibility_api_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 7, occurrences: 9},

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -377,6 +377,7 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/typed_storage_naming_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 7, occurrences: 7},
 	{path: "TreeDB/collections/vector_index.go", classification: typedStorageLegacyDerived, matchingLines: 1, occurrences: 1},
 	{path: "TreeDB/collections/vector_index_metadata_test.go", classification: typedStorageLegacyDerived, matchingLines: 9, occurrences: 11},
+	{path: "TreeDB/collections/vector_index_search_test.go", classification: typedStorageLegacyDerived, matchingLines: 2, occurrences: 2},
 	{path: "TreeDB/collections/vector_index_rebuild.go", classification: typedStorageLegacyDerived, matchingLines: 16, occurrences: 18},
 	{path: "TreeDB/collections/vector_index_rebuild_test.go", classification: typedStorageLegacyDerived, matchingLines: 32, occurrences: 38},
 	{path: "TreeDB/docs/guides/collections-quickstart.md", classification: typedStorageLegacyCompatibility, matchingLines: 18, occurrences: 22},

--- a/TreeDB/collections/vector_index_search.go
+++ b/TreeDB/collections/vector_index_search.go
@@ -465,26 +465,36 @@ func (s *VectorIndexSearcher) Search(opts VectorIndexSearcherSearchOptions) (Vec
 		for i := range results {
 			ids[i] = results[i].ID
 		}
-		rowRefs, err := s.documentView.LookupDocumentRowRefsByID(ids, DocumentFetchOptions{})
-		if err != nil {
-			return response, err
-		}
-		if err := addDocumentMaterializationStatsToVectorStats(&response.Stats, rowRefs.Stats); err != nil {
-			return response, err
-		}
-		if len(rowRefs.Results) != len(response.Results) {
-			return response, errors.New("collections: vector index document row-ref result count mismatch")
-		}
-		refs := make([]DocumentRowRef, len(rowRefs.Results))
-		for i := range rowRefs.Results {
-			if !rowRefs.Results[i].Found {
-				return response, fmt.Errorf("collections: vector index %q result document %q not found", s.indexName, results[i].ID)
+		var documents DocumentFetchResponse
+		var err error
+		if columnStoreCanReconstructDocument(s.catalog.meta) {
+			rowRefs, lookupErr := s.documentView.LookupDocumentRowRefsByID(ids, DocumentFetchOptions{})
+			if lookupErr != nil {
+				return response, lookupErr
 			}
-			refs[i] = rowRefs.Results[i].RowRef
-		}
-		documents, err := s.documentView.FetchDocumentsByRowRef(refs, DocumentFetchOptions{})
-		if err != nil {
-			return response, err
+			if err := addDocumentMaterializationStatsToVectorStats(&response.Stats, rowRefs.Stats); err != nil {
+				return response, err
+			}
+			if len(rowRefs.Results) != len(response.Results) {
+				return response, errors.New("collections: vector index document row-ref result count mismatch")
+			}
+			refs := make([]DocumentRowRef, len(rowRefs.Results))
+			for i := range rowRefs.Results {
+				if !rowRefs.Results[i].Found {
+					return response, fmt.Errorf("collections: vector index %q result document %q not found", s.indexName, results[i].ID)
+				}
+				refs[i] = rowRefs.Results[i].RowRef
+			}
+			documents, err = s.documentView.FetchDocumentsByRowRef(refs, DocumentFetchOptions{})
+			if err != nil {
+				return response, err
+			}
+		} else {
+			response.Stats.DocumentRowRefUnsupported++
+			documents, err = s.documentView.FetchDocumentsByID(ids, DocumentFetchOptions{})
+			if err != nil {
+				return response, err
+			}
 		}
 		if len(documents.Results) != len(response.Results) {
 			return response, errors.New("collections: vector index document materializer result count mismatch")

--- a/TreeDB/collections/vector_index_search.go
+++ b/TreeDB/collections/vector_index_search.go
@@ -122,8 +122,28 @@ type VectorIndexSearchStats struct {
 	DocumentJSONReconstructionRows uint64 `json:"document_json_reconstruction_rows,omitempty"`
 	// DocumentJSONReconstructionNanos attributes JSON merge/serialization time.
 	DocumentJSONReconstructionNanos uint64 `json:"document_json_reconstruction_nanos,omitempty"`
-	// DocumentRowRefFallbackScans counts row-ref requests served by the interim target-ID scan path.
+	// DocumentRowLocatorBuilds counts snapshot-derived row-locator map builds.
+	DocumentRowLocatorBuilds uint64 `json:"document_row_locator_builds,omitempty"`
+	// DocumentRowLocatorLookups counts document-id to row-ref locator lookups.
+	DocumentRowLocatorLookups uint64 `json:"document_row_locator_lookups,omitempty"`
+	// DocumentRowLocatorMisses counts locator lookups with no latest-visible row.
+	DocumentRowLocatorMisses uint64 `json:"document_row_locator_misses,omitempty"`
+	// DocumentRowLocatorRowsScanned counts physical rows scanned to build locator maps.
+	DocumentRowLocatorRowsScanned uint64 `json:"document_row_locator_rows_scanned,omitempty"`
+	// DocumentRowLocatorPhysicalBytes counts physical bytes scanned to build locator maps.
+	DocumentRowLocatorPhysicalBytes uint64 `json:"document_row_locator_physical_bytes,omitempty"`
+	// DocumentRowLocatorNanos attributes row-locator map build time.
+	DocumentRowLocatorNanos uint64 `json:"document_row_locator_nanos,omitempty"`
+	// DocumentPointRowFetches counts direct row-ref point fetch attempts.
+	DocumentPointRowFetches uint64 `json:"document_point_row_fetches,omitempty"`
+	// DocumentPointRowDecodes counts physical rows decoded by direct row-ref point fetch.
+	DocumentPointRowDecodes uint64 `json:"document_point_row_decodes,omitempty"`
+	// DocumentRowRefFallbackScans counts row-ref requests served by an explicit scan fallback.
 	DocumentRowRefFallbackScans uint64 `json:"document_row_ref_fallback_scans,omitempty"`
+	// DocumentRowRefUnsupported counts unsupported row-ref materialization states.
+	DocumentRowRefUnsupported uint64 `json:"document_row_ref_unsupported,omitempty"`
+	// DocumentRowRefValidationFailures counts row-ref fail-closed validation failures.
+	DocumentRowRefValidationFailures uint64 `json:"document_row_ref_validation_failures,omitempty"`
 	// DocumentAssetMmapHits counts document materializer typed-row/typed-column asset reads served from mmap-backed views.
 	DocumentAssetMmapHits uint64 `json:"document_asset_mmap_hits,omitempty"`
 	// DocumentAssetReadAtFallbacks counts document materializer asset reads that fell back to heap/read-at.
@@ -445,7 +465,24 @@ func (s *VectorIndexSearcher) Search(opts VectorIndexSearcherSearchOptions) (Vec
 		for i := range results {
 			ids[i] = results[i].ID
 		}
-		documents, err := s.documentView.FetchDocumentsByID(ids, DocumentFetchOptions{})
+		rowRefs, err := s.documentView.LookupDocumentRowRefsByID(ids, DocumentFetchOptions{})
+		if err != nil {
+			return response, err
+		}
+		if err := addDocumentMaterializationStatsToVectorStats(&response.Stats, rowRefs.Stats); err != nil {
+			return response, err
+		}
+		if len(rowRefs.Results) != len(response.Results) {
+			return response, errors.New("collections: vector index document row-ref result count mismatch")
+		}
+		refs := make([]DocumentRowRef, len(rowRefs.Results))
+		for i := range rowRefs.Results {
+			if !rowRefs.Results[i].Found {
+				return response, fmt.Errorf("collections: vector index %q result document %q not found", s.indexName, results[i].ID)
+			}
+			refs[i] = rowRefs.Results[i].RowRef
+		}
+		documents, err := s.documentView.FetchDocumentsByRowRef(refs, DocumentFetchOptions{})
 		if err != nil {
 			return response, err
 		}

--- a/TreeDB/collections/vector_index_search_test.go
+++ b/TreeDB/collections/vector_index_search_test.go
@@ -172,6 +172,58 @@ func TestSearchVectorIndexColumnGraphMaterializesDocumentsAfterTopKV4(t *testing
 	}
 }
 
+func TestSearchVectorIndexColumnGraphRetainedFullDocumentsFallbackV4(t *testing.T) {
+	rows := []columnGraphRebuildInputRowV2A{
+		{id: "doc-a", vector: []float32{1, 0, 0}},
+		{id: "doc-b", vector: []float32{0, 1, 0}},
+	}
+	dir := t.TempDir()
+	if err := backenddb.SaveFormatConfig(dir, backenddb.FormatConfig{RequiredFeatures: []string{backenddb.RequiredFeatureCommandWALV1}}); err != nil {
+		t.Fatalf("SaveFormatConfig: %v", err)
+	}
+	d := openCollectionCommandWALDB(t, dir)
+	defer func() { _ = d.Close() }()
+	def := columnGraphRebuildVectorIndexDefinitionV2A(3, 0)
+	cfg := columnGraphRebuildColumnStoreConfigV2A(3)
+	cfg.RetainedPayload = ColumnRetainedPayloadFull
+	meta := CollectionMeta{
+		Name: "docs",
+		Options: CollectionOptions{
+			DocumentFormat: DocumentFormatJSON,
+			ColumnStore:    cfg,
+		},
+		VectorIndexes: []VectorIndexDefinition{def},
+	}
+	if _, err := NewCollectionManager(d).CreateCollection(&meta); err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	col, err := NewCollectionManager(d).OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("OpenCollection: %v", err)
+	}
+	insertColumnGraphRebuildRowsV2A(t, col, rows)
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	got, err := col.SearchVectorIndex(VectorIndexSearchOptions{
+		IndexName:        def.Name,
+		Query:            []float32{1, 0, 0},
+		TopK:             1,
+		EfSearch:         len(rows),
+		IncludeDocuments: true,
+	})
+	if err != nil {
+		t.Fatalf("SearchVectorIndex: %v", err)
+	}
+	if len(got.Results) != 1 || string(got.Results[0].ID) != "doc-a" {
+		t.Fatalf("results=%+v want doc-a", got.Results)
+	}
+	assertVectorIndexSearchDocumentDIDV4(t, got.Results[0].Document, "doc-a")
+	if got.Stats.DocumentRowRefUnsupported != 1 || got.Stats.DocumentPointRowFetches != 0 || got.Stats.DocumentVisibilityScans != 0 || got.Stats.DocumentsFetched != 1 {
+		t.Fatalf("stats=%+v want retained-full fallback without row-ref point fetch", got.Stats)
+	}
+}
+
 func TestSearchVectorIndexFlushesBufferedWritesBeforeSnapshotV4(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{
 		Dir:                    t.TempDir(),

--- a/TreeDB/collections/vector_index_search_test.go
+++ b/TreeDB/collections/vector_index_search_test.go
@@ -157,6 +157,12 @@ func TestSearchVectorIndexColumnGraphMaterializesDocumentsAfterTopKV4(t *testing
 	if got.Stats.DocumentsFetched != uint64(len(got.Results)) {
 		t.Fatalf("DocumentsFetched=%d want %d", got.Stats.DocumentsFetched, len(got.Results))
 	}
+	if got.Stats.DocumentRowLocatorLookups != uint64(len(got.Results)) || got.Stats.DocumentRowLocatorMisses != 0 || got.Stats.DocumentPointRowFetches != uint64(len(got.Results)) || got.Stats.DocumentPointRowDecodes != uint64(len(got.Results)) {
+		t.Fatalf("stats=%+v want row-locator lookup and point row fetch per document", got.Stats)
+	}
+	if got.Stats.DocumentRowRefFallbackScans != 0 || got.Stats.DocumentVisibilityScans != 0 || got.Stats.DocumentVisibilityRowsScanned != 0 {
+		t.Fatalf("stats=%+v want IncludeDocuments to avoid row-ref scan fallback on supported manifest", got.Stats)
+	}
 	documentBefore := append([]byte(nil), got.Results[0].Document...)
 	if _, err := col.SearchVectorIndex(opts); err != nil {
 		t.Fatalf("second SearchVectorIndex: %v", err)
@@ -273,6 +279,9 @@ func TestOpenVectorIndexSearcherFetchesDocumentsFromBoundSnapshotV4(t *testing.T
 	assertVectorIndexSearchDocumentDIDV4(t, got.Results[0].Document, "doc-a")
 	if got.Stats.DocumentsFetched != 1 {
 		t.Fatalf("DocumentsFetched=%d want 1", got.Stats.DocumentsFetched)
+	}
+	if got.Stats.DocumentRowLocatorLookups != 1 || got.Stats.DocumentPointRowFetches != 1 || got.Stats.DocumentPointRowDecodes != 1 || got.Stats.DocumentRowRefFallbackScans != 0 || got.Stats.DocumentVisibilityScans != 0 {
+		t.Fatalf("stats=%+v want prepared IncludeDocuments to use row refs and point fetches", got.Stats)
 	}
 	if searcher.documentView == nil || searcher.documentView.assetScopeKind != mappedresource.ScopePreparedSearch {
 		t.Fatalf("document view=%+v want prepared_search scope", searcher.documentView)
@@ -1217,6 +1226,17 @@ func reportVectorIndexSearchBenchMetricsV4(b *testing.B, n int, stats VectorInde
 	b.ReportMetric(float64(stats.DocumentTypedColumnNanos), "doc_typed_column_ns/search")
 	b.ReportMetric(float64(stats.DocumentJSONReconstructionRows), "doc_json_reconstruction_rows/search")
 	b.ReportMetric(float64(stats.DocumentJSONReconstructionNanos), "doc_json_reconstruction_ns/search")
+	b.ReportMetric(float64(stats.DocumentRowLocatorBuilds), "doc_row_locator_builds/search")
+	b.ReportMetric(float64(stats.DocumentRowLocatorLookups), "doc_row_locator_lookups/search")
+	b.ReportMetric(float64(stats.DocumentRowLocatorMisses), "doc_row_locator_misses/search")
+	b.ReportMetric(float64(stats.DocumentRowLocatorRowsScanned), "doc_row_locator_rows_scanned/search")
+	b.ReportMetric(float64(stats.DocumentRowLocatorPhysicalBytes), "doc_row_locator_physical_B/search")
+	b.ReportMetric(float64(stats.DocumentRowLocatorNanos), "doc_row_locator_ns/search")
+	b.ReportMetric(float64(stats.DocumentPointRowFetches), "doc_point_row_fetches/search")
+	b.ReportMetric(float64(stats.DocumentPointRowDecodes), "doc_point_row_decodes/search")
+	b.ReportMetric(float64(stats.DocumentRowRefFallbackScans), "doc_row_ref_fallback_scans/search")
+	b.ReportMetric(float64(stats.DocumentRowRefUnsupported), "doc_row_ref_unsupported/search")
+	b.ReportMetric(float64(stats.DocumentRowRefValidationFailures), "doc_row_ref_validation_failures/search")
 	b.ReportMetric(float64(stats.DocumentAssetMmapHits), "doc_asset_mmap_hits/search")
 	b.ReportMetric(float64(stats.DocumentAssetReadAtFallbacks), "doc_asset_readat_fallbacks/search")
 	b.ReportMetric(float64(stats.DocumentAssetFileOpens), "doc_asset_file_opens/search")


### PR DESCRIPTION
Closes #1874.

## Linked tracker issue and milestone

- Issue: #1874 — Land typed-storage row-locator point fetch for document materialization.
- Milestones covered: M0 baselines, M1 row-ref lookup contract, M2 materializer fetch by row-ref, M3 vector integration/scaling evidence.

## Start-phase test plan

- Focused row-ref correctness around insert-only, mutation latest-visible, stale snapshots, mismatch fail-closed, response ownership, and vector IncludeDocuments integration.
- Full package validation for `TreeDB/collections`.

## Start-phase performance plan

Baseline branch/commit: `origin/main` at `876d41481` (after #1873/#1880/#1881, before this PR; benchmark-only `document_row_locator_bench_test.go` copied into baseline worktree). Candidate branch head: `f06c4b1d` (`snissn/1874-manager`, merged with latest `origin/main` plus AI-review fixes). Hardware: Apple M3, darwin/arm64.

Commands used:

```sh
go test ./TreeDB/collections -run '^$' -bench 'BenchmarkCollectionReadViewFetchDocumentsByRowRefMaterializerRows1874' -benchtime=100x -count=3 -benchmem

go test ./TreeDB/collections -run '^$' -bench 'Benchmark(SearchVectorIndexColumnGraphNativeReaderWithDocumentsV4|OpenVectorIndexSearcherColumnGraphNativeReaderWithDocumentsV4|SearchVectorIndexColumnGraphNativeReaderWithDocumentsRows1874|OpenVectorIndexSearcherColumnGraphNativeReaderWithDocumentsRows1874)$' -benchtime=20x -count=3 -benchmem
```

Artifacts:

- `/tmp/1874_base_rowref_bench_876d414.txt`
- `/tmp/1874_candidate_rowref_bench_f06c4b.txt`
- `/tmp/1874_base_vector_docs_bench_876d414.txt`
- `/tmp/1874_candidate_vector_docs_bench_f06c4b.txt`
- Profiles captured for the row-ref benchmark: `/tmp/1874_base_rowref_cpu.pprof`, `/tmp/1874_base_rowref_mem.pprof`, `/tmp/1874_candidate_rowref_cpu.pprof`, `/tmp/1874_candidate_rowref_mem.pprof`

## What changed

- Added generic snapshot-derived `documentID -> DocumentRowRef` locator support on `CollectionReadView`.
- Added direct typed-row point fetch by `(generation, part_id, row_index, applied_command_lsn)` with fail-closed physical-row validation.
- Preserved latest-visible/delete/update semantics by validating stale row refs against the snapshot locator when mutation parts exist.
- Routed vector `IncludeDocuments` through `LookupDocumentRowRefsByID` + `FetchDocumentsByRowRef` instead of scan reconstruction on supported typed-storage manifests.
- Added counters for locator builds/lookups/misses, locator rows/bytes/time, point-row fetches/decodes, fallback scans, unsupported states, and validation failures.

## Close-phase test evidence

```sh
go test ./TreeDB/collections -run 'TestCollectionReadViewEnsureAssetReadCachesInvalidatesDerivedRowCaches1874|TestCollectionReadViewFetchDocumentsByRowRef' -count=1
# ok github.com/snissn/gomap/TreeDB/collections 1.046s

go test ./TreeDB/collections -count=1
# ok github.com/snissn/gomap/TreeDB/collections 26.699s
```

Coverage highlights:

- Insert-only row-ref point fetch preserves order/duplicates and avoids scan fallback.
- Update/delete latest-visible validation rejects stale/deleted refs and preserves old snapshot behavior.
- Generation/part/row_index/LSN/document-ID mismatches fail closed.
- Row-ref response documents remain response-owned.
- Vector IncludeDocuments uses locator lookups and point fetches with zero visibility scans on supported manifests.

## Close-phase benchmark evidence

Median of 3 runs. TopK/docs fetched = 10.

| Benchmark | Rows | Branch/commit | ns/op | ops/sec | B/op | allocs/op | locator lookups | point row decodes | row/ref fallback scans | row visibility rows scanned | Notes |
| --- | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| `CollectionReadViewFetchDocumentsByRowRefMaterializerRows1874` | 1,024 | baseline `876d41481` | 283,601 | 3,526 | 1,039,797 | 533 | n/a | n/a | 1 scan fallback | 1,024 | old row-ref path scanned typed rows |
| same | 1,024 | candidate `f06c4b1d` | 32,665 | 30,614 | 24,848 | 337 | 0 hot | 10 | 0 | 0 | direct point fetch |
| same | 8,192 | baseline `876d41481` | 816,709 | 1,224 | 3,362,292 | 533 | n/a | n/a | 1 scan fallback | 8,192 | O(rows) baseline |
| same | 8,192 | candidate `f06c4b1d` | 23,339 | 42,847 | 24,848 | 337 | 0 hot | 10 | 0 | 0 | O(topK) hot row-ref fetch |
| `OpenVectorIndexSearcherColumnGraphNativeReaderWithDocumentsRows1874` | 1,024 | baseline `876d41481` | 338,792 | 2,952 | 1,299,696 | 1,639 | n/a | n/a | 1 scan fallback | 1,024 | prepared searcher, old doc scan |
| same | 1,024 | candidate `f06c4b1d` | 112,892 | 8,858 | 112,672 | 571 | 10 | 10 | 0 | 0 | warm prepared searcher reuses locator |
| same | 8,192 | baseline `876d41481` | 1,973,475 | 507 | 4,969,746 | 8,796 | n/a | n/a | 1 scan fallback | 8,192 | O(rows) doc fetch dominates |
| same | 8,192 | candidate `f06c4b1d` | 115,808 | 8,635 | 112,176 | 560 | 10 | 10 | 0 | 0 | O(topK) doc fetch after locator warmup |
| `SearchVectorIndexColumnGraphNativeReaderWithDocumentsV4` | 1,024 | baseline `876d41481` | 761,085 | 1,314 | 2,717,753 | 1,780 | n/a | n/a | 1 scan fallback | 1,024 | one-shot |
| same | 1,024 | candidate `f06c4b1d` | 661,331 | 1,512 | 1,567,280 | 1,783 | 10 | 10 | 0 | 0 visibility / 1,024 locator build | one-shot pays locator build |

Interpretation:

- Hot row-ref materialization becomes O(topK): 8k rows drop from ~817µs to ~23µs and scanned rows drop from 8,192 to 0.
- Prepared vector search with documents is now nearly row-count independent for these fixtures: ~113µs at 1k rows and ~116µs at 8k rows after warmup.
- One-shot vector search no longer performs visibility scan fallback, but still builds the snapshot locator per call; that is expected for unprepared use, is visible in `doc_row_locator_builds/search=1`, and remains less stable under local load than the prepared-searcher hot path.

## Setup/decode/search/doc-fetch timing boundary

- Graph traversal/search counters are unchanged by design (`visited_nodes`, `visited_edges`, `candidate_fetches`, and vector/adjacency bytes match baseline fixtures).
- Document timing now splits row-locator work (`doc_row_locator_*`) from row-ref point fetch (`doc_point_row_*`) and JSON reconstruction (`doc_json_reconstruction_*`).
- Prepared searcher benchmark warms the locator before timing; timed searches report `doc_row_locator_builds/search=0`, `doc_point_row_decodes/search=10`, and `doc_visibility_scans/search=0`.

## AI review status and unresolved threads

- Requested: `@codex review`, `@copilot review`, `@coderabbitai review`.
- Addressed AI findings: retained-payload-full vector fallback restored; derived row caches/projection invalidated on asset cache rebuild; redundant deleted-row check removed; benchmark result guards added; strict row-ref missing/stale semantics documented; `RowRefUnsupported` now only counts concrete unsupported conditions rather than generic runtime/init failures; row-locator tie-breaking now matches latest-visible ordinal semantics; Close drops derived row-fetch caches.
- Current status: latest Codex review found no major issues; latest Copilot threads fixed and resolved; CodeRabbit latest status passed and acknowledged `f06c4b1d`; required CI checks are green.
- Unresolved review threads: 0.
