### PR TITLE
Optimize TreeDB HNSW frontier scratch

### DIFF
--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -19,6 +19,10 @@ const columnVectorGraphNativeScratchOversizeSlack = 16
 // Larger result sets switch to sort.Slice so result ordering does not go O(k^2).
 const columnVectorGraphNativeResultOrderInsertionSortLimit = 32
 
+// Frontier traversal uses a max-heap ordered by score/ordinal. A modest fanout
+// lowers sift depth while preserving the same total comparator and pop order.
+const columnVectorGraphNativeFrontierHeapFanout = 4
+
 var (
 	errColumnVectorGraphNativeSearchScratchRequired            = errors.New("collections: column_graph native search requires caller-owned scratch")
 	errColumnVectorGraphNativeSearchQueryDimensionMismatch     = errors.New("collections: column_graph native search query dimension mismatch")
@@ -330,17 +334,11 @@ type columnVectorGraphNativeSearchLoopCounters struct {
 }
 
 func (c *columnVectorGraphNativeSearchLoopCounters) recordEdge() {
-	if c == nil {
-		return
-	}
 	c.Edges++
 	c.VisitedEdges++
 }
 
 func (c *columnVectorGraphNativeSearchLoopCounters) recordCandidate() {
-	if c == nil {
-		return
-	}
 	c.Candidates++
 }
 
@@ -965,8 +963,12 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 	var loopCounters columnVectorGraphNativeSearchLoopCounters
 	var preparedMinimalCounters *columnVectorGraphPreparedMinimalSearchCounters
 	var debugCounters *columnVectorGraphNativeSearchDebugCounters
+	var debugStats *columnVectorGraphNativeSearchStats
 	if statsMode == columnVectorGraphNativeSearchStatsModeBenchmarkDebug {
 		debugCounters = newColumnVectorGraphNativeSearchDebugCounters(&stats, candidateLimit == uint64(candidateRowCount))
+		if debugCounters != nil {
+			debugStats = debugCounters.stats
+		}
 	}
 	defer func() {
 		loopCounters.publish(&stats)
@@ -1066,22 +1068,26 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 					neighbor := adjacency[i]
 					i++
 					loopCounters.recordEdge()
-					if debugCounters != nil {
-						debugCounters.recordLayer0Edge()
+					if debugStats != nil {
+						debugStats.Layer0EdgeVisits++
 					}
 					if uint64(neighbor) >= uint64(rowCount) {
 						return nil, stats, fmt.Errorf("collections: column_graph %q ordinal=%d adjacency[%d]=%d outside row_count=%d: %w", r.def.Name, candidate.ordinal, neighborIndex, neighbor, rowCount, errColumnVectorGraphAdjacencyOrdinalOutOfBounds)
 					}
 					neighborOrdinal := int(neighbor)
 					if visitMarks[neighborOrdinal] == visitEpoch {
-						if debugCounters != nil {
-							debugCounters.recordVisitedMark(true)
-							debugCounters.recordAlreadyVisitedSkip()
+						if debugStats != nil {
+							debugStats.VisitedMarkChecks++
+							debugStats.VisitedMarkHits++
+							debugStats.AlreadyVisitedSkips++
+							debugStats.SkippedNeighbors++
+							debugStats.Layer0AlreadyVisitedSkips++
 						}
 						continue
 					}
-					if debugCounters != nil {
-						debugCounters.recordVisitedMark(false)
+					if debugStats != nil {
+						debugStats.VisitedMarkChecks++
+						debugStats.VisitedMarkMisses++
 					}
 					if !columnVectorGraphCandidateRowAllowed(candidateRows, hasCandidateRows, neighborOrdinal) {
 						if debugCounters != nil {
@@ -1107,22 +1113,26 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 				break
 			}
 			loopCounters.recordEdge()
-			if debugCounters != nil {
-				debugCounters.recordLayer0Edge()
+			if debugStats != nil {
+				debugStats.Layer0EdgeVisits++
 			}
 			if uint64(neighbor) >= uint64(rowCount) {
 				return nil, stats, fmt.Errorf("collections: column_graph %q ordinal=%d adjacency[%d]=%d outside row_count=%d: %w", r.def.Name, candidate.ordinal, i, neighbor, rowCount, errColumnVectorGraphAdjacencyOrdinalOutOfBounds)
 			}
 			neighborOrdinal := int(neighbor)
 			if visitMarks[neighborOrdinal] == visitEpoch {
-				if debugCounters != nil {
-					debugCounters.recordVisitedMark(true)
-					debugCounters.recordAlreadyVisitedSkip()
+				if debugStats != nil {
+					debugStats.VisitedMarkChecks++
+					debugStats.VisitedMarkHits++
+					debugStats.AlreadyVisitedSkips++
+					debugStats.SkippedNeighbors++
+					debugStats.Layer0AlreadyVisitedSkips++
 				}
 				continue
 			}
-			if debugCounters != nil {
-				debugCounters.recordVisitedMark(false)
+			if debugStats != nil {
+				debugStats.VisitedMarkChecks++
+				debugStats.VisitedMarkMisses++
 			}
 			if !columnVectorGraphCandidateRowAllowed(candidateRows, hasCandidateRows, neighborOrdinal) {
 				if debugCounters != nil {
@@ -1890,14 +1900,14 @@ func (s *columnVectorGraphNativeSearchScratch) markVisited(ordinal int) bool {
 }
 
 func (s *columnVectorGraphNativeSearchScratch) pushFrontier(candidate columnVectorGraphSearchCandidate) {
-	s.frontier = append(s.frontier, candidate)
-	s.frontierSiftUp(len(s.frontier) - 1)
+	s.frontier = append(s.frontier, columnVectorGraphSearchCandidate{})
+	s.frontierSiftUp(len(s.frontier)-1, candidate)
 }
 
 func (s *columnVectorGraphNativeSearchScratch) pushFrontierDebug(candidate columnVectorGraphSearchCandidate, debugCounters *columnVectorGraphNativeSearchDebugCounters) {
 	debugCounters.stats.FrontierPushes++
-	s.frontier = append(s.frontier, candidate)
-	s.frontierSiftUpDebug(len(s.frontier)-1, debugCounters)
+	s.frontier = append(s.frontier, columnVectorGraphSearchCandidate{})
+	s.frontierSiftUpDebug(len(s.frontier)-1, candidate, debugCounters)
 }
 
 func (s *columnVectorGraphNativeSearchScratch) popFrontier() (columnVectorGraphSearchCandidate, bool) {
@@ -1909,8 +1919,7 @@ func (s *columnVectorGraphNativeSearchScratch) popFrontier() (columnVectorGraphS
 	last := s.frontier[lastIdx]
 	s.frontier = s.frontier[:lastIdx]
 	if len(s.frontier) > 0 {
-		s.frontier[0] = last
-		s.frontierSiftDown(0)
+		s.frontierSiftDown(0, last)
 	}
 	return best, true
 }
@@ -1926,70 +1935,101 @@ func (s *columnVectorGraphNativeSearchScratch) popFrontierDebug(debugCounters *c
 	last := s.frontier[lastIdx]
 	s.frontier = s.frontier[:lastIdx]
 	if len(s.frontier) > 0 {
-		s.frontier[0] = last
-		s.frontierSiftDownDebug(0, debugCounters)
+		s.frontierSiftDownDebug(0, last, debugCounters)
 	}
 	return best, true
 }
 
-func (s *columnVectorGraphNativeSearchScratch) frontierSiftUp(idx int) {
+func (s *columnVectorGraphNativeSearchScratch) frontierSiftUp(idx int, candidate columnVectorGraphSearchCandidate) {
+	frontier := s.frontier
 	for idx > 0 {
-		parent := (idx - 1) / 2
-		if !columnVectorGraphSearchCandidateBetter(s.frontier[idx], s.frontier[parent]) {
-			return
+		parent := (idx - 1) / columnVectorGraphNativeFrontierHeapFanout
+		parentCandidate := frontier[parent]
+		if !columnVectorGraphSearchCandidateBetter(candidate, parentCandidate) {
+			break
 		}
-		s.frontier[idx], s.frontier[parent] = s.frontier[parent], s.frontier[idx]
+		frontier[idx] = parentCandidate
 		idx = parent
 	}
+	frontier[idx] = candidate
 }
 
-func (s *columnVectorGraphNativeSearchScratch) frontierSiftUpDebug(idx int, debugCounters *columnVectorGraphNativeSearchDebugCounters) {
+func (s *columnVectorGraphNativeSearchScratch) frontierSiftUpDebug(idx int, candidate columnVectorGraphSearchCandidate, debugCounters *columnVectorGraphNativeSearchDebugCounters) {
+	frontier := s.frontier
+	var steps uint64
 	for idx > 0 {
-		parent := (idx - 1) / 2
-		if !columnVectorGraphSearchCandidateBetter(s.frontier[idx], s.frontier[parent]) {
-			return
+		parent := (idx - 1) / columnVectorGraphNativeFrontierHeapFanout
+		parentCandidate := frontier[parent]
+		if !columnVectorGraphSearchCandidateBetter(candidate, parentCandidate) {
+			break
 		}
-		debugCounters.stats.FrontierSiftUpSteps++
-		s.frontier[idx], s.frontier[parent] = s.frontier[parent], s.frontier[idx]
+		steps++
+		frontier[idx] = parentCandidate
 		idx = parent
 	}
+	frontier[idx] = candidate
+	debugCounters.stats.FrontierSiftUpSteps += steps
 }
 
-func (s *columnVectorGraphNativeSearchScratch) frontierSiftDown(idx int) {
+func (s *columnVectorGraphNativeSearchScratch) frontierSiftDown(idx int, candidate columnVectorGraphSearchCandidate) {
+	frontier := s.frontier
+	n := len(frontier)
 	for {
-		left := idx*2 + 1
-		if left >= len(s.frontier) {
-			return
+		firstChild := idx*columnVectorGraphNativeFrontierHeapFanout + 1
+		if firstChild >= n {
+			break
 		}
-		child := left
-		if right := left + 1; right < len(s.frontier) && columnVectorGraphSearchCandidateBetter(s.frontier[right], s.frontier[left]) {
-			child = right
+		child := firstChild
+		childCandidate := frontier[firstChild]
+		lastChild := firstChild + columnVectorGraphNativeFrontierHeapFanout
+		if lastChild > n {
+			lastChild = n
 		}
-		if !columnVectorGraphSearchCandidateBetter(s.frontier[child], s.frontier[idx]) {
-			return
+		for next := firstChild + 1; next < lastChild; next++ {
+			if columnVectorGraphSearchCandidateBetter(frontier[next], childCandidate) {
+				child = next
+				childCandidate = frontier[next]
+			}
 		}
-		s.frontier[idx], s.frontier[child] = s.frontier[child], s.frontier[idx]
+		if !columnVectorGraphSearchCandidateBetter(childCandidate, candidate) {
+			break
+		}
+		frontier[idx] = childCandidate
 		idx = child
 	}
+	frontier[idx] = candidate
 }
 
-func (s *columnVectorGraphNativeSearchScratch) frontierSiftDownDebug(idx int, debugCounters *columnVectorGraphNativeSearchDebugCounters) {
+func (s *columnVectorGraphNativeSearchScratch) frontierSiftDownDebug(idx int, candidate columnVectorGraphSearchCandidate, debugCounters *columnVectorGraphNativeSearchDebugCounters) {
+	frontier := s.frontier
+	n := len(frontier)
+	var steps uint64
 	for {
-		left := idx*2 + 1
-		if left >= len(s.frontier) {
-			return
+		firstChild := idx*columnVectorGraphNativeFrontierHeapFanout + 1
+		if firstChild >= n {
+			break
 		}
-		child := left
-		if right := left + 1; right < len(s.frontier) && columnVectorGraphSearchCandidateBetter(s.frontier[right], s.frontier[left]) {
-			child = right
+		child := firstChild
+		childCandidate := frontier[firstChild]
+		lastChild := firstChild + columnVectorGraphNativeFrontierHeapFanout
+		if lastChild > n {
+			lastChild = n
 		}
-		if !columnVectorGraphSearchCandidateBetter(s.frontier[child], s.frontier[idx]) {
-			return
+		for next := firstChild + 1; next < lastChild; next++ {
+			if columnVectorGraphSearchCandidateBetter(frontier[next], childCandidate) {
+				child = next
+				childCandidate = frontier[next]
+			}
 		}
-		debugCounters.stats.FrontierSiftDownSteps++
-		s.frontier[idx], s.frontier[child] = s.frontier[child], s.frontier[idx]
+		if !columnVectorGraphSearchCandidateBetter(childCandidate, candidate) {
+			break
+		}
+		steps++
+		frontier[idx] = childCandidate
 		idx = child
 	}
+	frontier[idx] = candidate
+	debugCounters.stats.FrontierSiftDownSteps += steps
 }
 
 func (s *columnVectorGraphNativeSearchScratch) insertTop(limit int, candidate columnVectorGraphSearchCandidate) {

--- a/TreeDB/collections/column_vector_graph_search_test.go
+++ b/TreeDB/collections/column_vector_graph_search_test.go
@@ -51,6 +51,96 @@ func TestColumnVectorGraphAdjacencySourceStatsSkipEmptyNoopV3(t *testing.T) {
 	}
 }
 
+func TestColumnVectorGraphNativeSearchFrontierHeapOrder1980(t *testing.T) {
+	candidates := []columnVectorGraphSearchCandidate{
+		{ordinal: 7, score: 0.70},
+		{ordinal: 3, score: 0.70},
+		{ordinal: 11, score: -0.10},
+		{ordinal: 1, score: 0.95},
+		{ordinal: 9, score: 0.20},
+		{ordinal: 5, score: 0.95},
+		{ordinal: 4, score: 0.20},
+		{ordinal: 2, score: -0.10},
+	}
+	want := make([]columnVectorGraphSearchCandidate, 0, len(candidates))
+	for _, candidate := range candidates {
+		want = insertColumnGraphTopForTest(want, len(candidates), candidate)
+	}
+
+	var scratch columnVectorGraphNativeSearchScratch
+	for _, candidate := range candidates {
+		scratch.pushFrontier(candidate)
+	}
+	assertColumnVectorGraphFrontierPopOrder1980(t, &scratch, want)
+
+	var interleavedScratch columnVectorGraphNativeSearchScratch
+	interleavedWant := make([]columnVectorGraphSearchCandidate, 0, len(candidates))
+	for i, candidate := range candidates {
+		interleavedScratch.pushFrontier(candidate)
+		interleavedWant = insertColumnGraphTopForTest(interleavedWant, len(candidates), candidate)
+		if i%3 == 2 {
+			got, ok := interleavedScratch.popFrontier()
+			if !ok {
+				t.Fatalf("interleaved frontier pop after push %d missing", i)
+			}
+			if got != interleavedWant[0] {
+				t.Fatalf("interleaved frontier pop after push %d=%+v want %+v", i, got, interleavedWant[0])
+			}
+			interleavedWant = interleavedWant[1:]
+		}
+	}
+	assertColumnVectorGraphFrontierPopOrder1980(t, &interleavedScratch, interleavedWant)
+
+	var debugScratch columnVectorGraphNativeSearchScratch
+	var stats columnVectorGraphNativeSearchStats
+	debugCounters := &columnVectorGraphNativeSearchDebugCounters{stats: &stats}
+	for _, candidate := range candidates {
+		debugScratch.pushFrontierDebug(candidate, debugCounters)
+	}
+	if stats.FrontierPushes != uint64(len(candidates)) {
+		t.Fatalf("debug frontier pushes=%d want %d", stats.FrontierPushes, len(candidates))
+	}
+	assertColumnVectorGraphFrontierPopOrderDebug1980(t, &debugScratch, debugCounters, want)
+	if stats.FrontierPops != uint64(len(candidates)) || stats.FrontierPopMisses != 1 {
+		t.Fatalf("debug frontier pop stats=%+v want pops=%d misses=1", stats, len(candidates))
+	}
+	if stats.FrontierSiftUpSteps == 0 || stats.FrontierSiftDownSteps == 0 {
+		t.Fatalf("debug frontier sift stats=%+v want non-zero up/down steps", stats)
+	}
+}
+
+func assertColumnVectorGraphFrontierPopOrder1980(t *testing.T, scratch *columnVectorGraphNativeSearchScratch, want []columnVectorGraphSearchCandidate) {
+	t.Helper()
+	for i, wantCandidate := range want {
+		got, ok := scratch.popFrontier()
+		if !ok {
+			t.Fatalf("frontier pop[%d] missing want %+v", i, wantCandidate)
+		}
+		if got != wantCandidate {
+			t.Fatalf("frontier pop[%d]=%+v want %+v", i, got, wantCandidate)
+		}
+	}
+	if got, ok := scratch.popFrontier(); ok {
+		t.Fatalf("frontier pop after drain=%+v, want empty", got)
+	}
+}
+
+func assertColumnVectorGraphFrontierPopOrderDebug1980(t *testing.T, scratch *columnVectorGraphNativeSearchScratch, debugCounters *columnVectorGraphNativeSearchDebugCounters, want []columnVectorGraphSearchCandidate) {
+	t.Helper()
+	for i, wantCandidate := range want {
+		got, ok := scratch.popFrontierDebug(debugCounters)
+		if !ok {
+			t.Fatalf("debug frontier pop[%d] missing want %+v", i, wantCandidate)
+		}
+		if got != wantCandidate {
+			t.Fatalf("debug frontier pop[%d]=%+v want %+v", i, got, wantCandidate)
+		}
+	}
+	if got, ok := scratch.popFrontierDebug(debugCounters); ok {
+		t.Fatalf("debug frontier pop after drain=%+v, want empty", got)
+	}
+}
+
 func columnVectorGraphNativeSearchSmallBenchShapeV3() columnVectorGraphNativeSearchBenchShapeV3 {
 	return columnVectorGraphNativeSearchBenchShapeV3{
 		rows:         1024,


### PR DESCRIPTION
## Summary

Closes #1980.

- Replace the TreeDB column-vector HNSW frontier binary heap with a comparator-equivalent 4-way hole heap to reduce frontier sift depth and assignments while preserving max-candidate pop ordering (`score desc`, `ordinal asc` ties).
- Keep top-k ordering and counts unchanged; optimize benchmark-debug visited/frontier counter updates without changing the published counter contracts.
- Add focused frontier heap order coverage, including tie ordering, interleaved push/pop behavior, and debug pop/counter sanity.

## Scope / semantics

- No scoring, `ef_search`, `topK`, result ordering, recall, topology fixture, or persistent-format changes.
- The candidate comparator is unchanged; exact-mode candidate-order counters stayed identical in the benchmark below.
- Top-k attempts/successes/rejections, visited marks, visited edges, fallback/source counters, and result/source counters stayed unchanged.

## Tests

```sh
GOWORK=off go test -count=1 ./TreeDB/collections -run 'TestColumnVectorGraphNativeSearchBenchmarkDebugCounters1979|TestColumnVectorGraphSearchTopologyParity2091|TestVectorGraphSearchTruthMatrixMetricContract2037|TestColumnVectorGraphNativeSearchFrontierHeapOrder1980'
GOWORK=off go test -count=1 ./TreeDB/collections ./TreeDB/docs
git diff --check origin/main...HEAD
```

## Benchmark evidence

Hardware: Apple M3, `GOMAXPROCS=8`, `GOWORK=off`.

Command used before (`origin/main`/8156cb60) and after (this PR):

```sh
GOMAXPROCS=8 GOWORK=off go test ./TreeDB/collections \
  -run '^$' \
  -bench '^BenchmarkColumnVectorGraphSearchBatchability1979/(ef_search_128|exact)/score=scalar$' \
  -benchmem -benchtime=1s -count=3
```

Selected median/constant metrics from local output (`benchstat` notes n=3 is too small for p<0.05, so treat runtime deltas as local evidence, not a broad claim):

| Row | ns/op before | ns/op after | ops/sec before | ops/sec after | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| `ef_search_128/score=scalar` | 10,046 | 9,199 | 99.54k | 108.70k | 0 → 0 | 0 → 0 |
| `exact/score=scalar` | 1,103,364 | 1,048,938 | 906.3 | 953.3 | 0 → 0 | 0 → 0 |

Counter preservation / scratch reductions:

| Row | visited_edges | frontier pushes/pops | frontier sift up | frontier sift down | top-k attempts/success/reject | visited marks hit/miss | fallbacks |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| `ef_search_128` before | 612 | 128 / 39 | 224 | 152 | 128 / 22 / 106 | 485 / 127 | 0 |
| `ef_search_128` after | 612 | 128 / 39 | 108 | 86 | 128 / 22 / 106 | 485 / 127 | 0 |
| `exact` before | 100,748 | 8,192 / 6,297 | 33,771 | 55,642 | 8,192 / 60 / 8,132 | 92,557 / 8,191 | 0 |
| `exact` after | 100,748 | 8,192 / 6,297 | 14,931 | 30,956 | 8,192 / 60 / 8,132 | 92,557 / 8,191 | 0 |

Additional local CPU profiles captured for exact scalar:

```sh
# before
GOMAXPROCS=8 GOWORK=off go test ./TreeDB/collections -run '^$' \
  -bench '^BenchmarkColumnVectorGraphSearchBatchability1979/exact/score=scalar$' \
  -benchmem -benchtime=2s -count=1 \
  -cpuprofile=/tmp/gomap_1980_evidence/before_exact_scalar_cpu.pprof

# after
GOMAXPROCS=8 GOWORK=off go test ./TreeDB/collections -run '^$' \
  -bench '^BenchmarkColumnVectorGraphSearchBatchability1979/exact/score=scalar$' \
  -benchmem -benchtime=2s -count=1 \
  -cpuprofile=/tmp/gomap_1980_evidence/after_final_exact_scalar_cpu.pprof
```

## Follow-ups / non-goals

- #2098 remains the owner for gathered/indexed exact-mode scoring.
- #1981 remains the owner for wavefront/relaxed traversal work.
- #1977 remains the owner for normalized-vector storage.
- Do **not** treat #2035 as performance-satisfied from this narrow frontier/visited scratch change alone.


## Handoff status

- Latest head: `a72eedc241e7a3eeaae8dd44f3e9d49086b21841`.
- CI: started for latest head; `gofmt` passed and remaining GitHub checks were pending at handoff.
- AI reviews requested: `@codex review`, `@copilot review`, `@coderabbitai review`. CodeRabbit reported a temporary/rate-limit state and was re-triggered; no AI review findings were available at handoff.
- Merge: intentionally not merged; coordinator to wait for CI/AI gates.
