### PR TITLE
Share prepared column graph search resources

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -358,22 +358,28 @@ type collectionManagerOptions struct {
 }
 
 type Collection struct {
-	db                *backenddb.DB
-	manager           *CollectionManager
-	writeDomain       *collectionWriteDomain
-	name              string
-	meta              CollectionMeta
-	catalogMu         sync.RWMutex
-	catalogCommitSeq  uint64
-	catalogSystemRoot uint64
-	catalog           *collectionCatalog
-	insertStatsMu     sync.RWMutex
-	lastInsertStats   CollectionInsertStats
-	updateStatsMu     sync.RWMutex
-	lastUpdateStats   CollectionUpdateStats
-	vectorIndexLoadMu sync.Mutex
-	vectorIndexesMu   sync.RWMutex
-	vectorIndexes     map[string]*VectorIndex
+	db                         *backenddb.DB
+	manager                    *CollectionManager
+	writeDomain                *collectionWriteDomain
+	name                       string
+	meta                       CollectionMeta
+	catalogMu                  sync.RWMutex
+	catalogCommitSeq           uint64
+	catalogSystemRoot          uint64
+	catalog                    *collectionCatalog
+	insertStatsMu              sync.RWMutex
+	lastInsertStats            CollectionInsertStats
+	updateStatsMu              sync.RWMutex
+	lastUpdateStats            CollectionUpdateStats
+	vectorIndexLoadMu          sync.Mutex
+	vectorIndexesMu            sync.RWMutex
+	vectorIndexes              map[string]*VectorIndex
+	vectorPreparedSearchMu     sync.Mutex
+	vectorPreparedSearch       map[string]*columnVectorGraphSharedPreparedSearchCacheEntry
+	vectorPreparedSearchHits   uint64
+	vectorPreparedSearchMisses uint64
+	vectorPreparedSearchWaits  uint64
+	vectorPreparedSearchBuilds uint64
 }
 
 type CollectionRootOverlayCompactionStats struct {

--- a/TreeDB/collections/column_vector_graph_adjacency_direct_source_test.go
+++ b/TreeDB/collections/column_vector_graph_adjacency_direct_source_test.go
@@ -335,7 +335,10 @@ func TestColumnVectorGraphLayer0AdjacencySourceBadNeighborOrdinalFails1919(t *te
 	}
 }
 
