### PR TITLE
Retire graph row payload from healthy search

### DIFF
--- a/TreeDB/collections/column_manifest_format.go
+++ b/TreeDB/collections/column_manifest_format.go
@@ -292,6 +292,9 @@ func validateRetainedColumnManifestVectorGraphRecordForWrite(record columnManife
 	if graph.IndexName != keyIndexName {
 		return false, fmt.Errorf("collections: column vector graph manifest key index=%q does not match record index=%q", keyIndexName, graph.IndexName)
 	}
+	if !columnVectorGraphManifestHasPhysicalAsset(graph) {
+		return graph.BaseManifestGeneration < generation, nil
+	}
 	if graph.AssetRef.Kind != ColumnAssetKindTCS1PartImage {
 		return false, fmt.Errorf("collections: column vector graph asset kind=%q want %q", graph.AssetRef.Kind, ColumnAssetKindTCS1PartImage)
 	}

--- a/TreeDB/collections/column_vector_graph_adjacency_direct_source_test.go
+++ b/TreeDB/collections/column_vector_graph_adjacency_direct_source_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"runtime"
+	"strings"
 	"testing"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
@@ -54,18 +55,12 @@ func TestColumnVectorGraphLayer0AdjacencySourceSearchParity1919(t *testing.T) {
 	defer func() { _ = fallbackReader.Close() }()
 	disableColumnVectorGraphAdjacencyDirectSourcesForTest(t, fallbackReader)
 	var fallbackScratch columnVectorGraphNativeSearchScratch
-	fallbackResults, fallbackStats, err := fallbackReader.SearchCosine(query, columnVectorGraphNativeSearchOptions{TopK: 10, EfSearch: 64}, &fallbackScratch)
-	if err != nil {
-		t.Fatalf("fallback SearchCosine: %v", err)
+	_, fallbackStats, err := fallbackReader.SearchCosine(query, columnVectorGraphNativeSearchOptions{TopK: 10, EfSearch: 64}, &fallbackScratch)
+	if err == nil || !strings.Contains(err.Error(), "adjacency graph-row fallback unavailable") {
+		t.Fatalf("fallback SearchCosine err=%v want fail-closed missing TVIS adjacency", err)
 	}
-	if mismatch := columnGraphNativeSearchResultsMismatchV3(directResults, fallbackResults); mismatch != "" {
-		t.Fatalf("direct/fallback mismatch: %s", mismatch)
-	}
-	if fallbackStats.AdjacencyMmapDirectViews != 0 || fallbackStats.AdjacencyHeapCopyTypedViews != 0 || fallbackStats.AdjacencySourceUnavailable != 1 {
-		t.Fatalf("fallback stats=%+v want row-asset fallback without adjacency direct views", fallbackStats)
-	}
-	if fallbackStats.AdjacencyScratchDecodes <= directStats.AdjacencyScratchDecodes {
-		t.Fatalf("direct stats=%+v fallback stats=%+v want direct source to reduce scratch decodes", directStats, fallbackStats)
+	if fallbackStats.AdjacencyLegacyFallbacks != 0 || fallbackStats.AdjacencyScratchDecodes != 0 {
+		t.Fatalf("fallback stats=%+v want no graph row adjacency reads after TVIS source disabled", fallbackStats)
 	}
 }
 
@@ -110,15 +105,12 @@ func TestColumnVectorGraphSearchUsesVectorIndexStateAdjacency1988(t *testing.T) 
 	defer func() { _ = fallbackReader.Close() }()
 	disableColumnVectorGraphAdjacencyDirectSourcesForTest(t, fallbackReader)
 	var fallbackScratch columnVectorGraphNativeSearchScratch
-	fallbackResults, fallbackStats, err := fallbackReader.SearchCosine(query, columnVectorGraphNativeSearchOptions{TopK: 10, EfSearch: 64}, &fallbackScratch)
-	if err != nil {
-		t.Fatalf("fallback SearchCosine: %v", err)
+	_, fallbackStats, err := fallbackReader.SearchCosine(query, columnVectorGraphNativeSearchOptions{TopK: 10, EfSearch: 64}, &fallbackScratch)
+	if err == nil || !strings.Contains(err.Error(), "adjacency graph-row fallback unavailable") {
+		t.Fatalf("fallback SearchCosine err=%v want fail-closed missing TVIS adjacency", err)
 	}
-	if mismatch := columnGraphNativeSearchResultsMismatchV3(directResults, fallbackResults); mismatch != "" {
-		t.Fatalf("direct/fallback mismatch: %s", mismatch)
-	}
-	if fallbackStats.AdjacencyTypedListMmapDirectViews+fallbackStats.AdjacencyTypedListHeapCopyTypedViews+fallbackStats.AdjacencyTypedListScratchDecodes != 0 || fallbackStats.AdjacencyLegacyFallbacks == 0 || fallbackStats.AdjacencyScratchDecodes == 0 {
-		t.Fatalf("fallback stats=%+v want explicit legacy row-image fallback after typed-state source disabled", fallbackStats)
+	if fallbackStats.AdjacencyTypedListMmapDirectViews+fallbackStats.AdjacencyTypedListHeapCopyTypedViews+fallbackStats.AdjacencyTypedListScratchDecodes != 0 || fallbackStats.AdjacencyLegacyFallbacks != 0 || fallbackStats.AdjacencyScratchDecodes != 0 {
+		t.Fatalf("fallback stats=%+v want no legacy graph row adjacency reads after typed-state source disabled", fallbackStats)
 	}
 }
 
@@ -256,11 +248,11 @@ func TestColumnVectorGraphLayer0AdjacencySourceStaleHandlesFallback1919(t *testi
 	releaseColumnVectorGraphAdjacencySourceHandlesForTest(t, reader)
 	var scratch columnVectorGraphNativeSearchScratch
 	got, stats, err := reader.SearchCosine(input[9].vector, columnVectorGraphNativeSearchOptions{TopK: 5, EfSearch: 32}, &scratch)
-	if err != nil {
-		t.Fatalf("SearchCosine with stale source handles: %v", err)
+	if err == nil || !strings.Contains(err.Error(), "adjacency graph-row fallback unavailable") {
+		t.Fatalf("SearchCosine stale handles err=%v want fail-closed missing graph fallback", err)
 	}
-	if len(got) == 0 || stats.AdjacencyStaleHandles == 0 || stats.AdjacencySourceFallbacks == 0 || stats.AdjacencyTypedListMmapDirectViews != 0 || stats.AdjacencyLegacyFallbacks == 0 || stats.AdjacencyScratchDecodes == 0 {
-		t.Fatalf("results=%d stats=%+v want stale typed-state handles to use explicit row fallback", len(got), stats)
+	if len(got) != 0 || stats.AdjacencyStaleHandles == 0 || stats.AdjacencySourceFallbacks == 0 || stats.AdjacencyTypedListMmapDirectViews != 0 || stats.AdjacencyLegacyFallbacks != 0 || stats.AdjacencyScratchDecodes != 0 {
+		t.Fatalf("results=%d stats=%+v want stale typed-state handles to fail closed without graph row reads", len(got), stats)
 	}
 }
 
@@ -333,7 +325,9 @@ func TestColumnVectorGraphLayer0AdjacencySourceBadNeighborOrdinalFails1919(t *te
 	}
 	defer func() { _ = reader.Close() }()
 	disableColumnVectorGraphAdjacencyDirectSourcesForTest(t, reader)
-	reader.layer0AdjacencySource = fakeColumnVectorGraphLayer0AdjacencySource1919(t, reader.RowCount(), uint32(reader.RowCount()))
+	fake := fakeColumnVectorGraphLayer0AdjacencySource1919(t, reader.RowCount(), uint32(reader.RowCount()))
+	reader.layer0AdjacencySource = fake
+	reader.adjacencyLayerSources = &columnVectorGraphAdjacencyDirectSources{sources: []*columnVectorGraphLayer0AdjacencyDirectSource{fake}, allLayers: true}
 	var scratch columnVectorGraphNativeSearchScratch
 	_, _, err = reader.SearchCosine(input[0].vector, columnVectorGraphNativeSearchOptions{TopK: 1, EfSearch: 2}, &scratch)
 	if !errors.Is(err, errColumnVectorGraphAdjacencyOrdinalOutOfBounds) {

--- a/TreeDB/collections/column_vector_graph_block_view.go
+++ b/TreeDB/collections/column_vector_graph_block_view.go
@@ -55,7 +55,7 @@ func (s *columnVectorGraphNativeSearchScratch) prepareSearchPlan(reader *columnV
 		return nil, errNilColumnVectorGraphPhysicalRowReader
 	}
 	physicalReader, err := reader.rowReader()
-	if err != nil {
+	if err != nil && columnVectorGraphManifestHasPhysicalAsset(reader.graph) {
 		return nil, err
 	}
 	plan := &s.searchPlan
@@ -74,8 +74,13 @@ func (s *columnVectorGraphNativeSearchScratch) prepareSearchPlan(reader *columnV
 	plan.hits = 0
 	plan.misses = 0
 	plan.builds = 0
-	if err := plan.prepareOrdinalRefs(); err != nil {
-		return nil, err
+	if physicalReader != nil {
+		if err := plan.prepareOrdinalRefs(); err != nil {
+			return nil, err
+		}
+	} else {
+		plan.ordinalRefsReady = true
+		plan.singleOrdinalRange = true
 	}
 	if err := plan.scoreSource.prepare(plan); err != nil {
 		return nil, err
@@ -100,7 +105,7 @@ func newColumnVectorGraphSearchPlan(reader *columnVectorGraphPhysicalRowReader) 
 		return nil, errNilColumnVectorGraphPhysicalRowReader
 	}
 	physicalReader, err := reader.rowReader()
-	if err != nil {
+	if err != nil && columnVectorGraphManifestHasPhysicalAsset(reader.graph) {
 		return nil, err
 	}
 	return &columnVectorGraphSearchPlan{reader: reader, physicalReader: physicalReader}, nil

--- a/TreeDB/collections/column_vector_graph_block_view_test.go
+++ b/TreeDB/collections/column_vector_graph_block_view_test.go
@@ -203,29 +203,13 @@ func TestColumnVectorGraphBlockViewRejectsMalformedRowsV1(t *testing.T) {
 }
 
 func TestColumnVectorGraphBlockViewInvNormStateSourceAndLegacyFallbackV1(t *testing.T) {
-	rows := []columnGraphRebuildInputRowV2A{
-		{id: "doc-a", vector: []float32{3, 4, 0}},
-		{id: "doc-b", vector: []float32{0, 2, 0}},
+	rows := []columnVectorGraphAssetRow{
+		{ID: []byte("doc-a"), Vector: []float32{3, 4, 0}, InvNorm: 0.2, Adjacency: []uint32{1}},
+		{ID: []byte("doc-b"), Vector: []float32{0, 2, 0}, InvNorm: 0.5, Adjacency: []uint32{0}},
 	}
-	dir, d, col, def := openColumnGraphRebuildTestCollectionV2A(t, 3, 2, rows)
-	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
-		_ = d.Close()
-		t.Fatalf("RebuildVectorIndex: %v", err)
-	}
-	if err := d.Checkpoint(); err != nil {
-		_ = d.Close()
-		t.Fatalf("Checkpoint: %v", err)
-	}
-	if err := d.Close(); err != nil {
-		t.Fatalf("Close: %v", err)
-	}
-	reopened := openCollectionCommandWALDB(t, dir)
-	defer func() { _ = reopened.Close() }()
-	reopenedCol, err := NewCollectionManager(reopened).OpenCollection("docs")
-	if err != nil {
-		t.Fatalf("OpenCollection reopen: %v", err)
-	}
-	reader, err := reopenedCol.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
+	d, col, def := publishColumnVectorGraphPhysicalReaderTestAssetV2B(t, rows)
+	defer func() { _ = d.Close() }()
+	reader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
 	if err != nil {
 		t.Fatalf("openColumnVectorGraphPhysicalRowReader: %v", err)
 	}
@@ -242,7 +226,7 @@ func TestColumnVectorGraphBlockViewInvNormStateSourceAndLegacyFallbackV1(t *test
 	if err != nil {
 		t.Fatalf("blockViewForOrdinal: %v", err)
 	}
-	want, err := columnVectorGraphInvNorm(rows[targetOrdinal].vector)
+	want, err := columnVectorGraphInvNorm(rows[targetOrdinal].Vector)
 	if err != nil {
 		t.Fatalf("columnVectorGraphInvNorm: %v", err)
 	}

--- a/TreeDB/collections/column_vector_graph_document_id_state_test.go
+++ b/TreeDB/collections/column_vector_graph_document_id_state_test.go
@@ -3,6 +3,7 @@ package collections
 import (
 	"bytes"
 	"encoding/json"
+	"strings"
 	"testing"
 )
 
@@ -125,7 +126,7 @@ func assertSearchResultIDsMatchGraphRows2013(t *testing.T, results []VectorIndex
 	}
 }
 
-func TestColumnVectorGraphDocumentIDStateMissingAssetFallsBackAndCounts2013(t *testing.T) {
+func TestColumnVectorGraphDocumentIDStateMissingAssetFailsClosed2013(t *testing.T) {
 	rows := []columnGraphRebuildInputRowV2A{
 		{id: "doc-a", vector: []float32{1, 0, 0}},
 		{id: "doc-b", vector: []float32{0, 1, 0}},
@@ -145,18 +146,15 @@ func TestColumnVectorGraphDocumentIDStateMissingAssetFallsBackAndCounts2013(t *t
 	removeTypedColumnAssetPayload1755(t, d, col, asset.Ref)
 
 	got, err := col.SearchVectorIndex(VectorIndexSearchOptions{IndexName: def.Name, Query: []float32{1, 0, 0}, TopK: 2, EfSearch: 3})
-	if err != nil {
-		t.Fatalf("SearchVectorIndex: %v", err)
+	if err == nil || !strings.Contains(err.Error(), "missing required vector-index document-id state source") {
+		t.Fatalf("SearchVectorIndex err=%v response=%+v want fail-closed missing document-id state", err, got)
 	}
-	if len(got.Results) != 2 {
-		t.Fatalf("results=%d want 2", len(got.Results))
-	}
-	if got.Stats.ResultIDTypedBytesState != 0 || got.Stats.ResultIDGraphFallbacks != uint64(len(got.Results)) || got.Stats.ResultIDStateValidationFailures != 1 {
-		t.Fatalf("stats=%+v want missing document-id asset validation failure and graph fallback", got.Stats)
+	if got.Stats.ResultIDGraphFallbacks != 0 || got.Stats.ResultIDTypedBytesState != 0 {
+		t.Fatalf("stats=%+v want no graph row result-id fallback", got.Stats)
 	}
 }
 
-func TestColumnVectorGraphDocumentIDStateCorruptFallsBackAndCounts2013(t *testing.T) {
+func TestColumnVectorGraphDocumentIDStateCorruptFailsClosed2013(t *testing.T) {
 	rows := []columnGraphRebuildInputRowV2A{
 		{id: "doc-a", vector: []float32{1, 0, 0}},
 		{id: "doc-b", vector: []float32{0, 1, 0}},
@@ -176,14 +174,11 @@ func TestColumnVectorGraphDocumentIDStateCorruptFallsBackAndCounts2013(t *testin
 	corruptTypedColumnAssetPayload1755(t, d, asset.Ref)
 
 	got, err := col.SearchVectorIndex(VectorIndexSearchOptions{IndexName: def.Name, Query: []float32{1, 0, 0}, TopK: 2, EfSearch: 3})
-	if err != nil {
-		t.Fatalf("SearchVectorIndex: %v", err)
+	if err == nil || !strings.Contains(err.Error(), "missing required vector-index document-id state source") {
+		t.Fatalf("SearchVectorIndex err=%v response=%+v want fail-closed corrupt document-id state", err, got)
 	}
-	if len(got.Results) != 2 {
-		t.Fatalf("results=%d want 2", len(got.Results))
-	}
-	if got.Stats.ResultIDTypedBytesState != 0 || got.Stats.ResultIDGraphFallbacks != uint64(len(got.Results)) || got.Stats.ResultIDStateValidationFailures != 1 {
-		t.Fatalf("stats=%+v want corrupt document-id state validation failure and graph fallback", got.Stats)
+	if got.Stats.ResultIDGraphFallbacks != 0 || got.Stats.ResultIDTypedBytesState != 0 {
+		t.Fatalf("stats=%+v want no graph row result-id fallback", got.Stats)
 	}
 }
 

--- a/TreeDB/collections/column_vector_graph_inv_norm_state_test.go
+++ b/TreeDB/collections/column_vector_graph_inv_norm_state_test.go
@@ -102,28 +102,6 @@ func TestColumnGraphInvNormStateReopenSearchParityAndCounters1992(t *testing.T) 
 		t.Fatalf("state stats=%+v want healthy norm state without fallback", stateStats)
 	}
 
-	legacyReader, err := reopenedCol.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
-	if err != nil {
-		t.Fatalf("open legacy reader: %v", err)
-	}
-	defer func() { _ = legacyReader.Close() }()
-	if legacyReader.invNormSource != nil {
-		if err := legacyReader.invNormSource.Close(); err != nil {
-			t.Fatalf("close inv_norm source: %v", err)
-		}
-		legacyReader.invNormSource = nil
-	}
-	legacyReader.invNormStateUnavailable = true
-	var legacyScratch columnVectorGraphNativeSearchScratch
-	legacyResults, legacyStats, err := legacyReader.SearchCosine(query, columnVectorGraphNativeSearchOptions{TopK: 8, EfSearch: 24}, &legacyScratch)
-	if err != nil {
-		t.Fatalf("legacy SearchCosine: %v", err)
-	}
-	assertColumnGraphSearchResultsEqual1992(t, stateResults, legacyResults)
-	if legacyStats.NormSourceUnavailable != 1 || legacyStats.NormSourceFallbacks != 1 || legacyStats.NormMmapDirectViews+legacyStats.NormHeapCopyTypedViews+legacyStats.NormScratchDecodes != 0 {
-		t.Fatalf("legacy stats=%+v want explicit graph-row norm fallback/quarantine", legacyStats)
-	}
-
 	publicResponse, err := reopenedCol.SearchVectorIndex(VectorIndexSearchOptions{IndexName: def.Name, Query: query, TopK: 8, EfSearch: 24})
 	if err != nil {
 		t.Fatalf("SearchVectorIndex: %v", err)
@@ -287,7 +265,7 @@ func TestColumnGraphInvNormStateMissingFallbackAndCorruptFailClosed1992(t *testi
 		{id: "doc-b", vector: []float32{0, 1, 0}},
 		{id: "doc-c", vector: []float32{0, 0, 1}},
 	}
-	t.Run("missing_state_asset_falls_back_to_graph_rows", func(t *testing.T) {
+	t.Run("missing_state_asset_fails_closed_without_graph_rows", func(t *testing.T) {
 		_, d, col, def := openColumnGraphRebuildTestCollectionV2A(t, 3, 2, rows)
 		defer func() { _ = d.Close() }()
 		if _, err := col.RebuildVectorIndex(def.Name); err != nil {
@@ -306,12 +284,39 @@ func TestColumnGraphInvNormStateMissingFallbackAndCorruptFailClosed1992(t *testi
 		}
 		reader.invNormStateUnavailable = true
 		var scratch columnVectorGraphNativeSearchScratch
-		_, stats, err := reader.SearchCosine([]float32{1, 0, 0}, columnVectorGraphNativeSearchOptions{TopK: 2, EfSearch: 3}, &scratch)
-		if err != nil {
-			t.Fatalf("SearchCosine fallback: %v", err)
+		_, _, err = reader.SearchCosine([]float32{1, 0, 0}, columnVectorGraphNativeSearchOptions{TopK: 2, EfSearch: 3}, &scratch)
+		if err == nil || !strings.Contains(err.Error(), "inverse-norm state") {
+			t.Fatalf("SearchCosine err=%v want fail-closed missing inverse-norm state", err)
 		}
-		if stats.NormSourceUnavailable != 1 || stats.NormSourceFallbacks != 1 || stats.NormMmapDirectViews+stats.NormHeapCopyTypedViews+stats.NormScratchDecodes != 0 {
-			t.Fatalf("stats=%+v want missing norm state to use explicit graph-row fallback", stats)
+	})
+
+	t.Run("legacy_physical_asset_norm_fallback_counts", func(t *testing.T) {
+		legacyRows := []columnVectorGraphAssetRow{
+			{ID: []byte("doc-a"), Vector: []float32{1, 0, 0}, InvNorm: 1, Adjacency: []uint32{1, 2}},
+			{ID: []byte("doc-b"), Vector: []float32{0, 1, 0}, InvNorm: 1, Adjacency: []uint32{0, 2}},
+			{ID: []byte("doc-c"), Vector: []float32{0, 0, 1}, InvNorm: 1, Adjacency: []uint32{0, 1}},
+		}
+		d, col, def := publishColumnVectorGraphPhysicalReaderTestAssetV2B(t, legacyRows)
+		defer func() { _ = d.Close() }()
+		reader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
+		if err != nil {
+			t.Fatalf("open legacy reader: %v", err)
+		}
+		defer func() { _ = reader.Close() }()
+		if reader.invNormSource != nil {
+			if err := reader.invNormSource.Close(); err != nil {
+				t.Fatalf("close inv_norm source: %v", err)
+			}
+			reader.invNormSource = nil
+		}
+		reader.invNormStateUnavailable = true
+		var scratch columnVectorGraphNativeSearchScratch
+		got, stats, err := reader.SearchCosine([]float32{1, 0, 0}, columnVectorGraphNativeSearchOptions{TopK: 2, EfSearch: 3}, &scratch)
+		if err != nil {
+			t.Fatalf("legacy SearchCosine fallback: %v", err)
+		}
+		if len(got) == 0 || stats.NormSourceUnavailable != 1 || stats.NormSourceFallbacks != 1 || stats.NormMmapDirectViews+stats.NormHeapCopyTypedViews+stats.NormScratchDecodes != 0 {
+			t.Fatalf("results=%d stats=%+v want explicit legacy graph-row norm fallback", len(got), stats)
 		}
 	})
 

--- a/TreeDB/collections/column_vector_graph_manifest.go
+++ b/TreeDB/collections/column_vector_graph_manifest.go
@@ -101,6 +101,18 @@ type columnVectorGraphPreparedPhysicalAsset struct {
 	RowCount     int
 }
 
+func columnVectorGraphManifestHasPhysicalAsset(snapshot columnVectorGraphManifestSnapshot) bool {
+	return snapshot.AssetBytes != 0 ||
+		snapshot.AssetRef.Kind != "" ||
+		snapshot.AssetRef.Namespace != "" ||
+		snapshot.AssetRef.Generation != 0 ||
+		snapshot.AssetRef.PartID != 0 ||
+		snapshot.AssetRef.FileID != 0 ||
+		snapshot.AssetRef.Offset != 0 ||
+		snapshot.AssetRef.Length != 0 ||
+		snapshot.AssetRef.Checksum != 0
+}
+
 func columnVectorGraphManifestRecordKey(indexName string) []byte {
 	key := make([]byte, len(columnManifestVectorGraphRecordPrefix)+len(indexName))
 	copy(key, columnManifestVectorGraphRecordPrefix)
@@ -548,8 +560,14 @@ func validateColumnVectorGraphManifestSnapshotCore(snapshot columnVectorGraphMan
 	if snapshot.RowCount < 0 {
 		return errors.New("collections: column vector graph manifest row count must be non-negative")
 	}
+	if !columnVectorGraphManifestHasPhysicalAsset(snapshot) {
+		return nil
+	}
 	if err := validateColumnAssetRefForPlan(snapshot.AssetRef); err != nil {
 		return err
+	}
+	if snapshot.AssetRef.Kind != ColumnAssetKindTCS1PartImage {
+		return fmt.Errorf("collections: column vector graph manifest asset kind=%q want %q", snapshot.AssetRef.Kind, ColumnAssetKindTCS1PartImage)
 	}
 	if snapshot.AssetBytes <= 0 {
 		return errors.New("collections: column vector graph manifest asset bytes must be positive")
@@ -645,9 +663,10 @@ func columnVectorGraphPhysicalColumnStoreConfig(collection string, base ColumnSt
 	if base.AssetManager == nil {
 		return ColumnStoreConfig{}, errors.New("collections: column vector graph physical config requires base asset manager")
 	}
-	// The physical graph row asset keeps adjacency in the legacy adjacency_list
-	// row-image format for compatibility/fallback only. Primary HNSW adjacency
-	// storage is published separately as vector-index state uint32_list assets.
+	// Legacy physical graph row assets kept adjacency in the adjacency_list
+	// row-image format for compatibility/fallback only. Current rebuilds publish
+	// HNSW adjacency through vector-index state uint32_list assets and do not need
+	// this physical graph config for healthy search.
 	cfg, err := normalizeColumnStoreConfig(collection, &ColumnStoreConfig{
 		Enabled: true,
 		Columns: []ColumnStoreColumn{
@@ -926,11 +945,13 @@ func (c *Collection) columnGraphVectorIndexStatusAtSnapshot(name string, snap *b
 		status.RebuildNeeded = true
 		return status, nil
 	}
-	if err := validateColumnVectorGraphAssetRefAvailable(c.db.ColumnAssetRootDir(), graph.AssetRef); err != nil {
-		status.State = VectorIndexStateColumnGraphUnavailable
-		status.Reason = VectorIndexReasonColumnGraphCorrupt
-		status.RebuildNeeded = true
-		return columnGraphVectorIndexStatusError(status, err)
+	if columnVectorGraphManifestHasPhysicalAsset(graph) {
+		if err := validateColumnVectorGraphAssetRefAvailable(c.db.ColumnAssetRootDir(), graph.AssetRef); err != nil {
+			status.State = VectorIndexStateColumnGraphUnavailable
+			status.Reason = VectorIndexReasonColumnGraphCorrupt
+			status.RebuildNeeded = true
+			return columnGraphVectorIndexStatusError(status, err)
+		}
 	}
 	if loadedState == nil {
 		status.State = VectorIndexStateColumnGraphRebuildNeeded
@@ -938,10 +959,29 @@ func (c *Collection) columnGraphVectorIndexStatusAtSnapshot(name string, snap *b
 		status.RebuildNeeded = true
 		return status, nil
 	}
-	// Certified adjacency sources are optional accelerators. Keep loaded-status
-	// gating tied to the base graph asset; search opens and validates sources
-	// independently and falls back to row assets when they are absent, corrupt,
-	// stale, incomplete, or non-certified.
+	if !columnVectorGraphManifestHasPhysicalAsset(graph) && graph.RowCount > 0 {
+		if _, ok := findColumnVectorGraphInvNormStateAsset(*loadedState); !ok {
+			status.State = VectorIndexStateColumnGraphRebuildNeeded
+			status.Reason = VectorIndexReasonColumnGraphAssetMismatch
+			status.RebuildNeeded = true
+			return status, nil
+		}
+		if !columnVectorGraphRowRefStatePresent(*loadedState) || !columnVectorGraphDocumentIDStatePresent(*loadedState) {
+			status.State = VectorIndexStateColumnGraphRebuildNeeded
+			status.Reason = VectorIndexReasonColumnGraphAssetMismatch
+			status.RebuildNeeded = true
+			return status, nil
+		}
+		if _, _, typedVectorOwner, err := columnVectorGraphTypedColumnVectorField(*cfg, graph.Field, graph.Dimensions); err != nil || !typedVectorOwner {
+			status.State = VectorIndexStateColumnGraphRebuildNeeded
+			status.Reason = VectorIndexReasonColumnGraphAssetMismatch
+			status.RebuildNeeded = true
+			return status, nil
+		}
+	}
+	// Healthy loaded status is gated by TVIS/base typed-column state. A remaining
+	// graph row asset, when present, is compatibility storage and is not required
+	// for current-format search.
 	bytesDisk := columnVectorGraphStorageBytesWithState(graph, *loadedState)
 	status.State = VectorIndexStateColumnGraphLoaded
 	status.Loaded = true
@@ -1030,9 +1070,13 @@ func columnVectorGraphDefinitionParametersMatch(graph *columnVectorGraphManifest
 }
 
 func columnVectorGraphAssetParametersMatch(graph *columnVectorGraphManifestSnapshot, cfg *ColumnStoreConfig, graphCfg *ColumnStoreConfig) bool {
-	return graph.BaseSchemaHash == cfg.SchemaHash &&
-		graph.GraphSchemaHash == graphCfg.SchemaHash &&
-		graph.AssetRef.Kind == ColumnAssetKindTCS1PartImage &&
+	if graph.BaseSchemaHash != cfg.SchemaHash || graph.GraphSchemaHash != graphCfg.SchemaHash {
+		return false
+	}
+	if !columnVectorGraphManifestHasPhysicalAsset(*graph) {
+		return true
+	}
+	return graph.AssetRef.Kind == ColumnAssetKindTCS1PartImage &&
 		graph.AssetRef.Namespace == graphCfg.AssetManager.Namespace &&
 		graph.AssetRef.Generation == graph.BaseManifestGeneration
 }
@@ -1086,22 +1130,25 @@ func columnVectorGraphAssetRefsFromManifestRecordsForReachability(records []colu
 }
 
 func columnVectorGraphManifestAssetRefsForScan(graph columnVectorGraphManifestSnapshot, activeGeneration uint64, expectedNamespace string) ([]ColumnAssetRef, error) {
-	if graph.AssetRef.Generation > activeGeneration {
-		return nil, fmt.Errorf("collections: column vector graph asset generation=%d is newer than active manifest generation=%d", graph.AssetRef.Generation, activeGeneration)
+	refs := make([]ColumnAssetRef, 0, 1+len(graph.AdjacencyLayerSources))
+	if columnVectorGraphManifestHasPhysicalAsset(graph) {
+		if graph.AssetRef.Generation > activeGeneration {
+			return nil, fmt.Errorf("collections: column vector graph asset generation=%d is newer than active manifest generation=%d", graph.AssetRef.Generation, activeGeneration)
+		}
+		if graph.BaseManifestGeneration != graph.AssetRef.Generation {
+			return nil, fmt.Errorf("collections: column vector graph base manifest generation=%d does not match asset generation=%d", graph.BaseManifestGeneration, graph.AssetRef.Generation)
+		}
+		if graph.AssetRef.Kind != ColumnAssetKindTCS1PartImage {
+			return nil, fmt.Errorf("collections: column vector graph asset kind=%q want %q", graph.AssetRef.Kind, ColumnAssetKindTCS1PartImage)
+		}
+		if graph.AssetRef.Namespace != expectedNamespace {
+			return nil, fmt.Errorf("collections: column vector graph asset namespace=%q want %q", graph.AssetRef.Namespace, expectedNamespace)
+		}
+		if err := validateColumnAssetRefForPlan(graph.AssetRef); err != nil {
+			return nil, err
+		}
+		refs = append(refs, graph.AssetRef)
 	}
-	if graph.BaseManifestGeneration != graph.AssetRef.Generation {
-		return nil, fmt.Errorf("collections: column vector graph base manifest generation=%d does not match asset generation=%d", graph.BaseManifestGeneration, graph.AssetRef.Generation)
-	}
-	if graph.AssetRef.Kind != ColumnAssetKindTCS1PartImage {
-		return nil, fmt.Errorf("collections: column vector graph asset kind=%q want %q", graph.AssetRef.Kind, ColumnAssetKindTCS1PartImage)
-	}
-	if graph.AssetRef.Namespace != expectedNamespace {
-		return nil, fmt.Errorf("collections: column vector graph asset namespace=%q want %q", graph.AssetRef.Namespace, expectedNamespace)
-	}
-	if err := validateColumnAssetRefForPlan(graph.AssetRef); err != nil {
-		return nil, err
-	}
-	refs := []ColumnAssetRef{graph.AssetRef}
 	if len(graph.AdjacencyLayerSources) > 0 {
 		for _, source := range graph.AdjacencyLayerSources {
 			if columnVectorGraphAdjacencySourceRefEligibleForScan(graph, source, activeGeneration, expectedNamespace) {

--- a/TreeDB/collections/column_vector_graph_row_reader.go
+++ b/TreeDB/collections/column_vector_graph_row_reader.go
@@ -34,12 +34,13 @@ var (
 	errColumnVectorGraphPhysicalRowReaderBatchVisitorNil = errors.New("collections: column_graph physical row reader batch visitor is nil")
 )
 
-// columnVectorGraphPhysicalRowReader fetches graph rows from the persisted
-// column graph asset by ordinal. It is a graph-specific wrapper around the
-// generic physical row reader, not a decoded ColumnVectorGraph.
+// columnVectorGraphPhysicalRowReader binds column_graph search state by ordinal.
+// Current rebuilds use TVIS/base typed-column sources and may have no physical
+// graph row reader; legacy compatibility records still expose graph rows through
+// the generic physical row reader when a physical asset is present.
 //
 // The reader is not concurrency-safe. Parallel native search uses one reader
-// and one scratch per worker over immutable physical graph assets.
+// and one scratch per worker over immutable bound graph state.
 type columnVectorGraphPhysicalRowReader struct {
 	def                                 VectorIndexDefinition
 	graph                               columnVectorGraphManifestSnapshot
@@ -96,21 +97,24 @@ func (c *Collection) openColumnVectorGraphPhysicalRowReaderAtSnapshot(name strin
 		catalog = catalog.copy()
 		view.Catalog = catalog
 	}
-	reader, err := newColumnPhysicalRowReaderFromSnapshotView(view, columnPhysicalRowReaderOptions{
-		ProjectedColumns: []string{
-			columnVectorGraphVectorColumnName,
-			columnVectorGraphInvNormColumnName,
-			columnVectorGraphAdjacencyColumnName,
-		},
-		MaxDecodedBlocks:  opts.MaxDecodedBlocks,
-		RequireInsertOnly: true,
-	})
-	if err != nil {
-		return nil, err
-	}
-	if got, want := reader.RowCount(), graph.RowCount; got != want {
-		_ = reader.Close()
-		return nil, fmt.Errorf("collections: column_graph %q manifest row_count=%d physical_row_count=%d: %w", def.Name, want, got, errColumnVectorGraphManifestMismatch)
+	var reader *columnPhysicalRowReader
+	if columnVectorGraphManifestHasPhysicalAsset(graph) {
+		reader, err = newColumnPhysicalRowReaderFromSnapshotView(view, columnPhysicalRowReaderOptions{
+			ProjectedColumns: []string{
+				columnVectorGraphVectorColumnName,
+				columnVectorGraphInvNormColumnName,
+				columnVectorGraphAdjacencyColumnName,
+			},
+			MaxDecodedBlocks:  opts.MaxDecodedBlocks,
+			RequireInsertOnly: true,
+		})
+		if err != nil {
+			return nil, err
+		}
+		if got, want := reader.RowCount(), graph.RowCount; got != want {
+			_ = reader.Close()
+			return nil, fmt.Errorf("collections: column_graph %q manifest row_count=%d physical_row_count=%d: %w", def.Name, want, got, errColumnVectorGraphManifestMismatch)
+		}
 	}
 	graphReader := &columnVectorGraphPhysicalRowReader{
 		def:     def,
@@ -206,6 +210,27 @@ func (c *Collection) openColumnVectorGraphPhysicalRowReaderAtSnapshot(name strin
 			} else if fallbackReason != "" {
 				graphReader.typedVectorFallbackReason = fallbackReason
 			}
+		}
+	}
+	if !columnVectorGraphManifestHasPhysicalAsset(graph) && graph.RowCount > 0 {
+		if graphReader.invNormSource == nil {
+			_ = graphReader.Close()
+			return nil, fmt.Errorf("collections: column_graph %q missing required vector-index inverse-norm state source: %w", def.Name, errColumnVectorGraphManifestMismatch)
+		}
+		if graphReader.rowRefSource == nil {
+			_ = graphReader.Close()
+			return nil, fmt.Errorf("collections: column_graph %q missing required vector-index row-ref state source: %w", def.Name, errColumnVectorGraphManifestMismatch)
+		}
+		if graphReader.documentIDSource == nil {
+			_ = graphReader.Close()
+			return nil, fmt.Errorf("collections: column_graph %q missing required vector-index document-id state source: %w", def.Name, errColumnVectorGraphManifestMismatch)
+		}
+		if graphReader.typedVectorSource == nil {
+			_ = graphReader.Close()
+			if graphReader.typedVectorFallbackReason != "" {
+				return nil, fmt.Errorf("collections: column_graph %q missing required base typed-column vector source: %s: %w", def.Name, graphReader.typedVectorFallbackReason, errColumnVectorGraphManifestMismatch)
+			}
+			return nil, fmt.Errorf("collections: column_graph %q missing required base typed-column vector source: %w", def.Name, errColumnVectorGraphManifestMismatch)
 		}
 	}
 	return graphReader, nil
@@ -321,8 +346,10 @@ func (c *Collection) columnVectorGraphPhysicalRowReaderSnapshotViewAtSnapshot(na
 	if columnVectorGraphManifestMatchStatusWithBaseChecksum(catalog.meta.Name, graph, def, *cfg, baseChecksum) != columnVectorGraphManifestMatchLoaded {
 		return VectorIndexDefinition{}, columnVectorGraphManifestSnapshot{}, columnPhysicalScanSnapshotView{}, fmt.Errorf("collections: column_graph %q graph manifest does not match vector index definition: %w", def.Name, errColumnVectorGraphManifestMismatch)
 	}
-	if err := validateColumnVectorGraphAssetRefAvailable(c.db.ColumnAssetRootDir(), graph.AssetRef); err != nil {
-		return VectorIndexDefinition{}, columnVectorGraphManifestSnapshot{}, columnPhysicalScanSnapshotView{}, err
+	if columnVectorGraphManifestHasPhysicalAsset(graph) {
+		if err := validateColumnVectorGraphAssetRefAvailable(c.db.ColumnAssetRootDir(), graph.AssetRef); err != nil {
+			return VectorIndexDefinition{}, columnVectorGraphManifestSnapshot{}, columnPhysicalScanSnapshotView{}, err
+		}
 	}
 	graphCfg, err := columnVectorGraphPhysicalColumnStoreConfig(catalog.meta.Name, *cfg, def)
 	if err != nil {
@@ -335,6 +362,13 @@ func (c *Collection) columnVectorGraphPhysicalRowReaderSnapshotViewAtSnapshot(na
 	if state == nil {
 		return VectorIndexDefinition{}, columnVectorGraphManifestSnapshot{}, columnPhysicalScanSnapshotView{}, backenddb.ErrClosed
 	}
+	assetRefs := make([]columnManifestAssetRefForScan, 0, 1)
+	if columnVectorGraphManifestHasPhysicalAsset(graph) {
+		assetRefs = append(assetRefs, columnManifestAssetRefForScan{
+			Ref:    graph.AssetRef,
+			Reason: ColumnPublishOperationInsert,
+		})
+	}
 	view := columnPhysicalScanSnapshotView{
 		CollectionName:        catalog.meta.Name,
 		Catalog:               catalog,
@@ -343,17 +377,14 @@ func (c *Collection) columnVectorGraphPhysicalRowReaderSnapshotViewAtSnapshot(na
 		CommitSeq:             state.CommitSeq,
 		VectorIndexState:      vectorState,
 		VectorIndexStateFound: true,
-		AssetRefs: []columnManifestAssetRefForScan{{
-			Ref:    graph.AssetRef,
-			Reason: ColumnPublishOperationInsert,
-		}},
+		AssetRefs:             assetRefs,
 		Diagnostics: columnPhysicalScanDiagnostics{
 			ManifestRoot:               rootID,
 			ManifestGeneration:         cfg.ActiveManifest.Generation,
 			RecoveryManifestGeneration: cfg.RecoveryAuthoritativeManifest.Generation,
 			AppliedCommandLSN:          cfg.RecoveryAuthoritativeAppliedCommandLSN,
 			ManifestRecords:            len(records),
-			AssetRefs:                  1,
+			AssetRefs:                  len(assetRefs),
 		},
 		ColumnAssetRootDir: c.db.ColumnAssetRootDir(),
 		AssetNamespace:     graphCfg.AssetManager.Namespace,
@@ -411,10 +442,13 @@ func (r *columnVectorGraphPhysicalRowReader) Close() error {
 }
 
 func (r *columnVectorGraphPhysicalRowReader) RowCount() int {
-	if r == nil || r.reader == nil {
+	if r == nil {
 		return 0
 	}
-	return r.reader.RowCount()
+	if r.reader != nil {
+		return r.reader.RowCount()
+	}
+	return r.graph.RowCount
 }
 
 func (r *columnVectorGraphPhysicalRowReader) Stats() columnPhysicalRowReaderStats {

--- a/TreeDB/collections/column_vector_graph_row_reader_test.go
+++ b/TreeDB/collections/column_vector_graph_row_reader_test.go
@@ -11,31 +11,14 @@ import (
 )
 
 func TestColumnVectorGraphPhysicalRowReaderFetchesPublishedGraphRowsV2B(t *testing.T) {
-	rows := []columnGraphRebuildInputRowV2A{
-		{id: "doc-a", vector: []float32{1, 0, 0}},
-		{id: "doc-b", vector: []float32{0, 1, 0}},
-		{id: "doc-c", vector: []float32{0, 0, 1}},
+	rows := []columnVectorGraphAssetRow{
+		{ID: []byte("doc-a"), Vector: []float32{1, 0, 0}, InvNorm: 1, Adjacency: []uint32{1}},
+		{ID: []byte("doc-b"), Vector: []float32{0, 1, 0}, InvNorm: 1, Adjacency: []uint32{2, 0}},
+		{ID: []byte("doc-c"), Vector: []float32{0, 0, 1}, InvNorm: 1, Adjacency: []uint32{1}},
 	}
-	dir, d, col, def := openColumnGraphRebuildTestCollectionV2A(t, 3, 2, rows)
-	status, err := col.RebuildVectorIndex(def.Name)
-	if err != nil {
-		t.Fatalf("RebuildVectorIndex: %v", err)
-	}
-	assertColumnGraphRebuildLoadedStatusV2A(t, status, def.Name)
-	if err := d.Close(); err != nil {
-		t.Fatalf("close: %v", err)
-	}
-
-	reopened, err := backenddb.Open(backenddb.Options{Dir: dir})
-	if err != nil {
-		t.Fatalf("reopen db: %v", err)
-	}
-	defer func() { _ = reopened.Close() }()
-	reopenedCol, err := NewCollectionManager(reopened).OpenCollection("docs")
-	if err != nil {
-		t.Fatalf("OpenCollection: %v", err)
-	}
-	reader, err := reopenedCol.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
+	d, col, def := publishColumnVectorGraphPhysicalReaderTestAssetV2B(t, rows)
+	defer func() { _ = d.Close() }()
+	reader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
 	if err != nil {
 		t.Fatalf("openColumnVectorGraphPhysicalRowReader: %v", err)
 	}
@@ -43,7 +26,6 @@ func TestColumnVectorGraphPhysicalRowReaderFetchesPublishedGraphRowsV2B(t *testi
 	if got, want := reader.RowCount(), len(rows); got != want {
 		t.Fatalf("RowCount=%d want %d", got, want)
 	}
-	wantGraph := columnGraphRebuildNativeGraphLayoutV2A(t, def, rows)
 	scratch := columnPhysicalRowReaderScratch{
 		Values:        make([]columnDeclaredValue, 0, 3),
 		Float32Values: make([]float32, 0, def.Dimensions),
@@ -53,8 +35,7 @@ func TestColumnVectorGraphPhysicalRowReaderFetchesPublishedGraphRowsV2B(t *testi
 	if err != nil {
 		t.Fatalf("FetchRow(1): %v", err)
 	}
-	wantInput := columnGraphRebuildInputByIDV2B(t, rows, wantGraph.ids[1])
-	assertColumnVectorGraphPhysicalRowV2B(t, row, wantGraph.ids[1], 1, 1, wantInput.vector, 1, wantGraph.adjacency[1])
+	assertColumnVectorGraphPhysicalRowV2B(t, row, "doc-b", 1, 1, rows[1].Vector, 1, rows[1].Adjacency)
 
 	var batchIDs []string
 	if err := reader.FetchBatch([]int{2, 0}, &scratch, func(row columnVectorGraphPhysicalRow) error {
@@ -63,7 +44,7 @@ func TestColumnVectorGraphPhysicalRowReaderFetchesPublishedGraphRowsV2B(t *testi
 	}); err != nil {
 		t.Fatalf("FetchBatch: %v", err)
 	}
-	if got, want := strings.Join(batchIDs, ","), strings.Join([]string{wantGraph.ids[2], wantGraph.ids[0]}, ","); got != want {
+	if got, want := strings.Join(batchIDs, ","), strings.Join([]string{"doc-c", "doc-a"}, ","); got != want {
 		t.Fatalf("batch IDs=%q want %q", got, want)
 	}
 	stats := reader.Stats()
@@ -83,14 +64,25 @@ func columnGraphRebuildInputByIDV2B(tb testing.TB, rows []columnGraphRebuildInpu
 	return columnGraphRebuildInputRowV2A{}
 }
 
-func TestColumnVectorGraphPhysicalRowReaderOpensEmptyPublishedGraphV2B(t *testing.T) {
-	_, d, col, def := openColumnGraphRebuildTestCollectionV2A(t, 3, 2, nil)
-	defer func() { _ = d.Close() }()
-	status, err := col.RebuildVectorIndex(def.Name)
-	if err != nil {
-		t.Fatalf("RebuildVectorIndex empty collection: %v", err)
+func columnVectorGraphAssetRowsFromSyntheticV2B(rows []columnGraphRebuildInputRowV2A) []columnVectorGraphAssetRow {
+	out := make([]columnVectorGraphAssetRow, len(rows))
+	for i, row := range rows {
+		invNorm, err := columnVectorGraphInvNorm(row.vector)
+		if err != nil {
+			panic(err)
+		}
+		var adjacency []uint32
+		if len(rows) > 1 {
+			adjacency = []uint32{uint32((i + 1) % len(rows))}
+		}
+		out[i] = columnVectorGraphAssetRow{ID: []byte(row.id), Vector: append([]float32(nil), row.vector...), InvNorm: invNorm, Adjacency: adjacency}
 	}
-	assertColumnGraphRebuildLoadedStatusV2A(t, status, def.Name)
+	return out
+}
+
+func TestColumnVectorGraphPhysicalRowReaderOpensEmptyPublishedGraphV2B(t *testing.T) {
+	d, col, def := publishColumnVectorGraphPhysicalReaderTestAssetV2B(t, nil)
+	defer func() { _ = d.Close() }()
 
 	reader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
 	if err != nil {
@@ -394,18 +386,13 @@ func TestColumnVectorGraphPhysicalRowReaderRejectsNonRecoveryAuthoritativeManife
 }
 
 func TestColumnVectorGraphPhysicalRowReaderWarmScratchHotFetchZeroAllocsV2B(t *testing.T) {
-	rows := []columnGraphRebuildInputRowV2A{
-		{id: "doc-a", vector: []float32{1, 0, 0}},
-		{id: "doc-b", vector: []float32{0, 1, 0}},
-		{id: "doc-c", vector: []float32{0, 0, 1}},
+	rows := []columnVectorGraphAssetRow{
+		{ID: []byte("doc-a"), Vector: []float32{1, 0, 0}, InvNorm: 1, Adjacency: []uint32{1}},
+		{ID: []byte("doc-b"), Vector: []float32{0, 1, 0}, InvNorm: 1, Adjacency: []uint32{2, 0}},
+		{ID: []byte("doc-c"), Vector: []float32{0, 0, 1}, InvNorm: 1, Adjacency: []uint32{1}},
 	}
-	_, d, col, def := openColumnGraphRebuildTestCollectionV2A(t, 3, 2, rows)
+	d, col, def := publishColumnVectorGraphPhysicalReaderTestAssetV2B(t, rows)
 	defer func() { _ = d.Close() }()
-	status, err := col.RebuildVectorIndex(def.Name)
-	if err != nil {
-		t.Fatalf("RebuildVectorIndex: %v", err)
-	}
-	assertColumnGraphRebuildLoadedStatusV2A(t, status, def.Name)
 	reader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
 	if err != nil {
 		t.Fatalf("openColumnVectorGraphPhysicalRowReader: %v", err)
@@ -445,14 +432,9 @@ func BenchmarkColumnVectorGraphPhysicalRowReaderFetchV2B(b *testing.B) {
 		dims = 128
 		m    = 16
 	)
-	input := columnGraphRebuildSyntheticRowsV2A(rows, dims)
-	_, d, col, def := openColumnGraphRebuildTestCollectionV2A(b, dims, m, input)
+	input := columnVectorGraphAssetRowsFromSyntheticV2B(columnGraphRebuildSyntheticRowsV2A(rows, dims))
+	d, col, def := publishColumnVectorGraphPhysicalReaderTestAssetWithShapeV2B(b, dims, m, input)
 	defer func() { _ = d.Close() }()
-	status, err := col.RebuildVectorIndex(def.Name)
-	if err != nil {
-		b.Fatalf("RebuildVectorIndex: %v", err)
-	}
-	assertColumnGraphRebuildLoadedStatusV2A(b, status, def.Name)
 	reader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
 	if err != nil {
 		b.Fatalf("openColumnVectorGraphPhysicalRowReader: %v", err)

--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -424,12 +424,17 @@ func columnVectorGraphNativeScratchCapOversized(capacity, target int) bool {
 	return capacity > target*2+columnVectorGraphNativeScratchOversizeSlack
 }
 
-// SearchCosine traverses the persisted column graph through the physical row
-// reader. It fetches only graph rows: document materialization stays outside
-// this kernel. Returned results and result IDs alias scratch-owned buffers and
-// must be copied before the next SearchCosine call with the same scratch.
+// SearchCosine traverses the persisted column graph through bound TVIS/base
+// typed-column sources. Legacy graph rows are read only through explicit
+// compatibility fallback when a physical row asset is present. Document
+// materialization stays outside this kernel. Returned results and result IDs
+// alias scratch-owned buffers and must be copied before the next SearchCosine
+// call with the same scratch.
 func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts columnVectorGraphNativeSearchOptions, scratch *columnVectorGraphNativeSearchScratch) (results []columnVectorGraphNativeSearchResult, stats columnVectorGraphNativeSearchStats, err error) {
-	if r == nil || r.reader == nil {
+	if r == nil {
+		return nil, columnVectorGraphNativeSearchStats{}, errNilColumnVectorGraphPhysicalRowReader
+	}
+	if r.reader == nil && columnVectorGraphManifestHasPhysicalAsset(r.graph) {
 		return nil, columnVectorGraphNativeSearchStats{}, errNilColumnVectorGraphPhysicalRowReader
 	}
 	if len(query) != r.def.Dimensions {
@@ -502,7 +507,7 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 	}
 	plan.scoreBatchMode = opts.ScoreBatchMode
 	var singleBlockView *columnVectorGraphBlockView
-	if plan.physicalReader != nil && len(plan.physicalReader.ranges) == 1 {
+	if plan.physicalReader != nil && len(plan.physicalReader.ranges) == 1 && (plan.scoreSource.vectorKind == columnVectorGraphSearchVectorSourceGraphRows || plan.scoreSource.normKind == columnVectorGraphSearchNormSourceGraphRows) {
 		singleBlockView, err = plan.blockViewForAssetOrdinal(0)
 		if err != nil {
 			return nil, stats, err
@@ -776,6 +781,9 @@ func (r *columnVectorGraphPhysicalRowReader) fetchTopSearchResults(plan *columnV
 			if r.documentIDStateFallbackReason != "" {
 				resultIDStateValidationFailure = true
 			}
+			if plan == nil || plan.physicalReader == nil {
+				return fmt.Errorf("collections: column_graph %q result-id graph-row fallback unavailable for ordinal=%d", r.def.Name, ordinal)
+			}
 			view := singleBlockView
 			rowIndex := ordinal
 			if view == nil {
@@ -888,6 +896,9 @@ func (r *columnVectorGraphPhysicalRowReader) scoreOrdinal(plan *columnVectorGrap
 }
 
 func (r *columnVectorGraphPhysicalRowReader) scoreOrdinalLegacy(plan *columnVectorGraphSearchPlan, singleBlockView *columnVectorGraphBlockView, query []float32, queryInvNorm float32, ordinal int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) (float64, error) {
+	if plan == nil || plan.physicalReader == nil {
+		return 0, fmt.Errorf("collections: column_graph %q graph-row score fallback unavailable", r.def.Name)
+	}
 	view := singleBlockView
 	rowIndex := ordinal
 	if view == nil {
@@ -1153,6 +1164,9 @@ func (r *columnVectorGraphPhysicalRowReader) rawCandidateAdjacency(plan *columnV
 }
 
 func (r *columnVectorGraphPhysicalRowReader) rawCandidateAdjacencyWithDirectView(plan *columnVectorGraphSearchPlan, singleBlockView *columnVectorGraphBlockView, ordinal int, scratch *columnVectorGraphNativeSearchScratch) ([]uint32, bool, error) {
+	if plan == nil || plan.physicalReader == nil {
+		return nil, false, fmt.Errorf("collections: column_graph %q adjacency graph-row fallback unavailable", r.def.Name)
+	}
 	view := singleBlockView
 	rowIndex := ordinal
 	if view == nil {

--- a/TreeDB/collections/column_vector_graph_search_source.go
+++ b/TreeDB/collections/column_vector_graph_search_source.go
@@ -70,7 +70,7 @@ func (s *columnVectorGraphSearchSource) prepare(plan *columnVectorGraphSearchPla
 	}
 	reader := plan.reader
 	physicalReader := plan.physicalReader
-	if physicalReader == nil {
+	if physicalReader == nil && columnVectorGraphManifestHasPhysicalAsset(reader.graph) {
 		var err error
 		physicalReader, err = reader.rowReader()
 		if err != nil {
@@ -80,7 +80,7 @@ func (s *columnVectorGraphSearchSource) prepare(plan *columnVectorGraphSearchPla
 	}
 	s.reader = reader
 	s.dims = reader.def.Dimensions
-	s.rowCount = physicalReader.totalRows
+	s.rowCount = reader.RowCount()
 	s.vectorKind = columnVectorGraphSearchVectorSourceGraphRows
 	s.normKind = columnVectorGraphSearchNormSourceGraphRows
 
@@ -101,6 +101,14 @@ func (s *columnVectorGraphSearchSource) prepare(plan *columnVectorGraphSearchPla
 		s.invNormFallback = fallbackReason
 	} else if reader.invNormSource != nil {
 		s.normFallbackReason = reason
+	}
+	if physicalReader == nil && s.rowCount > 0 {
+		if s.vectorKind != columnVectorGraphSearchVectorSourceTypedColumn {
+			return fmt.Errorf("collections: column_graph %q search requires base typed-column vectors when graph row fallback is unavailable", reader.def.Name)
+		}
+		if s.normKind != columnVectorGraphSearchNormSourceInvNormByOrdinal {
+			return fmt.Errorf("collections: column_graph %q search requires vector-index inverse-norm state when graph row fallback is unavailable", reader.def.Name)
+		}
 	}
 	return nil
 }
@@ -156,15 +164,19 @@ func (s *columnVectorGraphSearchSource) scoreOrdinal(plan *columnVectorGraphSear
 		}
 		return plan.reader.scoreOrdinalLegacy(plan, singleBlockView, query, queryInvNorm, ordinal, scratch, stats)
 	}
-	view := singleBlockView
+	var view *columnVectorGraphBlockView
 	rowIndex := ordinal
-	if view == nil {
-		refView, ref, err := plan.blockViewForOrdinal(ordinal)
-		if err != nil {
-			return 0, err
+	needsGraphRow := s.vectorKind == columnVectorGraphSearchVectorSourceGraphRows || s.normKind == columnVectorGraphSearchNormSourceGraphRows
+	if needsGraphRow {
+		view = singleBlockView
+		if view == nil {
+			refView, ref, err := plan.blockViewForOrdinal(ordinal)
+			if err != nil {
+				return 0, err
+			}
+			view = refView
+			rowIndex = ref.rowIndex
 		}
-		view = refView
-		rowIndex = ref.rowIndex
 	}
 	if stats != nil {
 		recordColumnVectorGraphScoreBatchStats(stats, 1, false, true)
@@ -387,6 +399,9 @@ func (s *columnVectorGraphSearchSource) vectorForOrdinal(view *columnVectorGraph
 			stats.TypedColumnFallbacks = 1
 		}
 	}
+	if view == nil {
+		return nil, fmt.Errorf("collections: column_graph %q vector graph-row fallback unavailable for ordinal=%d", s.reader.def.Name, ordinal)
+	}
 	scratch.scoreScratch.Float32Values = scratch.scoreScratch.Float32Values[:0]
 	var vectorScratch []float32
 	vector, vectorScratch := view.vectorUnchecked(rowIndex, scratch.scoreScratch.Float32Values)
@@ -413,6 +428,9 @@ func (s *columnVectorGraphSearchSource) invNormForOrdinal(view *columnVectorGrap
 		if stats != nil {
 			stats.NormSourceFallbacks++
 		}
+	}
+	if view == nil {
+		return 0, fmt.Errorf("collections: column_graph %q inverse-norm graph-row fallback unavailable for ordinal=%d", s.reader.def.Name, ordinal)
 	}
 	return view.legacyInvNorm(rowIndex)
 }

--- a/TreeDB/collections/column_vector_graph_search_source_test.go
+++ b/TreeDB/collections/column_vector_graph_search_source_test.go
@@ -54,26 +54,13 @@ func TestColumnVectorGraphSearchSourceDisablesUnsupportedTypedVector1968(t *test
 	}
 	reader.typedVectorSource.dims = def.Dimensions + 1
 
-	plan, scratch, queryInvNorm := prepareColumnVectorGraphScoreSourceTestPlan1968(t, reader, rows[3].vector)
-	if plan.scoreSource.vectorKind != columnVectorGraphSearchVectorSourceGraphRows || plan.scoreSource.vectorFallbackReason != typeddecode.ReasonDimensionMismatch {
-		t.Fatalf("vector source kind=%s reason=%s want graph-row fallback from dimension mismatch", plan.scoreSource.vectorKind, plan.scoreSource.vectorFallbackReason)
+	scratch := &columnVectorGraphNativeSearchScratch{}
+	if err := scratch.prepare(reader.RowCount(), reader.def.Dimensions, reader.def.M, 8, 8); err != nil {
+		t.Fatalf("scratch prepare: %v", err)
 	}
-	var stats columnVectorGraphNativeSearchStats
-	got, err := plan.scoreSource.scoreOrdinal(plan, nil, rows[3].vector, queryInvNorm, 3, scratch, &stats)
-	if err != nil {
-		t.Fatalf("score source fallback: %v", err)
-	}
-	if stats.TypedColumnFallbacks != 1 || stats.VectorScratchDecodes != 1 || stats.VectorCertificationFailures == 0 {
-		t.Fatalf("stats=%+v want typed-column fallback, graph-row scratch decode, and certification failure", stats)
-	}
-	legacyReader := *reader
-	legacyReader.typedVectorSource = nil
-	legacy, err := legacyReader.scoreOrdinalLegacy(plan, nil, rows[3].vector, queryInvNorm, 3, scratch, nil)
-	if err != nil {
-		t.Fatalf("legacy graph-row score: %v", err)
-	}
-	if math.Abs(got-legacy) > 1e-6 {
-		t.Fatalf("fallback score=%g legacy=%g", got, legacy)
+	_, err = scratch.prepareSearchPlan(reader)
+	if err == nil || !strings.Contains(err.Error(), "search requires base typed-column vectors") {
+		t.Fatalf("prepareSearchPlan err=%v want fail-closed typed-column vector mismatch without graph row fallback", err)
 	}
 }
 
@@ -113,6 +100,7 @@ func TestColumnVectorGraphSearchSourceScoresMatchLegacyContiguousAndScattered196
 		t.Fatalf("source vector=%s norm=%s want typed vector and inv_norm state", plan.scoreSource.vectorKind, plan.scoreSource.normKind)
 	}
 
+	wantGraph := columnGraphRebuildNativeGraphLayoutV2A(t, def, rows)
 	for _, tc := range []struct {
 		name     string
 		ordinals []int
@@ -127,12 +115,17 @@ func TestColumnVectorGraphSearchSourceScoresMatchLegacyContiguousAndScattered196
 				if err != nil {
 					t.Fatalf("source ordinal %d: %v", ordinal, err)
 				}
-				legacyScore, err := reader.scoreOrdinalLegacy(plan, nil, query, queryInvNorm, ordinal, scratch, nil)
+				input := columnGraphRebuildInputByIDV2B(t, rows, wantGraph.ids[ordinal])
+				wantInvNorm, err := columnVectorGraphInvNorm(input.vector)
 				if err != nil {
-					t.Fatalf("legacy ordinal %d: %v", ordinal, err)
+					t.Fatalf("ordinal %d inv norm: %v", ordinal, err)
 				}
-				if math.Abs(sourceScore-legacyScore) > 1e-6 {
-					t.Fatalf("ordinal %d source=%g legacy=%g", ordinal, sourceScore, legacyScore)
+				wantScore, err := columnVectorGraphNativeCosineScoreVector(query, queryInvNorm, ordinal, input.vector, wantInvNorm)
+				if err != nil {
+					t.Fatalf("ordinal %d expected score: %v", ordinal, err)
+				}
+				if math.Abs(sourceScore-wantScore) > 1e-6 {
+					t.Fatalf("ordinal %d source=%g want=%g", ordinal, sourceScore, wantScore)
 				}
 				if sourceStats.VectorSourceCounters().MmapDirectViews+sourceStats.VectorSourceCounters().HeapCopyTypedViews+sourceStats.VectorSourceCounters().ScratchDecodes != 1 {
 					t.Fatalf("source stats=%+v want one vector source outcome", sourceStats)
@@ -166,9 +159,8 @@ func TestColumnVectorGraphSearchSourcePolicyMatchesLegacy1968(t *testing.T) {
 			t.Fatalf("query inv norm: %v", err)
 		}
 		_, sourceErr := plan.scoreSource.scoreOrdinal(plan, nil, query, queryInvNorm, 0, scratch, nil)
-		_, legacyErr := reader.scoreOrdinalLegacy(plan, nil, query, queryInvNorm, 0, scratch, nil)
-		if !errors.Is(sourceErr, errColumnVectorGraphNativeSearchCandidateDimensionMismatch) || !errors.Is(legacyErr, errColumnVectorGraphNativeSearchCandidateDimensionMismatch) {
-			t.Fatalf("sourceErr=%v legacyErr=%v want candidate dimension mismatch", sourceErr, legacyErr)
+		if !errors.Is(sourceErr, errColumnVectorGraphNativeSearchCandidateDimensionMismatch) {
+			t.Fatalf("sourceErr=%v want candidate dimension mismatch", sourceErr)
 		}
 	})
 
@@ -211,25 +203,8 @@ func TestColumnVectorGraphSearchSourcePolicyMatchesLegacy1968(t *testing.T) {
 		fallbackReader.invNormStateUnavailable = true
 		fallbackPlan := *plan
 		fallbackPlan.reader = &fallbackReader
-		if err := fallbackPlan.scoreSource.prepare(&fallbackPlan); err != nil {
-			t.Fatalf("prepare fallback source: %v", err)
-		}
-		query := rows[2].vector
-		queryInvNorm, err := columnVectorGraphInvNorm(query)
-		if err != nil {
-			t.Fatalf("query inv norm: %v", err)
-		}
-		var stats columnVectorGraphNativeSearchStats
-		sourceScore, err := fallbackPlan.scoreSource.scoreOrdinal(&fallbackPlan, nil, query, queryInvNorm, 2, scratch, &stats)
-		if err != nil {
-			t.Fatalf("source fallback score: %v", err)
-		}
-		legacyScore, err := fallbackReader.scoreOrdinalLegacy(&fallbackPlan, nil, query, queryInvNorm, 2, scratch, nil)
-		if err != nil {
-			t.Fatalf("legacy fallback score: %v", err)
-		}
-		if math.Abs(sourceScore-legacyScore) > 1e-6 || stats.NormMmapDirectViews+stats.NormHeapCopyTypedViews+stats.NormScratchDecodes != 0 {
-			t.Fatalf("source=%g legacy=%g stats=%+v want graph-row norm fallback parity", sourceScore, legacyScore, stats)
+		if err := fallbackPlan.scoreSource.prepare(&fallbackPlan); err == nil || !strings.Contains(err.Error(), "search requires vector-index inverse-norm state") {
+			t.Fatalf("prepare fallback source err=%v want fail-closed missing inverse-norm state", err)
 		}
 	})
 
@@ -247,19 +222,12 @@ func TestColumnVectorGraphSearchSourcePolicyMatchesLegacy1968(t *testing.T) {
 			t.Fatalf("close inv_norm source: %v", err)
 		}
 		var stats columnVectorGraphNativeSearchStats
-		sourceScore, err := stalePlan.scoreSource.scoreOrdinal(stalePlan, nil, rows[1].vector, queryInvNorm, 1, staleScratch, &stats)
-		if err != nil {
-			t.Fatalf("stale source score: %v", err)
+		_, err = stalePlan.scoreSource.scoreOrdinal(stalePlan, nil, rows[1].vector, queryInvNorm, 1, staleScratch, &stats)
+		if err == nil || !strings.Contains(err.Error(), "inverse-norm graph-row fallback unavailable") {
+			t.Fatalf("stale source score err=%v want fail-closed missing graph fallback", err)
 		}
-		legacyReader := *staleReader
-		legacyReader.invNormSource = nil
-		legacyReader.invNormStateUnavailable = true
-		legacyScore, err := legacyReader.scoreOrdinalLegacy(stalePlan, nil, rows[1].vector, queryInvNorm, 1, staleScratch, nil)
-		if err != nil {
-			t.Fatalf("stale legacy score: %v", err)
-		}
-		if math.Abs(sourceScore-legacyScore) > 1e-6 || stats.NormSourceFallbacks != 1 || stats.NormStaleHandles != 1 || stats.NormMmapDirectViews+stats.NormHeapCopyTypedViews+stats.NormScratchDecodes != 0 {
-			t.Fatalf("source=%g legacy=%g stats=%+v want stale norm fallback with counters", sourceScore, legacyScore, stats)
+		if stats.NormSourceFallbacks != 1 || stats.NormStaleHandles != 1 || stats.NormMmapDirectViews+stats.NormHeapCopyTypedViews+stats.NormScratchDecodes != 0 {
+			t.Fatalf("stats=%+v want stale norm fallback counters without graph row read", stats)
 		}
 	})
 }
@@ -421,8 +389,10 @@ func prepareColumnVectorGraphScoreSourceTestPlan1968(tb testing.TB, reader *colu
 	if err != nil {
 		tb.Fatalf("prepareSearchPlan: %v", err)
 	}
-	if _, err := plan.blockViewForAssetOrdinal(0); err != nil {
-		tb.Fatalf("warm block view: %v", err)
+	if plan.physicalReader != nil {
+		if _, err := plan.blockViewForAssetOrdinal(0); err != nil {
+			tb.Fatalf("warm block view: %v", err)
+		}
 	}
 	var stats columnVectorGraphNativeSearchStats
 	if _, err := plan.scoreSource.scoreOrdinal(plan, nil, query, queryInvNorm, 0, scratch, &stats); err != nil {

--- a/TreeDB/collections/column_vector_graph_typed_column.go
+++ b/TreeDB/collections/column_vector_graph_typed_column.go
@@ -110,7 +110,7 @@ func (c *Collection) newColumnVectorGraphTypedColumnVectorSource(catalog *collec
 	if graph.RowCount == 0 {
 		return &columnVectorGraphTypedColumnVectorSource{field: field, column: adapterColumn, dims: graph.Dimensions, manager: mappedresource.NewManager()}, nil
 	}
-	if reader == nil || reader.reader == nil {
+	if reader == nil {
 		return nil, errNilColumnVectorGraphPhysicalRowReader
 	}
 	if graph.BaseManifestGeneration != manifest.Generation || graph.BaseManifestGeneration != cfg.ActiveManifest.Generation || graph.BaseSchemaHash != cfg.SchemaHash {
@@ -146,7 +146,11 @@ func (c *Collection) newColumnVectorGraphTypedColumnVectorSource(catalog *collec
 	// manifest violates that shape.
 	usedGenerations := make(map[uint64]struct{})
 	locationSource := columnVectorGraphTypedColumnVectorLocationSourceUnknown
-	if rowRefs, ok := reader.rowRefSource.rowRefs(); ok {
+	if reader.rowRefSource != nil {
+		rowRefs, ok := reader.rowRefSource.rowRefs()
+		if !ok {
+			return nil, fmt.Errorf("collections: column_graph %q typed-column vector source row-ref state unavailable", graph.IndexName)
+		}
 		if len(rowRefs) != graph.RowCount {
 			return nil, fmt.Errorf("collections: column_graph %q typed-column vector source row refs=%d want row_count=%d", graph.IndexName, len(rowRefs), graph.RowCount)
 		}
@@ -168,6 +172,9 @@ func (c *Collection) newColumnVectorGraphTypedColumnVectorSource(catalog *collec
 		}
 		locationSource = columnVectorGraphTypedColumnVectorLocationSourceRowRefState
 	} else {
+		if reader.reader == nil {
+			return nil, errors.New("collections: column_graph typed-column vector source requires row-ref state when graph row fallback is unavailable")
+		}
 		graphIDs, err := columnVectorGraphDocumentIDsFromReader(reader)
 		if err != nil {
 			return nil, err

--- a/TreeDB/collections/column_vector_graph_typed_column_test.go
+++ b/TreeDB/collections/column_vector_graph_typed_column_test.go
@@ -48,21 +48,14 @@ func TestColumnVectorGraphTypedColumnVectorReaderParity1782(t *testing.T) {
 	if reader.typedVectorSource == nil || reader.typedVectorFallbackReason != "" {
 		t.Fatalf("typed vector source=%v fallback=%q want active typed_column_part source", reader.typedVectorSource != nil, reader.typedVectorFallbackReason)
 	}
-	if reader.graph.AssetRef.Kind != ColumnAssetKindTCS1PartImage {
-		t.Fatalf("graph asset kind=%q want derived physical graph asset kind %q", reader.graph.AssetRef.Kind, ColumnAssetKindTCS1PartImage)
+	if columnVectorGraphManifestHasPhysicalAsset(reader.graph) {
+		t.Fatalf("graph manifest has physical row asset %+v; healthy typed-column search should use TVIS/base state", reader.graph.AssetRef)
 	}
 	assertColumnGraphTypedColumnAdjacencyDeferred1782(t, col, def.Name)
 
 	var scratch columnPhysicalRowReaderScratch
-	for ordinal := 0; ordinal < reader.RowCount(); ordinal++ {
-		row, err := reader.FetchRow(ordinal, &scratch)
-		if err != nil {
-			t.Fatalf("FetchRow(%d): %v", ordinal, err)
-		}
-		input := columnGraphRebuildInputByIDV2B(t, rows, string(row.ID))
-		if !float32SlicesEqual1782(row.Vector, input.vector) {
-			t.Fatalf("row %d id=%q vector=%v want typed-column vector %v", ordinal, row.ID, row.Vector, input.vector)
-		}
+	if _, err := reader.FetchRow(0, &scratch); err == nil || !errors.Is(err, errNilColumnVectorGraphPhysicalRowReader) {
+		t.Fatalf("FetchRow healthy current-format err=%v want no physical graph row reader", err)
 	}
 
 	query := []float32{0, 0.2, 1}
@@ -231,23 +224,12 @@ func TestColumnVectorGraphTypedColumnVectorCorruptPartFallsBack1782(t *testing.T
 	corruptFirstTypedColumnPartForVectorTest1782(t, col)
 
 	reader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
-	if err != nil {
-		t.Fatalf("openColumnVectorGraphPhysicalRowReader with corrupt typed_column_part should fall back to graph asset: %v", err)
+	if err == nil {
+		_ = reader.Close()
+		t.Fatal("openColumnVectorGraphPhysicalRowReader with corrupt typed_column_part succeeded; want fail-closed without graph row fallback")
 	}
-	defer func() { _ = reader.Close() }()
-	if reader.typedVectorSource != nil || reader.typedVectorFallbackReason == "" {
-		t.Fatalf("typed source active=%v fallback=%q want fallback reason after corrupt typed_column_part", reader.typedVectorSource != nil, reader.typedVectorFallbackReason)
-	}
-
-	query := []float32{0, 0, 1}
-	var scratch columnVectorGraphNativeSearchScratch
-	got, stats, err := reader.SearchCosine(query, columnVectorGraphNativeSearchOptions{TopK: 2, EfSearch: len(rows)}, &scratch)
-	if err != nil {
-		t.Fatalf("SearchCosine fallback: %v", err)
-	}
-	assertColumnGraphNativeSearchResultsV3(t, got, exactColumnGraphTopKForTest(t, rows, query, 2))
-	if stats.TypedColumnFallbacks != 1 || stats.VectorMmapDirectViews != 0 || stats.VectorHeapCopyTypedViews != 0 || stats.VectorScratchDecodes == 0 {
-		t.Fatalf("stats=%+v want typed-column source fallback to graph row vector scratch decodes", stats)
+	if !strings.Contains(err.Error(), "missing required base typed-column vector source") {
+		t.Fatalf("openColumnVectorGraphPhysicalRowReader err=%v want fail-closed typed-column source error", err)
 	}
 }
 
@@ -270,22 +252,12 @@ func TestColumnVectorGraphTypedColumnVectorNonColumnPartOwnerUsesGraphVectors178
 		}
 	})
 	reader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
-	if err != nil {
-		t.Fatalf("openColumnVectorGraphPhysicalRowReader non-column-part owner: %v", err)
+	if err == nil {
+		_ = reader.Close()
+		t.Fatal("openColumnVectorGraphPhysicalRowReader non-column-part owner succeeded; want fail-closed without graph row fallback")
 	}
-	defer func() { _ = reader.Close() }()
-	if reader.typedVectorSource != nil || reader.typedVectorFallbackReason != "" {
-		t.Fatalf("typed source active=%v fallback=%q want ordinary graph-vector path for non-column-part owner", reader.typedVectorSource != nil, reader.typedVectorFallbackReason)
-	}
-	query := []float32{0, 0, 1}
-	var scratch columnVectorGraphNativeSearchScratch
-	got, stats, err := reader.SearchCosine(query, columnVectorGraphNativeSearchOptions{TopK: 2, EfSearch: len(rows)}, &scratch)
-	if err != nil {
-		t.Fatalf("SearchCosine non-column-part owner: %v", err)
-	}
-	assertColumnGraphNativeSearchResultsV3(t, got, exactColumnGraphTopKForTest(t, rows, query, 2))
-	if stats.TypedColumnFallbacks != 0 || stats.VectorMmapDirectViews != 0 || stats.VectorHeapCopyTypedViews != 0 || stats.VectorScratchDecodes == 0 || stats.VectorCertificationFailures != 0 {
-		t.Fatalf("stats=%+v want ordinary graph row vector scratch decodes", stats)
+	if !strings.Contains(err.Error(), "missing required base typed-column vector source") {
+		t.Fatalf("openColumnVectorGraphPhysicalRowReader err=%v want missing typed-column source", err)
 	}
 }
 
@@ -972,8 +944,8 @@ func assertColumnGraphTypedColumnAdjacencyDeferred1782(tb testing.TB, col *Colle
 	if err != nil {
 		tb.Fatalf("decode graph manifest: %v", err)
 	}
-	if graph.AssetRef.Kind != ColumnAssetKindTCS1PartImage {
-		tb.Fatalf("graph asset kind=%q want derived tcs1_part_image asset, not authoritative adjacency typed-column storage", graph.AssetRef.Kind)
+	if columnVectorGraphManifestHasPhysicalAsset(graph) {
+		tb.Fatalf("graph manifest has physical row asset %+v; adjacency must be TVIS state, not graph row storage", graph.AssetRef)
 	}
 	cfg := catalog.meta.Options.ColumnStore
 	if cfg == nil {

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -408,7 +408,7 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/vector_index_retained_payload_policy_1876_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 5, occurrences: 5},
 	{path: "TreeDB/collections/vector_index_search_test.go", classification: typedStorageLegacyDerived, matchingLines: 2, occurrences: 2},
 	{path: "TreeDB/collections/vector_index_rebuild.go", classification: typedStorageLegacyDerived, matchingLines: 16, occurrences: 18},
-	{path: "TreeDB/collections/vector_index_rebuild_test.go", classification: typedStorageLegacyDerived, matchingLines: 44, occurrences: 51},
+	{path: "TreeDB/collections/vector_index_rebuild_test.go", classification: typedStorageLegacyDerived, matchingLines: 46, occurrences: 54},
 	{path: "TreeDB/docs/guides/collections-quickstart.md", classification: typedStorageLegacyCompatibility, matchingLines: 18, occurrences: 22},
 	{path: "TreeDB/docs/guides/jsonbench-columnstore-clickhouse-experiment.md", classification: typedStorageLegacyCompatibility, matchingLines: 17, occurrences: 17},
 	{path: "TreeDB/docs/guides/README.md", classification: typedStorageLegacyCompatibility, matchingLines: 2, occurrences: 2},

--- a/TreeDB/collections/vector_index_rebuild.go
+++ b/TreeDB/collections/vector_index_rebuild.go
@@ -723,12 +723,20 @@ func prepareColumnVectorGraphRebuildManifest(collection string, cfg ColumnStoreC
 	if err != nil {
 		return columnVectorGraphPreparedPhysicalAsset{}, nil, ColumnManifestIdentity{}, err
 	}
-	partID := nextColumnVectorGraphPartID(recordsForLSN, graphCfg.AssetManager.Namespace)
-	prepared, err := prepareColumnVectorGraphPhysicalAsset(assetRootDir, collection, cfg, def, manifest.Generation, partID, appliedCommandLSN, rows)
-	if err != nil {
-		return columnVectorGraphPreparedPhysicalAsset{}, nil, ColumnManifestIdentity{}, err
+	if len(rows) > 0 {
+		if _, _, typedVectorOwner, ownerErr := columnVectorGraphTypedColumnVectorField(cfg, def.Field, def.Dimensions); ownerErr != nil {
+			return columnVectorGraphPreparedPhysicalAsset{}, nil, ColumnManifestIdentity{}, ownerErr
+		} else if !typedVectorOwner {
+			return columnVectorGraphPreparedPhysicalAsset{}, nil, ColumnManifestIdentity{}, fmt.Errorf("collections: column_graph rebuild for %q requires base float32_vector typed-column owner for field %q; rebuild collection metadata before rebuilding the vector index", def.Name, def.Field)
+		}
 	}
-	invNormPartID := columnVectorGraphNextPartIDAfterPreparedAssets(prepared)
+	partID := nextColumnVectorGraphPartID(recordsForLSN, graphCfg.AssetManager.Namespace)
+	prepared := columnVectorGraphPreparedPhysicalAsset{
+		AssetRootDir: assetRootDir,
+		Config:       graphCfg,
+		RowCount:     len(rows),
+	}
+	invNormPartID := partID
 	preparedInvNorm, err := prepareColumnVectorGraphInvNormStateAsset(assetRootDir, collection, cfg, def, manifest.Generation, invNormPartID, rows)
 	if err != nil {
 		return columnVectorGraphPreparedPhysicalAsset{}, nil, ColumnManifestIdentity{}, err
@@ -747,8 +755,6 @@ func prepareColumnVectorGraphRebuildManifest(collection string, cfg ColumnStoreC
 		BaseSchemaHash:         cfg.SchemaHash,
 		GraphSchemaHash:        graphCfg.SchemaHash,
 		RowCount:               prepared.RowCount,
-		AssetRef:               prepared.Ref,
-		AssetBytes:             prepared.Bytes,
 	}
 	statePartID := invNormPartID
 	if preparedInvNorm.Present {

--- a/TreeDB/collections/vector_index_rebuild_test.go
+++ b/TreeDB/collections/vector_index_rebuild_test.go
@@ -22,6 +22,9 @@ var columnGraphRebuildBenchSinkV2A VectorIndexStatus
 
 func assertColumnGraphNoLegacyAdjacencySources1989(tb testing.TB, graph columnVectorGraphManifestSnapshot) {
 	tb.Helper()
+	if columnVectorGraphManifestHasPhysicalAsset(graph) {
+		tb.Fatalf("graph manifest has physical row asset %+v; new graph builds must use TVIS/base typed-column state", graph.AssetRef)
+	}
 	if graph.Layer0AdjacencySource.Present || graph.AdjacencyLayerCount != 0 || len(graph.AdjacencyLayerSources) != 0 {
 		tb.Fatalf("graph manifest has legacy adjacency sources layer0=%+v count=%d sources=%d; new graph builds must use vector-index state uint32_list assets", graph.Layer0AdjacencySource, graph.AdjacencyLayerCount, len(graph.AdjacencyLayerSources))
 	}
@@ -790,8 +793,8 @@ func TestColumnGraphRebuildVectorIndexAdjacencyUsesFlattenedNativeGraphV2A(t *te
 		t.Fatalf("RebuildVectorIndex: %v", err)
 	}
 	graph, scanned := loadAndScanColumnGraphRebuildRowsV2A(t, d, "docs", def)
-	if graph.AssetRef.Namespace != col.Meta().Options.ColumnStore.AssetManager.Namespace {
-		t.Fatalf("graph namespace=%q want base namespace=%q", graph.AssetRef.Namespace, col.Meta().Options.ColumnStore.AssetManager.Namespace)
+	if columnVectorGraphManifestHasPhysicalAsset(graph) {
+		t.Fatalf("graph manifest has physical row asset %+v; current rebuild should use TVIS/base typed-column state", graph.AssetRef)
 	}
 	wantGraph := columnGraphRebuildNativeGraphLayoutV2A(t, def, rows)
 	for i := range rows {
@@ -816,6 +819,7 @@ func TestColumnGraphRebuildVectorIndexAllocatesPartIDsAcrossGraphIndexesV2A(t *t
 	cfg.Columns = append(cfg.Columns, ColumnStoreColumn{
 		Name:       "other_embedding",
 		Path:       "other_embedding",
+		Owner:      TypedStorageOwnerColumnPart,
 		ValueType:  ColumnStoreValueFloat32Vector,
 		VectorDims: 2,
 	})
@@ -858,11 +862,20 @@ func TestColumnGraphRebuildVectorIndexAllocatesPartIDsAcrossGraphIndexesV2A(t *t
 	}
 	graphA, _ := loadAndScanColumnGraphRebuildRowsV2A(t, d, "docs", defA)
 	graphB, _ := loadAndScanColumnGraphRebuildRowsV2A(t, d, "docs", defB)
-	if graphA.AssetRef.Namespace != graphB.AssetRef.Namespace {
-		t.Fatalf("graph namespaces differ %q vs %q, test requires shared namespace", graphA.AssetRef.Namespace, graphB.AssetRef.Namespace)
+	if columnVectorGraphManifestHasPhysicalAsset(graphA) || columnVectorGraphManifestHasPhysicalAsset(graphB) {
+		t.Fatalf("current graph rebuilds should not publish physical row assets: graphA=%+v graphB=%+v", graphA.AssetRef, graphB.AssetRef)
 	}
-	if graphA.AssetRef.PartID == graphB.AssetRef.PartID {
-		t.Fatalf("graph indexes reused part_id=%d in namespace %q", graphA.AssetRef.PartID, graphA.AssetRef.Namespace)
+	records, _ := loadColumnGraphRebuildManifestRecordsAndConfigV2A(t, d, "docs")
+	stateA := columnVectorIndexStateFromRecords1987(t, records, defA)
+	stateB := columnVectorIndexStateFromRecords1987(t, records, defB)
+	seen := make(map[uint64]string)
+	for _, asset := range stateA.Assets {
+		seen[asset.Ref.PartID] = defA.Name + ":" + asset.Role + ":" + asset.AssetID
+	}
+	for _, asset := range stateB.Assets {
+		if previous := seen[asset.Ref.PartID]; previous != "" {
+			t.Fatalf("vector-index state assets reused part_id=%d between %s and %s:%s:%s", asset.Ref.PartID, previous, defB.Name, asset.Role, asset.AssetID)
+		}
 	}
 }
 
@@ -934,16 +947,26 @@ func TestColumnGraphRebuildVectorIndexReachabilityReclaimsSupersededGraphSegment
 	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
 		t.Fatalf("first RebuildVectorIndex: %v", err)
 	}
-	first, _ := loadAndScanColumnGraphRebuildRowsV2A(t, d, "docs", def)
+	firstRecords, _ := loadColumnGraphRebuildManifestRecordsAndConfigV2A(t, d, "docs")
+	firstState := columnVectorIndexStateFromRecords1987(t, firstRecords, def)
+	if len(firstState.Assets) == 0 {
+		t.Fatal("first rebuild produced no vector-index state assets")
+	}
+	firstRef := firstState.Assets[0].Ref
 	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
 		t.Fatalf("second RebuildVectorIndex: %v", err)
 	}
-	second, _ := loadAndScanColumnGraphRebuildRowsV2A(t, d, "docs", def)
-	if first.AssetRef == second.AssetRef {
-		t.Fatalf("second rebuild reused graph asset ref %+v", first.AssetRef)
+	secondRecords, _ := loadColumnGraphRebuildManifestRecordsAndConfigV2A(t, d, "docs")
+	secondState := columnVectorIndexStateFromRecords1987(t, secondRecords, def)
+	if len(secondState.Assets) == 0 {
+		t.Fatal("second rebuild produced no vector-index state assets")
 	}
-	if first.AssetRef.FileID == second.AssetRef.FileID {
-		t.Fatalf("second rebuild reused graph segment file_id=%d; want fresh segment for whole-segment reclaim", first.AssetRef.FileID)
+	secondRef := secondState.Assets[0].Ref
+	if firstRef == secondRef {
+		t.Fatalf("second rebuild reused vector-index state asset ref %+v", firstRef)
+	}
+	if firstRef.FileID == secondRef.FileID {
+		t.Fatalf("second rebuild reused vector-index state segment file_id=%d; want fresh segment for whole-segment reclaim", firstRef.FileID)
 	}
 
 	plan, err := col.PlanColumnAssetReachability(context.Background(), ColumnAssetReachabilityOptions{Detailed: true})
@@ -953,8 +976,8 @@ func TestColumnGraphRebuildVectorIndexReachabilityReclaimsSupersededGraphSegment
 	if !plan.Complete {
 		t.Fatalf("reachability plan incomplete: refs=%+v segments=%+v", plan.Refs, plan.Segments)
 	}
-	assertColumnGraphReachabilityEntryV2A(t, plan, second.AssetRef)
-	assertColumnGraphSegmentStatusV2A(t, plan, first.AssetRef.FileID, ColumnAssetReachabilitySegmentReclaimable)
+	assertColumnGraphReachabilityEntryV2A(t, plan, secondRef)
+	assertColumnGraphSegmentStatusV2A(t, plan, firstRef.FileID, ColumnAssetReachabilitySegmentReclaimable)
 }
 
 func TestColumnGraphReachabilityPrunesDroppedVectorIndexGraphRefV2A(t *testing.T) {
@@ -1561,6 +1584,7 @@ func columnGraphRebuildColumnStoreConfigV2A(dims int) *ColumnStoreConfig {
 	cfg.Columns = append(append([]ColumnStoreColumn(nil), cfg.Columns...), ColumnStoreColumn{
 		Name:       "embedding",
 		Path:       "embedding",
+		Owner:      TypedStorageOwnerColumnPart,
 		ValueType:  ColumnStoreValueFloat32Vector,
 		VectorDims: dims,
 	})
@@ -1743,6 +1767,9 @@ func loadAndScanColumnGraphRebuildRowsV2A(tb testing.TB, d *backenddb.DB, collec
 	if err != nil {
 		tb.Fatalf("decodeColumnVectorGraphManifestRecord: %v", err)
 	}
+	if !columnVectorGraphManifestHasPhysicalAsset(graph) {
+		return graph, loadColumnGraphRebuildRowsFromStateV2A(tb, d, collection, cfg, def, graph, records)
+	}
 	graphCfg, err := columnVectorGraphPhysicalColumnStoreConfig(collection, *cfg, def)
 	if err != nil {
 		tb.Fatalf("columnVectorGraphPhysicalColumnStoreConfig: %v", err)
@@ -1787,6 +1814,128 @@ func loadAndScanColumnGraphRebuildRowsV2A(tb testing.TB, d *backenddb.DB, collec
 		}
 	}
 	return graph, rows
+}
+
+func loadColumnGraphRebuildRowsFromStateV2A(tb testing.TB, d *backenddb.DB, collection string, cfg *ColumnStoreConfig, def VectorIndexDefinition, graph columnVectorGraphManifestSnapshot, records []columnManifestRecord) []columnGraphRebuildScannedRowV2A {
+	tb.Helper()
+	state := columnVectorIndexStateFromRecords1987(tb, records, def)
+	documentIDs, _, err := newColumnVectorGraphDocumentIDStateSourceFromRoot(d.ColumnAssetRootDir(), collection, *cfg, def, graph, state)
+	if err != nil {
+		tb.Fatalf("open document-id state source: %v", err)
+	}
+	if documentIDs != nil {
+		defer func() { _ = documentIDs.Close() }()
+	}
+	invNorms, _, err := newColumnVectorGraphInvNormStateSourceFromRoot(d.ColumnAssetRootDir(), collection, *cfg, def, graph, state)
+	if err != nil {
+		tb.Fatalf("open inv_norm state source: %v", err)
+	}
+	if invNorms != nil {
+		defer func() { _ = invNorms.Close() }()
+	}
+	layers := make([]typedcolumn.RawUint32OffsetsList, state.AdjacencyLayerCount)
+	for layer := range layers {
+		layers[layer] = loadColumnVectorIndexStateAdjacencyList1987(tb, d, collection, cfg, def, state, layer)
+	}
+	col, err := NewCollectionManager(d).OpenCollection(collection)
+	if err != nil {
+		tb.Fatalf("OpenCollection for state rows: %v", err)
+	}
+	rows := make([]columnGraphRebuildScannedRowV2A, graph.RowCount)
+	for ordinal := range rows {
+		id, ok := documentIDs.documentIDForOrdinal(ordinal)
+		if !ok {
+			tb.Fatalf("document-id state missing ordinal %d", ordinal)
+		}
+		document, err := col.Get(id)
+		if err != nil {
+			tb.Fatalf("Get %q: %v", string(id), err)
+		}
+		vector := columnGraphRebuildVectorFromDocumentV2A(tb, collection, def, id, document)
+		invNorm, _, _, ok := invNorms.invNormForOrdinal(ordinal)
+		if !ok {
+			tb.Fatalf("inv_norm state missing ordinal %d", ordinal)
+		}
+		rows[ordinal] = columnGraphRebuildScannedRowV2A{
+			id:        string(id),
+			vector:    vector,
+			invNorm:   invNorm,
+			adjacency: columnGraphRebuildAdjacencyFromStateLayersV2A(tb, layers, ordinal),
+		}
+	}
+	return rows
+}
+
+func columnGraphRebuildVectorFromDocumentV2A(tb testing.TB, collection string, def VectorIndexDefinition, id []byte, document []byte) []float32 {
+	tb.Helper()
+	vectorCfg, err := normalizeColumnStoreConfig(collection, &ColumnStoreConfig{
+		Enabled: true,
+		Columns: []ColumnStoreColumn{{
+			Name:       columnVectorGraphVectorColumnName,
+			Path:       def.Field,
+			ValueType:  ColumnStoreValueFloat32Vector,
+			VectorDims: def.Dimensions,
+		}},
+	})
+	if err != nil {
+		tb.Fatalf("normalize vector config: %v", err)
+	}
+	declared, err := extractColumnDeclaredRowsFromJSONDocuments(*vectorCfg, []columnWriteDocument{{ID: id, Document: document}})
+	if err != nil {
+		tb.Fatalf("extract vector for %q: %v", string(id), err)
+	}
+	if len(declared) != 1 || len(declared[0].Values) != 1 {
+		values := 0
+		if len(declared) != 0 {
+			values = len(declared[0].Values)
+		}
+		tb.Fatalf("extract vector rows=%d values=%d want 1 row and 1 value", len(declared), values)
+	}
+	value := declared[0].Values[0]
+	if !value.Present || value.Null || len(value.Float32Vector) != def.Dimensions {
+		tb.Fatalf("extract vector for %q present/null/dims=(%t,%t,%d) want present non-null dims=%d", string(id), value.Present, value.Null, len(value.Float32Vector), def.Dimensions)
+	}
+	return append([]float32(nil), value.Float32Vector...)
+}
+
+func columnGraphRebuildAdjacencyFromStateLayersV2A(tb testing.TB, layers []typedcolumn.RawUint32OffsetsList, ordinal int) []uint32 {
+	tb.Helper()
+	if len(layers) == 0 {
+		return nil
+	}
+	if len(layers) == 1 {
+		row, err := layers[0].Row(ordinal)
+		if err != nil {
+			tb.Fatalf("adjacency layer 0 row %d: %v", ordinal, err)
+		}
+		return append([]uint32(nil), row...)
+	}
+	maxLayer := 0
+	layerRows := make([][]uint32, len(layers))
+	for layer := range layers {
+		row, err := layers[layer].Row(ordinal)
+		if err != nil {
+			tb.Fatalf("adjacency layer %d row %d: %v", layer, ordinal, err)
+		}
+		layerRows[layer] = row
+		if len(row) > 0 {
+			maxLayer = layer
+		}
+	}
+	if maxLayer == 0 {
+		return append([]uint32(nil), layerRows[0]...)
+	}
+	total := 2 + maxLayer + 1
+	for layer := 0; layer <= maxLayer; layer++ {
+		total += len(layerRows[layer])
+	}
+	encoded := make([]uint32, 0, total)
+	encoded = append(encoded, columnVectorGraphLayeredAdjacencyMagic, uint32(maxLayer))
+	for _, row := range layerRows[:maxLayer+1] {
+		encoded = append(encoded, uint32(len(row)))
+		encoded = append(encoded, row...)
+	}
+	return encoded
 }
 
 func loadColumnGraphLayer0AdjacencySourceList1918(tb testing.TB, d *backenddb.DB, collection string, cfg *ColumnStoreConfig, def VectorIndexDefinition, graph columnVectorGraphManifestSnapshot) typedcolumn.RawUint32OffsetsList {
@@ -2071,6 +2220,9 @@ func assertColumnGraphRebuildLoadedStatusV2A(tb testing.TB, status VectorIndexSt
 
 func assertColumnAssetReachabilityProtectsGraphRefV2A(tb testing.TB, col *Collection, graphRef ColumnAssetRef) {
 	tb.Helper()
+	if graphRef.Kind == "" {
+		return
+	}
 	plan, err := col.PlanColumnAssetReachability(context.Background(), ColumnAssetReachabilityOptions{Detailed: true})
 	if err != nil {
 		tb.Fatalf("PlanColumnAssetReachability: %v", err)

--- a/TreeDB/collections/vector_index_search.go
+++ b/TreeDB/collections/vector_index_search.go
@@ -18,9 +18,10 @@ var ErrVectorIndexSearchUnavailable = errors.New("collections: vector index sear
 type VectorIndexSearchPath string
 
 const (
-	// VectorIndexSearchPathColumnGraphNativeReader searches the persisted
-	// column_graph asset through the physical column row reader. It does not
-	// build or query a decoded in-memory ColumnVectorGraph.
+	// VectorIndexSearchPathColumnGraphNativeReader searches persisted column_graph
+	// state through the native reader. Current healthy indexes use TVIS/base
+	// typed-column sources; legacy physical graph rows are compatibility fallback
+	// only. It does not build or query a decoded in-memory ColumnVectorGraph.
 	VectorIndexSearchPathColumnGraphNativeReader VectorIndexSearchPath = "column_graph_native_reader"
 )
 
@@ -237,9 +238,9 @@ type VectorIndexSearchStats struct {
 	AdjacencyTypedListScratchDecodes uint64 `json:"adjacency_typed_list_scratch_decodes,omitempty"`
 	// AdjacencyLegacyFallbacks counts row-image graph adjacency fallback/quarantine reads.
 	AdjacencyLegacyFallbacks uint64 `json:"adjacency_legacy_fallbacks,omitempty"`
-	// AdjacencySourceUnavailable reports that this searcher had no usable certified adjacency source and used row-asset fallback.
+	// AdjacencySourceUnavailable reports that this searcher had no usable certified adjacency source.
 	AdjacencySourceUnavailable uint64 `json:"adjacency_source_unavailable,omitempty"`
-	// AdjacencySourceFallbacks reports searches or observations that fell back from certified adjacency sources to row assets.
+	// AdjacencySourceFallbacks reports searches or observations that fell back from certified adjacency sources to legacy rows or fail-closed fallback handling.
 	AdjacencySourceFallbacks uint64 `json:"adjacency_source_fallbacks,omitempty"`
 	// AdjacencyCertificationFailures counts adjacency source certification, shape, or validation failures.
 	AdjacencyCertificationFailures uint64 `json:"adjacency_certification_failures,omitempty"`
@@ -263,7 +264,7 @@ type VectorIndexSearchStats struct {
 	NormScratchDecodes uint64 `json:"norm_scratch_decodes,omitempty"`
 	// NormSourceUnavailable reports that this searcher had no usable inverse-norm state source and used graph-row fallback.
 	NormSourceUnavailable uint64 `json:"norm_source_unavailable,omitempty"`
-	// NormSourceFallbacks reports searches or observations that fell back from inverse-norm state to graph rows.
+	// NormSourceFallbacks reports searches or observations that fell back from inverse-norm state to legacy rows or fail-closed fallback handling.
 	NormSourceFallbacks uint64 `json:"norm_source_fallbacks,omitempty"`
 	// NormValidationFailures counts inverse-norm state source certification, shape, or validation failures.
 	NormValidationFailures uint64 `json:"norm_validation_failures,omitempty"`

--- a/TreeDB/collections/vector_index_search_test.go
+++ b/TreeDB/collections/vector_index_search_test.go
@@ -55,6 +55,18 @@ func TestSearchVectorIndexColumnGraphNativeReaderReopenV4(t *testing.T) {
 	}
 	assertColumnGraphSearchResponseLoadedV4(t, got, def.Name, 2)
 	assertVectorIndexSearchResultsV4(t, got.Results, exactColumnGraphTopKForTest(t, rows, query, 2), false)
+	records, _ := loadColumnGraphRebuildManifestRecordsAndConfigV2A(t, reopened, "docs")
+	graphRecord, ok := findColumnVectorGraphManifestRecord(records, def.Name)
+	if !ok {
+		t.Fatalf("graph manifest record %q missing", def.Name)
+	}
+	graph, err := decodeColumnVectorGraphManifestRecord(graphRecord.value)
+	if err != nil {
+		t.Fatalf("decodeColumnVectorGraphManifestRecord: %v", err)
+	}
+	if columnVectorGraphManifestHasPhysicalAsset(graph) {
+		t.Fatalf("healthy rebuilt graph has physical row asset %+v; want TVIS/base typed-column state only", graph.AssetRef)
+	}
 	if got.Stats.Candidates == 0 || got.Stats.CandidateFetches == 0 || got.Stats.ResultFetches < uint64(len(got.Results)) {
 		t.Fatalf("stats=%+v want public search to expose non-zero native graph traversal/result accounting", got.Stats)
 	}
@@ -63,6 +75,12 @@ func TestSearchVectorIndexColumnGraphNativeReaderReopenV4(t *testing.T) {
 	}
 	if got.Stats.AdjacencyTypedListMmapDirectViews+got.Stats.AdjacencyTypedListHeapCopyTypedViews+got.Stats.AdjacencyTypedListScratchDecodes == 0 || got.Stats.AdjacencyLegacyFallbacks != 0 {
 		t.Fatalf("stats=%+v want public search to expose typed-list adjacency and no legacy fallback on healthy state", got.Stats)
+	}
+	if got.Stats.RowFetches != 0 || got.Stats.BatchFetches != 0 || got.Stats.RowsFetched != 0 || got.Stats.PhysicalBytesRead != 0 || got.Stats.OpenPhysicalBytesRead != 0 {
+		t.Fatalf("stats=%+v want zero graph row payload reads on healthy current-format search", got.Stats)
+	}
+	if got.Stats.TypedColumnFallbacks != 0 || got.Stats.RowRefVectorSourceLegacyGraphIDs != 0 || got.Stats.ResultIDGraphFallbacks != 0 || got.Stats.NormSourceFallbacks != 0 {
+		t.Fatalf("stats=%+v want TVIS/base typed-column sources without graph row fallback", got.Stats)
 	}
 	if got.Stats.DocumentsFetched != 0 {
 		t.Fatalf("DocumentsFetched=%d want no document fetch without IncludeDocuments", got.Stats.DocumentsFetched)

--- a/TreeDB/docs/guides/vector-search-typed-column.md
+++ b/TreeDB/docs/guides/vector-search-typed-column.md
@@ -16,8 +16,8 @@ changes.
 | Embedding/vector payload | `typed_column_part` fixed-dimension `float32_vector` | Contiguous row-major `float32` sections can be viewed directly after validation. |
 | Document title/body/source text | Retained document / residual payload | Usually needed only after top-k; keep flexible. |
 | Filter/sort metadata | `typed_row_asset` or scalar `typed_column_part` depending on query shape | Use typed-row for point reconstruction; use typed-column when filtering/scanning dominates. |
-| Vector graph/ANN data | `derived_accelerator` | It accelerates search but is not the authoritative owner of the embedding field. |
-| Adjacency list | typed-column `uint32_list` assets owned by vector-index state | `raw_uint32_offsets_list` is the physical encoding for HNSW adjacency state. Legacy `column_graph` adjacency direct sources and the `adjacency_layout: "uint32_offsets_list"` selector are quarantined compatibility only; new graph builds should not publish those graph-specific source assets. |
+| Vector graph/ANN data | `derived_accelerator` plus TVIS control state | It accelerates search but is not the authoritative owner of the embedding field. Current healthy rebuilds do not publish duplicate physical graph row payloads. |
+| Adjacency list | typed-column `uint32_list` assets owned by vector-index state | `raw_uint32_offsets_list` is the physical encoding for HNSW adjacency state. Legacy `column_graph` adjacency direct sources and the `adjacency_layout: "uint32_offsets_list"` selector are quarantined compatibility only; new graph builds should not publish those graph-specific source assets or legacy graph row adjacency payloads. |
 | Ordinal-to-base-row references | vector-index state `row_refs` assets (`int64` / `raw_int64`) | Search uses row-ref state to map HNSW ordinals to base rows and to materialize documents without an ID-to-row-ref locator lookup. |
 | Returned opaque document IDs | vector-index state `document_ids` asset (`bytes` / `raw_bytes_offsets`) | Exact arbitrary binary IDs are opaque bytes state. Legacy graph row ID bytes are compatibility or quarantine fallback only. |
 
@@ -146,7 +146,7 @@ TreeDB column_graph native-reader demo
 db_dir=/tmp/treedb-column-graph-doc-smoke rows=64 dims=8 degree=4 top_k=5 ef_search=32
 rebuild status=column_graph_loaded loaded=true reason=
 search path=column_graph_native_reader status=column_graph_loaded loaded=true results=5 include_docs=false
-stats candidates=... edges=... row_fetches=... cache_hits=... cache_misses=... decoded_blocks=... granules_touched=... physical_B=... max_resident_B=... docs_fetched=0
+stats candidates=... edges=... row_fetches=0 cache_hits=0 cache_misses=0 decoded_blocks=0 granules_touched=0 physical_B=0 max_resident_B=0 docs_fetched=0
 result[0] id=doc-... ordinal=... score=...
 ```
 
@@ -154,8 +154,9 @@ Interpretation:
 
 - `search path=column_graph_native_reader` means the native reader path was used.
 - `docs_fetched=0` means search/scoring did not materialize final documents.
-- `physical_B` and `max_resident_B` describe physical bytes read/resident for the
-  native reader/cache path.
+- `physical_B=0` and `row_fetches=0` on current healthy rebuilds mean search did
+  not read legacy graph row payloads. Non-zero values indicate an explicit
+  legacy compatibility path or a benchmark using old physical graph fixtures.
 - Add `-include-docs` when you intentionally want final document fetch included;
   then `docs_fetched` should be non-zero.
 
@@ -312,6 +313,6 @@ counters.
 | `docs_fetched` is non-zero in a search-only comparison | You included final document materialization. | Drop `-include-docs` or move document fetch into a separate benchmark row. |
 | Search benchmark allocates heavily | You may be timing setup/open, public document materialization, or fallback decode. | Compare reusable-searcher vs one-shot names and inspect allocation profiles. |
 | Results differ across branches | On-disk formats/APIs are pre-alpha. | Rebuild DB directories and rerun with the same rows/dims/degree/top-k/seed. |
-| Adjacency typed-list counters show scratch decodes or legacy fallback | The vector-index state `uint32_list` direct source is missing, stale, disabled, or failed validation, so search fell back to row-asset adjacency or dense compatibility/corruption recovery. | Rebuild the graph so vector-index state owns certified `uint32_list` / `raw_uint32_offsets_list` adjacency assets. Treat old `column_graph` adjacency-source assets as compatibility-only, not a fix target. |
-| `row_ref_vector_source_legacy_graph_ids` is non-zero | The vector-index row-ref state is missing or stale, so typed-column vector source setup used legacy graph row ID scans. | Rebuild the graph so TVIS publishes `row_refs` assets; keep graph ID reads only as explicit compatibility fallback. |
-| `result_id_graph_fallbacks` is non-zero | The vector-index document-ID bytes state is missing or failed validation, so returned IDs came from legacy graph row ID bytes. | Rebuild the graph so TVIS publishes `document_ids` bytes assets; inspect `result_id_state_validation_failures` for corrupt or stale state. |
+| Adjacency typed-list counters show scratch decodes or legacy fallback | The vector-index state `uint32_list` direct source is missing, stale, disabled, or failed validation. Current healthy indexes fail closed when no legacy graph row asset is available; old fixtures may report explicit compatibility fallback. | Rebuild the graph so vector-index state owns certified `uint32_list` / `raw_uint32_offsets_list` adjacency assets. Treat old `column_graph` adjacency-source assets as compatibility-only, not a fix target. |
+| `row_ref_vector_source_legacy_graph_ids` is non-zero | A legacy physical graph row asset was used to map graph ordinals to base typed-column rows because row-ref state was missing or stale. | Rebuild the graph so TVIS publishes `row_refs` assets; keep graph ID reads only as explicit compatibility fallback. |
+| `result_id_graph_fallbacks` is non-zero | A legacy physical graph row asset supplied returned IDs because vector-index document-ID bytes state was missing or failed validation. Current healthy indexes fail closed instead of silently recanonicalizing graph row IDs. | Rebuild the graph so TVIS publishes `document_ids` bytes assets; inspect `result_id_state_validation_failures` for corrupt or stale state. |

--- a/TreeDB/docs/spec/vector-index-state-manifest.md
+++ b/TreeDB/docs/spec/vector-index-state-manifest.md
@@ -24,9 +24,11 @@ checksum includes the state record for durability, while the state record's
 `base_manifest_checksum` is computed over the authoritative base collection
 manifest records with vector-index derived records excluded.
 
-Current legacy `column_graph` records may still exist so old pre-alpha graph
-assets can be searched or rebuilt through compatibility paths. New derived
-state should be described here and should reference generic typed-column assets.
+Current rebuilt `column_graph` records are control records tied to TVIS state;
+new healthy rebuilds do not publish a physical graph row payload. Legacy
+pre-alpha records with graph row assets may still be searched or rebuilt through
+explicit compatibility paths. New derived state should be described here and
+should reference generic typed-column assets.
 
 ## Record identity
 
@@ -75,7 +77,8 @@ layer. Row-ref state uses multiple `row_refs` assets distinguished by asset id
 (for generation, part id, row index, and applied command LSN). Document-ID state
 uses one `document_ids` asset with one opaque byte value per graph ordinal.
 Legacy graph row ID bytes remain compatibility or quarantine fallback records
-until graph-row payload retirement work removes or shrinks them.
+only for old physical graph row assets; current healthy rebuilds return IDs from
+TVIS `document_ids` bytes state.
 
 ## Validation and fail-closed behavior
 
@@ -93,6 +96,6 @@ Opening/status validation must reject:
 - missing, out-of-bounds, or corrupt referenced assets.
 
 Old `column_graph` graph records without a `TVIS` state record are legacy
-compatibility. They may still be used by current fallback readers, but new
-vector-index derived assets should not be added to the graph-record trailer
-format.
+compatibility. They may still be used by explicit fallback readers, but new
+healthy rebuilds must rely on TVIS/base typed-column state and must not add new
+vector-index derived assets to the graph-record trailer format.

--- a/cmd/treedb_column_graph_demo/main.go
+++ b/cmd/treedb_column_graph_demo/main.go
@@ -365,7 +365,7 @@ func demoCollectionMeta(dims, degree int) *collections.CollectionMeta {
 					{Name: "kind", Path: "kind", ValueType: collections.ColumnStoreValueString, Dictionary: true},
 					{Name: "did", Path: "did", ValueType: collections.ColumnStoreValueString, Dictionary: true},
 					{Name: "label", Path: "label", ValueType: collections.ColumnStoreValueString, Dictionary: true, Nullable: true},
-					{Name: "embedding", Path: "embedding", ValueType: collections.ColumnStoreValueFloat32Vector, VectorDims: dims},
+					{Name: "embedding", Path: "embedding", Owner: collections.TypedStorageOwnerColumnPart, ValueType: collections.ColumnStoreValueFloat32Vector, VectorDims: dims},
 				},
 				SortKey: []collections.ColumnSortKey{{Column: "time_us"}},
 			},

--- a/cmd/treedb_vector_search_demo/main.go
+++ b/cmd/treedb_vector_search_demo/main.go
@@ -568,6 +568,7 @@ func columnGraphDemoColumnStoreConfig(dims int) *collections.ColumnStoreConfig {
 			{
 				Name:       "embedding",
 				Path:       "embedding",
+				Owner:      collections.TypedStorageOwnerColumnPart,
 				ValueType:  collections.ColumnStoreValueFloat32Vector,
 				VectorDims: dims,
 			},


### PR DESCRIPTION
## Summary

Fixes #2014.
Refs #1991 and #1971.

- Stop publishing the duplicate column_graph physical row payload for current rebuilds; healthy search now relies on TVIS/base typed-column state.
- Treat any graph row asset as compatibility-only legacy state and keep old fallback tests explicit.
- Require current rebuilds to have base typed-column vectors plus TVIS inverse norms, adjacency, row refs, and document IDs before opening healthy search without a graph asset.
- Update counters/tests/docs to prove graph row payload reads are zero on the healthy path and graph_asset_B/op is zero for rebuilds.

## Validation

- PASS: git diff --check
- PASS: go test ./TreeDB/collections -run 'TestColumnGraphRebuildVectorIndexPublishesPhysicalManifestV2A|TestColumnVectorGraphNativeSearchCosineUsesPhysicalRowsV3|TestColumnVectorGraphSearchSourceConstructionHealthyTypedColumn1968|TestTypedStorageLegacyNameAllowlistIsComplete' -count=1
- PASS: go test ./TreeDB/collections -run 'TestColumnVectorGraph|TestColumnGraphRebuild|TestVectorIndexSearcher|TestSearchVectorIndex' -count=1
- PASS: go test ./TreeDB/docs ./TreeDB/collections -count=1
- PASS: go test ./cmd/treedb_column_graph_demo ./cmd/treedb_vector_search_demo -count=1
- PASS: go test ./TreeDB/caching -run TestCheckpoint_KicksVlogGenerationRewriteDespiteRecentForegroundActivity -count=1
- PASS: go test ./...

## Benchmark evidence

Command: go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnGraphRebuildVectorIndexV2A|BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderV4' -benchtime=5x -count=1 -benchmem

Hardware: Apple M3, darwin arm64. Short smoke run for storage and source counters.

| Benchmark | ns/op | ops/sec | B/op | allocs/op | Key counters |
| --- | ---: | ---: | ---: | ---: | --- |
| BenchmarkColumnGraphRebuildVectorIndexV2A | 21464125 | 46.59 | 2903324 | 15182 | graph_asset_B/op=0, graph_total_storage_B/op=85240, document_id_state_asset_B/row=70.81, state_assets_B/op=85240 |
| BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderV4 | 13158 | n/a | 784 | 2 | result_id_graph_fallbacks/search=0, result_id_typed_bytes_state/search=10.00, row_ref_state_result_refs/search=10.00, typed_column_vector_source_mmap=1.000, norm_mmap_direct/search=164.0, adjacency_typed_list_mmap_direct/search=104.0, row_fetches/search=0 |

## Notes

- Old graph row assets remain readable through explicit legacy compatibility/fallback tests.
- New current-format graph manifests have no graph physical row asset and use TVIS/base typed-column state for healthy search.
- Demo column-graph configs now mark embedding as typed_column_part so current rebuild preconditions are satisfied.

## Review requests

Codex, Copilot, and CodeRabbit reviews requested.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
- Vector index searches now return explicit errors when required state assets are missing, instead of attempting fallback paths
- Improved validation for vector graph manifests to ensure consistency between physical assets and vector-index state

**Documentation**
- Clarified vector search architecture: rebuilt graphs now leverage vector-index state storage without duplicating physical row assets
- Updated telemetry guidance and troubleshooting documentation to explain state asset dependencies and search behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->