### PR TITLE
nativewire: share metadata read lock for inserts

### DIFF
--- a/TreeDB/nativewire/mutation_test.go
+++ b/TreeDB/nativewire/mutation_test.go
@@ -276,6 +276,67 @@ func TestMutationSingleReplaceBatchSharesMetadataReadLock(t *testing.T) {
 	}
 }
 
+func TestMutationInsertBatchSharesMetadataReadLock(t *testing.T) {
+	client, server, mgr, _ := serveCollectionPipeWithServer(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := client.Hello(ctx); err != nil {
+		t.Fatalf("Hello: %v", err)
+	}
+	if _, err := client.CreateCollection(ctx, collections.CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+
+	server.metadataMu.RLock()
+	locked := true
+	unlock := func() {
+		if locked {
+			server.metadataMu.RUnlock()
+			locked = false
+		}
+	}
+	defer unlock()
+
+	done := make(chan error, 1)
+	go func() {
+		ids, err := client.InsertBatch(ctx, "users", collections.DocumentFormatJSON,
+			[][]byte{[]byte("u1")},
+			[][]byte{[]byte(`{"name":"Ada"}`)},
+			AckVisible,
+		)
+		if err == nil && (len(ids) != 1 || string(ids[0]) != "u1") {
+			err = errors.New("unexpected insert IDs")
+		}
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("InsertBatch: %v", err)
+		}
+	case <-time.After(500 * time.Millisecond):
+		unlock()
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+		}
+		t.Fatalf("InsertBatch blocked behind metadata read lock")
+	}
+
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("OpenCollection: %v", err)
+	}
+	doc, err := col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("Get u1: %v", err)
+	}
+	if !bytes.Contains(doc, []byte(`"Ada"`)) {
+		t.Fatalf("u1 doc=%s", doc)
+	}
+}
+
 func TestMutationConcurrentSingleReplaceBatch(t *testing.T) {
 	client, server, mgr, _ := serveCollectionPipeWithServer(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/TreeDB/nativewire/server_mutation.go
+++ b/TreeDB/nativewire/server_mutation.go
@@ -40,8 +40,8 @@ func (s *Server) handleInsertBatchBody(state *connState, sections []iwire.Sectio
 }
 
 func (s *Server) handleInsertBatchFastBody(req insertBatchFastRequest, dst []byte) ([]byte, error) {
-	s.metadataMu.Lock()
-	defer s.metadataMu.Unlock()
+	s.metadataMu.RLock()
+	defer s.metadataMu.RUnlock()
 	if err := s.checkCatalogGuard(req.sections); err != nil {
 		return nil, err
 	}
@@ -75,8 +75,8 @@ func (s *Server) insertBatch(state *connState, sections []iwire.Section) ([][]by
 	if err := managerRequired(s.collections); err != nil {
 		return nil, 0, 0, false, err
 	}
-	s.metadataMu.Lock()
-	defer s.metadataMu.Unlock()
+	s.metadataMu.RLock()
+	defer s.metadataMu.RUnlock()
 	if err := s.checkCatalogGuard(sections); err != nil {
 		return nil, 0, 0, false, err
 	}


### PR DESCRIPTION
## Summary

Links #2051.

This keeps ordinary nativewire insert mutations on the catalog metadata read side instead of taking the exclusive metadata lock. Inserts still validate the catalog guard while metadata mutations retain exclusive access, but concurrent data mutations no longer serialize on a catalog lock they do not modify.

Changes:

- `handleInsertBatchFastBody` uses `metadataMu.RLock`/`RUnlock`.
- the generic `insertBatch` path uses the same read-lock behavior.
- adds a regression test that holds an existing metadata read lock while issuing `InsertBatch`, proving inserts do not require exclusive metadata access.

## Why

After the merged run-phase fixes, load-phase profiling on current `main` still showed insert handling paying for exclusive metadata locking:

- artifact: `/tmp/treedb_ycsb_load_profile_1780226076`
- `handleInsertBatchFastBody`: `2.41s` cumulative
- `metadataMu.Lock` in `handleInsertBatchFastBody`: `490ms` cumulative

This PR makes insert metadata access match the earlier replace-batch read-lock behavior: data mutations read catalog state, while schema/catalog mutations remain exclusive.

## Tests

```sh
git diff --check

go test ./TreeDB/nativewire \
  -run 'TestMutationInsertBatchSharesMetadataReadLock|TestMutationSingleReplaceBatchSharesMetadataReadLock|TestMutationCommandsRoundTrip' \
  -count=1

go test -race ./TreeDB/nativewire \
  -run 'TestMutationInsertBatchSharesMetadataReadLock|TestMutationSingleReplaceBatchSharesMetadataReadLock|TestMutationConcurrentSingleReplaceBatch' \
  -count=1

go test ./TreeDB/nativewire ./cmd/treedb-native-server -count=1

go test ./TreeDB/collections -count=1
```

All passed locally.

## Benchmark Evidence

Host/context:

```text
host: mikers-B560-DS3H-AC-Y1
kernel: Linux 6.8.0-111-generic x86_64
cpu: 11th Gen Intel(R) Core(TM) i5-11400F @ 2.60GHz, 6 cores / 12 threads
server profile: fast
YCSB: recordcount=100000, threadcount=16
```

Baseline current `main`: `659a231da1f31cab4011d6ac1c486c6b39a0d220`

Candidate: `b07fa090c8dadc11482f59e6f6cb02e8918b5102`

| Run | Artifact | Load OPS | Load avg | Load max | Run total OPS | Update avg | Update p99 | Update max | Errors |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| baseline `main` | `/tmp/treedb_ycsb_main659a_1780224770` | `43790.5` | `351us` | `16927us` | `90829.0` | `374us` | `940us` | `5675us` | `0` |
| candidate full check | `/tmp/treedb_ycsb_insert_rlock_fullcheck_1780226652` | `47190.5` | `325us` | `8823us` | `92748.6` | `367us` | `909us` | `7235us` | `0` |

Load throughput improved by about `7.8%` in the full check. A second load-only candidate check was consistent:

| Run | Artifact | Load OPS | Load avg | Load max | Errors |
| --- | --- | ---: | ---: | ---: | ---: |
| candidate load-only | `/tmp/treedb_ycsb_insert_rlock_loadcheck_1780226473` | `47140.5` | `326us` | `11119us` | `0` |

Load-profile confirmation on the candidate:

- artifact: `/tmp/treedb_ycsb_insert_rlock_only_1780226422`
- load OPS: `46847.9`
- `handleInsertBatchFastBody`: `2.43s` cumulative
- `sync.(*RWMutex).RLock`: `0.02s` cumulative
- remaining lock cost is collection mutation locking, not metadata locking (`lockCollectionDomainMutation` / `bufferDirectIndexedInsertPlanLocked`).

Slow-command counts for the full check:

```text
create_collection 1
flush_all 2
insert_batch_fast 64
```

No run-phase nativewire requests exceeded the 5ms slow threshold in that run.

## Regression Assessment

This is scoped to insert/load metadata-lock contention. The 1M run-phase check stayed in the current post-#2057 performance band and had zero `READ_ERROR` / `UPDATE_ERROR`. Broader read/update profiling continues under #2051; I intentionally left the larger value-log hinted-read experiment out of this PR because its isolated gain was marginal.

## Review Status

AI reviews not requested yet at PR creation time; this PR is intended to be ready for Codex/Copilot/CodeRabbit review after creation because it has a narrow diff, focused regression coverage, broader tests, and before/after benchmark evidence.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved concurrency for batch insert operations by reducing lock contention during metadata checks.

* **Tests**
  * Added test verifying batch insert performance with concurrent operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->