### PR TITLE
docs: tighten typed-column JSONBench q2 plan and naming allowlist

### DIFF
--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -406,6 +406,7 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/docs/spec/typed-column-adapter.md", classification: typedStorageLegacyCompatibility, matchingLines: 2, occurrences: 2},
 	{path: "TreeDB/docs/spec/typed-column-direct-view-alignment.md", classification: typedStorageLegacyCompatibility, matchingLines: 10, occurrences: 10},
 	{path: "TreeDB/docs/spec/typed-column-direct-view-closeout-1899.md", classification: typedStorageLegacyCompatibility, matchingLines: 3, occurrences: 3},
+	{path: "TreeDB/docs/spec/typed-column-production-jsonbench-plan.md", classification: typedStorageLegacyCompatibility, matchingLines: 24, occurrences: 25},
 	{path: "TreeDB/docs/spec/typed-column-semantics.md", classification: typedStorageLegacyCompatibility, matchingLines: 1, occurrences: 1},
 	{path: "TreeDB/docs/spec/typed-column-transplant.md", classification: typedStorageLegacyCompatibility, matchingLines: 4, occurrences: 5},
 	{path: "TreeDB/docs/spec/typed-storage-closeout-1758.md", classification: typedStorageLegacyCompatibility, matchingLines: 11, occurrences: 18},

--- a/TreeDB/docs/spec/README.md
+++ b/TreeDB/docs/spec/README.md
@@ -206,10 +206,10 @@ Given pre-alpha status, this is a living spec that tracks implementation.
     row assets deferred to #1897 and adjacency direct views deferred to #1901.
 - `TreeDB/docs/spec/typed-column-production-jsonbench-plan.md`
   - planning note for promoting `experiments/colgranule` sort order, granule
-    metadata, codecs/compression, q1-q5 kernels, aggregate metadata, multipart
-    visibility, lifecycle accounting, and JSONBench reporting into production
-    `TreeDB/collections`, with direct query performance as the first-class
-    target.
+    metadata, codecs/compression, q1-q5 kernels, q2 real-predicate grouped
+    distinct execution, aggregate metadata, multipart visibility, lifecycle
+    accounting, and JSONBench reporting into production `TreeDB/collections`,
+    with direct query performance as the first-class target.
 
 ## Canonical Ownership
 

--- a/TreeDB/docs/spec/typed-column-production-jsonbench-plan.md
+++ b/TreeDB/docs/spec/typed-column-production-jsonbench-plan.md
@@ -20,8 +20,8 @@ queries do not pay avoidable setup, mapping, allocation, or document
 materialization costs.
 
 JSONBench parity must use real query predicates over stored columns. In
-particular, q2 must store full `kind`, `operation`, `collection/event`, and
-`did` values, then execute `kind = commit` and `operation = create` predicates
+particular, q2 must store full `kind`, `operation`, `collection` (reported as
+`event`), and `did` values, then execute `kind = commit` and `operation = create` predicates
 at query time. Do not regain ClickHouse-like numbers by write-time masking,
 sentinel substitution, or benchmark-specific q2 pre-filtering.
 
@@ -764,7 +764,8 @@ There are two different JSONBench-related locations.
 | `experiments/colgranule/jsonbench_treedb_columnstore_bench_test.go` | In-repo synthetic benchmark that compares the reference experiment kernels with the current production collection physical query path. |
 | external `snissn/JSONBench/treedb` checkout | Canonical benchmark/reporting home for cross-database JSONBench runs. Common local checkouts include `/Users/michaelseiler/dev/snissn/JSONBench/treedb` and Orca workspaces, but the repository state is the authority. Current external work has transitional TreeDB column-store rows; this plan targets the final production typed-column cells and must keep direct, prepared, and metadata rows unambiguous. |
 
-The external harness entry points are:
+The external harness entry points below are relative to the `snissn/JSONBench`
+repository root:
 
 - `treedb/run_matrix.sh`
 - `treedb/cmd/jsonbench_treedb/run.go`
