### PR TITLE
TreeDB: cache mutable pressure threshold

### DIFF
--- a/TreeDB/caching/append_only_hint_test.go
+++ b/TreeDB/caching/append_only_hint_test.go
@@ -99,6 +99,7 @@ func TestAppendOnlyEntryHint_CapacityTracksPressureScaledMutableThreshold(t *tes
 	}
 
 	fake.HeapInuse = 1 << 30 // normal
+	_ = currentPoolPressureSnapshot()
 	normal := cache.appendOnlyMemtableCapacityHint(requestedCap, appendOnlyEstimatedBytesPerEntryDefault)
 	if want := expectedCapFor(poolPressureNormal); normal != want {
 		t.Fatalf("normal pressure cap=%d want=%d", normal, want)
@@ -106,6 +107,7 @@ func TestAppendOnlyEntryHint_CapacityTracksPressureScaledMutableThreshold(t *tes
 
 	now = now.Add(poolPressureRefreshInterval + time.Millisecond)
 	fake.HeapInuse = 5 << 30 // high
+	_ = currentPoolPressureSnapshot()
 	high := cache.appendOnlyMemtableCapacityHint(requestedCap, appendOnlyEstimatedBytesPerEntryDefault)
 	if want := expectedCapFor(poolPressureHigh); high != want {
 		t.Fatalf("high pressure cap=%d want=%d", high, want)
@@ -113,6 +115,7 @@ func TestAppendOnlyEntryHint_CapacityTracksPressureScaledMutableThreshold(t *tes
 
 	now = now.Add(poolPressureRefreshInterval + time.Millisecond)
 	fake.HeapInuse = 9 << 30 // critical
+	_ = currentPoolPressureSnapshot()
 	critical := cache.appendOnlyMemtableCapacityHint(requestedCap, appendOnlyEstimatedBytesPerEntryDefault)
 	if want := expectedCapFor(poolPressureCritical); critical != want {
 		t.Fatalf("critical pressure cap=%d want=%d", critical, want)

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -126,6 +126,7 @@ var snapshotGetCallerSamplesTotal atomic.Uint64
 var snapshotGetCallerSampleSeq atomic.Uint64
 var snapshotGetCallerStatsMap sync.Map
 var poolPressureState atomic.Value
+var poolPressureLevelState atomic.Uint64
 var poolPressureMu sync.Mutex
 var poolPressureLastLeaseTrimUnixNano atomic.Int64
 var poolPressureNormalSamplesTotal atomic.Uint64
@@ -204,6 +205,53 @@ const (
 	poolPressureHigh
 	poolPressureCritical
 )
+
+const (
+	poolPressureLevelStateLevelBits = 8
+	poolPressureLevelStateLevelMask = uint64(1<<poolPressureLevelStateLevelBits - 1)
+)
+
+func packPoolPressureLevelState(version uint64, level poolPressureLevel) uint64 {
+	return (version << poolPressureLevelStateLevelBits) | (uint64(level) & poolPressureLevelStateLevelMask)
+}
+
+func unpackPoolPressureLevelState(state uint64) (uint64, poolPressureLevel) {
+	return state >> poolPressureLevelStateLevelBits, poolPressureLevel(state & poolPressureLevelStateLevelMask)
+}
+
+func resetPoolPressureLevelState(level poolPressureLevel) {
+	poolPressureLevelState.Store(packPoolPressureLevelState(1, level))
+}
+
+func currentPoolPressureLevelState() uint64 {
+	if state := poolPressureLevelState.Load(); state != 0 {
+		return state
+	}
+	initial := packPoolPressureLevelState(1, poolPressureNormal)
+	if poolPressureLevelState.CompareAndSwap(0, initial) {
+		return initial
+	}
+	return poolPressureLevelState.Load()
+}
+
+func currentPoolPressureLevelFast() poolPressureLevel {
+	_, level := unpackPoolPressureLevelState(currentPoolPressureLevelState())
+	return level
+}
+
+func publishPoolPressureLevel(level poolPressureLevel) uint64 {
+	for {
+		state := currentPoolPressureLevelState()
+		version, currentLevel := unpackPoolPressureLevelState(state)
+		if currentLevel == level {
+			return state
+		}
+		next := packPoolPressureLevelState(version+1, level)
+		if poolPressureLevelState.CompareAndSwap(state, next) {
+			return next
+		}
+	}
+}
 
 type poolPressureSnapshot struct {
 	sampledUnixNano    int64
@@ -631,6 +679,20 @@ func maybeTrimEntrySliceLeasesUnderPressure(level poolPressureLevel, sampledAt t
 	}
 }
 
+func publishPoolPressureSnapshot(snap poolPressureSnapshot, sampledAt time.Time) {
+	poolPressureState.Store(snap)
+	publishPoolPressureLevel(snap.level)
+	switch snap.level {
+	case poolPressureCritical:
+		poolPressureCriticalSamplesTotal.Add(1)
+	case poolPressureHigh:
+		poolPressureHighSamplesTotal.Add(1)
+	default:
+		poolPressureNormalSamplesTotal.Add(1)
+	}
+	maybeTrimEntrySliceLeasesUnderPressure(snap.level, sampledAt)
+}
+
 func currentPoolPressureSnapshot() poolPressureSnapshot {
 	now := poolPressureNow()
 	if cached, ok := poolPressureState.Load().(poolPressureSnapshot); ok {
@@ -650,16 +712,7 @@ func currentPoolPressureSnapshot() poolPressureSnapshot {
 	}
 
 	snap := samplePoolPressureSnapshot(now)
-	poolPressureState.Store(snap)
-	switch snap.level {
-	case poolPressureCritical:
-		poolPressureCriticalSamplesTotal.Add(1)
-	case poolPressureHigh:
-		poolPressureHighSamplesTotal.Add(1)
-	default:
-		poolPressureNormalSamplesTotal.Add(1)
-	}
-	maybeTrimEntrySliceLeasesUnderPressure(snap.level, now)
+	publishPoolPressureSnapshot(snap, now)
 	return snap
 }
 
@@ -957,6 +1010,7 @@ type batchArenaPoolBudgetCache struct {
 func init() {
 	batchArenaPoolBudgetState.Store(batchArenaPoolBudgetCache{})
 	poolPressureState.Store(poolPressureSnapshot{})
+	resetPoolPressureLevelState(poolPressureNormal)
 }
 
 func noteBatchArenaPoolGC(numGC uint64) {
@@ -6662,6 +6716,9 @@ type DB struct {
 	mutableShardMask              uint64
 	mutableBytes                  atomic.Int64
 	mutableThreshold              atomic.Int64
+	mutableThresholdEffective     atomic.Int64
+	mutableThresholdEffectiveBase atomic.Int64
+	mutableThresholdPressureState atomic.Uint64
 	rotatePending                 atomic.Bool
 	queue                         []memtable.Table
 	queueShardIDs                 []uint16
@@ -8909,6 +8966,26 @@ func (db *DB) updateMutableThresholdLocked() {
 		threshold = db.memtableWarmupThreshold
 	}
 	db.mutableThreshold.Store(threshold)
+	db.refreshMutableFlushThresholdForPressureState(currentPoolPressureLevelState())
+}
+
+func (db *DB) refreshMutableFlushThresholdForPressureState(state uint64) int64 {
+	if state == 0 {
+		state = currentPoolPressureLevelState()
+	}
+	base := db.mutableThreshold.Load()
+	if base <= 0 {
+		db.mutableThresholdEffective.Store(base)
+		db.mutableThresholdEffectiveBase.Store(base)
+		db.mutableThresholdPressureState.Store(state)
+		return base
+	}
+	_, level := unpackPoolPressureLevelState(state)
+	effective := scaleMutableFlushThresholdForPressure(base, level)
+	db.mutableThresholdEffective.Store(effective)
+	db.mutableThresholdEffectiveBase.Store(base)
+	db.mutableThresholdPressureState.Store(state)
+	return effective
 }
 
 func (db *DB) mutableFlushThreshold() int64 {
@@ -8916,8 +8993,15 @@ func (db *DB) mutableFlushThreshold() int64 {
 	if base <= 0 {
 		return base
 	}
-	level := currentPoolPressureSnapshot().level
-	return scaleMutableFlushThresholdForPressure(base, level)
+	state := currentPoolPressureLevelState()
+	if db.mutableThresholdEffectiveBase.Load() != base || db.mutableThresholdPressureState.Load() != state {
+		return db.refreshMutableFlushThresholdForPressureState(state)
+	}
+	effective := db.mutableThresholdEffective.Load()
+	if effective <= 0 {
+		return db.refreshMutableFlushThresholdForPressureState(state)
+	}
+	return effective
 }
 
 func (db *DB) adaptiveBTreeMinIteratorSamples() uint64 {
@@ -10083,7 +10167,9 @@ func (db *DB) sampleProcessMemoryPeaks(backendMmap vlogMmapStatsSnapshot) {
 	if db == nil {
 		return
 	}
-	snap := samplePoolPressureSnapshot(time.Now())
+	now := poolPressureNow()
+	snap := samplePoolPressureSnapshot(now)
+	publishPoolPressureSnapshot(snap, now)
 	updateAtomicMax(&db.processPeakHeapAllocBytes, snap.heapAllocBytes)
 	updateAtomicMax(&db.processPeakHeapInuseBytes, snap.heapInuseBytes)
 	updateAtomicMax(&db.processPeakTotalSysBytes, snap.totalSysBytes)

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -128,6 +128,10 @@ var snapshotGetCallerStatsMap sync.Map
 var poolPressureState atomic.Value
 var poolPressureLevelState atomic.Uint64
 var poolPressureMu sync.Mutex
+var poolPressureSamplerMu sync.Mutex
+var poolPressureSamplerRefs int
+var poolPressureSamplerStop chan struct{}
+var poolPressureSamplerDone chan struct{}
 var poolPressureLastLeaseTrimUnixNano atomic.Int64
 var poolPressureNormalSamplesTotal atomic.Uint64
 var poolPressureHighSamplesTotal atomic.Uint64
@@ -693,6 +697,66 @@ func publishPoolPressureSnapshot(snap poolPressureSnapshot, sampledAt time.Time)
 	maybeTrimEntrySliceLeasesUnderPressure(snap.level, sampledAt)
 }
 
+func sampleAndPublishPoolPressureSnapshot() poolPressureSnapshot {
+	now := poolPressureNow()
+	snap := samplePoolPressureSnapshot(now)
+	publishPoolPressureSnapshot(snap, now)
+	return snap
+}
+
+// Keep the pressure-level atomic fresh without putting time/memstats sampling
+// back on write paths that only need the scaled mutable flush threshold.
+func runPoolPressureSampler(stop <-chan struct{}, done chan<- struct{}) {
+	defer close(done)
+	ticker := time.NewTicker(poolPressureRefreshInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			_ = sampleAndPublishPoolPressureSnapshot()
+		case <-stop:
+			return
+		}
+	}
+}
+
+func retainPoolPressureSampler() func() {
+	poolPressureSamplerMu.Lock()
+	if poolPressureSamplerRefs == 0 {
+		stop := make(chan struct{})
+		done := make(chan struct{})
+		poolPressureSamplerStop = stop
+		poolPressureSamplerDone = done
+		go runPoolPressureSampler(stop, done)
+	}
+	poolPressureSamplerRefs++
+	poolPressureSamplerMu.Unlock()
+
+	var released atomic.Bool
+	return func() {
+		if !released.CompareAndSwap(false, true) {
+			return
+		}
+
+		var done chan struct{}
+		poolPressureSamplerMu.Lock()
+		if poolPressureSamplerRefs > 0 {
+			poolPressureSamplerRefs--
+		}
+		if poolPressureSamplerRefs == 0 && poolPressureSamplerStop != nil {
+			close(poolPressureSamplerStop)
+			done = poolPressureSamplerDone
+			poolPressureSamplerStop = nil
+			poolPressureSamplerDone = nil
+		}
+		poolPressureSamplerMu.Unlock()
+
+		if done != nil {
+			<-done
+		}
+	}
+}
+
 func currentPoolPressureSnapshot() poolPressureSnapshot {
 	now := poolPressureNow()
 	if cached, ok := poolPressureState.Load().(poolPressureSnapshot); ok {
@@ -711,9 +775,7 @@ func currentPoolPressureSnapshot() poolPressureSnapshot {
 		}
 	}
 
-	snap := samplePoolPressureSnapshot(now)
-	publishPoolPressureSnapshot(snap, now)
-	return snap
+	return sampleAndPublishPoolPressureSnapshot()
 }
 
 func currentZipperParallelMergePressure() zipper.ParallelMergePressureLevel {
@@ -7414,10 +7476,11 @@ type DB struct {
 	processPeakVlogMmapSealedSegments  atomic.Uint64
 
 	// Lifecycle
-	closeCh chan struct{}
-	closing atomic.Bool
-	flushCh chan struct{}
-	wg      sync.WaitGroup
+	closeCh                    chan struct{}
+	closing                    atomic.Bool
+	flushCh                    chan struct{}
+	wg                         sync.WaitGroup
+	releasePoolPressureSampler func()
 
 	autoCheckpointOnceCh  chan struct{}
 	autoCheckpointWriteCh chan struct{}
@@ -9967,6 +10030,7 @@ func Open(dir string, backend BackendDB, opts Options) (*DB, error) {
 	db.mu.Unlock()
 
 	db.startDomainIngressWorkers()
+	db.releasePoolPressureSampler = retainPoolPressureSampler()
 	db.startProcessMemorySampler()
 
 	// Start background flusher
@@ -10167,9 +10231,7 @@ func (db *DB) sampleProcessMemoryPeaks(backendMmap vlogMmapStatsSnapshot) {
 	if db == nil {
 		return
 	}
-	now := poolPressureNow()
-	snap := samplePoolPressureSnapshot(now)
-	publishPoolPressureSnapshot(snap, now)
+	snap := sampleAndPublishPoolPressureSnapshot()
 	updateAtomicMax(&db.processPeakHeapAllocBytes, snap.heapAllocBytes)
 	updateAtomicMax(&db.processPeakHeapInuseBytes, snap.heapInuseBytes)
 	updateAtomicMax(&db.processPeakTotalSysBytes, snap.totalSysBytes)
@@ -20323,6 +20385,10 @@ func (db *DB) Close() error {
 	db.writeMu.Unlock()
 	db.flushMu.Unlock()
 	db.wg.Wait()
+	if release := db.releasePoolPressureSampler; release != nil {
+		db.releasePoolPressureSampler = nil
+		release()
+	}
 	db.releaseClosingEmptyMemtables()
 	// Drain any in-flight dict-profile publish callbacks before teardown.
 	// New callbacks will observe closing=true and return without touching stores.

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -723,6 +723,7 @@ func runPoolPressureSampler(stop <-chan struct{}, done chan<- struct{}) {
 func retainPoolPressureSampler() func() {
 	poolPressureSamplerMu.Lock()
 	if poolPressureSamplerRefs == 0 {
+		_ = sampleAndPublishPoolPressureSnapshot()
 		stop := make(chan struct{})
 		done := make(chan struct{})
 		poolPressureSamplerStop = stop

--- a/TreeDB/caching/pool_pressure_test.go
+++ b/TreeDB/caching/pool_pressure_test.go
@@ -576,6 +576,42 @@ func TestSampleProcessMemoryPeaksPublishesFreshPressureSnapshot(t *testing.T) {
 	}
 }
 
+func TestPoolPressureSamplerPublishesInitialPressureSnapshot(t *testing.T) {
+	poolPressureTestMu.Lock()
+	defer poolPressureTestMu.Unlock()
+
+	resetPoolPressureStateForTest()
+	savedNow := poolPressureNow
+	savedReadMemStats := poolPressureReadMemStats
+	savedMemLimit := poolPressureMemoryLimit
+	t.Cleanup(func() {
+		poolPressureNow = savedNow
+		poolPressureReadMemStats = savedReadMemStats
+		poolPressureMemoryLimit = savedMemLimit
+		resetPoolPressureStateForTest()
+	})
+
+	now := time.Unix(1, 0)
+	poolPressureNow = func() time.Time { return now }
+	var readMemStatsCalls atomic.Uint64
+	poolPressureReadMemStats = func(ms *runtime.MemStats) {
+		readMemStatsCalls.Add(1)
+		ms.HeapInuse = 9 << 30
+	}
+	poolPressureMemoryLimit = func() int64 { return -1 }
+
+	release := retainPoolPressureSampler()
+	t.Cleanup(release)
+
+	if got := currentPoolPressureLevelFast(); got != poolPressureCritical {
+		t.Fatalf("fast pressure level=%v want critical after initial sampler retain", got)
+	}
+	release()
+	if got := readMemStatsCalls.Load(); got == 0 {
+		t.Fatalf("initial sampler did not read memstats")
+	}
+}
+
 func TestPoolPressureSamplerPublishesFreshPressureSnapshot(t *testing.T) {
 	poolPressureTestMu.Lock()
 	defer poolPressureTestMu.Unlock()

--- a/TreeDB/caching/pool_pressure_test.go
+++ b/TreeDB/caching/pool_pressure_test.go
@@ -13,6 +13,7 @@ var poolPressureTestMu sync.Mutex
 
 func resetPoolPressureStateForTest() {
 	poolPressureState.Store(poolPressureSnapshot{})
+	resetPoolPressureLevelState(poolPressureNormal)
 	poolPressureLastLeaseTrimUnixNano.Store(0)
 }
 
@@ -380,4 +381,196 @@ func TestScaleMutableFlushThresholdForPressure(t *testing.T) {
 			t.Fatalf("small base critical scaled=%d want=%d", got, want)
 		}
 	})
+}
+
+func TestMutableFlushThresholdUsesCachedEffectivePressure(t *testing.T) {
+	poolPressureTestMu.Lock()
+	defer poolPressureTestMu.Unlock()
+
+	resetPoolPressureStateForTest()
+	savedNow := poolPressureNow
+	savedReadMemStats := poolPressureReadMemStats
+	savedMemLimit := poolPressureMemoryLimit
+	t.Cleanup(func() {
+		poolPressureNow = savedNow
+		poolPressureReadMemStats = savedReadMemStats
+		poolPressureMemoryLimit = savedMemLimit
+		resetPoolPressureStateForTest()
+	})
+
+	now := time.Unix(1, 0)
+	nowCalls := 0
+	poolPressureNow = func() time.Time {
+		nowCalls++
+		return now
+	}
+	var fake runtime.MemStats
+	readMemStatsCalls := 0
+	poolPressureReadMemStats = func(ms *runtime.MemStats) {
+		readMemStatsCalls++
+		*ms = fake
+	}
+	poolPressureMemoryLimit = func() int64 { return -1 }
+
+	const base = int64(256 << 20)
+	db := &DB{flushThreshold: base}
+	db.updateMutableThresholdLocked()
+	for i := 0; i < 1000; i++ {
+		if got := db.mutableFlushThreshold(); got != base {
+			t.Fatalf("normal cached threshold=%d want=%d", got, base)
+		}
+	}
+	if nowCalls != 0 {
+		t.Fatalf("mutableFlushThreshold called poolPressureNow %d times", nowCalls)
+	}
+	if readMemStatsCalls != 0 {
+		t.Fatalf("mutableFlushThreshold sampled memstats %d times", readMemStatsCalls)
+	}
+
+	fake.HeapInuse = 5 << 30
+	now = now.Add(poolPressureRefreshInterval + time.Millisecond)
+	snap := samplePoolPressureSnapshot(now)
+	publishPoolPressureSnapshot(snap, now)
+	if readMemStatsCalls != 1 {
+		t.Fatalf("pressure publish memstats calls=%d want=1", readMemStatsCalls)
+	}
+	want := scaleMutableFlushThresholdForPressure(base, poolPressureHigh)
+	if got := db.mutableFlushThreshold(); got != want {
+		t.Fatalf("high cached threshold=%d want=%d", got, want)
+	}
+	nowCallsBefore := nowCalls
+	readMemStatsCallsBefore := readMemStatsCalls
+	for i := 0; i < 1000; i++ {
+		if got := db.mutableFlushThreshold(); got != want {
+			t.Fatalf("repeated high cached threshold=%d want=%d", got, want)
+		}
+	}
+	if nowCalls != nowCallsBefore {
+		t.Fatalf("repeated mutableFlushThreshold called poolPressureNow %d times", nowCalls-nowCallsBefore)
+	}
+	if readMemStatsCalls != readMemStatsCallsBefore {
+		t.Fatalf("repeated mutableFlushThreshold sampled memstats %d times", readMemStatsCalls-readMemStatsCallsBefore)
+	}
+}
+
+func TestMutableFlushThresholdTracksPressureTransitions(t *testing.T) {
+	poolPressureTestMu.Lock()
+	defer poolPressureTestMu.Unlock()
+
+	resetPoolPressureStateForTest()
+	t.Cleanup(resetPoolPressureStateForTest)
+
+	const base = int64(256 << 20)
+	db := &DB{flushThreshold: base}
+	db.updateMutableThresholdLocked()
+
+	now := time.Unix(1, 0)
+	for _, tc := range []struct {
+		name  string
+		level poolPressureLevel
+	}{
+		{name: "normal", level: poolPressureNormal},
+		{name: "high", level: poolPressureHigh},
+		{name: "critical", level: poolPressureCritical},
+		{name: "recovered", level: poolPressureNormal},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			now = now.Add(poolPressureRefreshInterval + time.Millisecond)
+			publishPoolPressureSnapshot(poolPressureSnapshot{
+				sampledUnixNano: now.UnixNano(),
+				level:           tc.level,
+			}, now)
+			want := scaleMutableFlushThresholdForPressure(base, tc.level)
+			if got := db.mutableFlushThreshold(); got != want {
+				t.Fatalf("cached threshold=%d want=%d", got, want)
+			}
+			if got := currentPoolPressureLevelFast(); got != tc.level {
+				t.Fatalf("fast pressure level=%v want=%v", got, tc.level)
+			}
+		})
+	}
+}
+
+func TestMutableFlushThresholdBaseChangeUnderPressure(t *testing.T) {
+	poolPressureTestMu.Lock()
+	defer poolPressureTestMu.Unlock()
+
+	resetPoolPressureStateForTest()
+	t.Cleanup(resetPoolPressureStateForTest)
+
+	now := time.Unix(1, 0)
+	publishPoolPressureSnapshot(poolPressureSnapshot{
+		sampledUnixNano: now.UnixNano(),
+		level:           poolPressureCritical,
+	}, now)
+
+	db := &DB{flushThreshold: 256 << 20}
+	db.updateMutableThresholdLocked()
+	if got, want := db.mutableFlushThreshold(), int64(64<<20); got != want {
+		t.Fatalf("initial critical threshold=%d want=%d", got, want)
+	}
+
+	db.flushThreshold = 64 << 20
+	db.updateMutableThresholdLocked()
+	if got, want := db.mutableFlushThreshold(), mutableFlushThresholdPressureFloorBytes; got != want {
+		t.Fatalf("critical floor threshold=%d want=%d", got, want)
+	}
+
+	db.memtableWarmupActive = true
+	db.memtableWarmupThreshold = 8 << 20
+	db.updateMutableThresholdLocked()
+	if got, want := db.mutableFlushThreshold(), int64(2<<20); got != want {
+		t.Fatalf("small warmup threshold=%d want=%d", got, want)
+	}
+}
+
+func TestSampleProcessMemoryPeaksPublishesFreshPressureSnapshot(t *testing.T) {
+	poolPressureTestMu.Lock()
+	defer poolPressureTestMu.Unlock()
+
+	resetPoolPressureStateForTest()
+	savedNow := poolPressureNow
+	savedReadMemStats := poolPressureReadMemStats
+	savedMemLimit := poolPressureMemoryLimit
+	t.Cleanup(func() {
+		poolPressureNow = savedNow
+		poolPressureReadMemStats = savedReadMemStats
+		poolPressureMemoryLimit = savedMemLimit
+		resetPoolPressureStateForTest()
+	})
+
+	now := time.Unix(1, 0)
+	poolPressureNow = func() time.Time { return now }
+	publishPoolPressureSnapshot(poolPressureSnapshot{
+		sampledUnixNano: now.UnixNano(),
+		level:           poolPressureNormal,
+		usedBytes:       1 << 20,
+	}, now)
+
+	var fake runtime.MemStats
+	fake.HeapInuse = 9 << 30
+	readMemStatsCalls := 0
+	poolPressureReadMemStats = func(ms *runtime.MemStats) {
+		readMemStatsCalls++
+		*ms = fake
+	}
+	poolPressureMemoryLimit = func() int64 { return -1 }
+
+	db := &DB{}
+	db.sampleProcessMemoryPeaks(vlogMmapStatsSnapshot{})
+	if readMemStatsCalls != 1 {
+		t.Fatalf("sampleProcessMemoryPeaks memstats calls=%d want=1", readMemStatsCalls)
+	}
+	if got := currentPoolPressureLevelFast(); got != poolPressureCritical {
+		t.Fatalf("fast pressure level=%v want critical", got)
+	}
+	if got := currentPoolPressureSnapshot().level; got != poolPressureCritical {
+		t.Fatalf("cached pressure level=%v want critical", got)
+	}
+	if readMemStatsCalls != 1 {
+		t.Fatalf("fresh currentPoolPressureSnapshot resampled memstats calls=%d want=1", readMemStatsCalls)
+	}
+	if got := db.processPeakHeapInuseBytes.Load(); got != fake.HeapInuse {
+		t.Fatalf("peak heap inuse=%d want=%d", got, fake.HeapInuse)
+	}
 }

--- a/TreeDB/caching/pool_pressure_test.go
+++ b/TreeDB/caching/pool_pressure_test.go
@@ -3,6 +3,7 @@ package caching
 import (
 	"runtime"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -572,5 +573,49 @@ func TestSampleProcessMemoryPeaksPublishesFreshPressureSnapshot(t *testing.T) {
 	}
 	if got := db.processPeakHeapInuseBytes.Load(); got != fake.HeapInuse {
 		t.Fatalf("peak heap inuse=%d want=%d", got, fake.HeapInuse)
+	}
+}
+
+func TestPoolPressureSamplerPublishesFreshPressureSnapshot(t *testing.T) {
+	poolPressureTestMu.Lock()
+	defer poolPressureTestMu.Unlock()
+
+	resetPoolPressureStateForTest()
+	savedNow := poolPressureNow
+	savedReadMemStats := poolPressureReadMemStats
+	savedMemLimit := poolPressureMemoryLimit
+	t.Cleanup(func() {
+		poolPressureNow = savedNow
+		poolPressureReadMemStats = savedReadMemStats
+		poolPressureMemoryLimit = savedMemLimit
+		resetPoolPressureStateForTest()
+	})
+
+	now := time.Unix(1, 0)
+	poolPressureNow = func() time.Time { return now }
+	var heapInuse atomic.Uint64
+	var readMemStatsCalls atomic.Uint64
+	poolPressureReadMemStats = func(ms *runtime.MemStats) {
+		readMemStatsCalls.Add(1)
+		ms.HeapInuse = heapInuse.Load()
+	}
+	poolPressureMemoryLimit = func() int64 { return -1 }
+
+	release := retainPoolPressureSampler()
+	t.Cleanup(release)
+
+	heapInuse.Store(9 << 30)
+	deadline := time.Now().Add(2*poolPressureRefreshInterval + 500*time.Millisecond)
+	for time.Now().Before(deadline) {
+		if currentPoolPressureLevelFast() == poolPressureCritical {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if got := currentPoolPressureLevelFast(); got != poolPressureCritical {
+		t.Fatalf("fast pressure level=%v want critical after sampler refresh", got)
+	}
+	if got := readMemStatsCalls.Load(); got == 0 {
+		t.Fatalf("sampler did not read memstats")
 	}
 }


### PR DESCRIPTION
Tracker:
- Issue: #2187
- Milestone: M0-M4 single implementation PR

Test Plan Start:
- Preserve TreeDB/caching pressure scaling, entry-slice trimming, append-only capacity hints, TreeDB package behavior, and collection integration.
- Add/adjust coverage for cached mutable threshold reads, pressure transitions, base-threshold updates under pressure, sampler freshness publishing, and append-only hint slow-path pressure publish setup.
- Guard against stale effective thresholds, accidental `poolPressureNow`/`ReadMemStats` calls in repeated threshold reads, and delayed pressure refresh after moving the lookup out of the write path.

Performance Plan Start:
- Fresh baseline artifacts:
  - `GOWORK=off make unified-bench`
  - `GOWORK=off make benchprof`
  - `./bin/unified-bench -dbs treedb,treedb_vlog_block_snappy -profile fast -keys 1000000 -test sequential_write,random_write,batch_write,batch_random -profile-dir /tmp/gomap_2187_fresh_base_1F8Uvb -path-label native-fastpath -progress=false`
  - `./bin/benchprof -profiles-dir /tmp/gomap_2187_fresh_base_1F8Uvb`
- Current candidate artifacts:
  - same command with `/tmp/gomap_2187_candidate_e77_fEHl3p`
  - `./bin/benchprof -profiles-dir /tmp/gomap_2187_candidate_e77_fEHl3p`
- Variance references retained from earlier local runs:
  - candidate repeat: `/tmp/gomap_2187_candidate_repeat_tO2dSu`
  - sampler-fix candidate: `/tmp/gomap_2187_candidate_sampler_qEN02m`
  - old-code recheck worktree/artifacts: `/tmp/gomap_2187_base_recheck_profiles_D5sNMj`
  - discarded under-contention runs: `/tmp/gomap_2187_candidate_final_yKbZr8`, `/tmp/gomap_2187_candidate_final_repeat_2FS5aq`
- Metrics: ops/sec from unified-bench; CPU pprof focus for `mutableFlushThreshold`, `currentPoolPressureSnapshot`, `sampleAndPublishPoolPressureSnapshot`, `time.Now`, and `runtime.duffcopy`.

Implementation Notes:
- Threshold cache/state shape: process-wide packed pressure level/version atomic plus per-DB cached effective mutable threshold derived from base threshold and pressure state.
- Hot-path behavior: `mutableFlushThreshold()` uses atomic cached base/effective/state values and does not call `currentPoolPressureSnapshot()`.
- Pressure freshness: open DBs retain one process-wide sampler that publishes pressure every `poolPressureRefreshInterval` (250ms), preserving the previous freshness bound without putting time/memstats sampling back on write paths.
- Full snapshot callers retained: `Stats()`, explicit `currentPoolPressureSnapshot()` callers, and process-memory peak accounting still use full `poolPressureSnapshot` data.

Test Plan Close:
- Formatting/build:
  - `gofmt -w TreeDB/caching/db.go TreeDB/caching/pool_pressure_test.go TreeDB/caching/append_only_hint_test.go`
  - `git diff --check`
  - `GOWORK=off make unified-bench`
  - `GOWORK=off make benchprof`
- Focused tests:
  - `GOWORK=off go test ./TreeDB/caching -run 'Test.*(PoolPressure|MutableFlushThreshold|AppendOnlyMemtableCapacityHint|ScaleMutableFlushThreshold)'`
  - `GOWORK=off go test -race ./TreeDB/caching -run 'TestMutableFlushThreshold|TestSampleProcessMemoryPeaksPublishesFreshPressureSnapshot|TestPoolPressureSampler'`
- Broader tests:
  - `GOWORK=off go test ./TreeDB/caching`
  - `GOWORK=off go test -race ./TreeDB/caching`
  - `GOWORK=off go test ./TreeDB ./TreeDB/caching ./TreeDB/collections`
- Residual gap: local full root `make test` was not rerun to completion after the sampler fix; latest-head CI is the broad full-repo gate.
- Latest-head GitHub CI: all PR checks passed on `e77c4af6b`.

Performance Plan Close:
- Fresh baseline vs current candidate throughput:

| Workload | TreeDB base | TreeDB cand | TreeDB block/snappy base | TreeDB block/snappy cand |
| --- | ---: | ---: | ---: | ---: |
| sequential_write | 2,655,562 | 2,815,510 | 2,528,535 | 2,872,367 |
| random_write | 1,982,367 | 2,314,076 | 1,912,441 | 2,276,243 |
| batch_write | 6,857,272 | 6,449,639 | 6,236,087 | 6,093,125 |
| batch_random | 2,576,782 | 2,874,039 | 1,819,279 | 1,597,702 |

- CPU profile attribution:
  - baseline `cpu_sequential_write_treedb_vlog_block_snappy.pprof`, focused on `mutableFlushThreshold`: 40ms / 850ms total, including `currentPoolPressureSnapshot`, `runtime.duffcopy`, and `time.runtimeNow`.
  - current candidate `cpu_sequential_write_treedb_vlog_block_snappy.pprof`, focused on `mutableFlushThreshold`: no matched samples.
  - baseline `cpu_random_write_treedb_vlog_block_snappy.pprof`, focused on `mutableFlushThreshold`: 0.11s / 1.53s total, including `currentPoolPressureSnapshot`, `runtime.duffcopy`, and `time.runtimeNow`.
  - current candidate `cpu_random_write_treedb_vlog_block_snappy.pprof`, focused on `mutableFlushThreshold`: no matched samples.
  - current candidate sequential block/snappy, focused on `currentPoolPressureSnapshot` and `sampleAndPublishPoolPressureSnapshot`: no matched samples.
- Regression assessment: the targeted single-write CPU issue is removed. Batch throughput remains noisy; current candidate `batch_write` is slightly lower than baseline and `batch_random` block/snappy is lower, while current `batch_random` TreeDB is higher. Prior and current profiles point at merge/read/compression work rather than the threshold path, so this remains documented variance rather than hidden evidence.
- Remaining bottlenecks deferred: `noteWrite` still has `time.Now` attribution in candidate single-write profiles; this PR intentionally limits scope to mutable flush-threshold pressure lookup.

AI Review Loop:
- Codex: reviewed `6ab0a2fd26` and `b12f52e95`; freshness findings fixed in `b12f52e95` and `e77c4af6b`; both threads replied to and resolved.
- Copilot: reviewed `e77c4af6b` with no new comments.
- CodeRabbit: check is passing; re-review trigger acknowledged after the mature head request.
- Unresolved threads or explicit rejections: none after resolving both Codex freshness threads.

