### PR TITLE
docs: canonicalize YCSB benchmark reports

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -45,7 +45,7 @@ Behavioral guarantees for downstream systems (e.g., replication layers).
 
 - **[Benchmark Spec](BENCHMARK_SPEC.md)**: Methodology and test definitions.
 - **[TreeDB Canonical Benchmark Runbook](benchmarks/treedb_canonical_benchmark_runbook.md)**: Standard TreeDB engine, collections, Mongo gateway, profiling, and reporting workflows.
-- **[YCSB MongoDB / TreeDB Report](benchmarks/ycsb_mongodb_treedb_2026-05-31.md)**: Exact `go-ycsb` comparison for MongoDB, `treedb-native`, and TreeDB Mongo gateway.
+- **[YCSB MongoDB / TreeDB Status](benchmarks/ycsb_mongodb_treedb_current.md)**: Current report index and rerun plan for MongoDB, `treedb-native`, and TreeDB Mongo gateway.
 - **[TreeDB Collections Canonical Benchmark](benchmarks/collections_canonical_benchmark.md)**: Canonical TreeDB-vs-SQLite collection benchmark and maintenance-phase semantics.
 - **[Unified Bench](../cmd/unified_bench/README.md)**: Usage guide for benchmark execution and artifact capture.
 - **[BenchProf](../cmd/benchprof/README.md)**: Analysis tool for CPU/alloc/block/mutex profiles and ops/sec outputs.

--- a/docs/TREEDB_BENCHMARKING.md
+++ b/docs/TREEDB_BENCHMARKING.md
@@ -9,7 +9,7 @@ trace-based replays that approximate Celestia workloads.
 - **Trace summary replay:** `BenchmarkTraceReplay`
 - **Trace timeline replay (overlap-aware):** `BenchmarkTraceReplayTimeline`
 - **Memtable mode matrices:** `BenchmarkTraceReplayMemtableModes`, `BenchmarkTraceReplayTimelineMemtableModes`
-- **External YCSB comparison:** `scripts/ycsb_compare_mongodb_treedb.sh`, with the current report in `docs/benchmarks/ycsb_mongodb_treedb_2026-05-31.md`
+- **External YCSB comparison:** `scripts/ycsb_compare_mongodb_treedb.sh`, with the current report index in `docs/benchmarks/ycsb_mongodb_treedb_current.md`
 
 ## Common Principles
 
@@ -38,8 +38,10 @@ default. For exploratory parsing of known-bad artifacts, set
 Use `PARSE_ONLY=true OUT_DIR=/path/to/run` to regenerate summaries from saved
 raw `*.out` files without rerunning servers.
 
-The current captured report is
-`docs/benchmarks/ycsb_mongodb_treedb_2026-05-31.md`.
+The current report index is
+`docs/benchmarks/ycsb_mongodb_treedb_current.md`. It points at the latest
+checked-in command-WAL profile evidence, labels older reports as historical or
+superseded, and records the next full rerun matrix.
 
 ## 1) Unified Bench (Synthetic)
 

--- a/docs/benchmarks/mongo_gateway_compare_2026-04-29/README.md
+++ b/docs/benchmarks/mongo_gateway_compare_2026-04-29/README.md
@@ -1,5 +1,10 @@
 # Mongo Gateway Comparison Artifact
 
+Status: historical non-YCSB gateway microbenchmark. This bundle is useful for
+Mongo-gateway attribution, but it is not a substitute for the external
+MongoDB / TreeDB / TreeDB Mongo YCSB matrix. Use
+`../ycsb_mongodb_treedb_current.md` for the current YCSB report index.
+
 This directory is the first checked-in TreeDB Mongo gateway vs MongoDB
 comparison bundle.
 

--- a/docs/benchmarks/ycsb_mongodb_treedb_2026-05-31.md
+++ b/docs/benchmarks/ycsb_mongodb_treedb_2026-05-31.md
@@ -1,5 +1,12 @@
 # YCSB MongoDB, TreeDB Native, and TreeDB Mongo Report
 
+Status: historical. This report used the legacy `fast` TreeDB profile and
+predates the command-WAL public-profile closeout plus PR #2164's command-WAL
+frame hashing change. Keep it as artifact-backed evidence for the original
+MongoDB / TreeDB comparison and post-load Mongo-gateway cliff attribution, but
+use `docs/benchmarks/ycsb_mongodb_treedb_current.md` for current report status
+and rerun guidance.
+
 This report captures the external `go-ycsb` workload used during the Mongo
 gateway throughput investigation. It compares:
 

