### PR TITLE
Add Mongo YCSB gateway compatibility

### DIFF
--- a/TreeDB/docs/spec/command-wal-support-matrix.json
+++ b/TreeDB/docs/spec/command-wal-support-matrix.json
@@ -36,6 +36,7 @@
     {"surface":"mongo_gateway","entry_point":"insert","command":"CollectionInsertBatchByID","status":"WAL-supported","first_pr":"PR4","tests":["TestMongoCompatibilityMatrix"]},
     {"surface":"mongo_gateway","entry_point":"update","command":"CollectionUpdateBatchByID","status":"WAL-supported","first_pr":"PR5","tests":["TestMongoCompatibilityMatrix"]},
     {"surface":"mongo_gateway","entry_point":"delete","command":"CollectionDeleteBatchByID","status":"WAL-supported","first_pr":"PR4","tests":["TestMongoCompatibilityMatrix"]},
+    {"surface":"mongo_gateway","entry_point":"listDatabases","command":"metadata read","status":"WAL-supported","first_pr":"PR2111","tests":["TestMongoCompatibilityMatrix"]},
     {"surface":"mongo_gateway","entry_point":"createIndexes (auto-create collection)","command":"CatalogCreateCollection","status":"WAL-supported","first_pr":"PR6","tests":["TestCollectionCommandWALCreateCollectionPublishesAppliedLSN"]},
     {"surface":"mongo_gateway","entry_point":"createIndexes (existing collection)","command":"future catalog index create","status":"WAL-rejected","public_error":"MongoCommandError(BadValue)","first_pr":"PR6","tests":["TestCollectionCommandWALRejectsCatalogIndexMutations"]},
     {"surface":"mongo_gateway","entry_point":"dropIndexes","command":"future catalog index drop","status":"WAL-rejected","public_error":"MongoCommandError(BadValue)","first_pr":"PR6","tests":["TestCollectionCommandWALRejectsCatalogIndexMutations"]},

--- a/TreeDB/mongo_gateway/COMPATIBILITY.md
+++ b/TreeDB/mongo_gateway/COMPATIBILITY.md
@@ -57,6 +57,7 @@ block drifts from the executable matrix rows.
 | crud | updateOne $set by _id | supported subset |
 | crud | delete by _id | supported subset |
 | metadata | listCollections | supported subset |
