### PR TITLE
Switch column_graph search to uint32_list adjacency state

### DIFF
--- a/TreeDB/collections/column_physical_scan.go
+++ b/TreeDB/collections/column_physical_scan.go
@@ -210,22 +210,24 @@ func columnManifestScanPartPreallocCapacity(expectedParts uint64) int {
 }
 
 type columnPhysicalScanSnapshotView struct {
-	CollectionName      string
-	Catalog             *collectionCatalog
-	Config              ColumnStoreConfig
-	FullConfig          ColumnStoreConfig
-	ColumnStoreEnabled  bool
-	CommitSeq           uint64
-	AssetRefs           []columnManifestAssetRefForScan
-	TypedColumnPartRefs []columnManifestAssetRefForScan
-	AggregateMetadata   []columnManifestAggregateMetadataSnapshot
-	DictionaryCodes     []columnManifestDictionaryCodesSnapshot
-	Int64Values         []columnManifestInt64ValuesSnapshot
-	GraphAssetRefs      []ColumnAssetRef
-	MutationParts       int
-	Diagnostics         columnPhysicalScanDiagnostics
-	ColumnAssetRootDir  string
-	AssetNamespace      string
+	CollectionName        string
+	Catalog               *collectionCatalog
+	Config                ColumnStoreConfig
+	FullConfig            ColumnStoreConfig
+	ColumnStoreEnabled    bool
+	CommitSeq             uint64
+	AssetRefs             []columnManifestAssetRefForScan
+	TypedColumnPartRefs   []columnManifestAssetRefForScan
+	AggregateMetadata     []columnManifestAggregateMetadataSnapshot
+	DictionaryCodes       []columnManifestDictionaryCodesSnapshot
+	Int64Values           []columnManifestInt64ValuesSnapshot
+	GraphAssetRefs        []ColumnAssetRef
+	VectorIndexState      columnVectorIndexStateSnapshot
+	VectorIndexStateFound bool
+	MutationParts         int
+	Diagnostics           columnPhysicalScanDiagnostics
+	ColumnAssetRootDir    string
+	AssetNamespace        string
 }
 
 var errColumnPhysicalAssetManifestOperationMismatch = errors.New("collections: column physical asset operation does not match manifest reason")

