### PR TITLE
Typed-column JSONBench uses typed-column-part assets

### DIFF
--- a/TreeDB/collections/column_physical_predicate.go
+++ b/TreeDB/collections/column_physical_predicate.go
@@ -29,9 +29,21 @@ type ColumnPhysicalQueryPredicate struct {
 }
 
 type columnPhysicalQueryPredicateSpec struct {
-	column string
-	kind   ColumnPhysicalQueryPredicateKind
-	values []string
+	column     string
+	kind       ColumnPhysicalQueryPredicateKind
+	values     []string
+	valueBytes [][]byte
+}
+
+func columnPhysicalQueryPredicateValueBytes(values []string) [][]byte {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make([][]byte, len(values))
+	for i, value := range values {
+		out[i] = []byte(value)
+	}
+	return out
 }
 
 type columnDictionaryPredicateAsset struct {

--- a/TreeDB/collections/column_physical_query.go
+++ b/TreeDB/collections/column_physical_query.go
@@ -120,6 +120,8 @@ type ColumnPhysicalQueryDiagnostics struct {
 	MutationParts               int
 	DecodedBlocks               int
 	DirectReduceBlocks          int
+	TypedColumnPartSections     int
+	TypedColumnPartSectionBytes uint64
 	MetadataHits                int
 	MetadataMisses              int
 	DictionaryCodeHits          int
@@ -189,6 +191,7 @@ type ColumnPhysicalQueryRunner struct {
 	int64Hour    *columnInt64ValueHourCountRunner
 	dictInt64    *columnDictionaryInt64GroupRunner
 	dictHour     *columnDictionaryHourCountRunner
+	typedColumn  *columnTypedColumnPhysicalQueryRunner
 	metadata     *columnAggregateMetadataRunner
 	closed       bool
 }
@@ -346,15 +349,24 @@ func (c *Collection) PrepareColumnPhysicalQuery(req ColumnPhysicalQueryRequest) 
 	readCache.returnViews = true
 	var metadata *columnAggregateMetadataRunner
 	var exec *columnPhysicalQueryExecutor
+	typedColumn, typedColumnCandidate, err := prepareColumnTypedColumnPhysicalQueryRunner(view, req, &readCache)
+	if err != nil {
+		_ = readCache.close()
+		return nil, err
+	}
 	if req.AggregateMetadataName != "" && columnPhysicalQueryHasPredicates(req) {
 		_ = readCache.close()
 		return nil, fmt.Errorf("%w: aggregate metadata physical predicates are not supported", ErrColumnQueryPlanUnsupported)
 	}
-	if req.Kind == ColumnPhysicalQueryHourCount && columnPhysicalQueryHasPredicates(req) {
+	if typedColumn == nil && req.Kind == ColumnPhysicalQueryHourCount && columnPhysicalQueryHasPredicates(req) {
 		_ = readCache.close()
 		return nil, fmt.Errorf("%w: hour-count physical predicates require a fused grouped-hour reducer", ErrColumnQueryPlanUnsupported)
 	}
-	if req.AggregateMetadataName != "" {
+	if typedColumn != nil {
+		// The typed-column part runner is prepared before compatibility sidecar
+		// runners so JSONBench-style typed-owned fields use the sectioned
+		// tcs1_typed_column_part image as their production substrate.
+	} else if req.AggregateMetadataName != "" {
 		metadata, err = prepareColumnAggregateMetadataRunner(view, req, &readCache)
 		if err != nil {
 			_ = readCache.close()
@@ -408,15 +420,19 @@ func (c *Collection) PrepareColumnPhysicalQuery(req ColumnPhysicalQueryRequest) 
 		_ = readCache.close()
 		return nil, err
 	}
-	if req.Kind == ColumnPhysicalQueryGroupCountAndDistinct && dictDistinct == nil {
+	if typedColumnCandidate && typedColumn == nil {
+		_ = readCache.close()
+		return nil, fmt.Errorf("%w: typed-column part physical query was selected but no runner was prepared", ErrColumnQueryPlanUnsupported)
+	}
+	if typedColumn == nil && req.Kind == ColumnPhysicalQueryGroupCountAndDistinct && dictDistinct == nil {
 		_ = readCache.close()
 		return nil, fmt.Errorf("%w: fused count-distinct physical query requires dictionary sidecar reducers", ErrColumnQueryPlanUnsupported)
 	}
-	if req.Kind == ColumnPhysicalQueryGroupHourCount && dictHour == nil {
+	if typedColumn == nil && req.Kind == ColumnPhysicalQueryGroupHourCount && dictHour == nil {
 		_ = readCache.close()
 		return nil, fmt.Errorf("%w: grouped-hour physical query requires dictionary/int64 sidecar reducers", ErrColumnQueryPlanUnsupported)
 	}
-	if columnPhysicalQueryHasPredicates(req) && dictCount == nil && dictDistinct == nil && dictInt64 == nil && dictHour == nil {
+	if typedColumn == nil && columnPhysicalQueryHasPredicates(req) && dictCount == nil && dictDistinct == nil && dictInt64 == nil && dictHour == nil {
 		_ = readCache.close()
 		return nil, fmt.Errorf("%w: physical predicates require supported dictionary sidecar reducers", ErrColumnQueryPlanUnsupported)
 	}
@@ -433,6 +449,7 @@ func (c *Collection) PrepareColumnPhysicalQuery(req ColumnPhysicalQueryRequest) 
 		int64Hour:    int64Hour,
 		dictInt64:    dictInt64,
 		dictHour:     dictHour,
+		typedColumn:  typedColumn,
 		metadata:     metadata,
 	}, nil
 }
@@ -462,6 +479,9 @@ func (r *ColumnPhysicalQueryRunner) Close() error {
 func (r *ColumnPhysicalQueryRunner) Run() (ColumnPhysicalQueryResult, error) {
 	if r == nil || r.closed {
 		return ColumnPhysicalQueryResult{}, errors.New("collections: prepared physical column query runner is closed")
+	}
+	if r.typedColumn != nil {
+		return r.typedColumn.run(r.view, r.req)
 	}
 	if r.dictCount != nil {
 		result := r.dictCount.run(r.view, r.req)
@@ -892,6 +912,9 @@ func columnManifestScanSidecarsForPhysicalQuery(req ColumnPhysicalQueryRequest) 
 }
 
 func (c *Collection) runColumnPhysicalQueryInSnapshotView(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest) (ColumnPhysicalQueryResult, error) {
+	if result, ok, err := c.runColumnPhysicalQueryTypedColumnPartInSnapshotView(view, req); ok {
+		return result, err
+	}
 	if result, ok, err := c.runColumnPhysicalQueryDictionaryCodesInSnapshotView(view, req); ok {
 		return result, err
 	}
@@ -1252,6 +1275,8 @@ func mergeColumnPhysicalQueryDiagnostics(left, right ColumnPhysicalQueryDiagnost
 	}
 	left.DecodedBlocks += right.DecodedBlocks
 	left.DirectReduceBlocks += right.DirectReduceBlocks
+	left.TypedColumnPartSections += right.TypedColumnPartSections
+	left.TypedColumnPartSectionBytes += right.TypedColumnPartSectionBytes
 	left.MetadataHits += right.MetadataHits
 	left.MetadataMisses += right.MetadataMisses
 	left.DictionaryCodeHits += right.DictionaryCodeHits

--- a/TreeDB/collections/column_physical_query.go
+++ b/TreeDB/collections/column_physical_query.go
@@ -392,49 +392,55 @@ func (c *Collection) PrepareColumnPhysicalQuery(req ColumnPhysicalQueryRequest) 
 			return nil, fmt.Errorf("%w: prepared physical column query requires direct asset reducer", ErrColumnQueryPlanUnsupported)
 		}
 	}
-	dictCount, err := prepareColumnDictionaryCodeGroupCountRunner(view, req, &readCache)
-	if err != nil {
-		_ = readCache.close()
-		return nil, err
-	}
-	dictDistinct, err := prepareColumnDictionaryCodeGroupCountDistinctRunner(view, req, &readCache)
-	if err != nil {
-		_ = readCache.close()
-		return nil, err
-	}
+	var dictCount *columnDictionaryCodeGroupCountRunner
+	var dictDistinct *columnDictionaryCodeGroupCountDistinctRunner
 	var int64Hour *columnInt64ValueHourCountRunner
-	if !columnPhysicalQueryHasPredicates(req) {
-		int64Hour, err = prepareColumnInt64ValueHourCountRunner(view, req, &readCache)
-		if err != nil {
-			_ = readCache.close()
-			return nil, err
-		}
-	}
-	dictInt64, err := prepareColumnDictionaryInt64GroupRunner(view, req, &readCache)
-	if err != nil {
-		_ = readCache.close()
-		return nil, err
-	}
-	dictHour, err := prepareColumnDictionaryHourCountRunner(view, req, &readCache)
-	if err != nil {
-		_ = readCache.close()
-		return nil, err
-	}
+	var dictInt64 *columnDictionaryInt64GroupRunner
+	var dictHour *columnDictionaryHourCountRunner
 	if typedColumnCandidate && typedColumn == nil {
 		_ = readCache.close()
 		return nil, fmt.Errorf("%w: typed-column part physical query was selected but no runner was prepared", ErrColumnQueryPlanUnsupported)
 	}
-	if typedColumn == nil && req.Kind == ColumnPhysicalQueryGroupCountAndDistinct && dictDistinct == nil {
-		_ = readCache.close()
-		return nil, fmt.Errorf("%w: fused count-distinct physical query requires dictionary sidecar reducers", ErrColumnQueryPlanUnsupported)
-	}
-	if typedColumn == nil && req.Kind == ColumnPhysicalQueryGroupHourCount && dictHour == nil {
-		_ = readCache.close()
-		return nil, fmt.Errorf("%w: grouped-hour physical query requires dictionary/int64 sidecar reducers", ErrColumnQueryPlanUnsupported)
-	}
-	if typedColumn == nil && columnPhysicalQueryHasPredicates(req) && dictCount == nil && dictDistinct == nil && dictInt64 == nil && dictHour == nil {
-		_ = readCache.close()
-		return nil, fmt.Errorf("%w: physical predicates require supported dictionary sidecar reducers", ErrColumnQueryPlanUnsupported)
+	if typedColumn == nil {
+		dictCount, err = prepareColumnDictionaryCodeGroupCountRunner(view, req, &readCache)
+		if err != nil {
+			_ = readCache.close()
+			return nil, err
+		}
+		dictDistinct, err = prepareColumnDictionaryCodeGroupCountDistinctRunner(view, req, &readCache)
+		if err != nil {
+			_ = readCache.close()
+			return nil, err
+		}
+		if !columnPhysicalQueryHasPredicates(req) {
+			int64Hour, err = prepareColumnInt64ValueHourCountRunner(view, req, &readCache)
+			if err != nil {
+				_ = readCache.close()
+				return nil, err
+			}
+		}
+		dictInt64, err = prepareColumnDictionaryInt64GroupRunner(view, req, &readCache)
+		if err != nil {
+			_ = readCache.close()
+			return nil, err
+		}
+		dictHour, err = prepareColumnDictionaryHourCountRunner(view, req, &readCache)
+		if err != nil {
+			_ = readCache.close()
+			return nil, err
+		}
+		if req.Kind == ColumnPhysicalQueryGroupCountAndDistinct && dictDistinct == nil {
+			_ = readCache.close()
+			return nil, fmt.Errorf("%w: fused count-distinct physical query requires dictionary sidecar reducers", ErrColumnQueryPlanUnsupported)
+		}
+		if req.Kind == ColumnPhysicalQueryGroupHourCount && dictHour == nil {
+			_ = readCache.close()
+			return nil, fmt.Errorf("%w: grouped-hour physical query requires dictionary/int64 sidecar reducers", ErrColumnQueryPlanUnsupported)
+		}
+		if columnPhysicalQueryHasPredicates(req) && dictCount == nil && dictDistinct == nil && dictInt64 == nil && dictHour == nil {
+			_ = readCache.close()
+			return nil, fmt.Errorf("%w: physical predicates require supported dictionary sidecar reducers", ErrColumnQueryPlanUnsupported)
+		}
 	}
 	release = false
 	return &ColumnPhysicalQueryRunner{

--- a/TreeDB/collections/column_physical_typed_column_1947_test.go
+++ b/TreeDB/collections/column_physical_typed_column_1947_test.go
@@ -1,0 +1,467 @@
+package collections
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+)
+
+func TestColumnPhysicalJSONBenchTypedColumnPartDirectPreparedReopen1947(t *testing.T) {
+	events := columnPhysicalJSONBenchParityEventsP0()
+	d, collection, closeFn, preCloseTypedRefs := openColumnPhysicalJSONBenchTypedColumnPartFixture1947(t, events)
+	defer closeFn()
+
+	postReopenTypedRefs := typedColumnPartRefs1755(columnManifestAssetRefsForCollectionM12A(t, d, collection))
+	assertColumnAssetRefsEqual1755(t, preCloseTypedRefs, postReopenTypedRefs)
+	assertTypedColumnManifestShape1755(t, d, collection, 1, 1)
+
+	scanned := scanColumnPhysicalJSONBenchParityEventsP0(t, collection, len(events))
+	assertColumnPhysicalJSONBenchRowScanPreservesFullPredicateColumnsP0(t, events, scanned)
+
+	commitCreate := []ColumnPhysicalQueryPredicate{
+		{Column: "kind", Value: "commit"},
+		{Column: "operation", Value: "create"},
+	}
+	postCreate := append(append([]ColumnPhysicalQueryPredicate(nil), commitCreate...), ColumnPhysicalQueryPredicate{Column: "collection", Value: "app.bsky.feed.post"})
+	feedCreate := append(append([]ColumnPhysicalQueryPredicate(nil), commitCreate...), ColumnPhysicalQueryPredicate{
+		Column: "collection",
+		Kind:   ColumnPhysicalQueryPredicateInList,
+		Values: []string{"app.bsky.feed.post", "app.bsky.feed.repost", "app.bsky.feed.like"},
+	})
+
+	cases := []struct {
+		name            string
+		req             ColumnPhysicalQueryRequest
+		wantPredicates  int
+		wantMatchedRows int
+		wantReduceRows  int
+	}{
+		{
+			name:            "q1",
+			req:             ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount, GroupColumn: "collection"},
+			wantPredicates:  0,
+			wantMatchedRows: 0,
+			wantReduceRows:  len(scanned),
+		},
+		{
+			name: "q2",
+			req: ColumnPhysicalQueryRequest{
+				Kind:           ColumnPhysicalQueryGroupCountAndDistinct,
+				GroupColumn:    "collection",
+				DistinctColumn: "did",
+				Predicates:     commitCreate,
+			},
+			wantPredicates:  len(commitCreate),
+			wantMatchedRows: columnPhysicalJSONBenchReferenceMatchedRowsP0("q2", scanned),
+			wantReduceRows:  columnPhysicalJSONBenchReferenceMatchedRowsP0("q2", scanned),
+		},
+		{
+			name: "q3",
+			req: ColumnPhysicalQueryRequest{
+				Kind:        ColumnPhysicalQueryGroupHourCount,
+				GroupColumn: "collection",
+				ValueColumn: "time_us",
+				Predicates:  feedCreate,
+			},
+			wantPredicates:  len(feedCreate),
+			wantMatchedRows: columnPhysicalJSONBenchReferenceMatchedRowsP0("q3", scanned),
+			wantReduceRows:  columnPhysicalJSONBenchReferenceMatchedRowsP0("q3", scanned),
+		},
+		{
+			name: "q4a",
+			req: ColumnPhysicalQueryRequest{
+				Kind:        ColumnPhysicalQueryGroupMinInt64,
+				GroupColumn: "did",
+				ValueColumn: "time_us",
+				Predicates:  postCreate,
+			},
+			wantPredicates:  len(postCreate),
+			wantMatchedRows: columnPhysicalJSONBenchReferenceMatchedRowsP0("q4a", scanned),
+			wantReduceRows:  columnPhysicalJSONBenchReferenceMatchedRowsP0("q4a", scanned),
+		},
+		{
+			name: "q4b",
+			req: ColumnPhysicalQueryRequest{
+				Kind:        ColumnPhysicalQueryGroupMaxInt64,
+				GroupColumn: "did",
+				ValueColumn: "time_us",
+				Predicates:  postCreate,
+			},
+			wantPredicates:  len(postCreate),
+			wantMatchedRows: columnPhysicalJSONBenchReferenceMatchedRowsP0("q4b", scanned),
+			wantReduceRows:  columnPhysicalJSONBenchReferenceMatchedRowsP0("q4b", scanned),
+		},
+		{
+			name: "q5",
+			req: ColumnPhysicalQueryRequest{
+				Kind:        ColumnPhysicalQueryGroupInt64Span,
+				GroupColumn: "did",
+				ValueColumn: "time_us",
+				Predicates:  postCreate,
+			},
+			wantPredicates:  len(postCreate),
+			wantMatchedRows: columnPhysicalJSONBenchReferenceMatchedRowsP0("q5", scanned),
+			wantReduceRows:  columnPhysicalJSONBenchReferenceMatchedRowsP0("q5", scanned),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rowHash := columnPhysicalJSONBenchHashLinesP0(columnPhysicalJSONBenchReferenceLinesP0(tc.name, scanned))
+
+			direct, err := collection.RunColumnPhysicalQuery(tc.req)
+			if err != nil {
+				t.Fatalf("RunColumnPhysicalQuery(%s): %v", tc.name, err)
+			}
+			assertColumnPhysicalJSONBenchTypedColumnDiagnostics1947(t, tc.name, direct.Diagnostics, len(scanned), tc.wantPredicates, tc.wantMatchedRows, tc.wantReduceRows)
+			directHash := columnPhysicalJSONBenchHashLinesP0(columnPhysicalJSONBenchPhysicalLinesP0(tc.name, direct.Groups))
+			if directHash != rowHash {
+				t.Fatalf("%s direct hash=%016x want row scan %016x groups=%+v", tc.name, directHash, rowHash, direct.Groups)
+			}
+
+			runner, err := collection.PrepareColumnPhysicalQuery(tc.req)
+			if err != nil {
+				t.Fatalf("PrepareColumnPhysicalQuery(%s): %v", tc.name, err)
+			}
+			defer func() { _ = runner.Close() }()
+			for run := 0; run < 2; run++ {
+				prepared, err := runner.Run()
+				if err != nil {
+					t.Fatalf("prepared %s run %d: %v", tc.name, run, err)
+				}
+				assertColumnPhysicalJSONBenchTypedColumnDiagnostics1947(t, tc.name, prepared.Diagnostics, len(scanned), tc.wantPredicates, tc.wantMatchedRows, tc.wantReduceRows)
+				preparedHash := columnPhysicalJSONBenchHashLinesP0(columnPhysicalJSONBenchPhysicalLinesP0(tc.name, prepared.Groups))
+				if preparedHash != rowHash {
+					t.Fatalf("%s prepared run %d hash=%016x want row scan %016x groups=%+v", tc.name, run, preparedHash, rowHash, prepared.Groups)
+				}
+			}
+		})
+	}
+}
+
+func TestColumnPhysicalJSONBenchTypedColumnPartStoresFullQ2Columns1947(t *testing.T) {
+	events := columnPhysicalJSONBenchParityEventsP0()
+	d, collection, closeFn, _ := openColumnPhysicalJSONBenchTypedColumnPartFixture1947(t, events)
+	defer closeFn()
+
+	rows := typedColumnPartRowsForGeneration1778(t, d, collection, 1)
+	if len(rows) != len(events) {
+		t.Fatalf("typed rows=%d want events=%d", len(rows), len(events))
+	}
+	for i, event := range events {
+		row := rows[i]
+		if row.Values["kind"].String != event.Kind || row.Values["operation"].String != event.Operation || row.Values["collection"].String != event.Collection || row.Values["did"].String != event.Did {
+			t.Fatalf("row %d typed q2 columns kind=%q operation=%q collection=%q did=%q want %+v", i, row.Values["kind"].String, row.Values["operation"].String, row.Values["collection"].String, row.Values["did"].String, event)
+		}
+		if (event.Kind != "commit" || event.Operation != "create") && (row.Values["collection"].String == "" || row.Values["did"].String == "") {
+			t.Fatalf("row %d used q2 masking/sentinel payload: %+v", i, row.Values)
+		}
+	}
+
+	q2 := ColumnPhysicalQueryRequest{
+		Kind:           ColumnPhysicalQueryGroupCountAndDistinct,
+		GroupColumn:    "collection",
+		DistinctColumn: "did",
+		Predicates: []ColumnPhysicalQueryPredicate{
+			{Column: "kind", Value: "commit"},
+			{Column: "operation", Value: "create"},
+		},
+	}
+	result, err := collection.RunColumnPhysicalQuery(q2)
+	if err != nil {
+		t.Fatalf("RunColumnPhysicalQuery(q2): %v", err)
+	}
+	got := columnPhysicalJSONBenchQ2CountsP0(result.Groups)
+	want := columnPhysicalJSONBenchQ2ReferenceCountsP0(events)
+	if !columnPhysicalJSONBenchQ2CountsEqualP0(got, want) {
+		t.Fatalf("q2 counts/distinct=%v want %v groups=%+v", got, want, result.Groups)
+	}
+	if result.Diagnostics.StorageSource != ColumnPhysicalQueryStorageSourceTypedColumnPartSection || result.Diagnostics.PredicateCount != 2 {
+		t.Fatalf("q2 diagnostics=%+v want typed-column source and real predicates", result.Diagnostics)
+	}
+}
+
+func TestColumnPhysicalJSONBenchTypedColumnPartAssetFailureFailClosed1947(t *testing.T) {
+	events := columnPhysicalJSONBenchParityEventsP0()
+	cases := []struct {
+		name string
+		fail func(testing.TB, *backenddb.DB, *Collection, ColumnAssetRef)
+	}{
+		{name: "missing_truncated_payload", fail: removeTypedColumnAssetPayload1755},
+		{name: "corrupt_checksum", fail: func(tb testing.TB, d *backenddb.DB, _ *Collection, ref ColumnAssetRef) {
+			corruptTypedColumnAssetPayload1755(tb, d, ref)
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d, collection, closeFn, typedRefs := openColumnPhysicalJSONBenchTypedColumnPartFixture1947(t, events)
+			defer closeFn()
+			if len(typedRefs) != 1 {
+				t.Fatalf("typed refs=%+v want one", typedRefs)
+			}
+			tc.fail(t, d, collection, typedRefs[0])
+
+			_, err := collection.RunColumnPhysicalQuery(ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount, GroupColumn: "collection"})
+			if err == nil {
+				t.Fatalf("RunColumnPhysicalQuery after %s typed_column_part succeeded; want fail-closed error", tc.name)
+			}
+			if !strings.Contains(err.Error(), "typed-column part physical query") && !strings.Contains(err.Error(), "checksum") && !strings.Contains(err.Error(), "short") {
+				t.Fatalf("%s typed_column_part error=%v want typed-column/checksum/short-read context", tc.name, err)
+			}
+		})
+	}
+}
+
+func TestColumnPhysicalJSONBenchTypedColumnPartDecodeMismatchesFailClosed1947(t *testing.T) {
+	events := columnPhysicalJSONBenchParityEventsP0()
+	d, collection, closeFn, _ := openColumnPhysicalJSONBenchTypedColumnPartFixture1947(t, events)
+	defer closeFn()
+
+	req := ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount, GroupColumn: "collection"}
+	view, closeView, err := collection.prepareColumnPhysicalScanSnapshotViewWithSidecars(columnManifestScanSidecarsForPhysicalQuery(req))
+	if closeView != nil {
+		defer closeView()
+	}
+	if err != nil {
+		t.Fatalf("prepareColumnPhysicalScanSnapshotViewWithSidecars: %v", err)
+	}
+	if len(view.TypedColumnPartRefs) != 1 || len(view.AssetRefs) != 1 {
+		t.Fatalf("typed refs=%+v physical refs=%+v want one paired generation", view.TypedColumnPartRefs, view.AssetRefs)
+	}
+	plan, candidate, err := planColumnTypedColumnPhysicalQuery(view.FullConfig, req)
+	if err != nil || !candidate {
+		t.Fatalf("planColumnTypedColumnPhysicalQuery candidate=%v err=%v", candidate, err)
+	}
+	typedRef := view.TypedColumnPartRefs[0]
+	physicalRef := view.AssetRefs[0]
+	raw, err := readColumnPhysicalAssetFromManager(d.ColumnAssetRootDir(), typedRef.Ref)
+	if err != nil {
+		t.Fatalf("read typed-column part: %v", err)
+	}
+
+	t.Run("typed_ref_row_count_mismatch", func(t *testing.T) {
+		staleTypedRef := typedRef
+		staleTypedRef.Rows++
+		_, err := decodeTypedColumnPhysicalQueryPart(plan, view.FullConfig.SchemaHash, staleTypedRef, physicalRef, raw)
+		if err == nil || !strings.Contains(err.Error(), "image/ref mismatch") {
+			t.Fatalf("decode row-count mismatch err=%v want image/ref mismatch", err)
+		}
+	})
+	t.Run("physical_ref_row_count_mismatch", func(t *testing.T) {
+		stalePhysicalRef := physicalRef
+		stalePhysicalRef.Rows++
+		_, err := decodeTypedColumnPhysicalQueryPart(plan, view.FullConfig.SchemaHash, typedRef, stalePhysicalRef, raw)
+		if err == nil || !strings.Contains(err.Error(), "do not match physical rows") {
+			t.Fatalf("decode physical row-count mismatch err=%v want physical row mismatch", err)
+		}
+	})
+	t.Run("schema_hash_mismatch", func(t *testing.T) {
+		_, err := decodeTypedColumnPhysicalQueryPart(plan, view.FullConfig.SchemaHash+1, typedRef, physicalRef, raw)
+		if err == nil || !strings.Contains(err.Error(), "schema_version") {
+			t.Fatalf("decode schema mismatch err=%v want schema_version mismatch", err)
+		}
+	})
+}
+
+func TestColumnPhysicalJSONBenchTypedColumnPartPreparedRunnerPinsSnapshot1947(t *testing.T) {
+	events := columnPhysicalJSONBenchParityEventsP0()
+	_, collection, closeFn, _ := openColumnPhysicalJSONBenchTypedColumnPartFixture1947(t, events)
+	defer closeFn()
+
+	req := ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount, GroupColumn: "collection"}
+	runner, err := collection.PrepareColumnPhysicalQuery(req)
+	if err != nil {
+		t.Fatalf("PrepareColumnPhysicalQuery: %v", err)
+	}
+	first, err := runner.Run()
+	if err != nil {
+		t.Fatalf("prepared initial Run: %v", err)
+	}
+	firstHash := columnPhysicalJSONBenchHashLinesP0(columnPhysicalJSONBenchPhysicalLinesP0("q1", first.Groups))
+	if first.Diagnostics.RowsScanned != len(events) || first.Diagnostics.StorageSource != ColumnPhysicalQueryStorageSourceTypedColumnPartSection {
+		t.Fatalf("initial prepared diagnostics=%+v want typed-column snapshot rows=%d", first.Diagnostics, len(events))
+	}
+
+	newEvent := columnPhysicalJSONBenchParityEventP0{ID: "e99", TimeUS: events[0].TimeUS + 99*columnPhysicalQueryHourUS, Kind: "commit", Operation: "create", Collection: "app.bsky.feed.reply", Did: "did_new"}
+	if _, err := collection.InsertBatch([][]byte{[]byte(newEvent.ID)}, [][]byte{[]byte(fmt.Sprintf(`{"time_us":%d,"kind":%q,"operation":%q,"collection":%q,"did":%q}`, newEvent.TimeUS, newEvent.Kind, newEvent.Operation, newEvent.Collection, newEvent.Did))}); err != nil {
+		t.Fatalf("InsertBatch after prepare: %v", err)
+	}
+	direct, err := collection.RunColumnPhysicalQuery(req)
+	if err != nil {
+		t.Fatalf("direct RunColumnPhysicalQuery after insert: %v", err)
+	}
+	directHash := columnPhysicalJSONBenchHashLinesP0(columnPhysicalJSONBenchPhysicalLinesP0("q1", direct.Groups))
+	if direct.Diagnostics.StorageSource != ColumnPhysicalQueryStorageSourceTypedColumnPartSection || direct.Diagnostics.RowsScanned != len(events)+1 || directHash == firstHash {
+		t.Fatalf("direct after insert diagnostics=%+v hash=%016x first=%016x want latest typed-column rows=%d and changed hash", direct.Diagnostics, directHash, firstHash, len(events)+1)
+	}
+
+	pinned, err := runner.Run()
+	if err != nil {
+		t.Fatalf("prepared pinned Run after insert: %v", err)
+	}
+	pinnedHash := columnPhysicalJSONBenchHashLinesP0(columnPhysicalJSONBenchPhysicalLinesP0("q1", pinned.Groups))
+	if pinned.Diagnostics.RowsScanned != len(events) || pinnedHash != firstHash {
+		t.Fatalf("prepared pinned diagnostics=%+v hash=%016x want original rows=%d hash=%016x", pinned.Diagnostics, pinnedHash, len(events), firstHash)
+	}
+	if err := runner.Close(); err != nil {
+		t.Fatalf("runner Close: %v", err)
+	}
+	if _, err := runner.Run(); err == nil {
+		t.Fatalf("runner Run after Close succeeded; want closed-runner error")
+	}
+}
+
+func BenchmarkColumnPhysicalJSONBenchTypedColumnPartDirectSmoke1947(b *testing.B) {
+	events := columnPhysicalJSONBenchParityEventsP0()
+	_, collection, closeFn, _ := openColumnPhysicalJSONBenchTypedColumnPartFixture1947(b, events)
+	defer closeFn()
+
+	cases := []struct {
+		name string
+		req  ColumnPhysicalQueryRequest
+	}{
+		{
+			name: "q1_typed_column_part_section_no_fallback",
+			req:  ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount, GroupColumn: "collection"},
+		},
+		{
+			name: "q2_typed_column_part_section_no_fallback",
+			req: ColumnPhysicalQueryRequest{
+				Kind:           ColumnPhysicalQueryGroupCountAndDistinct,
+				GroupColumn:    "collection",
+				DistinctColumn: "did",
+				Predicates: []ColumnPhysicalQueryPredicate{
+					{Column: "kind", Value: "commit"},
+					{Column: "operation", Value: "create"},
+				},
+			},
+		},
+	}
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			preview, err := collection.RunColumnPhysicalQuery(tc.req)
+			if err != nil {
+				b.Fatalf("preview RunColumnPhysicalQuery: %v", err)
+			}
+			if preview.Diagnostics.StorageSource != ColumnPhysicalQueryStorageSourceTypedColumnPartSection || preview.Diagnostics.FallbackReason != ColumnPhysicalQueryFallbackNone {
+				b.Fatalf("preview diagnostics=%+v want typed_column_part_section/no fallback", preview.Diagnostics)
+			}
+			b.SetBytes(preview.Diagnostics.PhysicalBytesScanned)
+			b.ReportAllocs()
+			b.ResetTimer()
+			var groups int
+			var last ColumnPhysicalQueryDiagnostics
+			for i := 0; i < b.N; i++ {
+				result, err := collection.RunColumnPhysicalQuery(tc.req)
+				if err != nil {
+					b.Fatalf("RunColumnPhysicalQuery: %v", err)
+				}
+				groups += len(result.Groups)
+				last = result.Diagnostics
+			}
+			b.StopTimer()
+			if groups == 0 {
+				b.Fatal("benchmark produced no result groups")
+			}
+			b.ReportMetric(float64(last.PhysicalBytesScanned), "physical_bytes/op")
+			b.ReportMetric(float64(last.RowsScanned), "rows_scanned/op")
+			b.ReportMetric(float64(last.TypedColumnPartSections), "typed_sections/op")
+		})
+	}
+}
+
+func openColumnPhysicalJSONBenchTypedColumnPartFixture1947(tb testing.TB, events []columnPhysicalJSONBenchParityEventP0) (*backenddb.DB, *Collection, func(), []ColumnAssetRef) {
+	tb.Helper()
+	dir := tb.TempDir()
+	if err := backenddb.SaveFormatConfig(dir, backenddb.FormatConfig{RequiredFeatures: []string{backenddb.RequiredFeatureCommandWALV1}}); err != nil {
+		tb.Fatalf("SaveFormatConfig: %v", err)
+	}
+	d, err := backenddb.Open(backenddb.Options{Dir: dir, DisableBackgroundPrune: true})
+	if err != nil {
+		tb.Fatalf("Open setup DB: %v", err)
+	}
+	mgr := NewCollectionManager(d)
+	cfg := &ColumnStoreConfig{Enabled: true, Columns: []ColumnStoreColumn{
+		{Name: "time_us", Path: "time_us", ValueType: ColumnStoreValueInt64, Owner: TypedStorageOwnerColumnPart},
+		{Name: "kind", Path: "kind", ValueType: ColumnStoreValueString, Owner: TypedStorageOwnerColumnPart, Dictionary: true},
+		{Name: "operation", Path: "operation", ValueType: ColumnStoreValueString, Owner: TypedStorageOwnerColumnPart, Dictionary: true},
+		{Name: "collection", Path: "collection", ValueType: ColumnStoreValueString, Owner: TypedStorageOwnerColumnPart, Dictionary: true},
+		{Name: "did", Path: "did", ValueType: ColumnStoreValueString, Owner: TypedStorageOwnerColumnPart, Dictionary: true},
+	}}
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "events", Options: CollectionOptions{ColumnStore: cfg}}); err != nil {
+		_ = d.Close()
+		tb.Fatalf("CreateCollection: %v", err)
+	}
+	if err := d.Checkpoint(); err != nil {
+		_ = d.Close()
+		tb.Fatalf("Checkpoint setup DB: %v", err)
+	}
+	col, err := mgr.OpenCollection("events")
+	if err != nil {
+		_ = d.Close()
+		tb.Fatalf("OpenCollection setup: %v", err)
+	}
+	ids := make([][]byte, len(events))
+	docs := make([][]byte, len(events))
+	for i, event := range events {
+		ids[i] = []byte(event.ID)
+		docs[i] = []byte(fmt.Sprintf(`{"time_us":%d,"kind":%q,"operation":%q,"collection":%q,"did":%q}`, event.TimeUS, event.Kind, event.Operation, event.Collection, event.Did))
+	}
+	if _, err := col.InsertBatch(ids, docs); err != nil {
+		_ = d.Close()
+		tb.Fatalf("InsertBatch: %v", err)
+	}
+	preCloseTypedRefs := typedColumnPartRefs1755(columnManifestAssetRefsForCollectionM12A(tb, d, col))
+	if len(preCloseTypedRefs) != 1 {
+		_ = d.Close()
+		tb.Fatalf("typed refs=%+v want one", preCloseTypedRefs)
+	}
+	if err := d.Checkpoint(); err != nil {
+		_ = d.Close()
+		tb.Fatalf("Checkpoint before reopen: %v", err)
+	}
+	if err := d.Close(); err != nil {
+		tb.Fatalf("Close before reopen: %v", err)
+	}
+
+	reopen, err := backenddb.Open(backenddb.Options{Dir: dir, DisableBackgroundPrune: true})
+	if err != nil {
+		tb.Fatalf("Open reopened DB: %v", err)
+	}
+	reopened, err := NewCollectionManager(reopen).OpenCollection("events")
+	if err != nil {
+		_ = reopen.Close()
+		tb.Fatalf("OpenCollection reopened: %v", err)
+	}
+	return reopen, reopened, func() { _ = reopen.Close() }, preCloseTypedRefs
+}
+
+func assertColumnPhysicalJSONBenchTypedColumnDiagnostics1947(tb testing.TB, query string, diag ColumnPhysicalQueryDiagnostics, wantRowsScanned, wantPredicates, wantMatchedRows, wantReduceRows int) {
+	tb.Helper()
+	if diag.ManifestRootName != "events/column/manifest" || diag.ManifestRoot == 0 {
+		tb.Fatalf("%s manifest root name/id missing: %+v", query, diag)
+	}
+	if diag.ManifestGeneration == 0 || diag.ActiveManifestChecksum == 0 {
+		tb.Fatalf("%s active manifest generation/checksum missing: %+v", query, diag)
+	}
+	if diag.StorageSource != ColumnPhysicalQueryStorageSourceTypedColumnPartSection {
+		tb.Fatalf("%s storage source=%q want %q diagnostics=%+v", query, diag.StorageSource, ColumnPhysicalQueryStorageSourceTypedColumnPartSection, diag)
+	}
+	if diag.FallbackReason != ColumnPhysicalQueryFallbackNone {
+		tb.Fatalf("%s fallback reason=%q want none diagnostics=%+v", query, diag.FallbackReason, diag)
+	}
+	if diag.TypedColumnPartSections == 0 || diag.TypedColumnPartSectionBytes == 0 {
+		tb.Fatalf("%s typed-column section diagnostics missing: %+v", query, diag)
+	}
+	if diag.PhysicalBytesScanned <= 0 {
+		tb.Fatalf("%s physical bytes scanned missing: %+v", query, diag)
+	}
+	if diag.RowMaterializations != 0 || diag.DocumentMaterializations != 0 {
+		tb.Fatalf("%s materialized row/document on typed-column physical path: %+v", query, diag)
+	}
+	if diag.RowsScanned != wantRowsScanned || diag.PredicateCount != wantPredicates || diag.RowsMatched != wantMatchedRows || diag.ReduceRows != wantReduceRows {
+		tb.Fatalf("%s row/predicate diagnostics=%+v want scanned=%d predicates=%d matched=%d reduced=%d", query, diag, wantRowsScanned, wantPredicates, wantMatchedRows, wantReduceRows)
+	}
+}

