### PR TITLE
[codex] Combine nativewire single replaces

### DIFF
--- a/TreeDB/nativewire/mutation_test.go
+++ b/TreeDB/nativewire/mutation_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"errors"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -148,6 +149,150 @@ func TestMutationCommandsRoundTrip(t *testing.T) {
 	}
 	if stats := db.Stats(); len(stats) == 0 {
 		t.Fatalf("empty backend stats after checkpoint")
+	}
+}
+
+func TestMutationSingleReplaceBatchSemantics(t *testing.T) {
+	client, mgr, _ := serveCollectionPipe(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := client.Hello(ctx); err != nil {
+		t.Fatalf("Hello: %v", err)
+	}
+	if _, err := client.CreateCollection(ctx, collections.CollectionMeta{
+		Name:    "users",
+		Indexes: []collections.IndexDefinition{{Name: "email", Field: "email", ValueType: collections.IndexValueString, Unique: true}},
+	}); err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	if _, err := client.InsertBatch(ctx, "users", collections.DocumentFormatJSON,
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"email":"ada@example.com","name":"Ada"}`)},
+		AckVisible,
+	); err != nil {
+		t.Fatalf("InsertBatch: %v", err)
+	}
+	matched, modified, err := client.ReplaceBatch(ctx, "users", collections.DocumentFormatJSON,
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"email":"ada@example.com","name":"Ada Lovelace"}`)},
+		AckVisible,
+	)
+	if err != nil {
+		t.Fatalf("ReplaceBatch existing: %v", err)
+	}
+	if matched != 1 || modified != 1 {
+		t.Fatalf("existing matched=%d modified=%d want 1/1", matched, modified)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("OpenCollection: %v", err)
+	}
+	doc, err := col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("Get u1: %v", err)
+	}
+	if !bytes.Contains(doc, []byte(`"Ada Lovelace"`)) {
+		t.Fatalf("u1 doc=%s", doc)
+	}
+
+	matched, modified, err = client.ReplaceBatch(ctx, "users", collections.DocumentFormatJSON,
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"email":"ada@example.com","name":"Ada Lovelace"}`)},
+		AckVisible,
+	)
+	if err != nil {
+		t.Fatalf("ReplaceBatch identical: %v", err)
+	}
+	if matched != 1 || modified != 0 {
+		t.Fatalf("identical matched=%d modified=%d want 1/0", matched, modified)
+	}
+
+	matched, modified, err = client.ReplaceBatch(ctx, "users", collections.DocumentFormatJSON,
+		[][]byte{[]byte("missing")},
+		[][]byte{[]byte(`{"email":"missing@example.com","name":"Missing"}`)},
+		AckVisible,
+	)
+	if err != nil {
+		t.Fatalf("ReplaceBatch missing: %v", err)
+	}
+	if matched != 0 || modified != 0 {
+		t.Fatalf("missing matched=%d modified=%d want 0/0", matched, modified)
+	}
+}
+
+func TestMutationConcurrentSingleReplaceBatch(t *testing.T) {
+	client, server, mgr, _ := serveCollectionPipeWithServer(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := client.Hello(ctx); err != nil {
+		t.Fatalf("Hello: %v", err)
+	}
+	if _, err := client.CreateCollection(ctx, collections.CollectionMeta{
+		Name:    "users",
+		Indexes: []collections.IndexDefinition{{Name: "email", Field: "email", ValueType: collections.IndexValueString, Unique: true}},
+	}); err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	const workers = 32
+	ids := make([][]byte, workers)
+	docs := make([][]byte, workers)
+	for i := range ids {
+		n := strconv.Itoa(i)
+		ids[i] = []byte("u" + n)
+		docs[i] = []byte(`{"email":"u` + n + `@example.com","name":"before"}`)
+	}
+	if _, err := client.InsertBatch(ctx, "users", collections.DocumentFormatJSON, ids, docs, AckVisible); err != nil {
+		t.Fatalf("InsertBatch: %v", err)
+	}
+
+	errCh := make(chan error, workers)
+	var wg sync.WaitGroup
+	for i := range ids {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			c, cleanup, err := NewInProcessClient(ctx, server)
+			if err != nil {
+				errCh <- err
+				return
+			}
+			defer func() { _ = cleanup() }()
+			n := strconv.Itoa(i)
+			matched, modified, err := c.ReplaceBatch(ctx, "users", collections.DocumentFormatJSON,
+				[][]byte{[]byte("u" + n)},
+				[][]byte{[]byte(`{"email":"u` + n + `@example.com","name":"after` + n + `"}`)},
+				AckVisible,
+			)
+			if err != nil {
+				errCh <- err
+				return
+			}
+			if matched != 1 || modified != 1 {
+				errCh <- errors.New("unexpected replace counts")
+			}
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		if err != nil {
+			t.Fatalf("concurrent ReplaceBatch: %v", err)
+		}
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("OpenCollection: %v", err)
+	}
+	for i := range ids {
+		doc, err := col.Get(ids[i])
+		if err != nil {
+			t.Fatalf("Get %s: %v", ids[i], err)
+		}
+		want := []byte(`"name":"after` + strconv.Itoa(i) + `"`)
+		if !bytes.Contains(doc, want) {
+			t.Fatalf("%s doc=%s want %s", ids[i], doc, want)
+		}
 	}
 }
 

--- a/TreeDB/nativewire/mutation_test.go
+++ b/TreeDB/nativewire/mutation_test.go
@@ -220,6 +220,62 @@ func TestMutationSingleReplaceBatchSemantics(t *testing.T) {
 	}
 }
 
+func TestMutationSingleReplaceBatchSharesMetadataReadLock(t *testing.T) {
+	client, server, _, _ := serveCollectionPipeWithServer(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := client.Hello(ctx); err != nil {
+		t.Fatalf("Hello: %v", err)
+	}
+	if _, err := client.CreateCollection(ctx, collections.CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	if _, err := client.InsertBatch(ctx, "users", collections.DocumentFormatJSON,
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"name":"before"}`)},
+		AckVisible,
+	); err != nil {
+		t.Fatalf("InsertBatch: %v", err)
+	}
+
+	server.metadataMu.RLock()
+	locked := true
+	unlock := func() {
+		if locked {
+			server.metadataMu.RUnlock()
+			locked = false
+		}
+	}
+	defer unlock()
+
+	done := make(chan error, 1)
+	go func() {
+		matched, modified, err := client.ReplaceBatch(ctx, "users", collections.DocumentFormatJSON,
+			[][]byte{[]byte("u1")},
+			[][]byte{[]byte(`{"name":"after"}`)},
+			AckVisible,
+		)
+		if err == nil && (matched != 1 || modified != 1) {
+			err = errors.New("unexpected replace counts")
+		}
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("ReplaceBatch: %v", err)
+		}
+	case <-time.After(500 * time.Millisecond):
+		unlock()
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+		}
+		t.Fatalf("ReplaceBatch blocked behind metadata read lock")
+	}
+}
+
 func TestMutationConcurrentSingleReplaceBatch(t *testing.T) {
 	client, server, mgr, _ := serveCollectionPipeWithServer(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/TreeDB/nativewire/server.go
+++ b/TreeDB/nativewire/server.go
@@ -112,7 +112,7 @@ type Server struct {
 	conns               map[net.Conn]struct{}
 	listeners           map[net.Listener]struct{}
 	locals              map[*localEndpoint]struct{}
-	metadataMu          sync.Mutex
+	metadataMu          sync.RWMutex
 	metadataIdempotency map[string]metadataIdempotencyEntry
 	metadataIdemOrder   []string
 

--- a/TreeDB/nativewire/server_mutation.go
+++ b/TreeDB/nativewire/server_mutation.go
@@ -1,6 +1,8 @@
 package nativewire
 
 import (
+	"bytes"
+
 	"github.com/snissn/gomap/TreeDB/collections"
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 	iwire "github.com/snissn/gomap/TreeDB/internal/nativewire"
@@ -309,8 +311,8 @@ func (s *Server) handleReplaceBatch(state *connState, sections []iwire.Section) 
 	if err := managerRequired(s.collections); err != nil {
 		return nil, err
 	}
-	s.metadataMu.Lock()
-	defer s.metadataMu.Unlock()
+	s.metadataMu.RLock()
+	defer s.metadataMu.RUnlock()
 	if err := s.checkCatalogGuard(sections); err != nil {
 		return nil, err
 	}
@@ -352,18 +354,9 @@ func (s *Server) handleReplaceBatch(state *connState, sections []iwire.Section) 
 	if err := s.admitMutationAck(ack); err != nil {
 		return nil, err
 	}
-	results, err := collection.UpdateBatch(updateBatchItems(ids, docs))
+	matched, modified, err := replaceBatchDocuments(collection, ids, docs)
 	if err != nil {
 		return nil, metadataWrap(err)
-	}
-	matched, modified := 0, 0
-	for _, result := range results {
-		if result.Matched {
-			matched++
-		}
-		if result.Modified {
-			modified++
-		}
 	}
 	actualAck, err := s.satisfyAck(collection, ack)
 	if err != nil {
@@ -374,6 +367,46 @@ func (s *Server) handleReplaceBatch(state *connState, sections []iwire.Section) 
 		responseMetaCount{key: "matched_count", value: matched},
 		responseMetaCount{key: "modified_count", value: modified},
 	)}, nil
+}
+
+func replaceBatchDocuments(collection *collections.Collection, ids, docs [][]byte) (int, int, error) {
+	if len(ids) == 1 && len(docs) == 1 {
+		doc := docs[0]
+		matched, modified, err := collection.Update(ids[0], func(current []byte) ([]byte, bool, error) {
+			if current == nil {
+				return nil, false, nil
+			}
+			if bytes.Equal(current, doc) {
+				return current, false, nil
+			}
+			return doc, true, nil
+		})
+		if err != nil {
+			return 0, 0, err
+		}
+		return boolCount(matched), boolCount(modified), nil
+	}
+	results, err := collection.UpdateBatch(updateBatchItems(ids, docs))
+	if err != nil {
+		return 0, 0, err
+	}
+	matched, modified := 0, 0
+	for _, result := range results {
+		if result.Matched {
+			matched++
+		}
+		if result.Modified {
+			modified++
+		}
+	}
+	return matched, modified, nil
+}
+
+func boolCount(v bool) int {
+	if v {
+		return 1
+	}
+	return 0
 }
 
 func (s *Server) handleDeleteBatch(state *connState, sections []iwire.Section) ([]iwire.Section, error) {


### PR DESCRIPTION
## Summary

Links #2051.

This slice routes single-document nativewire `replace_batch` requests through the existing collection `Update` path and allows those replace requests to share the nativewire metadata read lock. Multi-document replaces keep the existing `UpdateBatch` path.

The intent is to let YCSB-style concurrent single-record updates use the collection update combiner instead of serializing every `replace_batch` at the nativewire metadata lock.

## Correctness notes

- Single replace preserves existing `ReplaceBatch` counts: existing changed documents report `matched=1 modified=1`, identical replacements report `matched=1 modified=0`, and missing IDs report `0/0`.
- BSON validation and replacement-mode validation still happen before mutation.
- Metadata/catalog operations still take the exclusive metadata lock; only `replace_batch` data mutations take a read lock.
- Added a concurrent in-process nativewire test for independent single-document replaces.

## Tests

- `go test ./TreeDB/nativewire -run 'TestMutationSingleReplaceBatchSemantics|TestMutationConcurrentSingleReplaceBatch|TestMutationCommandsRoundTrip|TestMutationReplaceValidatesBSONBeforeSkippingMissingIDs|TestMutationCatalogGuardAllowsPriorDataCommitVersion|TestCatalogMetadataVersion|TestMutationCatalogCache' -count=1`
- `go test -race ./TreeDB/nativewire -run 'TestMutationConcurrentSingleReplaceBatch|TestMutationSingleReplaceBatchSemantics' -count=1`
- `go test ./TreeDB/nativewire ./cmd/treedb-native-server -count=1`
- `go test ./TreeDB/collections -count=1`

## Benchmark Evidence

Environment: same local YCSB setup as #2051, `recordcount=100000`, `operationcount=1000000` for run, `threadcount=16`, fresh DB per run, `TREEDB_NATIVE_SLOW_REQUEST=5ms`.

Baseline: `main` at `a356df7fc856c25afd40df514736698aee208151`, artifact `/tmp/treedb_ycsb_slow5_next_10PDv5`.

Candidate: `fced07d92`, artifact `/tmp/treedb_ycsb_single_replace_v2_0qZ3UT`.

| Metric | Baseline main | Candidate | Delta |
| --- | ---: | ---: | ---: |
| Load OPS | 44,709.6 | 43,745.8 | -2.2% |
| Load errors | 0 | 0 | unchanged |
| Run total OPS | 82,194.7 | 91,826.9 | +11.7% |
| Run errors | 0 | 0 | unchanged |
| READ avg / max | 164us / 93,695us | 159us / 5,539us | lower tail |
| UPDATE avg | 662us | 370us | -44.1% |
| UPDATE p99 | 1,724us | 901us | -47.7% |
| UPDATE p99.9 | 4,059us | 1,455us | -64.2% |
| UPDATE p99.99 | 94,079us | 2,227us | -97.6% |
| UPDATE max | 94,335us | 5,495us | -94.2% |
| Slow `replace_batch` >5ms | 31 | 0 | removed in this run |

Supporting clean pprof run: artifact `/tmp/treedb_ycsb_single_replace_v2_pprof_clean_cfrwMI`.

- Load: 100,000 inserts, 0 errors, 44,607.8 OPS.
- Run: 1,000,000 ops, 0 errors, 93,366.2 total OPS.
- UPDATE avg/p99/p99.9/max: 362us / 864us / 1,321us / 3,347us.
- CPU profile shows the collection update combiner active: `collectionUpdateCombiner.runBatchWithScratch` 1.03s cumulative, `handleReplaceBatch` 0.20s cumulative.
- Slow counts: `create_collection 1`, `flush_all 2`, `insert_batch_fast 63`; no `replace_batch` slow requests.

## Risk

This intentionally changes concurrency for single-document nativewire replaces. The branch keeps metadata/catalog changes exclusive and adds focused semantic, concurrent, and race coverage for the new path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for single-document replace behavior, concurrency, and interaction with metadata read locking.

* **Refactor**
  * Improved batch replace performance with a fast path for single-item replacements and reduced metadata write contention by allowing concurrent metadata reads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->