### PR TITLE
Fail YCSB benchmark reports on operation errors

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -45,6 +45,7 @@ Behavioral guarantees for downstream systems (e.g., replication layers).
 
 - **[Benchmark Spec](BENCHMARK_SPEC.md)**: Methodology and test definitions.
 - **[TreeDB Canonical Benchmark Runbook](benchmarks/treedb_canonical_benchmark_runbook.md)**: Standard TreeDB engine, collections, Mongo gateway, profiling, and reporting workflows.
+- **[YCSB MongoDB / TreeDB Report](benchmarks/ycsb_mongodb_treedb_2026-05-31.md)**: Exact `go-ycsb` comparison for MongoDB, `treedb-native`, and TreeDB Mongo gateway.
 - **[TreeDB Collections Canonical Benchmark](benchmarks/collections_canonical_benchmark.md)**: Canonical TreeDB-vs-SQLite collection benchmark and maintenance-phase semantics.
 - **[Unified Bench](../cmd/unified_bench/README.md)**: Usage guide for benchmark execution and artifact capture.
 - **[BenchProf](../cmd/benchprof/README.md)**: Analysis tool for CPU/alloc/block/mutex profiles and ops/sec outputs.

--- a/docs/TREEDB_BENCHMARKING.md
+++ b/docs/TREEDB_BENCHMARKING.md
@@ -9,6 +9,7 @@ trace-based replays that approximate Celestia workloads.
 - **Trace summary replay:** `BenchmarkTraceReplay`
 - **Trace timeline replay (overlap-aware):** `BenchmarkTraceReplayTimeline`
 - **Memtable mode matrices:** `BenchmarkTraceReplayMemtableModes`, `BenchmarkTraceReplayTimelineMemtableModes`
+- **External YCSB comparison:** `scripts/ycsb_compare_mongodb_treedb.sh`, with the current report in `docs/benchmarks/ycsb_mongodb_treedb_2026-05-31.md`
 
 ## Common Principles
 
@@ -16,6 +17,29 @@ trace-based replays that approximate Celestia workloads.
 - Keep env and flags identical (journal, value log, compression, memtable settings).
 - Prefer multiple runs or `-count` to reduce noise.
 - Record inputs (trace file, summary, scaling, memtable mode) with results.
+
+## External YCSB Comparison
+
+Use this when comparing MongoDB, `treedb-native`, and the TreeDB Mongo gateway
+with the external `go-ycsb` client:
+
+```bash
+scripts/ycsb_compare_mongodb_treedb.sh
+```
+
+The script writes host metadata, raw `go-ycsb` output, exact commands,
+`summary.tsv`, and `summary.md` under `OUT_DIR`. Set `RUN_REPEATS=3` when
+investigating first-run versus steady-state behavior after a load phase.
+
+Any nonzero YCSB operation error counter such as `INSERT_ERROR`, `READ_ERROR`,
+or `UPDATE_ERROR` marks that phase invalid and makes the script exit nonzero by
+default. For exploratory parsing of known-bad artifacts, set
+`ALLOW_YCSB_ERRORS=true`; the generated summaries still show the invalid rows.
+Use `PARSE_ONLY=true OUT_DIR=/path/to/run` to regenerate summaries from saved
+raw `*.out` files without rerunning servers.
+
+The current captured report is
+`docs/benchmarks/ycsb_mongodb_treedb_2026-05-31.md`.
 
 ## 1) Unified Bench (Synthetic)
 