--- a/docs/benchmarks/ycsb_mongodb_treedb_current.md
+++ b/docs/benchmarks/ycsb_mongodb_treedb_current.md
@@ -30,7 +30,7 @@ numbers without a rerun on the new command-WAL frame format. The no-WAL `bench`
 rows are less directly affected, but should still be rerun in the same matrix as
 a same-host ceiling/control.
 
-## Historical Reports
+## Report Inventory
 
 | report | status | use |
 | --- | --- | --- |

--- a/docs/benchmarks/ycsb_mongodb_treedb_current.md
+++ b/docs/benchmarks/ycsb_mongodb_treedb_current.md
@@ -1,0 +1,174 @@
+# YCSB MongoDB / TreeDB Benchmark Status
+
+This page is the current entry point for external `go-ycsb` comparisons across:
+
+- MongoDB through the `go-ycsb mongodb` binding.
+- `treedb-native` through the `go-ycsb treedb-native` binding.
+- TreeDB Mongo gateway through the `go-ycsb mongodb` binding.
+
+It explains which checked-in reports are current, which are historical, and
+which cells should be rerun next.
+
+## Current Canonical Report
+
+Use `docs/benchmarks/ycsb_profile_closeout_2026-06-01.md` as the current
+checked-in command-WAL profile evidence until a fresh post-#2164 rerun lands.
+
+That closeout report covers the intended public TreeDB profile surface:
+
+- `command_wal_durable`
+- `command_wal_relaxed`
+- `bench`, as the explicit no-WAL benchmark-only ceiling
+
+It also records zero YCSB operation errors and separates the repeated `bench`
+ceiling run from an initial slow no-WAL Mongo-gateway run that did not reproduce.
+
+Important freshness note: PR #2164 removed mandatory command-WAL payload
+SHA-256 hashing. Command-WAL throughput numbers collected before that PR remain
+valid historical evidence, but should not be used as final current headline
+numbers without a rerun on the new command-WAL frame format. The no-WAL `bench`
+rows are less directly affected, but should still be rerun in the same matrix as
+a same-host ceiling/control.
+
+## Historical Reports
+
+| report | status | use |
+| --- | --- | --- |
+| `docs/benchmarks/ycsb_mongodb_treedb_2026-05-31.md` | Historical legacy-profile report. | Keep for the original MongoDB / TreeDB native / TreeDB Mongo comparison and the post-load Mongo-gateway cliff attribution. Do not use its `fast` rows as current public-profile guidance. |
+| `docs/benchmarks/ycsb_treedb_profile_sweep_2026-06-01.md` | Superseded initial command-WAL sweep. | Keep as prior-run evidence. Prefer the closeout report for profile-surface conclusions. |
+| `docs/benchmarks/ycsb_profile_closeout_2026-06-01.md` | Current checked-in command-WAL/public-profile report until post-#2164 rerun. | Use for current docs and profile-surface discussion, with the #2164 freshness caveat above. |
+| `docs/benchmarks/mongo_gateway_compare_2026-04-29/` | Historical non-YCSB Mongo-gateway microbenchmark. | Useful for gateway-specific attribution, but not a substitute for external YCSB comparisons. |
+
+## Standard Benchmark Boundary
+
+Use this workload unless a report explicitly says otherwise:
+
+- `recordcount=100000`
+- `operationcount=10000`
+- `threadcount=16`
+- `table=usertable`
+- load phase: 100,000 inserts
+- run phase: 10,000 operations, roughly 95% reads and 5% updates
+- local loopback TCP
+
+The standard harness is:
+
+```sh
+scripts/ycsb_compare_mongodb_treedb.sh
+```
+
+The harness writes host metadata, exact commands, raw `go-ycsb` output,
+`summary.tsv`, `summary.md`, server logs, and fresh DB directories under
+`OUT_DIR`.
+
+Any nonzero YCSB operation error counter such as `INSERT_ERROR`, `READ_ERROR`,
+or `UPDATE_ERROR` invalidates that phase unless the report explicitly marks it
+as exploratory known-bad evidence.
+
+## Next Full Rerun Matrix
+
+Run this matrix to replace the current pre-#2164 command-WAL numbers with fresh
+headline evidence.
+
+### Baseline And Durable Cell
+
+For a formal fresh report, run the first cell with `RUN_REPEATS=3`. That repeats
+the YCSB run phase for MongoDB, TreeDB nativewire, and TreeDB Mongo gateway
+after each target's load phase, which is useful for separating first-run and
+repeat behavior:
+
+```sh
+RUN_ROOT=/tmp/treedb_ycsb_post2164_$(date +%Y%m%d_%H%M%S)
+mkdir -p "$RUN_ROOT"
+
+OUT_DIR="$RUN_ROOT/command_wal_durable" \
+TREEDB_PROFILE=command_wal_durable \
+MONGODB_MODE=docker \
+MONGODB_ADDR=127.0.0.1:27018 \
+NATIVE_ADDR=127.0.0.1:17130 \
+TREEDB_MONGO_ADDR=127.0.0.1:27130 \
+TREEDB_MONGO_DOCUMENT_FORMAT=bson \
+RUN_REPEATS=3 \
+BUILD=true \
+BUILD_GOYCSB=false \
+scripts/ycsb_compare_mongodb_treedb.sh
+```
+
+For a cheaper informal sweep, set `RUN_REPEATS=1` in this first command and use
+the resulting MongoDB row as the once-per-matrix baseline. Then run the durable
+TreeDB cell again with `MONGODB_MODE=skip RUN_REPEATS=3` if repeated durable
+TreeDB rows are needed.
+
+### Remaining TreeDB Profiles
+
+Reuse the MongoDB baseline from the first cell and run the other TreeDB profile
+cells:
+
+```sh
+OUT_DIR="$RUN_ROOT/command_wal_relaxed" \
+TREEDB_PROFILE=command_wal_relaxed \
+MONGODB_MODE=skip \
+NATIVE_ADDR=127.0.0.1:17131 \
+TREEDB_MONGO_ADDR=127.0.0.1:27131 \
+TREEDB_MONGO_DOCUMENT_FORMAT=bson \
+RUN_REPEATS=3 \
+BUILD=false \
+BUILD_GOYCSB=false \
+scripts/ycsb_compare_mongodb_treedb.sh
+
+OUT_DIR="$RUN_ROOT/bench" \
+TREEDB_PROFILE=bench \
+MONGODB_MODE=skip \
+NATIVE_ADDR=127.0.0.1:17132 \
+TREEDB_MONGO_ADDR=127.0.0.1:27132 \
+TREEDB_MONGO_DOCUMENT_FORMAT=bson \
+RUN_REPEATS=3 \
+BUILD=false \
+BUILD_GOYCSB=false \
+scripts/ycsb_compare_mongodb_treedb.sh
+```
+
+Use `RUN_REPEATS=3` for TreeDB cells so reports can separate first-run-after-load
+behavior from repeat or median behavior. `RUN_REPEATS` repeats the run phase on
+the same loaded DB/server; it does not rebuild a fresh DB for each repeat.
+
+## Optional Long Diagnostic Run
+
+If command-WAL tail latency or first-run-after-load behavior looks suspicious,
+add a longer durable-profile run:
+
+```sh
+OUT_DIR="$RUN_ROOT/command_wal_durable_100k_run" \
+TREEDB_PROFILE=command_wal_durable \
+MONGODB_MODE=skip \
+NATIVE_ADDR=127.0.0.1:17133 \
+TREEDB_MONGO_ADDR=127.0.0.1:27133 \
+TREEDB_MONGO_DOCUMENT_FORMAT=bson \
+OPERATIONCOUNT=100000 \
+RUN_REPEATS=1 \
+BUILD=false \
+BUILD_GOYCSB=false \
+scripts/ycsb_compare_mongodb_treedb.sh
+```
+
+Use that long run for profiling and tail attribution, not as a replacement for
+the standard 10k-operation headline matrix.
+
+## Report Requirements
+
+Fresh reports should include:
+
+- exact commands;
+- host and hardware context;
+- gomap commit and go-ycsb commit;
+- MongoDB image and digest;
+- TreeDB profile and document format;
+- load and run ops/sec;
+- average, p95, p99, and max latency;
+- all YCSB `*_ERROR` counters;
+- first-run versus repeat or median behavior;
+- artifact directories.
+
+Do not mix old `fast` profile rows into current public-profile headline tables.
+If a historical row is useful for context, label it as historical and explain
+which commit/profile produced it.

