### PR TITLE
Fix fast Mongo no-index buffered update cliff

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -14101,7 +14101,7 @@ func (c *Collection) shouldUseDirectBufferedUpdatePlan(meta CollectionMeta, opts
 
 func (c *Collection) updateBatchOnce(items []updateBatchItem, mode updateBatchMode, commandWALIntent *backenddb.CommandWALIntent) ([]UpdateBatchResult, error) {
 	commandWALBufferedMode := c.commandWALActive(commandWALIntent) && commandWALIntent == nil && mode != updateBatchModeAny
-	if (!c.commandWALActive(commandWALIntent) || commandWALBufferedMode) && (c.shouldPlanUpdateBatchWithBufferedWrites(mode) || commandWALBufferedMode) {
+	if (!c.commandWALActive(commandWALIntent) || commandWALBufferedMode) && (c.shouldPlanUpdateBatchWithBufferedWrites(mode, items) || commandWALBufferedMode) {
 		useBufferedRead := true
 		bufferedReadReplans := 0
 		for {
@@ -14396,7 +14396,24 @@ func (c *Collection) withMutationLock(fn func() error) error {
 	return fn()
 }
 
-func (c *Collection) shouldPlanUpdateBatchWithBufferedWrites(mode updateBatchMode) bool {
+func updateBatchCanStageDirectNoIndexTableUpdate(c *Collection, domain *collectionWriteDomain, mode updateBatchMode, items []updateBatchItem) bool {
+	if c == nil || domain == nil || mode != updateBatchModeNoSecondaryUniqueIndexChanges {
+		return false
+	}
+	if !c.canBufferDirectUpdateAck() || !updateBatchItemsAllHaveBSONSet(items) {
+		return false
+	}
+	meta := c.meta
+	if domain.loaded {
+		meta = domain.meta
+	}
+	if len(meta.Indexes) != 0 || columnStoreNeedsRetainedPayloadTransform(meta) {
+		return false
+	}
+	return isBSONDocumentFormat(normalizedDocumentFormat(meta.Options.DocumentFormat))
+}
+
+func (c *Collection) shouldPlanUpdateBatchWithBufferedWrites(mode updateBatchMode, items []updateBatchItem) bool {
 	if c == nil || c.writeDomain == nil {
 		return false
 	}
@@ -14406,7 +14423,16 @@ func (c *Collection) shouldPlanUpdateBatchWithBufferedWrites(mode updateBatchMod
 	domain := c.writeDomain
 	domain.mu.RLock()
 	defer domain.mu.RUnlock()
-	return domain.count > 0 && hasBufferedPrimaryWritesLocked(domain, c.meta.Name)
+	if domain.count == 0 {
+		return false
+	}
+	if hasBufferedIndexedPendingWrites(domain) {
+		return true
+	}
+	if hasBufferedNoIndexTableWritesLocked(domain) {
+		return updateBatchCanStageDirectNoIndexTableUpdate(c, domain, mode, items)
+	}
+	return hasBufferedPrimaryWritesLocked(domain, c.meta.Name)
 }
 
 func updateBatchCanReadBufferedDomainLocked(domain *collectionWriteDomain, meta CollectionMeta, baseSystemRoot uint64) bool {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3774,9 +3774,11 @@ func (c *Collection) insertOneNoIndexBuffered(id, document []byte) ([]byte, erro
 		}
 	}
 	domain.storagePolicy = plannerOptions.dataStoragePolicy
-	domain.table.SetEntry(id, document, page.ValuePtr{}, node.FlagInline)
-	domain.count++
 	resultID := bytes.Clone(id)
+	domain.table.SetEntry(resultID, document, page.ValuePtr{}, node.FlagInline)
+	domain.count++
+	domain.writeGeneration++
+	domain.notePrimaryWriteKeysLocked([][]byte{resultID}, domain.writeGeneration)
 	domain.mu.Unlock()
 	return resultID, nil
 }
@@ -3967,6 +3969,8 @@ func (c *Collection) bufferNoIndexInsertBatch(
 		domain.table.SetEntry(entry.id, entry.document, page.ValuePtr{}, node.FlagInline)
 	}
 	domain.count += len(entries)
+	domain.writeGeneration++
+	domain.notePrimaryWriteKeysLocked(resultIDs, domain.writeGeneration)
 	c.setLastInsertStats(CollectionInsertStats{
 		Documents: len(entries),
 		Indexes:   0,

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -15841,9 +15841,18 @@ func (c *Collection) stageDirectNoIndexTableUpdateLocked(domain *collectionWrite
 		domain.storagePolicy = policy
 	}
 	newEntries := 0
+	var stagedByteDelta int64
 	for _, entry := range direct.primaryEntries {
-		if _, _, _, found := domain.table.GetEntry(entry.key); !found {
+		entryBytes := int64(len(entry.key) + len(entry.value))
+		oldValue, _, _, found := domain.table.GetEntry(entry.key)
+		if !found {
 			newEntries++
+			stagedByteDelta = saturatingAddNonNegativeInt64(stagedByteDelta, entryBytes)
+		} else {
+			oldBytes := int64(len(entry.key) + len(oldValue))
+			if entryBytes > oldBytes {
+				stagedByteDelta = saturatingAddNonNegativeInt64(stagedByteDelta, entryBytes-oldBytes)
+			}
 		}
 		domain.table.SetEntry(entry.key, entry.value, page.ValuePtr{}, entry.flags)
 	}
@@ -15856,9 +15865,9 @@ func (c *Collection) stageDirectNoIndexTableUpdateLocked(domain *collectionWrite
 		domain.primaryRoot = plan.catalog.rootID(collectionPrimaryRootName(plan.meta.Name))
 	}
 	domain.count = saturatingAddNonNegativeInt(domain.count, newEntries)
-	domain.bufferedBytes = saturatingAddNonNegativeInt64(domain.bufferedBytes, direct.stagedBytes)
+	domain.bufferedBytes = saturatingAddNonNegativeInt64(domain.bufferedBytes, stagedByteDelta)
 	domain.mutableCount = saturatingAddNonNegativeInt(domain.mutableCount, modifiedCount)
-	domain.mutableBytes = saturatingAddNonNegativeInt64(domain.mutableBytes, direct.stagedBytes)
+	domain.mutableBytes = saturatingAddNonNegativeInt64(domain.mutableBytes, stagedByteDelta)
 	domain.indexedDeletesOnly = false
 	domain.writeGeneration++
 	domain.notePrimaryWriteEntriesLocked(direct.primaryEntries, domain.writeGeneration)

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -4285,6 +4285,7 @@ func (c *Collection) flushBufferedNoIndexLocked(domain *collectionWriteDomain) e
 	domain.primaryRoot = rootIDs[0]
 	domain.table = newCollectionRunTable(0)
 	domain.count = 0
+	domain.bufferedBytes = 0
 	domain.indexedDeletesOnly = false
 	domain.mutableCount = 0
 	domain.mutableBytes = 0
@@ -6703,6 +6704,10 @@ func hasPendingIndexedPrimaryOverlay(domain *collectionWriteDomain) bool {
 	return domain != nil &&
 		(hasIndexedFlushUnitPrimaryOverlay(domain.indexedFlushUnits) ||
 			hasIndexedFlushUnitPrimaryOverlay(domain.indexedPublishingUnits))
+}
+
+func hasBufferedNoIndexTableWritesLocked(domain *collectionWriteDomain) bool {
+	return domain != nil && domain.table != nil && domain.table.Len() > 0
 }
 
 func hasBufferedIndexedPendingWrites(domain *collectionWriteDomain) bool {
@@ -14401,11 +14406,11 @@ func (c *Collection) shouldPlanUpdateBatchWithBufferedWrites(mode updateBatchMod
 	domain := c.writeDomain
 	domain.mu.RLock()
 	defer domain.mu.RUnlock()
-	return domain.count > 0 && hasBufferedIndexedPendingWrites(domain)
+	return domain.count > 0 && hasBufferedPrimaryWritesLocked(domain, c.meta.Name)
 }
 
 func updateBatchCanReadBufferedDomainLocked(domain *collectionWriteDomain, meta CollectionMeta, baseSystemRoot uint64) bool {
-	if domain == nil || domain.count == 0 || !hasBufferedIndexedPendingWrites(domain) {
+	if domain == nil || domain.count == 0 || !hasBufferedPrimaryWritesLocked(domain, meta.Name) {
 		return false
 	}
 	if !domain.loaded || domain.catalog == nil {
@@ -14607,6 +14612,31 @@ func snapshotUpdateBatchBufferedPrimaryEntriesFromIndex(index *bufferedPrimaryRu
 	return entries, buffer, nil
 }
 
+func fillUpdateBatchBufferedPrimaryEntriesFromTable(entries []updateBatchBufferedEntry, buffer *updateBatchBufferedEntryBuffer, table memtable.Table, items []updateBatchItem, missing int) int {
+	if table == nil || missing <= 0 {
+		return missing
+	}
+	for i, item := range items {
+		if entries[i].found {
+			continue
+		}
+		value, _, flags, found := table.GetEntry(item.DocumentID)
+		if !found {
+			continue
+		}
+		entries[i] = updateBatchBufferedEntry{
+			value: buffer.copyValue(value),
+			flags: flags,
+			found: true,
+		}
+		missing--
+		if missing <= 0 {
+			break
+		}
+	}
+	return missing
+}
+
 func snapshotUpdateBatchBufferedPrimaryEntriesLocked(domain *collectionWriteDomain, collectionName string, items []updateBatchItem) ([]updateBatchBufferedEntry, *updateBatchBufferedEntryBuffer, error) {
 	entries, buffer := getUpdateBatchBufferedEntries(len(items))
 	if domain == nil || len(items) == 0 {
@@ -14684,10 +14714,12 @@ func snapshotUpdateBatchBufferedPrimaryEntriesLocked(domain *collectionWriteDoma
 			}
 			missing--
 		}
+		fillUpdateBatchBufferedPrimaryEntriesFromTable(entries, buffer, domain.table, items, missing)
 		return entries, buffer, nil
 	}
 	runs := pendingIndexedRootRunsLocked(domain, collectionPrimaryRootName(collectionName))
 	if len(runs) == 0 {
+		fillUpdateBatchBufferedPrimaryEntriesFromTable(entries, buffer, domain.table, items, missing)
 		return entries, buffer, nil
 	}
 	if len(runs) <= 1 || len(runs)*len(items) <= updateBatchBufferedPrimaryDirectProbeLimit {
@@ -14703,6 +14735,7 @@ func snapshotUpdateBatchBufferedPrimaryEntriesLocked(domain *collectionWriteDoma
 				}
 			}
 		}
+		fillUpdateBatchBufferedPrimaryEntriesFromTable(entries, buffer, domain.table, items, missing)
 		return entries, buffer, nil
 	}
 	targets := make(map[string]int, missing)
@@ -14737,6 +14770,7 @@ func snapshotUpdateBatchBufferedPrimaryEntriesLocked(domain *collectionWriteDoma
 		}
 		_ = it.Close()
 	}
+	fillUpdateBatchBufferedPrimaryEntriesFromTable(entries, buffer, domain.table, items, len(targets))
 	return entries, buffer, nil
 }
 
@@ -14801,7 +14835,7 @@ func snapshotUpdateBatchBufferedReadLocked(domain *collectionWriteDomain, meta C
 			writeGeneration: domain.writeGeneration,
 		}, templateRuns, false, false, false, nil
 	}
-	if domain.count > 0 && hasBufferedIndexedPendingWrites(domain) {
+	if domain.count > 0 && hasBufferedPrimaryWritesLocked(domain, meta.Name) {
 		return updateBatchBufferedRead{}, nil, true, false, false, nil
 	}
 	if updateBatchBufferedSnapshotStaleLocked(domain, baseCommitSeq, baseSystemRoot) {
@@ -15754,6 +15788,62 @@ func (c *Collection) stageDirectPrimaryOverlayLocked(domain *collectionWriteDoma
 	return true, nil
 }
 
+func (c *Collection) stageDirectNoIndexTableUpdateLocked(domain *collectionWriteDomain, plan *updateBatchPlan, modifiedCount int) (bool, error) {
+	if c == nil || domain == nil || plan == nil || plan.directBufferedUpdate == nil {
+		return false, nil
+	}
+	direct := plan.directBufferedUpdate
+	if len(plan.meta.Indexes) != 0 ||
+		len(direct.templateEntries) != 0 ||
+		len(direct.secondaryRootPlans) != 0 ||
+		!hasBufferedNoIndexTableWritesLocked(domain) ||
+		hasBufferedIndexedPendingWrites(domain) {
+		return false, nil
+	}
+	if direct.primaryRootName == "" || direct.primaryRootName != collectionPrimaryRootName(plan.meta.Name) {
+		return false, nil
+	}
+	baseRoot, ok := plan.baseRootIDs[direct.primaryRootName]
+	if !ok {
+		return false, fmt.Errorf("collections: UpdateBatch collection %q direct no-index table update missing base root for %q", plan.meta.Name, direct.primaryRootName)
+	}
+	if domain.primaryRoot != baseRoot {
+		return false, errConcurrentRootModification(plan.meta.Name, direct.primaryRootName)
+	}
+	policy, ok := directUpdatePrimaryRootPolicy(plan, direct.primaryRootName)
+	if ok {
+		domain.storagePolicy = policy
+	}
+	newEntries := 0
+	for _, entry := range direct.primaryEntries {
+		if _, _, _, found := domain.table.GetEntry(entry.key); !found {
+			newEntries++
+		}
+		domain.table.SetEntry(entry.key, entry.value, page.ValuePtr{}, entry.flags)
+	}
+	domain.loaded = true
+	domain.meta = plan.meta
+	domain.catalog = plan.catalog
+	domain.baseCommitSeq = plan.baseCommitSeq
+	domain.baseSystemRoot = plan.baseSystemRoot
+	if plan.catalog != nil {
+		domain.primaryRoot = plan.catalog.rootID(collectionPrimaryRootName(plan.meta.Name))
+	}
+	domain.count = saturatingAddNonNegativeInt(domain.count, newEntries)
+	domain.bufferedBytes = saturatingAddNonNegativeInt64(domain.bufferedBytes, direct.stagedBytes)
+	domain.mutableCount = saturatingAddNonNegativeInt(domain.mutableCount, modifiedCount)
+	domain.mutableBytes = saturatingAddNonNegativeInt64(domain.mutableBytes, direct.stagedBytes)
+	domain.indexedDeletesOnly = false
+	domain.writeGeneration++
+	domain.notePrimaryWriteEntriesLocked(direct.primaryEntries, domain.writeGeneration)
+	if modifiedCount > 0 {
+		domain.observePrimaryOnlyUpdateBatch(plan.stats.Items, plan.stats.Matched, plan.stats.Modified, false, collectionRootDeltaPlanStats{})
+	}
+	c.meta = plan.meta
+	plan.stats.BufferedBatches = 1
+	return true, nil
+}
+
 func (c *Collection) bufferDirectUpdateBatchPlanLocked(plan *updateBatchPlan) (buffered bool, err error) {
 	if c == nil || plan == nil || plan.directBufferedUpdate == nil || len(plan.directBufferedUpdate.primaryEntries) == 0 {
 		return false, nil
@@ -15947,6 +16037,14 @@ func (c *Collection) bufferDirectUpdateBatchPlanLocked(plan *updateBatchPlan) (b
 	}
 	if err := appendCommandWALBeforeStage(); err != nil {
 		return false, err
+	}
+	if primaryOnlyDirectUpdate && commandWALStageIntent == nil && hasBufferedNoIndexTableWritesLocked(domain) && !hasBufferedIndexedPendingWrites(domain) {
+		tableAppendStart := updateBatchStatsNow(detailedStats)
+		buffered, err := c.stageDirectNoIndexTableUpdateLocked(domain, plan, modifiedCount)
+		tableAppendDuration := updateBatchStatsSince(detailedStats, tableAppendStart)
+		plan.stats.BufferStagePrimaryAppend += tableAppendDuration
+		plan.stats.BufferStageRootAppend += tableAppendDuration
+		return buffered, err
 	}
 	if canStageDirectPrimaryOverlay(plan, direct, primaryOnlyDirectUpdate, shouldAutoFlushAfterAdding || overlayWouldFlush) {
 		overlayAppendStart := updateBatchStatsNow(detailedStats)
@@ -18027,6 +18125,9 @@ func hasBufferedPrimaryRootRuns(domain *collectionWriteDomain, fallbackCollectio
 }
 
 func hasBufferedPrimaryWritesLocked(domain *collectionWriteDomain, fallbackCollectionName string) bool {
+	if hasBufferedNoIndexTableWritesLocked(domain) {
+		return true
+	}
 	if hasBufferedPrimaryOverlay(domain) {
 		return true
 	}

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -14513,6 +14513,98 @@ func TestCollectionUpdateBSONSetBatchReadsNoIndexBufferedInsertWithoutFlush(t *t
 	}
 }
 
+func TestCollectionUpdateBSONSetBatchNoIndexBufferedInsertInvalidatesStalePlan(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{
+		Dir:        t.TempDir(),
+		Durability: backenddb.DurabilityWALOffRelaxed,
+	})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			DocumentFormat: DocumentFormatBSON,
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatchValidatedBSON(
+		[][]byte{[]byte("u1")},
+		[][]byte{mustBSONCollectionDocument(t, bson.D{{Key: "_id", Value: "u1"}, {Key: "city", Value: "hnl"}})},
+	); err != nil {
+		t.Fatalf("insert first buffered BSON document: %v", err)
+	}
+
+	col.writeDomain.mu.RLock()
+	initialGeneration := col.writeDomain.writeGeneration
+	var firstWriteGeneration uint64
+	var firstWriteNoted bool
+	if col.writeDomain.primaryWriteIndex != nil {
+		firstWriteGeneration, firstWriteNoted = col.writeDomain.primaryWriteIndex.generation([]byte("u1"))
+	}
+	col.writeDomain.mu.RUnlock()
+	if initialGeneration == 0 {
+		t.Fatalf("initial buffered insert write generation=0")
+	}
+	if !firstWriteNoted || firstWriteGeneration != initialGeneration {
+		t.Fatalf("primary write generation for u1=%d noted=%v want %d/true", firstWriteGeneration, firstWriteNoted, initialGeneration)
+	}
+
+	spec, err := newBSONSetUpdate([]BSONSetField{{
+		Key:   "city",
+		Value: mustBSONRawValue(t, "sea"),
+	}})
+	if err != nil {
+		t.Fatalf("prepare bson set spec: %v", err)
+	}
+	plan, err := col.buildUpdateBatchPlan([]updateBatchItem{
+		newBSONSetUpdateBatchItem([]byte("u1"), spec),
+	}, updateBatchModeNoSecondaryUniqueIndexChanges, true, nil)
+	if err != nil {
+		t.Fatalf("build buffered plan: %v", err)
+	}
+	defer plan.close()
+	if !plan.bufferedBase || plan.bufferedReadGeneration != initialGeneration {
+		t.Fatalf("plan bufferedBase=%v generation=%d want true/%d", plan.bufferedBase, plan.bufferedReadGeneration, initialGeneration)
+	}
+	if !col.bufferedUpdateBatchPlanStillCurrent(plan) {
+		t.Fatalf("fresh buffered plan unexpectedly stale")
+	}
+
+	if _, err := col.InsertBatchValidatedBSON(
+		[][]byte{[]byte("u2")},
+		[][]byte{mustBSONCollectionDocument(t, bson.D{{Key: "_id", Value: "u2"}, {Key: "city", Value: "hnl"}})},
+	); err != nil {
+		t.Fatalf("insert second buffered BSON document: %v", err)
+	}
+
+	col.writeDomain.mu.RLock()
+	afterGeneration := col.writeDomain.writeGeneration
+	var secondWriteGeneration uint64
+	var secondWriteNoted bool
+	if col.writeDomain.primaryWriteIndex != nil {
+		secondWriteGeneration, secondWriteNoted = col.writeDomain.primaryWriteIndex.generation([]byte("u2"))
+	}
+	col.writeDomain.mu.RUnlock()
+	if afterGeneration <= initialGeneration {
+		t.Fatalf("second buffered insert write generation=%d want > %d", afterGeneration, initialGeneration)
+	}
+	if !secondWriteNoted || secondWriteGeneration != afterGeneration {
+		t.Fatalf("primary write generation for u2=%d noted=%v want %d/true", secondWriteGeneration, secondWriteNoted, afterGeneration)
+	}
+	if col.bufferedUpdateBatchPlanStillCurrent(plan) {
+		t.Fatalf("buffered update plan stayed current after a later buffered insert")
+	}
+}
+
 func TestCollectionUpdateBSONSetBatchFlushesStaleNoIndexBufferedInsert(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{
 		Dir:        t.TempDir(),

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -14567,6 +14567,71 @@ func TestCollectionUpdateBSONSetBatchFlushesStaleNoIndexBufferedInsert(t *testin
 	}
 }
 
+func TestCollectionUpdateBatchGenericFlushesNoIndexBufferedInsertBeforeCallback(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{
+		Dir:        t.TempDir(),
+		Durability: backenddb.DurabilityWALOffRelaxed,
+	})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			DocumentFormat: DocumentFormatBSON,
+		},
+	}); err != nil {
+		t.Fatalf("create users collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open users collection: %v", err)
+	}
+	before := d.State()
+	if _, err := col.InsertBatchValidatedBSON(
+		[][]byte{[]byte("u1")},
+		[][]byte{mustBSONCollectionDocument(t, bson.D{{Key: "_id", Value: "u1"}, {Key: "city", Value: "hnl"}})},
+	); err != nil {
+		t.Fatalf("insert buffered BSON document: %v", err)
+	}
+
+	var callbackCalls atomic.Int32
+	setCity := setBSONField("city", "sea")
+	results, batched, err := col.UpdateBatchIfNoSecondaryUniqueIndexChanges([]UpdateBatchItem{{
+		DocumentID: []byte("u1"),
+		Update: func(current []byte) ([]byte, bool, error) {
+			callbackCalls.Add(1)
+			return setCity(current)
+		},
+	}})
+	if err != nil {
+		t.Fatalf("UpdateBatchIfNoSecondaryUniqueIndexChanges: %v", err)
+	}
+	if !batched {
+		t.Fatalf("batched=%v results=%+v want batched", batched, results)
+	}
+	if got := callbackCalls.Load(); got != 1 {
+		t.Fatalf("callback calls=%d want 1", got)
+	}
+	if len(results) != 1 || !results[0].Matched || !results[0].Modified {
+		t.Fatalf("results=%+v want one modified row", results)
+	}
+	after := d.State()
+	if after.CommitSeq != before.CommitSeq+2 {
+		t.Fatalf("generic update advanced commit seq by %d, want buffered flush plus update publish", after.CommitSeq-before.CommitSeq)
+	}
+	doc, err := col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get updated BSON document: %v", err)
+	}
+	if got := bson.Raw(doc).Lookup("city").StringValue(); got != "sea" {
+		t.Fatalf("city=%q want sea", got)
+	}
+}
+
 func TestCollectionUpdateBatchIfNoSecondaryUniqueIndexChangesBuffersStaleNonOverlappingPrimaryOnlyDirectPlan(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{
 		Dir:        t.TempDir(),

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -14431,24 +14431,29 @@ func TestCollectionUpdateBSONSetBatchReadsNoIndexBufferedInsertWithoutFlush(t *t
 		t.Fatalf("open collection: %v", err)
 	}
 	before := d.State()
-	if _, err := col.InsertBatchValidatedBSON(
-		[][]byte{[]byte("u1"), []byte("u2")},
-		[][]byte{
-			mustBSONCollectionDocument(t, bson.D{{Key: "_id", Value: "u1"}, {Key: "city", Value: "hnl"}}),
-			mustBSONCollectionDocument(t, bson.D{{Key: "_id", Value: "u2"}, {Key: "city", Value: "hnl"}}),
-		},
-	); err != nil {
+	ids := [][]byte{[]byte("u1"), []byte("u2")}
+	docs := [][]byte{
+		mustBSONCollectionDocument(t, bson.D{{Key: "_id", Value: "u1"}, {Key: "city", Value: "hnl"}}),
+		mustBSONCollectionDocument(t, bson.D{{Key: "_id", Value: "u2"}, {Key: "city", Value: "hnl"}}),
+	}
+	wantBuffered := len(ids)
+	if wantBuffered != len(docs) {
+		t.Fatalf("test fixture ids=%d docs=%d", len(ids), len(docs))
+	}
+	if _, err := col.InsertBatchValidatedBSON(ids, docs); err != nil {
 		t.Fatalf("insert buffered BSON documents: %v", err)
 	}
 	col.writeDomain.mu.RLock()
 	bufferedCount := col.writeDomain.count
+	bufferedBytes := col.writeDomain.bufferedBytes
+	mutableBytes := col.writeDomain.mutableBytes
 	tableLen := 0
 	if col.writeDomain.table != nil {
 		tableLen = col.writeDomain.table.Len()
 	}
 	col.writeDomain.mu.RUnlock()
-	if bufferedCount != 2 || tableLen != 2 {
-		t.Fatalf("buffered count=%d tableLen=%d want 2/2", bufferedCount, tableLen)
+	if bufferedCount != wantBuffered || tableLen != wantBuffered {
+		t.Fatalf("buffered count=%d tableLen=%d want %d/%d", bufferedCount, tableLen, wantBuffered, wantBuffered)
 	}
 
 	results, batched, err := col.UpdateBSONSetBatchIfNoSecondaryUniqueIndexChanges([]BSONSetUpdateBatchItem{{
@@ -14480,9 +14485,17 @@ func TestCollectionUpdateBSONSetBatchReadsNoIndexBufferedInsertWithoutFlush(t *t
 	}
 	col.writeDomain.mu.RLock()
 	bufferedCount = col.writeDomain.count
+	bufferedBytesAfterUpdate := col.writeDomain.bufferedBytes
+	mutableBytesAfterUpdate := col.writeDomain.mutableBytes
 	col.writeDomain.mu.RUnlock()
-	if bufferedCount != 2 {
-		t.Fatalf("after update buffered count=%d want 2", bufferedCount)
+	if bufferedCount != wantBuffered {
+		t.Fatalf("after update buffered count=%d want %d", bufferedCount, wantBuffered)
+	}
+	if bufferedBytesAfterUpdate != bufferedBytes {
+		t.Fatalf("after same-size update bufferedBytes=%d want %d", bufferedBytesAfterUpdate, bufferedBytes)
+	}
+	if mutableBytesAfterUpdate != mutableBytes {
+		t.Fatalf("after same-size update mutableBytes=%d want %d", mutableBytesAfterUpdate, mutableBytes)
 	}
 	if err := col.Flush(); err != nil {
 		t.Fatalf("flush buffered insert+update: %v", err)

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -14407,6 +14407,166 @@ func TestCollectionUpdateBatchIfNoSecondaryUniqueIndexChangesRejectsStalePrimary
 	}
 }
 
+func TestCollectionUpdateBSONSetBatchReadsNoIndexBufferedInsertWithoutFlush(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{
+		Dir:        t.TempDir(),
+		Durability: backenddb.DurabilityWALOffRelaxed,
+	})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			DocumentFormat: DocumentFormatBSON,
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	before := d.State()
+	if _, err := col.InsertBatchValidatedBSON(
+		[][]byte{[]byte("u1"), []byte("u2")},
+		[][]byte{
+			mustBSONCollectionDocument(t, bson.D{{Key: "_id", Value: "u1"}, {Key: "city", Value: "hnl"}}),
+			mustBSONCollectionDocument(t, bson.D{{Key: "_id", Value: "u2"}, {Key: "city", Value: "hnl"}}),
+		},
+	); err != nil {
+		t.Fatalf("insert buffered BSON documents: %v", err)
+	}
+	col.writeDomain.mu.RLock()
+	bufferedCount := col.writeDomain.count
+	tableLen := 0
+	if col.writeDomain.table != nil {
+		tableLen = col.writeDomain.table.Len()
+	}
+	col.writeDomain.mu.RUnlock()
+	if bufferedCount != 2 || tableLen != 2 {
+		t.Fatalf("buffered count=%d tableLen=%d want 2/2", bufferedCount, tableLen)
+	}
+
+	results, batched, err := col.UpdateBSONSetBatchIfNoSecondaryUniqueIndexChanges([]BSONSetUpdateBatchItem{{
+		DocumentID: []byte("u1"),
+		Fields: []BSONSetField{{
+			Key:   "city",
+			Value: mustBSONRawValue(t, "sea"),
+		}},
+	}})
+	if err != nil {
+		t.Fatalf("UpdateBSONSetBatchIfNoSecondaryUniqueIndexChanges: %v", err)
+	}
+	if !batched {
+		t.Fatalf("batched=%v results=%+v want batched", batched, results)
+	}
+	if len(results) != 1 || !results[0].Matched || !results[0].Modified {
+		t.Fatalf("results=%+v want one modified row", results)
+	}
+	afterUpdate := d.State()
+	if afterUpdate.CommitSeq != before.CommitSeq {
+		t.Fatalf("buffered insert+update advanced commit seq by %d, want 0", afterUpdate.CommitSeq-before.CommitSeq)
+	}
+	doc, err := col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get updated buffered BSON document: %v", err)
+	}
+	if got := bson.Raw(doc).Lookup("city").StringValue(); got != "sea" {
+		t.Fatalf("city=%q want sea", got)
+	}
+	col.writeDomain.mu.RLock()
+	bufferedCount = col.writeDomain.count
+	col.writeDomain.mu.RUnlock()
+	if bufferedCount != 2 {
+		t.Fatalf("after update buffered count=%d want 2", bufferedCount)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush buffered insert+update: %v", err)
+	}
+	flushed := d.State()
+	if flushed.CommitSeq != before.CommitSeq+1 {
+		t.Fatalf("flush advanced commit seq by %d, want 1", flushed.CommitSeq-before.CommitSeq)
+	}
+	doc, err = col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get flushed BSON document: %v", err)
+	}
+	if got := bson.Raw(doc).Lookup("city").StringValue(); got != "sea" {
+		t.Fatalf("flushed city=%q want sea", got)
+	}
+}
+
+func TestCollectionUpdateBSONSetBatchFlushesStaleNoIndexBufferedInsert(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{
+		Dir:        t.TempDir(),
+		Durability: backenddb.DurabilityWALOffRelaxed,
+	})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			DocumentFormat: DocumentFormatBSON,
+		},
+	}); err != nil {
+		t.Fatalf("create users collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open users collection: %v", err)
+	}
+	if _, err := col.InsertBatchValidatedBSON(
+		[][]byte{[]byte("u1")},
+		[][]byte{mustBSONCollectionDocument(t, bson.D{{Key: "_id", Value: "u1"}, {Key: "city", Value: "hnl"}})},
+	); err != nil {
+		t.Fatalf("insert buffered BSON document: %v", err)
+	}
+	beforeSchemaChange := d.State()
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "audit"}); err != nil {
+		t.Fatalf("create audit collection: %v", err)
+	}
+	afterSchemaChange := d.State()
+	if afterSchemaChange.SystemRootPageID == beforeSchemaChange.SystemRootPageID {
+		t.Fatalf("schema change did not advance system root: before=%d after=%d", beforeSchemaChange.SystemRootPageID, afterSchemaChange.SystemRootPageID)
+	}
+
+	results, batched, err := col.UpdateBSONSetBatchIfNoSecondaryUniqueIndexChanges([]BSONSetUpdateBatchItem{{
+		DocumentID: []byte("u1"),
+		Fields: []BSONSetField{{
+			Key:   "city",
+			Value: mustBSONRawValue(t, "sea"),
+		}},
+	}})
+	if err != nil {
+		t.Fatalf("UpdateBSONSetBatchIfNoSecondaryUniqueIndexChanges: %v", err)
+	}
+	if !batched {
+		t.Fatalf("batched=%v results=%+v want batched", batched, results)
+	}
+	if len(results) != 1 || !results[0].Matched || !results[0].Modified {
+		t.Fatalf("results=%+v want one modified row from flushed buffered insert", results)
+	}
+	afterUpdate := d.State()
+	if afterUpdate.CommitSeq == afterSchemaChange.CommitSeq {
+		t.Fatalf("stale buffered insert was not flushed before update: commit seq stayed %d", afterUpdate.CommitSeq)
+	}
+	doc, err := col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get updated BSON document: %v", err)
+	}
+	if got := bson.Raw(doc).Lookup("city").StringValue(); got != "sea" {
+		t.Fatalf("city=%q want sea", got)
+	}
+}
+
 func TestCollectionUpdateBatchIfNoSecondaryUniqueIndexChangesBuffersStaleNonOverlappingPrimaryOnlyDirectPlan(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{
 		Dir:        t.TempDir(),


### PR DESCRIPTION
## Objective
Fixes #2115 by letting fast-profile BSON no-index updates read and restage unflushed no-index insert-buffer entries instead of forcing the first post-load update to publish the full load buffer.

## Context
The remaining Mongo YCSB gap was a reproducible first-run cliff after load: main at e109e02df showed fast Mongo first run 24,045.9 ops/s with p999 235.1ms / max 236.2ms, while reopening the loaded DB removed the cliff. Perf attributed the stall to runtime.memmove under Collection.flushBufferedNoIndexLocked reached from the first BSON $set update.

## Design
- Treat the no-index write-domain table as readable buffered primary state for update-batch planning when the catalog/system-root snapshot is still current.
- Fill buffered update reads from domain.table after indexed overlays/runs.
- Stage primary-only BSON no-index updates back into the same no-index table when command WAL is not active and there are no indexed pending writes.
- Preserve fail-closed behavior: stale system roots still force a flush/replan, root mismatch still reports concurrent mutation, and no-index buffered inserts now advance write-domain generation / primary-write accounting so stale optimistic plans are invalidated or conflict-checked.
- Account only positive staged-byte growth for in-table overwrites so repeated buffered updates do not inflate flush-pressure counters.

## Scope
Includes:
- TreeDB/collections/api.go: buffered-read detection, no-index table read fill, no-index table update staging, buffered byte reset on flush, overwrite byte-delta accounting, no-index buffered insert generation accounting.
- TreeDB/collections/api_test.go: BSON no-index buffered insert/update regression coverage, stale-root fail-closed coverage, generic callback flush coverage, overwrite counter coverage, stale-plan invalidation coverage.

Excludes:
- Command-WAL semantics.
- Indexed collection buffering.
- Workload changes.

## Correctness
Latest local validation on head 6f81bfb74:
- `GOWORK=off go test ./TreeDB/collections -run 'TestCollectionUpdateBSONSetBatch(NoIndexBufferedInsertInvalidatesStalePlan|ReadsNoIndexBufferedInsertWithoutFlush|FlushesStaleNoIndexBufferedInsert)|TestCollectionUpdateBatchGenericFlushesNoIndexBufferedInsertBeforeCallback|TestCollectionUpdateBatchIfNoSecondaryUniqueIndexChanges(RejectsStalePrimaryOnlyDirectPlan|ReadsBufferedInsert)' -count=1`
- `GOWORK=off go test ./TreeDB/collections -count=1`
- `GOWORK=off go test ./TreeDB/mongo_gateway -count=1`
- `GOWORK=off go test ./TreeDB/nativewire ./cmd/treedb-native-server -count=1`
- `git diff --check`

Regression coverage:
- BSON no-index buffered insert followed by BSON $set no longer advances commit seq before flush.
- Same-size buffered BSON $set does not inflate bufferedBytes or mutableBytes.
- Stale no-index buffered insert after system-root/catalog drift still flushes before update.
- Generic callback updates still flush no-index buffered inserts before invoking the callback.
- Later no-index buffered inserts advance write generation and primary-write accounting so an older buffered update plan no longer reports current.

## Performance
Benchmark command shape:
- Built `./bin/treedb-mongo-gateway` from head 6f81bfb74.
- Fresh DB: `./bin/treedb-mongo-gateway -dir "$DB_DIR" -profile fast -document-format bson -addr 127.0.0.1:<port>`
- YCSB Mongo with `mongodb://127.0.0.1:<port>/ycsb?w=1`, `recordcount=100000`, `operationcount=10000`, `threadcount=16`.

Latest native+Mongo gateway harness artifact: `/tmp/treedb_ycsb_fast_mongo_pr2130_genfix_20260601_013506`

| Target | Case | OPS | Avg us | p99 us | p999 us | Max us | Errors |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
| TreeDB Mongo gateway | load | 62,439.7 | 237 | 851 | 1,683 | 20,847 | 0 |
| TreeDB Mongo gateway | first run after load | 59,320.8 | 259 | 966 | 1,947 | 2,209 | 0 |
| TreeDB Mongo gateway | second run | 61,320.6 | 248 | 1,043 | 2,055 | 2,653 | 0 |
| TreeDB nativewire | load | 70,897.1 | 207 | 593 | 3,051 | 12,407 | 0 |
| TreeDB nativewire | first run after load | 95,931.8 | 160 | 681 | 1,493 | 2,965 | 0 |
| TreeDB nativewire | second run | 92,967.0 | 162 | 802 | 2,649 | 3,729 | 0 |

Earlier PR artifact `/tmp/treedb_ycsb_fast_mongo_pr2130_20260601_011548` on 188ab81d1 showed TreeDB Mongo gateway load 61,564.3 ops/s and first run 57,373.5 ops/s with zero errors. The generation-accounting fix did not regress the measured YCSB shape.

Before on main e109e02df, artifact `/tmp/treedb_ycsb_final_main_20260601_001138`: fast Mongo first run 24,045.9 ops/s, p999 235.1ms, max 236.2ms, zero errors.

## Rollout / Toggle Plan
Default behavior only changes for non-command-WAL, no-index BSON direct buffered updates when the buffered domain is current. Stale domains keep the existing flush/replan safety path.

## AI Review Loop
The PR was updated only after local tests and benchmark evidence were attached. Review findings were fixed through head 6f81bfb74; review threads were replied to and resolved before another review pass is requested.

## Follow-ups
After merge, rerun the broader YCSB matrix and update #2106/#2115 with the remaining-gap review.
