### PR TITLE
Integrate fused indexed batch scoring into TreeDB HNSW search

### DIFF
--- a/TreeDB/collections/column_vector_graph_block_view.go
+++ b/TreeDB/collections/column_vector_graph_block_view.go
@@ -41,6 +41,7 @@ type columnVectorGraphSearchPlan struct {
 	ordinalRefsReady   bool
 	singleOrdinalRange bool
 	scoreSource        columnVectorGraphSearchSource
+	scoreBatchMode     columnVectorGraphScoreBatchMode
 	hits               uint64
 	misses             uint64
 	builds             uint64

--- a/TreeDB/collections/column_vector_graph_indexed_scoring_test.go
+++ b/TreeDB/collections/column_vector_graph_indexed_scoring_test.go
@@ -1,0 +1,365 @@
+package collections
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"runtime"
+	"sync"
+	"testing"
+)
+
+func TestColumnVectorGraphIndexedScoringSearchCosineParity1969(t *testing.T) {
+	rows := columnVectorGraphNativeSearchBenchAssetRowsV3(t, 64, 16, 8)
+	d, col, def := publishColumnVectorGraphPhysicalReaderTestAssetWithShapeV2B(t, 16, 8, rows)
+	defer func() { _ = d.Close() }()
+	reader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("openColumnVectorGraphPhysicalRowReader: %v", err)
+	}
+	defer func() { _ = reader.Close() }()
+	attachColumnVectorGraphIndexedScoreSources1969(t, reader, rows)
+	query := append([]float32(nil), rows[17].Vector...)
+
+	scalarResults, scalarStats := searchColumnVectorGraphIndexedScoring1969(t, reader, query, columnVectorGraphScoreBatchModeScalar, 10, 32)
+	indexedResults, indexedStats := searchColumnVectorGraphIndexedScoring1969(t, reader, query, columnVectorGraphScoreBatchModeIndexed, 10, 32)
+	assertColumnVectorGraphIndexedScoringResultsEqual1969(t, indexedResults, scalarResults)
+	if indexedStats.Candidates != scalarStats.Candidates {
+		t.Fatalf("indexed candidates=%d scalar=%d indexedStats=%+v scalarStats=%+v", indexedStats.Candidates, scalarStats.Candidates, indexedStats, scalarStats)
+	}
+	if indexedStats.ScoreBatchCandidates != indexedStats.CandidateFetches || indexedStats.ScoreBatchCalls == 0 || indexedStats.ScoreBatchMaxTileSize < 2 {
+		t.Fatalf("indexed stats=%+v want tiled score-batch candidates covering score fetches", indexedStats)
+	}
+	if indexedStats.VectorScratchDecodes != 0 || indexedStats.VectorMmapDirectViews+indexedStats.VectorHeapCopyTypedViews == 0 {
+		t.Fatalf("indexed stats=%+v want direct typed vector source without scratch decodes", indexedStats)
+	}
+}
+
+func TestColumnVectorGraphIndexedScoringUpperLayerGreedyParity1969(t *testing.T) {
+	rows := []columnVectorGraphAssetRow{
+		{ID: []byte("doc-entry"), Vector: []float32{0, 1}, InvNorm: 1, Adjacency: []uint32{columnVectorGraphLayeredAdjacencyMagic, 1, 1, 3, 2, 1, 2}},
+		{ID: []byte("doc-upper-mid"), Vector: []float32{0.8, 0.2}, InvNorm: 1, Adjacency: []uint32{3}},
+		{ID: []byte("doc-upper-best"), Vector: []float32{1, 0}, InvNorm: 1, Adjacency: []uint32{3}},
+		{ID: []byte("doc-base"), Vector: []float32{0.1, 0.9}, InvNorm: 1},
+	}
+	d, col, def := publishColumnVectorGraphPhysicalReaderTestAssetWithShapeV2B(t, 2, 4, rows)
+	defer func() { _ = d.Close() }()
+	reader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("openColumnVectorGraphPhysicalRowReader: %v", err)
+	}
+	defer func() { _ = reader.Close() }()
+	attachColumnVectorGraphIndexedScoreSources1969(t, reader, rows)
+
+	query := []float32{1, 0}
+	scalarResults, scalarStats := searchColumnVectorGraphIndexedScoring1969(t, reader, query, columnVectorGraphScoreBatchModeScalar, 1, 1)
+	indexedResults, indexedStats := searchColumnVectorGraphIndexedScoring1969(t, reader, query, columnVectorGraphScoreBatchModeIndexed, 1, 1)
+	assertColumnVectorGraphIndexedScoringResultsEqual1969(t, indexedResults, scalarResults)
+	if len(indexedResults) != 1 || indexedResults[0].Ordinal != 2 {
+		t.Fatalf("indexed results=%+v want upper-layer greedy best ordinal 2", indexedResults)
+	}
+	if indexedStats.Candidates != scalarStats.Candidates || indexedStats.ScoreBatchMaxTileSize < 2 {
+		t.Fatalf("indexedStats=%+v scalarStats=%+v want upper-layer tile scoring parity", indexedStats, scalarStats)
+	}
+}
+
+func TestColumnVectorGraphIndexedScoringLayer0ExpansionParity1969(t *testing.T) {
+	rows := []columnVectorGraphAssetRow{
+		{ID: []byte("doc-entry"), Vector: []float32{0, 1, 0}, InvNorm: 1, Adjacency: []uint32{1, 2, 3, 4}},
+		{ID: []byte("doc-a"), Vector: []float32{0.2, 0.8, 0}, InvNorm: 1},
+		{ID: []byte("doc-b"), Vector: []float32{0.9, 0.1, 0}, InvNorm: 1},
+		{ID: []byte("doc-c"), Vector: []float32{0.1, 0.1, 0.8}, InvNorm: 1},
+		{ID: []byte("doc-d"), Vector: []float32{1, 0, 0}, InvNorm: 1},
+	}
+	d, col, def := publishColumnVectorGraphPhysicalReaderTestAssetWithShapeV2B(t, 3, 4, rows)
+	defer func() { _ = d.Close() }()
+	reader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("openColumnVectorGraphPhysicalRowReader: %v", err)
+	}
+	defer func() { _ = reader.Close() }()
+	attachColumnVectorGraphIndexedScoreSources1969(t, reader, rows)
+
+	query := []float32{1, 0, 0}
+	scalarResults, scalarStats := searchColumnVectorGraphIndexedScoring1969(t, reader, query, columnVectorGraphScoreBatchModeScalar, 2, len(rows))
+	indexedResults, indexedStats := searchColumnVectorGraphIndexedScoring1969(t, reader, query, columnVectorGraphScoreBatchModeIndexed, 2, len(rows))
+	assertColumnVectorGraphIndexedScoringResultsEqual1969(t, indexedResults, scalarResults)
+	if indexedStats.Candidates != scalarStats.Candidates || indexedStats.ScoreBatchMaxTileSize < 4 {
+		t.Fatalf("indexedStats=%+v scalarStats=%+v want layer-0 expansion tile parity", indexedStats, scalarStats)
+	}
+}
+
+func TestColumnVectorGraphIndexedScoringTieAndApplicationOrder1969(t *testing.T) {
+	rows := []columnVectorGraphAssetRow{
+		{ID: []byte("doc-entry"), Vector: []float32{0, 1}, InvNorm: 1, Adjacency: []uint32{2, 1, 3}},
+		{ID: []byte("doc-tie-low-ordinal"), Vector: []float32{0.5, 0}, InvNorm: 1},
+		{ID: []byte("doc-tie-high-ordinal"), Vector: []float32{0.5, 0}, InvNorm: 1},
+		{ID: []byte("doc-must-not-be-scored-after-ef-limit"), Vector: []float32{1, 0}, InvNorm: 1},
+	}
+	d, col, def := publishColumnVectorGraphPhysicalReaderTestAssetWithShapeV2B(t, 2, 3, rows)
+	defer func() { _ = d.Close() }()
+	reader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("openColumnVectorGraphPhysicalRowReader: %v", err)
+	}
+	defer func() { _ = reader.Close() }()
+	attachColumnVectorGraphIndexedScoreSources1969(t, reader, rows)
+
+	indexedResults, indexedStats := searchColumnVectorGraphIndexedScoring1969(t, reader, []float32{1, 0}, columnVectorGraphScoreBatchModeIndexed, 2, 3)
+	if indexedStats.Candidates != 3 || indexedStats.ScoreBatchMaxTileSize != 2 {
+		t.Fatalf("indexed stats=%+v want entry plus first two adjacency candidates only", indexedStats)
+	}
+	if len(indexedResults) != 2 || indexedResults[0].Ordinal != 1 || indexedResults[1].Ordinal != 2 {
+		t.Fatalf("indexed results=%+v want tie broken by ordinal after applying first two adjacency entries", indexedResults)
+	}
+	for _, result := range indexedResults {
+		if result.Ordinal == 3 {
+			t.Fatalf("indexed results=%+v scored adjacency beyond efSearch limit", indexedResults)
+		}
+	}
+}
+
+func TestColumnVectorGraphIndexedScoringUnsupportedFallback1969(t *testing.T) {
+	rows := []columnVectorGraphAssetRow{
+		{ID: []byte("doc-entry"), Vector: []float32{0, 1, 0}, InvNorm: 1, Adjacency: []uint32{1, 2, 3}},
+		{ID: []byte("doc-a"), Vector: []float32{1, 0, 0}, InvNorm: 1},
+		{ID: []byte("doc-b"), Vector: []float32{0.5, 0.5, 0}, InvNorm: 1},
+		{ID: []byte("doc-c"), Vector: []float32{0, 0, 1}, InvNorm: 1},
+	}
+	d, col, def := publishColumnVectorGraphPhysicalReaderTestAssetWithShapeV2B(t, 3, 3, rows)
+	defer func() { _ = d.Close() }()
+	reader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("openColumnVectorGraphPhysicalRowReader: %v", err)
+	}
+	defer func() { _ = reader.Close() }()
+
+	scalarResults, _ := searchColumnVectorGraphIndexedScoring1969(t, reader, []float32{1, 0, 0}, columnVectorGraphScoreBatchModeScalar, 2, len(rows))
+	indexedResults, indexedStats := searchColumnVectorGraphIndexedScoring1969(t, reader, []float32{1, 0, 0}, columnVectorGraphScoreBatchModeIndexed, 2, len(rows))
+	assertColumnVectorGraphIndexedScoringResultsEqual1969(t, indexedResults, scalarResults)
+	if indexedStats.ScoreBatchOptimizedCalls != 0 || indexedStats.ScoreBatchScalarFallbackCalls == 0 || indexedStats.VectorScratchDecodes == 0 {
+		t.Fatalf("indexed fallback stats=%+v want unsupported layout to use scalar graph-row fallback", indexedStats)
+	}
+}
+
+func TestColumnVectorGraphIndexedScoringParallelReadersAndSearchers1969(t *testing.T) {
+	const (
+		rows = 128
+		dims = 32
+		m    = 16
+	)
+	input := columnGraphRebuildSyntheticRowsV2A(rows, dims)
+	_, d, col, def := openColumnGraphTypedColumnVectorTestCollection1782(t, dims, m, input)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	query := append([]float32(nil), input[17].vector...)
+	workers := runtime.GOMAXPROCS(0)
+	if workers < 2 {
+		workers = 2
+	}
+	if workers > columnVectorGraphNativeSearchParallelBenchMaxWorkersV3 {
+		workers = columnVectorGraphNativeSearchParallelBenchMaxWorkersV3
+	}
+
+	t.Run("readers", func(t *testing.T) {
+		readers := make([]*columnVectorGraphPhysicalRowReader, workers)
+		for i := range readers {
+			reader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
+			if err != nil {
+				t.Fatalf("open reader %d: %v", i, err)
+			}
+			defer func() { _ = reader.Close() }()
+			readers[i] = reader
+		}
+		want, _, err := readers[0].SearchCosine(query, columnVectorGraphNativeSearchOptions{TopK: 10, EfSearch: 64, ScoreBatchMode: columnVectorGraphScoreBatchModeIndexed}, &columnVectorGraphNativeSearchScratch{})
+		if err != nil {
+			t.Fatalf("baseline SearchCosine: %v", err)
+		}
+		want = cloneColumnVectorGraphIndexedScoringResults1969(want)
+		var wg sync.WaitGroup
+		errs := make(chan string, workers)
+		for worker := range readers {
+			worker := worker
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				var scratch columnVectorGraphNativeSearchScratch
+				for i := 0; i < 50; i++ {
+					got, stats, err := readers[worker].SearchCosine(query, columnVectorGraphNativeSearchOptions{TopK: 10, EfSearch: 64, ScoreBatchMode: columnVectorGraphScoreBatchModeIndexed}, &scratch)
+					if err != nil {
+						errs <- fmt.Sprintf("worker %d iteration %d SearchCosine: %v", worker, i, err)
+						return
+					}
+					if stats.ScoreBatchCandidates == 0 || stats.VectorScratchDecodes != 0 {
+						errs <- fmt.Sprintf("worker %d iteration %d stats=%+v want indexed typed source without vector scratch", worker, i, stats)
+						return
+					}
+					if mismatch := columnVectorGraphIndexedScoringResultsMismatch1969(got, want); mismatch != "" {
+						errs <- fmt.Sprintf("worker %d iteration %d: %s", worker, i, mismatch)
+						return
+					}
+				}
+			}()
+		}
+		wg.Wait()
+		close(errs)
+		for err := range errs {
+			t.Error(err)
+		}
+	})
+
+	t.Run("searchers", func(t *testing.T) {
+		searchers := make([]*VectorIndexSearcher, workers)
+		for i := range searchers {
+			searcher, err := col.OpenVectorIndexSearcher(VectorIndexSearcherOptions{IndexName: def.Name, MaxDecodedBlocks: 1})
+			if err != nil {
+				t.Fatalf("OpenVectorIndexSearcher %d: %v", i, err)
+			}
+			defer func() { _ = searcher.Close() }()
+			searchers[i] = searcher
+		}
+		opts := VectorIndexSearcherSearchOptions{Query: query, TopK: 10, EfSearch: 64, scoreBatchMode: columnVectorGraphScoreBatchModeIndexed}
+		var baselineBuffer VectorIndexSearchBuffer
+		baseline, err := searchers[0].SearchWithBuffer(opts, &baselineBuffer)
+		if err != nil {
+			t.Fatalf("baseline SearchWithBuffer: %v", err)
+		}
+		want := cloneVectorIndexSearchResults1969(baseline.Results)
+		var wg sync.WaitGroup
+		errs := make(chan string, workers)
+		for worker := range searchers {
+			worker := worker
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				var buffer VectorIndexSearchBuffer
+				for i := 0; i < 50; i++ {
+					got, err := searchers[worker].SearchWithBuffer(opts, &buffer)
+					if err != nil {
+						errs <- fmt.Sprintf("worker %d iteration %d SearchWithBuffer: %v", worker, i, err)
+						return
+					}
+					if got.Stats.ScoreBatchCandidates == 0 || got.Stats.VectorScratchDecodes != 0 {
+						errs <- fmt.Sprintf("worker %d iteration %d stats=%+v want indexed typed source without vector scratch", worker, i, got.Stats)
+						return
+					}
+					if mismatch := vectorIndexSearchResultsMismatch1969(got.Results, want); mismatch != "" {
+						errs <- fmt.Sprintf("worker %d iteration %d: %s", worker, i, mismatch)
+						return
+					}
+				}
+			}()
+		}
+		wg.Wait()
+		close(errs)
+		for err := range errs {
+			t.Error(err)
+		}
+	})
+}
+
+func attachColumnVectorGraphIndexedScoreSources1969(tb testing.TB, reader *columnVectorGraphPhysicalRowReader, rows []columnVectorGraphAssetRow) {
+	tb.Helper()
+	if reader == nil {
+		tb.Fatal("nil reader")
+	}
+	dims := reader.def.Dimensions
+	part := &columnVectorGraphTypedColumnVectorPart{
+		generation: 1,
+		partID:     1,
+		rows:       len(rows),
+		values:     make([]float32, 0, len(rows)*dims),
+		outcome:    columnVectorGraphTypedColumnVectorOutcomeMmapDirect,
+	}
+	locations := make([]columnVectorGraphTypedColumnVectorLocation, len(rows))
+	invNorms := make([]float32, len(rows))
+	for ordinal, row := range rows {
+		if len(row.Vector) != dims {
+			tb.Fatalf("row %d dims=%d want %d", ordinal, len(row.Vector), dims)
+		}
+		part.values = append(part.values, row.Vector...)
+		locations[ordinal] = columnVectorGraphTypedColumnVectorLocation{part: part, generation: 1, rowIndex: ordinal}
+		invNorm := row.InvNorm
+		if invNorm == 0 {
+			var err error
+			invNorm, err = columnVectorGraphInvNorm(row.Vector)
+			if err != nil {
+				tb.Fatalf("row %d inv_norm: %v", ordinal, err)
+			}
+		}
+		invNorms[ordinal] = invNorm
+	}
+	reader.typedVectorSource = &columnVectorGraphTypedColumnVectorSource{
+		dims:           dims,
+		locationSource: columnVectorGraphTypedColumnVectorLocationSourceRowRefState,
+		locations:      locations,
+		parts:          []*columnVectorGraphTypedColumnVectorPart{part},
+	}
+	reader.invNormSource = &columnVectorGraphInvNormStateSource{
+		rows:    len(rows),
+		values:  invNorms,
+		outcome: columnVectorGraphInvNormStateOutcomeMmapDirect,
+	}
+}
+
+func searchColumnVectorGraphIndexedScoring1969(tb testing.TB, reader *columnVectorGraphPhysicalRowReader, query []float32, mode columnVectorGraphScoreBatchMode, topK int, efSearch int) ([]columnVectorGraphNativeSearchResult, columnVectorGraphNativeSearchStats) {
+	tb.Helper()
+	var scratch columnVectorGraphNativeSearchScratch
+	results, stats, err := reader.SearchCosine(query, columnVectorGraphNativeSearchOptions{TopK: topK, EfSearch: efSearch, ScoreBatchMode: mode}, &scratch)
+	if err != nil {
+		tb.Fatalf("SearchCosine mode=%s: %v", mode.String(), err)
+	}
+	return cloneColumnVectorGraphIndexedScoringResults1969(results), stats
+}
+
+func cloneColumnVectorGraphIndexedScoringResults1969(in []columnVectorGraphNativeSearchResult) []columnVectorGraphNativeSearchResult {
+	out := make([]columnVectorGraphNativeSearchResult, len(in))
+	for i, result := range in {
+		out[i] = result
+		out[i].ID = append([]byte(nil), result.ID...)
+	}
+	return out
+}
+
+func assertColumnVectorGraphIndexedScoringResultsEqual1969(tb testing.TB, got, want []columnVectorGraphNativeSearchResult) {
+	tb.Helper()
+	if mismatch := columnVectorGraphIndexedScoringResultsMismatch1969(got, want); mismatch != "" {
+		tb.Fatal(mismatch)
+	}
+}
+
+func columnVectorGraphIndexedScoringResultsMismatch1969(got, want []columnVectorGraphNativeSearchResult) string {
+	if len(got) != len(want) {
+		return fmt.Sprintf("results len=%d want %d got=%+v want=%+v", len(got), len(want), got, want)
+	}
+	for i := range want {
+		if got[i].Ordinal != want[i].Ordinal || !bytes.Equal(got[i].ID, want[i].ID) || math.Abs(got[i].Score-want[i].Score) > 1e-6 {
+			return fmt.Sprintf("result[%d]=%s want %s", i, columnGraphNativeSearchResultStringV3(got[i]), columnGraphNativeSearchResultStringV3(want[i]))
+		}
+	}
+	return ""
+}
+
+func cloneVectorIndexSearchResults1969(in []VectorIndexSearchResult) []VectorIndexSearchResult {
+	out := make([]VectorIndexSearchResult, len(in))
+	for i, result := range in {
+		out[i] = result
+		out[i].ID = append([]byte(nil), result.ID...)
+		out[i].Document = append([]byte(nil), result.Document...)
+	}
+	return out
+}
+
+func vectorIndexSearchResultsMismatch1969(got, want []VectorIndexSearchResult) string {
+	if len(got) != len(want) {
+		return fmt.Sprintf("results len=%d want %d got=%+v want=%+v", len(got), len(want), got, want)
+	}
+	for i := range want {
+		if got[i].Ordinal != want[i].Ordinal || !bytes.Equal(got[i].ID, want[i].ID) || math.Abs(got[i].Score-want[i].Score) > 1e-6 {
+			return fmt.Sprintf("result[%d]={ordinal:%d id:%q score:%.9f} want {ordinal:%d id:%q score:%.9f}", i, got[i].Ordinal, string(got[i].ID), got[i].Score, want[i].Ordinal, string(want[i].ID), want[i].Score)
+		}
+	}
+	return ""
+}

