### PR TITLE
nativewire: combine concurrent BSON insert requests

### DIFF
--- a/TreeDB/nativewire/server.go
+++ b/TreeDB/nativewire/server.go
@@ -67,6 +67,8 @@ const (
 	defaultCursorBatchSize               = 101
 	defaultCursorIdleTimeout             = 10 * time.Minute
 	defaultMaxMetadataIdempotencyEntries = 1024
+	defaultInsertBatchCombineMaxBatch    = 256
+	defaultInsertBatchCombineDrainYields = 2
 )
 
 // ServerOptions configures a native-wire server.
@@ -83,6 +85,8 @@ type ServerOptions struct {
 	CursorIdleTimeout             time.Duration
 	DefaultAckPolicy              iwire.AckPolicy
 	MaxMetadataIdempotencyEntries int
+	InsertBatchCombineMaxBatch    int
+	InsertBatchCombineDrainYields int
 	Collections                   *collections.CollectionManager
 	Backend                       *backenddb.DB
 }
@@ -101,10 +105,13 @@ type Server struct {
 	cursorIdleTimeout             time.Duration
 	defaultAckPolicy              iwire.AckPolicy
 	maxMetadataIdempotencyEntries int
+	insertBatchCombineMaxBatch    int
+	insertBatchCombineDrainYields int
 	registry                      *iwire.Registry
 	collections                   *collections.CollectionManager
 	backend                       *backenddb.DB
 	catalogVersion                atomic.Uint64
+	insertBatchCombiner           nativewireInsertBatchCombiner
 
 	closed              atomic.Bool
 	connMu              sync.Mutex
@@ -326,6 +333,14 @@ func NewServer(opts ServerOptions) *Server {
 	if maxMetadataIdempotencyEntries == 0 {
 		maxMetadataIdempotencyEntries = defaultMaxMetadataIdempotencyEntries
 	}
+	insertBatchCombineMaxBatch := opts.InsertBatchCombineMaxBatch
+	if insertBatchCombineMaxBatch == 0 {
+		insertBatchCombineMaxBatch = defaultInsertBatchCombineMaxBatch
+	}
+	insertBatchCombineDrainYields := opts.InsertBatchCombineDrainYields
+	if insertBatchCombineDrainYields == 0 {
+		insertBatchCombineDrainYields = defaultInsertBatchCombineDrainYields
+	}
 	server := &Server{
 		limits:                        limits,
 		maxInFlight:                   maxInFlight,
@@ -339,6 +354,8 @@ func NewServer(opts ServerOptions) *Server {
 		cursorIdleTimeout:             cursorIdleTimeout,
 		defaultAckPolicy:              defaultAck,
 		maxMetadataIdempotencyEntries: maxMetadataIdempotencyEntries,
+		insertBatchCombineMaxBatch:    insertBatchCombineMaxBatch,
+		insertBatchCombineDrainYields: insertBatchCombineDrainYields,
 		registry:                      iwire.MustV1Registry(),
 		collections:                   opts.Collections,
 		backend:                       opts.Backend,

--- a/TreeDB/nativewire/server.go
+++ b/TreeDB/nativewire/server.go
@@ -334,11 +334,11 @@ func NewServer(opts ServerOptions) *Server {
 		maxMetadataIdempotencyEntries = defaultMaxMetadataIdempotencyEntries
 	}
 	insertBatchCombineMaxBatch := opts.InsertBatchCombineMaxBatch
-	if insertBatchCombineMaxBatch == 0 {
+	if insertBatchCombineMaxBatch <= 0 {
 		insertBatchCombineMaxBatch = defaultInsertBatchCombineMaxBatch
 	}
 	insertBatchCombineDrainYields := opts.InsertBatchCombineDrainYields
-	if insertBatchCombineDrainYields == 0 {
+	if insertBatchCombineDrainYields <= 0 {
 		insertBatchCombineDrainYields = defaultInsertBatchCombineDrainYields
 	}
 	server := &Server{
@@ -941,6 +941,10 @@ func (s *Server) Stats() map[string]string {
 		"cursors.opened_total",
 		"cursors.closed_total",
 		"cursors.timeouts_total",
+		"insert_batch_combiner.batches_total",
+		"insert_batch_combiner.requests_total",
+		"insert_batch_combiner.single_requests_total",
+		"insert_batch_combiner.fallback_requests_total",
 	} {
 		out[nativeStatsPrefix+key] = "0"
 	}

--- a/TreeDB/nativewire/server_insert_combiner.go
+++ b/TreeDB/nativewire/server_insert_combiner.go
@@ -60,7 +60,7 @@ func (c *nativewireInsertBatchCombiner) run(s *Server, req insertBatchFastReques
 	c.mu.Unlock()
 
 	if leader {
-		c.drain(s, req.collectionName, lane)
+		go c.drain(s, req.collectionName, lane)
 	}
 	<-item.done
 	return item.result, true

--- a/TreeDB/nativewire/server_insert_combiner.go
+++ b/TreeDB/nativewire/server_insert_combiner.go
@@ -1,0 +1,192 @@
+package nativewire
+
+import (
+	"errors"
+	"runtime"
+	"sync"
+
+	"github.com/snissn/gomap/TreeDB/collections"
+	iwire "github.com/snissn/gomap/TreeDB/internal/nativewire"
+)
+
+type nativewireInsertBatchCombiner struct {
+	mu    sync.Mutex
+	lanes map[string]*nativewireInsertBatchCombineLane
+}
+
+type nativewireInsertBatchCombineLane struct {
+	draining bool
+	queue    []*nativewireInsertBatchCombineItem
+}
+
+type nativewireInsertBatchCombineItem struct {
+	req    insertBatchFastRequest
+	done   chan struct{}
+	result nativewireInsertBatchCombineResult
+}
+
+type nativewireInsertBatchCombineResult struct {
+	actualAck         iwire.AckPolicy
+	catalogVersion    uint64
+	hasCatalogVersion bool
+	err               error
+}
+
+// run keeps each request handler blocked until its item is applied, so decoded
+// ids/docs may safely borrow from the request frame buffer.
+func (c *nativewireInsertBatchCombiner) run(s *Server, req insertBatchFastRequest) (nativewireInsertBatchCombineResult, bool) {
+	if !canCombineInsertBatchFastRequest(s, req) {
+		return nativewireInsertBatchCombineResult{}, false
+	}
+	item := &nativewireInsertBatchCombineItem{
+		req:  req,
+		done: make(chan struct{}),
+	}
+
+	c.mu.Lock()
+	if c.lanes == nil {
+		c.lanes = make(map[string]*nativewireInsertBatchCombineLane)
+	}
+	lane := c.lanes[req.collectionName]
+	if lane == nil {
+		lane = &nativewireInsertBatchCombineLane{}
+		c.lanes[req.collectionName] = lane
+	}
+	lane.queue = append(lane.queue, item)
+	leader := !lane.draining
+	if leader {
+		lane.draining = true
+	}
+	c.mu.Unlock()
+
+	if leader {
+		c.drain(s, req.collectionName, lane)
+	}
+	<-item.done
+	return item.result, true
+}
+
+func canCombineInsertBatchFastRequest(s *Server, req insertBatchFastRequest) bool {
+	if s == nil || s.insertBatchCombineMaxBatch <= 1 {
+		return false
+	}
+	if req.collection == nil || req.collectionName == "" {
+		return false
+	}
+	if req.format != collections.DocumentFormatBSON {
+		return false
+	}
+	if req.includeResultIDs {
+		return false
+	}
+	if req.ack != 0 && req.ack != iwire.AckVisible {
+		return false
+	}
+	if len(req.ids) != 1 || len(req.docs) != 1 {
+		return false
+	}
+	return validateBSONDocuments(req.docs) == nil
+}
+
+func (c *nativewireInsertBatchCombiner) drain(s *Server, collectionName string, lane *nativewireInsertBatchCombineLane) {
+	yieldInsertBatchCombiner(s)
+	for {
+		c.mu.Lock()
+		batch := popInsertBatchCombineItems(lane, s.insertBatchCombineMaxBatch)
+		if len(batch) == 0 {
+			lane.draining = false
+			delete(c.lanes, collectionName)
+			c.mu.Unlock()
+			return
+		}
+		c.mu.Unlock()
+
+		applyInsertBatchCombineItems(s, batch)
+		yieldInsertBatchCombiner(s)
+	}
+}
+
+func popInsertBatchCombineItems(lane *nativewireInsertBatchCombineLane, max int) []*nativewireInsertBatchCombineItem {
+	if lane == nil || len(lane.queue) == 0 {
+		return nil
+	}
+	if max <= 0 || max > len(lane.queue) {
+		max = len(lane.queue)
+	}
+	out := append([]*nativewireInsertBatchCombineItem(nil), lane.queue[:max]...)
+	copy(lane.queue, lane.queue[max:])
+	clear(lane.queue[len(lane.queue)-max:])
+	lane.queue = lane.queue[:len(lane.queue)-max]
+	return out
+}
+
+func yieldInsertBatchCombiner(s *Server) {
+	yields := defaultInsertBatchCombineDrainYields
+	if s != nil {
+		yields = s.insertBatchCombineDrainYields
+	}
+	for i := 0; i < yields; i++ {
+		runtime.Gosched()
+	}
+}
+
+func applyInsertBatchCombineItems(s *Server, batch []*nativewireInsertBatchCombineItem) {
+	if len(batch) == 0 {
+		return
+	}
+	if len(batch) == 1 {
+		applySingleInsertBatchCombineItem(s, batch[0])
+		if s != nil {
+			s.counters.add("insert_batch_combiner.single_requests_total", 1)
+		}
+		return
+	}
+
+	ids := make([][]byte, len(batch))
+	docs := make([][]byte, len(batch))
+	for i, item := range batch {
+		ids[i] = item.req.ids[0]
+		docs[i] = item.req.docs[0]
+	}
+	err := batch[0].req.collection.NativewireInsertBatchNoResultIDs(ids, docs, true)
+	if err != nil && !errors.Is(err, collections.ErrCommitAmbiguous) {
+		for _, item := range batch {
+			applySingleInsertBatchCombineItem(s, item)
+		}
+		if s != nil {
+			s.counters.add("insert_batch_combiner.fallback_requests_total", uint64(len(batch)))
+		}
+		return
+	}
+
+	result := nativewireInsertBatchCombineResult{err: metadataWrap(err)}
+	if err == nil {
+		result.actualAck = iwire.AckVisible
+		result.catalogVersion, result.hasCatalogVersion = s.mutationCatalogVersion()
+	}
+	for _, item := range batch {
+		finishInsertBatchCombineItem(item, result)
+	}
+	if s != nil {
+		s.counters.add("insert_batch_combiner.batches_total", 1)
+		s.counters.add("insert_batch_combiner.requests_total", uint64(len(batch)))
+	}
+}
+
+func applySingleInsertBatchCombineItem(s *Server, item *nativewireInsertBatchCombineItem) {
+	if item == nil {
+		return
+	}
+	err := item.req.collection.NativewireInsertBatchNoResultIDs(item.req.ids, item.req.docs, true)
+	result := nativewireInsertBatchCombineResult{err: metadataWrap(err)}
+	if err == nil {
+		result.actualAck = iwire.AckVisible
+		result.catalogVersion, result.hasCatalogVersion = s.mutationCatalogVersion()
+	}
+	finishInsertBatchCombineItem(item, result)
+}
+
+func finishInsertBatchCombineItem(item *nativewireInsertBatchCombineItem, result nativewireInsertBatchCombineResult) {
+	item.result = result
+	close(item.done)
+}

--- a/TreeDB/nativewire/server_insert_combiner_test.go
+++ b/TreeDB/nativewire/server_insert_combiner_test.go
@@ -124,6 +124,34 @@ func TestInsertBatchCombinerSkipsIncompatibleRequests(t *testing.T) {
 	}
 }
 
+func TestInsertBatchCombinerStatsStartAtZero(t *testing.T) {
+	server := NewServer(ServerOptions{})
+	stats := server.Stats()
+	for _, key := range []string{
+		"insert_batch_combiner.batches_total",
+		"insert_batch_combiner.requests_total",
+		"insert_batch_combiner.single_requests_total",
+		"insert_batch_combiner.fallback_requests_total",
+	} {
+		if got := stats[nativeStatsPrefix+key]; got != "0" {
+			t.Fatalf("Stats()[%q]=%q want 0", nativeStatsPrefix+key, got)
+		}
+	}
+}
+
+func TestInsertBatchCombinerNonPositiveOptionsUseDefaults(t *testing.T) {
+	server := NewServer(ServerOptions{
+		InsertBatchCombineMaxBatch:    -1,
+		InsertBatchCombineDrainYields: -1,
+	})
+	if server.insertBatchCombineMaxBatch != defaultInsertBatchCombineMaxBatch {
+		t.Fatalf("max batch=%d want default %d", server.insertBatchCombineMaxBatch, defaultInsertBatchCombineMaxBatch)
+	}
+	if server.insertBatchCombineDrainYields != defaultInsertBatchCombineDrainYields {
+		t.Fatalf("drain yields=%d want default %d", server.insertBatchCombineDrainYields, defaultInsertBatchCombineDrainYields)
+	}
+}
+
 func newInsertBatchCombinerTestServer(t *testing.T) (*Server, *collections.Collection, func()) {
 	t.Helper()
 	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})

--- a/TreeDB/nativewire/server_insert_combiner_test.go
+++ b/TreeDB/nativewire/server_insert_combiner_test.go
@@ -1,0 +1,267 @@
+package nativewire
+
+import (
+	"errors"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/collections"
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+	iwire "github.com/snissn/gomap/TreeDB/internal/nativewire"
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+func TestInsertBatchCombinerBatchesConcurrentBSONNoResultRequests(t *testing.T) {
+	server, col, cleanup := newInsertBatchCombinerTestServer(t)
+	defer cleanup()
+
+	const requests = 16
+	errs := runConcurrentInsertBatchCombinerRequests(t, server, col, requests, func(i int) (string, []byte) {
+		id := "user-" + strconv.Itoa(i)
+		return id, insertBatchCombinerBSONDoc(t, id, "user-"+strconv.Itoa(i)+"@example.com")
+	})
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("request %d: %v", i, err)
+		}
+	}
+	for i := 0; i < requests; i++ {
+		id := "user-" + strconv.Itoa(i)
+		if _, err := col.Get([]byte(id)); err != nil {
+			t.Fatalf("Get(%q): %v", id, err)
+		}
+	}
+	if got := nativewireTestStatUint64(t, server, "insert_batch_combiner.requests_total"); got < 2 {
+		t.Fatalf("combined requests=%d want at least 2", got)
+	}
+}
+
+func TestInsertBatchCombinerFallbackPreservesDuplicateRequestOutcome(t *testing.T) {
+	server, col, cleanup := newInsertBatchCombinerTestServer(t)
+	defer cleanup()
+
+	errs := applyInsertBatchCombinerRequestsDirect(t, server, col, 2, func(i int) (string, []byte) {
+		return "same-id", insertBatchCombinerBSONDoc(t, "same-id", "dupe-"+strconv.Itoa(i)+"@example.com")
+	})
+
+	successes := 0
+	conflicts := 0
+	for _, err := range errs {
+		switch {
+		case err == nil:
+			successes++
+		case errors.Is(err, collections.ErrDocumentExists) || errors.Is(err, collections.ErrDuplicateDocumentID):
+			conflicts++
+		default:
+			t.Fatalf("unexpected duplicate outcome err=%v", err)
+		}
+	}
+	if successes != 1 || conflicts != 1 {
+		t.Fatalf("successes=%d conflicts=%d want 1/1; errs=%v", successes, conflicts, errs)
+	}
+	if _, err := col.Get([]byte("same-id")); err != nil {
+		t.Fatalf("Get(same-id): %v", err)
+	}
+	if got := nativewireTestStatUint64(t, server, "insert_batch_combiner.fallback_requests_total"); got == 0 {
+		t.Fatalf("fallback requests=%d want nonzero", got)
+	}
+}
+
+func TestInsertBatchCombinerFallbackPreservesUniqueConflictOutcome(t *testing.T) {
+	server, col, cleanup := newInsertBatchCombinerTestServer(t)
+	defer cleanup()
+
+	errs := applyInsertBatchCombinerRequestsDirect(t, server, col, 2, func(i int) (string, []byte) {
+		id := "user-" + strconv.Itoa(i)
+		return id, insertBatchCombinerBSONDoc(t, id, "same@example.com")
+	})
+
+	successes := 0
+	conflicts := 0
+	for _, err := range errs {
+		switch {
+		case err == nil:
+			successes++
+		case errors.Is(err, collections.ErrUniqueIndexConflict):
+			conflicts++
+		default:
+			t.Fatalf("unexpected unique conflict outcome err=%v", err)
+		}
+	}
+	if successes != 1 || conflicts != 1 {
+		t.Fatalf("successes=%d conflicts=%d want 1/1; errs=%v", successes, conflicts, errs)
+	}
+	if got := nativewireTestStatUint64(t, server, "insert_batch_combiner.fallback_requests_total"); got == 0 {
+		t.Fatalf("fallback requests=%d want nonzero", got)
+	}
+}
+
+func TestInsertBatchCombinerSkipsIncompatibleRequests(t *testing.T) {
+	server, col, cleanup := newInsertBatchCombinerTestServer(t)
+	defer cleanup()
+
+	req := insertBatchCombinerFastRequest(t, col, "user-1", insertBatchCombinerBSONDoc(t, "user-1", "user-1@example.com"))
+	if !canCombineInsertBatchFastRequest(server, req) {
+		t.Fatal("baseline BSON batch-1 no-result request was not combinable")
+	}
+
+	req.includeResultIDs = true
+	if canCombineInsertBatchFastRequest(server, req) {
+		t.Fatal("request with result IDs should not combine")
+	}
+	req.includeResultIDs = false
+
+	req.ack = AckFlushed
+	if canCombineInsertBatchFastRequest(server, req) {
+		t.Fatal("flushed ack request should not combine")
+	}
+	req.ack = AckVisible
+
+	req.format = collections.DocumentFormatJSON
+	if canCombineInsertBatchFastRequest(server, req) {
+		t.Fatal("JSON request should not combine")
+	}
+}
+
+func newInsertBatchCombinerTestServer(t *testing.T) (*Server, *collections.Collection, func()) {
+	t.Helper()
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	mgr := collections.NewCollectionManager(db)
+	if _, err := mgr.CreateCollection(&collections.CollectionMeta{
+		Name: "users",
+		Options: collections.CollectionOptions{
+			DocumentFormat: collections.DocumentFormatBSON,
+		},
+		Indexes: []collections.IndexDefinition{{
+			Name:      "email_1",
+			Field:     "email",
+			ValueType: collections.IndexValueString,
+			Unique:    true,
+		}},
+	}); err != nil {
+		_ = db.Close()
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		_ = db.Close()
+		t.Fatalf("OpenCollection: %v", err)
+	}
+	server := NewServer(ServerOptions{
+		Collections:                   mgr,
+		Backend:                       db,
+		InsertBatchCombineDrainYields: 4096,
+	})
+	return server, col, func() {
+		if err := errors.Join(server.Close(), db.Close()); err != nil {
+			t.Fatalf("cleanup: %v", err)
+		}
+	}
+}
+
+func runConcurrentInsertBatchCombinerRequests(t *testing.T, server *Server, col *collections.Collection, requests int, build func(int) (string, []byte)) []error {
+	t.Helper()
+	states := make([]*connState, requests)
+	bodies := make([][]byte, requests)
+	for i := 0; i < requests; i++ {
+		state := benchmarkConnState()
+		handle := benchmarkAddCollectionHandle(t, state, server, "users", col)
+		id, doc := build(i)
+		guard := benchmarkMutationGuard(t, server, "insert_batch_combiner", i)
+		body, err := appendInsertBatchRequestBodyRefFlags(nil, "", handle, true, collections.DocumentFormatBSON,
+			[][]byte{[]byte(id)},
+			[][]byte{doc},
+			AckVisible,
+			iwire.CommandFlagOmitResultIDs|iwire.CommandFlagOmitResponseMeta,
+			guard,
+		)
+		if err != nil {
+			t.Fatalf("append request %d: %v", i, err)
+		}
+		states[i] = state
+		bodies[i] = body
+	}
+
+	start := make(chan struct{})
+	errs := make([]error, requests)
+	var wg sync.WaitGroup
+	for i := 0; i < requests; i++ {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			_, errs[i] = benchmarkDispatchRequestError(server, states[i], &benchmarkFrameSink{}, bodies[i])
+		}()
+	}
+	close(start)
+	wg.Wait()
+	return errs
+}
+
+func applyInsertBatchCombinerRequestsDirect(t *testing.T, server *Server, col *collections.Collection, requests int, build func(int) (string, []byte)) []error {
+	t.Helper()
+	items := make([]*nativewireInsertBatchCombineItem, requests)
+	for i := 0; i < requests; i++ {
+		id, doc := build(i)
+		items[i] = &nativewireInsertBatchCombineItem{
+			req:  insertBatchCombinerFastRequest(t, col, id, doc),
+			done: make(chan struct{}),
+		}
+	}
+
+	applyInsertBatchCombineItems(server, items)
+
+	errs := make([]error, requests)
+	for i, item := range items {
+		select {
+		case <-item.done:
+		default:
+			t.Fatalf("combined item %d was not completed", i)
+		}
+		errs[i] = item.result.err
+	}
+	return errs
+}
+
+func insertBatchCombinerFastRequest(t *testing.T, col *collections.Collection, id string, doc []byte) insertBatchFastRequest {
+	t.Helper()
+	return insertBatchFastRequest{
+		collectionName: "users",
+		collection:     col,
+		format:         collections.DocumentFormatBSON,
+		ids:            [][]byte{[]byte(id)},
+		docs:           [][]byte{doc},
+		ack:            AckVisible,
+	}
+}
+
+func insertBatchCombinerBSONDoc(t *testing.T, id, email string) []byte {
+	t.Helper()
+	doc, err := bson.Marshal(bson.D{
+		{Key: "_id", Value: id},
+		{Key: "email", Value: email},
+		{Key: "name", Value: id},
+	})
+	if err != nil {
+		t.Fatalf("marshal BSON: %v", err)
+	}
+	return doc
+}
+
+func nativewireTestStatUint64(t *testing.T, server *Server, key string) uint64 {
+	t.Helper()
+	raw := server.Stats()[nativeStatsPrefix+key]
+	if raw == "" {
+		return 0
+	}
+	value, err := strconv.ParseUint(raw, 10, 64)
+	if err != nil {
+		t.Fatalf("parse stat %s=%q: %v", key, raw, err)
+	}
+	return value
+}

--- a/TreeDB/nativewire/server_mutation.go
+++ b/TreeDB/nativewire/server_mutation.go
@@ -10,6 +10,7 @@ import (
 )
 
 type insertBatchFastRequest struct {
+	collectionName   string
 	collection       *collections.Collection
 	sections         []iwire.Section
 	format           collections.DocumentFormat
@@ -44,6 +45,12 @@ func (s *Server) handleInsertBatchFastBody(req insertBatchFastRequest, dst []byt
 	defer s.metadataMu.RUnlock()
 	if err := s.checkCatalogGuard(req.sections); err != nil {
 		return nil, err
+	}
+	if result, combined := s.insertBatchCombiner.run(s, req); combined {
+		if result.err != nil {
+			return nil, result.err
+		}
+		return appendInsertBatchResponseBody(dst, nil, len(req.ids), result.actualAck, result.catalogVersion, result.hasCatalogVersion, false, req.includeMeta)
 	}
 	resultIDs, insertedCount, actualAck, catalogVersion, hasCatalogVersion, err := s.insertBatchDecoded(req.collection, req.format, req.ids, req.docs, req.ack, req.includeResultIDs)
 	if err != nil {
@@ -228,7 +235,7 @@ func (s *Server) decodeInsertBatchFastRequest(state *connState, sections []iwire
 	if !seen.has(iwire.SectionExpectedCatalogVersion) {
 		return insertBatchFastRequest{}, true, protocolError(iwire.ErrInvalidCommand, "missing required section %d", iwire.SectionExpectedCatalogVersion)
 	}
-	_, collection, err := s.openCollectionRawRef(state, rawCollection)
+	collectionName, collection, err := s.openCollectionRawRef(state, rawCollection)
 	if err != nil {
 		return insertBatchFastRequest{}, true, err
 	}
@@ -276,6 +283,7 @@ func (s *Server) decodeInsertBatchFastRequest(state *connState, sections []iwire
 		return insertBatchFastRequest{}, true, err
 	}
 	return insertBatchFastRequest{
+		collectionName:   collectionName,
 		collection:       collection,
 		sections:         sections,
 		format:           format,

--- a/TreeDB/nativewire/ycsb_bench_test.go
+++ b/TreeDB/nativewire/ycsb_bench_test.go
@@ -231,6 +231,7 @@ func benchmarkNativewireYCSBLoadServerPrecomputed(b *testing.B, format ycsbLoadF
 		b.Fatalf("encode sample: %v", err)
 	}
 	beforeStats := env.server.collections.StatsSnapshot()
+	beforeNativeCounters := env.server.counters.snapshot()
 	b.ReportAllocs()
 	b.SetBytes(int64(len(sample)))
 	b.ResetTimer()
@@ -289,6 +290,7 @@ func benchmarkNativewireYCSBLoadServerPrecomputed(b *testing.B, format ycsbLoadF
 	b.ReportMetric(float64(len(sample)), "document_bytes")
 	b.ReportMetric(float64(ycsbBenchClients), "clients")
 	reportYCSBCollectionStatsDelta(b, beforeStats, afterStats, b.N)
+	reportYCSBNativeCounterDelta(b, beforeNativeCounters, env.server.counters.snapshot(), b.N)
 }
 
 type ycsbPrecomputedNativewireWorker struct {
@@ -341,6 +343,20 @@ func reportYCSBCollectionStatsDelta(b *testing.B, before, after collections.Coll
 	reportUint64("indexed_stage_root_runs/op", uint64Delta(after.IndexedStageRootRuns, before.IndexedStageRootRuns))
 	reportUint64("validation_preflight_reused/op", uint64Delta(after.InsertValidationPreflightReused, before.InsertValidationPreflightReused))
 	reportUint64("validation_preflight_rechecked/op", uint64Delta(after.InsertValidationPreflightRechecked, before.InsertValidationPreflightRechecked))
+}
+
+func reportYCSBNativeCounterDelta(b *testing.B, before, after map[string]uint64, ops int) {
+	b.Helper()
+	if ops <= 0 {
+		return
+	}
+	report := func(metricName, counterName string) {
+		b.ReportMetric(float64(uint64Delta(after[counterName], before[counterName]))/float64(ops), metricName)
+	}
+	report("combiner_batches/op", "insert_batch_combiner.batches_total")
+	report("combiner_requests/op", "insert_batch_combiner.requests_total")
+	report("combiner_single_requests/op", "insert_batch_combiner.single_requests_total")
+	report("combiner_fallback_requests/op", "insert_batch_combiner.fallback_requests_total")
 }
 
 func uint64Delta(after, before uint64) uint64 {


### PR DESCRIPTION
Closes #2095.

## Summary

This adds a narrow server-side combiner for the nativewire YCSB BSON insert hot path. Compatible concurrent `insert_batch` requests are grouped per collection before entering the collection mutation path, so batch-1 callers share one internal `NativewireInsertBatchNoResultIDs` call instead of serializing every request as a separate collection mutation.

The combiner is deliberately scoped to the measured workload:

- nativewire fast-path `insert_batch` only
- BSON only
- one document per request
- omit result IDs only
- visible ack only
- same collection lane
- existing catalog guard must pass before queueing

## Compatibility And Failure Semantics

- Request handlers remain blocked until their queued item is applied, so decoded IDs/documents may safely borrow from the request frame buffer.
- Each request still runs the existing catalog guard under `metadataMu.RLock`; the read lock is held until the item is applied, preventing interleaved schema/catalog mutations from invalidating queued writes.
- Combined ordinary conflicts fall back to per-request single inserts, preserving duplicate primary-key and unique-index outcomes.
- Commit-ambiguous errors are not retried or decomposed; they propagate to all grouped requests.
- Incompatible requests skip the combiner and use the existing direct path.
- Data-mutation idempotency semantics are unchanged; metadata idempotency remains separate.

## Tests

```sh
go test ./TreeDB/nativewire -run 'TestInsertBatchCombiner|TestInsertBatchFast|TestMutationCommandsRoundTrip|TestMutationCatalogGuardRejectsPriorVersionAfterMetadataChange|TestMutationCatalogGuardAllowsPriorDataCommitVersion|TestCatalogMetadataVersionIgnoresDataRootChanges' -count=1
```

Result: pass.

```sh
go test -race ./TreeDB/nativewire -run 'TestInsertBatchCombiner' -count=1
```

Result: pass.

```sh
go test ./TreeDB/nativewire ./TreeDB/collections -count=1
```

Result: pass. `TreeDB/collections` completed in about 92s locally.

```sh
go test ./cmd/treedb-native-server -count=1
```

Result: pass, no test files.

## Benchmark Boundary

Hardware from Go benchmark output: `11th Gen Intel(R) Core(TM) i5-11400F @ 2.60GHz`, linux/amd64.

Fixture: nativewire YCSB load shape, BSON binary documents, 16 benchmark clients, 1174-byte sample document, one logical insert per request unless explicitly noted by the precomputed server benchmark.

Baseline branch/commit: `main` at `746a02ea0`.
Candidate branch/commit: `codex/2095-nativewire-insert-combiner-v2` at `7fea4ef17`.

## Microbenchmark Evidence

### Clean server-side precomputed BSON path

Command:

```sh
go test ./TreeDB/nativewire -run '^$' \
  -bench '^BenchmarkNativewireYCSBLoadServerPrecomputed$/inproc/bson_binary$' \
  -benchtime=100000x -count=3 -benchmem
```

| Build | ns/op | ops/sec | MB/s | B/op | allocs/op | combiner_requests/op | mutation_lock_calls/op | mutation_lock_wait_ns/op |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| baseline | 6766-7044 | 142k-148k | 166.7-173.5 | 3797-5091 | 32 | n/a | 1.000 | 95,573-99,726 |
| candidate | 3766-4136 | 242k-265k | 283.8-311.8 | 2958-4253 | 8 | 0.991-0.994 | 0.257-0.259 | 14.98-15.19 |

### Full in-process nativewire BSON path

Command:

```sh
go test ./TreeDB/nativewire -run '^$' \
  -bench '^BenchmarkNativewireYCSBLoad$/inproc/bson_binary$' \
  -benchtime=100000x -count=3 -benchmem
```

| Build | ns/op | ops/sec | MB/s | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: | ---: |
| baseline | 8943-9548 | 105k-112k | 123.0-131.3 | 5954-7248 | 53 |
| candidate | 3997-4678 | 214k-250k | 251.0-293.7 | 5116-6410 | 29-30 |

### TCP nativewire BSON path

Command:

```sh
go test ./TreeDB/nativewire -run '^$' \
  -bench '^BenchmarkNativewireYCSBLoad$/tcp/bson_binary$' \
  -benchtime=100000x -count=3 -benchmem
```

| Build | ns/op | ops/sec | MB/s | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: | ---: |
| baseline | 10779-11583 | 86k-93k | 101.4-108.9 | 6043-7338 | 55 |
| candidate | 6012-6974 | 143k-166k | 168.3-195.3 | 5329-6619 | 34-35 |

## External go-ycsb Sanity Check

Client repo: `/home/mikers/dev/pingcap/go-ycsb`, branch `codex/treedb-native-bson-default`, head `304788a`.

Command:

```sh
./bin/go-ycsb load treedb-native \
  -p treedb.addr=127.0.0.1:<port> \
  -p recordcount=100000 \
  -p operationcount=10000 \
  -p threadcount=16
```

| Build | INSERT count | OPS | Avg | p99 | Max |
| --- | ---: | ---: | ---: | ---: | ---: |
| baseline main | 100000 | 71516.7 | 208us | 785us | 7487us |
| candidate | 100000 | 92641.0 | 157us | 452us | 6235us |

The external client path improves less than the clean server benchmark because client/network/request construction remain inside the measured boundary.

## Profile Evidence

Profile artifact directory: `/tmp/treedb_2095_combiner_profile_20260531_155858`.

Command included timed CPU, allocation, mutex, and block profiles for `BenchmarkNativewireYCSBLoadServerPrecomputed/inproc/bson_binary` at `1000000x`.

Profiled run result under profiling overhead:

- `11029 ns/op`
- `106.44 MB/s`
- `9731 B/op`
- `13 allocs/op`
- `combiner_batches/op`: `0.1265`
- `combiner_requests/op`: `0.9941`
- `mutation_lock_calls/op`: `0.2589`
- `mutation_lock_wait_ns/op`: `15.13`

Profile interpretation:

- `lockMutation` wait is no longer a material block-profile bottleneck for this benchmark.
- Remaining CPU is mostly collection/tree work such as `tree.(*Tree).HasAnySortedWithStats`, insert staging, BSON validation/decode, plus combiner channel/wait accounting in block profile.
- Mutex profile is dominated by value-log/zipper background persistence locks rather than collection mutation-lock wait.

## AI Review Status

AI reviews have not been requested before this mature PR body and benchmark evidence were prepared. After latest-head CI is running or green, I will request the configured AI reviews once and address actionable findings before claiming mergeability.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable insert batch combination for server insert operations.

* **Tests**
  * Added comprehensive test coverage for batch combination behavior, fallback scenarios, and request compatibility validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->