### PR TITLE
Optimize YCSB BSON set update path

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3095,28 +3095,30 @@ func (c *Collection) Meta() CollectionMeta {
 	return *c.meta.copy()
 }
 
-// SameCachedCatalog reports whether both handles were opened against the same
-// collection catalog state.
+// SameCachedCatalog reports whether both handles are cached against the same
+// collection catalog state. For commit-agnostic catalog shapes, the system root
+// is the catalog identity; data-only commits can advance CommitSeq without
+// changing collection metadata or root descriptors.
 func (c *Collection) SameCachedCatalog(other *Collection) bool {
 	if c == nil || other == nil {
 		return false
 	}
-	cName, cSystemRoot, cCommitSeq := c.cachedCatalogIdentity()
-	otherName, otherSystemRoot, otherCommitSeq := other.cachedCatalogIdentity()
+	cName, cSystemRoot, cCommitSeq, cCommitAgnostic := c.cachedCatalogIdentity()
+	otherName, otherSystemRoot, otherCommitSeq, otherCommitAgnostic := other.cachedCatalogIdentity()
 	return cName != "" &&
 		cName == otherName &&
 		cSystemRoot != 0 &&
 		cSystemRoot == otherSystemRoot &&
-		cCommitSeq == otherCommitSeq
+		(cCommitSeq == otherCommitSeq || (cCommitAgnostic && otherCommitAgnostic))
 }
 
