### PR TITLE
collections: reuse vector search result buffers

### DIFF
--- a/TreeDB/collections/vector_index_search.go
+++ b/TreeDB/collections/vector_index_search.go
@@ -49,6 +49,48 @@ type VectorIndexSearcherSearchOptions struct {
 	// DocumentFetchOptions controls optional projected final-fetch materialization.
 	// It is used only when IncludeDocuments is true; the zero value returns full documents.
 	DocumentFetchOptions DocumentFetchOptions
+	// Buffer optionally supplies caller-owned reusable storage for response
+	// result assembly and document-fetch staging. When Buffer is nil, Search
+	// allocates response-owned result and ID slices as before. When Buffer is
+	// non-nil, returned Results and result ID slices alias Buffer and remain
+	// valid until the next Search that reuses the same Buffer; one Buffer must
+	// not be shared by concurrent Search calls.
+	Buffer *VectorIndexSearchBuffer
+}
+
+// VectorIndexSearchBuffer is caller-owned reusable storage for
+// VectorIndexSearcher.Search response assembly. Its zero value is ready for use.
+// Pass one buffer per searcher/worker on steady-state hot paths to avoid
+// allocating result slices and result ID byte arenas on every Search.
+//
+// The fields are exported so callers may pre-size them, but Search owns their
+// contents while the response is live. Responses produced with a buffer alias
+// these slices until the buffer is reused or Reset is called.
+type VectorIndexSearchBuffer struct {
+	// Results stores the reusable public result slice returned in VectorIndexSearchResponse.Results.
+	Results []VectorIndexSearchResult
+	// IDBytes is the reusable byte arena backing each result ID.
+	IDBytes []byte
+	// DocumentIDs stages result IDs for optional post-top-k document materialization.
+	DocumentIDs [][]byte
+	// DocumentRowRefs stages row-ref materialization requests for document fetches.
+	DocumentRowRefs []DocumentRowRef
+}
+
+// Reset releases the buffer's current response view while retaining capacity for
+// reuse. It also clears result slots so buffered document payloads from an older
+// response are not kept live by the buffer.
+func (b *VectorIndexSearchBuffer) Reset() {
+	if b == nil {
+		return
+	}
+	clear(b.Results)
+	b.Results = b.Results[:0]
+	b.IDBytes = b.IDBytes[:0]
+	clear(b.DocumentIDs)
+	b.DocumentIDs = b.DocumentIDs[:0]
+	clear(b.DocumentRowRefs)
+	b.DocumentRowRefs = b.DocumentRowRefs[:0]
 }
 
 // VectorIndexSearchResult is one public vector-index search hit.
@@ -443,7 +485,9 @@ func failClosedColumnGraphReaderOpenStatus(def VectorIndexDefinition, status Vec
 }
 
 // Search runs one vector-index query against the searcher's bound snapshot.
