### PR TITLE
nativewire: omit insert result id clones

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3790,6 +3790,7 @@ func (c *Collection) bufferNoIndexInsertBatch(
 	snap *backenddb.Snapshot,
 	plannerOptions collectionOptions,
 	ids, documents [][]byte,
+	execOpts insertBatchExecutionOptions,
 ) ([][]byte, bool, error) {
 	if domain == nil || catalog == nil || snap == nil || len(catalog.meta.Indexes) > 0 {
 		return nil, false, nil
@@ -3885,7 +3886,7 @@ func (c *Collection) bufferNoIndexInsertBatch(
 		Indexes:   0,
 		Runs:      1,
 	})
-	return resultIDs, true, nil
+	return maybeInsertBatchResultIDs(resultIDs, execOpts), true, nil
 }
 
 func (c *Collection) ensureWriteDomainLocked(domain *collectionWriteDomain) (*collectionCatalog, collectionOptions, bool, error) {
@@ -8687,11 +8688,31 @@ func (c *Collection) InsertBatchValidatedBSON(ids, documents [][]byte) ([][]byte
 	return resultIDs, err
 }
 
-func (c *Collection) insertBatch(ids, documents [][]byte, trustedValidBSON bool, templateEncoder *TemplateV1Encoder) ([][]byte, error) {
-	return c.insertBatchWithCommandWALIntent(ids, documents, trustedValidBSON, templateEncoder, nil)
+// NativewireInsertBatchNoResultIDs executes an insert batch without cloning
+// response-owned result IDs. It exists for the nativewire gateway omit-result
+// fast path; public callers that need returned IDs should keep using
+// InsertBatch or InsertBatchValidatedBSON.
+func (c *Collection) NativewireInsertBatchNoResultIDs(ids, documents [][]byte, trustedValidBSON bool) error {
+	_, err := c.insertBatchWithCommandWALIntent(ids, documents, trustedValidBSON, nil, nil, insertBatchExecutionOptions{returnResultIDs: false})
+	if err == nil {
+		if trustedValidBSON {
+			err = commitAmbiguousError("InsertBatchValidatedBSON vector index maintenance", c.notifyVectorIndexesUpsert(ids))
+		} else {
+			err = commitAmbiguousError("InsertBatch vector index maintenance", c.notifyVectorIndexesUpsert(ids))
+		}
+	}
+	return err
 }
 
-func (c *Collection) insertBatchWithCommandWALIntent(ids, documents [][]byte, trustedValidBSON bool, templateEncoder *TemplateV1Encoder, commandWALIntent *backenddb.CommandWALIntent) ([][]byte, error) {
+func (c *Collection) insertBatch(ids, documents [][]byte, trustedValidBSON bool, templateEncoder *TemplateV1Encoder) ([][]byte, error) {
+	return c.insertBatchWithCommandWALIntent(ids, documents, trustedValidBSON, templateEncoder, nil, insertBatchExecutionOptions{returnResultIDs: true})
+}
+
+type insertBatchExecutionOptions struct {
+	returnResultIDs bool
+}
+
+func (c *Collection) insertBatchWithCommandWALIntent(ids, documents [][]byte, trustedValidBSON bool, templateEncoder *TemplateV1Encoder, commandWALIntent *backenddb.CommandWALIntent, execOpts insertBatchExecutionOptions) ([][]byte, error) {
 	if c == nil {
 		return nil, errCollectionNil
 	}
@@ -8703,7 +8724,7 @@ func (c *Collection) insertBatchWithCommandWALIntent(ids, documents [][]byte, tr
 	}
 
 	return retryInsertBatchMutation(func() ([][]byte, error) {
-		return c.insertBatchOnce(ids, documents, trustedValidBSON, templateEncoder, commandWALIntent)
+		return c.insertBatchOnce(ids, documents, trustedValidBSON, templateEncoder, commandWALIntent, execOpts)
 	})
 }
 
@@ -8732,19 +8753,19 @@ func isRetriableCollectionCatalogReadEOF(err error) bool {
 	return strings.Contains(err.Error(), "collections: load catalog")
 }
 
-func (c *Collection) insertBatchOnce(ids, documents [][]byte, trustedValidBSON bool, templateEncoder *TemplateV1Encoder, commandWALIntent *backenddb.CommandWALIntent) ([][]byte, error) {
+func (c *Collection) insertBatchOnce(ids, documents [][]byte, trustedValidBSON bool, templateEncoder *TemplateV1Encoder, commandWALIntent *backenddb.CommandWALIntent, execOpts insertBatchExecutionOptions) ([][]byte, error) {
 	if shouldAttemptOptimisticInsertBatchPlanning(documents, templateEncoder, commandWALIntent, c.commandWALActive(commandWALIntent)) {
 		if unlockMutation, locked := c.tryLockMutation(); locked {
 			mutationLocked := true
-			return c.insertBatchOnceWithLockState(ids, documents, trustedValidBSON, templateEncoder, commandWALIntent, &unlockMutation, &mutationLocked)
+			return c.insertBatchOnceWithLockState(ids, documents, trustedValidBSON, templateEncoder, commandWALIntent, execOpts, &unlockMutation, &mutationLocked)
 		}
-		if resultIDs, err, attempted := c.insertBatchOnceWithOptimisticPlanning(ids, documents, trustedValidBSON); attempted {
+		if resultIDs, err, attempted := c.insertBatchOnceWithOptimisticPlanning(ids, documents, trustedValidBSON, execOpts); attempted {
 			return resultIDs, err
 		}
 	}
 	unlockMutation := c.lockMutation()
 	mutationLocked := true
-	return c.insertBatchOnceWithLockState(ids, documents, trustedValidBSON, templateEncoder, commandWALIntent, &unlockMutation, &mutationLocked)
+	return c.insertBatchOnceWithLockState(ids, documents, trustedValidBSON, templateEncoder, commandWALIntent, execOpts, &unlockMutation, &mutationLocked)
 }
 
 func shouldAttemptOptimisticInsertBatchPlanning(documents [][]byte, templateEncoder *TemplateV1Encoder, commandWALIntent *backenddb.CommandWALIntent, commandWALActive bool) bool {
@@ -8755,7 +8776,7 @@ func shouldAttemptOptimisticInsertBatchPlanning(documents [][]byte, templateEnco
 		!commandWALActive
 }
 
-func (c *Collection) insertBatchOnceWithOptimisticPlanning(ids, documents [][]byte, trustedValidBSON bool) ([][]byte, error, bool) {
+func (c *Collection) insertBatchOnceWithOptimisticPlanning(ids, documents [][]byte, trustedValidBSON bool, execOpts insertBatchExecutionOptions) ([][]byte, error, bool) {
 	if c == nil || c.db == nil {
 		return nil, nil, false
 	}
@@ -8841,9 +8862,9 @@ func (c *Collection) insertBatchOnceWithOptimisticPlanning(ids, documents [][]by
 	if !insertBatchPlanHasRootWork(plan) {
 		closePlanningSnapshot()
 		c.setLastInsertStats(plan.stats.CollectionInsertStats)
-		return plan.resultIDs, nil, true
+		return maybeInsertBatchResultIDs(plan.resultIDs, execOpts), nil, true
 	}
-	resultIDs, err := cloneBatchDocumentIDs(plan.resultIDs)
+	resultIDs, err := cloneInsertBatchResultIDs(plan.resultIDs, execOpts)
 	if err != nil {
 		closePlanningSnapshot()
 		resetCollectionRunTables(plan.runs)
@@ -8896,6 +8917,7 @@ func (c *Collection) insertBatchOnceWithLockState(
 	trustedValidBSON bool,
 	templateEncoder *TemplateV1Encoder,
 	commandWALIntent *backenddb.CommandWALIntent,
+	execOpts insertBatchExecutionOptions,
 	unlockMutation *collectionMutationUnlock,
 	mutationLocked *bool,
 ) ([][]byte, error) {
@@ -9079,7 +9101,7 @@ func (c *Collection) insertBatchOnceWithLockState(
 		len(meta.Indexes) == 0 &&
 		c.canBufferNoIndexInsertBatchAck() &&
 		canBufferNoIndexInsertBatchFormat(plannerOptions.documentFormat, trustedValidBSON) {
-		if resultIDs, buffered, err := c.bufferNoIndexInsertBatch(c.writeDomain, catalog, snap, plannerOptions, ids, documents); buffered {
+		if resultIDs, buffered, err := c.bufferNoIndexInsertBatch(c.writeDomain, catalog, snap, plannerOptions, ids, documents, execOpts); buffered {
 			closePlanningSnapshot()
 			return resultIDs, err
 		} else if skipInitialNoIndexFlush {
@@ -9093,7 +9115,7 @@ func (c *Collection) insertBatchOnceWithLockState(
 	baseCommitSeq := snapshotCommitSeq(snap)
 	if len(meta.Indexes) == 0 {
 		if plannerOptions.documentFormat == DocumentFormatJSON {
-			return c.insertBatchNoIndex(catalog, snap, baseCommitSeq, baseSystemRoot, plannerOptions, ids, documents, commandWALIntent)
+			return c.insertBatchNoIndex(catalog, snap, baseCommitSeq, baseSystemRoot, plannerOptions, ids, documents, commandWALIntent, execOpts)
 		}
 	}
 
@@ -9151,13 +9173,13 @@ func (c *Collection) insertBatchOnceWithLockState(
 		closePlanningSnapshot()
 		templateEncoder.learnTemplateV1Templates(c, plan.templateLearned)
 		c.setLastInsertStats(plan.stats.CollectionInsertStats)
-		return plan.resultIDs, nil
+		return maybeInsertBatchResultIDs(plan.resultIDs, execOpts), nil
 	}
 
 	rootNames, baseRootIDs := insertBatchPlanRootNamesAndBaseIDs(plan, catalog)
 
 	if bufferIndexedInserts {
-		resultIDs, err := cloneBatchDocumentIDs(plan.resultIDs)
+		resultIDs, err := cloneInsertBatchResultIDs(plan.resultIDs, execOpts)
 		if err != nil {
 			closePlanningSnapshot()
 			resetCollectionRunTables(plan.runs)
@@ -9303,7 +9325,7 @@ func (c *Collection) insertBatchOnceWithLockState(
 	c.noteWriteDomainCatalog(newSystemRoot, nextCatalog)
 	templateEncoder.learnTemplateV1Templates(c, plan.templateLearned)
 	c.setLastInsertStats(plan.stats.CollectionInsertStats)
-	return plan.resultIDs, nil
+	return maybeInsertBatchResultIDs(plan.resultIDs, execOpts), nil
 }
 
 func (c *Collection) reloadInsertBatchPlanningSnapshot(
@@ -9492,6 +9514,20 @@ func insertBatchPlanHasRootWork(plan *insertBatchPlan) bool {
 	return plan.directBufferedInsert != nil && len(plan.directBufferedInsert.rootNames) > 0
 }
 
+func maybeInsertBatchResultIDs(resultIDs [][]byte, execOpts insertBatchExecutionOptions) [][]byte {
+	if !execOpts.returnResultIDs {
+		return nil
+	}
+	return resultIDs
+}
+
+func cloneInsertBatchResultIDs(resultIDs [][]byte, execOpts insertBatchExecutionOptions) ([][]byte, error) {
+	if !execOpts.returnResultIDs {
+		return nil, nil
+	}
+	return cloneBatchDocumentIDs(resultIDs)
+}
+
 type insertBatchValidationContext struct {
 	snap                      *backenddb.Snapshot
 	catalog                   *collectionCatalog
@@ -9677,6 +9713,7 @@ func (c *Collection) insertBatchNoIndex(
 	plannerOptions collectionOptions,
 	ids, documents [][]byte,
 	commandWALIntent *backenddb.CommandWALIntent,
+	execOpts insertBatchExecutionOptions,
 ) ([][]byte, error) {
 	if len(ids) != len(documents) {
 		_ = snap.Close()
@@ -9829,7 +9866,7 @@ func (c *Collection) insertBatchNoIndex(
 		c.rememberCatalogAtSystemRoot(newSystemRoot, nextCatalog)
 		c.noteWriteDomainCatalog(newSystemRoot, nextCatalog)
 		c.setLastInsertStats(stats)
-		return resultIDs, nil
+		return maybeInsertBatchResultIDs(resultIDs, execOpts), nil
 	}
 
 	baseRootIDs := map[string]uint64{rootName: baseRoot}
@@ -9857,7 +9894,7 @@ func (c *Collection) insertBatchNoIndex(
 	c.rememberCatalogAtSystemRoot(newSystemRoot, nextCatalog)
 	c.noteWriteDomainCatalog(newSystemRoot, nextCatalog)
 	c.setLastInsertStats(stats)
-	return resultIDs, nil
+	return maybeInsertBatchResultIDs(resultIDs, execOpts), nil
 }
 
 // Delete removes one document. See DeleteDocument for the matched/deleted

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -2999,6 +2999,58 @@ func TestCollectionInsertBatchBridge_IndexedReturnedIDsAreOwned(t *testing.T) {
 	}
 }
 
+func TestCollectionInsertBatchBridge_ValidatedBSONReturnedIDsAreOwned(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			DocumentFormat: DocumentFormatBSON,
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+
+	inputID := []byte("u1")
+	inputDocument, err := bson.Marshal(bson.D{{Key: "name", Value: "ada"}})
+	if err != nil {
+		t.Fatalf("marshal bson: %v", err)
+	}
+	ids, err := col.InsertBatchValidatedBSON(
+		[][]byte{inputID},
+		[][]byte{inputDocument},
+	)
+	if err != nil {
+		t.Fatalf("insert batch validated bson: %v", err)
+	}
+	inputID[0] = 'x'
+	inputDocument[len(inputDocument)-2] = 'x'
+	if len(ids) != 1 || !bytes.Equal(ids[0], []byte("u1")) {
+		t.Fatalf("returned ids=%q want owned u1", ids)
+	}
+
+	ids[0][0] = 'z'
+	got, err := col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get original id after mutating returned id: %v", err)
+	}
+	if len(got) == 0 {
+		t.Fatal("get original id returned empty document")
+	}
+	if got, err := col.Get([]byte("z1")); err != nil || got != nil {
+		t.Fatalf("mutated returned id lookup got=%q err=%v want missing", got, err)
+	}
+}
+
 func TestCollectionSingleInsertBufferedNoIndexReadsBeforeFlush(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -3051,6 +3051,52 @@ func TestCollectionInsertBatchBridge_ValidatedBSONReturnedIDsAreOwned(t *testing
 	}
 }
 
+func TestCollectionNativewireInsertBatchNoResultIDsUpdatesVectorIndex(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "docs"}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	index, err := newVectorIndex(col, VectorIndexOptions{
+		Name:       "embedding",
+		Field:      "embedding",
+		Metric:     VectorMetricCosine,
+		Dimensions: 2,
+	})
+	if err != nil {
+		t.Fatalf("new vector index: %v", err)
+	}
+	col.RegisterVectorIndex(index)
+
+	inputID := []byte("a")
+	if err := col.NativewireInsertBatchNoResultIDs(
+		[][]byte{inputID},
+		[][]byte{[]byte(`{"embedding":[1,0]}`)},
+		false,
+	); err != nil {
+		t.Fatalf("nativewire insert no result ids: %v", err)
+	}
+	inputID[0] = 'z'
+
+	results, _, err := index.Search([]float32{1, 0}, VectorIndexSearchOptions{TopK: 1, DisableExactFallback: true})
+	if err != nil {
+		t.Fatalf("search vector index: %v", err)
+	}
+	requireVectorResultIDs(t, results, "a")
+	if got, err := col.Get([]byte("z")); err != nil || got != nil {
+		t.Fatalf("mutated request id lookup got=%q err=%v want missing", got, err)
+	}
+}
+
 func TestCollectionSingleInsertBufferedNoIndexReadsBeforeFlush(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/command_wal.go
+++ b/TreeDB/collections/command_wal.go
@@ -279,7 +279,7 @@ func replayCollectionInsertBatchByIDCommandWAL(db *backenddb.DB, env commitlog.C
 		ids[i] = payload.Documents[i].ID
 		docs[i] = payload.Documents[i].Document
 	}
-	_, err = collection.insertBatchWithCommandWALIntent(ids, docs, false, templateV1ReplayStoredDocumentEncoder(collection), intent)
+	_, err = collection.insertBatchWithCommandWALIntent(ids, docs, false, templateV1ReplayStoredDocumentEncoder(collection), intent, insertBatchExecutionOptions{returnResultIDs: true})
 	return err
 }
 

--- a/TreeDB/collections/insert_batch_planning_unlock_test.go
+++ b/TreeDB/collections/insert_batch_planning_unlock_test.go
@@ -111,7 +111,7 @@ func insertIndexedPlanningTestDocumentWithMutationWait(t *testing.T, col *Collec
 	unlockMutation := col.lockMutation()
 	unlockMutation.wait = wait
 	mutationLocked := true
-	return col.insertBatchOnceWithLockState(ids, docs, trustedValidBSON, nil, nil, &unlockMutation, &mutationLocked)
+	return col.insertBatchOnceWithLockState(ids, docs, trustedValidBSON, nil, nil, insertBatchExecutionOptions{returnResultIDs: true}, &unlockMutation, &mutationLocked)
 }
 
 func TestCollectionIndexedInsertBatchSingleDocumentPlanningUnlockByFormat(t *testing.T) {

--- a/TreeDB/nativewire/mutation_test.go
+++ b/TreeDB/nativewire/mutation_test.go
@@ -153,6 +153,86 @@ func TestMutationCommandsRoundTrip(t *testing.T) {
 	}
 }
 
+func TestMutationInsertBatchOmitResultIDsJSONAndBSON(t *testing.T) {
+	client, mgr, _ := serveCollectionPipe(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := client.Hello(ctx); err != nil {
+		t.Fatalf("Hello: %v", err)
+	}
+
+	jsonDoc := []byte(`{"email":"ada@example.com","name":"Ada"}`)
+	bsonDoc, err := bson.Marshal(bson.D{{Key: "email", Value: "grace@example.com"}, {Key: "name", Value: "Grace"}})
+	if err != nil {
+		t.Fatalf("marshal bson: %v", err)
+	}
+
+	tests := []struct {
+		name       string
+		collection string
+		format     collections.DocumentFormat
+		doc        []byte
+	}{
+		{name: "json", collection: "users_json", format: collections.DocumentFormatJSON, doc: jsonDoc},
+		{name: "bson", collection: "users_bson", format: collections.DocumentFormatBSON, doc: bsonDoc},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := client.CreateCollection(ctx, collections.CollectionMeta{
+				Name: tc.collection,
+				Options: collections.CollectionOptions{
+					DocumentFormat: tc.format,
+				},
+			}); err != nil {
+				t.Fatalf("CreateCollection: %v", err)
+			}
+			guard, err := client.replicatedMutationGuard(ctx, "insert_batch_no_ids_"+tc.name)
+			if err != nil {
+				t.Fatalf("mutation guard: %v", err)
+			}
+			body, err := appendInsertBatchRequestBodyRefFlags(nil, tc.collection, 0, false, tc.format,
+				[][]byte{[]byte("u1")},
+				[][]byte{tc.doc},
+				AckVisible,
+				iwire.CommandFlagOmitResultIDs,
+				guard,
+			)
+			if err != nil {
+				t.Fatalf("append insert: %v", err)
+			}
+			_, response, err := client.roundTrip(ctx, iwire.FrameRequest, body, iwire.FrameResponse)
+			if err != nil {
+				t.Fatalf("roundTrip omit-result insert: %v", err)
+			}
+			sections, err := iwire.DecodeSections(response, client.limits)
+			if err != nil {
+				t.Fatalf("decode omit-result response: %v", err)
+			}
+			if _, ok, err := singletonSection(sections, iwire.SectionDocumentIDs); err != nil {
+				t.Fatalf("document_ids section: %v", err)
+			} else if ok {
+				t.Fatalf("omit-result response unexpectedly included document_ids")
+			}
+			if inserted, err := responseCount(sections, "inserted_count"); err != nil || inserted != 1 {
+				t.Fatalf("inserted_count=%d err=%v want 1", inserted, err)
+			}
+
+			col, err := mgr.OpenCollection(tc.collection)
+			if err != nil {
+				t.Fatalf("open collection: %v", err)
+			}
+			got, err := col.Get([]byte("u1"))
+			if err != nil {
+				t.Fatalf("get inserted document: %v", err)
+			}
+			if len(got) == 0 {
+				t.Fatal("get inserted document returned empty payload")
+			}
+		})
+	}
+}
+
 func TestMutationSingleReplaceBatchSemantics(t *testing.T) {
 	client, mgr, _ := serveCollectionPipe(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)

--- a/TreeDB/nativewire/server_mutation.go
+++ b/TreeDB/nativewire/server_mutation.go
@@ -21,22 +21,22 @@ type insertBatchFastRequest struct {
 }
 
 func (s *Server) handleInsertBatch(state *connState, sections []iwire.Section) ([]iwire.Section, error) {
-	resultIDs, actualAck, catalogVersion, hasCatalogVersion, err := s.insertBatch(state, sections)
+	resultIDs, insertedCount, actualAck, catalogVersion, hasCatalogVersion, err := s.insertBatch(state, sections, true)
 	if err != nil {
 		return nil, err
 	}
 	return []iwire.Section{
 		{ID: iwire.SectionDocumentIDs, Bytes: iwire.AppendByteVector(nil, resultIDs...)},
-		ackMetaCountsVersion(actualAck, catalogVersion, hasCatalogVersion, responseMetaCount{key: "inserted_count", value: len(resultIDs)}),
+		ackMetaCountsVersion(actualAck, catalogVersion, hasCatalogVersion, responseMetaCount{key: "inserted_count", value: insertedCount}),
 	}, nil
 }
 
 func (s *Server) handleInsertBatchBody(state *connState, sections []iwire.Section, dst []byte, includeResultIDs, includeMeta bool) ([]byte, error) {
-	resultIDs, actualAck, catalogVersion, hasCatalogVersion, err := s.insertBatch(state, sections)
+	resultIDs, insertedCount, actualAck, catalogVersion, hasCatalogVersion, err := s.insertBatch(state, sections, includeResultIDs)
 	if err != nil {
 		return nil, err
 	}
-	return appendInsertBatchResponseBody(dst, resultIDs, actualAck, catalogVersion, hasCatalogVersion, includeResultIDs, includeMeta)
+	return appendInsertBatchResponseBody(dst, resultIDs, insertedCount, actualAck, catalogVersion, hasCatalogVersion, includeResultIDs, includeMeta)
 }
 
 func (s *Server) handleInsertBatchFastBody(req insertBatchFastRequest, dst []byte) ([]byte, error) {
@@ -45,19 +45,19 @@ func (s *Server) handleInsertBatchFastBody(req insertBatchFastRequest, dst []byt
 	if err := s.checkCatalogGuard(req.sections); err != nil {
 		return nil, err
 	}
-	resultIDs, actualAck, catalogVersion, hasCatalogVersion, err := s.insertBatchDecoded(req.collection, req.format, req.ids, req.docs, req.ack)
+	resultIDs, insertedCount, actualAck, catalogVersion, hasCatalogVersion, err := s.insertBatchDecoded(req.collection, req.format, req.ids, req.docs, req.ack, req.includeResultIDs)
 	if err != nil {
 		return nil, err
 	}
-	return appendInsertBatchResponseBody(dst, resultIDs, actualAck, catalogVersion, hasCatalogVersion, req.includeResultIDs, req.includeMeta)
+	return appendInsertBatchResponseBody(dst, resultIDs, insertedCount, actualAck, catalogVersion, hasCatalogVersion, req.includeResultIDs, req.includeMeta)
 }
 
-func appendInsertBatchResponseBody(dst []byte, resultIDs [][]byte, actualAck iwire.AckPolicy, catalogVersion uint64, hasCatalogVersion, includeResultIDs, includeMeta bool) ([]byte, error) {
+func appendInsertBatchResponseBody(dst []byte, resultIDs [][]byte, insertedCount int, actualAck iwire.AckPolicy, catalogVersion uint64, hasCatalogVersion, includeResultIDs, includeMeta bool) ([]byte, error) {
 	if !includeResultIDs {
 		if !includeMeta {
 			return dst[:0], nil
 		}
-		return appendAckMetaSectionVersion(dst, actualAck, catalogVersion, hasCatalogVersion, responseMetaCount{key: "inserted_count", value: len(resultIDs)})
+		return appendAckMetaSectionVersion(dst, actualAck, catalogVersion, hasCatalogVersion, responseMetaCount{key: "inserted_count", value: insertedCount})
 	}
 	idsLen := iwire.ByteVectorEncodedLen(resultIDs)
 	body, err := iwire.AppendSectionHeader(dst, iwire.SectionDocumentIDs, 0, idsLen)
@@ -68,25 +68,25 @@ func appendInsertBatchResponseBody(dst []byte, resultIDs [][]byte, actualAck iwi
 	if !includeMeta {
 		return body, nil
 	}
-	return appendAckMetaSectionVersion(body, actualAck, catalogVersion, hasCatalogVersion, responseMetaCount{key: "inserted_count", value: len(resultIDs)})
+	return appendAckMetaSectionVersion(body, actualAck, catalogVersion, hasCatalogVersion, responseMetaCount{key: "inserted_count", value: insertedCount})
 }
 
-func (s *Server) insertBatch(state *connState, sections []iwire.Section) ([][]byte, iwire.AckPolicy, uint64, bool, error) {
+func (s *Server) insertBatch(state *connState, sections []iwire.Section, includeResultIDs bool) ([][]byte, int, iwire.AckPolicy, uint64, bool, error) {
 	if err := managerRequired(s.collections); err != nil {
-		return nil, 0, 0, false, err
+		return nil, 0, 0, 0, false, err
 	}
 	s.metadataMu.RLock()
 	defer s.metadataMu.RUnlock()
 	if err := s.checkCatalogGuard(sections); err != nil {
-		return nil, 0, 0, false, err
+		return nil, 0, 0, 0, false, err
 	}
 	_, collection, err := s.openCollectionRef(state, sections)
 	if err != nil {
-		return nil, 0, 0, false, err
+		return nil, 0, 0, 0, false, err
 	}
 	format, err := decodeDocumentFormatSection(sections)
 	if err != nil {
-		return nil, 0, 0, false, err
+		return nil, 0, 0, 0, false, err
 	}
 	var ids, docs [][]byte
 	if state != nil {
@@ -97,42 +97,50 @@ func (s *Server) insertBatch(state *connState, sections []iwire.Section) ([][]by
 		ids, docs, err = decodeIDsAndDocuments(sections, s.limits)
 	}
 	if err != nil {
-		return nil, 0, 0, false, err
+		return nil, 0, 0, 0, false, err
 	}
 	docs, err = applyTemplateRecords(format, sections, docs, s.limits)
 	if err != nil {
-		return nil, 0, 0, false, err
+		return nil, 0, 0, 0, false, err
 	}
 	ack, err := ackPolicyFromSections(sections, s.defaultAckPolicy)
 	if err != nil {
-		return nil, 0, 0, false, err
+		return nil, 0, 0, 0, false, err
 	}
 	if err := s.admitMutationAck(ack); err != nil {
-		return nil, 0, 0, false, err
+		return nil, 0, 0, 0, false, err
 	}
-	return s.insertBatchDecoded(collection, format, ids, docs, ack)
+	return s.insertBatchDecoded(collection, format, ids, docs, ack, includeResultIDs)
 }
 
-func (s *Server) insertBatchDecoded(collection *collections.Collection, format collections.DocumentFormat, ids, docs [][]byte, ack AckPolicy) ([][]byte, iwire.AckPolicy, uint64, bool, error) {
+func (s *Server) insertBatchDecoded(collection *collections.Collection, format collections.DocumentFormat, ids, docs [][]byte, ack AckPolicy, includeResultIDs bool) ([][]byte, int, iwire.AckPolicy, uint64, bool, error) {
 	var err error
 	var resultIDs [][]byte
 	if format == collections.DocumentFormatBSON {
 		if err := validateBSONDocuments(docs); err != nil {
-			return nil, 0, 0, false, err
+			return nil, 0, 0, 0, false, err
 		}
-		resultIDs, err = collection.InsertBatchValidatedBSON(ids, docs)
+		if includeResultIDs {
+			resultIDs, err = collection.InsertBatchValidatedBSON(ids, docs)
+		} else {
+			err = collection.NativewireInsertBatchNoResultIDs(ids, docs, true)
+		}
 	} else {
-		resultIDs, err = collection.InsertBatch(ids, docs)
+		if includeResultIDs {
+			resultIDs, err = collection.InsertBatch(ids, docs)
+		} else {
+			err = collection.NativewireInsertBatchNoResultIDs(ids, docs, false)
+		}
 	}
 	if err != nil {
-		return nil, 0, 0, false, metadataWrap(err)
+		return nil, 0, 0, 0, false, metadataWrap(err)
 	}
 	actualAck, err := s.satisfyAck(collection, ack)
 	if err != nil {
-		return nil, 0, 0, false, err
+		return nil, 0, 0, 0, false, err
 	}
 	catalogVersion, hasCatalogVersion := s.mutationCatalogVersion()
-	return resultIDs, actualAck, catalogVersion, hasCatalogVersion, nil
+	return resultIDs, len(ids), actualAck, catalogVersion, hasCatalogVersion, nil
 }
 
 func (s *Server) mutationCatalogVersion() (uint64, bool) {


### PR DESCRIPTION
## Summary

Closes #2086.

This removes the response-owned result ID allocation path for nativewire `insert_batch` requests that set `CommandFlagOmitResultIDs`, while preserving public collection API behavior for callers that expect returned IDs.

## Correctness / Ownership

- Public `InsertBatch` and `InsertBatchValidatedBSON` still return owned result IDs.
- Nativewire omit-result inserts use a narrow collection bridge that suppresses only the response-owned result ID clone.
- Insert validation, duplicate detection, primary/index staging, unique checks, command WAL replay, and vector-index maintenance still run through the existing insert path.
- The server now tracks `inserted_count` independently from returned IDs so omit-result responses can omit `document_ids` and still report correct mutation metadata.

## Tests

```sh
go test ./TreeDB/collections -run '^TestCollectionNativewireInsertBatchNoResultIDsUpdatesVectorIndex$' -count=1
go test ./TreeDB/nativewire ./TreeDB/collections -count=1
```

Result:

```text
ok  github.com/snissn/gomap/TreeDB/collections 0.014s
ok  github.com/snissn/gomap/TreeDB/nativewire   0.899s
ok  github.com/snissn/gomap/TreeDB/collections 96.721s
```

Focused coverage added:

- nativewire JSON/BSON omit-result insert response omits `document_ids`, reports `inserted_count=1`, and persists the document.
- BSON public collection bridge still returns owned IDs.
- omit-result collection bridge still updates registered vector indexes, and mutating the original request ID after insertion does not change lookup identity.

## Benchmark

Compared against current `origin/main` after #2090 (`600ee4f0f`) on the same host.

Command:

```sh
go test ./TreeDB/nativewire \
  -run '^$' \
  -bench '^BenchmarkNativewireYCSBLoad/inproc/bson_binary$' \
  -benchtime=10s \
  -count=3 \
  -benchmem
```

Artifacts: `/tmp/treedb_2086_bench_2jnYLK`

Initial same-window comparison:

| branch | samples | ns/op | MB/s | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: | ---: |
| `origin/main` | 3 | 13603, 13410, 13513 | 86.30, 87.55, 86.88 | 9580, 9573, 9572 | 65, 65, 64 |
| `codex/2086-omit-result-ids` | 3 | 13301, 13208, 13183 | 88.26, 88.89, 89.05 | 9630, 9305, 9633 | 62, 62, 63 |

After the test-only follow-up commit, I reran both sides. Runtime showed normal local noise, including one branch outlier, but the allocation reduction remained stable:

```text
sec/op:    13.49us -> 13.93us, p=0.100 n=3
B/op:      9.453Ki -> 9.297Ki, p=0.400 n=3
allocs/op: 64.00   -> 62.00,   p=0.100 n=3
```

The target allocation count improves by about 2-3 allocs/op with no accepted material runtime regression signal.

## Review Notes

- Internal review found one useful coverage gap around vector-index side effects; fixed in `8991b14` with `TestCollectionNativewireInsertBatchNoResultIDsUpdatesVectorIndex`.
- CodeRabbit auto-ran on PR creation but also posted a rate-limit/credit warning; do not manually re-trigger CodeRabbit unless needed after this mature head.
