### PR TITLE
Land certified typed-column direct-view readers

### DIFF
--- a/.orca/1896-manager-plan.md
+++ b/.orca/1896-manager-plan.md
@@ -1,0 +1,49 @@
+# #1896 manager plan — certified typed-column-part direct-view readers
+
+## Dependency and start-phase inventory
+
+- Base: `origin/main`/`snissn/1896-manager` at `37d3cb2b1e30a7c2ddb9bce59a05e323d2c69900` (#1895 merge).
+- Verified prerequisites:
+  - #1893 / PR #1902 merged (`29dd3cb3857baff8b7889c21b8be30957f9e9bc2`).
+  - #1737 / PR #1905 merged (`7dc8eb7c895ff198280660348ee9cd6ed0287241`).
+  - #1895 / PR #1907 merged (`37d3cb2b1e30a7c2ddb9bce59a05e323d2c69900`).
+- Issue/tracker read: #1896 and #1886 bodies/comments. Current scope is typed-column-part fixed-width scalar/vector readers only: raw int64, native raw float32, native raw double/float64, fixed-dim float32_vector. `adjacency_list` and physical row assets are deferred/fallback-only.
+
+## Reader path inventory (start phase)
+
+| Path | Files | Current state / #1896 action |
+| --- | --- | --- |
+| Shared direct-view validation | `TreeDB/internal/typeddecode/plan.go`, `TreeDB/internal/mappedresource/typed_view.go` | Existing int64/vector/adjacency validation vocabulary and handle checks; add native scalar float plans/views, source counters, stronger tests. |
+| Prepared int64 predicate aggregate/reducer | `TreeDB/collections/typed_column_prepared_int64.go`, `typed_column_int64_scan.go`, `typed_column_prepared_state.go` | Existing certified direct-view candidate over raw int64 blocks; add source/reason counters, fallback accounting, stale session tests, absolute-offset test coverage. |
+| Generic typed-column adapter materialization/reconstruction | `typed_column_adapter.go`, `typed_column_publication.go`, `document_materializer.go` | Uses typed-column-part decoded values and copies into document values. Keep semantics; add lower-level certified direct-view helper/tests where hot paths can consume section handles safely. |
+| Native scalar float reader fixtures | `typed_column_adapter.go`, `typed_column_float_fallback_test.go`, `typeddecode` tests | Writer emits native raw_float32/raw_float64 when `fixed_width_encoding=little_endian`; add certified reader plans/views and raw-bit tests. Raw-int64 logical float carriers remain fallback/compat only. |
+| Fixed-dim float32_vector typed-column source | `column_vector_graph_typed_column.go` | Already validates certification and handle before direct-viewing section; keep within #1896 safety helper scope, avoid #1898 graph search counter expansion. Add stale/absolute/fallback tests if needed. |
+| Adjacency/list | `typed_column_adapter.go`, `column_vector_graph_block_view.go`, conformance tests | Explicitly deferred to #1901. Ensure plan/refusal reason is stable and tests prove no accidental direct view. |
+| Bool/string/dictionary/nullable/default/compressed/delta | `typed_column_direct_view_contract.go`, `typed_column_semantics_test.go`, typeddecode/layout tests | Fallback-only; ensure counters/reasons and direct-view validation fail closed. |
+
+## Subtask chunks
+
+| ID | Scope | Files/packages | Dependencies | Tests/benchmarks/evidence | Executor thinking | Reviewer thinking |
+| --- | --- | --- | --- | --- | --- | --- |
+| A | Shared typeddecode native scalar float direct-view plans/views, source counters, reason mapping, raw-bit/validation tests. | `TreeDB/internal/typeddecode/*`, `TreeDB/internal/mappedresource/*` | #1737 native scalar LE encodings, #1895 certification fields | `go test ./TreeDB/internal/typeddecode ./TreeDB/internal/mappedresource`; checkptr if feasible | high (unsafe/lifetime) | xhigh (safety/lifetime) |
+| B | Collections reader integration/accounting for prepared int64 direct-view path and vector typed-column section helper; add source/reason counters without #1898 search expansion. | `TreeDB/collections/typed_column_prepared_int64.go`, `typed_column_int64_scan.go`, `column_vector_graph_typed_column.go` | A | Focused collections tests; new stale/absolute-offset/counter tests | high | xhigh |
+| C | Scalar float/vector/adjacency conformance tests: raw-bit float32/float64 direct views, missing/wrong/corrupt fallback/fail-closed, adjacency deferred. | `TreeDB/collections/typed_column_direct_view_conformance_test.go`, `typed_column_adapter_test.go`, `typed_column_float_fallback_test.go` | A, B | Focused test regex for direct-view/float/fallback | high | high |
+| D | Benchmarks/evidence and PR docs: before/after commands, counters table, no-scope-drift review. | benchmark tests under `TreeDB/collections`, PR body | A-C | `go test -bench ... -benchmem`; full `go test ./TreeDB/internal/typeddecode ./TreeDB/collections` if time | medium | xhigh |
+
+## Close-phase evidence
+
+- Implemented typeddecode native scalar float plans/views, stricter fixed-width certification validation, and raw-bit/stale/unaligned tests.
+- Implemented prepared int64 source/reason counters, mmap vs heap-copy typed-view accounting, scratch-decode accounting, production absolute-offset fallback and heap-copy typed-view tests.
+- Added certified scalar float resource readers and tests; retained adjacency as fallback-only/deferred and fixed typed-vector source close/stale-slice exposure.
+- Local validation:
+  - `go test ./TreeDB/internal/typeddecode ./TreeDB/internal/mappedresource ./TreeDB/collections`
+  - `go test -gcflags=all=-d=checkptr=2 ./TreeDB/internal/typeddecode ./TreeDB/internal/mappedresource ./TreeDB/collections -run 'Test.*DirectView|TestTypedColumnAdapterNativeFixedWidthScalarByteFixtures|TestColumnVectorGraphTypedColumnVectorCloseReleasesHandles1782|TestTypedColumnInt64PreparedHeapCopyTypedViewCounters|TestTypedColumnInt64PreparedAbsoluteOffsetUnalignedFallsBack'`
+  - `go test ./...`
+  - `TREEDB_TYPED_COLUMN_BENCH_LAYOUTS=raw TREEDB_TYPED_COLUMN_BENCH_ROWS=4096 TREEDB_TYPED_COLUMN_BENCH_SHAPES=selective_range_1pct TREEDB_TYPED_COLUMN_BENCH_DISTS=clustered_monotonic go test ./TreeDB/collections -run '^$' -bench '^BenchmarkTypedColumnInt64PredicateAggregate' -benchtime=100ms -count=1`
+
+## Scope guards
+
+- Do not change on-disk writer layouts beyond tiny test fixtures.
+- Do not implement row-asset or adjacency direct views; report adjacency as deferred/fallback (#1901), row assets as #1897 deferred.
+- Do not claim raw-int64 float carriers as native scalar float direct views.
+- Unsafe typed slices remain internal and tied to mappedresource handles/sessions; released handles/sessions must fail closed.

--- a/TreeDB/collections/column_vector_graph_typed_column.go
+++ b/TreeDB/collections/column_vector_graph_typed_column.go
@@ -28,6 +28,7 @@ type columnVectorGraphTypedColumnVectorSource struct {
 	heapCopyBytes       uint64
 	activeHandles       int64
 	deniedResources     uint64
+	closed              bool
 }
 
 type columnVectorGraphTypedColumnVectorLocation struct {
@@ -582,7 +583,7 @@ func (r *columnVectorGraphPhysicalRowReader) populateTypedColumnVectorSearchStat
 }
 
 func (s *columnVectorGraphTypedColumnVectorSource) vectorForOrdinal(ordinal int) ([]float32, bool, bool) {
-	if s == nil || ordinal < 0 || ordinal >= len(s.locations) || s.dims <= 0 {
+	if s == nil || s.closed || ordinal < 0 || ordinal >= len(s.locations) || s.dims <= 0 {
 		return nil, false, false
 	}
 	loc := s.locations[ordinal]
@@ -615,18 +616,28 @@ func (s *columnVectorGraphTypedColumnVectorSource) captureResourceStats() {
 }
 
 func (s *columnVectorGraphTypedColumnVectorSource) Close() error {
-	if s == nil {
+	if s == nil || s.closed {
 		return nil
 	}
+	s.closed = true
 	var closeErr error
 	for _, part := range s.parts {
-		if part == nil || part.handle == nil {
+		if part == nil {
 			continue
 		}
-		if err := part.handle.Release(); err != nil && closeErr == nil {
-			closeErr = err
+		if part.handle != nil {
+			if err := part.handle.Release(); err != nil && closeErr == nil {
+				closeErr = err
+			}
+			part.handle = nil
 		}
-		part.handle = nil
+		part.values = nil
+		part.direct = false
+		part.rows = 0
+	}
+	for i := range s.locations {
+		s.locations[i].part = nil
+		s.locations[i].rowIndex = 0
 	}
 	return closeErr
 }

--- a/TreeDB/collections/column_vector_graph_typed_column_test.go
+++ b/TreeDB/collections/column_vector_graph_typed_column_test.go
@@ -120,6 +120,9 @@ func TestColumnVectorGraphTypedColumnVectorCloseReleasesHandles1782(t *testing.T
 	if stats := source.manager.Stats(); stats.ActiveHandles != 0 || stats.ActiveMappedBytes != 0 || stats.ActiveHeapCopyBytes != 0 {
 		t.Fatalf("stats after close=%+v want released typed-column handles", stats)
 	}
+	if vector, direct, ok := source.vectorForOrdinal(0); ok || direct || vector != nil {
+		t.Fatalf("vectorForOrdinal after close vector=%v direct=%t ok=%t want no newly exposed stale slice", vector, direct, ok)
+	}
 }
 
 func TestColumnVectorGraphTypedColumnVectorPinKeyUsesTypedColumnAssetRef1782(t *testing.T) {

--- a/TreeDB/collections/typed_column_adapter.go
+++ b/TreeDB/collections/typed_column_adapter.go
@@ -1162,12 +1162,132 @@ func (r typedColumnAdapterResourceReader) ReadSection(section typedcolumn.Column
 	return bytes.Clone(h.Bytes()), nil
 }
 
+type typedColumnAdapterFloat32ScalarResourceView struct {
+	Rows   int
+	Values []float32
+	Handle *mappedresource.Handle
+	Direct bool
+}
+
+type typedColumnAdapterFloat64ScalarResourceView struct {
+	Rows   int
+	Values []float64
+	Handle *mappedresource.Handle
+	Direct bool
+}
+
 type typedColumnAdapterDenseUint32ResourceView struct {
 	Rows           int
 	ElementsPerRow int
 	Values         []uint32
 	Handle         *mappedresource.Handle
 	Direct         bool
+}
+
+func typedColumnAdapterAcquireFloat32ScalarColumnView(reader typedColumnAdapterResourceReader, column typedColumnAdapterColumn, rows int) (typedColumnAdapterFloat32ScalarResourceView, error) {
+	if column.Field.ValueType != ColumnStoreValueFloat32 || column.Definition.Type != typedcolumn.ColumnTypeFloat32 || column.Definition.Encoding != typedcolumn.EncodingRawFloat32 {
+		return typedColumnAdapterFloat32ScalarResourceView{}, fmt.Errorf("collections: typed-column adapter column %q is not native raw float32", column.Definition.Name)
+	}
+	if rows == 0 {
+		rows = reader.Image.Rows
+	}
+	section, found := typedColumnAdapterColumnDataSection(reader.Image, column.Definition.Name)
+	if !found {
+		return typedColumnAdapterFloat32ScalarResourceView{}, fmt.Errorf("collections: typed-column adapter image missing column data section %q", column.Definition.Name)
+	}
+	if section.Encoding != typedcolumn.EncodingRawFloat32 || section.Compression != typedcolumn.CompressionNone {
+		return typedColumnAdapterFloat32ScalarResourceView{}, fmt.Errorf("collections: typed-column adapter column %q section encoding/compression mismatch", column.Definition.Name)
+	}
+	certification, err := typedcolumn.CertifyColumnPartLayoutContractFromImage(reader.Image)
+	if err != nil {
+		return typedColumnAdapterFloat32ScalarResourceView{}, fmt.Errorf("collections: typed-column adapter column %q layout certification: %w", column.Definition.Name, err)
+	}
+	certColumn, ok := certification.Column(column.Definition.Name)
+	if !ok {
+		return typedColumnAdapterFloat32ScalarResourceView{}, fmt.Errorf("collections: typed-column adapter image missing layout certification for column %q", column.Definition.Name)
+	}
+	plan := typeddecode.Float32ScalarPlan(certColumn)
+	directReq := typeddecode.DirectViewColumnRequest{Plan: plan, Certification: certColumn, Rows: rows, PayloadBytes: section.Length, AssetOffset: 0, HasAssetOffset: true}
+	certStatus := typeddecode.ValidateDirectViewColumn(directReq)
+	h, err := reader.AcquireSection(section)
+	if err != nil {
+		return typedColumnAdapterFloat32ScalarResourceView{}, err
+	}
+	viewStatus := certStatus
+	if certStatus.Direct() {
+		values, status := typeddecode.Float32ScalarView(reader.Manager, h, directReq, typeddecode.ResourceViewOptions{ExpectedElements: rows, RequireMapped: true})
+		viewStatus = status
+		if viewStatus.Direct() {
+			return typedColumnAdapterFloat32ScalarResourceView{Rows: rows, Values: values, Handle: h, Direct: true}, nil
+		}
+	}
+	viewErr := fmt.Errorf("collections: typed-column adapter column %q float32 direct-view validation: %s", column.Definition.Name, viewStatus.String())
+	if !typedColumnDenseDecodeFallbackAllowed(viewStatus) {
+		_ = h.Release()
+		return typedColumnAdapterFloat32ScalarResourceView{}, viewErr
+	}
+	decoded, decodeErr := typedcolumn.DecodeRawFloat32Payload(nil, h.Bytes(), rows)
+	releaseErr := h.Release()
+	if decodeErr != nil {
+		return typedColumnAdapterFloat32ScalarResourceView{}, errors.Join(viewErr, decodeErr, releaseErr)
+	}
+	if releaseErr != nil {
+		return typedColumnAdapterFloat32ScalarResourceView{}, errors.Join(viewErr, releaseErr)
+	}
+	return typedColumnAdapterFloat32ScalarResourceView{Rows: rows, Values: decoded, Direct: false}, nil
+}
+
+func typedColumnAdapterAcquireFloat64ScalarColumnView(reader typedColumnAdapterResourceReader, column typedColumnAdapterColumn, rows int) (typedColumnAdapterFloat64ScalarResourceView, error) {
+	if column.Field.ValueType != ColumnStoreValueDouble || column.Definition.Type != typedcolumn.ColumnTypeFloat64 || column.Definition.Encoding != typedcolumn.EncodingRawFloat64 {
+		return typedColumnAdapterFloat64ScalarResourceView{}, fmt.Errorf("collections: typed-column adapter column %q is not native raw float64", column.Definition.Name)
+	}
+	if rows == 0 {
+		rows = reader.Image.Rows
+	}
+	section, found := typedColumnAdapterColumnDataSection(reader.Image, column.Definition.Name)
+	if !found {
+		return typedColumnAdapterFloat64ScalarResourceView{}, fmt.Errorf("collections: typed-column adapter image missing column data section %q", column.Definition.Name)
+	}
+	if section.Encoding != typedcolumn.EncodingRawFloat64 || section.Compression != typedcolumn.CompressionNone {
+		return typedColumnAdapterFloat64ScalarResourceView{}, fmt.Errorf("collections: typed-column adapter column %q section encoding/compression mismatch", column.Definition.Name)
+	}
+	certification, err := typedcolumn.CertifyColumnPartLayoutContractFromImage(reader.Image)
+	if err != nil {
+		return typedColumnAdapterFloat64ScalarResourceView{}, fmt.Errorf("collections: typed-column adapter column %q layout certification: %w", column.Definition.Name, err)
+	}
+	certColumn, ok := certification.Column(column.Definition.Name)
+	if !ok {
+		return typedColumnAdapterFloat64ScalarResourceView{}, fmt.Errorf("collections: typed-column adapter image missing layout certification for column %q", column.Definition.Name)
+	}
+	plan := typeddecode.Float64ScalarPlan(certColumn)
+	directReq := typeddecode.DirectViewColumnRequest{Plan: plan, Certification: certColumn, Rows: rows, PayloadBytes: section.Length, AssetOffset: 0, HasAssetOffset: true}
+	certStatus := typeddecode.ValidateDirectViewColumn(directReq)
+	h, err := reader.AcquireSection(section)
+	if err != nil {
+		return typedColumnAdapterFloat64ScalarResourceView{}, err
+	}
+	viewStatus := certStatus
+	if certStatus.Direct() {
+		values, status := typeddecode.Float64ScalarView(reader.Manager, h, directReq, typeddecode.ResourceViewOptions{ExpectedElements: rows, RequireMapped: true})
+		viewStatus = status
+		if viewStatus.Direct() {
+			return typedColumnAdapterFloat64ScalarResourceView{Rows: rows, Values: values, Handle: h, Direct: true}, nil
+		}
+	}
+	viewErr := fmt.Errorf("collections: typed-column adapter column %q float64 direct-view validation: %s", column.Definition.Name, viewStatus.String())
+	if !typedColumnDenseDecodeFallbackAllowed(viewStatus) {
+		_ = h.Release()
+		return typedColumnAdapterFloat64ScalarResourceView{}, viewErr
+	}
+	decoded, decodeErr := typedcolumn.DecodeRawFloat64Payload(nil, h.Bytes(), rows)
+	releaseErr := h.Release()
+	if decodeErr != nil {
+		return typedColumnAdapterFloat64ScalarResourceView{}, errors.Join(viewErr, decodeErr, releaseErr)
+	}
+	if releaseErr != nil {
+		return typedColumnAdapterFloat64ScalarResourceView{}, errors.Join(viewErr, releaseErr)
+	}
+	return typedColumnAdapterFloat64ScalarResourceView{Rows: rows, Values: decoded, Direct: false}, nil
 }
 
 func typedColumnAdapterAcquireDenseUint32ColumnView(reader typedColumnAdapterResourceReader, column typedColumnAdapterColumn, rows int) (typedColumnAdapterDenseUint32ResourceView, error) {
@@ -1943,6 +2063,7 @@ func scanTypedColumnInt64PredicatePartWithVisibility(part *typedcolumn.ColumnPar
 		}
 		decodedAny = true
 		result.Diagnostics.BlocksDecoded++
+		result.Diagnostics.FastDecodeScratchDecodes++
 		result.Diagnostics.DecodedHeapCopyBytes += uint64(g.RawBytes + idBlock.Granule.RawBytes)
 		result.Diagnostics.RowsScanned += len(values)
 		for i, v := range values {
@@ -2026,6 +2147,7 @@ func scanTypedColumnInt64PredicateAggregatePartWithVisibilityAndScratch(part *ty
 		}
 		decodedAny = true
 		result.Diagnostics.BlocksDecoded++
+		result.Diagnostics.FastDecodeScratchDecodes++
 		result.Diagnostics.DecodedHeapCopyBytes += uint64(g.RawBytes)
 		result.Diagnostics.RowsScanned += len(values)
 

--- a/TreeDB/collections/typed_column_adapter_test.go
+++ b/TreeDB/collections/typed_column_adapter_test.go
@@ -220,6 +220,39 @@ func TestTypedColumnAdapterNativeFixedWidthScalarByteFixtures(t *testing.T) {
 		t.Fatalf("certify float32 image: %v", err)
 	}
 	assertTypedColumnAdapterNativeScalarDirectViewContract(t, f32Cert, f32Section, "score", "float32", typedcolumn.ColumnTypeFloat32, typedcolumn.EncodingRawFloat32, 4, 4, len(wantF32))
+	f32Path := filepath.Join(t.TempDir(), "f32.tcs1")
+	if err := os.WriteFile(f32Path, f32Image.Bytes, 0o600); err != nil {
+		t.Fatalf("write float32 image: %v", err)
+	}
+	f32Mgr := mappedresource.NewManager()
+	f32Reader := typedColumnAdapterResourceReader{Manager: f32Mgr, Image: f32Image, Path: f32Path, Namespace: "typed-column-adapter-f32", PartID: f32Image.PartID, PreferMapped: true, AllowHeapCopy: true}
+	f32Column, ok := f32Part.columnByName("score")
+	if !ok {
+		t.Fatalf("missing float32 adapter column")
+	}
+	f32View, err := typedColumnAdapterAcquireFloat32ScalarColumnView(f32Reader, f32Column, f32Image.Rows)
+	if err != nil {
+		t.Fatalf("AcquireFloat32ScalarColumnView: %v", err)
+	}
+	if len(f32View.Values) != 2 {
+		t.Fatalf("float32 view len=%d want 2", len(f32View.Values))
+	}
+	for i, want := range []uint32{0x7fc12345, 0x80000000} {
+		if got := math.Float32bits(f32View.Values[i]); got != want {
+			t.Fatalf("float32 direct view bits[%d]=0x%08x want 0x%08x", i, got, want)
+		}
+	}
+	if typedColumnInt64DirectViewSupportedForTest() {
+		if !f32View.Direct || f32View.Handle == nil {
+			t.Fatalf("float32 view=%+v want mapped direct view", f32View)
+		}
+		if err := f32View.Handle.Release(); err != nil {
+			t.Fatalf("release float32 view: %v", err)
+		}
+	} else if f32View.Direct {
+		t.Fatalf("float32 view direct on unsupported platform: %+v", f32View)
+	}
+	assertTypedColumnAdapterNoActive(t, f32Mgr)
 
 	f64Field := typedColumnAdapterField("ratio", ColumnStoreValueDouble)
 	f64Field.FixedWidthEncoding = ColumnFixedWidthEncodingLittleEndian
@@ -242,6 +275,39 @@ func TestTypedColumnAdapterNativeFixedWidthScalarByteFixtures(t *testing.T) {
 		t.Fatalf("certify double image: %v", err)
 	}
 	assertTypedColumnAdapterNativeScalarDirectViewContract(t, f64Cert, f64Section, "ratio", "double", typedcolumn.ColumnTypeFloat64, typedcolumn.EncodingRawFloat64, 8, 8, len(wantF64))
+	f64Path := filepath.Join(t.TempDir(), "f64.tcs1")
+	if err := os.WriteFile(f64Path, f64Image.Bytes, 0o600); err != nil {
+		t.Fatalf("write float64 image: %v", err)
+	}
+	f64Mgr := mappedresource.NewManager()
+	f64Reader := typedColumnAdapterResourceReader{Manager: f64Mgr, Image: f64Image, Path: f64Path, Namespace: "typed-column-adapter-f64", PartID: f64Image.PartID, PreferMapped: true, AllowHeapCopy: true}
+	f64Column, ok := f64Part.columnByName("ratio")
+	if !ok {
+		t.Fatalf("missing float64 adapter column")
+	}
+	f64View, err := typedColumnAdapterAcquireFloat64ScalarColumnView(f64Reader, f64Column, f64Image.Rows)
+	if err != nil {
+		t.Fatalf("AcquireFloat64ScalarColumnView: %v", err)
+	}
+	if len(f64View.Values) != 2 {
+		t.Fatalf("float64 view len=%d want 2", len(f64View.Values))
+	}
+	for i, want := range []uint64{0x7ff8000000000042, 0x8000000000000000} {
+		if got := math.Float64bits(f64View.Values[i]); got != want {
+			t.Fatalf("float64 direct view bits[%d]=0x%016x want 0x%016x", i, got, want)
+		}
+	}
+	if typedColumnInt64DirectViewSupportedForTest() {
+		if !f64View.Direct || f64View.Handle == nil {
+			t.Fatalf("float64 view=%+v want mapped direct view", f64View)
+		}
+		if err := f64View.Handle.Release(); err != nil {
+			t.Fatalf("release float64 view: %v", err)
+		}
+	} else if f64View.Direct {
+		t.Fatalf("float64 view direct on unsupported platform: %+v", f64View)
+	}
+	assertTypedColumnAdapterNoActive(t, f64Mgr)
 }
 
 func assertTypedColumnAdapterNativeScalarDirectViewContract(t *testing.T, cert typedcolumn.ColumnPartLayoutCertification, section typedcolumn.ColumnPartImageSection, name string, logicalType string, columnType typedcolumn.ColumnType, encoding typedcolumn.Encoding, elementSize int, alignment int, payloadLength int) {
@@ -1114,6 +1180,17 @@ func TestTypedColumnAdapterAdjacencyDenseFallbackOnly(t *testing.T) {
 		t.Fatalf("write image: %v", err)
 	}
 	mgr := mappedresource.NewManager()
+	certification, err := typedcolumn.CertifyColumnPartLayoutContractFromImage(image)
+	if err != nil {
+		t.Fatalf("CertifyColumnPartLayoutContractFromImage: %v", err)
+	}
+	certColumn, ok := certification.Column("neighbors")
+	if !ok {
+		t.Fatal("missing adjacency layout certification")
+	}
+	if plan := typeddecode.AdjacencyListPlan(certColumn, field.AdjacencyDegree); plan.DirectCandidate() {
+		t.Fatalf("adjacency direct-view plan=%+v want fallback-only", plan)
+	}
 	reader := typedColumnAdapterResourceReader{Manager: mgr, Image: image, Path: path, Namespace: "typed-column-adapter-adjacency", PartID: image.PartID, PreferMapped: true, AllowHeapCopy: true}
 	view, err := typedColumnAdapterAcquireDenseUint32ColumnView(reader, column, image.Rows)
 	if err != nil {

--- a/TreeDB/collections/typed_column_direct_view_conformance_test.go
+++ b/TreeDB/collections/typed_column_direct_view_conformance_test.go
@@ -424,6 +424,83 @@ func TestTypedColumnDirectViewFailClosedFixtures(t *testing.T) {
 	}
 }
 
+func TestTypedColumnScalarFloatDirectViewReaderValidation1896(t *testing.T) {
+	cases := []struct {
+		name      string
+		cert      typedcolumn.ColumnPartLayoutContractColumn
+		plan      func(typedcolumn.ColumnPartLayoutContractColumn) typeddecode.Plan
+		elemBytes int
+	}{
+		{name: "float32", cert: directViewConformanceScalarCert("score32", "float32", typedcolumn.ColumnTypeFloat32, typedcolumn.EncodingRawFloat32, 3, 4), plan: typeddecode.Float32ScalarPlan, elemBytes: 4},
+		{name: "double", cert: directViewConformanceScalarCert("score64", "double", typedcolumn.ColumnTypeFloat64, typedcolumn.EncodingRawFloat64, 3, 8), plan: typeddecode.Float64ScalarPlan, elemBytes: 8},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			plan := tc.plan(tc.cert)
+			valid := typeddecode.DirectViewColumnRequest{Plan: plan, Certification: tc.cert, Rows: 3, PayloadBytes: 3 * tc.elemBytes, AssetOffset: 0, HasAssetOffset: true}
+			if status := typeddecode.ValidateDirectViewColumn(valid); !status.Direct() {
+				t.Fatalf("valid %s status=%+v want direct", tc.name, status)
+			}
+			checks := []struct {
+				name string
+				edit func(*typedcolumn.ColumnPartLayoutContractColumn, *typeddecode.DirectViewColumnRequest)
+				want typeddecode.Reason
+			}{
+				{name: "wrong endian", edit: func(c *typedcolumn.ColumnPartLayoutContractColumn, _ *typeddecode.DirectViewColumnRequest) {
+					c.Endian = typedcolumn.ColumnPartLayoutEndianCodecDefined
+				}, want: typeddecode.ReasonWrongEndian},
+				{name: "wrong length", edit: func(c *typedcolumn.ColumnPartLayoutContractColumn, r *typeddecode.DirectViewColumnRequest) {
+					c.Section.Length--
+					c.Blocks[0].PayloadLength--
+					c.Blocks[0].RawBytes--
+					c.Blocks[0].StoredBytes--
+					r.PayloadBytes--
+				}, want: typeddecode.ReasonLengthMultipleMismatch},
+				{name: "wrong row count", edit: func(_ *typedcolumn.ColumnPartLayoutContractColumn, r *typeddecode.DirectViewColumnRequest) {
+					r.Rows = 2
+				}, want: typeddecode.ReasonRowCountMismatch},
+				{name: "absolute offset unaligned", edit: func(_ *typedcolumn.ColumnPartLayoutContractColumn, r *typeddecode.DirectViewColumnRequest) {
+					r.AssetOffset = 1
+				}, want: typeddecode.ReasonAbsoluteOffsetUnaligned},
+				{name: "missing absolute offset", edit: func(_ *typedcolumn.ColumnPartLayoutContractColumn, r *typeddecode.DirectViewColumnRequest) {
+					r.HasAssetOffset = false
+				}, want: typeddecode.ReasonAbsoluteOffsetUnaligned},
+				{name: "nullable", edit: func(c *typedcolumn.ColumnPartLayoutContractColumn, _ *typeddecode.DirectViewColumnRequest) {
+					c.NullMaskPresent = true
+					c.NullCount = 1
+				}, want: typeddecode.ReasonNullableWrapper},
+				{name: "default", edit: func(c *typedcolumn.ColumnPartLayoutContractColumn, _ *typeddecode.DirectViewColumnRequest) {
+					c.DefaultMaskPresent = true
+					c.DefaultCount = 1
+				}, want: typeddecode.ReasonNullableWrapper},
+				{name: "compressed", edit: func(c *typedcolumn.ColumnPartLayoutContractColumn, _ *typeddecode.DirectViewColumnRequest) {
+					c.Compression = typedcolumn.CompressionSnappy
+				}, want: typeddecode.ReasonCompressed},
+				{name: "not certified", edit: func(c *typedcolumn.ColumnPartLayoutContractColumn, _ *typeddecode.DirectViewColumnRequest) {
+					c.DirectViewCertified = false
+				}, want: typeddecode.ReasonNotWriterCertified},
+			}
+			for _, check := range checks {
+				t.Run(check.name, func(t *testing.T) {
+					cert := cloneConformanceCert(tc.cert)
+					req := valid
+					req.Certification = cert
+					check.edit(&cert, &req)
+					req.Certification = cert
+					req.Plan = tc.plan(cert)
+					if status := typeddecode.ValidateDirectViewColumn(req); status.Reason != check.want {
+						t.Fatalf("status=%+v want %s", status, check.want)
+					}
+				})
+			}
+		})
+	}
+	rawInt64FloatCarrier := typedcolumn.ColumnPartLayoutContractColumn{Name: "score", LogicalType: "float32", Type: typedcolumn.ColumnTypeInt64, Encoding: typedcolumn.EncodingRawInt64, Compression: typedcolumn.CompressionNone, Rows: 1, Section: typedcolumn.ColumnPartLayoutContractSection{Length: 8}, ElementSize: 8, Alignment: 8, Endian: typedcolumn.ColumnPartLayoutEndianLittle, LengthMultiple: 8, DirectViewCertified: true, Blocks: []typedcolumn.ColumnPartLayoutContractBlock{{RowCount: 1, Encoding: typedcolumn.EncodingRawInt64, Compression: typedcolumn.CompressionNone, RawBytes: 8, StoredBytes: 8, PayloadLength: 8}}}
+	if plan := typeddecode.Float32ScalarPlan(rawInt64FloatCarrier); plan.DirectCandidate() {
+		t.Fatalf("raw-int64 logical float carrier plan=%+v want fallback/non-direct", plan)
+	}
+}
+
 func TestTypedColumnDirectViewActualPointerStaleAndChecksumFailures(t *testing.T) {
 	cert := directViewConformanceVectorCert(2, 3)
 	plan := typeddecode.DenseFloat32VectorPlan(cert, 3)
@@ -501,6 +578,15 @@ func currentColumnStoreValueTypesFromSource(t *testing.T) []ColumnStoreValueType
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
 	return out
+}
+
+func directViewConformanceScalarCert(name string, logical string, columnType typedcolumn.ColumnType, encoding typedcolumn.Encoding, rows int, elemBytes int) typedcolumn.ColumnPartLayoutContractColumn {
+	bytes := rows * elemBytes
+	return typedcolumn.ColumnPartLayoutContractColumn{
+		Name: name, LogicalType: logical, Type: columnType, Encoding: encoding, Compression: typedcolumn.CompressionNone,
+		Rows: rows, Section: typedcolumn.ColumnPartLayoutContractSection{Offset: 8, Length: bytes}, ElementSize: elemBytes, Alignment: elemBytes, Endian: typedcolumn.ColumnPartLayoutEndianLittle, LengthMultiple: elemBytes, DirectViewCertified: true,
+		Blocks: []typedcolumn.ColumnPartLayoutContractBlock{{FirstRow: 0, RowCount: rows, Encoding: encoding, Compression: typedcolumn.CompressionNone, RawBytes: bytes, StoredBytes: bytes, PayloadOffset: 8, PayloadLength: bytes}},
+	}
 }
 
 func directViewConformanceVectorCert(rows, dims int) typedcolumn.ColumnPartLayoutContractColumn {

--- a/TreeDB/collections/typed_column_int64_scan.go
+++ b/TreeDB/collections/typed_column_int64_scan.go
@@ -88,6 +88,14 @@ type TypedColumnInt64PredicateScanDiagnostics struct {
 	FastDecodeStreamingPlans       int
 	FastDecodeMaterializePlans     int
 	FastDecodeUnsupportedPlans     int
+	FastDecodeMmapDirectViews      int
+	FastDecodeHeapCopyTypedViews   int
+	FastDecodeScratchDecodes       int
+	FastDecodeStreamingFallbacks   int
+	FastDecodeCertificationFailure int
+	FastDecodeAbsoluteUnaligned    int
+	FastDecodeActualUnaligned      int
+	FastDecodeStaleHandles         int
 	DirectViewSuccesses            int
 	DirectViewFailures             int
 	KernelBlocks                   int
@@ -971,6 +979,14 @@ func addTypedColumnInt64PredicateAggregateDiagnostics(dst *TypedColumnInt64Predi
 	dst.FastDecodeStreamingPlans += src.FastDecodeStreamingPlans
 	dst.FastDecodeMaterializePlans += src.FastDecodeMaterializePlans
 	dst.FastDecodeUnsupportedPlans += src.FastDecodeUnsupportedPlans
+	dst.FastDecodeMmapDirectViews += src.FastDecodeMmapDirectViews
+	dst.FastDecodeHeapCopyTypedViews += src.FastDecodeHeapCopyTypedViews
+	dst.FastDecodeScratchDecodes += src.FastDecodeScratchDecodes
+	dst.FastDecodeStreamingFallbacks += src.FastDecodeStreamingFallbacks
+	dst.FastDecodeCertificationFailure += src.FastDecodeCertificationFailure
+	dst.FastDecodeAbsoluteUnaligned += src.FastDecodeAbsoluteUnaligned
+	dst.FastDecodeActualUnaligned += src.FastDecodeActualUnaligned
+	dst.FastDecodeStaleHandles += src.FastDecodeStaleHandles
 	dst.DirectViewSuccesses += src.DirectViewSuccesses
 	dst.DirectViewFailures += src.DirectViewFailures
 	dst.KernelBlocks += src.KernelBlocks

--- a/TreeDB/collections/typed_column_int64_scan_test.go
+++ b/TreeDB/collections/typed_column_int64_scan_test.go
@@ -1004,8 +1004,8 @@ func TestTypedColumnInt64PreparedDeltaUsesStreamingCursor(t *testing.T) {
 		t.Fatalf("Run: %v", err)
 	}
 	assertTypedColumnInt64Aggregate(t, result, 4, 34)
-	if result.Diagnostics.FastDecodeStreamingPlans == 0 || result.Diagnostics.FastDecodeDirectViewPlans != 0 || result.Diagnostics.DirectViewSuccesses != 0 || result.Diagnostics.DecodedHeapCopyBytes != 0 {
-		t.Fatalf("diagnostics=%+v want delta-varint streaming cursor without direct view or []int64 materialization", result.Diagnostics)
+	if result.Diagnostics.FastDecodeStreamingPlans == 0 || result.Diagnostics.FastDecodeDirectViewPlans != 0 || result.Diagnostics.DirectViewSuccesses != 0 || result.Diagnostics.FastDecodeStreamingFallbacks != 0 || result.Diagnostics.DecodedHeapCopyBytes != 0 {
+		t.Fatalf("diagnostics=%+v want planned delta-varint streaming cursor without direct view/fallback or []int64 materialization", result.Diagnostics)
 	}
 }
 

--- a/TreeDB/collections/typed_column_int64_scan_test.go
+++ b/TreeDB/collections/typed_column_int64_scan_test.go
@@ -698,11 +698,15 @@ func TestTypedColumnInt64RawLayoutRoundTripReopenQuery(t *testing.T) {
 		t.Fatalf("prepared raw diagnostics=%+v want fast raw reducer without decoded heap copy", prepared.Diagnostics)
 	}
 	if typedColumnInt64DirectViewSupportedForTest() {
-		if prepared.Diagnostics.DirectViewSuccesses == 0 || prepared.Diagnostics.HeapCopyBytes != 0 {
-			t.Fatalf("prepared raw diagnostics=%+v want mmap direct-view reducer", prepared.Diagnostics)
+		if prepared.Diagnostics.DirectViewSuccesses == 0 || prepared.Diagnostics.FastDecodeMmapDirectViews == 0 || prepared.Diagnostics.FastDecodeHeapCopyTypedViews != 0 || prepared.Diagnostics.FastDecodeStreamingFallbacks != 0 || prepared.Diagnostics.HeapCopyBytes != 0 {
+			t.Fatalf("prepared raw diagnostics=%+v want mmap direct-view reducer with source counters", prepared.Diagnostics)
 		}
-	} else if prepared.Diagnostics.DirectViewFailures == 0 || prepared.Diagnostics.FastDecodeFallbackReason != string(typeddecode.ReasonHandleSourceUnsupported) {
-		t.Fatalf("prepared raw diagnostics=%+v want platform heap fallback without materialization", prepared.Diagnostics)
+	} else if prepared.Diagnostics.FastDecodeHeapCopyTypedViews > 0 {
+		if prepared.Diagnostics.DirectViewSuccesses == 0 || prepared.Diagnostics.FastDecodeScratchDecodes != 0 || prepared.Diagnostics.FastDecodeFallbackReason != string(typeddecode.ReasonHandleSourceUnsupported) {
+			t.Fatalf("prepared raw diagnostics=%+v want platform heap typed-view fallback without scratch decode", prepared.Diagnostics)
+		}
+	} else if prepared.Diagnostics.DirectViewFailures == 0 || prepared.Diagnostics.FastDecodeStreamingFallbacks == 0 || prepared.Diagnostics.FastDecodeFallbackReason != string(typeddecode.ReasonHandleSourceUnsupported) {
+		t.Fatalf("prepared raw diagnostics=%+v want platform streaming fallback without materialization", prepared.Diagnostics)
 	}
 	if session.prepareDiagnostics.DirectViewCertified == 0 || session.prepareDiagnostics.CertificationFailures != 0 {
 		t.Fatalf("prepare diagnostics=%+v want certified direct-view layout with no failures", session.prepareDiagnostics)
@@ -756,11 +760,15 @@ func TestTypedColumnInt64PreparedCertificationDiagnosticsAndClose(t *testing.T) 
 		t.Fatalf("hot diagnostics first=%+v second=%+v want no per-run metadata or heap decode", first.Diagnostics, second.Diagnostics)
 	}
 	if typedColumnInt64DirectViewSupportedForTest() {
-		if first.Diagnostics.DirectViewSuccesses == 0 || second.Diagnostics.DirectViewSuccesses == 0 || first.Diagnostics.HeapCopyBytes != 0 || second.Diagnostics.HeapCopyBytes != 0 {
-			t.Fatalf("hot diagnostics first=%+v second=%+v want mmap direct-view runs", first.Diagnostics, second.Diagnostics)
+		if first.Diagnostics.DirectViewSuccesses == 0 || second.Diagnostics.DirectViewSuccesses == 0 || first.Diagnostics.FastDecodeMmapDirectViews == 0 || second.Diagnostics.FastDecodeMmapDirectViews == 0 || first.Diagnostics.FastDecodeStreamingFallbacks != 0 || second.Diagnostics.FastDecodeStreamingFallbacks != 0 || first.Diagnostics.HeapCopyBytes != 0 || second.Diagnostics.HeapCopyBytes != 0 {
+			t.Fatalf("hot diagnostics first=%+v second=%+v want mmap direct-view runs with source counters", first.Diagnostics, second.Diagnostics)
 		}
-	} else if first.Diagnostics.DirectViewFailures == 0 || second.Diagnostics.DirectViewFailures == 0 || first.Diagnostics.FastDecodeFallbackReason != string(typeddecode.ReasonHandleSourceUnsupported) || second.Diagnostics.FastDecodeFallbackReason != string(typeddecode.ReasonHandleSourceUnsupported) {
-		t.Fatalf("hot diagnostics first=%+v second=%+v want platform heap fallback without materialization", first.Diagnostics, second.Diagnostics)
+	} else if first.Diagnostics.FastDecodeHeapCopyTypedViews > 0 || second.Diagnostics.FastDecodeHeapCopyTypedViews > 0 {
+		if first.Diagnostics.DirectViewSuccesses == 0 || second.Diagnostics.DirectViewSuccesses == 0 || first.Diagnostics.FastDecodeScratchDecodes != 0 || second.Diagnostics.FastDecodeScratchDecodes != 0 || first.Diagnostics.FastDecodeFallbackReason != string(typeddecode.ReasonHandleSourceUnsupported) || second.Diagnostics.FastDecodeFallbackReason != string(typeddecode.ReasonHandleSourceUnsupported) {
+			t.Fatalf("hot diagnostics first=%+v second=%+v want platform heap typed-view fallback without scratch decode", first.Diagnostics, second.Diagnostics)
+		}
+	} else if first.Diagnostics.DirectViewFailures == 0 || second.Diagnostics.DirectViewFailures == 0 || first.Diagnostics.FastDecodeStreamingFallbacks == 0 || second.Diagnostics.FastDecodeStreamingFallbacks == 0 || first.Diagnostics.FastDecodeFallbackReason != string(typeddecode.ReasonHandleSourceUnsupported) || second.Diagnostics.FastDecodeFallbackReason != string(typeddecode.ReasonHandleSourceUnsupported) {
+		t.Fatalf("hot diagnostics first=%+v second=%+v want platform streaming fallback without materialization", first.Diagnostics, second.Diagnostics)
 	}
 	if err := session.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
@@ -768,6 +776,114 @@ func TestTypedColumnInt64PreparedCertificationDiagnosticsAndClose(t *testing.T) 
 	if diag := session.Diagnostics(); !diag.Closed || diag.ActiveResourceHandles != 0 || diag.ActiveMappedBytes != 0 || diag.ActiveHeapCopyBytes != 0 {
 		t.Fatalf("session diagnostics after close=%+v want resources released", diag)
 	}
+}
+
+func TestTypedColumnInt64PreparedHeapCopyTypedViewCounters(t *testing.T) {
+	d, col := setupTypedColumnInt64RawScanCollection(t)
+	defer func() { _ = d.Close() }()
+	insertTypedColumnInt64ScanRows(t, col, []int64{1, 2, 3})
+	session, err := col.PrepareTypedColumnInt64PredicateAggregate(TypedColumnInt64PredicateAggregateRequest{Column: "time_us", Kind: TypedColumnInt64PredicateEqual, Value: 2, ColumnAssetReadIntegrity: ColumnAssetReadIntegrityCachedVerify})
+	if err != nil {
+		t.Fatalf("PrepareTypedColumnInt64PredicateAggregate: %v", err)
+	}
+	defer func() { _ = session.Close() }()
+	if err := session.readCache.close(); err != nil {
+		t.Fatalf("close prepared read cache before forced heap run: %v", err)
+	}
+	session.readCache.forceReadAtFallback = true
+	result, err := session.Run()
+	if err != nil {
+		t.Fatalf("Run forced heap-copy typed view: %v", err)
+	}
+	assertTypedColumnInt64Aggregate(t, result, 1, 2)
+	if result.Diagnostics.FastDecodeHeapCopyTypedViews == 0 || result.Diagnostics.FastDecodeMmapDirectViews != 0 || result.Diagnostics.FastDecodeScratchDecodes != 0 || result.Diagnostics.FastDecodeStreamingFallbacks != 0 || result.Diagnostics.HeapCopyBytes == 0 {
+		t.Fatalf("diagnostics=%+v want heap-copy typed view without mmap or scratch decode fallback", result.Diagnostics)
+	}
+}
+
+func TestTypedColumnInt64PreparedAbsoluteOffsetUnalignedFallsBack(t *testing.T) {
+	d, col := setupTypedColumnInt64RawScanCollection(t)
+	defer func() { _ = d.Close() }()
+	insertTypedColumnInt64ScanRows(t, col, []int64{1, 2, 3})
+	insertTypedColumnInt64ScanRows(t, col, []int64{4, 5, 6})
+
+	view, closeView, err := col.prepareColumnPhysicalScanSnapshotViewWithSidecars(columnManifestScanNoSidecars())
+	if err != nil {
+		if closeView != nil {
+			closeView()
+		}
+		t.Fatalf("prepareColumnPhysicalScanSnapshotViewWithSidecars: %v", err)
+	}
+	if len(view.TypedColumnPartRefs) < 2 {
+		if closeView != nil {
+			closeView()
+		}
+		t.Fatalf("typed refs=%+v want multi-asset typed-column parts", view.TypedColumnPartRefs)
+	}
+	unalignedRef := appendUnalignedTypedColumnAssetCopyForTest(t, d.ColumnAssetRootDir(), view.TypedColumnPartRefs[0].Ref)
+	for i := range view.TypedColumnPartRefs {
+		if view.TypedColumnPartRefs[i].Ref.Generation == unalignedRef.Generation {
+			view.TypedColumnPartRefs[i].Ref = unalignedRef
+		}
+	}
+
+	req := TypedColumnInt64PredicateAggregateRequest{Column: "time_us", Kind: TypedColumnInt64PredicateEqual, Value: 2, ColumnAssetReadIntegrity: ColumnAssetReadIntegrityCachedVerify}
+	session, _, err := col.prepareTypedColumnInt64PredicateAggregateSessionFromView(view, closeView, req)
+	if err != nil {
+		if closeView != nil {
+			closeView()
+		}
+		t.Fatalf("prepareTypedColumnInt64PredicateAggregateSessionFromView: %v", err)
+	}
+	defer func() { _ = session.Close() }()
+	result, err := session.Run()
+	if err != nil {
+		t.Fatalf("Run with unaligned absolute offset: %v", err)
+	}
+	assertTypedColumnInt64Aggregate(t, result, 1, 2)
+	if result.Diagnostics.FastDecodeAbsoluteUnaligned == 0 || result.Diagnostics.DirectViewFailures == 0 || result.Diagnostics.FastDecodeScratchDecodes == 0 || result.Diagnostics.FastDecodeStreamingFallbacks == 0 || result.Diagnostics.FastDecodeFallbackReason != string(typeddecode.ReasonAbsoluteOffsetUnaligned) {
+		t.Fatalf("diagnostics=%+v want absolute-offset unaligned direct-view fallback counters", result.Diagnostics)
+	}
+}
+
+func appendUnalignedTypedColumnAssetCopyForTest(t *testing.T, rootDir string, ref ColumnAssetRef) ColumnAssetRef {
+	t.Helper()
+	raw, err := readColumnPhysicalAssetFromManager(rootDir, ref)
+	if err != nil {
+		t.Fatalf("readColumnPhysicalAssetFromManager: %v", err)
+	}
+	path, err := columnAssetSegmentPath(rootDir, ref)
+	if err != nil {
+		t.Fatalf("columnAssetSegmentPath: %v", err)
+	}
+	file, err := os.OpenFile(path, os.O_RDWR|os.O_APPEND, 0o600)
+	if err != nil {
+		t.Fatalf("open segment append: %v", err)
+	}
+	defer func() { _ = file.Close() }()
+	offset, err := file.Seek(0, 2)
+	if err != nil {
+		t.Fatalf("seek segment end: %v", err)
+	}
+	if offset%8 == 0 {
+		if _, err := file.Write([]byte{0}); err != nil {
+			t.Fatalf("write unalignment padding: %v", err)
+		}
+		offset++
+	}
+	if offset%8 == 0 {
+		t.Fatalf("failed to choose unaligned offset=%d", offset)
+	}
+	if _, err := file.Write(raw); err != nil {
+		t.Fatalf("write duplicate typed-column asset: %v", err)
+	}
+	if err := file.Sync(); err != nil {
+		t.Fatalf("sync duplicate typed-column asset: %v", err)
+	}
+	dup := ref
+	dup.Offset = offset
+	dup.Length = int64(len(raw))
+	return dup
 }
 
 func TestTypedColumnInt64PreparedStatsRoundTripReopen(t *testing.T) {
@@ -3156,6 +3272,14 @@ func reportTypedColumnInt64AggregateBenchMetrics(b *testing.B, totalRows int, di
 	b.ReportMetric(float64(diag.FastDecodeStreamingPlans), "fast_decode_streaming_plans/op")
 	b.ReportMetric(float64(diag.FastDecodeMaterializePlans), "fast_decode_materialize_plans/op")
 	b.ReportMetric(float64(diag.FastDecodeUnsupportedPlans), "fast_decode_unsupported_plans/op")
+	b.ReportMetric(float64(diag.FastDecodeMmapDirectViews), "mmap_direct_view/op")
+	b.ReportMetric(float64(diag.FastDecodeHeapCopyTypedViews), "heap_copy_typed_view/op")
+	b.ReportMetric(float64(diag.FastDecodeScratchDecodes), "scratch_decode/op")
+	b.ReportMetric(float64(diag.FastDecodeStreamingFallbacks), "streaming_fallback/op")
+	b.ReportMetric(float64(diag.FastDecodeCertificationFailure), "certification_failure/op")
+	b.ReportMetric(float64(diag.FastDecodeAbsoluteUnaligned), "absolute_offset_unaligned/op")
+	b.ReportMetric(float64(diag.FastDecodeActualUnaligned), "actual_pointer_unaligned/op")
+	b.ReportMetric(float64(diag.FastDecodeStaleHandles), "stale_handle/op")
 	b.ReportMetric(float64(diag.DirectViewSuccesses), "direct_view_successes/op")
 	b.ReportMetric(float64(diag.DirectViewFailures), "direct_view_failures/op")
 	b.ReportMetric(float64(diag.KernelBlocks), "kernel_blocks/op")

--- a/TreeDB/collections/typed_column_prepared_int64.go
+++ b/TreeDB/collections/typed_column_prepared_int64.go
@@ -448,10 +448,16 @@ func recordTypedColumnInt64FastDecodePlan(diag *TypedColumnInt64PredicateScanDia
 		diag.FastDecodeDirectViewPlans++
 	case typeddecode.PathStreaming:
 		diag.FastDecodeStreamingPlans++
+		if plan.Reason != "" && plan.Reason != typeddecode.ReasonSupported {
+			recordTypedColumnInt64FallbackReasonCounter(diag, plan.Reason)
+		}
 	case typeddecode.PathMaterialize:
 		diag.FastDecodeMaterializePlans++
 	case typeddecode.PathUnsupported:
 		diag.FastDecodeUnsupportedPlans++
+		if plan.Reason != "" && plan.Reason != typeddecode.ReasonSupported {
+			recordTypedColumnInt64FallbackReasonCounter(diag, plan.Reason)
+		}
 	}
 	if plan.Reason != "" && plan.Reason != typeddecode.ReasonSupported {
 		diag.FastDecodeFallbackReason = string(plan.Reason)
@@ -459,16 +465,53 @@ func recordTypedColumnInt64FastDecodePlan(diag *TypedColumnInt64PredicateScanDia
 }
 
 func recordTypedColumnInt64DirectViewStatus(diag *TypedColumnInt64PredicateScanDiagnostics, status typeddecode.Status) {
+	recordTypedColumnInt64DirectViewStatusWithHandle(diag, status, nil)
+}
+
+func recordTypedColumnInt64DirectViewStatusWithHandle(diag *TypedColumnInt64PredicateScanDiagnostics, status typeddecode.Status, handle *mappedresource.Handle) {
 	if diag == nil {
 		return
 	}
 	if status.Direct() {
 		diag.DirectViewSuccesses++
+		if handle != nil && handle.Source() == mappedresource.SourceHeapCopy {
+			diag.FastDecodeHeapCopyTypedViews++
+		} else {
+			diag.FastDecodeMmapDirectViews++
+		}
 		return
 	}
 	diag.DirectViewFailures++
+	recordTypedColumnInt64FallbackReasonCounter(diag, status.Reason)
 	if status.Reason != "" && status.Reason != typeddecode.ReasonSupported {
 		diag.FastDecodeFallbackReason = string(status.Reason)
+	}
+}
+
+func recordTypedColumnInt64ScratchDecode(diag *TypedColumnInt64PredicateScanDiagnostics, reason typeddecode.Reason) {
+	if diag == nil {
+		return
+	}
+	diag.FastDecodeScratchDecodes++
+	diag.FastDecodeStreamingFallbacks++
+	if reason != "" && reason != typeddecode.ReasonSupported {
+		diag.FastDecodeFallbackReason = string(reason)
+	}
+}
+
+func recordTypedColumnInt64FallbackReasonCounter(diag *TypedColumnInt64PredicateScanDiagnostics, reason typeddecode.Reason) {
+	if diag == nil || reason == "" || reason == typeddecode.ReasonSupported {
+		return
+	}
+	switch reason {
+	case typeddecode.ReasonAbsoluteOffsetUnaligned, typeddecode.ReasonUnaligned:
+		diag.FastDecodeAbsoluteUnaligned++
+	case typeddecode.ReasonActualPointerUnaligned:
+		diag.FastDecodeActualUnaligned++
+	case typeddecode.ReasonStaleHandle:
+		diag.FastDecodeStaleHandles++
+	case typeddecode.ReasonNotWriterCertified, typeddecode.ReasonWrongEndian, typeddecode.ReasonLengthMultipleMismatch, typeddecode.ReasonPayloadLengthMismatch, typeddecode.ReasonRowCountMismatch, typeddecode.ReasonDimensionMismatch, typeddecode.ReasonCompressed, typeddecode.ReasonNullableWrapper, typeddecode.ReasonValidationFailed:
+		diag.FastDecodeCertificationFailure++
 	}
 }
 
@@ -630,6 +673,51 @@ func addTypedColumnInt64AggregateStatsBlock(result *TypedColumnInt64PredicateAgg
 	return true, nil
 }
 
+func (s *TypedColumnInt64PredicateAggregateSession) addTypedColumnInt64AggregateTypedViewValues(result *TypedColumnInt64PredicateAggregateResult, preparedColumn *typedColumnPreparedColumnState, block *typedColumnPreparedBlockPlan, granule typedcolumn.EncodedGranule, values []int64, visibility *typedColumnLatestPhysicalPart) error {
+	if result == nil || preparedColumn == nil || block == nil {
+		return errors.New("collections: typed-column int64 aggregate typed-view path missing state")
+	}
+	result.Diagnostics.BlocksDecoded++
+	result.Diagnostics.RowsScanned += len(values)
+	selection := block.CandidateSelection
+	if block.NeedsPredicate {
+		predicateSelection, err := typedColumnInt64PredicateAggregateBlockSelection(typedColumnInt64PredicateAggregateScanRequest(s.req), granule, values, &s.aggregateScratch)
+		if err != nil {
+			return err
+		}
+		selection = predicateSelection
+		if !block.CandidateSelection.IsAll() {
+			composed, err := typedcolumn.ComposeRowSelectionsInto(block.Descriptor.RowCount, typedcolumn.RowSelectionComponents{Predicate: &predicateSelection, Visibility: &block.CandidateSelection}, &s.aggregateScratch.selection)
+			if err != nil {
+				return err
+			}
+			selection = composed
+			result.Diagnostics.SelectionCompositions++
+		}
+	}
+	if visibility != nil && !selection.IsEmpty() {
+		visibilitySelection, err := typedColumnInt64VisibilitySelectionForBlock(visibility, block.Descriptor.FirstRow, block.Descriptor.RowCount, &s.aggregateScratch)
+		if err != nil {
+			return err
+		}
+		composed, err := typedcolumn.ComposeRowSelectionsInto(block.Descriptor.RowCount, typedcolumn.RowSelectionComponents{Predicate: &selection, Visibility: &visibilitySelection}, &s.aggregateScratch.selection)
+		if err != nil {
+			return err
+		}
+		selection = composed
+		result.Diagnostics.SelectionCompositions++
+	}
+	recordTypedColumnSelectionDiagnostics(&result.Diagnostics, selection)
+	if selection.IsEmpty() {
+		return nil
+	}
+	if err := addTypedColumnInt64AggregateKernelValues(result, preparedColumn.AggregateReducer, values, selection, &s.aggregateScratch.kernel); err != nil {
+		return err
+	}
+	recordTypedColumnInt64KernelBlock(&result.Diagnostics, !block.NeedsPredicate && visibility == nil && selection.IsAll(), false)
+	return nil
+}
+
 func (s *TypedColumnInt64PredicateAggregateSession) scanPreparedAggregateColumnState(preparedColumn *typedColumnPreparedColumnState, ref ColumnAssetRef, visibility *typedColumnLatestPhysicalPart, result *TypedColumnInt64PredicateAggregateResult, updateCacheDeltas func()) (bool, error) {
 	if preparedColumn == nil {
 		return false, errors.New("collections: typed-column int64 predicate aggregate nil prepared column")
@@ -695,6 +783,7 @@ func (s *TypedColumnInt64PredicateAggregateSession) scanPreparedAggregateColumnS
 		if columnPlan.Path == typeddecode.PathUnsupported {
 			return false, fmt.Errorf("collections: typed-column int64 aggregate fast decode unsupported for column %q: %s", preparedColumn.Plan.Definition.Name, columnPlan.Status().String())
 		}
+		streamingFallbackReason := typeddecode.Reason("")
 		if columnPlan.DirectCandidate() {
 			if block.Index < 0 || block.Index >= len(preparedColumn.Certification.Blocks) {
 				return false, fmt.Errorf("collections: typed-column int64 aggregate direct-view block index=%d outside certification blocks=%d", block.Index, len(preparedColumn.Certification.Blocks))
@@ -702,55 +791,40 @@ func (s *TypedColumnInt64PredicateAggregateSession) scanPreparedAggregateColumnS
 			blockStatus := typeddecode.ValidateDirectViewBlock(typeddecode.DirectViewBlockRequest{Plan: columnPlan, Certification: preparedColumn.Certification, Block: preparedColumn.Certification.Blocks[block.Index], Rows: granule.Rows, PayloadBytes: len(payload), AssetOffset: int64(ref.Offset), HasAssetOffset: true})
 			if blockStatus.Direct() {
 				values, viewStatus := typeddecode.Int64View(s.resourceManager, handle, typeddecode.ResourceViewOptions{ExpectedElements: granule.Rows, RequireMapped: true})
-				recordTypedColumnInt64DirectViewStatus(&result.Diagnostics, viewStatus)
+				recordTypedColumnInt64DirectViewStatusWithHandle(&result.Diagnostics, viewStatus, handle)
 				if viewStatus.Direct() {
 					decodedAny = true
-					result.Diagnostics.BlocksDecoded++
-					result.Diagnostics.RowsScanned += len(values)
-					selection := block.CandidateSelection
-					if block.NeedsPredicate {
-						predicateSelection, err := typedColumnInt64PredicateAggregateBlockSelection(typedColumnInt64PredicateAggregateScanRequest(s.req), granule, values, &s.aggregateScratch)
-						if err != nil {
-							return false, err
-						}
-						selection = predicateSelection
-						if !block.CandidateSelection.IsAll() {
-							selection, err = typedcolumn.ComposeRowSelectionsInto(block.Descriptor.RowCount, typedcolumn.RowSelectionComponents{Predicate: &predicateSelection, Visibility: &block.CandidateSelection}, &s.aggregateScratch.selection)
-							if err != nil {
-								return false, err
-							}
-							result.Diagnostics.SelectionCompositions++
-						}
-					}
-					if visibility != nil && !selection.IsEmpty() {
-						visibilitySelection, err := typedColumnInt64VisibilitySelectionForBlock(visibility, block.Descriptor.FirstRow, block.Descriptor.RowCount, &s.aggregateScratch)
-						if err != nil {
-							return false, err
-						}
-						selection, err = typedcolumn.ComposeRowSelectionsInto(block.Descriptor.RowCount, typedcolumn.RowSelectionComponents{Predicate: &selection, Visibility: &visibilitySelection}, &s.aggregateScratch.selection)
-						if err != nil {
-							return false, err
-						}
-						result.Diagnostics.SelectionCompositions++
-					}
-					recordTypedColumnSelectionDiagnostics(&result.Diagnostics, selection)
-					if selection.IsEmpty() {
-						continue
-					}
-					if err := addTypedColumnInt64AggregateKernelValues(result, preparedColumn.AggregateReducer, values, selection, &s.aggregateScratch.kernel); err != nil {
+					if err := s.addTypedColumnInt64AggregateTypedViewValues(result, preparedColumn, block, granule, values, visibility); err != nil {
 						return false, err
 					}
-					recordTypedColumnInt64KernelBlock(&result.Diagnostics, !block.NeedsPredicate && visibility == nil && selection.IsAll(), false)
 					continue
 				}
-				if !typedColumnInt64DirectViewFallbackAllowed(viewStatus) {
+				if viewStatus.Reason == typeddecode.ReasonHandleSourceUnsupported {
+					heapValues, heapStatus := typeddecode.Int64View(s.resourceManager, handle, typeddecode.ResourceViewOptions{ExpectedElements: granule.Rows, RequireMapped: false})
+					if heapStatus.Direct() {
+						recordTypedColumnInt64DirectViewStatusWithHandle(&result.Diagnostics, heapStatus, handle)
+						decodedAny = true
+						if err := s.addTypedColumnInt64AggregateTypedViewValues(result, preparedColumn, block, granule, heapValues, visibility); err != nil {
+							return false, err
+						}
+						continue
+					}
+					recordTypedColumnInt64FallbackReasonCounter(&result.Diagnostics, heapStatus.Reason)
+					if !typedColumnInt64DirectViewFallbackAllowed(heapStatus) {
+						return false, fmt.Errorf("collections: typed-column int64 aggregate heap typed view failed closed for column %q block %d: %s", preparedColumn.Plan.Definition.Name, block.Index, heapStatus.String())
+					}
+					streamingFallbackReason = heapStatus.Reason
+				} else if !typedColumnInt64DirectViewFallbackAllowed(viewStatus) {
 					return false, fmt.Errorf("collections: typed-column int64 aggregate direct view failed closed for column %q block %d: %s", preparedColumn.Plan.Definition.Name, block.Index, viewStatus.String())
+				} else {
+					streamingFallbackReason = viewStatus.Reason
 				}
 			} else if !typedColumnInt64DirectViewFallbackAllowed(blockStatus) {
 				recordTypedColumnInt64DirectViewStatus(&result.Diagnostics, blockStatus)
 				return false, fmt.Errorf("collections: typed-column int64 aggregate direct-view contract failed for column %q block %d: %s", preparedColumn.Plan.Definition.Name, block.Index, blockStatus.String())
 			} else {
 				recordTypedColumnInt64DirectViewStatus(&result.Diagnostics, blockStatus)
+				streamingFallbackReason = blockStatus.Reason
 			}
 		}
 
@@ -759,6 +833,10 @@ func (s *TypedColumnInt64PredicateAggregateSession) scanPreparedAggregateColumnS
 		}
 		decodedAny = true
 		result.Diagnostics.BlocksDecoded++
+		if streamingFallbackReason == "" && columnPlan.Path == typeddecode.PathStreaming {
+			streamingFallbackReason = columnPlan.Reason
+		}
+		recordTypedColumnInt64ScratchDecode(&result.Diagnostics, streamingFallbackReason)
 		if err := addTypedColumnInt64AggregateStreamingValues(result, typedColumnInt64PredicateAggregateScanRequest(s.req), granule, *block, preparedColumn.AggregateReducer, visibility, &s.aggregateScratch); err != nil {
 			return false, err
 		}

--- a/TreeDB/collections/typed_column_prepared_int64.go
+++ b/TreeDB/collections/typed_column_prepared_int64.go
@@ -493,8 +493,8 @@ func recordTypedColumnInt64ScratchDecode(diag *TypedColumnInt64PredicateScanDiag
 		return
 	}
 	diag.FastDecodeScratchDecodes++
-	diag.FastDecodeStreamingFallbacks++
 	if reason != "" && reason != typeddecode.ReasonSupported {
+		diag.FastDecodeStreamingFallbacks++
 		diag.FastDecodeFallbackReason = string(reason)
 	}
 }
@@ -833,7 +833,7 @@ func (s *TypedColumnInt64PredicateAggregateSession) scanPreparedAggregateColumnS
 		}
 		decodedAny = true
 		result.Diagnostics.BlocksDecoded++
-		if streamingFallbackReason == "" && columnPlan.Path == typeddecode.PathStreaming {
+		if streamingFallbackReason == "" && columnPlan.Path == typeddecode.PathStreaming && columnPlan.Reason != typeddecode.ReasonVariableWidth {
 			streamingFallbackReason = columnPlan.Reason
 		}
 		recordTypedColumnInt64ScratchDecode(&result.Diagnostics, streamingFallbackReason)

--- a/TreeDB/collections/typed_column_prepared_state_test.go
+++ b/TreeDB/collections/typed_column_prepared_state_test.go
@@ -5,7 +5,9 @@ import (
 	"testing"
 
 	"github.com/snissn/gomap/TreeDB/internal/columnsemantics"
+	"github.com/snissn/gomap/TreeDB/internal/mappedresource"
 	"github.com/snissn/gomap/TreeDB/internal/typedcolumn"
+	"github.com/snissn/gomap/TreeDB/internal/typeddecode"
 )
 
 func TestTypedColumnPreparedStateNonInt64DependencyDescriptions(t *testing.T) {
@@ -126,6 +128,54 @@ func TestTypedColumnPreparedStateNonInt64DependencyDescriptions(t *testing.T) {
 	}
 	if vectorScalar.Capability.Status != columnsemantics.StatusUnsupported || vectorScalar.Capability.Reason != columnsemantics.ReasonVectorScalarOperationUnsupported {
 		t.Fatalf("vector scalar capability=%+v want #1843 unsupported scalar operation", vectorScalar.Capability)
+	}
+}
+
+func TestTypedColumnPreparedFastDecodeSourceCounters1896(t *testing.T) {
+	var diag TypedColumnInt64PredicateScanDiagnostics
+	recordTypedColumnInt64FastDecodePlan(&diag, typeddecode.Plan{Path: typeddecode.PathStreaming, Reason: typeddecode.ReasonNotWriterCertified})
+	if diag.FastDecodeStreamingPlans != 1 || diag.FastDecodeCertificationFailure != 1 || diag.FastDecodeFallbackReason != string(typeddecode.ReasonNotWriterCertified) {
+		t.Fatalf("streaming plan counters=%+v want certification streaming plan", diag)
+	}
+	recordTypedColumnInt64ScratchDecode(&diag, typeddecode.ReasonNotWriterCertified)
+	if diag.FastDecodeScratchDecodes != 1 || diag.FastDecodeStreamingFallbacks != 1 || diag.FastDecodeFallbackReason != string(typeddecode.ReasonNotWriterCertified) {
+		t.Fatalf("scratch counters=%+v want certification streaming fallback", diag)
+	}
+	recordTypedColumnInt64DirectViewStatus(&diag, typeddecode.StreamingStatus(typeddecode.ReasonAbsoluteOffsetUnaligned, "absolute"))
+	if diag.DirectViewFailures != 1 || diag.FastDecodeAbsoluteUnaligned != 1 || diag.FastDecodeStreamingFallbacks != 1 {
+		t.Fatalf("absolute counters=%+v want direct-view failure without scratch fallback", diag)
+	}
+	recordTypedColumnInt64ScratchDecode(&diag, typeddecode.ReasonAbsoluteOffsetUnaligned)
+	if diag.FastDecodeScratchDecodes != 2 || diag.FastDecodeStreamingFallbacks != 2 {
+		t.Fatalf("absolute scratch counters=%+v want streaming fallback", diag)
+	}
+	recordTypedColumnInt64DirectViewStatus(&diag, typeddecode.StreamingStatus(typeddecode.ReasonActualPointerUnaligned, "actual"))
+	if diag.DirectViewFailures != 2 || diag.FastDecodeActualUnaligned != 1 {
+		t.Fatalf("actual counters=%+v want actual pointer counter", diag)
+	}
+	recordTypedColumnInt64DirectViewStatus(&diag, typeddecode.UnsupportedStatus(typeddecode.ReasonStaleHandle, "stale"))
+	if diag.DirectViewFailures != 3 || diag.FastDecodeStaleHandles != 1 || diag.FastDecodeStreamingFallbacks != 2 {
+		t.Fatalf("stale counters=%+v want stale counter without fallback", diag)
+	}
+
+	mgr := mappedresource.NewManager()
+	h, err := mgr.AcquireBytes(mappedresource.Key{Class: mappedresource.ClassTypedColumnAsset, Namespace: "test", Kind: "counter", Generation: 1, PartID: 1, FileID: 1, Length: 8}, mappedresource.Scope{Kind: mappedresource.ScopePreparedQuery, ID: "counter", Namespace: "test"}, mappedresource.SourceMapped, make([]byte, 8), mappedresource.AcquireOptions{Reason: "counter"})
+	if err != nil {
+		t.Fatalf("AcquireBytes: %v", err)
+	}
+	defer func() { _ = h.Release() }()
+	recordTypedColumnInt64DirectViewStatusWithHandle(&diag, typeddecode.DirectStatus(), h)
+	if diag.DirectViewSuccesses != 1 || diag.FastDecodeMmapDirectViews != 1 || diag.FastDecodeHeapCopyTypedViews != 0 {
+		t.Fatalf("direct counters=%+v want one mmap direct view", diag)
+	}
+	heap, err := mgr.AcquireBytes(mappedresource.Key{Class: mappedresource.ClassTypedColumnAsset, Namespace: "test", Kind: "counter", Generation: 1, PartID: 2, FileID: 1, Length: 8}, mappedresource.Scope{Kind: mappedresource.ScopePreparedQuery, ID: "counter", Namespace: "test"}, mappedresource.SourceHeapCopy, make([]byte, 8), mappedresource.AcquireOptions{Reason: "counter heap"})
+	if err != nil {
+		t.Fatalf("AcquireBytes heap: %v", err)
+	}
+	defer func() { _ = heap.Release() }()
+	recordTypedColumnInt64DirectViewStatusWithHandle(&diag, typeddecode.DirectStatus(), heap)
+	if diag.DirectViewSuccesses != 2 || diag.FastDecodeMmapDirectViews != 1 || diag.FastDecodeHeapCopyTypedViews != 1 {
+		t.Fatalf("heap counters=%+v want separate heap-copy typed view", diag)
 	}
 }
 

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -356,7 +356,7 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/column_vector_graph_typed_column.go", classification: typedStorageLegacyDerived, matchingLines: 6, occurrences: 6},
 	{path: "TreeDB/collections/column_vector_graph_typed_column_test.go", classification: typedStorageLegacyDerived, matchingLines: 21, occurrences: 24},
 	{path: "TreeDB/collections/command_wal_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 4, occurrences: 6},
-	{path: "TreeDB/collections/typed_column_adapter.go", classification: typedStorageLegacyCompatibility, matchingLines: 47, occurrences: 53},
+	{path: "TreeDB/collections/typed_column_adapter.go", classification: typedStorageLegacyCompatibility, matchingLines: 49, occurrences: 55},
 	{path: "TreeDB/collections/typed_column_adapter_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 222, occurrences: 230},
 	{path: "TreeDB/collections/typed_column_bool_scan.go", classification: typedStorageLegacyCompatibility, matchingLines: 14, occurrences: 19},
 	{path: "TreeDB/collections/typed_column_bool_scan_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 3, occurrences: 4},

--- a/TreeDB/internal/typeddecode/plan.go
+++ b/TreeDB/internal/typeddecode/plan.go
@@ -220,10 +220,43 @@ func Int64ReducerPlan(layout columnlayout.Capabilities, cert typedcolumn.ColumnP
 }
 
 func validateDirectViewCertification(layout columnlayout.Capabilities, cert typedcolumn.ColumnPartLayoutContractColumn, elementSize int, elementsPerRow int) Status {
+	if status := validateDirectViewCertificationFields(cert, elementSize, elementsPerRow); !status.Direct() {
+		return status
+	}
 	if cap := layout.Supports(columnlayout.OpDirectView); !cap.Supported() {
 		return statusFromLayoutCapability(cap)
 	}
-	return validateDirectViewCertificationFields(cert, elementSize, elementsPerRow)
+	return DirectStatus()
+}
+
+// Float32ScalarPlan selects a direct-view candidate only for writer-certified
+// native raw little-endian float32 scalar sections. Raw-int64 compatibility
+// carriers for logical float32 remain non-native fallback layouts.
+func Float32ScalarPlan(cert typedcolumn.ColumnPartLayoutContractColumn) Plan {
+	layout := columnlayout.CapabilitiesFor(columnlayout.Descriptor{
+		Logical:     columnsemantics.LogicalFloat32,
+		Physical:    typedcolumn.ColumnTypeFloat32,
+		Encoding:    cert.Encoding,
+		Compression: cert.Compression,
+		Nullable:    cert.NullMaskPresent || cert.NullCount != 0,
+		Defaultable: cert.DefaultMaskPresent || cert.DefaultCount != 0,
+	})
+	return scalarDirectViewPlan(layout, cert, columnsemantics.LogicalFloat32, typedcolumn.ColumnTypeFloat32, typedcolumn.EncodingRawFloat32, 4)
+}
+
+// Float64ScalarPlan selects a direct-view candidate only for writer-certified
+// native raw little-endian float64/double scalar sections. Raw-int64
+// compatibility carriers for logical double remain non-native fallback layouts.
+func Float64ScalarPlan(cert typedcolumn.ColumnPartLayoutContractColumn) Plan {
+	layout := columnlayout.CapabilitiesFor(columnlayout.Descriptor{
+		Logical:     columnsemantics.LogicalDouble,
+		Physical:    typedcolumn.ColumnTypeFloat64,
+		Encoding:    cert.Encoding,
+		Compression: cert.Compression,
+		Nullable:    cert.NullMaskPresent || cert.NullCount != 0,
+		Defaultable: cert.DefaultMaskPresent || cert.DefaultCount != 0,
+	})
+	return scalarDirectViewPlan(layout, cert, columnsemantics.LogicalDouble, typedcolumn.ColumnTypeFloat64, typedcolumn.EncodingRawFloat64, 8)
 }
 
 // DenseFloat32VectorPlan selects a direct-view candidate only for writer-
@@ -257,6 +290,21 @@ func AdjacencyListPlan(cert typedcolumn.ColumnPartLayoutContractColumn, degree i
 		FixedWidthElements: degree,
 	})
 	return denseDirectViewPlan(layout, cert, columnsemantics.LogicalAdjacencyList, typedcolumn.ColumnTypeAdjacencyList, typedcolumn.EncodingRawUint32Dense, 4, degree)
+}
+
+func scalarDirectViewPlan(layout columnlayout.Capabilities, cert typedcolumn.ColumnPartLayoutContractColumn, logical columnsemantics.LogicalType, physical typedcolumn.ColumnType, encoding typedcolumn.Encoding, elementSize int) Plan {
+	plan := Plan{Path: PathDirectView, Reason: ReasonSupported, ElementSize: elementSize, ElementsPerRow: 1, Alignment: elementSize, Rows: cert.Rows}
+	status := validateDirectViewCertification(layout, cert, elementSize, 1)
+	if !status.Direct() {
+		return Plan{Path: status.Path, Reason: status.Reason, Message: status.Message, ElementSize: elementSize, ElementsPerRow: 1, Alignment: elementSize, Rows: cert.Rows}
+	}
+	if cert.LogicalType != string(logical) {
+		return Plan{Path: PathUnsupported, Reason: ReasonValidationFailed, Message: fmt.Sprintf("logical_type=%q want %q", cert.LogicalType, logical), ElementSize: elementSize, ElementsPerRow: 1, Alignment: elementSize, Rows: cert.Rows}
+	}
+	if cert.Type != physical || cert.Encoding != encoding {
+		return Plan{Path: PathUnsupported, Reason: ReasonValidationFailed, Message: fmt.Sprintf("type/encoding=(%s,%s) want (%s,%s)", cert.Type, cert.Encoding, physical, encoding), ElementSize: elementSize, ElementsPerRow: 1, Alignment: elementSize, Rows: cert.Rows}
+	}
+	return plan
 }
 
 func denseDirectViewPlan(layout columnlayout.Capabilities, cert typedcolumn.ColumnPartLayoutContractColumn, logical columnsemantics.LogicalType, physical typedcolumn.ColumnType, encoding typedcolumn.Encoding, elementSize int, elementsPerRow int) Plan {
@@ -293,11 +341,25 @@ func validateDirectViewCertificationFields(cert typedcolumn.ColumnPartLayoutCont
 	if cert.ElementSize != elementSize {
 		return StreamingStatus(ReasonLengthMultipleMismatch, fmt.Sprintf("element_size=%d want %d", cert.ElementSize, elementSize))
 	}
-	if cert.FixedWidthElements != 0 && cert.FixedWidthElements != elementsPerRow {
-		return StreamingStatus(ReasonDimensionMismatch, fmt.Sprintf("elements_per_row=%d want %d", cert.FixedWidthElements, elementsPerRow))
+	if status := validateFixedWidthElements(cert, elementsPerRow); !status.Direct() {
+		return status
 	}
 	if cert.Alignment <= 0 || cert.Alignment < elementSize || cert.LengthMultiple <= 0 || cert.LengthMultiple%elementSize != 0 {
 		return StreamingStatus(ReasonLengthMultipleMismatch, fmt.Sprintf("alignment=%d length_multiple=%d element_size=%d", cert.Alignment, cert.LengthMultiple, elementSize))
+	}
+	return DirectStatus()
+}
+
+func validateFixedWidthElements(cert typedcolumn.ColumnPartLayoutContractColumn, elementsPerRow int) Status {
+	switch cert.Type {
+	case typedcolumn.ColumnTypeFloat32Vector, typedcolumn.ColumnTypeAdjacencyList:
+		if elementsPerRow <= 0 || cert.FixedWidthElements != elementsPerRow {
+			return StreamingStatus(ReasonDimensionMismatch, fmt.Sprintf("elements_per_row=%d want %d", cert.FixedWidthElements, elementsPerRow))
+		}
+	default:
+		if cert.FixedWidthElements != 0 {
+			return StreamingStatus(ReasonDimensionMismatch, fmt.Sprintf("fixed_width_elements=%d want scalar", cert.FixedWidthElements))
+		}
 	}
 	return DirectStatus()
 }
@@ -568,8 +630,8 @@ func Uint32View(mgr *mappedresource.Manager, h *mappedresource.Handle, opts Reso
 
 // Float32ByteView validates and exposes immutable bytes as []float32 without a
 // mappedresource handle. Callers are responsible for tying the byte slice to an
-// explicit lifetime; handle-backed optimized paths should prefer Float32View or
-// DenseFloat32VectorView.
+// explicit lifetime; handle-backed optimized paths should prefer Float32View,
+// Float32ScalarView, or DenseFloat32VectorView.
 func Float32ByteView(raw []byte, opts ResourceViewOptions) ([]float32, Status) {
 	view, err := mappedresource.Float32View(raw)
 	return validateViewLen(view, opts.ExpectedElements, err)
@@ -584,12 +646,36 @@ func Uint32ByteView(raw []byte, opts ResourceViewOptions) ([]uint32, Status) {
 	return validateViewLen(view, opts.ExpectedElements, err)
 }
 
+func Float32ScalarView(mgr *mappedresource.Manager, h *mappedresource.Handle, req DirectViewColumnRequest, opts ResourceViewOptions) ([]float32, Status) {
+	status := ValidateDirectViewColumn(req)
+	if !status.Direct() {
+		return nil, status
+	}
+	opts, status = normalizeFixedWidthViewOptions(req, opts)
+	if !status.Direct() {
+		return nil, status
+	}
+	return Float32View(mgr, h, opts)
+}
+
+func Float64ScalarView(mgr *mappedresource.Manager, h *mappedresource.Handle, req DirectViewColumnRequest, opts ResourceViewOptions) ([]float64, Status) {
+	status := ValidateDirectViewColumn(req)
+	if !status.Direct() {
+		return nil, status
+	}
+	opts, status = normalizeFixedWidthViewOptions(req, opts)
+	if !status.Direct() {
+		return nil, status
+	}
+	return Float64View(mgr, h, opts)
+}
+
 func DenseFloat32VectorView(mgr *mappedresource.Manager, h *mappedresource.Handle, req DirectViewColumnRequest, opts ResourceViewOptions) ([]float32, Status) {
 	status := ValidateDirectViewColumn(req)
 	if !status.Direct() {
 		return nil, status
 	}
-	opts, status = normalizeDenseViewOptions(req, opts)
+	opts, status = normalizeFixedWidthViewOptions(req, opts)
 	if !status.Direct() {
 		return nil, status
 	}
@@ -601,14 +687,14 @@ func AdjacencyListView(mgr *mappedresource.Manager, h *mappedresource.Handle, re
 	if !status.Direct() {
 		return nil, status
 	}
-	opts, status = normalizeDenseViewOptions(req, opts)
+	opts, status = normalizeFixedWidthViewOptions(req, opts)
 	if !status.Direct() {
 		return nil, status
 	}
 	return Uint32View(mgr, h, opts)
 }
 
-func normalizeDenseViewOptions(req DirectViewColumnRequest, opts ResourceViewOptions) (ResourceViewOptions, Status) {
+func normalizeFixedWidthViewOptions(req DirectViewColumnRequest, opts ResourceViewOptions) (ResourceViewOptions, Status) {
 	elementsPerRow := req.Plan.ElementsPerRow
 	if elementsPerRow <= 0 {
 		elementsPerRow = 1

--- a/TreeDB/internal/typeddecode/plan_test.go
+++ b/TreeDB/internal/typeddecode/plan_test.go
@@ -156,6 +156,137 @@ func TestInt64DeltaPlanUsesStreamingNotDirectView(t *testing.T) {
 	}
 }
 
+func TestScalarFloatDirectViewPlansPreserveRawBitsAndValidateHandles(t *testing.T) {
+	cases := []struct {
+		name      string
+		bits      []uint64
+		cert      typedcolumn.ColumnPartLayoutContractColumn
+		plan      func(typedcolumn.ColumnPartLayoutContractColumn) Plan
+		put       func([]byte, uint64)
+		viewBits  func(*mappedresource.Manager, *mappedresource.Handle, DirectViewColumnRequest, int) ([]uint64, Status)
+		elemBytes int
+	}{
+		{
+			name:      "float32",
+			bits:      []uint64{0x00000000, 0x80000000, 0x7f800000, 0xff800000, 0x7f7fffff, 0xff7fffff, 0x7fc00001, 0x7fa12345},
+			cert:      testFloat32ScalarDirectCert(8),
+			plan:      Float32ScalarPlan,
+			put:       func(dst []byte, bits uint64) { binary.LittleEndian.PutUint32(dst, uint32(bits)) },
+			elemBytes: 4,
+			viewBits: func(mgr *mappedresource.Manager, h *mappedresource.Handle, req DirectViewColumnRequest, want int) ([]uint64, Status) {
+				view, status := Float32ScalarView(mgr, h, req, ResourceViewOptions{ExpectedElements: want, RequireMapped: true})
+				out := make([]uint64, len(view))
+				for i, value := range view {
+					out[i] = uint64(math.Float32bits(value))
+				}
+				return out, status
+			},
+		},
+		{
+			name:      "float64",
+			bits:      []uint64{0x0000000000000000, 0x8000000000000000, 0x7ff0000000000000, 0xfff0000000000000, 0x7fefffffffffffff, 0xffefffffffffffff, 0x7ff8000000000001, 0x7ff123456789abcd},
+			cert:      testFloat64ScalarDirectCert(8),
+			plan:      Float64ScalarPlan,
+			put:       func(dst []byte, bits uint64) { binary.LittleEndian.PutUint64(dst, bits) },
+			elemBytes: 8,
+			viewBits: func(mgr *mappedresource.Manager, h *mappedresource.Handle, req DirectViewColumnRequest, want int) ([]uint64, Status) {
+				view, status := Float64ScalarView(mgr, h, req, ResourceViewOptions{ExpectedElements: want, RequireMapped: true})
+				out := make([]uint64, len(view))
+				for i, value := range view {
+					out[i] = math.Float64bits(value)
+				}
+				return out, status
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			plan := tc.plan(tc.cert)
+			if !plan.DirectCandidate() {
+				t.Fatalf("plan=%+v want direct candidate", plan)
+			}
+			req := DirectViewColumnRequest{Plan: plan, Certification: tc.cert, Rows: len(tc.bits), PayloadBytes: len(tc.bits) * tc.elemBytes, AssetOffset: 0, HasAssetOffset: true}
+			if status := ValidateDirectViewColumn(req); !status.Direct() {
+				t.Fatalf("column status=%+v want direct", status)
+			}
+			raw := alignedBytes(tc.elemBytes, len(tc.bits)*tc.elemBytes)
+			for i, bits := range tc.bits {
+				tc.put(raw[i*tc.elemBytes:], bits)
+			}
+			mgr := mappedresource.NewManager()
+			h, err := mgr.AcquireBytes(testKeyWithPart(uint64(20+tc.elemBytes), int64(len(raw))), testScope(), mappedresource.SourceMapped, raw, mappedresource.AcquireOptions{Reason: tc.name + " scalar direct view"})
+			if err != nil {
+				t.Fatalf("AcquireBytes: %v", err)
+			}
+			got, status := tc.viewBits(mgr, h, req, len(tc.bits))
+			if !status.Direct() {
+				t.Fatalf("view status=%+v want direct", status)
+			}
+			for i, bits := range tc.bits {
+				if got[i] != bits {
+					t.Fatalf("bits[%d]=0x%x want 0x%x", i, got[i], bits)
+				}
+			}
+			misalignedRaw := alignedBytes(tc.elemBytes, len(raw)+1)[1:]
+			mh, err := mgr.AcquireBytes(testKeyWithPart(uint64(40+tc.elemBytes), int64(len(misalignedRaw))), testScope(), mappedresource.SourceMapped, misalignedRaw, mappedresource.AcquireOptions{Reason: tc.name + " scalar misaligned"})
+			if err != nil {
+				t.Fatalf("AcquireBytes misaligned: %v", err)
+			}
+			if _, status := tc.viewBits(mgr, mh, req, len(tc.bits)); status.Reason != ReasonActualPointerUnaligned {
+				t.Fatalf("misaligned status=%+v want %s", status, ReasonActualPointerUnaligned)
+			}
+			_ = mh.Release()
+			if err := h.Release(); err != nil {
+				t.Fatalf("Release: %v", err)
+			}
+			if _, status := tc.viewBits(mgr, h, req, len(tc.bits)); status.Reason != ReasonStaleHandle {
+				t.Fatalf("stale status=%+v want %s", status, ReasonStaleHandle)
+			}
+		})
+	}
+}
+
+func TestScalarFloatDirectViewValidationRejectsFallbackLayouts(t *testing.T) {
+	cert := testFloat32ScalarDirectCert(2)
+	plan := Float32ScalarPlan(cert)
+	valid := DirectViewColumnRequest{Plan: plan, Certification: cert, Rows: 2, PayloadBytes: 8, AssetOffset: 0, HasAssetOffset: true}
+	if status := ValidateDirectViewColumn(valid); !status.Direct() {
+		t.Fatalf("valid status=%+v want direct", status)
+	}
+	wrongEndian := cloneDirectViewCert(cert)
+	wrongEndian.Endian = typedcolumn.ColumnPartLayoutEndianCodecDefined
+	if status := ValidateDirectViewColumn(DirectViewColumnRequest{Plan: Float32ScalarPlan(wrongEndian), Certification: wrongEndian, Rows: 2, PayloadBytes: 8, AssetOffset: 0, HasAssetOffset: true}); status.Reason != ReasonWrongEndian {
+		t.Fatalf("wrong endian status=%+v want %s", status, ReasonWrongEndian)
+	}
+	wrongRows := valid
+	wrongRows.Rows = 3
+	if status := ValidateDirectViewColumn(wrongRows); status.Reason != ReasonRowCountMismatch {
+		t.Fatalf("wrong rows status=%+v want %s", status, ReasonRowCountMismatch)
+	}
+	wrongDims := cloneDirectViewCert(cert)
+	wrongDims.FixedWidthElements = 1
+	if status := ValidateDirectViewColumn(DirectViewColumnRequest{Plan: Float32ScalarPlan(wrongDims), Certification: wrongDims, Rows: 2, PayloadBytes: 8, AssetOffset: 0, HasAssetOffset: true}); status.Reason != ReasonDimensionMismatch {
+		t.Fatalf("scalar dims status=%+v want %s", status, ReasonDimensionMismatch)
+	}
+	wrongLength := cloneDirectViewCert(cert)
+	wrongLength.Section.Length = 7
+	wrongLength.Blocks[0].PayloadLength = 7
+	wrongLength.Blocks[0].RawBytes = 7
+	wrongLength.Blocks[0].StoredBytes = 7
+	if status := ValidateDirectViewColumn(DirectViewColumnRequest{Plan: plan, Certification: wrongLength, Rows: 2, PayloadBytes: 7, AssetOffset: 0, HasAssetOffset: true}); status.Reason != ReasonLengthMultipleMismatch {
+		t.Fatalf("wrong length status=%+v want %s", status, ReasonLengthMultipleMismatch)
+	}
+	notCertified := cloneDirectViewCert(cert)
+	notCertified.DirectViewCertified = false
+	if status := ValidateDirectViewColumn(DirectViewColumnRequest{Plan: Float32ScalarPlan(notCertified), Certification: notCertified, Rows: 2, PayloadBytes: 8, AssetOffset: 0, HasAssetOffset: true}); status.Reason != ReasonNotWriterCertified {
+		t.Fatalf("missing cert status=%+v want %s", status, ReasonNotWriterCertified)
+	}
+	rawInt64Carrier := typedcolumn.ColumnPartLayoutContractColumn{Name: "score", LogicalType: "float32", Type: typedcolumn.ColumnTypeInt64, Encoding: typedcolumn.EncodingRawInt64, Compression: typedcolumn.CompressionNone, Rows: 2, Section: typedcolumn.ColumnPartLayoutContractSection{Length: 16}, ElementSize: 8, Alignment: 8, Endian: typedcolumn.ColumnPartLayoutEndianLittle, LengthMultiple: 8, DirectViewCertified: true, Blocks: []typedcolumn.ColumnPartLayoutContractBlock{{RowCount: 2, Encoding: typedcolumn.EncodingRawInt64, Compression: typedcolumn.CompressionNone, RawBytes: 16, StoredBytes: 16, PayloadLength: 16}}}
+	if rawPlan := Float32ScalarPlan(rawInt64Carrier); rawPlan.DirectCandidate() || rawPlan.Reason == ReasonSupported {
+		t.Fatalf("raw-int64 float carrier plan=%+v want non-native fallback/unsupported", rawPlan)
+	}
+}
+
 func TestDenseDirectViewBlockValidatesDimensionsAndLength(t *testing.T) {
 	cert := testFloat32VectorDirectCert(2, 4)
 	plan := Plan{Path: PathDirectView, Reason: ReasonSupported, ElementSize: 4, ElementsPerRow: 4, Alignment: 4, Rows: 2}
@@ -253,6 +384,24 @@ func TestAdjacencyDirectViewValidationIsDeferredForCurrentStack(t *testing.T) {
 func cloneDirectViewCert(cert typedcolumn.ColumnPartLayoutContractColumn) typedcolumn.ColumnPartLayoutContractColumn {
 	cert.Blocks = append([]typedcolumn.ColumnPartLayoutContractBlock(nil), cert.Blocks...)
 	return cert
+}
+
+func testFloat32ScalarDirectCert(rows int) typedcolumn.ColumnPartLayoutContractColumn {
+	bytes := rows * 4
+	return typedcolumn.ColumnPartLayoutContractColumn{
+		Name: "score32", LogicalType: "float32", Type: typedcolumn.ColumnTypeFloat32, Encoding: typedcolumn.EncodingRawFloat32, Compression: typedcolumn.CompressionNone,
+		Rows: rows, Section: typedcolumn.ColumnPartLayoutContractSection{Length: bytes}, ElementSize: 4, Alignment: 4, Endian: typedcolumn.ColumnPartLayoutEndianLittle, LengthMultiple: 4, DirectViewCertified: true,
+		Blocks: []typedcolumn.ColumnPartLayoutContractBlock{{FirstRow: 0, RowCount: rows, Encoding: typedcolumn.EncodingRawFloat32, Compression: typedcolumn.CompressionNone, RawBytes: bytes, StoredBytes: bytes, PayloadOffset: 0, PayloadLength: bytes}},
+	}
+}
+
+func testFloat64ScalarDirectCert(rows int) typedcolumn.ColumnPartLayoutContractColumn {
+	bytes := rows * 8
+	return typedcolumn.ColumnPartLayoutContractColumn{
+		Name: "score64", LogicalType: "double", Type: typedcolumn.ColumnTypeFloat64, Encoding: typedcolumn.EncodingRawFloat64, Compression: typedcolumn.CompressionNone,
+		Rows: rows, Section: typedcolumn.ColumnPartLayoutContractSection{Length: bytes}, ElementSize: 8, Alignment: 8, Endian: typedcolumn.ColumnPartLayoutEndianLittle, LengthMultiple: 8, DirectViewCertified: true,
+		Blocks: []typedcolumn.ColumnPartLayoutContractBlock{{FirstRow: 0, RowCount: rows, Encoding: typedcolumn.EncodingRawFloat64, Compression: typedcolumn.CompressionNone, RawBytes: bytes, StoredBytes: bytes, PayloadOffset: 0, PayloadLength: bytes}},
+	}
 }
 
 func testFloat32VectorDirectCert(rows, dims int) typedcolumn.ColumnPartLayoutContractColumn {


### PR DESCRIPTION
## Linked issues

- Closes #1896
- Refs parent #1886

## Start-phase reader inventory / paths touched

- `TreeDB/internal/typeddecode`: shared direct-view plans/views now include certified native scalar `float32` and `double` readers, fixed-width dimension checks, absolute-offset validation, handle-source/lifetime/pointer-alignment statuses.
- `TreeDB/collections/typed_column_prepared_int64.go`: prepared int64 aggregate hot path distinguishes true mmap direct views, heap-copy typed views, and scratch streaming fallbacks.
- `TreeDB/collections/typed_column_adapter.go`: internal certified scalar float section readers for native raw `float32`/`float64` payloads; adjacency remains fallback-only/deferred.
- `TreeDB/collections/column_vector_graph_typed_column.go`: fixed-dim typed-column vector source keeps direct slices tied to source lifetime and refuses access after close.
- Tests/conformance: scalar float raw-bit preservation, wrong cert/layout cases, absolute vs actual unaligned offsets, stale/closed handles/sources, heap-copy typed-view counters, adjacency negative coverage.

## Reader outcome table

| Value type | Reader outcome |
| --- | --- |
| `ColumnStoreValueBool` | unsafe direct view refused; existing bool streaming/materialized path retained |
| `ColumnStoreValueInt64` | certified raw little-endian int64 prepared path uses direct view; delta/nullable/default/compressed/non-certified fall back/fail closed with counters |
| `ColumnStoreValueFloat32` | native raw little-endian scalar float reader plan/view added; raw bits preserved; raw-int64 logical carriers remain non-direct fallback |
| `ColumnStoreValueDouble` | native raw little-endian scalar float64 reader plan/view added; raw bits preserved; raw-int64 logical carriers remain non-direct fallback |
| `ColumnStoreValueString` | unsafe direct view refused; dictionary/string paths remain semantic fallback paths |
| `ColumnStoreValueFloat32Vector` | certified fixed-dim dense `[]float32` vector source uses mmap direct view when safe, otherwise fallback; closed source no longer exposes stale slices |
| `ColumnStoreValueAdjacencyList` | explicitly not direct-viewed in this PR; deferred/fallback-only for #1901 |

## Safety-check placement

| Check | Placement |
| --- | --- |
| Writer certification, logical/physical type, encoding/compression, nullable/default, row count, dims, section/block byte lengths | certification/plan and block validation before exposing a typed view |
| Absolute payload offset (`asset_ref.offset + section/block offset`) | read-path direct-view validation before mmap direct view |
| Actual pointer alignment, source kind (mmap vs heap), exact element count, stale/released handle | immediately before unsafe slice construction |
| Stale/closed API exposure | source/session close rejects later access; vector source clears retained slices/locations |

## Fallback/status counter evidence

Added/reported counters:

- `mmap_direct_view`
- `heap_copy_typed_view`
- `scratch_decode`
- `streaming_fallback`
- `certification_failure`
- `absolute_offset_unaligned`
- `actual_pointer_unaligned`
- `stale_handle`

Production tests cover heap-copy typed view separation and a multi-asset absolute-offset unaligned fallback with `absolute_offset_unaligned` and scratch/streaming fallback counters.

## Tests run

- `go test ./TreeDB/internal/typeddecode ./TreeDB/internal/mappedresource ./TreeDB/collections`
- `go test -gcflags=all=-d=checkptr=2 ./TreeDB/internal/typeddecode ./TreeDB/internal/mappedresource ./TreeDB/collections -run 'Test.*DirectView|TestTypedColumnAdapterNativeFixedWidthScalarByteFixtures|TestColumnVectorGraphTypedColumnVectorCloseReleasesHandles1782|TestTypedColumnInt64PreparedHeapCopyTypedViewCounters|TestTypedColumnInt64PreparedAbsoluteOffsetUnalignedFallsBack'`
- `go test ./...`

## Benchmarks

Hardware/context: Apple M3 / darwin arm64, current PR head `bd140790c`. Command:

```sh
TREEDB_TYPED_COLUMN_BENCH_LAYOUTS=raw \
TREEDB_TYPED_COLUMN_BENCH_ROWS=4096 \
TREEDB_TYPED_COLUMN_BENCH_SHAPES=selective_range_1pct \
TREEDB_TYPED_COLUMN_BENCH_DISTS=clustered_monotonic \
go test ./TreeDB/collections -run '^$' -bench '^BenchmarkTypedColumnInt64PredicateAggregate' -benchtime=100ms -count=1
```

| Benchmark | Type | Rows | ns/op | ops/sec | B/op | allocs/op | direct views/op | mmap direct/op | heap typed/op | scratch decodes/op | notes |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| `path_typed_column_part_raw_int64/.../timed_prepared_session_hot_scan/.../execution_serial` | raw int64 prepared hot scan | 4,096 | 7,092 | 141,001 | 512 | 4 | 1 | 1 | 0 | 0 | true mmap direct-view counter, no scratch/streaming fallback |
| `path_typed_column_part_raw_int64/.../timed_one_shot_api/.../execution_serial` | raw int64 one-shot | 4,096 | 127,540 | 7,841 | 105,820 | 195 | 1 | 1 | 0 | 0 | setup/read-cache included in one-shot boundary |
| `path_document_full_scan_fallback/.../timed_one_shot_api/.../execution_serial` | document fallback baseline | 4,096 | 2,966,385 | 337.1 | 6,593,133 | 81,914 | 0 | 0 | 0 | 0 | same command fallback path |

## AI review status

- Codex: passed on initial head and latest `bd140790c`.
- Copilot: initial review produced no actionable threads; re-requested after `bd140790c`, no new findings observed.
- CodeRabbit: one streaming-fallback counter finding fixed in `bd140790c`; thread resolved; latest CodeRabbit check passed.

## Scope boundaries / caveats

- No public API or query semantic changes.
- No writer layout changes beyond test fixtures.
- No physical row-asset direct views (#1897).
- No adjacency direct views (#1901); negative tests ensure it is not counted as a direct-view success.
- Raw-int64 logical float carriers remain compatibility/fallback layouts and are not native scalar float direct views.

## Merge status

Not merged by this PR/agent.
