### PR TITLE
Optimize projected primary-key find path

### DIFF
--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -687,6 +687,13 @@ func (s *Server) findResponsePayload(command wire.Document, cursorOwner int64) (
 		return findResponsePayload{document: doc}, err
 	}
 	ns := db + "." + collection
+	if payload, ok, err := s.findSimpleProjectedPrimaryEqualityPayload(col, ns, plan, int(batchSize), batchSizeSet); ok || err != nil {
+		if err != nil {
+			doc, err := commandError(commandCodeBadValue, "BadValue", err.Error())
+			return findResponsePayload{document: doc}, err
+		}
+		return payload, nil
+	}
 	if !plan.projection.present {
 		idx, opts, limit, ok, empty, err := pureIndexedRangeLimitPlan(col.Meta(), plan, s.maxFindScanDocuments())
 		if err != nil {
@@ -781,6 +788,58 @@ func (s *Server) findResponsePayload(command wire.Document, cursorOwner int64) (
 	}
 	doc, err := marshalCursorResponseWithID(ns, cursorID, "firstBatch", firstBatch)
 	return findResponsePayload{document: doc}, err
+}
+
+func (s *Server) findSimpleProjectedPrimaryEqualityPayload(col *collections.Collection, ns string, plan findPlan, batchSize int, batchSizeSet bool) (findResponsePayload, bool, error) {
+	if !plan.projection.present {
+		return findResponsePayload{}, false, nil
+	}
+	value, ok := simplePrimaryEqualityFindValue(plan)
+	if !ok {
+		return findResponsePayload{}, false, nil
+	}
+	normalizedBatchSize, err := normalizeBatchSize(batchSize, batchSizeSet, defaultCursorBatchSize)
+	if err != nil {
+		return findResponsePayload{}, true, err
+	}
+	if normalizedBatchSize < 1 {
+		return findResponsePayload{}, false, nil
+	}
+	key, err := encodePrimaryKey(value)
+	if err != nil {
+		return findResponsePayload{}, true, err
+	}
+	stored, err := col.Get(key)
+	if err != nil {
+		return findResponsePayload{}, true, err
+	}
+	if len(stored) == 0 {
+		return findResponsePayload{
+			kind: findResponsePayloadRaw,
+			raw:  rawCursorDocumentsResponse{ns: ns, cursorID: 0, batchKey: "firstBatch"},
+		}, true, nil
+	}
+	materializer, err := storedDocumentMaterializerForCollection(col)
+	if err != nil {
+		return findResponsePayload{}, true, err
+	}
+	defer func() { _ = materializer.Close() }()
+	doc, err := storedDocumentToBSON(col, materializer, stored)
+	if err != nil {
+		return findResponsePayload{}, true, err
+	}
+	projected, err := projectDocumentWithProjection(doc, plan.projection)
+	if err != nil {
+		return findResponsePayload{}, true, err
+	}
+	docBytes := findBatchDocumentBytes(projected, 0)
+	if findBatchOverheadBytes+docBytes > s.maxFindBatchBytes() {
+		return findResponsePayload{}, true, fmt.Errorf("mongo gateway cursor document exceeds max batch bytes: docBytes=%d maxBatchBytes=%d", docBytes, s.maxFindBatchBytes())
+	}
+	return findResponsePayload{
+		kind: findResponsePayloadRaw,
+		raw:  rawCursorDocumentsResponse{ns: ns, cursorID: 0, batchKey: "firstBatch", batch: []wire.Document{projected}},
+	}, true, nil
 }
 
 func (s *Server) updateResponse(command wire.Document, sequences []wire.DocumentSequence) (wire.Document, error) {

--- a/TreeDB/mongo_gateway/find_planner.go
+++ b/TreeDB/mongo_gateway/find_planner.go
@@ -14,6 +14,7 @@ import (
 	"github.com/snissn/gomap/TreeDB/collections"
 	"github.com/snissn/gomap/TreeDB/mongo_gateway/wire"
 	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/x/bsonx/bsoncore"
 )
 
 type findPredicateOp uint8
@@ -709,6 +710,20 @@ func primaryCandidatePredicate(predicates []findPredicate) (findPredicate, bool)
 		}
 	}
 	return findPredicate{}, false
+}
+
+func simplePrimaryEqualityFindValue(plan findPlan) (bson.RawValue, bool) {
+	if plan.sort.field != "" || plan.skip != 0 || plan.limit > 1 {
+		return bson.RawValue{}, false
+	}
+	if len(plan.predicates) != 1 {
+		return bson.RawValue{}, false
+	}
+	pred := plan.predicates[0]
+	if pred.field != "_id" || pred.op != findPredicateEq || len(pred.values) != 1 {
+		return bson.RawValue{}, false
+	}
+	return pred.values[0], true
 }
 
 func documentsForPrimaryPredicate(col *collections.Collection, materializer *collections.StoredDocumentJSONMaterializer, pred findPredicate, maxDocuments int) ([]wire.Document, error) {
@@ -1431,11 +1446,15 @@ func projectDocumentWithProjection(doc wire.Document, projection compiledProject
 			mode = projectionExclude
 		}
 	}
