### PR TITLE
Typed-column latest-visible dense q1/q3/q5 reducers

### DIFF
--- a/TreeDB/collections/column_physical_latest_visible_1953_test.go
+++ b/TreeDB/collections/column_physical_latest_visible_1953_test.go
@@ -1,0 +1,409 @@
+package collections
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+)
+
+func TestColumnPhysicalQ1DenseLatestVisibleMutation1953(t *testing.T) {
+	batches := columnPhysicalQ1DenseEventBatches1950([][]string{
+		{"app.m", "app.z", "app.m", "app.z"},
+		{"app.a", "app.m", "app.a", "app.m"},
+	})
+	_, _, col, closeFn := openTypedColumnLatestVisibleFixture1953(t, nil, batches)
+	defer closeFn()
+
+	latest := latestEventMap1953(flattenColumnPhysicalEvents1950(batches))
+	updated := latest["doc_00_000000"]
+	updated.Collection = "app.updated"
+	updated.TimeUS += 77
+	updateTypedColumnEvent1953(t, col, updated)
+	latest[updated.ID] = updated
+	deleteTypedColumnEvent1953(t, col, "doc_01_000001")
+	delete(latest, "doc_01_000001")
+
+	want := collectionCounts1953(latestEvents1953(latest))
+	result, err := col.RunColumnPhysicalQuery(ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount, GroupColumn: "collection"})
+	if err != nil {
+		t.Fatalf("RunColumnPhysicalQuery(q1 latest-visible): %v", err)
+	}
+	if got := columnPhysicalGroupCountMap1953(result.Groups); !reflect.DeepEqual(got, want) {
+		t.Fatalf("q1 latest-visible groups=%v want %v full=%+v", got, want, result.Groups)
+	}
+	assertLatestVisibleDenseDiagnostics1953(t, "q1", result.Diagnostics, len(latest), -1, "q1")
+	assertPreparedMutationFailsClosed1953(t, col, ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount, GroupColumn: "collection"})
+}
+
+func TestColumnPhysicalQ3DenseLatestVisibleMutationReopen1953(t *testing.T) {
+	batches := [][]columnPhysicalJSONBenchParityEventP0{columnPhysicalQ3DenseBatchA1950(), columnPhysicalQ3DenseBatchB1950()}
+	dir, d, col, closeFn := openTypedColumnLatestVisibleFixture1953(t, nil, batches)
+	latest := latestEventMap1953(flattenColumnPhysicalEvents1950(batches))
+
+	promoted := latest["a-kind-guard"]
+	promoted.Kind = "commit"
+	promoted.Operation = "create"
+	promoted.Collection = "app.bsky.feed.post"
+	promoted.TimeUS += 11
+	updateTypedColumnEvent1953(t, col, promoted)
+	latest[promoted.ID] = promoted
+
+	demoted := latest["b-post-1"]
+	demoted.Operation = "delete"
+	demoted.TimeUS += 13
+	updateTypedColumnEvent1953(t, col, demoted)
+	latest[demoted.ID] = demoted
+
+	deleteTypedColumnEvent1953(t, col, "a-like-1")
+	delete(latest, "a-like-1")
+
+	_, col, closeFn = checkpointAndReopenTypedColumnLatestVisibleFixture1953(t, dir, d, closeFn)
+	defer closeFn()
+
+	live := latestEvents1953(latest)
+	want := columnPhysicalQ3DenseReferenceGroups1950(live)
+	matchedRows := columnPhysicalJSONBenchReferenceMatchedRowsP0("q3", live)
+	result, err := col.RunColumnPhysicalQuery(columnPhysicalQ3DenseRequest1950())
+	if err != nil {
+		t.Fatalf("RunColumnPhysicalQuery(q3 latest-visible): %v", err)
+	}
+	if !reflect.DeepEqual(result.Groups, want) {
+		t.Fatalf("q3 latest-visible groups=%+v want %+v", result.Groups, want)
+	}
+	assertLatestVisibleDenseDiagnostics1953(t, "q3", result.Diagnostics, len(live), matchedRows, "q3")
+	assertPreparedMutationFailsClosed1953(t, col, columnPhysicalQ3DenseRequest1950())
+}
+
+func TestColumnPhysicalQ5DenseLatestVisibleMutation1953(t *testing.T) {
+	batches := [][]columnPhysicalJSONBenchParityEventP0{columnPhysicalQ5DenseBatchA1950(), columnPhysicalQ5DenseBatchB1950()}
+	_, _, col, closeFn := openTypedColumnLatestVisibleFixture1953(t, nil, batches)
+	defer closeFn()
+	latest := latestEventMap1953(flattenColumnPhysicalEvents1950(batches))
+
+	promoted := latest["a-kind-guard"]
+	promoted.Kind = "commit"
+	promoted.Operation = "create"
+	promoted.Collection = "app.bsky.feed.post"
+	promoted.Did = "did:beta"
+	promoted.TimeUS += 500
+	updateTypedColumnEvent1953(t, col, promoted)
+	latest[promoted.ID] = promoted
+
+	moved := latest["a-collection-guard"]
+	moved.Collection = "app.bsky.feed.post"
+	moved.Did = "did:epsilon"
+	moved.TimeUS += 300
+	updateTypedColumnEvent1953(t, col, moved)
+	latest[moved.ID] = moved
+
+	deleteTypedColumnEvent1953(t, col, "b-m-3")
+	delete(latest, "b-m-3")
+
+	live := latestEvents1953(latest)
+	req := columnPhysicalQ5DenseRequest1950()
+	want := columnPhysicalQ5DenseReferenceGroups1950(live, req.TopK)
+	matchedRows := columnPhysicalJSONBenchReferenceMatchedRowsP0("q5", live)
+	result, err := col.RunColumnPhysicalQuery(req)
+	if err != nil {
+		t.Fatalf("RunColumnPhysicalQuery(q5 latest-visible): %v", err)
+	}
+	if !reflect.DeepEqual(result.Groups, want) {
+		t.Fatalf("q5 latest-visible groups=%+v want %+v", result.Groups, want)
+	}
+	assertLatestVisibleDenseDiagnostics1953(t, "q5", result.Diagnostics, len(live), matchedRows, "q5")
+	assertPreparedMutationFailsClosed1953(t, col, req)
+}
+
+func TestColumnPhysicalSortedMutationShapesStillFailClosed1953(t *testing.T) {
+	t.Run("q2", func(t *testing.T) {
+		batches := [][]columnPhysicalJSONBenchParityEventP0{typedColumnQ2SortedBatchA1950(), typedColumnQ2SortedBatchB1950()}
+		_, _, col, closeFn := openTypedColumnLatestVisibleFixture1953(t, typedColumnQ2ClickHouseSortKey1950(), batches)
+		defer closeFn()
+		updated := typedColumnQ2SortedBatchA1950()[0]
+		updated.Collection = "app.bsky.feed.like"
+		updateTypedColumnEvent1953(t, col, updated)
+		assertSortedMutationUnsupported1953(t, "q2", col, typedColumnQ2Request1950())
+	})
+
+	t.Run("q4b", func(t *testing.T) {
+		events := typedColumnQ4BTopKTieBreakEvents1950()
+		_, _, col, closeFn := openTypedColumnLatestVisibleFixture1953(t, typedColumnQ4BTopKClickHouseSortKey1950(), [][]columnPhysicalJSONBenchParityEventP0{events})
+		defer closeFn()
+		updated := events[0]
+		updated.TimeUS += 17
+		updateTypedColumnEvent1953(t, col, updated)
+		assertSortedMutationUnsupported1953(t, "q4b", col, typedColumnQ4BTopKRequest1950())
+	})
+
+	t.Run("q4a", func(t *testing.T) {
+		batches := columnPhysicalQ4ATimeOrderBatches1950(8)
+		_, _, col, closeFn := openTypedColumnLatestVisibleFixture1953(t, []ColumnSortKey{{Column: "time_us"}}, batches)
+		defer closeFn()
+		updated := batches[0][0]
+		updated.Kind = "commit"
+		updated.TimeUS += 19
+		updateTypedColumnEvent1953(t, col, updated)
+		assertSortedMutationUnsupported1953(t, "q4a", col, columnPhysicalQ4ATimeOrderRequest1950())
+	})
+}
+
+func BenchmarkColumnPhysicalDenseLatestVisible1953(b *testing.B) {
+	cases := []struct {
+		name    string
+		batches [][]columnPhysicalJSONBenchParityEventP0
+		req     ColumnPhysicalQueryRequest
+		mutate  func(testing.TB, *Collection)
+	}{
+		{
+			name:    "q1_insert_only",
+			batches: columnPhysicalQ1DenseEventBatches1950([][]string{{"app.m", "app.z", "app.m", "app.z"}, {"app.a", "app.m", "app.a", "app.m"}}),
+			req:     ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount, GroupColumn: "collection"},
+		},
+		{
+			name:    "q1_latest_visible",
+			batches: columnPhysicalQ1DenseEventBatches1950([][]string{{"app.m", "app.z", "app.m", "app.z"}, {"app.a", "app.m", "app.a", "app.m"}}),
+			req:     ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount, GroupColumn: "collection"},
+			mutate: func(tb testing.TB, col *Collection) {
+				updateTypedColumnEvent1953(tb, col, columnPhysicalJSONBenchParityEventP0{ID: "doc_00_000000", TimeUS: 1_900_000_000_000_000, Kind: "commit", Operation: "create", Collection: "app.updated", Did: "did:q1:000000"})
+				deleteTypedColumnEvent1953(tb, col, "doc_01_000001")
+			},
+		},
+		{
+			name:    "q3_insert_only",
+			batches: [][]columnPhysicalJSONBenchParityEventP0{columnPhysicalQ3DenseBenchmarkEvents1950(2048)},
+			req:     columnPhysicalQ3DenseRequest1950(),
+		},
+		{
+			name:    "q3_latest_visible",
+			batches: [][]columnPhysicalJSONBenchParityEventP0{columnPhysicalQ3DenseBenchmarkEvents1950(2048)},
+			req:     columnPhysicalQ3DenseRequest1950(),
+			mutate: func(tb testing.TB, col *Collection) {
+				updateTypedColumnEvent1953(tb, col, columnPhysicalJSONBenchParityEventP0{ID: "q3-bench-000019", TimeUS: 1_960_000_000_000_000, Kind: "commit", Operation: "create", Collection: "app.bsky.feed.post", Did: "did:q3:0019"})
+				deleteTypedColumnEvent1953(tb, col, "q3-bench-000001")
+			},
+		},
+		{
+			name:    "q5_insert_only",
+			batches: [][]columnPhysicalJSONBenchParityEventP0{columnPhysicalQ5DenseBenchmarkEvents1950(2048)},
+			req:     columnPhysicalQ5DenseRequest1950(),
+		},
+		{
+			name:    "q5_latest_visible",
+			batches: [][]columnPhysicalJSONBenchParityEventP0{columnPhysicalQ5DenseBenchmarkEvents1950(2048)},
+			req:     columnPhysicalQ5DenseRequest1950(),
+			mutate: func(tb testing.TB, col *Collection) {
+				updateTypedColumnEvent1953(tb, col, columnPhysicalJSONBenchParityEventP0{ID: "q5-bench-000023", TimeUS: 1_950_000_000_999_999, Kind: "commit", Operation: "create", Collection: "app.bsky.feed.post", Did: "did:q5:0023"})
+				deleteTypedColumnEvent1953(tb, col, "q5-bench-000001")
+			},
+		},
+	}
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			_, _, col, closeFn := openTypedColumnLatestVisibleFixture1953(b, nil, tc.batches)
+			defer closeFn()
+			if tc.mutate != nil {
+				tc.mutate(b, col)
+			}
+			preview, err := col.RunColumnPhysicalQuery(tc.req)
+			if err != nil {
+				b.Fatalf("preview RunColumnPhysicalQuery: %v", err)
+			}
+			b.ReportAllocs()
+			b.SetBytes(preview.Diagnostics.PhysicalBytesScanned)
+			b.ResetTimer()
+			var last ColumnPhysicalQueryDiagnostics
+			var groups int
+			for i := 0; i < b.N; i++ {
+				result, err := col.RunColumnPhysicalQuery(tc.req)
+				if err != nil {
+					b.Fatalf("RunColumnPhysicalQuery: %v", err)
+				}
+				groups += len(result.Groups)
+				last = result.Diagnostics
+			}
+			b.StopTimer()
+			if groups == 0 {
+				b.Fatal("benchmark produced no groups")
+			}
+			b.ReportMetric(float64(last.RowsScanned), "rows_scanned/op")
+			b.ReportMetric(float64(last.RowsMatched), "rows_matched/op")
+			b.ReportMetric(float64(last.ReduceRows), "reduce_rows/op")
+			b.ReportMetric(float64(last.VisibilityRows), "visibility_rows/op")
+			b.ReportMetric(float64(last.DeletedRows), "deleted_rows/op")
+			b.ReportMetric(float64(last.TypedColumnPartSections), "typed_sections/op")
+		})
+	}
+}
+
+func openTypedColumnLatestVisibleFixture1953(tb testing.TB, sortKey []ColumnSortKey, batches [][]columnPhysicalJSONBenchParityEventP0) (string, *backenddb.DB, *Collection, func()) {
+	tb.Helper()
+	dir := tb.TempDir()
+	if err := backenddb.SaveFormatConfig(dir, backenddb.FormatConfig{RequiredFeatures: []string{backenddb.RequiredFeatureCommandWALV1}}); err != nil {
+		tb.Fatalf("SaveFormatConfig: %v", err)
+	}
+	d, err := backenddb.Open(backenddb.Options{Dir: dir, DisableBackgroundPrune: true})
+	if err != nil {
+		tb.Fatalf("Open setup DB: %v", err)
+	}
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "events", Options: CollectionOptions{ColumnStore: typedColumnSortKeyConfig1948(sortKey)}}); err != nil {
+		_ = d.Close()
+		tb.Fatalf("CreateCollection: %v", err)
+	}
+	col, err := mgr.OpenCollection("events")
+	if err != nil {
+		_ = d.Close()
+		tb.Fatalf("OpenCollection setup: %v", err)
+	}
+	for batchIdx, batch := range batches {
+		ids := make([][]byte, len(batch))
+		docs := make([][]byte, len(batch))
+		for i, event := range batch {
+			ids[i] = []byte(event.ID)
+			docs[i] = typedColumnEventDocument1953(event)
+		}
+		if _, err := col.InsertBatch(ids, docs); err != nil {
+			_ = d.Close()
+			tb.Fatalf("InsertBatch[%d]: %v", batchIdx, err)
+		}
+	}
+	if err := d.Checkpoint(); err != nil {
+		_ = d.Close()
+		tb.Fatalf("Checkpoint setup: %v", err)
+	}
+	return dir, d, col, func() { _ = d.Close() }
+}
+
+func checkpointAndReopenTypedColumnLatestVisibleFixture1953(tb testing.TB, dir string, d *backenddb.DB, closeFn func()) (*backenddb.DB, *Collection, func()) {
+	tb.Helper()
+	if err := d.Checkpoint(); err != nil {
+		tb.Fatalf("Checkpoint before reopen: %v", err)
+	}
+	if closeFn != nil {
+		closeFn()
+	}
+	reopen, err := backenddb.Open(backenddb.Options{Dir: dir, DisableBackgroundPrune: true})
+	if err != nil {
+		tb.Fatalf("Open reopened DB: %v", err)
+	}
+	reopened, err := NewCollectionManager(reopen).OpenCollection("events")
+	if err != nil {
+		_ = reopen.Close()
+		tb.Fatalf("OpenCollection reopened: %v", err)
+	}
+	return reopen, reopened, func() { _ = reopen.Close() }
+}
+
+func typedColumnEventDocument1953(event columnPhysicalJSONBenchParityEventP0) []byte {
+	return []byte(fmt.Sprintf(`{"time_us":%d,"kind":%q,"operation":%q,"collection":%q,"did":%q}`, event.TimeUS, event.Kind, event.Operation, event.Collection, event.Did))
+}
+
+func updateTypedColumnEvent1953(tb testing.TB, col *Collection, event columnPhysicalJSONBenchParityEventP0) {
+	tb.Helper()
+	_, modified, err := col.Update([]byte(event.ID), func([]byte) ([]byte, bool, error) {
+		return typedColumnEventDocument1953(event), true, nil
+	})
+	if err != nil || !modified {
+		tb.Fatalf("Update %s modified=%t err=%v", event.ID, modified, err)
+	}
+}
+
+func deleteTypedColumnEvent1953(tb testing.TB, col *Collection, id string) {
+	tb.Helper()
+	deleted, err := col.DeleteBatch([][]byte{[]byte(id)})
+	if err != nil || deleted != 1 {
+		tb.Fatalf("DeleteBatch %s deleted=%d err=%v", id, deleted, err)
+	}
+}
+
+func latestEventMap1953(events []columnPhysicalJSONBenchParityEventP0) map[string]columnPhysicalJSONBenchParityEventP0 {
+	latest := make(map[string]columnPhysicalJSONBenchParityEventP0, len(events))
+	for _, event := range events {
+		latest[event.ID] = event
+	}
+	return latest
+}
+
+func latestEvents1953(latest map[string]columnPhysicalJSONBenchParityEventP0) []columnPhysicalJSONBenchParityEventP0 {
+	out := make([]columnPhysicalJSONBenchParityEventP0, 0, len(latest))
+	for _, event := range latest {
+		out = append(out, event)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return out
+}
+
+func collectionCounts1953(events []columnPhysicalJSONBenchParityEventP0) map[string]int {
+	counts := make(map[string]int)
+	for _, event := range events {
+		counts[event.Collection]++
+	}
+	return counts
+}
+
+func columnPhysicalGroupCountMap1953(groups []ColumnPhysicalQueryGroup) map[string]int {
+	out := make(map[string]int, len(groups))
+	for _, group := range groups {
+		out[group.Key] = group.Count
+	}
+	return out
+}
+
+func assertLatestVisibleDenseDiagnostics1953(tb testing.TB, label string, diag ColumnPhysicalQueryDiagnostics, visibleRows int, matchedRows int, shape string) {
+	tb.Helper()
+	if diag.StorageSource != ColumnPhysicalQueryStorageSourceTypedColumnPartSection || diag.FallbackReason != ColumnPhysicalQueryFallbackNone {
+		tb.Fatalf("%s diagnostics storage/fallback=%+v want latest-visible typed-column path", label, diag)
+	}
+	if diag.MutationParts == 0 || diag.VisibilityRows != visibleRows || diag.DeletedRows == 0 {
+		tb.Fatalf("%s visibility diagnostics=%+v want mutation parts, visible=%d, deleted rows", label, diag, visibleRows)
+	}
+	if diag.RowMaterializations != 0 || diag.DocumentMaterializations != 0 || diag.ReconstructionRows != 0 {
+		tb.Fatalf("%s materialization diagnostics=%+v want zero row/document reconstruction", label, diag)
+	}
+	if diag.TypedColumnPartSections == 0 || diag.TypedColumnPartSectionBytes == 0 || diag.DecodedBlocks == 0 || diag.PhysicalBytesScanned == 0 {
+		tb.Fatalf("%s typed-column diagnostics=%+v want section/decode/byte counters", label, diag)
+	}
+	if diag.RowsScanned < visibleRows {
+		tb.Fatalf("%s rows scanned=%d visible=%d diagnostics=%+v", label, diag.RowsScanned, visibleRows, diag)
+	}
+	switch shape {
+	case "q1":
+		if !diag.DenseGroupCountUsed || diag.RowsMatched != 0 || diag.ReduceRows != visibleRows || diag.PredicateCount != 0 {
+			tb.Fatalf("%s q1 diagnostics=%+v want dense group-count over visible rows", label, diag)
+		}
+	case "q3":
+		if !diag.DenseGroupHourCountUsed || diag.RowsMatched != matchedRows || diag.ReduceRows != matchedRows || diag.PredicateCount != 3 {
+			tb.Fatalf("%s q3 diagnostics=%+v want dense grouped-hour matched=%d", label, diag, matchedRows)
+		}
+	case "q5":
+		if !diag.DenseInt64SpanUsed || diag.RowsMatched != matchedRows || diag.ReduceRows != matchedRows || diag.PredicateCount != 3 || diag.TopKLimit == 0 || diag.TopKCandidates == 0 {
+			tb.Fatalf("%s q5 diagnostics=%+v want dense int64-span topK matched=%d", label, diag, matchedRows)
+		}
+	default:
+		tb.Fatalf("unknown shape %q", shape)
+	}
+}
+
+func assertSortedMutationUnsupported1953(tb testing.TB, label string, col *Collection, req ColumnPhysicalQueryRequest) {
+	tb.Helper()
+	result, err := col.RunColumnPhysicalQuery(req)
+	if !errors.Is(err, ErrColumnQueryPlanUnsupported) || !strings.Contains(err.Error(), "mutation visibility") {
+		tb.Fatalf("%s sorted mutation err=%v diagnostics=%+v want mutation visibility fail-closed", label, err, result.Diagnostics)
+	}
+	if result.Diagnostics.StorageSource != ColumnPhysicalQueryStorageSourceTypedColumnPartSection || result.Diagnostics.FallbackReason != ColumnPhysicalQueryFallbackMutationVisibilityUnsupported || result.Diagnostics.VisibilityRows == 0 || result.Diagnostics.MutationParts == 0 {
+		tb.Fatalf("%s sorted mutation diagnostics=%+v want explicit typed-column unsupported visibility", label, result.Diagnostics)
+	}
+}
+
+func assertPreparedMutationFailsClosed1953(tb testing.TB, col *Collection, req ColumnPhysicalQueryRequest) {
+	tb.Helper()
+	_, err := col.PrepareColumnPhysicalQuery(req)
+	if !errors.Is(err, ErrColumnQueryPlanUnsupported) || !strings.Contains(err.Error(), "insert-only") || !strings.Contains(err.Error(), "lifecycle") {
+		tb.Fatalf("PrepareColumnPhysicalQuery mutation err=%v want insert-only/lifecycle fail-closed", err)
+	}
+}

--- a/TreeDB/collections/column_physical_latest_visible_1953_test.go
+++ b/TreeDB/collections/column_physical_latest_visible_1953_test.go
@@ -142,6 +142,43 @@ func TestColumnPhysicalQ5DenseLatestVisibleMutation1953(t *testing.T) {
 	assertPreparedMutationFailsClosed1953(t, col, req)
 }
 
+func TestColumnPhysicalNonDenseNoPredicateMutationUsesTypedLatestVisible1953(t *testing.T) {
+	batches := [][]columnPhysicalJSONBenchParityEventP0{{
+		{ID: "a1", TimeUS: 100, Kind: "commit", Operation: "create", Collection: "app.test", Did: "did:a"},
+		{ID: "b1", TimeUS: 200, Kind: "commit", Operation: "create", Collection: "app.test", Did: "did:b"},
+		{ID: "c1", TimeUS: 50, Kind: "commit", Operation: "create", Collection: "app.test", Did: "did:c"},
+	}, {
+		{ID: "a2", TimeUS: 90, Kind: "commit", Operation: "create", Collection: "app.test", Did: "did:a"},
+		{ID: "b2", TimeUS: 210, Kind: "commit", Operation: "create", Collection: "app.test", Did: "did:b"},
+	}}
+	_, _, col, closeFn := openTypedColumnLatestVisibleFixture1953(t, nil, batches)
+	defer closeFn()
+	events := flattenColumnPhysicalEvents1950(batches)
+	latest := latestEventMap1953(events)
+	updated := latest["a1"]
+	updated.TimeUS = 80
+	updateTypedColumnEvent1953(t, col, updated)
+	latest[updated.ID] = updated
+	deleteTypedColumnEvent1953(t, col, "c1")
+	delete(latest, "c1")
+
+	req := ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupMinInt64, GroupColumn: "did", ValueColumn: "time_us"}
+	result, err := col.RunColumnPhysicalQuery(req)
+	if err != nil {
+		t.Fatalf("RunColumnPhysicalQuery(non-dense no-predicate latest-visible): %v", err)
+	}
+	if got, want := columnPhysicalGroupInt64Map1953(result.Groups), didMinTimes1953(latestEvents1953(latest)); !reflect.DeepEqual(got, want) {
+		t.Fatalf("non-dense visibility overlay groups=%v want %v full=%+v", got, want, result.Groups)
+	}
+	if result.Diagnostics.StorageSource != ColumnPhysicalQueryStorageSourceTypedColumnPartSection || result.Diagnostics.FallbackReason != ColumnPhysicalQueryFallbackNone {
+		t.Fatalf("non-dense diagnostics=%+v want typed-column latest-visible path", result.Diagnostics)
+	}
+	if result.Diagnostics.MutationParts == 0 || result.Diagnostics.VisibilityRows != len(latest) || result.Diagnostics.RowMaterializations != 0 || result.Diagnostics.DocumentMaterializations != 0 {
+		t.Fatalf("non-dense visibility diagnostics=%+v want latest-visible typed-column merge without document materialization", result.Diagnostics)
+	}
+	assertPreparedMutationFailsClosed1953(t, col, req)
+}
+
 func TestColumnPhysicalSortedMutationShapesStillFailClosed1953(t *testing.T) {
 	t.Run("q2", func(t *testing.T) {
 		batches := [][]columnPhysicalJSONBenchParityEventP0{typedColumnQ2SortedBatchA1950(), typedColumnQ2SortedBatchB1950()}
@@ -412,6 +449,25 @@ func columnPhysicalGroupCountMap1953(groups []ColumnPhysicalQueryGroup) map[stri
 	out := make(map[string]int, len(groups))
 	for _, group := range groups {
 		out[group.Key] = group.Count
+	}
+	return out
+}
+
+func columnPhysicalGroupInt64Map1953(groups []ColumnPhysicalQueryGroup) map[string]int64 {
+	out := make(map[string]int64, len(groups))
+	for _, group := range groups {
+		out[group.Key] = group.Int64
+	}
+	return out
+}
+
+func didMinTimes1953(events []columnPhysicalJSONBenchParityEventP0) map[string]int64 {
+	out := make(map[string]int64)
+	for _, event := range events {
+		cur, ok := out[event.Did]
+		if !ok || event.TimeUS < cur {
+			out[event.Did] = event.TimeUS
+		}
 	}
 	return out
 }

--- a/TreeDB/collections/column_physical_latest_visible_1953_test.go
+++ b/TreeDB/collections/column_physical_latest_visible_1953_test.go
@@ -19,14 +19,17 @@ func TestColumnPhysicalQ1DenseLatestVisibleMutation1953(t *testing.T) {
 	_, _, col, closeFn := openTypedColumnLatestVisibleFixture1953(t, nil, batches)
 	defer closeFn()
 
-	latest := latestEventMap1953(flattenColumnPhysicalEvents1950(batches))
-	updated := latest["doc_00_000000"]
+	events := flattenColumnPhysicalEvents1950(batches)
+	latest := latestEventMap1953(events)
+	updateID := events[0].ID
+	deleteID := events[len(events)-1].ID
+	updated := latest[updateID]
 	updated.Collection = "app.updated"
 	updated.TimeUS += 77
 	updateTypedColumnEvent1953(t, col, updated)
 	latest[updated.ID] = updated
-	deleteTypedColumnEvent1953(t, col, "doc_01_000001")
-	delete(latest, "doc_01_000001")
+	deleteTypedColumnEvent1953(t, col, deleteID)
+	delete(latest, deleteID)
 
 	want := collectionCounts1953(latestEvents1953(latest))
 	result, err := col.RunColumnPhysicalQuery(ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount, GroupColumn: "collection"})
@@ -43,9 +46,13 @@ func TestColumnPhysicalQ1DenseLatestVisibleMutation1953(t *testing.T) {
 func TestColumnPhysicalQ3DenseLatestVisibleMutationReopen1953(t *testing.T) {
 	batches := [][]columnPhysicalJSONBenchParityEventP0{columnPhysicalQ3DenseBatchA1950(), columnPhysicalQ3DenseBatchB1950()}
 	dir, d, col, closeFn := openTypedColumnLatestVisibleFixture1953(t, nil, batches)
-	latest := latestEventMap1953(flattenColumnPhysicalEvents1950(batches))
+	events := flattenColumnPhysicalEvents1950(batches)
+	latest := latestEventMap1953(events)
 
-	promoted := latest["a-kind-guard"]
+	promoteID := pickEventID1953(t, events, func(event columnPhysicalJSONBenchParityEventP0) bool {
+		return event.Kind == "identity" && event.Operation == "create" && event.Collection == "app.bsky.feed.post"
+	})
+	promoted := latest[promoteID]
 	promoted.Kind = "commit"
 	promoted.Operation = "create"
 	promoted.Collection = "app.bsky.feed.post"
@@ -53,14 +60,20 @@ func TestColumnPhysicalQ3DenseLatestVisibleMutationReopen1953(t *testing.T) {
 	updateTypedColumnEvent1953(t, col, promoted)
 	latest[promoted.ID] = promoted
 
-	demoted := latest["b-post-1"]
+	demoteID := pickEventID1953(t, events, func(event columnPhysicalJSONBenchParityEventP0) bool {
+		return event.ID != promoteID && columnPhysicalJSONBenchReferenceMatchP0("q3", event) && event.Collection == "app.bsky.feed.post"
+	})
+	demoted := latest[demoteID]
 	demoted.Operation = "delete"
 	demoted.TimeUS += 13
 	updateTypedColumnEvent1953(t, col, demoted)
 	latest[demoted.ID] = demoted
 
-	deleteTypedColumnEvent1953(t, col, "a-like-1")
-	delete(latest, "a-like-1")
+	deleteID := pickEventID1953(t, events, func(event columnPhysicalJSONBenchParityEventP0) bool {
+		return event.ID != promoteID && event.ID != demoteID && columnPhysicalJSONBenchReferenceMatchP0("q3", event)
+	})
+	deleteTypedColumnEvent1953(t, col, deleteID)
+	delete(latest, deleteID)
 
 	_, col, closeFn = checkpointAndReopenTypedColumnLatestVisibleFixture1953(t, dir, d, closeFn)
 	defer closeFn()
@@ -83,9 +96,13 @@ func TestColumnPhysicalQ5DenseLatestVisibleMutation1953(t *testing.T) {
 	batches := [][]columnPhysicalJSONBenchParityEventP0{columnPhysicalQ5DenseBatchA1950(), columnPhysicalQ5DenseBatchB1950()}
 	_, _, col, closeFn := openTypedColumnLatestVisibleFixture1953(t, nil, batches)
 	defer closeFn()
-	latest := latestEventMap1953(flattenColumnPhysicalEvents1950(batches))
+	events := flattenColumnPhysicalEvents1950(batches)
+	latest := latestEventMap1953(events)
 
-	promoted := latest["a-kind-guard"]
+	promoteID := pickEventID1953(t, events, func(event columnPhysicalJSONBenchParityEventP0) bool {
+		return event.Kind == "identity" && event.Collection == "app.bsky.feed.post"
+	})
+	promoted := latest[promoteID]
 	promoted.Kind = "commit"
 	promoted.Operation = "create"
 	promoted.Collection = "app.bsky.feed.post"
@@ -94,15 +111,21 @@ func TestColumnPhysicalQ5DenseLatestVisibleMutation1953(t *testing.T) {
 	updateTypedColumnEvent1953(t, col, promoted)
 	latest[promoted.ID] = promoted
 
-	moved := latest["a-collection-guard"]
+	moveID := pickEventID1953(t, events, func(event columnPhysicalJSONBenchParityEventP0) bool {
+		return event.ID != promoteID && event.Kind == "commit" && event.Operation == "create" && event.Collection != "app.bsky.feed.post"
+	})
+	moved := latest[moveID]
 	moved.Collection = "app.bsky.feed.post"
 	moved.Did = "did:epsilon"
 	moved.TimeUS += 300
 	updateTypedColumnEvent1953(t, col, moved)
 	latest[moved.ID] = moved
 
-	deleteTypedColumnEvent1953(t, col, "b-m-3")
-	delete(latest, "b-m-3")
+	deleteID := pickEventID1953(t, events, func(event columnPhysicalJSONBenchParityEventP0) bool {
+		return event.ID != promoteID && event.ID != moveID && columnPhysicalJSONBenchReferenceMatchP0("q5", event)
+	})
+	deleteTypedColumnEvent1953(t, col, deleteID)
+	delete(latest, deleteID)
 
 	live := latestEvents1953(latest)
 	req := columnPhysicalQ5DenseRequest1950()
@@ -157,7 +180,7 @@ func BenchmarkColumnPhysicalDenseLatestVisible1953(b *testing.B) {
 		name    string
 		batches [][]columnPhysicalJSONBenchParityEventP0
 		req     ColumnPhysicalQueryRequest
-		mutate  func(testing.TB, *Collection)
+		mutate  func(testing.TB, *Collection, [][]columnPhysicalJSONBenchParityEventP0)
 	}{
 		{
 			name:    "q1_insert_only",
@@ -168,9 +191,12 @@ func BenchmarkColumnPhysicalDenseLatestVisible1953(b *testing.B) {
 			name:    "q1_latest_visible",
 			batches: columnPhysicalQ1DenseEventBatches1950([][]string{{"app.m", "app.z", "app.m", "app.z"}, {"app.a", "app.m", "app.a", "app.m"}}),
 			req:     ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount, GroupColumn: "collection"},
-			mutate: func(tb testing.TB, col *Collection) {
-				updateTypedColumnEvent1953(tb, col, columnPhysicalJSONBenchParityEventP0{ID: "doc_00_000000", TimeUS: 1_900_000_000_000_000, Kind: "commit", Operation: "create", Collection: "app.updated", Did: "did:q1:000000"})
-				deleteTypedColumnEvent1953(tb, col, "doc_01_000001")
+			mutate: func(tb testing.TB, col *Collection, batches [][]columnPhysicalJSONBenchParityEventP0) {
+				events := flattenColumnPhysicalEvents1950(batches)
+				updated := events[0]
+				updated.Collection = "app.updated"
+				updateTypedColumnEvent1953(tb, col, updated)
+				deleteTypedColumnEvent1953(tb, col, events[len(events)-1].ID)
 			},
 		},
 		{
@@ -182,9 +208,19 @@ func BenchmarkColumnPhysicalDenseLatestVisible1953(b *testing.B) {
 			name:    "q3_latest_visible",
 			batches: [][]columnPhysicalJSONBenchParityEventP0{columnPhysicalQ3DenseBenchmarkEvents1950(2048)},
 			req:     columnPhysicalQ3DenseRequest1950(),
-			mutate: func(tb testing.TB, col *Collection) {
-				updateTypedColumnEvent1953(tb, col, columnPhysicalJSONBenchParityEventP0{ID: "q3-bench-000019", TimeUS: 1_960_000_000_000_000, Kind: "commit", Operation: "create", Collection: "app.bsky.feed.post", Did: "did:q3:0019"})
-				deleteTypedColumnEvent1953(tb, col, "q3-bench-000001")
+			mutate: func(tb testing.TB, col *Collection, batches [][]columnPhysicalJSONBenchParityEventP0) {
+				events := flattenColumnPhysicalEvents1950(batches)
+				byID := eventsByID1953(events)
+				updateID := pickEventID1953(tb, events, func(event columnPhysicalJSONBenchParityEventP0) bool { return event.Kind == "identity" })
+				updated := byID[updateID]
+				updated.Kind = "commit"
+				updated.Operation = "create"
+				updated.Collection = "app.bsky.feed.post"
+				updateTypedColumnEvent1953(tb, col, updated)
+				deleteID := pickEventID1953(tb, events, func(event columnPhysicalJSONBenchParityEventP0) bool {
+					return event.ID != updateID && columnPhysicalJSONBenchReferenceMatchP0("q3", event)
+				})
+				deleteTypedColumnEvent1953(tb, col, deleteID)
 			},
 		},
 		{
@@ -196,9 +232,20 @@ func BenchmarkColumnPhysicalDenseLatestVisible1953(b *testing.B) {
 			name:    "q5_latest_visible",
 			batches: [][]columnPhysicalJSONBenchParityEventP0{columnPhysicalQ5DenseBenchmarkEvents1950(2048)},
 			req:     columnPhysicalQ5DenseRequest1950(),
-			mutate: func(tb testing.TB, col *Collection) {
-				updateTypedColumnEvent1953(tb, col, columnPhysicalJSONBenchParityEventP0{ID: "q5-bench-000023", TimeUS: 1_950_000_000_999_999, Kind: "commit", Operation: "create", Collection: "app.bsky.feed.post", Did: "did:q5:0023"})
-				deleteTypedColumnEvent1953(tb, col, "q5-bench-000001")
+			mutate: func(tb testing.TB, col *Collection, batches [][]columnPhysicalJSONBenchParityEventP0) {
+				events := flattenColumnPhysicalEvents1950(batches)
+				byID := eventsByID1953(events)
+				updateID := pickEventID1953(tb, events, func(event columnPhysicalJSONBenchParityEventP0) bool { return event.Kind == "identity" })
+				updated := byID[updateID]
+				updated.Kind = "commit"
+				updated.Operation = "create"
+				updated.Collection = "app.bsky.feed.post"
+				updated.TimeUS += 999_999
+				updateTypedColumnEvent1953(tb, col, updated)
+				deleteID := pickEventID1953(tb, events, func(event columnPhysicalJSONBenchParityEventP0) bool {
+					return event.ID != updateID && columnPhysicalJSONBenchReferenceMatchP0("q5", event)
+				})
+				deleteTypedColumnEvent1953(tb, col, deleteID)
 			},
 		},
 	}
@@ -207,7 +254,7 @@ func BenchmarkColumnPhysicalDenseLatestVisible1953(b *testing.B) {
 			_, _, col, closeFn := openTypedColumnLatestVisibleFixture1953(b, nil, tc.batches)
 			defer closeFn()
 			if tc.mutate != nil {
-				tc.mutate(b, col)
+				tc.mutate(b, col, tc.batches)
 			}
 			preview, err := col.RunColumnPhysicalQuery(tc.req)
 			if err != nil {
@@ -322,11 +369,26 @@ func deleteTypedColumnEvent1953(tb testing.TB, col *Collection, id string) {
 }
 
 func latestEventMap1953(events []columnPhysicalJSONBenchParityEventP0) map[string]columnPhysicalJSONBenchParityEventP0 {
-	latest := make(map[string]columnPhysicalJSONBenchParityEventP0, len(events))
+	return eventsByID1953(events)
+}
+
+func eventsByID1953(events []columnPhysicalJSONBenchParityEventP0) map[string]columnPhysicalJSONBenchParityEventP0 {
+	out := make(map[string]columnPhysicalJSONBenchParityEventP0, len(events))
 	for _, event := range events {
-		latest[event.ID] = event
+		out[event.ID] = event
 	}
-	return latest
+	return out
+}
+
+func pickEventID1953(tb testing.TB, events []columnPhysicalJSONBenchParityEventP0, match func(columnPhysicalJSONBenchParityEventP0) bool) string {
+	tb.Helper()
+	for _, event := range events {
+		if match(event) {
+			return event.ID
+		}
+	}
+	tb.Fatalf("no generated fixture event matched predicate")
+	return ""
 }
 
 func latestEvents1953(latest map[string]columnPhysicalJSONBenchParityEventP0) []columnPhysicalJSONBenchParityEventP0 {

--- a/TreeDB/collections/column_physical_query.go
+++ b/TreeDB/collections/column_physical_query.go
@@ -284,9 +284,10 @@ func validateColumnPhysicalTopKRequest(req ColumnPhysicalQueryRequest) error {
 }
 
 // RunColumnPhysicalQuery executes an explicit serial physical column query over
-// the recovery-authoritative manifest. Insert-only manifests use the direct
-// scanner path; mutation-bearing manifests fall back to the M13C visibility
-// overlay before reducing.
+// the recovery-authoritative manifest. Insert-only manifests use direct physical
+// reducers. Supported dense typed-column mutation queries use latest-visible
+// typed-column reducers; unsupported mutation-bearing shapes fail closed or use
+// the legacy typed-row visibility overlay only where explicitly routed.
 func (c *Collection) RunColumnPhysicalQuery(req ColumnPhysicalQueryRequest) (ColumnPhysicalQueryResult, error) {
 	if err := validateColumnPhysicalQueryRequest(req); err != nil {
 		return ColumnPhysicalQueryResult{}, err
@@ -303,19 +304,19 @@ func (c *Collection) RunColumnPhysicalQuery(req ColumnPhysicalQueryRequest) (Col
 		if err != nil {
 			return ColumnPhysicalQueryResult{}, err
 		}
-		if columnPhysicalQueryHasPredicates(req) {
-			if columnTypedColumnPhysicalQueryTouchesTypedColumnPart(cfg, req) {
-				view, closeView, err := c.prepareColumnPhysicalScanSnapshotViewWithSidecars(columnManifestScanSidecarsForPhysicalQuery(req))
-				if closeView != nil {
-					defer closeView()
-				}
-				if err != nil {
-					return ColumnPhysicalQueryResult{}, err
-				}
-				if result, ok, err := c.runColumnPhysicalQueryTypedColumnPartInSnapshotView(view, req); ok {
-					return result, err
-				}
+		if columnTypedColumnPhysicalQueryTouchesTypedColumnPart(cfg, req) {
+			view, closeView, err := c.prepareColumnPhysicalScanSnapshotViewWithSidecars(columnManifestScanSidecarsForPhysicalQuery(req))
+			if closeView != nil {
+				defer closeView()
 			}
+			if err != nil {
+				return ColumnPhysicalQueryResult{}, err
+			}
+			if result, ok, err := c.runColumnPhysicalQueryTypedColumnPartInSnapshotView(view, req); ok {
+				return result, err
+			}
+		}
+		if columnPhysicalQueryHasPredicates(req) {
 			return ColumnPhysicalQueryResult{}, fmt.Errorf("%w: physical predicates require insert-only manifest", ErrColumnQueryPlanUnsupported)
 		}
 		return c.runColumnPhysicalQueryWithVisibility(cfg, req)
@@ -331,10 +332,10 @@ func (c *Collection) RunColumnPhysicalQuery(req ColumnPhysicalQueryRequest) (Col
 		if req.AggregateMetadataName != "" {
 			return ColumnPhysicalQueryResult{}, fmt.Errorf("%w: aggregate metadata physical query requires insert-only manifest", ErrColumnQueryPlanUnsupported)
 		}
+		if result, ok, err := c.runColumnPhysicalQueryTypedColumnPartInSnapshotView(view, req); ok {
+			return result, err
+		}
 		if columnPhysicalQueryHasPredicates(req) {
-			if result, ok, err := c.runColumnPhysicalQueryTypedColumnPartInSnapshotView(view, req); ok {
-				return result, err
-			}
 			return ColumnPhysicalQueryResult{}, fmt.Errorf("%w: physical predicates require insert-only manifest", ErrColumnQueryPlanUnsupported)
 		}
 		return c.runColumnPhysicalQueryWithVisibility(view.Config, req)
@@ -367,7 +368,7 @@ func (c *Collection) PrepareColumnPhysicalQuery(req ColumnPhysicalQueryRequest) 
 		}
 	}()
 	if view.MutationParts > 0 {
-		return nil, fmt.Errorf("%w: prepared physical column query requires insert-only manifest", ErrColumnQueryPlanUnsupported)
+		return nil, fmt.Errorf("%w: prepared physical column query requires insert-only manifest until typed-column asset lifecycle/pinning is available", ErrColumnQueryPlanUnsupported)
 	}
 	readCache, err := newColumnPhysicalAssetReadCacheWithIntegrity(view.ColumnAssetRootDir, view.AssetNamespace, req.ColumnAssetReadIntegrity)
 	if err != nil {

--- a/TreeDB/collections/column_physical_typed_column_query.go
+++ b/TreeDB/collections/column_physical_typed_column_query.go
@@ -198,7 +198,7 @@ func runColumnPhysicalQueryTypedColumnPartMutationUnsupported(view columnPhysica
 }
 
 func runColumnPhysicalQueryTypedColumnPartLatestVisibleInSnapshotView(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest, plan columnTypedColumnPhysicalQueryPlan, start time.Time) (ColumnPhysicalQueryResult, bool, error) {
-	if !columnTypedColumnPhysicalQueryUseDenseLatestVisible(plan, req) {
+	if !columnTypedColumnPhysicalQueryUseDenseLatestVisible(plan, req) && columnPhysicalQueryHasPredicates(req) {
 		return runColumnPhysicalQueryTypedColumnPartMutationUnsupported(view, req, start)
 	}
 	readCache, err := newColumnPhysicalAssetReadCacheWithIntegrity(view.ColumnAssetRootDir, view.AssetNamespace, req.ColumnAssetReadIntegrity)
@@ -258,7 +258,7 @@ func runColumnPhysicalQueryTypedColumnPartLatestVisibleInSnapshotView(view colum
 		result.Diagnostics.ScanNanos = time.Since(start).Nanoseconds()
 		return result, true, err
 	}
-	result, err := runner.runLatestVisibleDense(view, req, state, visibilityDiag.PhysicalBytesScanned, visibilityNanos)
+	result, err := runner.runLatestVisible(view, req, state, visibilityDiag.PhysicalBytesScanned, visibilityNanos)
 	result.Diagnostics.ScanNanos = time.Since(start).Nanoseconds()
 	result.Diagnostics.SegmentFileCacheHits = readCache.hits
 	result.Diagnostics.SegmentFileCacheMisses = readCache.misses
@@ -792,7 +792,7 @@ func (r *columnTypedColumnPhysicalQueryRunner) run(view columnPhysicalScanSnapsh
 	return result, nil
 }
 
-func (r *columnTypedColumnPhysicalQueryRunner) runLatestVisibleDense(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest, state *typedColumnLatestVisibilityState, visibilityBytes int64, visibilityNanos int64) (ColumnPhysicalQueryResult, error) {
+func (r *columnTypedColumnPhysicalQueryRunner) runLatestVisible(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest, state *typedColumnLatestVisibilityState, visibilityBytes int64, visibilityNanos int64) (ColumnPhysicalQueryResult, error) {
 	if columnTypedColumnPhysicalQueryUseDenseGroupCount(r.plan, req) {
 		return r.runLatestVisibleDenseGroupCount(view, req, state, visibilityBytes, visibilityNanos)
 	}
@@ -801,6 +801,9 @@ func (r *columnTypedColumnPhysicalQueryRunner) runLatestVisibleDense(view column
 	}
 	if columnTypedColumnPhysicalQueryUseDenseInt64Span(r.plan, req) {
 		return r.runLatestVisibleDenseInt64Span(view, req, state, visibilityBytes, visibilityNanos)
+	}
+	if !columnPhysicalQueryHasPredicates(req) {
+		return r.runLatestVisibleGeneric(view, req, state, visibilityBytes, visibilityNanos)
 	}
 	result := ColumnPhysicalQueryResult{Diagnostics: r.latestVisibleDiagnostics(view, req, state, visibilityBytes, visibilityNanos, 0, 0, 0, 0)}
 	annotateColumnPhysicalQueryResult(&result, ColumnPhysicalQueryStorageSourceTypedColumnPartSection, ColumnPhysicalQueryFallbackMutationVisibilityUnsupported)
@@ -825,6 +828,43 @@ func (r *columnTypedColumnPhysicalQueryRunner) latestVisibleDiagnostics(view col
 	diag := r.diagnostics(view, req, rowsScanned, matchedRows, reduceRows, scanNanos)
 	applyTypedColumnLatestVisibilityDiagnostics(&diag, state, visibilityBytes, visibilityNanos)
 	return diag
+}
+
+func (r *columnTypedColumnPhysicalQueryRunner) runLatestVisibleGeneric(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest, state *typedColumnLatestVisibilityState, visibilityBytes int64, visibilityNanos int64) (ColumnPhysicalQueryResult, error) {
+	start := time.Now()
+	acc := newColumnTypedColumnPhysicalQueryAccumulator(req.Kind)
+	rowsScanned := 0
+	for partIdx := range r.parts {
+		part := r.parts[partIdx]
+		visibility, err := r.latestVisiblePartForRunnerPart(part, state)
+		if err != nil {
+			return ColumnPhysicalQueryResult{Diagnostics: r.latestVisibleDiagnostics(view, req, state, visibilityBytes, visibilityNanos, rowsScanned, 0, acc.reduceRows, time.Since(start).Nanoseconds())}, err
+		}
+		partRows := len(part.RowIndexes)
+		if part.RowIndexes == nil {
+			partRows = part.Rows
+		}
+		for rowIdx := 0; rowIdx < partRows; rowIdx++ {
+			physicalRow := rowIdx
+			if part.RowIndexes != nil {
+				physicalRow = part.RowIndexes[rowIdx]
+			}
+			rowsScanned++
+			if !visibility.rowVisible(physicalRow) {
+				continue
+			}
+			if err := acc.visit(req, part.Values, rowIdx); err != nil {
+				return ColumnPhysicalQueryResult{Diagnostics: r.latestVisibleDiagnostics(view, req, state, visibilityBytes, visibilityNanos, rowsScanned, 0, acc.reduceRows, time.Since(start).Nanoseconds())}, err
+			}
+		}
+	}
+	groups := acc.groups(req, r.resultGroups)
+	r.resultGroups = groups
+	diag := r.latestVisibleDiagnostics(view, req, state, visibilityBytes, visibilityNanos, rowsScanned, 0, acc.reduceRows, time.Since(start).Nanoseconds())
+	result := ColumnPhysicalQueryResult{Groups: groups, Diagnostics: diag}
+	finalizeColumnPhysicalQueryResultGroups(req, &result)
+	r.resultGroups = result.Groups
+	return result, nil
 }
 
 func (r *columnTypedColumnPhysicalQueryRunner) runLatestVisibleDenseGroupCount(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest, state *typedColumnLatestVisibilityState, visibilityBytes int64, visibilityNanos int64) (ColumnPhysicalQueryResult, error) {

--- a/TreeDB/collections/column_physical_typed_column_query.go
+++ b/TreeDB/collections/column_physical_typed_column_query.go
@@ -112,12 +112,23 @@ func (c *Collection) runColumnPhysicalQueryTypedColumnPartInSnapshotView(view co
 	if !columnTypedColumnPhysicalQueryTouchesTypedColumnPart(view.FullConfig, req) {
 		return ColumnPhysicalQueryResult{}, false, nil
 	}
-	if _, candidate, err := planColumnTypedColumnPhysicalQuery(view.FullConfig, req); err != nil || !candidate {
+	start := time.Now()
+	plan, candidate, err := planColumnTypedColumnPhysicalQuery(view.FullConfig, req)
+	if err != nil {
+		if view.MutationParts != 0 && candidate {
+			result := ColumnPhysicalQueryResult{Diagnostics: columnTypedColumnPhysicalMutationDiagnostics(view, req)}
+			annotateColumnPhysicalQueryResult(&result, ColumnPhysicalQueryStorageSourceTypedColumnPartSection, ColumnPhysicalQueryFallbackMutationVisibilityUnsupported)
+			applyColumnPhysicalQueryPredicateDiagnostics(&result.Diagnostics, newColumnPhysicalQueryPredicateDiagnosticPlan(req), 0, 0)
+			result.Diagnostics.ScanNanos = time.Since(start).Nanoseconds()
+			return result, candidate, err
+		}
 		return ColumnPhysicalQueryResult{}, candidate, err
 	}
-	start := time.Now()
+	if !candidate {
+		return ColumnPhysicalQueryResult{}, false, nil
+	}
 	if view.MutationParts != 0 {
-		return runColumnPhysicalQueryTypedColumnPartMutationUnsupported(view, req, start)
+		return runColumnPhysicalQueryTypedColumnPartLatestVisibleInSnapshotView(view, req, plan, start)
 	}
 	readCache, err := newColumnPhysicalAssetReadCacheWithIntegrity(view.ColumnAssetRootDir, view.AssetNamespace, req.ColumnAssetReadIntegrity)
 	if err != nil {
@@ -138,11 +149,15 @@ func (c *Collection) runColumnPhysicalQueryTypedColumnPartInSnapshotView(view co
 	return result, true, err
 }
 
-func runColumnPhysicalQueryTypedColumnPartMutationUnsupported(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest, start time.Time) (ColumnPhysicalQueryResult, bool, error) {
+func columnTypedColumnPhysicalMutationDiagnostics(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest) ColumnPhysicalQueryDiagnostics {
 	diag := columnPhysicalQueryDiagnosticsFromScan(view.Diagnostics)
 	diag.WorkerCount = 1
 	diag.ColumnAssetReadIntegrity = columnAssetReadIntegrityLabel(req.ColumnAssetReadIntegrity)
-	result := ColumnPhysicalQueryResult{Diagnostics: diag}
+	return diag
+}
+
+func runColumnPhysicalQueryTypedColumnPartMutationUnsupported(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest, start time.Time) (ColumnPhysicalQueryResult, bool, error) {
+	result := ColumnPhysicalQueryResult{Diagnostics: columnTypedColumnPhysicalMutationDiagnostics(view, req)}
 	annotateColumnPhysicalQueryResult(&result, ColumnPhysicalQueryStorageSourceTypedColumnPartSection, ColumnPhysicalQueryFallbackMutationVisibilityUnsupported)
 	predicateDiagnostics := newColumnPhysicalQueryPredicateDiagnosticPlan(req)
 	applyColumnPhysicalQueryPredicateDiagnostics(&result.Diagnostics, predicateDiagnostics, 0, 0)
@@ -182,6 +197,95 @@ func runColumnPhysicalQueryTypedColumnPartMutationUnsupported(view columnPhysica
 	return result, true, fmt.Errorf("%w: typed-column part physical query with mutation visibility is deferred to multipart reducers", ErrColumnQueryPlanUnsupported)
 }
 
+func runColumnPhysicalQueryTypedColumnPartLatestVisibleInSnapshotView(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest, plan columnTypedColumnPhysicalQueryPlan, start time.Time) (ColumnPhysicalQueryResult, bool, error) {
+	if !columnTypedColumnPhysicalQueryUseDenseLatestVisible(plan, req) {
+		return runColumnPhysicalQueryTypedColumnPartMutationUnsupported(view, req, start)
+	}
+	readCache, err := newColumnPhysicalAssetReadCacheWithIntegrity(view.ColumnAssetRootDir, view.AssetNamespace, req.ColumnAssetReadIntegrity)
+	if err != nil {
+		result := ColumnPhysicalQueryResult{}
+		result.Diagnostics.ScanNanos = time.Since(start).Nanoseconds()
+		return result, true, err
+	}
+	defer func() { _ = readCache.close() }()
+	refsByGeneration, err := typedColumnPhysicalQueryRefsByGeneration(view)
+	if err != nil {
+		result := ColumnPhysicalQueryResult{Diagnostics: columnTypedColumnPhysicalMutationDiagnostics(view, req)}
+		annotateColumnPhysicalQueryResult(&result, ColumnPhysicalQueryStorageSourceTypedColumnPartSection, ColumnPhysicalQueryFallbackMutationVisibilityUnsupported)
+		result.Diagnostics.ScanNanos = time.Since(start).Nanoseconds()
+		return result, true, err
+	}
+	if err := validateTypedColumnMultipartAssetPairing(refsByGeneration, view.AssetRefs); err != nil {
+		result := ColumnPhysicalQueryResult{Diagnostics: columnTypedColumnPhysicalMutationDiagnostics(view, req)}
+		annotateColumnPhysicalQueryResult(&result, ColumnPhysicalQueryStorageSourceTypedColumnPartSection, ColumnPhysicalQueryFallbackMutationVisibilityUnsupported)
+		result.Diagnostics.ScanNanos = time.Since(start).Nanoseconds()
+		return result, true, err
+	}
+
+	visibilityStart := time.Now()
+	var visibilityDiag TypedColumnInt64PredicateScanDiagnostics
+	state, err := buildTypedColumnLatestVisibilityState(view, &readCache, &visibilityDiag)
+	visibilityNanos := time.Since(visibilityStart).Nanoseconds()
+	if err != nil {
+		result := ColumnPhysicalQueryResult{Diagnostics: columnTypedColumnPhysicalMutationDiagnostics(view, req)}
+		annotateColumnPhysicalQueryResult(&result, ColumnPhysicalQueryStorageSourceTypedColumnPartSection, ColumnPhysicalQueryFallbackMutationVisibilityUnsupported)
+		result.Diagnostics.PhysicalBytesScanned += visibilityDiag.PhysicalBytesScanned
+		result.Diagnostics.SegmentFileCacheHits = visibilityDiag.SegmentFileCacheHits
+		result.Diagnostics.SegmentFileCacheMisses = visibilityDiag.SegmentFileCacheMisses
+		result.Diagnostics.VisibilityNanos = visibilityNanos
+		result.Diagnostics.ScanNanos = time.Since(start).Nanoseconds()
+		return result, true, err
+	}
+	if typedColumnRefsHaveSortKey(refsByGeneration) {
+		result := ColumnPhysicalQueryResult{Diagnostics: columnTypedColumnPhysicalMutationDiagnostics(view, req)}
+		annotateColumnPhysicalQueryResult(&result, ColumnPhysicalQueryStorageSourceTypedColumnPartSection, ColumnPhysicalQueryFallbackMutationVisibilityUnsupported)
+		applyColumnPhysicalQueryPredicateDiagnostics(&result.Diagnostics, plan.PredicateDiagnostics, 0, 0)
+		applyTypedColumnLatestVisibilityDiagnostics(&result.Diagnostics, state, visibilityDiag.PhysicalBytesScanned, visibilityNanos)
+		result.Diagnostics.SegmentFileCacheHits = visibilityDiag.SegmentFileCacheHits
+		result.Diagnostics.SegmentFileCacheMisses = visibilityDiag.SegmentFileCacheMisses
+		result.Diagnostics.ScanNanos = time.Since(start).Nanoseconds()
+		return result, true, typedColumnSortedMutationVisibilityUnsupported("typed-column part physical query")
+	}
+
+	runner, err := decodeColumnTypedColumnPhysicalQueryRunnerParts(view, req, plan, refsByGeneration, &readCache)
+	if err != nil {
+		result := ColumnPhysicalQueryResult{Diagnostics: columnTypedColumnPhysicalMutationDiagnostics(view, req)}
+		annotateColumnPhysicalQueryResult(&result, ColumnPhysicalQueryStorageSourceTypedColumnPartSection, ColumnPhysicalQueryFallbackMutationVisibilityUnsupported)
+		applyColumnPhysicalQueryPredicateDiagnostics(&result.Diagnostics, plan.PredicateDiagnostics, 0, 0)
+		applyTypedColumnLatestVisibilityDiagnostics(&result.Diagnostics, state, visibilityDiag.PhysicalBytesScanned, visibilityNanos)
+		result.Diagnostics.SegmentFileCacheHits = readCache.hits
+		result.Diagnostics.SegmentFileCacheMisses = readCache.misses
+		result.Diagnostics.ScanNanos = time.Since(start).Nanoseconds()
+		return result, true, err
+	}
+	result, err := runner.runLatestVisibleDense(view, req, state, visibilityDiag.PhysicalBytesScanned, visibilityNanos)
+	result.Diagnostics.ScanNanos = time.Since(start).Nanoseconds()
+	result.Diagnostics.SegmentFileCacheHits = readCache.hits
+	result.Diagnostics.SegmentFileCacheMisses = readCache.misses
+	if err != nil {
+		return result, true, err
+	}
+	return result, true, nil
+}
+
+func columnTypedColumnPhysicalQueryUseDenseLatestVisible(plan columnTypedColumnPhysicalQueryPlan, req ColumnPhysicalQueryRequest) bool {
+	return columnTypedColumnPhysicalQueryUseDenseGroupCount(plan, req) ||
+		columnTypedColumnPhysicalQueryUseDenseGroupHourCount(plan, req) ||
+		columnTypedColumnPhysicalQueryUseDenseInt64Span(plan, req)
+}
+
+func applyTypedColumnLatestVisibilityDiagnostics(diag *ColumnPhysicalQueryDiagnostics, state *typedColumnLatestVisibilityState, physicalBytes int64, visibilityNanos int64) {
+	if diag == nil {
+		return
+	}
+	if state != nil {
+		diag.VisibilityRows = state.VisibleRows
+		diag.DeletedRows = state.DeletedRows
+	}
+	diag.PhysicalBytesScanned += physicalBytes
+	diag.VisibilityNanos = visibilityNanos
+}
+
 func prepareColumnTypedColumnPhysicalQueryRunner(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest, readCache *columnPhysicalAssetReadCache) (*columnTypedColumnPhysicalQueryRunner, bool, error) {
 	if !columnTypedColumnPhysicalQueryTouchesTypedColumnPart(view.FullConfig, req) {
 		return nil, false, nil
@@ -200,8 +304,8 @@ func prepareColumnTypedColumnPhysicalQueryRunner(view columnPhysicalScanSnapshot
 	if err != nil {
 		return nil, true, err
 	}
-	runner := &columnTypedColumnPhysicalQueryRunner{plan: plan, parts: make([]columnTypedColumnPhysicalQueryPart, 0, len(view.AssetRefs))}
 	if len(refsByGeneration) == 0 {
+		runner := &columnTypedColumnPhysicalQueryRunner{plan: plan, parts: make([]columnTypedColumnPhysicalQueryPart, 0, len(view.AssetRefs))}
 		if len(view.AssetRefs) == 0 {
 			return runner, true, nil
 		}
@@ -209,6 +313,24 @@ func prepareColumnTypedColumnPhysicalQueryRunner(view columnPhysicalScanSnapshot
 	}
 	if _, err := validateTypedColumnPhysicalAssetPairing(refsByGeneration, view.AssetRefs); err != nil {
 		return nil, true, typedColumnPhysicalQueryPairingError(err)
+	}
+	runner, err := decodeColumnTypedColumnPhysicalQueryRunnerParts(view, req, plan, refsByGeneration, readCache)
+	if err != nil {
+		return nil, true, err
+	}
+	return runner, true, nil
+}
+
+func decodeColumnTypedColumnPhysicalQueryRunnerParts(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest, plan columnTypedColumnPhysicalQueryPlan, refsByGeneration map[uint64]columnManifestAssetRefForScan, readCache *columnPhysicalAssetReadCache) (*columnTypedColumnPhysicalQueryRunner, error) {
+	if readCache == nil {
+		return nil, errors.New("collections: typed-column part physical query missing read cache")
+	}
+	runner := &columnTypedColumnPhysicalQueryRunner{plan: plan, parts: make([]columnTypedColumnPhysicalQueryPart, 0, len(view.AssetRefs))}
+	if len(refsByGeneration) == 0 {
+		if len(view.AssetRefs) == 0 {
+			return runner, nil
+		}
+		return nil, errors.New("collections: missing typed_column_part assets for typed-column part physical query")
 	}
 
 	// Disable returnViews during decode to avoid pinning mmaps/handles for the runner lifetime,
@@ -224,16 +346,16 @@ func prepareColumnTypedColumnPhysicalQueryRunner(view columnPhysicalScanSnapshot
 		}
 		typedRef, ok := refsByGeneration[physical.Ref.Generation]
 		if !ok {
-			return nil, true, fmt.Errorf("collections: missing typed_column_part asset for generation=%d", physical.Ref.Generation)
+			return nil, fmt.Errorf("collections: missing typed_column_part asset for generation=%d", physical.Ref.Generation)
 		}
 		raw, err := readCache.read(typedRef.Ref, rawScratch)
 		runner.segmentFileCacheHits = readCache.hits
 		runner.segmentFileCacheMisses = readCache.misses
 		if err != nil {
 			if errors.Is(err, io.ErrUnexpectedEOF) {
-				return nil, true, fmt.Errorf("collections: typed-column part physical query read generation=%d part_id=%d short read: %w", typedRef.Ref.Generation, typedRef.Ref.PartID, err)
+				return nil, fmt.Errorf("collections: typed-column part physical query read generation=%d part_id=%d short read: %w", typedRef.Ref.Generation, typedRef.Ref.PartID, err)
 			}
-			return nil, true, fmt.Errorf("collections: typed-column part physical query read generation=%d part_id=%d: %w", typedRef.Ref.Generation, typedRef.Ref.PartID, err)
+			return nil, fmt.Errorf("collections: typed-column part physical query read generation=%d part_id=%d: %w", typedRef.Ref.Generation, typedRef.Ref.PartID, err)
 		}
 		rawScratch = raw
 		var part columnTypedColumnPhysicalQueryPart
@@ -250,7 +372,7 @@ func prepareColumnTypedColumnPhysicalQueryRunner(view columnPhysicalScanSnapshot
 			part, err = decodeTypedColumnPhysicalQueryPart(plan, view.FullConfig.SchemaHash, typedRef, physical, raw)
 		}
 		if err != nil {
-			return nil, true, fmt.Errorf("collections: typed-column part physical query decode generation=%d part_id=%d: %w", typedRef.Ref.Generation, typedRef.Ref.PartID, err)
+			return nil, fmt.Errorf("collections: typed-column part physical query decode generation=%d part_id=%d: %w", typedRef.Ref.Generation, typedRef.Ref.PartID, err)
 		}
 		runner.assetBytes += part.Bytes
 		runner.sections += part.Sections
@@ -267,9 +389,9 @@ func prepareColumnTypedColumnPhysicalQueryRunner(view columnPhysicalScanSnapshot
 		runner.parts = append(runner.parts, part)
 	}
 	if len(runner.parts) == 0 && len(view.AssetRefs) != 0 {
-		return nil, true, errors.New("collections: typed-column part physical query has no live typed_column_part assets")
+		return nil, errors.New("collections: typed-column part physical query has no live typed_column_part assets")
 	}
-	return runner, true, nil
+	return runner, nil
 }
 
 func columnTypedColumnPhysicalQueryTouchesTypedColumnPart(cfg ColumnStoreConfig, req ColumnPhysicalQueryRequest) bool {
@@ -665,6 +787,345 @@ func (r *columnTypedColumnPhysicalQueryRunner) run(view columnPhysicalScanSnapsh
 	r.resultGroups = groups
 	diag := r.diagnostics(view, req, rowsScanned, matchedRows, acc.reduceRows, time.Since(start).Nanoseconds())
 	result := ColumnPhysicalQueryResult{Groups: groups, Diagnostics: diag}
+	finalizeColumnPhysicalQueryResultGroups(req, &result)
+	r.resultGroups = result.Groups
+	return result, nil
+}
+
+func (r *columnTypedColumnPhysicalQueryRunner) runLatestVisibleDense(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest, state *typedColumnLatestVisibilityState, visibilityBytes int64, visibilityNanos int64) (ColumnPhysicalQueryResult, error) {
+	if columnTypedColumnPhysicalQueryUseDenseGroupCount(r.plan, req) {
+		return r.runLatestVisibleDenseGroupCount(view, req, state, visibilityBytes, visibilityNanos)
+	}
+	if columnTypedColumnPhysicalQueryUseDenseGroupHourCount(r.plan, req) {
+		return r.runLatestVisibleDenseGroupHourCount(view, req, state, visibilityBytes, visibilityNanos)
+	}
+	if columnTypedColumnPhysicalQueryUseDenseInt64Span(r.plan, req) {
+		return r.runLatestVisibleDenseInt64Span(view, req, state, visibilityBytes, visibilityNanos)
+	}
+	result := ColumnPhysicalQueryResult{Diagnostics: r.latestVisibleDiagnostics(view, req, state, visibilityBytes, visibilityNanos, 0, 0, 0, 0)}
+	annotateColumnPhysicalQueryResult(&result, ColumnPhysicalQueryStorageSourceTypedColumnPartSection, ColumnPhysicalQueryFallbackMutationVisibilityUnsupported)
+	return result, fmt.Errorf("%w: typed-column part physical query with mutation visibility is deferred to multipart reducers", ErrColumnQueryPlanUnsupported)
+}
+
+func (r *columnTypedColumnPhysicalQueryRunner) latestVisiblePartForRunnerPart(part columnTypedColumnPhysicalQueryPart, state *typedColumnLatestVisibilityState) (*typedColumnLatestPhysicalPart, error) {
+	if state == nil || state.resolver == nil {
+		return nil, errors.New("collections: typed-column latest-visible physical state is missing")
+	}
+	visibility, ok := state.resolver.partForGeneration(part.PhysicalRef.Ref.Generation)
+	if !ok {
+		return nil, fmt.Errorf("collections: typed-column latest-visible physical state missing generation=%d", part.PhysicalRef.Ref.Generation)
+	}
+	if visibility.Rows != part.Rows {
+		return nil, fmt.Errorf("collections: typed-column latest-visible rows=%d do not match typed-column part rows=%d for generation=%d", visibility.Rows, part.Rows, part.PhysicalRef.Ref.Generation)
+	}
+	return visibility, nil
+}
+
+func (r *columnTypedColumnPhysicalQueryRunner) latestVisibleDiagnostics(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest, state *typedColumnLatestVisibilityState, visibilityBytes int64, visibilityNanos int64, rowsScanned, matchedRows, reduceRows int, scanNanos int64) ColumnPhysicalQueryDiagnostics {
+	diag := r.diagnostics(view, req, rowsScanned, matchedRows, reduceRows, scanNanos)
+	applyTypedColumnLatestVisibilityDiagnostics(&diag, state, visibilityBytes, visibilityNanos)
+	return diag
+}
+
+func (r *columnTypedColumnPhysicalQueryRunner) runLatestVisibleDenseGroupCount(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest, state *typedColumnLatestVisibilityState, visibilityBytes int64, visibilityNanos int64) (ColumnPhysicalQueryResult, error) {
+	start := time.Now()
+	if r.denseGroupCounts == nil {
+		r.denseGroupCounts = make(map[string]int, 16)
+	} else {
+		clear(r.denseGroupCounts)
+	}
+	rowsScanned := 0
+	reduceRows := 0
+	for partIdx := range r.parts {
+		part := r.parts[partIdx]
+		visibility, err := r.latestVisiblePartForRunnerPart(part, state)
+		if err != nil {
+			diag := r.latestVisibleDiagnostics(view, req, state, visibilityBytes, visibilityNanos, rowsScanned, 0, reduceRows, time.Since(start).Nanoseconds())
+			diag.DenseGroupCountUsed = true
+			return ColumnPhysicalQueryResult{Diagnostics: diag}, err
+		}
+		dense := part.DenseGroupCount
+		if dense == nil {
+			diag := r.latestVisibleDiagnostics(view, req, state, visibilityBytes, visibilityNanos, rowsScanned, 0, reduceRows, time.Since(start).Nanoseconds())
+			diag.DenseGroupCountUsed = true
+			return ColumnPhysicalQueryResult{Diagnostics: diag}, fmt.Errorf("collections: dense typed-column group-count missing prepared part %d", partIdx)
+		}
+		if dense.Cardinality == 0 && len(dense.Codes) != 0 {
+			diag := r.latestVisibleDiagnostics(view, req, state, visibilityBytes, visibilityNanos, rowsScanned, 0, reduceRows, time.Since(start).Nanoseconds())
+			diag.DenseGroupCountUsed = true
+			return ColumnPhysicalQueryResult{Diagnostics: diag}, fmt.Errorf("collections: dense typed-column group-count part %d has empty dictionary", partIdx)
+		}
+		if cap(r.denseLocalCounts) < dense.Cardinality {
+			r.denseLocalCounts = make([]int, dense.Cardinality)
+		} else {
+			r.denseLocalCounts = r.denseLocalCounts[:dense.Cardinality]
+			clear(r.denseLocalCounts)
+		}
+		for rowIdx, code := range dense.Codes {
+			rowsScanned++
+			if !visibility.rowVisible(rowIdx) {
+				continue
+			}
+			localIdx, ok := columnDictionaryCodeIndex(code, len(r.denseLocalCounts))
+			if !ok {
+				diag := r.latestVisibleDiagnostics(view, req, state, visibilityBytes, visibilityNanos, rowsScanned, 0, reduceRows, time.Since(start).Nanoseconds())
+				diag.DenseGroupCountUsed = true
+				return ColumnPhysicalQueryResult{Diagnostics: diag}, fmt.Errorf("collections: dense typed-column group-count part %d code[%d]=%d outside cardinality=%d", partIdx, rowIdx, code, len(r.denseLocalCounts))
+			}
+			r.denseLocalCounts[localIdx]++
+			reduceRows++
+		}
+		for localCode, count := range r.denseLocalCounts {
+			if count == 0 {
+				continue
+			}
+			key, ok := dense.DictionaryByCode[int64(localCode)]
+			if !ok {
+				diag := r.latestVisibleDiagnostics(view, req, state, visibilityBytes, visibilityNanos, rowsScanned, 0, reduceRows, time.Since(start).Nanoseconds())
+				diag.DenseGroupCountUsed = true
+				return ColumnPhysicalQueryResult{Diagnostics: diag}, fmt.Errorf("collections: dense typed-column group-count part %d dictionary missing local code %d", partIdx, localCode)
+			}
+			r.denseGroupCounts[key] += count
+		}
+	}
+	r.resultGroups = r.resultGroups[:0]
+	for key, count := range r.denseGroupCounts {
+		if count == 0 {
+			continue
+		}
+		r.resultGroups = append(r.resultGroups, ColumnPhysicalQueryGroup{Key: key, Count: count})
+	}
+	sortColumnPhysicalQueryGroupsByKey(r.resultGroups)
+	diag := r.latestVisibleDiagnostics(view, req, state, visibilityBytes, visibilityNanos, rowsScanned, 0, reduceRows, time.Since(start).Nanoseconds())
+	diag.DenseGroupCountUsed = true
+	result := ColumnPhysicalQueryResult{Groups: r.resultGroups, Diagnostics: diag}
+	finalizeColumnPhysicalQueryResultGroups(req, &result)
+	r.resultGroups = result.Groups
+	return result, nil
+}
+
+func (r *columnTypedColumnPhysicalQueryRunner) runLatestVisibleDenseGroupHourCount(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest, state *typedColumnLatestVisibilityState, visibilityBytes int64, visibilityNanos int64) (ColumnPhysicalQueryResult, error) {
+	start := time.Now()
+	if r.denseGroupHourCounts == nil {
+		r.denseGroupHourCounts = make(map[string][24]int, 16)
+	} else {
+		clear(r.denseGroupHourCounts)
+	}
+	rowsScanned := 0
+	matchedRows := 0
+	reduceRows := 0
+	for partIdx := range r.parts {
+		part := r.parts[partIdx]
+		visibility, err := r.latestVisiblePartForRunnerPart(part, state)
+		if err != nil {
+			diag := r.latestVisibleDiagnostics(view, req, state, visibilityBytes, visibilityNanos, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
+			diag.DenseGroupHourCountUsed = true
+			return ColumnPhysicalQueryResult{Diagnostics: diag}, err
+		}
+		dense := part.DenseGroupHourCount
+		if dense == nil {
+			diag := r.latestVisibleDiagnostics(view, req, state, visibilityBytes, visibilityNanos, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
+			diag.DenseGroupHourCountUsed = true
+			return ColumnPhysicalQueryResult{Diagnostics: diag}, fmt.Errorf("collections: dense typed-column group-hour missing prepared part %d", partIdx)
+		}
+		if dense.Cardinality == 0 && len(dense.GroupCodes) != 0 {
+			diag := r.latestVisibleDiagnostics(view, req, state, visibilityBytes, visibilityNanos, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
+			diag.DenseGroupHourCountUsed = true
+			return ColumnPhysicalQueryResult{Diagnostics: diag}, fmt.Errorf("collections: dense typed-column group-hour part %d has empty dictionary", partIdx)
+		}
+		if len(dense.GroupCodes) != len(dense.Values) {
+			diag := r.latestVisibleDiagnostics(view, req, state, visibilityBytes, visibilityNanos, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
+			diag.DenseGroupHourCountUsed = true
+			return ColumnPhysicalQueryResult{Diagnostics: diag}, fmt.Errorf("collections: dense typed-column group-hour part %d group/value rows=%d/%d", partIdx, len(dense.GroupCodes), len(dense.Values))
+		}
+		needLocal := dense.Cardinality * 24
+		if cap(r.denseLocalHourCounts) < needLocal {
+			r.denseLocalHourCounts = make([]int, needLocal)
+		} else {
+			r.denseLocalHourCounts = r.denseLocalHourCounts[:needLocal]
+			clear(r.denseLocalHourCounts)
+		}
+		if columnTypedColumnDensePredicatesRejectAll(dense.Predicates) {
+			rowsScanned += len(dense.GroupCodes)
+			continue
+		}
+		for rowIdx, code := range dense.GroupCodes {
+			rowsScanned++
+			if !visibility.rowVisible(rowIdx) {
+				continue
+			}
+			if !columnTypedColumnDensePredicatesMatch(dense.Predicates, rowIdx) {
+				continue
+			}
+			if len(dense.Predicates) != 0 {
+				matchedRows++
+			}
+			reduceRows++
+			localIdx, ok := columnDictionaryCodeIndex(code, dense.Cardinality)
+			if !ok {
+				diag := r.latestVisibleDiagnostics(view, req, state, visibilityBytes, visibilityNanos, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
+				diag.DenseGroupHourCountUsed = true
+				return ColumnPhysicalQueryResult{Diagnostics: diag}, fmt.Errorf("collections: dense typed-column group-hour part %d code[%d]=%d outside cardinality=%d", partIdx, rowIdx, code, dense.Cardinality)
+			}
+			hour := columnPhysicalQueryUTCHour(dense.Values[rowIdx])
+			r.denseLocalHourCounts[localIdx*24+hour]++
+		}
+		for localCode := 0; localCode < dense.Cardinality; localCode++ {
+			key := ""
+			var byHour [24]int
+			seen := false
+			base := localCode * 24
+			for hour := 0; hour < 24; hour++ {
+				count := r.denseLocalHourCounts[base+hour]
+				if count == 0 {
+					continue
+				}
+				if !seen {
+					var ok bool
+					key, ok = dense.DictionaryByCode[int64(localCode)]
+					if !ok {
+						diag := r.latestVisibleDiagnostics(view, req, state, visibilityBytes, visibilityNanos, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
+						diag.DenseGroupHourCountUsed = true
+						return ColumnPhysicalQueryResult{Diagnostics: diag}, fmt.Errorf("collections: dense typed-column group-hour part %d dictionary missing local code %d", partIdx, localCode)
+					}
+					byHour = r.denseGroupHourCounts[key]
+					seen = true
+				}
+				byHour[hour] += count
+			}
+			if seen {
+				r.denseGroupHourCounts[key] = byHour
+			}
+		}
+	}
+	r.resultGroups = r.resultGroups[:0]
+	for key, byHour := range r.denseGroupHourCounts {
+		for hour, count := range byHour {
+			if count == 0 {
+				continue
+			}
+			r.resultGroups = append(r.resultGroups, ColumnPhysicalQueryGroup{Key: key, Hour: hour, Count: count})
+		}
+	}
+	sortColumnPhysicalQueryGroupsByKeyHour(r.resultGroups)
+	diag := r.latestVisibleDiagnostics(view, req, state, visibilityBytes, visibilityNanos, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
+	diag.DenseGroupHourCountUsed = true
+	result := ColumnPhysicalQueryResult{Groups: r.resultGroups, Diagnostics: diag}
+	finalizeColumnPhysicalQueryResultGroups(req, &result)
+	r.resultGroups = result.Groups
+	return result, nil
+}
+
+func (r *columnTypedColumnPhysicalQueryRunner) runLatestVisibleDenseInt64Span(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest, state *typedColumnLatestVisibilityState, visibilityBytes int64, visibilityNanos int64) (ColumnPhysicalQueryResult, error) {
+	start := time.Now()
+	if r.denseSpanValues == nil {
+		r.denseSpanValues = make(map[string]columnPhysicalQuerySpan, 16)
+	} else {
+		clear(r.denseSpanValues)
+	}
+	rowsScanned := 0
+	matchedRows := 0
+	reduceRows := 0
+	for partIdx := range r.parts {
+		part := r.parts[partIdx]
+		visibility, err := r.latestVisiblePartForRunnerPart(part, state)
+		if err != nil {
+			diag := r.latestVisibleDiagnostics(view, req, state, visibilityBytes, visibilityNanos, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
+			diag.DenseInt64SpanUsed = true
+			return ColumnPhysicalQueryResult{Diagnostics: diag}, err
+		}
+		dense := part.DenseInt64Span
+		if dense == nil {
+			diag := r.latestVisibleDiagnostics(view, req, state, visibilityBytes, visibilityNanos, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
+			diag.DenseInt64SpanUsed = true
+			return ColumnPhysicalQueryResult{Diagnostics: diag}, fmt.Errorf("collections: dense typed-column int64-span missing prepared part %d", partIdx)
+		}
+		if len(dense.GroupCodes) != len(dense.Values) {
+			diag := r.latestVisibleDiagnostics(view, req, state, visibilityBytes, visibilityNanos, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
+			diag.DenseInt64SpanUsed = true
+			return ColumnPhysicalQueryResult{Diagnostics: diag}, fmt.Errorf("collections: dense typed-column int64-span part %d group/value rows=%d/%d", partIdx, len(dense.GroupCodes), len(dense.Values))
+		}
+		if cap(r.denseLocalSpans) < dense.Cardinality {
+			r.denseLocalSpans = make([]columnPhysicalQuerySpan, dense.Cardinality)
+			r.denseLocalSpanSeen = make([]bool, dense.Cardinality)
+		} else {
+			r.denseLocalSpans = r.denseLocalSpans[:dense.Cardinality]
+			clear(r.denseLocalSpans)
+			r.denseLocalSpanSeen = r.denseLocalSpanSeen[:dense.Cardinality]
+			clear(r.denseLocalSpanSeen)
+		}
+		if columnTypedColumnDensePredicatesRejectAll(dense.Predicates) {
+			rowsScanned += len(dense.GroupCodes)
+			continue
+		}
+		for rowIdx, code := range dense.GroupCodes {
+			rowsScanned++
+			if !visibility.rowVisible(rowIdx) {
+				continue
+			}
+			if !columnTypedColumnDensePredicatesMatch(dense.Predicates, rowIdx) {
+				continue
+			}
+			if len(dense.Predicates) != 0 {
+				matchedRows++
+			}
+			reduceRows++
+			localIdx, ok := columnDictionaryCodeIndex(code, len(r.denseLocalSpans))
+			if !ok {
+				diag := r.latestVisibleDiagnostics(view, req, state, visibilityBytes, visibilityNanos, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
+				diag.DenseInt64SpanUsed = true
+				return ColumnPhysicalQueryResult{Diagnostics: diag}, fmt.Errorf("collections: dense typed-column int64-span part %d code[%d]=%d outside cardinality=%d", partIdx, rowIdx, code, len(r.denseLocalSpans))
+			}
+			value := dense.Values[rowIdx]
+			if !r.denseLocalSpanSeen[localIdx] {
+				r.denseLocalSpans[localIdx] = columnPhysicalQuerySpan{min: value, max: value}
+				r.denseLocalSpanSeen[localIdx] = true
+				continue
+			}
+			span := r.denseLocalSpans[localIdx]
+			if value < span.min {
+				span.min = value
+			}
+			if value > span.max {
+				span.max = value
+			}
+			r.denseLocalSpans[localIdx] = span
+		}
+		for localCode, seen := range r.denseLocalSpanSeen {
+			if !seen {
+				continue
+			}
+			key, ok := dense.DictionaryByCode[int64(localCode)]
+			if !ok {
+				diag := r.latestVisibleDiagnostics(view, req, state, visibilityBytes, visibilityNanos, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
+				diag.DenseInt64SpanUsed = true
+				return ColumnPhysicalQueryResult{Diagnostics: diag}, fmt.Errorf("collections: dense typed-column int64-span part %d dictionary missing local code %d", partIdx, localCode)
+			}
+			partSpan := r.denseLocalSpans[localCode]
+			cur, ok := r.denseSpanValues[key]
+			if !ok {
+				r.denseSpanValues[key] = partSpan
+				continue
+			}
+			if partSpan.min < cur.min {
+				cur.min = partSpan.min
+			}
+			if partSpan.max > cur.max {
+				cur.max = partSpan.max
+			}
+			r.denseSpanValues[key] = cur
+		}
+	}
+	r.resultGroups = r.resultGroups[:0]
+	for key, span := range r.denseSpanValues {
+		r.resultGroups = append(r.resultGroups, ColumnPhysicalQueryGroup{Key: key, Int64: span.max - span.min})
+	}
+	if req.TopK == 0 {
+		sortColumnPhysicalQueryGroupsByKey(r.resultGroups)
+	}
+	diag := r.latestVisibleDiagnostics(view, req, state, visibilityBytes, visibilityNanos, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
+	diag.DenseInt64SpanUsed = true
+	result := ColumnPhysicalQueryResult{Groups: r.resultGroups, Diagnostics: diag}
 	finalizeColumnPhysicalQueryResultGroups(req, &result)
 	r.resultGroups = result.Groups
 	return result, nil

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -331,6 +331,7 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/column_physical_query.go", classification: typedStorageLegacyDeferred, matchingLines: 37, occurrences: 39},
 	{path: "TreeDB/collections/column_physical_query_1890_bench_test.go", classification: typedStorageLegacyDeferred, matchingLines: 1, occurrences: 2},
 	{path: "TreeDB/collections/column_physical_jsonbench_parity_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 7, occurrences: 8},
+	{path: "TreeDB/collections/column_physical_latest_visible_1953_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 1, occurrences: 1},
 	{path: "TreeDB/collections/column_physical_q2_1950_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 1, occurrences: 1},
 	{path: "TreeDB/collections/column_physical_typed_column_1947_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 7, occurrences: 8},
 	{path: "TreeDB/collections/column_physical_typed_column_query.go", classification: typedStorageLegacyCompatibility, matchingLines: 19, occurrences: 19},


### PR DESCRIPTION
## Summary

C2 for #1953: direct dense typed-column reducers now execute over mutation-bearing manifests for the q1/q3/q5 shapes when row identity is safe.

- Adds a direct latest-visible typed-column path for dense q1 `GroupCount`, q3 `GroupHourCount`, and q5 `GroupInt64Span`/TopK.
- Reuses C1 `typedColumnLatestVisibilityState`/resolver, validates physical/typed asset pairing, rejects sorted typed-column refs, skips tombstone/delete parts, and filters live typed-column rows with `rowVisible(row)` before predicate/reduce logic.
- Preserves no-predicate non-dense typed-column correctness with a generic latest-visible typed-column reducer instead of falling through to document scans.
- Keeps prepared mutation-bearing physical queries fail-closed with insert-only/lifecycle wording.
- Keeps q2/q4b/q4a sorted multipart shapes fail-closed with `mutation_visibility_unsupported` diagnostics.
- Adds mutation matrix tests and benchmark smoke for insert-only vs latest-visible dense execution.

## Scope boundaries / deferred

Not included in this C2 PR:

- C3 q2/q4b sorted multipart merge.
- C4 q4a time-order multipart merge.
- C5 compaction/metadata rebuild/invalidation.
- #1952 codecs and #1954 lifecycle/pinning.
- Document-leaf column pointers or changes to the `<collection>/column/manifest` catalog-root shape.

## Local validation

Head: `bb0aaceb09248be52b2f6dbdc8819f06826a2182` (includes latest `origin/main` `269ebe3a130322657441ecbdb717c4bad8ae8802`).

- `GOWORK=off go test ./TreeDB/collections -count=1 -run 'TestColumnPhysicalNonDenseNoPredicateMutationUsesTypedLatestVisible1953|TestColumnPhysicalQ1DenseLatestVisibleMutation1953|TestColumnPhysicalQ3DenseLatestVisibleMutationReopen1953|TestColumnPhysicalQ5DenseLatestVisibleMutation1953|TestColumnPhysicalSortedMutationShapesStillFailClosed1953|TestTypedColumnQ2MutationVisibilityFailsClosedC1|TestColumnPhysicalQ1DenseTypedColumnDirectPreparedParity1950|TestColumnPhysicalQ3DenseTypedColumnDirectPreparedParity1950|TestColumnPhysicalQ5DenseTypedColumnDirectPreparedParity1950|TestTypedColumnQ2SortedGroupedDistinctStreaming1950|TestTypedColumnQ4BTopKMarkPrunedParity1950|TestColumnPhysicalQ4ATimeOrderTopKDirectPreparedParity1950'` — PASS (`/tmp/orca_issue_graph_1945_1955/pr2049_focused_after_codex_overlay_fix.txt`)
- `GOWORK=off go test ./TreeDB/collections -count=1` — PASS (`/tmp/orca_issue_graph_1945_1955/pr2049_collections_after_codex_overlay_fix.txt`)
- `GOWORK=off go test ./TreeDB/docs -count=1` — PASS (`/tmp/orca_issue_graph_1945_1955/pr2049_docs_after_codex_overlay_fix.txt`)
- `GOWORK=off go test ./TreeDB/...` — PASS (`/tmp/orca_issue_graph_1945_1955/pr2049_treedb_all_after_codex_overlay_fix.txt`)

Earlier full-TreeDB coordinator run on `9d3d1e0a` hit one unrelated `TreeDB/caching` scheduler flake; targeted rerun and full rerun passed (`/tmp/orca_issue_graph_1945_1955/pr2049_coordinator_caching_flake_rerun_9d3d1e0a.txt`, `/tmp/orca_issue_graph_1945_1955/pr2049_coordinator_treedb_all_rerun_9d3d1e0a.txt`).

## Benchmark smoke

Command: `GOWORK=off go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnPhysicalDenseLatestVisible1953' -benchtime=20x -count=1 -benchmem`
Artifact: `/tmp/orca_issue_graph_1945_1955/pr2049_bench_dense_latest_visible_20x_after_codex_overlay_fix.txt`

| Shape | Mode | ns/op | B/op | allocs/op | visibility_rows/op | deleted_rows/op |
| --- | --- | ---: | ---: | ---: | ---: | ---: |
| q1 | insert-only | 60,077 | 64,880 | 402 | 0 | 0 |
| q1 | latest-visible | 79,904 | 105,721 | 607 | 7 | 1 |
| q3 | insert-only | 317,538 | 608,032 | 2,370 | 0 | 0 |
| q3 | latest-visible | 575,781 | 1,519,867 | 2,612 | 2,047 | 1 |
| q5 | insert-only | 403,040 | 801,480 | 2,383 | 0 | 0 |
| q5 | latest-visible | 618,962 | 1,691,864 | 2,632 | 2,047 | 1 |

Insert-only dense hot-loop regression check (base vs PR):

- Base artifact: `/tmp/orca_issue_graph_1945_1955/pr2049_base_insert_only_dense_1950_50x_count5.txt`
- Latest production-code artifact before the generic non-dense fix: `/tmp/orca_issue_graph_1945_1955/pr2049_head9d_insert_only_dense_1950_50x_count5.txt`
- Benchstat: `/tmp/orca_issue_graph_1945_1955/pr2049_benchstat_insert_only_dense_1950_50x_count5_head9d.txt`

Benchstat showed no allocation/counter regression; geomean `sec/op` improved ~4.4%, and `B/op`, `allocs/op`, decoded bytes, rows scanned, reduce rows, and typed sections were unchanged. The final generic non-dense fix does not touch insert-only prepared/direct routing.

## Review / risk notes

- Internal Pi final review: PASS after addressing the latest Codex finding.
- CodeRabbit finding about hard-coded fixture IDs was fixed in `9d3d1e0a`; latest CodeRabbit review has no actionable comments.
- Codex finding about non-dense no-predicate typed-column mutation queries was fixed in `bb0aaceb` by using a generic latest-visible typed-column reducer and adding `TestColumnPhysicalNonDenseNoPredicateMutationUsesTypedLatestVisible1953`.
- Main risk: direct latest-visible q1/q3/q5 intentionally pays one-shot visibility construction over physical row assets; prepared mutation-bearing remains fail-closed until #1954 lifecycle/pinning.
- Unsupported sorted/multipart reducers stay explicit fail-closed rather than falling back to document scans.

Closes part of #1953 (C2 only).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for column query mutations with latest-visible semantics across multiple query types
  * Added performance benchmark tests for mutation query execution

* **Bug Fixes**
  * Improved query execution routing to better handle mutation scenarios in column physical queries

<!-- end of auto-generated comment: release notes by coderabbit.ai -->