### PR TITLE
Add projection-oriented vector document fetch preset

### DIFF
--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -418,6 +418,7 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/typed_storage_naming_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 9, occurrences: 9},
 	{path: "TreeDB/collections/vector_index.go", classification: typedStorageLegacyDerived, matchingLines: 1, occurrences: 1},
 	{path: "TreeDB/collections/vector_index_metadata_test.go", classification: typedStorageLegacyDerived, matchingLines: 9, occurrences: 11},
+	{path: "TreeDB/collections/vector_document_fetch_preset_1903_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 4, occurrences: 5},
 	{path: "TreeDB/collections/vector_index_retained_payload_policy_1876_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 5, occurrences: 5},
 	{path: "TreeDB/collections/vector_index_search_test.go", classification: typedStorageLegacyDerived, matchingLines: 2, occurrences: 2},
 	{path: "TreeDB/collections/vector_index_rebuild.go", classification: typedStorageLegacyDerived, matchingLines: 16, occurrences: 18},

--- a/TreeDB/collections/vector_document_fetch_preset.go
+++ b/TreeDB/collections/vector_document_fetch_preset.go
@@ -92,6 +92,9 @@ func cloneDocumentFetchOptions(opts DocumentFetchOptions) DocumentFetchOptions {
 	return out
 }
 
+// mergeDocumentFetchOptionsPreset applies preset projection paths to existing
+// fetch options while preserving existing scalar settings unless the preset
+// explicitly overrides them.
 func mergeDocumentFetchOptionsPreset(existing, preset DocumentFetchOptions) DocumentFetchOptions {
 	out := cloneDocumentFetchOptions(existing)
 	out.IncludePaths = append([]string(nil), preset.IncludePaths...)

--- a/TreeDB/collections/vector_document_fetch_preset.go
+++ b/TreeDB/collections/vector_document_fetch_preset.go
@@ -57,25 +57,27 @@ func ProjectionOrientedVectorDocumentFetchPresetForField(vectorField string) (Ve
 }
 
 // ApplyToSearchOptions applies p to collection-level SearchVectorIndex options.
-// It replaces opts.DocumentFetchOptions; callers that need custom fetch options
-// should apply the preset first, then set their overrides.
+// It enables IncludeDocuments, replaces projection paths from
+// opts.DocumentFetchOptions, and preserves existing scalar fetch settings unless
+// the preset explicitly overrides them.
 func (p VectorDocumentFetchPreset) ApplyToSearchOptions(opts *VectorIndexSearchOptions) {
 	if opts == nil {
 		return
 	}
 	opts.IncludeDocuments = p.IncludeDocuments
-	opts.DocumentFetchOptions = cloneDocumentFetchOptions(p.DocumentFetchOptions)
+	opts.DocumentFetchOptions = mergeDocumentFetchOptionsPreset(opts.DocumentFetchOptions, p.DocumentFetchOptions)
 }
 
 // ApplyToSearcherSearchOptions applies p to reusable VectorIndexSearcher.Search
-// options. It replaces opts.DocumentFetchOptions; callers that need custom fetch
-// options should apply the preset first, then set their overrides.
+// options. It enables IncludeDocuments, replaces projection paths from
+// opts.DocumentFetchOptions, and preserves existing scalar fetch settings unless
+// the preset explicitly overrides them.
 func (p VectorDocumentFetchPreset) ApplyToSearcherSearchOptions(opts *VectorIndexSearcherSearchOptions) {
 	if opts == nil {
 		return
 	}
 	opts.IncludeDocuments = p.IncludeDocuments
-	opts.DocumentFetchOptions = cloneDocumentFetchOptions(p.DocumentFetchOptions)
+	opts.DocumentFetchOptions = mergeDocumentFetchOptionsPreset(opts.DocumentFetchOptions, p.DocumentFetchOptions)
 }
 
 // cloneDocumentFetchOptions returns a shallow copy of opts with independent
@@ -87,5 +89,18 @@ func cloneDocumentFetchOptions(opts DocumentFetchOptions) DocumentFetchOptions {
 	out := opts
 	out.IncludePaths = append([]string(nil), opts.IncludePaths...)
 	out.ExcludePaths = append([]string(nil), opts.ExcludePaths...)
+	return out
+}
+
+func mergeDocumentFetchOptionsPreset(existing, preset DocumentFetchOptions) DocumentFetchOptions {
+	out := cloneDocumentFetchOptions(existing)
+	out.IncludePaths = append([]string(nil), preset.IncludePaths...)
+	out.ExcludePaths = append([]string(nil), preset.ExcludePaths...)
+	if preset.Format != "" {
+		out.Format = preset.Format
+	}
+	if preset.ColumnAssetReadIntegrity != "" {
+		out.ColumnAssetReadIntegrity = preset.ColumnAssetReadIntegrity
+	}
 	return out
 }

--- a/TreeDB/collections/vector_document_fetch_preset.go
+++ b/TreeDB/collections/vector_document_fetch_preset.go
@@ -21,7 +21,10 @@ type VectorDocumentFetchPreset struct {
 	// projection-oriented preset sets this to true because projection is only
 	// meaningful when callers request final documents.
 	IncludeDocuments bool
-	// DocumentFetchOptions should be copied to vector search options.
+	// DocumentFetchOptions should be copied to vector search options. ApplyTo*
+	// always replaces IncludePaths/ExcludePaths from the target options. Scalar
+	// fields use merge semantics: zero-valued preset scalars preserve the target
+	// option's existing value, and non-zero preset scalars override it.
 	DocumentFetchOptions DocumentFetchOptions
 }
 
@@ -93,8 +96,8 @@ func cloneDocumentFetchOptions(opts DocumentFetchOptions) DocumentFetchOptions {
 }
 
 // mergeDocumentFetchOptionsPreset applies preset projection paths to existing
-// fetch options while preserving existing scalar settings unless the preset
-// explicitly overrides them.
+// fetch options while preserving existing scalar settings when the preset uses
+// their zero value. Non-zero preset scalar fields override the existing value.
 func mergeDocumentFetchOptionsPreset(existing, preset DocumentFetchOptions) DocumentFetchOptions {
 	out := cloneDocumentFetchOptions(existing)
 	out.IncludePaths = append([]string(nil), preset.IncludePaths...)

--- a/TreeDB/collections/vector_document_fetch_preset.go
+++ b/TreeDB/collections/vector_document_fetch_preset.go
@@ -1,0 +1,83 @@
+package collections
+
+import (
+	"fmt"
+	"strings"
+)
+
+// VectorDocumentFetchPreset is a named, opt-in final-document fetch preset for
+// vector search APIs. Apply it to VectorIndexSearchOptions or
+// VectorIndexSearcherSearchOptions when a vector search response should include
+// top-k documents while omitting the vector payload field from those documents.
+//
+// The projection-oriented preset is the storage-efficient product path for
+// vector-heavy document responses: use ColumnRetainedPayloadNonColumn at storage
+// setup time, then use this preset at search time to fetch documents with the
+// vector field excluded from the final response. The preset is deliberately
+// opt-in; zero-valued search options and IncludeDocuments=true without this
+// preset continue to return full documents.
+type VectorDocumentFetchPreset struct {
+	// IncludeDocuments should be copied to vector search options. The
+	// projection-oriented preset sets this to true because projection is only
+	// meaningful when callers request final documents.
+	IncludeDocuments bool
+	// DocumentFetchOptions should be copied to vector search options.
+	DocumentFetchOptions DocumentFetchOptions
+}
+
+// ProjectionOrientedVectorDocumentFetchPreset returns the preferred vector
+// final-document fetch preset for the field declared by def.Field. It excludes
+// that vector field from materialized JSON documents and sets IncludeDocuments
+// for the target vector search options.
+//
+// Current DocumentFetchOptions projection supports top-level JSON fields only;
+// nested vector fields fail closed with a clear error instead of silently
+// projecting a broader document shape.
+func ProjectionOrientedVectorDocumentFetchPreset(def VectorIndexDefinition) (VectorDocumentFetchPreset, error) {
+	return ProjectionOrientedVectorDocumentFetchPresetForField(def.Field)
+}
+
+// ProjectionOrientedVectorDocumentFetchPresetForField returns the preferred
+// vector final-document fetch preset for a custom vector field path. The field
+// path must be a supported top-level JSON projection path.
+func ProjectionOrientedVectorDocumentFetchPresetForField(vectorField string) (VectorDocumentFetchPreset, error) {
+	field := strings.TrimSpace(vectorField)
+	if field != vectorField {
+		return VectorDocumentFetchPreset{}, fmt.Errorf("collections: projection-oriented vector document fetch field %q has leading or trailing spaces", vectorField)
+	}
+	if err := validateDocumentProjectionPath(field); err != nil {
+		return VectorDocumentFetchPreset{}, fmt.Errorf("collections: projection-oriented vector document fetch field %q: %w", vectorField, err)
+	}
+	return VectorDocumentFetchPreset{
+		IncludeDocuments: true,
+		DocumentFetchOptions: DocumentFetchOptions{
+			ExcludePaths: []string{field},
+		},
+	}, nil
+}
+
+// ApplyToSearchOptions applies p to collection-level SearchVectorIndex options.
+func (p VectorDocumentFetchPreset) ApplyToSearchOptions(opts *VectorIndexSearchOptions) {
+	if opts == nil {
+		return
+	}
+	opts.IncludeDocuments = p.IncludeDocuments
+	opts.DocumentFetchOptions = cloneDocumentFetchOptions(p.DocumentFetchOptions)
+}
+
+// ApplyToSearcherSearchOptions applies p to reusable VectorIndexSearcher.Search
+// options.
+func (p VectorDocumentFetchPreset) ApplyToSearcherSearchOptions(opts *VectorIndexSearcherSearchOptions) {
+	if opts == nil {
+		return
+	}
+	opts.IncludeDocuments = p.IncludeDocuments
+	opts.DocumentFetchOptions = cloneDocumentFetchOptions(p.DocumentFetchOptions)
+}
+
+func cloneDocumentFetchOptions(opts DocumentFetchOptions) DocumentFetchOptions {
+	out := opts
+	out.IncludePaths = append([]string(nil), opts.IncludePaths...)
+	out.ExcludePaths = append([]string(nil), opts.ExcludePaths...)
+	return out
+}

--- a/TreeDB/collections/vector_document_fetch_preset.go
+++ b/TreeDB/collections/vector_document_fetch_preset.go
@@ -57,6 +57,8 @@ func ProjectionOrientedVectorDocumentFetchPresetForField(vectorField string) (Ve
 }
 
 // ApplyToSearchOptions applies p to collection-level SearchVectorIndex options.
+// It replaces opts.DocumentFetchOptions; callers that need custom fetch options
+// should apply the preset first, then set their overrides.
 func (p VectorDocumentFetchPreset) ApplyToSearchOptions(opts *VectorIndexSearchOptions) {
 	if opts == nil {
 		return
@@ -66,7 +68,8 @@ func (p VectorDocumentFetchPreset) ApplyToSearchOptions(opts *VectorIndexSearchO
 }
 
 // ApplyToSearcherSearchOptions applies p to reusable VectorIndexSearcher.Search
-// options.
+// options. It replaces opts.DocumentFetchOptions; callers that need custom fetch
+// options should apply the preset first, then set their overrides.
 func (p VectorDocumentFetchPreset) ApplyToSearcherSearchOptions(opts *VectorIndexSearcherSearchOptions) {
 	if opts == nil {
 		return
@@ -75,6 +78,11 @@ func (p VectorDocumentFetchPreset) ApplyToSearcherSearchOptions(opts *VectorInde
 	opts.DocumentFetchOptions = cloneDocumentFetchOptions(p.DocumentFetchOptions)
 }
 
+// cloneDocumentFetchOptions returns a shallow copy of opts with independent
+// slice backing arrays for IncludePaths and ExcludePaths.
+//
+// MAINTENANCE: update this function whenever DocumentFetchOptions gains new
+// reference-typed slice, map, or pointer fields.
 func cloneDocumentFetchOptions(opts DocumentFetchOptions) DocumentFetchOptions {
 	out := opts
 	out.IncludePaths = append([]string(nil), opts.IncludePaths...)

--- a/TreeDB/collections/vector_document_fetch_preset_1903_test.go
+++ b/TreeDB/collections/vector_document_fetch_preset_1903_test.go
@@ -1,0 +1,217 @@
+package collections
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+)
+
+func TestProjectionOrientedVectorDocumentFetchPresetOutput1903(t *testing.T) {
+	preset, err := ProjectionOrientedVectorDocumentFetchPreset(VectorIndexDefinition{Field: "embedding"})
+	if err != nil {
+		t.Fatalf("ProjectionOrientedVectorDocumentFetchPreset: %v", err)
+	}
+	if !preset.IncludeDocuments {
+		t.Fatalf("IncludeDocuments=false want true")
+	}
+	if got, want := preset.DocumentFetchOptions.ExcludePaths, []string{"embedding"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("ExcludePaths=%v want %v", got, want)
+	}
+	if len(preset.DocumentFetchOptions.IncludePaths) != 0 || preset.DocumentFetchOptions.Format != "" || preset.DocumentFetchOptions.ColumnAssetReadIntegrity != "" {
+		t.Fatalf("unexpected fetch options: %+v", preset.DocumentFetchOptions)
+	}
+
+	searchOpts := VectorIndexSearchOptions{
+		IncludeDocuments:     false,
+		DocumentFetchOptions: DocumentFetchOptions{IncludePaths: []string{"title"}},
+	}
+	preset.ApplyToSearchOptions(&searchOpts)
+	if !searchOpts.IncludeDocuments || !reflect.DeepEqual(searchOpts.DocumentFetchOptions.ExcludePaths, []string{"embedding"}) || len(searchOpts.DocumentFetchOptions.IncludePaths) != 0 {
+		t.Fatalf("applied VectorIndexSearchOptions=%+v", searchOpts)
+	}
+
+	searcherOpts := VectorIndexSearcherSearchOptions{
+		IncludeDocuments:     false,
+		DocumentFetchOptions: DocumentFetchOptions{ExcludePaths: []string{"old"}},
+	}
+	preset.ApplyToSearcherSearchOptions(&searcherOpts)
+	if !searcherOpts.IncludeDocuments || !reflect.DeepEqual(searcherOpts.DocumentFetchOptions.ExcludePaths, []string{"embedding"}) {
+		t.Fatalf("applied VectorIndexSearcherSearchOptions=%+v", searcherOpts)
+	}
+
+	preset.DocumentFetchOptions.ExcludePaths[0] = "mutated"
+	if searchOpts.DocumentFetchOptions.ExcludePaths[0] != "embedding" || searcherOpts.DocumentFetchOptions.ExcludePaths[0] != "embedding" {
+		t.Fatalf("applied options alias preset exclude slice: search=%v searcher=%v", searchOpts.DocumentFetchOptions.ExcludePaths, searcherOpts.DocumentFetchOptions.ExcludePaths)
+	}
+}
+
+func TestProjectionOrientedVectorDocumentFetchPresetRejectsUnsupportedField1903(t *testing.T) {
+	if _, err := ProjectionOrientedVectorDocumentFetchPreset(VectorIndexDefinition{}); err == nil || !strings.Contains(err.Error(), "path cannot be empty") {
+		t.Fatalf("ProjectionOrientedVectorDocumentFetchPreset(empty def) err=%v want missing field failure", err)
+	}
+	for _, tc := range []struct {
+		name      string
+		field     string
+		wantError string
+	}{
+		{name: "missing", field: "", wantError: "path cannot be empty"},
+		{name: "nested", field: "embedding.values", wantError: "nested paths are not supported"},
+		{name: "trimmed", field: " embedding", wantError: "leading or trailing spaces"},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ProjectionOrientedVectorDocumentFetchPresetForField(tc.field)
+			if err == nil || !strings.Contains(err.Error(), tc.wantError) {
+				t.Fatalf("ProjectionOrientedVectorDocumentFetchPresetForField(%q) err=%v want %q", tc.field, err, tc.wantError)
+			}
+		})
+	}
+}
+
+func TestProjectionOrientedVectorDocumentFetchPresetPreservesDefaultDocuments1903(t *testing.T) {
+	rows := []columnGraphRebuildInputRowV2A{
+		{id: "doc-a", vector: []float32{1, 0, 0}},
+		{id: "doc-b", vector: []float32{0, 1, 0}},
+		{id: "doc-c", vector: []float32{0, 0, 1}},
+	}
+	_, d, col, def := openColumnGraphRebuildTestCollectionV2A(t, 3, 2, rows)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+
+	base := VectorIndexSearchOptions{
+		IndexName:        def.Name,
+		Query:            []float32{0, 0, 1},
+		TopK:             2,
+		EfSearch:         len(rows),
+		MaxDecodedBlocks: 1,
+	}
+	withoutDocs, err := col.SearchVectorIndex(base)
+	if err != nil {
+		t.Fatalf("SearchVectorIndex without documents: %v", err)
+	}
+	if len(withoutDocs.Results) == 0 || len(withoutDocs.Results[0].Document) != 0 || withoutDocs.Stats.DocumentsFetched != 0 {
+		t.Fatalf("withoutDocs results/stats=%+v/%+v want existing no-document default", withoutDocs.Results, withoutDocs.Stats)
+	}
+
+	fullOpts := base
+	fullOpts.IncludeDocuments = true
+	full, err := col.SearchVectorIndex(fullOpts)
+	if err != nil {
+		t.Fatalf("SearchVectorIndex full documents: %v", err)
+	}
+	assertSearchDocumentsHaveField1903(t, full, "embedding", true)
+
+	preset, err := ProjectionOrientedVectorDocumentFetchPreset(def)
+	if err != nil {
+		t.Fatalf("ProjectionOrientedVectorDocumentFetchPreset: %v", err)
+	}
+	projectedOpts := base
+	preset.ApplyToSearchOptions(&projectedOpts)
+	projected, err := col.SearchVectorIndex(projectedOpts)
+	if err != nil {
+		t.Fatalf("SearchVectorIndex preset projection: %v", err)
+	}
+	assertColumnGraphSearchResponseLoadedV4(t, projected, def.Name, 2)
+	assertSearchDocumentsHaveField1903(t, projected, "embedding", false)
+	assertSearchDocumentsHaveField1903(t, projected, "did", true)
+	if projected.Stats.DocumentsFetched != uint64(len(projected.Results)) || projected.Stats.DocumentFieldsSkipped == 0 || projected.Stats.DocumentOutputBytes >= full.Stats.DocumentOutputBytes {
+		t.Fatalf("projected stats=%+v full stats=%+v want fetched projection below full output", projected.Stats, full.Stats)
+	}
+}
+
+func TestProjectionOrientedVectorDocumentFetchPresetCustomVectorField1903(t *testing.T) {
+	dir := t.TempDir()
+	if err := backenddb.SaveFormatConfig(dir, backenddb.FormatConfig{RequiredFeatures: []string{backenddb.RequiredFeatureCommandWALV1}}); err != nil {
+		t.Fatalf("SaveFormatConfig: %v", err)
+	}
+	d := openCollectionCommandWALDB(t, dir)
+	defer func() { _ = d.Close() }()
+
+	cfg := testColumnStoreConfig(nil)
+	cfg.Columns = append(append([]ColumnStoreColumn(nil), cfg.Columns...), ColumnStoreColumn{
+		Name:       "other_embedding",
+		Path:       "other_embedding",
+		Owner:      TypedStorageOwnerColumnPart,
+		ValueType:  ColumnStoreValueFloat32Vector,
+		VectorDims: 2,
+	})
+	def, err := normalizeVectorIndexDefinition(VectorIndexDefinition{
+		Name:       "other_embedding_graph",
+		Field:      "other_embedding",
+		Metric:     VectorMetricCosine,
+		Dimensions: 2,
+		M:          1,
+		Strategy:   VectorIndexStrategyColumnGraph,
+	})
+	if err != nil {
+		t.Fatalf("normalizeVectorIndexDefinition: %v", err)
+	}
+	meta := CollectionMeta{
+		Name: "docs",
+		Options: CollectionOptions{
+			DocumentFormat: DocumentFormatJSON,
+			ColumnStore:    cfg,
+		},
+		VectorIndexes: []VectorIndexDefinition{def},
+	}
+	if _, err := NewCollectionManager(d).CreateCollection(&meta); err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	col, err := NewCollectionManager(d).OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("OpenCollection: %v", err)
+	}
+	insertColumnGraphRebuildDualVectorRowsV2A(t, col, []columnGraphRebuildDualInputRowV2A{
+		{id: "doc-a", embedding: []float32{1, 0}, otherEmbedding: []float32{0, 1}},
+		{id: "doc-b", embedding: []float32{0, 1}, otherEmbedding: []float32{1, 0}},
+	})
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	searcher, err := col.OpenVectorIndexSearcher(VectorIndexSearcherOptions{IndexName: def.Name, MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("OpenVectorIndexSearcher: %v", err)
+	}
+	defer func() { _ = searcher.Close() }()
+
+	preset, err := ProjectionOrientedVectorDocumentFetchPreset(def)
+	if err != nil {
+		t.Fatalf("ProjectionOrientedVectorDocumentFetchPreset: %v", err)
+	}
+	opts := VectorIndexSearcherSearchOptions{
+		Query:    []float32{0, 1},
+		TopK:     2,
+		EfSearch: 2,
+	}
+	preset.ApplyToSearcherSearchOptions(&opts)
+	got, err := searcher.Search(opts)
+	if err != nil {
+		t.Fatalf("Search preset projection: %v", err)
+	}
+	assertColumnGraphSearchResponseLoadedV4(t, got, def.Name, 2)
+	assertSearchDocumentsHaveField1903(t, got, "other_embedding", false)
+	assertSearchDocumentsHaveField1903(t, got, "embedding", true)
+	assertSearchDocumentsHaveField1903(t, got, "did", true)
+}
+
+func assertSearchDocumentsHaveField1903(tb testing.TB, got VectorIndexSearchResponse, field string, want bool) {
+	tb.Helper()
+	if got.Stats.DocumentsFetched != uint64(len(got.Results)) {
+		tb.Fatalf("stats=%+v want one fetched document per result", got.Stats)
+	}
+	for i, result := range got.Results {
+		var doc map[string]any
+		if err := json.Unmarshal(result.Document, &doc); err != nil {
+			tb.Fatalf("document[%d]=%q invalid JSON: %v", i, result.Document, err)
+		}
+		_, ok := doc[field]
+		if ok != want {
+			tb.Fatalf("document[%d]=%v field %q present=%t want %t", i, doc, field, ok, want)
+		}
+	}
+}

--- a/TreeDB/collections/vector_document_fetch_preset_1903_test.go
+++ b/TreeDB/collections/vector_document_fetch_preset_1903_test.go
@@ -25,20 +25,35 @@ func TestProjectionOrientedVectorDocumentFetchPresetOutput1903(t *testing.T) {
 	}
 
 	searchOpts := VectorIndexSearchOptions{
-		IncludeDocuments:     false,
-		DocumentFetchOptions: DocumentFetchOptions{IncludePaths: []string{"title"}},
+		IncludeDocuments: false,
+		DocumentFetchOptions: DocumentFetchOptions{
+			IncludePaths:             []string{"title"},
+			Format:                   DocumentFormatBSON,
+			ColumnAssetReadIntegrity: ColumnAssetReadIntegritySkipChecksums,
+		},
 	}
 	preset.ApplyToSearchOptions(&searchOpts)
-	if !searchOpts.IncludeDocuments || !reflect.DeepEqual(searchOpts.DocumentFetchOptions.ExcludePaths, []string{"embedding"}) || len(searchOpts.DocumentFetchOptions.IncludePaths) != 0 {
+	if !searchOpts.IncludeDocuments ||
+		!reflect.DeepEqual(searchOpts.DocumentFetchOptions.ExcludePaths, []string{"embedding"}) ||
+		len(searchOpts.DocumentFetchOptions.IncludePaths) != 0 ||
+		searchOpts.DocumentFetchOptions.Format != DocumentFormatBSON ||
+		searchOpts.DocumentFetchOptions.ColumnAssetReadIntegrity != ColumnAssetReadIntegritySkipChecksums {
 		t.Fatalf("applied VectorIndexSearchOptions=%+v", searchOpts)
 	}
 
 	searcherOpts := VectorIndexSearcherSearchOptions{
-		IncludeDocuments:     false,
-		DocumentFetchOptions: DocumentFetchOptions{ExcludePaths: []string{"old"}},
+		IncludeDocuments: false,
+		DocumentFetchOptions: DocumentFetchOptions{
+			ExcludePaths:             []string{"old"},
+			Format:                   DocumentFormatTemplateV1,
+			ColumnAssetReadIntegrity: ColumnAssetReadIntegrityCachedVerify,
+		},
 	}
 	preset.ApplyToSearcherSearchOptions(&searcherOpts)
-	if !searcherOpts.IncludeDocuments || !reflect.DeepEqual(searcherOpts.DocumentFetchOptions.ExcludePaths, []string{"embedding"}) {
+	if !searcherOpts.IncludeDocuments ||
+		!reflect.DeepEqual(searcherOpts.DocumentFetchOptions.ExcludePaths, []string{"embedding"}) ||
+		searcherOpts.DocumentFetchOptions.Format != DocumentFormatTemplateV1 ||
+		searcherOpts.DocumentFetchOptions.ColumnAssetReadIntegrity != ColumnAssetReadIntegrityCachedVerify {
 		t.Fatalf("applied VectorIndexSearcherSearchOptions=%+v", searcherOpts)
 	}
 

--- a/TreeDB/collections/vector_index_retained_payload_policy_1876_test.go
+++ b/TreeDB/collections/vector_index_retained_payload_policy_1876_test.go
@@ -130,6 +130,80 @@ func BenchmarkOpenVectorIndexSearcherColumnGraphRetainedPayloadPolicy1876(b *tes
 	}
 }
 
+func BenchmarkOpenVectorIndexSearcherProjectionOrientedFetchPreset1903(b *testing.B) {
+	// Issue #1903 focused helper route: compare manual #1876 preferred projection
+	// construction with the named preset over the same non-column retained-payload
+	// fixture. Preset construction is intentionally outside the timed search loop.
+	shape := retainedPayloadPolicyFixtureShape1876{rows: 1024, dims: 128, m: 16, topK: 10, efSearch: 128, bodyBytes: 192}
+	for _, tc := range []struct {
+		name      string
+		configure func(VectorIndexDefinition) (VectorIndexSearcherSearchOptions, error)
+	}{
+		{
+			name: "manual_non_column_exclude_embedding",
+			configure: func(VectorIndexDefinition) (VectorIndexSearcherSearchOptions, error) {
+				return VectorIndexSearcherSearchOptions{IncludeDocuments: true, DocumentFetchOptions: DocumentFetchOptions{ExcludePaths: []string{"embedding"}}}, nil
+			},
+		},
+		{
+			name: "preset_non_column_exclude_embedding",
+			configure: func(def VectorIndexDefinition) (VectorIndexSearcherSearchOptions, error) {
+				preset, err := ProjectionOrientedVectorDocumentFetchPreset(def)
+				if err != nil {
+					return VectorIndexSearcherSearchOptions{}, err
+				}
+				var opts VectorIndexSearcherSearchOptions
+				preset.ApplyToSearcherSearchOptions(&opts)
+				return opts, nil
+			},
+		},
+	} {
+		tc := tc
+		b.Run(tc.name, func(b *testing.B) {
+			benchmarkOpenVectorIndexSearcherProjectionOrientedFetchPreset1903(b, shape, tc.configure)
+		})
+	}
+}
+
+func benchmarkOpenVectorIndexSearcherProjectionOrientedFetchPreset1903(b *testing.B, shape retainedPayloadPolicyFixtureShape1876, configure func(VectorIndexDefinition) (VectorIndexSearcherSearchOptions, error)) {
+	b.Helper()
+	fixture := openRetainedPayloadPolicyFixture1876(b, shape, ColumnRetainedPayloadNonColumn, false)
+	defer func() { _ = fixture.db.Close() }()
+	searcher, err := fixture.col.OpenVectorIndexSearcher(VectorIndexSearcherOptions{IndexName: fixture.def.Name, MaxDecodedBlocks: 1})
+	if err != nil {
+		b.Fatalf("OpenVectorIndexSearcher: %v", err)
+	}
+	defer func() { _ = searcher.Close() }()
+	opts, err := configure(fixture.def)
+	if err != nil {
+		b.Fatalf("configure preset: %v", err)
+	}
+	opts.Query = fixture.query
+	opts.TopK = fixture.shape.topK
+	opts.EfSearch = fixture.shape.efSearch
+	if _, err := searcher.Search(opts); err != nil {
+		b.Fatalf("warm Search: %v", err)
+	}
+	measured, err := searcher.Search(opts)
+	if err != nil {
+		b.Fatalf("measure Search: %v", err)
+	}
+	stats := measured.Stats
+	b.ReportMetric(float64(stats.DocumentsFetched), "docs/search")
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		got, err := searcher.Search(opts)
+		if err != nil {
+			b.Fatalf("Search: %v", err)
+		}
+		vectorSearchBenchSinkOrdinalV4 += len(got.Results[0].Document)
+	}
+	b.StopTimer()
+	reportVectorIndexSearchBenchMetricsV4(b, b.N, stats, false)
+	reportRetainedPayloadPolicyFixtureMetrics1876(b, fixture, retainedPayloadPolicySearchMode1876{name: "exclude_embedding", opts: opts.DocumentFetchOptions})
+}
+
 func benchmarkOpenVectorIndexSearcherRetainedPayloadPolicy1876(b *testing.B, shape retainedPayloadPolicyFixtureShape1876, policy ColumnRetainedPayloadPolicy, mode retainedPayloadPolicySearchMode1876) {
 	b.Helper()
 	fixture := openRetainedPayloadPolicyFixture1876(b, shape, policy, false)

--- a/TreeDB/docs/guides/vector-search-typed-column.md
+++ b/TreeDB/docs/guides/vector-search-typed-column.md
@@ -73,10 +73,32 @@ storing a second copy of declared typed fields such as `embedding` in the primar
 row value. This is the storage-efficient full-document path.
 
 For projection-oriented responses, also use `ColumnRetainedPayloadNonColumn` and
-apply `DocumentFetchOptions` projection, especially `ExcludePaths: []string{"embedding"}`
-when the response does not return embeddings. This is the post-#1875 baseline and
-is the recommended default starting point for vector search APIs that fetch top-k
-documents but normally suppress the vector payload.
+apply the opt-in `ProjectionOrientedVectorDocumentFetchPreset` helper. The preset
+sets `IncludeDocuments=true` and configures `DocumentFetchOptions` to exclude the
+vector field declared by `VectorIndexDefinition.Field` (for example
+`ExcludePaths: []string{"embedding"}`) when the response does not return
+embeddings. This is the post-#1875/#1903 baseline and is the recommended default
+starting point for vector search APIs that fetch top-k documents but normally
+suppress the vector payload.
+
+```go
+fetchPreset, err := collections.ProjectionOrientedVectorDocumentFetchPreset(def)
+if err != nil {
+    // Current projection supports top-level JSON vector fields only.
+    return err
+}
+opts := collections.VectorIndexSearcherSearchOptions{
+    Query:    query,
+    TopK:     10,
+    EfSearch: 128,
+}
+fetchPreset.ApplyToSearcherSearchOptions(&opts)
+response, err := searcher.Search(opts)
+```
+
+Use `ProjectionOrientedVectorDocumentFetchPresetForField` when the vector field
+path comes from a custom API surface rather than an already-loaded
+`VectorIndexDefinition`.
 
 `ColumnRetainedPayloadFull` is supported for latency-oriented compatibility: the
 full retained document can be fetched directly from the primary root/value-log
@@ -105,6 +127,17 @@ Recommended retained-payload policy matrix command:
 GOWORK=off go test ./TreeDB/collections \
   -run '^$' \
   -bench 'BenchmarkOpenVectorIndexSearcherColumnGraphRetainedPayloadPolicy1876$' \
+  -benchmem \
+  -benchtime=500ms \
+  -count=5
+```
+
+Focused helper-route validation for the #1903 preset:
+
+```sh
+GOWORK=off go test ./TreeDB/collections \
+  -run '^$' \
+  -bench 'BenchmarkOpenVectorIndexSearcherProjectionOrientedFetchPreset1903$' \
   -benchmem \
   -benchtime=500ms \
   -count=5


### PR DESCRIPTION
## Objective

Land issue #1903’s smallest opt-in API seam for projection-oriented vector final-document fetch, with review-driven merge semantics that preserve existing scalar `DocumentFetchOptions` settings when callers apply the preset. The goal remains a named helper for the preferred projection-oriented response shape without changing existing defaults.


## Mergeable-candidate status (2026-06-02 UTC)

- Latest PR head: `d53e5c77c1f16c00e2671ba2a603439e488acc6e` (`snissn/1903-manager`, base `main` at `f9293d2a82f538d5fb8447f4206fe6bb41255900`).
- Merge/CI: `mergeStateStatus=CLEAN`, `mergeable=MERGEABLE`; latest-head GitHub checks are green after re-running the initially `action_required` Copilot-authored workflow runs.
- Latest-head local validation:
  - `GOWORK=off go test ./TreeDB/collections -run 'TestProjectionOrientedVectorDocumentFetchPreset|TestTypedStorageLegacyNameAllowlistIsComplete' -count=1` — PASS
  - `GOWORK=off go test ./TreeDB/collections -count=1` — PASS
  - `GOWORK=off go test ./TreeDB/docs -count=1` — PASS
- Latest-head benchmark refresh (Apple M3, `darwin/arm64`, `GOMAXPROCS=8`, median-of-5): preferred #1876 row is `51,985 ns/op` / `19,236 ops/sec`, `40,488 B/op`, `415 allocs/op`; preset route is `51,758 ns/op` / `19,321 ops/sec`, same `B/op`/`allocs/op` as manual. No material regression versus base or manual route.
- AI/thread status: Codex latest-head review reported no major issues; Copilot's two comments were fixed in code/tests, replied to, and resolved; CodeRabbit latest-head check is pass, with earlier suggestions addressed. GraphQL review-thread inventory shows `0` unresolved threads.
- #1904 dependency-ready seam: follow-on audit/adoption should consume `ProjectionOrientedVectorDocumentFetchPreset(def)` or `ProjectionOrientedVectorDocumentFetchPresetForField(field)` and apply it to both collection and reusable-searcher vector search options; #1904 remains blocked until this PR lands.

## Context

#1876 showed the preferred vector document response path is:

```text
ColumnRetainedPayloadNonColumn + exclude the vector field from final document responses
```

This PR makes that response shape a named helper/preset instead of ad hoc `DocumentFetchOptions{ExcludePaths: ...}` plumbing. Review feedback also surfaced that applying the preset must not silently discard caller-provided scalar fetch settings such as explicit materialization format or relaxed asset-read integrity.

## Non-goals

- Do not make `ColumnRetainedPayloadFull` the default.
- Do not silently change existing `IncludeDocuments=true` response shape.
- Do not start the broad #1904 docs/API/examples/benchmark audit.
- Do not touch graph-search QPS, #1735 resource sharing, quantized storage, on-disk formats, or migrations.
- Do not broaden preset behavior beyond projection-path setup plus preserving existing scalar fetch settings unless the preset explicitly overrides them.

## Design

- Formats/flags/APIs changed (include diagrams if applicable)
  - Added:
    - `collections.VectorDocumentFetchPreset`
    - `collections.ProjectionOrientedVectorDocumentFetchPreset(def VectorIndexDefinition)`
    - `collections.ProjectionOrientedVectorDocumentFetchPresetForField(vectorField string)`
    - `VectorDocumentFetchPreset.ApplyToSearchOptions(*VectorIndexSearchOptions)`
    - `VectorDocumentFetchPreset.ApplyToSearcherSearchOptions(*VectorIndexSearcherSearchOptions)`
  - The preset sets `IncludeDocuments=true` and `DocumentFetchOptions.ExcludePaths` to the vector field from `VectorIndexDefinition.Field` (or an explicit custom top-level field path).
  - `ApplyTo*` now replaces projection paths (`IncludePaths` / `ExcludePaths`) but preserves existing scalar fetch settings (`Format`, `ColumnAssetReadIntegrity`) unless the preset explicitly sets non-zero scalar overrides.
- Invariants that must hold
  - Existing zero-valued vector search options are unchanged.
  - Existing `IncludeDocuments=true` with zero `DocumentFetchOptions` still returns full documents, including embeddings.
  - Projection remains explicit opt-in through the new preset.
  - Applying the preset must not silently discard caller-provided scalar fetch settings.
  - `ColumnRetainedPayloadFull` remains opt-in only.
- Fail-closed behavior (caps before alloc; CRC/error handling)
  - Current document projection supports top-level JSON paths only.
  - Missing, empty, nested, or leading/trailing-space-invalid helper inputs fail closed with a clear error.
  - No checksum or integrity relaxation is introduced by the preset itself; any caller-provided integrity mode is preserved instead of overwritten.

## Scope

- Includes (files/symbols):
  - `TreeDB/collections/vector_document_fetch_preset.go`
  - `TreeDB/collections/vector_document_fetch_preset_1903_test.go`
  - Focused #1903 benchmark row in `TreeDB/collections/vector_index_retained_payload_policy_1876_test.go`
  - Focused typed-storage naming allowlist update for the new test file
  - Focused guide update in `TreeDB/docs/guides/vector-search-typed-column.md`
- Excludes (files/symbols):
  - Broad #1904 audit/adoption
  - Demo/default rewrites
  - Nativewire expansion
  - On-disk storage changes
  - Any change to vector-search defaults or retained-payload defaults

## Correctness

- Tests run (exact commands):
  ```sh
  # Earlier implementation-head validation
  GOWORK=off go test ./TreeDB/collections -run 'TestProjectionOrientedVectorDocumentFetchPreset'
  GOWORK=off go test ./TreeDB/collections -run 'TestTypedStorageLegacyNameAllowlistIsComplete|TestProjectionOrientedVectorDocumentFetchPreset' -count=1
  GOWORK=off go test ./TreeDB/collections
  GOWORK=off go test ./TreeDB/docs
  GOWORK=off go test ./TreeDB/...

  # Latest-head refresh after Copilot merge-semantics fix (`d53e5c77c1f16c00e2671ba2a603439e488acc6e`)
  GOWORK=off go test ./TreeDB/collections -run 'TestProjectionOrientedVectorDocumentFetchPreset|TestTypedStorageLegacyNameAllowlistIsComplete' -count=1
  GOWORK=off go test ./TreeDB/collections -count=1
  GOWORK=off go test ./TreeDB/docs -count=1
  ```
- Corruption/edge cases covered:
  - Helper output and slice-copy behavior.
  - Empty/missing field rejection.
  - Nested field rejection.
  - Leading/trailing-space field rejection.
  - Existing no-document default remains no-document.
  - Existing full-document response still includes `embedding` without the helper.
  - Helper-applied collection search excludes `VectorIndexDefinition.Field`.
  - Helper-applied reusable searcher excludes a custom top-level vector field (`other_embedding`) while retaining other fields.
  - Review regression coverage now asserts `ApplyTo*` preserves existing scalar `DocumentFetchOptions` fields while still overriding projection paths.
- Concurrency/race coverage (if applicable):
  - Not applicable; the change is option shaping and search-time document-fetch configuration, with no new concurrency state machine.

## Performance

- Benchmarks run (exact commands):
  ```sh
  (cd /tmp/gomap_1903_base && GOMAXPROCS=8 GOWORK=off go test ./TreeDB/collections \
    -run '^$' \
    -bench 'BenchmarkOpenVectorIndexSearcherColumnGraphRetainedPayloadPolicy1876$' \
    -benchmem \
    -benchtime=500ms \
    -count=5)

  # Latest-head refresh (`d53e5c77c1f16c00e2671ba2a603439e488acc6e`)
  GOMAXPROCS=8 GOWORK=off go test ./TreeDB/collections \
    -run '^$' \
    -bench '^BenchmarkOpenVectorIndexSearcherColumnGraphRetainedPayloadPolicy1876/non_column/exclude_embedding$' \
    -benchmem \
    -benchtime=500ms \
    -count=5

  GOMAXPROCS=8 GOWORK=off go test ./TreeDB/collections \
    -run '^$' \
    -bench '^BenchmarkOpenVectorIndexSearcherProjectionOrientedFetchPreset1903$' \
    -benchmem \
    -benchtime=500ms \
    -count=5
  ```
- Results table (before/after; median-of-5 per G1 in `docs/OPT_SPRINT_NEXT.md`):

  Hardware/context: Apple M3, `darwin/arm64`, `GOMAXPROCS=8`. Fixture: 1024 rows, 128 dims, topK=10, efSearch=128, non-column retained payload with retained body/tag.

  | Source | Benchmark row | ns/op | ops/sec | B/op | allocs/op | docs/search | output_B/search | retained_payload_B_total | db_dir_B_total | write_amplification |
  | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
  | base f9293d2a | `1876/non_column/exclude_embedding-8` | 52,210 | 19,153 | 40,488 | 415 | 10 | 2,816 | 237,568 | 3,412,194 | 2.087 |
  | head d53e5c77 | `1876/non_column/exclude_embedding-8` | 51,985 | 19,236 | 40,488 | 415 | 10 | 2,816 | 237,568 | 3,412,194 | 2.087 |
  | head d53e5c77 | `1903/manual_non_column_exclude_embedding-8` | 51,330 | 19,482 | 40,488 | 415 | 10 | 2,816 | 237,568 | 3,412,194 | 2.087 |
  | head d53e5c77 | `1903/preset_non_column_exclude_embedding-8` | 51,758 | 19,321 | 40,488 | 415 | 10 | 2,816 | 237,568 | 3,412,194 | 2.087 |

- Regressions (if any) and why acceptable:
  - Preferred #1876 row on latest head: `51,985 ns/op` vs base `52,210 ns/op` (benchstat: ~, p=0.690; no material regression), identical `B/op` and `allocs/op`.
  - Preset route vs manual route on latest head: `51,758 ns/op` vs `51,330 ns/op` (+0.83%), identical `B/op`, `allocs/op`, docs/search, output bytes, retained-payload bytes, and storage counters; preset construction/application remains outside the steady-state timed loop, so no material helper-route overhead is observed.
  - The post-review merge-semantics fix affects `ApplyTo*` option shaping and preserves caller scalar fetch settings; the latest-head refresh above confirms unchanged steady-state allocation and storage counters.

## Rollout / Toggle Plan

- Default setting:
  - No behavior change by default. Callers must explicitly apply the preset.
- How to disable quickly:
  - Stop applying `ProjectionOrientedVectorDocumentFetchPreset*`; existing full-doc/no-doc option behavior remains available.

## Follow-ups

- #1904 should consume this seam for broad docs/API/examples/demos/benchmark audit and adoption.
- #1887 remains separate reconstruction optimization evidence.
- Follow-on adopters should preserve the documented merge semantics for scalar `DocumentFetchOptions` fields when composing presets with caller-specific fetch settings.

## Column Graph Native Workstream (#1646, if applicable)

### Copied/Adapted From Old Stack

- Copied:
  - Not applicable.
- Adapted:
  - Not applicable.
- Oracle/comparator only:
  - Existing vector search/document materialization paths are used as the comparator surface for the new preset seam.
- Quarantined/not copied:
  - Not applicable.

### Path Identity

- Native reader:
  - Existing collection/searcher document materialization path; unchanged.
- Decoded comparator:
  - Existing full-document fetch and explicit manual `ExcludePaths` fetch behavior.
- Legacy/native vector index:
  - Existing vector-index search APIs; unchanged except for the new opt-in preset seam.
- Unsupported/fail-closed:
  - Nested or malformed projection paths fail closed.

### Base And Dependency State

- Base branch:
  - Current PR base branch.
- Base commit:
  - Not updated here.
- Base PR/head:
  - Not updated here.
- #1621/#1634 assumptions:
  - Not applicable.
- Missing generic column-store primitives:
  - None for this seam; it reuses existing `DocumentFetchOptions` projection/materialization support.
- Parent review fixes propagated:
  - Review-driven fix preserves existing scalar `DocumentFetchOptions` settings during preset application.

### Evidence

- Tests:
  - Focused preset tests plus existing collections/docs/package coverage listed above.
- Benchmarks:
  - Focused #1876/#1903 benchmark rows listed above.
- Status/fallback proof:
  - Zero-valued search options and plain `IncludeDocuments=true` behavior remain unchanged.
- Performance attribution:
  - Helper construction/application remains outside the timed benchmark loop.
- Local regressions found/fixed:
  - Fixed preset-application behavior that previously overwrote caller-provided scalar fetch settings.

### Test Plan Start

- Milestone tasks targeted:
  - Smallest opt-in API seam for projection-oriented vector final-document fetch.
- Tests to add before or with implementation:
  - Helper output, default preservation, projection behavior, custom vector field, unsupported/missing/nested field handling, retained-payload benchmark row.
- Existing tests to preserve:
  - Existing no-document default and existing full-document `IncludeDocuments=true` behavior.
- #1646 test-list changes made before implementation:
  - Not applicable.

### Performance Plan Start

- Relevant benchmarks/metrics for this PR:
  - Search latency, allocations, output bytes/search for the preferred non-column retained-payload + exclude-embedding route.
- Baseline/comparator command or reason not applicable:
  - Baseline and candidate commands listed above.
- Expected setup/search/materialization boundary:
  - Fixture build, graph rebuild, reusable searcher open, and warmup are outside the timed loop; timed operation is steady-state search plus post-topK document fetch/materialization.
- Upstream costs explicitly out of scope:
  - Graph-build costs, resource sharing, storage/layout changes, and broader #1904 adoption work.
- Local performance risks to watch:
  - Avoid helper-route overhead and avoid any regression in the preferred #1876 route.

### Test Plan Close

- Additional tests found during implementation/review:
  - Added review-driven assertions that `ApplyTo*` preserves scalar `DocumentFetchOptions` settings while overriding projection paths.
- Tests added or changed:
  - Focused preset test updated to cover preserved `Format` and `ColumnAssetReadIntegrity` behavior for both search option types.
- Failing tests fixed:
  - None; change was made proactively from review feedback.
- #1646 test-list changes made at close:
  - Not applicable.
- Residual untested gaps, if any:
  - No new known gaps within the scoped preset/apply behavior.

### Performance Plan Close

- Benchmark commands run:
  - Commands listed above.
- Results summary with throughput/latency/allocations:
  - No material regression on the preferred route; preset route matches manual route allocations and counters with only a sub-1% median timing delta in the measured run set.
- Before/after or baseline comparison:
  - Base vs PR head and manual vs preset comparisons listed above.
- Local slow/heavy code found and fixed:
  - None in the timed path.
- Remaining upstream or deferred costs:
  - Broad adoption/perf audit remains deferred to follow-on work.

### AI Review Loop

- Codex latest-head review:
  - Reported no major issues on latest head `d53e5c77c1f16c00e2671ba2a603439e488acc6e`.
- Copilot review:
  - Generated two comments about preserving scalar fetch settings and updating the regression test; both were addressed in code/tests, replied to, and resolved. The Copilot cloud-agent run completed successfully on latest head.
- CodeRabbit latest-head review:
  - Latest-head CodeRabbit check is pass. Earlier suggestions were addressed with clone-maintenance and merge-semantics documentation.
- Review comments/threads resolved or explicitly dismissed:
  - GraphQL review-thread inventory after resolution shows `0` unresolved threads.
- Re-requested after final meaningful push:
  - Yes; no additional AI review request was made after thread replies/resolution because no code changed.

---

## Optimization PR Checklist (TreeDB)

### Scope
- [x] Single, clear objective for this PR (not a bundle)
- [x] Explicit include list (files/symbols touched):
- [x] Explicit exclude list (files/symbols NOT touched):
- [x] No unwanted feature reintroduction (e.g. async slab writer, hard zones, ValueIndex) unless explicitly stated in the PR objective

### Safety / Correctness
- [x] Clear written-vs-durable semantics for any `*Sync` path touched
- [x] No new mmap usage on mutable/truncating files
- [x] All new length fields are capped before allocation (OOM-safe)
- [x] CRC/checksum behavior is fail-closed (clean error, no panic)
- [x] Any concurrency change has a defined state machine and invariants

### Tests
- [x] Added deterministic regression tests for the targeted failure mode
- [x] Tests avoid sleeps where possible (use latches/hooks)
- [x] Added corruption/edge-case tests (truncation, bad headers, invalid lengths) when format/parsing changes
- [x] Ran locally:
  - [x] `go test ./... -count=1`
  - [x] Any targeted packages/benchmarks:

### Benchmarks / Measurements
- [x] Added or updated a benchmark relevant to the change
- [x] Reported results in PR description (before/after, command, machine)
- [x] Included “incompressible” (worst-case) results if compression is involved

### Docs
- [ ] Updated `docs/OPT_SPRINT_NEXT.md` milestone status (if applicable)
- [x] Documented any new config knobs + defaults
- [x] Called out any format change in PR description (pre-alpha OK)

### Rollout / Toggle Plan (if behavior-affecting)
- [x] Safe defaults (feature off or conservative threshold)
- [x] Clear knobs to disable/revert behavior quickly
- [ ] Observability: counters/logs to verify effectiveness