### PR TITLE
collections: pin prepared physical query assets

### DIFF
--- a/TreeDB/collections/column_asset_lifecycle_test.go
+++ b/TreeDB/collections/column_asset_lifecycle_test.go
@@ -418,6 +418,138 @@ func TestColumnAssetLifecycleReportExplicitPinSetScaffold1954(t *testing.T) {
 	}
 }
 
+func TestColumnPhysicalPreparedQueryLifecyclePinsSnapshotRefs1954(t *testing.T) {
+	dir := prepareColumnAssetReachabilityCommandWALDirM15A(t)
+	d := openCollectionCommandWALDB(t, dir)
+	defer func() { _ = d.Close() }()
+	mgr := NewCollectionManager(d)
+	col, err := mgr.OpenCollection("events")
+	if err != nil {
+		t.Fatalf("OpenCollection: %v", err)
+	}
+
+	if _, err := col.InsertBatch([][]byte{[]byte("e1"), []byte("e2")}, [][]byte{
+		[]byte(`{"time_us":10,"kind":"like","did":"did:a"}`),
+		[]byte(`{"time_us":20,"kind":"post","did":"did:b"}`),
+	}); err != nil {
+		t.Fatalf("InsertBatch: %v", err)
+	}
+	runner, err := col.PrepareColumnPhysicalQuery(ColumnPhysicalQueryRequest{
+		Kind:        ColumnPhysicalQueryGroupMinInt64,
+		GroupColumn: "did",
+		ValueColumn: "time_us",
+	})
+	if err != nil {
+		t.Fatalf("PrepareColumnPhysicalQuery: %v", err)
+	}
+	refs := columnPhysicalScanSnapshotViewAssetRefs(runner.view)
+	if len(refs) == 0 {
+		t.Fatalf("prepared runner snapshot refs empty")
+	}
+	if runner.lifecyclePin == nil || runner.lifecyclePin.ID() == 0 || runner.lifecyclePin.Source() != ColumnAssetLifecyclePinSourcePreparedQuery {
+		t.Fatalf("prepared runner lifecycle pin=%+v", runner.lifecyclePin)
+	}
+	if pinRefs := runner.lifecyclePin.Refs(); !slices.Equal(pinRefs, refs) {
+		t.Fatalf("pin refs=%+v want snapshot refs=%+v", pinRefs, refs)
+	}
+	if result, err := runner.Run(); err != nil || len(result.Groups) == 0 {
+		t.Fatalf("prepared runner Run result=%+v err=%v", result, err)
+	}
+
+	report, err := col.PlanColumnAssetLifecycle(context.Background(), ColumnAssetLifecycleOptions{Detailed: true})
+	if err != nil {
+		t.Fatalf("PlanColumnAssetLifecycle with open prepared runner: %v", err)
+	}
+	if report.PinSets.OpenSessions != 1 || report.PinSets.Refs != len(refs) {
+		t.Fatalf("pin summary=%+v want one prepared runner with %d refs", report.PinSets, len(refs))
+	}
+	if report.Roots.LifecyclePinSets != 1 || report.Roots.LifecyclePinnedRefs != len(refs) || report.Roots.PreparedQueryRefs != len(refs) || report.Reachability.Sources.PreparedQueryRefs != len(refs) {
+		t.Fatalf("prepared root counts=%+v sources=%+v want %d prepared-query refs", report.Roots, report.Reachability.Sources, len(refs))
+	}
+	for _, ref := range refs {
+		entry, ok := columnAssetLifecycleFindEntry(report.Reachability.Entries, ref)
+		if !ok {
+			t.Fatalf("missing prepared runner ref entry: %+v", ref)
+		}
+		if entry.Status != ColumnAssetReachabilityProtected || !slices.Contains(entry.Sources, ColumnAssetReachabilitySourcePreparedQuery) {
+			t.Fatalf("prepared runner entry=%+v want protected prepared_query", entry)
+		}
+	}
+
+	if err := runner.Close(); err != nil {
+		t.Fatalf("runner close: %v", err)
+	}
+	if err := runner.Close(); err != nil {
+		t.Fatalf("runner close second call: %v", err)
+	}
+	if runner.lifecyclePin != nil {
+		t.Fatalf("runner retained lifecycle pin after Close")
+	}
+	afterClose, err := col.PlanColumnAssetLifecycle(context.Background(), ColumnAssetLifecycleOptions{Detailed: true})
+	if err != nil {
+		t.Fatalf("PlanColumnAssetLifecycle after prepared runner close: %v", err)
+	}
+	if afterClose.PinSets.OpenSessions != 0 || afterClose.PinSets.Refs != 0 || afterClose.Roots.PreparedQueryRefs != 0 || afterClose.Reachability.Sources.PreparedQueryRefs != 0 {
+		t.Fatalf("prepared pin still reported after Close: pins=%+v roots=%+v sources=%+v", afterClose.PinSets, afterClose.Roots, afterClose.Reachability.Sources)
+	}
+	for _, ref := range refs {
+		entry, ok := columnAssetLifecycleFindEntry(afterClose.Reachability.Entries, ref)
+		if !ok {
+			t.Fatalf("missing prepared runner ref entry after Close: %+v", ref)
+		}
+		if slices.Contains(entry.Sources, ColumnAssetReachabilitySourcePreparedQuery) {
+			t.Fatalf("entry retained prepared_query after Close: %+v", entry)
+		}
+	}
+}
+
+func TestColumnPhysicalPreparedQueryLifecyclePinReleasedOnDBClose1954(t *testing.T) {
+	dir := prepareColumnAssetReachabilityCommandWALDirM15A(t)
+	d := openCollectionCommandWALDB(t, dir)
+	defer func() { _ = d.Close() }()
+	col := openColumnAssetLifecycleTestCollection1954(t, d)
+	if _, err := col.Insert([]byte("e1"), []byte(`{"time_us":1,"kind":"like","did":"d1"}`)); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+	runner, err := col.PrepareColumnPhysicalQuery(ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount, GroupColumn: "kind"})
+	if err != nil {
+		t.Fatalf("PrepareColumnPhysicalQuery: %v", err)
+	}
+	pinID := uint64(0)
+	if runner.lifecyclePin != nil {
+		pinID = runner.lifecyclePin.ID()
+	}
+	if pinID == 0 {
+		t.Fatalf("prepared runner lifecycle pin id is zero")
+	}
+	dbID := columnAssetLifecycleProcessDBID(d)
+	if dbID == 0 {
+		t.Fatalf("lifecycle pin DB id is zero")
+	}
+	if err := d.RunCloseHooks(); err != nil {
+		t.Fatalf("RunCloseHooks: %v", err)
+	}
+	columnAssetLifecycleProcessPins.Lock()
+	if _, ok := columnAssetLifecycleProcessPins.pins[pinID]; ok {
+		columnAssetLifecycleProcessPins.Unlock()
+		t.Fatalf("prepared runner pin record for closed DB leaked under id %d", pinID)
+	}
+	for _, record := range columnAssetLifecycleProcessPins.pins {
+		if record.Scope.dbID == dbID {
+			columnAssetLifecycleProcessPins.Unlock()
+			t.Fatalf("prepared runner pin record for closed DB leaked: %+v", record)
+		}
+	}
+	if _, ok := columnAssetLifecycleProcessPins.dbIDs[d]; ok {
+		columnAssetLifecycleProcessPins.Unlock()
+		t.Fatalf("closed DB remained registered for prepared runner lifecycle pin cleanup")
+	}
+	columnAssetLifecycleProcessPins.Unlock()
+	if err := runner.Close(); err != nil {
+		t.Fatalf("runner close after DB close hook cleanup: %v", err)
+	}
+}
+
 func TestColumnAssetLifecycleReportPinSetSharedAcrossHandles1954(t *testing.T) {
 	dir := prepareColumnAssetReachabilityCommandWALDirM15A(t)
 	d := openCollectionCommandWALDB(t, dir)

--- a/TreeDB/collections/column_physical_query.go
+++ b/TreeDB/collections/column_physical_query.go
@@ -211,6 +211,7 @@ type ColumnPhysicalQueryRunner struct {
 	dictHour     *columnDictionaryHourCountRunner
 	typedColumn  *columnTypedColumnPhysicalQueryRunner
 	metadata     *columnAggregateMetadataRunner
+	lifecyclePin *ColumnAssetLifecyclePinSet
 	closed       bool
 }
 
@@ -466,6 +467,15 @@ func (c *Collection) PrepareColumnPhysicalQuery(req ColumnPhysicalQueryRequest) 
 			return nil, fmt.Errorf("%w: physical predicates require supported dictionary sidecar reducers", ErrColumnQueryPlanUnsupported)
 		}
 	}
