### PR TITLE
Land raw uint32 offsets-list typed-column writer with fallback decode-path optimizations

### DIFF
--- a/TreeDB/collections/typed_column_adapter.go
+++ b/TreeDB/collections/typed_column_adapter.go
@@ -100,7 +100,7 @@ func typedColumnAdapterTypeMatrix() []typedColumnAdapterTypeMapping {
 		{ValueType: ColumnStoreValueDouble, Status: typedColumnAdapterRepresented, ColumnType: typedcolumn.ColumnTypeInt64, Encoding: typedcolumn.EncodingRawInt64, Reason: "default compatibility carrier stores raw int64 float64 bit patterns; fixed_width_encoding little_endian selects native raw_float64"},
 		{ValueType: ColumnStoreValueString, Status: typedColumnAdapterRepresented, ColumnType: typedcolumn.ColumnTypeLowCardinalityCode, Encoding: typedcolumn.EncodingLowCardinalityUint32, Reason: "stored as dictionary codes with dictionary section metadata"},
 		{ValueType: ColumnStoreValueFloat32Vector, Status: typedColumnAdapterRepresented, ColumnType: typedcolumn.ColumnTypeFloat32Vector, Encoding: typedcolumn.EncodingRawFloat32Vector, Reason: "stored as fixed-dim dense little-endian float32 sections"},
-		{ValueType: ColumnStoreValueAdjacencyList, Status: typedColumnAdapterRepresented, ColumnType: typedcolumn.ColumnTypeAdjacencyList, Encoding: typedcolumn.EncodingRawUint32Dense, Reason: "stored as fixed-degree dense little-endian uint32 sections by default; explicit adjacency_layout uint32_offsets_list is the #1914 variable-list target but writer support is deferred"},
+		{ValueType: ColumnStoreValueAdjacencyList, Status: typedColumnAdapterRepresented, ColumnType: typedcolumn.ColumnTypeAdjacencyList, Encoding: typedcolumn.EncodingRawUint32Dense, Reason: "stored as fixed-degree dense little-endian uint32 sections by default; explicit adjacency_layout uint32_offsets_list selects the #1915 safe offsets-list writer/fallback reader"},
 	}
 }
 
