### PR TITLE
treedb: stream sorted q2 distinct over dictionary codes

### DIFF
--- a/TreeDB/collections/column_physical_q2_1950_test.go
+++ b/TreeDB/collections/column_physical_q2_1950_test.go
@@ -97,6 +97,63 @@ func TestTypedColumnQ2SortedGroupedDistinctFallback1950(t *testing.T) {
 	}
 }
 
+func TestTypedColumnQ2SortedGroupedDistinctLocalDictionariesAndEmptyValues1950(t *testing.T) {
+	batches := [][]columnPhysicalJSONBenchParityEventP0{typedColumnQ2LocalDictBatchA1950(), typedColumnQ2LocalDictBatchB1950()}
+	events := flattenColumnPhysicalEvents1950(batches)
+	d, col, closeFn := openTypedColumnSortKeyFixtureBatches1950(t, typedColumnQ2ClickHouseSortKey1950(), batches)
+	defer closeFn()
+
+	codesByGeneration := typedColumnQ1DictionaryCodeByGeneration1950(t, d, col, "did", "did:m")
+	if len(codesByGeneration) < 2 {
+		t.Fatalf("did:m dictionary codes by generation=%v want at least two", codesByGeneration)
+	}
+	seenCodes := make(map[int64]struct{}, len(codesByGeneration))
+	for _, code := range codesByGeneration {
+		seenCodes[code] = struct{}{}
+	}
+	if len(seenCodes) < 2 {
+		t.Fatalf("did:m local dictionary codes=%v want differing local dictionary orders", codesByGeneration)
+	}
+
+	result, err := col.RunColumnPhysicalQuery(typedColumnQ2Request1950())
+	if err != nil {
+		t.Fatalf("RunColumnPhysicalQuery(q2 local dictionaries): %v", err)
+	}
+	rowHash := columnPhysicalJSONBenchHashLinesP0(columnPhysicalJSONBenchReferenceLinesP0("q2", events))
+	want := columnPhysicalJSONBenchQ2ReferenceCountsP0(events)
+	assertTypedColumnQ2SortedGroupedDistinctResult1950(t, "local dictionaries", result, rowHash, want)
+	assertTypedColumnQ2SortedGroupedDistinctDiagnostics1950(t, "local dictionaries", result.Diagnostics, len(events), columnPhysicalJSONBenchReferenceMatchedRowsP0("q2", events), true)
+	got := columnPhysicalJSONBenchQ2CountsP0(result.Groups)
+	if got["app.z"].Count != 4 || got["app.z"].Distinct != 2 {
+		t.Fatalf("app.z counts=%+v want duplicate did:m counted once across different local dictionaries", got["app.z"])
+	}
+	if got[""].Count != 1 || got[""].Distinct != 1 {
+		t.Fatalf("empty event counts=%+v want real empty group value", got[""])
+	}
+	if got["app.emptydid"].Count != 2 || got["app.emptydid"].Distinct != 1 {
+		t.Fatalf("empty did counts=%+v want empty distinct value counted once", got["app.emptydid"])
+	}
+}
+
+func TestTypedColumnQ2SortedGroupedDistinctPrefixMismatchFallback1950(t *testing.T) {
+	batches := [][]columnPhysicalJSONBenchParityEventP0{typedColumnQ2SortedBatchA1950(), typedColumnQ2SortedBatchB1950()}
+	events := flattenColumnPhysicalEvents1950(batches)
+	mismatchSortKey := []ColumnSortKey{{Column: "kind"}, {Column: "collection"}, {Column: "operation"}, {Column: "did"}, {Column: "time_us"}}
+	_, col, closeFn := openTypedColumnSortKeyFixtureBatches1950(t, mismatchSortKey, batches)
+	defer closeFn()
+
+	result, err := col.RunColumnPhysicalQuery(typedColumnQ2Request1950())
+	if err != nil {
+		t.Fatalf("RunColumnPhysicalQuery(q2 prefix mismatch): %v", err)
+	}
+	rowHash := columnPhysicalJSONBenchHashLinesP0(columnPhysicalJSONBenchReferenceLinesP0("q2", events))
+	assertTypedColumnQ2SortedGroupedDistinctResult1950(t, "prefix mismatch", result, rowHash, columnPhysicalJSONBenchQ2ReferenceCountsP0(events))
+	assertTypedColumnQ2SortedGroupedDistinctDiagnostics1950(t, "prefix mismatch", result.Diagnostics, len(events), columnPhysicalJSONBenchReferenceMatchedRowsP0("q2", events), false)
+	if result.Diagnostics.SortedGroupedDistinctFallbackReason != columnSortedGroupedDistinctFallbackSortKeyLayout {
+		t.Fatalf("prefix mismatch diagnostics=%+v want sort-key-layout fallback", result.Diagnostics)
+	}
+}
+
 func BenchmarkTypedColumnQ2SortedGroupedDistinct1950(b *testing.B) {
 	events := typedColumnQ2BenchmarkEvents1950(65_536)
 	cases := []struct {
@@ -202,6 +259,30 @@ func typedColumnQ2SortedBatchB1950() []columnPhysicalJSONBenchParityEventP0 {
 		{ID: "b-like-shared", TimeUS: base + 33, Kind: "commit", Operation: "create", Collection: "app.bsky.feed.like", Did: "did:shared"},
 		{ID: "b-repost", TimeUS: base + 34, Kind: "commit", Operation: "create", Collection: "app.bsky.feed.repost", Did: "did:repost"},
 		{ID: "b-graph", TimeUS: base + 35, Kind: "commit", Operation: "create", Collection: "app.bsky.graph.follow", Did: "did:graph"},
+	}
+}
+
+func typedColumnQ2LocalDictBatchA1950() []columnPhysicalJSONBenchParityEventP0 {
+	const base = int64(1_810_000_000_000_000)
+	return []columnPhysicalJSONBenchParityEventP0{
+		{ID: "a-z-m-1", TimeUS: base + 1, Kind: "commit", Operation: "create", Collection: "app.z", Did: "did:m"},
+		{ID: "a-z-m-2", TimeUS: base + 2, Kind: "commit", Operation: "create", Collection: "app.z", Did: "did:m"},
+		{ID: "a-a-x", TimeUS: base + 3, Kind: "commit", Operation: "create", Collection: "app.a", Did: "did:x"},
+		{ID: "a-empty-event", TimeUS: base + 4, Kind: "commit", Operation: "create", Collection: "", Did: "did:empty-event"},
+		{ID: "a-kind-guard", TimeUS: base + 5, Kind: "identity", Operation: "create", Collection: "app.z", Did: "did:guard"},
+	}
+}
+
+func typedColumnQ2LocalDictBatchB1950() []columnPhysicalJSONBenchParityEventP0 {
+	const base = int64(1_810_000_000_000_000)
+	return []columnPhysicalJSONBenchParityEventP0{
+		{ID: "b-z-m", TimeUS: base + 6, Kind: "commit", Operation: "create", Collection: "app.z", Did: "did:m"},
+		{ID: "b-z-n", TimeUS: base + 7, Kind: "commit", Operation: "create", Collection: "app.z", Did: "did:n"},
+		{ID: "b-a-x", TimeUS: base + 8, Kind: "commit", Operation: "create", Collection: "app.a", Did: "did:x"},
+		{ID: "b-empty-did-1", TimeUS: base + 9, Kind: "commit", Operation: "create", Collection: "app.emptydid", Did: ""},
+		{ID: "b-empty-did-2", TimeUS: base + 10, Kind: "commit", Operation: "create", Collection: "app.emptydid", Did: ""},
+		{ID: "b-op-guard", TimeUS: base + 11, Kind: "commit", Operation: "delete", Collection: "app.z", Did: "did:a"},
+		{ID: "b-kind-guard", TimeUS: base + 12, Kind: "identity", Operation: "create", Collection: "app.z", Did: "did:b"},
 	}
 }
 

--- a/TreeDB/collections/column_physical_typed_column_query.go
+++ b/TreeDB/collections/column_physical_typed_column_query.go
@@ -54,6 +54,26 @@ type columnTypedColumnDenseInt64SpanPart struct {
 	Predicates       []columnTypedColumnDensePredicatePart
 }
 
+type columnTypedColumnSortedGroupedDistinctCodeColumn struct {
+	Codes      []int64
+	Dictionary []string
+}
+
+type columnTypedColumnSortedGroupedDistinctPredicate struct {
+	Codes      []int64
+	Allowed    []uint64
+	RejectsAll bool
+}
+
+type columnTypedColumnSortedGroupedDistinctPart struct {
+	Rows         int
+	RowIndexes   []int
+	PhysicalRows []int
+	Group        columnTypedColumnSortedGroupedDistinctCodeColumn
+	Distinct     columnTypedColumnSortedGroupedDistinctCodeColumn
+	Predicates   []columnTypedColumnSortedGroupedDistinctPredicate
+}
+
 type columnTypedColumnPhysicalQueryPart struct {
 	Ref                       columnManifestAssetRefForScan
 	PhysicalRef               columnManifestAssetRefForScan
@@ -76,6 +96,7 @@ type columnTypedColumnPhysicalQueryPart struct {
 	DenseGroupCount           *columnTypedColumnDenseGroupCountPart
 	DenseGroupHourCount       *columnTypedColumnDenseGroupHourCountPart
 	DenseInt64Span            *columnTypedColumnDenseInt64SpanPart
+	SortedGroupedDistinct     *columnTypedColumnSortedGroupedDistinctPart
 	TimeOrderTopK             *columnTypedColumnTimeOrderTopKPart
 }
 
@@ -393,6 +414,8 @@ func decodeColumnTypedColumnPhysicalQueryRunnerParts(view columnPhysicalScanSnap
 			part, err = decodeTypedColumnPhysicalQueryDenseInt64SpanPart(plan, view.FullConfig.SchemaHash, typedRef, physical, raw)
 		case columnTypedColumnPhysicalQueryUseTimeOrderTopK(plan, req):
 			part, err = decodeTypedColumnPhysicalQueryTimeOrderTopKPart(plan, view.FullConfig.SchemaHash, typedRef, physical, raw, includePhysicalRows)
+		case columnTypedColumnPhysicalQueryUseSortedGroupedDistinct(plan, req):
+			part, err = decodeTypedColumnPhysicalQuerySortedGroupedDistinctPart(plan, view.FullConfig.SchemaHash, typedRef, physical, raw, includePhysicalRows)
 		default:
 			part, err = decodeTypedColumnPhysicalQueryPart(plan, view.FullConfig.SchemaHash, typedRef, physical, raw, includePhysicalRows)
 		}
@@ -2156,6 +2179,7 @@ type columnTypedColumnSortedGroupedDistinctIterator struct {
 	rowIndexes       []int
 	physicalRows     []int
 	visibility       *typedColumnLatestPhysicalPart
+	codePart         *columnTypedColumnSortedGroupedDistinctPart
 	groupValues      []columnDeclaredValue
 	distinctValues   []columnDeclaredValue
 	predicateSpecs   []columnPhysicalQueryPredicateSpec
@@ -2168,6 +2192,16 @@ type columnTypedColumnSortedGroupedDistinctIterator struct {
 }
 
 func newColumnTypedColumnSortedGroupedDistinctIterator(part *columnTypedColumnPhysicalQueryPart, plan columnTypedColumnPhysicalQueryPlan, req ColumnPhysicalQueryRequest, partIndex int, visibility *typedColumnLatestPhysicalPart) (*columnTypedColumnSortedGroupedDistinctIterator, error) {
+	if part.SortedGroupedDistinct != nil {
+		return &columnTypedColumnSortedGroupedDistinctIterator{
+			partIndex:    partIndex,
+			rows:         part.SortedGroupedDistinct.Rows,
+			rowIndexes:   part.SortedGroupedDistinct.RowIndexes,
+			physicalRows: part.SortedGroupedDistinct.PhysicalRows,
+			visibility:   visibility,
+			codePart:     part.SortedGroupedDistinct,
+		}, nil
+	}
 	partRows := len(part.RowIndexes)
 	if part.RowIndexes == nil {
 		partRows = part.Rows
@@ -2202,6 +2236,9 @@ func newColumnTypedColumnSortedGroupedDistinctIterator(part *columnTypedColumnPh
 }
 
 func (it *columnTypedColumnSortedGroupedDistinctIterator) advance() error {
+	if it.codePart != nil {
+		return it.advanceCodes()
+	}
 	// These slices come from typed-column adapter decoding, which materializes
 	// owned String values (not physical-row StringBytes views). Keep the hot loop
 	// on direct string header comparisons and avoid per-row map lookups or string
@@ -2237,6 +2274,60 @@ func (it *columnTypedColumnSortedGroupedDistinctIterator) advance() error {
 		}
 		it.currentGroup = it.groupValues[rowIdx].String
 		it.currentDistinct = it.distinctValues[rowIdx].String
+		return nil
+	}
+	it.done = true
+	it.currentGroup = ""
+	it.currentDistinct = ""
+	return nil
+}
+
+func (it *columnTypedColumnSortedGroupedDistinctIterator) advanceCodes() error {
+	for it.row < it.rows {
+		rowIdx := it.row
+		it.row++
+		it.rowsScanned++
+		if it.visibility != nil {
+			physicalRow := rowIdx
+			if it.physicalRows != nil {
+				physicalRow = it.physicalRows[rowIdx]
+			} else if it.rowIndexes != nil {
+				physicalRow = it.rowIndexes[rowIdx]
+			}
+			if !it.visibility.rowVisible(physicalRow) {
+				continue
+			}
+		}
+		matched := true
+		for _, predicate := range it.codePart.Predicates {
+			if predicate.RejectsAll || rowIdx < 0 || rowIdx >= len(predicate.Codes) {
+				matched = false
+				break
+			}
+			code := predicate.Codes[rowIdx]
+			word := int(code / 64)
+			bit := uint(code % 64)
+			if word < 0 || word >= len(predicate.Allowed) || (predicate.Allowed[word]&(uint64(1)<<bit)) == 0 {
+				matched = false
+				break
+			}
+		}
+		if !matched {
+			continue
+		}
+		if len(it.codePart.Predicates) != 0 {
+			it.matchedRows++
+		}
+		groupCode := it.codePart.Group.Codes[rowIdx]
+		distinctCode := it.codePart.Distinct.Codes[rowIdx]
+		if groupCode < 0 || groupCode >= int64(len(it.codePart.Group.Dictionary)) {
+			return fmt.Errorf("collections: sorted grouped-distinct group code=%d outside cardinality=%d", groupCode, len(it.codePart.Group.Dictionary))
+		}
+		if distinctCode < 0 || distinctCode >= int64(len(it.codePart.Distinct.Dictionary)) {
+			return fmt.Errorf("collections: sorted grouped-distinct distinct code=%d outside cardinality=%d", distinctCode, len(it.codePart.Distinct.Dictionary))
+		}
+		it.currentGroup = it.codePart.Group.Dictionary[groupCode]
+		it.currentDistinct = it.codePart.Distinct.Dictionary[distinctCode]
 		return nil
 	}
 	it.done = true

--- a/TreeDB/collections/typed_column_adapter.go
+++ b/TreeDB/collections/typed_column_adapter.go
@@ -920,6 +920,9 @@ func typedColumnSortedGroupedDistinctDictionaryValuesByCode(column typedColumnAd
 	if err := validateTypedColumnAdapterStringDictionary(column, column.Definition.Cardinality, column.Dictionary); err != nil {
 		return nil, err
 	}
+	if uint64(int(column.Definition.Cardinality)) != uint64(column.Definition.Cardinality) {
+		return nil, fmt.Errorf("collections: sorted grouped-distinct dictionary cardinality=%d exceeds host int for column %q", column.Definition.Cardinality, column.Definition.Name)
+	}
 	valuesByCode := make([]string, int(column.Definition.Cardinality))
 	for value, code := range column.Dictionary {
 		valuesByCode[code] = value

--- a/TreeDB/collections/typed_column_adapter.go
+++ b/TreeDB/collections/typed_column_adapter.go
@@ -706,6 +706,227 @@ func (p *typedColumnAdapterPart) buildImage() (typedcolumn.ColumnPartImage, erro
 	return typedcolumn.BuildColumnPartImage(p.Part, typedcolumn.ColumnPartImageOptions{Dictionaries: p.Dictionary, LayoutLogicalTypes: logicalTypes})
 }
 
+func decodeTypedColumnPhysicalQuerySortedGroupedDistinctPart(plan columnTypedColumnPhysicalQueryPlan, schemaHash uint64, typedRef, physical columnManifestAssetRefForScan, raw []byte, includePhysicalRows bool) (columnTypedColumnPhysicalQueryPart, error) {
+	image, err := typedcolumn.ParseColumnPartImage(raw)
+	if err != nil {
+		return columnTypedColumnPhysicalQueryPart{}, err
+	}
+	adapterPart, err := typedColumnAdapterPartFromImageWithoutRowLocators(typedColumnAdapterOptions{Fields: plan.Fields, SchemaVersion: uint32(schemaHash)}, image)
+	if err != nil {
+		return columnTypedColumnPhysicalQueryPart{}, err
+	}
+	summary := typedColumnAdapterImageSummary{PartID: image.PartID, Rows: image.Rows, Sections: len(image.Sections), SectionBytes: typedColumnPhysicalQueryImageSectionBytes(image), SortKey: columnSortKeysFromTypedColumnSortKeys(adapterPart.Part.Descriptor.SortKey)}
+	if summary.PartID != typedRef.Ref.PartID || summary.Rows != typedRef.Rows {
+		return columnTypedColumnPhysicalQueryPart{}, fmt.Errorf("typed_column_part image/ref mismatch image_part=%d ref_part=%d image_rows=%d manifest_rows=%d", summary.PartID, typedRef.Ref.PartID, summary.Rows, typedRef.Rows)
+	}
+	if physical.Rows != 0 && summary.Rows != physical.Rows {
+		return columnTypedColumnPhysicalQueryPart{}, fmt.Errorf("typed_column_part rows=%d do not match physical rows=%d", summary.Rows, physical.Rows)
+	}
+	if err := validateTypedColumnPhysicalQuerySortMetadata(plan.SortKey, typedRef.SortKey, summary.SortKey); err != nil {
+		return columnTypedColumnPhysicalQueryPart{}, err
+	}
+	pruned, err := plan.SortKeyPrefix.prunePartRows(adapterPart)
+	if err != nil {
+		return columnTypedColumnPhysicalQueryPart{}, err
+	}
+	selectedRows := pruned.Rows
+	if pruned.AllRows {
+		selectedRows = nil
+	} else if selectedRows == nil {
+		selectedRows = []int{}
+	}
+	selectedRowCount := len(selectedRows)
+	if selectedRows == nil {
+		selectedRowCount = summary.Rows
+	}
+
+	projection, err := typedColumnSortedGroupedDistinctProjection(adapterPart, plan)
+	if err != nil {
+		return columnTypedColumnPhysicalQueryPart{}, err
+	}
+	scan, err := typedColumnScanSortedGroupedDistinctColumns(adapterPart, projection, selectedRows)
+	if err != nil {
+		return columnTypedColumnPhysicalQueryPart{}, err
+	}
+
+	group, err := typedColumnSortedGroupedDistinctCodeColumn(adapterPart, scan, plan.GroupColumn, selectedRowCount)
+	if err != nil {
+		return columnTypedColumnPhysicalQueryPart{}, err
+	}
+	distinct, err := typedColumnSortedGroupedDistinctCodeColumn(adapterPart, scan, plan.DistinctColumn, selectedRowCount)
+	if err != nil {
+		return columnTypedColumnPhysicalQueryPart{}, err
+	}
+	predicates := make([]columnTypedColumnSortedGroupedDistinctPredicate, len(plan.PredicateSpecs))
+	for i, spec := range plan.PredicateSpecs {
+		predicate, err := typedColumnSortedGroupedDistinctPredicate(adapterPart, scan, spec, selectedRowCount)
+		if err != nil {
+			return columnTypedColumnPhysicalQueryPart{}, err
+		}
+		predicates[i] = predicate
+	}
+
+	physicalRowIndexes := []int(nil)
+	if includePhysicalRows {
+		var primaryDiag columnTypedColumnPhysicalRowIndexDiagnostics
+		physicalRowIndexes, primaryDiag, err = typedColumnPhysicalQueryPhysicalRows(adapterPart, selectedRows, selectedRowCount)
+		if err != nil {
+			return columnTypedColumnPhysicalQueryPart{}, err
+		}
+		if primaryDiag.GranulesDecoded > scan.Diagnostics.GranulesDecoded {
+			scan.Diagnostics.GranulesDecoded = primaryDiag.GranulesDecoded
+		}
+		scan.Diagnostics.BlocksDecoded += primaryDiag.BlocksDecoded
+		scan.Diagnostics.BytesDecoded += primaryDiag.BytesDecoded
+	}
+
+	return columnTypedColumnPhysicalQueryPart{
+		Ref:                       typedRef,
+		PhysicalRef:               physical,
+		RowIndexes:                selectedRows,
+		PhysicalRowIndexes:        physicalRowIndexes,
+		Rows:                      summary.Rows,
+		Bytes:                     int64(len(raw)),
+		Sections:                  summary.Sections,
+		SectionBytes:              summary.SectionBytes,
+		GranulesConsidered:        pruned.Considered,
+		GranulesDecoded:           scan.Diagnostics.GranulesDecoded,
+		GranulesSkipped:           pruned.Skips,
+		DecodedBlocks:             scan.Diagnostics.BlocksDecoded,
+		DecodedPayloadBytes:       uint64(scan.Diagnostics.BytesDecoded),
+		SortKeyMarkChecks:         pruned.Checks,
+		SortKeyMarkMatches:        pruned.Matches,
+		SortKeyMarkSkips:          pruned.Skips,
+		SortKeyMarkFallbackReason: pruned.FallbackReason,
+		SortedGroupedDistinct: &columnTypedColumnSortedGroupedDistinctPart{
+			Rows:         selectedRowCount,
+			RowIndexes:   selectedRows,
+			PhysicalRows: physicalRowIndexes,
+			Group:        group,
+			Distinct:     distinct,
+			Predicates:   predicates,
+		},
+	}, nil
+}
+
+func typedColumnSortedGroupedDistinctProjection(part *typedColumnAdapterPart, plan columnTypedColumnPhysicalQueryPlan) ([]string, error) {
+	seen := make(map[string]struct{}, 2+len(plan.PredicateSpecs))
+	projection := make([]string, 0, 2+len(plan.PredicateSpecs))
+	add := func(name string) error {
+		column, ok := part.columnByName(name)
+		if !ok {
+			return fmt.Errorf("collections: sorted grouped-distinct missing typed-column column %q", name)
+		}
+		if _, exists := seen[column.Definition.Name]; exists {
+			return nil
+		}
+		seen[column.Definition.Name] = struct{}{}
+		projection = append(projection, column.Definition.Name)
+		return nil
+	}
+	if err := add(plan.GroupColumn); err != nil {
+		return nil, err
+	}
+	if err := add(plan.DistinctColumn); err != nil {
+		return nil, err
+	}
+	for _, spec := range plan.PredicateSpecs {
+		if err := add(spec.column); err != nil {
+			return nil, err
+		}
+	}
+	return projection, nil
+}
+
+func typedColumnScanSortedGroupedDistinctColumns(part *typedColumnAdapterPart, projection []string, selectedRows []int) (typedcolumn.ProjectedScanResult, error) {
+	if selectedRows != nil && len(selectedRows) == 0 {
+		columns := make(map[string][]int64, len(projection))
+		for _, name := range projection {
+			columns[name] = []int64{}
+		}
+		return typedcolumn.ProjectedScanResult{Columns: columns, Diagnostics: typedcolumn.PartScanDiagnostics{RowsScanned: 0, ColumnsProjected: len(projection), GranulesConsidered: len(part.Part.Descriptor.Granules)}}, nil
+	}
+	if selectedRows == nil {
+		return part.Part.NewScanner().ScanProjected(projection)
+	}
+	return part.Part.NewScanner().ScanProjectedRows(projection, selectedRows)
+}
+
+func typedColumnSortedGroupedDistinctCodeColumn(part *typedColumnAdapterPart, scan typedcolumn.ProjectedScanResult, columnName string, rows int) (columnTypedColumnSortedGroupedDistinctCodeColumn, error) {
+	column, valuesByCode, codes, err := typedColumnSortedGroupedDistinctScannedColumn(part, scan, columnName, rows)
+	if err != nil {
+		return columnTypedColumnSortedGroupedDistinctCodeColumn{}, err
+	}
+	if column.Field.ValueType != ColumnStoreValueString || column.Definition.Type != typedcolumn.ColumnTypeLowCardinalityCode || column.Definition.Encoding != typedcolumn.EncodingLowCardinalityUint32 {
+		return columnTypedColumnSortedGroupedDistinctCodeColumn{}, fmt.Errorf("%w: sorted grouped-distinct column %q is not a non-null dictionary string", ErrColumnQueryPlanUnsupported, columnName)
+	}
+	return columnTypedColumnSortedGroupedDistinctCodeColumn{Codes: codes, Dictionary: valuesByCode}, nil
+}
+
+func typedColumnSortedGroupedDistinctPredicate(part *typedColumnAdapterPart, scan typedcolumn.ProjectedScanResult, spec columnPhysicalQueryPredicateSpec, rows int) (columnTypedColumnSortedGroupedDistinctPredicate, error) {
+	column, valuesByCode, codes, err := typedColumnSortedGroupedDistinctScannedColumn(part, scan, spec.column, rows)
+	if err != nil {
+		return columnTypedColumnSortedGroupedDistinctPredicate{}, err
+	}
+	allowed := make([]uint64, (len(valuesByCode)+63)/64)
+	matched := 0
+	for _, value := range spec.values {
+		code, ok := column.Dictionary[value]
+		if !ok {
+			continue
+		}
+		word := int(code / 64)
+		bit := uint(code % 64)
+		mask := uint64(1) << bit
+		if allowed[word]&mask == 0 {
+			allowed[word] |= mask
+			matched++
+		}
+	}
+	return columnTypedColumnSortedGroupedDistinctPredicate{Codes: codes, Allowed: allowed, RejectsAll: matched == 0}, nil
+}
+
+func typedColumnSortedGroupedDistinctScannedColumn(part *typedColumnAdapterPart, scan typedcolumn.ProjectedScanResult, columnName string, rows int) (typedColumnAdapterColumn, []string, []int64, error) {
+	column, ok := part.columnByName(columnName)
+	if !ok {
+		return typedColumnAdapterColumn{}, nil, nil, fmt.Errorf("collections: sorted grouped-distinct missing typed-column column %q", columnName)
+	}
+	if column.Field.Nullable {
+		return typedColumnAdapterColumn{}, nil, nil, fmt.Errorf("%w: sorted grouped-distinct column %q is nullable", ErrColumnQueryPlanUnsupported, columnName)
+	}
+	if column.Field.ValueType != ColumnStoreValueString || column.Definition.Type != typedcolumn.ColumnTypeLowCardinalityCode || column.Definition.Encoding != typedcolumn.EncodingLowCardinalityUint32 {
+		return typedColumnAdapterColumn{}, nil, nil, fmt.Errorf("%w: sorted grouped-distinct column %q is not a dictionary string", ErrColumnQueryPlanUnsupported, columnName)
+	}
+	valuesByCode, err := typedColumnSortedGroupedDistinctDictionaryValuesByCode(column)
+	if err != nil {
+		return typedColumnAdapterColumn{}, nil, nil, err
+	}
+	codes, ok := scan.Columns[column.Definition.Name]
+	if !ok {
+		return typedColumnAdapterColumn{}, nil, nil, fmt.Errorf("collections: sorted grouped-distinct scan missing column %q", column.Definition.Name)
+	}
+	if len(codes) != rows {
+		return typedColumnAdapterColumn{}, nil, nil, fmt.Errorf("collections: sorted grouped-distinct column %q rows=%d want %d", columnName, len(codes), rows)
+	}
+	for row, code := range codes {
+		if code < 0 || code >= int64(len(valuesByCode)) {
+			return typedColumnAdapterColumn{}, nil, nil, fmt.Errorf("collections: sorted grouped-distinct column %q row=%d code=%d outside cardinality=%d", columnName, row, code, len(valuesByCode))
+		}
+	}
+	return column, valuesByCode, codes, nil
+}
+
+func typedColumnSortedGroupedDistinctDictionaryValuesByCode(column typedColumnAdapterColumn) ([]string, error) {
+	if err := validateTypedColumnAdapterStringDictionary(column, column.Definition.Cardinality, column.Dictionary); err != nil {
+		return nil, err
+	}
+	valuesByCode := make([]string, int(column.Definition.Cardinality))
+	for value, code := range column.Dictionary {
+		valuesByCode[code] = value
+	}
+	return valuesByCode, nil
+}
+
 // decodeTypedColumnPhysicalQueryDenseGroupCountPart prepares the q1 typed-column
 // section fast path from the adapter seam so production query routing does not
 // import the typedcolumn data plane directly.

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -387,7 +387,7 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/command_wal_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 4, occurrences: 6},
 	{path: "TreeDB/collections/column_physical_sortkey_pruning.go", classification: typedStorageLegacyCompatibility, matchingLines: 6, occurrences: 7},
 	{path: "TreeDB/collections/column_physical_sortkey_pruning_1949_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 4, occurrences: 5},
-	{path: "TreeDB/collections/typed_column_adapter.go", classification: typedStorageLegacyCompatibility, matchingLines: 51, occurrences: 53},
+	{path: "TreeDB/collections/typed_column_adapter.go", classification: typedStorageLegacyCompatibility, matchingLines: 53, occurrences: 55},
 	{path: "TreeDB/collections/typed_column_adapter_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 261, occurrences: 269},
 	{path: "TreeDB/collections/typed_column_capability.go", classification: typedStorageLegacyCompatibility, matchingLines: 20, occurrences: 28},
 	{path: "TreeDB/collections/typed_column_capability_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 18, occurrences: 18},


### PR DESCRIPTION
## Summary

- Links: closes #1943 (root for #1955 q2 SortKey/report contract).
- Scope: TreeDB collection column-store `SortKey` / q2 sorted-prefix grouped count+distinct only; no codec, compression, lifecycle, report API, or value-log changes.
- Change: the already-planned sorted q2 path now decodes predicate/group/distinct **dictionary code streams** directly for sorted grouped distinct instead of materializing `columnDeclaredValue` string rows first, then performs the existing k-way merge by logical group/distinct strings.
- Tests add coverage for different local dictionaries across parts, real empty event/DID strings, and prefix-mismatch fallback.

## Stable public/diagnostic contract surface

- `ColumnStoreConfig.SortKey` remains the public physical-order declaration for supported non-null typed-column string/bool/int64 columns.
- `ColumnPhysicalQueryGroupCountAndDistinct` remains the q2-shaped public request; sorted execution is selected only when equality predicates cover a sort-key prefix and `GroupColumn`/`DistinctColumn` immediately follow that prefix.
- Existing diagnostics remain the contract for downstream #1955: `SortKeyPrefixPlanned`, `SortKeyPrefixColumns`, `SortKeyPrefixLiterals`, `SortKeyMark*`, `SortedGroupedDistinctReady`, `SortedGroupedDistinctUsed`, and `SortedGroupedDistinctFallbackReason`.
- Fallback remains fail-closed: missing/stale marks, uncertified dictionary order, prefix mismatch, unsupported predicates, nullable/defaulted columns, and unsupported sort-key layout use existing fallback/error paths.

## Colgranule reuse map

| colgranule file/function | production target file/API | decision | reason/evidence |
| --- | --- | --- | --- |
| `experiments/colgranule/part.go`: `SortKey`, `SortKeyColumn`, option normalization | `TreeDB/internal/typedcolumn/part.go`; `TreeDB/collections/column_store.go`; `typedColumnPartPublicationSortKey` | ported/adapted | Production supports the same ascending logical-value sort key for typed-column parts, with additional fail-closed production validation for nullable/default/unsupported owner/type cases. Covered by `TestTypedColumnPartSortKey*1948`. |
| `experiments/colgranule/part.go`: `ColumnPartBuilder.sortedOrder` and row tie-break by primary id/input row | `TreeDB/internal/typedcolumn/part.go: sortedOrder`; adapter primary-id mapping in `typedColumnAdapterRowsFromDeclaredRows` | ported | Production sorted rows are built before payload/mark construction and preserve deterministic primary-id tie breaking. Covered by sort-key ordering/reopen/tie tests. |
| `experiments/colgranule/part.go`: `GranuleDescriptor`, `RowLocator` | `TreeDB/internal/typedcolumn/part.go`; `typedColumnPhysicalQueryPhysicalRows` | ported/adapted | Production descriptors/locators are persisted in typed-column images and used for latest-visible sorted execution physical-row mapping. Reviewed by high-thinking reviewer; mutation q2 tests pass. |
| `experiments/colgranule/predicate.go`: `SortKeyMark`, prefix bounds, `MayContainRanges` | `TreeDB/internal/typedcolumn/predicate.go`; `TreeDB/collections/column_physical_sortkey_pruning.go` | copied/ported | Production uses the same mark structure/range pruning and adds collection diagnostics/fallback reasons. Covered by `TestTypedColumnSortKeyPrefixPlannerFallbacks1949` and q4b/q2 prefix tests. |
| `experiments/colgranule/part_image.go` / `part_image_decode.go`: sort-key metadata and marks sections, descriptor/image consistency | `TreeDB/internal/typedcolumn/part_image.go`; `part_image_decode.go`; `validateTypedColumnPhysicalQuerySortMetadata` | ported/adapted | Production persists `sort_key_metadata` + `sort_key_marks`, validates manifest/image/config agreement, and fails closed on corrupt/stale metadata. Covered by image decode/validation, reopen, and corruption/fallback tests. |
| `experiments/colgranule/jsonbench_part_queries.go`: `JSONBenchColumnPartLayoutClickHouseFilterUserTime` ordering over kind/operation/collection/did/time | `typedColumnQ2ClickHouseSortKey1950`; JSONBench parity fixtures and `ColumnPhysicalQueryGroupCountAndDistinct` predicates | ported/adapted | Production models ClickHouse-like q2 ordering with real predicates (`kind=commit`, `operation=create`) and no write-time masking. Covered by JSONBench parity/no-masking and q2 sorted tests. |
| `experiments/colgranule/jsonbench_part_queries.go`: q2 fused code reducer (`fused_dense_group_count_distinct_codes`) | `decodeTypedColumnPhysicalQuerySortedGroupedDistinctPart`; `advanceCodes` in `column_physical_typed_column_query.go` | adapted | Production now decodes sorted predicate/group/distinct dictionary code streams and uses bitset predicate checks plus k-way logical merge across parts, avoiding per-query global DID map rebuild and avoiding row-string materialization for the sorted path. Benchmarks below show direct sorted q2 B/op drops ~50.2 MiB -> ~4.5 MiB and ns/op ~14.2 ms -> ~3.1 ms on the synthetic fixture. |
| `experiments/colgranule/part_set.go`: multipart q2 over visible rows | `runSortedGroupedDistinct`; `runLatestVisibleSortedGroupedDistinct` | adapted | Production differs because local dictionaries are per typed-column part and are merged by logical strings rather than assuming a global code space; new tests force different local `did` codes across generations and duplicate DID semantics. |

## Start-phase test plan

- Focused sort-key persistence/planner/q2/jsonbench tests in `TreeDB/collections`.
- Typed-column mark/image validation tests in `TreeDB/internal/typedcolumn`.
- Unified-bench column-store report smoke tests for downstream #1955 contract compatibility.

## Start-phase performance plan

- Baseline and candidate: `BenchmarkTypedColumnQ2SortedGroupedDistinct1950` with `-benchmem -count=3` on `origin/main` / candidate.
- Candidate focused direct q2 CPU/alloc profile with `-cpuprofile`/`-memprofile`.
- Treat sorted q2 or fallback/prepared material regressions as blocking.

## Close-phase test evidence

- `GOWORK=off go test ./TreeDB/collections` ✅
- `GOWORK=off go test ./TreeDB/internal/typedcolumn` ✅
- `GOWORK=off go test ./cmd/unified_bench -run 'TestColumnStore'` ✅
- `GOWORK=off go test ./TreeDB/docs` ✅
- Internal high-thinking reviewer: PASS/no blocking findings; focused q2/sort-key/mutation tests passed in review worktree.

## Close-phase benchmark/profile evidence

Hardware/context: Apple M3, darwin/arm64. Dataset shape: in-repo synthetic q2 fixture, 65,536 rows/op, query timing inside benchmark after fixture setup. Baseline branch/SHA: `origin/main` `7419f1e1162ce602831fba6cd2490f18d9205c88`. Candidate branch/SHA: `snissn/1943-manager` `fda217b83ad7b8537e4ff40930eeabdb9d08d98a`.

Commands/artifacts:

- Baseline: `GOWORK=off go test ./TreeDB/collections -run '^$' -bench '^BenchmarkTypedColumnQ2SortedGroupedDistinct1950$' -benchmem -count=3` → `/tmp/1943_q2_bench_baseline.txt`
- Candidate: same command → `/tmp/1943_q2_bench_after_review.txt`
- Benchstat: `/tmp/1943_q2_benchstat_after_review.txt`
- Candidate profile: `GOWORK=off go test ./TreeDB/collections -run '^$' -bench '^BenchmarkTypedColumnQ2SortedGroupedDistinct1950/direct/sorted_prefix$' -benchmem -benchtime=50x -cpuprofile ... -memprofile ...` → `/tmp/1943_q2_profiles_20260601_110715/`

| Benchmark | Baseline ns/op | Candidate ns/op | Baseline ops/sec | Candidate ops/sec | Rows/sec (base → cand) | B/op (base → cand) | allocs/op (base → cand) |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| direct/sorted_prefix | ~14,196,000 | ~3,020,000 | ~70.4 | ~331.1 | ~4.6M → ~21.7M | ~50.2 MiB → ~4.5 MiB | 8,890 → 8,917 |
| prepared/sorted_prefix | ~2,396,000 | ~858,000 | ~417.4 | ~1,165.5 | ~27.4M → ~76.4M | 296 B → 248 B | 3 → 2 |
| direct/primary_id_fallback | ~22,110,000 | ~22,050,000 | ~45.2 | ~45.4 | ~3.0M → ~3.0M | ~51.1 MiB → ~51.1 MiB | 8,749 → 8,749 |
| prepared/primary_id_fallback | ~10,920,000 | ~10,650,000 | ~91.6 | ~93.9 | ~6.0M → ~6.2M | ~853 KiB → ~853 KiB | 128 → 128 |

Regression assessment: sorted q2 materially improves runtime and bytes allocated. Fallback rows are not on the changed code path; the direct fallback timing movement in the after-review n=3 sample was neutral/not statistically significant (`p=0.700`) and B/op/allocs are unchanged. No material local regression accepted or pending.

## AI/CI/review status

- CI: latest head `fda217b83` green on all reported checks.
- AI reviews: Codex passed on initial and post-fix review; Copilot found one host-int cardinality guard issue, fixed in `fda217b83`, replied, resolved, and Copilot follow-up reported the guard correctly implemented; CodeRabbit status is passing/review completed with no unresolved findings.
- Known caveats: profile captures include benchmark fixture setup because Go test profiles cover the whole test process; benchmark rows above are the query-timed evidence.
