### PR TITLE
Add public graph search promotion matrix for #2105

### DIFF
--- a/TreeDB/collections/vector_graph_search_truth_matrix_2037_test.go
+++ b/TreeDB/collections/vector_graph_search_truth_matrix_2037_test.go
@@ -134,6 +134,22 @@ func vectorGraphSearchTruthMatrixRequiredMetricLabels2037() []string {
 		"adjacency_typed_list_scratch_decodes/search",
 		"adjacency_legacy_fallbacks/search",
 		"adjacency_source_fallbacks/search",
+		"benchmark_debug_searches/search",
+		"neighbor_tiles/search",
+		"neighbor_tile_avg_size",
+		"score_batch_singletons/search",
+		"score_batch_size_2_4/search",
+		"score_batch_size_5_8/search",
+		"score_batch_size_9_16/search",
+		"score_batch_size_17_plus/search",
+		"already_visited_skips/search",
+		"frontier_pushes/search",
+		"frontier_pops/search",
+		"top_k_insert_rejections/search",
+		"visited_mark_hits/search",
+		"visited_mark_misses/search",
+		"exact_candidate_order_observations/search",
+		"exact_candidate_order_backward_jumps/search",
 	}
 }
 
@@ -215,6 +231,9 @@ func TestVectorGraphSearchTruthMatrixMetricContract2037(t *testing.T) {
 		"adjacency_prepared_csr_mmap_direct/search",
 		"adjacency_typed_list_mmap_direct/search",
 		"typed_column_vector_fallbacks/search",
+		"benchmark_debug_searches/search",
+		"score_batch_singletons/search",
+		"exact_candidate_order_observations/search",
 	} {
 		if _, ok := seen[required]; !ok {
 			t.Fatalf("missing required metric label %q", required)

--- a/TreeDB/collections/vector_graph_search_truth_matrix_2037_test.go
+++ b/TreeDB/collections/vector_graph_search_truth_matrix_2037_test.go
@@ -73,15 +73,15 @@ func vectorGraphSearchTruthMatrixRows2037() []vectorGraphSearchTruthMatrixRow203
 		{Mode: vectorGraphSearchTruthMatrixModeCombinedPrepared2037, Boundary: vectorGraphSearchTruthMatrixBoundaryGraphOnly2037, Concurrency: vectorGraphSearchTruthMatrixConcurrencyParallel2037, Fixture: vectorGraphSearchTruthMatrixFixtureProduction81922037, CanonicalBenchmark: "BenchmarkColumnVectorGraphSearchTruthMatrix2037 combined prepared graph-only parallel row"},
 		{Mode: vectorGraphSearchTruthMatrixModeCombinedPrepared2037, Boundary: vectorGraphSearchTruthMatrixBoundaryGraphOnly2037, Concurrency: vectorGraphSearchTruthMatrixConcurrencyParallel2037, Fixture: vectorGraphSearchTruthMatrixFixtureProduction81922037, StatsMode: columnVectorGraphNativeSearchStatsModeMinimal, CanonicalBenchmark: "BenchmarkColumnVectorGraphSearchTruthMatrix2037 combined prepared graph-only parallel minimal-stats row"},
 
-		{Mode: vectorGraphSearchTruthMatrixModeCurrentTypedColumn2037, Boundary: vectorGraphSearchTruthMatrixBoundaryResultID2037, Concurrency: vectorGraphSearchTruthMatrixConcurrencySerial2037, Fixture: vectorGraphSearchTruthMatrixFixtureServing10242037, CanonicalBenchmark: "BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderV4"},
-		{Mode: vectorGraphSearchTruthMatrixModeCurrentTypedColumn2037, Boundary: vectorGraphSearchTruthMatrixBoundaryResultID2037, Concurrency: vectorGraphSearchTruthMatrixConcurrencyParallel2037, Fixture: vectorGraphSearchTruthMatrixFixtureServing10242037, CanonicalBenchmark: "BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderParallelV4"},
-		{Mode: vectorGraphSearchTruthMatrixModeCombinedPrepared2037, Boundary: vectorGraphSearchTruthMatrixBoundaryResultID2037, Concurrency: vectorGraphSearchTruthMatrixConcurrencySerial2037, Fixture: vectorGraphSearchTruthMatrixFixtureServing10242037, CanonicalBenchmark: "BenchmarkColumnVectorGraphSearchTruthMatrix2037 combined prepared result-ID serial row"},
-		{Mode: vectorGraphSearchTruthMatrixModeCombinedPrepared2037, Boundary: vectorGraphSearchTruthMatrixBoundaryResultID2037, Concurrency: vectorGraphSearchTruthMatrixConcurrencyParallel2037, Fixture: vectorGraphSearchTruthMatrixFixtureServing10242037, CanonicalBenchmark: "BenchmarkColumnVectorGraphSearchTruthMatrix2037 combined prepared result-ID parallel row"},
+		{Mode: vectorGraphSearchTruthMatrixModeCurrentTypedColumn2037, Boundary: vectorGraphSearchTruthMatrixBoundaryResultID2037, Concurrency: vectorGraphSearchTruthMatrixConcurrencySerial2037, Fixture: vectorGraphSearchTruthMatrixFixtureServing10242037, StatsMode: columnVectorGraphNativeSearchStatsModeBenchmarkDebug, CanonicalBenchmark: "BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderV4"},
+		{Mode: vectorGraphSearchTruthMatrixModeCurrentTypedColumn2037, Boundary: vectorGraphSearchTruthMatrixBoundaryResultID2037, Concurrency: vectorGraphSearchTruthMatrixConcurrencyParallel2037, Fixture: vectorGraphSearchTruthMatrixFixtureServing10242037, StatsMode: columnVectorGraphNativeSearchStatsModeBenchmarkDebug, CanonicalBenchmark: "BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderParallelV4"},
+		{Mode: vectorGraphSearchTruthMatrixModeCombinedPrepared2037, Boundary: vectorGraphSearchTruthMatrixBoundaryResultID2037, Concurrency: vectorGraphSearchTruthMatrixConcurrencySerial2037, Fixture: vectorGraphSearchTruthMatrixFixtureServing10242037, StatsMode: columnVectorGraphNativeSearchStatsModeBenchmarkDebug, CanonicalBenchmark: "BenchmarkColumnVectorGraphSearchTruthMatrix2037 combined prepared result-ID serial row"},
+		{Mode: vectorGraphSearchTruthMatrixModeCombinedPrepared2037, Boundary: vectorGraphSearchTruthMatrixBoundaryResultID2037, Concurrency: vectorGraphSearchTruthMatrixConcurrencyParallel2037, Fixture: vectorGraphSearchTruthMatrixFixtureServing10242037, StatsMode: columnVectorGraphNativeSearchStatsModeBenchmarkDebug, CanonicalBenchmark: "BenchmarkColumnVectorGraphSearchTruthMatrix2037 combined prepared result-ID parallel row"},
 
-		{Mode: vectorGraphSearchTruthMatrixModeCurrentTypedColumn2037, Boundary: vectorGraphSearchTruthMatrixBoundaryDocumentMaterialize2037, Concurrency: vectorGraphSearchTruthMatrixConcurrencySerial2037, Fixture: vectorGraphSearchTruthMatrixFixtureServing10242037, CanonicalBenchmark: "BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderWithDocumentsV4"},
-		{Mode: vectorGraphSearchTruthMatrixModeCurrentTypedColumn2037, Boundary: vectorGraphSearchTruthMatrixBoundaryDocumentMaterialize2037, Concurrency: vectorGraphSearchTruthMatrixConcurrencyParallel2037, Fixture: vectorGraphSearchTruthMatrixFixtureServing10242037, CanonicalBenchmark: "BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderParallelWithDocumentsV4"},
-		{Mode: vectorGraphSearchTruthMatrixModeCombinedPrepared2037, Boundary: vectorGraphSearchTruthMatrixBoundaryDocumentMaterialize2037, Concurrency: vectorGraphSearchTruthMatrixConcurrencySerial2037, Fixture: vectorGraphSearchTruthMatrixFixtureServing10242037, CanonicalBenchmark: "BenchmarkColumnVectorGraphSearchTruthMatrix2037 combined prepared document-materialization serial row"},
-		{Mode: vectorGraphSearchTruthMatrixModeCombinedPrepared2037, Boundary: vectorGraphSearchTruthMatrixBoundaryDocumentMaterialize2037, Concurrency: vectorGraphSearchTruthMatrixConcurrencyParallel2037, Fixture: vectorGraphSearchTruthMatrixFixtureServing10242037, CanonicalBenchmark: "BenchmarkColumnVectorGraphSearchTruthMatrix2037 combined prepared document-materialization parallel row"},
+		{Mode: vectorGraphSearchTruthMatrixModeCurrentTypedColumn2037, Boundary: vectorGraphSearchTruthMatrixBoundaryDocumentMaterialize2037, Concurrency: vectorGraphSearchTruthMatrixConcurrencySerial2037, Fixture: vectorGraphSearchTruthMatrixFixtureServing10242037, StatsMode: columnVectorGraphNativeSearchStatsModeBenchmarkDebug, CanonicalBenchmark: "BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderWithDocumentsV4"},
+		{Mode: vectorGraphSearchTruthMatrixModeCurrentTypedColumn2037, Boundary: vectorGraphSearchTruthMatrixBoundaryDocumentMaterialize2037, Concurrency: vectorGraphSearchTruthMatrixConcurrencyParallel2037, Fixture: vectorGraphSearchTruthMatrixFixtureServing10242037, StatsMode: columnVectorGraphNativeSearchStatsModeBenchmarkDebug, CanonicalBenchmark: "BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderParallelWithDocumentsV4"},
+		{Mode: vectorGraphSearchTruthMatrixModeCombinedPrepared2037, Boundary: vectorGraphSearchTruthMatrixBoundaryDocumentMaterialize2037, Concurrency: vectorGraphSearchTruthMatrixConcurrencySerial2037, Fixture: vectorGraphSearchTruthMatrixFixtureServing10242037, StatsMode: columnVectorGraphNativeSearchStatsModeBenchmarkDebug, CanonicalBenchmark: "BenchmarkColumnVectorGraphSearchTruthMatrix2037 combined prepared document-materialization serial row"},
+		{Mode: vectorGraphSearchTruthMatrixModeCombinedPrepared2037, Boundary: vectorGraphSearchTruthMatrixBoundaryDocumentMaterialize2037, Concurrency: vectorGraphSearchTruthMatrixConcurrencyParallel2037, Fixture: vectorGraphSearchTruthMatrixFixtureServing10242037, StatsMode: columnVectorGraphNativeSearchStatsModeBenchmarkDebug, CanonicalBenchmark: "BenchmarkColumnVectorGraphSearchTruthMatrix2037 combined prepared document-materialization parallel row"},
 	}
 }
 
