### PR TITLE
Avoid buffered primary index read stalls

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -2285,11 +2285,13 @@ func runCollectionWaitIndexedAsyncFlushHook() {
 }
 
 var collectionPrimaryRunIndexRebuildHook struct {
-	mu sync.Mutex
-	fn func(collection string, tables, entries int)
+	installMu sync.Mutex
+	mu        sync.Mutex
+	fn        func(collection string, tables, entries int)
 }
 
 func setCollectionPrimaryRunIndexRebuildHookForTest(fn func(collection string, tables, entries int)) func() {
+	collectionPrimaryRunIndexRebuildHook.installMu.Lock()
 	collectionPrimaryRunIndexRebuildHook.mu.Lock()
 	prev := collectionPrimaryRunIndexRebuildHook.fn
 	collectionPrimaryRunIndexRebuildHook.fn = fn
@@ -2298,6 +2300,7 @@ func setCollectionPrimaryRunIndexRebuildHookForTest(fn func(collection string, t
 		collectionPrimaryRunIndexRebuildHook.mu.Lock()
 		collectionPrimaryRunIndexRebuildHook.fn = prev
 		collectionPrimaryRunIndexRebuildHook.mu.Unlock()
+		collectionPrimaryRunIndexRebuildHook.installMu.Unlock()
 	}
 }
 

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -2284,6 +2284,32 @@ func runCollectionWaitIndexedAsyncFlushHook() {
 	}
 }
 
