### PR TITLE
nativewire: retain catalog cache for no-result inserts

### DIFF
--- a/TreeDB/nativewire/client_mutation.go
+++ b/TreeDB/nativewire/client_mutation.go
@@ -81,7 +81,6 @@ func (c *Client) insertBatchNoResult(ctx context.Context, collection string, han
 		c.clearCatalogVersionOnMismatch(err)
 		return err
 	}
-	c.clearCatalogVersionAfterOpaqueMutation()
 	return nil
 }
 

--- a/TreeDB/nativewire/mutation_test.go
+++ b/TreeDB/nativewire/mutation_test.go
@@ -482,6 +482,42 @@ func TestMutationInsertResponseShapingFlags(t *testing.T) {
 	}
 }
 
+func TestInsertBatchNoResultRetainsCatalogVersionCache(t *testing.T) {
+	client, server, _, _ := serveCollectionPipeWithServer(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := client.Hello(ctx); err != nil {
+		t.Fatalf("Hello: %v", err)
+	}
+	if _, err := client.CreateCollection(ctx, collections.CollectionMeta{Name: "users"}); err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	handle, err := client.OpenCollection(ctx, "users")
+	if err != nil {
+		t.Fatalf("OpenCollection: %v", err)
+	}
+
+	if err := client.InsertBatchHandleNoResult(ctx, handle, collections.DocumentFormatJSON,
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"x":1}`)},
+		AckVisible,
+	); err != nil {
+		t.Fatalf("first InsertBatchHandleNoResult: %v", err)
+	}
+	waitForCounter(t, server, "commands.stats.requests_total", 2)
+
+	if err := client.InsertBatchHandleNoResult(ctx, handle, collections.DocumentFormatJSON,
+		[][]byte{[]byte("u2")},
+		[][]byte{[]byte(`{"x":2}`)},
+		AckVisible,
+	); err != nil {
+		t.Fatalf("second InsertBatchHandleNoResult: %v", err)
+	}
+	if got := server.Stats()[nativeStatsPrefix+"commands.stats.requests_total"]; got != "2" {
+		t.Fatalf("stats requests after cached no-result insert=%s want 2", got)
+	}
+}
+
 func TestMutationInsertRejectsUnsupportedFastFlags(t *testing.T) {
 	client, mgr, _ := serveCollectionPipe(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)


### PR DESCRIPTION
## Objective

Reduce nativewire no-result insert overhead by avoiding a catalog-version cache clear after successful opaque data mutations.

Part of #2051.

## Context

`InsertBatchHandleNoResult` already sends insert requests with `omit_result_ids` and `omit_response_meta`, which means a successful response carries no catalog metadata. The client was treating that successful opaque response as cache invalidation and clearing `catalogVersionPlusOne`. The next no-result insert then had to call `Stats()` to rebuild the same catalog version even though ordinary data mutations do not change catalog metadata.

## Change

- Keep the cached catalog version after successful no-result inserts.
- Preserve mismatch handling: catalog-version mismatch errors still clear the cache before retry/recovery.
- Add a regression test showing the second no-result insert reuses the cached catalog version and does not issue another `Stats()` command.

## Validation

Tests:

```sh
go test ./TreeDB/nativewire -run "Test(InsertBatchNoResultRetainsCatalogVersionCache|MutationInsertResponseShapingFlags)" -count=1
go test ./TreeDB/nativewire -count=1
go test ./TreeDB/nativewire ./cmd/treedb-native-server -count=1
```

Benchmarks:

```sh
go test ./TreeDB/nativewire -run "^$" -bench "BenchmarkNativewireCollectionInsertBatch/native_wire_inproc_no_result$" -benchmem -benchtime=500x -count=10
benchstat /tmp/nativewire_no_result_baseline_b2b944d.txt /tmp/nativewire_no_result_patched_cache.txt
```

Benchstat on this host:

```text
NativewireCollectionInsertBatch/native_wire_inproc_no_result-12
sec/op:    252.98us +- 12%  -> 47.09us +- 6%   -81.39% (p=0.000 n=10)
B/op:      258.465Ki +- 0%  -> 7.563Ki +- 2%   -97.07% (p=0.000 n=10)
allocs/op: 906.00 +- 0%     -> 56.00 +- 2%     -93.82% (p=0.000 n=10)
```

## Notes

I also tested omitting response metadata in the go-ycsb adapter, but the YCSB load A/B was flat to slightly negative, so that experiment was backed out and is not included here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where batch insert operations were unnecessarily clearing the internal version cache, which could impact the efficiency of subsequent database operations.

* **Tests**
  * Added test coverage to verify proper cache retention behavior during batch insert operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->