### PR TITLE
Optimize trusted collection command WAL appends

### DIFF
--- a/TreeDB/collections/command_wal.go
+++ b/TreeDB/collections/command_wal.go
@@ -52,7 +52,7 @@ func (c *Collection) newCollectionInsertCommandWALIntent(docs []commitlog.Collec
 	if err != nil {
 		return nil, err
 	}
-	return c.db.NewCommandWALIntent(
+	return c.db.NewTrustedCommandWALIntent(
 		commitlog.CommandKindCollectionInsertBatchByID,
 		commitlog.CommandScopeCollection,
 		commitlog.PayloadFormatCollectionInsertBatchByIDV1,
@@ -71,7 +71,7 @@ func (c *Collection) newCollectionDeleteCommandWALIntent(ids [][]byte, replay *b
 	if err != nil {
 		return nil, err
 	}
-	return c.db.NewCommandWALIntent(
+	return c.db.NewTrustedCommandWALIntent(
 		commitlog.CommandKindCollectionDeleteBatchByID,
 		commitlog.CommandScopeCollection,
 		commitlog.PayloadFormatCollectionDeleteBatchByIDV1,
@@ -90,7 +90,7 @@ func (c *Collection) newCollectionUpdateCommandWALIntent(docs []commitlog.Collec
 	if err != nil {
 		return nil, err
 	}
-	return c.db.NewCommandWALIntent(
+	return c.db.NewTrustedCommandWALIntent(
 		commitlog.CommandKindCollectionUpdateBatchByID,
 		commitlog.CommandScopeCollection,
 		commitlog.PayloadFormatCollectionUpdateBatchByIDV1,

--- a/TreeDB/db/command_wal_raw.go
+++ b/TreeDB/db/command_wal_raw.go
@@ -18,6 +18,7 @@ type commandWALBatchIntent struct {
 	scope              commitlog.CommandScope
 	payloadFormat      commitlog.PayloadFormat
 	payload            []byte
+	trustedPayload     bool
 	externalRefs       bool
 	externalRefFileIDs []uint32
 	fromReplay         bool
@@ -122,6 +123,19 @@ func (db *DB) NewCommandWALIntent(kind commitlog.CommandKind, scope commitlog.Co
 		payloadFormat: payloadFormat,
 		payload:       payload,
 	}}, nil
+}
+
+// NewTrustedCommandWALIntent creates a command-WAL intent for payload bytes
+// constructed through a canonical commitlog encoder. The append path still
+// validates command identity and size, but it skips payload decoding because
+// the caller owns that construction boundary.
+func (db *DB) NewTrustedCommandWALIntent(kind commitlog.CommandKind, scope commitlog.CommandScope, payloadFormat commitlog.PayloadFormat, payload []byte) (*CommandWALIntent, error) {
+	intent, err := db.NewCommandWALIntent(kind, scope, payloadFormat, payload)
+	if err != nil || intent == nil {
+		return intent, err
+	}
+	intent.inner.trustedPayload = true
+	return intent, nil
 }
 
 func newCommandWALReplayIntent(env commitlog.CommandEnvelope, replayToken uint64) *CommandWALIntent {
@@ -652,13 +666,19 @@ func (db *DB) appendCommandWALIntent(intent *commandWALBatchIntent, sync bool) (
 	db.mu.RLock()
 	baseAppliedLSN := db.meta.AppliedCommandLSN
 	db.mu.RUnlock()
-	lsn, err := db.commandJournal.AppendCommand(commitlog.CommandEnvelope{
-		Kind:           intent.kind,
-		Scope:          intent.scope,
-		BaseAppliedLSN: baseAppliedLSN,
-		PayloadFormat:  intent.payloadFormat,
-		Payload:        intent.payload,
-	})
+	var lsn uint64
+	var err error
+	if intent.trustedPayload && !intent.externalRefs {
+		lsn, err = db.commandJournal.AppendCommandPayloadTrusted(intent.kind, intent.scope, intent.payloadFormat, baseAppliedLSN, intent.payload)
+	} else {
+		lsn, err = db.commandJournal.AppendCommand(commitlog.CommandEnvelope{
+			Kind:           intent.kind,
+			Scope:          intent.scope,
+			BaseAppliedLSN: baseAppliedLSN,
+			PayloadFormat:  intent.payloadFormat,
+			Payload:        intent.payload,
+		})
+	}
 	if err != nil {
 		return 0, err
 	}

--- a/TreeDB/db/command_wal_raw_test.go
+++ b/TreeDB/db/command_wal_raw_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"errors"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -23,6 +24,59 @@ func TestCommandWALIntentZeroValueLSNSentinelsM10C(t *testing.T) {
 	}
 	if got, replay := zero.ReplayAssignedLSN(); got != 0 || replay {
 		t.Fatalf("zero ReplayAssignedLSN=(%d,%t), want (0,false)", got, replay)
+	}
+}
+
+func TestTrustedCommandWALIntentAppendsCanonicalCollectionPayload(t *testing.T) {
+	dir := t.TempDir()
+	d, err := Open(Options{Dir: dir, CommandWAL: true, DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	payload, err := commitlog.EncodeCollectionInsertBatchByIDPayload("users", []commitlog.CollectionDocument{
+		{ID: []byte("user-001"), Document: []byte(`{"_id":"user-001"}`)},
+	})
+	if err != nil {
+		_ = d.Close()
+		t.Fatalf("EncodeCollectionInsertBatchByIDPayload: %v", err)
+	}
+	intent, err := d.NewTrustedCommandWALIntent(
+		commitlog.CommandKindCollectionInsertBatchByID,
+		commitlog.CommandScopeCollection,
+		commitlog.PayloadFormatCollectionInsertBatchByIDV1,
+		payload,
+	)
+	if err != nil {
+		_ = d.Close()
+		t.Fatalf("NewTrustedCommandWALIntent: %v", err)
+	}
+	lsn, err := d.AppendCommandWALIntent(intent, false)
+	if err != nil {
+		_ = d.Close()
+		t.Fatalf("AppendCommandWALIntent: %v", err)
+	}
+	if lsn == 0 || intent.AssignedLSN() != lsn {
+		_ = d.Close()
+		t.Fatalf("trusted intent lsn=%d assigned=%d, want non-zero match", lsn, intent.AssignedLSN())
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	r, err := commitlog.NewReader(filepath.Join(WALDirPath(dir), "commit-l0-000001.log"))
+	if err != nil {
+		t.Fatalf("NewReader: %v", err)
+	}
+	defer r.Close()
+	env, err := r.ReadCommandFrame()
+	if err != nil {
+		t.Fatalf("ReadCommandFrame: %v", err)
+	}
+	if env.LSN != lsn || env.Kind != commitlog.CommandKindCollectionInsertBatchByID || env.Scope != commitlog.CommandScopeCollection || env.PayloadFormat != commitlog.PayloadFormatCollectionInsertBatchByIDV1 {
+		t.Fatalf("decoded trusted command identity mismatch: %+v", env)
+	}
+	if _, err := commitlog.DecodeCollectionInsertBatchByIDPayload(env.Payload); err != nil {
+		t.Fatalf("DecodeCollectionInsertBatchByIDPayload: %v", err)
 	}
 }
 

--- a/TreeDB/internal/commitlog/command_frame_test.go
+++ b/TreeDB/internal/commitlog/command_frame_test.go
@@ -768,6 +768,53 @@ func TestWriterAppendRawKVBatchPayloadCommandDirect(t *testing.T) {
 	}
 }
 
+func TestWriterAppendCommandPayloadDirectTrustedCollectionInsert(t *testing.T) {
+	payload, err := EncodeCollectionInsertBatchByIDPayload("users", []CollectionDocument{
+		{ID: []byte("user-001"), Document: []byte(`{"_id":"user-001","field0":"value0"}`)},
+	})
+	if err != nil {
+		t.Fatalf("EncodeCollectionInsertBatchByIDPayload: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "commit-l0-000001.log")
+	w, err := NewWriterWithOptions(path, Options{DeferredCommandBufferSize: 4096})
+	if err != nil {
+		t.Fatalf("NewWriterWithOptions: %v", err)
+	}
+	if err := w.AppendCommandPayloadDirectTrusted(7, 3, CommandKindCollectionInsertBatchByID, CommandScopeCollection, PayloadFormatCollectionInsertBatchByIDV1, payload); err != nil {
+		_ = w.Close()
+		t.Fatalf("AppendCommandPayloadDirectTrusted: %v", err)
+	}
+	if got := len(w.commandBuf); got == 0 {
+		_ = w.Close()
+		t.Fatal("trusted collection command frame was not buffered")
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close writer: %v", err)
+	}
+	r, err := NewReader(path)
+	if err != nil {
+		t.Fatalf("NewReader: %v", err)
+	}
+	defer r.Close()
+	env, err := r.ReadCommandFrame()
+	if err != nil {
+		t.Fatalf("ReadCommandFrame: %v", err)
+	}
+	if env.LSN != 7 || env.BaseAppliedLSN != 3 || env.Kind != CommandKindCollectionInsertBatchByID || env.Scope != CommandScopeCollection || env.PayloadFormat != PayloadFormatCollectionInsertBatchByIDV1 {
+		t.Fatalf("decoded command identity mismatch: %+v", env)
+	}
+	if !bytes.Equal(env.Payload, payload) {
+		t.Fatalf("payload mismatch\ngot  %x\nwant %x", env.Payload, payload)
+	}
+	decoded, err := DecodeCollectionInsertBatchByIDPayload(env.Payload)
+	if err != nil {
+		t.Fatalf("DecodeCollectionInsertBatchByIDPayload: %v", err)
+	}
+	if decoded.Collection != "users" || len(decoded.Documents) != 1 || string(decoded.Documents[0].ID) != "user-001" {
+		t.Fatalf("decoded collection payload mismatch: %+v", decoded)
+	}
+}
+
 func TestWriterBufferedCommandFlushFailurePoisonsWriter(t *testing.T) {
 	payload, err := EncodeRawKVBatchPayload([]RawKVOperation{
 		{Op: RawKVOpSet, Key: []byte("alpha"), Value: []byte("one")},

--- a/TreeDB/internal/commitlog/journal_owner.go
+++ b/TreeDB/internal/commitlog/journal_owner.go
@@ -639,6 +639,49 @@ func (j *CommandJournal) AppendRawKVBatchPayloadCommandTrusted(baseAppliedLSN ui
 	return lsn, nil
 }
 
+// AppendCommandPayloadTrusted appends a caller-validated canonical command
+// payload. It validates only command identity and frame size; callers must use
+// this only for payloads built by the matching commitlog encoder.
+func (j *CommandJournal) AppendCommandPayloadTrusted(kind CommandKind, scope CommandScope, format PayloadFormat, baseAppliedLSN uint64, payload []byte) (uint64, error) {
+	if j == nil {
+		return 0, errors.New("commitlog: command journal is closed")
+	}
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	if j.writer == nil || j.owner == nil {
+		return 0, errors.New("commitlog: command journal is closed")
+	}
+	if err := validateCommandEnvelopeIdentity(CommandEnvelope{
+		LSN:           1,
+		Kind:          kind,
+		Scope:         scope,
+		PayloadFormat: format,
+	}); err != nil {
+		return 0, err
+	}
+	size, err := commandFrameEncodedSizeFromLengths(len(payload), 0, 0, 0)
+	if err != nil {
+		return 0, err
+	}
+	if j.writer.maxSegmentSize > 0 && int64(size) > j.writer.maxSegmentSize {
+		return 0, ErrRecordTooLarge
+	}
+	if size > int(segmentLenMask) {
+		return 0, ErrRecordTooLarge
+	}
+	lsn, err := j.reserveLSNLocked()
+	if err != nil {
+		return 0, err
+	}
+	if err := j.writer.AppendCommandPayloadDirectTrusted(lsn, baseAppliedLSN, kind, scope, format, payload); err != nil {
+		if rollbackErr := j.owner.rollbackReservedLSN(lsn); rollbackErr != nil {
+			return 0, errors.Join(err, rollbackErr)
+		}
+		return 0, err
+	}
+	return lsn, nil
+}
+
 // AppendRawKVBatchPayloadCommandTrustedAndFlush appends a caller-validated
 // RawKVBatch payload and flushes/syncs the writer while holding the journal
 // lock. If the append succeeds but the flush fails, the allocated LSN is

--- a/TreeDB/internal/commitlog/journal_owner_bench_test.go
+++ b/TreeDB/internal/commitlog/journal_owner_bench_test.go
@@ -30,3 +30,51 @@ func BenchmarkCommandJournalAllocateAndAppendRawKVBatch(b *testing.B) {
 		}
 	}
 }
+
+func BenchmarkCommandJournalAppendCollectionInsertPayload(b *testing.B) {
+	payload, err := EncodeCollectionInsertBatchByIDPayload("usertable", []CollectionDocument{
+		{
+			ID:       []byte("user000000000000"),
+			Document: []byte(`{"_id":"user000000000000","field0":"value0","field1":"value1","field2":"value2","field3":"value3","field4":"value4","field5":"value5","field6":"value6","field7":"value7","field8":"value8","field9":"value9"}`),
+		},
+	})
+	if err != nil {
+		b.Fatalf("EncodeCollectionInsertBatchByIDPayload: %v", err)
+	}
+	env := CommandEnvelope{
+		Kind:          CommandKindCollectionInsertBatchByID,
+		Scope:         CommandScopeCollection,
+		PayloadFormat: PayloadFormatCollectionInsertBatchByIDV1,
+		Payload:       payload,
+	}
+	b.Run("generic", func(b *testing.B) {
+		j, err := OpenCommandJournal(b.TempDir(), CommandJournalOptions{})
+		if err != nil {
+			b.Fatalf("OpenCommandJournal: %v", err)
+		}
+		b.Cleanup(func() { _ = j.Close() })
+		b.ReportAllocs()
+		b.SetBytes(int64(len(payload)))
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if _, err := j.AppendCommand(env); err != nil {
+				b.Fatalf("AppendCommand: %v", err)
+			}
+		}
+	})
+	b.Run("trusted", func(b *testing.B) {
+		j, err := OpenCommandJournal(b.TempDir(), CommandJournalOptions{})
+		if err != nil {
+			b.Fatalf("OpenCommandJournal: %v", err)
+		}
+		b.Cleanup(func() { _ = j.Close() })
+		b.ReportAllocs()
+		b.SetBytes(int64(len(payload)))
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if _, err := j.AppendCommandPayloadTrusted(CommandKindCollectionInsertBatchByID, CommandScopeCollection, PayloadFormatCollectionInsertBatchByIDV1, 0, payload); err != nil {
+				b.Fatalf("AppendCommandPayloadTrusted: %v", err)
+			}
+		}
+	})
+}

--- a/TreeDB/internal/commitlog/writer.go
+++ b/TreeDB/internal/commitlog/writer.go
@@ -707,6 +707,53 @@ func (w *Writer) AppendRawKVBatchPayloadCommandDirectTrusted(lsn, baseAppliedLSN
 	return w.appendRawKVBatchPayloadCommandDirect(lsn, baseAppliedLSN, payload, size)
 }
 
+// AppendCommandPayloadDirectTrusted appends a canonical command payload whose
+// bytes were constructed by the matching payload encoder.
+func (w *Writer) AppendCommandPayloadDirectTrusted(lsn, baseAppliedLSN uint64, kind CommandKind, scope CommandScope, format PayloadFormat, payload []byte) error {
+	if err := w.commandBufferError(); err != nil {
+		return err
+	}
+	if lsn == 0 {
+		return fmt.Errorf("%w: zero lsn", ErrCorrupt)
+	}
+	if err := validateCommandEnvelopeIdentity(CommandEnvelope{
+		LSN:           lsn,
+		Kind:          kind,
+		Scope:         scope,
+		PayloadFormat: format,
+	}); err != nil {
+		return err
+	}
+	size, err := commandFrameEncodedSizeFromLengths(len(payload), 0, 0, 0)
+	if err != nil {
+		return err
+	}
+	if w.maxSegmentSize > 0 && int64(size) > w.maxSegmentSize {
+		return ErrRecordTooLarge
+	}
+	if size > int(segmentLenMask) {
+		return ErrRecordTooLarge
+	}
+	total := segmentHeaderSize + size
+	if len(payload) >= directCommandPayloadMinLen {
+		return w.appendCommandPayloadDirectTrusted(lsn, baseAppliedLSN, kind, scope, format, payload, size)
+	}
+	if w.canBufferCommandFrame(total) {
+		off, err := w.reserveCommandBufferSpace(total)
+		if err != nil {
+			return err
+		}
+		newLen := off + total
+		buf := w.commandBuf[off:newLen]
+		frameHeader := buf[segmentHeaderSize : segmentHeaderSize+commandFrameHeaderSize]
+		fillTrustedCommandFrameHeader(frameHeader, lsn, baseAppliedLSN, kind, scope, format, len(payload))
+		copy(buf[segmentHeaderSize+commandFrameHeaderSize:], payload)
+		binary.LittleEndian.PutUint32(buf[0:4], uint32(size))
+		return nil
+	}
+	return w.appendCommandPayloadDirectTrusted(lsn, baseAppliedLSN, kind, scope, format, payload, size)
+}
+
 func (w *Writer) appendRawKVBatchPayloadCommandDirect(lsn, baseAppliedLSN uint64, payload []byte, size int) error {
 	if err := w.flushBufferedCommandFrames(); err != nil {
 		return err
@@ -740,6 +787,51 @@ func (w *Writer) appendRawKVBatchPayloadCommandDirect(lsn, baseAppliedLSN uint64
 	}
 	w.size += int64(segmentHeaderSize + size)
 	return nil
+}
+
+func (w *Writer) appendCommandPayloadDirectTrusted(lsn, baseAppliedLSN uint64, kind CommandKind, scope CommandScope, format PayloadFormat, payload []byte, size int) error {
+	if err := w.flushBufferedCommandFrames(); err != nil {
+		return err
+	}
+	var prefix [segmentHeaderSize + commandFrameHeaderSize]byte
+	frameHeader := prefix[segmentHeaderSize:]
+	fillTrustedCommandFrameHeader(frameHeader, lsn, baseAppliedLSN, kind, scope, format, len(payload))
+	digest := sha256.Sum256(payload)
+	copy(frameHeader[72:72+sha256.Size], digest[:])
+	binary.LittleEndian.PutUint32(prefix[0:4], uint32(size))
+	binary.LittleEndian.PutUint32(prefix[4:8], crc.ChecksumParts(frameHeader, payload))
+	if len(payload) >= directCommandPayloadMinLen {
+		if err := w.bw.Flush(); err != nil {
+			return err
+		}
+		parts := [2][]byte{prefix[:], payload}
+		if err := writevFull(w.f, parts[:]); err != nil {
+			return w.poisonCommandBuffer(err)
+		}
+		w.size += int64(segmentHeaderSize + size)
+		return nil
+	}
+	if _, err := w.bw.Write(prefix[:]); err != nil {
+		return err
+	}
+	if _, err := w.bw.Write(payload); err != nil {
+		return err
+	}
+	w.size += int64(segmentHeaderSize + size)
+	return nil
+}
+
+func fillTrustedCommandFrameHeader(frame []byte, lsn, baseAppliedLSN uint64, kind CommandKind, scope CommandScope, format PayloadFormat, payloadLen int) {
+	clear(frame[:commandFrameHeaderSize])
+	copy(frame[0:4], commandFrameMagic[:])
+	binary.LittleEndian.PutUint16(frame[4:6], CommandFrameVersion)
+	binary.LittleEndian.PutUint16(frame[6:8], CommandFrameVersion)
+	binary.LittleEndian.PutUint16(frame[8:10], uint16(kind))
+	binary.LittleEndian.PutUint16(frame[10:12], uint16(scope))
+	binary.LittleEndian.PutUint64(frame[20:28], lsn)
+	binary.LittleEndian.PutUint64(frame[44:52], baseAppliedLSN)
+	binary.LittleEndian.PutUint16(frame[52:54], uint16(format))
+	binary.LittleEndian.PutUint32(frame[56:60], uint32(payloadLen))
 }
 
 func (w *Writer) reserveCommandBufferSpace(total int) (int, error) {


### PR DESCRIPTION
## Summary

Fixes #2135.

This removes redundant collection command-WAL payload decoding from the hot insert/update/delete append path when the payload was just built by the canonical commitlog encoder.

Changes:
- Add a trusted command-WAL intent bit for canonical payloads.
- Add a generic trusted command-journal/writer append path that validates command identity and frame size while skipping payload decode/clone validation.
- Use the trusted intent only for collection insert/delete/update intents created from commitlog canonical encoders.
- Add writer and DB coverage for trusted collection command frames.
- Add a microbenchmark for generic vs trusted collection insert command append.

## Evidence

Local tests:
- `GOWORK=off go test ./TreeDB/internal/commitlog ./TreeDB/db ./TreeDB/collections -run 'CommandWAL|TrustedCommand|WriterAppendCommandPayloadDirectTrusted|WriterAppendRawKVBatchPayloadCommandDirect' -count=1`
- `GOWORK=off go test ./TreeDB/collections -count=1` (`115.401s`)
- `GOWORK=off go test ./TreeDB/nativewire ./cmd/treedb-native-server ./TreeDB/mongo_gateway ./cmd/mongo_gateway_bench -count=1`
- `GOWORK=off go test ./TreeDB/internal/commitlog ./TreeDB/db -count=1` (`TreeDB/db` `322.564s`)

Microbenchmark:
- `GOWORK=off go test ./TreeDB/internal/commitlog -run '^$' -bench BenchmarkCommandJournalAppendCollectionInsertPayload -benchmem -count=5`
- generic: about `1011-1332 ns/op`, `576 B/op`, `8 allocs/op`
- trusted: about `519-677 ns/op`, `112 B/op`, `1 alloc/op`

External YCSB, 100k load + 3x10k run, 16 threads, BSON native default, MongoDB baseline skipped, host i5-11400F/12 CPU/31 GiB/tsc:

`command_wal_relaxed`, artifact `/tmp/treedb_ycsb_command_wal_relaxed_trusted_20260601_030828`:
- TreeDB nativewire load: `80,971.0 OPS`, errors `0` (prior sample before this PR: `60,756.1 OPS`)
- TreeDB Mongo gateway load: `66,674.2 OPS`, errors `0` (prior sample before this PR: `49,226.6 OPS`)
- Native run totals: `117,822.4`, `112,238.1`, `114,473.1 OPS`, errors `0`
- Mongo gateway run totals: `88,840.4`, `86,833.0`, `79,224.7 OPS`, errors `0`

`command_wal_durable`, artifact `/tmp/treedb_ycsb_command_wal_durable_trusted_20260601_030859`:
- TreeDB nativewire load: `82,100.1 OPS`, errors `0` (prior sample before this PR: `59,315.6 OPS`)
- TreeDB Mongo gateway load: `64,968.9 OPS`, errors `0` (prior sample before this PR: `49,713.1 OPS`)
- Native run totals: `113,839.1`, `114,838.4`, `111,519.0 OPS`, errors `0`
- Mongo gateway run totals: `83,871.8`, `86,484.3`, `81,116.5 OPS`, errors `0`

Same-branch `fast`, artifact `/tmp/treedb_ycsb_fast_trusted_20260601_030915`:
- TreeDB nativewire load: `92,981.4 OPS`, errors `0`
- TreeDB Mongo gateway load: `84,795.0 OPS`, errors `0`

Fresh command-WAL native load CPU profile, artifact `/tmp/treedb_command_wal_load_profile_trusted_20260601_030944`:
- `DB.AppendCommandWALIntent` cumulative fell to `0.79s / 5.48%` in this sample.
- The old redundant `DecodeCollectionInsertBatchByIDPayload`/payload validation signal is no longer a visible top bottleneck.
- Remaining command-WAL load cost is mostly flush/write/digest plus normal collection staging; the largest visible costs are network/syscall response writes, command-WAL flush, pointerization/staging, payload encoding, and SHA-256 digest.
