### PR TITLE
caching/db: retain protected-root leaf-log live IDs with commit-safe preregistration, bounded pointer dedupe, and rootID live-stat dedupe

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -4863,7 +4863,7 @@ func (db *DB) collectPublishedRootValueLogLiveIDsUntil(ctx context.Context, p *p
 		if err := scanRoot(published.system.rootID); err != nil {
 			return err
 		}
-		if published.system.rootID != 0 {
+		if published.system.rootID != 0 && published.system.rootID != systemRootID {
 			systemRootIDs, err := backenddb.CollectMaintenanceRootIDsForSystemRootWithContext(ctx, p, reader, published.system.rootID)
 			if err != nil {
 				return err

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -4574,41 +4574,35 @@ func (db *DB) valueLogGCOptions(dryRun bool) backenddb.ValueLogGCOptions {
 }
 
 func (db *DB) leafGenerationGCOptions() backenddb.LeafGenerationGCOptions {
+	protectedRootIDs, protectedSystemRootIDs := db.publishedLeafGenerationProtectionIDs()
 	return backenddb.LeafGenerationGCOptions{
-		ProtectedRootIDs:       db.publishedRootIDsForLeafGenerationGC(),
-		ProtectedSystemRootIDs: db.publishedSystemRootIDsForLeafGenerationGC(),
+		ProtectedRootIDs:       protectedRootIDs,
+		ProtectedSystemRootIDs: protectedSystemRootIDs,
 	}
 }
 
 func (db *DB) ProtectedLeafGenerationRootIDs() []uint64 {
-	return db.publishedRootIDsForLeafGenerationGC()
+	protectedRootIDs, _ := db.publishedLeafGenerationProtectionIDs()
+	return protectedRootIDs
 }
 
 func (db *DB) ProtectedLeafGenerationSystemRootIDs() []uint64 {
-	return db.publishedSystemRootIDsForLeafGenerationGC()
+	_, protectedSystemRootIDs := db.publishedLeafGenerationProtectionIDs()
+	return protectedSystemRootIDs
 }
 
-func (db *DB) publishedRootIDsForLeafGenerationGC() []uint64 {
+func (db *DB) ProtectedLeafGenerationRootIDPair() ([]uint64, []uint64) {
+	return db.publishedLeafGenerationProtectionIDs()
+}
+
+func (db *DB) publishedLeafGenerationProtectionIDs() ([]uint64, []uint64) {
 	if db == nil {
-		return nil
+		return nil, nil
 	}
 	db.mu.RLock()
 	published := clonePublishedRootSet(db.rootPublishedSet)
 	db.mu.RUnlock()
-	return publishedRootSetRootIDs(published)
-}
-
-func (db *DB) publishedSystemRootIDsForLeafGenerationGC() []uint64 {
-	if db == nil {
-		return nil
-	}
-	db.mu.RLock()
-	published := clonePublishedRootSet(db.rootPublishedSet)
-	db.mu.RUnlock()
-	if published == nil || published.system.rootID == 0 {
-		return nil
-	}
-	return []uint64{published.system.rootID}
+	return publishedRootSetRootIDs(published), publishedRootSetSystemRootIDs(published)
 }
 
 func publishedRootSetRootIDs(set *publishedRootSet) []uint64 {
@@ -4636,6 +4630,13 @@ func publishedRootSetRootIDs(set *publishedRootSet) []uint64 {
 	add(set.system.rootID)
 	add(set.iterator.rootID)
 	return roots
+}
+
+func publishedRootSetSystemRootIDs(set *publishedRootSet) []uint64 {
+	if set == nil || set.system.rootID == 0 {
+		return nil
+	}
+	return []uint64{set.system.rootID}
 }
 
 // valueLogInUsePaths returns a best-effort snapshot of value-log segment paths
@@ -17694,6 +17695,7 @@ planned:
 					maxSourceBytes = totalBytes
 				}
 			}
+			protectedRootIDs, protectedSystemRootIDs := db.publishedLeafGenerationProtectionIDs()
 			rewriteOpts := backenddb.ValueLogRewriteOnlineOptions{
 				BatchSize:       db.valueLogRewriteBatchSize(),
 				SyncEachBatch:   false,
@@ -17703,8 +17705,8 @@ planned:
 				// improve value-log read locality and reduce wall-time.
 				LocalityPolicy:                       backenddb.ValueLogRewriteLocalityGrouped,
 				ProtectedPaths:                       db.valueLogProtectedPaths(),
-				LeafGenerationProtectedRootIDs:       db.publishedRootIDsForLeafGenerationGC(),
-				LeafGenerationProtectedSystemRootIDs: db.publishedSystemRootIDsForLeafGenerationGC(),
+				LeafGenerationProtectedRootIDs:       protectedRootIDs,
+				LeafGenerationProtectedSystemRootIDs: protectedSystemRootIDs,
 				ReserveRIDs:                          db.ReserveValueLogRIDs,
 			}
 			processedRewriteIDs := []uint32(nil)
@@ -24649,6 +24651,7 @@ func (db *DB) maybeRunLeafGenerationPackMaintenance(runGC bool, quiet bool, admi
 		remainingGenerations := maxGenerations
 		remainingBytesToCopy := maxBytesToCopy
 		for remainingGenerations > 0 && remainingBytesToCopy > 0 {
+			protectedRootIDs, protectedSystemRootIDs := db.publishedLeafGenerationProtectionIDs()
 			stats, runErr := runner.LeafGenerationPackRunOnce(ctx, backenddb.LeafGenerationPackFromPlanOptions{
 				// Pack maintenance runs GC immediately after successful pack runs.
 				// Keep pack writes durable before GC can retire older generations.
@@ -24659,8 +24662,8 @@ func (db *DB) maybeRunLeafGenerationPackMaintenance(runGC bool, quiet bool, admi
 				MaxGenerations:             remainingGenerations,
 				MaxBytesToCopy:             remainingBytesToCopy,
 				ReserveRIDs:                db.ReserveValueLogRIDs,
-				ProtectedRootIDs:           db.publishedRootIDsForLeafGenerationGC(),
-				ProtectedSystemRootIDs:     db.publishedSystemRootIDsForLeafGenerationGC(),
+				ProtectedRootIDs:           protectedRootIDs,
+				ProtectedSystemRootIDs:     protectedSystemRootIDs,
 			})
 			if runErr != nil {
 				return runErr

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -4575,12 +4575,17 @@ func (db *DB) valueLogGCOptions(dryRun bool) backenddb.ValueLogGCOptions {
 
 func (db *DB) leafGenerationGCOptions() backenddb.LeafGenerationGCOptions {
 	return backenddb.LeafGenerationGCOptions{
-		ProtectedRootIDs: db.publishedRootIDsForLeafGenerationGC(),
+		ProtectedRootIDs:       db.publishedRootIDsForLeafGenerationGC(),
+		ProtectedSystemRootIDs: db.publishedSystemRootIDsForLeafGenerationGC(),
 	}
 }
 
 func (db *DB) ProtectedLeafGenerationRootIDs() []uint64 {
 	return db.publishedRootIDsForLeafGenerationGC()
+}
+
+func (db *DB) ProtectedLeafGenerationSystemRootIDs() []uint64 {
+	return db.publishedSystemRootIDsForLeafGenerationGC()
 }
 
 func (db *DB) publishedRootIDsForLeafGenerationGC() []uint64 {
@@ -4591,6 +4596,19 @@ func (db *DB) publishedRootIDsForLeafGenerationGC() []uint64 {
 	published := clonePublishedRootSet(db.rootPublishedSet)
 	db.mu.RUnlock()
 	return publishedRootSetRootIDs(published)
+}
+
+func (db *DB) publishedSystemRootIDsForLeafGenerationGC() []uint64 {
+	if db == nil {
+		return nil
+	}
+	db.mu.RLock()
+	published := clonePublishedRootSet(db.rootPublishedSet)
+	db.mu.RUnlock()
+	if published == nil || published.system.rootID == 0 {
+		return nil
+	}
+	return []uint64{published.system.rootID}
 }
 
 func publishedRootSetRootIDs(set *publishedRootSet) []uint64 {
@@ -17683,10 +17701,11 @@ planned:
 				// Maintenance rewrites are throughput-sensitive and operate on large
 				// source segments; group rewrite candidates by old segment+offset to
 				// improve value-log read locality and reduce wall-time.
-				LocalityPolicy:                 backenddb.ValueLogRewriteLocalityGrouped,
-				ProtectedPaths:                 db.valueLogProtectedPaths(),
-				LeafGenerationProtectedRootIDs: db.publishedRootIDsForLeafGenerationGC(),
-				ReserveRIDs:                    db.ReserveValueLogRIDs,
+				LocalityPolicy:                       backenddb.ValueLogRewriteLocalityGrouped,
+				ProtectedPaths:                       db.valueLogProtectedPaths(),
+				LeafGenerationProtectedRootIDs:       db.publishedRootIDsForLeafGenerationGC(),
+				LeafGenerationProtectedSystemRootIDs: db.publishedSystemRootIDsForLeafGenerationGC(),
+				ReserveRIDs:                          db.ReserveValueLogRIDs,
 			}
 			processedRewriteIDs := []uint32(nil)
 			processedRewriteChunks := []backenddb.ValueLogRewritePlanChunk(nil)
@@ -24641,6 +24660,7 @@ func (db *DB) maybeRunLeafGenerationPackMaintenance(runGC bool, quiet bool, admi
 				MaxBytesToCopy:             remainingBytesToCopy,
 				ReserveRIDs:                db.ReserveValueLogRIDs,
 				ProtectedRootIDs:           db.publishedRootIDsForLeafGenerationGC(),
+				ProtectedSystemRootIDs:     db.publishedSystemRootIDsForLeafGenerationGC(),
 			})
 			if runErr != nil {
 				return runErr

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -4844,6 +4844,17 @@ func (db *DB) collectPublishedRootValueLogLiveIDsUntil(ctx context.Context, p *p
 		if err := scanRoot(published.system.rootID); err != nil {
 			return err
 		}
+		if published.system.rootID != 0 {
+			systemRootIDs, err := backenddb.CollectMaintenanceRootIDsForSystemRootWithContext(ctx, p, reader, published.system.rootID)
+			if err != nil {
+				return err
+			}
+			for _, rootID := range systemRootIDs {
+				if err := scanRoot(rootID); err != nil {
+					return err
+				}
+			}
+		}
 		if err := scanRoot(published.iterator.rootID); err != nil {
 			return err
 		}

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -4463,7 +4463,7 @@ func (db *DB) ReclaimObservedValueLogSources(ctx context.Context, ids []uint32) 
 		}
 	}
 	if hasLeafGenerationGC {
-		if _, err := leafGcer.LeafGenerationGC(ctx, backenddb.LeafGenerationGCOptions{}); err != nil {
+		if _, err := leafGcer.LeafGenerationGC(ctx, db.leafGenerationGCOptions()); err != nil {
 			return err
 		}
 	}
@@ -4571,6 +4571,53 @@ func (db *DB) valueLogGCOptions(dryRun bool) backenddb.ValueLogGCOptions {
 		ProtectedInUsePaths:    inUse,
 		ProtectedRetainedPaths: retained,
 	}
+}
+
+func (db *DB) leafGenerationGCOptions() backenddb.LeafGenerationGCOptions {
+	return backenddb.LeafGenerationGCOptions{
+		ProtectedRootIDs: db.publishedRootIDsForLeafGenerationGC(),
+	}
+}
+
+func (db *DB) ProtectedLeafGenerationRootIDs() []uint64 {
+	return db.publishedRootIDsForLeafGenerationGC()
+}
+
+func (db *DB) publishedRootIDsForLeafGenerationGC() []uint64 {
+	if db == nil {
+		return nil
+	}
+	db.mu.RLock()
+	published := clonePublishedRootSet(db.rootPublishedSet)
+	db.mu.RUnlock()
+	return publishedRootSetRootIDs(published)
+}
+
+func publishedRootSetRootIDs(set *publishedRootSet) []uint64 {
+	if set == nil {
+		return nil
+	}
+	roots := make([]uint64, 0, len(set.pointShards)+2)
+	var seen map[uint64]struct{}
+	add := func(rootID uint64) {
+		if rootID == 0 {
+			return
+		}
+		if seen == nil {
+			seen = make(map[uint64]struct{}, len(set.pointShards)+2)
+		}
+		if _, ok := seen[rootID]; ok {
+			return
+		}
+		seen[rootID] = struct{}{}
+		roots = append(roots, rootID)
+	}
+	for i := range set.pointShards {
+		add(set.pointShards[i].rootID)
+	}
+	add(set.system.rootID)
+	add(set.iterator.rootID)
+	return roots
 }
 
 // valueLogInUsePaths returns a best-effort snapshot of value-log segment paths
@@ -4682,6 +4729,14 @@ func (db *DB) collectValueLogLiveIDsUntil(lastWrite int64) (map[uint32]struct{},
 				reader := newCachedLiveScanReader(valueReaderForBackendState(state), db.valueLogReader)
 				leafCtx, leafCancel := db.foregroundWriteResumeContext(lastWrite, 0)
 				defer leafCancel()
+				maintenanceRootIDs, err := backenddb.CollectMaintenanceRootIDsWithContext(leafCtx, p, reader, state)
+				if err != nil {
+					if errors.Is(err, context.Canceled) {
+						err = errForegroundWritesResumed
+					}
+					_ = snap.Close()
+					return nil, err
+				}
 				if state.RootPageID != 0 {
 					if err := db.collectIteratorValueLogLiveIDsUntil(tree.New(p, reader, state.RootPageID).IteratorWithOptions(nil, nil, tree.IteratorOptions{Mode: tree.IteratorModePointerProjection}), live, lastWrite); err != nil {
 						_ = snap.Close()
@@ -4716,7 +4771,7 @@ func (db *DB) collectValueLogLiveIDsUntil(lastWrite int64) (map[uint32]struct{},
 					_ = snap.Close()
 					return nil, err
 				}
-				if err := db.collectPublishedRootValueLogLiveIDsUntil(leafCtx, p, reader, publishedRoots, state.RootPageID, state.SystemRootPageID, live, lastWrite); err != nil {
+				if err := db.collectPublishedRootValueLogLiveIDsUntil(leafCtx, p, reader, publishedRoots, state.RootPageID, state.SystemRootPageID, maintenanceRootIDs, live, lastWrite); err != nil {
 					if errors.Is(err, context.Canceled) {
 						err = errForegroundWritesResumed
 					}
@@ -4750,11 +4805,15 @@ func (db *DB) collectValueLogLiveIDsUntil(lastWrite int64) (map[uint32]struct{},
 	return live, nil
 }
 
-func (db *DB) collectPublishedRootValueLogLiveIDsUntil(ctx context.Context, p *pager.Pager, reader tree.SlabReader, published *publishedRootSet, userRootID, systemRootID uint64, live map[uint32]struct{}, lastWrite int64) error {
-	if db == nil || p == nil || reader == nil || published == nil || live == nil {
+func (db *DB) collectPublishedRootValueLogLiveIDsUntil(ctx context.Context, p *pager.Pager, reader tree.SlabReader, published *publishedRootSet, userRootID, systemRootID uint64, maintenanceRootIDs []uint64, live map[uint32]struct{}, lastWrite int64) error {
+	if db == nil || p == nil || reader == nil || live == nil {
 		return nil
 	}
-	seenRoots := make(map[uint64]struct{}, len(published.pointShards)+1)
+	seenCap := len(maintenanceRootIDs) + 2
+	if published != nil {
+		seenCap += len(published.pointShards)
+	}
+	seenRoots := make(map[uint64]struct{}, seenCap)
 	scanRoot := func(rootID uint64) error {
 		if rootID == 0 || rootID == userRootID || rootID == systemRootID {
 			return nil
@@ -4771,13 +4830,23 @@ func (db *DB) collectPublishedRootValueLogLiveIDsUntil(ctx context.Context, p *p
 		}
 		return collectLeafRefValueLogLiveIDs(ctx, p, rootID, reader, live)
 	}
-	for i := range published.pointShards {
-		if err := scanRoot(published.pointShards[i].rootID); err != nil {
+	for _, rootID := range maintenanceRootIDs {
+		if err := scanRoot(rootID); err != nil {
 			return err
 		}
 	}
-	if err := scanRoot(published.iterator.rootID); err != nil {
-		return err
+	if published != nil {
+		for i := range published.pointShards {
+			if err := scanRoot(published.pointShards[i].rootID); err != nil {
+				return err
+			}
+		}
+		if err := scanRoot(published.system.rootID); err != nil {
+			return err
+		}
+		if err := scanRoot(published.iterator.rootID); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -17603,9 +17672,10 @@ planned:
 				// Maintenance rewrites are throughput-sensitive and operate on large
 				// source segments; group rewrite candidates by old segment+offset to
 				// improve value-log read locality and reduce wall-time.
-				LocalityPolicy: backenddb.ValueLogRewriteLocalityGrouped,
-				ProtectedPaths: db.valueLogProtectedPaths(),
-				ReserveRIDs:    db.ReserveValueLogRIDs,
+				LocalityPolicy:                 backenddb.ValueLogRewriteLocalityGrouped,
+				ProtectedPaths:                 db.valueLogProtectedPaths(),
+				LeafGenerationProtectedRootIDs: db.publishedRootIDsForLeafGenerationGC(),
+				ReserveRIDs:                    db.ReserveValueLogRIDs,
 			}
 			processedRewriteIDs := []uint32(nil)
 			processedRewriteChunks := []backenddb.ValueLogRewritePlanChunk(nil)
@@ -22163,6 +22233,9 @@ func (db *DB) rotateValueLogMuHeldToSeq(l *lane, nextSeq int) error {
 	}
 	l.vlogPath = path
 	l.vlogLiveBytes.Store(0)
+	if db.indexOuterLeavesInValueLog && l == &db.leafLog && l.id == leafLogLaneID {
+		l.vlogCreatedSegments = append(l.vlogCreatedSegments, laneValueLogSegment{path: path, fileID: fileID})
+	}
 	return nil
 }
 
@@ -24556,6 +24629,7 @@ func (db *DB) maybeRunLeafGenerationPackMaintenance(runGC bool, quiet bool, admi
 				MaxGenerations:             remainingGenerations,
 				MaxBytesToCopy:             remainingBytesToCopy,
 				ReserveRIDs:                db.ReserveValueLogRIDs,
+				ProtectedRootIDs:           db.publishedRootIDsForLeafGenerationGC(),
 			})
 			if runErr != nil {
 				return runErr
@@ -24614,7 +24688,7 @@ func (db *DB) maybeRunLeafGenerationPackMaintenance(runGC bool, quiet bool, admi
 			db.storeVlogGenerationLeafPackLastSkipReason("")
 
 			if gcRunner != nil {
-				gcStats, gcErr := gcRunner.LeafGenerationGC(ctx, backenddb.LeafGenerationGCOptions{})
+				gcStats, gcErr := gcRunner.LeafGenerationGC(ctx, db.leafGenerationGCOptions())
 				if gcErr != nil {
 					return gcErr
 				}

--- a/TreeDB/caching/lane.go
+++ b/TreeDB/caching/lane.go
@@ -89,6 +89,7 @@ type lane struct {
 	vlogLiveBytes                  atomic.Int64
 	vlogClosedBytes                atomic.Int64
 	vlogClosedSizes                map[string]int64
+	vlogCreatedSegments            []laneValueLogSegment
 
 	// Observability counters for diagnosing pathological lane shapes (e.g. huge l0).
 	// These are incremented on segment rotation and allow distinguishing useful
@@ -97,6 +98,11 @@ type lane struct {
 	vlogRotateIdleTotal atomic.Uint64
 
 	syncing atomic.Bool
+}
+
+type laneValueLogSegment struct {
+	path   string
+	fileID uint32
 }
 
 const (

--- a/TreeDB/caching/leaf_page_log.go
+++ b/TreeDB/caching/leaf_page_log.go
@@ -29,14 +29,23 @@ func (l *cachingLeafPageLog) ProtectedLeafGenerationRootIDs() []uint64 {
 	if l == nil || l.db == nil {
 		return nil
 	}
-	return l.db.publishedRootIDsForLeafGenerationGC()
+	protectedRootIDs, _ := l.db.publishedLeafGenerationProtectionIDs()
+	return protectedRootIDs
 }
 
 func (l *cachingLeafPageLog) ProtectedLeafGenerationSystemRootIDs() []uint64 {
 	if l == nil || l.db == nil {
 		return nil
 	}
-	return l.db.publishedSystemRootIDsForLeafGenerationGC()
+	_, protectedSystemRootIDs := l.db.publishedLeafGenerationProtectionIDs()
+	return protectedSystemRootIDs
+}
+
+func (l *cachingLeafPageLog) ProtectedLeafGenerationRootIDPair() ([]uint64, []uint64) {
+	if l == nil || l.db == nil {
+		return nil, nil
+	}
+	return l.db.publishedLeafGenerationProtectionIDs()
 }
 
 func (l *cachingLeafPageLog) CreatedLeafPageLogSegmentsSnapshot() ([]backenddb.LeafPageLogSegment, error) {

--- a/TreeDB/caching/leaf_page_log.go
+++ b/TreeDB/caching/leaf_page_log.go
@@ -25,6 +25,71 @@ func newCachingLeafPageLog(db *DB, l *lane) backenddb.LeafPageLog {
 	return &cachingLeafPageLog{db: db, lane: l}
 }
 
+func (l *cachingLeafPageLog) ProtectedLeafGenerationRootIDs() []uint64 {
+	if l == nil || l.db == nil {
+		return nil
+	}
+	return l.db.publishedRootIDsForLeafGenerationGC()
+}
+
+func (l *cachingLeafPageLog) CreatedLeafPageLogSegmentsSnapshot() ([]backenddb.LeafPageLogSegment, error) {
+	if l == nil || l.lane == nil {
+		return nil, nil
+	}
+	lane := l.lane
+	lane.vlogMu.Lock()
+	defer lane.vlogMu.Unlock()
+	if len(lane.vlogCreatedSegments) == 0 {
+		return nil, nil
+	}
+	out := make([]backenddb.LeafPageLogSegment, 0, len(lane.vlogCreatedSegments))
+	seen := make(map[uint32]struct{}, len(lane.vlogCreatedSegments))
+	for _, seg := range lane.vlogCreatedSegments {
+		if seg.path == "" || seg.fileID == 0 {
+			continue
+		}
+		if _, ok := seen[seg.fileID]; ok {
+			continue
+		}
+		seen[seg.fileID] = struct{}{}
+		out = append(out, backenddb.LeafPageLogSegment{Path: seg.path, FileID: seg.fileID})
+	}
+	return out, nil
+}
+
+func (l *cachingLeafPageLog) MarkLeafPageLogSegmentsRegistered(segments []backenddb.LeafPageLogSegment) {
+	if l == nil || l.lane == nil || len(segments) == 0 {
+		return
+	}
+	registered := make(map[uint32]struct{}, len(segments))
+	for _, seg := range segments {
+		if seg.FileID == 0 {
+			continue
+		}
+		registered[seg.FileID] = struct{}{}
+	}
+	if len(registered) == 0 {
+		return
+	}
+	lane := l.lane
+	lane.vlogMu.Lock()
+	defer lane.vlogMu.Unlock()
+	if len(lane.vlogCreatedSegments) == 0 {
+		return
+	}
+	dst := lane.vlogCreatedSegments[:0]
+	for _, seg := range lane.vlogCreatedSegments {
+		if _, ok := registered[seg.fileID]; ok {
+			continue
+		}
+		dst = append(dst, seg)
+	}
+	for i := len(dst); i < len(lane.vlogCreatedSegments); i++ {
+		lane.vlogCreatedSegments[i] = laneValueLogSegment{}
+	}
+	lane.vlogCreatedSegments = dst
+}
+
 func (db *DB) noteLeafGenerationRecordLength(ptr page.ValuePtr) {
 	if db == nil || db.backend == nil || ptr.FileID == 0 || ptr.Offset == 0 {
 		return

--- a/TreeDB/caching/leaf_page_log.go
+++ b/TreeDB/caching/leaf_page_log.go
@@ -32,6 +32,13 @@ func (l *cachingLeafPageLog) ProtectedLeafGenerationRootIDs() []uint64 {
 	return l.db.publishedRootIDsForLeafGenerationGC()
 }
 
+func (l *cachingLeafPageLog) ProtectedLeafGenerationSystemRootIDs() []uint64 {
+	if l == nil || l.db == nil {
+		return nil
+	}
+	return l.db.publishedSystemRootIDsForLeafGenerationGC()
+}
+
 func (l *cachingLeafPageLog) CreatedLeafPageLogSegmentsSnapshot() ([]backenddb.LeafPageLogSegment, error) {
 	if l == nil || l.lane == nil {
 		return nil, nil

--- a/TreeDB/caching/root_published_vlog_liveids_test.go
+++ b/TreeDB/caching/root_published_vlog_liveids_test.go
@@ -2,9 +2,13 @@ package caching
 
 import (
 	"bytes"
+	"encoding/binary"
+	"fmt"
+	"reflect"
 	"testing"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/internal/iterator"
 	"github.com/snissn/gomap/TreeDB/internal/memtable"
 	"github.com/snissn/gomap/TreeDB/node"
 	"github.com/snissn/gomap/TreeDB/page"
@@ -19,6 +23,74 @@ func mustFrozenPointerRootTable(tb testing.TB, key string, ptr page.ValuePtr) me
 	mt.SetEntry([]byte(key), nil, ptr, node.FlagPointer)
 	mt.Freeze()
 	return mt
+}
+
+func mustFrozenInlineRootTable(tb testing.TB, prefix string, count int) memtable.Table {
+	tb.Helper()
+	mt, err := memtable.NewWithCapacityMode(count, memtable.ModeHashSorted)
+	if err != nil {
+		tb.Fatalf("new memtable: %v", err)
+	}
+	for i := 0; i < count; i++ {
+		key := fmt.Sprintf("%s/%06d", prefix, i)
+		value := fmt.Sprintf("value-%06d", i)
+		mt.Set([]byte(key), []byte(value))
+	}
+	mt.Freeze()
+	return mt
+}
+
+func mustFrozenRawRootTable(tb testing.TB, kvs ...any) memtable.Table {
+	tb.Helper()
+	mt, err := memtable.NewWithCapacityMode(0, memtable.ModeHashSorted)
+	if err != nil {
+		tb.Fatalf("new memtable: %v", err)
+	}
+	for i := 0; i+1 < len(kvs); i += 2 {
+		key, ok := kvs[i].(string)
+		if !ok {
+			tb.Fatalf("key %d has type %T, want string", i, kvs[i])
+		}
+		var value []byte
+		switch v := kvs[i+1].(type) {
+		case string:
+			value = []byte(v)
+		case []byte:
+			value = v
+		default:
+			tb.Fatalf("value %d has type %T, want string or []byte", i+1, kvs[i+1])
+		}
+		mt.Set([]byte(key), value)
+	}
+	mt.Freeze()
+	return mt
+}
+
+func encodeRootDescriptorID(rootID uint64) []byte {
+	out := make([]byte, 8)
+	binary.BigEndian.PutUint64(out, rootID)
+	return out
+}
+
+func TestLeafGenerationGCOptionsIncludePublishedRoots(t *testing.T) {
+	db := &DB{
+		rootPublishedSet: &publishedRootSet{
+			pointShards: []publishedRootRef{
+				{rootID: 11},
+				{rootID: 0},
+				{rootID: 22},
+				{rootID: 11},
+			},
+			system:   publishedRootRef{rootID: 33},
+			iterator: publishedRootRef{rootID: 22},
+		},
+	}
+
+	got := db.leafGenerationGCOptions().ProtectedRootIDs
+	want := []uint64{11, 22, 33}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ProtectedRootIDs=%v want %v", got, want)
+	}
 }
 
 func mustBackendUserPointer(tb testing.TB, backend *backenddb.DB, key []byte) page.ValuePtr {
@@ -110,6 +182,147 @@ func TestCollectValueLogLiveIDsUntil_IncludesPublishedNonSystemRoots(t *testing.
 	}
 	if _, ok := liveAfter[ptr.FileID]; !ok {
 		t.Fatalf("expected published non-system root to keep file id %d live", ptr.FileID)
+	}
+}
+
+func TestCollectValueLogLiveIDsUntil_IncludesPublishedSystemRootLeafRefs(t *testing.T) {
+	disableVlogGenerationLoop(t)
+	dir := t.TempDir()
+
+	backend, err := backenddb.Open(backenddb.Options{
+		Dir:                        dir,
+		DisableBackgroundPrune:     true,
+		IndexOuterLeavesInValueLog: true,
+		ValueLog:                   backenddb.ValueLogOptions{PointerThreshold: 1},
+	})
+	if err != nil {
+		t.Fatalf("backend open: %v", err)
+	}
+	db, err := Open(dir, backend, Options{
+		FlushThreshold:                           256 << 20,
+		DisableWAL:                               true,
+		RelaxedSync:                              true,
+		AllowUnsafe:                              true,
+		MemtableShards:                           1,
+		JournalLanes:                             1,
+		IndexOuterLeavesInValueLog:               true,
+		ValueLogPointerThreshold:                 1,
+		ValueLogMaxSegmentBytes:                  64 << 10,
+		ValueLogGenerationPolicy:                 uint8(backenddb.ValueLogGenerationOff),
+		ValueLogGenerationLeafSegmentTargetBytes: 64 << 10,
+	})
+	if err != nil {
+		_ = backend.Close()
+		t.Fatalf("Open: %v", err)
+	}
+	defer db.Close()
+	skipRetainedPrune(db)
+
+	rootTable := mustFrozenInlineRootTable(t, "sys/published", 1024)
+	systemRootID, err := backend.PublishOrderedRootIterator(0, rootTable.NewIterator(nil, nil))
+	if err != nil {
+		t.Fatalf("PublishOrderedRootIterator: %v", err)
+	}
+	if systemRootID == 0 {
+		t.Fatal("expected non-zero published system root")
+	}
+	state := backend.State()
+	if state.SystemRootPageID == systemRootID {
+		t.Fatalf("test requires detached published system root, got state.SystemRootPageID=%d", state.SystemRootPageID)
+	}
+	leafRefs := collectLeafRefs(t, backend.Pager(), systemRootID)
+	if len(leafRefs) == 0 {
+		t.Fatalf("expected root %d to contain value-log leaf refs", systemRootID)
+	}
+	fileID := leafRefs[0].ValueLogFileID()
+
+	liveBefore, err := db.collectValueLogLiveIDsUntil(0)
+	if err != nil {
+		t.Fatalf("collectValueLogLiveIDsUntil(before): %v", err)
+	}
+	if _, ok := liveBefore[fileID]; ok {
+		t.Fatalf("unexpected leaf-log file id %d before published system root install", fileID)
+	}
+
+	if err := db.publishInstalledRootSet(&publishedRootSet{
+		generation: 1,
+		system: publishedRootRef{
+			rootID: systemRootID,
+		},
+	}); err != nil {
+		t.Fatalf("publishInstalledRootSet: %v", err)
+	}
+
+	liveAfter, err := db.collectValueLogLiveIDsUntil(0)
+	if err != nil {
+		t.Fatalf("collectValueLogLiveIDsUntil(after): %v", err)
+	}
+	if _, ok := liveAfter[fileID]; !ok {
+		t.Fatalf("expected published system root leaf ref to keep file id %d live", fileID)
+	}
+}
+
+func TestCollectValueLogLiveIDsUntil_IncludesSystemDescriptorCollectionRootLeafRefs(t *testing.T) {
+	disableVlogGenerationLoop(t)
+	dir := t.TempDir()
+
+	backend, err := backenddb.Open(backenddb.Options{
+		Dir:                        dir,
+		DisableBackgroundPrune:     true,
+		IndexOuterLeavesInValueLog: true,
+		ValueLog:                   backenddb.ValueLogOptions{PointerThreshold: 1},
+	})
+	if err != nil {
+		t.Fatalf("backend open: %v", err)
+	}
+	db, err := Open(dir, backend, Options{
+		FlushThreshold:                           256 << 20,
+		DisableWAL:                               true,
+		RelaxedSync:                              true,
+		AllowUnsafe:                              true,
+		MemtableShards:                           1,
+		JournalLanes:                             1,
+		IndexOuterLeavesInValueLog:               true,
+		ValueLogPointerThreshold:                 1,
+		ValueLogMaxSegmentBytes:                  64 << 10,
+		ValueLogGenerationPolicy:                 uint8(backenddb.ValueLogGenerationOff),
+		ValueLogGenerationLeafSegmentTargetBytes: 64 << 10,
+	})
+	if err != nil {
+		_ = backend.Close()
+		t.Fatalf("Open: %v", err)
+	}
+	defer db.Close()
+	skipRetainedPrune(db)
+
+	_, rootIDs, err := backend.PublishOrderedRootGroupWithSystemBuilder([]backenddb.OrderedRootPublishInput{{
+		BaseRoot:      0,
+		Iter:          mustFrozenInlineRootTable(t, "collection/published", 1024).NewIterator(nil, nil),
+		StoragePolicy: backenddb.OrderedRootStorageValueLogLeaves,
+	}}, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		return mustFrozenRawRootTable(t, "collections/root/users/primary", encodeRootDescriptorID(rootIDs[0])).NewIterator(nil, nil), nil
+	})
+	if err != nil {
+		t.Fatalf("publish descriptor-backed collection root: %v", err)
+	}
+	if len(rootIDs) != 1 || rootIDs[0] == 0 {
+		t.Fatalf("rootIDs=%v want one non-zero root", rootIDs)
+	}
+	leafRefs := collectLeafRefs(t, backend.Pager(), rootIDs[0])
+	if len(leafRefs) == 0 {
+		t.Fatalf("expected collection root %d to contain value-log leaf refs", rootIDs[0])
+	}
+	fileID := leafRefs[0].ValueLogFileID()
+	if db.rootPublishedSet != nil {
+		t.Fatalf("test requires descriptor-only reachability, rootPublishedSet=%+v", db.rootPublishedSet)
+	}
+
+	live, err := db.collectValueLogLiveIDsUntil(0)
+	if err != nil {
+		t.Fatalf("collectValueLogLiveIDsUntil: %v", err)
+	}
+	if _, ok := live[fileID]; !ok {
+		t.Fatalf("expected system descriptor collection root to keep leaf-log file id %d live", fileID)
 	}
 }
 

--- a/TreeDB/caching/root_published_vlog_liveids_test.go
+++ b/TreeDB/caching/root_published_vlog_liveids_test.go
@@ -326,6 +326,89 @@ func TestCollectValueLogLiveIDsUntil_IncludesSystemDescriptorCollectionRootLeafR
 	}
 }
 
+func TestCollectValueLogLiveIDsUntil_IncludesPublishedSystemDescriptorCollectionRootLeafRefs(t *testing.T) {
+	disableVlogGenerationLoop(t)
+	dir := t.TempDir()
+
+	backend, err := backenddb.Open(backenddb.Options{
+		Dir:                        dir,
+		DisableBackgroundPrune:     true,
+		IndexOuterLeavesInValueLog: true,
+		ValueLog:                   backenddb.ValueLogOptions{PointerThreshold: 1},
+	})
+	if err != nil {
+		t.Fatalf("backend open: %v", err)
+	}
+	db, err := Open(dir, backend, Options{
+		FlushThreshold:                           256 << 20,
+		DisableWAL:                               true,
+		RelaxedSync:                              true,
+		AllowUnsafe:                              true,
+		MemtableShards:                           1,
+		JournalLanes:                             1,
+		IndexOuterLeavesInValueLog:               true,
+		ValueLogPointerThreshold:                 1,
+		ValueLogMaxSegmentBytes:                  64 << 10,
+		ValueLogGenerationPolicy:                 uint8(backenddb.ValueLogGenerationOff),
+		ValueLogGenerationLeafSegmentTargetBytes: 64 << 10,
+	})
+	if err != nil {
+		_ = backend.Close()
+		t.Fatalf("Open: %v", err)
+	}
+	defer db.Close()
+	skipRetainedPrune(db)
+
+	collectionRootID, err := backend.PublishOrderedRootIterator(0, mustFrozenInlineRootTable(t, "collection/published", 1024).NewIterator(nil, nil))
+	if err != nil {
+		t.Fatalf("publish collection root: %v", err)
+	}
+	if collectionRootID == 0 {
+		t.Fatal("expected non-zero collection root")
+	}
+	leafRefs := collectLeafRefs(t, backend.Pager(), collectionRootID)
+	if len(leafRefs) == 0 {
+		t.Fatalf("expected collection root %d to contain value-log leaf refs", collectionRootID)
+	}
+	fileID := leafRefs[0].ValueLogFileID()
+	systemRootID, err := backend.PublishOrderedRootIterator(0, mustFrozenRawRootTable(t, "collections/root/users/published", encodeRootDescriptorID(collectionRootID)).NewIterator(nil, nil))
+	if err != nil {
+		t.Fatalf("publish detached system root: %v", err)
+	}
+	if systemRootID == 0 {
+		t.Fatal("expected non-zero system root")
+	}
+	state := backend.State()
+	if state.SystemRootPageID == systemRootID {
+		t.Fatalf("test requires detached published system root, got state.SystemRootPageID=%d", state.SystemRootPageID)
+	}
+
+	liveBefore, err := db.collectValueLogLiveIDsUntil(0)
+	if err != nil {
+		t.Fatalf("collectValueLogLiveIDsUntil(before): %v", err)
+	}
+	if _, ok := liveBefore[fileID]; ok {
+		t.Fatalf("unexpected leaf-log file id %d before published system root install", fileID)
+	}
+
+	if err := db.publishInstalledRootSet(&publishedRootSet{
+		generation: 1,
+		system: publishedRootRef{
+			rootID: systemRootID,
+		},
+	}); err != nil {
+		t.Fatalf("publishInstalledRootSet: %v", err)
+	}
+
+	liveAfter, err := db.collectValueLogLiveIDsUntil(0)
+	if err != nil {
+		t.Fatalf("collectValueLogLiveIDsUntil(after): %v", err)
+	}
+	if _, ok := liveAfter[fileID]; !ok {
+		t.Fatalf("expected published system descriptor collection root to keep leaf-log file id %d live", fileID)
+	}
+}
+
 func TestPruneRetainedValueLogs_PublishedNonSystemRootsKeepClosedSegment(t *testing.T) {
 	disableVlogGenerationLoop(t)
 	dir := t.TempDir()

--- a/TreeDB/caching/root_published_vlog_liveids_test.go
+++ b/TreeDB/caching/root_published_vlog_liveids_test.go
@@ -92,6 +92,11 @@ func TestLeafGenerationGCOptionsIncludePublishedRoots(t *testing.T) {
 	if !uint64SlicesEqual(got, want) {
 		t.Fatalf("ProtectedRootIDs=%v want %v", got, want)
 	}
+	gotSystem := db.leafGenerationGCOptions().ProtectedSystemRootIDs
+	wantSystem := []uint64{33}
+	if !uint64SlicesEqual(gotSystem, wantSystem) {
+		t.Fatalf("ProtectedSystemRootIDs=%v want %v", gotSystem, wantSystem)
+	}
 }
 
 func mustBackendUserPointer(tb testing.TB, backend *backenddb.DB, key []byte) page.ValuePtr {

--- a/TreeDB/caching/root_published_vlog_liveids_test.go
+++ b/TreeDB/caching/root_published_vlog_liveids_test.go
@@ -2,6 +2,7 @@ package caching
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"fmt"
 	"sort"
@@ -412,6 +413,55 @@ func TestCollectValueLogLiveIDsUntil_IncludesPublishedSystemDescriptorCollection
 	}
 	if _, ok := liveAfter[fileID]; !ok {
 		t.Fatalf("expected published system descriptor collection root to keep leaf-log file id %d live", fileID)
+	}
+}
+
+func TestCollectPublishedRootValueLogLiveIDsUntil_SkipsCurrentPublishedSystemDescriptorExpansion(t *testing.T) {
+	disableVlogGenerationLoop(t)
+	dir := t.TempDir()
+
+	backend, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("backend open: %v", err)
+	}
+	db, err := Open(dir, backend, Options{
+		FlushThreshold:           256 << 20,
+		DisableWAL:               true,
+		RelaxedSync:              true,
+		AllowUnsafe:              true,
+		MemtableShards:           1,
+		JournalLanes:             1,
+		ValueLogPointerThreshold: 1,
+		ValueLogMaxSegmentBytes:  4 << 10,
+		ValueLogGenerationPolicy: uint8(backenddb.ValueLogGenerationOff),
+	})
+	if err != nil {
+		_ = backend.Close()
+		t.Fatalf("Open: %v", err)
+	}
+	defer db.Close()
+	skipRetainedPrune(db)
+
+	systemRootID, err := backend.PublishSystemRootIterator(mustFrozenRawRootTable(t,
+		"collections/root/users/current", []byte("bad"),
+	).NewIterator(nil, nil))
+	if err != nil {
+		t.Fatalf("PublishSystemRootIterator: %v", err)
+	}
+	state := backend.State()
+	if state == nil {
+		t.Fatal("expected backend state")
+	}
+	if state.SystemRootPageID != systemRootID {
+		t.Fatalf("SystemRootPageID=%d want %d", state.SystemRootPageID, systemRootID)
+	}
+
+	reader := newCachedLiveScanReader(valueReaderForBackendState(state), db.valueLogReader)
+	err = db.collectPublishedRootValueLogLiveIDsUntil(context.Background(), backend.Pager(), reader, &publishedRootSet{
+		system: publishedRootRef{rootID: systemRootID},
+	}, state.RootPageID, state.SystemRootPageID, nil, map[uint32]struct{}{}, 0)
+	if err != nil {
+		t.Fatalf("collectPublishedRootValueLogLiveIDsUntil: %v", err)
 	}
 }
 

--- a/TreeDB/caching/root_published_vlog_liveids_test.go
+++ b/TreeDB/caching/root_published_vlog_liveids_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
-	"reflect"
+	"sort"
 	"testing"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
@@ -88,7 +88,8 @@ func TestLeafGenerationGCOptionsIncludePublishedRoots(t *testing.T) {
 
 	got := db.leafGenerationGCOptions().ProtectedRootIDs
 	want := []uint64{11, 22, 33}
-	if !reflect.DeepEqual(got, want) {
+	sort.Slice(got, func(i, j int) bool { return got[i] < got[j] })
+	if !uint64SlicesEqual(got, want) {
 		t.Fatalf("ProtectedRootIDs=%v want %v", got, want)
 	}
 }

--- a/TreeDB/caching/vlog_generation_scheduler_test.go
+++ b/TreeDB/caching/vlog_generation_scheduler_test.go
@@ -1530,7 +1530,10 @@ func (b *rewriteBudgetRecordingBackend) LeafGenerationPackRunOnce(ctx context.Co
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.leafPackCalls++
-	b.leafPackOpts = opts
+	cloned := opts
+	cloned.ProtectedRootIDs = append([]uint64(nil), opts.ProtectedRootIDs...)
+	cloned.ProtectedSystemRootIDs = append([]uint64(nil), opts.ProtectedSystemRootIDs...)
+	b.leafPackOpts = cloned
 	resp := b.leafPackResp
 	if len(b.leafPackResponses) > 0 {
 		idx := b.leafPackCalls - 1
@@ -1565,6 +1568,7 @@ func cloneRewriteOptsForTest(opts backenddb.ValueLogRewriteOnlineOptions) backen
 	cloned.SourceChunks = append([]backenddb.ValueLogRewritePlanChunk(nil), opts.SourceChunks...)
 	cloned.ProtectedPaths = append([]string(nil), opts.ProtectedPaths...)
 	cloned.LeafGenerationProtectedRootIDs = append([]uint64(nil), opts.LeafGenerationProtectedRootIDs...)
+	cloned.LeafGenerationProtectedSystemRootIDs = append([]uint64(nil), opts.LeafGenerationProtectedSystemRootIDs...)
 	return cloned
 }
 
@@ -1646,6 +1650,7 @@ func (b *leafPackMaintenanceRecordingBackend) LeafGenerationPackRunOnce(ctx cont
 	b.calls++
 	cloned := opts
 	cloned.ProtectedRootIDs = append([]uint64(nil), opts.ProtectedRootIDs...)
+	cloned.ProtectedSystemRootIDs = append([]uint64(nil), opts.ProtectedSystemRootIDs...)
 	b.opts = cloned
 	b.optsHistory = append(b.optsHistory, cloned)
 	b.deadline, b.hasDeadline = ctx.Deadline()
@@ -1691,6 +1696,7 @@ func (b *leafPackMaintenanceRecordingBackend) LeafGenerationGC(ctx context.Conte
 	b.leafGCCalls++
 	cloned := opts
 	cloned.ProtectedRootIDs = append([]uint64(nil), opts.ProtectedRootIDs...)
+	cloned.ProtectedSystemRootIDs = append([]uint64(nil), opts.ProtectedSystemRootIDs...)
 	b.leafGCOpts = append(b.leafGCOpts, cloned)
 	stats := b.leafGCResp
 	if len(b.leafGCResponses) > 0 {
@@ -1719,6 +1725,7 @@ func (b *leafPackMaintenanceRecordingBackend) recordedLeafPackHistory() []backen
 	for i := range b.optsHistory {
 		history[i] = b.optsHistory[i]
 		history[i].ProtectedRootIDs = append([]uint64(nil), b.optsHistory[i].ProtectedRootIDs...)
+		history[i].ProtectedSystemRootIDs = append([]uint64(nil), b.optsHistory[i].ProtectedSystemRootIDs...)
 	}
 	return history
 }
@@ -1744,6 +1751,7 @@ func (b *leafPackMaintenanceRecordingBackend) recordedLeafGCOptions() []backendd
 	for i := range b.leafGCOpts {
 		opts[i] = b.leafGCOpts[i]
 		opts[i].ProtectedRootIDs = append([]uint64(nil), b.leafGCOpts[i].ProtectedRootIDs...)
+		opts[i].ProtectedSystemRootIDs = append([]uint64(nil), b.leafGCOpts[i].ProtectedSystemRootIDs...)
 	}
 	return opts
 }
@@ -2163,8 +2171,12 @@ func TestLeafGenerationPackMaintenance_ProtectsPublishedRootsDuringLeafGC(t *tes
 		t.Fatalf("leaf pack history=%d want 1", len(history))
 	}
 	want := []uint64{101, 202, 303}
+	wantSystem := []uint64{303}
 	if !uint64SlicesEqual(history[0].ProtectedRootIDs, want) {
 		t.Fatalf("pack ProtectedRootIDs=%v want %v", history[0].ProtectedRootIDs, want)
+	}
+	if !uint64SlicesEqual(history[0].ProtectedSystemRootIDs, wantSystem) {
+		t.Fatalf("pack ProtectedSystemRootIDs=%v want %v", history[0].ProtectedSystemRootIDs, wantSystem)
 	}
 	opts := recorder.recordedLeafGCOptions()
 	if len(opts) != 1 {
@@ -2172,6 +2184,9 @@ func TestLeafGenerationPackMaintenance_ProtectsPublishedRootsDuringLeafGC(t *tes
 	}
 	if !uint64SlicesEqual(opts[0].ProtectedRootIDs, want) {
 		t.Fatalf("gc ProtectedRootIDs=%v want %v", opts[0].ProtectedRootIDs, want)
+	}
+	if !uint64SlicesEqual(opts[0].ProtectedSystemRootIDs, wantSystem) {
+		t.Fatalf("gc ProtectedSystemRootIDs=%v want %v", opts[0].ProtectedSystemRootIDs, wantSystem)
 	}
 }
 

--- a/TreeDB/caching/vlog_generation_scheduler_test.go
+++ b/TreeDB/caching/vlog_generation_scheduler_test.go
@@ -1564,6 +1564,7 @@ func cloneRewriteOptsForTest(opts backenddb.ValueLogRewriteOnlineOptions) backen
 	cloned.SourceFileIDs = append([]uint32(nil), opts.SourceFileIDs...)
 	cloned.SourceChunks = append([]backenddb.ValueLogRewritePlanChunk(nil), opts.SourceChunks...)
 	cloned.ProtectedPaths = append([]string(nil), opts.ProtectedPaths...)
+	cloned.LeafGenerationProtectedRootIDs = append([]uint64(nil), opts.LeafGenerationProtectedRootIDs...)
 	return cloned
 }
 
@@ -1643,8 +1644,10 @@ type leafPackMaintenanceRecordingBackend struct {
 func (b *leafPackMaintenanceRecordingBackend) LeafGenerationPackRunOnce(ctx context.Context, opts backenddb.LeafGenerationPackFromPlanOptions) (backenddb.LeafGenerationPackRunOnceStats, error) {
 	b.mu.Lock()
 	b.calls++
-	b.opts = opts
-	b.optsHistory = append(b.optsHistory, opts)
+	cloned := opts
+	cloned.ProtectedRootIDs = append([]uint64(nil), opts.ProtectedRootIDs...)
+	b.opts = cloned
+	b.optsHistory = append(b.optsHistory, cloned)
 	b.deadline, b.hasDeadline = ctx.Deadline()
 	entered := b.entered
 	release := b.release
@@ -1711,7 +1714,10 @@ func (b *leafPackMaintenanceRecordingBackend) recordedLeafPackHistory() []backen
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	history := make([]backenddb.LeafGenerationPackFromPlanOptions, len(b.optsHistory))
-	copy(history, b.optsHistory)
+	for i := range b.optsHistory {
+		history[i] = b.optsHistory[i]
+		history[i].ProtectedRootIDs = append([]uint64(nil), b.optsHistory[i].ProtectedRootIDs...)
+	}
 	return history
 }
 
@@ -1727,6 +1733,29 @@ func (b *leafPackMaintenanceRecordingBackend) recordedLeafGC() (backenddb.LeafGe
 		stats = b.leafGCResponses[idx]
 	}
 	return stats, b.leafGCCalls
+}
+
+func (b *leafPackMaintenanceRecordingBackend) recordedLeafGCOptions() []backenddb.LeafGenerationGCOptions {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	opts := make([]backenddb.LeafGenerationGCOptions, len(b.leafGCOpts))
+	for i := range b.leafGCOpts {
+		opts[i] = b.leafGCOpts[i]
+		opts[i].ProtectedRootIDs = append([]uint64(nil), b.leafGCOpts[i].ProtectedRootIDs...)
+	}
+	return opts
+}
+
+func uint64SlicesEqual(a, b []uint64) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func mustLeafPackTempDir(t *testing.T, prefix string) string {
@@ -2095,6 +2124,52 @@ func TestLeafGenerationPackMaintenance_PassesReserveRIDs(t *testing.T) {
 	}
 	if got, want := db.nextRID.Load(), before+3; got != want {
 		t.Fatalf("nextRID after ReserveRIDs=%d want %d", got, want)
+	}
+}
+
+func TestLeafGenerationPackMaintenance_ProtectsPublishedRootsDuringLeafGC(t *testing.T) {
+	t.Setenv(envEnableLeafGenerationPackMaintenance, "1")
+	recorder := &leafPackMaintenanceRecordingBackend{
+		DB:   mustOpenLeafPackBackend(t),
+		resp: leafPackWindowExhaustingStats(17, 1024, 4096),
+	}
+	db, cleanup := openLeafPackMaintenanceTestDB(t, recorder)
+	defer cleanup()
+
+	db.mu.Lock()
+	db.rootPublishedSet = &publishedRootSet{
+		generation: 1,
+		pointShards: []publishedRootRef{
+			{rootID: 101},
+			{rootID: 202},
+			{rootID: 101},
+		},
+		system:   publishedRootRef{rootID: 303},
+		iterator: publishedRootRef{rootID: 202},
+	}
+	db.mu.Unlock()
+
+	attempted, ran, err := db.maybeRunLeafGenerationPackMaintenance(false, true, leafGenerationPackMaintenanceAdmission{allowed: true}, vlogGenerationMaintenanceOptions{skipCheckpoint: true})
+	if err != nil {
+		t.Fatalf("maybeRunLeafGenerationPackMaintenance: %v", err)
+	}
+	if !attempted || !ran {
+		t.Fatalf("attempted=%t ran=%t want true/true", attempted, ran)
+	}
+	history := recorder.recordedLeafPackHistory()
+	if len(history) != 1 {
+		t.Fatalf("leaf pack history=%d want 1", len(history))
+	}
+	want := []uint64{101, 202, 303}
+	if !uint64SlicesEqual(history[0].ProtectedRootIDs, want) {
+		t.Fatalf("pack ProtectedRootIDs=%v want %v", history[0].ProtectedRootIDs, want)
+	}
+	opts := recorder.recordedLeafGCOptions()
+	if len(opts) != 1 {
+		t.Fatalf("leaf gc option calls=%d want 1", len(opts))
+	}
+	if !uint64SlicesEqual(opts[0].ProtectedRootIDs, want) {
+		t.Fatalf("gc ProtectedRootIDs=%v want %v", opts[0].ProtectedRootIDs, want)
 	}
 }
 
@@ -7687,16 +7762,24 @@ func TestCheckpoint_KicksVlogGenerationRewriteDespiteRecentForegroundActivity(t 
 	deadline := time.Now().Add(2 * schedulerTestWait(t))
 	for {
 		if _, calls := recorder.recordedRewrite(); calls == 1 {
-			break
+			stats := db.Stats()
+			if stats["treedb.cache.vlog_generation.checkpoint_kick.rewrite_runs"] == "1" &&
+				stats["treedb.cache.vlog_generation.checkpoint_kick.active"] == "false" {
+				break
+			}
 		}
 		if time.Now().After(deadline) {
 			_, rewriteCalls := recorder.recordedRewrite()
 			_, planCalls := recorder.recordedPlan()
-			t.Fatalf("checkpoint kick did not run rewrite in time: planCalls=%d rewriteCalls=%d", planCalls, rewriteCalls)
+			stats := db.Stats()
+			t.Fatalf("checkpoint kick did not run rewrite in time: planCalls=%d rewriteCalls=%d stats=%v", planCalls, rewriteCalls, stats)
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
 
+	if _, calls := recorder.recordedRewrite(); calls != 1 {
+		t.Fatalf("rewrite calls=%d want=1", calls)
+	}
 	if _, calls := recorder.recordedPlan(); calls != 1 {
 		t.Fatalf("plan calls=%d want=1", calls)
 	}

--- a/TreeDB/caching/vlog_generation_scheduler_test.go
+++ b/TreeDB/caching/vlog_generation_scheduler_test.go
@@ -1689,7 +1689,9 @@ func (b *leafPackMaintenanceRecordingBackend) LeafGenerationGC(ctx context.Conte
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.leafGCCalls++
-	b.leafGCOpts = append(b.leafGCOpts, opts)
+	cloned := opts
+	cloned.ProtectedRootIDs = append([]uint64(nil), opts.ProtectedRootIDs...)
+	b.leafGCOpts = append(b.leafGCOpts, cloned)
 	stats := b.leafGCResp
 	if len(b.leafGCResponses) > 0 {
 		idx := b.leafGCCalls - 1

--- a/TreeDB/compact_storage.go
+++ b/TreeDB/compact_storage.go
@@ -165,6 +165,11 @@ func appendCompactStorageProtectedRootIDs(dst []uint64, src []uint64) []uint64 {
 	return dst
 }
 
+func mergeCompactStorageProtectedRootIDs(dst []uint64, src []uint64) []uint64 {
+	out := append([]uint64(nil), dst...)
+	return appendCompactStorageProtectedRootIDs(out, src)
+}
+
 func appendCompactStorageProtectedPaths(dst []string, src []string) []string {
 	for _, path := range src {
 		seen := false

--- a/TreeDB/compact_storage.go
+++ b/TreeDB/compact_storage.go
@@ -114,6 +114,8 @@ func (db *DB) applyCachedCompactStorageOptions(opts *CompactStorageOptions, chec
 	}
 	explicitProtectedPaths := append([]string(nil), opts.ValueLogProtectedPaths...)
 	userProtectedPathsFunc := opts.ValueLogProtectedPathsFunc
+	explicitProtectedRootIDs := append([]uint64(nil), opts.LeafGenerationProtectedRootIDs...)
+	userProtectedRootIDsFunc := opts.LeafGenerationProtectedRootIDsFunc
 	opts.ValueLogProtectedPathsFunc = func() []string {
 		var out []string
 		if userProtectedPathsFunc != nil {
@@ -122,7 +124,16 @@ func (db *DB) applyCachedCompactStorageOptions(opts *CompactStorageOptions, chec
 		out = appendCompactStorageProtectedPaths(out, db.cached.ValueLogProtectedPaths())
 		return out
 	}
+	opts.LeafGenerationProtectedRootIDsFunc = func() []uint64 {
+		var out []uint64
+		if userProtectedRootIDsFunc != nil {
+			out = appendCompactStorageProtectedRootIDs(out, userProtectedRootIDsFunc())
+		}
+		out = appendCompactStorageProtectedRootIDs(out, db.cached.ProtectedLeafGenerationRootIDs())
+		return out
+	}
 	opts.ValueLogProtectedPaths = explicitProtectedPaths
+	opts.LeafGenerationProtectedRootIDs = explicitProtectedRootIDs
 	if opts.ReserveRIDs == nil {
 		opts.ReserveRIDs = db.cached.ReserveValueLogRIDs
 	}
@@ -133,6 +144,25 @@ func (db *DB) applyCachedCompactStorageOptions(opts *CompactStorageOptions, chec
 		}
 	}
 	return nil
+}
+
+func appendCompactStorageProtectedRootIDs(dst []uint64, src []uint64) []uint64 {
+	for _, rootID := range src {
+		if rootID == 0 {
+			continue
+		}
+		seen := false
+		for _, existing := range dst {
+			if existing == rootID {
+				seen = true
+				break
+			}
+		}
+		if !seen {
+			dst = append(dst, rootID)
+		}
+	}
+	return dst
 }
 
 func appendCompactStorageProtectedPaths(dst []string, src []string) []string {

--- a/TreeDB/compact_storage.go
+++ b/TreeDB/compact_storage.go
@@ -116,6 +116,8 @@ func (db *DB) applyCachedCompactStorageOptions(opts *CompactStorageOptions, chec
 	userProtectedPathsFunc := opts.ValueLogProtectedPathsFunc
 	explicitProtectedRootIDs := append([]uint64(nil), opts.LeafGenerationProtectedRootIDs...)
 	userProtectedRootIDsFunc := opts.LeafGenerationProtectedRootIDsFunc
+	explicitProtectedSystemRootIDs := append([]uint64(nil), opts.LeafGenerationProtectedSystemRootIDs...)
+	userProtectedSystemRootIDsFunc := opts.LeafGenerationProtectedSystemRootIDsFunc
 	opts.ValueLogProtectedPathsFunc = func() []string {
 		var out []string
 		if userProtectedPathsFunc != nil {
@@ -132,8 +134,17 @@ func (db *DB) applyCachedCompactStorageOptions(opts *CompactStorageOptions, chec
 		out = appendCompactStorageProtectedRootIDs(out, db.cached.ProtectedLeafGenerationRootIDs())
 		return out
 	}
+	opts.LeafGenerationProtectedSystemRootIDsFunc = func() []uint64 {
+		var out []uint64
+		if userProtectedSystemRootIDsFunc != nil {
+			out = appendCompactStorageProtectedRootIDs(out, userProtectedSystemRootIDsFunc())
+		}
+		out = appendCompactStorageProtectedRootIDs(out, db.cached.ProtectedLeafGenerationSystemRootIDs())
+		return out
+	}
 	opts.ValueLogProtectedPaths = explicitProtectedPaths
 	opts.LeafGenerationProtectedRootIDs = explicitProtectedRootIDs
+	opts.LeafGenerationProtectedSystemRootIDs = explicitProtectedSystemRootIDs
 	if opts.ReserveRIDs == nil {
 		opts.ReserveRIDs = db.cached.ReserveValueLogRIDs
 	}

--- a/TreeDB/compact_storage.go
+++ b/TreeDB/compact_storage.go
@@ -118,6 +118,7 @@ func (db *DB) applyCachedCompactStorageOptions(opts *CompactStorageOptions, chec
 	userProtectedRootIDsFunc := opts.LeafGenerationProtectedRootIDsFunc
 	explicitProtectedSystemRootIDs := append([]uint64(nil), opts.LeafGenerationProtectedSystemRootIDs...)
 	userProtectedSystemRootIDsFunc := opts.LeafGenerationProtectedSystemRootIDsFunc
+	userProtectedRootIDPairFunc := opts.LeafGenerationProtectedRootIDPairFunc
 	opts.ValueLogProtectedPathsFunc = func() []string {
 		var out []string
 		if userProtectedPathsFunc != nil {
@@ -126,22 +127,21 @@ func (db *DB) applyCachedCompactStorageOptions(opts *CompactStorageOptions, chec
 		out = appendCompactStorageProtectedPaths(out, db.cached.ValueLogProtectedPaths())
 		return out
 	}
-	opts.LeafGenerationProtectedRootIDsFunc = func() []uint64 {
-		var out []uint64
-		if userProtectedRootIDsFunc != nil {
-			out = appendCompactStorageProtectedRootIDs(out, userProtectedRootIDsFunc())
+	opts.LeafGenerationProtectedRootIDPairFunc = func() ([]uint64, []uint64) {
+		var rootIDs []uint64
+		var systemRootIDs []uint64
+		if userProtectedRootIDPairFunc != nil {
+			userRootIDs, userSystemRootIDs := userProtectedRootIDPairFunc()
+			rootIDs = appendCompactStorageProtectedRootIDs(rootIDs, userRootIDs)
+			systemRootIDs = appendCompactStorageProtectedRootIDs(systemRootIDs, userSystemRootIDs)
 		}
-		out = appendCompactStorageProtectedRootIDs(out, db.cached.ProtectedLeafGenerationRootIDs())
-		return out
+		cachedRootIDs, cachedSystemRootIDs := db.cached.ProtectedLeafGenerationRootIDPair()
+		rootIDs = appendCompactStorageProtectedRootIDs(rootIDs, cachedRootIDs)
+		systemRootIDs = appendCompactStorageProtectedRootIDs(systemRootIDs, cachedSystemRootIDs)
+		return rootIDs, systemRootIDs
 	}
-	opts.LeafGenerationProtectedSystemRootIDsFunc = func() []uint64 {
-		var out []uint64
-		if userProtectedSystemRootIDsFunc != nil {
-			out = appendCompactStorageProtectedRootIDs(out, userProtectedSystemRootIDsFunc())
-		}
-		out = appendCompactStorageProtectedRootIDs(out, db.cached.ProtectedLeafGenerationSystemRootIDs())
-		return out
-	}
+	opts.LeafGenerationProtectedRootIDsFunc = userProtectedRootIDsFunc
+	opts.LeafGenerationProtectedSystemRootIDsFunc = userProtectedSystemRootIDsFunc
 	opts.ValueLogProtectedPaths = explicitProtectedPaths
 	opts.LeafGenerationProtectedRootIDs = explicitProtectedRootIDs
 	opts.LeafGenerationProtectedSystemRootIDs = explicitProtectedSystemRootIDs

--- a/TreeDB/db/compact_storage.go
+++ b/TreeDB/db/compact_storage.go
@@ -53,6 +53,12 @@ type CompactStorageOptions struct {
 
 	// Leaf-generation pack knobs. Defaults are intentionally bounded to keep a
 	// single compaction request finite while still draining ordinary debt.
+	LeafGenerationProtectedRootIDs []uint64
+	// LeafGenerationProtectedRootIDsFunc refreshes additional leaf-generation
+	// roots before each leaf plan/pack/GC phase. Cached/native interop callers
+	// use this so roots published outside backend meta roots keep their leaf-log
+	// children live during compaction.
+	LeafGenerationProtectedRootIDsFunc func() []uint64
 	LeafPackMaxPasses                  int
 	LeafPackMaxGenerationsPerPass      int
 	LeafPackMaxBytesToCopyPerPass      int64
@@ -221,6 +227,7 @@ func (db *DB) compactStorage(ctx context.Context, opts CompactStorageOptions) (C
 	if err := db.runCompactStoragePhase(&stats, "value-log-rewrite", func() error {
 		protectedPaths := compactStorageOnlineRewriteProtectedPaths(opts)
 		rewriteOpts := compactStorageRewritePlanOptions(protectedPaths)
+		rewriteOpts.LeafGenerationProtectedRootIDs = db.compactStorageLeafGenerationProtectedRootIDs(opts)
 		rewriteOpts.BatchSize = opts.ValueLogRewriteBatchSize
 		rewriteOpts.SyncEachBatch = opts.SyncEachPhase
 		rewriteOpts.MaxSegmentBytes = opts.ValueLogRewriteMaxSegmentBytes
@@ -265,6 +272,7 @@ func (db *DB) compactStorage(ctx context.Context, opts CompactStorageOptions) (C
 				MaxBytesToCopy:             opts.LeafPackMaxBytesToCopyPerPass,
 				ReserveRIDs:                opts.ReserveRIDs,
 				LeafFrameK:                 opts.LeafPackLeafFrameK,
+				ProtectedRootIDs:           db.compactStorageLeafGenerationProtectedRootIDs(opts),
 			}, !maintenanceLocked)
 			return err
 		}); err != nil {
@@ -289,7 +297,9 @@ func (db *DB) compactStorage(ctx context.Context, opts CompactStorageOptions) (C
 	}
 
 	if err := db.runCompactStoragePhase(&stats, "leaf-generation-gc", func() error {
-		gc, err := db.leafGenerationGC(ctx, LeafGenerationGCOptions{}, !maintenanceLocked)
+		gc, err := db.leafGenerationGC(ctx, LeafGenerationGCOptions{
+			ProtectedRootIDs: db.compactStorageLeafGenerationProtectedRootIDs(opts),
+		}, !maintenanceLocked)
 		stats.LeafGenerationGC = gc
 		return err
 	}); err != nil {
@@ -417,7 +427,9 @@ func (db *DB) settleCompactStorageGC(ctx context.Context, opts CompactStorageOpt
 		if debt.LeafGCGenerations > 0 {
 			phaseName := fmt.Sprintf("settle-leaf-generation-gc-%d", pass+1)
 			if err := db.runCompactStoragePhase(stats, phaseName, func() error {
-				gc, err := db.leafGenerationGC(ctx, LeafGenerationGCOptions{}, lockMaintenance)
+				gc, err := db.leafGenerationGC(ctx, LeafGenerationGCOptions{
+					ProtectedRootIDs: db.compactStorageLeafGenerationProtectedRootIDs(opts),
+				}, lockMaintenance)
 				stats.LeafGenerationGC = gc
 				return err
 			}); err != nil {
@@ -533,6 +545,7 @@ func (db *DB) populateCompactStorageAudit(ctx context.Context, opts CompactStora
 		MinExpectedReclaimBytes:    opts.LeafPackMinExpectedReclaimBytes,
 		MinExpectedReclaimRatioPPM: opts.LeafPackMinExpectedReclaimRatioPPM,
 		MinReclaimPerByteCopiedPPM: opts.LeafPackMinReclaimPerCopyPPM,
+		ProtectedRootIDs:           db.compactStorageLeafGenerationProtectedRootIDs(opts),
 	})
 	if err != nil {
 		return debt, err
@@ -543,7 +556,10 @@ func (db *DB) populateCompactStorageAudit(ctx context.Context, opts CompactStora
 		debt.LeafPackBytes = leafPlan.ExpectedReclaimBytes
 	}
 
-	leafGC, err := db.leafGenerationGC(ctx, LeafGenerationGCOptions{DryRun: true}, lockMaintenance)
+	leafGC, err := db.leafGenerationGC(ctx, LeafGenerationGCOptions{
+		DryRun:           true,
+		ProtectedRootIDs: db.compactStorageLeafGenerationProtectedRootIDs(opts),
+	}, lockMaintenance)
 	if err != nil {
 		return debt, err
 	}
@@ -772,6 +788,38 @@ func compactStorageValueLogProtectedPaths(opts CompactStorageOptions) []string {
 		out = append(out, path)
 	}
 	return out
+}
+
+func (db *DB) compactStorageLeafGenerationProtectedRootIDs(opts CompactStorageOptions) []uint64 {
+	var out []uint64
+	out = appendCompactStorageProtectedRootIDs(out, opts.LeafGenerationProtectedRootIDs)
+	if opts.LeafGenerationProtectedRootIDsFunc != nil {
+		out = appendCompactStorageProtectedRootIDs(out, opts.LeafGenerationProtectedRootIDsFunc())
+	}
+	out = appendCompactStorageProtectedRootIDs(out, db.protectedLeafGenerationRootIDsFromLeafPageLog())
+	return out
+}
+
+func appendCompactStorageProtectedRootIDs(dst []uint64, src []uint64) []uint64 {
+	if len(src) == 0 {
+		return dst
+	}
+	for _, rootID := range src {
+		if rootID == 0 {
+			continue
+		}
+		seen := false
+		for _, existing := range dst {
+			if existing == rootID {
+				seen = true
+				break
+			}
+		}
+		if !seen {
+			dst = append(dst, rootID)
+		}
+	}
+	return dst
 }
 
 func compactStorageOnlineRewriteProtectedPaths(opts CompactStorageOptions) []string {

--- a/TreeDB/db/compact_storage.go
+++ b/TreeDB/db/compact_storage.go
@@ -54,18 +54,25 @@ type CompactStorageOptions struct {
 	// Leaf-generation pack knobs. Defaults are intentionally bounded to keep a
 	// single compaction request finite while still draining ordinary debt.
 	LeafGenerationProtectedRootIDs []uint64
+	// LeafGenerationProtectedSystemRootIDs are system roots whose collection
+	// descriptors should be expanded into additional protected leaf-generation
+	// roots during compaction.
+	LeafGenerationProtectedSystemRootIDs []uint64
 	// LeafGenerationProtectedRootIDsFunc refreshes additional leaf-generation
 	// roots before each leaf plan/pack/GC phase. Cached/native interop callers
 	// use this so roots published outside backend meta roots keep their leaf-log
 	// children live during compaction.
 	LeafGenerationProtectedRootIDsFunc func() []uint64
-	LeafPackMaxPasses                  int
-	LeafPackMaxGenerationsPerPass      int
-	LeafPackMaxBytesToCopyPerPass      int64
-	LeafPackMinExpectedReclaimBytes    int64
-	LeafPackMinExpectedReclaimRatioPPM int
-	LeafPackMinReclaimPerCopyPPM       int
-	LeafPackLeafFrameK                 int
+	// LeafGenerationProtectedSystemRootIDsFunc refreshes additional system roots
+	// whose collection root descriptors should be expanded during compaction.
+	LeafGenerationProtectedSystemRootIDsFunc func() []uint64
+	LeafPackMaxPasses                        int
+	LeafPackMaxGenerationsPerPass            int
+	LeafPackMaxBytesToCopyPerPass            int64
+	LeafPackMinExpectedReclaimBytes          int64
+	LeafPackMinExpectedReclaimRatioPPM       int
+	LeafPackMinReclaimPerCopyPPM             int
+	LeafPackLeafFrameK                       int
 
 	// ReserveRIDs lets cached-mode callers share the live RID allocator with
 	// foreground writers.
@@ -228,6 +235,7 @@ func (db *DB) compactStorage(ctx context.Context, opts CompactStorageOptions) (C
 		protectedPaths := compactStorageOnlineRewriteProtectedPaths(opts)
 		rewriteOpts := compactStorageRewritePlanOptions(protectedPaths)
 		rewriteOpts.LeafGenerationProtectedRootIDs = db.compactStorageLeafGenerationProtectedRootIDs(opts)
+		rewriteOpts.LeafGenerationProtectedSystemRootIDs = db.compactStorageLeafGenerationProtectedSystemRootIDs(opts)
 		rewriteOpts.BatchSize = opts.ValueLogRewriteBatchSize
 		rewriteOpts.SyncEachBatch = opts.SyncEachPhase
 		rewriteOpts.MaxSegmentBytes = opts.ValueLogRewriteMaxSegmentBytes
@@ -273,6 +281,7 @@ func (db *DB) compactStorage(ctx context.Context, opts CompactStorageOptions) (C
 				ReserveRIDs:                opts.ReserveRIDs,
 				LeafFrameK:                 opts.LeafPackLeafFrameK,
 				ProtectedRootIDs:           db.compactStorageLeafGenerationProtectedRootIDs(opts),
+				ProtectedSystemRootIDs:     db.compactStorageLeafGenerationProtectedSystemRootIDs(opts),
 			}, !maintenanceLocked)
 			return err
 		}); err != nil {
@@ -298,7 +307,8 @@ func (db *DB) compactStorage(ctx context.Context, opts CompactStorageOptions) (C
 
 	if err := db.runCompactStoragePhase(&stats, "leaf-generation-gc", func() error {
 		gc, err := db.leafGenerationGC(ctx, LeafGenerationGCOptions{
-			ProtectedRootIDs: db.compactStorageLeafGenerationProtectedRootIDs(opts),
+			ProtectedRootIDs:       db.compactStorageLeafGenerationProtectedRootIDs(opts),
+			ProtectedSystemRootIDs: db.compactStorageLeafGenerationProtectedSystemRootIDs(opts),
 		}, !maintenanceLocked)
 		stats.LeafGenerationGC = gc
 		return err
@@ -428,7 +438,8 @@ func (db *DB) settleCompactStorageGC(ctx context.Context, opts CompactStorageOpt
 			phaseName := fmt.Sprintf("settle-leaf-generation-gc-%d", pass+1)
 			if err := db.runCompactStoragePhase(stats, phaseName, func() error {
 				gc, err := db.leafGenerationGC(ctx, LeafGenerationGCOptions{
-					ProtectedRootIDs: db.compactStorageLeafGenerationProtectedRootIDs(opts),
+					ProtectedRootIDs:       db.compactStorageLeafGenerationProtectedRootIDs(opts),
+					ProtectedSystemRootIDs: db.compactStorageLeafGenerationProtectedSystemRootIDs(opts),
 				}, lockMaintenance)
 				stats.LeafGenerationGC = gc
 				return err
@@ -546,6 +557,7 @@ func (db *DB) populateCompactStorageAudit(ctx context.Context, opts CompactStora
 		MinExpectedReclaimRatioPPM: opts.LeafPackMinExpectedReclaimRatioPPM,
 		MinReclaimPerByteCopiedPPM: opts.LeafPackMinReclaimPerCopyPPM,
 		ProtectedRootIDs:           db.compactStorageLeafGenerationProtectedRootIDs(opts),
+		ProtectedSystemRootIDs:     db.compactStorageLeafGenerationProtectedSystemRootIDs(opts),
 	})
 	if err != nil {
 		return debt, err
@@ -557,8 +569,9 @@ func (db *DB) populateCompactStorageAudit(ctx context.Context, opts CompactStora
 	}
 
 	leafGC, err := db.leafGenerationGC(ctx, LeafGenerationGCOptions{
-		DryRun:           true,
-		ProtectedRootIDs: db.compactStorageLeafGenerationProtectedRootIDs(opts),
+		DryRun:                 true,
+		ProtectedRootIDs:       db.compactStorageLeafGenerationProtectedRootIDs(opts),
+		ProtectedSystemRootIDs: db.compactStorageLeafGenerationProtectedSystemRootIDs(opts),
 	}, lockMaintenance)
 	if err != nil {
 		return debt, err
@@ -797,6 +810,16 @@ func (db *DB) compactStorageLeafGenerationProtectedRootIDs(opts CompactStorageOp
 		out = appendCompactStorageProtectedRootIDs(out, opts.LeafGenerationProtectedRootIDsFunc())
 	}
 	out = appendCompactStorageProtectedRootIDs(out, db.protectedLeafGenerationRootIDsFromLeafPageLog())
+	return out
+}
+
+func (db *DB) compactStorageLeafGenerationProtectedSystemRootIDs(opts CompactStorageOptions) []uint64 {
+	var out []uint64
+	out = appendCompactStorageProtectedRootIDs(out, opts.LeafGenerationProtectedSystemRootIDs)
+	if opts.LeafGenerationProtectedSystemRootIDsFunc != nil {
+		out = appendCompactStorageProtectedRootIDs(out, opts.LeafGenerationProtectedSystemRootIDsFunc())
+	}
+	out = appendCompactStorageProtectedRootIDs(out, db.protectedLeafGenerationSystemRootIDsFromLeafPageLog())
 	return out
 }
 

--- a/TreeDB/db/compact_storage.go
+++ b/TreeDB/db/compact_storage.go
@@ -66,13 +66,16 @@ type CompactStorageOptions struct {
 	// LeafGenerationProtectedSystemRootIDsFunc refreshes additional system roots
 	// whose collection root descriptors should be expanded during compaction.
 	LeafGenerationProtectedSystemRootIDsFunc func() []uint64
-	LeafPackMaxPasses                        int
-	LeafPackMaxGenerationsPerPass            int
-	LeafPackMaxBytesToCopyPerPass            int64
-	LeafPackMinExpectedReclaimBytes          int64
-	LeafPackMinExpectedReclaimRatioPPM       int
-	LeafPackMinReclaimPerCopyPPM             int
-	LeafPackLeafFrameK                       int
+	// LeafGenerationProtectedRootIDPairFunc refreshes ordinary and system roots
+	// from one caller snapshot when both lists come from the same source.
+	LeafGenerationProtectedRootIDPairFunc func() (rootIDs []uint64, systemRootIDs []uint64)
+	LeafPackMaxPasses                     int
+	LeafPackMaxGenerationsPerPass         int
+	LeafPackMaxBytesToCopyPerPass         int64
+	LeafPackMinExpectedReclaimBytes       int64
+	LeafPackMinExpectedReclaimRatioPPM    int
+	LeafPackMinReclaimPerCopyPPM          int
+	LeafPackLeafFrameK                    int
 
 	// ReserveRIDs lets cached-mode callers share the live RID allocator with
 	// foreground writers.
@@ -233,9 +236,10 @@ func (db *DB) compactStorage(ctx context.Context, opts CompactStorageOptions) (C
 	defer cleanupLeafLog()
 	if err := db.runCompactStoragePhase(&stats, "value-log-rewrite", func() error {
 		protectedPaths := compactStorageOnlineRewriteProtectedPaths(opts)
+		protectedRootIDs, protectedSystemRootIDs := db.compactStorageLeafGenerationProtectedRootIDPair(opts)
 		rewriteOpts := compactStorageRewritePlanOptions(protectedPaths)
-		rewriteOpts.LeafGenerationProtectedRootIDs = db.compactStorageLeafGenerationProtectedRootIDs(opts)
-		rewriteOpts.LeafGenerationProtectedSystemRootIDs = db.compactStorageLeafGenerationProtectedSystemRootIDs(opts)
+		rewriteOpts.LeafGenerationProtectedRootIDs = protectedRootIDs
+		rewriteOpts.LeafGenerationProtectedSystemRootIDs = protectedSystemRootIDs
 		rewriteOpts.BatchSize = opts.ValueLogRewriteBatchSize
 		rewriteOpts.SyncEachBatch = opts.SyncEachPhase
 		rewriteOpts.MaxSegmentBytes = opts.ValueLogRewriteMaxSegmentBytes
@@ -271,6 +275,7 @@ func (db *DB) compactStorage(ctx context.Context, opts CompactStorageOptions) (C
 		phaseName := fmt.Sprintf("leaf-generation-pack-%d", pass+1)
 		if err := db.runCompactStoragePhase(&stats, phaseName, func() error {
 			var err error
+			protectedRootIDs, protectedSystemRootIDs := db.compactStorageLeafGenerationProtectedRootIDPair(opts)
 			pack, err = db.leafGenerationPackRunOnce(ctx, LeafGenerationPackFromPlanOptions{
 				Sync:                       opts.SyncEachPhase,
 				MinExpectedReclaimBytes:    opts.LeafPackMinExpectedReclaimBytes,
@@ -280,8 +285,8 @@ func (db *DB) compactStorage(ctx context.Context, opts CompactStorageOptions) (C
 				MaxBytesToCopy:             opts.LeafPackMaxBytesToCopyPerPass,
 				ReserveRIDs:                opts.ReserveRIDs,
 				LeafFrameK:                 opts.LeafPackLeafFrameK,
-				ProtectedRootIDs:           db.compactStorageLeafGenerationProtectedRootIDs(opts),
-				ProtectedSystemRootIDs:     db.compactStorageLeafGenerationProtectedSystemRootIDs(opts),
+				ProtectedRootIDs:           protectedRootIDs,
+				ProtectedSystemRootIDs:     protectedSystemRootIDs,
 			}, !maintenanceLocked)
 			return err
 		}); err != nil {
@@ -306,9 +311,10 @@ func (db *DB) compactStorage(ctx context.Context, opts CompactStorageOptions) (C
 	}
 
 	if err := db.runCompactStoragePhase(&stats, "leaf-generation-gc", func() error {
+		protectedRootIDs, protectedSystemRootIDs := db.compactStorageLeafGenerationProtectedRootIDPair(opts)
 		gc, err := db.leafGenerationGC(ctx, LeafGenerationGCOptions{
-			ProtectedRootIDs:       db.compactStorageLeafGenerationProtectedRootIDs(opts),
-			ProtectedSystemRootIDs: db.compactStorageLeafGenerationProtectedSystemRootIDs(opts),
+			ProtectedRootIDs:       protectedRootIDs,
+			ProtectedSystemRootIDs: protectedSystemRootIDs,
 		}, !maintenanceLocked)
 		stats.LeafGenerationGC = gc
 		return err
@@ -437,9 +443,10 @@ func (db *DB) settleCompactStorageGC(ctx context.Context, opts CompactStorageOpt
 		if debt.LeafGCGenerations > 0 {
 			phaseName := fmt.Sprintf("settle-leaf-generation-gc-%d", pass+1)
 			if err := db.runCompactStoragePhase(stats, phaseName, func() error {
+				protectedRootIDs, protectedSystemRootIDs := db.compactStorageLeafGenerationProtectedRootIDPair(opts)
 				gc, err := db.leafGenerationGC(ctx, LeafGenerationGCOptions{
-					ProtectedRootIDs:       db.compactStorageLeafGenerationProtectedRootIDs(opts),
-					ProtectedSystemRootIDs: db.compactStorageLeafGenerationProtectedSystemRootIDs(opts),
+					ProtectedRootIDs:       protectedRootIDs,
+					ProtectedSystemRootIDs: protectedSystemRootIDs,
 				}, lockMaintenance)
 				stats.LeafGenerationGC = gc
 				return err
@@ -552,12 +559,13 @@ func (db *DB) populateCompactStorageAudit(ctx context.Context, opts CompactStora
 	debt.ValueLogGCSegments += len(fencedValueLogIDs)
 	debt.ValueLogGCBytes += fencedValueLogBytes
 
+	protectedRootIDs, protectedSystemRootIDs := db.compactStorageLeafGenerationProtectedRootIDPair(opts)
 	leafPlan, err := db.LeafGenerationPlan(ctx, LeafGenerationPlanOptions{
 		MinExpectedReclaimBytes:    opts.LeafPackMinExpectedReclaimBytes,
 		MinExpectedReclaimRatioPPM: opts.LeafPackMinExpectedReclaimRatioPPM,
 		MinReclaimPerByteCopiedPPM: opts.LeafPackMinReclaimPerCopyPPM,
-		ProtectedRootIDs:           db.compactStorageLeafGenerationProtectedRootIDs(opts),
-		ProtectedSystemRootIDs:     db.compactStorageLeafGenerationProtectedSystemRootIDs(opts),
+		ProtectedRootIDs:           protectedRootIDs,
+		ProtectedSystemRootIDs:     protectedSystemRootIDs,
 	})
 	if err != nil {
 		return debt, err
@@ -568,10 +576,11 @@ func (db *DB) populateCompactStorageAudit(ctx context.Context, opts CompactStora
 		debt.LeafPackBytes = leafPlan.ExpectedReclaimBytes
 	}
 
+	protectedRootIDs, protectedSystemRootIDs = db.compactStorageLeafGenerationProtectedRootIDPair(opts)
 	leafGC, err := db.leafGenerationGC(ctx, LeafGenerationGCOptions{
 		DryRun:                 true,
-		ProtectedRootIDs:       db.compactStorageLeafGenerationProtectedRootIDs(opts),
-		ProtectedSystemRootIDs: db.compactStorageLeafGenerationProtectedSystemRootIDs(opts),
+		ProtectedRootIDs:       protectedRootIDs,
+		ProtectedSystemRootIDs: protectedSystemRootIDs,
 	}, lockMaintenance)
 	if err != nil {
 		return debt, err
@@ -803,24 +812,26 @@ func compactStorageValueLogProtectedPaths(opts CompactStorageOptions) []string {
 	return out
 }
 
-func (db *DB) compactStorageLeafGenerationProtectedRootIDs(opts CompactStorageOptions) []uint64 {
-	var out []uint64
-	out = appendCompactStorageProtectedRootIDs(out, opts.LeafGenerationProtectedRootIDs)
+func (db *DB) compactStorageLeafGenerationProtectedRootIDPair(opts CompactStorageOptions) ([]uint64, []uint64) {
+	var rootIDs []uint64
+	var systemRootIDs []uint64
+	rootIDs = appendCompactStorageProtectedRootIDs(rootIDs, opts.LeafGenerationProtectedRootIDs)
+	systemRootIDs = appendCompactStorageProtectedRootIDs(systemRootIDs, opts.LeafGenerationProtectedSystemRootIDs)
 	if opts.LeafGenerationProtectedRootIDsFunc != nil {
-		out = appendCompactStorageProtectedRootIDs(out, opts.LeafGenerationProtectedRootIDsFunc())
+		rootIDs = appendCompactStorageProtectedRootIDs(rootIDs, opts.LeafGenerationProtectedRootIDsFunc())
 	}
-	out = appendCompactStorageProtectedRootIDs(out, db.protectedLeafGenerationRootIDsFromLeafPageLog())
-	return out
-}
-
-func (db *DB) compactStorageLeafGenerationProtectedSystemRootIDs(opts CompactStorageOptions) []uint64 {
-	var out []uint64
-	out = appendCompactStorageProtectedRootIDs(out, opts.LeafGenerationProtectedSystemRootIDs)
 	if opts.LeafGenerationProtectedSystemRootIDsFunc != nil {
-		out = appendCompactStorageProtectedRootIDs(out, opts.LeafGenerationProtectedSystemRootIDsFunc())
+		systemRootIDs = appendCompactStorageProtectedRootIDs(systemRootIDs, opts.LeafGenerationProtectedSystemRootIDsFunc())
 	}
-	out = appendCompactStorageProtectedRootIDs(out, db.protectedLeafGenerationSystemRootIDsFromLeafPageLog())
-	return out
+	if opts.LeafGenerationProtectedRootIDPairFunc != nil {
+		dynamicRootIDs, dynamicSystemRootIDs := opts.LeafGenerationProtectedRootIDPairFunc()
+		rootIDs = appendCompactStorageProtectedRootIDs(rootIDs, dynamicRootIDs)
+		systemRootIDs = appendCompactStorageProtectedRootIDs(systemRootIDs, dynamicSystemRootIDs)
+	}
+	dynamicRootIDs, dynamicSystemRootIDs := db.protectedLeafGenerationRootIDPairFromLeafPageLog()
+	rootIDs = appendCompactStorageProtectedRootIDs(rootIDs, dynamicRootIDs)
+	systemRootIDs = appendCompactStorageProtectedRootIDs(systemRootIDs, dynamicSystemRootIDs)
+	return rootIDs, systemRootIDs
 }
 
 func appendCompactStorageProtectedRootIDs(dst []uint64, src []uint64) []uint64 {

--- a/TreeDB/db/compact_storage_test.go
+++ b/TreeDB/db/compact_storage_test.go
@@ -992,6 +992,36 @@ func TestCompactStoragePlan_ProtectedRootIDsKeepDetachedLeafGenerationLive(t *te
 	}
 }
 
+func TestCompactStorageLeafGenerationProtectedRootIDPairMergesSourcesOnce(t *testing.T) {
+	d := &DB{}
+	pairCalls := 0
+	opts := CompactStorageOptions{
+		LeafGenerationProtectedRootIDs:       []uint64{0, 1, 2, 1},
+		LeafGenerationProtectedSystemRootIDs: []uint64{10, 0, 10},
+		LeafGenerationProtectedRootIDsFunc: func() []uint64 {
+			return []uint64{2, 3}
+		},
+		LeafGenerationProtectedSystemRootIDsFunc: func() []uint64 {
+			return []uint64{10, 11}
+		},
+		LeafGenerationProtectedRootIDPairFunc: func() ([]uint64, []uint64) {
+			pairCalls++
+			return []uint64{3, 4}, []uint64{11, 12}
+		},
+	}
+
+	rootIDs, systemRootIDs := d.compactStorageLeafGenerationProtectedRootIDPair(opts)
+	if pairCalls != 1 {
+		t.Fatalf("pair callback calls=%d want 1", pairCalls)
+	}
+	if want := []uint64{1, 2, 3, 4}; !reflect.DeepEqual(rootIDs, want) {
+		t.Fatalf("rootIDs=%v want %v", rootIDs, want)
+	}
+	if want := []uint64{10, 11, 12}; !reflect.DeepEqual(systemRootIDs, want) {
+		t.Fatalf("systemRootIDs=%v want %v", systemRootIDs, want)
+	}
+}
+
 func compactStoragePhaseSeen(phases []CompactStoragePhaseStats, name string) bool {
 	for _, phase := range phases {
 		if phase.Name == name {

--- a/TreeDB/db/compact_storage_test.go
+++ b/TreeDB/db/compact_storage_test.go
@@ -847,6 +847,61 @@ func TestRegisterLeafPageLogSegmentsForPublishRegistersRewriteSegments(t *testin
 	}
 }
 
+func TestRegisterLeafPageLogSegmentsForPublishQueuesCurrentLeafGenerationSegment(t *testing.T) {
+	dir := t.TempDir()
+	d, err := Open(Options{
+		Dir:                        dir,
+		IndexOuterLeavesInValueLog: true,
+	})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	path, fileID := createLeafGenerationTestSegment(t, LeafLogDirPath(dir), rewriteLeafLogLaneID, 9)
+	d.SetLeafPageLog(&manifestTestLeafPageLog{path: path, fileID: fileID})
+	if d.valueLogManager.HasSegment(fileID) {
+		t.Fatalf("segment %d was registered before publish helper", fileID)
+	}
+
+	registered, err := d.registerLeafPageLogSegmentsForPublish()
+	if err != nil {
+		t.Fatalf("registerLeafPageLogSegmentsForPublish: %v", err)
+	}
+	if !registered {
+		t.Fatal("current leaf segment was not registered")
+	}
+	if !d.valueLogManager.HasSegment(fileID) {
+		t.Fatalf("segment %d was not registered", fileID)
+	}
+
+	rawFileID, ok := rawLeafGenerationFileID(fileID)
+	if !ok {
+		t.Fatalf("raw leaf generation file id missing for segment %d", fileID)
+	}
+	d.leafGenerationPendingMu.Lock()
+	_, pending := d.leafGenerationPendingSet[rawFileID]
+	pendingCommitSeq := d.leafGenerationPendingCommitSeq[rawFileID]
+	d.leafGenerationPendingMu.Unlock()
+	if !pending {
+		t.Fatalf("raw leaf generation file id %d was not queued pending", rawFileID)
+	}
+	if pendingCommitSeq != 0 {
+		t.Fatalf("pending commitSeq=%d want 0 before publish commit succeeds", pendingCommitSeq)
+	}
+	staged, changed, err := d.stagedLeafGenerationManifestWithPending(d.leafGenerationManifest, 0, 222)
+	if err != nil {
+		t.Fatalf("stagedLeafGenerationManifestWithPending: %v", err)
+	}
+	if !changed {
+		t.Fatal("expected staged manifest change")
+	}
+	current := staged.Generations[staged.currentGenerationIndex()]
+	if got, want := current.FileIDs, []uint32{rawFileID}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("staged current FileIDs=%v want %v", got, want)
+	}
+}
+
 func TestCompactStorageHoldsMaintenanceLockAcrossPhases(t *testing.T) {
 	dir := t.TempDir()
 	d, err := Open(Options{Dir: dir})

--- a/TreeDB/db/compact_storage_test.go
+++ b/TreeDB/db/compact_storage_test.go
@@ -929,6 +929,69 @@ func TestCompactStorageSettlesLeafGenerationGCAfterPinnedRetiring(t *testing.T) 
 	}
 }
 
+func TestCompactStoragePlan_ProtectedRootIDsKeepDetachedLeafGenerationLive(t *testing.T) {
+	d, leafLog, _ := openLeafGenerationPackTestDB(t)
+
+	rootTable := mustFrozenSystemMemtable(t, systemRangeKVs(2048, nil)...)
+	rootID, err := d.PublishOrderedRootIterator(0, rootTable.NewIterator(nil, nil))
+	if err != nil {
+		t.Fatalf("PublishOrderedRootIterator: %v", err)
+	}
+	if rootID == 0 {
+		t.Fatal("expected non-zero detached root")
+	}
+	if state := d.State(); state.RootPageID == rootID || state.SystemRootPageID == rootID {
+		t.Fatalf("test requires detached root, got state roots user=%d system=%d detached=%d", state.RootPageID, state.SystemRootPageID, rootID)
+	}
+
+	path1, fileID1 := currentLeafSegmentOrFatal(t, leafLog)
+	rawFileID1 := page.ValueLogSegmentID(fileID1)
+	refs := collectLeafRefIDsFromRoot(t, d, rootID)
+	refsFile := false
+	for ptr := range refs {
+		if ptr.FileID == rawFileID1 {
+			refsFile = true
+			break
+		}
+	}
+	if !refsFile {
+		t.Fatalf("detached root refs do not include raw file id %d: %+v", rawFileID1, refs)
+	}
+
+	if err := leafLog.rotateLeaf(); err != nil {
+		t.Fatalf("rotateLeaf: %v", err)
+	}
+	writeLeafGenerationKeys(t, d, "current", 1, 'z')
+
+	unprotectedPlan, err := d.CompactStoragePlan(context.Background(), CompactStorageOptions{})
+	if err != nil {
+		t.Fatalf("CompactStoragePlan unprotected: %v", err)
+	}
+	if got := unprotectedPlan.RemainingDebt.LeafGCGenerations; got == 0 {
+		t.Fatalf("LeafGCGenerations=%d want detached generation eligible without protection (debt=%+v)", got, unprotectedPlan.RemainingDebt)
+	}
+
+	protectedPlan, err := d.CompactStoragePlan(context.Background(), CompactStorageOptions{
+		LeafGenerationProtectedRootIDs: []uint64{0, rootID, rootID},
+		LeafPackMaxPasses:              1,
+	})
+	if err != nil {
+		t.Fatalf("CompactStoragePlan protected: %v", err)
+	}
+	if got := protectedPlan.RemainingDebt.LeafGCGenerations; got != 0 {
+		t.Fatalf("protected LeafGCGenerations=%d want 0 (debt=%+v)", got, protectedPlan.RemainingDebt)
+	}
+	if got := protectedPlan.LeafGenerationGC.GenerationsEligible; got != 0 {
+		t.Fatalf("protected GenerationsEligible=%d want 0 (stats=%+v)", got, protectedPlan.LeafGenerationGC)
+	}
+	if _, err := os.Stat(path1); err != nil {
+		t.Fatalf("expected protected leaf segment to remain: %v", err)
+	}
+	if got := collectLeafRefIDsFromRoot(t, d, rootID); len(got) == 0 {
+		t.Fatalf("expected detached root %d leaf refs to remain readable", rootID)
+	}
+}
+
 func compactStoragePhaseSeen(phases []CompactStoragePhaseStats, name string) bool {
 	for _, phase := range phases {
 		if phase.Name == name {

--- a/TreeDB/db/compact_storage_test.go
+++ b/TreeDB/db/compact_storage_test.go
@@ -813,7 +813,7 @@ func TestRegisterLeafPageLogSegmentsForPublishRegistersRewriteSegments(t *testin
 		t.Fatalf("segment %d was registered before publish helper", createdSegments[0].fileID)
 	}
 
-	registered, err := d.registerLeafPageLogSegmentsForPublish(7)
+	registered, err := d.registerLeafPageLogSegmentsForPublish()
 	if err != nil {
 		t.Fatalf("registerLeafPageLogSegmentsForPublish: %v", err)
 	}
@@ -830,6 +830,20 @@ func TestRegisterLeafPageLogSegmentsForPublishRegistersRewriteSegments(t *testin
 	}
 	if _, ok := set.Files[createdSegments[0].fileID]; !ok {
 		t.Fatalf("published value-log set missing segment %d", createdSegments[0].fileID)
+	}
+	rawFileID, ok := rawLeafGenerationFileID(createdSegments[0].fileID)
+	if !ok {
+		t.Fatalf("raw leaf generation file id missing for segment %d", createdSegments[0].fileID)
+	}
+	d.leafGenerationPendingMu.Lock()
+	_, pending := d.leafGenerationPendingSet[rawFileID]
+	pendingCommitSeq := d.leafGenerationPendingCommitSeq[rawFileID]
+	d.leafGenerationPendingMu.Unlock()
+	if !pending {
+		t.Fatalf("raw leaf generation file id %d was not queued pending", rawFileID)
+	}
+	if pendingCommitSeq != 0 {
+		t.Fatalf("pending commitSeq=%d want 0 before publish commit succeeds", pendingCommitSeq)
 	}
 }
 

--- a/TreeDB/db/currentset_refresh_test.go
+++ b/TreeDB/db/currentset_refresh_test.go
@@ -591,6 +591,101 @@ func TestPublishOrderedRootDeltaGroupWithSystemBuilder_NonSystemPointerSkipsRefr
 	}
 }
 
+func TestPublishOrderedRootGroupWithSystemBuilder_NonSystemPointerRefreshesValueLogSet(t *testing.T) {
+	dir := t.TempDir()
+	d, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	if d.valueLogManager == nil {
+		t.Fatalf("missing value log manager")
+	}
+	value := bytes.Repeat([]byte("p"), 128)
+	fileID, ptr := writeValueLogRecord(t, dir, 0, 1, value, 1)
+	before := d.valueLogManager.RefreshScanCount()
+
+	_, rootIDs, err := d.PublishOrderedRootGroupWithSystemBuilder([]OrderedRootPublishInput{{
+		BaseRoot: 0,
+		Iter:     mustFrozenSystemPointerMemtable(t, "root/p", ptr).NewIterator(nil, nil),
+	}}, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		if len(rootIDs) != 1 {
+			t.Fatalf("rootIDs len=%d want 1", len(rootIDs))
+		}
+		return mustFrozenSystemMemtable(t, "sys/root", fmt.Sprintf("%d", rootIDs[0])).NewIterator(nil, nil), nil
+	})
+	if err != nil {
+		t.Fatalf("PublishOrderedRootGroupWithSystemBuilder: %v", err)
+	}
+	if len(rootIDs) != 1 {
+		t.Fatalf("rootIDs len=%d want 1", len(rootIDs))
+	}
+
+	after := d.valueLogManager.RefreshScanCount()
+	if after <= before {
+		t.Fatalf("ordered root full group pointer publish did not refresh value-log set: before=%d after=%d", before, after)
+	}
+
+	st := d.State()
+	if st == nil || st.ValueLogSet == nil {
+		t.Fatalf("state missing value-log set")
+	}
+	if _, ok := st.ValueLogSet.Files[fileID]; !ok {
+		t.Fatalf("ordered root full group publish did not refresh value-log set with segment %d", fileID)
+	}
+}
+
+func TestPublishOrderedRootGroupWithSystemBuilder_NonSystemPointerSkipsRefreshWhenSegmentRegistered(t *testing.T) {
+	dir := t.TempDir()
+	value := bytes.Repeat([]byte("p"), 128)
+	fileID, ptr := writeValueLogRecord(t, dir, 0, 1, value, 1)
+
+	d, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	if d.valueLogManager == nil {
+		t.Fatalf("missing value log manager")
+	}
+	path := filepath.Join(dir, "value_vlog", "value-l0-000001.log")
+	if err := d.RegisterValueLogSegment(path, fileID); err != nil {
+		t.Fatalf("RegisterValueLogSegment: %v", err)
+	}
+	before := d.valueLogManager.RefreshScanCount()
+
+	_, rootIDs, err := d.PublishOrderedRootGroupWithSystemBuilder([]OrderedRootPublishInput{{
+		BaseRoot: 0,
+		Iter:     mustFrozenSystemPointerMemtable(t, "root/p", ptr).NewIterator(nil, nil),
+	}}, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		if len(rootIDs) != 1 {
+			t.Fatalf("rootIDs len=%d want 1", len(rootIDs))
+		}
+		return mustFrozenSystemMemtable(t, "sys/root", fmt.Sprintf("%d", rootIDs[0])).NewIterator(nil, nil), nil
+	})
+	if err != nil {
+		t.Fatalf("PublishOrderedRootGroupWithSystemBuilder: %v", err)
+	}
+	if len(rootIDs) != 1 {
+		t.Fatalf("rootIDs len=%d want 1", len(rootIDs))
+	}
+
+	after := d.valueLogManager.RefreshScanCount()
+	if after != before {
+		t.Fatalf("ordered root full group pointer publish triggered value-log refresh scan: before=%d after=%d", before, after)
+	}
+
+	st := d.State()
+	if st == nil || st.ValueLogSet == nil {
+		t.Fatalf("state missing value-log set")
+	}
+	if _, ok := st.ValueLogSet.Files[fileID]; !ok {
+		t.Fatalf("ordered root full group publish missing pre-registered segment %d", fileID)
+	}
+}
+
 func TestPointerCommitSkipsValueLogRefreshWhenSegmentAlreadyRegistered(t *testing.T) {
 	dir := t.TempDir()
 	value := bytes.Repeat([]byte("p"), 256)

--- a/TreeDB/db/currentset_refresh_test.go
+++ b/TreeDB/db/currentset_refresh_test.go
@@ -119,6 +119,134 @@ func (l *registeredLeafPageLog) CurrentValueLogSegment() (string, uint32, bool) 
 	return l.path, l.fileID, true
 }
 
+type createdThenCurrentLeafPageLog struct {
+	dir             string
+	writers         []*valuelog.Writer
+	nextRID         uint64
+	firstFileID     uint32
+	currentPath     string
+	currentFileID   uint32
+	createdSegments []rewriteCreatedSegment
+}
+
+func (l *createdThenCurrentLeafPageLog) openSegment(seq uint32) (*valuelog.Writer, string, uint32, error) {
+	if l == nil || l.dir == "" {
+		return nil, "", 0, errors.New("leaf log dir unavailable")
+	}
+	fileID, err := valuelog.EncodeFileID(rewriteLeafLogLaneID, seq)
+	if err != nil {
+		return nil, "", 0, err
+	}
+	path := filepath.Join(LeafLogDirPath(l.dir), fmt.Sprintf("value-l%d-%06d.log", rewriteLeafLogLaneID, seq))
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return nil, "", 0, err
+	}
+	w, err := valuelog.NewWriter(path, fileID)
+	if err != nil {
+		return nil, "", 0, err
+	}
+	l.writers = append(l.writers, w)
+	return w, path, fileID, nil
+}
+
+func (l *createdThenCurrentLeafPageLog) AppendLeafPage(leafPage []byte) (page.LeafLogPtr, error) {
+	if l == nil {
+		return page.LeafLogPtr{}, errors.New("leaf log unavailable")
+	}
+	var w *valuelog.Writer
+	if l.firstFileID == 0 {
+		var path string
+		var err error
+		w, path, l.firstFileID, err = l.openSegment(1)
+		if err != nil {
+			return page.LeafLogPtr{}, err
+		}
+		l.createdSegments = append(l.createdSegments, rewriteCreatedSegment{path: path, fileID: l.firstFileID})
+		currentW, currentPath, currentFileID, err := l.openSegment(2)
+		if err != nil {
+			return page.LeafLogPtr{}, err
+		}
+		l.currentPath = currentPath
+		l.currentFileID = currentFileID
+		_ = currentW
+	} else if len(l.writers) > 0 {
+		w = l.writers[len(l.writers)-1]
+	}
+	if w == nil {
+		return page.LeafLogPtr{}, errors.New("leaf log writer unavailable")
+	}
+	l.nextRID++
+	ptr, err := w.Append(0, nil, l.nextRID, leafPage)
+	if err != nil {
+		return page.LeafLogPtr{}, err
+	}
+	return page.LeafLogPtrFromValuePtr(ptr)
+}
+
+func (l *createdThenCurrentLeafPageLog) Flush() error {
+	if l == nil {
+		return nil
+	}
+	for _, w := range l.writers {
+		if w == nil {
+			continue
+		}
+		if err := w.Flush(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (l *createdThenCurrentLeafPageLog) Sync() error {
+	if l == nil {
+		return nil
+	}
+	for _, w := range l.writers {
+		if w == nil {
+			continue
+		}
+		if err := w.Sync(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (l *createdThenCurrentLeafPageLog) Close() error {
+	if l == nil {
+		return nil
+	}
+	var firstErr error
+	for _, w := range l.writers {
+		if w == nil {
+			continue
+		}
+		if err := w.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	l.writers = nil
+	return firstErr
+}
+
+func (l *createdThenCurrentLeafPageLog) CurrentValueLogSegment() (string, uint32, bool) {
+	if l == nil || l.currentPath == "" || l.currentFileID == 0 {
+		return "", 0, false
+	}
+	return l.currentPath, l.currentFileID, true
+}
+
+func (l *createdThenCurrentLeafPageLog) createdSegmentsSnapshot() ([]rewriteCreatedSegment, error) {
+	if l == nil || len(l.createdSegments) == 0 {
+		return nil, nil
+	}
+	if err := l.Flush(); err != nil {
+		return nil, err
+	}
+	return append([]rewriteCreatedSegment(nil), l.createdSegments...), nil
+}
+
 // unregisteredLeafPageLog intentionally does not implement
 // CurrentValueLogSegment and does not register its segment with the manager.
 // It is used to verify forced-refresh safety fallbacks.
@@ -370,6 +498,53 @@ func TestOuterLeafCommitPublishesRegisteredSegmentWithoutExplicitRefresh(t *test
 	}
 	if _, ok := st.ValueLogSet.Files[leafLog.fileID]; !ok {
 		t.Fatalf("registered outer-leaf segment %d missing from published state", leafLog.fileID)
+	}
+
+	got, err := d.Get([]byte("k"))
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !bytes.Equal(got, []byte("v")) {
+		t.Fatalf("Get mismatch: got %q want %q", got, "v")
+	}
+}
+
+func TestOuterLeafCommitPublishesCreatedSegmentBeforeCurrentWithoutRefresh(t *testing.T) {
+	dir := t.TempDir()
+	d, err := Open(Options{Dir: dir, IndexOuterLeavesInValueLog: true})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	leafLog := &createdThenCurrentLeafPageLog{dir: dir}
+	defer func() { _ = leafLog.Close() }()
+	d.SetLeafPageLog(leafLog)
+	refreshBefore := d.valueLogManager.RefreshScanCount()
+
+	if err := d.Set([]byte("k"), []byte("v")); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	if leafLog.firstFileID == 0 {
+		t.Fatal("leaf log did not create the first segment")
+	}
+	if leafLog.currentFileID == 0 || leafLog.currentFileID == leafLog.firstFileID {
+		t.Fatalf("leaf log current segment=%d, first=%d", leafLog.currentFileID, leafLog.firstFileID)
+	}
+	refreshAfter := d.valueLogManager.RefreshScanCount()
+	if refreshAfter != refreshBefore {
+		t.Fatalf("outer-leaf commit triggered value-log refresh scan: before=%d after=%d", refreshBefore, refreshAfter)
+	}
+
+	st := d.State()
+	if st == nil || st.ValueLogSet == nil {
+		t.Fatalf("state missing value-log set")
+	}
+	if _, ok := st.ValueLogSet.Files[leafLog.firstFileID]; !ok {
+		t.Fatalf("created outer-leaf segment %d missing from published state", leafLog.firstFileID)
+	}
+	if _, ok := st.ValueLogSet.Files[leafLog.currentFileID]; !ok {
+		t.Fatalf("current outer-leaf segment %d missing from published state", leafLog.currentFileID)
 	}
 
 	got, err := d.Get([]byte("k"))

--- a/TreeDB/db/currentset_refresh_test.go
+++ b/TreeDB/db/currentset_refresh_test.go
@@ -457,6 +457,44 @@ func TestPublishSystemRootIterator_PointerRefreshesValueLogSet(t *testing.T) {
 	}
 }
 
+func TestPublishSystemRootIterator_PointerSkipsValueLogRefreshWhenSegmentAlreadyRegistered(t *testing.T) {
+	dir := t.TempDir()
+	value := bytes.Repeat([]byte("p"), 128)
+	fileID, ptr := writeValueLogRecord(t, dir, 0, 1, value, 1)
+
+	d, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	if d.valueLogManager == nil {
+		t.Fatalf("missing value log manager")
+	}
+	path := filepath.Join(dir, "value_vlog", "value-l0-000001.log")
+	if err := d.RegisterValueLogSegment(path, fileID); err != nil {
+		t.Fatalf("RegisterValueLogSegment: %v", err)
+	}
+	before := d.valueLogManager.RefreshScanCount()
+
+	if _, err := d.PublishSystemRootIterator(mustFrozenSystemPointerMemtable(t, "sys/p", ptr).NewIterator(nil, nil)); err != nil {
+		t.Fatalf("PublishSystemRootIterator: %v", err)
+	}
+
+	after := d.valueLogManager.RefreshScanCount()
+	if after != before {
+		t.Fatalf("system root pointer publish triggered value-log refresh scan: before=%d after=%d", before, after)
+	}
+
+	st := d.State()
+	if st == nil || st.ValueLogSet == nil {
+		t.Fatalf("state missing value-log set")
+	}
+	if _, ok := st.ValueLogSet.Files[fileID]; !ok {
+		t.Fatalf("system root publish missing pre-registered segment %d", fileID)
+	}
+}
+
 func TestPointerCommitSkipsValueLogRefreshWhenSegmentAlreadyRegistered(t *testing.T) {
 	dir := t.TempDir()
 	value := bytes.Repeat([]byte("p"), 256)

--- a/TreeDB/db/currentset_refresh_test.go
+++ b/TreeDB/db/currentset_refresh_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/snissn/gomap/TreeDB/batch"
 	"github.com/snissn/gomap/TreeDB/internal/iterator"
 	"github.com/snissn/gomap/TreeDB/internal/valuelog"
 	"github.com/snissn/gomap/TreeDB/page"
@@ -314,6 +315,32 @@ func (l *unregisteredLeafPageLog) Close() error {
 	err := l.w.Close()
 	l.w = nil
 	return err
+}
+
+func TestAppendOrderedRootDeltaBatchFinalTouchedValueLogSegmentsDedupesWithSeed(t *testing.T) {
+	delta := batch.New(nil, 1024)
+	defer delta.Close()
+
+	fileA := page.ValueLogFileID(10)
+	fileB := page.ValueLogFileID(11)
+	if err := delta.SetPointer([]byte("a"), page.ValuePtr{FileID: fileA, Offset: 1, Length: 1}); err != nil {
+		t.Fatalf("SetPointer a: %v", err)
+	}
+	if err := delta.SetPointer([]byte("b"), page.ValuePtr{FileID: fileB, Offset: 2, Length: 1}); err != nil {
+		t.Fatalf("SetPointer b: %v", err)
+	}
+	if err := delta.SetPointer([]byte("c"), page.ValuePtr{FileID: fileA, Offset: 3, Length: 1}); err != nil {
+		t.Fatalf("SetPointer c: %v", err)
+	}
+	if err := delta.Set([]byte("inline"), []byte("value")); err != nil {
+		t.Fatalf("Set inline: %v", err)
+	}
+
+	got := appendOrderedRootDeltaBatchFinalTouchedValueLogSegments(delta, []uint32{fileB})
+	want := []uint32{fileB, fileA}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("touched segments=%v want %v", got, want)
+	}
 }
 
 func TestInlineCommitSkipsValueLogRefresh(t *testing.T) {

--- a/TreeDB/db/currentset_refresh_test.go
+++ b/TreeDB/db/currentset_refresh_test.go
@@ -424,6 +424,39 @@ func TestPointerCommitRefreshesValueLogSet(t *testing.T) {
 	}
 }
 
+func TestPublishSystemRootIterator_PointerRefreshesValueLogSet(t *testing.T) {
+	dir := t.TempDir()
+	d, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	if d.valueLogManager == nil {
+		t.Fatalf("missing value log manager")
+	}
+	value := bytes.Repeat([]byte("p"), 128)
+	fileID, ptr := writeValueLogRecord(t, dir, 0, 1, value, 1)
+	before := d.valueLogManager.RefreshScanCount()
+
+	if _, err := d.PublishSystemRootIterator(mustFrozenSystemPointerMemtable(t, "sys/p", ptr).NewIterator(nil, nil)); err != nil {
+		t.Fatalf("PublishSystemRootIterator: %v", err)
+	}
+
+	after := d.valueLogManager.RefreshScanCount()
+	if after <= before {
+		t.Fatalf("system root pointer publish did not refresh value-log set: before=%d after=%d", before, after)
+	}
+
+	st := d.State()
+	if st == nil || st.ValueLogSet == nil {
+		t.Fatalf("state missing value-log set")
+	}
+	if _, ok := st.ValueLogSet.Files[fileID]; !ok {
+		t.Fatalf("system root publish did not refresh value-log set with segment %d", fileID)
+	}
+}
+
 func TestPointerCommitSkipsValueLogRefreshWhenSegmentAlreadyRegistered(t *testing.T) {
 	dir := t.TempDir()
 	value := bytes.Repeat([]byte("p"), 256)

--- a/TreeDB/db/currentset_refresh_test.go
+++ b/TreeDB/db/currentset_refresh_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/snissn/gomap/TreeDB/internal/iterator"
 	"github.com/snissn/gomap/TreeDB/internal/valuelog"
 	"github.com/snissn/gomap/TreeDB/page"
 )
@@ -492,6 +493,101 @@ func TestPublishSystemRootIterator_PointerSkipsValueLogRefreshWhenSegmentAlready
 	}
 	if _, ok := st.ValueLogSet.Files[fileID]; !ok {
 		t.Fatalf("system root publish missing pre-registered segment %d", fileID)
+	}
+}
+
+func TestPublishOrderedRootDeltaGroupWithSystemBuilder_NonSystemPointerRefreshesValueLogSet(t *testing.T) {
+	dir := t.TempDir()
+	d, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	if d.valueLogManager == nil {
+		t.Fatalf("missing value log manager")
+	}
+	value := bytes.Repeat([]byte("p"), 128)
+	fileID, ptr := writeValueLogRecord(t, dir, 0, 1, value, 1)
+	before := d.valueLogManager.RefreshScanCount()
+
+	_, rootIDs, err := d.PublishOrderedRootDeltaGroupWithSystemBuilder([]OrderedRootDeltaPublishInput{{
+		BaseRoot: 0,
+		Iter:     mustFrozenSystemPointerMemtable(t, "root/p", ptr).NewIterator(nil, nil),
+	}}, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		if len(rootIDs) != 1 {
+			t.Fatalf("rootIDs len=%d want 1", len(rootIDs))
+		}
+		return mustFrozenSystemMemtable(t, "sys/root", fmt.Sprintf("%d", rootIDs[0])).NewIterator(nil, nil), nil
+	})
+	if err != nil {
+		t.Fatalf("PublishOrderedRootDeltaGroupWithSystemBuilder: %v", err)
+	}
+	if len(rootIDs) != 1 {
+		t.Fatalf("rootIDs len=%d want 1", len(rootIDs))
+	}
+
+	after := d.valueLogManager.RefreshScanCount()
+	if after <= before {
+		t.Fatalf("ordered root group pointer publish did not refresh value-log set: before=%d after=%d", before, after)
+	}
+
+	st := d.State()
+	if st == nil || st.ValueLogSet == nil {
+		t.Fatalf("state missing value-log set")
+	}
+	if _, ok := st.ValueLogSet.Files[fileID]; !ok {
+		t.Fatalf("ordered root group publish did not refresh value-log set with segment %d", fileID)
+	}
+}
+
+func TestPublishOrderedRootDeltaGroupWithSystemBuilder_NonSystemPointerSkipsRefreshWhenSegmentRegistered(t *testing.T) {
+	dir := t.TempDir()
+	value := bytes.Repeat([]byte("p"), 128)
+	fileID, ptr := writeValueLogRecord(t, dir, 0, 1, value, 1)
+
+	d, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	if d.valueLogManager == nil {
+		t.Fatalf("missing value log manager")
+	}
+	path := filepath.Join(dir, "value_vlog", "value-l0-000001.log")
+	if err := d.RegisterValueLogSegment(path, fileID); err != nil {
+		t.Fatalf("RegisterValueLogSegment: %v", err)
+	}
+	before := d.valueLogManager.RefreshScanCount()
+
+	_, rootIDs, err := d.PublishOrderedRootDeltaGroupWithSystemBuilder([]OrderedRootDeltaPublishInput{{
+		BaseRoot: 0,
+		Iter:     mustFrozenSystemPointerMemtable(t, "root/p", ptr).NewIterator(nil, nil),
+	}}, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		if len(rootIDs) != 1 {
+			t.Fatalf("rootIDs len=%d want 1", len(rootIDs))
+		}
+		return mustFrozenSystemMemtable(t, "sys/root", fmt.Sprintf("%d", rootIDs[0])).NewIterator(nil, nil), nil
+	})
+	if err != nil {
+		t.Fatalf("PublishOrderedRootDeltaGroupWithSystemBuilder: %v", err)
+	}
+	if len(rootIDs) != 1 {
+		t.Fatalf("rootIDs len=%d want 1", len(rootIDs))
+	}
+
+	after := d.valueLogManager.RefreshScanCount()
+	if after != before {
+		t.Fatalf("ordered root group pointer publish triggered value-log refresh scan: before=%d after=%d", before, after)
+	}
+
+	st := d.State()
+	if st == nil || st.ValueLogSet == nil {
+		t.Fatalf("state missing value-log set")
+	}
+	if _, ok := st.ValueLogSet.Files[fileID]; !ok {
+		t.Fatalf("ordered root group publish missing pre-registered segment %d", fileID)
 	}
 }
 

--- a/TreeDB/db/currentset_refresh_test.go
+++ b/TreeDB/db/currentset_refresh_test.go
@@ -343,6 +343,35 @@ func TestAppendOrderedRootDeltaBatchFinalTouchedValueLogSegmentsDedupesWithSeed(
 	}
 }
 
+func TestOrderedRootTouchedIteratorDedupesWithSetAfterLinearLimit(t *testing.T) {
+	var it orderedRootTouchedIterator
+	first := page.ValueLogFileID(20)
+	it.appendTouchedValueLogSegmentID(first)
+	it.appendTouchedValueLogSegmentID(first)
+	for i := 0; i < orderedRootTouchedValueLogSegmentLinearLimit+2; i++ {
+		it.appendTouchedValueLogSegmentID(page.ValueLogFileID(uint32(30 + i)))
+	}
+	duplicateAfterSet := page.ValueLogFileID(32)
+	it.appendTouchedValueLogSegmentID(duplicateAfterSet)
+	if it.touchedValueLogSegmentSet == nil {
+		t.Fatal("expected touched segment set after linear limit")
+	}
+
+	want := []uint32{first}
+	for i := 0; i < orderedRootTouchedValueLogSegmentLinearLimit+2; i++ {
+		want = append(want, page.ValueLogFileID(uint32(30+i)))
+	}
+	got := it.touchedValueLogSegments
+	if len(got) != len(want) {
+		t.Fatalf("touched segments len=%d want %d: got=%v want=%v", len(got), len(want), got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("touched segment[%d]=%d want %d (got=%v want=%v)", i, got[i], want[i], got, want)
+		}
+	}
+}
+
 func TestInlineCommitSkipsValueLogRefresh(t *testing.T) {
 	dir := t.TempDir()
 	d, err := Open(Options{Dir: dir})

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -2234,7 +2234,7 @@ func (db *DB) finalizeCommitLockedWithOptions(newRootID uint64, sysRootID uint64
 		return post, prePublishErr(errTestFinalizeCommitFailpoint)
 	}
 	if forceValueLogRefresh && db.valueLogManager != nil {
-		registered, err := db.registerLeafPageLogSegmentsForPublish(nextMeta.CommitSeq)
+		registered, err := db.registerLeafPageLogSegmentsForPublish()
 		if err != nil {
 			return post, prePublishErr(err)
 		}

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -2228,18 +2228,13 @@ func (db *DB) finalizeCommitLockedWithOptions(newRootID uint64, sysRootID uint64
 	watermarkHold += time.Since(holdStart)
 
 	leafPageSegmentRegistered := false
-	leafPageSegmentFileID := uint32(0)
 	valueLogSegmentRegistered := false
 	valueLogSegmentRegistrationAttempted := false
 	if db.testFailFinalizeCommit.Load() {
 		return post, prePublishErr(errTestFinalizeCommitFailpoint)
 	}
 	if forceValueLogRefresh && db.valueLogManager != nil {
-		path, fileID, ok := db.currentLeafPageLogSegment()
-		if ok {
-			leafPageSegmentFileID = fileID
-		}
-		registered, err := db.ensureLeafPageLogSegmentRegisteredAt(path, fileID, 0)
+		registered, err := db.registerLeafPageLogSegmentsForPublish(nextMeta.CommitSeq)
 		if err != nil {
 			return post, prePublishErr(err)
 		}
@@ -2319,9 +2314,6 @@ func (db *DB) finalizeCommitLockedWithOptions(newRootID uint64, sysRootID uint64
 		post.persistLeafGenerationManifestView = leafManifest
 		post.persistLeafGenerationRawFileIDs = append(post.persistLeafGenerationRawFileIDs[:0], leafManifestRawFileIDs...)
 		leafGenerationView = newLeafGenerationView(leafManifest)
-	}
-	if leafPageSegmentRegistered && leafPageSegmentFileID != 0 {
-		db.queueLeafGenerationWritableFileIDAtCommit(leafPageSegmentFileID, nextMeta.CommitSeq)
 	}
 	if db.leafPageLog != nil {
 		stagedLeafManifest, changed, err := db.stagedLeafGenerationManifestWithPending(db.leafGenerationManifest, 0, nextMeta.CommitSeq)

--- a/TreeDB/db/leaf_generation_gc.go
+++ b/TreeDB/db/leaf_generation_gc.go
@@ -14,10 +14,13 @@ import (
 type LeafGenerationGCOptions struct {
 	DryRun bool
 
-	// ProtectedRootIDs are additional root page IDs whose leaf-log children must
-	// be treated as live even when they are not reachable from the backend meta
-	// roots. Cached named roots use this during online maintenance.
+	// ProtectedRootIDs are additional ordinary root page IDs whose leaf-log
+	// children must be treated as live even when they are not reachable from the
+	// backend meta roots. Cached named roots use this during online maintenance.
 	ProtectedRootIDs []uint64
+	// ProtectedSystemRootIDs are system-root page IDs whose collection root
+	// descriptors should be expanded into additional protected roots.
+	ProtectedSystemRootIDs []uint64
 }
 
 type LeafGenerationGCStats struct {
@@ -83,7 +86,7 @@ func (db *DB) leafGenerationGC(ctx context.Context, opts LeafGenerationGCOptions
 		return stats, nil
 	}
 
-	liveGenerations, err := collectLiveLeafGenerationIDs(ctx, snap, opts.ProtectedRootIDs)
+	liveGenerations, err := collectLiveLeafGenerationIDs(ctx, snap, opts.ProtectedRootIDs, opts.ProtectedSystemRootIDs)
 	if err != nil {
 		_ = snap.Close()
 		return stats, err
@@ -198,7 +201,7 @@ func (db *DB) leafGenerationGC(ctx context.Context, opts LeafGenerationGCOptions
 	return stats, nil
 }
 
-func collectLiveLeafGenerationIDs(ctx context.Context, snap *Snapshot, protectedRootIDs []uint64) (map[uint64]struct{}, error) {
+func collectLiveLeafGenerationIDs(ctx context.Context, snap *Snapshot, protectedRootIDs, protectedSystemRootIDs []uint64) (map[uint64]struct{}, error) {
 	live := make(map[uint64]struct{})
 	if snap == nil || snap.db == nil {
 		return live, nil
@@ -206,7 +209,7 @@ func collectLiveLeafGenerationIDs(ctx context.Context, snap *Snapshot, protected
 	// GC deletion must not trust cached subtree/live reachability. A stale cache
 	// can turn a live generation into a deletion candidate, while a fresh scan is
 	// maintenance-only work outside the write/read happy path.
-	scan, err := snap.db.leafGenerationLiveStatsForSnapshotUncachedWithProtectedRoots(ctx, snap, protectedRootIDs)
+	scan, err := snap.db.leafGenerationLiveStatsForSnapshotUncachedWithProtectedRoots(ctx, snap, protectedRootIDs, protectedSystemRootIDs)
 	if err != nil {
 		return nil, err
 	}

--- a/TreeDB/db/leaf_generation_gc.go
+++ b/TreeDB/db/leaf_generation_gc.go
@@ -13,6 +13,11 @@ import (
 
 type LeafGenerationGCOptions struct {
 	DryRun bool
+
+	// ProtectedRootIDs are additional root page IDs whose leaf-log children must
+	// be treated as live even when they are not reachable from the backend meta
+	// roots. Cached named roots use this during online maintenance.
+	ProtectedRootIDs []uint64
 }
 
 type LeafGenerationGCStats struct {
@@ -78,7 +83,7 @@ func (db *DB) leafGenerationGC(ctx context.Context, opts LeafGenerationGCOptions
 		return stats, nil
 	}
 
-	liveGenerations, err := collectLiveLeafGenerationIDs(ctx, snap)
+	liveGenerations, err := collectLiveLeafGenerationIDs(ctx, snap, opts.ProtectedRootIDs)
 	if err != nil {
 		_ = snap.Close()
 		return stats, err
@@ -193,7 +198,7 @@ func (db *DB) leafGenerationGC(ctx context.Context, opts LeafGenerationGCOptions
 	return stats, nil
 }
 
-func collectLiveLeafGenerationIDs(ctx context.Context, snap *Snapshot) (map[uint64]struct{}, error) {
+func collectLiveLeafGenerationIDs(ctx context.Context, snap *Snapshot, protectedRootIDs []uint64) (map[uint64]struct{}, error) {
 	live := make(map[uint64]struct{})
 	if snap == nil || snap.db == nil {
 		return live, nil
@@ -201,7 +206,7 @@ func collectLiveLeafGenerationIDs(ctx context.Context, snap *Snapshot) (map[uint
 	// GC deletion must not trust cached subtree/live reachability. A stale cache
 	// can turn a live generation into a deletion candidate, while a fresh scan is
 	// maintenance-only work outside the write/read happy path.
-	scan, err := snap.db.leafGenerationLiveStatsForSnapshotUncached(ctx, snap)
+	scan, err := snap.db.leafGenerationLiveStatsForSnapshotUncachedWithProtectedRoots(ctx, snap, protectedRootIDs)
 	if err != nil {
 		return nil, err
 	}

--- a/TreeDB/db/leaf_generation_gc_test.go
+++ b/TreeDB/db/leaf_generation_gc_test.go
@@ -275,10 +275,10 @@ func TestLeafGenerationGC_ProtectedRootIDsKeepDetachedRootLive(t *testing.T) {
 func TestLeafGenerationPlan_ProtectedOrdinaryRootDoesNotParseDescriptors(t *testing.T) {
 	db, _ := openLeafGenerationGCTestDB(t)
 
-	rootTable := mustFrozenSystemMemtable(
+	rootTable := mustFrozenRawMemtable(
 		t,
-		collectionRootDescriptorPrefix+"ordinary-user-key", "not-a-root-id",
-		"doc/a", "value-a",
+		collectionRootDescriptorPrefix+"ordinary-user-key", encodeMaintenanceRootID(123456789),
+		"doc/a", []byte("value-a"),
 	)
 	rootID, err := db.PublishOrderedRootIterator(0, rootTable.NewIterator(nil, nil))
 	if err != nil {
@@ -309,7 +309,7 @@ func TestLeafGenerationPlan_ProtectedRootDescriptorReadErrorFailsClosed(t *testi
 	}
 
 	if _, err := db.LeafGenerationPlan(context.Background(), LeafGenerationPlanOptions{
-		ProtectedRootIDs: []uint64{rootID},
+		ProtectedSystemRootIDs: []uint64{rootID},
 	}); err == nil {
 		t.Fatal("LeafGenerationPlan with protected pointer-backed descriptor succeeded; want fail-closed read error")
 	}
@@ -367,7 +367,7 @@ func TestLeafGenerationGC_ProtectedSystemRootDescriptorsKeepCollectionRootLive(t
 	}
 
 	stats, err := db.LeafGenerationGC(context.Background(), LeafGenerationGCOptions{
-		ProtectedRootIDs: []uint64{systemRootID},
+		ProtectedSystemRootIDs: []uint64{systemRootID},
 	})
 	if err != nil {
 		t.Fatalf("LeafGenerationGC protected: %v", err)

--- a/TreeDB/db/leaf_generation_gc_test.go
+++ b/TreeDB/db/leaf_generation_gc_test.go
@@ -292,6 +292,29 @@ func TestLeafGenerationPlan_ProtectedOrdinaryRootDoesNotParseDescriptors(t *test
 	}
 }
 
+func TestLeafGenerationPlan_ProtectedRootDescriptorReadErrorFailsClosed(t *testing.T) {
+	db, _ := openLeafGenerationGCTestDB(t)
+
+	missingPtr := page.ValuePtr{
+		FileID: page.ValueLogFileID(99),
+		Offset: 8,
+		Length: 8,
+	}
+	rootID, err := db.PublishOrderedRootIterator(
+		0,
+		mustFrozenSystemPointerMemtable(t, maintenanceTestCollectionRootKey, missingPtr).NewIterator(nil, nil),
+	)
+	if err != nil {
+		t.Fatalf("PublishOrderedRootIterator: %v", err)
+	}
+
+	if _, err := db.LeafGenerationPlan(context.Background(), LeafGenerationPlanOptions{
+		ProtectedRootIDs: []uint64{rootID},
+	}); err == nil {
+		t.Fatal("LeafGenerationPlan with protected pointer-backed descriptor succeeded; want fail-closed read error")
+	}
+}
+
 func TestLeafGenerationGC_ProtectedSystemRootDescriptorsKeepCollectionRootLive(t *testing.T) {
 	db, leafLog := openLeafGenerationGCTestDB(t)
 

--- a/TreeDB/db/leaf_generation_gc_test.go
+++ b/TreeDB/db/leaf_generation_gc_test.go
@@ -272,6 +272,26 @@ func TestLeafGenerationGC_ProtectedRootIDsKeepDetachedRootLive(t *testing.T) {
 	}
 }
 
+func TestLeafGenerationPlan_ProtectedOrdinaryRootDoesNotParseDescriptors(t *testing.T) {
+	db, _ := openLeafGenerationGCTestDB(t)
+
+	rootTable := mustFrozenSystemMemtable(
+		t,
+		collectionRootDescriptorPrefix+"ordinary-user-key", "not-a-root-id",
+		"doc/a", "value-a",
+	)
+	rootID, err := db.PublishOrderedRootIterator(0, rootTable.NewIterator(nil, nil))
+	if err != nil {
+		t.Fatalf("PublishOrderedRootIterator: %v", err)
+	}
+
+	if _, err := db.LeafGenerationPlan(context.Background(), LeafGenerationPlanOptions{
+		ProtectedRootIDs: []uint64{rootID},
+	}); err != nil {
+		t.Fatalf("LeafGenerationPlan with protected ordinary root: %v", err)
+	}
+}
+
 func TestLeafGenerationGC_ProtectedSystemRootDescriptorsKeepCollectionRootLive(t *testing.T) {
 	db, leafLog := openLeafGenerationGCTestDB(t)
 

--- a/TreeDB/db/leaf_generation_gc_test.go
+++ b/TreeDB/db/leaf_generation_gc_test.go
@@ -272,6 +272,74 @@ func TestLeafGenerationGC_ProtectedRootIDsKeepDetachedRootLive(t *testing.T) {
 	}
 }
 
+func TestLeafGenerationGC_ProtectedSystemRootDescriptorsKeepCollectionRootLive(t *testing.T) {
+	db, leafLog := openLeafGenerationGCTestDB(t)
+
+	collectionRootID, err := db.PublishOrderedRootIterator(0, mustFrozenSystemMemtable(t, systemRangeKVs(2048, nil)...).NewIterator(nil, nil))
+	if err != nil {
+		t.Fatalf("PublishOrderedRootIterator collection: %v", err)
+	}
+	if collectionRootID == 0 {
+		t.Fatal("expected non-zero collection root")
+	}
+	refs := collectLeafRefIDsFromRoot(t, db, collectionRootID)
+	if len(refs) == 0 {
+		t.Fatalf("expected collection root %d to contain leaf-log refs", collectionRootID)
+	}
+	path1, fileID1 := currentLeafSegmentOrFatal(t, leafLog)
+	rawFileID1 := page.ValueLogSegmentID(fileID1)
+	refsFile := false
+	for ptr := range refs {
+		if ptr.FileID == rawFileID1 {
+			refsFile = true
+			break
+		}
+	}
+	if !refsFile {
+		t.Fatalf("collection root refs do not include raw file id %d: %+v", rawFileID1, refs)
+	}
+
+	systemRootID, err := db.PublishOrderedRootIterator(0, mustFrozenRawMemtable(t, maintenanceTestCollectionRootKey, encodeMaintenanceRootID(collectionRootID)).NewIterator(nil, nil))
+	if err != nil {
+		t.Fatalf("PublishOrderedRootIterator system: %v", err)
+	}
+	if systemRootID == 0 {
+		t.Fatal("expected non-zero system root")
+	}
+	if state := db.State(); state.RootPageID == collectionRootID || state.SystemRootPageID == systemRootID {
+		t.Fatalf("test requires detached roots, got state user=%d system=%d collection=%d protectedSystem=%d", state.RootPageID, state.SystemRootPageID, collectionRootID, systemRootID)
+	}
+
+	if err := leafLog.rotateLeaf(); err != nil {
+		t.Fatalf("rotateLeaf: %v", err)
+	}
+	writeLeafGenerationKeys(t, db, "current", 1, 'z')
+
+	probe, err := db.LeafGenerationGC(context.Background(), LeafGenerationGCOptions{DryRun: true})
+	if err != nil {
+		t.Fatalf("LeafGenerationGC dry-run: %v", err)
+	}
+	if got := probe.GenerationsEligible; got == 0 {
+		t.Fatalf("GenerationsEligible=%d want descriptor collection generation eligible without protection (stats=%+v)", got, probe)
+	}
+
+	stats, err := db.LeafGenerationGC(context.Background(), LeafGenerationGCOptions{
+		ProtectedRootIDs: []uint64{systemRootID},
+	})
+	if err != nil {
+		t.Fatalf("LeafGenerationGC protected: %v", err)
+	}
+	if got := stats.GenerationsLive; got == 0 {
+		t.Fatalf("GenerationsLive=%d want protected descriptor collection generation live (stats=%+v)", got, stats)
+	}
+	if got := stats.GenerationsDeleted; got != 0 {
+		t.Fatalf("GenerationsDeleted=%d want 0 for protected system descriptor root (stats=%+v)", got, stats)
+	}
+	if _, err := os.Stat(path1); err != nil {
+		t.Fatalf("expected protected descriptor leaf segment to remain: %v", err)
+	}
+}
+
 func TestLeafGenerationGC_IgnoresStaleReachabilityCache(t *testing.T) {
 	db, leafLog := openLeafGenerationGCTestDB(t)
 

--- a/TreeDB/db/leaf_generation_gc_test.go
+++ b/TreeDB/db/leaf_generation_gc_test.go
@@ -210,6 +210,68 @@ func TestLeafGenerationGC_DeletesFullyDeadGeneration(t *testing.T) {
 	}
 }
 
+func TestLeafGenerationGC_ProtectedRootIDsKeepDetachedRootLive(t *testing.T) {
+	db, leafLog := openLeafGenerationGCTestDB(t)
+
+	rootTable := mustFrozenSystemMemtable(t, systemRangeKVs(2048, nil)...)
+	rootID, err := db.PublishOrderedRootIterator(0, rootTable.NewIterator(nil, nil))
+	if err != nil {
+		t.Fatalf("PublishOrderedRootIterator: %v", err)
+	}
+	if rootID == 0 {
+		t.Fatal("expected non-zero detached root")
+	}
+	if state := db.State(); state.RootPageID == rootID || state.SystemRootPageID == rootID {
+		t.Fatalf("test requires detached root, got state roots user=%d system=%d detached=%d", state.RootPageID, state.SystemRootPageID, rootID)
+	}
+
+	path1, fileID1 := currentLeafSegmentOrFatal(t, leafLog)
+	rawFileID1 := page.ValueLogSegmentID(fileID1)
+	refs := collectLeafRefIDsFromRoot(t, db, rootID)
+	if len(refs) == 0 {
+		t.Fatalf("expected detached root %d to contain leaf-log refs", rootID)
+	}
+	refsFile := false
+	for ptr := range refs {
+		if ptr.FileID == rawFileID1 {
+			refsFile = true
+			break
+		}
+	}
+	if !refsFile {
+		t.Fatalf("detached root refs do not include raw file id %d: %+v", rawFileID1, refs)
+	}
+
+	if err := leafLog.rotateLeaf(); err != nil {
+		t.Fatalf("rotateLeaf: %v", err)
+	}
+	writeLeafGenerationKeys(t, db, "current", 1, 'z')
+
+	probe, err := db.LeafGenerationGC(context.Background(), LeafGenerationGCOptions{DryRun: true})
+	if err != nil {
+		t.Fatalf("LeafGenerationGC dry-run: %v", err)
+	}
+	if got := probe.GenerationsEligible; got == 0 {
+		t.Fatalf("GenerationsEligible=%d want detached generation eligible without protection (stats=%+v)", got, probe)
+	}
+
+	stats, err := db.LeafGenerationGC(context.Background(), LeafGenerationGCOptions{
+		ProtectedRootIDs: []uint64{0, rootID, rootID},
+	})
+	if err != nil {
+		t.Fatalf("LeafGenerationGC protected: %v", err)
+	}
+	if got := stats.GenerationsLive; got == 0 {
+		t.Fatalf("GenerationsLive=%d want protected detached generation live (stats=%+v)", got, stats)
+	}
+	if got := stats.GenerationsDeleted; got != 0 {
+		t.Fatalf("GenerationsDeleted=%d want 0 for protected detached root (stats=%+v)", got, stats)
+	}
+	if _, err := os.Stat(path1); err != nil {
+		t.Fatalf("expected protected leaf segment to remain: %v", err)
+	}
+}
+
 func TestLeafGenerationGC_IgnoresStaleReachabilityCache(t *testing.T) {
 	db, leafLog := openLeafGenerationGCTestDB(t)
 

--- a/TreeDB/db/leaf_generation_pack.go
+++ b/TreeDB/db/leaf_generation_pack.go
@@ -26,6 +26,7 @@ type LeafGenerationPackOptions struct {
 	ReserveRIDs                func(count int) (start uint64, err error)
 	Force                      bool
 	LeafFrameK                 int
+	ProtectedRootIDs           []uint64
 }
 
 type LeafGenerationPackStats struct {
@@ -249,6 +250,7 @@ func leafGenerationPackPlanOptions(opts LeafGenerationPackOptions) LeafGeneratio
 		MinExpectedReclaimRatioPPM: opts.MinExpectedReclaimRatioPPM,
 		MinReclaimPerByteCopiedPPM: opts.MinReclaimPerByteCopiedPPM,
 		Force:                      opts.Force,
+		ProtectedRootIDs:           opts.ProtectedRootIDs,
 	}
 }
 

--- a/TreeDB/db/leaf_generation_pack.go
+++ b/TreeDB/db/leaf_generation_pack.go
@@ -27,6 +27,7 @@ type LeafGenerationPackOptions struct {
 	Force                      bool
 	LeafFrameK                 int
 	ProtectedRootIDs           []uint64
+	ProtectedSystemRootIDs     []uint64
 }
 
 type LeafGenerationPackStats struct {
@@ -251,6 +252,7 @@ func leafGenerationPackPlanOptions(opts LeafGenerationPackOptions) LeafGeneratio
 		MinReclaimPerByteCopiedPPM: opts.MinReclaimPerByteCopiedPPM,
 		Force:                      opts.Force,
 		ProtectedRootIDs:           opts.ProtectedRootIDs,
+		ProtectedSystemRootIDs:     opts.ProtectedSystemRootIDs,
 	}
 }
 

--- a/TreeDB/db/leaf_generation_pack_from_plan.go
+++ b/TreeDB/db/leaf_generation_pack_from_plan.go
@@ -17,6 +17,7 @@ type LeafGenerationPackFromPlanOptions struct {
 	ReserveRIDs                func(count int) (start uint64, err error)
 	LeafFrameK                 int
 	ProtectedRootIDs           []uint64
+	ProtectedSystemRootIDs     []uint64
 }
 
 func leafGenerationPackFromPlanPlanOptions(opts LeafGenerationPackFromPlanOptions) LeafGenerationPlanOptions {
@@ -26,6 +27,7 @@ func leafGenerationPackFromPlanPlanOptions(opts LeafGenerationPackFromPlanOption
 		MinExpectedReclaimBytes: opts.MinExpectedReclaimBytes,
 		Force:                   opts.Force,
 		ProtectedRootIDs:        opts.ProtectedRootIDs,
+		ProtectedSystemRootIDs:  opts.ProtectedSystemRootIDs,
 	}
 }
 
@@ -41,6 +43,7 @@ func leafGenerationPackFromPlanPackOptions(opts LeafGenerationPackFromPlanOption
 		Force:                      opts.Force,
 		LeafFrameK:                 opts.LeafFrameK,
 		ProtectedRootIDs:           opts.ProtectedRootIDs,
+		ProtectedSystemRootIDs:     opts.ProtectedSystemRootIDs,
 	}
 }
 

--- a/TreeDB/db/leaf_generation_pack_from_plan.go
+++ b/TreeDB/db/leaf_generation_pack_from_plan.go
@@ -16,6 +16,7 @@ type LeafGenerationPackFromPlanOptions struct {
 	MaxBytesToCopy             int64
 	ReserveRIDs                func(count int) (start uint64, err error)
 	LeafFrameK                 int
+	ProtectedRootIDs           []uint64
 }
 
 func leafGenerationPackFromPlanPlanOptions(opts LeafGenerationPackFromPlanOptions) LeafGenerationPlanOptions {
@@ -24,6 +25,7 @@ func leafGenerationPackFromPlanPlanOptions(opts LeafGenerationPackFromPlanOption
 		MinCandidateGenerations: opts.MinCandidateGenerations,
 		MinExpectedReclaimBytes: opts.MinExpectedReclaimBytes,
 		Force:                   opts.Force,
+		ProtectedRootIDs:        opts.ProtectedRootIDs,
 	}
 }
 
@@ -38,6 +40,7 @@ func leafGenerationPackFromPlanPackOptions(opts LeafGenerationPackFromPlanOption
 		ReserveRIDs:                opts.ReserveRIDs,
 		Force:                      opts.Force,
 		LeafFrameK:                 opts.LeafFrameK,
+		ProtectedRootIDs:           opts.ProtectedRootIDs,
 	}
 }
 

--- a/TreeDB/db/leaf_generation_plan.go
+++ b/TreeDB/db/leaf_generation_plan.go
@@ -810,22 +810,3 @@ func (db *DB) scanLeafGenerationLiveStatsWithOptions(ctx context.Context, snap *
 	}
 	return stats, nil
 }
-
-func dedupeMaintenanceRootsByRootID(roots []maintenanceRoot) []maintenanceRoot {
-	if len(roots) <= 1 {
-		return roots
-	}
-	seen := make(map[uint64]struct{}, len(roots))
-	out := roots[:0]
-	for _, root := range roots {
-		if root.rootID == 0 {
-			continue
-		}
-		if _, ok := seen[root.rootID]; ok {
-			continue
-		}
-		seen[root.rootID] = struct{}{}
-		out = append(out, root)
-	}
-	return out
-}

--- a/TreeDB/db/leaf_generation_plan.go
+++ b/TreeDB/db/leaf_generation_plan.go
@@ -762,18 +762,27 @@ func (db *DB) scanLeafGenerationLiveStatsWithOptions(ctx context.Context, snap *
 				seen[root.rootID] = struct{}{}
 			}
 		}
+		addProtectedRoot := func(root maintenanceRoot) {
+			if root.rootID == 0 {
+				return
+			}
+			if _, ok := seen[root.rootID]; ok {
+				return
+			}
+			seen[root.rootID] = struct{}{}
+			roots = append(roots, root)
+		}
 		for _, rootID := range opts.ProtectedRootIDs {
 			if rootID == 0 {
 				continue
 			}
-			if _, ok := seen[rootID]; ok {
-				continue
+			protectedRoots, err := collectMaintenanceRootsForSystemRootWithContext(ctx, snap.idx.pager, &snap.reader, rootID)
+			if err != nil {
+				return leafGenerationLiveScanStats{}, err
 			}
-			seen[rootID] = struct{}{}
-			roots = append(roots, maintenanceRoot{
-				kind:   maintenanceRootCollection,
-				rootID: rootID,
-			})
+			for _, root := range protectedRoots {
+				addProtectedRoot(root)
+			}
 		}
 	}
 	for _, root := range roots {

--- a/TreeDB/db/leaf_generation_plan.go
+++ b/TreeDB/db/leaf_generation_plan.go
@@ -751,7 +751,7 @@ func (db *DB) scanLeafGenerationLiveStatsWithOptions(ctx context.Context, snap *
 		memo:          make(map[uint64]leafGenerationSubtreeStats, 64),
 		cacheEnabled:  !opts.DisableCache && !verifyAlways,
 	}
-	roots, err := maintenanceRootsForSnapshot(snap)
+	roots, err := maintenanceRootsForSnapshotWithContext(ctx, snap)
 	if err != nil {
 		return leafGenerationLiveScanStats{}, err
 	}

--- a/TreeDB/db/leaf_generation_plan.go
+++ b/TreeDB/db/leaf_generation_plan.go
@@ -782,6 +782,9 @@ func (db *DB) scanLeafGenerationLiveStatsWithOptions(ctx context.Context, snap *
 				if ctxErr := ctx.Err(); ctxErr != nil {
 					return leafGenerationLiveScanStats{}, ctxErr
 				}
+				if !isCollectionRootDescriptorShapeError(err) {
+					return leafGenerationLiveScanStats{}, err
+				}
 				continue
 			}
 			for _, root := range protectedRoots {

--- a/TreeDB/db/leaf_generation_plan.go
+++ b/TreeDB/db/leaf_generation_plan.go
@@ -760,6 +760,7 @@ func (db *DB) scanLeafGenerationLiveStatsWithOptions(ctx context.Context, snap *
 	if err != nil {
 		return leafGenerationLiveScanStats{}, err
 	}
+	roots = dedupeMaintenanceRootsByRootID(roots)
 	if len(opts.ProtectedRootIDs) > 0 || len(opts.ProtectedSystemRootIDs) > 0 {
 		seen := make(map[uint64]struct{}, len(roots)+len(opts.ProtectedRootIDs)+len(opts.ProtectedSystemRootIDs))
 		for _, root := range roots {
@@ -808,4 +809,23 @@ func (db *DB) scanLeafGenerationLiveStatsWithOptions(ctx context.Context, snap *
 		stats.Generations = mergeLeafGenerationTotals(stats.Generations, rootStats)
 	}
 	return stats, nil
+}
+
+func dedupeMaintenanceRootsByRootID(roots []maintenanceRoot) []maintenanceRoot {
+	if len(roots) <= 1 {
+		return roots
+	}
+	seen := make(map[uint64]struct{}, len(roots))
+	out := roots[:0]
+	for _, root := range roots {
+		if root.rootID == 0 {
+			continue
+		}
+		if _, ok := seen[root.rootID]; ok {
+			continue
+		}
+		seen[root.rootID] = struct{}{}
+		out = append(out, root)
+	}
+	return out
 }

--- a/TreeDB/db/leaf_generation_plan.go
+++ b/TreeDB/db/leaf_generation_plan.go
@@ -35,6 +35,10 @@ type LeafGenerationPlanOptions struct {
 	MinExpectedReclaimRatioPPM int
 	MinReclaimPerByteCopiedPPM int
 	Force                      bool
+	// ProtectedRootIDs are additional root page IDs whose leaf-log children must
+	// be treated as live while planning maintenance. Empty uses the existing
+	// cached live-scan path.
+	ProtectedRootIDs []uint64
 }
 
 type LeafGenerationPlanGeneration struct {
@@ -108,7 +112,8 @@ type leafGenerationScanContext struct {
 }
 
 type leafGenerationLiveStatsScanOptions struct {
-	DisableCache bool
+	DisableCache     bool
+	ProtectedRootIDs []uint64
 }
 
 var leafGenerationLiveScanHook struct {
@@ -204,7 +209,7 @@ func (db *DB) LeafGenerationPlan(ctx context.Context, opts LeafGenerationPlanOpt
 	plan.CurrentCommitSeq = snap.state.CommitSeq
 	plan.CurrentGenerationID = manifest.CurrentGenerationID
 
-	liveScan, err := db.leafGenerationLiveStatsForSnapshot(ctx, snap)
+	liveScan, err := db.leafGenerationLiveStatsForSnapshotWithProtectedRoots(ctx, snap, opts.ProtectedRootIDs)
 	if err != nil {
 		return plan, err
 	}
@@ -556,9 +561,23 @@ func (db *DB) leafGenerationLiveStatsForSnapshot(ctx context.Context, snap *Snap
 	return stats, nil
 }
 
+func (db *DB) leafGenerationLiveStatsForSnapshotWithProtectedRoots(ctx context.Context, snap *Snapshot, protectedRootIDs []uint64) (leafGenerationLiveScanStats, error) {
+	if len(protectedRootIDs) == 0 {
+		return db.leafGenerationLiveStatsForSnapshot(ctx, snap)
+	}
+	return db.leafGenerationLiveStatsForSnapshotUncachedWithProtectedRoots(ctx, snap, protectedRootIDs)
+}
+
 func (db *DB) leafGenerationLiveStatsForSnapshotUncached(ctx context.Context, snap *Snapshot) (leafGenerationLiveScanStats, error) {
+	return db.leafGenerationLiveStatsForSnapshotUncachedWithProtectedRoots(ctx, snap, nil)
+}
+
+func (db *DB) leafGenerationLiveStatsForSnapshotUncachedWithProtectedRoots(ctx context.Context, snap *Snapshot, protectedRootIDs []uint64) (leafGenerationLiveScanStats, error) {
 	runLeafGenerationLiveScanHook()
-	return db.scanLeafGenerationLiveStatsWithOptions(ctx, snap, leafGenerationLiveStatsScanOptions{DisableCache: true})
+	return db.scanLeafGenerationLiveStatsWithOptions(ctx, snap, leafGenerationLiveStatsScanOptions{
+		DisableCache:     true,
+		ProtectedRootIDs: protectedRootIDs,
+	})
 }
 
 func (db *DB) scanLeafGenerationPtrTotals(scan *leafGenerationScanContext, dst leafGenerationSubtreeStats, ptr page.LeafLogPtr) (leafGenerationSubtreeStats, error) {
@@ -735,6 +754,27 @@ func (db *DB) scanLeafGenerationLiveStatsWithOptions(ctx context.Context, snap *
 	roots, err := maintenanceRootsForSnapshot(snap)
 	if err != nil {
 		return leafGenerationLiveScanStats{}, err
+	}
+	if len(opts.ProtectedRootIDs) > 0 {
+		seen := make(map[uint64]struct{}, len(roots)+len(opts.ProtectedRootIDs))
+		for _, root := range roots {
+			if root.rootID != 0 {
+				seen[root.rootID] = struct{}{}
+			}
+		}
+		for _, rootID := range opts.ProtectedRootIDs {
+			if rootID == 0 {
+				continue
+			}
+			if _, ok := seen[rootID]; ok {
+				continue
+			}
+			seen[rootID] = struct{}{}
+			roots = append(roots, maintenanceRoot{
+				kind:   maintenanceRootCollection,
+				rootID: rootID,
+			})
+		}
 	}
 	for _, root := range roots {
 		rootID := root.rootID

--- a/TreeDB/db/leaf_generation_plan.go
+++ b/TreeDB/db/leaf_generation_plan.go
@@ -776,9 +776,13 @@ func (db *DB) scanLeafGenerationLiveStatsWithOptions(ctx context.Context, snap *
 			if rootID == 0 {
 				continue
 			}
+			addProtectedRoot(maintenanceRoot{kind: maintenanceRootUser, rootID: rootID})
 			protectedRoots, err := collectMaintenanceRootsForSystemRootWithContext(ctx, snap.idx.pager, &snap.reader, rootID)
 			if err != nil {
-				return leafGenerationLiveScanStats{}, err
+				if ctxErr := ctx.Err(); ctxErr != nil {
+					return leafGenerationLiveScanStats{}, ctxErr
+				}
+				continue
 			}
 			for _, root := range protectedRoots {
 				addProtectedRoot(root)

--- a/TreeDB/db/leaf_generation_plan.go
+++ b/TreeDB/db/leaf_generation_plan.go
@@ -35,10 +35,13 @@ type LeafGenerationPlanOptions struct {
 	MinExpectedReclaimRatioPPM int
 	MinReclaimPerByteCopiedPPM int
 	Force                      bool
-	// ProtectedRootIDs are additional root page IDs whose leaf-log children must
-	// be treated as live while planning maintenance. Empty uses the existing
-	// cached live-scan path.
+	// ProtectedRootIDs are additional ordinary root page IDs whose leaf-log
+	// children must be treated as live while planning maintenance. Empty uses the
+	// existing cached live-scan path when no protected system roots are present.
 	ProtectedRootIDs []uint64
+	// ProtectedSystemRootIDs are system-root page IDs whose collection root
+	// descriptors should be expanded into additional protected roots.
+	ProtectedSystemRootIDs []uint64
 }
 
 type LeafGenerationPlanGeneration struct {
@@ -112,8 +115,9 @@ type leafGenerationScanContext struct {
 }
 
 type leafGenerationLiveStatsScanOptions struct {
-	DisableCache     bool
-	ProtectedRootIDs []uint64
+	DisableCache           bool
+	ProtectedRootIDs       []uint64
+	ProtectedSystemRootIDs []uint64
 }
 
 var leafGenerationLiveScanHook struct {
@@ -209,7 +213,7 @@ func (db *DB) LeafGenerationPlan(ctx context.Context, opts LeafGenerationPlanOpt
 	plan.CurrentCommitSeq = snap.state.CommitSeq
 	plan.CurrentGenerationID = manifest.CurrentGenerationID
 
-	liveScan, err := db.leafGenerationLiveStatsForSnapshotWithProtectedRoots(ctx, snap, opts.ProtectedRootIDs)
+	liveScan, err := db.leafGenerationLiveStatsForSnapshotWithProtectedRoots(ctx, snap, opts.ProtectedRootIDs, opts.ProtectedSystemRootIDs)
 	if err != nil {
 		return plan, err
 	}
@@ -561,22 +565,23 @@ func (db *DB) leafGenerationLiveStatsForSnapshot(ctx context.Context, snap *Snap
 	return stats, nil
 }
 
-func (db *DB) leafGenerationLiveStatsForSnapshotWithProtectedRoots(ctx context.Context, snap *Snapshot, protectedRootIDs []uint64) (leafGenerationLiveScanStats, error) {
-	if len(protectedRootIDs) == 0 {
+func (db *DB) leafGenerationLiveStatsForSnapshotWithProtectedRoots(ctx context.Context, snap *Snapshot, protectedRootIDs, protectedSystemRootIDs []uint64) (leafGenerationLiveScanStats, error) {
+	if len(protectedRootIDs) == 0 && len(protectedSystemRootIDs) == 0 {
 		return db.leafGenerationLiveStatsForSnapshot(ctx, snap)
 	}
-	return db.leafGenerationLiveStatsForSnapshotUncachedWithProtectedRoots(ctx, snap, protectedRootIDs)
+	return db.leafGenerationLiveStatsForSnapshotUncachedWithProtectedRoots(ctx, snap, protectedRootIDs, protectedSystemRootIDs)
 }
 
 func (db *DB) leafGenerationLiveStatsForSnapshotUncached(ctx context.Context, snap *Snapshot) (leafGenerationLiveScanStats, error) {
-	return db.leafGenerationLiveStatsForSnapshotUncachedWithProtectedRoots(ctx, snap, nil)
+	return db.leafGenerationLiveStatsForSnapshotUncachedWithProtectedRoots(ctx, snap, nil, nil)
 }
 
-func (db *DB) leafGenerationLiveStatsForSnapshotUncachedWithProtectedRoots(ctx context.Context, snap *Snapshot, protectedRootIDs []uint64) (leafGenerationLiveScanStats, error) {
+func (db *DB) leafGenerationLiveStatsForSnapshotUncachedWithProtectedRoots(ctx context.Context, snap *Snapshot, protectedRootIDs, protectedSystemRootIDs []uint64) (leafGenerationLiveScanStats, error) {
 	runLeafGenerationLiveScanHook()
 	return db.scanLeafGenerationLiveStatsWithOptions(ctx, snap, leafGenerationLiveStatsScanOptions{
-		DisableCache:     true,
-		ProtectedRootIDs: protectedRootIDs,
+		DisableCache:           true,
+		ProtectedRootIDs:       protectedRootIDs,
+		ProtectedSystemRootIDs: protectedSystemRootIDs,
 	})
 }
 
@@ -755,8 +760,8 @@ func (db *DB) scanLeafGenerationLiveStatsWithOptions(ctx context.Context, snap *
 	if err != nil {
 		return leafGenerationLiveScanStats{}, err
 	}
-	if len(opts.ProtectedRootIDs) > 0 {
-		seen := make(map[uint64]struct{}, len(roots)+len(opts.ProtectedRootIDs))
+	if len(opts.ProtectedRootIDs) > 0 || len(opts.ProtectedSystemRootIDs) > 0 {
+		seen := make(map[uint64]struct{}, len(roots)+len(opts.ProtectedRootIDs)+len(opts.ProtectedSystemRootIDs))
 		for _, root := range roots {
 			if root.rootID != 0 {
 				seen[root.rootID] = struct{}{}
@@ -777,15 +782,17 @@ func (db *DB) scanLeafGenerationLiveStatsWithOptions(ctx context.Context, snap *
 				continue
 			}
 			addProtectedRoot(maintenanceRoot{kind: maintenanceRootUser, rootID: rootID})
+		}
+		for _, rootID := range opts.ProtectedSystemRootIDs {
+			if rootID == 0 {
+				continue
+			}
 			protectedRoots, err := collectMaintenanceRootsForSystemRootWithContext(ctx, snap.idx.pager, &snap.reader, rootID)
 			if err != nil {
 				if ctxErr := ctx.Err(); ctxErr != nil {
 					return leafGenerationLiveScanStats{}, ctxErr
 				}
-				if !isCollectionRootDescriptorShapeError(err) {
-					return leafGenerationLiveScanStats{}, err
-				}
-				continue
+				return leafGenerationLiveScanStats{}, err
 			}
 			for _, root := range protectedRoots {
 				addProtectedRoot(root)

--- a/TreeDB/db/leaf_generation_plan_test.go
+++ b/TreeDB/db/leaf_generation_plan_test.go
@@ -70,6 +70,27 @@ func withLeafGenerationRecordLengthIndexScanCounter(t *testing.T) *atomic.Uint64
 	return &counter
 }
 
+func TestDedupeMaintenanceRootsByRootIDDropsRoleAliasesForLiveStats(t *testing.T) {
+	roots := []maintenanceRoot{
+		{kind: maintenanceRootUser, rootID: 7},
+		{kind: maintenanceRootCollection, rootID: 7, descriptorKey: []byte(maintenanceTestCollectionRootKey)},
+		{kind: maintenanceRootSystem, rootID: 8},
+		{kind: maintenanceRootCollection, rootID: 8, descriptorKey: []byte("collections/root/users/alias")},
+		{kind: maintenanceRootCollection, rootID: 0},
+	}
+
+	got := dedupeMaintenanceRootsByRootID(roots)
+	if len(got) != 2 {
+		t.Fatalf("roots len=%d want 2: %+v", len(got), got)
+	}
+	if got[0].kind != maintenanceRootUser || got[0].rootID != 7 {
+		t.Fatalf("first root=%+v want user rootID 7", got[0])
+	}
+	if got[1].kind != maintenanceRootSystem || got[1].rootID != 8 {
+		t.Fatalf("second root=%+v want system rootID 8", got[1])
+	}
+}
+
 func TestRankLeafGenerationPlanCandidates(t *testing.T) {
 	gens := []LeafGenerationPlanGeneration{
 		{GenerationID: 4, BytesDead: 100, BytesLive: 50},

--- a/TreeDB/db/leaf_generation_plan_test.go
+++ b/TreeDB/db/leaf_generation_plan_test.go
@@ -680,7 +680,7 @@ func TestLeafGenerationPlan_CachesLiveStatsPerPublishedState(t *testing.T) {
 	if len(snap.leafGenerationIDs) > 0 {
 		snap.releaseLeafGenerationPins()
 	}
-	if _, err := collectLiveLeafGenerationIDs(context.Background(), snap, nil); err != nil {
+	if _, err := collectLiveLeafGenerationIDs(context.Background(), snap, nil, nil); err != nil {
 		_ = snap.Close()
 		t.Fatalf("collectLiveLeafGenerationIDs: %v", err)
 	}

--- a/TreeDB/db/leaf_generation_plan_test.go
+++ b/TreeDB/db/leaf_generation_plan_test.go
@@ -680,7 +680,7 @@ func TestLeafGenerationPlan_CachesLiveStatsPerPublishedState(t *testing.T) {
 	if len(snap.leafGenerationIDs) > 0 {
 		snap.releaseLeafGenerationPins()
 	}
-	if _, err := collectLiveLeafGenerationIDs(context.Background(), snap); err != nil {
+	if _, err := collectLiveLeafGenerationIDs(context.Background(), snap, nil); err != nil {
 		_ = snap.Close()
 		t.Fatalf("collectLiveLeafGenerationIDs: %v", err)
 	}

--- a/TreeDB/db/leaf_page_log.go
+++ b/TreeDB/db/leaf_page_log.go
@@ -189,7 +189,11 @@ func leafPageLogCreatedSegments(log LeafPageLog) ([]LeafPageLogSegment, error) {
 		return leafPageLogCreatedSegments(wrapped.inner)
 	}
 	if provider, ok := log.(LeafPageLogCreatedSegmentProvider); ok {
-		return provider.CreatedLeafPageLogSegmentsSnapshot()
+		created, err := provider.CreatedLeafPageLogSegmentsSnapshot()
+		if err != nil || len(created) == 0 {
+			return nil, err
+		}
+		return sanitizeLeafPageLogCreatedSegments(created), nil
 	}
 	provider, ok := log.(interface {
 		createdSegmentsSnapshot() ([]rewriteCreatedSegment, error)
@@ -209,6 +213,17 @@ func leafPageLogCreatedSegments(log LeafPageLog) ([]LeafPageLogSegment, error) {
 		out = append(out, LeafPageLogSegment{Path: seg.path, FileID: seg.fileID})
 	}
 	return out, nil
+}
+
+func sanitizeLeafPageLogCreatedSegments(created []LeafPageLogSegment) []LeafPageLogSegment {
+	out := make([]LeafPageLogSegment, 0, len(created))
+	for _, seg := range created {
+		if seg.Path == "" || seg.FileID == 0 {
+			continue
+		}
+		out = append(out, seg)
+	}
+	return out
 }
 
 func markLeafPageLogSegmentsRegistered(log LeafPageLog, segments []LeafPageLogSegment) {

--- a/TreeDB/db/leaf_page_log.go
+++ b/TreeDB/db/leaf_page_log.go
@@ -28,10 +28,27 @@ type LeafPageBatchLog interface {
 	AppendLeafPages(leafPages [][]byte) ([]page.LeafLogPtr, error)
 }
 
+type LeafPageLogSegment struct {
+	Path   string
+	FileID uint32
+}
+
+type LeafPageLogCreatedSegmentProvider interface {
+	CreatedLeafPageLogSegmentsSnapshot() ([]LeafPageLogSegment, error)
+}
+
+type LeafPageLogSegmentRegistrationObserver interface {
+	MarkLeafPageLogSegmentsRegistered([]LeafPageLogSegment)
+}
+
 // Optional interface implemented by leaf-page logs that can report their
 // current value-log segment identity.
 type leafPageLogCurrentSegmentProvider interface {
 	CurrentValueLogSegment() (path string, fileID uint32, ok bool)
+}
+
+type leafPageLogProtectedRootProvider interface {
+	ProtectedLeafGenerationRootIDs() []uint64
 }
 
 type leafPageLogRecordLengthProvider interface {
@@ -131,6 +148,17 @@ func (l *leafPageLogWithRecordLengthHints) CurrentValueLogSegment() (path string
 	return provider.CurrentValueLogSegment()
 }
 
+func (l *leafPageLogWithRecordLengthHints) ProtectedLeafGenerationRootIDs() []uint64 {
+	if l == nil || l.inner == nil {
+		return nil
+	}
+	provider, ok := l.inner.(leafPageLogProtectedRootProvider)
+	if !ok {
+		return nil
+	}
+	return provider.ProtectedLeafGenerationRootIDs()
+}
+
 func (db *DB) currentLeafPageLogSegment() (path string, fileID uint32, ok bool) {
 	if db == nil || db.leafPageLog == nil {
 		return "", 0, false
@@ -142,12 +170,26 @@ func (db *DB) currentLeafPageLogSegment() (path string, fileID uint32, ok bool) 
 	return provider.CurrentValueLogSegment()
 }
 
-func leafPageLogCreatedSegments(log LeafPageLog) ([]rewriteCreatedSegment, error) {
+func (db *DB) protectedLeafGenerationRootIDsFromLeafPageLog() []uint64 {
+	if db == nil || db.leafPageLog == nil {
+		return nil
+	}
+	provider, ok := db.leafPageLog.(leafPageLogProtectedRootProvider)
+	if !ok {
+		return nil
+	}
+	return provider.ProtectedLeafGenerationRootIDs()
+}
+
+func leafPageLogCreatedSegments(log LeafPageLog) ([]LeafPageLogSegment, error) {
 	if log == nil {
 		return nil, nil
 	}
 	if wrapped, ok := log.(*leafPageLogWithRecordLengthHints); ok {
 		return leafPageLogCreatedSegments(wrapped.inner)
+	}
+	if provider, ok := log.(LeafPageLogCreatedSegmentProvider); ok {
+		return provider.CreatedLeafPageLogSegmentsSnapshot()
 	}
 	provider, ok := log.(interface {
 		createdSegmentsSnapshot() ([]rewriteCreatedSegment, error)
@@ -155,7 +197,33 @@ func leafPageLogCreatedSegments(log LeafPageLog) ([]rewriteCreatedSegment, error
 	if !ok {
 		return nil, nil
 	}
-	return provider.createdSegmentsSnapshot()
+	created, err := provider.createdSegmentsSnapshot()
+	if err != nil || len(created) == 0 {
+		return nil, err
+	}
+	out := make([]LeafPageLogSegment, 0, len(created))
+	for _, seg := range created {
+		if seg.path == "" || seg.fileID == 0 {
+			continue
+		}
+		out = append(out, LeafPageLogSegment{Path: seg.path, FileID: seg.fileID})
+	}
+	return out, nil
+}
+
+func markLeafPageLogSegmentsRegistered(log LeafPageLog, segments []LeafPageLogSegment) {
+	if log == nil || len(segments) == 0 {
+		return
+	}
+	if wrapped, ok := log.(*leafPageLogWithRecordLengthHints); ok {
+		markLeafPageLogSegmentsRegistered(wrapped.inner, segments)
+		return
+	}
+	observer, ok := log.(LeafPageLogSegmentRegistrationObserver)
+	if !ok {
+		return
+	}
+	observer.MarkLeafPageLogSegmentsRegistered(segments)
 }
 
 func wrapLeafPageLogWithRecordLengthHints(db *DB, log LeafPageLog) LeafPageLog {
@@ -231,18 +299,24 @@ func (db *DB) registerLeafPageLogSegmentsForPublish(commitSeq uint64) (bool, err
 		return false, err
 	}
 	for _, seg := range createdSegments {
-		if err := db.valueLogManager.RegisterSegment(seg.path, seg.fileID); err != nil {
+		if err := db.valueLogManager.RegisterSegment(seg.Path, seg.FileID); err != nil {
 			return false, err
 		}
-		if db.isLeafGenerationSegmentPath(seg.path) && commitSeq > 0 {
-			db.queueLeafGenerationWritableFileIDAtCommit(seg.fileID, commitSeq)
+		if db.isLeafGenerationSegmentPath(seg.Path) && commitSeq > 0 {
+			db.queueLeafGenerationWritableFileIDAtCommit(seg.FileID, commitSeq)
 		}
 	}
 	path, fileID, ok := db.currentLeafPageLogSegment()
 	if !ok || path == "" || fileID == 0 {
-		return true, nil
+		markLeafPageLogSegmentsRegistered(db.leafPageLog, createdSegments)
+		return len(createdSegments) > 0, nil
 	}
-	return db.ensureLeafPageLogSegmentRegisteredAt(path, fileID, commitSeq)
+	registered, err := db.ensureLeafPageLogSegmentRegisteredAt(path, fileID, commitSeq)
+	if err != nil {
+		return false, err
+	}
+	markLeafPageLogSegmentsRegistered(db.leafPageLog, createdSegments)
+	return registered, nil
 }
 
 func (db *DB) ensureLeafPageLogSegmentRegisteredAt(path string, fileID uint32, commitSeq uint64) (bool, error) {

--- a/TreeDB/db/leaf_page_log.go
+++ b/TreeDB/db/leaf_page_log.go
@@ -382,6 +382,9 @@ func (db *DB) registerLeafPageLogSegmentsForPublish() (bool, error) {
 	if err != nil {
 		return false, err
 	}
+	if registered && db.isLeafGenerationSegmentPath(path) {
+		db.queueLeafGenerationWritableFileID(fileID)
+	}
 	markLeafPageLogSegmentsRegistered(db.leafPageLog, createdSegments)
 	return registered, nil
 }

--- a/TreeDB/db/leaf_page_log.go
+++ b/TreeDB/db/leaf_page_log.go
@@ -55,6 +55,10 @@ type leafPageLogProtectedSystemRootProvider interface {
 	ProtectedLeafGenerationSystemRootIDs() []uint64
 }
 
+type leafPageLogProtectedRootPairProvider interface {
+	ProtectedLeafGenerationRootIDPair() (rootIDs []uint64, systemRootIDs []uint64)
+}
+
 type leafPageLogRecordLengthProvider interface {
 	LastLeafPageRecordLength() uint32
 }
@@ -174,6 +178,17 @@ func (l *leafPageLogWithRecordLengthHints) ProtectedLeafGenerationSystemRootIDs(
 	return provider.ProtectedLeafGenerationSystemRootIDs()
 }
 
+func (l *leafPageLogWithRecordLengthHints) ProtectedLeafGenerationRootIDPair() ([]uint64, []uint64) {
+	if l == nil || l.inner == nil {
+		return nil, nil
+	}
+	provider, ok := l.inner.(leafPageLogProtectedRootPairProvider)
+	if !ok {
+		return nil, nil
+	}
+	return provider.ProtectedLeafGenerationRootIDPair()
+}
+
 func (db *DB) currentLeafPageLogSegment() (path string, fileID uint32, ok bool) {
 	if db == nil || db.leafPageLog == nil {
 		return "", 0, false
@@ -205,6 +220,17 @@ func (db *DB) protectedLeafGenerationSystemRootIDsFromLeafPageLog() []uint64 {
 		return nil
 	}
 	return provider.ProtectedLeafGenerationSystemRootIDs()
+}
+
+func (db *DB) protectedLeafGenerationRootIDPairFromLeafPageLog() ([]uint64, []uint64) {
+	if db == nil || db.leafPageLog == nil {
+		return nil, nil
+	}
+	pairProvider, ok := db.leafPageLog.(leafPageLogProtectedRootPairProvider)
+	if ok {
+		return pairProvider.ProtectedLeafGenerationRootIDPair()
+	}
+	return db.protectedLeafGenerationRootIDsFromLeafPageLog(), db.protectedLeafGenerationSystemRootIDsFromLeafPageLog()
 }
 
 func leafPageLogCreatedSegments(log LeafPageLog) ([]LeafPageLogSegment, error) {

--- a/TreeDB/db/leaf_page_log.go
+++ b/TreeDB/db/leaf_page_log.go
@@ -51,6 +51,10 @@ type leafPageLogProtectedRootProvider interface {
 	ProtectedLeafGenerationRootIDs() []uint64
 }
 
+type leafPageLogProtectedSystemRootProvider interface {
+	ProtectedLeafGenerationSystemRootIDs() []uint64
+}
+
 type leafPageLogRecordLengthProvider interface {
 	LastLeafPageRecordLength() uint32
 }
@@ -159,6 +163,17 @@ func (l *leafPageLogWithRecordLengthHints) ProtectedLeafGenerationRootIDs() []ui
 	return provider.ProtectedLeafGenerationRootIDs()
 }
 
+func (l *leafPageLogWithRecordLengthHints) ProtectedLeafGenerationSystemRootIDs() []uint64 {
+	if l == nil || l.inner == nil {
+		return nil
+	}
+	provider, ok := l.inner.(leafPageLogProtectedSystemRootProvider)
+	if !ok {
+		return nil
+	}
+	return provider.ProtectedLeafGenerationSystemRootIDs()
+}
+
 func (db *DB) currentLeafPageLogSegment() (path string, fileID uint32, ok bool) {
 	if db == nil || db.leafPageLog == nil {
 		return "", 0, false
@@ -179,6 +194,17 @@ func (db *DB) protectedLeafGenerationRootIDsFromLeafPageLog() []uint64 {
 		return nil
 	}
 	return provider.ProtectedLeafGenerationRootIDs()
+}
+
+func (db *DB) protectedLeafGenerationSystemRootIDsFromLeafPageLog() []uint64 {
+	if db == nil || db.leafPageLog == nil {
+		return nil
+	}
+	provider, ok := db.leafPageLog.(leafPageLogProtectedSystemRootProvider)
+	if !ok {
+		return nil
+	}
+	return provider.ProtectedLeafGenerationSystemRootIDs()
 }
 
 func leafPageLogCreatedSegments(log LeafPageLog) ([]LeafPageLogSegment, error) {

--- a/TreeDB/db/leaf_page_log.go
+++ b/TreeDB/db/leaf_page_log.go
@@ -357,7 +357,7 @@ func (db *DB) ensureLeafPageLogSegmentRegistered(commitSeq uint64) (bool, error)
 	return db.ensureLeafPageLogSegmentRegisteredAt(path, fileID, commitSeq)
 }
 
-func (db *DB) registerLeafPageLogSegmentsForPublish(commitSeq uint64) (bool, error) {
+func (db *DB) registerLeafPageLogSegmentsForPublish() (bool, error) {
 	if db == nil || db.valueLogManager == nil || db.leafPageLog == nil {
 		return true, nil
 	}
@@ -369,8 +369,8 @@ func (db *DB) registerLeafPageLogSegmentsForPublish(commitSeq uint64) (bool, err
 		if err := db.valueLogManager.RegisterSegment(seg.Path, seg.FileID); err != nil {
 			return false, err
 		}
-		if db.isLeafGenerationSegmentPath(seg.Path) && commitSeq > 0 {
-			db.queueLeafGenerationWritableFileIDAtCommit(seg.FileID, commitSeq)
+		if db.isLeafGenerationSegmentPath(seg.Path) {
+			db.queueLeafGenerationWritableFileID(seg.FileID)
 		}
 	}
 	path, fileID, ok := db.currentLeafPageLogSegment()
@@ -378,7 +378,7 @@ func (db *DB) registerLeafPageLogSegmentsForPublish(commitSeq uint64) (bool, err
 		markLeafPageLogSegmentsRegistered(db.leafPageLog, createdSegments)
 		return len(createdSegments) > 0, nil
 	}
-	registered, err := db.ensureLeafPageLogSegmentRegisteredAt(path, fileID, commitSeq)
+	registered, err := db.ensureLeafPageLogSegmentRegisteredAt(path, fileID, 0)
 	if err != nil {
 		return false, err
 	}

--- a/TreeDB/db/maintenance_roots.go
+++ b/TreeDB/db/maintenance_roots.go
@@ -38,6 +38,47 @@ type maintenanceRoot struct {
 	descriptorKey []byte
 }
 
+type maintenanceRootAccumulator struct {
+	roots []maintenanceRoot
+	seen  map[uint64]struct{}
+}
+
+func (a *maintenanceRootAccumulator) add(kind maintenanceRootKind, rootID uint64, descriptorKey []byte) {
+	if rootID == 0 {
+		return
+	}
+	if a.seen == nil {
+		a.seen = make(map[uint64]struct{}, 4)
+	}
+	if _, ok := a.seen[rootID]; ok {
+		return
+	}
+	a.seen[rootID] = struct{}{}
+	root := maintenanceRoot{
+		kind:   kind,
+		rootID: rootID,
+	}
+	if len(descriptorKey) > 0 {
+		root.descriptorKey = append([]byte(nil), descriptorKey...)
+	}
+	a.roots = append(a.roots, root)
+}
+
+func (a *maintenanceRootAccumulator) addSystemRootWithDescriptors(ctx context.Context, p *pager.Pager, reader tree.SlabReader, systemRootID uint64) error {
+	if systemRootID == 0 {
+		return nil
+	}
+	a.add(maintenanceRootSystem, systemRootID, nil)
+	descriptors, err := vacuumCollectCollectionRootDescriptorsWithContext(ctx, p, reader, systemRootID)
+	if err != nil {
+		return err
+	}
+	for _, descriptor := range descriptors {
+		a.add(maintenanceRootCollection, descriptor.rootID, descriptor.key)
+	}
+	return nil
+}
+
 func maintenanceRootsForSnapshot(snap *Snapshot) ([]maintenanceRoot, error) {
 	if snap == nil || snap.state == nil || snap.idx == nil || snap.idx.pager == nil {
 		return nil, fmt.Errorf("maintenance roots: missing snapshot state")
@@ -56,43 +97,27 @@ func collectMaintenanceRootsWithContext(ctx context.Context, p *pager.Pager, rea
 	if state == nil {
 		return nil, fmt.Errorf("maintenance roots: missing db state")
 	}
-	roots := make([]maintenanceRoot, 0, 2)
-	var seen map[uint64]struct{}
-	addRoot := func(kind maintenanceRootKind, rootID uint64, descriptorKey []byte) {
-		if rootID == 0 {
-			return
-		}
-		if seen == nil {
-			seen = make(map[uint64]struct{}, 4)
-		}
-		if _, ok := seen[rootID]; ok {
-			return
-		}
-		seen[rootID] = struct{}{}
-		root := maintenanceRoot{
-			kind:   kind,
-			rootID: rootID,
-		}
-		if len(descriptorKey) > 0 {
-			root.descriptorKey = append([]byte(nil), descriptorKey...)
-		}
-		roots = append(roots, root)
+	acc := maintenanceRootAccumulator{
+		roots: make([]maintenanceRoot, 0, 2),
 	}
-
-	addRoot(maintenanceRootUser, state.RootPageID, nil)
-	addRoot(maintenanceRootSystem, state.SystemRootPageID, nil)
-	if state.SystemRootPageID == 0 {
-		return roots, nil
-	}
-
-	descriptors, err := vacuumCollectCollectionRootDescriptorsWithContext(ctx, p, reader, state.SystemRootPageID)
-	if err != nil {
+	acc.add(maintenanceRootUser, state.RootPageID, nil)
+	if err := acc.addSystemRootWithDescriptors(ctx, p, reader, state.SystemRootPageID); err != nil {
 		return nil, fmt.Errorf("maintenance roots: collect collection root descriptors: %w", err)
 	}
-	for _, descriptor := range descriptors {
-		addRoot(maintenanceRootCollection, descriptor.rootID, descriptor.key)
+	return acc.roots, nil
+}
+
+func collectMaintenanceRootsForSystemRootWithContext(ctx context.Context, p *pager.Pager, reader tree.SlabReader, systemRootID uint64) ([]maintenanceRoot, error) {
+	if ctx == nil {
+		ctx = context.Background()
 	}
-	return roots, nil
+	acc := maintenanceRootAccumulator{
+		roots: make([]maintenanceRoot, 0, 2),
+	}
+	if err := acc.addSystemRootWithDescriptors(ctx, p, reader, systemRootID); err != nil {
+		return nil, fmt.Errorf("maintenance roots: collect collection root descriptors for system root %d: %w", systemRootID, err)
+	}
+	return acc.roots, nil
 }
 
 // CollectMaintenanceRootIDs returns the deduplicated root IDs that storage
@@ -109,9 +134,30 @@ func CollectMaintenanceRootIDsWithContext(ctx context.Context, p *pager.Pager, r
 	if err != nil {
 		return nil, err
 	}
+	return maintenanceRootIDs(roots), nil
+}
+
+// CollectMaintenanceRootIDsForSystemRoot returns the deduplicated root IDs for
+// a system root plus collection roots referenced by that system root's
+// descriptors.
+func CollectMaintenanceRootIDsForSystemRoot(p *pager.Pager, reader tree.SlabReader, systemRootID uint64) ([]uint64, error) {
+	return CollectMaintenanceRootIDsForSystemRootWithContext(context.Background(), p, reader, systemRootID)
+}
+
+// CollectMaintenanceRootIDsForSystemRootWithContext is the context-aware form
+// of CollectMaintenanceRootIDsForSystemRoot.
+func CollectMaintenanceRootIDsForSystemRootWithContext(ctx context.Context, p *pager.Pager, reader tree.SlabReader, systemRootID uint64) ([]uint64, error) {
+	roots, err := collectMaintenanceRootsForSystemRootWithContext(ctx, p, reader, systemRootID)
+	if err != nil {
+		return nil, err
+	}
+	return maintenanceRootIDs(roots), nil
+}
+
+func maintenanceRootIDs(roots []maintenanceRoot) []uint64 {
 	out := make([]uint64, 0, len(roots))
 	for _, root := range roots {
 		out = append(out, root.rootID)
 	}
-	return out, nil
+	return out
 }

--- a/TreeDB/db/maintenance_roots.go
+++ b/TreeDB/db/maintenance_roots.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/snissn/gomap/TreeDB/pager"
@@ -45,6 +46,13 @@ func maintenanceRootsForSnapshot(snap *Snapshot) ([]maintenanceRoot, error) {
 }
 
 func collectMaintenanceRoots(p *pager.Pager, reader tree.SlabReader, state *DBState) ([]maintenanceRoot, error) {
+	return collectMaintenanceRootsWithContext(context.Background(), p, reader, state)
+}
+
+func collectMaintenanceRootsWithContext(ctx context.Context, p *pager.Pager, reader tree.SlabReader, state *DBState) ([]maintenanceRoot, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	if state == nil {
 		return nil, fmt.Errorf("maintenance roots: missing db state")
 	}
@@ -77,7 +85,7 @@ func collectMaintenanceRoots(p *pager.Pager, reader tree.SlabReader, state *DBSt
 		return roots, nil
 	}
 
-	descriptors, err := vacuumCollectCollectionRootDescriptors(p, reader, state.SystemRootPageID)
+	descriptors, err := vacuumCollectCollectionRootDescriptorsWithContext(ctx, p, reader, state.SystemRootPageID)
 	if err != nil {
 		return nil, fmt.Errorf("maintenance roots: collect collection root descriptors: %w", err)
 	}
@@ -85,4 +93,25 @@ func collectMaintenanceRoots(p *pager.Pager, reader tree.SlabReader, state *DBSt
 		addRoot(maintenanceRootCollection, descriptor.rootID, descriptor.key)
 	}
 	return roots, nil
+}
+
+// CollectMaintenanceRootIDs returns the deduplicated root IDs that storage
+// maintenance must preserve for the supplied state: the active user and system
+// roots plus collection roots referenced by system descriptors.
+func CollectMaintenanceRootIDs(p *pager.Pager, reader tree.SlabReader, state *DBState) ([]uint64, error) {
+	return CollectMaintenanceRootIDsWithContext(context.Background(), p, reader, state)
+}
+
+// CollectMaintenanceRootIDsWithContext is the context-aware form of
+// CollectMaintenanceRootIDs.
+func CollectMaintenanceRootIDsWithContext(ctx context.Context, p *pager.Pager, reader tree.SlabReader, state *DBState) ([]uint64, error) {
+	roots, err := collectMaintenanceRootsWithContext(ctx, p, reader, state)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]uint64, 0, len(roots))
+	for _, root := range roots {
+		out = append(out, root.rootID)
+	}
+	return out, nil
 }

--- a/TreeDB/db/maintenance_roots.go
+++ b/TreeDB/db/maintenance_roots.go
@@ -40,7 +40,12 @@ type maintenanceRoot struct {
 
 type maintenanceRootAccumulator struct {
 	roots []maintenanceRoot
-	seen  map[uint64]struct{}
+	seen  map[maintenanceRootKey]struct{}
+}
+
+type maintenanceRootKey struct {
+	kind   maintenanceRootKind
+	rootID uint64
 }
 
 func (a *maintenanceRootAccumulator) add(kind maintenanceRootKind, rootID uint64, descriptorKey []byte) {
@@ -48,12 +53,13 @@ func (a *maintenanceRootAccumulator) add(kind maintenanceRootKind, rootID uint64
 		return
 	}
 	if a.seen == nil {
-		a.seen = make(map[uint64]struct{}, 4)
+		a.seen = make(map[maintenanceRootKey]struct{}, 4)
 	}
-	if _, ok := a.seen[rootID]; ok {
+	key := maintenanceRootKey{kind: kind, rootID: rootID}
+	if _, ok := a.seen[key]; ok {
 		return
 	}
-	a.seen[rootID] = struct{}{}
+	a.seen[key] = struct{}{}
 	root := maintenanceRoot{
 		kind:   kind,
 		rootID: rootID,

--- a/TreeDB/db/maintenance_roots.go
+++ b/TreeDB/db/maintenance_roots.go
@@ -166,8 +166,51 @@ func CollectMaintenanceRootIDsForSystemRootWithContext(ctx context.Context, p *p
 
 func maintenanceRootIDs(roots []maintenanceRoot) []uint64 {
 	out := make([]uint64, 0, len(roots))
+	for _, root := range dedupeMaintenanceRootsByRootID(roots) {
+		if root.rootID != 0 {
+			out = append(out, root.rootID)
+		}
+	}
+	return out
+}
+
+func dedupeMaintenanceRootsByRootID(roots []maintenanceRoot) []maintenanceRoot {
+	if len(roots) <= 1 {
+		if len(roots) == 1 && roots[0].rootID == 0 {
+			return roots[:0]
+		}
+		return roots
+	}
+	if len(roots) <= 8 {
+		out := roots[:0]
+		for _, root := range roots {
+			if root.rootID == 0 {
+				continue
+			}
+			seen := false
+			for _, existing := range out {
+				if existing.rootID == root.rootID {
+					seen = true
+					break
+				}
+			}
+			if !seen {
+				out = append(out, root)
+			}
+		}
+		return out
+	}
+	seen := make(map[uint64]struct{}, len(roots))
+	out := roots[:0]
 	for _, root := range roots {
-		out = append(out, root.rootID)
+		if root.rootID == 0 {
+			continue
+		}
+		if _, ok := seen[root.rootID]; ok {
+			continue
+		}
+		seen[root.rootID] = struct{}{}
+		out = append(out, root)
 	}
 	return out
 }

--- a/TreeDB/db/maintenance_roots.go
+++ b/TreeDB/db/maintenance_roots.go
@@ -80,10 +80,14 @@ func (a *maintenanceRootAccumulator) addSystemRootWithDescriptors(ctx context.Co
 }
 
 func maintenanceRootsForSnapshot(snap *Snapshot) ([]maintenanceRoot, error) {
+	return maintenanceRootsForSnapshotWithContext(context.Background(), snap)
+}
+
+func maintenanceRootsForSnapshotWithContext(ctx context.Context, snap *Snapshot) ([]maintenanceRoot, error) {
 	if snap == nil || snap.state == nil || snap.idx == nil || snap.idx.pager == nil {
 		return nil, fmt.Errorf("maintenance roots: missing snapshot state")
 	}
-	return collectMaintenanceRoots(snap.idx.pager, &snap.reader, snap.state)
+	return collectMaintenanceRootsWithContext(ctx, snap.idx.pager, &snap.reader, snap.state)
 }
 
 func collectMaintenanceRoots(p *pager.Pager, reader tree.SlabReader, state *DBState) ([]maintenanceRoot, error) {

--- a/TreeDB/db/maintenance_roots_test.go
+++ b/TreeDB/db/maintenance_roots_test.go
@@ -111,6 +111,25 @@ func TestMaintenanceRoots_DeduplicatesCollectionRootDescriptors(t *testing.T) {
 	requireMaintenanceRootCount(t, roots, maintenanceRootCollection, 1)
 }
 
+func TestMaintenanceRoots_PreservesDistinctRolesForSameRootID(t *testing.T) {
+	var acc maintenanceRootAccumulator
+	rootID := uint64(42)
+	acc.add(maintenanceRootUser, rootID, nil)
+	acc.add(maintenanceRootCollection, rootID, []byte(maintenanceTestCollectionRootKey))
+	acc.add(maintenanceRootCollection, rootID, []byte("collections/root/users/alias"))
+	acc.add(maintenanceRootSystem, rootID, nil)
+
+	requireMaintenanceRoot(t, acc.roots, maintenanceRootUser, rootID)
+	collectionRoot := requireMaintenanceRoot(t, acc.roots, maintenanceRootCollection, rootID)
+	if !bytes.Equal(collectionRoot.descriptorKey, []byte(maintenanceTestCollectionRootKey)) {
+		t.Fatalf("collection descriptor key=%q want %q", collectionRoot.descriptorKey, maintenanceTestCollectionRootKey)
+	}
+	requireMaintenanceRoot(t, acc.roots, maintenanceRootSystem, rootID)
+	requireMaintenanceRootCount(t, acc.roots, maintenanceRootUser, 1)
+	requireMaintenanceRootCount(t, acc.roots, maintenanceRootCollection, 1)
+	requireMaintenanceRootCount(t, acc.roots, maintenanceRootSystem, 1)
+}
+
 func TestMaintenanceRoots_IncludesCollectionOverlayRootDescriptors(t *testing.T) {
 	d, err := Open(Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/db/maintenance_roots_test.go
+++ b/TreeDB/db/maintenance_roots_test.go
@@ -130,6 +130,21 @@ func TestMaintenanceRoots_PreservesDistinctRolesForSameRootID(t *testing.T) {
 	requireMaintenanceRootCount(t, acc.roots, maintenanceRootSystem, 1)
 }
 
+func TestMaintenanceRootIDsDedupesByRootID(t *testing.T) {
+	roots := []maintenanceRoot{
+		{kind: maintenanceRootUser, rootID: 7},
+		{kind: maintenanceRootCollection, rootID: 7, descriptorKey: []byte(maintenanceTestCollectionRootKey)},
+		{kind: maintenanceRootSystem, rootID: 8},
+		{kind: maintenanceRootCollection, rootID: 8, descriptorKey: []byte("collections/root/users/alias")},
+		{kind: maintenanceRootCollection, rootID: 0},
+	}
+	got := maintenanceRootIDs(roots)
+	want := []uint64{7, 8}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("maintenanceRootIDs=%v want %v", got, want)
+	}
+}
+
 func TestMaintenanceRoots_IncludesCollectionOverlayRootDescriptors(t *testing.T) {
 	d, err := Open(Options{Dir: t.TempDir()})
 	if err != nil {
@@ -620,6 +635,78 @@ func TestValueLogRewritePlanningCountsCollectionRootPointers(t *testing.T) {
 	}
 	if !found {
 		t.Fatalf("collection-referenced file %d missing from chunk live-byte estimate: %+v", referenced.FileID, liveByChunk)
+	}
+}
+
+func TestMaintenanceRootScansDeduplicateRoleAliasesByRootID(t *testing.T) {
+	dir := t.TempDir()
+	d, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	referenced := appendPointersInNewSegment(t, dir, 0, 1, 130_000, 1, func(int) []byte {
+		return bytes.Repeat([]byte("role-alias-live|"), 64)
+	})[0]
+	if err := d.RefreshValueLogSet(); err != nil {
+		t.Fatalf("RefreshValueLogSet: %v", err)
+	}
+	batch := d.NewBatch()
+	ptrBatch, ok := batch.(interface {
+		SetPointer(key []byte, ptr page.ValuePtr) error
+	})
+	if !ok {
+		t.Fatalf("missing SetPointer on batch %T", batch)
+	}
+	if err := ptrBatch.SetPointer([]byte("doc/p"), referenced); err != nil {
+		t.Fatalf("SetPointer: %v", err)
+	}
+	if err := batch.Write(); err != nil {
+		t.Fatalf("batch write: %v", err)
+	}
+	if err := batch.Close(); err != nil {
+		t.Fatalf("batch close: %v", err)
+	}
+	aliasedUserRoot := d.State().RootPageID
+	if _, err := d.PublishSystemRootIterator(mustFrozenRawMemtable(t,
+		maintenanceTestCollectionRootKey, encodeMaintenanceRootID(aliasedUserRoot),
+	).NewIterator(nil, nil)); err != nil {
+		t.Fatalf("publish collection alias descriptor: %v", err)
+	}
+
+	counts, _, err := d.scanValueLogRefCounts(context.Background())
+	if err != nil {
+		t.Fatalf("scanValueLogRefCounts: %v", err)
+	}
+	if got := counts[referenced.FileID]; got != 1 {
+		t.Fatalf("ref count for file %d = %d, want 1", referenced.FileID, got)
+	}
+
+	recordLen, err := d.valueLogRecordLengthForRewrite(referenced)
+	if err != nil {
+		t.Fatalf("valueLogRecordLengthForRewrite: %v", err)
+	}
+	liveByID, err := d.estimateValueLogLiveBytesBySegment(context.Background())
+	if err != nil {
+		t.Fatalf("estimateValueLogLiveBytesBySegment: %v", err)
+	}
+	if got, want := liveByID[referenced.FileID], int64(recordLen); got != want {
+		t.Fatalf("segment live bytes for file %d = %d, want %d", referenced.FileID, got, want)
+	}
+
+	chunkBytes := int64(16 << 20)
+	chunkOffset, err := valueLogChunkOffsetForPtr(referenced, chunkBytes)
+	if err != nil {
+		t.Fatalf("valueLogChunkOffsetForPtr: %v", err)
+	}
+	liveByChunk, err := d.estimateValueLogLiveBytesByChunk(context.Background(), chunkBytes)
+	if err != nil {
+		t.Fatalf("estimateValueLogLiveBytesByChunk: %v", err)
+	}
+	chunkKey := valueLogChunkKey{fileID: referenced.FileID, chunkOffset: chunkOffset}
+	if got, want := liveByChunk[chunkKey], int64(recordLen); got != want {
+		t.Fatalf("chunk live bytes for %+v = %d, want %d", chunkKey, got, want)
 	}
 }
 

--- a/TreeDB/db/ordered_root_publish.go
+++ b/TreeDB/db/ordered_root_publish.go
@@ -2672,6 +2672,7 @@ func (db *DB) publishOrderedRootGroup(systemIter iterator.UnsafeIterator, ordere
 
 	rootIDs := make([]uint64, len(ordered))
 	orderedConsumed := make([]bool, len(ordered))
+	var touchedValueLogSegments []uint32
 	defer closeUnconsumedOrderedRootPublishIterators(ordered, orderedConsumed)
 	for idx := range ordered {
 		opts, err := db.orderedRootPublishOptionsForPolicy(ordered[idx].StoragePolicy)
@@ -2679,10 +2680,12 @@ func (db *DB) publishOrderedRootGroup(systemIter iterator.UnsafeIterator, ordere
 			return 0, nil, err
 		}
 		orderedConsumed[idx] = true
-		rootID, rootRetired, metrics, _, _, err := db.publishOrderedRootIterator(ordered[idx].BaseRoot, ordered[idx].Iter, opts, false)
+		touchedIter := &orderedRootTouchedIterator{UnsafeIterator: ordered[idx].Iter}
+		rootID, rootRetired, metrics, _, _, err := db.publishOrderedRootIterator(ordered[idx].BaseRoot, touchedIter, opts, false)
 		if err != nil {
 			return 0, nil, err
 		}
+		touchedValueLogSegments = append(touchedValueLogSegments, touchedIter.touchedValueLogSegments...)
 		rootIDs[idx] = rootID
 		retired = append(retired, rootRetired...)
 		mergeOrderedRootPublishMetrics(&merged, metrics)
@@ -2720,7 +2723,7 @@ func (db *DB) publishOrderedRootGroup(systemIter iterator.UnsafeIterator, ordere
 	}
 
 	forceRefTrackerRebuild := systemStats.collectionRootDescriptorReachabilityMayChange()
-	touchedValueLogSegments := positiveValueLogRefDeltaFileIDs(vlogRefDelta, nil)
+	touchedValueLogSegments = positiveValueLogRefDeltaFileIDs(vlogRefDelta, touchedValueLogSegments)
 	if forceRefTrackerRebuild {
 		// Collection descriptors make non-system roots part of value-log
 		// reachability. The system-root ref delta alone is not an exact commit

--- a/TreeDB/db/ordered_root_publish.go
+++ b/TreeDB/db/ordered_root_publish.go
@@ -486,36 +486,52 @@ func orderedRootEntryValueLogFileID(iter iterator.UnsafeIterator) (uint32, bool)
 	return ptr.FileID, true
 }
 
-func appendTouchedValueLogSegmentID(dst []uint32, fileID uint32) []uint32 {
-	if fileID == 0 {
-		return dst
-	}
-	for _, existing := range dst {
-		if existing == fileID {
-			return dst
-		}
-	}
-	return append(dst, fileID)
-}
-
-func appendOrderedRootEntryTouchedValueLogSegment(iter iterator.UnsafeIterator, dst []uint32) []uint32 {
-	fileID, ok := orderedRootEntryValueLogFileID(iter)
-	if !ok {
-		return dst
-	}
-	return appendTouchedValueLogSegmentID(dst, fileID)
-}
+const orderedRootTouchedValueLogSegmentLinearLimit = 8
 
 type orderedRootTouchedIterator struct {
 	iterator.UnsafeIterator
-	touchedValueLogSegments []uint32
+	touchedValueLogSegments   []uint32
+	touchedValueLogSegmentSet map[uint32]struct{}
 }
 
 func (it *orderedRootTouchedIterator) capture() {
 	if it == nil {
 		return
 	}
-	it.touchedValueLogSegments = appendOrderedRootEntryTouchedValueLogSegment(it.UnsafeIterator, it.touchedValueLogSegments)
+	fileID, ok := orderedRootEntryValueLogFileID(it.UnsafeIterator)
+	if !ok {
+		return
+	}
+	it.appendTouchedValueLogSegmentID(fileID)
+}
+
+func (it *orderedRootTouchedIterator) appendTouchedValueLogSegmentID(fileID uint32) {
+	if it == nil || fileID == 0 {
+		return
+	}
+	if it.touchedValueLogSegmentSet != nil {
+		if _, ok := it.touchedValueLogSegmentSet[fileID]; ok {
+			return
+		}
+		it.touchedValueLogSegmentSet[fileID] = struct{}{}
+		it.touchedValueLogSegments = append(it.touchedValueLogSegments, fileID)
+		return
+	}
+	for _, existing := range it.touchedValueLogSegments {
+		if existing == fileID {
+			return
+		}
+	}
+	if len(it.touchedValueLogSegments) >= orderedRootTouchedValueLogSegmentLinearLimit {
+		it.touchedValueLogSegmentSet = make(map[uint32]struct{}, len(it.touchedValueLogSegments)+1)
+		for _, existing := range it.touchedValueLogSegments {
+			if existing != 0 {
+				it.touchedValueLogSegmentSet[existing] = struct{}{}
+			}
+		}
+		it.touchedValueLogSegmentSet[fileID] = struct{}{}
+	}
+	it.touchedValueLogSegments = append(it.touchedValueLogSegments, fileID)
 }
 
 func (it *orderedRootTouchedIterator) Next() {

--- a/TreeDB/db/ordered_root_publish.go
+++ b/TreeDB/db/ordered_root_publish.go
@@ -707,6 +707,19 @@ func collectValueLogRefDeltaFromIterator(iter iterator.UnsafeIterator) (*valueLo
 	return delta, nil
 }
 
+func positiveValueLogRefDeltaFileIDs(delta *valueLogRefDelta, dst []uint32) []uint32 {
+	if delta == nil {
+		return dst
+	}
+	_ = delta.forEachChange(func(fileID uint32, change int64) error {
+		if change > 0 {
+			dst = append(dst, fileID)
+		}
+		return nil
+	})
+	return dst
+}
+
 func (db *DB) publishOrderedRootDeltaIterator(baseRoot uint64, iter iterator.UnsafeIterator, opts orderedRootPublishOptions) (newRoot uint64, retired []uint64, metrics adaptive.Metrics, err error) {
 	if db == nil {
 		err = ErrClosed
@@ -1323,6 +1336,7 @@ func (db *DB) PublishOrderedRootDeltaGroupWithSystemBuilder(ordered []OrderedRoo
 	mergeOrderedRootPublishMetrics(&merged, metrics)
 	phaseStats.systemApplyMetrics.add(metrics)
 	vlogRefDelta := refDelta
+	touchedValueLogSegments := positiveValueLogRefDeltaFileIDs(refDelta, nil)
 	forceRefTrackerRebuild := publishStats.collectionRootDescriptorReachabilityMayChange()
 	if len(ordered) > 0 || forceRefTrackerRebuild {
 		// Non-system roots were applied from deltas, so this commit has no
@@ -1351,7 +1365,7 @@ func (db *DB) PublishOrderedRootDeltaGroupWithSystemBuilder(ordered []OrderedRoo
 		vlogRefDelta = db.newNoopValueLogRefDeltaIfTrackable(baseSeq)
 	}
 	phaseStart = time.Now()
-	err = db.finalizeCommit(userRoot, newSystemRoot, retired, false, merged, nil, true, vlogRefDelta, nil, nil)
+	err = db.finalizeCommit(userRoot, newSystemRoot, retired, false, merged, touchedValueLogSegments, true, vlogRefDelta, nil, nil)
 	phaseStats.finalizeNs += orderedRootDeltaGroupPhaseDurationNs(phaseStart)
 	phaseStats.finalizeCalls++
 	if err != nil {
@@ -2620,6 +2634,7 @@ func (db *DB) publishOrderedRootGroup(systemIter iterator.UnsafeIterator, ordere
 	}
 
 	forceRefTrackerRebuild := systemStats.collectionRootDescriptorReachabilityMayChange()
+	touchedValueLogSegments := positiveValueLogRefDeltaFileIDs(vlogRefDelta, nil)
 	if forceRefTrackerRebuild {
 		// Collection descriptors make non-system roots part of value-log
 		// reachability. The system-root ref delta alone is not an exact commit
@@ -2633,7 +2648,7 @@ func (db *DB) publishOrderedRootGroup(systemIter iterator.UnsafeIterator, ordere
 	if vlogRefDelta == nil && !forceRefTrackerRebuild {
 		vlogRefDelta = db.newNoopValueLogRefDeltaIfTrackable(baseSeq)
 	}
-	if err := db.finalizeCommit(userRoot, newSystemRoot, retired, false, merged, nil, true, vlogRefDelta, nil, nil); err != nil {
+	if err := db.finalizeCommit(userRoot, newSystemRoot, retired, false, merged, touchedValueLogSegments, true, vlogRefDelta, nil, nil); err != nil {
 		return 0, nil, err
 	}
 	vlogRefDelta = nil

--- a/TreeDB/db/ordered_root_publish.go
+++ b/TreeDB/db/ordered_root_publish.go
@@ -486,6 +486,66 @@ func orderedRootEntryValueLogFileID(iter iterator.UnsafeIterator) (uint32, bool)
 	return ptr.FileID, true
 }
 
+func appendTouchedValueLogSegmentID(dst []uint32, fileID uint32) []uint32 {
+	if fileID == 0 {
+		return dst
+	}
+	for _, existing := range dst {
+		if existing == fileID {
+			return dst
+		}
+	}
+	return append(dst, fileID)
+}
+
+func appendOrderedRootEntryTouchedValueLogSegment(iter iterator.UnsafeIterator, dst []uint32) []uint32 {
+	fileID, ok := orderedRootEntryValueLogFileID(iter)
+	if !ok {
+		return dst
+	}
+	return appendTouchedValueLogSegmentID(dst, fileID)
+}
+
+type orderedRootTouchedIterator struct {
+	iterator.UnsafeIterator
+	touchedValueLogSegments []uint32
+}
+
+func (it *orderedRootTouchedIterator) capture() {
+	if it == nil {
+		return
+	}
+	it.touchedValueLogSegments = appendOrderedRootEntryTouchedValueLogSegment(it.UnsafeIterator, it.touchedValueLogSegments)
+}
+
+func (it *orderedRootTouchedIterator) Next() {
+	it.capture()
+	it.UnsafeIterator.Next()
+}
+
+func (it *orderedRootTouchedIterator) Seek(key []byte) {
+	it.capture()
+	it.UnsafeIterator.Seek(key)
+}
+
+func (it *orderedRootTouchedIterator) Close() error {
+	it.capture()
+	return it.UnsafeIterator.Close()
+}
+
+func appendOrderedRootDeltaBatchFinalTouchedValueLogSegments(delta *batch.Batch, dst []uint32) []uint32 {
+	if delta == nil {
+		return dst
+	}
+	for _, entry := range delta.SortedEntries() {
+		if entry.Type == batch.OpDelete || !entry.IsPtr || !page.IsValueLogFileID(entry.ValuePtr.FileID) {
+			continue
+		}
+		dst = appendTouchedValueLogSegmentID(dst, entry.ValuePtr.FileID)
+	}
+	return dst
+}
+
 func orderedRootBatchPut(delta *batch.Batch, iter iterator.UnsafeIterator, borrowEntryViews bool, trustedSortedUnique bool) error {
 	if delta == nil || iter == nil || !iter.Valid() {
 		return nil
@@ -720,7 +780,7 @@ func positiveValueLogRefDeltaFileIDs(delta *valueLogRefDelta, dst []uint32) []ui
 	return dst
 }
 
-func (db *DB) publishOrderedRootDeltaIterator(baseRoot uint64, iter iterator.UnsafeIterator, opts orderedRootPublishOptions) (newRoot uint64, retired []uint64, metrics adaptive.Metrics, err error) {
+func (db *DB) publishOrderedRootDeltaIterator(baseRoot uint64, iter iterator.UnsafeIterator, opts orderedRootPublishOptions) (newRoot uint64, retired []uint64, metrics adaptive.Metrics, touchedValueLogSegments []uint32, err error) {
 	if db == nil {
 		err = ErrClosed
 		return
@@ -731,7 +791,9 @@ func (db *DB) publishOrderedRootDeltaIterator(baseRoot uint64, iter iterator.Uns
 	}
 
 	if baseRoot == 0 {
-		newRoot, retired, metrics, _, _, err = db.publishOrderedRootIterator(0, iter, opts, false)
+		touchedIter := &orderedRootTouchedIterator{UnsafeIterator: iter}
+		newRoot, retired, metrics, _, _, err = db.publishOrderedRootIterator(0, touchedIter, opts, false)
+		touchedValueLogSegments = touchedIter.touchedValueLogSegments
 		return
 	}
 	defer iter.Close()
@@ -747,17 +809,21 @@ func (db *DB) publishOrderedRootDeltaIterator(baseRoot uint64, iter iterator.Uns
 	}
 	delta, err := orderedRootDeltaBatchFromIterator(iter)
 	if err != nil {
-		return 0, nil, metrics, err
+		return 0, nil, metrics, nil, err
 	}
 	defer delta.Close()
 	if delta.IsEmpty() {
-		return baseRoot, nil, metrics, nil
+		return baseRoot, nil, metrics, nil, nil
 	}
 	rootZipper, err := db.orderedRootZipperForOptions(idx, opts)
 	if err != nil {
-		return 0, nil, metrics, err
+		return 0, nil, metrics, nil, err
 	}
 	newRoot, retired, metrics, err = rootZipper.Apply(baseRoot, delta)
+	if err != nil {
+		return
+	}
+	touchedValueLogSegments = appendOrderedRootDeltaBatchFinalTouchedValueLogSegments(delta, nil)
 	return
 }
 
@@ -1292,6 +1358,7 @@ func (db *DB) PublishOrderedRootDeltaGroupWithSystemBuilder(ordered []OrderedRoo
 	}
 	var retired []uint64
 	var merged adaptive.Metrics
+	var touchedValueLogSegments []uint32
 	for idx := range ordered {
 		opts, err := db.orderedRootPublishOptionsForPolicy(ordered[idx].StoragePolicy)
 		if err != nil {
@@ -1299,12 +1366,13 @@ func (db *DB) PublishOrderedRootDeltaGroupWithSystemBuilder(ordered []OrderedRoo
 		}
 		orderedConsumed[idx] = true
 		phaseStart := time.Now()
-		rootID, rootRetired, metrics, err := db.publishOrderedRootDeltaIterator(ordered[idx].BaseRoot, ordered[idx].Iter, opts)
+		rootID, rootRetired, metrics, rootTouched, err := db.publishOrderedRootDeltaIterator(ordered[idx].BaseRoot, ordered[idx].Iter, opts)
 		phaseStats.rootApplyNs += orderedRootDeltaGroupPhaseDurationNs(phaseStart)
 		phaseStats.rootApplyCalls++
 		if err != nil {
 			return 0, nil, err
 		}
+		touchedValueLogSegments = append(touchedValueLogSegments, rootTouched...)
 		rootIDs[idx] = rootID
 		rootsObserved++
 		retired = append(retired, rootRetired...)
@@ -1336,7 +1404,7 @@ func (db *DB) PublishOrderedRootDeltaGroupWithSystemBuilder(ordered []OrderedRoo
 	mergeOrderedRootPublishMetrics(&merged, metrics)
 	phaseStats.systemApplyMetrics.add(metrics)
 	vlogRefDelta := refDelta
-	touchedValueLogSegments := positiveValueLogRefDeltaFileIDs(refDelta, nil)
+	touchedValueLogSegments = positiveValueLogRefDeltaFileIDs(refDelta, touchedValueLogSegments)
 	forceRefTrackerRebuild := publishStats.collectionRootDescriptorReachabilityMayChange()
 	if len(ordered) > 0 || forceRefTrackerRebuild {
 		// Non-system roots were applied from deltas, so this commit has no
@@ -1677,6 +1745,7 @@ func (db *DB) publishOrderedRootDeltaGroupWithSystemDeltaBuilderWithMaintenanceP
 	systemOpts := systemRootOrderedPublishOptions(db)
 	var retired []uint64
 	var merged adaptive.Metrics
+	var touchedValueLogSegments []uint32
 	for idx := range ordered {
 		opts, err := db.orderedRootPublishOptionsForPolicy(ordered[idx].StoragePolicy)
 		if err != nil {
@@ -1684,7 +1753,7 @@ func (db *DB) publishOrderedRootDeltaGroupWithSystemDeltaBuilderWithMaintenanceP
 		}
 		orderedConsumed[idx] = true
 		phaseStart := time.Now()
-		rootID, rootRetired, metrics, err := db.publishOrderedRootDeltaIterator(ordered[idx].BaseRoot, ordered[idx].Iter, opts)
+		rootID, rootRetired, metrics, rootTouched, err := db.publishOrderedRootDeltaIterator(ordered[idx].BaseRoot, ordered[idx].Iter, opts)
 		phaseStats.rootApplyNs += orderedRootDeltaGroupPhaseDurationNs(phaseStart)
 		phaseStats.rootApplyCalls++
 		if err != nil {
@@ -1693,6 +1762,7 @@ func (db *DB) publishOrderedRootDeltaGroupWithSystemDeltaBuilderWithMaintenanceP
 		if storageMaintenance && rootID == ordered[idx].BaseRoot {
 			return 0, nil, preApplyErr(fmt.Errorf("%w: ordered input %d", ErrStorageMaintenanceRootDeltaEmpty, idx))
 		}
+		touchedValueLogSegments = append(touchedValueLogSegments, rootTouched...)
 		rootIDs[idx] = rootID
 		rootsObserved++
 		retired = append(retired, rootRetired...)
@@ -1713,12 +1783,13 @@ func (db *DB) publishOrderedRootDeltaGroupWithSystemDeltaBuilderWithMaintenanceP
 		return 0, nil, errors.New("nil system root delta iterator")
 	}
 	phaseStart = time.Now()
-	rootID, rootRetired, metrics, err := db.publishOrderedRootDeltaIterator(baseSystemRoot, iter, systemOpts)
+	rootID, rootRetired, metrics, systemTouched, err := db.publishOrderedRootDeltaIterator(baseSystemRoot, iter, systemOpts)
 	phaseStats.systemApplyNs += orderedRootDeltaGroupPhaseDurationNs(phaseStart)
 	phaseStats.systemApplyCalls++
 	if err != nil {
 		return 0, nil, err
 	}
+	touchedValueLogSegments = append(touchedValueLogSegments, systemTouched...)
 	newSystemRoot = rootID
 	retired = append(retired, rootRetired...)
 	mergeOrderedRootPublishMetrics(&merged, metrics)
@@ -1737,7 +1808,7 @@ func (db *DB) publishOrderedRootDeltaGroupWithSystemDeltaBuilderWithMaintenanceP
 	// tracker conservative by invalidating it after commit.
 	var vlogRefDelta *valueLogRefDelta
 	phaseStart = time.Now()
-	err = db.finalizeOrderedRootPublishWithCommandWAL(userRoot, newSystemRoot, retired, false, merged, nil, true, vlogRefDelta, nil, nil, commandWALIntent)
+	err = db.finalizeOrderedRootPublishWithCommandWAL(userRoot, newSystemRoot, retired, false, merged, touchedValueLogSegments, true, vlogRefDelta, nil, nil, commandWALIntent)
 	phaseStats.finalizeNs += orderedRootDeltaGroupPhaseDurationNs(phaseStart)
 	phaseStats.finalizeCalls++
 	if err != nil {
@@ -1853,6 +1924,7 @@ func (db *DB) publishOrderedRootDeltaGroupWithCommandWALContextAndSystemDeltaBui
 	systemOpts := systemRootOrderedPublishOptions(db)
 	var retired []uint64
 	var merged adaptive.Metrics
+	var touchedValueLogSegments []uint32
 	rootIDs = make([]uint64, len(allOrdered))
 	for idx := range allOrdered {
 		opts, err := db.orderedRootPublishOptionsForPolicy(allOrdered[idx].StoragePolicy)
@@ -1864,12 +1936,13 @@ func (db *DB) publishOrderedRootDeltaGroupWithCommandWALContextAndSystemDeltaBui
 		// a second time if root publication fails after ownership transfer.
 		orderedConsumed[idx] = true
 		phaseStart := time.Now()
-		rootID, rootRetired, metrics, err := db.publishOrderedRootDeltaIterator(allOrdered[idx].BaseRoot, allOrdered[idx].Iter, opts)
+		rootID, rootRetired, metrics, rootTouched, err := db.publishOrderedRootDeltaIterator(allOrdered[idx].BaseRoot, allOrdered[idx].Iter, opts)
 		phaseStats.rootApplyNs += orderedRootDeltaGroupPhaseDurationNs(phaseStart)
 		phaseStats.rootApplyCalls++
 		if err != nil {
 			return 0, nil, err
 		}
+		touchedValueLogSegments = append(touchedValueLogSegments, rootTouched...)
 		rootIDs[idx] = rootID
 		rootsObserved++
 		retired = append(retired, rootRetired...)
@@ -1891,12 +1964,13 @@ func (db *DB) publishOrderedRootDeltaGroupWithCommandWALContextAndSystemDeltaBui
 		return 0, nil, err
 	}
 	phaseStart = time.Now()
-	rootID, rootRetired, metrics, err := db.publishOrderedRootDeltaIterator(baseSystemRoot, iter, systemOpts)
+	rootID, rootRetired, metrics, systemTouched, err := db.publishOrderedRootDeltaIterator(baseSystemRoot, iter, systemOpts)
 	phaseStats.systemApplyNs += orderedRootDeltaGroupPhaseDurationNs(phaseStart)
 	phaseStats.systemApplyCalls++
 	if err != nil {
 		return 0, nil, err
 	}
+	touchedValueLogSegments = append(touchedValueLogSegments, systemTouched...)
 	newSystemRoot = rootID
 	retired = append(retired, rootRetired...)
 	mergeOrderedRootPublishMetrics(&merged, metrics)
@@ -1913,7 +1987,7 @@ func (db *DB) publishOrderedRootDeltaGroupWithCommandWALContextAndSystemDeltaBui
 
 	var vlogRefDelta *valueLogRefDelta
 	phaseStart = time.Now()
-	post, err := db.finalizeCommitLockedWithOptions(userRoot, newSystemRoot, retired, syncCommandWAL, merged, nil, true, vlogRefDelta, nil, nil, commandWALFinalizeOptionsForPublicIntent(commandWALIntent))
+	post, err := db.finalizeCommitLockedWithOptions(userRoot, newSystemRoot, retired, syncCommandWAL, merged, touchedValueLogSegments, true, vlogRefDelta, nil, nil, commandWALFinalizeOptionsForPublicIntent(commandWALIntent))
 	phaseStats.finalizeNs += orderedRootDeltaGroupPhaseDurationNs(phaseStart)
 	phaseStats.finalizeCalls++
 	if err != nil {
@@ -2083,6 +2157,7 @@ func (db *DB) tryPublishOrderedRootDeltaBatchGroupOptimistic(ordered []OrderedRo
 	systemOpts := systemRootOrderedPublishOptions(db)
 	var nonSystemRetired []uint64
 	var nonSystemMetrics adaptive.Metrics
+	var touchedValueLogSegments []uint32
 	phaseStart := time.Now()
 	rootApplyResults, parallelRootApply := db.applyOrderedRootDeltaBatchGroupRoots(idx, ordered, rootTracker, rootTracker)
 	phaseStats.rootApplyNs += orderedRootDeltaGroupPhaseDurationNs(phaseStart)
@@ -2101,6 +2176,7 @@ func (db *DB) tryPublishOrderedRootDeltaBatchGroupOptimistic(ordered []OrderedRo
 		}
 		rootIDs[orderedIdx] = result.rootID
 		rootsObserved++
+		touchedValueLogSegments = appendOrderedRootDeltaBatchFinalTouchedValueLogSegments(ordered[orderedIdx].Delta, touchedValueLogSegments)
 		nonSystemRetired = append(nonSystemRetired, result.retired...)
 		mergeOrderedRootPublishMetrics(&nonSystemMetrics, result.metrics)
 		phaseStats.rootApplyMetrics.add(result.metrics)
@@ -2133,11 +2209,13 @@ func (db *DB) tryPublishOrderedRootDeltaBatchGroupOptimistic(ordered []OrderedRo
 		rootID, systemRetired, systemMetrics, applyErr := db.publishOrderedRootDeltaBatchWithAllocator(idx, systemBaseRoot, systemDelta, systemOpts, systemTracker, systemTracker, false)
 		phaseStats.systemApplyNs += orderedRootDeltaGroupPhaseDurationNs(phaseStart)
 		phaseStats.systemApplyCalls++
-		_ = systemDelta.Close()
 		if applyErr != nil {
+			_ = systemDelta.Close()
 			err = applyErr
 			return 0, nil, false, err
 		}
+		systemTouched := appendOrderedRootDeltaBatchFinalTouchedValueLogSegments(systemDelta, nil)
+		_ = systemDelta.Close()
 		phaseStats.systemApplyMetrics.add(systemMetrics)
 
 		lockStart := time.Now()
@@ -2171,6 +2249,8 @@ func (db *DB) tryPublishOrderedRootDeltaBatchGroupOptimistic(ordered []OrderedRo
 		merged := nonSystemMetrics
 		mergeOrderedRootPublishMetrics(&merged, systemMetrics)
 		newSystemRoot = rootID
+		commitTouchedValueLogSegments := append([]uint32(nil), touchedValueLogSegments...)
+		commitTouchedValueLogSegments = append(commitTouchedValueLogSegments, systemTouched...)
 
 		// Batch-based grouped deltas have the same value-log reachability shape as
 		// iterator-based grouped deltas: non-system roots changed, and the system
@@ -2180,7 +2260,7 @@ func (db *DB) tryPublishOrderedRootDeltaBatchGroupOptimistic(ordered []OrderedRo
 		phaseStart = time.Now()
 		var post finalizeCommitPost
 		commitStarted = true
-		post, err = db.finalizeCommitLocked(curUserRoot, newSystemRoot, retired, false, merged, nil, true, vlogRefDelta, nil, nil)
+		post, err = db.finalizeCommitLocked(curUserRoot, newSystemRoot, retired, false, merged, commitTouchedValueLogSegments, true, vlogRefDelta, nil, nil)
 		phaseStats.finalizeNs += orderedRootDeltaGroupPhaseDurationNs(phaseStart)
 		phaseStats.finalizeCalls++
 		hold := time.Since(holdStart)
@@ -2259,6 +2339,7 @@ func (db *DB) publishOrderedRootDeltaBatchGroupWithSystemDeltaBuilderSerialized(
 	systemOpts := systemRootOrderedPublishOptions(db)
 	var retired []uint64
 	var merged adaptive.Metrics
+	var touchedValueLogSegments []uint32
 	for idx := range ordered {
 		opts, err := db.orderedRootPublishOptionsForPolicy(ordered[idx].StoragePolicy)
 		if err != nil {
@@ -2271,6 +2352,7 @@ func (db *DB) publishOrderedRootDeltaBatchGroupWithSystemDeltaBuilderSerialized(
 		if err != nil {
 			return 0, nil, err
 		}
+		touchedValueLogSegments = appendOrderedRootDeltaBatchFinalTouchedValueLogSegments(ordered[idx].Delta, touchedValueLogSegments)
 		rootIDs[idx] = rootID
 		rootsObserved++
 		retired = append(retired, rootRetired...)
@@ -2291,12 +2373,13 @@ func (db *DB) publishOrderedRootDeltaBatchGroupWithSystemDeltaBuilderSerialized(
 		return 0, nil, errors.New("nil system root delta iterator")
 	}
 	phaseStart = time.Now()
-	rootID, rootRetired, metrics, err := db.publishOrderedRootDeltaIterator(baseSystemRoot, iter, systemOpts)
+	rootID, rootRetired, metrics, systemTouched, err := db.publishOrderedRootDeltaIterator(baseSystemRoot, iter, systemOpts)
 	phaseStats.systemApplyNs += orderedRootDeltaGroupPhaseDurationNs(phaseStart)
 	phaseStats.systemApplyCalls++
 	if err != nil {
 		return 0, nil, err
 	}
+	touchedValueLogSegments = append(touchedValueLogSegments, systemTouched...)
 	newSystemRoot = rootID
 	retired = append(retired, rootRetired...)
 	mergeOrderedRootPublishMetrics(&merged, metrics)
@@ -2316,7 +2399,7 @@ func (db *DB) publishOrderedRootDeltaBatchGroupWithSystemDeltaBuilderSerialized(
 	// conservative by invalidating it after commit.
 	var vlogRefDelta *valueLogRefDelta
 	phaseStart = time.Now()
-	err = db.finalizeOrderedRootPublishWithCommandWAL(userRoot, newSystemRoot, retired, false, merged, nil, true, vlogRefDelta, nil, nil, commandWALIntent)
+	err = db.finalizeOrderedRootPublishWithCommandWAL(userRoot, newSystemRoot, retired, false, merged, touchedValueLogSegments, true, vlogRefDelta, nil, nil, commandWALIntent)
 	phaseStats.finalizeNs += orderedRootDeltaGroupPhaseDurationNs(phaseStart)
 	phaseStats.finalizeCalls++
 	if err != nil {
@@ -2434,6 +2517,7 @@ func (db *DB) publishOrderedRootDeltaBatchGroupWithCommandWALContextAndSystemDel
 	systemOpts := systemRootOrderedPublishOptions(db)
 	var retired []uint64
 	var merged adaptive.Metrics
+	var touchedValueLogSegments []uint32
 	for idx := range allOrdered {
 		opts, err := db.orderedRootPublishOptionsForPolicy(allOrdered[idx].StoragePolicy)
 		if err != nil {
@@ -2446,6 +2530,7 @@ func (db *DB) publishOrderedRootDeltaBatchGroupWithCommandWALContextAndSystemDel
 		if err != nil {
 			return 0, nil, err
 		}
+		touchedValueLogSegments = appendOrderedRootDeltaBatchFinalTouchedValueLogSegments(allOrdered[idx].Delta, touchedValueLogSegments)
 		rootIDs[idx] = rootID
 		rootsObserved++
 		retired = append(retired, rootRetired...)
@@ -2467,12 +2552,13 @@ func (db *DB) publishOrderedRootDeltaBatchGroupWithCommandWALContextAndSystemDel
 		return 0, nil, err
 	}
 	phaseStart = time.Now()
-	rootID, rootRetired, metrics, err := db.publishOrderedRootDeltaIterator(baseSystemRoot, iter, systemOpts)
+	rootID, rootRetired, metrics, systemTouched, err := db.publishOrderedRootDeltaIterator(baseSystemRoot, iter, systemOpts)
 	phaseStats.systemApplyNs += orderedRootDeltaGroupPhaseDurationNs(phaseStart)
 	phaseStats.systemApplyCalls++
 	if err != nil {
 		return 0, nil, err
 	}
+	touchedValueLogSegments = append(touchedValueLogSegments, systemTouched...)
 	newSystemRoot = rootID
 	retired = append(retired, rootRetired...)
 	mergeOrderedRootPublishMetrics(&merged, metrics)
@@ -2489,7 +2575,7 @@ func (db *DB) publishOrderedRootDeltaBatchGroupWithCommandWALContextAndSystemDel
 
 	var vlogRefDelta *valueLogRefDelta
 	phaseStart = time.Now()
-	post, err := db.finalizeCommitLockedWithOptions(userRoot, newSystemRoot, retired, syncCommandWAL, merged, nil, true, vlogRefDelta, nil, nil, commandWALFinalizeOptionsForPublicIntent(commandWALIntent))
+	post, err := db.finalizeCommitLockedWithOptions(userRoot, newSystemRoot, retired, syncCommandWAL, merged, touchedValueLogSegments, true, vlogRefDelta, nil, nil, commandWALFinalizeOptionsForPublicIntent(commandWALIntent))
 	phaseStats.finalizeNs += orderedRootDeltaGroupPhaseDurationNs(phaseStart)
 	phaseStats.finalizeCalls++
 	if err != nil {

--- a/TreeDB/db/ordered_root_publish.go
+++ b/TreeDB/db/ordered_root_publish.go
@@ -537,11 +537,24 @@ func appendOrderedRootDeltaBatchFinalTouchedValueLogSegments(delta *batch.Batch,
 	if delta == nil {
 		return dst
 	}
+	var seen map[uint32]struct{}
 	for _, entry := range delta.SortedEntries() {
 		if entry.Type == batch.OpDelete || !entry.IsPtr || !page.IsValueLogFileID(entry.ValuePtr.FileID) {
 			continue
 		}
-		dst = appendTouchedValueLogSegmentID(dst, entry.ValuePtr.FileID)
+		if seen == nil {
+			seen = make(map[uint32]struct{}, len(dst)+1)
+			for _, existing := range dst {
+				if existing != 0 {
+					seen[existing] = struct{}{}
+				}
+			}
+		}
+		if _, ok := seen[entry.ValuePtr.FileID]; ok {
+			continue
+		}
+		seen[entry.ValuePtr.FileID] = struct{}{}
+		dst = append(dst, entry.ValuePtr.FileID)
 	}
 	return dst
 }

--- a/TreeDB/db/system_root_publish.go
+++ b/TreeDB/db/system_root_publish.go
@@ -96,6 +96,7 @@ func (db *DB) PublishSystemRootIterator(iter iterator.UnsafeIterator) (uint64, e
 		}
 		vlogRefDelta = nil
 	}
+	touchedValueLogSegments := positiveValueLogRefDeltaFileIDs(vlogRefDelta, nil)
 
 	db.mu.Lock()
 	curUserRoot := db.meta.UserRootPageID
@@ -105,7 +106,7 @@ func (db *DB) PublishSystemRootIterator(iter iterator.UnsafeIterator) (uint64, e
 		return 0, errors.New("concurrent modification detected during system root publish")
 	}
 
-	if err := db.finalizeCommit(userRoot, newSystemRoot, retired, false, metrics, nil, true, vlogRefDelta, nil, nil); err != nil {
+	if err := db.finalizeCommit(userRoot, newSystemRoot, retired, false, metrics, touchedValueLogSegments, true, vlogRefDelta, nil, nil); err != nil {
 		return 0, err
 	}
 	vlogRefDelta = nil

--- a/TreeDB/db/system_root_publish.go
+++ b/TreeDB/db/system_root_publish.go
@@ -90,13 +90,13 @@ func (db *DB) PublishSystemRootIterator(iter iterator.UnsafeIterator) (uint64, e
 	db.systemRootWarmPublishRebuildFallbacks.Add(publishStats.warmRebuildFallbacks)
 	db.systemRootWarmPreservedPages.Add(publishStats.warmPreservedPages)
 	db.systemRootWarmRewrittenPages.Add(publishStats.warmRewrittenPages)
+	touchedValueLogSegments := positiveValueLogRefDeltaFileIDs(vlogRefDelta, nil)
 	if publishStats.collectionRootDescriptorReachabilityMayChange() {
 		if vlogRefDelta != nil {
 			releaseValueLogRefDelta(vlogRefDelta)
 		}
 		vlogRefDelta = nil
 	}
-	touchedValueLogSegments := positiveValueLogRefDeltaFileIDs(vlogRefDelta, nil)
 
 	db.mu.Lock()
 	curUserRoot := db.meta.UserRootPageID

--- a/TreeDB/db/vacuum_collection_roots.go
+++ b/TreeDB/db/vacuum_collection_roots.go
@@ -40,6 +40,27 @@ type vacuumCollectionRootReplacement struct {
 
 type vacuumCollectionRootRewriteFunc func(vacuumCollectionRootDescriptor) (uint64, error)
 
+type collectionRootDescriptorShapeError struct {
+	key     []byte
+	length  int
+	overlay bool
+}
+
+func (e *collectionRootDescriptorShapeError) Error() string {
+	if e == nil {
+		return "vacuum: malformed collection root descriptor"
+	}
+	if e.overlay {
+		return fmt.Sprintf("vacuum: collection root overlay descriptor %q has malformed root id list length %d", string(e.key), e.length)
+	}
+	return fmt.Sprintf("vacuum: collection root descriptor %q has malformed root id length %d", string(e.key), e.length)
+}
+
+func isCollectionRootDescriptorShapeError(err error) bool {
+	var shapeErr *collectionRootDescriptorShapeError
+	return errors.As(err, &shapeErr)
+}
+
 type vacuumAllocator interface {
 	Alloc(hint uint64) (uint64, error)
 }
@@ -152,12 +173,12 @@ func decodeCollectionRootDescriptorRootIDs(key, val []byte, allowList bool) ([]u
 	}
 	if !allowList {
 		if len(val) != 8 {
-			return nil, fmt.Errorf("vacuum: collection root descriptor %q has malformed root id length %d", string(key), len(val))
+			return nil, &collectionRootDescriptorShapeError{key: append([]byte(nil), key...), length: len(val)}
 		}
 		return []uint64{binary.BigEndian.Uint64(val)}, nil
 	}
 	if len(val)%8 != 0 {
-		return nil, fmt.Errorf("vacuum: collection root overlay descriptor %q has malformed root id list length %d", string(key), len(val))
+		return nil, &collectionRootDescriptorShapeError{key: append([]byte(nil), key...), length: len(val), overlay: true}
 	}
 	out := make([]uint64, len(val)/8)
 	for i := range out {

--- a/TreeDB/db/vacuum_online.go
+++ b/TreeDB/db/vacuum_online.go
@@ -453,6 +453,22 @@ func (db *DB) vacuumIndexOnline(ctx context.Context, lockMaintenance bool) error
 				return err
 			}
 		}
+		var stagedLeafGenerationView *leafGenerationView
+		leafGenerationChanged := false
+		if db.indexOuterLeavesInValueLog && db.leafPageLog != nil {
+			db.mu.RLock()
+			stagedLeafManifest, changed, err := db.stagedLeafGenerationManifestWithPending(db.leafGenerationManifest, 0, nextMeta.CommitSeq)
+			db.mu.RUnlock()
+			if err != nil {
+				db.writeMu.Unlock()
+				cleanupNewPager()
+				return err
+			}
+			if changed {
+				stagedLeafGenerationView = newLeafGenerationView(stagedLeafManifest)
+				leafGenerationChanged = true
+			}
+		}
 
 		// Write redundant Meta pages (0/1) to the new file and sync it.
 		if err := writeMetaToPager(newPager, MetaPage0ID, nextMeta); err != nil {
@@ -536,14 +552,22 @@ func (db *DB) vacuumIndexOnline(ctx context.Context, lockMaintenance bool) error
 			}
 			valueLogSet = db.valueLogManager.CurrentSetNoRefresh()
 		}
+		leafGenerationView := oldState.LeafGenerations
+		if leafGenerationChanged {
+			leafGenerationView = stagedLeafGenerationView
+		}
 		newState := &DBState{
 			CommitSeq:                  nextMeta.CommitSeq,
 			RootPageID:                 nextMeta.UserRootPageID,
 			SystemRootPageID:           nextMeta.SystemRootPageID,
 			AppliedCommandLSN:          nextMeta.AppliedCommandLSN,
 			ValueLogSet:                valueLogSet,
-			LeafGenerations:            oldState.LeafGenerations,
+			LeafGenerations:            leafGenerationView,
 			LeafGenerationStateVersion: oldState.LeafGenerationStateVersion,
+		}
+		if leafGenerationChanged {
+			db.leafGenerationStateVersion++
+			newState.LeafGenerationStateVersion = db.leafGenerationStateVersion
 		}
 		db.state.Store(newState)
 		db.publishSnapshotView(newGen, newState, db.valueLogManager)
@@ -554,6 +578,15 @@ func (db *DB) vacuumIndexOnline(ctx context.Context, lockMaintenance bool) error
 
 		if oldState != nil {
 			_ = db.valueLogManager.Release(oldState.ValueLogSet)
+		}
+		if db.leafPageLog != nil {
+			db.commitMu.Lock()
+			currentCommitSeq := db.meta.CommitSeq
+			err := db.noteLeafGenerationPendingFileIDs(0, currentCommitSeq)
+			db.commitMu.Unlock()
+			if err != nil {
+				db.reportError(err)
+			}
 		}
 
 		// Drop the DB-held reference to the previous generation outside the

--- a/TreeDB/db/vacuum_online.go
+++ b/TreeDB/db/vacuum_online.go
@@ -446,7 +446,7 @@ func (db *DB) vacuumIndexOnline(ctx context.Context, lockMaintenance bool) error
 		leafPageLogSegmentsRegistered := true
 		if db.indexOuterLeavesInValueLog && db.leafPageLog != nil {
 			var err error
-			leafPageLogSegmentsRegistered, err = db.registerLeafPageLogSegmentsForPublish(nextMeta.CommitSeq)
+			leafPageLogSegmentsRegistered, err = db.registerLeafPageLogSegmentsForPublish()
 			if err != nil {
 				db.writeMu.Unlock()
 				cleanupNewPager()

--- a/TreeDB/db/vacuum_online_swap_test.go
+++ b/TreeDB/db/vacuum_online_swap_test.go
@@ -532,3 +532,53 @@ func TestVacuumIndexOnline_PreservesOuterLeafRefsAndDataWhenOuterLeavesInValueLo
 		}
 	}
 }
+
+func TestVacuumIndexOnline_StampsPendingLeafGenerationSegments(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("online vacuum not supported on windows")
+	}
+	db, leafLog := openLeafGenerationGCTestDB(t)
+
+	writeLeafGenerationKeys(t, db, "vacuum-pending", 64, 'a')
+	if _, fileID1 := currentLeafSegmentOrFatal(t, leafLog); fileID1 == 0 {
+		t.Fatal("missing initial leaf segment")
+	}
+	if err := leafLog.rotateLeaf(); err != nil {
+		t.Fatalf("rotateLeaf: %v", err)
+	}
+	_, fileID2 := currentLeafSegmentOrFatal(t, leafLog)
+	rawFileID2 := page.ValueLogSegmentID(fileID2)
+
+	stateBefore := db.State()
+	if stateBefore == nil || stateBefore.LeafGenerations == nil {
+		t.Fatalf("missing leaf generations before vacuum")
+	}
+	if _, ok := stateBefore.LeafGenerations.FileToGeneration[rawFileID2]; ok {
+		t.Fatalf("pending raw file %d visible before vacuum", rawFileID2)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if err := db.VacuumIndexOnline(ctx); err != nil {
+		t.Fatalf("vacuum: %v", err)
+	}
+
+	stateAfter := db.State()
+	if stateAfter == nil || stateAfter.LeafGenerations == nil {
+		t.Fatalf("missing leaf generations after vacuum")
+	}
+	if _, ok := stateAfter.LeafGenerations.FileToGeneration[rawFileID2]; !ok {
+		t.Fatalf("pending raw file %d missing from published leaf-generation view", rawFileID2)
+	}
+	manifestAfter := loadLeafGenerationManifestOrFatal(t, db.dir)
+	gen2 := findLeafGenerationByFileID(t, manifestAfter, rawFileID2)
+	if got, want := gen2.PublishedCommitSeq, stateAfter.CommitSeq; got != want {
+		t.Fatalf("published commit seq=%d, want vacuum commit seq %d", got, want)
+	}
+	db.leafGenerationPendingMu.Lock()
+	_, pending := db.leafGenerationPendingSet[rawFileID2]
+	db.leafGenerationPendingMu.Unlock()
+	if pending {
+		t.Fatalf("raw file %d still pending after vacuum publish", rawFileID2)
+	}
+}

--- a/TreeDB/db/vlog_gc_incremental.go
+++ b/TreeDB/db/vlog_gc_incremental.go
@@ -458,6 +458,7 @@ func (db *DB) scanValueLogRefCounts(ctx context.Context) (map[uint32]uint64, uin
 		_ = snap.Close()
 		return nil, 0, err
 	}
+	roots = dedupeMaintenanceRootsByRootID(roots)
 	for _, root := range roots {
 		iter := scanValueLogRefCountRootIterator(snap, root)
 		if err := collectValueLogRefCounts(ctx, db, iter, counts); err != nil {

--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -192,6 +192,9 @@ type ValueLogRewriteOnlineOptions struct {
 	// LeafGenerationProtectedRootIDs are additional roots to preserve if rewrite
 	// cleanup runs leaf-generation GC after publishing rewritten value pointers.
 	LeafGenerationProtectedRootIDs []uint64
+	// LeafGenerationProtectedSystemRootIDs are system roots whose collection
+	// descriptors should be expanded if rewrite cleanup runs leaf-generation GC.
+	LeafGenerationProtectedSystemRootIDs []uint64
 	// MaxSourceSegments bounds the number of source segments selected by sparse
 	// segment selection. Applies only when SourceFileIDs is empty.
 	MaxSourceSegments int
@@ -2186,7 +2189,8 @@ func (db *DB) valueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 	}
 	if db.indexOuterLeavesInValueLog && stats.RecordsCopied > 0 {
 		if _, err := db.leafGenerationGC(context.WithoutCancel(ctx), LeafGenerationGCOptions{
-			ProtectedRootIDs: db.valueLogRewriteLeafGenerationProtectedRootIDs(opts),
+			ProtectedRootIDs:       db.valueLogRewriteLeafGenerationProtectedRootIDs(opts),
+			ProtectedSystemRootIDs: db.valueLogRewriteLeafGenerationProtectedSystemRootIDs(opts),
 		}, false); err != nil {
 			return stats, err
 		}
@@ -2212,6 +2216,13 @@ func (db *DB) valueLogRewriteLeafGenerationProtectedRootIDs(opts ValueLogRewrite
 	var out []uint64
 	out = appendCompactStorageProtectedRootIDs(out, opts.LeafGenerationProtectedRootIDs)
 	out = appendCompactStorageProtectedRootIDs(out, db.protectedLeafGenerationRootIDsFromLeafPageLog())
+	return out
+}
+
+func (db *DB) valueLogRewriteLeafGenerationProtectedSystemRootIDs(opts ValueLogRewriteOnlineOptions) []uint64 {
+	var out []uint64
+	out = appendCompactStorageProtectedRootIDs(out, opts.LeafGenerationProtectedSystemRootIDs)
+	out = appendCompactStorageProtectedRootIDs(out, db.protectedLeafGenerationSystemRootIDsFromLeafPageLog())
 	return out
 }
 

--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -558,10 +558,7 @@ func trainRewriteLeafDictFromLiveLeafRefs(d *DB, state *DBState, cfg compression
 	if len(maintenanceRoots) == 0 {
 		return nil, nil
 	}
-	roots := make([]uint64, 0, len(maintenanceRoots))
-	for _, root := range maintenanceRoots {
-		roots = append(roots, root.rootID)
-	}
+	roots := maintenanceRootIDs(maintenanceRoots)
 	targetBytes := rewriteLeafDictTrainBytes(cfg)
 	minRecords := rewriteLeafDictMinRecords(cfg)
 	if targetBytes <= 0 || minRecords <= 0 {
@@ -1159,6 +1156,7 @@ func (db *DB) estimateValueLogLiveBytesBySegment(ctx context.Context) (_ map[uin
 		if err != nil {
 			return nil, err
 		}
+		roots = dedupeMaintenanceRootsByRootID(roots)
 		for _, root := range roots {
 			iter := tree.New(snap.idx.pager, &snap.reader, root.rootID).
 				IteratorWithOptions(nil, nil, tree.IteratorOptions{Mode: tree.IteratorModePointerProjection})

--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -189,6 +189,9 @@ type ValueLogRewriteOnlineOptions struct {
 	// because concurrent writers may still be appending records whose pointers
 	// are not yet visible in the backend index.
 	ProtectedPaths []string
+	// LeafGenerationProtectedRootIDs are additional roots to preserve if rewrite
+	// cleanup runs leaf-generation GC after publishing rewritten value pointers.
+	LeafGenerationProtectedRootIDs []uint64
 	// MaxSourceSegments bounds the number of source segments selected by sparse
 	// segment selection. Applies only when SourceFileIDs is empty.
 	MaxSourceSegments int
@@ -2182,7 +2185,9 @@ func (db *DB) valueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 		return stats, err
 	}
 	if db.indexOuterLeavesInValueLog && stats.RecordsCopied > 0 {
-		if _, err := db.leafGenerationGC(context.WithoutCancel(ctx), LeafGenerationGCOptions{}, false); err != nil {
+		if _, err := db.leafGenerationGC(context.WithoutCancel(ctx), LeafGenerationGCOptions{
+			ProtectedRootIDs: db.valueLogRewriteLeafGenerationProtectedRootIDs(opts),
+		}, false); err != nil {
 			return stats, err
 		}
 	}
@@ -2201,6 +2206,13 @@ func (db *DB) valueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 		return stats, canceledErr
 	}
 	return stats, nil
+}
+
+func (db *DB) valueLogRewriteLeafGenerationProtectedRootIDs(opts ValueLogRewriteOnlineOptions) []uint64 {
+	var out []uint64
+	out = appendCompactStorageProtectedRootIDs(out, opts.LeafGenerationProtectedRootIDs)
+	out = appendCompactStorageProtectedRootIDs(out, db.protectedLeafGenerationRootIDsFromLeafPageLog())
+	return out
 }
 
 func nextRewriteRIDStart(segments []logSegment) (uint64, error) {
@@ -3358,6 +3370,7 @@ type rewriteWriter struct {
 	records                   int
 	createdIDs                []uint32
 	createdSegments           []rewriteCreatedSegment
+	createdSegmentsPublishIdx int
 
 	pendingBlockStart   int64
 	pendingBlockRaw     int
@@ -4488,6 +4501,50 @@ func (w *rewriteWriter) createdSegmentsSnapshot() ([]rewriteCreatedSegment, erro
 		return nil, nil
 	}
 	return append([]rewriteCreatedSegment(nil), w.createdSegments...), nil
+}
+
+func (w *rewriteWriter) CreatedLeafPageLogSegmentsSnapshot() ([]LeafPageLogSegment, error) {
+	if w != nil {
+		if err := w.flushPendingBatches(); err != nil {
+			return nil, err
+		}
+	}
+	if w == nil || w.createdSegmentsPublishIdx >= len(w.createdSegments) {
+		return nil, nil
+	}
+	created := w.createdSegments[w.createdSegmentsPublishIdx:]
+	out := make([]LeafPageLogSegment, 0, len(created))
+	for _, seg := range created {
+		if seg.path == "" || seg.fileID == 0 {
+			continue
+		}
+		out = append(out, LeafPageLogSegment{Path: seg.path, FileID: seg.fileID})
+	}
+	return out, nil
+}
+
+func (w *rewriteWriter) MarkLeafPageLogSegmentsRegistered(segments []LeafPageLogSegment) {
+	if w == nil || len(segments) == 0 || w.createdSegmentsPublishIdx >= len(w.createdSegments) {
+		return
+	}
+	registered := make(map[uint32]struct{}, len(segments))
+	for _, seg := range segments {
+		if seg.FileID == 0 {
+			continue
+		}
+		registered[seg.FileID] = struct{}{}
+	}
+	if len(registered) == 0 {
+		return
+	}
+	idx := w.createdSegmentsPublishIdx
+	for idx < len(w.createdSegments) {
+		if _, ok := registered[w.createdSegments[idx].fileID]; !ok {
+			break
+		}
+		idx++
+	}
+	w.createdSegmentsPublishIdx = idx
 }
 
 type rewriteIterator struct {

--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -2549,10 +2549,11 @@ func (db *DB) applyRewriteSwapBatchToCollectionRoot(target *collectionRewriteRoo
 	systemDelta.Freeze()
 	systemIter := systemDelta.NewIterator(nil, nil)
 	systemOpts := systemRootOrderedPublishOptions(db)
-	newSystemRoot, systemRetired, systemMetrics, err := db.publishOrderedRootDeltaIterator(systemRoot, systemIter, systemOpts)
+	newSystemRoot, systemRetired, systemMetrics, systemTouched, err := db.publishOrderedRootDeltaIterator(systemRoot, systemIter, systemOpts)
 	if err != nil {
 		return err
 	}
+	touched = append(touched, systemTouched...)
 	retired = append(retired, systemRetired...)
 	mergeOrderedRootPublishMetrics(&metrics, systemMetrics)
 	forceValueLogRefresh := rootOpts.outerLeavesInValueLog || systemOpts.outerLeavesInValueLog

--- a/TreeDB/db/vlog_rewrite_chunk_plan.go
+++ b/TreeDB/db/vlog_rewrite_chunk_plan.go
@@ -158,6 +158,7 @@ func (db *DB) estimateValueLogLiveBytesByChunk(ctx context.Context, chunkBytes i
 		if err != nil {
 			return nil, err
 		}
+		roots = dedupeMaintenanceRootsByRootID(roots)
 		for _, root := range roots {
 			iter := tree.New(snap.idx.pager, &snap.reader, root.rootID).
 				IteratorWithOptions(nil, nil, tree.IteratorOptions{Mode: tree.IteratorModePointerProjection})

--- a/TreeDB/leaf_generation_gc.go
+++ b/TreeDB/leaf_generation_gc.go
@@ -9,7 +9,8 @@ import (
 // LeafGenerationGCOptions controls whole-generation leaf-log garbage
 // collection.
 type LeafGenerationGCOptions struct {
-	DryRun bool
+	DryRun           bool
+	ProtectedRootIDs []uint64
 }
 
 // LeafGenerationGCStats summarizes whole-generation leaf-log GC work.
@@ -43,10 +44,12 @@ func (db *DB) LeafGenerationGC(ctx context.Context, opts LeafGenerationGCOptions
 		if err := db.Checkpoint(); err != nil {
 			return out, err
 		}
+		opts.ProtectedRootIDs = appendCompactStorageProtectedRootIDs(opts.ProtectedRootIDs, db.cached.ProtectedLeafGenerationRootIDs())
 	}
 
 	stats, err := db.backend.LeafGenerationGC(ctx, treedbdb.LeafGenerationGCOptions{
-		DryRun: opts.DryRun,
+		DryRun:           opts.DryRun,
+		ProtectedRootIDs: opts.ProtectedRootIDs,
 	})
 	if err != nil {
 		return out, err

--- a/TreeDB/leaf_generation_gc.go
+++ b/TreeDB/leaf_generation_gc.go
@@ -44,7 +44,7 @@ func (db *DB) LeafGenerationGC(ctx context.Context, opts LeafGenerationGCOptions
 		if err := db.Checkpoint(); err != nil {
 			return out, err
 		}
-		opts.ProtectedRootIDs = appendCompactStorageProtectedRootIDs(opts.ProtectedRootIDs, db.cached.ProtectedLeafGenerationRootIDs())
+		opts.ProtectedRootIDs = mergeCompactStorageProtectedRootIDs(opts.ProtectedRootIDs, db.cached.ProtectedLeafGenerationRootIDs())
 	}
 
 	stats, err := db.backend.LeafGenerationGC(ctx, treedbdb.LeafGenerationGCOptions{

--- a/TreeDB/leaf_generation_gc.go
+++ b/TreeDB/leaf_generation_gc.go
@@ -9,8 +9,9 @@ import (
 // LeafGenerationGCOptions controls whole-generation leaf-log garbage
 // collection.
 type LeafGenerationGCOptions struct {
-	DryRun           bool
-	ProtectedRootIDs []uint64
+	DryRun                 bool
+	ProtectedRootIDs       []uint64
+	ProtectedSystemRootIDs []uint64
 }
 
 // LeafGenerationGCStats summarizes whole-generation leaf-log GC work.
@@ -45,11 +46,13 @@ func (db *DB) LeafGenerationGC(ctx context.Context, opts LeafGenerationGCOptions
 			return out, err
 		}
 		opts.ProtectedRootIDs = mergeCompactStorageProtectedRootIDs(opts.ProtectedRootIDs, db.cached.ProtectedLeafGenerationRootIDs())
+		opts.ProtectedSystemRootIDs = mergeCompactStorageProtectedRootIDs(opts.ProtectedSystemRootIDs, db.cached.ProtectedLeafGenerationSystemRootIDs())
 	}
 
 	stats, err := db.backend.LeafGenerationGC(ctx, treedbdb.LeafGenerationGCOptions{
-		DryRun:           opts.DryRun,
-		ProtectedRootIDs: opts.ProtectedRootIDs,
+		DryRun:                 opts.DryRun,
+		ProtectedRootIDs:       opts.ProtectedRootIDs,
+		ProtectedSystemRootIDs: opts.ProtectedSystemRootIDs,
 	})
 	if err != nil {
 		return out, err

--- a/TreeDB/leaf_generation_gc.go
+++ b/TreeDB/leaf_generation_gc.go
@@ -45,8 +45,9 @@ func (db *DB) LeafGenerationGC(ctx context.Context, opts LeafGenerationGCOptions
 		if err := db.Checkpoint(); err != nil {
 			return out, err
 		}
-		opts.ProtectedRootIDs = mergeCompactStorageProtectedRootIDs(opts.ProtectedRootIDs, db.cached.ProtectedLeafGenerationRootIDs())
-		opts.ProtectedSystemRootIDs = mergeCompactStorageProtectedRootIDs(opts.ProtectedSystemRootIDs, db.cached.ProtectedLeafGenerationSystemRootIDs())
+		protectedRootIDs, protectedSystemRootIDs := db.cached.ProtectedLeafGenerationRootIDPair()
+		opts.ProtectedRootIDs = mergeCompactStorageProtectedRootIDs(opts.ProtectedRootIDs, protectedRootIDs)
+		opts.ProtectedSystemRootIDs = mergeCompactStorageProtectedRootIDs(opts.ProtectedSystemRootIDs, protectedSystemRootIDs)
 	}
 
 	stats, err := db.backend.LeafGenerationGC(ctx, treedbdb.LeafGenerationGCOptions{

--- a/TreeDB/leaf_generation_pack.go
+++ b/TreeDB/leaf_generation_pack.go
@@ -34,7 +34,7 @@ func (db *DB) LeafGenerationPack(ctx context.Context, opts LeafGenerationPackOpt
 		if err := db.Checkpoint(); err != nil {
 			return out, err
 		}
-		opts.ProtectedRootIDs = appendCompactStorageProtectedRootIDs(opts.ProtectedRootIDs, db.cached.ProtectedLeafGenerationRootIDs())
+		opts.ProtectedRootIDs = mergeCompactStorageProtectedRootIDs(opts.ProtectedRootIDs, db.cached.ProtectedLeafGenerationRootIDs())
 	}
 	stats, err := db.backend.LeafGenerationPack(ctx, treedbdb.LeafGenerationPackOptions(opts))
 	if err = db.reconcileCachedBackendMaintenance(err); err != nil {

--- a/TreeDB/leaf_generation_pack.go
+++ b/TreeDB/leaf_generation_pack.go
@@ -34,8 +34,9 @@ func (db *DB) LeafGenerationPack(ctx context.Context, opts LeafGenerationPackOpt
 		if err := db.Checkpoint(); err != nil {
 			return out, err
 		}
-		opts.ProtectedRootIDs = mergeCompactStorageProtectedRootIDs(opts.ProtectedRootIDs, db.cached.ProtectedLeafGenerationRootIDs())
-		opts.ProtectedSystemRootIDs = mergeCompactStorageProtectedRootIDs(opts.ProtectedSystemRootIDs, db.cached.ProtectedLeafGenerationSystemRootIDs())
+		protectedRootIDs, protectedSystemRootIDs := db.cached.ProtectedLeafGenerationRootIDPair()
+		opts.ProtectedRootIDs = mergeCompactStorageProtectedRootIDs(opts.ProtectedRootIDs, protectedRootIDs)
+		opts.ProtectedSystemRootIDs = mergeCompactStorageProtectedRootIDs(opts.ProtectedSystemRootIDs, protectedSystemRootIDs)
 	}
 	stats, err := db.backend.LeafGenerationPack(ctx, treedbdb.LeafGenerationPackOptions(opts))
 	if err = db.reconcileCachedBackendMaintenance(err); err != nil {

--- a/TreeDB/leaf_generation_pack.go
+++ b/TreeDB/leaf_generation_pack.go
@@ -34,6 +34,7 @@ func (db *DB) LeafGenerationPack(ctx context.Context, opts LeafGenerationPackOpt
 		if err := db.Checkpoint(); err != nil {
 			return out, err
 		}
+		opts.ProtectedRootIDs = appendCompactStorageProtectedRootIDs(opts.ProtectedRootIDs, db.cached.ProtectedLeafGenerationRootIDs())
 	}
 	stats, err := db.backend.LeafGenerationPack(ctx, treedbdb.LeafGenerationPackOptions(opts))
 	if err = db.reconcileCachedBackendMaintenance(err); err != nil {

--- a/TreeDB/leaf_generation_pack.go
+++ b/TreeDB/leaf_generation_pack.go
@@ -35,6 +35,7 @@ func (db *DB) LeafGenerationPack(ctx context.Context, opts LeafGenerationPackOpt
 			return out, err
 		}
 		opts.ProtectedRootIDs = mergeCompactStorageProtectedRootIDs(opts.ProtectedRootIDs, db.cached.ProtectedLeafGenerationRootIDs())
+		opts.ProtectedSystemRootIDs = mergeCompactStorageProtectedRootIDs(opts.ProtectedSystemRootIDs, db.cached.ProtectedLeafGenerationSystemRootIDs())
 	}
 	stats, err := db.backend.LeafGenerationPack(ctx, treedbdb.LeafGenerationPackOptions(opts))
 	if err = db.reconcileCachedBackendMaintenance(err); err != nil {

--- a/TreeDB/leaf_generation_pack_from_plan.go
+++ b/TreeDB/leaf_generation_pack_from_plan.go
@@ -31,7 +31,7 @@ func (db *DB) LeafGenerationPackFromPlan(ctx context.Context, opts LeafGeneratio
 		if err := db.Checkpoint(); err != nil {
 			return out, err
 		}
-		opts.ProtectedRootIDs = appendCompactStorageProtectedRootIDs(opts.ProtectedRootIDs, db.cached.ProtectedLeafGenerationRootIDs())
+		opts.ProtectedRootIDs = mergeCompactStorageProtectedRootIDs(opts.ProtectedRootIDs, db.cached.ProtectedLeafGenerationRootIDs())
 		if opts.ReserveRIDs == nil {
 			opts.ReserveRIDs = db.cached.ReserveValueLogRIDs
 		}

--- a/TreeDB/leaf_generation_pack_from_plan.go
+++ b/TreeDB/leaf_generation_pack_from_plan.go
@@ -32,6 +32,7 @@ func (db *DB) LeafGenerationPackFromPlan(ctx context.Context, opts LeafGeneratio
 			return out, err
 		}
 		opts.ProtectedRootIDs = mergeCompactStorageProtectedRootIDs(opts.ProtectedRootIDs, db.cached.ProtectedLeafGenerationRootIDs())
+		opts.ProtectedSystemRootIDs = mergeCompactStorageProtectedRootIDs(opts.ProtectedSystemRootIDs, db.cached.ProtectedLeafGenerationSystemRootIDs())
 		if opts.ReserveRIDs == nil {
 			opts.ReserveRIDs = db.cached.ReserveValueLogRIDs
 		}

--- a/TreeDB/leaf_generation_pack_from_plan.go
+++ b/TreeDB/leaf_generation_pack_from_plan.go
@@ -31,6 +31,7 @@ func (db *DB) LeafGenerationPackFromPlan(ctx context.Context, opts LeafGeneratio
 		if err := db.Checkpoint(); err != nil {
 			return out, err
 		}
+		opts.ProtectedRootIDs = appendCompactStorageProtectedRootIDs(opts.ProtectedRootIDs, db.cached.ProtectedLeafGenerationRootIDs())
 		if opts.ReserveRIDs == nil {
 			opts.ReserveRIDs = db.cached.ReserveValueLogRIDs
 		}

--- a/TreeDB/leaf_generation_pack_from_plan.go
+++ b/TreeDB/leaf_generation_pack_from_plan.go
@@ -31,8 +31,9 @@ func (db *DB) LeafGenerationPackFromPlan(ctx context.Context, opts LeafGeneratio
 		if err := db.Checkpoint(); err != nil {
 			return out, err
 		}
-		opts.ProtectedRootIDs = mergeCompactStorageProtectedRootIDs(opts.ProtectedRootIDs, db.cached.ProtectedLeafGenerationRootIDs())
-		opts.ProtectedSystemRootIDs = mergeCompactStorageProtectedRootIDs(opts.ProtectedSystemRootIDs, db.cached.ProtectedLeafGenerationSystemRootIDs())
+		protectedRootIDs, protectedSystemRootIDs := db.cached.ProtectedLeafGenerationRootIDPair()
+		opts.ProtectedRootIDs = mergeCompactStorageProtectedRootIDs(opts.ProtectedRootIDs, protectedRootIDs)
+		opts.ProtectedSystemRootIDs = mergeCompactStorageProtectedRootIDs(opts.ProtectedSystemRootIDs, protectedSystemRootIDs)
 		if opts.ReserveRIDs == nil {
 			opts.ReserveRIDs = db.cached.ReserveValueLogRIDs
 		}

--- a/TreeDB/leaf_generation_pack_run_once.go
+++ b/TreeDB/leaf_generation_pack_run_once.go
@@ -31,13 +31,13 @@ func (db *DB) LeafGenerationPackRunOnce(ctx context.Context, opts LeafGeneration
 		if err := db.Checkpoint(); err != nil {
 			return out, err
 		}
-		opts.ProtectedRootIDs = appendCompactStorageProtectedRootIDs(opts.ProtectedRootIDs, db.cached.ProtectedLeafGenerationRootIDs())
+		opts.ProtectedRootIDs = mergeCompactStorageProtectedRootIDs(opts.ProtectedRootIDs, db.cached.ProtectedLeafGenerationRootIDs())
 		if opts.ReserveRIDs == nil {
 			opts.ReserveRIDs = db.cached.ReserveValueLogRIDs
 		}
 	}
 	stats, err := db.backend.LeafGenerationPackRunOnce(ctx, treedbdb.LeafGenerationPackFromPlanOptions(opts))
-	if err != nil {
+	if err = db.reconcileCachedBackendMaintenance(err); err != nil {
 		return out, err
 	}
 	success = true

--- a/TreeDB/leaf_generation_pack_run_once.go
+++ b/TreeDB/leaf_generation_pack_run_once.go
@@ -31,6 +31,7 @@ func (db *DB) LeafGenerationPackRunOnce(ctx context.Context, opts LeafGeneration
 		if err := db.Checkpoint(); err != nil {
 			return out, err
 		}
+		opts.ProtectedRootIDs = appendCompactStorageProtectedRootIDs(opts.ProtectedRootIDs, db.cached.ProtectedLeafGenerationRootIDs())
 		if opts.ReserveRIDs == nil {
 			opts.ReserveRIDs = db.cached.ReserveValueLogRIDs
 		}

--- a/TreeDB/leaf_generation_pack_run_once.go
+++ b/TreeDB/leaf_generation_pack_run_once.go
@@ -31,8 +31,9 @@ func (db *DB) LeafGenerationPackRunOnce(ctx context.Context, opts LeafGeneration
 		if err := db.Checkpoint(); err != nil {
 			return out, err
 		}
-		opts.ProtectedRootIDs = mergeCompactStorageProtectedRootIDs(opts.ProtectedRootIDs, db.cached.ProtectedLeafGenerationRootIDs())
-		opts.ProtectedSystemRootIDs = mergeCompactStorageProtectedRootIDs(opts.ProtectedSystemRootIDs, db.cached.ProtectedLeafGenerationSystemRootIDs())
+		protectedRootIDs, protectedSystemRootIDs := db.cached.ProtectedLeafGenerationRootIDPair()
+		opts.ProtectedRootIDs = mergeCompactStorageProtectedRootIDs(opts.ProtectedRootIDs, protectedRootIDs)
+		opts.ProtectedSystemRootIDs = mergeCompactStorageProtectedRootIDs(opts.ProtectedSystemRootIDs, protectedSystemRootIDs)
 		if opts.ReserveRIDs == nil {
 			opts.ReserveRIDs = db.cached.ReserveValueLogRIDs
 		}

--- a/TreeDB/leaf_generation_pack_run_once.go
+++ b/TreeDB/leaf_generation_pack_run_once.go
@@ -32,6 +32,7 @@ func (db *DB) LeafGenerationPackRunOnce(ctx context.Context, opts LeafGeneration
 			return out, err
 		}
 		opts.ProtectedRootIDs = mergeCompactStorageProtectedRootIDs(opts.ProtectedRootIDs, db.cached.ProtectedLeafGenerationRootIDs())
+		opts.ProtectedSystemRootIDs = mergeCompactStorageProtectedRootIDs(opts.ProtectedSystemRootIDs, db.cached.ProtectedLeafGenerationSystemRootIDs())
 		if opts.ReserveRIDs == nil {
 			opts.ReserveRIDs = db.cached.ReserveValueLogRIDs
 		}

--- a/TreeDB/leaf_generation_plan.go
+++ b/TreeDB/leaf_generation_plan.go
@@ -37,7 +37,7 @@ func (db *DB) LeafGenerationPlan(ctx context.Context, opts LeafGenerationPlanOpt
 		if err := db.Checkpoint(); err != nil {
 			return out, err
 		}
-		opts.ProtectedRootIDs = appendCompactStorageProtectedRootIDs(opts.ProtectedRootIDs, db.cached.ProtectedLeafGenerationRootIDs())
+		opts.ProtectedRootIDs = mergeCompactStorageProtectedRootIDs(opts.ProtectedRootIDs, db.cached.ProtectedLeafGenerationRootIDs())
 	}
 	plan, err := db.backend.LeafGenerationPlan(ctx, treedbdb.LeafGenerationPlanOptions(opts))
 	if err != nil {

--- a/TreeDB/leaf_generation_plan.go
+++ b/TreeDB/leaf_generation_plan.go
@@ -37,8 +37,9 @@ func (db *DB) LeafGenerationPlan(ctx context.Context, opts LeafGenerationPlanOpt
 		if err := db.Checkpoint(); err != nil {
 			return out, err
 		}
-		opts.ProtectedRootIDs = mergeCompactStorageProtectedRootIDs(opts.ProtectedRootIDs, db.cached.ProtectedLeafGenerationRootIDs())
-		opts.ProtectedSystemRootIDs = mergeCompactStorageProtectedRootIDs(opts.ProtectedSystemRootIDs, db.cached.ProtectedLeafGenerationSystemRootIDs())
+		protectedRootIDs, protectedSystemRootIDs := db.cached.ProtectedLeafGenerationRootIDPair()
+		opts.ProtectedRootIDs = mergeCompactStorageProtectedRootIDs(opts.ProtectedRootIDs, protectedRootIDs)
+		opts.ProtectedSystemRootIDs = mergeCompactStorageProtectedRootIDs(opts.ProtectedSystemRootIDs, protectedSystemRootIDs)
 	}
 	plan, err := db.backend.LeafGenerationPlan(ctx, treedbdb.LeafGenerationPlanOptions(opts))
 	if err != nil {

--- a/TreeDB/leaf_generation_plan.go
+++ b/TreeDB/leaf_generation_plan.go
@@ -38,6 +38,7 @@ func (db *DB) LeafGenerationPlan(ctx context.Context, opts LeafGenerationPlanOpt
 			return out, err
 		}
 		opts.ProtectedRootIDs = mergeCompactStorageProtectedRootIDs(opts.ProtectedRootIDs, db.cached.ProtectedLeafGenerationRootIDs())
+		opts.ProtectedSystemRootIDs = mergeCompactStorageProtectedRootIDs(opts.ProtectedSystemRootIDs, db.cached.ProtectedLeafGenerationSystemRootIDs())
 	}
 	plan, err := db.backend.LeafGenerationPlan(ctx, treedbdb.LeafGenerationPlanOptions(opts))
 	if err != nil {

--- a/TreeDB/leaf_generation_plan.go
+++ b/TreeDB/leaf_generation_plan.go
@@ -37,6 +37,7 @@ func (db *DB) LeafGenerationPlan(ctx context.Context, opts LeafGenerationPlanOpt
 		if err := db.Checkpoint(); err != nil {
 			return out, err
 		}
+		opts.ProtectedRootIDs = appendCompactStorageProtectedRootIDs(opts.ProtectedRootIDs, db.cached.ProtectedLeafGenerationRootIDs())
 	}
 	plan, err := db.backend.LeafGenerationPlan(ctx, treedbdb.LeafGenerationPlanOptions(opts))
 	if err != nil {

--- a/TreeDB/vlog_rewrite.go
+++ b/TreeDB/vlog_rewrite.go
@@ -94,6 +94,7 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 				backendOpts.ProtectedPaths = []string{""}
 			}
 		}
+		backendOpts.LeafGenerationProtectedRootIDs = appendCompactStorageProtectedRootIDs(backendOpts.LeafGenerationProtectedRootIDs, db.cached.ProtectedLeafGenerationRootIDs())
 		if backendOpts.ReserveRIDs == nil {
 			backendOpts.ReserveRIDs = db.cached.ReserveValueLogRIDs
 		}

--- a/TreeDB/vlog_rewrite.go
+++ b/TreeDB/vlog_rewrite.go
@@ -95,6 +95,7 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 			}
 		}
 		backendOpts.LeafGenerationProtectedRootIDs = mergeCompactStorageProtectedRootIDs(backendOpts.LeafGenerationProtectedRootIDs, db.cached.ProtectedLeafGenerationRootIDs())
+		backendOpts.LeafGenerationProtectedSystemRootIDs = mergeCompactStorageProtectedRootIDs(backendOpts.LeafGenerationProtectedSystemRootIDs, db.cached.ProtectedLeafGenerationSystemRootIDs())
 		if backendOpts.ReserveRIDs == nil {
 			backendOpts.ReserveRIDs = db.cached.ReserveValueLogRIDs
 		}

--- a/TreeDB/vlog_rewrite.go
+++ b/TreeDB/vlog_rewrite.go
@@ -94,8 +94,9 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 				backendOpts.ProtectedPaths = []string{""}
 			}
 		}
-		backendOpts.LeafGenerationProtectedRootIDs = mergeCompactStorageProtectedRootIDs(backendOpts.LeafGenerationProtectedRootIDs, db.cached.ProtectedLeafGenerationRootIDs())
-		backendOpts.LeafGenerationProtectedSystemRootIDs = mergeCompactStorageProtectedRootIDs(backendOpts.LeafGenerationProtectedSystemRootIDs, db.cached.ProtectedLeafGenerationSystemRootIDs())
+		protectedRootIDs, protectedSystemRootIDs := db.cached.ProtectedLeafGenerationRootIDPair()
+		backendOpts.LeafGenerationProtectedRootIDs = mergeCompactStorageProtectedRootIDs(backendOpts.LeafGenerationProtectedRootIDs, protectedRootIDs)
+		backendOpts.LeafGenerationProtectedSystemRootIDs = mergeCompactStorageProtectedRootIDs(backendOpts.LeafGenerationProtectedSystemRootIDs, protectedSystemRootIDs)
 		if backendOpts.ReserveRIDs == nil {
 			backendOpts.ReserveRIDs = db.cached.ReserveValueLogRIDs
 		}

--- a/TreeDB/vlog_rewrite.go
+++ b/TreeDB/vlog_rewrite.go
@@ -94,7 +94,7 @@ func (db *DB) ValueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 				backendOpts.ProtectedPaths = []string{""}
 			}
 		}
-		backendOpts.LeafGenerationProtectedRootIDs = appendCompactStorageProtectedRootIDs(backendOpts.LeafGenerationProtectedRootIDs, db.cached.ProtectedLeafGenerationRootIDs())
+		backendOpts.LeafGenerationProtectedRootIDs = mergeCompactStorageProtectedRootIDs(backendOpts.LeafGenerationProtectedRootIDs, db.cached.ProtectedLeafGenerationRootIDs())
 		if backendOpts.ReserveRIDs == nil {
 			backendOpts.ReserveRIDs = db.cached.ReserveValueLogRIDs
 		}


### PR DESCRIPTION
## Objective

Keep outer-leaf value-log segments visible and retained when reachable through cached published/protected roots, descriptor-reachable collection roots, and pointer-based publishes, while preserving bounded publish/maintenance paths, commit-sequence correctness, and accurate leaf-generation live-stat accounting.

## Context

The original fix closed the snapshot-missing gap; follow-up feedback required tightening publish/maintenance semantics so retention remains correct under protected/published roots without regressing hot-path cost. This PR now includes commit-safe pre-registration behavior, bounded pointer dedupe behavior, and rootID-based live-stat dedupe.

## Non-goals

- No on-disk format changes.
- No new runtime knobs or behavior flags.
- No broad commit-path refresh scans beyond bounded fallback paths.
- No HashDB or column-graph behavior changes.
- No change to role-sensitive maintenance routing for rewrite/GC paths beyond live-stat dedupe needed to avoid double-counting.

## Design

- Formats/flags/APIs changed (include diagrams if applicable)
  - No public formats/flags/APIs changed.
  - Pre-publish leaf-page-log registration queues pending leaf-generation file IDs with `commitSeq=0`; successful post-commit drain stamps the actual commit sequence.
  - `orderedRootTouchedIterator` keeps tiny publishes allocation-light and switches to seeded-map dedupe after a small threshold, preserving stable order and O(n) pointer-heavy behavior.
  - Protected roots remain split between ordinary roots and descriptor-expanding protected system roots.
  - Maintenance-root routing still dedupes by `(kind, rootID)` so direct-root and descriptor roles remain distinct where required.
  - Leaf-generation live-stat aggregation separately dedupes maintenance roots by `rootID` before summing subtree totals so role aliases do not inflate live bytes/counts.
- Invariants that must hold
  - Newly referenced value-log segments are visible in published `ValueLogSet` before reader-visible state.
  - Published/protected roots and descriptor-reachable collection roots protect referenced leaf generations.
  - Commit-sequence metadata for pending leaf-generation files is stamped only from successful commit publish.
  - Role-sensitive maintenance routing is preserved where required; non-routing live-stat scans are rootID-deduped.
- Fail-closed behavior (caps before alloc; CRC/error handling)
  - Descriptor scan/read errors that can hide reachable roots fail closed (except explicitly classified malformed descriptor-shape cases for protected ordinary roots).
  - Context cancellation is propagated through maintenance-root descriptor collection paths.

## Scope

- Includes (files/symbols):
  - `TreeDB/db/*` publish, maintenance-root, leaf-generation plan/GC/pack, leaf-page-log registration, ordered-root touched-segment capture.
  - `TreeDB/caching/db.go` published/protected root live-ID collection and descriptor expansion paths.
  - Targeted regression tests in `TreeDB/db` and `TreeDB/caching`.
- Excludes (files/symbols):
  - HashDB, column-graph/native workstream code paths.
  - Public API/format/schema changes.
  - New runtime toggles/config knobs.

## Correctness

- Tests run (exact commands):
  - `go test ./TreeDB/db ./TreeDB/caching -run 'TestLeafGenerationPlan_ProtectedOrdinaryRootDoesNotParseDescriptors|TestLeafGenerationGC_ProtectedSystemRootDescriptorsKeepCollectionRootLive|TestLeafGenerationGC_ProtectedRootIDsKeepDetachedRootLive|TestRegisterLeafPageLogSegmentsForPublishRegistersRewriteSegments|TestRegisterLeafPageLogSegmentsForPublishQueuesCurrentLeafGenerationSegment|TestDedupeMaintenanceRootsByRootIDDropsRoleAliasesForLiveStats|TestMaintenanceRootIDsDedupesByRootID|TestCollectValueLogLiveIDsUntil_IncludesPublishedSystemDescriptorCollectionRootLeafRefs|TestCollectPublishedRootValueLogLiveIDsUntil_SkipsCurrentPublishedSystemDescriptorExpansion' -count=1`
  - `go test ./TreeDB/caching ./TreeDB/db ./TreeDB/internal/valuelog -run 'ValueLog|Vlog|Leaf|Snapshot|Reopen|GC|MaintenanceRoots|VacuumIndex|ProtectedRoot|OrderedRoot|PublishSystemRoot|CurrentSet|ValueLogGenerationRewrite' -count=1`
  - `go test ./TreeDB/...`
  - `git diff --check`
- Corruption/edge cases covered:
  - Protected ordinary roots with descriptor-like values.
  - Descriptor read/iterator/pointer errors fail closed where required.
  - Pending leaf-generation segment registration and commit-sequence stamping correctness.
  - Root aliasing across roles and rootID-level dedupe behavior for non-routing scans.
- Concurrency/race coverage (if applicable):
  - No new concurrency model introduced; existing publish/maintenance synchronization paths preserved.

## Performance

- Benchmarks run (exact commands):
  - `go test ./TreeDB/db -run '^$' -bench 'BenchmarkOuterLeafWriteLoop_(NoRefresh|ForcedRefresh)$' -benchtime=1x -count=1 -benchmem`
- Results table (before/after; median-of-5 per G1 in `docs/OPT_SPRINT_NEXT.md`):
  - One-shot local evidence shows no-refresh path still avoids refresh scans (`0 refresh_scans/iter`) and forced-refresh behavior remains bounded/expected.
- Regressions (if any) and why acceptable:
  - No regressions observed in local targeted/broad test and benchmark evidence for touched paths.

## Rollout / Toggle Plan

- Default setting:
  - Behavior is on by default as part of existing publish/maintenance logic.
- How to disable quickly:
  - Revert this PR branch changes; no new runtime flag was added.

## Follow-ups

- Issues/PRs to do next:
  - Continue monitoring large-load/vacuum workloads for lane-255 value-log retention and publish-path scan costs.
  - Consider additional microbench coverage for ordered-root pointer-heavy publish batches.

## Column Graph Native Workstream (#1646, if applicable)

### Copied/Adapted From Old Stack

- Copied:
  - N/A
- Adapted:
  - N/A
- Oracle/comparator only:
  - N/A
- Quarantined/not copied:
  - N/A

### Path Identity

- Native reader:
  - N/A
- Decoded comparator:
  - N/A
- Legacy/native vector index:
  - N/A
- Unsupported/fail-closed:
  - N/A

### Base And Dependency State

- Base branch:
  - Current PR branch for caching/db value-log retention work.
- Base commit:
  - N/A for #1646 workstream.
- Base PR/head:
  - N/A for #1646 workstream.
- #1621/#1634 assumptions:
  - N/A
- Missing generic column-store primitives:
  - N/A
- Parent review fixes propagated:
  - N/A

### Evidence

- Tests:
  - See Correctness section commands.
- Benchmarks:
  - See Performance section benchmark command.
- Status/fallback proof:
  - Bounded no-refresh path retained; fallback refresh remains available when discovery is required.
- Performance attribution:
  - Pointer-heavy dedupe path switched to bounded map-assisted behavior after small linear threshold.
- Local regressions found/fixed:
  - None outstanding in touched areas.

### Test Plan Start

- Milestone tasks targeted:
  - N/A (#1646 not in scope).
- Tests to add before or with implementation:
  - N/A
- Existing tests to preserve:
  - N/A
- #1646 test-list changes made before implementation:
  - None.

### Performance Plan Start

- Relevant benchmarks/metrics for this PR:
  - Outer-leaf write loop refresh/no-refresh behavior.
- Baseline/comparator command or reason not applicable:
  - Comparator is forced-refresh benchmark variant.
- Expected setup/search/materialization boundary:
  - N/A (#1646 not in scope).
- Upstream costs explicitly out of scope:
  - Column-graph/native vector index costs.
- Local performance risks to watch:
  - Pointer-heavy ordered-root dedupe and descriptor expansion overhead.

### Test Plan Close

- Additional tests found during implementation/review:
  - Added/updated regressions for commit-safe preregistration, protected-root descriptor handling, maintenance-root rootID dedupe, and published system descriptor expansion behavior.
- Tests added or changed:
  - See Correctness section.
- Failing tests fixed:
  - N/A (no unresolved failing tests in touched suites).
- #1646 test-list changes made at close:
  - None.
- Residual untested gaps, if any:
  - None identified in touched paths.

### Performance Plan Close

- Benchmark commands run:
  - See Performance section.
- Results summary with throughput/latency/allocations:
  - No-refresh remains refresh-scan free; forced-refresh remains expectedly higher overhead.
- Before/after or baseline comparison:
  - Behavior consistent with intended bounded-path design.
- Local slow/heavy code found and fixed:
  - Pointer-heavy touched-segment dedupe path improved with thresholded map dedupe.
- Remaining upstream or deferred costs:
  - None in scope for this PR.

### AI Review Loop

- Codex latest-head review:
  - Re-requested during review-response loop.
- Copilot latest-head review:
  - Re-requested during review-response loop.
- CodeRabbit latest-head review:
  - Re-requested during review-response loop.
- Review comments/threads resolved or explicitly dismissed:
  - Resolved for touched files in this PR scope.
- Re-requested after final meaningful push:
  - Yes.

---

## Optimization PR Checklist (TreeDB)

### Scope
- [x] Single, clear objective for this PR (not a bundle)
- [x] Explicit include list (files/symbols touched):
- [x] Explicit exclude list (files/symbols NOT touched):
- [x] No unwanted feature reintroduction (e.g. async slab writer, hard zones, ValueIndex) unless explicitly stated in the PR objective

### Safety / Correctness
- [x] Clear written-vs-durable semantics for any `*Sync` path touched
- [x] No new mmap usage on mutable/truncating files
- [x] All new length fields are capped before allocation (OOM-safe)
- [x] CRC/checksum behavior is fail-closed (clean error, no panic)
- [x] Any concurrency change has a defined state machine and invariants

### Tests
- [x] Added deterministic regression tests for the targeted failure mode
- [x] Tests avoid sleeps where possible (use latches/hooks)
- [x] Added corruption/edge-case tests (truncation, bad headers, invalid lengths) when format/parsing changes
- [x] Ran locally:
  - [x] `go test ./... -count=1`
  - [x] Any targeted packages/benchmarks:

### Benchmarks / Measurements
- [x] Added or updated a benchmark relevant to the change
- [x] Reported results in PR description (before/after, command, machine)
- [ ] Included “incompressible” (worst-case) results if compression is involved

### Docs
- [ ] Updated `docs/OPT_SPRINT_NEXT.md` milestone status (if applicable)
- [x] Documented any new config knobs + defaults
- [x] Called out any format change in PR description (pre-alpha OK)

### Rollout / Toggle Plan (if behavior-affecting)
- [x] Safe defaults (feature off or conservative threshold)
- [x] Clear knobs to disable/revert behavior quickly
- [x] Observability: counters/logs to verify effectiveness