+| metadata | listDatabases | supported subset |
 | metadata | create collection | supported subset |
 | session | logical session handshake and endSessions | supported subset |
 | metadata | createIndexes, listIndexes, and dropIndexes | supported subset |

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -465,12 +466,13 @@ func (s *Server) updateResponse(command wire.Document, sequences []wire.Document
 }
 
 type mongoUpdateItem struct {
-	index         int
-	key           []byte
-	updateDoc     wire.Document
-	setFields     map[string]struct{}
-	bsonSetFields []collections.BSONSetField
-	setFieldsOK   bool
+	index           int
+	key             []byte
+	updateDoc       wire.Document
+	setFields       map[string]struct{}
+	bsonSetFields   []collections.BSONSetField
+	setFieldsOK     bool
+	bsonSetFieldsOK bool
 }
 
 type mongoUpdateParseError struct {
@@ -511,7 +513,19 @@ func parseMongoUpdateItem(index int, update wire.Document) (mongoUpdateItem, err
 		return mongoUpdateItem{}, mongoUpdateParseError{code: commandCodeFailedToParse, codeName: "FailedToParse", message: fmt.Sprintf("updates[%d]: %v", index, err)}
 	}
 	setFields, bsonSetFields, setFieldsOK := mongoSetUpdateFields(updateDoc)
-	return mongoUpdateItem{index: index, key: key, updateDoc: updateDoc, setFields: setFields, bsonSetFields: bsonSetFields, setFieldsOK: setFieldsOK}, nil
+	bsonSetFields, bsonSetFieldNames, bsonSetFieldsOK := mongoBSONSetUpdateFields(updateDoc)
+	if !setFieldsOK && bsonSetFieldsOK {
+		setFields = bsonSetFieldNames
+	}
+	return mongoUpdateItem{
+		index:           index,
+		key:             key,
+		updateDoc:       updateDoc,
+		setFields:       setFields,
+		bsonSetFields:   bsonSetFields,
+		setFieldsOK:     setFieldsOK,
+		bsonSetFieldsOK: bsonSetFieldsOK,
+	}, nil
 }
 
 func mongoUpdateParseCommandError(err error) (wire.Document, error) {
@@ -1113,7 +1127,7 @@ func mongoUpdateItemsCanUseBSONSet(col *collections.Collection, updates []mongoU
 		return false
 	}
 	for _, update := range updates {
-		if !update.setFieldsOK {
+		if !update.bsonSetFieldsOK {
 			return false
 		}
 	}
@@ -1121,7 +1135,7 @@ func mongoUpdateItemsCanUseBSONSet(col *collections.Collection, updates []mongoU
 }
 
 func mongoUpdateCanUseBSONSet(col *collections.Collection, update mongoUpdateItem) bool {
-	return col != nil && normalizedMongoUpdateDocumentFormat(col) == collections.DocumentFormatBSON && update.setFieldsOK
+	return col != nil && normalizedMongoUpdateDocumentFormat(col) == collections.DocumentFormatBSON && update.bsonSetFieldsOK
 }
 
 func normalizedMongoUpdateDocumentFormat(col *collections.Collection) collections.DocumentFormat {
@@ -1136,14 +1150,22 @@ func normalizedMongoUpdateDocumentFormat(col *collections.Collection) collection
 }
 
 func mongoUpdateCanUseBatchMeta(meta collections.CollectionMeta, update mongoUpdateItem) bool {
-	if !update.setFieldsOK {
+	format := meta.Options.DocumentFormat
+	if format == collections.DocumentFormatDefault {
+		format = collections.DocumentFormatJSON
+	}
+	if format == collections.DocumentFormatBSON {
+		if !update.bsonSetFieldsOK {
+			return false
+		}
+	} else if !update.setFieldsOK {
 		return false
 	}
 	return !mongoUpdateSetFieldsTouchSecondaryUniqueIndexMeta(meta, update)
 }
 
 func mongoUpdateSetFieldsTouchSecondaryUniqueIndexMeta(meta collections.CollectionMeta, update mongoUpdateItem) bool {
-	if !update.setFieldsOK {
+	if update.setFields == nil {
 		return true
 	}
 	for _, idx := range meta.Indexes {
@@ -1184,6 +1206,35 @@ func mongoSetUpdateFields(updateDoc wire.Document) (map[string]struct{}, []colle
 		})
 	}
 	return out, fields, true
+}
+
+func mongoBSONSetUpdateFields(updateDoc wire.Document) ([]collections.BSONSetField, map[string]struct{}, bool) {
+	updateElements, err := bson.Raw(updateDoc).Elements()
+	if err != nil || len(updateElements) != 1 {
+		return nil, nil, false
+	}
+	operator, err := updateElements[0].KeyErr()
+	if err != nil || operator != "$set" {
+		return nil, nil, false
+	}
+	setDoc, ok := updateElements[0].Value().DocumentOK()
+	if !ok {
+		return nil, nil, false
+	}
+	sets, order, err := parseBSONSetDocument(setDoc)
+	if err != nil {
+		return nil, nil, false
+	}
+	fields := make([]collections.BSONSetField, 0, len(order))
+	fieldNames := make(map[string]struct{}, len(order))
+	for _, field := range order {
+		fieldNames[field] = struct{}{}
+		fields = append(fields, collections.BSONSetField{
+			Key:   field,
+			Value: sets[field],
+		})
+	}
+	return fields, fieldNames, true
 }
 
 func (s *Server) deleteResponse(command wire.Document, sequences []wire.DocumentSequence) (wire.Document, error) {
@@ -1289,6 +1340,56 @@ func (s *Server) listCollectionsResponse(command wire.Document) (wire.Document, 
 		firstBatch = append(firstBatch, mongoCollectionDocument(collectionName, nameOnly))
 	}
 	return marshalCursorResponse(db, "$cmd.listCollections", firstBatch)
+}
+
+func (s *Server) listDatabasesResponse(command wire.Document) (wire.Document, error) {
+	if s.Collections == nil {
+		return commandError(commandCodeBadValue, "BadValue", "Mongo gateway collection manager is not configured")
+	}
+	filter, err := commandOptionalDocument(command, "filter")
+	if err != nil {
+		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
+	}
+	nameFilter, err := databaseNameFilter(filter)
+	if err != nil {
+		return commandError(commandCodeBadValue, "BadValue", err.Error())
+	}
+
+	metas, err := s.Collections.ListCollections()
+	if err != nil {
+		return commandError(commandCodeBadValue, "BadValue", err.Error())
+	}
+	names := make(map[string]struct{})
+	for _, meta := range metas {
+		db, _, ok := strings.Cut(meta.Name, ".")
+		if !ok || db == "" {
+			continue
+		}
+		if nameFilter != "" && db != nameFilter {
+			continue
+		}
+		names[db] = struct{}{}
+	}
+	ordered := make([]string, 0, len(names))
+	for name := range names {
+		ordered = append(ordered, name)
+	}
+	sort.Strings(ordered)
+
+	databases := make(bson.A, 0, len(ordered))
+	for _, name := range ordered {
+		databases = append(databases, bson.D{
+			{Key: "name", Value: name},
+			{Key: "sizeOnDisk", Value: int64(0)},
+			{Key: "empty", Value: false},
+		})
+	}
+	return marshalDocument(bson.D{
+		{Key: "ok", Value: 1.0},
+		{Key: "databases", Value: databases},
+		{Key: "totalSize", Value: int64(0)},
+		{Key: "totalSizeMb", Value: int64(0)},
+	})
 }
 
 func (s *Server) createCollectionResponse(command wire.Document) (wire.Document, error) {
@@ -2551,6 +2652,37 @@ func collectionNameFilter(filter wire.Document) (string, error) {
 	return name, nil
 }
 
+func databaseNameFilter(filter wire.Document) (string, error) {
+	if filter == nil {
+		return "", nil
+	}
+	elements, err := bson.Raw(filter).Elements()
+	if err != nil {
+		return "", err
+	}
+	if len(elements) == 0 {
+		return "", nil
+	}
+	if len(elements) != 1 {
+		return "", errors.New("Mongo gateway listDatabases filter currently supports name equality only")
+	}
+	key, err := elements[0].KeyErr()
+	if err != nil {
+		return "", err
+	}
+	if key != "name" {
+		return "", errors.New("Mongo gateway listDatabases filter currently supports name equality only")
+	}
+	name, ok := elements[0].Value().StringValueOK()
+	if !ok {
+		return "", errors.New("Mongo gateway listDatabases name filter must be a string")
+	}
+	if err := validateMongoDatabaseName(name); err != nil {
+		return "", err
+	}
+	return name, nil
+}
+
 func commandDocumentArray(doc wire.Document, key string) ([]wire.Document, error) {
 	value := bson.Raw(doc).Lookup(key)
 	if value.IsZero() {
@@ -3328,6 +3460,19 @@ func dropIndexNames(command wire.Document) ([]string, bool, error) {
 }
 
 func parseSetDocument(doc bson.Raw) (map[string]bson.RawValue, []string, error) {
+	return parseSetDocumentWithValueValidator(doc, validateSupportedValue)
+}
+
+func parseBSONSetDocument(doc bson.Raw) (map[string]bson.RawValue, []string, error) {
+	return parseSetDocumentWithValueValidator(doc, func(path string, value bson.RawValue) error {
+		if err := value.Validate(); err != nil {
+			return fmt.Errorf("Mongo document field %q is not a valid BSON value: %w", path, err)
+		}
+		return nil
+	})
+}
+
+func parseSetDocumentWithValueValidator(doc bson.Raw, validateValue func(string, bson.RawValue) error) (map[string]bson.RawValue, []string, error) {
 	elements, err := doc.Elements()
 	if err != nil {
 		return nil, nil, err
@@ -3344,7 +3489,7 @@ func parseSetDocument(doc bson.Raw) (map[string]bson.RawValue, []string, error) 
 			return nil, nil, err
 		}
 		value := elem.Value()
-		if err := validateSupportedValue(key, value); err != nil {
+		if err := validateValue(key, value); err != nil {
 			return nil, nil, err
 		}
 		if _, ok := seen[key]; !ok {

--- a/TreeDB/mongo_gateway/compatibility_matrix_test.go
+++ b/TreeDB/mongo_gateway/compatibility_matrix_test.go
@@ -292,6 +292,38 @@ func mongoCompatibilityMatrixRows() []mongoCompatibilityMatrixRow {
 		},
 		{
 			category: "metadata",
+			feature:  "listDatabases",
+			status:   "supported subset",
+			probe: func(t *testing.T, server *Server) {
+				resp := serveCommand(t, server, 130, bson.D{
+					{Key: "listDatabases", Value: int32(1)},
+					{Key: "nameOnly", Value: true},
+					{Key: "filter", Value: bson.D{{Key: "name", Value: "app"}}},
+					{Key: "$db", Value: "admin"},
+				})
+				assertOK(t, resp)
+				databases, ok := resp.Lookup("databases").ArrayOK()
+				if !ok {
+					t.Fatalf("databases missing or non-array in %s", resp)
+				}
+				values, err := databases.Values()
+				if err != nil {
+					t.Fatalf("databases values: %v", err)
+				}
+				if len(values) != 1 {
+					t.Fatalf("databases len=%d want 1", len(values))
+				}
+				doc, ok := values[0].DocumentOK()
+				if !ok {
+					t.Fatalf("databases[0] is not a document")
+				}
+				if got, ok := doc.Lookup("name").StringValueOK(); !ok || got != "app" {
+					t.Fatalf("database name=%q ok=%v want app", got, ok)
+				}
+			},
+		},
+		{
+			category: "metadata",
 			feature:  "create collection",
 			status:   "supported subset",
 			probe: func(t *testing.T, server *Server) {

--- a/TreeDB/mongo_gateway/server_core.go
+++ b/TreeDB/mongo_gateway/server_core.go
@@ -464,7 +464,7 @@ func bufferedMessageCanRetainRequestBody(h wire.Header, body []byte) bool {
 		return false
 	}
 	switch name {
-	case "buildInfo", "connectionStatus", "endSessions", "find", "getMore", "hello", "hostInfo", "isMaster", "ismaster", "killCursors", "listCollections", "listIndexes", "ping":
+	case "buildInfo", "connectionStatus", "endSessions", "find", "getMore", "hello", "hostInfo", "isMaster", "ismaster", "killCursors", "listCollections", "listDatabases", "listIndexes", "ping":
 		return true
 	default:
 		return false
@@ -663,6 +663,8 @@ func (s *Server) commandResponse(name string, command wire.Document, sequences [
 		return s.deleteResponse(command, sequences)
 	case "listCollections":
 		return s.listCollectionsResponse(command)
+	case "listDatabases":
+		return s.listDatabasesResponse(command)
 	case "createIndexes":
 		return s.createIndexesResponse(command)
 	case "listIndexes":
@@ -676,7 +678,7 @@ func (s *Server) commandResponse(name string, command wire.Document, sequences [
 
 func commandRejectsTransactionMarkers(name string) bool {
 	switch name {
-	case "create", "createIndexes", "delete", "dropIndexes", "find", "getMore", "insert", "killCursors", "listCollections", "listIndexes", "update":
+	case "create", "createIndexes", "delete", "dropIndexes", "find", "getMore", "insert", "killCursors", "listCollections", "listDatabases", "listIndexes", "update":
 		return true
 	default:
 		return false

--- a/TreeDB/mongo_gateway/server_driver_test.go
+++ b/TreeDB/mongo_gateway/server_driver_test.go
@@ -75,6 +75,13 @@ func TestServerOfficialGoDriverBasicCRUD(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("driver insert one: %v", err)
 	}
+	names, err := client.ListDatabaseNames(opCtx, bson.D{{Key: "name", Value: "app"}})
+	if err != nil {
+		t.Fatalf("driver list database names: %v", err)
+	}
+	if len(names) != 1 || names[0] != "app" {
+		t.Fatalf("driver list database names=%v want [app]", names)
+	}
 
 	var got bson.M
 	if err := coll.FindOne(opCtx, bson.D{{Key: "_id", Value: id}}).Decode(&got); err != nil {

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -789,6 +789,54 @@ func TestPrepareInsertDocumentBSONAllowsNativeUnindexedTypes(t *testing.T) {
 	}
 }
 
+func TestServerUpdateBSONSetAllowsNativeBinaryValues(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	server := NewServer()
+	server.Collections = collections.NewCollectionManager(db)
+	server.DefaultCollectionOptions = collections.CollectionOptions{DocumentFormat: collections.DocumentFormatBSON}
+
+	assertOK(t, serveCommand(t, server, 22540, bson.D{
+		{Key: "insert", Value: "users"},
+		{Key: "documents", Value: bson.A{bson.D{
+			{Key: "_id", Value: "binary-set"},
+			{Key: "payload", Value: bson.Binary{Subtype: 0x00, Data: []byte{1}}},
+		}}},
+		{Key: "$db", Value: "app"},
+	}))
+	updateResponse := serveCommand(t, server, 22541, bson.D{
+		{Key: "update", Value: "users"},
+		{Key: "updates", Value: bson.A{bson.D{
+			{Key: "q", Value: bson.D{{Key: "_id", Value: "binary-set"}}},
+			{Key: "u", Value: bson.D{{Key: "$set", Value: bson.D{
+				{Key: "payload", Value: bson.Binary{Subtype: 0x00, Data: []byte{2, 3, 4}}},
+			}}}},
+		}}},
+		{Key: "$db", Value: "app"},
+	})
+	assertOK(t, updateResponse)
+	assertInt32(t, updateResponse, "n", 1)
+	assertInt32(t, updateResponse, "nModified", 1)
+
+	findResponse := serveCommand(t, server, 22542, bson.D{
+		{Key: "find", Value: "users"},
+		{Key: "filter", Value: bson.D{{Key: "_id", Value: "binary-set"}}},
+		{Key: "$db", Value: "app"},
+	})
+	batch := cursorFirstBatch(t, findResponse)
+	if len(batch) != 1 {
+		t.Fatalf("batch len=%d want 1", len(batch))
+	}
+	subtype, payload := batch[0].Lookup("payload").Binary()
+	if subtype != 0x00 || !bytes.Equal(payload, []byte{2, 3, 4}) {
+		t.Fatalf("payload subtype/data=%#x/%v want 0/[2 3 4]", subtype, payload)
+	}
+}
+
 func TestServerUpdateTemplateV1RefreshesMaterializerBetweenStatements(t *testing.T) {
 	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {


### PR DESCRIPTION
## Objective

Enable exact `go-ycsb mongodb` load/run initialization against TreeDB's Mongo gateway for #2107, then close the second compatibility gap the exact run exposed: BSON binary values in YCSB `$set` updates.

Closes #2107. Parent tracker: #2106.

## Context

The Go YCSB Mongo driver calls `ListDatabaseNames()` after `Ping()` and reports any failure as `auth failed`. TreeDB's gateway did not implement `listDatabases`, so exact Mongo YCSB could not start. Once that was fixed, run-phase updates still failed because YCSB values are `[]byte`, encoded by the Mongo driver as BSON binary, and the BSON `$set` fast path still used JSON/template value validation.

## Non-goals

- No insert coalescer or throughput optimization in this PR.
- No broad MongoDB compatibility expansion beyond the commands/types needed by exact YCSB.
- No workload or go-ycsb client changes.

## Design

- Add a minimal `listDatabases` command that derives database names from `CollectionManager.ListCollections()` and returns Mongo-driver-compatible `databases[].name`, `sizeOnDisk`, `empty`, and `totalSize` fields.
- Include `listDatabases` in the normal command dispatch, buffered request handling, and transaction/retryable-write rejection path.
- Split `$set` parsing into JSON/template-safe validation and BSON-native validation so BSON collections can update native binary fields through `UpdateBSONSet` while JSON/template paths still reject unsupported values at the storage-format boundary.
- Keep empty databases out of the result because TreeDB currently has collection metadata, not a separate database catalog.

## Scope

Includes:

- `TreeDB/mongo_gateway/commands.go`
- `TreeDB/mongo_gateway/server_core.go`
- `TreeDB/mongo_gateway/compatibility_matrix_test.go`
- `TreeDB/mongo_gateway/server_driver_test.go`
- `TreeDB/mongo_gateway/server_test.go`
- `TreeDB/mongo_gateway/COMPATIBILITY.md`

Excludes:

- `cmd/mongo_gateway_bench`
- collection mutation architecture
- nativewire insert combiner behavior

## Correctness

Tests run:

```sh
GOWORK=off go test ./TreeDB/mongo_gateway -run 'TestServerUpdateBSONSetAllowsNativeBinaryValues|TestServerOfficialGoDriverBasicCRUD|TestMongoCompatibilityMatrix' -count=1
GOWORK=off go test ./TreeDB/mongo_gateway -run TestMongoCompatibilityMatrixDocumentationUpToDate -update-mongo-compatibility-docs -count=1
GOWORK=off go test ./TreeDB/mongo_gateway -count=1
git diff --check
```

Covered:

- direct `listDatabases` response through the compatibility matrix;
- official Go driver `ListDatabaseNames()` against the gateway;
- BSON `$set` update with binary values;
- generated compatibility docs stay in sync.

## Performance

This PR is compatibility-gating rather than an optimization PR. The exact Mongo YCSB baseline now runs without client patches or workload changes.

Commands:

```sh
make build-mongo-gateway
./bin/treedb-mongo-gateway -dir "$DB_DIR" -profile fast -addr 127.0.0.1:27018 -document-format bson
/home/mikers/dev/pingcap/go-ycsb/bin/go-ycsb load mongodb \
  -p mongodb.url='mongodb://127.0.0.1:27018/ycsb?directConnection=true&w=1' \
  -p recordcount=100000 \
  -p operationcount=10000 \
  -p threadcount=16
/home/mikers/dev/pingcap/go-ycsb/bin/go-ycsb run mongodb \
  -p mongodb.url='mongodb://127.0.0.1:27018/ycsb?directConnection=true&w=1' \
  -p recordcount=100000 \
  -p operationcount=10000 \
  -p threadcount=16
```

Artifact: `/tmp/treedb_mongo_ycsb_2107_full_20260531_182848`

| Phase | Count | OPS | Avg | p95 | p99 | Max | Errors |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| load INSERT | 100000 | 69436.3 | 211us | 483us | 798us | 11263us | 0 |
| run TOTAL | 10000 | 24680.8 | 637us | 495us | 938us | 253311us | 0 |
| run READ | 9514 | 23458.9 | 578us | 495us | 917us | 253311us | 0 |
| run UPDATE | 486 | 3212.3 | 1804us | 561us | 1370us | 253183us | 0 |

Regression assessment: no performance claim is made here beyond unlocking the exact benchmark. The run-phase max stall remains a measured bottleneck for #2109/#2110.

## Rollout / Toggle Plan

Default behavior: enabled as part of the Mongo compatibility subset.

Disable path: revert this PR if `listDatabases` compatibility or BSON binary `$set` support needs to be backed out.

## Follow-ups

- #2108: durable Mongo gateway YCSB attribution lane.
- #2109: Mongo gateway insert coalescer for indexed batch-1 load.
- #2110: re-profile remaining bottlenecks after coalescing.

## AI Review Loop

- Codex latest-head review: not requested yet.
- Copilot latest-head review: not requested yet.
- CodeRabbit latest-head review: not requested yet.
- Reviews will be requested only after the PR head is mature and latest-head CI is running or green, per #2106.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `listDatabases` command to query available databases
  * Enhanced update operations to better handle binary data types

* **Documentation**
  * Updated compatibility matrix to reflect new command support

* **Tests**
  * Added tests validating new functionality with official MongoDB drivers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->