--- a/TreeDB/collections/column_vector_graph_adjacency_direct_source.go
+++ b/TreeDB/collections/column_vector_graph_adjacency_direct_source.go
@@ -23,6 +23,10 @@ const (
 	columnVectorGraphLayer0AdjacencySourceOutcomeUnknown columnVectorGraphLayer0AdjacencySourceOutcome = iota
 	columnVectorGraphLayer0AdjacencySourceOutcomeMmapDirect
 	columnVectorGraphLayer0AdjacencySourceOutcomeHeapCopyTypedView
+	columnVectorGraphLayer0AdjacencySourceOutcomeScratchDecode
+	columnVectorGraphLayer0AdjacencySourceOutcomeTypedListMmapDirect
+	columnVectorGraphLayer0AdjacencySourceOutcomeTypedListHeapCopyTypedView
+	columnVectorGraphLayer0AdjacencySourceOutcomeTypedListScratchDecode
 )
 
 func (o columnVectorGraphLayer0AdjacencySourceOutcome) String() string {
@@ -31,6 +35,14 @@ func (o columnVectorGraphLayer0AdjacencySourceOutcome) String() string {
 		return "mmap_direct"
 	case columnVectorGraphLayer0AdjacencySourceOutcomeHeapCopyTypedView:
 		return "heap_copy_typed_view"
+	case columnVectorGraphLayer0AdjacencySourceOutcomeScratchDecode:
+		return "scratch_decode"
+	case columnVectorGraphLayer0AdjacencySourceOutcomeTypedListMmapDirect:
+		return "typed_list_mmap_direct"
+	case columnVectorGraphLayer0AdjacencySourceOutcomeTypedListHeapCopyTypedView:
+		return "typed_list_heap_copy_typed_view"
+	case columnVectorGraphLayer0AdjacencySourceOutcomeTypedListScratchDecode:
+		return "typed_list_scratch_decode"
 	default:
 		return "unknown"
 	}
@@ -49,8 +61,10 @@ type columnVectorGraphLayer0AdjacencyDirectSource struct {
 
 	mappedBytes     uint64
 	heapCopyBytes   uint64
+	decodedBytes    uint64
 	activeHandles   int64
 	deniedResources uint64
+	owned           bool
 	closed          bool
 }
 
@@ -261,38 +275,68 @@ func (c *Collection) acquireColumnVectorGraphLayer0AdjacencySourceSection(collec
 }
 
 func columnVectorGraphLayer0AdjacencyDirectSourceFromHandles(manager *mappedresource.Manager, layer int, rows int, valuesCount int, directReq typeddecode.Uint32OffsetsListDirectViewRequest, offsetsHandle *mappedresource.Handle, valuesHandle *mappedresource.Handle) (*columnVectorGraphLayer0AdjacencyDirectSource, typeddecode.Reason, error) {
+	return columnVectorGraphAdjacencyDirectSourceFromHandles(manager, layer, rows, valuesCount, directReq, offsetsHandle, valuesHandle, columnVectorGraphLayer0AdjacencySourceOutcomeMmapDirect, columnVectorGraphLayer0AdjacencySourceOutcomeHeapCopyTypedView, columnVectorGraphLayer0AdjacencySourceOutcomeScratchDecode, false, "column_graph adjacency source")
+}
+
+func columnVectorGraphTypedListAdjacencyDirectSourceFromHandles(manager *mappedresource.Manager, layer int, rows int, valuesCount int, directReq typeddecode.Uint32OffsetsListDirectViewRequest, offsetsHandle *mappedresource.Handle, valuesHandle *mappedresource.Handle) (*columnVectorGraphLayer0AdjacencyDirectSource, typeddecode.Reason, error) {
+	return columnVectorGraphAdjacencyDirectSourceFromHandles(manager, layer, rows, valuesCount, directReq, offsetsHandle, valuesHandle, columnVectorGraphLayer0AdjacencySourceOutcomeTypedListMmapDirect, columnVectorGraphLayer0AdjacencySourceOutcomeTypedListHeapCopyTypedView, columnVectorGraphLayer0AdjacencySourceOutcomeTypedListScratchDecode, true, "vector-index state adjacency")
+}
+
+func columnVectorGraphAdjacencyDirectSourceFromHandles(manager *mappedresource.Manager, layer int, rows int, valuesCount int, directReq typeddecode.Uint32OffsetsListDirectViewRequest, offsetsHandle *mappedresource.Handle, valuesHandle *mappedresource.Handle, mmapOutcome, heapOutcome, scratchOutcome columnVectorGraphLayer0AdjacencySourceOutcome, allowScratch bool, label string) (*columnVectorGraphLayer0AdjacencyDirectSource, typeddecode.Reason, error) {
 	if offsetsHandle == nil || valuesHandle == nil {
 		status := typeddecode.StreamingStatus(typeddecode.ReasonNilHandle, "nil adjacency source handle")
-		return nil, status.Reason, fmt.Errorf("collections: column_graph adjacency source handle validation: %s", status.String())
+		return nil, status.Reason, fmt.Errorf("collections: %s handle validation: %s", label, status.String())
 	}
 	if offsetsHandle.Released() || valuesHandle.Released() {
 		status := typeddecode.UnsupportedStatus(typeddecode.ReasonStaleHandle, "released adjacency source handle")
-		return nil, status.Reason, fmt.Errorf("collections: column_graph adjacency source handle validation: %s", status.String())
+		return nil, status.Reason, fmt.Errorf("collections: %s handle validation: %s", label, status.String())
+	}
+	decodeScratch := func(firstStatus typeddecode.Status, fallbackReason typeddecode.Reason) (*columnVectorGraphLayer0AdjacencyDirectSource, typeddecode.Reason, error) {
+		decoded, decodeErr := typedcolumn.DecodeRawUint32OffsetsListFallback(nil, nil, offsetsHandle.Bytes(), valuesHandle.Bytes(), rows)
+		releaseErr := errors.Join(offsetsHandle.Release(), valuesHandle.Release())
+		if decodeErr != nil {
+			return nil, typeddecode.ReasonValidationFailed, errors.Join(fmt.Errorf("collections: %s direct-view validation: %s", label, firstStatus.String()), decodeErr, releaseErr)
+		}
+		if releaseErr != nil {
+			return nil, fallbackReason, errors.Join(fmt.Errorf("collections: %s direct-view validation: %s", label, firstStatus.String()), releaseErr)
+		}
+		if len(decoded.Values) != valuesCount {
+			return nil, typeddecode.ReasonValuesLengthMismatch, fmt.Errorf("collections: %s layer %d decoded values=%d want %d", label, layer, len(decoded.Values), valuesCount)
+		}
+		return &columnVectorGraphLayer0AdjacencyDirectSource{layer: layer, rows: rows, offsets: decoded.Offsets, values: decoded.Values, outcome: scratchOutcome, manager: manager, decodedBytes: uint64(len(decoded.Offsets))*8 + uint64(len(decoded.Values))*4, owned: true}, fallbackReason, nil
 	}
 	if status := typeddecode.ValidateUint32OffsetsListDirectViewSections(directReq); !status.Direct() {
-		return nil, status.Reason, fmt.Errorf("collections: column_graph adjacency source section validation: %s", status.String())
+		if allowScratch && typedColumnUint32OffsetsListScratchFallbackAllowed(status) {
+			return decodeScratch(status, status.Reason)
+		}
+		return nil, status.Reason, fmt.Errorf("collections: %s section validation: %s", label, status.String())
 	}
 	offsets, values, status := typeddecode.Uint32OffsetsListView(manager, offsetsHandle, valuesHandle, directReq, typeddecode.ResourceViewOptions{RequireMapped: true})
 	if status.Direct() {
 		if len(values) != valuesCount {
-			return nil, typeddecode.ReasonValuesLengthMismatch, fmt.Errorf("collections: column_graph adjacency source layer %d values=%d want %d", layer, len(values), valuesCount)
+			return nil, typeddecode.ReasonValuesLengthMismatch, fmt.Errorf("collections: %s layer %d values=%d want %d", label, layer, len(values), valuesCount)
 		}
-		return &columnVectorGraphLayer0AdjacencyDirectSource{layer: layer, rows: rows, offsets: offsets, values: values, outcome: columnVectorGraphLayer0AdjacencySourceOutcomeMmapDirect, manager: manager, offsetsHandle: offsetsHandle, valuesHandle: valuesHandle}, "", nil
+		return &columnVectorGraphLayer0AdjacencyDirectSource{layer: layer, rows: rows, offsets: offsets, values: values, outcome: mmapOutcome, manager: manager, offsetsHandle: offsetsHandle, valuesHandle: valuesHandle}, "", nil
 	}
 	firstStatus := status
+	fallbackReason := status.Reason
 	if status.Reason == typeddecode.ReasonHandleSourceUnsupported || status.Reason == typeddecode.ReasonActualPointerUnaligned {
 		offsets, values, status = typeddecode.Uint32OffsetsListView(manager, offsetsHandle, valuesHandle, directReq, typeddecode.ResourceViewOptions{RequireMapped: false})
 		if status.Direct() {
 			if len(values) != valuesCount {
-				return nil, typeddecode.ReasonValuesLengthMismatch, fmt.Errorf("collections: column_graph adjacency source layer %d values=%d want %d", layer, len(values), valuesCount)
+				return nil, typeddecode.ReasonValuesLengthMismatch, fmt.Errorf("collections: %s layer %d values=%d want %d", label, layer, len(values), valuesCount)
 			}
-			return &columnVectorGraphLayer0AdjacencyDirectSource{layer: layer, rows: rows, offsets: offsets, values: values, outcome: columnVectorGraphLayer0AdjacencySourceOutcomeHeapCopyTypedView, manager: manager, offsetsHandle: offsetsHandle, valuesHandle: valuesHandle}, "", nil
+			return &columnVectorGraphLayer0AdjacencyDirectSource{layer: layer, rows: rows, offsets: offsets, values: values, outcome: heapOutcome, manager: manager, offsetsHandle: offsetsHandle, valuesHandle: valuesHandle}, "", nil
 		}
+		fallbackReason = status.Reason
+	}
+	if allowScratch && typedColumnUint32OffsetsListScratchFallbackAllowed(status) {
+		return decodeScratch(firstStatus, fallbackReason)
 	}
 	if status.Reason == "" {
 		status = firstStatus
 	}
-	return nil, status.Reason, fmt.Errorf("collections: column_graph adjacency source direct-view validation: %s", status.String())
+	return nil, status.Reason, fmt.Errorf("collections: %s direct-view validation: %s", label, status.String())
 }
 
 func (g *columnVectorGraphAdjacencyDirectSources) Neighbors(layer, ordinal int) ([]uint32, columnVectorGraphLayer0AdjacencySourceOutcome, typeddecode.Reason, bool) {
@@ -355,7 +399,7 @@ func (s *columnVectorGraphLayer0AdjacencyDirectSource) Neighbors(ordinal int) ([
 	if s.closed {
 		return nil, columnVectorGraphLayer0AdjacencySourceOutcomeUnknown, typeddecode.ReasonStaleHandle, false
 	}
-	if s.offsetsHandle == nil || s.valuesHandle == nil || s.offsetsHandle.Released() || s.valuesHandle.Released() {
+	if !s.owned && (s.offsetsHandle == nil || s.valuesHandle == nil || s.offsetsHandle.Released() || s.valuesHandle.Released()) {
 		return nil, columnVectorGraphLayer0AdjacencySourceOutcomeUnknown, typeddecode.ReasonStaleHandle, false
 	}
 	if ordinal < 0 || ordinal >= s.rows || ordinal+1 >= len(s.offsets) {
@@ -398,6 +442,8 @@ func (s *columnVectorGraphLayer0AdjacencyDirectSource) Close() error {
 	s.values = nil
 	s.outcome = columnVectorGraphLayer0AdjacencySourceOutcomeUnknown
 	s.rows = 0
+	s.decodedBytes = 0
 	s.activeHandles = 0
+	s.owned = false
 	return closeErr
 }

--- a/TreeDB/collections/column_vector_graph_adjacency_direct_source_test.go
+++ b/TreeDB/collections/column_vector_graph_adjacency_direct_source_test.go
@@ -69,6 +69,59 @@ func TestColumnVectorGraphLayer0AdjacencySourceSearchParity1919(t *testing.T) {
 	}
 }
 
+func TestColumnVectorGraphSearchUsesVectorIndexStateAdjacency1988(t *testing.T) {
+	const (
+		rows = 128
+		dims = 32
+		m    = 12
+	)
+	input := columnGraphRebuildSyntheticRowsV2A(rows, dims)
+	_, d, col, def := openColumnGraphRebuildTestCollectionV2A(t, dims, m, input)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	query := append([]float32(nil), input[23].vector...)
+	directReader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("open direct reader: %v", err)
+	}
+	defer func() { _ = directReader.Close() }()
+	if directReader.adjacencyLayerSources == nil || !directReader.adjacencyLayerSources.allLayers || directReader.layer0AdjacencySource == nil {
+		t.Fatalf("adjacency state sources=%+v layer0=%v want typed uint32_list state sources", directReader.adjacencyLayerSources, directReader.layer0AdjacencySource != nil)
+	}
+	var directScratch columnVectorGraphNativeSearchScratch
+	directResults, directStats, err := directReader.SearchCosine(query, columnVectorGraphNativeSearchOptions{TopK: 10, EfSearch: 64}, &directScratch)
+	if err != nil {
+		t.Fatalf("direct SearchCosine: %v", err)
+	}
+	if len(directResults) == 0 {
+		t.Fatal("direct SearchCosine returned no results")
+	}
+	typedDirect := directStats.AdjacencyTypedListMmapDirectViews + directStats.AdjacencyTypedListHeapCopyTypedViews + directStats.AdjacencyTypedListScratchDecodes
+	if typedDirect == 0 || directStats.AdjacencyLegacyFallbacks != 0 || directStats.AdjacencySourceFallbacks != 0 {
+		t.Fatalf("direct stats=%+v want typed-list adjacency state and no legacy fallback", directStats)
+	}
+
+	fallbackReader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("open fallback reader: %v", err)
+	}
+	defer func() { _ = fallbackReader.Close() }()
+	disableColumnVectorGraphAdjacencyDirectSourcesForTest(t, fallbackReader)
+	var fallbackScratch columnVectorGraphNativeSearchScratch
+	fallbackResults, fallbackStats, err := fallbackReader.SearchCosine(query, columnVectorGraphNativeSearchOptions{TopK: 10, EfSearch: 64}, &fallbackScratch)
+	if err != nil {
+		t.Fatalf("fallback SearchCosine: %v", err)
+	}
+	if mismatch := columnGraphNativeSearchResultsMismatchV3(directResults, fallbackResults); mismatch != "" {
+		t.Fatalf("direct/fallback mismatch: %s", mismatch)
+	}
+	if fallbackStats.AdjacencyTypedListMmapDirectViews+fallbackStats.AdjacencyTypedListHeapCopyTypedViews+fallbackStats.AdjacencyTypedListScratchDecodes != 0 || fallbackStats.AdjacencyLegacyFallbacks == 0 || fallbackStats.AdjacencyScratchDecodes == 0 {
+		t.Fatalf("fallback stats=%+v want explicit legacy row-image fallback after typed-state source disabled", fallbackStats)
+	}
+}
+
 func TestColumnVectorGraphLayer0AdjacencySourceCertifiedMmapDirect1919(t *testing.T) {
 	if !columnVectorGraphLayer0AdjacencyMmapExpectedOnPlatform1919() {
 		t.Skipf("mmap direct source is unsupported on %s", runtime.GOOS)
@@ -87,16 +140,16 @@ func TestColumnVectorGraphLayer0AdjacencySourceCertifiedMmapDirect1919(t *testin
 	if reader.layer0AdjacencySource == nil {
 		t.Fatalf("layer-0 adjacency source missing fallback=%s", reader.layer0AdjacencySourceFallbackReason)
 	}
-	if got := reader.layer0AdjacencySource.outcome; got != columnVectorGraphLayer0AdjacencySourceOutcomeMmapDirect {
-		t.Fatalf("source outcome=%s want mmap_direct", got)
+	if got := reader.layer0AdjacencySource.outcome; got != columnVectorGraphLayer0AdjacencySourceOutcomeTypedListMmapDirect {
+		t.Fatalf("source outcome=%s want typed_list_mmap_direct", got)
 	}
 	var scratch columnVectorGraphNativeSearchScratch
 	_, stats, err := reader.SearchCosine(input[11].vector, columnVectorGraphNativeSearchOptions{TopK: 5, EfSearch: 32}, &scratch)
 	if err != nil {
 		t.Fatalf("SearchCosine: %v", err)
 	}
-	if stats.AdjacencyMmapDirectViews == 0 || stats.AdjacencyHeapCopyTypedViews != 0 {
-		t.Fatalf("stats=%+v want mmap direct adjacency and no heap-copy typed view", stats)
+	if stats.AdjacencyTypedListMmapDirectViews == 0 || stats.AdjacencyTypedListHeapCopyTypedViews != 0 || stats.AdjacencyLegacyFallbacks != 0 {
+		t.Fatalf("stats=%+v want typed-list mmap direct adjacency and no legacy fallback", stats)
 	}
 }
 
@@ -113,16 +166,17 @@ func TestColumnVectorGraphLayer0AdjacencySourceAbsentFallback1919(t *testing.T) 
 		t.Fatalf("open reader: %v", err)
 	}
 	defer func() { _ = reader.Close() }()
-	if reader.layer0AdjacencySource != nil || !reader.layer0AdjacencySourceUnavailable {
-		t.Fatalf("source=%v unavailable=%v want absent source row fallback", reader.layer0AdjacencySource != nil, reader.layer0AdjacencySourceUnavailable)
+	if reader.layer0AdjacencySource == nil || reader.adjacencyLayerSources == nil {
+		t.Fatalf("source=%v all_layers=%v want typed adjacency state source before explicit row fallback", reader.layer0AdjacencySource != nil, reader.adjacencyLayerSources != nil)
 	}
+	disableColumnVectorGraphAdjacencyDirectSourcesForTest(t, reader)
 	var scratch columnVectorGraphNativeSearchScratch
 	got, stats, err := reader.SearchCosine([]float32{1, 0, 0}, columnVectorGraphNativeSearchOptions{TopK: 2, EfSearch: 3}, &scratch)
 	if err != nil {
 		t.Fatalf("SearchCosine: %v", err)
 	}
-	if len(got) == 0 || stats.AdjacencySourceUnavailable != 1 || stats.AdjacencySourceFallbacks != 1 || stats.AdjacencyMmapDirectViews != 0 || stats.AdjacencyScratchDecodes == 0 {
-		t.Fatalf("results=%d stats=%+v want source-unavailable row fallback", len(got), stats)
+	if len(got) == 0 || stats.AdjacencySourceUnavailable != 1 || stats.AdjacencySourceFallbacks != 1 || stats.AdjacencyTypedListMmapDirectViews != 0 || stats.AdjacencyScratchDecodes == 0 || stats.AdjacencyLegacyFallbacks == 0 {
+		t.Fatalf("results=%d stats=%+v want explicit source-unavailable row fallback", len(got), stats)
 	}
 }
 
@@ -174,16 +228,16 @@ func TestColumnVectorGraphLayer0AdjacencySourceChecksumFallback1919(t *testing.T
 		t.Fatalf("open reader after corrupt source: %v", err)
 	}
 	defer func() { _ = reader.Close() }()
-	if reader.layer0AdjacencySource != nil || reader.layer0AdjacencySourceFallbackReason == "" {
-		t.Fatalf("source=%v fallback=%s want source fallback after checksum corruption", reader.layer0AdjacencySource != nil, reader.layer0AdjacencySourceFallbackReason)
+	if reader.layer0AdjacencySource == nil || reader.adjacencyLayerSources == nil {
+		t.Fatalf("source=%v all_layers=%v fallback=%s want typed adjacency state despite corrupt legacy source", reader.layer0AdjacencySource != nil, reader.adjacencyLayerSources != nil, reader.layer0AdjacencySourceFallbackReason)
 	}
 	var scratch columnVectorGraphNativeSearchScratch
 	got, stats, err := reader.SearchCosine(input[5].vector, columnVectorGraphNativeSearchOptions{TopK: 5, EfSearch: 32}, &scratch)
 	if err != nil {
 		t.Fatalf("SearchCosine after corrupt source: %v", err)
 	}
-	if len(got) == 0 || stats.AdjacencySourceUnavailable != 1 || stats.AdjacencySourceFallbacks != 1 || stats.AdjacencyCertificationFailures == 0 || stats.AdjacencyMmapDirectViews != 0 {
-		t.Fatalf("results=%d stats=%+v want row-asset fallback with source certification failure", len(got), stats)
+	if len(got) == 0 || stats.AdjacencyTypedListMmapDirectViews+stats.AdjacencyTypedListHeapCopyTypedViews == 0 || stats.AdjacencySourceUnavailable != 0 || stats.AdjacencySourceFallbacks != 0 || stats.AdjacencyLegacyFallbacks != 0 {
+		t.Fatalf("results=%d stats=%+v want typed adjacency state and quarantined legacy source corruption", len(got), stats)
 	}
 }
 
@@ -208,8 +262,8 @@ func TestColumnVectorGraphLayer0AdjacencySourceStaleHandlesFallback1919(t *testi
 	if err != nil {
 		t.Fatalf("SearchCosine with stale source handles: %v", err)
 	}
-	if len(got) == 0 || stats.AdjacencyStaleHandles == 0 || stats.AdjacencySourceFallbacks == 0 || stats.AdjacencyMmapDirectViews != 0 {
-		t.Fatalf("results=%d stats=%+v want stale-handle row fallback", len(got), stats)
+	if len(got) == 0 || stats.AdjacencyStaleHandles == 0 || stats.AdjacencySourceFallbacks == 0 || stats.AdjacencyTypedListMmapDirectViews != 0 || stats.AdjacencyLegacyFallbacks == 0 || stats.AdjacencyScratchDecodes == 0 {
+		t.Fatalf("results=%d stats=%+v want stale typed-state handles to use explicit row fallback", len(got), stats)
 	}
 }
 
@@ -237,8 +291,8 @@ func TestVectorIndexSearcherCloseReleasesLayer0AdjacencySource1919(t *testing.T)
 	}
 	expectedPinnedRefs := make([]ColumnAssetRef, 0, len(pins))
 	for _, pin := range pins {
-		if pin.Root == "" || pin.Path == "" || pin.Key.Section.Column != columnVectorGraphLayer0AdjacencySourceColumnName {
-			t.Fatalf("pin=%+v missing root/path/column identity", pin)
+		if pin.Root == "" || pin.Path == "" || pin.Key.Section.Column != columnVectorIndexStateAdjacencyColumnName {
+			t.Fatalf("pin=%+v missing root/path/typed-state column identity", pin)
 		}
 		ref, ok := columnAssetRefForMappedResourceKey(pin.Key)
 		if !ok {
@@ -484,16 +538,16 @@ func TestColumnVectorGraphAllLayerAdjacencySourceMissingLayerFallback1921(t *tes
 		t.Fatalf("open reader with missing optional source: %v", err)
 	}
 	defer func() { _ = reader.Close() }()
-	if reader.adjacencyLayerSources != nil || reader.layer0AdjacencySource != nil || reader.layer0AdjacencySourceFallbackReason == "" {
-		t.Fatalf("sources=%v layer0=%v fallback=%s want all-layer source fallback", reader.adjacencyLayerSources != nil, reader.layer0AdjacencySource != nil, reader.layer0AdjacencySourceFallbackReason)
+	if reader.adjacencyLayerSources == nil || reader.layer0AdjacencySource == nil {
+		t.Fatalf("sources=%v layer0=%v fallback=%s want typed adjacency state despite missing legacy source", reader.adjacencyLayerSources != nil, reader.layer0AdjacencySource != nil, reader.layer0AdjacencySourceFallbackReason)
 	}
 	var scratch columnVectorGraphNativeSearchScratch
 	got, stats, err := reader.SearchCosine(rows[0].Vector, columnVectorGraphNativeSearchOptions{TopK: 2, EfSearch: len(rows)}, &scratch)
 	if err != nil {
 		t.Fatalf("SearchCosine with missing optional source: %v", err)
 	}
-	if len(got) == 0 || stats.AdjacencySourceUnavailable != 1 || stats.AdjacencySourceFallbacks != 1 || stats.AdjacencyCertificationFailures == 0 || stats.AdjacencyScratchDecodes == 0 || stats.AdjacencyMmapDirectViews != 0 {
-		t.Fatalf("results=%d stats=%+v want row-asset fallback after missing source", len(got), stats)
+	if len(got) == 0 || stats.AdjacencyTypedListMmapDirectViews+stats.AdjacencyTypedListHeapCopyTypedViews == 0 || stats.AdjacencySourceUnavailable != 0 || stats.AdjacencySourceFallbacks != 0 || stats.AdjacencyLegacyFallbacks != 0 {
+		t.Fatalf("results=%d stats=%+v want typed adjacency state after quarantined missing legacy source", len(got), stats)
 	}
 }
 
@@ -537,16 +591,16 @@ func TestColumnVectorGraphAllLayerAdjacencySourceCorruptLayerFallback1921(t *tes
 		t.Fatalf("open reader after corrupt optional source: %v", err)
 	}
 	defer func() { _ = reader.Close() }()
-	if reader.adjacencyLayerSources != nil || reader.layer0AdjacencySource != nil || reader.layer0AdjacencySourceFallbackReason == "" {
-		t.Fatalf("sources=%v layer0=%v fallback=%s want all-layer source fallback", reader.adjacencyLayerSources != nil, reader.layer0AdjacencySource != nil, reader.layer0AdjacencySourceFallbackReason)
+	if reader.adjacencyLayerSources == nil || reader.layer0AdjacencySource == nil {
+		t.Fatalf("sources=%v layer0=%v fallback=%s want typed adjacency state despite corrupt legacy source", reader.adjacencyLayerSources != nil, reader.layer0AdjacencySource != nil, reader.layer0AdjacencySourceFallbackReason)
 	}
 	var scratch columnVectorGraphNativeSearchScratch
 	got, stats, err := reader.SearchCosine(rows[2].Vector, columnVectorGraphNativeSearchOptions{TopK: 2, EfSearch: len(rows)}, &scratch)
 	if err != nil {
 		t.Fatalf("SearchCosine after corrupt optional source: %v", err)
 	}
-	if len(got) == 0 || stats.AdjacencySourceUnavailable != 1 || stats.AdjacencySourceFallbacks != 1 || stats.AdjacencyCertificationFailures == 0 || stats.AdjacencyScratchDecodes == 0 || stats.AdjacencyMmapDirectViews != 0 {
-		t.Fatalf("results=%d stats=%+v want row-asset fallback after corrupt source", len(got), stats)
+	if len(got) == 0 || stats.AdjacencyTypedListMmapDirectViews+stats.AdjacencyTypedListHeapCopyTypedViews == 0 || stats.AdjacencySourceUnavailable != 0 || stats.AdjacencySourceFallbacks != 0 || stats.AdjacencyLegacyFallbacks != 0 {
+		t.Fatalf("results=%d stats=%+v want typed adjacency state after quarantined corrupt legacy source", len(got), stats)
 	}
 }
 
@@ -572,18 +626,21 @@ func TestVectorIndexSearcherCloseReleasesAllLayerAdjacencySources1921(t *testing
 		}
 		activeHandles += source.manager.Stats().ActiveHandles
 		for _, pin := range source.manager.PinSummary() {
-			if pin.Root == "" || pin.Path == "" || pin.Key.Section.Column != columnVectorGraphAdjacencySourceColumnName(layer) {
-				t.Fatalf("pin=%+v missing root/path/column identity for layer %d", pin, layer)
+			if pin.Root == "" || pin.Path == "" || pin.Key.Section.Column != columnVectorIndexStateAdjacencyColumnName {
+				t.Fatalf("pin=%+v missing root/path/typed-state column identity for layer %d", pin, layer)
 			}
 			ref, ok := columnAssetRefForMappedResourceKey(pin.Key)
 			if !ok {
-				t.Fatalf("pin=%+v could not convert to column asset ref", pin)
+				if pin.Key.Length != 0 {
+					t.Fatalf("pin=%+v could not convert to column asset ref", pin)
+				}
+				continue
 			}
 			expectedPinnedRefs = append(expectedPinnedRefs, ref)
 		}
 	}
-	if activeHandles != int64(graph.AdjacencyLayerCount*2) || sources.ActiveHandles() != activeHandles || len(expectedPinnedRefs) != graph.AdjacencyLayerCount*2 {
-		t.Fatalf("active handles=%d grouped=%d pinnedRefs=%d want %d", activeHandles, sources.ActiveHandles(), len(expectedPinnedRefs), graph.AdjacencyLayerCount*2)
+	if activeHandles != int64(graph.AdjacencyLayerCount*2) || sources.ActiveHandles() != activeHandles || len(expectedPinnedRefs) == 0 {
+		t.Fatalf("active handles=%d grouped=%d pinnedRefs=%d want active handles and at least one convertible pinned ref", activeHandles, sources.ActiveHandles(), len(expectedPinnedRefs))
 	}
 	plan, err := col.PlanColumnAssetReachability(context.Background(), ColumnAssetReachabilityOptions{Detailed: true})
 	if err != nil {

--- a/TreeDB/collections/column_vector_graph_adjacency_state_source.go
+++ b/TreeDB/collections/column_vector_graph_adjacency_state_source.go
@@ -1,0 +1,245 @@
+package collections
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/snissn/gomap/TreeDB/internal/mappedresource"
+	"github.com/snissn/gomap/TreeDB/internal/typedcolumn"
+	"github.com/snissn/gomap/TreeDB/internal/typeddecode"
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+const columnVectorGraphAdjacencyStateSourceScopeID = "column-vector-graph-adjacency-state"
+
+func (c *Collection) openColumnVectorGraphAdjacencyStateSourcesForReader(collection string, cfg ColumnStoreConfig, def VectorIndexDefinition, graph columnVectorGraphManifestSnapshot, state columnVectorIndexStateSnapshot) (*columnVectorGraphAdjacencyDirectSources, typeddecode.Reason, error) {
+	if c == nil {
+		return nil, typeddecode.ReasonValidationFailed, errCollectionNil
+	}
+	if c.db == nil {
+		return nil, typeddecode.ReasonValidationFailed, errCollectionDBNil
+	}
+	return openColumnVectorGraphAdjacencyStateSourcesFromRoot(c.db.ColumnAssetRootDir(), collection, cfg, def, graph, state)
+}
+
+func openColumnVectorGraphAdjacencyStateSourcesFromRoot(rootDir, collection string, cfg ColumnStoreConfig, def VectorIndexDefinition, graph columnVectorGraphManifestSnapshot, state columnVectorIndexStateSnapshot) (*columnVectorGraphAdjacencyDirectSources, typeddecode.Reason, error) {
+	if !columnVectorIndexStateDefinitionParametersMatch(&state, &def) || !columnVectorIndexStateMatchesGraph(state, graph) {
+		return nil, typeddecode.ReasonValidationFailed, fmt.Errorf("collections: column_graph %q adjacency state identity mismatch", def.Name)
+	}
+	assets, reason, err := columnVectorGraphAdjacencyStateAssetsByLayer(state, graph)
+	if err != nil {
+		return nil, reason, err
+	}
+	group := &columnVectorGraphAdjacencyDirectSources{sources: make([]*columnVectorGraphLayer0AdjacencyDirectSource, 0, len(assets)), allLayers: true}
+	for layer, asset := range assets {
+		source, sourceReason, sourceErr := newColumnVectorGraphAdjacencyStateDirectSourceFromRoot(rootDir, collection, cfg, def, graph, state, asset, layer)
+		if sourceErr != nil {
+			_ = group.Close()
+			if sourceReason == "" {
+				sourceReason = typeddecode.ReasonValidationFailed
+			}
+			return nil, sourceReason, sourceErr
+		}
+		group.sources = append(group.sources, source)
+	}
+	return group, "", nil
+}
+
+func columnVectorGraphAdjacencyStateAssetsByLayer(state columnVectorIndexStateSnapshot, graph columnVectorGraphManifestSnapshot) ([]columnVectorIndexStateAssetSnapshot, typeddecode.Reason, error) {
+	seen := make(map[int]struct{})
+	maxLayer := -1
+	for _, asset := range state.Assets {
+		if asset.Role != columnVectorIndexStateAssetRoleAdjacency {
+			continue
+		}
+		layer, err := columnVectorIndexStateAdjacencyLayerFromAssetID(asset.AssetID)
+		if err != nil {
+			return nil, typeddecode.ReasonValidationFailed, err
+		}
+		if _, ok := seen[layer]; ok {
+			return nil, typeddecode.ReasonValidationFailed, fmt.Errorf("collections: vector-index state duplicate adjacency layer=%d", layer)
+		}
+		seen[layer] = struct{}{}
+		if layer > maxLayer {
+			maxLayer = layer
+		}
+	}
+	if len(seen) == 0 {
+		return nil, typeddecode.ReasonValidationFailed, errors.New("collections: vector-index state missing adjacency uint32_list assets")
+	}
+	expectedLayers := graph.AdjacencyLayerCount
+	if expectedLayers <= 0 {
+		expectedLayers = maxLayer + 1
+	}
+	if len(seen) != expectedLayers {
+		return nil, typeddecode.ReasonValidationFailed, fmt.Errorf("collections: vector-index state adjacency layers=%d want %d", len(seen), expectedLayers)
+	}
+	assets := make([]columnVectorIndexStateAssetSnapshot, expectedLayers)
+	for _, asset := range state.Assets {
+		if asset.Role != columnVectorIndexStateAssetRoleAdjacency {
+			continue
+		}
+		layer, _ := columnVectorIndexStateAdjacencyLayerFromAssetID(asset.AssetID)
+		if layer < 0 || layer >= expectedLayers {
+			return nil, typeddecode.ReasonValidationFailed, fmt.Errorf("collections: vector-index state adjacency layer=%d outside expected layers=%d", layer, expectedLayers)
+		}
+		assets[layer] = asset
+	}
+	for layer := 0; layer < expectedLayers; layer++ {
+		if assets[layer].Role == "" {
+			return nil, typeddecode.ReasonValidationFailed, fmt.Errorf("collections: vector-index state missing adjacency layer %d", layer)
+		}
+	}
+	return assets, "", nil
+}
+
+func newColumnVectorGraphAdjacencyStateDirectSourceFromRoot(rootDir, collection string, cfg ColumnStoreConfig, def VectorIndexDefinition, graph columnVectorGraphManifestSnapshot, state columnVectorIndexStateSnapshot, asset columnVectorIndexStateAssetSnapshot, layer int) (*columnVectorGraphLayer0AdjacencyDirectSource, typeddecode.Reason, error) {
+	if asset.Role != columnVectorIndexStateAssetRoleAdjacency || asset.AssetID != columnVectorIndexStateAdjacencyAssetID(layer) || asset.LogicalType != columnVectorIndexStateLogicalTypeUint32List || asset.PhysicalEncoding != columnVectorIndexStateEncodingRawUint32List {
+		return nil, typeddecode.ReasonValidationFailed, fmt.Errorf("collections: column_graph %q adjacency state layer %d asset contract mismatch role=%q id=%q logical=%q physical=%q", def.Name, layer, asset.Role, asset.AssetID, asset.LogicalType, asset.PhysicalEncoding)
+	}
+	if asset.RowCount != graph.RowCount || asset.RowCount != state.RowCount || asset.Ref.Generation != graph.BaseManifestGeneration || asset.Ref.Namespace != cfg.AssetManager.Namespace || asset.Ref.Kind != ColumnAssetKindTCS1TypedColumnPart || asset.AssetBytes != asset.Ref.Length {
+		return nil, typeddecode.ReasonValidationFailed, fmt.Errorf("collections: column_graph %q adjacency state layer %d asset identity mismatch", def.Name, layer)
+	}
+	sourceCfg, adapterColumn, err := columnVectorIndexStateAdjacencyColumnStoreConfig(collection, cfg, def, layer)
+	if err != nil {
+		return nil, typeddecode.ReasonValidationFailed, err
+	}
+	if asset.SourceSchemaHash != sourceCfg.SchemaHash {
+		return nil, typeddecode.ReasonValidationFailed, fmt.Errorf("collections: column_graph %q adjacency state layer %d schema_hash=%d want %d", def.Name, layer, asset.SourceSchemaHash, sourceCfg.SchemaHash)
+	}
+	if err := validateColumnVectorIndexStateAssetRefAvailable(rootDir, asset); err != nil {
+		return nil, typeddecode.ReasonValidationFailed, err
+	}
+	raw, err := readColumnPhysicalAssetFromManager(rootDir, asset.Ref)
+	if err != nil {
+		return nil, typeddecode.ReasonValidationFailed, err
+	}
+	if int64(len(raw)) != asset.AssetBytes || int64(len(raw)) != asset.Ref.Length {
+		return nil, typeddecode.ReasonPayloadLengthMismatch, fmt.Errorf("collections: column_graph %q adjacency state layer %d bytes=%d manifest=%d ref=%d", def.Name, layer, len(raw), asset.AssetBytes, asset.Ref.Length)
+	}
+	image, err := typedcolumn.ParseColumnPartImage(raw)
+	if err != nil {
+		return nil, typeddecode.ReasonValidationFailed, err
+	}
+	if image.PartID != asset.Ref.PartID || image.Rows != asset.RowCount || image.Rows != state.RowCount {
+		return nil, typeddecode.ReasonRowCountMismatch, fmt.Errorf("collections: column_graph %q adjacency state layer %d image part/rows=(%d,%d) want (%d,%d)", def.Name, layer, image.PartID, image.Rows, asset.Ref.PartID, state.RowCount)
+	}
+	fields := columnStoreTypedColumnPartFields(sourceCfg)
+	adapterPart, err := typedColumnAdapterPartFromImageWithoutRowLocators(typedColumnAdapterOptions{Fields: fields, SchemaVersion: uint32(sourceCfg.SchemaHash)}, image)
+	if err != nil {
+		return nil, typeddecode.ReasonValidationFailed, err
+	}
+	if adapterPart.Part.Descriptor.SchemaVersion != uint32(sourceCfg.SchemaHash) {
+		return nil, typeddecode.ReasonValidationFailed, fmt.Errorf("collections: column_graph %q adjacency state layer %d schema_version=%d want %d", def.Name, layer, adapterPart.Part.Descriptor.SchemaVersion, uint32(sourceCfg.SchemaHash))
+	}
+	offsetsSection, valuesSection, ok := image.ColumnOffsetsListSections(adapterColumn.Definition.Name)
+	if !ok {
+		return nil, typeddecode.ReasonValidationFailed, fmt.Errorf("collections: column_graph %q adjacency state layer %d missing offsets-list sections for column %q", def.Name, layer, adapterColumn.Definition.Name)
+	}
+	wantOffsetsBytes, err := columnVectorIndexStateAdjacencyOffsetsBytes(state.RowCount)
+	if err != nil {
+		return nil, typeddecode.ReasonValidationFailed, err
+	}
+	if offsetsSection.Length != wantOffsetsBytes {
+		return nil, typeddecode.ReasonOffsetsCountMismatch, fmt.Errorf("collections: column_graph %q adjacency state layer %d offsets bytes=%d want %d", def.Name, layer, offsetsSection.Length, wantOffsetsBytes)
+	}
+	offsetsRaw, err := image.SectionBytes(offsetsSection)
+	if err != nil {
+		return nil, typeddecode.ReasonValidationFailed, err
+	}
+	valuesRaw, err := image.SectionBytes(valuesSection)
+	if err != nil {
+		return nil, typeddecode.ReasonValidationFailed, err
+	}
+	if err := validateColumnVectorIndexStateAdjacencySections(layer, offsetsSection, valuesSection, offsetsRaw, valuesRaw, state.RowCount); err != nil {
+		return nil, typeddecode.ReasonValidationFailed, err
+	}
+	certification, err := typedcolumn.CertifyColumnPartLayoutContractFromImage(image)
+	if err != nil {
+		return nil, typeddecode.ReasonValidationFailed, fmt.Errorf("collections: column_graph %q adjacency state layer %d layout certification: %w", def.Name, layer, err)
+	}
+	certColumn, ok := certification.Column(adapterColumn.Definition.Name)
+	if !ok {
+		return nil, typeddecode.ReasonValidationFailed, fmt.Errorf("collections: column_graph %q adjacency state layer %d missing layout certification for column %q", def.Name, layer, adapterColumn.Definition.Name)
+	}
+	if certColumn.LogicalType != columnVectorIndexStateLogicalTypeUint32List || certColumn.Type != typedcolumn.ColumnTypeUint32List || certColumn.Encoding != typedcolumn.EncodingRawUint32OffsetsList {
+		return nil, typeddecode.ReasonValidationFailed, fmt.Errorf("collections: column_graph %q adjacency state layer %d logical/type/encoding=(%q,%s,%s) want (%q,%s,%s)", def.Name, layer, certColumn.LogicalType, certColumn.Type, certColumn.Encoding, columnVectorIndexStateLogicalTypeUint32List, typedcolumn.ColumnTypeUint32List, typedcolumn.EncodingRawUint32OffsetsList)
+	}
+	plan := typeddecode.Uint32ListPlan(certColumn)
+	directReq := typeddecode.Uint32OffsetsListDirectViewRequest{
+		Plan:           plan,
+		Certification:  certColumn,
+		Rows:           state.RowCount,
+		OffsetsBytes:   offsetsSection.Length,
+		ValuesBytes:    valuesSection.Length,
+		AssetOffset:    asset.Ref.Offset,
+		HasAssetOffset: true,
+	}
+	manager := mappedresource.NewManager()
+	offsetsHandle, err := acquireColumnVectorGraphAdjacencyStateSection(rootDir, collection, asset.Ref, image.Version, offsetsSection, page.Checksum(offsetsRaw), manager, fmt.Sprintf("layer %d offsets", layer))
+	if err != nil {
+		return nil, typeddecode.ReasonValidationFailed, err
+	}
+	valuesHandle, err := acquireColumnVectorGraphAdjacencyStateSection(rootDir, collection, asset.Ref, image.Version, valuesSection, page.Checksum(valuesRaw), manager, fmt.Sprintf("layer %d values", layer))
+	if err != nil {
+		releaseErr := offsetsHandle.Release()
+		return nil, typeddecode.ReasonValidationFailed, errors.Join(err, releaseErr)
+	}
+	source, reason, err := columnVectorGraphTypedListAdjacencyDirectSourceFromHandles(manager, layer, state.RowCount, valuesSection.Length/4, directReq, offsetsHandle, valuesHandle)
+	if err != nil {
+		releaseErr := errors.Join(offsetsHandle.Release(), valuesHandle.Release())
+		return nil, reason, errors.Join(err, releaseErr)
+	}
+	source.captureResourceStats()
+	return source, "", nil
+}
+
+func acquireColumnVectorGraphAdjacencyStateSection(rootDir, collection string, ref ColumnAssetRef, imageVersion uint16, section typedcolumn.ColumnPartImageSection, checksum uint32, manager *mappedresource.Manager, label string) (*mappedresource.Handle, error) {
+	if manager == nil {
+		return nil, errors.New("collections: column_graph adjacency state requires mappedresource manager")
+	}
+	path, err := columnAssetSegmentPath(rootDir, ref)
+	if err != nil {
+		return nil, err
+	}
+	sectionOffset, err := columnVectorGraphTypedColumnSectionOffset(ref, section)
+	if err != nil {
+		return nil, err
+	}
+	key := mappedresource.Key{
+		Class:      mappedresource.ClassTypedColumnAsset,
+		Namespace:  ref.Namespace,
+		Kind:       string(ref.Kind),
+		Generation: ref.Generation,
+		PartID:     ref.PartID,
+		FileID:     ref.FileID,
+		Offset:     sectionOffset,
+		Length:     int64(section.Length),
+		Checksum:   uint64(checksum),
+		Version:    imageVersion,
+		Encoding:   section.Encoding.String(),
+		Section: mappedresource.Section{
+			Kind:     string(section.Kind),
+			Category: string(section.Category),
+			Name:     section.Name,
+			Column:   section.Column,
+		},
+	}
+	scope := mappedresource.Scope{Kind: mappedresource.ScopeColumnPartReader, ID: columnVectorGraphAdjacencyStateSourceScopeID, Collection: collection, Namespace: ref.Namespace, Generation: ref.Generation, Reason: "column_graph adjacency state"}
+	handle, err := manager.AcquireFileRange(key, scope, path, mappedresource.AcquireOptions{
+		Reason:         "column_graph adjacency state " + label,
+		ValidationMode: mappedresource.ValidationVerify,
+		PreferMapped:   true,
+		AllowHeapCopy:  true,
+		ResourceRoot:   rootDir,
+		ResourcePath:   path,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if got := page.Checksum(handle.Bytes()); got != checksum {
+		releaseErr := handle.Release()
+		return nil, errors.Join(fmt.Errorf("collections: column_graph adjacency state %s checksum=%d want %d", label, got, checksum), releaseErr)
+	}
+	return handle, nil
+}

--- a/TreeDB/collections/column_vector_graph_row_reader.go
+++ b/TreeDB/collections/column_vector_graph_row_reader.go
@@ -307,7 +307,10 @@ func (c *Collection) columnVectorGraphPhysicalRowReaderSnapshotViewAtSnapshot(na
 	if columnVectorIndexStateMatchStatusWithBaseChecksum(vectorState, def, *cfg, baseChecksum) != columnVectorIndexStateMatchLoaded || !columnVectorIndexStateMatchesGraph(vectorState, graph) {
 		return VectorIndexDefinition{}, columnVectorGraphManifestSnapshot{}, columnPhysicalScanSnapshotView{}, fmt.Errorf("collections: column_graph %q vector-index state does not match graph manifest: %w", def.Name, errColumnVectorGraphManifestMismatch)
 	}
-	if err := validateColumnVectorIndexStateAssets(c.db.ColumnAssetRootDir(), catalog.meta.Name, *cfg, def, vectorState, graph); err != nil {
+	// Keep snapshot-view validation cheap: this path is also used by status/open
+	// setup. The adjacency state source binder below performs the single full
+	// typed-list payload validation/read when it acquires offset/value sections.
+	if err := validateColumnVectorIndexStateAssetsForStatus(c.db.ColumnAssetRootDir(), catalog.meta.Name, *cfg, def, vectorState, graph); err != nil {
 		return VectorIndexDefinition{}, columnVectorGraphManifestSnapshot{}, columnPhysicalScanSnapshotView{}, err
 	}
 	if err := validateColumnVectorGraphInvNormStateAssetIfPresent(c.db.ColumnAssetRootDir(), catalog.meta.Name, *cfg, def, graph, vectorState); err != nil {

--- a/TreeDB/collections/column_vector_graph_row_reader.go
+++ b/TreeDB/collections/column_vector_graph_row_reader.go
@@ -136,37 +136,8 @@ func (c *Collection) openColumnVectorGraphPhysicalRowReaderAtSnapshot(name strin
 			baseManifestLoaded = true
 			return baseManifest, baseRecords, nil
 		}
-		var vectorState columnVectorIndexStateSnapshot
-		var vectorStateFound bool
-		var vectorStateLoaded bool
-		loadVectorIndexState := func() (columnVectorIndexStateSnapshot, bool, error) {
-			if vectorStateLoaded {
-				return vectorState, vectorStateFound, nil
-			}
-			_, records, recordsErr := loadBaseManifestRecords()
-			if recordsErr != nil {
-				return columnVectorIndexStateSnapshot{}, false, recordsErr
-			}
-			stateRecord, ok := findColumnVectorIndexStateRecord(records, def.Name)
-			if !ok {
-				vectorStateLoaded = true
-				return columnVectorIndexStateSnapshot{}, false, nil
-			}
-			state, stateErr := decodeColumnVectorIndexStateRecord(stateRecord.value)
-			if stateErr != nil {
-				return columnVectorIndexStateSnapshot{}, false, stateErr
-			}
-			vectorState = state
-			vectorStateFound = true
-			vectorStateLoaded = true
-			return vectorState, true, nil
-		}
-		state, stateFound, stateErr := loadVectorIndexState()
-		if stateErr != nil {
-			_ = graphReader.Close()
-			return nil, stateErr
-		}
-		if !stateFound {
+		state := view.VectorIndexState
+		if !view.VectorIndexStateFound {
 			_ = graphReader.Close()
 			return nil, fmt.Errorf("collections: column_graph %q missing vector-index state record: %w", def.Name, errColumnVectorGraphManifestMismatch)
 		}
@@ -334,11 +305,13 @@ func (c *Collection) columnVectorGraphPhysicalRowReaderSnapshotViewAtSnapshot(na
 		return VectorIndexDefinition{}, columnVectorGraphManifestSnapshot{}, columnPhysicalScanSnapshotView{}, backenddb.ErrClosed
 	}
 	view := columnPhysicalScanSnapshotView{
-		CollectionName:     catalog.meta.Name,
-		Catalog:            catalog,
-		Config:             graphCfg,
-		ColumnStoreEnabled: true,
-		CommitSeq:          state.CommitSeq,
+		CollectionName:        catalog.meta.Name,
+		Catalog:               catalog,
+		Config:                graphCfg,
+		ColumnStoreEnabled:    true,
+		CommitSeq:             state.CommitSeq,
+		VectorIndexState:      vectorState,
+		VectorIndexStateFound: true,
 		AssetRefs: []columnManifestAssetRefForScan{{
 			Ref:    graph.AssetRef,
 			Reason: ColumnPublishOperationInsert,

--- a/TreeDB/collections/column_vector_graph_row_reader.go
+++ b/TreeDB/collections/column_vector_graph_row_reader.go
@@ -136,43 +136,62 @@ func (c *Collection) openColumnVectorGraphPhysicalRowReaderAtSnapshot(name strin
 			baseManifestLoaded = true
 			return baseManifest, baseRecords, nil
 		}
-		if sources, fallbackReason, sourceErr := c.openColumnVectorGraphAdjacencyDirectSourcesForReader(catalog.meta.Name, *baseCfg, def, graph); sourceErr == nil && sources != nil {
+		var vectorState columnVectorIndexStateSnapshot
+		var vectorStateFound bool
+		var vectorStateLoaded bool
+		loadVectorIndexState := func() (columnVectorIndexStateSnapshot, bool, error) {
+			if vectorStateLoaded {
+				return vectorState, vectorStateFound, nil
+			}
+			_, records, recordsErr := loadBaseManifestRecords()
+			if recordsErr != nil {
+				return columnVectorIndexStateSnapshot{}, false, recordsErr
+			}
+			stateRecord, ok := findColumnVectorIndexStateRecord(records, def.Name)
+			if !ok {
+				vectorStateLoaded = true
+				return columnVectorIndexStateSnapshot{}, false, nil
+			}
+			state, stateErr := decodeColumnVectorIndexStateRecord(stateRecord.value)
+			if stateErr != nil {
+				return columnVectorIndexStateSnapshot{}, false, stateErr
+			}
+			vectorState = state
+			vectorStateFound = true
+			vectorStateLoaded = true
+			return vectorState, true, nil
+		}
+		state, stateFound, stateErr := loadVectorIndexState()
+		if stateErr != nil {
+			_ = graphReader.Close()
+			return nil, stateErr
+		}
+		if !stateFound {
+			_ = graphReader.Close()
+			return nil, fmt.Errorf("collections: column_graph %q missing vector-index state record: %w", def.Name, errColumnVectorGraphManifestMismatch)
+		}
+		if sources, _, sourceErr := c.openColumnVectorGraphAdjacencyStateSourcesForReader(catalog.meta.Name, *baseCfg, def, graph, state); sourceErr != nil {
+			_ = graphReader.Close()
+			return nil, sourceErr
+		} else if sources != nil {
 			graphReader.adjacencyLayerSources = sources
 			if len(sources.sources) > 0 {
 				graphReader.layer0AdjacencySource = sources.sources[0]
 			}
-		} else if len(graph.AdjacencyLayerSources) > 0 || graph.Layer0AdjacencySource.Present {
-			if fallbackReason == "" {
-				fallbackReason = typeddecode.ReasonValidationFailed
-			}
-			graphReader.layer0AdjacencySourceFallbackReason = fallbackReason
 		} else {
-			graphReader.layer0AdjacencySourceUnavailable = true
+			_ = graphReader.Close()
+			return nil, fmt.Errorf("collections: column_graph %q missing vector-index adjacency state source: %w", def.Name, errColumnVectorGraphManifestMismatch)
 		}
-		if _, records, recordsErr := loadBaseManifestRecords(); recordsErr == nil {
-			if stateRecord, ok := findColumnVectorIndexStateRecord(records, def.Name); ok {
-				state, stateErr := decodeColumnVectorIndexStateRecord(stateRecord.value)
-				if stateErr != nil {
-					_ = graphReader.Close()
-					return nil, stateErr
-				}
-				if _, ok := findColumnVectorGraphInvNormStateAsset(state); ok {
-					source, fallbackReason, sourceErr := c.openColumnVectorGraphInvNormStateSourceForReader(catalog.meta.Name, *baseCfg, def, graph, state)
-					if sourceErr != nil {
-						_ = graphReader.Close()
-						return nil, sourceErr
-					}
-					graphReader.invNormSource = source
-					graphReader.invNormStateFallbackReason = fallbackReason
-				} else {
-					graphReader.invNormStateUnavailable = true
-				}
-			} else {
-				graphReader.invNormStateUnavailable = true
+		if _, ok := findColumnVectorGraphInvNormStateAsset(state); ok {
+			source, fallbackReason, sourceErr := c.openColumnVectorGraphInvNormStateSourceForReader(catalog.meta.Name, *baseCfg, def, graph, state)
+			if sourceErr != nil {
+				_ = graphReader.Close()
+				return nil, sourceErr
 			}
+			graphReader.invNormSource = source
+			graphReader.invNormStateFallbackReason = fallbackReason
 		} else {
 			graphReader.invNormStateUnavailable = true
-			graphReader.invNormStateFallbackReason = typeddecode.ReasonValidationFailed
 		}
 		if _, _, typedVectorOwner, ownerErr := columnVectorGraphTypedColumnVectorField(*baseCfg, graph.Field, graph.Dimensions); ownerErr != nil {
 			graphReader.typedVectorFallbackReason = ownerErr.Error()

--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -41,11 +41,15 @@ type columnVectorGraphNativeSearchOptions struct {
 }
 
 type columnVectorGraphAdjacencySourceCounterSnapshot struct {
-	AdjacencyBytesRead          uint64
-	AdjacencyDirectViews        uint64
-	AdjacencyMmapDirectViews    uint64
-	AdjacencyHeapCopyTypedViews uint64
-	AdjacencyScratchDecodes     uint64
+	AdjacencyBytesRead                   uint64
+	AdjacencyDirectViews                 uint64
+	AdjacencyMmapDirectViews             uint64
+	AdjacencyHeapCopyTypedViews          uint64
+	AdjacencyScratchDecodes              uint64
+	AdjacencyTypedListDirectViews        uint64
+	AdjacencyTypedListMmapDirectViews    uint64
+	AdjacencyTypedListHeapCopyTypedViews uint64
+	AdjacencyTypedListScratchDecodes     uint64
 }
 
 func (c *columnVectorGraphAdjacencySourceCounterSnapshot) addOutcome(adjacencyLen int, outcome columnVectorGraphLayer0AdjacencySourceOutcome) {
@@ -59,6 +63,19 @@ func (c *columnVectorGraphAdjacencySourceCounterSnapshot) addOutcome(adjacencyLe
 		c.AdjacencyMmapDirectViews++
 	case columnVectorGraphLayer0AdjacencySourceOutcomeHeapCopyTypedView:
 		c.AdjacencyHeapCopyTypedViews++
+	case columnVectorGraphLayer0AdjacencySourceOutcomeTypedListMmapDirect:
+		c.AdjacencyDirectViews++
+		c.AdjacencyMmapDirectViews++
+		c.AdjacencyTypedListDirectViews++
+		c.AdjacencyTypedListMmapDirectViews++
+	case columnVectorGraphLayer0AdjacencySourceOutcomeTypedListHeapCopyTypedView:
+		c.AdjacencyHeapCopyTypedViews++
+		c.AdjacencyTypedListHeapCopyTypedViews++
+	case columnVectorGraphLayer0AdjacencySourceOutcomeTypedListScratchDecode:
+		if adjacencyLen > 0 {
+			c.AdjacencyScratchDecodes++
+			c.AdjacencyTypedListScratchDecodes++
+		}
 	default:
 		if adjacencyLen > 0 {
 			c.AdjacencyScratchDecodes++
@@ -67,62 +84,68 @@ func (c *columnVectorGraphAdjacencySourceCounterSnapshot) addOutcome(adjacencyLe
 }
 
 type columnVectorGraphNativeSearchStats struct {
-	CandidateRows                    uint64
-	Candidates                       uint64
-	Edges                            uint64
-	VisitedNodes                     uint64
-	VisitedEdges                     uint64
-	VectorBytesRead                  uint64
-	NormBytesRead                    uint64
-	AdjacencyBytesRead               uint64
-	CandidateFetches                 uint64
-	ExpansionFetches                 uint64
-	ResultFetches                    uint64
-	ScoreBatches                     uint64
-	OrdinalsGrouped                  uint64
-	BlockViewHits                    uint64
-	BlockViewMisses                  uint64
-	BlockViewBuilds                  uint64
-	AdjacencyExpansions              uint64
-	AdjacencyScratchDecodes          uint64
-	AdjacencyDirectViews             uint64
-	AdjacencyMmapDirectViews         uint64
-	AdjacencyHeapCopyTypedViews      uint64
-	AdjacencySourceUnavailable       uint64
-	AdjacencySourceFallbacks         uint64
-	AdjacencyCertificationFailures   uint64
-	AdjacencyAbsoluteOffsetUnaligned uint64
-	AdjacencyActualPointerUnaligned  uint64
-	AdjacencyStaleHandles            uint64
-	NormDirectViews                  uint64
-	NormMmapDirectViews              uint64
-	NormHeapCopyTypedViews           uint64
-	NormScratchDecodes               uint64
-	NormSourceUnavailable            uint64
-	NormSourceFallbacks              uint64
-	NormValidationFailures           uint64
-	NormAbsoluteOffsetUnaligned      uint64
-	NormActualPointerUnaligned       uint64
-	NormStaleHandles                 uint64
-	NormMappedBytes                  uint64
-	NormHeapCopyBytes                uint64
-	NormDecodedBytes                 uint64
-	NormActiveHandles                int64
-	NormDeniedResources              uint64
-	VectorDirectViews                uint64
-	VectorMmapDirectViews            uint64
-	VectorHeapCopyTypedViews         uint64
-	VectorScratchDecodes             uint64
-	VectorCertificationFailures      uint64
-	VectorAbsoluteOffsetUnaligned    uint64
-	VectorActualPointerUnaligned     uint64
-	VectorStaleHandles               uint64
-	TypedColumnMappedBytes           uint64
-	TypedColumnHeapCopyBytes         uint64
-	TypedColumnDecodedBytes          uint64
-	TypedColumnActiveHandles         int64
-	TypedColumnDeniedResources       uint64
-	TypedColumnFallbacks             uint64
+	CandidateRows                        uint64
+	Candidates                           uint64
+	Edges                                uint64
+	VisitedNodes                         uint64
+	VisitedEdges                         uint64
+	VectorBytesRead                      uint64
+	NormBytesRead                        uint64
+	AdjacencyBytesRead                   uint64
+	CandidateFetches                     uint64
+	ExpansionFetches                     uint64
+	ResultFetches                        uint64
+	ScoreBatches                         uint64
+	OrdinalsGrouped                      uint64
+	BlockViewHits                        uint64
+	BlockViewMisses                      uint64
+	BlockViewBuilds                      uint64
+	AdjacencyExpansions                  uint64
+	AdjacencyScratchDecodes              uint64
+	AdjacencyDirectViews                 uint64
+	AdjacencyMmapDirectViews             uint64
+	AdjacencyHeapCopyTypedViews          uint64
+	AdjacencyTypedListDirectViews        uint64
+	AdjacencyTypedListMmapDirectViews    uint64
+	AdjacencyTypedListHeapCopyTypedViews uint64
+	AdjacencyTypedListScratchDecodes     uint64
+	AdjacencyLegacyFallbacks             uint64
+	AdjacencySourceUnavailable           uint64
+	AdjacencySourceFallbacks             uint64
+	AdjacencyCertificationFailures       uint64
+	AdjacencyValidationFailures          uint64
+	AdjacencyAbsoluteOffsetUnaligned     uint64
+	AdjacencyActualPointerUnaligned      uint64
+	AdjacencyStaleHandles                uint64
+	NormDirectViews                      uint64
+	NormMmapDirectViews                  uint64
+	NormHeapCopyTypedViews               uint64
+	NormScratchDecodes                   uint64
+	NormSourceUnavailable                uint64
+	NormSourceFallbacks                  uint64
+	NormValidationFailures               uint64
+	NormAbsoluteOffsetUnaligned          uint64
+	NormActualPointerUnaligned           uint64
+	NormStaleHandles                     uint64
+	NormMappedBytes                      uint64
+	NormHeapCopyBytes                    uint64
+	NormDecodedBytes                     uint64
+	NormActiveHandles                    int64
+	NormDeniedResources                  uint64
+	VectorDirectViews                    uint64
+	VectorMmapDirectViews                uint64
+	VectorHeapCopyTypedViews             uint64
+	VectorScratchDecodes                 uint64
+	VectorCertificationFailures          uint64
+	VectorAbsoluteOffsetUnaligned        uint64
+	VectorActualPointerUnaligned         uint64
+	VectorStaleHandles                   uint64
+	TypedColumnMappedBytes               uint64
+	TypedColumnHeapCopyBytes             uint64
+	TypedColumnDecodedBytes              uint64
+	TypedColumnActiveHandles             int64
+	TypedColumnDeniedResources           uint64
+	TypedColumnFallbacks                 uint64
 }
 
 // columnVectorGraphNativeSearchResult aliases buffers owned by the search
@@ -770,6 +793,7 @@ func recordColumnVectorGraphAdjacencySourceStats(stats *columnVectorGraphNativeS
 		return
 	}
 	stats.AdjacencyBytesRead += uint64(adjacencyLen) * 4
+	stats.AdjacencyLegacyFallbacks++
 	if adjacencyLen == 0 {
 		return
 	}
@@ -795,6 +819,10 @@ func recordColumnVectorGraphAdjacencySourceCounterSnapshotStats(stats *columnVec
 	stats.AdjacencyMmapDirectViews += counters.AdjacencyMmapDirectViews
 	stats.AdjacencyHeapCopyTypedViews += counters.AdjacencyHeapCopyTypedViews
 	stats.AdjacencyScratchDecodes += counters.AdjacencyScratchDecodes
+	stats.AdjacencyTypedListDirectViews += counters.AdjacencyTypedListDirectViews
+	stats.AdjacencyTypedListMmapDirectViews += counters.AdjacencyTypedListMmapDirectViews
+	stats.AdjacencyTypedListHeapCopyTypedViews += counters.AdjacencyTypedListHeapCopyTypedViews
+	stats.AdjacencyTypedListScratchDecodes += counters.AdjacencyTypedListScratchDecodes
 }
 
 func recordColumnVectorGraphAdjacencyFallbackReasonStats(stats *columnVectorGraphNativeSearchStats, reason typeddecode.Reason) {
@@ -810,6 +838,7 @@ func recordColumnVectorGraphAdjacencyFallbackReasonStats(stats *columnVectorGrap
 		stats.AdjacencyStaleHandles++
 	case typeddecode.ReasonNotWriterCertified, typeddecode.ReasonWrongEndian, typeddecode.ReasonLengthMultipleMismatch, typeddecode.ReasonPayloadLengthMismatch, typeddecode.ReasonRowCountMismatch, typeddecode.ReasonDimensionMismatch, typeddecode.ReasonCompressed, typeddecode.ReasonNullableWrapper, typeddecode.ReasonValidationFailed, typeddecode.ReasonOffsetsCountMismatch, typeddecode.ReasonOffsetsStartMismatch, typeddecode.ReasonOffsetsNonMonotonic, typeddecode.ReasonOffsetsGoIntRange, typeddecode.ReasonValuesLengthMismatch:
 		stats.AdjacencyCertificationFailures++
+		stats.AdjacencyValidationFailures++
 	}
 }
 

--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -836,9 +836,10 @@ func recordColumnVectorGraphAdjacencyFallbackReasonStats(stats *columnVectorGrap
 		stats.AdjacencyActualPointerUnaligned++
 	case typeddecode.ReasonNilHandle, typeddecode.ReasonStaleHandle:
 		stats.AdjacencyStaleHandles++
-	case typeddecode.ReasonNotWriterCertified, typeddecode.ReasonWrongEndian, typeddecode.ReasonLengthMultipleMismatch, typeddecode.ReasonPayloadLengthMismatch, typeddecode.ReasonRowCountMismatch, typeddecode.ReasonDimensionMismatch, typeddecode.ReasonCompressed, typeddecode.ReasonNullableWrapper, typeddecode.ReasonValidationFailed, typeddecode.ReasonOffsetsCountMismatch, typeddecode.ReasonOffsetsStartMismatch, typeddecode.ReasonOffsetsNonMonotonic, typeddecode.ReasonOffsetsGoIntRange, typeddecode.ReasonValuesLengthMismatch:
-		stats.AdjacencyCertificationFailures++
+	case typeddecode.ReasonValidationFailed:
 		stats.AdjacencyValidationFailures++
+	case typeddecode.ReasonNotWriterCertified, typeddecode.ReasonWrongEndian, typeddecode.ReasonLengthMultipleMismatch, typeddecode.ReasonPayloadLengthMismatch, typeddecode.ReasonRowCountMismatch, typeddecode.ReasonDimensionMismatch, typeddecode.ReasonCompressed, typeddecode.ReasonNullableWrapper, typeddecode.ReasonOffsetsCountMismatch, typeddecode.ReasonOffsetsStartMismatch, typeddecode.ReasonOffsetsNonMonotonic, typeddecode.ReasonOffsetsGoIntRange, typeddecode.ReasonValuesLengthMismatch:
+		stats.AdjacencyCertificationFailures++
 	}
 }
 

--- a/TreeDB/collections/column_vector_graph_search_test.go
+++ b/TreeDB/collections/column_vector_graph_search_test.go
@@ -314,22 +314,24 @@ func TestColumnVectorGraphNativeSearchCandidateCarriesNoAdjacencyV3(t *testing.T
 }
 
 func TestColumnVectorGraphNativeSearchRejectsBadAdjacencyOrdinalV3(t *testing.T) {
-	rows := []columnVectorGraphAssetRow{
-		{ID: []byte("doc-start"), Vector: []float32{1, 0, 0}, InvNorm: 1, Adjacency: []uint32{2}},
-		{ID: []byte("doc-other"), Vector: []float32{0, 1, 0}, InvNorm: 1, Adjacency: []uint32{0}},
-	}
-	d, col, def := publishColumnVectorGraphPhysicalReaderTestAssetV2B(t, rows)
+	d := openCollectionCommandWALDB(t, t.TempDir())
 	defer func() { _ = d.Close() }()
-	reader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
+	ctx := makeColumnVectorIndexStateAdjacencyStatusContext1987(t, d)
+	bad := writeUncheckedColumnVectorIndexStateAdjacencyAsset1987(t, d, *ctx.cfg, ctx.def, ctx.identity.Generation, 500, 0, typedcolumn.Uint32List{Rows: 2, Offsets: []uint64{0, 1, 1}, Values: []uint32{2}}, nil)
+	ctx.state.Assets[0] = bad
+	ctx.records, ctx.identity = appendVectorIndexStateRecordForTest1986(t, *ctx.cfg, ctx.records, ctx.identity, ctx.state)
+	publishColumnVectorIndexStateAdjacencyContext1987(t, d, ctx)
+	col, err := NewCollectionManager(d).OpenCollection("docs")
 	if err != nil {
-		t.Fatalf("openColumnVectorGraphPhysicalRowReader: %v", err)
+		t.Fatalf("OpenCollection: %v", err)
 	}
-	defer func() { _ = reader.Close() }()
-
-	var scratch columnVectorGraphNativeSearchScratch
-	_, _, err = reader.SearchCosine([]float32{1, 0, 0}, columnVectorGraphNativeSearchOptions{TopK: 1, EfSearch: 2}, &scratch)
+	reader, err := col.openColumnVectorGraphPhysicalRowReader(ctx.def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
+	if err == nil {
+		_ = reader.Close()
+		t.Fatalf("openColumnVectorGraphPhysicalRowReader err=nil want typed adjacency state ordinal validation failure")
+	}
 	if !errors.Is(err, errColumnVectorGraphAdjacencyOrdinalOutOfBounds) {
-		t.Fatalf("SearchCosine err=%v want adjacency bounds sentinel", err)
+		t.Fatalf("openColumnVectorGraphPhysicalRowReader err=%v want adjacency bounds sentinel", err)
 	}
 }
 
@@ -862,9 +864,15 @@ func benchmarkColumnVectorGraphNativeSearchCosineV3(b *testing.B, shape columnVe
 		searchStats.AdjacencyDirectViews += stats.AdjacencyDirectViews
 		searchStats.AdjacencyMmapDirectViews += stats.AdjacencyMmapDirectViews
 		searchStats.AdjacencyHeapCopyTypedViews += stats.AdjacencyHeapCopyTypedViews
+		searchStats.AdjacencyTypedListDirectViews += stats.AdjacencyTypedListDirectViews
+		searchStats.AdjacencyTypedListMmapDirectViews += stats.AdjacencyTypedListMmapDirectViews
+		searchStats.AdjacencyTypedListHeapCopyTypedViews += stats.AdjacencyTypedListHeapCopyTypedViews
+		searchStats.AdjacencyTypedListScratchDecodes += stats.AdjacencyTypedListScratchDecodes
+		searchStats.AdjacencyLegacyFallbacks += stats.AdjacencyLegacyFallbacks
 		searchStats.AdjacencySourceUnavailable += stats.AdjacencySourceUnavailable
 		searchStats.AdjacencySourceFallbacks += stats.AdjacencySourceFallbacks
 		searchStats.AdjacencyCertificationFailures += stats.AdjacencyCertificationFailures
+		searchStats.AdjacencyValidationFailures += stats.AdjacencyValidationFailures
 		searchStats.AdjacencyAbsoluteOffsetUnaligned += stats.AdjacencyAbsoluteOffsetUnaligned
 		searchStats.AdjacencyActualPointerUnaligned += stats.AdjacencyActualPointerUnaligned
 		searchStats.AdjacencyStaleHandles += stats.AdjacencyStaleHandles
@@ -999,9 +1007,15 @@ func benchmarkColumnVectorGraphNativeSearchCosineParallelV3(b *testing.B, shape 
 	var totalAdjacencyDirectViews atomic.Uint64
 	var totalAdjacencyMmapDirectViews atomic.Uint64
 	var totalAdjacencyHeapCopyTypedViews atomic.Uint64
+	var totalAdjacencyTypedListDirectViews atomic.Uint64
+	var totalAdjacencyTypedListMmapDirectViews atomic.Uint64
+	var totalAdjacencyTypedListHeapCopyTypedViews atomic.Uint64
+	var totalAdjacencyTypedListScratchDecodes atomic.Uint64
+	var totalAdjacencyLegacyFallbacks atomic.Uint64
 	var totalAdjacencySourceUnavailable atomic.Uint64
 	var totalAdjacencySourceFallbacks atomic.Uint64
 	var totalAdjacencyCertificationFailures atomic.Uint64
+	var totalAdjacencyValidationFailures atomic.Uint64
 	var totalAdjacencyAbsoluteOffsetUnaligned atomic.Uint64
 	var totalAdjacencyActualPointerUnaligned atomic.Uint64
 	var totalAdjacencyStaleHandles atomic.Uint64
@@ -1084,9 +1098,15 @@ func benchmarkColumnVectorGraphNativeSearchCosineParallelV3(b *testing.B, shape 
 			localStats.AdjacencyDirectViews += stats.AdjacencyDirectViews
 			localStats.AdjacencyMmapDirectViews += stats.AdjacencyMmapDirectViews
 			localStats.AdjacencyHeapCopyTypedViews += stats.AdjacencyHeapCopyTypedViews
+			localStats.AdjacencyTypedListDirectViews += stats.AdjacencyTypedListDirectViews
+			localStats.AdjacencyTypedListMmapDirectViews += stats.AdjacencyTypedListMmapDirectViews
+			localStats.AdjacencyTypedListHeapCopyTypedViews += stats.AdjacencyTypedListHeapCopyTypedViews
+			localStats.AdjacencyTypedListScratchDecodes += stats.AdjacencyTypedListScratchDecodes
+			localStats.AdjacencyLegacyFallbacks += stats.AdjacencyLegacyFallbacks
 			localStats.AdjacencySourceUnavailable += stats.AdjacencySourceUnavailable
 			localStats.AdjacencySourceFallbacks += stats.AdjacencySourceFallbacks
 			localStats.AdjacencyCertificationFailures += stats.AdjacencyCertificationFailures
+			localStats.AdjacencyValidationFailures += stats.AdjacencyValidationFailures
 			localStats.AdjacencyAbsoluteOffsetUnaligned += stats.AdjacencyAbsoluteOffsetUnaligned
 			localStats.AdjacencyActualPointerUnaligned += stats.AdjacencyActualPointerUnaligned
 			localStats.AdjacencyStaleHandles += stats.AdjacencyStaleHandles
@@ -1142,9 +1162,15 @@ func benchmarkColumnVectorGraphNativeSearchCosineParallelV3(b *testing.B, shape 
 		totalAdjacencyDirectViews.Add(localStats.AdjacencyDirectViews)
 		totalAdjacencyMmapDirectViews.Add(localStats.AdjacencyMmapDirectViews)
 		totalAdjacencyHeapCopyTypedViews.Add(localStats.AdjacencyHeapCopyTypedViews)
+		totalAdjacencyTypedListDirectViews.Add(localStats.AdjacencyTypedListDirectViews)
+		totalAdjacencyTypedListMmapDirectViews.Add(localStats.AdjacencyTypedListMmapDirectViews)
+		totalAdjacencyTypedListHeapCopyTypedViews.Add(localStats.AdjacencyTypedListHeapCopyTypedViews)
+		totalAdjacencyTypedListScratchDecodes.Add(localStats.AdjacencyTypedListScratchDecodes)
+		totalAdjacencyLegacyFallbacks.Add(localStats.AdjacencyLegacyFallbacks)
 		totalAdjacencySourceUnavailable.Add(localStats.AdjacencySourceUnavailable)
 		totalAdjacencySourceFallbacks.Add(localStats.AdjacencySourceFallbacks)
 		totalAdjacencyCertificationFailures.Add(localStats.AdjacencyCertificationFailures)
+		totalAdjacencyValidationFailures.Add(localStats.AdjacencyValidationFailures)
 		totalAdjacencyAbsoluteOffsetUnaligned.Add(localStats.AdjacencyAbsoluteOffsetUnaligned)
 		totalAdjacencyActualPointerUnaligned.Add(localStats.AdjacencyActualPointerUnaligned)
 		totalAdjacencyStaleHandles.Add(localStats.AdjacencyStaleHandles)
@@ -1190,62 +1216,68 @@ func benchmarkColumnVectorGraphNativeSearchCosineParallelV3(b *testing.B, shape 
 		stats = addColumnPhysicalRowReaderStatsV3(stats, worker.reader.Stats())
 	}
 	reportColumnGraphNativeSearchBenchMetricsV3(b, b.N, baseStats, stats, columnVectorGraphNativeSearchStats{
-		CandidateRows:                    totalCandidateRows.Load(),
-		Candidates:                       totalCandidates.Load(),
-		Edges:                            totalEdges.Load(),
-		VisitedNodes:                     totalVisitedNodes.Load(),
-		VisitedEdges:                     totalVisitedEdges.Load(),
-		VectorBytesRead:                  totalVectorBytesRead.Load(),
-		NormBytesRead:                    totalNormBytesRead.Load(),
-		AdjacencyBytesRead:               totalAdjacencyBytesRead.Load(),
-		CandidateFetches:                 totalCandidateFetches.Load(),
-		ExpansionFetches:                 totalExpansionFetches.Load(),
-		ResultFetches:                    totalResultFetches.Load(),
-		ScoreBatches:                     totalScoreBatches.Load(),
-		OrdinalsGrouped:                  totalOrdinalsGrouped.Load(),
-		BlockViewHits:                    totalBlockViewHits.Load(),
-		BlockViewMisses:                  totalBlockViewMisses.Load(),
-		BlockViewBuilds:                  totalBlockViewBuilds.Load(),
-		AdjacencyExpansions:              totalAdjacencyExpansions.Load(),
-		AdjacencyScratchDecodes:          totalAdjacencyScratchDecodes.Load(),
-		AdjacencyDirectViews:             totalAdjacencyDirectViews.Load(),
-		AdjacencyMmapDirectViews:         totalAdjacencyMmapDirectViews.Load(),
-		AdjacencyHeapCopyTypedViews:      totalAdjacencyHeapCopyTypedViews.Load(),
-		AdjacencySourceUnavailable:       totalAdjacencySourceUnavailable.Load(),
-		AdjacencySourceFallbacks:         totalAdjacencySourceFallbacks.Load(),
-		AdjacencyCertificationFailures:   totalAdjacencyCertificationFailures.Load(),
-		AdjacencyAbsoluteOffsetUnaligned: totalAdjacencyAbsoluteOffsetUnaligned.Load(),
-		AdjacencyActualPointerUnaligned:  totalAdjacencyActualPointerUnaligned.Load(),
-		AdjacencyStaleHandles:            totalAdjacencyStaleHandles.Load(),
-		NormDirectViews:                  totalNormDirectViews.Load(),
-		NormMmapDirectViews:              totalNormMmapDirectViews.Load(),
-		NormHeapCopyTypedViews:           totalNormHeapCopyTypedViews.Load(),
-		NormScratchDecodes:               totalNormScratchDecodes.Load(),
-		NormSourceUnavailable:            totalNormSourceUnavailable.Load(),
-		NormSourceFallbacks:              totalNormSourceFallbacks.Load(),
-		NormValidationFailures:           totalNormValidationFailures.Load(),
-		NormAbsoluteOffsetUnaligned:      totalNormAbsoluteOffsetUnaligned.Load(),
-		NormActualPointerUnaligned:       totalNormActualPointerUnaligned.Load(),
-		NormStaleHandles:                 totalNormStaleHandles.Load(),
-		NormMappedBytes:                  totalNormMappedBytes.Load(),
-		NormHeapCopyBytes:                totalNormHeapCopyBytes.Load(),
-		NormDecodedBytes:                 totalNormDecodedBytes.Load(),
-		NormActiveHandles:                totalNormActiveHandles.Load(),
-		NormDeniedResources:              totalNormDeniedResources.Load(),
-		VectorDirectViews:                totalVectorDirectViews.Load(),
-		VectorMmapDirectViews:            totalVectorMmapDirectViews.Load(),
-		VectorHeapCopyTypedViews:         totalVectorHeapCopyTypedViews.Load(),
-		VectorScratchDecodes:             totalVectorScratchDecodes.Load(),
-		VectorCertificationFailures:      totalVectorCertificationFailures.Load(),
-		VectorAbsoluteOffsetUnaligned:    totalVectorAbsoluteOffsetUnaligned.Load(),
-		VectorActualPointerUnaligned:     totalVectorActualPointerUnaligned.Load(),
-		VectorStaleHandles:               totalVectorStaleHandles.Load(),
-		TypedColumnMappedBytes:           totalTypedColumnMappedBytes.Load(),
-		TypedColumnHeapCopyBytes:         totalTypedColumnHeapCopyBytes.Load(),
-		TypedColumnDecodedBytes:          totalTypedColumnDecodedBytes.Load(),
-		TypedColumnActiveHandles:         totalTypedColumnActiveHandles.Load(),
-		TypedColumnDeniedResources:       totalTypedColumnDeniedResources.Load(),
-		TypedColumnFallbacks:             totalTypedColumnFallbacks.Load(),
+		CandidateRows:                        totalCandidateRows.Load(),
+		Candidates:                           totalCandidates.Load(),
+		Edges:                                totalEdges.Load(),
+		VisitedNodes:                         totalVisitedNodes.Load(),
+		VisitedEdges:                         totalVisitedEdges.Load(),
+		VectorBytesRead:                      totalVectorBytesRead.Load(),
+		NormBytesRead:                        totalNormBytesRead.Load(),
+		AdjacencyBytesRead:                   totalAdjacencyBytesRead.Load(),
+		CandidateFetches:                     totalCandidateFetches.Load(),
+		ExpansionFetches:                     totalExpansionFetches.Load(),
+		ResultFetches:                        totalResultFetches.Load(),
+		ScoreBatches:                         totalScoreBatches.Load(),
+		OrdinalsGrouped:                      totalOrdinalsGrouped.Load(),
+		BlockViewHits:                        totalBlockViewHits.Load(),
+		BlockViewMisses:                      totalBlockViewMisses.Load(),
+		BlockViewBuilds:                      totalBlockViewBuilds.Load(),
+		AdjacencyExpansions:                  totalAdjacencyExpansions.Load(),
+		AdjacencyScratchDecodes:              totalAdjacencyScratchDecodes.Load(),
+		AdjacencyDirectViews:                 totalAdjacencyDirectViews.Load(),
+		AdjacencyMmapDirectViews:             totalAdjacencyMmapDirectViews.Load(),
+		AdjacencyHeapCopyTypedViews:          totalAdjacencyHeapCopyTypedViews.Load(),
+		AdjacencyTypedListDirectViews:        totalAdjacencyTypedListDirectViews.Load(),
+		AdjacencyTypedListMmapDirectViews:    totalAdjacencyTypedListMmapDirectViews.Load(),
+		AdjacencyTypedListHeapCopyTypedViews: totalAdjacencyTypedListHeapCopyTypedViews.Load(),
+		AdjacencyTypedListScratchDecodes:     totalAdjacencyTypedListScratchDecodes.Load(),
+		AdjacencyLegacyFallbacks:             totalAdjacencyLegacyFallbacks.Load(),
+		AdjacencySourceUnavailable:           totalAdjacencySourceUnavailable.Load(),
+		AdjacencySourceFallbacks:             totalAdjacencySourceFallbacks.Load(),
+		AdjacencyCertificationFailures:       totalAdjacencyCertificationFailures.Load(),
+		AdjacencyValidationFailures:          totalAdjacencyValidationFailures.Load(),
+		AdjacencyAbsoluteOffsetUnaligned:     totalAdjacencyAbsoluteOffsetUnaligned.Load(),
+		AdjacencyActualPointerUnaligned:      totalAdjacencyActualPointerUnaligned.Load(),
+		AdjacencyStaleHandles:                totalAdjacencyStaleHandles.Load(),
+		NormDirectViews:                      totalNormDirectViews.Load(),
+		NormMmapDirectViews:                  totalNormMmapDirectViews.Load(),
+		NormHeapCopyTypedViews:               totalNormHeapCopyTypedViews.Load(),
+		NormScratchDecodes:                   totalNormScratchDecodes.Load(),
+		NormSourceUnavailable:                totalNormSourceUnavailable.Load(),
+		NormSourceFallbacks:                  totalNormSourceFallbacks.Load(),
+		NormValidationFailures:               totalNormValidationFailures.Load(),
+		NormAbsoluteOffsetUnaligned:          totalNormAbsoluteOffsetUnaligned.Load(),
+		NormActualPointerUnaligned:           totalNormActualPointerUnaligned.Load(),
+		NormStaleHandles:                     totalNormStaleHandles.Load(),
+		NormMappedBytes:                      totalNormMappedBytes.Load(),
+		NormHeapCopyBytes:                    totalNormHeapCopyBytes.Load(),
+		NormDecodedBytes:                     totalNormDecodedBytes.Load(),
+		NormActiveHandles:                    totalNormActiveHandles.Load(),
+		NormDeniedResources:                  totalNormDeniedResources.Load(),
+		VectorDirectViews:                    totalVectorDirectViews.Load(),
+		VectorMmapDirectViews:                totalVectorMmapDirectViews.Load(),
+		VectorHeapCopyTypedViews:             totalVectorHeapCopyTypedViews.Load(),
+		VectorScratchDecodes:                 totalVectorScratchDecodes.Load(),
+		VectorCertificationFailures:          totalVectorCertificationFailures.Load(),
+		VectorAbsoluteOffsetUnaligned:        totalVectorAbsoluteOffsetUnaligned.Load(),
+		VectorActualPointerUnaligned:         totalVectorActualPointerUnaligned.Load(),
+		VectorStaleHandles:                   totalVectorStaleHandles.Load(),
+		TypedColumnMappedBytes:               totalTypedColumnMappedBytes.Load(),
+		TypedColumnHeapCopyBytes:             totalTypedColumnHeapCopyBytes.Load(),
+		TypedColumnDecodedBytes:              totalTypedColumnDecodedBytes.Load(),
+		TypedColumnActiveHandles:             totalTypedColumnActiveHandles.Load(),
+		TypedColumnDeniedResources:           totalTypedColumnDeniedResources.Load(),
+		TypedColumnFallbacks:                 totalTypedColumnFallbacks.Load(),
 	})
 }
 
@@ -1503,9 +1535,15 @@ func reportColumnGraphNativeSearchBenchMetricsV3(b *testing.B, n int, baseStats,
 	b.ReportMetric(float64(searchStats.AdjacencyDirectViews)/float64(n), "adjacency_direct_views/search")
 	b.ReportMetric(float64(searchStats.AdjacencyMmapDirectViews)/float64(n), "adjacency_mmap_direct/search")
 	b.ReportMetric(float64(searchStats.AdjacencyHeapCopyTypedViews)/float64(n), "adjacency_heap_copy_typed_view/search")
+	b.ReportMetric(float64(searchStats.AdjacencyTypedListDirectViews)/float64(n), "adjacency_typed_list_direct_views/search")
+	b.ReportMetric(float64(searchStats.AdjacencyTypedListMmapDirectViews)/float64(n), "adjacency_typed_list_mmap_direct/search")
+	b.ReportMetric(float64(searchStats.AdjacencyTypedListHeapCopyTypedViews)/float64(n), "adjacency_typed_list_heap_copy_typed_view/search")
+	b.ReportMetric(float64(searchStats.AdjacencyTypedListScratchDecodes)/float64(n), "adjacency_typed_list_scratch_decodes/search")
+	b.ReportMetric(float64(searchStats.AdjacencyLegacyFallbacks)/float64(n), "adjacency_legacy_fallbacks/search")
 	b.ReportMetric(float64(searchStats.AdjacencySourceUnavailable)/float64(n), "adjacency_source_unavailable/search")
 	b.ReportMetric(float64(searchStats.AdjacencySourceFallbacks)/float64(n), "adjacency_source_fallbacks/search")
 	b.ReportMetric(float64(searchStats.AdjacencyCertificationFailures)/float64(n), "adjacency_certification_failures/search")
+	b.ReportMetric(float64(searchStats.AdjacencyValidationFailures)/float64(n), "adjacency_validation_failures/search")
 	b.ReportMetric(float64(searchStats.AdjacencyAbsoluteOffsetUnaligned)/float64(n), "adjacency_absolute_offset_unaligned/search")
 	b.ReportMetric(float64(searchStats.AdjacencyActualPointerUnaligned)/float64(n), "adjacency_actual_pointer_unaligned/search")
 	b.ReportMetric(float64(searchStats.AdjacencyStaleHandles)/float64(n), "adjacency_stale_handles/search")

--- a/TreeDB/collections/column_vector_index_state_adjacency.go
+++ b/TreeDB/collections/column_vector_index_state_adjacency.go
@@ -505,7 +505,7 @@ func validateColumnVectorIndexStateAdjacencySections(layer int, offsetsSection t
 		for idx := beginInt; idx < endInt; idx++ {
 			neighbor := binary.LittleEndian.Uint32(valuesRaw[idx*4:])
 			if uint64(neighbor) >= uint64(rows) {
-				return fmt.Errorf("collections: vector-index state adjacency layer %d row %d value[%d]=%d outside row_count=%d", layer, row, idx-beginInt, neighbor, rows)
+				return fmt.Errorf("collections: vector-index state adjacency layer %d row %d value[%d]=%d outside row_count=%d: %w", layer, row, idx-beginInt, neighbor, rows, errColumnVectorGraphAdjacencyOrdinalOutOfBounds)
 			}
 		}
 	}
@@ -535,7 +535,7 @@ func validateColumnVectorIndexStateAdjacencyList(layer int, list typedcolumn.Uin
 		for idx := begin; idx < end; idx++ {
 			neighbor := list.Values[idx]
 			if uint64(neighbor) >= uint64(list.Rows) {
-				return fmt.Errorf("collections: vector-index state adjacency layer %d row %d value[%d]=%d outside row_count=%d", layer, row, idx-begin, neighbor, list.Rows)
+				return fmt.Errorf("collections: vector-index state adjacency layer %d row %d value[%d]=%d outside row_count=%d: %w", layer, row, idx-begin, neighbor, list.Rows, errColumnVectorGraphAdjacencyOrdinalOutOfBounds)
 			}
 		}
 	}

--- a/TreeDB/collections/column_vector_index_state_adjacency_test.go
+++ b/TreeDB/collections/column_vector_index_state_adjacency_test.go
@@ -312,6 +312,9 @@ func columnVectorGraphStateRowsForTest1987(rows []columnVectorGraphAssetRow, row
 		if i < len(rows) {
 			out[i].ID = append([]byte(nil), rows[i].ID...)
 			out[i].Vector = append([]float32(nil), rows[i].Vector...)
+			if err := validateColumnVectorGraphAdjacency("vector-index-state-test", i, rows[i].Adjacency, rowCount); err == nil {
+				out[i].Adjacency = append([]uint32(nil), rows[i].Adjacency...)
+			}
 		}
 		if len(out[i].ID) == 0 {
 			out[i].ID = []byte("state-row")
@@ -322,7 +325,7 @@ func columnVectorGraphStateRowsForTest1987(rows []columnVectorGraphAssetRow, row
 		if _, err := columnVectorGraphInvNorm(out[i].Vector); err != nil && dims > 0 {
 			out[i].Vector[0] = 1
 		}
-		if layerCount > 1 {
+		if len(out[i].Adjacency) == 0 && layerCount > 1 {
 			out[i].Adjacency = make([]uint32, 2+layerCount)
 			out[i].Adjacency[0] = columnVectorGraphLayeredAdjacencyMagic
 			out[i].Adjacency[1] = uint32(layerCount - 1)

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -355,6 +355,7 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/column_vector_graph_adjacency_source.go", classification: typedStorageLegacyDerived, matchingLines: 36, occurrences: 41},
 	{path: "TreeDB/collections/column_vector_graph_adjacency_direct_source.go", classification: typedStorageLegacyDerived, matchingLines: 5, occurrences: 5},
 	{path: "TreeDB/collections/column_vector_graph_adjacency_direct_source_test.go", classification: typedStorageLegacyDerived, matchingLines: 1, occurrences: 1},
+	{path: "TreeDB/collections/column_vector_graph_adjacency_state_source.go", classification: typedStorageLegacyDerived, matchingLines: 4, occurrences: 4},
 	{path: "TreeDB/collections/column_vector_graph_manifest.go", classification: typedStorageLegacyDerived, matchingLines: 27, occurrences: 32},
 	{path: "TreeDB/collections/column_vector_graph_manifest_test.go", classification: typedStorageLegacyDerived, matchingLines: 60, occurrences: 79},
 	{path: "TreeDB/collections/column_vector_graph_row_reader.go", classification: typedStorageLegacyDerived, matchingLines: 12, occurrences: 13},

--- a/TreeDB/collections/vector_index_search.go
+++ b/TreeDB/collections/vector_index_search.go
@@ -214,12 +214,24 @@ type VectorIndexSearchStats struct {
 	AdjacencyMmapDirectViews uint64 `json:"adjacency_mmap_direct,omitempty"`
 	// AdjacencyHeapCopyTypedViews is the per-search count of adjacency payloads served from typed heap-copy fallback views.
 	AdjacencyHeapCopyTypedViews uint64 `json:"adjacency_heap_copy_typed_view,omitempty"`
+	// AdjacencyTypedListDirectViews is the per-search count of vector-index state uint32_list adjacency payloads served from direct typed-list views.
+	AdjacencyTypedListDirectViews uint64 `json:"adjacency_typed_list_direct_views,omitempty"`
+	// AdjacencyTypedListMmapDirectViews is the per-search count of vector-index state uint32_list adjacency payloads served from mmap direct views.
+	AdjacencyTypedListMmapDirectViews uint64 `json:"adjacency_typed_list_mmap_direct,omitempty"`
+	// AdjacencyTypedListHeapCopyTypedViews is the per-search count of vector-index state uint32_list adjacency payloads served from heap-copy typed views.
+	AdjacencyTypedListHeapCopyTypedViews uint64 `json:"adjacency_typed_list_heap_copy_typed_view,omitempty"`
+	// AdjacencyTypedListScratchDecodes is the per-search count of vector-index state uint32_list adjacency payloads served from decoded fallback views.
+	AdjacencyTypedListScratchDecodes uint64 `json:"adjacency_typed_list_scratch_decodes,omitempty"`
+	// AdjacencyLegacyFallbacks counts row-image graph adjacency fallback/quarantine reads.
+	AdjacencyLegacyFallbacks uint64 `json:"adjacency_legacy_fallbacks,omitempty"`
 	// AdjacencySourceUnavailable reports that this searcher had no usable certified adjacency source and used row-asset fallback.
 	AdjacencySourceUnavailable uint64 `json:"adjacency_source_unavailable,omitempty"`
 	// AdjacencySourceFallbacks reports searches or observations that fell back from certified adjacency sources to row assets.
 	AdjacencySourceFallbacks uint64 `json:"adjacency_source_fallbacks,omitempty"`
 	// AdjacencyCertificationFailures counts adjacency source certification, shape, or validation failures.
 	AdjacencyCertificationFailures uint64 `json:"adjacency_certification_failures,omitempty"`
+	// AdjacencyValidationFailures counts typed-list adjacency validation failures.
+	AdjacencyValidationFailures uint64 `json:"adjacency_validation_failures,omitempty"`
 	// AdjacencyAbsoluteOffsetUnaligned counts adjacency source fallbacks caused by absolute storage offset misalignment.
 	AdjacencyAbsoluteOffsetUnaligned uint64 `json:"adjacency_absolute_offset_unaligned,omitempty"`
 	// AdjacencyActualPointerUnaligned counts adjacency source fallbacks caused by actual mapped pointer misalignment.
@@ -820,66 +832,72 @@ func deltaInt64(before, after int64) int64 {
 
 func vectorIndexSearchStatsFromInternal(searchStats columnVectorGraphNativeSearchStats, readerStats columnPhysicalRowReaderStats) VectorIndexSearchStats {
 	return VectorIndexSearchStats{
-		CandidateRows:                    searchStats.CandidateRows,
-		Candidates:                       searchStats.Candidates,
-		Edges:                            searchStats.Edges,
-		VisitedNodes:                     searchStats.VisitedNodes,
-		VisitedEdges:                     searchStats.VisitedEdges,
-		VectorBytesRead:                  searchStats.VectorBytesRead,
-		NormBytesRead:                    searchStats.NormBytesRead,
-		AdjacencyBytesRead:               searchStats.AdjacencyBytesRead,
-		CandidateFetches:                 searchStats.CandidateFetches,
-		ExpansionFetches:                 searchStats.ExpansionFetches,
-		ResultFetches:                    searchStats.ResultFetches,
-		RowFetches:                       readerStats.RowFetches,
-		BatchFetches:                     readerStats.BatchFetches,
-		RowsFetched:                      readerStats.RowsFetched,
-		CacheHits:                        readerStats.CacheHits,
-		CacheMisses:                      readerStats.CacheMisses,
-		DecodedBlocks:                    readerStats.DecodedBlocks,
-		GranulesTouched:                  readerStats.GranulesTouched,
-		PhysicalBytesRead:                readerStats.PhysicalBytesRead,
-		MaxResidentBytes:                 readerStats.MaxResidentBytes,
-		OpenGranulesRead:                 uint64(readerStats.OpenGranulesRead),
-		OpenPhysicalBytesRead:            readerStats.OpenPhysicalBytesRead,
-		VectorDirectViews:                searchStats.VectorDirectViews,
-		VectorMmapDirectViews:            searchStats.VectorMmapDirectViews,
-		VectorHeapCopyTypedViews:         searchStats.VectorHeapCopyTypedViews,
-		VectorScratchDecodes:             searchStats.VectorScratchDecodes,
-		VectorCertificationFailures:      searchStats.VectorCertificationFailures,
-		VectorAbsoluteOffsetUnaligned:    searchStats.VectorAbsoluteOffsetUnaligned,
-		VectorActualPointerUnaligned:     searchStats.VectorActualPointerUnaligned,
-		VectorStaleHandles:               searchStats.VectorStaleHandles,
-		AdjacencyDirectViews:             searchStats.AdjacencyDirectViews,
-		AdjacencyMmapDirectViews:         searchStats.AdjacencyMmapDirectViews,
-		AdjacencyHeapCopyTypedViews:      searchStats.AdjacencyHeapCopyTypedViews,
-		AdjacencySourceUnavailable:       searchStats.AdjacencySourceUnavailable,
-		AdjacencySourceFallbacks:         searchStats.AdjacencySourceFallbacks,
-		AdjacencyCertificationFailures:   searchStats.AdjacencyCertificationFailures,
-		AdjacencyAbsoluteOffsetUnaligned: searchStats.AdjacencyAbsoluteOffsetUnaligned,
-		AdjacencyActualPointerUnaligned:  searchStats.AdjacencyActualPointerUnaligned,
-		AdjacencyStaleHandles:            searchStats.AdjacencyStaleHandles,
-		AdjacencyScratchDecodes:          searchStats.AdjacencyScratchDecodes,
-		NormDirectViews:                  searchStats.NormDirectViews,
-		NormMmapDirectViews:              searchStats.NormMmapDirectViews,
-		NormHeapCopyTypedViews:           searchStats.NormHeapCopyTypedViews,
-		NormScratchDecodes:               searchStats.NormScratchDecodes,
-		NormSourceUnavailable:            searchStats.NormSourceUnavailable,
-		NormSourceFallbacks:              searchStats.NormSourceFallbacks,
-		NormValidationFailures:           searchStats.NormValidationFailures,
-		NormAbsoluteOffsetUnaligned:      searchStats.NormAbsoluteOffsetUnaligned,
-		NormActualPointerUnaligned:       searchStats.NormActualPointerUnaligned,
-		NormStaleHandles:                 searchStats.NormStaleHandles,
-		NormMappedBytes:                  searchStats.NormMappedBytes,
-		NormHeapCopyBytes:                searchStats.NormHeapCopyBytes,
-		NormDecodedBytes:                 searchStats.NormDecodedBytes,
-		NormActiveHandles:                searchStats.NormActiveHandles,
-		NormDeniedResources:              searchStats.NormDeniedResources,
-		TypedColumnMappedBytes:           searchStats.TypedColumnMappedBytes,
-		TypedColumnHeapCopyBytes:         searchStats.TypedColumnHeapCopyBytes,
-		TypedColumnDecodedBytes:          searchStats.TypedColumnDecodedBytes,
-		TypedColumnActiveHandles:         searchStats.TypedColumnActiveHandles,
-		TypedColumnDeniedResources:       searchStats.TypedColumnDeniedResources,
-		TypedColumnFallbacks:             searchStats.TypedColumnFallbacks,
+		CandidateRows:                        searchStats.CandidateRows,
+		Candidates:                           searchStats.Candidates,
+		Edges:                                searchStats.Edges,
+		VisitedNodes:                         searchStats.VisitedNodes,
+		VisitedEdges:                         searchStats.VisitedEdges,
+		VectorBytesRead:                      searchStats.VectorBytesRead,
+		NormBytesRead:                        searchStats.NormBytesRead,
+		AdjacencyBytesRead:                   searchStats.AdjacencyBytesRead,
+		CandidateFetches:                     searchStats.CandidateFetches,
+		ExpansionFetches:                     searchStats.ExpansionFetches,
+		ResultFetches:                        searchStats.ResultFetches,
+		RowFetches:                           readerStats.RowFetches,
+		BatchFetches:                         readerStats.BatchFetches,
+		RowsFetched:                          readerStats.RowsFetched,
+		CacheHits:                            readerStats.CacheHits,
+		CacheMisses:                          readerStats.CacheMisses,
+		DecodedBlocks:                        readerStats.DecodedBlocks,
+		GranulesTouched:                      readerStats.GranulesTouched,
+		PhysicalBytesRead:                    readerStats.PhysicalBytesRead,
+		MaxResidentBytes:                     readerStats.MaxResidentBytes,
+		OpenGranulesRead:                     uint64(readerStats.OpenGranulesRead),
+		OpenPhysicalBytesRead:                readerStats.OpenPhysicalBytesRead,
+		VectorDirectViews:                    searchStats.VectorDirectViews,
+		VectorMmapDirectViews:                searchStats.VectorMmapDirectViews,
+		VectorHeapCopyTypedViews:             searchStats.VectorHeapCopyTypedViews,
+		VectorScratchDecodes:                 searchStats.VectorScratchDecodes,
+		VectorCertificationFailures:          searchStats.VectorCertificationFailures,
+		VectorAbsoluteOffsetUnaligned:        searchStats.VectorAbsoluteOffsetUnaligned,
+		VectorActualPointerUnaligned:         searchStats.VectorActualPointerUnaligned,
+		VectorStaleHandles:                   searchStats.VectorStaleHandles,
+		AdjacencyDirectViews:                 searchStats.AdjacencyDirectViews,
+		AdjacencyMmapDirectViews:             searchStats.AdjacencyMmapDirectViews,
+		AdjacencyHeapCopyTypedViews:          searchStats.AdjacencyHeapCopyTypedViews,
+		AdjacencyTypedListDirectViews:        searchStats.AdjacencyTypedListDirectViews,
+		AdjacencyTypedListMmapDirectViews:    searchStats.AdjacencyTypedListMmapDirectViews,
+		AdjacencyTypedListHeapCopyTypedViews: searchStats.AdjacencyTypedListHeapCopyTypedViews,
+		AdjacencyTypedListScratchDecodes:     searchStats.AdjacencyTypedListScratchDecodes,
+		AdjacencyLegacyFallbacks:             searchStats.AdjacencyLegacyFallbacks,
+		AdjacencySourceUnavailable:           searchStats.AdjacencySourceUnavailable,
+		AdjacencySourceFallbacks:             searchStats.AdjacencySourceFallbacks,
+		AdjacencyCertificationFailures:       searchStats.AdjacencyCertificationFailures,
+		AdjacencyValidationFailures:          searchStats.AdjacencyValidationFailures,
+		AdjacencyAbsoluteOffsetUnaligned:     searchStats.AdjacencyAbsoluteOffsetUnaligned,
+		AdjacencyActualPointerUnaligned:      searchStats.AdjacencyActualPointerUnaligned,
+		AdjacencyStaleHandles:                searchStats.AdjacencyStaleHandles,
+		AdjacencyScratchDecodes:              searchStats.AdjacencyScratchDecodes,
+		NormDirectViews:                      searchStats.NormDirectViews,
+		NormMmapDirectViews:                  searchStats.NormMmapDirectViews,
+		NormHeapCopyTypedViews:               searchStats.NormHeapCopyTypedViews,
+		NormScratchDecodes:                   searchStats.NormScratchDecodes,
+		NormSourceUnavailable:                searchStats.NormSourceUnavailable,
+		NormSourceFallbacks:                  searchStats.NormSourceFallbacks,
+		NormValidationFailures:               searchStats.NormValidationFailures,
+		NormAbsoluteOffsetUnaligned:          searchStats.NormAbsoluteOffsetUnaligned,
+		NormActualPointerUnaligned:           searchStats.NormActualPointerUnaligned,
+		NormStaleHandles:                     searchStats.NormStaleHandles,
+		NormMappedBytes:                      searchStats.NormMappedBytes,
+		NormHeapCopyBytes:                    searchStats.NormHeapCopyBytes,
+		NormDecodedBytes:                     searchStats.NormDecodedBytes,
+		NormActiveHandles:                    searchStats.NormActiveHandles,
+		NormDeniedResources:                  searchStats.NormDeniedResources,
+		TypedColumnMappedBytes:               searchStats.TypedColumnMappedBytes,
+		TypedColumnHeapCopyBytes:             searchStats.TypedColumnHeapCopyBytes,
+		TypedColumnDecodedBytes:              searchStats.TypedColumnDecodedBytes,
+		TypedColumnActiveHandles:             searchStats.TypedColumnActiveHandles,
+		TypedColumnDeniedResources:           searchStats.TypedColumnDeniedResources,
+		TypedColumnFallbacks:                 searchStats.TypedColumnFallbacks,
 	}
 }

--- a/TreeDB/collections/vector_index_search_test.go
+++ b/TreeDB/collections/vector_index_search_test.go
@@ -61,6 +61,9 @@ func TestSearchVectorIndexColumnGraphNativeReaderReopenV4(t *testing.T) {
 	if got.Stats.CandidateRows != uint64(len(rows)) || got.Stats.VisitedNodes < got.Stats.Candidates || got.Stats.VisitedEdges != got.Stats.Edges || got.Stats.VectorBytesRead == 0 || got.Stats.AdjacencyBytesRead == 0 {
 		t.Fatalf("stats=%+v want public operation-specific candidate row, non-undercounting visited graph, vector-byte, and adjacency-byte counters", got.Stats)
 	}
+	if got.Stats.AdjacencyTypedListMmapDirectViews+got.Stats.AdjacencyTypedListHeapCopyTypedViews+got.Stats.AdjacencyTypedListScratchDecodes == 0 || got.Stats.AdjacencyLegacyFallbacks != 0 {
+		t.Fatalf("stats=%+v want public search to expose typed-list adjacency and no legacy fallback on healthy state", got.Stats)
+	}
 	if got.Stats.DocumentsFetched != 0 {
 		t.Fatalf("DocumentsFetched=%d want no document fetch without IncludeDocuments", got.Stats.DocumentsFetched)
 	}
@@ -2052,9 +2055,15 @@ func reportVectorIndexSearchBenchMetricsV4(b *testing.B, n int, stats VectorInde
 	b.ReportMetric(float64(stats.AdjacencyDirectViews), "adjacency_direct_views/search")
 	b.ReportMetric(float64(stats.AdjacencyMmapDirectViews), "adjacency_mmap_direct/search")
 	b.ReportMetric(float64(stats.AdjacencyHeapCopyTypedViews), "adjacency_heap_copy_typed_view/search")
+	b.ReportMetric(float64(stats.AdjacencyTypedListDirectViews), "adjacency_typed_list_direct_views/search")
+	b.ReportMetric(float64(stats.AdjacencyTypedListMmapDirectViews), "adjacency_typed_list_mmap_direct/search")
+	b.ReportMetric(float64(stats.AdjacencyTypedListHeapCopyTypedViews), "adjacency_typed_list_heap_copy_typed_view/search")
+	b.ReportMetric(float64(stats.AdjacencyTypedListScratchDecodes), "adjacency_typed_list_scratch_decodes/search")
+	b.ReportMetric(float64(stats.AdjacencyLegacyFallbacks), "adjacency_legacy_fallbacks/search")
 	b.ReportMetric(float64(stats.AdjacencySourceUnavailable), "adjacency_source_unavailable/search")
 	b.ReportMetric(float64(stats.AdjacencySourceFallbacks), "adjacency_source_fallbacks/search")
 	b.ReportMetric(float64(stats.AdjacencyCertificationFailures), "adjacency_certification_failures/search")
+	b.ReportMetric(float64(stats.AdjacencyValidationFailures), "adjacency_validation_failures/search")
 	b.ReportMetric(float64(stats.AdjacencyAbsoluteOffsetUnaligned), "adjacency_absolute_offset_unaligned/search")
 	b.ReportMetric(float64(stats.AdjacencyActualPointerUnaligned), "adjacency_actual_pointer_unaligned/search")
 	b.ReportMetric(float64(stats.AdjacencyStaleHandles), "adjacency_stale_handles/search")

--- a/TreeDB/internal/typedcolumn/transplant_test.go
+++ b/TreeDB/internal/typedcolumn/transplant_test.go
@@ -402,6 +402,9 @@ func TestTypedColumnTransplantNoProductionPublication(t *testing.T) {
 		// #1987 is the scoped production vector-index state writer/validator that
 		// publishes HNSW adjacency as generic uint32_list typed-column assets.
 		filepath.Clean(filepath.Join(collectionsDir, "column_vector_index_state_adjacency.go")): {},
+		// #1988 is the scoped production vector graph reader that consumes HNSW
+		// adjacency from generic uint32_list vector-index state assets.
+		filepath.Clean(filepath.Join(collectionsDir, "column_vector_graph_adjacency_state_source.go")): {},
 		// #1992 is the scoped production vector graph writer/reader that publishes
 		// and consumes raw_float32 inverse-norm state through typed-column assets.
 		filepath.Clean(filepath.Join(collectionsDir, "column_vector_graph_inv_norm_state.go")): {},


### PR DESCRIPTION
## Objective

Switch `column_graph` search to consume HNSW adjacency from vector-index typed-column `uint32_list` state assets instead of graph-specific adjacency sources on the healthy path.

Closes #1988. Depends on / built on merged #1987 (`96c775292b832ea442b5d3ceddf660f3ef55ae0b`) and preserves its contract: `VectorIndexStatus` remains cheap (manifest/ref/layer/schema checks), while full adjacency payload validation happens on open/rebuild.

## Design

- Opens vector-index state adjacency assets by role `adjacency`, asset IDs `hnsw/layer/<n>`, logical `uint32_list`, physical `raw_uint32_offsets_list`.
- Binds one direct list source per HNSW layer at searcher/reader open.
- Serves neighbors as `values[offsets[ordinal]:offsets[ordinal+1]]` with no per-expansion decode/copy on the healthy direct path.
- Keeps HNSW traversal/scoring/result ID/document fetch boundaries unchanged.
- Keeps row-image graph adjacency as explicit fallback/quarantine only when a bound source becomes unusable (for example stale handles in tests); missing/gapped/corrupt state fails closed at status/open per #1987.

## Counters

Adds distinct adjacency typed-list counters separate from vector direct-view counters:

- `adjacency_typed_list_direct_views`
- `adjacency_typed_list_mmap_direct`
- `adjacency_typed_list_heap_copy_typed_view`
- `adjacency_typed_list_scratch_decodes`
- `adjacency_legacy_fallbacks`
- `adjacency_validation_failures`

Legacy aliases (`adjacency_direct_views`, `adjacency_mmap_direct`, etc.) remain populated for compatibility.

## Tests

- `go test ./TreeDB/collections -run 'TestColumnVectorGraphSearchUsesVectorIndexStateAdjacency1988|TestColumnVectorIndexStateAdjacencyStatusValidation1987|TestColumnGraphRebuildPublishesUint32ListAdjacencyState1987|TestColumnVectorGraphNativeSearch|TestSearchVectorIndexColumnGraphNativeReaderReopenV4' -count=1`
- `go test ./TreeDB/collections -count=1`
- `GOWORK=off go test ./TreeDB/collections -count=1`
- `go test ./TreeDB/internal/typedcolumn -count=1`
- `go test ./TreeDB/... -count=1`

Internal review subagent latest-head check:

- `go test ./TreeDB/internal/typedcolumn -run TestTypedColumnTransplantNoProductionPublication -count=1`
- `go test ./TreeDB/collections -run TestTypedStorageLegacyNameAllowlistIsComplete -count=1`
- Result: no blockers found.

## Benchmarks / counters

Commands run on Apple M3:

- `go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnVectorGraphNativeSearchCosine(TypedColumnV3|ParallelTypedColumnV3)$' -benchmem -benchtime=200x -count=1`
- `go test ./TreeDB/collections -run '^$' -bench 'BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReader(ReusableBuffer)?(Parallel)?V4$' -benchmem -benchtime=200x -count=1`

Representative results:

| Benchmark | ns/op | B/op | allocs/op | typed-list mmap/search | adjacency scratch/search | legacy fallback/search |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| `ColumnVectorGraphNativeSearchCosineTypedColumnV3` | 10,477 | 0 | 0 | 104.0 | 0 | 0 |
| `ColumnVectorGraphNativeSearchCosineParallelTypedColumnV3` | 2,360 | 24 | 0 | 104.0 | 0 | 0 |
| `OpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderV4` | 10,915 | 784 | 2 | 104.0 | 0 | 0 |
| `OpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderReusableBufferV4` | 10,972 | 0 | 0 | 104.0 | 0 | 0 |
| `OpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderParallelV4` | 2,361 | 806 | 2 | 104.0 | 0 | 0 |
| `OpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderReusableBufferParallelV4` | 2,365 | 22 | 0 | 104.0 | 0 | 0 |

Healthy typed state removes row-image adjacency scratch decodes from the measured search path.


## Latest-head review fix evidence (Copilot)

After Copilot noted duplicate adjacency payload validation/read on searcher open, the open snapshot-view now performs only cheap vector-index state manifest/ref/layer/schema validation; `column_vector_graph_adjacency_state_source.go` performs the single full typed-list payload validation/read while binding offset/value sections.

Latest head: `7c3d8dcf8`. Additional commands run after this fix:

- `go test ./TreeDB/collections -run 'TestColumnVectorIndexStateAdjacencyStatusValidation1987|TestColumnVectorGraphSearchUsesVectorIndexStateAdjacency1988|TestColumnVectorGraphNativeSearchRejectsBadAdjacencyOrdinalV3|TestSearchVectorIndexColumnGraphNativeReaderReopenV4|TestColumnGraphRebuildPublishesUint32ListAdjacencyState1987' -count=1`
- `go test ./TreeDB/collections -count=1`
- `GOWORK=off go test ./TreeDB/collections -count=1`
- `go test ./TreeDB/internal/typedcolumn -count=1`
- `go test ./TreeDB/... -count=1`
- `go test ./TreeDB/collections -run '^$' -bench 'BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReader(ReusableBuffer)?(Parallel)?V4$' -benchmem -benchtime=200x -count=1`

Review-fix benchmark counters still show healthy typed state with `adjacency_typed_list_mmap_direct/search=104.0`, `adjacency_scratch_decodes/search=0`, and `adjacency_legacy_fallbacks/search=0`.

## Latest-head review fix evidence (CodeRabbit/Copilot follow-up)

Latest head: `bc0c778dd`. Follow-up fixes:

- Threaded the decoded `columnVectorIndexStateSnapshot` and found bool through `columnPhysicalScanSnapshotView`, so reader open no longer reloads/re-decodes the vector-index state record.
- Split adjacency validation/certification telemetry so only `typeddecode.ReasonValidationFailed` increments `AdjacencyValidationFailures`; certification reasons increment only `AdjacencyCertificationFailures`.
- Resolved the old Copilot duplicate-payload thread after confirming the open path keeps full typed-list payload validation in the adjacency source binder only.

Additional commands run after this follow-up:

- `git diff --check`
- `go test ./TreeDB/internal/typedcolumn -run TestTypedColumnTransplantNoProductionPublication -count=1`
- `go test ./TreeDB/collections -run 'TestColumnVectorIndexStateAdjacencyStatusValidation1987|TestColumnVectorGraphSearchUsesVectorIndexStateAdjacency1988|TestColumnVectorGraphNativeSearchRejectsBadAdjacencyOrdinalV3|TestSearchVectorIndexColumnGraphNativeReaderReopenV4|TestColumnGraphRebuildPublishesUint32ListAdjacencyState1987' -count=1`
- `go test ./TreeDB/collections -count=1`

## AI / review status

- Internal high-thinking Pi review: no blockers.
- External AI reviews re-requested on latest head `bc0c778dd`: Codex, Copilot, and CodeRabbit pending/refreshing.

## Risks / caveats

- This is pre-alpha format/state plumbing; no migration support for old DB dirs is added.
- Legacy graph-specific adjacency source code remains as quarantine/fallback until follow-up cleanup (#1989).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added typed-list adjacency state sources for column-vector graph reads with an optional scratch decode fallback.

* **Improvements**
  * Search now prefers vector-index state adjacency; expanded adjacency telemetry and finer-grained fallback/validation counters.
  * Stronger snapshot/asset validation and clearer error signaling when adjacency state mismatches occur.

* **Bug Fixes**
  * Better handle lifecycle, stale-handle detection, and more thorough cleanup on close.

* **Tests**
  * Updated and added tests/benchmarks covering typed-list adjacency, fallback paths, and new metrics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/2001?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