-// Returned result IDs and documents are copied into response-owned buffers.
+// Returned result IDs and documents are copied into response-owned buffers unless
+// opts.Buffer is non-nil; with a buffer, Results and result IDs alias caller-owned
+// reusable storage until that buffer is reused or reset.
 func (s *VectorIndexSearcher) Search(opts VectorIndexSearcherSearchOptions) (VectorIndexSearchResponse, error) {
 	var response VectorIndexSearchResponse
 	if s == nil || s.reader == nil || s.collection == nil {
@@ -475,37 +519,20 @@ func (s *VectorIndexSearcher) Search(opts VectorIndexSearcherSearchOptions) (Vec
 		return response, err
 	}
 	if len(results) == 0 {
+		if opts.Buffer != nil {
+			opts.Buffer.Reset()
+		}
 		return response, nil
 	}
-	response.Results = make([]VectorIndexSearchResult, len(results))
-	idByteCount, err := vectorIndexSearchResultIDBytes(results)
+	response.Results, err = vectorIndexSearchResultsInto(results, opts.Buffer)
 	if err != nil {
 		return response, err
-	}
-	idBytes := make([]byte, idByteCount)
-	idOffset := 0
-	for i, result := range results {
-		if len(result.ID) > len(idBytes)-idOffset {
-			return response, errors.New("collections: vector index search result id byte accounting mismatch")
-		}
-		nextIDOffset := idOffset + len(result.ID)
-		id := idBytes[idOffset:nextIDOffset:nextIDOffset]
-		idOffset = nextIDOffset
-		copy(id, result.ID)
-		response.Results[i] = VectorIndexSearchResult{
-			ID:      id,
-			Ordinal: result.Ordinal,
-			Score:   result.Score,
-		}
 	}
 	if opts.IncludeDocuments {
 		if s.documentView == nil {
 			s.documentView = newCollectionReadViewAtSnapshot(s.collection, s.snapshot, s.catalog, false, mappedresource.ScopePreparedSearch)
 		}
-		ids := make([][]byte, len(results))
-		for i := range results {
-			ids[i] = results[i].ID
-		}
+		ids := vectorIndexSearchDocumentIDsInto(response.Results, opts.Buffer)
 		documentFetchOptions := opts.DocumentFetchOptions
 		var documents DocumentFetchResponse
 		var err error
@@ -520,7 +547,7 @@ func (s *VectorIndexSearcher) Search(opts VectorIndexSearcherSearchOptions) (Vec
 			if len(rowRefs.Results) != len(response.Results) {
 				return response, errors.New("collections: vector index document row-ref result count mismatch")
 			}
-			refs := make([]DocumentRowRef, len(rowRefs.Results))
+			refs := vectorIndexSearchDocumentRowRefsInto(len(rowRefs.Results), opts.Buffer)
 			for i := range rowRefs.Results {
 				if !rowRefs.Results[i].Found {
 					return response, fmt.Errorf("collections: vector index %q result document %q not found", s.indexName, results[i].ID)
@@ -552,6 +579,111 @@ func (s *VectorIndexSearcher) Search(opts VectorIndexSearcherSearchOptions) (Vec
 		}
 	}
 	return response, nil
+}
+
+func vectorIndexSearchResultsInto(results []columnVectorGraphNativeSearchResult, buffer *VectorIndexSearchBuffer) ([]VectorIndexSearchResult, error) {
+	if len(results) == 0 {
+		if buffer != nil {
+			buffer.Reset()
+		}
+		return nil, nil
+	}
+	idByteCount, err := vectorIndexSearchResultIDBytes(results)
+	if err != nil {
+		return nil, err
+	}
+	var out []VectorIndexSearchResult
+	var idBytes []byte
+	if buffer == nil {
+		out = make([]VectorIndexSearchResult, len(results))
+		idBytes = make([]byte, idByteCount)
+	} else {
+		if len(buffer.Results) > len(results) {
+			clear(buffer.Results[len(results):])
+		}
+		if len(buffer.DocumentIDs) > 0 {
+			clear(buffer.DocumentIDs)
+			buffer.DocumentIDs = buffer.DocumentIDs[:0]
+		}
+		if len(buffer.DocumentRowRefs) > 0 {
+			clear(buffer.DocumentRowRefs)
+			buffer.DocumentRowRefs = buffer.DocumentRowRefs[:0]
+		}
+		if cap(buffer.Results) < len(results) {
+			buffer.Results = make([]VectorIndexSearchResult, len(results))
+		} else {
+			buffer.Results = buffer.Results[:len(results)]
+		}
+		if cap(buffer.IDBytes) < idByteCount {
+			buffer.IDBytes = make([]byte, idByteCount)
+		} else {
+			buffer.IDBytes = buffer.IDBytes[:idByteCount]
+		}
+		out = buffer.Results
+		idBytes = buffer.IDBytes
+	}
+	idOffset := 0
+	for i, result := range results {
+		if len(result.ID) > len(idBytes)-idOffset {
+			return nil, errors.New("collections: vector index search result id byte accounting mismatch")
+		}
+		nextIDOffset := idOffset + len(result.ID)
+		id := idBytes[idOffset:nextIDOffset:nextIDOffset]
+		idOffset = nextIDOffset
+		copy(id, result.ID)
+		out[i] = VectorIndexSearchResult{
+			ID:      id,
+			Ordinal: result.Ordinal,
+			Score:   result.Score,
+		}
+	}
+	return out, nil
+}
+
+func vectorIndexSearchDocumentIDsInto(results []VectorIndexSearchResult, buffer *VectorIndexSearchBuffer) [][]byte {
+	if len(results) == 0 {
+		if buffer != nil {
+			clear(buffer.DocumentIDs)
+			buffer.DocumentIDs = buffer.DocumentIDs[:0]
+		}
+		return nil
+	}
+	var ids [][]byte
+	if buffer == nil {
+		ids = make([][]byte, len(results))
+	} else {
+		clear(buffer.DocumentIDs)
+		if cap(buffer.DocumentIDs) < len(results) {
+			buffer.DocumentIDs = make([][]byte, len(results))
+		} else {
+			buffer.DocumentIDs = buffer.DocumentIDs[:len(results)]
+		}
+		ids = buffer.DocumentIDs
+	}
+	for i := range results {
+		ids[i] = results[i].ID
+	}
+	return ids
+}
+
+func vectorIndexSearchDocumentRowRefsInto(count int, buffer *VectorIndexSearchBuffer) []DocumentRowRef {
+	if count <= 0 {
+		if buffer != nil {
+			clear(buffer.DocumentRowRefs)
+			buffer.DocumentRowRefs = buffer.DocumentRowRefs[:0]
+		}
+		return nil
+	}
+	if buffer == nil {
+		return make([]DocumentRowRef, count)
+	}
+	clear(buffer.DocumentRowRefs)
+	if cap(buffer.DocumentRowRefs) < count {
+		buffer.DocumentRowRefs = make([]DocumentRowRef, count)
+	} else {
+		buffer.DocumentRowRefs = buffer.DocumentRowRefs[:count]
+	}
+	return buffer.DocumentRowRefs
 }
 
 func validateVectorIndexSearchRequest(topK, efSearch int) error {

--- a/TreeDB/collections/vector_index_search_test.go
+++ b/TreeDB/collections/vector_index_search_test.go
@@ -98,6 +98,79 @@ func TestSearchVectorIndexColumnGraphResultIDsAreCapacityIsolatedV4(t *testing.T
 	}
 }
 
+func TestOpenVectorIndexSearcherSearchBufferReusesCallerStorageV4(t *testing.T) {
+	rows := []columnGraphRebuildInputRowV2A{
+		{id: "doc-a", vector: []float32{1, 0, 0}},
+		{id: "doc-b", vector: []float32{0.9, 0.1, 0}},
+		{id: "doc-c", vector: []float32{0, 1, 0}},
+		{id: "doc-d", vector: []float32{0, 0, 1}},
+	}
+	_, d, col, def := openColumnGraphRebuildTestCollectionV2A(t, 3, 2, rows)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	searcher, err := col.OpenVectorIndexSearcher(VectorIndexSearcherOptions{
+		IndexName:        def.Name,
+		MaxDecodedBlocks: 1,
+	})
+	if err != nil {
+		t.Fatalf("OpenVectorIndexSearcher: %v", err)
+	}
+	defer func() { _ = searcher.Close() }()
+
+	var buffer VectorIndexSearchBuffer
+	opts := VectorIndexSearcherSearchOptions{
+		Query:    []float32{1, 0, 0},
+		TopK:     2,
+		EfSearch: len(rows),
+		Buffer:   &buffer,
+	}
+	first, err := searcher.Search(opts)
+	if err != nil {
+		t.Fatalf("Search first: %v", err)
+	}
+	assertColumnGraphSearchResponseLoadedV4(t, first, def.Name, 2)
+	if len(buffer.Results) != len(first.Results) || len(buffer.IDBytes) == 0 {
+		t.Fatalf("buffer results=%d id_bytes=%d want populated caller storage", len(buffer.Results), len(buffer.IDBytes))
+	}
+	if &first.Results[0] != &buffer.Results[0] {
+		t.Fatalf("response results do not alias caller buffer")
+	}
+	if &first.Results[0].ID[0] != &buffer.IDBytes[0] {
+		t.Fatalf("response result IDs do not alias caller ID arena")
+	}
+	resultPtr := &buffer.Results[0]
+	idPtr := &buffer.IDBytes[0]
+	secondID := append([]byte(nil), first.Results[1].ID...)
+	_ = append(first.Results[0].ID, '!')
+	if !bytes.Equal(first.Results[1].ID, secondID) {
+		t.Fatalf("second result ID changed after appending to first buffered result ID: got %q want %q", first.Results[1].ID, secondID)
+	}
+
+	opts.Query = []float32{0, 0, 1}
+	second, err := searcher.Search(opts)
+	if err != nil {
+		t.Fatalf("Search second: %v", err)
+	}
+	assertColumnGraphSearchResponseLoadedV4(t, second, def.Name, 2)
+	if &second.Results[0] != resultPtr || &buffer.Results[0] != resultPtr {
+		t.Fatalf("result storage was not reused across buffered searches")
+	}
+	if &second.Results[0].ID[0] != idPtr || &buffer.IDBytes[0] != idPtr {
+		t.Fatalf("ID arena was not reused across buffered searches")
+	}
+
+	opts.TopK = 0
+	empty, err := searcher.Search(opts)
+	if err != nil {
+		t.Fatalf("Search empty: %v", err)
+	}
+	if len(empty.Results) != 0 || len(buffer.Results) != 0 || len(buffer.IDBytes) != 0 {
+		t.Fatalf("empty buffered search results=%d buffer_results=%d id_bytes=%d, want all empty", len(empty.Results), len(buffer.Results), len(buffer.IDBytes))
+	}
+}
+
 func TestSearchVectorIndexByteAccountingRejectsOverflowV4(t *testing.T) {
 	total, err := addVectorIndexSearchByteTotal(3, 4, 10, "document")
 	if err != nil || total != 7 {
@@ -1435,12 +1508,14 @@ func benchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderV4(b *tes
 	}
 	defer func() { _ = searcher.Close() }()
 	query := append([]float32(nil), input[37].vector...)
+	var searchBuffer VectorIndexSearchBuffer
 	opts := VectorIndexSearcherSearchOptions{
 		Query:                query,
 		TopK:                 topK,
 		EfSearch:             efSearch,
 		IncludeDocuments:     includeDocuments,
 		DocumentFetchOptions: fetchOptions,
+		Buffer:               &searchBuffer,
 	}
 	if _, err := searcher.Search(opts); err != nil {
 		b.Fatalf("warm Search: %v", err)
@@ -1524,12 +1599,18 @@ func benchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderParallelV
 			b.Fatalf("OpenVectorIndexSearcher worker %d: %v", i, err)
 		}
 		defer func() { _ = searcher.Close() }()
-		if _, err := searcher.Search(opts); err != nil {
+		benchWorkers[i].searcher = searcher
+		var warmBuffer VectorIndexSearchBuffer
+		workerOpts := opts
+		workerOpts.Buffer = &warmBuffer
+		if _, err := searcher.Search(workerOpts); err != nil {
 			b.Fatalf("warm Search worker %d: %v", i, err)
 		}
-		benchWorkers[i] = preparedWorker{searcher: searcher}
 	}
-	measuredStats, err := benchWorkers[0].searcher.Search(opts)
+	var measureBuffer VectorIndexSearchBuffer
+	measureOpts := opts
+	measureOpts.Buffer = &measureBuffer
+	measuredStats, err := benchWorkers[0].searcher.Search(measureOpts)
 	if err != nil {
 		b.Fatalf("measure Search stats: %v", err)
 	}
@@ -1559,12 +1640,17 @@ func benchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderParallelV
 			return
 		}
 		searcher := benchWorkers[workerIndex].searcher
+		// Keep the response buffer goroutine-local in the hot loop: sharing
+		// mutable slice headers between parallel workers can create false sharing.
+		var workerBuffer VectorIndexSearchBuffer
+		workerOpts := opts
+		workerOpts.Buffer = &workerBuffer
 		var localSink int64
 		for pb.Next() {
 			if failed.Load() {
 				continue
 			}
-			got, err := searcher.Search(opts)
+			got, err := searcher.Search(workerOpts)
 			if err != nil {
 				recordParallelErr("Search: %v", err)
 				continue


### PR DESCRIPTION
## Summary

Extends #1959 by removing the steady-state result/ID buffer allocation from `VectorIndexSearcher.Search` callers that opt into a reusable buffer.

- Adds `VectorIndexSearchBuffer` and `VectorIndexSearcherSearchOptions.Buffer` for caller-owned result/ID/document-fetch staging storage.
- Keeps existing `Search` behavior unchanged when `Buffer` is nil.
- Updates the typed-column native-reader serial and parallel benchmarks to reuse one buffer per serial loop / parallel worker instead of allocating result buffers on every search.
- Covers buffered result aliasing, ID arena reuse, cap isolation, and empty-search reset behavior.

## Allocation profile proof

Profile command (baseline at #1959 head `0e309897d`, after at this branch):

```sh
go test ./TreeDB/collections \
  -run '^$' \
  -bench '^BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderV4$' \
  -benchmem -count=1 \
  -memprofile /tmp/search_allocs_{before,after}.pprof

go tool pprof -top -sample_index=alloc_space /tmp/search_allocs_before_fair.pprof
go tool pprof -top -sample_index=alloc_space /tmp/search_allocs_after_final.pprof
```

Before, the steady-state benchmark reported `784 B/op` and `2 allocs/op`, and the allocation profile showed `collections.(*VectorIndexSearcher).Search` as the hot search-loop allocator:

```text
85.55MB  11.71%  github.com/snissn/gomap/TreeDB/collections.(*VectorIndexSearcher).Search
BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderV4-8 ... 784 B/op 2 allocs/op
```

After, the same benchmark reports `0 B/op` and `0 allocs/op`, and `VectorIndexSearcher.Search` no longer appears in the alloc-space top list:

```text
BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderV4-8 ... 0 B/op 0 allocs/op
```

## Benchmarks

Baseline was #1959 head (`0e309897d`) from a detached worktree; after is this branch. Command:

```sh
go test ./TreeDB/collections \
  -run '^$' \
  -bench '^(BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderV4|BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderWithDocumentsV4|BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderParallelV4|BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderParallelWithDocumentsV4)$' \
  -benchmem -count=3
benchstat -filter '.unit:(sec/op OR B/op OR allocs/op)' before.txt after.txt
```

| Benchmark | before ops/sec | after ops/sec | bytes/op | allocs/op |
|---|---:|---:|---:|---:|
| serial, no doc fetch | 86,806 | 84,203 | 784 → 0 | 2 → 0 |
| serial, doc fetch | 8,802 | 8,952 | 93.00 KiB → 91.44 KiB | 345 → 341 |
| parallel, no doc fetch | 291,121 | 332,116 | 784 → 0 | 2 → 0 |
| parallel, doc fetch | 33,756 | 40,074 | 93.01 KiB → 91.45 KiB | 345 → 341 |

Core benchstat output:

```text
OpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderV4-8                         11.52µ → 11.88µ sec/op, 784 B/op → 0 B/op, 2 → 0 allocs/op
OpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderWithDocumentsV4-8            113.6µ → 111.7µ sec/op, 93.00 KiB/op → 91.44 KiB/op, 345 → 341 allocs/op
OpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderParallelV4-8                 3.435µ → 3.011µ sec/op, 784 B/op → 0 B/op, 2 → 0 allocs/op
OpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderParallelWithDocumentsV4-8    29.62µ → 24.95µ sec/op, 93.01 KiB/op → 91.45 KiB/op, 345 → 341 allocs/op
```

## Tests

```sh
go test ./TreeDB/collections
```
