### PR TITLE
docs: make root README TreeDB-focused

### DIFF
--- a/HashDB/README.md
+++ b/HashDB/README.md
@@ -1,0 +1,114 @@
+# HashDB
+
+HashDB is a sibling storage engine in this repository. It is an mmap-backed hash
+index with an append-only slab value log, optimized for high-throughput point
+lookups and random I/O experiments.
+
+TreeDB is the main current focus of the repository. HashDB remains useful for
+comparison, Redis-wrapper experiments, hash-index research, and workloads that
+do not need ordered scans.
+
+## Design
+
+HashDB is implemented as:
+
+- an mmap-backed hash index with SwissHash-style control bytes and key metadata;
+- append-only slab segment files (`slab-*`) that store key/value records;
+- optional sharding for concurrent point operations;
+- optional per-shard write-back cache WAL for sharded cache durability
+  experiments.
+
+HashDB does not provide ordered iteration. `ForEach` walks live entries in
+arbitrary order.
+
+## Entry Points
+
+- Sharded, thread-safe store: `hashdb.Open(dir)` or
+  `hashdb.OpenWithShards(dir, n)`.
+- Single-shard store: `hashdb.OpenSingle(dir)`.
+- Redis protocol wrapper: `HashDB/redisserver`.
+- BTree-on-HashDB comparison engine: `HashDB/BTreeOnHashDB`.
+
+## Minimal Usage
+
+```go
+package main
+
+import (
+	"fmt"
+	"log"
+
+	hashdb "github.com/snissn/gomap/HashDB"
+)
+
+func main() {
+	db, err := hashdb.Open("/tmp/hashdb-example")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer db.Close()
+
+	if err := db.PutSync([]byte("key"), []byte("value")); err != nil {
+		log.Fatal(err)
+	}
+	value, err := db.Get([]byte("key"))
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(string(value))
+}
+```
+
+## Durability
+
+HashDB durability is slab-log based:
+
+- `Put` / `Delete`: fast, best-effort durability.
+- `PutSync` / `DeleteSync`: fsync the active slab segment.
+- `ApplyBatchSync`: crash-atomic batch mutation with explicit slab-log markers.
+
+The mmap hash index is derived state. After an unclean shutdown, HashDB rebuilds
+the index by scanning slab segments and truncating torn tail records.
+
+For the sharded store, commits are atomic per shard but not across shards.
+
+## Benchmarking
+
+HashDB is covered by the unified benchmark harness alongside TreeDB, Badger, and
+LevelDB:
+
+```sh
+make unified-bench
+./bin/unified-bench
+```
+
+HashDB-specific benchmark binaries:
+
+```sh
+make build-hashdb
+./bin/hashdb-benchmark --help
+./bin/hashdb-shardbench
+./bin/hashdb-loadfactorbench
+./bin/hashdb-resizebench
+```
+
+Update the generated benchmark snapshot below:
+
+```sh
+make bench-readme
+```
+
+`make bench-readme` writes the unified benchmark markdown into this file so the
+TreeDB root README can stay focused on the current TreeDB/YCSB headline.
+
+<!-- BENCHMARK_START -->
+_No generated benchmark snapshot is checked in here yet. Run `make bench-readme`
+to insert the current unified benchmark markdown for this host._
+<!-- BENCHMARK_END -->
+
+## More Docs
+
+- `docs/HASHDB_CONCEPTS.md`
+- `docs/HASHDB_TUNING.md`
+- `docs/HASHDB_SNAPSHOT.md`
+- `docs/contracts/README.md`

--- a/HashDB/README.md
+++ b/HashDB/README.md
@@ -108,7 +108,7 @@ to insert the current unified benchmark markdown for this host._
 
 ## More Docs
 
-- `docs/HASHDB_CONCEPTS.md`
-- `docs/HASHDB_TUNING.md`
-- `docs/HASHDB_SNAPSHOT.md`
-- `docs/contracts/README.md`
+- `../docs/HASHDB_CONCEPTS.md`
+- `../docs/HASHDB_TUNING.md`
+- `../docs/HASHDB_SNAPSHOT.md`
+- `../docs/contracts/README.md`

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ help:
 	@echo "  make build-mongo-gateway - build TreeDB MongoDB gateway server"
 	@echo "  make run-mongo-gateway - run TreeDB MongoDB gateway server"
 	@echo "  make bench          - run unified bench"
-	@echo "  make bench-readme   - regenerate README benchmark snapshot"
+	@echo "  make bench-readme   - regenerate HashDB README benchmark snapshot"
 	@echo "  make benchmark-all  - run HashDB redis-benchmark suite (legacy)"
 	@echo "  make unified-bench  - build unified bench binary"
 	@echo "  make benchprof      - build profile analyzer binary"
@@ -177,7 +177,7 @@ bench: unified-bench
 	./$(BIN_DIR)/unified-bench
 
 bench-readme: unified-bench
-	./$(BIN_DIR)/unified-bench -suite readme -format markdown -seed 1 -keycounts "$(BENCH_KEYCOUNTS)" -valsize "$(BENCH_VALSIZE)" -batchsize "$(BENCH_BATCHSIZE)" -range-queries "$(BENCH_RANGE_QUERIES)" -range-span "$(BENCH_RANGE_SPAN)" -outdir "$(BENCH_OUTDIR)" -progress=false | go run ./scripts/update_readme_bench.go
+	./$(BIN_DIR)/unified-bench -suite readme -format markdown -seed 1 -keycounts "$(BENCH_KEYCOUNTS)" -valsize "$(BENCH_VALSIZE)" -batchsize "$(BENCH_BATCHSIZE)" -range-queries "$(BENCH_RANGE_QUERIES)" -range-span "$(BENCH_RANGE_SPAN)" -outdir "$(BENCH_OUTDIR)" -progress=false | go run ./scripts/update_readme_bench.go -readme HashDB/README.md
 
 .PHONY: bench-collections-canonical
 bench-collections-canonical:

--- a/Makefile
+++ b/Makefile
@@ -177,7 +177,7 @@ bench: unified-bench
 	./$(BIN_DIR)/unified-bench
 
 bench-readme: unified-bench
-	./$(BIN_DIR)/unified-bench -suite readme -format markdown -seed 1 -keycounts "$(BENCH_KEYCOUNTS)" -valsize "$(BENCH_VALSIZE)" -batchsize "$(BENCH_BATCHSIZE)" -range-queries "$(BENCH_RANGE_QUERIES)" -range-span "$(BENCH_RANGE_SPAN)" -outdir "$(BENCH_OUTDIR)" -progress=false | go run ./scripts/update_readme_bench.go -readme HashDB/README.md
+	./$(BIN_DIR)/unified-bench -suite readme -format markdown -seed 1 -keycounts "$(BENCH_KEYCOUNTS)" -valsize "$(BENCH_VALSIZE)" -batchsize "$(BENCH_BATCHSIZE)" -range-queries "$(BENCH_RANGE_QUERIES)" -range-span "$(BENCH_RANGE_SPAN)" -outdir "$(BENCH_OUTDIR)" -progress=false | sed 's#($(BENCH_OUTDIR)/#(../$(BENCH_OUTDIR)/#g' | go run ./scripts/update_readme_bench.go -readme HashDB/README.md
 
 .PHONY: bench-collections-canonical
 bench-collections-canonical:

--- a/README.md
+++ b/README.md
@@ -22,18 +22,10 @@ TreeDB is pre-alpha:
 ## Benchmark Highlights
 
 These checked-in reports use different workloads, profiles, and caveats. Treat
-each row as scoped evidence from its linked benchmark, not as one combined
+each workload as scoped evidence from its linked benchmark, not as one combined
 benchmark suite.
 
-| workload | TreeDB result | comparison / context | report |
-| --- | ---: | --- | --- |
-| YCSB run phase | nativewire durable `120,500.7 ops/sec`; nativewire relaxed `126,762.5 ops/sec`; Mongo gateway durable `74,544.7 ops/sec` | MongoDB 8 baseline `26,102.5 ops/sec`; full table below | [June 2 YCSB](docs/benchmarks/ycsb_post_update_stack_2026-06-02.md) |
-| Two-index collection insert | template-v1 `1,079,797 docs/sec`; JSON `960,922 docs/sec` | SQLite JSON `394,685 docs/sec`; SQLite native columns `450,180 docs/sec` | [April 27 matrix](docs/benchmarks/collections_rewrite_vacuum_matrix_pr1075_2026-04-27.md) |
-| Collection read/lookup | template-v1 primary read `771,803 ops/sec`; parallel primary read `1,503,458 ops/sec`; nonunique secondary lookup `243,625-257,356 ops/sec` | SQLite nonunique secondary lookup `39,399-68,815 ops/sec` | [April 27 matrix](docs/benchmarks/collections_rewrite_vacuum_matrix_pr1075_2026-04-27.md) |
-| Collection storage density | index-vlog template-v1 `104.90 B/doc` | default template-v1 `155.10 B/doc`; SQLite native columns after `VACUUM` `156.40 B/doc`; `13-14%` write-throughput cost | [April 27 matrix](docs/benchmarks/collections_rewrite_vacuum_matrix_pr1075_2026-04-27.md) |
-| `application.db` offline density | TreeDB self-roundtrip compacted size `2.092 GiB` | PebbleDB `1.773 GiB`; goleveldb `2.316 GiB` | [April 13 density](docs/benchmarks/application_db_engine_matrix_2026-04-13.md) |
-
-## Current YCSB Headline
+### YCSB Server Workload
 
 External `go-ycsb`, local loopback TCP, `recordcount=100000`,
 `operationcount=10000`, `threadcount=16`, BSON document format, and zero YCSB
@@ -50,11 +42,66 @@ June 2, 2026 report.
 | TreeDB nativewire | `bench` no-WAL | 85,201.7 | 134,415.5 | 114.0 | 365.0 |
 
 Full report, commands, host context, run repeats, and artifact paths:
-`docs/benchmarks/ycsb_post_update_stack_2026-06-02.md`.
+[June 2 YCSB report](docs/benchmarks/ycsb_post_update_stack_2026-06-02.md).
 
 The `bench` profile is a no-WAL benchmark-only ceiling. Use
 `command_wal_durable` as the default server profile unless you are deliberately
 running relaxed durability or a benchmark ceiling.
+
+### Indexed Collection Insert Workload
+
+Two secondary indexes, April 27 collection/SQLite matrix.
+
+| engine / format | layout | ns/doc | docs/sec | disk B/doc |
+| --- | --- | ---: | ---: | ---: |
+| TreeDB template-v1 | default index leaves | 926.10 | 1,079,797 | 155.10 |
+| TreeDB JSON | default index leaves | 1,040.67 | 960,922 | 153.70 |
+| SQLite native columns | WAL normal | 2,221.33 | 450,180 | 175.77 |
+| SQLite JSON | WAL normal | 2,533.67 | 394,685 | 262.30 |
+
+Source:
+[April 27 collection/SQLite matrix](docs/benchmarks/collections_rewrite_vacuum_matrix_pr1075_2026-04-27.md).
+
+### Collection Read And Lookup Workload
+
+Two secondary indexes, April 27 collection/SQLite matrix.
+
+| operation | TreeDB template-v1 ops/sec | TreeDB JSON ops/sec | SQLite native columns ops/sec | SQLite JSON ops/sec |
+| --- | ---: | ---: | ---: | ---: |
+| Primary read | 771,803 | 524,843 | 357,398 | 473,634 |
+| Unique secondary lookup | 815,661 | 845,785 | 484,574 | 442,478 |
+| Nonunique secondary lookup | 243,625 | 257,356 | 68,815 | 39,399 |
+
+Source:
+[April 27 collection/SQLite matrix](docs/benchmarks/collections_rewrite_vacuum_matrix_pr1075_2026-04-27.md).
+
+### Collection Storage Density Workload
+
+Two secondary indexes, April 27 collection/SQLite matrix. The index-vlog rows
+move index outer leaves into the persistent value log.
+
+| engine / format | layout / maintenance | docs/sec | B/doc |
+| --- | --- | ---: | ---: |
+| TreeDB template-v1 | default index leaves | 1,079,797 | 155.10 |
+| TreeDB template-v1 | index outer leaves in value log | 941,029 | 104.90 |
+| SQLite native columns | after `VACUUM` | - | 156.40 |
+| SQLite JSON | after `VACUUM` | - | 231.40 |
+
+Source:
+[April 27 collection/SQLite matrix](docs/benchmarks/collections_rewrite_vacuum_matrix_pr1075_2026-04-27.md).
+
+### `application.db` Offline Density Workload
+
+Offline compacted-size comparison from the April 13 density report.
+
+| engine | compacted size | workflow |
+| --- | ---: | --- |
+| PebbleDB | 1.773 GiB | aggressive rebuild, then full compact |
+| TreeDB | 2.092 GiB | self-roundtrip rebuild, then offline `vlog_rewrite` |
+| goleveldb | 2.316 GiB | aggressive rebuild, then full compact |
+
+Source:
+[April 13 density report](docs/benchmarks/application_db_engine_matrix_2026-04-13.md).
 
 ## What TreeDB Provides
 

