### PR TITLE
TreeDB: compact typed-column mutations

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -18974,6 +18974,7 @@ func getSystemValue(snap *backenddb.Snapshot, key string) ([]byte, bool, error) 
 type systemTargetEntry struct {
 	key   []byte
 	value []byte
+	flags byte
 }
 
 type systemTargetIterator struct {
@@ -19008,7 +19009,7 @@ func (it *systemTargetIterator) UnsafeKey() []byte {
 }
 
 func (it *systemTargetIterator) UnsafeValue() []byte {
-	if !it.Valid() {
+	if !it.Valid() || it.IsDeleted() {
 		return nil
 	}
 	return it.entries[it.idx].value
@@ -19018,7 +19019,15 @@ func (it *systemTargetIterator) UnsafeEntry() ([]byte, page.ValuePtr, byte) {
 	if !it.Valid() {
 		return nil, page.ValuePtr{}, node.FlagInline
 	}
-	return it.entries[it.idx].value, page.ValuePtr{}, node.FlagInline
+	entry := it.entries[it.idx]
+	if entry.flags&node.FlagTombstone != 0 {
+		return nil, page.ValuePtr{}, node.FlagTombstone
+	}
+	flags := entry.flags
+	if flags == 0 {
+		flags = node.FlagInline
+	}
+	return entry.value, page.ValuePtr{}, flags
 }
 
 func (it *systemTargetIterator) Key() []byte {
@@ -19037,14 +19046,14 @@ func (it *systemTargetIterator) KeyCopy(dst []byte) []byte {
 }
 
 func (it *systemTargetIterator) ValueCopy(dst []byte) []byte {
-	if !it.Valid() {
-		return dst
+	if !it.Valid() || it.IsDeleted() {
+		return dst[:0]
 	}
 	return append(dst, it.entries[it.idx].value...)
 }
 
 func (it *systemTargetIterator) IsDeleted() bool {
-	return false
+	return it.Valid() && it.entries[it.idx].flags&node.FlagTombstone != 0
 }
 
 func (it *systemTargetIterator) Error() error {

--- a/TreeDB/collections/column_physical_visibility.go
+++ b/TreeDB/collections/column_physical_visibility.go
@@ -374,6 +374,18 @@ func cloneColumnDeclaredValuesInto(out []columnDeclaredValue, values []columnDec
 	}
 	for i := range values {
 		out[i] = values[i]
+		if values[i].Float32Vector != nil {
+			out[i].Float32Vector = append([]float32(nil), values[i].Float32Vector...)
+		}
+		if values[i].Uint32List != nil {
+			out[i].Uint32List = append([]uint32(nil), values[i].Uint32List...)
+		}
+		if values[i].AdjacencyList != nil {
+			out[i].AdjacencyList = append([]uint32(nil), values[i].AdjacencyList...)
+		}
+		if values[i].Bytes != nil {
+			out[i].Bytes = append([]byte(nil), values[i].Bytes...)
+		}
 		if values[i].StringBytes != nil {
 			out[i].String = string(values[i].StringBytes)
 			out[i].StringBytes = nil

--- a/TreeDB/collections/column_publish_write.go
+++ b/TreeDB/collections/column_publish_write.go
@@ -498,7 +498,18 @@ func (c *Collection) prepareColumnPhysicalAssetsForCommand(input columnWritePubl
 	}
 }
 
-func (c *Collection) prepareColumnPhysicalAssetRowsForCommand(prepared ColumnPublishPreparedAssets, input columnWritePublishInput, hookInput ColumnPublishAssetPrepareInput, rows []columnDeclaredRow) (ColumnPublishPreparedAssets, error) {
+func (c *Collection) prepareColumnPhysicalAssetRowsForCommand(prepared ColumnPublishPreparedAssets, input columnWritePublishInput, hookInput ColumnPublishAssetPrepareInput, rows []columnDeclaredRow) (_ ColumnPublishPreparedAssets, retErr error) {
+	cleanupAssets := make([]ColumnPreparedAsset, 0, 8)
+	defer func() {
+		if retErr != nil && len(cleanupAssets) != 0 {
+			if cleanupErr := cleanupColumnPreparedAssets(c.db.ColumnAssetRootDir(), cleanupAssets); cleanupErr != nil {
+				retErr = errors.Join(retErr, cleanupErr)
+			}
+		}
+	}()
+	trackCleanupAsset := func(ref ColumnAssetRef) {
+		cleanupAssets = append(cleanupAssets, ColumnPreparedAsset{Ref: ref})
+	}
 	generation := uint64(1)
 	if hookInput.CurrentManifest != nil {
 		generation = hookInput.CurrentManifest.Generation + 1
@@ -527,6 +538,7 @@ func (c *Collection) prepareColumnPhysicalAssetRowsForCommand(prepared ColumnPub
 	if err != nil {
 		return ColumnPublishPreparedAssets{}, err
 	}
+	trackCleanupAsset(ref)
 	if err := validateColumnPhysicalAssetPreparedRefForManifest(ref, rowAssetConfig, generation, columnPhysicalRowAssetPartID, len(encoded)); err != nil {
 		return ColumnPublishPreparedAssets{}, err
 	}
@@ -558,6 +570,7 @@ func (c *Collection) prepareColumnPhysicalAssetRowsForCommand(prepared ColumnPub
 			if err != nil {
 				return ColumnPublishPreparedAssets{}, err
 			}
+			trackCleanupAsset(typedColumnRef)
 			if typedColumnRef.Namespace != hookInput.ColumnStore.AssetManager.Namespace || typedColumnRef.Kind != ColumnAssetKindTCS1TypedColumnPart ||
 				typedColumnRef.Generation != generation || typedColumnRef.PartID != typedColumnPartAssetPartID || typedColumnRef.Length != int64(len(typedColumnImage)) {
 				return ColumnPublishPreparedAssets{}, fmt.Errorf("collections: invalid typed-column part asset ref %+v", typedColumnRef)
@@ -592,6 +605,7 @@ func (c *Collection) prepareColumnPhysicalAssetRowsForCommand(prepared ColumnPub
 			if err != nil {
 				return ColumnPublishPreparedAssets{}, err
 			}
+			trackCleanupAsset(metadataRef)
 			if metadataRef.Namespace != hookInput.ColumnStore.AssetManager.Namespace || metadataRef.Kind != ColumnAssetKindTCS1AggregateMetadata ||
 				metadataRef.Generation != generation || metadataRef.PartID != typedColumnPartAssetPartID || metadataRef.Length != int64(len(encodedMetadata)) {
 				return ColumnPublishPreparedAssets{}, fmt.Errorf("collections: invalid typed-column aggregate metadata asset ref %+v", metadataRef)
@@ -618,6 +632,7 @@ func (c *Collection) prepareColumnPhysicalAssetRowsForCommand(prepared ColumnPub
 			if err != nil {
 				return ColumnPublishPreparedAssets{}, err
 			}
+			trackCleanupAsset(dictionaryRef)
 			if dictionaryRef.Namespace != hookInput.ColumnStore.AssetManager.Namespace || dictionaryRef.Kind != ColumnAssetKindTCS1DictionaryCodes ||
 				dictionaryRef.Generation != generation || dictionaryRef.PartID != columnPhysicalRowAssetPartID || dictionaryRef.Length != int64(len(encodedDictionary)) {
 				return ColumnPublishPreparedAssets{}, fmt.Errorf("collections: invalid dictionary codes asset ref %+v", dictionaryRef)
@@ -644,6 +659,7 @@ func (c *Collection) prepareColumnPhysicalAssetRowsForCommand(prepared ColumnPub
 			if err != nil {
 				return ColumnPublishPreparedAssets{}, err
 			}
+			trackCleanupAsset(valuesRef)
 			if valuesRef.Namespace != hookInput.ColumnStore.AssetManager.Namespace || valuesRef.Kind != ColumnAssetKindTCS1Int64Values ||
 				valuesRef.Generation != generation || valuesRef.PartID != columnPhysicalRowAssetPartID || valuesRef.Length != int64(len(encodedValues)) {
 				return ColumnPublishPreparedAssets{}, fmt.Errorf("collections: invalid int64 values asset ref %+v", valuesRef)
@@ -673,6 +689,7 @@ func (c *Collection) prepareColumnPhysicalAssetRowsForCommand(prepared ColumnPub
 			if err != nil {
 				return ColumnPublishPreparedAssets{}, err
 			}
+			trackCleanupAsset(metadataRef)
 			if metadataRef.Namespace != hookInput.ColumnStore.AssetManager.Namespace || metadataRef.Kind != ColumnAssetKindTCS1AggregateMetadata ||
 				metadataRef.Generation != generation || metadataRef.PartID != columnPhysicalRowAssetPartID || metadataRef.Length != int64(len(encodedMetadata)) {
 				return ColumnPublishPreparedAssets{}, fmt.Errorf("collections: invalid aggregate metadata asset ref %+v", metadataRef)
@@ -687,6 +704,7 @@ func (c *Collection) prepareColumnPhysicalAssetRowsForCommand(prepared ColumnPub
 			})
 		}
 	}
+	cleanupAssets = nil
 	return prepared, nil
 }
 

--- a/TreeDB/collections/column_store_compaction.go
+++ b/TreeDB/collections/column_store_compaction.go
@@ -403,8 +403,11 @@ func cleanupColumnPreparedAssets(rootDir string, assets []ColumnPreparedAsset) e
 		}
 	}
 	for _, target := range targets {
+		lock := columnAssetSegmentWriteLock(target.path)
+		lock.Lock()
 		info, err := os.Stat(target.path)
 		if err != nil {
+			lock.Unlock()
 			if os.IsNotExist(err) {
 				continue
 			}
@@ -412,6 +415,7 @@ func cleanupColumnPreparedAssets(rootDir string, assets []ColumnPreparedAsset) e
 			continue
 		}
 		if info.Size() != target.maxEnd {
+			lock.Unlock()
 			// Another writer appended to the shared segment after these assets were
 			// prepared. Leave the orphaned bytes for reachability/GC rather than
 			// truncating potentially live refs from the winning manifest.
@@ -420,12 +424,15 @@ func cleanupColumnPreparedAssets(rootDir string, assets []ColumnPreparedAsset) e
 		if target.remove {
 			if err := os.Remove(target.path); err != nil && !os.IsNotExist(err) {
 				cleanupErrs = append(cleanupErrs, err)
+				lock.Unlock()
 				continue
 			}
 		} else if err := os.Truncate(target.path, target.truncateTo); err != nil && !os.IsNotExist(err) {
 			cleanupErrs = append(cleanupErrs, err)
+			lock.Unlock()
 			continue
 		}
+		lock.Unlock()
 		if err := syncColumnAssetDir(filepath.Dir(target.path)); err != nil {
 			cleanupErrs = append(cleanupErrs, err)
 		}

--- a/TreeDB/collections/column_store_compaction.go
+++ b/TreeDB/collections/column_store_compaction.go
@@ -393,10 +393,6 @@ func cleanupColumnPreparedAssets(rootDir string, assets []ColumnPreparedAsset) e
 			target = &cleanupTarget{path: assetPath, truncateTo: ref.Offset, maxEnd: ref.Offset + ref.Length}
 			targets[assetPath] = target
 		}
-		if ref.FileID >= columnAssetDirectViewSegmentFileIDBase {
-			target.remove = true
-			continue
-		}
 		if ref.Offset < target.truncateTo {
 			target.truncateTo = ref.Offset
 		}

--- a/TreeDB/collections/column_store_compaction.go
+++ b/TreeDB/collections/column_store_compaction.go
@@ -372,6 +372,7 @@ func cleanupColumnPreparedAssets(rootDir string, assets []ColumnPreparedAsset) e
 	type cleanupTarget struct {
 		path       string
 		truncateTo int64
+		maxEnd     int64
 		remove     bool
 	}
 	targets := make(map[string]*cleanupTarget)
@@ -386,7 +387,7 @@ func cleanupColumnPreparedAssets(rootDir string, assets []ColumnPreparedAsset) e
 		}
 		target := targets[assetPath]
 		if target == nil {
-			target = &cleanupTarget{path: assetPath, truncateTo: ref.Offset}
+			target = &cleanupTarget{path: assetPath, truncateTo: ref.Offset, maxEnd: ref.Offset + ref.Length}
 			targets[assetPath] = target
 		}
 		if ref.FileID >= columnAssetDirectViewSegmentFileIDBase {
@@ -396,8 +397,24 @@ func cleanupColumnPreparedAssets(rootDir string, assets []ColumnPreparedAsset) e
 		if ref.Offset < target.truncateTo {
 			target.truncateTo = ref.Offset
 		}
+		if end := ref.Offset + ref.Length; end > target.maxEnd {
+			target.maxEnd = end
+		}
 	}
 	for _, target := range targets {
+		info, err := os.Stat(target.path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return err
+		}
+		if info.Size() != target.maxEnd {
+			// Another writer appended to the shared segment after these assets were
+			// prepared. Leave the orphaned bytes for reachability/GC rather than
+			// truncating potentially live refs from the winning manifest.
+			continue
+		}
 		if target.remove {
 			if err := os.Remove(target.path); err != nil && !os.IsNotExist(err) {
 				return err

--- a/TreeDB/collections/column_store_compaction.go
+++ b/TreeDB/collections/column_store_compaction.go
@@ -128,7 +128,7 @@ func (c *Collection) columnStoreCompact(ctx context.Context, opts ColumnStoreCom
 		return stats, err
 	}
 	cleanupPrepared := func(baseErr error) error {
-		if cleanupErr := cleanupColumnStoreCompactionPreparedAssets(c.db.ColumnAssetRootDir(), prepared.Assets); cleanupErr != nil {
+		if cleanupErr := cleanupColumnPreparedAssets(c.db.ColumnAssetRootDir(), prepared.Assets); cleanupErr != nil {
 			return errors.Join(baseErr, cleanupErr)
 		}
 		return baseErr
@@ -367,7 +367,7 @@ func columnStoreCompactionManifestRootStoragePolicy(state columnStoreCompactionS
 	return backendRootStoragePolicy(state.cfg.ManifestRoot.StoragePolicy)
 }
 
-func cleanupColumnStoreCompactionPreparedAssets(rootDir string, assets []ColumnPreparedAsset) error {
+func cleanupColumnPreparedAssets(rootDir string, assets []ColumnPreparedAsset) error {
 	type cleanupTarget struct {
 		path       string
 		truncateTo int64

--- a/TreeDB/collections/column_store_compaction.go
+++ b/TreeDB/collections/column_store_compaction.go
@@ -125,6 +125,9 @@ func (c *Collection) columnStoreCompact(ctx context.Context, opts ColumnStoreCom
 	if err != nil {
 		return stats, err
 	}
+	if err := ctx.Err(); err != nil {
+		return stats, err
+	}
 	stats.AssetsPublished = len(prepared.Assets)
 	stats.AggregateMetadataPublished = columnStoreCompactionAggregateMetadataAssets(prepared.Assets)
 	stats.PublishedRefs = columnStoreCompactionPreparedRefs(prepared.Assets)
@@ -149,6 +152,9 @@ func (c *Collection) columnStoreCompact(ctx context.Context, opts ColumnStoreCom
 	}
 	policy, err := columnStoreCompactionManifestRootStoragePolicy(state)
 	if err != nil {
+		return stats, err
+	}
+	if err := ctx.Err(); err != nil {
 		return stats, err
 	}
 	identityRecord := encodeColumnManifestIdentityRecordArray(manifest.Identity)
@@ -346,7 +352,7 @@ func columnStoreCompactionUpdatedMeta(base CollectionMeta, identity ColumnManife
 
 func columnStoreCompactionManifestRootStoragePolicy(state columnStoreCompactionState) (backenddb.OrderedRootStoragePolicy, error) {
 	if state.cfg.ManifestRoot == nil {
-		return backenddb.OrderedRootStorageDefault, errors.New("collections: column store compaction requires manifest root descriptor")
+		return backenddb.OrderedRootStorageDefault, nil
 	}
 	return backendRootStoragePolicy(state.cfg.ManifestRoot.StoragePolicy)
 }

--- a/TreeDB/collections/column_store_compaction.go
+++ b/TreeDB/collections/column_store_compaction.go
@@ -115,7 +115,7 @@ func (c *Collection) columnStoreCompact(ctx context.Context, opts ColumnStoreCom
 	if visibilityDiag.MutationParts == 0 && state.cfg.PhysicalMutationParts == 0 {
 		return stats, nil
 	}
-	stats.SupersededRefs = columnStoreCompactionRefsFromManifestRecords(state.records)
+	supersededRefs := columnStoreCompactionRefsFromManifestRecords(state.records)
 	if state.cfg.RecoveryAuthoritativeAppliedCommandLSN == 0 {
 		return stats, errors.New("collections: column store compaction requires recovery-authoritative AppliedCommandLSN")
 	}
@@ -190,6 +190,7 @@ func (c *Collection) columnStoreCompact(ctx context.Context, opts ColumnStoreCom
 	stats.AssetsPublished = len(prepared.Assets)
 	stats.AggregateMetadataPublished = columnStoreCompactionAggregateMetadataAssets(prepared.Assets)
 	stats.PublishedRefs = columnStoreCompactionPreparedRefs(prepared.Assets)
+	stats.SupersededRefs = supersededRefs
 	stats.Compacted = true
 	stats.ManifestRoot = rootIDs[0]
 	stats.SystemRoot = newSystemRoot

--- a/TreeDB/collections/column_store_compaction.go
+++ b/TreeDB/collections/column_store_compaction.go
@@ -110,11 +110,11 @@ func (c *Collection) columnStoreCompact(ctx context.Context, opts ColumnStoreCom
 	stats.MutationPartsBefore = visibilityDiag.MutationParts
 	stats.RowsScanned = visibilityDiag.RowsScanned
 	stats.DeletedRows = visibilityDiag.DeletedRows
-	stats.RowsCompacted = len(rows)
 	stats.PhysicalBytesRead = visibilityDiag.PhysicalBytesScanned
 	if visibilityDiag.MutationParts == 0 && state.cfg.PhysicalMutationParts == 0 {
 		return stats, nil
 	}
+	stats.RowsCompacted = len(rows)
 	supersededRefs := columnStoreCompactionRefsFromManifestRecords(state.records)
 	if err := ctx.Err(); err != nil {
 		return stats, err
@@ -122,6 +122,9 @@ func (c *Collection) columnStoreCompact(ctx context.Context, opts ColumnStoreCom
 
 	prepared, err := c.prepareColumnStoreCompactionAssets(state, rows)
 	if err != nil {
+		if cleanupErr := cleanupColumnPreparedAssets(c.db.ColumnAssetRootDir(), prepared.Assets); cleanupErr != nil {
+			return stats, errors.Join(err, cleanupErr)
+		}
 		return stats, err
 	}
 	cleanupPrepared := func(baseErr error) error {

--- a/TreeDB/collections/column_store_compaction.go
+++ b/TreeDB/collections/column_store_compaction.go
@@ -376,6 +376,7 @@ func cleanupColumnPreparedAssets(rootDir string, assets []ColumnPreparedAsset) e
 		remove     bool
 	}
 	targets := make(map[string]*cleanupTarget)
+	var cleanupErrs []error
 	for _, asset := range assets {
 		ref := asset.Ref
 		if ref.Namespace == "" || ref.FileID == 0 {
@@ -407,7 +408,8 @@ func cleanupColumnPreparedAssets(rootDir string, assets []ColumnPreparedAsset) e
 			if os.IsNotExist(err) {
 				continue
 			}
-			return err
+			cleanupErrs = append(cleanupErrs, err)
+			continue
 		}
 		if info.Size() != target.maxEnd {
 			// Another writer appended to the shared segment after these assets were
@@ -417,16 +419,18 @@ func cleanupColumnPreparedAssets(rootDir string, assets []ColumnPreparedAsset) e
 		}
 		if target.remove {
 			if err := os.Remove(target.path); err != nil && !os.IsNotExist(err) {
-				return err
+				cleanupErrs = append(cleanupErrs, err)
+				continue
 			}
 		} else if err := os.Truncate(target.path, target.truncateTo); err != nil && !os.IsNotExist(err) {
-			return err
+			cleanupErrs = append(cleanupErrs, err)
+			continue
 		}
 		if err := syncColumnAssetDir(filepath.Dir(target.path)); err != nil {
-			return err
+			cleanupErrs = append(cleanupErrs, err)
 		}
 	}
-	return nil
+	return errors.Join(cleanupErrs...)
 }
 
 func (c *Collection) columnStoreCompactionRootDescriptorPreflight(state columnStoreCompactionState, rootNames []string, baseRootIDs map[string]uint64) backenddb.OrderedRootGroupPreflight {

--- a/TreeDB/collections/column_store_compaction.go
+++ b/TreeDB/collections/column_store_compaction.go
@@ -1,0 +1,429 @@
+package collections
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/internal/iterator"
+	"github.com/snissn/gomap/TreeDB/internal/storagemaintenance"
+	"github.com/snissn/gomap/TreeDB/node"
+)
+
+// ColumnStoreCompactOptions controls logical column-store compaction.
+type ColumnStoreCompactOptions struct {
+	// ReadIntegrity controls validation while reading existing column assets to
+	// materialize the latest-visible row set. The zero value uses the default
+	// column-asset read policy.
+	ReadIntegrity ColumnAssetReadIntegrity
+}
+
+// ColumnStoreCompactStats summarizes a logical column-store compaction.
+type ColumnStoreCompactStats struct {
+	Compacted bool
+
+	PreviousGeneration uint64
+	NewGeneration      uint64
+	ManifestRoot       uint64
+	SystemRoot         uint64
+
+	ManifestRecordsBefore int
+	ManifestRecordsAfter  int
+	MutationPartsBefore   int
+	MutationPartsAfter    int
+
+	RowsScanned       int
+	DeletedRows       int
+	RowsCompacted     int
+	PhysicalBytesRead int64
+
+	AssetsPublished            int
+	AggregateMetadataPublished int
+	PublishedRefs              []ColumnAssetRef
+	SupersededRefs             []ColumnAssetRef
+}
+
+type columnStoreCompactionState struct {
+	snap           *backenddb.Snapshot
+	catalog        *collectionCatalog
+	meta           CollectionMeta
+	cfg            ColumnStoreConfig
+	rootName       string
+	baseRoot       uint64
+	baseCommitSeq  uint64
+	baseSystemRoot uint64
+	manifest       columnManifestSnapshot
+	records        []columnManifestRecord
+}
+
+// ColumnStoreCompact collapses the current mutation-bearing column manifest
+// lineage into one insert-only generation containing exactly latest-visible live
+// rows. It rewrites only column assets/manifest metadata; primary document and
+// index roots are unchanged.
+func (c *Collection) ColumnStoreCompact(ctx context.Context, opts ColumnStoreCompactOptions) (ColumnStoreCompactStats, error) {
+	var stats ColumnStoreCompactStats
+	if c == nil {
+		return stats, errCollectionNil
+	}
+	if c.db == nil {
+		return stats, errCollectionDBNil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return stats, err
+	}
+	if err := c.db.CheckStorageMaintenanceReady(); err != nil {
+		return stats, err
+	}
+	unlock := c.lockMutation()
+	defer unlock.Unlock()
+	return c.columnStoreCompact(ctx, opts)
+}
+
+func (c *Collection) columnStoreCompact(ctx context.Context, opts ColumnStoreCompactOptions) (ColumnStoreCompactStats, error) {
+	state, closeState, err := c.loadColumnStoreCompactionState(ctx)
+	if closeState != nil {
+		defer closeState()
+	}
+	stats := ColumnStoreCompactStats{}
+	if err != nil {
+		return stats, err
+	}
+	stats.PreviousGeneration = state.manifest.Generation
+	stats.ManifestRecordsBefore = len(state.records)
+
+	if err := columnStoreCompactionRejectUnsupportedManifestRecords(state.records); err != nil {
+		return stats, err
+	}
+
+	rows, visibilityDiag, err := c.materializeColumnStoreCompactionRows(ctx, state, opts.ReadIntegrity)
+	if err != nil {
+		return stats, err
+	}
+	stats.MutationPartsBefore = visibilityDiag.MutationParts
+	stats.RowsScanned = visibilityDiag.RowsScanned
+	stats.DeletedRows = visibilityDiag.DeletedRows
+	stats.RowsCompacted = len(rows)
+	stats.PhysicalBytesRead = visibilityDiag.PhysicalBytesScanned
+	if visibilityDiag.MutationParts == 0 && state.cfg.PhysicalMutationParts == 0 {
+		return stats, nil
+	}
+	stats.SupersededRefs = columnStoreCompactionRefsFromManifestRecords(state.records)
+	if state.cfg.RecoveryAuthoritativeAppliedCommandLSN == 0 {
+		return stats, errors.New("collections: column store compaction requires recovery-authoritative AppliedCommandLSN")
+	}
+	if err := ctx.Err(); err != nil {
+		return stats, err
+	}
+
+	prepared, err := c.prepareColumnStoreCompactionAssets(state, rows)
+	if err != nil {
+		return stats, err
+	}
+	stats.AssetsPublished = len(prepared.Assets)
+	stats.AggregateMetadataPublished = columnStoreCompactionAggregateMetadataAssets(prepared.Assets)
+	stats.PublishedRefs = columnStoreCompactionPreparedRefs(prepared.Assets)
+
+	manifest, err := encodeColumnManifestForWrite(ColumnPublishManifestEncodeInput{
+		Collection:        state.meta.Name,
+		ColumnStore:       state.cfg,
+		Operation:         ColumnPublishOperationInsert,
+		AppliedCommandLSN: state.cfg.RecoveryAuthoritativeAppliedCommandLSN,
+		CurrentManifest:   state.cfg.ActiveManifest,
+		Prepared:          prepared,
+	})
+	if err != nil {
+		return stats, fmt.Errorf("collections: column store compaction manifest encode failed: %w", err)
+	}
+	stats.NewGeneration = manifest.Identity.Generation
+	stats.ManifestRecordsAfter = len(manifest.Records)
+
+	updatedMeta, err := columnStoreCompactionUpdatedMeta(state.meta, manifest.Identity)
+	if err != nil {
+		return stats, err
+	}
+	policy, err := columnStoreCompactionManifestRootStoragePolicy(state)
+	if err != nil {
+		return stats, err
+	}
+	identityRecord := encodeColumnManifestIdentityRecordArray(manifest.Identity)
+	deltaIter := columnStoreCompactionManifestDeltaIterator(identityRecord, state.records, manifest.Records)
+	rootNames := []string{state.rootName}
+	baseRootIDs := map[string]uint64{state.rootName: state.baseRoot}
+	preflight := c.columnStoreCompactionRootDescriptorPreflight(state, rootNames, baseRootIDs)
+	newSystemRoot, rootIDs, err := c.db.PublishOrderedRootDeltaGroupWithPreflightMaintenanceSystemDeltaBuilder(
+		storagemaintenance.ColumnAssetRewritePlan(),
+		[]backenddb.StorageMaintenanceRootDeltaPublishInput{{
+			BaseRoot:      state.baseRoot,
+			Iter:          deltaIter,
+			StoragePolicy: policy,
+		}},
+		preflight,
+		func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+			return c.buildColumnAssetRewriteSystemDeltaIteratorForMeta(state.meta, updatedMeta, state.baseCommitSeq, state.baseSystemRoot, rootNames, baseRootIDs, rootIDs)
+		},
+	)
+	if err != nil {
+		return stats, err
+	}
+	if len(rootIDs) != 1 || rootIDs[0] == 0 {
+		return stats, unexpectedOrderedRootCountError(state.meta.Name, 1, len(rootIDs))
+	}
+	stats.Compacted = true
+	stats.ManifestRoot = rootIDs[0]
+	stats.SystemRoot = newSystemRoot
+	stats.MutationPartsAfter = 0
+	nextCatalog := cloneCatalogWithRootUpdates(state.catalog, updatedMeta, rootNames, rootIDs)
+	c.meta = updatedMeta
+	c.rememberCatalogAtSystemRoot(newSystemRoot, nextCatalog)
+	c.noteWriteDomainCatalog(newSystemRoot, nextCatalog)
+	return stats, nil
+}
+
+func (c *Collection) loadColumnStoreCompactionState(ctx context.Context) (columnStoreCompactionState, func(), error) {
+	if err := ctx.Err(); err != nil {
+		return columnStoreCompactionState{}, nil, err
+	}
+	snap := c.db.AcquireSnapshot()
+	if snap == nil {
+		return columnStoreCompactionState{}, nil, backenddb.ErrClosed
+	}
+	closeState := func() { _ = snap.Close() }
+	catalog, err := loadCollectionCatalog(snap, c.meta.Name)
+	if err != nil {
+		closeState()
+		return columnStoreCompactionState{}, nil, err
+	}
+	if catalog == nil {
+		closeState()
+		return columnStoreCompactionState{}, nil, errCollectionNotFound
+	}
+	meta := catalog.meta
+	if meta.Options.ColumnStore == nil || !meta.Options.ColumnStore.Enabled {
+		closeState()
+		return columnStoreCompactionState{}, nil, errors.New("collections: column store compaction requires enabled column_store")
+	}
+	cfg := meta.Options.ColumnStore.copy()
+	if cfg.ActiveManifest == nil {
+		closeState()
+		return columnStoreCompactionState{}, nil, errors.New("collections: column store compaction requires active column manifest")
+	}
+	if cfg.RecoveryAuthoritativeManifest == nil {
+		closeState()
+		return columnStoreCompactionState{}, nil, errors.New("collections: column store compaction requires recovery-authoritative column manifest")
+	}
+	if !columnManifestIdentityValueEqual(*cfg.ActiveManifest, *cfg.RecoveryAuthoritativeManifest) {
+		closeState()
+		return columnStoreCompactionState{}, nil, errors.New("collections: column store compaction requires active recovery-authoritative manifest")
+	}
+	if cfg.AssetManager == nil {
+		closeState()
+		return columnStoreCompactionState{}, nil, errors.New("collections: column store compaction requires column asset manager metadata")
+	}
+	rootName := collectionColumnManifestRootName(meta.Name)
+	if cfg.ManifestRoot != nil && cfg.ManifestRoot.Name != "" {
+		rootName = cfg.ManifestRoot.Name
+	}
+	baseRoot := catalog.rootID(rootName)
+	if baseRoot == 0 {
+		closeState()
+		return columnStoreCompactionState{}, nil, fmt.Errorf("collections: column store compaction missing manifest root %q", rootName)
+	}
+	if err := validateColumnManifestIdentityAtRoot(snap, baseRoot, *cfg.ActiveManifest); err != nil {
+		closeState()
+		return columnStoreCompactionState{}, nil, err
+	}
+	records, err := loadColumnManifestRecordsFromRoot(snap, baseRoot)
+	if err != nil {
+		closeState()
+		return columnStoreCompactionState{}, nil, err
+	}
+	manifest, err := decodeColumnManifestSnapshotForScan(records)
+	if err != nil {
+		closeState()
+		return columnStoreCompactionState{}, nil, err
+	}
+	if err := validateColumnManifestSnapshot(manifest, records, cfg, *cfg.ActiveManifest, meta.Name, "column store compaction"); err != nil {
+		closeState()
+		return columnStoreCompactionState{}, nil, err
+	}
+	return columnStoreCompactionState{
+		snap:           snap,
+		catalog:        catalog,
+		meta:           meta,
+		cfg:            cfg,
+		rootName:       rootName,
+		baseRoot:       baseRoot,
+		baseCommitSeq:  snapshotCommitSeq(snap),
+		baseSystemRoot: snapshotSystemRoot(snap),
+		manifest:       manifest,
+		records:        records,
+	}, closeState, nil
+}
+
+func (c *Collection) materializeColumnStoreCompactionRows(ctx context.Context, state columnStoreCompactionState, readIntegrity ColumnAssetReadIntegrity) ([]columnDeclaredRow, columnPhysicalScanDiagnostics, error) {
+	visible, err := c.scanColumnPhysicalVisibleRowsAtSnapshotWithReadIntegrity(state.snap, state.catalog, state.meta.Name, state.baseRoot, state.cfg, true, nil, readIntegrity)
+	if err != nil {
+		return nil, visible.Diagnostics, err
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, visible.Diagnostics, err
+	}
+	readCache, err := newColumnPhysicalAssetReadCacheWithIntegrity(c.db.ColumnAssetRootDir(), state.cfg.AssetManager.Namespace, readIntegrity)
+	if err != nil {
+		return nil, visible.Diagnostics, err
+	}
+	defer func() { _ = readCache.close() }()
+	typedCache := typedColumnPartReconstructionCache{ReadCache: &readCache}
+	rows := make([]columnDeclaredRow, 0, len(visible.Rows))
+	var typedScratch []columnDeclaredValue
+	var fullScratch []columnDeclaredValue
+	for _, row := range visible.Rows {
+		if err := ctx.Err(); err != nil {
+			return nil, visible.Diagnostics, err
+		}
+		if row.Deleted {
+			continue
+		}
+		typedValues, err := c.typedColumnPartValuesForVisibleRowAtSnapshotIntoWithCache(state.snap, state.baseRoot, state.cfg, row, &typedCache, typedScratch)
+		if err != nil {
+			return nil, visible.Diagnostics, err
+		}
+		typedScratch = typedValues.Values
+		fullValues, err := mergeColumnReconstructionValuesInto(state.cfg, row.Values, typedValues.Values, fullScratch)
+		if err != nil {
+			return nil, visible.Diagnostics, err
+		}
+		fullScratch = fullValues
+		rows = append(rows, columnDeclaredRow{
+			ID:     bytes.Clone(row.ID),
+			Values: cloneColumnDeclaredValues(fullValues),
+		})
+	}
+	return rows, visible.Diagnostics, nil
+}
+
+func (c *Collection) prepareColumnStoreCompactionAssets(state columnStoreCompactionState, rows []columnDeclaredRow) (ColumnPublishPreparedAssets, error) {
+	prepared := ColumnPublishPreparedAssets{RowCount: len(rows)}
+	if len(rows) == 0 {
+		return prepared, nil
+	}
+	input := columnWritePublishInput{
+		meta:              state.meta,
+		operation:         ColumnPublishOperationInsert,
+		rows:              len(rows),
+		declaredRows:      rows,
+		declaredRowsReady: true,
+	}
+	return c.prepareColumnPhysicalAssetRowsForCommand(prepared, input, ColumnPublishAssetPrepareInput{
+		Collection:        state.meta.Name,
+		ColumnStore:       state.cfg,
+		Operation:         ColumnPublishOperationInsert,
+		AppliedCommandLSN: state.cfg.RecoveryAuthoritativeAppliedCommandLSN,
+		CurrentManifest:   state.cfg.ActiveManifest,
+	}, rows)
+}
+
+func columnStoreCompactionUpdatedMeta(base CollectionMeta, identity ColumnManifestIdentity) (CollectionMeta, error) {
+	if base.Options.ColumnStore == nil || !base.Options.ColumnStore.Enabled {
+		return CollectionMeta{}, errors.New("collections: column store compaction requires enabled column_store")
+	}
+	updated := copyCollectionMeta(base)
+	cfg := updated.Options.ColumnStore.copy()
+	active := identity
+	recovery := identity
+	cfg.ActiveManifest = &active
+	cfg.RecoveryAuthoritativeManifest = &recovery
+	cfg.PhysicalMutationParts = 0
+	updated.Options.ColumnStore = &cfg
+	return normalizeCollectionMeta(updated)
+}
+
+func columnStoreCompactionManifestRootStoragePolicy(state columnStoreCompactionState) (backenddb.OrderedRootStoragePolicy, error) {
+	if state.cfg.ManifestRoot == nil {
+		return backenddb.OrderedRootStorageDefault, errors.New("collections: column store compaction requires manifest root descriptor")
+	}
+	return backendRootStoragePolicy(state.cfg.ManifestRoot.StoragePolicy)
+}
+
+func (c *Collection) columnStoreCompactionRootDescriptorPreflight(state columnStoreCompactionState, rootNames []string, baseRootIDs map[string]uint64) backenddb.OrderedRootGroupPreflight {
+	return func() error {
+		if err := c.validateRootDescriptorSystemDeltaForMeta(state.meta, state.baseCommitSeq, state.baseSystemRoot, rootNames, baseRootIDs); err != nil {
+			return errors.Join(errColumnAssetRewritePublishPreflightFailed, err)
+		}
+		return nil
+	}
+}
+
+func columnStoreCompactionManifestDeltaIterator(identityRecord [columnManifestIdentityRecordSize]byte, oldRecords, newRecords []columnManifestRecord) *systemTargetIterator {
+	entries := make([]systemTargetEntry, 0, 1+len(newRecords)+len(oldRecords))
+	identityValue := make([]byte, len(identityRecord))
+	copy(identityValue, identityRecord[:])
+	entries = append(entries, systemTargetEntry{key: newColumnManifestIdentityRecordKey(), value: identityValue})
+	newKeys := make(map[string]struct{}, len(newRecords))
+	for _, record := range newRecords {
+		newKeys[string(record.key)] = struct{}{}
+		entries = append(entries, systemTargetEntry{key: bytes.Clone(record.key), value: bytes.Clone(record.value)})
+	}
+	for _, record := range oldRecords {
+		if _, keep := newKeys[string(record.key)]; keep {
+			continue
+		}
+		entries = append(entries, systemTargetEntry{key: bytes.Clone(record.key), flags: node.FlagTombstone})
+	}
+	sort.Slice(entries, func(i, j int) bool { return bytes.Compare(entries[i].key, entries[j].key) < 0 })
+	return &systemTargetIterator{entries: entries}
+}
+
+func columnStoreCompactionRejectUnsupportedManifestRecords(records []columnManifestRecord) error {
+	for _, record := range records {
+		if bytes.HasPrefix(record.key, columnManifestVectorGraphRecordPrefixBytes) || bytes.HasPrefix(record.key, columnVectorIndexStateRecordPrefixBytes) {
+			return fmt.Errorf("%w: column store compaction with vector graph/index state records is not supported in C5", ErrColumnQueryPlanUnsupported)
+		}
+	}
+	return nil
+}
+
+func columnStoreCompactionRefsFromManifestRecords(records []columnManifestRecord) []ColumnAssetRef {
+	refs := make([]ColumnAssetRef, 0, len(records))
+	for _, record := range records {
+		if !bytes.HasPrefix(record.key, columnManifestPartRecordPrefixBytes) &&
+			!bytes.HasPrefix(record.key, columnManifestAggregateMetadataRecordPrefixBytes) &&
+			!bytes.HasPrefix(record.key, columnManifestDictionaryCodesRecordPrefixBytes) &&
+			!bytes.HasPrefix(record.key, columnManifestInt64ValuesRecordPrefixBytes) {
+			continue
+		}
+		part, err := decodeColumnManifestPartRecord(record.value)
+		if err != nil {
+			continue
+		}
+		refs = append(refs, part.AssetRef)
+	}
+	return refs
+}
+
+func columnStoreCompactionPreparedRefs(assets []ColumnPreparedAsset) []ColumnAssetRef {
+	if len(assets) == 0 {
+		return nil
+	}
+	refs := make([]ColumnAssetRef, len(assets))
+	for i, asset := range assets {
+		refs[i] = asset.Ref
+	}
+	return refs
+}
+
+func columnStoreCompactionAggregateMetadataAssets(assets []ColumnPreparedAsset) int {
+	count := 0
+	for _, asset := range assets {
+		if asset.Ref.Kind == ColumnAssetKindTCS1AggregateMetadata {
+			count++
+		}
+	}
+	return count
+}

--- a/TreeDB/collections/column_store_compaction.go
+++ b/TreeDB/collections/column_store_compaction.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"sort"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
@@ -125,8 +127,14 @@ func (c *Collection) columnStoreCompact(ctx context.Context, opts ColumnStoreCom
 	if err != nil {
 		return stats, err
 	}
+	cleanupPrepared := func(baseErr error) error {
+		if cleanupErr := cleanupColumnStoreCompactionPreparedAssets(c.db.ColumnAssetRootDir(), prepared.Assets); cleanupErr != nil {
+			return errors.Join(baseErr, cleanupErr)
+		}
+		return baseErr
+	}
 	if err := ctx.Err(); err != nil {
-		return stats, err
+		return stats, cleanupPrepared(err)
 	}
 	manifest, err := encodeColumnManifestForWrite(ColumnPublishManifestEncodeInput{
 		Collection:        state.meta.Name,
@@ -137,21 +145,21 @@ func (c *Collection) columnStoreCompact(ctx context.Context, opts ColumnStoreCom
 		Prepared:          prepared,
 	})
 	if err != nil {
-		return stats, fmt.Errorf("collections: column store compaction manifest encode failed: %w", err)
+		return stats, cleanupPrepared(fmt.Errorf("collections: column store compaction manifest encode failed: %w", err))
 	}
 	stats.NewGeneration = manifest.Identity.Generation
 	stats.ManifestRecordsAfter = len(manifest.Records)
 
 	updatedMeta, err := columnStoreCompactionUpdatedMeta(state.meta, manifest.Identity)
 	if err != nil {
-		return stats, err
+		return stats, cleanupPrepared(err)
 	}
 	policy, err := columnStoreCompactionManifestRootStoragePolicy(state)
 	if err != nil {
-		return stats, err
+		return stats, cleanupPrepared(err)
 	}
 	if err := ctx.Err(); err != nil {
-		return stats, err
+		return stats, cleanupPrepared(err)
 	}
 	identityRecord := encodeColumnManifestIdentityRecordArray(manifest.Identity)
 	deltaIter := columnStoreCompactionManifestDeltaIterator(identityRecord, state.records, manifest.Records)
@@ -171,6 +179,9 @@ func (c *Collection) columnStoreCompact(ctx context.Context, opts ColumnStoreCom
 		},
 	)
 	if err != nil {
+		if columnAssetRewritePublishFailedBeforeApply(err) {
+			return stats, cleanupPrepared(err)
+		}
 		return stats, err
 	}
 	if len(rootIDs) != 1 || rootIDs[0] == 0 {
@@ -354,6 +365,50 @@ func columnStoreCompactionManifestRootStoragePolicy(state columnStoreCompactionS
 		return backenddb.OrderedRootStorageDefault, nil
 	}
 	return backendRootStoragePolicy(state.cfg.ManifestRoot.StoragePolicy)
+}
+
+func cleanupColumnStoreCompactionPreparedAssets(rootDir string, assets []ColumnPreparedAsset) error {
+	type cleanupTarget struct {
+		path       string
+		truncateTo int64
+		remove     bool
+	}
+	targets := make(map[string]*cleanupTarget)
+	for _, asset := range assets {
+		ref := asset.Ref
+		if ref.Namespace == "" || ref.FileID == 0 {
+			continue
+		}
+		assetPath, err := columnAssetSegmentPath(rootDir, ref)
+		if err != nil {
+			return err
+		}
+		target := targets[assetPath]
+		if target == nil {
+			target = &cleanupTarget{path: assetPath, truncateTo: ref.Offset}
+			targets[assetPath] = target
+		}
+		if ref.FileID >= columnAssetDirectViewSegmentFileIDBase {
+			target.remove = true
+			continue
+		}
+		if ref.Offset < target.truncateTo {
+			target.truncateTo = ref.Offset
+		}
+	}
+	for _, target := range targets {
+		if target.remove {
+			if err := os.Remove(target.path); err != nil && !os.IsNotExist(err) {
+				return err
+			}
+		} else if err := os.Truncate(target.path, target.truncateTo); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+		if err := syncColumnAssetDir(filepath.Dir(target.path)); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (c *Collection) columnStoreCompactionRootDescriptorPreflight(state columnStoreCompactionState, rootNames []string, baseRootIDs map[string]uint64) backenddb.OrderedRootGroupPreflight {

--- a/TreeDB/collections/column_store_compaction.go
+++ b/TreeDB/collections/column_store_compaction.go
@@ -128,10 +128,6 @@ func (c *Collection) columnStoreCompact(ctx context.Context, opts ColumnStoreCom
 	if err := ctx.Err(); err != nil {
 		return stats, err
 	}
-	stats.AssetsPublished = len(prepared.Assets)
-	stats.AggregateMetadataPublished = columnStoreCompactionAggregateMetadataAssets(prepared.Assets)
-	stats.PublishedRefs = columnStoreCompactionPreparedRefs(prepared.Assets)
-
 	manifest, err := encodeColumnManifestForWrite(ColumnPublishManifestEncodeInput{
 		Collection:        state.meta.Name,
 		ColumnStore:       state.cfg,
@@ -180,6 +176,9 @@ func (c *Collection) columnStoreCompact(ctx context.Context, opts ColumnStoreCom
 	if len(rootIDs) != 1 || rootIDs[0] == 0 {
 		return stats, unexpectedOrderedRootCountError(state.meta.Name, 1, len(rootIDs))
 	}
+	stats.AssetsPublished = len(prepared.Assets)
+	stats.AggregateMetadataPublished = columnStoreCompactionAggregateMetadataAssets(prepared.Assets)
+	stats.PublishedRefs = columnStoreCompactionPreparedRefs(prepared.Assets)
 	stats.Compacted = true
 	stats.ManifestRoot = rootIDs[0]
 	stats.SystemRoot = newSystemRoot

--- a/TreeDB/collections/column_store_compaction.go
+++ b/TreeDB/collections/column_store_compaction.go
@@ -116,9 +116,6 @@ func (c *Collection) columnStoreCompact(ctx context.Context, opts ColumnStoreCom
 		return stats, nil
 	}
 	supersededRefs := columnStoreCompactionRefsFromManifestRecords(state.records)
-	if state.cfg.RecoveryAuthoritativeAppliedCommandLSN == 0 {
-		return stats, errors.New("collections: column store compaction requires recovery-authoritative AppliedCommandLSN")
-	}
 	if err := ctx.Err(); err != nil {
 		return stats, err
 	}
@@ -255,6 +252,10 @@ func (c *Collection) loadColumnStoreCompactionState(ctx context.Context) (column
 		closeState()
 		return columnStoreCompactionState{}, nil, err
 	}
+	if cfg.RecoveryAuthoritativeAppliedCommandLSN == 0 {
+		closeState()
+		return columnStoreCompactionState{}, nil, errors.New("collections: column store compaction requires recovery-authoritative AppliedCommandLSN")
+	}
 	records, err := loadColumnManifestRecordsFromRoot(snap, baseRoot)
 	if err != nil {
 		closeState()
@@ -384,7 +385,8 @@ func cleanupColumnPreparedAssets(rootDir string, assets []ColumnPreparedAsset) e
 		}
 		assetPath, err := columnAssetSegmentPath(rootDir, ref)
 		if err != nil {
-			return err
+			cleanupErrs = append(cleanupErrs, err)
+			continue
 		}
 		target := targets[assetPath]
 		if target == nil {

--- a/TreeDB/collections/column_store_compaction_test.go
+++ b/TreeDB/collections/column_store_compaction_test.go
@@ -1,0 +1,722 @@
+package collections
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/node"
+)
+
+func TestColumnStoreCompactQ2SortedLatestVisibleReopen1953(t *testing.T) {
+	batches := [][]columnPhysicalJSONBenchParityEventP0{typedColumnQ2SortedBatchA1950(), typedColumnQ2SortedBatchB1950()}
+	dir, d, col, closeFn := openTypedColumnLatestVisibleFixture1953(t, typedColumnQ2ClickHouseSortKey1950(), batches)
+	events := flattenColumnPhysicalEvents1950(batches)
+	latest := latestEventMap1953(events)
+
+	promoted := latest["a-kind-guard"]
+	promoted.Kind = "commit"
+	promoted.Operation = "create"
+	promoted.Collection = "app.bsky.feed.like"
+	promoted.Did = "did:promoted"
+	promoted.TimeUS += 101
+	updateTypedColumnEvent1953(t, col, promoted)
+	latest[promoted.ID] = promoted
+
+	demoted := latest["a-post-a-1"]
+	demoted.Operation = "delete"
+	demoted.TimeUS += 102
+	updateTypedColumnEvent1953(t, col, demoted)
+	latest[demoted.ID] = demoted
+
+	moved := latest["a-post-shared"]
+	moved.Collection = "app.bsky.feed.like"
+	moved.TimeUS += 103
+	updateTypedColumnEvent1953(t, col, moved)
+	latest[moved.ID] = moved
+
+	deleteTypedColumnEvent1953(t, col, "b-repost")
+	delete(latest, "b-repost")
+
+	live := latestEvents1953(latest)
+	req := typedColumnQ2Request1950()
+	before, err := col.RunColumnPhysicalQuery(req)
+	if err != nil {
+		t.Fatalf("RunColumnPhysicalQuery(q2 before compaction): %v", err)
+	}
+	if got, want := columnPhysicalJSONBenchQ2CountsP0(before.Groups), columnPhysicalJSONBenchQ2ReferenceCountsP0(live); !columnPhysicalJSONBenchQ2CountsEqualP0(got, want) {
+		t.Fatalf("q2 before compaction counts=%v want %v groups=%+v", got, want, before.Groups)
+	}
+	if before.Diagnostics.StorageSource != ColumnPhysicalQueryStorageSourceTypedColumnPartSection || before.Diagnostics.FallbackReason != ColumnPhysicalQueryFallbackNone || before.Diagnostics.MutationParts == 0 || before.Diagnostics.VisibilityRows != len(live) || before.Diagnostics.DocumentMaterializations != 0 || before.Diagnostics.RowMaterializations != 0 {
+		t.Fatalf("q2 before compaction diagnostics=%+v want latest-visible typed-column path", before.Diagnostics)
+	}
+	if _, err := col.PrepareColumnPhysicalQuery(req); !errors.Is(err, ErrColumnQueryPlanUnsupported) || !strings.Contains(err.Error(), "insert-only") {
+		t.Fatalf("PrepareColumnPhysicalQuery before compaction err=%v want insert-only guard", err)
+	}
+
+	beforeView := loadColumnStoreCompactionManifestView1953(t, d, col)
+	oldRefs := columnStoreCompactionRefsFromRecordsForTest1953(t, beforeView.records)
+	if beforeView.mutationParts == 0 || len(oldRefs) == 0 {
+		t.Fatalf("before compaction manifest mutation_parts=%d refs=%d want mutation-bearing refs", beforeView.mutationParts, len(oldRefs))
+	}
+
+	stats, err := col.ColumnStoreCompact(context.Background(), ColumnStoreCompactOptions{})
+	if err != nil {
+		t.Fatalf("ColumnStoreCompact: %v", err)
+	}
+	if !stats.Compacted || stats.PreviousGeneration != beforeView.manifest.Generation || stats.NewGeneration <= stats.PreviousGeneration || stats.RowsCompacted != len(live) || stats.MutationPartsBefore == 0 || stats.MutationPartsAfter != 0 || stats.AssetsPublished == 0 {
+		t.Fatalf("compaction stats=%+v want logical rewrite of latest-visible rows", stats)
+	}
+	if got := col.Meta().Options.ColumnStore.PhysicalMutationParts; got != 0 {
+		t.Fatalf("PhysicalMutationParts=%d want reset after compaction", got)
+	}
+
+	after, err := col.RunColumnPhysicalQuery(req)
+	if err != nil {
+		t.Fatalf("RunColumnPhysicalQuery(q2 after compaction): %v", err)
+	}
+	if got, want := columnPhysicalJSONBenchQ2CountsP0(after.Groups), columnPhysicalJSONBenchQ2ReferenceCountsP0(live); !columnPhysicalJSONBenchQ2CountsEqualP0(got, want) {
+		t.Fatalf("q2 after compaction counts=%v want %v groups=%+v", got, want, after.Groups)
+	}
+	assertTypedColumnQ2SortedGroupedDistinctDiagnostics1950(t, "q2 after compaction", after.Diagnostics, len(live), columnPhysicalJSONBenchReferenceMatchedRowsP0("q2", live), true)
+	if after.Diagnostics.MutationParts != 0 || after.Diagnostics.VisibilityRows != 0 || after.Diagnostics.DeletedRows != 0 {
+		t.Fatalf("q2 after compaction diagnostics=%+v want insert-only manifest", after.Diagnostics)
+	}
+	runner, err := col.PrepareColumnPhysicalQuery(req)
+	if err != nil {
+		t.Fatalf("PrepareColumnPhysicalQuery after compaction: %v", err)
+	}
+	prepared, err := runner.Run()
+	closeErr := runner.Close()
+	if err != nil || closeErr != nil {
+		t.Fatalf("prepared q2 after compaction run=%v close=%v", err, closeErr)
+	}
+	if got, want := columnPhysicalJSONBenchQ2CountsP0(prepared.Groups), columnPhysicalJSONBenchQ2ReferenceCountsP0(live); !columnPhysicalJSONBenchQ2CountsEqualP0(got, want) {
+		t.Fatalf("prepared q2 after compaction counts=%v want %v groups=%+v", got, want, prepared.Groups)
+	}
+
+	afterView := loadColumnStoreCompactionManifestView1953(t, d, col)
+	assertColumnStoreCompactionManifestOnlyGeneration1953(t, afterView.records, stats.NewGeneration, false)
+	assertColumnStoreCompactionRefsAbsent1953(t, afterView.records, oldRefs)
+	assertColumnStoreCompactionRefsReclaimable1953(t, col, oldRefs)
+
+	_, col, closeFn = checkpointAndReopenTypedColumnLatestVisibleFixture1953(t, dir, d, closeFn)
+	defer closeFn()
+	reopened, err := col.RunColumnPhysicalQuery(req)
+	if err != nil {
+		t.Fatalf("RunColumnPhysicalQuery(q2 after compaction reopen): %v", err)
+	}
+	if got, want := columnPhysicalJSONBenchQ2CountsP0(reopened.Groups), columnPhysicalJSONBenchQ2ReferenceCountsP0(live); !columnPhysicalJSONBenchQ2CountsEqualP0(got, want) {
+		t.Fatalf("q2 after compaction reopen counts=%v want %v groups=%+v", got, want, reopened.Groups)
+	}
+	if reopened.Diagnostics.MutationParts != 0 || reopened.Diagnostics.VisibilityRows != 0 || reopened.Diagnostics.DocumentMaterializations != 0 || reopened.Diagnostics.RowMaterializations != 0 {
+		t.Fatalf("q2 after compaction reopen diagnostics=%+v want insert-only typed-column path", reopened.Diagnostics)
+	}
+}
+
+func TestColumnStoreCompactRebuildsAggregateMetadata1953(t *testing.T) {
+	batches := [][]columnPhysicalJSONBenchParityEventP0{columnPhysicalQ5DenseBatchA1950(), columnPhysicalQ5DenseBatchB1950()}
+	dir, d, col, closeFn := openColumnStoreCompactionFixture1953(t, predicateAggregateMetadataConfig1951(), batches)
+	events := flattenColumnPhysicalEvents1950(batches)
+	latest := latestEventMap1953(events)
+
+	updated := latest["a-m-1"]
+	updated.TimeUS += 1_000
+	updateTypedColumnEvent1953(t, col, updated)
+	latest[updated.ID] = updated
+
+	demoted := latest["b-beta-2"]
+	demoted.Operation = "delete"
+	demoted.TimeUS += 2_000
+	updateTypedColumnEvent1953(t, col, demoted)
+	latest[demoted.ID] = demoted
+
+	deleteTypedColumnEvent1953(t, col, "b-m-3")
+	delete(latest, "b-m-3")
+
+	metadataReq := columnPredicateAggregateMetadataQ5Request1951(true)
+	fallbackReq := metadataReq
+	fallbackReq.AggregateMetadataName = ""
+	want, err := col.RunColumnPhysicalQuery(fallbackReq)
+	if err != nil {
+		t.Fatalf("RunColumnPhysicalQuery(q5 latest-visible fallback before compaction): %v", err)
+	}
+	if want.Diagnostics.MutationParts == 0 || want.Diagnostics.StorageSource != ColumnPhysicalQueryStorageSourceTypedColumnPartSection || want.Diagnostics.DocumentMaterializations != 0 || want.Diagnostics.RowMaterializations != 0 {
+		t.Fatalf("fallback before compaction diagnostics=%+v want latest-visible typed-column path", want.Diagnostics)
+	}
+	if _, err := col.RunColumnPhysicalQuery(metadataReq); !errors.Is(err, ErrColumnQueryPlanUnsupported) {
+		t.Fatalf("RunColumnPhysicalQuery metadata before compaction err=%v want unsupported", err)
+	}
+	if _, err := col.PrepareColumnPhysicalQuery(metadataReq); !errors.Is(err, ErrColumnQueryPlanUnsupported) {
+		t.Fatalf("PrepareColumnPhysicalQuery metadata before compaction err=%v want unsupported", err)
+	}
+
+	beforeView := loadColumnStoreCompactionManifestView1953(t, d, col)
+	oldRefs := columnStoreCompactionRefsFromRecordsForTest1953(t, beforeView.records)
+	oldMetadataRefs := columnStoreCompactionRefsWithKind1953(oldRefs, ColumnAssetKindTCS1AggregateMetadata)
+	if beforeView.mutationParts == 0 || len(oldMetadataRefs) == 0 {
+		t.Fatalf("before compaction mutation_parts=%d old metadata refs=%d want stale metadata lineage", beforeView.mutationParts, len(oldMetadataRefs))
+	}
+
+	stats, err := col.ColumnStoreCompact(context.Background(), ColumnStoreCompactOptions{})
+	if err != nil {
+		t.Fatalf("ColumnStoreCompact aggregate metadata: %v", err)
+	}
+	if !stats.Compacted || stats.RowsCompacted != len(latestEvents1953(latest)) || stats.AggregateMetadataPublished == 0 || stats.MutationPartsAfter != 0 {
+		t.Fatalf("aggregate compaction stats=%+v want rebuilt insert-only metadata", stats)
+	}
+
+	after, err := col.RunColumnPhysicalQuery(metadataReq)
+	if err != nil {
+		t.Fatalf("RunColumnPhysicalQuery metadata after compaction: %v", err)
+	}
+	if !reflect.DeepEqual(after.Groups, want.Groups) {
+		t.Fatalf("metadata after compaction groups=%+v want latest-visible %+v", after.Groups, want.Groups)
+	}
+	assertColumnStoreCompactionAggregateMetadataDiagnostics1953(t, after.Diagnostics, want.Diagnostics.RowsMatched)
+
+	runner, err := col.PrepareColumnPhysicalQuery(metadataReq)
+	if err != nil {
+		t.Fatalf("PrepareColumnPhysicalQuery metadata after compaction: %v", err)
+	}
+	prepared, err := runner.Run()
+	closeErr := runner.Close()
+	if err != nil || closeErr != nil {
+		t.Fatalf("prepared metadata after compaction run=%v close=%v", err, closeErr)
+	}
+	if !reflect.DeepEqual(prepared.Groups, want.Groups) {
+		t.Fatalf("prepared metadata after compaction groups=%+v want %+v", prepared.Groups, want.Groups)
+	}
+	assertColumnStoreCompactionAggregateMetadataDiagnostics1953(t, prepared.Diagnostics, want.Diagnostics.RowsMatched)
+
+	afterView := loadColumnStoreCompactionManifestView1953(t, d, col)
+	assertColumnStoreCompactionManifestOnlyGeneration1953(t, afterView.records, stats.NewGeneration, true)
+	assertColumnStoreCompactionRefsAbsent1953(t, afterView.records, oldRefs)
+	assertColumnStoreCompactionRefsReclaimable1953(t, col, oldMetadataRefs)
+
+	_, col, closeFn = checkpointAndReopenTypedColumnLatestVisibleFixture1953(t, dir, d, closeFn)
+	defer closeFn()
+	reopened, err := col.RunColumnPhysicalQuery(metadataReq)
+	if err != nil {
+		t.Fatalf("RunColumnPhysicalQuery metadata after compaction reopen: %v", err)
+	}
+	if !reflect.DeepEqual(reopened.Groups, want.Groups) {
+		t.Fatalf("metadata after compaction reopen groups=%+v want %+v", reopened.Groups, want.Groups)
+	}
+	assertColumnStoreCompactionAggregateMetadataDiagnostics1953(t, reopened.Diagnostics, want.Diagnostics.RowsMatched)
+}
+
+func TestColumnStoreCompactRebuildsRowAssetSidecars1953(t *testing.T) {
+	batches := [][]columnPhysicalJSONBenchParityEventP0{{
+		{ID: "a", TimeUS: 100, Kind: "commit", Operation: "create", Collection: "app.bsky.feed.post", Did: "did:a"},
+		{ID: "b", TimeUS: 200, Kind: "identity", Operation: "create", Collection: "app.bsky.feed.like", Did: "did:b"},
+		{ID: "c", TimeUS: 300, Kind: "commit", Operation: "delete", Collection: "app.bsky.feed.repost", Did: "did:c"},
+	}}
+	_, d, col, closeFn := openColumnStoreCompactionFixture1953(t, columnStoreCompactionMixedSidecarConfig1953(), batches)
+	defer closeFn()
+	events := flattenColumnPhysicalEvents1950(batches)
+	latest := latestEventMap1953(events)
+
+	updated := latest["b"]
+	updated.Kind = "commit"
+	updated.Collection = "app.bsky.feed.post"
+	updated.TimeUS += 55
+	updateTypedColumnEvent1953(t, col, updated)
+	latest[updated.ID] = updated
+	deleteTypedColumnEvent1953(t, col, "c")
+	delete(latest, "c")
+
+	beforeView := loadColumnStoreCompactionManifestView1953(t, d, col)
+	oldRefs := columnStoreCompactionRefsFromRecordsForTest1953(t, beforeView.records)
+	oldDictionaryRefs := columnStoreCompactionRefsWithKind1953(oldRefs, ColumnAssetKindTCS1DictionaryCodes)
+	oldInt64Refs := columnStoreCompactionRefsWithKind1953(oldRefs, ColumnAssetKindTCS1Int64Values)
+	if beforeView.mutationParts == 0 || len(oldDictionaryRefs) == 0 || len(oldInt64Refs) == 0 {
+		t.Fatalf("before sidecar compaction mutation_parts=%d dictionary_refs=%d int64_refs=%d", beforeView.mutationParts, len(oldDictionaryRefs), len(oldInt64Refs))
+	}
+
+	stats, err := col.ColumnStoreCompact(context.Background(), ColumnStoreCompactOptions{})
+	if err != nil {
+		t.Fatalf("ColumnStoreCompact sidecars: %v", err)
+	}
+	if !stats.Compacted || stats.RowsCompacted != len(latestEvents1953(latest)) {
+		t.Fatalf("sidecar compaction stats=%+v want compacted live rows", stats)
+	}
+	afterView := loadColumnStoreCompactionManifestView1953(t, d, col)
+	afterRefs := columnStoreCompactionRefsFromRecordsForTest1953(t, afterView.records)
+	if got := len(columnStoreCompactionRefsWithKind1953(afterRefs, ColumnAssetKindTCS1DictionaryCodes)); got == 0 {
+		t.Fatalf("compacted sidecar manifest refs=%+v want dictionary sidecar", afterRefs)
+	}
+	if got := len(columnStoreCompactionRefsWithKind1953(afterRefs, ColumnAssetKindTCS1Int64Values)); got == 0 {
+		t.Fatalf("compacted sidecar manifest refs=%+v want int64 values sidecar", afterRefs)
+	}
+	assertColumnStoreCompactionManifestOnlyGeneration1953(t, afterView.records, stats.NewGeneration, false)
+	assertColumnStoreCompactionRefsAbsent1953(t, afterView.records, oldRefs)
+	assertColumnStoreCompactionRefsReclaimable1953(t, col, append(oldDictionaryRefs, oldInt64Refs...))
+
+	result, err := col.RunColumnPhysicalQuery(ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount, GroupColumn: "collection"})
+	if err != nil {
+		t.Fatalf("RunColumnPhysicalQuery after sidecar compaction: %v", err)
+	}
+	if got, want := columnPhysicalGroupCountMap1953(result.Groups), collectionCounts1953(latestEvents1953(latest)); !reflect.DeepEqual(got, want) {
+		t.Fatalf("sidecar compaction groups=%v want %v full=%+v", got, want, result.Groups)
+	}
+}
+
+func TestColumnStoreCompactPostCompactionWritesAdvanceFromCompactedManifest1953(t *testing.T) {
+	batches := [][]columnPhysicalJSONBenchParityEventP0{{
+		{ID: "a", TimeUS: 100, Kind: "commit", Operation: "create", Collection: "app.bsky.feed.post", Did: "did:a"},
+		{ID: "b", TimeUS: 200, Kind: "commit", Operation: "create", Collection: "app.bsky.feed.like", Did: "did:b"},
+	}}
+	dir, d, col, closeFn := openTypedColumnLatestVisibleFixture1953(t, nil, batches)
+	events := flattenColumnPhysicalEvents1950(batches)
+	latest := latestEventMap1953(events)
+
+	updated := latest["a"]
+	updated.Collection = "app.bsky.feed.repost"
+	updated.TimeUS += 10
+	updateTypedColumnEvent1953(t, col, updated)
+	latest[updated.ID] = updated
+	deleteTypedColumnEvent1953(t, col, "b")
+	delete(latest, "b")
+
+	beforeView := loadColumnStoreCompactionManifestView1953(t, d, col)
+	beforeLSN := d.State().AppliedCommandLSN
+	stats, err := col.ColumnStoreCompact(context.Background(), ColumnStoreCompactOptions{})
+	if err != nil {
+		t.Fatalf("ColumnStoreCompact before post-write: %v", err)
+	}
+	compactedView := loadColumnStoreCompactionManifestView1953(t, d, col)
+	if got := d.State().AppliedCommandLSN; got != beforeLSN {
+		t.Fatalf("DB AppliedCommandLSN advanced during compaction: got %d want %d", got, beforeLSN)
+	}
+	if compactedView.manifest.AppliedCommandLSN != beforeView.cfg.RecoveryAuthoritativeAppliedCommandLSN || compactedView.cfg.RecoveryAuthoritativeAppliedCommandLSN != beforeLSN {
+		t.Fatalf("compacted manifest/config LSN manifest=%d cfg=%d before_cfg=%d db=%d", compactedView.manifest.AppliedCommandLSN, compactedView.cfg.RecoveryAuthoritativeAppliedCommandLSN, beforeView.cfg.RecoveryAuthoritativeAppliedCommandLSN, beforeLSN)
+	}
+
+	inserted := columnPhysicalJSONBenchParityEventP0{ID: "c", TimeUS: 300, Kind: "commit", Operation: "create", Collection: "app.bsky.feed.post", Did: "did:c"}
+	if _, err := col.InsertBatch([][]byte{[]byte(inserted.ID)}, [][]byte{typedColumnEventDocument1953(inserted)}); err != nil {
+		t.Fatalf("InsertBatch after compaction: %v", err)
+	}
+	latest[inserted.ID] = inserted
+	insertView := loadColumnStoreCompactionManifestView1953(t, d, col)
+	if insertView.manifest.Generation != stats.NewGeneration+1 || insertView.manifest.AppliedCommandLSN != beforeLSN+1 || d.State().AppliedCommandLSN != beforeLSN+1 {
+		t.Fatalf("post-compaction insert manifest=%+v db_lsn=%d want generation=%d lsn=%d", insertView.manifest, d.State().AppliedCommandLSN, stats.NewGeneration+1, beforeLSN+1)
+	}
+
+	updated = latest["a"]
+	updated.Collection = "app.bsky.feed.like"
+	updated.TimeUS += 20
+	updateTypedColumnEvent1953(t, col, updated)
+	latest[updated.ID] = updated
+	deleteTypedColumnEvent1953(t, col, "c")
+	delete(latest, "c")
+	mutationView := loadColumnStoreCompactionManifestView1953(t, d, col)
+	if mutationView.manifest.Generation != stats.NewGeneration+3 || mutationView.manifest.AppliedCommandLSN != beforeLSN+3 || d.State().AppliedCommandLSN != beforeLSN+3 || mutationView.mutationParts == 0 {
+		t.Fatalf("post-compaction mutation manifest=%+v mutation_parts=%d db_lsn=%d want generation=%d lsn=%d mutation parts", mutationView.manifest, mutationView.mutationParts, d.State().AppliedCommandLSN, stats.NewGeneration+3, beforeLSN+3)
+	}
+
+	result, err := col.RunColumnPhysicalQuery(ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount, GroupColumn: "collection"})
+	if err != nil {
+		t.Fatalf("RunColumnPhysicalQuery after post-compaction writes: %v", err)
+	}
+	if got, want := columnPhysicalGroupCountMap1953(result.Groups), collectionCounts1953(latestEvents1953(latest)); !reflect.DeepEqual(got, want) {
+		t.Fatalf("post-compaction write groups=%v want %v full=%+v", got, want, result.Groups)
+	}
+
+	_, col, closeFn = checkpointAndReopenTypedColumnLatestVisibleFixture1953(t, dir, d, closeFn)
+	defer closeFn()
+	reopened, err := col.RunColumnPhysicalQuery(ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount, GroupColumn: "collection"})
+	if err != nil {
+		t.Fatalf("RunColumnPhysicalQuery post-compaction writes reopen: %v", err)
+	}
+	if got, want := columnPhysicalGroupCountMap1953(reopened.Groups), collectionCounts1953(latestEvents1953(latest)); !reflect.DeepEqual(got, want) {
+		t.Fatalf("post-compaction write reopen groups=%v want %v full=%+v", got, want, reopened.Groups)
+	}
+}
+
+func TestColumnStoreCompactRejectsVectorManifestRecords1953(t *testing.T) {
+	cases := []struct {
+		name string
+		key  []byte
+	}{
+		{name: "graph", key: columnVectorGraphManifestRecordKey("c5-unsupported-vector-graph")},
+		{name: "state", key: columnVectorIndexStateRecordKey("c5-unsupported-vector-state")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			batches := [][]columnPhysicalJSONBenchParityEventP0{{
+				{ID: "a", TimeUS: 100, Kind: "commit", Operation: "create", Collection: "app.bsky.feed.post", Did: "did:a"},
+			}}
+			_, d, col, closeFn := openTypedColumnLatestVisibleFixture1953(t, nil, batches)
+			defer closeFn()
+
+			installColumnStoreCompactionManifestRecord1953(t, col, columnManifestRecord{
+				key:   tc.key,
+				value: []byte("unsupported-vector-record-for-c5-compaction-guard"),
+			})
+			if _, err := col.ColumnStoreCompact(context.Background(), ColumnStoreCompactOptions{}); !errors.Is(err, ErrColumnQueryPlanUnsupported) || !strings.Contains(err.Error(), "vector") {
+				t.Fatalf("ColumnStoreCompact with vector manifest record err=%v want explicit unsupported vector failure", err)
+			}
+
+			// The failed compaction must leave the vector-bearing manifest readable.
+			_ = loadColumnStoreCompactionManifestView1953(t, d, col)
+		})
+	}
+}
+
+func TestSystemTargetIteratorTombstoneEntry1953(t *testing.T) {
+	it := &systemTargetIterator{entries: []systemTargetEntry{{
+		key:   []byte("deleted"),
+		value: []byte("stale-value"),
+		flags: node.FlagTombstone,
+	}}}
+	if !it.Valid() || !it.IsDeleted() {
+		t.Fatalf("iterator valid/deleted=%t/%t want tombstone", it.Valid(), it.IsDeleted())
+	}
+	if value := it.UnsafeValue(); value != nil {
+		t.Fatalf("UnsafeValue for tombstone=%q want nil", value)
+	}
+	value, _, flags := it.UnsafeEntry()
+	if value != nil || flags&node.FlagTombstone == 0 {
+		t.Fatalf("UnsafeEntry value=%q flags=0x%x want tombstone", value, flags)
+	}
+	if copied := it.ValueCopy([]byte("keep")); len(copied) != 0 {
+		t.Fatalf("ValueCopy tombstone=%q want empty copy", copied)
+	}
+}
+
+func TestColumnStoreCompactAllRowsDeletedPublishesEmptyInsertOnlyManifest1953(t *testing.T) {
+	batches := [][]columnPhysicalJSONBenchParityEventP0{{
+		{ID: "a", TimeUS: 100, Kind: "commit", Operation: "create", Collection: "app.bsky.feed.post", Did: "did:a"},
+		{ID: "b", TimeUS: 200, Kind: "commit", Operation: "create", Collection: "app.bsky.feed.post", Did: "did:b"},
+	}}
+	dir, d, col, closeFn := openTypedColumnLatestVisibleFixture1953(t, nil, batches)
+
+	deleteTypedColumnEvent1953(t, col, "a")
+	deleteTypedColumnEvent1953(t, col, "b")
+	beforeView := loadColumnStoreCompactionManifestView1953(t, d, col)
+	oldRefs := columnStoreCompactionRefsFromRecordsForTest1953(t, beforeView.records)
+
+	stats, err := col.ColumnStoreCompact(context.Background(), ColumnStoreCompactOptions{})
+	if err != nil {
+		t.Fatalf("ColumnStoreCompact all deleted: %v", err)
+	}
+	if !stats.Compacted || stats.RowsCompacted != 0 || stats.AssetsPublished != 0 || stats.MutationPartsBefore == 0 || stats.MutationPartsAfter != 0 {
+		t.Fatalf("all-deleted compaction stats=%+v want empty insert-only generation", stats)
+	}
+
+	afterView := loadColumnStoreCompactionManifestView1953(t, d, col)
+	if afterView.manifest.RowCount != 0 || afterView.manifest.ExpectedParts != 0 || afterView.mutationParts != 0 {
+		t.Fatalf("all-deleted manifest=%+v mutation_parts=%d want empty insert-only manifest", afterView.manifest, afterView.mutationParts)
+	}
+	assertColumnStoreCompactionManifestOnlyGeneration1953(t, afterView.records, stats.NewGeneration, false)
+	assertColumnStoreCompactionRefsAbsent1953(t, afterView.records, oldRefs)
+
+	result, err := col.RunColumnPhysicalQuery(ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount, GroupColumn: "collection"})
+	if err != nil {
+		t.Fatalf("RunColumnPhysicalQuery all deleted after compaction: %v", err)
+	}
+	if len(result.Groups) != 0 || result.Diagnostics.MutationParts != 0 || result.Diagnostics.VisibilityRows != 0 || result.Diagnostics.DocumentMaterializations != 0 {
+		t.Fatalf("all-deleted query result=%+v diagnostics=%+v want empty insert-only typed query", result.Groups, result.Diagnostics)
+	}
+
+	_, col, closeFn = checkpointAndReopenTypedColumnLatestVisibleFixture1953(t, dir, d, closeFn)
+	defer closeFn()
+	reopened, err := col.RunColumnPhysicalQuery(ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount, GroupColumn: "collection"})
+	if err != nil {
+		t.Fatalf("RunColumnPhysicalQuery all deleted reopen: %v", err)
+	}
+	if len(reopened.Groups) != 0 || reopened.Diagnostics.MutationParts != 0 {
+		t.Fatalf("all-deleted reopen result=%+v diagnostics=%+v want empty insert-only manifest", reopened.Groups, reopened.Diagnostics)
+	}
+}
+
+type columnStoreCompactionManifestView1953 struct {
+	cfg           ColumnStoreConfig
+	manifest      columnManifestSnapshot
+	records       []columnManifestRecord
+	mutationParts int
+	rootID        uint64
+}
+
+func columnStoreCompactionMixedSidecarConfig1953() *ColumnStoreConfig {
+	return &ColumnStoreConfig{Enabled: true, Columns: []ColumnStoreColumn{
+		{Name: "time_us", Path: "time_us", ValueType: ColumnStoreValueInt64, Owner: TypedStorageOwnerRowAsset},
+		{Name: "kind", Path: "kind", ValueType: ColumnStoreValueString, Owner: TypedStorageOwnerRowAsset, Dictionary: true},
+		{Name: "operation", Path: "operation", ValueType: ColumnStoreValueString, Owner: TypedStorageOwnerColumnPart, Dictionary: true},
+		{Name: "collection", Path: "collection", ValueType: ColumnStoreValueString, Owner: TypedStorageOwnerColumnPart, Dictionary: true},
+		{Name: "did", Path: "did", ValueType: ColumnStoreValueString, Owner: TypedStorageOwnerColumnPart, Dictionary: true},
+	}}
+}
+
+func installColumnStoreCompactionManifestRecord1953(tb testing.TB, col *Collection, record columnManifestRecord) {
+	tb.Helper()
+	state, err := col.loadColumnAssetRewriteManifestState()
+	if err != nil {
+		tb.Fatalf("loadColumnAssetRewriteManifestState: %v", err)
+	}
+	records := append(cloneColumnManifestRecords(state.records), columnManifestRecord{key: bytes.Clone(record.key), value: bytes.Clone(record.value)})
+	sortColumnManifestRecords(records)
+	identity, err := columnAssetRewriteUpdatedIdentity(state, records)
+	if err != nil {
+		tb.Fatalf("columnAssetRewriteUpdatedIdentity: %v", err)
+	}
+	updatedMeta, err := columnAssetRewriteUpdatedMeta(state.meta, identity)
+	if err != nil {
+		tb.Fatalf("columnAssetRewriteUpdatedMeta: %v", err)
+	}
+	newSystemRoot, rootIDs, err := col.publishColumnAssetRewriteManifestState(state, updatedMeta, identity, records)
+	if err != nil {
+		tb.Fatalf("publish manifest fixture record: %v", err)
+	}
+	if len(rootIDs) != 1 || rootIDs[0] == 0 || newSystemRoot == 0 {
+		tb.Fatalf("publish manifest fixture roots system=%d roots=%v", newSystemRoot, rootIDs)
+	}
+	nextCatalog := cloneCatalogWithRootUpdates(state.catalog, updatedMeta, []string{state.rootName}, rootIDs)
+	col.meta = updatedMeta
+	col.rememberCatalogAtSystemRoot(newSystemRoot, nextCatalog)
+	col.noteWriteDomainCatalog(newSystemRoot, nextCatalog)
+}
+
+func openColumnStoreCompactionFixture1953(tb testing.TB, cfg *ColumnStoreConfig, batches [][]columnPhysicalJSONBenchParityEventP0) (string, *backenddb.DB, *Collection, func()) {
+	tb.Helper()
+	dir := tb.TempDir()
+	if err := backenddb.SaveFormatConfig(dir, backenddb.FormatConfig{RequiredFeatures: []string{backenddb.RequiredFeatureCommandWALV1}}); err != nil {
+		tb.Fatalf("SaveFormatConfig: %v", err)
+	}
+	d, err := backenddb.Open(backenddb.Options{Dir: dir, DisableBackgroundPrune: true})
+	if err != nil {
+		tb.Fatalf("Open setup DB: %v", err)
+	}
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "events", Options: CollectionOptions{ColumnStore: cfg}}); err != nil {
+		_ = d.Close()
+		tb.Fatalf("CreateCollection: %v", err)
+	}
+	col, err := mgr.OpenCollection("events")
+	if err != nil {
+		_ = d.Close()
+		tb.Fatalf("OpenCollection setup: %v", err)
+	}
+	for batchIdx, batch := range batches {
+		ids := make([][]byte, len(batch))
+		docs := make([][]byte, len(batch))
+		for i, event := range batch {
+			ids[i] = []byte(event.ID)
+			docs[i] = typedColumnEventDocument1953(event)
+		}
+		if _, err := col.InsertBatch(ids, docs); err != nil {
+			_ = d.Close()
+			tb.Fatalf("InsertBatch[%d]: %v", batchIdx, err)
+		}
+	}
+	if err := d.Checkpoint(); err != nil {
+		_ = d.Close()
+		tb.Fatalf("Checkpoint setup: %v", err)
+	}
+	return dir, d, col, func() { _ = d.Close() }
+}
+
+func loadColumnStoreCompactionManifestView1953(tb testing.TB, d *backenddb.DB, col *Collection) columnStoreCompactionManifestView1953 {
+	tb.Helper()
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		tb.Fatal("AcquireSnapshot returned nil")
+	}
+	defer func() { _ = snap.Close() }()
+	catalog, err := loadCollectionCatalog(snap, col.Meta().Name)
+	if err != nil {
+		tb.Fatalf("loadCollectionCatalog: %v", err)
+	}
+	if catalog == nil {
+		tb.Fatal("loadCollectionCatalog returned nil")
+	}
+	cfg := catalog.meta.Options.ColumnStore.copy()
+	if cfg.ActiveManifest == nil {
+		tb.Fatal("missing active column manifest")
+	}
+	rootName := collectionColumnManifestRootName(catalog.meta.Name)
+	if cfg.ManifestRoot != nil && cfg.ManifestRoot.Name != "" {
+		rootName = cfg.ManifestRoot.Name
+	}
+	rootID := catalog.rootID(rootName)
+	if rootID == 0 {
+		tb.Fatalf("missing manifest root %q", rootName)
+	}
+	records, err := loadColumnManifestRecordsFromRoot(snap, rootID)
+	if err != nil {
+		tb.Fatalf("loadColumnManifestRecordsFromRoot: %v", err)
+	}
+	manifest, _, _, mutationParts, _, err := loadColumnManifestSnapshotViewForScanFromRoot(snap, rootID, cfg, *cfg.ActiveManifest, catalog.meta.Name, true, catalog.meta.VectorIndexes)
+	if err != nil {
+		tb.Fatalf("loadColumnManifestSnapshotViewForScanFromRoot: %v", err)
+	}
+	return columnStoreCompactionManifestView1953{cfg: cfg, manifest: manifest, records: records, mutationParts: mutationParts, rootID: rootID}
+}
+
+func columnStoreCompactionRefsFromRecordsForTest1953(tb testing.TB, records []columnManifestRecord) []ColumnAssetRef {
+	tb.Helper()
+	refs := make([]ColumnAssetRef, 0, len(records))
+	for _, record := range records {
+		if !columnStoreCompactionRecordCanHoldRef1953(record.key) {
+			continue
+		}
+		part, err := decodeColumnManifestPartRecord(record.value)
+		if err != nil {
+			tb.Fatalf("decodeColumnManifestPartRecord key=%q: %v", string(record.key), err)
+		}
+		refs = append(refs, part.AssetRef)
+	}
+	return refs
+}
+
+func columnStoreCompactionRecordCanHoldRef1953(key []byte) bool {
+	return bytes.HasPrefix(key, columnManifestPartRecordPrefixBytes) ||
+		bytes.HasPrefix(key, columnManifestAggregateMetadataRecordPrefixBytes) ||
+		bytes.HasPrefix(key, columnManifestDictionaryCodesRecordPrefixBytes) ||
+		bytes.HasPrefix(key, columnManifestInt64ValuesRecordPrefixBytes)
+}
+
+func columnStoreCompactionRefsWithKind1953(refs []ColumnAssetRef, kind ColumnAssetKind) []ColumnAssetRef {
+	out := make([]ColumnAssetRef, 0, len(refs))
+	for _, ref := range refs {
+		if ref.Kind == kind {
+			out = append(out, ref)
+		}
+	}
+	return out
+}
+
+func assertColumnStoreCompactionManifestOnlyGeneration1953(tb testing.TB, records []columnManifestRecord, generation uint64, wantAggregateMetadata bool) {
+	tb.Helper()
+	aggregateRecords := 0
+	for _, record := range records {
+		switch {
+		case bytes.Equal(record.key, columnManifestHeaderRecordKeyBytes):
+			continue
+		case bytes.HasPrefix(record.key, columnManifestPartRecordPrefixBytes):
+			keyGeneration, _, err := columnManifestPartKeyFromRecordKeyForScan(record.key)
+			if err != nil {
+				tb.Fatalf("columnManifestPartKeyFromRecordKeyForScan: %v", err)
+			}
+			part, err := decodeColumnManifestPartRecord(record.value)
+			if err != nil {
+				tb.Fatalf("decode part record: %v", err)
+			}
+			if keyGeneration != generation || part.AssetRef.Generation != generation || part.GenerationID != generation || part.Reason != string(ColumnPublishOperationInsert) || part.PartRole != ColumnManifestPartRoleBase {
+				tb.Fatalf("part record key_generation=%d part=%+v want generation=%d insert/base", keyGeneration, part, generation)
+			}
+		case bytes.HasPrefix(record.key, columnManifestAggregateMetadataRecordPrefixBytes):
+			aggregateRecords++
+			keyGeneration, _, name, err := columnManifestAggregateMetadataKeyPartsFromRecordKey(record.key)
+			if err != nil {
+				tb.Fatalf("columnManifestAggregateMetadataKeyPartsFromRecordKey: %v", err)
+			}
+			part, err := decodeColumnManifestPartRecord(record.value)
+			if err != nil {
+				tb.Fatalf("decode aggregate metadata record: %v", err)
+			}
+			if keyGeneration != generation || part.AssetRef.Generation != generation || part.GenerationID != generation || part.AssetRef.Kind != ColumnAssetKindTCS1AggregateMetadata || part.Reason != string(name) {
+				tb.Fatalf("aggregate metadata key_generation=%d name=%q part=%+v want generation=%d", keyGeneration, string(name), part, generation)
+			}
+		case bytes.HasPrefix(record.key, columnManifestDictionaryCodesRecordPrefixBytes):
+			keyGeneration, _, columnName, err := columnManifestDictionaryCodesKeyPartsFromRecordKey(record.key)
+			if err != nil {
+				tb.Fatalf("columnManifestDictionaryCodesKeyPartsFromRecordKey: %v", err)
+			}
+			part, err := decodeColumnManifestPartRecord(record.value)
+			if err != nil {
+				tb.Fatalf("decode dictionary record: %v", err)
+			}
+			if keyGeneration != generation || part.AssetRef.Generation != generation || part.GenerationID != generation || part.AssetRef.Kind != ColumnAssetKindTCS1DictionaryCodes || part.Reason != string(columnName) {
+				tb.Fatalf("dictionary key_generation=%d column=%q part=%+v want generation=%d", keyGeneration, string(columnName), part, generation)
+			}
+		case bytes.HasPrefix(record.key, columnManifestInt64ValuesRecordPrefixBytes):
+			keyGeneration, _, columnName, err := columnManifestInt64ValuesKeyPartsFromRecordKey(record.key)
+			if err != nil {
+				tb.Fatalf("columnManifestInt64ValuesKeyPartsFromRecordKey: %v", err)
+			}
+			part, err := decodeColumnManifestPartRecord(record.value)
+			if err != nil {
+				tb.Fatalf("decode int64 values record: %v", err)
+			}
+			if keyGeneration != generation || part.AssetRef.Generation != generation || part.GenerationID != generation || part.AssetRef.Kind != ColumnAssetKindTCS1Int64Values || part.Reason != string(columnName) {
+				tb.Fatalf("int64 values key_generation=%d column=%q part=%+v want generation=%d", keyGeneration, string(columnName), part, generation)
+			}
+		case bytes.HasPrefix(record.key, columnManifestVectorGraphRecordPrefixBytes), bytes.HasPrefix(record.key, columnVectorIndexStateRecordPrefixBytes):
+			tb.Fatalf("compacted manifest retained unsupported vector record key=%q", string(record.key))
+		default:
+			tb.Fatalf("unexpected manifest record key=%q", string(record.key))
+		}
+	}
+	if wantAggregateMetadata && aggregateRecords == 0 {
+		tb.Fatal("compacted manifest has no aggregate metadata records")
+	}
+}
+
+func assertColumnStoreCompactionRefsAbsent1953(tb testing.TB, records []columnManifestRecord, refs []ColumnAssetRef) {
+	tb.Helper()
+	active := make(map[ColumnAssetRef]struct{})
+	for _, ref := range columnStoreCompactionRefsFromRecordsForTest1953(tb, records) {
+		active[ref] = struct{}{}
+	}
+	for _, ref := range refs {
+		if _, ok := active[ref]; ok {
+			tb.Fatalf("superseded ref %+v still present in compacted manifest", ref)
+		}
+	}
+}
+
+func assertColumnStoreCompactionRefsReclaimable1953(tb testing.TB, col *Collection, refs []ColumnAssetRef) {
+	tb.Helper()
+	plan, err := col.PlanColumnAssetReachability(context.Background(), ColumnAssetReachabilityOptions{Detailed: true, CandidateRefs: refs})
+	if err != nil {
+		tb.Fatalf("PlanColumnAssetReachability: %v", err)
+	}
+	for _, ref := range refs {
+		assertColumnAssetReachabilityEntry1755(tb, plan, ref, ColumnAssetReachabilityReclaimable, false)
+	}
+}
+
+func assertColumnStoreCompactionAggregateMetadataDiagnostics1953(tb testing.TB, diag ColumnPhysicalQueryDiagnostics, matchedRows int) {
+	tb.Helper()
+	if diag.StorageSource != ColumnPhysicalQueryStorageSourceAggregateMetadata || diag.FallbackReason != ColumnPhysicalQueryFallbackNone {
+		tb.Fatalf("aggregate metadata diagnostics=%+v want metadata source", diag)
+	}
+	if diag.MutationParts != 0 || diag.VisibilityRows != 0 || diag.RowsScanned != 0 || diag.RowMaterializations != 0 || diag.DocumentMaterializations != 0 {
+		tb.Fatalf("aggregate metadata diagnostics=%+v want insert-only metadata without scans/materialization", diag)
+	}
+	if diag.MetadataHits == 0 || diag.MetadataEntries == 0 || diag.DecodedMetadataBytes == 0 || diag.PhysicalBytesScanned <= 0 {
+		tb.Fatalf("aggregate metadata diagnostics=%+v want metadata hits/entries/bytes", diag)
+	}
+	if diag.RowsMatched != matchedRows || diag.ReduceRows != matchedRows {
+		tb.Fatalf("aggregate metadata diagnostics=%+v want matched/reduced=%d", diag, matchedRows)
+	}
+}
+
+func TestColumnStoreCompactRequiresColumnStore1953(t *testing.T) {
+	dir := t.TempDir()
+	if err := backenddb.SaveFormatConfig(dir, backenddb.FormatConfig{RequiredFeatures: []string{backenddb.RequiredFeatureCommandWALV1}}); err != nil {
+		t.Fatalf("SaveFormatConfig: %v", err)
+	}
+	d, err := backenddb.Open(backenddb.Options{Dir: dir, DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "docs"}); err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	col, err := mgr.OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("OpenCollection: %v", err)
+	}
+	if _, err := col.ColumnStoreCompact(context.Background(), ColumnStoreCompactOptions{}); err == nil || !strings.Contains(err.Error(), "column_store") {
+		t.Fatalf("ColumnStoreCompact without column store err=%v want explicit failure", err)
+	}
+}

--- a/TreeDB/collections/column_store_compaction_test.go
+++ b/TreeDB/collections/column_store_compaction_test.go
@@ -15,6 +15,7 @@ import (
 func TestColumnStoreCompactQ2SortedLatestVisibleReopen1953(t *testing.T) {
 	batches := [][]columnPhysicalJSONBenchParityEventP0{typedColumnQ2SortedBatchA1950(), typedColumnQ2SortedBatchB1950()}
 	dir, d, col, closeFn := openTypedColumnLatestVisibleFixture1953(t, typedColumnQ2ClickHouseSortKey1950(), batches)
+	defer func() { closeFn() }()
 	events := flattenColumnPhysicalEvents1950(batches)
 	latest := latestEventMap1953(events)
 
@@ -105,7 +106,6 @@ func TestColumnStoreCompactQ2SortedLatestVisibleReopen1953(t *testing.T) {
 	assertColumnStoreCompactionRefsReclaimable1953(t, col, oldRefs)
 
 	_, col, closeFn = checkpointAndReopenTypedColumnLatestVisibleFixture1953(t, dir, d, closeFn)
-	defer closeFn()
 	reopened, err := col.RunColumnPhysicalQuery(req)
 	if err != nil {
 		t.Fatalf("RunColumnPhysicalQuery(q2 after compaction reopen): %v", err)
@@ -121,6 +121,7 @@ func TestColumnStoreCompactQ2SortedLatestVisibleReopen1953(t *testing.T) {
 func TestColumnStoreCompactRebuildsAggregateMetadata1953(t *testing.T) {
 	batches := [][]columnPhysicalJSONBenchParityEventP0{columnPhysicalQ5DenseBatchA1950(), columnPhysicalQ5DenseBatchB1950()}
 	dir, d, col, closeFn := openColumnStoreCompactionFixture1953(t, predicateAggregateMetadataConfig1951(), batches)
+	defer func() { closeFn() }()
 	events := flattenColumnPhysicalEvents1950(batches)
 	latest := latestEventMap1953(events)
 
@@ -199,7 +200,6 @@ func TestColumnStoreCompactRebuildsAggregateMetadata1953(t *testing.T) {
 	assertColumnStoreCompactionRefsReclaimable1953(t, col, oldMetadataRefs)
 
 	_, col, closeFn = checkpointAndReopenTypedColumnLatestVisibleFixture1953(t, dir, d, closeFn)
-	defer closeFn()
 	reopened, err := col.RunColumnPhysicalQuery(metadataReq)
 	if err != nil {
 		t.Fatalf("RunColumnPhysicalQuery metadata after compaction reopen: %v", err)
@@ -272,6 +272,7 @@ func TestColumnStoreCompactPostCompactionWritesAdvanceFromCompactedManifest1953(
 		{ID: "b", TimeUS: 200, Kind: "commit", Operation: "create", Collection: "app.bsky.feed.like", Did: "did:b"},
 	}}
 	dir, d, col, closeFn := openTypedColumnLatestVisibleFixture1953(t, nil, batches)
+	defer func() { closeFn() }()
 	events := flattenColumnPhysicalEvents1950(batches)
 	latest := latestEventMap1953(events)
 
@@ -328,7 +329,6 @@ func TestColumnStoreCompactPostCompactionWritesAdvanceFromCompactedManifest1953(
 	}
 
 	_, col, closeFn = checkpointAndReopenTypedColumnLatestVisibleFixture1953(t, dir, d, closeFn)
-	defer closeFn()
 	reopened, err := col.RunColumnPhysicalQuery(ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount, GroupColumn: "collection"})
 	if err != nil {
 		t.Fatalf("RunColumnPhysicalQuery post-compaction writes reopen: %v", err)
@@ -395,6 +395,7 @@ func TestColumnStoreCompactAllRowsDeletedPublishesEmptyInsertOnlyManifest1953(t 
 		{ID: "b", TimeUS: 200, Kind: "commit", Operation: "create", Collection: "app.bsky.feed.post", Did: "did:b"},
 	}}
 	dir, d, col, closeFn := openTypedColumnLatestVisibleFixture1953(t, nil, batches)
+	defer func() { closeFn() }()
 
 	deleteTypedColumnEvent1953(t, col, "a")
 	deleteTypedColumnEvent1953(t, col, "b")
@@ -425,7 +426,6 @@ func TestColumnStoreCompactAllRowsDeletedPublishesEmptyInsertOnlyManifest1953(t 
 	}
 
 	_, col, closeFn = checkpointAndReopenTypedColumnLatestVisibleFixture1953(t, dir, d, closeFn)
-	defer closeFn()
 	reopened, err := col.RunColumnPhysicalQuery(ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount, GroupColumn: "collection"})
 	if err != nil {
 		t.Fatalf("RunColumnPhysicalQuery all deleted reopen: %v", err)
@@ -655,6 +655,9 @@ func assertColumnStoreCompactionManifestOnlyGeneration1953(tb testing.TB, record
 	}
 	if wantAggregateMetadata && aggregateRecords == 0 {
 		tb.Fatal("compacted manifest has no aggregate metadata records")
+	}
+	if !wantAggregateMetadata && aggregateRecords != 0 {
+		tb.Fatalf("compacted manifest has %d aggregate metadata records, want none", aggregateRecords)
 	}
 }
 

--- a/TreeDB/collections/column_store_compaction_test.go
+++ b/TreeDB/collections/column_store_compaction_test.go
@@ -555,7 +555,19 @@ func loadColumnStoreCompactionManifestView1953(tb testing.TB, d *backenddb.DB, c
 	if err != nil {
 		tb.Fatalf("loadColumnManifestSnapshotViewForScanFromRoot: %v", err)
 	}
-	return columnStoreCompactionManifestView1953{cfg: cfg, manifest: manifest, records: records, mutationParts: mutationParts, rootID: rootID}
+	return columnStoreCompactionManifestView1953{cfg: cfg, manifest: cloneColumnStoreCompactionManifestSnapshot1953(manifest), records: cloneColumnManifestRecords(records), mutationParts: mutationParts, rootID: rootID}
+}
+
+func cloneColumnStoreCompactionManifestSnapshot1953(manifest columnManifestSnapshot) columnManifestSnapshot {
+	clone := manifest
+	clone.Parts = append([]columnManifestPartSnapshot(nil), manifest.Parts...)
+	for i := range clone.Parts {
+		clone.Parts[i].SortKey = cloneColumnSortKeys(manifest.Parts[i].SortKey)
+	}
+	clone.AggregateMetadata = append([]columnManifestAggregateMetadataSnapshot(nil), manifest.AggregateMetadata...)
+	clone.DictionaryCodes = append([]columnManifestDictionaryCodesSnapshot(nil), manifest.DictionaryCodes...)
+	clone.Int64Values = append([]columnManifestInt64ValuesSnapshot(nil), manifest.Int64Values...)
+	return clone
 }
 
 func columnStoreCompactionRefsFromRecordsForTest1953(tb testing.TB, records []columnManifestRecord) []ColumnAssetRef {

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -356,6 +356,8 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/document_materializer_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 32, occurrences: 32},
 	{path: "TreeDB/collections/document_projection.go", classification: typedStorageLegacyCompatibility, matchingLines: 3, occurrences: 3},
 	{path: "TreeDB/collections/column_store.go", classification: typedStorageLegacyCompatibility, matchingLines: 83, occurrences: 139},
+	{path: "TreeDB/collections/column_store_compaction.go", classification: typedStorageLegacyCompatibility, matchingLines: 35, occurrences: 42},
+	{path: "TreeDB/collections/column_store_compaction_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 69, occurrences: 80},
 	{path: "TreeDB/collections/column_store_compatibility_api_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 7, occurrences: 9},
 	{path: "TreeDB/collections/column_store_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 209, occurrences: 270},
 	{path: "TreeDB/collections/column_vector_graph_document_id_state.go", classification: typedStorageLegacyDerived, matchingLines: 25, occurrences: 28},

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -356,7 +356,7 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/document_materializer_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 32, occurrences: 32},
 	{path: "TreeDB/collections/document_projection.go", classification: typedStorageLegacyCompatibility, matchingLines: 3, occurrences: 3},
 	{path: "TreeDB/collections/column_store.go", classification: typedStorageLegacyCompatibility, matchingLines: 83, occurrences: 139},
-	{path: "TreeDB/collections/column_store_compaction.go", classification: typedStorageLegacyCompatibility, matchingLines: 36, occurrences: 43},
+	{path: "TreeDB/collections/column_store_compaction.go", classification: typedStorageLegacyCompatibility, matchingLines: 34, occurrences: 41},
 	{path: "TreeDB/collections/column_store_compaction_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 69, occurrences: 80},
 	{path: "TreeDB/collections/column_store_compatibility_api_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 7, occurrences: 9},
 	{path: "TreeDB/collections/column_store_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 209, occurrences: 270},

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -356,7 +356,7 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/document_materializer_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 32, occurrences: 32},
 	{path: "TreeDB/collections/document_projection.go", classification: typedStorageLegacyCompatibility, matchingLines: 3, occurrences: 3},
 	{path: "TreeDB/collections/column_store.go", classification: typedStorageLegacyCompatibility, matchingLines: 83, occurrences: 139},
-	{path: "TreeDB/collections/column_store_compaction.go", classification: typedStorageLegacyCompatibility, matchingLines: 34, occurrences: 41},
+	{path: "TreeDB/collections/column_store_compaction.go", classification: typedStorageLegacyCompatibility, matchingLines: 36, occurrences: 43},
 	{path: "TreeDB/collections/column_store_compaction_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 69, occurrences: 80},
 	{path: "TreeDB/collections/column_store_compatibility_api_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 7, occurrences: 9},
 	{path: "TreeDB/collections/column_store_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 209, occurrences: 270},

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -356,7 +356,7 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/document_materializer_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 32, occurrences: 32},
 	{path: "TreeDB/collections/document_projection.go", classification: typedStorageLegacyCompatibility, matchingLines: 3, occurrences: 3},
 	{path: "TreeDB/collections/column_store.go", classification: typedStorageLegacyCompatibility, matchingLines: 83, occurrences: 139},
-	{path: "TreeDB/collections/column_store_compaction.go", classification: typedStorageLegacyCompatibility, matchingLines: 35, occurrences: 42},
+	{path: "TreeDB/collections/column_store_compaction.go", classification: typedStorageLegacyCompatibility, matchingLines: 34, occurrences: 41},
 	{path: "TreeDB/collections/column_store_compaction_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 69, occurrences: 80},
 	{path: "TreeDB/collections/column_store_compatibility_api_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 7, occurrences: 9},
 	{path: "TreeDB/collections/column_store_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 209, occurrences: 270},

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -357,7 +357,7 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/document_projection.go", classification: typedStorageLegacyCompatibility, matchingLines: 3, occurrences: 3},
 	{path: "TreeDB/collections/column_store.go", classification: typedStorageLegacyCompatibility, matchingLines: 83, occurrences: 139},
 	{path: "TreeDB/collections/column_store_compaction.go", classification: typedStorageLegacyCompatibility, matchingLines: 34, occurrences: 41},
-	{path: "TreeDB/collections/column_store_compaction_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 69, occurrences: 80},
+	{path: "TreeDB/collections/column_store_compaction_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 71, occurrences: 82},
 	{path: "TreeDB/collections/column_store_compatibility_api_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 7, occurrences: 9},
 	{path: "TreeDB/collections/column_store_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 209, occurrences: 270},
 	{path: "TreeDB/collections/column_vector_graph_document_id_state.go", classification: typedStorageLegacyDerived, matchingLines: 25, occurrences: 28},


### PR DESCRIPTION
## Summary

C5 for #1953: typed-column mutation compaction plus aggregate-metadata/sidecar rebuild.

- Adds explicit `Collection.ColumnStoreCompact(ctx, opts)` maintenance API for typed-storage logical compaction.
- Materializes latest-visible live rows from mutation-bearing typed manifests and republishes one insert-only generation.
- Rebuilds aggregate metadata and row-asset dictionary/int64 sidecars through existing publish asset builders.
- Tombstones superseded manifest records so stale parts/metadata/sidecars become unreachable, and resets `PhysicalMutationParts`.
- Cleans up newly/partially prepared compaction asset bytes if preparation, cancellation, or other pre-publish errors happen before the manifest root commits; cleanup holds the segment write lock, truncates only when no later bytes were appended, never removes direct-view/shared segment files, and aggregates cleanup failures.
- Deep-copies retained slice-backed column values before compaction republish.
- Reports published/superseded compaction refs/rows only after compaction actually runs and commits.

## Scope boundaries / deferred

- Prepared mutation-bearing physical queries remain fail-closed until #1954. Prepared insert-only paths work after successful compaction when the manifest has no mutation parts.
- #1952 codecs and #1954 lifecycle/pinning are not included.
- Vector graph/index state compaction is intentionally deferred/fail-closed.
- No document-leaf column pointers; the separate `<collection>/column/manifest` catalog root remains intact.

## Local validation

Latest head: `599d5400ef5793b98aaa9d361cab09ee74650108`.

After the slice-clone / rows-stats / prepare-cleanup fix:

- `GOWORK=off go test ./TreeDB/collections -count=1 -run 'TestColumnStoreCompact|TestSystemTargetIteratorTombstoneEntry1953|TestTypedStorageLegacyNameAllowlistIsComplete'` — PASS (`/tmp/orca_issue_graph_1945_1955/1953_c5_focused_after_slice_clone_rows_stats.txt`)
- `GOWORK=off go test ./TreeDB/collections -count=1` — PASS (`/tmp/orca_issue_graph_1945_1955/1953_c5_collections_after_slice_clone_rows_stats.txt`)
- `GOWORK=off go test ./TreeDB/...` — PASS (`/tmp/orca_issue_graph_1945_1955/1953_c5_treedb_all_after_slice_clone_rows_stats.txt`)

Prior latest-main validation at `abc4b5112` included C2/C3/C4 regression tests and passed (`/tmp/orca_issue_graph_1945_1955/1953_c5_focused_after_latest_main_62a65.txt`).

Manager-side validation also ran `go test ./...` and internal xhigh reviews; review artifacts:

- `/tmp/orca_issue_graph_1945_1955/1953_c5_design_plan.md`
- `/tmp/orca_issue_graph_1945_1955/1953_c5_design_review_terminal.txt`
- `/tmp/orca_issue_graph_1945_1955/1953_c5_impl_review_terminal.txt`
- `/tmp/orca_issue_graph_1945_1955/1953_c5_impl_review_followup_terminal.txt`

## Benchmark smoke

Command:

```sh
GOWORK=off go test ./TreeDB/collections -run '^$' -bench 'BenchmarkColumnPhysical(Sorted|Dense)LatestVisible1953/(q2_insert_only|q2_latest_visible|q5_insert_only|q5_latest_visible)$' -benchtime=20x -count=1 -benchmem
```

Artifact: `/tmp/orca_issue_graph_1945_1955/1953_c5_bench_visibility_coordinator_final.txt`

Apple M3 / darwin arm64:

| Benchmark | ns/op | B/op | allocs/op | rows_scanned | rows_matched/reduce_rows | visibility_rows | deleted_rows |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| q2 insert-only | 75,583 | 71,528 | 554 | 11 | 9 / 9 | 0 | 0 |
| q2 latest-visible | 98,875 | 111,839 | 824 | 12 | 8 / 8 | 10 | 1 |
| q5 insert-only | 395,183 | 801,528 | 2,383 | 2,048 | 631 / 631 | 0 | 0 |
| q5 latest-visible | 702,596 | 1,691,992 | 2,632 | 2,049 | 631 / 631 | 2,047 | 1 |

## Review / risk notes

- Internal xhigh Orca implementation review: PASS after follow-up fixes.
- CodeRabbit/Codex comments addressed through `599d5400e`: immediate test fixture cleanup, aggregate-metadata absence assertion, early recovery-authoritative LSN guard, context cancellation re-checks before publish, implicit default manifest-root storage policy support, delayed `Published*`/`SupersededRefs` stats until root-delta commit succeeds, rows-compacted only on real compaction, pre-publish/partial-prepare cleanup, shared-segment cleanup guard with segment write lock, cleanup-error aggregation, best-effort path-error handling, cloned test manifest views after snapshot close, no direct-view/shared segment file removal, and deep cloned retained slice-backed column values.
- Compaction is explicit maintenance; it does not advance command WAL LSN and keeps recovery-authoritative manifest LSN consistent.
- Stale metadata/sidecar refs are tombstoned from the manifest and tested as reclaimable.

Closes part of #1953 (C5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added column-store compaction capability to consolidate and optimize storage of column data.

* **Bug Fixes**
  * Improved deletion handling with proper tombstone marking for deleted entries.
  * Enhanced error handling and asset cleanup during column operations.

* **Tests**
  * Added comprehensive test suite for column-store compaction scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->