### PR TITLE
[codex] specialize single-document direct-buffered insert planning

### DIFF
--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -3137,6 +3137,28 @@ func TestCollectionInsertBatchSingleDirectBufferedBSONRejectsPendingUniqueConfli
 	}
 }
 
+func TestCollectionInsertBatchSingleDirectBufferedBSONRejectsOversizedSecondaryKey(t *testing.T) {
+	_, col := newSingleDirectBufferedBSONUsersCollection(t)
+
+	_, err := col.InsertBatchValidatedBSON(
+		[][]byte{[]byte("u1")},
+		[][]byte{mustBSONCollectionDocument(t, bson.D{
+			{Key: "email", Value: "ada@example.com"},
+			{Key: "city", Value: strings.Repeat("x", 70000)},
+		})},
+	)
+	if err == nil || !strings.Contains(err.Error(), "index key too large") {
+		t.Fatalf("oversized secondary key err=%v want index key too large", err)
+	}
+	got, err := col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get u1: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("u1=%q want no staged document after oversized secondary key", got)
+	}
+}
+
 func TestCollectionInsertBatchSingleDirectBufferedTemplateV1StagesExpectedRoots(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -3053,6 +3053,8 @@ func TestCollectionInsertBatchBridge_ValidatedBSONReturnedIDsAreOwned(t *testing
 
 func TestCollectionInsertBatchSingleDirectBufferedBSONStats(t *testing.T) {
 	_, col := newSingleDirectBufferedBSONUsersCollection(t)
+	indexDefs := singleDirectBufferedUserIndexes()
+	wantIndexes := len(indexDefs)
 
 	if _, err := col.InsertBatchValidatedBSON(
 		[][]byte{[]byte("u1")},
@@ -3065,20 +3067,20 @@ func TestCollectionInsertBatchSingleDirectBufferedBSONStats(t *testing.T) {
 	}
 
 	stats := col.LastInsertStats()
-	if stats.Documents != 1 || stats.Indexes != 2 {
-		t.Fatalf("stats documents/indexes=%d/%d want 1/2", stats.Documents, stats.Indexes)
+	if stats.Documents != 1 || stats.Indexes != wantIndexes {
+		t.Fatalf("stats documents/indexes=%d/%d want 1/%d", stats.Documents, stats.Indexes, wantIndexes)
 	}
 	if stats.BufferedIndexedBatches != 1 || stats.BufferedIndexedBypassBatches != 0 {
 		t.Fatalf("buffered stats batches=%d bypass=%d want 1/0", stats.BufferedIndexedBatches, stats.BufferedIndexedBypassBatches)
 	}
-	if stats.Runs != 3 {
-		t.Fatalf("runs=%d want primary,email,city roots", stats.Runs)
+	if wantRuns := 1 + wantIndexes; stats.Runs != wantRuns {
+		t.Fatalf("runs=%d want %d primary plus secondary roots", stats.Runs, wantRuns)
 	}
-	if stats.SecondaryEntries != 2 || stats.SecondarySortedRuns != 2 || stats.SecondaryUnsortedRuns != 0 {
-		t.Fatalf("secondary stats entries=%d sorted=%d unsorted=%d want 2/2/0", stats.SecondaryEntries, stats.SecondarySortedRuns, stats.SecondaryUnsortedRuns)
+	if stats.SecondaryEntries != wantIndexes || stats.SecondarySortedRuns != wantIndexes || stats.SecondaryUnsortedRuns != 0 {
+		t.Fatalf("secondary stats entries=%d sorted=%d unsorted=%d want %d/%d/0", stats.SecondaryEntries, stats.SecondarySortedRuns, stats.SecondaryUnsortedRuns, wantIndexes, wantIndexes)
 	}
-	if len(stats.SecondaryRuns) != 2 {
-		t.Fatalf("secondary run stats=%d want 2", len(stats.SecondaryRuns))
+	if len(stats.SecondaryRuns) != wantIndexes {
+		t.Fatalf("secondary run stats=%d want %d", len(stats.SecondaryRuns), wantIndexes)
 	}
 	for _, run := range stats.SecondaryRuns {
 		if run.Entries != 1 || !run.AlreadySorted {
@@ -3169,13 +3171,11 @@ func TestCollectionInsertBatchSingleDirectBufferedTemplateV1StagesExpectedRoots(
 	mgr := NewCollectionManager(d)
 	opts := bufferedIndexedUpdateNoAsyncHighThresholdOptionsForTests()
 	opts.DocumentFormat = DocumentFormatTemplateV1
+	indexDefs := singleDirectBufferedUserIndexes()
 	if _, err := mgr.CreateCollection(&CollectionMeta{
 		Name:    "users",
 		Options: opts,
-		Indexes: []IndexDefinition{
-			{Name: "email", Field: "email", ValueType: IndexValueString, Unique: true},
-			{Name: "city", Field: "city", ValueType: IndexValueString},
-		},
+		Indexes: indexDefs,
 	}); err != nil {
 		t.Fatalf("create collection: %v", err)
 	}
@@ -3191,35 +3191,35 @@ func TestCollectionInsertBatchSingleDirectBufferedTemplateV1StagesExpectedRoots(
 		t.Fatalf("insert single template-v1 document: %v", err)
 	}
 	stats := col.LastInsertStats()
-	if stats.Documents != 1 || stats.Indexes != 2 || stats.Runs != 4 {
-		t.Fatalf("stats documents/indexes/runs=%d/%d/%d want 1/2/4", stats.Documents, stats.Indexes, stats.Runs)
+	wantIndexes := len(indexDefs)
+	wantRuns := 2 + wantIndexes
+	if stats.Documents != 1 || stats.Indexes != wantIndexes || stats.Runs != wantRuns {
+		t.Fatalf("stats documents/indexes/runs=%d/%d/%d want 1/%d/%d", stats.Documents, stats.Indexes, stats.Runs, wantIndexes, wantRuns)
 	}
-	if stats.SecondaryEntries != 2 || stats.SecondarySortedRuns != 2 || stats.SecondaryUnsortedRuns != 0 {
-		t.Fatalf("secondary stats entries=%d sorted=%d unsorted=%d want 2/2/0", stats.SecondaryEntries, stats.SecondarySortedRuns, stats.SecondaryUnsortedRuns)
+	if stats.SecondaryEntries != wantIndexes || stats.SecondarySortedRuns != wantIndexes || stats.SecondaryUnsortedRuns != 0 {
+		t.Fatalf("secondary stats entries=%d sorted=%d unsorted=%d want %d/%d/0", stats.SecondaryEntries, stats.SecondarySortedRuns, stats.SecondaryUnsortedRuns, wantIndexes, wantIndexes)
 	}
 
 	expectedRoots := []string{
 		collectionTemplateRootName("users"),
 		collectionPrimaryRootName("users"),
-		collectionSecondaryRootName("users", "email"),
-		collectionSecondaryRootName("users", "city"),
+	}
+	for _, indexDef := range indexDefs {
+		expectedRoots = append(expectedRoots, collectionSecondaryRootName("users", indexDef.Name))
 	}
 	col.writeDomain.mu.RLock()
+	defer col.writeDomain.mu.RUnlock()
 	for _, rootName := range expectedRoots {
 		if got := len(col.writeDomain.rootRuns[rootName]); got != 1 {
-			col.writeDomain.mu.RUnlock()
 			t.Fatalf("pending root %q runs=%d want 1", rootName, got)
 		}
 	}
 	if got := len(col.writeDomain.uniqueValueRuns["email"]); got != 1 {
-		col.writeDomain.mu.RUnlock()
 		t.Fatalf("pending email unique runs=%d want 1", got)
 	}
 	if got := col.writeDomain.count; got != 1 {
-		col.writeDomain.mu.RUnlock()
 		t.Fatalf("pending count=%d want 1", got)
 	}
-	col.writeDomain.mu.RUnlock()
 }
 
 func TestCollectionNativewireInsertBatchNoResultIDsUpdatesVectorIndex(t *testing.T) {
@@ -3268,6 +3268,13 @@ func TestCollectionNativewireInsertBatchNoResultIDsUpdatesVectorIndex(t *testing
 	}
 }
 
+func singleDirectBufferedUserIndexes() []IndexDefinition {
+	return []IndexDefinition{
+		{Name: "email", Field: "email", ValueType: IndexValueString, Unique: true},
+		{Name: "city", Field: "city", ValueType: IndexValueString},
+	}
+}
+
 func newSingleDirectBufferedBSONUsersCollection(t *testing.T) (*backenddb.DB, *Collection) {
 	t.Helper()
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
@@ -3282,10 +3289,7 @@ func newSingleDirectBufferedBSONUsersCollection(t *testing.T) (*backenddb.DB, *C
 	if _, err := mgr.CreateCollection(&CollectionMeta{
 		Name:    "users",
 		Options: opts,
-		Indexes: []IndexDefinition{
-			{Name: "email", Field: "email", ValueType: IndexValueString, Unique: true},
-			{Name: "city", Field: "city", ValueType: IndexValueString},
-		},
+		Indexes: singleDirectBufferedUserIndexes(),
 	}); err != nil {
 		t.Fatalf("create collection: %v", err)
 	}

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -3051,6 +3051,155 @@ func TestCollectionInsertBatchBridge_ValidatedBSONReturnedIDsAreOwned(t *testing
 	}
 }
 
+func TestCollectionInsertBatchSingleDirectBufferedBSONStats(t *testing.T) {
+	_, col := newSingleDirectBufferedBSONUsersCollection(t)
+
+	if _, err := col.InsertBatchValidatedBSON(
+		[][]byte{[]byte("u1")},
+		[][]byte{mustBSONCollectionDocument(t, bson.D{
+			{Key: "email", Value: "ada@example.com"},
+			{Key: "city", Value: "hnl"},
+		})},
+	); err != nil {
+		t.Fatalf("insert single direct-buffered bson: %v", err)
+	}
+
+	stats := col.LastInsertStats()
+	if stats.Documents != 1 || stats.Indexes != 2 {
+		t.Fatalf("stats documents/indexes=%d/%d want 1/2", stats.Documents, stats.Indexes)
+	}
+	if stats.BufferedIndexedBatches != 1 || stats.BufferedIndexedBypassBatches != 0 {
+		t.Fatalf("buffered stats batches=%d bypass=%d want 1/0", stats.BufferedIndexedBatches, stats.BufferedIndexedBypassBatches)
+	}
+	if stats.Runs != 3 {
+		t.Fatalf("runs=%d want primary,email,city roots", stats.Runs)
+	}
+	if stats.SecondaryEntries != 2 || stats.SecondarySortedRuns != 2 || stats.SecondaryUnsortedRuns != 0 {
+		t.Fatalf("secondary stats entries=%d sorted=%d unsorted=%d want 2/2/0", stats.SecondaryEntries, stats.SecondarySortedRuns, stats.SecondaryUnsortedRuns)
+	}
+	if len(stats.SecondaryRuns) != 2 {
+		t.Fatalf("secondary run stats=%d want 2", len(stats.SecondaryRuns))
+	}
+	for _, run := range stats.SecondaryRuns {
+		if run.Entries != 1 || !run.AlreadySorted {
+			t.Fatalf("secondary run %+v want one already-sorted entry", run)
+		}
+	}
+}
+
+func TestCollectionInsertBatchSingleDirectBufferedBSONRejectsPendingDocumentID(t *testing.T) {
+	_, col := newSingleDirectBufferedBSONUsersCollection(t)
+
+	if _, err := col.InsertBatchValidatedBSON(
+		[][]byte{[]byte("u1")},
+		[][]byte{mustBSONCollectionDocument(t, bson.D{{Key: "email", Value: "ada@example.com"}, {Key: "city", Value: "hnl"}})},
+	); err != nil {
+		t.Fatalf("insert pending document: %v", err)
+	}
+	_, err := col.InsertBatchValidatedBSON(
+		[][]byte{[]byte("u1")},
+		[][]byte{mustBSONCollectionDocument(t, bson.D{{Key: "email", Value: "grace@example.com"}, {Key: "city", Value: "sea"}})},
+	)
+	if !errors.Is(err, ErrDocumentExists) {
+		t.Fatalf("duplicate pending document id err=%v want ErrDocumentExists", err)
+	}
+	got, err := col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get u1: %v", err)
+	}
+	if gotCity := bson.Raw(got).Lookup("city").StringValue(); gotCity != "hnl" {
+		t.Fatalf("u1 city=%q want original pending document", gotCity)
+	}
+}
+
+func TestCollectionInsertBatchSingleDirectBufferedBSONRejectsPendingUniqueConflict(t *testing.T) {
+	_, col := newSingleDirectBufferedBSONUsersCollection(t)
+
+	if _, err := col.InsertBatchValidatedBSON(
+		[][]byte{[]byte("u1")},
+		[][]byte{mustBSONCollectionDocument(t, bson.D{{Key: "email", Value: "ada@example.com"}, {Key: "city", Value: "hnl"}})},
+	); err != nil {
+		t.Fatalf("insert pending unique document: %v", err)
+	}
+	_, err := col.InsertBatchValidatedBSON(
+		[][]byte{[]byte("u2")},
+		[][]byte{mustBSONCollectionDocument(t, bson.D{{Key: "email", Value: "ada@example.com"}, {Key: "city", Value: "sea"}})},
+	)
+	if !errors.Is(err, ErrUniqueIndexConflict) {
+		t.Fatalf("duplicate pending unique err=%v want ErrUniqueIndexConflict", err)
+	}
+	got, err := col.Get([]byte("u2"))
+	if err != nil {
+		t.Fatalf("get u2: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("u2=%q want no staged document after unique conflict", got)
+	}
+}
+
+func TestCollectionInsertBatchSingleDirectBufferedTemplateV1StagesExpectedRoots(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = d.Close() })
+
+	mgr := NewCollectionManager(d)
+	opts := bufferedIndexedUpdateNoAsyncHighThresholdOptionsForTests()
+	opts.DocumentFormat = DocumentFormatTemplateV1
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name:    "users",
+		Options: opts,
+		Indexes: []IndexDefinition{
+			{Name: "email", Field: "email", ValueType: IndexValueString, Unique: true},
+			{Name: "city", Field: "city", ValueType: IndexValueString},
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{mustTemplateV1Document(t, []string{"email", "city"}, []any{"ada@example.com", "hnl"})},
+	); err != nil {
+		t.Fatalf("insert single template-v1 document: %v", err)
+	}
+	stats := col.LastInsertStats()
+	if stats.Documents != 1 || stats.Indexes != 2 || stats.Runs != 4 {
+		t.Fatalf("stats documents/indexes/runs=%d/%d/%d want 1/2/4", stats.Documents, stats.Indexes, stats.Runs)
+	}
+	if stats.SecondaryEntries != 2 || stats.SecondarySortedRuns != 2 || stats.SecondaryUnsortedRuns != 0 {
+		t.Fatalf("secondary stats entries=%d sorted=%d unsorted=%d want 2/2/0", stats.SecondaryEntries, stats.SecondarySortedRuns, stats.SecondaryUnsortedRuns)
+	}
+
+	expectedRoots := []string{
+		collectionTemplateRootName("users"),
+		collectionPrimaryRootName("users"),
+		collectionSecondaryRootName("users", "email"),
+		collectionSecondaryRootName("users", "city"),
+	}
+	col.writeDomain.mu.RLock()
+	for _, rootName := range expectedRoots {
+		if got := len(col.writeDomain.rootRuns[rootName]); got != 1 {
+			col.writeDomain.mu.RUnlock()
+			t.Fatalf("pending root %q runs=%d want 1", rootName, got)
+		}
+	}
+	if got := len(col.writeDomain.uniqueValueRuns["email"]); got != 1 {
+		col.writeDomain.mu.RUnlock()
+		t.Fatalf("pending email unique runs=%d want 1", got)
+	}
+	if got := col.writeDomain.count; got != 1 {
+		col.writeDomain.mu.RUnlock()
+		t.Fatalf("pending count=%d want 1", got)
+	}
+	col.writeDomain.mu.RUnlock()
+}
+
 func TestCollectionNativewireInsertBatchNoResultIDsUpdatesVectorIndex(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {
@@ -3095,6 +3244,34 @@ func TestCollectionNativewireInsertBatchNoResultIDsUpdatesVectorIndex(t *testing
 	if got, err := col.Get([]byte("z")); err != nil || got != nil {
 		t.Fatalf("mutated request id lookup got=%q err=%v want missing", got, err)
 	}
+}
+
+func newSingleDirectBufferedBSONUsersCollection(t *testing.T) (*backenddb.DB, *Collection) {
+	t.Helper()
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = d.Close() })
+
+	mgr := NewCollectionManager(d)
+	opts := bufferedIndexedUpdateNoAsyncHighThresholdOptionsForTests()
+	opts.DocumentFormat = DocumentFormatBSON
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name:    "users",
+		Options: opts,
+		Indexes: []IndexDefinition{
+			{Name: "email", Field: "email", ValueType: IndexValueString, Unique: true},
+			{Name: "city", Field: "city", ValueType: IndexValueString},
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	return d, col
 }
 
 func TestCollectionSingleInsertBufferedNoIndexReadsBeforeFlush(t *testing.T) {

--- a/TreeDB/collections/overhead_bench_test.go
+++ b/TreeDB/collections/overhead_bench_test.go
@@ -264,7 +264,7 @@ func BenchmarkCollectionOverheadPlanDirectBufferedIndexedSingle(b *testing.B) {
 		if err != nil {
 			b.Fatalf("plan direct-buffered indexed batch: %v", err)
 		}
-		_ = plan
+		resetCollectionRunTables(plan.runs)
 	}
 }
 
@@ -280,7 +280,7 @@ func BenchmarkCollectionOverheadPlanDirectBufferedIndexedTemplateV1Single(b *tes
 		if err != nil {
 			b.Fatalf("plan direct-buffered template-v1 batch: %v", err)
 		}
-		_ = plan
+		resetCollectionRunTables(plan.runs)
 	}
 }
 

--- a/TreeDB/collections/overhead_bench_test.go
+++ b/TreeDB/collections/overhead_bench_test.go
@@ -252,6 +252,38 @@ func BenchmarkCollectionOverheadPlanIndexedTemplateV1(b *testing.B) {
 	}
 }
 
+func BenchmarkCollectionOverheadPlanDirectBufferedIndexedSingle(b *testing.B) {
+	ids, docs := overheadBenchDocumentBatch(1, true)
+	planner := overheadBenchIndexedPlanner()
+	planner.buildPrimaryVal = clonePrimaryDocument
+	planner.directBufferedRuns = true
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		plan, err := planner.planInsertBatch(ids, docs)
+		if err != nil {
+			b.Fatalf("plan direct-buffered indexed batch: %v", err)
+		}
+		_ = plan
+	}
+}
+
+func BenchmarkCollectionOverheadPlanDirectBufferedIndexedTemplateV1Single(b *testing.B) {
+	ids, docs := overheadBenchTemplateDocumentBatch(b, 1, true)
+	planner := overheadBenchTemplateIndexedPlanner()
+	planner.buildPrimaryVal = clonePrimaryDocument
+	planner.directBufferedRuns = true
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		plan, err := planner.planInsertBatch(ids, docs)
+		if err != nil {
+			b.Fatalf("plan direct-buffered template-v1 batch: %v", err)
+		}
+		_ = plan
+	}
+}
+
 func BenchmarkCollectionOverheadIndexStateJSONExtraction(b *testing.B) {
 	batchSize := overheadBenchBatchSize(b)
 	_, docs := overheadBenchDocumentBatch(batchSize, true)

--- a/TreeDB/collections/planner.go
+++ b/TreeDB/collections/planner.go
@@ -234,6 +234,9 @@ func (p insertBatchPlanner) planInsertBatchWithPreflight(ids, documents [][]byte
 	if err != nil {
 		return nil, err
 	}
+	if p.directBufferedRuns && len(preparedDocuments) == 1 {
+		return p.planSingleDirectBufferedInsertWithPreflight(resultIDs[0], preparedDocuments[0], runtimes, persistIndexState, templateRecords, templateLearned, preflight, stats)
+	}
 	items := make([]insertBatchItem, len(preparedDocuments))
 	for i := range preparedDocuments {
 		id := resultIDs[i]
@@ -354,6 +357,45 @@ func cloneBatchDocumentIDs(ids [][]byte) ([][]byte, error) {
 		out[i] = arena[start:len(arena):len(arena)]
 	}
 	return out, nil
+}
+
+func (p insertBatchPlanner) planSingleDirectBufferedInsertWithPreflight(resultID, preparedDocument []byte, runtimes []indexRuntime, persistIndexState bool, templateRecords []templateV1Record, templateLearned []templateV1LearnedTemplate, preflight insertBatchPreflight, stats CollectionInsertStats) (*insertBatchPlan, error) {
+	primaryKeys := [][]byte{resultID}
+	if err := preflight.checkDocumentConflictKeys(primaryKeys); err != nil {
+		return nil, err
+	}
+
+	item := insertBatchItem{id: resultID, document: preparedDocument}
+	phaseStart := time.Now()
+	allUniqueProbeRuns, uniqueProbeRuns, err := p.singleItemIndexStateAndUniqueProbeRuns(&item, runtimes, preflight)
+	stats.IndexStateExtraction = time.Since(phaseStart)
+	if err != nil {
+		return nil, err
+	}
+
+	phaseStart = time.Now()
+	if err := preflight.checkUniqueConflicts(uniqueProbeRuns); err != nil {
+		return nil, err
+	}
+	stats.UniqueIndexPreflight = time.Since(phaseStart)
+
+	plan := &insertBatchPlan{
+		resultIDs:               primaryKeys,
+		primaryKeys:             primaryKeys,
+		uniqueProbeRuns:         uniqueProbeRuns,
+		allUniqueProbeRuns:      allUniqueProbeRuns,
+		allUniqueProbeRunsBuilt: true,
+		templateRecords:         templateRecords,
+		templateLearned:         templateLearned,
+		stats:                   insertBatchPlanStats{CollectionInsertStats: stats},
+	}
+	if err := p.buildSingleDirectBufferedInsertPlan(plan, &item, runtimes, persistIndexState, templateRecords); err != nil {
+		return nil, err
+	}
+	if plan.directBufferedInsert != nil {
+		plan.stats.Runs = len(plan.directBufferedInsert.rootNames)
+	}
+	return plan, nil
 }
 
 func (p insertBatchPreflight) checkDocumentConflicts(items []insertBatchItem, order []int, presortedIDs [][]byte) error {
@@ -612,6 +654,70 @@ func (p insertBatchPlanner) planIndexStateAndUniqueProbes(items []insertBatchIte
 	return uniqueProbes, nil
 }
 
+func (p insertBatchPlanner) singleItemIndexStateAndUniqueProbeRuns(item *insertBatchItem, runtimes []indexRuntime, preflight insertBatchPreflight) ([]collectionUniqueProbeRun, []collectionUniqueProbeRun, error) {
+	if item == nil || len(runtimes) == 0 {
+		return nil, nil, nil
+	}
+	encoder := indexEncodeArena{
+		buf:       make([]byte, 0, estimateDocumentIndexEncodeArenaBytes(len(runtimes))),
+		valueRefs: make([][]byte, 0, len(runtimes)),
+	}
+	state, err := orderedIndexStateForDocumentWithArena(item.document, runtimes, p.options, &encoder)
+	if err != nil {
+		return nil, nil, err
+	}
+	item.state = state
+
+	uniqueRunCount := 0
+	prefixBytes := 0
+	for runtimeIdx, runtime := range runtimes {
+		if !runtime.def.unique {
+			continue
+		}
+		values := state.valuesAt(runtimeIdx)
+		if len(values) == 0 {
+			continue
+		}
+		uniqueRunCount++
+		for _, value := range values {
+			prefixBytes += len(value)
+		}
+	}
+	if uniqueRunCount == 0 {
+		return nil, nil, nil
+	}
+
+	allRuns := make([]collectionUniqueProbeRun, 0, uniqueRunCount)
+	preflightRuns := make([]collectionUniqueProbeRun, 0, uniqueRunCount)
+	prefixArena := make([]byte, 0, prefixBytes)
+	for runtimeIdx, runtime := range runtimes {
+		if !runtime.def.unique {
+			continue
+		}
+		values := state.valuesAt(runtimeIdx)
+		if len(values) == 0 {
+			continue
+		}
+		run := collectionUniqueProbeRun{
+			indexName: runtime.def.name,
+			prefixes:  make([][]byte, 0, len(values)),
+		}
+		for _, value := range values {
+			var prefix []byte
+			prefixArena, prefix, err = appendIndexValuePrefixSlice(prefixArena, value)
+			if err != nil {
+				return nil, nil, err
+			}
+			run.prefixes = append(run.prefixes, prefix)
+		}
+		allRuns = append(allRuns, run)
+		if preflight.snapshot != nil && preflight.uniqueIndexRootIDs[runtime.def.name] != 0 {
+			preflightRuns = append(preflightRuns, run)
+		}
+	}
+	return allRuns, preflightRuns, nil
+}
+
 func sortUniqueProbeCandidates(candidates []uniqueProbeCandidate) {
 	sort.Slice(candidates, func(i, j int) bool {
 		if candidates[i].indexName != candidates[j].indexName {
@@ -853,6 +959,83 @@ func (p insertBatchPlanner) buildDirectBufferedInsertPlan(plan *insertBatchPlan,
 	return nil
 }
 
+func (p insertBatchPlanner) buildSingleDirectBufferedInsertPlan(plan *insertBatchPlan, item *insertBatchItem, runtimes []indexRuntime, persistIndexState bool, templateRecords []templateV1Record) error {
+	if item == nil {
+		return nil
+	}
+	rootCap := 1
+	if len(templateRecords) > 0 {
+		rootCap++
+	}
+	if len(runtimes) > 0 {
+		if persistIndexState {
+			rootCap++
+		}
+		rootCap += len(runtimes)
+	}
+	direct := &directBufferedInsertPlan{
+		templateRootName:   p.templateRoot,
+		primaryRootName:    p.primaryRoot,
+		indexStateRootName: p.indexStateRoot,
+		rootNames:          make([]string, 0, rootCap),
+		policies:           make([]backenddb.OrderedRootStoragePolicy, 0, rootCap),
+	}
+	if len(templateRecords) > 0 {
+		phaseStart := time.Now()
+		entries, err := p.directBufferedTemplateRootEntries(templateRecords)
+		if err != nil {
+			return err
+		}
+		direct.templateEntries = entries
+		direct.addRoot(p.templateRoot, p.options.dataStoragePolicy)
+		direct.stagedBytes = saturatingAddNonNegativeInt64(direct.stagedBytes, directBufferedRootEntriesSize(entries))
+		plan.stats.TemplateRunBuild = time.Since(phaseStart)
+	}
+
+	phaseStart := time.Now()
+	value, err := p.buildPrimaryVal(item.id, item.document)
+	if err != nil {
+		return err
+	}
+	plan.stats.payloadBuilds++
+	direct.primaryEntries = []directBufferedRootEntry{{
+		key:   item.id,
+		value: value,
+		flags: node.FlagInline,
+	}}
+	direct.addRoot(p.primaryRoot, p.options.dataStoragePolicy)
+	direct.stagedBytes = saturatingAddNonNegativeInt64(direct.stagedBytes, directBufferedRootEntriesSize(direct.primaryEntries))
+	plan.stats.PrimaryRunBuild = time.Since(phaseStart)
+
+	if len(runtimes) > 0 {
+		if persistIndexState {
+			phaseStart = time.Now()
+			entry, size, err := p.singleDirectBufferedIndexStateRootEntry(item, runtimes)
+			if err != nil {
+				return err
+			}
+			direct.indexStateEntries = []directBufferedRootEntry{entry}
+			direct.addRoot(p.indexStateRoot, p.options.indexStateStoragePolicy)
+			direct.stagedBytes = saturatingAddNonNegativeInt64(direct.stagedBytes, int64(size))
+			plan.stats.IndexStateRunBuild = time.Since(phaseStart)
+		}
+		phaseStart = time.Now()
+		secondaryPlans, secondaryBytes := p.singleDirectBufferedSecondaryRootPlans(item, runtimes, &plan.stats.CollectionInsertStats)
+		direct.secondaryRootPlans = secondaryPlans
+		direct.stagedBytes = saturatingAddNonNegativeInt64(direct.stagedBytes, secondaryBytes)
+		for _, secondaryPlan := range secondaryPlans {
+			direct.addRoot(secondaryPlan.rootName, runtimes[secondaryPlan.runtimeIdx].def.storagePolicy)
+		}
+		direct.uniqueValueRootPlans = directBufferedUniqueValueRootPlans(plan.allUniqueProbeRuns, runtimes)
+		for _, uniquePlan := range direct.uniqueValueRootPlans {
+			direct.stagedBytes = saturatingAddNonNegativeInt64(direct.stagedBytes, int64(uniquePlan.keyBytes))
+		}
+		plan.stats.SecondaryRunBuild = time.Since(phaseStart)
+	}
+	plan.directBufferedInsert = direct
+	return nil
+}
+
 func (p insertBatchPlanner) directBufferedTemplateRootEntries(records []templateV1Record) ([]directBufferedRootEntry, error) {
 	if len(records) == 0 {
 		return nil, nil
@@ -949,6 +1132,23 @@ func (p insertBatchPlanner) directBufferedIndexStateRootEntries(items []insertBa
 	return entries, nil
 }
 
+func (p insertBatchPlanner) singleDirectBufferedIndexStateRootEntry(item *insertBatchItem, runtimes []indexRuntime) (directBufferedRootEntry, int, error) {
+	if item == nil {
+		return directBufferedRootEntry{}, 0, nil
+	}
+	count, size, err := runtimeOrderedDocumentIndexStateStats(item.state, runtimes)
+	if err != nil {
+		return directBufferedRootEntry{}, 0, err
+	}
+	valueArena := make([]byte, 0, size)
+	_, value := appendRuntimeOrderedDocumentIndexState(valueArena, item.state, runtimes, count)
+	return directBufferedRootEntry{
+		key:   item.id,
+		value: value,
+		flags: node.FlagInline,
+	}, len(item.id) + len(value), nil
+}
+
 func (p insertBatchPlanner) directBufferedSecondaryRootPlans(items []insertBatchItem, runtimes []indexRuntime, stats *CollectionInsertStats) ([]directBufferedSecondaryRootPlan, int64, error) {
 	if len(items) == 0 || len(runtimes) == 0 {
 		return nil, 0, nil
@@ -1016,23 +1216,77 @@ func (p insertBatchPlanner) directBufferedSecondaryRootPlans(items []insertBatch
 	return plans, stagedBytes, nil
 }
 
+func (p insertBatchPlanner) singleDirectBufferedSecondaryRootPlans(item *insertBatchItem, runtimes []indexRuntime, stats *CollectionInsertStats) ([]directBufferedSecondaryRootPlan, int64) {
+	if item == nil || len(runtimes) == 0 {
+		return nil, 0
+	}
+	plans := make([]directBufferedSecondaryRootPlan, 0, len(runtimes))
+	var stagedBytes int64
+	for runtimeIdx, runtime := range runtimes {
+		runStart := time.Now()
+		values := item.state.valuesAt(runtimeIdx)
+		entryCount := len(values)
+		keyBytes := 0
+		for _, encoded := range values {
+			keyBytes += len(encoded) + len(item.id)
+		}
+		runStats := CollectionSecondaryRunStats{
+			IndexName:     runtime.def.name,
+			Entries:       entryCount,
+			KeyBytes:      keyBytes,
+			AlreadySorted: true,
+		}
+		if entryCount == 0 {
+			runStats.Build = time.Since(runStart)
+			if stats != nil {
+				stats.SecondaryRuns = append(stats.SecondaryRuns, runStats)
+			}
+			continue
+		}
+		rootName := runtime.secondaryRootName
+		if rootName == "" {
+			rootName = collectionSecondaryRootName(p.collection, runtime.def.name)
+		}
+		secondaryPlan := directBufferedSecondaryRootPlan{
+			rootName:   rootName,
+			entries:    make([]directBufferedSecondaryRootEntry, entryCount),
+			arena:      make([]byte, 0, keyBytes),
+			indexName:  runtime.def.name,
+			valueType:  runtime.def.valueType,
+			unique:     runtime.def.unique,
+			sets:       entryCount,
+			keyBytes:   keyBytes,
+			runtimeIdx: runtimeIdx,
+		}
+		for i, encoded := range values {
+			var key []byte
+			secondaryPlan.arena, key, _ = appendIndexEntryKey(secondaryPlan.arena, encoded, item.id)
+			secondaryPlan.entries[i] = directBufferedSecondaryRootEntry{key: key}
+		}
+		runStats.Build = time.Since(runStart)
+		if stats != nil {
+			stats.SecondaryRuns = append(stats.SecondaryRuns, runStats)
+			stats.SecondaryEntries += entryCount
+			stats.SecondaryKeyBytes += keyBytes
+			stats.SecondarySortedRuns++
+		}
+		stagedBytes = saturatingAddNonNegativeInt64(stagedBytes, int64(keyBytes))
+		plans = append(plans, secondaryPlan)
+	}
+	return plans, stagedBytes
+}
+
 func directBufferedUniqueValueRootPlans(runs []collectionUniqueProbeRun, runtimes []indexRuntime) []directBufferedUniqueValueRootPlan {
 	if len(runs) == 0 || len(runtimes) == 0 {
 		return nil
 	}
-	valueTypes := make(map[string]IndexValueType, len(runtimes))
-	for _, runtime := range runtimes {
-		if runtime.def.unique {
-			valueTypes[runtime.def.name] = runtime.def.valueType
-		}
-	}
-	if len(valueTypes) == 0 {
-		return nil
-	}
 	plans := make([]directBufferedUniqueValueRootPlan, 0, len(runs))
 	for _, run := range runs {
-		valueType, ok := valueTypes[run.indexName]
-		if !ok || len(run.prefixes) == 0 {
+		if len(run.prefixes) == 0 {
+			continue
+		}
+		valueType, ok := uniqueIndexValueTypeForName(runtimes, run.indexName)
+		if !ok {
 			continue
 		}
 		keyBytes := 0
@@ -1047,6 +1301,15 @@ func directBufferedUniqueValueRootPlans(runs []collectionUniqueProbeRun, runtime
 		})
 	}
 	return plans
+}
+
+func uniqueIndexValueTypeForName(runtimes []indexRuntime, indexName string) (IndexValueType, bool) {
+	for _, runtime := range runtimes {
+		if runtime.def.unique && runtime.def.name == indexName {
+			return runtime.def.valueType, true
+		}
+	}
+	return "", false
 }
 
 func (plan *directBufferedInsertPlan) addRoot(rootName string, policy backenddb.OrderedRootStoragePolicy) {

--- a/TreeDB/collections/planner.go
+++ b/TreeDB/collections/planner.go
@@ -662,6 +662,7 @@ func (p insertBatchPlanner) singleItemIndexStateAndUniqueProbeRuns(item *insertB
 	}
 	encoder := indexEncodeArena{
 		buf:       make([]byte, 0, estimateDocumentIndexEncodeArenaBytes(len(runtimes))),
+		states:    make([][][]byte, 0, len(runtimes)),
 		valueRefs: make([][]byte, 0, len(runtimes)),
 	}
 	state, err := orderedIndexStateForDocumentWithArena(item.document, runtimes, p.options, &encoder)
@@ -1296,12 +1297,24 @@ func directBufferedUniqueValueRootPlans(runs []collectionUniqueProbeRun, runtime
 	if len(runs) == 0 || len(runtimes) == 0 {
 		return nil
 	}
+	var valueTypes map[string]IndexValueType
+	if len(runs) > 2 && len(runtimes) > 2 {
+		valueTypes = make(map[string]IndexValueType, len(runtimes))
+		for _, runtime := range runtimes {
+			if runtime.def.unique {
+				valueTypes[runtime.def.name] = runtime.def.valueType
+			}
+		}
+	}
 	plans := make([]directBufferedUniqueValueRootPlan, 0, len(runs))
 	for _, run := range runs {
 		if len(run.prefixes) == 0 {
 			continue
 		}
-		valueType, ok := uniqueIndexValueTypeForName(runtimes, run.indexName)
+		valueType, ok := valueTypes[run.indexName]
+		if valueTypes == nil {
+			valueType, ok = uniqueIndexValueTypeForName(runtimes, run.indexName)
+		}
 		if !ok {
 			continue
 		}

--- a/TreeDB/collections/planner.go
+++ b/TreeDB/collections/planner.go
@@ -1022,7 +1022,10 @@ func (p insertBatchPlanner) buildSingleDirectBufferedInsertPlan(plan *insertBatc
 			plan.stats.IndexStateRunBuild = time.Since(phaseStart)
 		}
 		phaseStart = time.Now()
-		secondaryPlans, secondaryBytes := p.singleDirectBufferedSecondaryRootPlans(item, runtimes, &plan.stats.CollectionInsertStats)
+		secondaryPlans, secondaryBytes, err := p.singleDirectBufferedSecondaryRootPlans(item, runtimes, &plan.stats.CollectionInsertStats)
+		if err != nil {
+			return err
+		}
 		direct.secondaryRootPlans = secondaryPlans
 		direct.stagedBytes = saturatingAddNonNegativeInt64(direct.stagedBytes, secondaryBytes)
 		for _, secondaryPlan := range secondaryPlans {
@@ -1218,9 +1221,9 @@ func (p insertBatchPlanner) directBufferedSecondaryRootPlans(items []insertBatch
 	return plans, stagedBytes, nil
 }
 
-func (p insertBatchPlanner) singleDirectBufferedSecondaryRootPlans(item *insertBatchItem, runtimes []indexRuntime, stats *CollectionInsertStats) ([]directBufferedSecondaryRootPlan, int64) {
+func (p insertBatchPlanner) singleDirectBufferedSecondaryRootPlans(item *insertBatchItem, runtimes []indexRuntime, stats *CollectionInsertStats) ([]directBufferedSecondaryRootPlan, int64, error) {
 	if item == nil || len(runtimes) == 0 {
-		return nil, 0
+		return nil, 0, nil
 	}
 	plans := make([]directBufferedSecondaryRootPlan, 0, len(runtimes))
 	var stagedBytes int64
@@ -1230,6 +1233,9 @@ func (p insertBatchPlanner) singleDirectBufferedSecondaryRootPlans(item *insertB
 		entryCount := len(values)
 		keyBytes := 0
 		for _, encoded := range values {
+			if len(encoded) > 65535 {
+				return nil, 0, errors.New("collections: index key too large")
+			}
 			keyBytes += len(encoded) + len(item.id)
 		}
 		runStats := CollectionSecondaryRunStats{
@@ -1262,7 +1268,11 @@ func (p insertBatchPlanner) singleDirectBufferedSecondaryRootPlans(item *insertB
 		}
 		for i, encoded := range values {
 			var key []byte
-			secondaryPlan.arena, key, _ = appendIndexEntryKey(secondaryPlan.arena, encoded, item.id)
+			var err error
+			secondaryPlan.arena, key, err = appendIndexEntryKey(secondaryPlan.arena, encoded, item.id)
+			if err != nil {
+				return nil, 0, err
+			}
 			secondaryPlan.entries[i] = directBufferedSecondaryRootEntry{key: key}
 		}
 		runStats.Build = time.Since(runStart)
@@ -1275,7 +1285,7 @@ func (p insertBatchPlanner) singleDirectBufferedSecondaryRootPlans(item *insertB
 		stagedBytes = saturatingAddNonNegativeInt64(stagedBytes, int64(keyBytes))
 		plans = append(plans, secondaryPlan)
 	}
-	return plans, stagedBytes
+	return plans, stagedBytes, nil
 }
 
 func directBufferedUniqueValueRootPlans(runs []collectionUniqueProbeRun, runtimes []indexRuntime) []directBufferedUniqueValueRootPlan {

--- a/TreeDB/collections/planner.go
+++ b/TreeDB/collections/planner.go
@@ -361,12 +361,14 @@ func cloneBatchDocumentIDs(ids [][]byte) ([][]byte, error) {
 
 func (p insertBatchPlanner) planSingleDirectBufferedInsertWithPreflight(resultID, preparedDocument []byte, runtimes []indexRuntime, persistIndexState bool, templateRecords []templateV1Record, templateLearned []templateV1LearnedTemplate, preflight insertBatchPreflight, stats CollectionInsertStats) (*insertBatchPlan, error) {
 	primaryKeys := [][]byte{resultID}
+	phaseStart := time.Now()
 	if err := preflight.checkDocumentConflictKeys(primaryKeys); err != nil {
 		return nil, err
 	}
+	stats.DuplicateDocumentPreflight = time.Since(phaseStart)
 
 	item := insertBatchItem{id: resultID, document: preparedDocument}
-	phaseStart := time.Now()
+	phaseStart = time.Now()
 	allUniqueProbeRuns, uniqueProbeRuns, err := p.singleItemIndexStateAndUniqueProbeRuns(&item, runtimes, preflight)
 	stats.IndexStateExtraction = time.Since(phaseStart)
 	if err != nil {

--- a/TreeDB/collections/planner.go
+++ b/TreeDB/collections/planner.go
@@ -1029,7 +1029,11 @@ func (p insertBatchPlanner) buildSingleDirectBufferedInsertPlan(plan *insertBatc
 		direct.secondaryRootPlans = secondaryPlans
 		direct.stagedBytes = saturatingAddNonNegativeInt64(direct.stagedBytes, secondaryBytes)
 		for _, secondaryPlan := range secondaryPlans {
-			direct.addRoot(secondaryPlan.rootName, runtimes[secondaryPlan.runtimeIdx].def.storagePolicy)
+			runtimeIdx := secondaryPlan.runtimeIdx
+			if runtimeIdx < 0 || runtimeIdx >= len(runtimes) {
+				return fmt.Errorf("collections: invalid direct buffered secondary runtime index %d", runtimeIdx)
+			}
+			direct.addRoot(secondaryPlan.rootName, runtimes[runtimeIdx].def.storagePolicy)
 		}
 		direct.uniqueValueRootPlans = directBufferedUniqueValueRootPlans(plan.allUniqueProbeRuns, runtimes)
 		for _, uniquePlan := range direct.uniqueValueRootPlans {

--- a/TreeDB/collections/planner_test.go
+++ b/TreeDB/collections/planner_test.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 	"github.com/snissn/gomap/TreeDB/node"
@@ -872,6 +873,33 @@ func TestInsertBatchPlanner_SingleDirectBufferedInsertPlanPreservesIndexedSemant
 	}
 }
 
+func TestInsertBatchPlanner_SingleDirectBufferedInsertPlanRecordsDocumentPreflightStats(t *testing.T) {
+	planner := insertBatchPlanner{
+		collection:          "users",
+		buildPrimaryVal:     clonePrimaryDocument,
+		directBufferedRuns:  true,
+		cachedIndexRuntimes: nil,
+	}
+	probe := &delayedRootSnapshotProbe{delay: 2 * time.Millisecond}
+	plan, err := planner.planInsertBatchWithPreflight(
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"name":"ada"}`)},
+		insertBatchPreflight{
+			snapshot:      probe,
+			primaryRootID: 9,
+		},
+	)
+	if err != nil {
+		t.Fatalf("plan insert batch: %v", err)
+	}
+	if probe.hasAnySortedCalls != 1 {
+		t.Fatalf("HasAnySortedAtRoot calls=%d want 1", probe.hasAnySortedCalls)
+	}
+	if got := plan.stats.DuplicateDocumentPreflight; got < probe.delay {
+		t.Fatalf("DuplicateDocumentPreflight=%s want at least %s", got, probe.delay)
+	}
+}
+
 func TestInsertBatchPreflightCheckUniqueConflictsSkipsMissingRoots(t *testing.T) {
 	probe := &recordingRootSnapshotProbe{}
 	preflight := insertBatchPreflight{
@@ -1250,6 +1278,16 @@ type recordingRootSnapshotProbe struct {
 	lastHasPrefixesRootID   uint64
 	lastHasAnySortedKeys    [][]byte
 	lastHasPrefixesPrefixes [][]byte
+}
+
+type delayedRootSnapshotProbe struct {
+	recordingRootSnapshotProbe
+	delay time.Duration
+}
+
+func (p *delayedRootSnapshotProbe) HasAnySortedAtRoot(rootID uint64, keys [][]byte) (bool, error) {
+	time.Sleep(p.delay)
+	return p.recordingRootSnapshotProbe.HasAnySortedAtRoot(rootID, keys)
 }
 
 func (p *recordingRootSnapshotProbe) HasAnySortedAtRoot(rootID uint64, keys [][]byte) (bool, error) {

--- a/TreeDB/collections/planner_test.go
+++ b/TreeDB/collections/planner_test.go
@@ -515,6 +515,18 @@ func requireEncodedIndexOrder(t *testing.T, valueType IndexValueType, values ...
 	}
 }
 
+func stringSliceEqual(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}
+
 func TestOrderedIndexStateForDocumentHandlesScalarAndArrayValues(t *testing.T) {
 	scalarRuntime := []indexRuntime{{
 		def:  indexDefinition{name: "email", field: "email", valueType: IndexValueString},
@@ -782,6 +794,81 @@ func TestInsertBatchPlanner_BuildsUniqueProbePrefixesOnlyForPersistedRoots(t *te
 	}
 	if noRootProbe.hasPrefixesCalls != 0 {
 		t.Fatalf("HasPrefixesAtRoot calls without persisted roots=%d want 0", noRootProbe.hasPrefixesCalls)
+	}
+}
+
+func TestInsertBatchPlanner_SingleDirectBufferedInsertPlanPreservesIndexedSemantics(t *testing.T) {
+	planner := insertBatchPlanner{
+		collection: "users",
+		indexes: []indexDefinition{
+			{name: "email", field: "email", valueType: IndexValueString, unique: true},
+			{name: "city", field: "city", valueType: IndexValueString, multiKey: true},
+		},
+		buildPrimaryVal:    clonePrimaryDocument,
+		directBufferedRuns: true,
+	}
+
+	plan, err := planner.planInsertBatchWithPreflight(
+		[][]byte{[]byte("u1")},
+		[][]byte{[]byte(`{"email":"ada@example.com","city":["hnl","hnl","iad"]}`)},
+		insertBatchPreflight{
+			snapshot: &recordingRootSnapshotProbe{},
+			uniqueIndexRootIDs: map[string]uint64{
+				"email": 77,
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("plan insert batch: %v", err)
+	}
+	if got := len(plan.runs); got != 0 {
+		t.Fatalf("runs len=%d want 0 for direct-buffered plan", got)
+	}
+	if plan.directBufferedInsert == nil {
+		t.Fatal("missing direct-buffered insert plan")
+	}
+	direct := plan.directBufferedInsert
+	if got, want := direct.rootNames, []string{"users/primary", "users/index-state", "users/index/email", "users/index/city"}; !stringSliceEqual(got, want) {
+		t.Fatalf("root names=%v want %v", got, want)
+	}
+	if got, want := len(direct.primaryEntries), 1; got != want {
+		t.Fatalf("primary entries=%d want %d", got, want)
+	}
+	if got, want := string(direct.primaryEntries[0].key), "u1"; got != want {
+		t.Fatalf("primary key=%q want %q", got, want)
+	}
+	if got, want := string(direct.primaryEntries[0].value), `{"email":"ada@example.com","city":["hnl","hnl","iad"]}`; got != want {
+		t.Fatalf("primary value=%q want %q", got, want)
+	}
+	if got, want := len(direct.indexStateEntries), 1; got != want {
+		t.Fatalf("index-state entries=%d want %d", got, want)
+	}
+	if len(direct.indexStateEntries[0].value) == 0 {
+		t.Fatal("index-state entry is empty")
+	}
+	if got, want := len(direct.secondaryRootPlans), 2; got != want {
+		t.Fatalf("secondary root plans=%d want %d", got, want)
+	}
+	if got, want := len(direct.secondaryRootPlans[0].entries), 1; got != want {
+		t.Fatalf("email secondary entries=%d want %d", got, want)
+	}
+	if got, want := len(direct.secondaryRootPlans[1].entries), 2; got != want {
+		t.Fatalf("city secondary entries=%d want %d", got, want)
+	}
+	if got, want := len(plan.allUniqueProbeRuns), 1; got != want {
+		t.Fatalf("all unique probe runs=%d want %d", got, want)
+	}
+	if got, want := len(plan.allUniqueProbeRuns[0].prefixes), 1; got != want {
+		t.Fatalf("all unique probe prefixes=%d want %d", got, want)
+	}
+	if got, want := len(plan.uniqueProbeRuns), 1; got != want {
+		t.Fatalf("preflight unique probe runs=%d want %d", got, want)
+	}
+	if got, want := len(direct.uniqueValueRootPlans), 1; got != want {
+		t.Fatalf("unique value root plans=%d want %d", got, want)
+	}
+	if got, want := len(direct.uniqueValueRootPlans[0].prefixes), 1; got != want {
+		t.Fatalf("unique value root prefixes=%d want %d", got, want)
 	}
 }
 


### PR DESCRIPTION
## Linked Issue

Closes #2087

Parent: #2083

## Summary

- Adds a `len(documents)==1` direct-buffered insert planning path for the dominant YCSB batch-1 insert shape.
- Avoids the generic batch scaffolding for unique probe run construction while preserving primary, unique, secondary, BSON, template-v1, and buffered staging semantics.
- Adds focused coverage for stats recording, pending primary conflicts, pending unique conflicts, and template-v1 staged roots.

## Tests

- `go test ./TreeDB/collections -run 'TestInsertBatchPlanner_SingleDirectBuffered|TestCollectionInsertBatchSingleDirectBuffered' -count=1`
- `go test ./TreeDB/collections -count=1`
- `go test ./TreeDB/nativewire -count=1`

## Benchmark Evidence

Collection benchmark command:

```sh
TREEDB_COLLECTION_DOCUMENT_FORMAT=bson TREEDB_COLLECTION_BENCH_BATCH_SIZE=1 \
  go test ./TreeDB/collections -run '^$' \
  -bench '^BenchmarkCollectionShapeInsertBatch$/indexes_1$' \
  -benchtime=3s -count=3 -benchmem
```

Baseline on `main` after #2093:

- `8769 ns/op`, `4891 B/op`, `37 allocs/op`, `unique_preflight_ns/doc=372.2`
- `9441 ns/op`, `4485 B/op`, `38 allocs/op`, `unique_preflight_ns/doc=402.0`
- `9035 ns/op`, `4612 B/op`, `37 allocs/op`, `unique_preflight_ns/doc=394.4`

This branch:

- `8799 ns/op`, `4924 B/op`, `37 allocs/op`, `unique_preflight_ns/doc=23.46`
- `8751 ns/op`, `4691 B/op`, `37 allocs/op`, `unique_preflight_ns/doc=23.50`
- `8793 ns/op`, `4421 B/op`, `37 allocs/op`, `unique_preflight_ns/doc=23.49`

Nativewire YCSB BSON benchmark command:

```sh
go test ./TreeDB/nativewire -run '^$' \
  -bench '^BenchmarkNativewireYCSBLoad$/inproc$/bson_binary$' \
  -benchtime=10s -count=1 -benchmem
```

- Baseline: `13370 ns/op`, `87.81 MB/s`, `9960 B/op`, `63 allocs/op`
- This branch: `13328 ns/op`, `88.08 MB/s`, `9643 B/op`, `61 allocs/op`

## Profile Evidence

Profile benchmark command:

```sh
go test ./TreeDB/nativewire -run '^$' \
  -bench '^BenchmarkNativewireYCSBLoad$/inproc$/bson_binary$' \
  -benchtime=10s -count=1 -benchmem \
  -cpuprofile <dir>/cpu.pprof \
  -memprofile <dir>/mem.pprof
```

Artifacts:

- Baseline: `/tmp/treedb_2087_profile_main_bP1oem`
- This branch: `/tmp/treedb_2087_profile_branch_OY1kob`

Observed profile movement:

- `buildUniqueProbeRunsFromSorted` drops out of the CPU and allocation profile top cutoff.
- Generic planner cumulative CPU moved from `insertBatchPlanner.planInsertBatchWithPreflight` at `3.32s` and `buildDirectBufferedInsertPlan` at `1.34s` to `planSingleDirectBufferedInsertWithPreflight` at `2.63s` and `buildSingleDirectBufferedInsertPlan` at `0.94s`.
- Allocation profile total moved from `9899.86MB` to `9668.40MB`; planner cumulative allocation moved from `2722.78MB` to `2563.74MB`.

## Regression Assessment

The total collection benchmark is within run noise, while the target unique-preflight scaffolding cost drops sharply and the nativewire YCSB BSON guard is neutral to slightly better with fewer allocations. This is a conservative local planner cleanup, not a server-side insert-combiner change.

## AI Review Gate

This PR has code, tests, benchmark numbers, and profile evidence in place before AI review is requested, following the mature-before-review rule from #2083.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized single document insertions on indexed collections for faster throughput.

* **Tests**
  * Expanded test coverage for buffered collection operations with secondary indexes.
  * Added benchmarking tests for single document insert planning performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->