@@ -777,6 +778,14 @@ layout split lands. Those labels are acceptable as interim reference rows, but
 final production typed-column reports must still expose the same dimensions as
 `column-direct`, `column-prepared`, `column-direct-metadata`, and
 `column-prepared-metadata` or provide explicit aliases.
+
+Draft label mapping:
+
+| Transitional label | Production dimension |
+| --- | --- |
+| `column-store` | `column-direct` data scan |
+| `column-store-prepared` | `column-prepared` data scan |
+| `column-store-prepared-metadata` | `column-prepared-metadata` for q4/q5 metadata Top-K |
 
 ## Current Gap Summary
 
@@ -879,8 +888,9 @@ Deliverables:
 
 Acceptance criteria:
 
-- q2 direct production query can use sorted-prefix planning for the
-  `kind/operation` predicate and exact grouped distinct over `collection/did`.
+- q2 direct production query uses sorted-prefix planning for the
+  `kind/operation` predicate and exact grouped distinct over `collection/did`
+  when the physical sort key is available and validated.
 - q4b direct production query skips granules when marks prove they cannot match.
 - Mark-pruning and sorted-prefix result hashes match full-scan result hashes.
 - Tests cover empty ranges, boundary equality, multi-column prefixes, missing
@@ -1021,7 +1031,7 @@ The production matrix should make every dimension explicit.
 | Query | Required production behavior |
 | --- | --- |
 | q1 | Count rows grouped by event/collection. |
-| q2 | Store full `kind`, `operation`, `collection/event`, and `did`; at query time apply `kind=commit` and `operation=create`, then count rows and exact distinct users grouped by event/collection. |
+| q2 | Store full `kind`, `operation`, `collection` (reported as `event`), and `did`; at query time apply `kind=commit` and `operation=create`, then count rows and exact distinct users grouped by event/collection. |
 | q3 | For `kind=commit`, `operation=create`, and event in the JSONBench event list, count rows grouped by event and hour of day. |
 | q4a | For post creates, return the three users with earliest post time using `time_us` physical order and early stop. |
 | q4b | For post creates, return the three users with earliest post time using ClickHouse-style physical order plus sort-key mark pruning. |

--- a/TreeDB/docs/spec/typed-column-production-jsonbench-plan.md
+++ b/TreeDB/docs/spec/typed-column-production-jsonbench-plan.md
@@ -19,6 +19,12 @@ The one-shot direct API must become fast and clear enough that ad-hoc physical
 queries do not pay avoidable setup, mapping, allocation, or document
 materialization costs.
 
+JSONBench parity must use real query predicates over stored columns. In
+particular, q2 must store full `kind`, `operation`, `collection/event`, and
+`did` values, then execute `kind = commit` and `operation = create` predicates
+at query time. Do not regain ClickHouse-like numbers by write-time masking,
+sentinel substitution, or benchmark-specific q2 pre-filtering.
+
 ## Terms
 
 Use these terms consistently in code, docs, benchmark names, and diagnostics.
@@ -265,11 +271,17 @@ typed-column part.
 Example JSONBench sort keys:
 
 - `time_us`
-- `(kind_code, operation_code, collection_code, did_code, time_us)`
+- `(kind, operation, collection, did, time_us)`
 
 Rows:
 
-- the sort key orders rows inside one part
+- the sort key orders rows inside one part by logical column values, not by
+  arbitrary per-part dictionary code assignment
+- dictionary-code carriers may only be used for sort comparison when their code
+  ordering is proven to preserve the declared logical value ordering, or when
+  comparison consults the dictionary values explicitly
+- nullable, missing, and default values must have a documented ordering before
+  a column can participate in a persisted sort key
 - equal sort-key values must tie-break by logical primary id so the order is
   deterministic
 
@@ -750,14 +762,21 @@ There are two different JSONBench-related locations.
 | Location | Role |
 | --- | --- |
 | `experiments/colgranule/jsonbench_treedb_columnstore_bench_test.go` | In-repo synthetic benchmark that compares the reference experiment kernels with the current production collection physical query path. |
