### PR TITLE
nativewire: reduce insert combiner allocations

### DIFF
--- a/TreeDB/collections/command_wal.go
+++ b/TreeDB/collections/command_wal.go
@@ -1,7 +1,6 @@
 package collections
 
 import (
-	"bytes"
 	"fmt"
 	"sync"
 
@@ -206,44 +205,16 @@ func collectionDocumentsFromInsertPlan(plan *insertBatchPlan, primaryRootName st
 		return nil, fmt.Errorf("collections: missing insert plan for command wal")
 	}
 	if direct := plan.directBufferedInsert; direct != nil && direct.primaryRootName == primaryRootName {
-		docs := make([]commitlog.CollectionDocument, 0, len(plan.resultIDs))
-		if len(plan.resultIDs) <= 8 {
-			for _, id := range plan.resultIDs {
-				found := false
-				for _, entry := range direct.primaryEntries {
-					if !bytes.Equal(entry.key, id) {
-						continue
-					}
-					if entry.flags&node.FlagTombstone != 0 {
-						return nil, fmt.Errorf("collections: insert plan tombstoned primary document for command wal")
-					}
-					docs = append(docs, commitlog.CollectionDocument{
-						ID:       id,
-						Document: entry.value,
-					})
-					found = true
-					break
-				}
-				if !found {
-					return nil, fmt.Errorf("collections: insert plan missing primary document for command wal")
-				}
-			}
-			return docs, nil
+		if len(direct.primaryEntries) != len(plan.resultIDs) {
+			return nil, fmt.Errorf("collections: insert plan primary document count mismatch for command wal")
 		}
-		primaryByID := make(map[string]directBufferedRootEntry, len(direct.primaryEntries))
+		docs := make([]commitlog.CollectionDocument, 0, len(direct.primaryEntries))
 		for _, entry := range direct.primaryEntries {
-			primaryByID[string(entry.key)] = entry
-		}
-		for _, id := range plan.resultIDs {
-			entry, found := primaryByID[string(id)]
-			if !found {
-				return nil, fmt.Errorf("collections: insert plan missing primary document for command wal")
-			}
 			if entry.flags&node.FlagTombstone != 0 {
 				return nil, fmt.Errorf("collections: insert plan tombstoned primary document for command wal")
 			}
 			docs = append(docs, commitlog.CollectionDocument{
-				ID:       id,
+				ID:       entry.key,
 				Document: entry.value,
 			})
 		}

--- a/TreeDB/collections/planner_test.go
+++ b/TreeDB/collections/planner_test.go
@@ -923,6 +923,29 @@ func TestInsertBatchPreflightCheckUniqueConflictsSkipsMissingRoots(t *testing.T)
 	}
 }
 
+func TestCollectionDocumentsFromDirectInsertPlanUsesPrimaryOrder(t *testing.T) {
+	plan := &insertBatchPlan{
+		resultIDs: [][]byte{[]byte("u2"), []byte("u1")},
+		directBufferedInsert: &directBufferedInsertPlan{
+			primaryRootName: collectionPrimaryRootName("users"),
+			primaryEntries: []directBufferedRootEntry{
+				{key: []byte("u1"), value: []byte(`{"name":"Ada"}`), flags: node.FlagInline},
+				{key: []byte("u2"), value: []byte(`{"name":"Grace"}`), flags: node.FlagInline},
+			},
+		},
+	}
+	docs, err := collectionDocumentsFromInsertPlan(plan, collectionPrimaryRootName("users"))
+	if err != nil {
+		t.Fatalf("collectionDocumentsFromInsertPlan: %v", err)
+	}
+	if got, want := len(docs), 2; got != want {
+		t.Fatalf("docs=%d want %d", got, want)
+	}
+	if string(docs[0].ID) != "u1" || string(docs[1].ID) != "u2" {
+		t.Fatalf("doc order=%q,%q want primary order u1,u2", docs[0].ID, docs[1].ID)
+	}
+}
+
 func TestInsertBatchPlanCheckPersistedConflictsRejectsMissingInputs(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/TreeDB/internal/commitlog/command_frame.go
+++ b/TreeDB/internal/commitlog/command_frame.go
@@ -1997,7 +1997,7 @@ func canonicalCollectionDocuments(docs []CollectionDocument) ([]CollectionDocume
 	if commandFrameIntExceedsUint32(len(docs)) {
 		return nil, ErrRecordTooLarge
 	}
-	ordered := make([]CollectionDocument, len(docs))
+	needsSort := false
 	for i := range docs {
 		doc := docs[i]
 		if len(doc.ID) == 0 || doc.ID == nil || doc.Document == nil {
@@ -2006,8 +2006,15 @@ func canonicalCollectionDocuments(docs []CollectionDocument) ([]CollectionDocume
 		if commandFrameIntExceedsUint32(len(doc.ID)) {
 			return nil, ErrRecordTooLarge
 		}
-		ordered[i] = doc
+		if i > 0 && bytes.Compare(docs[i-1].ID, doc.ID) >= 0 {
+			needsSort = true
+		}
 	}
+	if !needsSort {
+		return docs, nil
+	}
+	ordered := make([]CollectionDocument, len(docs))
+	copy(ordered, docs)
 	sort.Slice(ordered, func(i, j int) bool {
 		return bytes.Compare(ordered[i].ID, ordered[j].ID) < 0
 	})
@@ -2021,7 +2028,7 @@ func canonicalCollectionIDs(ids [][]byte) ([][]byte, error) {
 	if commandFrameIntExceedsUint32(len(ids)) {
 		return nil, ErrRecordTooLarge
 	}
-	ordered := make([][]byte, len(ids))
+	needsSort := false
 	for i := range ids {
 		if len(ids[i]) == 0 || ids[i] == nil {
 			return nil, ErrCorrupt
@@ -2029,8 +2036,15 @@ func canonicalCollectionIDs(ids [][]byte) ([][]byte, error) {
 		if commandFrameIntExceedsUint32(len(ids[i])) {
 			return nil, ErrRecordTooLarge
 		}
-		ordered[i] = ids[i]
+		if i > 0 && bytes.Compare(ids[i-1], ids[i]) >= 0 {
+			needsSort = true
+		}
 	}
+	if !needsSort {
+		return ids, nil
+	}
+	ordered := make([][]byte, len(ids))
+	copy(ordered, ids)
 	sort.Slice(ordered, func(i, j int) bool {
 		return bytes.Compare(ordered[i], ordered[j]) < 0
 	})

--- a/TreeDB/internal/commitlog/command_frame_test.go
+++ b/TreeDB/internal/commitlog/command_frame_test.go
@@ -261,6 +261,26 @@ func TestCommandWALFormatGoldenV1CollectionInsertBatchByID(t *testing.T) {
 	}
 }
 
+func TestEncodeCollectionInsertBatchByIDPayloadSortedAndUnsortedMatch(t *testing.T) {
+	sorted, err := EncodeCollectionInsertBatchByIDPayload("users", []CollectionDocument{
+		{ID: []byte("u1"), Document: []byte(`{"name":"Ada"}`)},
+		{ID: []byte("u2"), Document: []byte(`{"name":"Grace"}`)},
+	})
+	if err != nil {
+		t.Fatalf("EncodeCollectionInsertBatchByIDPayload sorted: %v", err)
+	}
+	unsorted, err := EncodeCollectionInsertBatchByIDPayload("users", []CollectionDocument{
+		{ID: []byte("u2"), Document: []byte(`{"name":"Grace"}`)},
+		{ID: []byte("u1"), Document: []byte(`{"name":"Ada"}`)},
+	})
+	if err != nil {
+		t.Fatalf("EncodeCollectionInsertBatchByIDPayload unsorted: %v", err)
+	}
+	if !bytes.Equal(sorted, unsorted) {
+		t.Fatalf("sorted and unsorted payloads differ\nsorted   %x\nunsorted %x", sorted, unsorted)
+	}
+}
+
 func TestCommandWALFormatGoldenV1CollectionDeleteBatchByID(t *testing.T) {
 	payload, err := EncodeCollectionDeleteBatchByIDPayload("users", [][]byte{[]byte("u2"), []byte("u1")})
 	if err != nil {

--- a/TreeDB/nativewire/server_insert_combiner.go
+++ b/TreeDB/nativewire/server_insert_combiner.go
@@ -20,9 +20,8 @@ type nativewireInsertBatchCombineLane struct {
 }
 
 type nativewireInsertBatchCombineItem struct {
-	req    insertBatchFastRequest
-	done   chan struct{}
-	result nativewireInsertBatchCombineResult
+	req  insertBatchFastRequest
+	done chan nativewireInsertBatchCombineResult
 }
 
 type nativewireInsertBatchCombineResult struct {
@@ -38,10 +37,7 @@ func (c *nativewireInsertBatchCombiner) run(s *Server, req insertBatchFastReques
 	if !canCombineInsertBatchFastRequest(s, req) {
 		return nativewireInsertBatchCombineResult{}, false
 	}
-	item := &nativewireInsertBatchCombineItem{
-		req:  req,
-		done: make(chan struct{}),
-	}
+	item := acquireInsertBatchCombineItem(req)
 
 	c.mu.Lock()
 	if c.lanes == nil {
@@ -62,8 +58,9 @@ func (c *nativewireInsertBatchCombiner) run(s *Server, req insertBatchFastReques
 	if leader {
 		go c.drain(s, req.collectionName, lane)
 	}
-	<-item.done
-	return item.result, true
+	result := <-item.done
+	releaseInsertBatchCombineItem(item)
+	return result, true
 }
 
 func canCombineInsertBatchFastRequest(s *Server, req insertBatchFastRequest) bool {
@@ -90,9 +87,11 @@ func canCombineInsertBatchFastRequest(s *Server, req insertBatchFastRequest) boo
 
 func (c *nativewireInsertBatchCombiner) drain(s *Server, collectionName string, lane *nativewireInsertBatchCombineLane) {
 	yieldInsertBatchCombiner(s)
+	var batchScratch []*nativewireInsertBatchCombineItem
 	for {
 		c.mu.Lock()
-		batch := popInsertBatchCombineItems(lane, s.insertBatchCombineMaxBatch)
+		batchScratch = popInsertBatchCombineItems(lane, s.insertBatchCombineMaxBatch, batchScratch[:0])
+		batch := batchScratch
 		if len(batch) == 0 {
 			lane.draining = false
 			delete(c.lanes, collectionName)
@@ -102,18 +101,20 @@ func (c *nativewireInsertBatchCombiner) drain(s *Server, collectionName string, 
 		c.mu.Unlock()
 
 		applyInsertBatchCombineItems(s, batch)
+		clear(batch)
+		batchScratch = batch[:0]
 		yieldInsertBatchCombiner(s)
 	}
 }
 
-func popInsertBatchCombineItems(lane *nativewireInsertBatchCombineLane, max int) []*nativewireInsertBatchCombineItem {
+func popInsertBatchCombineItems(lane *nativewireInsertBatchCombineLane, max int, dst []*nativewireInsertBatchCombineItem) []*nativewireInsertBatchCombineItem {
 	if lane == nil || len(lane.queue) == 0 {
 		return nil
 	}
 	if max <= 0 || max > len(lane.queue) {
 		max = len(lane.queue)
 	}
-	out := append([]*nativewireInsertBatchCombineItem(nil), lane.queue[:max]...)
+	out := append(dst[:0], lane.queue[:max]...)
 	copy(lane.queue, lane.queue[max:])
 	clear(lane.queue[len(lane.queue)-max:])
 	lane.queue = lane.queue[:len(lane.queue)-max]
@@ -142,8 +143,17 @@ func applyInsertBatchCombineItems(s *Server, batch []*nativewireInsertBatchCombi
 		return
 	}
 
-	ids := make([][]byte, len(batch))
-	docs := make([][]byte, len(batch))
+	var idScratch [64][]byte
+	var docScratch [64][]byte
+	ids := idScratch[:]
+	docs := docScratch[:]
+	if len(batch) > len(idScratch) {
+		ids = make([][]byte, len(batch))
+		docs = make([][]byte, len(batch))
+	} else {
+		ids = ids[:len(batch)]
+		docs = docs[:len(batch)]
+	}
 	for i, item := range batch {
 		ids[i] = item.req.ids[0]
 		docs[i] = item.req.docs[0]
@@ -187,6 +197,30 @@ func applySingleInsertBatchCombineItem(s *Server, item *nativewireInsertBatchCom
 }
 
 func finishInsertBatchCombineItem(item *nativewireInsertBatchCombineItem, result nativewireInsertBatchCombineResult) {
-	item.result = result
-	close(item.done)
+	item.done <- result
+}
+
+var nativewireInsertBatchCombineItemPool sync.Pool
+
+func acquireInsertBatchCombineItem(req insertBatchFastRequest) *nativewireInsertBatchCombineItem {
+	if pooled := nativewireInsertBatchCombineItemPool.Get(); pooled != nil {
+		item := pooled.(*nativewireInsertBatchCombineItem)
+		item.req = req
+		if item.done == nil {
+			item.done = make(chan nativewireInsertBatchCombineResult, 1)
+		}
+		return item
+	}
+	return &nativewireInsertBatchCombineItem{
+		req:  req,
+		done: make(chan nativewireInsertBatchCombineResult, 1),
+	}
+}
+
+func releaseInsertBatchCombineItem(item *nativewireInsertBatchCombineItem) {
+	if item == nil {
+		return
+	}
+	item.req = insertBatchFastRequest{}
+	nativewireInsertBatchCombineItemPool.Put(item)
 }

--- a/TreeDB/nativewire/server_insert_combiner_test.go
+++ b/TreeDB/nativewire/server_insert_combiner_test.go
@@ -238,7 +238,7 @@ func applyInsertBatchCombinerRequestsDirect(t *testing.T, server *Server, col *c
 		id, doc := build(i)
 		items[i] = &nativewireInsertBatchCombineItem{
 			req:  insertBatchCombinerFastRequest(t, col, id, doc),
-			done: make(chan struct{}),
+			done: make(chan nativewireInsertBatchCombineResult, 1),
 		}
 	}
 
@@ -247,11 +247,11 @@ func applyInsertBatchCombinerRequestsDirect(t *testing.T, server *Server, col *c
 	errs := make([]error, requests)
 	for i, item := range items {
 		select {
-		case <-item.done:
+		case result := <-item.done:
+			errs[i] = result.err
 		default:
 			t.Fatalf("combined item %d was not completed", i)
 		}
-		errs[i] = item.result.err
 	}
 	return errs
 }

--- a/TreeDB/nativewire/ycsb_bench_test.go
+++ b/TreeDB/nativewire/ycsb_bench_test.go
@@ -34,6 +34,7 @@ const (
 	ycsbBenchFields     = 10
 	ycsbBenchFieldLen   = 100
 
+	ycsbBenchProfileEnv                = "TREEDB_NATIVEWIRE_YCSB_PROFILE"
 	ycsbTimedCPUProfilePathEnv         = "TREEDB_NATIVEWIRE_YCSB_TIMED_CPU_PROFILE_PATH"
 	maxYCSBPrecomputedRequests         = 500_000
 	maxProfiledYCSBPrecomputedRequests = 1_000_000
@@ -88,6 +89,18 @@ func BenchmarkNativewireYCSBLoadServerPrecomputed(b *testing.B) {
 	b.Run("inproc/"+tc.name, func(b *testing.B) {
 		benchmarkNativewireYCSBLoadServerPrecomputed(b, tc)
 	})
+}
+
+func TestYCSBBenchTreeDBProfileFromEnv(t *testing.T) {
+	t.Setenv(ycsbBenchProfileEnv, "")
+	if got := ycsbBenchTreeDBProfile(t); got != treedb.ProfileFast {
+		t.Fatalf("default profile=%q want %q", got, treedb.ProfileFast)
+	}
+
+	t.Setenv(ycsbBenchProfileEnv, string(treedb.ProfileCommandWALRelaxed))
+	if got := ycsbBenchTreeDBProfile(t); got != treedb.ProfileCommandWALRelaxed {
+		t.Fatalf("env profile=%q want %q", got, treedb.ProfileCommandWALRelaxed)
+	}
 }
 
 type ycsbLoadFormat struct {
@@ -417,7 +430,7 @@ func requireSafeYCSBPrecomputedRequests(b *testing.B) {
 
 func newYCSBBenchEnv(tb testing.TB, format collections.DocumentFormat, tcp bool) *ycsbBenchEnv {
 	tb.Helper()
-	opts := treedb.OptionsFor(treedb.ProfileFast, tb.TempDir())
+	opts := treedb.OptionsFor(ycsbBenchTreeDBProfile(tb), tb.TempDir())
 	db, cleanup, err := treedb.OpenBackendWithCachedLeafLog(opts)
 	if err != nil {
 		tb.Fatalf("OpenBackendWithCachedLeafLog: %v", err)
@@ -479,6 +492,20 @@ func newYCSBBenchEnv(tb testing.TB, format collections.DocumentFormat, tcp bool)
 		return err
 	}
 	return env
+}
+
+func ycsbBenchTreeDBProfile(tb testing.TB) treedb.Profile {
+	tb.Helper()
+
+	raw := strings.TrimSpace(os.Getenv(ycsbBenchProfileEnv))
+	if raw == "" {
+		return treedb.ProfileFast
+	}
+	profile, ok := treedb.NormalizeProfile(treedb.Profile(raw))
+	if !ok {
+		tb.Fatalf("unknown %s %q", ycsbBenchProfileEnv, raw)
+	}
+	return profile
 }
 
 func newYCSBBenchClient(tb testing.TB, ctx context.Context, env *ycsbBenchEnv, transport string) (*Client, func() error) {


### PR DESCRIPTION
## Summary

- adds `TREEDB_NATIVEWIRE_YCSB_PROFILE` so the focused nativewire YCSB load benchmark can run under `fast`, `command_wal_relaxed`, and `command_wal_durable`
- reuses nativewire insert-combiner scratch storage and pools per-request combiner items/result channels
- avoids redundant command-WAL insert canonicalization work when direct buffered insert plans already provide primary documents in canonical primary-key order
- lets command-WAL collection payload canonicalization reuse already sorted doc/id slices instead of always allocating and sorting

## Evidence

Tests:

```sh
GOWORK=off go test ./TreeDB/internal/commitlog -count=1
GOWORK=off go test ./TreeDB/nativewire ./cmd/treedb-native-server -count=1
GOWORK=off go test ./TreeDB/collections -count=1
```

Focused benchmark command:

```sh
TREEDB_NATIVEWIRE_YCSB_PROFILE=<profile> GOWORK=off go test ./TreeDB/nativewire \
  -run '^$' \
  -bench '^BenchmarkNativewireYCSBLoadServerPrecomputed/inproc/bson_binary$' \
  -benchmem -count=5 -benchtime=100000x
```

Artifacts:

- Original branch baseline: `/tmp/treedb_nativewire_precomputed_profiles_20260601_034429`
- After combiner allocation cleanup: `/tmp/treedb_nativewire_precomputed_profiles_item_pool_20260601_034915`
- After command-WAL sorted payload path: `/tmp/treedb_nativewire_precomputed_profiles_sorted_cwal_20260601_035859`

Benchstat highlights vs the original branch baseline:

- `fast`: `allocs/op 8 -> 5` (-37.5%), `B/op 2.874Ki -> 2.539Ki` (-11.65%), `sec/op` not significant
- `command_wal_relaxed`: `allocs/op 10 -> 6` (-40.0%); latest step alone moved `allocs/op 7 -> 6` and `sec/op 6.388µ -> 5.899µ` (trend, p=0.056 with n=5)
- `command_wal_durable`: `allocs/op 10 -> 6` (-40.0%); latest step alone moved `allocs/op 7 -> 6`; `sec/op` not significant

Current CPU profile after the first allocation cleanup still showed the remaining command-WAL load bottleneck in WAL append/flush, SHA-256 digesting, staged root sorting/coalescing, and direct buffered insert planning:

```sh
TREEDB_NATIVEWIRE_YCSB_PROFILE=command_wal_relaxed \
TREEDB_NATIVEWIRE_YCSB_TIMED_CPU_PROFILE_PATH=/tmp/treedb_nativewire_precomputed_cwal_profile_item_pool_20260601_035348/cpu.pprof \
GOWORK=off go test ./TreeDB/nativewire \
  -run '^$' \
  -bench '^BenchmarkNativewireYCSBLoadServerPrecomputed/inproc/bson_binary$' \
  -benchmem -count=1 -benchtime=500000x
```

This PR reduces allocation and redundant command-WAL payload work, but it does not fully close #2138. Remaining throughput work should target the WAL append/flush/digest path and staged-root planning/apply costs.

## Tracker

Refs #2138.