+	return projectDocumentWithEffectiveProjection(doc, projection, mode)
+}
+
+func projectDocumentWithEffectiveProjection(doc wire.Document, projection compiledProjection, mode projectionMode) (wire.Document, error) {
 	elements, err := bson.Raw(doc).Elements()
 	if err != nil {
 		return nil, err
 	}
-	out := make(bson.D, 0, len(elements))
+	idx, out := bsoncore.AppendDocumentStart(make([]byte, 0, len(doc)))
 	for _, elem := range elements {
 		key, err := elem.KeyErr()
 		if err != nil {
@@ -1446,17 +1465,24 @@ func projectDocumentWithProjection(doc wire.Document, projection compiledProject
 		}
 		_, selected := projection.fields[key]
 		if mode == projectionInclude && (selected || key == "_id") {
-			out = append(out, bson.E{Key: key, Value: elem.Value()})
+			out = appendRawValueElement(out, key, elem.Value())
 		}
 		if mode == projectionExclude && !selected {
-			out = append(out, bson.E{Key: key, Value: elem.Value()})
+			out = appendRawValueElement(out, key, elem.Value())
 		}
 	}
-	raw, err := bson.Marshal(out)
+	out, err = bsoncore.AppendDocumentEnd(out, idx)
 	if err != nil {
 		return nil, err
 	}
-	return wire.Document(raw), nil
+	return wire.Document(out), nil
+}
+
+func appendRawValueElement(dst []byte, key string, value bson.RawValue) []byte {
+	return bsoncore.AppendValueElement(dst, key, bsoncore.Value{
+		Type: bsoncore.Type(value.Type),
+		Data: value.Value,
+	})
 }
 
 type projectionMode uint8

--- a/TreeDB/mongo_gateway/server_test.go
+++ b/TreeDB/mongo_gateway/server_test.go
@@ -3607,6 +3607,22 @@ func TestServerFindPlannerIndexedAndBoundedPredicates(t *testing.T) {
 		t.Fatalf("_id include projection=%v want only _id", firstBatch[0])
 	}
 
+	missingProjected := serveCommand(t, server, 2371, bson.D{
+		{Key: "find", Value: "users"},
+		{Key: "filter", Value: bson.D{{Key: "_id", Value: bson.NewObjectID()}}},
+		{Key: "projection", Value: bson.D{{Key: "name", Value: int32(1)}, {Key: "_id", Value: int32(0)}}},
+		{Key: "limit", Value: int32(1)},
+		{Key: "singleBatch", Value: true},
+		{Key: "$db", Value: "app"},
+	})
+	firstBatch = cursorFirstBatch(t, missingProjected)
+	if len(firstBatch) != 0 {
+		t.Fatalf("missing projected primary find firstBatch len=%d want 0", len(firstBatch))
+	}
+	if cursorID := cursorIDFromResponse(t, missingProjected); cursorID != 0 {
+		t.Fatalf("missing projected primary find cursor id=%d want 0", cursorID)
+	}
+
 	id4 := bson.NewObjectID()
 	id5 := bson.NewObjectID()
 	assertOK(t, serveCommand(t, server, 238, bson.D{
@@ -3891,6 +3907,36 @@ func TestServerFindBatchSizeZeroKeepsCursorEmpty(t *testing.T) {
 	name, ok := nextBatch[0].Lookup("name").StringValueOK()
 	if !ok || name != "ada" {
 		t.Fatalf("nextBatch[0].name=%q ok=%v want ada", name, ok)
+	}
+
+	projectedFindResponse := serveCommand(t, server, 2431, bson.D{
+		{Key: "find", Value: "users"},
+		{Key: "filter", Value: bson.D{{Key: "_id", Value: "u1"}}},
+		{Key: "projection", Value: bson.D{{Key: "name", Value: int32(1)}, {Key: "_id", Value: int32(0)}}},
+		{Key: "batchSize", Value: int32(0)},
+		{Key: "$db", Value: "app"},
+	})
+	if firstBatch := cursorFirstBatch(t, projectedFindResponse); len(firstBatch) != 0 {
+		t.Fatalf("projected primary firstBatch len=%d want 0", len(firstBatch))
+	}
+	projectedCursorID := cursorIDFromResponse(t, projectedFindResponse)
+	if projectedCursorID == 0 {
+		t.Fatal("projected primary cursor id=0 want open cursor")
+	}
+	projectedGetMore := serveCommand(t, server, 2432, bson.D{
+		{Key: "getMore", Value: projectedCursorID},
+		{Key: "collection", Value: "users"},
+		{Key: "$db", Value: "app"},
+	})
+	projectedNextBatch := cursorNextBatch(t, projectedGetMore)
+	if len(projectedNextBatch) != 1 {
+		t.Fatalf("projected primary nextBatch len=%d want 1", len(projectedNextBatch))
+	}
+	if got, ok := projectedNextBatch[0].Lookup("name").StringValueOK(); !ok || got != "ada" {
+		t.Fatalf("projected primary nextBatch name=%q ok=%v want ada", got, ok)
+	}
+	if !projectedNextBatch[0].Lookup("_id").IsZero() {
+		t.Fatalf("projected primary nextBatch unexpectedly includes _id: %v", projectedNextBatch[0])
 	}
 }
 
@@ -5386,6 +5432,53 @@ func TestFindPlanHasDirectCandidateRequiresUsableRangeIndex(t *testing.T) {
 		{field: "age", op: findPredicateGTE, values: []bson.RawValue{mustRawValue(t, "10")}},
 	}) {
 		t.Fatal("wrong-type int64 range should use direct empty-candidate mode")
+	}
+}
+
+func TestSimplePrimaryEqualityFindValue(t *testing.T) {
+	value := mustRawValue(t, "user1")
+	got, ok := simplePrimaryEqualityFindValue(findPlan{
+		predicates: []findPredicate{{field: "_id", op: findPredicateEq, values: []bson.RawValue{value}}},
+		projection: compiledProjection{present: true},
+		limit:      1,
+	})
+	if !ok || got.Type != value.Type || !bytes.Equal(got.Value, value.Value) {
+		t.Fatalf("simple primary value ok=%v got=%v want %v", ok, got, value)
+	}
+	if _, ok := simplePrimaryEqualityFindValue(findPlan{
+		predicates: []findPredicate{{field: "_id", op: findPredicateEq, values: []bson.RawValue{value}}},
+		sort:       findSort{field: "name"},
+		limit:      1,
+	}); ok {
+		t.Fatal("sorted primary find should not use simple path")
+	}
+	if _, ok := simplePrimaryEqualityFindValue(findPlan{
+		predicates: []findPredicate{{field: "_id", op: findPredicateEq, values: []bson.RawValue{value}}},
+		skip:       1,
+		limit:      1,
+	}); ok {
+		t.Fatal("skipped primary find should not use simple path")
+	}
+	if _, ok := simplePrimaryEqualityFindValue(findPlan{
+		predicates: []findPredicate{{field: "_id", op: findPredicateEq, values: []bson.RawValue{value}}},
+		limit:      2,
+	}); ok {
+		t.Fatal("multi-limit primary find should not use simple path")
+	}
+	if _, ok := simplePrimaryEqualityFindValue(findPlan{
+		predicates: []findPredicate{{field: "_id", op: findPredicateIn, values: []bson.RawValue{value}}},
+		limit:      1,
+	}); ok {
+		t.Fatal("$in primary find should not use simple path")
+	}
+	if _, ok := simplePrimaryEqualityFindValue(findPlan{
+		predicates: []findPredicate{
+			{field: "_id", op: findPredicateEq, values: []bson.RawValue{value}},
+			{field: "field0", op: findPredicateEq, values: []bson.RawValue{mustRawValue(t, []byte("v"))}},
+		},
+		limit: 1,
+	}); ok {
+		t.Fatal("compound predicate primary find should not use simple path")
 	}
 }
 


### PR DESCRIPTION
## Summary

- add a strict Mongo gateway fast path for projected single `_id` equality finds
- keep `batchSize: 0` cursor semantics on the generic path and enforce max batch bytes on the fast path
- project BSON documents by copying raw elements instead of rebuilding through `bson.D`

Closes #2133.
Refs #2116, #2106.

## Verification

- `GOWORK=off go test ./TreeDB/mongo_gateway ./cmd/mongo_gateway_bench -count=1`

## Benchmark Evidence

Baseline from PR #2132 projected-read attribution, `command_wal_relaxed`, 100k docs / 50k projected reads:

- driver projected read: `75,418.7 ops/s`
- raw-wire TCP projected read: `126,512.1 ops/s`
- direct projected read ceiling: `209,426.7 ops/s`

This PR, final no-profile run on the same shape:

- driver projected read: `80,923.8 ops/s`
- raw-wire TCP projected read: `156,115.6 ops/s`
- direct projected read ceiling: `216,215.9 ops/s`

Interpretation: the server-side projected primary read path was a real bottleneck, especially below the driver layer. Remaining driver-path overhead is mostly command parse/protocol/syscall/driver decode rather than collection lookup.