--- a/README.md
+++ b/README.md
@@ -51,25 +51,16 @@ running relaxed durability or a benchmark ceiling.
 ### Indexed Collection Insert Workload
 
 Two secondary indexes, June 2 rerun, `100000` documents, batch size `16000`,
-and `command_wal_relaxed` for TreeDB. The first table is timed post-insert
-throughput; its B/doc column is not compacted storage.
+and `command_wal_relaxed` for TreeDB. Throughput columns are timed insert
+measurements; B/doc uses the fully compacted storage phase from the same
+canonical run.
 
-| engine / format | layout | ns/doc | docs/sec | post-insert B/doc |
+| engine / format | layout | ns/doc | docs/sec | fully compacted B/doc |
 | --- | --- | ---: | ---: | ---: |
-| TreeDB JSON | data and index outer leaves in value log | 3,730 | 268,097 | 233.2 |
-| SQLite native columns | WAL normal | 4,026 | 248,385 | 176.1 |
-| TreeDB template-v1 | data and index outer leaves in value log | 4,451 | 224,669 | 214.8 |
-| SQLite JSON | WAL normal | 4,512 | 221,631 | 262.6 |
-
-Compacted-state storage comparison from the same canonical run:
-
-| engine / format | phase | B/doc | basis |
-| --- | --- | ---: | --- |
-| TreeDB template-v1 | `full_leafgen_pack_gc` | 22.2 | full leaf generation pack/GC plus offline index vacuum |
-| TreeDB JSON | `full_leafgen_pack_gc` | 30.4 | full leaf generation pack/GC plus offline index vacuum |
-| TreeDB template-v1 | `offline_compact` | 49.7 | high-level `treemap compact <dir> -rw` |
-| SQLite native columns | `sqlite_vacuum` | 156.7 | SQLite `VACUUM` |
-| SQLite JSON | `sqlite_vacuum` | 231.7 | SQLite `VACUUM` |
+| TreeDB JSON | data and index outer leaves in value log | 3,730 | 268,097 | 30.4 |
+| SQLite native columns | WAL normal | 4,026 | 248,385 | 156.7 |
+| TreeDB template-v1 | data and index outer leaves in value log | 4,451 | 224,669 | 22.2 |
+| SQLite JSON | WAL normal | 4,512 | 221,631 | 231.7 |
 
 Source:
 [June 2 two-index insert rerun](docs/benchmarks/collections_insert_two_index_current_2026-06-02.md).

--- a/README.md
+++ b/README.md
@@ -50,17 +50,29 @@ running relaxed durability or a benchmark ceiling.
 
 ### Indexed Collection Insert Workload
 
-Two secondary indexes, April 27 collection/SQLite matrix.
+Two secondary indexes, June 2 rerun, `100000` documents, batch size `16000`,
+and `command_wal_relaxed` for TreeDB. The first table is timed post-insert
+throughput; its B/doc column is not compacted storage.
 
-| engine / format | layout | ns/doc | docs/sec | disk B/doc |
+| engine / format | layout | ns/doc | docs/sec | post-insert B/doc |
 | --- | --- | ---: | ---: | ---: |
-| TreeDB template-v1 | default index leaves | 926.10 | 1,079,797 | 155.10 |
-| TreeDB JSON | default index leaves | 1,040.67 | 960,922 | 153.70 |
-| SQLite native columns | WAL normal | 2,221.33 | 450,180 | 175.77 |
-| SQLite JSON | WAL normal | 2,533.67 | 394,685 | 262.30 |
+| TreeDB JSON | data and index outer leaves in value log | 3,730 | 268,097 | 233.2 |
+| SQLite native columns | WAL normal | 4,026 | 248,385 | 176.1 |
+| TreeDB template-v1 | data and index outer leaves in value log | 4,451 | 224,669 | 214.8 |
+| SQLite JSON | WAL normal | 4,512 | 221,631 | 262.6 |
+
+Compacted-state storage comparison from the same canonical run:
+
+| engine / format | phase | B/doc | basis |
+| --- | --- | ---: | --- |
+| TreeDB template-v1 | `full_leafgen_pack_gc` | 22.2 | full leaf generation pack/GC plus offline index vacuum |
+| TreeDB JSON | `full_leafgen_pack_gc` | 30.4 | full leaf generation pack/GC plus offline index vacuum |
+| TreeDB template-v1 | `offline_compact` | 49.7 | high-level `treemap compact <dir> -rw` |
+| SQLite native columns | `sqlite_vacuum` | 156.7 | SQLite `VACUUM` |
+| SQLite JSON | `sqlite_vacuum` | 231.7 | SQLite `VACUUM` |
 
 Source:
-[April 27 collection/SQLite matrix](docs/benchmarks/collections_rewrite_vacuum_matrix_pr1075_2026-04-27.md).
+[June 2 two-index insert rerun](docs/benchmarks/collections_insert_two_index_current_2026-06-02.md).
 
 ### Collection Read And Lookup Workload
 
@@ -200,6 +212,7 @@ Current YCSB status and rerun commands:
 
 Collection and engine benchmark runbooks:
 
+- `docs/benchmarks/collections_insert_two_index_current_2026-06-02.md`
 - `docs/benchmarks/treedb_canonical_benchmark_runbook.md`
 - `docs/benchmarks/collections_canonical_benchmark.md`
 - `cmd/unified_bench/README.md`

--- a/README.md
+++ b/README.md
@@ -42,6 +42,34 @@ The `bench` profile is a no-WAL benchmark-only ceiling. Use
 `command_wal_durable` as the default server profile unless you are deliberately
 running relaxed durability or a benchmark ceiling.
 
+## Additional Benchmark Highlights
+
+These are separate report-backed engineering benchmarks with their own
+workloads, profiles, and caveats. Treat them as scoped evidence, not as extra
+rows in the YCSB comparison above.
+
+- In the April 27, 2026 collection/SQLite matrix, two-index TreeDB collection
+  inserts measured `1,079,797 docs/sec` for template-v1 and
+  `960,922 docs/sec` for JSON, versus SQLite JSON at `394,685 docs/sec` and
+  SQLite native columns at `450,180 docs/sec`.
+- The same matrix measured two-index template-v1 primary reads at
+  `771,803 ops/sec`, parallel primary reads at `1,503,458 ops/sec`, and
+  nonunique secondary lookups at `243,625 ops/sec` for template-v1 and
+  `257,356 ops/sec` for JSON; the SQLite nonunique secondary lookup rows were
+  `39,399 ops/sec` for JSON and `68,815 ops/sec` for native columns.
+- Its index-vlog layout reduced two-index TreeDB template-v1 storage from
+  `155.10 B/doc` to `104.90 B/doc`, below SQLite native columns after
+  `VACUUM` at `156.40 B/doc`, with roughly a `13-14%` write-throughput cost on
+  that insert shape.
+- In the April 13, 2026 `application.db` offline density report, TreeDB's
+  self-roundtrip compacted size was `2.092 GiB`, between PebbleDB at
+  `1.773 GiB` and goleveldb at `2.316 GiB`.
+
+Sources:
+[`collections_rewrite_vacuum_matrix_pr1075_2026-04-27.md`](docs/benchmarks/collections_rewrite_vacuum_matrix_pr1075_2026-04-27.md)
+and
+[`application_db_engine_matrix_2026-04-13.md`](docs/benchmarks/application_db_engine_matrix_2026-04-13.md).
+
 ## What TreeDB Provides
 
 - Persistent B+Tree index with copy-on-write root publishing.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,20 @@ TreeDB is pre-alpha:
 - Benchmark DB directories should be rebuilt from scratch unless a report says
   otherwise.
 
+## Benchmark Highlights
+
+These checked-in reports use different workloads, profiles, and caveats. Treat
+each row as scoped evidence from its linked benchmark, not as one combined
+benchmark suite.
+
+| workload | TreeDB result | comparison / context | report |
+| --- | ---: | --- | --- |
+| YCSB run phase | nativewire durable `120,500.7 ops/sec`; nativewire relaxed `126,762.5 ops/sec`; Mongo gateway durable `74,544.7 ops/sec` | MongoDB 8 baseline `26,102.5 ops/sec`; full table below | [June 2 YCSB](docs/benchmarks/ycsb_post_update_stack_2026-06-02.md) |
+| Two-index collection insert | template-v1 `1,079,797 docs/sec`; JSON `960,922 docs/sec` | SQLite JSON `394,685 docs/sec`; SQLite native columns `450,180 docs/sec` | [April 27 matrix](docs/benchmarks/collections_rewrite_vacuum_matrix_pr1075_2026-04-27.md) |
+| Collection read/lookup | template-v1 primary read `771,803 ops/sec`; parallel primary read `1,503,458 ops/sec`; nonunique secondary lookup `243,625-257,356 ops/sec` | SQLite nonunique secondary lookup `39,399-68,815 ops/sec` | [April 27 matrix](docs/benchmarks/collections_rewrite_vacuum_matrix_pr1075_2026-04-27.md) |
+| Collection storage density | index-vlog template-v1 `104.90 B/doc` | default template-v1 `155.10 B/doc`; SQLite native columns after `VACUUM` `156.40 B/doc`; `13-14%` write-throughput cost | [April 27 matrix](docs/benchmarks/collections_rewrite_vacuum_matrix_pr1075_2026-04-27.md) |
+| `application.db` offline density | TreeDB self-roundtrip compacted size `2.092 GiB` | PebbleDB `1.773 GiB`; goleveldb `2.316 GiB` | [April 13 density](docs/benchmarks/application_db_engine_matrix_2026-04-13.md) |
+
 ## Current YCSB Headline
 
 External `go-ycsb`, local loopback TCP, `recordcount=100000`,
@@ -41,34 +55,6 @@ Full report, commands, host context, run repeats, and artifact paths:
 The `bench` profile is a no-WAL benchmark-only ceiling. Use
 `command_wal_durable` as the default server profile unless you are deliberately
 running relaxed durability or a benchmark ceiling.
-
-## Additional Benchmark Highlights
-
-These are separate report-backed engineering benchmarks with their own
-workloads, profiles, and caveats. Treat them as scoped evidence, not as extra
-rows in the YCSB comparison above.
-
-- In the April 27, 2026 collection/SQLite matrix, two-index TreeDB collection
-  inserts measured `1,079,797 docs/sec` for template-v1 and
-  `960,922 docs/sec` for JSON, versus SQLite JSON at `394,685 docs/sec` and
-  SQLite native columns at `450,180 docs/sec`.
-- The same matrix measured two-index template-v1 primary reads at
-  `771,803 ops/sec`, parallel primary reads at `1,503,458 ops/sec`, and
-  nonunique secondary lookups at `243,625 ops/sec` for template-v1 and
-  `257,356 ops/sec` for JSON; the SQLite nonunique secondary lookup rows were
-  `39,399 ops/sec` for JSON and `68,815 ops/sec` for native columns.
-- Its index-vlog layout reduced two-index TreeDB template-v1 storage from
-  `155.10 B/doc` to `104.90 B/doc`, below SQLite native columns after
-  `VACUUM` at `156.40 B/doc`, with roughly a `13-14%` write-throughput cost on
-  that insert shape.
-- In the April 13, 2026 `application.db` offline density report, TreeDB's
-  self-roundtrip compacted size was `2.092 GiB`, between PebbleDB at
-  `1.773 GiB` and goleveldb at `2.316 GiB`.
-
-Sources:
-[`collections_rewrite_vacuum_matrix_pr1075_2026-04-27.md`](docs/benchmarks/collections_rewrite_vacuum_matrix_pr1075_2026-04-27.md)
-and
-[`application_db_engine_matrix_2026-04-13.md`](docs/benchmarks/application_db_engine_matrix_2026-04-13.md).
 
 ## What TreeDB Provides
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Source:
 Build the primary TreeDB servers:
 
 ```sh
+mkdir -p bin
 go build -o bin/treedb-native-server ./cmd/treedb-native-server
 go build -o bin/treedb-mongo-gateway ./TreeDB/mongo_gateway/server.go
 ```

