### PR TITLE
Instrument HNSW batchability counters

### DIFF
--- a/TreeDB/collections/column_vector_graph_batchability_1979_test.go
+++ b/TreeDB/collections/column_vector_graph_batchability_1979_test.go
@@ -1,0 +1,298 @@
+package collections
+
+import (
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/internal/typedcolumn"
+)
+
+func TestColumnVectorGraphNativeSearchBenchmarkDebugCounters1979(t *testing.T) {
+	rows := []columnVectorGraphAssetRow{
+		{ID: []byte("doc-entry"), Vector: []float32{1, 0}, InvNorm: 1, Adjacency: []uint32{columnVectorGraphLayeredAdjacencyMagic, 1, 3, 1, 2, 3, 1, 1}},
+		{ID: []byte("doc-cycle"), Vector: []float32{0.9, 0.1}, InvNorm: 1, Adjacency: []uint32{0, 2, 4}},
+		{ID: []byte("doc-filtered-a"), Vector: []float32{0.1, 0.9}, InvNorm: 1},
+		{ID: []byte("doc-neighbor"), Vector: []float32{0.8, 0.2}, InvNorm: 1, Adjacency: []uint32{0, 1, 4}},
+		{ID: []byte("doc-tail"), Vector: []float32{0.7, 0.3}, InvNorm: 1, Adjacency: []uint32{1, 5}},
+		{ID: []byte("doc-filtered-b"), Vector: []float32{0.2, 0.8}, InvNorm: 1},
+	}
+	d, col, def := publishColumnVectorGraphPhysicalReaderTestAssetWithShapeV2B(t, 2, 3, rows)
+	defer func() { _ = d.Close() }()
+	reader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("openColumnVectorGraphPhysicalRowReader: %v", err)
+	}
+	defer func() { _ = reader.Close() }()
+	candidateRows, err := typedcolumn.NewSparseRowSelection(len(rows), []int{0, 1, 3, 4})
+	if err != nil {
+		t.Fatalf("NewSparseRowSelection: %v", err)
+	}
+	var scratch columnVectorGraphNativeSearchScratch
+	got, stats, err := reader.SearchCosine([]float32{1, 0}, columnVectorGraphNativeSearchOptions{
+		TopK:             2,
+		EfSearch:         len(rows),
+		StatsMode:        columnVectorGraphNativeSearchStatsModeBenchmarkDebug,
+		CandidateRows:    candidateRows,
+		HasCandidateRows: true,
+	}, &scratch)
+	if err != nil {
+		t.Fatalf("SearchCosine benchmark_debug: %v", err)
+	}
+	if len(got) != 2 || got[0].Ordinal != 0 {
+		t.Fatalf("results=%+v want doc-entry first", got)
+	}
+	assertColumnVectorGraphBenchmarkDebugStats1979(t, stats, true)
+	if stats.Layer0AlreadyVisitedSkips == 0 || stats.Layer0FilterSkips == 0 {
+		t.Fatalf("stats=%+v want benchmark_debug already-visited and filter skip buckets", stats)
+	}
+	if stats.UpperLayerScores == 0 || stats.Layer0Scores == 0 {
+		t.Fatalf("stats=%+v want upper-layer and layer-0 score buckets", stats)
+	}
+	if stats.ScoreBatchSingletons != stats.ScoreBatchCalls {
+		t.Fatalf("stats=%+v want scalar debug search to report singleton score batches", stats)
+	}
+}
+
+func BenchmarkColumnVectorGraphSearchBatchability1979(b *testing.B) {
+	if !columnGraphTypedColumnMmapDirectViewSupportedForTest() {
+		b.Skip("batchability benchmark requires mmap_direct prepared typed-column views")
+	}
+	baseShape := columnVectorGraphSearchTopologyParityProductionShape2091()
+	exactShape := baseShape
+	exactShape.efSearch = exactShape.rows
+	cases := []struct {
+		name           string
+		shape          columnVectorGraphSearchTopologyParityShape2091
+		scoreBatchMode columnVectorGraphScoreBatchMode
+		exactMode      bool
+	}{
+		{name: "ef_search_128/score=scalar", shape: baseShape, scoreBatchMode: columnVectorGraphScoreBatchModeScalar},
+		{name: "ef_search_128/score=indexed", shape: baseShape, scoreBatchMode: columnVectorGraphScoreBatchModeIndexed},
+		{name: "exact/score=scalar", shape: exactShape, scoreBatchMode: columnVectorGraphScoreBatchModeScalar, exactMode: true},
+		{name: "exact/score=indexed", shape: exactShape, scoreBatchMode: columnVectorGraphScoreBatchModeIndexed, exactMode: true},
+	}
+	for _, tc := range cases {
+		tc := tc
+		b.Run(tc.name, func(b *testing.B) {
+			benchmarkColumnVectorGraphSearchBatchability1979(b, tc.shape, tc.scoreBatchMode, tc.exactMode)
+		})
+	}
+}
+
+func benchmarkColumnVectorGraphSearchBatchability1979(b *testing.B, shape columnVectorGraphSearchTopologyParityShape2091, scoreBatchMode columnVectorGraphScoreBatchMode, exactMode bool) {
+	b.Helper()
+	rows := columnVectorGraphSearchTopologyParityRows2091(b, shape)
+	closeFn, reader, query := openColumnVectorGraphSearchTopologyParityReader2091(b, shape, rows, columnVectorGraphSearchTopologyParityModeCurrentPrepared2091)
+	defer closeFn()
+	var scratch columnVectorGraphNativeSearchScratch
+	opts := columnVectorGraphSearchTopologyParityOptions2091(shape, columnVectorGraphSearchTopologyParityBoundaryGraphOnly2091)
+	opts.StatsMode = columnVectorGraphNativeSearchStatsModeBenchmarkDebug
+	opts.ScoreBatchMode = scoreBatchMode
+	warm, warmStats, err := reader.SearchCosine(query, opts, &scratch)
+	if err != nil {
+		b.Fatalf("warm SearchCosine: %v", err)
+	}
+	if len(warm) == 0 {
+		b.Fatalf("warm SearchCosine returned no results")
+	}
+	assertColumnVectorGraphSearchTopologyParityCurrentStats2091(b, columnVectorGraphSearchTopologyParityBoundaryGraphOnly2091, warmStats)
+	assertColumnVectorGraphBenchmarkDebugStats1979(b, warmStats, exactMode)
+	baseReaderStats := reader.Stats()
+	var totals columnVectorGraphNativeSearchStats
+	var checksum int64
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		got, stats, err := reader.SearchCosine(query, opts, &scratch)
+		if err != nil {
+			b.Fatalf("SearchCosine: %v", err)
+		}
+		if len(got) == 0 {
+			b.Fatalf("SearchCosine returned no results")
+		}
+		checksum += int64(got[0].Ordinal)
+		addColumnVectorGraphSearchTopologyParityStats2091(&totals, stats)
+	}
+	b.StopTimer()
+	columnPhysicalScanBenchSum += checksum
+	b.ReportMetric(1979, "batchability_issue")
+	b.ReportMetric(1, "batchability_score_mode_"+scoreBatchMode.String())
+	if exactMode {
+		b.ReportMetric(1, "batchability_exact_mode")
+	}
+	reportColumnVectorGraphSearchTopologyParityMetrics2091(b, shape, columnVectorGraphSearchTopologyParityBoundaryGraphOnly2091, columnVectorGraphSearchTopologyParityModeCurrentPrepared2091, b.N, baseReaderStats, reader.Stats(), totals)
+}
+
+func assertColumnVectorGraphBenchmarkDebugStats1979(tb testing.TB, stats columnVectorGraphNativeSearchStats, exactMode bool) {
+	tb.Helper()
+	if stats.BenchmarkDebugSearches != 1 {
+		tb.Fatalf("stats=%+v want one benchmark_debug search", stats)
+	}
+	if stats.VisitedEdges != stats.Edges || stats.UpperLayerEdgeVisits+stats.Layer0EdgeVisits != stats.VisitedEdges {
+		tb.Fatalf("stats=%+v want upper/layer-0 edge buckets to reconcile with visited_edges", stats)
+	}
+	if stats.UpperLayerScores+stats.Layer0Scores != stats.CandidateFetches || stats.ScoreBatchCandidates != stats.CandidateFetches {
+		tb.Fatalf("stats=%+v want score buckets to reconcile with candidate fetches", stats)
+	}
+	if stats.Layer0Scores != stats.Candidates {
+		tb.Fatalf("stats=%+v want layer-0 scores to equal candidate applications", stats)
+	}
+	if stats.Layer0ScoredNeighbors+stats.Layer0AlreadyVisitedSkips+stats.Layer0FilterSkips != stats.Layer0EdgeVisits {
+		tb.Fatalf("stats=%+v want layer-0 scored/skip buckets to reconcile with layer-0 edges", stats)
+	}
+	if stats.UpperLayerScoredNeighbors+stats.UpperLayerFilterSkips != stats.UpperLayerEdgeVisits {
+		tb.Fatalf("stats=%+v want upper-layer scored/filter buckets to reconcile with upper-layer edges", stats)
+	}
+	if stats.ScoredNeighbors+stats.SkippedNeighbors != stats.VisitedEdges {
+		tb.Fatalf("stats=%+v want scored+skipped neighbor buckets to reconcile with visited_edges", stats)
+	}
+	if stats.VisitedMarkHits+stats.VisitedMarkMisses != stats.VisitedMarkChecks || stats.VisitedMarkHits != stats.Layer0AlreadyVisitedSkips {
+		tb.Fatalf("stats=%+v want visited-mark hits/misses to reconcile", stats)
+	}
+	if stats.FrontierPushes != stats.Candidates || stats.TopKInsertAttempts != stats.Candidates || stats.TopKInsertSuccesses+stats.TopKInsertRejections != stats.TopKInsertAttempts {
+		tb.Fatalf("stats=%+v want frontier/top-k operation counts to reconcile with candidates", stats)
+	}
+	if stats.NeighborTileSize0+stats.NeighborTileSize1+stats.NeighborTileSize2To4+stats.NeighborTileSize5To8+stats.NeighborTileSize9To16+stats.NeighborTileSize17Plus != stats.NeighborTiles {
+		tb.Fatalf("stats=%+v want neighbor tile histogram to sum to neighbor_tiles", stats)
+	}
+	if stats.ScoreBatchSingletons+stats.ScoreBatchSize2To4+stats.ScoreBatchSize5To8+stats.ScoreBatchSize9To16+stats.ScoreBatchSize17Plus != stats.ScoreBatchCalls {
+		tb.Fatalf("stats=%+v want score batch histogram to sum to score_batch_calls", stats)
+	}
+	if exactMode {
+		if stats.ExactModeSearches != 1 || stats.ExactCandidateOrderObservations != stats.Candidates {
+			tb.Fatalf("stats=%+v want exact-mode candidate order observations for each candidate", stats)
+		}
+		if stats.ExactCandidateOrderObservations > 0 && stats.ExactCandidateOrderTransitions+1 != stats.ExactCandidateOrderObservations {
+			tb.Fatalf("stats=%+v want exact candidate order transitions to reconcile", stats)
+		}
+		return
+	}
+	if stats.ExactModeSearches != 0 || stats.ExactCandidateOrderObservations != 0 {
+		tb.Fatalf("stats=%+v want exact-mode counters disabled for bounded ef_search", stats)
+	}
+}
+
+func addColumnVectorGraphNativeSearchDebugStats1979(dst *columnVectorGraphNativeSearchStats, src columnVectorGraphNativeSearchStats) {
+	if dst == nil {
+		return
+	}
+	dst.BenchmarkDebugSearches += src.BenchmarkDebugSearches
+	dst.NeighborTiles += src.NeighborTiles
+	dst.NeighborTileNeighbors += src.NeighborTileNeighbors
+	if src.NeighborTileMaxSize > dst.NeighborTileMaxSize {
+		dst.NeighborTileMaxSize = src.NeighborTileMaxSize
+	}
+	dst.NeighborTileSize0 += src.NeighborTileSize0
+	dst.NeighborTileSize1 += src.NeighborTileSize1
+	dst.NeighborTileSize2To4 += src.NeighborTileSize2To4
+	dst.NeighborTileSize5To8 += src.NeighborTileSize5To8
+	dst.NeighborTileSize9To16 += src.NeighborTileSize9To16
+	dst.NeighborTileSize17Plus += src.NeighborTileSize17Plus
+	dst.ScoreBatchSingletons += src.ScoreBatchSingletons
+	dst.ScoreBatchSize2To4 += src.ScoreBatchSize2To4
+	dst.ScoreBatchSize5To8 += src.ScoreBatchSize5To8
+	dst.ScoreBatchSize9To16 += src.ScoreBatchSize9To16
+	dst.ScoreBatchSize17Plus += src.ScoreBatchSize17Plus
+	dst.ScoredNeighbors += src.ScoredNeighbors
+	dst.SkippedNeighbors += src.SkippedNeighbors
+	dst.AlreadyVisitedSkips += src.AlreadyVisitedSkips
+	dst.FilterSkips += src.FilterSkips
+	dst.UpperLayerScores += src.UpperLayerScores
+	dst.UpperLayerEntryScores += src.UpperLayerEntryScores
+	dst.UpperLayerNeighborScores += src.UpperLayerNeighborScores
+	dst.UpperLayerEdgeVisits += src.UpperLayerEdgeVisits
+	dst.UpperLayerScoredNeighbors += src.UpperLayerScoredNeighbors
+	dst.UpperLayerFilterSkips += src.UpperLayerFilterSkips
+	dst.Layer0Scores += src.Layer0Scores
+	dst.Layer0SeedScores += src.Layer0SeedScores
+	dst.Layer0NeighborScores += src.Layer0NeighborScores
+	dst.Layer0EdgeVisits += src.Layer0EdgeVisits
+	dst.Layer0ScoredNeighbors += src.Layer0ScoredNeighbors
+	dst.Layer0AlreadyVisitedSkips += src.Layer0AlreadyVisitedSkips
+	dst.Layer0FilterSkips += src.Layer0FilterSkips
+	dst.FrontierPushes += src.FrontierPushes
+	dst.FrontierPops += src.FrontierPops
+	dst.FrontierPopMisses += src.FrontierPopMisses
+	dst.FrontierSiftUpSteps += src.FrontierSiftUpSteps
+	dst.FrontierSiftDownSteps += src.FrontierSiftDownSteps
+	dst.TopKInsertAttempts += src.TopKInsertAttempts
+	dst.TopKInsertSuccesses += src.TopKInsertSuccesses
+	dst.TopKInsertRejections += src.TopKInsertRejections
+	dst.TopKShiftSteps += src.TopKShiftSteps
+	dst.VisitedMarkChecks += src.VisitedMarkChecks
+	dst.VisitedMarkHits += src.VisitedMarkHits
+	dst.VisitedMarkMisses += src.VisitedMarkMisses
+	dst.ExactModeSearches += src.ExactModeSearches
+	dst.ExactCandidateOrderObservations += src.ExactCandidateOrderObservations
+	dst.ExactCandidateOrderTransitions += src.ExactCandidateOrderTransitions
+	dst.ExactCandidateOrderAdjacentForward += src.ExactCandidateOrderAdjacentForward
+	dst.ExactCandidateOrderNonAdjacentForward += src.ExactCandidateOrderNonAdjacentForward
+	dst.ExactCandidateOrderBackwardJumps += src.ExactCandidateOrderBackwardJumps
+	if src.ExactCandidateOrderMaxForwardRun > dst.ExactCandidateOrderMaxForwardRun {
+		dst.ExactCandidateOrderMaxForwardRun = src.ExactCandidateOrderMaxForwardRun
+	}
+}
+
+func reportColumnVectorGraphNativeSearchDebugMetrics1979(b *testing.B, n int, stats columnVectorGraphNativeSearchStats) {
+	b.Helper()
+	if n <= 0 {
+		return
+	}
+	denom := float64(n)
+	b.ReportMetric(float64(stats.BenchmarkDebugSearches)/denom, "benchmark_debug_searches/search")
+	b.ReportMetric(float64(stats.NeighborTiles)/denom, "neighbor_tiles/search")
+	b.ReportMetric(float64(stats.NeighborTileNeighbors)/denom, "neighbor_tile_neighbors/search")
+	b.ReportMetric(float64(stats.NeighborTileMaxSize), "neighbor_tile_max_size")
+	if stats.NeighborTiles > 0 {
+		b.ReportMetric(float64(stats.NeighborTileNeighbors)/float64(stats.NeighborTiles), "neighbor_tile_avg_size")
+	}
+	b.ReportMetric(float64(stats.NeighborTileSize0)/denom, "neighbor_tile_size_0/search")
+	b.ReportMetric(float64(stats.NeighborTileSize1)/denom, "neighbor_tile_size_1/search")
+	b.ReportMetric(float64(stats.NeighborTileSize2To4)/denom, "neighbor_tile_size_2_4/search")
+	b.ReportMetric(float64(stats.NeighborTileSize5To8)/denom, "neighbor_tile_size_5_8/search")
+	b.ReportMetric(float64(stats.NeighborTileSize9To16)/denom, "neighbor_tile_size_9_16/search")
+	b.ReportMetric(float64(stats.NeighborTileSize17Plus)/denom, "neighbor_tile_size_17_plus/search")
+	b.ReportMetric(float64(stats.ScoreBatchSingletons)/denom, "score_batch_singletons/search")
+	b.ReportMetric(float64(stats.ScoreBatchSize2To4)/denom, "score_batch_size_2_4/search")
+	b.ReportMetric(float64(stats.ScoreBatchSize5To8)/denom, "score_batch_size_5_8/search")
+	b.ReportMetric(float64(stats.ScoreBatchSize9To16)/denom, "score_batch_size_9_16/search")
+	b.ReportMetric(float64(stats.ScoreBatchSize17Plus)/denom, "score_batch_size_17_plus/search")
+	b.ReportMetric(float64(stats.ScoredNeighbors)/denom, "scored_neighbors/search")
+	b.ReportMetric(float64(stats.SkippedNeighbors)/denom, "skipped_neighbors/search")
+	b.ReportMetric(float64(stats.AlreadyVisitedSkips)/denom, "already_visited_skips/search")
+	b.ReportMetric(float64(stats.FilterSkips)/denom, "filter_skips/search")
+	b.ReportMetric(float64(stats.UpperLayerScores)/denom, "upper_layer_scores/search")
+	b.ReportMetric(float64(stats.UpperLayerEntryScores)/denom, "upper_layer_entry_scores/search")
+	b.ReportMetric(float64(stats.UpperLayerNeighborScores)/denom, "upper_layer_neighbor_scores/search")
+	b.ReportMetric(float64(stats.UpperLayerEdgeVisits)/denom, "upper_layer_edge_visits/search")
+	b.ReportMetric(float64(stats.UpperLayerScoredNeighbors)/denom, "upper_layer_scored_neighbors/search")
+	b.ReportMetric(float64(stats.UpperLayerFilterSkips)/denom, "upper_layer_filter_skips/search")
+	b.ReportMetric(float64(stats.Layer0Scores)/denom, "layer0_scores/search")
+	b.ReportMetric(float64(stats.Layer0SeedScores)/denom, "layer0_seed_scores/search")
+	b.ReportMetric(float64(stats.Layer0NeighborScores)/denom, "layer0_neighbor_scores/search")
+	b.ReportMetric(float64(stats.Layer0EdgeVisits)/denom, "layer0_edge_visits/search")
+	b.ReportMetric(float64(stats.Layer0ScoredNeighbors)/denom, "layer0_scored_neighbors/search")
+	b.ReportMetric(float64(stats.Layer0AlreadyVisitedSkips)/denom, "layer0_already_visited_skips/search")
+	b.ReportMetric(float64(stats.Layer0FilterSkips)/denom, "layer0_filter_skips/search")
+	b.ReportMetric(float64(stats.FrontierPushes)/denom, "frontier_pushes/search")
+	b.ReportMetric(float64(stats.FrontierPops)/denom, "frontier_pops/search")
+	b.ReportMetric(float64(stats.FrontierPopMisses)/denom, "frontier_pop_misses/search")
+	b.ReportMetric(float64(stats.FrontierSiftUpSteps)/denom, "frontier_sift_up_steps/search")
+	b.ReportMetric(float64(stats.FrontierSiftDownSteps)/denom, "frontier_sift_down_steps/search")
+	b.ReportMetric(float64(stats.TopKInsertAttempts)/denom, "top_k_insert_attempts/search")
+	b.ReportMetric(float64(stats.TopKInsertSuccesses)/denom, "top_k_insert_successes/search")
+	b.ReportMetric(float64(stats.TopKInsertRejections)/denom, "top_k_insert_rejections/search")
+	b.ReportMetric(float64(stats.TopKShiftSteps)/denom, "top_k_shift_steps/search")
+	b.ReportMetric(float64(stats.VisitedMarkChecks)/denom, "visited_mark_checks/search")
+	b.ReportMetric(float64(stats.VisitedMarkHits)/denom, "visited_mark_hits/search")
+	b.ReportMetric(float64(stats.VisitedMarkMisses)/denom, "visited_mark_misses/search")
+	b.ReportMetric(float64(stats.ExactModeSearches)/denom, "exact_mode_searches/search")
+	b.ReportMetric(float64(stats.ExactCandidateOrderObservations)/denom, "exact_candidate_order_observations/search")
+	b.ReportMetric(float64(stats.ExactCandidateOrderTransitions)/denom, "exact_candidate_order_transitions/search")
+	b.ReportMetric(float64(stats.ExactCandidateOrderAdjacentForward)/denom, "exact_candidate_order_adjacent_forward/search")
+	b.ReportMetric(float64(stats.ExactCandidateOrderNonAdjacentForward)/denom, "exact_candidate_order_non_adjacent_forward/search")
+	b.ReportMetric(float64(stats.ExactCandidateOrderBackwardJumps)/denom, "exact_candidate_order_backward_jumps/search")
+	b.ReportMetric(float64(stats.ExactCandidateOrderMaxForwardRun), "exact_candidate_order_max_forward_run")
+	if stats.VisitedNodes > 0 {
+		b.ReportMetric(float64(stats.VisitedEdges)/float64(stats.VisitedNodes), "edges_per_visited_node")
+	}
+}

