### PR TITLE
[codex] Reuse nativewire GetMany response scratch

### DIFF
--- a/TreeDB/nativewire/read_test.go
+++ b/TreeDB/nativewire/read_test.go
@@ -77,6 +77,16 @@ func TestReadCommandsParity(t *testing.T) {
 	if !bytes.Contains(handleDocs[0], []byte(`"Ada"`)) || len(handleDocs[1]) != 0 {
 		t.Fatalf("handle docs=%q", handleDocs)
 	}
+	missingDocs, missingPresent, err := client.GetManyHandle(ctx, handle, [][]byte{[]byte("missing")})
+	if err != nil {
+		t.Fatalf("GetManyHandle missing after present: %v", err)
+	}
+	if got, want := missingPresent, []bool{false}; !boolSlicesEqual(got, want) {
+		t.Fatalf("missing present after present=%v want %v", got, want)
+	}
+	if len(missingDocs) != 1 || len(missingDocs[0]) != 0 {
+		t.Fatalf("missing docs after present=%q", missingDocs)
+	}
 
 	ids, truncated, err := client.IndexLookup(ctx, "users", "email", "ada@example.com", CursorLimits{MaxItems: 10})
 	if err != nil {

--- a/TreeDB/nativewire/server.go
+++ b/TreeDB/nativewire/server.go
@@ -149,13 +149,16 @@ type connState struct {
 	handleCols  map[CollectionHandle]*collections.Collection
 	collections map[string]*collections.Collection
 
-	readBody       []byte
-	writeBody      []byte
-	responseBody   []byte
-	sections       []iwire.Section
-	commandScratch iwire.CommandScratch
-	idsScratch     [][]byte
-	docsScratch    [][]byte
+	readBody        []byte
+	writeBody       []byte
+	responseBody    []byte
+	sections        []iwire.Section
+	commandScratch  iwire.CommandScratch
+	idsScratch      [][]byte
+	docsScratch     [][]byte
+	getManyLengths  []int
+	getManyPresence []byte
+	getManyPayload  []byte
 }
 
 func (s *connState) addCollectionHandle(name string, collection *collections.Collection, handleLimit, cacheLimit int) (CollectionHandle, error) {

--- a/TreeDB/nativewire/server_read.go
+++ b/TreeDB/nativewire/server_read.go
@@ -38,9 +38,9 @@ func (s *Server) handleGetManyBody(state *connState, sections []iwire.Section, d
 		return nil, err
 	}
 
-	lengths := make([]int, len(ids))
-	presence := make([]byte, (len(ids)+7)/8)
-	payload := make([]byte, 0, getManyPayloadCapacityHint(len(ids), s.limits))
+	lengths := getManyLengthsScratch(state, len(ids))
+	presence := getManyPresenceScratch(state, len(ids))
+	payload := getManyPayloadScratch(state, len(ids), s.limits)
 	for i, id := range ids {
 		start := len(payload)
 		doc, found, err := collection.GetInto(id, payload[start:start])
@@ -102,7 +102,12 @@ func (s *Server) handleGetManyBody(state *connState, sections []iwire.Section, d
 	if err != nil {
 		return nil, err
 	}
-	return iwire.AppendByteVectorPayload(body, lengths, payload)
+	body, err = iwire.AppendByteVectorPayload(body, lengths, payload)
+	if err != nil {
+		return nil, err
+	}
+	retainGetManyScratch(state, lengths, presence, payload)
+	return body, nil
 }
 
 func (s *Server) checkResponseSectionLen(name string, sectionLen int) error {
@@ -164,6 +169,68 @@ func getManyPayloadCapacityHint(count int, limits iwire.Limits) int {
 		return int(maxBytes)
 	}
 	return hint
+}
+
+const (
+	maxRetainedGetManyScratchItems = 4096
+	maxRetainedGetManyPayloadBytes = maxBufferedWriteFrameBody
+)
+
+func getManyLengthsScratch(state *connState, count int) []int {
+	if count <= 0 {
+		return nil
+	}
+	if state != nil && count <= cap(state.getManyLengths) {
+		out := state.getManyLengths[:count]
+		clear(out)
+		return out
+	}
+	return make([]int, count)
+}
+
+func getManyPresenceScratch(state *connState, idCount int) []byte {
+	count := (idCount + 7) / 8
+	if count <= 0 {
+		return nil
+	}
+	if state != nil && count <= cap(state.getManyPresence) {
+		out := state.getManyPresence[:count]
+		clear(out)
+		return out
+	}
+	return make([]byte, count)
+}
+
+func getManyPayloadScratch(state *connState, idCount int, limits iwire.Limits) []byte {
+	hint := getManyPayloadCapacityHint(idCount, limits)
+	if hint <= 0 {
+		return nil
+	}
+	if state != nil && hint <= cap(state.getManyPayload) {
+		return state.getManyPayload[:0]
+	}
+	return make([]byte, 0, hint)
+}
+
+func retainGetManyScratch(state *connState, lengths []int, presence []byte, payload []byte) {
+	if state == nil {
+		return
+	}
+	if cap(lengths) <= maxRetainedGetManyScratchItems {
+		state.getManyLengths = lengths[:0]
+	} else {
+		state.getManyLengths = nil
+	}
+	if cap(presence) <= (maxRetainedGetManyScratchItems+7)/8 {
+		state.getManyPresence = presence[:0]
+	} else {
+		state.getManyPresence = nil
+	}
+	if cap(payload) <= maxRetainedGetManyPayloadBytes {
+		state.getManyPayload = payload[:0]
+	} else {
+		state.getManyPayload = nil
+	}
 }
 
 func (s *Server) getManyDocuments(state *connState, sections []iwire.Section) ([][]byte, [][]byte, []bool, error) {


### PR DESCRIPTION
## Summary

Linked tracker: #2051, M4 broader native server profiling.

This PR reuses per-connection scratch buffers for nativewire `get_many` fast-body responses:

- length table scratch
- presence bitmap scratch
- document payload scratch

The change is scoped to the response assembly hot path and keeps the existing response encoding and collection lookup semantics. A parity test now performs a present `GetManyHandle` followed by a missing `GetManyHandle` on the same connection to guard against stale presence/doc scratch state.

## Validation

```sh
go test ./TreeDB/nativewire -run 'TestReadCommandsParity|TestGetMany' -count=1
go test ./TreeDB/nativewire ./cmd/treedb-native-server -count=1
go test ./TreeDB/collections -count=1
```

All passed locally.

## Benchmark Evidence

Host/context:

```text
cpu: 11th Gen Intel(R) Core(TM) i5-11400F @ 2.60GHz
server profile: fast
base: origin/main worktree at 269ebe3a130322657441ecbdb717c4bad8ae8802
candidate: codex/nativewire-getmany-scratch at dab5c2d45
```

Microbenchmark command:

```sh
go test ./TreeDB/nativewire -run '^$' -bench 'BenchmarkNativewireCollectionGetMany' -benchmem -count=7
```

Artifact: `/tmp/treedb_getmany_scratch_bench_1780220145`

| Case | Base sec/op | Candidate sec/op | Base B/op | Candidate B/op | Base allocs/op | Candidate allocs/op |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| `native_wire_inproc` | `29.06us +/- 4%` | `28.53us +/- 9%` | `6.312Ki` | `1.812Ki` | `4` | `2` |
| `native_wire_direct_dispatch` | `29.06us +/- 2%` | `30.04us +/- 27%` | `6.312Ki` | `1.812Ki` | `4` | `2` |

Benchstat reports no statistically significant `sec/op` regression, with `-71.29% B/op` and `-50.00% allocs/op` for both nativewire paths.

YCSB command shape:

```sh
./bin/treedb-native-server -dir "$DB_DIR" -profile fast -addr 127.0.0.1:17113 -pprof 127.0.0.1:18113

./bin/go-ycsb load treedb-native \
  -p treedb.addr=127.0.0.1:17113 \
  -p recordcount=100000 \
  -p operationcount=10000 \
  -p threadcount=16

./bin/go-ycsb run treedb-native \
  -p treedb.addr=127.0.0.1:17113 \
  -p recordcount=100000 \
  -p operationcount=1000000 \
  -p threadcount=16
```

Artifact: `/tmp/treedb_ycsb_getmanyscratch_1780220006`

| Metric | Candidate |
| --- | ---: |
| load insert count/errors | `100000` / `0` |
| load OPS / avg / max | `44129.3` / `348us` / `10295us` |
| run read count/errors | `949892` / `0` |
| run update count/errors | `50108` / `0` |
| run total OPS | `85498.5` |
| read avg / max | `159us` / `8171us` |
| update avg / p99 / p99.9 / max | `605us` / `1488us` / `2465us` / `8423us` |
| slow requests >5ms | `get_many=3`, `replace_batch=11` |

CPU profile from the same run no longer shows the previous GetMany allocation lines as material. The profile is dominated by response writes and `Collection.GetInto`.

## Review Status

Internal review completed before publish. Latest-head CI passed before the PR was moved out of draft. Codex, Copilot, and CodeRabbit reviews were requested after the patch, tests, and benchmark evidence were ready.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage to verify correct behavior when handling data requests containing both present and missing records, ensuring comprehensive validation.

* **Chores**
  * Optimized internal memory management by implementing per-connection buffer reuse mechanisms. This reduces unnecessary memory allocations during request and response processing, improving overall system performance and resource efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->