--- a/README.md
+++ b/README.md
@@ -50,17 +50,17 @@ running relaxed durability or a benchmark ceiling.
 
 ### Indexed Collection Insert Workload
 
-Two secondary indexes, June 2 rerun, `100000` documents, batch size `16000`,
-and `command_wal_relaxed` for TreeDB. Throughput columns are timed insert
-measurements; B/doc uses the fully compacted storage phase from the same
-canonical run.
+Two secondary indexes, June 2 current-code rerun, `100000` documents, batch
+size `16000`, and `command_wal_relaxed` for TreeDB. Throughput columns are timed
+insert measurements for the value-log outer-leaf layout; B/doc uses the fully
+compacted storage phase for the same TreeDB layout and SQLite after `VACUUM`.
 
 | engine / format | layout | ns/doc | docs/sec | fully compacted B/doc |
 | --- | --- | ---: | ---: | ---: |
-| TreeDB JSON | data and index outer leaves in value log | 3,730 | 268,097 | 30.4 |
-| SQLite native columns | WAL normal | 4,026 | 248,385 | 156.7 |
-| TreeDB template-v1 | data and index outer leaves in value log | 4,451 | 224,669 | 22.2 |
-| SQLite JSON | WAL normal | 4,512 | 221,631 | 231.7 |
+| TreeDB template-v1 | data and index outer leaves in value log | 1,595 | 626,959 | 22.2 |
+| TreeDB JSON | data and index outer leaves in value log | 2,384 | 419,463 | 30.4 |
+| SQLite native columns | WAL normal | 3,023 | 330,797 | 156.7 |
+| SQLite JSON | WAL normal | 3,310 | 302,115 | 231.7 |
 
 Source:
 [June 2 two-index insert rerun](docs/benchmarks/collections_insert_two_index_current_2026-06-02.md).

--- a/README.md
+++ b/README.md
@@ -73,16 +73,17 @@ Source:
 
 ### `application.db` Offline Density Workload
 
-Offline compacted-size comparison from the April 13 density report.
+Offline compacted-size comparison from the June 2 Celestia `application.db`
+rerun.
 
 | engine | compacted size | workflow |
 | --- | ---: | --- |
-| PebbleDB | 1.773 GiB | aggressive rebuild, then full compact |
-| TreeDB | 2.092 GiB | self-roundtrip rebuild, then offline `vlog_rewrite` |
-| goleveldb | 2.316 GiB | aggressive rebuild, then full compact |
+| TreeDB | 1.690 GiB | `command_wal_relaxed`, rebuild, `CompactStorageFull`, offline index vacuum |
+| PebbleDB | 2.108 GiB | snappy, 64 KiB blocks, 64 MiB target files, full compact |
+| goleveldb | 2.221 GiB | snappy, 64 KiB blocks, restart interval 256, full compact |
 
 Source:
-[April 13 density report](docs/benchmarks/application_db_engine_matrix_2026-04-13.md).
+[June 2 density rerun](docs/benchmarks/application_db_engine_matrix_2026-06-02.md).
 
 ## What TreeDB Provides
 

--- a/README.md
+++ b/README.md
@@ -71,21 +71,6 @@ Two secondary indexes, April 27 collection/SQLite matrix.
 Source:
 [April 27 collection/SQLite matrix](docs/benchmarks/collections_rewrite_vacuum_matrix_pr1075_2026-04-27.md).
 
-### Collection Storage Density Workload
-
-Two secondary indexes, April 27 collection/SQLite matrix. The index-vlog rows
-move index outer leaves into the persistent value log.
-
-| engine / format | layout / maintenance | docs/sec | B/doc |
-| --- | --- | ---: | ---: |
-| TreeDB template-v1 | default index leaves | 1,079,797 | 155.10 |
-| TreeDB template-v1 | index outer leaves in value log | 941,029 | 104.90 |
-| SQLite native columns | after `VACUUM` | - | 156.40 |
-| SQLite JSON | after `VACUUM` | - | 231.40 |
-
-Source:
-[April 27 collection/SQLite matrix](docs/benchmarks/collections_rewrite_vacuum_matrix_pr1075_2026-04-27.md).
-
 ### `application.db` Offline Density Workload
 
 Offline compacted-size comparison from the April 13 density report.

--- a/README.md
+++ b/README.md
@@ -1,174 +1,184 @@
-# gomap (dev): HashDB + TreeDB
+# TreeDB
 
-This repo is a development playground for two storage engines plus benchmarking tools:
+TreeDB is a pre-alpha persistent storage engine built around a copy-on-write
+B+Tree, a persistent value log, and command-WAL recovery. It includes a native
+wire server, a Mongo-compatible gateway, a collection/document layer, secondary
+indexes, and benchmark tooling for comparing TreeDB against MongoDB and other
+engines.
 
-- **Status: pre-alpha.** APIs and on-disk formats may change without backward-compatibility guarantees.
+TreeDB is the main focus of this repository. The repo also contains HashDB, an
+older mmap-backed hash engine used for experiments and comparison; see
+`HashDB/README.md`.
 
-- **HashDB** (`HashDB/`, package `hashdb`): mmap-backed hash index + slab value log.
-- **TreeDB** (`TreeDB/`, package `treedb`): persistent B+Tree with an optional cached write-back layer.
-- **BTreeOnHashDB** (`HashDB/BTreeOnHashDB/`): a B-Tree built on top of HashDB (benchmark/comparison).
-- **Unified Bench** (`cmd/unified_bench/`): runs a consistent workload across engines.
+## Status
+
+TreeDB is pre-alpha:
+
+- APIs and on-disk formats may change without backward-compatibility guarantees.
+- New binaries may intentionally reject old DB directories.
+- Benchmark DB directories should be rebuilt from scratch unless a report says
+  otherwise.
+
+## Current YCSB Headline
+
+External `go-ycsb`, local loopback TCP, `recordcount=100000`,
+`operationcount=10000`, `threadcount=16`, BSON document format, and zero YCSB
+operation errors. Run rows use the median total-throughput repeat from the
+June 2, 2026 report.
+
+| target | profile | load ops/sec | run ops/sec | run avg us | run p99 us |
+| --- | --- | ---: | ---: | ---: | ---: |
+| MongoDB 8 | baseline | 33,255.6 | 26,102.5 | 601.0 | 1,461.0 |
+| TreeDB nativewire | `command_wal_durable` | 77,065.3 | 120,500.7 | 128.0 | 477.0 |
+| TreeDB Mongo gateway | `command_wal_durable` | 57,370.1 | 74,544.7 | 206.0 | 649.0 |
+| TreeDB nativewire | `command_wal_relaxed` | 76,411.7 | 126,762.5 | 121.0 | 374.0 |
+| TreeDB Mongo gateway | `command_wal_relaxed` | 62,444.0 | 75,371.9 | 203.0 | 629.0 |
+| TreeDB nativewire | `bench` no-WAL | 85,201.7 | 134,415.5 | 114.0 | 365.0 |
+
+Full report, commands, host context, run repeats, and artifact paths:
+`docs/benchmarks/ycsb_post_update_stack_2026-06-02.md`.
+
+The `bench` profile is a no-WAL benchmark-only ceiling. Use
+`command_wal_durable` as the default server profile unless you are deliberately
+running relaxed durability or a benchmark ceiling.
+
+## What TreeDB Provides
+
+- Persistent B+Tree index with copy-on-write root publishing.
+- Persistent value log for large values and leaf/value placement experiments.
+- Command WAL for collection and raw-key redo/recovery.
+- Snapshot-isolated readers and exclusive process-level DB directory locking.
+- Collection/document APIs with BSON, template-v1, secondary indexes, and vector
+  search experiments.
+- Native wire protocol through `cmd/treedb-native-server`.
+- Mongo-compatible gateway through `TreeDB/mongo_gateway`.
+- Benchmark and profiling scripts for YCSB, collections, vector search, and
+  storage-engine comparison.
 
 ## Quickstart
 
-- `make test`
-- `make build`
-- `make unified-bench && ./bin/unified-bench`
+Build the primary TreeDB servers:
 
-More docs:
+```sh
+go build -o bin/treedb-native-server ./cmd/treedb-native-server
+go build -o bin/treedb-mongo-gateway ./TreeDB/mongo_gateway/server.go
+```
 
-- `docs/README.md`
-- `docs/GETTING_STARTED.md`
-- `docs/TREEDB_CACHED_VS_BACKEND.md`
-- `docs/TREEDB_CONCEPTS.md`
-- `docs/TREEDB_STORAGE_FORMAT.md`
-- `docs/TREEDB_RECOVERY.md`
-- `CONTRIBUTING.md`
+Run the native server:
 
-## Choosing An Engine
+```sh
+./bin/treedb-native-server \
+  -dir /tmp/treedb-native \
+  -profile command_wal_durable \
+  -addr 127.0.0.1:17130
+```
 
-High-level guidance:
+Run the Mongo-compatible gateway:
 
-- **HashDB**: best for high-throughput random reads and perf experiments; use `PutSync`/`DeleteSync`/`ApplyBatchSync` for durable commits (non-`*Sync` writes are best-effort; sharded HashDB uses a write-back cache and can optionally enable a per-shard cache WAL via `OpenWithOptions`).
-- **TreeDB (cached, default)**: best for workloads dominated by many small random writes; WAL on/off is configurable; use `*Sync` for durability.
+```sh
+./bin/treedb-mongo-gateway \
+  -dir /tmp/treedb-mongo \
+  -profile command_wal_durable \
+  -document-format bson \
+  -addr 127.0.0.1:27130
+```
 
-Contracts (durability/locking/concurrency/iteration):
+Minimal Go usage:
 
-- `docs/contracts/README.md`
+```go
+package main
+
+import (
+	"fmt"
+	"log"
+
+	treedb "github.com/snissn/gomap/TreeDB"
+)
+
+func main() {
+	opts := treedb.OptionsFor(treedb.ProfileCommandWALDurable, "./my-db")
+	db, err := treedb.Open(opts)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer db.Close()
+
+	if err := db.Set([]byte("key"), []byte("value")); err != nil {
+		log.Fatal(err)
+	}
+	value, err := db.Get([]byte("key"))
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(string(value))
+}
+```
+
+## Profiles
+
+The current public TreeDB profile surface is intentionally small:
+
+- `command_wal_durable`: recommended server default; command WAL enabled with
+  durable sync/checksum settings.
+- `command_wal_relaxed`: command WAL enabled with relaxed sync/read-integrity
+  settings for high-throughput ingest and comparative benchmarks.
+- `bench`: explicit no-WAL benchmark-only ceiling.
+
+Legacy/raw profile names are retained only for compatibility and focused
+low-level tests. They should not be used as public server defaults.
+
+More detail: `docs/TREEDB_PROFILES.md` and `docs/TREEDB_WRITE_PATHS.md`.
 
 ## Benchmarking
 
-Primary tool: `cmd/unified_bench/` (side-by-side: HashDB, TreeDB, Badger, LevelDB).
+Current YCSB status and rerun commands:
 
-- Run: `make unified-bench && ./bin/unified-bench`
-- Sweep key counts (markdown output): `./bin/unified-bench -format markdown -keycounts 100000,1000000`
-- Profile + analyze (recommended):
-  - `OUT=$(mktemp -d /tmp/gomap_profiles_XXXXXX)`
-  - `./bin/unified-bench ... -profile-dir "$OUT"`
-  - `make benchprof && ./bin/benchprof -profiles-dir "$OUT"`
-- Update the README benchmark snapshot: `make bench-readme`
+- `docs/benchmarks/ycsb_mongodb_treedb_current.md`
+- `docs/benchmarks/ycsb_post_update_stack_2026-06-02.md`
+- `scripts/ycsb_compare_mongodb_treedb.sh`
 
-More details:
+Collection and engine benchmark runbooks:
 
