### PR TITLE
Stage no-index BSON updates in primary overlay

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -15842,10 +15842,8 @@ func directUpdatePrimaryRootPolicy(plan *updateBatchPlan, primaryRootName string
 func canStageDirectPrimaryOverlay(plan *updateBatchPlan, direct *directBufferedUpdatePlan, primaryOnlyDirectUpdate bool, wouldFlush bool) bool {
 	return plan != nil &&
 		direct != nil &&
-		!primaryOnlyDirectUpdate &&
 		!wouldFlush &&
-		len(plan.meta.Indexes) > 0 &&
-		plan.meta.Options.BufferedIndexedWrites &&
+		(primaryOnlyDirectUpdate || (len(plan.meta.Indexes) > 0 && plan.meta.Options.BufferedIndexedWrites)) &&
 		len(direct.templateEntries) == 0 &&
 		len(direct.secondaryRootPlans) == 0 &&
 		direct.primaryRootName != "" &&

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -15904,6 +15904,9 @@ func (c *Collection) stageDirectPrimaryOverlayLocked(domain *collectionWriteDoma
 	domain.writeGeneration++
 	domain.notePrimaryWriteEntriesLocked(direct.primaryEntries, domain.writeGeneration)
 	domain.observeIndexedStage(modifiedCount, direct.stagedBytes, 0)
+	if len(plan.meta.Indexes) == 0 {
+		domain.observePrimaryOnlyUpdateBatch(plan.stats.Items, plan.stats.Matched, plan.stats.Modified, false, collectionRootDeltaPlanStats{})
+	}
 	c.meta = plan.meta
 	plan.stats.BufferedBatches = 1
 	return true, nil

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3563,7 +3563,7 @@ func (c *Collection) Insert(id, document []byte) ([]byte, error) {
 		return nil, err
 	}
 	if len(c.meta.Indexes) == 0 && len(c.meta.VectorIndexes) == 0 && !c.db.CommandWALEnabled() {
-		if c.hasBufferedNoIndexBSONRootRuns() {
+		if c.hasBufferedNoIndexBSONPrimaryOverlayOrRootRuns() {
 			if err := c.withMutationLock(func() error {
 				return c.flushBufferedWrites()
 			}); err != nil {
@@ -3863,7 +3863,7 @@ func isBSONDocumentFormat(format DocumentFormat) bool {
 	return err == nil && normalized == DocumentFormatBSON
 }
 
-func (c *Collection) hasBufferedNoIndexBSONRootRuns() bool {
+func (c *Collection) hasBufferedNoIndexBSONPrimaryOverlayOrRootRuns() bool {
 	if c == nil || c.writeDomain == nil {
 		return false
 	}
@@ -3874,7 +3874,13 @@ func (c *Collection) hasBufferedNoIndexBSONRootRuns() bool {
 		return false
 	}
 	collectionName := bufferedDomainCollectionName(domain, c.meta.Name)
-	if collectionName == "" || !hasPendingRootRunsForRootLocked(domain, collectionPrimaryRootName(collectionName)) {
+	if collectionName == "" {
+		return false
+	}
+	hasPrimaryWrites := hasBufferedPrimaryOverlay(domain) ||
+		hasPendingIndexedPrimaryOverlay(domain) ||
+		hasPendingRootRunsForRootLocked(domain, collectionPrimaryRootName(collectionName))
+	if !hasPrimaryWrites {
 		return false
 	}
 	return isBSONDocumentFormat(domain.meta.Options.DocumentFormat)
@@ -8932,7 +8938,7 @@ func (c *Collection) insertBatchOnceWithOptimisticPlanning(ids, documents [][]by
 	if c == nil || c.db == nil {
 		return nil, nil, false
 	}
-	if c.hasBufferedNoIndexBSONRootRuns() || c.hasBufferedIndexedDeletesOnly() {
+	if c.hasBufferedNoIndexBSONPrimaryOverlayOrRootRuns() || c.hasBufferedIndexedDeletesOnly() {
 		return nil, nil, false
 	}
 	snap := c.db.AcquireSnapshot()
@@ -9026,7 +9032,7 @@ func (c *Collection) insertBatchOnceWithOptimisticPlanning(ids, documents [][]by
 
 	unlockMutation := c.lockMutation()
 	defer unlockMutation.Unlock()
-	if c.hasBufferedNoIndexBSONRootRuns() || c.hasBufferedIndexedDeletesOnly() {
+	if c.hasBufferedNoIndexBSONPrimaryOverlayOrRootRuns() || c.hasBufferedIndexedDeletesOnly() {
 		closePlanningSnapshot()
 		resetCollectionRunTables(plan.runs)
 		return nil, ErrConcurrentMutation, true
@@ -9102,7 +9108,7 @@ func (c *Collection) insertBatchOnceWithLockState(
 			return nil, err
 		}
 	}
-	if c.hasBufferedNoIndexBSONRootRuns() && !commandWALNoIndexBufferCandidate {
+	if c.hasBufferedNoIndexBSONPrimaryOverlayOrRootRuns() && !commandWALNoIndexBufferCandidate {
 		if err := c.flushBufferedWrites(); err != nil {
 			return nil, err
 		}

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -12678,7 +12678,7 @@ func TestCollectionUpdateBSONSetDirectFallbackReportsStructuredApply(t *testing.
 	}
 }
 
-func TestCollectionUpdateBSONSetNoIndexBuffersPrimaryRoot(t *testing.T) {
+func TestCollectionUpdateBSONSetNoIndexBuffersPrimaryOverlay(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{
 		Dir:        t.TempDir(),
 		Durability: backenddb.DurabilityWALOffRelaxed,
@@ -12732,12 +12732,10 @@ func TestCollectionUpdateBSONSetNoIndexBuffersPrimaryRoot(t *testing.T) {
 	if got, want := stats.BufferedBatches, 1; got != want {
 		t.Fatalf("buffered batches=%d want %d", got, want)
 	}
-	col.writeDomain.mu.RLock()
-	rootRunCount := col.writeDomain.rootRunCount
-	primaryRuns := len(col.writeDomain.rootRuns[collectionPrimaryRootName("users")])
-	col.writeDomain.mu.RUnlock()
-	if rootRunCount != 1 || primaryRuns != 1 {
-		t.Fatalf("root runs=%d primary=%d want 1/1", rootRunCount, primaryRuns)
+	rootCounts, rootRunCount := bufferedRootRunCountsForTest(t, col, collectionPrimaryRootName("users"))
+	overlayEntries := bufferedPrimaryOverlayCountForTest(t, col)
+	if rootRunCount != 0 || rootCounts[collectionPrimaryRootName("users")] != 0 || overlayEntries != 1 {
+		t.Fatalf("root runs=%d primary=%d overlay=%d want 0/0/1", rootRunCount, rootCounts[collectionPrimaryRootName("users")], overlayEntries)
 	}
 	if err := col.Flush(); err != nil {
 		t.Fatalf("flush buffered update: %v", err)
@@ -12809,12 +12807,10 @@ func TestCollectionUpdateBSONSetNoIndexIgnoresIndexedThresholds(t *testing.T) {
 	if afterUpdate.CommitSeq != before.CommitSeq {
 		t.Fatalf("UpdateBSONSet advanced commit seq by %d before flush, want buffered", afterUpdate.CommitSeq-before.CommitSeq)
 	}
-	col.writeDomain.mu.RLock()
-	rootRunCount := col.writeDomain.rootRunCount
-	primaryRuns := len(col.writeDomain.rootRuns[collectionPrimaryRootName("users")])
-	col.writeDomain.mu.RUnlock()
-	if rootRunCount != 1 || primaryRuns != 1 {
-		t.Fatalf("root runs=%d primary=%d want 1/1", rootRunCount, primaryRuns)
+	rootCounts, rootRunCount := bufferedRootRunCountsForTest(t, col, collectionPrimaryRootName("users"))
+	overlayEntries := bufferedPrimaryOverlayCountForTest(t, col)
+	if rootRunCount != 0 || rootCounts[collectionPrimaryRootName("users")] != 0 || overlayEntries != 1 {
+		t.Fatalf("root runs=%d primary=%d overlay=%d want 0/0/1", rootRunCount, rootCounts[collectionPrimaryRootName("users")], overlayEntries)
 	}
 }
 
@@ -13041,7 +13037,7 @@ func TestCollectionUpdateBSONSetNoIndexNoopSkipsDirectBufferedRetryLoop(t *testi
 	}
 }
 
-func TestCollectionUpdateBSONSetNoIndexWALOnBuffersBeforeAck(t *testing.T) {
+func TestCollectionUpdateBSONSetNoIndexWALOnBuffersPrimaryOverlayBeforeAck(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{
 		Dir:        t.TempDir(),
 		Durability: backenddb.DurabilityWALOnRelaxed,
@@ -13092,11 +13088,10 @@ func TestCollectionUpdateBSONSetNoIndexWALOnBuffersBeforeAck(t *testing.T) {
 	if afterUpdate.CommitSeq != before.CommitSeq {
 		t.Fatalf("UpdateBSONSet commit seq=%d before=%d want buffered", afterUpdate.CommitSeq, before.CommitSeq)
 	}
-	col.writeDomain.mu.RLock()
-	rootRunCount := col.writeDomain.rootRunCount
-	col.writeDomain.mu.RUnlock()
-	if rootRunCount != 1 {
-		t.Fatalf("root runs=%d want 1", rootRunCount)
+	rootCounts, rootRunCount := bufferedRootRunCountsForTest(t, col, collectionPrimaryRootName("users"))
+	overlayEntries := bufferedPrimaryOverlayCountForTest(t, col)
+	if rootRunCount != 0 || rootCounts[collectionPrimaryRootName("users")] != 0 || overlayEntries != 1 {
+		t.Fatalf("root runs=%d primary=%d overlay=%d want 0/0/1", rootRunCount, rootCounts[collectionPrimaryRootName("users")], overlayEntries)
 	}
 	doc, err := col.Get([]byte("u1"))
 	if err != nil {

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -12714,6 +12714,7 @@ func TestCollectionUpdateBSONSetNoIndexBuffersPrimaryOverlay(t *testing.T) {
 		t.Fatalf("flush insert: %v", err)
 	}
 	before := d.State()
+	statsBefore := mgr.StatsSnapshot()
 	matched, modified, err := col.UpdateBSONSet([]byte("u1"), []BSONSetField{{
 		Key:   "city",
 		Value: mustBSONRawValue(t, "sea"),
@@ -12731,6 +12732,19 @@ func TestCollectionUpdateBSONSetNoIndexBuffersPrimaryOverlay(t *testing.T) {
 	stats := col.LastUpdateStats()
 	if got, want := stats.BufferedBatches, 1; got != want {
 		t.Fatalf("buffered batches=%d want %d", got, want)
+	}
+	statsAfterStage := mgr.StatsSnapshot()
+	if got, want := statsAfterStage.PrimaryOnlyUpdateCalls-statsBefore.PrimaryOnlyUpdateCalls, uint64(1); got != want {
+		t.Fatalf("primary-only update calls delta=%d want %d", got, want)
+	}
+	if got, want := statsAfterStage.PrimaryOnlyMatched-statsBefore.PrimaryOnlyMatched, uint64(1); got != want {
+		t.Fatalf("primary-only matched delta=%d want %d", got, want)
+	}
+	if got, want := statsAfterStage.PrimaryOnlyModified-statsBefore.PrimaryOnlyModified, uint64(1); got != want {
+		t.Fatalf("primary-only modified delta=%d want %d", got, want)
+	}
+	if got, want := statsAfterStage.PrimaryOnlyRootPublishes-statsBefore.PrimaryOnlyRootPublishes, uint64(0); got != want {
+		t.Fatalf("primary-only root publishes delta=%d want %d before flush", got, want)
 	}
 	rootCounts, rootRunCount := bufferedRootRunCountsForTest(t, col, collectionPrimaryRootName("users"))
 	overlayEntries := bufferedPrimaryOverlayCountForTest(t, col)

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -12975,6 +12975,92 @@ func TestCollectionInsertBatchNoIndexBSONFlushesPendingRootRunsBeforeBatchInsert
 	}
 }
 
+func TestCollectionNativewireInsertBatchNoIndexBSONFlushesPendingPrimaryOverlay(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{
+		Dir:        t.TempDir(),
+		Durability: backenddb.DurabilityWALOffRelaxed,
+	})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "users",
+		Options: CollectionOptions{
+			DocumentFormat: DocumentFormatBSON,
+		},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("users")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch(
+		[][]byte{[]byte("u1")},
+		[][]byte{mustBSONCollectionDocument(t, bson.D{
+			{Key: "_id", Value: "u1"},
+			{Key: "city", Value: "hnl"},
+		})},
+	); err != nil {
+		t.Fatalf("insert seed: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush seed: %v", err)
+	}
+
+	matched, modified, err := col.UpdateBSONSet([]byte("u1"), []BSONSetField{{
+		Key:   "city",
+		Value: mustBSONRawValue(t, "sea"),
+	}})
+	if err != nil {
+		t.Fatalf("UpdateBSONSet: %v", err)
+	}
+	if !matched || !modified {
+		t.Fatalf("UpdateBSONSet matched=%v modified=%v want true/true", matched, modified)
+	}
+	rootCounts, rootRunCount := bufferedRootRunCountsForTest(t, col, collectionPrimaryRootName("users"))
+	overlayEntries := bufferedPrimaryOverlayCountForTest(t, col)
+	if rootRunCount != 0 || rootCounts[collectionPrimaryRootName("users")] != 0 || overlayEntries != 1 {
+		t.Fatalf("root runs=%d primary=%d overlay=%d want 0/0/1 before trusted insert", rootRunCount, rootCounts[collectionPrimaryRootName("users")], overlayEntries)
+	}
+
+	beforeInsert := d.State()
+	if err := col.NativewireInsertBatchNoResultIDs(
+		[][]byte{[]byte("u2")},
+		[][]byte{mustBSONCollectionDocument(t, bson.D{
+			{Key: "_id", Value: "u2"},
+			{Key: "city", Value: "sfo"},
+		})},
+		true,
+	); err != nil {
+		t.Fatalf("trusted nativewire insert after overlay update: %v", err)
+	}
+	afterInsert := d.State()
+	if afterInsert.CommitSeq <= beforeInsert.CommitSeq {
+		t.Fatalf("trusted insert commit seq=%d before=%d want pending overlay flushed first", afterInsert.CommitSeq, beforeInsert.CommitSeq)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("flush trusted insert: %v", err)
+	}
+	doc1, err := col.Get([]byte("u1"))
+	if err != nil {
+		t.Fatalf("get u1: %v", err)
+	}
+	if got := bson.Raw(doc1).Lookup("city").StringValue(); got != "sea" {
+		t.Fatalf("u1 city=%q want sea", got)
+	}
+	doc2, err := col.Get([]byte("u2"))
+	if err != nil {
+		t.Fatalf("get u2: %v", err)
+	}
+	if got := bson.Raw(doc2).Lookup("city").StringValue(); got != "sfo" {
+		t.Fatalf("u2 city=%q want sfo", got)
+	}
+}
+
 func TestCollectionUpdateBSONSetNoIndexNoopSkipsDirectBufferedRetryLoop(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{
 		Dir:        t.TempDir(),

--- a/TreeDB/collections/command_wal_test.go
+++ b/TreeDB/collections/command_wal_test.go
@@ -1122,6 +1122,28 @@ func TestCollectionCommandWALUpdateBSONSetNoIndexStagesAfterWALAppend(t *testing
 		_ = d.Close()
 		t.Fatalf("AppliedCommandLSN after staged update=%d, want 0 before flush", got)
 	}
+	if domain := col.writeDomain; domain == nil {
+		_ = d.Close()
+		t.Fatal("writeDomain=nil after staged update")
+	} else {
+		domain.mu.RLock()
+		overlayEntries := 0
+		if domain.primaryOverlay != nil {
+			overlayEntries = domain.primaryOverlay.len()
+		}
+		rootRuns := domain.rootRunCount
+		pendingFirst := domain.pendingCommandWALFirst
+		pendingLast := domain.pendingCommandWALLast
+		domain.mu.RUnlock()
+		if overlayEntries != 1 || rootRuns != 0 {
+			_ = d.Close()
+			t.Fatalf("staged update overlay_entries=%d root_runs=%d, want primary overlay and no root runs", overlayEntries, rootRuns)
+		}
+		if pendingFirst != 1 || pendingLast != 1 {
+			_ = d.Close()
+			t.Fatalf("pending command WAL range=[%d,%d], want [1,1]", pendingFirst, pendingLast)
+		}
+	}
 	frames := collectionCommandWALFrames(t, dir)
 	if len(frames) != 1 || frames[0].Kind != commitlog.CommandKindCollectionUpdateBatchByID {
 		_ = d.Close()

--- a/TreeDB/collections/direct_buffered_update_bench_test.go
+++ b/TreeDB/collections/direct_buffered_update_bench_test.go
@@ -202,14 +202,20 @@ func collectionManagerStatsBenchmarkDelta(after, before CollectionManagerStats) 
 		UpdateBatchPrimaryRunBuild:       after.UpdateBatchPrimaryRunBuild - before.UpdateBatchPrimaryRunBuild,
 		UpdateBatchSecondaryRunBuild:     after.UpdateBatchSecondaryRunBuild - before.UpdateBatchSecondaryRunBuild,
 		UpdateBatchBufferStage:           after.UpdateBatchBufferStage - before.UpdateBatchBufferStage,
+		UpdateBatchBufferPrecheck:        after.UpdateBatchBufferPrecheck - before.UpdateBatchBufferPrecheck,
 		UpdateBatchBufferLockWait:        after.UpdateBatchBufferLockWait - before.UpdateBatchBufferLockWait,
 		UpdateBatchBufferLockHold:        after.UpdateBatchBufferLockHold - before.UpdateBatchBufferLockHold,
+		UpdateBatchBufferValidation:      after.UpdateBatchBufferValidation - before.UpdateBatchBufferValidation,
+		UpdateBatchBufferRootScan:        after.UpdateBatchBufferRootScan - before.UpdateBatchBufferRootScan,
 		UpdateBatchBufferDomainPrepare:   after.UpdateBatchBufferDomainPrepare - before.UpdateBatchBufferDomainPrepare,
 		UpdateBatchBufferFreeze:          after.UpdateBatchBufferFreeze - before.UpdateBatchBufferFreeze,
 		UpdateBatchBufferRootTable:       after.UpdateBatchBufferRootTable - before.UpdateBatchBufferRootTable,
+		UpdateBatchBufferPrimaryIdx:      after.UpdateBatchBufferPrimaryIdx - before.UpdateBatchBufferPrimaryIdx,
+		UpdateBatchBufferUniqueIdx:       after.UpdateBatchBufferUniqueIdx - before.UpdateBatchBufferUniqueIdx,
 		UpdateBatchBufferPrimaryAppend:   after.UpdateBatchBufferPrimaryAppend - before.UpdateBatchBufferPrimaryAppend,
 		UpdateBatchBufferSecondaryAppend: after.UpdateBatchBufferSecondaryAppend - before.UpdateBatchBufferSecondaryAppend,
 		UpdateBatchBufferRootAppend:      after.UpdateBatchBufferRootAppend - before.UpdateBatchBufferRootAppend,
+		UpdateBatchBufferFlush:           after.UpdateBatchBufferFlush - before.UpdateBatchBufferFlush,
 		UpdateBatchPublish:               after.UpdateBatchPublish - before.UpdateBatchPublish,
 		UpdateBatchSecondaryDeletes:      after.UpdateBatchSecondaryDeletes - before.UpdateBatchSecondaryDeletes,
 		UpdateBatchSecondarySets:         after.UpdateBatchSecondarySets - before.UpdateBatchSecondarySets,
@@ -300,14 +306,20 @@ func reportCollectionUpdateStatsForBenchmark(b *testing.B, stats CollectionManag
 	reportDurationPerDoc(stats.UpdateBatchPrimaryRunBuild, "update_primary_run_build_ns/doc")
 	reportDurationPerDoc(stats.UpdateBatchSecondaryRunBuild, "update_secondary_run_build_ns/doc")
 	reportDurationPerDoc(stats.UpdateBatchBufferStage, "update_buffer_stage_ns/doc")
+	reportDurationPerDoc(stats.UpdateBatchBufferPrecheck, "update_buffer_precheck_ns/doc")
 	reportDurationPerDoc(stats.UpdateBatchBufferLockWait, "update_buffer_lock_wait_ns/doc")
 	reportDurationPerDoc(stats.UpdateBatchBufferLockHold, "update_buffer_lock_hold_ns/doc")
+	reportDurationPerDoc(stats.UpdateBatchBufferValidation, "update_buffer_validation_ns/doc")
+	reportDurationPerDoc(stats.UpdateBatchBufferRootScan, "update_buffer_root_scan_ns/doc")
 	reportDurationPerDoc(stats.UpdateBatchBufferDomainPrepare, "update_buffer_domain_prepare_ns/doc")
 	reportDurationPerDoc(stats.UpdateBatchBufferFreeze, "update_buffer_freeze_ns/doc")
 	reportDurationPerDoc(stats.UpdateBatchBufferRootTable, "update_buffer_root_table_ns/doc")
+	reportDurationPerDoc(stats.UpdateBatchBufferPrimaryIdx, "update_buffer_primary_index_ns/doc")
+	reportDurationPerDoc(stats.UpdateBatchBufferUniqueIdx, "update_buffer_unique_index_ns/doc")
 	reportDurationPerDoc(stats.UpdateBatchBufferPrimaryAppend, "update_buffer_primary_append_ns/doc")
 	reportDurationPerDoc(stats.UpdateBatchBufferSecondaryAppend, "update_buffer_secondary_append_ns/doc")
 	reportDurationPerDoc(stats.UpdateBatchBufferRootAppend, "update_buffer_root_append_ns/doc")
+	reportDurationPerDoc(stats.UpdateBatchBufferFlush, "update_buffer_flush_ns/doc")
 	reportDurationPerDoc(stats.UpdateBatchPublish, "update_publish_ns/doc")
 	if stats.UpdateCombineRequests > 0 {
 		b.ReportMetric(float64(stats.UpdateCombineRequests), "update_combine_requests")


### PR DESCRIPTION
## Summary

Closes #2177.

This changes the no-index BSON `$set` direct-buffered update path to stage primary-only updates in the existing primary overlay instead of building a mutable primary root-run table for each update. The overlay path was already used for primary-only direct updates in indexed collections; this extends it to the YCSB no-index shape when there are no secondary/template root plans and no flush is required.

The PR also updates tests to assert the new staging contract, guards the mixed overlay/table-buffer edge case found in review, preserves primary-only update counters, and adds benchmark reporting for the direct-buffered update lock/precheck/root-scan/validation/flush breakdown metrics.

## Correctness Notes

- The mutation still goes through the direct-buffered update path and still stages before publish/flush.
- No-index BSON updates stage in `primaryOverlay`, with `rootRunCount==0` before flush.
- Trusted/no-index insert buffering now drains pending no-index BSON primary overlays/root-runs before appending table writes, so table writes cannot be cleared behind an indexed/overlay flush.
- Primary-only update call/matched/modified counters are recorded on the no-index overlay staging path with `published=false`; root-publish counters remain tied to actual publish/flush work.
- Command-WAL no-index BSON updates explicitly assert `primaryOverlay.len()==1`, `rootRunCount==0`, and pending command-WAL LSN `[1,1]` before flush.
- Existing API tests assert no commit-seq advance before flush/ack and that staged updates remain visible through `Get`.

## Performance Evidence

Baseline branch/head: `origin/main` at `db4f823e5b8e77d7f9ae56eaff6abe7a024ff65c`
Candidate branch/head: `codex/2177-bson-update-lock-boundary` at `77229c01f`
Host/context: local Go benchmark, linux/amd64, 11th Gen Intel(R) Core(TM) i5-11400F @ 2.60GHz, `GOWORK=off`, same checkout/machine, `count=5`.

Commands:

```sh
GOWORK=off go test ./TreeDB/collections \
  -run '^$' \
  -bench 'BenchmarkCollectionUpdateBSONSetYCSBNoIndexParallel16' \
  -benchmem \
  -count=5 \
  | tee /tmp/treedb_2177_bson_update_lock_baseline_20260602.out

GOWORK=off go test ./TreeDB/collections \
  -run '^$' \
  -bench 'BenchmarkCollectionUpdateBSONSetYCSBNoIndexParallel16' \
  -benchmem \
  -count=5 \
  | tee /tmp/treedb_2177_bson_update_primary_overlay_counterfix_clean_20260602.out

benchstat /tmp/treedb_2177_baseline.clean.bench \
  /tmp/treedb_2177_overlay_counterfix.clean.bench \
  | tee /tmp/treedb_2177_benchstat_primary_overlay_counterfix_20260602.txt
```

Key benchstat results:

```text
sec/op direct:          9.372µ -> 7.626µ  -18.63% (p=0.008 n=5)
sec/op public_combiner: 5.992µ -> 4.913µ  -18.01% (p=0.008 n=5)
updates/sec direct:          106.7k -> 131.1k  +22.89% (p=0.008 n=5)
updates/sec public_combiner: 166.9k -> 203.6k  +21.97% (p=0.008 n=5)
mutation_lock_hold_ns/doc direct:          4.889k -> 3.990k  -18.39% (p=0.008 n=5)
mutation_lock_hold_ns/doc public_combiner: 1.482k -> 1.214k  -18.08% (p=0.008 n=5)
update_buffer_stage_ns/doc direct:          4.194k -> 3.376k  -19.50% (p=0.008 n=5)
update_buffer_stage_ns/doc public_combiner: 1.423k -> 1.160k  -18.48% (p=0.008 n=5)
allocs/op direct:          15 -> 13  -13.33% (p=0.008 n=5)
allocs/op public_combiner:  2 ->  1  -50.00% (p=0.008 n=5)
```

No material benchmark regression was observed in the focused YCSB-shaped update cell. The previous `indexed_stage_root_runs/doc` metric disappears in the candidate because the no-index update is staged in the primary overlay, leaving `rootRunCount==0` before flush.

## Test Evidence

```sh
GOWORK=off go test ./TreeDB/collections \
  -run 'TestCollectionUpdateBSONSetNoIndex(BuffersPrimaryOverlay|IgnoresIndexedThresholds|WALOnBuffersPrimaryOverlayBeforeAck)$|TestCollectionNativewireInsertBatchNoIndexBSONFlushesPendingPrimaryOverlay$|TestCollectionCommandWAL(UpdateBSONSetNoIndexStagesAfterWALAppend|UpdateBSONSetNoIndexDrainsBeforeRawKVCommandWAL|UpdateBSONSetNoIndexWaitsForRawKVCommandWALPublish|UpdateBSONSetNoIndexDoesNotDeadlockRawPublish|UpdateBSONSetNoIndexDoesNotReserveBeforeMutation|UpdateBSONSetNoIndexInterleavedCollectionsDrainOwner|UpdateBSONSetCombinerLaneWorkerStagesAfterWALAppend|UpdateBSONSetCombinerMergedPreparedBatchesStageOneWALFrame)$|TestCollectionUpdateBatchIfNoSecondaryUniqueIndexChanges(RejectsStalePrimaryOnlyDirectPlan|BuffersStaleNonOverlappingPrimaryOnlyDirectPlan)$' \
  -count=1
# ok github.com/snissn/gomap/TreeDB/collections 0.801s

GOWORK=off go test ./TreeDB/collections -count=1
# ok github.com/snissn/gomap/TreeDB/collections 97.486s

GOWORK=off go test ./TreeDB/nativewire ./cmd/treedb-native-server -count=1
# ok github.com/snissn/gomap/TreeDB/nativewire 1.898s
# ok github.com/snissn/gomap/cmd/treedb-native-server 0.002s
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized buffered insert operations to better handle primary overlays and pending writes
  * Enhanced direct primary overlay staging for no-index collection scenarios
  * Improved performance tracking for buffered update operations

* **Tests**
  * Updated buffering tests to verify primary overlay behavior
  * Added test coverage for pending primary overlay flushing during inserts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->