--- a/docs/benchmarks/ycsb_profile_closeout_2026-06-01.md
+++ b/docs/benchmarks/ycsb_profile_closeout_2026-06-01.md
@@ -1,5 +1,13 @@
 # TreeDB YCSB Profile Closeout: Command WAL Public Surface
 
+Status: current checked-in command-WAL/public-profile evidence until a fresh
+post-#2164 YCSB rerun lands. PR #2164 removed mandatory command-WAL payload
+SHA-256 hashing, so these pre-#2164 command-WAL throughput numbers remain
+historical evidence and should be refreshed before they are used as final
+current headline performance. See
+`docs/benchmarks/ycsb_mongodb_treedb_current.md` for the report index and rerun
+matrix.
+
 This report is the closeout evidence for the TreeDB profile-surface sprint. It
 checks the intended public profiles:
 

--- a/docs/benchmarks/ycsb_treedb_profile_sweep_2026-06-01.md
+++ b/docs/benchmarks/ycsb_treedb_profile_sweep_2026-06-01.md
@@ -1,5 +1,11 @@
 # YCSB TreeDB Profile Sweep: Command WAL vs No-WAL Benchmark
 
+Status: superseded. This initial single-run profile sweep is retained as
+prior-run evidence, but `docs/benchmarks/ycsb_profile_closeout_2026-06-01.md`
+is the preferred checked-in command-WAL profile report until a post-#2164 rerun
+lands. Use `docs/benchmarks/ycsb_mongodb_treedb_current.md` for the current
+report index and rerun matrix.
+
 This report captures an external `go-ycsb` profile sweep over the current
 TreeDB collection entry points:
 


