### PR TITLE
Typed-column latest-visible sorted q2/q4b reducers

### DIFF
--- a/TreeDB/collections/column_physical_latest_visible_1953_test.go
+++ b/TreeDB/collections/column_physical_latest_visible_1953_test.go
@@ -179,37 +179,203 @@ func TestColumnPhysicalNonDenseNoPredicateMutationUsesTypedLatestVisible1953(t *
 	assertPreparedMutationFailsClosed1953(t, col, req)
 }
 
-func TestColumnPhysicalSortedMutationShapesStillFailClosed1953(t *testing.T) {
-	t.Run("q2", func(t *testing.T) {
-		batches := [][]columnPhysicalJSONBenchParityEventP0{typedColumnQ2SortedBatchA1950(), typedColumnQ2SortedBatchB1950()}
-		_, _, col, closeFn := openTypedColumnLatestVisibleFixture1953(t, typedColumnQ2ClickHouseSortKey1950(), batches)
-		defer closeFn()
-		updated := typedColumnQ2SortedBatchA1950()[0]
-		updated.Collection = "app.bsky.feed.like"
-		updateTypedColumnEvent1953(t, col, updated)
-		assertSortedMutationUnsupported1953(t, "q2", col, typedColumnQ2Request1950())
-	})
+func TestColumnPhysicalQ2SortedLatestVisibleMutationReopen1953(t *testing.T) {
+	batches := [][]columnPhysicalJSONBenchParityEventP0{typedColumnQ2SortedBatchA1950(), typedColumnQ2SortedBatchB1950()}
+	dir, d, col, closeFn := openTypedColumnLatestVisibleFixture1953(t, typedColumnQ2ClickHouseSortKey1950(), batches)
+	events := flattenColumnPhysicalEvents1950(batches)
+	latest := latestEventMap1953(events)
 
-	t.Run("q4b", func(t *testing.T) {
-		events := typedColumnQ4BTopKTieBreakEvents1950()
-		_, _, col, closeFn := openTypedColumnLatestVisibleFixture1953(t, typedColumnQ4BTopKClickHouseSortKey1950(), [][]columnPhysicalJSONBenchParityEventP0{events})
-		defer closeFn()
-		updated := events[0]
-		updated.TimeUS += 17
-		updateTypedColumnEvent1953(t, col, updated)
-		assertSortedMutationUnsupported1953(t, "q4b", col, typedColumnQ4BTopKRequest1950())
-	})
+	promoted := latest["a-kind-guard"]
+	promoted.Kind = "commit"
+	promoted.Operation = "create"
+	promoted.Collection = "app.bsky.feed.like"
+	promoted.Did = "did:promoted"
+	promoted.TimeUS += 101
+	updateTypedColumnEvent1953(t, col, promoted)
+	latest[promoted.ID] = promoted
 
-	t.Run("q4a", func(t *testing.T) {
-		batches := columnPhysicalQ4ATimeOrderBatches1950(8)
-		_, _, col, closeFn := openTypedColumnLatestVisibleFixture1953(t, []ColumnSortKey{{Column: "time_us"}}, batches)
-		defer closeFn()
-		updated := batches[0][0]
-		updated.Kind = "commit"
-		updated.TimeUS += 19
-		updateTypedColumnEvent1953(t, col, updated)
-		assertSortedMutationUnsupported1953(t, "q4a", col, columnPhysicalQ4ATimeOrderRequest1950())
-	})
+	demoted := latest["a-post-a-1"]
+	demoted.Operation = "delete"
+	demoted.TimeUS += 102
+	updateTypedColumnEvent1953(t, col, demoted)
+	latest[demoted.ID] = demoted
+
+	moved := latest["a-post-shared"]
+	moved.Collection = "app.bsky.feed.like"
+	moved.TimeUS += 103
+	updateTypedColumnEvent1953(t, col, moved)
+	latest[moved.ID] = moved
+
+	deleteTypedColumnEvent1953(t, col, "b-repost")
+	delete(latest, "b-repost")
+
+	_, col, closeFn = checkpointAndReopenTypedColumnLatestVisibleFixture1953(t, dir, d, closeFn)
+	defer closeFn()
+
+	live := latestEvents1953(latest)
+	req := typedColumnQ2Request1950()
+	result, err := col.RunColumnPhysicalQuery(req)
+	if err != nil {
+		t.Fatalf("RunColumnPhysicalQuery(q2 sorted latest-visible): %v diagnostics=%+v", err, result.Diagnostics)
+	}
+	got := columnPhysicalJSONBenchQ2CountsP0(result.Groups)
+	want := columnPhysicalJSONBenchQ2ReferenceCountsP0(live)
+	if !columnPhysicalJSONBenchQ2CountsEqualP0(got, want) {
+		t.Fatalf("q2 latest-visible counts=%v want %v groups=%+v", got, want, result.Groups)
+	}
+	if _, ok := got[""]; ok {
+		t.Fatalf("q2 latest-visible produced sentinel empty collection group: %v", got)
+	}
+	matchedRows := columnPhysicalJSONBenchReferenceMatchedRowsP0("q2", live)
+	assertLatestVisibleSortedQ2Diagnostics1953(t, result.Diagnostics, len(live), matchedRows)
+	assertPreparedMutationFailsClosed1953(t, col, req)
+}
+
+func TestColumnPhysicalQ4BTopKSortedLatestVisibleMutation1953(t *testing.T) {
+	events := typedColumnQ4BTopKTieBreakEvents1950()
+	batches := splitColumnPhysicalEvents1953(events)
+	_, _, col, closeFn := openTypedColumnLatestVisibleFixture1953(t, typedColumnQ4BTopKClickHouseSortKey1950(), batches)
+	defer closeFn()
+	latest := latestEventMap1953(events)
+
+	moved := latest["post-0"]
+	moved.Did = "did:post:aaa"
+	moved.TimeUS = 1_999_990
+	updateTypedColumnEvent1953(t, col, moved)
+	latest[moved.ID] = moved
+
+	demoted := latest["post-1"]
+	demoted.Collection = "app.bsky.feed.like"
+	demoted.TimeUS += 201
+	updateTypedColumnEvent1953(t, col, demoted)
+	latest[demoted.ID] = demoted
+
+	promoted := latest["identity-0"]
+	promoted.Kind = "commit"
+	promoted.Operation = "create"
+	promoted.Collection = "app.bsky.feed.post"
+	promoted.Did = "did:post:tie-z"
+	promoted.TimeUS = moved.TimeUS
+	updateTypedColumnEvent1953(t, col, promoted)
+	latest[promoted.ID] = promoted
+
+	deleteTypedColumnEvent1953(t, col, "post-2")
+	delete(latest, "post-2")
+
+	live := latestEvents1953(latest)
+	req := typedColumnQ4BTopKRequest1950()
+	want := typedColumnQ4BTopKReferenceGroups1950(live, req.TopK)
+	matchedRows := columnPhysicalJSONBenchReferenceMatchedRowsP0("q4b", live)
+	result, err := col.RunColumnPhysicalQuery(req)
+	if err != nil {
+		t.Fatalf("RunColumnPhysicalQuery(q4b sorted latest-visible): %v diagnostics=%+v", err, result.Diagnostics)
+	}
+	assertTypedColumnQ4BTopKGroups1950(t, "latest-visible q4b", result.Groups, want)
+	assertLatestVisibleQ4BTopKDiagnostics1953(t, result.Diagnostics, len(live), matchedRows, req.TopK, len(want), typedColumnQ4BTopKReferenceCandidateCount1950(live))
+	assertPreparedMutationFailsClosed1953(t, col, req)
+}
+
+func TestColumnPhysicalQ4ATimeOrderSortedMutationStillFailsClosed1953(t *testing.T) {
+	batches := columnPhysicalQ4ATimeOrderBatches1950(8)
+	_, _, col, closeFn := openTypedColumnLatestVisibleFixture1953(t, []ColumnSortKey{{Column: "time_us"}}, batches)
+	defer closeFn()
+	updated := batches[0][0]
+	updated.Kind = "commit"
+	updated.TimeUS += 19
+	updateTypedColumnEvent1953(t, col, updated)
+	assertSortedMutationUnsupported1953(t, "q4a", col, columnPhysicalQ4ATimeOrderRequest1950())
+}
+
+func BenchmarkColumnPhysicalSortedLatestVisible1953(b *testing.B) {
+	q2Batches := [][]columnPhysicalJSONBenchParityEventP0{typedColumnQ2SortedBatchA1950(), typedColumnQ2SortedBatchB1950()}
+	q4bEvents := typedColumnQ4BTopKTieBreakEvents1950()
+	q4bEventsByID := eventsByID1953(q4bEvents)
+	q4bBatches := splitColumnPhysicalEvents1953(q4bEvents)
+	cases := []struct {
+		name    string
+		sortKey []ColumnSortKey
+		batches [][]columnPhysicalJSONBenchParityEventP0
+		req     ColumnPhysicalQueryRequest
+		mutate  func(testing.TB, *Collection)
+	}{
+		{
+			name:    "q2_insert_only",
+			sortKey: typedColumnQ2ClickHouseSortKey1950(),
+			batches: q2Batches,
+			req:     typedColumnQ2Request1950(),
+		},
+		{
+			name:    "q2_latest_visible",
+			sortKey: typedColumnQ2ClickHouseSortKey1950(),
+			batches: q2Batches,
+			req:     typedColumnQ2Request1950(),
+			mutate: func(tb testing.TB, col *Collection) {
+				updated := typedColumnQ2SortedBatchA1950()[0]
+				updated.Collection = "app.bsky.feed.like"
+				updated.TimeUS += 10
+				updateTypedColumnEvent1953(tb, col, updated)
+				deleteTypedColumnEvent1953(tb, col, "b-repost")
+			},
+		},
+		{
+			name:    "q4b_insert_only",
+			sortKey: typedColumnQ4BTopKClickHouseSortKey1950(),
+			batches: q4bBatches,
+			req:     typedColumnQ4BTopKRequest1950(),
+		},
+		{
+			name:    "q4b_latest_visible",
+			sortKey: typedColumnQ4BTopKClickHouseSortKey1950(),
+			batches: q4bBatches,
+			req:     typedColumnQ4BTopKRequest1950(),
+			mutate: func(tb testing.TB, col *Collection) {
+				updated := q4bEventsByID["post-0"]
+				updated.Did = "did:post:aaa"
+				updated.TimeUS = 1_999_990
+				updateTypedColumnEvent1953(tb, col, updated)
+				deleteTypedColumnEvent1953(tb, col, "post-2")
+			},
+		},
+	}
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			_, _, col, closeFn := openTypedColumnLatestVisibleFixture1953(b, tc.sortKey, tc.batches)
+			defer closeFn()
+			if tc.mutate != nil {
+				tc.mutate(b, col)
+			}
+			preview, err := col.RunColumnPhysicalQuery(tc.req)
+			if err != nil {
+				b.Fatalf("preview RunColumnPhysicalQuery: %v", err)
+			}
+			b.ReportAllocs()
+			b.SetBytes(preview.Diagnostics.PhysicalBytesScanned)
+			b.ResetTimer()
+			var last ColumnPhysicalQueryDiagnostics
+			var groups int
+			for i := 0; i < b.N; i++ {
+				result, err := col.RunColumnPhysicalQuery(tc.req)
+				if err != nil {
+					b.Fatalf("RunColumnPhysicalQuery: %v", err)
+				}
+				groups += len(result.Groups)
+				last = result.Diagnostics
+			}
+			b.StopTimer()
+			if groups == 0 {
+				b.Fatal("benchmark produced no groups")
+			}
+			b.ReportMetric(float64(last.RowsScanned), "rows_scanned/op")
+			b.ReportMetric(float64(last.RowsMatched), "rows_matched/op")
+			b.ReportMetric(float64(last.ReduceRows), "reduce_rows/op")
+			b.ReportMetric(float64(last.VisibilityRows), "visibility_rows/op")
+			b.ReportMetric(float64(last.DeletedRows), "deleted_rows/op")
+			b.ReportMetric(float64(last.TypedColumnPartSections), "typed_sections/op")
+			b.ReportMetric(float64(last.SortKeyMarkChecks), "mark_checks/op")
+			b.ReportMetric(float64(last.SortKeyMarkSkips), "mark_skips/op")
+			b.ReportMetric(float64(last.TopKCandidates), "topk_candidates/op")
+		})
+	}
 }
 
 func BenchmarkColumnPhysicalDenseLatestVisible1953(b *testing.B) {
@@ -470,6 +636,67 @@ func didMinTimes1953(events []columnPhysicalJSONBenchParityEventP0) map[string]i
 		}
 	}
 	return out