-| `/Users/michaelseiler/dev/snissn/JSONBench/treedb` | Local checkout of the external JSONBench TreeDB harness. This is the canonical benchmark/reporting home for cross-database JSONBench runs. Current code is a public collections API row-scan/template baseline, not a production column-store cell. |
+| external `snissn/JSONBench/treedb` checkout | Canonical benchmark/reporting home for cross-database JSONBench runs. Common local checkouts include `/Users/michaelseiler/dev/snissn/JSONBench/treedb` and Orca workspaces, but the repository state is the authority. Current external work has transitional TreeDB column-store rows; this plan targets the final production typed-column cells and must keep direct, prepared, and metadata rows unambiguous. |
 
 The external harness entry points are:
 
-- `/Users/michaelseiler/dev/snissn/JSONBench/treedb/run_matrix.sh`
-- `/Users/michaelseiler/dev/snissn/JSONBench/treedb/cmd/jsonbench_treedb/run.go`
-- `/Users/michaelseiler/dev/snissn/JSONBench/treedb/cmd/jsonbench_treedb/queries.go`
-- `/Users/michaelseiler/dev/snissn/JSONBench/treedb/README.md`
+- `treedb/run_matrix.sh`
+- `treedb/cmd/jsonbench_treedb/run.go`
+- `treedb/cmd/jsonbench_treedb/queries.go`
+- `treedb/README.md`
+
+Current transitional external labels include `column-store`,
+`column-store-prepared`, and `column-store-prepared-metadata` once the prepared
+layout split lands. Those labels are acceptable as interim reference rows, but
+final production typed-column reports must still expose the same dimensions as
+`column-direct`, `column-prepared`, `column-direct-metadata`, and
+`column-prepared-metadata` or provide explicit aliases.
 
 ## Current Gap Summary
 
@@ -767,7 +786,7 @@ The external harness entry points are:
 | Granules and marks | Per-granule descriptors and sort-key prefix marks support pruning. | Present in the data plane. | Not used by production dictionary/int64 physical query paths. |
 | Sectioned column part image | One row-aligned image contains descriptors, marks, locators, dictionaries, metadata, and payloads. | Present, with extra stats/pruning/layout sections. | Published for `typed_column_part` owners, but JSONBench string/int64 production query paths still largely use compatibility per-column assets. |
 | Encodings and compression | Delta, double-delta, nullable, bool bitpack/RLE, compact string codes, adaptive codec block sizing, Snappy/LZ4 keep-if-smaller. | Mostly present or extended. | Production JSONBench-style physical queries do not consistently consume the typed-column codec/block model. |
-| q1-q5 kernels | Dense low-allocation kernels, fused q2, q4 time-order early stop, q4 prefix-pruned scan, q4/q5 metadata paths. | General primitives exist, but JSONBench kernels are not production APIs. | Prepared paths are strong in some cases, but direct paths still pay avoidable setup/mapping costs and lack q4 sort-order operators. |
+| q1-q5 kernels | Dense low-allocation kernels, fused q2, q2 sorted-prefix grouped distinct, q4 time-order early stop, q4 prefix-pruned scan, q4/q5 metadata paths. | General primitives exist, but JSONBench kernels are not production APIs. | Prepared paths are strong in some cases, but direct paths still pay avoidable setup/mapping costs, direct q2 rebuilds high-cardinality distinct state, and q4 sort-order operators are absent. |
 | Predicate-qualified aggregate metadata | Per-granule metadata can be built only for rows matching declared predicates. | Present in the data plane. | Production `ColumnAggregateMetadata` has no predicate declaration and aggregate metadata queries reject physical predicates. |
 | Multipart visibility and compaction | Base/delta/tombstones, latest-row visibility, part-set scans, compaction planning. | Data-plane subset exists. | Production has mutation manifests and visibility fallback, but optimized physical predicates, aggregate metadata, and prepared paths are mostly insert-only. |
 | Lifecycle control plane | Workspace inventory, prepared assets, reachability/reclaim/rewrite debt/quarantine planning. | Mostly deferred from internal typedcolumn. | Production has real asset manager/publish/GC/rewrite plumbing, but not a sorted typed-column part-set lifecycle model with full JSONBench diagnostics. |
