### PR TITLE
Surface vector search benchmark tiers and reusable buffers

### DIFF
--- a/TreeDB/README.md
+++ b/TreeDB/README.md
@@ -161,6 +161,13 @@ The initial API lives in `TreeDB/collections`:
   snapshot dirtiness, candidate counts, selected strategy, exact fallback
   reason, rebuild duration, and recall-at-k.
 
+Native `column_graph` benchmark tiers are documented in
+`docs/guides/vector-search-typed-column.md#vector-search-benchmark-tiers`.
+Use that matrix to distinguish core graph search, existing public response-owned
+`Search`, reusable-buffer no-document `SearchWithBuffer`, parallel callers, and
+explicit document-fetch paths. Report `ops/sec` (`1e9 / ns/op`) with `ns/op`,
+`B/op`, `allocs/op`, and vector/adjacency direct-vs-scratch counters.
+
 Smoke benchmark:
 
 ```sh

--- a/TreeDB/collections/column_vector_graph_search_test.go
+++ b/TreeDB/collections/column_vector_graph_search_test.go
@@ -804,6 +804,10 @@ func BenchmarkColumnVectorGraphNativeSearchCosineTypedColumnV3(b *testing.B) {
 	benchmarkColumnVectorGraphNativeSearchCosineV3(b, shape)
 }
 
+func BenchmarkVectorSearchCoreGraphSerialTypedColumn1961(b *testing.B) {
+	BenchmarkColumnVectorGraphNativeSearchCosineTypedColumnV3(b)
+}
+
 func BenchmarkColumnVectorGraphNativeSearchCosineTypedColumnProduction8192V3(b *testing.B) {
 	shape := columnVectorGraphNativeSearchProduction8192BenchShapeV3()
 	shape.typedColumnVector = true
@@ -896,6 +900,10 @@ func BenchmarkColumnVectorGraphNativeSearchCosineParallelTypedColumnV3(b *testin
 	shape := columnVectorGraphNativeSearchSmallBenchShapeV3()
 	shape.typedColumnVector = true
 	benchmarkColumnVectorGraphNativeSearchCosineParallelV3(b, shape)
+}
+
+func BenchmarkVectorSearchCoreGraphParallelTypedColumn1961(b *testing.B) {
+	BenchmarkColumnVectorGraphNativeSearchCosineParallelTypedColumnV3(b)
 }
 
 func BenchmarkColumnVectorGraphNativeSearchCosineParallelTypedColumnProduction8192V3(b *testing.B) {

--- a/TreeDB/collections/vector_index_search.go
+++ b/TreeDB/collections/vector_index_search.go
@@ -53,7 +53,9 @@ type VectorIndexSearcherSearchOptions struct {
 
 // VectorIndexSearchResult is one public vector-index search hit.
 type VectorIndexSearchResult struct {
-	// ID is the collection document ID. The returned slice is response-owned.
+	// ID is the collection document ID. Search and SearchVectorIndex return
+	// response-owned bytes. SearchWithBuffer returns bytes owned by the caller's
+	// VectorIndexSearchBuffer and valid only until that buffer is reused or reset.
 	ID []byte `json:"id"`
 	// Ordinal is the vector row ordinal in the persisted column_graph index.
 	Ordinal int `json:"ordinal"`
@@ -250,8 +252,36 @@ type VectorIndexSearchResponse struct {
 	Status VectorIndexStatus `json:"status"`
 	// Stats contains search and reader telemetry.
 	Stats VectorIndexSearchStats `json:"stats,omitempty"`
-	// Results contains top-k hits in descending score order.
+	// Results contains top-k hits in descending score order. Search and
+	// SearchVectorIndex return response-owned slices; SearchWithBuffer returns a
+	// slice owned by the caller's VectorIndexSearchBuffer.
 	Results []VectorIndexSearchResult `json:"results,omitempty"`
+}
+
+// VectorIndexSearchBuffer is caller-owned reusable response storage for
+// VectorIndexSearcher.SearchWithBuffer. It is intended for steady-state
+// no-document searches that need to avoid per-call response allocation.
+//
+// A VectorIndexSearchBuffer is not safe for concurrent use. Do not reuse or
+// reset the same buffer while any caller still needs a response previously
+// returned from it. The response Results slice and each result ID returned by
+// SearchWithBuffer alias this buffer and remain valid only until the same
+// buffer is reused or Reset is called. Parallel callers should use independent
+// searcher/buffer pairs per worker.
+type VectorIndexSearchBuffer struct {
+	results []VectorIndexSearchResult
+	idBytes []byte
+}
+
+// Reset clears the buffer's current response view while retaining reusable
+// capacity. Any response previously returned by SearchWithBuffer with this
+// buffer must be considered invalid after Reset returns.
+func (b *VectorIndexSearchBuffer) Reset() {
+	if b == nil {
+		return
+	}
+	b.results = b.results[:0]
+	b.idBytes = b.idBytes[:0]
 }
 
 // VectorIndexSearcher is a reusable, snapshot-bound vector index search handle.
@@ -552,6 +582,98 @@ func (s *VectorIndexSearcher) Search(opts VectorIndexSearcherSearchOptions) (Vec
 		}
 	}
 	return response, nil
+}
+
+// SearchWithBuffer runs one no-document vector-index query against the
+// searcher's bound snapshot using caller-owned reusable response storage.
+// Returned result slices and result IDs alias buffer and are valid only until
+// buffer is reused or Reset is called. The same buffer must not be reused
+// concurrently; parallel callers should use independent searcher/buffer pairs
+// per worker. IncludeDocuments is not supported by this reusable no-document
+// path.
+//
+// On any error after a non-nil buffer is supplied, the buffer's reusable
+// result/id views are reset to length zero and the returned response has no
+// Results. Search metadata and any telemetry collected before the error may
+// still be present in the returned response.
+func (s *VectorIndexSearcher) SearchWithBuffer(opts VectorIndexSearcherSearchOptions, buffer *VectorIndexSearchBuffer) (VectorIndexSearchResponse, error) {
+	if buffer == nil {
+		return VectorIndexSearchResponse{}, errors.New("collections: nil vector index search buffer")
+	}
+	buffer.Reset()
+	var response VectorIndexSearchResponse
+	if s == nil || s.reader == nil || s.collection == nil {
+		return response, errors.New("collections: nil vector index searcher")
+	}
+	response.IndexName = s.indexName
+	response.Strategy = s.strategy
+	response.Path = s.path
+	response.Status = s.status
+	if s.closed {
+		return response, errors.New("collections: vector index searcher is closed")
+	}
+	if err := validateVectorIndexSearchRequest(opts.TopK, opts.EfSearch); err != nil {
+		return response, err
+	}
+	if opts.IncludeDocuments {
+		return response, errors.New("collections: vector index SearchWithBuffer does not support IncludeDocuments")
+	}
+	if documentFetchOptionsHasProjection(opts.DocumentFetchOptions) {
+		return response, errors.New("collections: vector index document projection requires IncludeDocuments")
+	}
+	readerStatsBefore := s.readerLast
+	results, searchStats, err := s.reader.SearchCosine(opts.Query, columnVectorGraphNativeSearchOptions{
+		TopK:     opts.TopK,
+		EfSearch: opts.EfSearch,
+	}, &s.scratch)
+	readerStatsAfter := s.reader.Stats()
+	s.readerLast = readerStatsAfter
+	readerStats := columnPhysicalRowReaderStatsDelta(readerStatsBefore, readerStatsAfter)
+	response.Stats = vectorIndexSearchStatsFromInternal(searchStats, readerStats)
+	if err != nil {
+		return response, err
+	}
+	if len(results) == 0 {
+		return response, nil
+	}
+	idByteCount, err := vectorIndexSearchResultIDBytes(results)
+	if err != nil {
+		return response, err
+	}
+	buffer.results = resizeVectorIndexSearchResultBuffer(buffer.results, len(results))
+	buffer.idBytes = resizeVectorIndexSearchByteBuffer(buffer.idBytes, idByteCount)
+	idOffset := 0
+	for i, result := range results {
+		if len(result.ID) > len(buffer.idBytes)-idOffset {
+			buffer.Reset()
+			return response, errors.New("collections: vector index search result id byte accounting mismatch")
+		}
+		nextIDOffset := idOffset + len(result.ID)
+		id := buffer.idBytes[idOffset:nextIDOffset:nextIDOffset]
+		idOffset = nextIDOffset
+		copy(id, result.ID)
+		buffer.results[i] = VectorIndexSearchResult{
+			ID:      id,
+			Ordinal: result.Ordinal,
+			Score:   result.Score,
+		}
+	}
+	response.Results = buffer.results
+	return response, nil
+}
+
+func resizeVectorIndexSearchResultBuffer(dst []VectorIndexSearchResult, target int) []VectorIndexSearchResult {
+	if cap(dst) < target || columnVectorGraphNativeScratchCapOversized(cap(dst), target) {
+		return make([]VectorIndexSearchResult, target)
+	}
+	return dst[:target]
+}
+
+func resizeVectorIndexSearchByteBuffer(dst []byte, target int) []byte {
+	if cap(dst) < target || columnVectorGraphNativeScratchCapOversized(cap(dst), target) {
+		return make([]byte, target)
+	}
+	return dst[:target]
 }
 
 func validateVectorIndexSearchRequest(topK, efSearch int) error {

--- a/TreeDB/collections/vector_index_search_test.go
+++ b/TreeDB/collections/vector_index_search_test.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"runtime"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 
@@ -545,6 +546,211 @@ func TestOpenVectorIndexSearcherReusesNativeReaderV4(t *testing.T) {
 	if first.Stats.Candidates == 0 || second.Stats.Candidates == 0 {
 		t.Fatalf("candidate stats first=%d second=%d want non-zero searches", first.Stats.Candidates, second.Stats.Candidates)
 	}
+}
+
+func TestVectorIndexSearcherSearchWithBufferReuseGrowShrinkNoStaleIDs1961(t *testing.T) {
+	rows := []columnGraphRebuildInputRowV2A{
+		{id: "doc-long-a", vector: []float32{1, 0, 0}},
+		{id: "b", vector: []float32{0, 1, 0}},
+		{id: "cc", vector: []float32{0, 0, 1}},
+		{id: "dddd", vector: []float32{0.7, 0.3, 0}},
+	}
+	_, d, col, def := openColumnGraphRebuildTestCollectionV2A(t, 3, 3, rows)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	searcher, err := col.OpenVectorIndexSearcher(VectorIndexSearcherOptions{IndexName: def.Name, MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("OpenVectorIndexSearcher: %v", err)
+	}
+	defer func() { _ = searcher.Close() }()
+
+	var buffer VectorIndexSearchBuffer
+	growOpts := VectorIndexSearcherSearchOptions{Query: []float32{1, 0, 0}, TopK: 3, EfSearch: len(rows)}
+	for i := 0; i < 3; i++ {
+		got, err := searcher.SearchWithBuffer(growOpts, &buffer)
+		if err != nil {
+			t.Fatalf("SearchWithBuffer grow iteration %d: %v", i, err)
+		}
+		assertColumnGraphSearchResponseLoadedV4(t, got, def.Name, 3)
+		assertVectorIndexSearchResultsV4(t, got.Results, exactColumnGraphTopKForTest(t, rows, growOpts.Query, growOpts.TopK), false)
+		for j, result := range got.Results {
+			if cap(result.ID) != len(result.ID) {
+				t.Fatalf("grow iteration %d result[%d] id len/cap=%d/%d want cap isolated", i, j, len(result.ID), cap(result.ID))
+			}
+		}
+	}
+
+	shrinkOpts := VectorIndexSearcherSearchOptions{Query: []float32{0, 1, 0}, TopK: 1, EfSearch: len(rows)}
+	shrunk, err := searcher.SearchWithBuffer(shrinkOpts, &buffer)
+	if err != nil {
+		t.Fatalf("SearchWithBuffer shrink: %v", err)
+	}
+	assertColumnGraphSearchResponseLoadedV4(t, shrunk, def.Name, 1)
+	assertVectorIndexSearchResultsV4(t, shrunk.Results, exactColumnGraphTopKForTest(t, rows, shrinkOpts.Query, shrinkOpts.TopK), false)
+	if gotID := string(shrunk.Results[0].ID); gotID != "b" {
+		t.Fatalf("shrunk top id=%q want b without stale bytes from longer prior IDs", gotID)
+	}
+	if cap(shrunk.Results[0].ID) != len(shrunk.Results[0].ID) {
+		t.Fatalf("shrunk id len/cap=%d/%d want cap isolated", len(shrunk.Results[0].ID), cap(shrunk.Results[0].ID))
+	}
+
+	regrown, err := searcher.SearchWithBuffer(growOpts, &buffer)
+	if err != nil {
+		t.Fatalf("SearchWithBuffer regrow: %v", err)
+	}
+	assertColumnGraphSearchResponseLoadedV4(t, regrown, def.Name, 3)
+	assertVectorIndexSearchResultsV4(t, regrown.Results, exactColumnGraphTopKForTest(t, rows, growOpts.Query, growOpts.TopK), false)
+}
+
+func TestVectorIndexSearcherSearchWithBufferDoesNotMutateSearchResponse1961(t *testing.T) {
+	rows := []columnGraphRebuildInputRowV2A{
+		{id: "doc-a", vector: []float32{1, 0, 0}},
+		{id: "doc-b", vector: []float32{0, 1, 0}},
+		{id: "doc-c", vector: []float32{0, 0, 1}},
+	}
+	_, d, col, def := openColumnGraphRebuildTestCollectionV2A(t, 3, 2, rows)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	searcher, err := col.OpenVectorIndexSearcher(VectorIndexSearcherOptions{IndexName: def.Name, MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("OpenVectorIndexSearcher: %v", err)
+	}
+	defer func() { _ = searcher.Close() }()
+
+	opts := VectorIndexSearcherSearchOptions{Query: []float32{1, 0, 0}, TopK: 2, EfSearch: len(rows)}
+	owned, err := searcher.Search(opts)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	assertColumnGraphSearchResponseLoadedV4(t, owned, def.Name, 2)
+	ownedID := append([]byte(nil), owned.Results[0].ID...)
+
+	var buffer VectorIndexSearchBuffer
+	buffered, err := searcher.SearchWithBuffer(opts, &buffer)
+	if err != nil {
+		t.Fatalf("SearchWithBuffer: %v", err)
+	}
+	assertColumnGraphSearchResponseLoadedV4(t, buffered, def.Name, 2)
+	buffered.Results[0].ID[0] = 'X'
+	if !bytes.Equal(owned.Results[0].ID, ownedID) {
+		t.Fatalf("Search response ID changed after mutating SearchWithBuffer response: got %q want %q", owned.Results[0].ID, ownedID)
+	}
+
+	if _, err := searcher.SearchWithBuffer(VectorIndexSearcherSearchOptions{Query: []float32{0, 1, 0}, TopK: 1, EfSearch: len(rows)}, &buffer); err != nil {
+		t.Fatalf("second SearchWithBuffer: %v", err)
+	}
+	if !bytes.Equal(owned.Results[0].ID, ownedID) {
+		t.Fatalf("Search response ID changed after reusing buffer: got %q want %q", owned.Results[0].ID, ownedID)
+	}
+}
+
+func TestVectorIndexSearcherSearchWithBufferParallelIndependentBuffers1961(t *testing.T) {
+	rows := []columnGraphRebuildInputRowV2A{
+		{id: "doc-a", vector: []float32{1, 0, 0}},
+		{id: "doc-b", vector: []float32{0, 1, 0}},
+		{id: "doc-c", vector: []float32{0, 0, 1}},
+		{id: "doc-d", vector: []float32{0.7, 0.3, 0}},
+	}
+	_, d, col, def := openColumnGraphRebuildTestCollectionV2A(t, 3, 3, rows)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	query := []float32{1, 0, 0}
+	topK := 2
+	want := exactColumnGraphTopKForTest(t, rows, query, topK)
+	const workers = 4
+	const iterations = 20
+	var wg sync.WaitGroup
+	errs := make(chan string, workers)
+	for worker := 0; worker < workers; worker++ {
+		wg.Add(1)
+		go func(worker int) {
+			defer wg.Done()
+			searcher, err := col.OpenVectorIndexSearcher(VectorIndexSearcherOptions{IndexName: def.Name, MaxDecodedBlocks: 1})
+			if err != nil {
+				errs <- fmt.Sprintf("worker %d OpenVectorIndexSearcher: %v", worker, err)
+				return
+			}
+			defer func() { _ = searcher.Close() }()
+			var buffer VectorIndexSearchBuffer
+			opts := VectorIndexSearcherSearchOptions{Query: query, TopK: topK, EfSearch: len(rows)}
+			for i := 0; i < iterations; i++ {
+				got, err := searcher.SearchWithBuffer(opts, &buffer)
+				if err != nil {
+					errs <- fmt.Sprintf("worker %d iteration %d SearchWithBuffer: %v", worker, i, err)
+					return
+				}
+				if len(got.Results) != len(want) {
+					errs <- fmt.Sprintf("worker %d iteration %d results=%d want %d", worker, i, len(got.Results), len(want))
+					return
+				}
+				for j := range want {
+					if !bytes.Equal(got.Results[j].ID, want[j].ID) || math.Abs(got.Results[j].Score-want[j].Score) > 1e-6 {
+						errs <- fmt.Sprintf("worker %d iteration %d result[%d]=%+v want id=%q score=%v", worker, i, j, got.Results[j], want[j].ID, want[j].Score)
+						return
+					}
+				}
+			}
+		}(worker)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Error(err)
+	}
+}
+
+func TestVectorIndexSearcherSearchWithBufferErrorResetsBuffer1961(t *testing.T) {
+	rows := []columnGraphRebuildInputRowV2A{
+		{id: "doc-a", vector: []float32{1, 0, 0}},
+		{id: "doc-b", vector: []float32{0, 1, 0}},
+	}
+	_, d, col, def := openColumnGraphRebuildTestCollectionV2A(t, 3, 1, rows)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	searcher, err := col.OpenVectorIndexSearcher(VectorIndexSearcherOptions{IndexName: def.Name, MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("OpenVectorIndexSearcher: %v", err)
+	}
+	defer func() { _ = searcher.Close() }()
+
+	var buffer VectorIndexSearchBuffer
+	validOpts := VectorIndexSearcherSearchOptions{Query: []float32{1, 0, 0}, TopK: 2, EfSearch: len(rows)}
+	if got, err := searcher.SearchWithBuffer(validOpts, &buffer); err != nil || len(got.Results) != 2 {
+		t.Fatalf("initial SearchWithBuffer results=%d err=%v want 2, nil", len(got.Results), err)
+	}
+
+	got, err := searcher.SearchWithBuffer(VectorIndexSearcherSearchOptions{Query: []float32{1, 0, 0}, TopK: 1, EfSearch: len(rows), IncludeDocuments: true}, &buffer)
+	if err == nil || !strings.Contains(err.Error(), "IncludeDocuments") {
+		t.Fatalf("SearchWithBuffer IncludeDocuments err=%v want documented no-document failure", err)
+	}
+	if len(got.Results) != 0 || len(buffer.results) != 0 || len(buffer.idBytes) != 0 {
+		t.Fatalf("IncludeDocuments error left results: returned=%d bufferResults=%d idBytes=%d", len(got.Results), len(buffer.results), len(buffer.idBytes))
+	}
+	if got.IndexName != def.Name || got.Status.State != VectorIndexStateColumnGraphLoaded {
+		t.Fatalf("error response metadata=%+v status=%+v want loaded search metadata", got, got.Status)
+	}
+
+	got, err = searcher.SearchWithBuffer(VectorIndexSearcherSearchOptions{Query: []float32{1, 0}, TopK: 1, EfSearch: len(rows)}, &buffer)
+	if err == nil || !errors.Is(err, errColumnVectorGraphNativeSearchQueryDimensionMismatch) {
+		t.Fatalf("SearchWithBuffer dimension err=%v want query dimension mismatch", err)
+	}
+	if len(got.Results) != 0 || len(buffer.results) != 0 || len(buffer.idBytes) != 0 {
+		t.Fatalf("dimension error left results: returned=%d bufferResults=%d idBytes=%d", len(got.Results), len(buffer.results), len(buffer.idBytes))
+	}
+
+	got, err = searcher.SearchWithBuffer(validOpts, &buffer)
+	if err != nil {
+		t.Fatalf("valid SearchWithBuffer after errors: %v", err)
+	}
+	assertColumnGraphSearchResponseLoadedV4(t, got, def.Name, 2)
 }
 
 func assertVectorIndexSearchDocumentDIDV4(tb testing.TB, document []byte, want string) {
@@ -1403,6 +1609,10 @@ func BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderV4(b *tes
 	benchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderV4(b, false, DocumentFetchOptions{})
 }
 
+func BenchmarkVectorSearchPublicSearchSerialTypedColumn1961(b *testing.B) {
+	BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderV4(b)
+}
+
 func BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderWithDocumentsV4(b *testing.B) {
 	benchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderV4(b, true, DocumentFetchOptions{})
 }
@@ -1470,8 +1680,69 @@ func benchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderV4(b *tes
 	reportVectorIndexSearchBenchMetricsV4(b, b.N, stats, false)
 }
 
+func BenchmarkVectorSearchReusableBufferSerialTypedColumn1961(b *testing.B) {
+	BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderReusableBufferV4(b)
+}
+
+func BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderReusableBufferV4(b *testing.B) {
+	const (
+		rows     = 1024
+		dims     = 128
+		m        = 16
+		topK     = 10
+		efSearch = 128
+	)
+	input := columnGraphRebuildSyntheticRowsV2A(rows, dims)
+	_, d, col, def := openColumnGraphTypedColumnVectorTestCollection1782(b, dims, m, input)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		b.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	searcher, err := col.OpenVectorIndexSearcher(VectorIndexSearcherOptions{
+		IndexName:        def.Name,
+		MaxDecodedBlocks: 1,
+	})
+	if err != nil {
+		b.Fatalf("OpenVectorIndexSearcher: %v", err)
+	}
+	defer func() { _ = searcher.Close() }()
+	query := append([]float32(nil), input[37].vector...)
+	opts := VectorIndexSearcherSearchOptions{
+		Query:    query,
+		TopK:     topK,
+		EfSearch: efSearch,
+	}
+	var buffer VectorIndexSearchBuffer
+	if _, err := searcher.SearchWithBuffer(opts, &buffer); err != nil {
+		b.Fatalf("warm SearchWithBuffer: %v", err)
+	}
+	measuredStats, err := searcher.SearchWithBuffer(opts, &buffer)
+	if err != nil {
+		b.Fatalf("measure SearchWithBuffer stats: %v", err)
+	}
+	stats := measuredStats.Stats
+	if stats.TypedColumnFallbacks != 0 || stats.VectorMmapDirectViews+stats.VectorHeapCopyTypedViews+stats.VectorScratchDecodes == 0 {
+		b.Fatalf("typed-column reusable-buffer benchmark stats=%+v want active typed-column vector source counters", stats)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		got, err := searcher.SearchWithBuffer(opts, &buffer)
+		if err != nil {
+			b.Fatalf("SearchWithBuffer: %v", err)
+		}
+		vectorSearchBenchSinkOrdinalV4 += got.Results[0].Ordinal
+	}
+	b.StopTimer()
+	reportVectorIndexSearchBenchMetricsV4(b, b.N, stats, false)
+}
+
 func BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderParallelV4(b *testing.B) {
 	benchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderParallelV4(b, false, DocumentFetchOptions{})
+}
+
+func BenchmarkVectorSearchPublicSearchParallelTypedColumn1961(b *testing.B) {
+	BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderParallelV4(b)
 }
 
 func BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderParallelWithDocumentsV4(b *testing.B) {
@@ -1578,6 +1849,117 @@ func benchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderParallelV
 			} else {
 				localSink += int64(got.Results[0].Ordinal)
 			}
+		}
+		sink.Add(localSink)
+	})
+	b.StopTimer()
+	if errValue := firstErr.Load(); errValue != nil {
+		b.Fatalf("%s", errValue.(string))
+	}
+	vectorSearchBenchSinkOrdinalV4 += int(sink.Load())
+	reportVectorIndexSearchBenchMetricsV4(b, b.N, stats, false)
+}
+
+func BenchmarkVectorSearchReusableBufferParallelTypedColumn1961(b *testing.B) {
+	BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderReusableBufferParallelV4(b)
+}
+
+func BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderReusableBufferParallelV4(b *testing.B) {
+	const (
+		rows     = 1024
+		dims     = 128
+		m        = 16
+		topK     = 10
+		efSearch = 128
+	)
+	input := columnGraphRebuildSyntheticRowsV2A(rows, dims)
+	_, d, col, def := openColumnGraphTypedColumnVectorTestCollection1782(b, dims, m, input)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		b.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	workers := runtime.GOMAXPROCS(0)
+	if workers > columnVectorGraphNativeSearchParallelBenchMaxWorkersV3 {
+		workers = columnVectorGraphNativeSearchParallelBenchMaxWorkersV3
+	}
+	if workers < 1 {
+		workers = 1
+	}
+	previousGOMAXPROCS := runtime.GOMAXPROCS(workers)
+	defer runtime.GOMAXPROCS(previousGOMAXPROCS)
+	query := append([]float32(nil), input[37].vector...)
+	opts := VectorIndexSearcherSearchOptions{
+		Query:    query,
+		TopK:     topK,
+		EfSearch: efSearch,
+	}
+	type preparedWorker struct {
+		searcher *VectorIndexSearcher
+		buffer   *VectorIndexSearchBuffer
+	}
+	type paddedBuffer struct {
+		buffer VectorIndexSearchBuffer
+		_      [128]byte
+	}
+	benchWorkers := make([]preparedWorker, workers)
+	buffers := make([]paddedBuffer, workers)
+	for i := range benchWorkers {
+		searcher, err := col.OpenVectorIndexSearcher(VectorIndexSearcherOptions{IndexName: def.Name, MaxDecodedBlocks: 1})
+		if err != nil {
+			b.Fatalf("OpenVectorIndexSearcher worker %d: %v", i, err)
+		}
+		defer func() { _ = searcher.Close() }()
+		buffer := &buffers[i].buffer
+		benchWorkers[i] = preparedWorker{searcher: searcher, buffer: buffer}
+		if _, err := searcher.SearchWithBuffer(opts, buffer); err != nil {
+			b.Fatalf("warm SearchWithBuffer worker %d: %v", i, err)
+		}
+	}
+	measuredStats, err := benchWorkers[0].searcher.SearchWithBuffer(opts, benchWorkers[0].buffer)
+	if err != nil {
+		b.Fatalf("measure SearchWithBuffer stats: %v", err)
+	}
+	stats := measuredStats.Stats
+	if stats.TypedColumnFallbacks != 0 || stats.VectorMmapDirectViews+stats.VectorHeapCopyTypedViews+stats.VectorScratchDecodes == 0 {
+		b.Fatalf("typed-column reusable-buffer parallel benchmark stats=%+v want active typed-column vector source counters", stats)
+	}
+	var nextWorker atomic.Uint64
+	var sink atomic.Int64
+	var firstErr atomic.Value
+	var failed atomic.Bool
+	recordParallelErr := func(format string, args ...any) {
+		if failed.CompareAndSwap(false, true) {
+			firstErr.Store(fmt.Sprintf(format, args...))
+		}
+	}
+	b.SetParallelism(1)
+	b.ReportMetric(float64(workers), "parallel_workers")
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		workerIndex := int(nextWorker.Add(1)) - 1
+		if workerIndex < 0 || workerIndex >= len(benchWorkers) {
+			recordParallelErr("parallel worker requested more than %d prepared searchers", workers)
+			for pb.Next() {
+			}
+			return
+		}
+		worker := &benchWorkers[workerIndex]
+		var localSink int64
+		for pb.Next() {
+			if failed.Load() {
+				continue
+			}
+			got, err := worker.searcher.SearchWithBuffer(opts, worker.buffer)
+			if err != nil {
+				recordParallelErr("SearchWithBuffer: %v", err)
+				continue
+			}
+			if len(got.Results) == 0 {
+				recordParallelErr("SearchWithBuffer returned no results")
+				continue
+			}
+			localSink += int64(got.Results[0].Ordinal)
 		}
 		sink.Add(localSink)
 	})

--- a/TreeDB/docs/guides/vector-search-typed-column.md
+++ b/TreeDB/docs/guides/vector-search-typed-column.md
@@ -181,12 +181,51 @@ Expected interpretation:
   after lifetime, range, checksum/integrity policy, endian/format, length, and
   alignment validation.
 
-## Column graph benchmark matrix
+## Vector search benchmark tiers
 
-For a broader benchmark matrix, use the canonical command from the spec guide:
+Use the tier aliases below when you need a quick serial/parallel matrix with
+clear timing boundaries. All six aliases use the same synthetic shape:
+`rows=1024`, `dims=128`, `M=16`, `topK=10`, and `efSearch=128`. Setup,
+fixture load, graph rebuild, searcher open, and warmup are outside the timed
+loop; each timed operation is one no-document search.
 
 ```sh
