### PR TITLE
docs: resolve typed-column JSONBench review fallout

### DIFF
--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -406,6 +406,7 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/docs/spec/typed-column-adapter.md", classification: typedStorageLegacyCompatibility, matchingLines: 2, occurrences: 2},
 	{path: "TreeDB/docs/spec/typed-column-direct-view-alignment.md", classification: typedStorageLegacyCompatibility, matchingLines: 10, occurrences: 10},
 	{path: "TreeDB/docs/spec/typed-column-direct-view-closeout-1899.md", classification: typedStorageLegacyCompatibility, matchingLines: 3, occurrences: 3},
+	{path: "TreeDB/docs/spec/typed-column-production-jsonbench-plan.md", classification: typedStorageLegacyCompatibility, matchingLines: 9, occurrences: 9},
 	{path: "TreeDB/docs/spec/typed-column-semantics.md", classification: typedStorageLegacyCompatibility, matchingLines: 1, occurrences: 1},
 	{path: "TreeDB/docs/spec/typed-column-transplant.md", classification: typedStorageLegacyCompatibility, matchingLines: 4, occurrences: 5},
 	{path: "TreeDB/docs/spec/typed-storage-closeout-1758.md", classification: typedStorageLegacyCompatibility, matchingLines: 11, occurrences: 18},

--- a/TreeDB/docs/spec/typed-column-production-jsonbench-plan.md
+++ b/TreeDB/docs/spec/typed-column-production-jsonbench-plan.md
@@ -1088,13 +1088,17 @@ GOWORK=off go test ./TreeDB/collections \
   -memprofile "$OUT/allocs.pprof"
 
 JSONBENCH_TREEDB_DIR=${JSONBENCH_TREEDB_DIR:-../JSONBench/treedb}
-cd "$JSONBENCH_TREEDB_DIR"
-DATA_DIR=./testdata/bluesky SUBSET_ROWS=6 TRIES=1 ./run_matrix.sh
+(
+  cd "$JSONBENCH_TREEDB_DIR"
+  DATA_DIR=./testdata/bluesky SUBSET_ROWS=6 TRIES=1 ./run_matrix.sh
+)
 
 # External JSONBench 100k working run.
 JSONBENCH_TREEDB_DIR=${JSONBENCH_TREEDB_DIR:-../JSONBench/treedb}