@@ -821,8 +840,12 @@ Deliverables:
 
 - Pass `ColumnStoreConfig.SortKey` into the typed-column adapter instead of
   always using the synthetic primary-id order.
-- Sort each typed-column part by the configured sort key, then by logical
-  primary key, then by stable input order if needed.
+- Sort each typed-column part by the configured sort key's logical values, then
+  by logical primary key, then by stable input order if needed.
+- Define and test nullable/missing/default ordering for every supported sort-key
+  value type before allowing that type in persisted sort metadata.
+- Ensure dictionary-backed string sort keys compare by logical string value or by
+  a dictionary code space whose ordering is explicitly certified as equivalent.
 - Persist sort-key metadata in the column part image and manifest.
 - Start with ascending sort keys. Add descending support only after the mark
   semantics and tests cover it.
@@ -832,7 +855,8 @@ Acceptance criteria:
 - A collection declared with `SortKey: time_us` physically stores typed-column
   part rows in ascending `time_us` order.
 - A collection declared with the ClickHouse-style key
-  `(kind, operation, collection, did, time_us)` physically stores that order.
+  `(kind, operation, collection, did, time_us)` physically stores that order for
+  both q2 grouped-distinct and q4b prefix-scan layouts.
 - Reopen tests verify that sort metadata and row locators survive checkpoint and
   reopen.
 - Direct q4 time-order early-stop tests prove that the query stops after it can
@@ -846,13 +870,19 @@ Deliverables:
 - Add a production pruning plan for sort-key prefix ranges.
 - Add diagnostics for granules considered, granules skipped by marks, granules
   decoded, rows scanned, and bytes decoded.
+- Make q2 use the ClickHouse-style sort key to restrict to the
+  `kind=commit`, `operation=create` prefix and stream grouped distinct over
+  `(collection, did)` without rebuilding a global `did` string map per direct
+  run.
 - Make q4b use the ClickHouse-style sort key to prune on
   `kind=commit`, `operation=create`, and `collection=app.bsky.feed.post`.
 
 Acceptance criteria:
 
+- q2 direct production query can use sorted-prefix planning for the
+  `kind/operation` predicate and exact grouped distinct over `collection/did`.
 - q4b direct production query skips granules when marks prove they cannot match.
-- Mark-pruning result hashes match full-scan result hashes.
+- Mark-pruning and sorted-prefix result hashes match full-scan result hashes.
 - Tests cover empty ranges, boundary equality, multi-column prefixes, missing
   marks, corrupt marks, and unsupported descending marks.
 
@@ -864,7 +894,10 @@ but direct performance is the priority for this phase.
 Deliverables:
 
 - q1: grouped count by event/collection over dictionary codes.
-- q2: one fused pass that returns both row count and distinct user count by event.
+- q2: one fused pass that applies real `kind=commit` and `operation=create`
+  predicates, returns both row count and exact distinct user count by event, and
+  uses the sorted-prefix/grouped-distinct plan when the physical sort key proves
+  it is available.
 - q3: filtered event/hour grouped count.
 - q4a: top-3 earliest posters using `time_us` physical order and early stop.
 - q4b: top-3 earliest posters using ClickHouse-style sort order and mark-pruned
@@ -875,7 +908,8 @@ Acceptance criteria:
 
 - Direct q1-q5 scan typed-column sections, not JSON documents.
 - q2 is one physical query shape, not two independent physical calls glued
-  together at the benchmark layer.
+  together at the benchmark layer, and not a write-time masked benchmark
+  shortcut.
 - Hot loops avoid per-row map lookups and avoid per-row string conversions.
 - Each query has parity tests, allocation benchmarks, and CPU/alloc profiles.
 