-GOWORK=off go test ./TreeDB/collections \
+GOMAXPROCS=8 go test ./TreeDB/collections \
+  -run '^$' \
+  -bench '^BenchmarkVectorSearch(CoreGraphSerialTypedColumn1961|CoreGraphParallelTypedColumn1961|PublicSearchSerialTypedColumn1961|PublicSearchParallelTypedColumn1961|ReusableBufferSerialTypedColumn1961|ReusableBufferParallelTypedColumn1961)$' \
+  -benchmem \
+  -benchtime=2s \
+  -count=5
+```
+
+Report both `ns/op` and `ops/sec`; compute `ops/sec` as `1e9 / ns/op` from the
+Go benchmark output. For parallel benchmarks, this is the aggregate operation
+rate implied by Go's parallel `ns/op` measurement. Always include `B/op`,
+`allocs/op`, and the direct/fallback counters
+(`adjacency_mmap_direct/search`, `adjacency_scratch_decodes/search`,
+`vector_mmap_direct/search`, and `vector_scratch_decodes/search`).
+
+| Tier alias | Canonical benchmark | Boundary |
+| --- | --- | --- |
+| `BenchmarkVectorSearchCoreGraphSerialTypedColumn1961` | `BenchmarkColumnVectorGraphNativeSearchCosineTypedColumnV3` | Core reader `SearchCosine`; graph traversal/scoring/top-k only, no public response materialization. |
+| `BenchmarkVectorSearchCoreGraphParallelTypedColumn1961` | `BenchmarkColumnVectorGraphNativeSearchCosineParallelTypedColumnV3` | Same core boundary with one reader/scratch per worker. |
+| `BenchmarkVectorSearchPublicSearchSerialTypedColumn1961` | `BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderV4` | Existing public `VectorIndexSearcher.Search`; response-owned result and ID buffers; no documents. |
+| `BenchmarkVectorSearchPublicSearchParallelTypedColumn1961` | `BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderParallelV4` | Existing public `Search` with one opened searcher per worker; no documents. |
+| `BenchmarkVectorSearchReusableBufferSerialTypedColumn1961` | `BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderReusableBufferV4` | Public no-document `SearchWithBuffer`; caller-owned reusable result/ID storage. |
+| `BenchmarkVectorSearchReusableBufferParallelTypedColumn1961` | `BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderReusableBufferParallelV4` | Reusable-buffer path with one independent searcher and buffer per worker. |
+
+Use the reusable-buffer tier only for no-document callers that can honor the
+buffer lifetime contract. `VectorIndexSearcher.SearchWithBuffer` rejects
+`IncludeDocuments`; callers that fetch documents should continue using
+`Search`/`SearchVectorIndex` and report the document-fetch counters separately.
+A `VectorIndexSearchBuffer` is not concurrency-safe, and returned `Results`/`ID`
+slices are valid only until the same buffer is reused or reset.
+
+The broader legacy/canonical matrix remains useful when you also need one-shot
+open/setup or document materialization:
+
+```sh
+go test ./TreeDB/collections \
   -run '^$' \
   -bench 'Benchmark(ColumnVectorGraphNativeSearchCosineV3|ColumnVectorGraphNativeSearchCosineParallelV3|OpenVectorIndexSearcherColumnGraphNativeReaderSetupV6|OpenVectorIndexSearcherColumnGraphNativeReaderV4|SearchVectorIndexColumnGraphNativeReaderV4|SearchVectorIndexColumnGraphNativeReaderWithDocumentsV4)$' \
   -benchmem \
