### PR TITLE
collections: hoist dictionary predicate scan accounting

### DIFF
--- a/TreeDB/collections/column_dictionary_query.go
+++ b/TreeDB/collections/column_dictionary_query.go
@@ -232,8 +232,8 @@ func (r *columnDictionaryCodeGroupCountRunner) run(view columnPhysicalScanSnapsh
 	} else {
 		for assetIdx, asset := range r.assets {
 			predicates := &r.predicateAssets[assetIdx]
+			rows += len(asset.codes)
 			for rowIdx, code := range asset.codes {
-				rows++
 				if !predicates.matches(rowIdx) {
 					continue
 				}


### PR DESCRIPTION
## Summary

- Hoist scanned-row accounting in the prepared dictionary `group_count` predicate loop from a per-row `rows++` to one `rows += len(asset.codes)` per asset.
- Keep predicate matching, group counts, and `matched++`/`ReduceRows` accounting inside the predicate-matched path.
- Scope is limited to `columnDictionaryCodeGroupCountRunner.run`; no sidecar/direct-view/mmap/query-planner changes.

## Linked issue

Fixes #1925.

## Start-phase test plan

- Confirm existing predicate-backed prepared dictionary group-count coverage exercises results and diagnostics:
  - `TestColumnDictionaryCodeGroupCountRunnerPredicateDiagnostics1912`
- Baseline the focused predicate-backed prepared group-count benchmark before the code change.

## Start-phase benchmark plan

```sh
go test ./TreeDB/collections -run '^$' -bench '^BenchmarkColumnPhysicalQueryDictionaryPredicates1869/q2_count$' -benchmem -benchtime=2s -count=7
```

## Close-phase test evidence

Latest local head `066875b29ee17eb4d48eedc5aaf5d0d9bdb73aa9`:

```sh
go test ./TreeDB/collections -run '^TestColumnDictionaryCodeGroupCountRunnerPredicateDiagnostics1912$' -count=1
go test ./TreeDB/collections -count=1
```

Both passed locally.

## Close-phase benchmark evidence

Hardware: Apple M3 (`darwin/arm64`). Command:

```sh
go test ./TreeDB/collections -run '^$' -bench '^BenchmarkColumnPhysicalQueryDictionaryPredicates1869/q2_count$' -benchmem -benchtime=2s -count=7
benchstat /tmp/gomap-1925-bench-before.txt /tmp/gomap-1925-bench-head.txt
```

| Variant | Commit | ns/op | ops/sec | rows/sec | B/op | allocs/op | Delta |
| --- | --- | ---: | ---: | ---: | ---: | ---: | --- |
| Before | `2b49e2a4193246fbf6ffed170f3f5cbc7df5fb5b` | 25,730 ± 8% | 38,865 | 318.4M ± 9% | 0 | 0 | base |
| After | `066875b29ee17eb4d48eedc5aaf5d0d9bdb73aa9` | 24,250 ± 6% | 41,237 | 337.8M ± 6% | 0 | 0 | ~, p=0.318 (small/noisy local trend) |

Diagnostics counters stayed identical in the benchmark: `8192 scanned_rows/op`, `6874 matched_rows/op`, `0 B/op`, `0 allocs/op`.

## Diagnostics preservation notes

- `RowsScanned` still counts every dictionary-code row scanned; it is now accumulated once per asset in the predicate-backed prepared loop.
- `RowsMatched`/`ReduceRows` still count only rows whose predicates matched.
- Existing correctness/diagnostics coverage verifies direct and prepared predicate-backed group-count results match and asserts `RowsScanned`, `RowsMatched`, and `ReduceRows` values.

## CI / AI review status

- CI: all GitHub checks passing on latest head `066875b29ee17eb4d48eedc5aaf5d0d9bdb73aa9`.
- Codex: requested with `@codex review`; no major issues reported.
- Copilot: requested with `@copilot review`; review completed with no blocking findings.
- CodeRabbit: requested with `@coderabbitai review`; no actionable comments / status passing.
- Review threads: none open.

## Risks / deferrals

- Benchmark delta is below stable significance locally; this PR removes redundant per-row work without relying on a claimed stable speedup.
- Does not include #1927 predicate specialization or #1934 sidecar/direct-view changes.
- Not merged.