@@ -987,7 +1021,7 @@ The production matrix should make every dimension explicit.
 | Query | Required production behavior |
 | --- | --- |
 | q1 | Count rows grouped by event/collection. |
-| q2 | For `kind=commit` and `operation=create`, count rows and distinct users grouped by event/collection. |
+| q2 | Store full `kind`, `operation`, `collection/event`, and `did`; at query time apply `kind=commit` and `operation=create`, then count rows and exact distinct users grouped by event/collection. |
 | q3 | For `kind=commit`, `operation=create`, and event in the JSONBench event list, count rows grouped by event and hour of day. |
 | q4a | For post creates, return the three users with earliest post time using `time_us` physical order and early stop. |
 | q4b | For post creates, return the three users with earliest post time using ClickHouse-style physical order plus sort-key mark pruning. |
@@ -999,7 +1033,7 @@ The production matrix should make every dimension explicit.
 | --- | --- | --- |
 | `typed-column-primary-id-control` | synthetic primary id | Control layout. It should be correct but should not claim sort-order optimizations. |
 | `typed-column-time` | `time_us` | q4a early-stop layout and a useful q1/q2/q3/q5 control. |
-| `typed-column-filter-user-time` | `kind`, `operation`, `collection`, `did`, `time_us` | q4b mark-pruned prefix-scan layout and ClickHouse-order comparison. |
+| `typed-column-filter-user-time` | `kind`, `operation`, `collection`, `did`, `time_us` | q2 sorted-prefix grouped-distinct layout, q4b mark-pruned prefix-scan layout, and ClickHouse-order comparison. |
 | `typed-column-unsorted-legacy-assets` | current compatibility row order | Legacy production comparison only. Do not use it as the target implementation. |
 
 ### Execution modes
@@ -1122,6 +1156,9 @@ Required metrics:
   without naming the exact asset or section.
 - Do not report prepared-only JSONBench results as the column-store result.
   Direct and prepared rows must stay separate.
+- Do not use q2 write-time masking, empty sentinels, or benchmark-specific
+  pre-filtered `event`/`did` payloads to simulate `kind=commit` and
+  `operation=create`. Store full predicate columns and execute real predicates.
 - Do not treat aggregate metadata as valid when mutation parts, stale manifests,
   compaction, or schema changes make the metadata unsafe.
 - Do not optimize by skipping checksum, schema, lifetime, or section-boundary
@@ -1135,10 +1172,15 @@ Required metrics:
    rather than only under `experiments/colgranule`.
 3. Wire `ColumnStoreConfig.SortKey` into typed-column publication for ascending
    int64/string-code sort carriers.
-4. Add q4a direct early-stop over `typed-column-time`.
-5. Add q2 direct fused count plus distinct over typed-column dictionary codes.
-6. Add sort-key mark diagnostics and q4b prefix pruning.
-7. Add predicate-qualified aggregate metadata declaration and q4/q5 metadata
+4. Add q2 direct fused count plus distinct over typed-column dictionary codes,
+   with real `kind`/`operation` predicates and no write-time sentinel masking.
+5. Wire sorted-prefix q2 planning over
+   `(kind, operation, collection, did, time_us)` so direct q2 stops rebuilding a
+   global high-cardinality `did` map when the sort contract is available.
+6. Add q4a direct early-stop over `typed-column-time`.
+7. Add sort-key mark diagnostics and q4b prefix pruning.
+8. Add predicate-qualified aggregate metadata declaration and q4/q5 metadata
    direct queries.
-8. Add external JSONBench `column-direct`, `column-prepared`,
-   `column-direct-metadata`, and `column-prepared-metadata` cells.
+9. Add or alias external JSONBench `column-direct`, `column-prepared`,
+   `column-direct-metadata`, and `column-prepared-metadata` cells, preserving
+   compatibility with transitional `column-store*` labels where needed.


