### PR TITLE
Typed-column q4b TopK mark-pruned scan

### DIFF
--- a/TreeDB/collections/column_aggregate_metadata_typed_column_test.go
+++ b/TreeDB/collections/column_aggregate_metadata_typed_column_test.go
@@ -272,7 +272,6 @@ func TestAggregateMetadataTopKValidation1871(t *testing.T) {
 		want string
 	}{
 		{name: "negative", req: ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupMinInt64, GroupColumn: "did", ValueColumn: "time_us", AggregateMetadataName: "min_time_us", TopK: -1}, want: "non-negative"},
-		{name: "missing metadata", req: ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupMinInt64, GroupColumn: "did", ValueColumn: "time_us", TopK: 3, TopKOrder: ColumnPhysicalQueryTopKInt64Asc}, want: "requires aggregate metadata"},
 		{name: "missing order", req: ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupMinInt64, GroupColumn: "did", ValueColumn: "time_us", AggregateMetadataName: "min_time_us", TopK: 3}, want: "order is required"},
 		{name: "order without limit", req: ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupMinInt64, GroupColumn: "did", ValueColumn: "time_us", AggregateMetadataName: "min_time_us", TopKOrder: ColumnPhysicalQueryTopKInt64Asc}, want: "requires a positive limit"},
 		{name: "unsupported kind", req: ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount, GroupColumn: "did", ValueColumn: "time_us", AggregateMetadataName: "min_time_us", TopK: 3, TopKOrder: ColumnPhysicalQueryTopKInt64Asc}, want: "requires an int64 aggregate kind"},

--- a/TreeDB/collections/column_dict_int64_query.go
+++ b/TreeDB/collections/column_dict_int64_query.go
@@ -237,7 +237,7 @@ func runColumnDictionaryInt64GroupOneShot(view columnPhysicalScanSnapshotView, r
 	if blocks == 0 {
 		return ColumnPhysicalQueryResult{}, false, nil
 	}
-	groups := reducer.groups()
+	groups := reducer.groups(req)
 	diag := columnPhysicalQueryDiagnosticsFromScan(view.Diagnostics)
 	diag.WorkerCount = 1
 	diag.ProjectedColumns = 2
@@ -375,7 +375,9 @@ func (r *columnDictionaryInt64GroupRunner) run(view columnPhysicalScanSnapshotVi
 		}
 		r.result = append(r.result, ColumnPhysicalQueryGroup{Key: key, Int64: value})
 	}
-	sortColumnPhysicalQueryGroupsByKey(r.result)
+	if req.TopK == 0 {
+		sortColumnPhysicalQueryGroupsByKey(r.result)
+	}
 	diag := columnPhysicalQueryDiagnosticsFromScan(view.Diagnostics)
 	diag.WorkerCount = 1
 	diag.ProjectedColumns = columnPhysicalQueryDiagnosticProjectedColumns(r.predicateDiagnostics, 2)
@@ -575,7 +577,7 @@ func (r *columnDictionaryInt64GroupOneShotReducer) reduceValue(code uint32, valu
 	}
 }
 
-func (r *columnDictionaryInt64GroupOneShotReducer) groups() []ColumnPhysicalQueryGroup {
+func (r *columnDictionaryInt64GroupOneShotReducer) groups(req ColumnPhysicalQueryRequest) []ColumnPhysicalQueryGroup {
 	r.result = r.result[:0]
 	for code, key := range r.groupDict {
 		word := code / 64
@@ -589,6 +591,8 @@ func (r *columnDictionaryInt64GroupOneShotReducer) groups() []ColumnPhysicalQuer
 		}
 		r.result = append(r.result, ColumnPhysicalQueryGroup{Key: key, Int64: value})
 	}
-	sortColumnPhysicalQueryGroupsByKey(r.result)
+	if req.TopK == 0 {
+		sortColumnPhysicalQueryGroupsByKey(r.result)
+	}
 	return r.result
 }

