### PR TITLE
Clean up vector-index state wording

### DIFF
--- a/TreeDB/collections/column_graph_adjacency_quarantine_test.go
+++ b/TreeDB/collections/column_graph_adjacency_quarantine_test.go
@@ -137,7 +137,7 @@ func TestColumnGraphAdjacencySourceDocsPointToQuarantine(t *testing.T) {
 		"TreeDB/docs/spec/storage-format.md": {
 			"Issue #1989 quarantines that\nconsumer-specific selector",
 			"New graph builds leave\nthese `TCGA`/`TCGL` fields empty",
-			"Old adjacency-source refs are #1989-quarantined\ncompatibility",
+			"Old adjacency-source refs are\n`#1989-quarantined` compatibility",
 		},
 		"TreeDB/docs/guides/vector-search-typed-column.md": {
 			"typed-column `uint32_list` assets owned by vector-index state",

--- a/TreeDB/collections/column_vector_graph_manifest.go
+++ b/TreeDB/collections/column_vector_graph_manifest.go
@@ -1006,9 +1006,10 @@ func columnVectorGraphManifestMatchStatusWithBaseChecksum(collection string, gra
 	if graph.BaseManifestChecksum != baseChecksum {
 		return columnVectorGraphManifestMatchMismatch
 	}
-	// Layer-0 adjacency-source metadata is intentionally not part of the loaded
-	// graph match. A bad optional source disables only the direct adjacency fast
-	// path; the row-asset graph remains the canonical searchable index.
+	// Legacy graph-specific adjacency-source metadata is intentionally not part of
+	// the cheap loaded-status match. Healthy search state is validated through the
+	// vector-index state manifest; corrupt legacy source metadata must not make the
+	// row-asset compatibility record look like the target architecture.
 	return columnVectorGraphManifestMatchLoaded
 }
 

--- a/TreeDB/collections/column_vector_graph_manifest.go
+++ b/TreeDB/collections/column_vector_graph_manifest.go
@@ -939,9 +939,9 @@ func (c *Collection) columnGraphVectorIndexStatusAtSnapshot(name string, snap *b
 		return status, nil
 	}
 	// Certified adjacency sources are optional accelerators. Keep loaded-status
-	// gating tied to the canonical row-asset graph; search opens and validates
-	// sources independently and falls back to row assets when they are absent,
-	// corrupt, stale, incomplete, or non-certified.
+	// gating tied to the base graph asset; search opens and validates sources
+	// independently and falls back to row assets when they are absent, corrupt,
+	// stale, incomplete, or non-certified.
 	bytesDisk := columnVectorGraphStorageBytesWithState(graph, *loadedState)
 	status.State = VectorIndexStateColumnGraphLoaded
 	status.Loaded = true

--- a/TreeDB/docs/docs_lint_test.go
+++ b/TreeDB/docs/docs_lint_test.go
@@ -155,9 +155,9 @@ func TestDocs_VectorIndexStateWordingDoesNotRecanonicalizeGraphRows(t *testing.T
 			if err != nil {
 				return err
 			}
-			text := string(data)
+			text := strings.ToLower(string(data))
 			for _, phrase := range stalePhrases {
-				if strings.Contains(text, phrase) {
+				if strings.Contains(text, strings.ToLower(phrase)) {
 					t.Fatalf("%s still contains stale vector-index wording %q", path, phrase)
 				}
 			}

--- a/TreeDB/docs/docs_lint_test.go
+++ b/TreeDB/docs/docs_lint_test.go
@@ -129,6 +129,56 @@ func TestDocs_CanonicalStoragePaths(t *testing.T) {
 	}
 }
 
+func TestDocs_VectorIndexStateWordingDoesNotRecanonicalizeGraphRows(t *testing.T) {
+	treeRoot, _ := repoRoots(t)
+	stalePhrases := []string{
+		"row-asset graph remains the canonical searchable index",
+		"row graph asset ref as the canonical graph asset",
+		"canonical graph row asset plus vector-index state",
+		"future row/document refs",
+	}
+	roots := []string{
+		filepath.Join(treeRoot, "collections"),
+		filepath.Join(treeRoot, "docs", "spec"),
+		filepath.Join(treeRoot, "docs", "guides"),
+	}
+	for _, root := range roots {
+		err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() || (!strings.HasSuffix(path, ".go") && !strings.HasSuffix(path, ".md")) {
+				return nil
+			}
+			data, err := os.ReadFile(path)
+			if err != nil {
+				return err
+			}
+			text := string(data)
+			for _, phrase := range stalePhrases {
+				if strings.Contains(text, phrase) {
+					t.Fatalf("%s still contains stale vector-index wording %q", path, phrase)
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("walk %s: %v", root, err)
+		}
+	}
+
+	guide, err := os.ReadFile(filepath.Join(treeRoot, "docs", "guides", "vector-search-typed-column.md"))
+	if err != nil {
+		t.Fatalf("read vector search guide: %v", err)
+	}
+	guideText := string(guide)
+	for _, want := range []string{"vector-index state `row_refs` assets", "Returned opaque document IDs", "graph row ID bytes, compatibility only"} {
+		if !strings.Contains(guideText, want) {
+			t.Fatalf("vector search guide missing current row-ref wording %q", want)
+		}
+	}
+}
+
 func TestTypedStorageStorageFormatDocsMentionCompatibilityDirectory(t *testing.T) {
 	treeRoot, _ := repoRoots(t)
 	path := filepath.Join(treeRoot, "docs", "spec", "storage-format.md")

--- a/TreeDB/docs/docs_lint_test.go
+++ b/TreeDB/docs/docs_lint_test.go
@@ -136,6 +136,7 @@ func TestDocs_VectorIndexStateWordingDoesNotRecanonicalizeGraphRows(t *testing.T
 		"row graph asset ref as the canonical graph asset",
 		"canonical graph row asset plus vector-index state",
 		"future row/document refs",
+		"gating tied to the canonical row-asset",
 	}
 	roots := []string{
 		filepath.Join(treeRoot, "collections"),

--- a/TreeDB/docs/guides/vector-search-typed-column.md
+++ b/TreeDB/docs/guides/vector-search-typed-column.md
@@ -18,6 +18,8 @@ changes.
 | Filter/sort metadata | `typed_row_asset` or scalar `typed_column_part` depending on query shape | Use typed-row for point reconstruction; use typed-column when filtering/scanning dominates. |
 | Vector graph/ANN data | `derived_accelerator` | It accelerates search but is not the authoritative owner of the embedding field. |
 | Adjacency list | typed-column `uint32_list` assets owned by vector-index state | `raw_uint32_offsets_list` is the physical encoding for HNSW adjacency state. Legacy `column_graph` adjacency direct sources and the `adjacency_layout: "uint32_offsets_list"` selector are quarantined compatibility only; new graph builds should not publish those graph-specific source assets. |
+| Ordinal-to-base-row references | vector-index state `row_refs` assets (`int64` / `raw_int64`) | Search uses row-ref state to map HNSW ordinals to base rows and to materialize documents without an ID-to-row-ref locator lookup. |
+| Returned opaque document IDs | graph row ID bytes, compatibility only | Exact arbitrary binary IDs stay on the graph row compatibility path until a first-class typed-column bytes primitive exists. |
 
 Best practice: keep vector payloads out of retained JSON for search-heavy
 workloads when the typed-column vector section is the intended search data plane.
@@ -289,6 +291,8 @@ counters.
 - Keep source documents and metadata out of the search/scoring hot loop.
 - Use retained document or typed-row metadata for final fetch and display data;
   use typed-column scalar metadata only when filters/scans justify it.
+- Treat vector-index `row_refs` as the healthy ordinal-to-base-row mapping. Do
+  not treat graph row ID scans as the target row-reference source.
 - Prefer reusable searchers for serving throughput; use one-shot APIs when you
   intentionally want setup/open included.
 - Run checkpoint/reopen demos when proving durable manifest/root discovery.
@@ -306,3 +310,4 @@ counters.
 | Search benchmark allocates heavily | You may be timing setup/open, public document materialization, or fallback decode. | Compare reusable-searcher vs one-shot names and inspect allocation profiles. |
 | Results differ across branches | On-disk formats/APIs are pre-alpha. | Rebuild DB directories and rerun with the same rows/dims/degree/top-k/seed. |
 | Adjacency typed-list counters show scratch decodes or legacy fallback | The vector-index state `uint32_list` direct source is missing, stale, disabled, or failed validation, so search fell back to row-asset adjacency or dense compatibility/corruption recovery. | Rebuild the graph so vector-index state owns certified `uint32_list` / `raw_uint32_offsets_list` adjacency assets. Treat old `column_graph` adjacency-source assets as compatibility-only, not a fix target. |
+| `row_ref_vector_source_legacy_graph_ids` is non-zero | The vector-index row-ref state is missing or stale, so typed-column vector source setup used legacy graph row ID scans. | Rebuild the graph so TVIS publishes `row_refs` assets; keep graph ID reads only as explicit compatibility fallback. |

--- a/TreeDB/docs/spec/storage-format.md
+++ b/TreeDB/docs/spec/storage-format.md
@@ -621,9 +621,10 @@ vector-index state. #1984 defines `uint32_list` semantics in
 primitive implementation, and #1986/#1988 own vector-index state/search
 consumption.
 
-The `column_graph` manifest keeps the row graph asset ref as the canonical graph
-asset. The legacy all-layer source metadata is an optional compatibility
-manifest trailer with magic `TCGL` and version `1`: it records `layer_count`,
+The `column_graph` manifest keeps the row graph asset ref for compatibility,
+opaque returned IDs, and controlled fallback. The legacy all-layer source
+metadata is an optional compatibility manifest trailer with magic `TCGL` and
+version `1`: it records `layer_count`,
 `source_count`, and then one `TCGA` v1 source record per layer in ascending layer
 order. Each source
 record binds the source schema/column name, value type/encoding, layer number,
@@ -646,10 +647,11 @@ count, and typed-column asset refs by logical type plus physical encoding. Its
 asset roles include adjacency (`uint32_list` over
 `raw_uint32_offsets_list`), inverse norms (`float32` over `raw_float32`),
 optional normalized vectors (`float32_vector` over `raw_float32_vector`), and
-future row/document refs. The active manifest checksum includes the control
-record, but the record's base checksum excludes vector-index derived records so
-stale-state checks compare against authoritative collection data. See
-`vector-index-state-manifest.md` for validation and fail-closed rules.
+row references (`int64` over `raw_int64`). The active manifest checksum includes
+the control record, but the record's base checksum excludes vector-index derived
+records so stale-state checks compare against authoritative collection data. See
+`vector-index-state-manifest.md` and `vector-index-row-ref-state-1993.md` for
+validation and fail-closed rules.
 
 As of the #1895 pre-alpha format update, newly written `typed_column_part` images
 carry a writer-built `layout_contract` section. The contract may mark only raw
@@ -1032,13 +1034,13 @@ The collection and index names must be non-empty. The command payload names the
 logical rebuild request only; it does not carry vector graph bytes, physical root
 deltas, or a vector-only sidecar file. Normal execution and replay re-enter the
 collection vector-index rebuild path for the named index. For explicit
-`column_graph` indexes, that path rebuilds vector, inverse-norm, and row-asset
-adjacency data into physical column assets, publishes HNSW adjacency as
-`uint32_list` vector-index state, and records vector-index control identity in
-the `TVIS` state record. Old adjacency-source refs are #1989-quarantined
-compatibility. Current graph manifests may still contain row graph refs and
-legacy layer-source trailer refs for compatibility; new derived-state refs belong
-in vector-index state. Replay outcomes that are
+`column_graph` indexes, that path rebuilds the legacy row graph asset for
+compatibility/opaque result IDs, publishes inverse norms, HNSW adjacency, and
+base row references as vector-index state assets, and records vector-index
+control identity in the `TVIS` state record. Old adjacency-source refs are
+#1989-quarantined compatibility. Current graph manifests may still contain row
+graph refs and legacy layer-source trailer refs for compatibility; new
+derived-state refs belong in vector-index state. Replay outcomes that are
 defined no-ops, such as a strategy/config drift status that no longer requires a
 physical rebuild, must still publish a no-op command-WAL boundary and advance
 `AppliedCommandLSN`. Corrupt payloads, unsupported payload versions, and

--- a/TreeDB/docs/spec/storage-format.md
+++ b/TreeDB/docs/spec/storage-format.md
@@ -1038,7 +1038,7 @@ collection vector-index rebuild path for the named index. For explicit
 compatibility/opaque result IDs, publishes inverse norms, HNSW adjacency, and
 base row references as vector-index state assets, and records vector-index
 control identity in the `TVIS` state record. Old adjacency-source refs are
-#1989-quarantined compatibility. Current graph manifests may still contain row
+`#1989-quarantined` compatibility. Current graph manifests may still contain row
 graph refs and legacy layer-source trailer refs for compatibility; new
 derived-state refs belong in vector-index state. Replay outcomes that are
 defined no-ops, such as a strategy/config drift status that no longer requires a

--- a/TreeDB/docs/spec/typed-column-uint32-list-adjacency-quarantine.md
+++ b/TreeDB/docs/spec/typed-column-uint32-list-adjacency-quarantine.md
@@ -103,9 +103,11 @@ old refs; do not add new storage features to them:
 
 ### Current #1989 behavior
 
-- New graph builds publish the canonical graph row asset plus vector-index state
-  assets. HNSW adjacency state is `uint32_list` with `raw_uint32_offsets_list`
-  sections owned by the vector-index state record.
+- New graph builds publish vector-index state assets for healthy search state.
+  HNSW adjacency state is `uint32_list` with `raw_uint32_offsets_list` sections
+  owned by the vector-index state record. The graph row asset remains a legacy
+  compatibility record for opaque result IDs and controlled fallback, not the
+  canonical adjacency source.
 - New graph builds do not publish `Layer0AdjacencySource`,
   `AdjacencyLayerSources`, `TCGA`, or `TCGL` graph-specific adjacency-source
   metadata.


### PR DESCRIPTION
## Objective

Cleans up stale wording after the typed-column vector-index state migration so that no code or documentation re-canonicalizes the legacy graph row asset as the primary searchable index.

## Context

After the TVIS typed-column migration, the healthy search path uses typed-column assets (adjacency `uint32_list`, inverse norms `raw_float32`, row refs `raw_int64`). Several comments and docs still described the row-asset graph as canonical, which misleads future readers and maintainers.

## Non-goals

- No storage format or search behavior changes.
- No changes to search fallback logic.

## Design

- Rewords storage-format and quarantine docs to frame TVIS typed-column assets as the healthy search-state path.
- Graph row assets and legacy adjacency-source records are explicitly compatibility/fallback only.
- Graph row ID bytes documented as compatibility-only for exact opaque returned IDs.
- `column_vector_graph_manifest.go` comment updated: `"gating tied to the canonical row-asset graph"` → `"gating tied to the base graph asset"`.
- Docs lint guard (`TestDocs_VectorIndexStateWordingDoesNotRecanonicalizeGraphRows`) extended with phrase `"gating tied to the canonical row-asset"` to prevent re-introduction.

## Scope

- Includes: `TreeDB/collections/column_vector_graph_manifest.go`, `TreeDB/docs/docs_lint_test.go`, `TreeDB/docs/spec/`, `TreeDB/docs/guides/vector-search-typed-column.md`
- Excludes: search logic, storage format, index build pipeline

## Correctness

- Tests run (exact commands):
  - `GOWORK=off go test ./TreeDB/docs -count=1` ✅
  - `GOWORK=off go test ./TreeDB/collections -run 'TestColumnGraphAdjacency|TestColumnVectorIndexState|TestColumnVectorGraphSearchUsesVectorIndexStateAdjacency|TestColumnGraphInvNormState|TestTypedStorageLegacyNameAllowlistIsComplete' -count=1` ✅
  - `GOWORK=off go test ./TreeDB/internal/typedcolumn ./TreeDB/internal/typeddecode -count=1` ✅
  - `GOWORK=off go test ./TreeDB/collections -count=1` ✅
- Corruption/edge cases covered: N/A (documentation and comment changes only)
- Concurrency/race coverage: N/A

## Performance

- Benchmarks run: N/A (no logic changes)
- Results table: N/A
- Regressions: None

## Rollout / Toggle Plan

- Default setting: N/A (documentation/comment changes only)
- How to disable quickly: N/A

## Follow-ups

- Monitor for any further stale row-asset canonicalization in new code via the extended lint guard.

## Column Graph Native Workstream (#1646, if applicable)

### Copied/Adapted From Old Stack

- Copied: N/A
- Adapted: N/A
- Oracle/comparator only: N/A
- Quarantined/not copied: N/A

### Path Identity

- Native reader: N/A
- Decoded comparator: N/A
- Legacy/native vector index: N/A
- Unsupported/fail-closed: N/A

### Base And Dependency State

- Base branch: main
- Base commit: N/A
- Base PR/head: N/A
- #1621/#1634 assumptions: N/A
- Missing generic column-store primitives: N/A
- Parent review fixes propagated: N/A

### Evidence

- Tests: see Correctness section
- Benchmarks: N/A
- Status/fallback proof: N/A
- Performance attribution: N/A
- Local regressions found/fixed: None

### Test Plan Start

- Milestone tasks targeted: docs lint coverage for stale row-asset canonicalization
- Tests to add before or with implementation: `TestDocs_VectorIndexStateWordingDoesNotRecanonicalizeGraphRows` extended
- Existing tests to preserve: all existing docs and collections tests
- #1646 test-list changes made before implementation: N/A

### Performance Plan Start

- Relevant benchmarks/metrics for this PR: N/A
- Baseline/comparator command or reason not applicable: documentation/comment changes only
- Expected setup/search/materialization boundary: N/A
- Upstream costs explicitly out of scope: N/A
- Local performance risks to watch: None

### Test Plan Close

- Additional tests found during implementation/review: lint guard phrase `"gating tied to the canonical row-asset"` added after review identified gap
- Tests added or changed: `TestDocs_VectorIndexStateWordingDoesNotRecanonicalizeGraphRows` in `docs_lint_test.go`
- Failing tests fixed: N/A
- #1646 test-list changes made at close: N/A
- Residual untested gaps, if any: None

### Performance Plan Close

- Benchmark commands run: N/A
- Results summary: N/A
- Before/after or baseline comparison: N/A
- Local slow/heavy code found and fixed: N/A
- Remaining upstream or deferred costs: N/A

### AI Review Loop

- Codex latest-head review: requested
- Copilot latest-head review: completed — stale wording in `column_vector_graph_manifest.go` fixed and lint guard extended
- CodeRabbit latest-head review: requested
- Review comments/threads resolved or explicitly dismissed: resolved stale canonical-row-asset phrase missed by initial lint guard
- Re-requested after final meaningful push: yes

---

## Optimization PR Checklist (TreeDB)

### Scope
- [x] Single, clear objective for this PR (not a bundle)
- [x] Explicit include list (files/symbols touched): `column_vector_graph_manifest.go`, `docs_lint_test.go`, spec/guide docs
- [x] Explicit exclude list (files/symbols NOT touched): search logic, storage format, index build pipeline
- [x] No unwanted feature reintroduction (e.g. async slab writer, hard zones, ValueIndex) unless explicitly stated in the PR objective

### Safety / Correctness
- [ ] Clear written-vs-durable semantics for any `*Sync` path touched — N/A
- [ ] No new mmap usage on mutable/truncating files — N/A
- [ ] All new length fields are capped before allocation (OOM-safe) — N/A
- [ ] CRC/checksum behavior is fail-closed (clean error, no panic) — N/A
- [ ] Any concurrency change has a defined state machine and invariants — N/A

### Tests
- [x] Added deterministic regression tests for the targeted failure mode
- [ ] Tests avoid sleeps where possible (use latches/hooks) — N/A
- [ ] Added corruption/edge-case tests — N/A
- [x] Ran locally:
  - [x] `go test ./... -count=1`
  - [x] Targeted packages: `./TreeDB/docs`, `./TreeDB/collections`, `./TreeDB/internal/typedcolumn`, `./TreeDB/internal/typeddecode`

### Benchmarks / Measurements
- [ ] Added or updated a benchmark relevant to the change — N/A
- [ ] Reported results in PR description — N/A
- [ ] Included "incompressible" results if compression is involved — N/A

### Docs
- [x] Updated `docs/` wording to reflect TVIS typed-column as healthy search state
- [ ] Documented any new config knobs + defaults — N/A
- [ ] Called out any format change in PR description — N/A (no format change)

### Rollout / Toggle Plan (if behavior-affecting)
- [ ] Safe defaults — N/A
- [ ] Clear knobs to disable/revert behavior quickly — N/A
- [ ] Observability: counters/logs to verify effectiveness — N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified vector-index state roles: treat row_refs as authoritative ordinal-to-base-row mapping and graph row IDs as compatibility-only.
  * Updated best-practices, troubleshooting, storage-format, and quarantine guidance to recommend rebuilding vector-index state when row_refs or state are missing/stale.
* **Tests**
  * Added a docs lint test to enforce the updated wording and prevent stale/ambiguous documentation phrasing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/2012?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->