--- a/TreeDB/collections/column_physical_typed_column_1947_test.go
+++ b/TreeDB/collections/column_physical_typed_column_1947_test.go
@@ -178,7 +178,7 @@ func TestColumnPhysicalJSONBenchTypedColumnPartStoresFullQ2Columns1947(t *testin
 	if !columnPhysicalJSONBenchQ2CountsEqualP0(got, want) {
 		t.Fatalf("q2 counts/distinct=%v want %v groups=%+v", got, want, result.Groups)
 	}
-	if result.Diagnostics.StorageSource != ColumnPhysicalQueryStorageSourceTypedColumnPartSection || result.Diagnostics.PredicateCount != 2 {
+	if result.Diagnostics.StorageSource != ColumnPhysicalQueryStorageSourceTypedColumnPartSection || result.Diagnostics.PredicateCount != len(q2.Predicates) {
 		t.Fatalf("q2 diagnostics=%+v want typed-column source and real predicates", result.Diagnostics)
 	}
 }

--- a/TreeDB/collections/column_physical_typed_column_1947_test.go
+++ b/TreeDB/collections/column_physical_typed_column_1947_test.go
@@ -209,8 +209,8 @@ func TestColumnPhysicalJSONBenchTypedColumnPartEdgeShapes1947(t *testing.T) {
 		t.Fatalf("hour-count result=%+v diagnostics=%+v want typed source groups", hourCount.Groups, hourCount.Diagnostics)
 	}
 	for _, group := range hourCount.Groups {
-		if group.Key == "" || group.Count == 0 || group.Hour != 0 {
-			t.Fatalf("hour-count group=%+v want key/count populated and Hour left at zero", group)
+		if group.Key == "" || group.Count == 0 || group.Key != columnPhysicalQueryHourKey(group.Hour) {
+			t.Fatalf("hour-count group=%+v want key/count/hour populated consistently", group)
 		}
 	}
 }

--- a/TreeDB/collections/column_physical_typed_column_1947_test.go
+++ b/TreeDB/collections/column_physical_typed_column_1947_test.go
@@ -239,8 +239,9 @@ func TestColumnPhysicalJSONBenchTypedColumnPartAssetFailureFailClosed1947(t *tes
 			if err == nil {
 				t.Fatalf("RunColumnPhysicalQuery after %s typed_column_part succeeded; want fail-closed error", tc.name)
 			}
-			if !strings.Contains(err.Error(), "typed-column part physical query") && !strings.Contains(err.Error(), "checksum") && !strings.Contains(err.Error(), "short") {
-				t.Fatalf("%s typed_column_part error=%v want typed-column/checksum/short-read context", tc.name, err)
+			errText := err.Error()
+			if !strings.Contains(errText, "typed-column") || (!strings.Contains(errText, "checksum") && !strings.Contains(errText, "short")) {
+				t.Fatalf("%s typed_column_part error=%v want typed-column context plus checksum/short-read context", tc.name, err)
 			}
 		})
 	}