+- `docs/benchmarks/treedb_canonical_benchmark_runbook.md`
+- `docs/benchmarks/collections_canonical_benchmark.md`
 - `cmd/unified_bench/README.md`
 - `cmd/benchprof/README.md`
-- `docs/BENCHMARK_SPEC.md`
 
-<!-- BENCHMARK_START -->
-_Generated by `go run ./cmd/unified_bench -suite readme -format markdown`._
+Profile capture workflow:
 
-_Generated at:_ 2025-12-16T22:33:24Z
-_Environment:_ darwin/arm64 | Go go1.25.5 | CPUs 8 | RAM 16 GiB | CPU Apple M3 | Model Mac15,13
-_Seed:_ 1
+```sh
+OUT=$(mktemp -d /tmp/gomap_profiles_XXXXXX)
+./bin/unified-bench ... -profile-dir "$OUT"
+./bin/benchprof -profiles-dir "$OUT"
+```
 
-_Key counts:_ 1…1,000,000 (valsize=128, batchsize=1000, range-queries=200, range-span=100)
+## Documentation
 
-Notes:
-- Results depend on hardware and OS.
-- `HashDB` does not support ordered scans.
+- TreeDB canonical spec: `TreeDB/docs/spec/README.md`
+- TreeDB guides: `TreeDB/docs/guides/README.md`
+- TreeDB concepts: `docs/TREEDB_CONCEPTS.md`
+- TreeDB storage format: `docs/TREEDB_STORAGE_FORMAT.md`
+- TreeDB recovery: `docs/TREEDB_RECOVERY.md`
+- TreeDB collection quickstart: `docs/TREEDB_COLLECTION_QUICKSTART.md`
+- Contracts: `docs/contracts/README.md`
+- Full docs index: `docs/README.md`
 
-### Graphs
+## Repo Contents
 
-![Unified bench: point ops scaling](docs/images/unified_bench_point_ops.png)
-
-![Unified bench: batch + scans scaling](docs/images/unified_bench_batch_scans.png)
-
-### Point Ops (writes + gets)
-
-_Key counts:_ 1, 10, 100, 1,000, 10,000, 100,000, 1,000,000
-
-#### Sequential Write
-
-| keys | HashDB | TreeDB | Badger | LevelDB |
-|---:|---:|---:|---:|---:|
-| 1 | 510,725 | **1,712,329** | 54,918 | 263,713 |
-| 10 | 1,983,340 | **3,528,582** | 178,571 | 326,083 |
-| 100 | 4,780,800 | **5,063,291** | 168,812 | 419,287 |
-| 1,000 | **7,192,123** | 3,799,262 | 248,669 | 463,043 |
-| 10,000 | **11,378,182** | 4,221,413 | 218,227 | 499,895 |
-| 100,000 | **9,683,472** | 2,512,929 | 216,848 | 397,116 |
-| 1,000,000 | 1,424,436 | **2,226,944** | 203,911 | 198,315 |
-
-#### Random Write
-
-| keys | HashDB | TreeDB | Badger | LevelDB |
-|---:|---:|---:|---:|---:|
-| 1 | 1,600,000 | **3,003,003** | 218,198 | 300,030 |
-| 10 | 3,478,261 | **4,444,444** | 223,464 | 446,090 |
-| 100 | **5,429,766** | 4,116,582 | 58,857 | 409,417 |
-| 1,000 | **7,899,893** | 3,092,777 | 183,454 | 445,244 |
-| 10,000 | **7,544,084** | 2,304,435 | 202,036 | 435,469 |
-| 100,000 | **5,498,282** | 1,724,264 | 174,231 | 202,791 |
-| 1,000,000 | **1,286,706** | 1,133,272 | 141,807 | 83,609 |
-
-#### Random Read
-
-| keys | HashDB | TreeDB | Badger | LevelDB |
-|---:|---:|---:|---:|---:|
-| 1 | **2,000,000** | 1,600,000 | 269,687 | 1,333,333 |
-| 10 | **9,606,148** | 6,317,119 | 995,818 | 1,764,602 |
-| 100 | **10,908,694** | 8,571,184 | 822,761 | 3,234,571 |
-| 1,000 | **15,604,763** | 5,578,801 | 705,592 | 2,977,670 |
-| 10,000 | **16,003,201** | 4,215,999 | 1,154,268 | 2,170,453 |
-| 100,000 | 451,616 | **1,765,626** | 663,813 | 277,092 |
-| 1,000,000 | 255,763 | **618,247** | 299,327 | 162,509 |
-
-
-### Batch + Scans
-
-_Key counts:_ 1, 10, 100, 1,000, 10,000, 100,000, 1,000,000
-
-#### Batch Write
-
-| keys | TreeDB | Badger | LevelDB |
-|---:|---:|---:|---:|
-| 1 | **235,294** | 55,685 | 315 |
-| 10 | **1,283,368** | 516,129 | 23,552 |
-| 100 | **3,883,495** | 1,325,223 | 40,679 |
-| 1,000 | **8,645,583** | 2,230,694 | 1,268,633 |
-| 10,000 | 3,455,774 | 2,232,392 | 827,923 |
-| 100,000 | 2,688,922 | 1,991,356 | 485,423 |
-| 1,000,000 | **2,059,133** | 1,530,078 | 700,450 |
-
-#### Full Scan
-
-| keys | TreeDB | Badger | LevelDB |
-|---:|---:|---:|---:|
-| 1 | 44,944 | 81,360 | 158,932 |
-| 10 | 53,214 | 186,047 | 2,329,916 |
-| 100 | 6,946 | 20,000 | **3,438,435** |
-| 1,000 | 49,793 | 163,265 | 20,184,894 |
-| 10,000 | 357,143 | 461,531 | 22,643,646 |
-| 100,000 | 200,988 | 1,331,842 | 6,679,896 |
-| 1,000,000 | 1,503,759 | 940,402 | **2,987,744** |
-
-#### Prefix Scan
-
-| keys | TreeDB | Badger | LevelDB |
-|---:|---:|---:|---:|
-| 1 | 2,313,262 | 360,009 | 1,503,759 |
-| 10 | 4,747,774 | 365,491 | 5,183,542 |
-| 100 | 5,155,835 | 362,455 | 15,768,899 |
-| 1,000 | 661,072 | 53,031 | 19,055,167 |
-| 10,000 | 495,519 | 18,224 | 14,127,553 |
-| 100,000 | 347,390 | 4,681 | 10,851,872 |
-| 1,000,000 | 223,210 | 1,858 | 2,303,174 |
-
-
-### Quick takeaways
-
-- `HashDB`: great for high-throughput point reads/writes; no ordered scan API yet.
-- `TreeDB` (cached): strong default for random-write-heavy workloads; scans include merge overhead.
-- `Badger`/`LevelDB`: useful baselines with different storage tradeoffs.
-<!-- BENCHMARK_END -->
+- `TreeDB/`: TreeDB storage engine, collection layer, native APIs, command WAL,
+  and Mongo gateway.
+- `cmd/treedb-native-server/`: native wire server.
+- `TreeDB/mongo_gateway/`: Mongo-compatible TreeDB gateway.
+- `cmd/unified_bench/`: cross-engine benchmark harness.
+- `cmd/benchprof/`: profile/result summarizer.
+- `HashDB/`: mmap-backed hash-index engine used for experiments and comparison.
 
 ## Testing
 
-- `go test ./...`
-- `cd TreeDB && go test ./...`
-- `cd cmd/unified_bench && go test ./...`
+```sh
+go test ./...
+go test ./TreeDB/... ./cmd/treedb-native-server ./TreeDB/mongo_gateway
+```
 
-## Notes
-
-- Exclusive open: TreeDB and HashDB take an exclusive lock on the DB directory (`ErrLocked`).
-- On-disk formats and public APIs may evolve; see `docs/API_STABILITY.md`.
+For large benchmark runs, prefer a fresh DB directory and record the exact
+commit, host, profile, command, and artifact path in the report.

--- a/README.md
+++ b/README.md
@@ -37,30 +37,23 @@ June 2, 2026 report.
 | MongoDB 8 | baseline | 33,255.6 | 26,102.5 | 601.0 | 1,461.0 |
 | TreeDB nativewire | `command_wal_durable` | 77,065.3 | 120,500.7 | 128.0 | 477.0 |
 | TreeDB Mongo gateway | `command_wal_durable` | 57,370.1 | 74,544.7 | 206.0 | 649.0 |
-| TreeDB nativewire | `command_wal_relaxed` | 76,411.7 | 126,762.5 | 121.0 | 374.0 |
-| TreeDB Mongo gateway | `command_wal_relaxed` | 62,444.0 | 75,371.9 | 203.0 | 629.0 |
-| TreeDB nativewire | `bench` no-WAL | 85,201.7 | 134,415.5 | 114.0 | 365.0 |
 
 Full report, commands, host context, run repeats, and artifact paths:
 [June 2 YCSB report](docs/benchmarks/ycsb_post_update_stack_2026-06-02.md).
 
-The `bench` profile is a no-WAL benchmark-only ceiling. Use
-`command_wal_durable` as the default server profile unless you are deliberately
-running relaxed durability or a benchmark ceiling.
-
 ### Indexed Collection Insert Workload
 
 Two secondary indexes, June 2 current-code rerun, `100000` documents, batch
-size `16000`, and `command_wal_relaxed` for TreeDB. Throughput columns are timed
-insert measurements for the value-log outer-leaf layout; B/doc uses the fully
+size `16000`, and `command_wal_relaxed` for TreeDB. `docs/sec` is the timed
+insert measurement for the value-log outer-leaf layout; B/doc uses the fully
 compacted storage phase for the same TreeDB layout and SQLite after `VACUUM`.
 