-func TestColumnVectorGraphLayer0AdjacencySourceParallelReadersIndependent1919(t *testing.T) {
+func TestColumnVectorGraphLayer0AdjacencySourceParallelReadersSharePreparedHandles1735(t *testing.T) {
+	if !columnGraphTypedColumnMmapDirectViewSupportedForTest() {
+		t.Skip("shared prepared adjacency-source handle test requires mmap_direct support")
+	}
 	input := columnGraphRebuildSyntheticRowsV2A(64, 16)
 	_, d, col, def := openColumnGraphRebuildTestCollectionV2A(t, 16, 8, input)
 	defer func() { _ = d.Close() }()
@@ -349,13 +352,22 @@ func TestColumnVectorGraphLayer0AdjacencySourceParallelReadersIndependent1919(t 
 			t.Fatalf("open reader %d: %v", i, err)
 		}
 		defer func() { _ = reader.Close() }()
-		if reader.layer0AdjacencySource == nil || reader.layer0AdjacencySource.manager == nil {
-			t.Fatalf("reader %d source=%v fallback=%s", i, reader.layer0AdjacencySource != nil, reader.layer0AdjacencySourceFallbackReason)
+		if reader.layer0AdjacencySource == nil || reader.layer0AdjacencySource.manager == nil || reader.sharedPreparedSearch == nil {
+			t.Fatalf("reader %d source=%v shared=%v fallback=%s", i, reader.layer0AdjacencySource != nil, reader.sharedPreparedSearch != nil, reader.layer0AdjacencySourceFallbackReason)
 		}
-		if i > 0 && reader.layer0AdjacencySource.manager == readers[0].layer0AdjacencySource.manager {
-			t.Fatalf("reader %d shares layer-0 source manager with reader 0", i)
+		if i > 0 {
+			if reader.sharedPreparedSearch.holder != readers[0].sharedPreparedSearch.holder {
+				t.Fatalf("reader %d did not share prepared holder with reader 0", i)
+			}
+			if reader.layer0AdjacencySource.manager != readers[0].layer0AdjacencySource.manager {
+				t.Fatalf("reader %d layer-0 source manager differs from reader 0; want shared immutable manager", i)
+			}
 		}
 		readers[i] = reader
+	}
+	snap := col.columnVectorGraphSharedPreparedSearchCacheSnapshot()
+	if snap.Entries != 1 || snap.Refs != len(readers) || snap.ActiveHandles == 0 || snap.ActiveMappedBytes == 0 {
+		t.Fatalf("shared prepared adjacency snapshot=%+v want one active holder with %d refs", snap, len(readers))
 	}
 	for i, reader := range readers {
 		var scratch columnVectorGraphNativeSearchScratch

--- a/TreeDB/collections/column_vector_graph_prepared_search_test.go
+++ b/TreeDB/collections/column_vector_graph_prepared_search_test.go
@@ -324,6 +324,146 @@ func TestColumnVectorGraphPreparedSearchParallelScratchSafety2045(t *testing.T) 
 	}
 }
 
+func TestColumnVectorGraphPreparedSearchSharedResourceRefcount1735(t *testing.T) {
+	if !columnGraphTypedColumnMmapDirectViewSupportedForTest() {
+		t.Skip("shared prepared resource refcount test requires mmap_direct support")
+	}
+	rows := columnGraphRebuildSyntheticRowsV2A(128, 16)
+	_, d, col, def := openColumnGraphTypedColumnVectorTestCollection1782(t, 16, 8, rows)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	reader1, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("open reader1: %v", err)
+	}
+	if reader1.sharedPreparedSearch == nil || reader1.preparedSearch == nil || !reader1.preparedSearch.ready() {
+		_ = reader1.Close()
+		t.Fatalf("reader1 sharedPrepared=%v prepared=%v want shared ready prepared search", reader1.sharedPreparedSearch != nil, reader1.preparedSearch != nil)
+	}
+	first := col.columnVectorGraphSharedPreparedSearchCacheSnapshot()
+	if first.Entries != 1 || first.Refs != 1 || first.ActiveHandles == 0 || first.ActiveMappedBytes == 0 || first.ActiveHeapCopyBytes != 0 {
+		_ = reader1.Close()
+		t.Fatalf("first shared prepared cache snapshot=%+v want one mapped entry/ref without heap-copy fallback", first)
+	}
+	reader2, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
+	if err != nil {
+		_ = reader1.Close()
+		t.Fatalf("open reader2: %v", err)
+	}
+	if reader2.sharedPreparedSearch == nil || reader2.sharedPreparedSearch.holder != reader1.sharedPreparedSearch.holder || reader2.preparedSearch != reader1.preparedSearch {
+		_ = reader2.Close()
+		_ = reader1.Close()
+		t.Fatal("reader2 did not share the immutable prepared holder/view with reader1")
+	}
+	second := col.columnVectorGraphSharedPreparedSearchCacheSnapshot()
+	if second.Entries != 1 || second.Refs != 2 || second.CacheHits != 1 || second.CacheMisses != 1 || second.CacheBuilds != 1 || second.ActiveHandles != first.ActiveHandles || second.ActiveMappedBytes != first.ActiveMappedBytes || second.TotalAcquires != first.TotalAcquires {
+		_ = reader2.Close()
+		_ = reader1.Close()
+		t.Fatalf("second shared prepared cache snapshot=%+v first=%+v want ref growth without new mapped handles", second, first)
+	}
+	query := append([]float32(nil), rows[7].vector...)
+	baseline, _, err := reader2.SearchCosine(query, columnVectorGraphNativeSearchOptions{TopK: 8, EfSearch: 64}, &columnVectorGraphNativeSearchScratch{})
+	if err != nil {
+		_ = reader2.Close()
+		_ = reader1.Close()
+		t.Fatalf("baseline SearchCosine: %v", err)
+	}
+	baseline = cloneColumnVectorGraphPreparedResults2045(baseline)
+	if err := reader1.Close(); err != nil {
+		_ = reader2.Close()
+		t.Fatalf("close reader1: %v", err)
+	}
+	afterFirstClose := col.columnVectorGraphSharedPreparedSearchCacheSnapshot()
+	if afterFirstClose.Entries != 1 || afterFirstClose.Refs != 1 || afterFirstClose.ActiveHandles != first.ActiveHandles || afterFirstClose.ActiveMappedBytes != first.ActiveMappedBytes {
+		_ = reader2.Close()
+		t.Fatalf("cache after first close=%+v want remaining reader to retain shared handles", afterFirstClose)
+	}
+	got, stats, err := reader2.SearchCosine(query, columnVectorGraphNativeSearchOptions{TopK: 8, EfSearch: 64, StatsMode: columnVectorGraphNativeSearchStatsModeMinimal}, &columnVectorGraphNativeSearchScratch{})
+	if err != nil {
+		_ = reader2.Close()
+		t.Fatalf("reader2 SearchCosine after reader1 close: %v", err)
+	}
+	if mismatch := columnGraphNativeSearchResultsMismatchV3(got, baseline); mismatch != "" {
+		_ = reader2.Close()
+		t.Fatalf("reader2 after reader1 close: %s", mismatch)
+	}
+	if stats.PreparedGraphSearchViews != 1 || stats.GraphRowFallbacks != 0 || stats.TypedColumnFallbacks != 0 || stats.ResultIDGraphFallbacks != 0 {
+		_ = reader2.Close()
+		t.Fatalf("reader2 stats=%+v want shared prepared path without fallback", stats)
+	}
+	holder := reader2.sharedPreparedSearch.holder
+	if err := reader2.Close(); err != nil {
+		t.Fatalf("close reader2: %v", err)
+	}
+	afterAllClosed := col.columnVectorGraphSharedPreparedSearchCacheSnapshot()
+	if afterAllClosed.Entries != 0 || afterAllClosed.Refs != 0 || afterAllClosed.ActiveHandles != 0 || afterAllClosed.ActiveMappedBytes != 0 {
+		t.Fatalf("cache after all close=%+v want no active shared handles", afterAllClosed)
+	}
+	if holder != nil {
+		if stats := holder.stats(); stats.ActiveHandles != 0 || stats.ActiveMappedBytes != 0 || stats.ActiveHeapCopyBytes != 0 {
+			t.Fatalf("holder stats after last close=%+v want released resources", stats)
+		}
+	}
+}
+
+func TestColumnVectorGraphPreparedSearchConcurrentOpenSharesSingleHolder1735(t *testing.T) {
+	if !columnGraphTypedColumnMmapDirectViewSupportedForTest() {
+		t.Skip("shared prepared concurrent-open test requires mmap_direct support")
+	}
+	rows := columnGraphRebuildSyntheticRowsV2A(96, 16)
+	_, d, col, def := openColumnGraphTypedColumnVectorTestCollection1782(t, 16, 8, rows)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	const workers = 4
+	readers := make([]*columnVectorGraphPhysicalRowReader, workers)
+	errs := make(chan string, workers)
+	var wg sync.WaitGroup
+	for worker := 0; worker < workers; worker++ {
+		worker := worker
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			reader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
+			if err != nil {
+				errs <- fmt.Sprintf("open reader %d: %v", worker, err)
+				return
+			}
+			readers[worker] = reader
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Error(err)
+	}
+	defer func() {
+		for _, reader := range readers {
+			_ = reader.Close()
+		}
+	}()
+	if t.Failed() {
+		return
+	}
+	holder := readers[0].sharedPreparedSearch.holder
+	for i, reader := range readers {
+		var gotHolder *columnVectorGraphSharedPreparedSearch
+		if reader != nil && reader.sharedPreparedSearch != nil {
+			gotHolder = reader.sharedPreparedSearch.holder
+		}
+		if reader == nil || reader.sharedPreparedSearch == nil || gotHolder != holder || reader.preparedSearch == nil || !reader.preparedSearch.ready() {
+			t.Fatalf("reader %d sharedPrepared=%v holder=%p first=%p prepared=%v", i, reader != nil && reader.sharedPreparedSearch != nil, gotHolder, holder, reader != nil && reader.preparedSearch != nil)
+		}
+	}
+	snap := col.columnVectorGraphSharedPreparedSearchCacheSnapshot()
+	if snap.Entries != 1 || snap.Refs != workers || snap.CacheBuilds != 1 || snap.CacheMisses != 1 || snap.CacheHits != workers-1 || snap.CacheWaits > workers-1 || snap.BuildingEntries != 0 || snap.ActiveHandles == 0 || snap.ActiveMappedBytes == 0 {
+		t.Fatalf("concurrent-open cache snapshot=%+v want one built holder with %d refs", snap, workers)
+	}
+}
+
 func assertColumnVectorGraphPreparedSearchStats2045(tb testing.TB, stats columnVectorGraphNativeSearchStats, results int) {
 	tb.Helper()
 	if stats.PreparedGraphSearchViews != 1 || stats.GraphRowFallbacks != 0 {

--- a/TreeDB/collections/column_vector_graph_row_reader.go
+++ b/TreeDB/collections/column_vector_graph_row_reader.go
@@ -57,6 +57,7 @@ type columnVectorGraphPhysicalRowReader struct {
 	documentIDSource                    *columnVectorGraphDocumentIDStateSource
 	documentIDStateFallbackReason       typeddecode.Reason
 	preparedSearch                      *columnVectorGraphPreparedSearchView
+	sharedPreparedSearch                *columnVectorGraphSharedPreparedSearchRef
 	adjacencyLayerSources               *columnVectorGraphAdjacencyDirectSources
 	layer0AdjacencySource               *columnVectorGraphLayer0AdjacencyDirectSource
 	layer0AdjacencySourceUnavailable    bool
@@ -123,6 +124,62 @@ func (c *Collection) openColumnVectorGraphPhysicalRowReaderAtSnapshot(name strin
 		catalog: catalog,
 		reader:  reader,
 	}
+	if !columnVectorGraphManifestHasPhysicalAsset(graph) && graph.RowCount > 0 && catalog != nil && view.VectorIndexStateFound && view.AssetNamespace != "" {
+		key, keyErr := columnVectorGraphSharedPreparedSearchCacheKey(catalog.meta.Name, view.AssetNamespace, def, graph, view.VectorIndexState)
+		if keyErr != nil {
+			_ = graphReader.Close()
+			return nil, keyErr
+		}
+		shared, err := c.acquireColumnVectorGraphSharedPreparedSearch(key, func() (*columnVectorGraphSharedPreparedSearch, error) {
+			buildReader := &columnVectorGraphPhysicalRowReader{def: def, graph: graph, catalog: catalog}
+			success := false
+			defer func() {
+				if !success {
+					_ = buildReader.Close()
+				}
+			}()
+			if err := c.prepareColumnVectorGraphPhysicalRowReaderSourcesAtSnapshot(buildReader, snap, view); err != nil {
+				return nil, err
+			}
+			holder, err := newColumnVectorGraphSharedPreparedSearchFromReader(buildReader)
+			if err != nil {
+				return nil, err
+			}
+			success = true
+			return holder, nil
+		})
+		if err != nil {
+			if errors.Is(err, errColumnVectorGraphSharedPreparedSearchNotEligible) {
+				if prepErr := c.prepareColumnVectorGraphPhysicalRowReaderSourcesAtSnapshot(graphReader, snap, view); prepErr != nil {
+					_ = graphReader.Close()
+					return nil, prepErr
+				}
+				return graphReader, nil
+			}
+			_ = graphReader.Close()
+			return nil, err
+		}
+		if err := graphReader.attachSharedPreparedSearch(shared); err != nil {
+			releaseErr := shared.release()
+			_ = graphReader.Close()
+			return nil, errors.Join(err, releaseErr)
+		}
+		return graphReader, nil
+	}
+	if err := c.prepareColumnVectorGraphPhysicalRowReaderSourcesAtSnapshot(graphReader, snap, view); err != nil {
+		_ = graphReader.Close()
+		return nil, err
+	}
+	return graphReader, nil
+}
+
+func (c *Collection) prepareColumnVectorGraphPhysicalRowReaderSourcesAtSnapshot(graphReader *columnVectorGraphPhysicalRowReader, snap *backenddb.Snapshot, view columnPhysicalScanSnapshotView) error {
+	if graphReader == nil {
+		return errNilColumnVectorGraphPhysicalRowReader
+	}
+	catalog := graphReader.catalog
+	def := graphReader.def
+	graph := graphReader.graph
 	if catalog != nil && catalog.meta.Options.ColumnStore != nil {
 		baseCfg := catalog.meta.Options.ColumnStore
 		var baseManifest columnManifestSnapshot
@@ -148,26 +205,22 @@ func (c *Collection) openColumnVectorGraphPhysicalRowReaderAtSnapshot(name strin
 		}
 		state := view.VectorIndexState
 		if !view.VectorIndexStateFound {
-			_ = graphReader.Close()
-			return nil, fmt.Errorf("collections: column_graph %q missing vector-index state record: %w", def.Name, errColumnVectorGraphManifestMismatch)
+			return fmt.Errorf("collections: column_graph %q missing vector-index state record: %w", def.Name, errColumnVectorGraphManifestMismatch)
 		}
 		if sources, _, sourceErr := c.openColumnVectorGraphAdjacencyStateSourcesForReader(catalog.meta.Name, *baseCfg, def, graph, state); sourceErr != nil {
-			_ = graphReader.Close()
-			return nil, sourceErr
+			return sourceErr
 		} else if sources != nil {
 			graphReader.adjacencyLayerSources = sources
 			if len(sources.sources) > 0 {
 				graphReader.layer0AdjacencySource = sources.sources[0]
 			}
 		} else {
-			_ = graphReader.Close()
-			return nil, fmt.Errorf("collections: column_graph %q missing vector-index adjacency state source: %w", def.Name, errColumnVectorGraphManifestMismatch)
+			return fmt.Errorf("collections: column_graph %q missing vector-index adjacency state source: %w", def.Name, errColumnVectorGraphManifestMismatch)
 		}
 		if _, ok := findColumnVectorGraphInvNormStateAsset(state); ok {
 			source, fallbackReason, sourceErr := c.openColumnVectorGraphInvNormStateSourceForReader(catalog.meta.Name, *baseCfg, def, graph, state)
 			if sourceErr != nil {
-				_ = graphReader.Close()
-				return nil, sourceErr
+				return sourceErr
 			}
 			graphReader.invNormSource = source
 			graphReader.invNormStateFallbackReason = fallbackReason
@@ -177,13 +230,11 @@ func (c *Collection) openColumnVectorGraphPhysicalRowReaderAtSnapshot(name strin
 		if columnVectorGraphRowRefStatePresent(state) {
 			_, records, recordsErr := loadBaseManifestRecords()
 			if recordsErr != nil {
-				_ = graphReader.Close()
-				return nil, recordsErr
+				return recordsErr
 			}
 			source, sourceErr := c.openColumnVectorGraphRowRefStateSourceForReader(catalog.meta.Name, *baseCfg, def, graph, state, records)
 			if sourceErr != nil {
-				_ = graphReader.Close()
-				return nil, sourceErr
+				return sourceErr
 			}
 			graphReader.rowRefSource = source
 		} else {
@@ -215,30 +266,25 @@ func (c *Collection) openColumnVectorGraphPhysicalRowReaderAtSnapshot(name strin
 	}
 	if !columnVectorGraphManifestHasPhysicalAsset(graph) && graph.RowCount > 0 {
 		if graphReader.invNormSource == nil {
-			_ = graphReader.Close()
-			return nil, fmt.Errorf("collections: column_graph %q missing required vector-index inverse-norm state source: %w", def.Name, errColumnVectorGraphManifestMismatch)
+			return fmt.Errorf("collections: column_graph %q missing required vector-index inverse-norm state source: %w", def.Name, errColumnVectorGraphManifestMismatch)
 		}
 		if graphReader.rowRefSource == nil {
-			_ = graphReader.Close()
-			return nil, fmt.Errorf("collections: column_graph %q missing required vector-index row-ref state source: %w", def.Name, errColumnVectorGraphManifestMismatch)
+			return fmt.Errorf("collections: column_graph %q missing required vector-index row-ref state source: %w", def.Name, errColumnVectorGraphManifestMismatch)
 		}
 		if graphReader.documentIDSource == nil {
-			_ = graphReader.Close()
-			return nil, fmt.Errorf("collections: column_graph %q missing required vector-index document-id state source: %w", def.Name, errColumnVectorGraphManifestMismatch)
+			return fmt.Errorf("collections: column_graph %q missing required vector-index document-id state source: %w", def.Name, errColumnVectorGraphManifestMismatch)
 		}
 		if graphReader.typedVectorSource == nil {
-			_ = graphReader.Close()
 			if graphReader.typedVectorFallbackReason != "" {
-				return nil, fmt.Errorf("collections: column_graph %q missing required base typed-column vector source: %s: %w", def.Name, graphReader.typedVectorFallbackReason, errColumnVectorGraphManifestMismatch)
+				return fmt.Errorf("collections: column_graph %q missing required base typed-column vector source: %s: %w", def.Name, graphReader.typedVectorFallbackReason, errColumnVectorGraphManifestMismatch)
 			}
-			return nil, fmt.Errorf("collections: column_graph %q missing required base typed-column vector source: %w", def.Name, errColumnVectorGraphManifestMismatch)
+			return fmt.Errorf("collections: column_graph %q missing required base typed-column vector source: %w", def.Name, errColumnVectorGraphManifestMismatch)
 		}
 		if prepareErr := maybePrepareColumnVectorGraphPreparedSearchView(graphReader); prepareErr != nil {
-			_ = graphReader.Close()
-			return nil, fmt.Errorf("collections: column_graph %q combined prepared graph-search view: %w: %w", def.Name, prepareErr, errColumnVectorGraphManifestMismatch)
+			return fmt.Errorf("collections: column_graph %q combined prepared graph-search view: %w: %w", def.Name, prepareErr, errColumnVectorGraphManifestMismatch)
 		}
 	}
-	return graphReader, nil
+	return nil
 }
 
 func (c *Collection) columnVectorGraphPhysicalRowReaderSnapshotView(name string) (VectorIndexDefinition, columnVectorGraphManifestSnapshot, columnPhysicalScanSnapshotView, error) {
@@ -402,6 +448,11 @@ func (r *columnVectorGraphPhysicalRowReader) Close() error {
 		return nil
 	}
 	var closeErr error
+	if r.sharedPreparedSearch != nil {
+		if err := r.releaseSharedPreparedSearch(); err != nil {
+			closeErr = err
+		}
+	}
 	if r.typedVectorSource != nil {
 		if err := r.typedVectorSource.Close(); err != nil {
 			closeErr = err

--- a/TreeDB/collections/column_vector_graph_search_source_test.go
+++ b/TreeDB/collections/column_vector_graph_search_source_test.go
@@ -346,6 +346,10 @@ func TestColumnVectorGraphSearchSourcePolicyMatchesLegacy1968(t *testing.T) {
 		}
 	})
 
+	if err := reader.Close(); err != nil {
+		t.Fatalf("close shared policy reader before stale source tests: %v", err)
+	}
+
 	t.Run("stale_prebound_vector_state_fallback", func(t *testing.T) {
 		staleReader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
 		if err != nil {

--- a/TreeDB/collections/column_vector_graph_shared_prepared.go
+++ b/TreeDB/collections/column_vector_graph_shared_prepared.go
@@ -104,7 +104,9 @@ func (c *Collection) acquireColumnVectorGraphSharedPreparedSearch(key string, bu
 			entry.err = err
 			entry.building = false
 			if err != nil {
-				delete(c.vectorPreparedSearch, key)
+				if !errors.Is(err, errColumnVectorGraphSharedPreparedSearchNotEligible) {
+					delete(c.vectorPreparedSearch, key)
+				}
 			} else {
 				entry.refs = 1
 			}
@@ -122,7 +124,15 @@ func (c *Collection) acquireColumnVectorGraphSharedPreparedSearch(key string, bu
 			<-ready
 			continue
 		}
-		if entry.err != nil || entry.holder == nil || !entry.holder.ready() {
+		if entry.err != nil {
+			err := entry.err
+			if !errors.Is(err, errColumnVectorGraphSharedPreparedSearchNotEligible) {
+				delete(c.vectorPreparedSearch, key)
+			}
+			c.vectorPreparedSearchMu.Unlock()
+			return nil, err
+		}
+		if entry.holder == nil || !entry.holder.ready() {
 			delete(c.vectorPreparedSearch, key)
 			c.vectorPreparedSearchMu.Unlock()
 			continue
@@ -294,7 +304,7 @@ func (c *Collection) columnVectorGraphSharedPreparedSearchCacheSnapshot() column
 		CacheBuilds: c.vectorPreparedSearchBuilds,
 	}
 	for _, entry := range c.vectorPreparedSearch {
-		if entry == nil {
+		if entry == nil || (entry.err != nil && entry.holder == nil && !entry.building) {
 			continue
 		}
 		snap.Entries++

--- a/TreeDB/collections/column_vector_graph_shared_prepared.go
+++ b/TreeDB/collections/column_vector_graph_shared_prepared.go
@@ -1,0 +1,490 @@
+package collections
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"sort"
+	"strconv"
+	"sync"
+
+	"github.com/snissn/gomap/TreeDB/internal/mappedresource"
+)
+
+var errColumnVectorGraphSharedPreparedSearchNotEligible = errors.New("collections: column_graph shared prepared search requires an mmap-direct prepared view")
+
+// columnVectorGraphSharedPreparedSearch is the local #1735 seam for immutable
+// prepared column_graph state. It is intentionally a collection-scoped,
+// ref-counted owner around the existing generic mappedresource handles and
+// prepared metadata; it does not define a new vector sidecar lifecycle. The key
+// includes graph/vector-index/base-manifest identity so a future DB-wide
+// mapped-resource manager can replace the backing owner without changing search
+// semantics.
+type columnVectorGraphSharedPreparedSearch struct {
+	key string
+
+	typedVectorSource     *columnVectorGraphTypedColumnVectorSource
+	invNormSource         *columnVectorGraphInvNormStateSource
+	rowRefSource          *columnVectorGraphRowRefStateSource
+	documentIDSource      *columnVectorGraphDocumentIDStateSource
+	adjacencyLayerSources *columnVectorGraphAdjacencyDirectSources
+	preparedSearch        *columnVectorGraphPreparedSearchView
+}
+
+type columnVectorGraphSharedPreparedSearchRef struct {
+	collection *Collection
+	key        string
+	holder     *columnVectorGraphSharedPreparedSearch
+	once       sync.Once
+}
+
+type columnVectorGraphSharedPreparedSearchCacheEntry struct {
+	ready    chan struct{}
+	building bool
+	holder   *columnVectorGraphSharedPreparedSearch
+	err      error
+	refs     int
+}
+
+type columnVectorGraphSharedPreparedSearchCacheSnapshot struct {
+	Entries                    int
+	Refs                       int
+	BuildingEntries            int
+	ActiveHandles              int64
+	ActiveMappedBytes          int64
+	ActiveHeapCopyBytes        int64
+	ActiveDerivedMetadataBytes int64
+	TotalAcquires              uint64
+	TotalReleases              uint64
+	CacheHits                  uint64
+	CacheMisses                uint64
+	CacheWaits                 uint64
+	CacheBuilds                uint64
+	Hits                       uint64
+	Misses                     uint64
+	FallbackReads              uint64
+	Opens                      uint64
+	Closes                     uint64
+	Errors                     uint64
+}
+
+func (c *Collection) acquireColumnVectorGraphSharedPreparedSearch(key string, build func() (*columnVectorGraphSharedPreparedSearch, error)) (*columnVectorGraphSharedPreparedSearchRef, error) {
+	if c == nil {
+		return nil, errCollectionNil
+	}
+	if key == "" {
+		return nil, errors.New("collections: column_graph shared prepared search key is empty")
+	}
+	if build == nil {
+		return nil, errors.New("collections: column_graph shared prepared search build function is nil")
+	}
+	for {
+		c.vectorPreparedSearchMu.Lock()
+		if c.vectorPreparedSearch == nil {
+			c.vectorPreparedSearch = make(map[string]*columnVectorGraphSharedPreparedSearchCacheEntry)
+		}
+		entry := c.vectorPreparedSearch[key]
+		if entry == nil {
+			entry = &columnVectorGraphSharedPreparedSearchCacheEntry{ready: make(chan struct{}), building: true}
+			c.vectorPreparedSearch[key] = entry
+			c.vectorPreparedSearchMisses++
+			c.vectorPreparedSearchBuilds++
+			c.vectorPreparedSearchMu.Unlock()
+
+			holder, err := build()
+			if err == nil && holder == nil {
+				err = errors.New("collections: column_graph shared prepared search build returned nil holder")
+			}
+			if err == nil {
+				holder.key = key
+			}
+
+			c.vectorPreparedSearchMu.Lock()
+			entry.holder = holder
+			entry.err = err
+			entry.building = false
+			if err != nil {
+				delete(c.vectorPreparedSearch, key)
+			} else {
+				entry.refs = 1
+			}
+			close(entry.ready)
+			c.vectorPreparedSearchMu.Unlock()
+			if err != nil {
+				return nil, err
+			}
+			return &columnVectorGraphSharedPreparedSearchRef{collection: c, key: key, holder: holder}, nil
+		}
+		ready := entry.ready
+		if entry.building {
+			c.vectorPreparedSearchWaits++
+			c.vectorPreparedSearchMu.Unlock()
+			<-ready
+			continue
+		}
+		if entry.err != nil || entry.holder == nil || !entry.holder.ready() {
+			delete(c.vectorPreparedSearch, key)
+			c.vectorPreparedSearchMu.Unlock()
+			continue
+		}
+		entry.refs++
+		c.vectorPreparedSearchHits++
+		holder := entry.holder
+		c.vectorPreparedSearchMu.Unlock()
+		return &columnVectorGraphSharedPreparedSearchRef{collection: c, key: key, holder: holder}, nil
+	}
+}
+
+func (r *columnVectorGraphSharedPreparedSearchRef) release() error {
+	if r == nil {
+		return nil
+	}
+	var closeErr error
+	r.once.Do(func() {
+		c := r.collection
+		if c == nil || r.key == "" {
+			return
+		}
+		var holder *columnVectorGraphSharedPreparedSearch
+		c.vectorPreparedSearchMu.Lock()
+		entry := c.vectorPreparedSearch[r.key]
+		if entry != nil && entry.holder == r.holder {
+			if entry.refs > 0 {
+				entry.refs--
+			}
+			if entry.refs == 0 && !entry.building {
+				holder = entry.holder
+				delete(c.vectorPreparedSearch, r.key)
+			}
+		}
+		c.vectorPreparedSearchMu.Unlock()
+		if holder != nil {
+			closeErr = holder.close()
+		}
+	})
+	return closeErr
+}
+
+func newColumnVectorGraphSharedPreparedSearchFromReader(reader *columnVectorGraphPhysicalRowReader) (*columnVectorGraphSharedPreparedSearch, error) {
+	if reader == nil {
+		return nil, errNilColumnVectorGraphPhysicalRowReader
+	}
+	if columnVectorGraphManifestHasPhysicalAsset(reader.graph) {
+		return nil, errors.New("collections: column_graph shared prepared search is disabled for legacy graph-row assets")
+	}
+	if reader.preparedSearch == nil {
+		return nil, errColumnVectorGraphSharedPreparedSearchNotEligible
+	}
+	if !reader.preparedSearch.ready() {
+		return nil, errors.New("collections: column_graph shared prepared search requires ready combined prepared view")
+	}
+	holder := &columnVectorGraphSharedPreparedSearch{
+		typedVectorSource:     reader.typedVectorSource,
+		invNormSource:         reader.invNormSource,
+		rowRefSource:          reader.rowRefSource,
+		documentIDSource:      reader.documentIDSource,
+		adjacencyLayerSources: reader.adjacencyLayerSources,
+		preparedSearch:        reader.preparedSearch,
+	}
+	if !holder.ready() {
+		return nil, errors.New("collections: column_graph shared prepared search holder is not ready")
+	}
+	// Ownership of immutable sources transfers to the shared holder. The build
+	// reader is temporary; the returned worker reader attaches via a ref below.
+	reader.typedVectorSource = nil
+	reader.invNormSource = nil
+	reader.rowRefSource = nil
+	reader.documentIDSource = nil
+	reader.adjacencyLayerSources = nil
+	reader.layer0AdjacencySource = nil
+	reader.preparedSearch = nil
+	return holder, nil
+}
+
+func (h *columnVectorGraphSharedPreparedSearch) ready() bool {
+	return h != nil && h.typedVectorSource != nil && h.invNormSource != nil && h.rowRefSource != nil && h.documentIDSource != nil && h.adjacencyLayerSources != nil && h.preparedSearch != nil && h.preparedSearch.ready()
+}
+
+func (h *columnVectorGraphSharedPreparedSearch) close() error {
+	if h == nil {
+		return nil
+	}
+	var closeErr error
+	if h.typedVectorSource != nil {
+		if err := h.typedVectorSource.Close(); err != nil && closeErr == nil {
+			closeErr = err
+		}
+		h.typedVectorSource = nil
+	}
+	if h.invNormSource != nil {
+		if err := h.invNormSource.Close(); err != nil && closeErr == nil {
+			closeErr = err
+		}
+		h.invNormSource = nil
+	}
+	if h.rowRefSource != nil {
+		if err := h.rowRefSource.Close(); err != nil && closeErr == nil {
+			closeErr = err
+		}
+		h.rowRefSource = nil
+	}
+	if h.documentIDSource != nil {
+		if err := h.documentIDSource.Close(); err != nil && closeErr == nil {
+			closeErr = err
+		}
+		h.documentIDSource = nil
+	}
+	if h.adjacencyLayerSources != nil {
+		if err := h.adjacencyLayerSources.Close(); err != nil && closeErr == nil {
+			closeErr = err
+		}
+		h.adjacencyLayerSources = nil
+	}
+	h.preparedSearch = nil
+	return closeErr
+}
+
+func (r *columnVectorGraphPhysicalRowReader) attachSharedPreparedSearch(ref *columnVectorGraphSharedPreparedSearchRef) error {
+	if r == nil {
+		return errNilColumnVectorGraphPhysicalRowReader
+	}
+	if ref == nil || ref.holder == nil || !ref.holder.ready() {
+		return errors.New("collections: column_graph shared prepared search ref is not ready")
+	}
+	h := ref.holder
+	r.sharedPreparedSearch = ref
+	r.typedVectorSource = h.typedVectorSource
+	r.invNormSource = h.invNormSource
+	r.rowRefSource = h.rowRefSource
+	r.documentIDSource = h.documentIDSource
+	r.adjacencyLayerSources = h.adjacencyLayerSources
+	if h.adjacencyLayerSources != nil && len(h.adjacencyLayerSources.sources) > 0 {
+		r.layer0AdjacencySource = h.adjacencyLayerSources.sources[0]
+	}
+	r.preparedSearch = h.preparedSearch
+	return nil
+}
+
+func (r *columnVectorGraphPhysicalRowReader) releaseSharedPreparedSearch() error {
+	if r == nil || r.sharedPreparedSearch == nil {
+		return nil
+	}
+	ref := r.sharedPreparedSearch
+	r.sharedPreparedSearch = nil
+	r.typedVectorSource = nil
+	r.invNormSource = nil
+	r.rowRefSource = nil
+	r.documentIDSource = nil
+	r.adjacencyLayerSources = nil
+	r.layer0AdjacencySource = nil
+	r.preparedSearch = nil
+	return ref.release()
+}
+
+func (c *Collection) columnVectorGraphSharedPreparedSearchCacheSnapshot() columnVectorGraphSharedPreparedSearchCacheSnapshot {
+	if c == nil {
+		return columnVectorGraphSharedPreparedSearchCacheSnapshot{}
+	}
+	c.vectorPreparedSearchMu.Lock()
+	defer c.vectorPreparedSearchMu.Unlock()
+	snap := columnVectorGraphSharedPreparedSearchCacheSnapshot{
+		CacheHits:   c.vectorPreparedSearchHits,
+		CacheMisses: c.vectorPreparedSearchMisses,
+		CacheWaits:  c.vectorPreparedSearchWaits,
+		CacheBuilds: c.vectorPreparedSearchBuilds,
+	}
+	for _, entry := range c.vectorPreparedSearch {
+		if entry == nil {
+			continue
+		}
+		snap.Entries++
+		snap.Refs += entry.refs
+		if entry.building {
+			snap.BuildingEntries++
+		}
+		if entry.holder != nil {
+			snap.add(entry.holder.stats())
+		}
+	}
+	return snap
+}
+
+func (s *columnVectorGraphSharedPreparedSearchCacheSnapshot) add(stats mappedresource.Stats) {
+	if s == nil {
+		return
+	}
+	s.ActiveHandles += stats.ActiveHandles
+	s.ActiveMappedBytes += stats.ActiveMappedBytes
+	s.ActiveHeapCopyBytes += stats.ActiveHeapCopyBytes
+	s.ActiveDerivedMetadataBytes += stats.ActiveDerivedMetadataBytes
+	s.TotalAcquires += stats.TotalAcquires
+	s.TotalReleases += stats.TotalReleases
+	s.Hits += stats.Hits
+	s.Misses += stats.Misses
+	s.FallbackReads += stats.FallbackReads
+	s.Opens += stats.Opens
+	s.Closes += stats.Closes
+	s.Errors += stats.Errors
+}
+
+func (h *columnVectorGraphSharedPreparedSearch) stats() mappedresource.Stats {
+	if h == nil {
+		return mappedresource.Stats{}
+	}
+	var out mappedresource.Stats
+	add := func(stats mappedresource.Stats) {
+		out.ActiveHandles += stats.ActiveHandles
+		out.ActiveMappedBytes += stats.ActiveMappedBytes
+		out.ActiveHeapCopyBytes += stats.ActiveHeapCopyBytes
+		out.ActiveDerivedMetadataBytes += stats.ActiveDerivedMetadataBytes
+		out.TotalAcquires += stats.TotalAcquires
+		out.TotalReleases += stats.TotalReleases
+		out.TotalMappedBytes += stats.TotalMappedBytes
+		out.TotalHeapCopyBytes += stats.TotalHeapCopyBytes
+		out.TotalDerivedMetadataBytes += stats.TotalDerivedMetadataBytes
+		out.Hits += stats.Hits
+		out.Misses += stats.Misses
+		out.FallbackReads += stats.FallbackReads
+		out.Opens += stats.Opens
+		out.Closes += stats.Closes
+		out.Errors += stats.Errors
+		out.DirectViewSuccesses += stats.DirectViewSuccesses
+		out.DirectViewFailures += stats.DirectViewFailures
+	}
+	if h.typedVectorSource != nil && h.typedVectorSource.manager != nil {
+		add(h.typedVectorSource.manager.Stats())
+	}
+	if h.invNormSource != nil && h.invNormSource.manager != nil {
+		add(h.invNormSource.manager.Stats())
+	}
+	if h.rowRefSource != nil && h.rowRefSource.manager != nil {
+		add(h.rowRefSource.manager.Stats())
+	}
+	if h.documentIDSource != nil && h.documentIDSource.manager != nil {
+		add(h.documentIDSource.manager.Stats())
+	}
+	if h.adjacencyLayerSources != nil {
+		for _, source := range h.adjacencyLayerSources.sources {
+			if source != nil && source.manager != nil {
+				add(source.manager.Stats())
+			}
+		}
+	}
+	return out
+}
+
+func columnVectorGraphSharedPreparedSearchCacheKey(collection string, namespace string, def VectorIndexDefinition, graph columnVectorGraphManifestSnapshot, state columnVectorIndexStateSnapshot) (string, error) {
+	if collection == "" || namespace == "" || def.Name == "" || graph.IndexName == "" || state.IndexName == "" {
+		return "", errors.New("collections: column_graph shared prepared search key requires collection, namespace, graph, and state identity")
+	}
+	var b bytes.Buffer
+	writeKeyString := func(label, value string) {
+		b.WriteString(label)
+		b.WriteByte('=')
+		b.WriteString(strconv.Itoa(len(value)))
+		b.WriteByte(':')
+		b.WriteString(value)
+		b.WriteByte('|')
+	}
+	writeKeyInt := func(label string, value int) {
+		b.WriteString(label)
+		b.WriteByte('=')
+		b.WriteString(strconv.Itoa(value))
+		b.WriteByte('|')
+	}
+	writeKeyU64 := func(label string, value uint64) {
+		b.WriteString(label)
+		b.WriteByte('=')
+		b.WriteString(strconv.FormatUint(value, 10))
+		b.WriteByte('|')
+	}
+	writeKeyI64 := func(label string, value int64) {
+		b.WriteString(label)
+		b.WriteByte('=')
+		b.WriteString(strconv.FormatInt(value, 10))
+		b.WriteByte('|')
+	}
+	writeKeyU32 := func(label string, value uint32) {
+		b.WriteString(label)
+		b.WriteByte('=')
+		b.WriteString(strconv.FormatUint(uint64(value), 10))
+		b.WriteByte('|')
+	}
+	writeRef := func(prefix string, ref ColumnAssetRef) {
+		writeKeyString(prefix+".kind", string(ref.Kind))
+		writeKeyString(prefix+".namespace", ref.Namespace)
+		writeKeyU64(prefix+".generation", ref.Generation)
+		writeKeyU64(prefix+".part_id", ref.PartID)
+		writeKeyU32(prefix+".file_id", ref.FileID)
+		writeKeyI64(prefix+".offset", ref.Offset)
+		writeKeyI64(prefix+".length", ref.Length)
+		writeKeyU32(prefix+".checksum", ref.Checksum)
+	}
+
+	writeKeyString("collection", collection)
+	writeKeyString("namespace", namespace)
+	writeKeyString("index", def.Name)
+	writeKeyString("field", def.Field)
+	writeKeyString("metric", def.Metric.String())
+	writeKeyString("encoding", def.Encoding.String())
+	writeKeyInt("dims", def.Dimensions)
+	writeKeyInt("m", def.M)
+	writeKeyInt("ef_construction", def.EfConstruction)
+	writeKeyInt("ef_search", def.EfSearch)
+
+	writeKeyString("graph.index", graph.IndexName)
+	writeKeyString("graph.field", graph.Field)
+	writeKeyString("graph.metric", graph.Metric.String())
+	writeKeyString("graph.encoding", graph.Encoding.String())
+	writeKeyInt("graph.dims", graph.Dimensions)
+	writeKeyInt("graph.m", graph.M)
+	writeKeyInt("graph.ef_construction", graph.EfConstruction)
+	writeKeyInt("graph.ef_search", graph.EfSearch)
+	writeKeyU64("graph.base_generation", graph.BaseManifestGeneration)
+	writeKeyU64("graph.base_checksum", graph.BaseManifestChecksum)
+	writeKeyU64("graph.base_schema", graph.BaseSchemaHash)
+	writeKeyU64("graph.schema", graph.GraphSchemaHash)
+	writeKeyInt("graph.rows", graph.RowCount)
+	writeKeyInt("graph.layers", graph.AdjacencyLayerCount)
+	writeRef("graph.asset", graph.AssetRef)
+
+	writeKeyString("state.index", state.IndexName)
+	writeKeyString("state.field", state.Field)
+	writeKeyString("state.metric", state.Metric.String())
+	writeKeyString("state.encoding", state.Encoding.String())
+	writeKeyInt("state.dims", state.Dimensions)
+	writeKeyInt("state.m", state.M)
+	writeKeyInt("state.ef_construction", state.EfConstruction)
+	writeKeyInt("state.ef_search", state.EfSearch)
+	writeKeyInt("state.rows", state.RowCount)
+	writeKeyU64("state.base_generation", state.BaseManifestGeneration)
+	writeKeyU64("state.base_checksum", state.BaseManifestChecksum)
+	writeKeyU64("state.base_schema", state.BaseSchemaHash)
+	writeKeyInt("state.layers", state.AdjacencyLayerCount)
+	assets := append([]columnVectorIndexStateAssetSnapshot(nil), state.Assets...)
+	sort.SliceStable(assets, func(i, j int) bool {
+		if assets[i].Role != assets[j].Role {
+			return assets[i].Role < assets[j].Role
+		}
+		if assets[i].AssetID != assets[j].AssetID {
+			return assets[i].AssetID < assets[j].AssetID
+		}
+		if assets[i].LogicalType != assets[j].LogicalType {
+			return assets[i].LogicalType < assets[j].LogicalType
+		}
+		return assets[i].PhysicalEncoding < assets[j].PhysicalEncoding
+	})
+	writeKeyInt("state.assets", len(assets))
+	for i, asset := range assets {
+		prefix := fmt.Sprintf("state.asset.%d", i)
+		writeKeyString(prefix+".role", asset.Role)
+		writeKeyString(prefix+".asset_id", asset.AssetID)
+		writeKeyString(prefix+".logical", asset.LogicalType)
+		writeKeyString(prefix+".physical", asset.PhysicalEncoding)
+		writeKeyInt(prefix+".rows", asset.RowCount)
+		writeKeyU64(prefix+".source_schema", asset.SourceSchemaHash)
+		writeKeyI64(prefix+".bytes", asset.AssetBytes)
+		writeRef(prefix+".ref", asset.Ref)
+	}
+	return b.String(), nil
+}

--- a/TreeDB/collections/column_vector_graph_shared_prepared_rss_unix_test.go
+++ b/TreeDB/collections/column_vector_graph_shared_prepared_rss_unix_test.go
@@ -1,0 +1,22 @@
+//go:build !windows
+
+package collections
+
+import (
+	"runtime"
+	"syscall"
+)
+
+func processMaxRSSBytes1735() uint64 {
+	var usage syscall.Rusage
+	if err := syscall.Getrusage(syscall.RUSAGE_SELF, &usage); err != nil || usage.Maxrss <= 0 {
+		return 0
+	}
+	maxRSS := uint64(usage.Maxrss)
+	switch runtime.GOOS {
+	case "linux", "freebsd", "openbsd", "netbsd":
+		return maxRSS * 1024
+	default:
+		return maxRSS
+	}
+}

--- a/TreeDB/collections/column_vector_graph_shared_prepared_rss_windows_test.go
+++ b/TreeDB/collections/column_vector_graph_shared_prepared_rss_windows_test.go
@@ -1,0 +1,7 @@
+//go:build windows
+
+package collections
+
+func processMaxRSSBytes1735() uint64 {
+	return 0
+}

--- a/TreeDB/collections/column_vector_graph_shared_prepared_test.go
+++ b/TreeDB/collections/column_vector_graph_shared_prepared_test.go
@@ -1,0 +1,297 @@
+package collections
+
+import (
+	"fmt"
+	"runtime"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestVectorIndexSearcherSharedPreparedResourceCounters1735(t *testing.T) {
+	if !columnGraphTypedColumnMmapDirectViewSupportedForTest() {
+		t.Skip("shared prepared public-searcher resource test requires mmap_direct support")
+	}
+	rows := columnGraphRebuildSyntheticRowsV2A(128, 16)
+	_, d, col, def := openColumnGraphTypedColumnVectorTestCollection1782(t, 16, 8, rows)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	const workers = 3
+	searchers := make([]*VectorIndexSearcher, workers)
+	defer func() {
+		for _, searcher := range searchers {
+			_ = searcher.Close()
+		}
+	}()
+	for i := range searchers {
+		searcher, err := col.OpenVectorIndexSearcher(VectorIndexSearcherOptions{IndexName: def.Name, MaxDecodedBlocks: 1})
+		if err != nil {
+			t.Fatalf("OpenVectorIndexSearcher worker %d: %v", i, err)
+		}
+		searchers[i] = searcher
+	}
+	snap := col.columnVectorGraphSharedPreparedSearchCacheSnapshot()
+	if snap.Entries != 1 || snap.Refs != workers || snap.CacheBuilds != 1 || snap.CacheMisses != 1 || snap.CacheHits != workers-1 || snap.ActiveHandles == 0 || snap.ActiveMappedBytes == 0 || snap.ActiveHeapCopyBytes != 0 {
+		t.Fatalf("shared prepared public-searcher snapshot=%+v want one mmap-backed holder with %d refs", snap, workers)
+	}
+	query := append([]float32(nil), rows[11].vector...)
+	opts := VectorIndexSearcherSearchOptions{Query: query, TopK: 8, EfSearch: 64, StatsMode: VectorIndexSearchStatsModeProduction}
+	baseline, err := searchers[0].SearchWithBuffer(opts, &VectorIndexSearchBuffer{})
+	if err != nil {
+		t.Fatalf("baseline SearchWithBuffer: %v", err)
+	}
+	var wg sync.WaitGroup
+	errs := make(chan string, workers)
+	for worker := range searchers {
+		worker := worker
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			var buffer VectorIndexSearchBuffer
+			for i := 0; i < 10; i++ {
+				got, err := searchers[worker].SearchWithBuffer(opts, &buffer)
+				if err != nil {
+					errs <- fmt.Sprintf("worker %d SearchWithBuffer: %v", worker, err)
+					return
+				}
+				if len(got.Results) != len(baseline.Results) || len(got.Results) == 0 || got.Results[0].Ordinal != baseline.Results[0].Ordinal {
+					errs <- fmt.Sprintf("worker %d iteration %d top result=%v baseline=%v", worker, i, got.Results, baseline.Results)
+					return
+				}
+				if got.Stats.PreparedGraphSearchViews != 1 || got.Stats.TypedColumnFallbacks != 0 || got.Stats.GraphRowFallbacks != 0 || got.Stats.ResultIDGraphFallbacks != 0 {
+					errs <- fmt.Sprintf("worker %d stats=%+v want prepared current-format path", worker, got.Stats)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Error(err)
+	}
+	if t.Failed() {
+		return
+	}
+	if err := searchers[0].Close(); err != nil {
+		t.Fatalf("close searcher 0: %v", err)
+	}
+	searchers[0] = nil
+	afterFirstClose := col.columnVectorGraphSharedPreparedSearchCacheSnapshot()
+	if afterFirstClose.Entries != 1 || afterFirstClose.Refs != workers-1 || afterFirstClose.ActiveHandles != snap.ActiveHandles || afterFirstClose.ActiveMappedBytes != snap.ActiveMappedBytes {
+		t.Fatalf("shared prepared after first close=%+v initial=%+v want remaining refs to retain one holder", afterFirstClose, snap)
+	}
+	if _, err := searchers[1].SearchWithBuffer(opts, &VectorIndexSearchBuffer{}); err != nil {
+		t.Fatalf("searcher 1 SearchWithBuffer after searcher 0 close: %v", err)
+	}
+	for i := range searchers {
+		if searchers[i] != nil {
+			if err := searchers[i].Close(); err != nil {
+				t.Fatalf("close searcher %d: %v", i, err)
+			}
+			searchers[i] = nil
+		}
+	}
+	afterAllClosed := col.columnVectorGraphSharedPreparedSearchCacheSnapshot()
+	if afterAllClosed.Entries != 0 || afterAllClosed.Refs != 0 || afterAllClosed.ActiveHandles != 0 || afterAllClosed.ActiveMappedBytes != 0 {
+		t.Fatalf("shared prepared after all searchers closed=%+v want no active shared resources", afterAllClosed)
+	}
+}
+
+func TestColumnVectorGraphSharedPreparedSearchCacheKeyCanonicalizesStateAssets1735(t *testing.T) {
+	def := VectorIndexDefinition{Name: "vec", Field: "embedding", Strategy: VectorIndexStrategyColumnGraph, Metric: VectorMetricCosine, Encoding: VectorIndexEncodingFloat32, Dimensions: 4, M: 8, EfConstruction: 32, EfSearch: 64}
+	graph := columnVectorGraphManifestSnapshot{IndexName: def.Name, Field: def.Field, Metric: def.Metric, Encoding: def.Encoding, Dimensions: def.Dimensions, M: def.M, EfConstruction: def.EfConstruction, EfSearch: def.EfSearch, BaseManifestGeneration: 7, BaseManifestChecksum: 11, BaseSchemaHash: 13, GraphSchemaHash: 17, RowCount: 2, AdjacencyLayerCount: 1}
+	assetA := columnVectorIndexStateAssetSnapshot{Role: columnVectorIndexStateAssetRoleInverseNorm, AssetID: columnVectorGraphInvNormStateAssetID, LogicalType: columnVectorIndexStateLogicalTypeFloat32, PhysicalEncoding: columnVectorIndexStateEncodingRawFloat32, RowCount: 2, SourceSchemaHash: 101, AssetBytes: 16, Ref: ColumnAssetRef{Kind: ColumnAssetKindTCS1TypedColumnPart, Namespace: "ns", Generation: 7, PartID: 1, FileID: 2, Offset: 3, Length: 16, Checksum: 5}}
+	assetB := columnVectorIndexStateAssetSnapshot{Role: columnVectorIndexStateAssetRoleAdjacency, AssetID: columnVectorIndexStateAdjacencyAssetID(0), LogicalType: columnVectorIndexStateLogicalTypeUint32List, PhysicalEncoding: columnVectorIndexStateEncodingRawUint32List, RowCount: 2, SourceSchemaHash: 103, AssetBytes: 24, Ref: ColumnAssetRef{Kind: ColumnAssetKindTCS1TypedColumnPart, Namespace: "ns", Generation: 7, PartID: 2, FileID: 3, Offset: 4, Length: 24, Checksum: 6}}
+	state := columnVectorIndexStateSnapshot{IndexName: def.Name, Field: def.Field, Metric: def.Metric, Encoding: def.Encoding, Dimensions: def.Dimensions, M: def.M, EfConstruction: def.EfConstruction, EfSearch: def.EfSearch, RowCount: 2, BaseManifestGeneration: 7, BaseManifestChecksum: 11, BaseSchemaHash: 13, AdjacencyLayerCount: 1, Assets: []columnVectorIndexStateAssetSnapshot{assetA, assetB}}
+	keyAB, err := columnVectorGraphSharedPreparedSearchCacheKey("docs", "ns", def, graph, state)
+	if err != nil {
+		t.Fatalf("cache key AB: %v", err)
+	}
+	state.Assets = []columnVectorIndexStateAssetSnapshot{assetB, assetA}
+	keyBA, err := columnVectorGraphSharedPreparedSearchCacheKey("docs", "ns", def, graph, state)
+	if err != nil {
+		t.Fatalf("cache key BA: %v", err)
+	}
+	if keyAB != keyBA {
+		t.Fatalf("cache keys differ after asset reordering\nAB=%s\nBA=%s", keyAB, keyBA)
+	}
+}
+
+func BenchmarkVectorSearchSharedPreparedOpenWarmupResources1735(b *testing.B) {
+	if !columnGraphTypedColumnMmapDirectViewSupportedForTest() {
+		b.Skip("shared prepared resource benchmark requires mmap_direct support")
+	}
+	for _, workers := range []int{1, 4, 8} {
+		workers := workers
+		b.Run(fmt.Sprintf("workers=%d", workers), func(b *testing.B) {
+			benchmarkVectorSearchSharedPreparedOpenWarmupResources1735(b, workers)
+		})
+	}
+}
+
+func benchmarkVectorSearchSharedPreparedOpenWarmupResources1735(b *testing.B, workers int) {
+	b.Helper()
+	const (
+		rows     = 8192
+		dims     = 128
+		m        = 16
+		topK     = 10
+		efSearch = 128
+	)
+	input := columnGraphRebuildSyntheticRowsV2A(rows, dims)
+	_, d, col, def := openColumnGraphTypedColumnVectorTestCollection1782(b, dims, m, input)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		b.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	query := append([]float32(nil), input[37].vector...)
+	opts := VectorIndexSearcherSearchOptions{Query: query, TopK: topK, EfSearch: efSearch, StatsMode: VectorIndexSearchStatsModeProduction}
+	sample, err := openWarmCloseVectorSearchersSharedPrepared1735(col, def.Name, opts, workers, true)
+	if err != nil {
+		b.Fatalf("sample open/warm/close: %v", err)
+	}
+	if sample.snapshot.Entries != 1 || sample.snapshot.Refs != workers || sample.snapshot.CacheBuilds == 0 || sample.snapshot.ActiveHandles == 0 || sample.snapshot.ActiveMappedBytes == 0 || sample.snapshot.ActiveHeapCopyBytes != 0 {
+		b.Fatalf("sample shared prepared snapshot=%+v want one mmap-backed holder with %d refs", sample.snapshot, workers)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := openWarmCloseVectorSearchersSharedPrepared1735(col, def.Name, opts, workers, false); err != nil {
+			b.Fatalf("iteration %d open/warm/close: %v", i, err)
+		}
+	}
+	b.StopTimer()
+	reportColumnVectorGraphSharedPreparedSearchBenchMetrics1735(b, sample.snapshot, workers)
+	b.ReportMetric(float64(rows), "graph_rows")
+	b.ReportMetric(float64(topK), "top_k")
+	b.ReportMetric(float64(efSearch), "ef_search")
+	b.ReportMetric(float64(sample.openPrepareNanos)/float64(workers), "open_prepare_ns/worker")
+	b.ReportMetric(float64(sample.warmupNanos)/float64(workers), "warmup_ns/worker")
+	if sample.heapAllocBytes > 0 {
+		b.ReportMetric(float64(sample.heapAllocBytes), "heap_alloc_B")
+	}
+	if sample.heapAllocDeltaBytes > 0 {
+		b.ReportMetric(float64(sample.heapAllocDeltaBytes), "heap_alloc_delta_B")
+	}
+	if sample.maxRSSBytes > 0 {
+		b.ReportMetric(float64(sample.maxRSSBytes), "process_maxrss_B")
+	}
+	if sample.maxRSSDeltaBytes > 0 {
+		b.ReportMetric(float64(sample.maxRSSDeltaBytes), "process_maxrss_delta_B")
+	}
+}
+
+type columnVectorGraphSharedPreparedOpenWarmupSample1735 struct {
+	snapshot            columnVectorGraphSharedPreparedSearchCacheSnapshot
+	openPrepareNanos    int64
+	warmupNanos         int64
+	heapAllocBytes      uint64
+	heapAllocDeltaBytes uint64
+	maxRSSBytes         uint64
+	maxRSSDeltaBytes    uint64
+}
+
+func openWarmCloseVectorSearchersSharedPrepared1735(col *Collection, indexName string, opts VectorIndexSearcherSearchOptions, workers int, captureMemory bool) (columnVectorGraphSharedPreparedOpenWarmupSample1735, error) {
+	var sample columnVectorGraphSharedPreparedOpenWarmupSample1735
+	if workers <= 0 {
+		return sample, fmt.Errorf("workers=%d", workers)
+	}
+	var heapBefore uint64
+	var rssBefore uint64
+	if captureMemory {
+		heapBefore = runtimeHeapAllocBytes1735()
+		rssBefore = processMaxRSSBytes1735()
+	}
+	searchers := make([]*VectorIndexSearcher, workers)
+	defer func() {
+		for _, searcher := range searchers {
+			_ = searcher.Close()
+		}
+	}()
+	openStart := time.Now()
+	for i := range searchers {
+		searcher, err := col.OpenVectorIndexSearcher(VectorIndexSearcherOptions{IndexName: indexName, MaxDecodedBlocks: 1})
+		if err != nil {
+			return sample, fmt.Errorf("OpenVectorIndexSearcher worker %d: %w", i, err)
+		}
+		searchers[i] = searcher
+	}
+	sample.openPrepareNanos = time.Since(openStart).Nanoseconds()
+	buffers := make([]VectorIndexSearchBuffer, workers)
+	warmStart := time.Now()
+	for i, searcher := range searchers {
+		got, err := searcher.SearchWithBuffer(opts, &buffers[i])
+		if err != nil {
+			return sample, fmt.Errorf("warm SearchWithBuffer worker %d: %w", i, err)
+		}
+		if len(got.Results) == 0 {
+			return sample, fmt.Errorf("warm SearchWithBuffer worker %d returned no results", i)
+		}
+		if got.Stats.PreparedGraphSearchViews != 1 || got.Stats.TypedColumnFallbacks != 0 || got.Stats.GraphRowFallbacks != 0 || got.Stats.ResultIDGraphFallbacks != 0 {
+			return sample, fmt.Errorf("warm SearchWithBuffer worker %d stats=%+v want shared prepared current-format path", i, got.Stats)
+		}
+	}
+	sample.warmupNanos = time.Since(warmStart).Nanoseconds()
+	sample.snapshot = col.columnVectorGraphSharedPreparedSearchCacheSnapshot()
+	if captureMemory {
+		heapAfter := runtimeHeapAllocBytes1735()
+		sample.heapAllocBytes = heapAfter
+		if heapAfter > heapBefore {
+			sample.heapAllocDeltaBytes = heapAfter - heapBefore
+		}
+		rssAfter := processMaxRSSBytes1735()
+		sample.maxRSSBytes = rssAfter
+		if rssAfter > rssBefore {
+			sample.maxRSSDeltaBytes = rssAfter - rssBefore
+		}
+	}
+	return sample, nil
+}
+
+func reportColumnVectorGraphSharedPreparedSearchBenchMetrics1735(b *testing.B, snap columnVectorGraphSharedPreparedSearchCacheSnapshot, workers int) {
+	b.Helper()
+	b.ReportMetric(float64(snap.Entries), "shared_prepared_entries")
+	b.ReportMetric(float64(snap.Refs), "shared_prepared_refs")
+	b.ReportMetric(float64(snap.BuildingEntries), "shared_prepared_building_entries")
+	b.ReportMetric(float64(snap.CacheBuilds), "shared_prepared_builds")
+	b.ReportMetric(float64(snap.CacheMisses), "shared_prepared_cache_misses")
+	b.ReportMetric(float64(snap.CacheHits), "shared_prepared_cache_hits")
+	b.ReportMetric(float64(snap.CacheWaits), "shared_prepared_cache_waits")
+	b.ReportMetric(float64(snap.ActiveHandles), "shared_prepared_active_handles")
+	b.ReportMetric(float64(snap.ActiveMappedBytes), "shared_prepared_mapped_B")
+	b.ReportMetric(float64(snap.ActiveHeapCopyBytes), "shared_prepared_heap_copy_B")
+	b.ReportMetric(float64(snap.ActiveDerivedMetadataBytes), "shared_prepared_derived_metadata_B")
+	b.ReportMetric(float64(snap.TotalAcquires), "shared_prepared_total_acquires")
+	b.ReportMetric(float64(snap.TotalReleases), "shared_prepared_total_releases")
+	b.ReportMetric(float64(snap.FallbackReads), "shared_prepared_fallback_reads")
+	if workers > 0 {
+		b.ReportMetric(float64(workers), "parallel_workers")
+		b.ReportMetric(float64(snap.ActiveHandles)/float64(workers), "shared_prepared_active_handles/worker")
+		b.ReportMetric(float64(snap.ActiveMappedBytes)/float64(workers), "shared_prepared_mapped_B/worker")
+	}
+}
+
+func runtimeHeapAllocBytes1735() uint64 {
+	runtime.GC()
+	var mem runtime.MemStats
+	runtime.ReadMemStats(&mem)
+	return mem.HeapAlloc
+}
+
+func processMaxRSSBytes1735() uint64 {
+	var usage syscall.Rusage
+	if err := syscall.Getrusage(syscall.RUSAGE_SELF, &usage); err != nil || usage.Maxrss <= 0 {
+		return 0
+	}
+	maxRSS := uint64(usage.Maxrss)
+	switch runtime.GOOS {
+	case "linux", "freebsd", "openbsd", "netbsd":
+		return maxRSS * 1024
+	default:
+		return maxRSS
+	}
+}

--- a/TreeDB/collections/column_vector_graph_shared_prepared_test.go
+++ b/TreeDB/collections/column_vector_graph_shared_prepared_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"runtime"
 	"sync"
-	"syscall"
 	"testing"
 	"time"
 )
@@ -280,18 +279,4 @@ func runtimeHeapAllocBytes1735() uint64 {
 	var mem runtime.MemStats
 	runtime.ReadMemStats(&mem)
 	return mem.HeapAlloc
-}
-
-func processMaxRSSBytes1735() uint64 {
-	var usage syscall.Rusage
-	if err := syscall.Getrusage(syscall.RUSAGE_SELF, &usage); err != nil || usage.Maxrss <= 0 {
-		return 0
-	}
-	maxRSS := uint64(usage.Maxrss)
-	switch runtime.GOOS {
-	case "linux", "freebsd", "openbsd", "netbsd":
-		return maxRSS * 1024
-	default:
-		return maxRSS
-	}
 }

--- a/TreeDB/collections/column_vector_graph_shared_prepared_test.go
+++ b/TreeDB/collections/column_vector_graph_shared_prepared_test.go
@@ -1,6 +1,7 @@
 package collections
 
 import (
+	"errors"
 	"fmt"
 	"runtime"
 	"sync"
@@ -97,6 +98,27 @@ func TestVectorIndexSearcherSharedPreparedResourceCounters1735(t *testing.T) {
 	afterAllClosed := col.columnVectorGraphSharedPreparedSearchCacheSnapshot()
 	if afterAllClosed.Entries != 0 || afterAllClosed.Refs != 0 || afterAllClosed.ActiveHandles != 0 || afterAllClosed.ActiveMappedBytes != 0 {
 		t.Fatalf("shared prepared after all searchers closed=%+v want no active shared resources", afterAllClosed)
+	}
+}
+
+func TestColumnVectorGraphSharedPreparedSearchCachesNotEligible1735(t *testing.T) {
+	col := &Collection{}
+	builds := 0
+	for i := 0; i < 2; i++ {
+		_, err := col.acquireColumnVectorGraphSharedPreparedSearch("not-eligible", func() (*columnVectorGraphSharedPreparedSearch, error) {
+			builds++
+			return nil, errColumnVectorGraphSharedPreparedSearchNotEligible
+		})
+		if !errors.Is(err, errColumnVectorGraphSharedPreparedSearchNotEligible) {
+			t.Fatalf("acquire %d err=%v want not-eligible sentinel", i, err)
+		}
+	}
+	if builds != 1 {
+		t.Fatalf("not-eligible builds=%d want one negative-cached build", builds)
+	}
+	snap := col.columnVectorGraphSharedPreparedSearchCacheSnapshot()
+	if snap.Entries != 0 || snap.CacheBuilds != 1 || snap.CacheMisses != 1 || snap.CacheHits != 0 {
+		t.Fatalf("not-eligible snapshot=%+v want inactive negative cache entry with one build/miss", snap)
 	}
 }
 

--- a/TreeDB/collections/column_vector_graph_typed_column_test.go
+++ b/TreeDB/collections/column_vector_graph_typed_column_test.go
@@ -578,7 +578,10 @@ func TestColumnVectorGraphTypedColumnVectorMisalignedSectionUsesScratchFallback1
 	}
 }
 
-func TestColumnVectorGraphTypedColumnVectorParallelReadersIndependentHandles1898(t *testing.T) {
+func TestColumnVectorGraphTypedColumnVectorParallelReadersSharePreparedHandles1735(t *testing.T) {
+	if !columnGraphTypedColumnMmapDirectViewSupportedForTest() {
+		t.Skip("shared prepared handle test requires mmap_direct support")
+	}
 	const (
 		rows = 96
 		dims = 16
@@ -607,19 +610,24 @@ func TestColumnVectorGraphTypedColumnVectorParallelReadersIndependentHandles1898
 			t.Fatalf("open reader %d: %v", i, err)
 		}
 		defer func(reader *columnVectorGraphPhysicalRowReader) { _ = reader.Close() }(reader)
-		if reader.typedVectorSource == nil || reader.typedVectorSource.manager == nil {
-			t.Fatalf("reader %d missing typed-column vector source", i)
+		if reader.typedVectorSource == nil || reader.typedVectorSource.manager == nil || reader.preparedSearch == nil {
+			t.Fatalf("reader %d missing shared prepared typed-column vector source", i)
 		}
-		if i > 0 && reader.typedVectorSource.manager == readers[0].typedVectorSource.manager {
-			t.Fatalf("reader %d shares typed-column vector manager with reader 0", i)
+		if i > 0 {
+			if reader.sharedPreparedSearch == nil || readers[0].sharedPreparedSearch == nil || reader.sharedPreparedSearch.holder != readers[0].sharedPreparedSearch.holder {
+				t.Fatalf("reader %d did not share prepared search holder with reader 0", i)
+			}
+			if reader.typedVectorSource.manager != readers[0].typedVectorSource.manager {
+				t.Fatalf("reader %d typed-column vector manager differs from reader 0; want shared immutable manager", i)
+			}
 		}
 		resourceStats := reader.typedVectorSource.manager.Stats()
 		if columnGraphTypedColumnMmapDirectViewSupportedForTest() {
 			if resourceStats.ActiveMappedBytes == 0 || resourceStats.ActiveHandles == 0 {
-				t.Fatalf("reader %d resource stats=%+v want independent mmap handles", i, resourceStats)
+				t.Fatalf("reader %d resource stats=%+v want shared mmap handles", i, resourceStats)
 			}
 		} else if resourceStats.ActiveHandles == 0 && reader.typedVectorSource.decodedDerivedBytes == 0 {
-			t.Fatalf("reader %d resource stats=%+v decoded=%d want independent heap-copy or scratch source", i, resourceStats, reader.typedVectorSource.decodedDerivedBytes)
+			t.Fatalf("reader %d resource stats=%+v decoded=%d want shared heap-copy or scratch source", i, resourceStats, reader.typedVectorSource.decodedDerivedBytes)
 		}
 		readers[i] = reader
 	}

--- a/TreeDB/collections/vector_index_search.go
+++ b/TreeDB/collections/vector_index_search.go
@@ -491,8 +491,11 @@ func (b *VectorIndexSearchBuffer) resetView() {
 
 // VectorIndexSearcher is a reusable, snapshot-bound vector index search handle.
 // It is not concurrency-safe; parallel query workers should open independent
-// searchers. Close and reopen the searcher after writes/rebuilds when callers
-// need the newest column_graph generation.
+// searchers/buffers. Current-format column_graph searchers opened over the same
+// immutable generation share prepared mmap/resource views internally, so worker
+// isolation applies to mutable scratch/result buffers rather than immutable
+// typed-column assets. Close and reopen the searcher after writes/rebuilds when
+// callers need the newest column_graph generation.
 type VectorIndexSearcher struct {
 	collection   *Collection
 	indexName    string

--- a/TreeDB/collections/vector_index_search_test.go
+++ b/TreeDB/collections/vector_index_search_test.go
@@ -2104,7 +2104,6 @@ func benchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderParallelW
 		}
 	}
 	b.SetParallelism(1)
-	b.ReportMetric(float64(workers), "parallel_workers")
 	b.ReportAllocs()
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
@@ -2139,6 +2138,8 @@ func benchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderParallelW
 		sink.Add(localSink)
 	})
 	b.StopTimer()
+	b.ReportMetric(float64(workers), "parallel_workers")
+	reportColumnVectorGraphSharedPreparedSearchBenchMetrics1735(b, col.columnVectorGraphSharedPreparedSearchCacheSnapshot(), workers)
 	if errValue := firstErr.Load(); errValue != nil {
 		b.Fatalf("%s", errValue.(string))
 	}
@@ -2220,7 +2221,6 @@ func BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderReusableB
 		}
 	}
 	b.SetParallelism(1)
-	b.ReportMetric(float64(workers), "parallel_workers")
 	b.ReportAllocs()
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
@@ -2251,6 +2251,8 @@ func BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderReusableB
 		sink.Add(localSink)
 	})
 	b.StopTimer()
+	b.ReportMetric(float64(workers), "parallel_workers")
+	reportColumnVectorGraphSharedPreparedSearchBenchMetrics1735(b, col.columnVectorGraphSharedPreparedSearchCacheSnapshot(), workers)
 	if errValue := firstErr.Load(); errValue != nil {
 		b.Fatalf("%s", errValue.(string))
 	}

--- a/TreeDB/collections/vector_index_search_test.go
+++ b/TreeDB/collections/vector_index_search_test.go
@@ -2138,7 +2138,6 @@ func benchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderParallelW
 		sink.Add(localSink)
 	})
 	b.StopTimer()
-	b.ReportMetric(float64(workers), "parallel_workers")
 	reportColumnVectorGraphSharedPreparedSearchBenchMetrics1735(b, col.columnVectorGraphSharedPreparedSearchCacheSnapshot(), workers)
 	if errValue := firstErr.Load(); errValue != nil {
 		b.Fatalf("%s", errValue.(string))
@@ -2251,7 +2250,6 @@ func BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderReusableB
 		sink.Add(localSink)
 	})
 	b.StopTimer()
-	b.ReportMetric(float64(workers), "parallel_workers")
 	reportColumnVectorGraphSharedPreparedSearchBenchMetrics1735(b, col.columnVectorGraphSharedPreparedSearchCacheSnapshot(), workers)
 	if errValue := firstErr.Load(); errValue != nil {
 		b.Fatalf("%s", errValue.(string))


### PR DESCRIPTION
## Scope

Closes #1735 under parent tracker #2169.

This PR adds the first shared prepared-resource seam for current-format `column_graph` vector search:

- collection-scoped, ref-counted shared holder for immutable prepared typed-column/vector-index search state;
- cache key includes collection/namespace, vector definition, graph manifest identity, base manifest identity, and canonicalized vector-index state assets;
- worker readers/searchers still own mutable scratch/result buffers, but share immutable mmap/resource handles and prepared metadata;
- mmap/direct-view ineligible paths fall back to the existing per-reader preparation path instead of failing open, and the ineligible sentinel is cached to avoid repeated rebuild attempts;
- legacy physical graph-row assets remain compatibility-only and are not re-canonicalized here.

Compatibility with future DB-wide mapped-resource work (#1736 direction): this is a local collection seam over existing generic `mappedresource` managers, with explicit identity/lifetime/refcount/accounting and no private vector sidecar file/cache format.

## Tests

Final head: `6eda94da23dc091b179470f9c1af444fb1fe7421`.

New/updated tests cover shared refcounts/resource counters, concurrent open sharing, public/reusable searcher sharing, cache-key canonicalization, and cached not-eligible fallback behavior.

- `go test -race ./TreeDB/collections -run 'TestColumnVectorGraph.*(Parallel|Share|Shared|Prepared)|TestVectorIndexSearcher.*(Parallel|Shared)|TestVectorIndexSearcherSearchWithBufferParallelIndependentBuffers1961' -count=1`
  - artifact: `/tmp/gomap_1735_race_focused_final_20260601_193804.txt`
- `go test ./TreeDB/collections -count=1`
  - artifact: `/tmp/gomap_1735_go_test_collections_final_20260601_193724.txt`
- `go test ./... -count=1`
  - artifact: `/tmp/gomap_1735_go_test_all_final_20260601_193951.txt`

Internal review: xhigh Orca reviewer reported no blocking findings on ownership/refcount/fallback/key/scope. Copilot review nits were addressed in `6eda94da2` and their review threads were resolved.

## Benchmarks / evidence

Hardware/context: Apple M3, darwin/arm64, `GOMAXPROCS=8`.

### Open / prepare / warmup / RSS-resource harness

Command:

```sh
GOMAXPROCS=8 go test ./TreeDB/collections -run '^$' \
  -bench 'BenchmarkVectorSearchSharedPreparedOpenWarmupResources1735' \
  -benchmem -benchtime=1x -count=1
```

Artifact: `/tmp/gomap_1735_resource_bench_final_20260601_193818.txt`.

Fixed shape: 8,192 rows, dims=128, m=16, topK=10, efSearch=128.

| workers | shared entries | shared refs | active handles | mapped B | heap-copy B | open+prepare ns/worker | warmup ns/worker | process max RSS B | heap alloc B |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 1 | 1 | 1 | 16 | 5,965,208 | 0 | 5,860,250 | 56,833 | 245,923,840 | 100,787,264 |
| 4 | 1 | 4 | 16 | 5,965,208 | 0 | 1,505,927 | 20,938 | 341,852,160 | 101,042,552 |
| 8 | 1 | 8 | 16 | 5,965,208 | 0 | 775,828 | 17,854 | 350,666,752 | 101,379,976 |

### Fixed topology/query/efSearch/topK parallel QPS

Command:

```sh
GOMAXPROCS=8 go test ./TreeDB/collections -run '^$' \
  -bench 'BenchmarkVectorSearch(PublicSearchParallelTypedColumn1961|ReusableBufferParallelTypedColumn1961)$' \
  -benchmem -benchtime=500ms -count=5
benchstat /tmp/gomap_1735_qps_bench_base_20260601_190309.txt \
  /tmp/gomap_1735_qps_bench_final_retry_20260601_193900.txt
```

Artifacts:

- base: `/tmp/gomap_1735_qps_bench_base_20260601_190309.txt`
- current: `/tmp/gomap_1735_qps_bench_final_retry_20260601_193900.txt`
- benchstat: `/tmp/gomap_1735_qps_benchstat_final_retry.txt`

Benchstat `sec/op` summary:

| benchmark | base | current | result |
| --- | ---: | ---: | --- |
| PublicSearchParallelTypedColumn | 2.759 µs | 2.819 µs | ~, p=0.786, n=3+5 |
| ReusableBufferParallelTypedColumn | 2.869 µs | 2.814 µs | ~, p=0.286, n=3+5 |
| geomean | 2.813 µs | 2.816 µs | +0.11% |

Current shared-resource counters for both public/reusable parallel rows: `shared_prepared_entries=1`, `shared_prepared_refs=8`, `shared_prepared_builds=1`, `shared_prepared_cache_hits=7`, `shared_prepared_active_handles=14`, `shared_prepared_mapped_B=737080`, `shared_prepared_heap_copy_B=0`.

Current allocation/QPS samples:

| benchmark | ns/op samples | ops/sec samples | B/op | allocs/op |
| --- | --- | --- | ---: | ---: |
| PublicSearchParallelTypedColumn | 2561, 2859, 2821, 2819, 2693 | 390,441; 349,819; 354,485; 354,688; 371,307 | 784 | 2 |
| ReusableBufferParallelTypedColumn | 2814, 2927, 2771, 2588, 2830 | 355,361; 341,616; 360,916; 386,450; 353,334 | 0 | 0 |

## Performance regression assessment

No material hot-loop regression observed in the fixed parallel public/reusable rows: benchstat is neutral/no-significant-difference with geomean +0.11% sec/op, and allocation behavior is unchanged (`784 B/op, 2 allocs/op` public; `0 B/op, 0 allocs/op` reusable). The new setup/resource harness shows active shared handles and mapped bytes stay constant as worker refs grow from 1 to 8.

## AI review / CI status

Latest-head CI for `6eda94da23dc091b179470f9c1af444fb1fe7421` is green. Copilot review nits were fixed in `6eda94da2` and all Copilot review threads are resolved; Copilot was re-requested after the final nit commit and has not posted a newer review response. Codex was re-requested after the final nit commit and reported no major issues. CodeRabbit remains externally rate-limited/skipped on this PR.

