### PR TITLE
Batch command-WAL BSON set updates

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -11209,6 +11209,9 @@ func (c *Collection) updateSingleInlineWithoutCombiner(domain *collectionWriteDo
 	results, batched, err := c.updateBatchOwnedItems(items, updateBatchModeNoSecondaryUniqueIndexChanges)
 	if !batched && err == nil {
 		if items[0].hasBSONSet {
+			if c.commandWALActive(nil) {
+				return c.updateBSONSetDirect(items[0].DocumentID, items[0].bsonSet)
+			}
 			return c.updateDirectBSONSet(items[0].DocumentID, items[0].bsonSet)
 		}
 		return c.updateDirect(items[0].DocumentID, items[0].Update)
@@ -11934,6 +11937,11 @@ func (combiner *collectionUpdateCombiner) prepareBatchWithScratch(batch []collec
 		prepared.err = err
 		return prepared
 	}
+	if plan != nil && plan.directBufferedUpdate == nil && len(plan.deltaTables) > 0 {
+		plan.close()
+		prepared.fallbackDirect = true
+		return prepared
+	}
 	if plan == nil || plan.directBufferedUpdate == nil {
 		prepared.plan = plan
 		return prepared
@@ -12002,7 +12010,23 @@ func (combiner *collectionUpdateCombiner) stagePreparedBatches(prepared []collec
 	}
 	merged, collection, err := mergeDirectBufferedPreparedBatches(direct)
 	if err == nil {
+		var unlockCommandWALRawStage func()
+		unlockCommandWALRawStage, err = collection.prepareDirectUpdateCommandWALStage(merged)
+		if unlockCommandWALRawStage != nil {
+			defer unlockCommandWALRawStage()
+		}
+	}
+	if err == nil {
 		err = collection.withMutationLock(func() error {
+			var unlockCommandWALStage func()
+			if merged.bufferedCommandWALIntent != nil {
+				var lockErr error
+				unlockCommandWALStage, lockErr = collection.lockCommandWALStageCoordinator()
+				if lockErr != nil {
+					return lockErr
+				}
+				defer unlockCommandWALStage()
+			}
 			buffered, bufferErr := collection.bufferDirectUpdateBatchPlanLocked(merged)
 			if bufferErr != nil {
 				return bufferErr
@@ -12042,7 +12066,24 @@ func (combiner *collectionUpdateCombiner) stageSingleDirectPreparedBatch(prepare
 		return
 	}
 	collection := prepared.batch[0].collection
-	err := collection.withMutationLock(func() error {
+	unlockCommandWALRawStage, err := collection.prepareDirectUpdateCommandWALStage(prepared.plan)
+	if unlockCommandWALRawStage != nil {
+		defer unlockCommandWALRawStage()
+	}
+	if err != nil {
+		combiner.completePreparedBatchWithError(prepared, err)
+		return
+	}
+	err = collection.withMutationLock(func() error {
+		var unlockCommandWALStage func()
+		if prepared.plan.bufferedCommandWALIntent != nil {
+			var lockErr error
+			unlockCommandWALStage, lockErr = collection.lockCommandWALStageCoordinator()
+			if lockErr != nil {
+				return lockErr
+			}
+			defer unlockCommandWALStage()
+		}
 		buffered, bufferErr := collection.bufferDirectUpdateBatchPlanLocked(prepared.plan)
 		if bufferErr != nil {
 			return bufferErr
@@ -12167,6 +12208,7 @@ func mergeDirectBufferedPreparedBatches(prepared []collectionUpdateCombinePrepar
 	totalTemplateEntries := 0
 	totalPrimaryEntries := 0
 	totalSecondaryRootPlans := 0
+	totalCommandWALDocuments := 0
 	for _, p := range prepared {
 		plan := p.plan
 		if plan == nil || plan.directBufferedUpdate == nil {
@@ -12191,6 +12233,7 @@ func mergeDirectBufferedPreparedBatches(prepared []collectionUpdateCombinePrepar
 		totalTemplateEntries += len(plan.directBufferedUpdate.templateEntries)
 		totalPrimaryEntries += len(plan.directBufferedUpdate.primaryEntries)
 		totalSecondaryRootPlans += len(plan.directBufferedUpdate.secondaryRootPlans)
+		totalCommandWALDocuments += len(plan.commandWALDocuments)
 	}
 	merged := &updateBatchPlan{
 		meta:                        firstPlan.meta,
@@ -12220,6 +12263,9 @@ func mergeDirectBufferedPreparedBatches(prepared []collectionUpdateCombinePrepar
 	}
 	if totalSecondaryRootPlans > 0 {
 		merged.directBufferedUpdate.secondaryRootPlans = make([]directBufferedSecondaryRootPlan, 0, totalSecondaryRootPlans)
+	}
+	if totalCommandWALDocuments > 0 {
+		merged.commandWALDocuments = make([]commitlog.CollectionDocument, 0, totalCommandWALDocuments)
 	}
 	rootIndex := make(map[string]int, len(firstPlan.rootNames))
 	addRoot := func(plan *updateBatchPlan, idx int) error {
@@ -12267,12 +12313,38 @@ func mergeDirectBufferedPreparedBatches(prepared []collectionUpdateCombinePrepar
 		}
 		merged.directBufferedUpdate.secondaryRootPlans = append(merged.directBufferedUpdate.secondaryRootPlans, plan.directBufferedUpdate.secondaryRootPlans...)
 		merged.directBufferedUpdate.stagedBytes += plan.directBufferedUpdate.stagedBytes
+		merged.commandWALDocuments = append(merged.commandWALDocuments, plan.commandWALDocuments...)
+		merged.rowRemainderBytes = saturatingAddNonNegativeInt64(merged.rowRemainderBytes, plan.rowRemainderBytes)
 	}
 	if sameBufferedRead {
 		merged.bufferedBase = commonBufferedBase
 		merged.bufferedReadGeneration = commonBufferedReadGeneration
 	}
 	return merged, collection, nil
+}
+
+func (c *Collection) prepareDirectUpdateCommandWALStage(plan *updateBatchPlan) (func(), error) {
+	if c == nil || plan == nil || !c.commandWALActive(nil) ||
+		plan.bufferedCommandWALIntent != nil ||
+		!plan.canStageDirectBufferedUpdateAfterCommandWALAppend() ||
+		len(plan.commandWALDocuments) == 0 {
+		return nil, nil
+	}
+	intent, err := c.newCollectionUpdateCommandWALIntent(plan.commandWALDocuments, nil)
+	if err != nil {
+		return nil, err
+	}
+	plan.bufferedCommandWALIntent = intent
+	if c.db == nil {
+		return nil, nil
+	}
+	runTestBeforeCommandWALBufferedUpdateStageLockHook()
+	unlockCommandWALRawStage := c.db.LockCommandWALStaging()
+	if err := c.drainCommandWALStageCoordinatorBeforeMutation(); err != nil {
+		unlockCommandWALRawStage()
+		return nil, err
+	}
+	return unlockCommandWALRawStage, nil
 }
 
 func addCollectionUpdateStatsForMerge(dst *CollectionUpdateStats, src CollectionUpdateStats) {
@@ -15942,6 +16014,10 @@ func (c *Collection) bufferDirectUpdateBatchPlanLocked(plan *updateBatchPlan) (b
 	if err := c.requireColumnStoreCommandWAL(plan.meta, nil); err != nil {
 		plan.stats.BufferStagePrecheck += updateBatchStatsSince(detailedStats, precheckStart)
 		return false, err
+	}
+	if c.commandWALActive(nil) && commandWALStageIntent == nil {
+		plan.stats.BufferStagePrecheck += updateBatchStatsSince(detailedStats, precheckStart)
+		return false, nil
 	}
 	plan.stats.BufferStagePrecheck += updateBatchStatsSince(detailedStats, precheckStart)
 

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -11942,6 +11942,13 @@ func (combiner *collectionUpdateCombiner) prepareBatchWithScratch(batch []collec
 		prepared.fallbackDirect = true
 		return prepared
 	}
+	if plan != nil && plan.directBufferedUpdate == nil && len(plan.deltaTables) == 0 &&
+		len(ownedBatch) > 0 && ownedBatch[0].collection != nil &&
+		ownedBatch[0].collection.commandWALActive(nil) {
+		plan.close()
+		prepared.fallbackDirect = true
+		return prepared
+	}
 	if plan == nil || plan.directBufferedUpdate == nil {
 		prepared.plan = plan
 		return prepared

--- a/TreeDB/collections/benchmark_update_bsonset_combiner_test.go
+++ b/TreeDB/collections/benchmark_update_bsonset_combiner_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"strconv"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -90,6 +91,8 @@ func benchmarkCollectionUpdateBSONSetYCSBNoIndexParallel16(b *testing.B, profile
 	if err := manager.FlushAll(); err != nil {
 		b.Fatalf("flush preload docs: %v", err)
 	}
+	manager.ResetUpdateCombinersForProfiling()
+	manager.ResetUpdateCombineQueueDepthMax()
 
 	valueA := bytes.Repeat([]byte{0xA5}, fieldLength)
 	valueB := bytes.Repeat([]byte{0x5A}, fieldLength)
@@ -111,19 +114,25 @@ func benchmarkCollectionUpdateBSONSetYCSBNoIndexParallel16(b *testing.B, profile
 	}
 
 	var next atomic.Uint64
+	var stop atomic.Bool
 	start := make(chan struct{})
-	errCh := make(chan error, workers)
+	errCh := make(chan error, 1)
+	var wg sync.WaitGroup
 	for worker := 0; worker < workers; worker++ {
+		wg.Add(1)
 		go func() {
+			defer wg.Done()
 			<-start
 			fields := []BSONSetField{{
 				Key:   "field0",
 				Value: values[0],
 			}}
 			for {
+				if stop.Load() {
+					return
+				}
 				n := int(next.Add(1) - 1)
 				if n >= b.N {
-					errCh <- nil
 					return
 				}
 				fields[0].Value = values[(n/docCount)&1]
@@ -136,11 +145,15 @@ func benchmarkCollectionUpdateBSONSetYCSBNoIndexParallel16(b *testing.B, profile
 					matched, _, err = collection.UpdateBSONSet(id, fields)
 				}
 				if err != nil {
-					errCh <- fmt.Errorf("update %d id=%q: %w", n, string(id), err)
+					if stop.CompareAndSwap(false, true) {
+						errCh <- fmt.Errorf("update %d id=%q: %w", n, string(id), err)
+					}
 					return
 				}
 				if !matched {
-					errCh <- fmt.Errorf("update %d missing id %q", n, string(id))
+					if stop.CompareAndSwap(false, true) {
+						errCh <- fmt.Errorf("update %d missing id %q", n, string(id))
+					}
 					return
 				}
 			}
@@ -152,13 +165,16 @@ func benchmarkCollectionUpdateBSONSetYCSBNoIndexParallel16(b *testing.B, profile
 	b.ResetTimer()
 	startTime := time.Now()
 	close(start)
-	for worker := 0; worker < workers; worker++ {
-		if err := <-errCh; err != nil {
-			b.Fatalf("worker update: %v", err)
-		}
-	}
+	wg.Wait()
 	elapsed := time.Since(startTime)
 	b.StopTimer()
+	select {
+	case err := <-errCh:
+		if err != nil {
+			b.Fatalf("worker update: %v", err)
+		}
+	default:
+	}
 
 	stats := collectionManagerStatsBenchmarkDelta(manager.StatsSnapshot(), statsBefore)
 	if elapsed > 0 {

--- a/TreeDB/collections/benchmark_update_bsonset_combiner_test.go
+++ b/TreeDB/collections/benchmark_update_bsonset_combiner_test.go
@@ -1,0 +1,200 @@
+package collections
+
+import (
+	"bytes"
+	"fmt"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	treedb "github.com/snissn/gomap/TreeDB"
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+func BenchmarkCollectionUpdateBSONSetYCSBNoIndexParallel16(b *testing.B) {
+	for _, tc := range []struct {
+		name    string
+		profile treedb.Profile
+	}{
+		{name: "command_wal_relaxed", profile: treedb.ProfileCommandWALRelaxed},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			b.Run("direct", func(b *testing.B) {
+				benchmarkCollectionUpdateBSONSetYCSBNoIndexParallel16(b, tc.profile, true)
+			})
+			b.Run("public_combiner", func(b *testing.B) {
+				benchmarkCollectionUpdateBSONSetYCSBNoIndexParallel16(b, tc.profile, false)
+			})
+		})
+	}
+}
+
+func benchmarkCollectionUpdateBSONSetYCSBNoIndexParallel16(b *testing.B, profile treedb.Profile, direct bool) {
+	b.Helper()
+	const (
+		docCount         = 10000
+		fieldCount       = 10
+		fieldLength      = 100
+		preloadBatchSize = 1000
+		workers          = 16
+	)
+
+	dbDir := b.TempDir()
+	opts := treedb.OptionsFor(profile, dbDir)
+	opts.IndexOuterLeavesInValueLog = true
+	backend, cleanup, err := treedb.OpenBackendWithCachedLeafLog(opts)
+	if err != nil {
+		b.Fatalf("open backend: %v", err)
+	}
+	defer func() { _ = cleanup() }()
+
+	manager := NewCollectionManager(backend)
+	manager.SetUpdateBatchDetailedStatsEnabled(true)
+	meta := &CollectionMeta{
+		Name: "bench.docs",
+		Options: CollectionOptions{
+			DocumentFormat:          DocumentFormatBSON,
+			DataRootStoragePolicy:   RootStorageCompressed,
+			IndexStateStoragePolicy: RootStorageCompressed,
+		},
+	}
+	if _, err := manager.CreateCollection(meta); err != nil {
+		b.Fatalf("create collection: %v", err)
+	}
+	collection, err := manager.OpenCollection("bench.docs")
+	if err != nil {
+		b.Fatalf("open collection: %v", err)
+	}
+
+	ids := make([][]byte, docCount)
+	docs := make([][]byte, docCount)
+	for i := 0; i < docCount; i++ {
+		id := "user" + strconv.Itoa(i)
+		ids[i] = []byte(id)
+		doc, err := bson.Marshal(benchmarkBSONSetCombinerYCSBDocument(id, i, fieldCount, fieldLength))
+		if err != nil {
+			b.Fatalf("marshal doc: %v", err)
+		}
+		docs[i] = doc
+	}
+	for i := 0; i < docCount; i += preloadBatchSize {
+		end := i + preloadBatchSize
+		if end > docCount {
+			end = docCount
+		}
+		if _, err := collection.InsertBatchValidatedBSON(ids[i:end], docs[i:end]); err != nil {
+			b.Fatalf("insert docs [%d:%d]: %v", i, end, err)
+		}
+	}
+	if err := manager.FlushAll(); err != nil {
+		b.Fatalf("flush preload docs: %v", err)
+	}
+
+	valueA := bytes.Repeat([]byte{0xA5}, fieldLength)
+	valueB := bytes.Repeat([]byte{0x5A}, fieldLength)
+	typeA, rawA, err := bson.MarshalValue(valueA)
+	if err != nil {
+		b.Fatalf("marshal value A: %v", err)
+	}
+	typeB, rawB, err := bson.MarshalValue(valueB)
+	if err != nil {
+		b.Fatalf("marshal value B: %v", err)
+	}
+	values := []bson.RawValue{
+		{Type: typeA, Value: rawA},
+		{Type: typeB, Value: rawB},
+	}
+
+	if !direct && collection.writeDomain != nil {
+		collection.writeDomain.updateCombineLastRequestUnixNano.Store(time.Now().Add(time.Hour).UnixNano())
+	}
+
+	var next atomic.Uint64
+	start := make(chan struct{})
+	errCh := make(chan error, workers)
+	for worker := 0; worker < workers; worker++ {
+		go func() {
+			<-start
+			fields := []BSONSetField{{
+				Key:   "field0",
+				Value: values[0],
+			}}
+			for {
+				n := int(next.Add(1) - 1)
+				if n >= b.N {
+					errCh <- nil
+					return
+				}
+				fields[0].Value = values[(n/docCount)&1]
+				id := ids[n%docCount]
+				var matched bool
+				var err error
+				if direct {
+					matched, _, err = collection.updateBSONSetDirect(id, mustBenchmarkBSONSetUpdate(fields))
+				} else {
+					matched, _, err = collection.UpdateBSONSet(id, fields)
+				}
+				if err != nil {
+					errCh <- fmt.Errorf("update %d id=%q: %w", n, string(id), err)
+					return
+				}
+				if !matched {
+					errCh <- fmt.Errorf("update %d missing id %q", n, string(id))
+					return
+				}
+			}
+		}()
+	}
+
+	statsBefore := manager.StatsSnapshot()
+	b.ReportAllocs()
+	b.ResetTimer()
+	startTime := time.Now()
+	close(start)
+	for worker := 0; worker < workers; worker++ {
+		if err := <-errCh; err != nil {
+			b.Fatalf("worker update: %v", err)
+		}
+	}
+	elapsed := time.Since(startTime)
+	b.StopTimer()
+
+	stats := collectionManagerStatsBenchmarkDelta(manager.StatsSnapshot(), statsBefore)
+	if elapsed > 0 {
+		b.ReportMetric(float64(b.N)/elapsed.Seconds(), "updates/sec")
+	}
+	reportCollectionUpdateStatsForBenchmark(b, stats, b.N)
+	if err := manager.FlushAll(); err != nil {
+		b.Fatalf("flush updates: %v", err)
+	}
+}
+
+func benchmarkBSONSetCombinerYCSBDocument(id string, ordinal int, fieldCount int, fieldLength int) bson.D {
+	doc := make(bson.D, 0, fieldCount+1)
+	doc = append(doc, bson.E{Key: "_id", Value: id})
+	for field := 0; field < fieldCount; field++ {
+		doc = append(doc, bson.E{
+			Key:   "field" + strconv.Itoa(field),
+			Value: benchmarkBSONSetCombinerYCSBFieldValue(ordinal, field, fieldLength),
+		})
+	}
+	return doc
+}
+
+func benchmarkBSONSetCombinerYCSBFieldValue(ordinal int, field int, length int) []byte {
+	out := make([]byte, length)
+	seed := byte((ordinal + field*17) & 0xff)
+	for i := range out {
+		out[i] = seed + byte(i)
+	}
+	return out
+}
+
+func mustBenchmarkBSONSetUpdate(fields []BSONSetField) bsonSetUpdate {
+	spec, err := newBSONSetUpdate(fields)
+	if err != nil {
+		panic(err)
+	}
+	return spec
+}

--- a/TreeDB/collections/bson_set_update.go
+++ b/TreeDB/collections/bson_set_update.go
@@ -65,9 +65,7 @@ func (c *Collection) UpdateBSONSet(documentID []byte, fields []BSONSetField) (bo
 		return false, false, err
 	}
 	var matched, modified bool
-	if c.commandWALActive(nil) {
-		matched, modified, err = c.updateBSONSetDirect(documentID, spec)
-	} else if combiner, domain := c.updateFastPathWithoutCreatingCombiner(); combiner != nil {
+	if combiner, domain := c.updateFastPathWithoutCreatingCombiner(); combiner != nil {
 		matched, modified, err = combiner.update(c, documentID, nil, spec, true)
 	} else if domain != nil {
 		defer domain.finishInlineUpdateWithoutCombiner()

--- a/TreeDB/collections/command_wal_test.go
+++ b/TreeDB/collections/command_wal_test.go
@@ -1255,6 +1255,141 @@ func TestCollectionCommandWALUpdateBSONSetCombinerLaneWorkerStagesAfterWALAppend
 	}
 }
 
+func TestCollectionCommandWALUpdateBSONSetCombinerMergedPreparedBatchesStageOneWALFrame(t *testing.T) {
+	dir := prepareCollectionCommandWALDir(t, CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			DocumentFormat: DocumentFormatBSON,
+		},
+	}, collectionCommandWALSetupInsert{
+		ids: [][]byte{[]byte("u1"), []byte("u2")},
+		docs: [][]byte{
+			mustBSONCollectionDocument(t, bson.D{{Key: "name", Value: "Ada"}, {Key: "city", Value: "hnl"}}),
+			mustBSONCollectionDocument(t, bson.D{{Key: "name", Value: "Grace"}, {Key: "city", Value: "nyc"}}),
+		},
+	})
+	d := openCollectionCommandWALDB(t, dir)
+	mgr := NewCollectionManager(d)
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		_ = d.Close()
+		t.Fatalf("OpenCollection: %v", err)
+	}
+
+	setCity := func(city string) bsonSetUpdate {
+		t.Helper()
+		spec, err := newBSONSetUpdate([]BSONSetField{{
+			Key:   "city",
+			Value: mustBSONRawValue(t, city),
+		}})
+		if err != nil {
+			t.Fatalf("prepare BSON set %q: %v", city, err)
+		}
+		return spec
+	}
+	done1 := make(chan collectionUpdateCombineResult, 1)
+	done2 := make(chan collectionUpdateCombineResult, 1)
+	req1 := newCollectionUpdateCombineRequest(col, []byte("u1"), nil, setCity("sea"), true, done1)
+	req2 := newCollectionUpdateCombineRequest(col, []byte("u2"), nil, setCity("bos"), true, done2)
+	combiner := &collectionUpdateCombiner{
+		maxBatch:        8,
+		domain:          col.writeDomain,
+		laneWorkers:     true,
+		shardedRequests: []chan collectionUpdateCombineRequest{make(chan collectionUpdateCombineRequest, 8)},
+	}
+	prepared1 := combiner.prepareBatchWithScratch([]collectionUpdateCombineRequest{req1}, nil)
+	prepared2 := combiner.prepareBatchWithScratch([]collectionUpdateCombineRequest{req2}, nil)
+	combiner.stagePreparedBatches([]collectionUpdateCombinePreparedBatch{prepared1, prepared2})
+
+	for name, done := range map[string]chan collectionUpdateCombineResult{"first": done1, "second": done2} {
+		select {
+		case result := <-done:
+			if result.err != nil || !result.matched || !result.modified {
+				_ = d.Close()
+				t.Fatalf("%s result=%+v want matched modified nil err", name, result)
+			}
+		case <-time.After(collectionTestTimeout(t, time.Second)):
+			_ = d.Close()
+			t.Fatalf("%s update did not complete", name)
+		}
+	}
+	for _, want := range []struct {
+		id   []byte
+		city string
+	}{
+		{id: []byte("u1"), city: "sea"},
+		{id: []byte("u2"), city: "bos"},
+	} {
+		doc, err := col.Get(want.id)
+		if err != nil {
+			_ = d.Close()
+			t.Fatalf("Get staged doc %q: %v", string(want.id), err)
+		}
+		if got := bson.Raw(doc).Lookup("city").StringValue(); got != want.city {
+			_ = d.Close()
+			t.Fatalf("staged city for %q=%q want %q", string(want.id), got, want.city)
+		}
+	}
+	if got := d.State().AppliedCommandLSN; got != 0 {
+		_ = d.Close()
+		t.Fatalf("AppliedCommandLSN after staged merged combiner update=%d, want 0 before flush", got)
+	}
+	frames := collectionCommandWALFrames(t, dir)
+	if len(frames) != 1 || frames[0].Kind != commitlog.CommandKindCollectionUpdateBatchByID {
+		_ = d.Close()
+		t.Fatalf("command WAL frames=%+v, want one merged update frame before flush", frames)
+	}
+	payload, err := commitlog.DecodeCollectionUpdateBatchByIDPayload(frames[0].Payload)
+	if err != nil {
+		_ = d.Close()
+		t.Fatalf("DecodeCollectionUpdateBatchByIDPayload: %v", err)
+	}
+	if payload.Collection != "users" || len(payload.Documents) != 2 {
+		_ = d.Close()
+		t.Fatalf("payload collection=%q documents=%d, want users/2", payload.Collection, len(payload.Documents))
+	}
+	if !bytes.Equal(payload.Documents[0].ID, []byte("u1")) || !bytes.Equal(payload.Documents[1].ID, []byte("u2")) {
+		_ = d.Close()
+		t.Fatalf("payload document IDs=%q,%q want u1,u2", payload.Documents[0].ID, payload.Documents[1].ID)
+	}
+	if err := col.Flush(); err != nil {
+		_ = d.Close()
+		t.Fatalf("Flush: %v", err)
+	}
+	if got := d.State().AppliedCommandLSN; got != 1 {
+		_ = d.Close()
+		t.Fatalf("AppliedCommandLSN after flush=%d, want 1", got)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	reopen := openCollectionCommandWALDB(t, dir)
+	defer func() { _ = reopen.Close() }()
+	reopened, err := NewCollectionManager(reopen).OpenCollection("users")
+	if err != nil {
+		t.Fatalf("OpenCollection reopen: %v", err)
+	}
+	for _, want := range []struct {
+		id   []byte
+		city string
+	}{
+		{id: []byte("u1"), city: "sea"},
+		{id: []byte("u2"), city: "bos"},
+	} {
+		doc, err := reopened.Get(want.id)
+		if err != nil {
+			t.Fatalf("Get reopened doc %q: %v", string(want.id), err)
+		}
+		if got := bson.Raw(doc).Lookup("city").StringValue(); got != want.city {
+			t.Fatalf("reopened city for %q=%q want %q", string(want.id), got, want.city)
+		}
+	}
+	if got := reopen.State().AppliedCommandLSN; got != 1 {
+		t.Fatalf("AppliedCommandLSN after reopen=%d, want 1", got)
+	}
+}
+
 func TestCollectionCommandWALUpdateBSONSetNoIndexDrainsBeforeRawKVCommandWAL(t *testing.T) {
 	dir := prepareCollectionCommandWALDir(t, CollectionMeta{
 		Name: "users",

--- a/TreeDB/collections/command_wal_test.go
+++ b/TreeDB/collections/command_wal_test.go
@@ -1157,6 +1157,104 @@ func TestCollectionCommandWALUpdateBSONSetNoIndexStagesAfterWALAppend(t *testing
 	}
 }
 
+func TestCollectionCommandWALUpdateBSONSetCombinerLaneWorkerStagesAfterWALAppend(t *testing.T) {
+	dir := prepareCollectionCommandWALDir(t, CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			DocumentFormat: DocumentFormatBSON,
+		},
+	}, collectionCommandWALSetupInsert{
+		ids: [][]byte{[]byte("u1")},
+		docs: [][]byte{
+			mustBSONCollectionDocument(t, bson.D{{Key: "name", Value: "Ada"}, {Key: "city", Value: "hnl"}}),
+		},
+	})
+	d := openCollectionCommandWALDB(t, dir)
+	mgr := NewCollectionManager(d)
+	mgr.SetUpdateBatchDetailedStatsEnabled(true)
+	mgr.SetUpdateCombineShardsForProfiling(4)
+	mgr.SetUpdateCombineLaneWorkersForProfiling(true)
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		_ = d.Close()
+		t.Fatalf("OpenCollection: %v", err)
+	}
+	col.writeDomain.updateCombineLastRequestUnixNano.Store(time.Now().Add(time.Hour).UnixNano())
+
+	before := mgr.StatsSnapshot()
+	matched, modified, err := col.UpdateBSONSet([]byte("u1"), []BSONSetField{{
+		Key:   "city",
+		Value: mustBSONRawValue(t, "sea"),
+	}})
+	if err != nil {
+		_ = d.Close()
+		t.Fatalf("UpdateBSONSet: %v", err)
+	}
+	if !matched || !modified {
+		_ = d.Close()
+		t.Fatalf("UpdateBSONSet matched=%t modified=%t, want true/true", matched, modified)
+	}
+	after := mgr.StatsSnapshot()
+	if got := after.UpdateCombineRequests - before.UpdateCombineRequests; got == 0 {
+		_ = d.Close()
+		t.Fatal("UpdateBSONSet did not enter the update combiner")
+	}
+	if got := after.UpdateCombineBatches - before.UpdateCombineBatches; got == 0 {
+		_ = d.Close()
+		t.Fatal("UpdateBSONSet combiner did not complete a batch")
+	}
+	if got := after.UpdateCombineFallbackRequests - before.UpdateCombineFallbackRequests; got != 0 {
+		_ = d.Close()
+		t.Fatalf("combiner fallback requests=%d, want 0", got)
+	}
+	doc, err := col.Get([]byte("u1"))
+	if err != nil {
+		_ = d.Close()
+		t.Fatalf("Get staged doc: %v", err)
+	}
+	if got := bson.Raw(doc).Lookup("city").StringValue(); got != "sea" {
+		_ = d.Close()
+		t.Fatalf("staged city=%q want sea", got)
+	}
+	if got := d.State().AppliedCommandLSN; got != 0 {
+		_ = d.Close()
+		t.Fatalf("AppliedCommandLSN after staged combiner update=%d, want 0 before flush", got)
+	}
+	frames := collectionCommandWALFrames(t, dir)
+	if len(frames) != 1 || frames[0].Kind != commitlog.CommandKindCollectionUpdateBatchByID {
+		_ = d.Close()
+		t.Fatalf("command WAL frames=%+v, want one update frame before flush", frames)
+	}
+	if err := col.Flush(); err != nil {
+		_ = d.Close()
+		t.Fatalf("Flush: %v", err)
+	}
+	if got := d.State().AppliedCommandLSN; got != 1 {
+		_ = d.Close()
+		t.Fatalf("AppliedCommandLSN after flush=%d, want 1", got)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	reopen := openCollectionCommandWALDB(t, dir)
+	defer func() { _ = reopen.Close() }()
+	reopened, err := NewCollectionManager(reopen).OpenCollection("users")
+	if err != nil {
+		t.Fatalf("OpenCollection reopen: %v", err)
+	}
+	doc, err = reopened.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("Get reopened doc: %v", err)
+	}
+	if got := bson.Raw(doc).Lookup("city").StringValue(); got != "sea" {
+		t.Fatalf("reopened city=%q want sea", got)
+	}
+	if got := reopen.State().AppliedCommandLSN; got != 1 {
+		t.Fatalf("AppliedCommandLSN after reopen=%d, want 1", got)
+	}
+}
+
 func TestCollectionCommandWALUpdateBSONSetNoIndexDrainsBeforeRawKVCommandWAL(t *testing.T) {
 	dir := prepareCollectionCommandWALDir(t, CollectionMeta{
 		Name: "users",

--- a/TreeDB/collections/command_wal_test.go
+++ b/TreeDB/collections/command_wal_test.go
@@ -1827,10 +1827,15 @@ func TestCollectionCommandWALUpdateBSONSetNoopFlushesStagedUpdate(t *testing.T) 
 	})
 	d := openCollectionCommandWALDB(t, dir)
 	defer func() { _ = d.Close() }()
-	col, err := NewCollectionManager(d).OpenCollection("users")
+	mgr := NewCollectionManager(d)
+	col, err := mgr.OpenCollection("users")
 	if err != nil {
 		t.Fatalf("OpenCollection: %v", err)
 	}
+	mgr.SetUpdateCombineShardsForProfiling(4)
+	mgr.SetUpdateCombineLaneWorkersForProfiling(true)
+	col.writeDomain.updateCombineLastRequestUnixNano.Store(time.Now().Add(time.Hour).UnixNano())
+	before := mgr.StatsSnapshot()
 	matched, modified, err := col.UpdateBSONSet([]byte("u1"), []BSONSetField{{
 		Key:   "city",
 		Value: mustBSONRawValue(t, "sea"),
@@ -1860,6 +1865,13 @@ func TestCollectionCommandWALUpdateBSONSetNoopFlushesStagedUpdate(t *testing.T) 
 	frames := collectionCommandWALFrames(t, dir)
 	if len(frames) != 2 {
 		t.Fatalf("command WAL frame count=%d, want 2", len(frames))
+	}
+	after := mgr.StatsSnapshot()
+	if got := after.UpdateCombineRequests - before.UpdateCombineRequests; got < 2 {
+		t.Fatalf("update combiner requests delta=%d want at least 2", got)
+	}
+	if got := after.UpdateCombineFallbackRequests - before.UpdateCombineFallbackRequests; got == 0 {
+		t.Fatal("update combiner fallback requests delta=0 want positive for command-WAL no-op")
 	}
 }
 

--- a/TreeDB/collections/direct_buffered_update_bench_test.go
+++ b/TreeDB/collections/direct_buffered_update_bench_test.go
@@ -168,6 +168,9 @@ func benchmarkTemplateV1ReplaceWith(raw []byte) func([]byte) ([]byte, bool, erro
 
 func collectionManagerStatsBenchmarkDelta(after, before CollectionManagerStats) CollectionManagerStats {
 	return CollectionManagerStats{
+		MutationLockCalls:                after.MutationLockCalls - before.MutationLockCalls,
+		MutationLockWait:                 after.MutationLockWait - before.MutationLockWait,
+		MutationLockHold:                 after.MutationLockHold - before.MutationLockHold,
 		IndexedStageBatches:              after.IndexedStageBatches - before.IndexedStageBatches,
 		IndexedStageDocs:                 after.IndexedStageDocs - before.IndexedStageDocs,
 		IndexedStageBytes:                after.IndexedStageBytes - before.IndexedStageBytes,
@@ -215,6 +218,18 @@ func collectionManagerStatsBenchmarkDelta(after, before CollectionManagerStats) 
 		UpdateBatchIndexValueUnchanged:   after.UpdateBatchIndexValueUnchanged - before.UpdateBatchIndexValueUnchanged,
 		UpdateBatchUniqueChecks:          after.UpdateBatchUniqueChecks - before.UpdateBatchUniqueChecks,
 		UpdateBatchUniqueCheckSkips:      after.UpdateBatchUniqueCheckSkips - before.UpdateBatchUniqueCheckSkips,
+		UpdateCombineRequests:            after.UpdateCombineRequests - before.UpdateCombineRequests,
+		UpdateCombineBatches:             after.UpdateCombineBatches - before.UpdateCombineBatches,
+		UpdateCombineBatchedRequests:     after.UpdateCombineBatchedRequests - before.UpdateCombineBatchedRequests,
+		UpdateCombineFallbackRequests:    after.UpdateCombineFallbackRequests - before.UpdateCombineFallbackRequests,
+		UpdateCombineInlineRequests:      after.UpdateCombineInlineRequests - before.UpdateCombineInlineRequests,
+		UpdateCombineQueueDepthMax:       after.UpdateCombineQueueDepthMax - before.UpdateCombineQueueDepthMax,
+		UpdateCombineEnqueue:             after.UpdateCombineEnqueue - before.UpdateCombineEnqueue,
+		UpdateCombineWait:                after.UpdateCombineWait - before.UpdateCombineWait,
+		UpdateCombineQueueWait:           after.UpdateCombineQueueWait - before.UpdateCombineQueueWait,
+		UpdateCombineDrain:               after.UpdateCombineDrain - before.UpdateCombineDrain,
+		UpdateCombineRun:                 after.UpdateCombineRun - before.UpdateCombineRun,
+		UpdateCombineResultDelivery:      after.UpdateCombineResultDelivery - before.UpdateCombineResultDelivery,
 	}
 }
 
@@ -233,6 +248,12 @@ func reportCollectionUpdateStatsForBenchmark(b *testing.B, stats CollectionManag
 			b.ReportMetric(float64(value.Nanoseconds())/float64(docs), name)
 		}
 	}
+	if stats.MutationLockCalls > 0 {
+		b.ReportMetric(float64(stats.MutationLockCalls), "mutation_lock_calls")
+		b.ReportMetric(float64(stats.MutationLockCalls)/float64(docs), "mutation_lock_calls/doc")
+	}
+	reportDurationPerDoc(stats.MutationLockWait, "mutation_lock_wait_ns/doc")
+	reportDurationPerDoc(stats.MutationLockHold, "mutation_lock_hold_ns/doc")
 	if stats.IndexedStageBatches > 0 {
 		b.ReportMetric(float64(stats.IndexedStageBatches), "indexed_stage_batches")
 		b.ReportMetric(float64(stats.IndexedStageDocs)/float64(stats.IndexedStageBatches), "indexed_stage_docs/batch")
@@ -288,4 +309,26 @@ func reportCollectionUpdateStatsForBenchmark(b *testing.B, stats CollectionManag
 	reportDurationPerDoc(stats.UpdateBatchBufferSecondaryAppend, "update_buffer_secondary_append_ns/doc")
 	reportDurationPerDoc(stats.UpdateBatchBufferRootAppend, "update_buffer_root_append_ns/doc")
 	reportDurationPerDoc(stats.UpdateBatchPublish, "update_publish_ns/doc")
+	if stats.UpdateCombineRequests > 0 {
+		b.ReportMetric(float64(stats.UpdateCombineRequests), "update_combine_requests")
+		b.ReportMetric(float64(stats.UpdateCombineRequests)/float64(docs), "update_combine_requests/doc")
+	}
+	if stats.UpdateCombineInlineRequests > 0 {
+		b.ReportMetric(float64(stats.UpdateCombineInlineRequests), "update_combine_inline_requests")
+	}
+	if stats.UpdateCombineBatches > 0 {
+		b.ReportMetric(float64(stats.UpdateCombineBatches), "update_combine_batches")
+		b.ReportMetric(float64(stats.UpdateCombineBatchedRequests)/float64(stats.UpdateCombineBatches), "update_combine_requests/batch")
+	}
+	reportUintPerDoc(stats.UpdateCombineBatchedRequests, "update_combine_batched_requests/doc")
+	reportUintPerDoc(stats.UpdateCombineFallbackRequests, "update_combine_fallback_requests/doc")
+	if stats.UpdateCombineQueueDepthMax > 0 {
+		b.ReportMetric(float64(stats.UpdateCombineQueueDepthMax), "update_combine_queue_depth_max")
+	}
+	reportDurationPerDoc(stats.UpdateCombineEnqueue, "update_combine_enqueue_ns/doc")
+	reportDurationPerDoc(stats.UpdateCombineWait, "update_combine_wait_ns/doc")
+	reportDurationPerDoc(stats.UpdateCombineQueueWait, "update_combine_queue_wait_ns/doc")
+	reportDurationPerDoc(stats.UpdateCombineDrain, "update_combine_drain_ns/doc")
+	reportDurationPerDoc(stats.UpdateCombineRun, "update_combine_run_ns/doc")
+	reportDurationPerDoc(stats.UpdateCombineResultDelivery, "update_combine_result_delivery_ns/doc")
 }

--- a/TreeDB/collections/direct_buffered_update_bench_test.go
+++ b/TreeDB/collections/direct_buffered_update_bench_test.go
@@ -223,7 +223,7 @@ func collectionManagerStatsBenchmarkDelta(after, before CollectionManagerStats) 
 		UpdateCombineBatchedRequests:     after.UpdateCombineBatchedRequests - before.UpdateCombineBatchedRequests,
 		UpdateCombineFallbackRequests:    after.UpdateCombineFallbackRequests - before.UpdateCombineFallbackRequests,
 		UpdateCombineInlineRequests:      after.UpdateCombineInlineRequests - before.UpdateCombineInlineRequests,
-		UpdateCombineQueueDepthMax:       after.UpdateCombineQueueDepthMax - before.UpdateCombineQueueDepthMax,
+		UpdateCombineQueueDepthMax:       after.UpdateCombineQueueDepthMax,
 		UpdateCombineEnqueue:             after.UpdateCombineEnqueue - before.UpdateCombineEnqueue,
 		UpdateCombineWait:                after.UpdateCombineWait - before.UpdateCombineWait,
 		UpdateCombineQueueWait:           after.UpdateCombineQueueWait - before.UpdateCombineQueueWait,


### PR DESCRIPTION
Closes #2176
Parent tracker: #2173

## Summary

- Routes public BSON `$set` updates through the update combiner in command-WAL mode instead of bypassing it with the direct path.
- Teaches direct buffered update-combiner staging to prepare and append command-WAL update intents before publishing buffered state, including merged multi-request prepared batches.
- Preserves command-WAL no-op frame semantics for lane-worker prepared combiner batches by falling back to the existing direct command-WAL path when a prepared batch has no root work.
- Adds command-WAL combiner coverage for lane-worker staging, merged prepared batches, and the no-op/staged-update LSN contract.
- Adds a package benchmark that isolates the YCSB-shaped concurrent update path and reports mutation-lock plus update-combine counters.

## Start-phase plan

Target #2176 specifically: concurrent batch-1 BSON `$set` updates into the same collection. The proof boundary is the collection update path, not the full mixed YCSB workload, because YCSB run is mostly reads and only about 5% updates.

## Close-phase tests

Passed locally on latest head `3baaf3de1`:

```sh
GOWORK=off go test ./TreeDB/collections -run 'TestCollectionCommandWALUpdateBSONSet(NoopFlushesStagedUpdate|CombinerLaneWorkerStagesAfterWALAppend|CombinerMergedPreparedBatchesStageOneWALFrame|NoIndexStagesAfterWALAppend)$' -count=1
```

Also passed locally on `afdd579ed` before the final benchmark-helper-only queue-depth metric fix:

```sh
GOWORK=off go test ./TreeDB/nativewire ./TreeDB/mongo_gateway ./cmd/treedb-native-server ./cmd/mongo_gateway_bench -count=1
GOWORK=off go test ./TreeDB/collections -count=1
go build -o bin/treedb-native-server ./cmd/treedb-native-server
```

New focused correctness coverage:

- `TestCollectionCommandWALUpdateBSONSetCombinerLaneWorkerStagesAfterWALAppend` verifies public `UpdateBSONSet` enters the combiner, does not fall back for a modified update, stages a command-WAL update frame before flush, keeps `AppliedCommandLSN=0` before flush, advances to `AppliedCommandLSN=1` after flush, and reopens with the updated BSON field.
- `TestCollectionCommandWALUpdateBSONSetCombinerMergedPreparedBatchesStageOneWALFrame` verifies two separately prepared combiner batches are merged into one command-WAL update frame containing both documents, staged reads see both updates, flush advances one LSN, and reopen sees both updates.
- `TestCollectionCommandWALUpdateBSONSetNoopFlushesStagedUpdate` now forces sharded lane-worker combiner mode and verifies a staged update followed by a no-op update still writes the required no-op command-WAL frame and advances `AppliedCommandLSN` to 2.

## Close-phase benchmark evidence

Hardware/context:

```text
host CPU: 11th Gen Intel(R) Core(TM) i5-11400F @ 2.60GHz
repo: snissn/gomap
base: main 94400fd2c
candidate: 3baaf3de1
benchmark artifact: /tmp/treedb_2176_parallel_bsonset_combiner_bench_20260602_queuefix.out
```

Command:

```sh
GOWORK=off go test ./TreeDB/collections \
  -run '^$' \
  -bench 'BenchmarkCollectionUpdateBSONSetYCSBNoIndexParallel16/command_wal_relaxed/(direct|public_combiner)$' \
  -benchmem \
  -benchtime=20000x \
  -count=5
```

Averages across 5 runs:

| path | ns/op | updates/sec | mutation_lock_calls/doc | mutation_lock_hold_ns/doc | mutation_lock_wait_ns/doc | update_combine_queue_depth_max | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| old direct route | 12,313.2 | 81,257.4 | 1.00000 | 6,218.8 | 177,655.0 | 0.0 | 4,827.6 | 15.0 |
| public combiner route | 7,313.8 | 137,203.6 | 0.09387 | 1,861.6 | 4.2 | 15.0 | 7,525.6 | 2.0 |

Delta:

- update throughput: `1.689x` higher in the isolated YCSB-shaped update benchmark;
- mutation-lock acquisitions: `90.6%` fewer per update;
- mutation-lock hold time: about `70.1%` lower per update;
- mutation-lock wait time: effectively eliminated in this benchmark;
- allocations: `15 -> 2 allocs/op`;
- allocated bytes: increases from about `4.8 KiB/op` to `7.5 KiB/op`. This is a known tradeoff of the current combiner buffering path; it did not block the targeted lock/throughput win, but it is the next allocation reuse area if profiles show it matters.

## External YCSB no-regression checks

The full YCSB workload is read-heavy, so this PR should not be expected to move headline run ops/sec as strongly as the isolated update benchmark. It should preserve correctness and avoid regressions.

The earlier candidate head `fce3ae5cc` ran the full YCSB no-regression sweep below. Later commits fixed command-WAL no-op handling and benchmark reporting; the modified-update hot path benchmark above was rerun on `3baaf3de1`.

`command_wal_durable` candidate run:

```sh
OUT_DIR=/tmp/treedb_ycsb_2176_candidate_durable_20260601_214925 \
TREEDB_PROFILE=command_wal_durable \
MONGODB_MODE=skip \
RUN_REPEATS=3 \
RECORDCOUNT=100000 \
OPERATIONCOUNT=10000 \
THREADCOUNT=16 \
NATIVE_ADDR=127.0.0.1:17146 \
TREEDB_MONGO_ADDR=127.0.0.1:27146 \
BUILD=false \
BUILD_GOYCSB=false \
scripts/ycsb_compare_mongodb_treedb.sh
```

Artifact: `/tmp/treedb_ycsb_2176_candidate_durable_20260601_214925/summary.md`

- zero parsed YCSB errors;
- native load: `79,139.0 ops/sec`;
- native run: `126,679.8 / 126,130.1 / 128,981.3 ops/sec`;
- native UPDATE avg: `197 / 195 / 199 us`;
- native UPDATE p99: `893 / 897 / 1273 us`;
- native UPDATE max: `1.750 / 1.186 / 1.579 ms`;
- TreeDB Mongo load: `61,857.9 ops/sec`;
- TreeDB Mongo run: `67,089.4 / 71,697.4 / 62,576.5 ops/sec`.

`command_wal_relaxed` candidate run:

```sh
OUT_DIR=/tmp/treedb_ycsb_2176_candidate_relaxed_20260601_214939 \
TREEDB_PROFILE=command_wal_relaxed \
MONGODB_MODE=skip \
RUN_REPEATS=3 \
RECORDCOUNT=100000 \
OPERATIONCOUNT=10000 \
THREADCOUNT=16 \
NATIVE_ADDR=127.0.0.1:17147 \
TREEDB_MONGO_ADDR=127.0.0.1:27147 \
BUILD=false \
BUILD_GOYCSB=false \
scripts/ycsb_compare_mongodb_treedb.sh
```

Artifact: `/tmp/treedb_ycsb_2176_candidate_relaxed_20260601_214939/summary.md`

- zero parsed YCSB errors;
- native load: `71,179.4 ops/sec`;
- native run: `128,514.2 / 126,828.3 / 131,647.1 ops/sec`;
- native UPDATE avg: `188 / 203 / 203 us`;
- native UPDATE p99: `900 / 1095 / 1134 us`;
- native UPDATE max: `1.375 / 1.652 / 2.030 ms`;
- TreeDB Mongo load: `61,891.2 ops/sec`;
- TreeDB Mongo run: `75,510.0 / 78,990.0 / 73,273.2 ops/sec`.

## Regression assessment

No correctness regressions found in affected package tests or external YCSB error counters. The targeted update benchmark shows the intended lock-contention win. Full YCSB headline throughput is roughly steady because the workload is only about 5% updates; that is expected for this slice.

The known tradeoff is higher B/op in the isolated combiner benchmark despite much lower allocs/op. I do not consider that a merge blocker for #2176 because the bottleneck being targeted is serialized tiny-update mutation locking, and the external YCSB checks do not show a correctness or headline regression. It should be tracked in the next allocation pass if profiles make it hot.

## Review status

- Internal Codex subagent correctness review found no blocking issue and identified one low residual test gap in merged prepared-batch command-WAL coverage. That gap is covered by `TestCollectionCommandWALUpdateBSONSetCombinerMergedPreparedBatchesStageOneWALFrame`.
- Codex GitHub review identified the lane-worker no-op command-WAL frame gap. `afdd579ed` fixed it and added forced lane-worker no-op coverage.
- Copilot review identified two benchmark harness issues. `afdd579ed` resets active combiners/queue-depth max before the measured window and uses a shared stop flag plus `WaitGroup` for worker errors.
- Copilot latest-head review identified a queue-depth max reporting issue. `3baaf3de1` reports the max-gauge snapshot directly instead of subtracting before/after.
- CodeRabbit auto-started on PR creation but was rate-limited / out of credits, so I did not re-trigger it.
- Latest-head CI must pass after `3baaf3de1` before merge.