@@ -200,7 +200,8 @@ func typedColumnAdapterMapField(field TypedStorageField) (typedColumnAdapterColu
 	case ColumnStoreValueAdjacencyList:
 		switch field.AdjacencyLayout {
 		case ColumnAdjacencyListLayoutUint32OffsetsList:
-			return typedColumnAdapterColumn{}, fmt.Errorf("%w: adjacency_list field %q adjacency_layout %q writer support deferred to #1915", errTypedColumnAdapterUnsupportedType, field.Path, field.AdjacencyLayout)
+			def.Encoding = typedcolumn.EncodingRawUint32OffsetsList
+			def.FixedWidthElements = 0
 		case ColumnAdjacencyListLayoutFixedDense:
 			if field.AdjacencyDegree <= 0 {
 				return typedColumnAdapterColumn{}, fmt.Errorf("collections: typed-column adapter field %q adjacency_list requires positive adjacency_degree", field.Path)
@@ -305,14 +306,21 @@ func buildTypedColumnAdapterPart(opts typedColumnAdapterOptions, rows []typedCol
 			}
 			batch.Float32Vectors[column.Definition.Name] = make([]float32, elements)
 		case typedcolumn.ColumnTypeAdjacencyList:
-			if batch.Uint32Vectors == nil {
-				batch.Uint32Vectors = make(map[string][]uint32)
+			if column.Definition.Encoding == typedcolumn.EncodingRawUint32OffsetsList {
+				if batch.Uint32OffsetsLists == nil {
+					batch.Uint32OffsetsLists = make(map[string]typedcolumn.RawUint32OffsetsList)
+				}
+				batch.Uint32OffsetsLists[column.Definition.Name] = typedcolumn.RawUint32OffsetsList{Rows: len(rows), Offsets: make([]uint64, len(rows)+1)}
+			} else {
+				if batch.Uint32Vectors == nil {
+					batch.Uint32Vectors = make(map[string][]uint32)
+				}
+				elements, err := typedColumnAdapterDenseElements(len(rows), column.Definition.FixedWidthElements)
+				if err != nil {
+					return nil, err
+				}
+				batch.Uint32Vectors[column.Definition.Name] = make([]uint32, elements)
 			}
-			elements, err := typedColumnAdapterDenseElements(len(rows), column.Definition.FixedWidthElements)
-			if err != nil {
-				return nil, err
-			}
-			batch.Uint32Vectors[column.Definition.Name] = make([]uint32, elements)
 		default:
 			batch.Columns[column.Definition.Name] = make([]int64, len(rows))
 			if column.Field.Nullable {
@@ -352,7 +360,14 @@ func buildTypedColumnAdapterPart(opts typedColumnAdapterOptions, rows []typedCol
 					return nil, fmt.Errorf("collections: typed-column adapter row %d field %q: %w", rowIdx, column.Field.Path, err)
 				}
 			case typedcolumn.ColumnTypeAdjacencyList:
-				if err := encodeTypedColumnAdapterAdjacencyListValue(batch.Uint32Vectors[column.Definition.Name], rowIdx, column, value); err != nil {
+				if column.Definition.Encoding == typedcolumn.EncodingRawUint32OffsetsList {
+					list := batch.Uint32OffsetsLists[column.Definition.Name]
+					updated, err := encodeTypedColumnAdapterAdjacencyOffsetsListValue(list, rowIdx, column, value)
+					if err != nil {
+						return nil, fmt.Errorf("collections: typed-column adapter row %d field %q: %w", rowIdx, column.Field.Path, err)
+					}
+					batch.Uint32OffsetsLists[column.Definition.Name] = updated
+				} else if err := encodeTypedColumnAdapterAdjacencyListValue(batch.Uint32Vectors[column.Definition.Name], rowIdx, column, value); err != nil {
 					return nil, fmt.Errorf("collections: typed-column adapter row %d field %q: %w", rowIdx, column.Field.Path, err)
 				}
 			default:
@@ -657,6 +672,19 @@ func (p *typedColumnAdapterPart) scanColumnValues(columnName string) ([]columnDe
 		return out, nil
 	}
 	if column.Field.ValueType == ColumnStoreValueAdjacencyList {
+		if column.Definition.Encoding == typedcolumn.EncodingRawUint32OffsetsList {
+			list, err := p.Part.Uint32OffsetsListColumn(column.Definition.Name, nil, nil)
+			if err != nil {
+				return nil, err
+			}
+			out := make([]columnDeclaredValue, list.Rows)
+			for i := 0; i < list.Rows; i++ {
+				start := int(list.Offsets[i])
+				end := int(list.Offsets[i+1])
+				out[i] = columnDeclaredValue{Type: column.Field.ValueType, Present: true, AdjacencyList: append([]uint32{}, list.Values[start:end]...)}
+			}
+			return out, nil
+		}
 		matrix, err := p.Part.DenseUint32Column(column.Definition.Name, nil)
 		if err != nil {
 			return nil, err
@@ -950,6 +978,24 @@ func encodeTypedColumnAdapterAdjacencyListValue(dst []uint32, rowIdx int, column
 	}
 	copy(dst[start:start+degree], value.AdjacencyList)
 	return nil
+}
+
+func encodeTypedColumnAdapterAdjacencyOffsetsListValue(list typedcolumn.RawUint32OffsetsList, rowIdx int, column typedColumnAdapterColumn, value columnDeclaredValue) (typedcolumn.RawUint32OffsetsList, error) {
+	if err := validateTypedColumnAdapterDeclaredValue(column, value); err != nil {
+		return typedcolumn.RawUint32OffsetsList{}, err
+	}
+	if column.Definition.Encoding != typedcolumn.EncodingRawUint32OffsetsList || column.Definition.FixedWidthElements != 0 {
+		return typedcolumn.RawUint32OffsetsList{}, fmt.Errorf("adjacency_list offsets-list column encoding=%s fixed_width_elements=%d", column.Definition.Encoding, column.Definition.FixedWidthElements)
+	}
+	if rowIdx < 0 || rowIdx >= list.Rows || len(list.Offsets) != list.Rows+1 {
+		return typedcolumn.RawUint32OffsetsList{}, fmt.Errorf("adjacency_list offsets-list row %d outside rows=%d offsets=%d", rowIdx, list.Rows, len(list.Offsets))
+	}
+	if uint64(len(list.Values)) > uint64(int(^uint(0)>>1))-uint64(len(value.AdjacencyList)) {
+		return typedcolumn.RawUint32OffsetsList{}, fmt.Errorf("adjacency_list offsets-list values overflow")
+	}
+	list.Values = append(list.Values, value.AdjacencyList...)
+	list.Offsets[rowIdx+1] = uint64(len(list.Values))
+	return list, nil
 }
 
 func typedColumnAdapterDenseElements(rows int, elementsPerRow int) (int, error) {

--- a/TreeDB/collections/typed_column_adapter_test.go
+++ b/TreeDB/collections/typed_column_adapter_test.go
@@ -366,6 +366,23 @@ func TestTypedColumnAdapterRoundTripAdjacencyList(t *testing.T) {
 	}
 }
 
+func TestTypedColumnAdapterRoundTripAdjacencyOffsetsList1915(t *testing.T) {
+	want := [][]uint32{{}, {7, 8}, {}, {9, 10, 11}}
+	values := make([]columnDeclaredValue, len(want))
+	for i, v := range want {
+		values[i] = columnDeclaredValue{Type: ColumnStoreValueAdjacencyList, Present: true, AdjacencyList: v}
+	}
+	field := typedColumnAdapterField("neighbors", ColumnStoreValueAdjacencyList)
+	field.AdjacencyLayout = ColumnAdjacencyListLayoutUint32OffsetsList
+	field.AdjacencyDegree = 0
+	got := typedColumnAdapterRoundTrip(t, field, values)
+	for i := range want {
+		if !slices.Equal(got[i].AdjacencyList, want[i]) {
+			t.Fatalf("offsets-list adjacency[%d]=%v want %v all=%+v", i, got[i].AdjacencyList, want[i], got)
+		}
+	}
+}
+
 func TestTypedColumnAdapterAdjacencyRequiresDegreeAndLength(t *testing.T) {
 	field := typedColumnAdapterField("neighbors", ColumnStoreValueAdjacencyList)
 	if _, err := typedColumnAdapterMapField(field); err == nil || !strings.Contains(err.Error(), "adjacency_degree") {
@@ -1067,12 +1084,16 @@ func TestTypedColumnAdapterVectorAdjacencyRepresented(t *testing.T) {
 	}
 }
 
-func TestTypedColumnAdapterAdjacencyOffsetsListSelectorFailsClosedUntil1915(t *testing.T) {
+func TestTypedColumnAdapterAdjacencyOffsetsListSelectorSupported1915(t *testing.T) {
 	field := typedColumnAdapterField("neighbors", ColumnStoreValueAdjacencyList)
 	field.AdjacencyLayout = ColumnAdjacencyListLayoutUint32OffsetsList
 	field.AdjacencyDegree = 0
-	if _, err := typedColumnAdapterMapField(field); !errors.Is(err, errTypedColumnAdapterUnsupportedType) || !strings.Contains(err.Error(), "#1915") {
-		t.Fatalf("typedColumnAdapterMapField offsets-list err=%v want #1915 unsupported", err)
+	column, err := typedColumnAdapterMapField(field)
+	if err != nil {
+		t.Fatalf("typedColumnAdapterMapField offsets-list: %v", err)
+	}
+	if column.Definition.Encoding != typedcolumn.EncodingRawUint32OffsetsList || column.Definition.FixedWidthElements != 0 {
+		t.Fatalf("offsets-list column definition=%+v", column.Definition)
 	}
 }
 

--- a/TreeDB/collections/typed_column_direct_view_contract.go
+++ b/TreeDB/collections/typed_column_direct_view_contract.go
@@ -129,7 +129,7 @@ func typedColumnDirectViewClassificationForAdjacencyLayout(valueType ColumnStore
 			base.OffsetsAlignment = 8
 			base.ValuesElementSize = 4
 			base.ValuesAlignment = 4
-			base.Reason = "#1914 selected typed-column ColumnStoreValueAdjacencyList raw_uint32_offsets_list: uint64 offsets plus uint32 values; writer/direct-view/search runtime remains deferred to #1915+"
+			base.Reason = "#1915 typed-column ColumnStoreValueAdjacencyList raw_uint32_offsets_list uses uint64 offsets plus uint32 values; unsafe direct-view/search runtime remains deferred to #1916+"
 			base.FollowUpIssues = []int{1901, 1915, 1916, 1917, 1919}
 		case typedColumnDirectViewAdjacencyLayoutRawUint32Dense:
 			base.RequiresElementsPerRow = true

--- a/TreeDB/collections/typed_column_offsets_list_test.go
+++ b/TreeDB/collections/typed_column_offsets_list_test.go
@@ -1,0 +1,89 @@
+package collections
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+)
+
+func TestTypedColumnAdjacencyOffsetsListReopen1915(t *testing.T) {
+	dir := t.TempDir()
+	if err := backenddb.SaveFormatConfig(dir, backenddb.FormatConfig{RequiredFeatures: []string{backenddb.RequiredFeatureCommandWALV1}}); err != nil {
+		t.Fatalf("SaveFormatConfig: %v", err)
+	}
+	d, err := backenddb.Open(backenddb.Options{Dir: dir, DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatalf("Open DB: %v", err)
+	}
+	cfg := &ColumnStoreConfig{
+		Enabled:         true,
+		RetainedPayload: ColumnRetainedPayloadNonColumn,
+		Reconstruction:  ColumnReconstructionRetainedPayloadAndColumns,
+		Columns: []ColumnStoreColumn{{
+			Name:            "neighbors",
+			Path:            "neighbors",
+			Owner:           TypedStorageOwnerColumnPart,
+			ValueType:       ColumnStoreValueAdjacencyList,
+			AdjacencyLayout: ColumnAdjacencyListLayoutUint32OffsetsList,
+		}},
+	}
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "graphs", Options: CollectionOptions{ColumnStore: cfg}}); err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	col, err := mgr.OpenCollection("graphs")
+	if err != nil {
+		t.Fatalf("OpenCollection: %v", err)
+	}
+	ids := [][]byte{[]byte("r0"), []byte("r1"), []byte("r2"), []byte("r3")}
+	docs := [][]byte{
+		[]byte(`{"neighbors":[],"label":"zero"}`),
+		[]byte(`{"neighbors":[7,8],"label":"two"}`),
+		[]byte(`{"neighbors":[],"label":"empty"}`),
+		[]byte(`{"neighbors":[9,10,11],"label":"three"}`),
+	}
+	if _, err := col.InsertBatch(ids, docs); err != nil {
+		t.Fatalf("InsertBatch: %v", err)
+	}
+	if err := d.Checkpoint(); err != nil {
+		t.Fatalf("Checkpoint: %v", err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	reopened, err := backenddb.Open(backenddb.Options{Dir: dir, DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatalf("Open reopened DB: %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+	reopenedCol, err := NewCollectionManager(reopened).OpenCollection("graphs")
+	if err != nil {
+		t.Fatalf("OpenCollection reopened: %v", err)
+	}
+	want := map[string][]any{
+		"r0": []any{},
+		"r1": []any{float64(7), float64(8)},
+		"r2": []any{},
+		"r3": []any{float64(9), float64(10), float64(11)},
+	}
+	for _, id := range ids {
+		gotRaw, err := reopenedCol.Get(id)
+		if err != nil {
+			t.Fatalf("Get %s: %v", id, err)
+		}
+		var got map[string]any
+		if err := json.Unmarshal(gotRaw, &got); err != nil {
+			t.Fatalf("json %s: %v raw=%s", id, err, gotRaw)
+		}
+		neighbors, ok := got["neighbors"].([]any)
+		if !ok {
+			t.Fatalf("neighbors for %s = %#v raw=%s", id, got["neighbors"], gotRaw)
+		}
+		if !reflect.DeepEqual(neighbors, want[string(id)]) {
+			t.Fatalf("neighbors for %s = %#v want %#v raw=%s", id, neighbors, want[string(id)], gotRaw)
+		}
+	}
+}

--- a/TreeDB/collections/typed_column_offsets_list_test.go
+++ b/TreeDB/collections/typed_column_offsets_list_test.go
@@ -17,6 +17,11 @@ func TestTypedColumnAdjacencyOffsetsListReopen1915(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Open DB: %v", err)
 	}
+	t.Cleanup(func() {
+		if d != nil {
+			_ = d.Close()
+		}
+	})
 	cfg := &ColumnStoreConfig{
 		Enabled:         true,
 		RetainedPayload: ColumnRetainedPayloadNonColumn,
@@ -53,6 +58,7 @@ func TestTypedColumnAdjacencyOffsetsListReopen1915(t *testing.T) {
 	if err := d.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
 	}
+	d = nil
 
 	reopened, err := backenddb.Open(backenddb.Options{Dir: dir, DisableBackgroundPrune: true})
 	if err != nil {

--- a/TreeDB/collections/typed_storage_layout.go
+++ b/TreeDB/collections/typed_storage_layout.go
@@ -535,7 +535,9 @@ func (l TypedStorageLayout) ensureTypedColumnPartSupported() error {
 			}
 			switch field.AdjacencyLayout {
 			case ColumnAdjacencyListLayoutUint32OffsetsList:
-				return fmt.Errorf("%w: adjacency_list field %q adjacency_layout %q writer/fallback reader deferred to #1915", ErrTypedStorageColumnPartUnsupported, field.Path, field.AdjacencyLayout)
+				if field.AdjacencyDegree != 0 {
+					return fmt.Errorf("%w: adjacency_list field %q offsets-list requires adjacency_degree=0", ErrTypedStorageColumnPartUnsupported, field.Path)
+				}
 			default:
 				if field.AdjacencyDegree <= 0 {
 					return fmt.Errorf("%w: adjacency_list field %q requires adjacency_degree", ErrTypedStorageColumnPartUnsupported, field.Path)

--- a/TreeDB/collections/typed_storage_layout_test.go
+++ b/TreeDB/collections/typed_storage_layout_test.go
@@ -176,7 +176,7 @@ func TestTypedStorageLayoutTypedColumnAdjacencySupportedWithDegree(t *testing.T)
 	}
 }
 
-func TestTypedStorageLayoutAdjacencyOffsetsListSelectorSpecOnly(t *testing.T) {
+func TestTypedStorageLayoutAdjacencyOffsetsListSelectorSupported1915(t *testing.T) {
 	layout, err := NormalizeTypedStorageLayout(TypedStorageLayout{
 		Collection: "events",
 		Fields: []TypedStorageField{{
@@ -194,11 +194,11 @@ func TestTypedStorageLayoutAdjacencyOffsetsListSelectorSpecOnly(t *testing.T) {
 	if field.AdjacencyLayout != ColumnAdjacencyListLayoutUint32OffsetsList || field.AdjacencyDegree != 0 {
 		t.Fatalf("normalized offsets-list field=%+v", field)
 	}
-	if err := layout.EnsureReadSupported(); !errors.Is(err, ErrTypedStorageColumnPartUnsupported) || !strings.Contains(err.Error(), "#1915") {
-		t.Fatalf("EnsureReadSupported err=%v want #1915 fail-closed", err)
+	if err := layout.EnsureReadSupported(); err != nil {
+		t.Fatalf("EnsureReadSupported: %v", err)
 	}
-	if err := layout.EnsurePublicationSupported(); !errors.Is(err, ErrTypedStorageColumnPartUnsupported) || !strings.Contains(err.Error(), "#1915") {
-		t.Fatalf("EnsurePublicationSupported err=%v want #1915 fail-closed", err)
+	if err := layout.EnsurePublicationSupported(); err != nil {
+		t.Fatalf("EnsurePublicationSupported: %v", err)
 	}
 }
 

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -357,7 +357,7 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/column_vector_graph_typed_column_test.go", classification: typedStorageLegacyDerived, matchingLines: 23, occurrences: 26},
 	{path: "TreeDB/collections/command_wal_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 4, occurrences: 6},
 	{path: "TreeDB/collections/typed_column_adapter.go", classification: typedStorageLegacyCompatibility, matchingLines: 49, occurrences: 55},
-	{path: "TreeDB/collections/typed_column_adapter_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 223, occurrences: 231},
+	{path: "TreeDB/collections/typed_column_adapter_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 225, occurrences: 233},
 	{path: "TreeDB/collections/typed_column_bool_scan.go", classification: typedStorageLegacyCompatibility, matchingLines: 14, occurrences: 19},
 	{path: "TreeDB/collections/typed_column_bool_scan_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 3, occurrences: 4},
 	{path: "TreeDB/collections/typed_column_conformance_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 26, occurrences: 33},

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -366,6 +366,7 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/typed_column_float_fallback_bench_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 14, occurrences: 14},
 	{path: "TreeDB/collections/typed_column_float_fallback_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 48, occurrences: 50},
 	{path: "TreeDB/collections/typed_column_int64_scan.go", classification: typedStorageLegacyCompatibility, matchingLines: 22, occurrences: 31},
+	{path: "TreeDB/collections/typed_column_offsets_list_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 4, occurrences: 4},
 	{path: "TreeDB/collections/typed_column_int64_scan_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 32, occurrences: 40},
 	{path: "TreeDB/collections/typed_column_prepared_int64.go", classification: typedStorageLegacyCompatibility, matchingLines: 1, occurrences: 1},
 	{path: "TreeDB/collections/typed_column_prepared_state.go", classification: typedStorageLegacyCompatibility, matchingLines: 8, occurrences: 8},

--- a/TreeDB/docs/spec/storage-format.md
+++ b/TreeDB/docs/spec/storage-format.md
@@ -543,7 +543,7 @@ little-endian identity, and separate section metadata/checksums for offsets
 (8-byte elements) and values (4-byte elements). #1915 adds the safe writer and
 fallback reader into owned Go slices; unsafe direct-view readers,
 adapter-to-column_graph wiring, and graph search consumption remain deferred to
-#1916+.
+issue #1916 and later.
 
 As of the #1895 pre-alpha format update, newly written `typed_column_part` images
 carry a writer-built `layout_contract` section. The contract may mark only raw

--- a/TreeDB/docs/spec/storage-format.md
+++ b/TreeDB/docs/spec/storage-format.md
@@ -531,13 +531,19 @@ offsets []uint64  // row_count + 1, little-endian
 values  []uint32  // flattened adjacency values, little-endian
 ```
 
-The offsets-list primitive validates exact offsets count, `offsets[0] == 0`,
-monotonic offsets, final offset equal to the value count, exact offsets/value
-byte lengths, Go `int` range before slicing, little-endian identity, and separate
-section metadata/checksums for offsets (8-byte elements) and values (4-byte
-elements). #1915 adds the safe writer and fallback reader into owned Go slices;
-unsafe direct-view readers, adapter-to-column_graph wiring, and graph search
-consumption remain deferred to #1916+.
+The serialized image stores one canonical column-wide offsets section and one
+column-wide values section per offsets-list column. For multi-block parts, block
+payloads may use block-local offsets internally, but the image writer publishes a
+single global `row_count + 1` offsets array by dropping duplicate block starts and
+adding cumulative value bases; readers reconstruct block-local fallback payloads
+from those global sections. The offsets-list primitive validates exact offsets
+count, `offsets[0] == 0`, monotonic offsets, final offset equal to the value
+count, exact offsets/value byte lengths, Go `int` range before slicing,
+little-endian identity, and separate section metadata/checksums for offsets
+(8-byte elements) and values (4-byte elements). #1915 adds the safe writer and
+fallback reader into owned Go slices; unsafe direct-view readers,
+adapter-to-column_graph wiring, and graph search consumption remain deferred to
+#1916+.
 
 As of the #1895 pre-alpha format update, newly written `typed_column_part` images
 carry a writer-built `layout_contract` section. The contract may mark only raw
@@ -546,8 +552,10 @@ and fixed-dimension `raw_float32_vector` typed-column payload sections as
 `DirectViewCertified`; the adapter-internal `__treedb_primary_id` row-locator
 column is not a declared-value direct-view certification target. The contract
 records section/block offsets, lengths, checksums, element size, endian, length
-multiple, row count, fixed elements per row, and null/default exclusion. Image
-padding bytes are deterministic zero bytes
+multiple, row count, fixed elements per row, and null/default exclusion. For
+`raw_uint32_offsets_list`, the contract records global offsets/value section
+identity and leaves generic per-block combined payload offsets empty because the
+two sections are discontiguous. Image padding bytes are deterministic zero bytes
 and are included in serialized-image byte accounting. When a typed-column-part
 asset contains an active direct-view-certified candidate, the column asset segment
 writer/appender also emits deterministic zero prefix padding as needed so the

--- a/TreeDB/docs/spec/storage-format.md
+++ b/TreeDB/docs/spec/storage-format.md
@@ -534,9 +534,10 @@ values  []uint32  // flattened adjacency values, little-endian
 The offsets-list primitive validates exact offsets count, `offsets[0] == 0`,
 monotonic offsets, final offset equal to the value count, exact offsets/value
 byte lengths, Go `int` range before slicing, little-endian identity, and separate
-absolute alignment for offsets (8-byte) and values (4-byte) sections. It is
-spec/conformance-only in #1914: no writer, unsafe direct-view reader, adapter
-runtime, or graph search behavior is enabled until #1915+.
+section metadata/checksums for offsets (8-byte elements) and values (4-byte
+elements). #1915 adds the safe writer and fallback reader into owned Go slices;
+unsafe direct-view readers, adapter-to-column_graph wiring, and graph search
+consumption remain deferred to #1916+.
 
 As of the #1895 pre-alpha format update, newly written `typed_column_part` images
 carry a writer-built `layout_contract` section. The contract may mark only raw
@@ -608,8 +609,8 @@ staged and fail-closed. Authoritative dense `adjacency_list` typed-column fields
 must be non-nullable, must declare positive `adjacency_degree`, and must fail
 closed when any source row length, schema descriptor, or asset payload length
 disagrees with that fixed degree. The offsets-list selector is also non-nullable,
-must not declare `adjacency_degree`, and remains writer/reader fail-closed until
-issue #1915 adds the concrete encoding.
+must not declare `adjacency_degree`, and uses the #1915 concrete encoding for
+safe publication/reopen/fallback reconstruction.
 
 ## 8. Commit-Log Segment Format
 

--- a/TreeDB/docs/spec/typed-column-adapter.md
+++ b/TreeDB/docs/spec/typed-column-adapter.md
@@ -54,6 +54,10 @@ positive `adjacency_degree` and each present row must contain exactly that many
 uint32 neighbors. Offsets-list adjacency uses explicit `adjacency_layout:
 "uint32_offsets_list"`; it must not be inferred from a missing degree and is
 supported only by the safe #1915 writer/fallback reader path (not direct views).
+Serialized typed-column images publish offsets-list columns as one global
+`row_count + 1` little-endian `uint64` offsets section plus one global flattened
+`uint32` values section, even when the typed-column part has multiple codec
+blocks/granules.
 
 Adapter input rows are keyed by `TypedStorageField.Path`, not by display `Name`.
 When `Name != Path`, the physical column name may use `Name`, but decoded rows

--- a/TreeDB/docs/spec/typed-column-adapter.md
+++ b/TreeDB/docs/spec/typed-column-adapter.md
@@ -41,7 +41,7 @@ time.
 | `double` / `float64` | represented | Default compatibility layout remains a raw int64 column carrying `math.Float64bits`; these bits must not be treated as int64 ordering/sum/min/max/stats/pruning semantics or native direct-view evidence. Explicit `fixed_width_encoding: "little_endian"` on a non-null `typed_column_part` double column selects native uncompressed `raw_float64` little-endian IEEE-754 payload bytes. |
 | `string` | represented | Low-cardinality uint32 codes plus typed-column dictionary section metadata; code order must not imply lexical range/prefix unless dictionary order and collation proof are supplied. |
 | `float32_vector` | represented | Fixed-dimension row-major dense little-endian `float32` sections with `vector_dims` as elements per row; active typed-column direct-view candidate after certification/read-time checks. |
-| `adjacency_list` | represented for dense compatibility; offsets-list spec-only | Empty `adjacency_layout` keeps fixed-degree row-major dense little-endian `uint32` sections with `adjacency_degree` as elements per row. `adjacency_layout: "uint32_offsets_list"` selects the #1914/#1901 variable-list target (`uint64` offsets plus `uint32` values) on the same value type, but writer/reader runtime support is deferred to #1915+. |
+| `adjacency_list` | represented for dense compatibility; offsets-list safe fallback | Empty `adjacency_layout` keeps fixed-degree row-major dense little-endian `uint32` sections with `adjacency_degree` as elements per row. `adjacency_layout: "uint32_offsets_list"` selects the #1915/#1901 variable-list target (`uint64` offsets plus `uint32` values) on the same value type for safe writer/fallback-reader publication. |
 
 Nullable scalar adapter support uses `nullable_int64` as the carrier encoding
 for bool, int64, float32, double, and low-cardinality string fields: explicit
@@ -52,8 +52,8 @@ nullable/missing support remains staged/fail-closed; `adjacency_list`
 `typed_column_part` owners using the dense compatibility layout must declare
 positive `adjacency_degree` and each present row must contain exactly that many
 uint32 neighbors. Offsets-list adjacency uses explicit `adjacency_layout:
-"uint32_offsets_list"`; it must not be inferred from a missing degree and remains
-fail-closed in the adapter until #1915 adds writer/fallback reader support.
+"uint32_offsets_list"`; it must not be inferred from a missing degree and is
+supported only by the safe #1915 writer/fallback reader path (not direct views).
 
 Adapter input rows are keyed by `TypedStorageField.Path`, not by display `Name`.
 When `Name != Path`, the physical column name may use `Name`, but decoded rows
@@ -118,9 +118,9 @@ payload rule.
 `float32_vector` typed-column data is stored as uncompressed raw little-endian
 `float32` payloads. Default/dense `adjacency_list` typed-column data is stored as
 uncompressed raw little-endian `uint32` payloads with exactly
-`adjacency_degree` elements per row. The #1914 offsets-list selector instead
-uses `uint64` offsets plus flattened `uint32` values and remains adapter
-fail-closed until #1915. Adjacency direct views are deferred to #1901. The
+`adjacency_degree` elements per row. The #1915 offsets-list selector instead
+uses `uint64` offsets plus flattened `uint32` values and decodes through safe
+owned fallback slices. Adjacency direct views are deferred to #1916+. The
 `typedcolumn` image builder keeps sections relatively aligned; current
 direct-view eligibility also requires absolute storage alignment
 (`asset_ref.offset + section/block offset`) and actual Go pointer alignment at

--- a/TreeDB/docs/spec/typed-column-direct-view-alignment.md
+++ b/TreeDB/docs/spec/typed-column-direct-view-alignment.md
@@ -128,8 +128,12 @@ offsets []uint64  // row_count + 1, little-endian
 values  []uint32  // flattened adjacency values, little-endian
 ```
 
-The direct-view contract records and validates the offsets and values sections
-separately:
+The image format records one canonical column-wide offsets section and one
+column-wide values section per offsets-list column. Multi-block typed-column
+parts keep block-local payloads internally, but serialized images publish global
+offsets (exactly `row_count + 1`) plus global flattened values so each section
+has a single checksum/range identity. The direct-view contract records and
+validates the offsets and values sections separately:
 
 | Section | Element type | Element size | Absolute alignment | Length rule |
 | --- | --- | ---: | ---: | --- |

--- a/TreeDB/docs/spec/typed-column-direct-view-alignment.md
+++ b/TreeDB/docs/spec/typed-column-direct-view-alignment.md
@@ -24,7 +24,7 @@ The active stack targets typed-column fixed-width scalar/vector payloads only:
 | `ColumnStoreValueFloat32Vector` | yes | fixed-dim row-major little-endian `float32` payloads. |
 | `ColumnStoreValueBool` | no | bitpack/RLE and future bool encodings remain fallback-only until separately specified. |
 | `ColumnStoreValueString` | no | string values, dictionaries, and dictionary codes are not string direct-view payloads. |
-| `ColumnStoreValueAdjacencyList` | spec-only v1 target plus fallback compatibility | #1914 selects an explicit typed-column `raw_uint32_offsets_list` variable-list primitive (`uint64` offsets, `uint32` values) for #1901. Existing dense fixed-degree `raw_uint32_dense` and physical row-asset adjacency remain fallback/compatibility; writer, unsafe direct-view reader, and graph search consumption are deferred to #1915+. |
+| `ColumnStoreValueAdjacencyList` | v1 offsets-list primitive plus fallback compatibility | #1915 implements the explicit typed-column `raw_uint32_offsets_list` variable-list primitive (`uint64` offsets, `uint32` values) for safe writer/fallback-reader use. Existing dense fixed-degree `raw_uint32_dense` and physical row-asset adjacency remain fallback/compatibility; unsafe direct-view readers and graph search consumption are deferred to #1916+. |
 
 Physical row assets are deferred/fallback-only for this stack and must remain
 linked to #1897. Row-asset vector/adjacency/generic consumers must not be counted
@@ -69,7 +69,7 @@ their image-local layout contract is otherwise valid.
 | --- | --- | --- |
 | `typed_column_part` | generic typed-column scalar/vector consumers | `int64`, native `float32`, native `double`, and `float32_vector` are active little-endian candidates after certification and read-time checks. |
 | `typed_column_part` | `column_graph` typed-column vector source | `float32_vector` is the active candidate. Other value types fallback or are inapplicable. |
-| `typed_column_part` | `adjacency_list` consumers | `raw_uint32_offsets_list` is the selected #1901 v1 primitive but is spec-only/deferred here; legacy dense fixed-degree `raw_uint32_dense` remains fallback/compatibility. |
+| `typed_column_part` | `adjacency_list` consumers | `raw_uint32_offsets_list` is the selected #1901 v1 primitive and has safe writer/fallback-reader support; legacy dense fixed-degree `raw_uint32_dense` remains fallback/compatibility. |
 | physical row asset | vector, adjacency, or generic row consumers | deferred/fallback-only; #1897 owns row-record alignment/padding; #1899 records this as a safe deferral, not current-stack mmap evidence. |
 
 ## Required payload byte order fixtures
@@ -163,8 +163,8 @@ Bool bitpack/RLE, strings/dictionaries, nullable/default wrappers, compressed
 payloads, variable-width varint/delta/double-delta layouts, physical row assets,
 and adjacency direct views are fallback-only or deferred unless a future issue
 adds a new explicit encoding and conformance row. For adjacency, that explicit
-row is `raw_uint32_offsets_list`, but this issue deliberately does not enable a
-writer, unsafe direct-view reader, adapter integration, or graph search runtime.
+row is `raw_uint32_offsets_list`; #1915 enables the safe writer/fallback reader,
+while unsafe direct-view readers and graph search runtime remain deferred.
 
 ## Old/non-certified behavior
 

--- a/TreeDB/docs/spec/typed-column-layout-capabilities.md
+++ b/TreeDB/docs/spec/typed-column-layout-capabilities.md
@@ -34,7 +34,7 @@ not just encodings. A key includes:
 | `double` | `float64` + `raw_float64` + `compression=none` | Explicit `fixed_width_encoding: "little_endian"` native scalar payload. It is a fixed-width direct-view candidate for downstream certification/readers, preserves raw IEEE-754 bits, and does not yet enable float numeric aggregate/range/stats/pruning fast paths. |
 | `float32_vector` | `float32_vector` + `raw_float32_vector` | Fixed-width little-endian dense rows with explicit vector direct-payload, similarity, dot-product, and vector-metric capabilities. Scalar aggregate/range shortcuts are rejected. |
 | `adjacency_list` | `adjacency_list` + `raw_uint32_dense` | Legacy fixed-width little-endian dense fallback/compatibility payload bytes. Direct-view certification remains deferred; this is not the #1901 v1 target. Graph traversal/metrics may use decoded payloads; scalar aggregate/range shortcuts are rejected. |
-| `adjacency_list` | `adjacency_list` + `raw_uint32_offsets_list` | #1914-selected v1 variable-list primitive selected by `adjacency_layout: "uint32_offsets_list"`: `uint64` offsets plus flattened `uint32` values. It is spec-only/deferred in this issue: no writer, unsafe direct-view reader, adapter runtime, or graph search consumption is enabled until #1915+. |
+| `adjacency_list` | `adjacency_list` + `raw_uint32_offsets_list` | #1915-selected v1 variable-list primitive selected by `adjacency_layout: "uint32_offsets_list"`: `uint64` offsets plus flattened `uint32` values. Safe writer/fallback-reader publication is enabled; unsafe direct-view reader, column_graph adapter wiring, and graph search consumption remain deferred to #1916+. |
 
 Nullable/default wrappers expose null and default-mask dependencies separately
 from carrier-value capabilities. Value predicates and aggregates over nullable
@@ -164,7 +164,8 @@ New layouts should declare unsupported operations explicitly. Examples:
   and vector metrics; adjacency direct payloads are deferred to #1901 while
   adjacency traversal/metrics continue through decoded/fallback dense payloads;
   the #1901 v1 target is the distinct `raw_uint32_offsets_list` variable-list
-  layout with `uint64` offsets and `uint32` values, which remains runtime
-  deferred until #1915+; vector/adjacency layouts reject scalar aggregate/range
+  layout with `uint64` offsets and `uint32` values, whose safe writer/fallback
+  reader is available while direct-view/search runtime remains deferred;
+  vector/adjacency layouts reject scalar aggregate/range
   shortcuts unless a future issue implements and tests them through the shared
   substrate.

--- a/TreeDB/docs/spec/typed-column-layout-capabilities.md
+++ b/TreeDB/docs/spec/typed-column-layout-capabilities.md
@@ -80,10 +80,14 @@ addition to the descriptor and column-data sections. The contract is versioned
 and writer-built before publication. It records the image/descriptor identity,
 descriptor checksum, per-column logical type, physical typedcolumn type,
 encoding, compression, section offsets and lengths, section checksums, block row
-spans, payload offsets/lengths, fixed-width
-element counts, element size/alignment/endian, null/default mask presence and
-counts, dictionary section identity/order/collation fields, and capability flags
-for direct-view, streaming reducer, stats, and pruning shortcuts.
+spans, payload offsets/lengths for contiguous fixed-width/scalar sections,
+fixed-width element counts, element size/alignment/endian, null/default mask
+presence and counts, dictionary section identity/order/collation fields, and
+capability flags for direct-view, streaming reducer, stats, and pruning
+shortcuts. `raw_uint32_offsets_list` uses separate global offsets/values section
+identity instead of per-block contiguous payload offsets; its v1 block
+payload-offset fields are empty and block descriptors retain row spans plus raw
+byte counts for fallback reconstruction.
 
 The writer validates the contract before returning the image. Fixed-width direct
 view candidates must be uncompressed, little-endian, aligned by absolute storage

--- a/TreeDB/internal/columnlayout/layout.go
+++ b/TreeDB/internal/columnlayout/layout.go
@@ -366,7 +366,7 @@ func CapabilitiesFor(desc Descriptor) Capabilities {
 		caps.Layout.ElementsPerRow = 0
 		caps.Layout.ElementWidthBytes = 4
 		caps.Layout.Endian = EndianLittle
-		caps.DirectView = DirectViewCapability{Eligible: false, Reason: ReasonAdjacencyOffsetsListDirectViewDeferred, Endian: EndianLittle, WidthBytes: 4, AlignmentBytes: 4, RequiresUncompressed: true, RequiresRowCount: true, RequiresNoNulls: true, RequiresNoDefaults: true, Lifetime: "offsets-list writer/reader/search integration deferred to #1915+", ValidationBoundary: "prepare"}
+		caps.DirectView = DirectViewCapability{Eligible: false, Reason: ReasonAdjacencyOffsetsListDirectViewDeferred, Endian: EndianLittle, WidthBytes: 4, AlignmentBytes: 4, RequiresUncompressed: true, RequiresRowCount: true, RequiresNoNulls: true, RequiresNoDefaults: true, Lifetime: "offsets-list unsafe direct-view/search integration deferred to #1916+", ValidationBoundary: "prepare"}
 	default:
 		caps.DirectView = DirectViewCapability{Eligible: false, Reason: ReasonUnsupportedEncoding, ValidationBoundary: "prepare"}
 	}
@@ -469,7 +469,7 @@ func (c Capabilities) Supports(op Operation) Capability {
 				if op == OpAdjacencyDirectView {
 					return Unsupported(op, ReasonAdjacencyOffsetsListDirectViewDeferred, "raw_uint32_offsets_list direct views are specified but deferred to #1916")
 				}
-				return Unsupported(op, ReasonAdjacencyOffsetsListRuntimeDeferred, "raw_uint32_offsets_list writer/fallback reader/search integration is deferred to #1915+")
+				return Unsupported(op, ReasonAdjacencyOffsetsListRuntimeDeferred, "raw_uint32_offsets_list graph/search runtime integration is deferred to #1917+")
 			}
 		}
 	}

--- a/TreeDB/internal/columnlayout/layout_test.go
+++ b/TreeDB/internal/columnlayout/layout_test.go
@@ -242,7 +242,7 @@ func TestFloatAndNonInt64LayoutsDoNotAdvertiseUnsafeScalarCapabilities(t *testin
 		t.Fatalf("offsets-list adjacency caps=%+v want variable-length non-dense layout", offsetsAdjacency)
 	}
 	if offsetsAdjacency.DirectView.Eligible || offsetsAdjacency.DirectView.Reason != ReasonAdjacencyOffsetsListDirectViewDeferred {
-		t.Fatalf("offsets-list adjacency direct=%+v want spec-only deferred direct view", offsetsAdjacency.DirectView)
+		t.Fatalf("offsets-list adjacency direct=%+v want deferred direct view", offsetsAdjacency.DirectView)
 	}
 	if cap := offsetsAdjacency.Supports(OpAdjacencyDirectView); cap.Supported() || cap.Reason != ReasonAdjacencyOffsetsListDirectViewDeferred {
 		t.Fatalf("offsets-list direct cap=%+v want %s", cap, ReasonAdjacencyOffsetsListDirectViewDeferred)

--- a/TreeDB/internal/typedcolumn/adaptive_mark.go
+++ b/TreeDB/internal/typedcolumn/adaptive_mark.go
@@ -116,7 +116,34 @@ func EstimateBatchUncompressedBytes(batch Batch, defs []ColumnDefinition) (int, 
 			total += rows * 4
 		case ColumnTypeBool:
 			total += rows
-		case ColumnTypeFloat32Vector, ColumnTypeAdjacencyList:
+		case ColumnTypeFloat32Vector:
+			rowBytes, err := checkedMulInt(def.FixedWidthElements, 4, "dense column row bytes")
+			if err != nil {
+				return 0, err
+			}
+			bytes, err := checkedMulInt(rows, rowBytes, "dense column uncompressed bytes")
+			if err != nil {
+				return 0, err
+			}
+			total += bytes
+		case ColumnTypeAdjacencyList:
+			if def.Encoding == EncodingRawUint32OffsetsList {
+				list := batch.Uint32OffsetsLists[def.Name]
+				offsetsBytes, err := checkedMulInt(list.Rows+1, 8, "offsets-list offsets bytes")
+				if err != nil {
+					return 0, err
+				}
+				valuesBytes, err := checkedMulInt(len(list.Values), 4, "offsets-list values bytes")
+				if err != nil {
+					return 0, err
+				}
+				bytes, err := checkedAddInt(offsetsBytes, valuesBytes, "offsets-list bytes")
+				if err != nil {
+					return 0, err
+				}
+				total += bytes
+				continue
+			}
 			rowBytes, err := checkedMulInt(def.FixedWidthElements, 4, "dense column row bytes")
 			if err != nil {
 				return 0, err

--- a/TreeDB/internal/typedcolumn/dense.go
+++ b/TreeDB/internal/typedcolumn/dense.go
@@ -411,8 +411,10 @@ func uint32OffsetsListColumnInto(offsetsDst []uint64, valuesDst []uint32, rows i
 	}
 	outValues := valuesDst[:0]
 	var reader GranuleReader
+	var offsetsScratch []uint64
+	var valuesScratch []uint32
 	for _, block := range column.Blocks {
-		decoded, err := reader.DecodeUint32OffsetsListInto(nil, nil, block.Granule)
+		decoded, err := reader.DecodeUint32OffsetsListInto(offsetsScratch[:0], valuesScratch[:0], block.Granule)
 		if err != nil {
 			return RawUint32OffsetsList{}, err
 		}
@@ -428,6 +430,8 @@ func uint32OffsetsListColumnInto(offsetsDst []uint64, valuesDst []uint32, rows i
 			return RawUint32OffsetsList{}, fmt.Errorf("typedcolumn: offsets-list values exceed host int")
 		}
 		outValues = append(outValues, decoded.Values...)
+		offsetsScratch = decoded.Offsets
+		valuesScratch = decoded.Values
 		for i := 0; i < decoded.Rows; i++ {
 			outOffsets[first+i] = base + decoded.Offsets[i]
 		}

--- a/TreeDB/internal/typedcolumn/dense.go
+++ b/TreeDB/internal/typedcolumn/dense.go
@@ -69,6 +69,38 @@ func (b *ColumnPartBuilder) gatherUint32Dense(source []uint32, elementsPerRow in
 	return b.u32dense, nil
 }
 
+func (b *ColumnPartBuilder) gatherUint32OffsetsList(source RawUint32OffsetsList, start int, end int) (RawUint32OffsetsList, error) {
+	if err := ValidateRawUint32OffsetsListShape(source.Rows, source.Offsets, uint64(len(source.Values))); err != nil {
+		return RawUint32OffsetsList{}, err
+	}
+	rows := end - start
+	b.u32offset = resizeFixedWidthValues(b.u32offset[:0], rows+1)
+	b.u32offset[0] = 0
+	b.u32dense = b.u32dense[:0]
+	for row := start; row < end; row++ {
+		sourceRow := b.order[row]
+		if sourceRow < 0 || sourceRow >= source.Rows {
+			return RawUint32OffsetsList{}, fmt.Errorf("typedcolumn: uint32 offsets-list source row %d outside rows=%d", sourceRow, source.Rows)
+		}
+		begin := source.Offsets[sourceRow]
+		finish := source.Offsets[sourceRow+1]
+		if begin > maxHostIntUint64() || finish > maxHostIntUint64() {
+			return RawUint32OffsetsList{}, fmt.Errorf("typedcolumn: uint32 offsets-list row %d offset outside host int", sourceRow)
+		}
+		if finish < begin {
+			return RawUint32OffsetsList{}, fmt.Errorf("typedcolumn: uint32 offsets-list row %d non-monotonic offsets", sourceRow)
+		}
+		beginInt := int(begin)
+		finishInt := int(finish)
+		if beginInt > len(source.Values) || finishInt > len(source.Values) {
+			return RawUint32OffsetsList{}, fmt.Errorf("typedcolumn: uint32 offsets-list row %d values range [%d,%d) outside values=%d", sourceRow, begin, finish, len(source.Values))
+		}
+		b.u32dense = append(b.u32dense, source.Values[beginInt:finishInt]...)
+		b.u32offset[row-start+1] = uint64(len(b.u32dense))
+	}
+	return RawUint32OffsetsList{Rows: rows, Offsets: b.u32offset, Values: b.u32dense}, nil
+}
+
 func (b *GranuleBuilder) BuildFloat32Vector(values []float32, rows int, elementsPerRow int) (EncodedGranule, error) {
 	if b.cfg.Encoding != 0 && b.cfg.Encoding != EncodingRawFloat32Vector {
 		return EncodedGranule{}, fmt.Errorf("typedcolumn: float32_vector encoding=%s want %s", b.cfg.Encoding, EncodingRawFloat32Vector)
@@ -284,6 +316,17 @@ func (p *ColumnPart) DenseUint32Column(name string, dst []uint32) (DenseUint32Co
 	return DenseUint32Column{Rows: p.Descriptor.RowCount, ElementsPerRow: column.Definition.FixedWidthElements, Values: out}, nil
 }
 
+func (p *ColumnPart) Uint32OffsetsListColumn(name string, offsetsDst []uint64, valuesDst []uint32) (RawUint32OffsetsList, error) {
+	column, ok := p.Columns[name]
+	if !ok {
+		return RawUint32OffsetsList{}, fmt.Errorf("typedcolumn: missing column %s", name)
+	}
+	if column.Definition.Type != ColumnTypeAdjacencyList || column.Definition.Encoding != EncodingRawUint32OffsetsList {
+		return RawUint32OffsetsList{}, fmt.Errorf("typedcolumn: column %s type/encoding=(%s,%s) is not raw_uint32_offsets_list adjacency_list", name, column.Definition.Type, column.Definition.Encoding)
+	}
+	return uint32OffsetsListColumnInto(offsetsDst, valuesDst, p.Descriptor.RowCount, column)
+}
+
 func denseFloat32ColumnInto(dst []float32, rows int, column ColumnPartColumn) ([]float32, error) {
 	elements, err := checkedMulInt(rows, column.Definition.FixedWidthElements, "float32_vector column elements")
 	if err != nil {
@@ -354,6 +397,46 @@ func denseUint32ColumnInto(dst []uint32, rows int, column ColumnPartColumn) ([]u
 		copy(out[start:start+len(values)], values)
 	}
 	return out, nil
+}
+
+func uint32OffsetsListColumnInto(offsetsDst []uint64, valuesDst []uint32, rows int, column ColumnPartColumn) (RawUint32OffsetsList, error) {
+	outOffsets := offsetsDst[:0]
+	if cap(outOffsets) < rows+1 {
+		outOffsets = make([]uint64, rows+1)
+	} else {
+		outOffsets = outOffsets[:rows+1]
+	}
+	for i := range outOffsets {
+		outOffsets[i] = 0
+	}
+	outValues := valuesDst[:0]
+	var reader GranuleReader
+	for _, block := range column.Blocks {
+		decoded, err := reader.DecodeUint32OffsetsListInto(nil, nil, block.Granule)
+		if err != nil {
+			return RawUint32OffsetsList{}, err
+		}
+		if decoded.Rows != block.Descriptor.RowCount || len(decoded.Offsets) != block.Descriptor.RowCount+1 {
+			return RawUint32OffsetsList{}, fmt.Errorf("typedcolumn: offsets-list block rows=%d decoded rows=%d offsets=%d", block.Descriptor.RowCount, decoded.Rows, len(decoded.Offsets))
+		}
+		first := block.Descriptor.FirstRow
+		if first < 0 || first > rows-decoded.Rows {
+			return RawUint32OffsetsList{}, fmt.Errorf("typedcolumn: offsets-list block first_row=%d rows=%d outside column rows=%d", first, decoded.Rows, rows)
+		}
+		base := uint64(len(outValues))
+		if base > maxHostIntUint64() {
+			return RawUint32OffsetsList{}, fmt.Errorf("typedcolumn: offsets-list values exceed host int")
+		}
+		outValues = append(outValues, decoded.Values...)
+		for i := 0; i < decoded.Rows; i++ {
+			outOffsets[first+i] = base + decoded.Offsets[i]
+		}
+		outOffsets[first+decoded.Rows] = uint64(len(outValues))
+	}
+	if err := ValidateRawUint32OffsetsListShape(rows, outOffsets, uint64(len(outValues))); err != nil {
+		return RawUint32OffsetsList{}, err
+	}
+	return RawUint32OffsetsList{Rows: rows, Offsets: outOffsets, Values: outValues}, nil
 }
 
 func ensureFloat32Len(dst []float32, n int) []float32 {

--- a/TreeDB/internal/typedcolumn/granule.go
+++ b/TreeDB/internal/typedcolumn/granule.go
@@ -29,10 +29,10 @@ const (
 	EncodingRawUint32Dense
 	EncodingRawFloat32
 	EncodingRawFloat64
-	// EncodingRawUint32OffsetsList is the spec-only v1 variable-length
-	// adjacency/list primitive: little-endian uint64 offsets plus little-endian
-	// uint32 values. Writers and unsafe direct-view readers are intentionally
-	// deferred to #1915/#1916.
+	// EncodingRawUint32OffsetsList is the v1 variable-length adjacency/list
+	// primitive: little-endian uint64 offsets plus little-endian uint32 values.
+	// The safe writer and fallback reader are implemented; unsafe direct-view
+	// readers are intentionally deferred to #1916.
 	EncodingRawUint32OffsetsList
 )
 
@@ -188,15 +188,17 @@ func (b *GranuleBuilder) BuildInt64(values []int64) (EncodedGranule, error) {
 }
 
 type GranuleReader struct {
-	raw      []byte
-	values   []int64
-	stored64 []int64
-	bools    []bool
-	nulls    []bool
-	defaults []bool
-	codes    []uint32
-	float32s []float32
-	float64s []float64
+	raw       []byte
+	values    []int64
+	stored64  []int64
+	bools     []bool
+	nulls     []bool
+	defaults  []bool
+	codes     []uint32
+	float32s  []float32
+	float64s  []float64
+	offsets64 []uint64
+	u32values []uint32
 }
 
 func (r *GranuleReader) DecodeInt64(g EncodedGranule) ([]int64, error) {

--- a/TreeDB/internal/typedcolumn/layout_contract.go
+++ b/TreeDB/internal/typedcolumn/layout_contract.go
@@ -61,6 +61,10 @@ type ColumnPartLayoutContractColumn struct {
 	Compression         Compression
 	Rows                int
 	Section             ColumnPartLayoutContractSection
+	OffsetsSection      ColumnPartLayoutContractSection
+	ValuesSection       ColumnPartLayoutContractSection
+	OffsetsBytes        int
+	ValuesBytes         int
 	FixedWidthElements  int
 	ElementSize         int
 	Alignment           int
@@ -305,11 +309,17 @@ func CertifyColumnPartLayoutContract(image ColumnPartImage, desc ColumnPartDescr
 	return cert, nil
 }
 
+type columnPartImageColumnSections struct {
+	data    columnPartImageSectionData
+	offsets columnPartImageSectionData
+	values  columnPartImageSectionData
+}
+
 func encodeColumnPartLayoutContract(part *ColumnPart, opts ColumnPartImageOptions, sectionData []columnPartImageSectionData, manifestBytes int) ([]byte, error) {
 	if part == nil {
 		return nil, fmt.Errorf("typedcolumn: nil part")
 	}
-	sectionsByColumn := make(map[string]columnPartImageSectionData, len(part.Descriptor.Columns))
+	sectionsByColumn := make(map[string]columnPartImageColumnSections, len(part.Descriptor.Columns))
 	var descriptorData columnPartImageSectionData
 	var dictionaryData columnPartImageSectionData
 	for _, section := range sectionData {
@@ -319,7 +329,17 @@ func encodeColumnPartLayoutContract(part *ColumnPart, opts ColumnPartImageOption
 		case ColumnPartImageSectionDictionaries:
 			dictionaryData = section
 		case ColumnPartImageSectionColumnData:
-			sectionsByColumn[section.section.Column] = section
+			entry := sectionsByColumn[section.section.Column]
+			entry.data = section
+			sectionsByColumn[section.section.Column] = entry
+		case ColumnPartImageSectionColumnOffsets:
+			entry := sectionsByColumn[section.section.Column]
+			entry.offsets = section
+			sectionsByColumn[section.section.Column] = entry
+		case ColumnPartImageSectionColumnValues:
+			entry := sectionsByColumn[section.section.Column]
+			entry.values = section
+			sectionsByColumn[section.section.Column] = entry
 		}
 	}
 	if descriptorData.section.Kind != ColumnPartImageSectionDescriptor {
@@ -340,11 +360,11 @@ func encodeColumnPartLayoutContract(part *ColumnPart, opts ColumnPartImageOption
 		if !ok {
 			return nil, fmt.Errorf("typedcolumn: layout contract missing part column %s", columnDesc.Name)
 		}
-		data, ok := sectionsByColumn[columnDesc.Name]
+		sections, ok := sectionsByColumn[columnDesc.Name]
 		if !ok {
 			return nil, fmt.Errorf("typedcolumn: layout contract missing data section %s", columnDesc.Name)
 		}
-		contractColumn, err := buildColumnPartLayoutContractColumn(opts, columnDesc, column, data, dictionaryData)
+		contractColumn, err := buildColumnPartLayoutContractColumn(opts, columnDesc, column, sections, dictionaryData)
 		if err != nil {
 			return nil, err
 		}
@@ -355,7 +375,7 @@ func encodeColumnPartLayoutContract(part *ColumnPart, opts ColumnPartImageOption
 	return enc.bytes(), nil
 }
 
-func buildColumnPartLayoutContractColumn(opts ColumnPartImageOptions, columnDesc ColumnPartColumnDescriptor, column ColumnPartColumn, data columnPartImageSectionData, dictionaryData columnPartImageSectionData) (ColumnPartLayoutContractColumn, error) {
+func buildColumnPartLayoutContractColumn(opts ColumnPartImageOptions, columnDesc ColumnPartColumnDescriptor, column ColumnPartColumn, sections columnPartImageColumnSections, dictionaryData columnPartImageSectionData) (ColumnPartLayoutContractColumn, error) {
 	logicalType := ""
 	if opts.LayoutLogicalTypes != nil {
 		logicalType = opts.LayoutLogicalTypes[columnDesc.Name]
@@ -368,18 +388,38 @@ func buildColumnPartLayoutContractColumn(opts ColumnPartImageOptions, columnDesc
 	if opts.DictionaryCollation != nil {
 		dictCollation = opts.DictionaryCollation[columnDesc.Name]
 	}
+	sectionEncoding := column.Definition.Encoding
+	sectionCompression := column.Definition.Compression
+	sectionRows := 0
+	var sectionContract ColumnPartLayoutContractSection
+	if column.Definition.Encoding == EncodingRawUint32OffsetsList {
+		if sections.offsets.section.Kind != ColumnPartImageSectionColumnOffsets || sections.values.section.Kind != ColumnPartImageSectionColumnValues {
+			return ColumnPartLayoutContractColumn{}, fmt.Errorf("typedcolumn: layout contract column %s missing offsets-list sections", columnDesc.Name)
+		}
+		sectionRows = sections.offsets.section.Rows
+		sectionEncoding = sections.offsets.section.Encoding
+		sectionCompression = sections.offsets.section.Compression
+	} else {
+		if sections.data.section.Kind != ColumnPartImageSectionColumnData {
+			return ColumnPartLayoutContractColumn{}, fmt.Errorf("typedcolumn: layout contract missing data section %s", columnDesc.Name)
+		}
+		sectionRows = sections.data.section.Rows
+		sectionEncoding = sections.data.section.Encoding
+		sectionCompression = sections.data.section.Compression
+		sectionContract = ColumnPartLayoutContractSection{Offset: sections.data.section.Offset, Length: len(sections.data.data), Checksum: crc.Checksum(sections.data.data)}
+	}
 	contractDef := column.Definition
-	contractDef.Encoding = data.section.Encoding
-	contractDef.Compression = data.section.Compression
+	contractDef.Encoding = sectionEncoding
+	contractDef.Compression = sectionCompression
 	layout := physicalColumnLayoutForContract(logicalType, contractDef)
 	contract := ColumnPartLayoutContractColumn{
 		Name:                columnDesc.Name,
 		LogicalType:         logicalType,
 		Type:                columnDesc.Type,
-		Encoding:            data.section.Encoding,
-		Compression:         data.section.Compression,
-		Rows:                data.section.Rows,
-		Section:             ColumnPartLayoutContractSection{Offset: data.section.Offset, Length: len(data.data), Checksum: crc.Checksum(data.data)},
+		Encoding:            sectionEncoding,
+		Compression:         sectionCompression,
+		Rows:                sectionRows,
+		Section:             sectionContract,
 		FixedWidthElements:  column.Definition.FixedWidthElements,
 		ElementSize:         layout.elementSize,
 		Alignment:           layout.alignment,
@@ -394,6 +434,12 @@ func buildColumnPartLayoutContractColumn(opts ColumnPartImageOptions, columnDesc
 		DictionaryCollation: dictCollation,
 		Blocks:              make([]ColumnPartLayoutContractBlock, 0, len(column.Blocks)),
 	}
+	if column.Definition.Encoding == EncodingRawUint32OffsetsList {
+		contract.OffsetsSection = ColumnPartLayoutContractSection{Offset: sections.offsets.section.Offset, Length: len(sections.offsets.data), Checksum: crc.Checksum(sections.offsets.data)}
+		contract.ValuesSection = ColumnPartLayoutContractSection{Offset: sections.values.section.Offset, Length: len(sections.values.data), Checksum: crc.Checksum(sections.values.data)}
+		contract.OffsetsBytes = len(sections.offsets.data)
+		contract.ValuesBytes = len(sections.values.data)
+	}
 	if contract.Dictionary && dictionaryData.section.Kind == ColumnPartImageSectionDictionaries {
 		contract.DictionarySection = ColumnPartLayoutContractSection{Offset: dictionaryData.section.Offset, Length: len(dictionaryData.data), Checksum: crc.Checksum(dictionaryData.data)}
 	} else if contract.Dictionary {
@@ -401,7 +447,10 @@ func buildColumnPartLayoutContractColumn(opts ColumnPartImageOptions, columnDesc
 		contract.StatsCertified = false
 		contract.PruningCertified = false
 	}
-	payloadOffset := data.section.Offset
+	payloadOffset := sections.data.section.Offset
+	if column.Definition.Encoding == EncodingRawUint32OffsetsList {
+		payloadOffset = sections.offsets.section.Offset
+	}
 	for i, block := range column.Blocks {
 		if i >= len(columnDesc.Blocks) {
 			return ColumnPartLayoutContractColumn{}, fmt.Errorf("typedcolumn: layout contract column %s block %d missing descriptor", columnDesc.Name, i)
@@ -462,6 +511,11 @@ func physicalColumnLayoutForContract(logicalType string, def ColumnDefinition) c
 		// adjacency_list payload bytes are little-endian dense uint32, but certified
 		// adjacency direct views are deferred to #1901 for the active #1886 stack.
 		return columnPartContractLayout{elementSize: 4, alignment: 4, endian: ColumnPartLayoutEndianLittle, lengthMultiple: 4}
+	case EncodingRawUint32OffsetsList:
+		// The fallback primitive is sectioned into uint64 offsets and uint32 values.
+		// Unsafe direct views remain deferred to #1916, so this records endian and
+		// value element identity without direct-view certification.
+		return columnPartContractLayout{elementSize: 4, alignment: 4, endian: ColumnPartLayoutEndianLittle, lengthMultiple: 4}
 	case EncodingDeltaVarint, EncodingDoubleDeltaVarint:
 		streaming := def.Compression == CompressionNone && logicalType == "int64"
 		return columnPartContractLayout{endian: ColumnPartLayoutEndianCodecDefined, streaming: streaming, stats: streaming, pruning: streaming}
@@ -479,6 +533,9 @@ func physicalColumnLayoutForContract(logicalType string, def ColumnDefinition) c
 }
 
 func certifyLayoutContractColumn(image ColumnPartImage, desc ColumnPartDescriptor, columnDesc ColumnPartColumnDescriptor, column ColumnPartColumn, contract ColumnPartLayoutContractColumn) error {
+	if contract.Encoding == EncodingRawUint32OffsetsList || column.Definition.Encoding == EncodingRawUint32OffsetsList {
+		return certifyLayoutContractOffsetsListColumn(image, desc, columnDesc, column, contract)
+	}
 	section, ok := image.columnDataSection(columnDesc.Name)
 	if !ok {
 		return fmt.Errorf("typedcolumn: layout contract column %s missing image section", columnDesc.Name)
@@ -564,6 +621,82 @@ func certifyLayoutContractColumn(image ColumnPartImage, desc ColumnPartDescripto
 		if nullCount != 0 || defaultCount != 0 || contract.NullMaskPresent || contract.DefaultMaskPresent {
 			return fmt.Errorf("typedcolumn: layout contract column %s direct-view null/default counts=(%d,%d) mask_flags=(%v,%v)", columnDesc.Name, nullCount, defaultCount, contract.NullMaskPresent, contract.DefaultMaskPresent)
 		}
+	}
+	return nil
+}
+
+func certifyLayoutContractOffsetsListColumn(image ColumnPartImage, desc ColumnPartDescriptor, columnDesc ColumnPartColumnDescriptor, column ColumnPartColumn, contract ColumnPartLayoutContractColumn) error {
+	offsetsSection, valuesSection, ok := image.columnOffsetsListSections(columnDesc.Name)
+	if !ok {
+		return fmt.Errorf("typedcolumn: layout contract column %s missing offsets-list image sections", columnDesc.Name)
+	}
+	if contract.Type != columnDesc.Type || contract.Type != column.Definition.Type || contract.Type != ColumnTypeAdjacencyList {
+		return fmt.Errorf("typedcolumn: layout contract column %s offsets-list type=%s descriptor=%s definition=%s", columnDesc.Name, contract.Type, columnDesc.Type, column.Definition.Type)
+	}
+	if contract.Encoding != EncodingRawUint32OffsetsList || column.Definition.Encoding != EncodingRawUint32OffsetsList || offsetsSection.Encoding != EncodingRawUint32OffsetsList || valuesSection.Encoding != EncodingRawUint32OffsetsList {
+		return fmt.Errorf("typedcolumn: layout contract column %s offsets-list encoding contract=%s definition=%s offsets=%s values=%s", columnDesc.Name, contract.Encoding, column.Definition.Encoding, offsetsSection.Encoding, valuesSection.Encoding)
+	}
+	if contract.Compression != CompressionNone || column.Definition.Compression != CompressionNone || offsetsSection.Compression != CompressionNone || valuesSection.Compression != CompressionNone {
+		return fmt.Errorf("typedcolumn: layout contract column %s offsets-list compression contract=%s definition=%s offsets=%s values=%s", columnDesc.Name, contract.Compression, column.Definition.Compression, offsetsSection.Compression, valuesSection.Compression)
+	}
+	if contract.FixedWidthElements != 0 || column.Definition.FixedWidthElements != 0 || columnDesc.FixedWidthElements != 0 {
+		return fmt.Errorf("typedcolumn: layout contract column %s offsets-list fixed_width_elements=(%d,%d,%d) want 0", columnDesc.Name, contract.FixedWidthElements, column.Definition.FixedWidthElements, columnDesc.FixedWidthElements)
+	}
+	if contract.Rows != desc.RowCount || offsetsSection.Rows != desc.RowCount || valuesSection.Rows != desc.RowCount {
+		return fmt.Errorf("typedcolumn: layout contract column %s offsets-list rows=%d offsets_rows=%d values_rows=%d descriptor_rows=%d", columnDesc.Name, contract.Rows, offsetsSection.Rows, valuesSection.Rows, desc.RowCount)
+	}
+	expectedLayout := physicalColumnLayoutForContract(contract.LogicalType, column.Definition)
+	if contract.ElementSize != expectedLayout.elementSize || contract.Alignment != expectedLayout.alignment || contract.Endian != expectedLayout.endian || contract.LengthMultiple != expectedLayout.lengthMultiple {
+		return fmt.Errorf("typedcolumn: layout contract column %s offsets-list element/alignment/endian/length=(%d,%d,%s,%d) want (%d,%d,%s,%d)", columnDesc.Name, contract.ElementSize, contract.Alignment, contract.Endian, contract.LengthMultiple, expectedLayout.elementSize, expectedLayout.alignment, expectedLayout.endian, expectedLayout.lengthMultiple)
+	}
+	if contract.DirectViewCertified || contract.StreamingCertified || contract.StatsCertified || contract.PruningCertified {
+		return fmt.Errorf("typedcolumn: layout contract column %s offsets-list capability flags direct=%v streaming=%v stats=%v pruning=%v want false", columnDesc.Name, contract.DirectViewCertified, contract.StreamingCertified, contract.StatsCertified, contract.PruningCertified)
+	}
+	if contract.Dictionary || contract.DictionarySection != (ColumnPartLayoutContractSection{}) {
+		return fmt.Errorf("typedcolumn: layout contract column %s offsets-list dictionary metadata present", columnDesc.Name)
+	}
+	if err := certifyLayoutContractSection("column "+columnDesc.Name+" offsets", contract.OffsetsSection, offsetsSection, image.sectionBytes(offsetsSection)); err != nil {
+		return err
+	}
+	if err := certifyLayoutContractSection("column "+columnDesc.Name+" values", contract.ValuesSection, valuesSection, image.sectionBytes(valuesSection)); err != nil {
+		return err
+	}
+	if contract.OffsetsBytes != offsetsSection.Length || contract.ValuesBytes != valuesSection.Length {
+		return fmt.Errorf("typedcolumn: layout contract column %s offsets-list bytes offsets=%d/%d values=%d/%d", columnDesc.Name, contract.OffsetsBytes, offsetsSection.Length, contract.ValuesBytes, valuesSection.Length)
+	}
+	if len(contract.Blocks) != len(column.Blocks) || len(contract.Blocks) != len(columnDesc.Blocks) {
+		return fmt.Errorf("typedcolumn: layout contract column %s offsets-list blocks=%d descriptor=%d", columnDesc.Name, len(contract.Blocks), len(column.Blocks))
+	}
+	offsetsBytes := 0
+	valuesBytes := 0
+	nullCount := 0
+	defaultCount := 0
+	for i, block := range column.Blocks {
+		certified := contract.Blocks[i]
+		want := block.Descriptor
+		if certified.FirstRow != want.FirstRow || certified.RowCount != want.RowCount || certified.FirstGranule != want.FirstGranule || certified.LastGranule != want.LastGranule {
+			return fmt.Errorf("typedcolumn: layout contract column %s block %d row span=(%d,%d,%d,%d) want (%d,%d,%d,%d)", columnDesc.Name, i, certified.FirstRow, certified.RowCount, certified.FirstGranule, certified.LastGranule, want.FirstRow, want.RowCount, want.FirstGranule, want.LastGranule)
+		}
+		if certified.Encoding != want.Encoding || certified.Compression != want.Compression || certified.RawBytes != want.RawBytes || certified.StoredBytes != want.StoredBytes {
+			return fmt.Errorf("typedcolumn: layout contract column %s block %d encoding/compression/raw/stored=(%s,%s,%d,%d) want (%s,%s,%d,%d)", columnDesc.Name, i, certified.Encoding, certified.Compression, certified.RawBytes, certified.StoredBytes, want.Encoding, want.Compression, want.RawBytes, want.StoredBytes)
+		}
+		blockOffsetsBytes, blockValuesBytes, err := RawUint32OffsetsListBlockPayloadBytes(block.Descriptor.RowCount, block.Descriptor.StoredBytes)
+		if err != nil {
+			return err
+		}
+		offsetsBytes += blockOffsetsBytes
+		valuesBytes += blockValuesBytes
+		nullCount += block.Granule.NullCount
+		defaultCount += block.Granule.DefaultCount
+		if certified.NullCount != block.Granule.NullCount || certified.DefaultCount != block.Granule.DefaultCount {
+			return fmt.Errorf("typedcolumn: layout contract column %s block %d null/default=(%d,%d) want (%d,%d)", columnDesc.Name, i, certified.NullCount, certified.DefaultCount, block.Granule.NullCount, block.Granule.DefaultCount)
+		}
+	}
+	if offsetsBytes != offsetsSection.Length || valuesBytes != valuesSection.Length {
+		return fmt.Errorf("typedcolumn: layout contract column %s offsets-list consumed offsets=%d/%d values=%d/%d", columnDesc.Name, offsetsBytes, offsetsSection.Length, valuesBytes, valuesSection.Length)
+	}
+	if contract.NullCount != nullCount || contract.DefaultCount != defaultCount || contract.NullMaskPresent || contract.DefaultMaskPresent || nullCount != 0 || defaultCount != 0 {
+		return fmt.Errorf("typedcolumn: layout contract column %s offsets-list null/default counts=(%d,%d) flags=(%v,%v)", columnDesc.Name, contract.NullCount, contract.DefaultCount, contract.NullMaskPresent, contract.DefaultMaskPresent)
 	}
 	return nil
 }
@@ -706,6 +839,12 @@ func encodeColumnPartLayoutContractColumn(enc *columnPartImageEncoder, column Co
 	enc.u32(flags)
 	enc.i64(int64(column.Rows))
 	encodeColumnPartLayoutContractSection(enc, column.Section)
+	if column.Encoding == EncodingRawUint32OffsetsList {
+		encodeColumnPartLayoutContractSection(enc, column.OffsetsSection)
+		encodeColumnPartLayoutContractSection(enc, column.ValuesSection)
+		enc.i64(int64(column.OffsetsBytes))
+		enc.i64(int64(column.ValuesBytes))
+	}
 	enc.i64(int64(column.FixedWidthElements))
 	enc.i64(int64(column.ElementSize))
 	enc.i64(int64(column.Alignment))
@@ -772,6 +911,28 @@ func decodeColumnPartLayoutContractColumn(dec *columnPartImageDecoder) (ColumnPa
 	if err != nil {
 		return ColumnPartLayoutContractColumn{}, err
 	}
+	var offsetsSection ColumnPartLayoutContractSection
+	var valuesSection ColumnPartLayoutContractSection
+	var offsetsBytes int
+	var valuesBytes int
+	if Encoding(encoding) == EncodingRawUint32OffsetsList {
+		offsetsSection, err = decodeColumnPartLayoutContractSection(dec)
+		if err != nil {
+			return ColumnPartLayoutContractColumn{}, err
+		}
+		valuesSection, err = decodeColumnPartLayoutContractSection(dec)
+		if err != nil {
+			return ColumnPartLayoutContractColumn{}, err
+		}
+		offsetsBytes, err = decodeNonNegativeLayoutInt(dec, "layout contract offsets bytes")
+		if err != nil {
+			return ColumnPartLayoutContractColumn{}, err
+		}
+		valuesBytes, err = decodeNonNegativeLayoutInt(dec, "layout contract values bytes")
+		if err != nil {
+			return ColumnPartLayoutContractColumn{}, err
+		}
+	}
 	fixedWidthElements, err := decodeNonNegativeLayoutInt(dec, "layout contract fixed-width elements")
 	if err != nil {
 		return ColumnPartLayoutContractColumn{}, err
@@ -832,6 +993,10 @@ func decodeColumnPartLayoutContractColumn(dec *columnPartImageDecoder) (ColumnPa
 		Compression:         Compression(compression),
 		Rows:                rows,
 		Section:             section,
+		OffsetsSection:      offsetsSection,
+		ValuesSection:       valuesSection,
+		OffsetsBytes:        offsetsBytes,
+		ValuesBytes:         valuesBytes,
 		FixedWidthElements:  fixedWidthElements,
 		ElementSize:         elementSize,
 		Alignment:           alignment,

--- a/TreeDB/internal/typedcolumn/layout_contract.go
+++ b/TreeDB/internal/typedcolumn/layout_contract.go
@@ -448,8 +448,13 @@ func buildColumnPartLayoutContractColumn(opts ColumnPartImageOptions, columnDesc
 		contract.PruningCertified = false
 	}
 	payloadOffset := sections.data.section.Offset
-	if column.Definition.Encoding == EncodingRawUint32OffsetsList {
-		payloadOffset = sections.offsets.section.Offset
+	offsetsList := column.Definition.Encoding == EncodingRawUint32OffsetsList
+	if offsetsList {
+		// Offsets-list images store two discontiguous global sections, so the generic
+		// per-block combined payload offset/length fields are intentionally empty.
+		// Section-level offsets/checksums plus block row spans carry the durable
+		// identity until a future contract version adds per-block split ranges.
+		payloadOffset = 0
 	}
 	for i, block := range column.Blocks {
 		if i >= len(columnDesc.Blocks) {
@@ -463,6 +468,10 @@ func buildColumnPartLayoutContractColumn(opts ColumnPartImageOptions, columnDesc
 		}
 		contract.NullCount += block.Granule.NullCount
 		contract.DefaultCount += block.Granule.DefaultCount
+		payloadLength := block.Descriptor.StoredBytes
+		if offsetsList {
+			payloadLength = 0
+		}
 		contract.Blocks = append(contract.Blocks, ColumnPartLayoutContractBlock{
 			FirstRow:      block.Descriptor.FirstRow,
 			RowCount:      block.Descriptor.RowCount,
@@ -473,11 +482,13 @@ func buildColumnPartLayoutContractColumn(opts ColumnPartImageOptions, columnDesc
 			RawBytes:      block.Descriptor.RawBytes,
 			StoredBytes:   block.Descriptor.StoredBytes,
 			PayloadOffset: payloadOffset,
-			PayloadLength: block.Descriptor.StoredBytes,
+			PayloadLength: payloadLength,
 			NullCount:     block.Granule.NullCount,
 			DefaultCount:  block.Granule.DefaultCount,
 		})
-		payloadOffset += block.Descriptor.StoredBytes
+		if !offsetsList {
+			payloadOffset += block.Descriptor.StoredBytes
+		}
 	}
 	return contract, nil
 }
@@ -667,7 +678,14 @@ func certifyLayoutContractOffsetsListColumn(image ColumnPartImage, desc ColumnPa
 	if len(contract.Blocks) != len(column.Blocks) || len(contract.Blocks) != len(columnDesc.Blocks) {
 		return fmt.Errorf("typedcolumn: layout contract column %s offsets-list blocks=%d descriptor=%d", columnDesc.Name, len(contract.Blocks), len(column.Blocks))
 	}
-	offsetsBytes := 0
+	expectedOffsetCount, err := checkedAddInt(desc.RowCount, 1, "layout contract offsets-list global offset count")
+	if err != nil {
+		return err
+	}
+	expectedOffsetsBytes, err := checkedMulInt(expectedOffsetCount, 8, "layout contract offsets-list global offsets bytes")
+	if err != nil {
+		return err
+	}
 	valuesBytes := 0
 	nullCount := 0
 	defaultCount := 0
@@ -680,11 +698,13 @@ func certifyLayoutContractOffsetsListColumn(image ColumnPartImage, desc ColumnPa
 		if certified.Encoding != want.Encoding || certified.Compression != want.Compression || certified.RawBytes != want.RawBytes || certified.StoredBytes != want.StoredBytes {
 			return fmt.Errorf("typedcolumn: layout contract column %s block %d encoding/compression/raw/stored=(%s,%s,%d,%d) want (%s,%s,%d,%d)", columnDesc.Name, i, certified.Encoding, certified.Compression, certified.RawBytes, certified.StoredBytes, want.Encoding, want.Compression, want.RawBytes, want.StoredBytes)
 		}
-		blockOffsetsBytes, blockValuesBytes, err := RawUint32OffsetsListBlockPayloadBytes(block.Descriptor.RowCount, block.Descriptor.StoredBytes)
+		if certified.PayloadOffset != 0 || certified.PayloadLength != 0 {
+			return fmt.Errorf("typedcolumn: layout contract column %s block %d offsets-list payload offset/length=(%d,%d) want (0,0)", columnDesc.Name, i, certified.PayloadOffset, certified.PayloadLength)
+		}
+		_, blockValuesBytes, err := RawUint32OffsetsListBlockPayloadBytes(block.Descriptor.RowCount, block.Descriptor.StoredBytes)
 		if err != nil {
 			return err
 		}
-		offsetsBytes += blockOffsetsBytes
 		valuesBytes += blockValuesBytes
 		nullCount += block.Granule.NullCount
 		defaultCount += block.Granule.DefaultCount
@@ -692,8 +712,8 @@ func certifyLayoutContractOffsetsListColumn(image ColumnPartImage, desc ColumnPa
 			return fmt.Errorf("typedcolumn: layout contract column %s block %d null/default=(%d,%d) want (%d,%d)", columnDesc.Name, i, certified.NullCount, certified.DefaultCount, block.Granule.NullCount, block.Granule.DefaultCount)
 		}
 	}
-	if offsetsBytes != offsetsSection.Length || valuesBytes != valuesSection.Length {
-		return fmt.Errorf("typedcolumn: layout contract column %s offsets-list consumed offsets=%d/%d values=%d/%d", columnDesc.Name, offsetsBytes, offsetsSection.Length, valuesBytes, valuesSection.Length)
+	if expectedOffsetsBytes != offsetsSection.Length || valuesBytes != valuesSection.Length {
+		return fmt.Errorf("typedcolumn: layout contract column %s offsets-list consumed offsets=%d/%d values=%d/%d", columnDesc.Name, expectedOffsetsBytes, offsetsSection.Length, valuesBytes, valuesSection.Length)
 	}
 	if contract.NullCount != nullCount || contract.DefaultCount != defaultCount || contract.NullMaskPresent || contract.DefaultMaskPresent || nullCount != 0 || defaultCount != 0 {
 		return fmt.Errorf("typedcolumn: layout contract column %s offsets-list null/default counts=(%d,%d) flags=(%v,%v)", columnDesc.Name, contract.NullCount, contract.DefaultCount, contract.NullMaskPresent, contract.DefaultMaskPresent)

--- a/TreeDB/internal/typedcolumn/part.go
+++ b/TreeDB/internal/typedcolumn/part.go
@@ -1048,13 +1048,6 @@ func (b *ColumnPartBuilder) buildColumn(batch Batch, def ColumnDefinition) (Colu
 	if blockRows == 0 {
 		blockRows = b.opts.PartPolicy.RowsPerGranule
 	}
-	if def.Encoding == EncodingRawUint32OffsetsList {
-		// The v1 offsets-list primitive stores one column-wide offsets section with
-		// exactly row_count+1 uint64 entries plus one values section. Keep the
-		// descriptor to a single block until a later format explicitly adds
-		// per-block offsets-list sections.
-		blockRows = len(b.order)
-	}
 	column := ColumnPartColumn{Definition: def}
 	descriptor := ColumnPartColumnDescriptor{Name: def.Name, Type: def.Type, FixedWidthElements: def.FixedWidthElements}
 	for start := 0; start < len(b.order); start += blockRows {

--- a/TreeDB/internal/typedcolumn/part.go
+++ b/TreeDB/internal/typedcolumn/part.go
@@ -90,15 +90,16 @@ type ColumnDefinition struct {
 }
 
 type Batch struct {
-	Rows           int
-	Columns        map[string][]int64
-	Nulls          map[string][]bool
-	Defaults       map[string][]bool
-	DefaultValues  map[string]int64
-	Float32Columns map[string][]float32
-	Float64Columns map[string][]float64
-	Float32Vectors map[string][]float32
-	Uint32Vectors  map[string][]uint32
+	Rows               int
+	Columns            map[string][]int64
+	Nulls              map[string][]bool
+	Defaults           map[string][]bool
+	DefaultValues      map[string]int64
+	Float32Columns     map[string][]float32
+	Float64Columns     map[string][]float64
+	Float32Vectors     map[string][]float32
+	Uint32Vectors      map[string][]uint32
+	Uint32OffsetsLists map[string]RawUint32OffsetsList
 }
 
 type ColumnPart struct {
@@ -173,17 +174,18 @@ type RowLocator struct {
 }
 
 type ColumnPartBuilder struct {
-	opts     Options
-	order    []int
-	values64 []int64
-	codes32  []uint32
-	bools    []bool
-	nulls    []bool
-	defaults []bool
-	float32s []float32
-	float64s []float64
-	u32dense []uint32
-	builder  *GranuleBuilder
+	opts      Options
+	order     []int
+	values64  []int64
+	codes32   []uint32
+	bools     []bool
+	nulls     []bool
+	defaults  []bool
+	float32s  []float32
+	float64s  []float64
+	u32dense  []uint32
+	u32offset []uint64
+	builder   *GranuleBuilder
 }
 
 func NewColumnPartBuilder(opts Options) (*ColumnPartBuilder, error) {
@@ -747,17 +749,26 @@ func normalizeColumnDefinition(def ColumnDefinition, defaultCompression Compress
 			return ColumnDefinition{}, fmt.Errorf("typedcolumn: float32_vector column %s requires uncompressed dense sections", def.Name)
 		}
 	case ColumnTypeAdjacencyList:
-		if def.FixedWidthElements <= 0 {
-			return ColumnDefinition{}, fmt.Errorf("typedcolumn: adjacency_list column %s requires positive fixed-width elements", def.Name)
-		}
 		if def.Encoding == 0 {
 			def.Encoding = EncodingRawUint32Dense
 		}
-		if def.Encoding != EncodingRawUint32Dense {
+		switch def.Encoding {
+		case EncodingRawUint32Dense:
+			if def.FixedWidthElements <= 0 {
+				return ColumnDefinition{}, fmt.Errorf("typedcolumn: adjacency_list column %s requires positive fixed-width elements", def.Name)
+			}
+			if def.Compression != CompressionNone {
+				return ColumnDefinition{}, fmt.Errorf("typedcolumn: adjacency_list column %s requires uncompressed dense sections", def.Name)
+			}
+		case EncodingRawUint32OffsetsList:
+			if def.FixedWidthElements != 0 {
+				return ColumnDefinition{}, fmt.Errorf("typedcolumn: adjacency_list column %s raw_uint32_offsets_list requires fixed-width elements=0", def.Name)
+			}
+			if def.Compression != CompressionNone {
+				return ColumnDefinition{}, fmt.Errorf("typedcolumn: adjacency_list column %s requires uncompressed offsets-list sections", def.Name)
+			}
+		default:
 			return ColumnDefinition{}, fmt.Errorf("typedcolumn: unsupported adjacency_list encoding %s for %s", def.Encoding, def.Name)
-		}
-		if def.Compression != CompressionNone {
-			return ColumnDefinition{}, fmt.Errorf("typedcolumn: adjacency_list column %s requires uncompressed dense sections", def.Name)
 		}
 	default:
 		return ColumnDefinition{}, fmt.Errorf("typedcolumn: unsupported column type %s for %s", def.Type, def.Name)
@@ -822,13 +833,27 @@ func validateBatch(batch Batch, defs []ColumnDefinition) (int, error) {
 				return 0, fmt.Errorf("typedcolumn: column %s rows=%d want=%d", def.Name, columnRows, rows)
 			}
 		case ColumnTypeAdjacencyList:
-			values, ok := batch.Uint32Vectors[def.Name]
-			if !ok {
-				return 0, fmt.Errorf("typedcolumn: missing adjacency_list column %s", def.Name)
-			}
-			columnRows, err := denseRowsForValues(len(values), def.FixedWidthElements, def.Name)
-			if err != nil {
-				return 0, err
+			var columnRows int
+			switch def.Encoding {
+			case EncodingRawUint32OffsetsList:
+				list, ok := batch.Uint32OffsetsLists[def.Name]
+				if !ok {
+					return 0, fmt.Errorf("typedcolumn: missing adjacency_list offsets-list column %s", def.Name)
+				}
+				if err := ValidateRawUint32OffsetsListShape(list.Rows, list.Offsets, uint64(len(list.Values))); err != nil {
+					return 0, fmt.Errorf("typedcolumn: column %s: %w", def.Name, err)
+				}
+				columnRows = list.Rows
+			default:
+				values, ok := batch.Uint32Vectors[def.Name]
+				if !ok {
+					return 0, fmt.Errorf("typedcolumn: missing adjacency_list column %s", def.Name)
+				}
+				var err error
+				columnRows, err = denseRowsForValues(len(values), def.FixedWidthElements, def.Name)
+				if err != nil {
+					return 0, err
+				}
 			}
 			if rows == 0 {
 				rows = columnRows
@@ -915,6 +940,11 @@ func validateBatch(batch Batch, defs []ColumnDefinition) (int, error) {
 	for name := range batch.Uint32Vectors {
 		if _, ok := declared[name]; !ok {
 			return 0, fmt.Errorf("typedcolumn: undeclared adjacency_list column %s", name)
+		}
+	}
+	for name := range batch.Uint32OffsetsLists {
+		if _, ok := declared[name]; !ok {
+			return 0, fmt.Errorf("typedcolumn: undeclared adjacency_list offsets-list column %s", name)
 		}
 	}
 	if rows <= 0 {
@@ -1018,6 +1048,13 @@ func (b *ColumnPartBuilder) buildColumn(batch Batch, def ColumnDefinition) (Colu
 	if blockRows == 0 {
 		blockRows = b.opts.PartPolicy.RowsPerGranule
 	}
+	if def.Encoding == EncodingRawUint32OffsetsList {
+		// The v1 offsets-list primitive stores one column-wide offsets section with
+		// exactly row_count+1 uint64 entries plus one values section. Keep the
+		// descriptor to a single block until a later format explicitly adds
+		// per-block offsets-list sections.
+		blockRows = len(b.order)
+	}
 	column := ColumnPartColumn{Definition: def}
 	descriptor := ColumnPartColumnDescriptor{Name: def.Name, Type: def.Type, FixedWidthElements: def.FixedWidthElements}
 	for start := 0; start < len(b.order); start += blockRows {
@@ -1071,6 +1108,13 @@ func (b *ColumnPartBuilder) buildColumnBlockGranule(batch Batch, def ColumnDefin
 		}
 		return b.builder.BuildFloat32Vector(values, end-start, def.FixedWidthElements)
 	case ColumnTypeAdjacencyList:
+		if def.Encoding == EncodingRawUint32OffsetsList {
+			list, err := b.gatherUint32OffsetsList(batch.Uint32OffsetsLists[def.Name], start, end)
+			if err != nil {
+				return EncodedGranule{}, err
+			}
+			return b.builder.BuildUint32OffsetsList(list.Rows, list.Offsets, list.Values)
+		}
 		sourceValues := batch.Uint32Vectors[def.Name]
 		values, err := b.gatherUint32Dense(sourceValues, def.FixedWidthElements, start, end)
 		if err != nil {

--- a/TreeDB/internal/typedcolumn/part_accounting.go
+++ b/TreeDB/internal/typedcolumn/part_accounting.go
@@ -17,32 +17,34 @@ const (
 )
 
 type ColumnPartByteAccounting struct {
-	Rows                    int                                    `json:"rows"`
-	Columns                 int                                    `json:"columns"`
-	Granules                int                                    `json:"granules"`
-	CodecBlocks             int                                    `json:"codec_blocks"`
-	PhysicalFiles           int                                    `json:"physical_files"`
-	SerializedImageBytes    int                                    `json:"serialized_image_bytes,omitempty"`
-	SerializedManifestBytes int                                    `json:"serialized_manifest_bytes,omitempty"`
-	SerializedPaddingBytes  int                                    `json:"serialized_padding_bytes,omitempty"`
-	LogicalValueBytes       int                                    `json:"logical_value_bytes"`
-	EncodedRawBytes         int                                    `json:"encoded_raw_bytes"`
-	DeclaredColumnBytes     int                                    `json:"declared_column_bytes"`
-	DictionaryBytes         int                                    `json:"dictionary_bytes"`
-	MarkBytes               int                                    `json:"mark_bytes"`
-	SortKeyMetadataBytes    int                                    `json:"sort_key_metadata_bytes"`
-	AggregateMetadataBytes  int                                    `json:"aggregate_metadata_bytes"`
-	ColumnStatsBytes        int                                    `json:"column_stats_bytes"`
-	PruningMetadataBytes    int                                    `json:"pruning_metadata_bytes"`
-	DescriptorBytes         int                                    `json:"descriptor_bytes"`
-	LayoutContractBytes     int                                    `json:"layout_contract_bytes"`
-	LocatorBytes            int                                    `json:"locator_bytes"`
-	TotalStoredBytes        int                                    `json:"total_stored_bytes"`
-	BytesPerRow             float64                                `json:"bytes_per_row"`
-	RetainedJSONPayload     string                                 `json:"retained_json_payload"`
-	ColumnsDetail           []ColumnPartColumnByteAccounting       `json:"columns_detail"`
-	CompressionDetail       []ColumnPartCompressionByteAccounting  `json:"compression_detail"`
-	SerializedSections      []ColumnPartImageSectionByteAccounting `json:"serialized_sections,omitempty"`
+	Rows                       int                                    `json:"rows"`
+	Columns                    int                                    `json:"columns"`
+	Granules                   int                                    `json:"granules"`
+	CodecBlocks                int                                    `json:"codec_blocks"`
+	PhysicalFiles              int                                    `json:"physical_files"`
+	SerializedImageBytes       int                                    `json:"serialized_image_bytes,omitempty"`
+	SerializedManifestBytes    int                                    `json:"serialized_manifest_bytes,omitempty"`
+	SerializedPaddingBytes     int                                    `json:"serialized_padding_bytes,omitempty"`
+	LogicalValueBytes          int                                    `json:"logical_value_bytes"`
+	EncodedRawBytes            int                                    `json:"encoded_raw_bytes"`
+	DeclaredColumnBytes        int                                    `json:"declared_column_bytes"`
+	DeclaredColumnOffsetsBytes int                                    `json:"declared_column_offsets_bytes,omitempty"`
+	DeclaredColumnValuesBytes  int                                    `json:"declared_column_values_bytes,omitempty"`
+	DictionaryBytes            int                                    `json:"dictionary_bytes"`
+	MarkBytes                  int                                    `json:"mark_bytes"`
+	SortKeyMetadataBytes       int                                    `json:"sort_key_metadata_bytes"`
+	AggregateMetadataBytes     int                                    `json:"aggregate_metadata_bytes"`
+	ColumnStatsBytes           int                                    `json:"column_stats_bytes"`
+	PruningMetadataBytes       int                                    `json:"pruning_metadata_bytes"`
+	DescriptorBytes            int                                    `json:"descriptor_bytes"`
+	LayoutContractBytes        int                                    `json:"layout_contract_bytes"`
+	LocatorBytes               int                                    `json:"locator_bytes"`
+	TotalStoredBytes           int                                    `json:"total_stored_bytes"`
+	BytesPerRow                float64                                `json:"bytes_per_row"`
+	RetainedJSONPayload        string                                 `json:"retained_json_payload"`
+	ColumnsDetail              []ColumnPartColumnByteAccounting       `json:"columns_detail"`
+	CompressionDetail          []ColumnPartCompressionByteAccounting  `json:"compression_detail"`
+	SerializedSections         []ColumnPartImageSectionByteAccounting `json:"serialized_sections,omitempty"`
 }
 
 type ColumnPartColumnByteAccounting struct {
@@ -217,7 +219,9 @@ func (p *ColumnPart) ByteAccountingFromImage(image ColumnPartImage) ColumnPartBy
 	out.SerializedImageBytes = image.TotalBytes()
 	out.SerializedManifestBytes = image.ManifestBytes
 	out.SerializedPaddingBytes = image.PaddingBytes()
-	out.DeclaredColumnBytes = image.CategoryBytes(ColumnPartImageCategoryDeclaredColumns)
+	out.DeclaredColumnOffsetsBytes = image.CategoryBytes(ColumnPartImageCategoryDeclaredColumnOffsets)
+	out.DeclaredColumnValuesBytes = image.CategoryBytes(ColumnPartImageCategoryDeclaredColumnValues)
+	out.DeclaredColumnBytes = image.CategoryBytes(ColumnPartImageCategoryDeclaredColumns) + out.DeclaredColumnOffsetsBytes + out.DeclaredColumnValuesBytes
 	out.DictionaryBytes = image.CategoryBytes(ColumnPartImageCategoryDictionaries)
 	out.MarkBytes = image.CategoryBytes(ColumnPartImageCategoryMarks)
 	out.SortKeyMetadataBytes = image.CategoryBytes(ColumnPartImageCategorySortKeyMetadata)

--- a/TreeDB/internal/typedcolumn/part_accounting.go
+++ b/TreeDB/internal/typedcolumn/part_accounting.go
@@ -110,6 +110,12 @@ func (p *ColumnPart) ByteAccounting() ColumnPartByteAccounting {
 			report := block.Granule.CodecReport
 			out.CodecBlocks++
 			valueBytes := logicalColumnValueBytes(column.Definition, block.Descriptor.RowCount)
+			if column.Definition.Encoding == EncodingRawUint32OffsetsList {
+				_, valuesBytes, err := RawUint32OffsetsListBlockPayloadBytes(block.Descriptor.RowCount, block.Descriptor.RawBytes)
+				if err == nil {
+					valueBytes = valuesBytes
+				}
+			}
 			detail.Rows += block.Descriptor.RowCount
 			detail.Blocks++
 			detail.LogicalValueBytes += valueBytes

--- a/TreeDB/internal/typedcolumn/part_image.go
+++ b/TreeDB/internal/typedcolumn/part_image.go
@@ -29,24 +29,28 @@ const (
 	ColumnPartImageSectionDictionaries      ColumnPartImageSectionKind = "dictionaries"
 	ColumnPartImageSectionLayoutContract    ColumnPartImageSectionKind = "layout_contract"
 	ColumnPartImageSectionColumnData        ColumnPartImageSectionKind = "column_data"
+	ColumnPartImageSectionColumnOffsets     ColumnPartImageSectionKind = "column_offsets"
+	ColumnPartImageSectionColumnValues      ColumnPartImageSectionKind = "column_values"
 	ColumnPartImageSectionPadding           ColumnPartImageSectionKind = "padding"
 )
 
 type ColumnPartImageSectionCategory string
 
 const (
-	ColumnPartImageCategoryManifest          ColumnPartImageSectionCategory = "manifest"
-	ColumnPartImageCategoryDescriptor        ColumnPartImageSectionCategory = "descriptor"
-	ColumnPartImageCategorySortKeyMetadata   ColumnPartImageSectionCategory = "sort_key_metadata"
-	ColumnPartImageCategoryMarks             ColumnPartImageSectionCategory = "marks"
-	ColumnPartImageCategoryLocators          ColumnPartImageSectionCategory = "locators"
-	ColumnPartImageCategoryAggregateMetadata ColumnPartImageSectionCategory = "aggregate_metadata"
-	ColumnPartImageCategoryColumnStats       ColumnPartImageSectionCategory = "column_stats"
-	ColumnPartImageCategoryPruningMetadata   ColumnPartImageSectionCategory = "pruning_metadata"
-	ColumnPartImageCategoryDictionaries      ColumnPartImageSectionCategory = "dictionaries"
-	ColumnPartImageCategoryLayoutContract    ColumnPartImageSectionCategory = "layout_contract"
-	ColumnPartImageCategoryDeclaredColumns   ColumnPartImageSectionCategory = "declared_columns"
-	ColumnPartImageCategoryPadding           ColumnPartImageSectionCategory = "padding"
+	ColumnPartImageCategoryManifest              ColumnPartImageSectionCategory = "manifest"
+	ColumnPartImageCategoryDescriptor            ColumnPartImageSectionCategory = "descriptor"
+	ColumnPartImageCategorySortKeyMetadata       ColumnPartImageSectionCategory = "sort_key_metadata"
+	ColumnPartImageCategoryMarks                 ColumnPartImageSectionCategory = "marks"
+	ColumnPartImageCategoryLocators              ColumnPartImageSectionCategory = "locators"
+	ColumnPartImageCategoryAggregateMetadata     ColumnPartImageSectionCategory = "aggregate_metadata"
+	ColumnPartImageCategoryColumnStats           ColumnPartImageSectionCategory = "column_stats"
+	ColumnPartImageCategoryPruningMetadata       ColumnPartImageSectionCategory = "pruning_metadata"
+	ColumnPartImageCategoryDictionaries          ColumnPartImageSectionCategory = "dictionaries"
+	ColumnPartImageCategoryLayoutContract        ColumnPartImageSectionCategory = "layout_contract"
+	ColumnPartImageCategoryDeclaredColumns       ColumnPartImageSectionCategory = "declared_columns"
+	ColumnPartImageCategoryDeclaredColumnOffsets ColumnPartImageSectionCategory = "declared_column_offsets"
+	ColumnPartImageCategoryDeclaredColumnValues  ColumnPartImageSectionCategory = "declared_column_values"
+	ColumnPartImageCategoryPadding               ColumnPartImageSectionCategory = "padding"
 )
 
 type ColumnPartImageOptions struct {
@@ -1028,6 +1032,8 @@ var columnPartImageSectionCodes = []columnPartImageSectionCode{
 	{kind: ColumnPartImageSectionLayoutContract, kindCode: 9, category: ColumnPartImageCategoryLayoutContract, categoryCode: 9},
 	{kind: ColumnPartImageSectionColumnStats, kindCode: 10, category: ColumnPartImageCategoryColumnStats, categoryCode: 10},
 	{kind: ColumnPartImageSectionPruningMetadata, kindCode: 11, category: ColumnPartImageCategoryPruningMetadata, categoryCode: 11},
+	{kind: ColumnPartImageSectionColumnOffsets, kindCode: 12, category: ColumnPartImageCategoryDeclaredColumnOffsets, categoryCode: 12},
+	{kind: ColumnPartImageSectionColumnValues, kindCode: 13, category: ColumnPartImageCategoryDeclaredColumnValues, categoryCode: 13},
 }
 
 func columnPartImageSectionKindCode(kind ColumnPartImageSectionKind) (uint16, error) {

--- a/TreeDB/internal/typedcolumn/part_image.go
+++ b/TreeDB/internal/typedcolumn/part_image.go
@@ -797,28 +797,48 @@ func (b *columnPartImageBuilder) addColumnDataSections() error {
 }
 
 func (b *columnPartImageBuilder) addUint32OffsetsListColumnSections(columnDescriptor ColumnPartColumnDescriptor, column ColumnPartColumn) error {
-	totalOffsetsBytes := 0
-	totalValuesBytes := 0
+	globalOffsets := resizeFixedWidthValues([]uint64(nil), b.part.Descriptor.RowCount+1)
+	globalValues := make([]uint32, 0)
+	expectedFirstRow := 0
+	var reader GranuleReader
 	for i, block := range column.Blocks {
 		if len(block.Granule.Payload) != block.Descriptor.StoredBytes {
 			return fmt.Errorf("typedcolumn: column %s block %d payload bytes=%d descriptor stored bytes=%d", columnDescriptor.Name, i, len(block.Granule.Payload), block.Descriptor.StoredBytes)
 		}
-		offsetsBytes, valuesBytes, err := RawUint32OffsetsListBlockPayloadBytes(block.Descriptor.RowCount, block.Descriptor.StoredBytes)
+		if block.Descriptor.FirstRow != expectedFirstRow {
+			return fmt.Errorf("typedcolumn: column %s block %d first_row=%d want %d", columnDescriptor.Name, i, block.Descriptor.FirstRow, expectedFirstRow)
+		}
+		decoded, err := reader.DecodeUint32OffsetsListInto(nil, nil, block.Granule)
 		if err != nil {
 			return fmt.Errorf("typedcolumn: column %s block %d offsets-list payload: %w", columnDescriptor.Name, i, err)
 		}
-		totalOffsetsBytes += offsetsBytes
-		totalValuesBytes += valuesBytes
-	}
-	offsetsData := make([]byte, 0, totalOffsetsBytes)
-	valuesData := make([]byte, 0, totalValuesBytes)
-	for _, block := range column.Blocks {
-		offsetsBytes, valuesBytes, err := RawUint32OffsetsListBlockPayloadBytes(block.Descriptor.RowCount, block.Descriptor.StoredBytes)
-		if err != nil {
-			return err
+		if decoded.Rows != block.Descriptor.RowCount || len(decoded.Offsets) != block.Descriptor.RowCount+1 {
+			return fmt.Errorf("typedcolumn: column %s block %d offsets-list rows=%d offsets=%d want rows=%d", columnDescriptor.Name, i, decoded.Rows, len(decoded.Offsets), block.Descriptor.RowCount)
 		}
-		offsetsData = append(offsetsData, block.Granule.Payload[:offsetsBytes]...)
-		valuesData = append(valuesData, block.Granule.Payload[offsetsBytes:offsetsBytes+valuesBytes]...)
+		base := uint64(len(globalValues))
+		if base > maxHostIntUint64() || uint64(len(decoded.Values)) > maxHostIntUint64()-base {
+			return fmt.Errorf("typedcolumn: column %s offsets-list values exceed host int", columnDescriptor.Name)
+		}
+		first := block.Descriptor.FirstRow
+		for row := 0; row <= decoded.Rows; row++ {
+			globalOffsets[first+row] = base + decoded.Offsets[row]
+		}
+		globalValues = append(globalValues, decoded.Values...)
+		expectedFirstRow += block.Descriptor.RowCount
+	}
+	if expectedFirstRow != b.part.Descriptor.RowCount {
+		return fmt.Errorf("typedcolumn: column %s offsets-list covers %d rows, want %d", columnDescriptor.Name, expectedFirstRow, b.part.Descriptor.RowCount)
+	}
+	if err := ValidateRawUint32OffsetsListShape(b.part.Descriptor.RowCount, globalOffsets, uint64(len(globalValues))); err != nil {
+		return fmt.Errorf("typedcolumn: column %s offsets-list global shape: %w", columnDescriptor.Name, err)
+	}
+	offsetsData, err := EncodeRawUint32OffsetsListOffsets(nil, globalOffsets)
+	if err != nil {
+		return err
+	}
+	valuesData, err := EncodeRawUint32OffsetsListValues(nil, globalValues)
+	if err != nil {
+		return err
 	}
 	offsetsSection, valuesSection, err := NewRawUint32OffsetsListImageSections(columnDescriptor.Name, b.part.Descriptor.RowCount, len(offsetsData), len(valuesData))
 	if err != nil {

--- a/TreeDB/internal/typedcolumn/part_image.go
+++ b/TreeDB/internal/typedcolumn/part_image.go
@@ -801,6 +801,8 @@ func (b *columnPartImageBuilder) addUint32OffsetsListColumnSections(columnDescri
 	globalValues := make([]uint32, 0)
 	expectedFirstRow := 0
 	var reader GranuleReader
+	var offsetsScratch []uint64
+	var valuesScratch []uint32
 	for i, block := range column.Blocks {
 		if len(block.Granule.Payload) != block.Descriptor.StoredBytes {
 			return fmt.Errorf("typedcolumn: column %s block %d payload bytes=%d descriptor stored bytes=%d", columnDescriptor.Name, i, len(block.Granule.Payload), block.Descriptor.StoredBytes)
@@ -808,7 +810,7 @@ func (b *columnPartImageBuilder) addUint32OffsetsListColumnSections(columnDescri
 		if block.Descriptor.FirstRow != expectedFirstRow {
 			return fmt.Errorf("typedcolumn: column %s block %d first_row=%d want %d", columnDescriptor.Name, i, block.Descriptor.FirstRow, expectedFirstRow)
 		}
-		decoded, err := reader.DecodeUint32OffsetsListInto(nil, nil, block.Granule)
+		decoded, err := reader.DecodeUint32OffsetsListInto(offsetsScratch[:0], valuesScratch[:0], block.Granule)
 		if err != nil {
 			return fmt.Errorf("typedcolumn: column %s block %d offsets-list payload: %w", columnDescriptor.Name, i, err)
 		}
@@ -824,6 +826,8 @@ func (b *columnPartImageBuilder) addUint32OffsetsListColumnSections(columnDescri
 			globalOffsets[first+row] = base + decoded.Offsets[row]
 		}
 		globalValues = append(globalValues, decoded.Values...)
+		offsetsScratch = decoded.Offsets
+		valuesScratch = decoded.Values
 		expectedFirstRow += block.Descriptor.RowCount
 	}
 	if expectedFirstRow != b.part.Descriptor.RowCount {

--- a/TreeDB/internal/typedcolumn/part_image.go
+++ b/TreeDB/internal/typedcolumn/part_image.go
@@ -207,6 +207,23 @@ func (i ColumnPartImage) columnDataSection(column string) (ColumnPartImageSectio
 	return ColumnPartImageSection{}, false
 }
 
+func (i ColumnPartImage) columnOffsetsListSections(column string) (ColumnPartImageSection, ColumnPartImageSection, bool) {
+	var offsets ColumnPartImageSection
+	var values ColumnPartImageSection
+	for _, section := range i.Sections {
+		if section.Column != column {
+			continue
+		}
+		switch section.Kind {
+		case ColumnPartImageSectionColumnOffsets:
+			offsets = section
+		case ColumnPartImageSectionColumnValues:
+			values = section
+		}
+	}
+	return offsets, values, offsets.Kind == ColumnPartImageSectionColumnOffsets && values.Kind == ColumnPartImageSectionColumnValues
+}
+
 func validateImageDescriptorMatchesPart(image ColumnPartImage, part *ColumnPart) error {
 	descriptorSection, err := image.singleSection(ColumnPartImageSectionDescriptor)
 	if err != nil {
@@ -455,9 +472,16 @@ func (b *columnPartImageBuilder) addDescriptorSection() error {
 			return fmt.Errorf("typedcolumn: descriptor column %s fixed-width elements=%d", column.Name, column.FixedWidthElements)
 		}
 		switch column.Type {
-		case ColumnTypeFloat32Vector, ColumnTypeAdjacencyList:
+		case ColumnTypeFloat32Vector:
 			if column.FixedWidthElements <= 0 {
 				return fmt.Errorf("typedcolumn: descriptor column %s type=%s requires positive fixed-width elements", column.Name, column.Type)
+			}
+		case ColumnTypeAdjacencyList:
+			if column.FixedWidthElements < 0 {
+				return fmt.Errorf("typedcolumn: descriptor column %s type=%s has negative fixed-width elements=%d", column.Name, column.Type, column.FixedWidthElements)
+			}
+			if column.FixedWidthElements == 0 && !columnDescriptorAllBlocksEncoding(column, EncodingRawUint32OffsetsList) {
+				return fmt.Errorf("typedcolumn: descriptor column %s type=%s requires positive fixed-width elements unless encoding=%s", column.Name, column.Type, EncodingRawUint32OffsetsList)
 			}
 		default:
 			if column.FixedWidthElements != 0 {
@@ -496,6 +520,18 @@ func (b *columnPartImageBuilder) addDescriptorSection() error {
 		Blocks:   countColumnBlocks(desc),
 	}, enc.bytes())
 	return nil
+}
+
+func columnDescriptorAllBlocksEncoding(column ColumnPartColumnDescriptor, encoding Encoding) bool {
+	if len(column.Blocks) == 0 {
+		return false
+	}
+	for _, block := range column.Blocks {
+		if block.Encoding != encoding {
+			return false
+		}
+	}
+	return true
 }
 
 func imageColumnCardinalityForDescriptor(column ColumnPartColumnDescriptor, partColumn ColumnPartColumn) (uint32, error) {
@@ -729,6 +765,12 @@ func (b *columnPartImageBuilder) addColumnDataSections() error {
 		if !ok {
 			return fmt.Errorf("typedcolumn: missing column %s", columnDescriptor.Name)
 		}
+		if column.Definition.Encoding == EncodingRawUint32OffsetsList {
+			if err := b.addUint32OffsetsListColumnSections(columnDescriptor, column); err != nil {
+				return err
+			}
+			continue
+		}
 		totalPayloadBytes := 0
 		for i, block := range column.Blocks {
 			if len(block.Granule.Payload) != block.Descriptor.StoredBytes {
@@ -751,6 +793,43 @@ func (b *columnPartImageBuilder) addColumnDataSections() error {
 			Compression: column.Definition.Compression,
 		}, data)
 	}
+	return nil
+}
+
+func (b *columnPartImageBuilder) addUint32OffsetsListColumnSections(columnDescriptor ColumnPartColumnDescriptor, column ColumnPartColumn) error {
+	totalOffsetsBytes := 0
+	totalValuesBytes := 0
+	for i, block := range column.Blocks {
+		if len(block.Granule.Payload) != block.Descriptor.StoredBytes {
+			return fmt.Errorf("typedcolumn: column %s block %d payload bytes=%d descriptor stored bytes=%d", columnDescriptor.Name, i, len(block.Granule.Payload), block.Descriptor.StoredBytes)
+		}
+		offsetsBytes, valuesBytes, err := RawUint32OffsetsListBlockPayloadBytes(block.Descriptor.RowCount, block.Descriptor.StoredBytes)
+		if err != nil {
+			return fmt.Errorf("typedcolumn: column %s block %d offsets-list payload: %w", columnDescriptor.Name, i, err)
+		}
+		totalOffsetsBytes += offsetsBytes
+		totalValuesBytes += valuesBytes
+	}
+	offsetsData := make([]byte, 0, totalOffsetsBytes)
+	valuesData := make([]byte, 0, totalValuesBytes)
+	for _, block := range column.Blocks {
+		offsetsBytes, valuesBytes, err := RawUint32OffsetsListBlockPayloadBytes(block.Descriptor.RowCount, block.Descriptor.StoredBytes)
+		if err != nil {
+			return err
+		}
+		offsetsData = append(offsetsData, block.Granule.Payload[:offsetsBytes]...)
+		valuesData = append(valuesData, block.Granule.Payload[offsetsBytes:offsetsBytes+valuesBytes]...)
+	}
+	offsetsSection, valuesSection, err := NewRawUint32OffsetsListImageSections(columnDescriptor.Name, b.part.Descriptor.RowCount, len(offsetsData), len(valuesData))
+	if err != nil {
+		return err
+	}
+	offsetsSection.Granules = len(b.part.Descriptor.Granules)
+	offsetsSection.Blocks = len(column.Blocks)
+	valuesSection.Granules = len(b.part.Descriptor.Granules)
+	valuesSection.Blocks = len(column.Blocks)
+	b.appendSection(offsetsSection, offsetsData)
+	b.appendSection(valuesSection, valuesData)
 	return nil
 }
 

--- a/TreeDB/internal/typedcolumn/part_image_decode.go
+++ b/TreeDB/internal/typedcolumn/part_image_decode.go
@@ -2029,6 +2029,10 @@ func expectedImageSectionCategory(kind ColumnPartImageSectionKind) (ColumnPartIm
 		return ColumnPartImageCategoryLayoutContract, true
 	case ColumnPartImageSectionColumnData:
 		return ColumnPartImageCategoryDeclaredColumns, true
+	case ColumnPartImageSectionColumnOffsets:
+		return ColumnPartImageCategoryDeclaredColumnOffsets, true
+	case ColumnPartImageSectionColumnValues:
+		return ColumnPartImageCategoryDeclaredColumnValues, true
 	case ColumnPartImageSectionManifest:
 		return ColumnPartImageCategoryManifest, true
 	default:

--- a/TreeDB/internal/typedcolumn/part_image_decode.go
+++ b/TreeDB/internal/typedcolumn/part_image_decode.go
@@ -487,9 +487,13 @@ func decodeColumnPartDescriptorSection(data []byte) (ColumnPartDescriptor, map[s
 			return ColumnPartDescriptor{}, nil, err
 		}
 		switch columnType {
-		case ColumnTypeFloat32Vector, ColumnTypeAdjacencyList:
+		case ColumnTypeFloat32Vector:
 			if fixedWidthElements <= 0 {
 				return ColumnPartDescriptor{}, nil, fmt.Errorf("typedcolumn: column %s type=%s requires positive fixed-width elements", name, columnType)
+			}
+		case ColumnTypeAdjacencyList:
+			if fixedWidthElements < 0 {
+				return ColumnPartDescriptor{}, nil, fmt.Errorf("typedcolumn: column %s type=%s has negative fixed-width elements %d", name, columnType, fixedWidthElements)
 			}
 		default:
 			if fixedWidthElements != 0 {
@@ -537,6 +541,9 @@ func decodeColumnPartDescriptorSection(data []byte) (ColumnPartDescriptor, map[s
 			columnDesc.Blocks = append(columnDesc.Blocks, blockDesc)
 			column.Blocks = append(column.Blocks, ColumnBlock{Descriptor: blockDesc, Granule: granule})
 		}
+		if err := validateDecodedColumnFixedWidthElements(name, columnType, fixedWidthElements, columnDesc.Blocks); err != nil {
+			return ColumnPartDescriptor{}, nil, err
+		}
 		if expectedFirstRow != desc.RowCount {
 			return ColumnPartDescriptor{}, nil, fmt.Errorf("typedcolumn: descriptor column %s covers %d rows, want %d", name, expectedFirstRow, desc.RowCount)
 		}
@@ -550,6 +557,34 @@ func decodeColumnPartDescriptorSection(data []byte) (ColumnPartDescriptor, map[s
 		return ColumnPartDescriptor{}, nil, err
 	}
 	return desc, columns, nil
+}
+
+func validateDecodedColumnFixedWidthElements(name string, columnType ColumnType, fixedWidthElements int, blocks []ColumnBlockDescriptor) error {
+	switch columnType {
+	case ColumnTypeFloat32Vector:
+		if fixedWidthElements <= 0 {
+			return fmt.Errorf("typedcolumn: column %s type=%s requires positive fixed-width elements", name, columnType)
+		}
+	case ColumnTypeAdjacencyList:
+		if fixedWidthElements < 0 {
+			return fmt.Errorf("typedcolumn: column %s type=%s has negative fixed-width elements %d", name, columnType, fixedWidthElements)
+		}
+		if fixedWidthElements == 0 {
+			if len(blocks) == 0 {
+				return fmt.Errorf("typedcolumn: column %s type=%s requires blocks for %s", name, columnType, EncodingRawUint32OffsetsList)
+			}
+			for _, block := range blocks {
+				if block.Encoding != EncodingRawUint32OffsetsList {
+					return fmt.Errorf("typedcolumn: column %s type=%s requires positive fixed-width elements unless encoding=%s", name, columnType, EncodingRawUint32OffsetsList)
+				}
+			}
+		}
+	default:
+		if fixedWidthElements != 0 {
+			return fmt.Errorf("typedcolumn: column %s type=%s has fixed-width elements %d", name, columnType, fixedWidthElements)
+		}
+	}
+	return nil
 }
 
 func validateDecodedGranuleDescriptors(desc ColumnPartDescriptor) error {
@@ -604,6 +639,9 @@ func validateDecodedColumnBlockDescriptor(desc ColumnPartDescriptor, column stri
 	if block.FirstGranule != firstGranule || block.LastGranule != lastGranule {
 		return fmt.Errorf("typedcolumn: descriptor column %s block %d granule range [%d,%d] want [%d,%d] for rows [%d,%d)", column, blockIndex, block.FirstGranule, block.LastGranule, firstGranule, lastGranule, block.FirstRow, block.FirstRow+block.RowCount)
 	}
+	if columnType == ColumnTypeAdjacencyList && block.Encoding == EncodingRawUint32OffsetsList {
+		return validateDecodedOffsetsListColumnBlockDescriptor(column, blockIndex, fixedWidthElements, block)
+	}
 	maxRawBytes, err := maxDecodedBlockRawBytes(columnType, cardinality, fixedWidthElements, block.Encoding, block.RowCount)
 	if err != nil {
 		return fmt.Errorf("typedcolumn: descriptor column %s block %d: %w", column, blockIndex, err)
@@ -651,6 +689,22 @@ func validateDecodedColumnBlockGranuleMetadata(column string, blockIndex int, gr
 	}
 	if granule.HasMinMax && granule.Min > granule.Max {
 		return fmt.Errorf("typedcolumn: descriptor column %s block %d granule min=%d exceeds max=%d", column, blockIndex, granule.Min, granule.Max)
+	}
+	return nil
+}
+
+func validateDecodedOffsetsListColumnBlockDescriptor(column string, blockIndex int, fixedWidthElements int, block ColumnBlockDescriptor) error {
+	if fixedWidthElements != 0 {
+		return fmt.Errorf("typedcolumn: descriptor column %s block %d raw_uint32_offsets_list fixed_width_elements=%d want 0", column, blockIndex, fixedWidthElements)
+	}
+	if block.Compression != CompressionNone {
+		return fmt.Errorf("typedcolumn: descriptor column %s block %d offsets-list compression=%s want %s", column, blockIndex, block.Compression, CompressionNone)
+	}
+	if _, _, err := RawUint32OffsetsListBlockPayloadBytes(block.RowCount, block.RawBytes); err != nil {
+		return fmt.Errorf("typedcolumn: descriptor column %s block %d offsets-list raw bytes: %w", column, blockIndex, err)
+	}
+	if block.StoredBytes != block.RawBytes {
+		return fmt.Errorf("typedcolumn: descriptor column %s block %d offsets-list stored bytes=%d raw bytes=%d", column, blockIndex, block.StoredBytes, block.RawBytes)
 	}
 	return nil
 }
@@ -1355,6 +1409,12 @@ func attachColumnPayloadsFromImage(image ColumnPartImage, columns map[string]Col
 		return err
 	}
 	for name, column := range columns {
+		if column.Definition.Encoding == EncodingRawUint32OffsetsList {
+			if err := attachUint32OffsetsListColumnPayloadsFromImage(image, name, column, columns); err != nil {
+				return err
+			}
+			continue
+		}
 		section, ok := image.columnDataSection(name)
 		if !ok {
 			return fmt.Errorf("typedcolumn: image missing column data section %s", name)
@@ -1380,31 +1440,92 @@ func attachColumnPayloadsFromImage(image ColumnPartImage, columns map[string]Col
 	return nil
 }
 
-func validateColumnDataSectionsForColumns(image ColumnPartImage, columns map[string]ColumnPartColumn) error {
-	required := make(map[string]struct{}, len(columns))
-	for name := range columns {
-		required[name] = struct{}{}
+func attachUint32OffsetsListColumnPayloadsFromImage(image ColumnPartImage, name string, column ColumnPartColumn, columns map[string]ColumnPartColumn) error {
+	offsetsSection, valuesSection, ok := image.columnOffsetsListSections(name)
+	if !ok {
+		return fmt.Errorf("typedcolumn: image missing offsets-list sections %s", name)
 	}
-	seen := make(map[string]ColumnPartImageSection, len(columns))
+	offsetsRaw := image.sectionBytes(offsetsSection)
+	valuesRaw := image.sectionBytes(valuesSection)
+	if err := ValidateRawUint32OffsetsListSections(offsetsSection, valuesSection, offsetsRaw, valuesRaw, image.Rows); err != nil {
+		return err
+	}
+	offsetsCursor := 0
+	valuesCursor := 0
+	for i := range column.Blocks {
+		block := &column.Blocks[i]
+		offsetsBytes, valuesBytes, err := RawUint32OffsetsListBlockPayloadBytes(block.Descriptor.RowCount, block.Descriptor.StoredBytes)
+		if err != nil {
+			return fmt.Errorf("typedcolumn: image column %s block %d offsets-list payload: %w", name, i, err)
+		}
+		if offsetsCursor > len(offsetsRaw)-offsetsBytes || valuesCursor > len(valuesRaw)-valuesBytes {
+			return fmt.Errorf("typedcolumn: image column %s block %d outside offsets/values sections", name, i)
+		}
+		payload := make([]byte, block.Descriptor.StoredBytes)
+		copy(payload[:offsetsBytes], offsetsRaw[offsetsCursor:offsetsCursor+offsetsBytes])
+		copy(payload[offsetsBytes:], valuesRaw[valuesCursor:valuesCursor+valuesBytes])
+		block.Granule.Payload = payload
+		block.Granule.PayloadRef = PayloadRef{Kind: PayloadRefInline, Length: len(payload)}
+		offsetsCursor += offsetsBytes
+		valuesCursor += valuesBytes
+	}
+	if offsetsCursor != len(offsetsRaw) || valuesCursor != len(valuesRaw) {
+		return fmt.Errorf("typedcolumn: image column %s consumed offsets=%d/%d values=%d/%d", name, offsetsCursor, len(offsetsRaw), valuesCursor, len(valuesRaw))
+	}
+	columns[name] = column
+	return nil
+}
+
+func validateColumnDataSectionsForColumns(image ColumnPartImage, columns map[string]ColumnPartColumn) error {
+	required := make(map[string]ColumnPartColumn, len(columns))
+	for name, column := range columns {
+		required[name] = column
+	}
+	seenData := make(map[string]ColumnPartImageSection, len(columns))
+	seenOffsets := make(map[string]ColumnPartImageSection, len(columns))
+	seenValues := make(map[string]ColumnPartImageSection, len(columns))
 	for _, section := range image.Sections {
-		if section.Kind != ColumnPartImageSectionColumnData {
+		switch section.Kind {
+		case ColumnPartImageSectionColumnData, ColumnPartImageSectionColumnOffsets, ColumnPartImageSectionColumnValues:
+		default:
 			continue
 		}
 		if section.Column == "" {
-			return fmt.Errorf("typedcolumn: image column data section at offset=%d has empty column", section.Offset)
+			return fmt.Errorf("typedcolumn: image %s section at offset=%d has empty column", section.Kind, section.Offset)
 		}
 		if _, ok := required[section.Column]; !ok {
-			return fmt.Errorf("typedcolumn: image has column data section for unknown column %s at offset=%d", section.Column, section.Offset)
+			return fmt.Errorf("typedcolumn: image has %s section for unknown column %s at offset=%d", section.Kind, section.Column, section.Offset)
+		}
+		var seen map[string]ColumnPartImageSection
+		switch section.Kind {
+		case ColumnPartImageSectionColumnData:
+			seen = seenData
+		case ColumnPartImageSectionColumnOffsets:
+			seen = seenOffsets
+		case ColumnPartImageSectionColumnValues:
+			seen = seenValues
 		}
 		previous, exists := seen[section.Column]
 		if exists {
-			return fmt.Errorf("typedcolumn: duplicate column data section %s at offset=%d previous_offset=%d", section.Column, section.Offset, previous.Offset)
+			return fmt.Errorf("typedcolumn: duplicate %s section %s at offset=%d previous_offset=%d", section.Kind, section.Column, section.Offset, previous.Offset)
 		}
 		seen[section.Column] = section
 	}
-	for name := range required {
-		if _, ok := seen[name]; !ok {
+	for name, column := range required {
+		_, hasData := seenData[name]
+		_, hasOffsets := seenOffsets[name]
+		_, hasValues := seenValues[name]
+		if column.Definition.Encoding == EncodingRawUint32OffsetsList {
+			if hasData || !hasOffsets || !hasValues {
+				return fmt.Errorf("typedcolumn: image column %s offsets-list sections data=%v offsets=%v values=%v", name, hasData, hasOffsets, hasValues)
+			}
+			continue
+		}
+		if !hasData && !hasOffsets && !hasValues {
 			return fmt.Errorf("typedcolumn: image missing column data section %s", name)
+		}
+		if !hasData || hasOffsets || hasValues {
+			return fmt.Errorf("typedcolumn: image column %s dense/scalar sections data=%v offsets=%v values=%v", name, hasData, hasOffsets, hasValues)
 		}
 	}
 	return nil

--- a/TreeDB/internal/typedcolumn/part_image_decode.go
+++ b/TreeDB/internal/typedcolumn/part_image_decode.go
@@ -1450,27 +1450,47 @@ func attachUint32OffsetsListColumnPayloadsFromImage(image ColumnPartImage, name 
 	if err := ValidateRawUint32OffsetsListSections(offsetsSection, valuesSection, offsetsRaw, valuesRaw, image.Rows); err != nil {
 		return err
 	}
-	offsetsCursor := 0
-	valuesCursor := 0
+	global, err := DecodeRawUint32OffsetsListFallback(nil, nil, offsetsRaw, valuesRaw, image.Rows)
+	if err != nil {
+		return err
+	}
+	expectedFirstRow := 0
 	for i := range column.Blocks {
 		block := &column.Blocks[i]
-		offsetsBytes, valuesBytes, err := RawUint32OffsetsListBlockPayloadBytes(block.Descriptor.RowCount, block.Descriptor.StoredBytes)
+		if block.Descriptor.FirstRow != expectedFirstRow {
+			return fmt.Errorf("typedcolumn: image column %s block %d first_row=%d want %d", name, i, block.Descriptor.FirstRow, expectedFirstRow)
+		}
+		if block.Descriptor.RowCount <= 0 || block.Descriptor.FirstRow > global.Rows-block.Descriptor.RowCount {
+			return fmt.Errorf("typedcolumn: image column %s block %d row span [%d,%d) outside rows=%d", name, i, block.Descriptor.FirstRow, block.Descriptor.FirstRow+block.Descriptor.RowCount, global.Rows)
+		}
+		first := block.Descriptor.FirstRow
+		begin := global.Offsets[first]
+		end := global.Offsets[first+block.Descriptor.RowCount]
+		if begin > end || end > maxHostIntUint64() {
+			return fmt.Errorf("typedcolumn: image column %s block %d offsets range [%d,%d) invalid", name, i, begin, end)
+		}
+		beginInt := int(begin)
+		endInt := int(end)
+		if beginInt > len(global.Values) || endInt > len(global.Values) {
+			return fmt.Errorf("typedcolumn: image column %s block %d values range [%d,%d) outside values=%d", name, i, begin, end, len(global.Values))
+		}
+		localOffsets := resizeFixedWidthValues([]uint64(nil), block.Descriptor.RowCount+1)
+		for row := 0; row <= block.Descriptor.RowCount; row++ {
+			localOffsets[row] = global.Offsets[first+row] - begin
+		}
+		payload, err := EncodeRawUint32OffsetsListPayload(nil, block.Descriptor.RowCount, localOffsets, global.Values[beginInt:endInt])
 		if err != nil {
 			return fmt.Errorf("typedcolumn: image column %s block %d offsets-list payload: %w", name, i, err)
 		}
-		if offsetsCursor > len(offsetsRaw)-offsetsBytes || valuesCursor > len(valuesRaw)-valuesBytes {
-			return fmt.Errorf("typedcolumn: image column %s block %d outside offsets/values sections", name, i)
+		if len(payload) != block.Descriptor.StoredBytes {
+			return fmt.Errorf("typedcolumn: image column %s block %d payload bytes=%d descriptor stored bytes=%d", name, i, len(payload), block.Descriptor.StoredBytes)
 		}
-		payload := make([]byte, block.Descriptor.StoredBytes)
-		copy(payload[:offsetsBytes], offsetsRaw[offsetsCursor:offsetsCursor+offsetsBytes])
-		copy(payload[offsetsBytes:], valuesRaw[valuesCursor:valuesCursor+valuesBytes])
 		block.Granule.Payload = payload
 		block.Granule.PayloadRef = PayloadRef{Kind: PayloadRefInline, Length: len(payload)}
-		offsetsCursor += offsetsBytes
-		valuesCursor += valuesBytes
+		expectedFirstRow += block.Descriptor.RowCount
 	}
-	if offsetsCursor != len(offsetsRaw) || valuesCursor != len(valuesRaw) {
-		return fmt.Errorf("typedcolumn: image column %s consumed offsets=%d/%d values=%d/%d", name, offsetsCursor, len(offsetsRaw), valuesCursor, len(valuesRaw))
+	if expectedFirstRow != global.Rows {
+		return fmt.Errorf("typedcolumn: image column %s covers %d rows, want %d", name, expectedFirstRow, global.Rows)
 	}
 	columns[name] = column
 	return nil

--- a/TreeDB/internal/typedcolumn/raw_uint32_offsets_list.go
+++ b/TreeDB/internal/typedcolumn/raw_uint32_offsets_list.go
@@ -1,0 +1,196 @@
+package typedcolumn
+
+import "fmt"
+
+// RawUint32OffsetsList is the owned fallback representation for the v1
+// variable-length uint32 list primitive. Offsets has Rows+1 entries and Values
+// stores all row values concatenated; row i spans Values[Offsets[i]:Offsets[i+1]].
+type RawUint32OffsetsList struct {
+	Rows    int
+	Offsets []uint64
+	Values  []uint32
+}
+
+// EncodeRawUint32OffsetsListOffsets writes offsets as little-endian uint64
+// values. The returned slice may alias dst.
+func EncodeRawUint32OffsetsListOffsets(dst []byte, offsets []uint64) ([]byte, error) {
+	return encodeLittleEndian8Payload(dst, offsets, "raw uint32 offsets-list offsets")
+}
+
+// EncodeRawUint32OffsetsListValues writes values as little-endian uint32
+// values. The returned slice may alias dst.
+func EncodeRawUint32OffsetsListValues(dst []byte, values []uint32) ([]byte, error) {
+	return encodeLittleEndian4Payload(dst, values, "raw uint32 offsets-list values")
+}
+
+// DecodeRawUint32OffsetsListFallback decodes the split offsets and values
+// sections into owned Go slices. The returned slices never alias offsetsRaw or
+// valuesRaw, but they may reuse caller-provided destination slices.
+func DecodeRawUint32OffsetsListFallback(offsetsDst []uint64, valuesDst []uint32, offsetsRaw []byte, valuesRaw []byte, rows int) (RawUint32OffsetsList, error) {
+	if err := validateRawUint32OffsetsListBytes(offsetsRaw, valuesRaw, rows); err != nil {
+		return RawUint32OffsetsList{}, err
+	}
+	offsetCount := rows + 1
+	offsets := resizeFixedWidthValues(offsetsDst, offsetCount)
+	for i := range offsets {
+		offsets[i] = readLittleEndianUint64(offsetsRaw[i*8:])
+	}
+	valuesCount, err := validateRawUint32OffsetsListOffsets(offsets, valuesRaw)
+	if err != nil {
+		return RawUint32OffsetsList{}, err
+	}
+	values := resizeFixedWidthValues(valuesDst, valuesCount)
+	for i := range values {
+		values[i] = readLittleEndianUint32(valuesRaw[i*4:])
+	}
+	return RawUint32OffsetsList{Rows: rows, Offsets: offsets, Values: values}, nil
+}
+
+// ValidateRawUint32OffsetsListSections validates split image section metadata
+// and payload shape for raw_uint32_offsets_list without exposing unsafe direct
+// views. It fails closed on any metadata or byte-shape mismatch.
+func ValidateRawUint32OffsetsListSections(offsetsSection ColumnPartImageSection, valuesSection ColumnPartImageSection, offsetsRaw []byte, valuesRaw []byte, rows int) error {
+	if offsetsSection.Kind != ColumnPartImageSectionColumnOffsets {
+		return fmt.Errorf("typedcolumn: offsets-list offsets section kind=%s want %s", offsetsSection.Kind, ColumnPartImageSectionColumnOffsets)
+	}
+	if valuesSection.Kind != ColumnPartImageSectionColumnValues {
+		return fmt.Errorf("typedcolumn: offsets-list values section kind=%s want %s", valuesSection.Kind, ColumnPartImageSectionColumnValues)
+	}
+	if offsetsSection.Category != ColumnPartImageCategoryDeclaredColumnOffsets {
+		return fmt.Errorf("typedcolumn: offsets-list offsets section category=%s want %s", offsetsSection.Category, ColumnPartImageCategoryDeclaredColumnOffsets)
+	}
+	if valuesSection.Category != ColumnPartImageCategoryDeclaredColumnValues {
+		return fmt.Errorf("typedcolumn: offsets-list values section category=%s want %s", valuesSection.Category, ColumnPartImageCategoryDeclaredColumnValues)
+	}
+	if offsetsSection.Column == "" || valuesSection.Column == "" || offsetsSection.Column != valuesSection.Column {
+		return fmt.Errorf("typedcolumn: offsets-list column mismatch offsets=%q values=%q", offsetsSection.Column, valuesSection.Column)
+	}
+	if offsetsSection.Rows != rows || valuesSection.Rows != rows {
+		return fmt.Errorf("typedcolumn: offsets-list section rows offsets=%d values=%d want %d", offsetsSection.Rows, valuesSection.Rows, rows)
+	}
+	if offsetsSection.Encoding != EncodingRawUint32OffsetsList || valuesSection.Encoding != EncodingRawUint32OffsetsList {
+		return fmt.Errorf("typedcolumn: offsets-list section encoding offsets=%s values=%s want %s", offsetsSection.Encoding, valuesSection.Encoding, EncodingRawUint32OffsetsList)
+	}
+	if offsetsSection.Compression != CompressionNone || valuesSection.Compression != CompressionNone {
+		return fmt.Errorf("typedcolumn: offsets-list section compression offsets=%s values=%s want %s", offsetsSection.Compression, valuesSection.Compression, CompressionNone)
+	}
+	if offsetsSection.Length != len(offsetsRaw) || valuesSection.Length != len(valuesRaw) {
+		return fmt.Errorf("typedcolumn: offsets-list section lengths offsets=%d/%d values=%d/%d", offsetsSection.Length, len(offsetsRaw), valuesSection.Length, len(valuesRaw))
+	}
+	return validateRawUint32OffsetsListBytes(offsetsRaw, valuesRaw, rows)
+}
+
+// NewRawUint32OffsetsListImageSections returns image-directory metadata for the
+// split offsets and values sections. Offsets and values byte lengths are checked
+// for exact element sizing; offsets length must be (rows+1)*8.
+func NewRawUint32OffsetsListImageSections(column string, rows int, offsetsBytes int, valuesBytes int) (ColumnPartImageSection, ColumnPartImageSection, error) {
+	if column == "" {
+		return ColumnPartImageSection{}, ColumnPartImageSection{}, fmt.Errorf("typedcolumn: empty offsets-list column")
+	}
+	if err := validateRawUint32OffsetsListSectionLengths(offsetsBytes, valuesBytes, rows); err != nil {
+		return ColumnPartImageSection{}, ColumnPartImageSection{}, err
+	}
+	offsets := ColumnPartImageSection{
+		Kind:        ColumnPartImageSectionColumnOffsets,
+		Category:    ColumnPartImageCategoryDeclaredColumnOffsets,
+		Column:      column,
+		Length:      offsetsBytes,
+		Rows:        rows,
+		Encoding:    EncodingRawUint32OffsetsList,
+		Compression: CompressionNone,
+	}
+	values := ColumnPartImageSection{
+		Kind:        ColumnPartImageSectionColumnValues,
+		Category:    ColumnPartImageCategoryDeclaredColumnValues,
+		Column:      column,
+		Length:      valuesBytes,
+		Rows:        rows,
+		Encoding:    EncodingRawUint32OffsetsList,
+		Compression: CompressionNone,
+	}
+	return offsets, values, nil
+}
+
+func validateRawUint32OffsetsListBytes(offsetsRaw []byte, valuesRaw []byte, rows int) error {
+	if rows < 0 {
+		return fmt.Errorf("typedcolumn: negative offsets-list rows=%d", rows)
+	}
+	if err := validateRawUint32OffsetsListSectionLengths(len(offsetsRaw), len(valuesRaw), rows); err != nil {
+		return err
+	}
+	if len(offsetsRaw) == 0 {
+		return fmt.Errorf("typedcolumn: offsets-list missing offsets")
+	}
+	first := readLittleEndianUint64(offsetsRaw)
+	if first != 0 {
+		return fmt.Errorf("typedcolumn: offsets-list offsets[0]=%d want 0", first)
+	}
+	prev := first
+	for i := 1; i <= rows; i++ {
+		current := readLittleEndianUint64(offsetsRaw[i*8:])
+		if current < prev {
+			return fmt.Errorf("typedcolumn: offsets-list offsets[%d]=%d before previous=%d", i, current, prev)
+		}
+		prev = current
+	}
+	if prev > maxHostIntUint64() {
+		return fmt.Errorf("typedcolumn: offsets-list final offset=%d exceeds host int", prev)
+	}
+	valueCount := len(valuesRaw) / 4
+	if int(prev) != valueCount {
+		return fmt.Errorf("typedcolumn: offsets-list final offset=%d values=%d", prev, valueCount)
+	}
+	return nil
+}
+
+func validateRawUint32OffsetsListSectionLengths(offsetsBytes int, valuesBytes int, rows int) error {
+	if rows < 0 {
+		return fmt.Errorf("typedcolumn: negative offsets-list rows=%d", rows)
+	}
+	offsetCount, err := checkedAddInt(rows, 1, "raw uint32 offsets-list offset count")
+	if err != nil {
+		return err
+	}
+	wantOffsetsBytes, err := checkedMulInt(offsetCount, 8, "raw uint32 offsets-list offsets bytes")
+	if err != nil {
+		return err
+	}
+	if offsetsBytes != wantOffsetsBytes {
+		return fmt.Errorf("typedcolumn: offsets-list offsets bytes=%d want=%d", offsetsBytes, wantOffsetsBytes)
+	}
+	if valuesBytes < 0 {
+		return fmt.Errorf("typedcolumn: offsets-list values bytes=%d", valuesBytes)
+	}
+	if valuesBytes%4 != 0 {
+		return fmt.Errorf("typedcolumn: offsets-list values bytes=%d not multiple of 4", valuesBytes)
+	}
+	return nil
+}
+
+func maxHostIntUint64() uint64 {
+	return uint64(^uint(0) >> 1)
+}
+
+func validateRawUint32OffsetsListOffsets(offsets []uint64, valuesRaw []byte) (int, error) {
+	if len(offsets) == 0 {
+		return 0, fmt.Errorf("typedcolumn: offsets-list missing offsets")
+	}
+	if offsets[0] != 0 {
+		return 0, fmt.Errorf("typedcolumn: offsets-list offsets[0]=%d want 0", offsets[0])
+	}
+	prev := offsets[0]
+	for i := 1; i < len(offsets); i++ {
+		if offsets[i] < prev {
+			return 0, fmt.Errorf("typedcolumn: offsets-list offsets[%d]=%d before previous=%d", i, offsets[i], prev)
+		}
+		prev = offsets[i]
+	}
+	if prev > maxHostIntUint64() {
+		return 0, fmt.Errorf("typedcolumn: offsets-list final offset=%d exceeds host int", prev)
+	}
+	valuesCount := len(valuesRaw) / 4
+	if int(prev) != valuesCount {
+		return 0, fmt.Errorf("typedcolumn: offsets-list final offset=%d values=%d", prev, valuesCount)
+	}
+	return valuesCount, nil
+}

--- a/TreeDB/internal/typedcolumn/raw_uint32_offsets_list.go
+++ b/TreeDB/internal/typedcolumn/raw_uint32_offsets_list.go
@@ -23,6 +23,40 @@ func EncodeRawUint32OffsetsListValues(dst []byte, values []uint32) ([]byte, erro
 	return encodeLittleEndian4Payload(dst, values, "raw uint32 offsets-list values")
 }
 
+// EncodeRawUint32OffsetsListPayload writes the canonical fallback block payload:
+// offsets bytes followed by values bytes. Image writers split this combined
+// block payload into independent offsets and values sections.
+func EncodeRawUint32OffsetsListPayload(dst []byte, rows int, offsets []uint64, values []uint32) ([]byte, error) {
+	if err := ValidateRawUint32OffsetsListShape(rows, offsets, uint64(len(values))); err != nil {
+		return nil, err
+	}
+	offsetsBytes, err := checkedMulInt(rows+1, 8, "raw uint32 offsets-list offsets bytes")
+	if err != nil {
+		return nil, err
+	}
+	valuesBytes, err := checkedMulInt(len(values), 4, "raw uint32 offsets-list values bytes")
+	if err != nil {
+		return nil, err
+	}
+	total, err := checkedAddInt(offsetsBytes, valuesBytes, "raw uint32 offsets-list payload bytes")
+	if err != nil {
+		return nil, err
+	}
+	out := dst
+	if cap(out) < total {
+		out = make([]byte, total)
+	} else {
+		out = out[:total]
+	}
+	if _, err := EncodeRawUint32OffsetsListOffsets(out[:0], offsets); err != nil {
+		return nil, err
+	}
+	if _, err := EncodeRawUint32OffsetsListValues(out[offsetsBytes:offsetsBytes], values); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // DecodeRawUint32OffsetsListFallback decodes the split offsets and values
 // sections into owned Go slices. The returned slices never alias offsetsRaw or
 // valuesRaw, but they may reuse caller-provided destination slices.
@@ -44,6 +78,81 @@ func DecodeRawUint32OffsetsListFallback(offsetsDst []uint64, valuesDst []uint32,
 		values[i] = readLittleEndianUint32(valuesRaw[i*4:])
 	}
 	return RawUint32OffsetsList{Rows: rows, Offsets: offsets, Values: values}, nil
+}
+
+// DecodeRawUint32OffsetsListPayload decodes the combined block payload produced
+// by EncodeRawUint32OffsetsListPayload into owned Go slices.
+func DecodeRawUint32OffsetsListPayload(offsetsDst []uint64, valuesDst []uint32, raw []byte, rows int) (RawUint32OffsetsList, error) {
+	offsetsBytes, valuesBytes, err := RawUint32OffsetsListBlockPayloadBytes(rows, len(raw))
+	if err != nil {
+		return RawUint32OffsetsList{}, err
+	}
+	return DecodeRawUint32OffsetsListFallback(offsetsDst, valuesDst, raw[:offsetsBytes], raw[offsetsBytes:offsetsBytes+valuesBytes], rows)
+}
+
+// ValidateRawUint32OffsetsListShape validates owned offset/value counts before
+// encoding or row slicing. values is the number of uint32 values, not bytes.
+func ValidateRawUint32OffsetsListShape(rows int, offsets []uint64, values uint64) error {
+	if rows < 0 {
+		return fmt.Errorf("typedcolumn: negative offsets-list rows=%d", rows)
+	}
+	maxInt := int(^uint(0) >> 1)
+	if rows == maxInt {
+		return fmt.Errorf("typedcolumn: offsets-list row_count+1 overflows int")
+	}
+	wantOffsets := rows + 1
+	if len(offsets) != wantOffsets {
+		return fmt.Errorf("typedcolumn: offsets-list offsets=%d want row_count+1=%d", len(offsets), wantOffsets)
+	}
+	if len(offsets) == 0 {
+		return fmt.Errorf("typedcolumn: offsets-list missing offsets")
+	}
+	if offsets[0] != 0 {
+		return fmt.Errorf("typedcolumn: offsets-list offsets[0]=%d want 0", offsets[0])
+	}
+	maxIndex := uint64(maxInt)
+	if values > maxIndex {
+		return fmt.Errorf("typedcolumn: offsets-list values=%d exceeds host int", values)
+	}
+	prev := uint64(0)
+	for i, offset := range offsets {
+		if offset > maxIndex {
+			return fmt.Errorf("typedcolumn: offsets-list offsets[%d]=%d exceeds host int", i, offset)
+		}
+		if i > 0 && offset < prev {
+			return fmt.Errorf("typedcolumn: offsets-list offsets[%d]=%d before previous=%d", i, offset, prev)
+		}
+		prev = offset
+	}
+	if final := offsets[rows]; final != values {
+		return fmt.Errorf("typedcolumn: offsets-list final offset=%d values=%d", final, values)
+	}
+	return nil
+}
+
+// RawUint32OffsetsListBlockPayloadBytes returns the split byte lengths for a
+// combined block payload. rawBytes must be exactly offsets bytes plus a uint32
+// values byte multiple.
+func RawUint32OffsetsListBlockPayloadBytes(rows int, rawBytes int) (offsetsBytes int, valuesBytes int, err error) {
+	if rows < 0 {
+		return 0, 0, fmt.Errorf("typedcolumn: negative offsets-list rows=%d", rows)
+	}
+	offsetCount, err := checkedAddInt(rows, 1, "raw uint32 offsets-list offset count")
+	if err != nil {
+		return 0, 0, err
+	}
+	offsetsBytes, err = checkedMulInt(offsetCount, 8, "raw uint32 offsets-list offsets bytes")
+	if err != nil {
+		return 0, 0, err
+	}
+	if rawBytes < offsetsBytes {
+		return 0, 0, fmt.Errorf("typedcolumn: offsets-list raw bytes=%d shorter than offsets bytes=%d", rawBytes, offsetsBytes)
+	}
+	valuesBytes = rawBytes - offsetsBytes
+	if valuesBytes%4 != 0 {
+		return 0, 0, fmt.Errorf("typedcolumn: offsets-list values bytes=%d not multiple of 4", valuesBytes)
+	}
+	return offsetsBytes, valuesBytes, nil
 }
 
 // ValidateRawUint32OffsetsListSections validates split image section metadata
@@ -93,6 +202,7 @@ func NewRawUint32OffsetsListImageSections(column string, rows int, offsetsBytes 
 	offsets := ColumnPartImageSection{
 		Kind:        ColumnPartImageSectionColumnOffsets,
 		Category:    ColumnPartImageCategoryDeclaredColumnOffsets,
+		Name:        "offsets",
 		Column:      column,
 		Length:      offsetsBytes,
 		Rows:        rows,
@@ -102,6 +212,7 @@ func NewRawUint32OffsetsListImageSections(column string, rows int, offsetsBytes 
 	values := ColumnPartImageSection{
 		Kind:        ColumnPartImageSectionColumnValues,
 		Category:    ColumnPartImageCategoryDeclaredColumnValues,
+		Name:        "values",
 		Column:      column,
 		Length:      valuesBytes,
 		Rows:        rows,
@@ -128,6 +239,9 @@ func validateRawUint32OffsetsListBytes(offsetsRaw []byte, valuesRaw []byte, rows
 	prev := first
 	for i := 1; i <= rows; i++ {
 		current := readLittleEndianUint64(offsetsRaw[i*8:])
+		if current > maxHostIntUint64() {
+			return fmt.Errorf("typedcolumn: offsets-list offsets[%d]=%d exceeds host int", i, current)
+		}
 		if current < prev {
 			return fmt.Errorf("typedcolumn: offsets-list offsets[%d]=%d before previous=%d", i, current, prev)
 		}
@@ -180,6 +294,9 @@ func validateRawUint32OffsetsListOffsets(offsets []uint64, valuesRaw []byte) (in
 	}
 	prev := offsets[0]
 	for i := 1; i < len(offsets); i++ {
+		if offsets[i] > maxHostIntUint64() {
+			return 0, fmt.Errorf("typedcolumn: offsets-list offsets[%d]=%d exceeds host int", i, offsets[i])
+		}
 		if offsets[i] < prev {
 			return 0, fmt.Errorf("typedcolumn: offsets-list offsets[%d]=%d before previous=%d", i, offsets[i], prev)
 		}
@@ -193,4 +310,69 @@ func validateRawUint32OffsetsListOffsets(offsets []uint64, valuesRaw []byte) (in
 		return 0, fmt.Errorf("typedcolumn: offsets-list final offset=%d values=%d", prev, valuesCount)
 	}
 	return valuesCount, nil
+}
+
+// BuildUint32OffsetsList builds an uncompressed raw_uint32_offsets_list granule.
+// The granule payload is the canonical combined block payload: offsets bytes
+// followed by values bytes. Image serialization splits that payload into
+// independently checksummed offsets and values sections.
+func (b *GranuleBuilder) BuildUint32OffsetsList(rows int, offsets []uint64, values []uint32) (EncodedGranule, error) {
+	if b.cfg.Encoding != 0 && b.cfg.Encoding != EncodingRawUint32OffsetsList {
+		return EncodedGranule{}, fmt.Errorf("typedcolumn: uint32 offsets-list encoding=%s want %s", b.cfg.Encoding, EncodingRawUint32OffsetsList)
+	}
+	if b.cfg.Compression != CompressionNone {
+		return EncodedGranule{}, fmt.Errorf("typedcolumn: uint32 offsets-list sections require compression=none, got %s", b.cfg.Compression)
+	}
+	if rows <= 0 {
+		return EncodedGranule{}, fmt.Errorf("typedcolumn: invalid uint32 offsets-list rows %d", rows)
+	}
+	raw, err := EncodeRawUint32OffsetsListPayload(b.raw[:0], rows, offsets, values)
+	if err != nil {
+		return EncodedGranule{}, err
+	}
+	b.raw = raw
+	selection, err := admitCompressionInto(b.compressed[:0], raw, EncodingRawUint32OffsetsList, b.cfg.Compression)
+	if err != nil {
+		return EncodedGranule{}, err
+	}
+	b.compressed = selection.Scratch
+	return newEncodedGranule(rows, 0, 0, false, EncodingRawUint32OffsetsList, selection), nil
+}
+
+// DecodeUint32OffsetsListInto decodes a raw_uint32_offsets_list granule into
+// owned offsets and values slices. It does not expose direct/mmap views.
+func (r *GranuleReader) DecodeUint32OffsetsListInto(offsetsDst []uint64, valuesDst []uint32, g EncodedGranule) (RawUint32OffsetsList, error) {
+	if g.Encoding != EncodingRawUint32OffsetsList {
+		return RawUint32OffsetsList{}, fmt.Errorf("typedcolumn: uint32 offsets-list encoding=%s want %s", g.Encoding, EncodingRawUint32OffsetsList)
+	}
+	if err := validateUint32OffsetsListGranule(g); err != nil {
+		return RawUint32OffsetsList{}, err
+	}
+	return DecodeRawUint32OffsetsListPayload(offsetsDst, valuesDst, g.Payload, g.Rows)
+}
+
+func validateUint32OffsetsListGranule(g EncodedGranule) error {
+	if g.Rows <= 0 {
+		return fmt.Errorf("typedcolumn: invalid uint32 offsets-list rows %d", g.Rows)
+	}
+	if err := validateGranuleDecodeRows(g.Rows); err != nil {
+		return err
+	}
+	if g.Compression != CompressionNone {
+		return fmt.Errorf("typedcolumn: uint32 offsets-list section requires compression=none, got %s", g.Compression)
+	}
+	if g.NullCount != 0 || g.DefaultCount != 0 {
+		return fmt.Errorf("typedcolumn: uint32 offsets-list section has null/default counts")
+	}
+	if g.HasMinMax {
+		return fmt.Errorf("typedcolumn: uint32 offsets-list section unexpectedly has min/max")
+	}
+	if g.StoredBytes != g.RawBytes || len(g.Payload) != g.RawBytes {
+		return fmt.Errorf("typedcolumn: uint32 offsets-list stored bytes=%d payload=%d raw=%d", g.StoredBytes, len(g.Payload), g.RawBytes)
+	}
+	if g.PayloadRef.Kind != PayloadRefInline || g.PayloadRef.Offset != 0 || g.PayloadRef.Length != len(g.Payload) {
+		return fmt.Errorf("typedcolumn: uint32 offsets-list payload ref kind=%s offset=%d length=%d payload=%d", g.PayloadRef.Kind, g.PayloadRef.Offset, g.PayloadRef.Length, len(g.Payload))
+	}
+	_, _, err := RawUint32OffsetsListBlockPayloadBytes(g.Rows, g.RawBytes)
+	return err
 }

--- a/TreeDB/internal/typedcolumn/raw_uint32_offsets_list.go
+++ b/TreeDB/internal/typedcolumn/raw_uint32_offsets_list.go
@@ -61,17 +61,14 @@ func EncodeRawUint32OffsetsListPayload(dst []byte, rows int, offsets []uint64, v
 // sections into owned Go slices. The returned slices never alias offsetsRaw or
 // valuesRaw, but they may reuse caller-provided destination slices.
 func DecodeRawUint32OffsetsListFallback(offsetsDst []uint64, valuesDst []uint32, offsetsRaw []byte, valuesRaw []byte, rows int) (RawUint32OffsetsList, error) {
-	if err := validateRawUint32OffsetsListBytes(offsetsRaw, valuesRaw, rows); err != nil {
+	valuesCount, err := validateRawUint32OffsetsListBytes(offsetsRaw, valuesRaw, rows)
+	if err != nil {
 		return RawUint32OffsetsList{}, err
 	}
 	offsetCount := rows + 1
 	offsets := resizeFixedWidthValues(offsetsDst, offsetCount)
 	for i := range offsets {
 		offsets[i] = readLittleEndianUint64(offsetsRaw[i*8:])
-	}
-	valuesCount, err := validateRawUint32OffsetsListOffsets(offsets, valuesRaw)
-	if err != nil {
-		return RawUint32OffsetsList{}, err
 	}
 	values := resizeFixedWidthValues(valuesDst, valuesCount)
 	for i := range values {
@@ -186,7 +183,8 @@ func ValidateRawUint32OffsetsListSections(offsetsSection ColumnPartImageSection,
 	if offsetsSection.Length != len(offsetsRaw) || valuesSection.Length != len(valuesRaw) {
 		return fmt.Errorf("typedcolumn: offsets-list section lengths offsets=%d/%d values=%d/%d", offsetsSection.Length, len(offsetsRaw), valuesSection.Length, len(valuesRaw))
 	}
-	return validateRawUint32OffsetsListBytes(offsetsRaw, valuesRaw, rows)
+	_, err := validateRawUint32OffsetsListBytes(offsetsRaw, valuesRaw, rows)
+	return err
 }
 
 // NewRawUint32OffsetsListImageSections returns image-directory metadata for the
@@ -222,39 +220,39 @@ func NewRawUint32OffsetsListImageSections(column string, rows int, offsetsBytes 
 	return offsets, values, nil
 }
 
-func validateRawUint32OffsetsListBytes(offsetsRaw []byte, valuesRaw []byte, rows int) error {
+func validateRawUint32OffsetsListBytes(offsetsRaw []byte, valuesRaw []byte, rows int) (int, error) {
 	if rows < 0 {
-		return fmt.Errorf("typedcolumn: negative offsets-list rows=%d", rows)
+		return 0, fmt.Errorf("typedcolumn: negative offsets-list rows=%d", rows)
 	}
 	if err := validateRawUint32OffsetsListSectionLengths(len(offsetsRaw), len(valuesRaw), rows); err != nil {
-		return err
+		return 0, err
 	}
 	if len(offsetsRaw) == 0 {
-		return fmt.Errorf("typedcolumn: offsets-list missing offsets")
+		return 0, fmt.Errorf("typedcolumn: offsets-list missing offsets")
 	}
 	first := readLittleEndianUint64(offsetsRaw)
 	if first != 0 {
-		return fmt.Errorf("typedcolumn: offsets-list offsets[0]=%d want 0", first)
+		return 0, fmt.Errorf("typedcolumn: offsets-list offsets[0]=%d want 0", first)
 	}
 	prev := first
 	for i := 1; i <= rows; i++ {
 		current := readLittleEndianUint64(offsetsRaw[i*8:])
 		if current > maxHostIntUint64() {
-			return fmt.Errorf("typedcolumn: offsets-list offsets[%d]=%d exceeds host int", i, current)
+			return 0, fmt.Errorf("typedcolumn: offsets-list offsets[%d]=%d exceeds host int", i, current)
 		}
 		if current < prev {
-			return fmt.Errorf("typedcolumn: offsets-list offsets[%d]=%d before previous=%d", i, current, prev)
+			return 0, fmt.Errorf("typedcolumn: offsets-list offsets[%d]=%d before previous=%d", i, current, prev)
 		}
 		prev = current
 	}
 	if prev > maxHostIntUint64() {
-		return fmt.Errorf("typedcolumn: offsets-list final offset=%d exceeds host int", prev)
+		return 0, fmt.Errorf("typedcolumn: offsets-list final offset=%d exceeds host int", prev)
 	}
 	valueCount := len(valuesRaw) / 4
 	if int(prev) != valueCount {
-		return fmt.Errorf("typedcolumn: offsets-list final offset=%d values=%d", prev, valueCount)
+		return 0, fmt.Errorf("typedcolumn: offsets-list final offset=%d values=%d", prev, valueCount)
 	}
-	return nil
+	return valueCount, nil
 }
 
 func validateRawUint32OffsetsListSectionLengths(offsetsBytes int, valuesBytes int, rows int) error {
@@ -283,33 +281,6 @@ func validateRawUint32OffsetsListSectionLengths(offsetsBytes int, valuesBytes in
 
 func maxHostIntUint64() uint64 {
 	return uint64(^uint(0) >> 1)
-}
-
-func validateRawUint32OffsetsListOffsets(offsets []uint64, valuesRaw []byte) (int, error) {
-	if len(offsets) == 0 {
-		return 0, fmt.Errorf("typedcolumn: offsets-list missing offsets")
-	}
-	if offsets[0] != 0 {
-		return 0, fmt.Errorf("typedcolumn: offsets-list offsets[0]=%d want 0", offsets[0])
-	}
-	prev := offsets[0]
-	for i := 1; i < len(offsets); i++ {
-		if offsets[i] > maxHostIntUint64() {
-			return 0, fmt.Errorf("typedcolumn: offsets-list offsets[%d]=%d exceeds host int", i, offsets[i])
-		}
-		if offsets[i] < prev {
-			return 0, fmt.Errorf("typedcolumn: offsets-list offsets[%d]=%d before previous=%d", i, offsets[i], prev)
-		}
-		prev = offsets[i]
-	}
-	if prev > maxHostIntUint64() {
-		return 0, fmt.Errorf("typedcolumn: offsets-list final offset=%d exceeds host int", prev)
-	}
-	valuesCount := len(valuesRaw) / 4
-	if int(prev) != valuesCount {
-		return 0, fmt.Errorf("typedcolumn: offsets-list final offset=%d values=%d", prev, valuesCount)
-	}
-	return valuesCount, nil
 }
 
 // BuildUint32OffsetsList builds an uncompressed raw_uint32_offsets_list granule.

--- a/TreeDB/internal/typedcolumn/raw_uint32_offsets_list_test.go
+++ b/TreeDB/internal/typedcolumn/raw_uint32_offsets_list_test.go
@@ -1,0 +1,289 @@
+package typedcolumn
+
+import (
+	"bytes"
+	"math"
+	"strings"
+	"testing"
+)
+
+func TestRawUint32OffsetsListLittleEndianFixtures(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name        string
+		rows        int
+		offsets     []uint64
+		values      []uint32
+		wantOffsets []byte
+		wantValues  []byte
+	}{
+		{
+			name:        "empty_rows",
+			rows:        0,
+			offsets:     []uint64{0},
+			values:      nil,
+			wantOffsets: []byte{0, 0, 0, 0, 0, 0, 0, 0},
+			wantValues:  []byte{},
+		},
+		{
+			name:        "all_empty_rows",
+			rows:        3,
+			offsets:     []uint64{0, 0, 0, 0},
+			values:      nil,
+			wantOffsets: []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			wantValues:  []byte{},
+		},
+		{
+			name:    "mixed_empty_and_non_empty_rows",
+			rows:    4,
+			offsets: []uint64{0, 0, 2, 2, 3},
+			values:  []uint32{7, 8, 9},
+			wantOffsets: []byte{
+				0, 0, 0, 0, 0, 0, 0, 0,
+				0, 0, 0, 0, 0, 0, 0, 0,
+				2, 0, 0, 0, 0, 0, 0, 0,
+				2, 0, 0, 0, 0, 0, 0, 0,
+				3, 0, 0, 0, 0, 0, 0, 0,
+			},
+			wantValues: []byte{7, 0, 0, 0, 8, 0, 0, 0, 9, 0, 0, 0},
+		},
+		{
+			name:    "multi_value_rows",
+			rows:    2,
+			offsets: []uint64{0, 3, 5},
+			values:  []uint32{1, 2, 3, 0x01020304, math.MaxUint32},
+			wantOffsets: []byte{
+				0, 0, 0, 0, 0, 0, 0, 0,
+				3, 0, 0, 0, 0, 0, 0, 0,
+				5, 0, 0, 0, 0, 0, 0, 0,
+			},
+			wantValues: []byte{
+				1, 0, 0, 0,
+				2, 0, 0, 0,
+				3, 0, 0, 0,
+				4, 3, 2, 1,
+				255, 255, 255, 255,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			offsetsRaw, err := EncodeRawUint32OffsetsListOffsets(nil, tc.offsets)
+			if err != nil {
+				t.Fatalf("encode offsets: %v", err)
+			}
+			valuesRaw, err := EncodeRawUint32OffsetsListValues(nil, tc.values)
+			if err != nil {
+				t.Fatalf("encode values: %v", err)
+			}
+			if !bytes.Equal(offsetsRaw, tc.wantOffsets) {
+				t.Fatalf("offset bytes\n got %v\nwant %v", offsetsRaw, tc.wantOffsets)
+			}
+			if !bytes.Equal(valuesRaw, tc.wantValues) {
+				t.Fatalf("value bytes\n got %v\nwant %v", valuesRaw, tc.wantValues)
+			}
+
+			decoded, err := DecodeRawUint32OffsetsListFallback(nil, nil, offsetsRaw, valuesRaw, tc.rows)
+			if err != nil {
+				t.Fatalf("decode fallback: %v", err)
+			}
+			if decoded.Rows != tc.rows || !equalUint64s(decoded.Offsets, tc.offsets) || !equalUint32s(decoded.Values, tc.values) {
+				t.Fatalf("decoded=%+v want rows=%d offsets=%v values=%v", decoded, tc.rows, tc.offsets, tc.values)
+			}
+			if len(offsetsRaw) != 0 && len(decoded.Offsets) != 0 {
+				offsetsRaw[0] = 99
+				if decoded.Offsets[0] != 0 {
+					t.Fatalf("decoded offsets alias raw bytes")
+				}
+			}
+			if len(valuesRaw) != 0 && len(decoded.Values) != 0 {
+				valuesRaw[0] = 99
+				if decoded.Values[0] != tc.values[0] {
+					t.Fatalf("decoded values alias raw bytes")
+				}
+			}
+		})
+	}
+}
+
+func TestRawUint32OffsetsListCorruptionValidation(t *testing.T) {
+	t.Parallel()
+	offsetsRaw := mustOffsetsListOffsets(t, []uint64{0, 1, 3})
+	valuesRaw := mustOffsetsListValues(t, []uint32{10, 20, 30})
+
+	tests := []struct {
+		name       string
+		offsetsRaw []byte
+		valuesRaw  []byte
+		rows       int
+		want       string
+	}{
+		{name: "offsets_first_not_zero", offsetsRaw: mustOffsetsListOffsets(t, []uint64{1, 1}), valuesRaw: nil, rows: 1, want: "offsets[0]"},
+		{name: "non_monotonic_offsets", offsetsRaw: mustOffsetsListOffsets(t, []uint64{0, 2, 1}), valuesRaw: mustOffsetsListValues(t, []uint32{1, 2}), rows: 2, want: "before previous"},
+		{name: "final_offset_less_than_values", offsetsRaw: mustOffsetsListOffsets(t, []uint64{0, 1}), valuesRaw: mustOffsetsListValues(t, []uint32{1, 2}), rows: 1, want: "final offset=1 values=2"},
+		{name: "final_offset_greater_than_values", offsetsRaw: mustOffsetsListOffsets(t, []uint64{0, 2}), valuesRaw: mustOffsetsListValues(t, []uint32{1}), rows: 1, want: "final offset=2 values=1"},
+		{name: "go_int_overflow", offsetsRaw: mustOffsetsListOffsets(t, []uint64{0, math.MaxUint64}), valuesRaw: nil, rows: 1, want: "exceeds host int"},
+		{name: "truncated_offsets", offsetsRaw: offsetsRaw[:len(offsetsRaw)-1], valuesRaw: valuesRaw, rows: 2, want: "offsets bytes"},
+		{name: "truncated_values", offsetsRaw: mustOffsetsListOffsets(t, []uint64{0, 1}), valuesRaw: []byte{1, 0, 0}, rows: 1, want: "not multiple of 4"},
+		{name: "row_count_mismatch", offsetsRaw: offsetsRaw, valuesRaw: valuesRaw, rows: 1, want: "offsets bytes"},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := DecodeRawUint32OffsetsListFallback(nil, nil, tc.offsetsRaw, tc.valuesRaw, tc.rows)
+			if err == nil {
+				t.Fatalf("expected error")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error %q does not contain %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestRawUint32OffsetsListSectionMetadataValidation(t *testing.T) {
+	t.Parallel()
+	offsetsRaw := mustOffsetsListOffsets(t, []uint64{0, 2})
+	valuesRaw := mustOffsetsListValues(t, []uint32{1, 2})
+	offsets, values, err := NewRawUint32OffsetsListImageSections("neighbors", 1, len(offsetsRaw), len(valuesRaw))
+	if err != nil {
+		t.Fatalf("sections: %v", err)
+	}
+	if err := ValidateRawUint32OffsetsListSections(offsets, values, offsetsRaw, valuesRaw, 1); err != nil {
+		t.Fatalf("validate sections: %v", err)
+	}
+
+	t.Run("unsupported_encoding", func(t *testing.T) {
+		bad := offsets
+		bad.Encoding = EncodingRawUint32Dense
+		if err := ValidateRawUint32OffsetsListSections(bad, values, offsetsRaw, valuesRaw, 1); err == nil || !strings.Contains(err.Error(), "encoding") {
+			t.Fatalf("err=%v", err)
+		}
+	})
+	t.Run("mismatched_encoding", func(t *testing.T) {
+		bad := values
+		bad.Encoding = EncodingRawUint32Dense
+		if err := ValidateRawUint32OffsetsListSections(offsets, bad, offsetsRaw, valuesRaw, 1); err == nil || !strings.Contains(err.Error(), "encoding") {
+			t.Fatalf("err=%v", err)
+		}
+	})
+	t.Run("row_count_mismatch", func(t *testing.T) {
+		bad := values
+		bad.Rows = 2
+		if err := ValidateRawUint32OffsetsListSections(offsets, bad, offsetsRaw, valuesRaw, 1); err == nil || !strings.Contains(err.Error(), "rows") {
+			t.Fatalf("err=%v", err)
+		}
+	})
+	t.Run("section_length_mismatch", func(t *testing.T) {
+		bad := values
+		bad.Length++
+		if err := ValidateRawUint32OffsetsListSections(offsets, bad, offsetsRaw, valuesRaw, 1); err == nil || !strings.Contains(err.Error(), "lengths") {
+			t.Fatalf("err=%v", err)
+		}
+	})
+}
+
+func TestRawUint32OffsetsListImageStorageAccounting(t *testing.T) {
+	t.Parallel()
+	part := &ColumnPart{Descriptor: ColumnPartDescriptor{RowCount: 2}}
+	image := ColumnPartImage{
+		ManifestBytes: 10,
+		Bytes:         make([]byte, 52),
+		Sections: []ColumnPartImageSection{
+			{Kind: ColumnPartImageSectionColumnOffsets, Category: ColumnPartImageCategoryDeclaredColumnOffsets, Column: "neighbors", Offset: 16, Length: 16},
+			{Kind: ColumnPartImageSectionColumnValues, Category: ColumnPartImageCategoryDeclaredColumnValues, Column: "neighbors", Offset: 40, Length: 12},
+		},
+	}
+	accounting := part.ByteAccountingFromImage(image)
+	if accounting.DeclaredColumnOffsetsBytes != 16 {
+		t.Fatalf("offsets bytes=%d", accounting.DeclaredColumnOffsetsBytes)
+	}
+	if accounting.DeclaredColumnValuesBytes != 12 {
+		t.Fatalf("values bytes=%d", accounting.DeclaredColumnValuesBytes)
+	}
+	if accounting.DeclaredColumnBytes != 28 {
+		t.Fatalf("declared column bytes=%d", accounting.DeclaredColumnBytes)
+	}
+	if accounting.SerializedPaddingBytes != 14 {
+		t.Fatalf("padding bytes=%d", accounting.SerializedPaddingBytes)
+	}
+	if accounting.TotalStoredBytes != 52 {
+		t.Fatalf("total stored bytes=%d", accounting.TotalStoredBytes)
+	}
+}
+
+func BenchmarkRawUint32OffsetsListFallbackDecode(b *testing.B) {
+	const rows = 8192
+	offsets := make([]uint64, rows+1)
+	values := make([]uint32, 0, rows*3)
+	for row := 0; row < rows; row++ {
+		count := row%7 + 1
+		for j := 0; j < count; j++ {
+			values = append(values, uint32(row+j))
+		}
+		offsets[row+1] = uint64(len(values))
+	}
+	offsetsRaw := mustOffsetsListOffsets(b, offsets)
+	valuesRaw := mustOffsetsListValues(b, values)
+	decodedBytes := len(offsetsRaw) + len(valuesRaw)
+	b.SetBytes(int64(decodedBytes))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		decoded, err := DecodeRawUint32OffsetsListFallback(nil, nil, offsetsRaw, valuesRaw, rows)
+		if err != nil {
+			b.Fatal(err)
+		}
+		rawUint32OffsetsListSink = decoded
+	}
+	b.ReportMetric(float64(rows), "rows/op")
+	b.ReportMetric(float64(len(values)), "total_values/op")
+	b.ReportMetric(float64(decodedBytes), "decoded_bytes/op")
+}
+
+var rawUint32OffsetsListSink RawUint32OffsetsList
+
+func mustOffsetsListOffsets(tb testing.TB, offsets []uint64) []byte {
+	tb.Helper()
+	raw, err := EncodeRawUint32OffsetsListOffsets(nil, offsets)
+	if err != nil {
+		tb.Fatalf("encode offsets: %v", err)
+	}
+	return raw
+}
+
+func mustOffsetsListValues(tb testing.TB, values []uint32) []byte {
+	tb.Helper()
+	raw, err := EncodeRawUint32OffsetsListValues(nil, values)
+	if err != nil {
+		tb.Fatalf("encode values: %v", err)
+	}
+	return raw
+}
+
+func equalUint64s(a, b []uint64) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func equalUint32s(a, b []uint32) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/TreeDB/internal/typedcolumn/raw_uint32_offsets_list_test.go
+++ b/TreeDB/internal/typedcolumn/raw_uint32_offsets_list_test.go
@@ -219,6 +219,13 @@ func TestRawUint32OffsetsListColumnPartImageRoundTrip1915(t *testing.T) {
 	if err != nil {
 		t.Fatalf("BuildColumnPart: %v", err)
 	}
+	neighbors := part.Columns["neighbors"]
+	if got := len(part.Descriptor.Granules); got != 2 {
+		t.Fatalf("granules=%d want 2", got)
+	}
+	if got := len(neighbors.Blocks); got != 2 {
+		t.Fatalf("offsets-list blocks=%d want 2", got)
+	}
 	image, err := BuildColumnPartImage(part, ColumnPartImageOptions{LayoutLogicalTypes: map[string]string{"neighbors": "adjacency_list"}})
 	if err != nil {
 		t.Fatalf("BuildColumnPartImage: %v", err)
@@ -236,6 +243,12 @@ func TestRawUint32OffsetsListColumnPartImageRoundTrip1915(t *testing.T) {
 	if offsetsSection.Offset >= valuesSection.Offset {
 		t.Fatalf("section order offsets=%d values=%d", offsetsSection.Offset, valuesSection.Offset)
 	}
+	if !bytes.Equal(image.sectionBytes(offsetsSection), mustOffsetsListOffsets(t, []uint64{0, 0, 2, 2, 5})) {
+		t.Fatalf("global offsets section bytes=%v", image.sectionBytes(offsetsSection))
+	}
+	if !bytes.Equal(image.sectionBytes(valuesSection), mustOffsetsListValues(t, []uint32{7, 8, 9, 10, 11})) {
+		t.Fatalf("values section bytes=%v", image.sectionBytes(valuesSection))
+	}
 	if err := ValidateRawUint32OffsetsListSections(offsetsSection, valuesSection, image.sectionBytes(offsetsSection), image.sectionBytes(valuesSection), 4); err != nil {
 		t.Fatalf("ValidateRawUint32OffsetsListSections: %v", err)
 	}
@@ -249,6 +262,11 @@ func TestRawUint32OffsetsListColumnPartImageRoundTrip1915(t *testing.T) {
 	}
 	if certColumn.OffsetsBytes != offsetsSection.Length || certColumn.ValuesBytes != valuesSection.Length || certColumn.DirectViewCertified {
 		t.Fatalf("certified offsets-list column=%+v", certColumn)
+	}
+	for i, block := range certColumn.Blocks {
+		if block.PayloadOffset != 0 || block.PayloadLength != 0 {
+			t.Fatalf("certified offsets-list block %d payload offset/length=(%d,%d) want (0,0)", i, block.PayloadOffset, block.PayloadLength)
+		}
 	}
 	parsed, err := ParseColumnPartImage(image.Bytes)
 	if err != nil {

--- a/TreeDB/internal/typedcolumn/raw_uint32_offsets_list_test.go
+++ b/TreeDB/internal/typedcolumn/raw_uint32_offsets_list_test.go
@@ -145,6 +145,18 @@ func TestRawUint32OffsetsListCorruptionValidation(t *testing.T) {
 	}
 }
 
+func TestRawUint32OffsetsListGranuleEncodingMismatchFailsClosed(t *testing.T) {
+	raw, err := EncodeRawUint32OffsetsListPayload(nil, 1, []uint64{0, 1}, []uint32{42})
+	if err != nil {
+		t.Fatalf("EncodeRawUint32OffsetsListPayload: %v", err)
+	}
+	g := EncodedGranule{Rows: 1, Encoding: EncodingRawUint32Dense, Compression: CompressionNone, RawBytes: len(raw), StoredBytes: len(raw), PayloadRef: PayloadRef{Kind: PayloadRefInline, Length: len(raw)}, Payload: raw}
+	var reader GranuleReader
+	if _, err := reader.DecodeUint32OffsetsListInto(nil, nil, g); err == nil || !strings.Contains(err.Error(), "encoding") {
+		t.Fatalf("DecodeUint32OffsetsListInto err=%v want encoding mismatch", err)
+	}
+}
+
 func TestRawUint32OffsetsListSectionMetadataValidation(t *testing.T) {
 	t.Parallel()
 	offsetsRaw := mustOffsetsListOffsets(t, []uint64{0, 2})
@@ -185,6 +197,81 @@ func TestRawUint32OffsetsListSectionMetadataValidation(t *testing.T) {
 			t.Fatalf("err=%v", err)
 		}
 	})
+}
+
+func TestRawUint32OffsetsListColumnPartImageRoundTrip1915(t *testing.T) {
+	opts := Options{
+		Columns: []ColumnDefinition{
+			{Name: "id", Type: ColumnTypeInt64, Encoding: EncodingRawInt64, Compression: CompressionNone, CompressionSet: true, StatsDisabled: true},
+			{Name: "neighbors", Type: ColumnTypeAdjacencyList, Encoding: EncodingRawUint32OffsetsList, Compression: CompressionNone, CompressionSet: true},
+		},
+		LogicalPrimaryKey: LogicalPrimaryKey{Columns: []string{"id"}},
+		PartPolicy:        ColumnPartPolicy{RowsPerGranule: 2},
+	}
+	batch := Batch{
+		Rows:    4,
+		Columns: map[string][]int64{"id": []int64{0, 1, 2, 3}},
+		Uint32OffsetsLists: map[string]RawUint32OffsetsList{
+			"neighbors": {Rows: 4, Offsets: []uint64{0, 0, 2, 2, 5}, Values: []uint32{7, 8, 9, 10, 11}},
+		},
+	}
+	part, err := BuildColumnPart(1915, opts, batch)
+	if err != nil {
+		t.Fatalf("BuildColumnPart: %v", err)
+	}
+	image, err := BuildColumnPartImage(part, ColumnPartImageOptions{LayoutLogicalTypes: map[string]string{"neighbors": "adjacency_list"}})
+	if err != nil {
+		t.Fatalf("BuildColumnPartImage: %v", err)
+	}
+	offsetsSection, valuesSection, ok := image.columnOffsetsListSections("neighbors")
+	if !ok {
+		t.Fatalf("missing offsets-list sections: %+v", image.Sections)
+	}
+	if offsetsSection.Kind != ColumnPartImageSectionColumnOffsets || offsetsSection.Name != "offsets" || offsetsSection.Length != 5*8 {
+		t.Fatalf("offsets section=%+v", offsetsSection)
+	}
+	if valuesSection.Kind != ColumnPartImageSectionColumnValues || valuesSection.Name != "values" || valuesSection.Length != 5*4 {
+		t.Fatalf("values section=%+v", valuesSection)
+	}
+	if offsetsSection.Offset >= valuesSection.Offset {
+		t.Fatalf("section order offsets=%d values=%d", offsetsSection.Offset, valuesSection.Offset)
+	}
+	if err := ValidateRawUint32OffsetsListSections(offsetsSection, valuesSection, image.sectionBytes(offsetsSection), image.sectionBytes(valuesSection), 4); err != nil {
+		t.Fatalf("ValidateRawUint32OffsetsListSections: %v", err)
+	}
+	cert, err := CertifyColumnPartLayoutContractFromImage(image)
+	if err != nil {
+		t.Fatalf("CertifyColumnPartLayoutContractFromImage: %v", err)
+	}
+	certColumn, ok := cert.Column("neighbors")
+	if !ok {
+		t.Fatalf("missing certified neighbors column")
+	}
+	if certColumn.OffsetsBytes != offsetsSection.Length || certColumn.ValuesBytes != valuesSection.Length || certColumn.DirectViewCertified {
+		t.Fatalf("certified offsets-list column=%+v", certColumn)
+	}
+	parsed, err := ParseColumnPartImage(image.Bytes)
+	if err != nil {
+		t.Fatalf("ParseColumnPartImage: %v", err)
+	}
+	decodedPart, err := ColumnPartFromImage(parsed)
+	if err != nil {
+		t.Fatalf("ColumnPartFromImage: %v", err)
+	}
+	decoded, err := decodedPart.Uint32OffsetsListColumn("neighbors", nil, nil)
+	if err != nil {
+		t.Fatalf("Uint32OffsetsListColumn: %v", err)
+	}
+	if !equalUint64s(decoded.Offsets, []uint64{0, 0, 2, 2, 5}) || !equalUint32s(decoded.Values, []uint32{7, 8, 9, 10, 11}) {
+		t.Fatalf("decoded=%+v", decoded)
+	}
+	accounting := part.ByteAccountingFromImage(image)
+	if accounting.DeclaredColumnOffsetsBytes != offsetsSection.Length || accounting.DeclaredColumnValuesBytes != valuesSection.Length {
+		t.Fatalf("accounting offsets=%d values=%d sections=%+v", accounting.DeclaredColumnOffsetsBytes, accounting.DeclaredColumnValuesBytes, accounting.SerializedSections)
+	}
+	if accounting.SerializedPaddingBytes != image.PaddingBytes() {
+		t.Fatalf("accounting padding=%d image padding=%d", accounting.SerializedPaddingBytes, image.PaddingBytes())
+	}
 }
 
 func TestRawUint32OffsetsListImageStorageAccounting(t *testing.T) {

--- a/TreeDB/internal/typeddecode/plan.go
+++ b/TreeDB/internal/typeddecode/plan.go
@@ -342,9 +342,9 @@ func AdjacencyListPlan(cert typedcolumn.ColumnPartLayoutContractColumn, degree i
 	return denseDirectViewPlan(layout, cert, columnsemantics.LogicalAdjacencyList, typedcolumn.ColumnTypeAdjacencyList, typedcolumn.EncodingRawUint32Dense, 4, degree)
 }
 
-// AdjacencyOffsetsListPlan records the #1914 v1 adjacency primitive identity:
-// little-endian uint64 offsets plus little-endian uint32 values. It is spec-only
-// in this issue and therefore never returns a direct-view candidate.
+// AdjacencyOffsetsListPlan records the #1901 v1 adjacency primitive identity:
+// little-endian uint64 offsets plus little-endian uint32 values. #1915 adds the
+// safe writer/fallback reader; unsafe direct-view candidates remain deferred.
 func AdjacencyOffsetsListPlan(cert typedcolumn.ColumnPartLayoutContractColumn) Plan {
 	if cert.LogicalType != string(columnsemantics.LogicalAdjacencyList) || cert.Type != typedcolumn.ColumnTypeAdjacencyList || cert.Encoding != typedcolumn.EncodingRawUint32OffsetsList {
 		return Plan{Path: PathUnsupported, Reason: ReasonValidationFailed, Message: fmt.Sprintf("logical/type/encoding=(%q,%s,%s) want (%q,%s,%s)", cert.LogicalType, cert.Type, cert.Encoding, columnsemantics.LogicalAdjacencyList, typedcolumn.ColumnTypeAdjacencyList, typedcolumn.EncodingRawUint32OffsetsList), ElementSize: 4, ElementsPerRow: 0, Alignment: 4, Rows: cert.Rows}


### PR DESCRIPTION
Closes #1915. Parent tracker: #1901.

## Objective

Land the safe typed-column `raw_uint32_offsets_list` primitive for `ColumnStoreValueAdjacencyList` (`adjacency_layout: "uint32_offsets_list"`) with deterministic image sections, fail-closed validation, and persistence/reopen support.  
In addition to the original landing scope, this also incorporates review-driven fallback decode-path optimizations (scratch reuse and duplicate-validation removal) without changing external format semantics.

## Context

This is needed now to unblock offsets-list adjacency storage in typed-column assets while keeping pre-alpha format behavior explicit and fail-closed. The follow-up review fixes reduce avoidable decode overhead on hot paths and keep the writer/reader implementation aligned with the intended performance envelope.

## Non-goals

- Unsafe mmap direct views for offsets-list columns.
- `column_graph`/search integration and graph speedup claims.
- `uint64` adjacency values.
- Padded-row offsets-list format.
- Migration tooling for old pre-alpha assets.

## Design

- Formats/flags/APIs changed (include diagrams if applicable)
  - Adds `EncodingRawUint32OffsetsList` (`uint64` offsets + flattened `uint32` values, little-endian).
  - Offsets-list typed-column image is published as two global sections:
    - `column_offsets`: `(row_count + 1) * 8` bytes
    - `column_values`: `values_count * 4` bytes
  - Adapter/layout selection supports `ColumnStoreValueAdjacencyList` with `adjacency_layout: "uint32_offsets_list"`.
  - Review-driven optimizations:
    - Reuse decode scratch slices in multi-block paths.
    - Remove duplicate fallback offsets re-validation pass while preserving fail-closed checks.
- Invariants that must hold
  - `offsets[0] == 0`
  - offsets monotonic and in host `int` range
  - final offset equals values count
  - row/section metadata and encoding match expected layout contract
  - offsets-list block descriptor payload ranges are zeroed in certified layout (global section model)
- Fail-closed behavior (caps before alloc; CRC/error handling)
  - Corrupt/truncated/mismatched offsets or values sections fail closed.
  - Shape/count/overflow mismatches fail closed before unsafe allocation/use.
  - Layout-contract section metadata mismatches fail closed.

## Scope

- Includes (files/symbols):
  - Typed-column raw uint32 offsets-list encode/decode and validation path.
  - Typed-column part image publish/read paths for global offsets/value sections.
  - Typed layout-contract certification for offsets-list global-section behavior.
  - Collection adapter/storage layout wiring and reopen coverage.
  - Targeted tests/docs for offsets-list format and accounting.
- Excludes (files/symbols):
  - Offsets-list direct mmap view APIs.
  - Column graph search integration/consumption.
  - Unrelated dense vector or fixed-degree adjacency behavior changes.

## Correctness

- Tests run (exact commands):
  - `go test ./TreeDB/internal/typedcolumn ./TreeDB/collections`
  - `go test ./TreeDB/internal/typedcolumn ./TreeDB/internal/typeddecode ./TreeDB/internal/columnlayout ./TreeDB/collections`
  - `go test ./TreeDB/...`
  - `git diff --check origin/main...HEAD`
- Corruption/edge cases covered:
  - Empty/all-empty/mixed/multi-value row fixtures with exact little-endian byte expectations.
  - Unsupported/mismatched encoding and truncated/corrupt offsets/value sections.
  - Row-count/section-metadata/layout-contract mismatch handling.
- Concurrency/race coverage (if applicable):
  - Not applicable for this change set (no new concurrent state machine introduced).

## Performance

- Benchmarks run (exact commands):
  - `go test ./TreeDB/internal/typedcolumn -run '^$' -bench '^BenchmarkRawUint32OffsetsListFallbackDecode$' -benchmem -count=5`
- Results table (before/after; median-of-5 per G1 in `docs/OPT_SPRINT_NEXT.md`):
  - Current latest-head fallback decode benchmark:

    | Benchmark | Rows/op | Total values/op | Decoded bytes/op | ns/op (median of 5) | ops/sec | MB/s | B/op | allocs/op |
    | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
    | `BenchmarkRawUint32OffsetsListFallbackDecode` | 8,192 | 32,763 | 196,596 | 37,229 | 26,860 | 5,280.66 | 204,801 | 2 |

  - Raw runs: `37,251 / 36,933 / 38,270 / 37,196 / 37,229 ns/op`.
- Regressions (if any) and why acceptable:
  - No known regressions observed in targeted validation.

## Rollout / Toggle Plan

- Default setting:
  - Offsets-list behavior is enabled only when explicitly configured via `adjacency_layout: "uint32_offsets_list"`.
- How to disable quickly:
  - Do not use the offsets-list layout; keep existing dense/fixed adjacency layouts.

## Follow-ups

- Issues/PRs to do next:
  - Deferred direct mmap views and column-graph/search integration for offsets-list (issue #1916 and later).

## Column Graph Native Workstream (#1646, if applicable)

### Copied/Adapted From Old Stack

- Copied: N/A
- Adapted: N/A
- Oracle/comparator only: N/A
- Quarantined/not copied: N/A

### Path Identity

- Native reader: Typed-column fallback reader path for offsets-list payloads.
- Decoded comparator: Existing typed decode validation and tests.
- Legacy/native vector index: Out of scope.
- Unsupported/fail-closed: Mismatched/corrupt offsets-list inputs fail closed.

### Base And Dependency State

- Base branch: Current PR branch against repository default base.
- Base commit: `f2e26ccf46945c630d0a3da9157ed1c61e95fdee` (#1914 / PR #1922 merged).
- Base PR/head: Latest head includes review-driven optimizations.
- #1621/#1634 assumptions: N/A
- Missing generic column-store primitives: None additionally introduced here.
- Parent review fixes propagated: Yes (scratch reuse + duplicate-validation removal).

### Evidence

- Tests:
  - `go test ./TreeDB/internal/typedcolumn ./TreeDB/collections`
  - `go test ./TreeDB/internal/typedcolumn ./TreeDB/internal/typeddecode ./TreeDB/internal/columnlayout ./TreeDB/collections`
  - `go test ./TreeDB/...`
- Benchmarks:
  - `go test ./TreeDB/internal/typedcolumn -run '^$' -bench '^BenchmarkRawUint32OffsetsListFallbackDecode$' -benchmem -count=5`
- Status/fallback proof:
  - Reopen persistence and fail-closed corruption/shape checks covered by targeted tests.
- Performance attribution:
  - Fallback decode-path optimizations reduce avoidable work/alloc pressure while preserving semantics.
- Local regressions found/fixed:
  - None beyond addressed review feedback.

### Test Plan Start

- Milestone tasks targeted:
  - Land primitive writer/reader and layout-contract behavior for offsets-list columns.
- Tests to add before or with implementation:
  - Added/updated round-trip, corruption, accounting, and reopen coverage.
- Existing tests to preserve:
  - Dense vector and fixed adjacency behavior in existing suites.
- #1646 test-list changes made before implementation:
  - N/A

### Performance Plan Start

- Relevant benchmarks/metrics for this PR:
  - Fallback decode ns/op, allocations/op, bytes/op.
- Baseline/comparator command or reason not applicable:
  - Same benchmark command used across latest review iterations.
- Expected setup/search/materialization boundary:
  - Benchmark measures safe fallback decode only (setup before `b.ResetTimer`).
- Upstream costs explicitly out of scope:
  - Write/open/search/doc-fetch and graph integration.
- Local performance risks to watch:
  - Multi-block decode allocations and duplicate validation passes (addressed).

### Test Plan Close

- Additional tests found during implementation/review:
  - Coverage retained for multi-block/multi-granule canonical global offsets sections and fail-closed cases.
- Tests added or changed:
  - Offsets-list typed-column and collection adapter/reopen targeted tests.
- Failing tests fixed:
  - None newly failing at latest head in listed runs.
- #1646 test-list changes made at close:
  - N/A
- Residual untested gaps, if any:
  - Direct mmap view path intentionally deferred.

### Performance Plan Close

- Benchmark commands run:
  - `go test ./TreeDB/internal/typedcolumn -run '^$' -bench '^BenchmarkRawUint32OffsetsListFallbackDecode$' -benchmem -count=5`
- Results summary with throughput/latency/allocations:
  - Median `37,229 ns/op`, `26,860 ops/sec`, `5,280.66 MB/s`, `204,801 B/op`, `2 allocs/op`.
- Before/after or baseline comparison:
  - Latest head reflects review-driven decode-path optimization updates.
- Local slow/heavy code found and fixed:
  - Reused decode scratch across block loops and removed duplicate offsets validation pass.
- Remaining upstream or deferred costs:
  - Direct mmap and graph consumption paths remain deferred.

### AI Review Loop

- Codex latest-head review: Passed with no major issues.
- Copilot latest-head review: Passed with no new correctness issues.
- CodeRabbit latest-head status: Passed.
- Review comments/threads resolved or explicitly dismissed:
  - Addressed allocation-scratch and duplicate-validation feedback in latest heads; all review threads resolved.
- Re-requested after final meaningful push:
  - Yes.

---

## Optimization PR Checklist (TreeDB)

### Scope
- [x] Single, clear objective for this PR (not a bundle)
- [x] Explicit include list (files/symbols touched):
- [x] Explicit exclude list (files/symbols NOT touched):
- [x] No unwanted feature reintroduction (e.g. async slab writer, hard zones, ValueIndex) unless explicitly stated in the PR objective

### Safety / Correctness
- [x] Clear written-vs-durable semantics for any `*Sync` path touched
- [x] No new mmap usage on mutable/truncating files
- [x] All new length fields are capped before allocation (OOM-safe)
- [x] CRC/checksum behavior is fail-closed (clean error, no panic)
- [x] Any concurrency change has a defined state machine and invariants

### Tests
- [x] Added deterministic regression tests for the targeted failure mode
- [x] Tests avoid sleeps where possible (use latches/hooks)
- [x] Added corruption/edge-case tests (truncation, bad headers, invalid lengths) when format/parsing changes
- [x] Ran locally:
  - [x] `go test ./TreeDB/...`
  - [x] Any targeted packages/benchmarks:

### Benchmarks / Measurements
- [x] Added or updated a benchmark relevant to the change
- [x] Reported results in PR description (before/after, command, machine)
- [x] Included “incompressible” (worst-case) results if compression is involved

### Docs
- [ ] Updated `docs/OPT_SPRINT_NEXT.md` milestone status (if applicable)
- [x] Documented any new config knobs + defaults
- [x] Called out any format change in PR description (pre-alpha OK)

### Rollout / Toggle Plan (if behavior-affecting)
- [x] Safe defaults (feature off or conservative threshold)
- [x] Clear knobs to disable/revert behavior quickly
- [ ] Observability: counters/logs to verify effectiveness