--- a/docs/benchmarks/ycsb_mongodb_treedb_2026-05-31.md
+++ b/docs/benchmarks/ycsb_mongodb_treedb_2026-05-31.md
@@ -1,0 +1,372 @@
+# YCSB MongoDB, TreeDB Native, and TreeDB Mongo Report
+
+This report captures the external `go-ycsb` workload used during the Mongo
+gateway throughput investigation. It compares:
+
+- MongoDB 8 through the `go-ycsb mongodb` binding.
+- `treedb-native` through the `go-ycsb treedb-native` binding.
+- TreeDB Mongo gateway through the `go-ycsb mongodb` binding.
+
+The goal is to document the exact benchmark shape, measured results, hardware
+context, and reproducibility commands. These are developer-machine results, not
+a formal product benchmark.
+
+## Benchmark Boundary
+
+Workload:
+
+- `recordcount=100000`
+- `operationcount=10000`
+- `threadcount=16`
+- `table=usertable`
+- request distribution: uniform, as emitted by `go-ycsb`
+- load phase: 100,000 inserts
+- run phase: 10,000 operations, observed as roughly 95% reads and 5% updates
+
+Storage and protocol boundary:
+
+- MongoDB used `mongo:8` in Docker with default server settings and `w=1`.
+- `treedb-native` used `./bin/treedb-native-server -profile fast`.
+- TreeDB Mongo gateway used `./bin/treedb-mongo-gateway -profile fast -document-format bson`.
+- All clients talked over local loopback TCP.
+- MongoDB ran in a Docker container published on `127.0.0.1:27018` with its
+  data directory bind-mounted under `/tmp`.
+- TreeDB servers ran as host processes.
+
+Important comparability note: TreeDB `fast` is a relaxed benchmark profile. It
+does not provide the same durability boundary as default MongoDB. These results
+compare the current benchmark shape and protocol paths, not equivalent
+production durability policies.
+
+## Host Context
+
+Captured on 2026-05-31 HST / 2026-06-01 UTC.
+
+```text
+host: mikers-B560-DS3H-AC-Y1
+kernel: Linux 6.8.0-111-generic x86_64
+go: go version go1.25.7 linux/amd64
+cpu: 11th Gen Intel(R) Core(TM) i5-11400F @ 2.60GHz
+logical CPUs: 12
+memory: 31GiB
+clocksource: tsc
+filesystem for /tmp: ext4 on /dev/nvme0n1p2
+primary disk: Samsung SSD 980 PRO with Heatsink 2TB
+free space during run: about 40G free on a 1.8T filesystem, 98% used
+```
+
+Source versions:
+
+```text
+gomap: f57b33fc92994727b2824194ba05cb0d64ebcac6
+       Merge pull request #2113 from snissn/codex/mongo-insert-coalescer-2109
+go-ycsb: 304788add5117f471def2e23a14f10ee46146285
+         close treedb-native handles on format mismatch
+MongoDB image: mongo:8
+MongoDB image id: sha256:690f1371c118a8389ecd6c82c9a7f0e37320732b1d56935a24b29dfca6933f54
+MongoDB image digest: mongo@sha256:7abfba0d07c9330373f8173981ea4d09cd8a82cdf0e86ccaf7008848d1d24f62
+```
+
+Primary artifact directories:
+
+```text
+MongoDB baseline: /tmp/mongodb_ycsb_compare_20260531_193813
+TreeDB native + TreeDB Mongo first comparison: /tmp/treedb_ycsb_post_coalesce_20260531_192612
+TreeDB Mongo repeated run check: /tmp/treedb_mongo_exact_rerun_20260531_193056
+TreeDB Mongo first-run reproduction: /tmp/treedb_mongo_first_run_repro_20260531_201950
+Mongo gateway load attribution: /tmp/treedb_mongo_ycsb_post_coalesce_attr_20260531_192632
+Mongo gateway run attribution: /tmp/treedb_mongo_ycsb_post_coalesce_run_attr_20260531_192751
+```
+
+## Reproduction Script
+
+The preferred reproduction entrypoint is:
+
+```sh
+scripts/ycsb_compare_mongodb_treedb.sh
+```
+
+Useful overrides:
+
+```sh
+RUN_REPEATS=3 \
+OUT_DIR=/tmp/treedb_ycsb_compare_repro \
+scripts/ycsb_compare_mongodb_treedb.sh
+```
+
+The script writes:
+
+- `host.txt`
+- `commands.txt`
+- `summary.tsv`
+- `summary.md`
+- per-target raw `go-ycsb` output
+- server logs and fresh DB directories
+
+The script treats nonzero YCSB operation error counters (`INSERT_ERROR`,
+`READ_ERROR`, `UPDATE_ERROR`, and other `*_ERROR` rows) as invalid benchmark
+evidence. It exits nonzero by default when such rows are present, annotates
+`summary.tsv`/`summary.md` with phase error counts, and supports
+`ALLOW_YCSB_ERRORS=true` only for exploratory parsing of known-bad artifacts.
+Use `PARSE_ONLY=true OUT_DIR=/path/to/run` to regenerate summaries from saved
+raw outputs.
+
+The script defaults to Docker MongoDB via `mongo:8`. To use an already-running
+MongoDB:
+
+```sh
+MONGODB_MODE=external \
+MONGODB_ADDR=127.0.0.1:27017 \
+scripts/ycsb_compare_mongodb_treedb.sh
+```
+
+To skip the MongoDB baseline:
+
+```sh
+MONGODB_MODE=skip scripts/ycsb_compare_mongodb_treedb.sh
+```
+
+## Manual Commands
+
+Build TreeDB servers:
+
+```sh
+cd /home/mikers/dev/snissn/gomap-clean
+go build -o bin/treedb-native-server ./cmd/treedb-native-server
+go build -o bin/treedb-mongo-gateway ./TreeDB/mongo_gateway/server.go
+```
+
+Build `go-ycsb`:
+
+```sh
+cd /home/mikers/dev/pingcap/go-ycsb
+make build
+```
+
+Run MongoDB 8 in Docker:
+
+```sh
+RUN_DIR=/tmp/mongodb_ycsb_compare_$(date +%Y%m%d_%H%M%S)
+mkdir -p "$RUN_DIR/db"
+
+docker run --rm -d --name treedb-ycsb-mongo \
+  -p 127.0.0.1:27018:27017 \
+  -v "$RUN_DIR/db:/data/db" \
+  mongo:8 --bind_ip_all --quiet
+```
+
+Run MongoDB YCSB:
+
+```sh
+cd /home/mikers/dev/pingcap/go-ycsb
+
+./bin/go-ycsb load mongodb \
+  -p mongodb.url='mongodb://127.0.0.1:27018/ycsb?w=1' \
+  -p recordcount=100000 \
+  -p operationcount=10000 \
+  -p threadcount=16 \
+  >"$RUN_DIR/load.out"
+
+./bin/go-ycsb run mongodb \
+  -p mongodb.url='mongodb://127.0.0.1:27018/ycsb?w=1' \
+  -p recordcount=100000 \
+  -p operationcount=10000 \
+  -p threadcount=16 \
+  >"$RUN_DIR/run.out"
+```
+
+Run TreeDB native:
+
+```sh
+cd /home/mikers/dev/snissn/gomap-clean
+
+RUN_DIR=/tmp/treedb_ycsb_$(date +%Y%m%d_%H%M%S)
+mkdir -p "$RUN_DIR/native_db"
+
+./bin/treedb-native-server \
+  -dir "$RUN_DIR/native_db" \
+  -profile fast \
+  -addr 127.0.0.1:17130 \
+  >"$RUN_DIR/native_server.log" 2>&1 &
+NATIVE_PID=$!
+
+cd /home/mikers/dev/pingcap/go-ycsb
+
+./bin/go-ycsb load treedb-native \
+  -p treedb.addr=127.0.0.1:17130 \
+  -p recordcount=100000 \
+  -p operationcount=10000 \
+  -p threadcount=16 \
+  >"$RUN_DIR/native_load.out"
+
+./bin/go-ycsb run treedb-native \
+  -p treedb.addr=127.0.0.1:17130 \
+  -p recordcount=100000 \
+  -p operationcount=10000 \
+  -p threadcount=16 \
+  >"$RUN_DIR/native_run.out"
+
+kill "$NATIVE_PID"
+wait "$NATIVE_PID" 2>/dev/null || true
+```
+
+Run TreeDB Mongo gateway:
+
+```sh
+cd /home/mikers/dev/snissn/gomap-clean
+
+RUN_DIR=/tmp/treedb_mongo_ycsb_$(date +%Y%m%d_%H%M%S)
+mkdir -p "$RUN_DIR/mongo_db"
+
+./bin/treedb-mongo-gateway \
+  -dir "$RUN_DIR/mongo_db" \
+  -profile fast \
+  -document-format bson \
+  -addr 127.0.0.1:27130 \
+  >"$RUN_DIR/mongo_server.log" 2>&1 &
+MONGO_GATEWAY_PID=$!
+
+cd /home/mikers/dev/pingcap/go-ycsb
+
+./bin/go-ycsb load mongodb \
+  -p mongodb.url='mongodb://127.0.0.1:27130/ycsb?w=1' \
+  -p recordcount=100000 \
+  -p operationcount=10000 \
+  -p threadcount=16 \
+  >"$RUN_DIR/mongo_load.out"
+
+./bin/go-ycsb run mongodb \
+  -p mongodb.url='mongodb://127.0.0.1:27130/ycsb?w=1' \
+  -p recordcount=100000 \
+  -p operationcount=10000 \
+  -p threadcount=16 \
+  >"$RUN_DIR/mongo_run.out"
+
+kill "$MONGO_GATEWAY_PID"
+wait "$MONGO_GATEWAY_PID" 2>/dev/null || true
+```
+
+## Headline Results
+
+First run after load:
+
+| Target | Load total ops/s | Run total ops/s | Run avg us | Run p50 us | Run p95 us | Run p99 us | Run p99.9 us | Run max us |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| MongoDB 8 Docker | 39,005.3 | 27,287.4 | 575 | 544 | 970 | 1,296 | 1,789 | 2,165 |
+| TreeDB nativewire | 91,706.6 | 123,002.9 | 124 | 112 | 259 | 414 | 851 | 1,293 |
+| TreeDB Mongo gateway | 85,635.8 | 28,932.5 | 544 | 178 | 392 | 584 | 215,807 | 216,703 |
+
+TreeDB Mongo repeated run check on the same loaded DB/server:
+
+| Run | Total ops/s | Avg us | p50 us | p95 us | p99 us | p99.9 us | Max us |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 1 | 28,968.6 | 543 | 177 | 404 | 669 | 213,631 | 214,783 |
+| 2 | 76,043.4 | 203 | 183 | 388 | 560 | 950 | 1,520 |
+| 3 | 74,430.0 | 206 | 185 | 394 | 659 | 923 | 1,405 |
+
+The first TreeDB Mongo run after load is therefore not representative of
+steady-state point-operation throughput. The observed pattern is a reproducible
+one-time post-load foreground drain: after the load phase, the first mixed
+read/update run pays to flush a large buffered primary-only write backlog, and
+subsequent runs avoid that cost because the backlog has already been drained.
+
+A fresh reproduction on the same host at
+`/tmp/treedb_mongo_first_run_repro_20260531_201950` showed the same shape:
+
+| Run | Total ops/s | Avg us | p50 us | p95 us | p99 us | p99.9 us | Max us |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 1 | 26,682.2 | 591 | 200 | 446 | 768 | 230,015 | 230,911 |
+| 2 | 69,855.0 | 220 | 196 | 433 | 768 | 1,218 | 1,721 |
+| 3 | 72,530.6 | 213 | 186 | 436 | 706 | 1,126 | 1,668 |
+
+## Detailed Results
+
+### Load Phase
+
+| Target | Insert count | Insert ops/s | Avg us | p50 us | p95 us | p99 us | p99.9 us | Max us |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| MongoDB 8 Docker | 100,000 | 39,006.4 | 421 | 277 | 537 | 737 | 1,230 | 888,831 |
+| TreeDB nativewire | 100,000 | 91,709.2 | 158 | 138 | 267 | 418 | 2,093 | 6,019 |
+| TreeDB Mongo gateway | 100,000 | 85,634.2 | 171 | 148 | 320 | 503 | 897 | 19,983 |
+
+### Run Phase: Reads
+
+| Target | Read count | Read ops/s | Avg us | p50 us | p95 us | p99 us | p99.9 us | Max us |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| MongoDB 8 Docker | 9,504 | 25,932.3 | 583 | 551 | 974 | 1,299 | 1,789 | 2,165 |
+| TreeDB nativewire | 9,500 | 116,885.9 | 116 | 109 | 211 | 363 | 612 | 1,293 |
+| TreeDB Mongo gateway, first run | 9,483 | 27,449.1 | 540 | 177 | 389 | 579 | 215,807 | 216,703 |
+| TreeDB Mongo gateway, repeated run 2 | 9,493 | 72,102.4 | 202 | 183 | 384 | 552 | 948 | 1,520 |
+| TreeDB Mongo gateway, repeated run 3 | 9,517 | 70,852.8 | 207 | 185 | 394 | 670 | 923 | 1,405 |
+
+### Run Phase: Updates
+
+| Target | Update count | Update ops/s | Avg us | p50 us | p95 us | p99 us | p99.9 us | Max us |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| MongoDB 8 Docker | 496 | 1,360.4 | 437 | 403 | 746 | 1,204 | 1,395 | 1,395 |
+| TreeDB nativewire | 500 | 6,226.5 | 278 | 253 | 519 | 863 | 1,254 | 1,254 |
+| TreeDB Mongo gateway, first run | 517 | 3,978.0 | 629 | 192 | 429 | 648 | 824 | 216,319 |
+| TreeDB Mongo gateway, repeated run 2 | 507 | 3,875.7 | 215 | 190 | 427 | 641 | 1,062 | 1,063 |
+| TreeDB Mongo gateway, repeated run 3 | 483 | 3,615.1 | 205 | 186 | 390 | 546 | 842 | 842 |
+
+## Attribution Evidence
+
+The Mongo gateway load path improved after the single-document BSON insert
+coalescer. Internal attribution from
+`/tmp/treedb_mongo_ycsb_post_coalesce_attr_20260531_192632`:
+
+| Secondary indexes | Driver ops/s | Raw wire TCP ops/s | Native wire TCP ops/s | Direct collection ops/s |
+| ---: | ---: | ---: | ---: | ---: |
+| 0 | 116,919.0 | 193,049.6 | 181,146.3 | 647,315.8 |
+| 1 | 93,547.7 | 125,154.4 | 87,837.0 | 194,662.1 |
+
+The remaining first-run Mongo gateway run cliff was isolated with
+`/tmp/treedb_mongo_ycsb_post_coalesce_run_attr_20260531_192751`:
+
+- driver `id_update_set`: 500 updates took `151.473ms`
+- `pending_docs` changed by `-99,500`
+- `indexed_stage.docs_total=500`
+- `mutation_lock.hold_ns_total=119,192,560`
+- CPU profile included `Collection.UpdateBSONSet`,
+  `flushBufferedNoIndexLocked`, `pointerizeCollectionRunTableValues`,
+  memtable iterator/sort work, value-log append/compression, and root publish
+
+Interpretation: the load phase leaves a large primary-only write-domain buffer.
+The first mixed run update forces most of that backlog through the foreground
+collection mutation path. Repeated runs avoid that cost because the backlog has
+already been drained. This is not general steady-state Mongo gateway overhead;
+it is a transition cost caused by running the mixed workload immediately after
+the bulk load.
+
+## Caveats
+
+- The benchmark host was not an isolated lab machine.
+- `/tmp` lived on the root filesystem, which was about 98% full.
+- MongoDB ran in Docker; TreeDB servers ran directly on the host.
+- MongoDB used default server behavior; TreeDB used the relaxed `fast` profile.
+- The `go-ycsb` run duration is short, so one large tail event can dominate
+  average and total OPS in the 10k operation run.
+- Results should be compared with exact commands, artifact paths, commits, and
+  host metadata, not copied as universal numbers.
+
+## Follow-Up Work
+
+The report points to two next benchmark-driven tasks:
+
+- #2115: reduce the first-run Mongo YCSB stall from post-load primary flush.
+- #2116: optimize steady-state Mongo gateway point-operation overhead after
+  the first-run flush cliff is fixed or controlled.
+
+## Summary
+
+TreeDB nativewire is currently the fastest path on this exact YCSB shape:
+about `91.7k` load ops/s and `123.0k` run ops/s. TreeDB Mongo gateway load is
+close to nativewire at about `85.6k` ops/s and is substantially faster than the
+Docker MongoDB baseline at about `39.0k` ops/s. The first TreeDB Mongo run after
+load looks similar to MongoDB in total OPS, but that is misleading: it includes
+a reproducible one-time `~215ms-230ms` foreground drain of the post-load buffered
+write backlog. Repeated TreeDB Mongo runs on the same loaded DB reach about
+`74k-76k` ops/s with sub-2ms max latency in the original run, and the fresh
+reproduction reached `70k-73k` ops/s. The next high-priority fix is to prevent
+or amortize that post-load foreground flush, then re-profile steady-state Mongo
+protocol and BSON response overhead.

