### PR TITLE
[codex] reduce nativewire response metadata allocations

### DIFF
--- a/TreeDB/nativewire/client_metadata.go
+++ b/TreeDB/nativewire/client_metadata.go
@@ -226,6 +226,14 @@ func (c *Client) updateCatalogVersionFromMutationResponse(sections []iwire.Secti
 	c.catalogVersionPlusOne.Store(version + 1)
 }
 
+func (c *Client) updateCatalogVersionFromResponseMetaFields(fields responseMetaFields) {
+	if !fields.hasCatalogVersion || fields.catalogVersion == ^uint64(0) {
+		c.catalogVersionPlusOne.Store(0)
+		return
+	}
+	c.catalogVersionPlusOne.Store(fields.catalogVersion + 1)
+}
+
 func (c *Client) clearCatalogVersionAfterOpaqueMutation() {
 	c.catalogVersionPlusOne.Store(0)
 }
@@ -235,19 +243,11 @@ func catalogVersionFromResponseMeta(sections []iwire.Section) (uint64, bool, err
 	if err != nil || !ok {
 		return 0, ok, err
 	}
-	values, err := decodeStringMap(raw)
+	fields, err := decodeResponseMetaFields(raw, "", "")
 	if err != nil {
 		return 0, false, err
 	}
-	rawVersion, ok := values["catalog_version"]
-	if !ok {
-		return 0, false, nil
-	}
-	version, err := strconv.ParseUint(rawVersion, 10, 64)
-	if err != nil {
-		return 0, true, protocolError(iwire.ErrMalformedFrame, "invalid catalog_version %q", rawVersion)
-	}
-	return version, true, nil
+	return fields.catalogVersion, fields.hasCatalogVersion, nil
 }
 
 func metadataGuardOptionsFromContext(ctx context.Context) metadataGuardOptions {

--- a/TreeDB/nativewire/client_mutation.go
+++ b/TreeDB/nativewire/client_mutation.go
@@ -205,18 +205,24 @@ func (c *Client) ReplaceBatch(ctx context.Context, collection string, format col
 		c.clearCatalogVersionOnMismatch(err)
 		return 0, 0, err
 	}
+	return c.replaceBatchCountsFromResponse(sections)
+}
+
+func (c *Client) replaceBatchCountsFromResponse(sections []iwire.Section) (int, int, error) {
 	fields, err := responseMetaFieldsFromSections(sections, "matched_count", "modified_count")
 	if err != nil {
 		c.clearCatalogVersionAfterOpaqueMutation()
 		return 0, 0, err
 	}
-	c.updateCatalogVersionFromResponseMetaFields(fields)
 	if !fields.hasCount1 {
+		c.clearCatalogVersionAfterOpaqueMutation()
 		return 0, 0, protocolError(iwire.ErrMalformedFrame, "response_meta missing matched_count")
 	}
 	if !fields.hasCount2 {
+		c.clearCatalogVersionAfterOpaqueMutation()
 		return 0, 0, protocolError(iwire.ErrMalformedFrame, "response_meta missing modified_count")
 	}
+	c.updateCatalogVersionFromResponseMetaFields(fields)
 	return fields.count1, fields.count2, nil
 }
 
@@ -237,15 +243,20 @@ func (c *Client) DeleteBatch(ctx context.Context, collection string, ids [][]byt
 		c.clearCatalogVersionOnMismatch(err)
 		return 0, err
 	}
+	return c.deleteBatchCountFromResponse(sections)
+}
+
+func (c *Client) deleteBatchCountFromResponse(sections []iwire.Section) (int, error) {
 	fields, err := responseMetaFieldsFromSections(sections, "deleted_count", "")
 	if err != nil {
 		c.clearCatalogVersionAfterOpaqueMutation()
 		return 0, err
 	}
-	c.updateCatalogVersionFromResponseMetaFields(fields)
 	if !fields.hasCount1 {
+		c.clearCatalogVersionAfterOpaqueMutation()
 		return 0, protocolError(iwire.ErrMalformedFrame, "response_meta missing deleted_count")
 	}
+	c.updateCatalogVersionFromResponseMetaFields(fields)
 	return fields.count1, nil
 }
 

--- a/TreeDB/nativewire/client_mutation.go
+++ b/TreeDB/nativewire/client_mutation.go
@@ -205,13 +205,19 @@ func (c *Client) ReplaceBatch(ctx context.Context, collection string, format col
 		c.clearCatalogVersionOnMismatch(err)
 		return 0, 0, err
 	}
