### PR TITLE
TreeDB: direct-view int64 value sidecar payloads

### DIFF
--- a/TreeDB/collections/column_asset_manager.go
+++ b/TreeDB/collections/column_asset_manager.go
@@ -35,6 +35,7 @@ const columnPhysicalAssetReadScratchPoolMaxRetainBytes = 16 << 20
 const columnAssetVerifiedChecksumCacheSlots = 4096
 const typedColumnPartDirectViewAssetAlignment = 8
 const dictionaryCodesDirectViewAssetAlignment = columnDictionaryCodesPayloadAlignment
+const int64ValuesDirectViewAssetAlignment = columnInt64ValuesPayloadAlignment
 
 // columnAssetSegmentWriteLocks is a bounded stripe set keyed by canonical
 // segment path. Writers to the same segment share a process-local offset lock
@@ -662,6 +663,8 @@ func columnAssetSegmentPayloadAlignment(kind ColumnAssetKind, cfg ColumnStoreCon
 	switch kind {
 	case ColumnAssetKindTCS1DictionaryCodes:
 		return dictionaryCodesDirectViewAssetAlignment
+	case ColumnAssetKindTCS1Int64Values:
+		return int64ValuesDirectViewAssetAlignment
 	case ColumnAssetKindTCS1TypedColumnPart:
 		if columnStoreConfigNeedsDirectViewTypedColumnAlignment(cfg) {
 			return typedColumnPartDirectViewAssetAlignment

--- a/TreeDB/collections/column_asset_reachability.go
+++ b/TreeDB/collections/column_asset_reachability.go
@@ -1280,6 +1280,8 @@ func columnAssetReachabilityRangeDeterministicPaddingAlignment(kind ColumnAssetK
 	switch kind {
 	case ColumnAssetKindTCS1DictionaryCodes:
 		return dictionaryCodesDirectViewAssetAlignment
+	case ColumnAssetKindTCS1Int64Values:
+		return int64ValuesDirectViewAssetAlignment
 	case ColumnAssetKindTCS1TypedColumnPart:
 		return typedColumnPartDirectViewAssetAlignment
 	default:

--- a/TreeDB/collections/column_dict_hour_query.go
+++ b/TreeDB/collections/column_dict_hour_query.go
@@ -88,13 +88,23 @@ func prepareColumnDictionaryHourCountRunner(view columnPhysicalScanSnapshotView,
 		if err != nil {
 			return nil, fmt.Errorf("collections: dictionary/hour values read generation=%d part_id=%d column=%q: %w", valueSnapshot.AssetRef.Generation, valueSnapshot.AssetRef.PartID, req.ValueColumn, err)
 		}
+		valueRawIsView := readCache.lastView
 		scratch = valueRaw
-		valueAsset, err := decodeColumnInt64ValuesAsset(valueRaw, valueSnapshot.AssetRef, view.Config, view.CollectionName, req.ValueColumn, false)
+		_, valuePayload, err := decodeColumnInt64ValuesAssetPayload(valueRaw, valueSnapshot.AssetRef, view.Config, view.CollectionName, req.ValueColumn, false)
 		if err != nil {
 			return nil, err
 		}
-		if len(groupAsset.Codes) != len(valueAsset.Values) || len(valueAsset.Values) != valueSnapshot.Rows {
-			return nil, fmt.Errorf("collections: dictionary/hour row count mismatch group=%d values=%d manifest=%d", len(groupAsset.Codes), len(valueAsset.Values), valueSnapshot.Rows)
+		if len(groupAsset.Codes) != valuePayload.rowCount || valuePayload.rowCount != valueSnapshot.Rows {
+			return nil, fmt.Errorf("collections: dictionary/hour row count mismatch group=%d values=%d manifest=%d", len(groupAsset.Codes), valuePayload.rowCount, valueSnapshot.Rows)
+		}
+		var values []int64
+		if valueRawIsView {
+			values, _, err = viewColumnInt64ValuesPayload(valueRaw, valuePayload)
+		} else {
+			values, err = copyColumnInt64ValuesPayload(valueRaw, valuePayload)
+		}
+		if err != nil {
+			return nil, err
 		}
 		groupCodes := make([]uint32, len(groupAsset.Codes))
 		for codeIdx, localCode := range groupAsset.Codes {
@@ -112,7 +122,7 @@ func prepareColumnDictionaryHourCountRunner(view columnPhysicalScanSnapshotView,
 		}
 		runner.assets = append(runner.assets, columnDictionaryHourCountAsset{
 			groupCodes: groupCodes,
-			values:     valueAsset.Values,
+			values:     values,
 		})
 		runner.assetBytes += groupSnapshot.AssetRef.Length + valueSnapshot.AssetRef.Length
 	}

--- a/TreeDB/collections/column_dict_int64_query.go
+++ b/TreeDB/collections/column_dict_int64_query.go
@@ -1,7 +1,6 @@
 package collections
 
 import (
-	"errors"
 	"fmt"
 	"time"
 )
@@ -78,13 +77,23 @@ func prepareColumnDictionaryInt64GroupRunner(view columnPhysicalScanSnapshotView
 		if err != nil {
 			return nil, fmt.Errorf("collections: dictionary/int64 values read generation=%d part_id=%d column=%q: %w", valueSnapshot.AssetRef.Generation, valueSnapshot.AssetRef.PartID, req.ValueColumn, err)
 		}
+		valueRawIsView := readCache.lastView
 		scratch = valueRaw
-		valueAsset, err := decodeColumnInt64ValuesAsset(valueRaw, valueSnapshot.AssetRef, view.Config, view.CollectionName, req.ValueColumn, false)
+		_, valuePayload, err := decodeColumnInt64ValuesAssetPayload(valueRaw, valueSnapshot.AssetRef, view.Config, view.CollectionName, req.ValueColumn, false)
 		if err != nil {
 			return nil, err
 		}
-		if len(groupAsset.Codes) != len(valueAsset.Values) || len(valueAsset.Values) != valueSnapshot.Rows {
-			return nil, fmt.Errorf("collections: dictionary/int64 row count mismatch group=%d values=%d manifest=%d", len(groupAsset.Codes), len(valueAsset.Values), valueSnapshot.Rows)
+		if len(groupAsset.Codes) != valuePayload.rowCount || valuePayload.rowCount != valueSnapshot.Rows {
+			return nil, fmt.Errorf("collections: dictionary/int64 row count mismatch group=%d values=%d manifest=%d", len(groupAsset.Codes), valuePayload.rowCount, valueSnapshot.Rows)
+		}
+		var values []int64
+		if valueRawIsView {
+			values, _, err = viewColumnInt64ValuesPayload(valueRaw, valuePayload)
+		} else {
+			values, err = copyColumnInt64ValuesPayload(valueRaw, valuePayload)
+		}
+		if err != nil {
+			return nil, err
 		}
 		groupCodes := make([]uint32, len(groupAsset.Codes))
 		for codeIdx, localCode := range groupAsset.Codes {
@@ -102,7 +111,7 @@ func prepareColumnDictionaryInt64GroupRunner(view columnPhysicalScanSnapshotView
 		}
 		runner.assets = append(runner.assets, columnDictionaryInt64GroupAsset{
 			groupCodes: groupCodes,
-			values:     valueAsset.Values,
+			values:     values,
 		})
 		runner.assetBytes += groupSnapshot.AssetRef.Length + valueSnapshot.AssetRef.Length
 	}
@@ -199,10 +208,13 @@ func runColumnDictionaryInt64GroupOneShot(view columnPhysicalScanSnapshotView, r
 		if groupPayload.rowCount != valuePayload.rowCount || valuePayload.rowCount != valueSnapshot.Rows {
 			return ColumnPhysicalQueryResult{}, true, fmt.Errorf("collections: dictionary/int64 row count mismatch group=%d values=%d manifest=%d", groupPayload.rowCount, valuePayload.rowCount, valueSnapshot.Rows)
 		}
-		valueCur := manifestCursor{raw: valueRaw, pos: valuePayload.offset}
+		values, _, err := viewColumnInt64ValuesPayload(valueRaw, valuePayload)
+		if err != nil {
+			return ColumnPhysicalQueryResult{}, true, err
+		}
 		if groupCodes != nil {
-			for _, localCode := range groupCodes {
-				reducer.reduceValue(localToGlobal[localCode], int64(valueCur.u64()))
+			for i, localCode := range groupCodes {
+				reducer.reduceValue(localToGlobal[localCode], values[i])
 				rows++
 			}
 		} else {
@@ -215,15 +227,9 @@ func runColumnDictionaryInt64GroupOneShot(view columnPhysicalScanSnapshotView, r
 				if !ok {
 					return ColumnPhysicalQueryResult{}, true, fmt.Errorf("collections: dictionary codes asset code[%d]=%d outside cardinality=%d", i, localCode, len(localToGlobal))
 				}
-				reducer.reduceValue(localToGlobal[localIdx], int64(valueCur.u64()))
+				reducer.reduceValue(localToGlobal[localIdx], values[i])
 				rows++
 			}
-		}
-		if valueCur.err != nil {
-			return ColumnPhysicalQueryResult{}, true, valueCur.err
-		}
-		if valueCur.pos != len(valueRaw) {
-			return ColumnPhysicalQueryResult{}, true, errors.New("collections: trailing bytes in int64 values asset")
 		}
 		assetBytes += groupSnapshot.AssetRef.Length + valueSnapshot.AssetRef.Length
 		blocks++

--- a/TreeDB/collections/column_int64_query.go
+++ b/TreeDB/collections/column_int64_query.go
@@ -1,7 +1,6 @@
 package collections
 
 import (
-	"errors"
 	"fmt"
 	"time"
 )
@@ -108,17 +107,13 @@ func runColumnInt64ValueHourCountOneShot(view columnPhysicalScanSnapshotView, re
 		if payload.rowCount != snapshot.Rows {
 			return ColumnPhysicalQueryResult{}, true, fmt.Errorf("collections: int64 values asset generation=%d part_id=%d column=%q rows=%d want manifest rows=%d", snapshot.AssetRef.Generation, snapshot.AssetRef.PartID, req.ValueColumn, payload.rowCount, snapshot.Rows)
 		}
-		cur := manifestCursor{raw: raw, pos: payload.offset}
-		for i := 0; i < payload.rowCount; i++ {
-			value := int64(cur.u64())
+		values, _, err := viewColumnInt64ValuesPayload(raw, payload)
+		if err != nil {
+			return ColumnPhysicalQueryResult{}, true, err
+		}
+		for _, value := range values {
 			counts[columnPhysicalQueryUTCHour(value)]++
 			rows++
-		}
-		if cur.err != nil {
-			return ColumnPhysicalQueryResult{}, true, cur.err
-		}
-		if cur.pos != len(raw) {
-			return ColumnPhysicalQueryResult{}, true, errors.New("collections: trailing bytes in int64 values asset")
 		}
 		assetBytes += snapshot.AssetRef.Length
 		blocks++
@@ -174,12 +169,21 @@ func visitColumnInt64ValueHourCountAssets(view columnPhysicalScanSnapshotView, r
 			return 0, 0, true, fmt.Errorf("collections: int64 values read generation=%d part_id=%d column=%q: %w", snapshot.AssetRef.Generation, snapshot.AssetRef.PartID, req.ValueColumn, err)
 		}
 		scratch = raw
-		decoded, err := decodeColumnInt64ValuesAsset(raw, snapshot.AssetRef, view.Config, view.CollectionName, req.ValueColumn, false)
+		rawIsView := readCache.lastView
+		decoded, payload, err := decodeColumnInt64ValuesAssetPayload(raw, snapshot.AssetRef, view.Config, view.CollectionName, req.ValueColumn, false)
 		if err != nil {
 			return 0, 0, true, err
 		}
-		if len(decoded.Values) != snapshot.Rows {
-			return 0, 0, true, fmt.Errorf("collections: int64 values asset generation=%d part_id=%d column=%q rows=%d want manifest rows=%d", snapshot.AssetRef.Generation, snapshot.AssetRef.PartID, req.ValueColumn, len(decoded.Values), snapshot.Rows)
+		if payload.rowCount != snapshot.Rows {
+			return 0, 0, true, fmt.Errorf("collections: int64 values asset generation=%d part_id=%d column=%q rows=%d want manifest rows=%d", snapshot.AssetRef.Generation, snapshot.AssetRef.PartID, req.ValueColumn, payload.rowCount, snapshot.Rows)
+		}
+		if rawIsView {
+			decoded.Values, _, err = viewColumnInt64ValuesPayload(raw, payload)
+		} else {
+			decoded.Values, err = copyColumnInt64ValuesPayload(raw, payload)
+		}
+		if err != nil {
+			return 0, 0, true, err
 		}
 		if err := visit(snapshot, decoded); err != nil {
 			return 0, 0, true, err

--- a/TreeDB/collections/column_int64_values_asset.go
+++ b/TreeDB/collections/column_int64_values_asset.go
@@ -2,15 +2,21 @@ package collections
 
 import (
 	"bytes"
+	"encoding/binary"
 	"errors"
 	"fmt"
+	"unsafe"
 
 	"github.com/snissn/gomap/TreeDB/page"
 )
 
 const (
-	columnInt64ValuesAssetMagic   = uint32(0x54434938) // TCI8
-	columnInt64ValuesAssetVersion = uint16(1)
+	columnInt64ValuesAssetMagic         = uint32(0x54434938) // TCI8
+	columnInt64ValuesAssetVersionV1     = uint16(1)
+	columnInt64ValuesAssetVersion       = uint16(2)
+	columnInt64ValuesPayloadElemBytes   = 8
+	columnInt64ValuesPayloadAlignment   = 8
+	columnInt64ValuesPayloadEndianLabel = "little_endian"
 )
 
 type columnInt64ValuesAsset struct {
@@ -26,8 +32,10 @@ type columnInt64ValuesAsset struct {
 }
 
 type columnInt64ValuesAssetPayload struct {
-	rowCount int
-	offset   int
+	rowCount  int
+	offset    int
+	byteLen   int
+	alignment int
 }
 
 func buildColumnInt64ValuesAssets(cfg ColumnStoreConfig, rows []columnDeclaredRow, collection, namespace string, generation, partID, appliedCommandLSN uint64) ([]columnInt64ValuesAsset, error) {
@@ -112,8 +120,11 @@ func encodeColumnInt64ValuesAsset(asset columnInt64ValuesAsset) ([]byte, error) 
 	writeManifestString(&b, asset.ColumnName)
 	writeManifestUint64(&b, uint64(asset.ColumnIndex))
 	writeManifestUint64(&b, uint64(len(asset.Values)))
+	writeColumnSidecarPayloadPadding(&b, columnInt64ValuesPayloadAlignment)
+	var valueBuf [columnInt64ValuesPayloadElemBytes]byte
 	for _, value := range asset.Values {
-		writeManifestUint64(&b, uint64(value))
+		binary.LittleEndian.PutUint64(valueBuf[:], uint64(value))
+		_, _ = b.Write(valueBuf[:])
 	}
 	return b.Bytes(), nil
 }
@@ -123,17 +134,11 @@ func decodeColumnInt64ValuesAsset(raw []byte, ref ColumnAssetRef, cfg ColumnStor
 	if err != nil {
 		return columnInt64ValuesAsset{}, err
 	}
-	cur := manifestCursor{raw: raw, pos: payload.offset}
-	asset.Values = make([]int64, payload.rowCount)
-	for i := range asset.Values {
-		asset.Values[i] = int64(cur.u64())
+	values, err := copyColumnInt64ValuesPayload(raw, payload)
+	if err != nil {
+		return columnInt64ValuesAsset{}, err
 	}
-	if cur.err != nil {
-		return columnInt64ValuesAsset{}, cur.err
-	}
-	if cur.pos != len(raw) {
-		return columnInt64ValuesAsset{}, errors.New("collections: trailing bytes in int64 values asset")
-	}
+	asset.Values = values
 	return asset, nil
 }
 
@@ -173,8 +178,9 @@ func decodeColumnInt64ValuesAssetPayload(raw []byte, ref ColumnAssetRef, cfg Col
 	if columnIndex > uint64(maxCollectionInt) || rowCount > uint64(maxCollectionInt) {
 		return columnInt64ValuesAsset{}, columnInt64ValuesAssetPayload{}, errors.New("collections: int64 values asset dimensions overflow int")
 	}
-	if rowCount > uint64((len(raw)-cur.pos)/8) {
-		return columnInt64ValuesAsset{}, columnInt64ValuesAssetPayload{}, errors.New("collections: int64 values asset row count exceeds payload bytes")
+	payload, err := columnInt64ValuesPayloadAfterHeader(raw, ref, &cur, int(rowCount))
+	if err != nil {
+		return columnInt64ValuesAsset{}, columnInt64ValuesAssetPayload{}, err
 	}
 	asset.ColumnIndex = int(columnIndex)
 	if !manifestBytesEqualString(collectionBytes, expectedCollection) {
@@ -212,5 +218,135 @@ func decodeColumnInt64ValuesAssetPayload(raw []byte, ref ColumnAssetRef, cfg Col
 	if col.Name != asset.ColumnName || col.ValueType != ColumnStoreValueInt64 || col.Nullable {
 		return columnInt64ValuesAsset{}, columnInt64ValuesAssetPayload{}, fmt.Errorf("collections: int64 values asset column %q is not a non-null declared int64 column", asset.ColumnName)
 	}
-	return asset, columnInt64ValuesAssetPayload{rowCount: int(rowCount), offset: cur.pos}, nil
+	return asset, payload, nil
+}
+
+func columnInt64ValuesPayloadAfterHeader(raw []byte, ref ColumnAssetRef, cur *manifestCursor, rowCount int) (columnInt64ValuesAssetPayload, error) {
+	if cur == nil {
+		return columnInt64ValuesAssetPayload{}, errors.New("collections: nil int64 values asset cursor")
+	}
+	if cur.err != nil {
+		return columnInt64ValuesAssetPayload{}, cur.err
+	}
+	if rowCount < 0 {
+		return columnInt64ValuesAssetPayload{}, fmt.Errorf("collections: int64 values asset negative row count=%d", rowCount)
+	}
+	padding := columnSidecarPayloadPadding(cur.pos, columnInt64ValuesPayloadAlignment)
+	if padding > len(raw)-cur.pos {
+		return columnInt64ValuesAssetPayload{}, errors.New("collections: short int64 values asset payload padding")
+	}
+	for i := 0; i < padding; i++ {
+		if raw[cur.pos+i] != 0 {
+			return columnInt64ValuesAssetPayload{}, fmt.Errorf("collections: non-zero int64 values asset payload padding byte[%d]", i)
+		}
+	}
+	cur.pos += padding
+	if rowCount > maxCollectionInt/columnInt64ValuesPayloadElemBytes {
+		return columnInt64ValuesAssetPayload{}, errors.New("collections: int64 values asset row payload overflows int")
+	}
+	byteLen := rowCount * columnInt64ValuesPayloadElemBytes
+	if byteLen > len(raw)-cur.pos {
+		return columnInt64ValuesAssetPayload{}, errors.New("collections: int64 values asset row count exceeds payload bytes")
+	}
+	if byteLen != len(raw)-cur.pos {
+		return columnInt64ValuesAssetPayload{}, errors.New("collections: trailing bytes in int64 values asset")
+	}
+	payload := columnInt64ValuesAssetPayload{
+		rowCount:  rowCount,
+		offset:    cur.pos,
+		byteLen:   byteLen,
+		alignment: columnInt64ValuesPayloadAlignment,
+	}
+	if (ref.Offset+int64(payload.offset))%int64(columnInt64ValuesPayloadAlignment) != 0 {
+		return columnInt64ValuesAssetPayload{}, fmt.Errorf("collections: int64 values asset payload absolute offset=%d is not %d-byte aligned", ref.Offset+int64(payload.offset), columnInt64ValuesPayloadAlignment)
+	}
+	return payload, nil
+}
+
+func columnInt64ValuesPayloadBytes(raw []byte, payload columnInt64ValuesAssetPayload) ([]byte, error) {
+	if payload.rowCount < 0 || payload.offset < 0 || payload.byteLen < 0 {
+		return nil, errors.New("collections: invalid int64 values asset payload bounds")
+	}
+	if payload.alignment != 0 && payload.alignment != columnInt64ValuesPayloadAlignment {
+		return nil, fmt.Errorf("collections: unsupported int64 values asset payload alignment=%d", payload.alignment)
+	}
+	if payload.rowCount > maxCollectionInt/columnInt64ValuesPayloadElemBytes {
+		return nil, errors.New("collections: int64 values asset row payload overflows int")
+	}
+	wantBytes := payload.rowCount * columnInt64ValuesPayloadElemBytes
+	if payload.byteLen != wantBytes {
+		return nil, fmt.Errorf("collections: int64 values asset payload bytes=%d want rows*8=%d", payload.byteLen, wantBytes)
+	}
+	end := payload.offset + payload.byteLen
+	if end < payload.offset || end > len(raw) {
+		return nil, errors.New("collections: int64 values asset payload outside raw bytes")
+	}
+	return raw[payload.offset:end], nil
+}
+
+// viewColumnInt64ValuesPayload returns dense int64 row values from the v2
+// little-endian payload. When directView is true, the returned []int64 aliases
+// raw and must not be retained beyond raw's mmap/cache lifetime; callers that
+// need owned data must use copyColumnInt64ValuesPayload or copy the slice.
+// Header, schema/ref, checksum, row-count, padding, length, and absolute
+// alignment validation happen before this helper is used.
+func viewColumnInt64ValuesPayload(raw []byte, payload columnInt64ValuesAssetPayload) ([]int64, bool, error) {
+	payloadBytes, err := columnInt64ValuesPayloadBytes(raw, payload)
+	if err != nil {
+		return nil, false, err
+	}
+	if values, ok := columnInt64ValuesLittleEndianDirectView(payloadBytes, payload.rowCount); ok {
+		return values, true, nil
+	}
+	values := make([]int64, payload.rowCount)
+	copyColumnInt64ValuesLittleEndian(values, payloadBytes)
+	return values, false, nil
+}
+
+// copyColumnInt64ValuesPayload always returns owned row values decoded from the
+// v2 little-endian payload, regardless of host byte order or alignment.
+func copyColumnInt64ValuesPayload(raw []byte, payload columnInt64ValuesAssetPayload) ([]int64, error) {
+	payloadBytes, err := columnInt64ValuesPayloadBytes(raw, payload)
+	if err != nil {
+		return nil, err
+	}
+	values := make([]int64, payload.rowCount)
+	copyColumnInt64ValuesLittleEndian(values, payloadBytes)
+	return values, nil
+}
+
+// columnInt64ValuesLittleEndianDirectView is the width-specific direct-view
+// primitive for int64 value sidecars. It only checks native little-endian
+// support, exact byte/count agreement, and pointer alignment; callers must do
+// asset-level validation first and must respect the returned slice's raw-data
+// lifetime.
+func columnInt64ValuesLittleEndianDirectView(raw []byte, count int) ([]int64, bool) {
+	if count < 0 || len(raw)%columnInt64ValuesPayloadElemBytes != 0 || len(raw)/columnInt64ValuesPayloadElemBytes != count {
+		return nil, false
+	}
+	if count == 0 {
+		return nil, true
+	}
+	ptr := unsafe.Pointer(unsafe.SliceData(raw))
+	if !columnPhysicalNativeLittleEndian || uintptr(ptr)%unsafe.Alignof(int64(0)) != 0 {
+		return nil, false
+	}
+	return unsafe.Slice((*int64)(ptr), count), true
+}
+
+func copyColumnInt64ValuesLittleEndian(dst []int64, raw []byte) {
+	if len(dst)*columnInt64ValuesPayloadElemBytes != len(raw) {
+		panic("collections: invalid int64 values little-endian copy length")
+	}
+	if len(dst) == 0 {
+		return
+	}
+	if columnPhysicalNativeLittleEndian {
+		dstBytes := unsafe.Slice((*byte)(unsafe.Pointer(unsafe.SliceData(dst))), len(raw))
+		copy(dstBytes, raw)
+		return
+	}
+	for i := range dst {
+		dst[i] = int64(binary.LittleEndian.Uint64(raw[i*columnInt64ValuesPayloadElemBytes:]))
+	}
 }

--- a/TreeDB/collections/column_int64_values_asset_1935_test.go
+++ b/TreeDB/collections/column_int64_values_asset_1935_test.go
@@ -1,0 +1,260 @@
+package collections
+
+import (
+	"encoding/binary"
+	"reflect"
+	"strings"
+	"testing"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+func TestColumnInt64ValuesAssetLittleEndianPayloadDirectView1935(t *testing.T) {
+	cfg := columnDictionaryCodesAssetTestConfig1934(t)
+	asset := columnInt64ValuesAssetTestAsset1935(cfg.AssetManager.Namespace, cfg.SchemaHash)
+	raw, err := encodeColumnInt64ValuesAsset(asset)
+	if err != nil {
+		t.Fatalf("encodeColumnInt64ValuesAsset: %v", err)
+	}
+	ref := columnInt64ValuesAssetTestRef1935(cfg.AssetManager.Namespace, asset, raw)
+	ref.Offset = int64(columnInt64ValuesPayloadAlignment)
+
+	_, payload, err := decodeColumnInt64ValuesAssetPayload(raw, ref, cfg, asset.Collection, "time_us", true)
+	if err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+	if payload.alignment != columnInt64ValuesPayloadAlignment || payload.byteLen != len(asset.Values)*columnInt64ValuesPayloadElemBytes || payload.offset%columnInt64ValuesPayloadAlignment != 0 {
+		t.Fatalf("payload=%+v want 8-byte aligned little-endian int64 payload", payload)
+	}
+	payloadBytes, err := columnInt64ValuesPayloadBytes(raw, payload)
+	if err != nil {
+		t.Fatalf("payload bytes: %v", err)
+	}
+	for i, want := range asset.Values {
+		if got := int64(binary.LittleEndian.Uint64(payloadBytes[i*columnInt64ValuesPayloadElemBytes:])); got != want {
+			t.Fatalf("payload value[%d] little-endian=%d want %d bytes=%x", i, got, want, payloadBytes[i*columnInt64ValuesPayloadElemBytes:i*columnInt64ValuesPayloadElemBytes+columnInt64ValuesPayloadElemBytes])
+		}
+	}
+	values, direct, err := viewColumnInt64ValuesPayload(raw, payload)
+	if err != nil {
+		t.Fatalf("view payload: %v", err)
+	}
+	if !reflect.DeepEqual(values, asset.Values) {
+		t.Fatalf("values=%v want %v", values, asset.Values)
+	}
+	if columnPhysicalNativeLittleEndian && !direct {
+		t.Fatalf("direct view=false on native little-endian aligned payload=%+v", payload)
+	}
+
+	decoded, err := decodeColumnInt64ValuesAsset(raw, ref, cfg, asset.Collection, "time_us", true)
+	if err != nil {
+		t.Fatalf("decode full asset: %v", err)
+	}
+	if !reflect.DeepEqual(decoded.Values, asset.Values) {
+		t.Fatalf("decoded values=%v want %v", decoded.Values, asset.Values)
+	}
+}
+
+func TestColumnInt64ValuesAssetRejectsLegacyV1Payload1935(t *testing.T) {
+	cfg := columnDictionaryCodesAssetTestConfig1934(t)
+	asset := columnInt64ValuesAssetTestAsset1935(cfg.AssetManager.Namespace, cfg.SchemaHash)
+	raw, err := encodeColumnInt64ValuesAsset(asset)
+	if err != nil {
+		t.Fatalf("encodeColumnInt64ValuesAsset: %v", err)
+	}
+	legacy := append([]byte(nil), raw...)
+	binary.BigEndian.PutUint16(legacy[4:6], columnInt64ValuesAssetVersionV1)
+	ref := columnInt64ValuesAssetTestRef1935(cfg.AssetManager.Namespace, asset, legacy)
+	if _, err := decodeColumnInt64ValuesAsset(legacy, ref, cfg, asset.Collection, "time_us", true); err == nil || !strings.Contains(err.Error(), "unsupported int64 values asset version=1") {
+		t.Fatalf("legacy v1 decode err=%v want unsupported version=1", err)
+	}
+}
+
+func TestColumnInt64ValuesAssetRejectsPayloadPaddingCorruption1935(t *testing.T) {
+	cfg := columnDictionaryCodesAssetTestConfig1934(t)
+	asset := columnInt64ValuesAssetTestAsset1935(cfg.AssetManager.Namespace, cfg.SchemaHash)
+	var raw []byte
+	var paddingStart, padding int
+	for suffix := ""; suffix != "xxxxxxxx"; suffix += "x" {
+		asset.Collection = "events" + suffix
+		encoded, err := encodeColumnInt64ValuesAsset(asset)
+		if err != nil {
+			t.Fatalf("encode suffix=%q: %v", suffix, err)
+		}
+		cur, _, err := columnInt64ValuesAssetHeaderCursorBeforePayload1935(encoded)
+		if err != nil {
+			t.Fatalf("header cursor suffix=%q: %v", suffix, err)
+		}
+		paddingStart = cur.pos
+		padding = columnSidecarPayloadPadding(cur.pos, columnInt64ValuesPayloadAlignment)
+		if padding > 0 {
+			raw = encoded
+			break
+		}
+	}
+	if padding == 0 {
+		t.Fatal("test asset did not produce int64 payload padding")
+	}
+	corrupt := append([]byte(nil), raw...)
+	corrupt[paddingStart] = 0x7f
+	ref := columnInt64ValuesAssetTestRef1935(cfg.AssetManager.Namespace, asset, corrupt)
+	if _, err := decodeColumnInt64ValuesAsset(corrupt, ref, cfg, asset.Collection, "time_us", true); err == nil || !strings.Contains(err.Error(), "payload padding") {
+		t.Fatalf("padding corruption err=%v want payload padding failure", err)
+	}
+}
+
+func TestColumnInt64ValuesAssetManagerAlignsPayloadForMmapDirectView1935(t *testing.T) {
+	cfg := columnDictionaryCodesAssetTestConfig1934(t)
+	asset := columnInt64ValuesAssetTestAsset1935(cfg.AssetManager.Namespace, cfg.SchemaHash)
+	raw, err := encodeColumnInt64ValuesAsset(asset)
+	if err != nil {
+		t.Fatalf("encodeColumnInt64ValuesAsset: %v", err)
+	}
+	root := backenddb.ColumnAssetRootDirPath(t.TempDir())
+	seedRef, err := writeColumnAssetToManagerSegment(root, cfg, []byte{0xab}, ColumnAssetKindTCS1PartImage, asset.Generation, 99, columnAssetM12ASegmentFileID)
+	if err != nil {
+		t.Fatalf("seed write: %v", err)
+	}
+	valuesRef, err := writeColumnInt64ValuesAssetToManager(root, cfg, raw, asset.Generation, asset.PartID)
+	if err != nil {
+		t.Fatalf("write int64 values: %v", err)
+	}
+	if valuesRef.Offset%int64(int64ValuesDirectViewAssetAlignment) != 0 {
+		t.Fatalf("int64 values ref offset=%d want %d-byte aligned", valuesRef.Offset, int64ValuesDirectViewAssetAlignment)
+	}
+	segment := readColumnAssetSegmentFileForTest(t, root, valuesRef)
+	assertZeroBytesForTest(t, segment[seedRef.Offset+seedRef.Length:valuesRef.Offset], "int64 values direct-view prefix padding")
+
+	readCache, err := newColumnPhysicalAssetReadCacheWithIntegrity(root, cfg.AssetManager.Namespace, ColumnAssetReadIntegritySkipChecksums)
+	if err != nil {
+		t.Fatalf("new read cache: %v", err)
+	}
+	readCache.returnViews = true
+	defer func() { _ = readCache.close() }()
+	viewRaw, err := readCache.read(valuesRef, nil)
+	if err != nil {
+		t.Fatalf("read int64 values: %v", err)
+	}
+	_, payload, err := decodeColumnInt64ValuesAssetPayload(viewRaw, valuesRef, cfg, asset.Collection, "time_us", false)
+	if err != nil {
+		t.Fatalf("decode mmap payload: %v", err)
+	}
+	values, direct, err := viewColumnInt64ValuesPayload(viewRaw, payload)
+	if err != nil {
+		t.Fatalf("mmap payload view: %v", err)
+	}
+	if columnPhysicalNativeLittleEndian && !direct {
+		t.Fatalf("mmap int64 payload did not use direct []int64 view: payload=%+v ref=%+v", payload, valuesRef)
+	}
+	if !reflect.DeepEqual(values, asset.Values) {
+		t.Fatalf("mmap values=%v want %v", values, asset.Values)
+	}
+}
+
+func TestColumnInt64ValuesAssetLittleEndianPersistsAfterReopen1935(t *testing.T) {
+	events := columnPhysicalQueryFixtureEventsM13B(128)
+	collection, closeFn := openColumnPhysicalQueryFixtureM13B(t, events)
+	defer closeFn()
+	req := ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryHourCount, ValueColumn: "time_us", ColumnAssetReadIntegrity: ColumnAssetReadIntegritySkipChecksums}
+	result, err := collection.RunColumnPhysicalQuery(req)
+	if err != nil {
+		t.Fatalf("RunColumnPhysicalQuery: %v", err)
+	}
+	if result.Diagnostics.Int64ValueHits == 0 || result.Diagnostics.ReduceRows != len(events) || len(result.Groups) == 0 {
+		t.Fatalf("reopened q3 result groups=%+v diagnostics=%+v", result.Groups, result.Diagnostics)
+	}
+
+	view, closeView, err := collection.prepareColumnPhysicalScanSnapshotViewWithSidecars(columnManifestScanSidecarsForPhysicalQuery(req))
+	if closeView != nil {
+		defer closeView()
+	}
+	if err != nil {
+		t.Fatalf("prepare scan view: %v", err)
+	}
+	byPart := columnInt64ValueSnapshotsByPart(view, "time_us")
+	if len(byPart) != 1 {
+		t.Fatalf("time_us int64 snapshots=%d want 1", len(byPart))
+	}
+	var snapshot columnManifestInt64ValuesSnapshot
+	for _, candidate := range byPart {
+		snapshot = candidate
+	}
+	readCache, err := newColumnPhysicalAssetReadCacheWithIntegrity(view.ColumnAssetRootDir, view.AssetNamespace, ColumnAssetReadIntegritySkipChecksums)
+	if err != nil {
+		t.Fatalf("new read cache: %v", err)
+	}
+	readCache.returnViews = true
+	defer func() { _ = readCache.close() }()
+	raw, err := readCache.read(snapshot.AssetRef, nil)
+	if err != nil {
+		t.Fatalf("read reopened int64 asset: %v", err)
+	}
+	_, payload, err := decodeColumnInt64ValuesAssetPayload(raw, snapshot.AssetRef, view.Config, view.CollectionName, "time_us", false)
+	if err != nil {
+		t.Fatalf("decode reopened payload: %v", err)
+	}
+	values, direct, err := viewColumnInt64ValuesPayload(raw, payload)
+	if err != nil {
+		t.Fatalf("view reopened payload: %v", err)
+	}
+	if len(values) != len(events) {
+		t.Fatalf("reopened payload values=%d want rows=%d", len(values), len(events))
+	}
+	if columnPhysicalNativeLittleEndian && !direct {
+		t.Fatalf("reopened int64 payload not direct-view eligible: payload=%+v ref=%+v", payload, snapshot.AssetRef)
+	}
+}
+
+func columnInt64ValuesAssetTestAsset1935(namespace string, schemaHash uint64) columnInt64ValuesAsset {
+	const minInt64 = -1 << 63
+	const maxInt64 = 1<<63 - 1
+	return columnInt64ValuesAsset{
+		Collection:        "events",
+		Namespace:         namespace,
+		Generation:        7,
+		PartID:            3,
+		AppliedCommandLSN: 42,
+		SchemaHash:        schemaHash,
+		ColumnName:        "time_us",
+		ColumnIndex:       0,
+		Values:            []int64{0, -1, 1, minInt64, maxInt64, -123456789012345, 123456789012345},
+	}
+}
+
+func columnInt64ValuesAssetTestRef1935(namespace string, asset columnInt64ValuesAsset, raw []byte) ColumnAssetRef {
+	return ColumnAssetRef{
+		Kind:       ColumnAssetKindTCS1Int64Values,
+		Namespace:  namespace,
+		Generation: asset.Generation,
+		PartID:     asset.PartID,
+		Length:     int64(len(raw)),
+		Checksum:   page.Checksum(raw),
+	}
+}
+
+func columnInt64ValuesAssetHeaderCursorBeforePayload1935(raw []byte) (manifestCursor, int, error) {
+	cur := manifestCursor{raw: raw}
+	if magic := cur.u32(); magic != columnInt64ValuesAssetMagic {
+		return manifestCursor{}, 0, nil
+	}
+	if version := cur.u16(); version != columnInt64ValuesAssetVersion {
+		return manifestCursor{}, 0, nil
+	}
+	_ = cur.stringBytes()
+	_ = cur.stringBytes()
+	_ = cur.u64()
+	_ = cur.u64()
+	_ = cur.u64()
+	_ = cur.u64()
+	_ = cur.stringBytes()
+	_ = cur.u64()
+	rowCount := cur.u64()
+	if err := cur.err; err != nil {
+		return manifestCursor{}, 0, err
+	}
+	if rowCount > uint64(maxCollectionInt) {
+		return manifestCursor{}, 0, nil
+	}
+	return cur, int(rowCount), nil
+}

--- a/TreeDB/docs/guides/typed-storage-performance.md
+++ b/TreeDB/docs/guides/typed-storage-performance.md
@@ -124,8 +124,10 @@ extracted from an int64 timestamp column. The supported insert-only sidecar path
 scans dictionary-code and int64 assets directly, reports zero document/row
 materializations, and emits groups keyed by `Key` plus `Hour`. Dictionary-code
 sidecars use a version-2 row-code payload: manifest-style metadata/dictionary
-headers followed by zero padding and an aligned little-endian `uint32` stream, so
-row-touching dictionary reducers can use the shared payload-view helper instead
+headers followed by zero padding and an aligned little-endian `uint32` stream.
+The matching int64 value sidecars use a version-2 manifest-style header followed
+by zero padding and an aligned little-endian `int64` stream. Row-touching
+dictionary and int64 reducers use sidecar-specific payload-view helpers instead
 of per-row manifest big-endian decoding.
 
 The low-level comparison harness exposes this as

--- a/TreeDB/docs/spec/storage-format.md
+++ b/TreeDB/docs/spec/storage-format.md
@@ -519,6 +519,20 @@ checksum mismatch when requested, or unsupported versions. Version 1
 big-endian/manifest row-code payloads are intentionally rejected by current
 pre-alpha readers; rebuild old DB directories instead of migrating in place.
 
+Dense int64 value derived sidecars referenced by
+`ColumnAssetRef.Kind = tcs1_int64_values` use asset magic `TCI8`. Version 2
+keeps the manifest-style big-endian header, collection/namespace/generation,
+schema, column identity, column index, and row-count fields, then adds
+zero padding until the row-value payload is 8-byte aligned. Writers then emit
+exactly `row_count * 8` bytes of little-endian two's-complement `int64` values.
+Segment writers prefix-pad int64 value assets so `asset_ref.offset +
+payload_offset` is 8-byte aligned for mmap direct-view consumers. Readers fail
+closed on non-zero payload padding, payload-length or row-count mismatch,
+absolute misalignment, checksum mismatch when requested, schema/ref/column
+mismatch, or unsupported versions. Version 1 big-endian/manifest row-value
+payloads are intentionally rejected by current pre-alpha readers; rebuild old DB
+directories instead of migrating in place.
+
 Sectioned typed-column part payloads are `TreeDB/internal/typedcolumn` part
 images referenced by `ColumnAssetRef.Kind = tcs1_typed_column_part`. The durable
 Issue `#1755` scalar path represents bool, int64, float32, double/float64, and

--- a/TreeDB/docs/spec/typed-column-direct-view-alignment.md
+++ b/TreeDB/docs/spec/typed-column-direct-view-alignment.md
@@ -30,17 +30,20 @@ Physical row assets are deferred/fallback-only for this stack and must remain
 linked to #1897. Row-asset vector/adjacency/generic consumers must not be counted
 as current-stack mmap direct-view evidence.
 
-Derived dictionary-code sidecars are outside the typed-column declared-value
-matrix but now follow the same fixed-width safety vocabulary: version-2
-`tcs1_dictionary_codes` assets keep manifest-style metadata/dictionary headers,
-then expose an exactly `rows * 4` little-endian `uint32` local-code payload after
-zero padding to 4-byte alignment. The sidecar writer pads both the asset payload
-(relative payload offset) and the segment prefix (absolute `asset_ref.offset +
-payload_offset`) so normal mmap reads can construct a `[]uint32` view on native
-little-endian hosts; readers still perform concrete pointer-alignment, length,
-row-count, cardinality, and schema/ref/checksum checks before using the view.
-Call sites are responsible for bounding the direct-view slice lifetime to the
-raw mmap/cache bytes it aliases, with a copy/fallback helper available when a
+Derived dictionary-code and int64 value sidecars are outside the typed-column
+declared-value matrix but now follow the same fixed-width safety vocabulary:
+version-2 `tcs1_dictionary_codes` assets keep manifest-style metadata/dictionary
+headers, then expose an exactly `rows * 4` little-endian `uint32` local-code
+payload after zero padding to 4-byte alignment; version-2 `tcs1_int64_values`
+assets keep manifest-style metadata headers, then expose an exactly `rows * 8`
+little-endian `int64` value payload after zero padding to 8-byte alignment. The
+sidecar writer pads both the asset payload (relative payload offset) and the
+segment prefix (absolute `asset_ref.offset + payload_offset`) so normal mmap
+reads can construct a `[]uint32` or `[]int64` view on native little-endian hosts;
+readers still perform concrete pointer-alignment, length, row-count,
+cardinality where applicable, and schema/ref/checksum checks before using the
+view. Call sites are responsible for bounding the direct-view slice lifetime to
+the raw mmap/cache bytes it aliases, with copy/fallback helpers available when a
 caller needs owned data or the source is unsupported.
 
 ## Writer certification and padding (#1895)


### PR DESCRIPTION
## Summary

Closes #1935.

This PR moves dense int64 value sidecars (`TCI8`) to a direct-view-friendly v2 row payload:

- bumps `TCI8` to version 2 and intentionally rejects v1 pre-alpha payloads;
- keeps manifest-style metadata/header, then zero-pads to 8-byte row-payload alignment;
- writes exactly `row_count * 8` little-endian int64 payload bytes;
- adds int64-specific direct-view/copy helpers; direct-view slices may alias mmap/cache bytes and must not outlive those raw bytes;
- prefix-pads int64 sidecar segment writes and teaches reachability to treat deterministic int64 prefix padding as known zero padding;
- routes q3 hour-count and dictionary/int64 direct/prepared sidecar paths through the int64 helpers instead of per-row `manifestCursor.u64()` over `TCI8` row payloads;
- updates storage/direct-view/perf docs.

## Scope / boundaries

- Owns only `TCI8` int64 value sidecar row payload format and int64-specific helpers.
- Does not modify `TCDC` dictionary-code format beyond consuming #1934 helper patterns.
- Does not implement #1927 predicate-loop specialization or aggregate metadata changes.

## Base / dependency status

#1934 / PR #1937 is merged in `origin/main` as `85d877ff8ead5935ea4b1c87e5a9b7714c8baf5d`.

Latest PR head: `b34cf1c4db3a36f059623d6ed08207077773fe14` on base `main`. The branch was updated with a merge of `origin/main` because repository rules disallow force-push; its tree is identical to the clean rebased final tree (`c74e5fac42c7ad035129a67c335ce49621d21fd6`).

## Format/version compatibility decision

TreeDB is pre-alpha. `TCI8` is bumped from v1 to v2. Current readers reject v1 big-endian/manifest row-value payloads instead of migrating old DB directories.

## Final-base local test evidence

Artifacts:
- Latest-head validation: `/tmp/gomap_1935_final_validation_merge_20260527_120106/final_tests.log`
- Earlier same-tree rebase validation: `/tmp/gomap_1935_final_validation_20260527_114122/final_tests.log`

Latest head `b34cf1c4db3a36f059623d6ed08207077773fe14`:

- `go test ./TreeDB/collections -run 'TestColumnInt64ValuesAsset.*1935|TestColumnInt64ValuesAssetCodecRejectsCorruptionM1634|TestColumnPhysicalQueryRunnerInt64ValueSidecarParityAndAllocationM1634|TestColumnPhysicalQueryRunnerDictInt64SidecarParityAndAllocationM1634|TestColumnPhysicalQuerySerialInt64ValueSidecarParityM1634|TestColumnPhysicalQuerySerialDictInt64SidecarParityM1634|TestColumnPhysicalQuerySerialSidecarAllocationBudgetM1634' -count=1` — PASS
- `go test ./TreeDB/collections -count=1` — PASS
- `go test ./TreeDB/... -count=1` — PASS
- Internal Orca xhigh review: PASS, no blocking/non-blocking findings (`/tmp/gomap_1935_review_summary.md`).

## Final-base benchmark/profile evidence

Hardware/context: darwin/arm64, Apple M3. Single-sample local numbers are noisy and are not claimed as statistically significant; the functional perf gate is that the TCI8 row payload path no longer uses per-row big-endian manifest decode.

Artifacts:
- Baseline on #1934 snapshot `55bd5a5`: `/tmp/gomap_1935_baseline_20260527_111408/`
- Final latest head `b34cf1c4`: `/tmp/gomap_1935_final_bench_merge_20260527_121236/`
- Final q3 CPU profile top: `/tmp/gomap_1935_final_bench_merge_20260527_121236/cpu_q3_direct_20000x_top.txt`
- Final q3 decode-hotspot grep: `/tmp/gomap_1935_final_bench_merge_20260527_121236/q3_decode_hotspot_grep.txt`

| Query/Reducer | Lane | Variant | Commit | ns/op | ops/sec | rows/sec | B/op | allocs/op | Decode hotspot before | Decode hotspot after |
| --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | --- | --- |
| q3 hour-count | direct one-shot | baseline 20k | `55bd5a5` | 45,266 | 22,092 | 181.0M | 2,144 | 10 | source used TCI8 `manifestCursor.u64()` loop | n/a |
| q3 hour-count | direct one-shot | final 20k | `b34cf1c` | 55,424 | 18,043 | 147.8M | 2,144 | 10 | n/a | no `manifestCursor`/`BigEndian`/`Uint64` matches in q3 top-all grep |
| q3 hour-count | prepared runner | baseline 300x | `55bd5a5` | 11,362 | 88,013 | 736.2M | 6 | 0 | prepared values copied from v1 manifest stream | n/a |
| q3 hour-count | prepared runner | final 300x | `b34cf1c` | 14,846 | 67,359 | 571.1M | 6 | 0 | n/a | prepared values from TCI8 helper/view path |
| q4a group-min-int64 | direct one-shot | baseline 300x | `55bd5a5` | 57,472 | 17,400 | 143.4M | 3,230 | 36 | source used TCI8 `manifestCursor.u64()` loop | n/a |
| q4a group-min-int64 | direct one-shot | final 10k | `b34cf1c` | 116,924 | 8,552 | 70.1M | 3,224 | 36 | n/a | dictionary/int64 reducer consumes helper values; no TCI8 cursor loop |
| q4a group-min-int64 | prepared runner | baseline 300x | `55bd5a5` | 27,228 | 36,727 | 307.8M | 6 | 0 | prepared values copied from v1 manifest stream | n/a |
| q4a group-min-int64 | prepared runner | final 10k | `b34cf1c` | 41,839 | 23,901 | 197.6M | 0 | 0 | n/a | prepared values from TCI8 helper/view path |

CPU profile summary:

- `grep -iE 'manifestCursor|BigEndian|u64|Uint64' /tmp/gomap_1935_final_bench_merge_20260527_121236/cpu_q3_direct_20000x_top_all.txt` returned no matches.
- Remaining q3 direct CPU samples are dominated by syscall/mmap/munmap/checksum/setup costs, not TCI8 row decode.

## CI and review status

- Final-base CI is green for latest head `b34cf1c4db3a36f059623d6ed08207077773fe14`.
- Codex review after final push: no major issues.
- Copilot review after final push: reviewed 10/10 files, generated no comments.
- CodeRabbit after final push: pass/skipped incremental review; earlier full review generated no actionable comments.
- Review threads: 0 unresolved.
- PR is not merged.
