### PR TITLE
Optimize prepared exact indexed graph scoring

### DIFF
--- a/TreeDB/collections/column_vector_graph_prepared_indexed_scoring_2098_test.go
+++ b/TreeDB/collections/column_vector_graph_prepared_indexed_scoring_2098_test.go
@@ -1,0 +1,115 @@
+package collections
+
+import "testing"
+
+func TestColumnVectorGraphPreparedExactIndexedScoringEquivalence2098(t *testing.T) {
+	if !columnGraphTypedColumnMmapDirectViewSupportedForTest() {
+		t.Skip("prepared indexed scoring equivalence requires mmap_direct prepared views")
+	}
+	shape := columnVectorGraphSearchTopologyParityTestShape2091()
+	shape.efSearch = shape.rows
+	rows := columnVectorGraphSearchTopologyParityRows2091(t, shape)
+	closeFn, reader, query := openColumnVectorGraphSearchTopologyParityReader2091(t, shape, rows, columnVectorGraphSearchTopologyParityModeCurrentPrepared2091)
+	defer closeFn()
+
+	scalarResults, scalarStats := searchColumnVectorGraphPreparedScoreMode2098(t, reader, query, shape, columnVectorGraphScoreBatchModeScalar)
+	indexedResults, indexedStats := searchColumnVectorGraphPreparedScoreMode2098(t, reader, query, shape, columnVectorGraphScoreBatchModeIndexed)
+	if mismatch := columnVectorGraphIndexedScoringResultsMismatch1969(indexedResults, scalarResults); mismatch != "" {
+		t.Fatal(mismatch)
+	}
+	assertColumnVectorGraphPreparedExactIndexedWorkStatsEqual2098(t, scalarStats, indexedStats)
+	if indexedStats.ScoreBatchMaxTileSize < 2 || indexedStats.ScoreBatchCalls >= scalarStats.ScoreBatchCalls {
+		t.Fatalf("indexed stats=%+v scalar stats=%+v want exact prepared indexed scoring to preserve work while grouping score batches", indexedStats, scalarStats)
+	}
+}
+
+func TestColumnVectorGraphPreparedExactIndexedScoringTieOrder2098(t *testing.T) {
+	if !columnGraphTypedColumnMmapDirectViewSupportedForTest() {
+		t.Skip("prepared indexed scoring tie-order test requires mmap_direct prepared views")
+	}
+	rows := []columnVectorGraphAssetRow{
+		{ID: []byte("doc-entry"), Vector: []float32{0, 1}, InvNorm: 1, Adjacency: []uint32{2, 1, 3, 4}},
+		{ID: []byte("doc-tie-low-ordinal"), Vector: []float32{1, 0}, InvNorm: 1},
+		{ID: []byte("doc-tie-high-ordinal"), Vector: []float32{1, 0}, InvNorm: 1},
+		{ID: []byte("doc-opposite-y"), Vector: []float32{0, -1}, InvNorm: 1},
+		{ID: []byte("doc-opposite-x"), Vector: []float32{-1, 0}, InvNorm: 1},
+	}
+	shape := columnVectorGraphSearchTopologyParityShape2091{rows: len(rows), dims: 2, degree: 4, topK: 2, efSearch: len(rows), queryOrdinal: 1}
+	closeFn, reader, query := openColumnVectorGraphSearchTopologyParityReader2091(t, shape, rows, columnVectorGraphSearchTopologyParityModeCurrentPrepared2091)
+	defer closeFn()
+
+	scalarResults, scalarStats := searchColumnVectorGraphPreparedScoreMode2098(t, reader, query, shape, columnVectorGraphScoreBatchModeScalar)
+	indexedResults, indexedStats := searchColumnVectorGraphPreparedScoreMode2098(t, reader, query, shape, columnVectorGraphScoreBatchModeIndexed)
+	if mismatch := columnVectorGraphIndexedScoringResultsMismatch1969(indexedResults, scalarResults); mismatch != "" {
+		t.Fatal(mismatch)
+	}
+	wantOrdinals := []int{1, 2}
+	for i, want := range wantOrdinals {
+		if i >= len(indexedResults) || indexedResults[i].Ordinal != want {
+			t.Fatalf("indexed results=%+v want ordinal %d at rank %d", indexedResults, want, i)
+		}
+	}
+	assertColumnVectorGraphPreparedExactIndexedWorkStatsEqual2098(t, scalarStats, indexedStats)
+	if indexedStats.ScoreBatchMaxTileSize < 2 {
+		t.Fatalf("indexed stats=%+v want tie fixture to exercise gathered score batch", indexedStats)
+	}
+}
+
+func searchColumnVectorGraphPreparedScoreMode2098(tb testing.TB, reader *columnVectorGraphPhysicalRowReader, query []float32, shape columnVectorGraphSearchTopologyParityShape2091, mode columnVectorGraphScoreBatchMode) ([]columnVectorGraphNativeSearchResult, columnVectorGraphNativeSearchStats) {
+	tb.Helper()
+	opts := columnVectorGraphSearchTopologyParityOptions2091(shape, columnVectorGraphSearchTopologyParityBoundaryGraphOnly2091)
+	opts.StatsMode = columnVectorGraphNativeSearchStatsModeBenchmarkDebug
+	opts.ScoreBatchMode = mode
+	var scratch columnVectorGraphNativeSearchScratch
+	results, stats, err := reader.SearchCosine(query, opts, &scratch)
+	if err != nil {
+		tb.Fatalf("SearchCosine score mode=%s: %v", mode.String(), err)
+	}
+	if len(results) == 0 {
+		tb.Fatalf("SearchCosine score mode=%s returned no results", mode.String())
+	}
+	assertColumnVectorGraphBenchmarkDebugStats1979(tb, stats, true)
+	assertColumnVectorGraphSearchTopologyParityCurrentStats2091(tb, columnVectorGraphSearchTopologyParityBoundaryGraphOnly2091, stats)
+	return cloneColumnVectorGraphPreparedResults2045(results), stats
+}
+
+func assertColumnVectorGraphPreparedExactIndexedWorkStatsEqual2098(tb testing.TB, scalar, indexed columnVectorGraphNativeSearchStats) {
+	tb.Helper()
+	checks := []struct {
+		name    string
+		scalar  uint64
+		indexed uint64
+	}{
+		{name: "candidate_rows", scalar: scalar.CandidateRows, indexed: indexed.CandidateRows},
+		{name: "candidates", scalar: scalar.Candidates, indexed: indexed.Candidates},
+		{name: "edges", scalar: scalar.Edges, indexed: indexed.Edges},
+		{name: "visited_edges", scalar: scalar.VisitedEdges, indexed: indexed.VisitedEdges},
+		{name: "visited_nodes", scalar: scalar.VisitedNodes, indexed: indexed.VisitedNodes},
+		{name: "candidate_fetches", scalar: scalar.CandidateFetches, indexed: indexed.CandidateFetches},
+		{name: "prepared_score_calls", scalar: scalar.PreparedScoreCalls, indexed: indexed.PreparedScoreCalls},
+		{name: "score_batch_candidates", scalar: scalar.ScoreBatchCandidates, indexed: indexed.ScoreBatchCandidates},
+		{name: "layer0_scores", scalar: scalar.Layer0Scores, indexed: indexed.Layer0Scores},
+		{name: "layer0_scored_neighbors", scalar: scalar.Layer0ScoredNeighbors, indexed: indexed.Layer0ScoredNeighbors},
+		{name: "frontier_pushes", scalar: scalar.FrontierPushes, indexed: indexed.FrontierPushes},
+		{name: "top_k_insert_attempts", scalar: scalar.TopKInsertAttempts, indexed: indexed.TopKInsertAttempts},
+		{name: "exact_order_observations", scalar: scalar.ExactCandidateOrderObservations, indexed: indexed.ExactCandidateOrderObservations},
+		{name: "exact_order_transitions", scalar: scalar.ExactCandidateOrderTransitions, indexed: indexed.ExactCandidateOrderTransitions},
+		{name: "exact_order_adjacent_forward", scalar: scalar.ExactCandidateOrderAdjacentForward, indexed: indexed.ExactCandidateOrderAdjacentForward},
+		{name: "exact_order_non_adjacent_forward", scalar: scalar.ExactCandidateOrderNonAdjacentForward, indexed: indexed.ExactCandidateOrderNonAdjacentForward},
+		{name: "exact_order_backward_jumps", scalar: scalar.ExactCandidateOrderBackwardJumps, indexed: indexed.ExactCandidateOrderBackwardJumps},
+		{name: "exact_order_max_forward_run", scalar: scalar.ExactCandidateOrderMaxForwardRun, indexed: indexed.ExactCandidateOrderMaxForwardRun},
+		{name: "vector_prepared_identity_mapping", scalar: scalar.VectorPreparedIdentityMappings, indexed: indexed.VectorPreparedIdentityMappings},
+		{name: "vector_prepared_row_ref_mapping", scalar: scalar.VectorPreparedRowRefMappings, indexed: indexed.VectorPreparedRowRefMappings},
+		{name: "graph_row_fallbacks", scalar: scalar.GraphRowFallbacks, indexed: indexed.GraphRowFallbacks},
+		{name: "typed_column_fallbacks", scalar: scalar.TypedColumnFallbacks, indexed: indexed.TypedColumnFallbacks},
+		{name: "norm_source_fallbacks", scalar: scalar.NormSourceFallbacks, indexed: indexed.NormSourceFallbacks},
+	}
+	for _, check := range checks {
+		if check.scalar != check.indexed {
+			tb.Fatalf("%s scalar=%d indexed=%d scalarStats=%+v indexedStats=%+v", check.name, check.scalar, check.indexed, scalar, indexed)
+		}
+	}
+	if indexed.GraphRowFallbacks != 0 || indexed.TypedColumnFallbacks != 0 || indexed.VectorScratchDecodes != 0 || indexed.NormScratchDecodes != 0 || indexed.AdjacencySourceFallbacks != 0 {
+		tb.Fatalf("indexed stats=%+v want healthy prepared sources with no graph-row/source fallback", indexed)
+	}
+}