--- a/scripts/ycsb_compare_mongodb_treedb.sh
+++ b/scripts/ycsb_compare_mongodb_treedb.sh
@@ -1,0 +1,499 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+cd "$ROOT"
+
+TMP_BASE="${TMPDIR:-/tmp}"
+TMP_BASE="${TMP_BASE%/}"
+OUT_DIR="${OUT_DIR:-$(mktemp -d "$TMP_BASE/treedb_ycsb_compare_XXXXXX")}"
+GOYCSB_DIR="${GOYCSB_DIR:-/home/mikers/dev/pingcap/go-ycsb}"
+RECORDCOUNT="${RECORDCOUNT:-100000}"
+OPERATIONCOUNT="${OPERATIONCOUNT:-10000}"
+THREADCOUNT="${THREADCOUNT:-16}"
+TREEDB_PROFILE="${TREEDB_PROFILE:-fast}"
+TREEDB_MONGO_DOCUMENT_FORMAT="${TREEDB_MONGO_DOCUMENT_FORMAT:-bson}"
+NATIVE_ADDR="${NATIVE_ADDR:-127.0.0.1:17130}"
+TREEDB_MONGO_ADDR="${TREEDB_MONGO_ADDR:-127.0.0.1:27130}"
+MONGODB_MODE="${MONGODB_MODE:-docker}"
+MONGODB_ADDR="${MONGODB_ADDR:-127.0.0.1:27018}"
+MONGODB_IMAGE="${MONGODB_IMAGE:-mongo:8}"
+RUN_REPEATS="${RUN_REPEATS:-1}"
+BUILD="${BUILD:-true}"
+BUILD_GOYCSB="${BUILD_GOYCSB:-false}"
+ALLOW_YCSB_ERRORS="${ALLOW_YCSB_ERRORS:-false}"
+PARSE_ONLY="${PARSE_ONLY:-false}"
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/ycsb_compare_mongodb_treedb.sh
+
+Runs the same external go-ycsb load/run shape against:
+  - MongoDB through the go-ycsb mongodb binding
+  - TreeDB nativewire through the go-ycsb treedb-native binding
+  - TreeDB Mongo gateway through the go-ycsb mongodb binding
+
+Outputs:
+  $OUT_DIR/host.txt
+  $OUT_DIR/commands.txt
+  $OUT_DIR/summary.tsv
+  $OUT_DIR/summary.md
+  $OUT_DIR/{mongodb,treedb_native,treedb_mongo}/*.out
+  server logs and DB directories for each target
+
+Environment overrides:
+  OUT_DIR, GOYCSB_DIR, RECORDCOUNT, OPERATIONCOUNT, THREADCOUNT,
+  TREEDB_PROFILE, TREEDB_MONGO_DOCUMENT_FORMAT,
+  NATIVE_ADDR, TREEDB_MONGO_ADDR,
+  MONGODB_MODE, MONGODB_ADDR, MONGODB_IMAGE,
+  RUN_REPEATS, BUILD, BUILD_GOYCSB,
+  ALLOW_YCSB_ERRORS, PARSE_ONLY.
+
+MONGODB_MODE values:
+  docker    Start a fresh Docker container from MONGODB_IMAGE (default).
+  external  Use an already-running MongoDB at MONGODB_ADDR.
+  skip      Do not run the MongoDB baseline.
+
+PARSE_ONLY=true expects an existing OUT_DIR with raw *.out files and only
+regenerates summary.tsv/summary.md. By default, any nonzero YCSB *_ERROR
+operation count marks the run invalid and exits nonzero; set
+ALLOW_YCSB_ERRORS=true for exploratory invalid-result summaries.
+
+Examples:
+  scripts/ycsb_compare_mongodb_treedb.sh
+  RUN_REPEATS=3 OUT_DIR=/tmp/ycsb_compare scripts/ycsb_compare_mongodb_treedb.sh
+  MONGODB_MODE=external MONGODB_ADDR=127.0.0.1:27017 scripts/ycsb_compare_mongodb_treedb.sh
+EOF
+}
+
+if [[ "${1-}" == "-h" || "${1-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+mkdir -p "$OUT_DIR"
+OUT_DIR=$(cd "$OUT_DIR" && pwd)
+
+case "$MONGODB_MODE" in
+  docker|external|skip) ;;
+  *)
+    echo "unknown MONGODB_MODE=$MONGODB_MODE; expected docker, external, or skip" >&2
+    exit 2
+    ;;
+esac
+
+if [[ "$RUN_REPEATS" -lt 1 ]]; then
+  echo "RUN_REPEATS must be >= 1" >&2
+  exit 2
+fi
+
+case "$ALLOW_YCSB_ERRORS" in
+  true|false) ;;
+  *)
+    echo "ALLOW_YCSB_ERRORS must be true or false" >&2
+    exit 2
+    ;;
+esac
+
+case "$PARSE_ONLY" in
+  true|false) ;;
+  *)
+    echo "PARSE_ONLY must be true or false" >&2
+    exit 2
+    ;;
+esac
+
+if [[ "$PARSE_ONLY" != "true" ]]; then
+  if [[ ! -x "$GOYCSB_DIR/bin/go-ycsb" ]]; then
+    BUILD_GOYCSB=true
+  fi
+
+  if [[ "$BUILD" == "true" ]]; then
+    go build -o bin/treedb-native-server ./cmd/treedb-native-server
+    go build -o bin/treedb-mongo-gateway ./TreeDB/mongo_gateway/server.go
+  fi
+
+  if [[ "$BUILD_GOYCSB" == "true" ]]; then
+    (cd "$GOYCSB_DIR" && make build)
+  fi
+fi
+
+GOYCSB="$GOYCSB_DIR/bin/go-ycsb"
+
+SERVER_PIDS=()
+MONGO_CONTAINER=""
+
+cleanup() {
+  local pid
+  for pid in "${SERVER_PIDS[@]:-}"; do
+    kill "$pid" 2>/dev/null || true
+  done
+  for pid in "${SERVER_PIDS[@]:-}"; do
+    wait "$pid" 2>/dev/null || true
+  done
+  if [[ -n "$MONGO_CONTAINER" ]]; then
+    docker rm -f "$MONGO_CONTAINER" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+wait_tcp() {
+  local addr=$1
+  local host=${addr%:*}
+  local port=${addr##*:}
+  local i
+  for i in $(seq 1 60); do
+    if timeout 1 bash -c "</dev/tcp/$host/$port" 2>/dev/null; then
+      return 0
+    fi
+    sleep 1
+  done
+  echo "timed out waiting for $addr" >&2
+  return 1
+}
+
+write_host_info() {
+  {
+    printf 'date_utc='
+    date -u '+%Y-%m-%dT%H:%M:%SZ'
+    printf 'gomap_commit='
+    git rev-parse HEAD
+    printf 'gomap_branch='
+    git rev-parse --abbrev-ref HEAD
+    printf 'go_ycsb_commit='
+    (cd "$GOYCSB_DIR" && git rev-parse HEAD)
+    printf 'go_ycsb_branch='
+    (cd "$GOYCSB_DIR" && git rev-parse --abbrev-ref HEAD)
+    printf 'go_version='
+    go version
+    printf 'uname='
+    uname -a
+    printf 'cpu_model='
+    lscpu | awk -F: '/Model name/{gsub(/^ +/, "", $2); print $2; exit}'
+    printf 'logical_cpus='
+    nproc
+    printf 'memory='
+    free -h | awk '/Mem:/{print $2}'
+    printf 'clocksource='
+    cat /sys/devices/system/clocksource/clocksource0/current_clocksource 2>/dev/null || true
+    printf 'recordcount=%s\n' "$RECORDCOUNT"
+    printf 'operationcount=%s\n' "$OPERATIONCOUNT"
+    printf 'threadcount=%s\n' "$THREADCOUNT"
+    printf 'treedb_profile=%s\n' "$TREEDB_PROFILE"
+    printf 'treedb_mongo_document_format=%s\n' "$TREEDB_MONGO_DOCUMENT_FORMAT"
+    printf 'mongodb_mode=%s\n' "$MONGODB_MODE"
+    printf 'mongodb_image=%s\n' "$MONGODB_IMAGE"
+    if command -v docker >/dev/null 2>&1 && [[ "$MONGODB_MODE" == "docker" ]]; then
+      docker image inspect "$MONGODB_IMAGE" \
+        --format 'mongodb_image_id={{.Id}} mongodb_image_created={{.Created}} mongodb_image_os={{.Os}} mongodb_image_arch={{.Architecture}} mongodb_image_digests={{json .RepoDigests}}' \
+        2>/dev/null || true
+    fi
+  } >"$OUT_DIR/host.txt"
+}
+
+log_command() {
+  printf '%q ' "$@" >>"$OUT_DIR/commands.txt"
+  printf '\n' >>"$OUT_DIR/commands.txt"
+}
+
+run_ycsb_load_run() {
+  local target=$1
+  local binding=$2
+  local prop_name=$3
+  local prop_value=$4
+  local dir="$OUT_DIR/$target"
+  mkdir -p "$dir"
+
+  local load_cmd=(
+    "$GOYCSB" load "$binding"
+    -p "$prop_name=$prop_value"
+    -p "recordcount=$RECORDCOUNT"
+    -p "operationcount=$OPERATIONCOUNT"
+    -p "threadcount=$THREADCOUNT"
+  )
+  log_command "${load_cmd[@]}"
+  "${load_cmd[@]}" >"$dir/load.out"
+
+  local i
+  for i in $(seq 1 "$RUN_REPEATS"); do
+    local run_cmd=(
+      "$GOYCSB" run "$binding"
+      -p "$prop_name=$prop_value"
+      -p "recordcount=$RECORDCOUNT"
+      -p "operationcount=$OPERATIONCOUNT"
+      -p "threadcount=$THREADCOUNT"
+    )
+    log_command "${run_cmd[@]}"
+    "${run_cmd[@]}" >"$dir/run_${i}.out"
+  done
+}
+
+write_summary() {
+  python - "$OUT_DIR" "$ALLOW_YCSB_ERRORS" <<'PY'
+import pathlib
+import re
+import sys
+
+out = pathlib.Path(sys.argv[1])
+allow_errors = sys.argv[2] == "true"
+
+line_re = re.compile(
+    r"^(?P<op>[A-Z_]+)\s+- Takes\(s\): (?P<takes>[0-9.]+), Count: (?P<count>[0-9]+), "
+    r"OPS: (?P<ops>[0-9.]+), Avg\(us\): (?P<avg>[0-9.]+), Min\(us\): (?P<min>[0-9.]+), "
+    r"Max\(us\): (?P<max>[0-9.]+), 50th\(us\): (?P<p50>[0-9.]+), 90th\(us\): (?P<p90>[0-9.]+), "
+    r"95th\(us\): (?P<p95>[0-9.]+), 99th\(us\): (?P<p99>[0-9.]+), "
+    r"99.9th\(us\): (?P<p999>[0-9.]+), 99.99th\(us\): (?P<p9999>[0-9.]+)"
+)
+
+labels = {
+    "mongodb": "MongoDB",
+    "treedb_native": "TreeDB nativewire",
+    "treedb_mongo": "TreeDB Mongo gateway",
+}
+
+rows_by_key = {}
+row_sequence = 0
+for target_dir in sorted(out.iterdir()):
+    if not target_dir.is_dir() or target_dir.name not in labels:
+        continue
+    for path in sorted(target_dir.glob("*.out")):
+        if path.name == "load.out":
+            phase = "load"
+            repeat = 0
+        elif path.name.startswith("run_"):
+            phase = "run"
+            repeat = int(path.stem.split("_", 1)[1])
+        else:
+            continue
+        for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+            m = line_re.match(line)
+            if not m:
+                continue
+            data = m.groupdict()
+            row_sequence += 1
+            row = {
+                "target": target_dir.name,
+                "target_label": labels[target_dir.name],
+                "phase": phase,
+                "repeat": repeat,
+                "operation": data["op"],
+                "is_error": data["op"].endswith("_ERROR"),
+                "sequence": row_sequence,
+                "output": str(path.relative_to(out)),
+            }
+            for key in ("takes", "ops", "avg", "min", "max", "p50", "p90", "p95", "p99", "p999", "p9999"):
+                row[key] = float(data[key])
+            row["count"] = int(data["count"])
+            rows_by_key[(target_dir.name, phase, repeat, data["op"])] = row
+
+rows = sorted(rows_by_key.values(), key=lambda row: row["sequence"])
+
+phase_error_counts = {}
+for row in rows:
+    key = (row["target"], row["phase"], row["repeat"])
+    phase_error_counts.setdefault(key, 0)
+    if row["is_error"]:
+        phase_error_counts[key] += row["count"]
+
+for row in rows:
+    row["phase_error_count"] = phase_error_counts[(row["target"], row["phase"], row["repeat"])]
+    row["valid"] = row["phase_error_count"] == 0
+
+headers = [
+    "target",
+    "phase",
+    "repeat",
+    "operation",
+    "count",
+    "ops_per_sec",
+    "avg_us",
+    "p50_us",
+    "p95_us",
+    "p99_us",
+    "p999_us",
+    "max_us",
+    "is_error",
+    "phase_error_count",
+    "valid",
+    "output",
+]
+
+with (out / "summary.tsv").open("w", encoding="utf-8") as f:
+    f.write("\t".join(headers) + "\n")
+    for row in rows:
+        f.write("\t".join([
+            row["target"],
+            row["phase"],
+            str(row["repeat"]),
+            row["operation"],
+            str(row["count"]),
+            f"{row['ops']:.1f}",
+            f"{row['avg']:.1f}",
+            f"{row['p50']:.1f}",
+            f"{row['p95']:.1f}",
+            f"{row['p99']:.1f}",
+            f"{row['p999']:.1f}",
+            f"{row['max']:.1f}",
+            "true" if row["is_error"] else "false",
+            str(row["phase_error_count"]),
+            "true" if row["valid"] else "false",
+            row["output"],
+        ]) + "\n")
+
+def pick(target, phase, operation, repeat=1):
+    for row in rows:
+        if row["target"] == target and row["phase"] == phase and row["operation"] == operation and row["repeat"] == repeat:
+            return row
+    return None
+
+def md_num(value):
+    return f"{value:,.1f}"
+
+with (out / "summary.md").open("w", encoding="utf-8") as f:
+    f.write("# YCSB MongoDB / TreeDB Comparison\n\n")
+    f.write("## Host\n\n")
+    f.write("```text\n")
+    host_path = out / "host.txt"
+    if host_path.exists():
+        f.write(host_path.read_text(encoding="utf-8", errors="replace"))
+    else:
+        f.write("host metadata unavailable\n")
+    f.write("```\n\n")
+    f.write("## Validity\n\n")
+    invalid = [
+        (target, phase, repeat, count)
+        for (target, phase, repeat), count in sorted(phase_error_counts.items())
+        if count
+    ]
+    if invalid:
+        f.write("At least one YCSB phase emitted nonzero `*_ERROR` operation counts. Those rows are invalid performance evidence.\n\n")
+        f.write("| target | phase | repeat | operation errors |\n")
+        f.write("| --- | --- | ---: | ---: |\n")
+        for target, phase, repeat, count in invalid:
+            f.write(f"| {labels[target]} | {phase} | {repeat} | {count:,} |\n")
+        f.write("\n")
+    else:
+        f.write("All parsed YCSB phases have zero `*_ERROR` operation counts.\n\n")
+    f.write("## Headline Totals\n\n")
+    f.write("| target | load status | load errors | load ops/sec | run repeat | run status | run errors | run ops/sec | run avg us | run p99 us | run max us |\n")
+    f.write("| --- | --- | ---: | ---: | ---: | --- | ---: | ---: | ---: | ---: | ---: |\n")
+    for target in ("mongodb", "treedb_native", "treedb_mongo"):
+        load = pick(target, "load", "TOTAL", 0)
+        repeats = sorted({row["repeat"] for row in rows if row["target"] == target and row["phase"] == "run"})
+        if not load and not repeats:
+            continue
+        for repeat in repeats or [1]:
+            run = pick(target, "run", "TOTAL", repeat)
+            if not run:
+                continue
+            load_errors = load["phase_error_count"] if load else 0
+            run_errors = run["phase_error_count"]
+            f.write(
+                f"| {labels[target]} | {'valid' if not load_errors else 'invalid'} | {load_errors:,} | "
+                f"{md_num(load['ops']) if load else ''} | {repeat} | {'valid' if not run_errors else 'invalid'} | "
+                f"{run_errors:,} | {md_num(run['ops'])} | {md_num(run['avg'])} | {md_num(run['p99'])} | {md_num(run['max'])} |\n"
+            )
+    f.write("\n## Detailed Rows\n\n")
+    f.write("| target | phase | repeat | op | count | ops/sec | avg us | p50 us | p95 us | p99 us | p99.9 us | max us | op error | phase errors | valid | output |\n")
+    f.write("| --- | --- | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- | ---: | --- | --- |\n")
+    for row in rows:
+        f.write(
+            f"| {row['target_label']} | {row['phase']} | {row['repeat']} | {row['operation']} | "
+            f"{row['count']:,} | {md_num(row['ops'])} | {md_num(row['avg'])} | {md_num(row['p50'])} | "
+            f"{md_num(row['p95'])} | {md_num(row['p99'])} | {md_num(row['p999'])} | {md_num(row['max'])} | "
+            f"{'yes' if row['is_error'] else 'no'} | {row['phase_error_count']:,} | {'yes' if row['valid'] else 'no'} | "
+            f"`{row['output']}` |\n"
+        )
+    f.write("\n## Commands\n\n")
+    f.write("```sh\n")
+    commands_path = out / "commands.txt"
+    if commands_path.exists():
+        f.write(commands_path.read_text(encoding="utf-8", errors="replace"))
+    f.write("```\n")
+
+if invalid and not allow_errors:
+    print(
+        f"YCSB operation errors detected in {len(invalid)} phase(s); "
+        "set ALLOW_YCSB_ERRORS=true to keep exploratory invalid summaries",
+        file=sys.stderr,
+    )
+    sys.exit(3)
+PY
+}
+
+if [[ "$PARSE_ONLY" == "true" ]]; then
+  write_summary
+  echo "wrote $OUT_DIR/summary.tsv"
+  echo "wrote $OUT_DIR/summary.md"
+  exit 0
+fi
+
+write_host_info
+: >"$OUT_DIR/commands.txt"
+
+native_dir="$OUT_DIR/treedb_native/db"
+mkdir -p "$native_dir"
+./bin/treedb-native-server \
+  -dir "$native_dir" \
+  -profile "$TREEDB_PROFILE" \
+  -addr "$NATIVE_ADDR" \
+  >"$OUT_DIR/treedb_native/server.log" 2>&1 &
+SERVER_PIDS+=("$!")
+wait_tcp "$NATIVE_ADDR"
+
+mongo_gateway_dir="$OUT_DIR/treedb_mongo/db"
+mkdir -p "$mongo_gateway_dir"
+./bin/treedb-mongo-gateway \
+  -dir "$mongo_gateway_dir" \
+  -profile "$TREEDB_PROFILE" \
+  -document-format "$TREEDB_MONGO_DOCUMENT_FORMAT" \
+  -addr "$TREEDB_MONGO_ADDR" \
+  >"$OUT_DIR/treedb_mongo/server.log" 2>&1 &
+SERVER_PIDS+=("$!")
+wait_tcp "$TREEDB_MONGO_ADDR"
+
+if [[ "$MONGODB_MODE" == "docker" ]]; then
+  if ! command -v docker >/dev/null 2>&1; then
+    echo "docker is required for MONGODB_MODE=docker" >&2
+    exit 2
+  fi
+  MONGO_CONTAINER="treedb-ycsb-mongo-$(date +%s)-$$"
+  mongodb_dir="$OUT_DIR/mongodb/db"
+  mkdir -p "$mongodb_dir"
+  docker run --rm -d --name "$MONGO_CONTAINER" \
+    -p "$MONGODB_ADDR:27017" \
+    -v "$mongodb_dir:/data/db" \
+    "$MONGODB_IMAGE" --bind_ip_all --quiet \
+    >"$OUT_DIR/mongodb/container.id"
+  wait_tcp "$MONGODB_ADDR"
+  sleep 2
+fi
+
+if [[ "$MONGODB_MODE" != "skip" ]]; then
+  run_ycsb_load_run \
+    mongodb \
+    mongodb \
+    mongodb.url \
+    "mongodb://$MONGODB_ADDR/ycsb?w=1"
+fi
+
+run_ycsb_load_run \
+  treedb_native \
+  treedb-native \
+  treedb.addr \
+  "$NATIVE_ADDR"
+
+run_ycsb_load_run \
+  treedb_mongo \
+  mongodb \
+  mongodb.url \
+  "mongodb://$TREEDB_MONGO_ADDR/ycsb?w=1"
+
+if [[ -n "$MONGO_CONTAINER" ]]; then
+  docker logs "$MONGO_CONTAINER" >"$OUT_DIR/mongodb/server.log" 2>&1 || true
+fi
+
+write_summary
+
+echo "wrote $OUT_DIR/summary.tsv"
+echo "wrote $OUT_DIR/summary.md"


### PR DESCRIPTION
## Summary

Linked issue: #2120
Parent tracker: #2106

This PR makes the external YCSB comparison script fail closed on YCSB operation errors and marks invalid rows explicitly in generated summaries. It also documents the error-gate behavior in the TreeDB benchmarking docs and includes the current YCSB comparison report artifact doc.

## Start-Phase Test Plan

- Add parser behavior for `*_ERROR` YCSB operations before treating benchmark rows as valid.
- Preserve clean zero-error summaries for valid runs.
- Keep exact raw `go-ycsb` output and command artifacts visible for audit.

## Start-Phase Performance Plan

- No hot server path changes.
- The script/report change prevents invalid performance rows from being used as optimization evidence.

## Close-Phase Test Evidence

```sh
bash -n scripts/ycsb_compare_mongodb_treedb.sh
GOWORK=off go test ./cmd/benchprof -count=1
GOWORK=off go test ./cmd/unified_bench -count=1
```

Results: all passed locally.

Parser fixture checks run locally:

```sh
PARSE_ONLY=true OUT_DIR=/tmp/ycsb_parse_fixture_* scripts/ycsb_compare_mongodb_treedb.sh
# exits 3 when READ_ERROR is present and marks the phase invalid

PARSE_ONLY=true OUT_DIR=/tmp/ycsb_parse_clean_* scripts/ycsb_compare_mongodb_treedb.sh
# exits 0 for zero-error output and marks rows valid
```

## Close-Phase Benchmark / Evidence

Known-bad command-WAL relaxed artifact:

```sh
PARSE_ONLY=true OUT_DIR=/tmp/treedb_ycsb_command_wal_relaxed_20260531_204847 scripts/ycsb_compare_mongodb_treedb.sh
# status 3: YCSB operation errors detected in 3 phase(s)

ALLOW_YCSB_ERRORS=true PARSE_ONLY=true OUT_DIR=/tmp/treedb_ycsb_command_wal_relaxed_20260531_204847 scripts/ycsb_compare_mongodb_treedb.sh
```

The regenerated summary marks TreeDB Mongo gateway run repeats invalid with `9,814`, `9,822`, and `9,842` operation errors while keeping TreeDB native rows valid.

Known-bad command-WAL durable artifact:

```sh
PARSE_ONLY=true OUT_DIR=/tmp/treedb_ycsb_command_wal_durable_20260531_205009 scripts/ycsb_compare_mongodb_treedb.sh
# status 3: YCSB operation errors detected in 3 phase(s)
```

The regenerated summary marks TreeDB Mongo gateway run repeats invalid with `9,828`, `9,835`, and `9,821` operation errors.

## Performance Regression Assessment

No server code changes. The only runtime behavior change is in the benchmark/reporting script. It now exits nonzero by default on invalid YCSB rows and supports `ALLOW_YCSB_ERRORS=true` for exploratory summaries.

## Measurement Boundary

This PR changes benchmark orchestration/reporting only. It does not change MongoDB, TreeDB nativewire, TreeDB Mongo gateway, collection code, command-WAL code, or the YCSB workload.

## AI Review Status

No AI reviews requested yet. The PR should only request review after CI is current on the pushed head.
