### PR TITLE
Audit vector fetch projection guidance

### DIFF
--- a/TreeDB/collections/column_vector_graph_prepared_search_test.go
+++ b/TreeDB/collections/column_vector_graph_prepared_search_test.go
@@ -131,7 +131,13 @@ func TestColumnVectorGraphPreparedSearchPublicDocumentsReopen2045(t *testing.T) 
 		t.Fatalf("RebuildVectorIndex: %v", err)
 	}
 	query := []float32{1, 0, 0, 0}
-	before, err := col.SearchVectorIndex(VectorIndexSearchOptions{IndexName: def.Name, Query: query, TopK: 2, EfSearch: len(rows), IncludeDocuments: true, MaxDecodedBlocks: 1})
+	searchOpts := VectorIndexSearchOptions{IndexName: def.Name, Query: query, TopK: 2, EfSearch: len(rows), MaxDecodedBlocks: 1}
+	fetchPreset, err := ProjectionOrientedVectorDocumentFetchPreset(def)
+	if err != nil {
+		t.Fatalf("ProjectionOrientedVectorDocumentFetchPreset: %v", err)
+	}
+	fetchPreset.ApplyToSearchOptions(&searchOpts)
+	before, err := col.SearchVectorIndex(searchOpts)
 	if err != nil {
 		t.Fatalf("SearchVectorIndex before reopen: %v", err)
 	}
@@ -152,7 +158,7 @@ func TestColumnVectorGraphPreparedSearchPublicDocumentsReopen2045(t *testing.T) 
 	if err != nil {
 		t.Fatalf("OpenCollection reopen: %v", err)
 	}
-	after, err := reopenedCol.SearchVectorIndex(VectorIndexSearchOptions{IndexName: def.Name, Query: query, TopK: 2, EfSearch: len(rows), IncludeDocuments: true, MaxDecodedBlocks: 1})
+	after, err := reopenedCol.SearchVectorIndex(searchOpts)
 	if err != nil {
 		t.Fatalf("SearchVectorIndex after reopen: %v", err)
 	}

--- a/TreeDB/collections/column_vector_graph_row_ref_state_test.go
+++ b/TreeDB/collections/column_vector_graph_row_ref_state_test.go
@@ -54,7 +54,14 @@ func TestColumnVectorGraphRowRefStatePublishesReopenAndSources1993(t *testing.T)
 	}
 
 	query := []float32{0.1, 0.2, 1}
