### PR TITLE
Land allocation-free column graph adjacency probes

### DIFF
--- a/TreeDB/collections/column_vector_graph_block_view.go
+++ b/TreeDB/collections/column_vector_graph_block_view.go
@@ -483,10 +483,11 @@ func columnVectorGraphLittleEndianUint32DirectView(raw []byte, count int) ([]uin
 	if count == 0 {
 		return nil, true
 	}
-	if !columnPhysicalNativeLittleEndian || uintptr(unsafe.Pointer(&raw[0]))%4 != 0 {
+	ptr := unsafe.Pointer(unsafe.SliceData(raw))
+	if !columnPhysicalNativeLittleEndian || uintptr(ptr)%unsafe.Alignof(uint32(0)) != 0 {
 		return nil, false
 	}
-	return unsafe.Slice((*uint32)(unsafe.Pointer(&raw[0])), count), true
+	return unsafe.Slice((*uint32)(ptr), count), true
 }
 
 func (v *columnVectorGraphBlockView) adjacencyLittleEndian() bool {

--- a/TreeDB/collections/column_vector_graph_block_view.go
+++ b/TreeDB/collections/column_vector_graph_block_view.go
@@ -4,8 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
-
-	"github.com/snissn/gomap/TreeDB/internal/typeddecode"
+	"unsafe"
 )
 
 var errColumnVectorGraphBlockViewRowOutOfBounds = errors.New("column_graph block view row outside block")
@@ -478,11 +477,16 @@ func columnVectorGraphBlockViewAdjacencyDirectView(reader *columnVectorGraphPhys
 }
 
 func columnVectorGraphLittleEndianUint32DirectView(raw []byte, count int) ([]uint32, bool) {
-	if count <= 0 || len(raw) != count*4 {
+	if count < 0 || len(raw)%4 != 0 || len(raw)/4 != count {
 		return nil, false
 	}
-	view, status := typeddecode.Uint32ByteView(raw, typeddecode.ResourceViewOptions{ExpectedElements: count})
-	return view, status.Direct()
+	if count == 0 {
+		return nil, true
+	}
+	if !columnPhysicalNativeLittleEndian || uintptr(unsafe.Pointer(&raw[0]))%4 != 0 {
+		return nil, false
+	}
+	return unsafe.Slice((*uint32)(unsafe.Pointer(&raw[0])), count), true
 }
 
 func (v *columnVectorGraphBlockView) adjacencyLittleEndian() bool {

--- a/TreeDB/collections/column_vector_graph_block_view_test.go
+++ b/TreeDB/collections/column_vector_graph_block_view_test.go
@@ -1,11 +1,13 @@
 package collections
 
 import (
+	"encoding/binary"
 	"errors"
 	"math"
 	"slices"
 	"strings"
 	"testing"
+	"unsafe"
 )
 
 func TestColumnVectorGraphSearchPlanOrdinalRefV1(t *testing.T) {
@@ -167,5 +169,147 @@ func TestColumnVectorGraphBlockViewRejectsMalformedRowsV1(t *testing.T) {
 	_, _, err = plan.blockViewForOrdinal(0)
 	if err == nil || !strings.Contains(err.Error(), "invalid inv_norm") {
 		t.Fatalf("blockViewForOrdinal err=%v want invalid inv_norm", err)
+	}
+}
+
+func TestColumnVectorGraphAdjacencyDirectViewProbeAlignedLittleEndianV1(t *testing.T) {
+	if !columnPhysicalNativeLittleEndian {
+		t.Skip("direct uint32 byte views require little-endian host order")
+	}
+	raw := columnVectorGraphAlignedBytesForTest(t, 8)
+	columnVectorGraphPutLittleEndianUint32sForTest(raw, []uint32{7, 11})
+	adjacency, ok := columnVectorGraphLittleEndianUint32DirectView(raw, 2)
+	if !ok {
+		t.Fatal("direct view probe returned ok=false for aligned little-endian adjacency")
+	}
+	if !slices.Equal(adjacency, []uint32{7, 11}) {
+		t.Fatalf("adjacency=%v want [7 11]", adjacency)
+	}
+}
+
+func TestColumnVectorGraphBlockViewAdjacencyAlignedDirectNoScratchV1(t *testing.T) {
+	if !columnPhysicalNativeLittleEndian {
+		t.Skip("direct uint32 byte views require little-endian host order")
+	}
+	raw := columnVectorGraphAlignedBytesForTest(t, 8)
+	columnVectorGraphPutLittleEndianUint32sForTest(raw, []uint32{3, 5})
+	view := columnVectorGraphAdjacencyBlockViewForTest(nil, raw, columnVectorGraphAdjacencySpan{start: 0, end: len(raw), count: 2})
+	adjacency, scratch, direct, err := view.adjacency(0, nil)
+	if err != nil {
+		t.Fatalf("adjacency: %v", err)
+	}
+	if !direct {
+		t.Fatal("adjacency direct=false want direct view")
+	}
+	if len(scratch) != 0 {
+		t.Fatalf("scratch len=%d want 0 for direct view", len(scratch))
+	}
+	if !slices.Equal(adjacency, []uint32{3, 5}) {
+		t.Fatalf("adjacency=%v want [3 5]", adjacency)
+	}
+}
+
+func TestColumnVectorGraphAdjacencyDirectViewProbeUnalignedFallsBackV1(t *testing.T) {
+	raw, start := columnVectorGraphUnalignedAdjacencyRawForTest(t, 8)
+	columnVectorGraphPutLittleEndianUint32sForTest(raw[start:start+8], []uint32{13, 17})
+	if adjacency, ok := columnVectorGraphLittleEndianUint32DirectView(raw[start:start+8], 2); ok || adjacency != nil {
+		t.Fatalf("direct view probe=(%v,%t) want ineligible unaligned span", adjacency, ok)
+	}
+	reader, cleanup := columnVectorGraphAdjacencyLittleEndianReaderForTest(t)
+	defer cleanup()
+	view := columnVectorGraphAdjacencyBlockViewForTest(reader, raw, columnVectorGraphAdjacencySpan{start: start, end: start + 8, count: 2})
+	adjacency, scratch, direct, err := view.adjacency(0, nil)
+	if err != nil {
+		t.Fatalf("adjacency: %v", err)
+	}
+	if direct {
+		t.Fatal("adjacency direct=true want scratch fallback for unaligned span")
+	}
+	if !slices.Equal(adjacency, []uint32{13, 17}) || !slices.Equal(scratch, []uint32{13, 17}) {
+		t.Fatalf("adjacency=%v scratch=%v want scratch decoded [13 17]", adjacency, scratch)
+	}
+}
+
+func TestColumnVectorGraphAdjacencyDirectViewProbeZeroLengthDirectV1(t *testing.T) {
+	adjacency, ok := columnVectorGraphLittleEndianUint32DirectView(nil, 0)
+	if !ok || adjacency != nil {
+		t.Fatalf("direct view probe=(%v,%t) want nil,true for zero-length adjacency", adjacency, ok)
+	}
+	view := columnVectorGraphAdjacencyBlockViewForTest(nil, nil, columnVectorGraphAdjacencySpan{})
+	adjacency, scratch, direct, err := view.adjacency(0, nil)
+	if err != nil {
+		t.Fatalf("adjacency: %v", err)
+	}
+	if !direct || adjacency != nil || scratch != nil {
+		t.Fatalf("adjacency=%v scratch=%v direct=%t want nil nil true", adjacency, scratch, direct)
+	}
+}
+
+func TestColumnVectorGraphAdjacencyDirectViewProbeMalformedLengthV1(t *testing.T) {
+	raw := columnVectorGraphAlignedBytesForTest(t, 7)
+	if adjacency, ok := columnVectorGraphLittleEndianUint32DirectView(raw, 2); ok || adjacency != nil {
+		t.Fatalf("direct view probe=(%v,%t) want ineligible malformed byte length", adjacency, ok)
+	}
+	raw = columnVectorGraphAlignedBytesForTest(t, 8)
+	if adjacency, ok := columnVectorGraphLittleEndianUint32DirectView(raw, 3); ok || adjacency != nil {
+		t.Fatalf("direct view probe=(%v,%t) want ineligible mismatched count", adjacency, ok)
+	}
+}
+
+func columnVectorGraphAdjacencyBlockViewForTest(reader *columnVectorGraphPhysicalRowReader, raw []byte, span columnVectorGraphAdjacencySpan) *columnVectorGraphBlockView {
+	return &columnVectorGraphBlockView{
+		reader:              reader,
+		block:               &columnPhysicalRowReaderBlock{raw: raw},
+		adjSpans:            []columnVectorGraphAdjacencySpan{span},
+		rowValidated:        []bool{true},
+		adjacencyDirectView: true,
+	}
+}
+
+func columnVectorGraphAdjacencyLittleEndianReaderForTest(tb testing.TB) (*columnVectorGraphPhysicalRowReader, func()) {
+	tb.Helper()
+	d, col, def := publishColumnVectorGraphPhysicalReaderTestAssetV2B(tb, []columnVectorGraphAssetRow{
+		{ID: []byte("doc-a"), Vector: []float32{1, 0, 0}, InvNorm: 1, Adjacency: []uint32{0}},
+	})
+	reader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
+	if err != nil {
+		_ = d.Close()
+		tb.Fatalf("openColumnVectorGraphPhysicalRowReader: %v", err)
+	}
+	return reader, func() {
+		_ = reader.Close()
+		_ = d.Close()
+	}
+}
+
+func columnVectorGraphAlignedBytesForTest(tb testing.TB, n int) []byte {
+	tb.Helper()
+	raw := make([]byte, n+3)
+	for off := 0; off < 4; off++ {
+		candidate := raw[off : off+n]
+		if n == 0 || uintptr(unsafe.Pointer(&candidate[0]))%4 == 0 {
+			return candidate
+		}
+	}
+	tb.Fatal("could not find aligned byte window")
+	return nil
+}
+
+func columnVectorGraphUnalignedAdjacencyRawForTest(tb testing.TB, n int) ([]byte, int) {
+	tb.Helper()
+	raw := make([]byte, n+4)
+	for off := 0; off < 4; off++ {
+		candidate := raw[off : off+1+n]
+		if uintptr(unsafe.Pointer(&candidate[1]))%4 != 0 {
+			return candidate, 1
+		}
+	}
+	tb.Fatal("could not find unaligned byte window")
+	return nil, 0
+}
+
+func columnVectorGraphPutLittleEndianUint32sForTest(raw []byte, values []uint32) {
+	for i, value := range values {
+		binary.LittleEndian.PutUint32(raw[i*4:], value)
 	}
 }


### PR DESCRIPTION
## Linked tracker issue and milestone

Closes #1885.

This is the reader-only column_graph adjacency direct-view probe milestone. It intentionally does **not** change writer layout, on-disk format, manifest certification/alignment (#1886), projection semantics (#1875), or retained-payload policy (#1876).

## What changed

- Replaced the column_graph adjacency direct-view eligibility path with a no-error probe that checks exact byte length/count, native little-endian host order, and 4-byte alignment before building an unsafe `[]uint32` view.
- Preserved scratch decode fallback for ineligible spans.
- Added focused coverage for aligned direct view, unaligned scratch fallback, zero-length adjacency, malformed length ineligibility, and checkptr validation of the unsafe view gate.

## Start-phase test plan

- Confirm the current hot path on post-#1875 `origin/main` (`c4addc6b`) with opened vector-search benchmarks and pprof.
- Add focused direct-view/fallback tests without changing writer layout or projection/materialization behavior.

## Start-phase performance plan with baseline branch/commit

Baseline branch/commit: `origin/main` at `c4addc6bfe0b4cc8604be679b482b0d77a6f2d3f` (post-#1875).

Benchmark command:

```sh
GOMAXPROCS=8 go test ./TreeDB/collections -run '^$' \
  -bench '^BenchmarkOpenVectorIndexSearcherColumnGraphNativeReader(V4|WithDocumentsV4|WithDocumentsExcludeEmbedding1875)$' \
  -benchmem -count=3 -benchtime=5s
```

Profile command:

```sh
GOMAXPROCS=8 go test ./TreeDB/collections -run '^$' \
  -bench '^BenchmarkOpenVectorIndexSearcherColumnGraphNativeReaderV4$' \
  -benchmem -count=1 -benchtime=5s \
  -cpuprofile <cpu.pprof> -memprofile <allocs.pprof>
```

## Close-phase test evidence

Candidate head: `56ba1acd497347cee7997a6d06f21693d034e842`.

Passed:

```sh
go test ./TreeDB/collections -run 'TestColumnVectorGraph(BlockView|NativeSearch|PhysicalRowReader|Adjacency)' -count=1
go test ./TreeDB/collections -run 'TestColumnVectorGraph(AdjacencyDirectViewProbe|BlockViewAdjacencyAligned)' -gcflags=all=-d=checkptr=2 -count=1
go test ./TreeDB/collections -run 'TestColumnVectorGraphNativeSearchWarmScratchZeroAllocsV3|TestColumnVectorGraphAdjacencyDirectViewProbeUnalignedFallsBackV1' -count=1
go test ./TreeDB/collections -run 'TestTypedStorageLegacyNameAllowlistIsComplete|TestColumnVectorGraph(BlockView|NativeSearch|PhysicalRowReader|Adjacency)' -count=1
go test ./TreeDB/collections -count=1
go test ./TreeDB/caching -run '^TestCheckpoint_KicksVlogGenerationRewriteDespiteRecentForegroundActivity$' -count=1 -v
go test ./TreeDB/caching -count=1
go test ./...
```

Note: an earlier broad `go test ./...` attempt hit a transient `TreeDB/caching` scheduler test miss; the exact test, the full `TreeDB/caching` package, and a later broad `go test ./...` all passed. Latest-head CI remains the mergeability gate.

## Close-phase benchmark evidence

Hardware/context: Apple M3 (`darwin/arm64`), `go1.25.5`, `GOMAXPROCS=8`. Values are medians of `-count=3 -benchtime=5s` unless noted. Benchmark artifacts:

- Baseline: `/tmp/issue1885_final_baseline_20260526_074935`
- Candidate: `/tmp/issue1885_candidate_latest_20260526_082047`

| Benchmark | Documents / projection | Commit | ns/op | ops/sec | B/op | allocs/op | adjacency direct views/search | adjacency scratch decodes/search | docs fetched/search | doc point row fetches/search | doc fetch ns/search | doc B/search | fields reconstructed/search | fields skipped/search |
| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| `BenchmarkOpenVectorIndexSearcherColumnGraphNativeReaderV4` | no docs | baseline `c4addc6b` | 29,752 | 33,611 | 9,688 | 214 | 51 | 53 | 0 | 0 | 0 | 0 | 0 | 0 |
| `BenchmarkOpenVectorIndexSearcherColumnGraphNativeReaderV4` | no docs | candidate `56ba1ac` | 12,519 | 79,879 | 784 | 2 | 51 | 53 | 0 | 0 | 0 | 0 | 0 | 0 |
| `BenchmarkOpenVectorIndexSearcherColumnGraphNativeReaderWithDocumentsV4` | full docs | baseline `c4addc6b` | 129,778 | 7,705 | 112,680 | 571 | 51 | 53 | 10 | 10 | 96,250 | 13,636 | 40 | 0 |
| `BenchmarkOpenVectorIndexSearcherColumnGraphNativeReaderWithDocumentsV4` | full docs | candidate `56ba1ac` | 108,819 | 9,190 | 103,773 | 359 | 51 | 53 | 10 | 10 | 96,083 | 13,636 | 40 | 0 |
| `BenchmarkOpenVectorIndexSearcherColumnGraphNativeReaderWithDocumentsExcludeEmbedding1875` | exclude embedding | baseline `c4addc6b` | 53,038 | 18,854 | 34,937 | 526 | 51 | 53 | 10 | 10 | 23,041 | 476 | 30 | 10 |
| `BenchmarkOpenVectorIndexSearcherColumnGraphNativeReaderWithDocumentsExcludeEmbedding1875` | exclude embedding | candidate `56ba1ac` | 38,645 | 25,877 | 26,032 | 314 | 51 | 53 | 10 | 10 | 26,042 | 476 | 30 | 10 |

Summary:

- No-doc opened search: 29,752 -> 12,519 ns/op (2.38x faster), 214 -> 2 allocs/op.
- Full-doc opened search: 129,778 -> 108,819 ns/op (1.19x faster), 571 -> 359 allocs/op.
- Exclude-embedding opened search: 53,038 -> 38,645 ns/op (1.37x faster), 526 -> 314 allocs/op.

## Profile summary

No-doc baseline pprof (`/tmp/issue1885_final_baseline_20260526_074935`):

- CPU: `mappedresource.ValidateDirectView` 31.44% cumulative; `typeddecode.Uint32ByteView` 39.05% cumulative; `fmt.Errorf` 26.03% cumulative; `columnVectorGraphLittleEndianUint32DirectView` 40.08% cumulative.
- alloc_space: `fmt.Errorf` 1,621.64 MB (60.59% flat); `mappedresource.ValidateDirectView` 1,900.15 MB cumulative (71.00%).

No-doc candidate pprof (`/tmp/issue1885_candidate_latest_20260526_082047`):

- CPU: `expandCandidateAdjacencyLayer` is 10.00% cumulative and `rawCandidateAdjacencyWithDirectView` is 9.43% cumulative.
- `fmt.Errorf`, `typeddecode.Uint32ByteView`, `mappedresource.ValidateDirectView`, and the old `columnVectorGraphLittleEndianUint32DirectView` error-probe stack are absent from the expected adjacency fallback path in both CPU and alloc-space tops.

## Setup/decode/search/doc-fetch timing boundary

The benchmark uses opened searchers and measures steady-state search. Graph search includes vector scoring and adjacency expansion. Document benchmarks additionally include topK=10 row-locator point fetch and document reconstruction/projection. Search counters (`candidate_fetches`, `expansion_fetches`, adjacency direct/scratch counts) remain unchanged; document fetch counters remain unchanged except total time/allocation from the graph-side probe removal.

## AI review status and unresolved thread summary

Codex: no major issues. Copilot: one non-blocking consistency suggestion to use `unsafe.SliceData` / `unsafe.Alignof(uint32(0))`; fixed in `56ba1ac`. CodeRabbit: no actionable comments; status passed/skipped. No unresolved internal reviewer findings.

## Parallel benchmark addendum

Latest-head parallel benchmark command:

```sh
GOMAXPROCS=8 go test ./TreeDB/collections -run '^$' \
  -bench '^BenchmarkColumnVectorGraphNativeSearchCosineParallel(V3|Production8192V3)$' \
  -benchmem -count=3 -benchtime=5s
```

Artifacts:

- Baseline post-#1875 `origin/main` (`c4addc6b`): `/tmp/issue1885_parallel_baseline_20260526_083641`
- Candidate `56ba1ac`: `/tmp/issue1885_parallel_candidate_20260526_083746`

| Benchmark | Rows | Workers | Commit | ns/op | ops/sec | B/op | allocs/op | adjacency direct views/search | adjacency scratch decodes/search | adjacency expansions/search | candidate fetches/search | edges/search |
| --- | ---: | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| `BenchmarkColumnVectorGraphNativeSearchCosineParallelV3` | 1,024 | 8 | baseline `c4addc6b` | 6,545 | 152,788 | 8,904 | 212 | 51 | 53 | 103 | 164 | 3,230 |
| `BenchmarkColumnVectorGraphNativeSearchCosineParallelV3` | 1,024 | 8 | candidate `56ba1ac` | 3,346 | 298,864 | 0 | 0 | 51 | 53 | 103 | 164 | 3,230 |
| `BenchmarkColumnVectorGraphNativeSearchCosineParallelProduction8192V3` | 8,192 | 8 | baseline `c4addc6b` | 4,663 | 214,454 | 6,720 | 160 | 0 | 40 | 39 | 128 | 612 |
| `BenchmarkColumnVectorGraphNativeSearchCosineParallelProduction8192V3` | 8,192 | 8 | candidate `56ba1ac` | 2,102 | 475,737 | 0 | 0 | 0 | 40 | 39 | 128 | 612 |