-	c.updateCatalogVersionFromMutationResponse(sections)
-	matched, err = responseCount(sections, "matched_count")
+	fields, err := responseMetaFieldsFromSections(sections, "matched_count", "modified_count")
 	if err != nil {
+		c.clearCatalogVersionAfterOpaqueMutation()
 		return 0, 0, err
 	}
-	modified, err = responseCount(sections, "modified_count")
-	return matched, modified, err
+	c.updateCatalogVersionFromResponseMetaFields(fields)
+	if !fields.hasCount1 {
+		return 0, 0, protocolError(iwire.ErrMalformedFrame, "response_meta missing matched_count")
+	}
+	if !fields.hasCount2 {
+		return 0, 0, protocolError(iwire.ErrMalformedFrame, "response_meta missing modified_count")
+	}
+	return fields.count1, fields.count2, nil
 }
 
 func (c *Client) DeleteBatch(ctx context.Context, collection string, ids [][]byte, ack AckPolicy) (int, error) {
@@ -231,8 +237,16 @@ func (c *Client) DeleteBatch(ctx context.Context, collection string, ids [][]byt
 		c.clearCatalogVersionOnMismatch(err)
 		return 0, err
 	}
-	c.updateCatalogVersionFromMutationResponse(sections)
-	return responseCount(sections, "deleted_count")
+	fields, err := responseMetaFieldsFromSections(sections, "deleted_count", "")
+	if err != nil {
+		c.clearCatalogVersionAfterOpaqueMutation()
+		return 0, err
+	}
+	c.updateCatalogVersionFromResponseMetaFields(fields)
+	if !fields.hasCount1 {
+		return 0, protocolError(iwire.ErrMalformedFrame, "response_meta missing deleted_count")
+	}
+	return fields.count1, nil
 }
 
 func (c *Client) FlushCollection(ctx context.Context, collection string) error {

--- a/TreeDB/nativewire/codec.go
+++ b/TreeDB/nativewire/codec.go
@@ -228,6 +228,23 @@ func readString(src []byte, off *int) (string, error) {
 	return out, nil
 }
 
+func readStringBytes(src []byte, off *int) ([]byte, error) {
+	if off == nil || *off > len(src) {
+		return nil, protocolError(iwire.ErrMalformedFrame, "invalid string offset")
+	}
+	n, read, err := readUvarint(src[*off:])
+	if err != nil {
+		return nil, err
+	}
+	*off += read
+	if n > uint64(len(src)-*off) {
+		return nil, protocolError(iwire.ErrMalformedFrame, "string length exceeds remaining payload")
+	}
+	out := src[*off : *off+int(n)]
+	*off += int(n)
+	return out, nil
+}
+
 func appendStringMap(dst []byte, values map[string]string) []byte {
 	keys := make([]string, 0, len(values))
 	for key := range values {

--- a/TreeDB/nativewire/mutation.go
+++ b/TreeDB/nativewire/mutation.go
@@ -336,6 +336,15 @@ type responseMetaCount struct {
 	value int
 }
 
+type responseMetaFields struct {
+	count1            int
+	hasCount1         bool
+	count2            int
+	hasCount2         bool
+	catalogVersion    uint64
+	hasCatalogVersion bool
+}
+
 func ackMeta(policy AckPolicy) iwire.Section {
 	return iwire.Section{ID: iwire.SectionResponseMeta, Bytes: appendAckMetaPayload(nil, policy)}
 }
@@ -421,35 +430,149 @@ func responseMetaMap(sections []iwire.Section) (map[string]string, error) {
 }
 
 func responseCount(sections []iwire.Section, key string) (int, error) {
-	values, err := responseMetaMap(sections)
+	fields, err := responseMetaFieldsFromSections(sections, key, "")
 	if err != nil {
 		return 0, err
 	}
-	value, ok := values[key]
-	if !ok {
+	if !fields.hasCount1 {
 		return 0, protocolError(iwire.ErrMalformedFrame, "response_meta missing %s", key)
 	}
-	n, err := strconv.Atoi(value)
-	if err != nil {
-		return 0, protocolError(iwire.ErrMalformedFrame, "response_meta %s is not an integer", key)
-	}
-	return n, nil
+	return fields.count1, nil
 }
 
 func responseCatalogVersion(sections []iwire.Section) (uint64, bool, error) {
-	values, err := responseMetaMap(sections)
+	fields, err := responseMetaFieldsFromSections(sections, "", "")
 	if err != nil {
 		return 0, false, err
 	}
-	value, ok := values["catalog_version"]
-	if !ok {
-		return 0, false, nil
-	}
-	version, err := strconv.ParseUint(value, 10, 64)
+	return fields.catalogVersion, fields.hasCatalogVersion, nil
+}
+
+func responseMetaFieldsFromSections(sections []iwire.Section, countKey1, countKey2 string) (responseMetaFields, error) {
+	raw, ok, err := singletonSection(sections, iwire.SectionResponseMeta)
 	if err != nil {
-		return 0, true, protocolError(iwire.ErrMalformedFrame, "response_meta catalog_version is not a uint64")
+		return responseMetaFields{}, err
 	}
-	return version, true, nil
+	if !ok {
+		return responseMetaFields{}, protocolError(iwire.ErrMalformedFrame, "missing response_meta")
+	}
+	return decodeResponseMetaFields(raw, countKey1, countKey2)
+}
+
+func decodeResponseMetaFields(src []byte, countKey1, countKey2 string) (responseMetaFields, error) {
+	count, off, err := readUvarint(src)
+	if err != nil {
+		return responseMetaFields{}, err
+	}
+	if count > uint64(maxInt) {
+		return responseMetaFields{}, protocolError(iwire.ErrResourceExhausted, "string map count exceeds int capacity")
+	}
+	if count > maxStringMapEntries {
+		return responseMetaFields{}, protocolError(iwire.ErrResourceExhausted, "string map count %d exceeds limit %d", count, maxStringMapEntries)
+	}
+	var fields responseMetaFields
+	for i := uint64(0); i < count; i++ {
+		key, err := readStringBytes(src, &off)
+		if err != nil {
+			return responseMetaFields{}, err
+		}
+		value, err := readStringBytes(src, &off)
+		if err != nil {
+			return responseMetaFields{}, err
+		}
+		switch {
+		case bytesEqualString(key, "catalog_version"):
+			version, err := parseResponseMetaUint(value, "catalog_version")
+			if err != nil {
+				return responseMetaFields{}, err
+			}
+			fields.catalogVersion = version
+			fields.hasCatalogVersion = true
+		case countKey1 != "" && bytesEqualString(key, countKey1):
+			n, err := parseResponseMetaInt(value, countKey1)
+			if err != nil {
+				return responseMetaFields{}, err
+			}
+			fields.count1 = n
+			fields.hasCount1 = true
+		case countKey2 != "" && bytesEqualString(key, countKey2):
+			n, err := parseResponseMetaInt(value, countKey2)
+			if err != nil {
+				return responseMetaFields{}, err
+			}
+			fields.count2 = n
+			fields.hasCount2 = true
+		}
+	}
+	if off != len(src) {
+		return responseMetaFields{}, protocolError(iwire.ErrMalformedFrame, "string map has %d trailing bytes", len(src)-off)
+	}
+	return fields, nil
+}
+
+func parseResponseMetaUint(src []byte, key string) (uint64, error) {
+	if len(src) == 0 {
+		return 0, protocolError(iwire.ErrMalformedFrame, "response_meta %s is not a uint64", key)
+	}
+	var value uint64
+	for _, c := range src {
+		if c < '0' || c > '9' {
+			return 0, protocolError(iwire.ErrMalformedFrame, "response_meta %s is not a uint64", key)
+		}
+		digit := uint64(c - '0')
+		if value > (^uint64(0)-digit)/10 {
+			return 0, protocolError(iwire.ErrMalformedFrame, "response_meta %s is not a uint64", key)
+		}
+		value = value*10 + digit
+	}
+	return value, nil
+}
+
+func parseResponseMetaInt(src []byte, key string) (int, error) {
+	if len(src) == 0 {
+		return 0, protocolError(iwire.ErrMalformedFrame, "response_meta %s is not an integer", key)
+	}
+	negative := src[0] == '-'
+	if negative {
+		src = src[1:]
+		if len(src) == 0 {
+			return 0, protocolError(iwire.ErrMalformedFrame, "response_meta %s is not an integer", key)
+		}
+	}
+	limit := uint64(maxInt)
+	if negative {
+		limit++
+	}
+	var value uint64
+	for _, c := range src {
+		if c < '0' || c > '9' {
+			return 0, protocolError(iwire.ErrMalformedFrame, "response_meta %s is not an integer", key)
+		}
+		digit := uint64(c - '0')
+		if value > (limit-digit)/10 {
+			return 0, protocolError(iwire.ErrMalformedFrame, "response_meta %s is not an integer", key)
+		}
+		value = value*10 + digit
+	}
+	if negative {
+		if value == limit {
+			return -maxInt - 1, nil
+		}
+		return -int(value), nil
+	}
+	return int(value), nil
+}
+
+func bytesEqualString(b []byte, s string) bool {
+	if len(b) != len(s) {
+		return false
+	}
+	for i := range b {
+		if b[i] != s[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func updateBatchItems(ids, docs [][]byte) []collections.UpdateBatchItem {

--- a/TreeDB/nativewire/mutation_test.go
+++ b/TreeDB/nativewire/mutation_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
+	"encoding/binary"
 	"errors"
 	"strconv"
 	"sync"
@@ -1266,6 +1267,62 @@ func TestResponseCountRejectsMalformedInteger(t *testing.T) {
 	if nativeCodeOf(err) != iwire.ErrMalformedFrame {
 		t.Fatalf("responseCount err=%v code=%d want malformed", err, nativeCodeOf(err))
 	}
+}
+
+func TestResponseMetaFieldsScansCountsAndCatalogVersion(t *testing.T) {
+	payload := appendAckMetaPayloadVersion(nil, AckVisible, 42, true,
+		responseMetaCount{key: "matched_count", value: 3},
+		responseMetaCount{key: "modified_count", value: 2},
+	)
+	fields, err := decodeResponseMetaFields(payload, "matched_count", "modified_count")
+	if err != nil {
+		t.Fatalf("decodeResponseMetaFields: %v", err)
+	}
+	if !fields.hasCatalogVersion || fields.catalogVersion != 42 {
+		t.Fatalf("catalog version=%d has=%v want 42/true", fields.catalogVersion, fields.hasCatalogVersion)
+	}
+	if !fields.hasCount1 || fields.count1 != 3 {
+		t.Fatalf("matched count=%d has=%v want 3/true", fields.count1, fields.hasCount1)
+	}
+	if !fields.hasCount2 || fields.count2 != 2 {
+		t.Fatalf("modified count=%d has=%v want 2/true", fields.count2, fields.hasCount2)
+	}
+}
+
+func TestResponseMetaFieldsPreservesLastDuplicateValue(t *testing.T) {
+	payload := responseMetaPayloadForTest(
+		"catalog_version", "41",
+		"matched_count", "1",
+		"catalog_version", "42",
+		"matched_count", "3",
+	)
+	fields, err := decodeResponseMetaFields(payload, "matched_count", "")
+	if err != nil {
+		t.Fatalf("decodeResponseMetaFields: %v", err)
+	}
+	if !fields.hasCatalogVersion || fields.catalogVersion != 42 {
+		t.Fatalf("catalog version=%d has=%v want 42/true", fields.catalogVersion, fields.hasCatalogVersion)
+	}
+	if !fields.hasCount1 || fields.count1 != 3 {
+		t.Fatalf("matched count=%d has=%v want 3/true", fields.count1, fields.hasCount1)
+	}
+}
+
+func TestResponseMetaFieldsRejectsTrailingBytes(t *testing.T) {
+	payload := append(appendAckMetaPayload(nil, AckVisible), 0)
+	if _, err := decodeResponseMetaFields(payload, "", ""); nativeCodeOf(err) != iwire.ErrMalformedFrame {
+		t.Fatalf("decodeResponseMetaFields err=%v code=%d want malformed", err, nativeCodeOf(err))
+	}
+}
+
+func responseMetaPayloadForTest(pairs ...string) []byte {
+	var dst []byte
+	dst = binary.AppendUvarint(dst, uint64(len(pairs)/2))
+	for i := 0; i+1 < len(pairs); i += 2 {
+		dst = appendString(dst, pairs[i])
+		dst = appendString(dst, pairs[i+1])
+	}
+	return dst
 }
 
 func assertDocumentMissing(t *testing.T, mgr *collections.CollectionManager, collectionName, id string) {

--- a/TreeDB/nativewire/mutation_test.go
+++ b/TreeDB/nativewire/mutation_test.go
@@ -1252,6 +1252,35 @@ func TestMutationCatalogVersionCacheClearsAfterMismatch(t *testing.T) {
 	}
 }
 
+func TestMutationMissingResponseCountsClearCatalogVersionCache(t *testing.T) {
+	client := &Client{}
+	replaceSections := []iwire.Section{{
+		ID: iwire.SectionResponseMeta,
+		Bytes: appendAckMetaPayloadVersion(nil, AckVisible, 42, true,
+			responseMetaCount{key: "matched_count", value: 1},
+		),
+	}}
+	client.catalogVersionPlusOne.Store(99)
+	if _, _, err := client.replaceBatchCountsFromResponse(replaceSections); nativeCodeOf(err) != iwire.ErrMalformedFrame {
+		t.Fatalf("replace count validation err=%v code=%d want malformed", err, nativeCodeOf(err))
+	}
+	if got := client.catalogVersionPlusOne.Load(); got != 0 {
+		t.Fatalf("replace catalogVersionPlusOne=%d want cleared", got)
+	}
+
+	deleteSections := []iwire.Section{{
+		ID:    iwire.SectionResponseMeta,
+		Bytes: appendAckMetaPayloadVersion(nil, AckVisible, 42, true),
+	}}
+	client.catalogVersionPlusOne.Store(99)
+	if _, err := client.deleteBatchCountFromResponse(deleteSections); nativeCodeOf(err) != iwire.ErrMalformedFrame {
+		t.Fatalf("delete count validation err=%v code=%d want malformed", err, nativeCodeOf(err))
+	}
+	if got := client.catalogVersionPlusOne.Load(); got != 0 {
+		t.Fatalf("delete catalogVersionPlusOne=%d want cleared", got)
+	}
+}
+
 func TestResponseCountRequiresKey(t *testing.T) {
 	_, err := responseCount([]iwire.Section{ackMeta(AckVisible)}, "deleted_count")
 	if nativeCodeOf(err) != iwire.ErrMalformedFrame {


### PR DESCRIPTION
## Summary

- Closes #2085.
- Adds a targeted response_meta scanner for nativewire mutation responses so hot insert/update paths no longer allocate a full `map[string]string` just to read catalog/count metadata.
- Updates ReplaceBatch/DeleteBatch to parse required count fields and catalog_version in one response_meta pass.
- Leaves the nativewire response format unchanged and keeps `decodeStringMap` for Stats/general metadata users.

## Measurement Boundary

Timed path is `BenchmarkNativewireYCSBLoad/inproc/bson_binary`: 16 in-process nativewire clients, one BSON `InsertBatch` per document, unique `_ycsb_key` index, request encoding, server mutation, and response handling included. Hardware from benchmark output: `11th Gen Intel(R) Core(TM) i5-11400F @ 2.60GHz`.

## Tests

```sh
go test ./TreeDB/nativewire -count=1
# ok github.com/snissn/gomap/TreeDB/nativewire 0.899s

go test ./TreeDB/collections -count=1
# ok github.com/snissn/gomap/TreeDB/collections 91.658s
```

## Benchmark Evidence

Artifacts: `/tmp/treedb_2085_response_meta_20260531_123416`

Command:

```sh
go test ./TreeDB/nativewire \
  -run '^$' \
  -bench '^BenchmarkNativewireYCSBLoad/inproc/bson_binary$' \
  -benchtime=10s \
  -count=1 \
  -benchmem \
  -memprofile <before_or_after_mem.pprof>
```

| Build | ns/op | ops/sec | MB/s | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: | ---: |
| before `ae224b557` | 13720 | 72,886 | 85.57 | 10072 | 69 |
| after `a63a1549a` | 13464 | 74,272 | 87.20 | 9675 | 64 |

Allocation profile movement:

| Build | `decodeStringMap` alloc profile |
| --- | --- |
| before | `328.59MB` flat, `389.09MB` cumulative in alloc-space top |
| after | absent from alloc-space top; top cutoff `49.26MB` |

## Regression Assessment

No material regression observed in the target benchmark. Runtime, throughput, bytes/op, and allocs/op all improved. Remaining top allocation sites are outside this PR scope: document cloning, BSON marshal, collection insert planning, result-ID clone path, and buffered index structures.

## AI Review Status

Not requested yet because this PR is draft while latest-head CI starts. Request Codex/CodeRabbit only after the mature gate is satisfied: current body/evidence, no known local blockers, and latest-head CI running or green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation of server responses during mutation operations to catch malformed data earlier.
  * Improved catalog version tracking reliability for cache consistency.

* **Performance**
  * Optimized response metadata parsing to reduce intermediate allocations and improve efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->