-	got, err := col.SearchVectorIndex(VectorIndexSearchOptions{IndexName: def.Name, Query: query, TopK: 2, EfSearch: len(rows), IncludeDocuments: true, DocumentFetchOptions: DocumentFetchOptions{ExcludePaths: []string{"embedding"}}})
+	searchOpts := VectorIndexSearchOptions{IndexName: def.Name, Query: query, TopK: 2, EfSearch: len(rows)}
+	fetchPreset, err := ProjectionOrientedVectorDocumentFetchPreset(def)
+	if err != nil {
+		_ = d.Close()
+		t.Fatalf("ProjectionOrientedVectorDocumentFetchPreset: %v", err)
+	}
+	fetchPreset.ApplyToSearchOptions(&searchOpts)
+	got, err := col.SearchVectorIndex(searchOpts)
 	if err != nil {
 		_ = d.Close()
 		t.Fatalf("SearchVectorIndex include docs: %v", err)

--- a/TreeDB/collections/vector_index_retained_payload_policy_1876_test.go
+++ b/TreeDB/collections/vector_index_retained_payload_policy_1876_test.go
@@ -52,7 +52,7 @@ func TestSearchVectorIndexColumnGraphRetainedPayloadPolicyMatrix1876(t *testing.
 		t.Run(retainedPayloadPolicyName1876(policy), func(t *testing.T) {
 			fixture := openRetainedPayloadPolicyFixture1876(t, shape, policy, false)
 			defer func() { _ = fixture.db.Close() }()
-			for _, mode := range retainedPayloadSearchModes1876() {
+			for _, mode := range retainedPayloadSearchModes1876(t, fixture.def) {
 				mode := mode
 				t.Run(mode.name, func(t *testing.T) {
 					got, err := fixture.col.SearchVectorIndex(VectorIndexSearchOptions{
@@ -105,7 +105,7 @@ func TestSearchVectorIndexColumnGraphRetainedFullDocumentsReopenValueLogPointers
 	}
 	assertColumnGraphSearchResponseLoadedV4(t, got, fixture.def.Name, fixture.shape.topK)
 	assertVectorIndexSearchResultsV4(t, got.Results, exactColumnGraphTopKForTest(t, fixture.input, fixture.query, fixture.shape.topK), true)
-	assertRetainedPayloadPolicySearchDocuments1876(t, got, ColumnRetainedPayloadFull, retainedPayloadPolicySearchMode1876{name: "full_documents"}, fixture.docs)
+	assertRetainedPayloadPolicySearchDocuments1876(t, got, ColumnRetainedPayloadFull, retainedPayloadPolicySearchMode1876{name: "full_documents_comparison"}, fixture.docs)
 	if got.Stats.DocumentRetainedBytes == 0 || got.Stats.DocumentRowRefUnsupported == 0 {
 		t.Fatalf("stats=%+v want retained-full fetch from primary value-log-backed payload after reopen", got.Stats)
 	}
@@ -120,10 +120,12 @@ func BenchmarkOpenVectorIndexSearcherColumnGraphRetainedPayloadPolicy1876(b *tes
 	for _, policy := range retainedPayloadPolicies1876() {
 		policy := policy
 		b.Run(retainedPayloadPolicyName1876(policy), func(b *testing.B) {
-			for _, mode := range retainedPayloadSearchModes1876() {
+			fixture := openRetainedPayloadPolicyFixture1876(b, shape, policy, false)
+			defer func() { _ = fixture.db.Close() }()
+			for _, mode := range retainedPayloadSearchModes1876(b, fixture.def) {
 				mode := mode
 				b.Run(mode.name, func(b *testing.B) {
-					benchmarkOpenVectorIndexSearcherRetainedPayloadPolicy1876(b, shape, policy, mode)
+					benchmarkOpenVectorIndexSearcherRetainedPayloadPolicy1876(b, fixture, mode)
 				})
 			}
 		})
@@ -201,13 +203,11 @@ func benchmarkOpenVectorIndexSearcherProjectionOrientedFetchPreset1903(b *testin
 	}
 	b.StopTimer()
 	reportVectorIndexSearchBenchMetricsV4(b, b.N, stats, false)
-	reportRetainedPayloadPolicyFixtureMetrics1876(b, fixture, retainedPayloadPolicySearchMode1876{name: "exclude_embedding", opts: opts.DocumentFetchOptions})
+	reportRetainedPayloadPolicyFixtureMetrics1876(b, fixture, retainedPayloadPolicySearchMode1876{name: "preferred_exclude_embedding", opts: opts.DocumentFetchOptions})
 }
 
-func benchmarkOpenVectorIndexSearcherRetainedPayloadPolicy1876(b *testing.B, shape retainedPayloadPolicyFixtureShape1876, policy ColumnRetainedPayloadPolicy, mode retainedPayloadPolicySearchMode1876) {
+func benchmarkOpenVectorIndexSearcherRetainedPayloadPolicy1876(b *testing.B, fixture retainedPayloadPolicyFixture1876, mode retainedPayloadPolicySearchMode1876) {
 	b.Helper()
-	fixture := openRetainedPayloadPolicyFixture1876(b, shape, policy, false)
-	defer func() { _ = fixture.db.Close() }()
 	searcher, err := fixture.col.OpenVectorIndexSearcher(VectorIndexSearcherOptions{IndexName: fixture.def.Name, MaxDecodedBlocks: 1})
 	if err != nil {
 		b.Fatalf("OpenVectorIndexSearcher: %v", err)
@@ -250,10 +250,15 @@ func retainedPayloadPolicies1876() []ColumnRetainedPayloadPolicy {
 	}
 }
 
-func retainedPayloadSearchModes1876() []retainedPayloadPolicySearchMode1876 {
+func retainedPayloadSearchModes1876(tb testing.TB, def VectorIndexDefinition) []retainedPayloadPolicySearchMode1876 {
+	tb.Helper()
+	fetchPreset, err := ProjectionOrientedVectorDocumentFetchPreset(def)
+	if err != nil {
+		tb.Fatalf("ProjectionOrientedVectorDocumentFetchPreset: %v", err)
+	}
 	return []retainedPayloadPolicySearchMode1876{
-		{name: "full_documents"},
-		{name: "exclude_embedding", opts: DocumentFetchOptions{ExcludePaths: []string{"embedding"}}},
+		{name: "preferred_exclude_embedding", opts: fetchPreset.DocumentFetchOptions},
+		{name: "full_documents_comparison"},
 	}
 }
 

--- a/TreeDB/collections/vector_index_search_test.go
+++ b/TreeDB/collections/vector_index_search_test.go
@@ -259,15 +259,19 @@ func TestSearchVectorIndexColumnGraphProjectedDocuments1875(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SearchVectorIndex full documents: %v", err)
 	}
-	projected, err := col.SearchVectorIndex(VectorIndexSearchOptions{
-		IndexName:            def.Name,
-		Query:                []float32{0, 0, 1},
-		TopK:                 2,
-		EfSearch:             len(rows),
-		IncludeDocuments:     true,
-		DocumentFetchOptions: DocumentFetchOptions{ExcludePaths: []string{"embedding"}},
-		MaxDecodedBlocks:     1,
-	})
+	projectedOpts := VectorIndexSearchOptions{
+		IndexName:        def.Name,
+		Query:            []float32{0, 0, 1},
+		TopK:             2,
+		EfSearch:         len(rows),
+		MaxDecodedBlocks: 1,
+	}
+	fetchPreset, err := ProjectionOrientedVectorDocumentFetchPreset(def)
+	if err != nil {
+		t.Fatalf("ProjectionOrientedVectorDocumentFetchPreset: %v", err)
+	}
+	fetchPreset.ApplyToSearchOptions(&projectedOpts)
+	projected, err := col.SearchVectorIndex(projectedOpts)
 	if err != nil {
 		t.Fatalf("SearchVectorIndex projected documents: %v", err)
 	}
@@ -325,13 +329,17 @@ func TestVectorIndexSearcherProjectedDocumentsSnapshotBound1875(t *testing.T) {
 	if err := col.Delete([]byte("doc-a")); err != nil {
 		t.Fatalf("Delete doc-a after opening searcher: %v", err)
 	}
-	got, err := searcher.Search(VectorIndexSearcherSearchOptions{
-		Query:                []float32{1, 0, 0},
-		TopK:                 1,
-		EfSearch:             len(rows),
-		IncludeDocuments:     true,
-		DocumentFetchOptions: DocumentFetchOptions{ExcludePaths: []string{"embedding"}},
-	})
+	searchOpts := VectorIndexSearcherSearchOptions{
+		Query:    []float32{1, 0, 0},
+		TopK:     1,
+		EfSearch: len(rows),
+	}
+	fetchPreset, err := ProjectionOrientedVectorDocumentFetchPreset(def)
+	if err != nil {
+		t.Fatalf("ProjectionOrientedVectorDocumentFetchPreset: %v", err)
+	}
+	fetchPreset.ApplyToSearcherSearchOptions(&searchOpts)
+	got, err := searcher.Search(searchOpts)
 	if err != nil {
 		t.Fatalf("Search projected after delete on bound searcher: %v", err)
 	}
@@ -1713,14 +1721,17 @@ func BenchmarkSearchVectorIndexColumnGraphNativeReaderWithDocumentsExcludeEmbedd
 	}
 	query := append([]float32(nil), input[37].vector...)
 	opts := VectorIndexSearchOptions{
-		IndexName:            def.Name,
-		Query:                query,
-		TopK:                 topK,
-		EfSearch:             efSearch,
-		IncludeDocuments:     true,
-		DocumentFetchOptions: DocumentFetchOptions{ExcludePaths: []string{"embedding"}},
-		MaxDecodedBlocks:     1,
+		IndexName:        def.Name,
+		Query:            query,
+		TopK:             topK,
+		EfSearch:         efSearch,
+		MaxDecodedBlocks: 1,
 	}
+	fetchPreset, err := ProjectionOrientedVectorDocumentFetchPreset(def)
+	if err != nil {
+		b.Fatalf("ProjectionOrientedVectorDocumentFetchPreset: %v", err)
+	}
+	fetchPreset.ApplyToSearchOptions(&opts)
 	warm, err := col.SearchVectorIndex(opts)
 	if err != nil {
 		b.Fatalf("warm SearchVectorIndex: %v", err)
@@ -1813,12 +1824,15 @@ func BenchmarkOpenVectorIndexSearcherColumnGraphNativeReaderWithDocumentsExclude
 	defer func() { _ = searcher.Close() }()
 	query := append([]float32(nil), input[37].vector...)
 	opts := VectorIndexSearcherSearchOptions{
-		Query:                query,
-		TopK:                 topK,
-		EfSearch:             efSearch,
-		IncludeDocuments:     true,
-		DocumentFetchOptions: DocumentFetchOptions{ExcludePaths: []string{"embedding"}},
+		Query:    query,
+		TopK:     topK,
+		EfSearch: efSearch,
 	}
+	fetchPreset, err := ProjectionOrientedVectorDocumentFetchPreset(def)
+	if err != nil {
+		b.Fatalf("ProjectionOrientedVectorDocumentFetchPreset: %v", err)
+	}
+	fetchPreset.ApplyToSearcherSearchOptions(&opts)
 	if _, err := searcher.Search(opts); err != nil {
 		b.Fatalf("warm Search: %v", err)
 	}
@@ -1857,7 +1871,11 @@ func BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderWithDocum
 }
 
 func BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderWithDocumentsExcludeEmbedding1875(b *testing.B) {
-	benchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderV4(b, true, DocumentFetchOptions{ExcludePaths: []string{"embedding"}})
+	fetchPreset, err := ProjectionOrientedVectorDocumentFetchPresetForField("embedding")
+	if err != nil {
+		b.Fatalf("ProjectionOrientedVectorDocumentFetchPresetForField: %v", err)
+	}
+	benchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderV4(b, fetchPreset.IncludeDocuments, fetchPreset.DocumentFetchOptions)
 }
 
 func benchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderV4(b *testing.B, includeDocuments bool, fetchOptions DocumentFetchOptions) {
@@ -2015,7 +2033,11 @@ func BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderParallelW
 }
 
 func BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderParallelWithDocumentsExcludeEmbedding1875(b *testing.B) {
-	benchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderParallelV4(b, true, DocumentFetchOptions{ExcludePaths: []string{"embedding"}})
+	fetchPreset, err := ProjectionOrientedVectorDocumentFetchPresetForField("embedding")
+	if err != nil {
+		b.Fatalf("ProjectionOrientedVectorDocumentFetchPresetForField: %v", err)
+	}
+	benchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderParallelV4(b, fetchPreset.IncludeDocuments, fetchPreset.DocumentFetchOptions)
 }
 
 func benchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderParallelV4(b *testing.B, includeDocuments bool, fetchOptions DocumentFetchOptions) {

--- a/TreeDB/docs/docs_lint_test.go
+++ b/TreeDB/docs/docs_lint_test.go
@@ -180,6 +180,49 @@ func TestDocs_VectorIndexStateWordingDoesNotRecanonicalizeGraphRows(t *testing.T
 	}
 }
 
+func TestDocs_VectorProjectionFetchGuidance(t *testing.T) {
+	treeRoot, repoRoot := repoRoots(t)
+	checks := map[string][]string{
+		filepath.Join(treeRoot, "docs", "guides", "vector-search-typed-column.md"): {
+			"ProjectionOrientedVectorDocumentFetchPreset",
+			"ColumnRetainedPayloadNonColumn",
+			"ColumnRetainedPayloadFull` is supported for latency-oriented compatibility",
+			"full-document comparison row",
+		},
+		filepath.Join(treeRoot, "docs", "spec", "column-graph-native-vector-search.md"): {
+			"ProjectionOrientedVectorDocumentFetchPresetForField(\"embedding\")",
+			"explicit full-document/embedding-echo",
+			"Keep these document-fetch rows separate from graph-search",
+		},
+		filepath.Join(repoRoot, "cmd", "unified_bench", "README.md"): {
+			"projection_without_embedding",
+			"ProjectionOrientedVectorDocumentFetchPreset",
+			"-collection-storage-vector-full-documents",
+		},
+		filepath.Join(repoRoot, "cmd", "treedb_vector_search_demo", "README.md"): {
+			"no-document ANN/search-throughput boundary",
+			"do not time final",
+			"ProjectionOrientedVectorDocumentFetchPreset",
+		},
+		filepath.Join(repoRoot, "cmd", "treedb_vector_demo", "README.md"): {
+			"explicit full-document/embedding-echo",
+			"ProjectionOrientedVectorDocumentFetchPreset",
+		},
+	}
+	for path, needles := range checks {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		text := string(data)
+		for _, needle := range needles {
+			if !strings.Contains(text, needle) {
+				t.Fatalf("%s missing vector projection guidance %q", path, needle)
+			}
+		}
+	}
+}
+
 func TestTypedStorageStorageFormatDocsMentionCompatibilityDirectory(t *testing.T) {
 	treeRoot, _ := repoRoots(t)
 	path := filepath.Join(treeRoot, "docs", "spec", "storage-format.md")

--- a/TreeDB/docs/guides/collections-quickstart.md
+++ b/TreeDB/docs/guides/collections-quickstart.md
@@ -323,6 +323,11 @@ go test -run '^$' \
   aggregate, or vector payloads.
 - Keep vector payloads out of retained JSON for search-heavy workloads when a
   dense typed-column section is the intended search data plane.
+- For vector APIs that return documents without embedding echo, use
+  `ColumnRetainedPayloadNonColumn` plus
+  `ProjectionOrientedVectorDocumentFetchPreset` so final documents exclude the
+  vector field; request full documents/embeddings only as an explicit comparison
+  or compatibility path.
 - Separate candidate search/aggregate from final document fetch.
 - Use `cached_verify` or `verify` for correctness-oriented validation; treat
   `skip_checksums` only as an unsafe ceiling benchmark.

--- a/TreeDB/docs/guides/typed-storage-performance.md
+++ b/TreeDB/docs/guides/typed-storage-performance.md
@@ -359,12 +359,15 @@ Expected output shape:
 TreeDB column_graph native-reader demo
 db_dir=/tmp/treedb-column-graph-doc-smoke rows=64 dims=8 degree=4 top_k=5 ef_search=32
 rebuild status=column_graph_loaded loaded=true reason=
-search path=column_graph_native_reader status=column_graph_loaded loaded=true results=5 include_docs=false
-stats candidates=... edges=... row_fetches=... cache_hits=... cache_misses=... decoded_blocks=... granules_touched=... physical_B=... max_resident_B=... docs_fetched=0
+search path=column_graph_native_reader status=column_graph_loaded loaded=true results=5 include_docs=false doc_projection=none
+stats candidates=... edges=... row_fetches=... cache_hits=... cache_misses=... decoded_blocks=... granules_touched=... physical_B=... max_resident_B=... docs_fetched=0 doc_output_B=0 doc_fields_skipped=0
 ```
 
 `docs_fetched=0` is the expected search/scoring boundary when documents are not
-requested. Use `-include-docs` only when you want final document fetch included.
+requested. Use `-include-docs` when you want projected final document fetch
+included; the demo excludes the embedding field by default. Add
+`-include-doc-embedding` only for explicit full-document/embedding-echo
+comparison runs.
 
 ### Unified-bench profile-dir workflow
 
@@ -539,7 +542,8 @@ it a ceiling and keep verified/cached-verify evidence nearby.
   generation-bound accelerator.
 - **Runnable command:** `cmd/treedb_column_graph_demo` smoke above.
 - **Expected counters:** search output should show `search path=column_graph_native_reader`
-  and `docs_fetched=0` unless `-include-docs` is set.
+  and `docs_fetched=0` unless `-include-docs` is set; with `-include-docs`,
+  `doc_projection=exclude_embedding` is the preferred response shape.
 - **Why:** keeps vector scoring/candidate traversal separate from document fetch.
 - **When not:** authoritative adjacency typed-column storage or SIMD kernels are
   required today; those are follow-ups.

--- a/TreeDB/docs/guides/vector-search-typed-column.md
+++ b/TreeDB/docs/guides/vector-search-typed-column.md
@@ -178,8 +178,8 @@ Expected output shape:
 TreeDB column_graph native-reader demo
 db_dir=/tmp/treedb-column-graph-doc-smoke rows=64 dims=8 degree=4 top_k=5 ef_search=32
 rebuild status=column_graph_loaded loaded=true reason=
-search path=column_graph_native_reader status=column_graph_loaded loaded=true results=5 include_docs=false
-stats candidates=... edges=... row_fetches=0 cache_hits=0 cache_misses=0 decoded_blocks=0 granules_touched=0 physical_B=0 max_resident_B=0 docs_fetched=0
+search path=column_graph_native_reader status=column_graph_loaded loaded=true results=5 include_docs=false doc_projection=none
+stats candidates=... edges=... row_fetches=0 cache_hits=0 cache_misses=0 decoded_blocks=0 granules_touched=0 physical_B=0 max_resident_B=0 docs_fetched=0 doc_output_B=0 doc_fields_skipped=0
 result[0] id=doc-... ordinal=... score=...
 ```
 
@@ -190,8 +190,12 @@ Interpretation:
 - `physical_B=0` and `row_fetches=0` on current healthy rebuilds mean search did
   not read legacy graph row payloads. Non-zero values indicate an explicit
   legacy compatibility path or a benchmark using old physical graph fixtures.
-- Add `-include-docs` when you intentionally want final document fetch included;
-  then `docs_fetched` should be non-zero.
+- Add `-include-docs` when you intentionally want projected final document
+  fetch included; the demo applies
+  `ProjectionOrientedVectorDocumentFetchPresetForField("embedding")`, so
+  documents omit the embedding field and `docs_fetched` plus
+  `doc_fields_skipped` should be non-zero. Add `-include-doc-embedding` only
+  for explicit full-document/embedding-echo comparison runs.
 
 ## Dense-section microbenchmarks
 
@@ -307,7 +311,7 @@ artifacts or when you also need one-shot open/setup names:
 ```sh
 go test ./TreeDB/collections \
   -run '^$' \
-  -bench 'Benchmark(ColumnVectorGraphNativeSearchCosineV3|ColumnVectorGraphNativeSearchCosineParallelV3|OpenVectorIndexSearcherColumnGraphNativeReaderSetupV6|OpenVectorIndexSearcherColumnGraphNativeReaderV4|SearchVectorIndexColumnGraphNativeReaderV4|SearchVectorIndexColumnGraphNativeReaderWithDocumentsV4)$' \
+  -bench 'Benchmark(ColumnVectorGraphNativeSearchCosineV3|ColumnVectorGraphNativeSearchCosineParallelV3|OpenVectorIndexSearcherColumnGraphNativeReaderSetupV6|OpenVectorIndexSearcherColumnGraphNativeReaderV4|SearchVectorIndexColumnGraphNativeReaderV4|SearchVectorIndexColumnGraphNativeReaderWithDocumentsExcludeEmbedding1875|SearchVectorIndexColumnGraphNativeReaderWithDocumentsV4)$' \
   -benchmem \
   -benchtime=500ms \
   -count=5
@@ -322,7 +326,8 @@ Read the benchmark names and row labels before comparing numbers:
 | `OpenVectorIndexSearcher...V4` | Reusable searcher steady-state query; setup/open outside timed loop. |
 | `SearchVectorIndex...V4` | Public one-shot search; setup/open inside each operation. |
 | `...ReusableBuffer...` | Opened public no-document search with caller-owned reusable response buffers. |
-| `...WithDocuments...` | Search plus post-top-k document materialization. |
+| `...WithDocumentsExcludeEmbedding1875` | Preferred projection-oriented final-fetch row: search plus post-top-k documents with the vector field excluded. |
+| `...WithDocumentsV4` | Explicit full-document comparison row: search plus post-top-k documents including the vector field. |
 
 Profile public response allocation and the reusable-buffer ceiling separately:
 

--- a/TreeDB/docs/spec/column-graph-native-vector-search.md
+++ b/TreeDB/docs/spec/column-graph-native-vector-search.md
@@ -118,10 +118,17 @@ Representative output shape:
 TreeDB column_graph native-reader demo
 db_dir=/tmp/treedb-column-graph-demo rows=1024 dims=128 degree=16 top_k=10 ef_search=128
 rebuild status=column_graph_loaded loaded=true reason=
-search path=column_graph_native_reader status=column_graph_loaded loaded=true results=10 include_docs=false
-stats candidate_rows=... candidates=... edges=... visited_nodes=... visited_edges=... vector_B=... adjacency_B=... row_fetches=... cache_hits=... cache_misses=... decoded_blocks=... granules_touched=... physical_B=... max_resident_B=... docs_fetched=0
+search path=column_graph_native_reader status=column_graph_loaded loaded=true results=10 include_docs=false doc_projection=none
+stats candidate_rows=... candidates=... edges=... visited_nodes=... visited_edges=... vector_B=... adjacency_B=... row_fetches=... cache_hits=... cache_misses=... decoded_blocks=... granules_touched=... physical_B=... max_resident_B=... docs_fetched=0 doc_output_B=0 doc_fields_skipped=0
 result[0] id=doc-000000 ordinal=0 score=1.000000
 ```
+
+When exercising document final fetch through the demo, `-include-docs` uses the
+preferred projection-oriented path and applies
+`ProjectionOrientedVectorDocumentFetchPresetForField("embedding")`; add
+`-include-doc-embedding` only for explicit full-document/embedding-echo
+comparison runs. Keep these document-fetch rows separate from graph-search
+throughput claims.
 
 Run an opt-in real public dataset smoke using GloVe 6B 50d:
 
@@ -163,7 +170,7 @@ Use the legacy/canonical benchmark set when comparing with older artifacts:
 ```sh
 GOWORK=off go test ./TreeDB/collections \
   -run '^$' \
-  -bench 'Benchmark(ColumnVectorGraphNativeSearchCosineV3|ColumnVectorGraphNativeSearchCosineParallelV3|OpenVectorIndexSearcherColumnGraphNativeReaderSetupV6|OpenVectorIndexSearcherColumnGraphNativeReaderV4|SearchVectorIndexColumnGraphNativeReaderV4|SearchVectorIndexColumnGraphNativeReaderWithDocumentsV4)$' \
+  -bench 'Benchmark(ColumnVectorGraphNativeSearchCosineV3|ColumnVectorGraphNativeSearchCosineParallelV3|OpenVectorIndexSearcherColumnGraphNativeReaderSetupV6|OpenVectorIndexSearcherColumnGraphNativeReaderV4|SearchVectorIndexColumnGraphNativeReaderV4|SearchVectorIndexColumnGraphNativeReaderWithDocumentsExcludeEmbedding1875|SearchVectorIndexColumnGraphNativeReaderWithDocumentsV4)$' \
   -benchmem \
   -benchtime=500ms \
   -count=5
@@ -181,8 +188,11 @@ The expected categories are:
   searcher steady-state query. Setup/open is outside the timed loop.
 - `BenchmarkSearchVectorIndexColumnGraphNativeReaderV4`: public one-shot search.
   Setup/open is inside each timed operation.
-- `BenchmarkSearchVectorIndexColumnGraphNativeReaderWithDocumentsV4`: public
-  one-shot search plus post-top-k document materialization.
+- `BenchmarkSearchVectorIndexColumnGraphNativeReaderWithDocumentsExcludeEmbedding1875`:
+  public one-shot search plus preferred projection-oriented post-top-k document
+  materialization; documents omit the vector field.
+- `BenchmarkSearchVectorIndexColumnGraphNativeReaderWithDocumentsV4`: explicit
+  full-document comparison path; documents include the vector field.
 
 Report and compare:
 

--- a/cmd/treedb_column_graph_demo/main.go
+++ b/cmd/treedb_column_graph_demo/main.go
@@ -21,16 +21,17 @@ const defaultIndexName = "embedding_graph"
 const minDemoResetDirLen = 8
 
 type demoConfig struct {
-	Dir              string
-	Reset            bool
-	Rows             int
-	Dims             int
-	Degree           int
-	TopK             int
-	EfSearch         int
-	MaxDecodedBlocks int
-	IncludeDocs      bool
-	GlovePath        string
+	Dir                 string
+	Reset               bool
+	Rows                int
+	Dims                int
+	Degree              int
+	TopK                int
+	EfSearch            int
+	MaxDecodedBlocks    int
+	IncludeDocs         bool
+	IncludeDocEmbedding bool
+	GlovePath           string
 }
 
 type demoRow struct {
@@ -59,6 +60,9 @@ func run(args []string, stdout, stderr io.Writer) error {
 	}
 	if cfg.Degree < 0 {
 		return errors.New("degree must be non-negative")
+	}
+	if cfg.IncludeDocEmbedding && !cfg.IncludeDocs {
+		return errors.New("include-doc-embedding requires include-docs")
 	}
 
 	cleanup := func() {}
@@ -160,12 +164,11 @@ func run(args []string, stdout, stderr io.Writer) error {
 		return err
 	}
 	defer func() { _ = searcher.Close() }()
-	got, err := searcher.Search(collections.VectorIndexSearcherSearchOptions{
-		Query:            query,
-		TopK:             cfg.TopK,
-		EfSearch:         cfg.EfSearch,
-		IncludeDocuments: cfg.IncludeDocs,
-	})
+	searchOpts, docProjection, err := demoVectorSearchOptions(cfg, query)
+	if err != nil {
+		return err
+	}
+	got, err := searcher.Search(searchOpts)
 	if err != nil {
 		return err
 	}
@@ -176,8 +179,8 @@ func run(args []string, stdout, stderr io.Writer) error {
 	fmt.Fprintf(stdout, "TreeDB column_graph native-reader demo\n")
 	fmt.Fprintf(stdout, "db_dir=%s rows=%d dims=%d degree=%d top_k=%d ef_search=%d\n", cfg.Dir, len(rows), dims, cfg.Degree, cfg.TopK, cfg.EfSearch)
 	fmt.Fprintf(stdout, "rebuild status=%s loaded=%t reason=%s\n", status.State, status.Loaded, status.Reason)
-	fmt.Fprintf(stdout, "search path=%s status=%s loaded=%t results=%d include_docs=%t\n", got.Path, got.Status.State, got.Status.Loaded, len(got.Results), cfg.IncludeDocs)
-	fmt.Fprintf(stdout, "stats candidate_rows=%d candidates=%d edges=%d visited_nodes=%d visited_edges=%d vector_B=%d adjacency_B=%d row_fetches=%d cache_hits=%d cache_misses=%d decoded_blocks=%d granules_touched=%d physical_B=%d max_resident_B=%d docs_fetched=%d\n",
+	fmt.Fprintf(stdout, "search path=%s status=%s loaded=%t results=%d include_docs=%t doc_projection=%s\n", got.Path, got.Status.State, got.Status.Loaded, len(got.Results), cfg.IncludeDocs, docProjection)
+	fmt.Fprintf(stdout, "stats candidate_rows=%d candidates=%d edges=%d visited_nodes=%d visited_edges=%d vector_B=%d adjacency_B=%d row_fetches=%d cache_hits=%d cache_misses=%d decoded_blocks=%d granules_touched=%d physical_B=%d max_resident_B=%d docs_fetched=%d doc_output_B=%d doc_fields_skipped=%d\n",
 		got.Stats.CandidateRows,
 		got.Stats.Candidates,
 		got.Stats.Edges,
@@ -193,6 +196,8 @@ func run(args []string, stdout, stderr io.Writer) error {
 		got.Stats.PhysicalBytesRead,
 		got.Stats.MaxResidentBytes,
 		got.Stats.DocumentsFetched,
+		got.Stats.DocumentOutputBytes,
+		got.Stats.DocumentFieldsSkipped,
 	)
 	for i, result := range got.Results {
 		if i >= 5 {
@@ -342,7 +347,8 @@ func parseConfig(args []string) (demoConfig, error) {
 	fs.IntVar(&cfg.TopK, "top-k", cfg.TopK, "number of nearest results")
 	fs.IntVar(&cfg.EfSearch, "ef-search", cfg.EfSearch, "graph search exploration bound")
 	fs.IntVar(&cfg.MaxDecodedBlocks, "max-decoded-blocks", cfg.MaxDecodedBlocks, "bounded physical column decoded-block cache size")
-	fs.BoolVar(&cfg.IncludeDocs, "include-docs", cfg.IncludeDocs, "materialize full documents after top-k")
+	fs.BoolVar(&cfg.IncludeDocs, "include-docs", cfg.IncludeDocs, "materialize projected documents after top-k, excluding the embedding field by default")
+	fs.BoolVar(&cfg.IncludeDocEmbedding, "include-doc-embedding", cfg.IncludeDocEmbedding, "with -include-docs, return full documents including the embedding field (explicit embedding echo/full-doc opt-in)")
 	fs.StringVar(&cfg.GlovePath, "glove", cfg.GlovePath, "optional GloVe text file to load as a real public embedding dataset")
 	if err := fs.Parse(args); err != nil {
 		return cfg, err
@@ -353,13 +359,35 @@ func parseConfig(args []string) (demoConfig, error) {
 	return cfg, nil
 }
 
+func demoVectorSearchOptions(cfg demoConfig, query []float32) (collections.VectorIndexSearcherSearchOptions, string, error) {
+	opts := collections.VectorIndexSearcherSearchOptions{
+		Query:    query,
+		TopK:     cfg.TopK,
+		EfSearch: cfg.EfSearch,
+	}
+	if !cfg.IncludeDocs {
+		return opts, "none", nil
+	}
+	if cfg.IncludeDocEmbedding {
+		opts.IncludeDocuments = true
+		return opts, "full_document_embedding_echo", nil
+	}
+	preset, err := collections.ProjectionOrientedVectorDocumentFetchPresetForField("embedding")
+	if err != nil {
+		return opts, "", err
+	}
+	preset.ApplyToSearcherSearchOptions(&opts)
+	return opts, "exclude_embedding", nil
+}
+
 func demoCollectionMeta(dims, degree int) *collections.CollectionMeta {
 	return &collections.CollectionMeta{
 		Name: "docs",
 		Options: collections.CollectionOptions{
 			DocumentFormat: collections.DocumentFormatJSON,
 			ColumnStore: &collections.ColumnStoreConfig{
-				Enabled: true,
+				Enabled:         true,
+				RetainedPayload: collections.ColumnRetainedPayloadNonColumn,
 				Columns: []collections.ColumnStoreColumn{
 					{Name: "time_us", Path: "time_us", ValueType: collections.ColumnStoreValueInt64},
 					{Name: "kind", Path: "kind", ValueType: collections.ColumnStoreValueString, Dictionary: true},

--- a/cmd/treedb_column_graph_demo/main_test.go
+++ b/cmd/treedb_column_graph_demo/main_test.go
@@ -48,6 +48,61 @@ func TestColumnGraphDemoRunsCloseReopenNativeReaderPath(t *testing.T) {
 	}
 }
 
+func TestColumnGraphDemoIncludeDocsUsesProjectionPreset(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "db")
+	var stdout, stderr bytes.Buffer
+	err := run([]string{
+		"-dir", dir,
+		"-reset",
+		"-rows", "32",
+		"-dims", "6",
+		"-degree", "4",
+		"-top-k", "2",
+		"-ef-search", "16",
+		"-include-docs",
+	}, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("run demo with include docs: %v\nstdout:\n%s\nstderr:\n%s", err, stdout.String(), stderr.String())
+	}
+	out := stdout.String()
+	for _, needle := range []string{"include_docs=true doc_projection=exclude_embedding", "docs_fetched=2", "doc_fields_skipped="} {
+		if !strings.Contains(out, needle) {
+			t.Fatalf("demo output missing %q\nstdout:\n%s\nstderr:\n%s", needle, out, stderr.String())
+		}
+	}
+}
+
+func TestDemoVectorSearchOptionsProjectionModes(t *testing.T) {
+	base := demoConfig{TopK: 3, EfSearch: 16}
+	opts, projection, err := demoVectorSearchOptions(base, []float32{1, 0, 0})
+	if err != nil {
+		t.Fatalf("no-doc options: %v", err)
+	}
+	if opts.IncludeDocuments || projection != "none" || len(opts.DocumentFetchOptions.ExcludePaths) != 0 {
+		t.Fatalf("no-doc opts=%+v projection=%q", opts, projection)
+	}
+
+	projected := base
+	projected.IncludeDocs = true
+	opts, projection, err = demoVectorSearchOptions(projected, []float32{1, 0, 0})
+	if err != nil {
+		t.Fatalf("projected options: %v", err)
+	}
+	if !opts.IncludeDocuments || projection != "exclude_embedding" || len(opts.DocumentFetchOptions.ExcludePaths) != 1 || opts.DocumentFetchOptions.ExcludePaths[0] != "embedding" {
+		t.Fatalf("projected opts=%+v projection=%q", opts, projection)
+	}
+
+	full := projected
+	full.IncludeDocEmbedding = true
+	opts, projection, err = demoVectorSearchOptions(full, []float32{1, 0, 0})
+	if err != nil {
+		t.Fatalf("full options: %v", err)
+	}
+	if !opts.IncludeDocuments || projection != "full_document_embedding_echo" || len(opts.DocumentFetchOptions.ExcludePaths) != 0 {
+		t.Fatalf("full opts=%+v projection=%q", opts, projection)
+	}
+}
+
 func TestValidateDemoResetDir(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "db")
 	got, err := validateDemoResetDir(dir)

--- a/cmd/treedb_vector_demo/README.md
+++ b/cmd/treedb_vector_demo/README.md
@@ -21,10 +21,15 @@ fields (`-metadata typed-row`). The pre-alpha demo currently requires
 `-vectors typed-column`; unsupported vector storage modes fail clearly instead
 of silently using a different path.
 
-Use `-final-fetch` to time full-document fetch after top-k selection. Use
-`-metadata-filter` for a deterministic tenant filter smoke; this uses exact
-scoring while still publishing typed-column vector assets because public
-`column_graph` metadata predicates are not wired yet.
+Use `-final-fetch` to time the explicit full-document/embedding-echo
+compatibility path after top-k selection; keep those numbers separate from
+search-only throughput. For the preferred vector response shape that fetches
+documents without returning embeddings, use the collection/vector APIs (or
+`cmd/treedb_column_graph_demo -include-docs`) with
+`ProjectionOrientedVectorDocumentFetchPreset`. Use `-metadata-filter` for a
+deterministic tenant filter smoke; this uses exact scoring while still
+publishing typed-column vector assets because public `column_graph` metadata
+predicates are not wired yet.
 
 Text, JSON, and markdown summaries include operation-specific vector search counters such as candidate rows, visited nodes/edges, vector payload bytes, adjacency payload bytes, and direct/scratch decode counts.
 

--- a/cmd/treedb_vector_demo/main.go
+++ b/cmd/treedb_vector_demo/main.go
@@ -82,6 +82,7 @@ type result struct {
 	MetadataFilter            bool        `json:"metadata_filter"`
 	MetadataFilterDescription string      `json:"metadata_filter_description,omitempty"`
 	FinalFetch                bool        `json:"final_fetch"`
+	FinalFetchShape           string      `json:"final_fetch_shape"`
 	SearchPath                string      `json:"search_path"`
 	SetupMillis               float64     `json:"setup_ms"`
 	SearchMillis              float64     `json:"search_ms"`
@@ -181,7 +182,7 @@ func parseConfig(args []string) (config, error) {
 	fs.IntVar(&cfg.TopK, "top-k", cfg.TopK, "nearest neighbors per query")
 	fs.IntVar(&cfg.BatchSize, "batch-size", cfg.BatchSize, "documents per InsertBatch call")
 	fs.BoolVar(&cfg.MetadataFilter, "metadata-filter", cfg.MetadataFilter, "restrict scoring/search output to a deterministic tenant filter when supported")
-	fs.BoolVar(&cfg.FinalFetch, "final-fetch", cfg.FinalFetch, "fetch full documents after top-k selection and time that separately")
+	fs.BoolVar(&cfg.FinalFetch, "final-fetch", cfg.FinalFetch, "fetch explicit full documents (including embeddings) after top-k selection and time that separately")
 	fs.StringVar(&cfg.Dir, "dir", cfg.Dir, "TreeDB directory; empty uses a temporary directory")
 	fs.BoolVar(&cfg.KeepDir, "keep-dir", cfg.KeepDir, "keep an automatically-created temporary DB directory after the run")
 	fs.Int64Var(&cfg.Seed, "seed", cfg.Seed, "deterministic fixture seed")
@@ -352,6 +353,7 @@ func execute(ctx context.Context, cfg config) (result, error) {
 		MetadataFilter:            cfg.MetadataFilter,
 		MetadataFilterDescription: metadataFilterDescription(cfg),
 		FinalFetch:                cfg.FinalFetch,
+		FinalFetchShape:           vectorDemoFinalFetchShape(cfg.FinalFetch),
 		SetupMillis:               millis(setupElapsed),
 		ProfileDir:                cfg.ProfileDir,
 	}
@@ -386,9 +388,10 @@ func collectionMeta(cfg config) *collections.CollectionMeta {
 		Options: collections.CollectionOptions{
 			DocumentFormat: collections.DocumentFormatJSON,
 			ColumnStore: &collections.ColumnStoreConfig{
-				Enabled: true,
-				Columns: columns,
-				SortKey: sortKey,
+				Enabled:         true,
+				RetainedPayload: collections.ColumnRetainedPayloadNonColumn,
+				Columns:         columns,
+				SortKey:         sortKey,
 			},
 		},
 		VectorIndexes: []collections.VectorIndexDefinition{{
@@ -491,6 +494,13 @@ func insertRows(col *collections.Collection, rows []vectorRow, batchSize int) er
 		}
 	}
 	return nil
+}
+
+func vectorDemoFinalFetchShape(finalFetch bool) string {
+	if finalFetch {
+		return "full_document_embedding_echo"
+	}
+	return "none"
 }
 
 func runColumnGraphQueries(col *collections.Collection, queries []queryFixture, cfg config, res *result) error {
@@ -740,14 +750,14 @@ func writeProfileArtifacts(dir string, res *result) error {
 func summaryMarkdown(res result) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "# TreeDB vector demo summary\n\n")
-	fmt.Fprintf(&b, "- preset: `%s`\n- vectors: `%s`\n- metadata: `%s`\n- rows: `%d`\n- dims: `%d`\n- queries: `%d`\n- top_k: `%d`\n- batch_size: `%d`\n- search_path: `%s`\n- setup_ms: `%.3f`\n- search_ms: `%.3f`\n- fetch_ms: `%.3f`\n- ops_sec: `%.2f`\n- candidate_rows: `%d`\n- visited_nodes: `%d`\n- visited_edges: `%d`\n- vector_bytes_read: `%d`\n- adjacency_bytes_read: `%d`\n- vector_direct_views: `%d`\n- vector_scratch_decodes: `%d`\n- adjacency_direct_views: `%d`\n- adjacency_scratch_decodes: `%d`\n- docs_fetched: `%d`\n- mapped_bytes_peak: `%d`\n- heap_copy_bytes_peak: `%d`\n- decoded_bytes_peak: `%d`\n", res.Preset, res.VectorMode, res.MetadataMode, res.Rows, res.Dims, res.Queries, res.TopK, res.BatchSize, res.SearchPath, res.SetupMillis, res.SearchMillis, res.FetchMillis, res.OpsPerSecond, res.CandidateRows, res.VisitedNodes, res.VisitedEdges, res.VectorBytesRead, res.AdjacencyBytesRead, res.VectorDirectViews, res.VectorScratchDecodes, res.AdjacencyDirectViews, res.AdjacencyScratchDecodes, res.DocsFetched, res.MappedBytesPeak, res.HeapCopyBytesPeak, res.DecodedBytesPeak)
+	fmt.Fprintf(&b, "- preset: `%s`\n- vectors: `%s`\n- metadata: `%s`\n- rows: `%d`\n- dims: `%d`\n- queries: `%d`\n- top_k: `%d`\n- batch_size: `%d`\n- search_path: `%s`\n- final_fetch_shape: `%s`\n- setup_ms: `%.3f`\n- search_ms: `%.3f`\n- fetch_ms: `%.3f`\n- ops_sec: `%.2f`\n- candidate_rows: `%d`\n- visited_nodes: `%d`\n- visited_edges: `%d`\n- vector_bytes_read: `%d`\n- adjacency_bytes_read: `%d`\n- vector_direct_views: `%d`\n- vector_scratch_decodes: `%d`\n- adjacency_direct_views: `%d`\n- adjacency_scratch_decodes: `%d`\n- docs_fetched: `%d`\n- mapped_bytes_peak: `%d`\n- heap_copy_bytes_peak: `%d`\n- decoded_bytes_peak: `%d`\n", res.Preset, res.VectorMode, res.MetadataMode, res.Rows, res.Dims, res.Queries, res.TopK, res.BatchSize, res.SearchPath, res.FinalFetchShape, res.SetupMillis, res.SearchMillis, res.FetchMillis, res.OpsPerSecond, res.CandidateRows, res.VisitedNodes, res.VisitedEdges, res.VectorBytesRead, res.AdjacencyBytesRead, res.VectorDirectViews, res.VectorScratchDecodes, res.AdjacencyDirectViews, res.AdjacencyScratchDecodes, res.DocsFetched, res.MappedBytesPeak, res.HeapCopyBytesPeak, res.DecodedBytesPeak)
 	fmt.Fprintf(&b, "\nArtifacts: `vector_demo_cpu.pprof`, `vector_demo_allocs.pprof`, `vector_demo_summary.json`, `vector_demo_summary.md`.\n")
 	return b.String()
 }
 
 func printText(w io.Writer, res result) {
 	fmt.Fprintf(w, "TreeDB vector/RAG demo (pre-alpha collections)\n")
-	fmt.Fprintf(w, "preset=%s vectors=%s metadata=%s metadata_filter=%t final_fetch=%t\n", res.Preset, res.VectorMode, res.MetadataMode, res.MetadataFilter, res.FinalFetch)
+	fmt.Fprintf(w, "preset=%s vectors=%s metadata=%s metadata_filter=%t final_fetch=%t final_fetch_shape=%s\n", res.Preset, res.VectorMode, res.MetadataMode, res.MetadataFilter, res.FinalFetch, res.FinalFetchShape)
 	fmt.Fprintf(w, "db_dir=%s rows=%d dims=%d queries=%d top_k=%d batch_size=%d search_path=%s\n", res.Dir, res.Rows, res.Dims, res.Queries, res.TopK, res.BatchSize, res.SearchPath)
 	fmt.Fprintf(w, "setup_ms=%.3f search_ms=%.3f fetch_ms=%.3f ops_sec=%.2f\n", res.SetupMillis, res.SearchMillis, res.FetchMillis, res.OpsPerSecond)
 	fmt.Fprintf(w, "candidate_rows=%d candidates=%d candidates_per_search=%.2f visited_nodes=%d visited_edges=%d scored_vectors=%d docs_fetched=%d document_bytes=%d\n", res.CandidateRows, res.Candidates, res.CandidatesPerSearch, res.VisitedNodes, res.VisitedEdges, res.ScoredVectors, res.DocsFetched, res.DocumentBytes)

--- a/cmd/treedb_vector_search_demo/README.md
+++ b/cmd/treedb_vector_search_demo/README.md
@@ -19,6 +19,13 @@ Each case:
 7. benchmark serial ANN search and parallel ANN search, and
 8. report storage/memory usage.
 
+The benchmark search phase is a no-document ANN/search-throughput boundary:
+serial and parallel search metrics return IDs/scores and do not time final
+document fetch, reconstruction, projection, or serialization. Document reads in
+validation are correctness checks, not the preferred vector response-shape
+evidence; use `ProjectionOrientedVectorDocumentFetchPreset` in collection/vector
+APIs when timing projected documents without embeddings.
+
 `CompactStorageFull` is intentionally used instead of manually chaining
 maintenance calls. It is TreeDB's canonical full storage compaction path:
 value-log rewrite/GC, leaf-generation pack/GC, index vacuum, settle passes,

--- a/cmd/treedb_vector_search_demo/main.go
+++ b/cmd/treedb_vector_search_demo/main.go
@@ -562,8 +562,9 @@ func resultBackendForStrategy(strategy collections.VectorIndexStrategy) string {
 
 func columnGraphDemoColumnStoreConfig(dims int) *collections.ColumnStoreConfig {
 	return &collections.ColumnStoreConfig{
-		Enabled:        true,
-		ProfileSupport: collections.ColumnStoreProfileBenchmarkRelaxed,
+		Enabled:         true,
+		RetainedPayload: collections.ColumnRetainedPayloadNonColumn,
+		ProfileSupport:  collections.ColumnStoreProfileBenchmarkRelaxed,
 		Columns: []collections.ColumnStoreColumn{
 			{
 				Name:       "embedding",

--- a/cmd/unified_bench/README.md
+++ b/cmd/unified_bench/README.md
@@ -274,7 +274,11 @@ Collection-storage flags:
 - `-collection-storage-selectivity`, `-collection-storage-cardinality`,
   `-collection-storage-payload-size`, `-collection-storage-field-count`.
 - `-collection-storage-vector-dims`, `-collection-storage-vector-top-k`,
-  `-collection-storage-include-final-fetch`.
+  `-collection-storage-include-final-fetch`. When final fetch is enabled, the
+  default vector response shape is `projection_without_embedding` via
+  `ProjectionOrientedVectorDocumentFetchPreset`; add
+  `-collection-storage-vector-full-documents` only for explicit
+  full-document/embedding-echo comparison rows.
 - `-collection-storage-checkpoint-reopen` to include the durability/recovery
   boundary before read workloads (default true).
 - `-collection-storage-asset-read-integrity` (`verify|cached_verify|skip_checksums`;

--- a/cmd/unified_bench/main.go
+++ b/cmd/unified_bench/main.go
@@ -704,6 +704,7 @@ func main() {
 				VectorDims:               *collectionStorageVectorDimsArg,
 				VectorTopK:               *collectionStorageVectorTopKArg,
 				IncludeFinalFetch:        *collectionStorageIncludeFinalFetchArg,
+				VectorFullDocuments:      *collectionStorageVectorFullDocumentsArg,
 				CheckpointReopen:         *collectionStorageCheckpointReopenArg,
 				ColumnAssetReadIntegrity: collections.ColumnAssetReadIntegrity(strings.TrimSpace(*collectionStorageAssetReadIntegrityArg)),
 				RunBenchprof:             true,

--- a/cmd/unified_bench/suite_collection_storage.go
+++ b/cmd/unified_bench/suite_collection_storage.go
@@ -60,6 +60,12 @@ const (
 	collectionStorageWorkloadMixed             = "mixed"
 )
 
+const (
+	collectionStorageVectorFinalFetchNone                  = "none"
+	collectionStorageVectorFinalFetchProjectionNoEmbedding = "projection_without_embedding"
+	collectionStorageVectorFinalFetchFullDocument          = "full_document_embedding_echo"
+)
+
 var (
 	collectionStorageAllModes = []string{
 		collectionStorageModeDocumentOnly,
@@ -92,17 +98,18 @@ var (
 		collectionStorageDefaultWorkloads,
 		"Comma-separated workloads for -suite collection_storage (insert_batch,point_get,predicate_scan,aggregate,vector_search_smoke,mixed; all=default)",
 	)
-	collectionStorageQueryCountArg         = flag.Int("collection-storage-query-count", collectionStorageDefaultQueryCount, "Per-mode query repetitions for scan/aggregate/vector/mixed workloads in -suite collection_storage")
-	collectionStoragePointGetCountArg      = flag.Int("collection-storage-point-get-count", collectionStorageDefaultPointGetCount, "Per-mode point-get operations for -suite collection_storage")
-	collectionStorageFieldCountArg         = flag.Int("collection-storage-field-count", 3, "Logical scalar field count reported for -suite collection_storage (current comparable fixture uses time_us, kind, score; higher values add payload-only fields)")
-	collectionStoragePayloadSizeArg        = flag.Int("collection-storage-payload-size", collectionStorageDefaultPayloadSize, "Payload bytes per logical document for -suite collection_storage")
-	collectionStorageCardinalityArg        = flag.Int("collection-storage-cardinality", collectionStorageDefaultCardinality, "Kind/cardinality bucket count for -suite collection_storage")
-	collectionStorageSelectivityArg        = flag.Float64("collection-storage-selectivity", collectionStorageDefaultSelectivity, "Target predicate selectivity for -suite collection_storage range/equality shapes (0<value<=1)")
-	collectionStorageVectorDimsArg         = flag.Int("collection-storage-vector-dims", collectionStorageDefaultVectorDims, "Vector dimensions for vector_typed_column mode in -suite collection_storage")
-	collectionStorageVectorTopKArg         = flag.Int("collection-storage-vector-top-k", collectionStorageDefaultVectorTopK, "TopK for vector_search_smoke in -suite collection_storage")
-	collectionStorageIncludeFinalFetchArg  = flag.Bool("collection-storage-include-final-fetch", true, "Include final document fetch/materialization in vector_search_smoke for -suite collection_storage")
-	collectionStorageCheckpointReopenArg   = flag.Bool("collection-storage-checkpoint-reopen", true, "Checkpoint, close, and reopen each collection before read workloads in -suite collection_storage")
-	collectionStorageAssetReadIntegrityArg = flag.String("collection-storage-asset-read-integrity", string(collections.ColumnAssetReadIntegrityVerify), "Typed column asset read integrity for -suite collection_storage (verify, cached_verify, skip_checksums; relaxed modes require -treedb-allow-unsafe)")
+	collectionStorageQueryCountArg          = flag.Int("collection-storage-query-count", collectionStorageDefaultQueryCount, "Per-mode query repetitions for scan/aggregate/vector/mixed workloads in -suite collection_storage")
+	collectionStoragePointGetCountArg       = flag.Int("collection-storage-point-get-count", collectionStorageDefaultPointGetCount, "Per-mode point-get operations for -suite collection_storage")
+	collectionStorageFieldCountArg          = flag.Int("collection-storage-field-count", 3, "Logical scalar field count reported for -suite collection_storage (current comparable fixture uses time_us, kind, score; higher values add payload-only fields)")
+	collectionStoragePayloadSizeArg         = flag.Int("collection-storage-payload-size", collectionStorageDefaultPayloadSize, "Payload bytes per logical document for -suite collection_storage")
+	collectionStorageCardinalityArg         = flag.Int("collection-storage-cardinality", collectionStorageDefaultCardinality, "Kind/cardinality bucket count for -suite collection_storage")
+	collectionStorageSelectivityArg         = flag.Float64("collection-storage-selectivity", collectionStorageDefaultSelectivity, "Target predicate selectivity for -suite collection_storage range/equality shapes (0<value<=1)")
+	collectionStorageVectorDimsArg          = flag.Int("collection-storage-vector-dims", collectionStorageDefaultVectorDims, "Vector dimensions for vector_typed_column mode in -suite collection_storage")
+	collectionStorageVectorTopKArg          = flag.Int("collection-storage-vector-top-k", collectionStorageDefaultVectorTopK, "TopK for vector_search_smoke in -suite collection_storage")
+	collectionStorageIncludeFinalFetchArg   = flag.Bool("collection-storage-include-final-fetch", true, "Include projection-oriented final document fetch/materialization in vector_search_smoke for -suite collection_storage")
+	collectionStorageVectorFullDocumentsArg = flag.Bool("collection-storage-vector-full-documents", false, "With collection-storage final fetch, return full documents including embedding instead of the preferred projection_without_embedding path")
+	collectionStorageCheckpointReopenArg    = flag.Bool("collection-storage-checkpoint-reopen", true, "Checkpoint, close, and reopen each collection before read workloads in -suite collection_storage")
+	collectionStorageAssetReadIntegrityArg  = flag.String("collection-storage-asset-read-integrity", string(collections.ColumnAssetReadIntegrityVerify), "Typed column asset read integrity for -suite collection_storage (verify, cached_verify, skip_checksums; relaxed modes require -treedb-allow-unsafe)")
 )
 
 type collectionStorageSuiteOptions struct {
@@ -119,6 +126,7 @@ type collectionStorageSuiteOptions struct {
 	VectorDims               int
 	VectorTopK               int
 	IncludeFinalFetch        bool
+	VectorFullDocuments      bool
 	CheckpointReopen         bool
 	ColumnAssetReadIntegrity collections.ColumnAssetReadIntegrity
 	RunBenchprof             bool
@@ -142,6 +150,7 @@ type collectionStorageReport struct {
 	VectorDims               int                               `json:"vector_dims"`
 	VectorTopK               int                               `json:"vector_top_k"`
 	IncludeFinalFetch        bool                              `json:"include_final_fetch"`
+	VectorFinalFetchShape    string                            `json:"vector_final_fetch_shape"`
 	CheckpointReopen         bool                              `json:"checkpoint_reopen"`
 	ColumnAssetReadIntegrity string                            `json:"column_asset_read_integrity"`
 	BenchmarkOnlyRelaxed     bool                              `json:"benchmark_only_relaxed"`
@@ -162,6 +171,7 @@ type collectionStorageSemantics struct {
 	FieldsQueried            []string `json:"fields_queried"`
 	ReturnedResultShape      string   `json:"returned_result_shape"`
 	FinalDocumentFetch       bool     `json:"final_document_fetch"`
+	VectorFinalFetchShape    string   `json:"vector_final_fetch_shape"`
 	CheckpointReopenIncluded bool     `json:"checkpoint_reopen_included"`
 	ReadIntegrityMode        string   `json:"read_integrity_mode"`
 	SelectivityDistribution  string   `json:"selectivity_distribution"`
@@ -242,6 +252,9 @@ type collectionStorageWorkloadCounters struct {
 	VectorDirectViews            uint64 `json:"vector_direct_views,omitempty"`
 	VectorScratchDecodes         uint64 `json:"vector_scratch_decodes,omitempty"`
 	VectorDocumentsFetched       uint64 `json:"vector_documents_fetched,omitempty"`
+	VectorDocumentOutputBytes    uint64 `json:"vector_document_output_bytes,omitempty"`
+	VectorDocumentFieldsSkipped  uint64 `json:"vector_document_fields_skipped,omitempty"`
+	VectorDocumentRetainedBytes  uint64 `json:"vector_document_retained_bytes,omitempty"`
 	VectorTypedColumnMappedBytes uint64 `json:"vector_typed_column_mapped_bytes,omitempty"`
 	VectorTypedColumnHeapBytes   uint64 `json:"vector_typed_column_heap_copy_bytes,omitempty"`
 	VectorTypedColumnDecoded     uint64 `json:"vector_typed_column_decoded_bytes,omitempty"`
@@ -425,6 +438,14 @@ func runCollectionStorageSuite(baseCfg BenchConfig, opts collectionStorageSuiteO
 	if !includeFinalFetch && !flagExplicit("collection-storage-include-final-fetch") {
 		includeFinalFetch = *collectionStorageIncludeFinalFetchArg
 	}
+	vectorFullDocuments := opts.VectorFullDocuments
+	if !vectorFullDocuments && !flagExplicit("collection-storage-vector-full-documents") {
+		vectorFullDocuments = *collectionStorageVectorFullDocumentsArg
+	}
+	if vectorFullDocuments && !includeFinalFetch {
+		return "", errors.New("collection_storage: -collection-storage-vector-full-documents requires -collection-storage-include-final-fetch")
+	}
+	vectorFinalFetchShape := collectionStorageVectorFinalFetchShape(includeFinalFetch, vectorFullDocuments)
 	checkpointReopen := opts.CheckpointReopen
 	if !checkpointReopen && !flagExplicit("collection-storage-checkpoint-reopen") {
 		checkpointReopen = *collectionStorageCheckpointReopenArg
@@ -533,7 +554,7 @@ func runCollectionStorageSuite(baseCfg BenchConfig, opts collectionStorageSuiteO
 
 	for _, rt := range modeRuntimes {
 		for _, workload := range workloads {
-			metric, err := runCollectionStorageWorkload(rt, workload, fixture, queryRange, queryCount, pointGetCount, vectorTopK, includeFinalFetch, assetReadIntegrity)
+			metric, err := runCollectionStorageWorkload(rt, workload, fixture, queryRange, queryCount, pointGetCount, vectorTopK, includeFinalFetch, vectorFullDocuments, assetReadIntegrity)
 			if err != nil {
 				return "", err
 			}
@@ -585,11 +606,12 @@ func runCollectionStorageSuite(baseCfg BenchConfig, opts collectionStorageSuiteO
 		VectorDims:               vectorDims,
 		VectorTopK:               vectorTopK,
 		IncludeFinalFetch:        includeFinalFetch,
+		VectorFinalFetchShape:    vectorFinalFetchShape,
 		CheckpointReopen:         checkpointReopen,
 		ColumnAssetReadIntegrity: string(assetReadIntegrity),
 		BenchmarkOnlyRelaxed:     collectionStorageAssetReadIntegrityBenchmarkRelaxed(assetReadIntegrity),
 		PathLabel:                strings.TrimSpace(opts.ExecutionPath),
-		Semantics:                collectionStorageReportSemantics(rows, queryRange, includeFinalFetch, checkpointReopen, assetReadIntegrity),
+		Semantics:                collectionStorageReportSemantics(rows, queryRange, includeFinalFetch, vectorFinalFetchShape, checkpointReopen, assetReadIntegrity),
 		ModeSemantics:            modeSemantics,
 		Stages:                   stages,
 		Metrics:                  metrics,
@@ -619,6 +641,16 @@ func runCollectionStorageSuite(baseCfg BenchConfig, opts collectionStorageSuiteO
 		return "", profileFinalizeErr
 	}
 	return md, nil
+}
+
+func collectionStorageVectorFinalFetchShape(includeFinalFetch, fullDocuments bool) string {
+	if !includeFinalFetch {
+		return collectionStorageVectorFinalFetchNone
+	}
+	if fullDocuments {
+		return collectionStorageVectorFinalFetchFullDocument
+	}
+	return collectionStorageVectorFinalFetchProjectionNoEmbedding
 }
 
 func collectionStorageEffectiveProfile(profile string) (string, error) {
@@ -1179,7 +1211,7 @@ func collectionStorageAssetByteBreakdown(col *collections.Collection) (rowBytes,
 	return rowBytes, columnBytes
 }
 
-func runCollectionStorageWorkload(rt *collectionStorageModeRuntime, workload string, fixture []collectionStorageFixtureRow, queryRange collectionStoragePredicateRange, queryCount, pointGetCount, vectorTopK int, includeFinalFetch bool, assetReadIntegrity collections.ColumnAssetReadIntegrity) (collectionStorageWorkloadMetric, error) {
+func runCollectionStorageWorkload(rt *collectionStorageModeRuntime, workload string, fixture []collectionStorageFixtureRow, queryRange collectionStoragePredicateRange, queryCount, pointGetCount, vectorTopK int, includeFinalFetch bool, vectorFullDocuments bool, assetReadIntegrity collections.ColumnAssetReadIntegrity) (collectionStorageWorkloadMetric, error) {
 	metric := collectionStorageWorkloadMetric{
 		Mode:                  rt.Mode,
 		Workload:              workload,
@@ -1217,7 +1249,7 @@ func runCollectionStorageWorkload(rt *collectionStorageModeRuntime, workload str
 	case collectionStorageWorkloadAggregate:
 		return runCollectionStorageAggregate(rt, metric, queryRange, queryCount, assetReadIntegrity)
 	case collectionStorageWorkloadVectorSearchSmoke:
-		return runCollectionStorageVectorSearch(rt, metric, fixture, queryCount, vectorTopK, includeFinalFetch)
+		return runCollectionStorageVectorSearch(rt, metric, fixture, queryCount, vectorTopK, includeFinalFetch, vectorFullDocuments)
 	case collectionStorageWorkloadMixed:
 		return runCollectionStorageMixed(rt, metric, fixture, queryRange, queryCount, assetReadIntegrity)
 	default:
@@ -1369,23 +1401,27 @@ func runCollectionStorageAggregate(rt *collectionStorageModeRuntime, metric coll
 	return metric, nil
 }
 
-func runCollectionStorageVectorSearch(rt *collectionStorageModeRuntime, metric collectionStorageWorkloadMetric, fixture []collectionStorageFixtureRow, queryCount, vectorTopK int, includeFinalFetch bool) (collectionStorageWorkloadMetric, error) {
+func runCollectionStorageVectorSearch(rt *collectionStorageModeRuntime, metric collectionStorageWorkloadMetric, fixture []collectionStorageFixtureRow, queryCount, vectorTopK int, includeFinalFetch bool, vectorFullDocuments bool) (collectionStorageWorkloadMetric, error) {
 	if len(fixture) == 0 {
 		return metric, errors.New("collection_storage: vector search needs at least one fixture row")
 	}
 	query := append([]float32(nil), fixture[0].Embedding...)
-	validate, err := rt.Collection.SearchVectorIndex(collections.VectorIndexSearchOptions{IndexName: collectionStorageVectorIndexName, Query: query, TopK: min(vectorTopK, len(fixture)), EfSearch: len(fixture), IncludeDocuments: includeFinalFetch, MaxDecodedBlocks: 1})
+	searchOpts, err := collectionStorageVectorSearchOptions(query, min(vectorTopK, len(fixture)), len(fixture), includeFinalFetch, vectorFullDocuments)
+	if err != nil {
+		return metric, err
+	}
+	validate, err := rt.Collection.SearchVectorIndex(searchOpts)
 	if err != nil {
 		return metric, fmt.Errorf("collection_storage: mode %s vector_search_smoke correctness: %w", rt.Mode, err)
 	}
-	if err := validateCollectionStorageVectorResults(rt.Mode, validate.Results, fixture, min(vectorTopK, len(fixture)), includeFinalFetch); err != nil {
+	if err := validateCollectionStorageVectorResults(rt.Mode, validate.Results, fixture, min(vectorTopK, len(fixture)), includeFinalFetch, vectorFullDocuments); err != nil {
 		return metric, err
 	}
 	allocStart := readCollectionStorageMemStats()
 	start := time.Now()
 	var last collections.VectorIndexSearchResponse
 	for i := 0; i < queryCount; i++ {
-		last, err = rt.Collection.SearchVectorIndex(collections.VectorIndexSearchOptions{IndexName: collectionStorageVectorIndexName, Query: query, TopK: min(vectorTopK, len(fixture)), EfSearch: len(fixture), IncludeDocuments: includeFinalFetch, MaxDecodedBlocks: 1})
+		last, err = rt.Collection.SearchVectorIndex(searchOpts)
 		if err != nil {
 			return metric, fmt.Errorf("collection_storage: mode %s vector_search_smoke: %w", rt.Mode, err)
 		}
@@ -1403,12 +1439,15 @@ func runCollectionStorageVectorSearch(rt *collectionStorageModeRuntime, metric c
 	metric.AllocsPerOp = perOp(float64(allocDelta.Allocs), int64(queryCount))
 	metric.Matches = int64(len(last.Results) * queryCount)
 	metric.MatchesPerSecond = rate(float64(metric.Matches), dur)
-	metric.SemanticNote = "vector scoring excludes full document materialization until top-k; include_final_fetch controls post-top-k document fetch"
+	metric.SemanticNote = collectionStorageVectorSearchSemanticNote(includeFinalFetch, vectorFullDocuments)
 	metric.Counters.VectorCandidates = last.Stats.Candidates * uint64(queryCount)
 	metric.Counters.VectorEdges = last.Stats.Edges * uint64(queryCount)
 	metric.Counters.VectorDirectViews = last.Stats.VectorDirectViews * uint64(queryCount)
 	metric.Counters.VectorScratchDecodes = last.Stats.VectorScratchDecodes * uint64(queryCount)
 	metric.Counters.VectorDocumentsFetched = last.Stats.DocumentsFetched * uint64(queryCount)
+	metric.Counters.VectorDocumentOutputBytes = last.Stats.DocumentOutputBytes * uint64(queryCount)
+	metric.Counters.VectorDocumentFieldsSkipped = last.Stats.DocumentFieldsSkipped * uint64(queryCount)
+	metric.Counters.VectorDocumentRetainedBytes = last.Stats.DocumentRetainedBytes * uint64(queryCount)
 	metric.Counters.VectorTypedColumnMappedBytes = last.Stats.TypedColumnMappedBytes
 	metric.Counters.VectorTypedColumnHeapBytes = last.Stats.TypedColumnHeapCopyBytes
 	metric.Counters.VectorTypedColumnDecoded = last.Stats.TypedColumnDecodedBytes
@@ -1419,7 +1458,40 @@ func runCollectionStorageVectorSearch(rt *collectionStorageModeRuntime, metric c
 	return metric, nil
 }
 
-func validateCollectionStorageVectorResults(mode string, results []collections.VectorIndexSearchResult, fixture []collectionStorageFixtureRow, topK int, includeFinalFetch bool) error {
+func collectionStorageVectorSearchOptions(query []float32, topK, efSearch int, includeFinalFetch, vectorFullDocuments bool) (collections.VectorIndexSearchOptions, error) {
+	opts := collections.VectorIndexSearchOptions{
+		IndexName:        collectionStorageVectorIndexName,
+		Query:            query,
+		TopK:             topK,
+		EfSearch:         efSearch,
+		MaxDecodedBlocks: 1,
+	}
+	if !includeFinalFetch {
+		return opts, nil
+	}
+	if vectorFullDocuments {
+		opts.IncludeDocuments = true
+		return opts, nil
+	}
+	preset, err := collections.ProjectionOrientedVectorDocumentFetchPresetForField("embedding")
+	if err != nil {
+		return opts, err
+	}
+	preset.ApplyToSearchOptions(&opts)
+	return opts, nil
+}
+
+func collectionStorageVectorSearchSemanticNote(includeFinalFetch, vectorFullDocuments bool) string {
+	if !includeFinalFetch {
+		return "vector scoring/search returns top-k IDs/scores only; no post-top-k document fetch is timed"
+	}
+	if vectorFullDocuments {
+		return "vector scoring/search excludes document materialization until top-k; final fetch is explicit full-document/embedding-echo comparison path"
+	}
+	return "vector scoring/search excludes document materialization until top-k; final fetch uses preferred projection_without_embedding preset path"
+}
+
+func validateCollectionStorageVectorResults(mode string, results []collections.VectorIndexSearchResult, fixture []collectionStorageFixtureRow, topK int, includeFinalFetch bool, vectorFullDocuments bool) error {
 	if len(results) == 0 {
 		return fmt.Errorf("collection_storage: mode %s vector_search_smoke correctness returned no results", mode)
 	}
@@ -1444,6 +1516,16 @@ func validateCollectionStorageVectorResults(mode string, results []collections.V
 			}
 			if _, err := decodeCollectionStorageDocument(result.Document); err != nil {
 				return fmt.Errorf("collection_storage: mode %s vector_search_smoke correctness id %q final document decode: %w", mode, id, err)
+			}
+			hasEmbedding, err := collectionStorageDocumentHasField(result.Document, "embedding")
+			if err != nil {
+				return fmt.Errorf("collection_storage: mode %s vector_search_smoke correctness id %q final document inspect: %w", mode, id, err)
+			}
+			if vectorFullDocuments && !hasEmbedding {
+				return fmt.Errorf("collection_storage: mode %s vector_search_smoke correctness id %q full-document final fetch omitted embedding", mode, id)
+			}
+			if !vectorFullDocuments && hasEmbedding {
+				return fmt.Errorf("collection_storage: mode %s vector_search_smoke correctness id %q projected final fetch retained embedding", mode, id)
 			}
 		}
 	}
@@ -1503,6 +1585,15 @@ func decodeCollectionStorageDocument(doc []byte) (collectionStorageDecodedDocume
 		return decoded, err
 	}
 	return decoded, nil
+}
+
+func collectionStorageDocumentHasField(doc []byte, field string) (bool, error) {
+	var decoded map[string]json.RawMessage
+	if err := json.Unmarshal(doc, &decoded); err != nil {
+		return false, err
+	}
+	_, ok := decoded[field]
+	return ok, nil
 }
 
 func collectionStorageSampleIndex(i, rows int) int {
@@ -1611,18 +1702,19 @@ func perOp(v float64, ops int64) float64 {
 	return v / float64(ops)
 }
 
-func collectionStorageReportSemantics(rows int, queryRange collectionStoragePredicateRange, includeFinalFetch, checkpointReopen bool, assetReadIntegrity collections.ColumnAssetReadIntegrity) collectionStorageSemantics {
+func collectionStorageReportSemantics(rows int, queryRange collectionStoragePredicateRange, includeFinalFetch bool, vectorFinalFetchShape string, checkpointReopen bool, assetReadIntegrity collections.ColumnAssetReadIntegrity) collectionStorageSemantics {
 	return collectionStorageSemantics{
 		LogicalRows:              rows,
 		InsertedDocuments:        rows,
 		FieldsProjected:          []string{"time_us", "kind", "score"},
 		FieldsQueried:            []string{"time_us", "embedding"},
-		ReturnedResultShape:      "point_get returns logical JSON fields; predicate_scan returns matched row count; aggregate returns count/sum/avg; vector_search_smoke returns top-k IDs/scores and optionally documents",
+		ReturnedResultShape:      "point_get returns logical JSON fields; predicate_scan returns matched row count; aggregate returns count/sum/avg; vector_search_smoke returns top-k IDs/scores plus either no docs, projection_without_embedding docs, or explicit full-document embedding echo",
 		FinalDocumentFetch:       includeFinalFetch,
+		VectorFinalFetchShape:    vectorFinalFetchShape,
 		CheckpointReopenIncluded: checkpointReopen,
 		ReadIntegrityMode:        string(assetReadIntegrity),
 		SelectivityDistribution:  fmt.Sprintf("clustered_monotonic time_us range [%d,%d] matching %d rows", queryRange.Low, queryRange.High, queryRange.ExpectedRows),
-		MaterializationBoundary:  "setup/fixture/create/insert/checkpoint/reopen/vector_rebuild are timed as stages; workload metrics time only the selected operation loop after correctness validation",
+		MaterializationBoundary:  "setup/fixture/create/insert/checkpoint/reopen/vector_rebuild are timed as stages; workload metrics time only the selected operation loop after correctness validation; vector_search_smoke includes post-top-k document fetch only when include_final_fetch is true",
 		SemanticComparability:    "scalar workloads use the same logical documents, ids, time_us/kind/score fields, predicate range, aggregate result, and point-get projection across all scalar modes; vector search is only semantically comparable for vector_typed_column and is marked unsupported elsewhere",
 	}
 }
@@ -1638,7 +1730,7 @@ func renderCollectionStorageSuiteMarkdown(report collectionStorageReport) string
 	sb.WriteString(fmt.Sprintf("- query_count: %d\n", report.QueryCount))
 	sb.WriteString(fmt.Sprintf("- point_get_count: %d\n", report.PointGetCount))
 	sb.WriteString(fmt.Sprintf("- selectivity: %.6f\n", report.Selectivity))
-	sb.WriteString(fmt.Sprintf("- vector_dims: %d vector_top_k: %d include_final_fetch: %v\n", report.VectorDims, report.VectorTopK, report.IncludeFinalFetch))
+	sb.WriteString(fmt.Sprintf("- vector_dims: %d vector_top_k: %d include_final_fetch: %v vector_final_fetch_shape: `%s`\n", report.VectorDims, report.VectorTopK, report.IncludeFinalFetch, report.VectorFinalFetchShape))
 	sb.WriteString(fmt.Sprintf("- checkpoint_reopen: %v\n", report.CheckpointReopen))
 	sb.WriteString(fmt.Sprintf("- collection asset read integrity: `%s`\n", report.ColumnAssetReadIntegrity))
 	if report.PathLabel != "" {
@@ -1654,6 +1746,7 @@ func renderCollectionStorageSuiteMarkdown(report collectionStorageReport) string
 	sb.WriteString(fmt.Sprintf("- projected fields: %s\n", markdownCodeList(report.Semantics.FieldsProjected)))
 	sb.WriteString(fmt.Sprintf("- queried fields: %s\n", markdownCodeList(report.Semantics.FieldsQueried)))
 	sb.WriteString(fmt.Sprintf("- returned result shape: %s\n", markdownTableText(report.Semantics.ReturnedResultShape)))
+	sb.WriteString(fmt.Sprintf("- vector final fetch shape: `%s`\n", report.Semantics.VectorFinalFetchShape))
 	sb.WriteString(fmt.Sprintf("- selectivity/distribution: %s\n", markdownTableText(report.Semantics.SelectivityDistribution)))
 	sb.WriteString(fmt.Sprintf("- materialization boundary: %s\n", markdownTableText(report.Semantics.MaterializationBoundary)))
 	sb.WriteString(fmt.Sprintf("- comparability: %s\n\n", markdownTableText(report.Semantics.SemanticComparability)))
@@ -1677,7 +1770,7 @@ func renderCollectionStorageSuiteMarkdown(report collectionStorageReport) string
 	sb.WriteString("\n")
 
 	sb.WriteString("## Workload Metrics\n\n")
-	sb.WriteString("| mode | workload | supported | rows/s | queries/s | matches/s | ns/op | B/op | allocs/op | rows processed | matches | row bytes | column bytes | materializations/reconstructions | typed parts decoded/pruned | typed blocks decoded/pruned | vector candidates/edges | note |\n")
+	sb.WriteString("| mode | workload | supported | rows/s | queries/s | matches/s | ns/op | B/op | allocs/op | rows processed | matches | row bytes | column bytes | materializations/reconstructions | typed parts decoded/pruned | typed blocks decoded/pruned | vector candidates/edges/docs/out_B/skipped | note |\n")
 	sb.WriteString("|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|---|---|---|---|\n")
 	for _, m := range report.Metrics {
 		supported := "yes"
@@ -1689,7 +1782,7 @@ func renderCollectionStorageSuiteMarkdown(report collectionStorageReport) string
 		mat := fmt.Sprintf("%d/%d", m.Counters.DocumentMaterializations+m.Counters.RowMaterializations, m.Counters.DocumentReconstructions)
 		parts := fmt.Sprintf("%d/%d", m.Counters.TypedColumnPartsDecoded, m.Counters.TypedColumnPartsPruned)
 		blocks := fmt.Sprintf("%d/%d", m.Counters.TypedColumnBlocksDecoded, m.Counters.TypedColumnBlocksPruned)
-		vector := fmt.Sprintf("%d/%d", m.Counters.VectorCandidates, m.Counters.VectorEdges)
+		vector := fmt.Sprintf("%d/%d/%d/%d/%d", m.Counters.VectorCandidates, m.Counters.VectorEdges, m.Counters.VectorDocumentsFetched, m.Counters.VectorDocumentOutputBytes, m.Counters.VectorDocumentFieldsSkipped)
 		sb.WriteString(fmt.Sprintf("| %s | %s | %s | %.3f | %.3f | %.3f | %.1f | %.1f | %.3f | %d | %d | %d | %d | %s | %s | %s | %s | %s |\n",
 			markdownCodeTableText(m.Mode), markdownCodeTableText(m.Workload), supported, m.RowsPerSecond, m.QueriesPerSecond, m.MatchesPerSecond, m.NsPerOp, m.BytesPerOp, m.AllocsPerOp, m.RowsProcessed, m.Matches, m.TypedRowAssetBytes, m.TypedColumnAssetBytes, markdownCodeTableText(mat), markdownCodeTableText(parts), markdownCodeTableText(blocks), markdownCodeTableText(vector), markdownTableText(note)))
 	}

--- a/cmd/unified_bench/suite_collection_storage_test.go
+++ b/cmd/unified_bench/suite_collection_storage_test.go
@@ -65,6 +65,27 @@ func TestBuildCollectionStorageFixtureHonorsFieldCount(t *testing.T) {
 	}
 }
 
+func TestCollectionStorageVectorSearchOptionsUseProjectionPreset(t *testing.T) {
+	opts, err := collectionStorageVectorSearchOptions([]float32{1, 0, 0}, 2, 8, true, false)
+	if err != nil {
+		t.Fatalf("projected options: %v", err)
+	}
+	if !opts.IncludeDocuments || len(opts.DocumentFetchOptions.ExcludePaths) != 1 || opts.DocumentFetchOptions.ExcludePaths[0] != "embedding" {
+		t.Fatalf("projected opts=%+v want include docs excluding embedding", opts)
+	}
+	if got := collectionStorageVectorFinalFetchShape(true, false); got != collectionStorageVectorFinalFetchProjectionNoEmbedding {
+		t.Fatalf("final fetch shape=%q", got)
+	}
+
+	full, err := collectionStorageVectorSearchOptions([]float32{1, 0, 0}, 2, 8, true, true)
+	if err != nil {
+		t.Fatalf("full options: %v", err)
+	}
+	if !full.IncludeDocuments || len(full.DocumentFetchOptions.ExcludePaths) != 0 {
+		t.Fatalf("full opts=%+v want full docs without projection", full)
+	}
+}
+
 func TestCollectionStorageSuiteSmoke(t *testing.T) {
 	withExplicitFlag(t, "keys")
 	out, err := runCollectionStorageSuite(BenchConfig{
@@ -87,7 +108,37 @@ func TestCollectionStorageSuiteSmoke(t *testing.T) {
 	if err != nil {
 		t.Fatalf("runCollectionStorageSuite: %v", err)
 	}
-	for _, needle := range []string{"collection_storage", "typed_column_part", "vector_typed_column", "vector_search_smoke", "unsupported workloads", "Comparison Semantics"} {
+	for _, needle := range []string{"collection_storage", "typed_column_part", "vector_typed_column", "vector_search_smoke", "projection_without_embedding", "unsupported workloads", "Comparison Semantics"} {
+		if !strings.Contains(out, needle) {
+			t.Fatalf("output missing %q:\n%s", needle, out)
+		}
+	}
+}
+
+func TestCollectionStorageSuiteVectorFullDocumentsShape(t *testing.T) {
+	withExplicitFlag(t, "keys")
+	out, err := runCollectionStorageSuite(BenchConfig{
+		Keys:       8,
+		BatchSize:  4,
+		Profile:    "durable",
+		DBsArg:     "treedb",
+		SeedUsed:   1,
+		CPUProfile: filepath.Join(t.TempDir(), "cpu"),
+	}, collectionStorageSuiteOptions{
+		ModesArg:            "vector_typed_column",
+		WorkloadsArg:        "vector_search_smoke",
+		QueryCount:          1,
+		PointGetCount:       2,
+		VectorDims:          3,
+		VectorTopK:          2,
+		IncludeFinalFetch:   true,
+		VectorFullDocuments: true,
+		CheckpointReopen:    true,
+	})
+	if err != nil {
+		t.Fatalf("runCollectionStorageSuite full docs: %v", err)
+	}
+	for _, needle := range []string{"vector_final_fetch_shape: `full_document_embedding_echo`", "explicit full-document/embedding-echo comparison path"} {
 		if !strings.Contains(out, needle) {
 			t.Fatalf("output missing %q:\n%s", needle, out)
 		}


### PR DESCRIPTION
## Objective

Close #1904 under umbrella #2169 by auditing vector document-fetch call sites, demos, docs, and benchmark presentation so the preferred post-#1903 path is the easy/default path:

```text
ColumnRetainedPayloadNonColumn + ProjectionOrientedVectorDocumentFetchPreset (exclude top-level vector field)
```

Full-document fetch, embedding echo, and `ColumnRetainedPayloadFull` remain explicit opt-in comparison/compatibility paths.

Base synced after #1735: `origin/main` at `34f858dde2a999a7d9aec943c34199b7a9387c6b`.

## Context

The #1903 preset exists but was not consistently applied across call sites, demos, and docs. Most existing call sites still used manual `DocumentFetchOptions{ExcludePaths: []string{"embedding"}}` inline literals or `IncludeDocuments: true` without projection. This PR makes the preset the default path and surfaces the distinction clearly in outputs and documentation.

## Non-goals

- No on-disk format or migration changes.
- No #1735 resource-sharing changes.
- No quantized scorer/typed-column type expansion changes.
- Exact full-document fetch and `ColumnRetainedPayloadFull` remain available and tested/labeled as explicit comparison/compatibility paths.

## Design

**New flag:** `-collection-storage-vector-full-documents` (default `false`) — when set with `-collection-storage-include-final-fetch`, uses the full-document/embedding-echo path instead of the preferred projection preset. Guard: passing `vectorFullDocuments=true` without `includeFinalFetch=true` returns an explicit error.

**New tristate shape label:** `collectionStorageVectorFinalFetchShape` returns one of `none`, `projection_without_embedding`, or `full_document_embedding_echo`, surfaced in the report JSON (`vector_final_fetch_shape`) and rendered markdown.

**Demo flag:** `cmd/treedb_column_graph_demo` gains `-include-doc-embedding` for explicit full-doc opt-in; `-include-docs` now applies the projection preset by default. `demoCollectionMeta` sets `RetainedPayload: ColumnRetainedPayloadNonColumn` explicitly.

**New counters:** `VectorDocumentOutputBytes`, `VectorDocumentFieldsSkipped`, and `VectorDocumentRetainedBytes` added to `collectionStorageWorkloadCounters`; first two appear in the abbreviated markdown vector counters string (`candidates/edges/docs/output_bytes/fields_skipped`); all three in JSON output.

**Invariants:**
- Projected results must omit the `embedding` field; full-doc results must include it (enforced by `validateCollectionStorageVectorResults` / `collectionStorageDocumentHasField`).
- `collectionStorageVectorSearchOptions` builds the options struct once and reuses it for both the correctness-check call and the timed benchmark loop.

## Scope

- Includes: `cmd/unified_bench/main.go`, `cmd/unified_bench/suite_collection_storage.go`, `cmd/unified_bench/suite_collection_storage_test.go`, `cmd/treedb_column_graph_demo/main.go`, `cmd/treedb_column_graph_demo/main_test.go`, `cmd/treedb_vector_demo/main.go`, `cmd/treedb_vector_demo/README.md`, `cmd/treedb_vector_search_demo/main.go`, `cmd/treedb_vector_search_demo/README.md`, `cmd/unified_bench/README.md`, `TreeDB/collections/vector_index_search_test.go`, `TreeDB/collections/column_vector_graph_prepared_search_test.go`, `TreeDB/collections/column_vector_graph_row_ref_state_test.go`, `TreeDB/collections/vector_index_retained_payload_policy_1876_test.go`, `TreeDB/docs/docs_lint_test.go`, `TreeDB/docs/guides/vector-search-typed-column.md`, `TreeDB/docs/guides/typed-storage-performance.md`, `TreeDB/docs/guides/collections-quickstart.md`, `TreeDB/docs/spec/column-graph-native-vector-search.md`.
- Excludes: on-disk storage format, wire protocol, graph-search hot loop, quantized scorer, #1735 resource-sharing paths.

## Correctness

- Tests run (exact commands):

```sh
GOWORK=off go test ./cmd/unified_bench -count=1
GOWORK=off go test ./TreeDB/collections -count=1
GOWORK=off go test ./TreeDB/docs -count=1
GOWORK=off go test ./cmd/treedb_column_graph_demo ./cmd/treedb_vector_demo ./cmd/treedb_vector_search_demo -count=1
GOWORK=off go test ./cmd/unified_bench -run 'TestCollectionStorage' -count=1
GOWORK=off go test ./cmd/treedb_column_graph_demo ./cmd/unified_bench ./TreeDB/docs -count=1
```

- Corruption/edge cases covered:
  - `validateCollectionStorageVectorResults` now asserts embedding presence/absence per fetch shape.
  - Guard clause rejects `vectorFullDocuments=true` without `includeFinalFetch=true` with an explicit error.
  - `TestCollectionStorageSuiteVectorFullDocumentsShape` validates the full-doc path end-to-end.
  - `TestDemoVectorSearchOptionsProjectionModes` validates all three projection modes for the demo helper.
  - `TestDocs_VectorProjectionFetchGuidance` pins required guidance strings in docs and READMEs.

- Concurrency/race coverage: no new concurrency changes; existing race coverage unaffected.

## Performance

- Benchmarks run (exact commands):

```sh
GOMAXPROCS=8 GOWORK=off go test ./TreeDB/collections \
  -run '^$' \
  -bench 'BenchmarkOpenVectorIndexSearcher(ColumnGraphRetainedPayloadPolicy1876|ProjectionOrientedFetchPreset1903)$' \
  -benchmem \
  -benchtime=100ms \
  -count=1
```

- Results table (smoke evidence, Apple M3 `darwin/arm64`, `GOMAXPROCS=8`):

| Row | ns/op | ops/sec | B/op | allocs/op | docs/search | output_B/search |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| `policy/non_column/preferred_exclude_embedding` | 54021 | 18511 | 40489 | 415 | 10.00 | 2816 |
| `policy/non_column/full_documents_comparison` | 126693 | 7893 | 103977 | 449 | 10.00 | 15976 |
| `policy/full/preferred_exclude_embedding` | 434682 | 2301 | 198400 | 3108 | 10.00 | 2816 |
| `policy/full/full_documents_comparison` | 302696 | 3304 | 83816 | 27 | 10.00 | 15976 |
| `policy/none/preferred_exclude_embedding` | 37708 | 26520 | 22552 | 282 | 10.00 | 506.0 |
| `policy/none/full_documents_comparison` | 108433 | 9222 | 92316 | 319 | 10.00 | 13666 |
| `preset/manual_non_column_exclude_embedding` | 68014 | 14703 | 40488 | 415 | 10.00 | 2816 |
| `preset/preset_non_column_exclude_embedding` | 51860 | 19283 | 40488 | 415 | 10.00 | 2816 |

Storage counters:

| Policy | retained_payload_B_total | column_asset_B_total | graph_asset_B_total | db_dir_B_total | write_amplification |
| --- | ---: | ---: | ---: | ---: | ---: |
| `non_column` | 237568 | 115450 | 0 | 3412194 | 2.087 |
| `full` | 1635231 | 115450 | 0 | 3565780 | 2.181 |
| `none` | 2048 | 115450 | 0 | 3381170 | 2.068 |

- Regressions: none. This is a presentation/response-shape change, not a graph-search hot-loop change.

## Rollout / Toggle Plan

- Default setting: `-collection-storage-include-final-fetch=true` uses `projection_without_embedding` by default. Full-document path requires explicit `-collection-storage-vector-full-documents`.
- How to disable quickly: pass `-collection-storage-vector-full-documents` to restore full-document/embedding-echo behaviour; pass `-collection-storage-include-final-fetch=false` to skip post-top-k fetch entirely.

## Follow-ups

- Full performance closeout matrix (longer `-benchtime`, `-count=5`) deferred.
- Historical spec tables remain historical evidence; relabeled without hiding compatibility/full-doc rows.

## Column Graph Native Workstream (#1646, if applicable)

### Copied/Adapted From Old Stack

- Copied: N/A
- Adapted: N/A
- Oracle/comparator only: N/A
- Quarantined/not copied: N/A

### Path Identity

- Native reader: `ProjectionOrientedVectorDocumentFetchPreset` applied at post-top-k fetch boundary
- Decoded comparator: N/A
- Legacy/native vector index: unaffected
- Unsupported/fail-closed: `vectorFullDocuments=true` without `includeFinalFetch` → explicit error

### Base And Dependency State

- Base branch: `origin/main`
- Base commit: `34f858dde2a999a7d9aec943c34199b7a9387c6b`
- Base PR/head: after #1735
- #1621/#1634 assumptions: N/A
- Missing generic column-store primitives: none
- Parent review fixes propagated: flag pass-through bug (`VectorFullDocuments` in `main.go`) fixed

### Evidence

- Tests: all targeted packages pass (see Correctness above)
- Benchmarks: smoke evidence table above
- Status/fallback proof: `vector_final_fetch_shape` label in report output; `doc_projection` in demo output
- Performance attribution: presentation/fetch-shape change only; graph-search hot loop unaffected
- Local regressions found/fixed: missing `VectorFullDocuments` flag pass-through in `cmd/unified_bench/main.go` (found during internal review, fixed in this commit)

### Test Plan Start

- Milestone tasks targeted: #1904 (vector fetch projection audit)
- Tests to add before or with implementation: `TestCollectionStorageSuiteVectorFullDocumentsShape`, `TestCollectionStorageVectorSearchOptionsUseProjectionPreset`, `TestColumnGraphDemoIncludeDocsUsesProjectionPreset`, `TestDemoVectorSearchOptionsProjectionModes`, `TestDocs_VectorProjectionFetchGuidance`
- Existing tests to preserve: all prior `vector_search_smoke`, benchmark, and collections tests
- #1646 test-list changes made before implementation: N/A

### Performance Plan Start

- Relevant benchmarks/metrics: `BenchmarkOpenVectorIndexSearcher(ColumnGraphRetainedPayloadPolicy1876|ProjectionOrientedFetchPreset1903)`
- Baseline/comparator command: see Benchmarks section
- Expected setup/search/materialization boundary: graph search hot loop untouched; only post-top-k fetch shape changes
- Upstream costs explicitly out of scope: full performance matrix
- Local performance risks to watch: none identified

### Test Plan Close

- Additional tests found during implementation/review: embedding presence/absence validation in `validateCollectionStorageVectorResults`
- Tests added or changed: 5 new tests; 4 existing benchmark/test call sites updated to use preset helper
- Failing tests fixed: flag pass-through bug caused `TestCollectionStorageSuiteVectorFullDocumentsShape` to fail before fix
- #1646 test-list changes made at close: N/A
- Residual untested gaps: `VectorDocumentRetainedBytes` collected in JSON but not in abbreviated markdown counter string (intentional)

### Performance Plan Close

- Benchmark commands run: see Performance section
- Results summary: `preset/preset_non_column_exclude_embedding` at 51860 ns/op vs manual at 68014 ns/op; preferred path is faster than manual inline equivalent
- Before/after or baseline comparison: full-doc comparison rows retained in table for reference
- Local slow/heavy code found and fixed: none
- Remaining upstream or deferred costs: full `-count=5` matrix deferred

### AI Review Loop

- Codex latest-head review: requested
- Copilot latest-head review: completed — no blocking issues found; all targeted tests pass; minor note on `VectorDocumentRetainedBytes` not appearing in abbreviated counter string (intentional)
- CodeRabbit latest-head review: not yet requested
- Review comments/threads resolved or explicitly dismissed: Copilot review comment addressed
- Re-requested after final meaningful push: yes

---

## Optimization PR Checklist (TreeDB)

### Scope
- [x] Single, clear objective for this PR (not a bundle)
- [x] Explicit include list (files/symbols touched): see Scope section
- [x] Explicit exclude list (files/symbols NOT touched): see Scope section
- [x] No unwanted feature reintroduction (e.g. async slab writer, hard zones, ValueIndex) unless explicitly stated in the PR objective

### Safety / Correctness
- [ ] Clear written-vs-durable semantics for any `*Sync` path touched — N/A, no sync path touched
- [ ] No new mmap usage on mutable/truncating files — N/A
- [x] All new length fields are capped before allocation (OOM-safe) — N/A, no new length fields
- [x] CRC/checksum behavior is fail-closed (clean error, no panic) — N/A
- [ ] Any concurrency change has a defined state machine and invariants — N/A, no concurrency changes

### Tests
- [x] Added deterministic regression tests for the targeted failure mode
- [x] Tests avoid sleeps where possible (use latches/hooks)
- [x] Added corruption/edge-case tests (truncation, bad headers, invalid lengths) when format/parsing changes — N/A, no format changes
- [x] Ran locally:
  - [ ] `go test ./... -count=1`
  - [x] Any targeted packages/benchmarks: `./cmd/unified_bench`, `./TreeDB/collections`, `./TreeDB/docs`, `./cmd/treedb_column_graph_demo`, `./cmd/treedb_vector_demo`, `./cmd/treedb_vector_search_demo`

### Benchmarks / Measurements
- [x] Added or updated a benchmark relevant to the change
- [x] Reported results in PR description (before/after, command, machine)
- [ ] Included "incompressible" (worst-case) results if compression is involved — N/A

### Docs
- [ ] Updated `docs/OPT_SPRINT_NEXT.md` milestone status (if applicable)
- [x] Documented any new config knobs + defaults (`-collection-storage-vector-full-documents`, `-include-doc-embedding`)
- [x] Called out any format change in PR description — N/A, no format changes

### Rollout / Toggle Plan (if behavior-affecting)
- [x] Safe defaults (projection preset on by default; full-doc requires explicit opt-in)
- [x] Clear knobs to disable/revert behavior quickly (`-collection-storage-vector-full-documents`, `-include-doc-embedding`)
- [x] Observability: `vector_final_fetch_shape`, `doc_projection`, `doc_output_B`, `doc_fields_skipped` counters in output