### PR TITLE
[codex] add nativewire YCSB load benchmark

### DIFF
--- a/TreeDB/nativewire/ycsb_bench_test.go
+++ b/TreeDB/nativewire/ycsb_bench_test.go
@@ -1,0 +1,354 @@
+package nativewire
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"hash/fnv"
+	"io"
+	"log"
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	treedb "github.com/snissn/gomap/TreeDB"
+	"github.com/snissn/gomap/TreeDB/collections"
+	iwire "github.com/snissn/gomap/TreeDB/internal/nativewire"
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+const (
+	ycsbBenchCollection = "usertable"
+	ycsbBenchKeyField   = "_ycsb_key"
+	ycsbBenchKeyIndex   = "_ycsb_key_1"
+	ycsbBenchClients    = 16
+	ycsbBenchFields     = 10
+	ycsbBenchFieldLen   = 100
+)
+
+var (
+	ycsbBenchFieldNames       = ycsbFieldNames()
+	ycsbBenchFieldValue       = ycsbFieldValue()
+	ycsbBenchFieldValueString = base64.StdEncoding.EncodeToString(ycsbBenchFieldValue)
+	ycsbTemplateFields        = append([]string{ycsbBenchKeyField}, ycsbBenchFieldNames...)
+)
+
+// BenchmarkNativewireYCSBLoad exercises the treedb-native load shape used by
+// go-ycsb's default workload: one InsertBatch request per document, 16 client
+// connections, a 10x100-byte row, AckVisible, and a unique _ycsb_key index.
+//
+// The JSON case intentionally mirrors the current go-ycsb treedb-native client:
+// json.Marshal(map[string]any) over []byte field values, which stores those
+// fields as base64 JSON strings. BSON and template-v1 are hypothetical native
+// client encodings for the same logical row shape; go-ycsb does not send them
+// today.
+func BenchmarkNativewireYCSBLoad(b *testing.B) {
+	logOutput := log.Writer()
+	log.SetOutput(io.Discard)
+	defer log.SetOutput(logOutput)
+
+	for _, transport := range []string{"tcp", "inproc"} {
+		transport := transport
+		for _, tc := range []ycsbLoadFormat{
+			{name: "json_go_ycsb", format: collections.DocumentFormatJSON, encode: encodeYCSBJSONDocument},
+			{name: "bson_binary", format: collections.DocumentFormatBSON, encode: encodeYCSBBSONBinaryDocument},
+			{name: "bson_base64_strings", format: collections.DocumentFormatBSON, encode: encodeYCSBBSONBase64StringDocument},
+			{name: "template_v1_base64_strings", format: collections.DocumentFormatTemplateV1, encode: encodeYCSBTemplateV1Document},
+		} {
+			tc := tc
+			b.Run(transport+"/"+tc.name, func(b *testing.B) {
+				benchmarkNativewireYCSBLoad(b, transport, tc)
+			})
+		}
+	}
+}
+
+type ycsbLoadFormat struct {
+	name   string
+	format collections.DocumentFormat
+	encode func(key string) ([]byte, error)
+}
+
+type ycsbBenchEnv struct {
+	server  *Server
+	cleanup func() error
+	address string
+}
+
+func benchmarkNativewireYCSBLoad(b *testing.B, transport string, format ycsbLoadFormat) {
+	env := newYCSBBenchEnv(b, format.format, transport == "tcp")
+	defer func() {
+		if err := env.cleanup(); err != nil {
+			b.Fatalf("cleanup: %v", err)
+		}
+	}()
+
+	clients := make([]*Client, ycsbBenchClients)
+	handles := make([]CollectionHandle, ycsbBenchClients)
+	cleanups := make([]func() error, ycsbBenchClients)
+	ctx := context.Background()
+	for i := range clients {
+		client, cleanup := newYCSBBenchClient(b, ctx, env, transport)
+		handle, err := client.OpenCollection(ctx, ycsbBenchCollection)
+		if err != nil {
+			_ = cleanup()
+			b.Fatalf("OpenCollection: %v", err)
+		}
+		clients[i] = client
+		handles[i] = handle
+		cleanups[i] = cleanup
+	}
+	defer func() {
+		for _, cleanup := range cleanups {
+			if cleanup != nil {
+				_ = cleanup()
+			}
+		}
+	}()
+
+	sample, err := format.encode(ycsbBenchKey(0))
+	if err != nil {
+		b.Fatalf("encode sample: %v", err)
+	}
+	b.ReportAllocs()
+	b.SetBytes(int64(len(sample)))
+	b.ResetTimer()
+
+	var failed atomic.Bool
+	var firstErr error
+	var firstErrOnce sync.Once
+	recordErr := func(err error) {
+		if err == nil {
+			return
+		}
+		failed.Store(true)
+		firstErrOnce.Do(func() {
+			firstErr = err
+		})
+	}
+
+	var wg sync.WaitGroup
+	base := 0
+	for worker := 0; worker < ycsbBenchClients; worker++ {
+		count := b.N / ycsbBenchClients
+		if worker < b.N%ycsbBenchClients {
+			count++
+		}
+		start := base
+		base += count
+		if count == 0 {
+			continue
+		}
+		worker := worker
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ids := make([][]byte, 1)
+			docs := make([][]byte, 1)
+			for i := 0; i < count && !failed.Load(); i++ {
+				key := ycsbBenchKey(start + i)
+				doc, err := format.encode(key)
+				if err != nil {
+					recordErr(fmt.Errorf("encode %s: %w", key, err))
+					return
+				}
+				ids[0] = []byte(key)
+				docs[0] = doc
+				if err := ycsbInsertBatchNoResultIDs(ctx, clients[worker], handles[worker], format.format, ids, docs); err != nil {
+					recordErr(fmt.Errorf("insert %s: %w", key, err))
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	b.StopTimer()
+	if firstErr != nil {
+		b.Fatal(firstErr)
+	}
+	b.ReportMetric(float64(len(sample)), "document_bytes")
+	b.ReportMetric(float64(ycsbBenchClients), "clients")
+}
+
+func newYCSBBenchEnv(tb testing.TB, format collections.DocumentFormat, tcp bool) *ycsbBenchEnv {
+	tb.Helper()
+	opts := treedb.OptionsFor(treedb.ProfileFast, tb.TempDir())
+	db, cleanup, err := treedb.OpenBackendWithCachedLeafLog(opts)
+	if err != nil {
+		tb.Fatalf("OpenBackendWithCachedLeafLog: %v", err)
+	}
+	mgr := collections.NewCollectionManager(db)
+	if _, err := mgr.CreateCollection(&collections.CollectionMeta{
+		Name: ycsbBenchCollection,
+		Options: collections.CollectionOptions{
+			DocumentFormat: format,
+		},
+		Indexes: []collections.IndexDefinition{
+			{
+				Name:      ycsbBenchKeyIndex,
+				Field:     ycsbBenchKeyField,
+				ValueType: collections.IndexValueString,
+				Unique:    true,
+			},
+		},
+	}); err != nil {
+		_ = cleanup()
+		tb.Fatalf("CreateCollection: %v", err)
+	}
+
+	server := NewServer(ServerOptions{Collections: mgr, Backend: db})
+	env := &ycsbBenchEnv{
+		server: server,
+		cleanup: func() error {
+			return errors.Join(server.Close(), cleanup())
+		},
+	}
+	if !tcp {
+		return env
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		cancel()
+		_ = env.cleanup()
+		tb.Fatalf("Listen: %v", err)
+	}
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- server.Serve(ctx, ln)
+	}()
+	baseCleanup := env.cleanup
+	env.address = ln.Addr().String()
+	env.cleanup = func() error {
+		cancel()
+		_ = ln.Close()
+		err := baseCleanup()
+		select {
+		case serveErr := <-errCh:
+			if serveErr != nil && !errors.Is(serveErr, context.Canceled) && !errors.Is(serveErr, net.ErrClosed) {
+				err = errors.Join(err, serveErr)
+			}
+		default:
+		}
+		return err
+	}
+	return env
+}
+
+func newYCSBBenchClient(tb testing.TB, ctx context.Context, env *ycsbBenchEnv, transport string) (*Client, func() error) {
+	tb.Helper()
+	if transport == "tcp" {
+		client, err := DialContext(ctx, "tcp", env.address)
+		if err != nil {
+			tb.Fatalf("DialContext: %v", err)
+		}
+		return client, client.Close
+	}
+	client, cleanup, err := NewInProcessClient(ctx, env.server)
+	if err != nil {
+		tb.Fatalf("NewInProcessClient: %v", err)
+	}
+	return client, cleanup
+}
+
+func ycsbInsertBatchNoResultIDs(ctx context.Context, c *Client, handle CollectionHandle, format collections.DocumentFormat, ids, docs [][]byte) error {
+	if c == nil {
+		return errors.New("nativewire: nil client")
+	}
+	guard, err := c.replicatedMutationGuard(ctx, "insert_batch")
+	if err != nil {
+		return err
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	body, err := appendInsertBatchRequestBodyRefFlags(c.requestBody[:0], "", handle, true, format, ids, docs, AckVisible, iwire.CommandFlagOmitResultIDs, guard)
+	if err != nil {
+		return err
+	}
+	_, response, err := c.roundTripLocked(ctx, iwire.FrameRequest, body, iwire.FrameResponse)
+	c.requestBody = body[:0]
+	if err != nil {
+		c.clearCatalogVersionOnMismatch(err)
+		return err
+	}
+	var sectionBuf [4]iwire.Section
+	sections, err := iwire.DecodeSectionsInto(sectionBuf[:0], response, c.limits)
+	if err != nil {
+		return err
+	}
+	c.updateCatalogVersionFromMutationResponse(sections)
+	return nil
+}
+
+func encodeYCSBJSONDocument(key string) ([]byte, error) {
+	row := make(map[string]any, ycsbBenchFields+1)
+	for _, field := range ycsbBenchFieldNames {
+		row[field] = ycsbBenchFieldValue
+	}
+	row[ycsbBenchKeyField] = key
+	return json.Marshal(row)
+}
+
+func encodeYCSBBSONBinaryDocument(key string) ([]byte, error) {
+	row := make(bson.D, 0, ycsbBenchFields+1)
+	row = append(row, bson.E{Key: ycsbBenchKeyField, Value: key})
+	for _, field := range ycsbBenchFieldNames {
+		row = append(row, bson.E{Key: field, Value: ycsbBenchFieldValue})
+	}
+	return bson.Marshal(row)
+}
+
+func encodeYCSBBSONBase64StringDocument(key string) ([]byte, error) {
+	row := make(bson.D, 0, ycsbBenchFields+1)
+	row = append(row, bson.E{Key: ycsbBenchKeyField, Value: key})
+	for _, field := range ycsbBenchFieldNames {
+		row = append(row, bson.E{Key: field, Value: ycsbBenchFieldValueString})
+	}
+	return bson.Marshal(row)
+}
+
+func encodeYCSBTemplateV1Document(key string) ([]byte, error) {
+	values := make([]any, 0, ycsbBenchFields+1)
+	values = append(values, key)
+	for range ycsbBenchFieldNames {
+		values = append(values, ycsbBenchFieldValueString)
+	}
+	return collections.EncodeTemplateV1Document(ycsbTemplateFields, values)
+}
+
+func ycsbBenchKey(n int) string {
+	return fmt.Sprintf("user%d", ycsbHash64(int64(n)))
+}
+
+func ycsbHash64(n int64) int64 {
+	var b [8]byte
+	binary.BigEndian.PutUint64(b[:], uint64(n))
+	hash := fnv.New64a()
+	_, _ = hash.Write(b[:])
+	result := int64(hash.Sum64())
+	if result < 0 {
+		return -result
+	}
+	return result
+}
+
+func ycsbFieldNames() []string {
+	fields := make([]string, ycsbBenchFields)
+	for i := range fields {
+		fields[i] = fmt.Sprintf("field%d", i)
+	}
+	return fields
+}
+
+func ycsbFieldValue() []byte {
+	value := make([]byte, ycsbBenchFieldLen)
+	for i := range value {
+		value[i] = byte('a' + i%26)
+	}
+	return value
+}

--- a/TreeDB/nativewire/ycsb_bench_test.go
+++ b/TreeDB/nativewire/ycsb_bench_test.go
@@ -41,11 +41,10 @@ var (
 // go-ycsb's default workload: one InsertBatch request per document, 16 client
 // connections, a 10x100-byte row, AckVisible, and a unique _ycsb_key index.
 //
-// The JSON case intentionally mirrors the current go-ycsb treedb-native client:
-// json.Marshal(map[string]any) over []byte field values, which stores those
-// fields as base64 JSON strings. BSON and template-v1 are hypothetical native
-// client encodings for the same logical row shape; go-ycsb does not send them
-// today.
+// The JSON case intentionally mirrors the original go-ycsb treedb-native
+// client: json.Marshal(map[string]any) over []byte field values, which stores
+// those fields as base64 JSON strings. BSON and template-v1 cover alternate
+// native encodings for the same logical row shape.
 func BenchmarkNativewireYCSBLoad(b *testing.B) {
 	logOutput := log.Writer()
 	log.SetOutput(io.Discard)

--- a/docs/benchmarks/nativewire_ycsb_profile_guard.md
+++ b/docs/benchmarks/nativewire_ycsb_profile_guard.md
@@ -1,0 +1,86 @@
+# Nativewire BSON YCSB Profile Guard
+
+Use this guard when changing the nativewire BSON YCSB load hot path tracked by
+issue #2083. The primary local target is:
+
+```sh
+go test ./TreeDB/nativewire \
+  -run '^$' \
+  -bench '^BenchmarkNativewireYCSBLoad/inproc/bson_binary$' \
+  -benchmem \
+  -benchtime=1s \
+  -count=3
+```
+
+Record the branch, commit, host context, `ns/op`, throughput, `B/op`, and
+`allocs/op`. For implementation PRs, compare before and after with `benchstat`
+when possible.
+
+## Profiles
+
+Capture CPU, allocation, block, and mutex profiles from the same benchmark
+shape:
+
+```sh
+OUT=$(mktemp -d /tmp/treedb_nativewire_ycsb_profiles_XXXXXX)
+
+go test ./TreeDB/nativewire \
+  -run '^$' \
+  -bench '^BenchmarkNativewireYCSBLoad/inproc/bson_binary$' \
+  -benchmem \
+  -benchtime=3s \
+  -count=1 \
+  -cpuprofile "$OUT/nativewire_ycsb_cpu.pprof" \
+  -memprofile "$OUT/nativewire_ycsb_allocs.pprof" \
+  -blockprofile "$OUT/nativewire_ycsb_block.pprof" \
+  -mutexprofile "$OUT/nativewire_ycsb_mutex.pprof" \
+  -mutexprofilefraction=1
+
+go tool pprof -top "$OUT/nativewire_ycsb_cpu.pprof" \
+  >"$OUT/nativewire_ycsb_cpu_top.txt"
+go tool pprof -top "$OUT/nativewire_ycsb_allocs.pprof" \
+  >"$OUT/nativewire_ycsb_allocs_top.txt"
+go tool pprof -top "$OUT/nativewire_ycsb_block.pprof" \
+  >"$OUT/nativewire_ycsb_block_top.txt"
+go tool pprof -top "$OUT/nativewire_ycsb_mutex.pprof" \
+  >"$OUT/nativewire_ycsb_mutex_top.txt"
+
+printf 'profiles: %s\n' "$OUT"
+```
+
+The block profile is the guard for `lockMutation` wait. Record the total delay
+reported for `(*Collection).lockMutation` or the nearest collection mutation
+lock frame. If the symbol is absent, record that explicitly rather than
+assuming there was no contention.
+
+## Collection Boundary
+
+Use the collection benchmark to separate nativewire/client overhead from raw
+collection insert cost:
+
+```sh
+for batch in 1 16 128 1024; do
+  TREEDB_COLLECTION_DOCUMENT_FORMAT=bson \
+  TREEDB_COLLECTION_BENCH_BATCH_SIZE=$batch \
+  go test ./TreeDB/collections \
+    -run '^$' \
+    -bench '^BenchmarkCollectionShapeInsertBatch/indexes_1$' \
+    -benchmem \
+    -benchtime=1s \
+    -count=3
+done
+```
+
+Record `ns/op`, `B/op`, `allocs/op`, and any reported docs/batch or insert
+stats. Batch size 1 is the closest collection-side comparison for YCSB's
+one-document nativewire insert shape; larger batches show the per-call overhead
+ceiling.
+
+## Correctness Gate
+
+Run the focused correctness packages before merging changes that affect this
+hot path:
+
+```sh
+go test ./TreeDB/nativewire ./TreeDB/collections -count=1
+```


### PR DESCRIPTION
## Summary

Closes #2084.

Adds `BenchmarkNativewireYCSBLoad`, a repo-local benchmark for the treedb-native YCSB load shape:

- 16 nativewire clients
- one `InsertBatch` request per document
- default YCSB-style `usertable` rows with 10 x 100-byte fields
- `_ycsb_key` string field plus unique `_ycsb_key_1` index
- `AckVisible` and the same omit-result-IDs response shape used by the go-ycsb treedb-native client
- TCP loopback and in-process transports

Also adds `docs/benchmarks/nativewire_ycsb_profile_guard.md` with the canonical BSON YCSB benchmark, CPU/alloc/block/mutex profile commands, collection batch-size decomposition command, and focused correctness gate for follow-on hot-path PRs.

The benchmark measures the nativewire client/server boundary, including client-side key/doc encoding and response handling. The collection batch-size comparison is the decomposition step for separating nativewire/client overhead from collection insert cost.

## Evidence

Latest commit: `f19dd914c31d822450de1ef25e1c52b995a727fc`

Focused correctness on latest head:

```sh
go test ./TreeDB/nativewire ./TreeDB/collections -count=1
go test ./cmd/treedb-native-server -count=1
```

Focused nativewire BSON smoke on latest head:

```sh
go test ./TreeDB/nativewire -run '^$' -bench '^BenchmarkNativewireYCSBLoad/inproc/bson_binary$' -benchmem -benchtime=100x -count=1
```

```text
BenchmarkNativewireYCSBLoad/inproc/bson_binary-12  100  23895 ns/op  49.13 MB/s  16.00 clients  1174 document_bytes  65899 B/op  196 allocs/op
```

Profile capture smoke on latest head:

```sh
go test ./TreeDB/nativewire -run '^$' -bench '^BenchmarkNativewireYCSBLoad/inproc/bson_binary$' -benchmem -benchtime=200x -count=1 -cpuprofile "$OUT/nativewire_ycsb_cpu.pprof" -memprofile "$OUT/nativewire_ycsb_allocs.pprof" -blockprofile "$OUT/nativewire_ycsb_block.pprof" -mutexprofile "$OUT/nativewire_ycsb_mutex.pprof" -mutexprofilefraction=1
```

Artifacts: `/tmp/treedb_nativewire_ycsb_profiles_LKmu86`

```text
BenchmarkNativewireYCSBLoad/inproc/bson_binary-12  200  15912 ns/op  73.78 MB/s  16.00 clients  1174 document_bytes  36614 B/op  129 allocs/op
```

Block profile top in the short smoke was dominated by runtime/vlog background waits; `sync.(*Mutex).Lock` accounted for ~0.02s, and this run did not surface a meaningful `lockMutation` frame. The guard doc requires recording that explicitly for future work.

Collection batch-size decomposition smoke on latest head:

```sh
for batch in 1 16 128; do
  TREEDB_COLLECTION_DOCUMENT_FORMAT=bson TREEDB_COLLECTION_BENCH_BATCH_SIZE=$batch \
  go test ./TreeDB/collections -run '^$' -bench '^BenchmarkCollectionShapeInsertBatch/indexes_1$' -benchmem -benchtime=100x -count=1
done
```

Primary insert rows:

```text
batch=1    11207 ns/op  6532 B/op  39 allocs/op
batch=16    5976 ns/op  4811 B/op   6 allocs/op
batch=128   4863 ns/op  4101 B/op   4 allocs/op
```

Earlier full-sample background on commit `d282914347602fc9c0265c369f4ecb8b68aed824` showed the same lane ordering, with BSON faster than JSON for this YCSB-shaped path and fresh-envelope template-v1 slower than BSON. Those older numbers are background only; latest-head gate evidence is above.

## AI Review Gate

This PR stayed draft while the benchmark shape, guard documentation, tests, and profile evidence were prepared. AI reviews should be requested only after the latest head is mature to avoid review-credit churn.