+}
+
+func splitColumnPhysicalEvents1953(events []columnPhysicalJSONBenchParityEventP0) [][]columnPhysicalJSONBenchParityEventP0 {
+	mid := len(events) / 2
+	if mid == 0 {
+		return [][]columnPhysicalJSONBenchParityEventP0{events}
+	}
+	return [][]columnPhysicalJSONBenchParityEventP0{events[:mid], events[mid:]}
+}
+
+func assertLatestVisibleSortedQ2Diagnostics1953(tb testing.TB, diag ColumnPhysicalQueryDiagnostics, visibleRows int, matchedRows int) {
+	tb.Helper()
+	if diag.StorageSource != ColumnPhysicalQueryStorageSourceTypedColumnPartSection || diag.FallbackReason != ColumnPhysicalQueryFallbackNone {
+		tb.Fatalf("q2 diagnostics storage/fallback=%+v want latest-visible typed-column path", diag)
+	}
+	if diag.MutationParts == 0 || diag.VisibilityRows != visibleRows || diag.DeletedRows == 0 {
+		tb.Fatalf("q2 visibility diagnostics=%+v want mutation parts, visible=%d, deleted rows", diag, visibleRows)
+	}
+	if diag.PredicateCount != 2 || diag.RowsMatched != matchedRows || diag.ReduceRows != matchedRows {
+		tb.Fatalf("q2 predicate diagnostics=%+v want predicates=2 matched/reduced=%d", diag, matchedRows)
+	}
+	if !diag.SortedGroupedDistinctUsed || !diag.SortedGroupedDistinctReady || diag.SortedGroupedDistinctFallbackReason != columnSortedGroupedDistinctFallbackNone {
+		tb.Fatalf("q2 grouped-distinct diagnostics=%+v want sorted latest-visible grouped distinct", diag)
+	}
+	if !diag.SortKeyPrefixPlanned || diag.SortKeyPrefixLiterals != 2 || !equalStrings1949(diag.SortKeyPrefixColumns, []string{"kind", "operation"}) || diag.SortKeyMarkChecks == 0 {
+		tb.Fatalf("q2 sort diagnostics=%+v want kind/operation sorted-prefix marks", diag)
+	}
+	if diag.TypedColumnPartSections == 0 || diag.TypedColumnPartSectionBytes == 0 || diag.DecodedBlocks == 0 || diag.PhysicalBytesScanned == 0 {
+		tb.Fatalf("q2 typed-column diagnostics=%+v want section/decode/byte counters", diag)
+	}
+	if diag.RowMaterializations != 0 || diag.DocumentMaterializations != 0 || diag.ReconstructionRows != 0 {
+		tb.Fatalf("q2 materialization diagnostics=%+v want zero row/document reconstruction", diag)
+	}
+}
+
+func assertLatestVisibleQ4BTopKDiagnostics1953(tb testing.TB, diag ColumnPhysicalQueryDiagnostics, visibleRows int, matchedRows int, wantTopK int, wantGroups int, wantCandidates int) {
+	tb.Helper()
+	if diag.StorageSource != ColumnPhysicalQueryStorageSourceTypedColumnPartSection || diag.FallbackReason != ColumnPhysicalQueryFallbackNone {
+		tb.Fatalf("q4b diagnostics storage/fallback=%+v want latest-visible typed-column path", diag)
+	}
+	if diag.MutationParts == 0 || diag.VisibilityRows != visibleRows || diag.DeletedRows == 0 {
+		tb.Fatalf("q4b visibility diagnostics=%+v want mutation parts, visible=%d, deleted rows", diag, visibleRows)
+	}
+	if diag.PredicateCount != 3 || diag.RowsMatched != matchedRows || diag.ReduceRows != matchedRows {
+		tb.Fatalf("q4b predicate diagnostics=%+v want predicates=3 matched/reduced=%d", diag, matchedRows)
+	}
+	if !diag.SortKeyPrefixPlanned || diag.SortKeyPrefixLiterals != 3 || !equalStrings1949(diag.SortKeyPrefixColumns, []string{"kind", "operation", "collection"}) {
+		tb.Fatalf("q4b prefix diagnostics=%+v want kind/operation/collection sorted prefix", diag)
+	}
+	if diag.SortKeyMarkChecks == 0 || diag.SortKeyMarkSkips == 0 || diag.SkippedGranules == 0 {
+		tb.Fatalf("q4b mark diagnostics=%+v want checked and skipped sort-key marks", diag)
+	}
+	if diag.RowsScanned <= 0 || diag.RowsScanned >= visibleRows || diag.DecodedPayloadBytes == 0 {
+		tb.Fatalf("q4b scan diagnostics=%+v want mark-pruned typed-column section decode", diag)
+	}
+	if diag.TopKLimit != wantTopK || diag.TopKOrder != string(ColumnPhysicalQueryTopKInt64Asc) || diag.TopKCandidates != wantCandidates || diag.ResultGroups != wantGroups {
+		tb.Fatalf("q4b topK diagnostics=%+v want limit/order/candidates/result groups", diag)
+	}
+	if diag.RowMaterializations != 0 || diag.DocumentMaterializations != 0 || diag.ReconstructionRows != 0 {
+		tb.Fatalf("q4b materialization diagnostics=%+v want zero row/document reconstruction", diag)
+	}
 }
 
 func assertLatestVisibleDenseDiagnostics1953(tb testing.TB, label string, diag ColumnPhysicalQueryDiagnostics, visibleRows int, matchedRows int, shape string) {

--- a/TreeDB/collections/column_physical_q2_1950_test.go
+++ b/TreeDB/collections/column_physical_q2_1950_test.go
@@ -45,7 +45,7 @@ func TestTypedColumnQ2SortedGroupedDistinctStreaming1950(t *testing.T) {
 	assertTypedColumnQ2SortedGroupedDistinctDiagnostics1950(t, "prepared", prepared.Diagnostics, len(events), matchedRows, true)
 }
 
-func TestTypedColumnQ2MutationVisibilityFailsClosedC1(t *testing.T) {
+func TestTypedColumnQ2MutationVisibilityLatestVisibleC3(t *testing.T) {
 	batches := [][]columnPhysicalJSONBenchParityEventP0{typedColumnQ2SortedBatchA1950(), typedColumnQ2SortedBatchB1950()}
 	_, col, closeFn := openTypedColumnSortKeyFixtureBatches1950(t, typedColumnQ2ClickHouseSortKey1950(), batches)
 	defer closeFn()
@@ -59,19 +59,17 @@ func TestTypedColumnQ2MutationVisibilityFailsClosedC1(t *testing.T) {
 		t.Fatalf("insert-only diagnostics=%+v want optimized typed-column q2 path", insertOnly.Diagnostics)
 	}
 
-	_, modified, err := col.Update([]byte("a-post-shared"), func([]byte) ([]byte, bool, error) {
-		return []byte(`{"time_us":1800000000000040,"kind":"commit","operation":"create","collection":"app.bsky.feed.like","did":"did:shared"}`), true, nil
-	})
-	if err != nil || !modified {
-		t.Fatalf("Update modified=%t err=%v", modified, err)
-	}
+	updated := typedColumnQ2SortedBatchA1950()[0]
+	updated.Collection = "app.bsky.feed.like"
+	updated.TimeUS += 10
+	updateTypedColumnEvent1953(t, col, updated)
 
 	result, err := col.RunColumnPhysicalQuery(req)
-	if !errors.Is(err, ErrColumnQueryPlanUnsupported) || !strings.Contains(err.Error(), "typed-column") || !strings.Contains(err.Error(), "mutation visibility") {
-		t.Fatalf("mutation q2 err=%v diagnostics=%+v want explicit typed-column mutation-visibility failure", err, result.Diagnostics)
+	if err != nil {
+		t.Fatalf("mutation q2 RunColumnPhysicalQuery: %v diagnostics=%+v", err, result.Diagnostics)
 	}
-	if result.Diagnostics.StorageSource != ColumnPhysicalQueryStorageSourceTypedColumnPartSection || result.Diagnostics.FallbackReason != ColumnPhysicalQueryFallbackMutationVisibilityUnsupported {
-		t.Fatalf("mutation q2 diagnostics=%+v want typed-column mutation-visibility unsupported route", result.Diagnostics)
+	if result.Diagnostics.StorageSource != ColumnPhysicalQueryStorageSourceTypedColumnPartSection || result.Diagnostics.FallbackReason != ColumnPhysicalQueryFallbackNone || !result.Diagnostics.SortedGroupedDistinctUsed {
+		t.Fatalf("mutation q2 diagnostics=%+v want latest-visible sorted grouped-distinct path", result.Diagnostics)
 	}
 	if result.Diagnostics.MutationParts == 0 || result.Diagnostics.VisibilityRows == 0 || result.Diagnostics.DocumentMaterializations != 0 || result.Diagnostics.RowMaterializations != 0 {
 		t.Fatalf("mutation q2 diagnostics=%+v want latest-visible physical state without document fallback", result.Diagnostics)

--- a/TreeDB/collections/column_physical_typed_column_1947_test.go
+++ b/TreeDB/collections/column_physical_typed_column_1947_test.go
@@ -298,7 +298,7 @@ func TestColumnPhysicalJSONBenchTypedColumnPartDecodeMismatchesFailClosed1947(t 
 	t.Run("typed_ref_row_count_mismatch", func(t *testing.T) {
 		staleTypedRef := typedRef
 		staleTypedRef.Rows++
-		_, err := decodeTypedColumnPhysicalQueryPart(plan, view.FullConfig.SchemaHash, staleTypedRef, physicalRef, raw)
+		_, err := decodeTypedColumnPhysicalQueryPart(plan, view.FullConfig.SchemaHash, staleTypedRef, physicalRef, raw, false)
 		if err == nil || !strings.Contains(err.Error(), "image/ref mismatch") {
 			t.Fatalf("decode row-count mismatch err=%v want image/ref mismatch", err)
 		}
@@ -306,13 +306,13 @@ func TestColumnPhysicalJSONBenchTypedColumnPartDecodeMismatchesFailClosed1947(t 
 	t.Run("physical_ref_row_count_mismatch", func(t *testing.T) {
 		stalePhysicalRef := physicalRef
 		stalePhysicalRef.Rows++
-		_, err := decodeTypedColumnPhysicalQueryPart(plan, view.FullConfig.SchemaHash, typedRef, stalePhysicalRef, raw)
+		_, err := decodeTypedColumnPhysicalQueryPart(plan, view.FullConfig.SchemaHash, typedRef, stalePhysicalRef, raw, false)
 		if err == nil || !strings.Contains(err.Error(), "do not match physical rows") {
 			t.Fatalf("decode physical row-count mismatch err=%v want physical row mismatch", err)
 		}
 	})
 	t.Run("schema_hash_mismatch", func(t *testing.T) {
-		_, err := decodeTypedColumnPhysicalQueryPart(plan, view.FullConfig.SchemaHash+1, typedRef, physicalRef, raw)
+		_, err := decodeTypedColumnPhysicalQueryPart(plan, view.FullConfig.SchemaHash+1, typedRef, physicalRef, raw, false)
 		if err == nil || !strings.Contains(err.Error(), "schema_version") {
 			t.Fatalf("decode schema mismatch err=%v want schema_version mismatch", err)
 		}

--- a/TreeDB/collections/column_physical_typed_column_query.go
+++ b/TreeDB/collections/column_physical_typed_column_query.go
@@ -59,6 +59,7 @@ type columnTypedColumnPhysicalQueryPart struct {
 	PhysicalRef               columnManifestAssetRefForScan
 	Values                    map[string][]columnDeclaredValue
 	RowIndexes                []int
+	PhysicalRowIndexes        []int
 	Rows                      int
 	Bytes                     int64
 	Sections                  int
@@ -198,7 +199,7 @@ func runColumnPhysicalQueryTypedColumnPartMutationUnsupported(view columnPhysica
 }
 
 func runColumnPhysicalQueryTypedColumnPartLatestVisibleInSnapshotView(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest, plan columnTypedColumnPhysicalQueryPlan, start time.Time) (ColumnPhysicalQueryResult, bool, error) {
-	if !columnTypedColumnPhysicalQueryUseDenseLatestVisible(plan, req) && columnPhysicalQueryHasPredicates(req) {
+	if !columnTypedColumnPhysicalQueryUseDenseLatestVisible(plan, req) && columnPhysicalQueryHasPredicates(req) && !columnTypedColumnPhysicalQueryUseSortedLatestVisible(plan, req) {
 		return runColumnPhysicalQueryTypedColumnPartMutationUnsupported(view, req, start)
 	}
 	readCache, err := newColumnPhysicalAssetReadCacheWithIntegrity(view.ColumnAssetRootDir, view.AssetNamespace, req.ColumnAssetReadIntegrity)
@@ -236,7 +237,8 @@ func runColumnPhysicalQueryTypedColumnPartLatestVisibleInSnapshotView(view colum
 		result.Diagnostics.ScanNanos = time.Since(start).Nanoseconds()
 		return result, true, err
 	}
-	if typedColumnRefsHaveSortKey(refsByGeneration) {
+	sortedRefs := typedColumnRefsHaveSortKey(refsByGeneration)
+	if sortedRefs && !columnTypedColumnPhysicalQueryUseSortedLatestVisible(plan, req) {
 		result := ColumnPhysicalQueryResult{Diagnostics: columnTypedColumnPhysicalMutationDiagnostics(view, req)}
 		annotateColumnPhysicalQueryResult(&result, ColumnPhysicalQueryStorageSourceTypedColumnPartSection, ColumnPhysicalQueryFallbackMutationVisibilityUnsupported)
 		applyColumnPhysicalQueryPredicateDiagnostics(&result.Diagnostics, plan.PredicateDiagnostics, 0, 0)
@@ -246,8 +248,18 @@ func runColumnPhysicalQueryTypedColumnPartLatestVisibleInSnapshotView(view colum
 		result.Diagnostics.ScanNanos = time.Since(start).Nanoseconds()
 		return result, true, typedColumnSortedMutationVisibilityUnsupported("typed-column part physical query")
 	}
+	if columnTypedColumnPhysicalQueryUseSortedLatestVisible(plan, req) && !sortedRefs {
+		result := ColumnPhysicalQueryResult{Diagnostics: columnTypedColumnPhysicalMutationDiagnostics(view, req)}
+		annotateColumnPhysicalQueryResult(&result, ColumnPhysicalQueryStorageSourceTypedColumnPartSection, ColumnPhysicalQueryFallbackMutationVisibilityUnsupported)
+		applyColumnPhysicalQueryPredicateDiagnostics(&result.Diagnostics, plan.PredicateDiagnostics, 0, 0)
+		applyTypedColumnLatestVisibilityDiagnostics(&result.Diagnostics, state, visibilityDiag.PhysicalBytesScanned, visibilityNanos)
+		result.Diagnostics.SegmentFileCacheHits = visibilityDiag.SegmentFileCacheHits
+		result.Diagnostics.SegmentFileCacheMisses = visibilityDiag.SegmentFileCacheMisses
+		result.Diagnostics.ScanNanos = time.Since(start).Nanoseconds()
+		return result, true, fmt.Errorf("%w: typed-column sorted latest-visible physical query requires sorted typed_column_part assets", ErrColumnQueryPlanUnsupported)
+	}
 
-	runner, err := decodeColumnTypedColumnPhysicalQueryRunnerParts(view, req, plan, refsByGeneration, &readCache)
+	runner, err := decodeColumnTypedColumnPhysicalQueryRunnerParts(view, req, plan, refsByGeneration, &readCache, columnTypedColumnPhysicalQueryUseSortedLatestVisible(plan, req))
 	if err != nil {
 		result := ColumnPhysicalQueryResult{Diagnostics: columnTypedColumnPhysicalMutationDiagnostics(view, req)}
 		annotateColumnPhysicalQueryResult(&result, ColumnPhysicalQueryStorageSourceTypedColumnPartSection, ColumnPhysicalQueryFallbackMutationVisibilityUnsupported)
@@ -272,6 +284,18 @@ func columnTypedColumnPhysicalQueryUseDenseLatestVisible(plan columnTypedColumnP
 	return columnTypedColumnPhysicalQueryUseDenseGroupCount(plan, req) ||
 		columnTypedColumnPhysicalQueryUseDenseGroupHourCount(plan, req) ||
 		columnTypedColumnPhysicalQueryUseDenseInt64Span(plan, req)
+}
+
+func columnTypedColumnPhysicalQueryUseSortedLatestVisible(plan columnTypedColumnPhysicalQueryPlan, req ColumnPhysicalQueryRequest) bool {
+	return columnTypedColumnPhysicalQueryUseSortedGroupedDistinct(plan, req) ||
+		columnTypedColumnPhysicalQueryUseSortedMarkPrunedTopK(plan, req)
+}
+
+func columnTypedColumnPhysicalQueryUseSortedMarkPrunedTopK(plan columnTypedColumnPhysicalQueryPlan, req ColumnPhysicalQueryRequest) bool {
+	return req.Kind == ColumnPhysicalQueryGroupMinInt64 &&
+		req.GroupColumn != "" && req.ValueColumn != "" && req.DistinctColumn == "" &&
+		req.AggregateMetadataName == "" && req.TopK > 0 && req.TopKOrder == ColumnPhysicalQueryTopKInt64Asc &&
+		len(plan.PredicateSpecs) != 0 && plan.SortKeyPrefix.Planned && !columnTypedColumnPhysicalQueryUseTimeOrderTopK(plan, req)
 }
 
 func applyTypedColumnLatestVisibilityDiagnostics(diag *ColumnPhysicalQueryDiagnostics, state *typedColumnLatestVisibilityState, physicalBytes int64, visibilityNanos int64) {
@@ -314,14 +338,14 @@ func prepareColumnTypedColumnPhysicalQueryRunner(view columnPhysicalScanSnapshot
 	if _, err := validateTypedColumnPhysicalAssetPairing(refsByGeneration, view.AssetRefs); err != nil {
 		return nil, true, typedColumnPhysicalQueryPairingError(err)
 	}
-	runner, err := decodeColumnTypedColumnPhysicalQueryRunnerParts(view, req, plan, refsByGeneration, readCache)
+	runner, err := decodeColumnTypedColumnPhysicalQueryRunnerParts(view, req, plan, refsByGeneration, readCache, false)
 	if err != nil {
 		return nil, true, err
 	}
 	return runner, true, nil
 }
 
-func decodeColumnTypedColumnPhysicalQueryRunnerParts(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest, plan columnTypedColumnPhysicalQueryPlan, refsByGeneration map[uint64]columnManifestAssetRefForScan, readCache *columnPhysicalAssetReadCache) (*columnTypedColumnPhysicalQueryRunner, error) {
+func decodeColumnTypedColumnPhysicalQueryRunnerParts(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest, plan columnTypedColumnPhysicalQueryPlan, refsByGeneration map[uint64]columnManifestAssetRefForScan, readCache *columnPhysicalAssetReadCache, includePhysicalRows bool) (*columnTypedColumnPhysicalQueryRunner, error) {
 	if readCache == nil {
 		return nil, errors.New("collections: typed-column part physical query missing read cache")
 	}
@@ -369,7 +393,7 @@ func decodeColumnTypedColumnPhysicalQueryRunnerParts(view columnPhysicalScanSnap
 		case columnTypedColumnPhysicalQueryUseTimeOrderTopK(plan, req):
 			part, err = decodeTypedColumnPhysicalQueryTimeOrderTopKPart(plan, view.FullConfig.SchemaHash, typedRef, physical, raw)
 		default:
-			part, err = decodeTypedColumnPhysicalQueryPart(plan, view.FullConfig.SchemaHash, typedRef, physical, raw)
+			part, err = decodeTypedColumnPhysicalQueryPart(plan, view.FullConfig.SchemaHash, typedRef, physical, raw, includePhysicalRows)
 		}
 		if err != nil {
 			return nil, fmt.Errorf("collections: typed-column part physical query decode generation=%d part_id=%d: %w", typedRef.Ref.Generation, typedRef.Ref.PartID, err)
@@ -663,7 +687,7 @@ func columnSortKeysEqual(left, right []ColumnSortKey) bool {
 	return true
 }
 
-func decodeTypedColumnPhysicalQueryPart(plan columnTypedColumnPhysicalQueryPlan, schemaHash uint64, typedRef, physical columnManifestAssetRefForScan, raw []byte) (columnTypedColumnPhysicalQueryPart, error) {
+func decodeTypedColumnPhysicalQueryPart(plan columnTypedColumnPhysicalQueryPlan, schemaHash uint64, typedRef, physical columnManifestAssetRefForScan, raw []byte, includePhysicalRows bool) (columnTypedColumnPhysicalQueryPart, error) {
 	adapterPart, summary, err := typedColumnAdapterPartFromBytesForReconstructionWithSummary(typedColumnAdapterOptions{Fields: plan.Fields, SchemaVersion: uint32(schemaHash)}, raw)
 	if err != nil {
 		return columnTypedColumnPhysicalQueryPart{}, err
@@ -690,6 +714,23 @@ func decodeTypedColumnPhysicalQueryPart(plan columnTypedColumnPhysicalQueryPlan,
 	decoded, scanDiag, err := adapterPart.scanDecodedValuesSelectedRows(plan.Selected, selectedRows)
 	if err != nil {
 		return columnTypedColumnPhysicalQueryPart{}, err
+	}
+	var physicalRowIndexes []int
+	if includePhysicalRows {
+		decodedRows := len(selectedRows)
+		if selectedRows == nil {
+			decodedRows = summary.Rows
+		}
+		var primaryDiag columnTypedColumnPhysicalRowIndexDiagnostics
+		physicalRowIndexes, primaryDiag, err = typedColumnPhysicalQueryPhysicalRows(adapterPart, selectedRows, decodedRows)
+		if err != nil {
+			return columnTypedColumnPhysicalQueryPart{}, err
+		}
+		if primaryDiag.GranulesDecoded > scanDiag.GranulesDecoded {
+			scanDiag.GranulesDecoded = primaryDiag.GranulesDecoded
+		}
+		scanDiag.BlocksDecoded += primaryDiag.BlocksDecoded
+		scanDiag.BytesDecoded += primaryDiag.BytesDecoded
 	}
 	values := make(map[string][]columnDeclaredValue, len(plan.ProjectedColumns))
 	for idx, field := range plan.Fields {
@@ -718,6 +759,7 @@ func decodeTypedColumnPhysicalQueryPart(plan columnTypedColumnPhysicalQueryPlan,
 		PhysicalRef:               physical,
 		Values:                    values,
 		RowIndexes:                selectedRows,
+		PhysicalRowIndexes:        physicalRowIndexes,
 		Rows:                      summary.Rows,
 		Bytes:                     int64(len(raw)),
 		Sections:                  summary.Sections,
@@ -802,7 +844,10 @@ func (r *columnTypedColumnPhysicalQueryRunner) runLatestVisible(view columnPhysi
 	if columnTypedColumnPhysicalQueryUseDenseInt64Span(r.plan, req) {
 		return r.runLatestVisibleDenseInt64Span(view, req, state, visibilityBytes, visibilityNanos)
 	}
-	if !columnPhysicalQueryHasPredicates(req) {
+	if columnTypedColumnPhysicalQueryUseSortedGroupedDistinct(r.plan, req) {
+		return r.runLatestVisibleSortedGroupedDistinct(view, req, state, visibilityBytes, visibilityNanos)
+	}
+	if !columnPhysicalQueryHasPredicates(req) || columnTypedColumnPhysicalQueryUseSortedMarkPrunedTopK(r.plan, req) {
 		return r.runLatestVisibleGeneric(view, req, state, visibilityBytes, visibilityNanos)
 	}
 	result := ColumnPhysicalQueryResult{Diagnostics: r.latestVisibleDiagnostics(view, req, state, visibilityBytes, visibilityNanos, 0, 0, 0, 0)}
@@ -834,11 +879,12 @@ func (r *columnTypedColumnPhysicalQueryRunner) runLatestVisibleGeneric(view colu
 	start := time.Now()
 	acc := newColumnTypedColumnPhysicalQueryAccumulator(req.Kind)
 	rowsScanned := 0
+	matchedRows := 0
 	for partIdx := range r.parts {
 		part := r.parts[partIdx]
 		visibility, err := r.latestVisiblePartForRunnerPart(part, state)
 		if err != nil {
-			return ColumnPhysicalQueryResult{Diagnostics: r.latestVisibleDiagnostics(view, req, state, visibilityBytes, visibilityNanos, rowsScanned, 0, acc.reduceRows, time.Since(start).Nanoseconds())}, err
+			return ColumnPhysicalQueryResult{Diagnostics: r.latestVisibleDiagnostics(view, req, state, visibilityBytes, visibilityNanos, rowsScanned, matchedRows, acc.reduceRows, time.Since(start).Nanoseconds())}, err
 		}
 		partRows := len(part.RowIndexes)
 		if part.RowIndexes == nil {
@@ -846,21 +892,33 @@ func (r *columnTypedColumnPhysicalQueryRunner) runLatestVisibleGeneric(view colu
 		}
 		for rowIdx := 0; rowIdx < partRows; rowIdx++ {
 			physicalRow := rowIdx
-			if part.RowIndexes != nil {
+			if part.PhysicalRowIndexes != nil {
+				physicalRow = part.PhysicalRowIndexes[rowIdx]
+			} else if part.RowIndexes != nil {
 				physicalRow = part.RowIndexes[rowIdx]
 			}
 			rowsScanned++
 			if !visibility.rowVisible(physicalRow) {
 				continue
 			}
+			matched, err := typedColumnPhysicalQueryPredicatesMatch(part.Values, r.plan.PredicateSpecs, rowIdx)
+			if err != nil {
+				return ColumnPhysicalQueryResult{Diagnostics: r.latestVisibleDiagnostics(view, req, state, visibilityBytes, visibilityNanos, rowsScanned, matchedRows, acc.reduceRows, time.Since(start).Nanoseconds())}, err
+			}
+			if !matched {
+				continue
+			}
+			if len(r.plan.PredicateSpecs) != 0 {
+				matchedRows++
+			}
 			if err := acc.visit(req, part.Values, rowIdx); err != nil {
-				return ColumnPhysicalQueryResult{Diagnostics: r.latestVisibleDiagnostics(view, req, state, visibilityBytes, visibilityNanos, rowsScanned, 0, acc.reduceRows, time.Since(start).Nanoseconds())}, err
+				return ColumnPhysicalQueryResult{Diagnostics: r.latestVisibleDiagnostics(view, req, state, visibilityBytes, visibilityNanos, rowsScanned, matchedRows, acc.reduceRows, time.Since(start).Nanoseconds())}, err
 			}
 		}
 	}
 	groups := acc.groups(req, r.resultGroups)
 	r.resultGroups = groups
-	diag := r.latestVisibleDiagnostics(view, req, state, visibilityBytes, visibilityNanos, rowsScanned, 0, acc.reduceRows, time.Since(start).Nanoseconds())
+	diag := r.latestVisibleDiagnostics(view, req, state, visibilityBytes, visibilityNanos, rowsScanned, matchedRows, acc.reduceRows, time.Since(start).Nanoseconds())
 	result := ColumnPhysicalQueryResult{Groups: groups, Diagnostics: diag}
 	finalizeColumnPhysicalQueryResultGroups(req, &result)
 	r.resultGroups = result.Groups
@@ -1763,7 +1821,7 @@ func (r *columnTypedColumnPhysicalQueryRunner) runSortedGroupedDistinct(view col
 	iterators := make([]*columnTypedColumnSortedGroupedDistinctIterator, 0, len(r.parts))
 	heap := columnTypedColumnSortedGroupedDistinctHeap{}
 	for partIdx := range r.parts {
-		iterator, err := newColumnTypedColumnSortedGroupedDistinctIterator(&r.parts[partIdx], r.plan, req, partIdx)
+		iterator, err := newColumnTypedColumnSortedGroupedDistinctIterator(&r.parts[partIdx], r.plan, req, partIdx, nil)
 		if err != nil {
 			rowsScanned, matchedRows := columnTypedColumnSortedGroupedDistinctIteratorTotals(iterators)
 			diag := r.diagnostics(view, req, rowsScanned, matchedRows, 0, time.Since(start).Nanoseconds())
@@ -1840,10 +1898,105 @@ func (r *columnTypedColumnPhysicalQueryRunner) runSortedGroupedDistinct(view col
 	return ColumnPhysicalQueryResult{Groups: groups, Diagnostics: diag}, nil
 }
 
+func (r *columnTypedColumnPhysicalQueryRunner) runLatestVisibleSortedGroupedDistinct(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest, state *typedColumnLatestVisibilityState, visibilityBytes int64, visibilityNanos int64) (ColumnPhysicalQueryResult, error) {
+	start := time.Now()
+	iterators := make([]*columnTypedColumnSortedGroupedDistinctIterator, 0, len(r.parts))
+	heap := columnTypedColumnSortedGroupedDistinctHeap{}
+	for partIdx := range r.parts {
+		part := &r.parts[partIdx]
+		visibility, err := r.latestVisiblePartForRunnerPart(*part, state)
+		if err != nil {
+			rowsScanned, matchedRows := columnTypedColumnSortedGroupedDistinctIteratorTotals(iterators)
+			diag := r.latestVisibleDiagnostics(view, req, state, visibilityBytes, visibilityNanos, rowsScanned, matchedRows, 0, time.Since(start).Nanoseconds())
+			diag.SortedGroupedDistinctUsed = true
+			return ColumnPhysicalQueryResult{Diagnostics: diag}, err
+		}
+		iterator, err := newColumnTypedColumnSortedGroupedDistinctIterator(part, r.plan, req, partIdx, visibility)
+		if err != nil {
+			rowsScanned, matchedRows := columnTypedColumnSortedGroupedDistinctIteratorTotals(iterators)
+			diag := r.latestVisibleDiagnostics(view, req, state, visibilityBytes, visibilityNanos, rowsScanned, matchedRows, 0, time.Since(start).Nanoseconds())
+			diag.SortedGroupedDistinctUsed = true
+			return ColumnPhysicalQueryResult{Diagnostics: diag}, err
+		}
+		iterators = append(iterators, iterator)
+		iteratorIdx := len(iterators) - 1
+		if err := iterator.advance(); err != nil {
+			rowsScanned, matchedRows := columnTypedColumnSortedGroupedDistinctIteratorTotals(iterators)
+			diag := r.latestVisibleDiagnostics(view, req, state, visibilityBytes, visibilityNanos, rowsScanned, matchedRows, 0, time.Since(start).Nanoseconds())
+			diag.SortedGroupedDistinctUsed = true
+			return ColumnPhysicalQueryResult{Diagnostics: diag}, err
+		}
+		if !iterator.done {
+			heap.push(iteratorIdx, iterators)
+		}
+	}
+
+	groups := r.resultGroups[:0]
+	firstGroup := true
+	currentGroup := ""
+	currentDistinct := ""
+	groupRows := 0
+	distinctRows := 0
+	reduceRows := 0
+	emitGroup := func() {
+		if firstGroup {
+			return
+		}
+		groups = append(groups, ColumnPhysicalQueryGroup{Key: currentGroup, Count: groupRows, DistinctCount: distinctRows})
+	}
+	for heap.len() != 0 {
+		iteratorIdx := heap.pop(iterators)
+		iterator := iterators[iteratorIdx]
+		group := iterator.currentGroup
+		distinct := iterator.currentDistinct
+		if firstGroup {
+			firstGroup = false
+			currentGroup = group
+			currentDistinct = distinct
+			groupRows = 1
+			distinctRows = 1
+		} else if group != currentGroup {
+			emitGroup()
+			currentGroup = group
+			currentDistinct = distinct
+			groupRows = 1
+			distinctRows = 1
+		} else {
+			groupRows++
+			if distinct != currentDistinct {
+				currentDistinct = distinct
+				distinctRows++
+			}
+		}
+		reduceRows++
+		if err := iterator.advance(); err != nil {
+			rowsScanned, matchedRows := columnTypedColumnSortedGroupedDistinctIteratorTotals(iterators)
+			diag := r.latestVisibleDiagnostics(view, req, state, visibilityBytes, visibilityNanos, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
+			diag.SortedGroupedDistinctUsed = true
+			return ColumnPhysicalQueryResult{Diagnostics: diag}, err
+		}
+		if !iterator.done {
+			heap.push(iteratorIdx, iterators)
+		}
+	}
+	emitGroup()
+	r.resultGroups = groups
+	rowsScanned, matchedRows := columnTypedColumnSortedGroupedDistinctIteratorTotals(iterators)
+	diag := r.latestVisibleDiagnostics(view, req, state, visibilityBytes, visibilityNanos, rowsScanned, matchedRows, reduceRows, time.Since(start).Nanoseconds())
+	diag.SortedGroupedDistinctUsed = true
+	result := ColumnPhysicalQueryResult{Groups: groups, Diagnostics: diag}
+	finalizeColumnPhysicalQueryResultGroups(req, &result)
+	r.resultGroups = result.Groups
+	return result, nil
+}
+
 type columnTypedColumnSortedGroupedDistinctIterator struct {
 	partIndex        int
 	row              int
 	rows             int
+	rowIndexes       []int
+	physicalRows     []int
+	visibility       *typedColumnLatestPhysicalPart
 	groupValues      []columnDeclaredValue
 	distinctValues   []columnDeclaredValue
 	predicateSpecs   []columnPhysicalQueryPredicateSpec
@@ -1855,7 +2008,7 @@ type columnTypedColumnSortedGroupedDistinctIterator struct {
 	matchedRows      int
 }
 
-func newColumnTypedColumnSortedGroupedDistinctIterator(part *columnTypedColumnPhysicalQueryPart, plan columnTypedColumnPhysicalQueryPlan, req ColumnPhysicalQueryRequest, partIndex int) (*columnTypedColumnSortedGroupedDistinctIterator, error) {
+func newColumnTypedColumnSortedGroupedDistinctIterator(part *columnTypedColumnPhysicalQueryPart, plan columnTypedColumnPhysicalQueryPlan, req ColumnPhysicalQueryRequest, partIndex int, visibility *typedColumnLatestPhysicalPart) (*columnTypedColumnSortedGroupedDistinctIterator, error) {
 	partRows := len(part.RowIndexes)
 	if part.RowIndexes == nil {
 		partRows = part.Rows
@@ -1879,6 +2032,9 @@ func newColumnTypedColumnSortedGroupedDistinctIterator(part *columnTypedColumnPh
 	return &columnTypedColumnSortedGroupedDistinctIterator{
 		partIndex:        partIndex,
 		rows:             partRows,
+		rowIndexes:       part.RowIndexes,
+		physicalRows:     part.PhysicalRowIndexes,
+		visibility:       visibility,
 		groupValues:      groupValues,
 		distinctValues:   distinctValues,
 		predicateSpecs:   plan.PredicateSpecs,
@@ -1896,6 +2052,17 @@ func (it *columnTypedColumnSortedGroupedDistinctIterator) advance() error {
 		rowIdx := it.row
 		it.row++
 		it.rowsScanned++
+		if it.visibility != nil {
+			physicalRow := rowIdx
+			if it.physicalRows != nil {
+				physicalRow = it.physicalRows[rowIdx]
+			} else if it.rowIndexes != nil {
+				physicalRow = it.rowIndexes[rowIdx]
+			}
+			if !it.visibility.rowVisible(physicalRow) {
+				continue
+			}
+		}
 		matched := true
 		for idx, spec := range it.predicateSpecs {
 			if !typedColumnPhysicalQueryPredicateStringMatches(it.predicateColumns[idx][rowIdx].String, spec) {
@@ -1982,6 +2149,66 @@ func columnTypedColumnSortedGroupedDistinctIteratorTotals(iterators []*columnTyp
 		matchedRows += iterator.matchedRows
 	}
 	return rowsScanned, matchedRows
+}
+
+type columnTypedColumnPhysicalRowIndexDiagnostics struct {
+	GranulesDecoded int
+	BlocksDecoded   int
+	BytesDecoded    int
+}
+
+func typedColumnPhysicalQueryPhysicalRows(part *typedColumnAdapterPart, selectedRows []int, wantRows int) ([]int, columnTypedColumnPhysicalRowIndexDiagnostics, error) {
+	if part == nil || part.Part == nil || len(part.Part.Descriptor.SortKey) == 0 || typedColumnSortKeyIsSyntheticPrimaryID(part.Part.Descriptor.SortKey) {
+		return nil, columnTypedColumnPhysicalRowIndexDiagnostics{}, nil
+	}
+	if selectedRows == nil {
+		scan, err := part.Part.NewScanner().ScanProjected([]string{typedColumnAdapterPrimaryIDColumn})
+		diag := columnTypedColumnPhysicalRowIndexDiagnostics{
+			GranulesDecoded: scan.Diagnostics.GranulesDecoded,
+			BlocksDecoded:   scan.Diagnostics.BlocksDecoded,
+			BytesDecoded:    scan.Diagnostics.BytesDecoded,
+		}
+		if err != nil {
+			return nil, diag, err
+		}
+		return typedColumnPhysicalQueryPhysicalRowsFromPrimaryIDs(part, nil, wantRows, scan.Columns[typedColumnAdapterPrimaryIDColumn], diag)
+	}
+	scan, err := part.Part.NewScanner().ScanProjectedRows([]string{typedColumnAdapterPrimaryIDColumn}, selectedRows)
+	diag := columnTypedColumnPhysicalRowIndexDiagnostics{
+		GranulesDecoded: scan.Diagnostics.GranulesDecoded,
+		BlocksDecoded:   scan.Diagnostics.BlocksDecoded,
+		BytesDecoded:    scan.Diagnostics.BytesDecoded,
+	}
+	if err != nil {
+		return nil, diag, err
+	}
+	return typedColumnPhysicalQueryPhysicalRowsFromPrimaryIDs(part, selectedRows, wantRows, scan.Columns[typedColumnAdapterPrimaryIDColumn], diag)
+}
+
+func typedColumnPhysicalQueryPhysicalRowsFromPrimaryIDs(part *typedColumnAdapterPart, selectedRows []int, wantRows int, primaryValues []int64, diag columnTypedColumnPhysicalRowIndexDiagnostics) ([]int, columnTypedColumnPhysicalRowIndexDiagnostics, error) {
+	if len(primaryValues) != wantRows {
+		return nil, diag, fmt.Errorf("collections: typed-column part physical query primary-id rows=%d want %d", len(primaryValues), wantRows)
+	}
+	physicalRows := make([]int, len(primaryValues))
+	identity := true
+	for rowIdx, primaryID := range primaryValues {
+		physicalRow, err := typedColumnPhysicalRowIndexFromPrimaryID(primaryID, part.Part.Descriptor.RowCount)
+		if err != nil {
+			return nil, diag, err
+		}
+		physicalRows[rowIdx] = physicalRow
+		wantPhysicalRow := rowIdx
+		if selectedRows != nil {
+			wantPhysicalRow = selectedRows[rowIdx]
+		}
+		if physicalRow != wantPhysicalRow {
+			identity = false
+		}
+	}
+	if identity {
+		return nil, diag, nil
+	}
+	return physicalRows, diag, nil
 }
 
 func typedColumnPhysicalQueryStringColumnValues(values map[string][]columnDeclaredValue, column string, wantRows int) ([]columnDeclaredValue, error) {

--- a/TreeDB/collections/column_physical_typed_column_sortkey_1948_test.go
+++ b/TreeDB/collections/column_physical_typed_column_sortkey_1948_test.go
@@ -497,7 +497,7 @@ func TestTypedColumnPartSortKeyQueryValidationFailsClosed1948(t *testing.T) {
 	}
 	_, err = decodeTypedColumnPhysicalQueryPart(plan, normalized.SchemaHash,
 		columnManifestAssetRefForScan{Ref: ref, Rows: rowCount, SortKey: nil},
-		columnManifestAssetRefForScan{Rows: rowCount}, raw)
+		columnManifestAssetRefForScan{Rows: rowCount}, raw, false)
 	if err == nil || !strings.Contains(err.Error(), "sort metadata mismatch") {
 		t.Fatalf("decodeTypedColumnPhysicalQueryPart err=%v want sort metadata mismatch", err)
 	}


### PR DESCRIPTION
## Summary

C3 for #1953: direct sorted typed-column q2/q4b physical queries now execute over mutation-bearing manifests when the sorted layout is safe.

- Enables q2 `GroupCountAndDistinct` over sorted typed-column parts with latest-visible filtering before predicates/reduction, while merging by logical collection/did strings so distinct users deduplicate across base/delta parts.
- Enables q4b sorted-prefix/mark-pruned TopK over mutation-bearing typed-column parts via latest-visible physical-row filtering, real predicates, and existing deterministic TopK value/key tie breaks.
- Adds sorted typed-row -> physical-row remapping from the typed-column primary-id locator only for sorted latest-visible paths; insert-only prepared/direct hot paths stay unchanged.
- Keeps q4a time-order early-stop multipart mutation-bearing sorted path fail-closed with `mutation_visibility_unsupported` diagnostics.
- Keeps prepared mutation-bearing physical queries fail-closed with insert-only/lifecycle wording until #1954.

## Scope boundaries / deferred

Not included in this C3 PR:

- C4 q4a time-order multipart merge/early-stop over mutations.
- C5 compaction + metadata rebuild/invalidation.
- #1952 codecs and #1954 lifecycle/pinning.
- Document-leaf column pointers or changes to the `<collection>/column/manifest` catalog-root shape.

## Local validation

Head: `ea6cf634b254beda6d36056cdf8e7e438968dd65` (merged latest `origin/main` `659a231da1f31cab4011d6ac1c486c6b39a0d220`).

- `GOWORK=off go test ./TreeDB/collections -count=1 -run 'TestTypedColumnQ2MutationVisibilityLatestVisibleC3|TestColumnPhysicalQ2SortedLatestVisibleMutationReopen1953|TestColumnPhysicalQ4BTopKSortedLatestVisibleMutation1953|TestColumnPhysicalQ4ATimeOrderSortedMutationStillFailsClosed1953|TestTypedColumnQ2SortedGroupedDistinctStreaming1950|TestTypedColumnQ4BTopKMarkPrunedParity1950|TestColumnPhysicalQ4ATimeOrderTopKDirectPreparedParity1950|TestColumnPhysicalNonDenseNoPredicateMutationUsesTypedLatestVisible1953|TestColumnPhysicalQ1DenseLatestVisibleMutation1953|TestColumnPhysicalQ3DenseLatestVisibleMutationReopen1953|TestColumnPhysicalQ5DenseLatestVisibleMutation1953|TestColumnPhysicalQ1DenseTypedColumnDirectPreparedParity1950|TestColumnPhysicalQ3DenseTypedColumnDirectPreparedParity1950|TestColumnPhysicalQ5DenseTypedColumnDirectPreparedParity1950'` — PASS (`/tmp/orca_issue_graph_1945_1955/1953_c3_focused_after_latest_main_659a231.txt`)
- `GOWORK=off go test ./TreeDB/collections -count=1` — PASS (`/tmp/orca_issue_graph_1945_1955/1953_c3_collections_after_latest_main_659a231.txt`)
- `GOWORK=off go test ./TreeDB/docs -count=1` — PASS (`/tmp/orca_issue_graph_1945_1955/1953_c3_docs_after_latest_main_659a231.txt`)
- `GOWORK=off go test ./TreeDB/...` — PASS (`/tmp/orca_issue_graph_1945_1955/1953_c3_treedb_all_after_latest_main_659a231.txt`)

Earlier validation before latest-main merge also passed; the first full TreeDB run hit known unrelated caching scheduler flake `TestCheckpoint_KicksVlogGenerationRewriteDespiteRecentForegroundActivity`, and targeted rerun passed (`/tmp/orca_issue_graph_1945_1955/1953_c3_caching_flake_rerun_final_20260531_003731.txt`).

Internal reviewer: PASS (`/tmp/orca_issue_graph_1945_1955/1953_c3_internal_reviewer_20260531_002833.txt`).

## Benchmark smoke

Latest after `origin/main` `659a231da1f31cab4011d6ac1c486c6b39a0d220`:

Command: `GOWORK=off go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnPhysicalSortedLatestVisible1953|BenchmarkTypedColumnQ2SortedGroupedDistinct1950/direct/sorted_prefix|BenchmarkTypedColumnQ4BTopK1950/direct/clickhouse_mark_pruned' -benchtime=20x -count=1 -benchmem`

Artifact: `/tmp/orca_issue_graph_1945_1955/1953_c3_bench_after_latest_main_659a231.txt`

| Shape | Mode | ns/op | B/op | allocs/op | rows_scanned | rows_matched/reduce_rows | visibility_rows | deleted_rows | mark_checks | mark_skips | topk_candidates |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| q2 | insert-only fixture | 85,798 | 71,544 | 554 | 11 | 9 / 9 | 0 | 0 | 2 | 0 | 0 |
| q2 | latest-visible fixture | 98,192 | 111,839 | 824 | 12 | 8 / 8 | 10 | 1 | 3 | 0 | 0 |
| q4b | insert-only fixture | 3,255,046 | 10,943,202 | 983 | 10,500 | 2,000 / 2,000 | 0 | 0 | 4 | 2 | 64 |
| q4b | latest-visible fixture | 6,094,340 | 20,591,222 | 1,285 | 10,501 | 1,999 / 1,999 | 20,999 | 1 | 5 | 2 | 65 |
| q2 | direct sorted-prefix 10M fixture smoke | 13,895,556 | 52,685,580 | 8,890 | 65,536 | 59,553 / 59,553 | 0 | 0 | 8 | 0 | 0 |
| q4b | direct clickhouse mark-pruned smoke | 2,567,242 | 8,506,764 | 667 | 8,192 | 2,000 / 2,000 | 0 | 0 | 3 | 2 | 64 |

Insert-only base vs head smoke from before the latest-main merge:

- Base artifact: `/tmp/orca_issue_graph_1945_1955/1953_c3_bench_insert_only_base_20260531_002804.txt`
- Benchstat: `/tmp/orca_issue_graph_1945_1955/1953_c3_benchstat_insert_only_base_vs_head_final2.txt`

Selected insert-only comparison (n=1 smoke):

| Benchmark | base ns/op | head ns/op | counters |
| --- | ---: | ---: | --- |
| q2 direct sorted-prefix | 13,948,798 | 13,968,771 | rows/marks/decoded bytes unchanged; allocs 8,892 -> 8,891 |
| q4b direct clickhouse mark-pruned | 2,582,271 | 2,590,888 | rows/marks/decoded bytes unchanged; allocs 667 -> 666 |

No material insert-only regression observed in smoke; latest-visible paths pay expected one-shot visibility construction and primary-id row remapping only on supported sorted mutation paths.

## Review / risk notes

- Sorted row visibility depends on typed-column primary-id locator remapping; tests cover q2 reopen, q4b duplicate/tie/update/delete, and q4a fail-closed.
- Unsupported sorted mutation shapes continue to fail closed rather than falling back to document scans.
- Prepared mutation-bearing q2/q4b remains unsupported until #1954 lifecycle/pinning.
- After the latest-main merge, AI reviews were re-requested for latest-head validation.

Closes part of #1953 (C3 only).
