### PR TITLE
nativewire: stop cancel deadline race

### DIFF
--- a/TreeDB/nativewire/client.go
+++ b/TreeDB/nativewire/client.go
@@ -233,10 +233,17 @@ func (c *Client) interruptDeadlineOnContextCancel(ctx context.Context) func() {
 	if c == nil || c.conn == nil || ctx == nil || ctx.Done() == nil {
 		return func() {}
 	}
+	done := make(chan struct{})
 	stop := context.AfterFunc(ctx, func() {
+		defer close(done)
 		_ = c.conn.SetDeadline(time.Now())
 	})
-	return func() { _ = stop() }
+	return func() {
+		if stop() {
+			close(done)
+		}
+		<-done
+	}
 }
 
 func (c *Client) errorOrCanceledOnWire(ctx context.Context, onWire bool, err error) error {

--- a/TreeDB/nativewire/server_test.go
+++ b/TreeDB/nativewire/server_test.go
@@ -471,6 +471,63 @@ func TestClientRoundTripHonorsCancellationWithoutDeadline(t *testing.T) {
 	}
 }
 
+func TestClientCancelDeadlineStopWaitsForRunningCallback(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	conn := &blockingDeadlineConn{
+		entered: make(chan time.Time, 1),
+		release: make(chan struct{}),
+		done:    make(chan struct{}),
+	}
+	client := &Client{conn: conn}
+	stop := client.interruptDeadlineOnContextCancel(ctx)
+	cancel()
+	select {
+	case deadline := <-conn.entered:
+		if deadline.IsZero() {
+			t.Fatal("cancel callback set zero deadline")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("cancel callback did not set deadline")
+	}
+	stopDone := make(chan struct{})
+	go func() {
+		stop()
+		close(stopDone)
+	}()
+	select {
+	case <-stopDone:
+		t.Fatal("stop returned before running cancel callback completed")
+	case <-time.After(25 * time.Millisecond):
+	}
+	close(conn.release)
+	select {
+	case <-stopDone:
+	case <-time.After(time.Second):
+		t.Fatal("stop did not return after cancel callback completed")
+	}
+	select {
+	case <-conn.done:
+	case <-time.After(time.Second):
+		t.Fatal("cancel callback did not complete")
+	}
+}
+
+type blockingDeadlineConn struct {
+	net.Conn
+	entered chan time.Time
+	release chan struct{}
+	done    chan struct{}
+}
+
+func (c *blockingDeadlineConn) SetDeadline(t time.Time) error {
+	if !t.IsZero() {
+		c.entered <- t
+		<-c.release
+		close(c.done)
+	}
+	return nil
+}
+
 func TestClientDetectsErrorResponseRequestIDMismatch(t *testing.T) {
 	left, right := net.Pipe()
 	defer left.Close()


### PR DESCRIPTION
## Objective
Fix a nativewire client cancellation race that can leave a reused connection with an expired deadline after a successful request.

## Context
Tracker: #2051. During treedb-native YCSB validation, a repeated load/run harness reproduced one run worker timing out on its first request, then reporting hundreds of near-zero-latency `READ_ERROR` / `UPDATE_ERROR` events because the same worker kept reusing the closed connection. The same pattern explains earlier exact-thread-quota `INSERT_ERROR` bursts.

Paired benchmark-client PR: snissn/go-ycsb#3.

## Non-goals
- No server mutation semantics change.
- No catalog/idempotency guard change.
- No benchmark throughput optimization beyond removing this correctness flake.

## Design
- `Client.interruptDeadlineOnContextCancel` now waits for a started `context.AfterFunc` deadline callback to finish before returning.
- The existing caller order still clears the connection deadline after stopping the callback.
- Cancellation still interrupts an in-flight blocking read/write by setting the connection deadline.

## Scope
- Includes: `TreeDB/nativewire/client.go`, `TreeDB/nativewire/server_test.go`.
- Excludes: server request dispatch, collection mutation paths, wire format, catalog/version semantics.

## Correctness
- Added deterministic regression coverage for the exact race: force the cancel callback to be running, block its `SetDeadline`, and assert the stop function does not return until the callback completes.
- Tests run:
  - `go test ./TreeDB/nativewire -run 'TestClient(CancelDeadlineStopWaitsForRunningCallback|RoundTripHonorsCancellationWithoutDeadline)' -count=1`
  - `go test ./TreeDB/nativewire ./cmd/treedb-native-server -count=1`
  - `go test ./TreeDB/collections -count=1`

## Performance
Benchmark/repro commands used `treedb-native`, `recordcount=100000`, `operationcount=10000`, `threadcount=16`, fresh DB dirs.

| Evidence | Result |
| --- | --- |
| Before repro `/tmp/treedb_ycsb_logged_error_repro_5ms_1780240364/run_4` | First worker error `read tcp 127.0.0.1:49028->127.0.0.1:17204: i/o timeout`; then repeated `use of closed network connection`; run `READ_ERROR Count: 597`, `UPDATE_ERROR Count: 28`. |
| After stress `/tmp/treedb_ycsb_deadline_fix_verify_1780240585` | 30 consecutive load+run cycles, all with `INSERT_ERROR=0`, `READ_ERROR=0`, `UPDATE_ERROR=0`. |
| After 1ns accounting `/tmp/treedb_ycsb_deadline_fix_1ns_1780240829` | Load `100000` inserts at `45880 OPS`; run `10000` ops at `84874 OPS`; read avg/p99/max `165/705/2793us`; update avg/p99/max `442/1614/2431us`; no YCSB errors. |
| Server command counts in 1ns run | `insert_batch_fast=100000`, `get_many=10000`, `replace_batch=496`, `stats=33`, no catalog mismatch errors. |

## Rollout / Toggle Plan
Default behavior only. Revert this PR to restore the old non-waiting callback stop behavior.

## Follow-ups
- Keep #2051 open for broader treedb-native throughput work after this correctness flake is merged.
- Continue investigating load hot-path allocation/copy costs separately.

## AI Review Loop
- Codex latest-head review: pending.
- Copilot latest-head review: pending.
- CodeRabbit latest-head review: pending.
- Review comments/threads resolved or explicitly dismissed: pending.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability and safety of connection deadline management during context cancellation to prevent potential synchronization issues.

* **Tests**
  * Added test coverage to verify proper synchronization when cancelling connection deadlines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->