### PR TITLE
Typed-column mutation visibility fail-closed routing

### DIFF
--- a/TreeDB/collections/column_physical_q2_1950_test.go
+++ b/TreeDB/collections/column_physical_q2_1950_test.go
@@ -1,7 +1,9 @@
 package collections
 
 import (
+	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
@@ -41,6 +43,42 @@ func TestTypedColumnQ2SortedGroupedDistinctStreaming1950(t *testing.T) {
 	}
 	assertTypedColumnQ2SortedGroupedDistinctResult1950(t, "prepared", prepared, rowHash, wantCounts)
 	assertTypedColumnQ2SortedGroupedDistinctDiagnostics1950(t, "prepared", prepared.Diagnostics, len(events), matchedRows, true)
+}
+
+func TestTypedColumnQ2MutationVisibilityFailsClosedC1(t *testing.T) {
+	batches := [][]columnPhysicalJSONBenchParityEventP0{typedColumnQ2SortedBatchA1950(), typedColumnQ2SortedBatchB1950()}
+	_, col, closeFn := openTypedColumnSortKeyFixtureBatches1950(t, typedColumnQ2ClickHouseSortKey1950(), batches)
+	defer closeFn()
+
+	req := typedColumnQ2Request1950()
+	insertOnly, err := col.RunColumnPhysicalQuery(req)
+	if err != nil {
+		t.Fatalf("insert-only RunColumnPhysicalQuery(q2): %v", err)
+	}
+	if insertOnly.Diagnostics.StorageSource != ColumnPhysicalQueryStorageSourceTypedColumnPartSection || !insertOnly.Diagnostics.SortedGroupedDistinctUsed || insertOnly.Diagnostics.FallbackReason != ColumnPhysicalQueryFallbackNone {
+		t.Fatalf("insert-only diagnostics=%+v want optimized typed-column q2 path", insertOnly.Diagnostics)
+	}
+
+	_, modified, err := col.Update([]byte("a-post-shared"), func([]byte) ([]byte, bool, error) {
+		return []byte(`{"time_us":1800000000000040,"kind":"commit","operation":"create","collection":"app.bsky.feed.like","did":"did:shared"}`), true, nil
+	})
+	if err != nil || !modified {
+		t.Fatalf("Update modified=%t err=%v", modified, err)
+	}
+
+	result, err := col.RunColumnPhysicalQuery(req)
+	if !errors.Is(err, ErrColumnQueryPlanUnsupported) || !strings.Contains(err.Error(), "typed-column") || !strings.Contains(err.Error(), "mutation visibility") {
+		t.Fatalf("mutation q2 err=%v diagnostics=%+v want explicit typed-column mutation-visibility failure", err, result.Diagnostics)
+	}
+	if result.Diagnostics.StorageSource != ColumnPhysicalQueryStorageSourceTypedColumnPartSection || result.Diagnostics.FallbackReason != ColumnPhysicalQueryFallbackMutationVisibilityUnsupported {
+		t.Fatalf("mutation q2 diagnostics=%+v want typed-column mutation-visibility unsupported route", result.Diagnostics)
+	}
+	if result.Diagnostics.MutationParts == 0 || result.Diagnostics.VisibilityRows == 0 || result.Diagnostics.DocumentMaterializations != 0 || result.Diagnostics.RowMaterializations != 0 {
+		t.Fatalf("mutation q2 diagnostics=%+v want latest-visible physical state without document fallback", result.Diagnostics)
+	}
+	if _, err := col.PrepareColumnPhysicalQuery(req); !errors.Is(err, ErrColumnQueryPlanUnsupported) || !strings.Contains(err.Error(), "insert-only") {
+		t.Fatalf("prepared mutation q2 err=%v want fail-closed prepared insert-only guard", err)
+	}
 }
 
 func TestTypedColumnQ2SortedGroupedDistinctFallback1950(t *testing.T) {

--- a/TreeDB/collections/column_physical_query.go
+++ b/TreeDB/collections/column_physical_query.go
@@ -60,12 +60,13 @@ const (
 type ColumnPhysicalQueryFallbackReason string
 
 const (
-	ColumnPhysicalQueryFallbackNone                         ColumnPhysicalQueryFallbackReason = "none"
-	ColumnPhysicalQueryFallbackDirectAssetReduceUnsupported ColumnPhysicalQueryFallbackReason = "direct_asset_reduce_unsupported"
-	ColumnPhysicalQueryFallbackAggregateMetadataUnsupported ColumnPhysicalQueryFallbackReason = "aggregate_metadata_unsupported"
-	ColumnPhysicalQueryFallbackMutationVisibilityOverlay    ColumnPhysicalQueryFallbackReason = "mutation_visibility_overlay"
-	ColumnPhysicalQueryFallbackDocumentRootRowScan          ColumnPhysicalQueryFallbackReason = "document_root_row_scan"
-	ColumnPhysicalQueryFallbackMixed                        ColumnPhysicalQueryFallbackReason = "mixed"
+	ColumnPhysicalQueryFallbackNone                          ColumnPhysicalQueryFallbackReason = "none"
+	ColumnPhysicalQueryFallbackDirectAssetReduceUnsupported  ColumnPhysicalQueryFallbackReason = "direct_asset_reduce_unsupported"
+	ColumnPhysicalQueryFallbackAggregateMetadataUnsupported  ColumnPhysicalQueryFallbackReason = "aggregate_metadata_unsupported"
+	ColumnPhysicalQueryFallbackMutationVisibilityOverlay     ColumnPhysicalQueryFallbackReason = "mutation_visibility_overlay"
+	ColumnPhysicalQueryFallbackMutationVisibilityUnsupported ColumnPhysicalQueryFallbackReason = "mutation_visibility_unsupported"
+	ColumnPhysicalQueryFallbackDocumentRootRowScan           ColumnPhysicalQueryFallbackReason = "document_root_row_scan"
+	ColumnPhysicalQueryFallbackMixed                         ColumnPhysicalQueryFallbackReason = "mixed"
 )
 
 const (
@@ -298,12 +299,24 @@ func (c *Collection) RunColumnPhysicalQuery(req ColumnPhysicalQueryRequest) (Col
 		if req.AggregateMetadataName != "" {
 			return ColumnPhysicalQueryResult{}, fmt.Errorf("%w: aggregate metadata physical query requires insert-only manifest", ErrColumnQueryPlanUnsupported)
 		}
-		if columnPhysicalQueryHasPredicates(req) {
-			return ColumnPhysicalQueryResult{}, fmt.Errorf("%w: physical predicates require insert-only manifest", ErrColumnQueryPlanUnsupported)
-		}
 		cfg, err := c.columnPhysicalQueryColumnStoreConfig()
 		if err != nil {
 			return ColumnPhysicalQueryResult{}, err
+		}
+		if columnPhysicalQueryHasPredicates(req) {
+			if columnTypedColumnPhysicalQueryTouchesTypedColumnPart(cfg, req) {
+				view, closeView, err := c.prepareColumnPhysicalScanSnapshotViewWithSidecars(columnManifestScanSidecarsForPhysicalQuery(req))
+				if closeView != nil {
+					defer closeView()
+				}
+				if err != nil {
+					return ColumnPhysicalQueryResult{}, err
+				}
+				if result, ok, err := c.runColumnPhysicalQueryTypedColumnPartInSnapshotView(view, req); ok {
+					return result, err
+				}
+			}
+			return ColumnPhysicalQueryResult{}, fmt.Errorf("%w: physical predicates require insert-only manifest", ErrColumnQueryPlanUnsupported)
 		}
 		return c.runColumnPhysicalQueryWithVisibility(cfg, req)
 	}
@@ -319,6 +332,9 @@ func (c *Collection) RunColumnPhysicalQuery(req ColumnPhysicalQueryRequest) (Col
 			return ColumnPhysicalQueryResult{}, fmt.Errorf("%w: aggregate metadata physical query requires insert-only manifest", ErrColumnQueryPlanUnsupported)
 		}
 		if columnPhysicalQueryHasPredicates(req) {
+			if result, ok, err := c.runColumnPhysicalQueryTypedColumnPartInSnapshotView(view, req); ok {
+				return result, err
+			}
 			return ColumnPhysicalQueryResult{}, fmt.Errorf("%w: physical predicates require insert-only manifest", ErrColumnQueryPlanUnsupported)
 		}
 		return c.runColumnPhysicalQueryWithVisibility(view.Config, req)

--- a/TreeDB/collections/column_physical_typed_column_query.go
+++ b/TreeDB/collections/column_physical_typed_column_query.go
@@ -116,6 +116,9 @@ func (c *Collection) runColumnPhysicalQueryTypedColumnPartInSnapshotView(view co
 		return ColumnPhysicalQueryResult{}, candidate, err
 	}
 	start := time.Now()
+	if view.MutationParts != 0 {
+		return runColumnPhysicalQueryTypedColumnPartMutationUnsupported(view, req, start)
+	}
 	readCache, err := newColumnPhysicalAssetReadCacheWithIntegrity(view.ColumnAssetRootDir, view.AssetNamespace, req.ColumnAssetReadIntegrity)
 	if err != nil {
 		result := ColumnPhysicalQueryResult{}
@@ -133,6 +136,50 @@ func (c *Collection) runColumnPhysicalQueryTypedColumnPartInSnapshotView(view co
 	result, err := runner.run(view, req)
 	result.Diagnostics.ScanNanos = time.Since(start).Nanoseconds()
 	return result, true, err
+}
+
+func runColumnPhysicalQueryTypedColumnPartMutationUnsupported(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest, start time.Time) (ColumnPhysicalQueryResult, bool, error) {
+	diag := columnPhysicalQueryDiagnosticsFromScan(view.Diagnostics)
+	diag.WorkerCount = 1
+	diag.ColumnAssetReadIntegrity = columnAssetReadIntegrityLabel(req.ColumnAssetReadIntegrity)
+	result := ColumnPhysicalQueryResult{Diagnostics: diag}
+	annotateColumnPhysicalQueryResult(&result, ColumnPhysicalQueryStorageSourceTypedColumnPartSection, ColumnPhysicalQueryFallbackMutationVisibilityUnsupported)
+	predicateDiagnostics := newColumnPhysicalQueryPredicateDiagnosticPlan(req)
+	applyColumnPhysicalQueryPredicateDiagnostics(&result.Diagnostics, predicateDiagnostics, 0, 0)
+	readCache, err := newColumnPhysicalAssetReadCacheWithIntegrity(view.ColumnAssetRootDir, view.AssetNamespace, req.ColumnAssetReadIntegrity)
+	if err != nil {
+		result.Diagnostics.ScanNanos = time.Since(start).Nanoseconds()
+		return result, true, err
+	}
+	defer func() { _ = readCache.close() }()
+	refsByGeneration, err := typedColumnPhysicalQueryRefsByGeneration(view)
+	if err != nil {
+		result.Diagnostics.ScanNanos = time.Since(start).Nanoseconds()
+		return result, true, err
+	}
+	if err := validateTypedColumnMultipartAssetPairing(refsByGeneration, view.AssetRefs); err != nil {
+		result.Diagnostics.ScanNanos = time.Since(start).Nanoseconds()
+		return result, true, err
+	}
+	var visibilityDiag TypedColumnInt64PredicateScanDiagnostics
+	state, err := buildTypedColumnLatestVisibilityState(view, &readCache, &visibilityDiag)
+	result.Diagnostics.PhysicalBytesScanned += visibilityDiag.PhysicalBytesScanned
+	result.Diagnostics.SegmentFileCacheHits = visibilityDiag.SegmentFileCacheHits
+	result.Diagnostics.SegmentFileCacheMisses = visibilityDiag.SegmentFileCacheMisses
+	if state != nil {
+		result.Diagnostics.RowsScanned = state.CandidateRows
+		result.Diagnostics.DeletedRows = state.DeletedRows
+		result.Diagnostics.VisibilityRows = state.VisibleRows
+	}
+	result.Diagnostics.ScanNanos = time.Since(start).Nanoseconds()
+	result.Diagnostics.VisibilityNanos = result.Diagnostics.ScanNanos
+	if err != nil {
+		return result, true, err
+	}
+	if typedColumnRefsHaveSortKey(refsByGeneration) {
+		return result, true, typedColumnSortedMutationVisibilityUnsupported("typed-column part physical query")
+	}
+	return result, true, fmt.Errorf("%w: typed-column part physical query with mutation visibility is deferred to multipart reducers", ErrColumnQueryPlanUnsupported)
 }
 
 func prepareColumnTypedColumnPhysicalQueryRunner(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest, readCache *columnPhysicalAssetReadCache) (*columnTypedColumnPhysicalQueryRunner, bool, error) {

--- a/TreeDB/collections/typed_column_latest_visibility.go
+++ b/TreeDB/collections/typed_column_latest_visibility.go
@@ -33,6 +33,41 @@ type typedColumnLatestCandidate struct {
 	deleted    bool
 }
 
+type typedColumnLatestVisibilityState struct {
+	resolver       *typedColumnLatestRowResolver
+	PhysicalParts  int
+	TombstoneParts int
+	CandidateRows  int
+	DeletedRows    int
+	VisibleRows    int
+}
+
+func buildTypedColumnLatestVisibilityState(view columnPhysicalScanSnapshotView, readCache *columnPhysicalAssetReadCache, diag *TypedColumnInt64PredicateScanDiagnostics) (*typedColumnLatestVisibilityState, error) {
+	resolver, err := buildTypedColumnLatestRowResolver(view, readCache, diag)
+	if err != nil {
+		return nil, err
+	}
+	state := &typedColumnLatestVisibilityState{resolver: resolver, CandidateRows: len(resolver.candidates)}
+	for _, part := range resolver.parts {
+		state.PhysicalParts++
+		if part.Role == ColumnManifestPartRoleTombstone {
+			state.TombstoneParts++
+		}
+		for _, word := range part.visibleBits {
+			for word != 0 {
+				state.VisibleRows++
+				word &= word - 1
+			}
+		}
+	}
+	for _, candidate := range resolver.candidates {
+		if candidate.deleted {
+			state.DeletedRows++
+		}
+	}
+	return state, nil
+}
+
 func buildTypedColumnLatestRowResolver(view columnPhysicalScanSnapshotView, readCache *columnPhysicalAssetReadCache, diag *TypedColumnInt64PredicateScanDiagnostics) (*typedColumnLatestRowResolver, error) {
 	if readCache == nil {
 		return nil, errors.New("collections: typed-column latest-visible resolver requires read cache")


### PR DESCRIPTION
## Summary

First reviewable chunk for #1953 multipart visibility work (C1: routing/diagnostics groundwork).

- Routes mutation-bearing typed-column physical query candidates through the typed-column planner before the generic predicate insert-only rejection.
- Adds explicit `mutation_visibility_unsupported` fallback diagnostics for typed-column multipart paths that are not implemented yet.
- Builds lightweight latest-visible typed-column visibility state from existing manifest/physical row/tombstone assets so diagnostics report candidate, visible, and deleted rows without document fallback.
- Keeps prepared mutation-bearing physical queries fail-closed; #1954 lifecycle/pinning remains out of scope.
- Adds q2 regression coverage proving insert-only q2 still uses the optimized typed-column path, while mutation-bearing q2 fails closed with typed-column mutation-visibility diagnostics and no row/document materialization.

This PR intentionally does **not** implement the dense/sorted multipart reducers. Follow-up chunks for #1953 remain:

- C2 q1/q3/q5 dense latest-visible reducers.
- C3 q2/q4b sorted multipart merge.
- C4 q4a time-order multipart merge.
- C5 compaction + metadata rebuild/invalidation.

## Validation

- `go test ./TreeDB/collections -run 'TestTypedColumnQ2MutationVisibilityFailsClosedC1|TestTypedColumnQ2SortedGroupedDistinctStreaming1950|TestColumnPhysicalQ1DenseTypedColumnDirectPreparedParity1950|TestColumnPhysicalQ3DenseTypedColumnDirectPreparedParity1950|TestColumnPhysicalQ4ATimeOrderTopKDirectPreparedParity1950|TestTypedColumnQ4BTopKMarkPrunedParity1950|TestColumnPhysicalQ5DenseTypedColumnDirectPreparedParity1950|TestColumnPhysicalQueryAdapterAppliesMutationVisibilityM13C'`
- `go test ./TreeDB/caching -run TestVlogGenerationRewriteQueue_BoundedSegmentEventuallyDrainsWithoutReplanning -count=1` (reran after one unrelated full-suite flake)
- `go test ./TreeDB/...` (rerun passed)
- `go test ./TreeDB/collections -run '^$' -bench 'BenchmarkTypedColumnQ2SortedGroupedDistinct1950/direct/sorted_prefix' -benchtime=20x -count=1`

Benchmark artifact: `/tmp/orca_issue_graph_1945_1955/1953_c1_bench_q2_sorted_prefix_20x.txt`

Selected benchmark result (Apple M3, 20x):

- q2 direct sorted-prefix insert-only: `14,325,498 ns/op`, `65,536 rows_scanned/op`, `59,553 rows_matched/op`, `52,685,741 B/op`, `8,890 allocs/op`.

Refs #1953.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of typed-column queries when the database contains mutations (updates). The system now provides more granular fallback behavior and enhanced diagnostics when mutation visibility constraints are encountered, ensuring queries fail safely with clearer error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->