@@ -202,11 +241,20 @@ Read the benchmark names before comparing numbers:
 | `ColumnVectorGraphNativeSearchCosine...` | Lower-level graph traversal/scoring/top-k over the physical reader. |
 | `OpenVectorIndexSearcher...V4` | Reusable searcher steady-state query; setup/open outside timed loop. |
 | `SearchVectorIndex...V4` | Public one-shot search; setup/open inside each operation. |
-| `...WithDocuments...` | One-shot search plus post-top-k document materialization. |
+| `...ReusableBuffer...` | Opened public no-document search with caller-owned reusable response buffers. |
+| `...WithDocuments...` | Search plus post-top-k document materialization. |
 
-Report `ns/op`, searches/sec, `B/op`, `allocs/op`, candidates/search,
-edges/search, row fetches, cache hits/misses, decoded blocks, granules touched,
-physical bytes, max resident bytes, and documents fetched.
+Profile public response allocation and the reusable-buffer ceiling separately:
+
+```sh
+OUT=$(mktemp -d /tmp/treedb_vector_search_response_XXXXXX)
+GOMAXPROCS=8 go test ./TreeDB/collections -run '^$' \
+  -bench '^BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderV4$|^BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderReusableBufferV4$' \
+  -benchmem -count=1 -benchtime=5s \
+  -cpuprofile "$OUT/cpu.pprof" -memprofile "$OUT/mem.pprof"
+go tool pprof -top -nodecount=40 "$OUT/cpu.pprof" > "$OUT/cpu_top.txt"
+go tool pprof -top -alloc_space -nodecount=40 "$OUT/mem.pprof" > "$OUT/alloc_space_top.txt"
+```
 
 ## Search/fetch timing boundary
 

