### PR TITLE
treedb: add grouped-hour physical reducer

### DIFF
--- a/TreeDB/collections/column_dict_hour_query.go
+++ b/TreeDB/collections/column_dict_hour_query.go
@@ -1,0 +1,197 @@
+package collections
+
+import (
+	"cmp"
+	"fmt"
+	"slices"
+	"time"
+)
+
+const columnDictionaryHourCountMaxGroups = 1 << 20
+
+type columnDictionaryHourCountRunner struct {
+	groupColumn          string
+	valueColumn          string
+	groupDict            []string
+	assets               []columnDictionaryHourCountAsset
+	predicateAssets      []columnDictionaryPredicateAsset
+	counts               []int
+	result               []ColumnPhysicalQueryGroup
+	assetBytes           int64
+	predicateBytes       int64
+	predicateCodeHit     int
+	predicateDiagnostics columnPhysicalQueryPredicateDiagnosticPlan
+}
+
+type columnDictionaryHourCountAsset struct {
+	groupCodes []uint32
+	values     []int64
+}
+
+func prepareColumnDictionaryHourCountRunner(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest, readCache *columnPhysicalAssetReadCache) (*columnDictionaryHourCountRunner, error) {
+	if req.AggregateMetadataName != "" || req.Kind != ColumnPhysicalQueryGroupHourCount || req.GroupColumn == "" || req.ValueColumn == "" || view.MutationParts != 0 {
+		return nil, nil
+	}
+	if readCache == nil {
+		return nil, fmt.Errorf("collections: dictionary/hour query missing read cache")
+	}
+	if !columnDictionaryInt64GroupColumnsEligible(view, req) {
+		return nil, nil
+	}
+	groupByPart := columnDictionaryCodeSnapshotsByPart(view, req.GroupColumn)
+	valueByPart := columnInt64ValueSnapshotsByPart(view, req.ValueColumn)
+	if len(groupByPart) == 0 || len(valueByPart) == 0 || !columnDictionaryInt64GroupSnapshotsCoverParts(view, groupByPart, valueByPart) {
+		return nil, nil
+	}
+	runner := &columnDictionaryHourCountRunner{
+		groupColumn: req.GroupColumn,
+		valueColumn: req.ValueColumn,
+		assets:      make([]columnDictionaryHourCountAsset, 0, len(view.AssetRefs)),
+	}
+	predicateAssets, predicateBytes, err := prepareColumnDictionaryPredicateAssets(view, req, readCache)
+	if err != nil {
+		return nil, err
+	}
+	runner.predicateAssets = predicateAssets
+	runner.predicateBytes = predicateBytes
+	runner.predicateCodeHit = columnDictionaryPredicateAssetHits(predicateAssets)
+	runner.predicateDiagnostics = newColumnPhysicalQueryPredicateDiagnosticPlan(req)
+	groupByValue := make(map[string]uint32)
+	var scratch []byte
+	for _, part := range view.AssetRefs {
+		partKey := [2]uint64{part.Ref.Generation, part.Ref.PartID}
+		groupSnapshot := groupByPart[partKey]
+		valueSnapshot := valueByPart[partKey]
+		groupRaw, err := readCache.read(groupSnapshot.AssetRef, scratch)
+		if err != nil {
+			return nil, fmt.Errorf("collections: dictionary/hour group codes read generation=%d part_id=%d column=%q: %w", groupSnapshot.AssetRef.Generation, groupSnapshot.AssetRef.PartID, req.GroupColumn, err)
+		}
+		scratch = groupRaw
+		groupAsset, err := decodeColumnDictionaryCodesAsset(groupRaw, groupSnapshot.AssetRef, view.Config, view.CollectionName, req.GroupColumn, false)
+		if err != nil {
+			return nil, err
+		}
+		valueRaw, err := readCache.read(valueSnapshot.AssetRef, scratch)
+		if err != nil {
+			return nil, fmt.Errorf("collections: dictionary/hour values read generation=%d part_id=%d column=%q: %w", valueSnapshot.AssetRef.Generation, valueSnapshot.AssetRef.PartID, req.ValueColumn, err)
+		}
+		scratch = valueRaw
+		valueAsset, err := decodeColumnInt64ValuesAsset(valueRaw, valueSnapshot.AssetRef, view.Config, view.CollectionName, req.ValueColumn, false)
+		if err != nil {
+			return nil, err
+		}
+		if len(groupAsset.Codes) != len(valueAsset.Values) || len(valueAsset.Values) != valueSnapshot.Rows {
+			return nil, fmt.Errorf("collections: dictionary/hour row count mismatch group=%d values=%d manifest=%d", len(groupAsset.Codes), len(valueAsset.Values), valueSnapshot.Rows)
+		}
+		groupCodes := make([]uint32, len(groupAsset.Codes))
+		for codeIdx, localCode := range groupAsset.Codes {
+			value := groupAsset.Dictionary[localCode]
+			globalCode, ok := groupByValue[value]
+			if !ok {
+				if len(runner.groupDict) >= columnDictionaryHourCountMaxGroups || uint64(len(runner.groupDict)) == uint64(^uint32(0)) {
+					return nil, nil
+				}
+				globalCode = uint32(len(runner.groupDict))
+				groupByValue[value] = globalCode
+				runner.groupDict = append(runner.groupDict, value)
+			}
+			groupCodes[codeIdx] = globalCode
+		}
+		runner.assets = append(runner.assets, columnDictionaryHourCountAsset{
+			groupCodes: groupCodes,
+			values:     valueAsset.Values,
+		})
+		runner.assetBytes += groupSnapshot.AssetRef.Length + valueSnapshot.AssetRef.Length
+	}
+	if len(runner.assets) == 0 || len(runner.groupDict) == 0 {
+		return nil, nil
+	}
+	runner.initScratch()
+	return runner, nil
+}
+
+func (r *columnDictionaryHourCountRunner) initScratch() {
+	groups := len(r.groupDict)
+	r.counts = make([]int, groups*24)
+	resultCap := groups * 24
+	if resultCap > 1024 {
+		resultCap = 1024
+	}
+	r.result = make([]ColumnPhysicalQueryGroup, 0, resultCap)
+}
+
+func (r *columnDictionaryHourCountRunner) run(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest) ColumnPhysicalQueryResult {
+	start := time.Now()
+	clear(r.counts)
+	rows := 0
+	matched := 0
+	for assetIdx, asset := range r.assets {
+		var predicates *columnDictionaryPredicateAsset
+		if len(r.predicateAssets) != 0 {
+			predicates = &r.predicateAssets[assetIdx]
+		}
+		for rowIdx, groupCode := range asset.groupCodes {
+			rows++
+			if predicates != nil && !predicates.matches(rowIdx) {
+				continue
+			}
+			hour := columnPhysicalQueryUTCHour(asset.values[rowIdx])
+			r.counts[int(groupCode)*24+hour]++
+			matched++
+		}
+	}
+	if len(r.predicateAssets) == 0 {
+		matched = rows
+	}
+	r.result = r.result[:0]
+	for code, key := range r.groupDict {
+		base := code * 24
+		for hour := 0; hour < 24; hour++ {
+			count := r.counts[base+hour]
+			if count == 0 {
+				continue
+			}
+			r.result = append(r.result, ColumnPhysicalQueryGroup{Key: key, Hour: hour, Count: count})
+		}
+	}
+	sortColumnPhysicalQueryGroupsByKeyHour(r.result)
+	diag := columnPhysicalQueryDiagnosticsFromScan(view.Diagnostics)
+	diag.WorkerCount = 1
+	diag.ProjectedColumns = columnPhysicalQueryDiagnosticProjectedColumns(r.predicateDiagnostics, 2)
+	diag.ScheduledGranules = len(r.assets)
+	diag.DecodedBlocks = len(r.assets)
+	diag.DirectReduceBlocks = len(r.assets)
+	diag.DictionaryCodeHits = len(r.assets)
+	diag.PredicateDictionaryCodeHits = r.predicateCodeHit
+	diag.Int64ValueHits = len(r.assets)
+	diag.RowsScanned = rows
+	diag.PhysicalBytesScanned = r.assetBytes + r.predicateBytes
+	diag.ReduceRows = matched
+	diag.ResultGroups = len(r.result)
+	diag.ColumnAssetReadIntegrity = columnAssetReadIntegrityLabel(req.ColumnAssetReadIntegrity)
+	applyColumnPhysicalQueryPredicateDiagnostics(&diag, r.predicateDiagnostics, matched, r.predicateCodeHit)
+	diag.ScanNanos = time.Since(start).Nanoseconds()
+	return ColumnPhysicalQueryResult{Groups: r.result, Diagnostics: diag}
+}
+
+func sortColumnPhysicalQueryGroupsByKeyHour(groups []ColumnPhysicalQueryGroup) {
+	const insertionSortLimit = 64
+	less := func(a, b ColumnPhysicalQueryGroup) int {
+		if c := cmp.Compare(a.Key, b.Key); c != 0 {
+			return c
+		}
+		return cmp.Compare(a.Hour, b.Hour)
+	}
+	if len(groups) > insertionSortLimit {
+		slices.SortFunc(groups, less)
+		return
+	}
+	for i := 1; i < len(groups); i++ {
+		group := groups[i]
+		j := i - 1
+		for ; j >= 0 && less(group, groups[j]) < 0; j-- {
+			groups[j+1] = groups[j]
+		}
+		groups[j+1] = group
+	}
+}

