### PR TITLE
treedb: fast-path prepared single-part row mapping

### DIFF
--- a/TreeDB/collections/column_vector_graph_prepared_search.go
+++ b/TreeDB/collections/column_vector_graph_prepared_search.go
@@ -276,8 +276,25 @@ func (v *columnVectorGraphPreparedSearchView) validateVectorLive() error {
 		if part.outcome != columnVectorGraphTypedColumnVectorOutcomeMmapDirect {
 			return fmt.Errorf("base vector prepared single-part outcome=%s want mmap_direct", part.outcome)
 		}
-		if len(v.vector.values) != part.rows*v.dims {
-			return fmt.Errorf("base vector prepared single-part values=%d want rows*dims=%d", len(v.vector.values), part.rows*v.dims)
+		if part.rows < 0 || part.rows > maxCollectionInt/v.dims {
+			return fmt.Errorf("base vector prepared single-part rows=%d dims=%d overflows rows*dims", part.rows, v.dims)
+		}
+		wantValues := part.rows * v.dims
+		if len(v.vector.values) != wantValues {
+			return fmt.Errorf("base vector prepared single-part values=%d want rows*dims=%d", len(v.vector.values), wantValues)
+		}
+		if len(part.values) != wantValues {
+			return fmt.Errorf("base vector prepared single-part part values=%d want rows*dims=%d", len(part.values), wantValues)
+		}
+		rowIndexByOrdinal := v.vector.rowIndexByOrdinal
+		if rowIndexByOrdinal == nil {
+			if v.rows > part.rows {
+				return fmt.Errorf("base vector prepared single-part identity rows=%d exceeds part rows=%d", v.rows, part.rows)
+			}
+			return nil
+		}
+		if len(rowIndexByOrdinal) != v.rows {
+			return fmt.Errorf("base vector prepared single-part row map rows=%d want %d", len(rowIndexByOrdinal), v.rows)
 		}
 		return nil
 	}
@@ -508,25 +525,52 @@ func (v *columnVectorGraphPreparedSearchView) scoreOrdinalsIndexedSinglePart(pla
 	if part == nil || part.handle == nil || part.handle.Released() || part.rows < 0 || v.dims <= 0 || part.rows > maxCollectionInt/v.dims || len(part.values) != part.rows*v.dims {
 		return dst, false, nil
 	}
+	if len(v.norm.values) != v.rows {
+		return dst, false, nil
+	}
+	rowIndexByOrdinal := v.vector.rowIndexByOrdinal
+	if rowIndexByOrdinal != nil && len(rowIndexByOrdinal) != v.rows {
+		return dst, false, nil
+	}
 	if cap(dst) < len(ordinals) {
 		dst = make([]float64, len(ordinals))
 	} else {
 		dst = dst[:len(ordinals)]
 	}
-	rowIndexByOrdinal := v.vector.rowIndexByOrdinal
+	dims := v.dims
+	values := part.values
 	if !vectorops.DotFloat32BatchOptimizedAvailable() {
-		for i, ordinal := range ordinals {
-			row, ok := v.singlePartRowForOrdinal(ordinal, rowIndexByOrdinal, part)
-			if !ok || ordinal >= len(v.norm.values) {
-				return dst, false, nil
+		if rowIndexByOrdinal == nil {
+			for i, ordinal := range ordinals {
+				if ordinal < 0 || ordinal >= v.rows || ordinal >= part.rows {
+					return dst, false, nil
+				}
+				start := ordinal * dims
+				vector := values[start : start+dims]
+				score, err := v.scorePreparedDot(query, queryInvNorm, ordinal, float64(vectorDotProductFloat32(query, vector)), vector, stats)
+				if err != nil {
+					return dst, true, err
+				}
+				dst[i] = score
 			}
-			start := row * v.dims
-			vector := part.values[start : start+v.dims]
-			score, err := v.scorePreparedDot(query, queryInvNorm, ordinal, float64(vectorDotProductFloat32(query, vector)), vector, stats)
-			if err != nil {
-				return dst, true, err
+		} else {
+			for i, ordinal := range ordinals {
+				if ordinal < 0 || ordinal >= v.rows {
+					return dst, false, nil
+				}
+				rowID := rowIndexByOrdinal[ordinal]
+				if uint64(rowID) >= uint64(part.rows) {
+					return dst, false, nil
+				}
+				row := int(rowID)
+				start := row * dims
+				vector := values[start : start+dims]
+				score, err := v.scorePreparedDot(query, queryInvNorm, ordinal, float64(vectorDotProductFloat32(query, vector)), vector, stats)
+				if err != nil {
+					return dst, true, err
+				}
+				dst[i] = score
 			}
-			dst[i] = score
 		}
 		if stats != nil {
 			recordColumnVectorGraphScoreBatchStats(stats, len(ordinals), false, true)
@@ -538,23 +582,35 @@ func (v *columnVectorGraphPreparedSearchView) scoreOrdinalsIndexedSinglePart(pla
 
 	scratch.scoreTileRowIDs = ensureColumnVectorGraphNativeUint32Scratch(scratch.scoreTileRowIDs, len(ordinals))
 	rowIDs := scratch.scoreTileRowIDs[:len(ordinals)]
-	for i, ordinal := range ordinals {
-		row, ok := v.singlePartRowForOrdinal(ordinal, rowIndexByOrdinal, part)
-		if !ok || ordinal >= len(v.norm.values) || uint64(row) > uint64(^uint32(0)) {
-			return dst, false, nil
+	if rowIndexByOrdinal == nil {
+		for i, ordinal := range ordinals {
+			if ordinal < 0 || ordinal >= v.rows || ordinal >= part.rows || uint64(ordinal) > uint64(^uint32(0)) {
+				return dst, false, nil
+			}
+			rowIDs[i] = uint32(ordinal)
 		}
-		rowIDs[i] = uint32(row)
+	} else {
+		for i, ordinal := range ordinals {
+			if ordinal < 0 || ordinal >= v.rows {
+				return dst, false, nil
+			}
+			rowID := rowIndexByOrdinal[ordinal]
+			if uint64(rowID) >= uint64(part.rows) {
+				return dst, false, nil
+			}
+			rowIDs[i] = rowID
+		}
 	}
 	scratch.scoreTileDots = ensureColumnVectorGraphNativeFloat32Scratch(scratch.scoreTileDots, len(ordinals))
 	dots := scratch.scoreTileDots[:len(ordinals)]
-	status := vectorops.DotFloat32Indexed(dots, part.values, query, rowIDs, v.dims)
+	status := vectorops.DotFloat32Indexed(dots, values, query, rowIDs, dims)
 	if status.Invalid || status.Rows != len(ordinals) {
 		return dst, false, nil
 	}
 	for i, ordinal := range ordinals {
 		row := int(rowIDs[i])
-		start := row * v.dims
-		vector := part.values[start : start+v.dims]
+		start := row * dims
+		vector := values[start : start+dims]
 		score, err := v.scorePreparedDot(query, queryInvNorm, ordinal, float64(dots[i]), vector, stats)
 		if err != nil {
 			return dst, true, err
@@ -572,28 +628,6 @@ func (v *columnVectorGraphPreparedSearchView) scoreOrdinalsIndexedSinglePart(pla
 		v.recordMappingStatsCount(stats, len(ordinals))
 	}
 	return dst, true, nil
-}
-
-func (v *columnVectorGraphPreparedSearchView) singlePartRowForOrdinal(ordinal int, rowIndexByOrdinal []uint32, part *columnVectorGraphTypedColumnVectorPart) (int, bool) {
-	if v == nil || part == nil || ordinal < 0 || ordinal >= v.rows {
-		return 0, false
-	}
-	row := ordinal
-	if rowIndexByOrdinal != nil {
-		if ordinal >= len(rowIndexByOrdinal) {
-			return 0, false
-		}
-		row = int(rowIndexByOrdinal[ordinal])
-	}
-	if row < 0 || row >= part.rows {
-		return 0, false
-	}
-	start := row * v.dims
-	end := start + v.dims
-	if start < 0 || end < start || end > len(part.values) {
-		return 0, false
-	}
-	return row, true
 }
 
 func (v *columnVectorGraphPreparedSearchView) scorePreparedDot(query []float32, queryInvNorm float32, ordinal int, dot float64, vector []float32, stats *columnVectorGraphNativeSearchStats) (float64, error) {

--- a/TreeDB/collections/column_vector_graph_prepared_search_test.go
+++ b/TreeDB/collections/column_vector_graph_prepared_search_test.go
@@ -235,6 +235,38 @@ func TestColumnVectorGraphPreparedSearchStaleStateFailsClosed2045(t *testing.T) 
 	}
 }
 
+func TestColumnVectorGraphPreparedSearchSinglePartRowMapFailsClosed2127(t *testing.T) {
+	if !columnGraphTypedColumnMmapDirectViewSupportedForTest() {
+		t.Skip("combined prepared graph-search view requires mmap_direct test support")
+	}
+	rows := columnGraphRebuildSyntheticRowsV2A(16, 6)
+	_, d, col, def := openColumnGraphTypedColumnVectorTestCollection1782(t, 6, 4, rows)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	reader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("openColumnVectorGraphPhysicalRowReader: %v", err)
+	}
+	defer func() { _ = reader.Close() }()
+	if reader.preparedSearch == nil || reader.preparedSearch.vector.singlePart == nil {
+		t.Fatalf("preparedSearch=%v singlePart=%v want single-part prepared view", reader.preparedSearch != nil, reader.preparedSearch != nil && reader.preparedSearch.vector.singlePart != nil)
+	}
+	rowIndexByOrdinal := make([]uint32, len(rows)-1)
+	for ordinal := range rowIndexByOrdinal {
+		rowIndexByOrdinal[ordinal] = uint32(ordinal)
+	}
+	reader.preparedSearch.vector.rowIndexByOrdinal = rowIndexByOrdinal
+	reader.preparedSearch.vectorIdentityMapping = false
+
+	var scratch columnVectorGraphNativeSearchScratch
+	_, _, err = reader.SearchCosine(rows[0].vector, columnVectorGraphNativeSearchOptions{TopK: 4, EfSearch: len(rows)}, &scratch)
+	if err == nil || !strings.Contains(err.Error(), "combined prepared graph-search view is stale") || !strings.Contains(err.Error(), "row map") {
+		t.Fatalf("SearchCosine err=%v want fail-closed stale prepared single-part row map", err)
+	}
+}
+
 func TestColumnVectorGraphPreparedSearchParallelScratchSafety2045(t *testing.T) {
 	if !columnGraphTypedColumnMmapDirectViewSupportedForTest() {
 		t.Skip("combined prepared graph-search view requires mmap_direct test support")


### PR DESCRIPTION
## Summary

Closes #2127.

This is a narrow C1-only hot-loop cleanup for exact prepared column-graph search. It fast-paths the validated single-part prepared vector row mapping inside indexed score batches by removing the repeated `singlePartRowForOrdinal` helper call from the scoring loop. It keeps exact HNSW traversal, candidate application order, tie behavior, `ef_search`/`topK`, and finite-score fail-closed semantics unchanged.

This is intentionally a low-risk cleanup with mostly neutral/no-regression benchmark evidence, not a breakthrough optimization.

## What changed

- Strengthen single-part prepared vector live validation for rows*dims bounds, value lengths, identity row count, and row-map length.
- Split `scoreOrdinalsIndexedSinglePart` into identity vs row-map paths and do direct per-ordinal row mapping in the hot loop.
- Keep per-candidate bounds checks and existing `scorePreparedDot` finite checks/fallbacks.
- Add a fail-closed test for stale/corrupt single-part row-map metadata.

## Scope boundaries

- No HNSW traversal, candidate ordering, tie policy, `ef_search`, `topK`, or recall behavior changes.
- No graph-row payload revival, graph-owned CSR optimization, normalized-vector storage, or wavefront/relaxed traversal.
- C2 result-ID/row-ref helper cleanup was explicitly deferred.

## Tests

```sh
GOWORK=off go test ./TreeDB/collections \
  -run 'TestColumnVectorGraphPreparedSearch|TestColumnVectorGraphIndexedScoring|TestVectorIndexSearcherSearchWithBuffer'
# ok github.com/snissn/gomap/TreeDB/collections 1.753s
```

```sh
GOMAXPROCS=8 GOWORK=off go test ./TreeDB/collections \
  -run 'TestColumnVectorGraphPreparedSearch|TestColumnVectorGraphIndexedScoring|TestOpenVectorIndexSearcherColumnGraphTypedColumnNativeReader|TestVectorIndexSearcherSearchWithBuffer' \
  -count=1
# ok github.com/snissn/gomap/TreeDB/collections 1.577s
```

## Benchmarks

Hardware: Apple M3, darwin/arm64, `GOMAXPROCS=8`.

Primary exclusive count=5 artifact:

- `/tmp/gomap_2127_c1_exclusive_20260601_080949/benchstat.txt`

Command:

```sh
GOMAXPROCS=8 GOWORK=off go test ./TreeDB/collections \
  -run '^$' \
  -bench 'Benchmark(OpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderV4|OpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderReusableBufferV4|OpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderParallelV4|OpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderReusableBufferParallelV4|ColumnVectorGraphNativeSearchCosineTypedColumnStatsMode2042)' \
  -benchmem -benchtime=1s -count=5
```

| Row | Base | Head | Result |
| --- | ---: | ---: | --- |
| graph-only full diagnostics | 12.36µs | 12.86µs | ~ p=0.056 |
| graph-only minimal | 11.94µs | 11.93µs | ~ p=0.841 |
| public serial | 13.43µs | 13.55µs | ~ p=1.000 |
| reusable serial | 13.85µs | 12.95µs | ~ p=0.151 |
| public parallel | 3.010µs | 2.729µs | ~ p=0.151 |
| reusable parallel | 3.116µs | 3.210µs | ~ p=0.421 |

Coordinator reruns to resolve noise:

- Graph-only count=10: `/tmp/gomap_2127_c1_graph_rerun_20260601_082240/benchstat.txt`
  - full diagnostics: `12.38µs -> 12.21µs`, p=0.210
  - minimal: `12.13µs -> 12.37µs`, p=0.796
  - geomean +0.27%
- Reusable serial count=10: `/tmp/gomap_2127_c1_full_rerun_20260601_082054/benchstat.txt`
  - reusable serial: `13.03µs -> 12.89µs`, p=0.315

Allocation/counter statement:

- Graph-only and reusable rows remain `0 B/op`, `0 allocs/op`.
- Public response-owned rows remain `784 B/op`, `2 allocs/op`.
- Healthy fallback counters remain zero: graph-row, result-ID graph fallback, typed-column vector fallback, adjacency source fallback, norm source fallback.
- Prepared/indexed scoring counters unchanged: prepared score calls, optimized/fallback score batches, row-ref mapping counts, and score float64 fallbacks (`0`).

No CPU profile was run because benchmark movement was not material and the coordinator said no profile slot was needed.

## Internal review notes

Reviewed the diff for exact traversal/result preservation, fail-closed stale/corrupt state behavior, and benchmark scope. The patch only changes row mapping inside the prepared indexed scoring batch after the search plan has validated the combined prepared view; traversal/frontier/top-k/result materialization code is unchanged.

## CI / review status

- Latest-head CI: green for head `34792af7472e4e65df086314ed7c770d032ab76a` (`gh pr checks 2144`).
- Codex: requested with `@codex review`; clean ("Didn't find any major issues").
- Copilot: requested with `@copilot review`; reviewed 2/2 files and generated no comments.
- CodeRabbit: requested with `@coderabbitai review`; skipped due repo review quota/rate limit, no actionable findings.
- Review threads: none.

## Merge status

Do not merge directly; coordinator owns final merge execution.
