### PR TITLE
treedb: buffer no-index JSON insert batches

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -8732,10 +8732,11 @@ func (c *Collection) insertBatchOnceWithLockState(
 	}
 	skipInitialNoIndexFlush := false
 	commandWALActive := c.commandWALActive(commandWALIntent)
-	if !commandWALActive && trustedValidBSON && c.canBufferNoIndexInsertBatchAck() && len(c.meta.Indexes) == 0 {
-		if isBSONDocumentFormat(c.meta.Options.DocumentFormat) {
-			skipInitialNoIndexFlush = true
-		}
+	if !commandWALActive &&
+		c.canBufferNoIndexInsertBatchAck() &&
+		len(c.meta.Indexes) == 0 &&
+		canBufferNoIndexInsertBatchFormat(c.meta.Options.DocumentFormat, trustedValidBSON) {
+		skipInitialNoIndexFlush = true
 	}
 	if !skipInitialNoIndexFlush {
 		if err := c.flushBufferedNoIndex(); err != nil {
@@ -8809,7 +8810,8 @@ func (c *Collection) insertBatchOnceWithLockState(
 	plannerOptions.learnTemplateIDs = templateEncoder != nil
 	plannerOptions.allowTemplateV1Stored = templateEncoder.allowsTemplateV1StoredDocuments(c)
 	plannerOptions = collectionOptionsWithTemplateV1Resolver(plannerOptions, snap, catalog)
-	if skipInitialNoIndexFlush && (len(meta.Indexes) != 0 || normalizedDocumentFormat(plannerOptions.documentFormat) != DocumentFormatBSON) {
+	if skipInitialNoIndexFlush &&
+		(len(meta.Indexes) != 0 || !canBufferNoIndexInsertBatchFormat(plannerOptions.documentFormat, trustedValidBSON)) {
 		catalog, meta, plannerOptions, err = c.reloadInsertBatchPlanningSnapshot(&snap, trustedValidBSON, c.flushBufferedNoIndex)
 		if err != nil {
 			return nil, err
@@ -8889,7 +8891,10 @@ func (c *Collection) insertBatchOnceWithLockState(
 			}
 		}
 	}
-	if !commandWALActive && len(meta.Indexes) == 0 && normalizedDocumentFormat(plannerOptions.documentFormat) == DocumentFormatBSON && trustedValidBSON && c.canBufferNoIndexInsertBatchAck() {
+	if !commandWALActive &&
+		len(meta.Indexes) == 0 &&
+		c.canBufferNoIndexInsertBatchAck() &&
+		canBufferNoIndexInsertBatchFormat(plannerOptions.documentFormat, trustedValidBSON) {
 		if resultIDs, buffered, err := c.bufferNoIndexInsertBatch(c.writeDomain, catalog, snap, plannerOptions, ids, documents); buffered {
 			closePlanningSnapshot()
 			return resultIDs, err
@@ -9155,6 +9160,17 @@ func (c *Collection) reloadInsertBatchPlanningSnapshot(
 
 func shouldUseDirectBufferedInsertAccumulators(documentCount int) bool {
 	return documentCount > 0 && documentCount <= DefaultIndexedWriteMemtableAccumulatorBatchDocuments
+}
+
+func canBufferNoIndexInsertBatchFormat(format DocumentFormat, trustedValidBSON bool) bool {
+	switch normalizedDocumentFormat(format) {
+	case DocumentFormatJSON:
+		return true
+	case DocumentFormatBSON:
+		return trustedValidBSON
+	default:
+		return false
+	}
 }
 
 func shouldPlanDirectBufferedInsertAccumulatorsWithMutationLocked(documentCount int) bool {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -2794,25 +2794,28 @@ func TestCollectionInsertBatchBuffersNoIndexJSONBeforeFlush(t *testing.T) {
 		[]byte(`{"name":"ada"}`),
 		[]byte(`{"name":"grace"}`),
 	}
+	firstIDs := [][]byte{[]byte("u1"), []byte("u2")}
 	secondDocs := [][]byte{
 		[]byte(`{"name":"katherine"}`),
 	}
+	secondIDs := [][]byte{[]byte("u3")}
+	wantPending := len(firstDocs) + len(secondDocs)
 	wantU1 := bytes.Clone(firstDocs[0])
 	wantU2 := bytes.Clone(firstDocs[1])
 	wantU3 := bytes.Clone(secondDocs[0])
-	insertedIDs, err := writer.InsertBatch([][]byte{[]byte("u1"), []byte("u2")}, firstDocs)
+	insertedIDs, err := writer.InsertBatch(firstIDs, firstDocs)
 	if err != nil {
 		t.Fatalf("first insert batch: %v", err)
 	}
-	if len(insertedIDs) != 2 || !bytes.Equal(insertedIDs[0], []byte("u1")) || !bytes.Equal(insertedIDs[1], []byte("u2")) {
-		t.Fatalf("inserted ids=%q want [u1 u2]", insertedIDs)
+	if len(insertedIDs) != len(firstIDs) || !bytes.Equal(insertedIDs[0], firstIDs[0]) || !bytes.Equal(insertedIDs[1], firstIDs[1]) {
+		t.Fatalf("inserted ids=%q want %q", insertedIDs, firstIDs)
 	}
-	insertedIDs, err = writer.InsertBatch([][]byte{[]byte("u3")}, secondDocs)
+	insertedIDs, err = writer.InsertBatch(secondIDs, secondDocs)
 	if err != nil {
 		t.Fatalf("second insert batch: %v", err)
 	}
-	if len(insertedIDs) != 1 || !bytes.Equal(insertedIDs[0], []byte("u3")) {
-		t.Fatalf("second inserted ids=%q want [u3]", insertedIDs)
+	if len(insertedIDs) != len(secondIDs) || !bytes.Equal(insertedIDs[0], secondIDs[0]) {
+		t.Fatalf("second inserted ids=%q want %q", insertedIDs, secondIDs)
 	}
 	firstDocs[0][len(firstDocs[0])-2] = 'x'
 	secondDocs[0][len(secondDocs[0])-2] = 'x'
@@ -2820,8 +2823,8 @@ func TestCollectionInsertBatchBuffersNoIndexJSONBeforeFlush(t *testing.T) {
 	if writer.writeDomain == nil {
 		t.Fatal("missing write domain")
 	}
-	if writer.writeDomain.count != 3 || writer.writeDomain.table == nil || writer.writeDomain.table.Len() != 3 {
-		t.Fatalf("write domain count=%d table=%v want three pending rows", writer.writeDomain.count, writer.writeDomain.table)
+	if writer.writeDomain.count != wantPending || writer.writeDomain.table == nil || writer.writeDomain.table.Len() != wantPending {
+		t.Fatalf("write domain count=%d table=%v want %d pending rows", writer.writeDomain.count, writer.writeDomain.table, wantPending)
 	}
 	got, err := reader.Get([]byte("u1"))
 	if err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -720,6 +720,9 @@ func TestCollectionFastJSONLargeDocumentsUseValueLogPointers(t *testing.T) {
 	if _, err := col.InsertBatch(ids, docs); err != nil {
 		t.Fatalf("insert large JSON batch: %v", err)
 	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush large JSON batch: %v", err)
+	}
 	if err := d.Checkpoint(); err != nil {
 		t.Fatalf("checkpoint: %v", err)
 	}
@@ -2764,6 +2767,101 @@ func TestCollectionInsertBatchBuffersNoIndexBSONBeforeFlush(t *testing.T) {
 	}
 	if !bytes.Equal(got, wantU2) {
 		t.Fatalf("reopened BSON doc=%v want %v", got, wantU2)
+	}
+}
+
+func TestCollectionInsertBatchBuffersNoIndexJSONBeforeFlush(t *testing.T) {
+	dir := t.TempDir()
+	d, err := backenddb.Open(backenddb.Options{Dir: dir, Durability: backenddb.DurabilityWALOffRelaxed})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	closeDB := collectionMaintenanceCloseOnce(d.Close)
+	defer func() { _ = closeDB() }()
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	writer, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open writer: %v", err)
+	}
+	reader, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open reader: %v", err)
+	}
+	firstDocs := [][]byte{
+		[]byte(`{"name":"ada"}`),
+		[]byte(`{"name":"grace"}`),
+	}
+	secondDocs := [][]byte{
+		[]byte(`{"name":"katherine"}`),
+	}
+	wantU1 := bytes.Clone(firstDocs[0])
+	wantU2 := bytes.Clone(firstDocs[1])
+	wantU3 := bytes.Clone(secondDocs[0])
+	insertedIDs, err := writer.InsertBatch([][]byte{[]byte("u1"), []byte("u2")}, firstDocs)
+	if err != nil {
+		t.Fatalf("first insert batch: %v", err)
+	}
+	if len(insertedIDs) != 2 || !bytes.Equal(insertedIDs[0], []byte("u1")) || !bytes.Equal(insertedIDs[1], []byte("u2")) {
+		t.Fatalf("inserted ids=%q want [u1 u2]", insertedIDs)
+	}
+	insertedIDs, err = writer.InsertBatch([][]byte{[]byte("u3")}, secondDocs)
+	if err != nil {
+		t.Fatalf("second insert batch: %v", err)
+	}
+	if len(insertedIDs) != 1 || !bytes.Equal(insertedIDs[0], []byte("u3")) {
+		t.Fatalf("second inserted ids=%q want [u3]", insertedIDs)
+	}
+	firstDocs[0][len(firstDocs[0])-2] = 'x'
+	secondDocs[0][len(secondDocs[0])-2] = 'x'
+	insertedIDs[0][0] = 'x'
+	if writer.writeDomain == nil {
+		t.Fatal("missing write domain")
+	}
+	if writer.writeDomain.count != 3 || writer.writeDomain.table == nil || writer.writeDomain.table.Len() != 3 {
+		t.Fatalf("write domain count=%d table=%v want three pending rows", writer.writeDomain.count, writer.writeDomain.table)
+	}
+	got, err := reader.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("reader get buffered JSON doc: %v", err)
+	}
+	if !bytes.Equal(got, wantU1) {
+		t.Fatalf("buffered JSON doc=%v want %v", got, wantU1)
+	}
+	got, err = reader.Get([]byte("u3"))
+	if err != nil {
+		t.Fatalf("reader get second buffered JSON doc: %v", err)
+	}
+	if !bytes.Equal(got, wantU3) {
+		t.Fatalf("second buffered JSON doc=%v want %v", got, wantU3)
+	}
+	if err := writer.Flush(); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+	if got := writer.writeDomain.count; got != 0 {
+		t.Fatalf("pending docs after flush=%d want 0", got)
+	}
+	if err := closeDB(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	reopened, err := backenddb.Open(backenddb.Options{Dir: dir, Durability: backenddb.DurabilityWALOffRelaxed})
+	if err != nil {
+		t.Fatalf("reopen db: %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+	reopenedCol, err := NewCollectionManager(reopened).OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open reopened collection: %v", err)
+	}
+	got, err = reopenedCol.Get([]byte("u2"))
+	if err != nil {
+		t.Fatalf("get after reopen: %v", err)
+	}
+	if !bytes.Equal(got, wantU2) {
+		t.Fatalf("reopened JSON doc=%v want %v", got, wantU2)
 	}
 }
 

--- a/TreeDB/collections/vector_index_rebuild_test.go
+++ b/TreeDB/collections/vector_index_rebuild_test.go
@@ -1691,6 +1691,9 @@ func insertColumnGraphRebuildRowsV2A(tb testing.TB, col *Collection, rows []colu
 	if _, err := col.InsertBatch(ids, docs); err != nil {
 		tb.Fatalf("InsertBatch: %v", err)
 	}
+	if err := col.Flush(); err != nil {
+		tb.Fatalf("Flush: %v", err)
+	}
 }
 
 func insertColumnGraphRebuildDualVectorRowsV2A(tb testing.TB, col *Collection, rows []columnGraphRebuildDualInputRowV2A) {
@@ -1713,6 +1716,9 @@ func insertColumnGraphRebuildDualVectorRowsV2A(tb testing.TB, col *Collection, r
 	}
 	if _, err := col.InsertBatch(ids, docs); err != nil {
 		tb.Fatalf("InsertBatch: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		tb.Fatalf("Flush: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- extend relaxed-mode no-index InsertBatch buffering from validated BSON to JSON
- keep the skip/reload/buffer eligibility checks on one shared document-format predicate
- add a regression test for two separate JSON InsertBatch calls staying buffered before explicit Flush
- update persisted-root/vector rebuild tests to flush before inspecting durable roots

## Evidence
- go test ./TreeDB/collections -run 'TestCollectionInsertBatchBuffersNoIndex(JSON|BSON)BeforeFlush|TestCollectionInsertBatchValidatedBSONNoIndexDurablePublishesBeforeReturn|TestCollectionSingleInsertBufferedNoIndex' -count=1
- go test ./TreeDB/collections -run 'TestCollectionFastJSONLargeDocumentsUseValueLogPointers|TestColumnGraphRebuildNonEmptyWithoutManifestRootFailsClosedV2A|TestCollectionInsertBatchBuffersNoIndexJSONBeforeFlush' -count=1
- go test ./TreeDB/collections -count=1
- go test ./TreeDB/nativewire ./cmd/treedb-native-server -count=1
- go build -o bin/treedb-native-server ./cmd/treedb-native-server

## Benchmarks
Artifacts are local under /tmp.

Before this fix, no-index JSON load stayed on the synchronous path:
- /tmp/treedb_ycsb_noindex_json_patch_1780236753
- load, recordcount=100000, threadcount=16, treedb.create_key_index=false
- 1,677 OPS, avg 9,528us, p99 33,695us, max 452,095us
- slow insert_batch_fast requests over 5ms: 67,566

After this fix, same no-index load/run on a fresh DB:
- /tmp/treedb_ycsb_noindex_json_loadrun_patch_1780237348
- load: 98,877 OPS, avg 143us, p99 483us, max 3,391us
- run: 87,152 total OPS, read avg 153us, update avg 589us, update p99 1,479us, update max 2,057us
- slow requests over 5ms: create_collection 1, flush_all 1
- nativewire errors: 0

Default indexed YCSB sanity check on the same patched build:
- /tmp/treedb_ycsb_default_patch_check_1780237374
- load: 49,116 OPS, avg 311us, p99 993us, max 12,983us
- run: 92,256 total OPS, read avg 155us, update avg 357us, update p99 1,047us, update max 1,934us
- nativewire errors: 0

Refs #2051

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Batch insert buffering now supports JSON-formatted documents for collections without indexes.

* **Refactor**
  * Buffering logic made document-format aware; planning reloads if format later proves ineligible.

* **Tests**
  * Added test validating no-index JSON buffering and persistence; updated several tests/helpers to flush buffered writes after inserts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->