--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -28,9 +28,46 @@ var (
 	errColumnVectorGraphNativeSearchCandidateDimensionMismatch = errors.New("collections: column_graph native search candidate dimension mismatch")
 )
 
+type columnVectorGraphScoreBatchMode uint8
+
+const (
+	columnVectorGraphScoreBatchModeDefault columnVectorGraphScoreBatchMode = iota
+	columnVectorGraphScoreBatchModeScalar
+	columnVectorGraphScoreBatchModeIndexed
+)
+
+var columnVectorGraphIndexedScoringDefaultEnabled = false
+
+func (m columnVectorGraphScoreBatchMode) indexedEnabled() bool {
+	switch m {
+	case columnVectorGraphScoreBatchModeIndexed:
+		return true
+	case columnVectorGraphScoreBatchModeDefault:
+		return columnVectorGraphIndexedScoringDefaultEnabled
+	default:
+		return false
+	}
+}
+
+func (m columnVectorGraphScoreBatchMode) String() string {
+	switch m {
+	case columnVectorGraphScoreBatchModeIndexed:
+		return "indexed"
+	case columnVectorGraphScoreBatchModeScalar:
+		return "scalar"
+	default:
+		if columnVectorGraphIndexedScoringDefaultEnabled {
+			return "default_indexed"
+		}
+		return "default_scalar"
+	}
+}
+
 type columnVectorGraphNativeSearchOptions struct {
 	TopK     int
 	EfSearch int
+
+	ScoreBatchMode columnVectorGraphScoreBatchMode
 
 	// CandidateRows is an optional pre-composed row-domain filter over graph
 	// ordinals. It is intentionally internal until public metadata predicate
@@ -97,6 +134,11 @@ type columnVectorGraphNativeSearchStats struct {
 	ResultFetches                        uint64
 	ScoreBatches                         uint64
 	OrdinalsGrouped                      uint64
+	ScoreBatchCalls                      uint64
+	ScoreBatchCandidates                 uint64
+	ScoreBatchMaxTileSize                uint64
+	ScoreBatchOptimizedCalls             uint64
+	ScoreBatchScalarFallbackCalls        uint64
 	BlockViewHits                        uint64
 	BlockViewMisses                      uint64
 	BlockViewBuilds                      uint64
@@ -174,20 +216,24 @@ type columnVectorGraphSearchCandidate struct {
 // It is not concurrency-safe. Parallel searches over immutable graph assets are
 // valid with one reader and one scratch per worker.
 type columnVectorGraphNativeSearchScratch struct {
-	scoreScratch   columnPhysicalRowReaderScratch
-	expandScratch  columnPhysicalRowReaderScratch
-	resultScratch  columnPhysicalRowReaderScratch
-	visitMarks     []uint64
-	visitEpoch     uint64
-	frontier       []columnVectorGraphSearchCandidate
-	top            []columnVectorGraphSearchCandidate
-	results        []columnVectorGraphNativeSearchResult
-	idBuffers      [][]byte
-	resultOrder    []int
-	resultOrdinals []int
-	resultRowRefs  []DocumentRowRef
-	resultHasRefs  []bool
-	searchPlan     columnVectorGraphSearchPlan
+	scoreScratch      columnPhysicalRowReaderScratch
+	expandScratch     columnPhysicalRowReaderScratch
+	resultScratch     columnPhysicalRowReaderScratch
+	visitMarks        []uint64
+	visitEpoch        uint64
+	frontier          []columnVectorGraphSearchCandidate
+	top               []columnVectorGraphSearchCandidate
+	results           []columnVectorGraphNativeSearchResult
+	idBuffers         [][]byte
+	resultOrder       []int
+	resultOrdinals    []int
+	resultRowRefs     []DocumentRowRef
+	resultHasRefs     []bool
+	scoreTileOrdinals []int
+	scoreTileScores   []float64
+	scoreTileRowIDs   []uint32
+	scoreTileDots     []float32
+	searchPlan        columnVectorGraphSearchPlan
 }
 
 func (s *columnVectorGraphNativeSearchScratch) prepare(rowCount, dimensions, degree, topK, efSearch int) error {
@@ -221,6 +267,10 @@ func (s *columnVectorGraphNativeSearchScratch) prepare(rowCount, dimensions, deg
 	s.resultOrdinals = resizeColumnVectorGraphNativeIntScratch(s.resultOrdinals, topK)
 	s.resultRowRefs = resizeColumnVectorGraphNativeRowRefScratch(s.resultRowRefs, topK)
 	s.resultHasRefs = resizeColumnVectorGraphNativeBoolScratch(s.resultHasRefs, topK)
+	s.scoreTileOrdinals = resizeColumnVectorGraphNativeIntScratch(s.scoreTileOrdinals, degree)
+	s.scoreTileScores = resizeColumnVectorGraphNativeFloat64Scratch(s.scoreTileScores, degree)
+	s.scoreTileRowIDs = resizeColumnVectorGraphNativeUint32Scratch(s.scoreTileRowIDs, degree)
+	s.scoreTileDots = resizeColumnVectorGraphNativeFloat32Scratch(s.scoreTileDots, degree)
 	return nil
 }
 
@@ -273,6 +323,55 @@ func resizeColumnVectorGraphNativeUint64Scratch(dst []uint64, target int) []uint
 		return make([]uint64, target)
 	}
 	return dst[:target]
+}
+
+func resizeColumnVectorGraphNativeUint32Scratch(dst []uint32, target int) []uint32 {
+	if cap(dst) < target || columnVectorGraphNativeScratchCapOversized(cap(dst), target) {
+		return make([]uint32, 0, target)
+	}
+	return dst[:0]
+}
+
+func resizeColumnVectorGraphNativeFloat32Scratch(dst []float32, target int) []float32 {
+	if cap(dst) < target || columnVectorGraphNativeScratchCapOversized(cap(dst), target) {
+		return make([]float32, 0, target)
+	}
+	return dst[:0]
+}
+
+func resizeColumnVectorGraphNativeFloat64Scratch(dst []float64, target int) []float64 {
+	if cap(dst) < target || columnVectorGraphNativeScratchCapOversized(cap(dst), target) {
+		return make([]float64, 0, target)
+	}
+	return dst[:0]
+}
+
+func ensureColumnVectorGraphNativeIntScratch(dst []int, target int) []int {
+	if cap(dst) < target {
+		return make([]int, 0, target)
+	}
+	return dst[:0]
+}
+
+func ensureColumnVectorGraphNativeUint32Scratch(dst []uint32, target int) []uint32 {
+	if cap(dst) < target {
+		return make([]uint32, 0, target)
+	}
+	return dst[:0]
+}
+
+func ensureColumnVectorGraphNativeFloat32Scratch(dst []float32, target int) []float32 {
+	if cap(dst) < target {
+		return make([]float32, 0, target)
+	}
+	return dst[:0]
+}
+
+func ensureColumnVectorGraphNativeFloat64Scratch(dst []float64, target int) []float64 {
+	if cap(dst) < target {
+		return make([]float64, 0, target)
+	}
+	return dst[:0]
 }
 
 func resizeColumnVectorGraphNativeRowRefScratch(dst []DocumentRowRef, target int) []DocumentRowRef {
@@ -399,6 +498,7 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 	if err != nil {
 		return nil, stats, err
 	}
+	plan.scoreBatchMode = opts.ScoreBatchMode
 	var singleBlockView *columnVectorGraphBlockView
 	if plan.physicalReader != nil && len(plan.physicalReader.ranges) == 1 {
 		singleBlockView, err = plan.blockViewForAssetOrdinal(0)
@@ -444,6 +544,47 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 		adjacency, err := r.expandCandidateAdjacencyLayer(plan, singleBlockView, candidate.ordinal, 0, scratch, &stats)
 		if err != nil {
 			return nil, stats, err
+		}
+		if plan.scoreBatchMode.indexedEnabled() {
+			for i := 0; i < len(adjacency) && stats.Candidates < uint64(efSearch); {
+				remaining := int(uint64(efSearch) - stats.Candidates)
+				if remaining <= 0 {
+					break
+				}
+				tileCap := len(adjacency) - i
+				if tileCap > remaining {
+					tileCap = remaining
+				}
+				scratch.scoreTileOrdinals = ensureColumnVectorGraphNativeIntScratch(scratch.scoreTileOrdinals, tileCap)
+				tile := scratch.scoreTileOrdinals[:0]
+				for i < len(adjacency) && len(tile) < remaining {
+					neighborIndex := i
+					neighbor := adjacency[i]
+					i++
+					stats.Edges++
+					stats.VisitedEdges++
+					if uint64(neighbor) >= uint64(rowCount) {
+						return nil, stats, fmt.Errorf("collections: column_graph %q ordinal=%d adjacency[%d]=%d outside row_count=%d: %w", r.def.Name, candidate.ordinal, neighborIndex, neighbor, rowCount, errColumnVectorGraphAdjacencyOrdinalOutOfBounds)
+					}
+					neighborOrdinal := int(neighbor)
+					if visitMarks[neighborOrdinal] == visitEpoch {
+						continue
+					}
+					if !columnVectorGraphCandidateRowAllowed(candidateRows, hasCandidateRows, neighborOrdinal) {
+						visitMarks[neighborOrdinal] = visitEpoch
+						continue
+					}
+					visitMarks[neighborOrdinal] = visitEpoch
+					tile = append(tile, neighborOrdinal)
+				}
+				if len(tile) == 0 {
+					continue
+				}
+				if err := r.scoreAndPushFrontierVisitedTile(plan, singleBlockView, query, queryInvNorm, tile, topK, scratch, &stats); err != nil {
+					return nil, stats, err
+				}
+			}
+			continue
 		}
 		for i, neighbor := range adjacency {
 			if stats.Candidates >= uint64(efSearch) {
@@ -548,6 +689,41 @@ func (r *columnVectorGraphPhysicalRowReader) greedyNearestAtLayer(plan *columnVe
 		adjacency, err := r.expandCandidateAdjacencyLayer(plan, singleBlockView, best, layer, scratch, stats)
 		if err != nil {
 			return 0, err
+		}
+		if plan.scoreBatchMode.indexedEnabled() {
+			scratch.scoreTileOrdinals = ensureColumnVectorGraphNativeIntScratch(scratch.scoreTileOrdinals, len(adjacency))
+			tile := scratch.scoreTileOrdinals[:0]
+			for i, neighbor := range adjacency {
+				if stats != nil {
+					stats.Edges++
+					stats.VisitedEdges++
+				}
+				if uint64(neighbor) >= uint64(r.RowCount()) {
+					return 0, fmt.Errorf("collections: column_graph %q ordinal=%d adjacency[%d]=%d outside row_count=%d: %w", r.def.Name, best, i, neighbor, r.RowCount(), errColumnVectorGraphAdjacencyOrdinalOutOfBounds)
+				}
+				neighborOrdinal := int(neighbor)
+				if !columnVectorGraphCandidateRowAllowed(candidateRows, hasCandidateRows, neighborOrdinal) {
+					continue
+				}
+				tile = append(tile, neighborOrdinal)
+			}
+			if len(tile) == 0 {
+				continue
+			}
+			scratch.scoreTileScores = ensureColumnVectorGraphNativeFloat64Scratch(scratch.scoreTileScores, len(tile))
+			scores, err := plan.scoreSource.scoreOrdinals(plan, singleBlockView, query, queryInvNorm, tile, scratch.scoreTileScores, scratch, stats)
+			if err != nil {
+				return 0, err
+			}
+			for i, neighborOrdinal := range tile {
+				score := scores[i]
+				if score > bestScore || (score == bestScore && neighborOrdinal < best) {
+					best = neighborOrdinal
+					bestScore = score
+					changed = true
+				}
+			}
+			continue
 		}
 		for i, neighbor := range adjacency {
 			if stats != nil {
@@ -671,6 +847,24 @@ func (r *columnVectorGraphPhysicalRowReader) scoreAndPushFrontierVisited(plan *c
 	return nil
 }
 
+func (r *columnVectorGraphPhysicalRowReader) scoreAndPushFrontierVisitedTile(plan *columnVectorGraphSearchPlan, singleBlockView *columnVectorGraphBlockView, query []float32, queryInvNorm float32, ordinals []int, topK int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) error {
+	if len(ordinals) == 0 {
+		return nil
+	}
+	scratch.scoreTileScores = ensureColumnVectorGraphNativeFloat64Scratch(scratch.scoreTileScores, len(ordinals))
+	scores, err := plan.scoreSource.scoreOrdinals(plan, singleBlockView, query, queryInvNorm, ordinals, scratch.scoreTileScores, scratch, stats)
+	if err != nil {
+		return err
+	}
+	for i, ordinal := range ordinals {
+		stats.Candidates++
+		candidate := columnVectorGraphSearchCandidate{ordinal: ordinal, score: scores[i]}
+		scratch.insertTop(topK, candidate)
+		scratch.pushFrontier(candidate)
+	}
+	return nil
+}
+
 func (r *columnVectorGraphPhysicalRowReader) scoreOrdinal(plan *columnVectorGraphSearchPlan, singleBlockView *columnVectorGraphBlockView, query []float32, queryInvNorm float32, ordinal int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) (float64, error) {
 	if plan != nil && plan.scoreSource.reader != nil {
 		return plan.scoreSource.scoreOrdinal(plan, singleBlockView, query, queryInvNorm, ordinal, scratch, stats)
@@ -690,8 +884,7 @@ func (r *columnVectorGraphPhysicalRowReader) scoreOrdinalLegacy(plan *columnVect
 		rowIndex = ref.rowIndex
 	}
 	if stats != nil {
-		stats.ScoreBatches++
-		stats.OrdinalsGrouped++
+		recordColumnVectorGraphScoreBatchStats(stats, 1, false, true)
 		stats.VisitedNodes++
 		stats.BlockViewHits = plan.hits
 		stats.BlockViewMisses = plan.misses
@@ -1046,6 +1239,25 @@ func columnVectorGraphSearchCandidateBetter(left, right columnVectorGraphSearchC
 	return left.score > right.score
 }
 
+func recordColumnVectorGraphScoreBatchStats(stats *columnVectorGraphNativeSearchStats, tileSize int, optimized bool, scalarFallback bool) {
+	if stats == nil || tileSize <= 0 {
+		return
+	}
+	stats.ScoreBatches++
+	stats.OrdinalsGrouped += uint64(tileSize)
+	stats.ScoreBatchCalls++
+	stats.ScoreBatchCandidates += uint64(tileSize)
+	if uint64(tileSize) > stats.ScoreBatchMaxTileSize {
+		stats.ScoreBatchMaxTileSize = uint64(tileSize)
+	}
+	if optimized {
+		stats.ScoreBatchOptimizedCalls++
+	}
+	if scalarFallback {
+		stats.ScoreBatchScalarFallbackCalls++
+	}
+}
+
 func columnVectorGraphNativeCosineScore(query []float32, queryInvNorm float32, row columnVectorGraphPhysicalRow) (float64, error) {
 	return columnVectorGraphNativeCosineScoreVector(query, queryInvNorm, row.Ordinal, row.Vector, row.InvNorm)
 }
@@ -1055,11 +1267,21 @@ func columnVectorGraphNativeCosineScoreVector(query []float32, queryInvNorm floa
 		return 0, fmt.Errorf("collections: column_graph candidate ordinal=%d vector dims=%d want %d: %w", ordinal, len(vector), len(query), errColumnVectorGraphNativeSearchCandidateDimensionMismatch)
 	}
 	dot := float64(vectorDotProductFloat32(query, vector))
-	if !math.IsInf(dot, 0) && !math.IsNaN(dot) {
-		return dot * float64(queryInvNorm) * float64(invNorm), nil
+	return columnVectorGraphNativeCosineScoreDot(query, queryInvNorm, ordinal, dot, vector, invNorm)
+}
+
+func columnVectorGraphNativeCosineScoreDot(query []float32, queryInvNorm float32, ordinal int, dot float64, vector []float32, invNorm float32) (float64, error) {
+	if len(vector) != len(query) {
+		return 0, fmt.Errorf("collections: column_graph candidate ordinal=%d vector dims=%d want %d: %w", ordinal, len(vector), len(query), errColumnVectorGraphNativeSearchCandidateDimensionMismatch)
 	}
-	dot = columnVectorGraphNativeDotProductFloat64(query, vector)
-	return dot * float64(queryInvNorm) * float64(invNorm), nil
+	if math.IsInf(dot, 0) || math.IsNaN(dot) {
+		dot = columnVectorGraphNativeDotProductFloat64(query, vector)
+	}
+	score := dot * float64(queryInvNorm) * float64(invNorm)
+	if math.IsNaN(score) || math.IsInf(score, 0) {
+		return 0, fmt.Errorf("collections: column_graph candidate ordinal=%d cosine score is not finite", ordinal)
+	}
+	return score, nil
 }
 
 func columnVectorGraphNativeDotProductFloat64(left, right []float32) float64 {

--- a/TreeDB/collections/column_vector_graph_search_source.go
+++ b/TreeDB/collections/column_vector_graph_search_source.go
@@ -5,6 +5,7 @@ import (
 	"math"
 
 	"github.com/snissn/gomap/TreeDB/internal/typeddecode"
+	"github.com/snissn/gomap/TreeDB/internal/vectorops"
 )
 
 type columnVectorGraphSearchVectorSourceKind uint8
@@ -166,8 +167,7 @@ func (s *columnVectorGraphSearchSource) scoreOrdinal(plan *columnVectorGraphSear
 		rowIndex = ref.rowIndex
 	}
 	if stats != nil {
-		stats.ScoreBatches++
-		stats.OrdinalsGrouped++
+		recordColumnVectorGraphScoreBatchStats(stats, 1, false, true)
 		stats.VisitedNodes++
 		stats.BlockViewHits = plan.hits
 		stats.BlockViewMisses = plan.misses
@@ -211,6 +211,140 @@ func (s *columnVectorGraphSearchSource) scoreOrdinalsScalar(plan *columnVectorGr
 		dst[i] = score
 	}
 	return dst, nil
+}
+
+func (s *columnVectorGraphSearchSource) scoreOrdinals(plan *columnVectorGraphSearchPlan, singleBlockView *columnVectorGraphBlockView, query []float32, queryInvNorm float32, ordinals []int, dst []float64, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) ([]float64, error) {
+	if len(ordinals) <= 1 || plan == nil || !plan.scoreBatchMode.indexedEnabled() || scratch == nil {
+		return s.scoreOrdinalsScalar(plan, singleBlockView, query, queryInvNorm, ordinals, dst, scratch, stats)
+	}
+	if got, ok, err := s.scoreOrdinalsIndexed(plan, query, queryInvNorm, ordinals, dst, scratch, stats); ok || err != nil {
+		return got, err
+	}
+	return s.scoreOrdinalsScalar(plan, singleBlockView, query, queryInvNorm, ordinals, dst, scratch, stats)
+}
+
+func (s *columnVectorGraphSearchSource) scoreOrdinalsIndexed(plan *columnVectorGraphSearchPlan, query []float32, queryInvNorm float32, ordinals []int, dst []float64, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) ([]float64, bool, error) {
+	if s == nil || s.reader == nil || s.vectorKind != columnVectorGraphSearchVectorSourceTypedColumn || s.normKind != columnVectorGraphSearchNormSourceInvNormByOrdinal || s.dims <= 0 || len(query) != s.dims || len(ordinals) == 0 || scratch == nil {
+		return dst, false, nil
+	}
+	if s.invNormSource != nil && (s.invNormSource.closed || (s.invNormSource.handle != nil && s.invNormSource.handle.Released())) {
+		return dst, false, nil
+	}
+	if cap(dst) < len(ordinals) {
+		dst = make([]float64, len(ordinals))
+	} else {
+		dst = dst[:len(ordinals)]
+	}
+	maxRun := 0
+	for i := 0; i < len(ordinals); {
+		loc, ok := s.indexedVectorLocationForOrdinal(ordinals[i])
+		if !ok || ordinals[i] < 0 || ordinals[i] >= len(s.invNormByOrdinal) || uint64(loc.rowIndex) > uint64(^uint32(0)) {
+			return dst, false, nil
+		}
+		part := loc.part
+		j := i + 1
+		for j < len(ordinals) {
+			nextLoc, ok := s.indexedVectorLocationForOrdinal(ordinals[j])
+			if !ok || nextLoc.part != part || ordinals[j] < 0 || ordinals[j] >= len(s.invNormByOrdinal) || uint64(nextLoc.rowIndex) > uint64(^uint32(0)) {
+				break
+			}
+			j++
+		}
+		if runLen := j - i; runLen > maxRun {
+			maxRun = runLen
+		}
+		i = j
+	}
+	if maxRun == 0 {
+		return dst, false, nil
+	}
+	scratch.scoreTileRowIDs = ensureColumnVectorGraphNativeUint32Scratch(scratch.scoreTileRowIDs, maxRun)
+	scratch.scoreTileDots = ensureColumnVectorGraphNativeFloat32Scratch(scratch.scoreTileDots, maxRun)
+	var optimizedCalls uint64
+	var scalarFallbackCalls uint64
+	for runStart := 0; runStart < len(ordinals); {
+		loc, _ := s.indexedVectorLocationForOrdinal(ordinals[runStart])
+		part := loc.part
+		runEnd := runStart + 1
+		for runEnd < len(ordinals) {
+			nextLoc, _ := s.indexedVectorLocationForOrdinal(ordinals[runEnd])
+			if nextLoc.part != part {
+				break
+			}
+			runEnd++
+		}
+		runLen := runEnd - runStart
+		rowIDs := scratch.scoreTileRowIDs[:runLen]
+		for i, ordinal := range ordinals[runStart:runEnd] {
+			loc := s.typedVectorLocations[ordinal]
+			rowIDs[i] = uint32(loc.rowIndex)
+		}
+		dots := scratch.scoreTileDots[:runLen]
+		status := vectorops.DotFloat32Indexed(dots, part.values, query, rowIDs, s.dims)
+		if status.Invalid || status.Rows != runLen {
+			return dst, false, nil
+		}
+		if status.Optimized {
+			optimizedCalls++
+		} else {
+			scalarFallbackCalls++
+		}
+		for i, ordinal := range ordinals[runStart:runEnd] {
+			loc := s.typedVectorLocations[ordinal]
+			score, err := columnVectorGraphNativeCosineScoreDot(query, queryInvNorm, ordinal, float64(dots[i]), part.values[loc.rowIndex*s.dims:loc.rowIndex*s.dims+s.dims], s.invNormByOrdinal[ordinal])
+			if err != nil {
+				return dst, true, err
+			}
+			dst[runStart+i] = score
+		}
+		runStart = runEnd
+	}
+	if stats != nil {
+		for runStart := 0; runStart < len(ordinals); {
+			loc := s.typedVectorLocations[ordinals[runStart]]
+			part := loc.part
+			runEnd := runStart + 1
+			for runEnd < len(ordinals) && s.typedVectorLocations[ordinals[runEnd]].part == part {
+				runEnd++
+			}
+			recordColumnVectorGraphScoreBatchStats(stats, runEnd-runStart, false, false)
+			runStart = runEnd
+		}
+		stats.ScoreBatchOptimizedCalls += optimizedCalls
+		stats.ScoreBatchScalarFallbackCalls += scalarFallbackCalls
+		stats.VisitedNodes += uint64(len(ordinals))
+		stats.CandidateFetches += uint64(len(ordinals))
+		stats.VectorBytesRead += uint64(len(ordinals) * s.dims * 4)
+		stats.NormBytesRead += uint64(len(ordinals) * 4)
+		stats.BlockViewHits = plan.hits
+		stats.BlockViewMisses = plan.misses
+		stats.BlockViewBuilds = plan.builds
+		for _, ordinal := range ordinals {
+			loc := s.typedVectorLocations[ordinal]
+			recordColumnVectorGraphVectorSourceStats(stats, loc.part.outcome, loc.part.fallbackReason)
+			recordColumnVectorGraphInvNormSourceStats(stats, s.invNormOutcome, s.invNormFallback)
+		}
+	}
+	return dst, true, nil
+}
+
+func (s *columnVectorGraphSearchSource) indexedVectorLocationForOrdinal(ordinal int) (columnVectorGraphTypedColumnVectorLocation, bool) {
+	if s == nil || ordinal < 0 || ordinal >= len(s.typedVectorLocations) || s.dims <= 0 {
+		return columnVectorGraphTypedColumnVectorLocation{}, false
+	}
+	loc := s.typedVectorLocations[ordinal]
+	if loc.part == nil || loc.rowIndex < 0 || loc.rowIndex >= loc.part.rows {
+		return columnVectorGraphTypedColumnVectorLocation{}, false
+	}
+	if loc.part.handle != nil && loc.part.handle.Released() {
+		return columnVectorGraphTypedColumnVectorLocation{}, false
+	}
+	start := loc.rowIndex * s.dims
+	end := start + s.dims
+	if start < 0 || end < start || end > len(loc.part.values) {
+		return columnVectorGraphTypedColumnVectorLocation{}, false
+	}
+	return loc, true
 }
 
 func (s *columnVectorGraphSearchSource) typedVectorForOrdinal(ordinal int) ([]float32, columnVectorGraphTypedColumnVectorOutcome, typeddecode.Reason, bool) {

--- a/TreeDB/collections/column_vector_graph_search_test.go
+++ b/TreeDB/collections/column_vector_graph_search_test.go
@@ -26,6 +26,7 @@ type columnVectorGraphNativeSearchBenchShapeV3 struct {
 	queryOrdinal        int
 	directPhysicalAsset bool
 	typedColumnVector   bool
+	scoreBatchMode      columnVectorGraphScoreBatchMode
 }
 
 func TestColumnVectorGraphAdjacencySourceStatsSkipEmptyNoopV3(t *testing.T) {
@@ -816,6 +817,24 @@ func BenchmarkColumnVectorGraphNativeSearchCosineTypedColumnProduction8192V3(b *
 	benchmarkColumnVectorGraphNativeSearchCosineV3(b, shape)
 }
 
+func BenchmarkColumnVectorGraphNativeSearchCosineIndexedScoring1969(b *testing.B) {
+	for _, tc := range []struct {
+		name string
+		mode columnVectorGraphScoreBatchMode
+	}{
+		{name: "scalar", mode: columnVectorGraphScoreBatchModeScalar},
+		{name: "indexed", mode: columnVectorGraphScoreBatchModeIndexed},
+	} {
+		tc := tc
+		b.Run(tc.name, func(b *testing.B) {
+			shape := columnVectorGraphNativeSearchSmallBenchShapeV3()
+			shape.typedColumnVector = true
+			shape.scoreBatchMode = tc.mode
+			benchmarkColumnVectorGraphNativeSearchCosineV3(b, shape)
+		})
+	}
+}
+
 func benchmarkColumnVectorGraphNativeSearchCosineV3(b *testing.B, shape columnVectorGraphNativeSearchBenchShapeV3) {
 	b.Helper()
 	closeFn, col, def, query := openColumnVectorGraphNativeSearchBenchFixtureV3(b, shape)
@@ -826,7 +845,7 @@ func benchmarkColumnVectorGraphNativeSearchCosineV3(b *testing.B, shape columnVe
 	}
 	defer reader.Close()
 	var scratch columnVectorGraphNativeSearchScratch
-	opts := columnVectorGraphNativeSearchOptions{TopK: shape.topK, EfSearch: shape.efSearch}
+	opts := columnVectorGraphNativeSearchOptions{TopK: shape.topK, EfSearch: shape.efSearch, ScoreBatchMode: shape.scoreBatchMode}
 	if _, _, err := reader.SearchCosine(query, opts, &scratch); err != nil {
 		b.Fatalf("warm SearchCosine: %v", err)
 	}
@@ -856,6 +875,13 @@ func benchmarkColumnVectorGraphNativeSearchCosineV3(b *testing.B, shape columnVe
 		searchStats.ResultFetches += stats.ResultFetches
 		searchStats.ScoreBatches += stats.ScoreBatches
 		searchStats.OrdinalsGrouped += stats.OrdinalsGrouped
+		searchStats.ScoreBatchCalls += stats.ScoreBatchCalls
+		searchStats.ScoreBatchCandidates += stats.ScoreBatchCandidates
+		if stats.ScoreBatchMaxTileSize > searchStats.ScoreBatchMaxTileSize {
+			searchStats.ScoreBatchMaxTileSize = stats.ScoreBatchMaxTileSize
+		}
+		searchStats.ScoreBatchOptimizedCalls += stats.ScoreBatchOptimizedCalls
+		searchStats.ScoreBatchScalarFallbackCalls += stats.ScoreBatchScalarFallbackCalls
 		searchStats.BlockViewHits += stats.BlockViewHits
 		searchStats.BlockViewMisses += stats.BlockViewMisses
 		searchStats.BlockViewBuilds += stats.BlockViewBuilds
@@ -960,7 +986,7 @@ func benchmarkColumnVectorGraphNativeSearchCosineParallelV3(b *testing.B, shape 
 	previousGOMAXPROCS := runtime.GOMAXPROCS(workers)
 	defer runtime.GOMAXPROCS(previousGOMAXPROCS)
 	benchWorkers := make([]*searchWorker, workers)
-	opts := columnVectorGraphNativeSearchOptions{TopK: shape.topK, EfSearch: shape.efSearch}
+	opts := columnVectorGraphNativeSearchOptions{TopK: shape.topK, EfSearch: shape.efSearch, ScoreBatchMode: shape.scoreBatchMode}
 	for i := range benchWorkers {
 		reader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
 		if err != nil {
@@ -999,6 +1025,11 @@ func benchmarkColumnVectorGraphNativeSearchCosineParallelV3(b *testing.B, shape 
 	var totalResultFetches atomic.Uint64
 	var totalScoreBatches atomic.Uint64
 	var totalOrdinalsGrouped atomic.Uint64
+	var totalScoreBatchCalls atomic.Uint64
+	var totalScoreBatchCandidates atomic.Uint64
+	var totalScoreBatchMaxTileSize atomic.Uint64
+	var totalScoreBatchOptimizedCalls atomic.Uint64
+	var totalScoreBatchScalarFallbackCalls atomic.Uint64
 	var totalBlockViewHits atomic.Uint64
 	var totalBlockViewMisses atomic.Uint64
 	var totalBlockViewBuilds atomic.Uint64
@@ -1090,6 +1121,13 @@ func benchmarkColumnVectorGraphNativeSearchCosineParallelV3(b *testing.B, shape 
 			localStats.ResultFetches += stats.ResultFetches
 			localStats.ScoreBatches += stats.ScoreBatches
 			localStats.OrdinalsGrouped += stats.OrdinalsGrouped
+			localStats.ScoreBatchCalls += stats.ScoreBatchCalls
+			localStats.ScoreBatchCandidates += stats.ScoreBatchCandidates
+			if stats.ScoreBatchMaxTileSize > localStats.ScoreBatchMaxTileSize {
+				localStats.ScoreBatchMaxTileSize = stats.ScoreBatchMaxTileSize
+			}
+			localStats.ScoreBatchOptimizedCalls += stats.ScoreBatchOptimizedCalls
+			localStats.ScoreBatchScalarFallbackCalls += stats.ScoreBatchScalarFallbackCalls
 			localStats.BlockViewHits += stats.BlockViewHits
 			localStats.BlockViewMisses += stats.BlockViewMisses
 			localStats.BlockViewBuilds += stats.BlockViewBuilds
@@ -1154,6 +1192,16 @@ func benchmarkColumnVectorGraphNativeSearchCosineParallelV3(b *testing.B, shape 
 		totalResultFetches.Add(localStats.ResultFetches)
 		totalScoreBatches.Add(localStats.ScoreBatches)
 		totalOrdinalsGrouped.Add(localStats.OrdinalsGrouped)
+		totalScoreBatchCalls.Add(localStats.ScoreBatchCalls)
+		totalScoreBatchCandidates.Add(localStats.ScoreBatchCandidates)
+		for {
+			current := totalScoreBatchMaxTileSize.Load()
+			if localStats.ScoreBatchMaxTileSize <= current || totalScoreBatchMaxTileSize.CompareAndSwap(current, localStats.ScoreBatchMaxTileSize) {
+				break
+			}
+		}
+		totalScoreBatchOptimizedCalls.Add(localStats.ScoreBatchOptimizedCalls)
+		totalScoreBatchScalarFallbackCalls.Add(localStats.ScoreBatchScalarFallbackCalls)
 		totalBlockViewHits.Add(localStats.BlockViewHits)
 		totalBlockViewMisses.Add(localStats.BlockViewMisses)
 		totalBlockViewBuilds.Add(localStats.BlockViewBuilds)
@@ -1229,6 +1277,11 @@ func benchmarkColumnVectorGraphNativeSearchCosineParallelV3(b *testing.B, shape 
 		ResultFetches:                        totalResultFetches.Load(),
 		ScoreBatches:                         totalScoreBatches.Load(),
 		OrdinalsGrouped:                      totalOrdinalsGrouped.Load(),
+		ScoreBatchCalls:                      totalScoreBatchCalls.Load(),
+		ScoreBatchCandidates:                 totalScoreBatchCandidates.Load(),
+		ScoreBatchMaxTileSize:                totalScoreBatchMaxTileSize.Load(),
+		ScoreBatchOptimizedCalls:             totalScoreBatchOptimizedCalls.Load(),
+		ScoreBatchScalarFallbackCalls:        totalScoreBatchScalarFallbackCalls.Load(),
 		BlockViewHits:                        totalBlockViewHits.Load(),
 		BlockViewMisses:                      totalBlockViewMisses.Load(),
 		BlockViewBuilds:                      totalBlockViewBuilds.Load(),
@@ -1290,6 +1343,13 @@ func reportColumnGraphNativeSearchBenchShapeMetricsV3(b *testing.B, shape column
 	b.ReportMetric(float64(shape.efSearch), "ef_search")
 	if shape.typedColumnVector {
 		b.ReportMetric(1, "typed_column_vector")
+	}
+	if shape.scoreBatchMode != columnVectorGraphScoreBatchModeDefault {
+		if shape.scoreBatchMode.indexedEnabled() {
+			b.ReportMetric(1, "score_batch_mode_indexed")
+		} else {
+			b.ReportMetric(1, "score_batch_mode_scalar")
+		}
 	}
 }
 
@@ -1522,6 +1582,14 @@ func reportColumnGraphNativeSearchBenchMetricsV3(b *testing.B, n int, baseStats,
 	b.ReportMetric(float64(searchStats.CandidateFetches)/float64(n), "candidate_fetches/search")
 	b.ReportMetric(float64(searchStats.ScoreBatches)/float64(n), "score_batches/search")
 	b.ReportMetric(float64(searchStats.OrdinalsGrouped)/float64(n), "ordinals_grouped/search")
+	b.ReportMetric(float64(searchStats.ScoreBatchCalls)/float64(n), "score_batch_calls/search")
+	b.ReportMetric(float64(searchStats.ScoreBatchCandidates)/float64(n), "score_batch_candidates/search")
+	b.ReportMetric(float64(searchStats.ScoreBatchMaxTileSize), "score_batch_max_tile_size")
+	b.ReportMetric(float64(searchStats.ScoreBatchOptimizedCalls)/float64(n), "score_batch_optimized/search")
+	b.ReportMetric(float64(searchStats.ScoreBatchScalarFallbackCalls)/float64(n), "score_batch_fallback/search")
+	if searchStats.ScoreBatchCalls > 0 {
+		b.ReportMetric(float64(searchStats.ScoreBatchCandidates)/float64(searchStats.ScoreBatchCalls), "score_batch_avg_tile_size")
+	}
 	b.ReportMetric(float64(searchStats.BlockViewHits)/float64(n), "block_view_hits/search")
 	b.ReportMetric(float64(searchStats.BlockViewMisses)/float64(n), "block_view_misses/search")
 	b.ReportMetric(float64(searchStats.BlockViewBuilds)/float64(n), "block_view_builds/search")

--- a/TreeDB/collections/vector_index.go
+++ b/TreeDB/collections/vector_index.go
@@ -175,6 +175,8 @@ type VectorIndexSearchOptions struct {
 	DocumentFetchOptions DocumentFetchOptions
 	// MaxDecodedBlocks bounds the physical column row reader cache for column_graph search.
 	MaxDecodedBlocks int
+	// scoreBatchMode is an internal exact-order indexed-scoring test/benchmark hook.
+	scoreBatchMode columnVectorGraphScoreBatchMode
 }
 
 // VectorIndexTrace reports how one vector-index search was executed.

--- a/TreeDB/collections/vector_index_search.go
+++ b/TreeDB/collections/vector_index_search.go
@@ -49,6 +49,9 @@ type VectorIndexSearcherSearchOptions struct {
 	// DocumentFetchOptions controls optional projected final-fetch materialization.
 	// It is used only when IncludeDocuments is true; the zero value returns full documents.
 	DocumentFetchOptions DocumentFetchOptions
+	// scoreBatchMode is an internal test/benchmark hook for exact-order indexed
+	// HNSW scoring. The public zero value follows the default scalar gate.
+	scoreBatchMode columnVectorGraphScoreBatchMode
 }
 
 // VectorIndexSearchResult is one public vector-index search hit.
@@ -87,6 +90,16 @@ type VectorIndexSearchStats struct {
 	AdjacencyBytesRead uint64 `json:"adjacency_bytes_read,omitempty"`
 	// CandidateFetches is the per-search count of vector row fetches for scored candidates.
 	CandidateFetches uint64 `json:"candidate_fetches,omitempty"`
+	// ScoreBatchCalls counts logical score calls: singleton scalar calls and indexed tile calls.
+	ScoreBatchCalls uint64 `json:"score_batch_calls,omitempty"`
+	// ScoreBatchCandidates counts candidate scores produced by score calls.
+	ScoreBatchCandidates uint64 `json:"score_batch_candidates,omitempty"`
+	// ScoreBatchMaxTileSize reports the largest score tile size observed by this search.
+	ScoreBatchMaxTileSize uint64 `json:"score_batch_max_tile_size,omitempty"`
+	// ScoreBatchOptimizedCalls counts score calls reported as optimized by the vectorops backend.
+	ScoreBatchOptimizedCalls uint64 `json:"score_batch_optimized,omitempty"`
+	// ScoreBatchScalarFallbackCalls counts score calls completed through scalar/fallback execution.
+	ScoreBatchScalarFallbackCalls uint64 `json:"score_batch_fallback,omitempty"`
 	// ExpansionFetches is the per-search count of adjacency row fetches for expanded nodes.
 	ExpansionFetches uint64 `json:"expansion_fetches,omitempty"`
 	// ResultFetches is the per-search count of vector row fetches for final results.
@@ -386,6 +399,7 @@ func (c *Collection) SearchVectorIndex(opts VectorIndexSearchOptions) (VectorInd
 		EfSearch:             opts.EfSearch,
 		IncludeDocuments:     opts.IncludeDocuments,
 		DocumentFetchOptions: opts.DocumentFetchOptions,
+		scoreBatchMode:       opts.scoreBatchMode,
 	})
 	documentView := searcher.documentView
 	if closeErr := searcher.Close(); err == nil && closeErr != nil {
@@ -554,8 +568,9 @@ func (s *VectorIndexSearcher) Search(opts VectorIndexSearcherSearchOptions) (Vec
 	}
 	readerStatsBefore := s.readerLast
 	results, searchStats, err := s.reader.SearchCosine(opts.Query, columnVectorGraphNativeSearchOptions{
-		TopK:     opts.TopK,
-		EfSearch: opts.EfSearch,
+		TopK:           opts.TopK,
+		EfSearch:       opts.EfSearch,
+		ScoreBatchMode: opts.scoreBatchMode,
 	}, &s.scratch)
 	readerStatsAfter := s.reader.Stats()
 	s.readerLast = readerStatsAfter
@@ -698,8 +713,9 @@ func (s *VectorIndexSearcher) SearchWithBuffer(opts VectorIndexSearcherSearchOpt
 	}
 	readerStatsBefore := s.readerLast
 	results, searchStats, err := s.reader.SearchCosine(opts.Query, columnVectorGraphNativeSearchOptions{
-		TopK:     opts.TopK,
-		EfSearch: opts.EfSearch,
+		TopK:           opts.TopK,
+		EfSearch:       opts.EfSearch,
+		ScoreBatchMode: opts.scoreBatchMode,
 	}, &s.scratch)
 	readerStatsAfter := s.reader.Stats()
 	s.readerLast = readerStatsAfter
@@ -872,6 +888,11 @@ func vectorIndexSearchStatsFromInternal(searchStats columnVectorGraphNativeSearc
 		NormBytesRead:                        searchStats.NormBytesRead,
 		AdjacencyBytesRead:                   searchStats.AdjacencyBytesRead,
 		CandidateFetches:                     searchStats.CandidateFetches,
+		ScoreBatchCalls:                      searchStats.ScoreBatchCalls,
+		ScoreBatchCandidates:                 searchStats.ScoreBatchCandidates,
+		ScoreBatchMaxTileSize:                searchStats.ScoreBatchMaxTileSize,
+		ScoreBatchOptimizedCalls:             searchStats.ScoreBatchOptimizedCalls,
+		ScoreBatchScalarFallbackCalls:        searchStats.ScoreBatchScalarFallbackCalls,
 		ExpansionFetches:                     searchStats.ExpansionFetches,
 		ResultFetches:                        searchStats.ResultFetches,
 		RowFetches:                           readerStats.RowFetches,

--- a/TreeDB/collections/vector_index_search_indexed_scoring_bench_test.go
+++ b/TreeDB/collections/vector_index_search_indexed_scoring_bench_test.go
@@ -1,0 +1,71 @@
+package collections
+
+import "testing"
+
+func BenchmarkVectorSearchReusableBufferSerialTypedColumnIndexedScoring1969(b *testing.B) {
+	for _, tc := range []struct {
+		name string
+		mode columnVectorGraphScoreBatchMode
+	}{
+		{name: "scalar", mode: columnVectorGraphScoreBatchModeScalar},
+		{name: "indexed", mode: columnVectorGraphScoreBatchModeIndexed},
+	} {
+		tc := tc
+		b.Run(tc.name, func(b *testing.B) {
+			benchmarkVectorSearchReusableBufferSerialTypedColumnIndexedScoring1969(b, tc.mode)
+		})
+	}
+}
+
+func benchmarkVectorSearchReusableBufferSerialTypedColumnIndexedScoring1969(b *testing.B, mode columnVectorGraphScoreBatchMode) {
+	const (
+		rows     = 1024
+		dims     = 128
+		m        = 16
+		topK     = 10
+		efSearch = 128
+	)
+	input := columnGraphRebuildSyntheticRowsV2A(rows, dims)
+	_, d, col, def := openColumnGraphTypedColumnVectorTestCollection1782(b, dims, m, input)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		b.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	searcher, err := col.OpenVectorIndexSearcher(VectorIndexSearcherOptions{IndexName: def.Name, MaxDecodedBlocks: 1})
+	if err != nil {
+		b.Fatalf("OpenVectorIndexSearcher: %v", err)
+	}
+	defer func() { _ = searcher.Close() }()
+	query := append([]float32(nil), input[37].vector...)
+	opts := VectorIndexSearcherSearchOptions{Query: query, TopK: topK, EfSearch: efSearch, scoreBatchMode: mode}
+	var buffer VectorIndexSearchBuffer
+	if _, err := searcher.SearchWithBuffer(opts, &buffer); err != nil {
+		b.Fatalf("warm SearchWithBuffer: %v", err)
+	}
+	measuredStats, err := searcher.SearchWithBuffer(opts, &buffer)
+	if err != nil {
+		b.Fatalf("measure SearchWithBuffer stats: %v", err)
+	}
+	stats := measuredStats.Stats
+	if stats.TypedColumnFallbacks != 0 || stats.VectorMmapDirectViews+stats.VectorHeapCopyTypedViews+stats.VectorScratchDecodes == 0 {
+		b.Fatalf("typed-column indexed-scoring benchmark stats=%+v want active typed-column vector source counters", stats)
+	}
+	if mode != columnVectorGraphScoreBatchModeDefault {
+		if mode.indexedEnabled() {
+			b.ReportMetric(1, "score_batch_mode_indexed")
+		} else {
+			b.ReportMetric(1, "score_batch_mode_scalar")
+		}
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		got, err := searcher.SearchWithBuffer(opts, &buffer)
+		if err != nil {
+			b.Fatalf("SearchWithBuffer: %v", err)
+		}
+		vectorSearchBenchSinkOrdinalV4 += got.Results[0].Ordinal
+	}
+	b.StopTimer()
+	reportVectorIndexSearchBenchMetricsV4(b, b.N, stats, false)
+}

--- a/TreeDB/collections/vector_index_search_test.go
+++ b/TreeDB/collections/vector_index_search_test.go
@@ -2041,6 +2041,14 @@ func reportVectorIndexSearchBenchMetricsV4(b *testing.B, n int, stats VectorInde
 		b.ReportMetric(float64(stats.Edges)/float64(stats.Candidates), "edges/node")
 	}
 	b.ReportMetric(float64(stats.CandidateFetches), "candidate_fetches/search")
+	b.ReportMetric(float64(stats.ScoreBatchCalls), "score_batch_calls/search")
+	b.ReportMetric(float64(stats.ScoreBatchCandidates), "score_batch_candidates/search")
+	b.ReportMetric(float64(stats.ScoreBatchMaxTileSize), "score_batch_max_tile_size")
+	b.ReportMetric(float64(stats.ScoreBatchOptimizedCalls), "score_batch_optimized/search")
+	b.ReportMetric(float64(stats.ScoreBatchScalarFallbackCalls), "score_batch_fallback/search")
+	if stats.ScoreBatchCalls > 0 {
+		b.ReportMetric(float64(stats.ScoreBatchCandidates)/float64(stats.ScoreBatchCalls), "score_batch_avg_tile_size")
+	}
 	b.ReportMetric(float64(stats.ExpansionFetches), "expansion_fetches/search")
 	b.ReportMetric(float64(stats.ResultFetches), "result_fetches/search")
 	b.ReportMetric(float64(stats.VectorDirectViews), "vector_direct_views/search")


### PR DESCRIPTION
## Summary
- integrate exact-order indexed tile scoring into TreeDB HNSW search using the prebound typed-vector/inv-norm source seam
- preserve scalar traversal/application/tie semantics by applying candidate scores in original adjacency order
- add indexed/scalar parity + tie-order + unsupported-fallback + parallel scratch safety tests
- add score batch counters (`score_batch_calls/candidates/max_tile/optimized/fallback`) and surface them in native/public benchmark reporting
- keep indexed scoring **gated off by default** (`columnVectorGraphIndexedScoringDefaultEnabled = false`)

## Why default remains off
Post-sync integrated benchmark matrix shows indexed mode regresses on current backend (vectorops indexed path reports fallback/per-row execution):
- native benchmark: indexed vs scalar **+3.80% slower**
- reusable public benchmark: indexed vs scalar **+3.98% slower**
- both paths remain 0 B/op, 0 allocs/op

Evidence:
- `artifacts/1969/bench_indexed_scalar_matrix_20260530_114826.txt`
- `artifacts/1969/bench_indexed_scalar_matrix_20260530_114826.summary.txt`

## Validation
- `go test ./TreeDB/collections -run 'TestColumnVectorGraph|TestVectorIndex|TestColumnGraph' -count=1`
  - log: `artifacts/1969/test_focused_20260530_114826.log`
- `go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnVectorGraphNativeSearchCosineIndexedScoring1969|BenchmarkVectorSearchReusableBufferSerialTypedColumnIndexedScoring1969' -benchmem -count=6`
  - log: `artifacts/1969/bench_indexed_scalar_matrix_20260530_114826.txt`
- `go test ./TreeDB/collections -count=1`
  - logs: `artifacts/1969/test_full_collections_20260530_1201.log`, `artifacts/1969/test_full_collections_20260530_1203.log`

Fixes #1969


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable batch scoring mode for vector search operations
  * Extended vector search telemetry with new performance metrics (batch call counts, tile sizes, optimization statistics)

* **Performance Improvements**
  * Optimized vector scoring with batch processing for improved search efficiency
  * Automatic fallback to scalar scoring for unsupported configurations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/snissn/gomap/pull/2019?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->