@@ -167,14 +167,14 @@ func TestVectorGraphSearchTruthMatrixRows2037(t *testing.T) {
 		"mode=combined_prepared_typed_column/boundary=graph_only/concurrency=serial/fixture=production8192/stats=minimal",
 		"mode=combined_prepared_typed_column/boundary=graph_only/concurrency=parallel/fixture=production8192",
 		"mode=combined_prepared_typed_column/boundary=graph_only/concurrency=parallel/fixture=production8192/stats=minimal",
-		"mode=current_tvis_base_typed_column/boundary=result_id/concurrency=serial/fixture=serving1024",
-		"mode=current_tvis_base_typed_column/boundary=result_id/concurrency=parallel/fixture=serving1024",
-		"mode=combined_prepared_typed_column/boundary=result_id/concurrency=serial/fixture=serving1024",
-		"mode=combined_prepared_typed_column/boundary=result_id/concurrency=parallel/fixture=serving1024",
-		"mode=current_tvis_base_typed_column/boundary=document_materialization/concurrency=serial/fixture=serving1024",
-		"mode=current_tvis_base_typed_column/boundary=document_materialization/concurrency=parallel/fixture=serving1024",
-		"mode=combined_prepared_typed_column/boundary=document_materialization/concurrency=serial/fixture=serving1024",
-		"mode=combined_prepared_typed_column/boundary=document_materialization/concurrency=parallel/fixture=serving1024",
+		"mode=current_tvis_base_typed_column/boundary=result_id/concurrency=serial/fixture=serving1024/stats=benchmark_debug",
+		"mode=current_tvis_base_typed_column/boundary=result_id/concurrency=parallel/fixture=serving1024/stats=benchmark_debug",
+		"mode=combined_prepared_typed_column/boundary=result_id/concurrency=serial/fixture=serving1024/stats=benchmark_debug",
+		"mode=combined_prepared_typed_column/boundary=result_id/concurrency=parallel/fixture=serving1024/stats=benchmark_debug",
+		"mode=current_tvis_base_typed_column/boundary=document_materialization/concurrency=serial/fixture=serving1024/stats=benchmark_debug",
+		"mode=current_tvis_base_typed_column/boundary=document_materialization/concurrency=parallel/fixture=serving1024/stats=benchmark_debug",
+		"mode=combined_prepared_typed_column/boundary=document_materialization/concurrency=serial/fixture=serving1024/stats=benchmark_debug",
+		"mode=combined_prepared_typed_column/boundary=document_materialization/concurrency=parallel/fixture=serving1024/stats=benchmark_debug",
 	}
 	if len(rows) != len(wantNames) {
 		t.Fatalf("rows=%d want %d", len(rows), len(wantNames))
@@ -363,10 +363,10 @@ func benchmarkVectorGraphSearchTruthMatrixResultID2037(b *testing.B, row vectorG
 		b.Fatalf("result-ID boundary currently supports only current/combined prepared typed-column modes, got %q", row.Mode)
 	}
 	if row.Concurrency == vectorGraphSearchTruthMatrixConcurrencyParallel2037 {
-		benchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderParallelV4(b, false, DocumentFetchOptions{})
+		benchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderParallelWithStatsModeV4(b, false, DocumentFetchOptions{}, vectorGraphSearchTruthMatrixPublicStatsMode2037(row.StatsMode))
 		return
 	}
-	benchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderV4(b, false, DocumentFetchOptions{})
+	benchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderWithStatsModeV4(b, false, DocumentFetchOptions{}, vectorGraphSearchTruthMatrixPublicStatsMode2037(row.StatsMode))
 }
 
 func benchmarkVectorGraphSearchTruthMatrixDocumentMaterialization2037(b *testing.B, row vectorGraphSearchTruthMatrixRow2037) {
@@ -375,10 +375,23 @@ func benchmarkVectorGraphSearchTruthMatrixDocumentMaterialization2037(b *testing
 		b.Fatalf("document-materialization boundary currently supports only current/combined prepared typed-column modes, got %q", row.Mode)
 	}
 	if row.Concurrency == vectorGraphSearchTruthMatrixConcurrencyParallel2037 {
-		benchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderParallelV4(b, true, DocumentFetchOptions{})
+		benchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderParallelWithStatsModeV4(b, true, DocumentFetchOptions{}, vectorGraphSearchTruthMatrixPublicStatsMode2037(row.StatsMode))
 		return
 	}
-	benchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderV4(b, true, DocumentFetchOptions{})
+	benchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderWithStatsModeV4(b, true, DocumentFetchOptions{}, vectorGraphSearchTruthMatrixPublicStatsMode2037(row.StatsMode))
+}
+
+func vectorGraphSearchTruthMatrixPublicStatsMode2037(mode columnVectorGraphNativeSearchStatsMode) VectorIndexSearchStatsMode {
+	switch mode {
+	case columnVectorGraphNativeSearchStatsModeDefault:
+		return VectorIndexSearchStatsModeDefault
+	case columnVectorGraphNativeSearchStatsModeMinimal:
+		return VectorIndexSearchStatsModeMinimal
+	case columnVectorGraphNativeSearchStatsModeBenchmarkDebug:
+		return VectorIndexSearchStatsModeBenchmarkDebug
+	default:
+		return VectorIndexSearchStatsModeDefault
+	}
 }
 
 func openVectorGraphSearchTruthMatrixCollection2037(b *testing.B, row vectorGraphSearchTruthMatrixRow2037) (func(), *Collection, VectorIndexDefinition, []float32) {

--- a/TreeDB/collections/vector_index_search.go
+++ b/TreeDB/collections/vector_index_search.go
@@ -82,7 +82,9 @@ type VectorIndexSearcherSearchOptions struct {
 	// reporting fallback/admission counters.
 	StatsMode VectorIndexSearchStatsMode
 	// scoreBatchMode is an internal test/benchmark hook for exact-order indexed
-	// HNSW scoring. The public zero value follows the default scalar gate.
+	// HNSW scoring. The public zero value follows the runtime default scoring
+	// gate: eligible prepared views may use indexed/gathered scoring; legacy,
+	// non-prepared, and fallback routes remain scalar.
 	scoreBatchMode columnVectorGraphScoreBatchMode
 }
 

--- a/TreeDB/collections/vector_index_search_promotion_2105_test.go
+++ b/TreeDB/collections/vector_index_search_promotion_2105_test.go
@@ -1,0 +1,454 @@
+package collections
+
+import (
+	"bytes"
+	"testing"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+)
+
+type vectorIndexSearchPromotionBoundary2105 string
+
+const (
+	vectorIndexSearchPromotionBoundaryResultID2105                vectorIndexSearchPromotionBoundary2105 = "result_id"
+	vectorIndexSearchPromotionBoundaryDocumentMaterialization2105 vectorIndexSearchPromotionBoundary2105 = "document_materialization"
+)
+
+type vectorIndexSearchPromotionRow2105 struct {
+	mode      columnVectorGraphSearchTopologyParityMode2091
+	scoreName string
+	scoreMode columnVectorGraphScoreBatchMode
+}
+
+func TestColumnVectorGraphPublicVectorIndexSearcherSearchPromotion2105(t *testing.T) {
+	if !columnGraphTypedColumnMmapDirectViewSupportedForTest() {
+		t.Skip("public promotion matrix requires mmap_direct prepared views")
+	}
+	shape := columnVectorGraphSearchTopologyParityTestShape2091()
+	shape.efSearch = shape.rows
+	rows := columnVectorGraphSearchTopologyParityRows2091(t, shape)
+
+	t.Run("prepared_default_scalar_indexed_equivalent", func(t *testing.T) {
+		closeFn, searcher, query := openVectorIndexSearcherPromotion2105(t, shape, rows, columnVectorGraphSearchTopologyParityModeCurrentPrepared2091)
+		defer closeFn()
+		if searcher.reader.preparedSearch == nil || !searcher.reader.preparedSearch.indexedScoringDefaultEligible() {
+			t.Fatalf("preparedSearch=%v eligible=%v want default-indexed eligible prepared public searcher", searcher.reader.preparedSearch != nil, searcher.reader.preparedSearch != nil && searcher.reader.preparedSearch.indexedScoringDefaultEligible())
+		}
+		for _, boundary := range []vectorIndexSearchPromotionBoundary2105{
+			vectorIndexSearchPromotionBoundaryResultID2105,
+			vectorIndexSearchPromotionBoundaryDocumentMaterialization2105,
+		} {
+			boundary := boundary
+			t.Run(string(boundary), func(t *testing.T) {
+				scalarResults, scalarStats := searchVectorIndexSearcherPromotion2105(t, searcher, query, shape, boundary, columnVectorGraphScoreBatchModeScalar)
+				defaultResults, defaultStats := searchVectorIndexSearcherPromotion2105(t, searcher, query, shape, boundary, columnVectorGraphScoreBatchModeDefault)
+				indexedResults, indexedStats := searchVectorIndexSearcherPromotion2105(t, searcher, query, shape, boundary, columnVectorGraphScoreBatchModeIndexed)
+
+				if mismatch := vectorIndexSearchResultsMismatch1969(defaultResults, scalarResults); mismatch != "" {
+					t.Fatalf("default vs scalar mismatch: %s", mismatch)
+				}
+				if mismatch := vectorIndexSearchResultsMismatch1969(defaultResults, indexedResults); mismatch != "" {
+					t.Fatalf("default vs indexed mismatch: %s", mismatch)
+				}
+				if boundary == vectorIndexSearchPromotionBoundaryDocumentMaterialization2105 {
+					assertVectorIndexSearchPromotionDocumentsEqual2105(t, defaultResults, scalarResults)
+					assertVectorIndexSearchPromotionDocumentsEqual2105(t, defaultResults, indexedResults)
+				}
+				assertVectorIndexSearchPromotionCurrentStats2105(t, boundary, defaultStats)
+				assertVectorIndexSearchPromotionCurrentStats2105(t, boundary, scalarStats)
+				assertVectorIndexSearchPromotionCurrentStats2105(t, boundary, indexedStats)
+				assertVectorIndexSearchDefaultIndexedScoreBatches2105(t, defaultStats, indexedStats, scalarStats)
+			})
+		}
+	})
+
+	t.Run("legacy_default_remains_scalar", func(t *testing.T) {
+		closeFn, searcher, query := openVectorIndexSearcherPromotion2105(t, shape, rows, columnVectorGraphSearchTopologyParityModeLegacyGraphRowDirect2091)
+		defer closeFn()
+		if searcher.reader.preparedSearch != nil {
+			t.Fatalf("legacy public searcher preparedSearch=%v want nil compatibility graph-row path", searcher.reader.preparedSearch)
+		}
+		scalarResults, scalarStats := searchVectorIndexSearcherPromotion2105(t, searcher, query, shape, vectorIndexSearchPromotionBoundaryResultID2105, columnVectorGraphScoreBatchModeScalar)
+		defaultResults, defaultStats := searchVectorIndexSearcherPromotion2105(t, searcher, query, shape, vectorIndexSearchPromotionBoundaryResultID2105, columnVectorGraphScoreBatchModeDefault)
+		if mismatch := vectorIndexSearchResultsMismatch1969(defaultResults, scalarResults); mismatch != "" {
+			t.Fatalf("legacy default vs scalar mismatch: %s", mismatch)
+		}
+		assertVectorIndexSearchPromotionLegacyStats2105(t, defaultStats)
+		if defaultStats.ScoreBatchCalls != scalarStats.ScoreBatchCalls || defaultStats.ScoreBatchCandidates != scalarStats.ScoreBatchCandidates {
+			t.Fatalf("legacy default stats=%+v scalar stats=%+v want scalar-equivalent score batches", defaultStats, scalarStats)
+		}
+		assertVectorIndexSearchScalarScoreBatches2105(t, defaultStats)
+	})
+}
+
+func BenchmarkVectorIndexSearcherSearchPromotion2105(b *testing.B) {
+	if !columnGraphTypedColumnMmapDirectViewSupportedForTest() {
+		b.Skip("public promotion matrix requires mmap_direct prepared views")
+	}
+	boundedShape := columnVectorGraphSearchTopologyParityProductionShape2091()
+	exactShape := boundedShape
+	exactShape.efSearch = exactShape.rows
+	resultIDRows := []vectorIndexSearchPromotionRow2105{
+		{mode: columnVectorGraphSearchTopologyParityModeLegacyGraphRowDirect2091, scoreName: "default", scoreMode: columnVectorGraphScoreBatchModeDefault},
+		{mode: columnVectorGraphSearchTopologyParityModeCurrentPrepared2091, scoreName: "default", scoreMode: columnVectorGraphScoreBatchModeDefault},
+		{mode: columnVectorGraphSearchTopologyParityModeCurrentPrepared2091, scoreName: "scalar", scoreMode: columnVectorGraphScoreBatchModeScalar},
+		{mode: columnVectorGraphSearchTopologyParityModeCurrentPrepared2091, scoreName: "indexed", scoreMode: columnVectorGraphScoreBatchModeIndexed},
+	}
+	documentRows := []vectorIndexSearchPromotionRow2105{
+		{mode: columnVectorGraphSearchTopologyParityModeCurrentPrepared2091, scoreName: "default", scoreMode: columnVectorGraphScoreBatchModeDefault},
+		{mode: columnVectorGraphSearchTopologyParityModeCurrentPrepared2091, scoreName: "scalar", scoreMode: columnVectorGraphScoreBatchModeScalar},
+		{mode: columnVectorGraphSearchTopologyParityModeCurrentPrepared2091, scoreName: "indexed", scoreMode: columnVectorGraphScoreBatchModeIndexed},
+	}
+	cases := []struct {
+		searchName string
+		shape      columnVectorGraphSearchTopologyParityShape2091
+		boundary   vectorIndexSearchPromotionBoundary2105
+		rows       []vectorIndexSearchPromotionRow2105
+	}{
+		{searchName: "ef_search_128", shape: boundedShape, boundary: vectorIndexSearchPromotionBoundaryResultID2105, rows: resultIDRows},
+		{searchName: "ef_search_128", shape: boundedShape, boundary: vectorIndexSearchPromotionBoundaryDocumentMaterialization2105, rows: documentRows},
+		{searchName: "exact", shape: exactShape, boundary: vectorIndexSearchPromotionBoundaryResultID2105, rows: resultIDRows},
+	}
+	for _, tc := range cases {
+		tc := tc
+		fixtureRows := columnVectorGraphSearchTopologyParityRows2091(b, tc.shape)
+		b.Run("search="+tc.searchName+"/boundary="+string(tc.boundary), func(b *testing.B) {
+			for _, row := range tc.rows {
+				row := row
+				b.Run("mode="+string(row.mode)+"/score="+row.scoreName, func(b *testing.B) {
+					benchmarkVectorIndexSearcherSearchPromotion2105(b, tc.searchName, tc.shape, fixtureRows, tc.boundary, row)
+				})
+			}
+		})
+	}
+}
+
+func benchmarkVectorIndexSearcherSearchPromotion2105(b *testing.B, searchName string, shape columnVectorGraphSearchTopologyParityShape2091, rows []columnVectorGraphAssetRow, boundary vectorIndexSearchPromotionBoundary2105, row vectorIndexSearchPromotionRow2105) {
+	b.Helper()
+	closeFn, searcher, query := openVectorIndexSearcherPromotion2105(b, shape, rows, row.mode)
+	defer closeFn()
+	opts := vectorIndexSearchPromotionOptions2105(shape, boundary, row.scoreMode)
+	opts.Query = query
+	warm, err := searcher.Search(opts)
+	if err != nil {
+		b.Fatalf("warm Search: %v", err)
+	}
+	if len(warm.Results) == 0 {
+		b.Fatalf("warm Search returned no results")
+	}
+	measured, err := searcher.Search(opts)
+	if err != nil {
+		b.Fatalf("measure Search: %v", err)
+	}
+	if len(measured.Results) == 0 {
+		b.Fatalf("measure Search returned no results")
+	}
+	assertVectorIndexSearchPromotionModeStats2105(b, boundary, row.mode, measured.Stats)
+	assertVectorIndexSearchBenchmarkDebugStats2105(b, measured.Stats, shape.efSearch >= shape.rows)
+	assertVectorIndexSearchPromotionScoreStats2105(b, row.mode, row.scoreName, measured.Stats)
+	var checksum int64
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		got, err := searcher.Search(opts)
+		if err != nil {
+			b.Fatalf("Search: %v", err)
+		}
+		if len(got.Results) == 0 {
+			b.Fatalf("Search returned no results")
+		}
+		if boundary == vectorIndexSearchPromotionBoundaryDocumentMaterialization2105 {
+			checksum += int64(len(got.Results[0].Document))
+		} else {
+			checksum += int64(got.Results[0].Ordinal)
+		}
+	}
+	b.StopTimer()
+	vectorSearchBenchSinkOrdinalV4 += int(checksum)
+	reportVectorIndexSearchBenchMetricsV4(b, b.N, measured.Stats, false)
+	reportVectorIndexSearchPromotionLabels2105(b, searchName, shape, boundary, row)
+}
+
+func openVectorIndexSearcherPromotion2105(tb testing.TB, shape columnVectorGraphSearchTopologyParityShape2091, rows []columnVectorGraphAssetRow, mode columnVectorGraphSearchTopologyParityMode2091) (func(), *VectorIndexSearcher, []float32) {
+	tb.Helper()
+	var d *backenddb.DB
+	var col *Collection
+	var def VectorIndexDefinition
+	switch mode {
+	case columnVectorGraphSearchTopologyParityModeLegacyGraphRowDirect2091:
+		d, col, def = publishColumnVectorGraphPhysicalReaderTestAssetWithShapeAndAdjacencyState1989(tb, shape.dims, shape.degree, cloneColumnVectorGraphTopologyParityRows2091(rows))
+	case columnVectorGraphSearchTopologyParityModeCurrentPrepared2091:
+		d, col, def = publishColumnVectorGraphCurrentPreparedTopologyParityCollection2091(tb, shape.dims, shape.degree, cloneColumnVectorGraphTopologyParityRows2091(rows))
+	default:
+		tb.Fatalf("unsupported promotion mode %q", mode)
+	}
+	searcher, err := col.OpenVectorIndexSearcher(VectorIndexSearcherOptions{IndexName: def.Name, MaxDecodedBlocks: 1})
+	if err != nil {
+		_ = d.Close()
+		tb.Fatalf("OpenVectorIndexSearcher mode=%s: %v", mode, err)
+	}
+	if mode == columnVectorGraphSearchTopologyParityModeCurrentPrepared2091 {
+		if searcher.reader == nil || searcher.reader.preparedSearch == nil || !searcher.reader.preparedSearch.ready() {
+			_ = searcher.Close()
+			_ = d.Close()
+			tb.Fatalf("current prepared public searcher preparedSearch=%v ready=%v", searcher.reader != nil && searcher.reader.preparedSearch != nil, searcher.reader != nil && searcher.reader.preparedSearch != nil && searcher.reader.preparedSearch.ready())
+		}
+		if stats := searcher.reader.Stats(); stats.Rows != 0 {
+			_ = searcher.Close()
+			_ = d.Close()
+			tb.Fatalf("current prepared public searcher graph rows=%d want 0", stats.Rows)
+		}
+	}
+	query := append([]float32(nil), rows[shape.queryOrdinal].Vector...)
+	return func() { _ = searcher.Close(); _ = d.Close() }, searcher, query
+}
+
+func vectorIndexSearchPromotionOptions2105(shape columnVectorGraphSearchTopologyParityShape2091, boundary vectorIndexSearchPromotionBoundary2105, scoreMode columnVectorGraphScoreBatchMode) VectorIndexSearcherSearchOptions {
+	opts := VectorIndexSearcherSearchOptions{
+		Query:          nil,
+		TopK:           shape.topK,
+		EfSearch:       shape.efSearch,
+		StatsMode:      VectorIndexSearchStatsModeBenchmarkDebug,
+		scoreBatchMode: scoreMode,
+	}
+	if boundary == vectorIndexSearchPromotionBoundaryDocumentMaterialization2105 {
+		opts.IncludeDocuments = true
+	}
+	return opts
+}
+
+func searchVectorIndexSearcherPromotion2105(tb testing.TB, searcher *VectorIndexSearcher, query []float32, shape columnVectorGraphSearchTopologyParityShape2091, boundary vectorIndexSearchPromotionBoundary2105, mode columnVectorGraphScoreBatchMode) ([]VectorIndexSearchResult, VectorIndexSearchStats) {
+	tb.Helper()
+	opts := vectorIndexSearchPromotionOptions2105(shape, boundary, mode)
+	opts.Query = query
+	response, err := searcher.Search(opts)
+	if err != nil {
+		tb.Fatalf("Search boundary=%s score mode=%s: %v", boundary, mode.String(), err)
+	}
+	if len(response.Results) == 0 {
+		tb.Fatalf("Search boundary=%s score mode=%s returned no results", boundary, mode.String())
+	}
+	assertVectorIndexSearchBenchmarkDebugStats2105(tb, response.Stats, shape.efSearch >= shape.rows)
+	return cloneVectorIndexSearchResults1969(response.Results), response.Stats
+}
+
+func assertVectorIndexSearchPromotionDocumentsEqual2105(tb testing.TB, got, want []VectorIndexSearchResult) {
+	tb.Helper()
+	if len(got) != len(want) {
+		tb.Fatalf("document results len=%d want %d", len(got), len(want))
+	}
+	for i := range want {
+		if len(got[i].Document) == 0 || len(want[i].Document) == 0 {
+			tb.Fatalf("document result[%d] empty got=%d want=%d", i, len(got[i].Document), len(want[i].Document))
+		}
+		if !bytes.Equal(got[i].Document, want[i].Document) {
+			tb.Fatalf("document result[%d] mismatch got=%q want=%q", i, string(got[i].Document), string(want[i].Document))
+		}
+	}
+}
+
+func reportVectorIndexSearchPromotionLabels2105(b *testing.B, searchName string, shape columnVectorGraphSearchTopologyParityShape2091, boundary vectorIndexSearchPromotionBoundary2105, row vectorIndexSearchPromotionRow2105) {
+	b.Helper()
+	b.ReportMetric(2105, "promotion_public_issue")
+	b.ReportMetric(1, "promotion_public_search_"+searchName)
+	b.ReportMetric(1, "promotion_public_mode_"+string(row.mode))
+	b.ReportMetric(1, "promotion_public_boundary_"+string(boundary))
+	b.ReportMetric(1, "promotion_public_score_mode_"+row.scoreName)
+	b.ReportMetric(float64(shape.rows), "rows")
+	b.ReportMetric(float64(shape.dims), "dims")
+	b.ReportMetric(float64(shape.degree), "degree")
+	b.ReportMetric(float64(shape.topK), "top_k")
+	b.ReportMetric(float64(shape.efSearch), "ef_search")
+	b.ReportMetric(float64(shape.queryOrdinal), "query_ordinal")
+}
+
+func assertVectorIndexSearchPromotionModeStats2105(tb testing.TB, boundary vectorIndexSearchPromotionBoundary2105, mode columnVectorGraphSearchTopologyParityMode2091, stats VectorIndexSearchStats) {
+	tb.Helper()
+	switch mode {
+	case columnVectorGraphSearchTopologyParityModeLegacyGraphRowDirect2091:
+		assertVectorIndexSearchPromotionLegacyStats2105(tb, stats)
+	case columnVectorGraphSearchTopologyParityModeCurrentPrepared2091:
+		assertVectorIndexSearchPromotionCurrentStats2105(tb, boundary, stats)
+	default:
+		tb.Fatalf("unsupported promotion mode %q", mode)
+	}
+}
+
+func assertVectorIndexSearchPromotionCurrentStats2105(tb testing.TB, boundary vectorIndexSearchPromotionBoundary2105, stats VectorIndexSearchStats) {
+	tb.Helper()
+	if stats.GraphRows != 0 || stats.PreparedGraphSearchViews != 1 || stats.GraphRowFallbacks != 0 || stats.TypedColumnFallbacks != 0 || stats.VectorScratchDecodes != 0 || stats.NormScratchDecodes != 0 || stats.ResultIDGraphFallbacks != 0 {
+		tb.Fatalf("current public %s stats=%+v want prepared current-format path without graph rows/fallback", boundary, stats)
+	}
+	if stats.PreparedScoreCalls != stats.CandidateFetches || stats.VectorPreparedDirectViews != stats.CandidateFetches || stats.NormPreparedDirectViews != stats.CandidateFetches {
+		tb.Fatalf("current public %s stats=%+v want prepared scoring to cover all candidates", boundary, stats)
+	}
+	if stats.AdjacencyLegacyFallbacks != 0 || stats.AdjacencyPreparedCSRMmapDirectViews == 0 || stats.AdjacencySourceFallbacks != 0 || stats.RowRefVectorSourceLegacyGraphIDs != 0 || stats.RowRefStateSourceFallbacks != 0 {
+		tb.Fatalf("current public %s stats=%+v want prepared adjacency/result sources with no fallback", boundary, stats)
+	}
+	if stats.ResultFetches == 0 || stats.ResultIDPreparedBytesViews != 1 || stats.ResultIDTypedBytesState != stats.ResultFetches || stats.RowRefStateResultRefs != stats.ResultFetches {
+		tb.Fatalf("current public %s stats=%+v want public result-ID and row-ref materialization", boundary, stats)
+	}
+	if boundary == vectorIndexSearchPromotionBoundaryDocumentMaterialization2105 {
+		if stats.DocumentsFetched != stats.ResultFetches || stats.DocumentRowRefStateFetches != stats.ResultFetches || stats.DocumentRowRefLookupFallbacks != 0 {
+			tb.Fatalf("current public document stats=%+v want post-top-k row-ref document materialization", stats)
+		}
+	} else if stats.DocumentsFetched != 0 || stats.DocumentBytes != 0 {
+		tb.Fatalf("current public result-ID stats=%+v want no document materialization", stats)
+	}
+}
+
+func assertVectorIndexSearchPromotionLegacyStats2105(tb testing.TB, stats VectorIndexSearchStats) {
+	tb.Helper()
+	if stats.GraphRows == 0 || stats.PreparedGraphSearchViews != 0 || stats.GraphRowFallbacks == 0 || stats.TypedColumnFallbacks == 0 || stats.VectorScratchDecodes == 0 {
+		tb.Fatalf("legacy public stats=%+v want graph-row/direct compatibility path", stats)
+	}
+	if stats.ResultFetches == 0 || stats.ResultIDGraphFallbacks != stats.ResultFetches {
+		tb.Fatalf("legacy public stats=%+v want graph-row result-ID fallback for each result", stats)
+	}
+	if stats.AdjacencyLegacyFallbacks != 0 || stats.AdjacencyPreparedCSRMmapDirectViews == 0 || stats.AdjacencySourceFallbacks != 0 {
+		tb.Fatalf("legacy public stats=%+v want shared prepared-CSR adjacency without source fallback", stats)
+	}
+}
+
+func assertVectorIndexSearchDefaultIndexedScoreBatches2105(tb testing.TB, defaultStats, indexedStats, scalarStats VectorIndexSearchStats) {
+	tb.Helper()
+	if defaultStats.ScoreBatchCalls != indexedStats.ScoreBatchCalls || defaultStats.ScoreBatchCandidates != indexedStats.ScoreBatchCandidates || defaultStats.ScoreBatchMaxTileSize != indexedStats.ScoreBatchMaxTileSize {
+		tb.Fatalf("default stats=%+v indexed stats=%+v want default to select indexed prepared score batching", defaultStats, indexedStats)
+	}
+	if defaultStats.ScoreBatchCalls >= scalarStats.ScoreBatchCalls || defaultStats.ScoreBatchMaxTileSize < 2 {
+		tb.Fatalf("default stats=%+v scalar stats=%+v want default indexed grouping", defaultStats, scalarStats)
+	}
+	if defaultStats.ScoreBatchSingletons+defaultStats.ScoreBatchSize2To4+defaultStats.ScoreBatchSize5To8+defaultStats.ScoreBatchSize9To16+defaultStats.ScoreBatchSize17Plus != defaultStats.ScoreBatchCalls {
+		tb.Fatalf("default stats=%+v want score-batch histogram to reconcile", defaultStats)
+	}
+	if defaultStats.GraphRowFallbacks != 0 || defaultStats.TypedColumnFallbacks != 0 || defaultStats.VectorScratchDecodes != 0 || defaultStats.NormScratchDecodes != 0 || defaultStats.AdjacencySourceFallbacks != 0 || defaultStats.ResultIDGraphFallbacks != 0 {
+		tb.Fatalf("default stats=%+v want healthy prepared path without graph-row/source fallback", defaultStats)
+	}
+}
+
+func assertVectorIndexSearchScalarScoreBatches2105(tb testing.TB, stats VectorIndexSearchStats) {
+	tb.Helper()
+	if stats.ScoreBatchCalls == 0 || stats.ScoreBatchCalls != stats.ScoreBatchCandidates || stats.ScoreBatchMaxTileSize != 1 || stats.ScoreBatchSingletons != stats.ScoreBatchCalls {
+		tb.Fatalf("stats=%+v want scalar singleton score batches", stats)
+	}
+}
+
+func assertVectorIndexSearchPromotionScoreStats2105(tb testing.TB, mode columnVectorGraphSearchTopologyParityMode2091, scoreName string, stats VectorIndexSearchStats) {
+	tb.Helper()
+	if mode == columnVectorGraphSearchTopologyParityModeCurrentPrepared2091 && (scoreName == "default" || scoreName == "indexed") {
+		if stats.ScoreBatchCalls >= stats.ScoreBatchCandidates || stats.ScoreBatchMaxTileSize < 2 {
+			tb.Fatalf("mode=%s score=%s stats=%+v want grouped prepared indexed score batches", mode, scoreName, stats)
+		}
+		return
+	}
+	assertVectorIndexSearchScalarScoreBatches2105(tb, stats)
+}
+
+func assertVectorIndexSearchBenchmarkDebugStats2105(tb testing.TB, stats VectorIndexSearchStats, exactMode bool) {
+	tb.Helper()
+	if stats.BenchmarkDebugSearches != 1 {
+		tb.Fatalf("stats=%+v want one benchmark_debug search", stats)
+	}
+	if stats.VisitedEdges != stats.Edges || stats.UpperLayerEdgeVisits+stats.Layer0EdgeVisits != stats.VisitedEdges {
+		tb.Fatalf("stats=%+v want upper/layer-0 edge buckets to reconcile with visited_edges", stats)
+	}
+	if stats.UpperLayerScores+stats.Layer0Scores != stats.CandidateFetches || stats.ScoreBatchCandidates != stats.CandidateFetches {
+		tb.Fatalf("stats=%+v want score buckets to reconcile with candidate fetches", stats)
+	}
+	if stats.Layer0Scores != stats.Candidates {
+		tb.Fatalf("stats=%+v want layer-0 scores to equal candidate applications", stats)
+	}
+	if stats.Layer0ScoredNeighbors+stats.Layer0AlreadyVisitedSkips+stats.Layer0FilterSkips != stats.Layer0EdgeVisits {
+		tb.Fatalf("stats=%+v want layer-0 scored/skip buckets to reconcile", stats)
+	}
+	if stats.UpperLayerScoredNeighbors+stats.UpperLayerFilterSkips != stats.UpperLayerEdgeVisits {
+		tb.Fatalf("stats=%+v want upper-layer scored/filter buckets to reconcile", stats)
+	}
+	if stats.ScoredNeighbors+stats.SkippedNeighbors != stats.VisitedEdges {
+		tb.Fatalf("stats=%+v want scored+skipped neighbor buckets to reconcile", stats)
+	}
+	if stats.VisitedMarkHits+stats.VisitedMarkMisses != stats.VisitedMarkChecks || stats.VisitedMarkHits != stats.Layer0AlreadyVisitedSkips {
+		tb.Fatalf("stats=%+v want visited-mark hits/misses to reconcile", stats)
+	}
+	if stats.FrontierPushes != stats.Candidates || stats.TopKInsertAttempts != stats.Candidates || stats.TopKInsertSuccesses+stats.TopKInsertRejections != stats.TopKInsertAttempts {
+		tb.Fatalf("stats=%+v want frontier/top-k operation counts to reconcile with candidates", stats)
+	}
+	if stats.NeighborTileSize0+stats.NeighborTileSize1+stats.NeighborTileSize2To4+stats.NeighborTileSize5To8+stats.NeighborTileSize9To16+stats.NeighborTileSize17Plus != stats.NeighborTiles {
+		tb.Fatalf("stats=%+v want neighbor tile histogram to sum to neighbor_tiles", stats)
+	}
+	if stats.ScoreBatchSingletons+stats.ScoreBatchSize2To4+stats.ScoreBatchSize5To8+stats.ScoreBatchSize9To16+stats.ScoreBatchSize17Plus != stats.ScoreBatchCalls {
+		tb.Fatalf("stats=%+v want score batch histogram to sum to score_batch_calls", stats)
+	}
+	if exactMode {
+		if stats.ExactModeSearches != 1 || stats.ExactCandidateOrderObservations != stats.Candidates {
+			tb.Fatalf("stats=%+v want exact-mode candidate order observations for each candidate", stats)
+		}
+		return
+	}
+	if stats.ExactModeSearches != 0 || stats.ExactCandidateOrderObservations != 0 {
+		tb.Fatalf("stats=%+v want exact-mode counters disabled for bounded ef_search", stats)
+	}
+}
+
+func reportVectorIndexSearchBenchmarkDebugMetrics2105(b *testing.B, stats VectorIndexSearchStats) {
+	b.Helper()
+	b.ReportMetric(float64(stats.BenchmarkDebugSearches), "benchmark_debug_searches/search")
+	b.ReportMetric(float64(stats.NeighborTiles), "neighbor_tiles/search")
+	b.ReportMetric(float64(stats.NeighborTileNeighbors), "neighbor_tile_neighbors/search")
+	b.ReportMetric(float64(stats.NeighborTileMaxSize), "neighbor_tile_max_size")
+	if stats.NeighborTiles > 0 {
+		b.ReportMetric(float64(stats.NeighborTileNeighbors)/float64(stats.NeighborTiles), "neighbor_tile_avg_size")
+	}
+	b.ReportMetric(float64(stats.NeighborTileSize0), "neighbor_tile_size_0/search")
+	b.ReportMetric(float64(stats.NeighborTileSize1), "neighbor_tile_size_1/search")
+	b.ReportMetric(float64(stats.NeighborTileSize2To4), "neighbor_tile_size_2_4/search")
+	b.ReportMetric(float64(stats.NeighborTileSize5To8), "neighbor_tile_size_5_8/search")
+	b.ReportMetric(float64(stats.NeighborTileSize9To16), "neighbor_tile_size_9_16/search")
+	b.ReportMetric(float64(stats.NeighborTileSize17Plus), "neighbor_tile_size_17_plus/search")
+	b.ReportMetric(float64(stats.ScoreBatchSingletons), "score_batch_singletons/search")
+	b.ReportMetric(float64(stats.ScoreBatchSize2To4), "score_batch_size_2_4/search")
+	b.ReportMetric(float64(stats.ScoreBatchSize5To8), "score_batch_size_5_8/search")
+	b.ReportMetric(float64(stats.ScoreBatchSize9To16), "score_batch_size_9_16/search")
+	b.ReportMetric(float64(stats.ScoreBatchSize17Plus), "score_batch_size_17_plus/search")
+	b.ReportMetric(float64(stats.ScoredNeighbors), "scored_neighbors/search")
+	b.ReportMetric(float64(stats.SkippedNeighbors), "skipped_neighbors/search")
+	b.ReportMetric(float64(stats.AlreadyVisitedSkips), "already_visited_skips/search")
+	b.ReportMetric(float64(stats.FilterSkips), "filter_skips/search")
+	b.ReportMetric(float64(stats.UpperLayerScores), "upper_layer_scores/search")
+	b.ReportMetric(float64(stats.UpperLayerEntryScores), "upper_layer_entry_scores/search")
+	b.ReportMetric(float64(stats.UpperLayerNeighborScores), "upper_layer_neighbor_scores/search")
+	b.ReportMetric(float64(stats.UpperLayerEdgeVisits), "upper_layer_edge_visits/search")
+	b.ReportMetric(float64(stats.UpperLayerScoredNeighbors), "upper_layer_scored_neighbors/search")
+	b.ReportMetric(float64(stats.UpperLayerFilterSkips), "upper_layer_filter_skips/search")
+	b.ReportMetric(float64(stats.Layer0Scores), "layer0_scores/search")
+	b.ReportMetric(float64(stats.Layer0SeedScores), "layer0_seed_scores/search")
+	b.ReportMetric(float64(stats.Layer0NeighborScores), "layer0_neighbor_scores/search")
+	b.ReportMetric(float64(stats.Layer0EdgeVisits), "layer0_edge_visits/search")
+	b.ReportMetric(float64(stats.Layer0ScoredNeighbors), "layer0_scored_neighbors/search")
+	b.ReportMetric(float64(stats.Layer0AlreadyVisitedSkips), "layer0_already_visited_skips/search")
+	b.ReportMetric(float64(stats.Layer0FilterSkips), "layer0_filter_skips/search")
+	b.ReportMetric(float64(stats.FrontierPushes), "frontier_pushes/search")
+	b.ReportMetric(float64(stats.FrontierPops), "frontier_pops/search")
+	b.ReportMetric(float64(stats.FrontierPopMisses), "frontier_pop_misses/search")
+	b.ReportMetric(float64(stats.FrontierSiftUpSteps), "frontier_sift_up_steps/search")
+	b.ReportMetric(float64(stats.FrontierSiftDownSteps), "frontier_sift_down_steps/search")
+	b.ReportMetric(float64(stats.TopKInsertAttempts), "top_k_insert_attempts/search")
+	b.ReportMetric(float64(stats.TopKInsertSuccesses), "top_k_insert_successes/search")
+	b.ReportMetric(float64(stats.TopKInsertRejections), "top_k_insert_rejections/search")
+	b.ReportMetric(float64(stats.TopKShiftSteps), "top_k_shift_steps/search")
+	b.ReportMetric(float64(stats.VisitedMarkChecks), "visited_mark_checks/search")
+	b.ReportMetric(float64(stats.VisitedMarkHits), "visited_mark_hits/search")
+	b.ReportMetric(float64(stats.VisitedMarkMisses), "visited_mark_misses/search")
+	b.ReportMetric(float64(stats.ExactModeSearches), "exact_mode_searches/search")
+	b.ReportMetric(float64(stats.ExactCandidateOrderObservations), "exact_candidate_order_observations/search")
+	b.ReportMetric(float64(stats.ExactCandidateOrderTransitions), "exact_candidate_order_transitions/search")
+	b.ReportMetric(float64(stats.ExactCandidateOrderAdjacentForward), "exact_candidate_order_adjacent_forward/search")
+	b.ReportMetric(float64(stats.ExactCandidateOrderNonAdjacentForward), "exact_candidate_order_non_adjacent_forward/search")
+	b.ReportMetric(float64(stats.ExactCandidateOrderBackwardJumps), "exact_candidate_order_backward_jumps/search")
+	b.ReportMetric(float64(stats.ExactCandidateOrderMaxForwardRun), "exact_candidate_order_max_forward_run")
+	if stats.VisitedNodes > 0 {
+		b.ReportMetric(float64(stats.VisitedEdges)/float64(stats.VisitedNodes), "edges_per_visited_node")
+	}
+}
+
+func (b vectorIndexSearchPromotionBoundary2105) String() string { return string(b) }