-cd "$JSONBENCH_TREEDB_DIR"
-DATA_DIR="$HOME/data/bluesky" SUBSET_ROWS=100000 TRIES=3 ./run_matrix.sh
+(
+  cd "$JSONBENCH_TREEDB_DIR"
+  DATA_DIR="$HOME/data/bluesky" SUBSET_ROWS=100000 TRIES=3 ./run_matrix.sh
+)
 ```
 
 Required metrics:

--- a/TreeDB/docs/spec/typed-column-production-jsonbench-plan.md
+++ b/TreeDB/docs/spec/typed-column-production-jsonbench-plan.md
@@ -1,7 +1,7 @@
 # Production Typed-Column JSONBench Plan
 
-Status: planning note for promoting the `experiments/colgranule` design into the
-production TreeDB collection column store.
+Status: planning note for promoting the `experiments/colgranule` design into
+production TreeDB collection typed-column storage.
 
 TreeDB is pre-alpha. This plan may change on-disk formats and public collection
 query APIs. If an implementation changes persisted typed-column formats, update
@@ -10,7 +10,7 @@ scaffolding unless the specific change requires it.
 
 ## Goal
 
-Build the production collection column store around the same feature set proven
+Build the production collection typed-column path around the same feature set proven
 in `experiments/colgranule`, then make JSONBench q1 through q5 exercise those
 features through production APIs.
 
@@ -25,7 +25,7 @@ Use these terms consistently in code, docs, benchmark names, and diagnostics.
 
 ### Storage Containers
 
-#### Collection Column Store
+#### Collection Typed Storage
 
 The production collection feature configured by `ColumnStoreConfig` in
 `TreeDB/collections/column_store.go`.
@@ -727,7 +727,7 @@ It is not the production owner by itself.
 | Aggregate metadata and pruning metadata | `TreeDB/internal/typedcolumn/aggregate_metadata.go`, `pruning.go`, `stats.go` |
 | Data-plane part-set visibility | `TreeDB/internal/typedcolumn/part_set.go` |
 
-### Production collection column store
+### Production collection typed storage
 
 `TreeDB/collections` is the production integration target.
 
@@ -750,14 +750,14 @@ There are two different JSONBench-related locations.
 | Location | Role |
 | --- | --- |
 | `experiments/colgranule/jsonbench_treedb_columnstore_bench_test.go` | In-repo synthetic benchmark that compares the reference experiment kernels with the current production collection physical query path. |
-| `/Users/michaelseiler/dev/snissn/JSONBench/treedb` | Local checkout of the external JSONBench TreeDB harness. This is the canonical benchmark/reporting home for cross-database JSONBench runs. Current code is a public collections API row-scan/template baseline, not a production column-store cell. |
+| `$JSONBENCH_TREEDB_DIR` or `<jsonbench-checkout>/treedb` | Local checkout of the external JSONBench TreeDB harness. This is the canonical benchmark/reporting home for cross-database JSONBench runs. Current code is a public collections API row-scan/template baseline, not a production typed-column cell. |
 
-The external harness entry points are:
+The external harness entry points are under `$JSONBENCH_TREEDB_DIR`:
 
-- `/Users/michaelseiler/dev/snissn/JSONBench/treedb/run_matrix.sh`
-- `/Users/michaelseiler/dev/snissn/JSONBench/treedb/cmd/jsonbench_treedb/run.go`
-- `/Users/michaelseiler/dev/snissn/JSONBench/treedb/cmd/jsonbench_treedb/queries.go`
-- `/Users/michaelseiler/dev/snissn/JSONBench/treedb/README.md`
+- `run_matrix.sh`
+- `cmd/jsonbench_treedb/run.go`
+- `cmd/jsonbench_treedb/queries.go`
+- `README.md`
 
 ## Current Gap Summary
 
@@ -780,7 +780,7 @@ Deliverables:
 
 - Add or update docs so the terms in this note are used consistently.
 - Preserve current benchmark baselines for direct and prepared production queries.
-- Add parity tests that compare production column-store q1-q5 results against a
+- Add parity tests that compare production typed-column q1-q5 results against a
   simple row-scan implementation on the same input.
 - Keep the experiment benchmarks runnable until each feature is represented by
   production tests and benchmarks.
@@ -962,7 +962,7 @@ Acceptance criteria:
 
 Deliverables:
 
-- In the external JSONBench TreeDB harness, add explicit TreeDB column-store
+- In the external JSONBench TreeDB harness, add explicit TreeDB typed-column
   cells instead of overloading or relabeling row-scan/template cells.
 - In gomap, keep a smaller in-repo synthetic benchmark that exercises the same
   production query modes without depending on external JSONBench data.
@@ -1082,17 +1082,18 @@ OUT=/tmp/treedb_column_jsonbench_profile_$(date +%Y%m%d_%H%M%S)
 mkdir -p "$OUT"
 GOWORK=off go test ./TreeDB/collections \
   -run '^$' \
-  -bench 'BenchmarkJSONBenchProductionColumnStore/q2/direct' \
+  -bench 'BenchmarkJSONBenchProductionTypedColumn/q2/direct' \
   -benchmem \
   -cpuprofile "$OUT/cpu.pprof" \
   -memprofile "$OUT/allocs.pprof"
 
-# External JSONBench smoke once column-store cells exist there.
-cd /Users/michaelseiler/dev/snissn/JSONBench/treedb
+JSONBENCH_TREEDB_DIR=${JSONBENCH_TREEDB_DIR:-../JSONBench/treedb}
+cd "$JSONBENCH_TREEDB_DIR"
 DATA_DIR=./testdata/bluesky SUBSET_ROWS=6 TRIES=1 ./run_matrix.sh
 
 # External JSONBench 100k working run.
-cd /Users/michaelseiler/dev/snissn/JSONBench/treedb
+JSONBENCH_TREEDB_DIR=${JSONBENCH_TREEDB_DIR:-../JSONBench/treedb}
+cd "$JSONBENCH_TREEDB_DIR"
 DATA_DIR="$HOME/data/bluesky" SUBSET_ROWS=100000 TRIES=3 ./run_matrix.sh
 ```
 
@@ -1120,7 +1121,7 @@ Required metrics:
   validates the metadata it relies on.
 - Do not describe a storage source as a "sidecar" in new docs or diagnostics
   without naming the exact asset or section.
-- Do not report prepared-only JSONBench results as the column-store result.
+- Do not report prepared-only JSONBench results as the typed-column result.
   Direct and prepared rows must stay separate.
 - Do not treat aggregate metadata as valid when mutation parts, stale manifests,
   compaction, or schema changes make the metadata unsafe.


### PR DESCRIPTION
## Summary
- replace personal JSONBench checkout paths in `typed-column-production-jsonbench-plan.md` with `$JSONBENCH_TREEDB_DIR` and portable relative paths
- switch remaining prose from legacy "column store" wording to typed-column / typed storage vocabulary
- classify the remaining literal compatibility references (`ColumnStoreConfig`, existing benchmark selector) in the typed-storage legacy-name allowlist

## Context
Follow-up to merged PR #1956. This resolves the unresolved Codex review about the hard-coded JSONBench checkout path and fixes the failing `TestTypedStorageLegacyNameAllowlistIsComplete` CI check on the merged docs spec.

Refs #1945.

## Tests
- `go test ./TreeDB/collections -run 'TestTypedStorage(LegacyNameAllowlistIsComplete|SpecLinksResolve|NamingVocabulary|LegacyNamesRemainClassified)' -count=1`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Revised typed-column production benchmark docs: consistent terminology, updated parity testing guidance, profiling examples, harness instructions, and deliverable rules.
* **Tests**
  * Updated legacy-name allowlist to include a documentation entry so naming/completeness checks remain current.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/1958?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->