--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -1026,7 +1026,13 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 	}
 	nextSeed := 0
 	for loopCounters.Candidates < candidateLimit {
-		candidate, ok := scratch.popFrontier(debugCounters)
+		var candidate columnVectorGraphSearchCandidate
+		var ok bool
+		if debugCounters != nil {
+			candidate, ok = scratch.popFrontierDebug(debugCounters)
+		} else {
+			candidate, ok = scratch.popFrontier()
+		}
 		if !ok {
 			seed, ok := columnVectorGraphNextCandidateSeed(nextSeed, rowCount, candidateRows, hasCandidateRows, visitMarks, visitEpoch)
 			if !ok {
@@ -1460,8 +1466,13 @@ func (r *columnVectorGraphPhysicalRowReader) scoreAndPushFrontierVisited(plan *c
 		ordinal: ordinal,
 		score:   score,
 	}
-	scratch.insertTop(topK, candidate, debugCounters)
-	scratch.pushFrontier(candidate, debugCounters)
+	if debugCounters != nil {
+		scratch.insertTopDebug(topK, candidate, debugCounters)
+		scratch.pushFrontierDebug(candidate, debugCounters)
+	} else {
+		scratch.insertTop(topK, candidate)
+		scratch.pushFrontier(candidate)
+	}
 	return nil
 }
 
@@ -1481,8 +1492,13 @@ func (r *columnVectorGraphPhysicalRowReader) scoreAndPushFrontierVisitedTile(pla
 	for i, ordinal := range ordinals {
 		loopCounters.recordCandidate()
 		candidate := columnVectorGraphSearchCandidate{ordinal: ordinal, score: scores[i]}
-		scratch.insertTop(topK, candidate, debugCounters)
-		scratch.pushFrontier(candidate, debugCounters)
+		if debugCounters != nil {
+			scratch.insertTopDebug(topK, candidate, debugCounters)
+			scratch.pushFrontierDebug(candidate, debugCounters)
+		} else {
+			scratch.insertTop(topK, candidate)
+			scratch.pushFrontier(candidate)
+		}
 	}
 	return nil
 }
@@ -1833,23 +1849,20 @@ func (s *columnVectorGraphNativeSearchScratch) markVisited(ordinal int) bool {
 	return true
 }
 
-func (s *columnVectorGraphNativeSearchScratch) pushFrontier(candidate columnVectorGraphSearchCandidate, debugCounters *columnVectorGraphNativeSearchDebugCounters) {
-	if debugCounters != nil && debugCounters.stats != nil {
-		debugCounters.stats.FrontierPushes++
-	}
+func (s *columnVectorGraphNativeSearchScratch) pushFrontier(candidate columnVectorGraphSearchCandidate) {
 	s.frontier = append(s.frontier, candidate)
-	s.frontierSiftUp(len(s.frontier)-1, debugCounters)
+	s.frontierSiftUp(len(s.frontier) - 1)
 }
 
-func (s *columnVectorGraphNativeSearchScratch) popFrontier(debugCounters *columnVectorGraphNativeSearchDebugCounters) (columnVectorGraphSearchCandidate, bool) {
+func (s *columnVectorGraphNativeSearchScratch) pushFrontierDebug(candidate columnVectorGraphSearchCandidate, debugCounters *columnVectorGraphNativeSearchDebugCounters) {
+	debugCounters.stats.FrontierPushes++
+	s.frontier = append(s.frontier, candidate)
+	s.frontierSiftUpDebug(len(s.frontier)-1, debugCounters)
+}
+
+func (s *columnVectorGraphNativeSearchScratch) popFrontier() (columnVectorGraphSearchCandidate, bool) {
 	if len(s.frontier) == 0 {
-		if debugCounters != nil && debugCounters.stats != nil {
-			debugCounters.stats.FrontierPopMisses++
-		}
 		return columnVectorGraphSearchCandidate{}, false
-	}
-	if debugCounters != nil && debugCounters.stats != nil {
-		debugCounters.stats.FrontierPops++
 	}
 	lastIdx := len(s.frontier) - 1
 	best := s.frontier[0]
@@ -1857,26 +1870,52 @@ func (s *columnVectorGraphNativeSearchScratch) popFrontier(debugCounters *column
 	s.frontier = s.frontier[:lastIdx]
 	if len(s.frontier) > 0 {
 		s.frontier[0] = last
-		s.frontierSiftDown(0, debugCounters)
+		s.frontierSiftDown(0)
 	}
 	return best, true
 }
 
-func (s *columnVectorGraphNativeSearchScratch) frontierSiftUp(idx int, debugCounters *columnVectorGraphNativeSearchDebugCounters) {
+func (s *columnVectorGraphNativeSearchScratch) popFrontierDebug(debugCounters *columnVectorGraphNativeSearchDebugCounters) (columnVectorGraphSearchCandidate, bool) {
+	if len(s.frontier) == 0 {
+		debugCounters.stats.FrontierPopMisses++
+		return columnVectorGraphSearchCandidate{}, false
+	}
+	debugCounters.stats.FrontierPops++
+	lastIdx := len(s.frontier) - 1
+	best := s.frontier[0]
+	last := s.frontier[lastIdx]
+	s.frontier = s.frontier[:lastIdx]
+	if len(s.frontier) > 0 {
+		s.frontier[0] = last
+		s.frontierSiftDownDebug(0, debugCounters)
+	}
+	return best, true
+}
+
+func (s *columnVectorGraphNativeSearchScratch) frontierSiftUp(idx int) {
 	for idx > 0 {
 		parent := (idx - 1) / 2
 		if !columnVectorGraphSearchCandidateBetter(s.frontier[idx], s.frontier[parent]) {
 			return
-		}
-		if debugCounters != nil && debugCounters.stats != nil {
-			debugCounters.stats.FrontierSiftUpSteps++
 		}
 		s.frontier[idx], s.frontier[parent] = s.frontier[parent], s.frontier[idx]
 		idx = parent
 	}
 }
 
-func (s *columnVectorGraphNativeSearchScratch) frontierSiftDown(idx int, debugCounters *columnVectorGraphNativeSearchDebugCounters) {
+func (s *columnVectorGraphNativeSearchScratch) frontierSiftUpDebug(idx int, debugCounters *columnVectorGraphNativeSearchDebugCounters) {
+	for idx > 0 {
+		parent := (idx - 1) / 2
+		if !columnVectorGraphSearchCandidateBetter(s.frontier[idx], s.frontier[parent]) {
+			return
+		}
+		debugCounters.stats.FrontierSiftUpSteps++
+		s.frontier[idx], s.frontier[parent] = s.frontier[parent], s.frontier[idx]
+		idx = parent
+	}
+}
+
+func (s *columnVectorGraphNativeSearchScratch) frontierSiftDown(idx int) {
 	for {
 		left := idx*2 + 1
 		if left >= len(s.frontier) {
@@ -1889,22 +1928,32 @@ func (s *columnVectorGraphNativeSearchScratch) frontierSiftDown(idx int, debugCo
 		if !columnVectorGraphSearchCandidateBetter(s.frontier[child], s.frontier[idx]) {
 			return
 		}
-		if debugCounters != nil && debugCounters.stats != nil {
-			debugCounters.stats.FrontierSiftDownSteps++
-		}
 		s.frontier[idx], s.frontier[child] = s.frontier[child], s.frontier[idx]
 		idx = child
 	}
 }
 
-func (s *columnVectorGraphNativeSearchScratch) insertTop(limit int, candidate columnVectorGraphSearchCandidate, debugCounters *columnVectorGraphNativeSearchDebugCounters) {
-	if debugCounters != nil && debugCounters.stats != nil {
-		debugCounters.stats.TopKInsertAttempts++
-	}
-	if limit <= 0 {
-		if debugCounters != nil && debugCounters.stats != nil {
-			debugCounters.stats.TopKInsertRejections++
+func (s *columnVectorGraphNativeSearchScratch) frontierSiftDownDebug(idx int, debugCounters *columnVectorGraphNativeSearchDebugCounters) {
+	for {
+		left := idx*2 + 1
+		if left >= len(s.frontier) {
+			return
 		}
+		child := left
+		if right := left + 1; right < len(s.frontier) && columnVectorGraphSearchCandidateBetter(s.frontier[right], s.frontier[left]) {
+			child = right
+		}
+		if !columnVectorGraphSearchCandidateBetter(s.frontier[child], s.frontier[idx]) {
+			return
+		}
+		debugCounters.stats.FrontierSiftDownSteps++
+		s.frontier[idx], s.frontier[child] = s.frontier[child], s.frontier[idx]
+		idx = child
+	}
+}
+
+func (s *columnVectorGraphNativeSearchScratch) insertTop(limit int, candidate columnVectorGraphSearchCandidate) {
+	if limit <= 0 {
 		return
 	}
 	pos := len(s.top)
@@ -1912,19 +1961,35 @@ func (s *columnVectorGraphNativeSearchScratch) insertTop(limit int, candidate co
 		pos--
 	}
 	if pos >= limit {
-		if debugCounters != nil && debugCounters.stats != nil {
-			debugCounters.stats.TopKInsertRejections++
-		}
 		return
 	}
-	if debugCounters != nil && debugCounters.stats != nil {
-		debugCounters.stats.TopKInsertSuccesses++
-		shiftSteps := len(s.top) - pos
-		if len(s.top) >= limit && shiftSteps > 0 {
-			shiftSteps--
-		}
-		debugCounters.stats.TopKShiftSteps += uint64(shiftSteps)
+	if len(s.top) < limit {
+		s.top = append(s.top, columnVectorGraphSearchCandidate{})
 	}
+	copy(s.top[pos+1:], s.top[pos:len(s.top)-1])
+	s.top[pos] = candidate
+}
+
+func (s *columnVectorGraphNativeSearchScratch) insertTopDebug(limit int, candidate columnVectorGraphSearchCandidate, debugCounters *columnVectorGraphNativeSearchDebugCounters) {
+	debugCounters.stats.TopKInsertAttempts++
+	if limit <= 0 {
+		debugCounters.stats.TopKInsertRejections++
+		return
+	}
+	pos := len(s.top)
+	for pos > 0 && columnVectorGraphSearchCandidateBetter(candidate, s.top[pos-1]) {
+		pos--
+	}
+	if pos >= limit {
+		debugCounters.stats.TopKInsertRejections++
+		return
+	}
+	debugCounters.stats.TopKInsertSuccesses++
+	shiftSteps := len(s.top) - pos
+	if len(s.top) >= limit && shiftSteps > 0 {
+		shiftSteps--
+	}
+	debugCounters.stats.TopKShiftSteps += uint64(shiftSteps)
 	if len(s.top) < limit {
 		s.top = append(s.top, columnVectorGraphSearchCandidate{})
 	}

--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -260,6 +260,67 @@ type columnVectorGraphNativeSearchStats struct {
 	ResultIDStateValidationFailures      uint64
 	PreparedGraphSearchViews             uint64
 	GraphRowFallbacks                    uint64
+
+	// Benchmark/debug-only HNSW control-flow counters. These are populated only
+	// when columnVectorGraphNativeSearchStatsModeBenchmarkDebug is selected so
+	// steady-state full/minimal stats avoid the detailed counter increments.
+	BenchmarkDebugSearches uint64
+
+	NeighborTiles          uint64
+	NeighborTileNeighbors  uint64
+	NeighborTileMaxSize    uint64
+	NeighborTileSize0      uint64
+	NeighborTileSize1      uint64
+	NeighborTileSize2To4   uint64
+	NeighborTileSize5To8   uint64
+	NeighborTileSize9To16  uint64
+	NeighborTileSize17Plus uint64
+
+	ScoreBatchSingletons      uint64
+	ScoreBatchSize2To4        uint64
+	ScoreBatchSize5To8        uint64
+	ScoreBatchSize9To16       uint64
+	ScoreBatchSize17Plus      uint64
+	ScoredNeighbors           uint64
+	SkippedNeighbors          uint64
+	AlreadyVisitedSkips       uint64
+	FilterSkips               uint64
+	UpperLayerScores          uint64
+	UpperLayerEntryScores     uint64
+	UpperLayerNeighborScores  uint64
+	UpperLayerEdgeVisits      uint64
+	UpperLayerScoredNeighbors uint64
+	UpperLayerFilterSkips     uint64
+	Layer0Scores              uint64
+	Layer0SeedScores          uint64
+	Layer0NeighborScores      uint64
+	Layer0EdgeVisits          uint64
+	Layer0ScoredNeighbors     uint64
+	Layer0AlreadyVisitedSkips uint64
+	Layer0FilterSkips         uint64
+
+	FrontierPushes        uint64
+	FrontierPops          uint64
+	FrontierPopMisses     uint64
+	FrontierSiftUpSteps   uint64
+	FrontierSiftDownSteps uint64
+
+	TopKInsertAttempts   uint64
+	TopKInsertSuccesses  uint64
+	TopKInsertRejections uint64
+	TopKShiftSteps       uint64
+
+	VisitedMarkChecks uint64
+	VisitedMarkHits   uint64
+	VisitedMarkMisses uint64
+
+	ExactModeSearches                     uint64
+	ExactCandidateOrderObservations       uint64
+	ExactCandidateOrderTransitions        uint64
+	ExactCandidateOrderAdjacentForward    uint64
+	ExactCandidateOrderNonAdjacentForward uint64
+	ExactCandidateOrderBackwardJumps      uint64
+	ExactCandidateOrderMaxForwardRun      uint64
 }
 
 type columnVectorGraphNativeSearchLoopCounters struct {
@@ -290,6 +351,213 @@ func (c *columnVectorGraphNativeSearchLoopCounters) publish(stats *columnVectorG
 	stats.Candidates += c.Candidates
 	stats.Edges += c.Edges
 	stats.VisitedEdges += c.VisitedEdges
+}
+
+type columnVectorGraphNativeSearchScoreContext uint8
+
+const (
+	columnVectorGraphNativeSearchScoreContextUpperEntry columnVectorGraphNativeSearchScoreContext = iota
+	columnVectorGraphNativeSearchScoreContextUpperNeighbor
+	columnVectorGraphNativeSearchScoreContextLayer0Seed
+	columnVectorGraphNativeSearchScoreContextLayer0Neighbor
+)
+
+type columnVectorGraphNativeSearchDebugCounters struct {
+	stats *columnVectorGraphNativeSearchStats
+
+	exactMode              bool
+	exactOrderStarted      bool
+	exactLastOrdinal       int
+	exactCurrentForwardRun uint64
+}
+
+func newColumnVectorGraphNativeSearchDebugCounters(stats *columnVectorGraphNativeSearchStats, exactMode bool) *columnVectorGraphNativeSearchDebugCounters {
+	if stats == nil {
+		return nil
+	}
+	stats.BenchmarkDebugSearches = 1
+	if exactMode {
+		stats.ExactModeSearches = 1
+	}
+	return &columnVectorGraphNativeSearchDebugCounters{stats: stats, exactMode: exactMode}
+}
+
+func (d *columnVectorGraphNativeSearchDebugCounters) recordNeighborTile(size int) {
+	if d == nil || d.stats == nil {
+		return
+	}
+	if size < 0 {
+		size = 0
+	}
+	s := d.stats
+	s.NeighborTiles++
+	s.NeighborTileNeighbors += uint64(size)
+	if uint64(size) > s.NeighborTileMaxSize {
+		s.NeighborTileMaxSize = uint64(size)
+	}
+	switch {
+	case size == 0:
+		s.NeighborTileSize0++
+	case size == 1:
+		s.NeighborTileSize1++
+	case size <= 4:
+		s.NeighborTileSize2To4++
+	case size <= 8:
+		s.NeighborTileSize5To8++
+	case size <= 16:
+		s.NeighborTileSize9To16++
+	default:
+		s.NeighborTileSize17Plus++
+	}
+}
+
+func recordColumnVectorGraphScoreBatchDebugStats(stats *columnVectorGraphNativeSearchStats, tileSize int) {
+	if stats == nil || stats.BenchmarkDebugSearches == 0 || tileSize <= 0 {
+		return
+	}
+	switch {
+	case tileSize == 1:
+		stats.ScoreBatchSingletons++
+	case tileSize <= 4:
+		stats.ScoreBatchSize2To4++
+	case tileSize <= 8:
+		stats.ScoreBatchSize5To8++
+	case tileSize <= 16:
+		stats.ScoreBatchSize9To16++
+	default:
+		stats.ScoreBatchSize17Plus++
+	}
+}
+
+func (d *columnVectorGraphNativeSearchDebugCounters) recordUpperLayerEdge() {
+	if d == nil || d.stats == nil {
+		return
+	}
+	d.stats.UpperLayerEdgeVisits++
+}
+
+func (d *columnVectorGraphNativeSearchDebugCounters) recordLayer0Edge() {
+	if d == nil || d.stats == nil {
+		return
+	}
+	d.stats.Layer0EdgeVisits++
+}
+
+func (d *columnVectorGraphNativeSearchDebugCounters) recordFilterSkip(layer0 bool) {
+	if d == nil || d.stats == nil {
+		return
+	}
+	s := d.stats
+	s.FilterSkips++
+	s.SkippedNeighbors++
+	if layer0 {
+		s.Layer0FilterSkips++
+	} else {
+		s.UpperLayerFilterSkips++
+	}
+}
+
+func (d *columnVectorGraphNativeSearchDebugCounters) recordAlreadyVisitedSkip() {
+	if d == nil || d.stats == nil {
+		return
+	}
+	s := d.stats
+	s.AlreadyVisitedSkips++
+	s.SkippedNeighbors++
+	s.Layer0AlreadyVisitedSkips++
+}
+
+func (d *columnVectorGraphNativeSearchDebugCounters) recordVisitedMark(hit bool) {
+	if d == nil || d.stats == nil {
+		return
+	}
+	d.stats.VisitedMarkChecks++
+	if hit {
+		d.stats.VisitedMarkHits++
+		return
+	}
+	d.stats.VisitedMarkMisses++
+}
+
+func (d *columnVectorGraphNativeSearchDebugCounters) recordScores(context columnVectorGraphNativeSearchScoreContext, ordinals []int) {
+	if d == nil || d.stats == nil || len(ordinals) == 0 {
+		return
+	}
+	d.recordScoresCount(context, len(ordinals))
+	if context == columnVectorGraphNativeSearchScoreContextLayer0Seed || context == columnVectorGraphNativeSearchScoreContextLayer0Neighbor {
+		for _, ordinal := range ordinals {
+			d.recordExactCandidateOrder(ordinal)
+		}
+	}
+}
+
+func (d *columnVectorGraphNativeSearchDebugCounters) recordScore(context columnVectorGraphNativeSearchScoreContext, ordinal int) {
+	if d == nil || d.stats == nil {
+		return
+	}
+	d.recordScoresCount(context, 1)
+	if context == columnVectorGraphNativeSearchScoreContextLayer0Seed || context == columnVectorGraphNativeSearchScoreContextLayer0Neighbor {
+		d.recordExactCandidateOrder(ordinal)
+	}
+}
+
+func (d *columnVectorGraphNativeSearchDebugCounters) recordScoresCount(context columnVectorGraphNativeSearchScoreContext, count int) {
+	if d == nil || d.stats == nil || count <= 0 {
+		return
+	}
+	s := d.stats
+	count64 := uint64(count)
+	switch context {
+	case columnVectorGraphNativeSearchScoreContextUpperEntry:
+		s.UpperLayerScores += count64
+		s.UpperLayerEntryScores += count64
+	case columnVectorGraphNativeSearchScoreContextUpperNeighbor:
+		s.UpperLayerScores += count64
+		s.UpperLayerNeighborScores += count64
+		s.UpperLayerScoredNeighbors += count64
+		s.ScoredNeighbors += count64
+	case columnVectorGraphNativeSearchScoreContextLayer0Seed:
+		s.Layer0Scores += count64
+		s.Layer0SeedScores += count64
+	case columnVectorGraphNativeSearchScoreContextLayer0Neighbor:
+		s.Layer0Scores += count64
+		s.Layer0NeighborScores += count64
+		s.Layer0ScoredNeighbors += count64
+		s.ScoredNeighbors += count64
+	}
+}
+
+func (d *columnVectorGraphNativeSearchDebugCounters) recordExactCandidateOrder(ordinal int) {
+	if d == nil || d.stats == nil || !d.exactMode {
+		return
+	}
+	s := d.stats
+	s.ExactCandidateOrderObservations++
+	if !d.exactOrderStarted {
+		d.exactOrderStarted = true
+		d.exactLastOrdinal = ordinal
+		d.exactCurrentForwardRun = 1
+		if s.ExactCandidateOrderMaxForwardRun < 1 {
+			s.ExactCandidateOrderMaxForwardRun = 1
+		}
+		return
+	}
+	s.ExactCandidateOrderTransitions++
+	switch {
+	case ordinal == d.exactLastOrdinal+1:
+		s.ExactCandidateOrderAdjacentForward++
+		d.exactCurrentForwardRun++
+		if d.exactCurrentForwardRun > s.ExactCandidateOrderMaxForwardRun {
+			s.ExactCandidateOrderMaxForwardRun = d.exactCurrentForwardRun
+		}
+	case ordinal > d.exactLastOrdinal:
+		s.ExactCandidateOrderNonAdjacentForward++
+		d.exactCurrentForwardRun = 1
+	default:
+		s.ExactCandidateOrderBackwardJumps++
+		d.exactCurrentForwardRun = 1
+	}
+	d.exactLastOrdinal = ordinal
 }
 
 type columnVectorGraphPreparedMinimalSearchCounters struct {
@@ -692,9 +960,14 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 	}
 
 	statsMode := opts.StatsMode.normalized()
+	candidateLimit := uint64(efSearch)
 	var plan *columnVectorGraphSearchPlan
 	var loopCounters columnVectorGraphNativeSearchLoopCounters
 	var preparedMinimalCounters *columnVectorGraphPreparedMinimalSearchCounters
+	var debugCounters *columnVectorGraphNativeSearchDebugCounters
+	if statsMode == columnVectorGraphNativeSearchStatsModeBenchmarkDebug {
+		debugCounters = newColumnVectorGraphNativeSearchDebugCounters(&stats, candidateLimit == uint64(candidateRowCount))
+	}
 	defer func() {
 		loopCounters.publish(&stats)
 		if preparedMinimalCounters != nil {
@@ -742,19 +1015,18 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 		return nil, stats, err
 	}
 	for layer := maxLayer; layer > 0; layer-- {
-		entryOrdinal, err = r.greedyNearestAtLayer(plan, singleBlockView, query, queryInvNorm, entryOrdinal, layer, candidateRows, hasCandidateRows, scratch, hotStats, &loopCounters, preparedMinimalCounters)
+		entryOrdinal, err = r.greedyNearestAtLayer(plan, singleBlockView, query, queryInvNorm, entryOrdinal, layer, candidateRows, hasCandidateRows, scratch, hotStats, &loopCounters, preparedMinimalCounters, debugCounters)
 		if err != nil {
 			return nil, stats, err
 		}
 	}
 	visitMarks[entryOrdinal] = visitEpoch
-	if err := r.scoreAndPushFrontierVisited(plan, singleBlockView, query, queryInvNorm, entryOrdinal, topK, scratch, hotStats, &loopCounters, preparedMinimalCounters); err != nil {
+	if err := r.scoreAndPushFrontierVisited(plan, singleBlockView, query, queryInvNorm, entryOrdinal, topK, scratch, hotStats, &loopCounters, preparedMinimalCounters, debugCounters, columnVectorGraphNativeSearchScoreContextLayer0Seed); err != nil {
 		return nil, stats, err
 	}
 	nextSeed := 0
-	candidateLimit := uint64(efSearch)
 	for loopCounters.Candidates < candidateLimit {
-		candidate, ok := scratch.popFrontier()
+		candidate, ok := scratch.popFrontier(debugCounters)
 		if !ok {
 			seed, ok := columnVectorGraphNextCandidateSeed(nextSeed, rowCount, candidateRows, hasCandidateRows, visitMarks, visitEpoch)
 			if !ok {
@@ -762,12 +1034,12 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 			}
 			nextSeed = seed + 1
 			visitMarks[seed] = visitEpoch
-			if err := r.scoreAndPushFrontierVisited(plan, singleBlockView, query, queryInvNorm, seed, topK, scratch, hotStats, &loopCounters, preparedMinimalCounters); err != nil {
+			if err := r.scoreAndPushFrontierVisited(plan, singleBlockView, query, queryInvNorm, seed, topK, scratch, hotStats, &loopCounters, preparedMinimalCounters, debugCounters, columnVectorGraphNativeSearchScoreContextLayer0Seed); err != nil {
 				return nil, stats, err
 			}
 			continue
 		}
-		adjacency, err := r.expandCandidateAdjacencyLayer(plan, singleBlockView, candidate.ordinal, 0, scratch, hotStats, preparedMinimalCounters)
+		adjacency, err := r.expandCandidateAdjacencyLayer(plan, singleBlockView, candidate.ordinal, 0, scratch, hotStats, preparedMinimalCounters, debugCounters)
 		if err != nil {
 			return nil, stats, err
 		}
@@ -788,14 +1060,19 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 					neighbor := adjacency[i]
 					i++
 					loopCounters.recordEdge()
+					debugCounters.recordLayer0Edge()
 					if uint64(neighbor) >= uint64(rowCount) {
 						return nil, stats, fmt.Errorf("collections: column_graph %q ordinal=%d adjacency[%d]=%d outside row_count=%d: %w", r.def.Name, candidate.ordinal, neighborIndex, neighbor, rowCount, errColumnVectorGraphAdjacencyOrdinalOutOfBounds)
 					}
 					neighborOrdinal := int(neighbor)
 					if visitMarks[neighborOrdinal] == visitEpoch {
+						debugCounters.recordVisitedMark(true)
+						debugCounters.recordAlreadyVisitedSkip()
 						continue
 					}
+					debugCounters.recordVisitedMark(false)
 					if !columnVectorGraphCandidateRowAllowed(candidateRows, hasCandidateRows, neighborOrdinal) {
+						debugCounters.recordFilterSkip(true)
 						visitMarks[neighborOrdinal] = visitEpoch
 						continue
 					}
@@ -805,7 +1082,7 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 				if len(tile) == 0 {
 					continue
 				}
-				if err := r.scoreAndPushFrontierVisitedTile(plan, singleBlockView, query, queryInvNorm, tile, topK, scratch, hotStats, &loopCounters, preparedMinimalCounters); err != nil {
+				if err := r.scoreAndPushFrontierVisitedTile(plan, singleBlockView, query, queryInvNorm, tile, topK, scratch, hotStats, &loopCounters, preparedMinimalCounters, debugCounters, columnVectorGraphNativeSearchScoreContextLayer0Neighbor); err != nil {
 					return nil, stats, err
 				}
 			}
@@ -816,19 +1093,24 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 				break
 			}
 			loopCounters.recordEdge()
+			debugCounters.recordLayer0Edge()
 			if uint64(neighbor) >= uint64(rowCount) {
 				return nil, stats, fmt.Errorf("collections: column_graph %q ordinal=%d adjacency[%d]=%d outside row_count=%d: %w", r.def.Name, candidate.ordinal, i, neighbor, rowCount, errColumnVectorGraphAdjacencyOrdinalOutOfBounds)
 			}
 			neighborOrdinal := int(neighbor)
 			if visitMarks[neighborOrdinal] == visitEpoch {
+				debugCounters.recordVisitedMark(true)
+				debugCounters.recordAlreadyVisitedSkip()
 				continue
 			}
+			debugCounters.recordVisitedMark(false)
 			if !columnVectorGraphCandidateRowAllowed(candidateRows, hasCandidateRows, neighborOrdinal) {
+				debugCounters.recordFilterSkip(true)
 				visitMarks[neighborOrdinal] = visitEpoch
 				continue
 			}
 			visitMarks[neighborOrdinal] = visitEpoch
-			if err := r.scoreAndPushFrontierVisited(plan, singleBlockView, query, queryInvNorm, neighborOrdinal, topK, scratch, hotStats, &loopCounters, preparedMinimalCounters); err != nil {
+			if err := r.scoreAndPushFrontierVisited(plan, singleBlockView, query, queryInvNorm, neighborOrdinal, topK, scratch, hotStats, &loopCounters, preparedMinimalCounters, debugCounters, columnVectorGraphNativeSearchScoreContextLayer0Neighbor); err != nil {
 				return nil, stats, err
 			}
 		}
@@ -922,19 +1204,20 @@ func (r *columnVectorGraphPhysicalRowReader) maxAdjacencyLayer(plan *columnVecto
 	return columnVectorGraphAdjacencyMaxLayer(adjacency)
 }
 
-func (r *columnVectorGraphPhysicalRowReader) greedyNearestAtLayer(plan *columnVectorGraphSearchPlan, singleBlockView *columnVectorGraphBlockView, query []float32, queryInvNorm float32, entryOrdinal int, layer int, candidateRows typedcolumn.RowSelection, hasCandidateRows bool, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats, loopCounters *columnVectorGraphNativeSearchLoopCounters, preparedMinimal *columnVectorGraphPreparedMinimalSearchCounters) (int, error) {
+func (r *columnVectorGraphPhysicalRowReader) greedyNearestAtLayer(plan *columnVectorGraphSearchPlan, singleBlockView *columnVectorGraphBlockView, query []float32, queryInvNorm float32, entryOrdinal int, layer int, candidateRows typedcolumn.RowSelection, hasCandidateRows bool, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats, loopCounters *columnVectorGraphNativeSearchLoopCounters, preparedMinimal *columnVectorGraphPreparedMinimalSearchCounters, debugCounters *columnVectorGraphNativeSearchDebugCounters) (int, error) {
 	best := entryOrdinal
 	bestScore, err := r.scoreOrdinal(plan, singleBlockView, query, queryInvNorm, best, scratch, stats)
 	if err != nil {
 		return 0, err
 	}
+	debugCounters.recordScore(columnVectorGraphNativeSearchScoreContextUpperEntry, best)
 	if preparedMinimal != nil {
 		preparedMinimal.recordPreparedScores(1, true)
 	}
 	changed := true
 	for changed {
 		changed = false
-		adjacency, err := r.expandCandidateAdjacencyLayer(plan, singleBlockView, best, layer, scratch, stats, preparedMinimal)
+		adjacency, err := r.expandCandidateAdjacencyLayer(plan, singleBlockView, best, layer, scratch, stats, preparedMinimal, debugCounters)
 		if err != nil {
 			return 0, err
 		}
@@ -943,11 +1226,13 @@ func (r *columnVectorGraphPhysicalRowReader) greedyNearestAtLayer(plan *columnVe
 			tile := scratch.scoreTileOrdinals[:0]
 			for i, neighbor := range adjacency {
 				loopCounters.recordEdge()
+				debugCounters.recordUpperLayerEdge()
 				if uint64(neighbor) >= uint64(r.RowCount()) {
 					return 0, fmt.Errorf("collections: column_graph %q ordinal=%d adjacency[%d]=%d outside row_count=%d: %w", r.def.Name, best, i, neighbor, r.RowCount(), errColumnVectorGraphAdjacencyOrdinalOutOfBounds)
 				}
 				neighborOrdinal := int(neighbor)
 				if !columnVectorGraphCandidateRowAllowed(candidateRows, hasCandidateRows, neighborOrdinal) {
+					debugCounters.recordFilterSkip(false)
 					continue
 				}
 				tile = append(tile, neighborOrdinal)
@@ -960,6 +1245,7 @@ func (r *columnVectorGraphPhysicalRowReader) greedyNearestAtLayer(plan *columnVe
 			if err != nil {
 				return 0, err
 			}
+			debugCounters.recordScores(columnVectorGraphNativeSearchScoreContextUpperNeighbor, tile)
 			if preparedMinimal != nil {
 				preparedMinimal.recordPreparedScores(len(tile), len(tile) <= 1)
 			}
@@ -975,17 +1261,20 @@ func (r *columnVectorGraphPhysicalRowReader) greedyNearestAtLayer(plan *columnVe
 		}
 		for i, neighbor := range adjacency {
 			loopCounters.recordEdge()
+			debugCounters.recordUpperLayerEdge()
 			if uint64(neighbor) >= uint64(r.RowCount()) {
 				return 0, fmt.Errorf("collections: column_graph %q ordinal=%d adjacency[%d]=%d outside row_count=%d: %w", r.def.Name, best, i, neighbor, r.RowCount(), errColumnVectorGraphAdjacencyOrdinalOutOfBounds)
 			}
 			neighborOrdinal := int(neighbor)
 			if !columnVectorGraphCandidateRowAllowed(candidateRows, hasCandidateRows, neighborOrdinal) {
+				debugCounters.recordFilterSkip(false)
 				continue
 			}
 			score, err := r.scoreOrdinal(plan, singleBlockView, query, queryInvNorm, neighborOrdinal, scratch, stats)
 			if err != nil {
 				return 0, err
 			}
+			debugCounters.recordScore(columnVectorGraphNativeSearchScoreContextUpperNeighbor, neighborOrdinal)
 			if preparedMinimal != nil {
 				preparedMinimal.recordPreparedScores(1, true)
 			}
@@ -1157,11 +1446,12 @@ func sortColumnVectorGraphResultOrderByOrdinal(order []int, top []columnVectorGr
 	})
 }
 
-func (r *columnVectorGraphPhysicalRowReader) scoreAndPushFrontierVisited(plan *columnVectorGraphSearchPlan, singleBlockView *columnVectorGraphBlockView, query []float32, queryInvNorm float32, ordinal, topK int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats, loopCounters *columnVectorGraphNativeSearchLoopCounters, preparedMinimal *columnVectorGraphPreparedMinimalSearchCounters) error {
+func (r *columnVectorGraphPhysicalRowReader) scoreAndPushFrontierVisited(plan *columnVectorGraphSearchPlan, singleBlockView *columnVectorGraphBlockView, query []float32, queryInvNorm float32, ordinal, topK int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats, loopCounters *columnVectorGraphNativeSearchLoopCounters, preparedMinimal *columnVectorGraphPreparedMinimalSearchCounters, debugCounters *columnVectorGraphNativeSearchDebugCounters, scoreContext columnVectorGraphNativeSearchScoreContext) error {
 	score, err := r.scoreOrdinal(plan, singleBlockView, query, queryInvNorm, ordinal, scratch, stats)
 	if err != nil {
 		return err
 	}
+	debugCounters.recordScore(scoreContext, ordinal)
 	if preparedMinimal != nil {
 		preparedMinimal.recordPreparedScores(1, true)
 	}
@@ -1170,12 +1460,12 @@ func (r *columnVectorGraphPhysicalRowReader) scoreAndPushFrontierVisited(plan *c
 		ordinal: ordinal,
 		score:   score,
 	}
-	scratch.insertTop(topK, candidate)
-	scratch.pushFrontier(candidate)
+	scratch.insertTop(topK, candidate, debugCounters)
+	scratch.pushFrontier(candidate, debugCounters)
 	return nil
 }
 
-func (r *columnVectorGraphPhysicalRowReader) scoreAndPushFrontierVisitedTile(plan *columnVectorGraphSearchPlan, singleBlockView *columnVectorGraphBlockView, query []float32, queryInvNorm float32, ordinals []int, topK int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats, loopCounters *columnVectorGraphNativeSearchLoopCounters, preparedMinimal *columnVectorGraphPreparedMinimalSearchCounters) error {
+func (r *columnVectorGraphPhysicalRowReader) scoreAndPushFrontierVisitedTile(plan *columnVectorGraphSearchPlan, singleBlockView *columnVectorGraphBlockView, query []float32, queryInvNorm float32, ordinals []int, topK int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats, loopCounters *columnVectorGraphNativeSearchLoopCounters, preparedMinimal *columnVectorGraphPreparedMinimalSearchCounters, debugCounters *columnVectorGraphNativeSearchDebugCounters, scoreContext columnVectorGraphNativeSearchScoreContext) error {
 	if len(ordinals) == 0 {
 		return nil
 	}
@@ -1184,14 +1474,15 @@ func (r *columnVectorGraphPhysicalRowReader) scoreAndPushFrontierVisitedTile(pla
 	if err != nil {
 		return err
 	}
+	debugCounters.recordScores(scoreContext, ordinals)
 	if preparedMinimal != nil {
 		preparedMinimal.recordPreparedScores(len(ordinals), len(ordinals) <= 1)
 	}
 	for i, ordinal := range ordinals {
 		loopCounters.recordCandidate()
 		candidate := columnVectorGraphSearchCandidate{ordinal: ordinal, score: scores[i]}
-		scratch.insertTop(topK, candidate)
-		scratch.pushFrontier(candidate)
+		scratch.insertTop(topK, candidate, debugCounters)
+		scratch.pushFrontier(candidate, debugCounters)
 	}
 	return nil
 }
@@ -1285,12 +1576,13 @@ func (r *columnVectorGraphPhysicalRowReader) scoreOrdinalLegacy(plan *columnVect
 	return score, nil
 }
 
-func (r *columnVectorGraphPhysicalRowReader) expandCandidateAdjacencyLayer(plan *columnVectorGraphSearchPlan, singleBlockView *columnVectorGraphBlockView, ordinal int, layer int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats, preparedMinimal *columnVectorGraphPreparedMinimalSearchCounters) ([]uint32, error) {
+func (r *columnVectorGraphPhysicalRowReader) expandCandidateAdjacencyLayer(plan *columnVectorGraphSearchPlan, singleBlockView *columnVectorGraphBlockView, ordinal int, layer int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats, preparedMinimal *columnVectorGraphPreparedMinimalSearchCounters, debugCounters *columnVectorGraphNativeSearchDebugCounters) ([]uint32, error) {
 	if plan != nil && plan.preparedSearch != nil {
 		layerAdjacency, outcome, err := plan.preparedSearch.adjacencyLayerForOrdinal(ordinal, layer)
 		if err != nil {
 			return nil, err
 		}
+		debugCounters.recordNeighborTile(len(layerAdjacency))
 		if preparedMinimal != nil {
 			preparedMinimal.recordPreparedAdjacency(len(layerAdjacency))
 		} else if stats != nil {
@@ -1304,6 +1596,7 @@ func (r *columnVectorGraphPhysicalRowReader) expandCandidateAdjacencyLayer(plan 
 		return layerAdjacency, nil
 	}
 	if layerAdjacency, outcome, fallbackReason, ok := r.directAdjacencyLayerForOrdinal(ordinal, layer); ok {
+		debugCounters.recordNeighborTile(len(layerAdjacency))
 		if stats != nil {
 			stats.ExpansionFetches++
 			stats.AdjacencyExpansions++
@@ -1327,6 +1620,7 @@ func (r *columnVectorGraphPhysicalRowReader) expandCandidateAdjacencyLayer(plan 
 	if err != nil {
 		return nil, fmt.Errorf("collections: column_graph %q ordinal=%d malformed adjacency layer=%d: %w", r.def.Name, ordinal, layer, err)
 	}
+	debugCounters.recordNeighborTile(len(layerAdjacency))
 	if stats != nil {
 		stats.ExpansionFetches++
 		stats.AdjacencyExpansions++
@@ -1539,14 +1833,23 @@ func (s *columnVectorGraphNativeSearchScratch) markVisited(ordinal int) bool {
 	return true
 }
 
-func (s *columnVectorGraphNativeSearchScratch) pushFrontier(candidate columnVectorGraphSearchCandidate) {
+func (s *columnVectorGraphNativeSearchScratch) pushFrontier(candidate columnVectorGraphSearchCandidate, debugCounters *columnVectorGraphNativeSearchDebugCounters) {
+	if debugCounters != nil && debugCounters.stats != nil {
+		debugCounters.stats.FrontierPushes++
+	}
 	s.frontier = append(s.frontier, candidate)
-	s.frontierSiftUp(len(s.frontier) - 1)
+	s.frontierSiftUp(len(s.frontier)-1, debugCounters)
 }
 
-func (s *columnVectorGraphNativeSearchScratch) popFrontier() (columnVectorGraphSearchCandidate, bool) {
+func (s *columnVectorGraphNativeSearchScratch) popFrontier(debugCounters *columnVectorGraphNativeSearchDebugCounters) (columnVectorGraphSearchCandidate, bool) {
 	if len(s.frontier) == 0 {
+		if debugCounters != nil && debugCounters.stats != nil {
+			debugCounters.stats.FrontierPopMisses++
+		}
 		return columnVectorGraphSearchCandidate{}, false
+	}
+	if debugCounters != nil && debugCounters.stats != nil {
+		debugCounters.stats.FrontierPops++
 	}
 	lastIdx := len(s.frontier) - 1
 	best := s.frontier[0]
@@ -1554,23 +1857,26 @@ func (s *columnVectorGraphNativeSearchScratch) popFrontier() (columnVectorGraphS
 	s.frontier = s.frontier[:lastIdx]
 	if len(s.frontier) > 0 {
 		s.frontier[0] = last
-		s.frontierSiftDown(0)
+		s.frontierSiftDown(0, debugCounters)
 	}
 	return best, true
 }
 
-func (s *columnVectorGraphNativeSearchScratch) frontierSiftUp(idx int) {
+func (s *columnVectorGraphNativeSearchScratch) frontierSiftUp(idx int, debugCounters *columnVectorGraphNativeSearchDebugCounters) {
 	for idx > 0 {
 		parent := (idx - 1) / 2
 		if !columnVectorGraphSearchCandidateBetter(s.frontier[idx], s.frontier[parent]) {
 			return
+		}
+		if debugCounters != nil && debugCounters.stats != nil {
+			debugCounters.stats.FrontierSiftUpSteps++
 		}
 		s.frontier[idx], s.frontier[parent] = s.frontier[parent], s.frontier[idx]
 		idx = parent
 	}
 }
 
-func (s *columnVectorGraphNativeSearchScratch) frontierSiftDown(idx int) {
+func (s *columnVectorGraphNativeSearchScratch) frontierSiftDown(idx int, debugCounters *columnVectorGraphNativeSearchDebugCounters) {
 	for {
 		left := idx*2 + 1
 		if left >= len(s.frontier) {
@@ -1583,13 +1889,22 @@ func (s *columnVectorGraphNativeSearchScratch) frontierSiftDown(idx int) {
 		if !columnVectorGraphSearchCandidateBetter(s.frontier[child], s.frontier[idx]) {
 			return
 		}
+		if debugCounters != nil && debugCounters.stats != nil {
+			debugCounters.stats.FrontierSiftDownSteps++
+		}
 		s.frontier[idx], s.frontier[child] = s.frontier[child], s.frontier[idx]
 		idx = child
 	}
 }
 
-func (s *columnVectorGraphNativeSearchScratch) insertTop(limit int, candidate columnVectorGraphSearchCandidate) {
+func (s *columnVectorGraphNativeSearchScratch) insertTop(limit int, candidate columnVectorGraphSearchCandidate, debugCounters *columnVectorGraphNativeSearchDebugCounters) {
+	if debugCounters != nil && debugCounters.stats != nil {
+		debugCounters.stats.TopKInsertAttempts++
+	}
 	if limit <= 0 {
+		if debugCounters != nil && debugCounters.stats != nil {
+			debugCounters.stats.TopKInsertRejections++
+		}
 		return
 	}
 	pos := len(s.top)
@@ -1597,7 +1912,18 @@ func (s *columnVectorGraphNativeSearchScratch) insertTop(limit int, candidate co
 		pos--
 	}
 	if pos >= limit {
+		if debugCounters != nil && debugCounters.stats != nil {
+			debugCounters.stats.TopKInsertRejections++
+		}
 		return
+	}
+	if debugCounters != nil && debugCounters.stats != nil {
+		debugCounters.stats.TopKInsertSuccesses++
+		shiftSteps := len(s.top) - pos
+		if len(s.top) >= limit && shiftSteps > 0 {
+			shiftSteps--
+		}
+		debugCounters.stats.TopKShiftSteps += uint64(shiftSteps)
 	}
 	if len(s.top) < limit {
 		s.top = append(s.top, columnVectorGraphSearchCandidate{})
@@ -1624,6 +1950,7 @@ func recordColumnVectorGraphScoreBatchStats(stats *columnVectorGraphNativeSearch
 	if uint64(tileSize) > stats.ScoreBatchMaxTileSize {
 		stats.ScoreBatchMaxTileSize = uint64(tileSize)
 	}
+	recordColumnVectorGraphScoreBatchDebugStats(stats, tileSize)
 	if optimized {
 		stats.ScoreBatchOptimizedCalls++
 	}

--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -1066,19 +1066,27 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 					neighbor := adjacency[i]
 					i++
 					loopCounters.recordEdge()
-					debugCounters.recordLayer0Edge()
+					if debugCounters != nil {
+						debugCounters.recordLayer0Edge()
+					}
 					if uint64(neighbor) >= uint64(rowCount) {
 						return nil, stats, fmt.Errorf("collections: column_graph %q ordinal=%d adjacency[%d]=%d outside row_count=%d: %w", r.def.Name, candidate.ordinal, neighborIndex, neighbor, rowCount, errColumnVectorGraphAdjacencyOrdinalOutOfBounds)
 					}
 					neighborOrdinal := int(neighbor)
 					if visitMarks[neighborOrdinal] == visitEpoch {
-						debugCounters.recordVisitedMark(true)
-						debugCounters.recordAlreadyVisitedSkip()
+						if debugCounters != nil {
+							debugCounters.recordVisitedMark(true)
+							debugCounters.recordAlreadyVisitedSkip()
+						}
 						continue
 					}
-					debugCounters.recordVisitedMark(false)
+					if debugCounters != nil {
+						debugCounters.recordVisitedMark(false)
+					}
 					if !columnVectorGraphCandidateRowAllowed(candidateRows, hasCandidateRows, neighborOrdinal) {
-						debugCounters.recordFilterSkip(true)
+						if debugCounters != nil {
+							debugCounters.recordFilterSkip(true)
+						}
 						visitMarks[neighborOrdinal] = visitEpoch
 						continue
 					}
@@ -1099,19 +1107,27 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 				break
 			}
 			loopCounters.recordEdge()
-			debugCounters.recordLayer0Edge()
+			if debugCounters != nil {
+				debugCounters.recordLayer0Edge()
+			}
 			if uint64(neighbor) >= uint64(rowCount) {
 				return nil, stats, fmt.Errorf("collections: column_graph %q ordinal=%d adjacency[%d]=%d outside row_count=%d: %w", r.def.Name, candidate.ordinal, i, neighbor, rowCount, errColumnVectorGraphAdjacencyOrdinalOutOfBounds)
 			}
 			neighborOrdinal := int(neighbor)
 			if visitMarks[neighborOrdinal] == visitEpoch {
-				debugCounters.recordVisitedMark(true)
-				debugCounters.recordAlreadyVisitedSkip()
+				if debugCounters != nil {
+					debugCounters.recordVisitedMark(true)
+					debugCounters.recordAlreadyVisitedSkip()
+				}
 				continue
 			}
-			debugCounters.recordVisitedMark(false)
+			if debugCounters != nil {
+				debugCounters.recordVisitedMark(false)
+			}
 			if !columnVectorGraphCandidateRowAllowed(candidateRows, hasCandidateRows, neighborOrdinal) {
-				debugCounters.recordFilterSkip(true)
+				if debugCounters != nil {
+					debugCounters.recordFilterSkip(true)
+				}
 				visitMarks[neighborOrdinal] = visitEpoch
 				continue
 			}
@@ -1216,7 +1232,9 @@ func (r *columnVectorGraphPhysicalRowReader) greedyNearestAtLayer(plan *columnVe
 	if err != nil {
 		return 0, err
 	}
-	debugCounters.recordScore(columnVectorGraphNativeSearchScoreContextUpperEntry, best)
+	if debugCounters != nil {
+		debugCounters.recordScore(columnVectorGraphNativeSearchScoreContextUpperEntry, best)
+	}
 	if preparedMinimal != nil {
 		preparedMinimal.recordPreparedScores(1, true)
 	}
@@ -1232,13 +1250,17 @@ func (r *columnVectorGraphPhysicalRowReader) greedyNearestAtLayer(plan *columnVe
 			tile := scratch.scoreTileOrdinals[:0]
 			for i, neighbor := range adjacency {
 				loopCounters.recordEdge()
-				debugCounters.recordUpperLayerEdge()
+				if debugCounters != nil {
+					debugCounters.recordUpperLayerEdge()
+				}
 				if uint64(neighbor) >= uint64(r.RowCount()) {
 					return 0, fmt.Errorf("collections: column_graph %q ordinal=%d adjacency[%d]=%d outside row_count=%d: %w", r.def.Name, best, i, neighbor, r.RowCount(), errColumnVectorGraphAdjacencyOrdinalOutOfBounds)
 				}
 				neighborOrdinal := int(neighbor)
 				if !columnVectorGraphCandidateRowAllowed(candidateRows, hasCandidateRows, neighborOrdinal) {
-					debugCounters.recordFilterSkip(false)
+					if debugCounters != nil {
+						debugCounters.recordFilterSkip(false)
+					}
 					continue
 				}
 				tile = append(tile, neighborOrdinal)
@@ -1251,7 +1273,9 @@ func (r *columnVectorGraphPhysicalRowReader) greedyNearestAtLayer(plan *columnVe
 			if err != nil {
 				return 0, err
 			}
-			debugCounters.recordScores(columnVectorGraphNativeSearchScoreContextUpperNeighbor, tile)
+			if debugCounters != nil {
+				debugCounters.recordScores(columnVectorGraphNativeSearchScoreContextUpperNeighbor, tile)
+			}
 			if preparedMinimal != nil {
 				preparedMinimal.recordPreparedScores(len(tile), len(tile) <= 1)
 			}
@@ -1267,20 +1291,26 @@ func (r *columnVectorGraphPhysicalRowReader) greedyNearestAtLayer(plan *columnVe
 		}
 		for i, neighbor := range adjacency {
 			loopCounters.recordEdge()
-			debugCounters.recordUpperLayerEdge()
+			if debugCounters != nil {
+				debugCounters.recordUpperLayerEdge()
+			}
 			if uint64(neighbor) >= uint64(r.RowCount()) {
 				return 0, fmt.Errorf("collections: column_graph %q ordinal=%d adjacency[%d]=%d outside row_count=%d: %w", r.def.Name, best, i, neighbor, r.RowCount(), errColumnVectorGraphAdjacencyOrdinalOutOfBounds)
 			}
 			neighborOrdinal := int(neighbor)
 			if !columnVectorGraphCandidateRowAllowed(candidateRows, hasCandidateRows, neighborOrdinal) {
-				debugCounters.recordFilterSkip(false)
+				if debugCounters != nil {
+					debugCounters.recordFilterSkip(false)
+				}
 				continue
 			}
 			score, err := r.scoreOrdinal(plan, singleBlockView, query, queryInvNorm, neighborOrdinal, scratch, stats)
 			if err != nil {
 				return 0, err
 			}
-			debugCounters.recordScore(columnVectorGraphNativeSearchScoreContextUpperNeighbor, neighborOrdinal)
+			if debugCounters != nil {
+				debugCounters.recordScore(columnVectorGraphNativeSearchScoreContextUpperNeighbor, neighborOrdinal)
+			}
 			if preparedMinimal != nil {
 				preparedMinimal.recordPreparedScores(1, true)
 			}
@@ -1457,7 +1487,9 @@ func (r *columnVectorGraphPhysicalRowReader) scoreAndPushFrontierVisited(plan *c
 	if err != nil {
 		return err
 	}
-	debugCounters.recordScore(scoreContext, ordinal)
+	if debugCounters != nil {
+		debugCounters.recordScore(scoreContext, ordinal)
+	}
 	if preparedMinimal != nil {
 		preparedMinimal.recordPreparedScores(1, true)
 	}
@@ -1485,7 +1517,9 @@ func (r *columnVectorGraphPhysicalRowReader) scoreAndPushFrontierVisitedTile(pla
 	if err != nil {
 		return err
 	}
-	debugCounters.recordScores(scoreContext, ordinals)
+	if debugCounters != nil {
+		debugCounters.recordScores(scoreContext, ordinals)
+	}
 	if preparedMinimal != nil {
 		preparedMinimal.recordPreparedScores(len(ordinals), len(ordinals) <= 1)
 	}
@@ -1598,7 +1632,9 @@ func (r *columnVectorGraphPhysicalRowReader) expandCandidateAdjacencyLayer(plan 
 		if err != nil {
 			return nil, err
 		}
-		debugCounters.recordNeighborTile(len(layerAdjacency))
+		if debugCounters != nil {
+			debugCounters.recordNeighborTile(len(layerAdjacency))
+		}
 		if preparedMinimal != nil {
 			preparedMinimal.recordPreparedAdjacency(len(layerAdjacency))
 		} else if stats != nil {
@@ -1612,7 +1648,9 @@ func (r *columnVectorGraphPhysicalRowReader) expandCandidateAdjacencyLayer(plan 
 		return layerAdjacency, nil
 	}
 	if layerAdjacency, outcome, fallbackReason, ok := r.directAdjacencyLayerForOrdinal(ordinal, layer); ok {
-		debugCounters.recordNeighborTile(len(layerAdjacency))
+		if debugCounters != nil {
+			debugCounters.recordNeighborTile(len(layerAdjacency))
+		}
 		if stats != nil {
 			stats.ExpansionFetches++
 			stats.AdjacencyExpansions++
@@ -1636,7 +1674,9 @@ func (r *columnVectorGraphPhysicalRowReader) expandCandidateAdjacencyLayer(plan 
 	if err != nil {
 		return nil, fmt.Errorf("collections: column_graph %q ordinal=%d malformed adjacency layer=%d: %w", r.def.Name, ordinal, layer, err)
 	}
-	debugCounters.recordNeighborTile(len(layerAdjacency))
+	if debugCounters != nil {
+		debugCounters.recordNeighborTile(len(layerAdjacency))
+	}
 	if stats != nil {
 		stats.ExpansionFetches++
 		stats.AdjacencyExpansions++
@@ -2015,7 +2055,9 @@ func recordColumnVectorGraphScoreBatchStats(stats *columnVectorGraphNativeSearch
 	if uint64(tileSize) > stats.ScoreBatchMaxTileSize {
 		stats.ScoreBatchMaxTileSize = uint64(tileSize)
 	}
-	recordColumnVectorGraphScoreBatchDebugStats(stats, tileSize)
+	if stats.BenchmarkDebugSearches != 0 {
+		recordColumnVectorGraphScoreBatchDebugStats(stats, tileSize)
+	}
 	if optimized {
 		stats.ScoreBatchOptimizedCalls++
 	}

--- a/TreeDB/collections/column_vector_graph_search_test.go
+++ b/TreeDB/collections/column_vector_graph_search_test.go
@@ -1244,6 +1244,7 @@ func benchmarkColumnVectorGraphNativeSearchCosineV3(b *testing.B, shape columnVe
 		searchStats.ResultIDStateValidationFailures += stats.ResultIDStateValidationFailures
 		searchStats.PreparedGraphSearchViews += stats.PreparedGraphSearchViews
 		searchStats.GraphRowFallbacks += stats.GraphRowFallbacks
+		addColumnVectorGraphNativeSearchDebugStats1979(&searchStats, stats)
 	}
 	b.StopTimer()
 	stats := reader.Stats()
@@ -2005,6 +2006,7 @@ func reportColumnGraphNativeSearchBenchMetricsV3(b *testing.B, n int, baseStats,
 	if searchStats.ScoreBatchCalls > 0 {
 		b.ReportMetric(float64(searchStats.ScoreBatchCandidates)/float64(searchStats.ScoreBatchCalls), "score_batch_avg_tile_size")
 	}
+	reportColumnVectorGraphNativeSearchDebugMetrics1979(b, n, searchStats)
 	b.ReportMetric(float64(searchStats.BlockViewHits)/float64(n), "block_view_hits/search")
 	b.ReportMetric(float64(searchStats.BlockViewMisses)/float64(n), "block_view_misses/search")
 	b.ReportMetric(float64(searchStats.BlockViewBuilds)/float64(n), "block_view_builds/search")

--- a/TreeDB/collections/column_vector_graph_topology_parity_2091_test.go
+++ b/TreeDB/collections/column_vector_graph_topology_parity_2091_test.go
@@ -523,6 +523,7 @@ func addColumnVectorGraphSearchTopologyParityStats2091(dst *columnVectorGraphNat
 	dst.ResultIDStateValidationFailures += src.ResultIDStateValidationFailures
 	dst.PreparedGraphSearchViews += src.PreparedGraphSearchViews
 	dst.GraphRowFallbacks += src.GraphRowFallbacks
+	addColumnVectorGraphNativeSearchDebugStats1979(dst, src)
 	dst.TypedColumnMappedBytes = src.TypedColumnMappedBytes
 	dst.TypedColumnHeapCopyBytes = src.TypedColumnHeapCopyBytes
 	dst.TypedColumnDecodedBytes = src.TypedColumnDecodedBytes
@@ -571,6 +572,7 @@ func reportColumnVectorGraphSearchTopologyParityMetrics2091(b *testing.B, shape 
 	b.ReportMetric(float64(searchStats.ScoreBatchScalarFallbackCalls)/denom, "score_batch_fallback/search")
 	b.ReportMetric(float64(searchStats.PreparedScoreCalls)/denom, "prepared_score_calls/search")
 	b.ReportMetric(float64(searchStats.ScoreFloat64Fallbacks)/denom, "score_float64_fallbacks/search")
+	reportColumnVectorGraphNativeSearchDebugMetrics1979(b, n, searchStats)
 	b.ReportMetric(float64(searchStats.VectorDirectViews)/denom, "vector_direct_views/search")
 	b.ReportMetric(float64(searchStats.VectorMmapDirectViews)/denom, "vector_mmap_direct/search")
 	b.ReportMetric(float64(searchStats.VectorHeapCopyTypedViews)/denom, "vector_heap_copy_typed_view/search")

--- a/TreeDB/collections/vector_index_search.go
+++ b/TreeDB/collections/vector_index_search.go
@@ -371,6 +371,64 @@ type VectorIndexSearchStats struct {
 	PreparedGraphSearchViews uint64 `json:"prepared_graph_search_views,omitempty"`
 	// GraphRowFallbacks aggregates compatibility graph-row reads/fallbacks observed during vector/norm/adjacency/result materialization.
 	GraphRowFallbacks uint64 `json:"graph_row_fallbacks,omitempty"`
+
+	// BenchmarkDebugSearches reports searches collected with benchmark_debug graph-control-flow instrumentation.
+	BenchmarkDebugSearches uint64 `json:"benchmark_debug_searches,omitempty"`
+	// NeighborTiles counts expanded adjacency neighbor tiles.
+	NeighborTiles uint64 `json:"neighbor_tiles,omitempty"`
+	// NeighborTileNeighbors sums neighbor counts across expanded adjacency tiles.
+	NeighborTileNeighbors uint64 `json:"neighbor_tile_neighbors,omitempty"`
+	// NeighborTileMaxSize is the largest expanded adjacency tile.
+	NeighborTileMaxSize    uint64 `json:"neighbor_tile_max_size,omitempty"`
+	NeighborTileSize0      uint64 `json:"neighbor_tile_size_0,omitempty"`
+	NeighborTileSize1      uint64 `json:"neighbor_tile_size_1,omitempty"`
+	NeighborTileSize2To4   uint64 `json:"neighbor_tile_size_2_4,omitempty"`
+	NeighborTileSize5To8   uint64 `json:"neighbor_tile_size_5_8,omitempty"`
+	NeighborTileSize9To16  uint64 `json:"neighbor_tile_size_9_16,omitempty"`
+	NeighborTileSize17Plus uint64 `json:"neighbor_tile_size_17_plus,omitempty"`
+	// ScoreBatchSingletons counts singleton scoring batches in benchmark_debug mode.
+	ScoreBatchSingletons uint64 `json:"score_batch_singletons,omitempty"`
+	ScoreBatchSize2To4   uint64 `json:"score_batch_size_2_4,omitempty"`
+	ScoreBatchSize5To8   uint64 `json:"score_batch_size_5_8,omitempty"`
+	ScoreBatchSize9To16  uint64 `json:"score_batch_size_9_16,omitempty"`
+	ScoreBatchSize17Plus uint64 `json:"score_batch_size_17_plus,omitempty"`
+	// ScoredNeighbors counts graph neighbors that reached scoring; skipped neighbors partition filter and already-visited skips.
+	ScoredNeighbors                       uint64 `json:"scored_neighbors,omitempty"`
+	SkippedNeighbors                      uint64 `json:"skipped_neighbors,omitempty"`
+	AlreadyVisitedSkips                   uint64 `json:"already_visited_skips,omitempty"`
+	FilterSkips                           uint64 `json:"filter_skips,omitempty"`
+	UpperLayerScores                      uint64 `json:"upper_layer_scores,omitempty"`
+	UpperLayerEntryScores                 uint64 `json:"upper_layer_entry_scores,omitempty"`
+	UpperLayerNeighborScores              uint64 `json:"upper_layer_neighbor_scores,omitempty"`
+	UpperLayerEdgeVisits                  uint64 `json:"upper_layer_edge_visits,omitempty"`
+	UpperLayerScoredNeighbors             uint64 `json:"upper_layer_scored_neighbors,omitempty"`
+	UpperLayerFilterSkips                 uint64 `json:"upper_layer_filter_skips,omitempty"`
+	Layer0Scores                          uint64 `json:"layer0_scores,omitempty"`
+	Layer0SeedScores                      uint64 `json:"layer0_seed_scores,omitempty"`
+	Layer0NeighborScores                  uint64 `json:"layer0_neighbor_scores,omitempty"`
+	Layer0EdgeVisits                      uint64 `json:"layer0_edge_visits,omitempty"`
+	Layer0ScoredNeighbors                 uint64 `json:"layer0_scored_neighbors,omitempty"`
+	Layer0AlreadyVisitedSkips             uint64 `json:"layer0_already_visited_skips,omitempty"`
+	Layer0FilterSkips                     uint64 `json:"layer0_filter_skips,omitempty"`
+	FrontierPushes                        uint64 `json:"frontier_pushes,omitempty"`
+	FrontierPops                          uint64 `json:"frontier_pops,omitempty"`
+	FrontierPopMisses                     uint64 `json:"frontier_pop_misses,omitempty"`
+	FrontierSiftUpSteps                   uint64 `json:"frontier_sift_up_steps,omitempty"`
+	FrontierSiftDownSteps                 uint64 `json:"frontier_sift_down_steps,omitempty"`
+	TopKInsertAttempts                    uint64 `json:"top_k_insert_attempts,omitempty"`
+	TopKInsertSuccesses                   uint64 `json:"top_k_insert_successes,omitempty"`
+	TopKInsertRejections                  uint64 `json:"top_k_insert_rejections,omitempty"`
+	TopKShiftSteps                        uint64 `json:"top_k_shift_steps,omitempty"`
+	VisitedMarkChecks                     uint64 `json:"visited_mark_checks,omitempty"`
+	VisitedMarkHits                       uint64 `json:"visited_mark_hits,omitempty"`
+	VisitedMarkMisses                     uint64 `json:"visited_mark_misses,omitempty"`
+	ExactModeSearches                     uint64 `json:"exact_mode_searches,omitempty"`
+	ExactCandidateOrderObservations       uint64 `json:"exact_candidate_order_observations,omitempty"`
+	ExactCandidateOrderTransitions        uint64 `json:"exact_candidate_order_transitions,omitempty"`
+	ExactCandidateOrderAdjacentForward    uint64 `json:"exact_candidate_order_adjacent_forward,omitempty"`
+	ExactCandidateOrderNonAdjacentForward uint64 `json:"exact_candidate_order_non_adjacent_forward,omitempty"`
+	ExactCandidateOrderBackwardJumps      uint64 `json:"exact_candidate_order_backward_jumps,omitempty"`
+	ExactCandidateOrderMaxForwardRun      uint64 `json:"exact_candidate_order_max_forward_run,omitempty"`
 	// DocumentRowRefStateFetches counts post-top-k document fetches served with vector-index row-ref state.
 	DocumentRowRefStateFetches uint64 `json:"document_row_ref_state_fetches,omitempty"`
 	// DocumentRowRefLookupFallbacks counts post-top-k document fetches that fell back to ID-to-row-ref lookup.
@@ -956,99 +1014,150 @@ func deltaInt64(before, after int64) int64 {
 
 func vectorIndexSearchStatsFromInternal(searchStats columnVectorGraphNativeSearchStats, readerStats columnPhysicalRowReaderStats) VectorIndexSearchStats {
 	return VectorIndexSearchStats{
-		GraphRows:                            uint64(readerStats.Rows),
-		CandidateRows:                        searchStats.CandidateRows,
-		Candidates:                           searchStats.Candidates,
-		Edges:                                searchStats.Edges,
-		VisitedNodes:                         searchStats.VisitedNodes,
-		VisitedEdges:                         searchStats.VisitedEdges,
-		VectorBytesRead:                      searchStats.VectorBytesRead,
-		NormBytesRead:                        searchStats.NormBytesRead,
-		AdjacencyBytesRead:                   searchStats.AdjacencyBytesRead,
-		CandidateFetches:                     searchStats.CandidateFetches,
-		ScoreBatchCalls:                      searchStats.ScoreBatchCalls,
-		ScoreBatchCandidates:                 searchStats.ScoreBatchCandidates,
-		ScoreBatchMaxTileSize:                searchStats.ScoreBatchMaxTileSize,
-		ScoreBatchOptimizedCalls:             searchStats.ScoreBatchOptimizedCalls,
-		ScoreBatchScalarFallbackCalls:        searchStats.ScoreBatchScalarFallbackCalls,
-		PreparedScoreCalls:                   searchStats.PreparedScoreCalls,
-		ScoreFloat64Fallbacks:                searchStats.ScoreFloat64Fallbacks,
-		ExpansionFetches:                     searchStats.ExpansionFetches,
-		ResultFetches:                        searchStats.ResultFetches,
-		RowFetches:                           readerStats.RowFetches,
-		BatchFetches:                         readerStats.BatchFetches,
-		RowsFetched:                          readerStats.RowsFetched,
-		CacheHits:                            readerStats.CacheHits,
-		CacheMisses:                          readerStats.CacheMisses,
-		DecodedBlocks:                        readerStats.DecodedBlocks,
-		GranulesTouched:                      readerStats.GranulesTouched,
-		PhysicalBytesRead:                    readerStats.PhysicalBytesRead,
-		MaxResidentBytes:                     readerStats.MaxResidentBytes,
-		OpenGranulesRead:                     uint64(readerStats.OpenGranulesRead),
-		OpenPhysicalBytesRead:                readerStats.OpenPhysicalBytesRead,
-		VectorDirectViews:                    searchStats.VectorDirectViews,
-		VectorMmapDirectViews:                searchStats.VectorMmapDirectViews,
-		VectorHeapCopyTypedViews:             searchStats.VectorHeapCopyTypedViews,
-		VectorScratchDecodes:                 searchStats.VectorScratchDecodes,
-		VectorPreparedDirectViews:            searchStats.VectorPreparedDirectViews,
-		VectorPreparedIdentityMappings:       searchStats.VectorPreparedIdentityMappings,
-		VectorPreparedRowRefMappings:         searchStats.VectorPreparedRowRefMappings,
-		VectorCertificationFailures:          searchStats.VectorCertificationFailures,
-		VectorAbsoluteOffsetUnaligned:        searchStats.VectorAbsoluteOffsetUnaligned,
-		VectorActualPointerUnaligned:         searchStats.VectorActualPointerUnaligned,
-		VectorStaleHandles:                   searchStats.VectorStaleHandles,
-		AdjacencyDirectViews:                 searchStats.AdjacencyDirectViews,
-		AdjacencyMmapDirectViews:             searchStats.AdjacencyMmapDirectViews,
-		AdjacencyHeapCopyTypedViews:          searchStats.AdjacencyHeapCopyTypedViews,
-		AdjacencyPreparedCSRDirectViews:      searchStats.AdjacencyPreparedCSRDirectViews,
-		AdjacencyPreparedCSRMmapDirectViews:  searchStats.AdjacencyPreparedCSRMmapDirectViews,
-		AdjacencyTypedListDirectViews:        searchStats.AdjacencyTypedListDirectViews,
-		AdjacencyTypedListMmapDirectViews:    searchStats.AdjacencyTypedListMmapDirectViews,
-		AdjacencyTypedListHeapCopyTypedViews: searchStats.AdjacencyTypedListHeapCopyTypedViews,
-		AdjacencyTypedListScratchDecodes:     searchStats.AdjacencyTypedListScratchDecodes,
-		AdjacencyLegacyFallbacks:             searchStats.AdjacencyLegacyFallbacks,
-		AdjacencySourceUnavailable:           searchStats.AdjacencySourceUnavailable,
-		AdjacencySourceFallbacks:             searchStats.AdjacencySourceFallbacks,
-		AdjacencyCertificationFailures:       searchStats.AdjacencyCertificationFailures,
-		AdjacencyValidationFailures:          searchStats.AdjacencyValidationFailures,
-		AdjacencyAbsoluteOffsetUnaligned:     searchStats.AdjacencyAbsoluteOffsetUnaligned,
-		AdjacencyActualPointerUnaligned:      searchStats.AdjacencyActualPointerUnaligned,
-		AdjacencyStaleHandles:                searchStats.AdjacencyStaleHandles,
-		AdjacencyScratchDecodes:              searchStats.AdjacencyScratchDecodes,
-		NormDirectViews:                      searchStats.NormDirectViews,
-		NormMmapDirectViews:                  searchStats.NormMmapDirectViews,
-		NormHeapCopyTypedViews:               searchStats.NormHeapCopyTypedViews,
-		NormScratchDecodes:                   searchStats.NormScratchDecodes,
-		NormPreparedDirectViews:              searchStats.NormPreparedDirectViews,
-		NormSourceUnavailable:                searchStats.NormSourceUnavailable,
-		NormSourceFallbacks:                  searchStats.NormSourceFallbacks,
-		NormValidationFailures:               searchStats.NormValidationFailures,
-		NormAbsoluteOffsetUnaligned:          searchStats.NormAbsoluteOffsetUnaligned,
-		NormActualPointerUnaligned:           searchStats.NormActualPointerUnaligned,
-		NormStaleHandles:                     searchStats.NormStaleHandles,
-		NormMappedBytes:                      searchStats.NormMappedBytes,
-		NormHeapCopyBytes:                    searchStats.NormHeapCopyBytes,
-		NormDecodedBytes:                     searchStats.NormDecodedBytes,
-		NormActiveHandles:                    searchStats.NormActiveHandles,
-		NormDeniedResources:                  searchStats.NormDeniedResources,
-		TypedColumnMappedBytes:               searchStats.TypedColumnMappedBytes,
-		TypedColumnHeapCopyBytes:             searchStats.TypedColumnHeapCopyBytes,
-		TypedColumnDecodedBytes:              searchStats.TypedColumnDecodedBytes,
-		TypedColumnActiveHandles:             searchStats.TypedColumnActiveHandles,
-		TypedColumnDeniedResources:           searchStats.TypedColumnDeniedResources,
-		TypedColumnFallbacks:                 searchStats.TypedColumnFallbacks,
-		RowRefVectorSourceState:              searchStats.RowRefVectorSourceState,
-		RowRefVectorSourceLegacyGraphIDs:     searchStats.RowRefVectorSourceLegacyGraphIDs,
-		RowRefStatePreparedViews:             searchStats.RowRefStatePreparedViews,
-		RowRefStateMmapDirectFields:          searchStats.RowRefStateMmapDirectFields,
-		RowRefStateResultRefs:                searchStats.RowRefStateResultRefs,
-		RowRefStateSourceUnavailable:         searchStats.RowRefStateSourceUnavailable,
-		RowRefStateSourceFallbacks:           searchStats.RowRefStateSourceFallbacks,
-		ResultIDPreparedBytesViews:           searchStats.ResultIDPreparedBytesViews,
-		ResultIDTypedBytesState:              searchStats.ResultIDTypedBytesState,
-		ResultIDGraphFallbacks:               searchStats.ResultIDGraphFallbacks,
-		ResultIDStateValidationFailures:      searchStats.ResultIDStateValidationFailures,
-		PreparedGraphSearchViews:             searchStats.PreparedGraphSearchViews,
-		GraphRowFallbacks:                    searchStats.GraphRowFallbacks,
+		GraphRows:                             uint64(readerStats.Rows),
+		CandidateRows:                         searchStats.CandidateRows,
+		Candidates:                            searchStats.Candidates,
+		Edges:                                 searchStats.Edges,
+		VisitedNodes:                          searchStats.VisitedNodes,
+		VisitedEdges:                          searchStats.VisitedEdges,
+		VectorBytesRead:                       searchStats.VectorBytesRead,
+		NormBytesRead:                         searchStats.NormBytesRead,
+		AdjacencyBytesRead:                    searchStats.AdjacencyBytesRead,
+		CandidateFetches:                      searchStats.CandidateFetches,
+		ScoreBatchCalls:                       searchStats.ScoreBatchCalls,
+		ScoreBatchCandidates:                  searchStats.ScoreBatchCandidates,
+		ScoreBatchMaxTileSize:                 searchStats.ScoreBatchMaxTileSize,
+		ScoreBatchOptimizedCalls:              searchStats.ScoreBatchOptimizedCalls,
+		ScoreBatchScalarFallbackCalls:         searchStats.ScoreBatchScalarFallbackCalls,
+		PreparedScoreCalls:                    searchStats.PreparedScoreCalls,
+		ScoreFloat64Fallbacks:                 searchStats.ScoreFloat64Fallbacks,
+		ExpansionFetches:                      searchStats.ExpansionFetches,
+		ResultFetches:                         searchStats.ResultFetches,
+		RowFetches:                            readerStats.RowFetches,
+		BatchFetches:                          readerStats.BatchFetches,
+		RowsFetched:                           readerStats.RowsFetched,
+		CacheHits:                             readerStats.CacheHits,
+		CacheMisses:                           readerStats.CacheMisses,
+		DecodedBlocks:                         readerStats.DecodedBlocks,
+		GranulesTouched:                       readerStats.GranulesTouched,
+		PhysicalBytesRead:                     readerStats.PhysicalBytesRead,
+		MaxResidentBytes:                      readerStats.MaxResidentBytes,
+		OpenGranulesRead:                      uint64(readerStats.OpenGranulesRead),
+		OpenPhysicalBytesRead:                 readerStats.OpenPhysicalBytesRead,
+		VectorDirectViews:                     searchStats.VectorDirectViews,
+		VectorMmapDirectViews:                 searchStats.VectorMmapDirectViews,
+		VectorHeapCopyTypedViews:              searchStats.VectorHeapCopyTypedViews,
+		VectorScratchDecodes:                  searchStats.VectorScratchDecodes,
+		VectorPreparedDirectViews:             searchStats.VectorPreparedDirectViews,
+		VectorPreparedIdentityMappings:        searchStats.VectorPreparedIdentityMappings,
+		VectorPreparedRowRefMappings:          searchStats.VectorPreparedRowRefMappings,
+		VectorCertificationFailures:           searchStats.VectorCertificationFailures,
+		VectorAbsoluteOffsetUnaligned:         searchStats.VectorAbsoluteOffsetUnaligned,
+		VectorActualPointerUnaligned:          searchStats.VectorActualPointerUnaligned,
+		VectorStaleHandles:                    searchStats.VectorStaleHandles,
+		AdjacencyDirectViews:                  searchStats.AdjacencyDirectViews,
+		AdjacencyMmapDirectViews:              searchStats.AdjacencyMmapDirectViews,
+		AdjacencyHeapCopyTypedViews:           searchStats.AdjacencyHeapCopyTypedViews,
+		AdjacencyPreparedCSRDirectViews:       searchStats.AdjacencyPreparedCSRDirectViews,
+		AdjacencyPreparedCSRMmapDirectViews:   searchStats.AdjacencyPreparedCSRMmapDirectViews,
+		AdjacencyTypedListDirectViews:         searchStats.AdjacencyTypedListDirectViews,
+		AdjacencyTypedListMmapDirectViews:     searchStats.AdjacencyTypedListMmapDirectViews,
+		AdjacencyTypedListHeapCopyTypedViews:  searchStats.AdjacencyTypedListHeapCopyTypedViews,
+		AdjacencyTypedListScratchDecodes:      searchStats.AdjacencyTypedListScratchDecodes,
+		AdjacencyLegacyFallbacks:              searchStats.AdjacencyLegacyFallbacks,
+		AdjacencySourceUnavailable:            searchStats.AdjacencySourceUnavailable,
+		AdjacencySourceFallbacks:              searchStats.AdjacencySourceFallbacks,
+		AdjacencyCertificationFailures:        searchStats.AdjacencyCertificationFailures,
+		AdjacencyValidationFailures:           searchStats.AdjacencyValidationFailures,
+		AdjacencyAbsoluteOffsetUnaligned:      searchStats.AdjacencyAbsoluteOffsetUnaligned,
+		AdjacencyActualPointerUnaligned:       searchStats.AdjacencyActualPointerUnaligned,
+		AdjacencyStaleHandles:                 searchStats.AdjacencyStaleHandles,
+		AdjacencyScratchDecodes:               searchStats.AdjacencyScratchDecodes,
+		NormDirectViews:                       searchStats.NormDirectViews,
+		NormMmapDirectViews:                   searchStats.NormMmapDirectViews,
+		NormHeapCopyTypedViews:                searchStats.NormHeapCopyTypedViews,
+		NormScratchDecodes:                    searchStats.NormScratchDecodes,
+		NormPreparedDirectViews:               searchStats.NormPreparedDirectViews,
+		NormSourceUnavailable:                 searchStats.NormSourceUnavailable,
+		NormSourceFallbacks:                   searchStats.NormSourceFallbacks,
+		NormValidationFailures:                searchStats.NormValidationFailures,
+		NormAbsoluteOffsetUnaligned:           searchStats.NormAbsoluteOffsetUnaligned,
+		NormActualPointerUnaligned:            searchStats.NormActualPointerUnaligned,
+		NormStaleHandles:                      searchStats.NormStaleHandles,
+		NormMappedBytes:                       searchStats.NormMappedBytes,
+		NormHeapCopyBytes:                     searchStats.NormHeapCopyBytes,
+		NormDecodedBytes:                      searchStats.NormDecodedBytes,
+		NormActiveHandles:                     searchStats.NormActiveHandles,
+		NormDeniedResources:                   searchStats.NormDeniedResources,
+		TypedColumnMappedBytes:                searchStats.TypedColumnMappedBytes,
+		TypedColumnHeapCopyBytes:              searchStats.TypedColumnHeapCopyBytes,
+		TypedColumnDecodedBytes:               searchStats.TypedColumnDecodedBytes,
+		TypedColumnActiveHandles:              searchStats.TypedColumnActiveHandles,
+		TypedColumnDeniedResources:            searchStats.TypedColumnDeniedResources,
+		TypedColumnFallbacks:                  searchStats.TypedColumnFallbacks,
+		RowRefVectorSourceState:               searchStats.RowRefVectorSourceState,
+		RowRefVectorSourceLegacyGraphIDs:      searchStats.RowRefVectorSourceLegacyGraphIDs,
+		RowRefStatePreparedViews:              searchStats.RowRefStatePreparedViews,
+		RowRefStateMmapDirectFields:           searchStats.RowRefStateMmapDirectFields,
+		RowRefStateResultRefs:                 searchStats.RowRefStateResultRefs,
+		RowRefStateSourceUnavailable:          searchStats.RowRefStateSourceUnavailable,
+		RowRefStateSourceFallbacks:            searchStats.RowRefStateSourceFallbacks,
+		ResultIDPreparedBytesViews:            searchStats.ResultIDPreparedBytesViews,
+		ResultIDTypedBytesState:               searchStats.ResultIDTypedBytesState,
+		ResultIDGraphFallbacks:                searchStats.ResultIDGraphFallbacks,
+		ResultIDStateValidationFailures:       searchStats.ResultIDStateValidationFailures,
+		PreparedGraphSearchViews:              searchStats.PreparedGraphSearchViews,
+		GraphRowFallbacks:                     searchStats.GraphRowFallbacks,
+		BenchmarkDebugSearches:                searchStats.BenchmarkDebugSearches,
+		NeighborTiles:                         searchStats.NeighborTiles,
+		NeighborTileNeighbors:                 searchStats.NeighborTileNeighbors,
+		NeighborTileMaxSize:                   searchStats.NeighborTileMaxSize,
+		NeighborTileSize0:                     searchStats.NeighborTileSize0,
+		NeighborTileSize1:                     searchStats.NeighborTileSize1,
+		NeighborTileSize2To4:                  searchStats.NeighborTileSize2To4,
+		NeighborTileSize5To8:                  searchStats.NeighborTileSize5To8,
+		NeighborTileSize9To16:                 searchStats.NeighborTileSize9To16,
+		NeighborTileSize17Plus:                searchStats.NeighborTileSize17Plus,
+		ScoreBatchSingletons:                  searchStats.ScoreBatchSingletons,
+		ScoreBatchSize2To4:                    searchStats.ScoreBatchSize2To4,
+		ScoreBatchSize5To8:                    searchStats.ScoreBatchSize5To8,
+		ScoreBatchSize9To16:                   searchStats.ScoreBatchSize9To16,
+		ScoreBatchSize17Plus:                  searchStats.ScoreBatchSize17Plus,
+		ScoredNeighbors:                       searchStats.ScoredNeighbors,
+		SkippedNeighbors:                      searchStats.SkippedNeighbors,
+		AlreadyVisitedSkips:                   searchStats.AlreadyVisitedSkips,
+		FilterSkips:                           searchStats.FilterSkips,
+		UpperLayerScores:                      searchStats.UpperLayerScores,
+		UpperLayerEntryScores:                 searchStats.UpperLayerEntryScores,
+		UpperLayerNeighborScores:              searchStats.UpperLayerNeighborScores,
+		UpperLayerEdgeVisits:                  searchStats.UpperLayerEdgeVisits,
+		UpperLayerScoredNeighbors:             searchStats.UpperLayerScoredNeighbors,
+		UpperLayerFilterSkips:                 searchStats.UpperLayerFilterSkips,
+		Layer0Scores:                          searchStats.Layer0Scores,
+		Layer0SeedScores:                      searchStats.Layer0SeedScores,
+		Layer0NeighborScores:                  searchStats.Layer0NeighborScores,
+		Layer0EdgeVisits:                      searchStats.Layer0EdgeVisits,
+		Layer0ScoredNeighbors:                 searchStats.Layer0ScoredNeighbors,
+		Layer0AlreadyVisitedSkips:             searchStats.Layer0AlreadyVisitedSkips,
+		Layer0FilterSkips:                     searchStats.Layer0FilterSkips,
+		FrontierPushes:                        searchStats.FrontierPushes,
+		FrontierPops:                          searchStats.FrontierPops,
+		FrontierPopMisses:                     searchStats.FrontierPopMisses,
+		FrontierSiftUpSteps:                   searchStats.FrontierSiftUpSteps,
+		FrontierSiftDownSteps:                 searchStats.FrontierSiftDownSteps,
+		TopKInsertAttempts:                    searchStats.TopKInsertAttempts,
+		TopKInsertSuccesses:                   searchStats.TopKInsertSuccesses,
+		TopKInsertRejections:                  searchStats.TopKInsertRejections,
+		TopKShiftSteps:                        searchStats.TopKShiftSteps,
+		VisitedMarkChecks:                     searchStats.VisitedMarkChecks,
+		VisitedMarkHits:                       searchStats.VisitedMarkHits,
+		VisitedMarkMisses:                     searchStats.VisitedMarkMisses,
+		ExactModeSearches:                     searchStats.ExactModeSearches,
+		ExactCandidateOrderObservations:       searchStats.ExactCandidateOrderObservations,
+		ExactCandidateOrderTransitions:        searchStats.ExactCandidateOrderTransitions,
+		ExactCandidateOrderAdjacentForward:    searchStats.ExactCandidateOrderAdjacentForward,
+		ExactCandidateOrderNonAdjacentForward: searchStats.ExactCandidateOrderNonAdjacentForward,
+		ExactCandidateOrderBackwardJumps:      searchStats.ExactCandidateOrderBackwardJumps,
+		ExactCandidateOrderMaxForwardRun:      searchStats.ExactCandidateOrderMaxForwardRun,
 	}
 }

--- a/TreeDB/docs/graph_search_benchmark_matrix_test.go
+++ b/TreeDB/docs/graph_search_benchmark_matrix_test.go
@@ -58,6 +58,14 @@ func TestDocs_GraphSearchBenchmarkTruthMatrix2037(t *testing.T) {
 		"current_prepared_typed_column",
 		"both paths visit exactly 612 edges/search",
 		"not yet throughput-superior",
+		"BenchmarkColumnVectorGraphSearchBatchability1979",
+		"StatsMode=benchmark_debug",
+		"neighbor_tile_avg_size=16",
+		"score_batch_singletons",
+		"already_visited_skips",
+		"top_k_insert_rejections",
+		"exact_order_observations=8192",
+		"keep #2035 open as not performance-satisfied",
 	}
 	for _, needle := range required {
 		if !strings.Contains(text, needle) {

--- a/TreeDB/docs/graph_search_prepared_views_test.go
+++ b/TreeDB/docs/graph_search_prepared_views_test.go
@@ -29,7 +29,7 @@ func TestDocs_GraphSearchPreparedViewPolicy(t *testing.T) {
 		"#2043 closeout status",
 		"not an unconditional wall-time win over the old legacy graph-row direct control",
 		"612` versus `3340` visited_edges/search",
-		"#1979 owns the follow-up instrumentation",
+		"#1979 now adds opt-in benchmark-debug control-flow counters",
 	} {
 		if !strings.Contains(normalized, strings.Join(strings.Fields(want), " ")) {
 			t.Fatalf("graph-search prepared-view spec missing required contract text %q", want)

--- a/TreeDB/docs/guides/vector-search-typed-column.md
+++ b/TreeDB/docs/guides/vector-search-typed-column.md
@@ -256,11 +256,15 @@ the closeout run kept graph-only search zero-allocation and fallback-free, but
 the legacy control visits 612 edges/search while current prepared rows visit 3340
 edges/search (about 5.5x). The #2043 focused adjacency-access microbenchmark is
 not an end-to-end search benchmark; it only shows prepared CSR adjacency access
-is not the source of that mismatch. Use #1979 to explain search
-work/batchability and add any exact-topology follow-up benchmark, #1980 for
-frontier/top-k optimization if future profiles continue to justify it, and keep
-#1977 normalized vectors deferred until a prototype beats raw vectors plus
-inverse norms including storage/rebuild cost.
+is not the source of that mismatch. #1979 adds opt-in benchmark-debug
+batchability/control-flow counters on the #2091 topology-parity fixture: the
+bounded `ef_search=128` row's 612 visited edges are mostly already-visited
+layer-0 skips over degree-16 neighbor tiles, while exact mode scores all 8192
+candidates and visits 100748 edges/search. Use #1980 for frontier/top-k or
+already-visited optimization if future profiles continue to justify it, use a
+separate narrow indexed-scoring ticket if exact-mode gathered score batching is
+desired, and keep #1977 normalized vectors deferred until a prototype beats raw
+vectors plus inverse norms including storage/rebuild cost.
 
 The broader legacy/canonical matrix remains useful when comparing with older
 artifacts or when you also need one-shot open/setup names:

--- a/TreeDB/docs/spec/column-graph-native-vector-search.md
+++ b/TreeDB/docs/spec/column-graph-native-vector-search.md
@@ -187,6 +187,13 @@ Report and compare:
 - open_granules/op and open_physical_B/op for setup/one-shot paths,
 - docs_fetched/search only for materializing public API benchmarks.
 
+When `StatsMode=benchmark_debug` is selected for #1979 evidence, also report
+neighbor tile histograms, score-batch histograms, scored/skipped neighbor
+buckets, already-visited skips, upper-layer versus layer-0 scores/edges,
+frontier/top-k operation counts, visited-mark hits/misses, and exact-mode
+candidate-order summaries. These counters are opt-in diagnostics and must not be
+used to claim a default hot-path optimization by themselves.
+
 ## Block Planner Follow-On
 
 The next native search optimization is planned in

--- a/TreeDB/docs/spec/typed-column-graph-search-benchmark-matrix.md
+++ b/TreeDB/docs/spec/typed-column-graph-search-benchmark-matrix.md
@@ -359,6 +359,70 @@ visited-edge/control flow under parity before assigning any remaining optimized
 implementation to #1980 frontier/top-k or #1977 normalized-vector
 storage/scoring.
 
+## #1979 HNSW batchability/control-flow instrumentation
+
+`BenchmarkColumnVectorGraphSearchBatchability1979` reuses the #2091 production
+fixture and runs the current prepared typed-column graph-only path with
+`StatsMode=benchmark_debug`. The benchmark is evidence/instrumentation only: it
+does not change traversal semantics, fixture topology, default scoring mode, or
+persistent formats. Rows report the normal `ns/op`, `ops/sec`, `B/op`, and
+`allocs/op` columns plus stable control-flow counters for neighbor tile sizes,
+score-batch histograms, scored-versus-skipped neighbors, visited-mark
+hits/misses, frontier/top-k operations, layer work, and exact-mode candidate
+order summaries.
+
+Command used for the local #1979 evidence run:
+
+```sh
+OUT=/tmp/gomap_1979_batchability_final_20260531_140228
+GOMAXPROCS=8 GOWORK=off go test ./TreeDB/collections \
+  -run '^$' \
+  -bench '^BenchmarkColumnVectorGraphSearchBatchability1979$' \
+  -benchmem -benchtime=500ms -count=3 | tee "$OUT/batchability_1979_bench.txt"
+```
+
+Run context: macOS 26.2, Apple M3, 8 logical CPUs, 16 GiB memory,
+`go version go1.25.5 darwin/arm64`. Median rows from the three-count run:
+
+| Search mode | Score mode | ns/op | ops/sec | B/op | allocs/op | Work counters | Batchability/control-flow counters |
+| --- | --- | ---: | ---: | ---: | ---: | --- | --- |
+| `ef_search=128` | `scalar` | 9.846 µs | 101,561 | 0 | 0 | `candidates=128`, `visited_nodes=128`, `visited_edges=612`, `edges_per_visited_node=4.781` | `neighbor_tiles=39`, `neighbor_tile_avg_size=16`, `score_batch_calls=128`, `score_batch_singletons=128`, `scored_neighbors=127`, `already_visited_skips=485`, `frontier_pushes=128`, `frontier_pops=39`, `top_k_insert_attempts=128`, `top_k_insert_successes=22`, `top_k_insert_rejections=106` |
+| `ef_search=128` | `indexed` | 12.232 µs | 81,751 | 0 | 0 | `candidates=128`, `visited_nodes=128`, `visited_edges=612`, `edges_per_visited_node=4.781` | `neighbor_tiles=39`, `neighbor_tile_avg_size=16`, `score_batch_calls=25`, `score_batch_singletons=4`, `score_batch_size_2_4=8`, `score_batch_size_5_8=12`, `score_batch_size_9_16=1`, `already_visited_skips=485`, `frontier_pushes=128`, `top_k_rejections=106` |
+| `exact` (`ef_search=8192`) | `scalar` | 1.091 ms | 916.7 | 0 | 0 | `candidates=8192`, `visited_nodes=8192`, `visited_edges=100748`, `edges_per_visited_node=12.30` | `neighbor_tiles=6297`, `neighbor_tile_avg_size=16`, `score_batch_calls=8192`, `score_batch_singletons=8192`, `scored_neighbors=8191`, `already_visited_skips=92557`, `frontier_pushes=8192`, `frontier_pops=6297`, `top_k_rejections=8132`, `exact_order_observations=8192`, `exact_order_backward_jumps=5977` |
+| `exact` (`ef_search=8192`) | `indexed` | 1.277 ms | 782.9 | 0 | 0 | `candidates=8192`, `visited_nodes=8192`, `visited_edges=100748`, `edges_per_visited_node=12.30` | `neighbor_tiles=6297`, `neighbor_tile_avg_size=16`, `score_batch_calls=1797`, `score_batch_singletons=364`, `score_batch_size_2_4=502`, `score_batch_size_5_8=930`, `score_batch_size_9_16=1`, `already_visited_skips=92557`, `frontier_pushes=8192`, `top_k_rejections=8132`, `exact_order_observations=8192`, `exact_order_backward_jumps=5977` |
+
+#1979 interpretation:
+
+- The equal-topology #2091 fixture's `ef_search=128` row explains its 612
+  visited edges as layer-0 expansion work over 39 degree-16 neighbor tiles. The
+  high skip bucket is already-visited neighbors (`485/search`), not metadata
+  filtering (`filter_skips=0`) and not a storage-source fallback
+  (`graph_row_fallbacks=0`, `adjacency_source_fallbacks=0`).
+- The exact row is intentionally much more search work: it scores all 8192
+  candidates and visits 100748 edges/search. That high visited-edge count is
+  topology/frontier revisitation (`92557 already_visited_skips/search`) plus the
+  expected exact traversal budget, not typed-column adjacency overhead.
+- Natural neighbor tiles are full degree-16 tiles in this fixture
+  (`neighbor_tile_avg_size=16`). The scalar default still performs singleton
+  scoring (`score_batch_singletons == score_batch_calls`), so batchability exists
+  in the traversal but is not consumed by the default scoring path.
+- The indexed diagnostic row demonstrates available score grouping without
+  changing result order or default runtime behavior: exact-mode score calls drop
+  from 8192 singleton calls to 1797 calls, mostly size 2-8 tiles. It is not a
+  promotion claim because this row runs under debug instrumentation and the
+  existing indexed scoring hook is not enabled by default.
+- Exact candidate order is not mostly sequential (`5977 backward jumps` versus
+  `2199 adjacent-forward transitions` in the exact row), so a renewed exact-mode
+  indexed-scoring ticket should expect graph-order/gathered batches rather than
+  long contiguous row runs.
+
+Follow-up recommendation: keep #2035 open as not performance-satisfied. Use this
+#1979 evidence to prioritize #1980 frontier/top-k and already-visited handling
+for control-flow overhead, and use a separate narrow indexed-scoring ticket if
+exact-mode gathered score batching becomes a goal. #1977 normalized-vector
+storage remains a separate scoring/storage-format follow-up and is not
+implemented here.
+
 ## Interpretation rules
 
 - `combined_prepared_typed_column` rows are #2045 prepared-routing evidence;

--- a/TreeDB/docs/spec/typed-column-graph-search-prepared-views.md
+++ b/TreeDB/docs/spec/typed-column-graph-search-prepared-views.md
@@ -40,10 +40,13 @@ is not an unconditional wall-time win over the old legacy graph-row direct
 control and does not close #2035 as fully performance-satisfied: the final matrix
 still shows net throughput gaps, and the legacy/current graph-only rows also
 expose a topology/search-work mismatch (`612` versus `3340` visited_edges/search,
-about 5.5x). #1979 owns the follow-up instrumentation needed to explain that
-work delta; #1980 remains a profile-backed frontier/top-k follow-up if future
-apples-to-apples profiles justify it; #1977 normalized-vector payloads remain
-deferred.
+about 5.5x). #1979 now adds opt-in benchmark-debug control-flow counters on the
+#2091 topology-parity fixture: the bounded equal-topology row visits 612 edges
+mostly through already-visited layer-0 skips, while exact mode visits 100748
+edges/search by scoring all 8192 candidates. #1980 remains a profile-backed
+frontier/top-k or already-visited follow-up if future apples-to-apples profiles
+justify it; exact-mode gathered scoring should be a separate narrow ticket;
+#1977 normalized-vector payloads remain deferred.
 
 Normative boundaries:
 

--- a/TreeDB/docs/spec/verification.md
+++ b/TreeDB/docs/spec/verification.md
@@ -889,6 +889,12 @@ Invariant:
   current prepared typed-column reader; parity tests must assert equal
   search-work counters and equivalent results before the benchmark evidence is
   used for #2035 promotion decisions.
+- The #1979 batchability benchmark must be opt-in (`benchmark_debug`) and must
+  report neighbor tile distribution, score-batch histograms, scored-versus-skipped
+  neighbors, already-visited skips, layer-0 versus upper-layer work,
+  frontier/top-k operation counts, visited-mark hits/misses, exact-mode candidate
+  order summaries, `ns/op`, `ops/sec`, `B/op`, and `allocs/op` without changing
+  traversal semantics or fixture topology.
 
 Coverage:
 - Policy owner: `TreeDB/docs/spec/typed-column-graph-search-benchmark-matrix.md`.
@@ -902,6 +908,11 @@ Coverage:
     topology/search-work/result parity gate, and
     `BenchmarkColumnVectorGraphSearchTopologyParity2091` emits the equal-work
     graph-only and result-ID rows.
+  - `TreeDB/collections/column_vector_graph_batchability_1979_test.go`:
+    `TestColumnVectorGraphNativeSearchBenchmarkDebugCounters1979` checks #1979
+    counter reconciliation, skip buckets, layer work, frontier/top-k counts, and
+    exact-mode candidate-order summaries; `BenchmarkColumnVectorGraphSearchBatchability1979`
+    emits the opt-in batchability/control-flow rows.
 
 ## 13. Native Wire Protocol
 


### PR DESCRIPTION
## Objective

Add opt-in `benchmark_debug` HNSW graph-search instrumentation and benchmark evidence to quantify natural batching opportunities and visited-edge work buckets without changing traversal semantics, persisted formats, or default scoring behavior. Keep the default search path free of any debug-counter overhead by isolating all counter updates strictly to benchmark-debug-only helper paths and explicit `debugCounters != nil` / `BenchmarkDebugSearches != 0` guards.

## Context

This change is needed to gather concrete evidence for #1979 on the native column-vector graph path using the #2091 topology-parity fixture. The hot-path helper split and per-call nil-check gating keep the instrumentation strictly opt-in, so the PR measures batchability without introducing any branch overhead on default/minimal/full-diagnostics search paths.

## Non-goals

- No persistent format changes.
- No default runtime optimization or scoring-path promotion.
- No traversal semantic, recall/order, or fixture-topology changes.
- No enabling indexed diagnostic scoring outside the existing internal benchmark hook.
- No broader exact-mode optimization beyond exposing and measuring current batching opportunity.

## Design

- Formats/flags/APIs changed (include diagrams if applicable)
  - Extends native search stats reporting under opt-in `StatsMode=benchmark_debug`.
  - Adds benchmark-debug counters for neighbor tiles, score-batch histograms/singletons, visited/skip buckets, frontier/top-k operations, visited-mark hits/misses, and exact-order summaries.
  - Restores no-argument default `pushFrontier` / `popFrontier` / `frontierSift*` / `insertTop` helpers with the original zero-branch path; separate `*Debug` variants are called only when benchmark-debug counters exist.
  - `recordScore` / `recordScores` calls in `scoreAndPushFrontierVisited` / `scoreAndPushFrontierVisitedTile` are gated behind `debugCounters != nil`.
  - All layer-0 traversal debug counter calls (`recordLayer0Edge`, `recordVisitedMark`, `recordAlreadyVisitedSkip`, `recordFilterSkip`) are gated behind `debugCounters != nil`.
  - Score-batch histogram recording in `recordColumnVectorGraphScoreBatchStats` is gated behind `stats.BenchmarkDebugSearches != 0`.
- Invariants that must hold
  - Default/minimal/full-diagnostics search behavior and results remain unchanged.
  - Benchmark-debug mode reports additional counters without changing traversal order, candidate limits, or returned results.
  - Frontier/top-k scratch operations and all traversal hot paths contain zero debug-counter branches when debug counters are disabled.
- Fail-closed behavior (caps before alloc; CRC/error handling)
  - No new persisted format, CRC, or allocation-surface changes are introduced in this PR.
  - Existing fail-closed search-source and adjacency validation behavior remains unchanged.

## Scope

- Includes (files/symbols):
  - `TreeDB/collections/column_vector_graph_search.go`
  - `TreeDB/collections/column_vector_graph_search_test.go`
  - `TreeDB/collections` benchmark/test coverage for `BenchmarkColumnVectorGraphSearchBatchability1979`
  - `TreeDB/docs` updates tied to #1979/#2091 reporting
- Excludes (files/symbols):
  - Persistent graph/index formats
  - Default indexed scoring enablement
  - Traversal algorithm changes
  - Fixture topology changes
  - #1977 normalized-vector storage/scoring work

## Correctness

- Tests run (exact commands):
  - `GOWORK=off go test ./TreeDB/collections -run 'TestColumnVectorGraphNativeSearchBenchmarkDebugCounters1979|TestColumnVectorGraphSearchTopologyParity2091|TestVectorGraphSearchTruthMatrixMetricContract2037'`
  - `GOWORK=off go test ./TreeDB/docs`
  - `GOWORK=off go test ./TreeDB/collections ./TreeDB/docs`
  - `git diff --check origin/main...HEAD`
- Corruption/edge cases covered:
  - Counter reconciliation for bounded vs exact search modes.
  - Topology-parity verification on the production fixture.
  - Exact-order summary coverage and visited-edge bucket accounting.
  - Review follow-up preserves the original non-debug frontier/top-k and traversal-loop hot paths while validating benchmark-debug counter collection separately.
- Concurrency/race coverage (if applicable):
  - Not applicable; no concurrency model changes in this PR.

## Performance

- Benchmarks run (exact commands):
  - ```sh
    OUT=/tmp/gomap_1979_batchability_final_20260531_140228
    GOMAXPROCS=8 GOWORK=off go test ./TreeDB/collections \
      -run '^$' \
      -bench '^BenchmarkColumnVectorGraphSearchBatchability1979$' \
      -benchmem -benchtime=500ms -count=3 | tee "$OUT/batchability_1979_bench.txt"
    ```
  - `GOMAXPROCS=8 GOWORK=off go test ./TreeDB/collections -run '^$' -bench '^BenchmarkColumnVectorGraphSearchBatchability1979$' -benchmem -benchtime=200ms -count=1`
- Results table (before/after; median-of-5 per G1 in `docs/OPT_SPRINT_NEXT.md`):
  - Reported evidence from the main run is median-of-3 on macOS 26.2 / Apple M3 / 8 logical CPUs / 16 GiB / `go version go1.25.5 darwin/arm64`.

| Search mode | Score mode | ns/op | ops/sec | B/op | allocs/op | Key counters |
| --- | --- | ---: | ---: | ---: | ---: | --- |
| `ef_search=128` | scalar | 9.846 µs | 101,561 | 0 | 0 | `visited_edges=612`, `visited_nodes=128`, `neighbor_tiles=39`, `neighbor_tile_avg_size=16`, `score_batch_calls=128`, `score_batch_singletons=128`, `already_visited_skips=485`, `filter_skips=0` |
| `ef_search=128` | indexed diagnostic | 12.232 µs | 81,751 | 0 | 0 | `visited_edges=612`, `score_batch_calls=25`, `score_batch_singletons=4`, `score_batch_size_2_4=8`, `score_batch_size_5_8=12`, `score_batch_size_9_16=1`, `already_visited_skips=485` |
| exact (`ef_search=8192`) | scalar | 1.091 ms | 916.7 | 0 | 0 | `candidates=8192`, `visited_edges=100748`, `neighbor_tiles=6297`, `score_batch_calls=8192`, `score_batch_singletons=8192`, `already_visited_skips=92557`, `exact_order_backward_jumps=5977` |
| exact (`ef_search=8192`) | indexed diagnostic | 1.277 ms | 782.9 | 0 | 0 | `candidates=8192`, `visited_edges=100748`, `score_batch_calls=1797`, `score_batch_singletons=364`, `score_batch_size_2_4=502`, `score_batch_size_5_8=930`, `exact_order_backward_jumps=5977` |

- Regressions (if any) and why acceptable:
  - Benchmark-debug mode adds diagnostic branches/counters by design.
  - Non-`benchmark_debug` paths avoid all debug-counter overhead: frontier/top-k helpers, scoring helpers, layer-0 traversal loops, and score-batch histogram recording all contain zero debug-counter calls when `debugCounters` is nil / `BenchmarkDebugSearches` is 0.

## Rollout / Toggle Plan

- Default setting:
  - Off by default; detailed counters are emitted only with `StatsMode=benchmark_debug`.
- How to disable quickly:
  - Leave `StatsMode` at default/minimal/full-diagnostics modes and do not use the internal indexed diagnostic benchmark hook.

## Follow-ups

- #1980 for frontier/top-k/already-visited optimization, if pursued.
- Separate narrow exact-mode indexed-scoring follow-up, if desired.
- #1977 normalized-vector storage/scoring remains out of scope for this PR.

## Column Graph Native Workstream (#1646, if applicable)

### Copied/Adapted From Old Stack

- Copied:
  - None.
- Adapted:
  - Native search stats/reporting and benchmark coverage were extended in the column-graph path.
- Oracle/comparator only:
  - Existing truth-matrix/topology-parity coverage remains the comparator for result correctness.
- Quarantined/not copied:
  - No old-stack feature promotion or format behavior was reintroduced.

### Path Identity

- Native reader:
  - `columnVectorGraphPhysicalRowReader` native search path with opt-in benchmark-debug instrumentation.
- Decoded comparator:
  - Existing truth-matrix contract tests remain the decoded-oracle comparison.
- Legacy/native vector index:
  - Indexed diagnostic scoring remains benchmark-only and non-default.
- Unsupported/fail-closed:
  - No new unsupported path is enabled; existing fail-closed validation remains intact.

### Base And Dependency State

- Base branch:
  - Unchanged from the original PR.
- Base commit:
  - Unchanged from the original PR.
- Base PR/head:
  - Latest head includes the hot-path helper split and full per-call nil-check gating follow-up.
- #1621/#1634 assumptions:
  - Unchanged by this PR.
- Missing generic column-store primitives:
  - None added here.
- Parent review fixes propagated:
  - Yes; latest head separates default scratch helpers from benchmark-debug-only helper variants and gates all remaining debug counter calls behind explicit nil/zero checks.

### Evidence

- Tests:
  - Focused collections counter/topology/truth-matrix tests and `TreeDB/docs` passed with the commands listed above.
- Benchmarks:
  - `BenchmarkColumnVectorGraphSearchBatchability1979` ran for bounded and exact scalar/indexed-diagnostic modes.
- Status/fallback proof:
  - Reported counters show no graph-row or adjacency-source fallback in the highlighted bounded row.
- Performance attribution:
  - Measured visited-edge work is attributed to graph expansion/revisitation and batching opportunity, not format overhead.
- Local regressions found/fixed:
  - Review-raised hot-path nil-check overhead in frontier/top-k scratch helpers was fixed by restoring non-debug helpers and adding separate `*Debug` variants.
  - Second review pass identified remaining unconditional `recordScore`/`recordScores` calls in scoring helpers and unconditional debug counter calls in layer-0 traversal loops and score-batch stats; all gated in latest head.

### Test Plan Start

- Milestone tasks targeted:
  - #1979 batchability evidence on the native column-graph search path.
- Tests to add before or with implementation:
  - Benchmark-debug counter reconciliation and topology-parity coverage.
- Existing tests to preserve:
  - Truth-matrix metric contract and existing native search correctness coverage.
- #1646 test-list changes made before implementation:
  - None.

### Performance Plan Start

- Relevant benchmarks/metrics for this PR:
  - Neighbor tile sizes, score-batch histograms, visited-edge/skip buckets, frontier/top-k counters, exact-order summaries.
- Baseline/comparator command or reason not applicable:
  - Comparator is topology parity plus bounded/exact scalar vs indexed-diagnostic rows on the same fixture.
- Expected setup/search/materialization boundary:
  - This PR measures search-path control flow only; no persistent materialization changes.
- Upstream costs explicitly out of scope:
  - Default indexed scoring enablement and broader exact-mode optimization.
- Local performance risks to watch:
  - Any non-opt-in overhead on default search paths; fully addressed in latest head by nil-check gating across all hot-path helpers and traversal loops.

### Test Plan Close

- Additional tests found during implementation/review:
  - No new test files were required for the helper split or gating fixes; existing focused coverage remained applicable.
- Tests added or changed:
  - Benchmark-debug counter reconciliation coverage and benchmark additions from the original PR remained in place.
- Failing tests fixed:
  - None beyond the review follow-up validations.
- #1646 test-list changes made at close:
  - None.
- Residual untested gaps, if any:
  - No full-repo `go test ./... -count=1` run was performed in this PR description.

### Performance Plan Close

- Benchmark commands run:
  - The two commands listed in the Performance section.
- Results summary with throughput/latency/allocations:
  - Scalar bounded: 9.846 µs / 101,561 ops/sec / 0 B/op / 0 allocs/op.
  - Indexed diagnostic bounded: 12.232 µs / 81,751 ops/sec / 0 B/op / 0 allocs/op.
  - Scalar exact: 1.091 ms / 916.7 ops/sec / 0 B/op / 0 allocs/op.
  - Indexed diagnostic exact: 1.277 ms / 782.9 ops/sec / 0 B/op / 0 allocs/op.
- Before/after or baseline comparison:
  - Main comparison is scalar/default vs indexed-diagnostic scoring under identical topology; latest head removes all default-path debug-counter branch overhead across scoring helpers, traversal loops, and score-batch stats recording.
- Local slow/heavy code found and fixed:
  - Yes; frontier/top-k debug-counter nil-checks in default helper paths were removed by splitting debug and non-debug helpers; subsequent review pass removed remaining unconditional `recordScore`/`recordScores` calls and gated all layer-0 traversal and score-batch debug counter calls.
- Remaining upstream or deferred costs:
  - Benchmark-debug overhead remains opt-in, and broader optimization follow-ups stay deferred.

### AI Review Loop

- Codex latest-head review:
  - Re-requested on latest head.
- Copilot latest-head review:
  - Re-requested on latest head; all raised concerns confirmed resolved.
- CodeRabbit latest-head review:
  - Re-requested on latest head.
- Review comments/threads resolved or explicitly dismissed:
  - First review: hot-path nil-check overhead in frontier/top-k scratch helpers resolved by helper split.
  - Second review: unconditional `recordScore`/`recordScores` in scoring helpers, unconditional layer-0 traversal debug counter calls, and unconditional score-batch debug histogram call all resolved by explicit nil/zero gating in latest head.
- Re-requested after final meaningful push:
  - Yes.

---

## Optimization PR Checklist (TreeDB)

### Scope
- [x] Single, clear objective for this PR (not a bundle)
- [x] Explicit include list (files/symbols touched):
- [x] Explicit exclude list (files/symbols NOT touched):
- [x] No unwanted feature reintroduction (e.g. async slab writer, hard zones, ValueIndex) unless explicitly stated in the PR objective

### Safety / Correctness
- [x] Clear written-vs-durable semantics for any `*Sync` path touched
- [x] No new mmap usage on mutable/truncating files
- [x] All new length fields are capped before allocation (OOM-safe)
- [x] CRC/checksum behavior is fail-closed (clean error, no panic)
- [x] Any concurrency change has a defined state machine and invariants

### Tests
- [x] Added deterministic regression tests for the targeted failure mode
- [x] Tests avoid sleeps where possible (use latches/hooks)
- [x] Added corruption/edge-case tests (truncation, bad headers, invalid lengths) when format/parsing changes
- [ ] Ran locally:
  - [ ] `go test ./... -count=1`
  - [x] Any targeted packages/benchmarks:

### Benchmarks / Measurements
- [x] Added or updated a benchmark relevant to the change
- [x] Reported results in PR description (before/after, command, machine)
- [x] Included "incompressible" (worst-case) results if compression is involved

### Docs
- [ ] Updated `docs/OPT_SPRINT_NEXT.md` milestone status (if applicable)
- [x] Documented any new config knobs + defaults
- [x] Called out any format change in PR description (pre-alpha OK)

### Rollout / Toggle Plan (if behavior-affecting)
- [x] Safe defaults (feature off or conservative threshold)
- [x] Clear knobs to disable/revert behavior quickly
- [x] Observability: counters/logs to verify effectiveness