### PR TITLE
Draft: intra-query batched vector scoring (#1963)

### DIFF
--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 	"math"
 	"sort"
+	"sync/atomic"
 
 	"github.com/snissn/gomap/TreeDB/internal/typedcolumn"
 	"github.com/snissn/gomap/TreeDB/internal/typeddecode"
+	"github.com/snissn/gomap/TreeDB/internal/vectorops"
 )
 
 // Keep modest scratch overgrowth to avoid realloc churn when callers vary
@@ -18,6 +20,23 @@ const columnVectorGraphNativeScratchOversizeSlack = 16
 // Default TopK values are small; insertion order avoids sort overhead there.
 // Larger result sets switch to sort.Slice so result ordering does not go O(k^2).
 const columnVectorGraphNativeResultOrderInsertionSortLimit = 32
+
+const (
+	columnVectorGraphBatchScoringTileSize = 32
+	columnVectorGraphBatchScoringMinTile  = 16
+)
+
+var columnVectorGraphBatchScoringEnabled atomic.Bool
+
+func columnVectorGraphBatchedScoringEnabled() bool {
+	return columnVectorGraphBatchScoringEnabled.Load()
+}
+
+func setColumnVectorGraphBatchedScoringEnabled(enabled bool) bool {
+	previous := columnVectorGraphBatchScoringEnabled.Load()
+	columnVectorGraphBatchScoringEnabled.Store(enabled)
+	return previous
+}
 
 var (
 	errColumnVectorGraphNativeSearchScratchRequired            = errors.New("collections: column_graph native search requires caller-owned scratch")
@@ -79,6 +98,14 @@ type columnVectorGraphNativeSearchStats struct {
 	ResultFetches                    uint64
 	ScoreBatches                     uint64
 	OrdinalsGrouped                  uint64
+	DotBatchCalls                    uint64
+	DotBatchCandidates               uint64
+	DotBatchTileSizeTotal            uint64
+	DotBatchTileSizeMax              uint64
+	DotBatchOptimizedCalls           uint64
+	DotBatchScalarKernelFallbacks    uint64
+	DotScalarFallbackCalls           uint64
+	DotScalarFallbackCandidates      uint64
 	BlockViewHits                    uint64
 	BlockViewMisses                  uint64
 	BlockViewBuilds                  uint64
@@ -138,6 +165,11 @@ type columnVectorGraphNativeSearchScratch struct {
 	idBuffers      [][]byte
 	resultOrder    []int
 	resultOrdinals []int
+	batchOrdinals  []int
+	batchVectors   [][]float32
+	batchDots      []float32
+	batchScores    []float64
+	batchInvNorms  []float32
 	searchPlan     columnVectorGraphSearchPlan
 }
 
@@ -170,6 +202,15 @@ func (s *columnVectorGraphNativeSearchScratch) prepare(rowCount, dimensions, deg
 	s.idBuffers = resizeColumnVectorGraphNativeIDBuffersScratch(s.idBuffers, topK)
 	s.resultOrder = resizeColumnVectorGraphNativeIntScratch(s.resultOrder, topK)
 	s.resultOrdinals = resizeColumnVectorGraphNativeIntScratch(s.resultOrdinals, topK)
+	tileCap := degree
+	if tileCap < columnVectorGraphBatchScoringTileSize {
+		tileCap = columnVectorGraphBatchScoringTileSize
+	}
+	s.batchOrdinals = resizeColumnVectorGraphNativeIntScratch(s.batchOrdinals, tileCap)
+	s.batchVectors = resizeColumnVectorGraphNativeVectorBatchScratch(s.batchVectors, tileCap)
+	s.batchDots = resizeColumnVectorGraphNativeFloat32Scratch(s.batchDots, tileCap)
+	s.batchScores = resizeColumnVectorGraphNativeFloat64Scratch(s.batchScores, tileCap)
+	s.batchInvNorms = resizeColumnVectorGraphNativeFloat32Scratch(s.batchInvNorms, tileCap)
 	return nil
 }
 
@@ -213,6 +254,30 @@ func resizeColumnVectorGraphNativeResultScratch(dst []columnVectorGraphNativeSea
 func resizeColumnVectorGraphNativeIntScratch(dst []int, target int) []int {
 	if cap(dst) < target || columnVectorGraphNativeScratchCapOversized(cap(dst), target) {
 		return make([]int, 0, target)
+	}
+	return dst[:0]
+}
+
+func resizeColumnVectorGraphNativeFloat32Scratch(dst []float32, target int) []float32 {
+	if cap(dst) < target || columnVectorGraphNativeScratchCapOversized(cap(dst), target) {
+		return make([]float32, 0, target)
+	}
+	return dst[:0]
+}
+
+func resizeColumnVectorGraphNativeFloat64Scratch(dst []float64, target int) []float64 {
+	if cap(dst) < target || columnVectorGraphNativeScratchCapOversized(cap(dst), target) {
+		return make([]float64, 0, target)
+	}
+	return dst[:0]
+}
+
+func resizeColumnVectorGraphNativeVectorBatchScratch(dst [][]float32, target int) [][]float32 {
+	if cap(dst) < target || columnVectorGraphNativeScratchCapOversized(cap(dst), target) {
+		return make([][]float32, 0, target)
+	}
+	if len(dst) > 0 {
+		clear(dst)
 	}
 	return dst[:0]
 }
@@ -339,8 +404,9 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 	if err != nil {
 		return nil, stats, err
 	}
+	batchScoring := columnVectorGraphBatchedScoringEnabled()
 	for layer := maxLayer; layer > 0; layer-- {
-		entryOrdinal, err = r.greedyNearestAtLayer(plan, singleBlockView, query, queryInvNorm, entryOrdinal, layer, candidateRows, hasCandidateRows, scratch, &stats)
+		entryOrdinal, err = r.greedyNearestAtLayer(plan, singleBlockView, query, queryInvNorm, entryOrdinal, layer, candidateRows, hasCandidateRows, batchScoring, scratch, &stats)
 		if err != nil {
 			return nil, stats, err
 		}
@@ -367,6 +433,12 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 		adjacency, err := r.expandCandidateAdjacencyLayer(plan, singleBlockView, candidate.ordinal, 0, scratch, &stats)
 		if err != nil {
 			return nil, stats, err
+		}
+		if batchScoring {
+			if err := r.expandLayer0AdjacencyBatched(plan, singleBlockView, query, queryInvNorm, adjacency, candidate.ordinal, rowCount, efSearch, topK, candidateRows, hasCandidateRows, scratch, &stats); err != nil {
+				return nil, stats, err
+			}
+			continue
 		}
 		for i, neighbor := range adjacency {
 			if stats.Candidates >= uint64(efSearch) {
@@ -459,7 +531,7 @@ func (r *columnVectorGraphPhysicalRowReader) maxAdjacencyLayer(plan *columnVecto
 	return columnVectorGraphAdjacencyMaxLayer(adjacency)
 }
 
-func (r *columnVectorGraphPhysicalRowReader) greedyNearestAtLayer(plan *columnVectorGraphSearchPlan, singleBlockView *columnVectorGraphBlockView, query []float32, queryInvNorm float32, entryOrdinal int, layer int, candidateRows typedcolumn.RowSelection, hasCandidateRows bool, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) (int, error) {
+func (r *columnVectorGraphPhysicalRowReader) greedyNearestAtLayer(plan *columnVectorGraphSearchPlan, singleBlockView *columnVectorGraphBlockView, query []float32, queryInvNorm float32, entryOrdinal int, layer int, candidateRows typedcolumn.RowSelection, hasCandidateRows bool, batchScoring bool, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) (int, error) {
 	best := entryOrdinal
 	bestScore, err := r.scoreOrdinal(plan, singleBlockView, query, queryInvNorm, best, scratch, stats)
 	if err != nil {
@@ -471,6 +543,16 @@ func (r *columnVectorGraphPhysicalRowReader) greedyNearestAtLayer(plan *columnVe
 		adjacency, err := r.expandCandidateAdjacencyLayer(plan, singleBlockView, best, layer, scratch, stats)
 		if err != nil {
 			return 0, err
+		}
+		if batchScoring {
+			nextBest, nextBestScore, layerChanged, err := r.greedyNearestAtLayerAdjacencyBatched(plan, singleBlockView, query, queryInvNorm, best, bestScore, layer, adjacency, candidateRows, hasCandidateRows, scratch, stats)
+			if err != nil {
+				return 0, err
+			}
+			best = nextBest
+			bestScore = nextBestScore
+			changed = layerChanged
+			continue
 		}
 		for i, neighbor := range adjacency {
 			if stats != nil {
@@ -496,6 +578,104 @@ func (r *columnVectorGraphPhysicalRowReader) greedyNearestAtLayer(plan *columnVe
 		}
 	}
 	return best, nil
+}
+
+func (r *columnVectorGraphPhysicalRowReader) greedyNearestAtLayerAdjacencyBatched(plan *columnVectorGraphSearchPlan, singleBlockView *columnVectorGraphBlockView, query []float32, queryInvNorm float32, best int, bestScore float64, layer int, adjacency []uint32, candidateRows typedcolumn.RowSelection, hasCandidateRows bool, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) (int, float64, bool, error) {
+	changed := false
+	ordinals := scratch.batchOrdinals[:0]
+	apply := func(ordinals []int) error {
+		if len(ordinals) == 0 {
+			return nil
+		}
+		scores, err := r.scoreOrdinalBatch(plan, singleBlockView, query, queryInvNorm, ordinals, scratch, stats)
+		if err != nil {
+			return err
+		}
+		for i, neighborOrdinal := range ordinals {
+			score := scores[i]
+			if score > bestScore || (score == bestScore && neighborOrdinal < best) {
+				best = neighborOrdinal
+				bestScore = score
+				changed = true
+			}
+		}
+		return nil
+	}
+	for i, neighbor := range adjacency {
+		if stats != nil {
+			stats.Edges++
+			stats.VisitedEdges++
+		}
+		if uint64(neighbor) >= uint64(r.RowCount()) {
+			return 0, 0, false, fmt.Errorf("collections: column_graph %q ordinal=%d layer=%d adjacency[%d]=%d outside row_count=%d: %w", r.def.Name, best, layer, i, neighbor, r.RowCount(), errColumnVectorGraphAdjacencyOrdinalOutOfBounds)
+		}
+		neighborOrdinal := int(neighbor)
+		if !columnVectorGraphCandidateRowAllowed(candidateRows, hasCandidateRows, neighborOrdinal) {
+			continue
+		}
+		ordinals = append(ordinals, neighborOrdinal)
+		if len(ordinals) >= columnVectorGraphBatchScoringTileSize {
+			if err := apply(ordinals); err != nil {
+				return 0, 0, false, err
+			}
+			ordinals = scratch.batchOrdinals[:0]
+		}
+	}
+	if err := apply(ordinals); err != nil {
+		return 0, 0, false, err
+	}
+	return best, bestScore, changed, nil
+}
+
+func (r *columnVectorGraphPhysicalRowReader) expandLayer0AdjacencyBatched(plan *columnVectorGraphSearchPlan, singleBlockView *columnVectorGraphBlockView, query []float32, queryInvNorm float32, adjacency []uint32, candidateOrdinal int, rowCount int, efSearch int, topK int, candidateRows typedcolumn.RowSelection, hasCandidateRows bool, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) error {
+	ordinals := scratch.batchOrdinals[:0]
+	apply := func(ordinals []int) error {
+		if len(ordinals) == 0 {
+			return nil
+		}
+		scores, err := r.scoreOrdinalBatch(plan, singleBlockView, query, queryInvNorm, ordinals, scratch, stats)
+		if err != nil {
+			return err
+		}
+		for i, ordinal := range ordinals {
+			stats.Candidates++
+			candidate := columnVectorGraphSearchCandidate{ordinal: ordinal, score: scores[i]}
+			scratch.insertTop(topK, candidate)
+			scratch.pushFrontier(candidate)
+		}
+		return nil
+	}
+	for i, neighbor := range adjacency {
+		remaining := uint64(0)
+		if uint64(efSearch) > stats.Candidates {
+			remaining = uint64(efSearch) - stats.Candidates
+		}
+		if remaining == 0 || uint64(len(ordinals)) >= remaining {
+			break
+		}
+		stats.Edges++
+		stats.VisitedEdges++
+		if uint64(neighbor) >= uint64(rowCount) {
+			return fmt.Errorf("collections: column_graph %q ordinal=%d adjacency[%d]=%d outside row_count=%d: %w", r.def.Name, candidateOrdinal, i, neighbor, rowCount, errColumnVectorGraphAdjacencyOrdinalOutOfBounds)
+		}
+		neighborOrdinal := int(neighbor)
+		if scratch.visitMarks[neighborOrdinal] == scratch.visitEpoch {
+			continue
+		}
+		if !columnVectorGraphCandidateRowAllowed(candidateRows, hasCandidateRows, neighborOrdinal) {
+			scratch.visitMarks[neighborOrdinal] = scratch.visitEpoch
+			continue
+		}
+		scratch.visitMarks[neighborOrdinal] = scratch.visitEpoch
+		ordinals = append(ordinals, neighborOrdinal)
+		if len(ordinals) >= columnVectorGraphBatchScoringTileSize {
+			if err := apply(ordinals); err != nil {
+				return err
+			}
+			ordinals = scratch.batchOrdinals[:0]
+		}
+	}
+	return apply(ordinals)
 }
 
 func (r *columnVectorGraphPhysicalRowReader) fetchTopSearchResults(plan *columnVectorGraphSearchPlan, singleBlockView *columnVectorGraphBlockView, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) error {
@@ -579,6 +759,166 @@ func (r *columnVectorGraphPhysicalRowReader) scoreAndPushFrontierVisited(plan *c
 	scratch.insertTop(topK, candidate)
 	scratch.pushFrontier(candidate)
 	return nil
+}
+
+func (r *columnVectorGraphPhysicalRowReader) scoreOrdinalBatch(plan *columnVectorGraphSearchPlan, singleBlockView *columnVectorGraphBlockView, query []float32, queryInvNorm float32, ordinals []int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) ([]float64, error) {
+	if len(ordinals) == 0 {
+		return scratch.batchScores[:0], nil
+	}
+	if len(ordinals) < columnVectorGraphBatchScoringMinTile || r == nil || r.typedVectorSource == nil {
+		return r.scoreOrdinalBatchScalarFallback(plan, singleBlockView, query, queryInvNorm, ordinals, scratch, stats)
+	}
+	n := len(ordinals)
+	if cap(scratch.batchVectors) < n {
+		scratch.batchVectors = make([][]float32, 0, n)
+	}
+	if cap(scratch.batchDots) < n {
+		scratch.batchDots = make([]float32, 0, n)
+	}
+	if cap(scratch.batchScores) < n {
+		scratch.batchScores = make([]float64, 0, n)
+	}
+	if cap(scratch.batchInvNorms) < n {
+		scratch.batchInvNorms = make([]float32, 0, n)
+	}
+	vectors := scratch.batchVectors[:n]
+	invNorms := scratch.batchInvNorms[:n]
+	if singleBlockView != nil {
+		if ok, err := r.prepareScoreOrdinalBatchSingleBlock(query, ordinals, vectors, invNorms, singleBlockView, stats); err != nil {
+			return nil, err
+		} else if !ok {
+			return r.scoreOrdinalBatchScalarFallback(plan, singleBlockView, query, queryInvNorm, ordinals, scratch, stats)
+		}
+	} else {
+		if ok, err := r.prepareScoreOrdinalBatchGeneric(plan, query, ordinals, vectors, invNorms, stats); err != nil {
+			return nil, err
+		} else if !ok {
+			return r.scoreOrdinalBatchScalarFallback(plan, singleBlockView, query, queryInvNorm, ordinals, scratch, stats)
+		}
+	}
+	scratch.batchVectors = vectors
+	scratch.batchInvNorms = invNorms
+	useOptimizedBatch := columnVectorGraphUseOptimizedDotBatch(len(query), n)
+	dots := scratch.batchDots[:n]
+	optimized := false
+	if useOptimizedBatch {
+		optimized = vectorops.DotFloat32Batch(dots, vectors, query)
+	} else {
+		for i := range vectors {
+			dots[i] = vectorDotProductFloat32(query, vectors[i])
+		}
+	}
+	scores := scratch.batchScores[:n]
+	for i, ordinal := range ordinals {
+		dot := float64(dots[i])
+		if math.IsInf(dot, 0) || math.IsNaN(dot) {
+			dot = columnVectorGraphNativeDotProductFloat64(query, vectors[i])
+		}
+		score := dot * float64(queryInvNorm) * float64(invNorms[i])
+		if math.IsNaN(score) || math.IsInf(score, 0) {
+			return nil, fmt.Errorf("collections: column_graph %q candidate ordinal=%d cosine score is not finite", r.def.Name, ordinal)
+		}
+		scores[i] = score
+	}
+	if stats != nil {
+		stats.ScoreBatches++
+		stats.OrdinalsGrouped += uint64(n)
+		stats.VisitedNodes += uint64(n)
+		stats.CandidateFetches += uint64(n)
+		stats.VectorBytesRead += uint64(n*len(query)) * 4
+		if useOptimizedBatch {
+			stats.DotBatchCalls++
+			stats.DotBatchCandidates += uint64(n)
+			stats.DotBatchTileSizeTotal += uint64(n)
+			if uint64(n) > stats.DotBatchTileSizeMax {
+				stats.DotBatchTileSizeMax = uint64(n)
+			}
+			if optimized {
+				stats.DotBatchOptimizedCalls++
+			} else {
+				stats.DotBatchScalarKernelFallbacks++
+			}
+		} else {
+			stats.DotScalarFallbackCalls++
+			stats.DotScalarFallbackCandidates += uint64(n)
+		}
+		stats.BlockViewHits = plan.hits
+		stats.BlockViewMisses = plan.misses
+		stats.BlockViewBuilds = plan.builds
+	}
+	return scores, nil
+}
+
+func columnVectorGraphUseOptimizedDotBatch(dims, candidates int) bool {
+	// The snissn/simd AVX-512 batch kernel computes four dot products per query
+	// vector load. Use it only for full HNSW adjacency tiles so the kernel gain
+	// can amortize TreeDB's gather/apply overhead; smaller groups stay on the
+	// scalar score path.
+	return dims >= 16 && candidates >= columnVectorGraphBatchScoringTileSize && vectorops.DotFloat32BatchOptimized()
+}
+
+func (r *columnVectorGraphPhysicalRowReader) prepareScoreOrdinalBatchSingleBlock(query []float32, ordinals []int, vectors [][]float32, invNorms []float32, view *columnVectorGraphBlockView, stats *columnVectorGraphNativeSearchStats) (bool, error) {
+	source := r.typedVectorSource
+	if source == nil || source.closed || source.dims != len(query) || view == nil {
+		return false, nil
+	}
+	for i, ordinal := range ordinals {
+		if ordinal < 0 || ordinal >= len(source.locations) || ordinal >= len(view.invNorms) {
+			return false, nil
+		}
+		loc := source.locations[ordinal]
+		if loc.part == nil || loc.rowIndex < 0 || loc.rowIndex >= loc.part.rows {
+			return false, nil
+		}
+		start := loc.rowIndex * source.dims
+		end := start + source.dims
+		if start < 0 || end < start || end > len(loc.part.values) {
+			return false, nil
+		}
+		vectors[i] = loc.part.values[start:end]
+		invNorms[i] = view.invNormUnchecked(ordinal)
+		recordColumnVectorGraphVectorSourceStats(stats, loc.part.outcome, loc.part.fallbackReason)
+	}
+	return true, nil
+}
+
+func (r *columnVectorGraphPhysicalRowReader) prepareScoreOrdinalBatchGeneric(plan *columnVectorGraphSearchPlan, query []float32, ordinals []int, vectors [][]float32, invNorms []float32, stats *columnVectorGraphNativeSearchStats) (bool, error) {
+	for i, ordinal := range ordinals {
+		view, ref, err := plan.blockViewForOrdinal(ordinal)
+		if err != nil {
+			return false, err
+		}
+		vector, outcome, fallbackReason, ok := r.typedVectorForOrdinal(ordinal)
+		if !ok {
+			return false, nil
+		}
+		if len(vector) != len(query) {
+			return false, fmt.Errorf("collections: column_graph candidate ordinal=%d vector dims=%d want %d: %w", ordinal, len(vector), len(query), errColumnVectorGraphNativeSearchCandidateDimensionMismatch)
+		}
+		vectors[i] = vector
+		invNorms[i] = view.invNormUnchecked(ref.rowIndex)
+		recordColumnVectorGraphVectorSourceStats(stats, outcome, fallbackReason)
+	}
+	return true, nil
+}
+
+func (r *columnVectorGraphPhysicalRowReader) scoreOrdinalBatchScalarFallback(plan *columnVectorGraphSearchPlan, singleBlockView *columnVectorGraphBlockView, query []float32, queryInvNorm float32, ordinals []int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) ([]float64, error) {
+	if stats != nil {
+		stats.DotScalarFallbackCalls++
+		stats.DotScalarFallbackCandidates += uint64(len(ordinals))
+	}
+	if cap(scratch.batchScores) < len(ordinals) {
+		scratch.batchScores = make([]float64, 0, len(ordinals))
+	}
+	scores := scratch.batchScores[:len(ordinals)]
+	for i, ordinal := range ordinals {
+		score, err := r.scoreOrdinal(plan, singleBlockView, query, queryInvNorm, ordinal, scratch, stats)
+		if err != nil {
+			return nil, err
+		}
+		scores[i] = score
+	}
+	return scores, nil
 }
 
 func (r *columnVectorGraphPhysicalRowReader) scoreOrdinal(plan *columnVectorGraphSearchPlan, singleBlockView *columnVectorGraphBlockView, query []float32, queryInvNorm float32, ordinal int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) (float64, error) {

--- a/TreeDB/collections/column_vector_graph_search_test.go
+++ b/TreeDB/collections/column_vector_graph_search_test.go
@@ -775,6 +775,376 @@ func TestColumnVectorGraphNativeSearchParallelReadersV3(t *testing.T) {
 	}
 }
 
+func setColumnVectorGraphBatchedScoringEnabledForTest(tb testing.TB, enabled bool) {
+	tb.Helper()
+	previous := setColumnVectorGraphBatchedScoringEnabled(enabled)
+	tb.Cleanup(func() { setColumnVectorGraphBatchedScoringEnabled(previous) })
+}
+
+func TestColumnVectorGraphScoreOrdinalBatchSeamParity1963(t *testing.T) {
+	const (
+		rows = 64
+		dims = 128
+		m    = 8
+	)
+	input := columnGraphRebuildSyntheticRowsV2A(rows, dims)
+	_, d, col, def := openColumnGraphTypedColumnVectorTestCollection1782(t, dims, m, input)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	reader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("openColumnVectorGraphPhysicalRowReader: %v", err)
+	}
+	defer func() { _ = reader.Close() }()
+	query := append([]float32(nil), input[7].vector...)
+	queryInvNorm, err := columnVectorGraphInvNorm(query)
+	if err != nil {
+		t.Fatalf("query inv norm: %v", err)
+	}
+	ordinals := make([]int, columnVectorGraphBatchScoringTileSize)
+	for i := range ordinals {
+		ordinals[i] = (i * 7) % rows
+	}
+	var scalarScratch columnVectorGraphNativeSearchScratch
+	if err := scalarScratch.prepare(reader.RowCount(), dims, m, len(ordinals), len(ordinals)); err != nil {
+		t.Fatalf("scalar scratch prepare: %v", err)
+	}
+	scalarPlan, err := scalarScratch.prepareSearchPlan(reader)
+	if err != nil {
+		t.Fatalf("scalar prepareSearchPlan: %v", err)
+	}
+	var scalarStats columnVectorGraphNativeSearchStats
+	want := make([]float64, len(ordinals))
+	for i, ordinal := range ordinals {
+		score, err := reader.scoreOrdinal(scalarPlan, nil, query, queryInvNorm, ordinal, &scalarScratch, &scalarStats)
+		if err != nil {
+			t.Fatalf("scoreOrdinal(%d): %v", ordinal, err)
+		}
+		want[i] = score
+	}
+	var batchScratch columnVectorGraphNativeSearchScratch
+	if err := batchScratch.prepare(reader.RowCount(), dims, len(ordinals), len(ordinals), len(ordinals)); err != nil {
+		t.Fatalf("batch scratch prepare: %v", err)
+	}
+	batchPlan, err := batchScratch.prepareSearchPlan(reader)
+	if err != nil {
+		t.Fatalf("batch prepareSearchPlan: %v", err)
+	}
+	var batchStats columnVectorGraphNativeSearchStats
+	got, err := reader.scoreOrdinalBatch(batchPlan, nil, query, queryInvNorm, ordinals, &batchScratch, &batchStats)
+	if err != nil {
+		t.Fatalf("scoreOrdinalBatch: %v", err)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("batch scores len=%d want %d", len(got), len(want))
+	}
+	for i := range want {
+		if math.Abs(got[i]-want[i]) > 1e-6 {
+			t.Fatalf("score[%d]=%.9f want %.9f", i, got[i], want[i])
+		}
+	}
+	if columnVectorGraphUseOptimizedDotBatch(dims, len(ordinals)) {
+		if batchStats.DotBatchCalls != 1 || batchStats.DotBatchCandidates != uint64(len(ordinals)) || batchStats.DotBatchTileSizeMax != uint64(len(ordinals)) {
+			t.Fatalf("batch stats=%+v want one optimized batch for %d ordinals", batchStats, len(ordinals))
+		}
+	} else if batchStats.DotScalarFallbackCalls != 1 || batchStats.DotScalarFallbackCandidates != uint64(len(ordinals)) {
+		t.Fatalf("batch stats=%+v want one scalar-kernel fallback batch for %d ordinals", batchStats, len(ordinals))
+	}
+	if batchStats.VectorScratchDecodes != 0 {
+		t.Fatalf("batch stats=%+v want typed-column direct path without vector scratch decodes", batchStats)
+	}
+}
+
+func TestColumnVectorGraphScoreOrdinalBatchTinyFallback1963(t *testing.T) {
+	const (
+		rows = 8
+		dims = 16
+		m    = 4
+	)
+	input := columnGraphRebuildSyntheticRowsV2A(rows, dims)
+	_, d, col, def := openColumnGraphTypedColumnVectorTestCollection1782(t, dims, m, input)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	reader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("openColumnVectorGraphPhysicalRowReader: %v", err)
+	}
+	defer func() { _ = reader.Close() }()
+	query := append([]float32(nil), input[3].vector...)
+	queryInvNorm, err := columnVectorGraphInvNorm(query)
+	if err != nil {
+		t.Fatalf("query inv norm: %v", err)
+	}
+	var scratch columnVectorGraphNativeSearchScratch
+	if err := scratch.prepare(reader.RowCount(), dims, m, 1, 1); err != nil {
+		t.Fatalf("scratch prepare: %v", err)
+	}
+	plan, err := scratch.prepareSearchPlan(reader)
+	if err != nil {
+		t.Fatalf("prepareSearchPlan: %v", err)
+	}
+	var stats columnVectorGraphNativeSearchStats
+	scores, err := reader.scoreOrdinalBatch(plan, nil, query, queryInvNorm, []int{2}, &scratch, &stats)
+	if err != nil {
+		t.Fatalf("scoreOrdinalBatch tiny: %v", err)
+	}
+	if len(scores) != 1 {
+		t.Fatalf("scores len=%d want 1", len(scores))
+	}
+	if stats.DotBatchCalls != 0 || stats.DotScalarFallbackCalls != 1 || stats.DotScalarFallbackCandidates != 1 || stats.ScoreBatches != 1 {
+		t.Fatalf("tiny fallback stats=%+v want scalar fallback without dot batch", stats)
+	}
+}
+
+func TestColumnVectorGraphNativeSearchCosineBatchedScoringParity1963(t *testing.T) {
+	const (
+		rows     = 192
+		dims     = 64
+		m        = 12
+		topK     = 10
+		efSearch = 96
+	)
+	input := columnGraphRebuildSyntheticRowsV2A(rows, dims)
+	_, d, col, def := openColumnGraphTypedColumnVectorTestCollection1782(t, dims, m, input)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	reader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("openColumnVectorGraphPhysicalRowReader scalar: %v", err)
+	}
+	defer func() { _ = reader.Close() }()
+	query := append([]float32(nil), input[37].vector...)
+	opts := columnVectorGraphNativeSearchOptions{TopK: topK, EfSearch: efSearch}
+	setColumnVectorGraphBatchedScoringEnabledForTest(t, false)
+	var scalarScratch columnVectorGraphNativeSearchScratch
+	scalarResults, scalarStats, err := reader.SearchCosine(query, opts, &scalarScratch)
+	if err != nil {
+		t.Fatalf("scalar SearchCosine: %v", err)
+	}
+	setColumnVectorGraphBatchedScoringEnabled(true)
+	var batchScratch columnVectorGraphNativeSearchScratch
+	batchResults, batchStats, err := reader.SearchCosine(query, opts, &batchScratch)
+	if err != nil {
+		t.Fatalf("batched SearchCosine: %v", err)
+	}
+	assertColumnGraphNativeSearchResultsV3(t, batchResults, scalarResults)
+	if batchStats.Candidates != scalarStats.Candidates || batchStats.CandidateFetches != scalarStats.CandidateFetches || batchStats.VisitedEdges != scalarStats.VisitedEdges || batchStats.Edges != scalarStats.Edges {
+		t.Fatalf("scalar stats=%+v batch stats=%+v want matching graph/candidate counts", scalarStats, batchStats)
+	}
+	if batchStats.DotBatchCandidates+batchStats.DotScalarFallbackCandidates == 0 {
+		t.Fatalf("batch stats=%+v want batch seam dot or scalar-fallback counters", batchStats)
+	}
+	if scalarStats.DotBatchCalls != 0 || scalarStats.DotBatchCandidates != 0 {
+		t.Fatalf("scalar stats=%+v want no dot batch counters", scalarStats)
+	}
+	if batchStats.AdjacencyScratchDecodes != 0 || batchStats.VectorScratchDecodes != 0 || scalarStats.AdjacencyScratchDecodes != 0 || scalarStats.VectorScratchDecodes != 0 {
+		t.Fatalf("scalar stats=%+v batch stats=%+v want healthy typed-column direct path scratch decodes at zero", scalarStats, batchStats)
+	}
+}
+
+func TestColumnVectorGraphNativeSearchBatchedScoringParallelScratch1963(t *testing.T) {
+	setColumnVectorGraphBatchedScoringEnabledForTest(t, true)
+	const (
+		rows     = 96
+		dims     = 32
+		m        = 8
+		topK     = 8
+		efSearch = 48
+	)
+	input := columnGraphRebuildSyntheticRowsV2A(rows, dims)
+	_, d, col, def := openColumnGraphTypedColumnVectorTestCollection1782(t, dims, m, input)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	query := append([]float32(nil), input[11].vector...)
+	baselineReader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("open baseline reader: %v", err)
+	}
+	defer func() { _ = baselineReader.Close() }()
+	want, _, err := baselineReader.SearchCosine(query, columnVectorGraphNativeSearchOptions{TopK: topK, EfSearch: efSearch}, &columnVectorGraphNativeSearchScratch{})
+	if err != nil {
+		t.Fatalf("baseline SearchCosine: %v", err)
+	}
+	workers := 4
+	readers := make([]*columnVectorGraphPhysicalRowReader, workers)
+	for i := range readers {
+		reader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
+		if err != nil {
+			t.Fatalf("open reader %d: %v", i, err)
+		}
+		defer func() { _ = reader.Close() }()
+		readers[i] = reader
+	}
+	var wg sync.WaitGroup
+	errs := make(chan string, workers)
+	for worker := range readers {
+		worker := worker
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			var scratch columnVectorGraphNativeSearchScratch
+			for i := 0; i < 20; i++ {
+				got, stats, err := readers[worker].SearchCosine(query, columnVectorGraphNativeSearchOptions{TopK: topK, EfSearch: efSearch}, &scratch)
+				if err != nil {
+					errs <- fmt.Sprintf("worker %d SearchCosine: %v", worker, err)
+					return
+				}
+				if mismatch := columnGraphNativeSearchResultsMismatchV3(got, want); mismatch != "" {
+					errs <- fmt.Sprintf("worker %d iteration %d: %s", worker, i, mismatch)
+					return
+				}
+				if stats.DotBatchCandidates+stats.DotScalarFallbackCandidates == 0 {
+					errs <- fmt.Sprintf("worker %d iteration %d stats=%+v want batch seam counters", worker, i, stats)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Error(err)
+	}
+}
+
+func withColumnVectorGraphBatchedScoringForBenchmark(b *testing.B, enabled bool) {
+	b.Helper()
+	previous := setColumnVectorGraphBatchedScoringEnabled(enabled)
+	b.Cleanup(func() { setColumnVectorGraphBatchedScoringEnabled(previous) })
+}
+
+func BenchmarkColumnVectorGraphScoreOrdinalTile1963(b *testing.B) {
+	const (
+		rows = 1024
+		dims = 128
+		m    = 32
+	)
+	input := columnGraphRebuildSyntheticRowsV2A(rows, dims)
+	_, d, col, def := openColumnGraphTypedColumnVectorTestCollection1782(b, dims, m, input)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		b.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	reader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
+	if err != nil {
+		b.Fatalf("openColumnVectorGraphPhysicalRowReader: %v", err)
+	}
+	defer func() { _ = reader.Close() }()
+	query := append([]float32(nil), input[37].vector...)
+	queryInvNorm, err := columnVectorGraphInvNorm(query)
+	if err != nil {
+		b.Fatalf("query inv norm: %v", err)
+	}
+	tiles := []int{1, 2, 4, 8, 16, 32, 13}
+	layouts := []struct {
+		name    string
+		ordinal func(i int) int
+	}{
+		{name: "contiguous", ordinal: func(i int) int { return 128 + i }},
+		{name: "scattered", ordinal: func(i int) int { return (17 + i*37) % rows }},
+	}
+	for _, layout := range layouts {
+		layout := layout
+		for _, tile := range tiles {
+			tile := tile
+			ordinals := make([]int, tile)
+			for i := range ordinals {
+				ordinals[i] = layout.ordinal(i)
+			}
+			name := fmt.Sprintf("%s/tile_%d", layout.name, tile)
+			b.Run(name+"/scalar", func(b *testing.B) {
+				var scratch columnVectorGraphNativeSearchScratch
+				if err := scratch.prepare(reader.RowCount(), dims, max(m, tile), tile, tile); err != nil {
+					b.Fatalf("scratch prepare: %v", err)
+				}
+				plan, err := scratch.prepareSearchPlan(reader)
+				if err != nil {
+					b.Fatalf("prepareSearchPlan: %v", err)
+				}
+				var stats columnVectorGraphNativeSearchStats
+				for _, ordinal := range ordinals {
+					if _, err := reader.scoreOrdinal(plan, nil, query, queryInvNorm, ordinal, &scratch, &stats); err != nil {
+						b.Fatalf("warm scoreOrdinal: %v", err)
+					}
+				}
+				b.ReportAllocs()
+				b.ResetTimer()
+				var sum float64
+				for i := 0; i < b.N; i++ {
+					for _, ordinal := range ordinals {
+						score, err := reader.scoreOrdinal(plan, nil, query, queryInvNorm, ordinal, &scratch, &stats)
+						if err != nil {
+							b.Fatalf("scoreOrdinal: %v", err)
+						}
+						sum += score
+					}
+				}
+				columnPhysicalScanBenchSum += int64(sum)
+			})
+			b.Run(name+"/batch", func(b *testing.B) {
+				var scratch columnVectorGraphNativeSearchScratch
+				if err := scratch.prepare(reader.RowCount(), dims, max(m, tile), tile, tile); err != nil {
+					b.Fatalf("scratch prepare: %v", err)
+				}
+				plan, err := scratch.prepareSearchPlan(reader)
+				if err != nil {
+					b.Fatalf("prepareSearchPlan: %v", err)
+				}
+				var stats columnVectorGraphNativeSearchStats
+				if _, err := reader.scoreOrdinalBatch(plan, nil, query, queryInvNorm, ordinals, &scratch, &stats); err != nil {
+					b.Fatalf("warm scoreOrdinalBatch: %v", err)
+				}
+				b.ReportMetric(float64(tile), "tile")
+				b.ReportAllocs()
+				b.ResetTimer()
+				var sum float64
+				for i := 0; i < b.N; i++ {
+					scores, err := reader.scoreOrdinalBatch(plan, nil, query, queryInvNorm, ordinals, &scratch, &stats)
+					if err != nil {
+						b.Fatalf("scoreOrdinalBatch: %v", err)
+					}
+					for _, score := range scores {
+						sum += score
+					}
+				}
+				b.StopTimer()
+				columnPhysicalScanBenchSum += int64(sum)
+				if stats.DotBatchCalls > 0 {
+					b.ReportMetric(float64(stats.DotBatchCandidates)/float64(stats.DotBatchCalls), "dot_batch_avg_candidates")
+				}
+				b.ReportMetric(float64(stats.DotBatchCalls)/float64(b.N+1), "dot_batch_calls/op")
+				b.ReportMetric(float64(stats.DotScalarFallbackCalls)/float64(b.N+1), "dot_scalar_fallback_calls/op")
+			})
+		}
+	}
+}
+
+func BenchmarkColumnVectorGraphNativeSearchCosineBatchedScoring1963(b *testing.B) {
+	for _, tc := range []struct {
+		name    string
+		batched bool
+	}{
+		{name: "scalar", batched: false},
+		{name: "batched", batched: true},
+	} {
+		tc := tc
+		b.Run(tc.name, func(b *testing.B) {
+			withColumnVectorGraphBatchedScoringForBenchmark(b, tc.batched)
+			shape := columnVectorGraphNativeSearchSmallBenchShapeV3()
+			shape.typedColumnVector = true
+			benchmarkColumnVectorGraphNativeSearchCosineV3(b, shape)
+		})
+	}
+}
+
 func BenchmarkColumnVectorGraphNativeSearchCosineV3(b *testing.B) {
 	benchmarkColumnVectorGraphNativeSearchCosineV3(b, columnVectorGraphNativeSearchSmallBenchShapeV3())
 }
@@ -853,6 +1223,16 @@ func benchmarkColumnVectorGraphNativeSearchCosineV3(b *testing.B, shape columnVe
 		searchStats.ResultFetches += stats.ResultFetches
 		searchStats.ScoreBatches += stats.ScoreBatches
 		searchStats.OrdinalsGrouped += stats.OrdinalsGrouped
+		searchStats.DotBatchCalls += stats.DotBatchCalls
+		searchStats.DotBatchCandidates += stats.DotBatchCandidates
+		searchStats.DotBatchTileSizeTotal += stats.DotBatchTileSizeTotal
+		if stats.DotBatchTileSizeMax > searchStats.DotBatchTileSizeMax {
+			searchStats.DotBatchTileSizeMax = stats.DotBatchTileSizeMax
+		}
+		searchStats.DotBatchOptimizedCalls += stats.DotBatchOptimizedCalls
+		searchStats.DotBatchScalarKernelFallbacks += stats.DotBatchScalarKernelFallbacks
+		searchStats.DotScalarFallbackCalls += stats.DotScalarFallbackCalls
+		searchStats.DotScalarFallbackCandidates += stats.DotScalarFallbackCandidates
 		searchStats.BlockViewHits += stats.BlockViewHits
 		searchStats.BlockViewMisses += stats.BlockViewMisses
 		searchStats.BlockViewBuilds += stats.BlockViewBuilds
@@ -1412,6 +1792,17 @@ func reportColumnGraphNativeSearchBenchMetricsV3(b *testing.B, n int, baseStats,
 	b.ReportMetric(float64(searchStats.CandidateFetches)/float64(n), "candidate_fetches/search")
 	b.ReportMetric(float64(searchStats.ScoreBatches)/float64(n), "score_batches/search")
 	b.ReportMetric(float64(searchStats.OrdinalsGrouped)/float64(n), "ordinals_grouped/search")
+	b.ReportMetric(float64(searchStats.DotBatchCalls)/float64(n), "dot_batch_calls/search")
+	b.ReportMetric(float64(searchStats.DotBatchCandidates)/float64(n), "dot_batch_candidates/search")
+	if searchStats.DotBatchCalls > 0 {
+		b.ReportMetric(float64(searchStats.DotBatchCandidates)/float64(searchStats.DotBatchCalls), "dot_batch_avg_candidates")
+	}
+	b.ReportMetric(float64(searchStats.DotBatchTileSizeTotal)/float64(n), "dot_batch_tile_candidates/search")
+	b.ReportMetric(float64(searchStats.DotBatchTileSizeMax), "dot_batch_tile_max")
+	b.ReportMetric(float64(searchStats.DotBatchOptimizedCalls)/float64(n), "dot_batch_optimized_calls/search")
+	b.ReportMetric(float64(searchStats.DotBatchScalarKernelFallbacks)/float64(n), "dot_batch_scalar_kernel_fallbacks/search")
+	b.ReportMetric(float64(searchStats.DotScalarFallbackCalls)/float64(n), "dot_scalar_fallback_calls/search")
+	b.ReportMetric(float64(searchStats.DotScalarFallbackCandidates)/float64(n), "dot_scalar_fallback_candidates/search")
 	b.ReportMetric(float64(searchStats.BlockViewHits)/float64(n), "block_view_hits/search")
 	b.ReportMetric(float64(searchStats.BlockViewMisses)/float64(n), "block_view_misses/search")
 	b.ReportMetric(float64(searchStats.BlockViewBuilds)/float64(n), "block_view_builds/search")

--- a/TreeDB/collections/vector_index_search.go
+++ b/TreeDB/collections/vector_index_search.go
@@ -89,6 +89,24 @@ type VectorIndexSearchStats struct {
 	ExpansionFetches uint64 `json:"expansion_fetches,omitempty"`
 	// ResultFetches is the per-search count of vector row fetches for final results.
 	ResultFetches uint64 `json:"result_fetches,omitempty"`
+	// DotBatchCalls counts within-query vector dot batch calls.
+	DotBatchCalls uint64 `json:"dot_batch_calls,omitempty"`
+	// DotBatchCandidates counts candidate vectors scored through dot batch calls.
+	DotBatchCandidates uint64 `json:"dot_batch_candidates,omitempty"`
+	// DotBatchAverageCandidates is DotBatchCandidates/DotBatchCalls rounded down.
+	DotBatchAverageCandidates uint64 `json:"dot_batch_avg_candidates,omitempty"`
+	// DotBatchTileSizeTotal sums the tile sizes passed to dot batch calls.
+	DotBatchTileSizeTotal uint64 `json:"dot_batch_tile_size_total,omitempty"`
+	// DotBatchTileSizeMax is the largest within-query dot batch tile size.
+	DotBatchTileSizeMax uint64 `json:"dot_batch_tile_size_max,omitempty"`
+	// DotBatchOptimizedCalls counts dot batch calls handled by an optimized kernel.
+	DotBatchOptimizedCalls uint64 `json:"dot_batch_optimized_calls,omitempty"`
+	// DotBatchScalarKernelFallbacks counts dot batch calls handled by the scalar batch fallback kernel.
+	DotBatchScalarKernelFallbacks uint64 `json:"dot_batch_scalar_kernel_fallbacks,omitempty"`
+	// DotScalarFallbackCalls counts batch-seam calls that fell back to scalar scoreOrdinal.
+	DotScalarFallbackCalls uint64 `json:"dot_scalar_fallback_calls,omitempty"`
+	// DotScalarFallbackCandidates counts candidates scored by scalar scoreOrdinal after a batch-seam fallback.
+	DotScalarFallbackCandidates uint64 `json:"dot_scalar_fallback_candidates,omitempty"`
 	// DocumentsFetched is the post-top-k document materialization count.
 	DocumentsFetched uint64 `json:"documents_fetched,omitempty"`
 	// DocumentsMissing is the post-top-k materialization miss count.
@@ -786,6 +804,13 @@ func deltaInt64(before, after int64) int64 {
 	return after - before
 }
 
+func columnVectorGraphDotBatchAverageCandidates(candidates, calls uint64) uint64 {
+	if calls == 0 {
+		return 0
+	}
+	return candidates / calls
+}
+
 func vectorIndexSearchStatsFromInternal(searchStats columnVectorGraphNativeSearchStats, readerStats columnPhysicalRowReaderStats) VectorIndexSearchStats {
 	return VectorIndexSearchStats{
 		CandidateRows:                    searchStats.CandidateRows,
@@ -798,6 +823,15 @@ func vectorIndexSearchStatsFromInternal(searchStats columnVectorGraphNativeSearc
 		CandidateFetches:                 searchStats.CandidateFetches,
 		ExpansionFetches:                 searchStats.ExpansionFetches,
 		ResultFetches:                    searchStats.ResultFetches,
+		DotBatchCalls:                    searchStats.DotBatchCalls,
+		DotBatchCandidates:               searchStats.DotBatchCandidates,
+		DotBatchAverageCandidates:        columnVectorGraphDotBatchAverageCandidates(searchStats.DotBatchCandidates, searchStats.DotBatchCalls),
+		DotBatchTileSizeTotal:            searchStats.DotBatchTileSizeTotal,
+		DotBatchTileSizeMax:              searchStats.DotBatchTileSizeMax,
+		DotBatchOptimizedCalls:           searchStats.DotBatchOptimizedCalls,
+		DotBatchScalarKernelFallbacks:    searchStats.DotBatchScalarKernelFallbacks,
+		DotScalarFallbackCalls:           searchStats.DotScalarFallbackCalls,
+		DotScalarFallbackCandidates:      searchStats.DotScalarFallbackCandidates,
 		RowFetches:                       readerStats.RowFetches,
 		BatchFetches:                     readerStats.BatchFetches,
 		RowsFetched:                      readerStats.RowsFetched,

--- a/TreeDB/collections/vector_index_search_test.go
+++ b/TreeDB/collections/vector_index_search_test.go
@@ -1684,6 +1684,22 @@ func BenchmarkVectorSearchReusableBufferSerialTypedColumn1961(b *testing.B) {
 	BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderReusableBufferV4(b)
 }
 
+func BenchmarkVectorSearchReusableBufferSerialTypedColumnBatchedScoring1963(b *testing.B) {
+	for _, tc := range []struct {
+		name    string
+		batched bool
+	}{
+		{name: "scalar", batched: false},
+		{name: "batched", batched: true},
+	} {
+		tc := tc
+		b.Run(tc.name, func(b *testing.B) {
+			withColumnVectorGraphBatchedScoringForBenchmark(b, tc.batched)
+			BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderReusableBufferV4(b)
+		})
+	}
+}
+
 func BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderReusableBufferV4(b *testing.B) {
 	const (
 		rows     = 1024
@@ -2039,6 +2055,15 @@ func reportVectorIndexSearchBenchMetricsV4(b *testing.B, n int, stats VectorInde
 	b.ReportMetric(float64(stats.CandidateFetches), "candidate_fetches/search")
 	b.ReportMetric(float64(stats.ExpansionFetches), "expansion_fetches/search")
 	b.ReportMetric(float64(stats.ResultFetches), "result_fetches/search")
+	b.ReportMetric(float64(stats.DotBatchCalls), "dot_batch_calls/search")
+	b.ReportMetric(float64(stats.DotBatchCandidates), "dot_batch_candidates/search")
+	b.ReportMetric(float64(stats.DotBatchAverageCandidates), "dot_batch_avg_candidates")
+	b.ReportMetric(float64(stats.DotBatchTileSizeTotal), "dot_batch_tile_candidates/search")
+	b.ReportMetric(float64(stats.DotBatchTileSizeMax), "dot_batch_tile_max")
+	b.ReportMetric(float64(stats.DotBatchOptimizedCalls), "dot_batch_optimized_calls/search")
+	b.ReportMetric(float64(stats.DotBatchScalarKernelFallbacks), "dot_batch_scalar_kernel_fallbacks/search")
+	b.ReportMetric(float64(stats.DotScalarFallbackCalls), "dot_scalar_fallback_calls/search")
+	b.ReportMetric(float64(stats.DotScalarFallbackCandidates), "dot_scalar_fallback_candidates/search")
 	b.ReportMetric(float64(stats.VectorDirectViews), "vector_direct_views/search")
 	b.ReportMetric(float64(stats.VectorMmapDirectViews), "vector_mmap_direct/search")
 	b.ReportMetric(float64(stats.VectorHeapCopyTypedViews), "vector_heap_copy_typed_view/search")

--- a/TreeDB/internal/vectorops/dot_batch_amd64.go
+++ b/TreeDB/internal/vectorops/dot_batch_amd64.go
@@ -1,0 +1,37 @@
+//go:build amd64 && !purego
+
+package vectorops
+
+import (
+	simdcpu "github.com/tphakala/simd/cpu"
+	simdf32 "github.com/tphakala/simd/f32"
+)
+
+const dotFloat32BatchImplementation = "simd_tphakala_f32_batch"
+
+// DotFloat32Batch computes one dot product for each row against vec and stores
+// the results in dst. It processes min(len(dst), len(rows)) rows and returns
+// true when the optimized batch kernel handled the work.
+func DotFloat32Batch(dst []float32, rows [][]float32, vec []float32) bool {
+	n := len(dst)
+	if len(rows) < n {
+		n = len(rows)
+	}
+	if n == 0 {
+		return true
+	}
+	if len(vec) == 0 {
+		clear(dst[:n])
+		return true
+	}
+	optimized := DotFloat32BatchOptimized() && n >= 4 && len(vec) >= 16
+	simdf32.DotProductBatch(dst[:n], rows[:n], vec)
+	return optimized
+}
+
+// DotFloat32BatchOptimized reports whether DotFloat32Batch is backed by a
+// platform batch kernel instead of the portable scalar fallback.
+func DotFloat32BatchOptimized() bool { return simdcpu.X86.AVX512F && simdcpu.X86.AVX512VL }
+
+// DotFloat32BatchImplementation identifies the active batch implementation.
+func DotFloat32BatchImplementation() string { return dotFloat32BatchImplementation }

--- a/TreeDB/internal/vectorops/dot_batch_fallback.go
+++ b/TreeDB/internal/vectorops/dot_batch_fallback.go
@@ -1,0 +1,27 @@
+//go:build purego || !amd64
+
+package vectorops
+
+const dotFloat32BatchImplementation = "scalar_batch_fallback"
+
+// DotFloat32Batch computes one dot product for each row against vec and stores
+// the results in dst. It processes min(len(dst), len(rows)) rows. On platforms
+// without an optimized batch kernel it uses the portable scalar dot product and
+// returns false.
+func DotFloat32Batch(dst []float32, rows [][]float32, vec []float32) bool {
+	n := len(dst)
+	if len(rows) < n {
+		n = len(rows)
+	}
+	for i := 0; i < n; i++ {
+		dst[i] = DotFloat32Scalar(rows[i], vec)
+	}
+	return false
+}
+
+// DotFloat32BatchOptimized reports whether DotFloat32Batch is backed by a
+// platform batch kernel instead of the portable scalar fallback.
+func DotFloat32BatchOptimized() bool { return false }
+
+// DotFloat32BatchImplementation identifies the active batch implementation.
+func DotFloat32BatchImplementation() string { return dotFloat32BatchImplementation }

--- a/TreeDB/internal/vectorops/dot_test.go
+++ b/TreeDB/internal/vectorops/dot_test.go
@@ -74,15 +74,46 @@ func TestDotFloat32SpecialValues1790(t *testing.T) {
 	}
 }
 
+func TestDotFloat32BatchParityWithScalar1963(t *testing.T) {
+	for _, dims := range []int{0, 1, 2, 3, 4, 7, 8, 13, 16, 31, 32, 63, 64, 127, 128, 129} {
+		for _, rowsN := range []int{0, 1, 2, 4, 8, 13, 16, 32} {
+			t.Run(fmt.Sprintf("dims_%d/rows_%d", dims, rowsN), func(t *testing.T) {
+				vec := dotTestVector1790(dims, 3)
+				rows := make([][]float32, rowsN)
+				for i := range rows {
+					rows[i] = dotTestVector1790(dims, i+5)
+				}
+				got := make([]float32, rowsN)
+				DotFloat32Batch(got, rows, vec)
+				for i := range rows {
+					want := DotFloat32Scalar(rows[i], vec)
+					if math.Abs(float64(got[i]-want)) > 1e-4 {
+						t.Fatalf("DotFloat32Batch[%d]=%v want scalar=%v implementation=%s", i, got[i], want, DotFloat32BatchImplementation())
+					}
+				}
+			})
+		}
+	}
+}
+
 func TestDotFloat32ZeroAllocs1790(t *testing.T) {
 	left := dotTestVector1790(257, 3)
 	right := dotTestVector1790(257, 5)
+	rows := [][]float32{left, dotTestVector1790(257, 7), dotTestVector1790(257, 9), right}
+	batchResults := make([]float32, len(rows))
 	var sink float32
 	allocsOptimized := testing.AllocsPerRun(1000, func() {
 		sink += DotFloat32(left, right)
 	})
 	if allocsOptimized != 0 {
 		t.Fatalf("DotFloat32 allocs/run=%v want 0", allocsOptimized)
+	}
+	allocsBatch := testing.AllocsPerRun(1000, func() {
+		DotFloat32Batch(batchResults, rows, right)
+		sink += batchResults[0]
+	})
+	if allocsBatch != 0 {
+		t.Fatalf("DotFloat32Batch allocs/run=%v want 0 implementation=%s", allocsBatch, DotFloat32BatchImplementation())
 	}
 	allocsScalar := testing.AllocsPerRun(1000, func() {
 		sink += DotFloat32Scalar(left, right)

--- a/go.mod
+++ b/go.mod
@@ -99,3 +99,5 @@ require (
 	google.golang.org/protobuf v1.36.6 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/tphakala/simd => github.com/snissn/simd v0.0.0-20260523073437-a4847ce2ce89

--- a/go.sum
+++ b/go.sum
@@ -159,6 +159,8 @@ github.com/snissn/compress v1.18.2-snissn.0.0.20260506201017-87fb149e4721 h1:2XY
 github.com/snissn/compress v1.18.2-snissn.0.0.20260506201017-87fb149e4721/go.mod h1:p4xiZN07JMUF5xuybNGkG+pozT12MAblxCx36z+PIYM=
 github.com/snissn/go-crc32-asm v0.0.0-20260522204125-08945951423a h1:uqSq50AAT36ZzDiRApq8GNsbeJASPaneZ6aKfw3KShc=
 github.com/snissn/go-crc32-asm v0.0.0-20260522204125-08945951423a/go.mod h1:PDwKLbWpRDAN2IPbK9PxIgSx0YdwQaSOLWObRawQJ58=
+github.com/snissn/simd v0.0.0-20260523073437-a4847ce2ce89 h1:JC6ua13UmE+uaf7MKurSdM4SjKKwF7+Mvsly3JCB1Po=
+github.com/snissn/simd v0.0.0-20260523073437-a4847ce2ce89/go.mod h1:8xsPUbOTnNI4WUdPlXVlWXt85Y8RCm3xqGAo8PLxYyA=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 h1:epCh84lMvA70Z7CTTCmYQn2CKbY8j86K7/FAIr141uY=
@@ -187,8 +189,6 @@ github.com/tidwall/rtred v0.1.2 h1:exmoQtOLvDoO8ud++6LwVsAMTu0KPzLTUrMln8u1yu8=
 github.com/tidwall/rtred v0.1.2/go.mod h1:hd69WNXQ5RP9vHd7dqekAz+RIdtfBogmglkZSRxCHFQ=
 github.com/tidwall/tinyqueue v0.1.1 h1:SpNEvEggbpyN5DIReaJ2/1ndroY8iyEGxPYxoSaymYE=
 github.com/tidwall/tinyqueue v0.1.1/go.mod h1:O/QNHwrnjqr6IHItYrzoHAKYhBkLI67Q096fQP5zMYw=
-github.com/tphakala/simd v1.0.22 h1:3wHL91t4yvhCB0ycyTznvucTHax+QGpYkvOhqfraTYw=
-github.com/tphakala/simd v1.0.22/go.mod h1:8xsPUbOTnNI4WUdPlXVlWXt85Y8RCm3xqGAo8PLxYyA=
 github.com/unum-cloud/usearch/golang v0.0.0-20260502205332-29e527731957 h1:IloOsa7abfb6f3i6TQvSh3ayA3LmN0GQNPk+aVwUIrQ=
 github.com/unum-cloud/usearch/golang v0.0.0-20260502205332-29e527731957/go.mod h1:UbKHPUIhYNwtzXpfbC5fgg/oPffBPRvk92TWK6swg6U=
 github.com/xdg-go/pbkdf2 v1.0.0 h1:Su7DPu48wXMwC3bs7MCNG+z4FhcyEuz5dlvchbq0B0c=


### PR DESCRIPTION
## Status

Draft evidence PR for #1963. **Recommendation: do not merge this implementation as-is.**

This branch preserves the current intra-query batched scoring experiment and switches TreeDB's `github.com/tphakala/simd` dependency to the requested `snissn/simd` fork at commit `a4847ce2ce89a9b96eaf24dc9c55ced324bcdd64` via:

```go
replace github.com/tphakala/simd => github.com/snissn/simd v0.0.0-20260523073437-a4847ce2ce89
```

The forked SIMD batch kernel is faster in isolation on the Intel host, but the integrated TreeDB/HNSW search path still regresses. This fails the #1963 merge gate.

Refs #1963.

## What this draft contains

- Adds `vectorops.DotFloat32Batch`/`DotFloat32BatchOptimized` wrappers.
- Adds intra-query adjacency-tile scoring that batches only within the current expansion and applies scores in original neighbor order.
- Adds batch/scalar counters and #1963 benchmark variants.
- Keeps public `Search` behavior, graph semantics, ordering, document fetch behavior, and on-disk formats unchanged.
- Keeps allocation and typed-column mmap health checks visible in benchmark counters.

## Intel validation host

Host: `mikers@192.168.0.185`

Artifacts:

- Final integrated run: `/tmp/gomap_1963_snissn_simd_final_20260528_074127`
- Earlier full-tile run: `/tmp/gomap_1963_snissn_simd_20260528_072547`
- WIP patch snapshot: `/tmp/issue1963_snissn_simd_avx512_wip_no_speedup.patch`

Module evidence:

```json
"Path": "github.com/tphakala/simd",
"Version": "v1.0.22",
"Replace": {
  "Path": "github.com/snissn/simd",
  "Version": "v0.0.0-20260523073437-a4847ce2ce89",
  "Time": "2026-05-23T07:34:37Z"
}
```

## Standalone SIMD evidence

The requested fork/commit helps the standalone `DotProductBatch` kernel:

| Benchmark | tphakala v1.0.22 | snissn/simd a4847ce | Delta |
|---|---:|---:|---:|
| `DotProductBatch768x128/tphakala_batch` | `4.644µs` | `2.956µs` | `-36.35%` |

Source artifact: `/tmp/gomap_1963_snissn_simd_final_20260528_074127/artifacts/benchstat_vector_distance_tphakala_vs_snissn.txt` from the earlier same-host run.

## Integrated TreeDB evidence

Despite the standalone win, integrated TreeDB search is slower:

| Benchmark | scalar | batched | Delta |
|---|---:|---:|---:|
| `BenchmarkColumnVectorGraphNativeSearchCosineBatchedScoring1963` | `12.37µs` | `14.22µs` | `+14.93%` slower |
| `BenchmarkVectorSearchReusableBufferSerialTypedColumnBatchedScoring1963` | `13.24µs` | `14.81µs` | `+11.85%` slower |

Health counters remain good:

- `0 B/op`, `0 allocs/op`
- `vector_scratch_decode/search=0`
- `adjacency_scratch_decodes/search=0`
- optimized batch invoked: `dot_batch_calls/search=3`, `dot_batch_candidates/search=96`, `dot_batch_optimized_calls/search=3`

Temporary larger-dimension integrated shapes were also mixed/noisy:

| dims | scalar | batched | Result |
|---:|---:|---:|---|
| 768 | `22.06µs` | `22.12µs` | flat/slightly slower |
| 2048 | `41.73µs` | `39.25µs` | small noisy win |
| 4096 | `76.58µs` | `91.72µs` | slower/noisy |

## Validation run

```sh
go test ./TreeDB/internal/vectorops -count=1
go test ./TreeDB/collections -run 'TestColumnVectorGraphScoreOrdinalBatch|TestColumnVectorGraphBatchedScoring|TestVectorIndexSearcherSearchWithBuffer' -count=1
GOMAXPROCS=12 go test ./TreeDB/collections -run '^$' -bench 'Benchmark(ColumnVectorGraphNativeSearchCosineBatchedScoring1963|VectorSearchReusableBufferSerialTypedColumnBatchedScoring1963)$' -benchmem -benchtime=1s -count=5
```

## Recommendation

Keep this PR as a draft evidence branch and **do not merge** until integrated Intel search shows a real speedup.

The likely next direction is a TreeDB-native fused gather cosine kernel that avoids `[][]float32` row-slice setup, avoids slice-header churn/pointer chasing, fuses dot + normalization, and writes scores directly while preserving original scalar neighbor order.