-func (c *Collection) cachedCatalogIdentity() (name string, systemRoot, commitSeq uint64) {
+func (c *Collection) cachedCatalogIdentity() (name string, systemRoot, commitSeq uint64, commitAgnostic bool) {
 	if c == nil {
-		return "", 0, 0
+		return "", 0, 0, false
 	}
 	c.catalogMu.RLock()
 	defer c.catalogMu.RUnlock()
-	return c.meta.Name, c.catalogSystemRoot, c.catalogCommitSeq
+	return c.meta.Name, c.catalogSystemRoot, c.catalogCommitSeq, c.canReuseCachedCatalogAcrossDataOnlyCommits(c.catalog)
 }
 
 // CreateIndex creates and backfills one secondary index as a schema barrier.
@@ -15803,7 +15805,7 @@ func (c *Collection) stageDirectPrimaryOverlayLocked(domain *collectionWriteDoma
 	domain.baseCommitSeq = plan.baseCommitSeq
 	domain.baseSystemRoot = plan.baseSystemRoot
 	if plan.catalog != nil {
-		domain.primaryRoot = plan.catalog.rootID(collectionPrimaryRootName(plan.meta.Name))
+		domain.primaryRoot = plan.catalog.rootID(direct.primaryRootName)
 	}
 	domain.count += modifiedCount
 	domain.bufferedBytes = saturatingAddNonNegativeInt64(domain.bufferedBytes, direct.stagedBytes)
@@ -15830,7 +15832,7 @@ func (c *Collection) stageDirectNoIndexTableUpdateLocked(domain *collectionWrite
 		hasBufferedIndexedPendingWrites(domain) {
 		return false, nil
 	}
-	if direct.primaryRootName == "" || direct.primaryRootName != collectionPrimaryRootName(plan.meta.Name) {
+	if direct.primaryRootName == "" || plan.catalog == nil || direct.primaryRootName != plan.catalog.primaryRootName {
 		return false, nil
 	}
 	baseRoot, ok := plan.baseRootIDs[direct.primaryRootName]
@@ -16774,7 +16776,10 @@ func (c *Collection) catalogForSnapshotWithWriteDomainLockState(snap *backenddb.
 	commitSeq := snapshotCommitSeq(snap)
 
 	c.catalogMu.RLock()
-	if cached := c.catalog; cached != nil && c.catalogSystemRoot == systemRoot && c.catalogCommitSeq == commitSeq {
+	if cached := c.catalog; cached != nil &&
+		systemRoot != 0 &&
+		c.catalogSystemRoot == systemRoot &&
+		(c.catalogCommitSeq == commitSeq || c.canReuseCachedCatalogAcrossDataOnlyCommits(cached)) {
 		c.catalogMu.RUnlock()
 		return cached, nil
 	}
@@ -16807,6 +16812,14 @@ func (c *Collection) collectionName() string {
 		return c.name
 	}
 	return c.meta.Name
+}
+
+func (c *Collection) canReuseCachedCatalogAcrossDataOnlyCommits(catalog *collectionCatalog) bool {
+	return c != nil &&
+		c.db != nil &&
+		c.db.CommandWALEnabled() &&
+		catalog != nil &&
+		len(catalog.meta.VectorIndexes) == 0
 }
 
 func cachedWriteDomainCatalogForState(domain *collectionWriteDomain, systemRoot, commitSeq uint64) *collectionCatalog {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -9306,23 +9306,40 @@ func TestCollectionCachedCatalogRefreshesAfterCrossHandleWrite(t *testing.T) {
 	}
 }
 
-func TestCollectionCachedCatalogUsesCommitSeq(t *testing.T) {
-	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+func TestCollectionCachedCatalogUsesSystemRoot(t *testing.T) {
+	opts := treedb.OptionsFor(treedb.ProfileCommandWALRelaxed, t.TempDir())
+	d, cleanup, err := treedb.OpenBackendWithCachedLeafLog(opts)
 	if err != nil {
 		t.Fatalf("open db: %v", err)
 	}
-	defer func() { _ = d.Close() }()
+	defer func() { _ = cleanup() }()
+	if !d.CommandWALEnabled() {
+		t.Fatal("expected command WAL")
+	}
 
 	mgr := NewCollectionManager(d)
-	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "users"}); err != nil {
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name:    "users",
+		Options: CollectionOptions{DocumentFormat: DocumentFormatBSON},
+	}); err != nil {
 		t.Fatalf("create collection: %v", err)
 	}
 	col, err := mgr.OpenCollection("users")
 	if err != nil {
 		t.Fatalf("open collection: %v", err)
 	}
-	if _, err := col.InsertBatch([][]byte{[]byte("u1")}, [][]byte{[]byte(`{"name":"ada"}`)}); err != nil {
+	doc, err := bson.Marshal(bson.D{
+		{Key: "_id", Value: "u1"},
+		{Key: "name", Value: "ada"},
+	})
+	if err != nil {
+		t.Fatalf("marshal doc: %v", err)
+	}
+	if _, err := col.InsertBatchValidatedBSON([][]byte{[]byte("u1")}, [][]byte{doc}); err != nil {
 		t.Fatalf("insert: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush insert: %v", err)
 	}
 
 	snap := d.AcquireSnapshot()
@@ -9335,10 +9352,9 @@ func TestCollectionCachedCatalogUsesCommitSeq(t *testing.T) {
 		t.Fatalf("load catalog: %v", err)
 	}
 	rootName := collectionPrimaryRootName("users")
-	staleCatalog := cloneCatalogWithRootUpdates(catalog, catalog.meta, []string{rootName}, []uint64{^uint64(0)})
 
 	col.catalogMu.Lock()
-	col.catalog = staleCatalog
+	col.catalog = catalog
 	col.catalogSystemRoot = snapshotSystemRoot(snap)
 	col.catalogCommitSeq = snapshotCommitSeq(snap) + 1
 	col.catalogMu.Unlock()
@@ -9347,8 +9363,8 @@ func TestCollectionCachedCatalogUsesCommitSeq(t *testing.T) {
 	if err != nil {
 		t.Fatalf("catalogForSnapshot: %v", err)
 	}
-	if got := refreshed.rootID(rootName); got == ^uint64(0) {
-		t.Fatalf("catalog cache ignored commit sequence and returned stale root %d", got)
+	if refreshed != catalog {
+		t.Fatal("catalog cache missed despite unchanged system root")
 	}
 	if got, want := refreshed.rootID(rootName), catalog.rootID(rootName); got != want {
 		t.Fatalf("refreshed root=%d want %d", got, want)

--- a/TreeDB/collections/benchmark_update_batch_size1_test.go
+++ b/TreeDB/collections/benchmark_update_batch_size1_test.go
@@ -239,3 +239,137 @@ func BenchmarkCollectionUpdateBSONSetVsBatch_NoIndex_Size1(b *testing.B) {
 		}
 	})
 }
+
+func BenchmarkCollectionUpdateBSONSetYCSB_NoIndex_Size1(b *testing.B) {
+	profiles := []struct {
+		name    string
+		profile treedb.Profile
+	}{
+		{name: "bench_no_wal", profile: treedb.ProfileBench},
+		{name: "command_wal_relaxed", profile: treedb.ProfileCommandWALRelaxed},
+	}
+	for _, profile := range profiles {
+		b.Run(profile.name, func(b *testing.B) {
+			benchmarkCollectionUpdateBSONSetYCSBNoIndexSize1(b, profile.profile)
+		})
+	}
+}
+
+func benchmarkCollectionUpdateBSONSetYCSBNoIndexSize1(b *testing.B, profile treedb.Profile) {
+	b.Helper()
+	const (
+		docCount         = 10000
+		fieldCount       = 10
+		fieldLength      = 100
+		preloadBatchSize = 1000
+	)
+	openCollection := func() (*collections.Collection, [][]byte, func()) {
+		dbDir := b.TempDir()
+		opts := treedb.OptionsFor(profile, dbDir)
+		opts.IndexOuterLeavesInValueLog = true
+		backend, cleanup, err := treedb.OpenBackendWithCachedLeafLog(opts)
+		if err != nil {
+			b.Fatalf("open backend: %v", err)
+		}
+		manager := collections.NewCollectionManager(backend)
+		meta := &collections.CollectionMeta{
+			Name: "bench.docs",
+			Options: collections.CollectionOptions{
+				DocumentFormat:          collections.DocumentFormatBSON,
+				DataRootStoragePolicy:   collections.RootStorageCompressed,
+				IndexStateStoragePolicy: collections.RootStorageCompressed,
+			},
+		}
+		if _, err := manager.CreateCollection(meta); err != nil {
+			_ = cleanup()
+			b.Fatalf("create collection: %v", err)
+		}
+		collection, err := manager.OpenCollection("bench.docs")
+		if err != nil {
+			_ = cleanup()
+			b.Fatalf("open collection: %v", err)
+		}
+		ids := make([][]byte, docCount)
+		docs := make([][]byte, docCount)
+		for i := 0; i < docCount; i++ {
+			id := "user" + strconv.Itoa(i)
+			ids[i] = []byte(id)
+			doc, err := bson.Marshal(benchmarkUpdateYCSBDocument(id, i, fieldCount, fieldLength))
+			if err != nil {
+				_ = cleanup()
+				b.Fatalf("marshal doc: %v", err)
+			}
+			docs[i] = doc
+		}
+		for i := 0; i < docCount; i += preloadBatchSize {
+			end := i + preloadBatchSize
+			if end > docCount {
+				end = docCount
+			}
+			if _, err := collection.InsertBatchValidatedBSON(ids[i:end], docs[i:end]); err != nil {
+				_ = cleanup()
+				b.Fatalf("insert docs [%d:%d]: %v", i, end, err)
+			}
+		}
+		if err := manager.FlushAll(); err != nil {
+			_ = cleanup()
+			b.Fatalf("flush preload docs: %v", err)
+		}
+		cleanupClosure := func() { _ = cleanup() }
+		return collection, ids, cleanupClosure
+	}
+
+	valueA := bytes.Repeat([]byte{0xA5}, fieldLength)
+	valueB := bytes.Repeat([]byte{0x5A}, fieldLength)
+	typeA, rawA, err := bson.MarshalValue(valueA)
+	if err != nil {
+		b.Fatalf("marshal value A: %v", err)
+	}
+	typeB, rawB, err := bson.MarshalValue(valueB)
+	if err != nil {
+		b.Fatalf("marshal value B: %v", err)
+	}
+	values := []bson.RawValue{
+		{Type: typeA, Value: rawA},
+		{Type: typeB, Value: rawB},
+	}
+	collection, ids, cleanup := openCollection()
+	b.Cleanup(cleanup)
+	fields := []collections.BSONSetField{{
+		Key:   "field0",
+		Value: values[0],
+	}}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		fields[0].Value = values[i&1]
+		matched, _, err := collection.UpdateBSONSet(ids[i%docCount], fields)
+		if err != nil {
+			b.Fatalf("UpdateBSONSet: %v", err)
+		}
+		if !matched {
+			b.Fatalf("UpdateBSONSet missing id %q", string(ids[i%docCount]))
+		}
+	}
+}
+
+func benchmarkUpdateYCSBDocument(id string, ordinal int, fieldCount int, fieldLength int) bson.D {
+	doc := make(bson.D, 0, fieldCount+1)
+	doc = append(doc, bson.E{Key: "_id", Value: id})
+	for field := 0; field < fieldCount; field++ {
+		doc = append(doc, bson.E{
+			Key:   "field" + strconv.Itoa(field),
+			Value: benchmarkUpdateYCSBFieldValue(ordinal, field, fieldLength),
+		})
+	}
+	return doc
+}
+
+func benchmarkUpdateYCSBFieldValue(ordinal int, field int, length int) []byte {
+	out := make([]byte, length)
+	seed := byte((ordinal + field*17) & 0xff)
+	for i := range out {
+		out[i] = seed + byte(i)
+	}
+	return out
+}

--- a/TreeDB/collections/bson_set_update.go
+++ b/TreeDB/collections/bson_set_update.go
@@ -98,7 +98,15 @@ func (c *Collection) updateBSONSetDirect(documentID []byte, spec bsonSetUpdate) 
 	if err := c.validateBSONSetDocumentFormat(); err != nil {
 		return false, false, err
 	}
-	items := []updateBatchItem{newBSONSetUpdateBatchItem(documentID, spec)}
+	var itemStorage [1]updateBatchItem
+	itemStorage[0] = updateBatchItem{
+		UpdateBatchItem: UpdateBatchItem{
+			DocumentID: documentID,
+		},
+		bsonSet:    spec,
+		hasBSONSet: true,
+	}
+	items := itemStorage[:]
 	mode := updateBatchModeNoSecondaryUniqueIndexChanges
 	results, batched, err := c.updateBatchOwnedItems(items, mode)
 	if c.commandWALActive(nil) && err == nil && !batched {


### PR DESCRIPTION
## Summary

- Add `BenchmarkCollectionUpdateBSONSetYCSB_NoIndex_Size1` for the YCSB BSON single-document `$set` update shape under `bench_no_wal` and `command_wal_relaxed`.
- Reuse immutable collection catalogs by system-root identity for command-WAL, data-only/no-vector catalog shapes instead of forcing reloads on commit-seq drift.
- Avoid one single-document wrapper allocation in `UpdateBSONSet` and remove a couple of repeated primary-root-name lookups in direct buffered update staging.

Part of #2173.
Closes #2175.

## Performance Evidence

Hardware/context from `go test`: Linux amd64, `11th Gen Intel(R) Core(TM) i5-11400F @ 2.60GHz`.

Baseline command:

```sh
GOWORK=off go test ./TreeDB/collections \
  -run '^$' \
  -bench 'BenchmarkCollectionUpdateBSONSetYCSB_NoIndex_Size1' \
  -benchmem \
  -count=3
```

After command:

```sh
GOWORK=off go test ./TreeDB/collections \
  -run '^$' \
  -bench 'BenchmarkCollectionUpdateBSONSetYCSB_NoIndex_Size1' \
  -benchmem \
  -count=5
```

`benchstat` summary:

```text
CollectionUpdateBSONSetYCSB_NoIndex_Size1/bench_no_wal-12          2.756us -> 2.549us  -7.51%  p=0.036 n=3+5
CollectionUpdateBSONSetYCSB_NoIndex_Size1/command_wal_relaxed-12  14.365us -> 6.017us -58.11%  p=0.036 n=3+5

CollectionUpdateBSONSetYCSB_NoIndex_Size1/bench_no_wal-12          165 B/op -> 155 B/op      ~  p=0.393 n=3+5
CollectionUpdateBSONSetYCSB_NoIndex_Size1/command_wal_relaxed-12  10.963KiB/op -> 1.630KiB/op -85.13% p=0.036 n=3+5

CollectionUpdateBSONSetYCSB_NoIndex_Size1/bench_no_wal-12          3 allocs/op -> 3 allocs/op       ~
CollectionUpdateBSONSetYCSB_NoIndex_Size1/command_wal_relaxed-12  50 allocs/op -> 20 allocs/op -60.00%
```

Final single profile run:

```text
BenchmarkCollectionUpdateBSONSetYCSB_NoIndex_Size1/command_wal_relaxed-12  188940  6408 ns/op  1655 B/op  20 allocs/op
```

Profile artifacts captured locally under `/tmp/ycsb_update_issues_pHWFlO/`:

- `after_2175_scoped_cmdwal_cpu.pprof`
- `after_2175_scoped_cmdwal_cpu_top.txt`
- `after_2175_scoped_cmdwal_allocs.pprof`
- `after_2175_scoped_cmdwal_alloc_objects_top.txt`
- `after_2175_scoped_cmdwal_alloc_space_top.txt`
- `benchstat_2175_commandwal_scoped.clean.txt`

Post-change CPU top no longer has `loadCollectionCatalog` as a top allocation/CPU source. Remaining visible costs are update planning, BSON same-shape replacement, command-WAL/syscall work, CRC, and buffered staging.

## Correctness / Safety

The catalog-cache relaxation is scoped to command-WAL-enabled handles and no-vector cached catalogs, and still requires identical nonzero system root. Existing write-domain cache lookups remain commit-seq sensitive. A focused test covers system-root catalog reuse in command-WAL mode, and stale vector-index handle tests are included in local verification.

## Verification

```sh
GOWORK=off go test ./TreeDB/collections \
  -run 'TestCollectionCachedCatalogUsesSystemRoot|TestOpenCollectionWriteDomainCatalogCacheUsesCommitSeq|TestCollectionVectorIndexNativeRootStaleHandleSingleInsertMaintainsGraph|TestCollectionVectorIndexNativeRootRebuildUsesCurrentRootForStaleHandle' \
  -count=1
# ok github.com/snissn/gomap/TreeDB/collections 0.139s

GOWORK=off go test ./TreeDB/collections -count=1
# ok github.com/snissn/gomap/TreeDB/collections 94.699s

GOWORK=off go test ./TreeDB/nativewire ./cmd/treedb-native-server -count=1
# ok github.com/snissn/gomap/TreeDB/nativewire 1.045s
# ok github.com/snissn/gomap/cmd/treedb-native-server 0.003s
```

AI reviews have not been requested yet; this PR now has focused tests, benchmark proof, and a current evidence body.
