### PR TITLE
[codex] treedb: mmap current value logs in fast profiles

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -6406,6 +6406,9 @@ type Options struct {
 	ForceValueLogPointers bool
 	// DisableReadChecksum skips CRC verification on value-log reads.
 	DisableReadChecksum bool
+	// ValueLogCurrentWritableMmap enables mmap-backed reads for current writable
+	// value-log segments.
+	ValueLogCurrentWritableMmap bool
 	// AllowUnsafe acknowledges unsafe durability options.
 	// When false, Open will reject DisableWAL or RelaxedSync.
 	AllowUnsafe bool
@@ -9326,6 +9329,7 @@ func Open(dir string, backend BackendDB, opts Options) (*DB, error) {
 		return nil, err
 	}
 	reader.SetDisableReadChecksum(opts.DisableReadChecksum)
+	reader.SetCurrentWritableMmapEnabled(opts.ValueLogCurrentWritableMmap)
 	valueLogReader := reader
 	debugFlushPointers := envBool(envDebugFlushPointers)
 	debugFlushTiming := envBool(envDebugFlushTiming)

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -561,6 +561,10 @@ type ValueLogOptions struct {
 
 	// ReadIntegrity configures checksum verification on value-log reads.
 	ReadIntegrity IntegrityMode
+	// CurrentWritableMmap enables mmap-backed reads for current writable
+	// value-log segments. This reduces random-read ReadAt syscall pressure at
+	// the cost of a larger mapped virtual-address window.
+	CurrentWritableMmap bool
 
 	// MaxRetainedBytes emits a warning when retained value-log bytes exceed this
 	// threshold (0 disables warnings). Cached mode only.
@@ -1405,6 +1409,7 @@ func openWithLock(opts Options, lock *lockfile.Lock) (*DB, error) {
 		return nil, err
 	}
 	vm.SetDisableReadChecksum(opts.ValueLog.ReadIntegrity == IntegritySkipChecksums)
+	vm.SetCurrentWritableMmapEnabled(opts.ValueLog.CurrentWritableMmap)
 	vm.SetDictLookup(opts.ValueLog.DictLookup)
 	vm.SetTemplateLookup(opts.ValueLog.TemplateLookup, opts.ValueLog.TemplateDecodeOptions)
 

--- a/TreeDB/db/open_readonly.go
+++ b/TreeDB/db/open_readonly.go
@@ -62,6 +62,7 @@ func openReadOnly(opts Options) (*DB, error) {
 		return nil, err
 	}
 	vm.SetDisableReadChecksum(opts.ValueLog.ReadIntegrity == IntegritySkipChecksums)
+	vm.SetCurrentWritableMmapEnabled(opts.ValueLog.CurrentWritableMmap)
 	vm.SetDictLookup(opts.ValueLog.DictLookup)
 	vm.SetTemplateLookup(opts.ValueLog.TemplateLookup, opts.ValueLog.TemplateDecodeOptions)
 
@@ -200,6 +201,7 @@ func openReadOnlyNoLock(opts Options) (*DB, error) {
 		return nil, err
 	}
 	vm.SetDisableReadChecksum(opts.ValueLog.ReadIntegrity == IntegritySkipChecksums)
+	vm.SetCurrentWritableMmapEnabled(opts.ValueLog.CurrentWritableMmap)
 	vm.SetDictLookup(opts.ValueLog.DictLookup)
 	vm.SetTemplateLookup(opts.ValueLog.TemplateLookup, opts.ValueLog.TemplateDecodeOptions)
 

--- a/TreeDB/internal/valuelog/manager.go
+++ b/TreeDB/internal/valuelog/manager.go
@@ -1180,6 +1180,7 @@ type Manager struct {
 	templateDefCache           *templateDefCache
 	groupedFrameCacheEntries   int
 	groupedFrameCacheMaxRaw    int
+	currentWritableMmap        atomic.Bool
 	currentWritableReadBarrier atomic.Value
 }
 
@@ -1201,6 +1202,15 @@ func (m *Manager) SetDisableReadChecksum(disable bool) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.disableReadChecksum = disable
+}
+
+// SetCurrentWritableMmapEnabled enables persistent read-only mmap views for
+// current writable value-log segments owned by this manager.
+func (m *Manager) SetCurrentWritableMmapEnabled(enabled bool) {
+	if m == nil {
+		return
+	}
+	m.currentWritableMmap.Store(enabled)
 }
 
 // SetCurrentWritableReadBarrier installs an optional callback that is invoked

--- a/TreeDB/internal/valuelog/mmap_safety_test.go
+++ b/TreeDB/internal/valuelog/mmap_safety_test.go
@@ -269,6 +269,72 @@ func TestCurrentWritableMmapTargetMapsAheadWithinLeafSegment(t *testing.T) {
 	}
 }
 
