### PR TITLE
Land column graph typed-column vector direct counters

### DIFF
--- a/TreeDB/collections/column_vector_graph_row_reader.go
+++ b/TreeDB/collections/column_vector_graph_row_reader.go
@@ -423,7 +423,7 @@ func (r *columnVectorGraphPhysicalRowReader) nativeGraphRowFromBlock(block *colu
 	scratch.Float32Values = scratch.Float32Values[:0]
 	scratch.Uint32Values = scratch.Uint32Values[:0]
 
-	vector, _, typedVectorOK := r.typedVectorForOrdinal(ordinal)
+	vector, _, _, typedVectorOK := r.typedVectorForOrdinal(ordinal)
 	if typedVectorOK {
 		if err := r.skipNativeGraphVector(&cur, block.version, ordinal); err != nil {
 			return columnVectorGraphPhysicalRow{}, fmt.Errorf("row[%d]: %w", rowIndex, err)
@@ -608,7 +608,7 @@ func (r *columnVectorGraphPhysicalRowReader) graphRowFromPhysicalRowUnchecked(ro
 	if invNorm.Null || adjacency.Null {
 		return columnVectorGraphPhysicalRow{}, fmt.Errorf("collections: column_graph %q ordinal=%d contains null graph value", r.def.Name, row.Ordinal)
 	}
-	vectorValues, _, typedVectorOK := r.typedVectorForOrdinal(row.Ordinal)
+	vectorValues, _, _, typedVectorOK := r.typedVectorForOrdinal(row.Ordinal)
 	if !typedVectorOK {
 		if vector.Type != ColumnStoreValueFloat32Vector {
 			return columnVectorGraphPhysicalRow{}, fmt.Errorf("collections: column_graph %q ordinal=%d unexpected graph vector type: vector=%q", r.def.Name, row.Ordinal, vector.Type)

--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 
 	"github.com/snissn/gomap/TreeDB/internal/typedcolumn"
+	"github.com/snissn/gomap/TreeDB/internal/typeddecode"
 )
 
 // Keep modest scratch overgrowth to avoid realloc churn when callers vary
@@ -40,32 +41,40 @@ type columnVectorGraphNativeSearchOptions struct {
 }
 
 type columnVectorGraphNativeSearchStats struct {
-	CandidateRows              uint64
-	Candidates                 uint64
-	Edges                      uint64
-	VisitedNodes               uint64
-	VisitedEdges               uint64
-	VectorBytesRead            uint64
-	AdjacencyBytesRead         uint64
-	CandidateFetches           uint64
-	ExpansionFetches           uint64
-	ResultFetches              uint64
-	ScoreBatches               uint64
-	OrdinalsGrouped            uint64
-	BlockViewHits              uint64
-	BlockViewMisses            uint64
-	BlockViewBuilds            uint64
-	AdjacencyExpansions        uint64
-	AdjacencyScratchDecodes    uint64
-	AdjacencyDirectViews       uint64
-	VectorDirectViews          uint64
-	VectorScratchDecodes       uint64
-	TypedColumnMappedBytes     uint64
-	TypedColumnHeapCopyBytes   uint64
-	TypedColumnDecodedBytes    uint64
-	TypedColumnActiveHandles   int64
-	TypedColumnDeniedResources uint64
-	TypedColumnFallbacks       uint64
+	CandidateRows                 uint64
+	Candidates                    uint64
+	Edges                         uint64
+	VisitedNodes                  uint64
+	VisitedEdges                  uint64
+	VectorBytesRead               uint64
+	AdjacencyBytesRead            uint64
+	CandidateFetches              uint64
+	ExpansionFetches              uint64
+	ResultFetches                 uint64
+	ScoreBatches                  uint64
+	OrdinalsGrouped               uint64
+	BlockViewHits                 uint64
+	BlockViewMisses               uint64
+	BlockViewBuilds               uint64
+	AdjacencyExpansions           uint64
+	AdjacencyScratchDecodes       uint64
+	AdjacencyDirectViews          uint64
+	AdjacencyMmapDirectViews      uint64
+	AdjacencyHeapCopyTypedViews   uint64
+	VectorDirectViews             uint64
+	VectorMmapDirectViews         uint64
+	VectorHeapCopyTypedViews      uint64
+	VectorScratchDecodes          uint64
+	VectorCertificationFailures   uint64
+	VectorAbsoluteOffsetUnaligned uint64
+	VectorActualPointerUnaligned  uint64
+	VectorStaleHandles            uint64
+	TypedColumnMappedBytes        uint64
+	TypedColumnHeapCopyBytes      uint64
+	TypedColumnDecodedBytes       uint64
+	TypedColumnActiveHandles      int64
+	TypedColumnDeniedResources    uint64
+	TypedColumnFallbacks          uint64
 }
 
 // columnVectorGraphNativeSearchResult aliases buffers owned by the search
@@ -547,15 +556,9 @@ func (r *columnVectorGraphPhysicalRowReader) scoreOrdinal(plan *columnVectorGrap
 		stats.BlockViewBuilds = plan.builds
 	}
 	var vector []float32
-	if typedVector, direct, ok := r.typedVectorForOrdinal(ordinal); ok {
+	if typedVector, outcome, fallbackReason, ok := r.typedVectorForOrdinal(ordinal); ok {
 		vector = typedVector
-		if stats != nil {
-			if direct {
-				stats.VectorDirectViews++
-			} else {
-				stats.VectorScratchDecodes++
-			}
-		}
+		recordColumnVectorGraphVectorSourceStats(stats, outcome, fallbackReason)
 	} else {
 		scratch.scoreScratch.Float32Values = scratch.scoreScratch.Float32Values[:0]
 		var vectorScratch []float32
@@ -600,6 +603,40 @@ func (r *columnVectorGraphPhysicalRowReader) expandCandidateAdjacencyLayer(plan 
 	return layerAdjacency, nil
 }
 
+func recordColumnVectorGraphVectorSourceStats(stats *columnVectorGraphNativeSearchStats, outcome columnVectorGraphTypedColumnVectorOutcome, fallbackReason typeddecode.Reason) {
+	if stats == nil {
+		return
+	}
+	switch outcome {
+	case columnVectorGraphTypedColumnVectorOutcomeMmapDirect:
+		stats.VectorMmapDirectViews++
+		stats.VectorDirectViews++
+	case columnVectorGraphTypedColumnVectorOutcomeHeapCopyTypedView:
+		stats.VectorHeapCopyTypedViews++
+	case columnVectorGraphTypedColumnVectorOutcomeScratchDecode:
+		stats.VectorScratchDecodes++
+	default:
+		stats.VectorScratchDecodes++
+	}
+	recordColumnVectorGraphVectorFallbackReasonStats(stats, fallbackReason)
+}
+
+func recordColumnVectorGraphVectorFallbackReasonStats(stats *columnVectorGraphNativeSearchStats, reason typeddecode.Reason) {
+	if stats == nil || reason == "" || reason == typeddecode.ReasonSupported {
+		return
+	}
+	switch reason {
+	case typeddecode.ReasonAbsoluteOffsetUnaligned, typeddecode.ReasonUnaligned:
+		stats.VectorAbsoluteOffsetUnaligned++
+	case typeddecode.ReasonActualPointerUnaligned:
+		stats.VectorActualPointerUnaligned++
+	case typeddecode.ReasonStaleHandle:
+		stats.VectorStaleHandles++
+	case typeddecode.ReasonNotWriterCertified, typeddecode.ReasonWrongEndian, typeddecode.ReasonLengthMultipleMismatch, typeddecode.ReasonPayloadLengthMismatch, typeddecode.ReasonRowCountMismatch, typeddecode.ReasonDimensionMismatch, typeddecode.ReasonCompressed, typeddecode.ReasonNullableWrapper, typeddecode.ReasonValidationFailed:
+		stats.VectorCertificationFailures++
+	}
+}
+
 func recordColumnVectorGraphAdjacencySourceStats(stats *columnVectorGraphNativeSearchStats, adjacencyLen int, direct bool) {
 	if stats == nil {
 		return
@@ -610,6 +647,7 @@ func recordColumnVectorGraphAdjacencySourceStats(stats *columnVectorGraphNativeS
 	}
 	if direct {
 		stats.AdjacencyDirectViews++
+		stats.AdjacencyMmapDirectViews++
 	} else {
 		stats.AdjacencyScratchDecodes++
 	}

--- a/TreeDB/collections/column_vector_graph_search_test.go
+++ b/TreeDB/collections/column_vector_graph_search_test.go
@@ -31,16 +31,16 @@ type columnVectorGraphNativeSearchBenchShapeV3 struct {
 func TestColumnVectorGraphAdjacencySourceStatsSkipEmptyNoopV3(t *testing.T) {
 	var stats columnVectorGraphNativeSearchStats
 	recordColumnVectorGraphAdjacencySourceStats(&stats, 0, false)
-	if stats.AdjacencyBytesRead != 0 || stats.AdjacencyDirectViews != 0 || stats.AdjacencyScratchDecodes != 0 {
+	if stats.AdjacencyBytesRead != 0 || stats.AdjacencyDirectViews != 0 || stats.AdjacencyMmapDirectViews != 0 || stats.AdjacencyHeapCopyTypedViews != 0 || stats.AdjacencyScratchDecodes != 0 {
 		t.Fatalf("empty adjacency stats=%+v want no direct/scratch decode counts", stats)
 	}
 	recordColumnVectorGraphAdjacencySourceStats(&stats, 2, false)
-	if stats.AdjacencyBytesRead != 8 || stats.AdjacencyDirectViews != 0 || stats.AdjacencyScratchDecodes != 1 {
+	if stats.AdjacencyBytesRead != 8 || stats.AdjacencyDirectViews != 0 || stats.AdjacencyMmapDirectViews != 0 || stats.AdjacencyHeapCopyTypedViews != 0 || stats.AdjacencyScratchDecodes != 1 {
 		t.Fatalf("scratch adjacency stats=%+v want bytes=8 scratch=1", stats)
 	}
 	recordColumnVectorGraphAdjacencySourceStats(&stats, 3, true)
-	if stats.AdjacencyBytesRead != 20 || stats.AdjacencyDirectViews != 1 || stats.AdjacencyScratchDecodes != 1 {
-		t.Fatalf("direct adjacency stats=%+v want cumulative bytes=20 direct=1 scratch=1", stats)
+	if stats.AdjacencyBytesRead != 20 || stats.AdjacencyDirectViews != 1 || stats.AdjacencyMmapDirectViews != 1 || stats.AdjacencyHeapCopyTypedViews != 0 || stats.AdjacencyScratchDecodes != 1 {
+		t.Fatalf("direct adjacency stats=%+v want cumulative bytes=20 mmap_direct=1 scratch=1", stats)
 	}
 }
 
@@ -848,13 +848,22 @@ func benchmarkColumnVectorGraphNativeSearchCosineV3(b *testing.B, shape columnVe
 		searchStats.AdjacencyExpansions += stats.AdjacencyExpansions
 		searchStats.AdjacencyScratchDecodes += stats.AdjacencyScratchDecodes
 		searchStats.AdjacencyDirectViews += stats.AdjacencyDirectViews
+		searchStats.AdjacencyMmapDirectViews += stats.AdjacencyMmapDirectViews
+		searchStats.AdjacencyHeapCopyTypedViews += stats.AdjacencyHeapCopyTypedViews
 		searchStats.VectorDirectViews += stats.VectorDirectViews
+		searchStats.VectorMmapDirectViews += stats.VectorMmapDirectViews
+		searchStats.VectorHeapCopyTypedViews += stats.VectorHeapCopyTypedViews
 		searchStats.VectorScratchDecodes += stats.VectorScratchDecodes
+		searchStats.VectorCertificationFailures += stats.VectorCertificationFailures
+		searchStats.VectorAbsoluteOffsetUnaligned += stats.VectorAbsoluteOffsetUnaligned
+		searchStats.VectorActualPointerUnaligned += stats.VectorActualPointerUnaligned
+		searchStats.VectorStaleHandles += stats.VectorStaleHandles
 		searchStats.TypedColumnMappedBytes = stats.TypedColumnMappedBytes
 		searchStats.TypedColumnHeapCopyBytes = stats.TypedColumnHeapCopyBytes
 		searchStats.TypedColumnDecodedBytes = stats.TypedColumnDecodedBytes
 		searchStats.TypedColumnActiveHandles = stats.TypedColumnActiveHandles
 		searchStats.TypedColumnDeniedResources = stats.TypedColumnDeniedResources
+		searchStats.TypedColumnFallbacks += stats.TypedColumnFallbacks
 	}
 	b.StopTimer()
 	stats := reader.Stats()
@@ -868,6 +877,18 @@ func BenchmarkColumnVectorGraphNativeSearchCosineParallelV3(b *testing.B) {
 
 func BenchmarkColumnVectorGraphNativeSearchCosineParallelProduction8192V3(b *testing.B) {
 	benchmarkColumnVectorGraphNativeSearchCosineParallelV3(b, columnVectorGraphNativeSearchProduction8192BenchShapeV3())
+}
+
+func BenchmarkColumnVectorGraphNativeSearchCosineParallelTypedColumnV3(b *testing.B) {
+	shape := columnVectorGraphNativeSearchSmallBenchShapeV3()
+	shape.typedColumnVector = true
+	benchmarkColumnVectorGraphNativeSearchCosineParallelV3(b, shape)
+}
+
+func BenchmarkColumnVectorGraphNativeSearchCosineParallelTypedColumnProduction8192V3(b *testing.B) {
+	shape := columnVectorGraphNativeSearchProduction8192BenchShapeV3()
+	shape.typedColumnVector = true
+	benchmarkColumnVectorGraphNativeSearchCosineParallelV3(b, shape)
 }
 
 func BenchmarkColumnVectorGraphNativeSearchCosineParallelProductionSweepV3(b *testing.B) {
@@ -938,13 +959,22 @@ func benchmarkColumnVectorGraphNativeSearchCosineParallelV3(b *testing.B, shape 
 	var totalAdjacencyExpansions atomic.Uint64
 	var totalAdjacencyScratchDecodes atomic.Uint64
 	var totalAdjacencyDirectViews atomic.Uint64
+	var totalAdjacencyMmapDirectViews atomic.Uint64
+	var totalAdjacencyHeapCopyTypedViews atomic.Uint64
 	var totalVectorDirectViews atomic.Uint64
+	var totalVectorMmapDirectViews atomic.Uint64
+	var totalVectorHeapCopyTypedViews atomic.Uint64
 	var totalVectorScratchDecodes atomic.Uint64
+	var totalVectorCertificationFailures atomic.Uint64
+	var totalVectorAbsoluteOffsetUnaligned atomic.Uint64
+	var totalVectorActualPointerUnaligned atomic.Uint64
+	var totalVectorStaleHandles atomic.Uint64
 	var totalTypedColumnMappedBytes atomic.Uint64
 	var totalTypedColumnHeapCopyBytes atomic.Uint64
 	var totalTypedColumnDecodedBytes atomic.Uint64
 	var totalTypedColumnActiveHandles atomic.Int64
 	var totalTypedColumnDeniedResources atomic.Uint64
+	var totalTypedColumnFallbacks atomic.Uint64
 	var nextWorker atomic.Uint64
 	b.SetParallelism(1) // Keep one prewarmed reader/scratch per RunParallel worker.
 	b.ReportAllocs()
@@ -992,13 +1022,22 @@ func benchmarkColumnVectorGraphNativeSearchCosineParallelV3(b *testing.B, shape 
 			localStats.AdjacencyExpansions += stats.AdjacencyExpansions
 			localStats.AdjacencyScratchDecodes += stats.AdjacencyScratchDecodes
 			localStats.AdjacencyDirectViews += stats.AdjacencyDirectViews
+			localStats.AdjacencyMmapDirectViews += stats.AdjacencyMmapDirectViews
+			localStats.AdjacencyHeapCopyTypedViews += stats.AdjacencyHeapCopyTypedViews
 			localStats.VectorDirectViews += stats.VectorDirectViews
+			localStats.VectorMmapDirectViews += stats.VectorMmapDirectViews
+			localStats.VectorHeapCopyTypedViews += stats.VectorHeapCopyTypedViews
 			localStats.VectorScratchDecodes += stats.VectorScratchDecodes
+			localStats.VectorCertificationFailures += stats.VectorCertificationFailures
+			localStats.VectorAbsoluteOffsetUnaligned += stats.VectorAbsoluteOffsetUnaligned
+			localStats.VectorActualPointerUnaligned += stats.VectorActualPointerUnaligned
+			localStats.VectorStaleHandles += stats.VectorStaleHandles
 			localStats.TypedColumnMappedBytes = stats.TypedColumnMappedBytes
 			localStats.TypedColumnHeapCopyBytes = stats.TypedColumnHeapCopyBytes
 			localStats.TypedColumnDecodedBytes = stats.TypedColumnDecodedBytes
 			localStats.TypedColumnActiveHandles = stats.TypedColumnActiveHandles
 			localStats.TypedColumnDeniedResources = stats.TypedColumnDeniedResources
+			localStats.TypedColumnFallbacks += stats.TypedColumnFallbacks
 		}
 		sink.Add(localSink)
 		totalCandidateRows.Add(localStats.CandidateRows)
@@ -1019,13 +1058,22 @@ func benchmarkColumnVectorGraphNativeSearchCosineParallelV3(b *testing.B, shape 
 		totalAdjacencyExpansions.Add(localStats.AdjacencyExpansions)
 		totalAdjacencyScratchDecodes.Add(localStats.AdjacencyScratchDecodes)
 		totalAdjacencyDirectViews.Add(localStats.AdjacencyDirectViews)
+		totalAdjacencyMmapDirectViews.Add(localStats.AdjacencyMmapDirectViews)
+		totalAdjacencyHeapCopyTypedViews.Add(localStats.AdjacencyHeapCopyTypedViews)
 		totalVectorDirectViews.Add(localStats.VectorDirectViews)
+		totalVectorMmapDirectViews.Add(localStats.VectorMmapDirectViews)
+		totalVectorHeapCopyTypedViews.Add(localStats.VectorHeapCopyTypedViews)
 		totalVectorScratchDecodes.Add(localStats.VectorScratchDecodes)
+		totalVectorCertificationFailures.Add(localStats.VectorCertificationFailures)
+		totalVectorAbsoluteOffsetUnaligned.Add(localStats.VectorAbsoluteOffsetUnaligned)
+		totalVectorActualPointerUnaligned.Add(localStats.VectorActualPointerUnaligned)
+		totalVectorStaleHandles.Add(localStats.VectorStaleHandles)
 		totalTypedColumnMappedBytes.Add(localStats.TypedColumnMappedBytes)
 		totalTypedColumnHeapCopyBytes.Add(localStats.TypedColumnHeapCopyBytes)
 		totalTypedColumnDecodedBytes.Add(localStats.TypedColumnDecodedBytes)
 		totalTypedColumnActiveHandles.Add(localStats.TypedColumnActiveHandles)
 		totalTypedColumnDeniedResources.Add(localStats.TypedColumnDeniedResources)
+		totalTypedColumnFallbacks.Add(localStats.TypedColumnFallbacks)
 	})
 	b.StopTimer()
 	reportColumnGraphNativeSearchBenchShapeMetricsV3(b, shape)
@@ -1039,31 +1087,40 @@ func benchmarkColumnVectorGraphNativeSearchCosineParallelV3(b *testing.B, shape 
 		stats = addColumnPhysicalRowReaderStatsV3(stats, worker.reader.Stats())
 	}
 	reportColumnGraphNativeSearchBenchMetricsV3(b, b.N, baseStats, stats, columnVectorGraphNativeSearchStats{
-		CandidateRows:              totalCandidateRows.Load(),
-		Candidates:                 totalCandidates.Load(),
-		Edges:                      totalEdges.Load(),
-		VisitedNodes:               totalVisitedNodes.Load(),
-		VisitedEdges:               totalVisitedEdges.Load(),
-		VectorBytesRead:            totalVectorBytesRead.Load(),
-		AdjacencyBytesRead:         totalAdjacencyBytesRead.Load(),
-		CandidateFetches:           totalCandidateFetches.Load(),
-		ExpansionFetches:           totalExpansionFetches.Load(),
-		ResultFetches:              totalResultFetches.Load(),
-		ScoreBatches:               totalScoreBatches.Load(),
-		OrdinalsGrouped:            totalOrdinalsGrouped.Load(),
-		BlockViewHits:              totalBlockViewHits.Load(),
-		BlockViewMisses:            totalBlockViewMisses.Load(),
-		BlockViewBuilds:            totalBlockViewBuilds.Load(),
-		AdjacencyExpansions:        totalAdjacencyExpansions.Load(),
-		AdjacencyScratchDecodes:    totalAdjacencyScratchDecodes.Load(),
-		AdjacencyDirectViews:       totalAdjacencyDirectViews.Load(),
-		VectorDirectViews:          totalVectorDirectViews.Load(),
-		VectorScratchDecodes:       totalVectorScratchDecodes.Load(),
-		TypedColumnMappedBytes:     totalTypedColumnMappedBytes.Load(),
-		TypedColumnHeapCopyBytes:   totalTypedColumnHeapCopyBytes.Load(),
-		TypedColumnDecodedBytes:    totalTypedColumnDecodedBytes.Load(),
-		TypedColumnActiveHandles:   totalTypedColumnActiveHandles.Load(),
-		TypedColumnDeniedResources: totalTypedColumnDeniedResources.Load(),
+		CandidateRows:                 totalCandidateRows.Load(),
+		Candidates:                    totalCandidates.Load(),
+		Edges:                         totalEdges.Load(),
+		VisitedNodes:                  totalVisitedNodes.Load(),
+		VisitedEdges:                  totalVisitedEdges.Load(),
+		VectorBytesRead:               totalVectorBytesRead.Load(),
+		AdjacencyBytesRead:            totalAdjacencyBytesRead.Load(),
+		CandidateFetches:              totalCandidateFetches.Load(),
+		ExpansionFetches:              totalExpansionFetches.Load(),
+		ResultFetches:                 totalResultFetches.Load(),
+		ScoreBatches:                  totalScoreBatches.Load(),
+		OrdinalsGrouped:               totalOrdinalsGrouped.Load(),
+		BlockViewHits:                 totalBlockViewHits.Load(),
+		BlockViewMisses:               totalBlockViewMisses.Load(),
+		BlockViewBuilds:               totalBlockViewBuilds.Load(),
+		AdjacencyExpansions:           totalAdjacencyExpansions.Load(),
+		AdjacencyScratchDecodes:       totalAdjacencyScratchDecodes.Load(),
+		AdjacencyDirectViews:          totalAdjacencyDirectViews.Load(),
+		AdjacencyMmapDirectViews:      totalAdjacencyMmapDirectViews.Load(),
+		AdjacencyHeapCopyTypedViews:   totalAdjacencyHeapCopyTypedViews.Load(),
+		VectorDirectViews:             totalVectorDirectViews.Load(),
+		VectorMmapDirectViews:         totalVectorMmapDirectViews.Load(),
+		VectorHeapCopyTypedViews:      totalVectorHeapCopyTypedViews.Load(),
+		VectorScratchDecodes:          totalVectorScratchDecodes.Load(),
+		VectorCertificationFailures:   totalVectorCertificationFailures.Load(),
+		VectorAbsoluteOffsetUnaligned: totalVectorAbsoluteOffsetUnaligned.Load(),
+		VectorActualPointerUnaligned:  totalVectorActualPointerUnaligned.Load(),
+		VectorStaleHandles:            totalVectorStaleHandles.Load(),
+		TypedColumnMappedBytes:        totalTypedColumnMappedBytes.Load(),
+		TypedColumnHeapCopyBytes:      totalTypedColumnHeapCopyBytes.Load(),
+		TypedColumnDecodedBytes:       totalTypedColumnDecodedBytes.Load(),
+		TypedColumnActiveHandles:      totalTypedColumnActiveHandles.Load(),
+		TypedColumnDeniedResources:    totalTypedColumnDeniedResources.Load(),
+		TypedColumnFallbacks:          totalTypedColumnFallbacks.Load(),
 	})
 }
 
@@ -1253,8 +1310,30 @@ func reportColumnGraphNativeSearchBenchMetricsV3(b *testing.B, n int, baseStats,
 	b.ReportMetric(float64(searchStats.AdjacencyExpansions)/float64(n), "adjacency_expansions/search")
 	b.ReportMetric(float64(searchStats.AdjacencyScratchDecodes)/float64(n), "adjacency_scratch_decodes/search")
 	b.ReportMetric(float64(searchStats.AdjacencyDirectViews)/float64(n), "adjacency_direct_views/search")
+	b.ReportMetric(float64(searchStats.AdjacencyMmapDirectViews)/float64(n), "adjacency_mmap_direct/search")
+	b.ReportMetric(float64(searchStats.AdjacencyHeapCopyTypedViews)/float64(n), "adjacency_heap_copy_typed_view/search")
 	b.ReportMetric(float64(searchStats.VectorDirectViews)/float64(n), "vector_direct_views/search")
+	b.ReportMetric(float64(searchStats.VectorMmapDirectViews)/float64(n), "vector_mmap_direct/search")
+	b.ReportMetric(float64(searchStats.VectorHeapCopyTypedViews)/float64(n), "vector_heap_copy_typed_view/search")
+	b.ReportMetric(float64(searchStats.VectorScratchDecodes)/float64(n), "vector_scratch_decode/search")
 	b.ReportMetric(float64(searchStats.VectorScratchDecodes)/float64(n), "vector_scratch_decodes/search")
+	b.ReportMetric(float64(searchStats.VectorCertificationFailures)/float64(n), "vector_certification_failures/search")
+	b.ReportMetric(float64(searchStats.VectorAbsoluteOffsetUnaligned)/float64(n), "vector_absolute_offset_unaligned/search")
+	b.ReportMetric(float64(searchStats.VectorActualPointerUnaligned)/float64(n), "vector_actual_pointer_unaligned/search")
+	b.ReportMetric(float64(searchStats.VectorStaleHandles)/float64(n), "vector_stale_handles/search")
+	if searchStats.VectorMmapDirectViews > 0 {
+		b.ReportMetric(1, "typed_column_vector_source_mmap")
+	}
+	if searchStats.VectorHeapCopyTypedViews > 0 {
+		b.ReportMetric(1, "typed_column_vector_source_heap_copy")
+	}
+	if searchStats.VectorScratchDecodes > 0 && searchStats.TypedColumnDecodedBytes > 0 {
+		b.ReportMetric(1, "typed_column_vector_source_scratch")
+	}
+	if searchStats.TypedColumnFallbacks > 0 {
+		b.ReportMetric(1, "typed_column_vector_source_fallback")
+	}
+	b.ReportMetric(float64(searchStats.TypedColumnFallbacks)/float64(n), "typed_column_vector_fallbacks/search")
 	b.ReportMetric(float64(searchStats.TypedColumnMappedBytes), "mapped_B")
 	b.ReportMetric(float64(searchStats.TypedColumnHeapCopyBytes), "heap_copy_B")
 	b.ReportMetric(float64(searchStats.TypedColumnDecodedBytes), "decoded_derived_B")

--- a/TreeDB/collections/column_vector_graph_typed_column.go
+++ b/TreeDB/collections/column_vector_graph_typed_column.go
@@ -524,8 +524,8 @@ func (c *Collection) acquireColumnVectorGraphTypedColumnDenseVectorValues(collec
 		return nil, nil, columnVectorGraphTypedColumnVectorOutcomeUnknown, "", err
 	}
 	if err := validateColumnVectorGraphTypedColumnHandleChecksum(handle, sectionChecksum); err != nil {
-		_ = handle.Release()
-		return nil, nil, columnVectorGraphTypedColumnVectorOutcomeUnknown, "", err
+		releaseErr := handle.Release()
+		return nil, nil, columnVectorGraphTypedColumnVectorOutcomeUnknown, "", errors.Join(err, releaseErr)
 	}
 	plan := typeddecode.DenseFloat32VectorPlan(certColumn, dims)
 	directReq := typeddecode.DirectViewColumnRequest{Plan: plan, Certification: certColumn, Rows: rows, PayloadBytes: section.Length, AssetOffset: int64(ref.Offset), HasAssetOffset: true}
@@ -535,8 +535,8 @@ func (c *Collection) acquireColumnVectorGraphTypedColumnDenseVectorValues(collec
 func columnVectorGraphTypedColumnDenseVectorValuesFromHandle(manager *mappedresource.Manager, handle *mappedresource.Handle, directReq typeddecode.DirectViewColumnRequest, rows, dims int) ([]float32, *mappedresource.Handle, columnVectorGraphTypedColumnVectorOutcome, typeddecode.Reason, error) {
 	expectedElements, err := typedColumnAdapterDenseElements(rows, dims)
 	if err != nil {
-		_ = handle.Release()
-		return nil, nil, columnVectorGraphTypedColumnVectorOutcomeUnknown, "", err
+		releaseErr := handle.Release()
+		return nil, nil, columnVectorGraphTypedColumnVectorOutcomeUnknown, "", errors.Join(err, releaseErr)
 	}
 	values, viewStatus := typeddecode.DenseFloat32VectorView(manager, handle, directReq, typeddecode.ResourceViewOptions{ExpectedElements: expectedElements, RequireMapped: true})
 	if viewStatus.Direct() {
@@ -551,12 +551,12 @@ func columnVectorGraphTypedColumnDenseVectorValuesFromHandle(manager *mappedreso
 		}
 		fallbackReason = heapStatus.Reason
 		if !typedColumnDenseDecodeFallbackAllowed(heapStatus) {
-			_ = handle.Release()
-			return nil, nil, columnVectorGraphTypedColumnVectorOutcomeUnknown, fallbackReason, errors.Join(firstErr, fmt.Errorf("float32 dense vector heap typed-view validation: %s", heapStatus.String()))
+			releaseErr := handle.Release()
+			return nil, nil, columnVectorGraphTypedColumnVectorOutcomeUnknown, fallbackReason, errors.Join(firstErr, fmt.Errorf("float32 dense vector heap typed-view validation: %s", heapStatus.String()), releaseErr)
 		}
 	} else if !typedColumnDenseDecodeFallbackAllowed(viewStatus) {
-		_ = handle.Release()
-		return nil, nil, columnVectorGraphTypedColumnVectorOutcomeUnknown, fallbackReason, firstErr
+		releaseErr := handle.Release()
+		return nil, nil, columnVectorGraphTypedColumnVectorOutcomeUnknown, fallbackReason, errors.Join(firstErr, releaseErr)
 	}
 	bytes := handle.Bytes()
 	decoded, decodeErr := typedcolumn.DecodeRawFloat32VectorPayload(nil, bytes, rows, dims)

--- a/TreeDB/collections/column_vector_graph_typed_column.go
+++ b/TreeDB/collections/column_vector_graph_typed_column.go
@@ -14,6 +14,28 @@ import (
 
 const columnVectorGraphTypedColumnVectorScopeID = "column-vector-graph-typed-column-vector"
 
+type columnVectorGraphTypedColumnVectorOutcome uint8
+
+const (
+	columnVectorGraphTypedColumnVectorOutcomeUnknown columnVectorGraphTypedColumnVectorOutcome = iota
+	columnVectorGraphTypedColumnVectorOutcomeMmapDirect
+	columnVectorGraphTypedColumnVectorOutcomeHeapCopyTypedView
+	columnVectorGraphTypedColumnVectorOutcomeScratchDecode
+)
+
+func (o columnVectorGraphTypedColumnVectorOutcome) String() string {
+	switch o {
+	case columnVectorGraphTypedColumnVectorOutcomeMmapDirect:
+		return "mmap_direct"
+	case columnVectorGraphTypedColumnVectorOutcomeHeapCopyTypedView:
+		return "heap_copy_typed_view"
+	case columnVectorGraphTypedColumnVectorOutcomeScratchDecode:
+		return "scratch_decode"
+	default:
+		return "unknown"
+	}
+}
+
 type columnVectorGraphTypedColumnVectorSource struct {
 	field  TypedStorageField
 	column typedColumnAdapterColumn
@@ -37,12 +59,13 @@ type columnVectorGraphTypedColumnVectorLocation struct {
 }
 
 type columnVectorGraphTypedColumnVectorPart struct {
-	generation uint64
-	partID     uint64
-	rows       int
-	values     []float32
-	direct     bool
-	handle     *mappedresource.Handle
+	generation     uint64
+	partID         uint64
+	rows           int
+	values         []float32
+	outcome        columnVectorGraphTypedColumnVectorOutcome
+	fallbackReason typeddecode.Reason
+	handle         *mappedresource.Handle
 }
 
 type columnVectorGraphTypedColumnPhysicalLocation struct {
@@ -344,21 +367,22 @@ func (c *Collection) loadColumnVectorGraphTypedColumnVectorPart(collection strin
 		return nil, 0, err
 	}
 	sectionChecksum := page.Checksum(sectionBytes)
-	values, handle, direct, scratchDecode, err := c.acquireColumnVectorGraphTypedColumnDenseVectorValues(collection, typedRef.Ref, image.Version, section, certColumn, sectionChecksum, typedRef.Rows, adapterColumn.Definition.FixedWidthElements, manager)
+	values, handle, outcome, fallbackReason, err := c.acquireColumnVectorGraphTypedColumnDenseVectorValues(collection, typedRef.Ref, image.Version, section, certColumn, sectionChecksum, typedRef.Rows, adapterColumn.Definition.FixedWidthElements, manager)
 	if err != nil {
 		return nil, 0, err
 	}
 	decodedBytes := uint64(image.ManifestBytes)
-	if scratchDecode {
+	if outcome == columnVectorGraphTypedColumnVectorOutcomeScratchDecode {
 		decodedBytes += uint64(len(values)) * 4
 	}
 	return &columnVectorGraphTypedColumnVectorPart{
-		generation: typedRef.Ref.Generation,
-		partID:     typedRef.Ref.PartID,
-		rows:       typedRef.Rows,
-		values:     values,
-		direct:     direct,
-		handle:     handle,
+		generation:     typedRef.Ref.Generation,
+		partID:         typedRef.Ref.PartID,
+		rows:           typedRef.Rows,
+		values:         values,
+		outcome:        outcome,
+		fallbackReason: fallbackReason,
+		handle:         handle,
 	}, decodedBytes, nil
 }
 
@@ -464,17 +488,17 @@ func columnVectorGraphTypedColumnDenseByteLen(rows, dims int) (int, error) {
 	return elements * 4, nil
 }
 
-func (c *Collection) acquireColumnVectorGraphTypedColumnDenseVectorValues(collection string, ref ColumnAssetRef, imageVersion uint16, section typedcolumn.ColumnPartImageSection, certColumn typedcolumn.ColumnPartLayoutContractColumn, sectionChecksum uint32, rows, dims int, manager *mappedresource.Manager) ([]float32, *mappedresource.Handle, bool, bool, error) {
+func (c *Collection) acquireColumnVectorGraphTypedColumnDenseVectorValues(collection string, ref ColumnAssetRef, imageVersion uint16, section typedcolumn.ColumnPartImageSection, certColumn typedcolumn.ColumnPartLayoutContractColumn, sectionChecksum uint32, rows, dims int, manager *mappedresource.Manager) ([]float32, *mappedresource.Handle, columnVectorGraphTypedColumnVectorOutcome, typeddecode.Reason, error) {
 	if manager == nil {
-		return nil, nil, false, false, errors.New("nil mappedresource manager")
+		return nil, nil, columnVectorGraphTypedColumnVectorOutcomeUnknown, "", errors.New("nil mappedresource manager")
 	}
 	path, err := columnAssetSegmentPath(c.db.ColumnAssetRootDir(), ref)
 	if err != nil {
-		return nil, nil, false, false, err
+		return nil, nil, columnVectorGraphTypedColumnVectorOutcomeUnknown, "", err
 	}
 	sectionOffset, err := columnVectorGraphTypedColumnSectionOffset(ref, section)
 	if err != nil {
-		return nil, nil, false, false, err
+		return nil, nil, columnVectorGraphTypedColumnVectorOutcomeUnknown, "", err
 	}
 	key := mappedresource.Key{
 		Class:      mappedresource.ClassTypedColumnAsset,
@@ -497,35 +521,53 @@ func (c *Collection) acquireColumnVectorGraphTypedColumnDenseVectorValues(collec
 	scope := mappedresource.Scope{Kind: mappedresource.ScopeColumnPartReader, ID: columnVectorGraphTypedColumnVectorScopeID, Collection: collection, Namespace: ref.Namespace, Generation: ref.Generation, Reason: "column_graph typed-column vector source"}
 	handle, err := manager.AcquireFileRange(key, scope, path, mappedresource.AcquireOptions{Reason: "column_graph typed-column dense vector section", ValidationMode: mappedresource.ValidationVerify, PreferMapped: true, AllowHeapCopy: true})
 	if err != nil {
-		return nil, nil, false, false, err
+		return nil, nil, columnVectorGraphTypedColumnVectorOutcomeUnknown, "", err
 	}
 	if err := validateColumnVectorGraphTypedColumnHandleChecksum(handle, sectionChecksum); err != nil {
 		_ = handle.Release()
-		return nil, nil, false, false, err
-	}
-	expectedElements, err := typedColumnAdapterDenseElements(rows, dims)
-	if err != nil {
-		_ = handle.Release()
-		return nil, nil, false, false, err
+		return nil, nil, columnVectorGraphTypedColumnVectorOutcomeUnknown, "", err
 	}
 	plan := typeddecode.DenseFloat32VectorPlan(certColumn, dims)
 	directReq := typeddecode.DirectViewColumnRequest{Plan: plan, Certification: certColumn, Rows: rows, PayloadBytes: section.Length, AssetOffset: int64(ref.Offset), HasAssetOffset: true}
+	return columnVectorGraphTypedColumnDenseVectorValuesFromHandle(manager, handle, directReq, rows, dims)
+}
+
+func columnVectorGraphTypedColumnDenseVectorValuesFromHandle(manager *mappedresource.Manager, handle *mappedresource.Handle, directReq typeddecode.DirectViewColumnRequest, rows, dims int) ([]float32, *mappedresource.Handle, columnVectorGraphTypedColumnVectorOutcome, typeddecode.Reason, error) {
+	expectedElements, err := typedColumnAdapterDenseElements(rows, dims)
+	if err != nil {
+		_ = handle.Release()
+		return nil, nil, columnVectorGraphTypedColumnVectorOutcomeUnknown, "", err
+	}
 	values, viewStatus := typeddecode.DenseFloat32VectorView(manager, handle, directReq, typeddecode.ResourceViewOptions{ExpectedElements: expectedElements, RequireMapped: true})
 	if viewStatus.Direct() {
-		return values, handle, true, false, nil
+		return values, handle, columnVectorGraphTypedColumnVectorOutcomeMmapDirect, "", nil
 	}
 	firstErr := fmt.Errorf("float32 dense vector direct-view validation: %s", viewStatus.String())
-	if !typedColumnDenseDecodeFallbackAllowed(viewStatus) {
+	fallbackReason := viewStatus.Reason
+	if viewStatus.Reason == typeddecode.ReasonHandleSourceUnsupported {
+		heapValues, heapStatus := typeddecode.DenseFloat32VectorView(manager, handle, directReq, typeddecode.ResourceViewOptions{ExpectedElements: expectedElements, RequireMapped: false})
+		if heapStatus.Direct() {
+			return heapValues, handle, columnVectorGraphTypedColumnVectorOutcomeHeapCopyTypedView, "", nil
+		}
+		fallbackReason = heapStatus.Reason
+		if !typedColumnDenseDecodeFallbackAllowed(heapStatus) {
+			_ = handle.Release()
+			return nil, nil, columnVectorGraphTypedColumnVectorOutcomeUnknown, fallbackReason, errors.Join(firstErr, fmt.Errorf("float32 dense vector heap typed-view validation: %s", heapStatus.String()))
+		}
+	} else if !typedColumnDenseDecodeFallbackAllowed(viewStatus) {
 		_ = handle.Release()
-		return nil, nil, false, false, errors.Join(firstErr, fmt.Errorf("float32 dense vector direct-view validation: %s", viewStatus.String()))
+		return nil, nil, columnVectorGraphTypedColumnVectorOutcomeUnknown, fallbackReason, firstErr
 	}
 	bytes := handle.Bytes()
 	decoded, decodeErr := typedcolumn.DecodeRawFloat32VectorPayload(nil, bytes, rows, dims)
-	_ = handle.Release()
+	releaseErr := handle.Release()
 	if decodeErr != nil {
-		return nil, nil, false, false, errors.Join(firstErr, fmt.Errorf("float32 dense vector direct-view validation: %s", viewStatus.String()), decodeErr)
+		return nil, nil, columnVectorGraphTypedColumnVectorOutcomeUnknown, fallbackReason, errors.Join(firstErr, decodeErr, releaseErr)
 	}
-	return decoded, nil, false, true, nil
+	if releaseErr != nil {
+		return nil, nil, columnVectorGraphTypedColumnVectorOutcomeUnknown, fallbackReason, errors.Join(firstErr, releaseErr)
+	}
+	return decoded, nil, columnVectorGraphTypedColumnVectorOutcomeScratchDecode, fallbackReason, nil
 }
 
 func validateColumnVectorGraphTypedColumnHandleChecksum(handle *mappedresource.Handle, want uint32) error {
@@ -552,9 +594,9 @@ func columnVectorGraphTypedColumnSectionOffset(ref ColumnAssetRef, section typed
 	return ref.Offset + int64(section.Offset), nil
 }
 
-func (r *columnVectorGraphPhysicalRowReader) typedVectorForOrdinal(ordinal int) ([]float32, bool, bool) {
+func (r *columnVectorGraphPhysicalRowReader) typedVectorForOrdinal(ordinal int) ([]float32, columnVectorGraphTypedColumnVectorOutcome, typeddecode.Reason, bool) {
 	if r == nil || r.typedVectorSource == nil {
-		return nil, false, false
+		return nil, columnVectorGraphTypedColumnVectorOutcomeUnknown, "", false
 	}
 	return r.typedVectorSource.vectorForOrdinal(ordinal)
 }
@@ -569,6 +611,7 @@ func (r *columnVectorGraphPhysicalRowReader) populateTypedColumnVectorSearchStat
 	}
 	if r.hasTypedColumnVectorFallback() {
 		stats.TypedColumnFallbacks = 1
+		stats.VectorCertificationFailures = 1
 		return
 	}
 	source := r.typedVectorSource
@@ -582,20 +625,20 @@ func (r *columnVectorGraphPhysicalRowReader) populateTypedColumnVectorSearchStat
 	stats.TypedColumnDeniedResources = source.deniedResources
 }
 
-func (s *columnVectorGraphTypedColumnVectorSource) vectorForOrdinal(ordinal int) ([]float32, bool, bool) {
+func (s *columnVectorGraphTypedColumnVectorSource) vectorForOrdinal(ordinal int) ([]float32, columnVectorGraphTypedColumnVectorOutcome, typeddecode.Reason, bool) {
 	if s == nil || s.closed || ordinal < 0 || ordinal >= len(s.locations) || s.dims <= 0 {
-		return nil, false, false
+		return nil, columnVectorGraphTypedColumnVectorOutcomeUnknown, "", false
 	}
 	loc := s.locations[ordinal]
 	if loc.part == nil || loc.rowIndex < 0 || loc.rowIndex >= loc.part.rows {
-		return nil, false, false
+		return nil, columnVectorGraphTypedColumnVectorOutcomeUnknown, "", false
 	}
 	start := loc.rowIndex * s.dims
 	end := start + s.dims
 	if start < 0 || end < start || end > len(loc.part.values) {
-		return nil, false, false
+		return nil, columnVectorGraphTypedColumnVectorOutcomeUnknown, "", false
 	}
-	return loc.part.values[start:end], loc.part.direct, true
+	return loc.part.values[start:end], loc.part.outcome, loc.part.fallbackReason, true
 }
 
 func (s *columnVectorGraphTypedColumnVectorSource) captureResourceStats() {
@@ -632,7 +675,8 @@ func (s *columnVectorGraphTypedColumnVectorSource) Close() error {
 			part.handle = nil
 		}
 		part.values = nil
-		part.direct = false
+		part.outcome = columnVectorGraphTypedColumnVectorOutcomeUnknown
+		part.fallbackReason = ""
 		part.rows = 0
 	}
 	for i := range s.locations {

--- a/TreeDB/collections/column_vector_graph_typed_column.go
+++ b/TreeDB/collections/column_vector_graph_typed_column.go
@@ -611,7 +611,6 @@ func (r *columnVectorGraphPhysicalRowReader) populateTypedColumnVectorSearchStat
 	}
 	if r.hasTypedColumnVectorFallback() {
 		stats.TypedColumnFallbacks = 1
-		stats.VectorCertificationFailures = 1
 		return
 	}
 	source := r.typedVectorSource

--- a/TreeDB/collections/column_vector_graph_typed_column_test.go
+++ b/TreeDB/collections/column_vector_graph_typed_column_test.go
@@ -3,14 +3,17 @@ package collections
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"os"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 	"github.com/snissn/gomap/TreeDB/internal/mappedresource"
 	"github.com/snissn/gomap/TreeDB/internal/typedcolumn"
+	"github.com/snissn/gomap/TreeDB/internal/typeddecode"
 	"github.com/snissn/gomap/TreeDB/page"
 )
 
@@ -69,19 +72,22 @@ func TestColumnVectorGraphTypedColumnVectorReaderParity1782(t *testing.T) {
 		t.Fatalf("SearchCosine: %v", err)
 	}
 	assertColumnGraphNativeSearchResultsV3(t, got, exactColumnGraphTopKForTest(t, rows, query, 2))
-	if stats.VectorDirectViews+stats.VectorScratchDecodes != stats.CandidateFetches {
-		t.Fatalf("stats=%+v want vector direct+scratch accounting to match candidate fetches", stats)
+	if stats.VectorMmapDirectViews+stats.VectorHeapCopyTypedViews+stats.VectorScratchDecodes != stats.CandidateFetches {
+		t.Fatalf("stats=%+v want vector mmap+heap-copy+scratch accounting to match candidate fetches", stats)
+	}
+	if stats.AdjacencyMmapDirectViews != 0 || stats.AdjacencyHeapCopyTypedViews != 0 {
+		t.Fatalf("stats=%+v want adjacency direct-view counters to remain deferred/zero", stats)
 	}
 	if columnGraphTypedColumnMmapDirectViewSupportedForTest() {
-		if stats.VectorDirectViews == 0 {
+		if stats.VectorMmapDirectViews == 0 || stats.VectorDirectViews != stats.VectorMmapDirectViews || stats.VectorHeapCopyTypedViews != 0 {
 			t.Fatalf("stats=%+v want typed-column vector mmap direct views on valid dense section", stats)
 		}
-		if stats.TypedColumnMappedBytes == 0 || stats.TypedColumnActiveHandles == 0 || stats.TypedColumnFallbacks != 0 {
+		if stats.TypedColumnMappedBytes == 0 || stats.TypedColumnActiveHandles == 0 || stats.TypedColumnFallbacks != 0 || stats.VectorCertificationFailures != 0 {
 			t.Fatalf("stats=%+v want live mappedresource-backed typed-column source without fallback", stats)
 		}
 	} else {
-		if stats.VectorDirectViews != 0 || stats.VectorScratchDecodes == 0 || stats.TypedColumnDecodedBytes == 0 || stats.TypedColumnFallbacks != 0 {
-			t.Fatalf("stats=%+v want platform scratch fallback from typed-column source", stats)
+		if stats.VectorMmapDirectViews != 0 || stats.VectorHeapCopyTypedViews+stats.VectorScratchDecodes == 0 || stats.TypedColumnFallbacks != 0 {
+			t.Fatalf("stats=%+v want non-mmap typed-column source fallback without row-asset fallback", stats)
 		}
 	}
 }
@@ -110,9 +116,9 @@ func TestColumnVectorGraphTypedColumnVectorCloseReleasesHandles1782(t *testing.T
 			_ = reader.Close()
 			t.Fatalf("stats before close=%+v want active typed-column mmap handles/bytes", stats)
 		}
-	} else if stats.ActiveHandles != 0 || stats.ActiveMappedBytes != 0 || stats.ActiveHeapCopyBytes != 0 || source.decodedDerivedBytes == 0 {
+	} else if stats.ActiveHandles == 0 && source.decodedDerivedBytes == 0 {
 		_ = reader.Close()
-		t.Fatalf("stats before close=%+v decoded=%d want released platform scratch fallback", stats, source.decodedDerivedBytes)
+		t.Fatalf("stats before close=%+v decoded=%d want active heap-copy typed view or scratch fallback evidence", stats, source.decodedDerivedBytes)
 	}
 	if err := reader.Close(); err != nil {
 		t.Fatalf("reader.Close: %v", err)
@@ -120,8 +126,8 @@ func TestColumnVectorGraphTypedColumnVectorCloseReleasesHandles1782(t *testing.T
 	if stats := source.manager.Stats(); stats.ActiveHandles != 0 || stats.ActiveMappedBytes != 0 || stats.ActiveHeapCopyBytes != 0 {
 		t.Fatalf("stats after close=%+v want released typed-column handles", stats)
 	}
-	if vector, direct, ok := source.vectorForOrdinal(0); ok || direct || vector != nil {
-		t.Fatalf("vectorForOrdinal after close vector=%v direct=%t ok=%t want no newly exposed stale slice", vector, direct, ok)
+	if vector, outcome, reason, ok := source.vectorForOrdinal(0); ok || outcome != columnVectorGraphTypedColumnVectorOutcomeUnknown || reason != "" || vector != nil {
+		t.Fatalf("vectorForOrdinal after close vector=%v outcome=%s reason=%s ok=%t want no newly exposed stale slice", vector, outcome, reason, ok)
 	}
 }
 
@@ -144,14 +150,11 @@ func TestColumnVectorGraphTypedColumnVectorPinKeyUsesTypedColumnAssetRef1782(t *
 		t.Fatalf("missing typed vector source")
 	}
 	pins := reader.typedVectorSource.manager.PinSummary()
-	if !columnGraphTypedColumnMmapDirectViewSupportedForTest() {
-		if len(pins) != 0 {
-			t.Fatalf("pins=%d want none when platform cannot provide mmap direct views", len(pins))
-		}
-		return
-	}
-	if len(pins) == 0 {
+	if columnGraphTypedColumnMmapDirectViewSupportedForTest() && len(pins) == 0 {
 		t.Fatal("typed vector source has no mappedresource pins")
+	}
+	if !columnGraphTypedColumnMmapDirectViewSupportedForTest() && len(pins) == 0 {
+		return
 	}
 	for _, pin := range pins {
 		ref, ok := columnAssetRefForMappedResourceKey(pin.Key)
@@ -206,11 +209,11 @@ func TestSearchVectorIndexTypedColumnVectorReopenGeneration1782(t *testing.T) {
 	assertColumnGraphSearchResponseLoadedV4(t, got, def.Name, 2)
 	assertVectorIndexSearchResultsV4(t, got.Results, exactColumnGraphTopKForTest(t, rows, query, 2), false)
 	if columnGraphTypedColumnMmapDirectViewSupportedForTest() {
-		if got.Stats.VectorDirectViews == 0 || got.Stats.TypedColumnMappedBytes == 0 || got.Stats.TypedColumnFallbacks != 0 {
+		if got.Stats.VectorMmapDirectViews == 0 || got.Stats.VectorDirectViews != got.Stats.VectorMmapDirectViews || got.Stats.TypedColumnMappedBytes == 0 || got.Stats.TypedColumnFallbacks != 0 {
 			t.Fatalf("stats=%+v want durable typed-column vector mmap direct reads after reopen", got.Stats)
 		}
-	} else if got.Stats.VectorDirectViews != 0 || got.Stats.VectorScratchDecodes == 0 || got.Stats.TypedColumnDecodedBytes == 0 || got.Stats.TypedColumnFallbacks != 0 {
-		t.Fatalf("stats=%+v want durable typed-column vector scratch fallback after reopen", got.Stats)
+	} else if got.Stats.VectorMmapDirectViews != 0 || got.Stats.VectorHeapCopyTypedViews+got.Stats.VectorScratchDecodes == 0 || got.Stats.TypedColumnFallbacks != 0 {
+		t.Fatalf("stats=%+v want durable typed-column vector non-mmap fallback after reopen", got.Stats)
 	}
 }
 
@@ -243,8 +246,8 @@ func TestColumnVectorGraphTypedColumnVectorCorruptPartFallsBack1782(t *testing.T
 		t.Fatalf("SearchCosine fallback: %v", err)
 	}
 	assertColumnGraphNativeSearchResultsV3(t, got, exactColumnGraphTopKForTest(t, rows, query, 2))
-	if stats.TypedColumnFallbacks != 1 || stats.VectorDirectViews != 0 || stats.VectorScratchDecodes == 0 {
-		t.Fatalf("stats=%+v want typed-column fallback to graph row vector scratch decodes", stats)
+	if stats.TypedColumnFallbacks != 1 || stats.VectorMmapDirectViews != 0 || stats.VectorHeapCopyTypedViews != 0 || stats.VectorScratchDecodes == 0 || stats.VectorCertificationFailures == 0 {
+		t.Fatalf("stats=%+v want typed-column certification fallback to graph row vector scratch decodes", stats)
 	}
 }
 
@@ -281,7 +284,7 @@ func TestColumnVectorGraphTypedColumnVectorNonColumnPartOwnerUsesGraphVectors178
 		t.Fatalf("SearchCosine non-column-part owner: %v", err)
 	}
 	assertColumnGraphNativeSearchResultsV3(t, got, exactColumnGraphTopKForTest(t, rows, query, 2))
-	if stats.TypedColumnFallbacks != 0 || stats.VectorDirectViews != 0 || stats.VectorScratchDecodes == 0 {
+	if stats.TypedColumnFallbacks != 0 || stats.VectorMmapDirectViews != 0 || stats.VectorHeapCopyTypedViews != 0 || stats.VectorScratchDecodes == 0 || stats.VectorCertificationFailures != 0 {
 		t.Fatalf("stats=%+v want ordinary graph row vector scratch decodes", stats)
 	}
 }
@@ -496,7 +499,7 @@ func TestColumnVectorGraphTypedColumnVectorMisalignedMappedSectionUsesScratchFal
 	if !ok {
 		t.Fatalf("missing layout certification for %q", adapterColumn.Definition.Name)
 	}
-	values, handle, direct, scratchDecode, err := (&Collection{db: d}).acquireColumnVectorGraphTypedColumnDenseVectorValues("docs", ref, image.Version, section, certColumn, page.Checksum(sectionBytes), imageRows, 3, manager)
+	values, handle, outcome, fallbackReason, err := (&Collection{db: d}).acquireColumnVectorGraphTypedColumnDenseVectorValues("docs", ref, image.Version, section, certColumn, page.Checksum(sectionBytes), imageRows, 3, manager)
 	if err != nil {
 		t.Fatalf("acquire dense vector values: %v", err)
 	}
@@ -509,8 +512,8 @@ func TestColumnVectorGraphTypedColumnVectorMisalignedMappedSectionUsesScratchFal
 	if handle != nil {
 		handleSource = handle.Source()
 	}
-	if direct || !scratchDecode || handle != nil || handleSource != mappedresource.Source("<nil>") {
-		t.Fatalf("direct=%v scratchDecode=%v handle=%v source=%s want scratch fallback, not mmap direct view", direct, scratchDecode, handle != nil, handleSource)
+	if outcome != columnVectorGraphTypedColumnVectorOutcomeScratchDecode || fallbackReason != typeddecode.ReasonAbsoluteOffsetUnaligned || handle != nil || handleSource != mappedresource.Source("<nil>") {
+		t.Fatalf("outcome=%s reason=%s handle=%v source=%s want absolute-offset scratch fallback, not mmap direct view", outcome, fallbackReason, handle != nil, handleSource)
 	}
 	if !float32SlicesEqual1782(values[:3], []float32{1, 0, 0}) || !float32SlicesEqual1782(values[3:], []float32{0, 1, 0}) {
 		t.Fatalf("values=%v want row-major typed vectors", values)
@@ -522,6 +525,272 @@ func TestColumnVectorGraphTypedColumnVectorMisalignedMappedSectionUsesScratchFal
 	if !columnGraphTypedColumnMmapDirectViewSupportedForTest() && stats.TotalHeapCopyBytes != uint64(section.Length) {
 		t.Fatalf("stats=%+v want one platform heap-copy fallback decode", stats)
 	}
+}
+
+func TestColumnVectorGraphTypedColumnVectorHeapCopyTypedViewCounters1898(t *testing.T) {
+	fixture := newColumnVectorGraphTypedColumnVectorViewFixture1898(t, 3, [][]float32{{1, 0, 0}, {0, 1, 0}})
+	manager := mappedresource.NewManager()
+	handle := columnVectorGraphTypedColumnVectorAcquireBytesHandle1898(t, manager, fixture, mappedresource.SourceHeapCopy, append([]byte(nil), fixture.sectionBytes...))
+	values, retained, outcome, fallbackReason, err := columnVectorGraphTypedColumnDenseVectorValuesFromHandle(manager, handle, fixture.directReq, fixture.rows, fixture.dims)
+	if err != nil {
+		t.Fatalf("columnVectorGraphTypedColumnDenseVectorValuesFromHandle heap copy: %v", err)
+	}
+	defer func() {
+		if retained != nil {
+			_ = retained.Release()
+		}
+	}()
+	if retained != handle || outcome != columnVectorGraphTypedColumnVectorOutcomeHeapCopyTypedView || fallbackReason != "" {
+		t.Fatalf("retained=%v handle=%v outcome=%s reason=%s want heap-copy typed view", retained != nil, handle != nil, outcome, fallbackReason)
+	}
+	if !float32SlicesEqual1782(values[:3], []float32{1, 0, 0}) || !float32SlicesEqual1782(values[3:], []float32{0, 1, 0}) {
+		t.Fatalf("values=%v want row-major typed vectors", values)
+	}
+	stats := manager.Stats()
+	if stats.ActiveHeapCopyBytes == 0 || stats.ActiveMappedBytes != 0 || stats.ActiveHandles == 0 {
+		t.Fatalf("stats=%+v want active heap-copy typed view handle, not mmap", stats)
+	}
+	var searchStats columnVectorGraphNativeSearchStats
+	recordColumnVectorGraphVectorSourceStats(&searchStats, outcome, fallbackReason)
+	if searchStats.VectorHeapCopyTypedViews != 1 || searchStats.VectorMmapDirectViews != 0 || searchStats.VectorDirectViews != 0 || searchStats.VectorScratchDecodes != 0 {
+		t.Fatalf("searchStats=%+v want heap-copy typed view separated from mmap direct wins", searchStats)
+	}
+}
+
+func TestColumnVectorGraphTypedColumnVectorActualPointerUnalignedUsesScratchFallback1898(t *testing.T) {
+	fixture := newColumnVectorGraphTypedColumnVectorViewFixture1898(t, 3, [][]float32{{1, 0, 0}, {0, 1, 0}})
+	manager := mappedresource.NewManager()
+	misaligned := append([]byte{0}, fixture.sectionBytes...)
+	handle := columnVectorGraphTypedColumnVectorAcquireBytesHandle1898(t, manager, fixture, mappedresource.SourceMapped, misaligned[1:])
+	values, retained, outcome, fallbackReason, err := columnVectorGraphTypedColumnDenseVectorValuesFromHandle(manager, handle, fixture.directReq, fixture.rows, fixture.dims)
+	if err != nil {
+		t.Fatalf("columnVectorGraphTypedColumnDenseVectorValuesFromHandle unaligned: %v", err)
+	}
+	if retained != nil || outcome != columnVectorGraphTypedColumnVectorOutcomeScratchDecode || fallbackReason != typeddecode.ReasonActualPointerUnaligned {
+		t.Fatalf("retained=%v outcome=%s reason=%s want actual-pointer scratch fallback", retained != nil, outcome, fallbackReason)
+	}
+	if !float32SlicesEqual1782(values[:3], []float32{1, 0, 0}) || !float32SlicesEqual1782(values[3:], []float32{0, 1, 0}) {
+		t.Fatalf("values=%v want row-major typed vectors", values)
+	}
+	stats := manager.Stats()
+	if stats.ActiveHandles != 0 || stats.ActiveMappedBytes != 0 || stats.DirectViewSuccesses != 0 || stats.DirectViewFailures == 0 {
+		t.Fatalf("stats=%+v want released scratch fallback with direct-view failure evidence", stats)
+	}
+	var searchStats columnVectorGraphNativeSearchStats
+	recordColumnVectorGraphVectorSourceStats(&searchStats, outcome, fallbackReason)
+	if searchStats.VectorScratchDecodes != 1 || searchStats.VectorActualPointerUnaligned != 1 || searchStats.VectorMmapDirectViews != 0 || searchStats.VectorHeapCopyTypedViews != 0 {
+		t.Fatalf("searchStats=%+v want actual-pointer unaligned scratch counter", searchStats)
+	}
+}
+
+func TestColumnVectorGraphTypedColumnVectorMisalignedSectionUsesScratchFallback1898(t *testing.T) {
+	fixture := newColumnVectorGraphTypedColumnVectorViewFixture1898(t, 3, [][]float32{{1, 0, 0}, {0, 1, 0}})
+	manager := mappedresource.NewManager()
+	handle := columnVectorGraphTypedColumnVectorAcquireBytesHandle1898(t, manager, fixture, mappedresource.SourceMapped, append([]byte(nil), fixture.sectionBytes...))
+	req := fixture.directReq
+	req.Certification.Section.Offset++
+	values, retained, outcome, fallbackReason, err := columnVectorGraphTypedColumnDenseVectorValuesFromHandle(manager, handle, req, fixture.rows, fixture.dims)
+	if err != nil {
+		t.Fatalf("columnVectorGraphTypedColumnDenseVectorValuesFromHandle misaligned section: %v", err)
+	}
+	if retained != nil || outcome != columnVectorGraphTypedColumnVectorOutcomeScratchDecode || fallbackReason != typeddecode.ReasonAbsoluteOffsetUnaligned {
+		t.Fatalf("retained=%v outcome=%s reason=%s want misaligned-section scratch fallback", retained != nil, outcome, fallbackReason)
+	}
+	if !float32SlicesEqual1782(values[:3], []float32{1, 0, 0}) || !float32SlicesEqual1782(values[3:], []float32{0, 1, 0}) {
+		t.Fatalf("values=%v want row-major typed vectors", values)
+	}
+	var searchStats columnVectorGraphNativeSearchStats
+	recordColumnVectorGraphVectorSourceStats(&searchStats, outcome, fallbackReason)
+	if searchStats.VectorScratchDecodes != 1 || searchStats.VectorAbsoluteOffsetUnaligned != 1 || searchStats.VectorMmapDirectViews != 0 || searchStats.VectorHeapCopyTypedViews != 0 {
+		t.Fatalf("searchStats=%+v want absolute-offset unaligned scratch counter", searchStats)
+	}
+}
+
+func TestColumnVectorGraphTypedColumnVectorParallelReadersIndependentHandles1898(t *testing.T) {
+	const (
+		rows = 96
+		dims = 16
+		m    = 8
+	)
+	input := columnGraphRebuildSyntheticRowsV2A(rows, dims)
+	_, d, col, def := openColumnGraphTypedColumnVectorTestCollection1782(t, dims, m, input)
+	defer func() { _ = d.Close() }()
+	status, err := col.RebuildVectorIndex(def.Name)
+	if err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	assertColumnGraphRebuildLoadedStatusV2A(t, status, def.Name)
+	query := append([]float32(nil), input[17].vector...)
+	workers := runtime.GOMAXPROCS(0)
+	if workers < 2 {
+		workers = 2
+	}
+	if workers > columnVectorGraphNativeSearchParallelBenchMaxWorkersV3 {
+		workers = columnVectorGraphNativeSearchParallelBenchMaxWorkersV3
+	}
+	readers := make([]*columnVectorGraphPhysicalRowReader, workers)
+	for i := range readers {
+		reader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
+		if err != nil {
+			t.Fatalf("open reader %d: %v", i, err)
+		}
+		defer func(reader *columnVectorGraphPhysicalRowReader) { _ = reader.Close() }(reader)
+		if reader.typedVectorSource == nil || reader.typedVectorSource.manager == nil {
+			t.Fatalf("reader %d missing typed-column vector source", i)
+		}
+		if i > 0 && reader.typedVectorSource.manager == readers[0].typedVectorSource.manager {
+			t.Fatalf("reader %d shares typed-column vector manager with reader 0", i)
+		}
+		resourceStats := reader.typedVectorSource.manager.Stats()
+		if columnGraphTypedColumnMmapDirectViewSupportedForTest() {
+			if resourceStats.ActiveMappedBytes == 0 || resourceStats.ActiveHandles == 0 {
+				t.Fatalf("reader %d resource stats=%+v want independent mmap handles", i, resourceStats)
+			}
+		} else if resourceStats.ActiveHandles == 0 && reader.typedVectorSource.decodedDerivedBytes == 0 {
+			t.Fatalf("reader %d resource stats=%+v decoded=%d want independent heap-copy or scratch source", i, resourceStats, reader.typedVectorSource.decodedDerivedBytes)
+		}
+		readers[i] = reader
+	}
+	want, _, err := readers[0].SearchCosine(query, columnVectorGraphNativeSearchOptions{TopK: 10, EfSearch: 64}, &columnVectorGraphNativeSearchScratch{})
+	if err != nil {
+		t.Fatalf("baseline SearchCosine: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	errs := make(chan string, len(readers))
+	for worker := range readers {
+		worker := worker
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			var scratch columnVectorGraphNativeSearchScratch
+			for i := 0; i < 25; i++ {
+				got, stats, err := readers[worker].SearchCosine(query, columnVectorGraphNativeSearchOptions{TopK: 10, EfSearch: 64}, &scratch)
+				if err != nil {
+					errs <- fmt.Sprintf("worker %d SearchCosine: %v", worker, err)
+					return
+				}
+				if mismatch := columnGraphNativeSearchResultsMismatchV3(got, want); mismatch != "" {
+					errs <- fmt.Sprintf("worker %d iteration %d: %s", worker, i, mismatch)
+					return
+				}
+				if stats.TypedColumnFallbacks != 0 || stats.AdjacencyMmapDirectViews != 0 || stats.AdjacencyHeapCopyTypedViews != 0 {
+					errs <- fmt.Sprintf("worker %d stats=%+v want typed vector source without adjacency direct-view claim", worker, stats)
+					return
+				}
+				if columnGraphTypedColumnMmapDirectViewSupportedForTest() {
+					if stats.VectorMmapDirectViews == 0 || stats.VectorHeapCopyTypedViews != 0 || stats.VectorScratchDecodes != 0 {
+						errs <- fmt.Sprintf("worker %d stats=%+v want mmap direct typed vectors", worker, stats)
+						return
+					}
+				} else if stats.VectorMmapDirectViews != 0 || stats.VectorHeapCopyTypedViews+stats.VectorScratchDecodes == 0 {
+					errs <- fmt.Sprintf("worker %d stats=%+v want non-mmap typed vector fallback", worker, stats)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Error(err)
+	}
+	if t.Failed() || len(readers) < 2 {
+		return
+	}
+	if err := readers[0].Close(); err != nil {
+		t.Fatalf("close reader 0: %v", err)
+	}
+	readers[0] = nil
+	var scratch columnVectorGraphNativeSearchScratch
+	got, _, err := readers[1].SearchCosine(query, columnVectorGraphNativeSearchOptions{TopK: 10, EfSearch: 64}, &scratch)
+	if err != nil {
+		t.Fatalf("reader 1 SearchCosine after reader 0 close: %v", err)
+	}
+	if mismatch := columnGraphNativeSearchResultsMismatchV3(got, want); mismatch != "" {
+		t.Fatalf("reader 1 after reader 0 close: %s", mismatch)
+	}
+}
+
+type columnVectorGraphTypedColumnVectorViewFixture1898 struct {
+	rows         int
+	dims         int
+	image        typedcolumn.ColumnPartImage
+	section      typedcolumn.ColumnPartImageSection
+	certColumn   typedcolumn.ColumnPartLayoutContractColumn
+	sectionBytes []byte
+	directReq    typeddecode.DirectViewColumnRequest
+}
+
+func newColumnVectorGraphTypedColumnVectorViewFixture1898(tb testing.TB, dims int, vectors [][]float32) columnVectorGraphTypedColumnVectorViewFixture1898 {
+	tb.Helper()
+	cfg, err := normalizeColumnStoreConfig("docs", columnGraphTypedColumnVectorStoreConfig1782(dims))
+	if err != nil {
+		tb.Fatalf("normalizeColumnStoreConfig: %v", err)
+	}
+	rows := typedColumnVectorDeclaredRows1782(tb, *cfg, vectors)
+	imageBytes, imageRows, err := buildTypedColumnPartImageForDeclaredRows(*cfg, 1, typedColumnPartAssetPartID, rows)
+	if err != nil {
+		tb.Fatalf("buildTypedColumnPartImageForDeclaredRows: %v", err)
+	}
+	image, err := typedcolumn.ParseColumnPartImage(imageBytes)
+	if err != nil {
+		tb.Fatalf("ParseColumnPartImage: %v", err)
+	}
+	_, adapterColumn, ok, err := columnVectorGraphTypedColumnVectorField(*cfg, "embedding", dims)
+	if err != nil || !ok {
+		tb.Fatalf("columnVectorGraphTypedColumnVectorField ok=%v err=%v", ok, err)
+	}
+	section, err := columnVectorGraphTypedColumnVectorSection(image, adapterColumn.Definition.Name)
+	if err != nil {
+		tb.Fatalf("columnVectorGraphTypedColumnVectorSection: %v", err)
+	}
+	sectionBytes, err := image.SectionBytes(section)
+	if err != nil {
+		tb.Fatalf("SectionBytes: %v", err)
+	}
+	certification, err := typedcolumn.CertifyColumnPartLayoutContractFromImage(image)
+	if err != nil {
+		tb.Fatalf("CertifyColumnPartLayoutContractFromImage: %v", err)
+	}
+	certColumn, ok := certification.Column(adapterColumn.Definition.Name)
+	if !ok {
+		tb.Fatalf("missing layout certification for %q", adapterColumn.Definition.Name)
+	}
+	plan := typeddecode.DenseFloat32VectorPlan(certColumn, dims)
+	directReq := typeddecode.DirectViewColumnRequest{Plan: plan, Certification: certColumn, Rows: imageRows, PayloadBytes: section.Length, AssetOffset: 0, HasAssetOffset: true}
+	if status := typeddecode.ValidateDirectViewColumn(directReq); !status.Direct() {
+		tb.Fatalf("ValidateDirectViewColumn: %s", status.String())
+	}
+	return columnVectorGraphTypedColumnVectorViewFixture1898{rows: imageRows, dims: dims, image: image, section: section, certColumn: certColumn, sectionBytes: sectionBytes, directReq: directReq}
+}
+
+func columnVectorGraphTypedColumnVectorAcquireBytesHandle1898(tb testing.TB, manager *mappedresource.Manager, fixture columnVectorGraphTypedColumnVectorViewFixture1898, source mappedresource.Source, data []byte) *mappedresource.Handle {
+	tb.Helper()
+	key := mappedresource.Key{
+		Class:      mappedresource.ClassTypedColumnAsset,
+		Namespace:  "test",
+		Kind:       string(ColumnAssetKindTCS1TypedColumnPart),
+		Generation: 1,
+		PartID:     typedColumnPartAssetPartID,
+		FileID:     1,
+		Offset:     0,
+		Length:     int64(len(data)),
+		Checksum:   uint64(page.Checksum(data)),
+		Version:    fixture.image.Version,
+		Encoding:   fixture.section.Encoding.String(),
+		Section: mappedresource.Section{
+			Kind:     string(fixture.section.Kind),
+			Category: string(fixture.section.Category),
+			Column:   fixture.section.Column,
+		},
+	}
+	scope := mappedresource.Scope{Kind: mappedresource.ScopeColumnPartReader, ID: columnVectorGraphTypedColumnVectorScopeID, Collection: "docs", Namespace: "test", Generation: 1, Reason: "column_graph typed-column vector test"}
+	handle, err := manager.AcquireBytes(key, scope, source, data, mappedresource.AcquireOptions{Reason: "column_graph typed-column vector test", ValidationMode: mappedresource.ValidationVerify})
+	if err != nil {
+		tb.Fatalf("AcquireBytes: %v", err)
+	}
+	return handle
 }
 
 func TestSearchVectorIndexColumnGraphL2RemainsFailClosed1782(t *testing.T) {
@@ -603,8 +872,8 @@ func assertTypedColumnVectorFallbackSearch1782(tb testing.TB, col *Collection, d
 		tb.Fatalf("SearchCosine fallback: %v", err)
 	}
 	assertColumnGraphNativeSearchResultsV3(tb, got, exactColumnGraphTopKForTest(tb, rows, query, 2))
-	if stats.TypedColumnFallbacks != 1 || stats.VectorDirectViews != 0 || stats.VectorScratchDecodes == 0 {
-		tb.Fatalf("stats=%+v want typed-column fallback to graph row vector scratch decodes", stats)
+	if stats.TypedColumnFallbacks != 1 || stats.VectorMmapDirectViews != 0 || stats.VectorHeapCopyTypedViews != 0 || stats.VectorScratchDecodes == 0 || stats.VectorCertificationFailures == 0 {
+		tb.Fatalf("stats=%+v want typed-column certification fallback to graph row vector scratch decodes", stats)
 	}
 }
 

--- a/TreeDB/collections/column_vector_graph_typed_column_test.go
+++ b/TreeDB/collections/column_vector_graph_typed_column_test.go
@@ -246,8 +246,8 @@ func TestColumnVectorGraphTypedColumnVectorCorruptPartFallsBack1782(t *testing.T
 		t.Fatalf("SearchCosine fallback: %v", err)
 	}
 	assertColumnGraphNativeSearchResultsV3(t, got, exactColumnGraphTopKForTest(t, rows, query, 2))
-	if stats.TypedColumnFallbacks != 1 || stats.VectorMmapDirectViews != 0 || stats.VectorHeapCopyTypedViews != 0 || stats.VectorScratchDecodes == 0 || stats.VectorCertificationFailures == 0 {
-		t.Fatalf("stats=%+v want typed-column certification fallback to graph row vector scratch decodes", stats)
+	if stats.TypedColumnFallbacks != 1 || stats.VectorMmapDirectViews != 0 || stats.VectorHeapCopyTypedViews != 0 || stats.VectorScratchDecodes == 0 {
+		t.Fatalf("stats=%+v want typed-column source fallback to graph row vector scratch decodes", stats)
 	}
 }
 
@@ -872,8 +872,8 @@ func assertTypedColumnVectorFallbackSearch1782(tb testing.TB, col *Collection, d
 		tb.Fatalf("SearchCosine fallback: %v", err)
 	}
 	assertColumnGraphNativeSearchResultsV3(tb, got, exactColumnGraphTopKForTest(tb, rows, query, 2))
-	if stats.TypedColumnFallbacks != 1 || stats.VectorMmapDirectViews != 0 || stats.VectorHeapCopyTypedViews != 0 || stats.VectorScratchDecodes == 0 || stats.VectorCertificationFailures == 0 {
-		tb.Fatalf("stats=%+v want typed-column certification fallback to graph row vector scratch decodes", stats)
+	if stats.TypedColumnFallbacks != 1 || stats.VectorMmapDirectViews != 0 || stats.VectorHeapCopyTypedViews != 0 || stats.VectorScratchDecodes == 0 {
+		tb.Fatalf("stats=%+v want typed-column source fallback to graph row vector scratch decodes", stats)
 	}
 }
 

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -354,7 +354,7 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/column_vector_graph_row_reader_test.go", classification: typedStorageLegacyDerived, matchingLines: 15, occurrences: 16},
 	{path: "TreeDB/collections/column_vector_graph_search_test.go", classification: typedStorageLegacyDerived, matchingLines: 1, occurrences: 1},
 	{path: "TreeDB/collections/column_vector_graph_typed_column.go", classification: typedStorageLegacyDerived, matchingLines: 6, occurrences: 6},
-	{path: "TreeDB/collections/column_vector_graph_typed_column_test.go", classification: typedStorageLegacyDerived, matchingLines: 21, occurrences: 24},
+	{path: "TreeDB/collections/column_vector_graph_typed_column_test.go", classification: typedStorageLegacyDerived, matchingLines: 23, occurrences: 26},
 	{path: "TreeDB/collections/command_wal_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 4, occurrences: 6},
 	{path: "TreeDB/collections/typed_column_adapter.go", classification: typedStorageLegacyCompatibility, matchingLines: 49, occurrences: 55},
 	{path: "TreeDB/collections/typed_column_adapter_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 222, occurrences: 230},

--- a/TreeDB/collections/vector_index_search.go
+++ b/TreeDB/collections/vector_index_search.go
@@ -188,13 +188,31 @@ type VectorIndexSearchStats struct {
 	// OpenPhysicalBytesRead is the absolute physical byte count read while opening the bound reader.
 	OpenPhysicalBytesRead int64 `json:"open_physical_bytes_read,omitempty"`
 
-	// VectorDirectViews is the per-search count of candidate vectors served from validated typed-column direct views.
+	// VectorDirectViews is a legacy alias for candidate vectors served from certified mmap direct views.
 	VectorDirectViews uint64 `json:"vector_direct_views,omitempty"`
+	// VectorMmapDirectViews is the per-search count of candidate vectors served from certified zero-copy mmap direct views.
+	VectorMmapDirectViews uint64 `json:"vector_mmap_direct,omitempty"`
+	// VectorHeapCopyTypedViews is the per-search count of candidate vectors served from typed views over heap-copy fallback buffers.
+	VectorHeapCopyTypedViews uint64 `json:"vector_heap_copy_typed_view,omitempty"`
 	// VectorScratchDecodes is the per-search count of candidate vectors served from scratch/fallback decoded vectors.
 	VectorScratchDecodes uint64 `json:"vector_scratch_decodes,omitempty"`
-	// AdjacencyDirectViews is the per-search count of adjacency payloads served from validated direct views.
+	// VectorCertificationFailures counts reason-specific vector source failures that are treated as certification/fail-closed fallbacks.
+	VectorCertificationFailures uint64 `json:"vector_certification_failures,omitempty"`
+	// VectorAbsoluteOffsetUnaligned counts typed-column vector fallback observations caused by absolute storage offset misalignment.
+	VectorAbsoluteOffsetUnaligned uint64 `json:"vector_absolute_offset_unaligned,omitempty"`
+	// VectorActualPointerUnaligned counts typed-column vector fallback observations caused by actual Go pointer misalignment.
+	VectorActualPointerUnaligned uint64 `json:"vector_actual_pointer_unaligned,omitempty"`
+	// VectorStaleHandles counts typed-column vector fallback observations caused by released/stale handles.
+	VectorStaleHandles uint64 `json:"vector_stale_handles,omitempty"`
+	// AdjacencyDirectViews is a legacy alias for adjacency payloads served from certified mmap direct views.
 	// It is expected to remain zero for current row-asset adjacency fallback paths until #1901.
 	AdjacencyDirectViews uint64 `json:"adjacency_direct_views,omitempty"`
+	// AdjacencyMmapDirectViews is the per-search count of adjacency payloads served from certified zero-copy mmap direct views.
+	// It is expected to remain zero for current row-asset adjacency fallback paths until #1901.
+	AdjacencyMmapDirectViews uint64 `json:"adjacency_mmap_direct,omitempty"`
+	// AdjacencyHeapCopyTypedViews is the per-search count of adjacency payloads served from typed heap-copy fallback views.
+	// It is expected to remain zero until adjacency direct-view work lands in #1901.
+	AdjacencyHeapCopyTypedViews uint64 `json:"adjacency_heap_copy_typed_view,omitempty"`
 	// AdjacencyScratchDecodes is the per-search count of adjacency payloads served from scratch/fallback decodes.
 	AdjacencyScratchDecodes uint64 `json:"adjacency_scratch_decodes,omitempty"`
 	// TypedColumnMappedBytes is the typed-column mapped-resource mapped byte total backing the bound vector source.
@@ -639,36 +657,44 @@ func deltaInt64(before, after int64) int64 {
 
 func vectorIndexSearchStatsFromInternal(searchStats columnVectorGraphNativeSearchStats, readerStats columnPhysicalRowReaderStats) VectorIndexSearchStats {
 	return VectorIndexSearchStats{
-		CandidateRows:              searchStats.CandidateRows,
-		Candidates:                 searchStats.Candidates,
-		Edges:                      searchStats.Edges,
-		VisitedNodes:               searchStats.VisitedNodes,
-		VisitedEdges:               searchStats.VisitedEdges,
-		VectorBytesRead:            searchStats.VectorBytesRead,
-		AdjacencyBytesRead:         searchStats.AdjacencyBytesRead,
-		CandidateFetches:           searchStats.CandidateFetches,
-		ExpansionFetches:           searchStats.ExpansionFetches,
-		ResultFetches:              searchStats.ResultFetches,
-		RowFetches:                 readerStats.RowFetches,
-		BatchFetches:               readerStats.BatchFetches,
-		RowsFetched:                readerStats.RowsFetched,
-		CacheHits:                  readerStats.CacheHits,
-		CacheMisses:                readerStats.CacheMisses,
-		DecodedBlocks:              readerStats.DecodedBlocks,
-		GranulesTouched:            readerStats.GranulesTouched,
-		PhysicalBytesRead:          readerStats.PhysicalBytesRead,
-		MaxResidentBytes:           readerStats.MaxResidentBytes,
-		OpenGranulesRead:           uint64(readerStats.OpenGranulesRead),
-		OpenPhysicalBytesRead:      readerStats.OpenPhysicalBytesRead,
-		VectorDirectViews:          searchStats.VectorDirectViews,
-		VectorScratchDecodes:       searchStats.VectorScratchDecodes,
-		AdjacencyDirectViews:       searchStats.AdjacencyDirectViews,
-		AdjacencyScratchDecodes:    searchStats.AdjacencyScratchDecodes,
-		TypedColumnMappedBytes:     searchStats.TypedColumnMappedBytes,
-		TypedColumnHeapCopyBytes:   searchStats.TypedColumnHeapCopyBytes,
-		TypedColumnDecodedBytes:    searchStats.TypedColumnDecodedBytes,
-		TypedColumnActiveHandles:   searchStats.TypedColumnActiveHandles,
-		TypedColumnDeniedResources: searchStats.TypedColumnDeniedResources,
-		TypedColumnFallbacks:       searchStats.TypedColumnFallbacks,
+		CandidateRows:                 searchStats.CandidateRows,
+		Candidates:                    searchStats.Candidates,
+		Edges:                         searchStats.Edges,
+		VisitedNodes:                  searchStats.VisitedNodes,
+		VisitedEdges:                  searchStats.VisitedEdges,
+		VectorBytesRead:               searchStats.VectorBytesRead,
+		AdjacencyBytesRead:            searchStats.AdjacencyBytesRead,
+		CandidateFetches:              searchStats.CandidateFetches,
+		ExpansionFetches:              searchStats.ExpansionFetches,
+		ResultFetches:                 searchStats.ResultFetches,
+		RowFetches:                    readerStats.RowFetches,
+		BatchFetches:                  readerStats.BatchFetches,
+		RowsFetched:                   readerStats.RowsFetched,
+		CacheHits:                     readerStats.CacheHits,
+		CacheMisses:                   readerStats.CacheMisses,
+		DecodedBlocks:                 readerStats.DecodedBlocks,
+		GranulesTouched:               readerStats.GranulesTouched,
+		PhysicalBytesRead:             readerStats.PhysicalBytesRead,
+		MaxResidentBytes:              readerStats.MaxResidentBytes,
+		OpenGranulesRead:              uint64(readerStats.OpenGranulesRead),
+		OpenPhysicalBytesRead:         readerStats.OpenPhysicalBytesRead,
+		VectorDirectViews:             searchStats.VectorDirectViews,
+		VectorMmapDirectViews:         searchStats.VectorMmapDirectViews,
+		VectorHeapCopyTypedViews:      searchStats.VectorHeapCopyTypedViews,
+		VectorScratchDecodes:          searchStats.VectorScratchDecodes,
+		VectorCertificationFailures:   searchStats.VectorCertificationFailures,
+		VectorAbsoluteOffsetUnaligned: searchStats.VectorAbsoluteOffsetUnaligned,
+		VectorActualPointerUnaligned:  searchStats.VectorActualPointerUnaligned,
+		VectorStaleHandles:            searchStats.VectorStaleHandles,
+		AdjacencyDirectViews:          searchStats.AdjacencyDirectViews,
+		AdjacencyMmapDirectViews:      searchStats.AdjacencyMmapDirectViews,
+		AdjacencyHeapCopyTypedViews:   searchStats.AdjacencyHeapCopyTypedViews,
+		AdjacencyScratchDecodes:       searchStats.AdjacencyScratchDecodes,
+		TypedColumnMappedBytes:        searchStats.TypedColumnMappedBytes,
+		TypedColumnHeapCopyBytes:      searchStats.TypedColumnHeapCopyBytes,
+		TypedColumnDecodedBytes:       searchStats.TypedColumnDecodedBytes,
+		TypedColumnActiveHandles:      searchStats.TypedColumnActiveHandles,
+		TypedColumnDeniedResources:    searchStats.TypedColumnDeniedResources,
+		TypedColumnFallbacks:          searchStats.TypedColumnFallbacks,
 	}
 }

--- a/TreeDB/collections/vector_index_search_test.go
+++ b/TreeDB/collections/vector_index_search_test.go
@@ -1396,6 +1396,77 @@ func BenchmarkOpenVectorIndexSearcherColumnGraphNativeReaderWithDocumentsExclude
 	reportVectorIndexSearchBenchMetricsV4(b, b.N, stats, false)
 }
 
+func BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderV4(b *testing.B) {
+	benchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderV4(b, false, DocumentFetchOptions{})
+}
+
+func BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderWithDocumentsV4(b *testing.B) {
+	benchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderV4(b, true, DocumentFetchOptions{})
+}
+
+func BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderWithDocumentsExcludeEmbedding1875(b *testing.B) {
+	benchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderV4(b, true, DocumentFetchOptions{ExcludePaths: []string{"embedding"}})
+}
+
+func benchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderV4(b *testing.B, includeDocuments bool, fetchOptions DocumentFetchOptions) {
+	b.Helper()
+	const (
+		rows     = 1024
+		dims     = 128
+		m        = 16
+		topK     = 10
+		efSearch = 128
+	)
+	input := columnGraphRebuildSyntheticRowsV2A(rows, dims)
+	_, d, col, def := openColumnGraphTypedColumnVectorTestCollection1782(b, dims, m, input)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		b.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	searcher, err := col.OpenVectorIndexSearcher(VectorIndexSearcherOptions{
+		IndexName:        def.Name,
+		MaxDecodedBlocks: 1,
+	})
+	if err != nil {
+		b.Fatalf("OpenVectorIndexSearcher: %v", err)
+	}
+	defer func() { _ = searcher.Close() }()
+	query := append([]float32(nil), input[37].vector...)
+	opts := VectorIndexSearcherSearchOptions{
+		Query:                query,
+		TopK:                 topK,
+		EfSearch:             efSearch,
+		IncludeDocuments:     includeDocuments,
+		DocumentFetchOptions: fetchOptions,
+	}
+	if _, err := searcher.Search(opts); err != nil {
+		b.Fatalf("warm Search: %v", err)
+	}
+	measuredStats, err := searcher.Search(opts)
+	if err != nil {
+		b.Fatalf("measure Search stats: %v", err)
+	}
+	stats := measuredStats.Stats
+	if stats.TypedColumnFallbacks != 0 || stats.VectorMmapDirectViews+stats.VectorHeapCopyTypedViews+stats.VectorScratchDecodes == 0 {
+		b.Fatalf("typed-column benchmark stats=%+v want active typed-column vector source counters", stats)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		got, err := searcher.Search(opts)
+		if err != nil {
+			b.Fatalf("Search: %v", err)
+		}
+		if includeDocuments {
+			vectorSearchBenchSinkOrdinalV4 += len(got.Results[0].Document)
+		} else {
+			vectorSearchBenchSinkOrdinalV4 += got.Results[0].Ordinal
+		}
+	}
+	b.StopTimer()
+	reportVectorIndexSearchBenchMetricsV4(b, b.N, stats, false)
+}
+
 func BenchmarkOpenVectorIndexSearcherColumnGraphNativeReaderSetupV6(b *testing.B) {
 	const (
 		rows = 1024
@@ -1464,8 +1535,38 @@ func reportVectorIndexSearchBenchMetricsV4(b *testing.B, n int, stats VectorInde
 	b.ReportMetric(float64(stats.CandidateFetches), "candidate_fetches/search")
 	b.ReportMetric(float64(stats.ExpansionFetches), "expansion_fetches/search")
 	b.ReportMetric(float64(stats.ResultFetches), "result_fetches/search")
+	b.ReportMetric(float64(stats.VectorDirectViews), "vector_direct_views/search")
+	b.ReportMetric(float64(stats.VectorMmapDirectViews), "vector_mmap_direct/search")
+	b.ReportMetric(float64(stats.VectorHeapCopyTypedViews), "vector_heap_copy_typed_view/search")
+	b.ReportMetric(float64(stats.VectorScratchDecodes), "vector_scratch_decode/search")
+	b.ReportMetric(float64(stats.VectorScratchDecodes), "vector_scratch_decodes/search")
+	b.ReportMetric(float64(stats.VectorCertificationFailures), "vector_certification_failures/search")
+	b.ReportMetric(float64(stats.VectorAbsoluteOffsetUnaligned), "vector_absolute_offset_unaligned/search")
+	b.ReportMetric(float64(stats.VectorActualPointerUnaligned), "vector_actual_pointer_unaligned/search")
+	b.ReportMetric(float64(stats.VectorStaleHandles), "vector_stale_handles/search")
 	b.ReportMetric(float64(stats.AdjacencyDirectViews), "adjacency_direct_views/search")
+	b.ReportMetric(float64(stats.AdjacencyMmapDirectViews), "adjacency_mmap_direct/search")
+	b.ReportMetric(float64(stats.AdjacencyHeapCopyTypedViews), "adjacency_heap_copy_typed_view/search")
+	b.ReportMetric(float64(stats.AdjacencyScratchDecodes), "adjacency_scratch_decode/search")
 	b.ReportMetric(float64(stats.AdjacencyScratchDecodes), "adjacency_scratch_decodes/search")
+	if stats.VectorMmapDirectViews > 0 {
+		b.ReportMetric(1, "typed_column_vector_source_mmap")
+	}
+	if stats.VectorHeapCopyTypedViews > 0 {
+		b.ReportMetric(1, "typed_column_vector_source_heap_copy")
+	}
+	if stats.VectorScratchDecodes > 0 && stats.TypedColumnDecodedBytes > 0 {
+		b.ReportMetric(1, "typed_column_vector_source_scratch")
+	}
+	if stats.TypedColumnFallbacks > 0 {
+		b.ReportMetric(1, "typed_column_vector_source_fallback")
+	}
+	b.ReportMetric(float64(stats.TypedColumnMappedBytes), "typed_column_mapped_B")
+	b.ReportMetric(float64(stats.TypedColumnHeapCopyBytes), "typed_column_heap_copy_B")
+	b.ReportMetric(float64(stats.TypedColumnDecodedBytes), "typed_column_decoded_derived_B")
+	b.ReportMetric(float64(stats.TypedColumnActiveHandles), "typed_column_active_handles")
+	b.ReportMetric(float64(stats.TypedColumnDeniedResources), "typed_column_denied_resources")
+	b.ReportMetric(float64(stats.TypedColumnFallbacks), "typed_column_vector_fallbacks/search")
 	b.ReportMetric(float64(stats.RowFetches), "row_fetches/search")
 	b.ReportMetric(float64(stats.BatchFetches), "batch_fetches/search")
 	b.ReportMetric(float64(stats.RowsFetched), "rows_fetched/search")


### PR DESCRIPTION
## Linked issues

- Closes #1898
- Refs parent #1886
- Defers physical row-asset direct views to #1897
- Defers adjacency direct views to #1901

## Start-phase graph-reader inventory

After #1896, `column_graph` already had a typed-column vector source for eligible `ColumnStoreValueFloat32Vector` / raw `float32_vector` typed-column-part payloads:

| Path | Main-after-#1896 status | This PR |
| --- | --- | --- |
| certified typed-column vector mmap view | implemented via typeddecode + mappedresource when the section is mmap-backed and certified | kept, counted as `vector_mmap_direct` |
| heap-copy typed view | possible resource source, but not separately consumed/accounted as a typed view | consumed and counted as `vector_heap_copy_typed_view`; not counted as mmap/zero-copy |
| scratch decode fallback | implemented for safe non-direct statuses | kept, counted as `vector_scratch_decode` with reason counters |
| stale/closed source lifetime | source close released handles and cleared retained slices | kept and tested with the richer outcome API |
| row-asset vector | graph row bytes copied/decoded into scratch | unchanged fallback/copy behavior |
| row-asset adjacency | direct-view gate is disabled; scratch decode remains current path | unchanged; adjacency mmap/heap typed counters remain zero |

## Contract validation and fallback behavior

- Typed-column vector source still validates writer certification, raw dense `float32_vector` type/encoding/compression, row counts, dims, section/block bounds, endian, absolute payload offset, checksum, actual pointer alignment, and handle lifetime before exposing typed views.
- Mmap-backed certified views increment `vector_mmap_direct` / legacy `vector_direct_views`.
- Heap-copy typed views are retained behind mappedresource handles and increment `vector_heap_copy_typed_view` only; they are not zero-copy mmap wins.
- Safe non-direct statuses decode into scratch and increment `vector_scratch_decode` plus reason counters (`vector_absolute_offset_unaligned`, `vector_actual_pointer_unaligned`, `vector_stale_handles`, `vector_certification_failures` where applicable).
- Typed-column source open failures increment `typed_column_vector_fallbacks` and fall back to existing graph row vectors; they do not automatically count as certification failures.
- Adjacency and physical row-asset direct views are not implemented or claimed in this PR.

## Tests run

- `go test ./TreeDB/collections -run 'TestColumnVectorGraphTypedColumn|TestSearchVectorIndexTypedColumn|TestColumnVectorGraphNativeSearchParallelReaders|TestColumnVectorGraphAdjacencySourceStats'`
- `go test ./TreeDB/internal/typeddecode ./TreeDB/internal/mappedresource ./TreeDB/collections`
- `go test -gcflags=all=-d=checkptr=2 ./TreeDB/collections -run 'TestColumnVectorGraphTypedColumnVector(ReaderParity|CloseReleasesHandles|PinKeyUsesTypedColumnAssetRef|MisalignedMappedSectionUsesScratchFallback|HeapCopyTypedViewCounters|ActualPointerUnalignedUsesScratchFallback|MisalignedSectionUsesScratchFallback|ParallelReadersIndependentHandles|CorruptPartFallsBack|NonColumnPartOwnerUsesGraphVectors)'`
- `go test ./...`

Coverage themes: certified mmap direct, heap-copy typed view, scratch decode fallback, misaligned typed-column section/ref, stale/closed source, corrupt/certification fallback, parallel independent readers/handles, source-open fallback counter separation, release-error propagation on aborted acquisitions, and no adjacency/row-asset direct-view claim.

## Benchmarks

Hardware/context: Apple M3, darwin/arm64, Go test benchmark harness, latest PR head `d62d40d06110793627062ebcbdeda1a29a21a6f7`. Commands:

```sh
go test ./TreeDB/collections -run '^$' -bench '^BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReader(V4|WithDocumentsV4|WithDocumentsExcludeEmbedding1875)$' -benchtime=100ms -count=1 -benchmem

go test ./TreeDB/collections -run '^$' -bench '^BenchmarkColumnVectorGraphNativeSearchCosine(TypedColumnProduction8192V3|ParallelTypedColumnProduction8192V3)$' -benchtime=100ms -count=1 -benchmem
```

| Benchmark | Docs/projection | Rows | Workers | ns/op | ops/sec | B/op | allocs/op | typed-column source | vector_mmap_direct/search | vector_heap_copy_typed_view/search | vector_scratch_decode/search | vector_certification_failures/search | adjacency_mmap_direct/search | adjacency_heap_copy_typed_view/search | adjacency_scratch_decode/search |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| `BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderV4` | none | 1,024 | 1 | 13,033 | 76,728 | 784 | 2 | mmap | 164 | 0 | 0 | 0 | 0 | 0 | 104 |
| `BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderWithDocumentsV4` | full docs | 1,024 | 1 | 102,872 | 9,721 | 95,041 | 345 | mmap | 164 | 0 | 0 | 0 | 0 | 0 | 104 |
| `BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderWithDocumentsExcludeEmbedding1875` | projected docs excluding embedding | 1,024 | 1 | 36,791 | 27,181 | 25,120 | 308 | mmap | 164 | 0 | 0 | 0 | 0 | 0 | 104 |
| `BenchmarkColumnVectorGraphNativeSearchCosineTypedColumnProduction8192V3` | graph only | 8,192 | 1 | 13,590 | 73,584 | 0 | 0 | mmap | 182 | 0 | 0 | 0 | 0 | 0 | 108 |
| `BenchmarkColumnVectorGraphNativeSearchCosineParallelTypedColumnProduction8192V3` | graph only | 8,192 | 8 | 2,650 | 377,358 | 0 | 0 | mmap | 182 | 0 | 0 | 0 | 0 | 0 | 108 |

## AI review status

- Internal subagent review: PASS/no blocking findings on the scoped #1898 patch.
- Codex: requested after latest push; latest visible response found no major issues.
- Copilot: requested after latest push; latest visible review generated no new comments.
- CodeRabbit: requested after latest push; earlier two actionable comments were fixed/resolved (source-open fallback certification counter separation and release-error propagation).

## Risks / deferrals

- Public stats gain new additive fields; existing legacy direct/scratch fields remain populated.
- Heap-copy typed views retain heap-copy handles until reader close when mmap is unavailable; they are intentionally counted separately from mmap.
- Physical row-asset direct views remain deferred to #1897.
- `ColumnStoreValueAdjacencyList` direct views remain deferred to #1901; current counters should show adjacency mmap/heap typed as zero.

## Merge status

Not merged by this PR/agent.
