### PR TITLE
Typed-column latest-visible q4a time-order merge

### DIFF
--- a/TreeDB/collections/column_physical_latest_visible_1953_test.go
+++ b/TreeDB/collections/column_physical_latest_visible_1953_test.go
@@ -275,15 +275,91 @@ func TestColumnPhysicalQ4BTopKSortedLatestVisibleMutation1953(t *testing.T) {
 	assertPreparedMutationFailsClosed1953(t, col, req)
 }
 
-func TestColumnPhysicalQ4ATimeOrderSortedMutationStillFailsClosed1953(t *testing.T) {
+func TestColumnPhysicalQ4ATimeOrderLatestVisibleMutationReopen1953(t *testing.T) {
+	const base = int64(1_930_000_000_000_000)
+	batches := [][]columnPhysicalJSONBenchParityEventP0{
+		{
+			{ID: "move-new", TimeUS: base + 100, Kind: "commit", Operation: "create", Collection: "app.bsky.feed.post", Did: "did:new"},
+			{ID: "move-old", TimeUS: base + 6, Kind: "commit", Operation: "create", Collection: "app.bsky.feed.post", Did: "did:old"},
+			{ID: "promote-predicate", TimeUS: base + 7, Kind: "identity", Operation: "create", Collection: "app.bsky.feed.post", Did: "did:promote"},
+			{ID: "demote-predicate", TimeUS: base + 9, Kind: "commit", Operation: "create", Collection: "app.bsky.feed.post", Did: "did:demote"},
+		},
+		{
+			{ID: "tie-b", TimeUS: base + 8, Kind: "commit", Operation: "create", Collection: "app.bsky.feed.post", Did: "did:tie:b"},
+			{ID: "tie-a", TimeUS: base + 8, Kind: "commit", Operation: "create", Collection: "app.bsky.feed.post", Did: "did:tie:a"},
+			{ID: "delete-me", TimeUS: base + 4, Kind: "commit", Operation: "create", Collection: "app.bsky.feed.post", Did: "did:delete"},
+			{ID: "stable", TimeUS: base + 12, Kind: "commit", Operation: "create", Collection: "app.bsky.feed.post", Did: "did:stable"},
+		},
+	}
+	dir, d, col, closeFn := openTypedColumnLatestVisibleFixture1953(t, []ColumnSortKey{{Column: "time_us"}}, batches)
+	events := flattenColumnPhysicalEvents1950(batches)
+	latest := latestEventMap1953(events)
+
+	movedNew := latest["move-new"]
+	movedNew.TimeUS = base + 5
+	updateTypedColumnEvent1953(t, col, movedNew)
+	latest[movedNew.ID] = movedNew
+
+	movedOld := latest["move-old"]
+	movedOld.TimeUS = base + 1_000
+	updateTypedColumnEvent1953(t, col, movedOld)
+	latest[movedOld.ID] = movedOld
+
+	promoted := latest["promote-predicate"]
+	promoted.Kind = "commit"
+	promoted.TimeUS = base + 8
+	updateTypedColumnEvent1953(t, col, promoted)
+	latest[promoted.ID] = promoted
+
+	demoted := latest["demote-predicate"]
+	demoted.Operation = "delete"
+	demoted.TimeUS = base + 3
+	updateTypedColumnEvent1953(t, col, demoted)
+	latest[demoted.ID] = demoted
+
+	deleteTypedColumnEvent1953(t, col, "delete-me")
+	delete(latest, "delete-me")
+
+	_, col, closeFn = checkpointAndReopenTypedColumnLatestVisibleFixture1953(t, dir, d, closeFn)
+	defer closeFn()
+
+	live := latestEvents1953(latest)
+	req := columnPhysicalQ4ATimeOrderRequest1950()
+	want := columnPhysicalQ4ATimeOrderReferenceGroups1950(live, req.TopK)
+	wantExact := []ColumnPhysicalQueryGroup{
+		{Key: "did:new", Int64: base + 5},
+		{Key: "did:promote", Int64: base + 8},
+		{Key: "did:tie:a", Int64: base + 8},
+	}
+	if !reflect.DeepEqual(want, wantExact) {
+		t.Fatalf("q4a latest-visible reference=%+v want exact %+v", want, wantExact)
+	}
+	matchedRows := columnPhysicalJSONBenchReferenceMatchedRowsP0("q4a", live)
+	result, err := col.RunColumnPhysicalQuery(req)
+	if err != nil {
+		t.Fatalf("RunColumnPhysicalQuery(q4a time-order latest-visible): %v diagnostics=%+v", err, result.Diagnostics)
+	}
+	assertTypedColumnQ4BTopKGroups1950(t, "latest-visible q4a", result.Groups, want)
+	assertLatestVisibleQ4ATimeOrderDiagnostics1953(t, result.Diagnostics, len(live), matchedRows, req.TopK, len(want), columnPhysicalQ4AMatchingGroupCandidateCount1953(live), len(events)+4)
+	assertPreparedMutationFailsClosed1953(t, col, req)
+}
+
+func TestColumnPhysicalQ4ATimeOrderMutationUnsupportedSortKey1953(t *testing.T) {
 	batches := columnPhysicalQ4ATimeOrderBatches1950(8)
-	_, _, col, closeFn := openTypedColumnLatestVisibleFixture1953(t, []ColumnSortKey{{Column: "time_us"}}, batches)
+	_, _, col, closeFn := openTypedColumnLatestVisibleFixture1953(t, []ColumnSortKey{{Column: "did"}}, batches)
 	defer closeFn()
 	updated := batches[0][0]
 	updated.Kind = "commit"
 	updated.TimeUS += 19
 	updateTypedColumnEvent1953(t, col, updated)
-	assertSortedMutationUnsupported1953(t, "q4a", col, columnPhysicalQ4ATimeOrderRequest1950())
+
+	result, err := col.RunColumnPhysicalQuery(columnPhysicalQ4ATimeOrderRequest1950())
+	if !errors.Is(err, ErrColumnQueryPlanUnsupported) || !strings.Contains(err.Error(), "mutation visibility") {
+		t.Fatalf("q4a unsupported-sort mutation err=%v diagnostics=%+v want explicit mutation visibility fail-closed", err, result.Diagnostics)
+	}
+	if result.Diagnostics.StorageSource != ColumnPhysicalQueryStorageSourceTypedColumnPartSection || result.Diagnostics.FallbackReason != ColumnPhysicalQueryFallbackMutationVisibilityUnsupported || result.Diagnostics.MutationParts == 0 || result.Diagnostics.VisibilityRows == 0 {
+		t.Fatalf("q4a unsupported-sort mutation diagnostics=%+v want typed-column unsupported visibility", result.Diagnostics)
+	}
 }
 
 func BenchmarkColumnPhysicalSortedLatestVisible1953(b *testing.B) {
@@ -291,6 +367,8 @@ func BenchmarkColumnPhysicalSortedLatestVisible1953(b *testing.B) {
 	q4bEvents := typedColumnQ4BTopKTieBreakEvents1950()
 	q4bEventsByID := eventsByID1953(q4bEvents)
 	q4bBatches := splitColumnPhysicalEvents1953(q4bEvents)
+	q4aBatches := columnPhysicalQ4ATimeOrderBatches1950(1024)
+	q4aEventsByID := eventsByID1953(flattenColumnPhysicalEvents1950(q4aBatches))
 	cases := []struct {
 		name    string
 		sortKey []ColumnSortKey
@@ -336,6 +414,28 @@ func BenchmarkColumnPhysicalSortedLatestVisible1953(b *testing.B) {
 				deleteTypedColumnEvent1953(tb, col, "post-2")
 			},
 		},
+		{
+			name:    "q4a_insert_only",
+			sortKey: []ColumnSortKey{{Column: "time_us"}},
+			batches: q4aBatches,
+			req:     columnPhysicalQ4ATimeOrderRequest1950(),
+		},
+		{
+			name:    "q4a_latest_visible",
+			sortKey: []ColumnSortKey{{Column: "time_us"}},
+			batches: q4aBatches,
+			req:     columnPhysicalQ4ATimeOrderRequest1950(),
+			mutate: func(tb testing.TB, col *Collection) {
+				updated := q4aEventsByID["a-m"]
+				updated.TimeUS -= 25
+				updateTypedColumnEvent1953(tb, col, updated)
+				promoted := q4aEventsByID["a-kind-guard"]
+				promoted.Kind = "commit"
+				promoted.TimeUS += 3
+				updateTypedColumnEvent1953(tb, col, promoted)
+				deleteTypedColumnEvent1953(tb, col, "b-b")
+			},
+		},
 	}
 	for _, tc := range cases {
 		b.Run(tc.name, func(b *testing.B) {
@@ -374,6 +474,11 @@ func BenchmarkColumnPhysicalSortedLatestVisible1953(b *testing.B) {
 			b.ReportMetric(float64(last.SortKeyMarkChecks), "mark_checks/op")
 			b.ReportMetric(float64(last.SortKeyMarkSkips), "mark_skips/op")
 			b.ReportMetric(float64(last.TopKCandidates), "topk_candidates/op")
+			if last.TimeOrderTopKUsed {
+				b.ReportMetric(1, "time_order_topk_used/op")
+			} else {
+				b.ReportMetric(0, "time_order_topk_used/op")
+			}
 		})
 	}
 }
@@ -697,6 +802,45 @@ func assertLatestVisibleQ4BTopKDiagnostics1953(tb testing.TB, diag ColumnPhysica
 	if diag.RowMaterializations != 0 || diag.DocumentMaterializations != 0 || diag.ReconstructionRows != 0 {
 		tb.Fatalf("q4b materialization diagnostics=%+v want zero row/document reconstruction", diag)
 	}
+}
+
+func assertLatestVisibleQ4ATimeOrderDiagnostics1953(tb testing.TB, diag ColumnPhysicalQueryDiagnostics, visibleRows int, matchedRows int, wantTopK int, wantGroups int, wantCandidates int, wantRowsScanned int) {
+	tb.Helper()
+	if diag.StorageSource != ColumnPhysicalQueryStorageSourceTypedColumnPartSection || diag.FallbackReason != ColumnPhysicalQueryFallbackNone {
+		tb.Fatalf("q4a diagnostics storage/fallback=%+v want latest-visible typed-column path", diag)
+	}
+	if diag.MutationParts == 0 || diag.VisibilityRows != visibleRows || diag.DeletedRows == 0 {
+		tb.Fatalf("q4a visibility diagnostics=%+v want mutation parts, visible=%d, deleted rows", diag, visibleRows)
+	}
+	if !diag.TimeOrderTopKUsed {
+		tb.Fatalf("q4a diagnostics=%+v want time-order topK latest-visible path", diag)
+	}
+	if diag.PredicateCount != 3 || diag.RowsMatched != matchedRows || diag.ReduceRows != matchedRows {
+		tb.Fatalf("q4a predicate diagnostics=%+v want predicates=3 matched/reduced=%d", diag, matchedRows)
+	}
+	if diag.RowsScanned != wantRowsScanned || diag.DecodedPayloadBytes == 0 || diag.DecodedBlocks == 0 {
+		tb.Fatalf("q4a scan diagnostics=%+v want full multipart latest-visible typed-column decode over %d non-tombstone candidates", diag, wantRowsScanned)
+	}
+	if diag.SortKeyMarkChecks == 0 || diag.TypedColumnPartSections == 0 || diag.TypedColumnPartSectionBytes == 0 || diag.PhysicalBytesScanned == 0 {
+		tb.Fatalf("q4a typed-column diagnostics=%+v want sorted typed-column section counters", diag)
+	}
+	if diag.TopKLimit != wantTopK || diag.TopKOrder != string(ColumnPhysicalQueryTopKInt64Asc) || diag.TopKCandidates != wantCandidates || diag.ResultGroups != wantGroups {
+		tb.Fatalf("q4a topK diagnostics=%+v want limit=%d candidates=%d groups=%d", diag, wantTopK, wantCandidates, wantGroups)
+	}
+	if diag.RowMaterializations != 0 || diag.DocumentMaterializations != 0 || diag.ReconstructionRows != 0 {
+		tb.Fatalf("q4a materialization diagnostics=%+v want zero row/document reconstruction", diag)
+	}
+}
+
+func columnPhysicalQ4AMatchingGroupCandidateCount1953(events []columnPhysicalJSONBenchParityEventP0) int {
+	seen := make(map[string]struct{})
+	for _, event := range events {
+		if !columnPhysicalJSONBenchReferenceMatchP0("q4a", event) {
+			continue
+		}
+		seen[event.Did] = struct{}{}
+	}
+	return len(seen)
 }
 
 func assertLatestVisibleDenseDiagnostics1953(tb testing.TB, label string, diag ColumnPhysicalQueryDiagnostics, visibleRows int, matchedRows int, shape string) {

--- a/TreeDB/collections/column_physical_latest_visible_1953_test.go
+++ b/TreeDB/collections/column_physical_latest_visible_1953_test.go
@@ -294,27 +294,32 @@ func TestColumnPhysicalQ4ATimeOrderLatestVisibleMutationReopen1953(t *testing.T)
 	dir, d, col, closeFn := openTypedColumnLatestVisibleFixture1953(t, []ColumnSortKey{{Column: "time_us"}}, batches)
 	events := flattenColumnPhysicalEvents1950(batches)
 	latest := latestEventMap1953(events)
+	updateRows := 0
 
 	movedNew := latest["move-new"]
 	movedNew.TimeUS = base + 5
 	updateTypedColumnEvent1953(t, col, movedNew)
+	updateRows++
 	latest[movedNew.ID] = movedNew
 
 	movedOld := latest["move-old"]
 	movedOld.TimeUS = base + 1_000
 	updateTypedColumnEvent1953(t, col, movedOld)
+	updateRows++
 	latest[movedOld.ID] = movedOld
 
 	promoted := latest["promote-predicate"]
 	promoted.Kind = "commit"
 	promoted.TimeUS = base + 8
 	updateTypedColumnEvent1953(t, col, promoted)
+	updateRows++
 	latest[promoted.ID] = promoted
 
 	demoted := latest["demote-predicate"]
 	demoted.Operation = "delete"
 	demoted.TimeUS = base + 3
 	updateTypedColumnEvent1953(t, col, demoted)
+	updateRows++
 	latest[demoted.ID] = demoted
 
 	deleteTypedColumnEvent1953(t, col, "delete-me")
@@ -340,7 +345,7 @@ func TestColumnPhysicalQ4ATimeOrderLatestVisibleMutationReopen1953(t *testing.T)
 		t.Fatalf("RunColumnPhysicalQuery(q4a time-order latest-visible): %v diagnostics=%+v", err, result.Diagnostics)
 	}
 	assertTypedColumnQ4BTopKGroups1950(t, "latest-visible q4a", result.Groups, want)
-	assertLatestVisibleQ4ATimeOrderDiagnostics1953(t, result.Diagnostics, len(live), matchedRows, req.TopK, len(want), columnPhysicalQ4AMatchingGroupCandidateCount1953(live), len(events)+4)
+	assertLatestVisibleQ4ATimeOrderDiagnostics1953(t, result.Diagnostics, len(live), matchedRows, req.TopK, len(want), columnPhysicalQ4AMatchingGroupCandidateCount1953(live), len(events)+updateRows)
 	assertPreparedMutationFailsClosed1953(t, col, req)
 }
 

--- a/TreeDB/collections/column_physical_typed_column_query.go
+++ b/TreeDB/collections/column_physical_typed_column_query.go
@@ -288,7 +288,8 @@ func columnTypedColumnPhysicalQueryUseDenseLatestVisible(plan columnTypedColumnP
 
 func columnTypedColumnPhysicalQueryUseSortedLatestVisible(plan columnTypedColumnPhysicalQueryPlan, req ColumnPhysicalQueryRequest) bool {
 	return columnTypedColumnPhysicalQueryUseSortedGroupedDistinct(plan, req) ||
-		columnTypedColumnPhysicalQueryUseSortedMarkPrunedTopK(plan, req)
+		columnTypedColumnPhysicalQueryUseSortedMarkPrunedTopK(plan, req) ||
+		columnTypedColumnPhysicalQueryUseTimeOrderTopK(plan, req)
 }
 
 func columnTypedColumnPhysicalQueryUseSortedMarkPrunedTopK(plan columnTypedColumnPhysicalQueryPlan, req ColumnPhysicalQueryRequest) bool {
@@ -391,7 +392,7 @@ func decodeColumnTypedColumnPhysicalQueryRunnerParts(view columnPhysicalScanSnap
 		case columnTypedColumnPhysicalQueryUseDenseInt64Span(plan, req):
 			part, err = decodeTypedColumnPhysicalQueryDenseInt64SpanPart(plan, view.FullConfig.SchemaHash, typedRef, physical, raw)
 		case columnTypedColumnPhysicalQueryUseTimeOrderTopK(plan, req):
-			part, err = decodeTypedColumnPhysicalQueryTimeOrderTopKPart(plan, view.FullConfig.SchemaHash, typedRef, physical, raw)
+			part, err = decodeTypedColumnPhysicalQueryTimeOrderTopKPart(plan, view.FullConfig.SchemaHash, typedRef, physical, raw, includePhysicalRows)
 		default:
 			part, err = decodeTypedColumnPhysicalQueryPart(plan, view.FullConfig.SchemaHash, typedRef, physical, raw, includePhysicalRows)
 		}
@@ -844,6 +845,9 @@ func (r *columnTypedColumnPhysicalQueryRunner) runLatestVisible(view columnPhysi
 	if columnTypedColumnPhysicalQueryUseDenseInt64Span(r.plan, req) {
 		return r.runLatestVisibleDenseInt64Span(view, req, state, visibilityBytes, visibilityNanos)
 	}
+	if columnTypedColumnPhysicalQueryUseTimeOrderTopK(r.plan, req) {
+		return r.runLatestVisibleTimeOrderTopK(view, req, state, visibilityBytes, visibilityNanos)
+	}
 	if columnTypedColumnPhysicalQueryUseSortedGroupedDistinct(r.plan, req) {
 		return r.runLatestVisibleSortedGroupedDistinct(view, req, state, visibilityBytes, visibilityNanos)
 	}
@@ -1285,7 +1289,7 @@ func (r *columnTypedColumnPhysicalQueryRunner) runTimeOrderTopK(view columnPhysi
 			diag.TimeOrderTopKUsed = true
 			return ColumnPhysicalQueryResult{Diagnostics: diag}, fmt.Errorf("collections: time-order topK missing prepared part %d", partIdx)
 		}
-		iterator, err := newColumnTypedColumnTimeOrderTopKIterator(partIdx, part)
+		iterator, err := newColumnTypedColumnTimeOrderTopKIterator(partIdx, part, nil)
 		if err != nil {
 			rowsScanned, matchedRows, decodedGranules, decodedBlocks, decodedBytes := columnTypedColumnTimeOrderTopKIteratorTotals(iterators)
 			diag := r.timeOrderTopKDiagnostics(view, req, rowsScanned, matchedRows, matchedRows, decodedGranules, decodedBlocks, decodedBytes, time.Since(start).Nanoseconds())
@@ -1359,9 +1363,105 @@ func (r *columnTypedColumnPhysicalQueryRunner) runTimeOrderTopK(view columnPhysi
 	return result, nil
 }
 
+func (r *columnTypedColumnPhysicalQueryRunner) runLatestVisibleTimeOrderTopK(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest, state *typedColumnLatestVisibilityState, visibilityBytes int64, visibilityNanos int64) (ColumnPhysicalQueryResult, error) {
+	start := time.Now()
+	if r.timeOrderMinValues == nil {
+		r.timeOrderMinValues = make(map[string]int64, req.TopK+1)
+	} else {
+		clear(r.timeOrderMinValues)
+	}
+	r.timeOrderHeap.items = r.timeOrderHeap.items[:0]
+	iterators := make([]columnTypedColumnTimeOrderTopKIterator, 0, len(r.parts))
+	reduceRows := 0
+	for partIdx := range r.parts {
+		runnerPart := r.parts[partIdx]
+		part := runnerPart.TimeOrderTopK
+		if part == nil {
+			diag := r.latestVisibleTimeOrderTopKDiagnostics(view, req, state, visibilityBytes, visibilityNanos, 0, 0, reduceRows, 0, 0, 0, time.Since(start).Nanoseconds())
+			return ColumnPhysicalQueryResult{Diagnostics: diag}, fmt.Errorf("collections: time-order topK missing prepared part %d", partIdx)
+		}
+		visibility, err := r.latestVisiblePartForRunnerPart(runnerPart, state)
+		if err != nil {
+			rowsScanned, matchedRows, decodedGranules, decodedBlocks, decodedBytes := columnTypedColumnTimeOrderTopKIteratorTotals(iterators)
+			diag := r.latestVisibleTimeOrderTopKDiagnostics(view, req, state, visibilityBytes, visibilityNanos, rowsScanned, matchedRows, reduceRows, decodedGranules, decodedBlocks, decodedBytes, time.Since(start).Nanoseconds())
+			return ColumnPhysicalQueryResult{Diagnostics: diag}, err
+		}
+		iterator, err := newColumnTypedColumnTimeOrderTopKIterator(partIdx, part, visibility)
+		if err != nil {
+			rowsScanned, matchedRows, decodedGranules, decodedBlocks, decodedBytes := columnTypedColumnTimeOrderTopKIteratorTotals(iterators)
+			diag := r.latestVisibleTimeOrderTopKDiagnostics(view, req, state, visibilityBytes, visibilityNanos, rowsScanned, matchedRows, reduceRows, decodedGranules, decodedBlocks, decodedBytes, time.Since(start).Nanoseconds())
+			return ColumnPhysicalQueryResult{Diagnostics: diag}, err
+		}
+		iterators = append(iterators, iterator)
+		if !iterator.done {
+			r.timeOrderHeap.push(len(iterators)-1, iterators)
+		}
+	}
+
+	// Mutation-bearing sorted parts cannot use the insert-only time-threshold
+	// early stop: a newer visible version may live in any later/delta part. Keep
+	// the logical time-order merge, but scan every non-tombstone candidate and
+	// apply latest-visible physical row identity before predicate/reduce emission.
+	for r.timeOrderHeap.len() != 0 {
+		iteratorIdx := r.timeOrderHeap.pop(iterators)
+		iterator := &iterators[iteratorIdx]
+		visible, err := iterator.currentVisible()
+		if err != nil {
+			rowsScanned, matchedRows, decodedGranules, decodedBlocks, decodedBytes := columnTypedColumnTimeOrderTopKIteratorTotals(iterators)
+			diag := r.latestVisibleTimeOrderTopKDiagnostics(view, req, state, visibilityBytes, visibilityNanos, rowsScanned, matchedRows, reduceRows, decodedGranules, decodedBlocks, decodedBytes, time.Since(start).Nanoseconds())
+			return ColumnPhysicalQueryResult{Diagnostics: diag}, err
+		}
+		if !visible {
+			if err := iterator.skipCurrent(); err != nil {
+				rowsScanned, matchedRows, decodedGranules, decodedBlocks, decodedBytes := columnTypedColumnTimeOrderTopKIteratorTotals(iterators)
+				diag := r.latestVisibleTimeOrderTopKDiagnostics(view, req, state, visibilityBytes, visibilityNanos, rowsScanned, matchedRows, reduceRows, decodedGranules, decodedBlocks, decodedBytes, time.Since(start).Nanoseconds())
+				return ColumnPhysicalQueryResult{Diagnostics: diag}, err
+			}
+		} else {
+			group, matched, err := iterator.evaluateCurrent(len(r.plan.PredicateSpecs) != 0)
+			if err != nil {
+				rowsScanned, matchedRows, decodedGranules, decodedBlocks, decodedBytes := columnTypedColumnTimeOrderTopKIteratorTotals(iterators)
+				diag := r.latestVisibleTimeOrderTopKDiagnostics(view, req, state, visibilityBytes, visibilityNanos, rowsScanned, matchedRows, reduceRows, decodedGranules, decodedBlocks, decodedBytes, time.Since(start).Nanoseconds())
+				return ColumnPhysicalQueryResult{Diagnostics: diag}, err
+			}
+			if matched {
+				reduceRows++
+				if !(req.SkipEmptyGroupKey && group == "") {
+					if _, exists := r.timeOrderMinValues[group]; !exists {
+						r.timeOrderMinValues[group] = iterator.currentTime
+					}
+				}
+			}
+		}
+		if err := iterator.advance(); err != nil {
+			rowsScanned, matchedRows, decodedGranules, decodedBlocks, decodedBytes := columnTypedColumnTimeOrderTopKIteratorTotals(iterators)
+			diag := r.latestVisibleTimeOrderTopKDiagnostics(view, req, state, visibilityBytes, visibilityNanos, rowsScanned, matchedRows, reduceRows, decodedGranules, decodedBlocks, decodedBytes, time.Since(start).Nanoseconds())
+			return ColumnPhysicalQueryResult{Diagnostics: diag}, err
+		}
+		if !iterator.done {
+			r.timeOrderHeap.push(iteratorIdx, iterators)
+		}
+	}
+
+	groups := r.resultGroups[:0]
+	for key, value := range r.timeOrderMinValues {
+		groups = append(groups, ColumnPhysicalQueryGroup{Key: key, Int64: value})
+	}
+	r.resultGroups = groups
+	rowsScanned, matchedRows, decodedGranules, decodedBlocks, decodedBytes := columnTypedColumnTimeOrderTopKIteratorTotals(iterators)
+	diag := r.latestVisibleTimeOrderTopKDiagnostics(view, req, state, visibilityBytes, visibilityNanos, rowsScanned, matchedRows, reduceRows, decodedGranules, decodedBlocks, decodedBytes, time.Since(start).Nanoseconds())
+	result := ColumnPhysicalQueryResult{Groups: groups, Diagnostics: diag}
+	finalizeColumnPhysicalQueryResultGroups(req, &result)
+	r.resultGroups = result.Groups
+	return result, nil
+}
+
 func (r *columnTypedColumnPhysicalQueryRunner) timeOrderTopKDiagnostics(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest, rowsScanned, matchedRows, reduceRows, decodedGranules, decodedBlocks int, decodedBytes uint64, scanNanos int64) ColumnPhysicalQueryDiagnostics {
 	diag := r.diagnostics(view, req, rowsScanned, matchedRows, reduceRows, scanNanos)
 	diag.TimeOrderTopKUsed = true
+	decodedGranules += r.granulesDecoded
+	decodedBlocks += r.decodedBlocks
+	decodedBytes += r.decodedPayloadBytes
 	diag.DecodedGranules = decodedGranules
 	diag.DecodedBlocks = decodedBlocks
 	diag.DirectReduceBlocks = decodedBlocks
@@ -1374,9 +1474,16 @@ func (r *columnTypedColumnPhysicalQueryRunner) timeOrderTopKDiagnostics(view col
 	return diag
 }
 
+func (r *columnTypedColumnPhysicalQueryRunner) latestVisibleTimeOrderTopKDiagnostics(view columnPhysicalScanSnapshotView, req ColumnPhysicalQueryRequest, state *typedColumnLatestVisibilityState, visibilityBytes int64, visibilityNanos int64, rowsScanned, matchedRows, reduceRows, decodedGranules, decodedBlocks int, decodedBytes uint64, scanNanos int64) ColumnPhysicalQueryDiagnostics {
+	diag := r.timeOrderTopKDiagnostics(view, req, rowsScanned, matchedRows, reduceRows, decodedGranules, decodedBlocks, decodedBytes, scanNanos)
+	applyTypedColumnLatestVisibilityDiagnostics(&diag, state, visibilityBytes, visibilityNanos)
+	return diag
+}
+
 type columnTypedColumnTimeOrderTopKIterator struct {
 	partIndex           int
 	part                *columnTypedColumnTimeOrderTopKPart
+	visibility          *typedColumnLatestPhysicalPart
 	granule             int
 	rowInGranule        int
 	currentTime         int64
@@ -1388,13 +1495,65 @@ type columnTypedColumnTimeOrderTopKIterator struct {
 	decodedPayloadBytes uint64
 }
 
-func newColumnTypedColumnTimeOrderTopKIterator(partIndex int, part *columnTypedColumnTimeOrderTopKPart) (columnTypedColumnTimeOrderTopKIterator, error) {
+func newColumnTypedColumnTimeOrderTopKIterator(partIndex int, part *columnTypedColumnTimeOrderTopKPart, visibility *typedColumnLatestPhysicalPart) (columnTypedColumnTimeOrderTopKIterator, error) {
 	part.resetTimeOrderTopKScan()
 	currentTime, ok, err := part.firstTimeOrderTopKTime()
 	if err != nil {
 		return columnTypedColumnTimeOrderTopKIterator{}, err
 	}
-	return columnTypedColumnTimeOrderTopKIterator{partIndex: partIndex, part: part, currentTime: currentTime, done: !ok}, nil
+	return columnTypedColumnTimeOrderTopKIterator{partIndex: partIndex, part: part, visibility: visibility, currentTime: currentTime, done: !ok}, nil
+}
+
+func (it *columnTypedColumnTimeOrderTopKIterator) currentPhysicalRow() (int, error) {
+	if it == nil || it.part == nil {
+		return 0, errors.New("collections: nil time-order topK iterator")
+	}
+	if it.granule < 0 || it.granule >= len(it.part.Granules) {
+		return 0, fmt.Errorf("collections: time-order topK granule %d outside %d", it.granule, len(it.part.Granules))
+	}
+	granule := it.part.Granules[it.granule]
+	if it.rowInGranule < 0 || it.rowInGranule >= granule.RowCount {
+		return 0, fmt.Errorf("collections: time-order topK row_in_granule=%d outside granule rows=%d", it.rowInGranule, granule.RowCount)
+	}
+	sortedRow := granule.FirstRow + it.rowInGranule
+	if sortedRow < 0 || sortedRow >= it.part.Rows {
+		return 0, fmt.Errorf("collections: time-order topK sorted row=%d outside rows=%d", sortedRow, it.part.Rows)
+	}
+	if it.part.PhysicalRows != nil {
+		if sortedRow >= len(it.part.PhysicalRows) {
+			return 0, fmt.Errorf("collections: time-order topK physical row map sorted row=%d outside rows=%d", sortedRow, len(it.part.PhysicalRows))
+		}
+		return it.part.PhysicalRows[sortedRow], nil
+	}
+	return sortedRow, nil
+}
+
+func (it *columnTypedColumnTimeOrderTopKIterator) currentVisible() (bool, error) {
+	if it.visibility == nil {
+		return true, nil
+	}
+	physicalRow, err := it.currentPhysicalRow()
+	if err != nil {
+		return false, err
+	}
+	return it.visibility.rowVisible(physicalRow), nil
+}
+
+func (it *columnTypedColumnTimeOrderTopKIterator) skipCurrent() error {
+	decoded, blocks, decodedBytes, err := it.part.ensureTimeOrderTopKGranuleDecoded(it.granule)
+	if err != nil {
+		return err
+	}
+	if it.rowInGranule < 0 || it.rowInGranule >= len(it.part.timeValues) {
+		return fmt.Errorf("collections: time-order topK row_in_granule=%d outside decoded time rows=%d", it.rowInGranule, len(it.part.timeValues))
+	}
+	it.rowsScanned++
+	if decoded {
+		it.decodedGranules++
+		it.decodedBlocks += blocks
+		it.decodedPayloadBytes += decodedBytes
+	}
+	return nil
 }
 
 func (it *columnTypedColumnTimeOrderTopKIterator) evaluateCurrent(countMatchedRows bool) (string, bool, error) {

--- a/TreeDB/collections/typed_column_adapter.go
+++ b/TreeDB/collections/typed_column_adapter.go
@@ -1003,6 +1003,7 @@ type columnTypedColumnTimeOrderTopKPart struct {
 	Rows           int
 	Granules       []typedcolumn.GranuleDescriptor
 	Marks          []typedcolumn.SortKeyMark
+	PhysicalRows   []int
 	ValueColumn    typedcolumn.ColumnPartColumn
 	Group          columnTypedColumnTimeOrderCodeColumn
 	Predicates     []columnTypedColumnTimeOrderPredicateColumn
@@ -1016,7 +1017,7 @@ type columnTypedColumnTimeOrderTopKPart struct {
 // typed-column section fast path. It keeps the encoded per-granule payloads and
 // validates time_us sort-key marks, then the query runner decodes group and
 // predicate code granules only until the Top-K time threshold is closed.
-func decodeTypedColumnPhysicalQueryTimeOrderTopKPart(plan columnTypedColumnPhysicalQueryPlan, schemaHash uint64, typedRef, physical columnManifestAssetRefForScan, raw []byte) (columnTypedColumnPhysicalQueryPart, error) {
+func decodeTypedColumnPhysicalQueryTimeOrderTopKPart(plan columnTypedColumnPhysicalQueryPlan, schemaHash uint64, typedRef, physical columnManifestAssetRefForScan, raw []byte, includePhysicalRows bool) (columnTypedColumnPhysicalQueryPart, error) {
 	// Unlike the dense q1/q3/q5 decoders, the time-order runner keeps encoded
 	// granule payloads and decodes only the prefix needed by Top-K. The physical
 	// query prepare loop reuses its read scratch between parts, so take ownership
@@ -1098,6 +1099,15 @@ func decodeTypedColumnPhysicalQueryTimeOrderTopKPart(plan columnTypedColumnPhysi
 		})
 	}
 
+	var physicalRows []int
+	var primaryDiag columnTypedColumnPhysicalRowIndexDiagnostics
+	if includePhysicalRows {
+		physicalRows, primaryDiag, err = typedColumnPhysicalQueryPhysicalRows(adapterPart, nil, summary.Rows)
+		if err != nil {
+			return columnTypedColumnPhysicalQueryPart{}, err
+		}
+	}
+
 	return columnTypedColumnPhysicalQueryPart{
 		Ref:                 typedRef,
 		PhysicalRef:         physical,
@@ -1106,12 +1116,15 @@ func decodeTypedColumnPhysicalQueryTimeOrderTopKPart(plan columnTypedColumnPhysi
 		Sections:            summary.Sections,
 		SectionBytes:        summary.SectionBytes,
 		GranulesConsidered:  len(adapterPart.Part.Descriptor.Granules),
+		GranulesDecoded:     primaryDiag.GranulesDecoded,
+		DecodedBlocks:       primaryDiag.BlocksDecoded,
 		SortKeyMarkChecks:   len(adapterPart.Part.Marks),
-		DecodedPayloadBytes: 0,
+		DecodedPayloadBytes: uint64(primaryDiag.BytesDecoded),
 		TimeOrderTopK: &columnTypedColumnTimeOrderTopKPart{
 			Rows:           summary.Rows,
 			Granules:       append([]typedcolumn.GranuleDescriptor(nil), adapterPart.Part.Descriptor.Granules...),
 			Marks:          append([]typedcolumn.SortKeyMark(nil), adapterPart.Part.Marks...),
+			PhysicalRows:   physicalRows,
 			ValueColumn:    valuePartColumn,
 			Group:          group,
 			Predicates:     predicates,


### PR DESCRIPTION
## Summary

Implements #1953 C4 for q4a time-order TopK direct physical typed-column queries over mutation-bearing sorted typed-column parts.

- Routes q4a `TimeOrderTopK` into the latest-visible typed-column direct path when mutation parts exist.
- Decodes sorted-row → physical-row remapping only for latest-visible q4a direct execution, then checks latest-visible physical row identity before predicate/reduce/result emission.
- Uses a correctness-first k-way logical `time_us` merge that scans all non-tombstone mutation candidates (no unsafe mutation early-stop) while preserving insert-only q4a early-stop/prepared hot paths.
- Adds reopen/checkpoint mutation matrix coverage for updates that move rows earlier/later, predicate match/nonmatch changes, duplicate/tie timestamps, deletes/tombstones, prepared fail-closed behavior, and unsupported sort-key fail-closed diagnostics.

## Scope boundaries

Deferred/not included: C5 compaction/metadata rebuild, #1952 codecs, #1954 lifecycle/pinning/prepared mutation support. Prepared mutation-bearing physical queries still fail closed with insert-only/lifecycle wording.

## Tests

Latest head: `621c45d4a58cdb24dd9642ce9d5560605a360349`.

- `go test ./TreeDB/collections -run 'TestColumnPhysicalQ4ATimeOrderLatestVisibleMutationReopen1953|TestColumnPhysicalQ4ATimeOrderMutationUnsupportedSortKey1953|TestColumnPhysicalQ4ATimeOrderTopKDirectPreparedParity1950|TestColumnPhysicalQ2SortedLatestVisibleMutationReopen1953|TestColumnPhysicalQ4BTopKSortedLatestVisibleMutation1953|TestColumnPhysicalQ1DenseLatestVisibleMutation1953|TestColumnPhysicalQ3DenseLatestVisibleMutationReopen1953|TestColumnPhysicalQ5DenseLatestVisibleMutation1953|TestColumnPhysicalNonDenseNoPredicateMutationUsesTypedLatestVisible1953' -count=1` — PASS  
  Artifact: `/tmp/orca_issue_graph_1945_1955/1953_c4_focused_after_coderabbit_20260531_014343.txt`
- `go test ./TreeDB/collections -count=1` — PASS  
  Artifact: `/tmp/orca_issue_graph_1945_1955/1953_c4_collections_after_coderabbit_20260531_014350.txt`
- `go test ./TreeDB/... -count=1` — PASS  
  Artifact: `/tmp/orca_issue_graph_1945_1955/1953_c4_treedb_all_after_coderabbit_20260531_014435.txt`

## Benchmarks

Hardware: Apple M3 / darwin arm64. Smoke runs use `-benchtime=20x -count=1`.

### C4 q4a latest-visible benchmark

Command: `go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnPhysicalSortedLatestVisible1953/q4a_(insert_only|latest_visible)$' -benchtime=20x -count=1`  
Artifact: `/tmp/orca_issue_graph_1945_1955/1953_c4_bench_q4a_latest_visible_after_coderabbit_20260531_014639.txt`

| Case | ns/op | ops/sec | B/op | allocs/op | rows_scanned | rows_matched | reduce_rows | visibility_rows | deleted_rows | topk_candidates | time_order_topk_used |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| q4a_insert_only | 356,762 | 2,803 | 987,295 | 2,612 | 6 | 4 | 4 | 0 | 0 | 4 | 1 |
| q4a_latest_visible | 851,273 | 1,175 | 2,402,638 | 3,147 | 2,057 | 2,053 | 2,053 | 2,054 | 1 | 2,052 | 1 |

Latest-visible q4a intentionally scans all non-tombstone candidates to avoid unsafe early-stop across base/delta parts.

### Insert-only q4a hot-path regression smoke

Command on current head: `go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnPhysicalQ4ATimeOrderTopK1950/direct/time_order_early_stop$' -benchtime=20x -count=1`  
Artifact: `/tmp/orca_issue_graph_1945_1955/1953_c4_bench_current_q4a_insert_only_after_coderabbit_20260531_014648.txt`

Command on base `55709bdb`: same benchmark in base review worktree.  
Artifact: `/tmp/orca_issue_graph_1945_1955/1953_c4_bench_base_q4a_insert_only_20260531_012256.txt`

| Head | ns/op | ops/sec | B/op | allocs/op | rows_scanned | rows_matched | reduce_rows | topk_candidates |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| base 55709bdb | 2,444,200 | 409 | 6,586,638 | 18,801 | 6 | 4 | 4 | 4 |
| current 621c45d | 2,203,179 | 454 | 6,586,369 | 18,800 | 6 | 4 | 4 | 4 |

No insert-only q4a hot-path regression evident in this smoke run.

## Internal / AI review

- High-thinking Pi reviewer PASS, no blocking findings. Artifact: `/tmp/orca_issue_graph_1945_1955/1953_c4_reviewer_report_tail.txt`.
- CodeRabbit nit about deriving the test row-count expectation fixed in `621c45d`.
- Codex review requested; initial review on prior head found no major issues. Re-requested after `621c45d`.
- Copilot review requested/re-requested.

## Risks / notes

- Latest-visible q4a does not use mutation early-stop; this is deliberate for correctness until a globally safe proof/diagnostic exists.
- Prepared mutation-bearing q4a remains unsupported until #1954 lifecycle/pinning.
