### PR TITLE
Profile and trim nativewire YCSB insert hot path

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -426,6 +426,8 @@ type CollectionInsertStats struct {
 	Runs                         int
 	BufferedIndexedBatches       int
 	BufferedIndexedBypassBatches int
+	ValidationPreflightReused    int
+	ValidationPreflightRechecked int
 	PrepareDocuments             time.Duration
 	IndexStateExtraction         time.Duration
 	// DuplicateDocumentPreflight includes duplicate-ID detection and
@@ -603,80 +605,82 @@ func collectionUpdateCombineBucketIndex(value int) int {
 // append timings, and UpdateBatchBufferLockHold encloses other buffer-stage
 // work done while holding the write-domain mutex.
 type CollectionManagerStats struct {
-	Domains                        int
-	PendingDocuments               int
-	PendingBytes                   int64
-	PendingRootRuns                int
-	PendingIndexedFlushUnits       int
-	OverlayMutableDocuments        int
-	OverlayQueuedIndexedFlushUnits int
-	OverlayActiveIndexedFlushUnits int
-	OverlayVisibleDepth            int
-	IndexedAsyncFlushRunning       int
-	MutationLockCalls              uint64
-	MutationLockWait               time.Duration
-	MutationLockHold               time.Duration
-	IndexedStageBatches            uint64
-	IndexedStageDocs               uint64
-	IndexedStageBytes              uint64
-	IndexedStageRootRuns           uint64
-	IndexedAutoFlushes             uint64
-	IndexedAsyncFlushScheduled     uint64
-	IndexedAsyncFlushBackpressure  uint64
-	IndexedAsyncFlushWait          time.Duration
-	IndexedAsyncFlushErrors        uint64
-	IndexedFlushCalls              uint64
-	IndexedFlushErrors             uint64
-	IndexedFlushForcedDrains       uint64
-	IndexedFlushUnits              uint64
-	IndexedFlushDocs               uint64
-	IndexedFlushBytes              uint64
-	IndexedFlushRootRuns           uint64
-	IndexedFlushRoots              uint64
-	IndexedFlushDuration           time.Duration
-	IndexedFlushMaterialize        time.Duration
-	IndexedFlushPublish            time.Duration
-	RootDeltaPlanPrimaryRoots      uint64
-	RootDeltaPlanTemplateRoots     uint64
-	RootDeltaPlanIndexStateRoots   uint64
-	RootDeltaPlanSecondaryRoots    uint64
-	RootDeltaPlanEntries           uint64
-	RootDeltaPlanKeyBytes          uint64
-	RootDeltaPlanValueBytes        uint64
-	RootDeltaPlanTombstones        uint64
-	PrimaryOnlyUpdateCalls         uint64
-	PrimaryOnlyMatched             uint64
-	PrimaryOnlyModified            uint64
-	PrimaryOnlyBufferedCalls       uint64
-	PrimaryOnlyRootPublishes       uint64
-	PrimaryOnlyRootDeltaEntries    uint64
-	PrimaryOnlyRootDeltaKeyBytes   uint64
-	PrimaryOnlyRootDeltaValueBytes uint64
-	PrimaryOnlyCoalescedDocs       uint64
-	UpdateCombineRequests          uint64
-	UpdateCombineBatches           uint64
-	UpdateCombineBatchedRequests   uint64
-	UpdateCombineFallbackRequests  uint64
-	UpdateCombineQueueDepthMax     uint64
-	UpdateCombineInlineRequests    uint64
-	UpdateCombineEnqueue           time.Duration
-	UpdateCombineWait              time.Duration
-	UpdateCombineQueueWait         time.Duration
-	UpdateCombineDrain             time.Duration
-	UpdateCombineRun               time.Duration
-	UpdateCombineResultDelivery    time.Duration
-	UpdateCombineQueueDepthBuckets [CollectionUpdateCombineBucketCount]uint64
-	UpdateCombineBatchSizeBuckets  [CollectionUpdateCombineBucketCount]uint64
-	UpdateBatchCalls               uint64
-	UpdateBatchItems               uint64
-	UpdateBatchMatched             uint64
-	UpdateBatchModified            uint64
-	UpdateBatchRuns                uint64
-	UpdateBatchBufferedBatches     uint64
-	UpdateBatchCurrentRead         time.Duration
-	UpdateBatchCallback            time.Duration
-	UpdateBatchStructuredApply     time.Duration
-	UpdateBatchPrepareDocuments    time.Duration
+	Domains                            int
+	PendingDocuments                   int
+	PendingBytes                       int64
+	PendingRootRuns                    int
+	PendingIndexedFlushUnits           int
+	OverlayMutableDocuments            int
+	OverlayQueuedIndexedFlushUnits     int
+	OverlayActiveIndexedFlushUnits     int
+	OverlayVisibleDepth                int
+	IndexedAsyncFlushRunning           int
+	MutationLockCalls                  uint64
+	MutationLockWait                   time.Duration
+	MutationLockHold                   time.Duration
+	IndexedStageBatches                uint64
+	IndexedStageDocs                   uint64
+	IndexedStageBytes                  uint64
+	IndexedStageRootRuns               uint64
+	InsertValidationPreflightReused    uint64
+	InsertValidationPreflightRechecked uint64
+	IndexedAutoFlushes                 uint64
+	IndexedAsyncFlushScheduled         uint64
+	IndexedAsyncFlushBackpressure      uint64
+	IndexedAsyncFlushWait              time.Duration
+	IndexedAsyncFlushErrors            uint64
+	IndexedFlushCalls                  uint64
+	IndexedFlushErrors                 uint64
+	IndexedFlushForcedDrains           uint64
+	IndexedFlushUnits                  uint64
+	IndexedFlushDocs                   uint64
+	IndexedFlushBytes                  uint64
+	IndexedFlushRootRuns               uint64
+	IndexedFlushRoots                  uint64
+	IndexedFlushDuration               time.Duration
+	IndexedFlushMaterialize            time.Duration
+	IndexedFlushPublish                time.Duration
+	RootDeltaPlanPrimaryRoots          uint64
+	RootDeltaPlanTemplateRoots         uint64
+	RootDeltaPlanIndexStateRoots       uint64
+	RootDeltaPlanSecondaryRoots        uint64
+	RootDeltaPlanEntries               uint64
+	RootDeltaPlanKeyBytes              uint64
+	RootDeltaPlanValueBytes            uint64
+	RootDeltaPlanTombstones            uint64
+	PrimaryOnlyUpdateCalls             uint64
+	PrimaryOnlyMatched                 uint64
+	PrimaryOnlyModified                uint64
+	PrimaryOnlyBufferedCalls           uint64
+	PrimaryOnlyRootPublishes           uint64
+	PrimaryOnlyRootDeltaEntries        uint64
+	PrimaryOnlyRootDeltaKeyBytes       uint64
+	PrimaryOnlyRootDeltaValueBytes     uint64
+	PrimaryOnlyCoalescedDocs           uint64
+	UpdateCombineRequests              uint64
+	UpdateCombineBatches               uint64
+	UpdateCombineBatchedRequests       uint64
+	UpdateCombineFallbackRequests      uint64
+	UpdateCombineQueueDepthMax         uint64
+	UpdateCombineInlineRequests        uint64
+	UpdateCombineEnqueue               time.Duration
+	UpdateCombineWait                  time.Duration
+	UpdateCombineQueueWait             time.Duration
+	UpdateCombineDrain                 time.Duration
+	UpdateCombineRun                   time.Duration
+	UpdateCombineResultDelivery        time.Duration
+	UpdateCombineQueueDepthBuckets     [CollectionUpdateCombineBucketCount]uint64
+	UpdateCombineBatchSizeBuckets      [CollectionUpdateCombineBucketCount]uint64
+	UpdateBatchCalls                   uint64
+	UpdateBatchItems                   uint64
+	UpdateBatchMatched                 uint64
+	UpdateBatchModified                uint64
+	UpdateBatchRuns                    uint64
+	UpdateBatchBufferedBatches         uint64
+	UpdateBatchCurrentRead             time.Duration
+	UpdateBatchCallback                time.Duration
+	UpdateBatchStructuredApply         time.Duration
+	UpdateBatchPrepareDocuments        time.Duration
 	// UpdateBatchIndexStateExtract includes UpdateBatchOldIndexStateExtract
 	// and UpdateBatchNewIndexStateExtract; do not add all three together.
 	UpdateBatchIndexStateExtract    time.Duration
@@ -1080,6 +1084,8 @@ type collectionWriteDomain struct {
 	indexedStageDocs                   atomic.Uint64
 	indexedStageBytes                  atomic.Uint64
 	indexedStageRootRuns               atomic.Uint64
+	insertValidationPreflightReused    atomic.Uint64
+	insertValidationPreflightRechecked atomic.Uint64
 	indexedAutoFlushes                 atomic.Uint64
 	indexedAsyncFlushScheduled         atomic.Uint64
 	indexedAsyncFlushBackpressure      atomic.Uint64
@@ -1271,8 +1277,15 @@ func (c *Collection) setLastInsertStats(stats CollectionInsertStats) {
 	if c == nil {
 		return
 	}
+	c.setLastInsertStatsOwned(cloneCollectionInsertStats(stats))
+}
+
+func (c *Collection) setLastInsertStatsOwned(stats CollectionInsertStats) {
+	if c == nil {
+		return
+	}
 	c.insertStatsMu.Lock()
-	c.lastInsertStats = cloneCollectionInsertStats(stats)
+	c.lastInsertStats = stats
 	c.insertStatsMu.Unlock()
 }
 
@@ -1390,6 +1403,8 @@ func (m *CollectionManager) Stats() map[string]string {
 	out["treedb.collections.write_domain.indexed_stage.docs_total"] = fmt.Sprintf("%d", stats.IndexedStageDocs)
 	out["treedb.collections.write_domain.indexed_stage.bytes_total"] = fmt.Sprintf("%d", stats.IndexedStageBytes)
 	out["treedb.collections.write_domain.indexed_stage.root_runs_total"] = fmt.Sprintf("%d", stats.IndexedStageRootRuns)
+	out["treedb.collections.write_domain.insert.validation_preflight_reused_total"] = fmt.Sprintf("%d", stats.InsertValidationPreflightReused)
+	out["treedb.collections.write_domain.insert.validation_preflight_rechecked_total"] = fmt.Sprintf("%d", stats.InsertValidationPreflightRechecked)
 	out["treedb.collections.write_domain.indexed_stage.auto_flushes_total"] = fmt.Sprintf("%d", stats.IndexedAutoFlushes)
 	out["treedb.collections.write_domain.indexed_async_flush.scheduled_total"] = fmt.Sprintf("%d", stats.IndexedAsyncFlushScheduled)
 	out["treedb.collections.write_domain.indexed_async_flush.backpressure_sync_total"] = fmt.Sprintf("%d", stats.IndexedAsyncFlushBackpressure)
@@ -1686,6 +1701,8 @@ func (s *CollectionManagerStats) add(other CollectionManagerStats) {
 	s.IndexedStageDocs += other.IndexedStageDocs
 	s.IndexedStageBytes += other.IndexedStageBytes
 	s.IndexedStageRootRuns += other.IndexedStageRootRuns
+	s.InsertValidationPreflightReused += other.InsertValidationPreflightReused
+	s.InsertValidationPreflightRechecked += other.InsertValidationPreflightRechecked
 	s.IndexedAutoFlushes += other.IndexedAutoFlushes
 	s.IndexedAsyncFlushScheduled += other.IndexedAsyncFlushScheduled
 	s.IndexedAsyncFlushBackpressure += other.IndexedAsyncFlushBackpressure
@@ -1825,6 +1842,8 @@ func (domain *collectionWriteDomain) statsSnapshot() CollectionManagerStats {
 	stats.IndexedStageDocs = domain.indexedStageDocs.Load()
 	stats.IndexedStageBytes = domain.indexedStageBytes.Load()
 	stats.IndexedStageRootRuns = domain.indexedStageRootRuns.Load()
+	stats.InsertValidationPreflightReused = domain.insertValidationPreflightReused.Load()
+	stats.InsertValidationPreflightRechecked = domain.insertValidationPreflightRechecked.Load()
 	stats.IndexedAutoFlushes = domain.indexedAutoFlushes.Load()
 	stats.IndexedAsyncFlushScheduled = domain.indexedAsyncFlushScheduled.Load()
 	stats.IndexedAsyncFlushBackpressure = domain.indexedAsyncFlushBackpressure.Load()
@@ -1985,6 +2004,17 @@ func (domain *collectionWriteDomain) observeMutationLock(wait, hold time.Duratio
 	domain.mutationLockCalls.Add(1)
 	domain.mutationLockWaitTotalNs.Add(durationToAtomicNs(wait))
 	domain.mutationLockHoldTotalNs.Add(durationToAtomicNs(hold))
+}
+
+func (domain *collectionWriteDomain) observeInsertValidationPreflight(rechecked bool) {
+	if domain == nil {
+		return
+	}
+	if rechecked {
+		domain.insertValidationPreflightRechecked.Add(1)
+		return
+	}
+	domain.insertValidationPreflightReused.Add(1)
 }
 
 func (domain *collectionWriteDomain) observeUpdateBatchStats(stats CollectionUpdateStats) {
@@ -4477,7 +4507,21 @@ func (c *Collection) bufferDirectIndexedInsertPlanLocked(domain *collectionWrite
 	}
 	defer freezePreAppendTables()
 
-	rootTables := make(map[string]memtable.Table, len(direct.rootNames))
+	var rootTablesScratch [8]memtable.Table
+	rootTables := rootTablesScratch[:0]
+	if len(direct.rootNames) > len(rootTablesScratch) {
+		rootTables = make([]memtable.Table, len(direct.rootNames))
+	} else {
+		rootTables = rootTablesScratch[:len(direct.rootNames)]
+	}
+	rootTable := func(rootName string) memtable.Table {
+		for i, existing := range direct.rootNames {
+			if existing == rootName {
+				return rootTables[i]
+			}
+		}
+		return nil
+	}
 	actualRootRuns := 0
 	for i, rootName := range direct.rootNames {
 		baseRoot := catalog.rootID(rootName)
@@ -4492,13 +4536,13 @@ func (c *Collection) bufferDirectIndexedInsertPlanLocked(domain *collectionWrite
 		if table == nil {
 			return 0, fmt.Errorf("collections: InsertBatch collection %q failed to allocate direct root accumulator for %q", catalog.meta.Name, rootName)
 		}
-		rootTables[rootName] = table
+		rootTables[i] = table
 		if created {
 			actualRootRuns = saturatingAddNonNegativeInt(actualRootRuns, 1)
 		}
 	}
 	if len(direct.templateEntries) > 0 {
-		templateTable := rootTables[direct.templateRootName]
+		templateTable := rootTable(direct.templateRootName)
 		if templateTable == nil {
 			return 0, fmt.Errorf("collections: InsertBatch collection %q missing direct template root accumulator for %q", catalog.meta.Name, direct.templateRootName)
 		}
@@ -4511,7 +4555,7 @@ func (c *Collection) bufferDirectIndexedInsertPlanLocked(domain *collectionWrite
 		}
 	}
 	if len(direct.indexStateEntries) > 0 {
-		indexStateTable := rootTables[direct.indexStateRootName]
+		indexStateTable := rootTable(direct.indexStateRootName)
 		if indexStateTable == nil {
 			return 0, fmt.Errorf("collections: InsertBatch collection %q missing direct index-state root accumulator for %q", catalog.meta.Name, direct.indexStateRootName)
 		}
@@ -4523,7 +4567,7 @@ func (c *Collection) bufferDirectIndexedInsertPlanLocked(domain *collectionWrite
 			return 0, err
 		}
 	}
-	primaryTable := rootTables[direct.primaryRootName]
+	primaryTable := rootTable(direct.primaryRootName)
 	if primaryTable == nil {
 		return 0, fmt.Errorf("collections: InsertBatch collection %q missing direct primary root accumulator for %q", catalog.meta.Name, direct.primaryRootName)
 	}
@@ -4542,7 +4586,7 @@ func (c *Collection) bufferDirectIndexedInsertPlanLocked(domain *collectionWrite
 		addBufferedPrimaryRunIndexKeys(domain.primaryRunIndex, plan.primaryKeys, primaryTable)
 	}
 	for _, secondaryPlan := range direct.secondaryRootPlans {
-		table := rootTables[secondaryPlan.rootName]
+		table := rootTable(secondaryPlan.rootName)
 		if table == nil {
 			continue
 		}
@@ -8861,7 +8905,7 @@ func (c *Collection) insertBatchOnceWithOptimisticPlanning(ids, documents [][]by
 	plan.stats.BufferedIndexedBatches = 1
 	if !insertBatchPlanHasRootWork(plan) {
 		closePlanningSnapshot()
-		c.setLastInsertStats(plan.stats.CollectionInsertStats)
+		c.setLastInsertStatsOwned(plan.stats.CollectionInsertStats)
 		return maybeInsertBatchResultIDs(plan.resultIDs, execOpts), nil, true
 	}
 	resultIDs, err := cloneInsertBatchResultIDs(plan.resultIDs, execOpts)
@@ -8908,7 +8952,7 @@ func (c *Collection) insertBatchOnceWithOptimisticPlanning(ids, documents [][]by
 		return nil, err, true
 	}
 	plan.stats.Publish += bufferFlushElapsed
-	c.setLastInsertStats(plan.stats.CollectionInsertStats)
+	c.setLastInsertStatsOwned(plan.stats.CollectionInsertStats)
 	return resultIDs, nil, true
 }
 
@@ -9172,7 +9216,7 @@ func (c *Collection) insertBatchOnceWithLockState(
 	if !insertBatchPlanHasRootWork(plan) {
 		closePlanningSnapshot()
 		templateEncoder.learnTemplateV1Templates(c, plan.templateLearned)
-		c.setLastInsertStats(plan.stats.CollectionInsertStats)
+		c.setLastInsertStatsOwned(plan.stats.CollectionInsertStats)
 		return maybeInsertBatchResultIDs(plan.resultIDs, execOpts), nil
 	}
 
@@ -9198,7 +9242,7 @@ func (c *Collection) insertBatchOnceWithLockState(
 		}
 		plan.stats.Publish += bufferFlushElapsed
 		templateEncoder.learnTemplateV1Templates(c, plan.templateLearned)
-		c.setLastInsertStats(plan.stats.CollectionInsertStats)
+		c.setLastInsertStatsOwned(plan.stats.CollectionInsertStats)
 		return resultIDs, nil
 	}
 	if err := rejectCatalogRootOverlaysForWrite(catalog); err != nil {
@@ -9265,15 +9309,19 @@ func (c *Collection) insertBatchOnceWithLockState(
 		}
 		resetCollectionRunTables(plan.runs)
 	}()
-	for _, run := range plan.runs {
+	for i, run := range plan.runs {
 		iter := run.table.NewIterator(nil, nil)
 		iterators = append(iterators, iter)
+		if i >= len(baseRootIDs) {
+			return nil, fmt.Errorf("collections: insert plan missing base root id collection=%q root=%q", meta.Name, run.name)
+		}
 		ordered = append(ordered, backenddb.OrderedRootDeltaPublishInput{
-			BaseRoot:      baseRootIDs[run.name],
+			BaseRoot:      baseRootIDs[i],
 			Iter:          iter,
 			StoragePolicy: run.storagePolicy,
 		})
 	}
+	baseRootIDMap := insertBatchBaseRootIDMap(rootNames, baseRootIDs)
 
 	publishStart := time.Now()
 	var newSystemRoot uint64
@@ -9288,7 +9336,7 @@ func (c *Collection) insertBatchOnceWithLockState(
 				baseCommitSeq:    baseCommitSeq,
 				baseSystemRoot:   baseSystemRoot,
 				rootNames:        cloneColumnPublishRootNames(rootNames),
-				baseRootIDs:      cloneColumnPublishBaseRootIDs(baseRootIDs),
+				baseRootIDs:      cloneColumnPublishBaseRootIDs(baseRootIDMap),
 				commandWALIntent: commandWALIntent,
 				operation:        ColumnPublishOperationInsert,
 				documents:        columnWriteDocumentsFromCommitLog(commandWALDocuments),
@@ -9301,7 +9349,7 @@ func (c *Collection) insertBatchOnceWithLockState(
 		publishRootNames = rootNames
 		err = c.withCommandWALPublishCoordinator(func() error {
 			newSystemRoot, rootIDs, err = c.db.PublishOrderedRootDeltaGroupWithCommandWALAndSystemDeltaBuilder(ordered, commandWALIntent, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
-				return c.buildRootDescriptorSystemDeltaIterator(baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, rootIDs)
+				return c.buildRootDescriptorSystemDeltaIterator(baseCommitSeq, baseSystemRoot, rootNames, baseRootIDMap, rootIDs)
 			})
 			return err
 		})
@@ -9309,7 +9357,7 @@ func (c *Collection) insertBatchOnceWithLockState(
 		publishMeta = meta
 		publishRootNames = rootNames
 		newSystemRoot, rootIDs, err = c.db.PublishOrderedRootDeltaGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
-			return c.buildRootDescriptorSystemDeltaIterator(baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, rootIDs)
+			return c.buildRootDescriptorSystemDeltaIterator(baseCommitSeq, baseSystemRoot, rootNames, baseRootIDMap, rootIDs)
 		})
 	}
 	plan.stats.Publish = time.Since(publishStart)
@@ -9324,7 +9372,7 @@ func (c *Collection) insertBatchOnceWithLockState(
 	c.rememberCatalogAtSystemRoot(newSystemRoot, nextCatalog)
 	c.noteWriteDomainCatalog(newSystemRoot, nextCatalog)
 	templateEncoder.learnTemplateV1Templates(c, plan.templateLearned)
-	c.setLastInsertStats(plan.stats.CollectionInsertStats)
+	c.setLastInsertStatsOwned(plan.stats.CollectionInsertStats)
 	return maybeInsertBatchResultIDs(plan.resultIDs, execOpts), nil
 }
 
@@ -9479,26 +9527,26 @@ func templateV1PlanningSnapshotNeedsRefresh(domain *collectionWriteDomain, snap 
 	return collectionWriteDomainSnapshotStale(domain, snapshotCommitSeq(snap), snapshotSystemRoot(snap))
 }
 
-func insertBatchPlanRootNamesAndBaseIDs(plan *insertBatchPlan, catalog *collectionCatalog) ([]string, map[string]uint64) {
+func insertBatchPlanRootNamesAndBaseIDs(plan *insertBatchPlan, catalog *collectionCatalog) ([]string, []uint64) {
 	if plan == nil {
 		return nil, nil
 	}
 	if direct := plan.directBufferedInsert; direct != nil && len(direct.rootNames) > 0 {
 		rootNames := direct.rootNames
-		baseRootIDs := make(map[string]uint64, len(rootNames))
-		for _, rootName := range rootNames {
+		baseRootIDs := make([]uint64, len(rootNames))
+		for i, rootName := range rootNames {
 			if catalog != nil {
-				baseRootIDs[rootName] = catalog.rootID(rootName)
+				baseRootIDs[i] = catalog.rootID(rootName)
 			}
 		}
 		return rootNames, baseRootIDs
 	}
 	rootNames := make([]string, len(plan.runs))
-	baseRootIDs := make(map[string]uint64, len(plan.runs))
+	baseRootIDs := make([]uint64, len(plan.runs))
 	for i, run := range plan.runs {
 		rootNames[i] = run.name
 		if catalog != nil {
-			baseRootIDs[run.name] = catalog.rootID(run.name)
+			baseRootIDs[i] = catalog.rootID(run.name)
 		}
 	}
 	return rootNames, baseRootIDs
@@ -9533,7 +9581,7 @@ type insertBatchValidationContext struct {
 	catalog                   *collectionCatalog
 	meta                      CollectionMeta
 	rootNames                 []string
-	baseRootIDs               map[string]uint64
+	baseRootIDs               []uint64
 	plan                      *insertBatchPlan
 	allowRootDrift            bool
 	persistedConflictsChecked bool
@@ -9548,7 +9596,7 @@ func (c *Collection) lockAndValidateInsertBatchPlan(
 	catalog *collectionCatalog,
 	meta CollectionMeta,
 	rootNames []string,
-	baseRootIDs map[string]uint64,
+	baseRootIDs []uint64,
 	persistedConflictsChecked bool,
 	preflightBaseCommitSeq uint64,
 	preflightBaseSystemRoot uint64,
@@ -9582,13 +9630,43 @@ func (c *Collection) lockAndValidateInsertBatchPlan(
 	return pin, currentCatalog, snapshotCommitSeq(pin), snapshotSystemRoot(pin), nil
 }
 
-func updateInsertBatchBaseRootIDs(rootNames []string, baseRootIDs map[string]uint64, catalog *collectionCatalog) {
+func updateInsertBatchBaseRootIDs(rootNames []string, baseRootIDs []uint64, catalog *collectionCatalog) {
 	if catalog == nil || baseRootIDs == nil {
 		return
 	}
-	for _, rootName := range rootNames {
-		baseRootIDs[rootName] = catalog.rootID(rootName)
+	for i, rootName := range rootNames {
+		if i >= len(baseRootIDs) {
+			return
+		}
+		baseRootIDs[i] = catalog.rootID(rootName)
 	}
+}
+
+func insertBatchBaseRootID(rootNames []string, baseRootIDs []uint64, rootName string) (uint64, bool) {
+	for i, name := range rootNames {
+		if name != rootName {
+			continue
+		}
+		if i >= len(baseRootIDs) {
+			return 0, false
+		}
+		return baseRootIDs[i], true
+	}
+	return 0, false
+}
+
+func insertBatchBaseRootIDMap(rootNames []string, baseRootIDs []uint64) map[string]uint64 {
+	if len(rootNames) == 0 {
+		return nil
+	}
+	out := make(map[string]uint64, len(rootNames))
+	for i, rootName := range rootNames {
+		if i >= len(baseRootIDs) {
+			break
+		}
+		out[rootName] = baseRootIDs[i]
+	}
+	return out
 }
 
 func runTestBeforeInsertBatchPlanningHook() {
@@ -9640,10 +9718,18 @@ func (c *Collection) validateInsertBatchPlanLocked(validation insertBatchValidat
 	if validation.persistedConflictsChecked && validation.snap != nil && validation.catalog != nil {
 		currentCommitSeq, currentSystemRoot := dbCommitSeqAndSystemRoot(c.db)
 		if currentCommitSeq == validation.preflightBaseCommitSeq && currentSystemRoot == validation.preflightBaseSystemRoot {
+			c.writeDomain.observeInsertValidationPreflight(false)
+			if validation.plan != nil {
+				validation.plan.stats.ValidationPreflightReused++
+			}
 			if err := c.validateInsertBatchPlanWithSnapshotLocked(validation); err != nil {
 				return nil, nil, err
 			}
 			return validation.snap, validation.catalog, nil
+		}
+		c.writeDomain.observeInsertValidationPreflight(true)
+		if validation.plan != nil {
+			validation.plan.stats.ValidationPreflightRechecked++
 		}
 	}
 	current := c.db.AcquireSnapshot()
@@ -9679,11 +9765,11 @@ func (c *Collection) validateInsertBatchPlanWithSnapshotLocked(validation insert
 	if !sameCollectionMeta(validation.catalog.meta, validation.meta) {
 		return fmt.Errorf("collections: concurrent schema modification detected for %q", validation.meta.Name)
 	}
-	for _, rootName := range validation.rootNames {
-		want, ok := validation.baseRootIDs[rootName]
-		if !ok {
+	for i, rootName := range validation.rootNames {
+		if i >= len(validation.baseRootIDs) {
 			return fmt.Errorf("collections: insert plan missing base root id collection=%q root=%q", validation.meta.Name, rootName)
 		}
+		want := validation.baseRootIDs[i]
 		if got := validation.catalog.rootID(rootName); got != want && !validation.allowRootDrift {
 			return errConcurrentRootModification(validation.meta.Name, rootName)
 		}

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -2128,6 +2128,8 @@ func TestCollectionManagerStatsExposeIndexedWriteDomainMetrics(t *testing.T) {
 		"treedb.collections.write_domain.overlay.active_indexed_flush_units",
 		"treedb.collections.write_domain.overlay.visible_depth",
 		"treedb.collections.write_domain.indexed_stage.batches_total",
+		"treedb.collections.write_domain.insert.validation_preflight_reused_total",
+		"treedb.collections.write_domain.insert.validation_preflight_rechecked_total",
 		"treedb.collections.write_domain.indexed_async_flush.scheduled_total",
 		"treedb.collections.write_domain.indexed_async_flush.wait_ns_total",
 		"treedb.collections.write_domain.mutation_lock.calls_total",
@@ -9388,7 +9390,16 @@ func TestCollectionValidateInsertBatchPlanLockedClassifiesRaces(t *testing.T) {
 		runs:        []collectionRootRun{{name: rootName}},
 	}
 	rootNames, baseRootIDs := insertBatchPlanRootNamesAndBaseIDs(plan, catalog)
-	staleRootIDs := map[string]uint64{rootName: baseRootIDs[rootName] + 1}
+	baseRoot, ok := insertBatchBaseRootID(rootNames, baseRootIDs, rootName)
+	if !ok {
+		t.Fatalf("base root for %q not found", rootName)
+	}
+	staleRootIDs := append([]uint64(nil), baseRootIDs...)
+	for i, name := range rootNames {
+		if name == rootName {
+			staleRootIDs[i] = baseRoot + 1
+		}
+	}
 	validation := insertBatchValidationContext{
 		meta:        catalog.meta,
 		rootNames:   rootNames,
@@ -9403,7 +9414,7 @@ func TestCollectionValidateInsertBatchPlanLockedClassifiesRaces(t *testing.T) {
 	} else if !strings.Contains(err.Error(), `collection="users"`) || !strings.Contains(err.Error(), `root="users/primary"`) {
 		t.Fatalf("root mismatch err=%v missing collection/root context", err)
 	}
-	validation.baseRootIDs = map[string]uint64{}
+	validation.baseRootIDs = nil
 	if current, _, err := col.validateInsertBatchPlanLocked(validation); current != nil || err == nil || errors.Is(err, ErrConcurrentMutation) || !strings.Contains(err.Error(), `collection="users"`) || !strings.Contains(err.Error(), `root="users/primary"`) {
 		if current != nil {
 			_ = current.Close()
@@ -9478,7 +9489,10 @@ func TestCollectionLockAndValidateInsertBatchPlanAllowsDisjointRootDrift(t *test
 	}
 	defer resetCollectionRunTables(plan.runs)
 	rootNames, baseRootIDs := insertBatchPlanRootNamesAndBaseIDs(plan, catalog)
-	oldPrimaryRoot := baseRootIDs[collectionPrimaryRootName("users")]
+	oldPrimaryRoot, ok := insertBatchBaseRootID(rootNames, baseRootIDs, collectionPrimaryRootName("users"))
+	if !ok {
+		t.Fatal("planned insert missing primary root base id")
+	}
 
 	if _, err := col.InsertBatch([][]byte{[]byte("u3")}, [][]byte{[]byte(`{"city":"c"}`)}); err != nil {
 		t.Fatalf("insert disjoint concurrent row: %v", err)
@@ -9496,7 +9510,7 @@ func TestCollectionLockAndValidateInsertBatchPlanAllowsDisjointRootDrift(t *test
 	if currentPrimaryRoot == oldPrimaryRoot {
 		t.Fatal("test did not create primary root drift")
 	}
-	if got := baseRootIDs[collectionPrimaryRootName("users")]; got != currentPrimaryRoot {
+	if got, ok := insertBatchBaseRootID(rootNames, baseRootIDs, collectionPrimaryRootName("users")); !ok || got != currentPrimaryRoot {
 		t.Fatalf("rebased primary root=%d want %d", got, currentPrimaryRoot)
 	}
 }

--- a/TreeDB/collections/planner.go
+++ b/TreeDB/collections/planner.go
@@ -672,7 +672,9 @@ func (p insertBatchPlanner) singleItemIndexStateAndUniqueProbeRuns(item *insertB
 	item.state = state
 
 	uniqueRunCount := 0
+	preflightRunCount := 0
 	prefixBytes := 0
+	hasUniquePreflight := preflight.snapshot != nil && len(preflight.uniqueIndexRootIDs) != 0
 	for runtimeIdx, runtime := range runtimes {
 		if !runtime.def.unique {
 			continue
@@ -682,6 +684,9 @@ func (p insertBatchPlanner) singleItemIndexStateAndUniqueProbeRuns(item *insertB
 			continue
 		}
 		uniqueRunCount++
+		if hasUniquePreflight && preflight.uniqueIndexRootIDs[runtime.def.name] != 0 {
+			preflightRunCount++
+		}
 		for _, value := range values {
 			prefixBytes += len(value)
 		}
@@ -691,7 +696,10 @@ func (p insertBatchPlanner) singleItemIndexStateAndUniqueProbeRuns(item *insertB
 	}
 
 	allRuns := make([]collectionUniqueProbeRun, 0, uniqueRunCount)
-	preflightRuns := make([]collectionUniqueProbeRun, 0, uniqueRunCount)
+	var preflightRuns []collectionUniqueProbeRun
+	if preflightRunCount > 0 && preflightRunCount < uniqueRunCount {
+		preflightRuns = make([]collectionUniqueProbeRun, 0, preflightRunCount)
+	}
 	prefixArena := make([]byte, 0, prefixBytes)
 	for runtimeIdx, runtime := range runtimes {
 		if !runtime.def.unique {
@@ -714,9 +722,12 @@ func (p insertBatchPlanner) singleItemIndexStateAndUniqueProbeRuns(item *insertB
 			run.prefixes = append(run.prefixes, prefix)
 		}
 		allRuns = append(allRuns, run)
-		if preflight.snapshot != nil && preflight.uniqueIndexRootIDs[runtime.def.name] != 0 {
+		if preflightRuns != nil && hasUniquePreflight && preflight.uniqueIndexRootIDs[runtime.def.name] != 0 {
 			preflightRuns = append(preflightRuns, run)
 		}
+	}
+	if preflightRunCount == uniqueRunCount {
+		preflightRuns = allRuns
 	}
 	return allRuns, preflightRuns, nil
 }

--- a/TreeDB/collections/shape_bench_test.go
+++ b/TreeDB/collections/shape_bench_test.go
@@ -27,6 +27,8 @@ func addCollectionInsertStats(dst *collections.CollectionInsertStats, src collec
 	dst.Runs += src.Runs
 	dst.BufferedIndexedBatches += src.BufferedIndexedBatches
 	dst.BufferedIndexedBypassBatches += src.BufferedIndexedBypassBatches
+	dst.ValidationPreflightReused += src.ValidationPreflightReused
+	dst.ValidationPreflightRechecked += src.ValidationPreflightRechecked
 	dst.PrepareDocuments += src.PrepareDocuments
 	dst.IndexStateExtraction += src.IndexStateExtraction
 	dst.DuplicateDocumentPreflight += src.DuplicateDocumentPreflight
@@ -76,6 +78,12 @@ func benchmarkReportCollectionInsertStats(b *testing.B, docs, batches int, stats
 		}
 		if stats.BufferedIndexedBypassBatches > 0 {
 			b.ReportMetric(float64(stats.BufferedIndexedBypassBatches), "buffered_indexed_bypass_batches")
+		}
+		if stats.ValidationPreflightReused > 0 {
+			b.ReportMetric(float64(stats.ValidationPreflightReused)/float64(batches), "validation_preflight_reused/batch")
+		}
+		if stats.ValidationPreflightRechecked > 0 {
+			b.ReportMetric(float64(stats.ValidationPreflightRechecked)/float64(batches), "validation_preflight_rechecked/batch")
 		}
 	}
 }

--- a/TreeDB/nativewire/bench_test.go
+++ b/TreeDB/nativewire/bench_test.go
@@ -274,6 +274,14 @@ func (w *benchmarkFrameSink) Write(p []byte) (int, error) {
 
 func benchmarkDispatchRequest(tb testing.TB, server *Server, state *connState, sink *benchmarkFrameSink, body []byte) []byte {
 	tb.Helper()
+	response, err := benchmarkDispatchRequestError(server, state, sink, body)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	return response
+}
+
+func benchmarkDispatchRequestError(server *Server, state *connState, sink *benchmarkFrameSink, body []byte) ([]byte, error) {
 	sink.frame = sink.frame[:0]
 	header := iwire.Header{
 		Version:   iwire.Version{Major: iwire.ProtocolMajorV1, Minor: iwire.ProtocolMinorV0},
@@ -281,26 +289,26 @@ func benchmarkDispatchRequest(tb testing.TB, server *Server, state *connState, s
 		RequestID: 1,
 	}
 	if err := server.handleFrame(context.Background(), sink, state, header, body); err != nil {
-		tb.Fatalf("handleFrame: %v", err)
+		return nil, fmt.Errorf("handleFrame: %w", err)
 	}
 	if len(sink.frame) < int(iwire.FrameHeaderLenV1) {
-		tb.Fatalf("response frame too short: %d", len(sink.frame))
+		return nil, fmt.Errorf("response frame too short: %d", len(sink.frame))
 	}
 	responseHeader, err := iwire.DecodeHeader(sink.frame[:iwire.FrameHeaderLenV1], server.limits)
 	if err != nil {
-		tb.Fatalf("decode response header: %v", err)
+		return nil, fmt.Errorf("decode response header: %w", err)
 	}
 	if responseHeader.Type == iwire.FrameError {
-		tb.Fatalf("server returned error frame: %v", decodeWireError(sink.frame[iwire.FrameHeaderLenV1:], server.limits))
+		return nil, fmt.Errorf("server returned error frame: %w", decodeWireError(sink.frame[iwire.FrameHeaderLenV1:], server.limits))
 	}
 	if responseHeader.Type != iwire.FrameResponse {
-		tb.Fatalf("response type=%d want %d", responseHeader.Type, iwire.FrameResponse)
+		return nil, fmt.Errorf("response type=%d want %d", responseHeader.Type, iwire.FrameResponse)
 	}
 	response := sink.frame[iwire.FrameHeaderLenV1:]
 	if uint64(len(response)) != responseHeader.BodyLen {
-		tb.Fatalf("response body len=%d want %d", len(response), responseHeader.BodyLen)
+		return nil, fmt.Errorf("response body len=%d want %d", len(response), responseHeader.BodyLen)
 	}
-	return response
+	return response, nil
 }
 
 func benchmarkAddCollectionHandle(tb testing.TB, state *connState, server *Server, name string, col *collections.Collection) CollectionHandle {

--- a/TreeDB/nativewire/ycsb_bench_test.go
+++ b/TreeDB/nativewire/ycsb_bench_test.go
@@ -11,9 +11,14 @@ import (
 	"io"
 	"log"
 	"net"
+	"os"
+	"path/filepath"
+	"runtime/pprof"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	treedb "github.com/snissn/gomap/TreeDB"
 	"github.com/snissn/gomap/TreeDB/collections"
@@ -28,6 +33,10 @@ const (
 	ycsbBenchClients    = 16
 	ycsbBenchFields     = 10
 	ycsbBenchFieldLen   = 100
+
+	ycsbTimedCPUProfilePathEnv         = "TREEDB_NATIVEWIRE_YCSB_TIMED_CPU_PROFILE_PATH"
+	maxYCSBPrecomputedRequests         = 500_000
+	maxProfiledYCSBPrecomputedRequests = 1_000_000
 )
 
 var (
@@ -64,6 +73,21 @@ func BenchmarkNativewireYCSBLoad(b *testing.B) {
 			})
 		}
 	}
+}
+
+// BenchmarkNativewireYCSBLoadServerPrecomputed keeps the YCSB load shape but
+// moves client-side request construction and document encoding out of the timed
+// region. It is intended for CPU, alloc, block, and mutex profiles of the
+// server-side nativewire dispatch plus collection insert path.
+func BenchmarkNativewireYCSBLoadServerPrecomputed(b *testing.B) {
+	logOutput := log.Writer()
+	log.SetOutput(io.Discard)
+	defer log.SetOutput(logOutput)
+
+	tc := ycsbLoadFormat{name: "bson_binary", format: collections.DocumentFormatBSON, encode: encodeYCSBBSONBinaryDocument}
+	b.Run("inproc/"+tc.name, func(b *testing.B) {
+		benchmarkNativewireYCSBLoadServerPrecomputed(b, tc)
+	})
 }
 
 type ycsbLoadFormat struct {
@@ -171,6 +195,208 @@ func benchmarkNativewireYCSBLoad(b *testing.B, transport string, format ycsbLoad
 	}
 	b.ReportMetric(float64(len(sample)), "document_bytes")
 	b.ReportMetric(float64(ycsbBenchClients), "clients")
+}
+
+func benchmarkNativewireYCSBLoadServerPrecomputed(b *testing.B, format ycsbLoadFormat) {
+	requireSafeYCSBPrecomputedRequests(b)
+	env := newYCSBBenchEnv(b, format.format, false)
+	defer func() {
+		if err := env.cleanup(); err != nil {
+			b.Fatalf("cleanup: %v", err)
+		}
+	}()
+
+	col, err := env.server.collections.OpenCollection(ycsbBenchCollection)
+	if err != nil {
+		b.Fatalf("OpenCollection: %v", err)
+	}
+	workers := make([]ycsbPrecomputedNativewireWorker, ycsbBenchClients)
+	base := 0
+	for worker := 0; worker < ycsbBenchClients; worker++ {
+		count := b.N / ycsbBenchClients
+		if worker < b.N%ycsbBenchClients {
+			count++
+		}
+		state := benchmarkConnState()
+		handle := benchmarkAddCollectionHandle(b, state, env.server, ycsbBenchCollection, col)
+		workers[worker] = ycsbPrecomputedNativewireWorker{
+			state:  state,
+			bodies: precomputeYCSBInsertRequests(b, env.server, handle, format, base, count),
+		}
+		base += count
+	}
+
+	sample, err := format.encode(ycsbBenchKey(0))
+	if err != nil {
+		b.Fatalf("encode sample: %v", err)
+	}
+	beforeStats := env.server.collections.StatsSnapshot()
+	b.ReportAllocs()
+	b.SetBytes(int64(len(sample)))
+	b.ResetTimer()
+	b.StopTimer()
+	stopProfile := startTimedYCSBCPUProfile(b)
+	profileActive := true
+	defer func() {
+		if profileActive {
+			stopProfile()
+		}
+	}()
+
+	var failed atomic.Bool
+	var firstErr error
+	var firstErrOnce sync.Once
+	recordErr := func(err error) {
+		if err == nil {
+			return
+		}
+		failed.Store(true)
+		firstErrOnce.Do(func() {
+			firstErr = err
+		})
+	}
+
+	var wg sync.WaitGroup
+	b.StartTimer()
+	for worker := range workers {
+		if len(workers[worker].bodies) == 0 {
+			continue
+		}
+		worker := worker
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			sink := benchmarkFrameSink{}
+			for _, body := range workers[worker].bodies {
+				if failed.Load() {
+					return
+				}
+				if _, err := benchmarkDispatchRequestError(env.server, workers[worker].state, &sink, body); err != nil {
+					recordErr(err)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	b.StopTimer()
+	profileActive = false
+	stopProfile()
+	afterStats := env.server.collections.StatsSnapshot()
+	if firstErr != nil {
+		b.Fatal(firstErr)
+	}
+	b.ReportMetric(float64(len(sample)), "document_bytes")
+	b.ReportMetric(float64(ycsbBenchClients), "clients")
+	reportYCSBCollectionStatsDelta(b, beforeStats, afterStats, b.N)
+}
+
+type ycsbPrecomputedNativewireWorker struct {
+	state  *connState
+	bodies [][]byte
+}
+
+func precomputeYCSBInsertRequests(b *testing.B, server *Server, handle CollectionHandle, format ycsbLoadFormat, start, count int) [][]byte {
+	b.Helper()
+	bodies := make([][]byte, count)
+	ids := make([][]byte, 1)
+	docs := make([][]byte, 1)
+	for i := 0; i < count; i++ {
+		key := ycsbBenchKey(start + i)
+		doc, err := format.encode(key)
+		if err != nil {
+			b.Fatalf("encode %s: %v", key, err)
+		}
+		ids[0] = []byte(key)
+		docs[0] = doc
+		guard := benchmarkMutationGuard(b, server, "insert_batch_precomputed", start+i)
+		body, err := appendInsertBatchRequestBodyRefFlags(nil, "", handle, true, format.format, ids, docs, AckVisible, iwire.CommandFlagOmitResultIDs|iwire.CommandFlagOmitResponseMeta, guard)
+		if err != nil {
+			b.Fatalf("append insert request: %v", err)
+		}
+		bodies[i] = body
+	}
+	return bodies
+}
+
+func reportYCSBCollectionStatsDelta(b *testing.B, before, after collections.CollectionManagerStats, ops int) {
+	b.Helper()
+	if ops <= 0 {
+		return
+	}
+	reportUint64 := func(name string, value uint64) {
+		b.ReportMetric(float64(value)/float64(ops), name)
+	}
+	reportDuration := func(name string, value time.Duration) {
+		if value < 0 {
+			value = 0
+		}
+		b.ReportMetric(float64(value.Nanoseconds())/float64(ops), name)
+	}
+	reportUint64("mutation_lock_calls/op", uint64Delta(after.MutationLockCalls, before.MutationLockCalls))
+	reportDuration("mutation_lock_wait_ns/op", after.MutationLockWait-before.MutationLockWait)
+	reportDuration("mutation_lock_hold_ns/op", after.MutationLockHold-before.MutationLockHold)
+	reportUint64("indexed_stage_batches/op", uint64Delta(after.IndexedStageBatches, before.IndexedStageBatches))
+	reportUint64("indexed_stage_docs/op", uint64Delta(after.IndexedStageDocs, before.IndexedStageDocs))
+	reportUint64("indexed_stage_root_runs/op", uint64Delta(after.IndexedStageRootRuns, before.IndexedStageRootRuns))
+	reportUint64("validation_preflight_reused/op", uint64Delta(after.InsertValidationPreflightReused, before.InsertValidationPreflightReused))
+	reportUint64("validation_preflight_rechecked/op", uint64Delta(after.InsertValidationPreflightRechecked, before.InsertValidationPreflightRechecked))
+}
+
+func uint64Delta(after, before uint64) uint64 {
+	if after < before {
+		return 0
+	}
+	return after - before
+}
+
+func startTimedYCSBCPUProfile(b *testing.B) func() {
+	b.Helper()
+
+	profilePath := strings.TrimSpace(os.Getenv(ycsbTimedCPUProfilePathEnv))
+	if profilePath == "" {
+		return func() {}
+	}
+	if dir := filepath.Dir(profilePath); dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			b.Fatalf("create timed cpu profile dir: %v", err)
+		}
+	}
+	file, err := os.Create(profilePath)
+	if err != nil {
+		b.Fatalf("create timed cpu profile: %v", err)
+	}
+	if err := pprof.StartCPUProfile(file); err != nil {
+		_ = file.Close()
+		b.Fatalf("start timed cpu profile: %v; do not also pass go test -cpuprofile", err)
+	}
+
+	stopped := false
+	return func() {
+		if stopped {
+			return
+		}
+		pprof.StopCPUProfile()
+		stopped = true
+		if err := file.Close(); err != nil {
+			b.Errorf("close timed cpu profile: %v", err)
+		}
+	}
+}
+
+func requireSafeYCSBPrecomputedRequests(b *testing.B) {
+	b.Helper()
+
+	if strings.TrimSpace(os.Getenv(ycsbTimedCPUProfilePathEnv)) != "" {
+		if b.N <= maxProfiledYCSBPrecomputedRequests {
+			return
+		}
+		b.Fatalf("precomputed nativewire YCSB profile would build %d requests outside the timed section; use a fixed -benchtime below %d ops", b.N, maxProfiledYCSBPrecomputedRequests)
+	}
+	if b.N <= maxYCSBPrecomputedRequests {
+		return
+	}
+	b.Skipf("skipping precomputed nativewire YCSB benchmark with no %s: use fixed -benchtime <= %d ops", ycsbTimedCPUProfilePathEnv, maxYCSBPrecomputedRequests)
 }
 
 func newYCSBBenchEnv(tb testing.TB, format collections.DocumentFormat, tcp bool) *ycsbBenchEnv {


### PR DESCRIPTION
## Objective

Close the local #2097 graph node: add a cleaner server-side BSON/nativewire YCSB insert benchmark, instrument optimistic validation reuse, and trim medium-risk single-document insert scaffolding without changing the YCSB workload or nativewire correctness semantics.

Closes #2097. Follow-up combiner work remains tracked in #2095.

## Context

Recent YCSB insert work reduced obvious allocation overhead, but OPS/sec did not move enough to call the path done. Fresh profiling on `main` showed one remaining local slice was worthwhile before the bigger insert-combiner work: root/base metadata maps, unique-probe slice churn, direct root-table maps, and `LastInsertStats` cloning on every insert.

## Non-goals

- No YCSB workload, thread-count, document shape, or client request-shape change.
- No weakening of catalog/schema validation, unique-conflict checks, idempotency, ambiguous-commit handling, or persistent value-log semantics.
- No server-side insert combiner in this PR; #2095 is the next implementation node if lock serialization remains material.

## Design

- Adds `BenchmarkNativewireYCSBLoadServerPrecomputed/inproc/bson_binary`, which precomputes nativewire insert request bodies and runs the timed section as server-side dispatch plus collection insertion.
- Adds `TREEDB_NATIVEWIRE_YCSB_TIMED_CPU_PROFILE_PATH` so CPU profiles can start after request precompute and exclude off-timer BSON/request generation.
- Changes insert validation root/base metadata from per-root maps to positional slices in the direct/common path, converting back to maps only for older generic publish helpers that still require keyed metadata.
- Avoids the direct insert root-table map by using positional tables aligned with direct root names.
- Lazily allocates unique preflight run slices and aliases `allRuns` when every unique run is preflight-eligible.
- Adds validation preflight reuse/recheck counters to collection stats and benchmark output.
- Avoids extra `LastInsertStats` clone on internally-owned plan stats while preserving owned copies for public `LastInsertStats()` callers.

## Scope

Includes:
- `TreeDB/nativewire/ycsb_bench_test.go`
- `TreeDB/nativewire/bench_test.go`
- `TreeDB/collections/api.go`
- `TreeDB/collections/planner.go`
- `TreeDB/collections/api_test.go`
- `TreeDB/collections/shape_bench_test.go`

Excludes:
- #2095 insert combiner implementation.
- Memtable internals or value-log format changes.

## Correctness

Tests run on latest local head `19bd1905c`:

```sh
go test ./TreeDB/collections ./TreeDB/nativewire ./cmd/treedb-native-server -count=1
```

Result:

```text
ok   github.com/snissn/gomap/TreeDB/collections 93.106s
ok   github.com/snissn/gomap/TreeDB/nativewire 1.515s
?    github.com/snissn/gomap/cmd/treedb-native-server [no test files]
```

Additional targeted check after the final root/base positional cleanup:

```sh
go test ./TreeDB/collections -run 'TestCollectionValidateInsertBatchPlanLocked|TestCollectionLockAndValidateInsertBatchPlanAllowsDisjointRootDrift' -count=1
```

Result: `ok github.com/snissn/gomap/TreeDB/collections 0.047s`.

## Performance

Machine from benchmark output: `11th Gen Intel(R) Core(TM) i5-11400F @ 2.60GHz`.

Baseline worktree: clean `main` at `5fec03afd`.
Candidate branch: `codex/2097-ycsb-insert-next-round` at `19bd1905c`.
Command:

```sh
go test ./TreeDB/nativewire -run '^$' \
  -bench '^BenchmarkNativewireYCSBLoad$/inproc/bson_binary$' \
  -benchtime=100000x -count=3 -benchmem
```

| Version | Run | ns/op | ops/sec | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: | ---: |
| main `5fec03afd` | 1 | 9981 | 100,190 | 7584 | 56 |
| main `5fec03afd` | 2 | 9455 | 105,764 | 6289 | 56 |
| main `5fec03afd` | 3 | 9444 | 105,887 | 6289 | 56 |
| candidate `19bd1905c` | 1 | 9544 | 104,778 | 7248 | 53 |
| candidate `19bd1905c` | 2 | 8931 | 111,970 | 5953 | 53 |
| candidate `19bd1905c` | 3 | 9079 | 110,144 | 5953 | 53 |

Median changed from `9455 ns/op` to `9079 ns/op` and allocs dropped from `56` to `53` per op. The first run includes warmup/dictionary noise, so the main value of this PR is reducing overhead and adding cleaner profile evidence, not claiming a large throughput win.

New server-side precomputed benchmark command:

```sh
go test ./TreeDB/nativewire -run '^$' \
  -bench '^BenchmarkNativewireYCSBLoadServerPrecomputed$/inproc/bson_binary$' \
  -benchtime=100000x -count=3 -benchmem
```

| Run | ns/op | ops/sec | B/op | allocs/op | mutation lock wait/op | mutation lock hold/op | validation reused/op | validation rechecked/op |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 1 | 6781 | 147,471 | 3798 | 32 | 96.179 us | 5.159 us | 0.1319 | 0 |
| 2 | 6575 | 152,091 | 3797 | 32 | 91.806 us | 4.982 us | 0.1264 | 0 |
| 3 | 6645 | 150,489 | 3797 | 32 | 94.063 us | 5.043 us | 0.1285 | 0 |

Timed CPU profile command:

```sh
OUT=/tmp/treedb_2097_timed_profile_20260531_153004
TREEDB_NATIVEWIRE_YCSB_TIMED_CPU_PROFILE_PATH="$OUT/timed_cpu.pprof" \
go test ./TreeDB/nativewire -run '^$' \
  -bench '^BenchmarkNativewireYCSBLoadServerPrecomputed$/inproc/bson_binary$' \
  -benchtime=500000x -count=1 -benchmem \
  -memprofile "$OUT/mem.pprof" \
  -mutexprofile "$OUT/mutex.pprof" -mutexprofilefraction=1 \
  -blockprofile "$OUT/block.pprof" -blockprofilerate=1
```

Timed profile result with profiling overhead: `9763 ns/op`, `7307 B/op`, `35 allocs/op`. The timed CPU top no longer includes off-timer BSON/request generation. Main remaining signals:

| Signal | Evidence |
| --- | --- |
| Collection/nativewire insert path | `nativewire.(*Server).insertBatchDecoded`: `4.96s` cum of `7.91s` samples |
| Direct buffered staging | `Collection.bufferDirectIndexedInsertPlanLocked`: `1.35s` cum |
| Insert planning/preflight | `planInsertBatchWithPreflight`: `1.28s` cum; `planSingleDirectBufferedInsertWithPreflight`: `1.17s` cum |
| Validation/persisted conflict checks | `validateInsertBatchPlanWithSnapshotLocked`: `0.67s` cum; `Tree.HasAnySortedWithStats`: `0.41s` cum |
| Lock serialization | block profile `lockCollectionDomainMutation`: `65.85s` delay; mutex profile via `collectionMutationUnlock.Unlock`: `66.67s` delay |

## Regression Assessment

No material local regression found. This PR removes allocation overhead and adds measurement clarity. The remaining throughput ceiling is still the one-request/one-mutation-lock-entry shape, so #2095 should be the next high-priority node.

## AI Review Loop

- Codex latest-head review: not requested yet; PR body and local evidence are now mature enough to request after latest-head CI is active.
- Copilot latest-head review: not requested yet for the same reason.
- CodeRabbit latest-head review: not requested yet for the same reason.
- Review comments/threads resolved: none yet.