--- a/TreeDB/collections/column_physical_typed_column_1947_test.go
+++ b/TreeDB/collections/column_physical_typed_column_1947_test.go
@@ -183,6 +183,38 @@ func TestColumnPhysicalJSONBenchTypedColumnPartStoresFullQ2Columns1947(t *testin
 	}
 }
 
+func TestColumnPhysicalJSONBenchTypedColumnPartEdgeShapes1947(t *testing.T) {
+	events := columnPhysicalJSONBenchParityEventsP0()
+	_, collection, closeFn, _ := openColumnPhysicalJSONBenchTypedColumnPartFixture1947(t, events)
+	defer closeFn()
+
+	sameColumn, err := collection.RunColumnPhysicalQuery(ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCountDistinct, GroupColumn: "collection", DistinctColumn: "collection"})
+	if err != nil {
+		t.Fatalf("RunColumnPhysicalQuery same-column count-distinct: %v", err)
+	}
+	if sameColumn.Diagnostics.StorageSource != ColumnPhysicalQueryStorageSourceTypedColumnPartSection || len(sameColumn.Groups) == 0 {
+		t.Fatalf("same-column count-distinct result=%+v diagnostics=%+v want typed source groups", sameColumn.Groups, sameColumn.Diagnostics)
+	}
+	for _, group := range sameColumn.Groups {
+		if group.Count != 1 {
+			t.Fatalf("same-column count-distinct group=%+v want distinct count 1", group)
+		}
+	}
+
+	hourCount, err := collection.RunColumnPhysicalQuery(ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryHourCount, ValueColumn: "time_us"})
+	if err != nil {
+		t.Fatalf("RunColumnPhysicalQuery hour-count: %v", err)
+	}
+	if hourCount.Diagnostics.StorageSource != ColumnPhysicalQueryStorageSourceTypedColumnPartSection || len(hourCount.Groups) == 0 {
+		t.Fatalf("hour-count result=%+v diagnostics=%+v want typed source groups", hourCount.Groups, hourCount.Diagnostics)
+	}
+	for _, group := range hourCount.Groups {
+		if group.Key == "" || group.Count == 0 || group.Hour != 0 {
+			t.Fatalf("hour-count group=%+v want key/count populated and Hour left at zero", group)
+		}
+	}
+}
+
 func TestColumnPhysicalJSONBenchTypedColumnPartAssetFailureFailClosed1947(t *testing.T) {
 	events := columnPhysicalJSONBenchParityEventsP0()
 	cases := []struct {
@@ -403,20 +435,26 @@ func openColumnPhysicalJSONBenchTypedColumnPartFixture1947(tb testing.TB, events
 		_ = d.Close()
 		tb.Fatalf("OpenCollection setup: %v", err)
 	}
-	ids := make([][]byte, len(events))
-	docs := make([][]byte, len(events))
-	for i, event := range events {
-		ids[i] = []byte(event.ID)
-		docs[i] = []byte(fmt.Sprintf(`{"time_us":%d,"kind":%q,"operation":%q,"collection":%q,"did":%q}`, event.TimeUS, event.Kind, event.Operation, event.Collection, event.Did))
-	}
-	if _, err := col.InsertBatch(ids, docs); err != nil {
-		_ = d.Close()
-		tb.Fatalf("InsertBatch: %v", err)
+	if len(events) != 0 {
+		ids := make([][]byte, len(events))
+		docs := make([][]byte, len(events))
+		for i, event := range events {
+			ids[i] = []byte(event.ID)
+			docs[i] = []byte(fmt.Sprintf(`{"time_us":%d,"kind":%q,"operation":%q,"collection":%q,"did":%q}`, event.TimeUS, event.Kind, event.Operation, event.Collection, event.Did))
+		}
+		if _, err := col.InsertBatch(ids, docs); err != nil {
+			_ = d.Close()
+			tb.Fatalf("InsertBatch: %v", err)
+		}
 	}
 	preCloseTypedRefs := typedColumnPartRefs1755(columnManifestAssetRefsForCollectionM12A(tb, d, col))
-	if len(preCloseTypedRefs) != 1 {
+	wantTypedRefs := 0
+	if len(events) != 0 {
+		wantTypedRefs = 1
+	}
+	if len(preCloseTypedRefs) != wantTypedRefs {
 		_ = d.Close()
-		tb.Fatalf("typed refs=%+v want one", preCloseTypedRefs)
+		tb.Fatalf("typed refs=%+v want %d", preCloseTypedRefs, wantTypedRefs)
 	}
 	if err := d.Checkpoint(); err != nil {
 		_ = d.Close()

--- a/TreeDB/collections/column_physical_typed_column_1947_test.go
+++ b/TreeDB/collections/column_physical_typed_column_1947_test.go
@@ -247,6 +247,27 @@ func TestColumnPhysicalJSONBenchTypedColumnPartAssetFailureFailClosed1947(t *tes
 	}
 }
 
+func TestColumnPhysicalJSONBenchTypedColumnPartMultipartRefFailsClosed1947(t *testing.T) {
+	events := columnPhysicalJSONBenchParityEventsP0()
+	d, collection, closeFn, typedRefs := openColumnPhysicalJSONBenchTypedColumnPartFixture1947(t, events)
+	defer closeFn()
+	if len(typedRefs) != 1 {
+		t.Fatalf("typed refs=%+v want one primary typed_column_part", typedRefs)
+	}
+	extraRef := publishTypedColumnMultipartPartRef1787(t, d, collection, 3)
+
+	_, err := collection.RunColumnPhysicalQuery(ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount, GroupColumn: "collection"})
+	if err == nil {
+		t.Fatalf("RunColumnPhysicalQuery with multipart typed_column_part ref succeeded; want fail-closed error")
+	}
+	errText := err.Error()
+	if !strings.Contains(errText, fmt.Sprintf("generation=%d", extraRef.Generation)) ||
+		!strings.Contains(errText, fmt.Sprintf("part_id=%d", extraRef.PartID)) ||
+		!strings.Contains(errText, "multipart/non-primary typed_column_part refs are unsupported by this physical query path") {
+		t.Fatalf("multipart typed_column_part error=%v want generation, part_id, and unsupported physical-query-path context", err)
+	}
+}
+
 func TestColumnPhysicalJSONBenchTypedColumnPartDecodeMismatchesFailClosed1947(t *testing.T) {
 	events := columnPhysicalJSONBenchParityEventsP0()
 	d, collection, closeFn, _ := openColumnPhysicalJSONBenchTypedColumnPartFixture1947(t, events)

--- a/TreeDB/collections/column_physical_typed_column_query.go
+++ b/TreeDB/collections/column_physical_typed_column_query.go
@@ -82,14 +82,17 @@ func prepareColumnTypedColumnPhysicalQueryRunner(view columnPhysicalScanSnapshot
 	if err != nil {
 		return nil, true, err
 	}
+	runner := &columnTypedColumnPhysicalQueryRunner{plan: plan, parts: make([]columnTypedColumnPhysicalQueryPart, 0, len(view.AssetRefs))}
 	if len(refsByGeneration) == 0 {
+		if len(view.AssetRefs) == 0 {
+			return runner, true, nil
+		}
 		return nil, true, errors.New("collections: missing typed_column_part assets for typed-column part physical query")
 	}
 	if _, err := validateTypedColumnPhysicalAssetPairing(refsByGeneration, view.AssetRefs); err != nil {
 		return nil, true, typedColumnPhysicalQueryPairingError(err)
 	}
 
-	runner := &columnTypedColumnPhysicalQueryRunner{plan: plan, parts: make([]columnTypedColumnPhysicalQueryPart, 0, len(view.AssetRefs))}
 	var rawScratch []byte
 	for _, physical := range view.AssetRefs {
 		if physical.Role == ColumnManifestPartRoleTombstone || physical.Reason == ColumnPublishOperationDelete {
@@ -115,7 +118,7 @@ func prepareColumnTypedColumnPhysicalQueryRunner(view columnPhysicalScanSnapshot
 		runner.sectionBytes += part.SectionBytes
 		runner.parts = append(runner.parts, part)
 	}
-	if len(runner.parts) == 0 {
+	if len(runner.parts) == 0 && len(view.AssetRefs) != 0 {
 		return nil, true, errors.New("collections: typed-column part physical query has no live typed_column_part assets")
 	}
 	return runner, true, nil
@@ -189,11 +192,12 @@ func planColumnTypedColumnPhysicalQuery(cfg ColumnStoreConfig, req ColumnPhysica
 	selected := make([]bool, len(fields))
 	fieldIndexByName := make(map[string]int, len(fields))
 	for idx, field := range fields {
-		name := field.Name
-		if name == "" {
-			name = field.Path
+		if field.Name != "" {
+			fieldIndexByName[field.Name] = idx
 		}
-		fieldIndexByName[name] = idx
+		if field.Path != "" {
+			fieldIndexByName[field.Path] = idx
+		}
 	}
 	for column := range requiredTypes {
 		idx, ok := fieldIndexByName[column]
@@ -248,7 +252,7 @@ func columnTypedColumnPhysicalQueryRequiredTypes(req ColumnPhysicalQueryRequest)
 		if err := add(req.DistinctColumn, ColumnStoreValueString, "distinct"); err != nil {
 			return nil, err
 		}
-		if req.GroupColumn == req.DistinctColumn {
+		if req.Kind == ColumnPhysicalQueryGroupCountAndDistinct && req.GroupColumn == req.DistinctColumn {
 			return nil, fmt.Errorf("%w: typed-column part physical query group and distinct columns must differ", ErrColumnQueryPlanUnsupported)
 		}
 	case ColumnPhysicalQueryHourCount:
@@ -386,6 +390,9 @@ func decodeTypedColumnPhysicalQueryPart(plan columnTypedColumnPhysicalQueryPlan,
 			return columnTypedColumnPhysicalQueryPart{}, fmt.Errorf("typed_column_part column %q decoded rows=%d want %d", name, len(columnValues), summary.Rows)
 		}
 		values[name] = columnValues
+		if field.Path != "" && field.Path != name {
+			values[field.Path] = columnValues
+		}
 	}
 	return columnTypedColumnPhysicalQueryPart{Ref: typedRef, PhysicalRef: physical, Values: values, Rows: summary.Rows, Bytes: int64(len(raw)), Sections: summary.Sections, SectionBytes: summary.SectionBytes}, nil
 }
@@ -581,7 +588,7 @@ func (a *columnTypedColumnPhysicalQueryAccumulator) groups(req ColumnPhysicalQue
 			if count == 0 {
 				continue
 			}
-			out = append(out, ColumnPhysicalQueryGroup{Key: columnPhysicalQueryHourKey(hour), Hour: hour, Count: count})
+			out = append(out, ColumnPhysicalQueryGroup{Key: columnPhysicalQueryHourKey(hour), Count: count})
 		}
 	case ColumnPhysicalQueryGroupHourCount:
 		for key, byHour := range a.groupHours {

--- a/TreeDB/collections/column_physical_typed_column_query.go
+++ b/TreeDB/collections/column_physical_typed_column_query.go
@@ -598,8 +598,11 @@ func (a *columnTypedColumnPhysicalQueryAccumulator) groups(req ColumnPhysicalQue
 			out = append(out, ColumnPhysicalQueryGroup{Key: key, Int64: span.max - span.min})
 		}
 	}
-	_ = req
-	sortColumnPhysicalQueryGroupsByKey(out)
+	if a.kind == ColumnPhysicalQueryGroupHourCount {
+		sortColumnPhysicalQueryGroupsByKeyHour(out)
+	} else {
+		sortColumnPhysicalQueryGroupsByKey(out)
+	}
 	return out
 }
 

--- a/TreeDB/collections/column_physical_typed_column_query.go
+++ b/TreeDB/collections/column_physical_typed_column_query.go
@@ -1,8 +1,10 @@
 package collections
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"sort"
 	"time"
 )
@@ -112,6 +114,9 @@ func prepareColumnTypedColumnPhysicalQueryRunner(view columnPhysicalScanSnapshot
 		runner.segmentFileCacheHits = readCache.hits
 		runner.segmentFileCacheMisses = readCache.misses
 		if err != nil {
+			if errors.Is(err, io.ErrUnexpectedEOF) {
+				return nil, true, fmt.Errorf("collections: typed-column part physical query read generation=%d part_id=%d short read: %w", typedRef.Ref.Generation, typedRef.Ref.PartID, err)
+			}
 			return nil, true, fmt.Errorf("collections: typed-column part physical query read generation=%d part_id=%d: %w", typedRef.Ref.Generation, typedRef.Ref.PartID, err)
 		}
 		rawScratch = raw
@@ -334,7 +339,7 @@ func columnTypedColumnPhysicalQueryPredicateSpecs(cfg ColumnStoreConfig, req Col
 		default:
 			return nil, fmt.Errorf("%w: unsupported typed-column part physical predicate kind %q for column %q", ErrColumnQueryPlanUnsupported, predicate.Kind, predicate.Column)
 		}
-		specs = append(specs, columnPhysicalQueryPredicateSpec{column: predicate.Column, kind: kind, values: values})
+		specs = append(specs, columnPhysicalQueryPredicateSpec{column: predicate.Column, kind: kind, values: values, valueBytes: columnPhysicalQueryPredicateValueBytes(values)})
 	}
 	return specs, nil
 }
@@ -621,22 +626,32 @@ func (a *columnTypedColumnPhysicalQueryAccumulator) groups(req ColumnPhysicalQue
 
 func typedColumnPhysicalQueryPredicatesMatch(values map[string][]columnDeclaredValue, specs []columnPhysicalQueryPredicateSpec, rowIdx int) (bool, error) {
 	for _, spec := range specs {
-		value, err := typedColumnPhysicalQueryStringAt(values, spec.column, rowIdx)
+		value, err := typedColumnPhysicalQueryStringValueAt(values, spec.column, rowIdx)
 		if err != nil {
 			return false, err
 		}
-		matched := false
-		for _, target := range spec.values {
-			if value == target {
-				matched = true
-				break
-			}
-		}
-		if !matched {
+		if !typedColumnPhysicalQueryPredicateValueMatches(value, spec) {
 			return false, nil
 		}
 	}
 	return true, nil
+}
+
+func typedColumnPhysicalQueryPredicateValueMatches(value columnDeclaredValue, spec columnPhysicalQueryPredicateSpec) bool {
+	if value.StringBytes != nil {
+		for _, target := range spec.valueBytes {
+			if bytes.Equal(value.StringBytes, target) {
+				return true
+			}
+		}
+		return false
+	}
+	for _, target := range spec.values {
+		if value.String == target {
+			return true
+		}
+	}
+	return false
 }
 
 func typedColumnPhysicalQueryStringInt64At(values map[string][]columnDeclaredValue, groupColumn, valueColumn string, rowIdx int) (string, int64, error) {
@@ -652,24 +667,32 @@ func typedColumnPhysicalQueryStringInt64At(values map[string][]columnDeclaredVal
 }
 
 func typedColumnPhysicalQueryStringAt(values map[string][]columnDeclaredValue, column string, rowIdx int) (string, error) {
-	columnValues, ok := values[column]
-	if !ok {
-		return "", fmt.Errorf("collections: typed-column part physical query missing string column %q", column)
-	}
-	if rowIdx < 0 || rowIdx >= len(columnValues) {
-		return "", fmt.Errorf("collections: typed-column part physical query row_index=%d outside column %q rows=%d", rowIdx, column, len(columnValues))
-	}
-	value := columnValues[rowIdx]
-	if value.Type != ColumnStoreValueString {
-		return "", fmt.Errorf("%w: typed-column part physical query expected string column %q, got %q", ErrColumnQueryPlanUnsupported, column, value.Type)
-	}
-	if !value.Present || value.Null {
-		return "", fmt.Errorf("%w: typed-column part physical query column %q has null/missing string value", ErrColumnQueryPlanUnsupported, column)
+	value, err := typedColumnPhysicalQueryStringValueAt(values, column, rowIdx)
+	if err != nil {
+		return "", err
 	}
 	if value.StringBytes != nil {
 		return string(value.StringBytes), nil
 	}
 	return value.String, nil
+}
+
+func typedColumnPhysicalQueryStringValueAt(values map[string][]columnDeclaredValue, column string, rowIdx int) (columnDeclaredValue, error) {
+	columnValues, ok := values[column]
+	if !ok {
+		return columnDeclaredValue{}, fmt.Errorf("collections: typed-column part physical query missing string column %q", column)
+	}
+	if rowIdx < 0 || rowIdx >= len(columnValues) {
+		return columnDeclaredValue{}, fmt.Errorf("collections: typed-column part physical query row_index=%d outside column %q rows=%d", rowIdx, column, len(columnValues))
+	}
+	value := columnValues[rowIdx]
+	if value.Type != ColumnStoreValueString {
+		return columnDeclaredValue{}, fmt.Errorf("%w: typed-column part physical query expected string column %q, got %q", ErrColumnQueryPlanUnsupported, column, value.Type)
+	}
+	if !value.Present || value.Null {
+		return columnDeclaredValue{}, fmt.Errorf("%w: typed-column part physical query column %q has null/missing string value", ErrColumnQueryPlanUnsupported, column)
+	}
+	return value, nil
 }
 
 func typedColumnPhysicalQueryInt64At(values map[string][]columnDeclaredValue, column string, rowIdx int) (int64, error) {

--- a/TreeDB/collections/column_physical_typed_column_query.go
+++ b/TreeDB/collections/column_physical_typed_column_query.go
@@ -51,18 +51,20 @@ func (c *Collection) runColumnPhysicalQueryTypedColumnPartInSnapshotView(view co
 	start := time.Now()
 	readCache, err := newColumnPhysicalAssetReadCacheWithIntegrity(view.ColumnAssetRootDir, view.AssetNamespace, req.ColumnAssetReadIntegrity)
 	if err != nil {
-		return ColumnPhysicalQueryResult{}, true, err
+		result := ColumnPhysicalQueryResult{}
+		result.Diagnostics.ScanNanos = time.Since(start).Nanoseconds()
+		return result, true, err
 	}
 	readCache.returnViews = true
 	defer func() { _ = readCache.close() }()
 	runner, candidate, err := prepareColumnTypedColumnPhysicalQueryRunner(view, req, &readCache)
 	if err != nil || !candidate {
-		return ColumnPhysicalQueryResult{}, candidate, err
+		result := ColumnPhysicalQueryResult{}
+		result.Diagnostics.ScanNanos = time.Since(start).Nanoseconds()
+		return result, candidate, err
 	}
 	result, err := runner.run(view, req)
-	if err == nil {
-		result.Diagnostics.ScanNanos = time.Since(start).Nanoseconds()
-	}
+	result.Diagnostics.ScanNanos = time.Since(start).Nanoseconds()
 	return result, true, err
 }
 

--- a/TreeDB/collections/column_physical_typed_column_query.go
+++ b/TreeDB/collections/column_physical_typed_column_query.go
@@ -349,8 +349,11 @@ func columnTypedColumnPhysicalQueryPredicateSpecs(cfg ColumnStoreConfig, req Col
 func typedColumnPhysicalQueryRefsByGeneration(view columnPhysicalScanSnapshotView) (map[uint64]columnManifestAssetRefForScan, error) {
 	refsByGeneration := make(map[uint64]columnManifestAssetRefForScan, len(view.TypedColumnPartRefs))
 	for _, ref := range view.TypedColumnPartRefs {
-		if ref.Ref.Kind != ColumnAssetKindTCS1TypedColumnPart || ref.Ref.PartID != typedColumnPartAssetPartID {
+		if ref.Ref.Kind != ColumnAssetKindTCS1TypedColumnPart {
 			continue
+		}
+		if ref.Ref.PartID != typedColumnPartAssetPartID {
+			return nil, fmt.Errorf("collections: typed-column part physical query generation=%d part_id=%d has multipart/non-primary typed_column_part ref; multipart/non-primary typed_column_part refs are unsupported by this physical query path", ref.Ref.Generation, ref.Ref.PartID)
 		}
 		if ref.Role == ColumnManifestPartRoleTombstone || ref.Reason == ColumnPublishOperationDelete {
 			return nil, fmt.Errorf("collections: typed-column part physical query got tombstone typed ref generation=%d", ref.Ref.Generation)

--- a/TreeDB/collections/column_physical_typed_column_query.go
+++ b/TreeDB/collections/column_physical_typed_column_query.go
@@ -93,6 +93,12 @@ func prepareColumnTypedColumnPhysicalQueryRunner(view columnPhysicalScanSnapshot
 		return nil, true, typedColumnPhysicalQueryPairingError(err)
 	}
 
+	// Disable returnViews during decode to avoid pinning mmaps/handles for the runner lifetime,
+	// since we fully decode to Go types and don't retain references to raw bytes.
+	savedReturnViews := readCache.returnViews
+	readCache.returnViews = false
+	defer func() { readCache.returnViews = savedReturnViews }()
+
 	var rawScratch []byte
 	for _, physical := range view.AssetRefs {
 		if physical.Role == ColumnManifestPartRoleTombstone || physical.Reason == ColumnPublishOperationDelete {

--- a/TreeDB/collections/column_physical_typed_column_query.go
+++ b/TreeDB/collections/column_physical_typed_column_query.go
@@ -599,7 +599,7 @@ func (a *columnTypedColumnPhysicalQueryAccumulator) groups(req ColumnPhysicalQue
 			if count == 0 {
 				continue
 			}
-			out = append(out, ColumnPhysicalQueryGroup{Key: columnPhysicalQueryHourKey(hour), Count: count})
+			out = append(out, ColumnPhysicalQueryGroup{Key: columnPhysicalQueryHourKey(hour), Hour: hour, Count: count})
 		}
 	case ColumnPhysicalQueryGroupHourCount:
 		for key, byHour := range a.groupHours {

--- a/TreeDB/collections/column_physical_typed_column_query.go
+++ b/TreeDB/collections/column_physical_typed_column_query.go
@@ -1,0 +1,671 @@
+package collections
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"time"
+)
+
+type columnTypedColumnPhysicalQueryPlan struct {
+	Fields               []TypedStorageField
+	Selected             []bool
+	ProjectedColumns     []string
+	PredicateDiagnostics columnPhysicalQueryPredicateDiagnosticPlan
+	GroupColumn          string
+	ValueColumn          string
+	DistinctColumn       string
+	PredicateSpecs       []columnPhysicalQueryPredicateSpec
+}
+
+type columnTypedColumnPhysicalQueryPart struct {
+	Ref          columnManifestAssetRefForScan
+	PhysicalRef  columnManifestAssetRefForScan
+	Values       map[string][]columnDeclaredValue
+	Rows         int
+	Bytes        int64
+	Sections     int
+	SectionBytes uint64
+}
+
+type columnTypedColumnPhysicalQueryRunner struct {
+	plan                   columnTypedColumnPhysicalQueryPlan
+	parts                  []columnTypedColumnPhysicalQueryPart
+	assetBytes             int64
+	sections               int
+	sectionBytes           uint64
+	segmentFileCacheHits   uint64
+	segmentFileCacheMisses uint64
+	resultGroups           []ColumnPhysicalQueryGroup
+}
+
+func (c *Collection) runColumnPhysicalQueryTypedColumnPartInSnapshotView(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest) (ColumnPhysicalQueryResult, bool, error) {
+	if !columnTypedColumnPhysicalQueryTouchesTypedColumnPart(view.FullConfig, req) {
+		return ColumnPhysicalQueryResult{}, false, nil
+	}
+	if _, candidate, err := planColumnTypedColumnPhysicalQuery(view.FullConfig, req); err != nil || !candidate {
+		return ColumnPhysicalQueryResult{}, candidate, err
+	}
+	readCache, err := newColumnPhysicalAssetReadCacheWithIntegrity(view.ColumnAssetRootDir, view.AssetNamespace, req.ColumnAssetReadIntegrity)
+	if err != nil {
+		return ColumnPhysicalQueryResult{}, true, err
+	}
+	readCache.returnViews = true
+	defer func() { _ = readCache.close() }()
+	runner, candidate, err := prepareColumnTypedColumnPhysicalQueryRunner(view, req, &readCache)
+	if err != nil || !candidate {
+		return ColumnPhysicalQueryResult{}, candidate, err
+	}
+	result, err := runner.run(view, req)
+	return result, true, err
+}
+
+func prepareColumnTypedColumnPhysicalQueryRunner(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest, readCache *columnPhysicalAssetReadCache) (*columnTypedColumnPhysicalQueryRunner, bool, error) {
+	if !columnTypedColumnPhysicalQueryTouchesTypedColumnPart(view.FullConfig, req) {
+		return nil, false, nil
+	}
+	plan, candidate, err := planColumnTypedColumnPhysicalQuery(view.FullConfig, req)
+	if err != nil || !candidate {
+		return nil, candidate, err
+	}
+	if view.MutationParts != 0 {
+		return nil, true, fmt.Errorf("%w: typed-column part physical query requires insert-only manifest", ErrColumnQueryPlanUnsupported)
+	}
+	if readCache == nil {
+		return nil, true, errors.New("collections: typed-column part physical query missing read cache")
+	}
+	refsByGeneration, err := typedColumnPhysicalQueryRefsByGeneration(view)
+	if err != nil {
+		return nil, true, err
+	}
+	if len(refsByGeneration) == 0 {
+		return nil, true, errors.New("collections: missing typed_column_part assets for typed-column part physical query")
+	}
+	if _, err := validateTypedColumnPhysicalAssetPairing(refsByGeneration, view.AssetRefs); err != nil {
+		return nil, true, typedColumnPhysicalQueryPairingError(err)
+	}
+
+	runner := &columnTypedColumnPhysicalQueryRunner{plan: plan, parts: make([]columnTypedColumnPhysicalQueryPart, 0, len(view.AssetRefs))}
+	var rawScratch []byte
+	for _, physical := range view.AssetRefs {
+		if physical.Role == ColumnManifestPartRoleTombstone || physical.Reason == ColumnPublishOperationDelete {
+			continue
+		}
+		typedRef, ok := refsByGeneration[physical.Ref.Generation]
+		if !ok {
+			return nil, true, fmt.Errorf("collections: missing typed_column_part asset for generation=%d", physical.Ref.Generation)
+		}
+		raw, err := readCache.read(typedRef.Ref, rawScratch)
+		runner.segmentFileCacheHits = readCache.hits
+		runner.segmentFileCacheMisses = readCache.misses
+		if err != nil {
+			return nil, true, fmt.Errorf("collections: typed-column part physical query read generation=%d part_id=%d: %w", typedRef.Ref.Generation, typedRef.Ref.PartID, err)
+		}
+		rawScratch = raw
+		part, err := decodeTypedColumnPhysicalQueryPart(plan, view.FullConfig.SchemaHash, typedRef, physical, raw)
+		if err != nil {
+			return nil, true, fmt.Errorf("collections: typed-column part physical query decode generation=%d part_id=%d: %w", typedRef.Ref.Generation, typedRef.Ref.PartID, err)
+		}
+		runner.assetBytes += part.Bytes
+		runner.sections += part.Sections
+		runner.sectionBytes += part.SectionBytes
+		runner.parts = append(runner.parts, part)
+	}
+	if len(runner.parts) == 0 {
+		return nil, true, errors.New("collections: typed-column part physical query has no live typed_column_part assets")
+	}
+	return runner, true, nil
+}
+
+func columnTypedColumnPhysicalQueryTouchesTypedColumnPart(cfg ColumnStoreConfig, req ColumnPhysicalQueryRequest) bool {
+	check := func(name string) bool {
+		if name == "" {
+			return false
+		}
+		col, _, ok := columnPhysicalQueryDeclaredColumn(cfg, name)
+		return ok && columnStoreColumnIsTypedColumnPart(col)
+	}
+	if check(req.GroupColumn) || check(req.ValueColumn) || check(req.DistinctColumn) {
+		return true
+	}
+	for _, predicate := range req.Predicates {
+		if check(predicate.Column) {
+			return true
+		}
+	}
+	return false
+}
+
+func planColumnTypedColumnPhysicalQuery(cfg ColumnStoreConfig, req ColumnPhysicalQueryRequest) (columnTypedColumnPhysicalQueryPlan, bool, error) {
+	if req.AggregateMetadataName != "" {
+		return columnTypedColumnPhysicalQueryPlan{}, false, nil
+	}
+	plan := columnTypedColumnPhysicalQueryPlan{PredicateDiagnostics: newColumnPhysicalQueryPredicateDiagnosticPlan(req)}
+	requiredTypes, err := columnTypedColumnPhysicalQueryRequiredTypes(req)
+	if err != nil {
+		return columnTypedColumnPhysicalQueryPlan{}, true, err
+	}
+	if len(requiredTypes) == 0 {
+		return columnTypedColumnPhysicalQueryPlan{}, false, nil
+	}
+	touchesTyped := columnTypedColumnPhysicalQueryTouchesTypedColumnPart(cfg, req)
+	anyTyped := false
+	allTyped := true
+	for column, wantType := range requiredTypes {
+		col, _, ok := columnPhysicalQueryDeclaredColumn(cfg, column)
+		if !ok {
+			if touchesTyped {
+				return columnTypedColumnPhysicalQueryPlan{}, true, fmt.Errorf("%w: typed-column part physical query requested undeclared column %q", ErrColumnQueryPlanUnsupported, column)
+			}
+			return columnTypedColumnPhysicalQueryPlan{}, false, nil
+		}
+		if col.ValueType != wantType {
+			return columnTypedColumnPhysicalQueryPlan{}, true, fmt.Errorf("%w: typed-column part physical query column %q has type %q, want %q", ErrColumnQueryPlanUnsupported, column, col.ValueType, wantType)
+		}
+		if col.Nullable {
+			return columnTypedColumnPhysicalQueryPlan{}, true, fmt.Errorf("%w: typed-column part physical query column %q does not support nullable values", ErrColumnQueryPlanUnsupported, column)
+		}
+		if columnStoreColumnIsTypedColumnPart(col) {
+			anyTyped = true
+		} else {
+			allTyped = false
+		}
+	}
+	if !anyTyped {
+		return columnTypedColumnPhysicalQueryPlan{}, false, nil
+	}
+	if !allTyped {
+		return columnTypedColumnPhysicalQueryPlan{}, true, fmt.Errorf("%w: typed-column part physical query cannot mix typed_column_part and compatibility-owned columns", ErrColumnQueryPlanUnsupported)
+	}
+	predicateSpecs, err := columnTypedColumnPhysicalQueryPredicateSpecs(cfg, req)
+	if err != nil {
+		return columnTypedColumnPhysicalQueryPlan{}, true, err
+	}
+	fields := columnStoreTypedColumnPartFields(cfg)
+	selected := make([]bool, len(fields))
+	fieldIndexByName := make(map[string]int, len(fields))
+	for idx, field := range fields {
+		name := field.Name
+		if name == "" {
+			name = field.Path
+		}
+		fieldIndexByName[name] = idx
+	}
+	for column := range requiredTypes {
+		idx, ok := fieldIndexByName[column]
+		if !ok {
+			return columnTypedColumnPhysicalQueryPlan{}, true, fmt.Errorf("collections: typed-column part physical query column %q is not in typed_column_part fields", column)
+		}
+		selected[idx] = true
+	}
+	plan.Fields = fields
+	plan.Selected = selected
+	plan.PredicateSpecs = predicateSpecs
+	plan.GroupColumn = req.GroupColumn
+	plan.ValueColumn = req.ValueColumn
+	plan.DistinctColumn = req.DistinctColumn
+	plan.ProjectedColumns = make([]string, 0, len(requiredTypes))
+	for column := range requiredTypes {
+		plan.ProjectedColumns = append(plan.ProjectedColumns, column)
+	}
+	sort.Strings(plan.ProjectedColumns)
+	return plan, true, nil
+}
+
+func columnTypedColumnPhysicalQueryRequiredTypes(req ColumnPhysicalQueryRequest) (map[string]ColumnStoreValueType, error) {
+	required := make(map[string]ColumnStoreValueType, 3+len(req.Predicates))
+	add := func(name string, valueType ColumnStoreValueType, role string) error {
+		if name == "" {
+			return fmt.Errorf("%w: typed-column part physical query %s column is required", ErrColumnQueryPlanUnsupported, role)
+		}
+		if existing, ok := required[name]; ok && existing != valueType {
+			return fmt.Errorf("%w: typed-column part physical query column %q used as both %s and %s", ErrColumnQueryPlanUnsupported, name, existing, valueType)
+		}
+		required[name] = valueType
+		return nil
+	}
+	for idx, predicate := range req.Predicates {
+		if predicate.Column == "" {
+			return nil, fmt.Errorf("%w: typed-column part physical predicate[%d] column is required", ErrColumnQueryPlanUnsupported, idx)
+		}
+		if err := add(predicate.Column, ColumnStoreValueString, "predicate"); err != nil {
+			return nil, err
+		}
+	}
+	switch req.Kind {
+	case ColumnPhysicalQueryGroupCount:
+		if err := add(req.GroupColumn, ColumnStoreValueString, "group"); err != nil {
+			return nil, err
+		}
+	case ColumnPhysicalQueryGroupCountDistinct, ColumnPhysicalQueryGroupCountAndDistinct:
+		if err := add(req.GroupColumn, ColumnStoreValueString, "group"); err != nil {
+			return nil, err
+		}
+		if err := add(req.DistinctColumn, ColumnStoreValueString, "distinct"); err != nil {
+			return nil, err
+		}
+		if req.GroupColumn == req.DistinctColumn {
+			return nil, fmt.Errorf("%w: typed-column part physical query group and distinct columns must differ", ErrColumnQueryPlanUnsupported)
+		}
+	case ColumnPhysicalQueryHourCount:
+		if err := add(req.ValueColumn, ColumnStoreValueInt64, "value"); err != nil {
+			return nil, err
+		}
+	case ColumnPhysicalQueryGroupHourCount:
+		if err := add(req.GroupColumn, ColumnStoreValueString, "group"); err != nil {
+			return nil, err
+		}
+		if err := add(req.ValueColumn, ColumnStoreValueInt64, "value"); err != nil {
+			return nil, err
+		}
+	case ColumnPhysicalQueryGroupMinInt64, ColumnPhysicalQueryGroupMaxInt64, ColumnPhysicalQueryGroupInt64Span:
+		if err := add(req.GroupColumn, ColumnStoreValueString, "group"); err != nil {
+			return nil, err
+		}
+		if err := add(req.ValueColumn, ColumnStoreValueInt64, "value"); err != nil {
+			return nil, err
+		}
+	default:
+		return nil, fmt.Errorf("%w: unsupported typed-column part physical query kind %q", ErrColumnQueryPlanUnsupported, req.Kind)
+	}
+	return required, nil
+}
+
+func columnTypedColumnPhysicalQueryPredicateSpecs(cfg ColumnStoreConfig, req ColumnPhysicalQueryRequest) ([]columnPhysicalQueryPredicateSpec, error) {
+	if len(req.Predicates) == 0 {
+		return nil, nil
+	}
+	seen := make(map[string]struct{}, len(req.Predicates))
+	specs := make([]columnPhysicalQueryPredicateSpec, 0, len(req.Predicates))
+	for idx, predicate := range req.Predicates {
+		if predicate.Column == "" {
+			return nil, fmt.Errorf("%w: typed-column part physical predicate[%d] column is required", ErrColumnQueryPlanUnsupported, idx)
+		}
+		if _, ok := seen[predicate.Column]; ok {
+			return nil, fmt.Errorf("%w: multiple typed-column part physical predicates on column %q are not supported", ErrColumnQueryPlanUnsupported, predicate.Column)
+		}
+		seen[predicate.Column] = struct{}{}
+		col, _, ok := columnPhysicalQueryDeclaredColumn(cfg, predicate.Column)
+		if !ok {
+			return nil, fmt.Errorf("%w: typed-column part physical predicate requested undeclared column %q", ErrColumnQueryPlanUnsupported, predicate.Column)
+		}
+		if col.ValueType != ColumnStoreValueString {
+			return nil, fmt.Errorf("%w: typed-column part physical predicate column %q has type %q, want %q", ErrColumnQueryPlanUnsupported, predicate.Column, col.ValueType, ColumnStoreValueString)
+		}
+		if col.Nullable {
+			return nil, fmt.Errorf("%w: typed-column part physical predicate column %q does not support nullable values", ErrColumnQueryPlanUnsupported, predicate.Column)
+		}
+		if !columnStoreColumnIsTypedColumnPart(col) {
+			return nil, fmt.Errorf("%w: typed-column part physical predicate column %q is not owned by typed_column_part", ErrColumnQueryPlanUnsupported, predicate.Column)
+		}
+		kind := columnPhysicalQueryPredicateKindOrDefault(predicate.Kind)
+		var values []string
+		switch kind {
+		case ColumnPhysicalQueryPredicateEqual:
+			if len(predicate.Values) != 0 {
+				return nil, fmt.Errorf("%w: typed-column part physical predicate column %q equal uses Value, not Values", ErrColumnQueryPlanUnsupported, predicate.Column)
+			}
+			values = []string{predicate.Value}
+		case ColumnPhysicalQueryPredicateInList:
+			if predicate.Value != "" {
+				return nil, fmt.Errorf("%w: typed-column part physical predicate column %q in-list uses Values, not Value", ErrColumnQueryPlanUnsupported, predicate.Column)
+			}
+			if len(predicate.Values) == 0 {
+				return nil, fmt.Errorf("%w: typed-column part physical predicate column %q in-list requires at least one value", ErrColumnQueryPlanUnsupported, predicate.Column)
+			}
+			if len(predicate.Values) > columnPhysicalQueryMaxPredicateValues {
+				return nil, fmt.Errorf("%w: typed-column part physical predicate column %q in-list values=%d exceeds limit=%d", ErrColumnQueryPlanUnsupported, predicate.Column, len(predicate.Values), columnPhysicalQueryMaxPredicateValues)
+			}
+			values = append([]string(nil), predicate.Values...)
+		default:
+			return nil, fmt.Errorf("%w: unsupported typed-column part physical predicate kind %q for column %q", ErrColumnQueryPlanUnsupported, predicate.Kind, predicate.Column)
+		}
+		specs = append(specs, columnPhysicalQueryPredicateSpec{column: predicate.Column, kind: kind, values: values})
+	}
+	return specs, nil
+}
+
+func typedColumnPhysicalQueryRefsByGeneration(view columnPhysicalScanSnapshotView) (map[uint64]columnManifestAssetRefForScan, error) {
+	refsByGeneration := make(map[uint64]columnManifestAssetRefForScan, len(view.TypedColumnPartRefs))
+	for _, ref := range view.TypedColumnPartRefs {
+		if ref.Ref.Kind != ColumnAssetKindTCS1TypedColumnPart || ref.Ref.PartID != typedColumnPartAssetPartID {
+			continue
+		}
+		if ref.Role == ColumnManifestPartRoleTombstone || ref.Reason == ColumnPublishOperationDelete {
+			return nil, fmt.Errorf("collections: typed-column part physical query got tombstone typed ref generation=%d", ref.Ref.Generation)
+		}
+		if _, exists := refsByGeneration[ref.Ref.Generation]; exists {
+			return nil, fmt.Errorf("collections: duplicate typed_column_part ref for generation=%d", ref.Ref.Generation)
+		}
+		refsByGeneration[ref.Ref.Generation] = ref
+	}
+	return refsByGeneration, nil
+}
+
+func typedColumnPhysicalQueryPairingError(err error) error {
+	var reasonErr typedColumnPhysicalAssetPairingReasonError
+	if errors.As(err, &reasonErr) {
+		return fmt.Errorf("collections: typed-column part physical query requires insert-only physical refs, got %s", reasonErr.reason)
+	}
+	return err
+}
+
+func decodeTypedColumnPhysicalQueryPart(plan columnTypedColumnPhysicalQueryPlan, schemaHash uint64, typedRef, physical columnManifestAssetRefForScan, raw []byte) (columnTypedColumnPhysicalQueryPart, error) {
+	adapterPart, summary, err := typedColumnAdapterPartFromBytesForReconstructionWithSummary(typedColumnAdapterOptions{Fields: plan.Fields, SchemaVersion: uint32(schemaHash)}, raw)
+	if err != nil {
+		return columnTypedColumnPhysicalQueryPart{}, err
+	}
+	if summary.PartID != typedRef.Ref.PartID || summary.Rows != typedRef.Rows {
+		return columnTypedColumnPhysicalQueryPart{}, fmt.Errorf("typed_column_part image/ref mismatch image_part=%d ref_part=%d image_rows=%d manifest_rows=%d", summary.PartID, typedRef.Ref.PartID, summary.Rows, typedRef.Rows)
+	}
+	if physical.Rows != 0 && summary.Rows != physical.Rows {
+		return columnTypedColumnPhysicalQueryPart{}, fmt.Errorf("typed_column_part rows=%d do not match physical rows=%d", summary.Rows, physical.Rows)
+	}
+	decoded, err := adapterPart.scanDecodedValuesSelected(plan.Selected)
+	if err != nil {
+		return columnTypedColumnPhysicalQueryPart{}, err
+	}
+	if len(decoded.PrimaryIDs) != summary.Rows {
+		return columnTypedColumnPhysicalQueryPart{}, fmt.Errorf("typed_column_part decoded primary rows=%d want %d", len(decoded.PrimaryIDs), summary.Rows)
+	}
+	values := make(map[string][]columnDeclaredValue, len(plan.ProjectedColumns))
+	for idx, field := range plan.Fields {
+		if !plan.Selected[idx] {
+			continue
+		}
+		name := field.Name
+		if name == "" {
+			name = field.Path
+		}
+		columnValues := decoded.Values[idx]
+		if len(columnValues) != summary.Rows {
+			return columnTypedColumnPhysicalQueryPart{}, fmt.Errorf("typed_column_part column %q decoded rows=%d want %d", name, len(columnValues), summary.Rows)
+		}
+		values[name] = columnValues
+	}
+	return columnTypedColumnPhysicalQueryPart{Ref: typedRef, PhysicalRef: physical, Values: values, Rows: summary.Rows, Bytes: int64(len(raw)), Sections: summary.Sections, SectionBytes: summary.SectionBytes}, nil
+}
+
+func (r *columnTypedColumnPhysicalQueryRunner) run(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest) (ColumnPhysicalQueryResult, error) {
+	start := time.Now()
+	acc := newColumnTypedColumnPhysicalQueryAccumulator(req.Kind)
+	rowsScanned := 0
+	matchedRows := 0
+	for _, part := range r.parts {
+		rowsScanned += part.Rows
+		for rowIdx := 0; rowIdx < part.Rows; rowIdx++ {
+			matched, err := typedColumnPhysicalQueryPredicatesMatch(part.Values, r.plan.PredicateSpecs, rowIdx)
+			if err != nil {
+				return ColumnPhysicalQueryResult{Diagnostics: r.diagnostics(view, req, rowsScanned, matchedRows, acc.reduceRows, time.Since(start).Nanoseconds())}, err
+			}
+			if !matched {
+				continue
+			}
+			if len(r.plan.PredicateSpecs) != 0 {
+				matchedRows++
+			}
+			if err := acc.visit(req, part.Values, rowIdx); err != nil {
+				result := ColumnPhysicalQueryResult{Diagnostics: r.diagnostics(view, req, rowsScanned, matchedRows, acc.reduceRows, time.Since(start).Nanoseconds())}
+				return result, err
+			}
+		}
+	}
+	groups := acc.groups(req, r.resultGroups)
+	r.resultGroups = groups
+	diag := r.diagnostics(view, req, rowsScanned, matchedRows, acc.reduceRows, time.Since(start).Nanoseconds())
+	diag.ResultGroups = len(groups)
+	return ColumnPhysicalQueryResult{Groups: groups, Diagnostics: diag}, nil
+}
+
+func (r *columnTypedColumnPhysicalQueryRunner) diagnostics(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest, rowsScanned, matchedRows, reduceRows int, scanNanos int64) ColumnPhysicalQueryDiagnostics {
+	diag := columnPhysicalQueryDiagnosticsFromScan(view.Diagnostics)
+	diag.WorkerCount = 1
+	diag.ProjectedColumns = len(r.plan.ProjectedColumns)
+	diag.ScheduledGranules = len(r.parts)
+	diag.DecodedBlocks = len(r.parts)
+	diag.DirectReduceBlocks = len(r.parts)
+	diag.TypedColumnPartSections = r.sections
+	diag.TypedColumnPartSectionBytes = r.sectionBytes
+	diag.RowsScanned = rowsScanned
+	diag.PhysicalBytesScanned = r.assetBytes
+	diag.ReduceRows = reduceRows
+	diag.ColumnAssetReadIntegrity = columnAssetReadIntegrityLabel(req.ColumnAssetReadIntegrity)
+	diag.StorageSource = ColumnPhysicalQueryStorageSourceTypedColumnPartSection
+	diag.FallbackReason = ColumnPhysicalQueryFallbackNone
+	diag.SegmentFileCacheHits = r.segmentFileCacheHits
+	diag.SegmentFileCacheMisses = r.segmentFileCacheMisses
+	applyColumnPhysicalQueryPredicateDiagnostics(&diag, r.plan.PredicateDiagnostics, matchedRows, 0)
+	diag.ScanNanos = scanNanos
+	return diag
+}
+
+type columnTypedColumnPhysicalQueryAccumulator struct {
+	kind        ColumnPhysicalQueryKind
+	counts      map[string]int
+	distinct    map[string]map[string]struct{}
+	hourCounts  [24]int
+	groupHours  map[string]map[int]int
+	int64Values map[string]int64
+	int64Spans  map[string]columnPhysicalQuerySpan
+	reduceRows  int
+}
+
+func newColumnTypedColumnPhysicalQueryAccumulator(kind ColumnPhysicalQueryKind) *columnTypedColumnPhysicalQueryAccumulator {
+	acc := &columnTypedColumnPhysicalQueryAccumulator{kind: kind}
+	switch kind {
+	case ColumnPhysicalQueryGroupCount:
+		acc.counts = make(map[string]int)
+	case ColumnPhysicalQueryGroupCountDistinct, ColumnPhysicalQueryGroupCountAndDistinct:
+		acc.counts = make(map[string]int)
+		acc.distinct = make(map[string]map[string]struct{})
+	case ColumnPhysicalQueryGroupHourCount:
+		acc.groupHours = make(map[string]map[int]int)
+	case ColumnPhysicalQueryGroupMinInt64, ColumnPhysicalQueryGroupMaxInt64:
+		acc.int64Values = make(map[string]int64)
+	case ColumnPhysicalQueryGroupInt64Span:
+		acc.int64Spans = make(map[string]columnPhysicalQuerySpan)
+	}
+	return acc
+}
+
+func (a *columnTypedColumnPhysicalQueryAccumulator) visit(req ColumnPhysicalQueryRequest, values map[string][]columnDeclaredValue, rowIdx int) error {
+	a.reduceRows++
+	switch a.kind {
+	case ColumnPhysicalQueryGroupCount:
+		key, err := typedColumnPhysicalQueryStringAt(values, req.GroupColumn, rowIdx)
+		if err != nil {
+			return err
+		}
+		a.counts[key]++
+	case ColumnPhysicalQueryGroupCountDistinct, ColumnPhysicalQueryGroupCountAndDistinct:
+		key, err := typedColumnPhysicalQueryStringAt(values, req.GroupColumn, rowIdx)
+		if err != nil {
+			return err
+		}
+		distinct, err := typedColumnPhysicalQueryStringAt(values, req.DistinctColumn, rowIdx)
+		if err != nil {
+			return err
+		}
+		if a.kind == ColumnPhysicalQueryGroupCountAndDistinct {
+			a.counts[key]++
+		}
+		set := a.distinct[key]
+		if set == nil {
+			set = make(map[string]struct{})
+			a.distinct[key] = set
+		}
+		set[distinct] = struct{}{}
+	case ColumnPhysicalQueryHourCount:
+		value, err := typedColumnPhysicalQueryInt64At(values, req.ValueColumn, rowIdx)
+		if err != nil {
+			return err
+		}
+		a.hourCounts[columnPhysicalQueryUTCHour(value)]++
+	case ColumnPhysicalQueryGroupHourCount:
+		key, err := typedColumnPhysicalQueryStringAt(values, req.GroupColumn, rowIdx)
+		if err != nil {
+			return err
+		}
+		value, err := typedColumnPhysicalQueryInt64At(values, req.ValueColumn, rowIdx)
+		if err != nil {
+			return err
+		}
+		hour := columnPhysicalQueryUTCHour(value)
+		byHour := a.groupHours[key]
+		if byHour == nil {
+			byHour = make(map[int]int)
+			a.groupHours[key] = byHour
+		}
+		byHour[hour]++
+	case ColumnPhysicalQueryGroupMinInt64:
+		key, value, err := typedColumnPhysicalQueryStringInt64At(values, req.GroupColumn, req.ValueColumn, rowIdx)
+		if err != nil {
+			return err
+		}
+		if cur, ok := a.int64Values[key]; !ok || value < cur {
+			a.int64Values[key] = value
+		}
+	case ColumnPhysicalQueryGroupMaxInt64:
+		key, value, err := typedColumnPhysicalQueryStringInt64At(values, req.GroupColumn, req.ValueColumn, rowIdx)
+		if err != nil {
+			return err
+		}
+		if cur, ok := a.int64Values[key]; !ok || value > cur {
+			a.int64Values[key] = value
+		}
+	case ColumnPhysicalQueryGroupInt64Span:
+		key, value, err := typedColumnPhysicalQueryStringInt64At(values, req.GroupColumn, req.ValueColumn, rowIdx)
+		if err != nil {
+			return err
+		}
+		cur, ok := a.int64Spans[key]
+		if !ok {
+			a.int64Spans[key] = columnPhysicalQuerySpan{min: value, max: value}
+			return nil
+		}
+		if value < cur.min {
+			cur.min = value
+		}
+		if value > cur.max {
+			cur.max = value
+		}
+		a.int64Spans[key] = cur
+	default:
+		return fmt.Errorf("%w: unsupported typed-column part physical query kind %q", ErrColumnQueryPlanUnsupported, a.kind)
+	}
+	return nil
+}
+
+func (a *columnTypedColumnPhysicalQueryAccumulator) groups(req ColumnPhysicalQueryRequest, dst []ColumnPhysicalQueryGroup) []ColumnPhysicalQueryGroup {
+	out := dst[:0]
+	switch a.kind {
+	case ColumnPhysicalQueryGroupCount:
+		for key, count := range a.counts {
+			out = append(out, ColumnPhysicalQueryGroup{Key: key, Count: count})
+		}
+	case ColumnPhysicalQueryGroupCountDistinct, ColumnPhysicalQueryGroupCountAndDistinct:
+		for key, set := range a.distinct {
+			group := ColumnPhysicalQueryGroup{Key: key, Count: len(set)}
+			if a.kind == ColumnPhysicalQueryGroupCountAndDistinct {
+				group.Count = a.counts[key]
+				group.DistinctCount = len(set)
+			}
+			out = append(out, group)
+		}
+	case ColumnPhysicalQueryHourCount:
+		for hour, count := range a.hourCounts {
+			if count == 0 {
+				continue
+			}
+			out = append(out, ColumnPhysicalQueryGroup{Key: columnPhysicalQueryHourKey(hour), Hour: hour, Count: count})
+		}
+	case ColumnPhysicalQueryGroupHourCount:
+		for key, byHour := range a.groupHours {
+			for hour, count := range byHour {
+				out = append(out, ColumnPhysicalQueryGroup{Key: key, Hour: hour, Count: count})
+			}
+		}
+	case ColumnPhysicalQueryGroupMinInt64, ColumnPhysicalQueryGroupMaxInt64:
+		for key, value := range a.int64Values {
+			out = append(out, ColumnPhysicalQueryGroup{Key: key, Int64: value})
+		}
+	case ColumnPhysicalQueryGroupInt64Span:
+		for key, span := range a.int64Spans {
+			out = append(out, ColumnPhysicalQueryGroup{Key: key, Int64: span.max - span.min})
+		}
+	}
+	_ = req
+	sortColumnPhysicalQueryGroupsByKey(out)
+	return out
+}
+
+func typedColumnPhysicalQueryPredicatesMatch(values map[string][]columnDeclaredValue, specs []columnPhysicalQueryPredicateSpec, rowIdx int) (bool, error) {
+	for _, spec := range specs {
+		value, err := typedColumnPhysicalQueryStringAt(values, spec.column, rowIdx)
+		if err != nil {
+			return false, err
+		}
+		matched := false
+		for _, target := range spec.values {
+			if value == target {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func typedColumnPhysicalQueryStringInt64At(values map[string][]columnDeclaredValue, groupColumn, valueColumn string, rowIdx int) (string, int64, error) {
+	key, err := typedColumnPhysicalQueryStringAt(values, groupColumn, rowIdx)
+	if err != nil {
+		return "", 0, err
+	}
+	value, err := typedColumnPhysicalQueryInt64At(values, valueColumn, rowIdx)
+	if err != nil {
+		return "", 0, err
+	}
+	return key, value, nil
+}
+
+func typedColumnPhysicalQueryStringAt(values map[string][]columnDeclaredValue, column string, rowIdx int) (string, error) {
+	columnValues, ok := values[column]
+	if !ok {
+		return "", fmt.Errorf("collections: typed-column part physical query missing string column %q", column)
+	}
+	if rowIdx < 0 || rowIdx >= len(columnValues) {
+		return "", fmt.Errorf("collections: typed-column part physical query row_index=%d outside column %q rows=%d", rowIdx, column, len(columnValues))
+	}
+	value := columnValues[rowIdx]
+	if value.Type != ColumnStoreValueString {
+		return "", fmt.Errorf("%w: typed-column part physical query expected string column %q, got %q", ErrColumnQueryPlanUnsupported, column, value.Type)
+	}
+	if !value.Present || value.Null {
+		return "", fmt.Errorf("%w: typed-column part physical query column %q has null/missing string value", ErrColumnQueryPlanUnsupported, column)
+	}
+	if value.StringBytes != nil {
+		return string(value.StringBytes), nil
+	}
+	return value.String, nil
+}
+
+func typedColumnPhysicalQueryInt64At(values map[string][]columnDeclaredValue, column string, rowIdx int) (int64, error) {
+	columnValues, ok := values[column]
+	if !ok {
+		return 0, fmt.Errorf("collections: typed-column part physical query missing int64 column %q", column)
+	}
+	if rowIdx < 0 || rowIdx >= len(columnValues) {
+		return 0, fmt.Errorf("collections: typed-column part physical query row_index=%d outside column %q rows=%d", rowIdx, column, len(columnValues))
+	}
+	value := columnValues[rowIdx]
+	if value.Type != ColumnStoreValueInt64 {
+		return 0, fmt.Errorf("%w: typed-column part physical query expected int64 column %q, got %q", ErrColumnQueryPlanUnsupported, column, value.Type)
+	}
+	if !value.Present || value.Null {
+		return 0, fmt.Errorf("%w: typed-column part physical query column %q has null/missing int64 value", ErrColumnQueryPlanUnsupported, column)
+	}
+	return value.Int64, nil
+}

--- a/TreeDB/collections/column_physical_typed_column_query.go
+++ b/TreeDB/collections/column_physical_typed_column_query.go
@@ -46,6 +46,7 @@ func (c *Collection) runColumnPhysicalQueryTypedColumnPartInSnapshotView(view co
 	if _, candidate, err := planColumnTypedColumnPhysicalQuery(view.FullConfig, req); err != nil || !candidate {
 		return ColumnPhysicalQueryResult{}, candidate, err
 	}
+	start := time.Now()
 	readCache, err := newColumnPhysicalAssetReadCacheWithIntegrity(view.ColumnAssetRootDir, view.AssetNamespace, req.ColumnAssetReadIntegrity)
 	if err != nil {
 		return ColumnPhysicalQueryResult{}, true, err
@@ -57,6 +58,9 @@ func (c *Collection) runColumnPhysicalQueryTypedColumnPartInSnapshotView(view co
 		return ColumnPhysicalQueryResult{}, candidate, err
 	}
 	result, err := runner.run(view, req)
+	if err == nil {
+		result.Diagnostics.ScanNanos = time.Since(start).Nanoseconds()
+	}
 	return result, true, err
 }
 
@@ -392,8 +396,8 @@ func (r *columnTypedColumnPhysicalQueryRunner) run(view columnPhysicalScanSnapsh
 	rowsScanned := 0
 	matchedRows := 0
 	for _, part := range r.parts {
-		rowsScanned += part.Rows
 		for rowIdx := 0; rowIdx < part.Rows; rowIdx++ {
+			rowsScanned++
 			matched, err := typedColumnPhysicalQueryPredicatesMatch(part.Values, r.plan.PredicateSpecs, rowIdx)
 			if err != nil {
 				return ColumnPhysicalQueryResult{Diagnostics: r.diagnostics(view, req, rowsScanned, matchedRows, acc.reduceRows, time.Since(start).Nanoseconds())}, err

--- a/TreeDB/collections/typed_column_adapter.go
+++ b/TreeDB/collections/typed_column_adapter.go
@@ -93,6 +93,13 @@ type typedColumnAdapterResourceReader struct {
 	AllowHeapCopy bool
 }
 
+type typedColumnAdapterImageSummary struct {
+	PartID       uint64
+	Rows         int
+	Sections     int
+	SectionBytes uint64
+}
+
 func typedColumnAdapterTypeMatrix() []typedColumnAdapterTypeMapping {
 	return []typedColumnAdapterTypeMapping{
 		{ValueType: ColumnStoreValueBool, Status: typedColumnAdapterRepresented, ColumnType: typedcolumn.ColumnTypeBool, Encoding: typedcolumn.EncodingBoolBitpackRLE},
@@ -466,11 +473,26 @@ func typedColumnAdapterPartFromBytes(opts typedColumnAdapterOptions, raw []byte)
 }
 
 func typedColumnAdapterPartFromBytesForReconstruction(opts typedColumnAdapterOptions, raw []byte) (*typedColumnAdapterPart, error) {
+	part, _, err := typedColumnAdapterPartFromBytesForReconstructionWithSummary(opts, raw)
+	return part, err
+}
+
+func typedColumnAdapterPartFromBytesForReconstructionWithSummary(opts typedColumnAdapterOptions, raw []byte) (*typedColumnAdapterPart, typedColumnAdapterImageSummary, error) {
 	image, err := typedcolumn.ParseColumnPartImage(raw)
 	if err != nil {
-		return nil, err
+		return nil, typedColumnAdapterImageSummary{}, err
 	}
-	return typedColumnAdapterPartFromImageWithoutRowLocators(opts, image)
+	part, err := typedColumnAdapterPartFromImageWithoutRowLocators(opts, image)
+	if err != nil {
+		return nil, typedColumnAdapterImageSummary{}, err
+	}
+	sectionBytes := uint64(0)
+	for _, section := range image.Sections {
+		if section.Length > 0 {
+			sectionBytes += uint64(section.Length)
+		}
+	}
+	return part, typedColumnAdapterImageSummary{PartID: image.PartID, Rows: image.Rows, Sections: len(image.Sections), SectionBytes: sectionBytes}, nil
 }
 
 func typedColumnAdapterPartFromImage(opts typedColumnAdapterOptions, image typedcolumn.ColumnPartImage) (*typedColumnAdapterPart, error) {

--- a/TreeDB/collections/typed_column_publication_test.go
+++ b/TreeDB/collections/typed_column_publication_test.go
@@ -1853,8 +1853,12 @@ func TestTypedColumnPhysicalQueryFailsClosedForColumnPartFields(t *testing.T) {
 func runTypedColumnPhysicalQueryFailsClosedForColumnPartFields1778(t *testing.T) {
 	d, col, _ := setupSingleTypedColumnPart1755(t)
 	defer func() { _ = d.Close() }()
-	if _, err := col.RunColumnPhysicalQuery(ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount, GroupColumn: "kind"}); !errors.Is(err, ErrColumnQueryPlanUnsupported) {
-		t.Fatalf("RunColumnPhysicalQuery typed-column group err=%v want ErrColumnQueryPlanUnsupported", err)
+	typedResult, err := col.RunColumnPhysicalQuery(ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount, GroupColumn: "kind"})
+	if err != nil {
+		t.Fatalf("RunColumnPhysicalQuery typed-column group: %v", err)
+	}
+	if typedResult.Diagnostics.StorageSource != ColumnPhysicalQueryStorageSourceTypedColumnPartSection || typedResult.Diagnostics.FallbackReason != ColumnPhysicalQueryFallbackNone || typedResult.Diagnostics.TypedColumnPartSections == 0 {
+		t.Fatalf("typed-column group diagnostics=%+v want typed_column_part_section without fallback", typedResult.Diagnostics)
 	}
 	result, err := col.RunColumnPhysicalQuery(ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryHourCount, ValueColumn: "time_us"})
 	if err != nil {

--- a/TreeDB/collections/typed_column_publication_test.go
+++ b/TreeDB/collections/typed_column_publication_test.go
@@ -1842,15 +1842,15 @@ func runTypedColumnColumnAssetRewriteRoundTripMixedRefs1778(t *testing.T) {
 	assertJSONEqualM13C(t, afterGC, []byte(`{"time_us":1,"kind":"like","score":2.5,"flag":true}`))
 }
 
-func TestTypedColumnPhysicalQueryTypedColumnFieldsFailClosed(t *testing.T) {
-	runTypedColumnPhysicalQueryFailsClosedForColumnPartFields1778(t)
+func TestTypedColumnPhysicalQueryTypedColumnFieldsSucceed(t *testing.T) {
+	runTypedColumnPhysicalQueryTypedColumnFieldsSucceed1778(t)
 }
 
-func TestTypedColumnPhysicalQueryFailsClosedForColumnPartFields(t *testing.T) {
-	runTypedColumnPhysicalQueryFailsClosedForColumnPartFields1778(t)
+func TestTypedColumnPhysicalQueryTypedColumnPartFields(t *testing.T) {
+	runTypedColumnPhysicalQueryTypedColumnFieldsSucceed1778(t)
 }
 
-func runTypedColumnPhysicalQueryFailsClosedForColumnPartFields1778(t *testing.T) {
+func runTypedColumnPhysicalQueryTypedColumnFieldsSucceed1778(t *testing.T) {
 	d, col, _ := setupSingleTypedColumnPart1755(t)
 	defer func() { _ = d.Close() }()
 	typedResult, err := col.RunColumnPhysicalQuery(ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount, GroupColumn: "kind"})

--- a/TreeDB/collections/typed_column_publication_test.go
+++ b/TreeDB/collections/typed_column_publication_test.go
@@ -1846,10 +1846,6 @@ func TestTypedColumnPhysicalQueryTypedColumnFieldsSucceed(t *testing.T) {
 	runTypedColumnPhysicalQueryTypedColumnFieldsSucceed1778(t)
 }
 
-func TestTypedColumnPhysicalQueryTypedColumnPartFields(t *testing.T) {
-	runTypedColumnPhysicalQueryTypedColumnFieldsSucceed1778(t)
-}
-
 func runTypedColumnPhysicalQueryTypedColumnFieldsSucceed1778(t *testing.T) {
 	d, col, _ := setupSingleTypedColumnPart1755(t)
 	defer func() { _ = d.Close() }()

--- a/TreeDB/collections/typed_column_publication_test.go
+++ b/TreeDB/collections/typed_column_publication_test.go
@@ -1853,8 +1853,11 @@ func runTypedColumnPhysicalQueryTypedColumnFieldsSucceed1778(t *testing.T) {
 	if err != nil {
 		t.Fatalf("RunColumnPhysicalQuery typed-column group: %v", err)
 	}
-	if typedResult.Diagnostics.StorageSource != ColumnPhysicalQueryStorageSourceTypedColumnPartSection || typedResult.Diagnostics.FallbackReason != ColumnPhysicalQueryFallbackNone || typedResult.Diagnostics.TypedColumnPartSections == 0 {
+	if typedResult.Diagnostics.StorageSource != ColumnPhysicalQueryStorageSourceTypedColumnPartSection || typedResult.Diagnostics.FallbackReason != ColumnPhysicalQueryFallbackNone || typedResult.Diagnostics.TypedColumnPartSections == 0 || typedResult.Diagnostics.TypedColumnPartSectionBytes == 0 {
 		t.Fatalf("typed-column group diagnostics=%+v want typed_column_part_section without fallback", typedResult.Diagnostics)
+	}
+	if len(typedResult.Groups) != 1 || typedResult.Groups[0].Key != "like" || typedResult.Groups[0].Count != 1 {
+		t.Fatalf("typed-column group result=%+v want one like group with count 1", typedResult.Groups)
 	}
 	result, err := col.RunColumnPhysicalQuery(ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryHourCount, ValueColumn: "time_us"})
 	if err != nil {

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -328,6 +328,8 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/column_physical_query.go", classification: typedStorageLegacyDeferred, matchingLines: 37, occurrences: 39},
 	{path: "TreeDB/collections/column_physical_query_1890_bench_test.go", classification: typedStorageLegacyDeferred, matchingLines: 1, occurrences: 2},
 	{path: "TreeDB/collections/column_physical_jsonbench_parity_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 7, occurrences: 8},
+	{path: "TreeDB/collections/column_physical_typed_column_1947_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 7, occurrences: 8},
+	{path: "TreeDB/collections/column_physical_typed_column_query.go", classification: typedStorageLegacyCompatibility, matchingLines: 19, occurrences: 19},
 	{path: "TreeDB/collections/column_physical_query_test.go", classification: typedStorageLegacyDeferred, matchingLines: 144, occurrences: 158},
 	{path: "TreeDB/collections/column_physical_row_reader.go", classification: typedStorageLegacyDeferred, matchingLines: 23, occurrences: 23},
 	{path: "TreeDB/collections/column_physical_row_reader_test.go", classification: typedStorageLegacyDeferred, matchingLines: 19, occurrences: 20},


### PR DESCRIPTION
## Summary

- Adds a typed-column-part physical query runner for JSONBench q1-q5-compatible scalar/string shapes.
- Routes fully `typed_column_part`-owned physical query columns through durable `tcs1_typed_column_part` assets before compatibility sidecars.
- Reports `StorageSource=typed_column_part_section`, `FallbackReason=none`, `TypedColumnPartSections`, and `TypedColumnPartSectionBytes` when that substrate is actually used.
- Keeps compatibility dictionary/int64 asset paths for row-asset-owned P0 fixtures.

## Scope boundaries

This is substrate-only. It does **not** add SortKey ordering, marks/pruning, dense direct kernels, aggregate metadata, codecs, multipart compaction, lifecycle/GC, JSONBench cells, or document-leaf column pointers. It intentionally makes no performance-improvement claim.

## Safety / tests

Latest head: `4cd8487`.

- `GOWORK=off go test ./TreeDB/collections -run 'TestTypedStorageLegacyNameAllowlistIsComplete|1947|JSONBenchParity|TypedColumnPhysicalQuery|TestColumnPhysicalQueryAdapterRejectsUnsupportedShapeM13B|TestColumnPhysicalQuerySerialSidecarAllocationBudgetM1634|TestColumnPhysicalQueryRunnerDistinctSidecarSkipsIdenticalColumnsM1634'`
  - artifact: `/tmp/orca_issue_graph_1945_1955/1947_test_post_review_focused_20260529_000347.txt`
- `GOWORK=off go test ./TreeDB/internal/typedcolumn ./TreeDB/collections`
  - artifact: `/tmp/orca_issue_graph_1945_1955/1947_test_typedcolumn_collections_20260529_000408.txt`
- `GOWORK=off go test ./TreeDB/collections -run '1947|TypedColumnPhysicalQuery'`
  - artifact: `/tmp/orca_issue_graph_1945_1955/1947_multipart_fix_tests_20260529_005526.txt`
- `GOWORK=off go test ./TreeDB/collections`
  - artifact: local coordinator final validation passed on 2026-05-29

Added coverage includes reopen/direct/prepared q1-q5 parity, full q2 predicate/group/distinct columns (no masking/sentinel payloads), missing/truncated/corrupt typed-column assets fail-closed, multipart/non-primary typed-column part refs fail-closed, schema/row-count mismatch decode fail-closed checks, prepared-runner snapshot/Close lifetime, same-column count-distinct and hour-count result shape, and typed-storage legacy-name allowlist classification for the new files.

## Benchmark smoke

Command:

```sh
GOWORK=off go test ./TreeDB/collections -run '^$' \
  -bench 'BenchmarkColumnPhysicalJSONBenchTypedColumnPartDirectSmoke1947|BenchmarkColumnPhysicalQuery(AdapterM13B|RunnerM1634)/(q1|q2)_rows_1024$' \
  -benchtime=200x -count=3 -benchmem
```

Latest head artifact: `/tmp/orca_issue_graph_1945_1955/1947_bench_head_smoke_20260529_000456.txt`.

Typed-column substrate smoke on Apple M3 (n=3, 200x):

| benchmark | median ns/op | physical bytes/op | rows/op | typed sections/op | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| q1 typed-column part | ~38.9µs | 5,986 | 8 | 14 | 31,992 | 217 |
| q2 typed-column part | ~43.1µs | 5,986 | 8 | 14 | 38,552 | 250 |

Compatibility smoke compared the unchanged q1/q2 adapter/runner rows against `origin/main` (`2d106b5f4`) with the same benchmark command minus the new typed-column benchmark. Artifacts:

- base: `/tmp/orca_issue_graph_1945_1955/1947_bench_origin_main_compat_20260528_233818.txt`
- benchstat: `/tmp/orca_issue_graph_1945_1955/1947_benchstat_compat_only_20260529_000506.txt`

Result: local timings are noisy at n=3, but compatibility q1/q2 adapter/runner allocations are unchanged and there is no material local regression signal. This PR should be read as correctness/substrate enablement only, not a performance PR.

## Review notes

- Internal review artifact: `/tmp/orca_issue_graph_1945_1955/1947_internal_review_20260528_2341.md`.
- Addressed CodeRabbit/Copilot/Codex findings by skipping unused compatibility sidecar preparation for typed-column prepared runners, sorting typed grouped-hour results by key+hour, preserving same-column count-distinct and hour-count result shape, accounting row scans per row, and renaming stale test names.
- Review pass (32f79b9) addressed duplicate test removal and memory optimization: removed `TestTypedColumnPhysicalQueryTypedColumnPartFields` duplicate test and disabled `returnViews` during typed-column asset decoding in `prepareColumnTypedColumnPhysicalQueryRunner` to avoid unnecessarily pinning mmaps/handles for the lifetime of prepared runners.
- Final review pass (9e697f4) fixed ScanNanos timing consistency: `ScanNanos` is now set for all typed-column query result paths (success, readCache errors, preparation errors, and runner execution errors) to consistently include preparation and decode time regardless of outcome.
- Final multipart fail-closed pass (4cd8487) rejects non-primary/multipart `typed_column_part` refs with generation/part context instead of pairing them ambiguously.


## Summary by CodeRabbit

* **New Features**
  * Added a typed-column-part execution path with upfront preparation and runtime fast-path selection.

* **Tests**
  * Expanded tests/benchmarks covering correctness, reopen/pinning, edge shapes, fail-closed asset/decode cases, prepared-runner snapshot pinning, and performance.

* **Refactor**
  * Added typed-section/byte diagnostics, typed-column-only planning/validation, decoding summaries, and predicate byte-precomputation.

* **Bug Fixes**
  * Enforced fail-closed validation and snapshot/prepare semantics to avoid silent fallback or stale runs.
  * Fixed ScanNanos diagnostics to report consistent timing for both success and error paths.

<a href="https://app.coderabbit.ai/change-stack/snissn/gomap/pull/2002?utm_source=github_walkthrough&amp;utm_medium=github&amp;utm_campaign=change_stack"><img src="https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg"></a>