### PR DESCRIPTION
## Objective

Tighten the typed-column JSONBench q2 production planning spec so predicate semantics, sort-key requirements, and transitional naming are explicit and non-ambiguous. Keep compatibility-retained legacy naming references explicitly classified in the typed-storage naming allowlist test.

## Context

Follow-up review feedback added clarifications needed for downstream implementation work (#1946/#1948/#1949/#1950/#1955), especially around q2 behavior constraints and transitional external-label mapping.

## Non-goals

- Implement runtime storage/query behavior changes.
- Change typed-column execution code paths.
- Add new benchmark harnesses or performance changes.

## Design

- Formats/flags/APIs changed (include diagrams if applicable)
  - Documentation-only updates in typed-column JSONBench planning docs.
  - Naming-allowlist test update for compatibility-retained `column-store` / `ColumnStore` references in the new planning doc.
- Invariants that must hold
  - q2 planning requires real-predicate semantics and no write-time masking/sentinel substitution.
  - SortKey contract requires logical-value ordering with explicit null/missing/default ordering and safe dictionary-backed comparisons.
  - Transitional external JSONBench labels are mapped explicitly to production typed-column terminology.
- Fail-closed behavior (caps before alloc; CRC/error handling)
  - Not applicable (no binary format/runtime parsing changes).

## Scope

- Includes (files/symbols):
  - `TreeDB/docs/spec/typed-column-production-jsonbench-plan.md`
  - `TreeDB/docs/spec/README.md`
  - `TreeDB/collections/typed_storage_naming_test.go` (`TestTypedStorageLegacyNameAllowlistIsComplete`)
- Excludes (files/symbols):
  - Runtime typed-column storage/query implementations and execution logic.

## Correctness

- Tests run (exact commands):
  - `git diff --check`
  - `GOWORK=off go test ./TreeDB/collections -run TestTypedStorageLegacyNameAllowlistIsComplete -count=1`
  - `GOWORK=off go test ./TreeDB/docs`
- Corruption/edge cases covered:
  - Naming guard coverage for legacy typed-storage terms remained enforced via allowlist test.
- Concurrency/race coverage (if applicable):
  - Not applicable.

## Performance

- Benchmarks run (exact commands):
  - Not run (docs + naming-allowlist follow-up only).
- Results table (before/after; median-of-5 per G1 in `docs/OPT_SPRINT_NEXT.md`):
  - Not applicable.
- Regressions (if any) and why acceptable:
  - None expected; no runtime code changes.

## Rollout / Toggle Plan

- Default setting:
  - No behavior change; documentation and guard test update only.
- How to disable quickly:
  - Not applicable.

## Follow-ups

- Continue implementation tracking under:
  - Umbrella: #1945
  - Related: #1946, #1948, #1949, #1950, #1955
  - Prior tracker context: #1943

## Column Graph Native Workstream (#1646, if applicable)

### Copied/Adapted From Old Stack

- Copied:
  - N/A
- Adapted:
  - N/A
- Oracle/comparator only:
  - N/A
- Quarantined/not copied:
  - N/A

### Path Identity

- Native reader:
  - N/A
- Decoded comparator:
  - N/A
- Legacy/native vector index:
  - N/A
- Unsupported/fail-closed:
  - N/A

### Base And Dependency State

- Base branch:
  - Current PR branch
- Base commit:
  - N/A
- Base PR/head:
  - N/A
- #1621/#1634 assumptions:
  - N/A
- Missing generic column-store primitives:
  - N/A
- Parent review fixes propagated:
  - Yes (minor docs feedback integrated).

### Evidence

- Tests:
  - `git diff --check`
  - `GOWORK=off go test ./TreeDB/collections -run TestTypedStorageLegacyNameAllowlistIsComplete -count=1`
  - `GOWORK=off go test ./TreeDB/docs`
- Benchmarks:
  - N/A
- Status/fallback proof:
  - N/A
- Performance attribution:
  - N/A
- Local regressions found/fixed:
  - None.

### Test Plan Start

- Milestone tasks targeted:
  - Documentation/spec tightening for typed-column JSONBench q2 planning.
- Tests to add before or with implementation:
  - None in this docs follow-up beyond allowlist guard maintenance.
- Existing tests to preserve:
  - `TestTypedStorageLegacyNameAllowlistIsComplete`, docs lint/tests.
- #1646 test-list changes made before implementation:
  - None.

### Performance Plan Start

- Relevant benchmarks/metrics for this PR:
  - N/A
- Baseline/comparator command or reason not applicable:
  - Not applicable for docs/test allowlist update.
- Expected setup/search/materialization boundary:
  - N/A
- Upstream costs explicitly out of scope:
  - All runtime performance work.
- Local performance risks to watch:
  - None.

### Test Plan Close

- Additional tests found during implementation/review:
  - None.
- Tests added or changed:
  - Naming allowlist classification updated for compatibility-retained terms.
- Failing tests fixed:
  - N/A
- #1646 test-list changes made at close:
  - None.
- Residual untested gaps, if any:
  - Runtime behavior remains out of scope.

### Performance Plan Close

- Benchmark commands run:
  - None.
- Results summary with throughput/latency/allocations:
  - N/A
- Before/after or baseline comparison:
  - N/A
- Local slow/heavy code found and fixed:
  - N/A
- Remaining upstream or deferred costs:
  - Runtime perf validation deferred to implementation PRs.

### AI Review Loop

- Codex latest-head review:
  - Not run.
- Copilot latest-head review:
  - Re-requested; no new comments.
- CodeRabbit latest-head review:
  - Minor docs suggestions addressed.
- Review comments/threads resolved or explicitly dismissed:
  - Addressed minor docs suggestions and allowlist classification follow-up.
- Re-requested after final meaningful push:
  - Yes.

---

## Optimization PR Checklist (TreeDB)

### Scope
- [x] Single, clear objective for this PR (not a bundle)
- [x] Explicit include list (files/symbols touched):
- [x] Explicit exclude list (files/symbols NOT touched):
- [x] No unwanted feature reintroduction (e.g. async slab writer, hard zones, ValueIndex) unless explicitly stated in the PR objective

### Safety / Correctness
- [x] Clear written-vs-durable semantics for any `*Sync` path touched
- [x] No new mmap usage on mutable/truncating files
- [x] All new length fields are capped before allocation (OOM-safe)
- [x] CRC/checksum behavior is fail-closed (clean error, no panic)
- [x] Any concurrency change has a defined state machine and invariants

### Tests
- [ ] Added deterministic regression tests for the targeted failure mode
- [ ] Tests avoid sleeps where possible (use latches/hooks)
- [ ] Added corruption/edge-case tests (truncation, bad headers, invalid lengths) when format/parsing changes
- [ ] Ran locally:
  - [ ] `go test ./... -count=1`
  - [x] Any targeted packages/benchmarks:

### Benchmarks / Measurements
- [ ] Added or updated a benchmark relevant to the change
- [ ] Reported results in PR description (before/after, command, machine)
- [ ] Included “incompressible” (worst-case) results if compression is involved

### Docs
- [ ] Updated `docs/OPT_SPRINT_NEXT.md` milestone status (if applicable)
- [x] Documented any new config knobs + defaults
- [x] Called out any format change in PR description (pre-alpha OK)

### Rollout / Toggle Plan (if behavior-affecting)
- [x] Safe defaults (feature off or conservative threshold)
- [x] Clear knobs to disable/revert behavior quickly
- [x] Observability: counters/logs to verify effectiveness

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated Design Proposals documentation with additional real-predicate query execution specifications
  * Refined JSONBench query requirements for improved accuracy in predicate execution and sort key handling
  * Enhanced external harness documentation with clarified implementation guidance
  * Updated specification details for physical data ordering and query planning
  * Aligned test validation expectations with refined specifications

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1957?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->