### PR TITLE
collections: bucket direct q1 local dictionary counts

### DIFF
--- a/TreeDB/collections/column_dictionary_query.go
+++ b/TreeDB/collections/column_dictionary_query.go
@@ -368,13 +368,15 @@ func runColumnDictionaryCodeGroupCountOneShot(view columnPhysicalScanSnapshotVie
 		if err != nil {
 			return ColumnPhysicalQueryResult{}, true, err
 		}
+		localCounts := reducer.prepareLocalCounts(len(localToGlobal))
 		for i, localCode := range codes {
-			localIdx, ok := columnDictionaryCodeIndex(localCode, len(localToGlobal))
+			localIdx, ok := columnDictionaryCodeIndex(localCode, len(localCounts))
 			if !ok {
-				return ColumnPhysicalQueryResult{}, true, fmt.Errorf("collections: dictionary codes asset code[%d]=%d outside cardinality=%d", i, localCode, len(localToGlobal))
+				return ColumnPhysicalQueryResult{}, true, fmt.Errorf("collections: dictionary codes asset code[%d]=%d outside cardinality=%d", i, localCode, len(localCounts))
 			}
-			reducer.counts[localToGlobal[localIdx]]++
+			localCounts[localIdx]++
 		}
+		reducer.mergeLocalCounts(localCounts, localToGlobal)
 		rows += rowCount
 		assetBytes += snapshot.AssetRef.Length
 		blocks++
@@ -1053,6 +1055,38 @@ func (r *columnDictionaryCodeGroupCountOneShotReducer) translateDictionaryValue(
 	}
 	localToGlobal[localCode] = globalCode
 	return true
+}
+
+func (r *columnDictionaryCodeGroupCountOneShotReducer) prepareLocalCounts(cardinality int) []int {
+	// Borrow scratch space from counts' spare capacity so direct q1 keeps the
+	// existing one-shot allocation budget while reusing the local buckets across
+	// assets. The returned slice is outside len(r.counts), so groups() and global
+	// count merges only observe the real global-count prefix.
+	needed := len(r.counts) + cardinality
+	if needed > cap(r.counts) {
+		newCap := cap(r.counts) * 2
+		if newCap < needed {
+			newCap = needed
+		}
+		if newCap < 16 {
+			newCap = 16
+		}
+		counts := make([]int, len(r.counts), newCap)
+		copy(counts, r.counts)
+		r.counts = counts
+	}
+	localCounts := r.counts[len(r.counts):needed]
+	clear(localCounts)
+	return localCounts
+}
+
+func (r *columnDictionaryCodeGroupCountOneShotReducer) mergeLocalCounts(localCounts []int, localToGlobal []uint32) {
+	for localIdx, count := range localCounts {
+		if count == 0 {
+			continue
+		}
+		r.counts[localToGlobal[localIdx]] += count
+	}
 }
 
 func (r *columnDictionaryCodeGroupCountOneShotReducer) groups() []ColumnPhysicalQueryGroup {

--- a/TreeDB/collections/column_dictionary_query.go
+++ b/TreeDB/collections/column_dictionary_query.go
@@ -10,8 +10,9 @@ const (
 	// Keep deferred/retained one-shot dictionary scans to small/medium payloads.
 	// Pure q1 group-count streams codes synchronously and intentionally does not
 	// use this cap, so direct one-shot calls avoid a throwaway translated arena.
-	columnDictionaryCodeOneShotMaxBytes          = 3 << 20
-	columnDictionaryCodeDistinctOneShotMaxValues = 1 << 16
+	columnDictionaryCodeOneShotMaxBytes                = 3 << 20
+	columnDictionaryCodeDistinctOneShotMaxValues       = 1 << 16
+	columnDictionaryCodeGroupCountOneShotLocalStackCap = 64
 )
 
 type columnDictionaryCodeGroupCountRunner struct {
@@ -326,6 +327,7 @@ func runColumnDictionaryCodeGroupCountOneShot(view columnPhysicalScanSnapshotVie
 		result:     make([]ColumnPhysicalQueryGroup, 0, 16),
 	}
 	var scratch []byte
+	var localCountStack [columnDictionaryCodeGroupCountOneShotLocalStackCap]int
 	assetBytes := int64(0)
 	blocks := 0
 	rows := 0
@@ -368,7 +370,7 @@ func runColumnDictionaryCodeGroupCountOneShot(view columnPhysicalScanSnapshotVie
 		if err != nil {
 			return ColumnPhysicalQueryResult{}, true, err
 		}
-		localCounts := reducer.prepareLocalCounts(len(localToGlobal))
+		localCounts := reducer.prepareLocalCounts(len(localToGlobal), localCountStack[:])
 		for i, localCode := range codes {
 			localIdx, ok := columnDictionaryCodeIndex(localCode, len(localCounts))
 			if !ok {
@@ -1057,11 +1059,17 @@ func (r *columnDictionaryCodeGroupCountOneShotReducer) translateDictionaryValue(
 	return true
 }
 
-func (r *columnDictionaryCodeGroupCountOneShotReducer) prepareLocalCounts(cardinality int) []int {
-	// Borrow scratch space from counts' spare capacity so direct q1 keeps the
-	// existing one-shot allocation budget while reusing the local buckets across
-	// assets. The returned slice is outside len(r.counts), so groups() and global
-	// count merges only observe the real global-count prefix.
+func (r *columnDictionaryCodeGroupCountOneShotReducer) prepareLocalCounts(cardinality int, stack []int) []int {
+	if cardinality <= len(stack) {
+		localCounts := stack[:cardinality]
+		clear(localCounts)
+		return localCounts
+	}
+	// For uncommon larger local dictionaries, borrow scratch space from counts'
+	// spare capacity so direct q1 avoids a separate per-call heap object while
+	// reusing the local buckets across assets. The returned slice is outside
+	// len(r.counts), so groups() and global count merges only observe the real
+	// global-count prefix.
 	needed := len(r.counts) + cardinality
 	if needed > cap(r.counts) {
 		newCap := cap(r.counts) * 2

--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -3056,8 +3056,8 @@ func TestColumnDictionaryCodeGroupCountOneShotLocalDictionaryReorderParityM1942(
 }
 
 func TestColumnDictionaryCodeGroupCountOneShotLocalDictionaryScratchOverStackCapM1942(t *testing.T) {
-	view, wantRows, wantBytes := buildColumnDictionaryCodeGroupCountOneShotOverStackCapViewM1942(t)
-	assertColumnDictionaryCodeGroupCountOneShotParityM1942(t, view, wantRows, 66, wantBytes)
+	view, wantRows, wantGroups, wantBytes := buildColumnDictionaryCodeGroupCountOneShotOverStackCapViewM1942(t)
+	assertColumnDictionaryCodeGroupCountOneShotParityM1942(t, view, wantRows, wantGroups, wantBytes)
 }
 
 func assertColumnDictionaryCodeGroupCountOneShotParityM1942(t *testing.T, view columnPhysicalScanSnapshotView, wantRows, wantGroups int, wantBytes int64) {
@@ -3428,7 +3428,7 @@ func buildColumnDictionaryCodeGroupCountOneShotMultiPartViewM1942(t testing.TB) 
 	return view, map[string]int{"alpha": 3, "beta": 2, "gamma": 4, "delta": 2}, bytes
 }
 
-func buildColumnDictionaryCodeGroupCountOneShotOverStackCapViewM1942(t testing.TB) (columnPhysicalScanSnapshotView, int, int64) {
+func buildColumnDictionaryCodeGroupCountOneShotOverStackCapViewM1942(t testing.TB) (columnPhysicalScanSnapshotView, int, int, int64) {
 	t.Helper()
 	dictionary := make([]string, columnDictionaryCodeGroupCountOneShotLocalStackCap+1)
 	codes := make([]uint32, len(dictionary))
@@ -3441,7 +3441,7 @@ func buildColumnDictionaryCodeGroupCountOneShotOverStackCapViewM1942(t testing.T
 		{partID: 2, dictionary: []string{"kind_064", "kind_000", "kind_extra"}, codes: []uint32{0, 1, 2, 0}},
 	}
 	view, bytes := buildColumnDictionaryCodeGroupCountOneShotPartsViewM1942(t, parts)
-	return view, len(codes) + 4, bytes
+	return view, len(codes) + 4, len(dictionary) + 1, bytes
 }
 
 type columnDictionaryCodeGroupCountOneShotPartSpecM1942 struct {

--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -3062,10 +3062,12 @@ func TestColumnDictionaryCodeGroupCountOneShotRejectsCorruptWideLocalCodeM1942(t
 	if err != nil {
 		t.Fatalf("newColumnPhysicalAssetReadCacheWithIntegrity read cache: %v", err)
 	}
+	defer func() {
+		if err := cache.close(); err != nil {
+			t.Fatalf("read cache close: %v", err)
+		}
+	}()
 	raw, err := cache.read(snapshot.AssetRef, nil)
-	if closeErr := cache.close(); closeErr != nil {
-		t.Fatalf("read cache close: %v", closeErr)
-	}
 	if err != nil {
 		t.Fatalf("read dictionary sidecar: %v", err)
 	}

--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -3055,6 +3055,60 @@ func TestColumnDictionaryCodeGroupCountOneShotLocalDictionaryReorderParityM1942(
 	}
 }
 
+func TestColumnDictionaryCodeGroupCountOneShotLocalDictionaryScratchOverStackCapM1942(t *testing.T) {
+	view, wantRows, wantBytes := buildColumnDictionaryCodeGroupCountOneShotOverStackCapViewM1942(t)
+	assertColumnDictionaryCodeGroupCountOneShotParityM1942(t, view, wantRows, 66, wantBytes)
+}
+
+func assertColumnDictionaryCodeGroupCountOneShotParityM1942(t *testing.T, view columnPhysicalScanSnapshotView, wantRows, wantGroups int, wantBytes int64) {
+	t.Helper()
+	req := ColumnPhysicalQueryRequest{
+		Kind:                     ColumnPhysicalQueryGroupCount,
+		GroupColumn:              "kind",
+		ColumnAssetReadIntegrity: ColumnAssetReadIntegrityVerify,
+	}
+	cache, err := newColumnPhysicalAssetReadCacheWithIntegrity(view.ColumnAssetRootDir, view.AssetNamespace, req.ColumnAssetReadIntegrity)
+	if err != nil {
+		t.Fatalf("newColumnPhysicalAssetReadCacheWithIntegrity one-shot cache: %v", err)
+	}
+	defer func() {
+		if err := cache.close(); err != nil {
+			t.Fatalf("one-shot cache close: %v", err)
+		}
+	}()
+	oneShot, ok, err := runColumnDictionaryCodeGroupCountOneShot(view, req, &cache)
+	if err != nil {
+		t.Fatalf("one-shot q1 local dictionaries: %v", err)
+	}
+	if !ok {
+		t.Fatal("one-shot q1 local dictionaries fell back")
+	}
+	if diag := oneShot.Diagnostics; diag.RowsScanned != wantRows || diag.ReduceRows != wantRows || diag.DictionaryCodeHits != len(view.AssetRefs) || diag.ScheduledGranules != len(view.AssetRefs) || diag.DecodedBlocks != len(view.AssetRefs) || diag.DirectReduceBlocks != len(view.AssetRefs) || diag.PhysicalBytesScanned != wantBytes || diag.ResultGroups != wantGroups || len(oneShot.Groups) != wantGroups {
+		t.Fatalf("one-shot diagnostics=%+v groups=%d want rows/reduce=%d blocks=%d bytes=%d groups=%d", diag, len(oneShot.Groups), wantRows, len(view.AssetRefs), wantBytes, wantGroups)
+	}
+
+	preparedCache, err := newColumnPhysicalAssetReadCacheWithIntegrity(view.ColumnAssetRootDir, view.AssetNamespace, req.ColumnAssetReadIntegrity)
+	if err != nil {
+		t.Fatalf("newColumnPhysicalAssetReadCacheWithIntegrity prepared cache: %v", err)
+	}
+	defer func() {
+		if err := preparedCache.close(); err != nil {
+			t.Fatalf("prepared cache close: %v", err)
+		}
+	}()
+	prepared, err := prepareColumnDictionaryCodeGroupCountRunner(view, req, &preparedCache)
+	if err != nil {
+		t.Fatalf("prepare q1 local dictionaries: %v", err)
+	}
+	if prepared == nil {
+		t.Fatal("prepare q1 local dictionaries returned nil")
+	}
+	preparedResult := prepared.run(view, req)
+	if !equalColumnPhysicalQueryGroups(oneShot.Groups, preparedResult.Groups) {
+		t.Fatalf("one-shot groups=%+v want prepared %+v", oneShot.Groups, preparedResult.Groups)
+	}
+}
+
 func TestColumnDictionaryCodeGroupCountOneShotRejectsCorruptWideLocalCodeM1942(t *testing.T) {
 	view := buildColumnDictionaryCodeGroupCountOneShotView1890(t, 16, false)
 	snapshot := view.DictionaryCodes[0]
@@ -3366,18 +3420,41 @@ func buildColumnDictionaryCodeGroupCountOneShotView1890(t testing.TB, rows int, 
 
 func buildColumnDictionaryCodeGroupCountOneShotMultiPartViewM1942(t testing.TB) (columnPhysicalScanSnapshotView, map[string]int, int64) {
 	t.Helper()
-	view := buildColumnDictionaryCodeGroupCountOneShotView1890(t, 1, false)
-	cfg := view.Config
-	root := view.ColumnAssetRootDir
-	type partSpec struct {
-		partID     uint64
-		dictionary []string
-		codes      []uint32
-	}
-	parts := []partSpec{
+	parts := []columnDictionaryCodeGroupCountOneShotPartSpecM1942{
 		{partID: 1, dictionary: []string{"alpha", "beta", "gamma"}, codes: []uint32{0, 1, 2, 0, 2}},
 		{partID: 2, dictionary: []string{"gamma", "alpha", "beta", "delta"}, codes: []uint32{0, 1, 3, 3, 2, 0}},
 	}
+	view, bytes := buildColumnDictionaryCodeGroupCountOneShotPartsViewM1942(t, parts)
+	return view, map[string]int{"alpha": 3, "beta": 2, "gamma": 4, "delta": 2}, bytes
+}
+
+func buildColumnDictionaryCodeGroupCountOneShotOverStackCapViewM1942(t testing.TB) (columnPhysicalScanSnapshotView, int, int64) {
+	t.Helper()
+	dictionary := make([]string, columnDictionaryCodeGroupCountOneShotLocalStackCap+1)
+	codes := make([]uint32, len(dictionary))
+	for i := range dictionary {
+		dictionary[i] = fmt.Sprintf("kind_%03d", i)
+		codes[i] = uint32(i)
+	}
+	parts := []columnDictionaryCodeGroupCountOneShotPartSpecM1942{
+		{partID: 1, dictionary: dictionary, codes: codes},
+		{partID: 2, dictionary: []string{"kind_064", "kind_000", "kind_extra"}, codes: []uint32{0, 1, 2, 0}},
+	}
+	view, bytes := buildColumnDictionaryCodeGroupCountOneShotPartsViewM1942(t, parts)
+	return view, len(codes) + 4, bytes
+}
+
+type columnDictionaryCodeGroupCountOneShotPartSpecM1942 struct {
+	partID     uint64
+	dictionary []string
+	codes      []uint32
+}
+
+func buildColumnDictionaryCodeGroupCountOneShotPartsViewM1942(t testing.TB, parts []columnDictionaryCodeGroupCountOneShotPartSpecM1942) (columnPhysicalScanSnapshotView, int64) {
+	t.Helper()
+	view := buildColumnDictionaryCodeGroupCountOneShotView1890(t, 1, false)
+	cfg := view.Config
+	root := view.ColumnAssetRootDir
 	assetRefs := make([]columnManifestAssetRefForScan, 0, len(parts))
 	dictionaryRefs := make([]columnManifestDictionaryCodesSnapshot, 0, len(parts))
 	var bytes int64
@@ -3412,7 +3489,7 @@ func buildColumnDictionaryCodeGroupCountOneShotMultiPartViewM1942(t testing.TB) 
 	view.AssetRefs = assetRefs
 	view.DictionaryCodes = dictionaryRefs
 	view.Diagnostics = columnPhysicalScanDiagnostics{AssetRefs: len(assetRefs)}
-	return view, map[string]int{"alpha": 3, "beta": 2, "gamma": 4, "delta": 2}, bytes
+	return view, bytes
 }
 
 func assertColumnDictionaryCodeGroupCountLargeQ11890(t testing.TB, result ColumnPhysicalQueryResult, rows int, bytes int64) {

--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -2,6 +2,7 @@ package collections
 
 import (
 	"bytes"
+	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -2998,6 +2999,120 @@ func TestColumnDictionaryCodeGroupCountOneShotStreamsLargeDirectQ11890(t *testin
 	}
 }
 
+func TestColumnDictionaryCodeGroupCountOneShotLocalDictionaryReorderParityM1942(t *testing.T) {
+	view, wantGroups, wantBytes := buildColumnDictionaryCodeGroupCountOneShotMultiPartViewM1942(t)
+	req := ColumnPhysicalQueryRequest{
+		Kind:                     ColumnPhysicalQueryGroupCount,
+		GroupColumn:              "kind",
+		ColumnAssetReadIntegrity: ColumnAssetReadIntegrityVerify,
+	}
+	cache, err := newColumnPhysicalAssetReadCacheWithIntegrity(view.ColumnAssetRootDir, view.AssetNamespace, req.ColumnAssetReadIntegrity)
+	if err != nil {
+		t.Fatalf("newColumnPhysicalAssetReadCacheWithIntegrity one-shot cache: %v", err)
+	}
+	defer func() {
+		if err := cache.close(); err != nil {
+			t.Fatalf("one-shot cache close: %v", err)
+		}
+	}()
+	ones, ok, err := runColumnDictionaryCodeGroupCountOneShot(view, req, &cache)
+	if err != nil {
+		t.Fatalf("one-shot q1 local dictionaries: %v", err)
+	}
+	if !ok {
+		t.Fatal("one-shot q1 local dictionaries fell back")
+	}
+	if got := columnPhysicalQueryGroupCountsM14B(ones.Groups); !reflect.DeepEqual(got, wantGroups) {
+		t.Fatalf("one-shot groups=%v want %v full=%+v", got, wantGroups, ones.Groups)
+	}
+	wantOrdered := []ColumnPhysicalQueryGroup{{Key: "alpha", Count: 3}, {Key: "beta", Count: 2}, {Key: "delta", Count: 2}, {Key: "gamma", Count: 4}}
+	if !reflect.DeepEqual(ones.Groups, wantOrdered) {
+		t.Fatalf("one-shot ordered groups=%+v want %+v", ones.Groups, wantOrdered)
+	}
+	if diag := ones.Diagnostics; diag.RowsScanned != 11 || diag.ReduceRows != 11 || diag.DictionaryCodeHits != 2 || diag.ScheduledGranules != 2 || diag.DecodedBlocks != 2 || diag.DirectReduceBlocks != 2 || diag.PhysicalBytesScanned != wantBytes || diag.ResultGroups != len(wantGroups) {
+		t.Fatalf("one-shot diagnostics=%+v want rows/reduce=11 blocks=2 bytes=%d groups=%d", diag, wantBytes, len(wantGroups))
+	}
+
+	preparedCache, err := newColumnPhysicalAssetReadCacheWithIntegrity(view.ColumnAssetRootDir, view.AssetNamespace, req.ColumnAssetReadIntegrity)
+	if err != nil {
+		t.Fatalf("newColumnPhysicalAssetReadCacheWithIntegrity prepared cache: %v", err)
+	}
+	defer func() {
+		if err := preparedCache.close(); err != nil {
+			t.Fatalf("prepared cache close: %v", err)
+		}
+	}()
+	prepared, err := prepareColumnDictionaryCodeGroupCountRunner(view, req, &preparedCache)
+	if err != nil {
+		t.Fatalf("prepare q1 local dictionaries: %v", err)
+	}
+	if prepared == nil {
+		t.Fatal("prepare q1 local dictionaries returned nil")
+	}
+	preparedResult := prepared.run(view, req)
+	if !equalColumnPhysicalQueryGroups(ones.Groups, preparedResult.Groups) {
+		t.Fatalf("one-shot groups=%+v want prepared %+v", ones.Groups, preparedResult.Groups)
+	}
+}
+
+func TestColumnDictionaryCodeGroupCountOneShotRejectsCorruptWideLocalCodeM1942(t *testing.T) {
+	view := buildColumnDictionaryCodeGroupCountOneShotView1890(t, 16, false)
+	snapshot := view.DictionaryCodes[0]
+	cache, err := newColumnPhysicalAssetReadCacheWithIntegrity(view.ColumnAssetRootDir, view.AssetNamespace, ColumnAssetReadIntegrityVerify)
+	if err != nil {
+		t.Fatalf("newColumnPhysicalAssetReadCacheWithIntegrity read cache: %v", err)
+	}
+	raw, err := cache.read(snapshot.AssetRef, nil)
+	if closeErr := cache.close(); closeErr != nil {
+		t.Fatalf("read cache close: %v", closeErr)
+	}
+	if err != nil {
+		t.Fatalf("read dictionary sidecar: %v", err)
+	}
+	dictCur, cardinality, rowCount, err := decodeColumnDictionaryCodesAssetHeader(raw, snapshot.AssetRef, view.Config, view.CollectionName, "kind", false)
+	if err != nil {
+		t.Fatalf("decode dictionary sidecar header: %v", err)
+	}
+	for localCode := 0; localCode < cardinality; localCode++ {
+		_ = dictCur.stringBytes()
+		if dictCur.err != nil {
+			break
+		}
+	}
+	if dictCur.err != nil {
+		t.Fatalf("decode dictionary entries: %v", dictCur.err)
+	}
+	payload, err := columnDictionaryCodesPayloadAfterDictionary(raw, snapshot.AssetRef, &dictCur, rowCount)
+	if err != nil {
+		t.Fatalf("dictionary payload bounds: %v", err)
+	}
+	corrupt := append([]byte(nil), raw...)
+	binary.LittleEndian.PutUint32(corrupt[payload.offset:], uint32(cardinality))
+	corruptRef, err := writeColumnDictionaryCodesAssetToManager(view.ColumnAssetRootDir, view.Config, corrupt, snapshot.AssetRef.Generation, snapshot.AssetRef.PartID)
+	if err != nil {
+		t.Fatalf("write corrupt dictionary sidecar: %v", err)
+	}
+	view.DictionaryCodes[0].AssetRef = corruptRef
+	view.DictionaryCodes[0].Bytes = corruptRef.Length
+
+	corruptCache, err := newColumnPhysicalAssetReadCacheWithIntegrity(view.ColumnAssetRootDir, view.AssetNamespace, ColumnAssetReadIntegrityVerify)
+	if err != nil {
+		t.Fatalf("newColumnPhysicalAssetReadCacheWithIntegrity corrupt cache: %v", err)
+	}
+	defer func() {
+		if err := corruptCache.close(); err != nil {
+			t.Fatalf("corrupt cache close: %v", err)
+		}
+	}()
+	_, ok, err := runColumnDictionaryCodeGroupCountOneShot(view, ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount, GroupColumn: "kind", ColumnAssetReadIntegrity: ColumnAssetReadIntegrityVerify}, &corruptCache)
+	if err == nil || !strings.Contains(err.Error(), "outside cardinality") {
+		t.Fatalf("corrupt one-shot ok=%v err=%v want outside cardinality", ok, err)
+	}
+	if !ok {
+		t.Fatalf("corrupt one-shot ok=false err=%v want direct path fail-closed error", err)
+	}
+}
+
 func TestColumnDictionaryCodeGroupCountOneShotFallbacks1890(t *testing.T) {
 	view := buildColumnDictionaryCodeGroupCountOneShotView1890(t, 128, false)
 	cache, err := newColumnPhysicalAssetReadCacheWithIntegrity(view.ColumnAssetRootDir, view.AssetNamespace, ColumnAssetReadIntegrityVerify)
@@ -3245,6 +3360,57 @@ func buildColumnDictionaryCodeGroupCountOneShotView1890(t testing.TB, rows int, 
 			AssetRefs: 1,
 		},
 	}
+}
+
+func buildColumnDictionaryCodeGroupCountOneShotMultiPartViewM1942(t testing.TB) (columnPhysicalScanSnapshotView, map[string]int, int64) {
+	t.Helper()
+	view := buildColumnDictionaryCodeGroupCountOneShotView1890(t, 1, false)
+	cfg := view.Config
+	root := view.ColumnAssetRootDir
+	type partSpec struct {
+		partID     uint64
+		dictionary []string
+		codes      []uint32
+	}
+	parts := []partSpec{
+		{partID: 1, dictionary: []string{"alpha", "beta", "gamma"}, codes: []uint32{0, 1, 2, 0, 2}},
+		{partID: 2, dictionary: []string{"gamma", "alpha", "beta", "delta"}, codes: []uint32{0, 1, 3, 3, 2, 0}},
+	}
+	assetRefs := make([]columnManifestAssetRefForScan, 0, len(parts))
+	dictionaryRefs := make([]columnManifestDictionaryCodesSnapshot, 0, len(parts))
+	var bytes int64
+	for _, part := range parts {
+		encoded, err := encodeColumnDictionaryCodesAsset(columnDictionaryCodesAsset{
+			Collection:        "events",
+			Namespace:         cfg.AssetManager.Namespace,
+			Generation:        19,
+			PartID:            part.partID,
+			AppliedCommandLSN: 1,
+			SchemaHash:        cfg.SchemaHash,
+			ColumnName:        "kind",
+			ColumnIndex:       1,
+			Dictionary:        part.dictionary,
+			Codes:             part.codes,
+		})
+		if err != nil {
+			t.Fatalf("encode dictionary codes part=%d: %v", part.partID, err)
+		}
+		ref, err := writeColumnDictionaryCodesAssetToManager(root, cfg, encoded, 19, part.partID)
+		if err != nil {
+			t.Fatalf("write dictionary codes part=%d: %v", part.partID, err)
+		}
+		assetRefs = append(assetRefs, columnManifestAssetRefForScan{
+			Ref:    ColumnAssetRef{Kind: ColumnAssetKindTCS1PartImage, Namespace: cfg.AssetManager.Namespace, Generation: 19, PartID: part.partID},
+			Reason: ColumnPublishOperationInsert,
+			Rows:   len(part.codes),
+		})
+		dictionaryRefs = append(dictionaryRefs, columnManifestDictionaryCodesSnapshot{ColumnName: "kind", AssetRef: ref, Bytes: ref.Length})
+		bytes += ref.Length
+	}
+	view.AssetRefs = assetRefs
+	view.DictionaryCodes = dictionaryRefs
+	view.Diagnostics = columnPhysicalScanDiagnostics{AssetRefs: len(assetRefs)}
+	return view, map[string]int{"alpha": 3, "beta": 2, "gamma": 4, "delta": 2}, bytes
 }
 
 func assertColumnDictionaryCodeGroupCountLargeQ11890(t testing.TB, result ColumnPhysicalQueryResult, rows int, bytes int64) {

--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -3436,9 +3436,11 @@ func buildColumnDictionaryCodeGroupCountOneShotOverStackCapViewM1942(t testing.T
 		dictionary[i] = fmt.Sprintf("kind_%03d", i)
 		codes[i] = uint32(i)
 	}
+	firstKind := dictionary[0]
+	lastKind := dictionary[len(dictionary)-1]
 	parts := []columnDictionaryCodeGroupCountOneShotPartSpecM1942{
 		{partID: 1, dictionary: dictionary, codes: codes},
-		{partID: 2, dictionary: []string{"kind_064", "kind_000", "kind_extra"}, codes: []uint32{0, 1, 2, 0}},
+		{partID: 2, dictionary: []string{lastKind, firstKind, "kind_extra"}, codes: []uint32{0, 1, 2, 0}},
 	}
 	view, bytes := buildColumnDictionaryCodeGroupCountOneShotPartsViewM1942(t, parts)
 	return view, len(codes) + 4, len(dictionary) + 1, bytes


### PR DESCRIPTION
## Summary

Fixes #1942.

- Aggregates direct one-shot q1 dictionary-code rows into per-asset local buckets before merging non-zero local counts into the global result counts.
- Keeps local-to-global dictionary translation out of the per-row q1 hot loop while preserving per-row local-code cardinality validation.
- Adds direct q1 multi-part local-dictionary parity/diagnostics coverage with different local dictionary value orders/code assignments, plus a direct corrupt local-code fail-closed test.
- Keeps scope limited to direct `ColumnPhysicalQueryGroupCount` one-shot q1; no prepared runner, q2/q3/q4/q5, sidecar format, write-path, hidden-cache, or mmap lifecycle changes.

## Start-phase test plan

- Inspect existing direct q1 one-shot and prepared parity coverage.
- Add/confirm a direct q1 multi-part local-dictionary parity test where the same values have different local codes across parts.
- Preserve diagnostics coverage for `RowsScanned`, `ReduceRows`, `DictionaryCodeHits`, `PhysicalBytesScanned`, result group count, and sorted result ordering.
- Add/confirm fail-closed direct one-shot coverage for corrupt/out-of-cardinality local codes.
- Run focused `TreeDB/collections` tests, then broader affected and repository-wide tests.

## Start-phase performance/profile plan

- Capture a fresh remote q1 direct JSONBench baseline on `mikers@192.168.0.185` at base `26515ad15384dca3182eabb95bd46afafeac589f` with JSONBench `9a60981712a5c685ebc0c8e059f65eb022b55251`.
- Use the q1 direct benchmark as the gold standard: 10M rows, `storage-layout=column-store`, projection `q1`, DB built before the benchmark and reopened by the benchmark harness.
- Rerun the same command/hardware after the change, capture CPU/mem profiles, and compare `ns/op`, ops/sec, rows/sec, `B/op`, and allocs/op.

## Close-phase test evidence

Local latest head `36af458502158928e1039eec9688b084f91b9418`:

```sh
go test ./TreeDB/collections -run 'TestColumnDictionaryCodeGroupCountOneShot(LocalDictionaryReorderParityM1942|LocalDictionaryScratchOverStackCapM1942|RejectsCorruptWideLocalCodeM1942|StreamsLargeDirectQ11890|Fallbacks1890)|TestColumnPhysicalQueryDirectQ1MatchesPrepared1890|TestColumnPhysicalQuerySerialDictionarySidecarParityM1634|TestColumnDictionaryCodeIndexRejectsCorruptWideCodeM1634|TestColumnPhysicalQuerySerialSidecarAllocationBudgetM1634' -count=1
go test ./TreeDB/collections -count=1
go test ./TreeDB/collections ./TreeDB/internal/typedcolumn ./TreeDB/internal/typeddecode ./TreeDB/internal/mappedresource -count=1
go test ./... -count=1
```

Focused and `TreeDB/collections` tests passed. Broad `go test ./... -count=1` passed on the prior production-code head and was rerun after review fixes; the latest broad rerun hit an unrelated `TreeDB/caching` scheduler timing flake (`TestCheckpoint_KicksVlogGenerationRewriteDespiteRecentForegroundActivity`), and both the exact test and `go test ./TreeDB/caching -count=1` passed immediately on rerun.

Internal Pi review: PASS; blocking findings none. CodeRabbit requested explicit cardinality >64 scratch fallback coverage, deriving the expected group count from the fixture, and deriving the reused over-stack fixture keys; `TestColumnDictionaryCodeGroupCountOneShotLocalDictionaryScratchOverStackCapM1942` was added, updated, and passes.

## Close-phase benchmark/profile evidence

Remote host: `mikers-B560-DS3H-AC-Y1`, Intel i5-11400F, linux/amd64, Go 1.25.0.

Artifacts:

- Baseline: `/home/mikers/jsonbench_runs/q1_direct_issue1942_baseline_20260527_142852/profile/summary.md`
- After: `/home/mikers/jsonbench_runs/q1_direct_issue1942_after_20260527_145723/profile/summary.md`
- Benchstat: `/home/mikers/jsonbench_runs/q1_direct_issue1942_after_20260527_145723/profile/benchstat_baseline_vs_after_count3.txt`

Benchmark command shape:

```sh
Q1_PROFILE_DB_DIR="$RUN/build_q1_direct_db/10m_column-store_json_q1_q1/db" \
Q1_PROFILE_ROWS=10000000 \
GOWORK=off \
go test ./cmd/jsonbench_treedb \
  -run '^$' \
  -bench '^BenchmarkQ1DirectRunColumnPhysicalQuery10M$' \
  -benchmem -benchtime=10s -count=3
```

Profile command used `-benchtime=30s -count=1 -cpuprofile ... -memprofile ...` with the same DB shape.

## Benchmark table

Count=3 median rows from no-pprof runs:

| Variant | Commit | ns/op | ops/sec | rows/sec | B/op | allocs/op | Top hotspot |
| --- | --- | ---: | ---: | ---: | ---: | ---: | --- |
| before | `26515ad15384` | 15,567,242 | 64.2 | 642.4M | 680,226 | 74 | `runColumnDictionaryCodeGroupCountOneShot`; per-row global update `reducer.counts[localToGlobal[localIdx]]++` sampled at 8.13s flat in profile |
| after | `de243356e9c9` (production code; latest `d1f29c261` adds tests only) | 14,731,138 | 67.9 | 679.9M | 680,177 | 74 | `runColumnDictionaryCodeGroupCountOneShot`; per-row local bucket increment remains, post-loop local-to-global merge sampled at ~10ms cum |

Median delta: ~5.4% lower `ns/op`, ~5.8% higher reported rows/sec, no alloc count regression, no material `B/op` regression.

## CPU profile summary before vs after

Before (`q1_direct_issue1942_baseline_20260527_142852`):

- `runColumnDictionaryCodeGroupCountOneShot`: 27.00s flat / 32.86s cum (83.44% cum).
- Per-row direct-view loop: line 371, 18.15s flat.
- Per-row cardinality guard: `columnDictionaryCodeIndex(...)`, 0.46s flat / 1.40s cum.
- Per-row global translation/count update: `reducer.counts[localToGlobal[localIdx]]++`, 8.13s flat.
- Remaining direct overhead: header decode ~4.09s cum; mmap/read-cache teardown ~4.16s cum.

After (`q1_direct_issue1942_after_20260527_145723`):

- `runColumnDictionaryCodeGroupCountOneShot`: 25.74s flat / 31.77s cum (82.93% cum).
- Per-row direct-view loop: line 374, 20.00s flat / 20.02s cum.
- Per-row cardinality guard: `columnDictionaryCodeIndex(localCode, len(localCounts))`, 1.46s flat / 2.53s cum.
- Per-row local bucket increment: `localCounts[localIdx]++`, 3.94s flat / 3.95s cum.
- Post-loop merge: `reducer.mergeLocalCounts(localCounts, localToGlobal)`, 0 flat / ~10ms cum.

Interpretation: local-to-global translation and global result-count updates are no longer in the per-row hot loop. New remaining bottlenecks are direct-view iteration, cardinality validation, local bucket increments, plus direct one-shot setup/teardown (header decode and mmap lifecycle).

## Diagnostics preservation notes

`TestColumnDictionaryCodeGroupCountOneShotLocalDictionaryReorderParityM1942` asserts direct one-shot q1 over two parts with different local dictionary order/code assignments:

- exact group counts and sorted group ordering;
- parity with the prepared runner result;
- `RowsScanned == ReduceRows == 11`;
- `DictionaryCodeHits == ScheduledGranules == DecodedBlocks == DirectReduceBlocks == 2`;
- exact `PhysicalBytesScanned` from the two dictionary-code sidecars;
- `ResultGroups` matches the returned groups.

`TestColumnDictionaryCodeGroupCountOneShotLocalDictionaryScratchOverStackCapM1942` builds a part with 65 local dictionary entries to exercise the non-stack local-count scratch path, compares one-shot to prepared, and asserts diagnostics.

`TestColumnDictionaryCodeGroupCountOneShotRejectsCorruptWideLocalCodeM1942` corrupts a direct dictionary-code payload to contain a code equal to cardinality and verifies the direct one-shot path returns the existing `outside cardinality` error.

## Regression assessment

No material regression remains. The q1 direct benchmark improves on median runtime/throughput and keeps `B/op`/allocs stable. Local allocation-budget coverage for the direct sidecar path still passes. Scope intentionally leaves mmap lifecycle/header setup overhead as a reported follow-up rather than changing it here.

## AI review status and unresolved threads

Requested Codex, Copilot, and CodeRabbit. Codex reported no major issues. Copilot found one test-lifetime issue; fixed in `ff2745a99` and thread resolved. CodeRabbit requested cardinality >64 fallback coverage; fixed in `d1f29c261` and thread resolved. CodeRabbit then requested deriving the fallback test expected group count from the fixture; fixed in `08aa3651`. Coordinator follow-up requested deriving the reused fixture key from the generated dictionary too; fixed in `36af4585`. A latest Copilot note about Go slice bounds was verified as a false positive because slices may be extended up to capacity and the over-stack-cap test exercises that path; the thread is resolved. Latest-head CI is green and no unresolved review threads remain.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests validating one-shot dictionary-code group counting across multi-part/local dictionaries, parity across orderings, behavior when local-buffer limits are exceeded, and proper rejection of corrupted on-disk local-dictionary metadata; includes helpers to construct multi-part test snapshots.

* **Refactor**
  * Local per-asset count buffering now uses a small stack-first buffer with a safe fallback to reusable scratch space, then merges into the global aggregator to reduce contention and improve performance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1944?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->




