### PR TITLE
Coalesce Mongo single-document inserts

### DIFF
--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -89,21 +89,29 @@ func (s *Server) insertResponse(command wire.Document, sequences []wire.Document
 		}
 	}
 	if format == collections.DocumentFormatBSON {
-		_, err = col.InsertBatchValidatedBSON(ids, stored)
+		if len(ids) == 1 {
+			err = s.runMongoInsertCoalesced(name, col, ids[0], stored[0])
+		} else {
+			_, err = col.InsertBatchValidatedBSON(ids, stored)
+		}
 	} else {
 		_, err = col.InsertBatch(ids, stored)
 	}
 	if err != nil {
-		code, codeName := commandCodeBadValue, "BadValue"
-		if collections.IsDuplicateKeyError(err) {
-			code, codeName = commandCodeDuplicateKey, "DuplicateKey"
-		}
-		return commandError(code, codeName, err.Error())
+		return mongoInsertCommandError(err)
 	}
 	return marshalDocument(bson.D{
 		{Key: "ok", Value: 1.0},
 		{Key: "n", Value: int32(len(documents))},
 	})
+}
+
+func mongoInsertCommandError(err error) (wire.Document, error) {
+	code, codeName := commandCodeBadValue, "BadValue"
+	if collections.IsDuplicateKeyError(err) {
+		code, codeName = commandCodeDuplicateKey, "DuplicateKey"
+	}
+	return commandError(code, codeName, err.Error())
 }
 
 func prepareInsertDocuments(documents []wire.Document, format collections.DocumentFormat) ([][]byte, [][]byte, error) {
@@ -118,6 +126,392 @@ func prepareInsertDocuments(documents []wire.Document, format collections.Docume
 		stored[i] = encoded
 	}
 	return ids, stored, nil
+}
+
+type mongoInsertCoalescer struct {
+	maxDelay  time.Duration
+	maxBatch  int
+	idleTTL   time.Duration
+	requests  chan mongoInsertCoalescerRequest
+	stoppedCh chan struct{}
+	done      chan struct{}
+	server    *Server
+	name      string
+
+	mu        sync.RWMutex
+	stopped   bool
+	enqueueMu sync.Mutex
+}
+
+type mongoInsertCoalescerRequest struct {
+	col    *collections.Collection
+	id     []byte
+	stored []byte
+	done   chan mongoInsertCoalescerResult
+}
+
+type mongoInsertCoalescerResult struct {
+	err error
+}
+
+func (s *Server) runMongoInsertCoalesced(name string, col *collections.Collection, id, stored []byte) error {
+	if col == nil {
+		return runMongoInsertOne(col, id, stored)
+	}
+	coalescer := s.mongoInsertCoalescer(name)
+	if coalescer == nil {
+		return runMongoInsertOne(col, id, stored)
+	}
+	done := make(chan mongoInsertCoalescerResult, 1)
+	// The handler waits for completion before returning, so request-body-backed
+	// BSON remains live while the worker builds and applies the coalesced batch.
+	if !coalescer.enqueue(mongoInsertCoalescerRequest{col: col, id: id, stored: stored, done: done}) {
+		return runMongoInsertOne(col, id, stored)
+	}
+	return coalescer.waitForInsertResult(done).err
+}
+
+func runMongoInsertOne(col *collections.Collection, id, stored []byte) error {
+	if col == nil {
+		return errCollectionMissingForInsert()
+	}
+	_, err := col.InsertBatchValidatedBSON([][]byte{id}, [][]byte{stored})
+	return err
+}
+
+func errCollectionMissingForInsert() error {
+	return errors.New("Mongo gateway insert collection handle is not configured")
+}
+
+func (c *mongoInsertCoalescer) waitForInsertResult(done chan mongoInsertCoalescerResult) mongoInsertCoalescerResult {
+	select {
+	case result := <-done:
+		return result
+	default:
+	}
+	if c == nil || c.done == nil {
+		return <-done
+	}
+	select {
+	case result := <-done:
+		return result
+	case <-c.done:
+		select {
+		case result := <-done:
+			return result
+		default:
+			return mongoInsertCoalescerResult{err: errors.New("mongo gateway insert coalescer stopped before completing request")}
+		}
+	}
+}
+
+func (s *Server) mongoInsertCoalescer(name string) *mongoInsertCoalescer {
+	if s == nil || s.InsertCoalescingMaxBatch <= 1 || s.InsertCoalescingMaxDelay < 0 {
+		return nil
+	}
+	maxBatch := clampInsertCoalescingMaxBatch(s.InsertCoalescingMaxBatch)
+	if maxBatch <= 1 {
+		return nil
+	}
+	maxDelay := s.InsertCoalescingMaxDelay
+	idleTTL := s.InsertCoalescingIdleTTL
+	if idleTTL == 0 {
+		idleTTL = defaultInsertCoalescingIdleTTL
+	}
+	s.insertMu.Lock()
+	defer s.insertMu.Unlock()
+	if s.closed.Load() {
+		return nil
+	}
+	if s.insertCoalescers == nil {
+		s.insertCoalescers = make(map[string]*mongoInsertCoalescer)
+	}
+	if coalescer := s.insertCoalescers[name]; coalescer != nil {
+		return coalescer
+	}
+	coalescer := &mongoInsertCoalescer{
+		maxDelay:  maxDelay,
+		maxBatch:  maxBatch,
+		idleTTL:   idleTTL,
+		requests:  make(chan mongoInsertCoalescerRequest, maxBatch*4),
+		stoppedCh: make(chan struct{}),
+		done:      make(chan struct{}),
+		server:    s,
+		name:      name,
+	}
+	s.insertCoalescers[name] = coalescer
+	go coalescer.run()
+	return coalescer
+}
+
+func clampInsertCoalescingMaxBatch(maxBatch int) int {
+	if maxBatch > maxInsertCoalescingBatch {
+		return maxInsertCoalescingBatch
+	}
+	return maxBatch
+}
+
+func (c *mongoInsertCoalescer) enqueue(req mongoInsertCoalescerRequest) bool {
+	if c == nil {
+		return false
+	}
+	for {
+		c.enqueueMu.Lock()
+		c.mu.RLock()
+		if c.stopped || c.requests == nil {
+			c.mu.RUnlock()
+			c.enqueueMu.Unlock()
+			return false
+		}
+		requests := c.requests
+		stoppedCh := c.stoppedCh
+		select {
+		case requests <- req:
+			c.mu.RUnlock()
+			c.enqueueMu.Unlock()
+			return true
+		default:
+		}
+		c.mu.RUnlock()
+		c.enqueueMu.Unlock()
+
+		select {
+		case <-stoppedCh:
+			return false
+		case <-time.After(time.Millisecond):
+		}
+	}
+}
+
+func (c *mongoInsertCoalescer) stop() {
+	if c == nil {
+		return
+	}
+	_ = c.closeRequests()
+	if c.done != nil {
+		<-c.done
+	}
+}
+
+func (c *mongoInsertCoalescer) closeRequests() bool {
+	c.enqueueMu.Lock()
+	defer c.enqueueMu.Unlock()
+	c.mu.Lock()
+	if c.stopped {
+		c.mu.Unlock()
+		return false
+	}
+	if c.stoppedCh == nil {
+		c.stoppedCh = make(chan struct{})
+	}
+	c.stopped = true
+	close(c.stoppedCh)
+	close(c.requests)
+	c.mu.Unlock()
+	return true
+}
+
+func (c *mongoInsertCoalescer) retireIdle() bool {
+	if c == nil {
+		return false
+	}
+	stopped := false
+	if c.server != nil {
+		c.server.insertMu.Lock()
+		if c.server.insertCoalescers != nil && c.server.insertCoalescers[c.name] == c {
+			stopped = c.closeRequests()
+			delete(c.server.insertCoalescers, c.name)
+		}
+		c.server.insertMu.Unlock()
+	} else {
+		stopped = c.closeRequests()
+	}
+	if !stopped {
+		if c.isStopped() {
+			c.drainRequestsDirect()
+			return true
+		}
+		return false
+	}
+	c.drainRequestsDirect()
+	return true
+}
+
+func (c *mongoInsertCoalescer) isStopped() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.stopped
+}
+
+func (c *mongoInsertCoalescer) markStopped() {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	c.stopped = true
+	c.mu.Unlock()
+}
+
+func (c *mongoInsertCoalescer) drainRequestsDirect() {
+	for req := range c.requests {
+		req.done <- mongoInsertCoalescerResult{err: runMongoInsertOne(req.col, req.id, req.stored)}
+	}
+}
+
+func (c *mongoInsertCoalescer) run() {
+	defer func() {
+		c.markStopped()
+		if c.done != nil {
+			close(c.done)
+		}
+	}()
+	var idle <-chan time.Time
+	var timer *time.Timer
+	if c.idleTTL > 0 {
+		timer = time.NewTimer(c.idleTTL)
+		idle = timer.C
+		defer timer.Stop()
+	}
+	resetIdle := func() {
+		if timer == nil {
+			return
+		}
+		if !timer.Stop() {
+			select {
+			case <-timer.C:
+			default:
+			}
+		}
+		timer.Reset(c.idleTTL)
+	}
+	for {
+		select {
+		case first, ok := <-c.requests:
+			if !ok {
+				return
+			}
+			c.runBatchStartingWith(first)
+			resetIdle()
+		case <-idle:
+			if c.retireIdle() {
+				return
+			}
+			resetIdle()
+		case <-c.stoppedCh:
+			c.drainRequestsDirect()
+			return
+		}
+	}
+}
+
+func (c *mongoInsertCoalescer) runBatchStartingWith(first mongoInsertCoalescerRequest) {
+	batch := []mongoInsertCoalescerRequest{first}
+	if c.maxDelay > 0 {
+		timer := time.NewTimer(c.maxDelay)
+	collect:
+		for len(batch) < c.maxBatch {
+			select {
+			case req, ok := <-c.requests:
+				if !ok {
+					break collect
+				}
+				batch = append(batch, req)
+			case <-timer.C:
+				break collect
+			case <-c.stoppedCh:
+				break collect
+			}
+		}
+		if !timer.Stop() {
+			select {
+			case <-timer.C:
+			default:
+			}
+		}
+	}
+	for len(batch) < c.maxBatch {
+		select {
+		case req, ok := <-c.requests:
+			if !ok {
+				goto drained
+			}
+			batch = append(batch, req)
+		case <-c.stoppedCh:
+			goto drained
+		default:
+			goto drained
+		}
+	}
+drained:
+	c.runBatch(batch)
+}
+
+func (c *mongoInsertCoalescer) runBatch(batch []mongoInsertCoalescerRequest) {
+	if len(batch) == 0 {
+		return
+	}
+	if len(batch) == 1 ||
+		mongoInsertCoalescerHasDuplicateKeys(batch) ||
+		!mongoInsertCoalescerUsesSingleCollection(batch) {
+		runMongoInsertCoalescerSequential(batch)
+		return
+	}
+	ids := make([][]byte, len(batch))
+	stored := make([][]byte, len(batch))
+	for i, req := range batch {
+		ids[i] = req.id
+		stored[i] = req.stored
+	}
+	_, err := batch[0].col.InsertBatchValidatedBSON(ids, stored)
+	if err != nil {
+		if collections.IsDuplicateKeyError(err) && !errors.Is(err, collections.ErrCommitAmbiguous) {
+			runMongoInsertCoalescerSequential(batch)
+			return
+		}
+		completeMongoInsertCoalescerBatch(batch, mongoInsertCoalescerResult{err: err})
+		return
+	}
+	completeMongoInsertCoalescerBatch(batch, mongoInsertCoalescerResult{})
+}
+
+func completeMongoInsertCoalescerBatch(batch []mongoInsertCoalescerRequest, result mongoInsertCoalescerResult) {
+	for _, req := range batch {
+		req.done <- result
+	}
+}
+
+func mongoInsertCoalescerHasDuplicateKeys(batch []mongoInsertCoalescerRequest) bool {
+	seen := make(map[string]struct{}, len(batch))
+	for _, req := range batch {
+		key := string(req.id)
+		if _, ok := seen[key]; ok {
+			return true
+		}
+		seen[key] = struct{}{}
+	}
+	return false
+}
+
+func mongoInsertCoalescerUsesSingleCollection(batch []mongoInsertCoalescerRequest) bool {
+	if len(batch) == 0 {
+		return true
+	}
+	col := batch[0].col
+	if col == nil {
+		return false
+	}
+	for _, req := range batch[1:] {
+		if !col.SameCachedCatalog(req.col) {
+			return false
+		}
+	}
+	return true
+}
+
+func runMongoInsertCoalescerSequential(batch []mongoInsertCoalescerRequest) {
+	for _, req := range batch {
+		req.done <- mongoInsertCoalescerResult{err: runMongoInsertOne(req.col, req.id, req.stored)}
+	}
 }
 
 type rawCursorDocumentsResponse struct {

--- a/TreeDB/mongo_gateway/server.go
+++ b/TreeDB/mongo_gateway/server.go
@@ -39,6 +39,10 @@ type cliConfig struct {
 	updateCoalescingBatch    int
 	updateCoalescingBatchSet bool
 	updateCoalescingIdleTTL  time.Duration
+	insertCoalescingDelay    time.Duration
+	insertCoalescingBatch    int
+	insertCoalescingBatchSet bool
+	insertCoalescingIdleTTL  time.Duration
 }
 
 func main() {
@@ -105,6 +109,8 @@ func parseFlags(args []string, stderr io.Writer) (cliConfig, error) {
 		indexRootStorage:        rootStorageFlagValue(collections.RootStorageDefault),
 		updateCoalescingBatch:   256,
 		updateCoalescingIdleTTL: 30 * time.Second,
+		insertCoalescingBatch:   256,
+		insertCoalescingIdleTTL: 30 * time.Second,
 	}
 	fs := flag.NewFlagSet("treedb-mongo-gateway", flag.ContinueOnError)
 	fs.SetOutput(flagSetOutput(args, stderr))
@@ -123,12 +129,18 @@ func parseFlags(args []string, stderr io.Writer) (cliConfig, error) {
 	fs.DurationVar(&cfg.updateCoalescingDelay, "update-coalescing-delay", cfg.updateCoalescingDelay, "maximum delay for same-collection update coalescing; 0 coalesces only queued work, negative disables")
 	fs.IntVar(&cfg.updateCoalescingBatch, "update-coalescing-batch", cfg.updateCoalescingBatch, "maximum same-collection updates in one coalesced batch")
 	fs.DurationVar(&cfg.updateCoalescingIdleTTL, "update-coalescing-idle-ttl", cfg.updateCoalescingIdleTTL, "idle TTL for update coalescers; 0 uses gateway default, negative disables idle removal")
+	fs.DurationVar(&cfg.insertCoalescingDelay, "insert-coalescing-delay", cfg.insertCoalescingDelay, "maximum delay for same-collection single-document BSON insert coalescing; 0 coalesces only queued work, negative disables")
+	fs.IntVar(&cfg.insertCoalescingBatch, "insert-coalescing-batch", cfg.insertCoalescingBatch, "maximum same-collection single-document BSON inserts in one coalesced batch")
+	fs.DurationVar(&cfg.insertCoalescingIdleTTL, "insert-coalescing-idle-ttl", cfg.insertCoalescingIdleTTL, "idle TTL for insert coalescers; 0 uses gateway default, negative disables idle removal")
 	if err := fs.Parse(args); err != nil {
 		return cfg, err
 	}
 	fs.Visit(func(f *flag.Flag) {
 		if f.Name == "update-coalescing-batch" {
 			cfg.updateCoalescingBatchSet = true
+		}
+		if f.Name == "insert-coalescing-batch" {
+			cfg.insertCoalescingBatchSet = true
 		}
 	})
 	if cfg.dir == "" {
@@ -148,6 +160,9 @@ func parseFlags(args []string, stderr io.Writer) (cliConfig, error) {
 	}
 	if cfg.updateCoalescingBatch < 0 {
 		return cfg, errors.New("-update-coalescing-batch must be >= 0")
+	}
+	if cfg.insertCoalescingBatch < 0 {
+		return cfg, errors.New("-insert-coalescing-batch must be >= 0")
 	}
 	return cfg, nil
 }
@@ -169,6 +184,10 @@ func standaloneOptions(cfg cliConfig) mongogateway.StandaloneOptions {
 	if cfg.updateCoalescingBatchSet {
 		coalescingBatch = cfg.updateCoalescingBatch
 	}
+	insertCoalescingBatch := 0
+	if cfg.insertCoalescingBatchSet {
+		insertCoalescingBatch = cfg.insertCoalescingBatch
+	}
 	return mongogateway.StandaloneOptions{
 		Dir:     cfg.dir,
 		Profile: treedb.Profile(cfg.profile),
@@ -187,6 +206,10 @@ func standaloneOptions(cfg cliConfig) mongogateway.StandaloneOptions {
 		UpdateCoalescingMaxBatchSet: cfg.updateCoalescingBatchSet,
 		UpdateCoalescingMaxBatch:    coalescingBatch,
 		UpdateCoalescingIdleTTL:     cfg.updateCoalescingIdleTTL,
+		InsertCoalescingMaxDelay:    cfg.insertCoalescingDelay,
+		InsertCoalescingMaxBatchSet: cfg.insertCoalescingBatchSet,
+		InsertCoalescingMaxBatch:    insertCoalescingBatch,
+		InsertCoalescingIdleTTL:     cfg.insertCoalescingIdleTTL,
 	}
 }
 

--- a/TreeDB/mongo_gateway/server_core.go
+++ b/TreeDB/mongo_gateway/server_core.go
@@ -40,6 +40,10 @@ const (
 	defaultUpdateCoalescingBatch   = 256
 	maxUpdateCoalescingBatch       = 4096
 	defaultUpdateCoalescingIdleTTL = 30 * time.Second
+	defaultInsertCoalescingDelay   = 0
+	defaultInsertCoalescingBatch   = 256
+	maxInsertCoalescingBatch       = 4096
+	defaultInsertCoalescingIdleTTL = 30 * time.Second
 	maxRetainedWireReadBuffer      = 1 << 20
 	maxRetainedWireWriteBuffer     = 1 << 20
 	defaultWireReadBufferSize      = 32 * 1024
@@ -63,7 +67,17 @@ type Server struct {
 	UpdateCoalescingMaxBatch int
 	// UpdateCoalescingIdleTTL removes an idle per-collection coalescer after this
 	// duration. Zero uses the default; negative disables idle removal.
-	UpdateCoalescingIdleTTL   time.Duration
+	UpdateCoalescingIdleTTL time.Duration
+	// InsertCoalescingMaxDelay waits for additional same-collection single-document
+	// BSON insert commands before publishing a batch. Zero means only coalesce
+	// already-queued work; negative disables coalescing.
+	InsertCoalescingMaxDelay time.Duration
+	// InsertCoalescingMaxBatch caps one coalesced same-collection insert publish.
+	// Values above maxInsertCoalescingBatch are clamped.
+	InsertCoalescingMaxBatch int
+	// InsertCoalescingIdleTTL removes an idle per-collection coalescer after this
+	// duration. Zero uses the default; negative disables idle removal.
+	InsertCoalescingIdleTTL   time.Duration
 	Collections               *collections.CollectionManager
 	DefaultCollectionOptions  collections.CollectionOptions
 	DefaultIndexStoragePolicy collections.RootStoragePolicy
@@ -81,6 +95,8 @@ type Server struct {
 	lastCursorReap   time.Time
 	updateMu         sync.Mutex
 	updateCoalescers map[string]*mongoUpdateCoalescer
+	insertMu         sync.Mutex
+	insertCoalescers map[string]*mongoInsertCoalescer
 	closed           atomic.Bool
 }
 
@@ -99,6 +115,9 @@ func NewServer() *Server {
 		UpdateCoalescingMaxDelay: defaultUpdateCoalescingDelay,
 		UpdateCoalescingMaxBatch: defaultUpdateCoalescingBatch,
 		UpdateCoalescingIdleTTL:  defaultUpdateCoalescingIdleTTL,
+		InsertCoalescingMaxDelay: defaultInsertCoalescingDelay,
+		InsertCoalescingMaxBatch: defaultInsertCoalescingBatch,
+		InsertCoalescingIdleTTL:  defaultInsertCoalescingIdleTTL,
 	}
 	s.nextResponseID.Store(0)
 	return s
@@ -112,6 +131,7 @@ func (s *Server) Close() error {
 	s.closeActiveListeners()
 	s.closeActiveConns()
 	s.closeUpdateCoalescers()
+	s.closeInsertCoalescers()
 	s.cursorMu.Lock()
 	s.cursors = nil
 	s.cursorCount.Store(0)
@@ -127,6 +147,19 @@ func (s *Server) closeUpdateCoalescers() {
 	coalescers := s.updateCoalescers
 	s.updateCoalescers = nil
 	s.updateMu.Unlock()
+	for _, coalescer := range coalescers {
+		coalescer.stop()
+	}
+}
+
+func (s *Server) closeInsertCoalescers() {
+	if s == nil {
+		return
+	}
+	s.insertMu.Lock()
+	coalescers := s.insertCoalescers
+	s.insertCoalescers = nil
+	s.insertMu.Unlock()
 	for _, coalescer := range coalescers {
 		coalescer.stop()
 	}

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -1311,6 +1311,275 @@ func TestServerUpdateAppliesEarlierOrderedUpdatesBeforeLaterWriteError(t *testin
 	}
 }
 
+func TestServerInsertCoalescesConcurrentDistinctIDs(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	server := NewServer()
+	server.Collections = collections.NewCollectionManager(db)
+	server.DefaultCollectionOptions = collections.CollectionOptions{
+		DocumentFormat: collections.DocumentFormatBSON,
+	}
+	server.InsertCoalescingMaxDelay = 5 * time.Second
+	server.InsertCoalescingMaxBatch = 2
+	assertOK(t, serveCommand(t, server, 22520, bson.D{
+		{Key: "createIndexes", Value: "users"},
+		{Key: "indexes", Value: bson.A{
+			bson.D{{Key: "key", Value: bson.D{{Key: "email", Value: int32(1)}}}, {Key: "name", Value: "email_1"}, {Key: "treedbValueType", Value: "string"}},
+		}},
+		{Key: "$db", Value: "app"},
+	}))
+
+	before := server.Collections.StatsSnapshot()
+	start := make(chan struct{})
+	responses := make(chan commandResult, 2)
+	var wg sync.WaitGroup
+	for i, id := range []string{"u1", "u2"} {
+		i, id := i, id
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			doc, err := serveCommandResult(server, int32(22521+i), bson.D{
+				{Key: "insert", Value: "users"},
+				{Key: "documents", Value: bson.A{bson.D{
+					{Key: "_id", Value: id},
+					{Key: "email", Value: fmt.Sprintf("%s@example.com", id)},
+				}}},
+				{Key: "$db", Value: "app"},
+			})
+			responses <- commandResult{doc: doc, err: err}
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(responses)
+	for response := range responses {
+		if response.err != nil {
+			t.Fatalf("ServeOneWithOwner: %v", response.err)
+		}
+		assertOK(t, response.doc)
+		assertInt32(t, response.doc, "n", 1)
+	}
+	after := server.Collections.StatsSnapshot()
+	if got := after.IndexedStageBatches - before.IndexedStageBatches; got != 1 {
+		t.Fatalf("indexed stage batches delta=%d want 1", got)
+	}
+	if got := after.IndexedStageDocs - before.IndexedStageDocs; got != 2 {
+		t.Fatalf("indexed stage docs delta=%d want 2", got)
+	}
+
+	for i, id := range []string{"u1", "u2"} {
+		findResponse := serveCommand(t, server, int32(22523+i), bson.D{
+			{Key: "find", Value: "users"},
+			{Key: "filter", Value: bson.D{{Key: "_id", Value: id}}},
+			{Key: "$db", Value: "app"},
+		})
+		firstBatch := cursorFirstBatch(t, findResponse)
+		if len(firstBatch) != 1 {
+			t.Fatalf("%s firstBatch len=%d want 1", id, len(firstBatch))
+		}
+	}
+}
+
+func TestMongoInsertCoalescerDuplicateIDsFallBackToOrderedSingles(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	manager := collections.NewCollectionManager(db)
+	if _, err := manager.CreateCollection(&collections.CollectionMeta{
+		Name: "app.users",
+		Options: collections.CollectionOptions{
+			DocumentFormat: collections.DocumentFormatBSON,
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := manager.OpenCollection("app.users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	id1, doc1, err := prepareInsertDocument(mustDocument(t, bson.D{{Key: "_id", Value: "u1"}, {Key: "score", Value: int32(1)}}), collections.DocumentFormatBSON)
+	if err != nil {
+		t.Fatalf("prepare doc1: %v", err)
+	}
+	id2, doc2, err := prepareInsertDocument(mustDocument(t, bson.D{{Key: "_id", Value: "u1"}, {Key: "score", Value: int32(2)}}), collections.DocumentFormatBSON)
+	if err != nil {
+		t.Fatalf("prepare doc2: %v", err)
+	}
+
+	done1 := make(chan mongoInsertCoalescerResult, 1)
+	done2 := make(chan mongoInsertCoalescerResult, 1)
+	(&mongoInsertCoalescer{}).runBatch([]mongoInsertCoalescerRequest{
+		{col: col, id: id1, stored: doc1, done: done1},
+		{col: col, id: id2, stored: doc2, done: done2},
+	})
+	first := <-done1
+	second := <-done2
+	if first.err != nil {
+		t.Fatalf("first insert err=%v", first.err)
+	}
+	if !collections.IsDuplicateKeyError(second.err) {
+		t.Fatalf("second insert err=%v want duplicate key", second.err)
+	}
+}
+
+func TestMongoInsertCoalescerUniqueIndexErrorFallsBackToOrderedSingles(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	server := NewServer()
+	server.Collections = collections.NewCollectionManager(db)
+	server.DefaultCollectionOptions = collections.CollectionOptions{
+		DocumentFormat: collections.DocumentFormatBSON,
+	}
+	assertOK(t, serveCommand(t, server, 22530, bson.D{
+		{Key: "createIndexes", Value: "users"},
+		{Key: "indexes", Value: bson.A{
+			bson.D{{Key: "key", Value: bson.D{{Key: "email", Value: int32(1)}}}, {Key: "name", Value: "email_1"}, {Key: "treedbValueType", Value: "string"}, {Key: "unique", Value: true}},
+		}},
+		{Key: "$db", Value: "app"},
+	}))
+	assertOK(t, serveCommand(t, server, 22531, bson.D{
+		{Key: "insert", Value: "users"},
+		{Key: "documents", Value: bson.A{
+			bson.D{{Key: "_id", Value: "u0"}, {Key: "email", Value: "a@example.com"}},
+		}},
+		{Key: "$db", Value: "app"},
+	}))
+	col, err := server.Collections.OpenCollection("app.users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	duplicateID, duplicateDoc, err := prepareInsertDocument(mustDocument(t, bson.D{{Key: "_id", Value: "u1"}, {Key: "email", Value: "a@example.com"}}), collections.DocumentFormatBSON)
+	if err != nil {
+		t.Fatalf("prepare duplicate doc: %v", err)
+	}
+	validID, validDoc, err := prepareInsertDocument(mustDocument(t, bson.D{{Key: "_id", Value: "u2"}, {Key: "email", Value: "b@example.com"}}), collections.DocumentFormatBSON)
+	if err != nil {
+		t.Fatalf("prepare valid doc: %v", err)
+	}
+
+	doneDuplicate := make(chan mongoInsertCoalescerResult, 1)
+	doneValid := make(chan mongoInsertCoalescerResult, 1)
+	(&mongoInsertCoalescer{}).runBatch([]mongoInsertCoalescerRequest{
+		{col: col, id: duplicateID, stored: duplicateDoc, done: doneDuplicate},
+		{col: col, id: validID, stored: validDoc, done: doneValid},
+	})
+	duplicateResult := <-doneDuplicate
+	validResult := <-doneValid
+	if !collections.IsDuplicateKeyError(duplicateResult.err) {
+		t.Fatalf("duplicate err=%v want duplicate key", duplicateResult.err)
+	}
+	if validResult.err != nil {
+		t.Fatalf("valid err=%v", validResult.err)
+	}
+
+	findResponse := serveCommand(t, server, 22532, bson.D{
+		{Key: "find", Value: "users"},
+		{Key: "filter", Value: bson.D{{Key: "_id", Value: "u2"}}},
+		{Key: "$db", Value: "app"},
+	})
+	firstBatch := cursorFirstBatch(t, findResponse)
+	if len(firstBatch) != 1 {
+		t.Fatalf("u2 firstBatch len=%d want 1", len(firstBatch))
+	}
+	gotEmail, ok := firstBatch[0].Lookup("email").StringValueOK()
+	if !ok || gotEmail != "b@example.com" {
+		t.Fatalf("u2 email=%q ok=%v want b@example.com", gotEmail, ok)
+	}
+}
+
+func TestServerInsertCoalescedSkipsCoalescerForNonBSONAndMultiDocument(t *testing.T) {
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	server := NewServer()
+	server.Collections = collections.NewCollectionManager(db)
+	server.DefaultCollectionOptions = collections.CollectionOptions{
+		DocumentFormat: collections.DocumentFormatJSON,
+	}
+	server.InsertCoalescingMaxDelay = 5 * time.Second
+	server.InsertCoalescingMaxBatch = 2
+	assertOK(t, serveCommand(t, server, 22540, bson.D{
+		{Key: "insert", Value: "json_users"},
+		{Key: "documents", Value: bson.A{bson.D{{Key: "_id", Value: "u1"}, {Key: "score", Value: int32(1)}}}},
+		{Key: "$db", Value: "app"},
+	}))
+
+	server.DefaultCollectionOptions = collections.CollectionOptions{
+		DocumentFormat: collections.DocumentFormatBSON,
+	}
+	assertOK(t, serveCommand(t, server, 22541, bson.D{
+		{Key: "insert", Value: "bson_users"},
+		{Key: "documents", Value: bson.A{
+			bson.D{{Key: "_id", Value: "u1"}, {Key: "score", Value: int32(1)}},
+			bson.D{{Key: "_id", Value: "u2"}, {Key: "score", Value: int32(2)}},
+		}},
+		{Key: "$db", Value: "app"},
+	}))
+
+	server.insertMu.Lock()
+	coalescers := len(server.insertCoalescers)
+	server.insertMu.Unlock()
+	if coalescers != 0 {
+		t.Fatalf("created %d insert coalescers for non-BSON or multi-document insert", coalescers)
+	}
+}
+
+func TestServerCloseStopsInsertCoalescers(t *testing.T) {
+	server := NewServer()
+	coalescer := server.mongoInsertCoalescer("app.users")
+	if coalescer == nil {
+		t.Fatal("expected coalescer")
+	}
+	if err := server.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	coalescer.mu.RLock()
+	stopped := coalescer.stopped
+	coalescer.mu.RUnlock()
+	if !stopped {
+		t.Fatal("coalescer was not stopped")
+	}
+	select {
+	case <-coalescer.done:
+	default:
+		t.Fatal("Close returned before insert coalescer worker exited")
+	}
+	if got := server.mongoInsertCoalescer("app.users"); got != nil {
+		t.Fatal("closed server created a new insert coalescer")
+	}
+}
+
+func TestMongoInsertCoalescerClampsConfiguredMaxBatch(t *testing.T) {
+	server := NewServer()
+	server.InsertCoalescingMaxBatch = maxInsertCoalescingBatch + 1
+	coalescer := server.mongoInsertCoalescer("app.users")
+	if coalescer == nil {
+		t.Fatal("expected coalescer")
+	}
+	defer func() { _ = server.Close() }()
+	if coalescer.maxBatch != maxInsertCoalescingBatch {
+		t.Fatalf("maxBatch=%d want %d", coalescer.maxBatch, maxInsertCoalescingBatch)
+	}
+	if got, want := cap(coalescer.requests), maxInsertCoalescingBatch*4; got != want {
+		t.Fatalf("request queue cap=%d want %d", got, want)
+	}
+}
+
 func TestServerUpdateCoalescesConcurrentDistinctIDs(t *testing.T) {
 	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/mongo_gateway/standalone.go
+++ b/TreeDB/mongo_gateway/standalone.go
@@ -42,6 +42,12 @@ type StandaloneOptions struct {
 	UpdateCoalescingMaxBatchSet bool
 	UpdateCoalescingMaxBatch    int
 	UpdateCoalescingIdleTTL     time.Duration
+	InsertCoalescingMaxDelay    time.Duration
+	// InsertCoalescingMaxBatchSet distinguishes an unset zero value from an
+	// explicit zero, which disables insert coalescing.
+	InsertCoalescingMaxBatchSet bool
+	InsertCoalescingMaxBatch    int
+	InsertCoalescingIdleTTL     time.Duration
 }
 
 // StandaloneServer owns the TreeDB backend, collection manager, and MongoDB
@@ -109,6 +115,9 @@ func NormalizeStandaloneOptions(opts StandaloneOptions) (StandaloneOptions, erro
 	if opts.UpdateCoalescingMaxBatch < 0 {
 		return opts, errors.New("mongo gateway standalone: UpdateCoalescingMaxBatch must be >= 0")
 	}
+	if opts.InsertCoalescingMaxBatch < 0 {
+		return opts, errors.New("mongo gateway standalone: InsertCoalescingMaxBatch must be >= 0")
+	}
 
 	return opts, nil
 }
@@ -147,6 +156,11 @@ func OpenStandaloneServer(opts StandaloneOptions) (*StandaloneServer, error) {
 		server.UpdateCoalescingMaxBatch = normalized.UpdateCoalescingMaxBatch
 	}
 	server.UpdateCoalescingIdleTTL = normalized.UpdateCoalescingIdleTTL
+	server.InsertCoalescingMaxDelay = normalized.InsertCoalescingMaxDelay
+	if normalized.InsertCoalescingMaxBatchSet || normalized.InsertCoalescingMaxBatch > 0 {
+		server.InsertCoalescingMaxBatch = normalized.InsertCoalescingMaxBatch
+	}
+	server.InsertCoalescingIdleTTL = normalized.InsertCoalescingIdleTTL
 
 	return &StandaloneServer{
 		Options:     normalized,

--- a/TreeDB/mongo_gateway/standalone_test.go
+++ b/TreeDB/mongo_gateway/standalone_test.go
@@ -123,6 +123,11 @@ func TestNormalizeStandaloneOptionsDefaultsAndValidation(t *testing.T) {
 			opts: StandaloneOptions{Dir: t.TempDir(), UpdateCoalescingMaxBatch: -1},
 			want: "UpdateCoalescingMaxBatch must be >= 0",
 		},
+		{
+			name: "bad insert coalescing max batch",
+			opts: StandaloneOptions{Dir: t.TempDir(), InsertCoalescingMaxBatch: -1},
+			want: "InsertCoalescingMaxBatch must be >= 0",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -627,6 +632,9 @@ func TestOpenStandaloneServerPreservesDefaultUpdateCoalescingBatch(t *testing.T)
 	if standalone.Server.UpdateCoalescingMaxBatch != defaultUpdateCoalescingBatch {
 		t.Fatalf("UpdateCoalescingMaxBatch=%d want default %d", standalone.Server.UpdateCoalescingMaxBatch, defaultUpdateCoalescingBatch)
 	}
+	if standalone.Server.InsertCoalescingMaxBatch != defaultInsertCoalescingBatch {
+		t.Fatalf("InsertCoalescingMaxBatch=%d want default %d", standalone.Server.InsertCoalescingMaxBatch, defaultInsertCoalescingBatch)
+	}
 }
 
 func TestOpenStandaloneServerAppliesExplicitZeroUpdateCoalescingBatch(t *testing.T) {
@@ -634,6 +642,8 @@ func TestOpenStandaloneServerAppliesExplicitZeroUpdateCoalescingBatch(t *testing
 		Dir:                         t.TempDir(),
 		UpdateCoalescingMaxBatchSet: true,
 		UpdateCoalescingMaxBatch:    0,
+		InsertCoalescingMaxBatchSet: true,
+		InsertCoalescingMaxBatch:    0,
 	})
 	if err != nil {
 		t.Fatalf("OpenStandaloneServer: %v", err)
@@ -642,6 +652,9 @@ func TestOpenStandaloneServerAppliesExplicitZeroUpdateCoalescingBatch(t *testing
 
 	if standalone.Server.UpdateCoalescingMaxBatch != 0 {
 		t.Fatalf("UpdateCoalescingMaxBatch=%d want explicit zero", standalone.Server.UpdateCoalescingMaxBatch)
+	}
+	if standalone.Server.InsertCoalescingMaxBatch != 0 {
+		t.Fatalf("InsertCoalescingMaxBatch=%d want explicit zero", standalone.Server.InsertCoalescingMaxBatch)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Adds a per-collection Mongo insert coalescer for compatible single-document BSON insert commands.
- Batches queued same-collection inserts into one `InsertBatchValidatedBSON` call while each request still receives its own `{ok: 1, n: 1}` command response.
- Preserves conservative fallbacks for disabled/stopped/full coalescers, duplicate primary keys, mixed cached catalog state, non-BSON collections, multi-document commands, and duplicate-key batch errors; commit-ambiguous errors are not decomposed.
- Adds standalone/CLI controls: `-insert-coalescing-delay`, `-insert-coalescing-batch`, and `-insert-coalescing-idle-ttl`.

Linked issue: closes #2109.
Stack: depends on #2112 / `codex/mongo-ycsb-attribution-2108`.

## Correctness / Tests
- `GOWORK=off go test ./TreeDB/mongo_gateway -run 'TestServerInsertCoalescesConcurrentDistinctIDs|TestMongoInsertCoalescerDuplicateIDsFallBackToOrderedSingles|TestMongoInsertCoalescerUniqueIndexErrorFallsBackToOrderedSingles|TestServerInsertCoalescedSkipsCoalescerForNonBSONAndMultiDocument|TestServerCloseStopsInsertCoalescers|TestMongoInsertCoalescerClampsConfiguredMaxBatch|TestOpenStandaloneServer' -count=1`
- `GOWORK=off go test ./TreeDB/mongo_gateway -count=1`
- `GOWORK=off go test ./TreeDB/collections -count=1`
- `GOWORK=off go test ./cmd/mongo_gateway_bench -count=1`
- `git diff --check`

## Benchmark Evidence
Command:

```sh
OUT_DIR=/tmp/treedb_mongo_insert_coalescer_2109_after_20260531_185409 \
  PROFILE=true INDEXES_LIST='0 1' CLIENT_MODES='driver raw-wire-tcp' \
  scripts/mongo_gateway_ycsb_attribution.sh
```

Baseline: `/tmp/treedb_mongo_ycsb_attr_2108_full_20260531_183701`, PR #2112 head `b280b890244ca8f94d300bd17f8ecac84a42c50f`.
Candidate: `/tmp/treedb_mongo_insert_coalescer_2109_after_20260531_185409`, this PR head `95f96adeace6f8c620248aca6f4b2743a9b518d7`.

| secondary indexes | client mode | baseline ops/sec | candidate ops/sec | change |
| ---: | --- | ---: | ---: | ---: |
| 0 | driver | 88,938.3 | 117,896.3 | +32.6% |
| 0 | raw-wire-tcp | 121,157.5 | 191,229.6 | +57.8% |
| 1 | driver | 53,589.4 | 91,434.0 | +70.6% |
| 1 | raw-wire-tcp | 67,779.2 | 117,858.6 | +73.9% |

Indexed raw-wire TCP counters after load:

| counter | baseline | candidate |
| --- | ---: | ---: |
| indexed_stage.batches_total | 100,000 | 23,437 |
| mutation_lock.calls_total | 100,000 | 40,473 |
| mutation_lock.wait_ns_total | 17,351,251,236 | 2,054,254 |
| mutation_lock.wait_share_pct | 94.437 | 0.418 |

## Review Status
- Internal review done for request-body lifetime, duplicate-key fallback, catalog-state gating, close/idle handling, and commit-ambiguous behavior.
- AI reviews were not manually requested before this mature head; CodeRabbit may run automatically.
