### PR TITLE
Add reusable graph direct-view certifiers

### DIFF
--- a/TreeDB/docs/spec/typed-column-graph-search-admission.md
+++ b/TreeDB/docs/spec/typed-column-graph-search-admission.md
@@ -7,8 +7,9 @@ and the #2036 prepared runtime-view contract in
 `typed-column-graph-search-prepared-views.md`.
 
 This document owns the repo-level readiness table that descendants must update
-before adding, changing, or promoting graph-search typed-column state roles. It
-does not implement reusable direct-view certifier APIs (#2046), type-specific
+before adding, changing, or promoting graph-search typed-column state roles. The
+reusable #2046 direct-view certifier substrate lives in
+`TreeDB/internal/typeddecode`, but this table does not implement type-specific
 prepared views (#2038/#2040/#2041), graph-search routing (#2045), hot-loop
 telemetry reduction (#2042), or benchmark truth-matrix collection (#2037).
 

--- a/TreeDB/docs/spec/typed-column-graph-search-prepared-views.md
+++ b/TreeDB/docs/spec/typed-column-graph-search-prepared-views.md
@@ -9,10 +9,11 @@ It consumes the tier vocabulary and generic type matrix in
 
 The #2044 readiness/admission table and docs-lint enforcement live in
 `typed-column-graph-search-admission.md`. This document does not implement
-runtime graph-search admission enforcement (#2044), reusable direct-view
-certifiers (#2046), type-specific prepared views (#2038/#2040/#2041), or the
-benchmark truth matrix (#2037). It defines the contract those issues must
-satisfy.
+runtime graph-search admission enforcement (#2044), type-specific prepared views
+(#2038/#2040/#2041), graph-search routing, or the benchmark truth matrix
+(#2037). The reusable #2046 primitive certifier substrate lives in
+`TreeDB/internal/typeddecode` and remains a prerequisite, not row-admission
+evidence by itself.
 
 ## Scope and ownership
 
@@ -38,8 +39,11 @@ Normative boundaries:
   state listed below unless `typed-column-graph-search-admission.md` admits a
   weaker tier for one named role with tests, counters, allocation evidence,
   memory evidence, and benchmark evidence.
-- #2046 owns reusable certifier APIs. This spec names the role-specific facts
-  those certifiers must prove before prepared views are trusted.
+- #2046 owns reusable certifier APIs. The shared `typeddecode` substrate
+  certifies primitive owner/role/column identity, logical type and encoding,
+  row counts, endian, wrapper, offset/bounds, alignment, direct-view handle, and
+  lifetime conditions; this spec names the additional role-specific facts those
+  certifiers and callers must prove before prepared views are trusted.
 - #2037 owns the benchmark matrix. This spec defines the timing boundaries and
   counters that benchmark matrix must report.
 

--- a/TreeDB/docs/spec/typed-column-optimized-consumer-capabilities.md
+++ b/TreeDB/docs/spec/typed-column-optimized-consumer-capabilities.md
@@ -7,8 +7,9 @@ by their highest committed optimized-consumer tier. The role-specific prepared
 graph-search view policy lives in
 `typed-column-graph-search-prepared-views.md`, and the #2044 readiness/admission
 table lives in `typed-column-graph-search-admission.md`; this document does not
-implement those views (#2036), graph-search admission enforcement (#2044), or
-reusable direct-view certifier APIs (#2046).
+implement those views (#2036) or graph-search admission enforcement (#2044). The
+reusable #2046 direct-view certifier substrate lives in
+`TreeDB/internal/typeddecode` and consumes the `mmap_direct` row contracts here.
 
 The matrix complements the semantic capability matrix in
 `typed-column-semantics.md`, the physical layout/codec contract in
@@ -40,8 +41,10 @@ pointers must not be described as transient or WAL-like storage.
   channels such as row refs and document IDs may be touched only at the documented
   result/materialization boundary.
 - Reusable direct-view certification and helper API work belongs to #2046. Rows
-  marked `mmap_direct` define the contract #2046 should certify; this PR does
-  not add new certifier implementation.
+  marked `mmap_direct` define the contract certified by the shared #2046
+  `typeddecode` substrate; type-specific graph-search tickets must still provide
+  role-specific prepared views, counters, and admission evidence before changing
+  #2044 row status.
 - Adding a new collection logical value type, `typedcolumn.ColumnType`, or
   `typedcolumn.Encoding` must update this document and the docs-lint coverage in
   `TreeDB/docs/column_store_capability_matrix_test.go` before merge.

--- a/TreeDB/internal/typeddecode/graph_direct_view.go
+++ b/TreeDB/internal/typeddecode/graph_direct_view.go
@@ -36,6 +36,7 @@ type GraphFloat32VectorDirectViewRequest struct {
 	Dims          int
 	Certification typedcolumn.ColumnPartLayoutContractColumn
 	Section       typedcolumn.ColumnPartImageSection
+	ExpectedKey   mappedresource.Key
 	Handle        *mappedresource.Handle
 	Manager       *mappedresource.Manager
 }
@@ -44,6 +45,7 @@ type GraphFloat32DirectViewRequest struct {
 	Expectation   GraphDirectViewExpectation
 	Certification typedcolumn.ColumnPartLayoutContractColumn
 	Section       typedcolumn.ColumnPartImageSection
+	ExpectedKey   mappedresource.Key
 	Handle        *mappedresource.Handle
 	Manager       *mappedresource.Manager
 }
@@ -52,28 +54,33 @@ type GraphInt64DirectViewRequest struct {
 	Expectation   GraphDirectViewExpectation
 	Certification typedcolumn.ColumnPartLayoutContractColumn
 	Section       typedcolumn.ColumnPartImageSection
+	ExpectedKey   mappedresource.Key
 	Handle        *mappedresource.Handle
 	Manager       *mappedresource.Manager
 }
 
 type GraphUint32ListDirectViewRequest struct {
-	Expectation    GraphDirectViewExpectation
-	Certification  typedcolumn.ColumnPartLayoutContractColumn
-	OffsetsSection typedcolumn.ColumnPartImageSection
-	ValuesSection  typedcolumn.ColumnPartImageSection
-	OffsetsHandle  *mappedresource.Handle
-	ValuesHandle   *mappedresource.Handle
-	Manager        *mappedresource.Manager
+	Expectation        GraphDirectViewExpectation
+	Certification      typedcolumn.ColumnPartLayoutContractColumn
+	OffsetsSection     typedcolumn.ColumnPartImageSection
+	ValuesSection      typedcolumn.ColumnPartImageSection
+	ExpectedOffsetsKey mappedresource.Key
+	ExpectedValuesKey  mappedresource.Key
+	OffsetsHandle      *mappedresource.Handle
+	ValuesHandle       *mappedresource.Handle
+	Manager            *mappedresource.Manager
 }
 
 type GraphBytesDirectViewRequest struct {
-	Expectation    GraphDirectViewExpectation
-	Certification  typedcolumn.ColumnPartLayoutContractColumn
-	OffsetsSection typedcolumn.ColumnPartImageSection
-	ValuesSection  typedcolumn.ColumnPartImageSection
-	OffsetsHandle  *mappedresource.Handle
-	ValuesHandle   *mappedresource.Handle
-	Manager        *mappedresource.Manager
+	Expectation        GraphDirectViewExpectation
+	Certification      typedcolumn.ColumnPartLayoutContractColumn
+	OffsetsSection     typedcolumn.ColumnPartImageSection
+	ValuesSection      typedcolumn.ColumnPartImageSection
+	ExpectedOffsetsKey mappedresource.Key
+	ExpectedValuesKey  mappedresource.Key
+	OffsetsHandle      *mappedresource.Handle
+	ValuesHandle       *mappedresource.Handle
+	Manager            *mappedresource.Manager
 }
 
 // PreparedFloat32VectorDirectView is a certified row-major graph-search vector
@@ -150,7 +157,7 @@ func CertifyGraphFloat32VectorDirectView(req GraphFloat32VectorDirectViewRequest
 	if status := ValidateDirectViewColumn(directReq); !status.Direct() {
 		return PreparedFloat32VectorDirectView{}, status
 	}
-	if status := validateFixedWidthGraphHandle(req.Handle, exp, req.Section, typedcolumn.EncodingRawFloat32Vector); !status.Direct() {
+	if status := validateFixedWidthGraphHandle(req.Handle, exp, req.Section, typedcolumn.EncodingRawFloat32Vector, req.ExpectedKey); !status.Direct() {
 		return PreparedFloat32VectorDirectView{}, status
 	}
 	expectedElements, ok := checkedMul3(exp.Rows, req.Dims, 1)
@@ -177,7 +184,7 @@ func CertifyGraphFloat32DirectView(req GraphFloat32DirectViewRequest) (PreparedF
 	if status := ValidateDirectViewColumn(directReq); !status.Direct() {
 		return PreparedFloat32DirectView{}, status
 	}
-	if status := validateFixedWidthGraphHandle(req.Handle, exp, req.Section, typedcolumn.EncodingRawFloat32); !status.Direct() {
+	if status := validateFixedWidthGraphHandle(req.Handle, exp, req.Section, typedcolumn.EncodingRawFloat32, req.ExpectedKey); !status.Direct() {
 		return PreparedFloat32DirectView{}, status
 	}
 	values, status := Float32ScalarView(req.Manager, req.Handle, directReq, ResourceViewOptions{ExpectedElements: exp.Rows, RequireMapped: true})
@@ -200,7 +207,7 @@ func CertifyGraphInt64DirectView(req GraphInt64DirectViewRequest) (PreparedInt64
 	if status := ValidateDirectViewColumn(directReq); !status.Direct() {
 		return PreparedInt64DirectView{}, status
 	}
-	if status := validateFixedWidthGraphHandle(req.Handle, exp, req.Section, typedcolumn.EncodingRawInt64); !status.Direct() {
+	if status := validateFixedWidthGraphHandle(req.Handle, exp, req.Section, typedcolumn.EncodingRawInt64, req.ExpectedKey); !status.Direct() {
 		return PreparedInt64DirectView{}, status
 	}
 	values, status := Int64View(req.Manager, req.Handle, ResourceViewOptions{ExpectedElements: exp.Rows, RequireMapped: true})
@@ -223,7 +230,7 @@ func CertifyGraphUint32ListDirectView(req GraphUint32ListDirectViewRequest) (Pre
 	if status := ValidateUint32OffsetsListDirectViewSections(directReq); !status.Direct() {
 		return PreparedUint32ListDirectView{}, status
 	}
-	if status := validateOffsetsValuesGraphHandles(req.OffsetsHandle, req.ValuesHandle, exp, req.OffsetsSection, req.ValuesSection, typedcolumn.EncodingRawUint32OffsetsList); !status.Direct() {
+	if status := validateOffsetsValuesGraphHandles(req.OffsetsHandle, req.ValuesHandle, exp, req.OffsetsSection, req.ValuesSection, typedcolumn.EncodingRawUint32OffsetsList, req.ExpectedOffsetsKey, req.ExpectedValuesKey); !status.Direct() {
 		return PreparedUint32ListDirectView{}, status
 	}
 	offsets, values, status := Uint32ListView(req.Manager, req.OffsetsHandle, req.ValuesHandle, directReq, ResourceViewOptions{RequireMapped: true})
@@ -246,7 +253,7 @@ func CertifyGraphBytesDirectView(req GraphBytesDirectViewRequest) (PreparedBytes
 	if status := ValidateBytesDirectViewSections(directReq); !status.Direct() {
 		return PreparedBytesDirectView{}, status
 	}
-	if status := validateOffsetsValuesGraphHandles(req.OffsetsHandle, req.ValuesHandle, exp, req.OffsetsSection, req.ValuesSection, typedcolumn.EncodingRawBytesOffsets); !status.Direct() {
+	if status := validateOffsetsValuesGraphHandles(req.OffsetsHandle, req.ValuesHandle, exp, req.OffsetsSection, req.ValuesSection, typedcolumn.EncodingRawBytesOffsets, req.ExpectedOffsetsKey, req.ExpectedValuesKey); !status.Direct() {
 		return PreparedBytesDirectView{}, status
 	}
 	offsets, values, status := BytesView(req.Manager, req.OffsetsHandle, req.ValuesHandle, directReq, ResourceViewOptions{RequireMapped: true})
@@ -331,45 +338,58 @@ func validateOffsetsValuesGraphSections(exp GraphDirectViewExpectation, cert typ
 	return DirectStatus()
 }
 
-func validateFixedWidthGraphHandle(h *mappedresource.Handle, exp GraphDirectViewExpectation, section typedcolumn.ColumnPartImageSection, encoding typedcolumn.Encoding) Status {
+func validateFixedWidthGraphHandle(h *mappedresource.Handle, exp GraphDirectViewExpectation, section typedcolumn.ColumnPartImageSection, encoding typedcolumn.Encoding, expectedKey mappedresource.Key) Status {
 	if status := validateHandle(h, mappedresource.SourceMapped, true); !status.Direct() {
 		return status
 	}
-	return validateGraphHandleKey(h, exp, section.Kind, section.Category, section.Length, encoding)
+	return validateGraphHandleKey(h, exp, section.Kind, section.Category, section.Length, encoding, expectedKey)
 }
 
-func validateOffsetsValuesGraphHandles(offsetsHandle, valuesHandle *mappedresource.Handle, exp GraphDirectViewExpectation, offsetsSection, valuesSection typedcolumn.ColumnPartImageSection, encoding typedcolumn.Encoding) Status {
+func validateOffsetsValuesGraphHandles(offsetsHandle, valuesHandle *mappedresource.Handle, exp GraphDirectViewExpectation, offsetsSection, valuesSection typedcolumn.ColumnPartImageSection, encoding typedcolumn.Encoding, expectedOffsetsKey, expectedValuesKey mappedresource.Key) Status {
 	if status := validateHandle(offsetsHandle, mappedresource.SourceMapped, true); !status.Direct() {
 		return status
 	}
 	if status := validateHandle(valuesHandle, mappedresource.SourceMapped, true); !status.Direct() {
 		return status
 	}
-	if status := validateGraphHandleKey(offsetsHandle, exp, offsetsSection.Kind, offsetsSection.Category, offsetsSection.Length, encoding); !status.Direct() {
+	if status := validateGraphHandleKey(offsetsHandle, exp, offsetsSection.Kind, offsetsSection.Category, offsetsSection.Length, encoding, expectedOffsetsKey); !status.Direct() {
 		return status
 	}
-	return validateGraphHandleKey(valuesHandle, exp, valuesSection.Kind, valuesSection.Category, valuesSection.Length, encoding)
+	return validateGraphHandleKey(valuesHandle, exp, valuesSection.Kind, valuesSection.Category, valuesSection.Length, encoding, expectedValuesKey)
 }
 
-func validateGraphHandleKey(h *mappedresource.Handle, exp GraphDirectViewExpectation, kind typedcolumn.ColumnPartImageSectionKind, category typedcolumn.ColumnPartImageSectionCategory, length int, encoding typedcolumn.Encoding) Status {
+func validateGraphHandleKey(h *mappedresource.Handle, exp GraphDirectViewExpectation, kind typedcolumn.ColumnPartImageSectionKind, category typedcolumn.ColumnPartImageSectionCategory, length int, encoding typedcolumn.Encoding, expectedKey mappedresource.Key) Status {
 	key := h.Key()
+	if status := validateGraphHandleKeyLayout(key, exp, kind, category, length, encoding, "resource"); !status.Direct() {
+		return status
+	}
+	if status := validateGraphHandleKeyLayout(expectedKey, exp, kind, category, length, encoding, "expected resource"); !status.Direct() {
+		return status
+	}
+	if key.Namespace != expectedKey.Namespace || key.Kind != expectedKey.Kind || key.Generation != expectedKey.Generation || key.PartID != expectedKey.PartID || key.FileID != expectedKey.FileID || key.Offset != expectedKey.Offset || key.Checksum != expectedKey.Checksum || key.Version != expectedKey.Version || key.Section.Name != expectedKey.Section.Name || key.Section.Ordinal != expectedKey.Section.Ordinal {
+		return UnsupportedStatus(ReasonResourceMismatch, fmt.Sprintf("resource identity namespace/kind/generation/part/file/offset/checksum/version/section_name/section_ordinal=(%q,%q,%d,%d,%d,%d,%d,%d,%q,%d) want (%q,%q,%d,%d,%d,%d,%d,%d,%q,%d)", key.Namespace, key.Kind, key.Generation, key.PartID, key.FileID, key.Offset, key.Checksum, key.Version, key.Section.Name, key.Section.Ordinal, expectedKey.Namespace, expectedKey.Kind, expectedKey.Generation, expectedKey.PartID, expectedKey.FileID, expectedKey.Offset, expectedKey.Checksum, expectedKey.Version, expectedKey.Section.Name, expectedKey.Section.Ordinal))
+	}
+	return DirectStatus()
+}
+
+func validateGraphHandleKeyLayout(key mappedresource.Key, exp GraphDirectViewExpectation, kind typedcolumn.ColumnPartImageSectionKind, category typedcolumn.ColumnPartImageSectionCategory, length int, encoding typedcolumn.Encoding, label string) Status {
 	if key.Class != mappedresource.ClassTypedColumnAsset {
-		return UnsupportedStatus(ReasonOwnerMismatch, fmt.Sprintf("resource class=%s want %s", key.Class, mappedresource.ClassTypedColumnAsset))
+		return UnsupportedStatus(ReasonOwnerMismatch, fmt.Sprintf("%s class=%s want %s", label, key.Class, mappedresource.ClassTypedColumnAsset))
 	}
 	if key.Section.Column != exp.Column {
-		return UnsupportedStatus(ReasonColumnMismatch, fmt.Sprintf("resource column=%q want %q", key.Section.Column, exp.Column))
+		return UnsupportedStatus(ReasonColumnMismatch, fmt.Sprintf("%s column=%q want %q", label, key.Section.Column, exp.Column))
 	}
 	if key.Section.Kind != string(kind) {
-		return UnsupportedStatus(ReasonColumnMismatch, fmt.Sprintf("resource section kind=%q want %q", key.Section.Kind, kind))
+		return UnsupportedStatus(ReasonColumnMismatch, fmt.Sprintf("%s section kind=%q want %q", label, key.Section.Kind, kind))
 	}
 	if key.Section.Category != string(category) {
-		return UnsupportedStatus(ReasonColumnMismatch, fmt.Sprintf("resource section category=%q want %q", key.Section.Category, category))
+		return UnsupportedStatus(ReasonColumnMismatch, fmt.Sprintf("%s section category=%q want %q", label, key.Section.Category, category))
 	}
 	if key.Encoding != encoding.String() {
-		return UnsupportedStatus(ReasonTypeEncodingMismatch, fmt.Sprintf("resource encoding=%q want %q", key.Encoding, encoding.String()))
+		return UnsupportedStatus(ReasonTypeEncodingMismatch, fmt.Sprintf("%s encoding=%q want %q", label, key.Encoding, encoding.String()))
 	}
 	if key.Length != int64(length) {
-		return UnsupportedStatus(ReasonPayloadLengthMismatch, fmt.Sprintf("resource length=%d want %d", key.Length, length))
+		return UnsupportedStatus(ReasonPayloadLengthMismatch, fmt.Sprintf("%s length=%d want %d", label, key.Length, length))
 	}
 	return DirectStatus()
 }

--- a/TreeDB/internal/typeddecode/graph_direct_view.go
+++ b/TreeDB/internal/typeddecode/graph_direct_view.go
@@ -1,0 +1,523 @@
+package typeddecode
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/snissn/gomap/TreeDB/internal/columnlayout"
+	"github.com/snissn/gomap/TreeDB/internal/columnsemantics"
+	"github.com/snissn/gomap/TreeDB/internal/mappedresource"
+	"github.com/snissn/gomap/TreeDB/internal/typedcolumn"
+)
+
+// GraphDirectViewExpectation is the caller-supplied identity and shape contract
+// for graph-search typed-column direct-view certification. The reusable helper
+// validates these fields against the writer-certified typed-column layout and
+// the live mappedresource handles before returning a prepared direct view.
+//
+// ExpectedOwner/ExpectedRole identify the graph/typed-column state the caller is
+// preparing, while ActualOwner/ActualRole must come from the caller's manifest or
+// asset context. The primitive certifier intentionally does not replace
+// graph-owned TVIS/manifest validation; it fails closed when those supplied
+// identities do not match.
+type GraphDirectViewExpectation struct {
+	ExpectedOwner  string
+	ActualOwner    string
+	ExpectedRole   string
+	ActualRole     string
+	Column         string
+	Rows           int
+	AssetOffset    int64
+	HasAssetOffset bool
+}
+
+type GraphFloat32VectorDirectViewRequest struct {
+	Expectation   GraphDirectViewExpectation
+	Dims          int
+	Certification typedcolumn.ColumnPartLayoutContractColumn
+	Section       typedcolumn.ColumnPartImageSection
+	Handle        *mappedresource.Handle
+	Manager       *mappedresource.Manager
+}
+
+type GraphFloat32DirectViewRequest struct {
+	Expectation   GraphDirectViewExpectation
+	Certification typedcolumn.ColumnPartLayoutContractColumn
+	Section       typedcolumn.ColumnPartImageSection
+	Handle        *mappedresource.Handle
+	Manager       *mappedresource.Manager
+}
+
+type GraphInt64DirectViewRequest struct {
+	Expectation   GraphDirectViewExpectation
+	Certification typedcolumn.ColumnPartLayoutContractColumn
+	Section       typedcolumn.ColumnPartImageSection
+	Handle        *mappedresource.Handle
+	Manager       *mappedresource.Manager
+}
+
+type GraphUint32ListDirectViewRequest struct {
+	Expectation    GraphDirectViewExpectation
+	Certification  typedcolumn.ColumnPartLayoutContractColumn
+	OffsetsSection typedcolumn.ColumnPartImageSection
+	ValuesSection  typedcolumn.ColumnPartImageSection
+	OffsetsHandle  *mappedresource.Handle
+	ValuesHandle   *mappedresource.Handle
+	Manager        *mappedresource.Manager
+}
+
+type GraphBytesDirectViewRequest struct {
+	Expectation    GraphDirectViewExpectation
+	Certification  typedcolumn.ColumnPartLayoutContractColumn
+	OffsetsSection typedcolumn.ColumnPartImageSection
+	ValuesSection  typedcolumn.ColumnPartImageSection
+	OffsetsHandle  *mappedresource.Handle
+	ValuesHandle   *mappedresource.Handle
+	Manager        *mappedresource.Manager
+}
+
+// PreparedFloat32VectorDirectView is a certified row-major graph-search vector
+// view. Values aliases Handle and is valid only while Handle remains live.
+type PreparedFloat32VectorDirectView struct {
+	Expectation GraphDirectViewExpectation
+	Rows        int
+	Dims        int
+	Values      []float32
+	Handle      *mappedresource.Handle
+}
+
+// PreparedFloat32DirectView is a certified fixed-width float32 scalar view.
+type PreparedFloat32DirectView struct {
+	Expectation GraphDirectViewExpectation
+	Rows        int
+	Values      []float32
+	Handle      *mappedresource.Handle
+}
+
+// PreparedInt64DirectView is a certified fixed-width int64 scalar view.
+type PreparedInt64DirectView struct {
+	Expectation GraphDirectViewExpectation
+	Rows        int
+	Values      []int64
+	Handle      *mappedresource.Handle
+}
+
+// PreparedUint32ListDirectView is a certified raw_uint32_offsets_list view.
+type PreparedUint32ListDirectView struct {
+	Expectation   GraphDirectViewExpectation
+	Rows          int
+	Offsets       []uint64
+	Values        []uint32
+	OffsetsHandle *mappedresource.Handle
+	ValuesHandle  *mappedresource.Handle
+}
+
+// PreparedBytesDirectView is a certified raw_bytes_offsets view.
+type PreparedBytesDirectView struct {
+	Expectation   GraphDirectViewExpectation
+	Rows          int
+	Offsets       []uint64
+	Values        []byte
+	OffsetsHandle *mappedresource.Handle
+	ValuesHandle  *mappedresource.Handle
+}
+
+func Int64DirectViewPlan(cert typedcolumn.ColumnPartLayoutContractColumn) Plan {
+	layout := columnlayout.CapabilitiesFor(columnlayout.Descriptor{
+		Logical:     columnsemantics.LogicalInt64,
+		Physical:    typedcolumn.ColumnTypeInt64,
+		Encoding:    cert.Encoding,
+		Compression: cert.Compression,
+		Nullable:    cert.NullMaskPresent || cert.NullCount != 0,
+		Defaultable: cert.DefaultMaskPresent || cert.DefaultCount != 0,
+	})
+	return scalarDirectViewPlan(layout, cert, columnsemantics.LogicalInt64, typedcolumn.ColumnTypeInt64, typedcolumn.EncodingRawInt64, 8)
+}
+
+func CertifyGraphFloat32VectorDirectView(req GraphFloat32VectorDirectViewRequest) (PreparedFloat32VectorDirectView, Status) {
+	exp := req.Expectation
+	if status := validateGraphDirectViewExpectation(exp, req.Certification, string(columnsemantics.LogicalFloat32Vector), typedcolumn.ColumnTypeFloat32Vector, typedcolumn.EncodingRawFloat32Vector); !status.Direct() {
+		return PreparedFloat32VectorDirectView{}, status
+	}
+	if req.Dims <= 0 {
+		return PreparedFloat32VectorDirectView{}, UnsupportedStatus(ReasonDimensionMismatch, fmt.Sprintf("dims=%d", req.Dims))
+	}
+	if status := validateFixedWidthGraphSection(exp, req.Certification, req.Section, typedcolumn.EncodingRawFloat32Vector); !status.Direct() {
+		return PreparedFloat32VectorDirectView{}, status
+	}
+	plan := DenseFloat32VectorPlan(req.Certification, req.Dims)
+	directReq := DirectViewColumnRequest{Plan: plan, Certification: req.Certification, Rows: exp.Rows, PayloadBytes: req.Section.Length, AssetOffset: exp.AssetOffset, HasAssetOffset: exp.HasAssetOffset}
+	if status := ValidateDirectViewColumn(directReq); !status.Direct() {
+		return PreparedFloat32VectorDirectView{}, status
+	}
+	if status := validateFixedWidthGraphHandle(req.Handle, exp, req.Section, typedcolumn.EncodingRawFloat32Vector); !status.Direct() {
+		return PreparedFloat32VectorDirectView{}, status
+	}
+	expectedElements, ok := checkedMul3(exp.Rows, req.Dims, 1)
+	if !ok {
+		return PreparedFloat32VectorDirectView{}, UnsupportedStatus(ReasonPayloadLengthMismatch, "float32_vector element count overflow")
+	}
+	values, status := DenseFloat32VectorView(req.Manager, req.Handle, directReq, ResourceViewOptions{ExpectedElements: expectedElements, RequireMapped: true})
+	if !status.Direct() {
+		return PreparedFloat32VectorDirectView{}, status
+	}
+	return PreparedFloat32VectorDirectView{Expectation: exp, Rows: exp.Rows, Dims: req.Dims, Values: values, Handle: req.Handle}, DirectStatus()
+}
+
+func CertifyGraphFloat32DirectView(req GraphFloat32DirectViewRequest) (PreparedFloat32DirectView, Status) {
+	exp := req.Expectation
+	if status := validateGraphDirectViewExpectation(exp, req.Certification, string(columnsemantics.LogicalFloat32), typedcolumn.ColumnTypeFloat32, typedcolumn.EncodingRawFloat32); !status.Direct() {
+		return PreparedFloat32DirectView{}, status
+	}
+	if status := validateFixedWidthGraphSection(exp, req.Certification, req.Section, typedcolumn.EncodingRawFloat32); !status.Direct() {
+		return PreparedFloat32DirectView{}, status
+	}
+	plan := Float32ScalarPlan(req.Certification)
+	directReq := DirectViewColumnRequest{Plan: plan, Certification: req.Certification, Rows: exp.Rows, PayloadBytes: req.Section.Length, AssetOffset: exp.AssetOffset, HasAssetOffset: exp.HasAssetOffset}
+	if status := ValidateDirectViewColumn(directReq); !status.Direct() {
+		return PreparedFloat32DirectView{}, status
+	}
+	if status := validateFixedWidthGraphHandle(req.Handle, exp, req.Section, typedcolumn.EncodingRawFloat32); !status.Direct() {
+		return PreparedFloat32DirectView{}, status
+	}
+	values, status := Float32ScalarView(req.Manager, req.Handle, directReq, ResourceViewOptions{ExpectedElements: exp.Rows, RequireMapped: true})
+	if !status.Direct() {
+		return PreparedFloat32DirectView{}, status
+	}
+	return PreparedFloat32DirectView{Expectation: exp, Rows: exp.Rows, Values: values, Handle: req.Handle}, DirectStatus()
+}
+
+func CertifyGraphInt64DirectView(req GraphInt64DirectViewRequest) (PreparedInt64DirectView, Status) {
+	exp := req.Expectation
+	if status := validateGraphDirectViewExpectation(exp, req.Certification, string(columnsemantics.LogicalInt64), typedcolumn.ColumnTypeInt64, typedcolumn.EncodingRawInt64); !status.Direct() {
+		return PreparedInt64DirectView{}, status
+	}
+	if status := validateFixedWidthGraphSection(exp, req.Certification, req.Section, typedcolumn.EncodingRawInt64); !status.Direct() {
+		return PreparedInt64DirectView{}, status
+	}
+	plan := Int64DirectViewPlan(req.Certification)
+	directReq := DirectViewColumnRequest{Plan: plan, Certification: req.Certification, Rows: exp.Rows, PayloadBytes: req.Section.Length, AssetOffset: exp.AssetOffset, HasAssetOffset: exp.HasAssetOffset}
+	if status := ValidateDirectViewColumn(directReq); !status.Direct() {
+		return PreparedInt64DirectView{}, status
+	}
+	if status := validateFixedWidthGraphHandle(req.Handle, exp, req.Section, typedcolumn.EncodingRawInt64); !status.Direct() {
+		return PreparedInt64DirectView{}, status
+	}
+	values, status := Int64View(req.Manager, req.Handle, ResourceViewOptions{ExpectedElements: exp.Rows, RequireMapped: true})
+	if !status.Direct() {
+		return PreparedInt64DirectView{}, status
+	}
+	return PreparedInt64DirectView{Expectation: exp, Rows: exp.Rows, Values: values, Handle: req.Handle}, DirectStatus()
+}
+
+func CertifyGraphUint32ListDirectView(req GraphUint32ListDirectViewRequest) (PreparedUint32ListDirectView, Status) {
+	exp := req.Expectation
+	if status := validateGraphDirectViewExpectation(exp, req.Certification, string(columnsemantics.LogicalUint32List), typedcolumn.ColumnTypeUint32List, typedcolumn.EncodingRawUint32OffsetsList); !status.Direct() {
+		return PreparedUint32ListDirectView{}, status
+	}
+	if status := validateOffsetsValuesGraphSections(exp, req.Certification, req.OffsetsSection, req.ValuesSection, typedcolumn.EncodingRawUint32OffsetsList, true); !status.Direct() {
+		return PreparedUint32ListDirectView{}, status
+	}
+	plan := Uint32ListPlan(req.Certification)
+	directReq := Uint32OffsetsListDirectViewRequest{Plan: plan, Certification: req.Certification, Rows: exp.Rows, OffsetsBytes: req.OffsetsSection.Length, ValuesBytes: req.ValuesSection.Length, AssetOffset: exp.AssetOffset, HasAssetOffset: exp.HasAssetOffset}
+	if status := ValidateUint32OffsetsListDirectViewSections(directReq); !status.Direct() {
+		return PreparedUint32ListDirectView{}, status
+	}
+	if status := validateOffsetsValuesGraphHandles(req.OffsetsHandle, req.ValuesHandle, exp, req.OffsetsSection, req.ValuesSection, typedcolumn.EncodingRawUint32OffsetsList); !status.Direct() {
+		return PreparedUint32ListDirectView{}, status
+	}
+	offsets, values, status := Uint32ListView(req.Manager, req.OffsetsHandle, req.ValuesHandle, directReq, ResourceViewOptions{RequireMapped: true})
+	if !status.Direct() {
+		return PreparedUint32ListDirectView{}, status
+	}
+	return PreparedUint32ListDirectView{Expectation: exp, Rows: exp.Rows, Offsets: offsets, Values: values, OffsetsHandle: req.OffsetsHandle, ValuesHandle: req.ValuesHandle}, DirectStatus()
+}
+
+func CertifyGraphBytesDirectView(req GraphBytesDirectViewRequest) (PreparedBytesDirectView, Status) {
+	exp := req.Expectation
+	if status := validateGraphDirectViewExpectation(exp, req.Certification, string(columnsemantics.LogicalBytes), typedcolumn.ColumnTypeBytes, typedcolumn.EncodingRawBytesOffsets); !status.Direct() {
+		return PreparedBytesDirectView{}, status
+	}
+	if status := validateOffsetsValuesGraphSections(exp, req.Certification, req.OffsetsSection, req.ValuesSection, typedcolumn.EncodingRawBytesOffsets, false); !status.Direct() {
+		return PreparedBytesDirectView{}, status
+	}
+	plan := BytesPlan(req.Certification)
+	directReq := BytesDirectViewRequest{Plan: plan, Certification: req.Certification, Rows: exp.Rows, OffsetsBytes: req.OffsetsSection.Length, ValuesBytes: req.ValuesSection.Length, AssetOffset: exp.AssetOffset, HasAssetOffset: exp.HasAssetOffset}
+	if status := ValidateBytesDirectViewSections(directReq); !status.Direct() {
+		return PreparedBytesDirectView{}, status
+	}
+	if status := validateOffsetsValuesGraphHandles(req.OffsetsHandle, req.ValuesHandle, exp, req.OffsetsSection, req.ValuesSection, typedcolumn.EncodingRawBytesOffsets); !status.Direct() {
+		return PreparedBytesDirectView{}, status
+	}
+	offsets, values, status := BytesView(req.Manager, req.OffsetsHandle, req.ValuesHandle, directReq, ResourceViewOptions{RequireMapped: true})
+	if !status.Direct() {
+		return PreparedBytesDirectView{}, status
+	}
+	return PreparedBytesDirectView{Expectation: exp, Rows: exp.Rows, Offsets: offsets, Values: values, OffsetsHandle: req.OffsetsHandle, ValuesHandle: req.ValuesHandle}, DirectStatus()
+}
+
+func validateGraphDirectViewExpectation(exp GraphDirectViewExpectation, cert typedcolumn.ColumnPartLayoutContractColumn, logical string, typ typedcolumn.ColumnType, encoding typedcolumn.Encoding) Status {
+	if exp.ExpectedOwner == "" || exp.ActualOwner == "" {
+		return UnsupportedStatus(ReasonOwnerMismatch, fmt.Sprintf("expected_owner=%q actual_owner=%q", exp.ExpectedOwner, exp.ActualOwner))
+	}
+	if exp.ExpectedOwner != exp.ActualOwner {
+		return UnsupportedStatus(ReasonOwnerMismatch, fmt.Sprintf("owner=%q want %q", exp.ActualOwner, exp.ExpectedOwner))
+	}
+	if exp.ExpectedRole == "" || exp.ActualRole == "" {
+		return UnsupportedStatus(ReasonRoleMismatch, fmt.Sprintf("expected_role=%q actual_role=%q", exp.ExpectedRole, exp.ActualRole))
+	}
+	if exp.ExpectedRole != exp.ActualRole {
+		return UnsupportedStatus(ReasonRoleMismatch, fmt.Sprintf("role=%q want %q", exp.ActualRole, exp.ExpectedRole))
+	}
+	if exp.Column == "" || cert.Name != exp.Column {
+		return UnsupportedStatus(ReasonColumnMismatch, fmt.Sprintf("cert_column=%q want %q", cert.Name, exp.Column))
+	}
+	if cert.LogicalType != logical || cert.Type != typ || cert.Encoding != encoding {
+		return UnsupportedStatus(ReasonTypeEncodingMismatch, fmt.Sprintf("logical/type/encoding=(%q,%s,%s) want (%q,%s,%s)", cert.LogicalType, cert.Type, cert.Encoding, logical, typ, encoding))
+	}
+	if exp.Rows < 0 || cert.Rows != exp.Rows {
+		return StreamingStatus(ReasonRowCountMismatch, fmt.Sprintf("cert_rows=%d request_rows=%d", cert.Rows, exp.Rows))
+	}
+	return DirectStatus()
+}
+
+func validateFixedWidthGraphSection(exp GraphDirectViewExpectation, cert typedcolumn.ColumnPartLayoutContractColumn, section typedcolumn.ColumnPartImageSection, encoding typedcolumn.Encoding) Status {
+	if section.Kind != typedcolumn.ColumnPartImageSectionColumnData || section.Category != typedcolumn.ColumnPartImageCategoryDeclaredColumns {
+		return UnsupportedStatus(ReasonColumnMismatch, fmt.Sprintf("section kind/category=(%s,%s) want (%s,%s)", section.Kind, section.Category, typedcolumn.ColumnPartImageSectionColumnData, typedcolumn.ColumnPartImageCategoryDeclaredColumns))
+	}
+	if section.Column != exp.Column {
+		return UnsupportedStatus(ReasonColumnMismatch, fmt.Sprintf("section column=%q want %q", section.Column, exp.Column))
+	}
+	if section.Encoding != encoding {
+		return UnsupportedStatus(ReasonTypeEncodingMismatch, fmt.Sprintf("section encoding=%s want %s", section.Encoding, encoding))
+	}
+	if section.Compression != typedcolumn.CompressionNone {
+		return UnsupportedStatus(ReasonCompressed, fmt.Sprintf("section compression=%s", section.Compression))
+	}
+	if section.Rows != exp.Rows {
+		return StreamingStatus(ReasonRowCountMismatch, fmt.Sprintf("section_rows=%d request_rows=%d", section.Rows, exp.Rows))
+	}
+	if section.Offset != cert.Section.Offset || section.Length != cert.Section.Length {
+		return UnsupportedStatus(ReasonPayloadLengthMismatch, fmt.Sprintf("section offset/length=(%d,%d) cert=(%d,%d)", section.Offset, section.Length, cert.Section.Offset, cert.Section.Length))
+	}
+	return DirectStatus()
+}
+
+func validateOffsetsValuesGraphSections(exp GraphDirectViewExpectation, cert typedcolumn.ColumnPartLayoutContractColumn, offsetsSection, valuesSection typedcolumn.ColumnPartImageSection, encoding typedcolumn.Encoding, valuesNeedUint32Multiple bool) Status {
+	if offsetsSection.Kind != typedcolumn.ColumnPartImageSectionColumnOffsets || offsetsSection.Category != typedcolumn.ColumnPartImageCategoryDeclaredColumnOffsets {
+		return UnsupportedStatus(ReasonColumnMismatch, fmt.Sprintf("offsets section kind/category=(%s,%s)", offsetsSection.Kind, offsetsSection.Category))
+	}
+	if valuesSection.Kind != typedcolumn.ColumnPartImageSectionColumnValues || valuesSection.Category != typedcolumn.ColumnPartImageCategoryDeclaredColumnValues {
+		return UnsupportedStatus(ReasonColumnMismatch, fmt.Sprintf("values section kind/category=(%s,%s)", valuesSection.Kind, valuesSection.Category))
+	}
+	if offsetsSection.Column != exp.Column || valuesSection.Column != exp.Column {
+		return UnsupportedStatus(ReasonColumnMismatch, fmt.Sprintf("section columns offsets=%q values=%q want %q", offsetsSection.Column, valuesSection.Column, exp.Column))
+	}
+	if offsetsSection.Encoding != encoding || valuesSection.Encoding != encoding {
+		return UnsupportedStatus(ReasonTypeEncodingMismatch, fmt.Sprintf("section encodings offsets=%s values=%s want %s", offsetsSection.Encoding, valuesSection.Encoding, encoding))
+	}
+	if offsetsSection.Compression != typedcolumn.CompressionNone || valuesSection.Compression != typedcolumn.CompressionNone {
+		return UnsupportedStatus(ReasonCompressed, fmt.Sprintf("section compression offsets=%s values=%s", offsetsSection.Compression, valuesSection.Compression))
+	}
+	if offsetsSection.Rows != exp.Rows || valuesSection.Rows != exp.Rows {
+		return StreamingStatus(ReasonRowCountMismatch, fmt.Sprintf("section rows offsets=%d values=%d request=%d", offsetsSection.Rows, valuesSection.Rows, exp.Rows))
+	}
+	if offsetsSection.Offset != cert.OffsetsSection.Offset || offsetsSection.Length != cert.OffsetsSection.Length || valuesSection.Offset != cert.ValuesSection.Offset || valuesSection.Length != cert.ValuesSection.Length {
+		return UnsupportedStatus(ReasonPayloadLengthMismatch, fmt.Sprintf("section offset/length mismatch offsets=(%d,%d)/(%d,%d) values=(%d,%d)/(%d,%d)", offsetsSection.Offset, offsetsSection.Length, cert.OffsetsSection.Offset, cert.OffsetsSection.Length, valuesSection.Offset, valuesSection.Length, cert.ValuesSection.Offset, cert.ValuesSection.Length))
+	}
+	if valuesNeedUint32Multiple && valuesSection.Length%4 != 0 {
+		return UnsupportedStatus(ReasonValuesLengthMismatch, fmt.Sprintf("values bytes=%d want multiple of 4", valuesSection.Length))
+	}
+	return DirectStatus()
+}
+
+func validateFixedWidthGraphHandle(h *mappedresource.Handle, exp GraphDirectViewExpectation, section typedcolumn.ColumnPartImageSection, encoding typedcolumn.Encoding) Status {
+	if status := validateHandle(h, mappedresource.SourceMapped, true); !status.Direct() {
+		return status
+	}
+	return validateGraphHandleKey(h, exp, section.Kind, section.Category, section.Length, encoding)
+}
+
+func validateOffsetsValuesGraphHandles(offsetsHandle, valuesHandle *mappedresource.Handle, exp GraphDirectViewExpectation, offsetsSection, valuesSection typedcolumn.ColumnPartImageSection, encoding typedcolumn.Encoding) Status {
+	if status := validateHandle(offsetsHandle, mappedresource.SourceMapped, true); !status.Direct() {
+		return status
+	}
+	if status := validateHandle(valuesHandle, mappedresource.SourceMapped, true); !status.Direct() {
+		return status
+	}
+	if status := validateGraphHandleKey(offsetsHandle, exp, offsetsSection.Kind, offsetsSection.Category, offsetsSection.Length, encoding); !status.Direct() {
+		return status
+	}
+	return validateGraphHandleKey(valuesHandle, exp, valuesSection.Kind, valuesSection.Category, valuesSection.Length, encoding)
+}
+
+func validateGraphHandleKey(h *mappedresource.Handle, exp GraphDirectViewExpectation, kind typedcolumn.ColumnPartImageSectionKind, category typedcolumn.ColumnPartImageSectionCategory, length int, encoding typedcolumn.Encoding) Status {
+	key := h.Key()
+	if key.Class != mappedresource.ClassTypedColumnAsset {
+		return UnsupportedStatus(ReasonOwnerMismatch, fmt.Sprintf("resource class=%s want %s", key.Class, mappedresource.ClassTypedColumnAsset))
+	}
+	if key.Section.Column != exp.Column {
+		return UnsupportedStatus(ReasonColumnMismatch, fmt.Sprintf("resource column=%q want %q", key.Section.Column, exp.Column))
+	}
+	if key.Section.Kind != string(kind) {
+		return UnsupportedStatus(ReasonColumnMismatch, fmt.Sprintf("resource section kind=%q want %q", key.Section.Kind, kind))
+	}
+	if key.Section.Category != string(category) {
+		return UnsupportedStatus(ReasonColumnMismatch, fmt.Sprintf("resource section category=%q want %q", key.Section.Category, category))
+	}
+	if key.Encoding != encoding.String() {
+		return UnsupportedStatus(ReasonTypeEncodingMismatch, fmt.Sprintf("resource encoding=%q want %q", key.Encoding, encoding.String()))
+	}
+	if key.Length != int64(length) {
+		return UnsupportedStatus(ReasonPayloadLengthMismatch, fmt.Sprintf("resource length=%d want %d", key.Length, length))
+	}
+	return DirectStatus()
+}
+
+func (v PreparedFloat32VectorDirectView) Alive() bool {
+	return v.Handle != nil && !v.Handle.Released() && len(v.Values) == v.Rows*v.Dims
+}
+
+func (v PreparedFloat32VectorDirectView) Row(row int) []float32 {
+	if !v.Alive() || row < 0 || row >= v.Rows || v.Dims <= 0 {
+		return nil
+	}
+	start := row * v.Dims
+	end := start + v.Dims
+	if start < 0 || end < start || end > len(v.Values) {
+		return nil
+	}
+	return v.Values[start:end]
+}
+
+func (v *PreparedFloat32VectorDirectView) Close() error {
+	if v == nil {
+		return nil
+	}
+	h := v.Handle
+	v.Handle = nil
+	v.Values = nil
+	v.Rows = 0
+	v.Dims = 0
+	if h == nil {
+		return nil
+	}
+	return h.Release()
+}
+
+func (v PreparedFloat32DirectView) Alive() bool {
+	return v.Handle != nil && !v.Handle.Released() && len(v.Values) == v.Rows
+}
+
+func (v PreparedFloat32DirectView) Value(row int) (float32, bool) {
+	if !v.Alive() || row < 0 || row >= v.Rows {
+		return 0, false
+	}
+	return v.Values[row], true
+}
+
+func (v *PreparedFloat32DirectView) Close() error {
+	if v == nil {
+		return nil
+	}
+	h := v.Handle
+	v.Handle = nil
+	v.Values = nil
+	v.Rows = 0
+	if h == nil {
+		return nil
+	}
+	return h.Release()
+}
+
+func (v PreparedInt64DirectView) Alive() bool {
+	return v.Handle != nil && !v.Handle.Released() && len(v.Values) == v.Rows
+}
+
+func (v PreparedInt64DirectView) Value(row int) (int64, bool) {
+	if !v.Alive() || row < 0 || row >= v.Rows {
+		return 0, false
+	}
+	return v.Values[row], true
+}
+
+func (v *PreparedInt64DirectView) Close() error {
+	if v == nil {
+		return nil
+	}
+	h := v.Handle
+	v.Handle = nil
+	v.Values = nil
+	v.Rows = 0
+	if h == nil {
+		return nil
+	}
+	return h.Release()
+}
+
+func (v PreparedUint32ListDirectView) Alive() bool {
+	return v.OffsetsHandle != nil && v.ValuesHandle != nil && !v.OffsetsHandle.Released() && !v.ValuesHandle.Released() && len(v.Offsets) == v.Rows+1
+}
+
+func (v PreparedUint32ListDirectView) Row(row int) []uint32 {
+	if !v.Alive() || row < 0 || row >= v.Rows {
+		return nil
+	}
+	begin := v.Offsets[row]
+	end := v.Offsets[row+1]
+	if begin > end || begin > uint64(len(v.Values)) || end > uint64(len(v.Values)) {
+		return nil
+	}
+	return v.Values[int(begin):int(end)]
+}
+
+func (v *PreparedUint32ListDirectView) Close() error {
+	if v == nil {
+		return nil
+	}
+	offsets := v.OffsetsHandle
+	values := v.ValuesHandle
+	v.OffsetsHandle = nil
+	v.ValuesHandle = nil
+	v.Offsets = nil
+	v.Values = nil
+	v.Rows = 0
+	return errors.Join(releaseDirectViewHandle(offsets), releaseDirectViewHandle(values))
+}
+
+func (v PreparedBytesDirectView) Alive() bool {
+	return v.OffsetsHandle != nil && v.ValuesHandle != nil && !v.OffsetsHandle.Released() && !v.ValuesHandle.Released() && len(v.Offsets) == v.Rows+1
+}
+
+func (v PreparedBytesDirectView) Row(row int) []byte {
+	if !v.Alive() || row < 0 || row >= v.Rows {
+		return nil
+	}
+	begin := v.Offsets[row]
+	end := v.Offsets[row+1]
+	if begin > end || begin > uint64(len(v.Values)) || end > uint64(len(v.Values)) {
+		return nil
+	}
+	return v.Values[int(begin):int(end)]
+}
+
+func (v *PreparedBytesDirectView) Close() error {
+	if v == nil {
+		return nil
+	}
+	offsets := v.OffsetsHandle
+	values := v.ValuesHandle
+	v.OffsetsHandle = nil
+	v.ValuesHandle = nil
+	v.Offsets = nil
+	v.Values = nil
+	v.Rows = 0
+	return errors.Join(releaseDirectViewHandle(offsets), releaseDirectViewHandle(values))
+}
+
+func releaseDirectViewHandle(h *mappedresource.Handle) error {
+	if h == nil {
+		return nil
+	}
+	return h.Release()
+}

--- a/TreeDB/internal/typeddecode/graph_direct_view_test.go
+++ b/TreeDB/internal/typeddecode/graph_direct_view_test.go
@@ -1,0 +1,761 @@
+package typeddecode
+
+import (
+	"encoding/binary"
+	"math"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/internal/mappedresource"
+	"github.com/snissn/gomap/TreeDB/internal/typedcolumn"
+)
+
+var graphDirectViewFloatSink float32
+var graphDirectViewIntSink int64
+var graphDirectViewUintSink uint32
+var graphDirectViewByteSink byte
+
+func TestGraphDirectViewCertifiersSuccessAndNoHotLoopAllocs(t *testing.T) {
+	t.Run("float32_vector", func(t *testing.T) {
+		req := graphFloat32VectorRequest(t, 2, 3, mappedresource.SourceMapped)
+		view, status := CertifyGraphFloat32VectorDirectView(req)
+		if !status.Direct() {
+			t.Fatalf("CertifyGraphFloat32VectorDirectView=%s", status.String())
+		}
+		t.Cleanup(func() { _ = view.Close() })
+		if got := view.Row(1); len(got) != 3 || got[0] != 4 || got[2] != 6 {
+			t.Fatalf("row=%v", got)
+		}
+		allocs := testing.AllocsPerRun(1000, func() {
+			row := view.Row(1)
+			graphDirectViewFloatSink += row[0]
+		})
+		if allocs != 0 {
+			t.Fatalf("Row allocations=%v want 0", allocs)
+		}
+	})
+
+	t.Run("float32", func(t *testing.T) {
+		req := graphFloat32Request(t, 3, mappedresource.SourceMapped)
+		view, status := CertifyGraphFloat32DirectView(req)
+		if !status.Direct() {
+			t.Fatalf("CertifyGraphFloat32DirectView=%s", status.String())
+		}
+		t.Cleanup(func() { _ = view.Close() })
+		if got, ok := view.Value(2); !ok || got != 3.5 {
+			t.Fatalf("value=%v ok=%v", got, ok)
+		}
+		allocs := testing.AllocsPerRun(1000, func() {
+			value, ok := view.Value(1)
+			if ok {
+				graphDirectViewFloatSink += value
+			}
+		})
+		if allocs != 0 {
+			t.Fatalf("Value allocations=%v want 0", allocs)
+		}
+	})
+
+	t.Run("int64", func(t *testing.T) {
+		req := graphInt64Request(t, 3, mappedresource.SourceMapped)
+		view, status := CertifyGraphInt64DirectView(req)
+		if !status.Direct() {
+			t.Fatalf("CertifyGraphInt64DirectView=%s", status.String())
+		}
+		t.Cleanup(func() { _ = view.Close() })
+		if got, ok := view.Value(2); !ok || got != 102 {
+			t.Fatalf("value=%v ok=%v", got, ok)
+		}
+		allocs := testing.AllocsPerRun(1000, func() {
+			value, ok := view.Value(1)
+			if ok {
+				graphDirectViewIntSink += value
+			}
+		})
+		if allocs != 0 {
+			t.Fatalf("Value allocations=%v want 0", allocs)
+		}
+	})
+
+	t.Run("uint32_list", func(t *testing.T) {
+		req := graphUint32ListRequest(t, []uint64{0, 2, 2, 5}, []uint32{7, 8, 9, 10, 11}, mappedresource.SourceMapped)
+		view, status := CertifyGraphUint32ListDirectView(req)
+		if !status.Direct() {
+			t.Fatalf("CertifyGraphUint32ListDirectView=%s", status.String())
+		}
+		t.Cleanup(func() { _ = view.Close() })
+		if got := view.Row(2); len(got) != 3 || got[0] != 9 || got[2] != 11 {
+			t.Fatalf("row=%v", got)
+		}
+		if got := view.Row(1); len(got) != 0 {
+			t.Fatalf("empty row=%v", got)
+		}
+		allocs := testing.AllocsPerRun(1000, func() {
+			row := view.Row(0)
+			graphDirectViewUintSink += row[0]
+		})
+		if allocs != 0 {
+			t.Fatalf("Row allocations=%v want 0", allocs)
+		}
+	})
+
+	t.Run("bytes", func(t *testing.T) {
+		req := graphBytesRequest(t, []uint64{0, 2, 2, 5}, []byte{'a', 0xff, 'x', 0, 'z'}, mappedresource.SourceMapped)
+		view, status := CertifyGraphBytesDirectView(req)
+		if !status.Direct() {
+			t.Fatalf("CertifyGraphBytesDirectView=%s", status.String())
+		}
+		t.Cleanup(func() { _ = view.Close() })
+		if got := view.Row(2); len(got) != 3 || got[0] != 'x' || got[2] != 'z' {
+			t.Fatalf("row=%v", got)
+		}
+		if got := view.Row(1); len(got) != 0 {
+			t.Fatalf("empty row=%v", got)
+		}
+		allocs := testing.AllocsPerRun(1000, func() {
+			row := view.Row(0)
+			graphDirectViewByteSink ^= row[0]
+		})
+		if allocs != 0 {
+			t.Fatalf("Row allocations=%v want 0", allocs)
+		}
+	})
+}
+
+func TestGraphDirectViewPreparedCloseReleasesHandles(t *testing.T) {
+	t.Run("float32_vector", func(t *testing.T) {
+		req := graphFloat32VectorRequest(t, 2, 3, mappedresource.SourceMapped)
+		view, status := CertifyGraphFloat32VectorDirectView(req)
+		if !status.Direct() {
+			t.Fatalf("CertifyGraphFloat32VectorDirectView=%s", status.String())
+		}
+		handle := view.Handle
+		if !view.Alive() || handle == nil || handle.Released() {
+			t.Fatalf("view alive=%v handle=%v released=%v", view.Alive(), handle != nil, handle != nil && handle.Released())
+		}
+		if err := view.Close(); err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+		if view.Alive() || view.Row(0) != nil || !handle.Released() {
+			t.Fatalf("closed vector view alive=%v row=%v handle_released=%v", view.Alive(), view.Row(0), handle.Released())
+		}
+		if err := view.Close(); err != nil {
+			t.Fatalf("second Close: %v", err)
+		}
+	})
+
+	t.Run("float32", func(t *testing.T) {
+		req := graphFloat32Request(t, 3, mappedresource.SourceMapped)
+		view, status := CertifyGraphFloat32DirectView(req)
+		if !status.Direct() {
+			t.Fatalf("CertifyGraphFloat32DirectView=%s", status.String())
+		}
+		handle := view.Handle
+		if err := view.Close(); err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+		if _, ok := view.Value(0); ok || !handle.Released() {
+			t.Fatalf("closed float32 view ok=%v handle_released=%v", ok, handle.Released())
+		}
+	})
+
+	t.Run("int64", func(t *testing.T) {
+		req := graphInt64Request(t, 3, mappedresource.SourceMapped)
+		view, status := CertifyGraphInt64DirectView(req)
+		if !status.Direct() {
+			t.Fatalf("CertifyGraphInt64DirectView=%s", status.String())
+		}
+		handle := view.Handle
+		if err := view.Close(); err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+		if _, ok := view.Value(0); ok || !handle.Released() {
+			t.Fatalf("closed int64 view ok=%v handle_released=%v", ok, handle.Released())
+		}
+	})
+
+	t.Run("uint32_list", func(t *testing.T) {
+		req := graphUint32ListRequest(t, []uint64{0, 1, 3}, []uint32{4, 5, 6}, mappedresource.SourceMapped)
+		view, status := CertifyGraphUint32ListDirectView(req)
+		if !status.Direct() {
+			t.Fatalf("CertifyGraphUint32ListDirectView=%s", status.String())
+		}
+		offsetsHandle, valuesHandle := view.OffsetsHandle, view.ValuesHandle
+		if err := view.Close(); err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+		if view.Row(0) != nil || !offsetsHandle.Released() || !valuesHandle.Released() {
+			t.Fatalf("closed uint32 list row=%v offsets_released=%v values_released=%v", view.Row(0), offsetsHandle.Released(), valuesHandle.Released())
+		}
+	})
+
+	t.Run("bytes", func(t *testing.T) {
+		req := graphBytesRequest(t, []uint64{0, 1, 3}, []byte("abc"), mappedresource.SourceMapped)
+		view, status := CertifyGraphBytesDirectView(req)
+		if !status.Direct() {
+			t.Fatalf("CertifyGraphBytesDirectView=%s", status.String())
+		}
+		offsetsHandle, valuesHandle := view.OffsetsHandle, view.ValuesHandle
+		if err := view.Close(); err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+		if view.Row(0) != nil || !offsetsHandle.Released() || !valuesHandle.Released() {
+			t.Fatalf("closed bytes row=%v offsets_released=%v values_released=%v", view.Row(0), offsetsHandle.Released(), valuesHandle.Released())
+		}
+	})
+}
+
+func TestGraphDirectViewCertifiersRejectIncompleteResourceIdentity(t *testing.T) {
+	t.Run("fixed_width_missing_section_metadata", func(t *testing.T) {
+		req := graphFloat32VectorRequest(t, 2, 3, mappedresource.SourceMapped)
+		key := graphKey(req.Section.Column, req.Section, typedcolumn.EncodingRawFloat32Vector)
+		key.Section = mappedresource.Section{}
+		mgr := mappedresource.NewManager()
+		req.Manager = mgr
+		req.Handle = graphAcquireHandle(t, mgr, mappedresource.SourceMapped, req.Handle.Bytes(), key)
+		if _, status := CertifyGraphFloat32VectorDirectView(req); status.Reason != ReasonColumnMismatch {
+			t.Fatalf("blank section status=%+v want %s", status, ReasonColumnMismatch)
+		}
+	})
+
+	t.Run("fixed_width_missing_encoding_metadata", func(t *testing.T) {
+		req := graphFloat32VectorRequest(t, 2, 3, mappedresource.SourceMapped)
+		key := graphKey(req.Section.Column, req.Section, typedcolumn.EncodingRawFloat32Vector)
+		key.Encoding = ""
+		mgr := mappedresource.NewManager()
+		req.Manager = mgr
+		req.Handle = graphAcquireHandle(t, mgr, mappedresource.SourceMapped, req.Handle.Bytes(), key)
+		if _, status := CertifyGraphFloat32VectorDirectView(req); status.Reason != ReasonTypeEncodingMismatch {
+			t.Fatalf("blank encoding status=%+v want %s", status, ReasonTypeEncodingMismatch)
+		}
+	})
+
+	t.Run("split_values_missing_section_metadata", func(t *testing.T) {
+		req := graphUint32ListRequest(t, []uint64{0, 2, 5}, []uint32{1, 2, 3, 4, 5}, mappedresource.SourceMapped)
+		key := graphKey(req.ValuesSection.Column, req.ValuesSection, typedcolumn.EncodingRawUint32OffsetsList)
+		key.Section = mappedresource.Section{}
+		mgr := mappedresource.NewManager()
+		req.Manager = mgr
+		req.ValuesHandle = graphAcquireHandle(t, mgr, mappedresource.SourceMapped, req.ValuesHandle.Bytes(), key)
+		if _, status := CertifyGraphUint32ListDirectView(req); status.Reason != ReasonColumnMismatch {
+			t.Fatalf("blank split section status=%+v want %s", status, ReasonColumnMismatch)
+		}
+	})
+}
+
+func TestGraphFixedWidthDirectViewCertifiersFailClosed(t *testing.T) {
+	t.Run("owner_role_column_type", func(t *testing.T) {
+		req := graphFloat32VectorRequest(t, 2, 3, mappedresource.SourceMapped)
+		req.Expectation.ActualOwner = "wrong_owner"
+		if _, status := CertifyGraphFloat32VectorDirectView(req); status.Reason != ReasonOwnerMismatch {
+			t.Fatalf("owner status=%+v want %s", status, ReasonOwnerMismatch)
+		}
+
+		req = graphFloat32VectorRequest(t, 2, 3, mappedresource.SourceMapped)
+		req.Expectation.ActualRole = "wrong_role"
+		if _, status := CertifyGraphFloat32VectorDirectView(req); status.Reason != ReasonRoleMismatch {
+			t.Fatalf("role status=%+v want %s", status, ReasonRoleMismatch)
+		}
+
+		req = graphFloat32VectorRequest(t, 2, 3, mappedresource.SourceMapped)
+		req.Certification.Name = "other_vec"
+		if _, status := CertifyGraphFloat32VectorDirectView(req); status.Reason != ReasonColumnMismatch {
+			t.Fatalf("column status=%+v want %s", status, ReasonColumnMismatch)
+		}
+
+		req = graphFloat32VectorRequest(t, 2, 3, mappedresource.SourceMapped)
+		req.Certification.Type = typedcolumn.ColumnTypeInt64
+		req.Certification.Encoding = typedcolumn.EncodingRawInt64
+		if _, status := CertifyGraphFloat32VectorDirectView(req); status.Reason != ReasonTypeEncodingMismatch {
+			t.Fatalf("type status=%+v want %s", status, ReasonTypeEncodingMismatch)
+		}
+	})
+
+	t.Run("row_dims_payload_alignment_and_wrappers", func(t *testing.T) {
+		req := graphFloat32VectorRequest(t, 2, 3, mappedresource.SourceMapped)
+		req.Expectation.Rows = 3
+		if _, status := CertifyGraphFloat32VectorDirectView(req); status.Reason != ReasonRowCountMismatch {
+			t.Fatalf("row status=%+v want %s", status, ReasonRowCountMismatch)
+		}
+
+		req = graphFloat32VectorRequest(t, 2, 3, mappedresource.SourceMapped)
+		req.Dims = 2
+		if _, status := CertifyGraphFloat32VectorDirectView(req); status.Reason != ReasonDimensionMismatch {
+			t.Fatalf("dims status=%+v want %s", status, ReasonDimensionMismatch)
+		}
+
+		req = graphFloat32VectorLengthRequest(t, 2, 3, 20)
+		if _, status := CertifyGraphFloat32VectorDirectView(req); status.Reason != ReasonPayloadLengthMismatch {
+			t.Fatalf("short payload status=%+v want %s", status, ReasonPayloadLengthMismatch)
+		}
+
+		req = graphFloat32VectorLengthRequest(t, 2, 3, 28)
+		if _, status := CertifyGraphFloat32VectorDirectView(req); status.Reason != ReasonPayloadLengthMismatch {
+			t.Fatalf("trailing payload status=%+v want %s", status, ReasonPayloadLengthMismatch)
+		}
+
+		req = graphFloat32VectorRequest(t, 2, 3, mappedresource.SourceMapped)
+		req.Expectation.AssetOffset = 1
+		if _, status := CertifyGraphFloat32VectorDirectView(req); status.Reason != ReasonAbsoluteOffsetUnaligned {
+			t.Fatalf("misaligned status=%+v want %s", status, ReasonAbsoluteOffsetUnaligned)
+		}
+
+		req = graphFloat32VectorRequest(t, 2, 3, mappedresource.SourceMapped)
+		req.Certification.NullMaskPresent = true
+		req.Certification.NullCount = 1
+		if _, status := CertifyGraphFloat32VectorDirectView(req); status.Reason != ReasonNullableWrapper {
+			t.Fatalf("nullable status=%+v want %s", status, ReasonNullableWrapper)
+		}
+
+		req = graphFloat32VectorRequest(t, 2, 3, mappedresource.SourceMapped)
+		req.Certification.DefaultMaskPresent = true
+		req.Certification.DefaultCount = 1
+		if _, status := CertifyGraphFloat32VectorDirectView(req); status.Reason != ReasonNullableWrapper {
+			t.Fatalf("default status=%+v want %s", status, ReasonNullableWrapper)
+		}
+
+		req = graphFloat32VectorRequest(t, 2, 3, mappedresource.SourceMapped)
+		req.Section.Compression = typedcolumn.CompressionSnappy
+		if _, status := CertifyGraphFloat32VectorDirectView(req); status.Reason != ReasonCompressed {
+			t.Fatalf("compressed status=%+v want %s", status, ReasonCompressed)
+		}
+	})
+
+	t.Run("resource_lifetime_source_and_identity", func(t *testing.T) {
+		req := graphFloat32VectorRequest(t, 2, 3, mappedresource.SourceHeapCopy)
+		if _, status := CertifyGraphFloat32VectorDirectView(req); status.Reason != ReasonHandleSourceUnsupported {
+			t.Fatalf("heap status=%+v want %s", status, ReasonHandleSourceUnsupported)
+		}
+
+		req = graphFloat32VectorRequest(t, 2, 3, mappedresource.SourceMapped)
+		if err := req.Handle.Release(); err != nil {
+			t.Fatalf("Release: %v", err)
+		}
+		if _, status := CertifyGraphFloat32VectorDirectView(req); status.Reason != ReasonStaleHandle {
+			t.Fatalf("stale status=%+v want %s", status, ReasonStaleHandle)
+		}
+
+		req = graphFloat32VectorRequest(t, 2, 3, mappedresource.SourceMapped)
+		misalignedRaw := alignedBytes(4, req.Section.Length+1)[1:]
+		for i := 0; i < len(misalignedRaw)/4; i++ {
+			binary.LittleEndian.PutUint32(misalignedRaw[i*4:], math.Float32bits(float32(i+1)))
+		}
+		misalignedMgr := mappedresource.NewManager()
+		req.Manager = misalignedMgr
+		req.Handle = graphAcquireHandle(t, misalignedMgr, mappedresource.SourceMapped, misalignedRaw, graphKey(req.Section.Column, req.Section, typedcolumn.EncodingRawFloat32Vector))
+		if _, status := CertifyGraphFloat32VectorDirectView(req); status.Reason != ReasonActualPointerUnaligned {
+			t.Fatalf("actual pointer status=%+v want %s", status, ReasonActualPointerUnaligned)
+		}
+
+		req = graphFloat32VectorRequestWithResourceColumn(t, 2, 3, "other_vec")
+		if _, status := CertifyGraphFloat32VectorDirectView(req); status.Reason != ReasonColumnMismatch {
+			t.Fatalf("resource column status=%+v want %s", status, ReasonColumnMismatch)
+		}
+	})
+
+	t.Run("scalar_families", func(t *testing.T) {
+		floatReq := graphFloat32Request(t, 3, mappedresource.SourceMapped)
+		floatReq.Certification.Encoding = typedcolumn.EncodingRawInt64
+		if _, status := CertifyGraphFloat32DirectView(floatReq); status.Reason != ReasonTypeEncodingMismatch {
+			t.Fatalf("float32 type status=%+v want %s", status, ReasonTypeEncodingMismatch)
+		}
+
+		intReq := graphInt64Request(t, 3, mappedresource.SourceMapped)
+		intReq.Certification.Endian = typedcolumn.ColumnPartLayoutEndianCodecDefined
+		if _, status := CertifyGraphInt64DirectView(intReq); status.Reason != ReasonWrongEndian {
+			t.Fatalf("int64 endian status=%+v want %s", status, ReasonWrongEndian)
+		}
+
+		intReq = graphInt64Request(t, 3, mappedresource.SourceMapped)
+		intReq.Handle = nil
+		if _, status := CertifyGraphInt64DirectView(intReq); status.Reason != ReasonNilHandle {
+			t.Fatalf("nil handle status=%+v want %s", status, ReasonNilHandle)
+		}
+	})
+}
+
+func TestGraphOffsetsDirectViewCertifiersFailClosed(t *testing.T) {
+	t.Run("uint32_list_identity_shape_and_sections", func(t *testing.T) {
+		req := graphUint32ListRequest(t, []uint64{0, 2, 5}, []uint32{1, 2, 3, 4, 5}, mappedresource.SourceMapped)
+		req.Certification.LogicalType = "adjacency_list"
+		req.Certification.Type = typedcolumn.ColumnTypeAdjacencyList
+		if _, status := CertifyGraphUint32ListDirectView(req); status.Reason != ReasonTypeEncodingMismatch {
+			t.Fatalf("type status=%+v want %s", status, ReasonTypeEncodingMismatch)
+		}
+
+		req = graphUint32ListRequest(t, []uint64{0, 2, 5}, []uint32{1, 2, 3, 4, 5}, mappedresource.SourceMapped)
+		req.Expectation.Rows = 3
+		if _, status := CertifyGraphUint32ListDirectView(req); status.Reason != ReasonRowCountMismatch {
+			t.Fatalf("rows status=%+v want %s", status, ReasonRowCountMismatch)
+		}
+
+		req = graphUint32ListRequest(t, []uint64{0, 2, 5}, []uint32{1, 2, 3, 4, 5}, mappedresource.SourceMapped)
+		req.ValuesSection.Length--
+		if _, status := CertifyGraphUint32ListDirectView(req); status.Reason != ReasonPayloadLengthMismatch {
+			t.Fatalf("short values section status=%+v want %s", status, ReasonPayloadLengthMismatch)
+		}
+
+		req = graphUint32ListRequest(t, []uint64{0, 2, 5}, []uint32{1, 2, 3, 4, 5}, mappedresource.SourceMapped)
+		req.ValuesSection.Length += 4
+		req.Certification.ValuesSection.Length += 4
+		req.Certification.ValuesBytes += 4
+		if _, status := CertifyGraphUint32ListDirectView(req); status.Reason != ReasonPayloadLengthMismatch {
+			t.Fatalf("trailing values section status=%+v want %s", status, ReasonPayloadLengthMismatch)
+		}
+
+		req = graphUint32ListRequest(t, []uint64{0, 2, 5}, []uint32{1, 2, 3, 4, 5}, mappedresource.SourceMapped)
+		req.Expectation.AssetOffset = 4
+		if _, status := CertifyGraphUint32ListDirectView(req); status.Reason != ReasonAbsoluteOffsetUnaligned {
+			t.Fatalf("misaligned offsets status=%+v want %s", status, ReasonAbsoluteOffsetUnaligned)
+		}
+
+		req = graphUint32ListRequest(t, []uint64{0, 2, 5}, []uint32{1, 2, 3, 4, 5}, mappedresource.SourceMapped)
+		req.Certification.NullMaskPresent = true
+		req.Certification.NullCount = 1
+		if _, status := CertifyGraphUint32ListDirectView(req); status.Reason != ReasonNullableWrapper {
+			t.Fatalf("nullable status=%+v want %s", status, ReasonNullableWrapper)
+		}
+
+		req = graphUint32ListRequest(t, []uint64{0, 2, 5}, []uint32{1, 2, 3, 4, 5}, mappedresource.SourceMapped)
+		req.OffsetsSection.Compression = typedcolumn.CompressionSnappy
+		if _, status := CertifyGraphUint32ListDirectView(req); status.Reason != ReasonCompressed {
+			t.Fatalf("compressed status=%+v want %s", status, ReasonCompressed)
+		}
+	})
+
+	t.Run("uint32_list_corrupt_offsets_and_resources", func(t *testing.T) {
+		req := graphUint32ListRequest(t, []uint64{1, 2, 5}, []uint32{1, 2, 3, 4, 5}, mappedresource.SourceMapped)
+		if _, status := CertifyGraphUint32ListDirectView(req); status.Reason != ReasonOffsetsStartMismatch {
+			t.Fatalf("start status=%+v want %s", status, ReasonOffsetsStartMismatch)
+		}
+
+		req = graphUint32ListRequest(t, []uint64{0, 4, 3}, []uint32{1, 2, 3, 4, 5}, mappedresource.SourceMapped)
+		if _, status := CertifyGraphUint32ListDirectView(req); status.Reason != ReasonOffsetsNonMonotonic {
+			t.Fatalf("monotonic status=%+v want %s", status, ReasonOffsetsNonMonotonic)
+		}
+
+		req = graphUint32ListRequest(t, []uint64{0, 2, 6}, []uint32{1, 2, 3, 4, 5}, mappedresource.SourceMapped)
+		if _, status := CertifyGraphUint32ListDirectView(req); status.Reason != ReasonValuesLengthMismatch {
+			t.Fatalf("final status=%+v want %s", status, ReasonValuesLengthMismatch)
+		}
+
+		req = graphUint32ListRequest(t, []uint64{0, 2, 5}, []uint32{1, 2, 3, 4, 5}, mappedresource.SourceHeapCopy)
+		if _, status := CertifyGraphUint32ListDirectView(req); status.Reason != ReasonHandleSourceUnsupported {
+			t.Fatalf("heap status=%+v want %s", status, ReasonHandleSourceUnsupported)
+		}
+
+		req = graphUint32ListRequest(t, []uint64{0, 2, 5}, []uint32{1, 2, 3, 4, 5}, mappedresource.SourceMapped)
+		if err := req.OffsetsHandle.Release(); err != nil {
+			t.Fatalf("Release: %v", err)
+		}
+		if _, status := CertifyGraphUint32ListDirectView(req); status.Reason != ReasonStaleHandle {
+			t.Fatalf("stale status=%+v want %s", status, ReasonStaleHandle)
+		}
+
+		req = graphUint32ListRequestWithResourceColumn(t, []uint64{0, 2, 5}, []uint32{1, 2, 3, 4, 5}, "other_tags")
+		if _, status := CertifyGraphUint32ListDirectView(req); status.Reason != ReasonColumnMismatch {
+			t.Fatalf("resource column status=%+v want %s", status, ReasonColumnMismatch)
+		}
+	})
+
+	t.Run("bytes_corrupt_offsets_sections_and_resources", func(t *testing.T) {
+		req := graphBytesRequest(t, []uint64{0, 2, 5}, []byte("abcde"), mappedresource.SourceMapped)
+		req.Certification.Encoding = typedcolumn.EncodingRawUint32OffsetsList
+		if _, status := CertifyGraphBytesDirectView(req); status.Reason != ReasonTypeEncodingMismatch {
+			t.Fatalf("type status=%+v want %s", status, ReasonTypeEncodingMismatch)
+		}
+
+		req = graphBytesRequest(t, []uint64{1, 2, 5}, []byte("abcde"), mappedresource.SourceMapped)
+		if _, status := CertifyGraphBytesDirectView(req); status.Reason != ReasonOffsetsStartMismatch {
+			t.Fatalf("start status=%+v want %s", status, ReasonOffsetsStartMismatch)
+		}
+
+		req = graphBytesRequest(t, []uint64{0, 4, 3}, []byte("abcde"), mappedresource.SourceMapped)
+		if _, status := CertifyGraphBytesDirectView(req); status.Reason != ReasonOffsetsNonMonotonic {
+			t.Fatalf("monotonic status=%+v want %s", status, ReasonOffsetsNonMonotonic)
+		}
+
+		req = graphBytesRequest(t, []uint64{0, 2, 6}, []byte("abcde"), mappedresource.SourceMapped)
+		if _, status := CertifyGraphBytesDirectView(req); status.Reason != ReasonValuesLengthMismatch {
+			t.Fatalf("final status=%+v want %s", status, ReasonValuesLengthMismatch)
+		}
+
+		req = graphBytesRequest(t, []uint64{0, 2, 5}, []byte("abcde"), mappedresource.SourceMapped)
+		req.ValuesSection.Length++
+		req.Certification.ValuesSection.Length++
+		req.Certification.ValuesBytes++
+		if _, status := CertifyGraphBytesDirectView(req); status.Reason != ReasonPayloadLengthMismatch {
+			t.Fatalf("trailing bytes status=%+v want %s", status, ReasonPayloadLengthMismatch)
+		}
+
+		req = graphBytesRequest(t, []uint64{0, 2, 5}, []byte("abcde"), mappedresource.SourceMapped)
+		req.Expectation.AssetOffset = 4
+		if _, status := CertifyGraphBytesDirectView(req); status.Reason != ReasonAbsoluteOffsetUnaligned {
+			t.Fatalf("misaligned offsets status=%+v want %s", status, ReasonAbsoluteOffsetUnaligned)
+		}
+
+		req = graphBytesRequest(t, []uint64{0, 2, 5}, []byte("abcde"), mappedresource.SourceMapped)
+		req.Certification.DefaultMaskPresent = true
+		req.Certification.DefaultCount = 1
+		if _, status := CertifyGraphBytesDirectView(req); status.Reason != ReasonNullableWrapper {
+			t.Fatalf("default status=%+v want %s", status, ReasonNullableWrapper)
+		}
+
+		req = graphBytesRequest(t, []uint64{0, 2, 5}, []byte("abcde"), mappedresource.SourceHeapCopy)
+		if _, status := CertifyGraphBytesDirectView(req); status.Reason != ReasonHandleSourceUnsupported {
+			t.Fatalf("heap status=%+v want %s", status, ReasonHandleSourceUnsupported)
+		}
+
+		req = graphBytesRequestWithResourceColumn(t, []uint64{0, 2, 5}, []byte("abcde"), "other_opaque")
+		if _, status := CertifyGraphBytesDirectView(req); status.Reason != ReasonColumnMismatch {
+			t.Fatalf("resource column status=%+v want %s", status, ReasonColumnMismatch)
+		}
+	})
+}
+
+func BenchmarkGraphDirectViewPreparedAccessor(b *testing.B) {
+	req := graphFloat32VectorRequest(b, 8, 16, mappedresource.SourceMapped)
+	view, status := CertifyGraphFloat32VectorDirectView(req)
+	if !status.Direct() {
+		b.Fatalf("CertifyGraphFloat32VectorDirectView=%s", status.String())
+	}
+	b.Cleanup(func() { _ = view.Close() })
+	var sum float32
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		row := view.Row(i & 7)
+		sum += row[i&15]
+	}
+	graphDirectViewFloatSink += sum
+}
+
+func BenchmarkGraphDirectViewCertification(b *testing.B) {
+	b.Run("float32_vector", func(b *testing.B) {
+		req := graphFloat32VectorRequest(b, 1024, 8, mappedresource.SourceMapped)
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			view, status := CertifyGraphFloat32VectorDirectView(req)
+			if !status.Direct() {
+				b.Fatalf("CertifyGraphFloat32VectorDirectView=%s", status.String())
+			}
+			graphDirectViewFloatSink += view.Values[0]
+		}
+	})
+
+	b.Run("float32", func(b *testing.B) {
+		req := graphFloat32Request(b, 1024, mappedresource.SourceMapped)
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			view, status := CertifyGraphFloat32DirectView(req)
+			if !status.Direct() {
+				b.Fatalf("CertifyGraphFloat32DirectView=%s", status.String())
+			}
+			graphDirectViewFloatSink += view.Values[0]
+		}
+	})
+
+	b.Run("int64", func(b *testing.B) {
+		req := graphInt64Request(b, 1024, mappedresource.SourceMapped)
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			view, status := CertifyGraphInt64DirectView(req)
+			if !status.Direct() {
+				b.Fatalf("CertifyGraphInt64DirectView=%s", status.String())
+			}
+			graphDirectViewIntSink += view.Values[0]
+		}
+	})
+
+	b.Run("uint32_list", func(b *testing.B) {
+		req := graphUint32ListRequest(b, []uint64{0, 2, 2, 5}, []uint32{7, 8, 9, 10, 11}, mappedresource.SourceMapped)
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			view, status := CertifyGraphUint32ListDirectView(req)
+			if !status.Direct() {
+				b.Fatalf("CertifyGraphUint32ListDirectView=%s", status.String())
+			}
+			graphDirectViewUintSink += view.Values[0]
+		}
+	})
+
+	b.Run("bytes", func(b *testing.B) {
+		req := graphBytesRequest(b, []uint64{0, 2, 2, 5}, []byte{'a', 0xff, 'x', 0, 'z'}, mappedresource.SourceMapped)
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			view, status := CertifyGraphBytesDirectView(req)
+			if !status.Direct() {
+				b.Fatalf("CertifyGraphBytesDirectView=%s", status.String())
+			}
+			graphDirectViewByteSink ^= view.Values[0]
+		}
+	})
+}
+
+func graphExpectation(column string, rows int) GraphDirectViewExpectation {
+	return GraphDirectViewExpectation{
+		ExpectedOwner:  "typed_column_part",
+		ActualOwner:    "typed_column_part",
+		ExpectedRole:   "graph_search_state",
+		ActualRole:     "graph_search_state",
+		Column:         column,
+		Rows:           rows,
+		AssetOffset:    0,
+		HasAssetOffset: true,
+	}
+}
+
+func graphFloat32VectorRequest(t testing.TB, rows, dims int, source mappedresource.Source) GraphFloat32VectorDirectViewRequest {
+	return graphFloat32VectorRequestWithResourceColumnAndLength(t, rows, dims, source, "vec", rows*dims*4)
+}
+
+func graphFloat32VectorLengthRequest(t testing.TB, rows, dims, length int) GraphFloat32VectorDirectViewRequest {
+	return graphFloat32VectorRequestWithResourceColumnAndLength(t, rows, dims, mappedresource.SourceMapped, "vec", length)
+}
+
+func graphFloat32VectorRequestWithResourceColumn(t testing.TB, rows, dims int, resourceColumn string) GraphFloat32VectorDirectViewRequest {
+	return graphFloat32VectorRequestWithResourceColumnAndLength(t, rows, dims, mappedresource.SourceMapped, resourceColumn, rows*dims*4)
+}
+
+func graphFloat32VectorRequestWithResourceColumnAndLength(t testing.TB, rows, dims int, source mappedresource.Source, resourceColumn string, length int) GraphFloat32VectorDirectViewRequest {
+	t.Helper()
+	cert := testFloat32VectorDirectCert(rows, dims)
+	cert.Section.Length = length
+	cert.Blocks[0].RawBytes = length
+	cert.Blocks[0].StoredBytes = length
+	cert.Blocks[0].PayloadLength = length
+	section := graphDataSection(cert, "vec", typedcolumn.EncodingRawFloat32Vector)
+	raw := alignedBytes(4, length)
+	for i := 0; i < length/4; i++ {
+		binary.LittleEndian.PutUint32(raw[i*4:], math.Float32bits(float32(i+1)))
+	}
+	mgr := mappedresource.NewManager()
+	h := graphAcquireHandle(t, mgr, source, raw, graphKey(resourceColumn, section, typedcolumn.EncodingRawFloat32Vector))
+	return GraphFloat32VectorDirectViewRequest{Expectation: graphExpectation("vec", rows), Dims: dims, Certification: cert, Section: section, Handle: h, Manager: mgr}
+}
+
+func graphFloat32Request(t testing.TB, rows int, source mappedresource.Source) GraphFloat32DirectViewRequest {
+	t.Helper()
+	cert := testFloat32ScalarDirectCert(rows)
+	section := graphDataSection(cert, cert.Name, typedcolumn.EncodingRawFloat32)
+	raw := alignedBytes(4, rows*4)
+	for i := 0; i < rows; i++ {
+		binary.LittleEndian.PutUint32(raw[i*4:], math.Float32bits(float32(i)+1.5))
+	}
+	mgr := mappedresource.NewManager()
+	h := graphAcquireHandle(t, mgr, source, raw, graphKey(cert.Name, section, typedcolumn.EncodingRawFloat32))
+	return GraphFloat32DirectViewRequest{Expectation: graphExpectation(cert.Name, rows), Certification: cert, Section: section, Handle: h, Manager: mgr}
+}
+
+func graphInt64Request(t testing.TB, rows int, source mappedresource.Source) GraphInt64DirectViewRequest {
+	t.Helper()
+	cert := testInt64DirectCert(rows)
+	section := graphDataSection(cert, cert.Name, typedcolumn.EncodingRawInt64)
+	raw := alignedBytes(8, rows*8)
+	for i := 0; i < rows; i++ {
+		binary.LittleEndian.PutUint64(raw[i*8:], uint64(100+i))
+	}
+	mgr := mappedresource.NewManager()
+	h := graphAcquireHandle(t, mgr, source, raw, graphKey(cert.Name, section, typedcolumn.EncodingRawInt64))
+	return GraphInt64DirectViewRequest{Expectation: graphExpectation(cert.Name, rows), Certification: cert, Section: section, Handle: h, Manager: mgr}
+}
+
+func graphUint32ListRequest(t testing.TB, offsets []uint64, values []uint32, source mappedresource.Source) GraphUint32ListDirectViewRequest {
+	return graphUint32ListRequestWithResourceColumnAndSource(t, offsets, values, "tags", source)
+}
+
+func graphUint32ListRequestWithResourceColumn(t testing.TB, offsets []uint64, values []uint32, resourceColumn string) GraphUint32ListDirectViewRequest {
+	return graphUint32ListRequestWithResourceColumnAndSource(t, offsets, values, resourceColumn, mappedresource.SourceMapped)
+}
+
+func graphUint32ListRequestWithResourceColumnAndSource(t testing.TB, offsets []uint64, values []uint32, resourceColumn string, source mappedresource.Source) GraphUint32ListDirectViewRequest {
+	t.Helper()
+	rows := len(offsets) - 1
+	cert := testUint32ListSpecCert(rows, len(values))
+	cert.Name = "tags"
+	offsetsSection := graphOffsetsSection(cert, "tags", typedcolumn.EncodingRawUint32OffsetsList)
+	valuesSection := graphValuesSection(cert, "tags", typedcolumn.EncodingRawUint32OffsetsList)
+	offsetsRaw := encodeUint64Slice(offsets)
+	valuesRaw := encodeUint32Slice(values)
+	mgr := mappedresource.NewManager()
+	offsetsHandle := graphAcquireHandle(t, mgr, source, offsetsRaw, graphKey(resourceColumn, offsetsSection, typedcolumn.EncodingRawUint32OffsetsList))
+	valuesHandle := graphAcquireHandle(t, mgr, source, valuesRaw, graphKey(resourceColumn, valuesSection, typedcolumn.EncodingRawUint32OffsetsList))
+	return GraphUint32ListDirectViewRequest{Expectation: graphExpectation("tags", rows), Certification: cert, OffsetsSection: offsetsSection, ValuesSection: valuesSection, OffsetsHandle: offsetsHandle, ValuesHandle: valuesHandle, Manager: mgr}
+}
+
+func graphBytesRequest(t testing.TB, offsets []uint64, values []byte, source mappedresource.Source) GraphBytesDirectViewRequest {
+	return graphBytesRequestWithResourceColumnAndSource(t, offsets, values, "opaque", source)
+}
+
+func graphBytesRequestWithResourceColumn(t testing.TB, offsets []uint64, values []byte, resourceColumn string) GraphBytesDirectViewRequest {
+	return graphBytesRequestWithResourceColumnAndSource(t, offsets, values, resourceColumn, mappedresource.SourceMapped)
+}
+
+func graphBytesRequestWithResourceColumnAndSource(t testing.TB, offsets []uint64, values []byte, resourceColumn string, source mappedresource.Source) GraphBytesDirectViewRequest {
+	t.Helper()
+	rows := len(offsets) - 1
+	cert := bytesDirectViewCert(rows, len(offsets)*8, len(values))
+	offsetsSection := graphOffsetsSection(cert, "opaque", typedcolumn.EncodingRawBytesOffsets)
+	valuesSection := graphValuesSection(cert, "opaque", typedcolumn.EncodingRawBytesOffsets)
+	offsetsRaw := encodeUint64Slice(offsets)
+	valuesRaw := append([]byte(nil), values...)
+	mgr := mappedresource.NewManager()
+	offsetsHandle := graphAcquireHandle(t, mgr, source, offsetsRaw, graphKey(resourceColumn, offsetsSection, typedcolumn.EncodingRawBytesOffsets))
+	valuesHandle := graphAcquireHandle(t, mgr, source, valuesRaw, graphKey(resourceColumn, valuesSection, typedcolumn.EncodingRawBytesOffsets))
+	return GraphBytesDirectViewRequest{Expectation: graphExpectation("opaque", rows), Certification: cert, OffsetsSection: offsetsSection, ValuesSection: valuesSection, OffsetsHandle: offsetsHandle, ValuesHandle: valuesHandle, Manager: mgr}
+}
+
+func graphDataSection(cert typedcolumn.ColumnPartLayoutContractColumn, column string, encoding typedcolumn.Encoding) typedcolumn.ColumnPartImageSection {
+	return typedcolumn.ColumnPartImageSection{Kind: typedcolumn.ColumnPartImageSectionColumnData, Category: typedcolumn.ColumnPartImageCategoryDeclaredColumns, Column: column, Offset: cert.Section.Offset, Length: cert.Section.Length, Rows: cert.Rows, Encoding: encoding, Compression: typedcolumn.CompressionNone}
+}
+
+func graphOffsetsSection(cert typedcolumn.ColumnPartLayoutContractColumn, column string, encoding typedcolumn.Encoding) typedcolumn.ColumnPartImageSection {
+	return typedcolumn.ColumnPartImageSection{Kind: typedcolumn.ColumnPartImageSectionColumnOffsets, Category: typedcolumn.ColumnPartImageCategoryDeclaredColumnOffsets, Column: column, Offset: cert.OffsetsSection.Offset, Length: cert.OffsetsSection.Length, Rows: cert.Rows, Encoding: encoding, Compression: typedcolumn.CompressionNone}
+}
+
+func graphValuesSection(cert typedcolumn.ColumnPartLayoutContractColumn, column string, encoding typedcolumn.Encoding) typedcolumn.ColumnPartImageSection {
+	return typedcolumn.ColumnPartImageSection{Kind: typedcolumn.ColumnPartImageSectionColumnValues, Category: typedcolumn.ColumnPartImageCategoryDeclaredColumnValues, Column: column, Offset: cert.ValuesSection.Offset, Length: cert.ValuesSection.Length, Rows: cert.Rows, Encoding: encoding, Compression: typedcolumn.CompressionNone}
+}
+
+func graphKey(column string, section typedcolumn.ColumnPartImageSection, encoding typedcolumn.Encoding) mappedresource.Key {
+	return mappedresource.Key{
+		Class:      mappedresource.ClassTypedColumnAsset,
+		Namespace:  "typeddecode-test",
+		Kind:       "tcs1_typed_column_part",
+		Generation: 2046,
+		PartID:     1,
+		FileID:     1,
+		Length:     int64(section.Length),
+		Encoding:   encoding.String(),
+		Section: mappedresource.Section{
+			Kind:     string(section.Kind),
+			Category: string(section.Category),
+			Column:   column,
+		},
+	}
+}
+
+func graphAcquireHandle(t testing.TB, mgr *mappedresource.Manager, source mappedresource.Source, raw []byte, key mappedresource.Key) *mappedresource.Handle {
+	t.Helper()
+	h, err := mgr.AcquireBytes(key, testScope(), source, raw, mappedresource.AcquireOptions{Reason: "graph direct-view certifier test"})
+	if err != nil {
+		t.Fatalf("AcquireBytes: %v", err)
+	}
+	t.Cleanup(func() { _ = h.Release() })
+	return h
+}
+
+func encodeUint64Slice(values []uint64) []byte {
+	raw := alignedBytes(8, len(values)*8)
+	for i, value := range values {
+		binary.LittleEndian.PutUint64(raw[i*8:], value)
+	}
+	return raw
+}
+
+func encodeUint32Slice(values []uint32) []byte {
+	raw := alignedBytes(4, len(values)*4)
+	for i, value := range values {
+		binary.LittleEndian.PutUint32(raw[i*4:], value)
+	}
+	return raw
+}

--- a/TreeDB/internal/typeddecode/graph_direct_view_test.go
+++ b/TreeDB/internal/typeddecode/graph_direct_view_test.go
@@ -240,6 +240,18 @@ func TestGraphDirectViewCertifiersRejectIncompleteResourceIdentity(t *testing.T)
 			t.Fatalf("blank split section status=%+v want %s", status, ReasonColumnMismatch)
 		}
 	})
+
+	t.Run("fixed_width_physical_resource_mismatch", func(t *testing.T) {
+		req := graphFloat32VectorRequest(t, 2, 3, mappedresource.SourceMapped)
+		key := req.ExpectedKey
+		key.Generation++
+		mgr := mappedresource.NewManager()
+		req.Manager = mgr
+		req.Handle = graphAcquireHandle(t, mgr, mappedresource.SourceMapped, req.Handle.Bytes(), key)
+		if _, status := CertifyGraphFloat32VectorDirectView(req); status.Reason != ReasonResourceMismatch {
+			t.Fatalf("physical resource status=%+v want %s", status, ReasonResourceMismatch)
+		}
+	})
 }
 
 func TestGraphFixedWidthDirectViewCertifiersFailClosed(t *testing.T) {
@@ -629,8 +641,9 @@ func graphFloat32VectorRequestWithResourceColumnAndLength(t testing.TB, rows, di
 		binary.LittleEndian.PutUint32(raw[i*4:], math.Float32bits(float32(i+1)))
 	}
 	mgr := mappedresource.NewManager()
+	expectedKey := graphKey("vec", section, typedcolumn.EncodingRawFloat32Vector)
 	h := graphAcquireHandle(t, mgr, source, raw, graphKey(resourceColumn, section, typedcolumn.EncodingRawFloat32Vector))
-	return GraphFloat32VectorDirectViewRequest{Expectation: graphExpectation("vec", rows), Dims: dims, Certification: cert, Section: section, Handle: h, Manager: mgr}
+	return GraphFloat32VectorDirectViewRequest{Expectation: graphExpectation("vec", rows), Dims: dims, Certification: cert, Section: section, ExpectedKey: expectedKey, Handle: h, Manager: mgr}
 }
 
 func graphFloat32Request(t testing.TB, rows int, source mappedresource.Source) GraphFloat32DirectViewRequest {
@@ -642,8 +655,9 @@ func graphFloat32Request(t testing.TB, rows int, source mappedresource.Source) G
 		binary.LittleEndian.PutUint32(raw[i*4:], math.Float32bits(float32(i)+1.5))
 	}
 	mgr := mappedresource.NewManager()
-	h := graphAcquireHandle(t, mgr, source, raw, graphKey(cert.Name, section, typedcolumn.EncodingRawFloat32))
-	return GraphFloat32DirectViewRequest{Expectation: graphExpectation(cert.Name, rows), Certification: cert, Section: section, Handle: h, Manager: mgr}
+	expectedKey := graphKey(cert.Name, section, typedcolumn.EncodingRawFloat32)
+	h := graphAcquireHandle(t, mgr, source, raw, expectedKey)
+	return GraphFloat32DirectViewRequest{Expectation: graphExpectation(cert.Name, rows), Certification: cert, Section: section, ExpectedKey: expectedKey, Handle: h, Manager: mgr}
 }
 
 func graphInt64Request(t testing.TB, rows int, source mappedresource.Source) GraphInt64DirectViewRequest {
@@ -655,8 +669,9 @@ func graphInt64Request(t testing.TB, rows int, source mappedresource.Source) Gra
 		binary.LittleEndian.PutUint64(raw[i*8:], uint64(100+i))
 	}
 	mgr := mappedresource.NewManager()
-	h := graphAcquireHandle(t, mgr, source, raw, graphKey(cert.Name, section, typedcolumn.EncodingRawInt64))
-	return GraphInt64DirectViewRequest{Expectation: graphExpectation(cert.Name, rows), Certification: cert, Section: section, Handle: h, Manager: mgr}
+	expectedKey := graphKey(cert.Name, section, typedcolumn.EncodingRawInt64)
+	h := graphAcquireHandle(t, mgr, source, raw, expectedKey)
+	return GraphInt64DirectViewRequest{Expectation: graphExpectation(cert.Name, rows), Certification: cert, Section: section, ExpectedKey: expectedKey, Handle: h, Manager: mgr}
 }
 
 func graphUint32ListRequest(t testing.TB, offsets []uint64, values []uint32, source mappedresource.Source) GraphUint32ListDirectViewRequest {
@@ -677,9 +692,11 @@ func graphUint32ListRequestWithResourceColumnAndSource(t testing.TB, offsets []u
 	offsetsRaw := encodeUint64Slice(offsets)
 	valuesRaw := encodeUint32Slice(values)
 	mgr := mappedresource.NewManager()
+	expectedOffsetsKey := graphKey("tags", offsetsSection, typedcolumn.EncodingRawUint32OffsetsList)
+	expectedValuesKey := graphKey("tags", valuesSection, typedcolumn.EncodingRawUint32OffsetsList)
 	offsetsHandle := graphAcquireHandle(t, mgr, source, offsetsRaw, graphKey(resourceColumn, offsetsSection, typedcolumn.EncodingRawUint32OffsetsList))
 	valuesHandle := graphAcquireHandle(t, mgr, source, valuesRaw, graphKey(resourceColumn, valuesSection, typedcolumn.EncodingRawUint32OffsetsList))
-	return GraphUint32ListDirectViewRequest{Expectation: graphExpectation("tags", rows), Certification: cert, OffsetsSection: offsetsSection, ValuesSection: valuesSection, OffsetsHandle: offsetsHandle, ValuesHandle: valuesHandle, Manager: mgr}
+	return GraphUint32ListDirectViewRequest{Expectation: graphExpectation("tags", rows), Certification: cert, OffsetsSection: offsetsSection, ValuesSection: valuesSection, ExpectedOffsetsKey: expectedOffsetsKey, ExpectedValuesKey: expectedValuesKey, OffsetsHandle: offsetsHandle, ValuesHandle: valuesHandle, Manager: mgr}
 }
 
 func graphBytesRequest(t testing.TB, offsets []uint64, values []byte, source mappedresource.Source) GraphBytesDirectViewRequest {
@@ -699,9 +716,11 @@ func graphBytesRequestWithResourceColumnAndSource(t testing.TB, offsets []uint64
 	offsetsRaw := encodeUint64Slice(offsets)
 	valuesRaw := append([]byte(nil), values...)
 	mgr := mappedresource.NewManager()
+	expectedOffsetsKey := graphKey("opaque", offsetsSection, typedcolumn.EncodingRawBytesOffsets)
+	expectedValuesKey := graphKey("opaque", valuesSection, typedcolumn.EncodingRawBytesOffsets)
 	offsetsHandle := graphAcquireHandle(t, mgr, source, offsetsRaw, graphKey(resourceColumn, offsetsSection, typedcolumn.EncodingRawBytesOffsets))
 	valuesHandle := graphAcquireHandle(t, mgr, source, valuesRaw, graphKey(resourceColumn, valuesSection, typedcolumn.EncodingRawBytesOffsets))
-	return GraphBytesDirectViewRequest{Expectation: graphExpectation("opaque", rows), Certification: cert, OffsetsSection: offsetsSection, ValuesSection: valuesSection, OffsetsHandle: offsetsHandle, ValuesHandle: valuesHandle, Manager: mgr}
+	return GraphBytesDirectViewRequest{Expectation: graphExpectation("opaque", rows), Certification: cert, OffsetsSection: offsetsSection, ValuesSection: valuesSection, ExpectedOffsetsKey: expectedOffsetsKey, ExpectedValuesKey: expectedValuesKey, OffsetsHandle: offsetsHandle, ValuesHandle: valuesHandle, Manager: mgr}
 }
 
 func graphDataSection(cert typedcolumn.ColumnPartLayoutContractColumn, column string, encoding typedcolumn.Encoding) typedcolumn.ColumnPartImageSection {

--- a/TreeDB/internal/typeddecode/plan.go
+++ b/TreeDB/internal/typeddecode/plan.go
@@ -64,6 +64,7 @@ const (
 	ReasonRoleMismatch               Reason = "role_mismatch"
 	ReasonColumnMismatch             Reason = "column_mismatch"
 	ReasonTypeEncodingMismatch       Reason = "type_encoding_mismatch"
+	ReasonResourceMismatch           Reason = "resource_mismatch"
 )
 
 // Status describes the outcome of planning or validating a fast-decode path.
@@ -192,6 +193,7 @@ func ReasonVocabulary() []Reason {
 		ReasonRoleMismatch,
 		ReasonColumnMismatch,
 		ReasonTypeEncodingMismatch,
+		ReasonResourceMismatch,
 	}
 }
 

--- a/TreeDB/internal/typeddecode/plan.go
+++ b/TreeDB/internal/typeddecode/plan.go
@@ -60,6 +60,10 @@ const (
 	ReasonDictionarySemanticsMissing Reason = "dictionary_semantics_missing"
 	ReasonMaterializationRequired    Reason = "materialization_required"
 	ReasonValidationFailed           Reason = "validation_failed"
+	ReasonOwnerMismatch              Reason = "owner_mismatch"
+	ReasonRoleMismatch               Reason = "role_mismatch"
+	ReasonColumnMismatch             Reason = "column_mismatch"
+	ReasonTypeEncodingMismatch       Reason = "type_encoding_mismatch"
 )
 
 // Status describes the outcome of planning or validating a fast-decode path.
@@ -184,6 +188,10 @@ func ReasonVocabulary() []Reason {
 		ReasonDictionarySemanticsMissing,
 		ReasonMaterializationRequired,
 		ReasonValidationFailed,
+		ReasonOwnerMismatch,
+		ReasonRoleMismatch,
+		ReasonColumnMismatch,
+		ReasonTypeEncodingMismatch,
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #2046.

Adds the shared `TreeDB/internal/typeddecode` graph direct-view certifier substrate for current prepared graph-search typed-column primitive families:

- `float32_vector` / `raw_float32_vector` -> row-major `[]float32` + dims
- `float32` / `raw_float32` -> scalar `[]float32`
- `uint32_list` / `raw_uint32_offsets_list` -> offsets + `[]uint32` values
- `int64` / `raw_int64` -> scalar `[]int64`
- `bytes` / `raw_bytes_offsets` -> offsets + opaque bytes

The helpers fail closed on owner/role/column/type/encoding/row-count mismatches, null/default/compression state, fixed-dim and payload length mismatches, offset monotonicity/bounds issues, absolute/actual pointer alignment failures, unsupported heap-copy handles, stale/nil handles, incomplete/mismatched mappedresource section metadata, and stale/wrong physical resource identity. Prepared view `Close` releases the tied mmap/resource handles.

Docs cross-link the reusable #2046 substrate from the #2036/#2044/#2047 policy docs without marking downstream type-specific graph-search rows admitted.

## Scope boundaries

- No graph-search routing, type-specific prepared runtime integration, or admission promotion in this PR.
- Graph-owned invariants such as finite vector/norm proofs, neighbor ordinal bounds, row-ref coordinate bounds, layer topology, and result materialization remain for #2038/#2040/#2041/#2045.
- No steady-state graph-search benchmark claim is made here.

## Tests

Latest head: `1cced73b5508e83eea13efb2344aa58b4feb4f06`

- `GOWORK=off go test ./TreeDB/internal/typeddecode ./TreeDB/internal/typedcolumn ./TreeDB/docs`
- `GOWORK=off go test ./TreeDB/collections -run 'TestTypedColumnDirectView'`
- `git diff --check`

Internal reviewer reran after latest-main rebase:

- `GOWORK=off go test ./TreeDB/internal/typeddecode ./TreeDB/docs`

## Benchmark / allocation evidence

Command (Apple M3, darwin/arm64):

```sh
GOWORK=off go test ./TreeDB/internal/typeddecode \
  -run '^$' \
  -bench '^BenchmarkGraphDirectView(Certification|PreparedAccessor)$' \
  -benchmem -count=5
```

| Benchmark | Median ns/op | Approx ops/sec | Range ns/op | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: | ---: |
| `BenchmarkGraphDirectViewPreparedAccessor` | 6.6 | 150,534,397 | 6.5-6.8 | 0 | 0 |
| `BenchmarkGraphDirectViewCertification/float32_vector` | 702.5 | 1,423,488 | 669.7-744.2 | 0 | 0 |
| `BenchmarkGraphDirectViewCertification/float32` | 683.2 | 1,463,700 | 643.5-785.9 | 0 | 0 |
| `BenchmarkGraphDirectViewCertification/int64` | 498.9 | 2,004,410 | 481.1-507.7 | 0 | 0 |
| `BenchmarkGraphDirectViewCertification/uint32_list` | 835.2 | 1,197,318 | 820.5-885.2 | 0 | 0 |
| `BenchmarkGraphDirectViewCertification/bytes` | 745.3 | 1,341,742 | 734.5-772.6 | 0 | 0 |

## Review status

- Internal Orca reviewer: PASS after blocking resource-identity metadata finding was fixed and rechecked after rebase.
- Latest-head CI: all 26 GitHub checks passed for `1cced73b5508e83eea13efb2344aa58b4feb4f06`.
- Codex: physical resource identity finding fixed in `1cced73b5`; Codex re-review reported no major issues. Thread replied to and resolved.
- CodeRabbit: completed with no actionable comments / review skipped status after latest push.
- Copilot: requested twice; no response observed.
- Review threads: 0 unresolved.

## Risks / follow-ups

- The substrate certifies primitive typed-column direct-view readiness only. Downstream graph tickets must still wire role-specific prepared views, counters, finite-value/neighbor/row-ref validations, and #2037 search benchmarks before #2044 rows can become admitted.
