### PR TITLE
Reduce vector graph search telemetry overhead

### DIFF
--- a/TreeDB/collections/column_vector_graph_prepared_search_test.go
+++ b/TreeDB/collections/column_vector_graph_prepared_search_test.go
@@ -45,6 +45,53 @@ func TestColumnVectorGraphPreparedSearchSelectedAndEquivalent2045(t *testing.T) 
 	}
 }
 
+func TestColumnVectorGraphPreparedSearchMinimalStats2042(t *testing.T) {
+	if !columnGraphTypedColumnMmapDirectViewSupportedForTest() {
+		t.Skip("combined prepared graph-search view requires mmap_direct test support")
+	}
+	rows := columnGraphRebuildSyntheticRowsV2A(48, 12)
+	_, d, col, def := openColumnGraphTypedColumnVectorTestCollection1782(t, 12, 6, rows)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	reader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("openColumnVectorGraphPhysicalRowReader: %v", err)
+	}
+	defer func() { _ = reader.Close() }()
+	if reader.preparedSearch == nil || !reader.preparedSearch.ready() {
+		t.Fatalf("preparedSearch=%v ready=%v want combined prepared view selected", reader.preparedSearch != nil, reader.preparedSearch != nil && reader.preparedSearch.ready())
+	}
+	query := append([]float32(nil), rows[7].vector...)
+	var fullScratch columnVectorGraphNativeSearchScratch
+	fullResults, fullStats, err := reader.SearchCosine(query, columnVectorGraphNativeSearchOptions{TopK: 6, EfSearch: 32, StatsMode: columnVectorGraphNativeSearchStatsModeFullDiagnostics}, &fullScratch)
+	if err != nil {
+		t.Fatalf("full SearchCosine: %v", err)
+	}
+	var minimalScratch columnVectorGraphNativeSearchScratch
+	minimalResults, minimalStats, err := reader.SearchCosine(query, columnVectorGraphNativeSearchOptions{TopK: 6, EfSearch: 32, StatsMode: columnVectorGraphNativeSearchStatsModeMinimal}, &minimalScratch)
+	if err != nil {
+		t.Fatalf("minimal SearchCosine: %v", err)
+	}
+	if mismatch := columnGraphNativeSearchResultsMismatchV3(minimalResults, fullResults); mismatch != "" {
+		t.Fatal(mismatch)
+	}
+	assertColumnVectorGraphPreparedSearchStats2045(t, fullStats, len(fullResults))
+	assertColumnVectorGraphPreparedMinimalStats2042(t, minimalStats, fullStats, len(minimalResults))
+
+	searcher, err := col.OpenVectorIndexSearcher(VectorIndexSearcherOptions{IndexName: def.Name, MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("OpenVectorIndexSearcher: %v", err)
+	}
+	defer func() { _ = searcher.Close() }()
+	publicMinimal, err := searcher.Search(VectorIndexSearcherSearchOptions{Query: query, TopK: 6, EfSearch: 32, StatsMode: VectorIndexSearchStatsModeMinimal})
+	if err != nil {
+		t.Fatalf("public minimal Search: %v", err)
+	}
+	assertColumnVectorGraphPreparedPublicMinimalStats2042(t, publicMinimal.Stats, len(publicMinimal.Results))
+}
+
 func TestColumnVectorGraphPreparedSearchPublicDocumentsReopen2045(t *testing.T) {
 	if !columnGraphTypedColumnMmapDirectViewSupportedForTest() {
 		t.Skip("combined prepared graph-search view requires mmap_direct test support")
@@ -119,7 +166,7 @@ func TestColumnVectorGraphPreparedSearchNonMmapCompatibility2045(t *testing.T) {
 	}
 	query := append([]float32(nil), rows[5].vector...)
 	var scratch columnVectorGraphNativeSearchScratch
-	got, stats, err := reader.SearchCosine(query, columnVectorGraphNativeSearchOptions{TopK: 5, EfSearch: len(rows)}, &scratch)
+	got, stats, err := reader.SearchCosine(query, columnVectorGraphNativeSearchOptions{TopK: 5, EfSearch: len(rows), StatsMode: columnVectorGraphNativeSearchStatsModeMinimal}, &scratch)
 	if err != nil {
 		t.Fatalf("SearchCosine: %v", err)
 	}
@@ -246,6 +293,41 @@ func assertColumnVectorGraphPreparedPublicStats2045(tb testing.TB, stats VectorI
 	}
 	if stats.ResultIDPreparedBytesViews != 1 || stats.ResultIDTypedBytesState != uint64(results) || stats.RowRefStatePreparedViews != 1 || stats.RowRefStateResultRefs != uint64(results) {
 		tb.Fatalf("stats=%+v want prepared result IDs and row refs for %d results", stats, results)
+	}
+}
+
+func assertColumnVectorGraphPreparedMinimalStats2042(tb testing.TB, stats, full columnVectorGraphNativeSearchStats, results int) {
+	tb.Helper()
+	if stats.PreparedGraphSearchViews != 1 || stats.GraphRowFallbacks != 0 || stats.TypedColumnFallbacks != 0 || stats.ResultIDGraphFallbacks != 0 || stats.AdjacencyLegacyFallbacks != 0 {
+		tb.Fatalf("minimal stats=%+v want prepared path with zero graph-row/source fallback", stats)
+	}
+	if stats.CandidateRows != full.CandidateRows || stats.Candidates != full.Candidates || stats.Edges != full.Edges || stats.VisitedEdges != full.VisitedEdges {
+		tb.Fatalf("minimal stats=%+v full=%+v want same production traversal counters", stats, full)
+	}
+	if stats.PreparedScoreCalls == 0 || stats.PreparedScoreCalls != stats.CandidateFetches || stats.VectorPreparedDirectViews != stats.CandidateFetches || stats.NormPreparedDirectViews != stats.CandidateFetches {
+		tb.Fatalf("minimal stats=%+v want prepared score/direct counters", stats)
+	}
+	if stats.AdjacencyPreparedCSRMmapDirectViews == 0 || stats.AdjacencyTypedListMmapDirectViews != 0 || stats.AdjacencyTypedListScratchDecodes != 0 {
+		tb.Fatalf("minimal stats=%+v want prepared CSR adjacency counters only", stats)
+	}
+	if stats.ResultFetches != uint64(results) || stats.ResultIDPreparedBytesViews != 1 || stats.ResultIDTypedBytesState != uint64(results) || stats.RowRefStatePreparedViews != 1 || stats.RowRefStateResultRefs != uint64(results) {
+		tb.Fatalf("minimal stats=%+v want prepared result IDs/row refs for %d results", stats, results)
+	}
+}
+
+func assertColumnVectorGraphPreparedPublicMinimalStats2042(tb testing.TB, stats VectorIndexSearchStats, results int) {
+	tb.Helper()
+	if stats.PreparedGraphSearchViews != 1 || stats.GraphRowFallbacks != 0 || stats.GraphRows != 0 || stats.RowFetches != 0 || stats.RowsFetched != 0 {
+		tb.Fatalf("public minimal stats=%+v want combined prepared public search without graph rows", stats)
+	}
+	if stats.TypedColumnFallbacks != 0 || stats.NormSourceFallbacks != 0 || stats.AdjacencyLegacyFallbacks != 0 || stats.AdjacencySourceFallbacks != 0 || stats.ResultIDGraphFallbacks != 0 || stats.RowRefVectorSourceLegacyGraphIDs != 0 {
+		tb.Fatalf("public minimal stats=%+v want zero public compatibility/source fallbacks", stats)
+	}
+	if stats.Candidates == 0 || stats.CandidateFetches == 0 || stats.PreparedScoreCalls != stats.CandidateFetches || stats.VectorPreparedDirectViews != stats.CandidateFetches || stats.NormPreparedDirectViews != stats.CandidateFetches {
+		tb.Fatalf("public minimal stats=%+v want production and prepared score counters", stats)
+	}
+	if stats.ResultIDPreparedBytesViews != 1 || stats.ResultIDTypedBytesState != uint64(results) || stats.RowRefStatePreparedViews != 1 || stats.RowRefStateResultRefs != uint64(results) {
+		tb.Fatalf("public minimal stats=%+v want prepared result IDs and row refs for %d results", stats, results)
 	}
 }
 

--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -30,10 +30,19 @@ var (
 
 type columnVectorGraphScoreBatchMode uint8
 
+type columnVectorGraphNativeSearchStatsMode uint8
+
 const (
 	columnVectorGraphScoreBatchModeDefault columnVectorGraphScoreBatchMode = iota
 	columnVectorGraphScoreBatchModeScalar
 	columnVectorGraphScoreBatchModeIndexed
+)
+
+const (
+	columnVectorGraphNativeSearchStatsModeDefault columnVectorGraphNativeSearchStatsMode = iota
+	columnVectorGraphNativeSearchStatsModeMinimal
+	columnVectorGraphNativeSearchStatsModeFullDiagnostics
+	columnVectorGraphNativeSearchStatsModeBenchmarkDebug
 )
 
 var columnVectorGraphIndexedScoringDefaultEnabled = false
@@ -63,11 +72,40 @@ func (m columnVectorGraphScoreBatchMode) String() string {
 	}
 }
 
+func (m columnVectorGraphNativeSearchStatsMode) normalized() columnVectorGraphNativeSearchStatsMode {
+	switch m {
+	case columnVectorGraphNativeSearchStatsModeMinimal, columnVectorGraphNativeSearchStatsModeFullDiagnostics, columnVectorGraphNativeSearchStatsModeBenchmarkDebug:
+		return m
+	default:
+		return columnVectorGraphNativeSearchStatsModeFullDiagnostics
+	}
+}
+
+func (m columnVectorGraphNativeSearchStatsMode) minimal() bool {
+	return m.normalized() == columnVectorGraphNativeSearchStatsModeMinimal
+}
+
+func (m columnVectorGraphNativeSearchStatsMode) String() string {
+	switch m.normalized() {
+	case columnVectorGraphNativeSearchStatsModeMinimal:
+		return "minimal"
+	case columnVectorGraphNativeSearchStatsModeBenchmarkDebug:
+		return "benchmark_debug"
+	default:
+		return "full_diagnostics"
+	}
+}
+
 type columnVectorGraphNativeSearchOptions struct {
 	TopK     int
 	EfSearch int
 
 	ScoreBatchMode columnVectorGraphScoreBatchMode
+	// StatsMode selects how much graph-search telemetry is collected. The zero
+	// value preserves full diagnostics; minimal mode keeps production/admission
+	// counters while avoiding per-candidate source/outcome accounting on the
+	// healthy combined prepared path.
+	StatsMode columnVectorGraphNativeSearchStatsMode
 
 	// OmitResultMaterialization is an internal benchmark/profiling hook for the
 	// graph-only boundary. It preserves traversal/scoring/top-k work but skips
@@ -222,6 +260,142 @@ type columnVectorGraphNativeSearchStats struct {
 	ResultIDStateValidationFailures      uint64
 	PreparedGraphSearchViews             uint64
 	GraphRowFallbacks                    uint64
+}
+
+type columnVectorGraphNativeSearchLoopCounters struct {
+	Candidates   uint64
+	Edges        uint64
+	VisitedEdges uint64
+}
+
+func (c *columnVectorGraphNativeSearchLoopCounters) recordEdge() {
+	if c == nil {
+		return
+	}
+	c.Edges++
+	c.VisitedEdges++
+}
+
+func (c *columnVectorGraphNativeSearchLoopCounters) recordCandidate() {
+	if c == nil {
+		return
+	}
+	c.Candidates++
+}
+
+func (c *columnVectorGraphNativeSearchLoopCounters) publish(stats *columnVectorGraphNativeSearchStats) {
+	if c == nil || stats == nil {
+		return
+	}
+	stats.Candidates += c.Candidates
+	stats.Edges += c.Edges
+	stats.VisitedEdges += c.VisitedEdges
+}
+
+type columnVectorGraphPreparedMinimalSearchCounters struct {
+	dims                  int
+	vectorIdentityMapping bool
+
+	ScoreBatches                        uint64
+	OrdinalsGrouped                     uint64
+	ScoreBatchCalls                     uint64
+	ScoreBatchCandidates                uint64
+	ScoreBatchMaxTileSize               uint64
+	ScoreBatchScalarFallbackCalls       uint64
+	PreparedScoreCalls                  uint64
+	AdjacencyBytesRead                  uint64
+	ExpansionFetches                    uint64
+	AdjacencyExpansions                 uint64
+	AdjacencyDirectViews                uint64
+	AdjacencyMmapDirectViews            uint64
+	AdjacencyPreparedCSRDirectViews     uint64
+	AdjacencyPreparedCSRMmapDirectViews uint64
+}
+
+func newColumnVectorGraphPreparedMinimalSearchCounters(view *columnVectorGraphPreparedSearchView) *columnVectorGraphPreparedMinimalSearchCounters {
+	if view == nil {
+		return nil
+	}
+	return &columnVectorGraphPreparedMinimalSearchCounters{dims: view.dims, vectorIdentityMapping: view.vectorIdentityMapping}
+}
+
+func (c *columnVectorGraphPreparedMinimalSearchCounters) recordPreparedScores(count int, scalarFallback bool) {
+	if c == nil || count <= 0 {
+		return
+	}
+	count64 := uint64(count)
+	c.ScoreBatches++
+	c.OrdinalsGrouped += count64
+	c.ScoreBatchCalls++
+	c.ScoreBatchCandidates += count64
+	if count64 > c.ScoreBatchMaxTileSize {
+		c.ScoreBatchMaxTileSize = count64
+	}
+	if scalarFallback {
+		c.ScoreBatchScalarFallbackCalls++
+	}
+	c.PreparedScoreCalls += count64
+}
+
+func (c *columnVectorGraphPreparedMinimalSearchCounters) recordPreparedAdjacency(adjacencyLen int) {
+	if c == nil {
+		return
+	}
+	c.ExpansionFetches++
+	c.AdjacencyExpansions++
+	c.AdjacencyBytesRead += uint64(adjacencyLen) * 4
+	c.AdjacencyDirectViews++
+	c.AdjacencyMmapDirectViews++
+	c.AdjacencyPreparedCSRDirectViews++
+	c.AdjacencyPreparedCSRMmapDirectViews++
+}
+
+func (c *columnVectorGraphPreparedMinimalSearchCounters) recordAdjacencyCounterSnapshot(counters columnVectorGraphAdjacencySourceCounterSnapshot) {
+	if c == nil {
+		return
+	}
+	c.AdjacencyBytesRead += counters.AdjacencyBytesRead
+	c.AdjacencyDirectViews += counters.AdjacencyDirectViews
+	c.AdjacencyMmapDirectViews += counters.AdjacencyMmapDirectViews
+	c.AdjacencyPreparedCSRDirectViews += counters.AdjacencyPreparedCSRDirectViews
+	c.AdjacencyPreparedCSRMmapDirectViews += counters.AdjacencyPreparedCSRMmapDirectViews
+}
+
+func (c *columnVectorGraphPreparedMinimalSearchCounters) publish(stats *columnVectorGraphNativeSearchStats) {
+	if c == nil || stats == nil {
+		return
+	}
+	stats.ScoreBatches += c.ScoreBatches
+	stats.OrdinalsGrouped += c.OrdinalsGrouped
+	stats.ScoreBatchCalls += c.ScoreBatchCalls
+	stats.ScoreBatchCandidates += c.ScoreBatchCandidates
+	if c.ScoreBatchMaxTileSize > stats.ScoreBatchMaxTileSize {
+		stats.ScoreBatchMaxTileSize = c.ScoreBatchMaxTileSize
+	}
+	stats.ScoreBatchScalarFallbackCalls += c.ScoreBatchScalarFallbackCalls
+	stats.PreparedScoreCalls += c.PreparedScoreCalls
+	stats.VisitedNodes += c.PreparedScoreCalls
+	stats.VectorBytesRead += c.PreparedScoreCalls * uint64(c.dims) * 4
+	stats.NormBytesRead += c.PreparedScoreCalls * 4
+	stats.AdjacencyBytesRead += c.AdjacencyBytesRead
+	stats.CandidateFetches += c.PreparedScoreCalls
+	stats.ExpansionFetches += c.ExpansionFetches
+	stats.AdjacencyExpansions += c.AdjacencyExpansions
+	stats.AdjacencyDirectViews += c.AdjacencyDirectViews
+	stats.AdjacencyMmapDirectViews += c.AdjacencyMmapDirectViews
+	stats.AdjacencyPreparedCSRDirectViews += c.AdjacencyPreparedCSRDirectViews
+	stats.AdjacencyPreparedCSRMmapDirectViews += c.AdjacencyPreparedCSRMmapDirectViews
+	stats.VectorDirectViews += c.PreparedScoreCalls
+	stats.VectorMmapDirectViews += c.PreparedScoreCalls
+	stats.VectorPreparedDirectViews += c.PreparedScoreCalls
+	if c.vectorIdentityMapping {
+		stats.VectorPreparedIdentityMappings += c.PreparedScoreCalls
+	} else {
+		stats.VectorPreparedRowRefMappings += c.PreparedScoreCalls
+	}
+	stats.NormDirectViews += c.PreparedScoreCalls
+	stats.NormMmapDirectViews += c.PreparedScoreCalls
+	stats.NormPreparedDirectViews += c.PreparedScoreCalls
 }
 
 // columnVectorGraphNativeSearchResult aliases buffers owned by the search
@@ -517,8 +691,15 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 		return nil, columnVectorGraphNativeSearchStats{}, fmt.Errorf("collections: column_graph %q native search scratch prepare: %w", r.def.Name, err)
 	}
 
+	statsMode := opts.StatsMode.normalized()
 	var plan *columnVectorGraphSearchPlan
+	var loopCounters columnVectorGraphNativeSearchLoopCounters
+	var preparedMinimalCounters *columnVectorGraphPreparedMinimalSearchCounters
 	defer func() {
+		loopCounters.publish(&stats)
+		if preparedMinimalCounters != nil {
+			preparedMinimalCounters.publish(&stats)
+		}
 		r.populateTypedColumnVectorSearchStats(&stats)
 		r.populateInvNormStateSearchStats(&stats)
 		r.populateRowRefStateSearchStats(&stats)
@@ -535,6 +716,13 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 	plan.scoreBatchMode = opts.ScoreBatchMode
 	if plan.preparedSearch != nil {
 		stats.PreparedGraphSearchViews = 1
+		if statsMode.minimal() {
+			preparedMinimalCounters = newColumnVectorGraphPreparedMinimalSearchCounters(plan.preparedSearch)
+		}
+	}
+	hotStats := &stats
+	if preparedMinimalCounters != nil {
+		hotStats = nil
 	}
 	var singleBlockView *columnVectorGraphBlockView
 	if plan.physicalReader != nil && len(plan.physicalReader.ranges) == 1 && (plan.scoreSource.vectorKind == columnVectorGraphSearchVectorSourceGraphRows || plan.scoreSource.normKind == columnVectorGraphSearchNormSourceGraphRows) {
@@ -549,22 +737,23 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 	if !ok {
 		return scratch.results, stats, nil
 	}
-	maxLayer, err := r.maxAdjacencyLayer(plan, singleBlockView, entryOrdinal, scratch, &stats)
+	maxLayer, err := r.maxAdjacencyLayer(plan, singleBlockView, entryOrdinal, scratch, hotStats, preparedMinimalCounters)
 	if err != nil {
 		return nil, stats, err
 	}
 	for layer := maxLayer; layer > 0; layer-- {
-		entryOrdinal, err = r.greedyNearestAtLayer(plan, singleBlockView, query, queryInvNorm, entryOrdinal, layer, candidateRows, hasCandidateRows, scratch, &stats)
+		entryOrdinal, err = r.greedyNearestAtLayer(plan, singleBlockView, query, queryInvNorm, entryOrdinal, layer, candidateRows, hasCandidateRows, scratch, hotStats, &loopCounters, preparedMinimalCounters)
 		if err != nil {
 			return nil, stats, err
 		}
 	}
 	visitMarks[entryOrdinal] = visitEpoch
-	if err := r.scoreAndPushFrontierVisited(plan, singleBlockView, query, queryInvNorm, entryOrdinal, topK, scratch, &stats); err != nil {
+	if err := r.scoreAndPushFrontierVisited(plan, singleBlockView, query, queryInvNorm, entryOrdinal, topK, scratch, hotStats, &loopCounters, preparedMinimalCounters); err != nil {
 		return nil, stats, err
 	}
 	nextSeed := 0
-	for stats.Candidates < uint64(efSearch) {
+	candidateLimit := uint64(efSearch)
+	for loopCounters.Candidates < candidateLimit {
 		candidate, ok := scratch.popFrontier()
 		if !ok {
 			seed, ok := columnVectorGraphNextCandidateSeed(nextSeed, rowCount, candidateRows, hasCandidateRows, visitMarks, visitEpoch)
@@ -573,18 +762,18 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 			}
 			nextSeed = seed + 1
 			visitMarks[seed] = visitEpoch
-			if err := r.scoreAndPushFrontierVisited(plan, singleBlockView, query, queryInvNorm, seed, topK, scratch, &stats); err != nil {
+			if err := r.scoreAndPushFrontierVisited(plan, singleBlockView, query, queryInvNorm, seed, topK, scratch, hotStats, &loopCounters, preparedMinimalCounters); err != nil {
 				return nil, stats, err
 			}
 			continue
 		}
-		adjacency, err := r.expandCandidateAdjacencyLayer(plan, singleBlockView, candidate.ordinal, 0, scratch, &stats)
+		adjacency, err := r.expandCandidateAdjacencyLayer(plan, singleBlockView, candidate.ordinal, 0, scratch, hotStats, preparedMinimalCounters)
 		if err != nil {
 			return nil, stats, err
 		}
 		if plan.scoreBatchMode.indexedEnabled() {
-			for i := 0; i < len(adjacency) && stats.Candidates < uint64(efSearch); {
-				remaining := int(uint64(efSearch) - stats.Candidates)
+			for i := 0; i < len(adjacency) && loopCounters.Candidates < candidateLimit; {
+				remaining := int(candidateLimit - loopCounters.Candidates)
 				if remaining <= 0 {
 					break
 				}
@@ -598,8 +787,7 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 					neighborIndex := i
 					neighbor := adjacency[i]
 					i++
-					stats.Edges++
-					stats.VisitedEdges++
+					loopCounters.recordEdge()
 					if uint64(neighbor) >= uint64(rowCount) {
 						return nil, stats, fmt.Errorf("collections: column_graph %q ordinal=%d adjacency[%d]=%d outside row_count=%d: %w", r.def.Name, candidate.ordinal, neighborIndex, neighbor, rowCount, errColumnVectorGraphAdjacencyOrdinalOutOfBounds)
 					}
@@ -617,18 +805,17 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 				if len(tile) == 0 {
 					continue
 				}
-				if err := r.scoreAndPushFrontierVisitedTile(plan, singleBlockView, query, queryInvNorm, tile, topK, scratch, &stats); err != nil {
+				if err := r.scoreAndPushFrontierVisitedTile(plan, singleBlockView, query, queryInvNorm, tile, topK, scratch, hotStats, &loopCounters, preparedMinimalCounters); err != nil {
 					return nil, stats, err
 				}
 			}
 			continue
 		}
 		for i, neighbor := range adjacency {
-			if stats.Candidates >= uint64(efSearch) {
+			if loopCounters.Candidates >= candidateLimit {
 				break
 			}
-			stats.Edges++
-			stats.VisitedEdges++
+			loopCounters.recordEdge()
 			if uint64(neighbor) >= uint64(rowCount) {
 				return nil, stats, fmt.Errorf("collections: column_graph %q ordinal=%d adjacency[%d]=%d outside row_count=%d: %w", r.def.Name, candidate.ordinal, i, neighbor, rowCount, errColumnVectorGraphAdjacencyOrdinalOutOfBounds)
 			}
@@ -641,7 +828,7 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 				continue
 			}
 			visitMarks[neighborOrdinal] = visitEpoch
-			if err := r.scoreAndPushFrontierVisited(plan, singleBlockView, query, queryInvNorm, neighborOrdinal, topK, scratch, &stats); err != nil {
+			if err := r.scoreAndPushFrontierVisited(plan, singleBlockView, query, queryInvNorm, neighborOrdinal, topK, scratch, hotStats, &loopCounters, preparedMinimalCounters); err != nil {
 				return nil, stats, err
 			}
 		}
@@ -707,10 +894,14 @@ func columnVectorGraphNextCandidateSeed(start int, rowCount int, selection typed
 	return 0, false
 }
 
-func (r *columnVectorGraphPhysicalRowReader) maxAdjacencyLayer(plan *columnVectorGraphSearchPlan, singleBlockView *columnVectorGraphBlockView, ordinal int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) (int, error) {
+func (r *columnVectorGraphPhysicalRowReader) maxAdjacencyLayer(plan *columnVectorGraphSearchPlan, singleBlockView *columnVectorGraphBlockView, ordinal int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats, preparedMinimal *columnVectorGraphPreparedMinimalSearchCounters) (int, error) {
 	if plan != nil && plan.preparedSearch != nil {
 		layer, counters, err := plan.preparedSearch.maxAdjacencyLayerForOrdinal(ordinal)
-		recordColumnVectorGraphAdjacencySourceCounterSnapshotStats(stats, counters)
+		if preparedMinimal != nil {
+			preparedMinimal.recordAdjacencyCounterSnapshot(counters)
+		} else {
+			recordColumnVectorGraphAdjacencySourceCounterSnapshotStats(stats, counters)
+		}
 		return layer, err
 	}
 	if layer, _, counters, fallbackReason, ok := r.maxDirectAdjacencyLayerForOrdinal(ordinal); ok {
@@ -731,16 +922,19 @@ func (r *columnVectorGraphPhysicalRowReader) maxAdjacencyLayer(plan *columnVecto
 	return columnVectorGraphAdjacencyMaxLayer(adjacency)
 }
 
-func (r *columnVectorGraphPhysicalRowReader) greedyNearestAtLayer(plan *columnVectorGraphSearchPlan, singleBlockView *columnVectorGraphBlockView, query []float32, queryInvNorm float32, entryOrdinal int, layer int, candidateRows typedcolumn.RowSelection, hasCandidateRows bool, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) (int, error) {
+func (r *columnVectorGraphPhysicalRowReader) greedyNearestAtLayer(plan *columnVectorGraphSearchPlan, singleBlockView *columnVectorGraphBlockView, query []float32, queryInvNorm float32, entryOrdinal int, layer int, candidateRows typedcolumn.RowSelection, hasCandidateRows bool, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats, loopCounters *columnVectorGraphNativeSearchLoopCounters, preparedMinimal *columnVectorGraphPreparedMinimalSearchCounters) (int, error) {
 	best := entryOrdinal
 	bestScore, err := r.scoreOrdinal(plan, singleBlockView, query, queryInvNorm, best, scratch, stats)
 	if err != nil {
 		return 0, err
 	}
+	if preparedMinimal != nil {
+		preparedMinimal.recordPreparedScores(1, true)
+	}
 	changed := true
 	for changed {
 		changed = false
-		adjacency, err := r.expandCandidateAdjacencyLayer(plan, singleBlockView, best, layer, scratch, stats)
+		adjacency, err := r.expandCandidateAdjacencyLayer(plan, singleBlockView, best, layer, scratch, stats, preparedMinimal)
 		if err != nil {
 			return 0, err
 		}
@@ -748,10 +942,7 @@ func (r *columnVectorGraphPhysicalRowReader) greedyNearestAtLayer(plan *columnVe
 			scratch.scoreTileOrdinals = ensureColumnVectorGraphNativeIntScratch(scratch.scoreTileOrdinals, len(adjacency))
 			tile := scratch.scoreTileOrdinals[:0]
 			for i, neighbor := range adjacency {
-				if stats != nil {
-					stats.Edges++
-					stats.VisitedEdges++
-				}
+				loopCounters.recordEdge()
 				if uint64(neighbor) >= uint64(r.RowCount()) {
 					return 0, fmt.Errorf("collections: column_graph %q ordinal=%d adjacency[%d]=%d outside row_count=%d: %w", r.def.Name, best, i, neighbor, r.RowCount(), errColumnVectorGraphAdjacencyOrdinalOutOfBounds)
 				}
@@ -769,6 +960,9 @@ func (r *columnVectorGraphPhysicalRowReader) greedyNearestAtLayer(plan *columnVe
 			if err != nil {
 				return 0, err
 			}
+			if preparedMinimal != nil {
+				preparedMinimal.recordPreparedScores(len(tile), len(tile) <= 1)
+			}
 			for i, neighborOrdinal := range tile {
 				score := scores[i]
 				if score > bestScore || (score == bestScore && neighborOrdinal < best) {
@@ -780,10 +974,7 @@ func (r *columnVectorGraphPhysicalRowReader) greedyNearestAtLayer(plan *columnVe
 			continue
 		}
 		for i, neighbor := range adjacency {
-			if stats != nil {
-				stats.Edges++
-				stats.VisitedEdges++
-			}
+			loopCounters.recordEdge()
 			if uint64(neighbor) >= uint64(r.RowCount()) {
 				return 0, fmt.Errorf("collections: column_graph %q ordinal=%d adjacency[%d]=%d outside row_count=%d: %w", r.def.Name, best, i, neighbor, r.RowCount(), errColumnVectorGraphAdjacencyOrdinalOutOfBounds)
 			}
@@ -794,6 +985,9 @@ func (r *columnVectorGraphPhysicalRowReader) greedyNearestAtLayer(plan *columnVe
 			score, err := r.scoreOrdinal(plan, singleBlockView, query, queryInvNorm, neighborOrdinal, scratch, stats)
 			if err != nil {
 				return 0, err
+			}
+			if preparedMinimal != nil {
+				preparedMinimal.recordPreparedScores(1, true)
 			}
 			if score > bestScore || (score == bestScore && neighborOrdinal < best) {
 				best = neighborOrdinal
@@ -963,12 +1157,15 @@ func sortColumnVectorGraphResultOrderByOrdinal(order []int, top []columnVectorGr
 	})
 }
 
-func (r *columnVectorGraphPhysicalRowReader) scoreAndPushFrontierVisited(plan *columnVectorGraphSearchPlan, singleBlockView *columnVectorGraphBlockView, query []float32, queryInvNorm float32, ordinal, topK int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) error {
+func (r *columnVectorGraphPhysicalRowReader) scoreAndPushFrontierVisited(plan *columnVectorGraphSearchPlan, singleBlockView *columnVectorGraphBlockView, query []float32, queryInvNorm float32, ordinal, topK int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats, loopCounters *columnVectorGraphNativeSearchLoopCounters, preparedMinimal *columnVectorGraphPreparedMinimalSearchCounters) error {
 	score, err := r.scoreOrdinal(plan, singleBlockView, query, queryInvNorm, ordinal, scratch, stats)
 	if err != nil {
 		return err
 	}
-	stats.Candidates++
+	if preparedMinimal != nil {
+		preparedMinimal.recordPreparedScores(1, true)
+	}
+	loopCounters.recordCandidate()
 	candidate := columnVectorGraphSearchCandidate{
 		ordinal: ordinal,
 		score:   score,
@@ -978,7 +1175,7 @@ func (r *columnVectorGraphPhysicalRowReader) scoreAndPushFrontierVisited(plan *c
 	return nil
 }
 
-func (r *columnVectorGraphPhysicalRowReader) scoreAndPushFrontierVisitedTile(plan *columnVectorGraphSearchPlan, singleBlockView *columnVectorGraphBlockView, query []float32, queryInvNorm float32, ordinals []int, topK int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) error {
+func (r *columnVectorGraphPhysicalRowReader) scoreAndPushFrontierVisitedTile(plan *columnVectorGraphSearchPlan, singleBlockView *columnVectorGraphBlockView, query []float32, queryInvNorm float32, ordinals []int, topK int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats, loopCounters *columnVectorGraphNativeSearchLoopCounters, preparedMinimal *columnVectorGraphPreparedMinimalSearchCounters) error {
 	if len(ordinals) == 0 {
 		return nil
 	}
@@ -987,8 +1184,11 @@ func (r *columnVectorGraphPhysicalRowReader) scoreAndPushFrontierVisitedTile(pla
 	if err != nil {
 		return err
 	}
+	if preparedMinimal != nil {
+		preparedMinimal.recordPreparedScores(len(ordinals), len(ordinals) <= 1)
+	}
 	for i, ordinal := range ordinals {
-		stats.Candidates++
+		loopCounters.recordCandidate()
 		candidate := columnVectorGraphSearchCandidate{ordinal: ordinal, score: scores[i]}
 		scratch.insertTop(topK, candidate)
 		scratch.pushFrontier(candidate)
@@ -1085,13 +1285,15 @@ func (r *columnVectorGraphPhysicalRowReader) scoreOrdinalLegacy(plan *columnVect
 	return score, nil
 }
 
-func (r *columnVectorGraphPhysicalRowReader) expandCandidateAdjacencyLayer(plan *columnVectorGraphSearchPlan, singleBlockView *columnVectorGraphBlockView, ordinal int, layer int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) ([]uint32, error) {
+func (r *columnVectorGraphPhysicalRowReader) expandCandidateAdjacencyLayer(plan *columnVectorGraphSearchPlan, singleBlockView *columnVectorGraphBlockView, ordinal int, layer int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats, preparedMinimal *columnVectorGraphPreparedMinimalSearchCounters) ([]uint32, error) {
 	if plan != nil && plan.preparedSearch != nil {
 		layerAdjacency, outcome, err := plan.preparedSearch.adjacencyLayerForOrdinal(ordinal, layer)
 		if err != nil {
 			return nil, err
 		}
-		if stats != nil {
+		if preparedMinimal != nil {
+			preparedMinimal.recordPreparedAdjacency(len(layerAdjacency))
+		} else if stats != nil {
 			stats.ExpansionFetches++
 			stats.AdjacencyExpansions++
 			recordColumnVectorGraphAdjacencySourceOutcomeStats(stats, len(layerAdjacency), outcome)

--- a/TreeDB/collections/column_vector_graph_search_test.go
+++ b/TreeDB/collections/column_vector_graph_search_test.go
@@ -28,6 +28,7 @@ type columnVectorGraphNativeSearchBenchShapeV3 struct {
 	typedColumnVector         bool
 	omitResultMaterialization bool
 	scoreBatchMode            columnVectorGraphScoreBatchMode
+	statsMode                 columnVectorGraphNativeSearchStatsMode
 }
 
 func TestColumnVectorGraphAdjacencySourceStatsSkipEmptyNoopV3(t *testing.T) {
@@ -102,7 +103,11 @@ func columnVectorGraphNativeSearchProductionSweepBenchShapesV3() []columnVectorG
 }
 
 func columnVectorGraphNativeSearchBenchShapeNameV3(shape columnVectorGraphNativeSearchBenchShapeV3) string {
-	return fmt.Sprintf("rows=%d/dims=%d/degree=%d/topK=%d/efSearch=%d", shape.rows, shape.dims, shape.m, shape.topK, shape.efSearch)
+	name := fmt.Sprintf("rows=%d/dims=%d/degree=%d/topK=%d/efSearch=%d", shape.rows, shape.dims, shape.m, shape.topK, shape.efSearch)
+	if shape.statsMode != columnVectorGraphNativeSearchStatsModeDefault {
+		name += "/stats=" + shape.statsMode.String()
+	}
+	return name
 }
 
 func TestColumnVectorGraphNativeSearchCosineUsesPhysicalRowsV3(t *testing.T) {
@@ -818,6 +823,33 @@ func BenchmarkColumnVectorGraphNativeSearchCosineTypedColumnProduction8192V3(b *
 	benchmarkColumnVectorGraphNativeSearchCosineV3(b, shape)
 }
 
+func BenchmarkColumnVectorGraphNativeSearchCosineTypedColumnStatsMode2042(b *testing.B) {
+	for _, tc := range []struct {
+		name string
+		mode columnVectorGraphNativeSearchStatsMode
+	}{
+		{name: "full_diagnostics", mode: columnVectorGraphNativeSearchStatsModeFullDiagnostics},
+		{name: "minimal", mode: columnVectorGraphNativeSearchStatsModeMinimal},
+	} {
+		tc := tc
+		b.Run(tc.name, func(b *testing.B) {
+			shape := columnVectorGraphNativeSearchProduction8192BenchShapeV3()
+			shape.typedColumnVector = true
+			shape.omitResultMaterialization = true
+			shape.statsMode = tc.mode
+			benchmarkColumnVectorGraphNativeSearchCosineV3(b, shape)
+		})
+	}
+}
+
+func BenchmarkColumnVectorGraphNativeSearchCosineParallelTypedColumnMinimalStats2042(b *testing.B) {
+	shape := columnVectorGraphNativeSearchProduction8192BenchShapeV3()
+	shape.typedColumnVector = true
+	shape.omitResultMaterialization = true
+	shape.statsMode = columnVectorGraphNativeSearchStatsModeMinimal
+	benchmarkColumnVectorGraphNativeSearchCosineParallelV3(b, shape)
+}
+
 func BenchmarkColumnVectorGraphNativeSearchCosineIndexedScoring1969(b *testing.B) {
 	for _, tc := range []struct {
 		name string
@@ -846,7 +878,7 @@ func benchmarkColumnVectorGraphNativeSearchCosineV3(b *testing.B, shape columnVe
 	}
 	defer reader.Close()
 	var scratch columnVectorGraphNativeSearchScratch
-	opts := columnVectorGraphNativeSearchOptions{TopK: shape.topK, EfSearch: shape.efSearch, ScoreBatchMode: shape.scoreBatchMode, OmitResultMaterialization: shape.omitResultMaterialization}
+	opts := columnVectorGraphNativeSearchOptions{TopK: shape.topK, EfSearch: shape.efSearch, ScoreBatchMode: shape.scoreBatchMode, StatsMode: shape.statsMode, OmitResultMaterialization: shape.omitResultMaterialization}
 	if _, _, err := reader.SearchCosine(query, opts, &scratch); err != nil {
 		b.Fatalf("warm SearchCosine: %v", err)
 	}
@@ -1008,7 +1040,7 @@ func benchmarkColumnVectorGraphNativeSearchCosineParallelV3(b *testing.B, shape 
 	previousGOMAXPROCS := runtime.GOMAXPROCS(workers)
 	defer runtime.GOMAXPROCS(previousGOMAXPROCS)
 	benchWorkers := make([]*searchWorker, workers)
-	opts := columnVectorGraphNativeSearchOptions{TopK: shape.topK, EfSearch: shape.efSearch, ScoreBatchMode: shape.scoreBatchMode, OmitResultMaterialization: shape.omitResultMaterialization}
+	opts := columnVectorGraphNativeSearchOptions{TopK: shape.topK, EfSearch: shape.efSearch, ScoreBatchMode: shape.scoreBatchMode, StatsMode: shape.statsMode, OmitResultMaterialization: shape.omitResultMaterialization}
 	for i := range benchWorkers {
 		reader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
 		if err != nil {
@@ -1459,6 +1491,14 @@ func reportColumnGraphNativeSearchBenchShapeMetricsV3(b *testing.B, shape column
 		} else {
 			b.ReportMetric(1, "score_batch_mode_scalar")
 		}
+	}
+	switch shape.statsMode.normalized() {
+	case columnVectorGraphNativeSearchStatsModeMinimal:
+		b.ReportMetric(1, "stats_mode_minimal")
+	case columnVectorGraphNativeSearchStatsModeBenchmarkDebug:
+		b.ReportMetric(1, "stats_mode_benchmark_debug")
+	default:
+		b.ReportMetric(1, "stats_mode_full_diagnostics")
 	}
 }
 

--- a/TreeDB/collections/vector_graph_search_truth_matrix_2037_test.go
+++ b/TreeDB/collections/vector_graph_search_truth_matrix_2037_test.go
@@ -41,12 +41,17 @@ type vectorGraphSearchTruthMatrixRow2037 struct {
 	Boundary           vectorGraphSearchTruthMatrixBoundary2037
 	Concurrency        vectorGraphSearchTruthMatrixConcurrency2037
 	Fixture            vectorGraphSearchTruthMatrixFixture2037
+	StatsMode          columnVectorGraphNativeSearchStatsMode
 	CanonicalBenchmark string
 	UnsupportedReason  string
 }
 
 func (r vectorGraphSearchTruthMatrixRow2037) Name() string {
-	return fmt.Sprintf("mode=%s/boundary=%s/concurrency=%s/fixture=%s", r.Mode, r.Boundary, r.Concurrency, r.Fixture)
+	name := fmt.Sprintf("mode=%s/boundary=%s/concurrency=%s/fixture=%s", r.Mode, r.Boundary, r.Concurrency, r.Fixture)
+	if r.StatsMode != columnVectorGraphNativeSearchStatsModeDefault {
+		name += "/stats=" + r.StatsMode.String()
+	}
+	return name
 }
 
 func (r vectorGraphSearchTruthMatrixRow2037) Supported() bool {
@@ -64,7 +69,9 @@ func vectorGraphSearchTruthMatrixRows2037() []vectorGraphSearchTruthMatrixRow203
 		{Mode: vectorGraphSearchTruthMatrixModeCurrentTypedColumn2037, Boundary: vectorGraphSearchTruthMatrixBoundaryGraphOnly2037, Concurrency: vectorGraphSearchTruthMatrixConcurrencySerial2037, Fixture: vectorGraphSearchTruthMatrixFixtureProduction81922037, CanonicalBenchmark: "BenchmarkColumnVectorGraphNativeSearchCosineTypedColumnProduction8192V3 with graph_only_no_result_materialization"},
 		{Mode: vectorGraphSearchTruthMatrixModeCurrentTypedColumn2037, Boundary: vectorGraphSearchTruthMatrixBoundaryGraphOnly2037, Concurrency: vectorGraphSearchTruthMatrixConcurrencyParallel2037, Fixture: vectorGraphSearchTruthMatrixFixtureProduction81922037, CanonicalBenchmark: "BenchmarkColumnVectorGraphNativeSearchCosineParallelTypedColumnProduction8192V3 with graph_only_no_result_materialization"},
 		{Mode: vectorGraphSearchTruthMatrixModeCombinedPrepared2037, Boundary: vectorGraphSearchTruthMatrixBoundaryGraphOnly2037, Concurrency: vectorGraphSearchTruthMatrixConcurrencySerial2037, Fixture: vectorGraphSearchTruthMatrixFixtureProduction81922037, CanonicalBenchmark: "BenchmarkColumnVectorGraphSearchTruthMatrix2037 combined prepared graph-only serial row"},
+		{Mode: vectorGraphSearchTruthMatrixModeCombinedPrepared2037, Boundary: vectorGraphSearchTruthMatrixBoundaryGraphOnly2037, Concurrency: vectorGraphSearchTruthMatrixConcurrencySerial2037, Fixture: vectorGraphSearchTruthMatrixFixtureProduction81922037, StatsMode: columnVectorGraphNativeSearchStatsModeMinimal, CanonicalBenchmark: "BenchmarkColumnVectorGraphSearchTruthMatrix2037 combined prepared graph-only serial minimal-stats row"},
 		{Mode: vectorGraphSearchTruthMatrixModeCombinedPrepared2037, Boundary: vectorGraphSearchTruthMatrixBoundaryGraphOnly2037, Concurrency: vectorGraphSearchTruthMatrixConcurrencyParallel2037, Fixture: vectorGraphSearchTruthMatrixFixtureProduction81922037, CanonicalBenchmark: "BenchmarkColumnVectorGraphSearchTruthMatrix2037 combined prepared graph-only parallel row"},
+		{Mode: vectorGraphSearchTruthMatrixModeCombinedPrepared2037, Boundary: vectorGraphSearchTruthMatrixBoundaryGraphOnly2037, Concurrency: vectorGraphSearchTruthMatrixConcurrencyParallel2037, Fixture: vectorGraphSearchTruthMatrixFixtureProduction81922037, StatsMode: columnVectorGraphNativeSearchStatsModeMinimal, CanonicalBenchmark: "BenchmarkColumnVectorGraphSearchTruthMatrix2037 combined prepared graph-only parallel minimal-stats row"},
 
 		{Mode: vectorGraphSearchTruthMatrixModeCurrentTypedColumn2037, Boundary: vectorGraphSearchTruthMatrixBoundaryResultID2037, Concurrency: vectorGraphSearchTruthMatrixConcurrencySerial2037, Fixture: vectorGraphSearchTruthMatrixFixtureServing10242037, CanonicalBenchmark: "BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderV4"},
 		{Mode: vectorGraphSearchTruthMatrixModeCurrentTypedColumn2037, Boundary: vectorGraphSearchTruthMatrixBoundaryResultID2037, Concurrency: vectorGraphSearchTruthMatrixConcurrencyParallel2037, Fixture: vectorGraphSearchTruthMatrixFixtureServing10242037, CanonicalBenchmark: "BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderParallelV4"},
@@ -141,7 +148,9 @@ func TestVectorGraphSearchTruthMatrixRows2037(t *testing.T) {
 		"mode=current_tvis_base_typed_column/boundary=graph_only/concurrency=serial/fixture=production8192",
 		"mode=current_tvis_base_typed_column/boundary=graph_only/concurrency=parallel/fixture=production8192",
 		"mode=combined_prepared_typed_column/boundary=graph_only/concurrency=serial/fixture=production8192",
+		"mode=combined_prepared_typed_column/boundary=graph_only/concurrency=serial/fixture=production8192/stats=minimal",
 		"mode=combined_prepared_typed_column/boundary=graph_only/concurrency=parallel/fixture=production8192",
+		"mode=combined_prepared_typed_column/boundary=graph_only/concurrency=parallel/fixture=production8192/stats=minimal",
 		"mode=current_tvis_base_typed_column/boundary=result_id/concurrency=serial/fixture=serving1024",
 		"mode=current_tvis_base_typed_column/boundary=result_id/concurrency=parallel/fixture=serving1024",
 		"mode=combined_prepared_typed_column/boundary=result_id/concurrency=serial/fixture=serving1024",
@@ -245,6 +254,7 @@ func reportVectorGraphSearchTruthMatrixRowLabels2037(b *testing.B, row vectorGra
 	b.ReportMetric(1, "matrix_boundary_"+string(row.Boundary))
 	b.ReportMetric(1, "matrix_concurrency_"+string(row.Concurrency))
 	b.ReportMetric(1, "matrix_fixture_"+string(row.Fixture))
+	b.ReportMetric(1, "matrix_stats_"+row.StatsMode.String())
 	b.ReportMetric(float64(shape.rows), "rows")
 	b.ReportMetric(float64(shape.dims), "dims")
 	b.ReportMetric(float64(shape.degree), "degree")
@@ -312,6 +322,7 @@ func benchmarkVectorGraphSearchTruthMatrixGraphOnly2037(b *testing.B, row vector
 	b.Helper()
 	shape := columnVectorGraphNativeSearchProduction8192BenchShapeV3()
 	shape.omitResultMaterialization = true
+	shape.statsMode = row.StatsMode
 	switch row.Mode {
 	case vectorGraphSearchTruthMatrixModeLegacyDirectGraphRow2037:
 		shape.typedColumnVector = false

--- a/TreeDB/collections/vector_index.go
+++ b/TreeDB/collections/vector_index.go
@@ -175,6 +175,10 @@ type VectorIndexSearchOptions struct {
 	DocumentFetchOptions DocumentFetchOptions
 	// MaxDecodedBlocks bounds the physical column row reader cache for column_graph search.
 	MaxDecodedBlocks int
+	// StatsMode selects column_graph search telemetry detail. The zero value
+	// preserves full diagnostics; minimal mode keeps production/admission counters
+	// with lower hot-loop overhead on the healthy combined prepared path.
+	StatsMode VectorIndexSearchStatsMode
 	// scoreBatchMode is an internal exact-order indexed-scoring test/benchmark hook.
 	scoreBatchMode columnVectorGraphScoreBatchMode
 }

--- a/TreeDB/collections/vector_index_search.go
+++ b/TreeDB/collections/vector_index_search.go
@@ -25,6 +25,32 @@ const (
 	VectorIndexSearchPathColumnGraphNativeReader VectorIndexSearchPath = "column_graph_native_reader"
 )
 
+// VectorIndexSearchStatsMode selects how much vector graph-search telemetry is
+// collected. The zero value preserves full diagnostics for compatibility; use
+// VectorIndexSearchStatsModeMinimal on steady-state production searches that
+// only need required production/admission counters.
+type VectorIndexSearchStatsMode string
+
+const (
+	VectorIndexSearchStatsModeDefault         VectorIndexSearchStatsMode = ""
+	VectorIndexSearchStatsModeMinimal         VectorIndexSearchStatsMode = "minimal"
+	VectorIndexSearchStatsModeFullDiagnostics VectorIndexSearchStatsMode = "full_diagnostics"
+	VectorIndexSearchStatsModeBenchmarkDebug  VectorIndexSearchStatsMode = "benchmark_debug"
+)
+
+func columnVectorGraphNativeSearchStatsModeFromPublic(mode VectorIndexSearchStatsMode) (columnVectorGraphNativeSearchStatsMode, error) {
+	switch mode {
+	case VectorIndexSearchStatsModeDefault, VectorIndexSearchStatsModeFullDiagnostics:
+		return columnVectorGraphNativeSearchStatsModeFullDiagnostics, nil
+	case VectorIndexSearchStatsModeMinimal:
+		return columnVectorGraphNativeSearchStatsModeMinimal, nil
+	case VectorIndexSearchStatsModeBenchmarkDebug:
+		return columnVectorGraphNativeSearchStatsModeBenchmarkDebug, nil
+	default:
+		return columnVectorGraphNativeSearchStatsModeDefault, fmt.Errorf("collections: vector index search stats mode %q is unsupported", mode)
+	}
+}
+
 // VectorIndexSearcherOptions configures a reusable snapshot-bound vector-index
 // searcher. Reuse this path for steady-state queries when setup/open cost should
 // not be paid on every search.
@@ -50,6 +76,11 @@ type VectorIndexSearcherSearchOptions struct {
 	// DocumentFetchOptions controls optional projected final-fetch materialization.
 	// It is used only when IncludeDocuments is true; the zero value returns full documents.
 	DocumentFetchOptions DocumentFetchOptions
+	// StatsMode selects graph-search telemetry detail. The zero value preserves
+	// full diagnostics; minimal mode avoids per-candidate/per-edge diagnostic
+	// source accounting on the healthy combined prepared path while still
+	// reporting fallback/admission counters.
+	StatsMode VectorIndexSearchStatsMode
 	// scoreBatchMode is an internal test/benchmark hook for exact-order indexed
 	// HNSW scoring. The public zero value follows the default scalar gate.
 	scoreBatchMode columnVectorGraphScoreBatchMode
@@ -432,6 +463,7 @@ func (c *Collection) SearchVectorIndex(opts VectorIndexSearchOptions) (VectorInd
 		EfSearch:             opts.EfSearch,
 		IncludeDocuments:     opts.IncludeDocuments,
 		DocumentFetchOptions: opts.DocumentFetchOptions,
+		StatsMode:            opts.StatsMode,
 		scoreBatchMode:       opts.scoreBatchMode,
 	})
 	documentView := searcher.documentView
@@ -599,11 +631,16 @@ func (s *VectorIndexSearcher) Search(opts VectorIndexSearcherSearchOptions) (Vec
 	if !opts.IncludeDocuments && documentFetchOptionsHasProjection(opts.DocumentFetchOptions) {
 		return response, errors.New("collections: vector index document projection requires IncludeDocuments")
 	}
+	statsMode, err := columnVectorGraphNativeSearchStatsModeFromPublic(opts.StatsMode)
+	if err != nil {
+		return response, err
+	}
 	readerStatsBefore := s.readerLast
 	results, searchStats, err := s.reader.SearchCosine(opts.Query, columnVectorGraphNativeSearchOptions{
 		TopK:           opts.TopK,
 		EfSearch:       opts.EfSearch,
 		ScoreBatchMode: opts.scoreBatchMode,
+		StatsMode:      statsMode,
 	}, &s.scratch)
 	readerStatsAfter := s.reader.Stats()
 	s.readerLast = readerStatsAfter
@@ -744,11 +781,16 @@ func (s *VectorIndexSearcher) SearchWithBuffer(opts VectorIndexSearcherSearchOpt
 	if documentFetchOptionsHasProjection(opts.DocumentFetchOptions) {
 		return response, errors.New("collections: vector index document projection requires IncludeDocuments")
 	}
+	statsMode, err := columnVectorGraphNativeSearchStatsModeFromPublic(opts.StatsMode)
+	if err != nil {
+		return response, err
+	}
 	readerStatsBefore := s.readerLast
 	results, searchStats, err := s.reader.SearchCosine(opts.Query, columnVectorGraphNativeSearchOptions{
 		TopK:           opts.TopK,
 		EfSearch:       opts.EfSearch,
 		ScoreBatchMode: opts.scoreBatchMode,
+		StatsMode:      statsMode,
 	}, &s.scratch)
 	readerStatsAfter := s.reader.Stats()
 	s.readerLast = readerStatsAfter


### PR DESCRIPTION
Closes #2042. Part of #2035.

## Summary
- Added vector graph search stats modes: default/full diagnostics, minimal production, and benchmark/debug.
- Minimal mode keeps production/admission/fallback counters on the healthy #2045 combined prepared path while bypassing per-candidate source/outcome stat recording in the hot loop.
- Search loops now accumulate candidate/edge counters locally and publish once per search.
- Extended #2037 truth-matrix benchmark rows with minimal-stats combined-prepared graph-only coverage.

## Validation
- `GOWORK=off go test ./TreeDB/collections -run 'TestColumnVectorGraphPreparedSearch(MinimalStats2042|SelectedAndEquivalent2045|NonMmapCompatibility2045|ParallelScratchSafety2045)|TestVectorGraphSearchTruthMatrix'`
- `GOWORK=off go test ./TreeDB/collections`
- `GOWORK=off go test ./TreeDB/collections ./TreeDB/docs`
- `git diff --check`

## Benchmark evidence (#2037 graph-only matrix)
Command:

```sh
GOWORK=off go test ./TreeDB/collections \
  -run '^$' \
  -bench '^BenchmarkColumnVectorGraphSearchTruthMatrix2037/mode=combined_prepared_typed_column/boundary=graph_only/concurrency=(serial|parallel)/fixture=production8192($|/stats=minimal$)' \
  -benchmem -benchtime=200ms -count=1
```

Hardware: Apple M3, darwin/arm64. Shape: production8192, dims=128, degree=16, topK=10, efSearch=128, graph-only/no result materialization.

| Row | ns/op | ops/sec | B/op | allocs/op | candidates/search | edges/search | prepared views/search | graph-row fallbacks/search | prepared score calls/search | vector prepared direct/search | adjacency prepared CSR mmap/search |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| serial full diagnostics | 20,965 | 47,698 | 0 | 0 | 128 | 3,340 | 1 | 0 | 182 | 182 | 108 |
| serial minimal | 12,268 | 81,510 | 0 | 0 | 128 | 3,340 | 1 | 0 | 182 | 182 | 108 |
| parallel minimal | 2,901 | 344,675 | 0 | 0 | 128 | 3,340 | 1 | 0 | 182 | 182 | 108 |

Additional row measured for comparison: parallel full diagnostics 3,102 ns/op, 322,384 ops/sec, 0 B/op, 0 allocs/op.

## CPU profile
Focused minimal serial graph-only profile captured at `/tmp/treedb_2042_profile_20260531_104045/`:
- `cpu_minimal_serial.pprof`
- `cpu_top.txt`

Timed row in that profile run: 13,564 ns/op, 73,725 ops/sec, 0 B/op, 0 allocs/op. The profile includes benchmark fixture setup; `SearchCosine` is visible in the top output.

## Notes / risks
- Default public behavior remains full diagnostics for compatibility; callers can opt into `VectorIndexSearchStatsModeMinimal`.
- Minimal mode is scoped to the healthy combined prepared path. Compatibility/fallback paths still report fallback/source counters instead of masking graph-row or generic-source regressions.