-| engine / format | layout | ns/doc | docs/sec | fully compacted B/doc |
-| --- | --- | ---: | ---: | ---: |
-| TreeDB template-v1 | data and index outer leaves in value log | 1,595 | 626,959 | 22.2 |
-| TreeDB JSON | data and index outer leaves in value log | 2,384 | 419,463 | 30.4 |
-| SQLite native columns | WAL normal | 3,023 | 330,797 | 156.7 |
-| SQLite JSON | WAL normal | 3,310 | 302,115 | 231.7 |
+| engine / format | layout | docs/sec | fully compacted B/doc |
+| --- | --- | ---: | ---: |
+| TreeDB template-v1 | data and index outer leaves in value log | 626,959 | 22.2 |
+| TreeDB JSON | data and index outer leaves in value log | 419,463 | 30.4 |
+| SQLite native columns | WAL normal | 330,797 | 156.7 |
+| SQLite JSON | WAL normal | 302,115 | 231.7 |
 
 Source:
 [June 2 two-index insert rerun](docs/benchmarks/collections_insert_two_index_current_2026-06-02.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -48,6 +48,7 @@ Behavioral guarantees for downstream systems (e.g., replication layers).
 - **[TreeDB Canonical Benchmark Runbook](benchmarks/treedb_canonical_benchmark_runbook.md)**: Standard TreeDB engine, collections, Mongo gateway, profiling, and reporting workflows.
 - **[YCSB MongoDB / TreeDB Status](benchmarks/ycsb_mongodb_treedb_current.md)**: Current report index and rerun plan for MongoDB, `treedb-native`, and TreeDB Mongo gateway.
 - **[TreeDB Collections Canonical Benchmark](benchmarks/collections_canonical_benchmark.md)**: Canonical TreeDB-vs-SQLite collection benchmark and maintenance-phase semantics.
+- **[Two-Index Collection Insert Rerun](benchmarks/collections_insert_two_index_current_2026-06-02.md)**: Current TreeDB-vs-SQLite two-index insert throughput and compacted storage rows.
 - **[Unified Bench](../cmd/unified_bench/README.md)**: Usage guide for benchmark execution and artifact capture.
 - **[BenchProf](../cmd/benchprof/README.md)**: Analysis tool for CPU/alloc/block/mutex profiles and ops/sec outputs.
 - **[Redis Protocol Benchmarking](REDIS_PROTOCOL_BENCHMARKING.md)**: Preferred way to measure Redis wrapper throughput.

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,7 @@ TreeDB is a persistent B+Tree with a high-throughput cached write-back layer.
 
 HashDB is a high-performance, memory-mapped hash index optimized for random I/O.
 
+- **[HashDB README](../HashDB/README.md)**: Focused HashDB overview, entry points, durability model, and benchmark snapshot target.
 - **[Concepts](HASHDB_CONCEPTS.md)**: Design overview (Swiss Tables, Slab Log).
 - **[Tuning](HASHDB_TUNING.md)**: Memory policies and performance configuration.
 - **[Snapshots](HASHDB_SNAPSHOT.md)**: Export/Restore and consistent iteration.

--- a/docs/TREEDB_TUNING.md
+++ b/docs/TREEDB_TUNING.md
@@ -413,7 +413,8 @@ Details: `docs/TREEDB_STORAGE_FORMAT.md`.
 TreeDB performance depends heavily on workload shape. Prefer tuning with:
 
 - `./bin/unified-bench` (after `make unified-bench`)
-- `make bench-readme` (reproducible suite; prints environment metadata)
+- `./bin/unified-bench -suite readme -format markdown` for the reproducible
+  cross-engine snapshot shape with environment metadata
 
 Recommended “gate-style” suites:
 

--- a/docs/benchmarks/application_db_engine_matrix_2026-06-02.md
+++ b/docs/benchmarks/application_db_engine_matrix_2026-06-02.md
@@ -1,0 +1,173 @@
+# application.db Offline Density Comparison: TreeDB vs goleveldb vs PebbleDB
+
+Date: 2026-06-02
+
+## Summary
+
+This rerun rebuilds a fresh Celestia mainnet `application.db` snapshot into
+TreeDB, goleveldb, and PebbleDB, then runs each engine's offline cleanup path.
+The TreeDB result uses latest `origin/main` at
+`94e322a0727f7a0d07154a006e9fa4ec4e3936f4`.
+
+Primary compacted-size result:
+
+| engine | compacted size | workflow |
+| --- | ---: | --- |
+| TreeDB | 1.690 GiB | `command_wal_relaxed`, rebuild, `CompactStorageFull`, offline index vacuum |
+| PebbleDB | 2.108 GiB | snappy, 64 KiB blocks, 64 MiB target files, full compact |
+| goleveldb | 2.221 GiB | snappy, 64 KiB blocks, restart interval 256, full compact |
+
+TreeDB is now the smallest result in the reproducible three-engine run. It also
+rebuilt the source corpus fastest, at the cost of higher peak RSS during
+rebuild.
+
+## Source Corpus
+
+The source corpus came from a fresh Celestia mainnet state-sync restore using
+goleveldb.
+
+| item | value |
+| --- | --- |
+| Celestia binary | `celestia-app v8.0.8` |
+| Go toolchain for Celestia binary | `go1.26.2` |
+| source home | `/home/mikers/.celestia-app-mainnet-goleveldb-20260602102758` |
+| source DB | `/home/mikers/.celestia-app-mainnet-goleveldb-20260602102758/data/application.db` |
+| final local height | `11361318` |
+| frozen target height | `11361263` |
+| source size used by matrix | `2.573 GiB` |
+| keys copied | `46,798,257` |
+| key bytes copied | `1,467,857,658` |
+| value bytes copied | `4,090,720,389` |
+
+The state-sync run completed cleanly:
+
+```text
+sync_complete_utc=2026-06-02T20:40:08Z
+duration_seconds=718
+final_local_height=11361318
+final_remote_height=11361263
+end_app_bytes=2806978561
+```
+
+## Hardware And Environment
+
+| item | value |
+| --- | --- |
+| host | `mikers-B560-DS3H-AC-Y1` |
+| CPU | 11th Gen Intel Core i5-11400F, 6 cores / 12 threads |
+| memory | 31 GiB RAM |
+| filesystem | `/dev/nvme0n1p2`, NVMe-backed root filesystem |
+| date captured | 2026-06-02 |
+
+## Results
+
+| engine | rebuild s | compact s | rebuild max RSS GiB | compact max RSS GiB | rebuild size GiB | final size GiB | delta vs source GiB |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| TreeDB | 31.89 | 67.35 | 4.711 | 1.450 | 2.115 | 1.690 | -0.883 |
+| PebbleDB | 65.38 | 8.42 | 0.502 | 0.022 | 2.171 | 2.108 | -0.465 |
+| goleveldb | 83.14 | 59.58 | 0.323 | 0.051 | 2.222 | 2.221 | -0.352 |
+
+TreeDB compact stats:
+
+| stat | value |
+| --- | ---: |
+| fully compacted | true |
+| phase count | 17 |
+| leaf generation GC files deleted | 65 |
+| remaining leaf GC generations | 0 |
+| remaining leaf pack generations | 0 |
+| remaining value-log GC segments | 0 |
+| remaining value-log rewrite segments | 0 |
+| value-log rewrite bytes after | 36,817,789 |
+
+Artifacts:
+
+- report: `/tmp/application_db_engine_matrix_current_snappy_20260602_105146/results.md`
+- JSON: `/tmp/application_db_engine_matrix_current_snappy_20260602_105146/results.json`
+
+## Reproduction
+
+Build the current Celestia binary used for the source restore:
+
+```bash
+git -C /home/mikers/dev/snissn/celestia-app fetch upstream --tags
+rm -rf /tmp/celestia-app-v8.0.8
+git -C /home/mikers/dev/snissn/celestia-app worktree add \
+  /tmp/celestia-app-v8.0.8 v8.0.8
+cd /tmp/celestia-app-v8.0.8
+GOTOOLCHAIN=auto go build -o build/celestia-appd ./cmd/celestia-appd
+```
+
+Create a fresh LevelDB source DB:
+
+```bash
+env \
+  CELESTIA_APPD_BIN=/tmp/celestia-app-v8.0.8/build/celestia-appd \
+  DB_BACKEND=goleveldb \
+  APP_DB_BACKEND=goleveldb \
+  FREEZE_REMOTE_HEIGHT_AT_START=1 \
+  POST_SYNC_DWELL_SECONDS=0 \
+  CAPTURE_HEAP_ON_MAX_RSS=0 \
+  CAPTURE_FULL_SMAPS_ON_MAX_RSS=0 \
+  CAPTURE_DEBUG_VARS_ON_MAX_RSS=0 \
+  CAPTURE_PPROF_ON_STUCK=0 \
+  CAPTURE_PPROF_ON_WARN_STUCK=0 \
+  NO_PROGRESS_FAIL_SECONDS=3600 \
+  NO_PROGRESS_HARD_FAIL_SECONDS=7200 \
+  KEEP_RECENT_RUNS=12 \
+  /home/mikers/dev/snissn/celestia-app-p4/scripts/mainnet-treedb-fast-sync-forensics.sh
+```
+
+Run the matrix against latest TreeDB:
+
+```bash
+git -C /home/mikers/dev/snissn/gomap-clean fetch origin main
+rm -rf /tmp/gomap-latest-main-bench
+git -C /home/mikers/dev/snissn/gomap-clean worktree add \
+  --detach /tmp/gomap-latest-main-bench origin/main
+
+OUT_DIR=/tmp/application_db_engine_matrix_current_snappy_$(date +%Y%m%d_%H%M%S)
+SOURCE_APP_DB=/home/mikers/.celestia-app-mainnet-goleveldb-20260602102758/data/application.db
+
+TREEDB_REPO=/tmp/gomap-latest-main-bench \
+COSMOS_DB_REPO=/home/mikers/dev/snissn/cosmos-db \
+TREEDB_PROFILE=command_wal_relaxed \
+TREEDB_FORCE_CHECKPOINT_ON_WRITE=0 \
+GOLEVELDB_BLOCK_SIZE=65536 \
+GOLEVELDB_BLOCK_RESTART_INTERVAL=256 \
+PEBBLE_COMPRESSION=snappy \
+PEBBLE_BLOCK_SIZE=65536 \
+PEBBLE_TARGET_FILE_SIZE=67108864 \
+OUT_DIR="$OUT_DIR" \
+/tmp/gomap-latest-main-bench/scripts/run_application_db_engine_matrix.sh \
+  "$SOURCE_APP_DB"
+```
+
+## Notes
+
+This rerun exposed a benchmark-harness edge case: current Celestia data contains
+zero-length values, and goleveldb rejects nil values. The matrix runner now
+copies source values with `append([]byte{}, iter.Value()...)` so zero-length
+values remain non-nil empty values. The logical data copied is unchanged.
+
+The old April report used a PebbleDB zstd aggressive row. Repeating zstd on this
+machine rebuilt PebbleDB to about `1.745 GiB`, but the compact step failed when
+reopening/scanning the generated tables:
+
+```text
+pebble/table: decompressed into unexpected buffer
+```
+
+That zstd attempt is not used as a published result here. The table above uses
+the complete reproducible snappy run for all three engines.
+
+## Bottom Line
+
+On the current Celestia source corpus and current TreeDB compaction path, the
+headline offline compacted sizes are:
+
+- TreeDB: `1.690 GiB`
+- PebbleDB: `2.108 GiB`
+- goleveldb: `2.221 GiB`
+
+This supersedes the README's older April 13 application-db density headline.

--- a/docs/benchmarks/collections_insert_two_index_current_2026-06-02.md
+++ b/docs/benchmarks/collections_insert_two_index_current_2026-06-02.md
@@ -1,0 +1,87 @@
+# Two-Index Collection Insert Rerun
+
+Date: 2026-06-02 HST / 2026-06-02 UTC
+
+This rerun refreshes the README benchmark claim for the two-index collection
+insert workload. The earlier README row cited the April 27 matrix and mixed a
+post-insert disk number into a high-level benchmark highlight, which made the
+TreeDB storage result easy to misread. This run records both the timed
+post-insert rows and the canonical compacted storage rows.
+
+## Command
+
+```sh
+OUT=/tmp/collections_insert_pr2186_$(date +%Y%m%d_%H%M%S)
+USE_BUILT_BIN=1 ./scripts/bench_collections_canonical.sh \
+  -out-dir "$OUT" \
+  -formats template-v1,json \
+  -indexes 2 \
+  -docs 100000 \
+  -batch-size 16000 \
+  -count 1 \
+  2>&1 | tee "$OUT.stdout.log"
+```
+
+Measured run:
+
+```text
+/tmp/collections_insert_pr2186_20260602_071510
+```
+
+Measured code:
+
+```text
+branch: codex/readme-treedb-ycsb-headline
+commit: 32f17af9af42
+```
+
+Generated artifacts:
+
+- `/tmp/collections_insert_pr2186_20260602_071510/benchmark_summary.md`
+- `/tmp/collections_insert_pr2186_20260602_071510/benchmark_results.json`
+- `/tmp/collections_insert_pr2186_20260602_071510/benchmark_matrix.csv`
+- `/tmp/collections_insert_pr2186_20260602_071510/timed_matrix/collections_matrix_summary.md`
+
+## Timed Insert Rows
+
+These rows are benchmark-timed post-insert measurements for two secondary
+indexes, `100000` documents, batch size `16000`, and `command_wal_relaxed` for
+TreeDB. The B/doc column is the post-insert footprint after the benchmark flush
+or checkpoint. It is not a compacted-state number.
+
+| engine / format | layout | ns/doc | docs/sec | post-insert B/doc |
+| --- | --- | ---: | ---: | ---: |
+| TreeDB JSON | data and index outer leaves in value log | 3,730 | 268,097 | 233.2 |
+| SQLite native columns | WAL normal | 4,026 | 248,385 | 176.1 |
+| TreeDB template-v1 | data and index outer leaves in value log | 4,451 | 224,669 | 214.8 |
+| SQLite JSON | WAL normal | 4,512 | 221,631 | 262.6 |
+
+## Compacted Storage Rows
+
+These rows use the canonical compacted-state comparison basis: TreeDB compacted
+phases are compared with SQLite after `VACUUM`.
+
+| engine / format | phase | B/doc | comparison basis |
+| --- | --- | ---: | --- |
+| TreeDB template-v1 | `full_leafgen_pack_gc` | 22.2 | full leaf generation pack/GC plus offline index vacuum |
+| TreeDB JSON | `full_leafgen_pack_gc` | 30.4 | full leaf generation pack/GC plus offline index vacuum |
+| TreeDB template-v1 | `offline_compact` | 49.7 | high-level `treemap compact <dir> -rw` |
+| SQLite native columns | `sqlite_vacuum` | 156.7 | SQLite `VACUUM` |
+| SQLite JSON | `sqlite_vacuum` | 231.7 | SQLite `VACUUM` |
+
+Derived comparison ratios from `benchmark_results.json`:
+
+| TreeDB row | vs SQLite native columns after `VACUUM` | vs SQLite JSON after `VACUUM` |
+| --- | ---: | ---: |
+| template-v1 `offline_compact` | 3.2x smaller | 4.7x smaller |
+| template-v1 `full_leafgen_pack_gc` | 7.1x smaller | 10.4x smaller |
+| JSON `full_leafgen_pack_gc` | 5.1x smaller | 7.6x smaller |
+
+## Guardrail Notes
+
+The canonical runner emitted one warning and one info note:
+
+- `phase.online_one_pass.partial`: online one-pass maintenance is partial and
+  should not be described as full compaction.
+- `raw_shape_labeled`: raw TreeDB rows are labeled separately and should not be
+  mixed with collection rows.

--- a/docs/benchmarks/collections_insert_two_index_current_2026-06-02.md
+++ b/docs/benchmarks/collections_insert_two_index_current_2026-06-02.md
@@ -33,7 +33,7 @@ Measured code:
 
 ```text
 branch: codex/readme-treedb-ycsb-headline
-commit: 32f17af9af42
+commit: 32f17af9af42133f41094caea085bce161795e58
 ```
 
 Generated artifacts:

--- a/docs/benchmarks/collections_insert_two_index_current_2026-06-02.md
+++ b/docs/benchmarks/collections_insert_two_index_current_2026-06-02.md
@@ -5,8 +5,9 @@ Date: 2026-06-02 HST / 2026-06-02 UTC
 This rerun refreshes the README benchmark claim for the two-index collection
 insert workload. The earlier README row cited the April 27 matrix and mixed a
 post-insert disk number into a high-level benchmark highlight, which made the
-TreeDB storage result easy to misread. This run records both the timed
-post-insert rows and the canonical compacted storage rows.
+TreeDB storage result easy to misread. This report records the canonical
+compacted storage rows and a follow-up timed layout comparison used for the
+current README headline.
 
 ## Command
 
@@ -49,12 +50,68 @@ indexes, `100000` documents, batch size `16000`, and `command_wal_relaxed` for
 TreeDB. The B/doc column is the post-insert footprint after the benchmark flush
 or checkpoint. It is not a compacted-state number.
 
+The canonical runner uses `storage-cells=index-vlog`, which is the TreeDB layout
+that writes data and index outer leaves to the value log. These timings should
+not be compared directly with the April 27 "default index leaves" rows, which
+used a legacy `production_fast` profile and a different index-leaf placement.
+
 | engine / format | layout | ns/doc | docs/sec | post-insert B/doc |
 | --- | --- | ---: | ---: | ---: |
 | TreeDB JSON | data and index outer leaves in value log | 3,730 | 268,097 | 233.2 |
 | SQLite native columns | WAL normal | 4,026 | 248,385 | 176.1 |
 | TreeDB template-v1 | data and index outer leaves in value log | 4,451 | 224,669 | 214.8 |
 | SQLite JSON | WAL normal | 4,512 | 221,631 | 262.6 |
+
+## Follow-up Timed Layout Comparison
+
+After the README table was reviewed, the timed insert comparison was rerun with
+both current TreeDB layout cells. This isolates the layout/profile difference
+from compaction storage accounting. The `docs/sec` column is still only the
+timed insert phase; no compaction time is included.
+
+```sh
+OUT=/tmp/collections_insert_layout_compare_$(date +%Y%m%d_%H%M%S)
+go run ./cmd/collection_bench_matrix \
+  -out-dir "$OUT" \
+  -formats template-v1,json \
+  -engine command_wal_relaxed \
+  -storage-cells mainline,index-vlog \
+  -tree-bench-pattern '^BenchmarkCollectionShapeInsertBatch$/^indexes_2$' \
+  -sqlite-bench-pattern '^(BenchmarkSQLiteShapeInsertBatchJSON|BenchmarkSQLiteShapeInsertBatchNativeColumns)$/^indexes_2$' \
+  -batch-size 16000 \
+  -benchtime 100000x \
+  -count 1 \
+  -leaf-segment-target-bytes 1048576 \
+  -leafgen-pack-frame-k 16 \
+  2>&1 | tee "$OUT.stdout.log"
+```
+
+Measured run:
+
+```text
+/tmp/collections_insert_layout_compare_20260602_083113
+```
+
+Measured code:
+
+```text
+branch: codex/readme-treedb-ycsb-headline
+commit: b8863137de27
+```
+
+| engine / format | layout | ns/doc | docs/sec | post-insert B/doc |
+| --- | --- | ---: | ---: | ---: |
+| TreeDB template-v1 | data outer leaves in value log, index outer leaves in pager | 1,292 | 773,994 | 237.9 |
+| TreeDB template-v1 | data and index outer leaves in value log | 1,595 | 626,959 | 214.8 |
+| TreeDB JSON | data outer leaves in value log, index outer leaves in pager | 1,927 | 518,941 | 255.5 |
+| TreeDB JSON | data and index outer leaves in value log | 2,384 | 419,463 | 233.2 |
+| SQLite native columns | WAL normal | 3,023 | 330,797 | 176.1 |
+| SQLite JSON | WAL normal | 3,310 | 302,115 | 262.6 |
+
+The root README uses the value-log outer-leaf TreeDB rows from this follow-up
+timed run, paired with the compacted storage values below. That keeps the
+headline compact while avoiding the impression that compacted storage time was
+included in the throughput measurement.
 
 ## Compacted Storage Rows
 

--- a/docs/benchmarks/ycsb_mongodb_treedb_current.md
+++ b/docs/benchmarks/ycsb_mongodb_treedb_current.md
@@ -11,32 +11,43 @@ which cells should be rerun next.
 
 ## Current Canonical Report
 
-Use `docs/benchmarks/ycsb_profile_closeout_2026-06-01.md` as the current
-checked-in command-WAL profile evidence until a fresh post-#2164 rerun lands.
+Use `docs/benchmarks/ycsb_post_update_stack_2026-06-02.md` as the current
+checked-in external YCSB evidence for MongoDB, TreeDB nativewire, and TreeDB
+Mongo gateway.
 
-That closeout report covers the intended public TreeDB profile surface:
+That report covers the intended public TreeDB profile surface:
 
 - `command_wal_durable`
 - `command_wal_relaxed`
 - `bench`, as the explicit no-WAL benchmark-only ceiling
 
-It also records zero YCSB operation errors and separates the repeated `bench`
-ceiling run from an initial slow no-WAL Mongo-gateway run that did not reproduce.
+It also records zero YCSB operation errors, uses three run repeats per target
+or profile, and refreshes the earlier pre-update-stack numbers after the
+nativewire BSON `$set` update path and collection update-path optimizations
+landed.
 
-Important freshness note: PR #2164 removed mandatory command-WAL payload
-SHA-256 hashing. Command-WAL throughput numbers collected before that PR remain
-valid historical evidence, but should not be used as final current headline
-numbers without a rerun on the new command-WAL frame format. The no-WAL `bench`
-rows are less directly affected, but should still be rerun in the same matrix as
-a same-host ceiling/control.
+## Current Headline
+
+Run rows use the median total-throughput repeat from the June 2 report.
+
+| target | profile | load ops/sec | run ops/sec | run avg us | run p99 us | run max us | errors |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| MongoDB | baseline | 33,255.6 | 26,102.5 | 601.0 | 1,461.0 | 3,401.0 | 0 |
+| TreeDB nativewire | `command_wal_durable` | 77,065.3 | 120,500.7 | 128.0 | 477.0 | 1,475.0 | 0 |
+| TreeDB Mongo gateway | `command_wal_durable` | 57,370.1 | 74,544.7 | 206.0 | 649.0 | 1,331.0 | 0 |
+| TreeDB nativewire | `command_wal_relaxed` | 76,411.7 | 126,762.5 | 121.0 | 374.0 | 1,687.0 | 0 |
+| TreeDB Mongo gateway | `command_wal_relaxed` | 62,444.0 | 75,371.9 | 203.0 | 629.0 | 1,674.0 | 0 |
+| TreeDB nativewire | `bench` no-WAL | 85,201.7 | 134,415.5 | 114.0 | 365.0 | 969.0 | 0 |
+| TreeDB Mongo gateway | `bench` no-WAL | 75,033.3 | 79,357.6 | 192.0 | 729.0 | 3,035.0 | 0 |
 
 ## Report Inventory
 
 | report | status | use |
 | --- | --- | --- |
+| `docs/benchmarks/ycsb_post_update_stack_2026-06-02.md` | Current external YCSB report. | Use for current headline MongoDB / TreeDB nativewire / TreeDB Mongo gateway results after the June 2 update-path stack. |
 | `docs/benchmarks/ycsb_mongodb_treedb_2026-05-31.md` | Historical legacy-profile report. | Keep for the original MongoDB / TreeDB native / TreeDB Mongo comparison and the post-load Mongo-gateway cliff attribution. Do not use its `fast` rows as current public-profile guidance. |
-| `docs/benchmarks/ycsb_treedb_profile_sweep_2026-06-01.md` | Superseded initial command-WAL sweep. | Keep as prior-run evidence. Prefer the closeout report for profile-surface conclusions. |
-| `docs/benchmarks/ycsb_profile_closeout_2026-06-01.md` | Current checked-in command-WAL/public-profile report until post-#2164 rerun. | Use for current docs and profile-surface discussion, with the #2164 freshness caveat above. |
+| `docs/benchmarks/ycsb_treedb_profile_sweep_2026-06-01.md` | Superseded initial command-WAL sweep. | Keep as prior-run evidence. Prefer the June 2 report for current performance and the closeout report only for profile-surface conclusions. |
+| `docs/benchmarks/ycsb_profile_closeout_2026-06-01.md` | Superseded profile-surface closeout. | Keep for profile-surface closeout evidence. Do not use as current headline performance after the June 2 update-path stack. |
 | `docs/benchmarks/mongo_gateway_compare_2026-04-29/` | Historical non-YCSB Mongo-gateway microbenchmark. | Useful for gateway-specific attribution, but not a substitute for external YCSB comparisons. |
 
 ## Standard Benchmark Boundary
@@ -65,20 +76,19 @@ Any nonzero YCSB operation error counter such as `INSERT_ERROR`, `READ_ERROR`,
 or `UPDATE_ERROR` invalidates that phase unless the report explicitly marks it
 as exploratory known-bad evidence.
 
-## Next Full Rerun Matrix
+## Standard Full Rerun Matrix
 
-Run this matrix to replace the current pre-#2164 command-WAL numbers with fresh
-headline evidence.
+Run this matrix to refresh the current headline evidence after performance,
+profile, nativewire, or Mongo gateway changes.
 
 ### Baseline And Durable Cell
 
-For a formal fresh report, run the first cell with `RUN_REPEATS=3`. That repeats
-the YCSB run phase for MongoDB, TreeDB nativewire, and TreeDB Mongo gateway
-after each target's load phase, which is useful for separating first-run and
-repeat behavior:
+Run the first cell with `RUN_REPEATS=3`. That repeats the YCSB run phase for
+MongoDB, TreeDB nativewire, and TreeDB Mongo gateway after each target's load
+phase, which is useful for separating first-run and repeat behavior:
 
 ```sh
-RUN_ROOT=/tmp/treedb_ycsb_post2164_$(date +%Y%m%d_%H%M%S)
+RUN_ROOT=/tmp/treedb_ycsb_current_$(date +%Y%m%d_%H%M%S)
 mkdir -p "$RUN_ROOT"
 
 OUT_DIR="$RUN_ROOT/command_wal_durable" \
@@ -90,14 +100,12 @@ TREEDB_MONGO_ADDR=127.0.0.1:27130 \
 TREEDB_MONGO_DOCUMENT_FORMAT=bson \
 RUN_REPEATS=3 \
 BUILD=true \
-BUILD_GOYCSB=false \
+BUILD_GOYCSB=true \
 scripts/ycsb_compare_mongodb_treedb.sh
 ```
 
 For a cheaper informal sweep, set `RUN_REPEATS=1` in this first command and use
-the resulting MongoDB row as the once-per-matrix baseline. Then run the durable
-TreeDB cell again with `MONGODB_MODE=skip RUN_REPEATS=3` if repeated durable
-TreeDB rows are needed.
+the resulting MongoDB row as the once-per-matrix baseline.
 
 ### Remaining TreeDB Profiles
 

--- a/docs/benchmarks/ycsb_post_update_stack_2026-06-02.md
+++ b/docs/benchmarks/ycsb_post_update_stack_2026-06-02.md
@@ -1,0 +1,227 @@
+# YCSB MongoDB / TreeDB Post Update-Path Stack
+
+Status: current checked-in external `go-ycsb` evidence for MongoDB, TreeDB
+nativewire, and TreeDB Mongo gateway after the June 2 YCSB update-path stack
+landed through `main` merge commit `5017f75216c7e410c444b3736be2d44517e06c71`.
+
+This report refreshes the previous June 1 command-WAL closeout numbers after:
+
+- command-WAL payload SHA-256 hashing removal;
+- nativewire BSON `$set` update support;
+- `UpdateBSONSet` single-document fast-path work;
+- command-WAL BSON set update combiner work;
+- no-index BSON update mutation-lock hold-time reduction.
+
+These are developer-machine results. Treat them as current local engineering
+evidence, not a formal product benchmark.
+
+## Benchmark Boundary
+
+Workload:
+
+- `recordcount=100000`
+- `operationcount=10000`
+- `threadcount=16`
+- load phase: 100,000 inserts
+- run phase: 10,000 operations, approximately 95% reads and 5% updates
+- all clients used local loopback TCP
+- TreeDB Mongo gateway document format: `bson`
+
+Targets:
+
+- MongoDB 8 through the `go-ycsb mongodb` binding
+- `treedb-native` through the `go-ycsb treedb-native` binding
+- TreeDB Mongo gateway through the `go-ycsb mongodb` binding
+
+Profiles:
+
+- `command_wal_durable`
+- `command_wal_relaxed`
+- `bench`, as the explicit no-WAL benchmark-only ceiling
+
+Validity:
+
+- Every parsed YCSB phase had zero `*_ERROR` operation counts.
+- MongoDB was run once in the durable artifact directory with three run repeats.
+- TreeDB profiles were run with three run repeats each.
+- Headline run rows use the median run throughput repeat for that target/profile.
+
+## Host Context
+
+Captured on 2026-06-02 HST / 2026-06-02 UTC.
+
+```text
+host: mikers-B560-DS3H-AC-Y1
+kernel: Linux 6.8.0-111-generic x86_64
+go: go version go1.25.7 linux/amd64
+cpu: 11th Gen Intel(R) Core(TM) i5-11400F @ 2.60GHz
+logical CPUs: 12
+memory: 31Gi
+clocksource: tsc
+```
+
+Source versions:
+
+```text
+gomap: 5017f75216c7e410c444b3736be2d44517e06c71
+gomap branch: main
+go-ycsb: 00a49395a30a4c1b9671200b8f0ec81a59c98546
+go-ycsb branch: master
+MongoDB image: mongo:8
+MongoDB image id: sha256:690f1371c118a8389ecd6c82c9a7f0e37320732b1d56935a24b29dfca6933f54
+MongoDB image digest: mongo@sha256:7abfba0d07c9330373f8173981ea4d09cd8a82cdf0e86ccaf7008848d1d24f62
+```
+
+Primary artifact root:
+
+```text
+/tmp/treedb_ycsb_post_update_stack_20260602_045120
+```
+
+Artifact directories:
+
+```text
+/tmp/treedb_ycsb_post_update_stack_20260602_045120/command_wal_durable
+/tmp/treedb_ycsb_post_update_stack_20260602_045120/command_wal_relaxed
+/tmp/treedb_ycsb_post_update_stack_20260602_045120/bench
+```
+
+## Reproduction
+
+The sweep used the checked-in comparison script:
+
+```sh
+cd /home/mikers/dev/snissn/gomap-clean
+
+RUN_ROOT=/tmp/treedb_ycsb_post_update_stack_$(date +%Y%m%d_%H%M%S)
+mkdir -p "$RUN_ROOT"
+
+OUT_DIR="$RUN_ROOT/command_wal_durable" \
+TREEDB_PROFILE=command_wal_durable \
+MONGODB_MODE=docker \
+MONGODB_ADDR=127.0.0.1:27018 \
+NATIVE_ADDR=127.0.0.1:17130 \
+TREEDB_MONGO_ADDR=127.0.0.1:27130 \
+TREEDB_MONGO_DOCUMENT_FORMAT=bson \
+RUN_REPEATS=3 \
+BUILD=true \
+BUILD_GOYCSB=true \
+scripts/ycsb_compare_mongodb_treedb.sh
+
+OUT_DIR="$RUN_ROOT/command_wal_relaxed" \
+TREEDB_PROFILE=command_wal_relaxed \
+MONGODB_MODE=skip \
+NATIVE_ADDR=127.0.0.1:17131 \
+TREEDB_MONGO_ADDR=127.0.0.1:27131 \
+TREEDB_MONGO_DOCUMENT_FORMAT=bson \
+RUN_REPEATS=3 \
+BUILD=false \
+BUILD_GOYCSB=false \
+scripts/ycsb_compare_mongodb_treedb.sh
+
+OUT_DIR="$RUN_ROOT/bench" \
+TREEDB_PROFILE=bench \
+MONGODB_MODE=skip \
+NATIVE_ADDR=127.0.0.1:17132 \
+TREEDB_MONGO_ADDR=127.0.0.1:27132 \
+TREEDB_MONGO_DOCUMENT_FORMAT=bson \
+RUN_REPEATS=3 \
+BUILD=false \
+BUILD_GOYCSB=false \
+scripts/ycsb_compare_mongodb_treedb.sh
+```
+
+Each artifact directory includes `host.txt`, `commands.txt`, `summary.tsv`,
+`summary.md`, raw YCSB outputs, server logs, and DB directories.
+
+## Headline Results
+
+Run rows use the median total-throughput repeat for each target/profile.
+
+| target | profile | load ops/sec | median run repeat | run ops/sec | run avg us | run p95 us | run p99 us | run max us | errors |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| MongoDB | baseline | 33,255.6 | 3 | 26,102.5 | 601.0 | 1,048.0 | 1,461.0 | 3,401.0 | 0 |
+| TreeDB nativewire | `command_wal_durable` | 77,065.3 | 2 | 120,500.7 | 128.0 | 244.0 | 477.0 | 1,475.0 | 0 |
+| TreeDB Mongo gateway | `command_wal_durable` | 57,370.1 | 3 | 74,544.7 | 206.0 | 426.0 | 649.0 | 1,331.0 | 0 |
+| TreeDB nativewire | `command_wal_relaxed` | 76,411.7 | 2 | 126,762.5 | 121.0 | 225.0 | 374.0 | 1,687.0 | 0 |
+| TreeDB Mongo gateway | `command_wal_relaxed` | 62,444.0 | 3 | 75,371.9 | 203.0 | 409.0 | 629.0 | 1,674.0 | 0 |
+| TreeDB nativewire | `bench` no-WAL | 85,201.7 | 2 | 134,415.5 | 114.0 | 212.0 | 365.0 | 969.0 | 0 |
+| TreeDB Mongo gateway | `bench` no-WAL | 75,033.3 | 3 | 79,357.6 | 192.0 | 401.0 | 729.0 | 3,035.0 | 0 |
+
+## Run Repeats
+
+| target | profile | repeat 1 ops/sec | repeat 2 ops/sec | repeat 3 ops/sec | selected median |
+| --- | --- | ---: | ---: | ---: | ---: |
+| MongoDB | baseline | 26,263.9 | 25,579.7 | 26,102.5 | 26,102.5 |
+| TreeDB nativewire | `command_wal_durable` | 122,093.1 | 120,500.7 | 117,078.8 | 120,500.7 |
+| TreeDB Mongo gateway | `command_wal_durable` | 66,225.1 | 78,587.1 | 74,544.7 | 74,544.7 |
+| TreeDB nativewire | `command_wal_relaxed` | 121,058.1 | 126,762.5 | 128,617.7 | 126,762.5 |
+| TreeDB Mongo gateway | `command_wal_relaxed` | 74,298.2 | 76,338.3 | 75,371.9 | 75,371.9 |
+| TreeDB nativewire | `bench` no-WAL | 133,589.4 | 134,415.5 | 138,742.9 | 134,415.5 |
+| TreeDB Mongo gateway | `bench` no-WAL | 79,955.7 | 74,334.5 | 79,357.6 | 79,357.6 |
+
+The durable Mongo gateway first run is lower than repeats 2 and 3, but this is
+not the old post-load cliff shape: it had zero errors and a 7.5ms max, not a
+100ms-scale foreground flush.
+
+## Selected Run Detail
+
+The rows below show the operation mix for each selected median repeat.
+
+| target | profile | op | count | ops/sec | avg us | p50 us | p95 us | p99 us | max us |
+| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| MongoDB | baseline | READ | 9,533 | 24,881.8 | 604.0 | 559.0 | 1,051.0 | 1,462.0 | 3,401.0 |
+| MongoDB | baseline | UPDATE | 467 | 1,221.2 | 527.0 | 486.0 | 946.0 | 1,285.0 | 2,383.0 |
+| MongoDB | baseline | TOTAL | 10,000 | 26,102.5 | 601.0 | 555.0 | 1,048.0 | 1,461.0 | 3,401.0 |
+| TreeDB nativewire | `command_wal_durable` | READ | 9,532 | 114,690.8 | 124.0 | 112.0 | 228.0 | 463.0 | 1,024.0 |
+| TreeDB nativewire | `command_wal_durable` | UPDATE | 468 | 5,731.7 | 213.0 | 168.0 | 388.0 | 987.0 | 1,475.0 |
+| TreeDB nativewire | `command_wal_durable` | TOTAL | 10,000 | 120,500.7 | 128.0 | 115.0 | 244.0 | 477.0 | 1,475.0 |
+| TreeDB Mongo gateway | `command_wal_durable` | READ | 9,495 | 70,699.1 | 202.0 | 173.0 | 415.0 | 646.0 | 1,325.0 |
+| TreeDB Mongo gateway | `command_wal_durable` | UPDATE | 505 | 3,773.1 | 280.0 | 253.0 | 503.0 | 771.0 | 1,331.0 |
+| TreeDB Mongo gateway | `command_wal_durable` | TOTAL | 10,000 | 74,544.7 | 206.0 | 176.0 | 426.0 | 649.0 | 1,331.0 |
+| TreeDB nativewire | `command_wal_relaxed` | READ | 9,505 | 120,528.6 | 117.0 | 110.0 | 209.0 | 348.0 | 1,655.0 |
+| TreeDB nativewire | `command_wal_relaxed` | UPDATE | 495 | 6,335.3 | 200.0 | 158.0 | 452.0 | 865.0 | 1,687.0 |
+| TreeDB nativewire | `command_wal_relaxed` | TOTAL | 10,000 | 126,762.5 | 121.0 | 112.0 | 225.0 | 374.0 | 1,687.0 |
+| TreeDB Mongo gateway | `command_wal_relaxed` | READ | 9,514 | 71,724.8 | 199.0 | 172.0 | 398.0 | 621.0 | 1,674.0 |
+| TreeDB Mongo gateway | `command_wal_relaxed` | UPDATE | 486 | 3,684.8 | 283.0 | 257.0 | 525.0 | 716.0 | 1,039.0 |
+| TreeDB Mongo gateway | `command_wal_relaxed` | TOTAL | 10,000 | 75,371.9 | 203.0 | 175.0 | 409.0 | 629.0 | 1,674.0 |
+| TreeDB nativewire | `bench` no-WAL | READ | 9,505 | 127,692.6 | 112.0 | 103.0 | 207.0 | 350.0 | 960.0 |
+| TreeDB nativewire | `bench` no-WAL | UPDATE | 495 | 6,748.7 | 151.0 | 124.0 | 295.0 | 683.0 | 969.0 |
+| TreeDB nativewire | `bench` no-WAL | TOTAL | 10,000 | 134,415.5 | 114.0 | 105.0 | 212.0 | 365.0 | 969.0 |
+| TreeDB Mongo gateway | `bench` no-WAL | READ | 9,512 | 75,577.2 | 191.0 | 160.0 | 398.0 | 702.0 | 3,035.0 |
+| TreeDB Mongo gateway | `bench` no-WAL | UPDATE | 488 | 3,869.7 | 216.0 | 182.0 | 463.0 | 850.0 | 1,496.0 |
+| TreeDB Mongo gateway | `bench` no-WAL | TOTAL | 10,000 | 79,357.6 | 192.0 | 161.0 | 401.0 | 729.0 | 3,035.0 |
+
+## Comparison With June 1 Closeout
+
+Previous checked-in closeout:
+`docs/benchmarks/ycsb_profile_closeout_2026-06-01.md`.
+
+| target | profile | previous load | current load | load delta | previous run | current run | run delta |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| MongoDB | `baseline` | 35,611.8 | 33,255.6 | -6.6% | 26,063.3 | 26,102.5 | +0.2% |
+| TreeDB nativewire | `command_wal_durable` | 77,591.9 | 77,065.3 | -0.7% | 96,947.9 | 120,500.7 | +24.3% |
+| TreeDB Mongo gateway | `command_wal_durable` | 63,123.2 | 57,370.1 | -9.1% | 75,218.6 | 74,544.7 | -0.9% |
+| TreeDB nativewire | `command_wal_relaxed` | 77,223.1 | 76,411.7 | -1.1% | 97,565.0 | 126,762.5 | +29.9% |
+| TreeDB Mongo gateway | `command_wal_relaxed` | 63,203.2 | 62,444.0 | -1.2% | 78,130.3 | 75,371.9 | -3.5% |
+| TreeDB nativewire | `bench` no-WAL | 86,430.2 | 85,201.7 | -1.4% | 131,470.0 | 134,415.5 | +2.2% |
+| TreeDB Mongo gateway | `bench` no-WAL | 74,568.4 | 75,033.3 | +0.6% | 81,813.8 | 79,357.6 | -3.0% |
+
+Nativewire run throughput is the clear win from the update-path stack because
+the external client now uses a BSON `$set` command instead of the older
+read-modify-replace shape. Mongo gateway total run throughput stays in the same
+range because the workload is roughly 95% reads and the gateway path still pays
+Mongo wire protocol, command parsing, and response overhead on every operation.
+
+## Summary
+
+Current TreeDB nativewire `command_wal_durable` run throughput is now about
+120.5k OPS on this host, with UPDATE average latency around 213us in the
+selected median repeat and no 100ms-scale stalls. `command_wal_relaxed` is
+slightly faster in the run phase at about 126.8k OPS, while `bench` no-WAL is
+the ceiling at about 134.4k OPS.
+
+TreeDB Mongo gateway remains faster than the MongoDB baseline on this local
+YCSB shape, but the June 2 update-path stack does not materially change its
+total run throughput. The remaining gateway work is likely in per-request
+Mongo protocol/gateway/read overhead rather than the collection update core.

--- a/docs/benchmarks/ycsb_profile_closeout_2026-06-01.md
+++ b/docs/benchmarks/ycsb_profile_closeout_2026-06-01.md
@@ -1,12 +1,10 @@
 # TreeDB YCSB Profile Closeout: Command WAL Public Surface
 
-Status: current checked-in command-WAL/public-profile evidence until a fresh
-post-#2164 YCSB rerun lands. PR #2164 removed mandatory command-WAL payload
-SHA-256 hashing, so these pre-#2164 command-WAL throughput numbers remain
-historical evidence and should be refreshed before they are used as final
-current headline performance. See
-`docs/benchmarks/ycsb_mongodb_treedb_current.md` for the report index and rerun
-matrix.
+Status: superseded for current headline performance by
+`docs/benchmarks/ycsb_post_update_stack_2026-06-02.md`. This report remains the
+checked-in closeout evidence for the profile-surface sprint and for the June 1
+public-profile audit, but its pre-update-stack throughput rows should not be
+used as the current MongoDB / TreeDB YCSB headline.
 
 This report is the closeout evidence for the TreeDB profile-surface sprint. It
 checks the intended public profiles:

--- a/docs/benchmarks/ycsb_treedb_profile_sweep_2026-06-01.md
+++ b/docs/benchmarks/ycsb_treedb_profile_sweep_2026-06-01.md
@@ -2,9 +2,10 @@
 
 Status: superseded. This initial single-run profile sweep is retained as
 prior-run evidence, but `docs/benchmarks/ycsb_profile_closeout_2026-06-01.md`
-is the preferred checked-in command-WAL profile report until a post-#2164 rerun
-lands. Use `docs/benchmarks/ycsb_mongodb_treedb_current.md` for the current
-report index and rerun matrix.
+is only the preferred checked-in profile-surface closeout. Use
+`docs/benchmarks/ycsb_post_update_stack_2026-06-02.md` for current headline
+YCSB performance, and use `docs/benchmarks/ycsb_mongodb_treedb_current.md` for
+the report index and rerun matrix.
 
 This report captures an external `go-ycsb` profile sweep over the current
 TreeDB collection entry points:

--- a/docs/benchmarks/ycsb_treedb_profile_sweep_2026-06-01.md
+++ b/docs/benchmarks/ycsb_treedb_profile_sweep_2026-06-01.md
@@ -2,7 +2,7 @@
 
 Status: superseded. This initial single-run profile sweep is retained as
 prior-run evidence, but `docs/benchmarks/ycsb_profile_closeout_2026-06-01.md`
-is only the preferred checked-in profile-surface closeout. Use
+is the preferred checked-in profile-surface closeout. Use
 `docs/benchmarks/ycsb_post_update_stack_2026-06-02.md` for current headline
 YCSB performance, and use `docs/benchmarks/ycsb_mongodb_treedb_current.md` for
 the report index and rerun matrix.

--- a/scripts/run_application_db_engine_matrix.sh
+++ b/scripts/run_application_db_engine_matrix.sh
@@ -288,7 +288,7 @@ func runRebuild(args []string) {
 
 	for iter.First(); iter.Valid(); iter.Next() {
 		key := append([]byte(nil), iter.Key()...)
-		value := append([]byte(nil), iter.Value()...)
+		value := append([]byte{}, iter.Value()...)
 		if err := batch.Set(key, value); err != nil {
 			fatalErr(fmt.Errorf("batch set: %w", err))
 		}


### PR DESCRIPTION
## Summary

- Rewrites the root README as a TreeDB-first landing page with benchmark highlights split by workload, each with its own focused table.
- Adds sourced benchmark highlights for YCSB, refreshed two-index collection inserts, reads/lookups, and `application.db` offline density.
- Adds `HashDB/README.md` for the HashDB-specific overview, durability notes, entry points, and generated benchmark snapshot target.
- Moves `make bench-readme` to update `HashDB/README.md` instead of the root README.
- Adds the June 2 post-update-stack YCSB report and updates the YCSB report index/superseded report status.

## Current YCSB evidence included

Report: `docs/benchmarks/ycsb_post_update_stack_2026-06-02.md`

Artifact root:

```text
/tmp/treedb_ycsb_post_update_stack_20260602_045120
```

Current headline rows added to the root README:

| target | profile | load ops/sec | run ops/sec | run avg us | run p99 us |
| --- | --- | ---: | ---: | ---: | ---: |
| MongoDB 8 | baseline | 33,255.6 | 26,102.5 | 601.0 | 1,461.0 |
| TreeDB nativewire | `command_wal_durable` | 77,065.3 | 120,500.7 | 128.0 | 477.0 |
| TreeDB Mongo gateway | `command_wal_durable` | 57,370.1 | 74,544.7 | 206.0 | 649.0 |

All parsed YCSB phases in the report had zero `*_ERROR` operation counters.

## Two-index collection insert rerun

Report: `docs/benchmarks/collections_insert_two_index_current_2026-06-02.md`

Canonical artifact root:

```text
/tmp/collections_insert_pr2186_20260602_071510
```

Follow-up timed layout comparison artifact root:

```text
/tmp/collections_insert_layout_compare_20260602_083113
```

The README table now uses timed insert throughput from the current-code value-log outer-leaf layout comparison. The B/doc column is compacted storage from the canonical run for the same TreeDB layout and SQLite after `VACUUM`; compaction time is not included in docs/sec.

| engine / format | docs/sec | fully compacted B/doc |
| --- | ---: | ---: |
| TreeDB template-v1 | 626,959 | 22.2 |
| TreeDB JSON | 419,463 | 30.4 |
| SQLite native columns | 330,797 | 156.7 |
| SQLite JSON | 302,115 | 231.7 |

For comparison, the same follow-up run measured the current pager-index layout at `773,994 docs/sec` for TreeDB template-v1 and `518,941 docs/sec` for TreeDB JSON. The older April `~1M docs/sec` table used legacy `production_fast` plus default index leaves, so it is not the same profile/layout basis as the current command-WAL README row.

## Celestia application.db density rerun

Report: `docs/benchmarks/application_db_engine_matrix_2026-06-02.md`

Artifact root:

```text
/tmp/application_db_engine_matrix_current_snappy_20260602_105146
```

This rerun used a fresh Celestia mainnet goleveldb source restored with `celestia-app v8.0.8`, then rebuilt/compacted goleveldb, PebbleDB, and latest TreeDB `origin/main` at `94e322a0727f7a0d07154a006e9fa4ec4e3936f4`.

| engine | compacted size | workflow |
| --- | ---: | --- |
| TreeDB | 1.690 GiB | `command_wal_relaxed`, rebuild, `CompactStorageFull`, offline index vacuum |
| PebbleDB | 2.108 GiB | snappy, 64 KiB blocks, 64 MiB target files, full compact |
| goleveldb | 2.221 GiB | snappy, 64 KiB blocks, restart interval 256, full compact |

The report documents the PebbleDB zstd retry caveat: zstd rebuilt to about `1.745 GiB`, but failed during reopen/compact with a Pebble table decompression error, so the published three-engine table uses the complete snappy run.

## Other benchmark highlights included

Sources:

- `docs/benchmarks/ycsb_post_update_stack_2026-06-02.md`
- `docs/benchmarks/collections_insert_two_index_current_2026-06-02.md`
- `docs/benchmarks/collections_rewrite_vacuum_matrix_pr1075_2026-04-27.md`
- `docs/benchmarks/application_db_engine_matrix_2026-06-02.md`

The root README has a `Benchmark Highlights` section with separate workload subsections and focused tables for:

- YCSB server workload.
- Indexed collection insert workload.
- Collection read and lookup workload.
- `application.db` offline density workload.

## Validation

Latest update:

```sh
git diff --check origin/main...HEAD
bash ./scripts/docs_check.sh
bash -n scripts/run_application_db_engine_matrix.sh
```

Benchmark commands run for refreshed insert/storage rows:

```sh
OUT=/tmp/collections_insert_pr2186_$(date +%Y%m%d_%H%M%S)
USE_BUILT_BIN=1 ./scripts/bench_collections_canonical.sh \
  -out-dir "$OUT" \
  -formats template-v1,json \
  -indexes 2 \
  -docs 100000 \
  -batch-size 16000 \
  -count 1 \
  2>&1 | tee "$OUT.stdout.log"

OUT=/tmp/collections_insert_layout_compare_$(date +%Y%m%d_%H%M%S)
go run ./cmd/collection_bench_matrix \
  -out-dir "$OUT" \
  -formats template-v1,json \
  -engine command_wal_relaxed \
  -storage-cells mainline,index-vlog \
  -tree-bench-pattern '^BenchmarkCollectionShapeInsertBatch$/^indexes_2$' \
  -sqlite-bench-pattern '^(BenchmarkSQLiteShapeInsertBatchJSON|BenchmarkSQLiteShapeInsertBatchNativeColumns)$/^indexes_2$' \
  -batch-size 16000 \
  -benchtime 100000x \
  -count 1 \
  -leaf-segment-target-bytes 1048576 \
  -leafgen-pack-frame-k 16 \
  2>&1 | tee "$OUT.stdout.log"
```

Earlier validation from this PR:

```sh
git diff --check
bash ./scripts/docs_check.sh
tmp=$(mktemp /tmp/hashdb_readme_marker_XXXXXX.md); cp HashDB/README.md "$tmp"; printf '# Synthetic Bench\n\nOK\n' | go run ./scripts/update_readme_bench.go -readme "$tmp"; rg -n 'Synthetic Bench|No generated benchmark' "$tmp"; rm -f "$tmp"
GOWORK=off go test ./cmd/unified_bench ./cmd/benchprof -count=1
```