--- a/TreeDB/docs/guides/vector-search-typed-column.md
+++ b/TreeDB/docs/guides/vector-search-typed-column.md
@@ -17,7 +17,7 @@ changes.
 | Document title/body/source text | Retained document / residual payload | Usually needed only after top-k; keep flexible. |
 | Filter/sort metadata | `typed_row_asset` or scalar `typed_column_part` depending on query shape | Use typed-row for point reconstruction; use typed-column when filtering/scanning dominates. |
 | Vector graph/ANN data | `derived_accelerator` | It accelerates search but is not the authoritative owner of the embedding field. |
-| Adjacency list | adapter direct/fallback path for explicit offsets-list; dense compatibility remains fallback | Dense fixed-degree `uint32` payload bytes remain compatibility/fallback. `adjacency_layout: "uint32_offsets_list"` selects variable adjacency with certified adapter direct reads; graph/search consumption remains separate follow-up work. |
+| Adjacency list | certified all-layer `column_graph` adjacency direct sources for explicit offsets-list assets; row-asset/dense paths remain fallback | `adjacency_layout: "uint32_offsets_list"` publishes certified variable-adjacency typed-column sources for every graph layer, and the native search reader consumes those direct sources. Row-asset adjacency is a legacy/corruption fallback; dense fixed-degree `uint32` compatibility remains a separate fallback path. |
 
 Best practice: keep vector payloads out of retained JSON for search-heavy
 workloads when the typed-column vector section is the intended search data plane.