--- a/TreeDB/collections/column_physical_q4b_topk_1950_test.go
+++ b/TreeDB/collections/column_physical_q4b_topk_1950_test.go
@@ -16,6 +16,7 @@ func TestTypedColumnQ4BTopKMarkPrunedParity1950(t *testing.T) {
 
 	req := typedColumnQ4BTopKRequest1950()
 	want := typedColumnQ4BTopKReferenceGroups1950(scanned, req.TopK)
+	wantCandidates := typedColumnQ4BTopKReferenceCandidateCount1950(scanned)
 	matchedRows := columnPhysicalJSONBenchReferenceMatchedRowsP0("q4b", scanned)
 
 	direct, err := col.RunColumnPhysicalQuery(req)
@@ -23,7 +24,7 @@ func TestTypedColumnQ4BTopKMarkPrunedParity1950(t *testing.T) {
 		t.Fatalf("RunColumnPhysicalQuery(q4b topK): %v", err)
 	}
 	assertTypedColumnQ4BTopKGroups1950(t, "direct", direct.Groups, want)
-	assertTypedColumnQ4BTopKDiagnostics1950(t, "direct", direct.Diagnostics, len(events), matchedRows, req.TopK, len(want), 64)
+	assertTypedColumnQ4BTopKDiagnostics1950(t, "direct", direct.Diagnostics, len(events), matchedRows, req.TopK, len(want), wantCandidates)
 
 	runner, err := col.PrepareColumnPhysicalQuery(req)
 	if err != nil {
@@ -35,7 +36,7 @@ func TestTypedColumnQ4BTopKMarkPrunedParity1950(t *testing.T) {
 		t.Fatalf("prepared q4b topK: %v", err)
 	}
 	assertTypedColumnQ4BTopKGroups1950(t, "prepared", prepared.Groups, want)
-	assertTypedColumnQ4BTopKDiagnostics1950(t, "prepared", prepared.Diagnostics, len(events), matchedRows, req.TopK, len(want), 64)
+	assertTypedColumnQ4BTopKDiagnostics1950(t, "prepared", prepared.Diagnostics, len(events), matchedRows, req.TopK, len(want), wantCandidates)
 }
 
 func TestColumnPhysicalNonMetadataTopKShaping1950(t *testing.T) {
@@ -150,14 +151,27 @@ func BenchmarkTypedColumnQ4BTopK1950(b *testing.B) {
 
 func typedColumnQ4BTopKTieBreakEvents1950() []columnPhysicalJSONBenchParityEventP0 {
 	events := typedColumnSortKeyPruningEvents1949()
-	for i := range events {
-		if events[i].ID == "post-1" {
-			// Force an equal min(time_us) across two groups so the top-K assertion
-			// exercises deterministic Key tie-break parity with the row-scan reference.
-			events[i].TimeUS = 2_000_000
+	firstIdx := -1
+	secondIdx := -1
+	for i, event := range events {
+		if !columnPhysicalJSONBenchReferenceMatchP0("q4b", event) {
+			continue
+		}
+		if firstIdx < 0 {
+			firstIdx = i
+			continue
+		}
+		if event.Did != events[firstIdx].Did {
+			secondIdx = i
 			break
 		}
 	}
+	if firstIdx < 0 || secondIdx < 0 {
+		panic("typedColumnQ4BTopKTieBreakEvents1950: fixture needs at least two q4b groups")
+	}
+	// Force an equal min(time_us) across two groups so the top-K assertion
+	// exercises deterministic Key tie-break parity with the row-scan reference.
+	events[secondIdx].TimeUS = events[firstIdx].TimeUS
 	return events
 }
 
@@ -181,15 +195,7 @@ func typedColumnQ4BTopKClickHouseSortKey1950() []ColumnSortKey {
 }
 
 func typedColumnQ4BTopKReferenceGroups1950(events []columnPhysicalJSONBenchParityEventP0, topK int) []ColumnPhysicalQueryGroup {
-	mins := make(map[string]int64)
-	for _, event := range events {
-		if !columnPhysicalJSONBenchReferenceMatchP0("q4b", event) {
-			continue
-		}
-		if cur, ok := mins[event.Did]; !ok || event.TimeUS < cur {
-			mins[event.Did] = event.TimeUS
-		}
-	}
+	mins := typedColumnQ4BTopKReferenceMins1950(events)
 	groups := make([]ColumnPhysicalQueryGroup, 0, len(mins))
 	for key, value := range mins {
 		groups = append(groups, ColumnPhysicalQueryGroup{Key: key, Int64: value})
@@ -204,6 +210,23 @@ func typedColumnQ4BTopKReferenceGroups1950(events []columnPhysicalJSONBenchParit
 		groups = groups[:topK]
 	}
 	return groups
+}
+
+func typedColumnQ4BTopKReferenceCandidateCount1950(events []columnPhysicalJSONBenchParityEventP0) int {
+	return len(typedColumnQ4BTopKReferenceMins1950(events))
+}
+
+func typedColumnQ4BTopKReferenceMins1950(events []columnPhysicalJSONBenchParityEventP0) map[string]int64 {
+	mins := make(map[string]int64)
+	for _, event := range events {
+		if !columnPhysicalJSONBenchReferenceMatchP0("q4b", event) {
+			continue
+		}
+		if cur, ok := mins[event.Did]; !ok || event.TimeUS < cur {
+			mins[event.Did] = event.TimeUS
+		}
+	}
+	return mins
 }
 
 func assertTypedColumnQ4BTopKGroups1950(tb testing.TB, label string, got, want []ColumnPhysicalQueryGroup) {

--- a/TreeDB/collections/column_physical_q4b_topk_1950_test.go
+++ b/TreeDB/collections/column_physical_q4b_topk_1950_test.go
@@ -1,0 +1,244 @@
+package collections
+
+import (
+	"sort"
+	"testing"
+)
+
+func TestTypedColumnQ4BTopKMarkPrunedParity1950(t *testing.T) {
+	sortKey := typedColumnQ4BTopKClickHouseSortKey1950()
+	events := typedColumnQ4BTopKTieBreakEvents1950()
+	_, col, closeFn := openTypedColumnSortKeyFixture1948(t, sortKey, events)
+	defer closeFn()
+
+	scanned := scanColumnPhysicalJSONBenchParityEventsP0(t, col, len(events))
+	assertColumnPhysicalJSONBenchRowScanPreservesFullPredicateColumnsP0(t, events, scanned)
+
+	req := typedColumnQ4BTopKRequest1950()
+	want := typedColumnQ4BTopKReferenceGroups1950(scanned, req.TopK)
+	matchedRows := columnPhysicalJSONBenchReferenceMatchedRowsP0("q4b", scanned)
+
+	direct, err := col.RunColumnPhysicalQuery(req)
+	if err != nil {
+		t.Fatalf("RunColumnPhysicalQuery(q4b topK): %v", err)
+	}
+	assertTypedColumnQ4BTopKGroups1950(t, "direct", direct.Groups, want)
+	assertTypedColumnQ4BTopKDiagnostics1950(t, "direct", direct.Diagnostics, len(events), matchedRows, req.TopK, len(want), 64)
+
+	runner, err := col.PrepareColumnPhysicalQuery(req)
+	if err != nil {
+		t.Fatalf("PrepareColumnPhysicalQuery(q4b topK): %v", err)
+	}
+	defer func() { _ = runner.Close() }()
+	prepared, err := runner.Run()
+	if err != nil {
+		t.Fatalf("prepared q4b topK: %v", err)
+	}
+	assertTypedColumnQ4BTopKGroups1950(t, "prepared", prepared.Groups, want)
+	assertTypedColumnQ4BTopKDiagnostics1950(t, "prepared", prepared.Diagnostics, len(events), matchedRows, req.TopK, len(want), 64)
+}
+
+func TestColumnPhysicalNonMetadataTopKShaping1950(t *testing.T) {
+	events := columnPhysicalJSONBenchParityEventsP0()
+	col, closeFn := openColumnPhysicalJSONBenchParityFixtureP0(t, events)
+	defer closeFn()
+
+	scanned := scanColumnPhysicalJSONBenchParityEventsP0(t, col, len(events))
+	req := typedColumnQ4BTopKRequest1950()
+	req.TopK = 1
+	want := typedColumnQ4BTopKReferenceGroups1950(scanned, req.TopK)
+
+	direct, err := col.RunColumnPhysicalQuery(req)
+	if err != nil {
+		t.Fatalf("RunColumnPhysicalQuery(non-metadata topK): %v", err)
+	}
+	assertTypedColumnQ4BTopKGroups1950(t, "direct compatibility", direct.Groups, want)
+	if direct.Diagnostics.StorageSource != ColumnPhysicalQueryStorageSourceCompatibilityDictionaryCodeInt64Asset || direct.Diagnostics.TopKLimit != req.TopK || direct.Diagnostics.TopKCandidates <= req.TopK || direct.Diagnostics.ResultGroups != len(want) {
+		t.Fatalf("direct diagnostics=%+v want non-metadata TopK-shaped compatibility path", direct.Diagnostics)
+	}
+
+	runner, err := col.PrepareColumnPhysicalQuery(req)
+	if err != nil {
+		t.Fatalf("PrepareColumnPhysicalQuery(non-metadata topK): %v", err)
+	}
+	defer func() { _ = runner.Close() }()
+	prepared, err := runner.Run()
+	if err != nil {
+		t.Fatalf("prepared non-metadata topK: %v", err)
+	}
+	assertTypedColumnQ4BTopKGroups1950(t, "prepared compatibility", prepared.Groups, want)
+	if prepared.Diagnostics.StorageSource != ColumnPhysicalQueryStorageSourceCompatibilityDictionaryCodeInt64Asset || prepared.Diagnostics.TopKLimit != req.TopK || prepared.Diagnostics.TopKCandidates <= req.TopK || prepared.Diagnostics.ResultGroups != len(want) {
+		t.Fatalf("prepared diagnostics=%+v want non-metadata TopK-shaped compatibility path", prepared.Diagnostics)
+	}
+}
+
+func BenchmarkTypedColumnQ4BTopK1950(b *testing.B) {
+	events := typedColumnSortKeyPruningEvents1949()
+	clickHouseSortKey := typedColumnQ4BTopKClickHouseSortKey1950()
+	cases := []struct {
+		name     string
+		sortKey  []ColumnSortKey
+		events   []columnPhysicalJSONBenchParityEventP0
+		prepared bool
+	}{
+		{name: "direct/primary_id_fallback", events: events},
+		{name: "prepared/primary_id_fallback", events: events, prepared: true},
+		{name: "direct/clickhouse_full_scan", sortKey: clickHouseSortKey, events: typedColumnSortKeyAllPostEvents1949(len(events))},
+		{name: "prepared/clickhouse_full_scan", sortKey: clickHouseSortKey, events: typedColumnSortKeyAllPostEvents1949(len(events)), prepared: true},
+		{name: "direct/clickhouse_mark_pruned", sortKey: clickHouseSortKey, events: events},
+		{name: "prepared/clickhouse_mark_pruned", sortKey: clickHouseSortKey, events: events, prepared: true},
+	}
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			_, col, closeFn := openTypedColumnSortKeyFixture1948(b, tc.sortKey, tc.events)
+			defer closeFn()
+			req := typedColumnQ4BTopKRequest1950()
+			preview, err := col.RunColumnPhysicalQuery(req)
+			if err != nil {
+				b.Fatalf("preview RunColumnPhysicalQuery: %v", err)
+			}
+			if len(preview.Groups) != req.TopK {
+				b.Fatalf("preview groups=%d want topK=%d diagnostics=%+v", len(preview.Groups), req.TopK, preview.Diagnostics)
+			}
+			b.SetBytes(preview.Diagnostics.PhysicalBytesScanned)
+			b.ReportAllocs()
+			var runner *ColumnPhysicalQueryRunner
+			if tc.prepared {
+				runner, err = col.PrepareColumnPhysicalQuery(req)
+				if err != nil {
+					b.Fatalf("PrepareColumnPhysicalQuery: %v", err)
+				}
+				defer func() { _ = runner.Close() }()
+			}
+
+			b.ResetTimer()
+			var last ColumnPhysicalQueryDiagnostics
+			var groups int
+			for i := 0; i < b.N; i++ {
+				var result ColumnPhysicalQueryResult
+				if tc.prepared {
+					result, err = runner.Run()
+				} else {
+					result, err = col.RunColumnPhysicalQuery(req)
+				}
+				if err != nil {
+					b.Fatalf("q4b topK run: %v", err)
+				}
+				last = result.Diagnostics
+				groups += len(result.Groups)
+			}
+			b.StopTimer()
+			if groups == 0 {
+				b.Fatal("benchmark produced no result groups")
+			}
+			b.ReportMetric(float64(last.RowsScanned), "rows_scanned/op")
+			b.ReportMetric(float64(last.RowsMatched), "rows_matched/op")
+			b.ReportMetric(float64(last.ReduceRows), "reduce_rows/op")
+			b.ReportMetric(float64(last.ScheduledGranules), "granules_considered/op")
+			b.ReportMetric(float64(last.SkippedGranules), "granules_skipped/op")
+			b.ReportMetric(float64(last.DecodedGranules), "granules_decoded/op")
+			b.ReportMetric(float64(last.SortKeyMarkChecks), "mark_checks/op")
+			b.ReportMetric(float64(last.SortKeyMarkSkips), "mark_skips/op")
+			b.ReportMetric(float64(last.DecodedPayloadBytes), "decoded_bytes/op")
+			b.ReportMetric(float64(last.TopKCandidates), "topk_candidates/op")
+			if last.ScanNanos > 0 {
+				b.ReportMetric(1e9/float64(last.ScanNanos), "diag_ops_per_sec")
+			}
+		})
+	}
+}
+
+func typedColumnQ4BTopKTieBreakEvents1950() []columnPhysicalJSONBenchParityEventP0 {
+	events := typedColumnSortKeyPruningEvents1949()
+	for i := range events {
+		if events[i].ID == "post-1" {
+			// Force an equal min(time_us) across two groups so the top-K assertion
+			// exercises deterministic Key tie-break parity with the row-scan reference.
+			events[i].TimeUS = 2_000_000
+			break
+		}
+	}
+	return events
+}
+
+func typedColumnQ4BTopKRequest1950() ColumnPhysicalQueryRequest {
+	return ColumnPhysicalQueryRequest{
+		Kind:        ColumnPhysicalQueryGroupMinInt64,
+		GroupColumn: "did",
+		ValueColumn: "time_us",
+		TopK:        3,
+		TopKOrder:   ColumnPhysicalQueryTopKInt64Asc,
+		Predicates: []ColumnPhysicalQueryPredicate{
+			{Column: "kind", Value: "commit"},
+			{Column: "operation", Value: "create"},
+			{Column: "collection", Value: "app.bsky.feed.post"},
+		},
+	}
+}
+
+func typedColumnQ4BTopKClickHouseSortKey1950() []ColumnSortKey {
+	return []ColumnSortKey{{Column: "kind"}, {Column: "operation"}, {Column: "collection"}, {Column: "did"}, {Column: "time_us"}}
+}
+
+func typedColumnQ4BTopKReferenceGroups1950(events []columnPhysicalJSONBenchParityEventP0, topK int) []ColumnPhysicalQueryGroup {
+	mins := make(map[string]int64)
+	for _, event := range events {
+		if !columnPhysicalJSONBenchReferenceMatchP0("q4b", event) {
+			continue
+		}
+		if cur, ok := mins[event.Did]; !ok || event.TimeUS < cur {
+			mins[event.Did] = event.TimeUS
+		}
+	}
+	groups := make([]ColumnPhysicalQueryGroup, 0, len(mins))
+	for key, value := range mins {
+		groups = append(groups, ColumnPhysicalQueryGroup{Key: key, Int64: value})
+	}
+	sort.Slice(groups, func(i, j int) bool {
+		if groups[i].Int64 != groups[j].Int64 {
+			return groups[i].Int64 < groups[j].Int64
+		}
+		return groups[i].Key < groups[j].Key
+	})
+	if len(groups) > topK {
+		groups = groups[:topK]
+	}
+	return groups
+}
+
+func assertTypedColumnQ4BTopKGroups1950(tb testing.TB, label string, got, want []ColumnPhysicalQueryGroup) {
+	tb.Helper()
+	if len(got) != len(want) {
+		tb.Fatalf("%s groups=%+v want %+v", label, got, want)
+	}
+	for i := range want {
+		if got[i].Key != want[i].Key || got[i].Int64 != want[i].Int64 {
+			tb.Fatalf("%s groups=%+v want %+v", label, got, want)
+		}
+	}
+}
+
+func assertTypedColumnQ4BTopKDiagnostics1950(tb testing.TB, label string, diag ColumnPhysicalQueryDiagnostics, totalRows, matchedRows, wantTopK, wantGroups, wantCandidates int) {
+	tb.Helper()
+	if diag.StorageSource != ColumnPhysicalQueryStorageSourceTypedColumnPartSection || diag.FallbackReason != ColumnPhysicalQueryFallbackNone {
+		tb.Fatalf("%s diagnostics=%+v want typed-column source without storage fallback", label, diag)
+	}
+	if diag.PredicateCount != 3 || diag.RowsMatched != matchedRows || diag.ReduceRows != matchedRows {
+		tb.Fatalf("%s predicate diagnostics=%+v want predicates=3 matched/reduced=%d", label, diag, matchedRows)
+	}
+	if !diag.SortKeyPrefixPlanned || diag.SortKeyPrefixLiterals != 3 || !equalStrings1949(diag.SortKeyPrefixColumns, []string{"kind", "operation", "collection"}) {
+		tb.Fatalf("%s prefix diagnostics=%+v want kind/operation/collection sorted prefix", label, diag)
+	}
+	if diag.SortKeyMarkChecks == 0 || diag.SortKeyMarkSkips == 0 || diag.SkippedGranules == 0 {
+		tb.Fatalf("%s mark diagnostics=%+v want checked and skipped sort-key marks", label, diag)
+	}
+	if diag.RowsScanned <= 0 || diag.RowsScanned >= totalRows || diag.DecodedPayloadBytes == 0 {
+		tb.Fatalf("%s scan diagnostics=%+v want mark-pruned typed-column section decode", label, diag)
+	}
+	if diag.RowMaterializations != 0 || diag.DocumentMaterializations != 0 {
+		tb.Fatalf("%s materialization diagnostics=%+v want no row/document materialization", label, diag)
+	}
+	if diag.TopKLimit != wantTopK || diag.TopKOrder != string(ColumnPhysicalQueryTopKInt64Asc) || diag.TopKCandidates != wantCandidates || diag.ResultGroups != wantGroups {
+		tb.Fatalf("%s topK diagnostics=%+v want limit/order/candidates/result groups", label, diag)
+	}
+}

--- a/TreeDB/collections/column_physical_q4b_topk_1950_test.go
+++ b/TreeDB/collections/column_physical_q4b_topk_1950_test.go
@@ -151,27 +151,37 @@ func BenchmarkTypedColumnQ4BTopK1950(b *testing.B) {
 
 func typedColumnQ4BTopKTieBreakEvents1950() []columnPhysicalJSONBenchParityEventP0 {
 	events := typedColumnSortKeyPruningEvents1949()
-	firstIdx := -1
-	secondIdx := -1
+	type didMin struct {
+		did  string
+		time int64
+		idx  int
+	}
+	minByDID := make(map[string]didMin)
 	for i, event := range events {
 		if !columnPhysicalJSONBenchReferenceMatchP0("q4b", event) {
 			continue
 		}
-		if firstIdx < 0 {
-			firstIdx = i
-			continue
-		}
-		if event.Did != events[firstIdx].Did {
-			secondIdx = i
-			break
+		cur, ok := minByDID[event.Did]
+		if !ok || event.TimeUS < cur.time {
+			minByDID[event.Did] = didMin{did: event.Did, time: event.TimeUS, idx: i}
 		}
 	}
-	if firstIdx < 0 || secondIdx < 0 {
+	mins := make([]didMin, 0, len(minByDID))
+	for _, min := range minByDID {
+		mins = append(mins, min)
+	}
+	if len(mins) < 2 {
 		panic("typedColumnQ4BTopKTieBreakEvents1950: fixture needs at least two q4b groups")
 	}
+	sort.Slice(mins, func(i, j int) bool {
+		if mins[i].time != mins[j].time {
+			return mins[i].time < mins[j].time
+		}
+		return mins[i].did < mins[j].did
+	})
 	// Force an equal min(time_us) across two groups so the top-K assertion
 	// exercises deterministic Key tie-break parity with the row-scan reference.
-	events[secondIdx].TimeUS = events[firstIdx].TimeUS
+	events[mins[1].idx].TimeUS = mins[0].time
 	return events
 }
 

--- a/TreeDB/collections/column_physical_query.go
+++ b/TreeDB/collections/column_physical_query.go
@@ -77,9 +77,9 @@ const (
 // does not invoke planner routing; M14 owns forced/automatic route selection.
 // Predicates are an AND-list of dictionary string equality/IN filters for the
 // insert-only physical sidecar path; unsupported predicate shapes fail closed.
-// TopK is optional and currently supported by aggregate-metadata int64 reducers
-// only. When TopK is set, TopKOrder chooses value order and Key is the tie-break;
-// SkipEmptyGroupKey omits empty-string group keys before applying the limit.
+// TopK is optional for int64 aggregate reducers. When TopK is set,
+// TopKOrder chooses value order and Key is the tie-break; SkipEmptyGroupKey
+// omits empty-string group keys before applying the limit.
 type ColumnPhysicalQueryRequest struct {
 	Kind                     ColumnPhysicalQueryKind
 	GroupColumn              string
@@ -261,9 +261,6 @@ func validateColumnPhysicalTopKRequest(req ColumnPhysicalQueryRequest) error {
 			return fmt.Errorf("%w: physical column query skip-empty group key requires a positive top-K limit", ErrColumnQueryPlanUnsupported)
 		}
 		return nil
-	}
-	if req.AggregateMetadataName == "" {
-		return fmt.Errorf("%w: physical column query top-K requires aggregate metadata", ErrColumnQueryPlanUnsupported)
 	}
 	switch req.Kind {
 	case ColumnPhysicalQueryGroupMinInt64, ColumnPhysicalQueryGroupMaxInt64, ColumnPhysicalQueryGroupInt64Span:
@@ -518,6 +515,7 @@ func (r *ColumnPhysicalQueryRunner) Run() (ColumnPhysicalQueryResult, error) {
 	}
 	if r.dictInt64 != nil {
 		result := r.dictInt64.run(r.view, r.req)
+		finalizeColumnPhysicalQueryResultGroups(r.req, &result)
 		annotateColumnPhysicalQueryResult(&result, ColumnPhysicalQueryStorageSourceCompatibilityDictionaryCodeInt64Asset, ColumnPhysicalQueryFallbackNone)
 		return result, nil
 	}
@@ -551,7 +549,7 @@ func (r *ColumnPhysicalQueryRunner) Run() (ColumnPhysicalQueryResult, error) {
 		return result, err
 	}
 	result.Groups = r.exec.groups()
-	result.Diagnostics.ResultGroups = len(result.Groups)
+	finalizeColumnPhysicalQueryResultGroups(r.req, &result)
 	return result, nil
 }
 
@@ -646,7 +644,7 @@ func (c *Collection) runColumnPhysicalQueryDirectInSnapshotView(view columnPhysi
 		return result, true, err
 	}
 	result.Groups = exec.groups()
-	result.Diagnostics.ResultGroups = len(result.Groups)
+	finalizeColumnPhysicalQueryResultGroups(req, &result)
 	return result, true, nil
 }
 
@@ -855,7 +853,7 @@ func (c *Collection) RunColumnPhysicalQueryParallel(req ColumnPhysicalQueryReque
 	}
 	result.Groups = merged.groups()
 	result.Diagnostics.ReduceRows = merged.reduceRows
-	result.Diagnostics.ResultGroups = len(result.Groups)
+	finalizeColumnPhysicalQueryResultGroups(req, &result)
 	return result, nil
 }
 
@@ -981,7 +979,7 @@ func (c *Collection) runColumnPhysicalQueryInSnapshotView(view columnPhysicalSca
 		return result, err
 	}
 	result.Groups = exec.groups()
-	result.Diagnostics.ResultGroups = len(result.Groups)
+	finalizeColumnPhysicalQueryResultGroups(req, &result)
 	return result, nil
 }
 
@@ -1090,6 +1088,7 @@ func (c *Collection) runColumnPhysicalQueryDictionaryInt64InSnapshotView(view co
 		if ok {
 			result.Diagnostics.SegmentFileCacheHits = readCache.hits
 			result.Diagnostics.SegmentFileCacheMisses = readCache.misses
+			finalizeColumnPhysicalQueryResultGroups(req, &result)
 			annotateColumnPhysicalQueryResult(&result, ColumnPhysicalQueryStorageSourceCompatibilityDictionaryCodeInt64Asset, ColumnPhysicalQueryFallbackNone)
 			return result, true, nil
 		}
@@ -1108,6 +1107,7 @@ func (c *Collection) runColumnPhysicalQueryDictionaryInt64InSnapshotView(view co
 	result := runner.run(view, req)
 	result.Diagnostics.SegmentFileCacheHits = readCache.hits
 	result.Diagnostics.SegmentFileCacheMisses = readCache.misses
+	finalizeColumnPhysicalQueryResultGroups(req, &result)
 	annotateColumnPhysicalQueryResult(&result, ColumnPhysicalQueryStorageSourceCompatibilityDictionaryCodeInt64Asset, ColumnPhysicalQueryFallbackNone)
 	return result, true, nil
 }
@@ -1173,7 +1173,7 @@ func (c *Collection) runColumnPhysicalQueryWithVisibility(cfg ColumnStoreConfig,
 	result.Diagnostics.ReduceNanos = time.Since(reduceStart).Nanoseconds()
 	result.Groups = exec.groups()
 	result.Diagnostics.ReduceRows = exec.reduceRows
-	result.Diagnostics.ResultGroups = len(result.Groups)
+	finalizeColumnPhysicalQueryResultGroups(req, &result)
 	return result, nil
 }
 
@@ -1979,6 +1979,53 @@ func (e *columnPhysicalQueryExecutor) groups() []ColumnPhysicalQueryGroup {
 	}
 	sortColumnPhysicalQueryGroupsByKey(e.resultGroups)
 	return e.resultGroups
+}
+
+func finalizeColumnPhysicalQueryResultGroups(req ColumnPhysicalQueryRequest, result *ColumnPhysicalQueryResult) {
+	if result == nil {
+		return
+	}
+	if req.TopK > 0 {
+		shapeStart := time.Now()
+		candidates := columnPhysicalQueryTopKCandidateGroups(req, result.Groups)
+		result.Groups = applyColumnPhysicalQueryTopKGroups(req, result.Groups)
+		result.Diagnostics.ResultShapeNanos += time.Since(shapeStart).Nanoseconds()
+		result.Diagnostics.TopKLimit = req.TopK
+		result.Diagnostics.TopKOrder = string(req.TopKOrder)
+		result.Diagnostics.TopKCandidates = candidates
+	}
+	result.Diagnostics.ResultGroups = len(result.Groups)
+}
+
+func columnPhysicalQueryTopKCandidateGroups(req ColumnPhysicalQueryRequest, groups []ColumnPhysicalQueryGroup) int {
+	if req.TopK <= 0 {
+		return 0
+	}
+	if !req.SkipEmptyGroupKey {
+		return len(groups)
+	}
+	candidates := 0
+	for _, group := range groups {
+		if group.Key != "" {
+			candidates++
+		}
+	}
+	return candidates
+}
+
+func applyColumnPhysicalQueryTopKGroups(req ColumnPhysicalQueryRequest, groups []ColumnPhysicalQueryGroup) []ColumnPhysicalQueryGroup {
+	if req.TopK <= 0 {
+		return groups
+	}
+	out := groups[:0]
+	for idx := 0; idx < len(groups); idx++ {
+		group := groups[idx]
+		if req.SkipEmptyGroupKey && group.Key == "" {
+			continue
+		}
+		insertColumnPhysicalTopKGroup(&out, group, req.TopK, req.TopKOrder)
+	}
+	return out
 }
 
 func sortColumnPhysicalQueryGroupsByKey(groups []ColumnPhysicalQueryGroup) {

--- a/TreeDB/collections/column_physical_query.go
+++ b/TreeDB/collections/column_physical_query.go
@@ -1381,6 +1381,7 @@ func mergeColumnPhysicalQueryFallbackReason(left, right ColumnPhysicalQueryFallb
 type columnPhysicalQueryExecutor struct {
 	kind              ColumnPhysicalQueryKind
 	readIntegrity     ColumnAssetReadIntegrity
+	topK              int
 	projected         []string
 	groupIdx          int
 	valueIdx          int
@@ -1412,6 +1413,7 @@ func newColumnPhysicalQueryExecutor(cfg ColumnStoreConfig, req ColumnPhysicalQue
 	exec := &columnPhysicalQueryExecutor{
 		kind:              req.Kind,
 		readIntegrity:     req.ColumnAssetReadIntegrity,
+		topK:              req.TopK,
 		groupIdx:          -1,
 		valueIdx:          -1,
 		distinctIdx:       -1,
@@ -1977,7 +1979,9 @@ func (e *columnPhysicalQueryExecutor) groups() []ColumnPhysicalQueryGroup {
 			e.resultGroups = append(e.resultGroups, ColumnPhysicalQueryGroup{Key: key, Int64: span.max - span.min})
 		}
 	}
-	sortColumnPhysicalQueryGroupsByKey(e.resultGroups)
+	if e.topK == 0 {
+		sortColumnPhysicalQueryGroupsByKey(e.resultGroups)
+	}
 	return e.resultGroups
 }
 

--- a/TreeDB/collections/column_physical_typed_column_query.go
+++ b/TreeDB/collections/column_physical_typed_column_query.go
@@ -538,8 +538,10 @@ func (r *columnTypedColumnPhysicalQueryRunner) run(view columnPhysicalScanSnapsh
 	groups := acc.groups(req, r.resultGroups)
 	r.resultGroups = groups
 	diag := r.diagnostics(view, req, rowsScanned, matchedRows, acc.reduceRows, time.Since(start).Nanoseconds())
-	diag.ResultGroups = len(groups)
-	return ColumnPhysicalQueryResult{Groups: groups, Diagnostics: diag}, nil
+	result := ColumnPhysicalQueryResult{Groups: groups, Diagnostics: diag}
+	finalizeColumnPhysicalQueryResultGroups(req, &result)
+	r.resultGroups = result.Groups
+	return result, nil
 }
 
 func columnTypedColumnPhysicalQueryUseSortedGroupedDistinct(plan columnTypedColumnPhysicalQueryPlan, req ColumnPhysicalQueryRequest) bool {

--- a/TreeDB/collections/column_physical_typed_column_query.go
+++ b/TreeDB/collections/column_physical_typed_column_query.go
@@ -505,7 +505,12 @@ func decodeTypedColumnPhysicalQueryPart(plan columnTypedColumnPhysicalQueryPlan,
 
 func (r *columnTypedColumnPhysicalQueryRunner) run(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest) (ColumnPhysicalQueryResult, error) {
 	if columnTypedColumnPhysicalQueryUseSortedGroupedDistinct(r.plan, req) {
-		return r.runSortedGroupedDistinct(view, req)
+		result, err := r.runSortedGroupedDistinct(view, req)
+		if err == nil {
+			finalizeColumnPhysicalQueryResultGroups(req, &result)
+			r.resultGroups = result.Groups
+		}
+		return result, err
 	}
 
 	start := time.Now()

--- a/TreeDB/collections/column_physical_typed_column_query.go
+++ b/TreeDB/collections/column_physical_typed_column_query.go
@@ -986,10 +986,12 @@ func (a *columnTypedColumnPhysicalQueryAccumulator) groups(req ColumnPhysicalQue
 			out = append(out, ColumnPhysicalQueryGroup{Key: key, Int64: span.max - span.min})
 		}
 	}
-	if a.kind == ColumnPhysicalQueryGroupHourCount {
-		sortColumnPhysicalQueryGroupsByKeyHour(out)
-	} else {
-		sortColumnPhysicalQueryGroupsByKey(out)
+	if req.TopK == 0 {
+		if a.kind == ColumnPhysicalQueryGroupHourCount {
+			sortColumnPhysicalQueryGroupsByKeyHour(out)
+		} else {
+			sortColumnPhysicalQueryGroupsByKey(out)
+		}
 	}
 	return out
 }


### PR DESCRIPTION
## Objective

Next #1950 chunk for parent #1945: implement q4b top-3 earliest posters as a typed-column physical query over the ClickHouse-style SortKey mark-pruned prefix scan.

This intentionally leaves q4a time-order early-stop and q1/q3/q5 dense kernels for follow-up chunks.

## What changed

- q4b request shape is now supported without aggregate metadata:
  - `ColumnPhysicalQueryGroupMinInt64`
  - group `did`
  - value `time_us`
  - predicates `kind=commit`, `operation=create`, `collection=app.bsky.feed.post`
  - `TopK=3`, `TopKOrder=int64_asc`
- Relaxed physical TopK validation so int64 aggregate physical reducers can request TopK beyond aggregate metadata.
- Added a shared finalizer that applies TopK result shaping and diagnostics for non-metadata int64 physical result paths.
- Avoided pre-TopK full key sorting in non-metadata int64 result builders when `TopK > 0`; final shaping keeps only the requested TopK by `Int64` plus key tie-break.
- Typed-column q4b keeps using the existing manifest/catalog/typed-column part section path and #1949/#2009 sorted-prefix mark pruning.
- Added deterministic q4b direct/prepared parity tests against an actual row scan, including tie-break coverage.
- Added direct/prepared q4b TopK benchmark rows for primary-id control, ClickHouse full scan, and ClickHouse mark pruning.

## Scope boundary / deferrals

Deferred:

- q4a `time_us` physical-order early-stop. This PR does not claim decoded-byte early-stop; the current typed-column physical runner decodes selected sections before reducing, so q4a should be a separate streaming/prefix decode chunk.
- q1 dense dictionary-code grouped count.
- q3 dense grouped-hour count.
- q5 top-3 user activity spans.

## Correctness evidence

Local Apple M3 / darwin arm64, `GOWORK=off`:

```sh
go test ./TreeDB/collections -run 'TestTypedColumnQ4BTopKMarkPrunedParity1950|TestTypedColumnQ2SortedGroupedDistinctStreaming1950|TestTypedColumnQ2SortedGroupedDistinctFallback1950|TestColumnPhysicalNonMetadataTopKShaping1950|TestTypedColumnSortKeyQ2StreamingReadinessDiagnostics1949' -count=1
go test ./TreeDB/collections -count=1
go test ./TreeDB/internal/typedcolumn ./TreeDB/collections ./TreeDB/docs -count=1
```

Results after latest CodeRabbit fixes: all passed.

Key test assertions:

- q4b direct uses one-shot `RunColumnPhysicalQuery`.
- q4b prepared uses `PrepareColumnPhysicalQuery` + `runner.Run`.
- expected top-3 is derived from `ScanDocumentsFunc` row scan.
- diagnostics assert typed-column source, no fallback, no row/document materialization, sorted-prefix `kind/operation/collection`, mark checks/skips, fewer rows scanned than total, decoded payload bytes, and TopK counters.
- non-metadata compatibility TopK shaping is covered so validation broadening does not silently return unshaped results.
- q2 sorted grouped-distinct tests were rerun after finalizer wiring touched that short-circuit.

Artifacts:

- Plan: `/tmp/orca_issue_graph_1945_1955/1950_next_plan.md`
- Executor evidence: `/tmp/orca_issue_graph_1945_1955/1950_next/executor_*`
- Reviewer pass: `/tmp/orca_issue_graph_1945_1955/1950_next/reviewer_findings.md`
- Manager review: `/tmp/orca_issue_graph_1945_1955/1950_next/internal_review.md`
- CodeRabbit-fix tests/benchmarks: `/tmp/orca_issue_graph_1945_1955/1950_next/*coderabbit*`
- Latest tie-break fixture validation: `/tmp/orca_issue_graph_1945_1955/1950_next/*coderabbit_third.txt`

## Benchmark / diagnostics evidence

Command:

```sh
go test ./TreeDB/collections -run '^$' -bench '^BenchmarkTypedColumnQ4BTopK1950$' -benchmem -benchtime=100x -count=1
```

| row | ns/op | ops/sec | rows scanned | rows matched | reduce rows | granules considered | granules skipped | granules decoded | mark checks | mark skips | decoded bytes | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| direct / primary_id_fallback | 5,810,738 | 172.10 | 21,000 | 2,000 | 2,000 | 3 | 0 | 3 | 0 | 0 | 109,012 | 18,266,358 | 550 |
| prepared / primary_id_fallback | 2,060,755 | 485.26 | 21,000 | 2,000 | 2,000 | 3 | 0 | 3 | 0 | 0 | 109,012 | 7,027 | 11 |
| direct / clickhouse_full_scan | 6,773,861 | 147.63 | 21,000 | 21,000 | 21,000 | 3 | 0 | 3 | 3 | 0 | 126,093 | 18,227,690 | 471 |
| prepared / clickhouse_full_scan | 3,131,103 | 319.38 | 21,000 | 21,000 | 21,000 | 3 | 0 | 3 | 3 | 0 | 126,093 | 7,027 | 11 |
| direct / clickhouse_mark_pruned | 2,619,867 | 381.70 | 8,192 | 2,000 | 2,000 | 3 | 2 | 1 | 3 | 2 | 49,207 | 7,522,885 | 666 |
| prepared / clickhouse_mark_pruned | 907,888 | 1,101.46 | 8,192 | 2,000 | 2,000 | 3 | 2 | 1 | 3 | 2 | 49,207 | 7,027 | 11 |

Direct q4b mark pruning is the optimization target in this PR: it keeps the typed-column section path, skips 2/3 granules, decodes 1/3 granules, scans 8,192 rows instead of 21,000, and decodes 49,207 bytes instead of the ClickHouse full-scan control's 126,093 bytes.

Focused direct q4b profile command:

```sh
go test ./TreeDB/collections -run '^$' -bench '^BenchmarkTypedColumnQ4BTopK1950/direct/clickhouse_mark_pruned$' -benchmem -benchtime=200x -count=1 -cpuprofile /tmp/orca_issue_graph_1945_1955/1950_next/q4b_topk_direct_cpu_after_coderabbit_second.pprof -memprofile /tmp/orca_issue_graph_1945_1955/1950_next/q4b_topk_direct_mem_after_coderabbit_second.pprof
```

Profile artifacts:

- `/tmp/orca_issue_graph_1945_1955/1950_next/q4b_topk_direct_cpu_after_coderabbit_second.pprof`
- `/tmp/orca_issue_graph_1945_1955/1950_next/q4b_topk_direct_cpu_top_after_coderabbit_second.txt`
- `/tmp/orca_issue_graph_1945_1955/1950_next/q4b_topk_direct_mem_after_coderabbit_second.pprof`
- `/tmp/orca_issue_graph_1945_1955/1950_next/q4b_topk_direct_mem_top_after_coderabbit_second.txt`

## Regression assessment

No material regression accepted. This PR adds TopK shaping after int64 reduction and q4b tests/benchmarks. The direct mark-pruned q4b row is materially better than the same-run ClickHouse full-scan control on rows scanned, decoded granules, decoded bytes, ns/op, and B/op. Prepared rows remain low-allocation (`7,027 B/op`, `11 allocs/op`) across controls.

The direct mark-pruned row has more allocs/op than the direct full-scan control (666 vs 471) while still materially reducing B/op and runtime; allocation profile points at existing typed-column selected-row decode/setup costs, not document materialization. No q4a early-stop allocation claim is made here.

## AI review / merge

CodeRabbit findings were fixed in commits `5e0c0a5ce`, `c934c12bc`, and `e2b2fa20b`. Codex/Copilot/CodeRabbit were re-requested after the latest push. Do not merge directly from this PR; coordinator will merge after gates pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Top-K behavior updated: validation rules tightened/relaxed, centralized post-processing applies Top-K ordering/limits, skips unnecessary group-key sorting when Top-K is used, and records richer Top-K diagnostics and timing.

* **Tests**
  * Added comprehensive Top-K tests and a benchmark covering parity, compatibility, diagnostics, and performance across execution paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/2016?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->