### PR TITLE
tree: fast path single-prefix probes

### DIFF
--- a/TreeDB/db/snapshot_probe_test.go
+++ b/TreeDB/db/snapshot_probe_test.go
@@ -148,6 +148,26 @@ func TestSnapshot_HasManyAtRootAndHasPrefixesAtRoot(t *testing.T) {
 	}
 
 	hasPrefixes, err = snap.HasPrefixesAtRoot(rootIDs[0], [][]byte{
+		[]byte("acct/alice/"),
+	})
+	if err != nil {
+		t.Fatalf("HasPrefixesAtRoot single hit: %v", err)
+	}
+	if want := []bool{true}; !reflect.DeepEqual(hasPrefixes, want) {
+		t.Fatalf("HasPrefixesAtRoot single hit mismatch: got=%v want=%v", hasPrefixes, want)
+	}
+
+	hasPrefixes, err = snap.HasPrefixesAtRoot(rootIDs[0], [][]byte{
+		[]byte("acct/zoe/"),
+	})
+	if err != nil {
+		t.Fatalf("HasPrefixesAtRoot single miss: %v", err)
+	}
+	if want := []bool{false}; !reflect.DeepEqual(hasPrefixes, want) {
+		t.Fatalf("HasPrefixesAtRoot single miss mismatch: got=%v want=%v", hasPrefixes, want)
+	}
+
+	hasPrefixes, err = snap.HasPrefixesAtRoot(rootIDs[0], [][]byte{
 		[]byte("acct/bob/"),
 		[]byte("acct/alice/doc-1"),
 		[]byte("acct/alice/"),
@@ -647,5 +667,25 @@ func TestSnapshotRootProbesSkipTombstones(t *testing.T) {
 	}
 	if want := []bool{false, true, false}; !reflect.DeepEqual(hasPrefixes, want) {
 		t.Fatalf("HasPrefixesAtRoot tombstone mismatch: got=%v want=%v", hasPrefixes, want)
+	}
+
+	hasPrefixes, err = snap.HasPrefixesAtRoot(rootID, [][]byte{
+		[]byte("acct/alice/doc-1"),
+	})
+	if err != nil {
+		t.Fatalf("HasPrefixesAtRoot single tombstone exact: %v", err)
+	}
+	if want := []bool{false}; !reflect.DeepEqual(hasPrefixes, want) {
+		t.Fatalf("HasPrefixesAtRoot single tombstone exact mismatch: got=%v want=%v", hasPrefixes, want)
+	}
+
+	hasPrefixes, err = snap.HasPrefixesAtRoot(rootID, [][]byte{
+		[]byte("acct/alice/"),
+	})
+	if err != nil {
+		t.Fatalf("HasPrefixesAtRoot single tombstone prefix: %v", err)
+	}
+	if want := []bool{true}; !reflect.DeepEqual(hasPrefixes, want) {
+		t.Fatalf("HasPrefixesAtRoot single tombstone prefix mismatch: got=%v want=%v", hasPrefixes, want)
 	}
 }

--- a/TreeDB/tree/tree.go
+++ b/TreeDB/tree/tree.go
@@ -987,6 +987,14 @@ func (t *Tree) HasPrefixesWithStats(prefixes [][]byte) ([]bool, ProbeFallbackSta
 	if len(prefixes) == 0 {
 		return out, stats, nil
 	}
+	if len(prefixes) == 1 {
+		found, err := t.hasPrefix(prefixes[0])
+		if err != nil {
+			return nil, stats, err
+		}
+		out[0] = found
+		return out, stats, nil
+	}
 
 	type prefixProbeRef struct {
 		prefix []byte
@@ -1043,4 +1051,29 @@ func (t *Tree) HasPrefixesWithStats(prefixes [][]byte) ([]bool, ProbeFallbackSta
 		return nil, stats, err
 	}
 	return out, stats, nil
+}
+
+func (t *Tree) hasPrefix(prefix []byte) (bool, error) {
+	it := t.IteratorWithOptions(prefix, nil, IteratorOptions{Mode: IteratorModeKeysOnly})
+	defer func() { _ = it.Close() }()
+	for {
+		if !it.Valid() {
+			if err := it.Error(); err != nil {
+				return false, err
+			}
+			return false, nil
+		}
+		curr := it.UnsafeKey()
+		if compareTreeKey(curr, prefix) < 0 {
+			it.Seek(prefix)
+			continue
+		}
+		if !bytes.HasPrefix(curr, prefix) {
+			return false, it.Error()
+		}
+		if !it.IsDeleted() {
+			return true, it.Error()
+		}
+		it.Next()
+	}
 }


### PR DESCRIPTION
## Summary

- Add a single-prefix fast path to `TreeDB/tree.HasPrefixesWithStats` so one-prefix probes avoid batch ref allocation and sorting.
- Add snapshot probe coverage for single-prefix hit, miss, and tombstone behavior.
- Link: #2051

## Scope

This is intentionally narrower than the rejected single-key + single-prefix experiment. The single-key `HasAnySorted` point-lookup shortcut improved a collection microbench but slowed YCSB load, so this PR keeps only the prefix path that survived end-to-end validation.

## Tests

- `go test ./TreeDB/db -run 'TestSnapshot_(HasManyAtRootAndHasPrefixesAtRoot)|TestSnapshotRootProbesSkipTombstones' -count=1`
- `go test ./TreeDB/tree ./TreeDB/db -run 'TestSnapshot_(HasManyAtRootAndHasPrefixesAtRoot|HasAnySortedAtRootRecordsPerItemFallback|HasAnySortedAtRootFallbackDedupesDuplicateKeys)' -count=1`
- `go test ./TreeDB/collections -run 'Test(InsertBatchPlanner|CollectionInsertBatch|CollectionIndexedWrite)' -count=1`
- `go test ./TreeDB/nativewire ./cmd/treedb-native-server -count=1`
- `go test ./TreeDB/tree ./TreeDB/db ./TreeDB/collections ./TreeDB/nativewire ./cmd/treedb-native-server -count=1`
  - `TreeDB/db`: 351.769s
  - `TreeDB/collections`: 137.120s
  - `TreeDB/nativewire`: 1.522s

## Benchmarks

Host: `11th Gen Intel(R) Core(TM) i5-11400F @ 2.60GHz`.
Baseline server: gomap `f6fd84d25`.
Candidate server: this branch.
Client: go-ycsb `master` at `e1e3cb0`.

### Collection microbench

Command:

```sh
TREEDB_COLLECTION_BENCH_BATCH_SIZE=1 go test ./TreeDB/collections \
  -run '^$' \
  -bench 'BenchmarkCollectionInsertBatchWithSecondaryIndexes$' \
  -benchmem -benchtime=2000x -count=10
```

Artifacts: `/tmp/tree_single_probe_baseline.txt`, `/tmp/tree_prefix_probe_candidate.txt`.

| metric | baseline | candidate | delta |
| --- | ---: | ---: | ---: |
| sec/op | 10.640us ±14% | 8.907us ±15% | -16.28% (p=0.009) |
| B/op | 3.983Ki ±0% | 3.983Ki ±0% | no change |
| allocs/op | 46.00 ±0% | 46.00 ±0% | no change |
| disk bytes/doc | 2.098k ±0% | 2.098k ±0% | no change |

### YCSB load

Command per trial:

```sh
./bin/go-ycsb load treedb-native \
  -p treedb.addr=127.0.0.1:PORT \
  -p recordcount=500000 \
  -p operationcount=10000 \
  -p threadcount=16
```

Artifacts: `/tmp/treedb_ycsb_prefix_probe_load_ab_1780247283`.

| trial | baseline OPS | candidate OPS |
| --- | ---: | ---: |
| 1 | 39,682.2 | 40,832.8 |
| 2 | 39,789.6 | 40,536.1 |
| average | 39,735.9 | 40,684.5 |

Average load throughput improved about 2.4%. Insert avg latency moved from about 389us baseline to about 379us candidate.

### YCSB run sanity

Command per trial after a 100k load:

```sh
./bin/go-ycsb run treedb-native \
  -p treedb.addr=127.0.0.1:PORT \
  -p recordcount=100000 \
  -p operationcount=500000 \
  -p threadcount=16
```

Artifacts: `/tmp/treedb_ycsb_prefix_probe_run_ab_1780247355`, `/tmp/treedb_ycsb_prefix_probe_run_rev_1780247393`.

| order | baseline TOTAL OPS | candidate TOTAL OPS |
| --- | ---: | ---: |
| baseline then candidate | 92,737.8 | 91,062.3 |
| candidate then baseline | 90,601.7 | 92,656.7 |
| average | 91,669.8 | 91,859.5 |

No consistent run-phase regression was observed; the result moves with trial order/noise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved prefix query functionality to correctly handle scenarios with tombstoned entries, ensuring accurate prefix matching results.

* **Performance**
  * Optimized single-prefix query performance by eliminating unnecessary processing steps for single-prefix lookups.

* **Tests**
  * Expanded test coverage for prefix query behavior, including edge cases with tombstoned data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->