### PR TITLE
treedb: reduce YCSB stalls and harden fast-path commits

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -22079,7 +22079,7 @@ func (db *DB) rotateValueLogMuHeldToSeq(l *lane, nextSeq int) error {
 
 	if l.vlog != nil {
 		oldSize := l.vlog.Size()
-		if err := l.vlog.RotateTo(path, fileID); err != nil {
+		if err := l.vlog.RotateToWithSync(path, fileID, !db.relaxedSync); err != nil {
 			return err
 		}
 		l.vlogRotateTotal.Add(1)

--- a/TreeDB/caching/log_writer.go
+++ b/TreeDB/caching/log_writer.go
@@ -31,6 +31,7 @@ type valueWriter interface {
 	AppendFrame(dictID uint64, dict []byte, records []valuelog.Record) ([]page.ValuePtr, error)
 	SetDictFrameEncoderOptions(level zstd.EncoderLevel, enableEntropy bool)
 	RotateTo(path string, fileID uint32) error
+	RotateToWithSync(path string, fileID uint32, syncCurrent bool) error
 	Size() int64
 	Flush() error
 	Sync() error

--- a/TreeDB/caching/vlog_dirty_order_test.go
+++ b/TreeDB/caching/vlog_dirty_order_test.go
@@ -54,8 +54,13 @@ func (w *vlogDirtyOrderWriter) AppendFrame(dictID uint64, dict []byte, records [
 
 func (w *vlogDirtyOrderWriter) SetDictFrameEncoderOptions(level zstd.EncoderLevel, enableEntropy bool) {
 }
-func (w *vlogDirtyOrderWriter) RotateTo(path string, fileID uint32) error { return nil }
-func (w *vlogDirtyOrderWriter) Size() int64                               { return w.size }
+func (w *vlogDirtyOrderWriter) RotateTo(path string, fileID uint32) error {
+	return w.RotateToWithSync(path, fileID, true)
+}
+func (w *vlogDirtyOrderWriter) RotateToWithSync(path string, fileID uint32, syncCurrent bool) error {
+	return nil
+}
+func (w *vlogDirtyOrderWriter) Size() int64 { return w.size }
 func (w *vlogDirtyOrderWriter) Flush() error {
 	w.flushes.Add(1)
 	return nil

--- a/TreeDB/caching/vlog_rotate_reload_test.go
+++ b/TreeDB/caching/vlog_rotate_reload_test.go
@@ -22,6 +22,8 @@ type rotateSwapValueWriter struct {
 	rotated         bool
 	usedAfterRotate bool
 	appends         int
+	syncCurrent     bool
+	syncCurrentSet  bool
 }
 
 var _ valueWriter = (*rotateSwapValueWriter)(nil)
@@ -65,10 +67,16 @@ func (w *rotateSwapValueWriter) AppendRawFramesWritevInto(records []valuelog.Rec
 }
 
 func (w *rotateSwapValueWriter) RotateTo(path string, fileID uint32) error {
+	return w.RotateToWithSync(path, fileID, true)
+}
+
+func (w *rotateSwapValueWriter) RotateToWithSync(path string, fileID uint32, syncCurrent bool) error {
 	if w.rotated {
 		return errors.New("test: duplicate rotation")
 	}
 	w.rotated = true
+	w.syncCurrent = syncCurrent
+	w.syncCurrentSet = true
 	w.lane.vlog = &rotateSwapValueWriter{
 		lane: w.lane,
 		size: 0,
@@ -95,11 +103,16 @@ func (w *rotateFailValueWriter) AppendFrame(dictID uint64, dict []byte, records 
 
 func (w *rotateFailValueWriter) SetDictFrameEncoderOptions(level zstd.EncoderLevel, enableEntropy bool) {
 }
-func (w *rotateFailValueWriter) RotateTo(path string, fileID uint32) error { return errRotateFailed }
-func (w *rotateFailValueWriter) Size() int64                               { return w.size }
-func (w *rotateFailValueWriter) Flush() error                              { return nil }
-func (w *rotateFailValueWriter) Sync() error                               { return nil }
-func (w *rotateFailValueWriter) Close() error                              { return nil }
+func (w *rotateFailValueWriter) RotateTo(path string, fileID uint32) error {
+	return w.RotateToWithSync(path, fileID, true)
+}
+func (w *rotateFailValueWriter) RotateToWithSync(path string, fileID uint32, syncCurrent bool) error {
+	return errRotateFailed
+}
+func (w *rotateFailValueWriter) Size() int64  { return w.size }
+func (w *rotateFailValueWriter) Flush() error { return nil }
+func (w *rotateFailValueWriter) Sync() error  { return nil }
+func (w *rotateFailValueWriter) Close() error { return nil }
 
 type rotateFailCommitWriter struct {
 	size int64
@@ -164,6 +177,48 @@ func TestAppendValueLog_ReloadWriterAfterRotation(t *testing.T) {
 		t.Fatalf("ptrs length: got %d want %d", got, want)
 	}
 	putValueLogPtrs(ptrs)
+}
+
+func TestAppendValueLog_RelaxedSyncRotatesWithoutFsync(t *testing.T) {
+	t.Parallel()
+
+	prevMetrics := vlogAutotuneMetricsEnabled.Load()
+	vlogAutotuneMetricsEnabled.Store(false)
+	t.Cleanup(func() { vlogAutotuneMetricsEnabled.Store(prevMetrics) })
+
+	db := &DB{
+		dir:                     t.TempDir(),
+		closeCh:                 make(chan struct{}),
+		valueLogCompressionMode: uint8(vlogCompressionOff),
+		relaxedSync:             true,
+	}
+	db.valueLogMaxSegmentBytes = 1024
+	db.valueLogAutotuneOptions.Mode = valuelog.AutotuneOff
+
+	l := &lane{id: 0}
+	old := &rotateSwapValueWriter{
+		lane: l,
+		size: 900,
+	}
+	l.vlog = old
+
+	ptrs, err := db.appendValueLog(l, 0, nil, []valuelog.Record{
+		{RID: 1, Value: bytes.Repeat([]byte("a"), 32)},
+		{RID: 2, Value: bytes.Repeat([]byte("b"), 32)},
+	}, journalDurabilityNone)
+	if err != nil {
+		t.Fatalf("appendValueLog: %v", err)
+	}
+	defer putValueLogPtrs(ptrs)
+	if !old.rotated {
+		t.Fatalf("expected writer rotation")
+	}
+	if !old.syncCurrentSet {
+		t.Fatalf("RotateToWithSync was not called")
+	}
+	if old.syncCurrent {
+		t.Fatalf("relaxed sync rotation used syncCurrent=true")
+	}
 }
 
 func TestRotateValueLogMuHeld_DoesNotAdvanceSeqOnFailure(t *testing.T) {

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -2514,10 +2514,12 @@ func (db *DB) Prune() {
 	idx.acquire()
 	defer db.releaseIndex(idx)
 
-	min := idx.registry.MinPinnedSeq()
-	db.mu.RLock()
-	current := db.meta.CommitSeq
-	db.mu.RUnlock()
+	min := db.MinPinnedSnapshotCommitSeq()
+	state := db.state.Load()
+	if state == nil {
+		return
+	}
+	current := state.CommitSeq
 
 	freed := idx.graveyard.Extract(min, current, db.keepRecent)
 

--- a/TreeDB/db/prune.go
+++ b/TreeDB/db/prune.go
@@ -158,7 +158,7 @@ func (db *DB) pruneSome(stopCh <-chan struct{}, maxPages int, maxDuration time.D
 			return freedPages, nil
 		}
 		currentSeq := state.CommitSeq
-		minPinned := idx.registry.MinPinnedSeq()
+		minPinned := db.MinPinnedSnapshotCommitSeq()
 
 		remaining := maxPages
 		if maxPages > 0 {

--- a/TreeDB/db/snapshot_view_test.go
+++ b/TreeDB/db/snapshot_view_test.go
@@ -2,10 +2,14 @@ package db
 
 import (
 	"math"
+	"path/filepath"
 	"testing"
 
+	"github.com/snissn/gomap/TreeDB/freelist"
 	"github.com/snissn/gomap/TreeDB/internal/valuelog"
 	"github.com/snissn/gomap/TreeDB/lifecycle"
+	"github.com/snissn/gomap/TreeDB/page"
+	"github.com/snissn/gomap/TreeDB/pager"
 )
 
 func TestAcquireSnapshot_UsesPublishedCoherentView(t *testing.T) {
@@ -144,6 +148,44 @@ func TestMinPinnedSnapshotCommitSeqProtectsInFlightSnapshotAcquire(t *testing.T)
 	db.snapshotAcquireRO[0].Store(0)
 	if got := db.MinPinnedSnapshotCommitSeq(); got != math.MaxUint64 {
 		t.Fatalf("MinPinnedSnapshotCommitSeq after acquire drain=%d, want MaxUint64", got)
+	}
+}
+
+func TestPruneSomeProtectsInFlightSnapshotAcquire(t *testing.T) {
+	p, err := pager.Open(filepath.Join(t.TempDir(), "index.db"), int64(page.PageSize*16))
+	if err != nil {
+		t.Fatalf("open pager: %v", err)
+	}
+	defer func() { _ = p.Close() }()
+
+	if _, err := p.Alloc(4); err != nil {
+		t.Fatalf("alloc pages: %v", err)
+	}
+	idx := newIndexGen(1, p, freelist.New(p, 0), nil)
+	db := &DB{
+		keepRecent: 1,
+		snapPool:   NewSnapshotPool(),
+	}
+	db.idx.Store(idx)
+	db.state.Store(&DBState{CommitSeq: 10})
+	idx.graveyard.Add(1, []uint64{2})
+
+	db.snapshotAcquireRO[0].Store(1)
+	freed, err := db.pruneSome(make(chan struct{}), 10, 0)
+	if err != nil {
+		t.Fatalf("pruneSome with in-flight acquire: %v", err)
+	}
+	if freed != 0 {
+		t.Fatalf("pruneSome freed %d pages during in-flight acquire, want 0", freed)
+	}
+
+	db.snapshotAcquireRO[0].Store(0)
+	freed, err = db.pruneSome(make(chan struct{}), 10, 0)
+	if err != nil {
+		t.Fatalf("pruneSome after acquire drain: %v", err)
+	}
+	if freed != 1 {
+		t.Fatalf("pruneSome freed %d pages after acquire drain, want 1", freed)
 	}
 }
 

--- a/TreeDB/internal/valuelog/valuelog_test.go
+++ b/TreeDB/internal/valuelog/valuelog_test.go
@@ -95,6 +95,71 @@ func TestWriterRotateTo_FlushesSinkBufferBeforeSwitchingToFileBacked(t *testing.
 	}
 }
 
+func TestWriterRotateToWithSyncFalseSkipsRotateSync(t *testing.T) {
+	dir := t.TempDir()
+	path1 := filepath.Join(dir, "value-l0-000001.log")
+	path2 := filepath.Join(dir, "value-l0-000002.log")
+	path3 := filepath.Join(dir, "value-l0-000003.log")
+
+	origSyncDir := syncDirFn
+	defer func() { syncDirFn = origSyncDir }()
+	var dirSyncs int
+	syncDirFn = func(string) error {
+		dirSyncs++
+		return nil
+	}
+
+	writer, err := NewWriter(path1, page.ValueLogFileID(1))
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	defer func() {
+		if err := writer.Close(); err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+	}()
+
+	var fileSyncs int
+	writer.syncFn = func(*os.File) error {
+		fileSyncs++
+		return nil
+	}
+
+	dirSyncs = 0
+	if _, err := writer.Append(0, nil, 1, []byte("value-1")); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	if err := writer.RotateToWithSync(path2, page.ValueLogFileID(2), false); err != nil {
+		t.Fatalf("RotateToWithSync(false): %v", err)
+	}
+	if fileSyncs != 0 {
+		t.Fatalf("fileSyncs after relaxed rotate=%d want 0", fileSyncs)
+	}
+	if dirSyncs != 0 {
+		t.Fatalf("dirSyncs after relaxed rotate=%d want 0", dirSyncs)
+	}
+
+	if err := writer.Sync(); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	if fileSyncs != 1 {
+		t.Fatalf("fileSyncs after explicit Sync=%d want 1", fileSyncs)
+	}
+
+	if _, err := writer.Append(0, nil, 2, []byte("value-2")); err != nil {
+		t.Fatalf("Append second: %v", err)
+	}
+	if err := writer.RotateToWithSync(path3, page.ValueLogFileID(3), true); err != nil {
+		t.Fatalf("RotateToWithSync(true): %v", err)
+	}
+	if fileSyncs != 2 {
+		t.Fatalf("fileSyncs after synced rotate=%d want 2", fileSyncs)
+	}
+	if dirSyncs != 1 {
+		t.Fatalf("dirSyncs after synced rotate=%d want 1", dirSyncs)
+	}
+}
+
 func TestValueLogAppendRead(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "value-000001.log")

--- a/TreeDB/internal/valuelog/writer.go
+++ b/TreeDB/internal/valuelog/writer.go
@@ -716,7 +716,16 @@ func (w *Writer) Flush() error {
 	return nil
 }
 
+// RotateTo flushes and closes the current file, then opens (or creates) the
+// provided path and reuses the writer's buffers for future appends.
 func (w *Writer) RotateTo(path string, fileID uint32) error {
+	return w.RotateToWithSync(path, fileID, true)
+}
+
+// RotateToWithSync flushes and closes the current file, then opens (or creates)
+// the provided path and reuses the writer's buffers for future appends. When
+// syncCurrent is false, the current file is flushed to the OS but not fsynced.
+func (w *Writer) RotateToWithSync(path string, fileID uint32, syncCurrent bool) error {
 	if w == nil {
 		return errors.New("valuelog: nil writer")
 	}
@@ -732,9 +741,11 @@ func (w *Writer) RotateTo(path string, fileID uint32) error {
 		if err != nil {
 			return err
 		}
-		if err := syncDirFn(path); err != nil {
-			_ = f.Close()
-			return err
+		if syncCurrent {
+			if err := syncDirFn(path); err != nil {
+				_ = f.Close()
+				return err
+			}
 		}
 		info, err := f.Stat()
 		if err != nil {
@@ -755,7 +766,7 @@ func (w *Writer) RotateTo(path string, fileID uint32) error {
 	if err := w.flushNoTrim(); err != nil {
 		return err
 	}
-	if w.syncFn != nil {
+	if syncCurrent && w.syncFn != nil {
 		if err := w.syncFn(w.f); err != nil {
 			return err
 		}
@@ -770,9 +781,11 @@ func (w *Writer) RotateTo(path string, fileID uint32) error {
 		_ = f.Close()
 		return err
 	}
-	if err := syncDirFn(path); err != nil {
-		_ = f.Close()
-		return err
+	if syncCurrent {
+		if err := syncDirFn(path); err != nil {
+			_ = f.Close()
+			return err
+		}
 	}
 
 	old := w.f

--- a/TreeDB/nativewire/client_metadata.go
+++ b/TreeDB/nativewire/client_metadata.go
@@ -140,8 +140,8 @@ func (c *Client) DropIndex(ctx context.Context, collection, index string) (colle
 	return firstMetaFromResponse(sections)
 }
 
-// CurrentCatalogVersion returns the catalog commit sequence advertised by the
-// server for guarded metadata mutations.
+// CurrentCatalogVersion returns the server-advertised catalog/schema version
+// used by guarded replicated mutations.
 func (c *Client) CurrentCatalogVersion(ctx context.Context) (uint64, error) {
 	stats, err := c.Stats(ctx)
 	if err != nil {

--- a/TreeDB/nativewire/metadata.go
+++ b/TreeDB/nativewire/metadata.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/snissn/gomap/TreeDB/collections"
+	backenddb "github.com/snissn/gomap/TreeDB/db"
 	iwire "github.com/snissn/gomap/TreeDB/internal/nativewire"
 )
 
@@ -788,20 +789,42 @@ func expectedCatalogVersionFromSections(sections []iwire.Section) (uint64, bool,
 	return version, true, nil
 }
 
+func initialCatalogVersion(db *backenddb.DB) uint64 {
+	if db == nil {
+		return 0
+	}
+	state := db.State()
+	if state == nil {
+		return 0
+	}
+	return state.CommitSeq
+}
+
+func (s *Server) backendCommitSeq() uint64 {
+	if s == nil || s.backend == nil {
+		return 0
+	}
+	state := s.backend.State()
+	if state == nil {
+		return 0
+	}
+	return state.CommitSeq
+}
+
+func (s *Server) bumpCatalogVersionIfBackendAdvanced(before uint64) {
+	if s == nil || s.backend == nil {
+		return
+	}
+	if after := s.backendCommitSeq(); after != before {
+		s.catalogVersion.Add(1)
+	}
+}
+
 func (s *Server) currentCatalogVersion() (uint64, error) {
 	if s == nil || s.backend == nil {
 		return 0, protocolError(iwire.ErrInvalidCommand, "catalog version guard requires a backend")
 	}
-	snap := s.backend.AcquireSnapshot()
-	if snap == nil {
-		return 0, protocolError(iwire.ErrInternal, "catalog snapshot unavailable")
-	}
-	defer func() { _ = snap.Close() }()
-	state := snap.State()
-	if state == nil {
-		return 0, protocolError(iwire.ErrInternal, "catalog snapshot state unavailable")
-	}
-	return state.CommitSeq, nil
+	return s.catalogVersion.Load(), nil
 }
 
 func (s *Server) checkCatalogGuard(sections []iwire.Section) error {

--- a/TreeDB/nativewire/metadata.go
+++ b/TreeDB/nativewire/metadata.go
@@ -1,6 +1,7 @@
 package nativewire
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/binary"
 	"errors"
@@ -800,22 +801,20 @@ func initialCatalogVersion(db *backenddb.DB) uint64 {
 	return state.CommitSeq
 }
 
-func (s *Server) backendCommitSeq() uint64 {
-	if s == nil || s.backend == nil {
-		return 0
+func (s *Server) catalogMetadataFingerprint() ([]byte, bool) {
+	if s == nil || s.collections == nil {
+		return nil, false
 	}
-	state := s.backend.State()
-	if state == nil {
-		return 0
+	metas, err := s.collections.ListCollections()
+	if err != nil {
+		return nil, false
 	}
-	return state.CommitSeq
+	return encodeCollectionMetaVector(metas), true
 }
 
-func (s *Server) bumpCatalogVersionIfBackendAdvanced(before uint64) {
-	if s == nil || s.backend == nil {
-		return
-	}
-	if after := s.backendCommitSeq(); after != before {
+func (s *Server) bumpCatalogVersionIfCatalogMetadataChanged(before []byte, beforeOK bool) {
+	after, afterOK := s.catalogMetadataFingerprint()
+	if !beforeOK || !afterOK || !bytes.Equal(before, after) {
 		s.catalogVersion.Add(1)
 	}
 }

--- a/TreeDB/nativewire/metadata_test.go
+++ b/TreeDB/nativewire/metadata_test.go
@@ -18,6 +18,17 @@ func serveCollectionPipe(t *testing.T) (*Client, *collections.CollectionManager,
 
 func serveCollectionPipeWithOptions(t *testing.T, opts ServerOptions) (*Client, *collections.CollectionManager, *backenddb.DB) {
 	t.Helper()
+	client, _, mgr, db := serveCollectionPipeWithServerAndOptions(t, opts)
+	return client, mgr, db
+}
+
+func serveCollectionPipeWithServer(t *testing.T) (*Client, *Server, *collections.CollectionManager, *backenddb.DB) {
+	t.Helper()
+	return serveCollectionPipeWithServerAndOptions(t, ServerOptions{})
+}
+
+func serveCollectionPipeWithServerAndOptions(t *testing.T, opts ServerOptions) (*Client, *Server, *collections.CollectionManager, *backenddb.DB) {
+	t.Helper()
 	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {
 		t.Fatalf("open db: %v", err)
@@ -28,7 +39,7 @@ func serveCollectionPipeWithOptions(t *testing.T, opts ServerOptions) (*Client, 
 	server := NewServer(opts)
 	client, _ := servePipe(t, server)
 	t.Cleanup(func() { _ = db.Close() })
-	return client, mgr, db
+	return client, server, mgr, db
 }
 
 func serveCommandWALCollectionPipe(t *testing.T) (*Client, *collections.CollectionManager, *backenddb.DB) {

--- a/TreeDB/nativewire/metadata_test.go
+++ b/TreeDB/nativewire/metadata_test.go
@@ -218,7 +218,7 @@ func TestDecodeCollectionRefPreservesRawNameCompatibility(t *testing.T) {
 }
 
 func TestMetadataHandleRefsWorkForIndexMetadata(t *testing.T) {
-	client, _, db := serveCollectionPipe(t)
+	client, _, _ := serveCollectionPipe(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 	if err := client.Hello(ctx); err != nil {
@@ -235,7 +235,7 @@ func TestMetadataHandleRefsWorkForIndexMetadata(t *testing.T) {
 		t.Fatalf("OpenCollection by handle err=%v want invalid command", err)
 	}
 
-	version := catalogVersion(t, db)
+	version := clientCatalogVersion(t, client, ctx)
 	createIndexReq := append(replicatedTestGuard("create_index_handle", version),
 		collectionHandleRef(handle),
 		iwire.Section{ID: iwire.SectionIndexDefinition, Bytes: encodeIndexDefinition(collections.IndexDefinition{
@@ -248,7 +248,7 @@ func TestMetadataHandleRefsWorkForIndexMetadata(t *testing.T) {
 		t.Fatalf("CreateIndex by handle: %v", err)
 	}
 
-	version = catalogVersion(t, db)
+	version = clientCatalogVersion(t, client, ctx)
 	dropIndexReq := append(replicatedTestGuard("drop_index_handle", version),
 		collectionHandleRef(handle),
 		iwire.Section{ID: iwire.SectionIndexName, Bytes: encodeIndexName("email")},
@@ -280,14 +280,14 @@ func TestMetadataUnsupportedCatalogCommandsReturnUnsupportedFeature(t *testing.T
 }
 
 func TestMetadataCatalogGuard(t *testing.T) {
-	client, _, db := serveCollectionPipe(t)
+	client, _, _ := serveCollectionPipe(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 	if err := client.Hello(ctx); err != nil {
 		t.Fatalf("Hello: %v", err)
 	}
 
-	version := catalogVersion(t, db)
+	version := clientCatalogVersion(t, client, ctx)
 	createStaleReq := append(replicatedTestGuard("create_collection_stale", version+1),
 		iwire.Section{ID: iwire.SectionCollectionMeta, Bytes: encodeCollectionMeta(collections.CollectionMeta{Name: "users"})},
 	)
@@ -301,7 +301,7 @@ func TestMetadataCatalogGuard(t *testing.T) {
 		t.Fatalf("CreateCollection guarded: %v", err)
 	}
 
-	version = catalogVersion(t, db)
+	version = clientCatalogVersion(t, client, ctx)
 	indexStaleReq := append(replicatedTestGuard("create_index_stale", version+1),
 		collectionNameRef("users"),
 		iwire.Section{ID: iwire.SectionIndexDefinition, Bytes: encodeIndexDefinition(collections.IndexDefinition{
@@ -327,7 +327,7 @@ func TestMetadataCatalogGuard(t *testing.T) {
 }
 
 func TestMetadataClientAllowsCallerSuppliedGuards(t *testing.T) {
-	client, _, db := serveCollectionPipe(t)
+	client, _, _ := serveCollectionPipe(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 	if err := client.Hello(ctx); err != nil {
@@ -335,7 +335,7 @@ func TestMetadataClientAllowsCallerSuppliedGuards(t *testing.T) {
 	}
 
 	key := []byte("stable-create-users")
-	guardedCtx := WithExpectedCatalogVersion(WithIdempotencyKey(ctx, key), catalogVersion(t, db))
+	guardedCtx := WithExpectedCatalogVersion(WithIdempotencyKey(ctx, key), clientCatalogVersion(t, client, ctx))
 	key[0] = 'X'
 	if _, err := client.CreateCollection(guardedCtx, collections.CollectionMeta{Name: "users"}); err != nil {
 		t.Fatalf("CreateCollection guarded: %v", err)
@@ -350,8 +350,9 @@ func TestMetadataClientAllowsCallerSuppliedGuards(t *testing.T) {
 	}
 	rawVersion := sectionBytes(t, sections, iwire.SectionExpectedCatalogVersion)
 	version, n := binary.Uvarint(rawVersion)
-	if n != len(rawVersion) || version+1 != catalogVersion(t, db) {
-		t.Fatalf("expected version raw=%v decoded=%d n=%d current=%d", rawVersion, version, n, catalogVersion(t, db))
+	current := clientCatalogVersion(t, client, ctx)
+	if n != len(rawVersion) || version+1 != current {
+		t.Fatalf("expected version raw=%v decoded=%d n=%d current=%d", rawVersion, version, n, current)
 	}
 }
 
@@ -381,19 +382,19 @@ func TestMetadataClientRejectsInvalidCollectionNamesBeforeSend(t *testing.T) {
 }
 
 func TestMetadataIdempotencyReplayPrecedesCatalogGuard(t *testing.T) {
-	client, _, db := serveCollectionPipe(t)
+	client, _, _ := serveCollectionPipe(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 	if err := client.Hello(ctx); err != nil {
 		t.Fatalf("Hello: %v", err)
 	}
 
-	guardedCtx := WithExpectedCatalogVersion(WithIdempotencyKey(ctx, []byte("create-users-once")), catalogVersion(t, db))
+	guardedCtx := WithExpectedCatalogVersion(WithIdempotencyKey(ctx, []byte("create-users-once")), clientCatalogVersion(t, client, ctx))
 	first, err := client.CreateCollection(guardedCtx, collections.CollectionMeta{Name: "users"})
 	if err != nil {
 		t.Fatalf("CreateCollection first: %v", err)
 	}
-	if got, want := catalogVersion(t, db), guardedCatalogVersion(t, guardedCtx)+1; got != want {
+	if got, want := clientCatalogVersion(t, client, ctx), guardedCatalogVersion(t, guardedCtx)+1; got != want {
 		t.Fatalf("catalog version after first=%d want %d", got, want)
 	}
 	second, err := client.CreateCollection(guardedCtx, collections.CollectionMeta{Name: "users"})
@@ -466,6 +467,15 @@ func catalogVersion(t *testing.T, db *backenddb.DB) uint64 {
 	}
 	defer func() { _ = snap.Close() }()
 	return snap.State().CommitSeq
+}
+
+func clientCatalogVersion(t *testing.T, client *Client, ctx context.Context) uint64 {
+	t.Helper()
+	version, err := client.CurrentCatalogVersion(ctx)
+	if err != nil {
+		t.Fatalf("CurrentCatalogVersion: %v", err)
+	}
+	return version
 }
 
 func guardedCatalogVersion(t *testing.T, ctx context.Context) uint64 {

--- a/TreeDB/nativewire/mutation_test.go
+++ b/TreeDB/nativewire/mutation_test.go
@@ -853,6 +853,40 @@ func TestMutationCatalogGuardAllowsPriorDataCommitVersion(t *testing.T) {
 	}
 }
 
+func TestCatalogMetadataVersionIgnoresDataRootChanges(t *testing.T) {
+	client, server, _, db := serveCollectionPipeWithServer(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := client.Hello(ctx); err != nil {
+		t.Fatalf("Hello: %v", err)
+	}
+	if _, err := client.CreateCollection(ctx, collections.CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	version := clientCatalogVersion(t, client, ctx)
+	beforeCatalog, beforeOK := server.catalogMetadataFingerprint()
+	if !beforeOK {
+		t.Fatalf("catalogMetadataFingerprint before data mutation failed")
+	}
+	beforeCommit := catalogVersion(t, db)
+	if _, err := client.InsertBatch(ctx, "users", collections.DocumentFormatJSON,
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"x":1}`)},
+		AckVisible,
+	); err != nil {
+		t.Fatalf("InsertBatch: %v", err)
+	}
+	afterCommit := catalogVersion(t, db)
+	if afterCommit <= beforeCommit {
+		t.Fatalf("backend commit seq did not advance after data mutation: before=%d after=%d", beforeCommit, afterCommit)
+	}
+
+	server.bumpCatalogVersionIfCatalogMetadataChanged(beforeCatalog, beforeOK)
+	if after := clientCatalogVersion(t, client, ctx); after != version {
+		t.Fatalf("data root change bumped catalog version from %d to %d", version, after)
+	}
+}
+
 func TestMutationCatalogGuardRejectsPriorVersionAfterMetadataChange(t *testing.T) {
 	client, _, _ := serveCollectionPipe(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)

--- a/TreeDB/nativewire/mutation_test.go
+++ b/TreeDB/nativewire/mutation_test.go
@@ -785,21 +785,112 @@ func TestMutationCatalogVersionCacheSurvivesSuccessfulDataMutation(t *testing.T)
 	if _, err := client.CreateCollection(ctx, collections.CollectionMeta{Name: "users"}); err != nil {
 		t.Fatalf("CreateCollection: %v", err)
 	}
-	version := catalogVersion(t, db)
+	version := clientCatalogVersion(t, client, ctx)
+	beforeCommit := catalogVersion(t, db)
 	client.catalogVersionPlusOne.Store(version + 1)
-	deleted, err := client.DeleteBatch(ctx, "users", [][]byte{[]byte("missing")}, AckVisible)
+	ids, err := client.InsertBatch(ctx, "users", collections.DocumentFormatJSON,
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"x":1}`)},
+		AckVisible,
+	)
 	if err != nil {
-		t.Fatalf("DeleteBatch missing: %v", err)
+		t.Fatalf("InsertBatch: %v", err)
 	}
-	if deleted != 0 {
-		t.Fatalf("deleted=%d want 0", deleted)
+	if len(ids) != 1 || string(ids[0]) != "u1" {
+		t.Fatalf("insert ids=%q want u1", ids)
 	}
-	after := catalogVersion(t, db)
-	if got := client.catalogVersionPlusOne.Load(); got != after+1 {
-		t.Fatalf("catalogVersionPlusOne=%d want %d", got, after+1)
+	afterCommit := catalogVersion(t, db)
+	if afterCommit <= beforeCommit {
+		t.Fatalf("backend commit seq did not advance after data mutation: before=%d after=%d", beforeCommit, afterCommit)
 	}
-	if after != version {
-		t.Fatalf("missing delete changed catalog version from %d to %d", version, after)
+	if got := client.catalogVersionPlusOne.Load(); got != version+1 {
+		t.Fatalf("catalogVersionPlusOne=%d want %d", got, version+1)
+	}
+	if after := clientCatalogVersion(t, client, ctx); after != version {
+		t.Fatalf("data mutation changed catalog version from %d to %d", version, after)
+	}
+}
+
+func TestMutationCatalogGuardAllowsPriorDataCommitVersion(t *testing.T) {
+	client, _, db := serveCollectionPipe(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := client.Hello(ctx); err != nil {
+		t.Fatalf("Hello: %v", err)
+	}
+	if _, err := client.CreateCollection(ctx, collections.CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+
+	version := clientCatalogVersion(t, client, ctx)
+	beforeCommit := catalogVersion(t, db)
+	guardedCtx := WithExpectedCatalogVersion(ctx, version)
+	if _, err := client.InsertBatch(guardedCtx, "users", collections.DocumentFormatJSON,
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"x":1}`)},
+		AckVisible,
+	); err != nil {
+		t.Fatalf("InsertBatch: %v", err)
+	}
+	afterCommit := catalogVersion(t, db)
+	if afterCommit <= beforeCommit {
+		t.Fatalf("backend commit seq did not advance after data mutation: before=%d after=%d", beforeCommit, afterCommit)
+	}
+
+	matched, modified, err := client.ReplaceBatch(guardedCtx, "users", collections.DocumentFormatJSON,
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"x":2}`)},
+		AckVisible,
+	)
+	if err != nil {
+		t.Fatalf("ReplaceBatch with catalog version predating data commit: %v", err)
+	}
+	if matched != 1 || modified != 1 {
+		t.Fatalf("matched=%d modified=%d want 1/1", matched, modified)
+	}
+	if after := clientCatalogVersion(t, client, ctx); after != version {
+		t.Fatalf("data mutations changed catalog version from %d to %d", version, after)
+	}
+}
+
+func TestMutationCatalogGuardRejectsPriorVersionAfterMetadataChange(t *testing.T) {
+	client, _, _ := serveCollectionPipe(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := client.Hello(ctx); err != nil {
+		t.Fatalf("Hello: %v", err)
+	}
+	if _, err := client.CreateCollection(ctx, collections.CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+
+	version := clientCatalogVersion(t, client, ctx)
+	if _, err := client.CreateIndex(WithExpectedCatalogVersion(ctx, version), "users", collections.IndexDefinition{
+		Name:      "email",
+		Field:     "email",
+		ValueType: collections.IndexValueString,
+	}); err != nil {
+		t.Fatalf("CreateIndex: %v", err)
+	}
+	after := clientCatalogVersion(t, client, ctx)
+	if after == version {
+		t.Fatalf("metadata mutation did not advance catalog version: %d", after)
+	}
+
+	_, err := client.InsertBatch(WithExpectedCatalogVersion(ctx, version), "users", collections.DocumentFormatJSON,
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"email":"ada@example.com"}`)},
+		AckVisible,
+	)
+	if !isRemoteError(err, iwire.ErrCatalogVersionMismatch) {
+		t.Fatalf("InsertBatch with stale schema version err=%v want catalog mismatch", err)
+	}
+	if _, err := client.InsertBatch(WithExpectedCatalogVersion(ctx, after), "users", collections.DocumentFormatJSON,
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"email":"ada@example.com"}`)},
+		AckVisible,
+	); err != nil {
+		t.Fatalf("InsertBatch with current schema version: %v", err)
 	}
 }
 
@@ -813,7 +904,8 @@ func TestMutationCatalogVersionCacheClearsAfterMismatch(t *testing.T) {
 	if _, err := client.CreateCollection(ctx, collections.CollectionMeta{Name: "users"}); err != nil {
 		t.Fatalf("CreateCollection: %v", err)
 	}
-	client.catalogVersionPlusOne.Store(1)
+	version := clientCatalogVersion(t, client, ctx)
+	client.catalogVersionPlusOne.Store(version + 2)
 	_, err := client.InsertBatch(ctx, "users", collections.DocumentFormatJSON,
 		[][]byte{[]byte("u1")},
 		[][]byte{[]byte(`{"x":1}`)},

--- a/TreeDB/nativewire/server.go
+++ b/TreeDB/nativewire/server.go
@@ -104,6 +104,7 @@ type Server struct {
 	registry                      *iwire.Registry
 	collections                   *collections.CollectionManager
 	backend                       *backenddb.DB
+	catalogVersion                atomic.Uint64
 
 	closed              atomic.Bool
 	connMu              sync.Mutex
@@ -322,7 +323,7 @@ func NewServer(opts ServerOptions) *Server {
 	if maxMetadataIdempotencyEntries == 0 {
 		maxMetadataIdempotencyEntries = defaultMaxMetadataIdempotencyEntries
 	}
-	return &Server{
+	server := &Server{
 		limits:                        limits,
 		maxInFlight:                   maxInFlight,
 		maxConnections:                maxConnections,
@@ -340,6 +341,8 @@ func NewServer(opts ServerOptions) *Server {
 		backend:                       opts.Backend,
 		cursorReaperDone:              make(chan struct{}),
 	}
+	server.catalogVersion.Store(initialCatalogVersion(opts.Backend))
+	return server
 }
 
 // Close closes all active server connections and rejects new ones.

--- a/TreeDB/nativewire/server_metadata.go
+++ b/TreeDB/nativewire/server_metadata.go
@@ -39,11 +39,13 @@ func (s *Server) handleCreateCollection(sections []iwire.Section) ([]iwire.Secti
 
 	logDebug("handleCreateCollection: creating collection with dataPolicy=%s indexPolicy=%s", meta.Options.DataRootStoragePolicy, meta.Options.IndexStateStoragePolicy)
 
+	before := s.backendCommitSeq()
 	created, err := s.collections.CreateCollection(&meta)
 	if err != nil {
 		logDebug("handleCreateCollection: CreateCollection failed: %v", err)
 		return nil, metadataWrap(err)
 	}
+	s.bumpCatalogVersionIfBackendAdvanced(before)
 	logDebug("handleCreateCollection: CreateCollection success")
 	return remember([]iwire.Section{{ID: iwire.SectionCollectionMeta, Bytes: encodeCollectionMeta(*created)}}), nil
 }
@@ -97,10 +99,12 @@ func (s *Server) handleCreateIndex(state *connState, sections []iwire.Section) (
 			return nil, protocolError(iwire.ErrInvalidCommand, "duplicate index %q", def.Name)
 		}
 	}
+	before := s.backendCommitSeq()
 	meta, err := collection.CreateIndex(def)
 	if err != nil {
 		return nil, metadataWrap(err)
 	}
+	s.bumpCatalogVersionIfBackendAdvanced(before)
 	if state != nil {
 		state.cacheCollection(name, collection, s.maxCachedCollections)
 	}
@@ -145,10 +149,12 @@ func (s *Server) handleDropIndex(state *connState, sections []iwire.Section) ([]
 	if err != nil {
 		return nil, metadataWrap(err)
 	}
+	before := s.backendCommitSeq()
 	meta, err := collection.DropIndex(indexName)
 	if err != nil {
 		return nil, metadataWrap(err)
 	}
+	s.bumpCatalogVersionIfBackendAdvanced(before)
 	if state != nil {
 		state.cacheCollection(name, collection, s.maxCachedCollections)
 	}

--- a/TreeDB/nativewire/server_metadata.go
+++ b/TreeDB/nativewire/server_metadata.go
@@ -39,13 +39,13 @@ func (s *Server) handleCreateCollection(sections []iwire.Section) ([]iwire.Secti
 
 	logDebug("handleCreateCollection: creating collection with dataPolicy=%s indexPolicy=%s", meta.Options.DataRootStoragePolicy, meta.Options.IndexStateStoragePolicy)
 
-	before := s.backendCommitSeq()
+	before, beforeOK := s.catalogMetadataFingerprint()
 	created, err := s.collections.CreateCollection(&meta)
 	if err != nil {
 		logDebug("handleCreateCollection: CreateCollection failed: %v", err)
 		return nil, metadataWrap(err)
 	}
-	s.bumpCatalogVersionIfBackendAdvanced(before)
+	s.bumpCatalogVersionIfCatalogMetadataChanged(before, beforeOK)
 	logDebug("handleCreateCollection: CreateCollection success")
 	return remember([]iwire.Section{{ID: iwire.SectionCollectionMeta, Bytes: encodeCollectionMeta(*created)}}), nil
 }
@@ -99,12 +99,12 @@ func (s *Server) handleCreateIndex(state *connState, sections []iwire.Section) (
 			return nil, protocolError(iwire.ErrInvalidCommand, "duplicate index %q", def.Name)
 		}
 	}
-	before := s.backendCommitSeq()
+	before, beforeOK := s.catalogMetadataFingerprint()
 	meta, err := collection.CreateIndex(def)
 	if err != nil {
 		return nil, metadataWrap(err)
 	}
-	s.bumpCatalogVersionIfBackendAdvanced(before)
+	s.bumpCatalogVersionIfCatalogMetadataChanged(before, beforeOK)
 	if state != nil {
 		state.cacheCollection(name, collection, s.maxCachedCollections)
 	}
@@ -149,12 +149,12 @@ func (s *Server) handleDropIndex(state *connState, sections []iwire.Section) ([]
 	if err != nil {
 		return nil, metadataWrap(err)
 	}
-	before := s.backendCommitSeq()
+	before, beforeOK := s.catalogMetadataFingerprint()
 	meta, err := collection.DropIndex(indexName)
 	if err != nil {
 		return nil, metadataWrap(err)
 	}
-	s.bumpCatalogVersionIfBackendAdvanced(before)
+	s.bumpCatalogVersionIfCatalogMetadataChanged(before, beforeOK)
 	if state != nil {
 		state.cacheCollection(name, collection, s.maxCachedCollections)
 	}


### PR DESCRIPTION
## Summary

Updates #2051.

This PR lands the first mature YCSB performance/correctness slice for `treedb-native`:

- decouples nativewire catalog/schema guard versions from ordinary backend data commit sequence advancement, so concurrent YCSB updates no longer invalidate each other through catalog-version retry loops;
- fixes DB pruning to account for DB-level in-flight snapshot acquisition pins, not only index registry pins, which eliminated the large-run read/checksum failures found while profiling;
- lets value-log rotations honor relaxed-sync mode, matching the existing commit-log rotation contract and removing the default fast-profile 32 MiB leaf-generation fsync tail without changing the value-log segment size policy.

## Correctness notes

- Metadata mutations remain serialized under `metadataMu`, idempotency replay still precedes catalog-guard evaluation, and guarded data mutations still reject stale versions after an actual schema/catalog mutation.
- The catalog version remains server-advertised and starts from the backend commit sequence on server startup for monotonic reconnect behavior, but ordinary data commits no longer advance it during a live server session.
- The value log remains persistent storage. This change only skips rotate-time fsyncs when the DB is already running with relaxed sync; explicit `Sync()` still fsyncs the active value-log file.

## Tests

Local host: `Linux mikers-B560-DS3H-AC-Y1 6.8.0-111-generic`, Intel i5-11400F, 6 cores / 12 threads.

```sh
go test ./TreeDB/internal/valuelog ./TreeDB/caching ./TreeDB/db ./TreeDB/nativewire ./cmd/treedb-native-server -count=1
# ok github.com/snissn/gomap/TreeDB/internal/valuelog 3.003s
# ok github.com/snissn/gomap/TreeDB/caching 101.596s
# ok github.com/snissn/gomap/TreeDB/db 358.718s
# ok github.com/snissn/gomap/TreeDB/nativewire 1.370s
# ?  github.com/snissn/gomap/cmd/treedb-native-server [no test files]

go test ./TreeDB/collections -count=1
# ok github.com/snissn/gomap/TreeDB/collections 154.763s
```

## Benchmark evidence

YCSB client: `/home/mikers/dev/pingcap/go-ycsb` at `6f6d1b7`.
Server command shape:

```sh
./bin/treedb-native-server -dir "$DB_DIR" -profile fast -addr 127.0.0.1:17100
./bin/go-ycsb load treedb-native -p treedb.addr=127.0.0.1:17100 -p recordcount=100000 -p operationcount=10000 -p threadcount=16
./bin/go-ycsb run  treedb-native -p treedb.addr=127.0.0.1:17100 -p recordcount=100000 -p operationcount=10000 -p threadcount=16
```

### 10k run, full request accounting

| Branch/commit | Artifact | Load insert OPS | Run total OPS | Update avg | Update max | Replace requests | Stats requests | Catalog mismatches | Errors |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| baseline `aff22b29a` | `/tmp/treedb_ycsb_instrumented_cTqCVo` | 41,328 | 25,207 | 8,115 us | 129,599 us | 1,672 | 1,168 | 1,135 | none |
| this PR `74ab1b1f2` | `/tmp/treedb_ycsb_postrotate_counts_4GJO0e` | 42,351 | 74,231 | 699 us | 3,581 us | 527 | 33 | 0 | none |

The baseline had 537 logical YCSB updates and 1,672 server `replace_batch` calls; the extra 1,135 calls matched catalog-version mismatch retries. This PR's 10k run had 527 logical updates and exactly 527 `replace_batch` calls.

### 1M run and CPU profile

Command shape:

```sh
TREEDB_NATIVE_SLOW_REQUEST=5ms ./bin/treedb-native-server \
  -dir "$DB_DIR" -profile fast -addr 127.0.0.1:17105 -pprof 127.0.0.1:18105
./bin/go-ycsb load treedb-native -p treedb.addr=127.0.0.1:17105 -p recordcount=100000 -p operationcount=10000 -p threadcount=16
curl -sS "http://127.0.0.1:18105/debug/pprof/profile?seconds=5" -o "$RUN_DIR/server_cpu.pprof" &
./bin/go-ycsb run treedb-native -p treedb.addr=127.0.0.1:17105 -p recordcount=100000 -p operationcount=1000000 -p threadcount=16
```

Final artifact: `/tmp/treedb_ycsb_final_pprof_7TC6cI`.

| Metric | Result |
| --- | ---: |
| Load insert OPS | 44,452 |
| Run total OPS | 81,487 |
| READ count / avg / p99 / p99.9 / max | 949,872 / 168 us / 546 us / 978 us / 4,843 us |
| UPDATE count / avg / p99 / p99.9 / max | 50,128 / 627 us / 1,655 us / 2,589 us / 4,831 us |
| TOTAL avg / p99 / p99.9 / max | 191 us / 855 us / 1,462 us / 4,843 us |
| YCSB errors | none |

The final CPU profile no longer shows `nativewire.(*Server).Stats` or `nativewire.appendStringMap` in the top profile. Slow-request logs for that final run only showed load-phase `insert_batch_fast` and close-phase `flush_all`; no run-phase request exceeded the 5 ms threshold.

## Follow-up scope

This does not close the broader tracker. I still expect follow-up profiling work around remaining syscall/read-path cost and any additional nativewire/server hot spots once this slice is reviewed and merged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional control over file synchronization when rotating value logs.
  * Server-side catalog version tracking to keep metadata consistency.

* **Bug Fixes**
  * Pruning now protects in-flight snapshots to avoid freeing active pages.

* **Tests**
  * Added tests verifying rotation sync behavior and pruning protection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->