### PR TITLE
treedb: reuse catalog planner metadata on mutations

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3109,10 +3109,7 @@ func (c *Collection) CreateIndex(def IndexDefinition) (*CollectionMeta, error) {
 		_ = snap.Close()
 		return nil, err
 	}
-	existingRuntimes, err := (insertBatchPlanner{
-		collection: baseMeta.Name,
-		indexes:    plannerIndexes(baseMeta.Indexes),
-	}).indexRuntimes()
+	existingRuntimes, err := catalog.cachedIndexRuntimes()
 	if err != nil {
 		_ = snap.Close()
 		return nil, err
@@ -8919,13 +8916,15 @@ func (c *Collection) insertBatchOnceWithLockState(
 		unlockIfLocked()
 	}
 
+	indexRuntimes, indexRuntimesErr := catalog.cachedIndexRuntimes()
 	planner := insertBatchPlanner{
-		collection:     meta.Name,
-		primaryRoot:    collectionPrimaryRootName(meta.Name),
-		templateRoot:   collectionTemplateRootName(meta.Name),
-		indexStateRoot: collectionIndexStateRootName(meta.Name),
-		indexes:        plannerIndexes(meta.Indexes),
-		options:        plannerOptions,
+		collection:             meta.Name,
+		primaryRoot:            catalog.primaryRootName,
+		templateRoot:           catalog.templateRootName,
+		indexStateRoot:         catalog.indexStateRootName,
+		cachedIndexRuntimes:    indexRuntimes,
+		cachedIndexRuntimesErr: indexRuntimesErr,
+		options:                plannerOptions,
 	}
 	if bufferIndexedInserts {
 		planner.buildPrimaryVal = clonePrimaryDocument
@@ -9235,7 +9234,7 @@ func insertBatchPlanRootNamesAndBaseIDs(plan *insertBatchPlan, catalog *collecti
 		return nil, nil
 	}
 	if direct := plan.directBufferedInsert; direct != nil && len(direct.rootNames) > 0 {
-		rootNames := append([]string(nil), direct.rootNames...)
+		rootNames := direct.rootNames
 		baseRootIDs := make(map[string]uint64, len(rootNames))
 		for _, rootName := range rootNames {
 			if catalog != nil {
@@ -9781,10 +9780,7 @@ func (c *Collection) deleteBatchOnce(documentIDs [][]byte, commandWALIntent *bac
 		}
 		return 0, nil
 	}
-	runtimes, err := (insertBatchPlanner{
-		collection: c.meta.Name,
-		indexes:    plannerIndexes(c.meta.Indexes),
-	}).indexRuntimes()
+	runtimes, err := catalog.cachedIndexRuntimes()
 	if err != nil {
 		_ = snap.Close()
 		return 0, err
@@ -10057,10 +10053,7 @@ func (c *Collection) deleteDocumentOnce(documentID []byte, commandWALIntent *bac
 		}
 		return false, nil
 	}
-	runtimes, err := (insertBatchPlanner{
-		collection: c.meta.Name,
-		indexes:    plannerIndexes(c.meta.Indexes),
-	}).indexRuntimes()
+	runtimes, err := catalog.cachedIndexRuntimes()
 	if err != nil {
 		_ = snap.Close()
 		return false, err
@@ -12539,10 +12532,7 @@ func (c *Collection) updateDocumentOnceApply(documentID []byte, update func(curr
 	}
 	primaryRoot := catalog.rootID(primaryRootName)
 
-	runtimes, err := (insertBatchPlanner{
-		collection: c.meta.Name,
-		indexes:    plannerIndexes(c.meta.Indexes),
-	}).indexRuntimes()
+	runtimes, err := catalog.cachedIndexRuntimes()
 	if err != nil {
 		_ = snap.Close()
 		return false, false, err
@@ -19538,6 +19528,18 @@ func uniqueIndexRootIDs(catalog *collectionCatalog) map[string]uint64 {
 		return nil
 	}
 	out := make(map[string]uint64)
+	if runtimes, err := catalog.cachedIndexRuntimes(); err == nil && len(runtimes) > 0 {
+		for _, runtime := range runtimes {
+			if !runtime.def.unique {
+				continue
+			}
+			rootID := catalog.rootID(runtimeSecondaryRootName(catalog.meta.Name, runtime))
+			if rootID != 0 {
+				out[runtime.def.name] = rootID
+			}
+		}
+		return out
+	}
 	for _, idx := range catalog.meta.Indexes {
 		if !idx.Unique {
 			continue

--- a/TreeDB/collections/planner.go
+++ b/TreeDB/collections/planner.go
@@ -79,6 +79,8 @@ type insertBatchPlanner struct {
 	templateRoot           string
 	indexStateRoot         string
 	indexes                []indexDefinition
+	cachedIndexRuntimes    []indexRuntime
+	cachedIndexRuntimesErr error
 	options                collectionOptions
 	buildPrimaryVal        func(documentID, document []byte) ([]byte, error)
 	cloneTemplateRunValues bool
@@ -204,7 +206,11 @@ func (p insertBatchPlanner) planInsertBatchWithPreflight(ids, documents [][]byte
 		p.templateRoot = p.collection + "/templates"
 	}
 	persistIndexState := persistIndexStateForOptions(p.options)
-	if len(p.indexes) > 0 && persistIndexState && p.indexStateRoot == "" {
+	runtimes, err := p.indexRuntimes()
+	if err != nil {
+		return nil, err
+	}
+	if len(runtimes) > 0 && persistIndexState && p.indexStateRoot == "" {
 		p.indexStateRoot = p.collection + "/index-state"
 	}
 	if p.buildPrimaryVal == nil {
@@ -212,7 +218,7 @@ func (p insertBatchPlanner) planInsertBatchWithPreflight(ids, documents [][]byte
 	}
 	stats := CollectionInsertStats{
 		Documents: len(documents),
-		Indexes:   len(p.indexes),
+		Indexes:   len(runtimes),
 	}
 	phaseStart := time.Now()
 	preparedDocuments, templateRecords, templateLearned, templateResolver, err := prepareInsertDocuments(documents, p.options)
@@ -249,10 +255,6 @@ func (p insertBatchPlanner) planInsertBatchWithPreflight(ids, documents [][]byte
 	}
 	stats.DuplicateDocumentPreflight = time.Since(phaseStart)
 
-	runtimes, err := p.indexRuntimes()
-	if err != nil {
-		return nil, err
-	}
 	phaseStart = time.Now()
 	uniqueProbes, err := p.planIndexStateAndUniqueProbes(items, runtimes)
 	stats.IndexStateExtraction = time.Since(phaseStart)
@@ -544,6 +546,9 @@ func rejectDuplicateDocumentIDs(items []insertBatchItem, order []int) error {
 }
 
 func (p insertBatchPlanner) indexRuntimes() ([]indexRuntime, error) {
+	if p.cachedIndexRuntimes != nil || p.cachedIndexRuntimesErr != nil {
+		return p.cachedIndexRuntimes, p.cachedIndexRuntimesErr
+	}
 	runtimes := make([]indexRuntime, len(p.indexes))
 	seen := make(map[string]struct{}, len(p.indexes))
 	for i, idx := range p.indexes {
@@ -773,10 +778,22 @@ func (p insertBatchPlanner) emitTemplateRun(plan *insertBatchPlan, records []tem
 }
 
 func (p insertBatchPlanner) buildDirectBufferedInsertPlan(plan *insertBatchPlan, items []insertBatchItem, primaryOrder []int, runtimes []indexRuntime, persistIndexState bool, templateRecords []templateV1Record) error {
+	rootCap := 1
+	if len(templateRecords) > 0 {
+		rootCap++
+	}
+	if len(runtimes) > 0 {
+		if persistIndexState {
+			rootCap++
+		}
+		rootCap += len(runtimes)
+	}
 	direct := &directBufferedInsertPlan{
 		templateRootName:   p.templateRoot,
 		primaryRootName:    p.primaryRoot,
 		indexStateRootName: p.indexStateRoot,
+		rootNames:          make([]string, 0, rootCap),
+		policies:           make([]backenddb.OrderedRootStoragePolicy, 0, rootCap),
 	}
 	if len(templateRecords) > 0 {
 		phaseStart := time.Now()


### PR DESCRIPTION
## Summary

Linked tracker: #2051, M4 broader native server profiling.

This PR reuses immutable collection catalog metadata in insert/update/delete hot paths instead of rebuilding planner index/runtime metadata per mutation:

- feeds cached root names and cached `indexRuntime` slices into `insertBatchPlanner`;
- computes insert planner runtimes once per plan and reuses them for stats, index-state planning, and direct buffered planning;
- avoids copying direct buffered insert root-name slices after planning, because the publish/validation paths only read them and the column-store path clones before appending;
- reuses cached catalog index runtimes in create-index backfill, delete, single update, and unique-index preflight helpers;
- preallocates direct buffered insert root-name/policy slices for the known root count.

The scope is intentionally limited to metadata/planner allocation removal. It does not change catalog/schema guard semantics, value-log persistence behavior, or on-disk formats.

## Tests

```sh
git diff --check

go test ./TreeDB/collections -run 'TestInsertBatchPlanner|TestOrderedIndexStateForDocument|TestCollectionIndexed|TestBufferedIndexed|TestCollection.*Insert|TestCollection.*Update|TestCollection.*Delete|TestCreateIndex' -count=1

go test ./TreeDB/nativewire -run 'Test.*InsertBatch|Test.*Mutation|Test.*Replace|Test.*Update' -count=1

go test ./TreeDB/nativewire ./cmd/treedb-native-server -count=1

go test ./TreeDB/collections -count=1
```

Results:

- `go test ./TreeDB/collections ... focused ...`: passed, `6.128s`
- `go test ./TreeDB/nativewire ... focused ...`: passed, `0.350s`
- `go test ./TreeDB/nativewire ./cmd/treedb-native-server -count=1`: passed, nativewire `1.251s`, server no test files
- `go test ./TreeDB/collections -count=1`: passed, `87.586s`

## Microbenchmark

Command:

```sh
TREEDB_COLLECTION_BENCH_BATCH_SIZE=1 go test ./TreeDB/collections \
  -run '^$' \
  -bench '^BenchmarkCollectionShapeInsertBatch$/^indexes_1$' \
  -benchmem \
  -count=6 \
  -benchtime=500ms

benchstat /tmp/treedb_borrow_primary_refs_baseline_bench.txt \
  /tmp/treedb_insert_planner_cache_current_bench.txt
```

Context:

- CPU: `11th Gen Intel(R) Core(TM) i5-11400F @ 2.60GHz`
- baseline: merged `main` `d674715f8`
- candidate: `fc93d9e9c753e6ee29dc80a0568170be7a44e820`
- artifacts: `/tmp/treedb_borrow_primary_refs_baseline_bench.txt`, `/tmp/treedb_insert_planner_cache_current_bench.txt`

| Benchmark | Baseline | Candidate | Delta |
| --- | ---: | ---: | ---: |
| `CollectionShapeInsertBatch/indexes_1` | `9.408us +/- 6%` | `8.242us +/- 8%` | `-12.39%`, p=0.004 |
| `B/op` | `4.506Ki +/- 34%` | `3.906Ki +/- 42%` | `-13.32%`, p=0.041 |
| `allocs/op` | `50.00` | `39.00` | `-22.00%`, p=0.002 |

## YCSB Evidence

Commands:

```sh
go build -o bin/treedb-native-server ./cmd/treedb-native-server

TREEDB_NATIVE_SLOW_REQUEST=5ms ./bin/treedb-native-server \
  -dir "$DB_DIR" \
  -profile fast \
  -addr 127.0.0.1:17125 \
  -pprof 127.0.0.1:18125

./bin/go-ycsb load treedb-native \
  -p treedb.addr=127.0.0.1:17125 \
  -p recordcount=100000 \
  -p operationcount=10000 \
  -p threadcount=16

./bin/go-ycsb run treedb-native \
  -p treedb.addr=127.0.0.1:17125 \
  -p recordcount=100000 \
  -p operationcount=1000000 \
  -p threadcount=16
```

Context:

- server profile: `fast`
- slow request threshold: `TREEDB_NATIVE_SLOW_REQUEST=5ms`
- pprof captured during the 1M run
- go-ycsb: `/home/mikers/dev/pingcap/go-ycsb`, `master` `6f6d1b7fb91e`

| Build | Artifact | Load OPS | Insert avg | Insert max | Run total OPS | Read avg | Read p99 | Update avg | Update p99 | Update max | Errors |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| baseline `main` `d674715f8` | `/tmp/treedb_ycsb_main_d674_retry_1780231619` | `46703.8` | `328us` | `8967us` | `97030.5` | `149us` | `465us` | `351us` | `886us` | `5591us` | `0` |
| candidate `fc93d9e9c` | `/tmp/treedb_ycsb_insert_planner_cache_current_1780234709` | `49299.0` | `311us` | `8231us` | `96724.7` | `150us` | `466us` | `352us` | `890us` | `5415us` | `0` |

Slow requests over 5ms on the candidate run:

```text
create_collection 1
flush_all 2
insert_batch_fast 48
```

CPU profile artifact: `/tmp/treedb_ycsb_insert_planner_cache_current_1780234709/server_cpu.pprof`.

The 1M run path remains dominated by nativewire socket I/O and read/update work rather than catalog stats retry amplification. The small total run OPS delta versus baseline is within observed run-to-run noise and is not a material regression; load throughput improves about 5.6% in the standard 100k load.

## Risk / Review Notes

- `collectionCatalog` is immutable after publication, so sharing cached runtime slices is safe under the existing catalog cache model.
- `insertBatchPlanRootNamesAndBaseIDs` now returns `direct.rootNames` directly for direct buffered insert plans. The validation and publish paths read the slice; column publish clones root names before appending the column manifest root.
- `planInsertBatchWithPreflight` now normalizes index runtimes before document preparation. Catalog-backed metadata is already normalized; this only changes error ordering for invalid planner metadata in direct unit-level use.
- No on-disk format or durability semantics changed.

## AI Review Status

- Codex: pending request after PR creation.
- Copilot: pending request after PR creation.
- CodeRabbit: pending request after PR creation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized batch database operations by implementing index runtime data caching. The system now reuses precomputed index information instead of redundantly rebuilding it during write operations, improving overall database performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->