+func TestManagerCurrentWritableMmapOptionMapsNormalSegment(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("mmap not supported on windows")
+	}
+	prevCurrent := enableCurrentWritableMmap
+	prevLeaf := enableCurrentLeafWritableMmap
+	enableCurrentWritableMmap = false
+	enableCurrentLeafWritableMmap = false
+	withCurrentWritableMmapTargetBytes(t, 64<<10)
+	defer func() {
+		enableCurrentWritableMmap = prevCurrent
+		enableCurrentLeafWritableMmap = prevLeaf
+	}()
+
+	dir := t.TempDir()
+	fileID := mustEncodeFileID(t, 0, 1)
+	path := filepath.Join(dir, "value-l0-000001.log")
+	w, err := NewWriter(path, fileID)
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+
+	value := bytes.Repeat([]byte("n"), 1024)
+	ptr, err := w.Append(0, nil, 1, value)
+	if err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	if err := w.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+
+	mgr, err := NewManager(dir)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	defer func() { _ = mgr.Close() }()
+	mgr.SetCurrentWritableMmapEnabled(true)
+	if err := mgr.RegisterSegment(path, fileID); err != nil {
+		t.Fatalf("RegisterSegment: %v", err)
+	}
+	if err := mgr.PromoteCurrentWritable(fileID); err != nil {
+		t.Fatalf("PromoteCurrentWritable: %v", err)
+	}
+
+	got, err := mgr.ReadUnsafe(ptr)
+	if err != nil {
+		t.Fatalf("ReadUnsafe: %v", err)
+	}
+	if !bytes.Equal(got, value) {
+		t.Fatalf("read mismatch")
+	}
+
+	f, err := mgr.fileFor(fileID)
+	if err != nil {
+		t.Fatalf("fileFor: %v", err)
+	}
+	data, _ := f.mmapData.Load().([]byte)
+	if gotLen := len(data); gotLen < 64<<10 {
+		t.Fatalf("mapped length=%d, want at least target", gotLen)
+	}
+	if fallbacks := f.mmapReadFallbackReadAt.Load(); fallbacks != 0 {
+		t.Fatalf("manager current writable mmap should avoid ReadAt fallback, got=%d", fallbacks)
+	}
+}
+
 func TestCurrentWritableMmapTargetSizeMapsAheadAtBoundary(t *testing.T) {
 	withCurrentWritableMmapTargetBytes(t, 64)
 

--- a/TreeDB/internal/valuelog/reader_mmap.go
+++ b/TreeDB/internal/valuelog/reader_mmap.go
@@ -163,6 +163,9 @@ func (f *File) currentWritablePersistentMmapEnabled() bool {
 	if f == nil || !f.currentWritable.Load() {
 		return false
 	}
+	if f.manager != nil && f.manager.currentWritableMmap.Load() {
+		return true
+	}
 	if enableCurrentWritableMmap {
 		return true
 	}

--- a/TreeDB/profiles.go
+++ b/TreeDB/profiles.go
@@ -280,6 +280,7 @@ func applyFastProfile(opts *Options) {
 	if opts.ValueLog.DictProbeIntervalBytes == 0 {
 		opts.ValueLog.DictProbeIntervalBytes = 32 << 20
 	}
+	opts.ValueLog.CurrentWritableMmap = true
 
 	applyIndexOptimizationsProfile(opts)
 }
@@ -296,6 +297,7 @@ func applyWALOnFastProfile(opts *Options) {
 	if opts.ValueLog.DictProbeIntervalBytes == 0 {
 		opts.ValueLog.DictProbeIntervalBytes = 32 << 20
 	}
+	opts.ValueLog.CurrentWritableMmap = true
 
 	applyIndexOptimizationsProfile(opts)
 }

--- a/TreeDB/profiles_test.go
+++ b/TreeDB/profiles_test.go
@@ -49,6 +49,9 @@ func TestApplyProfile_FastSetsPolicyBools(t *testing.T) {
 	if opts.ValueLog.ForcePointers {
 		t.Fatalf("expected ValueLog.ForcePointers=false for fast profile")
 	}
+	if !opts.ValueLog.CurrentWritableMmap {
+		t.Fatalf("expected ValueLog.CurrentWritableMmap=true for fast profile")
+	}
 	if !opts.LeafPrefixCompression {
 		t.Fatalf("expected LeafPrefixCompression=true for fast profile")
 	}
@@ -105,6 +108,9 @@ func TestApplyProfile_WALOnFastKeepsWALOn(t *testing.T) {
 	}
 	if opts.ValueLog.ForcePointers {
 		t.Fatalf("expected ValueLog.ForcePointers=false for wal_on_fast profile")
+	}
+	if !opts.ValueLog.CurrentWritableMmap {
+		t.Fatalf("expected ValueLog.CurrentWritableMmap=true for wal_on_fast profile")
 	}
 	if !opts.LeafPrefixCompression {
 		t.Fatalf("expected LeafPrefixCompression=true for wal_on_fast profile")
@@ -172,6 +178,9 @@ func TestApplyProfile_CommandWALDurableSetsCommandWALAndFastDurablePolicy(t *tes
 	if !opts.IndexOuterLeavesInValueLog || !opts.LeafPrefixCompression || !opts.IndexColumnarLeaves || !opts.IndexPackedValuePtr {
 		t.Fatalf("expected command_wal_durable to keep the fast collection/index layout bundle: %+v", opts)
 	}
+	if !opts.ValueLog.CurrentWritableMmap {
+		t.Fatalf("expected command_wal_durable to keep fast value-log mmap policy")
+	}
 	if opts.IndexInternalBaseDelta {
 		t.Fatalf("expected IndexInternalBaseDelta=false for command_wal_durable profile")
 	}
@@ -192,6 +201,9 @@ func TestApplyProfile_CommandWALRelaxedSetsCommandWALAndRelaxedPolicy(t *testing
 	}
 	if !opts.IndexOuterLeavesInValueLog || !opts.LeafPrefixCompression || !opts.IndexColumnarLeaves || !opts.IndexPackedValuePtr {
 		t.Fatalf("expected command_wal_relaxed to keep the fast collection/index layout bundle: %+v", opts)
+	}
+	if !opts.ValueLog.CurrentWritableMmap {
+		t.Fatalf("expected command_wal_relaxed to keep fast value-log mmap policy")
 	}
 	if opts.IndexInternalBaseDelta {
 		t.Fatalf("expected IndexInternalBaseDelta=false for command_wal_relaxed profile")
@@ -240,6 +252,9 @@ func TestApplyProfile_BenchDisablesBackgroundDefaults(t *testing.T) {
 	if opts.ValueLog.ForcePointers {
 		t.Fatalf("expected ValueLog.ForcePointers=false for bench profile")
 	}
+	if !opts.ValueLog.CurrentWritableMmap {
+		t.Fatalf("expected ValueLog.CurrentWritableMmap=true for bench profile")
+	}
 	if !opts.LeafPrefixCompression {
 		t.Fatalf("expected LeafPrefixCompression=true for bench profile")
 	}
@@ -277,6 +292,9 @@ func TestApplyProfile_DurableKeepsIndexOptimizationsDisabled(t *testing.T) {
 	}
 	if opts.IndexInternalBaseDelta {
 		t.Fatalf("expected IndexInternalBaseDelta=false for durable profile")
+	}
+	if opts.ValueLog.CurrentWritableMmap {
+		t.Fatalf("expected ValueLog.CurrentWritableMmap=false for durable profile")
 	}
 }
 

--- a/TreeDB/public.go
+++ b/TreeDB/public.go
@@ -706,6 +706,7 @@ func Open(opts Options) (*DB, error) {
 		ValueLogRewriteTriggerChurnPerSec:        opts.ValueLog.Generational.RewriteTriggerChurnPerSec,
 		ValueLogRewriteMinSegmentAge:             opts.ValueLog.Generational.RewriteMinSegmentAge,
 		ForceValueLogPointers:                    opts.ValueLog.ForcePointers,
+		ValueLogCurrentWritableMmap:              opts.ValueLog.CurrentWritableMmap,
 		ValueLogDictTrain:                        opts.ValueLog.DictTrain,
 		ValueLogDictMaxK:                         opts.ValueLog.DictMaxK,
 		ValueLogDictClassMode:                    uint8(opts.ValueLog.DictClassMode),


### PR DESCRIPTION
## Objective

Enable mmap-backed reads for current writable value-log segments in the fast-family TreeDB profiles, so `treedb-native` YCSB random reads avoid falling back to `ReadAt` for almost every value-log lookup.

Links #2051.

## Context

After the nativewire catalog retry fixes and insert metadata read-lock slice, the remaining run-phase profile still showed value-log reads spending material time in `os.File.ReadAt` because normal value-log current segments were not persistently mapped unless `TREEDB_VLOG_ENABLE_CURRENT_WRITABLE_MMAP=1` was set. The existing mapped-ahead current-writable safety path was already used for leaf value logs; this PR makes it an explicit per-manager option and enables it through `fast`, `no_wal_fast`, `wal_on_fast`, `legacy_wal_relaxed_fast`, `bench`, and command-WAL fast-family profiles.

## Non-goals

- No on-disk format change.
- No change to durable-profile defaults.
- No change to value-log read/decode semantics, checksum policy, or current-writable read barriers.
- No nativewire protocol change.

## Design

- Adds `ValueLogOptions.CurrentWritableMmap` and wires it through backend DB open, read-only open, public cached open, and cached-layer value-log readers.
- Adds `valuelog.Manager.SetCurrentWritableMmapEnabled` so this is no longer only controlled by process-wide env.
- Keeps `TREEDB_VLOG_ENABLE_CURRENT_WRITABLE_MMAP` working as a process-wide override.
- Enables the option only in fast-family profiles. `durable` remains false.
- Existing mmap range checks still verify file size/read barriers before slicing mapped-ahead bytes.

## Scope

Includes:

- `TreeDB/db.ValueLogOptions.CurrentWritableMmap`
- `TreeDB/internal/valuelog.Manager.SetCurrentWritableMmapEnabled`
- profile defaults and profile tests
- backend/cached/open-readonly option wiring
- focused non-leaf current-writable mmap safety test

Excludes:

- YCSB client changes
- nativewire command/protocol changes
- value-log format or generation policy changes

## Correctness

Tests run:

```sh
git diff --check
go test ./TreeDB/internal/valuelog -run 'TestManagerCurrentWritableMmapOptionMapsNormalSegment|TestCurrentWritableMmapTarget|TestMmapSafety' -count=1
go test ./TreeDB -run 'TestApplyProfile' -count=1
go test ./TreeDB/nativewire ./cmd/treedb-native-server -count=1
go test ./TreeDB/collections -count=1
go test ./TreeDB/db ./TreeDB/caching ./TreeDB -count=1
```

Covered edge cases:

- Non-leaf current writable value-log segments can be mapped through the manager option while both global mmap env switches are false.
- Mapped-ahead current writable reads still do not read past the verified file size.
- Existing zero-copy remap safety tests continue to cover retained dead mappings.
- Profile tests verify fast-family profiles enable the option and durable does not.

## Performance

Host/context:

```text
host: mikers-B560-DS3H-AC-Y1
kernel: Linux 6.8.0-111-generic x86_64
cpu: 11th Gen Intel(R) Core(TM) i5-11400F @ 2.60GHz, 6 cores / 12 threads
server profile: fast
```

Benchmark commands:

```sh
./bin/treedb-native-server \
  -dir "$DB_DIR" \
  -profile fast \
  -addr 127.0.0.1:17123 \
  -pprof 127.0.0.1:18123

./bin/go-ycsb load treedb-native \
  -p treedb.addr=127.0.0.1:17123 \
  -p recordcount=100000 \
  -p operationcount=10000 \
  -p threadcount=16

./bin/go-ycsb run treedb-native \
  -p treedb.addr=127.0.0.1:17123 \
  -p recordcount=100000 \
  -p operationcount=1000000 \
  -p threadcount=16
```

Before/after:

| Build | Artifact | Load OPS | Run total OPS | Read avg | Read p99 | Update avg | Update p99 | Update max | Errors |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| `main` `bec15b17a` | `/tmp/treedb_ycsb_stats_1780229112` | `47352.2` | `90451.5` | `161us` | `517us` | `378us` | `978us` | `11759us` | `0` |
| this PR `48b8b6864` | `/tmp/treedb_ycsb_profile_mmap_1780230262` | `46833.5` | `97084.0` | `149us` | `466us` | `351us` | `871us` | `4599us` | `0` |

Value-log mmap counters:

| Build | Artifact | Workload | mmap hit ratio | hits | fallback `ReadAt` | miss no mapping |
| --- | --- | --- | ---: | ---: | ---: | ---: |
| `main` `bec15b17a` | `/tmp/treedb_ycsb_vlogstats_1780229216` | 200k run | `0.009884` | `1992` | `199554` | `199555` |
| this PR `48b8b6864` | `/tmp/treedb_ycsb_profile_mmap_1780230262` | 1M run | `0.999996` | `830552` | `3` | `4` |

CPU profile after:

- Artifact: `/tmp/treedb_ycsb_profile_mmap_1780230262/server_cpu.pprof`
- `valuelog.(*File).readViaMmapAppend`: `0.82s` cumulative in the 8s profile.
- `os.File.ReadAt` is no longer a top read-path cost in this run.
- Remaining dominant syscall cost is nativewire request/response socket I/O, which is a follow-up profiling target.

Regression assessment:

- Run throughput improved about 7.3% versus the fresh merged-main 1M baseline (`90.45k` to `97.08k` OPS).
- Read avg improved `161us` to `149us`; update avg improved `378us` to `351us`.
- Load throughput is within noise/slightly lower (`47.35k` to `46.83k` OPS); this PR changes read-side mmap behavior and does not target load.
- No YCSB load/run errors were observed.

## Rollout / Toggle Plan

Default setting:

- Enabled by fast-family profiles only.
- Durable profile remains disabled.

Disable quickly:

- Apply the profile, then set `opts.ValueLog.CurrentWritableMmap = false` before opening the DB.
- As before, the process-wide env flag can still force current-writable mmap on for experiments.

Observability:

- Existing `treedb.vlog.mmap_*` and `treedb.vlog.mmap_read.*` stats show active mapped bytes, hits, misses, and fallback `ReadAt` counts.

## Follow-ups

- Continue #2051 M4 profiling on nativewire socket write/read-frame syscall cost.
- Investigate load-phase collection mutation locking/insert planning separately if it remains material.

## AI Review Loop

- Codex latest-head review: not yet requested.
- Copilot latest-head review: not yet requested.
- CodeRabbit latest-head review: not yet requested.
- Review comments/threads resolved or explicitly dismissed: pending.
- Re-requested after final meaningful push: pending.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration option to control memory-mapped access for current writable value-log segments, providing enhanced performance tuning flexibility. Enabled by default in fast profiles.

* **Tests**
  * Added and extended test coverage for the new memory mapping configuration option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->