### PR TITLE
Buffer indexed command-WAL native inserts

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3806,6 +3806,27 @@ func (c *Collection) canBufferCommandWALNoIndexInsertBatch(meta CollectionMeta, 
 	}
 }
 
+func (c *Collection) canBufferCommandWALIndexedInsertBatch(meta CollectionMeta, format DocumentFormat, commandWALIntent *backenddb.CommandWALIntent, documentCount int) bool {
+	if c == nil || c.db == nil || c.writeDomain == nil || commandWALIntent != nil || documentCount <= 0 {
+		return false
+	}
+	if !c.db.CommandWALEnabled() || c.db.DurabilityMode() == backenddb.DurabilityWALOffRelaxed {
+		return false
+	}
+	if len(meta.VectorIndexes) != 0 || columnStoreWriteEnabled(meta) {
+		return false
+	}
+	if !c.shouldBufferIndexedInsertBatch(meta, documentCount) {
+		return false
+	}
+	switch normalizedDocumentFormat(format) {
+	case DocumentFormatJSON, DocumentFormatBSON:
+		return true
+	default:
+		return false
+	}
+}
+
 func (c *Collection) canBufferDirectUpdateAck() bool {
 	if c == nil || c.db == nil || c.writeDomain == nil {
 		return false
@@ -9133,8 +9154,10 @@ func (c *Collection) insertBatchOnceWithLockState(
 		}
 	}
 	commandWALNoIndexBufferedMode := c.canBufferCommandWALNoIndexInsertBatch(meta, plannerOptions.documentFormat, commandWALIntent, len(documents))
-	indexedMemtablesEnabled := (!commandWALActive && c.shouldBufferIndexedInserts(meta)) || commandWALNoIndexBufferedMode
-	bufferIndexedInserts := (!commandWALActive && c.shouldBufferIndexedInsertBatch(meta, len(documents))) || commandWALNoIndexBufferedMode
+	commandWALIndexedBufferedMode := c.canBufferCommandWALIndexedInsertBatch(meta, plannerOptions.documentFormat, commandWALIntent, len(documents))
+	commandWALBufferedMode := commandWALNoIndexBufferedMode || commandWALIndexedBufferedMode
+	indexedMemtablesEnabled := (!commandWALActive && c.shouldBufferIndexedInserts(meta)) || commandWALBufferedMode
+	bufferIndexedInserts := (!commandWALActive && c.shouldBufferIndexedInsertBatch(meta, len(documents))) || commandWALBufferedMode
 	if indexedMemtablesEnabled && !bufferIndexedInserts {
 		closePlanningSnapshot()
 		if err := c.flushBufferedWrites(); err != nil {
@@ -9181,8 +9204,10 @@ func (c *Collection) insertBatchOnceWithLockState(
 		plannerOptions.allowTemplateV1Stored = templateEncoder.allowsTemplateV1StoredDocuments(c)
 		plannerOptions = collectionOptionsWithTemplateV1Resolver(plannerOptions, snap, catalog)
 		commandWALNoIndexBufferedMode = c.canBufferCommandWALNoIndexInsertBatch(meta, plannerOptions.documentFormat, commandWALIntent, len(documents))
-		indexedMemtablesEnabled = (!commandWALActive && c.shouldBufferIndexedInserts(meta)) || commandWALNoIndexBufferedMode
-		bufferIndexedInserts = (!commandWALActive && c.shouldBufferIndexedInsertBatch(meta, len(documents))) || commandWALNoIndexBufferedMode
+		commandWALIndexedBufferedMode = c.canBufferCommandWALIndexedInsertBatch(meta, plannerOptions.documentFormat, commandWALIntent, len(documents))
+		commandWALBufferedMode = commandWALNoIndexBufferedMode || commandWALIndexedBufferedMode
+		indexedMemtablesEnabled = (!commandWALActive && c.shouldBufferIndexedInserts(meta)) || commandWALBufferedMode
+		bufferIndexedInserts = (!commandWALActive && c.shouldBufferIndexedInsertBatch(meta, len(documents))) || commandWALBufferedMode
 	}
 	if bufferIndexedInserts {
 		if normalizedDocumentFormat(plannerOptions.documentFormat) == DocumentFormatTemplateV1 {
@@ -9203,8 +9228,11 @@ func (c *Collection) insertBatchOnceWithLockState(
 				c.meta = meta
 				plannerOptions.learnTemplateIDs = templateEncoder != nil
 				plannerOptions.allowTemplateV1Stored = templateEncoder.allowsTemplateV1StoredDocuments(c)
-				indexedMemtablesEnabled = !commandWALActive && c.shouldBufferIndexedInserts(meta)
-				bufferIndexedInserts = !commandWALActive && c.shouldBufferIndexedInsertBatch(meta, len(documents))
+				commandWALNoIndexBufferedMode = c.canBufferCommandWALNoIndexInsertBatch(meta, plannerOptions.documentFormat, commandWALIntent, len(documents))
+				commandWALIndexedBufferedMode = c.canBufferCommandWALIndexedInsertBatch(meta, plannerOptions.documentFormat, commandWALIntent, len(documents))
+				commandWALBufferedMode = commandWALNoIndexBufferedMode || commandWALIndexedBufferedMode
+				indexedMemtablesEnabled = (!commandWALActive && c.shouldBufferIndexedInserts(meta)) || commandWALBufferedMode
+				bufferIndexedInserts = (!commandWALActive && c.shouldBufferIndexedInsertBatch(meta, len(documents))) || commandWALBufferedMode
 			}
 		}
 	}
@@ -9297,7 +9325,7 @@ func (c *Collection) insertBatchOnceWithLockState(
 			return nil, err
 		}
 		var bufferedCommandWALIntent *backenddb.CommandWALIntent
-		if commandWALNoIndexBufferedMode {
+		if commandWALBufferedMode {
 			docs, err := collectionDocumentsFromInsertPlan(plan, collectionPrimaryRootName(meta.Name))
 			if err != nil {
 				closePlanningSnapshot()

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3806,8 +3806,8 @@ func (c *Collection) canBufferCommandWALNoIndexInsertBatch(meta CollectionMeta, 
 	}
 }
 
-func (c *Collection) canBufferCommandWALIndexedInsertBatch(meta CollectionMeta, format DocumentFormat, commandWALIntent *backenddb.CommandWALIntent, documentCount int) bool {
-	if c == nil || c.db == nil || c.writeDomain == nil || commandWALIntent != nil || documentCount <= 0 {
+func (c *Collection) canUseCommandWALIndexedInsertBuffer(meta CollectionMeta, format DocumentFormat, commandWALIntent *backenddb.CommandWALIntent) bool {
+	if c == nil || c.db == nil || c.writeDomain == nil || commandWALIntent != nil {
 		return false
 	}
 	if !c.db.CommandWALEnabled() || c.db.DurabilityMode() == backenddb.DurabilityWALOffRelaxed {
@@ -3816,7 +3816,7 @@ func (c *Collection) canBufferCommandWALIndexedInsertBatch(meta CollectionMeta, 
 	if len(meta.VectorIndexes) != 0 || columnStoreWriteEnabled(meta) {
 		return false
 	}
-	if !c.shouldBufferIndexedInsertBatch(meta, documentCount) {
+	if !c.shouldBufferIndexedInserts(meta) {
 		return false
 	}
 	switch normalizedDocumentFormat(format) {
@@ -3825,6 +3825,12 @@ func (c *Collection) canBufferCommandWALIndexedInsertBatch(meta CollectionMeta, 
 	default:
 		return false
 	}
+}
+
+func (c *Collection) canBufferCommandWALIndexedInsertBatch(meta CollectionMeta, format DocumentFormat, commandWALIntent *backenddb.CommandWALIntent, documentCount int) bool {
+	return documentCount > 0 &&
+		c.canUseCommandWALIndexedInsertBuffer(meta, format, commandWALIntent) &&
+		c.shouldBufferIndexedInsertBatch(meta, documentCount)
 }
 
 func (c *Collection) canBufferDirectUpdateAck() bool {
@@ -9154,9 +9160,10 @@ func (c *Collection) insertBatchOnceWithLockState(
 		}
 	}
 	commandWALNoIndexBufferedMode := c.canBufferCommandWALNoIndexInsertBatch(meta, plannerOptions.documentFormat, commandWALIntent, len(documents))
+	commandWALIndexedBufferEnabled := c.canUseCommandWALIndexedInsertBuffer(meta, plannerOptions.documentFormat, commandWALIntent)
 	commandWALIndexedBufferedMode := c.canBufferCommandWALIndexedInsertBatch(meta, plannerOptions.documentFormat, commandWALIntent, len(documents))
 	commandWALBufferedMode := commandWALNoIndexBufferedMode || commandWALIndexedBufferedMode
-	indexedMemtablesEnabled := (!commandWALActive && c.shouldBufferIndexedInserts(meta)) || commandWALBufferedMode
+	indexedMemtablesEnabled := (!commandWALActive && c.shouldBufferIndexedInserts(meta)) || commandWALNoIndexBufferedMode || commandWALIndexedBufferEnabled
 	bufferIndexedInserts := (!commandWALActive && c.shouldBufferIndexedInsertBatch(meta, len(documents))) || commandWALBufferedMode
 	if indexedMemtablesEnabled && !bufferIndexedInserts {
 		closePlanningSnapshot()
@@ -9204,9 +9211,10 @@ func (c *Collection) insertBatchOnceWithLockState(
 		plannerOptions.allowTemplateV1Stored = templateEncoder.allowsTemplateV1StoredDocuments(c)
 		plannerOptions = collectionOptionsWithTemplateV1Resolver(plannerOptions, snap, catalog)
 		commandWALNoIndexBufferedMode = c.canBufferCommandWALNoIndexInsertBatch(meta, plannerOptions.documentFormat, commandWALIntent, len(documents))
+		commandWALIndexedBufferEnabled = c.canUseCommandWALIndexedInsertBuffer(meta, plannerOptions.documentFormat, commandWALIntent)
 		commandWALIndexedBufferedMode = c.canBufferCommandWALIndexedInsertBatch(meta, plannerOptions.documentFormat, commandWALIntent, len(documents))
 		commandWALBufferedMode = commandWALNoIndexBufferedMode || commandWALIndexedBufferedMode
-		indexedMemtablesEnabled = (!commandWALActive && c.shouldBufferIndexedInserts(meta)) || commandWALBufferedMode
+		indexedMemtablesEnabled = (!commandWALActive && c.shouldBufferIndexedInserts(meta)) || commandWALNoIndexBufferedMode || commandWALIndexedBufferEnabled
 		bufferIndexedInserts = (!commandWALActive && c.shouldBufferIndexedInsertBatch(meta, len(documents))) || commandWALBufferedMode
 	}
 	if bufferIndexedInserts {
@@ -9229,9 +9237,10 @@ func (c *Collection) insertBatchOnceWithLockState(
 				plannerOptions.learnTemplateIDs = templateEncoder != nil
 				plannerOptions.allowTemplateV1Stored = templateEncoder.allowsTemplateV1StoredDocuments(c)
 				commandWALNoIndexBufferedMode = c.canBufferCommandWALNoIndexInsertBatch(meta, plannerOptions.documentFormat, commandWALIntent, len(documents))
+				commandWALIndexedBufferEnabled = c.canUseCommandWALIndexedInsertBuffer(meta, plannerOptions.documentFormat, commandWALIntent)
 				commandWALIndexedBufferedMode = c.canBufferCommandWALIndexedInsertBatch(meta, plannerOptions.documentFormat, commandWALIntent, len(documents))
 				commandWALBufferedMode = commandWALNoIndexBufferedMode || commandWALIndexedBufferedMode
-				indexedMemtablesEnabled = (!commandWALActive && c.shouldBufferIndexedInserts(meta)) || commandWALBufferedMode
+				indexedMemtablesEnabled = (!commandWALActive && c.shouldBufferIndexedInserts(meta)) || commandWALNoIndexBufferedMode || commandWALIndexedBufferEnabled
 				bufferIndexedInserts = (!commandWALActive && c.shouldBufferIndexedInsertBatch(meta, len(documents))) || commandWALBufferedMode
 			}
 		}

--- a/TreeDB/collections/command_wal_test.go
+++ b/TreeDB/collections/command_wal_test.go
@@ -3,6 +3,7 @@ package collections
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -190,6 +191,75 @@ func TestCollectionCommandWALIndexedInsertBatchStagesAppliedLSNUntilFlush(t *tes
 	assertCollectionIndexIDs(t, reopened, "email", "ada@example.com", "u1")
 	if got := reopen.State().AppliedCommandLSN; got != 1 {
 		t.Fatalf("AppliedCommandLSN after reopen=%d, want 1", got)
+	}
+}
+
+func TestCollectionCommandWALIndexedInsertBatchFlushesBeforeDirectBypass(t *testing.T) {
+	dir := prepareCollectionCommandWALDir(t, CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			DocumentFormat: DocumentFormatBSON,
+		},
+		Indexes: []IndexDefinition{
+			{Name: "email", Field: "email", ValueType: IndexValueString, Unique: true},
+		},
+	})
+	d := openCollectionCommandWALDB(t, dir)
+	mgr := NewCollectionManager(d)
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("OpenCollection: %v", err)
+	}
+	firstDoc := mustBSONCollectionDocument(t, bson.D{
+		{Key: "_id", Value: "staged"},
+		{Key: "email", Value: "staged@example.com"},
+		{Key: "city", Value: "hnl"},
+	})
+	if _, err := col.InsertBatchValidatedBSON([][]byte{[]byte("staged")}, [][]byte{firstDoc}); err != nil {
+		t.Fatalf("staged InsertBatchValidatedBSON: %v", err)
+	}
+	if got := d.State().AppliedCommandLSN; got != 0 {
+		t.Fatalf("AppliedCommandLSN after staged indexed insert=%d, want 0 before bypass batch", got)
+	}
+
+	largeCount := DefaultIndexedWriteMemtableDirectBatchDocuments
+	ids := make([][]byte, largeCount)
+	docs := make([][]byte, largeCount)
+	for i := 0; i < largeCount; i++ {
+		id := fmt.Sprintf("bulk-%05d", i)
+		email := fmt.Sprintf("bulk-%05d@example.com", i)
+		ids[i] = []byte(id)
+		docs[i] = mustBSONCollectionDocument(t, bson.D{
+			{Key: "_id", Value: id},
+			{Key: "email", Value: email},
+			{Key: "city", Value: "hnl"},
+		})
+	}
+	if _, err := col.InsertBatchValidatedBSON(ids, docs); err != nil {
+		t.Fatalf("large bypass InsertBatchValidatedBSON: %v", err)
+	}
+	if got := d.State().AppliedCommandLSN; got != 2 {
+		t.Fatalf("AppliedCommandLSN after bypass batch=%d, want 2", got)
+	}
+	assertCollectionIndexIDs(t, col, "email", "staged@example.com", "staged")
+	assertCollectionIndexIDs(t, col, "email", "bulk-00000@example.com", "bulk-00000")
+	lastID := fmt.Sprintf("bulk-%05d", largeCount-1)
+	lastEmail := fmt.Sprintf("bulk-%05d@example.com", largeCount-1)
+	assertCollectionIndexIDs(t, col, "email", lastEmail, lastID)
+	if err := d.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	reopen := openCollectionCommandWALDB(t, dir)
+	defer func() { _ = reopen.Close() }()
+	reopened, err := NewCollectionManager(reopen).OpenCollection("users")
+	if err != nil {
+		t.Fatalf("OpenCollection reopen: %v", err)
+	}
+	assertCollectionIndexIDs(t, reopened, "email", "staged@example.com", "staged")
+	assertCollectionIndexIDs(t, reopened, "email", lastEmail, lastID)
+	if got := reopen.State().AppliedCommandLSN; got != 2 {
+		t.Fatalf("AppliedCommandLSN after reopen=%d, want 2", got)
 	}
 }
 

--- a/TreeDB/collections/command_wal_test.go
+++ b/TreeDB/collections/command_wal_test.go
@@ -119,6 +119,80 @@ func TestCollectionCommandWALInsertByIDStagesAppliedLSNUntilFlush(t *testing.T) 
 	}
 }
 
+func TestCollectionCommandWALIndexedInsertBatchStagesAppliedLSNUntilFlush(t *testing.T) {
+	dir := prepareCollectionCommandWALDir(t, CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			DocumentFormat: DocumentFormatBSON,
+		},
+		Indexes: []IndexDefinition{
+			{Name: "email", Field: "email", ValueType: IndexValueString, Unique: true},
+		},
+	})
+	d := openCollectionCommandWALDB(t, dir)
+	mgr := NewCollectionManager(d)
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("OpenCollection: %v", err)
+	}
+	doc := mustBSONCollectionDocument(t, bson.D{
+		{Key: "_id", Value: "u1"},
+		{Key: "email", Value: "ada@example.com"},
+		{Key: "city", Value: "hnl"},
+	})
+	if _, err := col.InsertBatchValidatedBSON([][]byte{[]byte("u1")}, [][]byte{doc}); err != nil {
+		t.Fatalf("InsertBatchValidatedBSON: %v", err)
+	}
+	got, found, err := col.GetInto([]byte("u1"), nil)
+	if err != nil {
+		t.Fatalf("buffered GetInto: %v", err)
+	}
+	if !found {
+		t.Fatal("buffered GetInto found=false")
+	}
+	if gotEmail := bson.Raw(got).Lookup("email").StringValue(); gotEmail != "ada@example.com" {
+		t.Fatalf("buffered email=%q, want ada@example.com", gotEmail)
+	}
+	assertCollectionIndexIDs(t, col, "email", "ada@example.com", "u1")
+	if got := d.State().AppliedCommandLSN; got != 0 {
+		t.Fatalf("AppliedCommandLSN after staged indexed insert=%d, want 0 before flush", got)
+	}
+	frames := collectionCommandWALFrames(t, dir)
+	if len(frames) != 1 || frames[0].Kind != commitlog.CommandKindCollectionInsertBatchByID {
+		t.Fatalf("command WAL frames=%+v, want one collection insert frame before flush", frames)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+	if got := d.State().AppliedCommandLSN; got != 1 {
+		t.Fatalf("AppliedCommandLSN after flush=%d, want 1", got)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	reopen := openCollectionCommandWALDB(t, dir)
+	defer func() { _ = reopen.Close() }()
+	reopened, err := NewCollectionManager(reopen).OpenCollection("users")
+	if err != nil {
+		t.Fatalf("OpenCollection reopen: %v", err)
+	}
+	got, found, err = reopened.GetInto([]byte("u1"), nil)
+	if err != nil {
+		t.Fatalf("reopen GetInto: %v", err)
+	}
+	if !found {
+		t.Fatal("reopen GetInto found=false")
+	}
+	if gotCity := bson.Raw(got).Lookup("city").StringValue(); gotCity != "hnl" {
+		t.Fatalf("reopen city=%q, want hnl", gotCity)
+	}
+	assertCollectionIndexIDs(t, reopened, "email", "ada@example.com", "u1")
+	if got := reopen.State().AppliedCommandLSN; got != 1 {
+		t.Fatalf("AppliedCommandLSN after reopen=%d, want 1", got)
+	}
+}
+
 func TestCollectionCommandWALInsertBatchByIDReplayRecoversUnappliedFrame(t *testing.T) {
 	dir := prepareCollectionCommandWALDir(t, CollectionMeta{
 		Name: "users",


### PR DESCRIPTION
## Summary

Fixes #2121.

This extends the command-WAL staged insert path to indexed JSON/BSON insert batches. Native YCSB creates a unique `_ycsb_key_1` index by default, so the previous no-index command-WAL staging fix did not apply: command-WAL native load still paid one ordered root publish per batch-1 insert.

The change keeps command-WAL intent append before staging, records the pending command-WAL LSN on the collection write domain, and preserves the ambiguous-commit wrapper if staging fails after the intent is appended.

## Tests

```sh
GOWORK=off go test ./TreeDB/collections -run 'TestCollectionCommandWAL(InsertBatchByIDStagesAppliedLSNUntilFlush|InsertByIDStagesAppliedLSNUntilFlush|IndexedInsertBatchStagesAppliedLSNUntilFlush|BSONYCSBPointLookupAfterLoad)' -count=1 -v
GOWORK=off go test ./TreeDB/nativewire ./TreeDB/collections ./cmd/treedb-native-server -count=1
```

Both passed on rebased head `36acd7723afcef1fe41faf121a2dce2b21d6984f`.

## Benchmark Evidence

Host/context inherited from #2121: `mikers-B560-DS3H-AC-Y1`, Intel i5-11400F, 12 logical CPUs, 31 GiB memory, Go `go1.25.7`, go-ycsb `304788add5117f471def2e23a14f10ee46146285`.

Exact command shape:

```sh
./bin/go-ycsb load treedb-native -p treedb.addr=127.0.0.1:<port> -p recordcount=100000 -p operationcount=10000 -p threadcount=16
./bin/go-ycsb run treedb-native -p treedb.addr=127.0.0.1:<port> -p recordcount=100000 -p operationcount=10000 -p threadcount=16
```

Artifacts: `/tmp/treedb_native_cwal_indexed_20260531_233828`.

| Profile | Baseline load from #2121 | This PR load | Run total | Errors |
| --- | ---: | ---: | ---: | ---: |
| `command_wal_relaxed` | `16,521.2 ops/s` | `60,090.9 ops/s` | `83,117.8 ops/s` | `0` printed YCSB operation errors |
| `command_wal_durable` | `15,399.2 ops/s` | `61,883.9 ops/s` | `69,702.2 ops/s` | `0` printed YCSB operation errors |

Longer CPU profile artifact: `/tmp/treedb_native_cwal_indexed_profile_20260531_233858`.

`command_wal_durable` 500k native load: `54,502.0 ops/s`, zero printed operation errors. CPU top now shifts away from ordered root publish: `insertBatchOnceWithLockState` is `25.75%` cumulative, `bufferIndexedInsertPlanLocked` is `17.03%` cumulative, `CommandJournal.AppendCommand` is `5.49%` cumulative, and the largest samples are syscall/network response writes and runtime scheduling.

## Risk

The main risk is command-WAL recovery/applied-LSN ordering for staged indexed inserts. The new regression test covers indexed BSON insert visibility before flush, command WAL frame emission, applied LSN staying at 0 before flush, advancing after flush, and reopen visibility through both primary and secondary index lookup.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced buffering mechanism for indexed batch inserts in command-WAL mode with stricter eligibility validation to ensure data integrity.

* **Tests**
  * Added test coverage for indexed batch inserts, verifying document readability, index persistence, and proper state management through flush and database recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->