### PR TITLE
Route column graph search through prepared view

### DIFF
--- a/TreeDB/collections/column_vector_graph_adjacency_direct_source_test.go
+++ b/TreeDB/collections/column_vector_graph_adjacency_direct_source_test.go
@@ -386,6 +386,7 @@ func disableColumnVectorGraphAdjacencyDirectSourcesForTest(tb testing.TB, reader
 		}
 		reader.layer0AdjacencySource = nil
 	}
+	reader.preparedSearch = nil
 	reader.layer0AdjacencySourceUnavailable = true
 	reader.layer0AdjacencySourceFallbackReason = ""
 }
@@ -395,6 +396,7 @@ func releaseColumnVectorGraphAdjacencySourceHandlesForTest(tb testing.TB, reader
 	if reader == nil {
 		return
 	}
+	reader.preparedSearch = nil
 	if reader.adjacencyLayerSources != nil {
 		for layer, source := range reader.adjacencyLayerSources.sources {
 			if source == nil {

--- a/TreeDB/collections/column_vector_graph_block_view.go
+++ b/TreeDB/collections/column_vector_graph_block_view.go
@@ -41,6 +41,7 @@ type columnVectorGraphSearchPlan struct {
 	ordinalRefsReady   bool
 	singleOrdinalRange bool
 	scoreSource        columnVectorGraphSearchSource
+	preparedSearch     *columnVectorGraphPreparedSearchView
 	scoreBatchMode     columnVectorGraphScoreBatchMode
 	hits               uint64
 	misses             uint64
@@ -48,6 +49,14 @@ type columnVectorGraphSearchPlan struct {
 }
 
 func (s *columnVectorGraphNativeSearchScratch) prepareSearchPlan(reader *columnVectorGraphPhysicalRowReader) (*columnVectorGraphSearchPlan, error) {
+	return s.prepareSearchPlanInternal(reader, false)
+}
+
+func (s *columnVectorGraphNativeSearchScratch) prepareSearchPlanForNativeSearch(reader *columnVectorGraphPhysicalRowReader) (*columnVectorGraphSearchPlan, error) {
+	return s.prepareSearchPlanInternal(reader, true)
+}
+
+func (s *columnVectorGraphNativeSearchScratch) prepareSearchPlanInternal(reader *columnVectorGraphPhysicalRowReader, useCombinedPrepared bool) (*columnVectorGraphSearchPlan, error) {
 	if s == nil {
 		return nil, errColumnVectorGraphNativeSearchScratchRequired
 	}
@@ -71,6 +80,7 @@ func (s *columnVectorGraphNativeSearchScratch) prepareSearchPlan(reader *columnV
 		plan.singleOrdinalRange = false
 	}
 	plan.physicalReader = physicalReader
+	plan.preparedSearch = nil
 	plan.hits = 0
 	plan.misses = 0
 	plan.builds = 0
@@ -81,6 +91,14 @@ func (s *columnVectorGraphNativeSearchScratch) prepareSearchPlan(reader *columnV
 	} else {
 		plan.ordinalRefsReady = true
 		plan.singleOrdinalRange = true
+	}
+	if useCombinedPrepared && reader.preparedSearch != nil {
+		if err := reader.preparedSearch.validateLive(); err != nil {
+			return nil, fmt.Errorf("collections: column_graph %q combined prepared graph-search view is stale: %w", reader.def.Name, err)
+		}
+		plan.preparedSearch = reader.preparedSearch
+		plan.scoreSource.reset()
+		return plan, nil
 	}
 	if err := plan.scoreSource.prepare(plan); err != nil {
 		return nil, err

--- a/TreeDB/collections/column_vector_graph_inv_norm_state_test.go
+++ b/TreeDB/collections/column_vector_graph_inv_norm_state_test.go
@@ -282,6 +282,7 @@ func TestColumnGraphInvNormStateMissingFallbackAndCorruptFailClosed1992(t *testi
 			}
 			reader.invNormSource = nil
 		}
+		reader.preparedSearch = nil
 		reader.invNormStateUnavailable = true
 		var scratch columnVectorGraphNativeSearchScratch
 		_, _, err = reader.SearchCosine([]float32{1, 0, 0}, columnVectorGraphNativeSearchOptions{TopK: 2, EfSearch: 3}, &scratch)

--- a/TreeDB/collections/column_vector_graph_prepared_scoring.go
+++ b/TreeDB/collections/column_vector_graph_prepared_scoring.go
@@ -142,28 +142,55 @@ func (v columnVectorGraphPreparedVectorView) identityMapping() bool {
 }
 
 func (v columnVectorGraphPreparedVectorView) vectorForOrdinal(ordinal int) ([]float32, typeddecode.Reason, bool) {
-	if !v.ready() || ordinal < 0 || ordinal >= v.rows {
-		return nil, typeddecode.ReasonRowCountMismatch, false
+	part, row, ok := v.locationForOrdinal(ordinal)
+	if !ok {
+		if !v.ready() || ordinal < 0 || ordinal >= v.rows {
+			return nil, typeddecode.ReasonRowCountMismatch, false
+		}
+		return nil, typeddecode.ReasonStaleHandle, false
+	}
+	start := row * v.dims
+	return part.values[start : start+v.dims], "", true
+}
+
+func (v columnVectorGraphPreparedVectorView) locationForOrdinal(ordinal int) (*columnVectorGraphTypedColumnVectorPart, int, bool) {
+	if !v.ready() || ordinal < 0 || ordinal >= v.rows || v.dims <= 0 {
+		return nil, 0, false
 	}
 	if v.singlePart != nil {
-		if v.singlePart.handle == nil || v.singlePart.handle.Released() {
-			return nil, typeddecode.ReasonStaleHandle, false
+		part := v.singlePart
+		if part.handle == nil || part.handle.Released() {
+			return nil, 0, false
 		}
 		row := ordinal
 		if v.rowIndexByOrdinal != nil {
 			row = int(v.rowIndexByOrdinal[ordinal])
 		}
 		start := row * v.dims
-		return v.values[start : start+v.dims], "", true
+		end := start + v.dims
+		if row < 0 || row >= part.rows || start < 0 || end < start || end > len(part.values) {
+			return nil, 0, false
+		}
+		return part, row, true
+	}
+	if ordinal >= len(v.partIndexByOrdinal) || ordinal >= len(v.rowIndexByOrdinal) {
+		return nil, 0, false
 	}
 	partIndex := int(v.partIndexByOrdinal[ordinal])
+	if partIndex < 0 || partIndex >= len(v.parts) {
+		return nil, 0, false
+	}
 	part := v.parts[partIndex]
 	if part == nil || part.handle == nil || part.handle.Released() {
-		return nil, typeddecode.ReasonStaleHandle, false
+		return nil, 0, false
 	}
 	row := int(v.rowIndexByOrdinal[ordinal])
 	start := row * v.dims
-	return part.values[start : start+v.dims], "", true
+	end := start + v.dims
+	if row < 0 || row >= part.rows || start < 0 || end < start || end > len(part.values) {
+		return nil, 0, false
+	}
+	return part, row, true
 }
 
 func (v columnVectorGraphPreparedNormView) ready() bool {

--- a/TreeDB/collections/column_vector_graph_prepared_search.go
+++ b/TreeDB/collections/column_vector_graph_prepared_search.go
@@ -25,6 +25,108 @@ type columnVectorGraphPreparedSearchView struct {
 	vectorIdentityMapping bool
 }
 
+// maybePrepareColumnVectorGraphPreparedSearchView admits the #2045 combined
+// prepared route only when every required current-format state is already
+// mmap_direct. Non-mmap resource/platform fallbacks keep reader.preparedSearch
+// nil so the existing counted source/compatibility path remains available;
+// nil, stale, or malformed prerequisites intentionally fall through to
+// prepareColumnVectorGraphPreparedSearchView so current-format corruption still
+// fails closed.
+func maybePrepareColumnVectorGraphPreparedSearchView(reader *columnVectorGraphPhysicalRowReader) error {
+	if !columnVectorGraphPreparedSearchMmapPrerequisitesPresent(reader) {
+		if reader != nil {
+			reader.preparedSearch = nil
+		}
+		return nil
+	}
+	preparedSearch, err := prepareColumnVectorGraphPreparedSearchView(reader)
+	if err != nil {
+		return err
+	}
+	reader.preparedSearch = preparedSearch
+	return nil
+}
+
+func columnVectorGraphPreparedSearchMmapPrerequisitesPresent(reader *columnVectorGraphPhysicalRowReader) bool {
+	if reader == nil || columnVectorGraphManifestHasPhysicalAsset(reader.graph) || reader.RowCount() <= 0 {
+		return true
+	}
+	if !columnVectorGraphPreparedSearchVectorMmapPrerequisitePresent(reader.typedVectorSource) {
+		return false
+	}
+	if !columnVectorGraphPreparedSearchNormMmapPrerequisitePresent(reader.invNormSource) {
+		return false
+	}
+	if !columnVectorGraphPreparedSearchAdjacencyMmapPrerequisitePresent(reader.adjacencyLayerSources) {
+		return false
+	}
+	if reader.rowRefSource != nil && reader.rowRefSource.preparedViewActive() && reader.rowRefSource.mmapDirectFieldCount() != uint64(len(columnVectorGraphRowRefStateFields)) {
+		return false
+	}
+	if reader.documentIDSource != nil && reader.documentIDSource.preparedViewActive() && !columnVectorGraphDocumentIDSourceMmapDirect(reader.documentIDSource) {
+		return false
+	}
+	return true
+}
+
+func columnVectorGraphPreparedSearchVectorMmapPrerequisitePresent(source *columnVectorGraphTypedColumnVectorSource) bool {
+	if source == nil || source.closed {
+		return true
+	}
+	for _, part := range source.parts {
+		if part == nil {
+			return true
+		}
+		switch part.outcome {
+		case columnVectorGraphTypedColumnVectorOutcomeMmapDirect:
+		case columnVectorGraphTypedColumnVectorOutcomeHeapCopyTypedView, columnVectorGraphTypedColumnVectorOutcomeScratchDecode:
+			return false
+		default:
+			return true
+		}
+		if part.handle == nil || part.handle.Released() {
+			return true
+		}
+	}
+	return true
+}
+
+func columnVectorGraphPreparedSearchNormMmapPrerequisitePresent(source *columnVectorGraphInvNormStateSource) bool {
+	if source == nil || source.closed || (source.handle != nil && source.handle.Released()) {
+		return true
+	}
+	switch source.outcome {
+	case columnVectorGraphInvNormStateOutcomeMmapDirect:
+		return true
+	case columnVectorGraphInvNormStateOutcomeHeapCopyTypedView, columnVectorGraphInvNormStateOutcomeScratchDecode:
+		return false
+	default:
+		return true
+	}
+}
+
+func columnVectorGraphPreparedSearchAdjacencyMmapPrerequisitePresent(group *columnVectorGraphAdjacencyDirectSources) bool {
+	if group == nil || group.closed {
+		return true
+	}
+	for _, source := range group.sources {
+		if source == nil || source.closed {
+			return true
+		}
+		switch source.outcome {
+		case columnVectorGraphLayer0AdjacencySourceOutcomePreparedCSRMmapDirect:
+		case columnVectorGraphLayer0AdjacencySourceOutcomeHeapCopyTypedView, columnVectorGraphLayer0AdjacencySourceOutcomeScratchDecode, columnVectorGraphLayer0AdjacencySourceOutcomeTypedListMmapDirect, columnVectorGraphLayer0AdjacencySourceOutcomeTypedListHeapCopyTypedView, columnVectorGraphLayer0AdjacencySourceOutcomeTypedListScratchDecode:
+			return false
+		default:
+			return true
+		}
+		if source.offsetsHandle == nil || source.valuesHandle == nil || source.offsetsHandle.Released() || source.valuesHandle.Released() {
+			return true
+		}
+	}
+	return true
+}
+
 func prepareColumnVectorGraphPreparedSearchView(reader *columnVectorGraphPhysicalRowReader) (*columnVectorGraphPreparedSearchView, error) {
 	if reader == nil {
 		return nil, errNilColumnVectorGraphPhysicalRowReader

--- a/TreeDB/collections/column_vector_graph_prepared_search.go
+++ b/TreeDB/collections/column_vector_graph_prepared_search.go
@@ -1,0 +1,419 @@
+package collections
+
+import (
+	"errors"
+	"fmt"
+	"math"
+
+	"github.com/snissn/gomap/TreeDB/internal/vectorops"
+)
+
+// columnVectorGraphPreparedSearchView is the #2045 combined prepared view for
+// healthy current-format column_graph search. It is assembled once at reader
+// open from already-admitted #2038/#2040/#2041 state and is then consumed by the
+// HNSW search loop without per-candidate source/fallback selection.
+type columnVectorGraphPreparedSearchView struct {
+	rows int
+	dims int
+
+	vector                columnVectorGraphPreparedVectorView
+	norm                  columnVectorGraphPreparedNormView
+	adjacency             *columnVectorGraphAdjacencyDirectSources
+	rowRefs               *columnVectorGraphRowRefStateSource
+	documentIDs           *columnVectorGraphDocumentIDStateSource
+	documentIDsMmapDirect bool
+	vectorIdentityMapping bool
+}
+
+func prepareColumnVectorGraphPreparedSearchView(reader *columnVectorGraphPhysicalRowReader) (*columnVectorGraphPreparedSearchView, error) {
+	if reader == nil {
+		return nil, errNilColumnVectorGraphPhysicalRowReader
+	}
+	if columnVectorGraphManifestHasPhysicalAsset(reader.graph) {
+		return nil, errors.New("legacy physical graph-row asset is compatibility-only")
+	}
+	rows := reader.RowCount()
+	if rows != reader.graph.RowCount {
+		return nil, fmt.Errorf("row_count=%d want graph rows=%d", rows, reader.graph.RowCount)
+	}
+	if rows <= 0 {
+		return &columnVectorGraphPreparedSearchView{rows: rows, dims: reader.def.Dimensions}, nil
+	}
+	vector, reason, description, ok := prepareColumnVectorGraphPreparedVectorView(reader.typedVectorSource, rows, reader.def.Dimensions)
+	if !ok {
+		if description != "" {
+			return nil, fmt.Errorf("base vector prepared view unavailable reason=%s: %s", reason, description)
+		}
+		return nil, fmt.Errorf("base vector prepared view unavailable reason=%s", reason)
+	}
+	norm, normReason, ok := prepareColumnVectorGraphPreparedNormView(reader.invNormSource, rows)
+	if !ok {
+		return nil, fmt.Errorf("inverse-norm prepared view unavailable reason=%s", normReason)
+	}
+	view := &columnVectorGraphPreparedSearchView{
+		rows:                  rows,
+		dims:                  reader.def.Dimensions,
+		vector:                vector,
+		norm:                  norm,
+		adjacency:             reader.adjacencyLayerSources,
+		rowRefs:               reader.rowRefSource,
+		documentIDs:           reader.documentIDSource,
+		documentIDsMmapDirect: columnVectorGraphDocumentIDSourceMmapDirect(reader.documentIDSource),
+		vectorIdentityMapping: vector.identityMapping(),
+	}
+	if err := view.validateLive(); err != nil {
+		return nil, err
+	}
+	return view, nil
+}
+
+func (v *columnVectorGraphPreparedSearchView) ready() bool {
+	return v != nil && v.rows >= 0 && v.dims > 0 && v.vector.ready() && v.norm.ready() && v.adjacency != nil && v.rowRefs != nil && v.documentIDs != nil
+}
+
+func (v *columnVectorGraphPreparedSearchView) validateLive() error {
+	if v == nil {
+		return errors.New("nil prepared graph-search view")
+	}
+	if v.rows < 0 || v.dims <= 0 {
+		return fmt.Errorf("invalid rows/dims=(%d,%d)", v.rows, v.dims)
+	}
+	if v.rows == 0 {
+		return nil
+	}
+	if !v.vector.ready() {
+		return errors.New("base vector prepared view is not ready")
+	}
+	if !v.norm.ready() {
+		return errors.New("inverse-norm prepared view is not ready")
+	}
+	if err := v.validateVectorLive(); err != nil {
+		return err
+	}
+	if err := v.validateNormLive(); err != nil {
+		return err
+	}
+	if err := validateColumnVectorGraphPreparedSearchAdjacency(v.adjacency, v.rows); err != nil {
+		return err
+	}
+	if v.rowRefs == nil || !v.rowRefs.preparedViewActive() {
+		return errors.New("row-ref prepared view is not active")
+	}
+	if got, want := v.rowRefs.mmapDirectFieldCount(), uint64(len(columnVectorGraphRowRefStateFields)); got != want {
+		return fmt.Errorf("row-ref prepared mmap fields=%d want %d", got, want)
+	}
+	if v.documentIDs == nil || !v.documentIDs.preparedViewActive() {
+		return errors.New("document-id prepared bytes view is not active")
+	}
+	if !v.documentIDsMmapDirect {
+		return errors.New("document-id prepared bytes view is not mmap_direct")
+	}
+	return nil
+}
+
+func (v *columnVectorGraphPreparedSearchView) validateVectorLive() error {
+	if v == nil || !v.vector.ready() {
+		return errors.New("base vector prepared view is not ready")
+	}
+	if v.vector.rows != v.rows || v.vector.dims != v.dims {
+		return fmt.Errorf("base vector prepared rows/dims=(%d,%d) want (%d,%d)", v.vector.rows, v.vector.dims, v.rows, v.dims)
+	}
+	if v.vector.singlePart != nil {
+		part := v.vector.singlePart
+		if part.handle == nil || part.handle.Released() {
+			return fmt.Errorf("base vector prepared single-part handle is stale: %w", errColumnVectorGraphManifestMismatch)
+		}
+		if part.outcome != columnVectorGraphTypedColumnVectorOutcomeMmapDirect {
+			return fmt.Errorf("base vector prepared single-part outcome=%s want mmap_direct", part.outcome)
+		}
+		if len(v.vector.values) != part.rows*v.dims {
+			return fmt.Errorf("base vector prepared single-part values=%d want rows*dims=%d", len(v.vector.values), part.rows*v.dims)
+		}
+		return nil
+	}
+	if len(v.vector.parts) == 0 || len(v.vector.partIndexByOrdinal) != v.rows || len(v.vector.rowIndexByOrdinal) != v.rows {
+		return errors.New("base vector prepared multipart mapping is incomplete")
+	}
+	for i, part := range v.vector.parts {
+		if part == nil || part.handle == nil || part.handle.Released() {
+			return fmt.Errorf("base vector prepared part[%d] handle is stale", i)
+		}
+		if part.outcome != columnVectorGraphTypedColumnVectorOutcomeMmapDirect {
+			return fmt.Errorf("base vector prepared part[%d] outcome=%s want mmap_direct", i, part.outcome)
+		}
+		if len(part.values) != part.rows*v.dims {
+			return fmt.Errorf("base vector prepared part[%d] values=%d want rows*dims=%d", i, len(part.values), part.rows*v.dims)
+		}
+	}
+	return nil
+}
+
+func (v *columnVectorGraphPreparedSearchView) validateNormLive() error {
+	if v == nil || !v.norm.ready() {
+		return errors.New("inverse-norm prepared view is not ready")
+	}
+	if v.norm.rows != v.rows || len(v.norm.values) != v.rows {
+		return fmt.Errorf("inverse-norm prepared rows/values=(%d,%d) want rows=%d", v.norm.rows, len(v.norm.values), v.rows)
+	}
+	if v.norm.source == nil || v.norm.source.closed || (v.norm.source.handle != nil && v.norm.source.handle.Released()) {
+		return errors.New("inverse-norm prepared handle is stale")
+	}
+	if v.norm.source.outcome != columnVectorGraphInvNormStateOutcomeMmapDirect {
+		return fmt.Errorf("inverse-norm prepared outcome=%s want mmap_direct", v.norm.source.outcome)
+	}
+	return nil
+}
+
+func validateColumnVectorGraphPreparedSearchAdjacency(group *columnVectorGraphAdjacencyDirectSources, rows int) error {
+	if group == nil || group.closed || !group.allLayers || len(group.sources) == 0 {
+		return errors.New("adjacency prepared CSR view is not active for all layers")
+	}
+	for layer, source := range group.sources {
+		if source == nil || source.closed {
+			return fmt.Errorf("adjacency prepared CSR layer %d is not active", layer)
+		}
+		if source.rows != rows || len(source.offsets) != rows+1 {
+			return fmt.Errorf("adjacency prepared CSR layer %d rows/offsets=(%d,%d) want (%d,%d)", layer, source.rows, len(source.offsets), rows, rows+1)
+		}
+		if source.outcome != columnVectorGraphLayer0AdjacencySourceOutcomePreparedCSRMmapDirect {
+			return fmt.Errorf("adjacency prepared CSR layer %d outcome=%s want prepared_csr_mmap_direct", layer, source.outcome)
+		}
+		if source.offsetsHandle == nil || source.valuesHandle == nil || source.offsetsHandle.Released() || source.valuesHandle.Released() {
+			return fmt.Errorf("adjacency prepared CSR layer %d handle is stale", layer)
+		}
+	}
+	return nil
+}
+
+func columnVectorGraphDocumentIDSourceMmapDirect(source *columnVectorGraphDocumentIDStateSource) bool {
+	if source == nil || source.manager == nil || !source.preparedViewActive() {
+		return false
+	}
+	stats := source.manager.Stats()
+	return stats.ActiveHandles >= 2 && stats.ActiveMappedBytes > 0 && stats.ActiveHeapCopyBytes == 0
+}
+
+func (v *columnVectorGraphPreparedSearchView) scoreOrdinal(plan *columnVectorGraphSearchPlan, query []float32, queryInvNorm float32, ordinal int, stats *columnVectorGraphNativeSearchStats) (float64, error) {
+	if v == nil || !v.ready() {
+		return 0, errors.New("collections: column_graph prepared graph-search view is unavailable")
+	}
+	if len(query) != v.dims {
+		return 0, fmt.Errorf("collections: column_graph candidate ordinal=%d vector dims=%d want %d: %w", ordinal, v.dims, len(query), errColumnVectorGraphNativeSearchCandidateDimensionMismatch)
+	}
+	vector, reason, ok := v.vector.vectorForOrdinal(ordinal)
+	if !ok {
+		return 0, fmt.Errorf("collections: column_graph prepared vector ordinal=%d unavailable reason=%s", ordinal, reason)
+	}
+	invNorm, reason, ok := v.norm.valueForOrdinal(ordinal)
+	if !ok {
+		return 0, fmt.Errorf("collections: column_graph prepared inverse-norm ordinal=%d unavailable reason=%s", ordinal, reason)
+	}
+	if stats != nil {
+		recordColumnVectorGraphScoreBatchStats(stats, 1, false, true)
+		v.recordScoreStats(stats, plan, 1)
+		v.recordMappingStats(stats, ordinal)
+	}
+	dot := float64(vectorDotProductFloat32(query, vector))
+	if math.IsInf(dot, 0) || math.IsNaN(dot) {
+		if stats != nil {
+			stats.ScoreFloat64Fallbacks++
+		}
+		dot = columnVectorGraphNativeDotProductFloat64(query, vector)
+	}
+	score := dot * float64(queryInvNorm) * float64(invNorm)
+	if math.IsNaN(score) || math.IsInf(score, 0) {
+		return 0, fmt.Errorf("collections: column_graph candidate ordinal=%d cosine score is not finite", ordinal)
+	}
+	return score, nil
+}
+
+func (v *columnVectorGraphPreparedSearchView) scoreOrdinals(plan *columnVectorGraphSearchPlan, query []float32, queryInvNorm float32, ordinals []int, dst []float64, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) ([]float64, error) {
+	if len(ordinals) <= 1 || plan == nil || !plan.scoreBatchMode.indexedEnabled() || scratch == nil {
+		return v.scoreOrdinalsScalar(plan, query, queryInvNorm, ordinals, dst, stats)
+	}
+	if got, ok, err := v.scoreOrdinalsIndexed(plan, query, queryInvNorm, ordinals, dst, scratch, stats); ok || err != nil {
+		return got, err
+	}
+	return v.scoreOrdinalsScalar(plan, query, queryInvNorm, ordinals, dst, stats)
+}
+
+func (v *columnVectorGraphPreparedSearchView) scoreOrdinalsScalar(plan *columnVectorGraphSearchPlan, query []float32, queryInvNorm float32, ordinals []int, dst []float64, stats *columnVectorGraphNativeSearchStats) ([]float64, error) {
+	if cap(dst) < len(ordinals) {
+		dst = make([]float64, len(ordinals))
+	} else {
+		dst = dst[:len(ordinals)]
+	}
+	for i, ordinal := range ordinals {
+		score, err := v.scoreOrdinal(plan, query, queryInvNorm, ordinal, stats)
+		if err != nil {
+			return dst[:i], err
+		}
+		dst[i] = score
+	}
+	return dst, nil
+}
+
+func (v *columnVectorGraphPreparedSearchView) scoreOrdinalsIndexed(plan *columnVectorGraphSearchPlan, query []float32, queryInvNorm float32, ordinals []int, dst []float64, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) ([]float64, bool, error) {
+	if v == nil || !v.ready() || len(query) != v.dims || len(ordinals) == 0 || scratch == nil {
+		return dst, false, nil
+	}
+	if cap(dst) < len(ordinals) {
+		dst = make([]float64, len(ordinals))
+	} else {
+		dst = dst[:len(ordinals)]
+	}
+	maxRun := 0
+	for i := 0; i < len(ordinals); {
+		part, row, ok := v.vector.locationForOrdinal(ordinals[i])
+		if !ok || ordinals[i] < 0 || ordinals[i] >= len(v.norm.values) || uint64(row) > uint64(^uint32(0)) {
+			return dst, false, nil
+		}
+		j := i + 1
+		for j < len(ordinals) {
+			nextPart, nextRow, ok := v.vector.locationForOrdinal(ordinals[j])
+			if !ok || nextPart != part || ordinals[j] < 0 || ordinals[j] >= len(v.norm.values) || uint64(nextRow) > uint64(^uint32(0)) {
+				break
+			}
+			j++
+		}
+		if runLen := j - i; runLen > maxRun {
+			maxRun = runLen
+		}
+		i = j
+	}
+	if maxRun == 0 {
+		return dst, false, nil
+	}
+	scratch.scoreTileRowIDs = ensureColumnVectorGraphNativeUint32Scratch(scratch.scoreTileRowIDs, maxRun)
+	scratch.scoreTileDots = ensureColumnVectorGraphNativeFloat32Scratch(scratch.scoreTileDots, maxRun)
+	var optimizedCalls uint64
+	var scalarFallbackCalls uint64
+	for runStart := 0; runStart < len(ordinals); {
+		part, _, _ := v.vector.locationForOrdinal(ordinals[runStart])
+		runEnd := runStart + 1
+		for runEnd < len(ordinals) {
+			nextPart, _, _ := v.vector.locationForOrdinal(ordinals[runEnd])
+			if nextPart != part {
+				break
+			}
+			runEnd++
+		}
+		runLen := runEnd - runStart
+		rowIDs := scratch.scoreTileRowIDs[:runLen]
+		for i, ordinal := range ordinals[runStart:runEnd] {
+			_, row, _ := v.vector.locationForOrdinal(ordinal)
+			rowIDs[i] = uint32(row)
+		}
+		dots := scratch.scoreTileDots[:runLen]
+		status := vectorops.DotFloat32Indexed(dots, part.values, query, rowIDs, v.dims)
+		if status.Invalid || status.Rows != runLen {
+			return dst, false, nil
+		}
+		if status.Optimized {
+			optimizedCalls++
+		} else {
+			scalarFallbackCalls++
+		}
+		for i, ordinal := range ordinals[runStart:runEnd] {
+			_, row, _ := v.vector.locationForOrdinal(ordinal)
+			vector := part.values[row*v.dims : row*v.dims+v.dims]
+			score, err := columnVectorGraphNativeCosineScoreDot(query, queryInvNorm, ordinal, float64(dots[i]), vector, v.norm.values[ordinal])
+			if err != nil {
+				return dst, true, err
+			}
+			dst[runStart+i] = score
+		}
+		runStart = runEnd
+	}
+	if stats != nil {
+		for runStart := 0; runStart < len(ordinals); {
+			part, _, _ := v.vector.locationForOrdinal(ordinals[runStart])
+			runEnd := runStart + 1
+			for runEnd < len(ordinals) {
+				nextPart, _, _ := v.vector.locationForOrdinal(ordinals[runEnd])
+				if nextPart != part {
+					break
+				}
+				runEnd++
+			}
+			recordColumnVectorGraphScoreBatchStats(stats, runEnd-runStart, false, false)
+			runStart = runEnd
+		}
+		stats.ScoreBatchOptimizedCalls += optimizedCalls
+		stats.ScoreBatchScalarFallbackCalls += scalarFallbackCalls
+		v.recordScoreStats(stats, plan, len(ordinals))
+		for _, ordinal := range ordinals {
+			v.recordMappingStats(stats, ordinal)
+		}
+	}
+	return dst, true, nil
+}
+
+func (v *columnVectorGraphPreparedSearchView) recordScoreStats(stats *columnVectorGraphNativeSearchStats, plan *columnVectorGraphSearchPlan, count int) {
+	if stats == nil || count <= 0 {
+		return
+	}
+	stats.PreparedScoreCalls += uint64(count)
+	stats.VisitedNodes += uint64(count)
+	stats.CandidateFetches += uint64(count)
+	stats.VectorBytesRead += uint64(count * v.dims * 4)
+	stats.NormBytesRead += uint64(count * 4)
+	stats.VectorDirectViews += uint64(count)
+	stats.VectorMmapDirectViews += uint64(count)
+	stats.VectorPreparedDirectViews += uint64(count)
+	stats.NormDirectViews += uint64(count)
+	stats.NormMmapDirectViews += uint64(count)
+	stats.NormPreparedDirectViews += uint64(count)
+	if plan != nil {
+		stats.BlockViewHits = plan.hits
+		stats.BlockViewMisses = plan.misses
+		stats.BlockViewBuilds = plan.builds
+	}
+}
+
+func (v *columnVectorGraphPreparedSearchView) recordMappingStats(stats *columnVectorGraphNativeSearchStats, ordinal int) {
+	if stats == nil {
+		return
+	}
+	if v.vectorIdentityMapping {
+		stats.VectorPreparedIdentityMappings++
+		return
+	}
+	stats.VectorPreparedRowRefMappings++
+}
+
+func (v *columnVectorGraphPreparedSearchView) maxAdjacencyLayerForOrdinal(ordinal int) (int, columnVectorGraphAdjacencySourceCounterSnapshot, error) {
+	if v == nil || v.adjacency == nil {
+		return 0, columnVectorGraphAdjacencySourceCounterSnapshot{}, errors.New("collections: column_graph prepared adjacency view is unavailable")
+	}
+	layer, _, counters, reason, ok := v.adjacency.MaxLayerForOrdinal(ordinal)
+	if !ok {
+		return 0, counters, fmt.Errorf("collections: column_graph prepared adjacency max-layer ordinal=%d unavailable reason=%s", ordinal, reason)
+	}
+	return layer, counters, nil
+}
+
+func (v *columnVectorGraphPreparedSearchView) adjacencyLayerForOrdinal(ordinal int, layer int) ([]uint32, columnVectorGraphLayer0AdjacencySourceOutcome, error) {
+	if v == nil || v.adjacency == nil {
+		return nil, columnVectorGraphLayer0AdjacencySourceOutcomeUnknown, errors.New("collections: column_graph prepared adjacency view is unavailable")
+	}
+	neighbors, outcome, reason, ok := v.adjacency.Neighbors(layer, ordinal)
+	if !ok {
+		return nil, outcome, fmt.Errorf("collections: column_graph prepared adjacency ordinal=%d layer=%d unavailable reason=%s", ordinal, layer, reason)
+	}
+	return neighbors, outcome, nil
+}
+
+func (v *columnVectorGraphPreparedSearchView) documentIDForOrdinal(ordinal int) ([]byte, bool) {
+	if v == nil || v.documentIDs == nil {
+		return nil, false
+	}
+	return v.documentIDs.documentIDForOrdinal(ordinal)
+}
+
+func (v *columnVectorGraphPreparedSearchView) rowRefForOrdinal(ordinal int) (DocumentRowRef, bool) {
+	if v == nil || v.rowRefs == nil {
+		return DocumentRowRef{}, false
+	}
+	return v.rowRefs.rowRefForOrdinal(ordinal)
+}

--- a/TreeDB/collections/column_vector_graph_prepared_search_test.go
+++ b/TreeDB/collections/column_vector_graph_prepared_search_test.go
@@ -98,6 +98,40 @@ func TestColumnVectorGraphPreparedSearchPublicDocumentsReopen2045(t *testing.T) 
 	}
 }
 
+func TestColumnVectorGraphPreparedSearchNonMmapCompatibility2045(t *testing.T) {
+	rows := columnGraphRebuildSyntheticRowsV2A(24, 8)
+	_, d, col, def := openColumnGraphTypedColumnVectorTestCollection1782(t, 8, 4, rows)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	reader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("openColumnVectorGraphPhysicalRowReader: %v", err)
+	}
+	defer func() { _ = reader.Close() }()
+	forceColumnVectorGraphPreparedSearchNonMmapCompatibility2045(reader)
+	if err := maybePrepareColumnVectorGraphPreparedSearchView(reader); err != nil {
+		t.Fatalf("maybePrepareColumnVectorGraphPreparedSearchView: %v", err)
+	}
+	if reader.preparedSearch != nil {
+		t.Fatalf("preparedSearch=%v want nil compatibility/source route when mmap-direct prerequisites are unavailable", reader.preparedSearch)
+	}
+	query := append([]float32(nil), rows[5].vector...)
+	var scratch columnVectorGraphNativeSearchScratch
+	got, stats, err := reader.SearchCosine(query, columnVectorGraphNativeSearchOptions{TopK: 5, EfSearch: len(rows)}, &scratch)
+	if err != nil {
+		t.Fatalf("SearchCosine: %v", err)
+	}
+	assertColumnGraphNativeSearchResultsV3(t, got, exactColumnGraphTopKForTest(t, rows, query, 5))
+	if stats.PreparedGraphSearchViews != 0 || stats.GraphRowFallbacks != 0 || stats.ResultIDGraphFallbacks != 0 {
+		t.Fatalf("stats=%+v want source compatibility route without graph-row fallback", stats)
+	}
+	if stats.VectorHeapCopyTypedViews+stats.VectorScratchDecodes == 0 || stats.NormHeapCopyTypedViews+stats.NormScratchDecodes == 0 || stats.AdjacencyTypedListHeapCopyTypedViews+stats.AdjacencyTypedListScratchDecodes == 0 {
+		t.Fatalf("stats=%+v want non-mmap vector/norm/adjacency compatibility counters", stats)
+	}
+}
+
 func TestColumnVectorGraphPreparedSearchStaleStateFailsClosed2045(t *testing.T) {
 	if !columnGraphTypedColumnMmapDirectViewSupportedForTest() {
 		t.Skip("combined prepared graph-search view requires mmap_direct test support")
@@ -212,6 +246,34 @@ func assertColumnVectorGraphPreparedPublicStats2045(tb testing.TB, stats VectorI
 	}
 	if stats.ResultIDPreparedBytesViews != 1 || stats.ResultIDTypedBytesState != uint64(results) || stats.RowRefStatePreparedViews != 1 || stats.RowRefStateResultRefs != uint64(results) {
 		tb.Fatalf("stats=%+v want prepared result IDs and row refs for %d results", stats, results)
+	}
+}
+
+func forceColumnVectorGraphPreparedSearchNonMmapCompatibility2045(reader *columnVectorGraphPhysicalRowReader) {
+	if reader == nil {
+		return
+	}
+	reader.preparedSearch = nil
+	if reader.typedVectorSource != nil {
+		reader.typedVectorSource.prepared = columnVectorGraphPreparedVectorView{}
+		for _, part := range reader.typedVectorSource.parts {
+			if part != nil {
+				part.outcome = columnVectorGraphTypedColumnVectorOutcomeHeapCopyTypedView
+				part.fallbackReason = ""
+			}
+		}
+	}
+	if reader.invNormSource != nil {
+		reader.invNormSource.prepared = columnVectorGraphPreparedNormView{}
+		reader.invNormSource.outcome = columnVectorGraphInvNormStateOutcomeHeapCopyTypedView
+		reader.invNormSource.fallbackReason = ""
+	}
+	if reader.adjacencyLayerSources != nil {
+		for _, source := range reader.adjacencyLayerSources.sources {
+			if source != nil {
+				source.outcome = columnVectorGraphLayer0AdjacencySourceOutcomeTypedListHeapCopyTypedView
+			}
+		}
 	}
 }
 

--- a/TreeDB/collections/column_vector_graph_prepared_search_test.go
+++ b/TreeDB/collections/column_vector_graph_prepared_search_test.go
@@ -1,0 +1,225 @@
+package collections
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestColumnVectorGraphPreparedSearchSelectedAndEquivalent2045(t *testing.T) {
+	if !columnGraphTypedColumnMmapDirectViewSupportedForTest() {
+		t.Skip("combined prepared graph-search view requires mmap_direct test support")
+	}
+	rows := []columnGraphRebuildInputRowV2A{
+		{id: "doc-a", vector: []float32{1, 0, 0, 0}},
+		{id: "doc-b", vector: []float32{0.7, 0.3, 0, 0}},
+		{id: "doc-c", vector: []float32{0, 1, 0, 0}},
+		{id: "doc-d", vector: []float32{0, 0, 1, 0}},
+		{id: "doc-e", vector: []float32{0, 0, 0, 1}},
+		{id: "doc-f", vector: []float32{0.4, 0.1, 0.5, 0}},
+	}
+	_, d, col, def := openColumnGraphTypedColumnVectorTestCollection1782(t, 4, 4, rows)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	reader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("openColumnVectorGraphPhysicalRowReader: %v", err)
+	}
+	defer func() { _ = reader.Close() }()
+	if reader.preparedSearch == nil || !reader.preparedSearch.ready() {
+		t.Fatalf("preparedSearch=%v ready=%v want combined prepared view selected", reader.preparedSearch != nil, reader.preparedSearch != nil && reader.preparedSearch.ready())
+	}
+	query := []float32{1, 0, 0, 0}
+	var scratch columnVectorGraphNativeSearchScratch
+	got, stats, err := reader.SearchCosine(query, columnVectorGraphNativeSearchOptions{TopK: 3, EfSearch: len(rows)}, &scratch)
+	if err != nil {
+		t.Fatalf("SearchCosine: %v", err)
+	}
+	assertColumnGraphNativeSearchResultsV3(t, got, exactColumnGraphTopKForTest(t, rows, query, 3))
+	assertColumnVectorGraphPreparedSearchStats2045(t, stats, len(got))
+	if readerStats := reader.Stats(); readerStats.Rows != 0 || readerStats.RowFetches != 0 || readerStats.RowsFetched != 0 || readerStats.PhysicalBytesRead != 0 {
+		t.Fatalf("reader stats=%+v want no graph-row reader residency or reads", readerStats)
+	}
+}
+
+func TestColumnVectorGraphPreparedSearchPublicDocumentsReopen2045(t *testing.T) {
+	if !columnGraphTypedColumnMmapDirectViewSupportedForTest() {
+		t.Skip("combined prepared graph-search view requires mmap_direct test support")
+	}
+	rows := []columnGraphRebuildInputRowV2A{
+		{id: "doc-a", vector: []float32{1, 0, 0, 0}},
+		{id: "doc-b", vector: []float32{0.8, 0.2, 0, 0}},
+		{id: "doc-c", vector: []float32{0, 1, 0, 0}},
+		{id: "doc-d", vector: []float32{0, 0, 1, 0}},
+	}
+	dir, d, col, def := openColumnGraphTypedColumnVectorTestCollection1782(t, 4, 3, rows)
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	query := []float32{1, 0, 0, 0}
+	before, err := col.SearchVectorIndex(VectorIndexSearchOptions{IndexName: def.Name, Query: query, TopK: 2, EfSearch: len(rows), IncludeDocuments: true, MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("SearchVectorIndex before reopen: %v", err)
+	}
+	assertColumnGraphSearchResponseLoadedV4(t, before, def.Name, 2)
+	assertVectorIndexSearchResultsV4(t, before.Results, exactColumnGraphTopKForTest(t, rows, query, 2), true)
+	assertColumnVectorGraphPreparedPublicStats2045(t, before.Stats, len(before.Results))
+	assertVectorIndexSearchDocumentDIDV4(t, before.Results[0].Document, string(before.Results[0].ID))
+	if err := d.Checkpoint(); err != nil {
+		t.Fatalf("Checkpoint: %v", err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	reopened := openCollectionCommandWALDB(t, dir)
+	defer func() { _ = reopened.Close() }()
+	reopenedCol, err := NewCollectionManager(reopened).OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("OpenCollection reopen: %v", err)
+	}
+	after, err := reopenedCol.SearchVectorIndex(VectorIndexSearchOptions{IndexName: def.Name, Query: query, TopK: 2, EfSearch: len(rows), IncludeDocuments: true, MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("SearchVectorIndex after reopen: %v", err)
+	}
+	assertColumnGraphSearchResponseLoadedV4(t, after, def.Name, 2)
+	assertVectorIndexSearchResultsV4(t, after.Results, exactColumnGraphTopKForTest(t, rows, query, 2), true)
+	assertColumnVectorGraphPreparedPublicStats2045(t, after.Stats, len(after.Results))
+	if len(after.Results) != len(before.Results) {
+		t.Fatalf("reopen results len=%d want %d", len(after.Results), len(before.Results))
+	}
+	for i := range after.Results {
+		if string(after.Results[i].ID) != string(before.Results[i].ID) || after.Results[i].Ordinal != before.Results[i].Ordinal || string(after.Results[i].Document) != string(before.Results[i].Document) {
+			t.Fatalf("result[%d] after=%+v before=%+v", i, after.Results[i], before.Results[i])
+		}
+	}
+}
+
+func TestColumnVectorGraphPreparedSearchStaleStateFailsClosed2045(t *testing.T) {
+	if !columnGraphTypedColumnMmapDirectViewSupportedForTest() {
+		t.Skip("combined prepared graph-search view requires mmap_direct test support")
+	}
+	rows := columnGraphRebuildSyntheticRowsV2A(12, 6)
+	_, d, col, def := openColumnGraphTypedColumnVectorTestCollection1782(t, 6, 4, rows)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	reader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("openColumnVectorGraphPhysicalRowReader: %v", err)
+	}
+	defer func() { _ = reader.Close() }()
+	if reader.preparedSearch == nil {
+		t.Fatal("preparedSearch is nil")
+	}
+	if err := reader.documentIDSource.Close(); err != nil {
+		t.Fatalf("close document ID source: %v", err)
+	}
+	var scratch columnVectorGraphNativeSearchScratch
+	_, _, err = reader.SearchCosine(rows[0].vector, columnVectorGraphNativeSearchOptions{TopK: 1, EfSearch: len(rows)}, &scratch)
+	if err == nil || !strings.Contains(err.Error(), "combined prepared graph-search view is stale") {
+		t.Fatalf("SearchCosine err=%v want stale combined prepared fail-closed", err)
+	}
+}
+
+func TestColumnVectorGraphPreparedSearchParallelScratchSafety2045(t *testing.T) {
+	if !columnGraphTypedColumnMmapDirectViewSupportedForTest() {
+		t.Skip("combined prepared graph-search view requires mmap_direct test support")
+	}
+	rows := columnGraphRebuildSyntheticRowsV2A(96, 16)
+	_, d, col, def := openColumnGraphTypedColumnVectorTestCollection1782(t, 16, 8, rows)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	reader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("open reader: %v", err)
+	}
+	defer func() { _ = reader.Close() }()
+	if reader.preparedSearch == nil || !reader.preparedSearch.ready() {
+		t.Fatalf("preparedSearch=%v ready=%v want shared immutable combined prepared view", reader.preparedSearch != nil, reader.preparedSearch != nil && reader.preparedSearch.ready())
+	}
+	const workers = 4
+	query := append([]float32(nil), rows[11].vector...)
+	baseline, _, err := reader.SearchCosine(query, columnVectorGraphNativeSearchOptions{TopK: 8, EfSearch: 64}, &columnVectorGraphNativeSearchScratch{})
+	if err != nil {
+		t.Fatalf("baseline SearchCosine: %v", err)
+	}
+	baseline = cloneColumnVectorGraphPreparedResults2045(baseline)
+	var wg sync.WaitGroup
+	errs := make(chan string, workers)
+	for worker := 0; worker < workers; worker++ {
+		worker := worker
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			var scratch columnVectorGraphNativeSearchScratch
+			for i := 0; i < 25; i++ {
+				got, stats, err := reader.SearchCosine(query, columnVectorGraphNativeSearchOptions{TopK: 8, EfSearch: 64}, &scratch)
+				if err != nil {
+					errs <- fmt.Sprintf("worker %d iteration %d SearchCosine: %v", worker, i, err)
+					return
+				}
+				if mismatch := columnGraphNativeSearchResultsMismatchV3(got, baseline); mismatch != "" {
+					errs <- fmt.Sprintf("worker %d iteration %d: %s", worker, i, mismatch)
+					return
+				}
+				if stats.PreparedGraphSearchViews != 1 || stats.GraphRowFallbacks != 0 || stats.TypedColumnFallbacks != 0 || stats.ResultIDGraphFallbacks != 0 || stats.AdjacencyLegacyFallbacks != 0 {
+					errs <- fmt.Sprintf("worker %d iteration %d stats=%+v want combined prepared without fallback", worker, i, stats)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Error(err)
+	}
+}
+
+func assertColumnVectorGraphPreparedSearchStats2045(tb testing.TB, stats columnVectorGraphNativeSearchStats, results int) {
+	tb.Helper()
+	if stats.PreparedGraphSearchViews != 1 || stats.GraphRowFallbacks != 0 {
+		tb.Fatalf("stats=%+v want one combined prepared view and zero graph-row fallback", stats)
+	}
+	if stats.TypedColumnFallbacks != 0 || stats.NormSourceFallbacks != 0 || stats.AdjacencyLegacyFallbacks != 0 || stats.AdjacencySourceFallbacks != 0 || stats.ResultIDGraphFallbacks != 0 {
+		tb.Fatalf("stats=%+v want zero compatibility/source fallbacks", stats)
+	}
+	if stats.PreparedScoreCalls == 0 || stats.PreparedScoreCalls != stats.CandidateFetches || stats.VectorPreparedDirectViews != stats.CandidateFetches || stats.NormPreparedDirectViews != stats.CandidateFetches {
+		tb.Fatalf("stats=%+v want prepared scoring to cover all candidate fetches", stats)
+	}
+	if stats.AdjacencyPreparedCSRMmapDirectViews == 0 || stats.AdjacencyTypedListMmapDirectViews != 0 || stats.AdjacencyTypedListScratchDecodes != 0 {
+		tb.Fatalf("stats=%+v want prepared CSR adjacency only", stats)
+	}
+	if stats.ResultFetches != uint64(results) || stats.ResultIDPreparedBytesViews != 1 || stats.ResultIDTypedBytesState != uint64(results) || stats.RowRefStatePreparedViews != 1 || stats.RowRefStateResultRefs != uint64(results) {
+		tb.Fatalf("stats=%+v want prepared result IDs/row refs for %d results", stats, results)
+	}
+}
+
+func assertColumnVectorGraphPreparedPublicStats2045(tb testing.TB, stats VectorIndexSearchStats, results int) {
+	tb.Helper()
+	if stats.PreparedGraphSearchViews != 1 || stats.GraphRowFallbacks != 0 || stats.GraphRows != 0 || stats.RowFetches != 0 || stats.RowsFetched != 0 {
+		tb.Fatalf("stats=%+v want combined prepared public search without graph rows", stats)
+	}
+	if stats.TypedColumnFallbacks != 0 || stats.NormSourceFallbacks != 0 || stats.AdjacencyLegacyFallbacks != 0 || stats.AdjacencySourceFallbacks != 0 || stats.ResultIDGraphFallbacks != 0 || stats.RowRefVectorSourceLegacyGraphIDs != 0 {
+		tb.Fatalf("stats=%+v want zero public compatibility/source fallbacks", stats)
+	}
+	if stats.ResultIDPreparedBytesViews != 1 || stats.ResultIDTypedBytesState != uint64(results) || stats.RowRefStatePreparedViews != 1 || stats.RowRefStateResultRefs != uint64(results) {
+		tb.Fatalf("stats=%+v want prepared result IDs and row refs for %d results", stats, results)
+	}
+}
+
+func cloneColumnVectorGraphPreparedResults2045(in []columnVectorGraphNativeSearchResult) []columnVectorGraphNativeSearchResult {
+	out := make([]columnVectorGraphNativeSearchResult, len(in))
+	for i, result := range in {
+		out[i] = result
+		out[i].ID = append([]byte(nil), result.ID...)
+	}
+	return out
+}

--- a/TreeDB/collections/column_vector_graph_row_reader.go
+++ b/TreeDB/collections/column_vector_graph_row_reader.go
@@ -56,6 +56,7 @@ type columnVectorGraphPhysicalRowReader struct {
 	rowRefStateFallbackReason           typeddecode.Reason
 	documentIDSource                    *columnVectorGraphDocumentIDStateSource
 	documentIDStateFallbackReason       typeddecode.Reason
+	preparedSearch                      *columnVectorGraphPreparedSearchView
 	adjacencyLayerSources               *columnVectorGraphAdjacencyDirectSources
 	layer0AdjacencySource               *columnVectorGraphLayer0AdjacencyDirectSource
 	layer0AdjacencySourceUnavailable    bool
@@ -232,6 +233,12 @@ func (c *Collection) openColumnVectorGraphPhysicalRowReaderAtSnapshot(name strin
 			}
 			return nil, fmt.Errorf("collections: column_graph %q missing required base typed-column vector source: %w", def.Name, errColumnVectorGraphManifestMismatch)
 		}
+		preparedSearch, prepareErr := prepareColumnVectorGraphPreparedSearchView(graphReader)
+		if prepareErr != nil {
+			_ = graphReader.Close()
+			return nil, fmt.Errorf("collections: column_graph %q combined prepared graph-search view: %w: %w", def.Name, prepareErr, errColumnVectorGraphManifestMismatch)
+		}
+		graphReader.preparedSearch = preparedSearch
 	}
 	return graphReader, nil
 }
@@ -421,6 +428,7 @@ func (r *columnVectorGraphPhysicalRowReader) Close() error {
 		}
 		r.documentIDSource = nil
 	}
+	r.preparedSearch = nil
 	if r.adjacencyLayerSources != nil {
 		if err := r.adjacencyLayerSources.Close(); closeErr == nil && err != nil {
 			closeErr = err

--- a/TreeDB/collections/column_vector_graph_row_reader.go
+++ b/TreeDB/collections/column_vector_graph_row_reader.go
@@ -233,12 +233,10 @@ func (c *Collection) openColumnVectorGraphPhysicalRowReaderAtSnapshot(name strin
 			}
 			return nil, fmt.Errorf("collections: column_graph %q missing required base typed-column vector source: %w", def.Name, errColumnVectorGraphManifestMismatch)
 		}
-		preparedSearch, prepareErr := prepareColumnVectorGraphPreparedSearchView(graphReader)
-		if prepareErr != nil {
+		if prepareErr := maybePrepareColumnVectorGraphPreparedSearchView(graphReader); prepareErr != nil {
 			_ = graphReader.Close()
 			return nil, fmt.Errorf("collections: column_graph %q combined prepared graph-search view: %w: %w", def.Name, prepareErr, errColumnVectorGraphManifestMismatch)
 		}
-		graphReader.preparedSearch = preparedSearch
 	}
 	return graphReader, nil
 }

--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -220,6 +220,8 @@ type columnVectorGraphNativeSearchStats struct {
 	ResultIDTypedBytesState              uint64
 	ResultIDGraphFallbacks               uint64
 	ResultIDStateValidationFailures      uint64
+	PreparedGraphSearchViews             uint64
+	GraphRowFallbacks                    uint64
 }
 
 // columnVectorGraphNativeSearchResult aliases buffers owned by the search
@@ -526,11 +528,14 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 			plan.scoreSource.populateConstructionStats(&stats)
 		}
 	}()
-	plan, err = scratch.prepareSearchPlan(r)
+	plan, err = scratch.prepareSearchPlanForNativeSearch(r)
 	if err != nil {
 		return nil, stats, err
 	}
 	plan.scoreBatchMode = opts.ScoreBatchMode
+	if plan.preparedSearch != nil {
+		stats.PreparedGraphSearchViews = 1
+	}
 	var singleBlockView *columnVectorGraphBlockView
 	if plan.physicalReader != nil && len(plan.physicalReader.ranges) == 1 && (plan.scoreSource.vectorKind == columnVectorGraphSearchVectorSourceGraphRows || plan.scoreSource.normKind == columnVectorGraphSearchNormSourceGraphRows) {
 		singleBlockView, err = plan.blockViewForAssetOrdinal(0)
@@ -703,6 +708,11 @@ func columnVectorGraphNextCandidateSeed(start int, rowCount int, selection typed
 }
 
 func (r *columnVectorGraphPhysicalRowReader) maxAdjacencyLayer(plan *columnVectorGraphSearchPlan, singleBlockView *columnVectorGraphBlockView, ordinal int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) (int, error) {
+	if plan != nil && plan.preparedSearch != nil {
+		layer, counters, err := plan.preparedSearch.maxAdjacencyLayerForOrdinal(ordinal)
+		recordColumnVectorGraphAdjacencySourceCounterSnapshotStats(stats, counters)
+		return layer, err
+	}
 	if layer, _, counters, fallbackReason, ok := r.maxDirectAdjacencyLayerForOrdinal(ordinal); ok {
 		recordColumnVectorGraphAdjacencySourceCounterSnapshotStats(stats, counters)
 		return layer, nil
@@ -755,7 +765,7 @@ func (r *columnVectorGraphPhysicalRowReader) greedyNearestAtLayer(plan *columnVe
 				continue
 			}
 			scratch.scoreTileScores = ensureColumnVectorGraphNativeFloat64Scratch(scratch.scoreTileScores, len(tile))
-			scores, err := plan.scoreSource.scoreOrdinals(plan, singleBlockView, query, queryInvNorm, tile, scratch.scoreTileScores, scratch, stats)
+			scores, err := r.scoreOrdinals(plan, singleBlockView, query, queryInvNorm, tile, scratch.scoreTileScores, scratch, stats)
 			if err != nil {
 				return 0, err
 			}
@@ -796,6 +806,9 @@ func (r *columnVectorGraphPhysicalRowReader) greedyNearestAtLayer(plan *columnVe
 }
 
 func (r *columnVectorGraphPhysicalRowReader) fetchTopSearchResults(plan *columnVectorGraphSearchPlan, singleBlockView *columnVectorGraphBlockView, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) error {
+	if plan != nil && plan.preparedSearch != nil {
+		return r.fetchTopPreparedSearchResults(plan.preparedSearch, plan, scratch, stats)
+	}
 	n := len(scratch.top)
 	scratch.resultOrder = scratch.resultOrder[:n]
 	scratch.resultOrdinals = scratch.resultOrdinals[:n]
@@ -837,6 +850,7 @@ func (r *columnVectorGraphPhysicalRowReader) fetchTopSearchResults(plan *columnV
 				return err
 			}
 			stats.ResultIDGraphFallbacks++
+			stats.GraphRowFallbacks++
 		} else {
 			stats.ResultIDTypedBytesState++
 		}
@@ -858,6 +872,63 @@ func (r *columnVectorGraphPhysicalRowReader) fetchTopSearchResults(plan *columnV
 	if resultIDStateValidationFailure {
 		stats.ResultIDStateValidationFailures++
 	}
+	stats.BlockViewHits = plan.hits
+	stats.BlockViewMisses = plan.misses
+	stats.BlockViewBuilds = plan.builds
+	for i, candidate := range scratch.top {
+		scratch.results = append(scratch.results, columnVectorGraphNativeSearchResult{
+			Ordinal:   candidate.ordinal,
+			ID:        scratch.idBuffers[i],
+			RowRef:    scratch.resultRowRefs[i],
+			HasRowRef: scratch.resultHasRefs[i],
+			Score:     candidate.score,
+		})
+	}
+	return nil
+}
+
+func (r *columnVectorGraphPhysicalRowReader) fetchTopPreparedSearchResults(view *columnVectorGraphPreparedSearchView, plan *columnVectorGraphSearchPlan, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) error {
+	if view == nil || !view.ready() {
+		return errors.New("collections: column_graph prepared result view is unavailable")
+	}
+	n := len(scratch.top)
+	scratch.resultOrder = scratch.resultOrder[:n]
+	scratch.resultOrdinals = scratch.resultOrdinals[:n]
+	for i := 0; i < n; i++ {
+		scratch.resultOrder[i] = i
+	}
+	sortColumnVectorGraphResultOrderByOrdinal(scratch.resultOrder, scratch.top)
+	for fetchPos, topIndex := range scratch.resultOrder {
+		scratch.resultOrdinals[fetchPos] = scratch.top[topIndex].ordinal
+	}
+	scratch.resultRowRefs = scratch.resultRowRefs[:n]
+	scratch.resultHasRefs = scratch.resultHasRefs[:n]
+	clear(scratch.resultRowRefs)
+	clear(scratch.resultHasRefs)
+	for resultPos, topIndex := range scratch.resultOrder {
+		ordinal := scratch.resultOrdinals[resultPos]
+		id, ok := view.documentIDForOrdinal(ordinal)
+		if !ok {
+			return fmt.Errorf("collections: column_graph %q prepared result-id unavailable for ordinal=%d", r.def.Name, ordinal)
+		}
+		if cap(scratch.idBuffers[topIndex]) < len(id) {
+			scratch.idBuffers[topIndex] = make([]byte, len(id))
+		} else if columnVectorGraphNativeScratchCapOversized(cap(scratch.idBuffers[topIndex]), len(id)) {
+			scratch.idBuffers[topIndex] = make([]byte, len(id))
+		}
+		scratch.idBuffers[topIndex] = scratch.idBuffers[topIndex][:len(id)]
+		copy(scratch.idBuffers[topIndex], id)
+		stats.ResultIDTypedBytesState++
+		if rowRef, ok := view.rowRefForOrdinal(ordinal); ok {
+			rowRef.DocumentID = scratch.idBuffers[topIndex]
+			scratch.resultRowRefs[topIndex] = rowRef
+			scratch.resultHasRefs[topIndex] = true
+			stats.RowRefStateResultRefs++
+		} else {
+			return fmt.Errorf("collections: column_graph %q prepared row-ref unavailable for ordinal=%d", r.def.Name, ordinal)
+		}
+	}
+	stats.ResultFetches += uint64(n)
 	stats.BlockViewHits = plan.hits
 	stats.BlockViewMisses = plan.misses
 	stats.BlockViewBuilds = plan.builds
@@ -912,7 +983,7 @@ func (r *columnVectorGraphPhysicalRowReader) scoreAndPushFrontierVisitedTile(pla
 		return nil
 	}
 	scratch.scoreTileScores = ensureColumnVectorGraphNativeFloat64Scratch(scratch.scoreTileScores, len(ordinals))
-	scores, err := plan.scoreSource.scoreOrdinals(plan, singleBlockView, query, queryInvNorm, ordinals, scratch.scoreTileScores, scratch, stats)
+	scores, err := r.scoreOrdinals(plan, singleBlockView, query, queryInvNorm, ordinals, scratch.scoreTileScores, scratch, stats)
 	if err != nil {
 		return err
 	}
@@ -926,10 +997,23 @@ func (r *columnVectorGraphPhysicalRowReader) scoreAndPushFrontierVisitedTile(pla
 }
 
 func (r *columnVectorGraphPhysicalRowReader) scoreOrdinal(plan *columnVectorGraphSearchPlan, singleBlockView *columnVectorGraphBlockView, query []float32, queryInvNorm float32, ordinal int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) (float64, error) {
+	if plan != nil && plan.preparedSearch != nil {
+		return plan.preparedSearch.scoreOrdinal(plan, query, queryInvNorm, ordinal, stats)
+	}
 	if plan != nil && plan.scoreSource.reader != nil {
 		return plan.scoreSource.scoreOrdinal(plan, singleBlockView, query, queryInvNorm, ordinal, scratch, stats)
 	}
 	return r.scoreOrdinalLegacy(plan, singleBlockView, query, queryInvNorm, ordinal, scratch, stats)
+}
+
+func (r *columnVectorGraphPhysicalRowReader) scoreOrdinals(plan *columnVectorGraphSearchPlan, singleBlockView *columnVectorGraphBlockView, query []float32, queryInvNorm float32, ordinals []int, dst []float64, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) ([]float64, error) {
+	if plan != nil && plan.preparedSearch != nil {
+		return plan.preparedSearch.scoreOrdinals(plan, query, queryInvNorm, ordinals, dst, scratch, stats)
+	}
+	if plan == nil {
+		return nil, errNilColumnVectorGraphPhysicalRowReader
+	}
+	return plan.scoreSource.scoreOrdinals(plan, singleBlockView, query, queryInvNorm, ordinals, dst, scratch, stats)
 }
 
 func (r *columnVectorGraphPhysicalRowReader) scoreOrdinalLegacy(plan *columnVectorGraphSearchPlan, singleBlockView *columnVectorGraphBlockView, query []float32, queryInvNorm float32, ordinal int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) (float64, error) {
@@ -964,6 +1048,7 @@ func (r *columnVectorGraphPhysicalRowReader) scoreOrdinalLegacy(plan *columnVect
 		scratch.scoreScratch.Float32Values = vectorScratch
 		if stats != nil {
 			stats.VectorScratchDecodes++
+			stats.GraphRowFallbacks++
 		}
 	}
 	invNorm, normOutcome, normFallbackReason, normOK := r.invNormForOrdinal(ordinal)
@@ -978,6 +1063,9 @@ func (r *columnVectorGraphPhysicalRowReader) scoreOrdinalLegacy(plan *columnVect
 		}
 		var err error
 		invNorm, err = view.legacyInvNorm(rowIndex)
+		if stats != nil {
+			stats.GraphRowFallbacks++
+		}
 		if err != nil {
 			return 0, err
 		}
@@ -998,6 +1086,21 @@ func (r *columnVectorGraphPhysicalRowReader) scoreOrdinalLegacy(plan *columnVect
 }
 
 func (r *columnVectorGraphPhysicalRowReader) expandCandidateAdjacencyLayer(plan *columnVectorGraphSearchPlan, singleBlockView *columnVectorGraphBlockView, ordinal int, layer int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) ([]uint32, error) {
+	if plan != nil && plan.preparedSearch != nil {
+		layerAdjacency, outcome, err := plan.preparedSearch.adjacencyLayerForOrdinal(ordinal, layer)
+		if err != nil {
+			return nil, err
+		}
+		if stats != nil {
+			stats.ExpansionFetches++
+			stats.AdjacencyExpansions++
+			recordColumnVectorGraphAdjacencySourceOutcomeStats(stats, len(layerAdjacency), outcome)
+			stats.BlockViewHits = plan.hits
+			stats.BlockViewMisses = plan.misses
+			stats.BlockViewBuilds = plan.builds
+		}
+		return layerAdjacency, nil
+	}
 	if layerAdjacency, outcome, fallbackReason, ok := r.directAdjacencyLayerForOrdinal(ordinal, layer); ok {
 		if stats != nil {
 			stats.ExpansionFetches++
@@ -1107,6 +1210,7 @@ func recordColumnVectorGraphAdjacencySourceStats(stats *columnVectorGraphNativeS
 	}
 	stats.AdjacencyBytesRead += uint64(adjacencyLen) * 4
 	stats.AdjacencyLegacyFallbacks++
+	stats.GraphRowFallbacks++
 	if adjacencyLen == 0 {
 		return
 	}

--- a/TreeDB/collections/column_vector_graph_search_source.go
+++ b/TreeDB/collections/column_vector_graph_search_source.go
@@ -433,6 +433,7 @@ func (s *columnVectorGraphSearchSource) vectorForOrdinal(view *columnVectorGraph
 	scratch.scoreScratch.Float32Values = vectorScratch
 	if stats != nil {
 		stats.VectorScratchDecodes++
+		stats.GraphRowFallbacks++
 	}
 	return vector, nil
 }
@@ -456,6 +457,9 @@ func (s *columnVectorGraphSearchSource) invNormForOrdinal(view *columnVectorGrap
 	}
 	if view == nil {
 		return 0, fmt.Errorf("collections: column_graph %q inverse-norm graph-row fallback unavailable for ordinal=%d", s.reader.def.Name, ordinal)
+	}
+	if stats != nil {
+		stats.GraphRowFallbacks++
 	}
 	return view.legacyInvNorm(rowIndex)
 }

--- a/TreeDB/collections/column_vector_graph_search_test.go
+++ b/TreeDB/collections/column_vector_graph_search_test.go
@@ -951,6 +951,8 @@ func benchmarkColumnVectorGraphNativeSearchCosineV3(b *testing.B, shape columnVe
 		searchStats.ResultIDTypedBytesState += stats.ResultIDTypedBytesState
 		searchStats.ResultIDGraphFallbacks += stats.ResultIDGraphFallbacks
 		searchStats.ResultIDStateValidationFailures += stats.ResultIDStateValidationFailures
+		searchStats.PreparedGraphSearchViews += stats.PreparedGraphSearchViews
+		searchStats.GraphRowFallbacks += stats.GraphRowFallbacks
 	}
 	b.StopTimer()
 	stats := reader.Stats()
@@ -1118,6 +1120,8 @@ func benchmarkColumnVectorGraphNativeSearchCosineParallelV3(b *testing.B, shape 
 	var totalResultIDTypedBytesState atomic.Uint64
 	var totalResultIDGraphFallbacks atomic.Uint64
 	var totalResultIDStateValidationFailures atomic.Uint64
+	var totalPreparedGraphSearchViews atomic.Uint64
+	var totalGraphRowFallbacks atomic.Uint64
 	var nextWorker atomic.Uint64
 	b.SetParallelism(1) // Keep one prewarmed reader/scratch per RunParallel worker.
 	b.ReportAllocs()
@@ -1235,6 +1239,8 @@ func benchmarkColumnVectorGraphNativeSearchCosineParallelV3(b *testing.B, shape 
 			localStats.ResultIDTypedBytesState += stats.ResultIDTypedBytesState
 			localStats.ResultIDGraphFallbacks += stats.ResultIDGraphFallbacks
 			localStats.ResultIDStateValidationFailures += stats.ResultIDStateValidationFailures
+			localStats.PreparedGraphSearchViews += stats.PreparedGraphSearchViews
+			localStats.GraphRowFallbacks += stats.GraphRowFallbacks
 		}
 		sink.Add(localSink)
 		totalCandidateRows.Add(localStats.CandidateRows)
@@ -1328,6 +1334,8 @@ func benchmarkColumnVectorGraphNativeSearchCosineParallelV3(b *testing.B, shape 
 		totalResultIDTypedBytesState.Add(localStats.ResultIDTypedBytesState)
 		totalResultIDGraphFallbacks.Add(localStats.ResultIDGraphFallbacks)
 		totalResultIDStateValidationFailures.Add(localStats.ResultIDStateValidationFailures)
+		totalPreparedGraphSearchViews.Add(localStats.PreparedGraphSearchViews)
+		totalGraphRowFallbacks.Add(localStats.GraphRowFallbacks)
 	})
 	b.StopTimer()
 	reportColumnGraphNativeSearchBenchShapeMetricsV3(b, shape)
@@ -1427,6 +1435,8 @@ func benchmarkColumnVectorGraphNativeSearchCosineParallelV3(b *testing.B, shape 
 		ResultIDTypedBytesState:              totalResultIDTypedBytesState.Load(),
 		ResultIDGraphFallbacks:               totalResultIDGraphFallbacks.Load(),
 		ResultIDStateValidationFailures:      totalResultIDStateValidationFailures.Load(),
+		PreparedGraphSearchViews:             totalPreparedGraphSearchViews.Load(),
+		GraphRowFallbacks:                    totalGraphRowFallbacks.Load(),
 	})
 }
 
@@ -1771,6 +1781,8 @@ func reportColumnGraphNativeSearchBenchMetricsV3(b *testing.B, n int, baseStats,
 	b.ReportMetric(float64(searchStats.ResultIDTypedBytesState)/float64(n), "result_id_typed_bytes_state/search")
 	b.ReportMetric(float64(searchStats.ResultIDGraphFallbacks)/float64(n), "result_id_graph_fallbacks/search")
 	b.ReportMetric(float64(searchStats.ResultIDStateValidationFailures)/float64(n), "result_id_state_validation_failures/search")
+	b.ReportMetric(float64(searchStats.PreparedGraphSearchViews)/float64(n), "prepared_graph_search_views/search")
+	b.ReportMetric(float64(searchStats.GraphRowFallbacks)/float64(n), "graph_row_fallbacks/search")
 	b.ReportMetric(float64(searchStats.TypedColumnMappedBytes), "mapped_B")
 	b.ReportMetric(float64(searchStats.TypedColumnHeapCopyBytes), "heap_copy_B")
 	b.ReportMetric(float64(searchStats.TypedColumnDecodedBytes), "decoded_derived_B")

--- a/TreeDB/collections/vector_graph_search_truth_matrix_2037_test.go
+++ b/TreeDB/collections/vector_graph_search_truth_matrix_2037_test.go
@@ -2,7 +2,6 @@ package collections
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 )
 
@@ -11,7 +10,7 @@ type vectorGraphSearchTruthMatrixMode2037 string
 const (
 	vectorGraphSearchTruthMatrixModeLegacyDirectGraphRow2037 vectorGraphSearchTruthMatrixMode2037 = "legacy_direct_graph_row"
 	vectorGraphSearchTruthMatrixModeCurrentTypedColumn2037   vectorGraphSearchTruthMatrixMode2037 = "current_tvis_base_typed_column"
-	vectorGraphSearchTruthMatrixModePreparedPlaceholder2037  vectorGraphSearchTruthMatrixMode2037 = "prepared_typed_column_placeholder"
+	vectorGraphSearchTruthMatrixModeCombinedPrepared2037     vectorGraphSearchTruthMatrixMode2037 = "combined_prepared_typed_column"
 )
 
 type vectorGraphSearchTruthMatrixBoundary2037 string
@@ -37,8 +36,6 @@ const (
 	vectorGraphSearchTruthMatrixFixtureProduction81922037 vectorGraphSearchTruthMatrixFixture2037 = "production8192"
 )
 
-const vectorGraphSearchTruthMatrixPreparedUnsupportedReason2037 = "full prepared typed-column graph-search path is a #2037 placeholder until #2041/#2045 add remaining prepared side-channel views and routing; skipped row is not performance data"
-
 type vectorGraphSearchTruthMatrixRow2037 struct {
 	Mode               vectorGraphSearchTruthMatrixMode2037
 	Boundary           vectorGraphSearchTruthMatrixBoundary2037
@@ -60,24 +57,24 @@ func vectorGraphSearchTruthMatrixRows2037() []vectorGraphSearchTruthMatrixRow203
 	return []vectorGraphSearchTruthMatrixRow2037{
 		{Mode: vectorGraphSearchTruthMatrixModeLegacyDirectGraphRow2037, Boundary: vectorGraphSearchTruthMatrixBoundarySetupOpenPrepare2037, Concurrency: vectorGraphSearchTruthMatrixConcurrencySerial2037, Fixture: vectorGraphSearchTruthMatrixFixtureServing10242037, CanonicalBenchmark: "BenchmarkColumnVectorGraphSearchTruthMatrix2037"},
 		{Mode: vectorGraphSearchTruthMatrixModeCurrentTypedColumn2037, Boundary: vectorGraphSearchTruthMatrixBoundarySetupOpenPrepare2037, Concurrency: vectorGraphSearchTruthMatrixConcurrencySerial2037, Fixture: vectorGraphSearchTruthMatrixFixtureServing10242037, CanonicalBenchmark: "BenchmarkColumnVectorGraphSearchTruthMatrix2037"},
-		{Mode: vectorGraphSearchTruthMatrixModePreparedPlaceholder2037, Boundary: vectorGraphSearchTruthMatrixBoundarySetupOpenPrepare2037, Concurrency: vectorGraphSearchTruthMatrixConcurrencySerial2037, Fixture: vectorGraphSearchTruthMatrixFixtureServing10242037, CanonicalBenchmark: "future BenchmarkColumnVectorGraphSearchTruthMatrix2037 prepared setup row", UnsupportedReason: vectorGraphSearchTruthMatrixPreparedUnsupportedReason2037},
+		{Mode: vectorGraphSearchTruthMatrixModeCombinedPrepared2037, Boundary: vectorGraphSearchTruthMatrixBoundarySetupOpenPrepare2037, Concurrency: vectorGraphSearchTruthMatrixConcurrencySerial2037, Fixture: vectorGraphSearchTruthMatrixFixtureServing10242037, CanonicalBenchmark: "BenchmarkColumnVectorGraphSearchTruthMatrix2037 combined prepared setup row"},
 
 		{Mode: vectorGraphSearchTruthMatrixModeLegacyDirectGraphRow2037, Boundary: vectorGraphSearchTruthMatrixBoundaryGraphOnly2037, Concurrency: vectorGraphSearchTruthMatrixConcurrencySerial2037, Fixture: vectorGraphSearchTruthMatrixFixtureProduction81922037, CanonicalBenchmark: "BenchmarkColumnVectorGraphNativeSearchCosineProduction8192V3 with graph_only_no_result_materialization"},
 		{Mode: vectorGraphSearchTruthMatrixModeLegacyDirectGraphRow2037, Boundary: vectorGraphSearchTruthMatrixBoundaryGraphOnly2037, Concurrency: vectorGraphSearchTruthMatrixConcurrencyParallel2037, Fixture: vectorGraphSearchTruthMatrixFixtureProduction81922037, CanonicalBenchmark: "BenchmarkColumnVectorGraphNativeSearchCosineParallelProduction8192V3 with graph_only_no_result_materialization"},
 		{Mode: vectorGraphSearchTruthMatrixModeCurrentTypedColumn2037, Boundary: vectorGraphSearchTruthMatrixBoundaryGraphOnly2037, Concurrency: vectorGraphSearchTruthMatrixConcurrencySerial2037, Fixture: vectorGraphSearchTruthMatrixFixtureProduction81922037, CanonicalBenchmark: "BenchmarkColumnVectorGraphNativeSearchCosineTypedColumnProduction8192V3 with graph_only_no_result_materialization"},
 		{Mode: vectorGraphSearchTruthMatrixModeCurrentTypedColumn2037, Boundary: vectorGraphSearchTruthMatrixBoundaryGraphOnly2037, Concurrency: vectorGraphSearchTruthMatrixConcurrencyParallel2037, Fixture: vectorGraphSearchTruthMatrixFixtureProduction81922037, CanonicalBenchmark: "BenchmarkColumnVectorGraphNativeSearchCosineParallelTypedColumnProduction8192V3 with graph_only_no_result_materialization"},
-		{Mode: vectorGraphSearchTruthMatrixModePreparedPlaceholder2037, Boundary: vectorGraphSearchTruthMatrixBoundaryGraphOnly2037, Concurrency: vectorGraphSearchTruthMatrixConcurrencySerial2037, Fixture: vectorGraphSearchTruthMatrixFixtureProduction81922037, CanonicalBenchmark: "future prepared graph-only serial row", UnsupportedReason: vectorGraphSearchTruthMatrixPreparedUnsupportedReason2037},
-		{Mode: vectorGraphSearchTruthMatrixModePreparedPlaceholder2037, Boundary: vectorGraphSearchTruthMatrixBoundaryGraphOnly2037, Concurrency: vectorGraphSearchTruthMatrixConcurrencyParallel2037, Fixture: vectorGraphSearchTruthMatrixFixtureProduction81922037, CanonicalBenchmark: "future prepared graph-only parallel row", UnsupportedReason: vectorGraphSearchTruthMatrixPreparedUnsupportedReason2037},
+		{Mode: vectorGraphSearchTruthMatrixModeCombinedPrepared2037, Boundary: vectorGraphSearchTruthMatrixBoundaryGraphOnly2037, Concurrency: vectorGraphSearchTruthMatrixConcurrencySerial2037, Fixture: vectorGraphSearchTruthMatrixFixtureProduction81922037, CanonicalBenchmark: "BenchmarkColumnVectorGraphSearchTruthMatrix2037 combined prepared graph-only serial row"},
+		{Mode: vectorGraphSearchTruthMatrixModeCombinedPrepared2037, Boundary: vectorGraphSearchTruthMatrixBoundaryGraphOnly2037, Concurrency: vectorGraphSearchTruthMatrixConcurrencyParallel2037, Fixture: vectorGraphSearchTruthMatrixFixtureProduction81922037, CanonicalBenchmark: "BenchmarkColumnVectorGraphSearchTruthMatrix2037 combined prepared graph-only parallel row"},
 
 		{Mode: vectorGraphSearchTruthMatrixModeCurrentTypedColumn2037, Boundary: vectorGraphSearchTruthMatrixBoundaryResultID2037, Concurrency: vectorGraphSearchTruthMatrixConcurrencySerial2037, Fixture: vectorGraphSearchTruthMatrixFixtureServing10242037, CanonicalBenchmark: "BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderV4"},
 		{Mode: vectorGraphSearchTruthMatrixModeCurrentTypedColumn2037, Boundary: vectorGraphSearchTruthMatrixBoundaryResultID2037, Concurrency: vectorGraphSearchTruthMatrixConcurrencyParallel2037, Fixture: vectorGraphSearchTruthMatrixFixtureServing10242037, CanonicalBenchmark: "BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderParallelV4"},
-		{Mode: vectorGraphSearchTruthMatrixModePreparedPlaceholder2037, Boundary: vectorGraphSearchTruthMatrixBoundaryResultID2037, Concurrency: vectorGraphSearchTruthMatrixConcurrencySerial2037, Fixture: vectorGraphSearchTruthMatrixFixtureServing10242037, CanonicalBenchmark: "future prepared result-ID serial row", UnsupportedReason: vectorGraphSearchTruthMatrixPreparedUnsupportedReason2037},
-		{Mode: vectorGraphSearchTruthMatrixModePreparedPlaceholder2037, Boundary: vectorGraphSearchTruthMatrixBoundaryResultID2037, Concurrency: vectorGraphSearchTruthMatrixConcurrencyParallel2037, Fixture: vectorGraphSearchTruthMatrixFixtureServing10242037, CanonicalBenchmark: "future prepared result-ID parallel row", UnsupportedReason: vectorGraphSearchTruthMatrixPreparedUnsupportedReason2037},
+		{Mode: vectorGraphSearchTruthMatrixModeCombinedPrepared2037, Boundary: vectorGraphSearchTruthMatrixBoundaryResultID2037, Concurrency: vectorGraphSearchTruthMatrixConcurrencySerial2037, Fixture: vectorGraphSearchTruthMatrixFixtureServing10242037, CanonicalBenchmark: "BenchmarkColumnVectorGraphSearchTruthMatrix2037 combined prepared result-ID serial row"},
+		{Mode: vectorGraphSearchTruthMatrixModeCombinedPrepared2037, Boundary: vectorGraphSearchTruthMatrixBoundaryResultID2037, Concurrency: vectorGraphSearchTruthMatrixConcurrencyParallel2037, Fixture: vectorGraphSearchTruthMatrixFixtureServing10242037, CanonicalBenchmark: "BenchmarkColumnVectorGraphSearchTruthMatrix2037 combined prepared result-ID parallel row"},
 
 		{Mode: vectorGraphSearchTruthMatrixModeCurrentTypedColumn2037, Boundary: vectorGraphSearchTruthMatrixBoundaryDocumentMaterialize2037, Concurrency: vectorGraphSearchTruthMatrixConcurrencySerial2037, Fixture: vectorGraphSearchTruthMatrixFixtureServing10242037, CanonicalBenchmark: "BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderWithDocumentsV4"},
 		{Mode: vectorGraphSearchTruthMatrixModeCurrentTypedColumn2037, Boundary: vectorGraphSearchTruthMatrixBoundaryDocumentMaterialize2037, Concurrency: vectorGraphSearchTruthMatrixConcurrencyParallel2037, Fixture: vectorGraphSearchTruthMatrixFixtureServing10242037, CanonicalBenchmark: "BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderParallelWithDocumentsV4"},
-		{Mode: vectorGraphSearchTruthMatrixModePreparedPlaceholder2037, Boundary: vectorGraphSearchTruthMatrixBoundaryDocumentMaterialize2037, Concurrency: vectorGraphSearchTruthMatrixConcurrencySerial2037, Fixture: vectorGraphSearchTruthMatrixFixtureServing10242037, CanonicalBenchmark: "future prepared document-materialization serial row", UnsupportedReason: vectorGraphSearchTruthMatrixPreparedUnsupportedReason2037},
-		{Mode: vectorGraphSearchTruthMatrixModePreparedPlaceholder2037, Boundary: vectorGraphSearchTruthMatrixBoundaryDocumentMaterialize2037, Concurrency: vectorGraphSearchTruthMatrixConcurrencyParallel2037, Fixture: vectorGraphSearchTruthMatrixFixtureServing10242037, CanonicalBenchmark: "future prepared document-materialization parallel row", UnsupportedReason: vectorGraphSearchTruthMatrixPreparedUnsupportedReason2037},
+		{Mode: vectorGraphSearchTruthMatrixModeCombinedPrepared2037, Boundary: vectorGraphSearchTruthMatrixBoundaryDocumentMaterialize2037, Concurrency: vectorGraphSearchTruthMatrixConcurrencySerial2037, Fixture: vectorGraphSearchTruthMatrixFixtureServing10242037, CanonicalBenchmark: "BenchmarkColumnVectorGraphSearchTruthMatrix2037 combined prepared document-materialization serial row"},
+		{Mode: vectorGraphSearchTruthMatrixModeCombinedPrepared2037, Boundary: vectorGraphSearchTruthMatrixBoundaryDocumentMaterialize2037, Concurrency: vectorGraphSearchTruthMatrixConcurrencyParallel2037, Fixture: vectorGraphSearchTruthMatrixFixtureServing10242037, CanonicalBenchmark: "BenchmarkColumnVectorGraphSearchTruthMatrix2037 combined prepared document-materialization parallel row"},
 	}
 }
 
@@ -105,6 +102,8 @@ func vectorGraphSearchTruthMatrixRequiredMetricLabels2037() []string {
 		"row_ref_state_result_refs/search",
 		"row_ref_state_source_fallbacks/search",
 		"result_id_prepared_bytes_views/search",
+		"prepared_graph_search_views/search",
+		"graph_row_fallbacks/search",
 		"doc_row_ref_state_fetches/search",
 		"doc_row_ref_lookup_fallbacks/search",
 		"vector_mmap_direct/search",
@@ -136,21 +135,21 @@ func TestVectorGraphSearchTruthMatrixRows2037(t *testing.T) {
 	wantNames := []string{
 		"mode=legacy_direct_graph_row/boundary=setup_open_prepare/concurrency=serial/fixture=serving1024",
 		"mode=current_tvis_base_typed_column/boundary=setup_open_prepare/concurrency=serial/fixture=serving1024",
-		"mode=prepared_typed_column_placeholder/boundary=setup_open_prepare/concurrency=serial/fixture=serving1024",
+		"mode=combined_prepared_typed_column/boundary=setup_open_prepare/concurrency=serial/fixture=serving1024",
 		"mode=legacy_direct_graph_row/boundary=graph_only/concurrency=serial/fixture=production8192",
 		"mode=legacy_direct_graph_row/boundary=graph_only/concurrency=parallel/fixture=production8192",
 		"mode=current_tvis_base_typed_column/boundary=graph_only/concurrency=serial/fixture=production8192",
 		"mode=current_tvis_base_typed_column/boundary=graph_only/concurrency=parallel/fixture=production8192",
-		"mode=prepared_typed_column_placeholder/boundary=graph_only/concurrency=serial/fixture=production8192",
-		"mode=prepared_typed_column_placeholder/boundary=graph_only/concurrency=parallel/fixture=production8192",
+		"mode=combined_prepared_typed_column/boundary=graph_only/concurrency=serial/fixture=production8192",
+		"mode=combined_prepared_typed_column/boundary=graph_only/concurrency=parallel/fixture=production8192",
 		"mode=current_tvis_base_typed_column/boundary=result_id/concurrency=serial/fixture=serving1024",
 		"mode=current_tvis_base_typed_column/boundary=result_id/concurrency=parallel/fixture=serving1024",
-		"mode=prepared_typed_column_placeholder/boundary=result_id/concurrency=serial/fixture=serving1024",
-		"mode=prepared_typed_column_placeholder/boundary=result_id/concurrency=parallel/fixture=serving1024",
+		"mode=combined_prepared_typed_column/boundary=result_id/concurrency=serial/fixture=serving1024",
+		"mode=combined_prepared_typed_column/boundary=result_id/concurrency=parallel/fixture=serving1024",
 		"mode=current_tvis_base_typed_column/boundary=document_materialization/concurrency=serial/fixture=serving1024",
 		"mode=current_tvis_base_typed_column/boundary=document_materialization/concurrency=parallel/fixture=serving1024",
-		"mode=prepared_typed_column_placeholder/boundary=document_materialization/concurrency=serial/fixture=serving1024",
-		"mode=prepared_typed_column_placeholder/boundary=document_materialization/concurrency=parallel/fixture=serving1024",
+		"mode=combined_prepared_typed_column/boundary=document_materialization/concurrency=serial/fixture=serving1024",
+		"mode=combined_prepared_typed_column/boundary=document_materialization/concurrency=parallel/fixture=serving1024",
 	}
 	if len(rows) != len(wantNames) {
 		t.Fatalf("rows=%d want %d", len(rows), len(wantNames))
@@ -167,12 +166,8 @@ func TestVectorGraphSearchTruthMatrixRows2037(t *testing.T) {
 		if row.CanonicalBenchmark == "" {
 			t.Fatalf("row %q missing canonical benchmark", row.Name())
 		}
-		if row.Mode == vectorGraphSearchTruthMatrixModePreparedPlaceholder2037 {
-			if row.Supported() || !strings.Contains(row.UnsupportedReason, "not performance data") || !strings.Contains(row.UnsupportedReason, "#2041") {
-				t.Fatalf("prepared placeholder row %q reason=%q", row.Name(), row.UnsupportedReason)
-			}
-		} else if !row.Supported() {
-			t.Fatalf("non-placeholder row %q unexpectedly unsupported: %s", row.Name(), row.UnsupportedReason)
+		if !row.Supported() {
+			t.Fatalf("row %q unexpectedly unsupported: %s", row.Name(), row.UnsupportedReason)
 		}
 	}
 }
@@ -200,6 +195,8 @@ func TestVectorGraphSearchTruthMatrixMetricContract2037(t *testing.T) {
 		"docs_fetched/search",
 		"result_id_typed_bytes_state/search",
 		"result_id_prepared_bytes_views/search",
+		"prepared_graph_search_views/search",
+		"graph_row_fallbacks/search",
 		"row_ref_state_prepared_views/search",
 		"row_ref_state_source_fallbacks/search",
 		"vector_mmap_direct/search",
@@ -289,6 +286,9 @@ func benchmarkVectorGraphSearchTruthMatrixSetup2037(b *testing.B, row vectorGrap
 		OpenPhysicalBytesRead: readerStats.OpenPhysicalBytesRead,
 		MaxResidentBytes:      readerStats.MaxResidentBytes,
 	}
+	if statsSearcher.reader != nil && statsSearcher.reader.preparedSearch != nil {
+		stats.PreparedGraphSearchViews = 1
+	}
 	if err := statsSearcher.Close(); err != nil {
 		b.Fatalf("Close stats searcher: %v", err)
 	}
@@ -315,7 +315,7 @@ func benchmarkVectorGraphSearchTruthMatrixGraphOnly2037(b *testing.B, row vector
 	switch row.Mode {
 	case vectorGraphSearchTruthMatrixModeLegacyDirectGraphRow2037:
 		shape.typedColumnVector = false
-	case vectorGraphSearchTruthMatrixModeCurrentTypedColumn2037:
+	case vectorGraphSearchTruthMatrixModeCurrentTypedColumn2037, vectorGraphSearchTruthMatrixModeCombinedPrepared2037:
 		shape.typedColumnVector = true
 	default:
 		b.Fatalf("unsupported graph-only mode %q", row.Mode)
@@ -329,8 +329,8 @@ func benchmarkVectorGraphSearchTruthMatrixGraphOnly2037(b *testing.B, row vector
 
 func benchmarkVectorGraphSearchTruthMatrixResultID2037(b *testing.B, row vectorGraphSearchTruthMatrixRow2037) {
 	b.Helper()
-	if row.Mode != vectorGraphSearchTruthMatrixModeCurrentTypedColumn2037 {
-		b.Fatalf("result-ID boundary currently supports only current typed-column mode, got %q", row.Mode)
+	if row.Mode != vectorGraphSearchTruthMatrixModeCurrentTypedColumn2037 && row.Mode != vectorGraphSearchTruthMatrixModeCombinedPrepared2037 {
+		b.Fatalf("result-ID boundary currently supports only current/combined prepared typed-column modes, got %q", row.Mode)
 	}
 	if row.Concurrency == vectorGraphSearchTruthMatrixConcurrencyParallel2037 {
 		benchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderParallelV4(b, false, DocumentFetchOptions{})
@@ -341,8 +341,8 @@ func benchmarkVectorGraphSearchTruthMatrixResultID2037(b *testing.B, row vectorG
 
 func benchmarkVectorGraphSearchTruthMatrixDocumentMaterialization2037(b *testing.B, row vectorGraphSearchTruthMatrixRow2037) {
 	b.Helper()
-	if row.Mode != vectorGraphSearchTruthMatrixModeCurrentTypedColumn2037 {
-		b.Fatalf("document-materialization boundary currently supports only current typed-column mode, got %q", row.Mode)
+	if row.Mode != vectorGraphSearchTruthMatrixModeCurrentTypedColumn2037 && row.Mode != vectorGraphSearchTruthMatrixModeCombinedPrepared2037 {
+		b.Fatalf("document-materialization boundary currently supports only current/combined prepared typed-column modes, got %q", row.Mode)
 	}
 	if row.Concurrency == vectorGraphSearchTruthMatrixConcurrencyParallel2037 {
 		benchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderParallelV4(b, true, DocumentFetchOptions{})
@@ -366,7 +366,7 @@ func openVectorGraphSearchTruthMatrixCollection2037(b *testing.B, row vectorGrap
 	case vectorGraphSearchTruthMatrixModeLegacyDirectGraphRow2037:
 		shape.directPhysicalAsset = true
 		shape.typedColumnVector = false
-	case vectorGraphSearchTruthMatrixModeCurrentTypedColumn2037:
+	case vectorGraphSearchTruthMatrixModeCurrentTypedColumn2037, vectorGraphSearchTruthMatrixModeCombinedPrepared2037:
 		shape.directPhysicalAsset = false
 		shape.typedColumnVector = true
 	default:

--- a/TreeDB/collections/vector_index_search.go
+++ b/TreeDB/collections/vector_index_search.go
@@ -336,6 +336,10 @@ type VectorIndexSearchStats struct {
 	ResultIDGraphFallbacks uint64 `json:"result_id_graph_fallbacks,omitempty"`
 	// ResultIDStateValidationFailures counts searches that fell back because present document-ID state failed validation.
 	ResultIDStateValidationFailures uint64 `json:"result_id_state_validation_failures,omitempty"`
+	// PreparedGraphSearchViews reports searches routed through the combined open-time prepared typed-column graph-search view.
+	PreparedGraphSearchViews uint64 `json:"prepared_graph_search_views,omitempty"`
+	// GraphRowFallbacks aggregates compatibility graph-row reads/fallbacks observed during vector/norm/adjacency/result materialization.
+	GraphRowFallbacks uint64 `json:"graph_row_fallbacks,omitempty"`
 	// DocumentRowRefStateFetches counts post-top-k document fetches served with vector-index row-ref state.
 	DocumentRowRefStateFetches uint64 `json:"document_row_ref_state_fetches,omitempty"`
 	// DocumentRowRefLookupFallbacks counts post-top-k document fetches that fell back to ID-to-row-ref lookup.
@@ -1002,5 +1006,7 @@ func vectorIndexSearchStatsFromInternal(searchStats columnVectorGraphNativeSearc
 		ResultIDTypedBytesState:              searchStats.ResultIDTypedBytesState,
 		ResultIDGraphFallbacks:               searchStats.ResultIDGraphFallbacks,
 		ResultIDStateValidationFailures:      searchStats.ResultIDStateValidationFailures,
+		PreparedGraphSearchViews:             searchStats.PreparedGraphSearchViews,
+		GraphRowFallbacks:                    searchStats.GraphRowFallbacks,
 	}
 }

--- a/TreeDB/collections/vector_index_search_test.go
+++ b/TreeDB/collections/vector_index_search_test.go
@@ -2164,6 +2164,8 @@ func reportVectorIndexSearchBenchMetricsV4(b *testing.B, n int, stats VectorInde
 	b.ReportMetric(float64(stats.ResultIDTypedBytesState), "result_id_typed_bytes_state/search")
 	b.ReportMetric(float64(stats.ResultIDGraphFallbacks), "result_id_graph_fallbacks/search")
 	b.ReportMetric(float64(stats.ResultIDStateValidationFailures), "result_id_state_validation_failures/search")
+	b.ReportMetric(float64(stats.PreparedGraphSearchViews), "prepared_graph_search_views/search")
+	b.ReportMetric(float64(stats.GraphRowFallbacks), "graph_row_fallbacks/search")
 	b.ReportMetric(float64(stats.RowFetches), "row_fetches/search")
 	b.ReportMetric(float64(stats.BatchFetches), "batch_fetches/search")
 	b.ReportMetric(float64(stats.RowsFetched), "rows_fetched/search")

--- a/TreeDB/docs/graph_search_benchmark_matrix_test.go
+++ b/TreeDB/docs/graph_search_benchmark_matrix_test.go
@@ -20,14 +20,16 @@ func TestDocs_GraphSearchBenchmarkTruthMatrix2037(t *testing.T) {
 		"mode=<mode>/boundary=<boundary>/concurrency=<serial|parallel>/fixture=<fixture>",
 		"legacy_direct_graph_row",
 		"current_tvis_base_typed_column",
-		"prepared_typed_column_placeholder",
+		"combined_prepared_typed_column",
 		"setup_open_prepare",
 		"graph_only",
 		"result_id",
 		"document_materialization",
 		"production8192",
 		"serving1024",
-		"Skipped placeholders; not performance data",
+		"Supported #2045 combined prepared graph-only rows",
+		"prepared_graph_search_views/search",
+		"graph_row_fallbacks/search",
 		"ops/sec",
 		"graph_rows",
 		"candidates/search",
@@ -46,7 +48,8 @@ func TestDocs_GraphSearchBenchmarkTruthMatrix2037(t *testing.T) {
 		}
 	}
 	forbidden := []string{
-		"prepared_typed_column_placeholder` | `graph_only` | serial/parallel | `production8192` | Supported",
+		"prepared_typed_column_placeholder",
+		"Skipped placeholders; not performance data",
 		"skipped placeholder is performance data",
 	}
 	for _, needle := range forbidden {

--- a/TreeDB/docs/spec/typed-column-graph-search-admission.md
+++ b/TreeDB/docs/spec/typed-column-graph-search-admission.md
@@ -11,11 +11,11 @@ before adding, changing, or promoting graph-search typed-column state roles. The
 reusable #2046 direct-view certifier substrate lives in
 `TreeDB/internal/typeddecode`. The #2037 benchmark truth-matrix labels and
 command contract live in `typed-column-graph-search-benchmark-matrix.md`. This
-table records #2038-admitted adjacency prepared CSR views and #2040-admitted
-base-vector and inverse-norm prepared scoring views, but does not implement the
-remaining side-channel prepared views (#2041), graph-search routing (#2045),
-hot-loop telemetry reduction (#2042), or benchmark truth-matrix collection
-(#2037).
+table records #2038-admitted adjacency prepared CSR views, #2040-admitted
+base-vector and inverse-norm prepared scoring views, #2041-admitted row-ref and
+document-ID side-channel views, and #2045 combined prepared graph-search routing.
+Hot-loop telemetry reduction (#2042) and benchmark truth-matrix collection
+(#2037) remain separate work.
 
 ## Admission status vocabulary
 
@@ -52,8 +52,28 @@ and MUST fail closed, stay non-default, or remain compatibility-only.
 - Healthy evidence must show no silent graph-row fallback: `graph_rows=0`,
   `adjacency_legacy_fallbacks/search=0`, `adjacency_source_fallbacks/search=0`,
   `typed_column_vector_fallbacks/search=0`,
-  `row_ref_vector_source_legacy_graph_ids=0`, and
-  `result_id_graph_fallbacks=0` where those counters apply.
+  `row_ref_vector_source_legacy_graph_ids=0`,
+  `result_id_graph_fallbacks=0`, `graph_row_fallbacks/search=0`, and
+  `prepared_graph_search_views/search=1` where those counters apply.
+
+## #2045 combined prepared routing
+
+A healthy current-format `column_graph` searcher is admitted to the optimized
+path only when all admitted state rows below are simultaneously certified for one
+immutable manifest identity: base vectors, HNSW adjacency, inverse norms, row
+refs, and document IDs. Reader/searcher open builds one combined prepared
+runtime view and the HNSW traversal consumes that view directly. If any required
+state is missing, stale, corrupt, below `mmap_direct`, or not certifiable, the
+current-format open/search path fails closed or uses an explicitly labeled
+compatibility path; it must not silently dispatch back to graph-row selectors in
+the healthy loop.
+
+#2045 evidence counters:
+
+- `prepared_graph_search_views/search=1` for healthy current-format searches;
+- `graph_row_fallbacks/search=0`, plus the role-specific fallback counters below
+  remaining zero;
+- `graph_rows=0` for current-format graph-only/result/document rows.
 
 ## Current graph-search optimized-state readiness table
 

--- a/TreeDB/docs/spec/typed-column-graph-search-benchmark-matrix.md
+++ b/TreeDB/docs/spec/typed-column-graph-search-benchmark-matrix.md
@@ -2,13 +2,11 @@
 
 Status: pre-alpha benchmark contract. This document owns the stable labels and
 reporting boundaries for comparing legacy/direct graph-row search, current
-TVIS/base typed-column search, and future fully prepared typed-column graph
-search. #2038 admits prepared adjacency CSR counters, and #2040 admits
-prepared base-vector and inverse-norm scoring counters on the current typed-column
-rows; remaining prepared side-channel work is owned by #2041 with routing by
-#2045. This matrix must not treat the skipped `prepared_typed_column_placeholder`
-rows as full prepared-path performance evidence until those rows stop being
-placeholders.
+TVIS/base typed-column search, and the #2045 combined prepared typed-column graph
+search. #2038 admits prepared adjacency CSR counters, #2040 admits prepared
+base-vector and inverse-norm scoring counters, #2041 admits row-ref and
+document-ID side-channel counters, and #2045 reports combined prepared routing
+with `prepared_graph_search_views/search` and `graph_row_fallbacks/search`.
 
 ## Command
 
@@ -41,11 +39,12 @@ Modes:
   physical graph rows where the fixture can still publish them. Healthy current
   promotion evidence must not rely on this mode.
 - `current_tvis_base_typed_column`: current source path using TVIS/vector-index
-  typed-column state and base typed-column vectors; after #2040, healthy
-  `mmap_direct` base-vector and inverse-norm scoring is reported through
-  prepared direct-view counters on these rows.
-- `prepared_typed_column_placeholder`: future prepared-view path. These rows are
-  skipped with a message naming #2041/#2045 and are not performance data.
+  typed-column state and base typed-column vectors. After #2045, healthy
+  current-format readers route through the combined prepared view and report
+  `prepared_graph_search_views/search=1`.
+- `combined_prepared_typed_column`: explicit #2045 evidence rows for the same
+  healthy current-format combined prepared route. These rows are supported and
+  must show zero graph-row/source fallback counters.
 
 Boundaries:
 
@@ -73,14 +72,14 @@ Fixtures:
 | --- | --- | --- | --- | --- |
 | `legacy_direct_graph_row` | `setup_open_prepare` | serial | `serving1024` | Supported control row. |
 | `current_tvis_base_typed_column` | `setup_open_prepare` | serial | `serving1024` | Supported current row. |
-| `prepared_typed_column_placeholder` | `setup_open_prepare` | serial | `serving1024` | Skipped placeholder; not performance data. |
+| `combined_prepared_typed_column` | `setup_open_prepare` | serial | `serving1024` | Supported #2045 combined prepared setup/open row. |
 | `legacy_direct_graph_row` | `graph_only` | serial/parallel | `production8192` | Supported control rows where explicit graph rows are published by the fixture. |
 | `current_tvis_base_typed_column` | `graph_only` | serial/parallel | `production8192` | Supported current rows; #2040 vector/norm prepared counters should cover healthy scoring when mmap direct views are available. |
-| `prepared_typed_column_placeholder` | `graph_only` | serial/parallel | `production8192` | Skipped placeholders for remaining prepared side-channel/routing work; not performance data. |
+| `combined_prepared_typed_column` | `graph_only` | serial/parallel | `production8192` | Supported #2045 combined prepared graph-only rows. |
 | `current_tvis_base_typed_column` | `result_id` | serial/parallel | `serving1024` | Supported current rows. |
-| `prepared_typed_column_placeholder` | `result_id` | serial/parallel | `serving1024` | Skipped placeholders; not performance data. |
+| `combined_prepared_typed_column` | `result_id` | serial/parallel | `serving1024` | Supported #2045 combined prepared result-ID rows. |
 | `current_tvis_base_typed_column` | `document_materialization` | serial/parallel | `serving1024` | Supported current rows. |
-| `prepared_typed_column_placeholder` | `document_materialization` | serial/parallel | `serving1024` | Skipped placeholders; not performance data. |
+| `combined_prepared_typed_column` | `document_materialization` | serial/parallel | `serving1024` | Supported #2045 combined prepared document-materialization rows. |
 
 Legacy/direct graph-row result-ID and document-materialization rows are omitted
 unless a future fixture can expose that path without silently using the current
@@ -105,6 +104,7 @@ must also carry the relevant domain/source counters:
   `norm_heap_copy_typed_view/search`, `norm_scratch_decodes/search`,
   `norm_prepared_direct/search`, `norm_source_fallbacks/search`,
   `prepared_score_calls/search`, `score_float64_fallbacks/search`,
+  `prepared_graph_search_views/search`, `graph_row_fallbacks/search`,
   `adjacency_prepared_csr_mmap_direct/search`,
   `adjacency_prepared_csr_direct_views/search`,
   `adjacency_typed_list_mmap_direct/search`,
@@ -125,15 +125,17 @@ must also carry the relevant domain/source counters:
 
 Healthy current-format evidence must keep graph-row/fallback counters at zero
 where those counters apply: `graph_rows=0` for current typed-column graph-only
-rows, `typed_column_vector_fallbacks/search=0`,
+rows, `prepared_graph_search_views/search=1`, `graph_row_fallbacks/search=0`,
+`typed_column_vector_fallbacks/search=0`,
 `row_ref_vector_source_legacy_graph_ids/search=0`,
 `result_id_graph_fallbacks/search=0`, `adjacency_legacy_fallbacks/search=0`, and
 `adjacency_source_fallbacks/search=0`.
 
 ## Interpretation rules
 
-- A skipped `prepared_typed_column_placeholder` row is a contract placeholder,
-  not a win, loss, or throughput number.
+- `combined_prepared_typed_column` rows are #2045 prepared-routing evidence;
+  they are comparable only to rows with identical boundary/concurrency/fixture
+  labels.
 - Compare only rows with identical `boundary`, `concurrency`, and `fixture`
   labels unless the report explicitly explains why a boundary change is the
   measurement target.

--- a/TreeDB/docs/spec/typed-column-graph-search-prepared-views.md
+++ b/TreeDB/docs/spec/typed-column-graph-search-prepared-views.md
@@ -10,14 +10,13 @@ It consumes the tier vocabulary and generic type matrix in
 The #2044 readiness/admission table and docs-lint enforcement live in
 `typed-column-graph-search-admission.md`; the #2037 benchmark truth-matrix labels
 and command contract live in `typed-column-graph-search-benchmark-matrix.md`.
-This document does not implement runtime graph-search admission enforcement
-(#2044), remaining side-channel prepared views (#2041), graph-search routing, or
-the benchmark truth matrix (#2037). The reusable #2046 primitive certifier
-substrate lives in `TreeDB/internal/typeddecode` and remains a prerequisite, not
-row-admission evidence by itself. #2038 admits adjacency prepared CSR views and
-#2040 admits the base-vector and inverse-norm rows in
-`typed-column-graph-search-admission.md`; this document defines the broader
-contract those rows and remaining issues must satisfy.
+Runtime graph-search admission enforcement is owned by #2044 and benchmark
+truth-matrix reporting by #2037. The reusable #2046 primitive certifier substrate
+lives in `TreeDB/internal/typeddecode` and remains a prerequisite, not
+row-admission evidence by itself. #2038 admits adjacency prepared CSR views,
+#2040 admits base-vector and inverse-norm prepared scoring views, #2041 admits
+row-ref and document-ID side-channel views, and #2045 routes healthy
+current-format search through one combined prepared graph-search view.
 
 ## Scope and ownership
 
@@ -26,7 +25,7 @@ The healthy current-format graph-search path is:
 ```text
 authoritative typed-column and vector-index state assets
   -> open/searcher-time certification against one immutable manifest identity
-  -> prepared graph-search runtime views
+  -> one combined prepared graph-search runtime view (#2045)
   -> zero-allocation HNSW traversal/scoring/top-k loop
   -> optional final result-ID and document materialization
 ```
@@ -103,8 +102,10 @@ used as healthy-path evidence.
 
 For healthy current-format graph-search evidence, all graph-row fallback counters
 MUST be zero and graph-row physical assets MUST NOT be the source of vectors,
-adjacency, inverse norms, row refs, or returned IDs. Benchmark and status output
-must make this visible with counters such as:
+adjacency, inverse norms, row refs, or returned IDs. #2045 additionally reports
+`prepared_graph_search_views/search=1` and `graph_row_fallbacks/search=0` for the
+combined prepared route. Benchmark and status output must make this visible with
+counters such as:
 
 - `graph_rows=0` and no graph-row `physical_B/search` for search-only typed-column
   runs;
@@ -112,7 +113,8 @@ must make this visible with counters such as:
   `adjacency_source_fallbacks/search=0`;
 - `typed_column_vector_fallbacks/search=0`;
 - `row_ref_vector_source_legacy_graph_ids=0`;
-- `result_id_graph_fallbacks=0`.
+- `result_id_graph_fallbacks=0`;
+- `prepared_graph_search_views/search=1` and `graph_row_fallbacks/search=0`.
 
 Old fixtures may continue to exercise explicit compatibility readers, but those
 runs must be labeled legacy/compatibility, excluded from healthy current-format


### PR DESCRIPTION
Closes #2045.

## Summary

- Add one open-time `columnVectorGraphPreparedSearchView` for healthy current-format `column_graph` readers, combining prepared base vectors, inverse norms, adjacency CSR, row refs, and document IDs.
- Route native graph search scoring, adjacency expansion, and final result ID/row-ref fetches through the combined prepared view when admitted; stale/missing prepared state fails closed, while legacy physical graph-row compatibility remains explicit and counted.
- Surface `prepared_graph_search_views` and aggregate `graph_row_fallbacks` counters through internal/public stats and benchmark reporters.
- Promote the #2037 truth-matrix prepared rows from skipped placeholder to `combined_prepared_typed_column`, and update docs/spec admission/benchmark contracts.

## Tests

- `GOWORK=off go test ./TreeDB/collections -run TestColumnVectorGraphPreparedSearch -count=1`
- `GOWORK=off go test -race ./TreeDB/collections -run TestColumnVectorGraphPreparedSearchParallelScratchSafety2045 -count=1`
- `GOWORK=off go test ./TreeDB/collections ./TreeDB/docs`
- `git diff --check`

## Benchmark evidence

Commands:

- `GOWORK=off go test ./TreeDB/collections -run '^$' -bench '^BenchmarkColumnVectorGraphSearchTruthMatrix2037$' -benchtime=1x -count=1 -benchmem`
- `GOWORK=off go test ./TreeDB/collections -run '^$' -bench '^BenchmarkColumnVectorGraphSearchTruthMatrix2037/mode=combined_prepared_typed_column/boundary=graph_only/concurrency=serial/fixture=production8192$' -benchtime=25x -count=1 -cpuprofile=/tmp/treedb_2045_graph_only_cpu.pprof`

Smoke results on Apple M3/darwin arm64:

| mode | boundary | concurrency | fixture | ns/op | ops/sec | B/op | allocs/op | prepared_graph_search_views/search | graph_row_fallbacks/search | graph_rows |
| --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| combined_prepared_typed_column | setup_open_prepare | serial | serving1024 | 1,309,625 | 763.6 | 1,599,160 | 2050 | 1 | 0 | 0 |
| combined_prepared_typed_column | graph_only | serial | production8192 | 20,328 | 49,192 | 0 | 0 | 1 | 0 | 0 |
| combined_prepared_typed_column | graph_only | parallel | production8192 | 81,625 | 12,251 | 2,912 | 23 | 1 | 0 | 0 |
| combined_prepared_typed_column | result_id | serial | serving1024 | 19,875 | 50,314 | 784 | 2 | 1 | 0 | 0 |
| combined_prepared_typed_column | document_materialization | serial | serving1024 | 147,542 | 6,778 | 92,160 | 319 | 1 | 0 | 0 |

Notes: graph-only serial remains `0 B/op` and `0 allocs/op`; parallel graph-only allocation counts are from the parallel benchmark harness/worker path while graph-row fallback counters remain zero.

## Caveats

- Current-format admission intentionally requires the combined prepared state to remain healthy and `mmap_direct`; stale/missing state fails closed rather than silently dispatching to graph-row selectors.
- The default `current_tvis_base_typed_column` truth-matrix rows now also report the prepared default route; `combined_prepared_typed_column` rows are explicit #2045 evidence rows for the same healthy current-format path.