+var collectionPrimaryRunIndexRebuildHook struct {
+	mu sync.Mutex
+	fn func(collection string, tables, entries int)
+}
+
+func setCollectionPrimaryRunIndexRebuildHookForTest(fn func(collection string, tables, entries int)) func() {
+	collectionPrimaryRunIndexRebuildHook.mu.Lock()
+	prev := collectionPrimaryRunIndexRebuildHook.fn
+	collectionPrimaryRunIndexRebuildHook.fn = fn
+	collectionPrimaryRunIndexRebuildHook.mu.Unlock()
+	return func() {
+		collectionPrimaryRunIndexRebuildHook.mu.Lock()
+		collectionPrimaryRunIndexRebuildHook.fn = prev
+		collectionPrimaryRunIndexRebuildHook.mu.Unlock()
+	}
+}
+
+func runCollectionPrimaryRunIndexRebuildHook(collection string, tables, entries int) {
+	collectionPrimaryRunIndexRebuildHook.mu.Lock()
+	fn := collectionPrimaryRunIndexRebuildHook.fn
+	collectionPrimaryRunIndexRebuildHook.mu.Unlock()
+	if fn != nil {
+		fn(collection, tables, entries)
+	}
+}
+
 func setTestBeforeCommandWALBufferedUpdateStageLockForTest(fn func()) func() {
 	testBeforeCommandWALBufferedUpdateStageLockHook.installMu.Lock()
 	prev := testBeforeCommandWALBufferedUpdateStageLockHook.ptr.Load()
@@ -4263,6 +4289,7 @@ func (c *Collection) bufferIndexedInsertPlanLocked(catalog *collectionCatalog, b
 	if domain.uniqueValueIndex == nil {
 		domain.uniqueValueIndex = make(map[string]*bufferedUniqueValueIndex)
 	}
+	ensureBufferedPrimaryRunIndexLocked(domain, len(plan.primaryKeys))
 	if plan.directBufferedInsert != nil {
 		return c.bufferDirectIndexedInsertPlanLocked(domain, catalog, plan)
 	}
@@ -4390,6 +4417,7 @@ func (c *Collection) bufferDirectIndexedInsertPlanLocked(domain *collectionWrite
 	if domain.uniqueValueIndex == nil {
 		domain.uniqueValueIndex = make(map[string]*bufferedUniqueValueIndex)
 	}
+	ensureBufferedPrimaryRunIndexLocked(domain, len(plan.primaryKeys))
 
 	addedRootRuns := estimateAccumulatedRootRunsForNamesLocked(domain, direct.rootNames)
 	shouldAutoFlushAfterAdding := shouldFlushBufferedIndexedWritesAfterAdding(domain, catalog.meta.Options, len(plan.resultIDs), direct.stagedBytes, addedRootRuns)
@@ -6592,6 +6620,16 @@ func newBufferedPrimaryRunIndex(capacity int) *bufferedPrimaryRunIndex {
 	return newBufferedPrimaryRunIndexWithDirectEntries(capacity, false)
 }
 
+func ensureBufferedPrimaryRunIndexLocked(domain *collectionWriteDomain, capacity int) *bufferedPrimaryRunIndex {
+	if domain == nil {
+		return nil
+	}
+	if domain.primaryRunIndex == nil {
+		domain.primaryRunIndex = newBufferedPrimaryRunIndex(max(1, capacity))
+	}
+	return domain.primaryRunIndex
+}
+
 func newBufferedPrimaryRunIndexWithDirectEntries(capacity int, directEntries bool) *bufferedPrimaryRunIndex {
 	if capacity < 0 {
 		capacity = 0
@@ -6741,7 +6779,9 @@ func rebuildBufferedPrimaryRunIndex(collectionName string, runs map[string][]mem
 	if len(tables) == 0 {
 		return nil, nil
 	}
-	index := newBufferedPrimaryRunIndexWithDirectEntries(bufferedRunLenHint(tables), true)
+	entries := bufferedRunLenHint(tables)
+	runCollectionPrimaryRunIndexRebuildHook(collectionName, len(tables), entries)
+	index := newBufferedPrimaryRunIndexWithDirectEntries(entries, true)
 	for _, table := range tables {
 		if err := addBufferedPrimaryRunIndexEntries(index, table); err != nil {
 			return nil, err
@@ -15416,6 +15456,7 @@ func (c *Collection) bufferDirectUpdateBatchPlanLocked(plan *updateBatchPlan) (b
 		}
 	}
 	primaryTable := rootTables[direct.primaryRootName]
+	ensureBufferedPrimaryRunIndexLocked(domain, len(direct.primaryEntries))
 	var primaryIndexKeys [][]byte
 	if domain.primaryRunIndex != nil {
 		primaryIndexKeys = make([][]byte, 0, len(direct.primaryEntries))
@@ -15684,6 +15725,7 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 	plan.stats.BufferStageDomainPrepare += updateBatchStatsSince(detailedStats, phaseStart)
 	materializePrimaryOverlayLocked(domain)
 	clearPrimaryDocumentCacheLocked(domain)
+	ensureBufferedPrimaryRunIndexLocked(domain, modifiedCount)
 	var primaryWriteTable memtable.Table
 	for i, rootName := range plan.rootNames {
 		baseRoot := plan.baseRootIDs[rootName]

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -6627,9 +6627,22 @@ func ensureBufferedPrimaryRunIndexLocked(domain *collectionWriteDomain, capacity
 	if domain == nil {
 		return nil
 	}
-	if domain.primaryRunIndex == nil {
-		domain.primaryRunIndex = newBufferedPrimaryRunIndex(max(1, capacity))
+	if domain.primaryRunIndex != nil {
+		return domain.primaryRunIndex
 	}
+	collectionName := bufferedDomainCollectionName(domain, "")
+	if hasBufferedPrimaryRootRuns(domain, collectionName) {
+		index, err := rebuildBufferedPrimaryRunIndex(collectionName, pendingIndexedRootRunMapLocked(domain))
+		if err != nil {
+			return nil
+		}
+		if index == nil {
+			index = newBufferedPrimaryRunIndex(0)
+		}
+		domain.primaryRunIndex = index
+		return domain.primaryRunIndex
+	}
+	domain.primaryRunIndex = newBufferedPrimaryRunIndex(max(1, capacity))
 	return domain.primaryRunIndex
 }
 

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -15424,6 +15424,7 @@ func (c *Collection) bufferDirectUpdateBatchPlanLocked(plan *updateBatchPlan) (b
 		}
 		return buffered, err
 	}
+	ensureBufferedPrimaryRunIndexLocked(domain, len(direct.primaryEntries))
 	materializePrimaryOverlayLocked(domain)
 
 	phaseStart = updateBatchStatsNow(detailedStats)
@@ -15459,7 +15460,6 @@ func (c *Collection) bufferDirectUpdateBatchPlanLocked(plan *updateBatchPlan) (b
 		}
 	}
 	primaryTable := rootTables[direct.primaryRootName]
-	ensureBufferedPrimaryRunIndexLocked(domain, len(direct.primaryEntries))
 	var primaryIndexKeys [][]byte
 	if domain.primaryRunIndex != nil {
 		primaryIndexKeys = make([][]byte, 0, len(direct.primaryEntries))
@@ -15726,9 +15726,9 @@ func (c *Collection) bufferUpdateBatchPlanLocked(plan *updateBatchPlan) (bool, e
 	}
 	rollbackGeneration := checkpoint.writeGeneration
 	plan.stats.BufferStageDomainPrepare += updateBatchStatsSince(detailedStats, phaseStart)
+	ensureBufferedPrimaryRunIndexLocked(domain, modifiedCount)
 	materializePrimaryOverlayLocked(domain)
 	clearPrimaryDocumentCacheLocked(domain)
-	ensureBufferedPrimaryRunIndexLocked(domain, modifiedCount)
 	var primaryWriteTable memtable.Table
 	for i, rootName := range plan.rootNames {
 		baseRoot := plan.baseRootIDs[rootName]

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -7741,6 +7741,75 @@ func TestBufferedIndexedUpdateMaterializedOverlayEntersPrimaryRunIndex(t *testin
 	}
 }
 
+func TestBufferedIndexedDeleteTombstoneSurvivesLaterPrimaryRunIndexEnable(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedWrites:            true,
+			BufferedIndexedWriteMaxDocuments: 1024,
+			BufferedIndexedWriteMaxRootRuns:  1024,
+			DisableBufferedIndexedAsyncFlush: true,
+		},
+		Indexes: []IndexDefinition{{Name: "city", Field: "city", ValueType: IndexValueString}},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1"), []byte("u2")},
+		[][]byte{
+			[]byte(`{"city":"hnl","score":0}`),
+			[]byte(`{"city":"sfo","score":0}`),
+		},
+	); err != nil {
+		t.Fatalf("insert batch: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush seed: %v", err)
+	}
+	if deleted, err := col.DeleteBatch([][]byte{[]byte("u1")}); err != nil {
+		t.Fatalf("DeleteBatch: %v", err)
+	} else if deleted != 1 {
+		t.Fatalf("DeleteBatch deleted=%d want 1", deleted)
+	}
+	if collectionHasBufferedPrimaryRunIndexForTest(t, col) {
+		t.Fatal("delete buffer unexpectedly left primary run index enabled")
+	}
+
+	if _, err := col.UpdateBatch([]UpdateBatchItem{{
+		DocumentID: []byte("u2"),
+		Update: func(current []byte) ([]byte, bool, error) {
+			var doc map[string]any
+			if err := json.Unmarshal(current, &doc); err != nil {
+				return nil, false, err
+			}
+			doc["city"] = "sea"
+			next, err := json.Marshal(doc)
+			return next, true, err
+		},
+	}}); err != nil {
+		t.Fatalf("secondary-changing UpdateBatch: %v", err)
+	}
+
+	got, found, err := col.GetInto([]byte("u1"), nil)
+	if err != nil {
+		t.Fatalf("GetInto deleted u1: %v", err)
+	}
+	if found || len(got) != 0 {
+		t.Fatalf("GetInto deleted u1 found=%v value=%q want missing tombstone", found, got)
+	}
+}
+
 func TestShouldFlushBufferedIndexedWritesAfterAddingBoundaries(t *testing.T) {
 	opts := CollectionOptions{
 		BufferedIndexedWriteMaxDocuments: 10,

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -7552,6 +7552,128 @@ func TestBufferedPrimaryRunIndexFindsNewestTable(t *testing.T) {
 	}
 }
 
+func TestBufferedIndexedInsertMaintainsPrimaryRunIndexBeforeRead(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedWrites:            true,
+			BufferedIndexedWriteMaxDocuments: 1024,
+			BufferedIndexedWriteMaxRootRuns:  1024,
+			DisableBufferedIndexedAsyncFlush: true,
+		},
+		Indexes: []IndexDefinition{{Name: "email", Field: "email", ValueType: IndexValueString}},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1"), []byte("u2"), []byte("u3")},
+		[][]byte{
+			[]byte(`{"email":"ada@example.com"}`),
+			[]byte(`{"email":"grace@example.com"}`),
+			[]byte(`{"email":"linus@example.com"}`),
+		},
+	); err != nil {
+		t.Fatalf("insert batch: %v", err)
+	}
+	if !collectionHasBufferedPrimaryRunIndexForTest(t, col) {
+		t.Fatal("buffered indexed insert did not maintain primary run index before first read")
+	}
+
+	var rebuilds atomic.Int32
+	restore := setCollectionPrimaryRunIndexRebuildHookForTest(func(string, int, int) {
+		rebuilds.Add(1)
+	})
+	defer restore()
+	got, found, err := col.GetInto([]byte("u2"), nil)
+	if err != nil {
+		t.Fatalf("GetInto: %v", err)
+	}
+	if !found || !bytes.Equal(got, []byte(`{"email":"grace@example.com"}`)) {
+		t.Fatalf("GetInto found=%v value=%q want buffered u2", found, got)
+	}
+	if got := rebuilds.Load(); got != 0 {
+		t.Fatalf("primary run index was rebuilt on read path %d times; want eager maintenance", got)
+	}
+}
+
+func TestBufferedIndexedUpdateMaintainsPrimaryRunIndexBeforeRead(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedWrites:            true,
+			BufferedIndexedWriteMaxDocuments: 1024,
+			BufferedIndexedWriteMaxRootRuns:  1024,
+			DisableBufferedIndexedAsyncFlush: true,
+		},
+		Indexes: []IndexDefinition{{Name: "email", Field: "email", ValueType: IndexValueString}},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"email":"ada@example.com","city":"hnl"}`)},
+	); err != nil {
+		t.Fatalf("insert batch: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush seed: %v", err)
+	}
+
+	results, err := col.UpdateBatch([]UpdateBatchItem{{
+		DocumentID: []byte("u1"),
+		Update: func(current []byte) ([]byte, bool, error) {
+			return []byte(`{"email":"ada@example.com","city":"lhr"}`), true, nil
+		},
+	}})
+	if err != nil {
+		t.Fatalf("UpdateBatch: %v", err)
+	}
+	if len(results) != 1 || !results[0].Matched || !results[0].Modified {
+		t.Fatalf("UpdateBatch results=%+v want one matched modified", results)
+	}
+	if !collectionHasBufferedPrimaryRunIndexForTest(t, col) {
+		t.Fatal("buffered indexed update did not maintain primary run index before first read")
+	}
+
+	var rebuilds atomic.Int32
+	restore := setCollectionPrimaryRunIndexRebuildHookForTest(func(string, int, int) {
+		rebuilds.Add(1)
+	})
+	defer restore()
+	got, found, err := col.GetInto([]byte("u1"), nil)
+	if err != nil {
+		t.Fatalf("GetInto: %v", err)
+	}
+	if !found || !bytes.Equal(got, []byte(`{"email":"ada@example.com","city":"lhr"}`)) {
+		t.Fatalf("GetInto found=%v value=%q want updated buffered document", found, got)
+	}
+	if got := rebuilds.Load(); got != 0 {
+		t.Fatalf("primary run index was rebuilt on read path %d times; want eager maintenance", got)
+	}
+}
+
 func TestShouldFlushBufferedIndexedWritesAfterAddingBoundaries(t *testing.T) {
 	opts := CollectionOptions{
 		BufferedIndexedWriteMaxDocuments: 10,
@@ -14397,8 +14519,8 @@ func TestCollectionUpdateBatchBuildsPrimaryRunIndexForBufferedPlanning(t *testin
 	if !batched || len(first) != 1 || !first[0].Matched || !first[0].Modified {
 		t.Fatalf("first results=%+v batched=%v want one modified row", first, batched)
 	}
-	if collectionHasBufferedPrimaryRunIndexForTest(t, col) {
-		t.Fatal("primary run index was built before buffered read planning")
+	if !collectionHasBufferedPrimaryRunIndexForTest(t, col) {
+		t.Fatal("primary run index was not maintained while buffering first update")
 	}
 
 	sawBufferedUpdate := false

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -7674,6 +7674,73 @@ func TestBufferedIndexedUpdateMaintainsPrimaryRunIndexBeforeRead(t *testing.T) {
 	}
 }
 
+func TestBufferedIndexedUpdateMaterializedOverlayEntersPrimaryRunIndex(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			BufferedIndexedWrites:            true,
+			BufferedIndexedWriteMaxDocuments: 1024,
+			BufferedIndexedWriteMaxRootRuns:  1024,
+			DisableBufferedIndexedAsyncFlush: true,
+		},
+		Indexes: []IndexDefinition{{Name: "city", Field: "city", ValueType: IndexValueString}},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1"), []byte("u2")},
+		[][]byte{
+			[]byte(`{"city":"hnl","score":0}`),
+			[]byte(`{"city":"sfo","score":0}`),
+		},
+	); err != nil {
+		t.Fatalf("insert batch: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush seed: %v", err)
+	}
+
+	if _, err := col.UpdateBatch([]UpdateBatchItem{{
+		DocumentID: []byte("u1"),
+		Update:     setJSONField("score", 1),
+	}}); err != nil {
+		t.Fatalf("primary-only UpdateBatch: %v", err)
+	}
+	if _, err := col.UpdateBatch([]UpdateBatchItem{{
+		DocumentID: []byte("u2"),
+		Update: func(current []byte) ([]byte, bool, error) {
+			var doc map[string]any
+			if err := json.Unmarshal(current, &doc); err != nil {
+				return nil, false, err
+			}
+			doc["city"] = "sea"
+			next, err := json.Marshal(doc)
+			return next, true, err
+		},
+	}}); err != nil {
+		t.Fatalf("secondary-changing UpdateBatch: %v", err)
+	}
+
+	got, found, err := col.GetInto([]byte("u1"), nil)
+	if err != nil {
+		t.Fatalf("GetInto u1: %v", err)
+	}
+	if !found || !bytes.Equal(got, []byte(`{"city":"hnl","score":1}`)) {
+		t.Fatalf("GetInto u1 found=%v value=%q want materialized overlay update", found, got)
+	}
+}
+
 func TestShouldFlushBufferedIndexedWritesAfterAddingBoundaries(t *testing.T) {
 	opts := CollectionOptions{
 		BufferedIndexedWriteMaxDocuments: 10,

--- a/TreeDB/collections/buffered_primary_index_bench_test.go
+++ b/TreeDB/collections/buffered_primary_index_bench_test.go
@@ -50,8 +50,9 @@ func BenchmarkBufferedIndexedFirstGetAfterInsert(b *testing.B) {
 				b.Fatalf("insert batch: %v", err)
 			}
 		}
+		lookupID := fmt.Sprintf("u%06d", entries-1)
 		b.StartTimer()
-		_, found, err := col.GetInto([]byte("u004095"), nil)
+		_, found, err := col.GetInto([]byte(lookupID), nil)
 		b.StopTimer()
 		if err != nil {
 			_ = d.Close()

--- a/TreeDB/collections/buffered_primary_index_bench_test.go
+++ b/TreeDB/collections/buffered_primary_index_bench_test.go
@@ -1,0 +1,68 @@
+package collections
+
+import (
+	"fmt"
+	"testing"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+)
+
+func BenchmarkBufferedIndexedFirstGetAfterInsert(b *testing.B) {
+	const entries = 4096
+	const batchSize = 256
+	b.ReportAllocs()
+	b.ReportMetric(entries, "pending_docs")
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		d, err := backenddb.Open(backenddb.Options{Dir: b.TempDir()})
+		if err != nil {
+			b.Fatalf("open db: %v", err)
+		}
+		mgr := NewCollectionManager(d)
+		if _, err := mgr.CreateCollection(&CollectionMeta{
+			Name: "users",
+			Options: CollectionOptions{
+				BufferedIndexedWrites:            true,
+				BufferedIndexedWriteMaxDocuments: entries * 2,
+				BufferedIndexedWriteMaxRootRuns:  entries * 2,
+				DisableBufferedIndexedAsyncFlush: true,
+			},
+			Indexes: []IndexDefinition{{Name: "email", Field: "email", ValueType: IndexValueString}},
+		}); err != nil {
+			_ = d.Close()
+			b.Fatalf("create collection: %v", err)
+		}
+		col, err := mgr.OpenCollection("users")
+		if err != nil {
+			_ = d.Close()
+			b.Fatalf("open collection: %v", err)
+		}
+		for start := 0; start < entries; start += batchSize {
+			ids := make([][]byte, 0, batchSize)
+			docs := make([][]byte, 0, batchSize)
+			for j := 0; j < batchSize && start+j < entries; j++ {
+				id := fmt.Sprintf("u%06d", start+j)
+				ids = append(ids, []byte(id))
+				docs = append(docs, []byte(fmt.Sprintf(`{"email":"%s@example.com"}`, id)))
+			}
+			if _, err := col.InsertBatch(ids, docs); err != nil {
+				_ = d.Close()
+				b.Fatalf("insert batch: %v", err)
+			}
+		}
+		b.StartTimer()
+		_, found, err := col.GetInto([]byte("u004095"), nil)
+		b.StopTimer()
+		if err != nil {
+			_ = d.Close()
+			b.Fatalf("GetInto: %v", err)
+		}
+		if !found {
+			_ = d.Close()
+			b.Fatal("GetInto missing final inserted document")
+		}
+		if err := d.Close(); err != nil {
+			b.Fatalf("close db: %v", err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #2033. Related to #2027.

Static analysis found that buffered indexed writes left `collectionWriteDomain.primaryRunIndex` nil until the first read/update that needed buffered primary lookup. `GetInto`/buffered update planning then called `rebuildBufferedPrimaryRunIndex`, scanning every pending primary root-run entry under the write-domain lock. That made the first request after a buffered write burst pay an O(pending docs/root-runs) cliff.

This PR moves that cost out of the surprise read path by eagerly creating/maintaining the buffered primary run index while staging buffered indexed inserts and updates. The read path still has the defensive lazy rebuild fallback, but focused tests assert that normal buffered insert/update staging no longer reaches it.

## Tests

```sh
go test ./TreeDB/collections -run 'TestBufferedIndexed(Insert|Update)MaintainsPrimaryRunIndexBeforeRead|TestBufferedPrimaryRunIndexFindsNewestTable|TestSnapshotUpdateBatchBufferedReadPrimaryRunIndexAvoidsCollectingPendingRuns' -count=1
go test ./TreeDB/collections -run 'Buffered|UpdateBatch|InsertBatch' -count=1
go test ./TreeDB/collections -count=1
go test ./TreeDB/nativewire ./cmd/treedb-native-server -count=1
```

## Benchmarks

Host/context: linux amd64, 11th Gen Intel(R) Core(TM) i5-11400F @ 2.60GHz. Baseline was `origin/main` plus the new benchmark file copied into a temporary worktree. Candidate is this branch.

### First read after buffered indexed writes

Command:

```sh
go test ./TreeDB/collections -run '^$' -bench BenchmarkBufferedIndexedFirstGetAfterInsert -benchtime=3x -count=1
```

Measured boundary: setup inserts 4096 pending buffered indexed docs outside the timer, then times the first `GetInto` for a buffered document.

| Branch | ns/op | ops/sec | B/op | allocs/op | pending docs |
| --- | ---: | ---: | ---: | ---: | ---: |
| `origin/main` | 534,868 | 1,869 | 1,049,288 | 26 | 4096 |
| candidate | 122,861 | 8,139 | 218,528 | 20 | 4096 |

### Insert/write staging regression check

Command:

```sh
TREEDB_COLLECTION_BENCH_BATCH_SIZE=1024 \
  go test ./TreeDB/collections -run '^$' -bench '^BenchmarkCollectionShapeInsertBatch/indexes_1$' -benchtime=20x -count=3
```

Measured boundary: existing collection shape insert benchmarks with one secondary index. Results are noisy at this short benchtime; no material write-staging regression was observed. Candidate `BenchmarkCollectionShapeInsertBatch/indexes_1` runs were 15.8-17.2µs/op vs baseline 14.5-30.7µs/op, with comparable allocation counts (~20 allocs/op).

## Risk / Notes

- This intentionally shifts primary-run index maintenance into buffered write staging for indexed collections so reads/updates do not pay the full deferred rebuild.
- The lazy rebuild path remains as a correctness fallback for manually constructed/older states.
- No storage format change.

## AI review status

Requested after PR creation:

- [ ] Codex
- [ ] Copilot
- [ ] CodeRabbit


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Buffered indexed insert/update now eagerly maintains primary indexes so reads after batched writes are faster and avoid extra rebuilds.

* **Tests**
  * Added unit tests ensuring primary-index is present before first read for buffered inserts, updates, deletes, and materialized overlays.
  * Added a benchmark measuring first-read latency after large batched inserts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->