--- a/TreeDB/collections/vector_index_search_promotion_2105_test.go
+++ b/TreeDB/collections/vector_index_search_promotion_2105_test.go
@@ -396,9 +396,11 @@ func reportVectorIndexSearchBenchmarkDebugMetrics2105(b *testing.B, stats Vector
 	b.ReportMetric(float64(stats.NeighborTiles), "neighbor_tiles/search")
 	b.ReportMetric(float64(stats.NeighborTileNeighbors), "neighbor_tile_neighbors/search")
 	b.ReportMetric(float64(stats.NeighborTileMaxSize), "neighbor_tile_max_size")
+	neighborTileAvg := 0.0
 	if stats.NeighborTiles > 0 {
-		b.ReportMetric(float64(stats.NeighborTileNeighbors)/float64(stats.NeighborTiles), "neighbor_tile_avg_size")
+		neighborTileAvg = float64(stats.NeighborTileNeighbors) / float64(stats.NeighborTiles)
 	}
+	b.ReportMetric(neighborTileAvg, "neighbor_tile_avg_size")
 	b.ReportMetric(float64(stats.NeighborTileSize0), "neighbor_tile_size_0/search")
 	b.ReportMetric(float64(stats.NeighborTileSize1), "neighbor_tile_size_1/search")
 	b.ReportMetric(float64(stats.NeighborTileSize2To4), "neighbor_tile_size_2_4/search")

--- a/TreeDB/collections/vector_index_search_test.go
+++ b/TreeDB/collections/vector_index_search_test.go
@@ -1654,6 +1654,10 @@ func BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderWithDocum
 }
 
 func benchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderV4(b *testing.B, includeDocuments bool, fetchOptions DocumentFetchOptions) {
+	benchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderWithStatsModeV4(b, includeDocuments, fetchOptions, VectorIndexSearchStatsModeDefault)
+}
+
+func benchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderWithStatsModeV4(b *testing.B, includeDocuments bool, fetchOptions DocumentFetchOptions, statsMode VectorIndexSearchStatsMode) {
 	b.Helper()
 	const (
 		rows     = 1024
@@ -1683,6 +1687,7 @@ func benchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderV4(b *tes
 		EfSearch:             efSearch,
 		IncludeDocuments:     includeDocuments,
 		DocumentFetchOptions: fetchOptions,
+		StatsMode:            statsMode,
 	}
 	if _, err := searcher.Search(opts); err != nil {
 		b.Fatalf("warm Search: %v", err)
@@ -1786,6 +1791,10 @@ func BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderParallelW
 }
 
 func benchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderParallelV4(b *testing.B, includeDocuments bool, fetchOptions DocumentFetchOptions) {
+	benchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderParallelWithStatsModeV4(b, includeDocuments, fetchOptions, VectorIndexSearchStatsModeDefault)
+}
+
+func benchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderParallelWithStatsModeV4(b *testing.B, includeDocuments bool, fetchOptions DocumentFetchOptions, statsMode VectorIndexSearchStatsMode) {
 	b.Helper()
 	const (
 		rows     = 1024
@@ -1816,6 +1825,7 @@ func benchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderParallelV
 		EfSearch:             efSearch,
 		IncludeDocuments:     includeDocuments,
 		DocumentFetchOptions: fetchOptions,
+		StatsMode:            statsMode,
 	}
 	type preparedWorker struct {
 		searcher *VectorIndexSearcher

--- a/TreeDB/collections/vector_index_search_test.go
+++ b/TreeDB/collections/vector_index_search_test.go
@@ -2085,7 +2085,7 @@ func reportVectorIndexSearchBenchMetricsV4(b *testing.B, n int, stats VectorInde
 	if stats.ScoreBatchCalls > 0 {
 		b.ReportMetric(float64(stats.ScoreBatchCandidates)/float64(stats.ScoreBatchCalls), "score_batch_avg_tile_size")
 	}
-	if stats.BenchmarkDebugSearches > 0 || stats.ExactModeSearches > 0 {
+	if stats.BenchmarkDebugSearches > 0 {
 		reportVectorIndexSearchBenchmarkDebugMetrics2105(b, stats)
 	}
 	b.ReportMetric(float64(stats.ExpansionFetches), "expansion_fetches/search")

--- a/TreeDB/collections/vector_index_search_test.go
+++ b/TreeDB/collections/vector_index_search_test.go
@@ -2085,6 +2085,9 @@ func reportVectorIndexSearchBenchMetricsV4(b *testing.B, n int, stats VectorInde
 	if stats.ScoreBatchCalls > 0 {
 		b.ReportMetric(float64(stats.ScoreBatchCandidates)/float64(stats.ScoreBatchCalls), "score_batch_avg_tile_size")
 	}
+	if stats.BenchmarkDebugSearches > 0 || stats.ExactModeSearches > 0 {
+		reportVectorIndexSearchBenchmarkDebugMetrics2105(b, stats)
+	}
 	b.ReportMetric(float64(stats.ExpansionFetches), "expansion_fetches/search")
 	b.ReportMetric(float64(stats.ResultFetches), "result_fetches/search")
 	b.ReportMetric(float64(stats.VectorDirectViews), "vector_direct_views/search")

--- a/TreeDB/docs/graph_search_benchmark_matrix_test.go
+++ b/TreeDB/docs/graph_search_benchmark_matrix_test.go
@@ -72,6 +72,15 @@ func TestDocs_GraphSearchBenchmarkTruthMatrix2037(t *testing.T) {
 		"eligible prepared typed-column path",
 		"legacy graph-row/direct compatibility",
 		"#2035 should remain open as the broader promotion tracker",
+		"#2105 public VectorIndexSearcher promotion matrix",
+		"BenchmarkVectorIndexSearcherSearchPromotion2105",
+		"TestColumnVectorGraphPublicVectorIndexSearcherSearchPromotion2105",
+		"Public result-ID response",
+		"document_materialization",
+		"exact",
+		"benchmark_debug_searches/search",
+		"exact_candidate_order_backward_jumps/search",
+		"legacy/direct `default` remains scalar",
 	}
 	for _, needle := range required {
 		if !strings.Contains(text, needle) {

--- a/TreeDB/docs/spec/typed-column-graph-search-benchmark-matrix.md
+++ b/TreeDB/docs/spec/typed-column-graph-search-benchmark-matrix.md
@@ -544,6 +544,133 @@ Decision for #2103 (promotion matrix):
   storage remain deferred/evidence-gated and are not prerequisites for this
   narrow default.
 
+## #2105 public VectorIndexSearcher promotion matrix
+
+`BenchmarkVectorIndexSearcherSearchPromotion2105` is the public-search follow-up
+to the #2103 internal `SearchCosine` promotion matrix. It uses the deterministic
+#2091 production topology-parity fixture (`rows=8192`, `dims=128`, degree 16,
+`topK=10`, bounded `efSearch=128`, exact `efSearch=8192`,
+`query_ordinal=4096`) and times an already-opened public
+`VectorIndexSearcher.Search` handle. Setup/open/rebuild are outside the timed
+search loop; `OpenVectorIndexSearcher` setup remains covered by the #2037
+`setup_open_prepare` boundary when that boundary is the measurement target.
+
+Command:
+
+```sh
+GOWORK=off go test ./TreeDB/collections \
+  -run '^$' \
+  -bench '^BenchmarkVectorIndexSearcherSearchPromotion2105$' \
+  -benchmem -benchtime=500ms -count=5
+```
+
+Smoke validation may use `-benchtime=1x -count=1`. Published comparisons should
+use one hardware/Go/GOMAXPROCS context and should keep the #2091 shape, query,
+`topK`, `efSearch`, and materialization boundary fixed within each table.
+
+Permanent rows:
+
+| Search | Boundary | Mode | Score mode | Fixture/materialization contract |
+| --- | --- | --- | --- | --- |
+| `ef_search_128` | `result_id` | `legacy_graph_row_direct` | `default` | Public result-ID response from the legacy/direct compatibility fixture; default must remain scalar. |
+| `ef_search_128` | `result_id` | `current_prepared_typed_column` | `default` | Public result-ID response from the prepared current-format fixture; default should select indexed/gathered scoring when eligible. |
+| `ef_search_128` | `result_id` | `current_prepared_typed_column` | `scalar` | Same public result-ID boundary and fixture, explicit scalar control. |
+| `ef_search_128` | `result_id` | `current_prepared_typed_column` | `indexed` | Same public result-ID boundary and fixture, explicit indexed/gathered control. |
+| `ef_search_128` | `document_materialization` | `current_prepared_typed_column` | `default` | Public response plus post-top-k document fetch/materialization; legacy is omitted because the physical-asset control fixture does not publish comparable base documents. |
+| `ef_search_128` | `document_materialization` | `current_prepared_typed_column` | `scalar` | Same document boundary, explicit scalar control. |
+| `ef_search_128` | `document_materialization` | `current_prepared_typed_column` | `indexed` | Same document boundary, explicit indexed/gathered control. |
+| `exact` | `result_id` | `legacy_graph_row_direct` | `default` | Public result-ID exact-mode control; default must remain scalar. |
+| `exact` | `result_id` | `current_prepared_typed_column` | `default` | Public result-ID exact-mode prepared default; default should select indexed/gathered scoring when eligible. |
+| `exact` | `result_id` | `current_prepared_typed_column` | `scalar` | Same exact public result-ID boundary, explicit scalar control. |
+| `exact` | `result_id` | `current_prepared_typed_column` | `indexed` | Same exact public result-ID boundary, explicit indexed/gathered control. |
+
+All #2105 rows run with `StatsMode=benchmark_debug` and emit the public metric
+labels from `reportVectorIndexSearchBenchMetricsV4`, including the #1979
+control-flow counters now exposed for public searcher benchmarks:
+`benchmark_debug_searches/search`, `neighbor_tile_avg_size`,
+`score_batch_singletons/search`, `score_batch_size_2_4/search`,
+`score_batch_size_5_8/search`, `score_batch_size_9_16/search`,
+`score_batch_size_17_plus/search`, `already_visited_skips/search`,
+`frontier_pushes/search`, `frontier_pops/search`,
+`top_k_insert_rejections/search`, `visited_mark_hits/search`,
+`visited_mark_misses/search`, `exact_candidate_order_observations/search`, and
+`exact_candidate_order_backward_jumps/search`. The regular public source and
+fallback labels still apply: healthy prepared rows must report
+`graph_rows=0`, `prepared_graph_search_views/search=1`,
+`graph_row_fallbacks/search=0`, `typed_column_vector_fallbacks/search=0`,
+`adjacency_source_fallbacks/search=0`, `result_id_graph_fallbacks/search=0`, and
+`row_ref_state_source_fallbacks/search=0`.
+
+Local #2105 evidence run:
+
+```sh
+OUT=/tmp/gomap_2105_public_matrix_rebased_20260531_190806
+GOMAXPROCS=8 GOWORK=off go test ./TreeDB/collections \
+  -run '^$' \
+  -bench '^BenchmarkVectorIndexSearcherSearchPromotion2105$' \
+  -benchmem -benchtime=1s -count=3 | tee "$OUT/public_promotion_2105_bench.txt"
+benchstat "$OUT/public_promotion_2105_bench.txt" > "$OUT/public_promotion_2105_benchstat.txt"
+```
+
+Run context: macOS 26.2, Apple M3, 8 logical CPUs, 16 GiB memory,
+`go version go1.25.5 darwin/arm64`. The tables below record medians from the
+three-count run. Raw artifacts contain every emitted counter; all rows below use
+`rows=8192`, `dims=128`, degree 16, `topK=10`, `query_ordinal=4096`, and
+`StatsMode=benchmark_debug`.
+
+Bounded public result-ID rows (`efSearch=128`, setup/open/rebuild excluded):
+
+| Mode | Score | ns/op | ops/sec | B/op | allocs/op | Work counters | Score/debug counters | Source/fallback counters |
+| --- | --- | ---: | ---: | ---: | ---: | --- | --- | --- |
+| `legacy_graph_row_direct` | `default` | 10.149 µs | 98,528 | 816 | 2 | `candidate_rows=8192`, `candidate_fetches=128`, `result_fetches=10`, `visited_edges=612`, `visited_mark_hits/misses=485/127` | scalar: `score_batch_calls=128`, max tile `1`, hist singleton `128`, exact obs/back `0/0` | `graph_rows=8192`, `graph_row_fallbacks=138`, `vector_scratch_decodes=128`, `typed_column_vector_fallbacks=1`, `result_id_graph_fallbacks=10`, `adjacency_source_fallbacks=0` |
+| `current_prepared_typed_column` | `default` | 8.870 µs | 112,734 | 816 | 2 | same fixed work: `candidate_fetches=128`, `result_fetches=10`, `visited_edges=612`, `visited_mark_hits/misses=485/127` | indexed/gathered: `score_batch_calls=25`, candidates `128`, max tile `16`, hist singleton/2-4/5-8/9-16 = `4/8/12/1`, exact obs/back `0/0` | `graph_rows=0`, `prepared_graph_search_views=1`, graph/vector/adjacency/result fallbacks `0`, vector/norm scratch decodes `0` |
+| `current_prepared_typed_column` | `scalar` | 11.440 µs | 87,414 | 816 | 2 | same fixed work | scalar: `score_batch_calls=128`, max tile `1`, hist singleton `128`, exact obs/back `0/0` | prepared path, all source/result fallbacks `0` |
+| `current_prepared_typed_column` | `indexed` | 8.473 µs | 118,027 | 816 | 2 | same fixed work | indexed/gathered: `score_batch_calls=25`, candidates `128`, max tile `16`, hist `4/8/12/1`, exact obs/back `0/0` | prepared path, all source/result fallbacks `0` |
+
+Bounded public document-materialization rows (`efSearch=128`, current prepared
+fixture only because the legacy physical-asset control does not publish
+comparable base documents):
+
+| Mode | Score | ns/op | ops/sec | B/op | allocs/op | Work/doc counters | Score/source counters |
+| --- | --- | ---: | ---: | ---: | ---: | --- | --- |
+| `current_prepared_typed_column` | `default` | 106.451 µs | 9,394 | 100,308 | 321 | `result_fetches=10`, `docs_fetched=10`, `doc_fetch_ns=108,042`, `visited_edges=612` | default indexed: `score_batch_calls=25`, hist `4/8/12/1`; prepared/source fallbacks `0` |
+| `current_prepared_typed_column` | `scalar` | 109.582 µs | 9,126 | 100,308 | 321 | `result_fetches=10`, `docs_fetched=10`, `doc_fetch_ns=108,667`, `visited_edges=612` | scalar: `score_batch_calls=128`, singleton hist `128`; prepared/source fallbacks `0` |
+| `current_prepared_typed_column` | `indexed` | 109.724 µs | 9,114 | 100,308 | 321 | `result_fetches=10`, `docs_fetched=10`, `doc_fetch_ns=109,500`, `visited_edges=612` | indexed: `score_batch_calls=25`, hist `4/8/12/1`; prepared/source fallbacks `0` |
+
+Exact public result-ID rows (`efSearch=8192`, setup/open/rebuild excluded):
+
+| Mode | Score | ns/op | ops/sec | B/op | allocs/op | Exact/work counters | Score/debug counters | Source/fallback counters |
+| --- | --- | ---: | ---: | ---: | ---: | --- | --- | --- |
+| `legacy_graph_row_direct` | `default` | 1.053 ms | 949.3 | 816 | 2 | `candidate_fetches=8192`, `result_fetches=10`, `visited_edges=100748`, `visited_mark_hits/misses=92557/8191`, exact obs/back `8192/5977` | scalar: `score_batch_calls=8192`, singleton hist `8192`, max tile `1` | `graph_rows=8192`, `graph_row_fallbacks=8202`, `vector_scratch_decodes=8192`, `typed_column_vector_fallbacks=1`, `result_id_graph_fallbacks=10`, `adjacency_source_fallbacks=0` |
+| `current_prepared_typed_column` | `default` | 919.201 µs | 1,088 | 816 | 2 | same exact work: `candidate_fetches=8192`, `result_fetches=10`, `visited_edges=100748`, exact obs/back `8192/5977` | indexed/gathered: `score_batch_calls=1797`, candidates `8192`, max tile `16`, hist singleton/2-4/5-8/9-16 = `364/502/930/1` | `graph_rows=0`, `prepared_graph_search_views=1`, graph/vector/adjacency/result fallbacks `0`, vector/norm scratch decodes `0` |
+| `current_prepared_typed_column` | `scalar` | 1.084 ms | 922.9 | 816 | 2 | same exact work | scalar: `score_batch_calls=8192`, singleton hist `8192`, exact obs/back `8192/5977` | prepared path, all source/result fallbacks `0` |
+| `current_prepared_typed_column` | `indexed` | 929.601 µs | 1,076 | 816 | 2 | same exact work | indexed/gathered: `score_batch_calls=1797`, hist `364/502/930/1`, exact obs/back `8192/5977` | prepared path, all source/result fallbacks `0` |
+
+#2105 decision: recommend closing #2035 as performance-satisfied. On the public
+larger topology-parity matrix, prepared `default` is faster than the valid
+legacy/direct public result-ID controls in bounded and exact rows, tracks the
+explicit indexed/gathered counter shape, remains equivalent to scalar/indexed
+results in the focused public test, and keeps healthy prepared fallback counters
+at zero. The document-materialization boundary is dominated by post-top-k
+fetch/reconstruction work; prepared `default` remains competitive while preserving
+the same search work and document counters. No narrow performance follow-up is
+needed from this matrix. #1981 wavefront traversal and #1977 normalized-vector
+storage remain separate deferred experiments, not blockers to #2035 closeout.
+
+`TestColumnVectorGraphPublicVectorIndexSearcherSearchPromotion2105` is the
+focused correctness/admission gate. It uses the exact #2091 test fixture to prove
+that public prepared `default`, `scalar`, and `indexed` rows return equivalent
+result IDs/order/scores at both public result-ID and document-materialization
+boundaries. It also asserts that prepared `default` follows indexed score-batch
+counters, explicit scalar uses singleton batches, healthy prepared
+fallback/source counters remain zero, and legacy/direct `default` remains scalar
+at the public result-ID boundary.
+
+This #2105 harness and evidence are docs/tests/benchmarks only. They must not
+change traversal semantics, frontier behavior, candidate/tie/result ordering,
+`efSearch`, `topK`, fixture topology, public response ownership, or persistent
+formats.
+
 ## Interpretation rules
 
 - `combined_prepared_typed_column` rows are #2045 prepared-routing evidence;

--- a/TreeDB/docs/spec/typed-column-graph-search-benchmark-matrix.md
+++ b/TreeDB/docs/spec/typed-column-graph-search-benchmark-matrix.md
@@ -547,8 +547,8 @@ Decision for #2103 (promotion matrix):
 ## #2105 public VectorIndexSearcher promotion matrix
 
 `BenchmarkVectorIndexSearcherSearchPromotion2105` is the public-search follow-up
-to the #2103 internal `SearchCosine` promotion matrix. It uses the deterministic
-#2091 production topology-parity fixture (`rows=8192`, `dims=128`, degree 16,
+to the #2103 internal `SearchCosine` promotion matrix. It uses the deterministic #2091
+production topology-parity fixture (`rows=8192`, `dims=128`, degree 16,
 `topK=10`, bounded `efSearch=128`, exact `efSearch=8192`,
 `query_ordinal=4096`) and times an already-opened public
 `VectorIndexSearcher.Search` handle. Setup/open/rebuild are outside the timed
@@ -646,7 +646,7 @@ Exact public result-ID rows (`efSearch=8192`, setup/open/rebuild excluded):
 | `current_prepared_typed_column` | `scalar` | 1.084 ms | 922.9 | 816 | 2 | same exact work | scalar: `score_batch_calls=8192`, singleton hist `8192`, exact obs/back `8192/5977` | prepared path, all source/result fallbacks `0` |
 | `current_prepared_typed_column` | `indexed` | 929.601 µs | 1,076 | 816 | 2 | same exact work | indexed/gathered: `score_batch_calls=1797`, hist `364/502/930/1`, exact obs/back `8192/5977` | prepared path, all source/result fallbacks `0` |
 
-#2105 decision: recommend closing #2035 as performance-satisfied. On the public
+Decision for #2105: recommend closing #2035 as performance-satisfied. On the public
 larger topology-parity matrix, prepared `default` is faster than the valid
 legacy/direct public result-ID controls in bounded and exact rows, tracks the
 explicit indexed/gathered counter shape, remains equivalent to scalar/indexed


### PR DESCRIPTION
## Objective

Add a public `VectorIndexSearcher.Search` promotion benchmark and correctness gate for the #2105 public-search follow-up to the #2103 internal `SearchCosine` promotion matrix, record the resulting #2035 performance recommendation in the benchmark-matrix spec, and keep the #2037 truth-matrix metric contract honest by ensuring the public truth-matrix rows actually emit the required `benchmark_debug` labels.

## Context

#2035 tracks whether prepared typed-column graph search is ready for production promotion. #2103 established the internal `SearchCosine` boundary. This PR closes the loop at the public `VectorIndexSearcher.Search` boundary using the deterministic #2091 topology-parity fixture, provides the final performance evidence needed to recommend closing #2035, and incorporates review follow-up so the truth-matrix public result-ID/document-materialization rows run with the same benchmark-debug telemetry required by the expanded #2037 metric contract.

## Non-goals

- No changes to traversal semantics, candidate/tie/result ordering, `efSearch`, `topK`, recall behavior, public response ownership, or persistent formats.
- Legacy/direct document-materialization control is intentionally omitted (the physical-asset compatibility fixture does not publish comparable base documents).
- #1981 wavefront traversal and #1977 normalized-vector storage are explicitly deferred and are not prerequisites.

## Design

- `BenchmarkVectorIndexSearcherSearchPromotion2105`: public benchmark measuring an already-opened `VectorIndexSearcher.Search` handle across legacy/direct and current-prepared modes, bounded (`efSearch=128`) and exact (`efSearch=8192`) result-ID boundaries, and document-materialization boundary. Setup/open/rebuild are outside the timed loop.
- `TestColumnVectorGraphPublicVectorIndexSearcherSearchPromotion2105`: focused correctness gate asserting result-ID/order/score equivalence across `default`/`scalar`/`indexed` score modes at both public boundaries, and asserting legacy `default` remains scalar.
- `reportVectorIndexSearchBenchmarkDebugMetrics2105`: extends `reportVectorIndexSearchBenchMetricsV4` to emit ~50 `benchmark_debug` counters (score-batch histograms, neighbor-tile histograms, visited/frontier/top-k/mark/exact-order counters) when `BenchmarkDebugSearches > 0`. Existing non-debug benchmark callers are unaffected. `neighbor_tile_avg_size` is always reported (0 when no tiles observed) so the metric label set is unconditionally stable.
- `vectorGraphSearchTruthMatrixRequiredMetricLabels2037` extended with the new required metric label set; `TestVectorGraphSearchTruthMatrixMetricContract2037` extended with three new required keys; the public truth-matrix result-ID/document-materialization rows now opt into `benchmark_debug` stats mode so the required labels are actually emitted.
- `benchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderWithStatsModeV4` and `benchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderParallelWithStatsModeV4` preserve the existing default benchmark helpers while allowing the truth-matrix path to thread an explicit public `StatsMode` override without changing ordinary public benchmark behavior.
- `scoreBatchMode` comment in `VectorIndexSearcherSearchOptions` updated to accurately describe the runtime-default behavior (eligible prepared views may use indexed/gathered scoring; legacy/non-prepared/fallback routes remain scalar).
- Invariants: counter-reconciliation assertions in `assertVectorIndexSearchBenchmarkDebugStats2105` cover every bucket pair (edges, scores, marks, frontier, top-k, histograms, exact-mode). Prepared-path assertions enforce `GraphRows=0`, `PreparedGraphSearchViews=1`, and all fallback counters at zero. Truth-matrix row names now encode `/stats=benchmark_debug` wherever the public rows require benchmark-debug-only labels.

## Scope

- Includes (files/symbols):
  - `TreeDB/collections/vector_index_search_promotion_2105_test.go` (new)
  - `TreeDB/collections/vector_graph_search_truth_matrix_2037_test.go` (required label extensions plus benchmark-debug public truth-matrix row wiring)
  - `TreeDB/collections/vector_index_search_test.go` (conditional debug metric delegation plus public benchmark helper stats-mode overrides)
  - `TreeDB/collections/vector_index_search.go` (comment update only)
  - `TreeDB/docs/graph_search_benchmark_matrix_test.go` (doc-lint needle extensions)
  - `TreeDB/docs/spec/typed-column-graph-search-benchmark-matrix.md` (#2105 section)
- Excludes (files/symbols):
  - all traversal, scoring, adjacency, and persistent-format code
  - `OpenVectorIndexSearcher` setup path behavior
  - #2037 `setup_open_prepare` boundary behavior
  - any production default `StatsMode` change for existing public benchmarks outside the truth-matrix override path

## Correctness

- Tests run (exact commands):

```sh
GOWORK=off go test ./TreeDB/collections \
  -run 'TestColumnVectorGraphPublicVectorIndexSearcherSearchPromotion2105|TestColumnVectorGraphPreparedDefaultIndexedScoring2103|TestColumnVectorGraphSearchTopologyParity2091|TestColumnVectorGraphNativeSearchBenchmarkDebugCounters1979|TestVectorGraphSearchTruthMatrixMetricContract2037' \
  -count=1

GOWORK=off go test ./TreeDB/docs \
  -run 'TestDocs_GraphSearchBenchmarkTruthMatrix2037' \
  -count=1

GOWORK=off go test ./TreeDB/collections ./TreeDB/docs -count=1

GOWORK=off go test ./TreeDB/collections \
  -run 'TestColumnVectorGraphPublicVectorIndexSearcherSearchPromotion2105|TestVectorGraphSearchTruthMatrixMetricContract2037|TestVectorGraphSearchTruthMatrixRows2037' \
  -count=1

GOWORK=off go test ./TreeDB/docs \
  -run 'TestDocs_GraphSearchBenchmarkTruthMatrix2037' \
  -count=1

GOWORK=off go test ./TreeDB/collections \
  -run '^$' \
  -bench '^BenchmarkColumnVectorGraphSearchTruthMatrix2037/mode=current_tvis_base_typed_column/boundary=result_id/concurrency=serial/fixture=serving1024/stats=benchmark_debug$' \
  -benchmem -benchtime=1x -count=1

git diff --check
```

All passed on latest head `cb6ea14`.

- Corruption/edge cases covered: `assertVectorIndexSearchBenchmarkDebugStats2105` reconciles every counter pair and bucket sum; `assertVectorIndexSearchPromotionCurrentStats2105` separately checks `document_materialization` vs `result_id` boundary counter expectations; `openVectorIndexSearcherPromotion2105` asserts `preparedSearch.ready()` and `stats.Rows == 0` before returning the prepared searcher; the truth-matrix benchmark smoke now verifies that a public result-ID row with `/stats=benchmark_debug` emits the required benchmark-debug labels instead of silently missing them.
- Concurrency/race coverage (if applicable): no new concurrency; existing race coverage unchanged. Parallel truth-matrix public rows reuse the same prepared-searcher worker model with only a stats-mode override.

## Performance

- Benchmarks run (exact commands):

```sh
OUT=/tmp/gomap_2105_public_matrix_rebased_20260531_190806
GOMAXPROCS=8 GOWORK=off go test ./TreeDB/collections \
  -run '^$' \
  -bench '^BenchmarkVectorIndexSearcherSearchPromotion2105$' \
  -benchmem -benchtime=1s -count=3 | tee "$OUT/public_promotion_2105_bench.txt"
benchstat "$OUT/public_promotion_2105_bench.txt" > "$OUT/public_promotion_2105_benchstat.txt"

GOWORK=off go test ./TreeDB/collections \
  -run '^$' \
  -bench '^BenchmarkColumnVectorGraphSearchTruthMatrix2037/mode=current_tvis_base_typed_column/boundary=result_id/concurrency=serial/fixture=serving1024/stats=benchmark_debug$' \
  -benchmem -benchtime=1x -count=1
```

Run context for the promotion matrix: macOS 26.2, Apple M3, 8 logical CPUs, 16 GiB memory, `go version go1.25.5 darwin/arm64`. Tables report medians. Setup/open/rebuild are outside the timed loop.

### Bounded public result-ID (`efSearch=128`)

| Mode | Score | ns/op | ops/sec | B/op | allocs/op | Work counters | Score/debug counters | Source/fallback counters |
| --- | --- | ---: | ---: | ---: | ---: | --- | --- | --- |
| legacy/direct | default | 10.149 µs | 98,528 | 816 | 2 | `candidate_rows=8192`, `candidate_fetches=128`, `result_fetches=10`, `visited_edges=612`, marks `485/127` | scalar `score_batch_calls=128`, max tile `1`, exact `0/0` | `graph_rows=8192`, `graph_row_fallbacks=138`, `vector_scratch_decodes=128`, `typed_column_vector_fallbacks=1`, `result_id_graph_fallbacks=10`, `adjacency_source_fallbacks=0` |
| prepared | default | 8.870 µs | 112,734 | 816 | 2 | same fixed work | indexed `score_batch_calls=25`, candidates `128`, max tile `16`, hist `4/8/12/1`, exact `0/0` | `graph_rows=0`, `prepared_graph_search_views=1`, graph/vector/adjacency/result fallbacks `0`, vector/norm scratch decodes `0` |
| prepared | scalar | 11.440 µs | 87,414 | 816 | 2 | same fixed work | scalar `score_batch_calls=128`, max tile `1` | prepared path, source/result fallbacks `0` |
| prepared | indexed | 8.473 µs | 118,027 | 816 | 2 | same fixed work | indexed `score_batch_calls=25`, hist `4/8/12/1` | prepared path, source/result fallbacks `0` |

### Public document materialization (`efSearch=128`, current prepared fixture)

| Score | ns/op | ops/sec | B/op | allocs/op | Work/doc counters | Score/source counters |
| --- | ---: | ---: | ---: | ---: | --- | --- |
| default | 106.451 µs | 9,394 | 100,308 | 321 | `result_fetches=10`, `docs_fetched=10`, `doc_fetch_ns=108,042`, `visited_edges=612` | default indexed `score_batch_calls=25`, hist `4/8/12/1`; prepared/source fallbacks `0` |
| scalar | 109.582 µs | 9,126 | 100,308 | 321 | `result_fetches=10`, `docs_fetched=10`, `doc_fetch_ns=108,667`, `visited_edges=612` | scalar `score_batch_calls=128`; prepared/source fallbacks `0` |
| indexed | 109.724 µs | 9,114 | 100,308 | 321 | `result_fetches=10`, `docs_fetched=10`, `doc_fetch_ns=109,500`, `visited_edges=612` | indexed `score_batch_calls=25`, hist `4/8/12/1`; prepared/source fallbacks `0` |

Legacy/direct document materialization is omitted because the physical-asset compatibility fixture does not publish comparable base documents.

### Exact public result-ID (`efSearch=8192`)

| Mode | Score | ns/op | ops/sec | B/op | allocs/op | Exact/work counters | Score/debug counters | Source/fallback counters |
| --- | --- | ---: | ---: | ---: | ---: | --- | --- | --- |
| legacy/direct | default | 1.053 ms | 949.3 | 816 | 2 | `candidate_fetches=8192`, `result_fetches=10`, `visited_edges=100748`, marks `92557/8191`, exact obs/back `8192/5977` | scalar `score_batch_calls=8192`, max tile `1` | `graph_rows=8192`, `graph_row_fallbacks=8202`, `vector_scratch_decodes=8192`, `typed_column_vector_fallbacks=1`, `result_id_graph_fallbacks=10`, `adjacency_source_fallbacks=0` |
| prepared | default | 919.201 µs | 1,088 | 816 | 2 | same exact work | indexed `score_batch_calls=1797`, candidates `8192`, max tile `16`, hist `364/502/930/1` | `graph_rows=0`, `prepared_graph_search_views=1`, graph/vector/adjacency/result fallbacks `0`, vector/norm scratch decodes `0` |
| prepared | scalar | 1.084 ms | 922.9 | 816 | 2 | same exact work | scalar `score_batch_calls=8192`, exact obs/back `8192/5977` | prepared path, source/result fallbacks `0` |
| prepared | indexed | 929.601 µs | 1,076 | 816 | 2 | same exact work | indexed `score_batch_calls=1797`, hist `364/502/930/1`, exact obs/back `8192/5977` | prepared path, source/result fallbacks `0` |

- Results table (before/after; median-of-5 per G1 in `docs/OPT_SPRINT_NEXT.md`): the promotion benchmark matrix above remains the primary evidence. The follow-up truth-matrix smoke is contract-validation only and confirms the public `/stats=benchmark_debug` row now reports the required debug labels (`benchmark_debug_searches/search`, neighbor-tile histogram labels, and exact-order labels); it is not used as a performance before/after table.
- Regressions (if any) and why acceptable: none. Changes are benchmark/test/docs evidence plus a stale internal comment update and truth-matrix test-helper wiring. Prepared `default` is faster than valid legacy/direct controls for bounded and exact result-ID, tracks the explicit indexed/gathered counter shape, remains competitive at document materialization where post-top-k fetch dominates, and keeps healthy prepared fallback counters at zero.

## Rollout / Toggle Plan

- Default setting: no behavior change; `scoreBatchMode` zero value behavior is unchanged (comment clarified only). Existing public benchmark helpers still default to their previous stats behavior; only the truth-matrix path opts into `benchmark_debug`.
- How to disable quickly: not applicable; PR contains no feature toggles.

## Follow-ups

- Recommend closing #2035 as performance-satisfied after this PR merges.
- #1981 wavefront traversal and #1977 normalized-vector storage remain separate deferred experiments, not blockers.
- If future truth-matrix rows require benchmark-debug-only labels, continue to encode the stats-mode requirement in the row definition/name instead of broadening default public benchmark behavior.

## Column Graph Native Workstream (#1646, if applicable)

### Copied/Adapted From Old Stack

- Copied: n/a
- Adapted: n/a
- Oracle/comparator only: n/a
- Quarantined/not copied: n/a

### Path Identity

- Native reader: public `VectorIndexSearcher.Search` (prepared and legacy/direct paths)
- Decoded comparator: n/a
- Legacy/native vector index: both exercised via topology-parity fixture modes
- Unsupported/fail-closed: `openVectorIndexSearcherPromotion2105` fails closed if `preparedSearch` is not ready or graph rows ≠ 0 for the prepared mode; truth-matrix public benchmark rows now fail closed against the metric contract by requiring explicit `benchmark_debug` row configuration where debug-only labels are required.

### Base And Dependency State

- Base branch: `main`
- Base commit: `f57b33fc9`
- Base PR/head: synced with latest `origin/main` via merge commit `9b7f8cb7`, latest work on `cb6ea14`
- #1621/#1634 assumptions: unchanged
- Missing generic column-store primitives: none
- Parent review fixes propagated: Copilot review follow-ups from `9a01bc4` plus the latest truth-matrix benchmark-debug alignment review fix from `cb6ea14`

### Evidence

- Tests: `TestColumnVectorGraphPublicVectorIndexSearcherSearchPromotion2105` (correctness/admission gate), `TestVectorGraphSearchTruthMatrixMetricContract2037` (metric label contract), `TestVectorGraphSearchTruthMatrixRows2037` (truth-matrix row naming/shape contract), `TestDocs_GraphSearchBenchmarkTruthMatrix2037` (doc needle contract)
- Benchmarks: `BenchmarkVectorIndexSearcherSearchPromotion2105` (11 rows: bounded/exact result-ID and bounded document-materialization, legacy and prepared, all three score modes), plus a truth-matrix public benchmark smoke row verifying `/stats=benchmark_debug`
- Status/fallback proof: `assertVectorIndexSearchPromotionCurrentStats2105` enforces zero fallback counters and prepared-path shape for every prepared row; truth-matrix public rows now explicitly route through public `StatsMode=benchmark_debug` overrides when the required label set includes benchmark-debug-only metrics
- Performance attribution: prepared `default` 8.87 µs vs legacy `default` 10.15 µs (bounded), 919 µs vs 1,053 ms (exact); document-materialization dominated by post-top-k fetch
- Local regressions found/fixed: fixed a truth-matrix contract mismatch where public result-ID/document-materialization rows required benchmark-debug labels without actually enabling benchmark-debug stats

### Test Plan Start

- Milestone tasks targeted: #2105 public promotion matrix, #2035 closeout evidence
- Tests to add before or with implementation: `TestColumnVectorGraphPublicVectorIndexSearcherSearchPromotion2105`
- Existing tests to preserve: all `2091`/`2103`/`2037`/`1979` suites
- #1646 test-list changes made before implementation: none required

### Performance Plan Start

- Relevant benchmarks/metrics for this PR: `BenchmarkVectorIndexSearcherSearchPromotion2105`; truth-matrix metric-contract labels for `BenchmarkColumnVectorGraphSearchTruthMatrix2037`
- Baseline/comparator command or reason not applicable: legacy/direct `default` control rows in the same promotion benchmark; no separate before/after comparator needed for the truth-matrix follow-up because it is a contract-alignment smoke
- Expected setup/search/materialization boundary: `VectorIndexSearcher.Search` only; setup/open/rebuild excluded
- Upstream costs explicitly out of scope: `OpenVectorIndexSearcher` setup (#2037 boundary)
- Local performance risks to watch: none; PR contains no traversal changes

### Test Plan Close

- Additional tests found during implementation/review: `TestVectorGraphSearchTruthMatrixRows2037` became part of the relevant regression surface once public truth-matrix rows started carrying explicit `/stats=benchmark_debug` suffixes
- Tests added or changed: `vector_index_search_promotion_2105_test.go` (new), `vector_graph_search_truth_matrix_2037_test.go` (label extensions plus public truth-matrix benchmark-debug row wiring and row-name updates), `vector_index_search_test.go` (debug metric delegation plus public helper stats-mode overrides), `docs/graph_search_benchmark_matrix_test.go` (needle extensions)
- Failing tests fixed: none
- #1646 test-list changes made at close: none
- Residual untested gaps, if any: none known

### Performance Plan Close

- Benchmark commands run: see Performance section above
- Results summary with throughput/latency/allocations: prepared `default` remains 11–12% faster than legacy/direct for bounded result-ID and ~13% faster for exact result-ID at 816 B/op and 2 allocs/op; document-materialization remains dominated by post-top-k fetch. The truth-matrix public smoke now emits the required benchmark-debug labels at `31.169 µs/op`, 784 B/op, and 2 allocs/op for the sampled serial current-typed-column result-ID row.
- Before/after or baseline comparison: legacy/direct `default` rows serve as baseline controls within the same promotion benchmark; truth-matrix follow-up has no functional before/after beyond “missing required debug labels” vs “labels emitted under explicit benchmark_debug row configuration”
- Local slow/heavy code found and fixed: none
- Remaining upstream or deferred costs: #1981, #1977 (explicitly deferred)

### AI Review Loop

- Codex latest-head review: requested after the latest sync/follow-up
- Copilot latest-head review: completed on `cb6ea14` — truth-matrix public result-ID/document-materialization rows now run with `benchmark_debug` stats mode so the required debug labels are actually emitted
- CodeRabbit latest-head review: requested after the latest sync/follow-up
- Review comments/threads resolved or explicitly dismissed: both earlier Copilot inline threads resolved in `9a01bc4` (`neighbor_tile_avg_size` always reported; redundant `ExactModeSearches` condition removed); latest Copilot truth-matrix contract thread addressed in `cb6ea14` by routing public truth-matrix rows through explicit `StatsMode=benchmark_debug`
- Re-requested after final meaningful push: yes

---

## Optimization PR Checklist (TreeDB)

### Scope
- [x] Single, clear objective for this PR (not a bundle)
- [x] Explicit include list (files/symbols touched): see Scope section
- [x] Explicit exclude list (files/symbols NOT touched): see Scope section
- [x] No unwanted feature reintroduction (e.g. async slab writer, hard zones, ValueIndex) unless explicitly stated in the PR objective

### Safety / Correctness
- [x] Clear written-vs-durable semantics for any `*Sync` path touched — n/a, no sync paths touched
- [x] No new mmap usage on mutable/truncating files
- [x] All new length fields are capped before allocation (OOM-safe) — n/a, no new length fields
- [x] CRC/checksum behavior is fail-closed (clean error, no panic) — n/a, no format changes
- [x] Any concurrency change has a defined state machine and invariants — n/a, no concurrency changes

### Tests
- [x] Added deterministic regression tests for the targeted failure mode
- [x] Tests avoid sleeps where possible (use latches/hooks)
- [x] Added corruption/edge-case tests (truncation, bad headers, invalid lengths) when format/parsing changes — n/a, no format changes
- [x] Ran locally:
  - [x] `go test ./... -count=1` — not run; focused `TreeDB/collections` and `TreeDB/docs` validation plus benchmark smoke were used for this benchmark/test/docs-only PR
  - [x] Any targeted packages/benchmarks: see Correctness and Performance sections

### Benchmarks / Measurements
- [x] Added or updated a benchmark relevant to the change
- [x] Reported results in PR description (before/after, command, machine)
- [x] Included “incompressible” (worst-case) results if compression is involved — n/a

### Docs
- [x] Updated `docs/OPT_SPRINT_NEXT.md` milestone status (if applicable) — updated `typed-column-graph-search-benchmark-matrix.md` with #2105 section and #2035 recommendation
- [x] Documented any new config knobs + defaults — n/a
- [x] Called out any format change in PR description (pre-alpha OK) — no format changes

### Rollout / Toggle Plan (if behavior-affecting)
- [x] Safe defaults (feature off or conservative threshold) — no behavior change
- [x] Clear knobs to disable/revert behavior quickly — n/a
- [x] Observability: counters/logs to verify effectiveness — new `benchmark_debug` metric labels are documented and contract-tested, `neighbor_tile_avg_size` is unconditionally reported for stable tooling consumption, and truth-matrix public rows now explicitly opt into `benchmark_debug` where those labels are required

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added extensive tests and benchmarks validating public vector search promotion behavior across scoring modes and boundaries, extended benchmark matrices, and new telemetry/metric validations for detailed debug and promotion metrics.

* **Documentation**
  * Added a benchmark/spec for the VectorIndexSearcher promotion matrix (`#2105`) documenting test coverage, required metric labels, sample evidence runs, and correctness gates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