### PR DESCRIPTION
Closes #2167.

## Summary

- Add `docs/benchmarks/ycsb_mongodb_treedb_current.md` as the current entry point for MongoDB / TreeDB / TreeDB Mongo YCSB report status.
- Mark the May 31 `fast` profile report as historical, the initial June 1 profile sweep as superseded, and the June 1 closeout as the current checked-in command-WAL evidence until a post-#2164 rerun lands.
- Update top-level benchmark docs to point at the new status page and label the older Mongo gateway comparison bundle as non-YCSB historical evidence.

## Current Canonical Report Decision

The current checked-in report remains `docs/benchmarks/ycsb_profile_closeout_2026-06-01.md`, with an explicit caveat that command-WAL throughput numbers predate PR #2164's command-WAL frame hashing change and need a fresh rerun before being used as final current headline performance.

## Rerun Matrix And Non-Goals

The new status page documents the next full rerun matrix:

- MongoDB baseline through `go-ycsb mongodb`.
- TreeDB nativewire and TreeDB Mongo gateway across `command_wal_durable`, `command_wal_relaxed`, and `bench`.
- `recordcount=100000`, `operationcount=10000`, `threadcount=16`.
- BSON documents for TreeDB Mongo gateway.
- `RUN_REPEATS=3` for formal fresh evidence, with the script's same-loaded-DB repeat semantics called out.

This PR is docs-only and does not claim fresh benchmark numbers.

## Validation

- `git diff --check`
- `rg -n "current captured report|with the current report in|YCSB MongoDB / TreeDB Report|ycsb_mongodb_treedb_2026-05-31.md" docs/README.md docs/TREEDB_BENCHMARKING.md docs/benchmarks/ycsb_mongodb_treedb_current.md docs/benchmarks/ycsb_*.md`
- `rg -n "docs/benchmarks/ycsb_mongodb_treedb_current.md|benchmarks/ycsb_mongodb_treedb_current.md|../ycsb_mongodb_treedb_current.md" docs`
- `go test ./TreeDB/docs -count=1`

## CI And Review Status

- Latest head: `812722c6e0cf9a162f4143b4a8f1a49801c25c5b`.
- GitHub Actions: all latest-head checks passed.
- Copilot: one docs clarity thread about the report inventory heading; fixed by renaming the section to `Report Inventory`, replied, and resolved.
- CodeRabbit: completed, no unresolved actionable findings.
- Codex graph subagent dispatch was attempted, but the local agent thread limit was reached; the coordinator executed the single-node graph locally.