--- a/TreeDB/collections/column_dict_hour_query.go
+++ b/TreeDB/collections/column_dict_hour_query.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-const columnDictionaryHourCountMaxGroups = 1 << 20
+const columnDictionaryHourCountMaxGroups = 1 << 16
 
 type columnDictionaryHourCountRunner struct {
 	groupColumn          string
@@ -38,12 +38,25 @@ func prepareColumnDictionaryHourCountRunner(view columnPhysicalScanSnapshotView,
 	if !columnDictionaryInt64GroupColumnsEligible(view, req) {
 		return nil, nil
 	}
+	runner := &columnDictionaryHourCountRunner{
+		groupColumn: req.GroupColumn,
+		valueColumn: req.ValueColumn,
+		assets:      make([]columnDictionaryHourCountAsset, 0, len(view.AssetRefs)),
+	}
+	if len(view.AssetRefs) == 0 {
+		if _, err := columnPhysicalQueryPredicateSpecs(view.Config, req); err != nil {
+			return nil, err
+		}
+		runner.predicateDiagnostics = newColumnPhysicalQueryPredicateDiagnosticPlan(req)
+		runner.initScratch()
+		return runner, nil
+	}
 	groupByPart := columnDictionaryCodeSnapshotsByPart(view, req.GroupColumn)
 	valueByPart := columnInt64ValueSnapshotsByPart(view, req.ValueColumn)
 	if len(groupByPart) == 0 || len(valueByPart) == 0 || !columnDictionaryInt64GroupSnapshotsCoverParts(view, groupByPart, valueByPart) {
 		return nil, nil
 	}
-	runner := &columnDictionaryHourCountRunner{
+	runner = &columnDictionaryHourCountRunner{
 		groupColumn: req.GroupColumn,
 		valueColumn: req.ValueColumn,
 		assets:      make([]columnDictionaryHourCountAsset, 0, len(view.AssetRefs)),
@@ -103,9 +116,6 @@ func prepareColumnDictionaryHourCountRunner(view columnPhysicalScanSnapshotView,
 		})
 		runner.assetBytes += groupSnapshot.AssetRef.Length + valueSnapshot.AssetRef.Length
 	}
-	if len(runner.assets) == 0 || len(runner.groupDict) == 0 {
-		return nil, nil
-	}
 	runner.initScratch()
 	return runner, nil
 }
@@ -129,6 +139,9 @@ func (r *columnDictionaryHourCountRunner) run(view columnPhysicalScanSnapshotVie
 		var predicates *columnDictionaryPredicateAsset
 		if len(r.predicateAssets) != 0 {
 			predicates = &r.predicateAssets[assetIdx]
+			if predicates.rejectsAll {
+				continue
+			}
 		}
 		for rowIdx, groupCode := range asset.groupCodes {
 			rows++

--- a/TreeDB/collections/column_physical_query.go
+++ b/TreeDB/collections/column_physical_query.go
@@ -33,6 +33,7 @@ const (
 	ColumnPhysicalQueryGroupCountDistinct    ColumnPhysicalQueryKind = "group_count_distinct"
 	ColumnPhysicalQueryGroupCountAndDistinct ColumnPhysicalQueryKind = "group_count_and_distinct"
 	ColumnPhysicalQueryHourCount             ColumnPhysicalQueryKind = "hour_count"
+	ColumnPhysicalQueryGroupHourCount        ColumnPhysicalQueryKind = "group_hour_count"
 	ColumnPhysicalQueryGroupMinInt64         ColumnPhysicalQueryKind = "group_min_int64"
 	ColumnPhysicalQueryGroupMaxInt64         ColumnPhysicalQueryKind = "group_max_int64"
 	ColumnPhysicalQueryGroupInt64Span        ColumnPhysicalQueryKind = "group_int64_span"
@@ -65,10 +66,11 @@ type ColumnPhysicalQueryRequest struct {
 
 // ColumnPhysicalQueryGroup is one reduced result row. Key is the group key.
 // Count is populated for count-style queries and remains the distinct count for
-// group_count_distinct. DistinctCount is populated by group_count_and_distinct;
-// Int64 is populated for min/max/span-style queries.
+// group_count_distinct. Hour is populated by group_hour_count. DistinctCount is
+// populated by group_count_and_distinct; Int64 is populated for min/max/span-style queries.
 type ColumnPhysicalQueryGroup struct {
 	Key           string
+	Hour          int
 	Count         int
 	DistinctCount int
 	Int64         int64
@@ -152,6 +154,7 @@ type ColumnPhysicalQueryRunner struct {
 	dictDistinct *columnDictionaryCodeGroupCountDistinctRunner
 	int64Hour    *columnInt64ValueHourCountRunner
 	dictInt64    *columnDictionaryInt64GroupRunner
+	dictHour     *columnDictionaryHourCountRunner
 	metadata     *columnAggregateMetadataRunner
 	closed       bool
 }
@@ -162,7 +165,23 @@ func validateColumnPhysicalQueryRequest(req ColumnPhysicalQueryRequest) error {
 	if err := validateColumnPhysicalGroupCountAndDistinctRequest(req); err != nil {
 		return err
 	}
+	if err := validateColumnPhysicalGroupHourRequest(req); err != nil {
+		return err
+	}
 	return validateColumnPhysicalTopKRequest(req)
+}
+
+func validateColumnPhysicalGroupHourRequest(req ColumnPhysicalQueryRequest) error {
+	if req.Kind != ColumnPhysicalQueryGroupHourCount {
+		return nil
+	}
+	if req.GroupColumn == "" {
+		return fmt.Errorf("%w: grouped-hour physical query group column is required", ErrColumnQueryPlanUnsupported)
+	}
+	if req.ValueColumn == "" {
+		return fmt.Errorf("%w: grouped-hour physical query value column is required", ErrColumnQueryPlanUnsupported)
+	}
+	return nil
 }
 
 func validateColumnPhysicalGroupCountAndDistinctRequest(req ColumnPhysicalQueryRequest) error {
@@ -311,11 +330,11 @@ func (c *Collection) PrepareColumnPhysicalQuery(req ColumnPhysicalQueryRequest) 
 			_ = readCache.close()
 			return nil, fmt.Errorf("%w: prepared aggregate metadata query requires metadata assets", ErrColumnQueryPlanUnsupported)
 		}
-	} else if !columnPhysicalQueryHasPredicates(req) && req.Kind != ColumnPhysicalQueryGroupCountAndDistinct {
-		// ColumnPhysicalQueryGroupCountAndDistinct intentionally skips the
+	} else if !columnPhysicalQueryHasPredicates(req) && req.Kind != ColumnPhysicalQueryGroupCountAndDistinct && req.Kind != ColumnPhysicalQueryGroupHourCount {
+		// Fused dictionary reducers intentionally skip the
 		// columnPhysicalQueryHasPredicates/no-predicate direct executor path:
-		// newColumnPhysicalQueryExecutor does not implement fused q2 semantics, so
-		// prepared execution must use the dictionary sidecar runner unless direct
+		// newColumnPhysicalQueryExecutor does not implement these semantics, so
+		// prepared execution must use dictionary sidecar runners unless direct
 		// fused support is added and validated here.
 		exec, err = newColumnPhysicalQueryExecutor(view.Config, req)
 		if err != nil {
@@ -350,11 +369,20 @@ func (c *Collection) PrepareColumnPhysicalQuery(req ColumnPhysicalQueryRequest) 
 		_ = readCache.close()
 		return nil, err
 	}
+	dictHour, err := prepareColumnDictionaryHourCountRunner(view, req, &readCache)
+	if err != nil {
+		_ = readCache.close()
+		return nil, err
+	}
 	if req.Kind == ColumnPhysicalQueryGroupCountAndDistinct && dictDistinct == nil {
 		_ = readCache.close()
 		return nil, fmt.Errorf("%w: fused count-distinct physical query requires dictionary sidecar reducers", ErrColumnQueryPlanUnsupported)
 	}
-	if columnPhysicalQueryHasPredicates(req) && dictCount == nil && dictDistinct == nil && dictInt64 == nil {
+	if req.Kind == ColumnPhysicalQueryGroupHourCount && dictHour == nil {
+		_ = readCache.close()
+		return nil, fmt.Errorf("%w: grouped-hour physical query requires dictionary/int64 sidecar reducers", ErrColumnQueryPlanUnsupported)
+	}
+	if columnPhysicalQueryHasPredicates(req) && dictCount == nil && dictDistinct == nil && dictInt64 == nil && dictHour == nil {
 		_ = readCache.close()
 		return nil, fmt.Errorf("%w: physical predicates require supported dictionary sidecar reducers", ErrColumnQueryPlanUnsupported)
 	}
@@ -370,6 +398,7 @@ func (c *Collection) PrepareColumnPhysicalQuery(req ColumnPhysicalQueryRequest) 
 		dictDistinct: dictDistinct,
 		int64Hour:    int64Hour,
 		dictInt64:    dictInt64,
+		dictHour:     dictHour,
 		metadata:     metadata,
 	}, nil
 }
@@ -411,6 +440,9 @@ func (r *ColumnPhysicalQueryRunner) Run() (ColumnPhysicalQueryResult, error) {
 	}
 	if r.dictInt64 != nil {
 		return r.dictInt64.run(r.view, r.req), nil
+	}
+	if r.dictHour != nil {
+		return r.dictHour.run(r.view, r.req), nil
 	}
 	if r.metadata != nil {
 		return r.metadata.run(r.view, r.req), nil
@@ -757,6 +789,8 @@ func columnManifestScanSidecarsForPhysicalQuery(req ColumnPhysicalQueryRequest) 
 			return columnManifestScanSidecarFilter{DictionaryCodes: true, DictionaryColumn: req.GroupColumn, DictionaryColumn2: req.DistinctColumn}
 		case ColumnPhysicalQueryHourCount:
 			return columnManifestScanSidecarFilter{Int64Values: true, Int64Column: req.ValueColumn}
+		case ColumnPhysicalQueryGroupHourCount:
+			return columnManifestScanSidecarFilter{DictionaryCodes: true, DictionaryColumn: req.GroupColumn, Int64Values: true, Int64Column: req.ValueColumn}
 		case ColumnPhysicalQueryGroupMinInt64, ColumnPhysicalQueryGroupMaxInt64, ColumnPhysicalQueryGroupInt64Span:
 			return columnManifestScanSidecarFilter{DictionaryCodes: true, DictionaryColumn: req.GroupColumn, Int64Values: true, Int64Column: req.ValueColumn}
 		default:
@@ -788,6 +822,10 @@ func columnManifestScanSidecarsForPhysicalQuery(req ColumnPhysicalQueryRequest) 
 	case ColumnPhysicalQueryHourCount:
 		filter.Int64Values = true
 		filter.Int64Column = req.ValueColumn
+	case ColumnPhysicalQueryGroupHourCount:
+		addDictionaryColumn(req.GroupColumn)
+		filter.Int64Values = true
+		filter.Int64Column = req.ValueColumn
 	case ColumnPhysicalQueryGroupMinInt64, ColumnPhysicalQueryGroupMaxInt64, ColumnPhysicalQueryGroupInt64Span:
 		addDictionaryColumn(req.GroupColumn)
 		filter.Int64Values = true
@@ -806,6 +844,9 @@ func (c *Collection) runColumnPhysicalQueryInSnapshotView(view columnPhysicalSca
 		return result, err
 	}
 	if result, ok, err := c.runColumnPhysicalQueryDictionaryInt64InSnapshotView(view, req); ok {
+		return result, err
+	}
+	if result, ok, err := c.runColumnPhysicalQueryDictionaryHourInSnapshotView(view, req); ok {
 		return result, err
 	}
 	if columnPhysicalQueryHasPredicates(req) {
@@ -959,6 +1000,33 @@ func (c *Collection) runColumnPhysicalQueryDictionaryInt64InSnapshotView(view co
 	if runner == nil {
 		if columnPhysicalQueryHasPredicates(req) {
 			return ColumnPhysicalQueryResult{}, true, fmt.Errorf("%w: physical predicates require dictionary/int64 sidecar reducers", ErrColumnQueryPlanUnsupported)
+		}
+		return ColumnPhysicalQueryResult{}, false, nil
+	}
+	result := runner.run(view, req)
+	result.Diagnostics.SegmentFileCacheHits = readCache.hits
+	result.Diagnostics.SegmentFileCacheMisses = readCache.misses
+	return result, true, nil
+}
+
+func (c *Collection) runColumnPhysicalQueryDictionaryHourInSnapshotView(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest) (ColumnPhysicalQueryResult, bool, error) {
+	if req.AggregateMetadataName != "" || view.MutationParts != 0 || req.Kind != ColumnPhysicalQueryGroupHourCount || req.GroupColumn == "" || req.ValueColumn == "" {
+		return ColumnPhysicalQueryResult{}, false, nil
+	}
+	readCache, err := newColumnPhysicalAssetReadCacheWithIntegrity(view.ColumnAssetRootDir, view.AssetNamespace, req.ColumnAssetReadIntegrity)
+	if err != nil {
+		return ColumnPhysicalQueryResult{}, true, err
+	}
+	readCache.returnViews = true
+	defer func() { _ = readCache.close() }()
+
+	runner, err := prepareColumnDictionaryHourCountRunner(view, req, &readCache)
+	if err != nil {
+		return ColumnPhysicalQueryResult{}, true, err
+	}
+	if runner == nil {
+		if columnPhysicalQueryHasPredicates(req) {
+			return ColumnPhysicalQueryResult{}, true, fmt.Errorf("%w: grouped-hour physical predicates require dictionary/int64 sidecar reducers", ErrColumnQueryPlanUnsupported)
 		}
 		return ColumnPhysicalQueryResult{}, false, nil
 	}

--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -2108,7 +2108,7 @@ func TestColumnPhysicalQueryGroupHourCountQ31858(t *testing.T) {
 	if err != nil {
 		t.Fatalf("RunColumnPhysicalQuery absent q3: %v", err)
 	}
-	if len(result.Groups) != 0 || result.Diagnostics.RowsScanned != len(events) || result.Diagnostics.RowsMatched != 0 || result.Diagnostics.ReduceRows != 0 {
+	if len(result.Groups) != 0 || result.Diagnostics.RowsScanned != 0 || result.Diagnostics.RowsMatched != 0 || result.Diagnostics.ReduceRows != 0 {
 		t.Fatalf("absent q3 result=%+v diagnostics=%+v", result.Groups, result.Diagnostics)
 	}
 	absentRunner, err := collection.PrepareColumnPhysicalQuery(absent)
@@ -2120,7 +2120,7 @@ func TestColumnPhysicalQueryGroupHourCountQ31858(t *testing.T) {
 	if err != nil {
 		t.Fatalf("prepared absent q3: %v", err)
 	}
-	if len(preparedAbsent.Groups) != 0 || preparedAbsent.Diagnostics.RowsScanned != len(events) || preparedAbsent.Diagnostics.RowsMatched != 0 || preparedAbsent.Diagnostics.ReduceRows != 0 {
+	if len(preparedAbsent.Groups) != 0 || preparedAbsent.Diagnostics.RowsScanned != 0 || preparedAbsent.Diagnostics.RowsMatched != 0 || preparedAbsent.Diagnostics.ReduceRows != 0 {
 		t.Fatalf("prepared absent q3 result=%+v diagnostics=%+v", preparedAbsent.Groups, preparedAbsent.Diagnostics)
 	}
 }

--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -2020,6 +2020,111 @@ func TestColumnPhysicalQueryDictionaryPredicatesJSONBenchShapes1869(t *testing.T
 	}
 }
 
+func TestColumnPhysicalQueryGroupHourCountQ31858(t *testing.T) {
+	base := int64(1_700_000_000_000_000)
+	events := []columnPhysicalPredicateEvent1869{
+		{ID: "e1", Kind: "commit", Operation: "create", Event: "post", Did: "did_a", TimeUS: base + 0*columnPhysicalQueryHourUS},
+		{ID: "e2", Kind: "commit", Operation: "create", Event: "post", Did: "did_b", TimeUS: base + 0*columnPhysicalQueryHourUS + 1},
+		{ID: "e3", Kind: "commit", Operation: "create", Event: "post", Did: "did_c", TimeUS: base + 1*columnPhysicalQueryHourUS},
+		{ID: "e4", Kind: "commit", Operation: "create", Event: "like", Did: "did_d", TimeUS: base + 1*columnPhysicalQueryHourUS},
+		{ID: "e5", Kind: "commit", Operation: "delete", Event: "post", Did: "did_e", TimeUS: base + 2*columnPhysicalQueryHourUS},
+		{ID: "e6", Kind: "identity", Operation: "create", Event: "post", Did: "did_f", TimeUS: base + 3*columnPhysicalQueryHourUS},
+		{ID: "e7", Kind: "commit", Operation: "create", Event: "repost", Did: "did_g", TimeUS: base + 23*columnPhysicalQueryHourUS},
+	}
+	collection, closeFn := openColumnPhysicalPredicateFixture1869(t, events)
+	defer closeFn()
+
+	req := ColumnPhysicalQueryRequest{
+		Kind:        ColumnPhysicalQueryGroupHourCount,
+		GroupColumn: "event",
+		ValueColumn: "time_us",
+		Predicates: []ColumnPhysicalQueryPredicate{
+			{Column: "kind", Value: "commit"},
+			{Column: "operation", Value: "create"},
+			{Column: "event", Kind: ColumnPhysicalQueryPredicateInList, Values: []string{"post", "like"}},
+		},
+	}
+	want := map[string]int{
+		fmt.Sprintf("like/%02d", columnPhysicalQueryUTCHour(base+1*columnPhysicalQueryHourUS)): 1,
+		fmt.Sprintf("post/%02d", columnPhysicalQueryUTCHour(base+0*columnPhysicalQueryHourUS)): 2,
+		fmt.Sprintf("post/%02d", columnPhysicalQueryUTCHour(base+1*columnPhysicalQueryHourUS)): 1,
+	}
+	assertQ3 := func(t *testing.T, result ColumnPhysicalQueryResult) {
+		t.Helper()
+		got := make(map[string]int, len(result.Groups))
+		for _, group := range result.Groups {
+			got[fmt.Sprintf("%s/%02d", group.Key, group.Hour)] = group.Count
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("q3 groups=%v want %v full=%+v", got, want, result.Groups)
+		}
+		if result.Diagnostics.RowsScanned != len(events) || result.Diagnostics.RowsMatched != 4 || result.Diagnostics.ReduceRows != 4 || result.Diagnostics.DocumentMaterializations != 0 || result.Diagnostics.RowMaterializations != 0 {
+			t.Fatalf("diagnostics=%+v want scanned=%d matched/reduced=4 no materialization", result.Diagnostics, len(events))
+		}
+		if result.Diagnostics.PredicateCount != 3 || result.Diagnostics.DictionaryCodeHits == 0 || result.Diagnostics.Int64ValueHits == 0 {
+			t.Fatalf("q3 sidecar diagnostics=%+v", result.Diagnostics)
+		}
+	}
+
+	t.Run("one-shot", func(t *testing.T) {
+		result, err := collection.RunColumnPhysicalQuery(req)
+		if err != nil {
+			t.Fatalf("RunColumnPhysicalQuery q3: %v", err)
+		}
+		assertQ3(t, result)
+	})
+	t.Run("prepared", func(t *testing.T) {
+		runner, err := collection.PrepareColumnPhysicalQuery(req)
+		if err != nil {
+			t.Fatalf("PrepareColumnPhysicalQuery q3: %v", err)
+		}
+		defer func() { _ = runner.Close() }()
+		for i := 0; i < 2; i++ {
+			result, err := runner.Run()
+			if err != nil {
+				t.Fatalf("prepared q3 run %d: %v", i, err)
+			}
+			assertQ3(t, result)
+		}
+	})
+	for _, tc := range []struct {
+		name string
+		req  ColumnPhysicalQueryRequest
+		want string
+	}{
+		{name: "missing group", req: ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupHourCount, ValueColumn: "time_us"}, want: "group column is required"},
+		{name: "missing value", req: ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupHourCount, GroupColumn: "event"}, want: "value column is required"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := collection.PrepareColumnPhysicalQuery(tc.req); !errors.Is(err, ErrColumnQueryPlanUnsupported) || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("PrepareColumnPhysicalQuery err=%v want ErrColumnQueryPlanUnsupported containing %q", err, tc.want)
+			}
+		})
+	}
+
+	absent := req
+	absent.Predicates = []ColumnPhysicalQueryPredicate{{Column: "event", Value: "missing"}}
+	result, err := collection.RunColumnPhysicalQuery(absent)
+	if err != nil {
+		t.Fatalf("RunColumnPhysicalQuery absent q3: %v", err)
+	}
+	if len(result.Groups) != 0 || result.Diagnostics.RowsScanned != len(events) || result.Diagnostics.RowsMatched != 0 || result.Diagnostics.ReduceRows != 0 {
+		t.Fatalf("absent q3 result=%+v diagnostics=%+v", result.Groups, result.Diagnostics)
+	}
+	absentRunner, err := collection.PrepareColumnPhysicalQuery(absent)
+	if err != nil {
+		t.Fatalf("PrepareColumnPhysicalQuery absent q3: %v", err)
+	}
+	defer func() { _ = absentRunner.Close() }()
+	preparedAbsent, err := absentRunner.Run()
+	if err != nil {
+		t.Fatalf("prepared absent q3: %v", err)
+	}
+	if len(preparedAbsent.Groups) != 0 || preparedAbsent.Diagnostics.RowsScanned != len(events) || preparedAbsent.Diagnostics.RowsMatched != 0 || preparedAbsent.Diagnostics.ReduceRows != 0 {
+		t.Fatalf("prepared absent q3 result=%+v diagnostics=%+v", preparedAbsent.Groups, preparedAbsent.Diagnostics)
+	}
+}
+
 func TestColumnPhysicalQueryGroupCountAndDistinctFused1870(t *testing.T) {
 	events := []columnPhysicalPredicateEvent1869{
 		{ID: "e1", Kind: "commit", Operation: "create", Event: "post", Did: "did_a", TimeUS: 1},
@@ -2232,6 +2337,7 @@ func BenchmarkColumnPhysicalQueryDictionaryPredicates1869(b *testing.B) {
 		{name: "q2_count", req: ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount, GroupColumn: "event", Predicates: commitCreate}},
 		{name: "q2_distinct", req: ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCountDistinct, GroupColumn: "event", DistinctColumn: "did", Predicates: commitCreate}},
 		{name: "q2_fused_count_distinct", req: ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCountAndDistinct, GroupColumn: "event", DistinctColumn: "did", Predicates: commitCreate}},
+		{name: "q3_group_hour_count", req: ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupHourCount, GroupColumn: "event", ValueColumn: "time_us", Predicates: postCreate}},
 		{name: "q4_min", req: ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupMinInt64, GroupColumn: "did", ValueColumn: "time_us", Predicates: postCreate}},
 		{name: "q5_span", req: ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupInt64Span, GroupColumn: "did", ValueColumn: "time_us", Predicates: postCreate}},
 	}

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -380,7 +380,7 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/vector_index_rebuild.go", classification: typedStorageLegacyDerived, matchingLines: 16, occurrences: 18},
 	{path: "TreeDB/collections/vector_index_rebuild_test.go", classification: typedStorageLegacyDerived, matchingLines: 32, occurrences: 38},
 	{path: "TreeDB/docs/guides/collections-quickstart.md", classification: typedStorageLegacyCompatibility, matchingLines: 18, occurrences: 22},
-	{path: "TreeDB/docs/guides/typed-storage-performance.md", classification: typedStorageLegacyCompatibility, matchingLines: 1, occurrences: 1},
+	{path: "TreeDB/docs/guides/typed-storage-performance.md", classification: typedStorageLegacyCompatibility, matchingLines: 2, occurrences: 2},
 	{path: "TreeDB/docs/guides/vector-search-typed-column.md", classification: typedStorageLegacyCompatibility, matchingLines: 5, occurrences: 6},
 	{path: "TreeDB/docs/spec/COMPRESSION_TECHNOLOGY_SPEC.md", classification: typedStorageLegacyDeferred, matchingLines: 5, occurrences: 5},
 	{path: "TreeDB/docs/spec/GOMAP_TREEDB_COLUMN_STORE_RFC.md", classification: typedStorageLegacyDeferred, matchingLines: 108, occurrences: 112},

--- a/TreeDB/docs/guides/typed-storage-performance.md
+++ b/TreeDB/docs/guides/typed-storage-performance.md
@@ -116,6 +116,25 @@ Key counters: `metadata_hits/op`, `metadata_decoded_bytes/op`,
 Top-K result shaping for int64 min/max/span results; this keeps all-groups
 semantics unchanged unless callers set `TopK` and `TopKOrder`.
 
+### JSONBench q3 grouped-hour physical reducer
+
+`ColumnPhysicalQueryGroupHourCount` covers the narrow q3-shaped physical reducer:
+dictionary string predicates, a dictionary string group column, and UTC hour
+extracted from an int64 timestamp column. The supported insert-only sidecar path
+scans dictionary-code and int64 assets directly, reports zero document/row
+materializations, and emits groups keyed by `Key` plus `Hour`.
+
+The low-level comparison harness exposes this as
+`q3_group_hour_count`:
+
+```sh
+TREEDB_JSONBENCH_COMPARE_ROWS=1000000 \
+  go test ./experiments/colgranule \
+    -run '^$' \
+    -bench '^BenchmarkJSONBenchColumnStoreCompare/rows_1000000/treedb_column_store_prepared/q3_group_hour_count$' \
+    -benchmem -benchtime=5x -count=1
+```
+
 ### Selecting #1808 matrix shapes and distributions
 
 Use the benchmark environment variables to cover shapes beyond the default

--- a/experiments/colgranule/README.md
+++ b/experiments/colgranule/README.md
@@ -318,10 +318,12 @@ The known q4 caveat is sort order, not row materialization: M2's single-part
 baseline can early-stop on a globally time-ordered part, while the correct M4
 multipart path currently scans visible rows. A future k-way sort-key/mark merge
 across parts is needed before multipart q4 can early-stop safely. The TreeDB
-comparison also includes explicit aggregate-metadata Top-K q4/q5 variants that
-report `topk_limit/op`, `topk_candidates/op`, and `result_shape_ns/op`; these
-use logical rows/sec with `rows_scanned/op=0` and should not be confused with
-full data-row scans or pruning metadata.
+comparison also includes `q3_group_hour_count`, a production physical reducer
+shape for dictionary predicates plus `collection/hour(time_us)` grouping, and
+explicit aggregate-metadata Top-K q4/q5 variants that report `topk_limit/op`,
+`topk_candidates/op`, and `result_shape_ns/op`; metadata paths use logical
+rows/sec with `rows_scanned/op=0` and should not be confused with full data-row
+scans or pruning metadata.
 
 ## M1D Gates Before Value-Log-Backed M2
 

--- a/experiments/colgranule/jsonbench_treedb_columnstore_bench_test.go
+++ b/experiments/colgranule/jsonbench_treedb_columnstore_bench_test.go
@@ -111,6 +111,11 @@ func benchmarkJSONBenchColumnStoreCompareTreeDB(b *testing.B, ds JSONBenchDatase
 		{name: "q1_grouped_count", req: collections.ColumnPhysicalQueryRequest{Kind: collections.ColumnPhysicalQueryGroupCount, GroupColumn: "collection"}},
 		{name: "q2_group_count_distinct", req: collections.ColumnPhysicalQueryRequest{Kind: collections.ColumnPhysicalQueryGroupCountDistinct, GroupColumn: "collection", DistinctColumn: "did"}},
 		{name: "q3_hourly_count", req: collections.ColumnPhysicalQueryRequest{Kind: collections.ColumnPhysicalQueryHourCount, ValueColumn: "time_us"}},
+		{name: "q3_group_hour_count", req: collections.ColumnPhysicalQueryRequest{Kind: collections.ColumnPhysicalQueryGroupHourCount, GroupColumn: "collection", ValueColumn: "time_us", Predicates: []collections.ColumnPhysicalQueryPredicate{
+			{Column: "kind", Value: "commit"},
+			{Column: "operation", Value: "create"},
+			{Column: "collection", Kind: collections.ColumnPhysicalQueryPredicateInList, Values: []string{"app.bsky.feed.post"}},
+		}}},
 		{name: "q4_min_by_user", req: collections.ColumnPhysicalQueryRequest{Kind: collections.ColumnPhysicalQueryGroupMinInt64, GroupColumn: "did", ValueColumn: "time_us"}},
 		{name: "q5_span_by_user", req: collections.ColumnPhysicalQueryRequest{Kind: collections.ColumnPhysicalQueryGroupInt64Span, GroupColumn: "did", ValueColumn: "time_us"}},
 		{name: "q4_metadata_min_by_user", req: collections.ColumnPhysicalQueryRequest{Kind: collections.ColumnPhysicalQueryGroupMinInt64, GroupColumn: "did", ValueColumn: "time_us", AggregateMetadataName: "min_time_us"}},
@@ -220,6 +225,9 @@ func jsonBenchColumnPhysicalResultDigest(groups []collections.ColumnPhysicalQuer
 		if ordered[i].Key != ordered[j].Key {
 			return ordered[i].Key < ordered[j].Key
 		}
+		if ordered[i].Hour != ordered[j].Hour {
+			return ordered[i].Hour < ordered[j].Hour
+		}
 		if ordered[i].Count != ordered[j].Count {
 			return ordered[i].Count < ordered[j].Count
 		}
@@ -227,7 +235,7 @@ func jsonBenchColumnPhysicalResultDigest(groups []collections.ColumnPhysicalQuer
 	})
 	h := sha256.New()
 	for _, group := range ordered {
-		_, _ = fmt.Fprintf(h, "%s\x00%d\x00%d\x00", group.Key, group.Count, group.Int64)
+		_, _ = fmt.Fprintf(h, "%s\x00%d\x00%d\x00%d\x00", group.Key, group.Hour, group.Count, group.Int64)
 	}
 	return hex.EncodeToString(h.Sum(nil))
 }


### PR DESCRIPTION
Closes #1858.

## Summary

Adds a TreeDB physical q3 reducer for the JSONBench column-store shape:

- new `ColumnPhysicalQueryGroupHourCount` public query kind;
- `ColumnPhysicalQueryGroup.Hour` for `group + UTC hour(time_us)` results;
- prepared dictionary/int64 sidecar runner that scans dictionary group codes + int64 timestamps and applies dictionary predicates directly;
- dense `groupCode*24 + hour` counters with deterministic `Key,Hour` result ordering;
- one-shot execution path and prepared runner path;
- explicit request validation and fail-closed behavior for unsupported grouped-hour shapes;
- tests for one-shot/prepared parity, predicate filtering, absent literal empty results, validation, and no document/row materialization;
- low-level JSONBench comparison q3 grouped-hour benchmark at 100K and 1M rows.

## Scope / milestone

Implements the M1-M3 gomap physical reducer portion of #1858. It does not update the separate `snissn/JSONBench` harness in this PR; the gomap API/benchmark seam is now available for that harness to consume in a follow-up.

## Start-phase baseline

Existing q3 materialized fallback evidence from #1858/#1832:

| rows | fallback time | rows/sec | ns/row | B/op | allocs/op |
|---:|---:|---:|---:|---:|---:|
| 25,000 | 0.571s | 44,191 | 22,629 | 80.8 MB | 938k |
| 50,000 | 2.247s | 22,299 | 44,845 | 167.2 MB | 1.88M |
| 100,000 | 8.853s | 11,302 | 88,482 | 331.1 MB | 3.75M |

The low-level TreeDB q3 shape before this PR only had `hour_count` (hour-only), not `collection/hour` grouping with predicates.

## Close-phase tests

```sh
go test ./TreeDB/collections -run 'TestColumnPhysicalQueryGroupHourCountQ31858|TestColumnPhysicalQueryDictionaryPredicatesJSONBenchShapes1869'
go test ./TreeDB/collections -run 'TestTypedStorageLegacyNameAllowlistIsComplete|TestColumnPhysicalQueryGroupHourCountQ31858'
go test ./TreeDB/collections
go test ./TreeDB/...
go test ./experiments/colgranule
```

All passed locally. One earlier `go test ./TreeDB/...` run hit existing flaky `TestCheckpoint_KicksVlogGenerationRewriteDespiteRecentForegroundActivity`; a focused rerun and the final full rerun passed.

## Close-phase benchmark evidence

Focused small physical reducer benchmark:

```sh
go test ./TreeDB/collections -run '^$' \
  -bench '^BenchmarkColumnPhysicalQueryDictionaryPredicates1869/q3_group_hour_count$' \
  -benchmem -benchtime=10x -count=1
```

| rows/op | matched rows/op | ns/op | scanned rows/sec | B/op | allocs/op |
|---:|---:|---:|---:|---:|---:|
| 8,192 | 2,291 | 47,358 | 175.0M | 0 | 0 |

Low-level JSONBench-shaped q3 grouped-hour benchmark:

```sh
TREEDB_JSONBENCH_COMPARE_ROWS=100000 go test ./experiments/colgranule -run '^$' \
  -bench '^BenchmarkJSONBenchColumnStoreCompare/rows_100000/treedb_column_store_(one_shot|prepared)/q3_group_hour_count$' \
  -benchmem -benchtime=5x -count=1
TREEDB_JSONBENCH_COMPARE_ROWS=1000000 go test ./experiments/colgranule -run '^$' \
  -bench '^BenchmarkJSONBenchColumnStoreCompare/rows_1000000/treedb_column_store_(one_shot|prepared)/q3_group_hour_count$' \
  -benchmem -benchtime=5x -count=1
```

Artifact: `/tmp/treedb_1858_q3_group_hour_20260526_002023_100k_1m_one_prepared.txt`

| rows | path | ns/op | rows/sec | rows_scanned/op | reduce_rows/op | result_groups/op | physical bytes/op | document materializations | row materializations | B/op | allocs/op |
|---:|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| 100,000 | one-shot | 2,759,525 | 36.2M | 100,000 | 100,000 | 24 | 2,402,808 | 0 | 0 | 2,819,168 | 98 |
| 100,000 | prepared | 613,350 | 164.5M | 100,000 | 100,000 | 24 | 2,402,808 | 0 | 0 | 0 | 0 |
| 1,000,000 | one-shot | 25,233,992 | 39.6M | 1,000,000 | 1,000,000 | 24 | 24,021,762 | 0 | 0 | 28,183,001 | 468 |
| 1,000,000 | prepared | 6,179,925 | 163.1M | 1,000,000 | 1,000,000 | 24 | 24,021,762 | 0 | 0 | 0 | 0 |

Timing boundary: setup/load and `PrepareColumnPhysicalQuery` are outside the timed loop for prepared cells; the hot run scans/reduces sidecar arrays only. This low-level fixture is filter-degenerate (`commit/create/app.bsky.feed.post`) but exercises the production q3 reducer contract: dictionary predicates + collection/hour grouping + no document reconstruction.

## Review / CI

Coordinator used the Orca issue-list workflow. AI review requested after PR creation; latest-head CI and review findings will be resolved before merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hour-count aggregation for grouped column queries: per-group per-UTC-hour counts with dictionary-backed filtering and reduced memory path.

* **Documentation**
  * Added guide subsection describing the grouped-hour reducer and example benchmark command.

* **Tests**
  * Added unit tests and benchmark scenarios covering grouped-hour aggregation and predicate behavior.

* **Benchmarks**
  * Updated benchmark matrix and result digesting to include hour in ordering/hashing and reflect the new reducer.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1883?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->