@@ -276,7 +276,7 @@ counters.
 | Limitation | Status/link |
 | --- | --- |
 | Native vector graph reads from typed-column dense sections are landed for the current `column_graph` path, but broader vector product tuning remains pre-alpha. | [#1782](https://github.com/snissn/gomap/issues/1782), [column graph native vector search spec](../spec/column-graph-native-vector-search.md). |
-| Authoritative fixed-degree `adjacency_list` typed-column storage is landed for explicit `typed_column_part` owners with positive `adjacency_degree`, but certified adjacency mmap direct views are deferred/fallback-only for this stack. | [#1783](https://github.com/snissn/gomap/issues/1783), [#1901](https://github.com/snissn/gomap/issues/1901) |
+| Certified all-layer `column_graph` adjacency direct sources are published for explicit offsets-list typed-column assets and consumed by native search. Row-asset adjacency remains a legacy/corruption fallback, and dense fixed-degree compatibility remains a separate fallback path. | [#1783](https://github.com/snissn/gomap/issues/1783), [#1901](https://github.com/snissn/gomap/issues/1901), [#1921](https://github.com/snissn/gomap/issues/1921) |
 | SIMD/vectorized dense-section kernels are follow-up optimization work. | [#1790](https://github.com/snissn/gomap/issues/1790) |
 | Row+column COW maintenance uses shared reachability and active mappedresource pin protection for typed assets; vector graph bytes remain derived, not authoritative. | [#1788](https://github.com/snissn/gomap/issues/1788), parent [#1736](https://github.com/snissn/gomap/issues/1736), [maintenance spec](../spec/typed-asset-maintenance-1788.md) |
 | Nullable/missing vector and adjacency typed-column support remains staged/fail-closed. | See typed-column adapter/spec caveats and follow-up roadmap. |
@@ -305,4 +305,4 @@ counters.
 | `docs_fetched` is non-zero in a search-only comparison | You included final document materialization. | Drop `-include-docs` or move document fetch into a separate benchmark row. |
 | Search benchmark allocates heavily | You may be timing setup/open, public document materialization, or fallback decode. | Compare reusable-searcher vs one-shot names and inspect allocation profiles. |
 | Results differ across branches | On-disk formats/APIs are pre-alpha. | Rebuild DB directories and rerun with the same rows/dims/degree/top-k/seed. |
-| Adjacency typed-column ownership is needed | Fixed-degree dense row-major little-endian `uint32` bytes are supported for explicit non-nullable `typed_column_part` owners with positive `adjacency_degree`, but direct-view certification is deferred to #1901. | Configure `adjacency_degree` on the authoritative field; expect decode/fallback paths until #1901 lands. |
+| Adjacency direct-source counters show scratch decodes | The certified all-layer `column_graph` adjacency direct sources are missing, stale, or failed validation, so search fell back to row-asset adjacency or dense compatibility/corruption recovery. | Rebuild or republish the graph so every layer has a certified `uint32_offsets_list` adjacency source; on the direct path expect adjacency mmap/direct counters with `adjacency_scratch_decodes/search=0`. |


### PR DESCRIPTION
## Objective

Add `VectorIndexSearchBuffer` and `VectorIndexSearcher.SearchWithBuffer` for no-document vector search callers that can reuse caller-owned result/ID buffers, eliminating the `2 allocs/op` / `784 B/op` overhead of the existing response-owned `Search` path. Surface clear benchmark tier aliases and update vector search documentation to accurately reflect the current landed adjacency direct-source state.

## Context

The existing `VectorIndexSearcher.Search` allocates a new response-owned result slice and ID byte buffer on every call (`2 allocs/op`, `784 B/op` at `topK=10`, `dims=128`). Steady-state, no-document search callers (e.g. ANN ranking pipelines) can eliminate this allocation by reusing caller-owned buffers across calls. Benchmark tier aliases were missing, making it hard to compare core/public/reusable-buffer tiers consistently. The adjacency direct-source wording in `vector-search-typed-column.md` was also stale and incorrectly described landed functionality as deferred; a doc-only fix at `bc4c82f` corrects this.

## Non-goals

- Does not change `column_graph` adjacency storage or search semantics.
- Does not add document fetch (`IncludeDocuments`) to the reusable-buffer path.
- Does not introduce SIMD/vectorized kernels or change the graph traversal algorithm.

## Design

- **`VectorIndexSearchBuffer`**: caller-owned struct with `results []VectorIndexSearchResult` and `idBytes []byte` fields; `Reset()` is nil-safe and clears length without releasing capacity.
- **`SearchWithBuffer`**: rejects `IncludeDocuments`; calls `buffer.Reset()` unconditionally on entry; aliases `response.Results` to `buffer.results` with documented lifetime (valid until next reuse or `Reset`); uses 3-index slice `buffer.idBytes[idOffset:nextIDOffset:nextIDOffset]` for per-result ID capacity isolation.
- **Oversized-cap shrink**: `resizeVectorIndexSearchResultBuffer` / `resizeVectorIndexSearchByteBuffer` reuse `columnVectorGraphNativeScratchCapOversized` — consistent with the internal search scratch shrink policy.
- **Fail-closed**: nil-buffer check returns error before any buffer access; `IncludeDocuments` is rejected before graph traversal; `buffer.Reset()` is called explicitly on the only post-resize error path (ID accounting mismatch).
- **Parallel callers**: `VectorIndexSearchBuffer` is not concurrency-safe; independent per-worker searcher+buffer pairs are required and demonstrated in the parallel benchmark with `[128]byte`-padded buffer structs to avoid false sharing.

## Scope

- Includes: `TreeDB/collections/vector_index_search.go`, `TreeDB/collections/vector_index_search_test.go`, `TreeDB/collections/column_vector_graph_search_test.go`, `TreeDB/README.md`, `TreeDB/docs/guides/vector-search-typed-column.md`
- Excludes: graph adjacency storage/search, document fetch path, SIMD kernels, graph rebuild

## Correctness

- Tests run:
  ```sh
  go test ./TreeDB/collections -run 'TestVectorIndexSearcherSearchWithBuffer'
  go test -race ./TreeDB/collections -run 'TestVectorIndexSearcherSearchWithBufferParallelIndependentBuffers1961'
  go test ./TreeDB/collections
  go test ./TreeDB/docs
  go test ./...
  ```
  All passed locally. Post-review doc-only fix (`bc4c82f`):
  ```sh
  go test ./TreeDB/docs
  go test ./TreeDB/collections -run 'Test(ColumnVectorGraphAllLayerAdjacency|ColumnGraphRebuildPublishesAllLayerAdjacencySources1920|ColumnGraphAllLayer|VectorIndexSearcherSearchWithBuffer)'
  ```
  Both passed locally.
- Corruption/edge cases covered: grow/shrink/regrow with no stale ID bytes (`TestVectorIndexSearcherSearchWithBufferReuseGrowShrinkNoStaleIDs1961`); `IncludeDocuments` error resets buffer before return; dimension-mismatch error resets buffer; post-error recovery confirms buffer is reusable (`TestVectorIndexSearcherSearchWithBufferErrorResetsBuffer1961`).
- Concurrency/race coverage: `TestVectorIndexSearcherSearchWithBufferParallelIndependentBuffers1961` runs 4 workers × 20 iterations with independent per-worker searcher+buffer pairs under `-race`.

## Performance

- Benchmarks run (hardware: Apple M3, macOS 26.2, 8 CPUs, 16 GiB RAM, `go1.25.5 darwin/arm64`, `GOMAXPROCS=8`):
  ```sh
  GOMAXPROCS=8 go test ./TreeDB/collections -run '^$' \
    -bench '^BenchmarkColumnVectorGraphNativeSearchCosineTypedColumnV3$|^BenchmarkColumnVectorGraphNativeSearchCosineParallelTypedColumnV3$|^BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderV4$|^BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderParallelV4$|^BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderReusableBufferV4$|^BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderReusableBufferParallelV4$' \
    -benchmem -count=3 -benchtime=2s
  ```
  Shape: `rows=1024`, `dims=128`, `M=16`, `topK=10`, `efSearch=128`. Setup/open/warmup outside timed loop; timed op = one no-document search.

- Results table:

  | Benchmark | Boundary | median ns/op | ops/sec | B/op | allocs/op | adj mmap/search | adj scratch/search | vec mmap/search | vec scratch/search |
  | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
  | `BenchmarkColumnVectorGraphNativeSearchCosineTypedColumnV3` | core serial | 9,569 | 104,504 | 0 | 0 | 104 | 0 | 164 | 0 |
  | `BenchmarkColumnVectorGraphNativeSearchCosineParallelTypedColumnV3` | core parallel | 2,272 | 440,141 | 0 | 0 | 104 | 0 | 164 | 0 |
  | `BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderV4` | public Search serial | 10,811 | 92,498 | 784 | 2 | 104 | 0 | 164 | 0 |
  | `BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderParallelV4` | public Search parallel | 2,756 | 362,845 | 784 | 2 | 104 | 0 | 164 | 0 |
  | `BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderReusableBufferV4` | reusable buffer serial | 10,542 | 94,859 | 0 | 0 | 104 | 0 | 164 | 0 |
  | `BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderReusableBufferParallelV4` | reusable buffer parallel | 2,823 | 354,233 | 0 | 0 | 104 | 0 | 164 | 0 |

  Focused parallel rerun (`-count=5 -benchtime=2s`):

  | Benchmark | median ns/op | ops/sec | B/op | allocs/op |
  | --- | ---: | ---: | ---: | ---: |
  | public Search parallel | 3,508 | 285,063 | 784 | 2 |
  | reusable buffer parallel | 3,274 | 305,437 | 0 | 0 |

  Allocation profile: `(*VectorIndexSearcher).Search` at 469.28 MiB flat alloc_space; `SearchWithBuffer` does not appear in top 40 alloc_space nodes. CPU: `runtime.memclrNoHeapPointers` drops from 0.62s flat (public) to 0.06s flat (reusable).

- Regressions: none. Existing `Search` allocation behavior is unchanged (`784 B/op`, `2 allocs/op`). Reusable path achieves `0 B/op`, `0 allocs/op` after warmup.

## Rollout / Toggle Plan

- Default setting: `SearchWithBuffer` is additive; existing `Search`/`SearchVectorIndex` callers are unaffected.
- How to disable quickly: callers choose the API at the call site; no flag or default to revert.

## Follow-ups

- SIMD/vectorized dense-section kernels: [#1790](https://github.com/snissn/gomap/issues/1790)
- Document reconstruction optimization: [#1887](https://github.com/snissn/gomap/issues/1887)

## Column Graph Native Workstream (#1646, if applicable)

### Copied/Adapted From Old Stack

- Copied: n/a
- Adapted: n/a
- Oracle/comparator only: n/a
- Quarantined/not copied: n/a

### Path Identity

- Native reader: `VectorIndexSearcher` → `columnVectorGraphPhysicalRowReader.SearchCosine`
- Decoded comparator: n/a
- Legacy/native vector index: `native_runtime` is fail-closed (existing behavior, not changed)
- Unsupported/fail-closed: `IncludeDocuments` on `SearchWithBuffer` returns error; nil buffer returns error before any buffer access

### Base And Dependency State

- Base branch: `snissn/1961-manager`
- Base commit: `e0c0cdb05aeaa6fcbebb035ebcedd56218babaa4`
- Base PR/head: merged #1959
- #1621/#1634 assumptions: n/a
- Missing generic column-store primitives: none blocking this PR
- Parent review fixes propagated: n/a

### Evidence

- Tests: see Correctness section
- Benchmarks: see Performance section
- Status/fallback proof: `TestSearchVectorIndexColumnGraphUnavailableStatusV4`, `TestSearchVectorIndexColumnGraphReaderOpenFailureDowngradesLoadedStatusV4`
- Performance attribution: allocation wins attributed to eliminating `make([]VectorIndexSearchResult, ...)` and `make([]byte, ...)` per call
- Local regressions found/fixed: none

### Test Plan Start

- Milestone tasks targeted: #1961 acceptance gates (reusable buffer API, correctness tests, race test, benchmark tiers, docs)
- Tests to add before or with implementation: grow/shrink/regrow, mutation isolation, parallel/race, error-reset
- Existing tests to preserve: all existing `vector_index_search_test.go` and `column_vector_graph_search_test.go` tests
- #1646 test-list changes made before implementation: n/a

### Performance Plan Start

- Relevant benchmarks/metrics: `B/op`, `allocs/op`, `memclrNoHeapPointers` CPU time, `alloc_space` profile
- Baseline/comparator command: `GOMAXPROCS=8 go test ./TreeDB/collections -run '^$' -bench '^BenchmarkColumnVectorGraphNativeSearchCosineTypedColumnV3$|...' -benchmem -count=3 -benchtime=2s` at base `e0c0cdb`
- Expected setup/search/materialization boundary: setup/open/warmup outside timed loop; timed op = one no-document search
- Upstream costs explicitly out of scope: graph rebuild, typed-column mmap setup
- Local performance risks to watch: oversized-buffer shrink triggering unnecessary reallocations

### Test Plan Close

- Additional tests found during implementation/review: `TestVectorIndexSearcherSearchWithBufferErrorResetsBuffer1961`
- Tests added or changed: 4 new correctness tests + 2 new benchmark functions + 6 tier alias benchmarks
- Failing tests fixed: none
- #1646 test-list changes made at close: n/a
- Residual untested gaps: none

### Performance Plan Close

- Benchmark commands run: see Performance section
- Results summary: `0 B/op`, `0 allocs/op` on reusable path; `784 B/op`, `2 allocs/op` on public path (unchanged)
- Before/after or baseline comparison: see results tables in Performance section
- Local slow/heavy code found and fixed: none
- Remaining upstream or deferred costs: SIMD kernels (#1790), document reconstruction (#1887)

### Latest-head CI / AI Review Loop

- Latest head: `bc4c82f745749ce88741f7397824ce846f4dea9c`
- Latest-head CI: all GitHub checks passing, including `TreeDB: vet+test`, `Root: vet+test`, `HashDB: vet+test (Windows)`, `Format`, `read-snapshot: guardrails`, `unified_bench` gates, race checks, and perf smoke.
- Codex latest-head review: re-requested after `bc4c82f`; no major issues.
- Copilot latest-head review: clean on implementation commit (`1e95027`) and doc-only fix (`bc4c82f`); no changes requested.
- CodeRabbit latest-head review: completed after `bc4c82f`; no review threads. Generic docstring-coverage warning is not actionable for this Go PR; all new exported API has doc comments.
- Review comments/threads resolved or explicitly dismissed: none open.
- Re-requested after final meaningful push: yes, re-requested after doc-only adjacency wording fix at `bc4c82f`.

---

## Optimization PR Checklist (TreeDB)

### Scope
- [x] Single, clear objective for this PR (not a bundle)
- [x] Explicit include list (files/symbols touched): `vector_index_search.go`, `vector_index_search_test.go`, `column_vector_graph_search_test.go`, `README.md`, `vector-search-typed-column.md`
- [x] Explicit exclude list (files/symbols NOT touched): graph adjacency storage/search, document fetch path, SIMD kernels, graph rebuild
- [x] No unwanted feature reintroduction (e.g. async slab writer, hard zones, ValueIndex) unless explicitly stated in the PR objective

### Safety / Correctness
- [ ] Clear written-vs-durable semantics for any `*Sync` path touched — n/a (no WAL/sync path touched)
- [x] No new mmap usage on mutable/truncating files
- [x] All new length fields are capped before allocation (OOM-safe) — ID byte total pre-computed before allocation; buffer resize uses `columnVectorGraphNativeScratchCapOversized`
- [x] CRC/checksum behavior is fail-closed (clean error, no panic) — n/a for this PR
- [x] Any concurrency change has a defined state machine and invariants — buffer is explicitly not concurrency-safe; documented in godoc; race-tested with independent per-worker pairs

### Tests
- [x] Added deterministic regression tests for the targeted failure mode
- [x] Tests avoid sleeps where possible (use latches/hooks)
- [x] Added corruption/edge-case tests (truncation, bad headers, invalid lengths) when format/parsing changes — n/a (no format change)
- [x] Ran locally:
  - [x] `go test ./... -count=1`
  - [x] Any targeted packages/benchmarks: see Correctness and Performance sections

### Benchmarks / Measurements
- [x] Added or updated a benchmark relevant to the change
- [x] Reported results in PR description (before/after, command, machine)
- [ ] Included "incompressible" (worst-case) results if compression is involved — n/a

### Docs
- [ ] Updated `docs/OPT_SPRINT_NEXT.md` milestone status (if applicable) — n/a
- [x] Documented any new config knobs + defaults — buffer lifetime contract documented in struct/method godoc and `vector-search-typed-column.md`
- [x] Called out any format change in PR description (pre-alpha OK) — no format change

### Rollout / Toggle Plan (if behavior-affecting)
- [x] Safe defaults (feature off or conservative threshold) — additive API; existing callers unaffected
- [x] Clear knobs to disable/revert behavior quickly — callers choose API at call site
- [x] Observability: counters/logs to verify effectiveness — `B/op`/`allocs/op` and vector/adjacency direct-vs-scratch counters reported per search
