### PR TITLE
Promote eligible prepared indexed graph scoring

### DIFF
--- a/TreeDB/collections/column_vector_graph_prepared_search.go
+++ b/TreeDB/collections/column_vector_graph_prepared_search.go
@@ -173,6 +173,10 @@ func (v *columnVectorGraphPreparedSearchView) ready() bool {
 	return v != nil && v.rows >= 0 && v.dims > 0 && v.vector.ready() && v.norm.ready() && v.adjacency != nil && v.rowRefs != nil && v.documentIDs != nil
 }
 
+func (v *columnVectorGraphPreparedSearchView) indexedScoringDefaultEligible() bool {
+	return v != nil && v.ready() && v.vector.singlePart != nil && v.norm.ready()
+}
+
 func (v *columnVectorGraphPreparedSearchView) validateLive() error {
 	if v == nil {
 		return errors.New("nil prepared graph-search view")

--- a/TreeDB/collections/column_vector_graph_prepared_search.go
+++ b/TreeDB/collections/column_vector_graph_prepared_search.go
@@ -174,7 +174,7 @@ func (v *columnVectorGraphPreparedSearchView) ready() bool {
 }
 
 func (v *columnVectorGraphPreparedSearchView) indexedScoringDefaultEligible() bool {
-	return v != nil && v.ready() && v.vector.singlePart != nil && v.norm.ready()
+	return v != nil && v.ready() && v.vector.singlePart != nil
 }
 
 func (v *columnVectorGraphPreparedSearchView) validateLive() error {

--- a/TreeDB/collections/column_vector_graph_promotion_2103_test.go
+++ b/TreeDB/collections/column_vector_graph_promotion_2103_test.go
@@ -1,0 +1,240 @@
+package collections
+
+import "testing"
+
+func TestColumnVectorGraphPreparedDefaultIndexedScoring2103(t *testing.T) {
+	if !columnGraphTypedColumnMmapDirectViewSupportedForTest() {
+		t.Skip("prepared default indexed scoring requires mmap_direct prepared views")
+	}
+	shape := columnVectorGraphSearchTopologyParityTestShape2091()
+	shape.efSearch = shape.rows
+	rows := columnVectorGraphSearchTopologyParityRows2091(t, shape)
+	closeFn, reader, query := openColumnVectorGraphSearchTopologyParityReader2091(t, shape, rows, columnVectorGraphSearchTopologyParityModeCurrentPrepared2091)
+	defer closeFn()
+	if reader.preparedSearch == nil || !reader.preparedSearch.indexedScoringDefaultEligible() {
+		t.Fatalf("preparedSearch=%v eligible=%v want default-indexed eligible prepared search", reader.preparedSearch != nil, reader.preparedSearch != nil && reader.preparedSearch.indexedScoringDefaultEligible())
+	}
+
+	for _, boundary := range []columnVectorGraphSearchTopologyParityBoundary2091{
+		columnVectorGraphSearchTopologyParityBoundaryGraphOnly2091,
+		columnVectorGraphSearchTopologyParityBoundaryResultID2091,
+	} {
+		boundary := boundary
+		t.Run(string(boundary), func(t *testing.T) {
+			scalarResults, scalarStats := searchColumnVectorGraphScoreMode2103(t, reader, query, shape, boundary, columnVectorGraphScoreBatchModeScalar)
+			defaultResults, defaultStats := searchColumnVectorGraphScoreMode2103(t, reader, query, shape, boundary, columnVectorGraphScoreBatchModeDefault)
+			indexedResults, indexedStats := searchColumnVectorGraphScoreMode2103(t, reader, query, shape, boundary, columnVectorGraphScoreBatchModeIndexed)
+
+			if mismatch := columnVectorGraphIndexedScoringResultsMismatch1969(defaultResults, scalarResults); mismatch != "" {
+				t.Fatalf("default vs scalar mismatch: %s", mismatch)
+			}
+			if mismatch := columnVectorGraphIndexedScoringResultsMismatch1969(defaultResults, indexedResults); mismatch != "" {
+				t.Fatalf("default vs indexed mismatch: %s", mismatch)
+			}
+			assertColumnVectorGraphPreparedExactIndexedWorkStatsEqual2098(t, scalarStats, defaultStats)
+			assertColumnVectorGraphPreparedExactIndexedWorkStatsEqual2098(t, scalarStats, indexedStats)
+			assertColumnVectorGraphDefaultIndexedScoreBatches2103(t, defaultStats, indexedStats, scalarStats)
+			assertColumnVectorGraphSearchTopologyParityCurrentStats2091(t, boundary, defaultStats)
+		})
+	}
+}
+
+func TestColumnVectorGraphNonPreparedDefaultScoringRemainsScalar2103(t *testing.T) {
+	if !columnGraphTypedColumnMmapDirectViewSupportedForTest() {
+		t.Skip("non-prepared default scalar scoring comparison requires mmap_direct state")
+	}
+	shape := columnVectorGraphSearchTopologyParityTestShape2091()
+	shape.efSearch = shape.rows
+	rows := columnVectorGraphSearchTopologyParityRows2091(t, shape)
+	closeFn, reader, query := openColumnVectorGraphSearchTopologyParityReader2091(t, shape, rows, columnVectorGraphSearchTopologyParityModeCurrentPrepared2091)
+	defer closeFn()
+	reader.preparedSearch = nil
+
+	for _, boundary := range []columnVectorGraphSearchTopologyParityBoundary2091{
+		columnVectorGraphSearchTopologyParityBoundaryGraphOnly2091,
+		columnVectorGraphSearchTopologyParityBoundaryResultID2091,
+	} {
+		boundary := boundary
+		t.Run(string(boundary), func(t *testing.T) {
+			scalarResults, scalarStats := searchColumnVectorGraphScoreMode2103(t, reader, query, shape, boundary, columnVectorGraphScoreBatchModeScalar)
+			defaultResults, defaultStats := searchColumnVectorGraphScoreMode2103(t, reader, query, shape, boundary, columnVectorGraphScoreBatchModeDefault)
+			if mismatch := columnVectorGraphIndexedScoringResultsMismatch1969(defaultResults, scalarResults); mismatch != "" {
+				t.Fatalf("non-prepared default vs scalar mismatch: %s", mismatch)
+			}
+			if defaultStats.PreparedGraphSearchViews != 0 || defaultStats.GraphRowFallbacks != 0 || defaultStats.TypedColumnFallbacks != 0 || defaultStats.AdjacencySourceFallbacks != 0 || defaultStats.ResultIDGraphFallbacks != 0 {
+				t.Fatalf("non-prepared default stats=%+v want typed-column source route without graph-row/source fallback", defaultStats)
+			}
+			if defaultStats.ScoreBatchCalls != scalarStats.ScoreBatchCalls || defaultStats.ScoreBatchCandidates != scalarStats.ScoreBatchCandidates {
+				t.Fatalf("non-prepared default stats=%+v scalar stats=%+v want scalar-equivalent score batches", defaultStats, scalarStats)
+			}
+			assertColumnVectorGraphScalarScoreBatches2103(t, defaultStats)
+		})
+	}
+}
+
+func TestColumnVectorGraphLegacyDefaultScoringRemainsScalar2103(t *testing.T) {
+	if !columnGraphTypedColumnMmapDirectViewSupportedForTest() {
+		t.Skip("legacy default scalar scoring comparison requires mmap_direct adjacency state")
+	}
+	shape := columnVectorGraphSearchTopologyParityTestShape2091()
+	shape.efSearch = shape.rows
+	rows := columnVectorGraphSearchTopologyParityRows2091(t, shape)
+	closeFn, reader, query := openColumnVectorGraphSearchTopologyParityReader2091(t, shape, rows, columnVectorGraphSearchTopologyParityModeLegacyGraphRowDirect2091)
+	defer closeFn()
+	if reader.preparedSearch != nil {
+		t.Fatalf("legacy reader preparedSearch=%v want nil compatibility graph-row path", reader.preparedSearch)
+	}
+
+	for _, boundary := range []columnVectorGraphSearchTopologyParityBoundary2091{
+		columnVectorGraphSearchTopologyParityBoundaryGraphOnly2091,
+		columnVectorGraphSearchTopologyParityBoundaryResultID2091,
+	} {
+		boundary := boundary
+		t.Run(string(boundary), func(t *testing.T) {
+			scalarResults, scalarStats := searchColumnVectorGraphScoreMode2103(t, reader, query, shape, boundary, columnVectorGraphScoreBatchModeScalar)
+			defaultResults, defaultStats := searchColumnVectorGraphScoreMode2103(t, reader, query, shape, boundary, columnVectorGraphScoreBatchModeDefault)
+			if mismatch := columnVectorGraphIndexedScoringResultsMismatch1969(defaultResults, scalarResults); mismatch != "" {
+				t.Fatalf("legacy default vs scalar mismatch: %s", mismatch)
+			}
+			assertColumnVectorGraphSearchTopologyParityLegacyStats2091(t, boundary, defaultStats)
+			if defaultStats.ScoreBatchCalls != scalarStats.ScoreBatchCalls || defaultStats.ScoreBatchCandidates != scalarStats.ScoreBatchCandidates {
+				t.Fatalf("legacy default stats=%+v scalar stats=%+v want scalar-equivalent score batches", defaultStats, scalarStats)
+			}
+			assertColumnVectorGraphScalarScoreBatches2103(t, defaultStats)
+		})
+	}
+}
+
+func BenchmarkColumnVectorGraphSearchPromotion2103(b *testing.B) {
+	if !columnGraphTypedColumnMmapDirectViewSupportedForTest() {
+		b.Skip("promotion matrix requires mmap_direct prepared views")
+	}
+	shape := columnVectorGraphSearchTopologyParityProductionShape2091()
+	type promotionRow struct {
+		mode      columnVectorGraphSearchTopologyParityMode2091
+		scoreName string
+		scoreMode columnVectorGraphScoreBatchMode
+	}
+	rows := []promotionRow{
+		{mode: columnVectorGraphSearchTopologyParityModeLegacyGraphRowDirect2091, scoreName: "default", scoreMode: columnVectorGraphScoreBatchModeDefault},
+		{mode: columnVectorGraphSearchTopologyParityModeCurrentPrepared2091, scoreName: "default", scoreMode: columnVectorGraphScoreBatchModeDefault},
+		{mode: columnVectorGraphSearchTopologyParityModeCurrentPrepared2091, scoreName: "scalar", scoreMode: columnVectorGraphScoreBatchModeScalar},
+		{mode: columnVectorGraphSearchTopologyParityModeCurrentPrepared2091, scoreName: "indexed", scoreMode: columnVectorGraphScoreBatchModeIndexed},
+	}
+	for _, boundary := range []columnVectorGraphSearchTopologyParityBoundary2091{
+		columnVectorGraphSearchTopologyParityBoundaryGraphOnly2091,
+		columnVectorGraphSearchTopologyParityBoundaryResultID2091,
+	} {
+		boundary := boundary
+		b.Run("boundary="+string(boundary), func(b *testing.B) {
+			for _, row := range rows {
+				row := row
+				b.Run("mode="+string(row.mode)+"/score="+row.scoreName, func(b *testing.B) {
+					benchmarkColumnVectorGraphSearchPromotion2103(b, shape, boundary, row.mode, row.scoreName, row.scoreMode)
+				})
+			}
+		})
+	}
+}
+
+func benchmarkColumnVectorGraphSearchPromotion2103(b *testing.B, shape columnVectorGraphSearchTopologyParityShape2091, boundary columnVectorGraphSearchTopologyParityBoundary2091, mode columnVectorGraphSearchTopologyParityMode2091, scoreName string, scoreMode columnVectorGraphScoreBatchMode) {
+	b.Helper()
+	rows := columnVectorGraphSearchTopologyParityRows2091(b, shape)
+	closeFn, reader, query := openColumnVectorGraphSearchTopologyParityReader2091(b, shape, rows, mode)
+	defer closeFn()
+	var scratch columnVectorGraphNativeSearchScratch
+	opts := columnVectorGraphSearchPromotionOptions2103(shape, boundary, scoreMode)
+	warm, warmStats, err := reader.SearchCosine(query, opts, &scratch)
+	if err != nil {
+		b.Fatalf("warm SearchCosine: %v", err)
+	}
+	if len(warm) == 0 {
+		b.Fatalf("warm SearchCosine returned no results")
+	}
+	assertColumnVectorGraphSearchTopologyParityModeStats2091(b, boundary, mode, warmStats)
+	assertColumnVectorGraphBenchmarkDebugStats1979(b, warmStats, false)
+	assertColumnVectorGraphSearchPromotionScoreStats2103(b, mode, scoreName, warmStats)
+	baseReaderStats := reader.Stats()
+	var totals columnVectorGraphNativeSearchStats
+	var checksum int64
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		got, stats, err := reader.SearchCosine(query, opts, &scratch)
+		if err != nil {
+			b.Fatalf("SearchCosine: %v", err)
+		}
+		if len(got) == 0 {
+			b.Fatalf("SearchCosine returned no results")
+		}
+		checksum += int64(got[0].Ordinal)
+		addColumnVectorGraphSearchTopologyParityStats2091(&totals, stats)
+	}
+	b.StopTimer()
+	columnPhysicalScanBenchSum += checksum
+	reportColumnVectorGraphSearchTopologyParityMetrics2091(b, shape, boundary, mode, b.N, baseReaderStats, reader.Stats(), totals)
+	b.ReportMetric(2103, "promotion_issue")
+	b.ReportMetric(1, "promotion_score_mode_"+scoreName)
+}
+
+func columnVectorGraphSearchPromotionOptions2103(shape columnVectorGraphSearchTopologyParityShape2091, boundary columnVectorGraphSearchTopologyParityBoundary2091, scoreMode columnVectorGraphScoreBatchMode) columnVectorGraphNativeSearchOptions {
+	opts := columnVectorGraphNativeSearchOptions{
+		TopK:           shape.topK,
+		EfSearch:       shape.efSearch,
+		ScoreBatchMode: scoreMode,
+		StatsMode:      columnVectorGraphNativeSearchStatsModeBenchmarkDebug,
+	}
+	if boundary == columnVectorGraphSearchTopologyParityBoundaryGraphOnly2091 {
+		opts.OmitResultMaterialization = true
+	}
+	return opts
+}
+
+func searchColumnVectorGraphScoreMode2103(tb testing.TB, reader *columnVectorGraphPhysicalRowReader, query []float32, shape columnVectorGraphSearchTopologyParityShape2091, boundary columnVectorGraphSearchTopologyParityBoundary2091, mode columnVectorGraphScoreBatchMode) ([]columnVectorGraphNativeSearchResult, columnVectorGraphNativeSearchStats) {
+	tb.Helper()
+	var scratch columnVectorGraphNativeSearchScratch
+	opts := columnVectorGraphSearchPromotionOptions2103(shape, boundary, mode)
+	results, stats, err := reader.SearchCosine(query, opts, &scratch)
+	if err != nil {
+		tb.Fatalf("SearchCosine boundary=%s score mode=%s: %v", boundary, mode.String(), err)
+	}
+	if len(results) == 0 {
+		tb.Fatalf("SearchCosine boundary=%s score mode=%s returned no results", boundary, mode.String())
+	}
+	assertColumnVectorGraphBenchmarkDebugStats1979(tb, stats, shape.efSearch >= shape.rows)
+	return cloneColumnVectorGraphPreparedResults2045(results), stats
+}
+
+func assertColumnVectorGraphDefaultIndexedScoreBatches2103(tb testing.TB, defaultStats, indexedStats, scalarStats columnVectorGraphNativeSearchStats) {
+	tb.Helper()
+	if defaultStats.ScoreBatchCalls != indexedStats.ScoreBatchCalls || defaultStats.ScoreBatchCandidates != indexedStats.ScoreBatchCandidates || defaultStats.ScoreBatchMaxTileSize != indexedStats.ScoreBatchMaxTileSize {
+		tb.Fatalf("default stats=%+v indexed stats=%+v want default to select indexed prepared score batching", defaultStats, indexedStats)
+	}
+	if defaultStats.ScoreBatchCalls >= scalarStats.ScoreBatchCalls || defaultStats.ScoreBatchMaxTileSize < 2 {
+		tb.Fatalf("default stats=%+v scalar stats=%+v want default indexed grouping", defaultStats, scalarStats)
+	}
+	if defaultStats.ScoreBatchSingletons+defaultStats.ScoreBatchSize2To4+defaultStats.ScoreBatchSize5To8+defaultStats.ScoreBatchSize9To16+defaultStats.ScoreBatchSize17Plus != defaultStats.ScoreBatchCalls {
+		tb.Fatalf("default stats=%+v want score-batch histogram to reconcile", defaultStats)
+	}
+	if defaultStats.GraphRowFallbacks != 0 || defaultStats.TypedColumnFallbacks != 0 || defaultStats.VectorScratchDecodes != 0 || defaultStats.NormScratchDecodes != 0 || defaultStats.AdjacencySourceFallbacks != 0 || defaultStats.ResultIDGraphFallbacks != 0 {
+		tb.Fatalf("default stats=%+v want healthy prepared path without graph-row/source fallback", defaultStats)
+	}
+}
+
+func assertColumnVectorGraphScalarScoreBatches2103(tb testing.TB, stats columnVectorGraphNativeSearchStats) {
+	tb.Helper()
+	if stats.ScoreBatchCalls == 0 || stats.ScoreBatchCalls != stats.ScoreBatchCandidates || stats.ScoreBatchMaxTileSize != 1 || stats.ScoreBatchSingletons != stats.ScoreBatchCalls {
+		tb.Fatalf("stats=%+v want scalar singleton score batches", stats)
+	}
+}
+
+func assertColumnVectorGraphSearchPromotionScoreStats2103(tb testing.TB, mode columnVectorGraphSearchTopologyParityMode2091, scoreName string, stats columnVectorGraphNativeSearchStats) {
+	tb.Helper()
+	if mode == columnVectorGraphSearchTopologyParityModeCurrentPrepared2091 && (scoreName == "default" || scoreName == "indexed") {
+		if stats.ScoreBatchCalls >= stats.ScoreBatchCandidates || stats.ScoreBatchMaxTileSize < 2 {
+			tb.Fatalf("mode=%s score=%s stats=%+v want grouped prepared indexed score batches", mode, scoreName, stats)
+		}
+		return
+	}
+	assertColumnVectorGraphScalarScoreBatches2103(tb, stats)
+}

--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -49,17 +49,8 @@ const (
 	columnVectorGraphNativeSearchStatsModeBenchmarkDebug
 )
 
-var columnVectorGraphIndexedScoringDefaultEnabled = false
-
 func (m columnVectorGraphScoreBatchMode) indexedEnabled() bool {
-	switch m {
-	case columnVectorGraphScoreBatchModeIndexed:
-		return true
-	case columnVectorGraphScoreBatchModeDefault:
-		return columnVectorGraphIndexedScoringDefaultEnabled
-	default:
-		return false
-	}
+	return m == columnVectorGraphScoreBatchModeIndexed
 }
 
 func (m columnVectorGraphScoreBatchMode) String() string {
@@ -69,11 +60,24 @@ func (m columnVectorGraphScoreBatchMode) String() string {
 	case columnVectorGraphScoreBatchModeScalar:
 		return "scalar"
 	default:
-		if columnVectorGraphIndexedScoringDefaultEnabled {
-			return "default_indexed"
-		}
-		return "default_scalar"
+		return "default"
 	}
+}
+
+func columnVectorGraphScoreBatchModeForSearchPlan(requested columnVectorGraphScoreBatchMode, plan *columnVectorGraphSearchPlan) columnVectorGraphScoreBatchMode {
+	switch requested {
+	case columnVectorGraphScoreBatchModeScalar, columnVectorGraphScoreBatchModeIndexed:
+		return requested
+	default:
+		if plan != nil && plan.preparedIndexedScoringDefaultEligible() {
+			return columnVectorGraphScoreBatchModeIndexed
+		}
+		return columnVectorGraphScoreBatchModeScalar
+	}
+}
+
+func (p *columnVectorGraphSearchPlan) preparedIndexedScoringDefaultEligible() bool {
+	return p != nil && p.preparedSearch != nil && p.preparedSearch.indexedScoringDefaultEligible()
 }
 
 func (m columnVectorGraphNativeSearchStatsMode) normalized() columnVectorGraphNativeSearchStatsMode {
@@ -988,7 +992,7 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 	if err != nil {
 		return nil, stats, err
 	}
-	plan.scoreBatchMode = opts.ScoreBatchMode
+	plan.scoreBatchMode = columnVectorGraphScoreBatchModeForSearchPlan(opts.ScoreBatchMode, plan)
 	if plan.preparedSearch != nil {
 		stats.PreparedGraphSearchViews = 1
 		if statsMode.minimal() {

--- a/TreeDB/collections/column_vector_graph_topology_parity_2091_test.go
+++ b/TreeDB/collections/column_vector_graph_topology_parity_2091_test.go
@@ -304,7 +304,7 @@ func cloneColumnVectorGraphTopologyParityRows2091(rows []columnVectorGraphAssetR
 }
 
 func columnVectorGraphSearchTopologyParityOptions2091(shape columnVectorGraphSearchTopologyParityShape2091, boundary columnVectorGraphSearchTopologyParityBoundary2091) columnVectorGraphNativeSearchOptions {
-	opts := columnVectorGraphNativeSearchOptions{TopK: shape.topK, EfSearch: shape.efSearch}
+	opts := columnVectorGraphNativeSearchOptions{TopK: shape.topK, EfSearch: shape.efSearch, ScoreBatchMode: columnVectorGraphScoreBatchModeScalar}
 	if boundary == columnVectorGraphSearchTopologyParityBoundaryGraphOnly2091 {
 		opts.OmitResultMaterialization = true
 	}

--- a/TreeDB/docs/graph_search_benchmark_matrix_test.go
+++ b/TreeDB/docs/graph_search_benchmark_matrix_test.go
@@ -66,6 +66,12 @@ func TestDocs_GraphSearchBenchmarkTruthMatrix2037(t *testing.T) {
 		"top_k_insert_rejections",
 		"exact_order_observations=8192",
 		"keep #2035 open as not performance-satisfied",
+		"#2103 prepared indexed-scoring promotion matrix",
+		"BenchmarkColumnVectorGraphSearchPromotion2103",
+		"ScoreBatchMode=default",
+		"eligible prepared typed-column path",
+		"legacy graph-row/direct compatibility",
+		"#2035 should remain open as the broader promotion tracker",
 	}
 	for _, needle := range required {
 		if !strings.Contains(text, needle) {

--- a/TreeDB/docs/spec/column-graph-native-vector-search.md
+++ b/TreeDB/docs/spec/column-graph-native-vector-search.md
@@ -28,6 +28,16 @@ Healthy search must use the documented prepared/direct state for vectors,
 adjacency, inverse norms, row refs, and document IDs; legacy graph-row payloads
 are compatibility inputs only and must not be counted as healthy-path evidence.
 
+Default scoring policy after #2103: when callers leave the internal score-batch
+mode at `default`, eligible prepared typed-column graph search uses
+prepared gathered/indexed scoring. Eligibility is deliberately narrow: the
+combined prepared graph-search view must be healthy, with a single-part prepared
+vector view and ready inverse norms. Explicit scalar remains available for parity
+tests and diagnostics, and legacy graph-row/direct or non-prepared fallback
+routes keep default scalar scoring. This policy does not change traversal
+semantics, frontier behavior, candidate order/tie behavior, `ef_search`, `topK`,
+result ordering, or persistent formats.
+
 ## Quickstart
 
 Declare a collection with JSON documents, physical column storage for the vector

--- a/TreeDB/docs/spec/typed-column-graph-search-benchmark-matrix.md
+++ b/TreeDB/docs/spec/typed-column-graph-search-benchmark-matrix.md
@@ -317,7 +317,7 @@ both graph-only and result-ID searches, and asserts equivalent results plus equa
 search-work counters (`candidate_rows/search`, `candidates/search`,
 `edges/search`, `visited_edges/search`, `visited_nodes/search`, score-batch
 candidate counts, fetch counts, and adjacency prepared-CSR counters). After
-#2103, these historical topology-parity rows explicitly pin scalar scoring so
+After #2103, these historical topology-parity rows explicitly pin scalar scoring so
 the gate continues to isolate topology/search-work parity rather than the
 prepared indexed-scoring default.
 
@@ -394,7 +394,7 @@ Run context: macOS 26.2, Apple M3, 8 logical CPUs, 16 GiB memory,
 | `exact` (`ef_search=8192`) | `scalar` | 1.091 ms | 916.7 | 0 | 0 | `candidates=8192`, `visited_nodes=8192`, `visited_edges=100748`, `edges_per_visited_node=12.30` | `neighbor_tiles=6297`, `neighbor_tile_avg_size=16`, `score_batch_calls=8192`, `score_batch_singletons=8192`, `scored_neighbors=8191`, `already_visited_skips=92557`, `frontier_pushes=8192`, `frontier_pops=6297`, `top_k_rejections=8132`, `exact_order_observations=8192`, `exact_order_backward_jumps=5977` |
 | `exact` (`ef_search=8192`) | `indexed` | 1.277 ms | 782.9 | 0 | 0 | `candidates=8192`, `visited_nodes=8192`, `visited_edges=100748`, `edges_per_visited_node=12.30` | `neighbor_tiles=6297`, `neighbor_tile_avg_size=16`, `score_batch_calls=1797`, `score_batch_singletons=364`, `score_batch_size_2_4=502`, `score_batch_size_5_8=930`, `score_batch_size_9_16=1`, `already_visited_skips=92557`, `frontier_pushes=8192`, `top_k_rejections=8132`, `exact_order_observations=8192`, `exact_order_backward_jumps=5977` |
 
-#1979 interpretation:
+Interpretation of #1979 historical evidence:
 
 - The equal-topology #2091 fixture's `ef_search=128` row explains its 612
   visited edges as layer-0 expansion work over 39 degree-16 neighbor tiles. The
@@ -421,7 +421,7 @@ Run context: macOS 26.2, Apple M3, 8 logical CPUs, 16 GiB memory,
   indexed-scoring ticket should expect graph-order/gathered batches rather than
   long contiguous row runs.
 
-#1979 follow-up recommendation: keep #2035 open as not performance-satisfied.
+Historical #1979 follow-up recommendation: keep #2035 open as not performance-satisfied.
 Use this #1979 evidence to prioritize #1980 frontier/top-k and already-visited
 handling for control-flow overhead, and use a separate narrow indexed-scoring
 ticket if exact-mode gathered score batching becomes a goal. #1977
@@ -430,7 +430,7 @@ and is not implemented here.
 
 ## #2098 exact-mode gathered scoring evaluation
 
-#2098 optimized the opt-in prepared typed-column indexed scoring path for the
+The later #2098 work optimized the opt-in prepared typed-column indexed scoring path for the
 common single-part base-vector view. On fallback-only batch backends, the
 indexed path now avoids repeated ordinal-location passes and the extra
 `DotFloat32Indexed` wrapper validation while preserving the same gathered score
@@ -456,16 +456,16 @@ Median rows on macOS/Apple M3, `go version go1.25.5 darwin/arm64`:
 | `exact` (`ef_search=8192`) | `scalar` | 1,086,851 | 1,148,337 | 0 | 0 | unchanged scalar singleton scoring: `score_batch_calls=8192`, `visited_edges=100748`, `exact_order_observations=8192` |
 | `exact` (`ef_search=8192`) | `indexed` | 1,238,033 | 963,815 | 0 | 0 | same exact work and fallback-free sources; `score_batch_calls=1797`, `score_batch_fallback=1797`, `score_batch_max_tile_size=16`, `exact_order_backward_jumps=5977` |
 
-#2098 interpretation: exact-mode gathered/indexed scoring is now a measured win
+Interpretation of #2098: exact-mode gathered/indexed scoring is now a measured win
 for the prepared single-part benchmark hook and remains exactly equivalent to
 scalar/default results in focused fixed-fixture tests, including tie-order
 coverage. #2103 owns the follow-up promotion matrix and default-gating decision.
-#1981 wavefront traversal and #1977 normalized-vector storage remain separate
+The #1981 wavefront traversal and #1977 normalized-vector storage remain separate
 evidence-gated follow-ups.
 
 ## #2103 prepared indexed-scoring promotion matrix
 
-#2103 promotes prepared indexed/gathered scoring as the **default only for the
+The #2103 work promotes prepared indexed/gathered scoring as the **default only for the
 eligible prepared typed-column path**. The runtime gate resolves
 `ScoreBatchMode=default` to indexed only when native search has a healthy
 combined prepared graph-search view with a single-part prepared vector view and
@@ -478,7 +478,7 @@ The default change is intentionally narrow. It does not change HNSW traversal,
 frontier behavior, candidate order/tie behavior, `ef_search`, `topK`, fixture
 topology, result ordering, public result IDs, or persistent formats. The #2091
 topology-parity benchmark remains scalar-pinned as a search-work parity control;
-#2103 adds `BenchmarkColumnVectorGraphSearchPromotion2103` for the
+The #2103 work adds `BenchmarkColumnVectorGraphSearchPromotion2103` for the
 `default`/`scalar`/`indexed` comparison.
 
 Commands used for local #2103 evidence on `0e114572f10e43377e7e07f055af1905ca5e7d16`
@@ -526,7 +526,7 @@ Median rows from the post-#2098/#2103 matrix:
 | #2103 `result_id` current prepared scalar | 10,259 | 97,471 | 0 | 0 | `visited_edges=612`, `result_fetches=10` | scalar: `score_batch_singletons=128`, max tile `1` | `graph_rows=0`, source/result fallbacks `0` |
 | #2103 `result_id` current prepared indexed | 7,768 | 128,732 | 0 | 0 | `visited_edges=612`, `result_fetches=10` | indexed: `score_batch_calls=25`, singleton/2-4/5-8/9-16 = `4/8/12/1`, max tile `16` | `graph_rows=0`, source/result fallbacks `0` |
 
-#2103 decision:
+Decision for #2103 (promotion matrix):
 
 - Enable the indexed/gathered scorer as the default for eligible prepared
   typed-column search only. In the bounded promotion rows, the prepared default

--- a/TreeDB/docs/spec/typed-column-graph-search-benchmark-matrix.md
+++ b/TreeDB/docs/spec/typed-column-graph-search-benchmark-matrix.md
@@ -316,7 +316,10 @@ ordinal, checks prepared vectors and document IDs against the source rows, runs
 both graph-only and result-ID searches, and asserts equivalent results plus equal
 search-work counters (`candidate_rows/search`, `candidates/search`,
 `edges/search`, `visited_edges/search`, `visited_nodes/search`, score-batch
-candidate counts, fetch counts, and adjacency prepared-CSR counters).
+candidate counts, fetch counts, and adjacency prepared-CSR counters). After
+#2103, these historical topology-parity rows explicitly pin scalar scoring so
+the gate continues to isolate topology/search-work parity rather than the
+prepared indexed-scoring default.
 
 Run context:
 
@@ -403,14 +406,16 @@ Run context: macOS 26.2, Apple M3, 8 logical CPUs, 16 GiB memory,
   topology/frontier revisitation (`92557 already_visited_skips/search`) plus the
   expected exact traversal budget, not typed-column adjacency overhead.
 - Natural neighbor tiles are full degree-16 tiles in this fixture
-  (`neighbor_tile_avg_size=16`). The scalar default still performs singleton
-  scoring (`score_batch_singletons == score_batch_calls`), so batchability exists
-  in the traversal but is not consumed by the default scoring path.
+  (`neighbor_tile_avg_size=16`). The scalar control performs singleton scoring
+  (`score_batch_singletons == score_batch_calls`), so batchability exists in the
+  traversal. At the time of #1979 this was also the default; #2103 later
+  promoted indexed/gathered scoring only for the eligible prepared path.
 - The indexed diagnostic row demonstrates available score grouping without
-  changing result order or default runtime behavior: exact-mode score calls drop
-  from 8192 singleton calls to 1797 calls, mostly size 2-8 tiles. It is not a
-  promotion claim because this row runs under debug instrumentation and the
-  existing indexed scoring hook is not enabled by default.
+  changing result order: exact-mode score calls drop from 8192 singleton calls
+  to 1797 calls, mostly size 2-8 tiles. At #1979 time it was not a promotion
+  claim because this row ran under debug instrumentation and the indexed scoring
+  hook was not enabled by default; #2103 later runs the promotion matrix and
+  changes only the eligible prepared default.
 - Exact candidate order is not mostly sequential (`5977 backward jumps` versus
   `2199 adjacent-forward transitions` in the exact row), so a renewed exact-mode
   indexed-scoring ticket should expect graph-order/gathered batches rather than
@@ -454,10 +459,90 @@ Median rows on macOS/Apple M3, `go version go1.25.5 darwin/arm64`:
 #2098 interpretation: exact-mode gathered/indexed scoring is now a measured win
 for the prepared single-part benchmark hook and remains exactly equivalent to
 scalar/default results in focused fixed-fixture tests, including tie-order
-coverage. Keep indexed scoring non-default until #2035 promotion work runs the
-broader truth-matrix/public-search matrix and decides whether a runtime default
-change is warranted. #1981 wavefront traversal and #1977 normalized-vector
-storage remain separate evidence-gated follow-ups.
+coverage. #2103 owns the follow-up promotion matrix and default-gating decision.
+#1981 wavefront traversal and #1977 normalized-vector storage remain separate
+evidence-gated follow-ups.
+
+## #2103 prepared indexed-scoring promotion matrix
+
+#2103 promotes prepared indexed/gathered scoring as the **default only for the
+eligible prepared typed-column path**. The runtime gate resolves
+`ScoreBatchMode=default` to indexed only when native search has a healthy
+combined prepared graph-search view with a single-part prepared vector view and
+ready inverse norms. Explicit scalar and explicit indexed modes continue to be
+honored. The legacy graph-row/direct compatibility path, non-prepared typed-column
+source routes, and fallback paths resolve default to scalar, so this does not
+force legacy/graph-row search into gathered scoring.
+
+The default change is intentionally narrow. It does not change HNSW traversal,
+frontier behavior, candidate order/tie behavior, `ef_search`, `topK`, fixture
+topology, result ordering, public result IDs, or persistent formats. The #2091
+topology-parity benchmark remains scalar-pinned as a search-work parity control;
+#2103 adds `BenchmarkColumnVectorGraphSearchPromotion2103` for the
+`default`/`scalar`/`indexed` comparison.
+
+Commands used for local #2103 evidence on `0e114572f10e43377e7e07f055af1905ca5e7d16`
+plus the #2103 branch changes:
+
+```sh
+GOMAXPROCS=8 GOWORK=off go test ./TreeDB/collections \
+  -run '^$' \
+  -bench '^BenchmarkColumnVectorGraphSearchTopologyParity2091' \
+  -benchmem -benchtime=1s -count=3
+
+GOMAXPROCS=8 GOWORK=off go test ./TreeDB/collections \
+  -run '^$' \
+  -bench '^BenchmarkColumnVectorGraphSearchBatchability1979/(ef_search_128|exact)/score=(scalar|indexed)$' \
+  -benchmem -benchtime=1s -count=3
+
+GOMAXPROCS=8 GOWORK=off go test ./TreeDB/collections \
+  -run '^$' \
+  -bench '^BenchmarkColumnVectorGraphSearchPromotion2103$' \
+  -benchmem -benchtime=1s -count=3
+```
+
+Run context: macOS 26.2, Apple M3, 8 logical CPUs, 16 GiB memory,
+`go version go1.25.5 darwin/arm64`. Local artifacts are under
+`/tmp/gomap_2103_evidence/`.
+
+Median rows from the post-#2098/#2103 matrix:
+
+| Benchmark row | ns/op | ops/sec | B/op | allocs/op | Work counters | Score-batch / order counters | Source/fallback counters |
+| --- | ---: | ---: | ---: | ---: | --- | --- | --- |
+| #2091 `graph_only` legacy scalar control | 8,572 | 116,653 | 0 | 0 | `visited_edges=612`, `candidate_fetches=128` | `score_batch_calls=128`, max tile `1` | `graph_rows=8192`, `graph_row_fallbacks=128`, `adjacency_source_fallbacks=0` |
+| #2091 `graph_only` current prepared scalar control | 8,463 | 118,158 | 0 | 0 | `visited_edges=612`, `candidate_fetches=128` | `score_batch_calls=128`, max tile `1` | `graph_rows=0`, `prepared_graph_search_views=1`, all graph-row/source fallbacks `0` |
+| #2091 `result_id` legacy scalar control | 8,581 | 116,530 | 0 | 0 | `visited_edges=612`, `result_fetches=10` | `score_batch_calls=128`, max tile `1` | `graph_rows=8192`, `result_id_graph_fallbacks=10` |
+| #2091 `result_id` current prepared scalar control | 9,369 | 106,737 | 0 | 0 | `visited_edges=612`, `result_fetches=10` | `score_batch_calls=128`, max tile `1` | `graph_rows=0`, `result_id_graph_fallbacks=0`, row-ref/doc-ID prepared counters healthy |
+| #1979 `ef_search=128` current prepared scalar | 9,412 | 106,247 | 0 | 0 | `visited_edges=612`, `already_visited_skips=485` | `score_batch_singletons=128`, exact-order counters `0` | prepared/source fallbacks `0` |
+| #1979 `ef_search=128` current prepared indexed | 7,183 | 139,223 | 0 | 0 | `visited_edges=612`, `already_visited_skips=485` | `score_batch_calls=25`, singleton/2-4/5-8/9-16 = `4/8/12/1`, max tile `16`, exact-order counters `0` | prepared/source fallbacks `0` |
+| #1979 exact current prepared scalar | 1,076,556 | 929 | 0 | 0 | `visited_edges=100748`, `already_visited_skips=92557` | `score_batch_singletons=8192`, `exact_order_observations=8192`, `backward_jumps=5977` | prepared/source fallbacks `0` |
+| #1979 exact current prepared indexed | 931,805 | 1,073 | 0 | 0 | `visited_edges=100748`, `already_visited_skips=92557` | `score_batch_calls=1797`, singleton/2-4/5-8/9-16 = `364/502/930/1`, max tile `16`, `exact_order_observations=8192`, `backward_jumps=5977` | prepared/source fallbacks `0` |
+| #2103 `graph_only` legacy default | 9,468 | 105,618 | 0 | 0 | `visited_edges=612`, `candidate_fetches=128` | scalar: `score_batch_singletons=128`, max tile `1` | `graph_rows=8192`, `graph_row_fallbacks=128`, `adjacency_source_fallbacks=0` |
+| #2103 `graph_only` current prepared default | 7,242 | 138,079 | 0 | 0 | `visited_edges=612`, `candidate_fetches=128` | indexed: `score_batch_calls=25`, singleton/2-4/5-8/9-16 = `4/8/12/1`, max tile `16` | `graph_rows=0`, `prepared_graph_search_views=1`, all source/result fallbacks `0` |
+| #2103 `graph_only` current prepared scalar | 9,346 | 107,002 | 0 | 0 | `visited_edges=612`, `candidate_fetches=128` | scalar: `score_batch_singletons=128`, max tile `1` | `graph_rows=0`, source fallbacks `0` |
+| #2103 `graph_only` current prepared indexed | 6,857 | 145,839 | 0 | 0 | `visited_edges=612`, `candidate_fetches=128` | indexed: `score_batch_calls=25`, singleton/2-4/5-8/9-16 = `4/8/12/1`, max tile `16` | `graph_rows=0`, source fallbacks `0` |
+| #2103 `result_id` legacy default | 9,537 | 104,851 | 0 | 0 | `visited_edges=612`, `result_fetches=10` | scalar: `score_batch_singletons=128`, max tile `1` | `graph_rows=8192`, `result_id_graph_fallbacks=10` |
+| #2103 `result_id` current prepared default | 7,786 | 128,432 | 0 | 0 | `visited_edges=612`, `result_fetches=10` | indexed: `score_batch_calls=25`, singleton/2-4/5-8/9-16 = `4/8/12/1`, max tile `16` | `graph_rows=0`, `result_id_graph_fallbacks=0`, row-ref/doc-ID prepared counters healthy |
+| #2103 `result_id` current prepared scalar | 10,259 | 97,471 | 0 | 0 | `visited_edges=612`, `result_fetches=10` | scalar: `score_batch_singletons=128`, max tile `1` | `graph_rows=0`, source/result fallbacks `0` |
+| #2103 `result_id` current prepared indexed | 7,768 | 128,732 | 0 | 0 | `visited_edges=612`, `result_fetches=10` | indexed: `score_batch_calls=25`, singleton/2-4/5-8/9-16 = `4/8/12/1`, max tile `16` | `graph_rows=0`, source/result fallbacks `0` |
+
+#2103 decision:
+
+- Enable the indexed/gathered scorer as the default for eligible prepared
+  typed-column search only. In the bounded promotion rows, the prepared default
+  now tracks the indexed row and is materially faster than the scalar control at
+  both graph-only and result-ID boundaries while keeping `visited_edges=612`,
+  `topK=10`, `ef_search=128`, result order, and zero allocations fixed.
+- Exact-mode evidence remains favorable for the same prepared path: indexed
+  scoring preserves exact candidate-order counters and reduces score calls from
+  `8192` to `1797` without source fallbacks.
+- Legacy/graph-row default remains scalar and keeps its existing fallback/source
+  counters. Explicit scalar remains available and is used by #2091 parity tests.
+- #2035 should remain open as the broader promotion tracker until public-search
+  and larger/real-workload evidence catches up, but its prepared scoring blocker
+  is resolved by #2103. #1981 wavefront traversal and #1977 normalized-vector
+  storage remain deferred/evidence-gated and are not prerequisites for this
+  narrow default.
 
 ## Interpretation rules
 

--- a/TreeDB/docs/spec/typed-column-graph-search-benchmark-matrix.md
+++ b/TreeDB/docs/spec/typed-column-graph-search-benchmark-matrix.md
@@ -316,8 +316,8 @@ ordinal, checks prepared vectors and document IDs against the source rows, runs
 both graph-only and result-ID searches, and asserts equivalent results plus equal
 search-work counters (`candidate_rows/search`, `candidates/search`,
 `edges/search`, `visited_edges/search`, `visited_nodes/search`, score-batch
-candidate counts, fetch counts, and adjacency prepared-CSR counters). After
-After #2103, these historical topology-parity rows explicitly pin scalar scoring so
+candidate counts, fetch counts, and adjacency prepared-CSR counters). After #2103,
+these historical topology-parity rows explicitly pin scalar scoring so
 the gate continues to isolate topology/search-work parity rather than the
 prepared indexed-scoring default.
 

--- a/TreeDB/docs/spec/verification.md
+++ b/TreeDB/docs/spec/verification.md
@@ -895,6 +895,11 @@ Invariant:
   frontier/top-k operation counts, visited-mark hits/misses, exact-mode candidate
   order summaries, `ns/op`, `ops/sec`, `B/op`, and `allocs/op` without changing
   traversal semantics or fixture topology.
+- The #2103 promotion gate must prove that default gathered/indexed scoring is
+  selected only for healthy eligible prepared typed-column search, that explicit
+  scalar/default/indexed prepared results match, and that legacy graph-row/direct
+  or non-prepared fallback routes keep default scalar scoring and existing
+  fallback/source counters.
 
 Coverage:
 - Policy owner: `TreeDB/docs/spec/typed-column-graph-search-benchmark-matrix.md`.
@@ -913,6 +918,12 @@ Coverage:
     counter reconciliation, skip buckets, layer work, frontier/top-k counts, and
     exact-mode candidate-order summaries; `BenchmarkColumnVectorGraphSearchBatchability1979`
     emits the opt-in batchability/control-flow rows.
+  - `TreeDB/collections/column_vector_graph_promotion_2103_test.go`:
+    `TestColumnVectorGraphPreparedDefaultIndexedScoring2103`,
+    `TestColumnVectorGraphNonPreparedDefaultScoringRemainsScalar2103`, and
+    `TestColumnVectorGraphLegacyDefaultScoringRemainsScalar2103` freeze the
+    default-gating decision; `BenchmarkColumnVectorGraphSearchPromotion2103`
+    emits the default/scalar/indexed promotion rows.
 
 ## 13. Native Wire Protocol
 


### PR DESCRIPTION
## Objective

Promote prepared gathered/indexed score batching as the runtime default only for eligible prepared typed-column graph search plans, while preserving scalar-default behavior for legacy, non-prepared, and fallback routes. Follow-up review feedback is incorporated without changing traversal semantics.

## Context

The post-#2098 matrix showed prepared indexed scoring wins, but runtime default remained scalar. This PR promotes the eligible prepared path by default, keeps conservative defaults elsewhere, and includes latest-head review fixes (predicate simplification plus markdown/spec wording cleanups).

## Non-goals

- No HNSW traversal/frontier/candidate-order/tie/recall behavior changes.
- No `ef_search`, `topK`, topology, query, fixture, or persistent-format changes.
- No #1981 wavefront/relaxed traversal.
- No #1977 normalized-vector storage.
- No global enablement for legacy graph-row/direct or non-prepared fallback routes.

## Design

- Formats/flags/APIs changed (include diagrams if applicable)
  - `ScoreBatchMode=default` is resolved per search plan.
  - Eligible healthy combined prepared typed-column view with single-part prepared vector view uses indexed/gathered scoring by default.
  - Explicit scalar/indexed selection remains honored.
  - Legacy graph-row/direct, non-prepared typed-column source, and fallback routes remain scalar by default.
- Invariants that must hold
  - Topology/search-work parity rows (#2091) stay pinned to explicit scalar scoring.
  - Default indexed promotion applies only on eligible prepared path.
  - Prepared source/result fallback counters remain zero on eligible prepared path.
- Fail-closed behavior (caps before alloc; CRC/error handling)
  - Eligibility remains fail-closed through existing prepared-view readiness checks.
  - Review fix removed redundant `v.norm.ready()` in `indexedScoringDefaultEligible()` because `v.ready()` already subsumes norm readiness.
  - Latest docs follow-up fixed duplicated wording in the benchmark matrix spec (`After After #2103` → `After #2103`) with no runtime behavior change.

## Scope

- Includes (files/symbols):
  - `TreeDB/collections/column_vector_graph_prepared_search.go` (`indexedScoringDefaultEligible`).
  - Prepared/default/scalar/indexed promotion tests and benchmark rows in `TreeDB/collections`.
  - Docs/spec updates for scoring default behavior, including benchmark matrix markdown heading-safe issue references and wording typo cleanup.
- Excludes (files/symbols):
  - HNSW traversal logic and candidate ordering.
  - Storage format/schema changes.
  - Global default changes for legacy or non-prepared routes.

## Correctness

- Tests run (exact commands):
  - `GOWORK=off go test ./TreeDB/collections -run 'TestColumnVectorGraphPreparedDefaultIndexedScoring2103|TestColumnVectorGraphNonPreparedDefaultScoringRemainsScalar2103|TestColumnVectorGraphLegacyDefaultScoringRemainsScalar2103|TestColumnVectorGraphPreparedExactIndexedScoring.*2098|TestColumnVectorGraphNativeSearchBenchmarkDebugCounters1979|TestColumnVectorGraphSearchTopologyParity2091|TestVectorGraphSearchTruthMatrixMetricContract2037' -count=1`
  - `GOWORK=off go test ./TreeDB/collections ./TreeDB/docs -count=1`
  - `GOWORK=off go test ./TreeDB/docs -count=1`
  - `git diff --check origin/main...HEAD`
- Corruption/edge cases covered:
  - Default/scalar/indexed parity and exact-order counters verified.
  - Eligible prepared path defaults indexed; non-prepared and legacy defaults remain scalar.
  - Prepared source/result fallback counters remain zero on eligible path.
  - Docs lint compatibility validated for benchmark matrix markdown/spec text.
- Concurrency/race coverage (if applicable):
  - Not applicable (no new concurrency behavior introduced).

## Performance

- Benchmarks run (exact commands):
  - `GOMAXPROCS=8 GOWORK=off go test ./TreeDB/collections -run '^$' -bench '^BenchmarkColumnVectorGraphSearchTopologyParity2091' -benchmem -benchtime=1s -count=3`
  - `GOMAXPROCS=8 GOWORK=off go test ./TreeDB/collections -run '^$' -bench '^BenchmarkColumnVectorGraphSearchBatchability1979/(ef_search_128|exact)/score=(scalar|indexed)$' -benchmem -benchtime=1s -count=3`
  - `GOMAXPROCS=8 GOWORK=off go test ./TreeDB/collections -run '^$' -bench '^BenchmarkColumnVectorGraphSearchPromotion2103$' -benchmem -benchtime=1s -count=3`
- Results table (before/after; median-of-5 per G1 in `docs/OPT_SPRINT_NEXT.md`):
  - Latest-head promotion medians continue to show prepared default ~= prepared indexed and faster than prepared scalar/legacy default.
  - Graph-only: prepared default `6872 ns/op` vs prepared scalar `9386 ns/op`, legacy default `9631 ns/op`.
  - Result-ID: prepared default `7664 ns/op` vs prepared scalar `10747 ns/op`, legacy default `9860 ns/op`.
- Regressions (if any) and why acceptable:
  - No functional regressions observed in targeted correctness suites.
  - No performance regression on promoted prepared default path; expected scalar behavior retained on non-eligible routes.

## Rollout / Toggle Plan

- Default setting:
  - `ScoreBatchMode=default` promotes to indexed only for eligible prepared typed-column graph search plans.
- How to disable quickly:
  - Set explicit scalar scoring mode (`ScoreBatchMode=scalar`) in affected search paths.

## Follow-ups

- Continue broader #2035 evidence collection for public-search/larger workload coverage.
- Keep #1981 and #1977 deferred per existing gating.

## Column Graph Native Workstream (#1646, if applicable)

### Copied/Adapted From Old Stack

- Copied:
  - Not applicable.
- Adapted:
  - Not applicable.
- Oracle/comparator only:
  - Not applicable.
- Quarantined/not copied:
  - Not applicable.

### Path Identity

- Native reader:
  - Prepared typed-column graph search path.
- Decoded comparator:
  - Existing scalar/indexed comparator behavior preserved.
- Legacy/native vector index:
  - Legacy graph-row/direct path remains scalar-default.
- Unsupported/fail-closed:
  - Non-eligible prepared conditions and fallback routes remain scalar-default.

### Base And Dependency State

- Base branch:
  - `origin/main` (synced in branch via merge).
- Base commit:
  - `10cca278f` (latest sync point noted during review cycle).
- Base PR/head:
  - Current PR head includes follow-up commits (`f3e10664c`, `c299bdad2`, `d03945bd8`) and merge sync.
- #1621/#1634 assumptions:
  - Not applicable.
- Missing generic column-store primitives:
  - None newly required for this change.
- Parent review fixes propagated:
  - Yes; redundant readiness predicate removed and docs markdown/spec review fixes applied.

### Evidence

- Tests:
  - Focused collections + docs commands listed above passed on latest head.
- Benchmarks:
  - Promotion benchmark rerun on latest head confirms expected default behavior and speedup.
- Status/fallback proof:
  - Prepared eligible rows show indexed batching counters; fallback counters remain zero.
- Performance attribution:
  - Gains attributable to indexed/gathered score batching on eligible prepared path.
- Local regressions found/fixed:
  - Fixed redundant predicate check, markdown heading parsing issue, and duplicated benchmark-matrix wording.

### Test Plan Start

- Milestone tasks targeted:
  - Default-mode promotion for eligible prepared graph search (#2103 scope).
- Tests to add before or with implementation:
  - Added/updated promotion matrix tests for prepared/non-prepared/legacy defaults.
- Existing tests to preserve:
  - #2091 topology parity and #1979/#2037 contracts.
- #1646 test-list changes made before implementation:
  - Not applicable.

### Performance Plan Start

- Relevant benchmarks/metrics for this PR:
  - #2091 topology parity, #1979 batchability, #2103 promotion benchmark rows.
- Baseline/comparator command or reason not applicable:
  - Scalar vs indexed explicit rows and legacy/default comparators included.
- Expected setup/search/materialization boundary:
  - Graph-only and result-ID boundaries explicitly measured.
- Upstream costs explicitly out of scope:
  - Public-search and larger workload validation remains follow-up work.
- Local performance risks to watch:
  - Unintended promotion outside eligible prepared path.

### Test Plan Close

- Additional tests found during implementation/review:
  - None beyond targeted promotion/default and docs-lint coverage.
- Tests added or changed:
  - Promotion default behavior tests and docs updates validated.
- Failing tests fixed:
  - None newly introduced.
- #1646 test-list changes made at close:
  - Not applicable.
- Residual untested gaps, if any:
  - Broader public-search/larger workload evidence still pending under #2035.

### Performance Plan Close

- Benchmark commands run:
  - Commands listed in Performance section.
- Results summary with throughput/latency/allocations:
  - Prepared default aligns with indexed profile; zero allocations/op retained.
- Before/after or baseline comparison:
  - Prepared default improves over scalar and legacy default in latest-head medians.
- Local slow/heavy code found and fixed:
  - No heavy-path change needed; only eligibility predicate simplification.
- Remaining upstream or deferred costs:
  - Broader rollout evidence remains deferred to #2035 follow-up.

### AI Review Loop

- Codex latest-head review:
  - Requested; latest feedback reported no major issues.
- Copilot latest-head review:
  - Requested.
- CodeRabbit latest-head review:
  - Requested; markdown/style review feedback addressed in follow-up commits.
- Review comments/threads resolved or explicitly dismissed:
  - Resolved redundant eligibility check thread and docs wording/markdown review feedback.
- Re-requested after final meaningful push:
  - Yes.

---

## Optimization PR Checklist (TreeDB)

### Scope
- [x] Single, clear objective for this PR (not a bundle)
- [x] Explicit include list (files/symbols touched):
- [x] Explicit exclude list (files/symbols NOT touched):
- [x] No unwanted feature reintroduction (e.g. async slab writer, hard zones, ValueIndex) unless explicitly stated in the PR objective

### Safety / Correctness
- [x] Clear written-vs-durable semantics for any `*Sync` path touched
- [x] No new mmap usage on mutable/truncating files
- [x] All new length fields are capped before allocation (OOM-safe)
- [x] CRC/checksum behavior is fail-closed (clean error, no panic)
- [x] Any concurrency change has a defined state machine and invariants

### Tests
- [x] Added deterministic regression tests for the targeted failure mode
- [x] Tests avoid sleeps where possible (use latches/hooks)
- [x] Added corruption/edge-case tests (truncation, bad headers, invalid lengths) when format/parsing changes
- [ ] Ran locally:
  - [ ] `go test ./... -count=1`
  - [x] Any targeted packages/benchmarks:

### Benchmarks / Measurements
- [x] Added or updated a benchmark relevant to the change
- [x] Reported results in PR description (before/after, command, machine)
- [x] Included “incompressible” (worst-case) results if compression is involved

### Docs
- [x] Updated `docs/OPT_SPRINT_NEXT.md` milestone status (if applicable)
- [x] Documented any new config knobs + defaults
- [x] Called out any format change in PR description (pre-alpha OK)

### Rollout / Toggle Plan (if behavior-affecting)
- [x] Safe defaults (feature off or conservative threshold)
- [x] Clear knobs to disable/revert behavior quickly
- [x] Observability: counters/logs to verify effectiveness