+	lifecyclePin, err := c.AcquireColumnAssetLifecyclePinSet(ColumnAssetLifecyclePinSetOptions{
+		Source: ColumnAssetLifecyclePinSourcePreparedQuery,
+		Owner:  "column_physical_query_runner",
+		Reason: fmt.Sprintf("prepared physical query kind=%s", req.Kind),
+		Refs:   columnPhysicalScanSnapshotViewAssetRefs(view),
+	})
+	if err != nil {
+		return nil, errors.Join(err, readCache.close())
+	}
 	release = false
 	return &ColumnPhysicalQueryRunner{
 		collection:   c,
@@ -481,11 +491,12 @@ func (c *Collection) PrepareColumnPhysicalQuery(req ColumnPhysicalQueryRequest) 
 		dictHour:     dictHour,
 		typedColumn:  typedColumn,
 		metadata:     metadata,
+		lifecyclePin: lifecyclePin,
 	}, nil
 }
 
-// Close releases the pinned snapshot and typed column asset readers owned by
-// the prepared physical query runner.
+// Close releases the pinned snapshot, lifecycle pin set, and typed column asset
+// readers owned by the prepared physical query runner.
 func (r *ColumnPhysicalQueryRunner) Close() error {
 	if r == nil || r.closed {
 		return nil
@@ -493,7 +504,11 @@ func (r *ColumnPhysicalQueryRunner) Close() error {
 	r.closed = true
 	var closeErr error
 	if err := r.readCache.close(); err != nil {
-		closeErr = err
+		closeErr = errors.Join(closeErr, err)
+	}
+	if r.lifecyclePin != nil {
+		closeErr = errors.Join(closeErr, r.lifecyclePin.Close())
+		r.lifecyclePin = nil
 	}
 	if r.closeView != nil {
 		r.closeView()

--- a/TreeDB/collections/column_physical_scan.go
+++ b/TreeDB/collections/column_physical_scan.go
@@ -235,6 +235,41 @@ type columnPhysicalScanSnapshotView struct {
 	AssetNamespace        string
 }
 
+func columnPhysicalScanSnapshotViewAssetRefs(view columnPhysicalScanSnapshotView) []ColumnAssetRef {
+	expectedRefs := len(view.AssetRefs) + len(view.TypedColumnPartRefs) + len(view.AggregateMetadata) + len(view.DictionaryCodes) + len(view.Int64Values) + len(view.GraphAssetRefs)
+	if expectedRefs == 0 {
+		return nil
+	}
+	refs := make([]ColumnAssetRef, 0, expectedRefs)
+	seen := make(map[ColumnAssetRef]struct{}, expectedRefs)
+	add := func(ref ColumnAssetRef) {
+		if _, ok := seen[ref]; ok {
+			return
+		}
+		seen[ref] = struct{}{}
+		refs = append(refs, ref)
+	}
+	for _, assetRef := range view.AssetRefs {
+		add(assetRef.Ref)
+	}
+	for _, typedPartRef := range view.TypedColumnPartRefs {
+		add(typedPartRef.Ref)
+	}
+	for _, metadataRef := range view.AggregateMetadata {
+		add(metadataRef.AssetRef)
+	}
+	for _, dictionaryRef := range view.DictionaryCodes {
+		add(dictionaryRef.AssetRef)
+	}
+	for _, valuesRef := range view.Int64Values {
+		add(valuesRef.AssetRef)
+	}
+	for _, ref := range view.GraphAssetRefs {
+		add(ref)
+	}
+	return refs
+}
+
 var errColumnPhysicalAssetManifestOperationMismatch = errors.New("collections: column physical asset operation does not match manifest reason")
 
 func (c *Collection) scanColumnPhysicalRows(req columnPhysicalScanRequest) (columnPhysicalScanDiagnostics, error) {


### PR DESCRIPTION
## Scope

Closes part of #1954 (slice 3): report-only prepared-query lifecycle roots.

- Adds a small snapshot-view helper that collects concrete `ColumnAssetRef`s reachable from a `columnPhysicalScanSnapshotView`:
  - typed-row/physical part images
  - typed-column part images
  - aggregate metadata assets
  - dictionary-code sidecars
  - int64 sidecars
  - graph/vector-index refs already exposed on the snapshot view
- Wires successful `PrepareColumnPhysicalQuery` calls to acquire a process-local `prepared_query` `ColumnAssetLifecyclePinSet` over the prepared runner's snapshot refs.
- Stores the pin on `ColumnPhysicalQueryRunner` and releases it idempotently from `Close`, alongside read-cache and snapshot cleanup.
- Adds tests proving an open prepared runner appears in `PlanColumnAssetLifecycle` as prepared-query lifecycle roots and drops after `Close`; also covers DB close-hook cleanup.

## Non-goals / safety boundaries

- Report-only/fail-closed only: no GC/rewrite/cleanup/destructive policy changes.
- No asset deletes, moves, truncation, or physical quarantine side effects.
- No on-disk manifest format changes.
- No query semantic changes or prepared mutation-query enablement.
- The `view.MutationParts > 0` prepared-query guard remains in place.

## Tests

Latest head: `76809a4b4` (merged latest `origin/main` `92d884604`, including #2079).

- `GOWORK=off go test ./TreeDB/collections -run 'TestColumnAssetLifecycle|TestColumnAssetReachability|TestColumnPhysical.*Prepared|TestTypedStorageLegacyNameAllowlistIsComplete' -count=1` — PASS (`/tmp/orca_issue_graph_1945_1955/1954_pins_focused_after_main_92d884.txt`)
- `GOWORK=off go test ./TreeDB/collections -count=1` — PASS (`/tmp/orca_issue_graph_1945_1955/1954_pins_collections_after_main_92d884.txt`)

Original manager artifacts:

- `/tmp/orca_issue_graph_1945_1955/1954_pins_focused.txt`
- `/tmp/orca_issue_graph_1945_1955/1954_pins_collections.txt`

## Risks / follow-ups

Lifecycle reports still remain incomplete/fail-closed for future destructive consumers because registries/pins are process-local and exact snapshot roots are not yet durable/recoverable. Later #1954 slices must add durable/exact root coverage and race tests before any destructive consumer is enabled.
