### PR TITLE
Build graph-search benchmark truth matrix

### DIFF
--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -69,6 +69,12 @@ type columnVectorGraphNativeSearchOptions struct {
 
 	ScoreBatchMode columnVectorGraphScoreBatchMode
 
+	// OmitResultMaterialization is an internal benchmark/profiling hook for the
+	// graph-only boundary. It preserves traversal/scoring/top-k work but skips
+	// final result-ID and row-ref materialization; public search paths must leave
+	// this false so returned IDs and row refs are populated and counted.
+	OmitResultMaterialization bool
+
 	// CandidateRows is an optional pre-composed row-domain filter over graph
 	// ordinals. It is intentionally internal until public metadata predicate
 	// planning is designed; callers that set it should compose predicate and
@@ -618,6 +624,18 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 	}
 
 	if len(scratch.top) == 0 {
+		return scratch.results, stats, nil
+	}
+	if opts.OmitResultMaterialization {
+		stats.BlockViewHits = plan.hits
+		stats.BlockViewMisses = plan.misses
+		stats.BlockViewBuilds = plan.builds
+		for _, candidate := range scratch.top {
+			scratch.results = append(scratch.results, columnVectorGraphNativeSearchResult{
+				Ordinal: candidate.ordinal,
+				Score:   candidate.score,
+			})
+		}
 		return scratch.results, stats, nil
 	}
 	if err := r.fetchTopSearchResults(plan, singleBlockView, scratch, &stats); err != nil {

--- a/TreeDB/collections/column_vector_graph_search_test.go
+++ b/TreeDB/collections/column_vector_graph_search_test.go
@@ -18,15 +18,16 @@ import (
 const columnVectorGraphNativeSearchParallelBenchMaxWorkersV3 = 8
 
 type columnVectorGraphNativeSearchBenchShapeV3 struct {
-	rows                int
-	dims                int
-	m                   int
-	topK                int
-	efSearch            int
-	queryOrdinal        int
-	directPhysicalAsset bool
-	typedColumnVector   bool
-	scoreBatchMode      columnVectorGraphScoreBatchMode
+	rows                      int
+	dims                      int
+	m                         int
+	topK                      int
+	efSearch                  int
+	queryOrdinal              int
+	directPhysicalAsset       bool
+	typedColumnVector         bool
+	omitResultMaterialization bool
+	scoreBatchMode            columnVectorGraphScoreBatchMode
 }
 
 func TestColumnVectorGraphAdjacencySourceStatsSkipEmptyNoopV3(t *testing.T) {
@@ -845,7 +846,7 @@ func benchmarkColumnVectorGraphNativeSearchCosineV3(b *testing.B, shape columnVe
 	}
 	defer reader.Close()
 	var scratch columnVectorGraphNativeSearchScratch
-	opts := columnVectorGraphNativeSearchOptions{TopK: shape.topK, EfSearch: shape.efSearch, ScoreBatchMode: shape.scoreBatchMode}
+	opts := columnVectorGraphNativeSearchOptions{TopK: shape.topK, EfSearch: shape.efSearch, ScoreBatchMode: shape.scoreBatchMode, OmitResultMaterialization: shape.omitResultMaterialization}
 	if _, _, err := reader.SearchCosine(query, opts, &scratch); err != nil {
 		b.Fatalf("warm SearchCosine: %v", err)
 	}
@@ -931,6 +932,14 @@ func benchmarkColumnVectorGraphNativeSearchCosineV3(b *testing.B, shape columnVe
 		searchStats.TypedColumnActiveHandles = stats.TypedColumnActiveHandles
 		searchStats.TypedColumnDeniedResources = stats.TypedColumnDeniedResources
 		searchStats.TypedColumnFallbacks += stats.TypedColumnFallbacks
+		searchStats.RowRefVectorSourceState += stats.RowRefVectorSourceState
+		searchStats.RowRefVectorSourceLegacyGraphIDs += stats.RowRefVectorSourceLegacyGraphIDs
+		searchStats.RowRefStateResultRefs += stats.RowRefStateResultRefs
+		searchStats.RowRefStateSourceUnavailable += stats.RowRefStateSourceUnavailable
+		searchStats.RowRefStateSourceFallbacks += stats.RowRefStateSourceFallbacks
+		searchStats.ResultIDTypedBytesState += stats.ResultIDTypedBytesState
+		searchStats.ResultIDGraphFallbacks += stats.ResultIDGraphFallbacks
+		searchStats.ResultIDStateValidationFailures += stats.ResultIDStateValidationFailures
 	}
 	b.StopTimer()
 	stats := reader.Stats()
@@ -986,7 +995,7 @@ func benchmarkColumnVectorGraphNativeSearchCosineParallelV3(b *testing.B, shape 
 	previousGOMAXPROCS := runtime.GOMAXPROCS(workers)
 	defer runtime.GOMAXPROCS(previousGOMAXPROCS)
 	benchWorkers := make([]*searchWorker, workers)
-	opts := columnVectorGraphNativeSearchOptions{TopK: shape.topK, EfSearch: shape.efSearch, ScoreBatchMode: shape.scoreBatchMode}
+	opts := columnVectorGraphNativeSearchOptions{TopK: shape.topK, EfSearch: shape.efSearch, ScoreBatchMode: shape.scoreBatchMode, OmitResultMaterialization: shape.omitResultMaterialization}
 	for i := range benchWorkers {
 		reader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
 		if err != nil {
@@ -1079,6 +1088,14 @@ func benchmarkColumnVectorGraphNativeSearchCosineParallelV3(b *testing.B, shape 
 	var totalTypedColumnActiveHandles atomic.Int64
 	var totalTypedColumnDeniedResources atomic.Uint64
 	var totalTypedColumnFallbacks atomic.Uint64
+	var totalRowRefVectorSourceState atomic.Uint64
+	var totalRowRefVectorSourceLegacyGraphIDs atomic.Uint64
+	var totalRowRefStateResultRefs atomic.Uint64
+	var totalRowRefStateSourceUnavailable atomic.Uint64
+	var totalRowRefStateSourceFallbacks atomic.Uint64
+	var totalResultIDTypedBytesState atomic.Uint64
+	var totalResultIDGraphFallbacks atomic.Uint64
+	var totalResultIDStateValidationFailures atomic.Uint64
 	var nextWorker atomic.Uint64
 	b.SetParallelism(1) // Keep one prewarmed reader/scratch per RunParallel worker.
 	b.ReportAllocs()
@@ -1177,6 +1194,14 @@ func benchmarkColumnVectorGraphNativeSearchCosineParallelV3(b *testing.B, shape 
 			localStats.TypedColumnActiveHandles = stats.TypedColumnActiveHandles
 			localStats.TypedColumnDeniedResources = stats.TypedColumnDeniedResources
 			localStats.TypedColumnFallbacks += stats.TypedColumnFallbacks
+			localStats.RowRefVectorSourceState += stats.RowRefVectorSourceState
+			localStats.RowRefVectorSourceLegacyGraphIDs += stats.RowRefVectorSourceLegacyGraphIDs
+			localStats.RowRefStateResultRefs += stats.RowRefStateResultRefs
+			localStats.RowRefStateSourceUnavailable += stats.RowRefStateSourceUnavailable
+			localStats.RowRefStateSourceFallbacks += stats.RowRefStateSourceFallbacks
+			localStats.ResultIDTypedBytesState += stats.ResultIDTypedBytesState
+			localStats.ResultIDGraphFallbacks += stats.ResultIDGraphFallbacks
+			localStats.ResultIDStateValidationFailures += stats.ResultIDStateValidationFailures
 		}
 		sink.Add(localSink)
 		totalCandidateRows.Add(localStats.CandidateRows)
@@ -1251,6 +1276,14 @@ func benchmarkColumnVectorGraphNativeSearchCosineParallelV3(b *testing.B, shape 
 		totalTypedColumnActiveHandles.Add(localStats.TypedColumnActiveHandles)
 		totalTypedColumnDeniedResources.Add(localStats.TypedColumnDeniedResources)
 		totalTypedColumnFallbacks.Add(localStats.TypedColumnFallbacks)
+		totalRowRefVectorSourceState.Add(localStats.RowRefVectorSourceState)
+		totalRowRefVectorSourceLegacyGraphIDs.Add(localStats.RowRefVectorSourceLegacyGraphIDs)
+		totalRowRefStateResultRefs.Add(localStats.RowRefStateResultRefs)
+		totalRowRefStateSourceUnavailable.Add(localStats.RowRefStateSourceUnavailable)
+		totalRowRefStateSourceFallbacks.Add(localStats.RowRefStateSourceFallbacks)
+		totalResultIDTypedBytesState.Add(localStats.ResultIDTypedBytesState)
+		totalResultIDGraphFallbacks.Add(localStats.ResultIDGraphFallbacks)
+		totalResultIDStateValidationFailures.Add(localStats.ResultIDStateValidationFailures)
 	})
 	b.StopTimer()
 	reportColumnGraphNativeSearchBenchShapeMetricsV3(b, shape)
@@ -1331,6 +1364,14 @@ func benchmarkColumnVectorGraphNativeSearchCosineParallelV3(b *testing.B, shape 
 		TypedColumnActiveHandles:             totalTypedColumnActiveHandles.Load(),
 		TypedColumnDeniedResources:           totalTypedColumnDeniedResources.Load(),
 		TypedColumnFallbacks:                 totalTypedColumnFallbacks.Load(),
+		RowRefVectorSourceState:              totalRowRefVectorSourceState.Load(),
+		RowRefVectorSourceLegacyGraphIDs:     totalRowRefVectorSourceLegacyGraphIDs.Load(),
+		RowRefStateResultRefs:                totalRowRefStateResultRefs.Load(),
+		RowRefStateSourceUnavailable:         totalRowRefStateSourceUnavailable.Load(),
+		RowRefStateSourceFallbacks:           totalRowRefStateSourceFallbacks.Load(),
+		ResultIDTypedBytesState:              totalResultIDTypedBytesState.Load(),
+		ResultIDGraphFallbacks:               totalResultIDGraphFallbacks.Load(),
+		ResultIDStateValidationFailures:      totalResultIDStateValidationFailures.Load(),
 	})
 }
 
@@ -1343,6 +1384,9 @@ func reportColumnGraphNativeSearchBenchShapeMetricsV3(b *testing.B, shape column
 	b.ReportMetric(float64(shape.efSearch), "ef_search")
 	if shape.typedColumnVector {
 		b.ReportMetric(1, "typed_column_vector")
+	}
+	if shape.omitResultMaterialization {
+		b.ReportMetric(1, "graph_only_no_result_materialization")
 	}
 	if shape.scoreBatchMode != columnVectorGraphScoreBatchModeDefault {
 		if shape.scoreBatchMode.indexedEnabled() {
@@ -1406,6 +1450,7 @@ func publishColumnVectorGraphPhysicalReaderTestAssetWithShapeAndAdjacencyState19
 		_ = d.Close()
 		tb.Fatalf("columnVectorGraphPhysicalColumnStoreConfig: %v", err)
 	}
+	identity := ColumnManifestIdentity{Generation: generation, Format: columnManifestFormatTCS1, Version: columnManifestIdentityVersion, Checksum: 0x1234}
 	graph := columnVectorGraphManifestSnapshot{
 		IndexName:              def.Name,
 		Field:                  def.Field,
@@ -1416,14 +1461,15 @@ func publishColumnVectorGraphPhysicalReaderTestAssetWithShapeAndAdjacencyState19
 		EfConstruction:         def.EfConstruction,
 		EfSearch:               def.EfSearch,
 		BaseManifestGeneration: generation,
+		BaseManifestChecksum:   identity.Checksum,
 		BaseSchemaHash:         baseCfg.SchemaHash,
 		GraphSchemaHash:        graphCfg.SchemaHash,
 		RowCount:               prepared.RowCount,
 		AssetRef:               prepared.Ref,
 		AssetBytes:             prepared.Bytes,
 	}
-	identity := ColumnManifestIdentity{Generation: generation, Format: columnManifestFormatTCS1, Version: columnManifestIdentityVersion, Checksum: 0x1234}
 	records, manifestIdentity := testColumnGraphManifestRecordsFromSnapshot1920(tb, *baseCfg, graph, identity)
+	graph = graphManifestFromRecords1918(tb, records, def)
 	stateRows := columnVectorGraphStateRowsForTest1987(rows, graph.RowCount, def.Dimensions, columnVectorGraphExpectedAdjacencyLayerCountFromAssetRows1989(tb, rows))
 	records, manifestIdentity = appendCompleteVectorIndexStateForGraphTest1987(tb, d, "docs", *baseCfg, def, graph, records, manifestIdentity, columnVectorIndexStateChecksumInput1986(*baseCfg), stateRows)
 	meta := CollectionMeta{
@@ -1566,6 +1612,9 @@ func reportColumnGraphNativeSearchBenchMetricsV3(b *testing.B, n int, baseStats,
 	if n <= 0 {
 		return
 	}
+	if elapsed := b.Elapsed(); elapsed > 0 {
+		b.ReportMetric(float64(n)/elapsed.Seconds(), "ops/sec")
+	}
 	b.ReportMetric(float64(stats.Rows), "graph_rows")
 	b.ReportMetric(float64(stats.Granules), "graph_granules")
 	b.ReportMetric(float64(searchStats.CandidateRows)/float64(n), "candidate_rows/search")
@@ -1648,6 +1697,14 @@ func reportColumnGraphNativeSearchBenchMetricsV3(b *testing.B, n int, baseStats,
 		b.ReportMetric(1, "typed_column_vector_source_fallback")
 	}
 	b.ReportMetric(float64(searchStats.TypedColumnFallbacks)/float64(n), "typed_column_vector_fallbacks/search")
+	b.ReportMetric(float64(searchStats.RowRefVectorSourceState)/float64(n), "row_ref_vector_source_state/search")
+	b.ReportMetric(float64(searchStats.RowRefVectorSourceLegacyGraphIDs)/float64(n), "row_ref_vector_source_legacy_graph_ids/search")
+	b.ReportMetric(float64(searchStats.RowRefStateResultRefs)/float64(n), "row_ref_state_result_refs/search")
+	b.ReportMetric(float64(searchStats.RowRefStateSourceUnavailable)/float64(n), "row_ref_state_source_unavailable/search")
+	b.ReportMetric(float64(searchStats.RowRefStateSourceFallbacks)/float64(n), "row_ref_state_source_fallbacks/search")
+	b.ReportMetric(float64(searchStats.ResultIDTypedBytesState)/float64(n), "result_id_typed_bytes_state/search")
+	b.ReportMetric(float64(searchStats.ResultIDGraphFallbacks)/float64(n), "result_id_graph_fallbacks/search")
+	b.ReportMetric(float64(searchStats.ResultIDStateValidationFailures)/float64(n), "result_id_state_validation_failures/search")
 	b.ReportMetric(float64(searchStats.TypedColumnMappedBytes), "mapped_B")
 	b.ReportMetric(float64(searchStats.TypedColumnHeapCopyBytes), "heap_copy_B")
 	b.ReportMetric(float64(searchStats.TypedColumnDecodedBytes), "decoded_derived_B")
@@ -1655,6 +1712,13 @@ func reportColumnGraphNativeSearchBenchMetricsV3(b *testing.B, n int, baseStats,
 	b.ReportMetric(float64(searchStats.TypedColumnDeniedResources), "denied_resources")
 	b.ReportMetric(float64(searchStats.ExpansionFetches)/float64(n), "expansion_fetches/search")
 	b.ReportMetric(float64(searchStats.ResultFetches)/float64(n), "result_fetches/search")
+	// Lower-level native search never materializes documents; keep these zero
+	// labels present so graph-only truth-matrix rows have the same report columns
+	// as public result/document boundary rows.
+	b.ReportMetric(0, "docs_fetched/search")
+	b.ReportMetric(0, "doc_fetch_ns/search")
+	b.ReportMetric(0, "doc_row_ref_state_fetches/search")
+	b.ReportMetric(0, "doc_row_ref_lookup_fallbacks/search")
 	b.ReportMetric(float64(deltaColumnGraphNativeBenchCounterV3(stats.CacheHits, baseStats.CacheHits))/float64(n), "cache_hits/search")
 	b.ReportMetric(float64(deltaColumnGraphNativeBenchCounterV3(stats.CacheMisses, baseStats.CacheMisses))/float64(n), "cache_misses/search")
 	b.ReportMetric(float64(deltaColumnGraphNativeBenchCounterV3(stats.DecodedBlocks, baseStats.DecodedBlocks))/float64(n), "decoded_blocks/search")
@@ -1681,10 +1745,22 @@ func deltaColumnGraphNativeBenchBytesV3(current, base int64) int64 {
 }
 
 func addColumnPhysicalRowReaderStatsV3(left, right columnPhysicalRowReaderStats) columnPhysicalRowReaderStats {
-	left.Rows += right.Rows
-	left.Granules += right.Granules
-	left.OpenGranulesRead += right.OpenGranulesRead
-	left.OpenPhysicalBytesRead += right.OpenPhysicalBytesRead
+	// Rows/granules and open bytes describe one bound graph asset/reader shape.
+	// Parallel benchmarks open one reader per worker, but reporting worker-summed
+	// graph_rows makes the fixture look larger than it is. Keep absolute shape
+	// counters at the per-reader maximum and sum only mutable search counters.
+	if right.Rows > left.Rows {
+		left.Rows = right.Rows
+	}
+	if right.Granules > left.Granules {
+		left.Granules = right.Granules
+	}
+	if right.OpenGranulesRead > left.OpenGranulesRead {
+		left.OpenGranulesRead = right.OpenGranulesRead
+	}
+	if right.OpenPhysicalBytesRead > left.OpenPhysicalBytesRead {
+		left.OpenPhysicalBytesRead = right.OpenPhysicalBytesRead
+	}
 	left.OpenSegmentCacheHits += right.OpenSegmentCacheHits
 	left.OpenSegmentCacheMisses += right.OpenSegmentCacheMisses
 	left.RowFetches += right.RowFetches

--- a/TreeDB/collections/vector_graph_search_truth_matrix_2037_test.go
+++ b/TreeDB/collections/vector_graph_search_truth_matrix_2037_test.go
@@ -1,0 +1,360 @@
+package collections
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+type vectorGraphSearchTruthMatrixMode2037 string
+
+const (
+	vectorGraphSearchTruthMatrixModeLegacyDirectGraphRow2037 vectorGraphSearchTruthMatrixMode2037 = "legacy_direct_graph_row"
+	vectorGraphSearchTruthMatrixModeCurrentTypedColumn2037   vectorGraphSearchTruthMatrixMode2037 = "current_tvis_base_typed_column"
+	vectorGraphSearchTruthMatrixModePreparedPlaceholder2037  vectorGraphSearchTruthMatrixMode2037 = "prepared_typed_column_placeholder"
+)
+
+type vectorGraphSearchTruthMatrixBoundary2037 string
+
+const (
+	vectorGraphSearchTruthMatrixBoundarySetupOpenPrepare2037    vectorGraphSearchTruthMatrixBoundary2037 = "setup_open_prepare"
+	vectorGraphSearchTruthMatrixBoundaryGraphOnly2037           vectorGraphSearchTruthMatrixBoundary2037 = "graph_only"
+	vectorGraphSearchTruthMatrixBoundaryResultID2037            vectorGraphSearchTruthMatrixBoundary2037 = "result_id"
+	vectorGraphSearchTruthMatrixBoundaryDocumentMaterialize2037 vectorGraphSearchTruthMatrixBoundary2037 = "document_materialization"
+)
+
+type vectorGraphSearchTruthMatrixConcurrency2037 string
+
+const (
+	vectorGraphSearchTruthMatrixConcurrencySerial2037   vectorGraphSearchTruthMatrixConcurrency2037 = "serial"
+	vectorGraphSearchTruthMatrixConcurrencyParallel2037 vectorGraphSearchTruthMatrixConcurrency2037 = "parallel"
+)
+
+type vectorGraphSearchTruthMatrixFixture2037 string
+
+const (
+	vectorGraphSearchTruthMatrixFixtureServing10242037    vectorGraphSearchTruthMatrixFixture2037 = "serving1024"
+	vectorGraphSearchTruthMatrixFixtureProduction81922037 vectorGraphSearchTruthMatrixFixture2037 = "production8192"
+)
+
+const vectorGraphSearchTruthMatrixPreparedUnsupportedReason2037 = "prepared typed-column graph-search path is a #2037 placeholder until #2038/#2040/#2041/#2045 add prepared views and routing; skipped row is not performance data"
+
+type vectorGraphSearchTruthMatrixRow2037 struct {
+	Mode               vectorGraphSearchTruthMatrixMode2037
+	Boundary           vectorGraphSearchTruthMatrixBoundary2037
+	Concurrency        vectorGraphSearchTruthMatrixConcurrency2037
+	Fixture            vectorGraphSearchTruthMatrixFixture2037
+	CanonicalBenchmark string
+	UnsupportedReason  string
+}
+
+func (r vectorGraphSearchTruthMatrixRow2037) Name() string {
+	return fmt.Sprintf("mode=%s/boundary=%s/concurrency=%s/fixture=%s", r.Mode, r.Boundary, r.Concurrency, r.Fixture)
+}
+
+func (r vectorGraphSearchTruthMatrixRow2037) Supported() bool {
+	return r.UnsupportedReason == ""
+}
+
+func vectorGraphSearchTruthMatrixRows2037() []vectorGraphSearchTruthMatrixRow2037 {
+	return []vectorGraphSearchTruthMatrixRow2037{
+		{Mode: vectorGraphSearchTruthMatrixModeLegacyDirectGraphRow2037, Boundary: vectorGraphSearchTruthMatrixBoundarySetupOpenPrepare2037, Concurrency: vectorGraphSearchTruthMatrixConcurrencySerial2037, Fixture: vectorGraphSearchTruthMatrixFixtureServing10242037, CanonicalBenchmark: "BenchmarkColumnVectorGraphSearchTruthMatrix2037"},
+		{Mode: vectorGraphSearchTruthMatrixModeCurrentTypedColumn2037, Boundary: vectorGraphSearchTruthMatrixBoundarySetupOpenPrepare2037, Concurrency: vectorGraphSearchTruthMatrixConcurrencySerial2037, Fixture: vectorGraphSearchTruthMatrixFixtureServing10242037, CanonicalBenchmark: "BenchmarkColumnVectorGraphSearchTruthMatrix2037"},
+		{Mode: vectorGraphSearchTruthMatrixModePreparedPlaceholder2037, Boundary: vectorGraphSearchTruthMatrixBoundarySetupOpenPrepare2037, Concurrency: vectorGraphSearchTruthMatrixConcurrencySerial2037, Fixture: vectorGraphSearchTruthMatrixFixtureServing10242037, CanonicalBenchmark: "future BenchmarkColumnVectorGraphSearchTruthMatrix2037 prepared setup row", UnsupportedReason: vectorGraphSearchTruthMatrixPreparedUnsupportedReason2037},
+
+		{Mode: vectorGraphSearchTruthMatrixModeLegacyDirectGraphRow2037, Boundary: vectorGraphSearchTruthMatrixBoundaryGraphOnly2037, Concurrency: vectorGraphSearchTruthMatrixConcurrencySerial2037, Fixture: vectorGraphSearchTruthMatrixFixtureProduction81922037, CanonicalBenchmark: "BenchmarkColumnVectorGraphNativeSearchCosineProduction8192V3 with graph_only_no_result_materialization"},
+		{Mode: vectorGraphSearchTruthMatrixModeLegacyDirectGraphRow2037, Boundary: vectorGraphSearchTruthMatrixBoundaryGraphOnly2037, Concurrency: vectorGraphSearchTruthMatrixConcurrencyParallel2037, Fixture: vectorGraphSearchTruthMatrixFixtureProduction81922037, CanonicalBenchmark: "BenchmarkColumnVectorGraphNativeSearchCosineParallelProduction8192V3 with graph_only_no_result_materialization"},
+		{Mode: vectorGraphSearchTruthMatrixModeCurrentTypedColumn2037, Boundary: vectorGraphSearchTruthMatrixBoundaryGraphOnly2037, Concurrency: vectorGraphSearchTruthMatrixConcurrencySerial2037, Fixture: vectorGraphSearchTruthMatrixFixtureProduction81922037, CanonicalBenchmark: "BenchmarkColumnVectorGraphNativeSearchCosineTypedColumnProduction8192V3 with graph_only_no_result_materialization"},
+		{Mode: vectorGraphSearchTruthMatrixModeCurrentTypedColumn2037, Boundary: vectorGraphSearchTruthMatrixBoundaryGraphOnly2037, Concurrency: vectorGraphSearchTruthMatrixConcurrencyParallel2037, Fixture: vectorGraphSearchTruthMatrixFixtureProduction81922037, CanonicalBenchmark: "BenchmarkColumnVectorGraphNativeSearchCosineParallelTypedColumnProduction8192V3 with graph_only_no_result_materialization"},
+		{Mode: vectorGraphSearchTruthMatrixModePreparedPlaceholder2037, Boundary: vectorGraphSearchTruthMatrixBoundaryGraphOnly2037, Concurrency: vectorGraphSearchTruthMatrixConcurrencySerial2037, Fixture: vectorGraphSearchTruthMatrixFixtureProduction81922037, CanonicalBenchmark: "future prepared graph-only serial row", UnsupportedReason: vectorGraphSearchTruthMatrixPreparedUnsupportedReason2037},
+		{Mode: vectorGraphSearchTruthMatrixModePreparedPlaceholder2037, Boundary: vectorGraphSearchTruthMatrixBoundaryGraphOnly2037, Concurrency: vectorGraphSearchTruthMatrixConcurrencyParallel2037, Fixture: vectorGraphSearchTruthMatrixFixtureProduction81922037, CanonicalBenchmark: "future prepared graph-only parallel row", UnsupportedReason: vectorGraphSearchTruthMatrixPreparedUnsupportedReason2037},
+
+		{Mode: vectorGraphSearchTruthMatrixModeCurrentTypedColumn2037, Boundary: vectorGraphSearchTruthMatrixBoundaryResultID2037, Concurrency: vectorGraphSearchTruthMatrixConcurrencySerial2037, Fixture: vectorGraphSearchTruthMatrixFixtureServing10242037, CanonicalBenchmark: "BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderV4"},
+		{Mode: vectorGraphSearchTruthMatrixModeCurrentTypedColumn2037, Boundary: vectorGraphSearchTruthMatrixBoundaryResultID2037, Concurrency: vectorGraphSearchTruthMatrixConcurrencyParallel2037, Fixture: vectorGraphSearchTruthMatrixFixtureServing10242037, CanonicalBenchmark: "BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderParallelV4"},
+		{Mode: vectorGraphSearchTruthMatrixModePreparedPlaceholder2037, Boundary: vectorGraphSearchTruthMatrixBoundaryResultID2037, Concurrency: vectorGraphSearchTruthMatrixConcurrencySerial2037, Fixture: vectorGraphSearchTruthMatrixFixtureServing10242037, CanonicalBenchmark: "future prepared result-ID serial row", UnsupportedReason: vectorGraphSearchTruthMatrixPreparedUnsupportedReason2037},
+		{Mode: vectorGraphSearchTruthMatrixModePreparedPlaceholder2037, Boundary: vectorGraphSearchTruthMatrixBoundaryResultID2037, Concurrency: vectorGraphSearchTruthMatrixConcurrencyParallel2037, Fixture: vectorGraphSearchTruthMatrixFixtureServing10242037, CanonicalBenchmark: "future prepared result-ID parallel row", UnsupportedReason: vectorGraphSearchTruthMatrixPreparedUnsupportedReason2037},
+
+		{Mode: vectorGraphSearchTruthMatrixModeCurrentTypedColumn2037, Boundary: vectorGraphSearchTruthMatrixBoundaryDocumentMaterialize2037, Concurrency: vectorGraphSearchTruthMatrixConcurrencySerial2037, Fixture: vectorGraphSearchTruthMatrixFixtureServing10242037, CanonicalBenchmark: "BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderWithDocumentsV4"},
+		{Mode: vectorGraphSearchTruthMatrixModeCurrentTypedColumn2037, Boundary: vectorGraphSearchTruthMatrixBoundaryDocumentMaterialize2037, Concurrency: vectorGraphSearchTruthMatrixConcurrencyParallel2037, Fixture: vectorGraphSearchTruthMatrixFixtureServing10242037, CanonicalBenchmark: "BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderParallelWithDocumentsV4"},
+		{Mode: vectorGraphSearchTruthMatrixModePreparedPlaceholder2037, Boundary: vectorGraphSearchTruthMatrixBoundaryDocumentMaterialize2037, Concurrency: vectorGraphSearchTruthMatrixConcurrencySerial2037, Fixture: vectorGraphSearchTruthMatrixFixtureServing10242037, CanonicalBenchmark: "future prepared document-materialization serial row", UnsupportedReason: vectorGraphSearchTruthMatrixPreparedUnsupportedReason2037},
+		{Mode: vectorGraphSearchTruthMatrixModePreparedPlaceholder2037, Boundary: vectorGraphSearchTruthMatrixBoundaryDocumentMaterialize2037, Concurrency: vectorGraphSearchTruthMatrixConcurrencyParallel2037, Fixture: vectorGraphSearchTruthMatrixFixtureServing10242037, CanonicalBenchmark: "future prepared document-materialization parallel row", UnsupportedReason: vectorGraphSearchTruthMatrixPreparedUnsupportedReason2037},
+	}
+}
+
+func vectorGraphSearchTruthMatrixRequiredMetricLabels2037() []string {
+	return []string{
+		"ns/op",
+		"ops/sec",
+		"B/op",
+		"allocs/op",
+		"graph_rows",
+		"parallel_workers",
+		"candidate_rows/search",
+		"candidates/search",
+		"edges/search",
+		"visited_edges/search",
+		"docs_fetched/search",
+		"doc_fetch_ns/search",
+		"result_fetches/search",
+		"result_id_typed_bytes_state/search",
+		"result_id_graph_fallbacks/search",
+		"row_ref_vector_source_state/search",
+		"row_ref_vector_source_legacy_graph_ids/search",
+		"row_ref_state_result_refs/search",
+		"row_ref_state_source_fallbacks/search",
+		"doc_row_ref_state_fetches/search",
+		"doc_row_ref_lookup_fallbacks/search",
+		"vector_mmap_direct/search",
+		"vector_heap_copy_typed_view/search",
+		"vector_scratch_decodes/search",
+		"typed_column_vector_fallbacks/search",
+		"norm_mmap_direct/search",
+		"norm_heap_copy_typed_view/search",
+		"norm_scratch_decodes/search",
+		"norm_source_fallbacks/search",
+		"adjacency_typed_list_mmap_direct/search",
+		"adjacency_typed_list_heap_copy_typed_view/search",
+		"adjacency_typed_list_scratch_decodes/search",
+		"adjacency_legacy_fallbacks/search",
+		"adjacency_source_fallbacks/search",
+	}
+}
+
+func TestVectorGraphSearchTruthMatrixRows2037(t *testing.T) {
+	rows := vectorGraphSearchTruthMatrixRows2037()
+	wantNames := []string{
+		"mode=legacy_direct_graph_row/boundary=setup_open_prepare/concurrency=serial/fixture=serving1024",
+		"mode=current_tvis_base_typed_column/boundary=setup_open_prepare/concurrency=serial/fixture=serving1024",
+		"mode=prepared_typed_column_placeholder/boundary=setup_open_prepare/concurrency=serial/fixture=serving1024",
+		"mode=legacy_direct_graph_row/boundary=graph_only/concurrency=serial/fixture=production8192",
+		"mode=legacy_direct_graph_row/boundary=graph_only/concurrency=parallel/fixture=production8192",
+		"mode=current_tvis_base_typed_column/boundary=graph_only/concurrency=serial/fixture=production8192",
+		"mode=current_tvis_base_typed_column/boundary=graph_only/concurrency=parallel/fixture=production8192",
+		"mode=prepared_typed_column_placeholder/boundary=graph_only/concurrency=serial/fixture=production8192",
+		"mode=prepared_typed_column_placeholder/boundary=graph_only/concurrency=parallel/fixture=production8192",
+		"mode=current_tvis_base_typed_column/boundary=result_id/concurrency=serial/fixture=serving1024",
+		"mode=current_tvis_base_typed_column/boundary=result_id/concurrency=parallel/fixture=serving1024",
+		"mode=prepared_typed_column_placeholder/boundary=result_id/concurrency=serial/fixture=serving1024",
+		"mode=prepared_typed_column_placeholder/boundary=result_id/concurrency=parallel/fixture=serving1024",
+		"mode=current_tvis_base_typed_column/boundary=document_materialization/concurrency=serial/fixture=serving1024",
+		"mode=current_tvis_base_typed_column/boundary=document_materialization/concurrency=parallel/fixture=serving1024",
+		"mode=prepared_typed_column_placeholder/boundary=document_materialization/concurrency=serial/fixture=serving1024",
+		"mode=prepared_typed_column_placeholder/boundary=document_materialization/concurrency=parallel/fixture=serving1024",
+	}
+	if len(rows) != len(wantNames) {
+		t.Fatalf("rows=%d want %d", len(rows), len(wantNames))
+	}
+	seen := make(map[string]struct{}, len(rows))
+	for i, row := range rows {
+		if got := row.Name(); got != wantNames[i] {
+			t.Fatalf("row[%d] name=%q want %q", i, got, wantNames[i])
+		}
+		if _, ok := seen[row.Name()]; ok {
+			t.Fatalf("duplicate row name %q", row.Name())
+		}
+		seen[row.Name()] = struct{}{}
+		if row.CanonicalBenchmark == "" {
+			t.Fatalf("row %q missing canonical benchmark", row.Name())
+		}
+		if row.Mode == vectorGraphSearchTruthMatrixModePreparedPlaceholder2037 {
+			if row.Supported() || !strings.Contains(row.UnsupportedReason, "not performance data") || !strings.Contains(row.UnsupportedReason, "#2038") {
+				t.Fatalf("prepared placeholder row %q reason=%q", row.Name(), row.UnsupportedReason)
+			}
+		} else if !row.Supported() {
+			t.Fatalf("non-placeholder row %q unexpectedly unsupported: %s", row.Name(), row.UnsupportedReason)
+		}
+	}
+}
+
+func TestVectorGraphSearchTruthMatrixMetricContract2037(t *testing.T) {
+	labels := vectorGraphSearchTruthMatrixRequiredMetricLabels2037()
+	if len(labels) == 0 {
+		t.Fatal("metric labels are empty")
+	}
+	seen := make(map[string]struct{}, len(labels))
+	for _, label := range labels {
+		if label == "" {
+			t.Fatal("empty metric label")
+		}
+		if _, ok := seen[label]; ok {
+			t.Fatalf("duplicate metric label %q", label)
+		}
+		seen[label] = struct{}{}
+	}
+	for _, required := range []string{
+		"ops/sec",
+		"graph_rows",
+		"candidates/search",
+		"edges/search",
+		"docs_fetched/search",
+		"result_id_typed_bytes_state/search",
+		"row_ref_state_source_fallbacks/search",
+		"vector_mmap_direct/search",
+		"norm_mmap_direct/search",
+		"adjacency_typed_list_mmap_direct/search",
+		"typed_column_vector_fallbacks/search",
+	} {
+		if _, ok := seen[required]; !ok {
+			t.Fatalf("missing required metric label %q", required)
+		}
+	}
+}
+
+func BenchmarkColumnVectorGraphSearchTruthMatrix2037(b *testing.B) {
+	for _, row := range vectorGraphSearchTruthMatrixRows2037() {
+		row := row
+		b.Run(row.Name(), func(b *testing.B) {
+			if !row.Supported() {
+				b.Skip(row.UnsupportedReason)
+			}
+			switch row.Boundary {
+			case vectorGraphSearchTruthMatrixBoundarySetupOpenPrepare2037:
+				benchmarkVectorGraphSearchTruthMatrixSetup2037(b, row)
+			case vectorGraphSearchTruthMatrixBoundaryGraphOnly2037:
+				benchmarkVectorGraphSearchTruthMatrixGraphOnly2037(b, row)
+			case vectorGraphSearchTruthMatrixBoundaryResultID2037:
+				benchmarkVectorGraphSearchTruthMatrixResultID2037(b, row)
+			case vectorGraphSearchTruthMatrixBoundaryDocumentMaterialize2037:
+				benchmarkVectorGraphSearchTruthMatrixDocumentMaterialization2037(b, row)
+			default:
+				b.Fatalf("unsupported truth-matrix boundary %q", row.Boundary)
+			}
+			reportVectorGraphSearchTruthMatrixRowLabels2037(b, row)
+		})
+	}
+}
+
+func reportVectorGraphSearchTruthMatrixRowLabels2037(b *testing.B, row vectorGraphSearchTruthMatrixRow2037) {
+	b.Helper()
+	shape := vectorGraphSearchTruthMatrixFixtureShape2037(row.Fixture)
+	b.ReportMetric(2037, "truth_matrix_issue")
+	b.ReportMetric(1, "matrix_mode_"+string(row.Mode))
+	b.ReportMetric(1, "matrix_boundary_"+string(row.Boundary))
+	b.ReportMetric(1, "matrix_concurrency_"+string(row.Concurrency))
+	b.ReportMetric(1, "matrix_fixture_"+string(row.Fixture))
+	b.ReportMetric(float64(shape.rows), "rows")
+	b.ReportMetric(float64(shape.dims), "dims")
+	b.ReportMetric(float64(shape.degree), "degree")
+	b.ReportMetric(float64(shape.topK), "top_k")
+	b.ReportMetric(float64(shape.efSearch), "ef_search")
+}
+
+type vectorGraphSearchTruthMatrixShape2037 struct {
+	rows     int
+	dims     int
+	degree   int
+	topK     int
+	efSearch int
+}
+
+func vectorGraphSearchTruthMatrixFixtureShape2037(fixture vectorGraphSearchTruthMatrixFixture2037) vectorGraphSearchTruthMatrixShape2037 {
+	switch fixture {
+	case vectorGraphSearchTruthMatrixFixtureServing10242037:
+		return vectorGraphSearchTruthMatrixShape2037{rows: 1024, dims: 128, degree: 16, topK: 10, efSearch: 128}
+	case vectorGraphSearchTruthMatrixFixtureProduction81922037:
+		return vectorGraphSearchTruthMatrixShape2037{rows: 8192, dims: 128, degree: 16, topK: 10, efSearch: 128}
+	default:
+		return vectorGraphSearchTruthMatrixShape2037{}
+	}
+}
+
+func benchmarkVectorGraphSearchTruthMatrixSetup2037(b *testing.B, row vectorGraphSearchTruthMatrixRow2037) {
+	b.Helper()
+	closeFn, col, def, _ := openVectorGraphSearchTruthMatrixCollection2037(b, row)
+	defer closeFn()
+	statsSearcher, err := col.OpenVectorIndexSearcher(VectorIndexSearcherOptions{IndexName: def.Name, MaxDecodedBlocks: 1})
+	if err != nil {
+		b.Fatalf("stats OpenVectorIndexSearcher: %v", err)
+	}
+	readerStats := statsSearcher.reader.Stats()
+	stats := VectorIndexSearchStats{
+		GraphRows:             uint64(readerStats.Rows),
+		OpenGranulesRead:      uint64(readerStats.OpenGranulesRead),
+		OpenPhysicalBytesRead: readerStats.OpenPhysicalBytesRead,
+		MaxResidentBytes:      readerStats.MaxResidentBytes,
+	}
+	if err := statsSearcher.Close(); err != nil {
+		b.Fatalf("Close stats searcher: %v", err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		searcher, err := col.OpenVectorIndexSearcher(VectorIndexSearcherOptions{IndexName: def.Name, MaxDecodedBlocks: 1})
+		if err != nil {
+			b.Fatalf("OpenVectorIndexSearcher: %v", err)
+		}
+		vectorSearchBenchSinkOrdinalV4 += searcher.reader.RowCount()
+		if err := searcher.Close(); err != nil {
+			b.Fatalf("Close searcher: %v", err)
+		}
+	}
+	b.StopTimer()
+	reportVectorIndexSearchBenchMetricsV4(b, b.N, stats, true)
+}
+
+func benchmarkVectorGraphSearchTruthMatrixGraphOnly2037(b *testing.B, row vectorGraphSearchTruthMatrixRow2037) {
+	b.Helper()
+	shape := columnVectorGraphNativeSearchProduction8192BenchShapeV3()
+	shape.omitResultMaterialization = true
+	switch row.Mode {
+	case vectorGraphSearchTruthMatrixModeLegacyDirectGraphRow2037:
+		shape.typedColumnVector = false
+	case vectorGraphSearchTruthMatrixModeCurrentTypedColumn2037:
+		shape.typedColumnVector = true
+	default:
+		b.Fatalf("unsupported graph-only mode %q", row.Mode)
+	}
+	if row.Concurrency == vectorGraphSearchTruthMatrixConcurrencyParallel2037 {
+		benchmarkColumnVectorGraphNativeSearchCosineParallelV3(b, shape)
+		return
+	}
+	benchmarkColumnVectorGraphNativeSearchCosineV3(b, shape)
+}
+
+func benchmarkVectorGraphSearchTruthMatrixResultID2037(b *testing.B, row vectorGraphSearchTruthMatrixRow2037) {
+	b.Helper()
+	if row.Mode != vectorGraphSearchTruthMatrixModeCurrentTypedColumn2037 {
+		b.Fatalf("result-ID boundary currently supports only current typed-column mode, got %q", row.Mode)
+	}
+	if row.Concurrency == vectorGraphSearchTruthMatrixConcurrencyParallel2037 {
+		benchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderParallelV4(b, false, DocumentFetchOptions{})
+		return
+	}
+	benchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderV4(b, false, DocumentFetchOptions{})
+}
+
+func benchmarkVectorGraphSearchTruthMatrixDocumentMaterialization2037(b *testing.B, row vectorGraphSearchTruthMatrixRow2037) {
+	b.Helper()
+	if row.Mode != vectorGraphSearchTruthMatrixModeCurrentTypedColumn2037 {
+		b.Fatalf("document-materialization boundary currently supports only current typed-column mode, got %q", row.Mode)
+	}
+	if row.Concurrency == vectorGraphSearchTruthMatrixConcurrencyParallel2037 {
+		benchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderParallelV4(b, true, DocumentFetchOptions{})
+		return
+	}
+	benchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderV4(b, true, DocumentFetchOptions{})
+}
+
+func openVectorGraphSearchTruthMatrixCollection2037(b *testing.B, row vectorGraphSearchTruthMatrixRow2037) (func(), *Collection, VectorIndexDefinition, []float32) {
+	b.Helper()
+	shape := columnVectorGraphNativeSearchSmallBenchShapeV3()
+	switch row.Fixture {
+	case vectorGraphSearchTruthMatrixFixtureServing10242037:
+		// default small shape
+	case vectorGraphSearchTruthMatrixFixtureProduction81922037:
+		shape = columnVectorGraphNativeSearchProduction8192BenchShapeV3()
+	default:
+		b.Fatalf("unsupported truth-matrix fixture %q", row.Fixture)
+	}
+	switch row.Mode {
+	case vectorGraphSearchTruthMatrixModeLegacyDirectGraphRow2037:
+		shape.directPhysicalAsset = true
+		shape.typedColumnVector = false
+	case vectorGraphSearchTruthMatrixModeCurrentTypedColumn2037:
+		shape.directPhysicalAsset = false
+		shape.typedColumnVector = true
+	default:
+		b.Fatalf("unsupported truth-matrix fixture mode %q", row.Mode)
+	}
+	return openColumnVectorGraphNativeSearchBenchFixtureV3(b, shape)
+}

--- a/TreeDB/collections/vector_index_search.go
+++ b/TreeDB/collections/vector_index_search.go
@@ -73,6 +73,8 @@ type VectorIndexSearchResult struct {
 // counters are per-search deltas unless the field starts with Open; Open*
 // counters describe the bound reader setup performed before Search.
 type VectorIndexSearchStats struct {
+	// GraphRows is the number of legacy physical graph rows resident in the bound reader. Healthy current typed-column search reports zero.
+	GraphRows uint64 `json:"graph_rows,omitempty"`
 	// CandidateRows is the candidate row domain after any internal row-selection/visibility composition.
 	CandidateRows uint64 `json:"candidate_rows,omitempty"`
 	// Candidates is the number of candidate nodes scored by graph search.
@@ -854,6 +856,8 @@ func (s *VectorIndexSearcher) Close() error {
 // absolute values from the bound reader.
 func columnPhysicalRowReaderStatsDelta(before, after columnPhysicalRowReaderStats) columnPhysicalRowReaderStats {
 	return columnPhysicalRowReaderStats{
+		Rows:                  after.Rows,
+		Granules:              after.Granules,
 		OpenGranulesRead:      after.OpenGranulesRead,
 		OpenPhysicalBytesRead: after.OpenPhysicalBytesRead,
 		RowFetches:            deltaUint64(before.RowFetches, after.RowFetches),
@@ -884,6 +888,7 @@ func deltaInt64(before, after int64) int64 {
 
 func vectorIndexSearchStatsFromInternal(searchStats columnVectorGraphNativeSearchStats, readerStats columnPhysicalRowReaderStats) VectorIndexSearchStats {
 	return VectorIndexSearchStats{
+		GraphRows:                            uint64(readerStats.Rows),
 		CandidateRows:                        searchStats.CandidateRows,
 		Candidates:                           searchStats.Candidates,
 		Edges:                                searchStats.Edges,

--- a/TreeDB/collections/vector_index_search_test.go
+++ b/TreeDB/collections/vector_index_search_test.go
@@ -76,8 +76,8 @@ func TestSearchVectorIndexColumnGraphNativeReaderReopenV4(t *testing.T) {
 	if got.Stats.AdjacencyTypedListMmapDirectViews+got.Stats.AdjacencyTypedListHeapCopyTypedViews+got.Stats.AdjacencyTypedListScratchDecodes == 0 || got.Stats.AdjacencyLegacyFallbacks != 0 {
 		t.Fatalf("stats=%+v want public search to expose typed-list adjacency and no legacy fallback on healthy state", got.Stats)
 	}
-	if got.Stats.RowFetches != 0 || got.Stats.BatchFetches != 0 || got.Stats.RowsFetched != 0 || got.Stats.PhysicalBytesRead != 0 || got.Stats.OpenPhysicalBytesRead != 0 {
-		t.Fatalf("stats=%+v want zero graph row payload reads on healthy current-format search", got.Stats)
+	if got.Stats.GraphRows != 0 || got.Stats.RowFetches != 0 || got.Stats.BatchFetches != 0 || got.Stats.RowsFetched != 0 || got.Stats.PhysicalBytesRead != 0 || got.Stats.OpenPhysicalBytesRead != 0 {
+		t.Fatalf("stats=%+v want zero graph row payload residency/reads on healthy current-format search", got.Stats)
 	}
 	if got.Stats.TypedColumnFallbacks != 0 || got.Stats.RowRefVectorSourceLegacyGraphIDs != 0 || got.Stats.ResultIDGraphFallbacks != 0 || got.Stats.NormSourceFallbacks != 0 {
 		t.Fatalf("stats=%+v want TVIS/base typed-column sources without graph row fallback", got.Stats)
@@ -2013,6 +2013,7 @@ func BenchmarkOpenVectorIndexSearcherColumnGraphNativeReaderSetupV6(b *testing.B
 	}
 	readerStats := statsSearcher.reader.Stats()
 	stats := VectorIndexSearchStats{
+		GraphRows:             uint64(readerStats.Rows),
 		OpenGranulesRead:      uint64(readerStats.OpenGranulesRead),
 		OpenPhysicalBytesRead: readerStats.OpenPhysicalBytesRead,
 		MaxResidentBytes:      readerStats.MaxResidentBytes,
@@ -2044,9 +2045,13 @@ func reportVectorIndexSearchBenchMetricsV4(b *testing.B, n int, stats VectorInde
 	if n <= 0 {
 		return
 	}
+	if elapsed := b.Elapsed(); elapsed > 0 {
+		b.ReportMetric(float64(n)/elapsed.Seconds(), "ops/sec")
+	}
 	// Callers pass one representative search/setup sample captured outside the
 	// timer; these labels are intentionally per-search or per-open, not averaged
 	// over b.N. Keep aggregation out of the hot benchmark loop.
+	b.ReportMetric(float64(stats.GraphRows), "graph_rows")
 	b.ReportMetric(float64(stats.CandidateRows), "candidate_rows/search")
 	b.ReportMetric(float64(stats.Candidates), "candidates/search")
 	b.ReportMetric(float64(stats.Edges), "edges/search")
@@ -2132,6 +2137,8 @@ func reportVectorIndexSearchBenchMetricsV4(b *testing.B, n int, stats VectorInde
 	b.ReportMetric(float64(stats.RowRefVectorSourceState), "row_ref_vector_source_state/search")
 	b.ReportMetric(float64(stats.RowRefVectorSourceLegacyGraphIDs), "row_ref_vector_source_legacy_graph_ids/search")
 	b.ReportMetric(float64(stats.RowRefStateResultRefs), "row_ref_state_result_refs/search")
+	b.ReportMetric(float64(stats.RowRefStateSourceUnavailable), "row_ref_state_source_unavailable/search")
+	b.ReportMetric(float64(stats.RowRefStateSourceFallbacks), "row_ref_state_source_fallbacks/search")
 	b.ReportMetric(float64(stats.ResultIDTypedBytesState), "result_id_typed_bytes_state/search")
 	b.ReportMetric(float64(stats.ResultIDGraphFallbacks), "result_id_graph_fallbacks/search")
 	b.ReportMetric(float64(stats.ResultIDStateValidationFailures), "result_id_state_validation_failures/search")

--- a/TreeDB/docs/graph_search_benchmark_matrix_test.go
+++ b/TreeDB/docs/graph_search_benchmark_matrix_test.go
@@ -1,0 +1,56 @@
+package docs_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDocs_GraphSearchBenchmarkTruthMatrix2037(t *testing.T) {
+	treeRoot, _ := repoRoots(t)
+	path := filepath.Join(treeRoot, "docs", "spec", "typed-column-graph-search-benchmark-matrix.md")
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read benchmark matrix spec: %v", err)
+	}
+	text := string(content)
+	required := []string{
+		"BenchmarkColumnVectorGraphSearchTruthMatrix2037",
+		"mode=<mode>/boundary=<boundary>/concurrency=<serial|parallel>/fixture=<fixture>",
+		"legacy_direct_graph_row",
+		"current_tvis_base_typed_column",
+		"prepared_typed_column_placeholder",
+		"setup_open_prepare",
+		"graph_only",
+		"result_id",
+		"document_materialization",
+		"production8192",
+		"serving1024",
+		"Skipped placeholders; not performance data",
+		"ops/sec",
+		"graph_rows",
+		"candidates/search",
+		"edges/search",
+		"docs_fetched/search",
+		"result_id_typed_bytes_state/search",
+		"row_ref_state_source_fallbacks/search",
+		"vector_mmap_direct/search",
+		"norm_mmap_direct/search",
+		"adjacency_typed_list_mmap_direct/search",
+	}
+	for _, needle := range required {
+		if !strings.Contains(text, needle) {
+			t.Fatalf("benchmark matrix spec missing %q", needle)
+		}
+	}
+	forbidden := []string{
+		"prepared_typed_column_placeholder` | `graph_only` | serial/parallel | `production8192` | Supported",
+		"skipped placeholder is performance data",
+	}
+	for _, needle := range forbidden {
+		if strings.Contains(text, needle) {
+			t.Fatalf("benchmark matrix spec contains misleading phrase %q", needle)
+		}
+	}
+}

--- a/TreeDB/docs/guides/vector-search-typed-column.md
+++ b/TreeDB/docs/guides/vector-search-typed-column.md
@@ -201,9 +201,9 @@ GOMAXPROCS=8 go test ./TreeDB/collections \
   -count=5
 ```
 
-Report both `ns/op` and `ops/sec`; compute `ops/sec` as `1e9 / ns/op` from the
-Go benchmark output. For parallel benchmarks, this is the aggregate operation
-rate implied by Go's parallel `ns/op` measurement. Always include `B/op`,
+Report both `ns/op` and the explicit `ops/sec` metric emitted by the benchmark
+helpers. For parallel benchmarks, `ops/sec` is the aggregate operation rate
+implied by Go's parallel `ns/op` measurement. Always include `B/op`,
 `allocs/op`, and the direct/fallback counters
 (`adjacency_typed_list_mmap_direct/search`,
 `adjacency_typed_list_scratch_decodes/search`, `norm_mmap_direct/search`,
@@ -228,8 +228,23 @@ buffer lifetime contract. `VectorIndexSearcher.SearchWithBuffer` rejects
 A `VectorIndexSearchBuffer` is not concurrency-safe, and returned `Results`/`ID`
 slices are valid only until the same buffer is reused or reset.
 
-The broader legacy/canonical matrix remains useful when you also need one-shot
-open/setup or document materialization:
+Use the #2037 truth matrix when comparing legacy/direct graph-row controls,
+current TVIS/base typed-column sources, and future prepared typed-column rows
+with stable labels:
+
+```sh
+go test ./TreeDB/collections \
+  -run '^$' \
+  -bench '^BenchmarkColumnVectorGraphSearchTruthMatrix2037$' \
+  -benchmem \
+  -benchtime=500ms \
+  -count=5
+```
+
+The truth-matrix row labels and skipped prepared placeholders are specified in
+[`typed-column-graph-search-benchmark-matrix.md`](../spec/typed-column-graph-search-benchmark-matrix.md).
+The broader legacy/canonical matrix remains useful when comparing with older
+artifacts or when you also need one-shot open/setup names:
 
 ```sh
 go test ./TreeDB/collections \
@@ -240,7 +255,7 @@ go test ./TreeDB/collections \
   -count=5
 ```
 
-Read the benchmark names before comparing numbers:
+Read the benchmark names and row labels before comparing numbers:
 
 | Benchmark category | What is timed |
 | --- | --- |

--- a/TreeDB/docs/spec/README.md
+++ b/TreeDB/docs/spec/README.md
@@ -112,6 +112,9 @@ Given pre-alpha status, this is a living spec that tracks implementation.
 - `TreeDB/docs/spec/typed-column-graph-search-admission.md`
   - issue #2044 optimized-state readiness/admission table and docs-lint gate for
     current-format graph-search typed-column state roles.
+- `TreeDB/docs/spec/typed-column-graph-search-benchmark-matrix.md`
+  - issue #2037 benchmark truth-matrix labels, timing boundaries, placeholder
+    prepared rows, and required graph-search report counters.
 
 ## Target Gates (Normative Target, Not Current Behavior)
 

--- a/TreeDB/docs/spec/column-graph-native-vector-search.md
+++ b/TreeDB/docs/spec/column-graph-native-vector-search.md
@@ -135,7 +135,20 @@ GOWORK=off go test ./TreeDB/collections \
   -count=1
 ```
 
-Focused benchmark matrix:
+Focused #2037 truth matrix for source/boundary comparisons:
+
+```sh
+GOWORK=off go test ./TreeDB/collections \
+  -run '^$' \
+  -bench '^BenchmarkColumnVectorGraphSearchTruthMatrix2037$' \
+  -benchmem \
+  -benchtime=500ms \
+  -count=5
+```
+
+The stable row labels and prepared typed-column placeholders are defined in
+[`typed-column-graph-search-benchmark-matrix.md`](typed-column-graph-search-benchmark-matrix.md).
+Use the legacy/canonical benchmark set when comparing with older artifacts:
 
 ```sh
 GOWORK=off go test ./TreeDB/collections \
@@ -163,7 +176,7 @@ The expected categories are:
 
 Report and compare:
 
-- searches/s or ns/op,
+- `ops/sec` and `ns/op`,
 - `B/op` and `allocs/op`,
 - candidate_rows/search, candidates/search, edges/search, visited_nodes/search, and visited_edges/search,
 - vector_B/search and adjacency_B/search,

--- a/TreeDB/docs/spec/typed-column-graph-search-admission.md
+++ b/TreeDB/docs/spec/typed-column-graph-search-admission.md
@@ -7,10 +7,12 @@ and the #2036 prepared runtime-view contract in
 `typed-column-graph-search-prepared-views.md`.
 
 This document owns the repo-level readiness table that descendants must update
-before adding, changing, or promoting graph-search typed-column state roles. It
-does not implement reusable direct-view certifier APIs (#2046), type-specific
-prepared views (#2038/#2040/#2041), graph-search routing (#2045), hot-loop
-telemetry reduction (#2042), or benchmark truth-matrix collection (#2037).
+before adding, changing, or promoting graph-search typed-column state roles. The
+#2037 benchmark truth-matrix labels and command contract live in
+`typed-column-graph-search-benchmark-matrix.md`. This document does not implement
+reusable direct-view certifier APIs (#2046), type-specific prepared views
+(#2038/#2040/#2041), graph-search routing (#2045), hot-loop telemetry reduction
+(#2042), or benchmark truth-matrix collection (#2037).
 
 ## Admission status vocabulary
 

--- a/TreeDB/docs/spec/typed-column-graph-search-benchmark-matrix.md
+++ b/TreeDB/docs/spec/typed-column-graph-search-benchmark-matrix.md
@@ -1,0 +1,135 @@
+# Typed-Column Graph-Search Benchmark Truth Matrix (#2037)
+
+Status: pre-alpha benchmark contract. This document owns the stable labels and
+reporting boundaries for comparing legacy/direct graph-row search, current
+TVIS/base typed-column search, and future prepared typed-column graph search.
+Prepared-view implementations remain owned by #2038/#2040/#2041 and routing by
+#2045; this matrix must not be treated as prepared-path performance evidence
+until those rows stop being skipped placeholders.
+
+## Command
+
+Use the truth-matrix benchmark when collecting comparable graph-search evidence:
+
+```sh
+GOWORK=off go test ./TreeDB/collections \
+  -run '^$' \
+  -bench '^BenchmarkColumnVectorGraphSearchTruthMatrix2037$' \
+  -benchmem \
+  -benchtime=500ms \
+  -count=5
+```
+
+For smoke validation, `-benchtime=1x -count=1` is acceptable, but publish only
+full runs for performance claims. Use the same hardware, fixture, Go version,
+`GOMAXPROCS`, and command when comparing commits.
+
+## Stable row labels
+
+Sub-benchmark names are the contract:
+
+```text
+mode=<mode>/boundary=<boundary>/concurrency=<serial|parallel>/fixture=<fixture>
+```
+
+Modes:
+
+- `legacy_direct_graph_row`: compatibility/control path backed by explicit
+  physical graph rows where the fixture can still publish them. Healthy current
+  promotion evidence must not rely on this mode.
+- `current_tvis_base_typed_column`: current source path using TVIS/vector-index
+  typed-column state and base typed-column vectors.
+- `prepared_typed_column_placeholder`: future prepared-view path. These rows are
+  skipped with a message naming #2038/#2040/#2041/#2045 and are not performance
+  data.
+
+Boundaries:
+
+- `setup_open_prepare`: searcher open, manifest discovery, current direct-source
+  binding, validation/certification work, and prepared-view construction once it
+  exists; no search.
+- `graph_only`: lower-level HNSW traversal/scoring/top-k with final result-ID and
+  row-ref materialization omitted by the #2037 benchmark hook.
+- `result_id`: opened public searcher, search plus final top-k result-ID/row-ref
+  materialization, no documents.
+- `document_materialization`: opened public searcher, search plus final document
+  fetch/materialization.
+
+Fixtures:
+
+- `production8192`: 8192 rows, 128 dimensions, degree 16, `topK=10`,
+  `efSearch=128`; used for graph-only serial/parallel source comparisons.
+- `serving1024`: 1024 rows, 128 dimensions, degree 16, `topK=10`,
+  `efSearch=128`; used for setup/open, result-ID, and document-materialization
+  serving-boundary rows.
+
+## Current row matrix
+
+| Mode | Boundary | Concurrency | Fixture | Current behavior |
+| --- | --- | --- | --- | --- |
+| `legacy_direct_graph_row` | `setup_open_prepare` | serial | `serving1024` | Supported control row. |
+| `current_tvis_base_typed_column` | `setup_open_prepare` | serial | `serving1024` | Supported current row. |
+| `prepared_typed_column_placeholder` | `setup_open_prepare` | serial | `serving1024` | Skipped placeholder; not performance data. |
+| `legacy_direct_graph_row` | `graph_only` | serial/parallel | `production8192` | Supported control rows where explicit graph rows are published by the fixture. |
+| `current_tvis_base_typed_column` | `graph_only` | serial/parallel | `production8192` | Supported current rows. |
+| `prepared_typed_column_placeholder` | `graph_only` | serial/parallel | `production8192` | Skipped placeholders; not performance data. |
+| `current_tvis_base_typed_column` | `result_id` | serial/parallel | `serving1024` | Supported current rows. |
+| `prepared_typed_column_placeholder` | `result_id` | serial/parallel | `serving1024` | Skipped placeholders; not performance data. |
+| `current_tvis_base_typed_column` | `document_materialization` | serial/parallel | `serving1024` | Supported current rows. |
+| `prepared_typed_column_placeholder` | `document_materialization` | serial/parallel | `serving1024` | Skipped placeholders; not performance data. |
+
+Legacy/direct graph-row result-ID and document-materialization rows are omitted
+unless a future fixture can expose that path without silently using the current
+TVIS/base typed-column source. Do not relabel current typed-column public rows as
+legacy controls.
+
+## Required reported metrics
+
+Every supported row must report Go's `ns/op`, `B/op`, and `allocs/op`, plus the
+explicit `ops/sec` metric emitted by the benchmark helper. Benchmark summaries
+must also carry the relevant domain/source counters:
+
+- fixture/search shape: `rows`, `dims`, `degree`, `top_k`, `ef_search`,
+  `parallel_workers` where applicable;
+- graph work: `graph_rows`, `candidate_rows/search`, `candidates/search`,
+  `edges/search`, `visited_edges/search`, `result_fetches/search`;
+- direct/fallback source counters: `vector_mmap_direct/search`,
+  `vector_heap_copy_typed_view/search`, `vector_scratch_decodes/search`,
+  `typed_column_vector_fallbacks/search`, `norm_mmap_direct/search`,
+  `norm_heap_copy_typed_view/search`, `norm_scratch_decodes/search`,
+  `norm_source_fallbacks/search`, `adjacency_typed_list_mmap_direct/search`,
+  `adjacency_typed_list_heap_copy_typed_view/search`,
+  `adjacency_typed_list_scratch_decodes/search`,
+  `adjacency_legacy_fallbacks/search`, and
+  `adjacency_source_fallbacks/search`;
+- result/document side channels: `result_id_typed_bytes_state/search`,
+  `result_id_graph_fallbacks/search`, `row_ref_vector_source_state/search`,
+  `row_ref_vector_source_legacy_graph_ids/search`,
+  `row_ref_state_result_refs/search`, `row_ref_state_source_fallbacks/search`,
+  `docs_fetched/search`, `doc_fetch_ns/search`,
+  `doc_row_ref_state_fetches/search`, and
+  `doc_row_ref_lookup_fallbacks/search`.
+
+Healthy current-format evidence must keep graph-row/fallback counters at zero
+where those counters apply: `graph_rows=0` for current typed-column graph-only
+rows, `typed_column_vector_fallbacks/search=0`,
+`row_ref_vector_source_legacy_graph_ids/search=0`,
+`result_id_graph_fallbacks/search=0`, `adjacency_legacy_fallbacks/search=0`, and
+`adjacency_source_fallbacks/search=0`.
+
+## Interpretation rules
+
+- A skipped `prepared_typed_column_placeholder` row is a contract placeholder,
+  not a win, loss, or throughput number.
+- Compare only rows with identical `boundary`, `concurrency`, and `fixture`
+  labels unless the report explicitly explains why a boundary change is the
+  measurement target.
+- `graph_only` rows intentionally omit final ID/row-ref materialization; use
+  `result_id` rows when comparing public no-document result production.
+- Document materialization is post-top-k side-channel work. It must be reported
+  with `docs_fetched/search`, allocation counters, and document timing counters,
+  not blended into graph-only claims.
+- A PR claiming a prepared typed-column speedup must show which profile bucket
+  moved: scoring/dot kernel, vector/norm lookup, adjacency retrieval,
+  frontier/top-k, stats/telemetry, result ID, document materialization, or
+  open/prepare.

--- a/TreeDB/docs/spec/typed-column-graph-search-prepared-views.md
+++ b/TreeDB/docs/spec/typed-column-graph-search-prepared-views.md
@@ -8,11 +8,12 @@ It consumes the tier vocabulary and generic type matrix in
 `generic_only`, or `unsupported/experimental` tiers.
 
 The #2044 readiness/admission table and docs-lint enforcement live in
-`typed-column-graph-search-admission.md`. This document does not implement
-runtime graph-search admission enforcement (#2044), reusable direct-view
-certifiers (#2046), type-specific prepared views (#2038/#2040/#2041), or the
-benchmark truth matrix (#2037). It defines the contract those issues must
-satisfy.
+`typed-column-graph-search-admission.md`; the #2037 benchmark truth-matrix labels
+and command contract live in `typed-column-graph-search-benchmark-matrix.md`.
+This document does not implement runtime graph-search admission enforcement
+(#2044), reusable direct-view certifiers (#2046), type-specific prepared views
+(#2038/#2040/#2041), or the benchmark truth matrix (#2037). It defines the
+contract those issues must satisfy.
 
 ## Scope and ownership
 

--- a/TreeDB/docs/spec/verification.md
+++ b/TreeDB/docs/spec/verification.md
@@ -866,6 +866,27 @@ Coverage:
   combined routing remains owned by #2045; this section enforces the documented
   admission gate and fail-closed readiness fields.
 
+## 12.9 Graph-Search Benchmark Truth Matrix
+
+Invariant:
+- Benchmark rows that compare graph-search source paths must carry stable labels
+  for mode, timing boundary, concurrency, and fixture so legacy/direct graph-row
+  controls, current TVIS/base typed-column rows, and future prepared typed-column
+  rows are not confused.
+- Prepared typed-column rows remain explicit skipped placeholders until
+  #2038/#2040/#2041/#2045 implement and route them; skipped placeholder rows are
+  not performance evidence.
+- Supported rows report `ns/op`, `ops/sec`, `B/op`, `allocs/op`, graph rows,
+  candidates/search, edges/search, result/document counters, and direct/fallback
+  typed-column source counters.
+
+Coverage:
+- Policy owner: `TreeDB/docs/spec/typed-column-graph-search-benchmark-matrix.md`.
+- Code/test owner: `TreeDB/collections/vector_graph_search_truth_matrix_2037_test.go`.
+  `TestVectorGraphSearchTruthMatrixRows2037` freezes row labels and placeholder
+  semantics; `TestVectorGraphSearchTruthMatrixMetricContract2037` freezes the
+  required report-counter vocabulary.
+
 ## 13. Native Wire Protocol
 
 Invariant:


### PR DESCRIPTION
## Objective

Build the #2037 benchmark truth matrix for typed-column graph search.

Links: parent tracker #2035; child issue #2037. Depends on merged #2036/#2044 policy/admission docs; synced after merged #2046. Coordinator will merge after gates pass.

## What changed

- Added `BenchmarkColumnVectorGraphSearchTruthMatrix2037` with stable row labels for mode, boundary, concurrency, and fixture.
- Added skipped `prepared_typed_column_placeholder` rows that explicitly say they are not performance data until #2038/#2040/#2041/#2045 implement prepared views/routing.
- Added graph-only benchmark hook (`OmitResultMaterialization`) so graph traversal/scoring/top-k can be timed without final result-ID/doc materialization.
- Added/normalized benchmark reporting for `ops/sec`, `graph_rows`, row-ref/result-ID counters, and zero document counters on graph-only rows.
- Added docs/spec contract: `typed-column-graph-search-benchmark-matrix.md` plus docs lint coverage.

Non-goals: no prepared-view implementation, no certifier APIs, no combined routing, no telemetry reduction beyond report labels/counters.

## Validation

Latest head: `34f2057b42c05e197d5c4319b979df9967fbe191` (merged latest `origin/main` including #2046).

Post-sync validation:

- `GOWORK=off go test ./TreeDB/collections -run 'Test(VectorGraphSearchTruthMatrix|ColumnVectorGraph|SearchVectorIndexColumnGraph|OpenVectorIndexSearcherColumnGraph)' -count=1`
- `GOWORK=off go test ./TreeDB/docs -count=1`
- `git diff --check`
- `GOWORK=off go test ./TreeDB/collections -run '^$' -bench '^BenchmarkColumnVectorGraphSearchTruthMatrix2037$' -benchtime=1x -count=1 -benchmem`
  - artifact: `/tmp/gomap_2037_post_sync_20260531_061702/bench_matrix_smoke_post_sync.txt`

Earlier full affected validation on the pre-sync head also passed:

- `GOWORK=off go test ./TreeDB/collections -count=1`

## Benchmark / performance evidence

Smoke rows below are label/counter validation only, not full performance claims:

| row | ns/op | ops/sec | B/op | allocs/op | graph_rows | candidates/search | edges/search | docs_fetched/search |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| legacy graph-only serial production8192 | 15000 | 66667 | 0 | 0 | 8192 | 128 | 612 | 0 |
| current typed graph-only serial production8192 | 17666 | 56606 | 0 | 0 | 0 | 128 | 3340 | 0 |
| current typed result-id serial serving1024 | 25333 | 39474 | 784 | 2 | 0 | 128 | 3230 | 0 |
| current typed docs serial serving1024 | 140542 | 7115 | 92160 | 319 | 0 | 128 | 3230 | 10 |

Before/after check for existing typed 8192 benchmarks was captured pre-sync in `/tmp/gomap_2037_bench_smoke_20260530_231108` with no significant regression and unchanged zero allocs for the existing typed 8192 rows.

## Performance regression assessment

The only runtime hook is an internal benchmark option checked after HNSW traversal and before final result materialization; public search paths leave it false. Existing typed 8192 before/after evidence showed no significant wall-time regression and no allocation regression. Reporting changes run after timers stop or outside hot loops.

## Review / AI status

- Latest-head GitHub CI on `34f2057b42c05e197d5c4319b979df9967fbe191`: PASS; all check runs passed.
- Merge state: mergeable after syncing latest `origin/main`/#2046.
- Review threads: 0 unresolved in GitHub review-thread inventory.
- Internal Orca review: PASS after fixes for missing graph-only zero document counters and label metric placement; coordinator also reran focused post-sync validation above.
- Codex: requested after PR open and reported no major issues on the pre-sync head; re-requested after the #2046 sync, no new response/finding observed.
- CodeRabbit: requested after PR open and after sync; status PASS/review skipped with no findings or threads to resolve.
- Copilot: requested after PR open and after sync; no Copilot review/comment/thread surfaced, and no findings to resolve.

## Caveats / deferrals

- Prepared typed-column rows are skipped placeholders and intentionally not performance data until #2038/#2040/#2041/#2045 add prepared views/routing.
- Full performance claims should use longer/count>1 matrix runs on the same hardware and fixture; the smoke rows above validate labels/counters only.
