### PR TITLE
Reject deprecated public TreeDB profiles

### DIFF
--- a/TreeDB/integration/kvstoreadapter/open.go
+++ b/TreeDB/integration/kvstoreadapter/open.go
@@ -64,13 +64,36 @@ type Opened struct {
 	KV      *treedbadapter.DB
 }
 
-// ParseProfile parses the public downstream profile vocabulary. Empty input
-// falls back to fallback, but the fallback must also be a public profile.
-func ParseProfile(raw string, fallback treedb.Profile) (treedb.Profile, error) {
+// ParseProfile parses the common downstream profile vocabulary and falls back
+// to fallback for empty or unknown values.
+//
+// Deprecated: use ParsePublicProfile at env/CLI boundaries that must reject
+// deprecated TreeDB profiles.
+func ParseProfile(raw string, fallback treedb.Profile) treedb.Profile {
 	if fallback == "" {
 		fallback = treedb.ProfileCommandWALRelaxed
 	}
-	if profile, ok := treedb.ParsePublicProfile(raw, fallback); ok {
+	if profile, ok := treedb.ParseProfile(raw, fallback); ok {
+		return profile
+	}
+	return fallback
+}
+
+// ParsePublicProfile parses the public downstream profile vocabulary. Empty
+// input falls back to fallback, but the fallback must also be a public profile.
+func ParsePublicProfile(raw string, fallback treedb.Profile) (treedb.Profile, error) {
+	if fallback == "" {
+		fallback = treedb.ProfileCommandWALRelaxed
+	}
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		profile, ok := treedb.ParsePublicProfile("", fallback)
+		if ok {
+			return profile, nil
+		}
+		return "", fmt.Errorf("unsupported TreeDB fallback profile %q; allowed: %s", fallback, treedb.ProfileFlagHelp)
+	}
+	if profile, ok := treedb.ParsePublicProfile(trimmed, fallback); ok {
 		return profile, nil
 	}
 	return "", fmt.Errorf("unsupported TreeDB profile %q; allowed: %s", raw, treedb.ProfileFlagHelp)
@@ -105,7 +128,7 @@ func ResolveOptions(cfg OpenConfig) (treedb.Options, string, error) {
 		profileEnvKey = EnvOpenProfile
 	}
 	rawProfile := os.Getenv(profileEnvKey)
-	profile, err := ParseProfile(rawProfile, cfg.DefaultProfile)
+	profile, err := ParsePublicProfile(rawProfile, cfg.DefaultProfile)
 	if err != nil {
 		return treedb.Options{}, "", fmt.Errorf("invalid %s=%q: %w", profileEnvKey, rawProfile, err)
 	}

--- a/TreeDB/integration/kvstoreadapter/open.go
+++ b/TreeDB/integration/kvstoreadapter/open.go
@@ -64,16 +64,16 @@ type Opened struct {
 	KV      *treedbadapter.DB
 }
 
-// ParseProfile parses the common downstream profile vocabulary and falls back
-// to fallback for empty or unknown values.
-func ParseProfile(raw string, fallback treedb.Profile) treedb.Profile {
+// ParseProfile parses the public downstream profile vocabulary. Empty input
+// falls back to fallback, but the fallback must also be a public profile.
+func ParseProfile(raw string, fallback treedb.Profile) (treedb.Profile, error) {
 	if fallback == "" {
 		fallback = treedb.ProfileCommandWALRelaxed
 	}
-	if profile, ok := treedb.ParseProfile(raw, fallback); ok {
-		return profile
+	if profile, ok := treedb.ParsePublicProfile(raw, fallback); ok {
+		return profile, nil
 	}
-	return fallback
+	return "", fmt.Errorf("unsupported TreeDB profile %q; allowed: %s", raw, treedb.ProfileFlagHelp)
 }
 
 // ResolveOptions converts downstream wrapper defaults and standard TREEDB_*
@@ -104,7 +104,11 @@ func ResolveOptions(cfg OpenConfig) (treedb.Options, string, error) {
 	if profileEnvKey == "" {
 		profileEnvKey = EnvOpenProfile
 	}
-	profile := ParseProfile(os.Getenv(profileEnvKey), cfg.DefaultProfile)
+	rawProfile := os.Getenv(profileEnvKey)
+	profile, err := ParseProfile(rawProfile, cfg.DefaultProfile)
+	if err != nil {
+		return treedb.Options{}, "", fmt.Errorf("invalid %s=%q: %w", profileEnvKey, rawProfile, err)
+	}
 	opts := treedb.OptionsFor(profile, dbPath)
 
 	keepRecentEnvKey := cfg.KeepRecentEnvKey

--- a/TreeDB/integration/kvstoreadapter/open_test.go
+++ b/TreeDB/integration/kvstoreadapter/open_test.go
@@ -3,12 +3,39 @@ package kvstoreadapter
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	treedb "github.com/snissn/gomap/TreeDB"
 )
 
-func TestParseProfileUsesPublicNames(t *testing.T) {
+func TestParseProfileUsesStandardNames(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		raw      string
+		fallback treedb.Profile
+		want     treedb.Profile
+	}{
+		{raw: "", fallback: "", want: treedb.ProfileCommandWALRelaxed},
+		{raw: "", fallback: treedb.ProfileWALOnFast, want: treedb.ProfileWALOnFast},
+		{raw: "fast", fallback: treedb.ProfileDurable, want: treedb.ProfileFast},
+		{raw: "walonfast", fallback: treedb.ProfileDurable, want: treedb.ProfileWALOnFast},
+		{raw: "durable", fallback: treedb.ProfileFast, want: treedb.ProfileDurable},
+		{raw: "command-wal-durable", fallback: treedb.ProfileFast, want: treedb.ProfileCommandWALDurable},
+		{raw: "legacy_wal_relaxed_fast", fallback: treedb.ProfileFast, want: treedb.ProfileLegacyWALRelaxedFast},
+		{raw: "no_wal_fast", fallback: treedb.ProfileDurable, want: treedb.ProfileNoWALFast},
+		{raw: "bench", fallback: treedb.ProfileFast, want: treedb.ProfileBench},
+		{raw: "unknown", fallback: treedb.ProfileFast, want: treedb.ProfileFast},
+	}
+	for _, tc := range cases {
+		if got := ParseProfile(tc.raw, tc.fallback); got != tc.want {
+			t.Fatalf("ParseProfile(%q, %q) = %q, want %q", tc.raw, tc.fallback, got, tc.want)
+		}
+	}
+}
+
+func TestParsePublicProfileUsesPublicNames(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
@@ -23,29 +50,31 @@ func TestParseProfileUsesPublicNames(t *testing.T) {
 		{raw: "bench", fallback: treedb.ProfileCommandWALRelaxed, want: treedb.ProfileBench},
 	}
 	for _, tc := range cases {
-		got, err := ParseProfile(tc.raw, tc.fallback)
+		got, err := ParsePublicProfile(tc.raw, tc.fallback)
 		if err != nil {
-			t.Fatalf("ParseProfile(%q, %q): %v", tc.raw, tc.fallback, err)
+			t.Fatalf("ParsePublicProfile(%q, %q): %v", tc.raw, tc.fallback, err)
 		}
 		if got != tc.want {
-			t.Fatalf("ParseProfile(%q, %q) = %q, want %q", tc.raw, tc.fallback, got, tc.want)
+			t.Fatalf("ParsePublicProfile(%q, %q) = %q, want %q", tc.raw, tc.fallback, got, tc.want)
 		}
 	}
 }
 
-func TestParseProfileRejectsDeprecatedAndUnknownNames(t *testing.T) {
+func TestParsePublicProfileRejectsDeprecatedAndUnknownNames(t *testing.T) {
 	t.Parallel()
 
 	for _, raw := range []string{"fast", "walonfast", "durable", "legacy_wal_relaxed_fast", "no_wal_fast", "unknown"} {
 		t.Run(raw, func(t *testing.T) {
-			_, err := ParseProfile(raw, treedb.ProfileCommandWALRelaxed)
+			_, err := ParsePublicProfile(raw, treedb.ProfileCommandWALRelaxed)
 			if err == nil {
-				t.Fatal("ParseProfile succeeded, want error")
+				t.Fatal("ParsePublicProfile succeeded, want error")
 			}
 		})
 	}
-	if _, err := ParseProfile("", treedb.ProfileFast); err == nil {
-		t.Fatal("ParseProfile accepted deprecated fallback, want error")
+	if _, err := ParsePublicProfile("", treedb.ProfileFast); err == nil {
+		t.Fatal("ParsePublicProfile accepted deprecated fallback, want error")
+	} else if !strings.Contains(err.Error(), "fallback profile") {
+		t.Fatalf("ParsePublicProfile deprecated fallback err=%v, want fallback profile context", err)
 	}
 }
 

--- a/TreeDB/integration/kvstoreadapter/open_test.go
+++ b/TreeDB/integration/kvstoreadapter/open_test.go
@@ -8,7 +8,7 @@ import (
 	treedb "github.com/snissn/gomap/TreeDB"
 )
 
-func TestParseProfileUsesStandardNames(t *testing.T) {
+func TestParseProfileUsesPublicNames(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
@@ -17,32 +17,47 @@ func TestParseProfileUsesStandardNames(t *testing.T) {
 		want     treedb.Profile
 	}{
 		{raw: "", fallback: "", want: treedb.ProfileCommandWALRelaxed},
-		{raw: "", fallback: treedb.ProfileWALOnFast, want: treedb.ProfileWALOnFast},
-		{raw: "fast", fallback: treedb.ProfileDurable, want: treedb.ProfileFast},
-		{raw: "walonfast", fallback: treedb.ProfileDurable, want: treedb.ProfileWALOnFast},
-		{raw: "durable", fallback: treedb.ProfileFast, want: treedb.ProfileDurable},
-		{raw: "command-wal-durable", fallback: treedb.ProfileFast, want: treedb.ProfileCommandWALDurable},
-		{raw: "legacy_wal_relaxed_fast", fallback: treedb.ProfileFast, want: treedb.ProfileLegacyWALRelaxedFast},
-		{raw: "no_wal_fast", fallback: treedb.ProfileDurable, want: treedb.ProfileNoWALFast},
-		{raw: "bench", fallback: treedb.ProfileFast, want: treedb.ProfileBench},
-		{raw: "unknown", fallback: treedb.ProfileFast, want: treedb.ProfileFast},
+		{raw: "", fallback: treedb.ProfileCommandWALDurable, want: treedb.ProfileCommandWALDurable},
+		{raw: "command-wal-durable", fallback: treedb.ProfileCommandWALRelaxed, want: treedb.ProfileCommandWALDurable},
+		{raw: "command_wal_relaxed", fallback: treedb.ProfileCommandWALDurable, want: treedb.ProfileCommandWALRelaxed},
+		{raw: "bench", fallback: treedb.ProfileCommandWALRelaxed, want: treedb.ProfileBench},
 	}
 	for _, tc := range cases {
-		if got := ParseProfile(tc.raw, tc.fallback); got != tc.want {
+		got, err := ParseProfile(tc.raw, tc.fallback)
+		if err != nil {
+			t.Fatalf("ParseProfile(%q, %q): %v", tc.raw, tc.fallback, err)
+		}
+		if got != tc.want {
 			t.Fatalf("ParseProfile(%q, %q) = %q, want %q", tc.raw, tc.fallback, got, tc.want)
 		}
 	}
 }
 
+func TestParseProfileRejectsDeprecatedAndUnknownNames(t *testing.T) {
+	t.Parallel()
+
+	for _, raw := range []string{"fast", "walonfast", "durable", "legacy_wal_relaxed_fast", "no_wal_fast", "unknown"} {
+		t.Run(raw, func(t *testing.T) {
+			_, err := ParseProfile(raw, treedb.ProfileCommandWALRelaxed)
+			if err == nil {
+				t.Fatal("ParseProfile succeeded, want error")
+			}
+		})
+	}
+	if _, err := ParseProfile("", treedb.ProfileFast); err == nil {
+		t.Fatal("ParseProfile accepted deprecated fallback, want error")
+	}
+}
+
 func TestResolveOptionsAppliesDefaultsAndEnvOverrides(t *testing.T) {
-	t.Setenv(EnvOpenProfile, "fast")
+	t.Setenv(EnvOpenProfile, "command_wal_relaxed")
 	t.Setenv(EnvKeepRecent, "7")
 	t.Setenv(EnvMemtableMode, "skiplist")
 
 	opts, path, err := ResolveOptions(OpenConfig{
 		ParentDir:                   t.TempDir(),
 		Name:                        "application",
-		DefaultProfile:              treedb.ProfileDurable,
+		DefaultProfile:              treedb.ProfileCommandWALDurable,
 		DefaultKeepRecent:           1,
 		DefaultAdaptiveMemtableBase: "hash_sorted",
 	})
@@ -52,8 +67,11 @@ func TestResolveOptionsAppliesDefaultsAndEnvOverrides(t *testing.T) {
 	if path != filepath.Join(opts.Dir) {
 		t.Fatalf("path %q != opts.Dir %q", path, opts.Dir)
 	}
-	if opts.Durability != treedb.DurabilityWALOffRelaxed {
-		t.Fatalf("Durability = %v, want fast WAL-off relaxed", opts.Durability)
+	if !opts.CommandWAL {
+		t.Fatal("CommandWAL=false, want command WAL profile")
+	}
+	if opts.Durability != treedb.DurabilityWALOnRelaxed {
+		t.Fatalf("Durability = %v, want command WAL relaxed durability", opts.Durability)
 	}
 	if opts.KeepRecent != 7 {
 		t.Fatalf("KeepRecent = %d, want 7", opts.KeepRecent)
@@ -87,7 +105,7 @@ func TestResolveOptionsAppliesAdaptiveMemtableFallback(t *testing.T) {
 	opts, _, err := ResolveOptions(OpenConfig{
 		ParentDir:                   t.TempDir(),
 		Name:                        "application",
-		DefaultProfile:              treedb.ProfileWALOnFast,
+		DefaultProfile:              treedb.ProfileCommandWALRelaxed,
 		DefaultKeepRecent:           1,
 		DefaultAdaptiveMemtableBase: "hash_sorted",
 	})
@@ -108,7 +126,7 @@ func TestResolveOptionsNormalizesDefaultMemtableMode(t *testing.T) {
 	opts, _, err := ResolveOptions(OpenConfig{
 		ParentDir:           t.TempDir(),
 		Name:                "application",
-		DefaultProfile:      treedb.ProfileWALOnFast,
+		DefaultProfile:      treedb.ProfileCommandWALRelaxed,
 		DefaultMemtableMode: "SkipList",
 	})
 	if err != nil {
@@ -124,9 +142,19 @@ func TestResolveOptionsRejectsInvalidKeepRecent(t *testing.T) {
 	if _, _, err := ResolveOptions(OpenConfig{
 		ParentDir:      t.TempDir(),
 		Name:           "application",
-		DefaultProfile: treedb.ProfileWALOnFast,
+		DefaultProfile: treedb.ProfileCommandWALRelaxed,
 	}); err == nil {
 		t.Fatal("expected invalid keep recent error")
+	}
+}
+
+func TestResolveOptionsRejectsDeprecatedProfileEnv(t *testing.T) {
+	t.Setenv(EnvOpenProfile, "fast")
+	if _, _, err := ResolveOptions(OpenConfig{
+		ParentDir: t.TempDir(),
+		Name:      "application",
+	}); err == nil {
+		t.Fatal("expected deprecated profile env error")
 	}
 }
 
@@ -137,28 +165,28 @@ func TestResolveOptionsRejectsInvalidPathInputs(t *testing.T) {
 		{
 			ParentDir:      "",
 			Name:           "application",
-			DefaultProfile: treedb.ProfileWALOnFast,
+			DefaultProfile: treedb.ProfileCommandWALRelaxed,
 		},
 		{
 			ParentDir:      t.TempDir(),
 			Name:           "",
-			DefaultProfile: treedb.ProfileWALOnFast,
+			DefaultProfile: treedb.ProfileCommandWALRelaxed,
 		},
 		{
 			ParentDir:      t.TempDir(),
 			Name:           "bad/name",
-			DefaultProfile: treedb.ProfileWALOnFast,
+			DefaultProfile: treedb.ProfileCommandWALRelaxed,
 		},
 		{
 			ParentDir:      t.TempDir(),
 			Name:           `bad\name`,
-			DefaultProfile: treedb.ProfileWALOnFast,
+			DefaultProfile: treedb.ProfileCommandWALRelaxed,
 		},
 		{
 			ParentDir:      t.TempDir(),
 			Name:           "application",
 			DBFileSuffix:   "../bad",
-			DefaultProfile: treedb.ProfileWALOnFast,
+			DefaultProfile: treedb.ProfileCommandWALRelaxed,
 		},
 	}
 	for _, cfg := range cases {
@@ -176,7 +204,7 @@ func TestResolveOptionsIsSideEffectFreeOnError(t *testing.T) {
 	if _, _, err := ResolveOptions(OpenConfig{
 		ParentDir:      parentDir,
 		Name:           "application",
-		DefaultProfile: treedb.ProfileWALOnFast,
+		DefaultProfile: treedb.ProfileCommandWALRelaxed,
 	}); err == nil {
 		t.Fatal("expected invalid keep recent error")
 	}
@@ -193,7 +221,7 @@ func TestOpenReturnsDBAndNamedAdapter(t *testing.T) {
 		ParentDir:         parentDir,
 		Name:              "application",
 		AdapterName:       "TreeDB Test",
-		DefaultProfile:    treedb.ProfileFast,
+		DefaultProfile:    treedb.ProfileCommandWALRelaxed,
 		DefaultKeepRecent: 1,
 	})
 	if err != nil {

--- a/TreeDB/mongo_gateway/server.go
+++ b/TreeDB/mongo_gateway/server.go
@@ -146,6 +146,11 @@ func parseFlags(args []string, stderr io.Writer) (cliConfig, error) {
 	if cfg.dir == "" {
 		return cfg, errors.New("TreeDB root directory -dir is required")
 	}
+	profile, ok := treedb.ParsePublicProfile(cfg.profile, treedb.ProfileCommandWALDurable)
+	if !ok {
+		return cfg, fmt.Errorf("unsupported TreeDB profile %q; allowed: %s", cfg.profile, treedb.ProfileFlagHelp)
+	}
+	cfg.profile = string(profile)
 	if cfg.maxFindScanDocuments < 0 {
 		return cfg, errors.New("-max-find-scan-documents must be >= 0")
 	}

--- a/TreeDB/mongo_gateway/standalone.go
+++ b/TreeDB/mongo_gateway/standalone.go
@@ -336,9 +336,9 @@ func (s *StandaloneServer) Close() error {
 }
 
 func normalizeStandaloneProfile(profile treedb.Profile) (treedb.Profile, error) {
-	normalized, ok := treedb.ParseProfile(string(profile), treedb.ProfileCommandWALDurable)
+	normalized, ok := treedb.ParsePublicProfile(string(profile), treedb.ProfileCommandWALDurable)
 	if !ok {
-		return "", fmt.Errorf("mongo gateway standalone: unsupported TreeDB profile %q", profile)
+		return "", fmt.Errorf("mongo gateway standalone: unsupported TreeDB profile %q; allowed: %s", profile, treedb.ProfileFlagHelp)
 	}
 	return normalized, nil
 }

--- a/TreeDB/mongo_gateway/standalone_test.go
+++ b/TreeDB/mongo_gateway/standalone_test.go
@@ -42,7 +42,7 @@ func TestNormalizeStandaloneOptionsDefaultsAndValidation(t *testing.T) {
 
 	normalized, err := NormalizeStandaloneOptions(StandaloneOptions{
 		Dir:     t.TempDir(),
-		Profile: treedb.Profile(" WAL_ON_FAST "),
+		Profile: treedb.Profile("command-wal-relaxed"),
 		DefaultCollectionOptions: collections.CollectionOptions{
 			DocumentFormat: collections.DocumentFormat(" BSON "),
 		},
@@ -50,8 +50,8 @@ func TestNormalizeStandaloneOptionsDefaultsAndValidation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NormalizeStandaloneOptions normalized strings: %v", err)
 	}
-	if normalized.Profile != treedb.ProfileWALOnFast {
-		t.Fatalf("normalized profile=%q want %q", normalized.Profile, treedb.ProfileWALOnFast)
+	if normalized.Profile != treedb.ProfileCommandWALRelaxed {
+		t.Fatalf("normalized profile=%q want %q", normalized.Profile, treedb.ProfileCommandWALRelaxed)
 	}
 	commandWAL, err := NormalizeStandaloneOptions(StandaloneOptions{
 		Dir:     t.TempDir(),
@@ -83,7 +83,12 @@ func TestNormalizeStandaloneOptionsDefaultsAndValidation(t *testing.T) {
 		{
 			name: "bad profile",
 			opts: StandaloneOptions{Dir: t.TempDir(), Profile: treedb.Profile("unsafe")},
-			want: "unsupported TreeDB profile",
+			want: "allowed: " + treedb.ProfileFlagHelp,
+		},
+		{
+			name: "deprecated profile",
+			opts: StandaloneOptions{Dir: t.TempDir(), Profile: treedb.Profile("WAL_ON_FAST")},
+			want: "allowed: " + treedb.ProfileFlagHelp,
 		},
 		{
 			name: "bad document format",

--- a/TreeDB/profiles.go
+++ b/TreeDB/profiles.go
@@ -149,6 +149,31 @@ func ParseProfile(raw string, fallback Profile) (Profile, bool) {
 	return NormalizeProfile(Profile(raw))
 }
 
+// ParsePublicProfile parses the public server/profile vocabulary. Empty input
+// returns fallback only when fallback is also a public profile. Deprecated
+// compatibility names such as fast, wal_on_fast, durable, legacy_wal_* and
+// no_wal_fast are intentionally rejected here.
+func ParsePublicProfile(raw string, fallback Profile) (Profile, bool) {
+	if strings.TrimSpace(raw) == "" {
+		return NormalizePublicProfile(fallback)
+	}
+	return NormalizePublicProfile(Profile(raw))
+}
+
+// NormalizePublicProfile normalizes supported public profile names and aliases.
+func NormalizePublicProfile(profile Profile) (Profile, bool) {
+	switch normalizeProfileToken(string(profile)) {
+	case string(ProfileCommandWALDurable):
+		return ProfileCommandWALDurable, true
+	case string(ProfileCommandWALRelaxed):
+		return ProfileCommandWALRelaxed, true
+	case string(ProfileBench):
+		return ProfileBench, true
+	default:
+		return "", false
+	}
+}
+
 // NormalizeProfile normalizes supported profile names and aliases to their
 // public Profile constants.
 func NormalizeProfile(profile Profile) (Profile, bool) {

--- a/TreeDB/profiles_test.go
+++ b/TreeDB/profiles_test.go
@@ -162,6 +162,55 @@ func TestParseProfile_ExplicitNamesAndAliases(t *testing.T) {
 	}
 }
 
+func TestParsePublicProfile_AllowedNamesAndAliases(t *testing.T) {
+	tests := []struct {
+		raw      string
+		fallback Profile
+		want     Profile
+	}{
+		{raw: "", fallback: ProfileCommandWALDurable, want: ProfileCommandWALDurable},
+		{raw: "", fallback: ProfileCommandWALRelaxed, want: ProfileCommandWALRelaxed},
+		{raw: "", fallback: ProfileBench, want: ProfileBench},
+		{raw: " COMMAND-WAL-DURABLE ", want: ProfileCommandWALDurable},
+		{raw: "command_wal_relaxed", want: ProfileCommandWALRelaxed},
+		{raw: "bench", want: ProfileBench},
+	}
+	for _, tt := range tests {
+		t.Run(tt.raw+"/"+string(tt.fallback), func(t *testing.T) {
+			got, ok := ParsePublicProfile(tt.raw, tt.fallback)
+			if !ok {
+				t.Fatalf("ParsePublicProfile(%q, %q) rejected, want %q", tt.raw, tt.fallback, tt.want)
+			}
+			if got != tt.want {
+				t.Fatalf("profile=%q want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParsePublicProfile_RejectsDeprecatedAndUnknownNames(t *testing.T) {
+	rejected := []string{
+		"fast",
+		"wal_on_fast",
+		"walonfast",
+		"durable",
+		"legacy_wal_durable",
+		"legacy_wal_relaxed_fast",
+		"no_wal_fast",
+		"raw",
+	}
+	for _, raw := range rejected {
+		t.Run(raw, func(t *testing.T) {
+			if got, ok := ParsePublicProfile(raw, ProfileCommandWALRelaxed); ok {
+				t.Fatalf("ParsePublicProfile(%q) = %q, want rejection", raw, got)
+			}
+		})
+	}
+	if got, ok := ParsePublicProfile("", ProfileFast); ok {
+		t.Fatalf("ParsePublicProfile empty fallback ProfileFast = %q, want rejection", got)
+	}
+}
+
 func TestApplyProfile_CommandWALDurableSetsCommandWALAndFastDurablePolicy(t *testing.T) {
 	var opts Options
 	ApplyProfile(&opts, ProfileCommandWALDurable)

--- a/cmd/collection_load_fixture/main.go
+++ b/cmd/collection_load_fixture/main.go
@@ -326,7 +326,7 @@ func parseConfig(args []string, output io.Writer) (config, error) {
 		DocumentFormat:             collections.DocumentFormatTemplateV1,
 		IndexCount:                 2,
 		BufferedIndexedWrites:      true,
-		Profile:                    treedb.ProfileNoWALFast,
+		Profile:                    treedb.ProfileBench,
 		DataOuterLeavesInValueLog:  true,
 		IndexOuterLeavesInValueLog: true,
 		KeepRecent:                 1,
@@ -529,14 +529,16 @@ func parseDocumentFormat(raw string) (collections.DocumentFormat, error) {
 func parseProfile(raw string) (treedb.Profile, error) {
 	switch strings.ToLower(strings.TrimSpace(raw)) {
 	case "production_fast", "backend_direct_fast", "backend_direct", "cached":
+		// Transitional collection benchmark engine aliases are migrated by #2148.
 		return treedb.ProfileNoWALFast, nil
 	case "production_wal_on_fast", "backend_direct_wal_on_fast":
+		// Transitional collection benchmark engine aliases are migrated by #2148.
 		return treedb.ProfileLegacyWALRelaxedFast, nil
 	default:
-		if profile, ok := treedb.ParseProfile(raw, treedb.ProfileNoWALFast); ok {
+		if profile, ok := treedb.ParsePublicProfile(raw, treedb.ProfileBench); ok {
 			return profile, nil
 		}
-		return "", fmt.Errorf("unsupported -profile %q", raw)
+		return "", fmt.Errorf("unsupported -profile %q; allowed: %s", raw, treedb.ProfileFlagHelp)
 	}
 }
 

--- a/cmd/collection_load_fixture/main_test.go
+++ b/cmd/collection_load_fixture/main_test.go
@@ -58,6 +58,26 @@ func TestParseConfigDefaultsToInspectableTwoIndexTemplateFixture(t *testing.T) {
 	}
 }
 
+func TestParseProfileRejectsDeprecatedProfileNames(t *testing.T) {
+	if got, err := parseProfile("command-wal-relaxed"); err != nil || got != treedb.ProfileCommandWALRelaxed {
+		t.Fatalf("parseProfile command WAL relaxed = %q err=%v", got, err)
+	}
+	if got, err := parseProfile("production_fast"); err != nil || got != treedb.ProfileNoWALFast {
+		t.Fatalf("parseProfile production_fast = %q err=%v", got, err)
+	}
+	for _, raw := range []string{"fast", "wal_on_fast", "durable", "legacy_wal_durable", "legacy_wal_relaxed_fast", "no_wal_fast"} {
+		t.Run(raw, func(t *testing.T) {
+			_, err := parseProfile(raw)
+			if err == nil {
+				t.Fatal("parseProfile succeeded, want error")
+			}
+			if !strings.Contains(err.Error(), treedb.ProfileFlagHelp) {
+				t.Fatalf("error=%v, want profile help", err)
+			}
+		})
+	}
+}
+
 func TestParseConfigPartialBufferedIndexedThresholdKeepsRootRunDefault(t *testing.T) {
 	cfg, err := parseConfig([]string{"-buffered-indexed-write-max-docs", "1234"}, io.Discard)
 	if err != nil {

--- a/cmd/collection_workload_bench/main.go
+++ b/cmd/collection_workload_bench/main.go
@@ -370,9 +370,9 @@ func parsePositiveOrZeroInts(raw, label string) ([]int, error) {
 }
 
 func parseProfile(raw string) (treedb.Profile, error) {
-	profile, ok := treedb.ParseProfile(raw, treedb.ProfileBench)
+	profile, ok := treedb.ParsePublicProfile(raw, treedb.ProfileBench)
 	if !ok {
-		return "", fmt.Errorf("unknown treedb-profile %q", raw)
+		return "", fmt.Errorf("unsupported -treedb-profile %q; allowed: %s", raw, treedb.ProfileFlagHelp)
 	}
 	return profile, nil
 }

--- a/cmd/collection_workload_bench/main_test.go
+++ b/cmd/collection_workload_bench/main_test.go
@@ -40,6 +40,40 @@ func TestParsePositiveIntsRejectsDuplicates(t *testing.T) {
 	}
 }
 
+func TestParseProfileAcceptsOnlyPublicProfiles(t *testing.T) {
+	tests := []struct {
+		raw  string
+		want treedb.Profile
+	}{
+		{raw: "", want: treedb.ProfileBench},
+		{raw: "command-wal-durable", want: treedb.ProfileCommandWALDurable},
+		{raw: "command_wal_relaxed", want: treedb.ProfileCommandWALRelaxed},
+		{raw: "bench", want: treedb.ProfileBench},
+	}
+	for _, tt := range tests {
+		t.Run(tt.raw, func(t *testing.T) {
+			got, err := parseProfile(tt.raw)
+			if err != nil {
+				t.Fatalf("parseProfile(%q): %v", tt.raw, err)
+			}
+			if got != tt.want {
+				t.Fatalf("profile=%q want %q", got, tt.want)
+			}
+		})
+	}
+	for _, raw := range []string{"fast", "wal_on_fast", "durable", "legacy_wal_durable", "legacy_wal_relaxed_fast", "no_wal_fast"} {
+		t.Run("reject_"+raw, func(t *testing.T) {
+			_, err := parseProfile(raw)
+			if err == nil {
+				t.Fatal("parseProfile succeeded, want error")
+			}
+			if !strings.Contains(err.Error(), treedb.ProfileFlagHelp) {
+				t.Fatalf("error=%v, want profile help", err)
+			}
+		})
+	}
+}
+
 func TestRunSmallNativeCollectionMatrix(t *testing.T) {
 	cfg := config{
 		Documents:             32,

--- a/cmd/mongo_gateway_bench/main.go
+++ b/cmd/mongo_gateway_bench/main.go
@@ -475,7 +475,7 @@ func run(parent context.Context, args []string) error {
 
 func parseConfig(args []string) (config, error) {
 	cfg := config{
-		TreeDBProfile:               treedb.ProfileLegacyWALRelaxedFast,
+		TreeDBProfile:               treedb.ProfileBench,
 		TreeDBDocumentFormat:        collections.DocumentFormatTemplateV1,
 		TreeDBDataRootStorage:       collections.RootStorageCompressed,
 		TreeDBIndexStateRootStorage: collections.RootStorageCompressed,
@@ -571,6 +571,9 @@ func parseConfig(args []string) (config, error) {
 	fs.Visit(func(f *flag.Flag) {
 		seenFlags[f.Name] = true
 	})
+	if cfg.Target == "treedb" && cfg.TreeDBCommandWAL && !seenFlags["treedb-profile"] {
+		treeDBProfile = string(treedb.ProfileCommandWALRelaxed)
+	}
 	if cfg.TreeDBDisableBufferedIndexedAsyncFlush && cfg.TreeDBBufferedIndexedAsyncFlush {
 		return config{}, errors.New("cannot set both -treedb-buffered-indexed-async-flush and -treedb-disable-buffered-indexed-async-flush")
 	}
@@ -804,9 +807,9 @@ func parseConfig(args []string) (config, error) {
 }
 
 func parseTreeDBProfile(raw string) (treedb.Profile, error) {
-	profile, ok := treedb.ParseProfile(raw, treedb.ProfileLegacyWALRelaxedFast)
+	profile, ok := treedb.ParsePublicProfile(raw, treedb.ProfileBench)
 	if !ok {
-		return "", fmt.Errorf("unknown treedb-profile %q", raw)
+		return "", fmt.Errorf("unsupported -treedb-profile %q; allowed: %s", raw, treedb.ProfileFlagHelp)
 	}
 	return profile, nil
 }

--- a/cmd/mongo_gateway_bench/main_test.go
+++ b/cmd/mongo_gateway_bench/main_test.go
@@ -1136,8 +1136,8 @@ func TestParseConfigTreeDBCorrectnessDefaults(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parse defaults: %v", err)
 	}
-	if cfg.TreeDBProfile != treedb.ProfileLegacyWALRelaxedFast {
-		t.Fatalf("TreeDBProfile=%q want %q", cfg.TreeDBProfile, treedb.ProfileLegacyWALRelaxedFast)
+	if cfg.TreeDBProfile != treedb.ProfileBench {
+		t.Fatalf("TreeDBProfile=%q want %q", cfg.TreeDBProfile, treedb.ProfileBench)
 	}
 	if cfg.TreeDBCommandWAL {
 		t.Fatal("TreeDBCommandWAL=true want false by default")
@@ -1174,6 +1174,26 @@ func TestParseConfigTreeDBCorrectnessDefaults(t *testing.T) {
 	}
 	if cfg.InsertProducers != 1 {
 		t.Fatalf("InsertProducers=%d want 1", cfg.InsertProducers)
+	}
+}
+
+func TestParseTreeDBProfileRejectsDeprecatedPublicNames(t *testing.T) {
+	if got, err := parseTreeDBProfile("command-wal-durable"); err != nil || got != treedb.ProfileCommandWALDurable {
+		t.Fatalf("parseTreeDBProfile command WAL durable = %q err=%v", got, err)
+	}
+	if got, err := parseTreeDBProfile(""); err != nil || got != treedb.ProfileBench {
+		t.Fatalf("parseTreeDBProfile empty = %q err=%v", got, err)
+	}
+	for _, raw := range []string{"fast", "wal_on_fast", "durable", "legacy_wal_durable", "legacy_wal_relaxed_fast", "no_wal_fast"} {
+		t.Run(raw, func(t *testing.T) {
+			_, err := parseTreeDBProfile(raw)
+			if err == nil {
+				t.Fatal("parseTreeDBProfile succeeded, want error")
+			}
+			if !strings.Contains(err.Error(), treedb.ProfileFlagHelp) {
+				t.Fatalf("error=%v, want profile help", err)
+			}
+		})
 	}
 }
 
@@ -1270,6 +1290,9 @@ func TestParseConfigAcceptsTreeDBCommandWAL(t *testing.T) {
 	if !cfg.TreeDBCommandWAL {
 		t.Fatal("TreeDBCommandWAL=false want true")
 	}
+	if cfg.TreeDBProfile != treedb.ProfileCommandWALRelaxed {
+		t.Fatalf("TreeDBProfile=%q want command_wal_relaxed when -treedb-command-wal is supplied without -treedb-profile", cfg.TreeDBProfile)
+	}
 	if _, err := parseConfig([]string{"-target", "mongo", "-treedb-command-wal"}); err == nil || !strings.Contains(err.Error(), "treedb-command-wal is only supported with -target treedb") {
 		t.Fatalf("parse mongo command WAL error=%v, want target error", err)
 	}
@@ -1282,8 +1305,8 @@ func TestParseConfigAcceptsTreeDBCommandWAL(t *testing.T) {
 	if _, err := parseConfig([]string{"-target", "treedb", "-treedb-command-wal", "-treedb-maintenance", treeDBMaintenanceNone}); err != nil {
 		t.Fatalf("parse command WAL none maintenance: %v", err)
 	}
-	if _, err := parseConfig([]string{"-target", "treedb", "-treedb-command-wal", "-treedb-profile", string(treedb.ProfileDurable)}); err != nil {
-		t.Fatalf("parse durable command WAL config: %v", err)
+	if _, err := parseConfig([]string{"-target", "treedb", "-treedb-command-wal", "-treedb-profile", string(treedb.ProfileDurable)}); err == nil || !strings.Contains(err.Error(), "allowed: "+treedb.ProfileFlagHelp) {
+		t.Fatalf("parse deprecated command WAL profile error=%v, want strict profile error", err)
 	}
 	cfg, err = parseConfig([]string{"-target", "treedb", "-treedb-profile", string(treedb.ProfileCommandWALDurable)})
 	if err != nil {
@@ -1292,7 +1315,7 @@ func TestParseConfigAcceptsTreeDBCommandWAL(t *testing.T) {
 	if !cfg.TreeDBCommandWAL {
 		t.Fatal("TreeDBCommandWAL=false for command_wal_durable profile")
 	}
-	for _, profile := range []treedb.Profile{treedb.ProfileFast, treedb.ProfileNoWALFast, treedb.ProfileBench} {
+	for _, profile := range []treedb.Profile{treedb.ProfileBench} {
 		_, err := parseConfig([]string{"-target", "treedb", "-treedb-command-wal", "-treedb-profile", string(profile)})
 		if err == nil || !strings.Contains(err.Error(), "treedb-command-wal requires a WAL-on treedb-profile") {
 			t.Fatalf("parse command WAL profile %q error=%v, want WAL-on profile error", profile, err)
@@ -1637,20 +1660,12 @@ func TestProfileRecorderSkipsDisabledBlockAndMutexProfiles(t *testing.T) {
 	}
 }
 
-func TestTreeDBProfileSmokeFastAndWALOnFast(t *testing.T) {
+func TestTreeDBProfileSmokeBench(t *testing.T) {
 	if testing.Short() {
 		t.Skip("profile smoke benchmark skipped in short mode")
 	}
-	fast := runTreeDBProfileSmoke(t, treedb.ProfileFast)
-	walOnFast := runTreeDBProfileSmoke(t, treedb.ProfileWALOnFast)
-	ratio := fast / walOnFast
-	if ratio < 1 {
-		ratio = 1 / ratio
-	}
-	t.Logf("fast load_insert_many ops/sec=%.1f wal_on_fast ops/sec=%.1f max ratio=%.2fx", fast, walOnFast, ratio)
-	if ratio > 4.0 {
-		t.Fatalf("fast and wal_on_fast write smoke diverged by %.2fx; fast=%.1f wal_on_fast=%.1f", ratio, fast, walOnFast)
-	}
+	ops := runTreeDBProfileSmoke(t, treedb.ProfileBench)
+	t.Logf("bench load_insert_many ops/sec=%.1f", ops)
 }
 
 func TestTreeDBClientModeSmoke(t *testing.T) {

--- a/cmd/treedb-native-server/main.go
+++ b/cmd/treedb-native-server/main.go
@@ -32,9 +32,9 @@ func main() {
 		log.Fatal("Data directory (-dir) is required")
 	}
 
-	normalizedProfile, ok := treedb.NormalizeProfile(treedb.Profile(*profile))
-	if !ok {
-		log.Fatalf("Unknown TreeDB profile %q", *profile)
+	normalizedProfile, err := parsePublicProfileFlag(*profile)
+	if err != nil {
+		log.Fatal(err)
 	}
 	opts := treedb.OptionsFor(normalizedProfile, *dataDir)
 
@@ -87,4 +87,12 @@ func main() {
 	if closeErr != nil {
 		log.Fatalf("Server close error: %v", closeErr)
 	}
+}
+
+func parsePublicProfileFlag(raw string) (treedb.Profile, error) {
+	profile, ok := treedb.ParsePublicProfile(raw, treedb.ProfileCommandWALDurable)
+	if !ok {
+		return "", fmt.Errorf("unsupported TreeDB profile %q; allowed: %s", raw, treedb.ProfileFlagHelp)
+	}
+	return profile, nil
 }

--- a/cmd/treedb-native-server/main_test.go
+++ b/cmd/treedb-native-server/main_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	treedb "github.com/snissn/gomap/TreeDB"
+)
+
+func TestParsePublicProfileFlagAcceptsPublicProfiles(t *testing.T) {
+	tests := []struct {
+		raw  string
+		want treedb.Profile
+	}{
+		{raw: "", want: treedb.ProfileCommandWALDurable},
+		{raw: "command-wal-durable", want: treedb.ProfileCommandWALDurable},
+		{raw: "command_wal_relaxed", want: treedb.ProfileCommandWALRelaxed},
+		{raw: "bench", want: treedb.ProfileBench},
+	}
+	for _, tt := range tests {
+		t.Run(tt.raw, func(t *testing.T) {
+			got, err := parsePublicProfileFlag(tt.raw)
+			if err != nil {
+				t.Fatalf("parsePublicProfileFlag(%q): %v", tt.raw, err)
+			}
+			if got != tt.want {
+				t.Fatalf("profile=%q want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParsePublicProfileFlagRejectsDeprecatedProfiles(t *testing.T) {
+	for _, raw := range []string{"fast", "wal_on_fast", "durable", "legacy_wal_durable", "legacy_wal_relaxed_fast", "no_wal_fast"} {
+		t.Run(raw, func(t *testing.T) {
+			_, err := parsePublicProfileFlag(raw)
+			if err == nil {
+				t.Fatal("parsePublicProfileFlag succeeded, want error")
+			}
+			if !strings.Contains(err.Error(), "allowed: "+treedb.ProfileFlagHelp) {
+				t.Fatalf("error=%v, want allowed profile guidance", err)
+			}
+		})
+	}
+}

--- a/cmd/treedb_out_of_core_smoke/main.go
+++ b/cmd/treedb_out_of_core_smoke/main.go
@@ -1094,14 +1094,16 @@ func runRawWorker(cfg config) error {
 func parseProfile(raw string) (treedb.Profile, error) {
 	switch strings.ToLower(strings.TrimSpace(raw)) {
 	case "production_fast":
+		// Transitional collection benchmark engine alias migrated by #2148.
 		return treedb.ProfileNoWALFast, nil
 	case "production_wal_on_fast":
+		// Transitional collection benchmark engine alias migrated by #2148.
 		return treedb.ProfileLegacyWALRelaxedFast, nil
 	default:
-		if profile, ok := treedb.ParseProfile(raw, treedb.ProfileNoWALFast); ok {
+		if profile, ok := treedb.ParsePublicProfile(raw, treedb.ProfileBench); ok {
 			return profile, nil
 		}
-		return "", fmt.Errorf("unsupported profile %q", raw)
+		return "", fmt.Errorf("unsupported profile %q; allowed: %s", raw, treedb.ProfileFlagHelp)
 	}
 }
 

--- a/cmd/treedb_out_of_core_smoke/main_test.go
+++ b/cmd/treedb_out_of_core_smoke/main_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	treedb "github.com/snissn/gomap/TreeDB"
 )
 
 func TestValidateSmokeRunRequiresShapeLabel(t *testing.T) {
@@ -26,6 +28,26 @@ func TestValidateSmokeRunRequiresShapeLabel(t *testing.T) {
 	}
 	if hasCheck(checks, "error", "invalid_shape_label") {
 		t.Fatalf("empty shape should not also report invalid_shape_label: %#v", checks)
+	}
+}
+
+func TestParseProfileRejectsDeprecatedProfileNames(t *testing.T) {
+	if got, err := parseProfile("bench"); err != nil || got != treedb.ProfileBench {
+		t.Fatalf("parseProfile bench = %q err=%v", got, err)
+	}
+	if got, err := parseProfile("production_wal_on_fast"); err != nil || got != treedb.ProfileLegacyWALRelaxedFast {
+		t.Fatalf("parseProfile production_wal_on_fast = %q err=%v", got, err)
+	}
+	for _, raw := range []string{"fast", "wal_on_fast", "durable", "legacy_wal_durable", "legacy_wal_relaxed_fast", "no_wal_fast"} {
+		t.Run(raw, func(t *testing.T) {
+			_, err := parseProfile(raw)
+			if err == nil {
+				t.Fatal("parseProfile succeeded, want error")
+			}
+			if !strings.Contains(err.Error(), treedb.ProfileFlagHelp) {
+				t.Fatalf("error=%v, want profile help", err)
+			}
+		})
 	}
 }
 

--- a/cmd/treedb_vector_search_demo/main.go
+++ b/cmd/treedb_vector_search_demo/main.go
@@ -402,9 +402,9 @@ func parseVectorIndexStrategy(raw string) (collections.VectorIndexStrategy, erro
 }
 
 func parseProfile(raw string) (treedb.Profile, error) {
-	profile, ok := treedb.ParseProfile(raw, treedb.ProfileBench)
+	profile, ok := treedb.ParsePublicProfile(raw, treedb.ProfileBench)
 	if !ok {
-		return "", fmt.Errorf("unsupported -profile %q", raw)
+		return "", fmt.Errorf("unsupported -profile %q; allowed: %s", raw, treedb.ProfileFlagHelp)
 	}
 	return profile, nil
 }

--- a/cmd/treedb_vector_search_demo/main_test.go
+++ b/cmd/treedb_vector_search_demo/main_test.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"testing"
 
+	treedb "github.com/snissn/gomap/TreeDB"
 	"github.com/snissn/gomap/TreeDB/collections"
 )
 
@@ -369,6 +370,23 @@ func TestParseProfileRejectsUnsupportedProfile(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "unsupported -profile") {
 		t.Fatalf("error=%v, want unsupported -profile", err)
+	}
+}
+
+func TestParseProfileRejectsDeprecatedProfiles(t *testing.T) {
+	if got, err := parseProfile("command-wal-durable"); err != nil || got != treedb.ProfileCommandWALDurable {
+		t.Fatalf("parseProfile command WAL durable = %q err=%v", got, err)
+	}
+	for _, raw := range []string{"fast", "wal_on_fast", "durable", "legacy_wal_durable", "legacy_wal_relaxed_fast", "no_wal_fast"} {
+		t.Run(raw, func(t *testing.T) {
+			_, err := parseProfile(raw)
+			if err == nil {
+				t.Fatal("parseProfile succeeded, want error")
+			}
+			if !strings.Contains(err.Error(), treedb.ProfileFlagHelp) {
+				t.Fatalf("error=%v, want profile help", err)
+			}
+		})
 	}
 }
 

--- a/scripts/compare_application_db_rebuilds.sh
+++ b/scripts/compare_application_db_rebuilds.sh
@@ -378,26 +378,11 @@ func runCompactTreeDB(args []string) {
 }
 
 func parseTreeDBProfile(raw string) (treedb.Profile, string, error) {
-	switch strings.ToLower(strings.TrimSpace(raw)) {
-	case "command_wal_relaxed", "command-wal-relaxed", "":
-		return treedb.ProfileCommandWALRelaxed, "command_wal_relaxed", nil
-	case "command_wal_durable", "command-wal-durable":
-		return treedb.ProfileCommandWALDurable, "command_wal_durable", nil
-	case "bench":
-		return treedb.ProfileBench, "bench", nil
-	case "fast":
-		return treedb.ProfileFast, "fast", nil
-	case "wal_on_fast", "walonfast":
-		return treedb.ProfileWALOnFast, "wal_on_fast", nil
-	case "legacy_wal_relaxed_fast":
-		return treedb.ProfileLegacyWALRelaxedFast, "legacy_wal_relaxed_fast", nil
-	case "legacy_wal_durable":
-		return treedb.ProfileLegacyWALDurable, "legacy_wal_durable", nil
-	case "no_wal_fast":
-		return treedb.ProfileNoWALFast, "no_wal_fast", nil
-	default:
-		return treedb.ProfileCommandWALRelaxed, "", fmt.Errorf("unsupported treedb profile %q", raw)
+	profile, ok := treedb.ParsePublicProfile(raw, treedb.ProfileCommandWALRelaxed)
+	if !ok {
+		return treedb.ProfileCommandWALRelaxed, "", fmt.Errorf("unsupported treedb profile %q; allowed: %s", raw, treedb.ProfileFlagHelp)
 	}
+	return profile, string(profile), nil
 }
 
 func maxRSSKB() int64 {

--- a/scripts/leafgen_cached_dwell_validate.sh
+++ b/scripts/leafgen_cached_dwell_validate.sh
@@ -155,7 +155,11 @@ func main() {
         fatalf("invalid -sample-interval-seconds %d", *sampleSeconds)
     }
 
-    opts := treedb.OptionsFor(treedb.Profile(*profile), *dbDir)
+    profileValue, ok := treedb.ParsePublicProfile(*profile, treedb.ProfileBench)
+    if !ok {
+        fatalf("unsupported -profile %q; allowed: %s", *profile, treedb.ProfileFlagHelp)
+    }
+    opts := treedb.OptionsFor(profileValue, *dbDir)
     if opts.ValueLog.Generational.Policy == treedb.ValueLogGenerationDefault {
         opts.ValueLog.Generational.Policy = treedb.ValueLogGenerationHotWarmCold
     }

--- a/scripts/leafgen_target_sweep.sh
+++ b/scripts/leafgen_target_sweep.sh
@@ -82,7 +82,11 @@ func main() {
         fatalf("mkdir parent: %v", err)
     }
 
-    opts := treedb.OptionsFor(treedb.Profile(*profile), *dbDir)
+    profileValue, ok := treedb.ParsePublicProfile(*profile, treedb.ProfileBench)
+    if !ok {
+        fatalf("unsupported -profile %q; allowed: %s", *profile, treedb.ProfileFlagHelp)
+    }
+    opts := treedb.OptionsFor(profileValue, *dbDir)
     opts.BackgroundCheckpointInterval = -1
     opts.BackgroundCheckpointIdleDuration = -1
     opts.MaxWALBytes = -1

--- a/scripts/mongo_gateway_compare.sh
+++ b/scripts/mongo_gateway_compare.sh
@@ -47,10 +47,10 @@ DATABASE_PREFIX="${DATABASE_PREFIX:-mongo_gateway_compare}"
 COLLECTION="${COLLECTION:-docs}"
 TIMEOUT="${TIMEOUT:-20m}"
 TITLE="${TITLE:-Mongo Gateway Benchmark Comparison}"
-# Transitional indexed benchmark baseline: default INDEXES_LIST includes
-# secondary indexes, and command WAL rejects catalog index mutation until
-# catalog index commands land.
-TREEDB_PROFILE="${TREEDB_PROFILE:-legacy_wal_relaxed_fast}"
+# Indexed benchmark baseline: default INDEXES_LIST includes secondary indexes.
+# Use command_wal_relaxed for command-WAL coverage once indexed catalog command
+# support is enabled for this workload; bench is the explicit no-WAL ceiling.
+TREEDB_PROFILE="${TREEDB_PROFILE:-bench}"
 TREEDB_DOCUMENT_FORMAT="${TREEDB_DOCUMENT_FORMAT:-template-v1}"
 TREEDB_DOCUMENT_FORMATS="${TREEDB_DOCUMENT_FORMATS:-$TREEDB_DOCUMENT_FORMAT}"
 TREEDB_CLIENT_MODE="${TREEDB_CLIENT_MODE:-driver}"
@@ -132,7 +132,7 @@ Options:
                         Space-separated MongoDB client modes. Example:
                         "driver driver-find-raw driver-command driver-command-raw driver-unack".
   --timeout DURATION    Per-run benchmark timeout. Default: 20m.
-  --treedb-profile NAME TreeDB profile. Default: legacy_wal_relaxed_fast.
+  --treedb-profile NAME TreeDB profile. Default: bench.
   --treedb-document-format FORMAT
                         Single TreeDB document format.
   --treedb-document-formats LIST

--- a/scripts/mongo_gateway_scaling_bench.sh
+++ b/scripts/mongo_gateway_scaling_bench.sh
@@ -21,10 +21,10 @@ RANGE_READS="${RANGE_READS:-0}"
 UPDATES="${UPDATES:-0}"
 DELETES="${DELETES:-0}"
 UPDATE_INDEXED_FIELD="${UPDATE_INDEXED_FIELD:-false}"
-# Transitional indexed benchmark baseline: the default shape uses secondary
-# indexes, and command WAL rejects catalog index mutation until catalog index
-# commands land.
-TREEDB_PROFILE="${TREEDB_PROFILE:-legacy_wal_relaxed_fast}"
+# Indexed benchmark baseline: the default shape uses secondary indexes. Use
+# command_wal_relaxed for command-WAL coverage once indexed catalog command
+# support is enabled for this workload; bench is the explicit no-WAL ceiling.
+TREEDB_PROFILE="${TREEDB_PROFILE:-bench}"
 TREEDB_DOCUMENT_FORMAT="${TREEDB_DOCUMENT_FORMAT:-bson}"
 TREEDB_CLIENT_MODE="${TREEDB_CLIENT_MODE:-driver-command-raw}"
 TREEDB_MAINTENANCE="${TREEDB_MAINTENANCE:-none}"
@@ -74,7 +74,7 @@ Options:
   --database-prefix NAME MongoDB database prefix. Default: mongo_gateway_scaling_<run_id>.
   --treedb-format NAME   TreeDB document format. Default: bson.
   --client-mode NAME     TreeDB client mode. Default: driver-command-raw.
-  --profile NAME         TreeDB profile. Default: legacy_wal_relaxed_fast.
+  --profile NAME         TreeDB profile. Default: bench.
   --maintenance MODE     TreeDB maintenance mode. Default: none.
   --update-indexed-field Include the city field in update phases to exercise
                          secondary-index maintenance; requires INDEXES=2.

--- a/scripts/mongo_gateway_ycsb_attribution.sh
+++ b/scripts/mongo_gateway_ycsb_attribution.sh
@@ -24,10 +24,10 @@ CLIENT_MODES="${CLIENT_MODES:-driver raw-wire-tcp native-wire-tcp direct}"
 DATABASE_PREFIX="${DATABASE_PREFIX:-ycsb_attr}"
 COLLECTION="${COLLECTION:-usertable}"
 TIMEOUT="${TIMEOUT:-10m}"
-# Transitional mixed-shape benchmark baseline: gateway-shape runs include
-# secondary indexes, and command WAL rejects catalog index mutation until
-# catalog index commands land.
-TREEDB_PROFILE="${TREEDB_PROFILE:-legacy_wal_relaxed_fast}"
+# Mixed-shape benchmark baseline: gateway-shape runs include secondary indexes.
+# Use command_wal_relaxed for command-WAL coverage once indexed catalog command
+# support is enabled for this workload; bench is the explicit no-WAL ceiling.
+TREEDB_PROFILE="${TREEDB_PROFILE:-bench}"
 TREEDB_DOCUMENT_FORMAT="${TREEDB_DOCUMENT_FORMAT:-bson}"
 TREEDB_MAINTENANCE="${TREEDB_MAINTENANCE:-none}"
 TREEDB_READ_STATE="${TREEDB_READ_STATE:-unsettled}"

--- a/scripts/run_application_db_engine_matrix.sh
+++ b/scripts/run_application_db_engine_matrix.sh
@@ -538,26 +538,11 @@ func runCompactTreeDB(args []string) {
 }
 
 func parseTreeDBProfile(raw string) (treedb.Profile, string, error) {
-	switch strings.ToLower(strings.TrimSpace(raw)) {
-	case "command_wal_relaxed", "command-wal-relaxed", "":
-		return treedb.ProfileCommandWALRelaxed, "command_wal_relaxed", nil
-	case "command_wal_durable", "command-wal-durable":
-		return treedb.ProfileCommandWALDurable, "command_wal_durable", nil
-	case "bench":
-		return treedb.ProfileBench, "bench", nil
-	case "fast":
-		return treedb.ProfileFast, "fast", nil
-	case "wal_on_fast", "walonfast":
-		return treedb.ProfileWALOnFast, "wal_on_fast", nil
-	case "legacy_wal_relaxed_fast":
-		return treedb.ProfileLegacyWALRelaxedFast, "legacy_wal_relaxed_fast", nil
-	case "legacy_wal_durable":
-		return treedb.ProfileLegacyWALDurable, "legacy_wal_durable", nil
-	case "no_wal_fast":
-		return treedb.ProfileNoWALFast, "no_wal_fast", nil
-	default:
-		return treedb.ProfileCommandWALRelaxed, "", fmt.Errorf("unsupported treedb profile %q", raw)
+	profile, ok := treedb.ParsePublicProfile(raw, treedb.ProfileCommandWALRelaxed)
+	if !ok {
+		return treedb.ProfileCommandWALRelaxed, "", fmt.Errorf("unsupported treedb profile %q; allowed: %s", raw, treedb.ProfileFlagHelp)
 	}
+	return profile, string(profile), nil
 }
 
 func maxRSSKB() int64 {

--- a/scripts/treedb_collection_compression_matrix.sh
+++ b/scripts/treedb_collection_compression_matrix.sh
@@ -39,7 +39,7 @@ func main() {
 	docs := flag.Int("docs", 100000, "documents to write")
 	batchSize := flag.Int("batch-size", 16000, "documents per batch")
 	reset := flag.Bool("reset", false, "remove directory before loading")
-	profile := flag.String("profile", "bench", "TreeDB profile: command_wal_relaxed, command_wal_durable, bench, or a legacy compatibility profile")
+	profile := flag.String("profile", "bench", "TreeDB profile: command_wal_durable, command_wal_relaxed, or bench")
 	flag.Parse()
 
 	if *dir == "" {
@@ -125,29 +125,11 @@ func main() {
 }
 
 func parseProfile(raw string) treedb.Profile {
-	switch raw {
-	case "", "bench":
-		return treedb.ProfileBench
-	case "command_wal_relaxed", "command-wal-relaxed":
-		return treedb.ProfileCommandWALRelaxed
-	case "command_wal_durable", "command-wal-durable":
-		return treedb.ProfileCommandWALDurable
-	case "fast":
-		return treedb.ProfileFast
-	case "wal_on_fast":
-		return treedb.ProfileWALOnFast
-	case "durable":
-		return treedb.ProfileDurable
-	case "legacy_wal_relaxed_fast":
-		return treedb.ProfileLegacyWALRelaxedFast
-	case "legacy_wal_durable":
-		return treedb.ProfileLegacyWALDurable
-	case "no_wal_fast":
-		return treedb.ProfileNoWALFast
-	default:
-		fatalf("unsupported -profile %q", raw)
-		return ""
+	profile, ok := treedb.ParsePublicProfile(raw, treedb.ProfileBench)
+	if !ok {
+		fatalf("unsupported -profile %q; allowed: %s", raw, treedb.ProfileFlagHelp)
 	}
+	return profile
 }
 
 func fatalf(format string, args ...any) {


### PR DESCRIPTION
Fixes #2147.
Refs #2145 and stacked on #2153.

## Summary

- Adds `treedb.ParsePublicProfile` / `NormalizePublicProfile` for the intended public profile vocabulary: `command_wal_durable`, `command_wal_relaxed`, and `bench`.
- Switches public profile-string boundaries to strict parsing: native server, Mongo gateway standalone/server, kvstore adapter env parsing, benchmark/demo command parsers, and scripts with embedded Go parsers.
- Makes rejected deprecated names fail loudly with the allowed profile set instead of flowing into `OptionsFor` / `ApplyProfile`.
- Updates benchmark-only defaults that were still `no_wal_fast` / legacy to public `bench` where command WAL is not the default path.

## Start-Phase Entry Point Plan

Strict now:

- `cmd/treedb-native-server -profile`
- `TreeDB/mongo_gateway` standalone options and ignored CLI server parser
- `TreeDB/integration/kvstoreadapter` `TREEDB_OPEN_PROFILE`
- `cmd/collection_workload_bench -treedb-profile`
- `cmd/mongo_gateway_bench -treedb-profile`
- `cmd/treedb_vector_search_demo -profile`
- application-db rebuild/matrix scripts, collection compression matrix generated loader, leafgen generated Go helpers

Transitional carve-out:

- `cmd/collection_load_fixture` and `cmd/treedb_out_of_core_smoke` still accept legacy collection benchmark engine aliases such as `production_fast` / `production_wal_on_fast`; #2148 owns migrating those engine labels. Exact deprecated profile names (`fast`, `wal_on_fast`, `durable`, `legacy_wal_*`, `no_wal_fast`) are rejected.
- `cmd/unified_bench -profile fast|wal_on_fast|durable|balanced` remains cross-DB benchmark preset vocabulary documented by #2153, not TreeDB server profile vocabulary.
- Low-level `treedb.ParseProfile`, `NormalizeProfile`, `OptionsFor`, and old profile constants remain for internal tests and explicit low-level option construction.

## Close-Phase Evidence

Local tests run on `c71d17aa3`:

- `gofmt -w TreeDB/profiles.go TreeDB/profiles_test.go cmd/treedb-native-server/main.go cmd/treedb-native-server/main_test.go TreeDB/mongo_gateway/server.go TreeDB/mongo_gateway/standalone.go TreeDB/mongo_gateway/standalone_test.go TreeDB/integration/kvstoreadapter/open.go TreeDB/integration/kvstoreadapter/open_test.go cmd/collection_workload_bench/main.go cmd/collection_workload_bench/main_test.go cmd/collection_load_fixture/main.go cmd/collection_load_fixture/main_test.go cmd/treedb_out_of_core_smoke/main.go cmd/treedb_out_of_core_smoke/main_test.go cmd/treedb_vector_search_demo/main.go cmd/treedb_vector_search_demo/main_test.go cmd/mongo_gateway_bench/main.go cmd/mongo_gateway_bench/main_test.go`
- `bash -n scripts/compare_application_db_rebuilds.sh scripts/run_application_db_engine_matrix.sh scripts/treedb_collection_compression_matrix.sh scripts/leafgen_cached_dwell_validate.sh scripts/leafgen_target_sweep.sh`
- `git diff --check`
- `go test ./TreeDB -run 'ParsePublicProfile|ParseProfile|Profile' -count=1`
- `go test ./TreeDB -count=1`
- `go test ./cmd/treedb-native-server -count=1`
- `go test ./TreeDB/mongo_gateway -count=1`
- `go test ./TreeDB/integration/kvstoreadapter -count=1`
- `go test ./cmd/collection_workload_bench ./cmd/collection_load_fixture ./cmd/treedb_out_of_core_smoke ./cmd/treedb_vector_search_demo -count=1`
- `go test ./cmd/mongo_gateway_bench -count=1`

Representative rejection behavior covered by tests:

- `fast`, `wal_on_fast`, `durable`, `legacy_wal_durable`, `legacy_wal_relaxed_fast`, and `no_wal_fast` are rejected at public profile parsers with the allowed set from `ProfileFlagHelp`.
- `TREEDB_OPEN_PROFILE=fast` now returns an explicit invalid-profile error instead of silently falling back.