--- a/TreeDB/collections/column_vector_graph_prepared_search.go
+++ b/TreeDB/collections/column_vector_graph_prepared_search.go
@@ -359,6 +359,9 @@ func (v *columnVectorGraphPreparedSearchView) scoreOrdinalsIndexed(plan *columnV
 	if v == nil || !v.ready() || len(query) != v.dims || len(ordinals) == 0 || scratch == nil {
 		return dst, false, nil
 	}
+	if got, ok, err := v.scoreOrdinalsIndexedSinglePart(plan, query, queryInvNorm, ordinals, dst, scratch, stats); ok || err != nil {
+		return got, ok, err
+	}
 	if cap(dst) < len(ordinals) {
 		dst = make([]float64, len(ordinals))
 	} else {
@@ -444,11 +447,119 @@ func (v *columnVectorGraphPreparedSearchView) scoreOrdinalsIndexed(plan *columnV
 		stats.ScoreBatchOptimizedCalls += optimizedCalls
 		stats.ScoreBatchScalarFallbackCalls += scalarFallbackCalls
 		v.recordScoreStats(stats, plan, len(ordinals))
-		for _, ordinal := range ordinals {
-			v.recordMappingStats(stats, ordinal)
-		}
+		v.recordMappingStatsCount(stats, len(ordinals))
 	}
 	return dst, true, nil
+}
+
+func (v *columnVectorGraphPreparedSearchView) scoreOrdinalsIndexedSinglePart(plan *columnVectorGraphSearchPlan, query []float32, queryInvNorm float32, ordinals []int, dst []float64, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) ([]float64, bool, error) {
+	if v == nil || !v.ready() || v.vector.singlePart == nil || len(query) != v.dims || len(ordinals) == 0 || scratch == nil {
+		return dst, false, nil
+	}
+	part := v.vector.singlePart
+	if part == nil || part.handle == nil || part.handle.Released() || part.rows < 0 || v.dims <= 0 || part.rows > maxCollectionInt/v.dims || len(part.values) != part.rows*v.dims {
+		return dst, false, nil
+	}
+	if cap(dst) < len(ordinals) {
+		dst = make([]float64, len(ordinals))
+	} else {
+		dst = dst[:len(ordinals)]
+	}
+	rowIndexByOrdinal := v.vector.rowIndexByOrdinal
+	if !vectorops.DotFloat32BatchOptimizedAvailable() {
+		for i, ordinal := range ordinals {
+			row, ok := v.singlePartRowForOrdinal(ordinal, rowIndexByOrdinal, part)
+			if !ok || ordinal >= len(v.norm.values) {
+				return dst, false, nil
+			}
+			start := row * v.dims
+			vector := part.values[start : start+v.dims]
+			score, err := v.scorePreparedDot(query, queryInvNorm, ordinal, float64(vectorDotProductFloat32(query, vector)), vector, stats)
+			if err != nil {
+				return dst, true, err
+			}
+			dst[i] = score
+		}
+		if stats != nil {
+			recordColumnVectorGraphScoreBatchStats(stats, len(ordinals), false, true)
+			v.recordScoreStats(stats, plan, len(ordinals))
+			v.recordMappingStatsCount(stats, len(ordinals))
+		}
+		return dst, true, nil
+	}
+
+	scratch.scoreTileRowIDs = ensureColumnVectorGraphNativeUint32Scratch(scratch.scoreTileRowIDs, len(ordinals))
+	rowIDs := scratch.scoreTileRowIDs[:len(ordinals)]
+	for i, ordinal := range ordinals {
+		row, ok := v.singlePartRowForOrdinal(ordinal, rowIndexByOrdinal, part)
+		if !ok || ordinal >= len(v.norm.values) || uint64(row) > uint64(^uint32(0)) {
+			return dst, false, nil
+		}
+		rowIDs[i] = uint32(row)
+	}
+	scratch.scoreTileDots = ensureColumnVectorGraphNativeFloat32Scratch(scratch.scoreTileDots, len(ordinals))
+	dots := scratch.scoreTileDots[:len(ordinals)]
+	status := vectorops.DotFloat32Indexed(dots, part.values, query, rowIDs, v.dims)
+	if status.Invalid || status.Rows != len(ordinals) {
+		return dst, false, nil
+	}
+	for i, ordinal := range ordinals {
+		row := int(rowIDs[i])
+		start := row * v.dims
+		vector := part.values[start : start+v.dims]
+		score, err := v.scorePreparedDot(query, queryInvNorm, ordinal, float64(dots[i]), vector, stats)
+		if err != nil {
+			return dst, true, err
+		}
+		dst[i] = score
+	}
+	if stats != nil {
+		recordColumnVectorGraphScoreBatchStats(stats, len(ordinals), false, false)
+		if status.Optimized {
+			stats.ScoreBatchOptimizedCalls++
+		} else {
+			stats.ScoreBatchScalarFallbackCalls++
+		}
+		v.recordScoreStats(stats, plan, len(ordinals))
+		v.recordMappingStatsCount(stats, len(ordinals))
+	}
+	return dst, true, nil
+}
+
+func (v *columnVectorGraphPreparedSearchView) singlePartRowForOrdinal(ordinal int, rowIndexByOrdinal []uint32, part *columnVectorGraphTypedColumnVectorPart) (int, bool) {
+	if v == nil || part == nil || ordinal < 0 || ordinal >= v.rows {
+		return 0, false
+	}
+	row := ordinal
+	if rowIndexByOrdinal != nil {
+		if ordinal >= len(rowIndexByOrdinal) {
+			return 0, false
+		}
+		row = int(rowIndexByOrdinal[ordinal])
+	}
+	if row < 0 || row >= part.rows {
+		return 0, false
+	}
+	start := row * v.dims
+	end := start + v.dims
+	if start < 0 || end < start || end > len(part.values) {
+		return 0, false
+	}
+	return row, true
+}
+
+func (v *columnVectorGraphPreparedSearchView) scorePreparedDot(query []float32, queryInvNorm float32, ordinal int, dot float64, vector []float32, stats *columnVectorGraphNativeSearchStats) (float64, error) {
+	if math.IsInf(dot, 0) || math.IsNaN(dot) {
+		if stats != nil {
+			stats.ScoreFloat64Fallbacks++
+		}
+		dot = columnVectorGraphNativeDotProductFloat64(query, vector)
+	}
+	score := dot * float64(queryInvNorm) * float64(v.norm.values[ordinal])
+	if math.IsNaN(score) || math.IsInf(score, 0) {
+		return 0, fmt.Errorf("collections: column_graph candidate ordinal=%d cosine score is not finite", ordinal)
+	}
+	return score, nil
 }
 
 func (v *columnVectorGraphPreparedSearchView) recordScoreStats(stats *columnVectorGraphNativeSearchStats, plan *columnVectorGraphSearchPlan, count int) {
@@ -482,6 +593,17 @@ func (v *columnVectorGraphPreparedSearchView) recordMappingStats(stats *columnVe
 		return
 	}
 	stats.VectorPreparedRowRefMappings++
+}
+
+func (v *columnVectorGraphPreparedSearchView) recordMappingStatsCount(stats *columnVectorGraphNativeSearchStats, count int) {
+	if stats == nil || count <= 0 {
+		return
+	}
+	if v.vectorIdentityMapping {
+		stats.VectorPreparedIdentityMappings += uint64(count)
+		return
+	}
+	stats.VectorPreparedRowRefMappings += uint64(count)
 }
 
 func (v *columnVectorGraphPreparedSearchView) maxAdjacencyLayerForOrdinal(ordinal int) (int, columnVectorGraphAdjacencySourceCounterSnapshot, error) {

--- a/TreeDB/docs/guides/vector-search-typed-column.md
+++ b/TreeDB/docs/guides/vector-search-typed-column.md
@@ -260,11 +260,13 @@ is not the source of that mismatch. #1979 adds opt-in benchmark-debug
 batchability/control-flow counters on the #2091 topology-parity fixture: the
 bounded `ef_search=128` row's 612 visited edges are mostly already-visited
 layer-0 skips over degree-16 neighbor tiles, while exact mode scores all 8192
-candidates and visits 100748 edges/search. Use #1980 for frontier/top-k or
-already-visited optimization if future profiles continue to justify it, use a
-separate narrow indexed-scoring ticket if exact-mode gathered score batching is
-desired, and keep #1977 normalized vectors deferred until a prototype beats raw
-vectors plus inverse norms including storage/rebuild cost.
+candidates and visits 100748 edges/search. #2098 adds an opt-in prepared
+single-part indexed-scoring fast path with scalar/default result-equivalence
+coverage, but indexed scoring remains non-default until broader #2035 promotion
+evidence justifies a runtime change. Use #1980 for frontier/top-k or
+already-visited optimization if future profiles continue to justify it, and keep
+#1977 normalized vectors deferred until a prototype beats raw vectors plus
+inverse norms including storage/rebuild cost.
 
 The broader legacy/canonical matrix remains useful when comparing with older
 artifacts or when you also need one-shot open/setup names:

--- a/TreeDB/docs/spec/typed-column-graph-search-benchmark-matrix.md
+++ b/TreeDB/docs/spec/typed-column-graph-search-benchmark-matrix.md
@@ -416,12 +416,48 @@ Run context: macOS 26.2, Apple M3, 8 logical CPUs, 16 GiB memory,
   indexed-scoring ticket should expect graph-order/gathered batches rather than
   long contiguous row runs.
 
-Follow-up recommendation: keep #2035 open as not performance-satisfied. Use this
-#1979 evidence to prioritize #1980 frontier/top-k and already-visited handling
-for control-flow overhead, and use a separate narrow indexed-scoring ticket if
-exact-mode gathered score batching becomes a goal. #1977 normalized-vector
-storage remains a separate scoring/storage-format follow-up and is not
-implemented here.
+#1979 follow-up recommendation: keep #2035 open as not performance-satisfied.
+Use this #1979 evidence to prioritize #1980 frontier/top-k and already-visited
+handling for control-flow overhead, and use a separate narrow indexed-scoring
+ticket if exact-mode gathered score batching becomes a goal. #1977
+normalized-vector storage remains a separate scoring/storage-format follow-up
+and is not implemented here.
+
+## #2098 exact-mode gathered scoring evaluation
+
+#2098 optimized the opt-in prepared typed-column indexed scoring path for the
+common single-part base-vector view. On fallback-only batch backends, the
+indexed path now avoids repeated ordinal-location passes and the extra
+`DotFloat32Indexed` wrapper validation while preserving the same gathered score
+batch counters. This does not change default scoring mode, traversal/frontier
+semantics, `ef_search`, `topK`, fixture topology, result ordering, or persistent
+formats.
+
+Command used for the local before/after #2098 evidence run:
+
+```sh
+GOMAXPROCS=8 GOWORK=off go test ./TreeDB/collections \
+  -run '^$' \
+  -bench '^BenchmarkColumnVectorGraphSearchBatchability1979/(ef_search_128|exact)/score=(scalar|indexed)$' \
+  -benchmem -benchtime=1s -count=3
+```
+
+Median rows on macOS/Apple M3, `go version go1.25.5 darwin/arm64`:
+
+| Search mode | Score mode | Before #2098 ns/op | After #2098 ns/op | B/op | allocs/op | Counter summary |
+| --- | --- | ---: | ---: | ---: | ---: | --- |
+| `ef_search=128` | `scalar` | 9,275 | 9,279 | 0 | 0 | unchanged scalar singleton scoring: `score_batch_calls=128`, `score_batch_singletons=128`, `visited_edges=612` |
+| `ef_search=128` | `indexed` | 11,775 | 7,033 | 0 | 0 | same work and fallback-free sources; `score_batch_calls=25`, `score_batch_fallback=25`, `score_batch_max_tile_size=16`, `visited_edges=612` |
+| `exact` (`ef_search=8192`) | `scalar` | 1,086,851 | 1,148,337 | 0 | 0 | unchanged scalar singleton scoring: `score_batch_calls=8192`, `visited_edges=100748`, `exact_order_observations=8192` |
+| `exact` (`ef_search=8192`) | `indexed` | 1,238,033 | 963,815 | 0 | 0 | same exact work and fallback-free sources; `score_batch_calls=1797`, `score_batch_fallback=1797`, `score_batch_max_tile_size=16`, `exact_order_backward_jumps=5977` |
+
+#2098 interpretation: exact-mode gathered/indexed scoring is now a measured win
+for the prepared single-part benchmark hook and remains exactly equivalent to
+scalar/default results in focused fixed-fixture tests, including tie-order
+coverage. Keep indexed scoring non-default until #2035 promotion work runs the
+broader truth-matrix/public-search matrix and decides whether a runtime default
+change is warranted. #1981 wavefront traversal and #1977 normalized-vector
+storage remain separate evidence-gated follow-ups.
 
 ## Interpretation rules
 

--- a/TreeDB/docs/spec/typed-column-graph-search-prepared-views.md
+++ b/TreeDB/docs/spec/typed-column-graph-search-prepared-views.md
@@ -43,10 +43,12 @@ expose a topology/search-work mismatch (`612` versus `3340` visited_edges/search
 about 5.5x). #1979 now adds opt-in benchmark-debug control-flow counters on the
 #2091 topology-parity fixture: the bounded equal-topology row visits 612 edges
 mostly through already-visited layer-0 skips, while exact mode visits 100748
-edges/search by scoring all 8192 candidates. #1980 remains a profile-backed
-frontier/top-k or already-visited follow-up if future apples-to-apples profiles
-justify it; exact-mode gathered scoring should be a separate narrow ticket;
-#1977 normalized-vector payloads remain deferred.
+edges/search by scoring all 8192 candidates. #2098 adds an opt-in prepared
+single-part indexed-scoring fast path with scalar/default result-equivalence
+coverage, but does not make indexed scoring default-on. #1980 remains a
+profile-backed frontier/top-k or already-visited follow-up if future
+apples-to-apples profiles justify it; #1977 normalized-vector payloads remain
+deferred.
 
 Normative boundaries:
 


### PR DESCRIPTION
Closes #2098.

## Summary

- Optimizes opt-in prepared typed-column indexed/gathered scoring for the common single-part vector view.
  - Avoids repeated `locationForOrdinal` passes on single-part prepared views.
  - On fallback-only batch backends, avoids the extra `DotFloat32Indexed` row-ID validation/wrapper pass and scores the gathered tile directly while preserving score-batch counters.
- Adds fixed-fixture exact-mode scalar vs indexed equivalence tests, including tie/order coverage.
- Updates graph-search docs with the #2098 evidence and decision.

No HNSW traversal/frontier semantics, candidate order/tie behavior, `ef_search`, `topK`, fixture topology, default scoring mode, public API, or persistent format changes.

## Decision

The opt-in indexed/gathered path is now a measured win for the prepared single-part benchmark hook, including exact mode. It remains non-default in this PR. Recommended next step: use #2035 promotion work to run the broader truth-matrix/public-search matrix before any runtime default change. #1981 wavefront traversal and #1977 normalized-vector storage remain separate evidence-gated follow-ups.

## Result equivalence and counters

Focused tests added:

- `TestColumnVectorGraphPreparedExactIndexedScoringEquivalence2098`
- `TestColumnVectorGraphPreparedExactIndexedScoringTieOrder2098`

They assert scalar vs indexed exact-mode result equivalence, equal search-work/exact-order counters, healthy prepared-source counters, and tie-order preservation.

Counter highlights from the benchmark matrix below:

- `candidates/search`, `visited_edges/search`, exact candidate-order counters, and top-k/frontier work are unchanged between scalar and indexed rows.
- Exact indexed score calls remain grouped: `8192` scalar singleton calls vs `1797` indexed gathered calls.
- Source/fallback counters remain healthy: `graph_row_fallbacks=0`, `typed_column_vector_fallbacks=0`, `norm_source_fallbacks=0`, `adjacency_source_fallbacks=0`, `vector_scratch_decodes=0`, `norm_scratch_decodes=0`.
- Current local backend reports `score_batch_optimized=0`, so indexed rows use scalar fallback tiles (`score_batch_fallback=score_batch_calls`).

## Benchmarks

Command used before and after:

```sh
GOMAXPROCS=8 GOWORK=off go test ./TreeDB/collections \
  -run '^$' \
  -bench '^BenchmarkColumnVectorGraphSearchBatchability1979/(ef_search_128|exact)/score=(scalar|indexed)$' \
  -benchmem -benchtime=1s -count=3
```

Environment: macOS/Apple M3, `go version go1.25.5 darwin/arm64`, `GOMAXPROCS=8`.

Median rows:

| Search mode | Score mode | Before ns/op | Before ops/sec | After ns/op | After ops/sec | B/op | allocs/op | Key counters |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| `ef_search=128` | scalar | 9,275 | 107,817 | 9,279 | 107,766 | 0 | 0 | `candidates=128`, `visited_edges=612`, `score_batch_calls=128`, `score_batch_singletons=128` |
| `ef_search=128` | indexed | 11,775 | 84,928 | 7,033 | 142,177 | 0 | 0 | `candidates=128`, `visited_edges=612`, `score_batch_calls=25`, `score_batch_fallback=25`, `score_batch_max_tile_size=16` |
| exact (`ef_search=8192`) | scalar | 1,086,851 | 920.1 | 1,148,337 | 870.8 | 0 | 0 | `candidates=8192`, `visited_edges=100748`, `score_batch_calls=8192`, `exact_order_observations=8192` |
| exact (`ef_search=8192`) | indexed | 1,238,033 | 807.7 | 963,815 | 1,038 | 0 | 0 | `candidates=8192`, `visited_edges=100748`, `score_batch_calls=1797`, `score_batch_fallback=1797`, `exact_order_backward_jumps=5977` |

CPU-profile sanity check after the change (`-cpuprofile`, exact rows, `-benchtime=2s`):

- scalar: `scoreOrdinal` cumulative sample time ~0.40s; `locationForOrdinal` still visible.
- indexed: `scoreOrdinalsIndexedSinglePart` cumulative sample time ~0.23s while preserving identical exact work counters.

## Validation

```sh
GOWORK=off go test ./TreeDB/collections -run 'TestColumnVectorGraphPreparedExactIndexedScoring.*2098'
GOWORK=off go test ./TreeDB/collections -run 'TestColumnVectorGraphNativeSearchBenchmarkDebugCounters1979|TestColumnVectorGraphSearchTopologyParity2091|TestVectorGraphSearchTruthMatrixMetricContract2037' -count=1
GOWORK=off go test ./TreeDB/collections ./TreeDB/docs -count=1
git diff --check origin/main...HEAD
```
