### PR TITLE
treedb: evaluate internal base-delta index compatibility

### DIFF
--- a/TreeDB/reopen_verify_test.go
+++ b/TreeDB/reopen_verify_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"encoding/json"
 	"fmt"
 	"hash/fnv"
 	"math/rand"
@@ -480,6 +481,196 @@ func TestReopenVerify_InternalBaseDelta_WALOn_Checkpoint(t *testing.T) {
 
 	checkGets(t, reopen, keys, values, false)
 	scanAndCheck(t, reopen, values, false, hash)
+}
+
+func TestReopenVerify_OuterLeavesExplicitInternalBaseDeltaDisabled_Churn(t *testing.T) {
+	dir := t.TempDir()
+	const total = 4096
+
+	type formatConfigView struct {
+		IndexOuterLeavesInValueLog bool `json:"index_outer_leaves_in_vlog"`
+		IndexInternalBaseDelta     bool `json:"index_internal_base_delta"`
+	}
+	readFormat := func() formatConfigView {
+		t.Helper()
+		data, err := os.ReadFile(filepath.Join(dir, "maindb", "format.json"))
+		if err != nil {
+			t.Fatalf("read format config: %v", err)
+		}
+		var cfg formatConfigView
+		if err := json.Unmarshal(data, &cfg); err != nil {
+			t.Fatalf("decode format config: %v", err)
+		}
+		return cfg
+	}
+	keyFor := func(i int) []byte {
+		var k [8]byte
+		binary.BigEndian.PutUint64(k[:], uint64(i))
+		return append([]byte(nil), k[:]...)
+	}
+	valueFor := func(i int, seed byte) []byte {
+		v := make([]byte, 192)
+		for j := range v {
+			v[j] = seed + byte((i+j)%251)
+		}
+		return v
+	}
+	dirSize := func(path string) (int64, error) {
+		var total int64
+		err := filepath.WalkDir(path, func(_ string, d os.DirEntry, err error) error {
+			if err != nil || d.IsDir() {
+				return err
+			}
+			info, err := d.Info()
+			if err != nil {
+				return err
+			}
+			total += info.Size()
+			return nil
+		})
+		return total, err
+	}
+
+	opts := treedb.Options{
+		Dir:                        dir,
+		LeafPrefixCompression:      true,
+		IndexColumnarLeaves:        true,
+		IndexPackedValuePtr:        true,
+		IndexInternalBaseDelta:     true, // Must resolve false with outer leaf-log refs.
+		IndexOuterLeavesInValueLog: true,
+		ValueLog: treedb.ValueLogOptions{
+			PointerThreshold: 1,
+		},
+	}
+
+	db, err := treedb.Open(opts)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+
+	expected := make(map[string][]byte, total)
+	for i := 0; i < total; i++ {
+		key := keyFor(i)
+		val := valueFor(i, 17)
+		if err := db.Set(key, val); err != nil {
+			_ = db.Close()
+			t.Fatalf("set initial %d: %v", i, err)
+		}
+		expected[string(key)] = val
+	}
+	if err := db.Checkpoint(); err != nil {
+		_ = db.Close()
+		t.Fatalf("checkpoint initial: %v", err)
+	}
+
+	if cfg := readFormat(); !cfg.IndexOuterLeavesInValueLog || cfg.IndexInternalBaseDelta {
+		_ = db.Close()
+		t.Fatalf("unexpected persisted index format after open: %+v", cfg)
+	}
+
+	if err := db.DeleteRange(keyFor(700), keyFor(1700)); err != nil {
+		_ = db.Close()
+		t.Fatalf("delete range: %v", err)
+	}
+	for i := 700; i < 1700; i++ {
+		delete(expected, string(keyFor(i)))
+	}
+	for i := 0; i < total; i++ {
+		if i >= 700 && i < 1700 {
+			continue
+		}
+		key := keyFor(i)
+		if i%11 == 0 {
+			val := valueFor(i, 83)
+			if err := db.Set(key, val); err != nil {
+				_ = db.Close()
+				t.Fatalf("overwrite %d: %v", i, err)
+			}
+			expected[string(key)] = val
+		}
+		if i%257 == 0 {
+			if err := db.Delete(key); err != nil {
+				_ = db.Close()
+				t.Fatalf("delete %d: %v", i, err)
+			}
+			delete(expected, string(key))
+		}
+	}
+	if err := db.Checkpoint(); err != nil {
+		_ = db.Close()
+		t.Fatalf("checkpoint churn: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	if cfg := readFormat(); !cfg.IndexOuterLeavesInValueLog || cfg.IndexInternalBaseDelta {
+		t.Fatalf("unexpected persisted index format after close: %+v", cfg)
+	}
+	if size, err := dirSize(filepath.Join(dir, "maindb", "leaf_vlog")); err != nil || size == 0 {
+		t.Fatalf("expected outer leaf log bytes, size=%d err=%v", size, err)
+	}
+
+	reopen, err := treedb.Open(opts)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer reopen.Close()
+
+	for i := 0; i < total; i++ {
+		key := keyFor(i)
+		got, err := reopen.Get(key)
+		want, ok := expected[string(key)]
+		if !ok {
+			if err != nil {
+				t.Fatalf("get deleted %d: %v", i, err)
+			}
+			if got != nil {
+				t.Fatalf("expected key %d deleted, got %d bytes", i, len(got))
+			}
+			continue
+		}
+		if err != nil {
+			t.Fatalf("get %d: %v", i, err)
+		}
+		if !bytes.Equal(got, want) {
+			t.Fatalf("get mismatch key=%d got=%d bytes want=%d bytes", i, len(got), len(want))
+		}
+	}
+
+	it, err := reopen.Iterator(nil, nil)
+	if err != nil {
+		t.Fatalf("iterator: %v", err)
+	}
+	defer it.Close()
+	seen := 0
+	for i := 0; i < total; i++ {
+		key := keyFor(i)
+		want, ok := expected[string(key)]
+		if !ok {
+			continue
+		}
+		if !it.Valid() {
+			t.Fatalf("iterator ended early at %d", i)
+		}
+		if gotKey := it.KeyCopy(nil); !bytes.Equal(gotKey, key) {
+			t.Fatalf("iterator key mismatch at %d: got=%x want=%x", i, gotKey, key)
+		}
+		if gotVal := it.ValueCopy(nil); !bytes.Equal(gotVal, want) {
+			t.Fatalf("iterator value mismatch at %d", i)
+		}
+		seen++
+		it.Next()
+	}
+	if it.Valid() {
+		t.Fatalf("iterator has extra entries")
+	}
+	if err := it.Error(); err != nil {
+		t.Fatalf("iterator error: %v", err)
+	}
+	if seen != len(expected) {
+		t.Fatalf("iterator count mismatch seen=%d want=%d", seen, len(expected))
+	}
 }
 
 func TestReopenVerify_WALOn_WriteSync(t *testing.T) {

--- a/TreeDB/reopen_verify_test.go
+++ b/TreeDB/reopen_verify_test.go
@@ -622,7 +622,7 @@ func TestReopenVerify_OuterLeavesExplicitInternalBaseDeltaDisabled_Churn(t *test
 		got, err := reopen.Get(key)
 		want, ok := expected[string(key)]
 		if !ok {
-			if err != nil {
+			if err != nil && err != treedb.ErrKeyNotFound {
 				t.Fatalf("get deleted %d: %v", i, err)
 			}
 			if got != nil {

--- a/artifacts/2196/index_base_delta_evaluation.md
+++ b/artifacts/2196/index_base_delta_evaluation.md
@@ -1,0 +1,133 @@
+# Issue #2196 TreeDB internal base-delta/index optimization evaluation
+
+Date: 2026-06-02
+Host/context: local darwin/arm64 manager worktree.
+Base: `origin/main` at `94e322a0727f7a0d07154a006e9fa4ec4e3936f4`.
+Candidate: `snissn/2196-manager`; exact latest PR head SHA is recorded in the PR body/final handoff to avoid a self-referential artifact SHA.
+
+## Scope and conclusion
+
+This pass keeps mmap and codec policy constant and evaluates only TreeDB index flags.
+
+Conclusion: keep `index_internal_base_delta=false` for native fastpath runs that use
+`index_outer_leaves_in_vlog=true`. The CLI accepts explicit
+`-treedb-index-internal-base-delta=true`, but resolved options still disable it
+because leaf-log child pages use explicit `LogRecordRef` child refs rather than
+base-delta page child IDs. The aggregate `-treedb-index-optimizations` bundle can
+still enable prefix-compressed/columnar/packed-pointer leaf encodings, but its
+resolved `index_optimizations` line remains false whenever internal base-delta is
+forced off by outer-leaf-vlog compatibility.
+
+No default/profile policy change is recommended in this PR. The pager-leaf
+control run where base-delta actually resolves on shows a random-read/full-scan
+regression and visible `internalBaseDeltaMeta` CPU, which supports leaving #357
+as future narrow search/decode work rather than enabling base-delta here.
+
+## Commands and environment
+
+Benchmark artifact root:
+
+```text
+/tmp/gomap_2196_index_eval_20260602_093447
+```
+
+Environment relevant to this matrix: no `TREEDB_*`, `GOMAP_*`, or `GOWORK`
+variables were set in the benchmark shell (`env.txt` files are empty). Codec was
+held explicit/declarative with `-treedb-vlog-compression=auto
+-treedb-vlog-block-codec=snappy -treedb-vlog-auto-policy=balanced`; mmap policy
+was default (no leaf mmap budget env overrides).
+
+Native 1M-key common command shape:
+
+```sh
+./bin/unified-bench -dbs=treedb -keys=1000000 -profile fast \
+  -path-label=native-fastpath -progress=false -read-workers=12 \
+  -test dataset_write_sorted,batch_write,batch_random,random_read_parallel,full_scan,prefix_scan \
+  -treedb-vlog-compression=auto -treedb-vlog-block-codec=snappy -treedb-vlog-auto-policy=balanced \
+  <index flags> -profile-dir=<case-dir>
+./bin/benchprof -profiles-dir <case-dir>
+```
+
+Pager-leaf control command shape used `-keys=300000` plus
+`-treedb-index-outer-leaves-in-vlog=false -treedb-index-optimizations=true` and
+toggled explicit `-treedb-index-internal-base-delta`.
+
+Each case directory contains `command.txt`, `env.txt`, `run.log`,
+`benchprof_results.{json,md}`, CPU/alloc/block/mutex pprof files, and focused
+`cpu_*_focus_treedb.txt`/`allocs_*_top60.txt` summaries for selected tests.
+
+## Matrix
+
+Throughput is ops/sec from `benchprof_results.json`.
+
+| case | keys | outer leaves | aggregate result | internal base-delta | index.db | leaf_vlog | sorted write | batch write | batch random | parallel read | full scan | prefix scan |
+|---|---:|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|
+| `native_aggregate_off` | 1,000,000 | true | false | false | 9 MiB | total=126 MiB files=8 value=126 MiB other=876 B | 2,228,791 | 5,904,193 | 2,301,382 | 1,074,291 | 4,066,718 | 567,892 |
+| `native_aggregate_on` | 1,000,000 | true | false | false | 9 MiB | total=91 MiB files=6 value=91 MiB other=665 B | 2,464,819 | 2,774,796 | 1,695,524 | 1,800,924 | 2,264,561 | 1,098,912 |
+| `native_internal_off` | 1,000,000 | true | false | false | 9 MiB | total=88 MiB files=6 value=88 MiB other=665 B | 2,557,402 | 6,150,273 | 2,462,836 | 2,672,713 | 1,623,467 | 834,565 |
+| `native_internal_on` | 1,000,000 | true | false | false | 9 MiB | total=99 MiB files=8 value=99 MiB other=876 B | 593,915 | 3,956,635 | 1,243,613 | 2,627,074 | 5,846,655 | 1,522,822 |
+| `pager_internal_off` | 300,000 | false | false | false | 125 MiB | n/a | 4,378,451 | 5,941,521 | 2,653,100 | 13,205,890 | 6,278,519 | 1,161,770 |
+| `pager_internal_on` | 300,000 | false | true | true | 124 MiB | n/a | 4,429,305 | 5,765,710 | 3,913,839 | 5,922,339 | 3,608,295 | 927,300 |
+
+Interpretation:
+
+- In native outer-leaf-vlog mode, explicit internal base-delta on/off resolves to
+  the same effective format (`index_internal_base_delta=false`). Differences
+  among those rows are run-to-run noise, not a code-path delta.
+- The aggregate leaf/index bundle reduces `leaf_vlog` bytes versus aggregate-off
+  runs, but read/write/scan results are mixed in this single-run matrix. This PR
+  therefore does not change aggregate defaults.
+- In the pager-leaf control where internal base-delta is truly enabled, index.db
+  shrinks only ~1 MiB at this scale while parallel random read and scans regress.
+
+## CPU and allocation attribution
+
+Selected pprof text summaries are under the case directories. Representative
+random-read CPU attribution:
+
+| case/test | selected attribution |
+|---|---|
+| `native_aggregate_off/random_read_parallel` | `SearchInternalChildRef` 1.00s cum / 6.13%; `SearchInternalChildID` 0.59s cum / 3.62%; `valuelog.File.ReadUnsafeTo` 0.65s cum / 3.99%; `leafPageReadCache.getViewLocked` 0.56s cum / 3.44%. |
+| `native_internal_off/random_read_parallel` | `valueReader.ReadUnsafeTo` 1.57s cum / 13.00%; `SearchInternalChildRef` 1.03s cum / 8.53%; `SearchInternalChildID` 0.68s cum / 5.63%; `leafPageReadCache.getViewLocked` 0.61s cum / 5.05%. |
+| `pager_internal_off/random_read_parallel` | `SearchInternalChildID` 0.19s cum / 15.83%. |
+| `pager_internal_on/random_read_parallel` | `SearchInternalChildID` 0.37s cum / 26.81%; `internalBaseDeltaMeta` 0.11s cum / 7.97%; `internalBaseDeltaChildIDAtPtr` 0.01s cum / 0.72%. |
+
+Representative scan attribution in native aggregate-on (`native_internal_off`):
+`tree.Iterator.Next/loadCurrent/loadNodeRef` and value-log leaf reads dominate
+full scan (`Iterator.Next` 0.33s cum / 26.61%, `valueReader.ReadUnsafeTo` 0.21s
+cum / 16.94%, `GetLeafKeyFlagsView` 0.04s cum / 3.23%). Prefix scan profiles
+were short/noisy; attribution was iterator construction/read-cache lookup, not a
+new decode-table allocation path.
+
+Allocation profiles did not show any new base-delta decode table/cache behavior
+because this PR introduces no such cache. Native random-read allocation profiles
+were dominated by memtable recycle/zipper setup samples; pager-control allocation
+profiles were dominated by pprof/gzip snapshot writing.
+
+## Correctness coverage added/confirmed
+
+Added tests:
+
+- `cmd/unified_bench`: explicit `-treedb-index-internal-base-delta=true` resolves
+  false with outer leaves and reports the compatibility note; the same explicit
+  flag resolves true when pager leaves are selected.
+- `TreeDB`: reopen/churn test with `IndexOuterLeavesInValueLog=true`, leaf
+  prefix/columnar/packed pointer flags enabled, and explicit
+  `IndexInternalBaseDelta=true`; verifies persisted `format.json` forces
+  `index_internal_base_delta=false`, confirms `leaf_vlog` bytes exist, checks
+  gets, deletes, range delete, overwrites, checkpoint/reopen, and forward scan
+  order.
+
+Existing tests covering node-level base-delta search boundaries, split/compact,
+fanout, reopen, and rewrite/vacuum compatibility remain in
+`TreeDB/node/internal_base_delta_test.go`, `TreeDB/reopen_verify_test.go`, and
+`TreeDB/db/*`.
+
+Focused local validation:
+
+```sh
+GOWORK=off go test ./cmd/unified_bench -run 'TestBuildTreeDBOptions_(ExplicitInternalBaseDelta|IndexOptimizationsPerFlagOverride|ExplicitCompositeFalse)' -count=1
+GOWORK=off go test ./TreeDB -run 'TestReopenVerify_(InternalBaseDelta_WALOn_Checkpoint|OuterLeavesExplicitInternalBaseDeltaDisabled_Churn)' -count=1
+GOWORK=off go test ./TreeDB/node ./TreeDB ./cmd/unified_bench -count=1
+GOWORK=off make unified-bench benchprof
+```

--- a/cmd/unified_bench/profiles_treedb_index_test.go
+++ b/cmd/unified_bench/profiles_treedb_index_test.go
@@ -563,3 +563,62 @@ func TestBuildTreeDBOptions_ExplicitCompositeFalseWinsUnlessPerFlagExplicit(t *t
 		t.Fatalf("expected explicit composite=false to disable remaining optimization fields")
 	}
 }
+
+func TestBuildTreeDBOptions_ExplicitInternalBaseDeltaDisabledWithOuterLeaves(t *testing.T) {
+	saved := saveTreeDBFlagState()
+	defer restoreTreeDBFlagState(saved)
+
+	resetTreeDBIndexFlagsForTest()
+	*treedbIndexInternalBaseDelta = true
+	explicitFlags = map[string]bool{
+		"treedb-index-internal-base-delta": true,
+	}
+
+	opts, rep, err := buildTreeDBOptions("")
+	if err != nil {
+		t.Fatalf("buildTreeDBOptions: %v", err)
+	}
+	if !opts.IndexOuterLeavesInValueLog {
+		t.Fatalf("expected outer leaves in value log to remain enabled")
+	}
+	if opts.IndexInternalBaseDelta {
+		t.Fatalf("expected explicit internal base-delta to resolve false with outer leaves in value log")
+	}
+	text := rep.formatText("")
+	if !strings.Contains(text, "index_internal_base_delta=false") {
+		t.Fatalf("resolved report missing disabled internal base-delta line:\n%s", text)
+	}
+	if !strings.Contains(text, "index_internal_base_delta disabled: leaf-log child pages use explicit LogRecordRef entries") {
+		t.Fatalf("resolved report missing leaf-log compatibility note:\n%s", text)
+	}
+}
+
+func TestBuildTreeDBOptions_ExplicitInternalBaseDeltaEnabledWithPagerLeaves(t *testing.T) {
+	saved := saveTreeDBFlagState()
+	defer restoreTreeDBFlagState(saved)
+
+	resetTreeDBIndexFlagsForTest()
+	*treedbIndexOptimizations = true
+	*treedbIndexOuterLeavesInVlog = false
+	*treedbIndexInternalBaseDelta = true
+	explicitFlags = map[string]bool{
+		"treedb-index-optimizations":        true,
+		"treedb-index-outer-leaves-in-vlog": true,
+		"treedb-index-internal-base-delta":  true,
+	}
+
+	opts, rep, err := buildTreeDBOptions("")
+	if err != nil {
+		t.Fatalf("buildTreeDBOptions: %v", err)
+	}
+	if opts.IndexOuterLeavesInValueLog {
+		t.Fatalf("expected explicit pager-leaf mode")
+	}
+	if !opts.IndexInternalBaseDelta {
+		t.Fatalf("expected internal base-delta to resolve true when pager leaves are used")
+	}
+	text := rep.formatText("")
+	if !strings.Contains(text, "index_optimizations=true") || !strings.Contains(text, "index_internal_base_delta=true") {
+		t.Fatalf("resolved report missing enabled index optimization lines:\n%s", text)
+	}
+}


### PR DESCRIPTION
## Objective

Evaluate TreeDB internal base-delta/index optimization behavior for the native fastpath lane, with outer leaves in the value log, and lock in the compatibility expectations discovered by the matrix.

Closes #2196. Refs #2191.

## Context

#2191 native-fastpath option reporting showed `index_optimizations=false` while individual leaf optimizations were true and `index_internal_base_delta=false`. This PR keeps mmap and value-log codec policy constant and verifies whether aggregate index optimizations or explicit internal base-delta should change the native-fastpath profile.

## Non-goals

- No value-log codec/default change.
- No mmap budget/default change.
- No leaf-vlog frame grouping, allocation, maintenance, or generation-policy change.
- No storage-format change or migration scaffold.

## Design / Scope

Includes:

- `cmd/unified_bench/profiles_treedb_index_test.go`: option-resolution regression tests for explicit internal base-delta with outer-leaf-vlog versus pager-leaf modes.
- `TreeDB/reopen_verify_test.go`: reopen/churn coverage proving explicit `IndexInternalBaseDelta=true` resolves/persists false when `IndexOuterLeavesInValueLog=true`, while leaf prefix/columnar/packed-pointer flags remain enabled.
- `artifacts/2196/index_base_delta_evaluation.md`: matrix summary, resolved options, throughput/storage/profile attribution, conclusion.

Conclusion: keep `index_internal_base_delta=false` for native fastpath with `index_outer_leaves_in_vlog=true`. The CLI accepts explicit `-treedb-index-internal-base-delta=true`, but resolved options disable it because leaf-log child pages use explicit `LogRecordRef` child refs. No default/profile policy change is recommended here.

## Correctness

Latest-head local validation on `c4023b053c1a4577af51b0d12c7633840e60b7d5`:

```sh
GOWORK=off go test ./cmd/unified_bench -run 'TestBuildTreeDBOptions_(ExplicitInternalBaseDelta|IndexOptimizationsPerFlagOverride|ExplicitCompositeFalse)' -count=1
GOWORK=off go test ./TreeDB -run 'TestReopenVerify_(InternalBaseDelta_WALOn_Checkpoint|OuterLeavesExplicitInternalBaseDeltaDisabled_Churn)' -count=1
GOWORK=off go test ./TreeDB/node ./TreeDB ./cmd/unified_bench -count=1
GOWORK=off make unified-bench benchprof
```

Local logs: `/tmp/gomap-2196-validation/head-c4023b053/`.

## Performance / Evaluation Evidence

Benchmark artifact root: `/tmp/gomap_2196_index_eval_20260602_093447` (matrix captured on the candidate tree before a final test-only assertion tighten; runtime/benchmark code is unchanged at PR head `c4023b053`).

Common native command shape:

```sh
./bin/unified-bench -dbs=treedb -keys=1000000 -profile fast \
  -path-label=native-fastpath -progress=false -read-workers=12 \
  -test dataset_write_sorted,batch_write,batch_random,random_read_parallel,full_scan,prefix_scan \
  -treedb-vlog-compression=auto -treedb-vlog-block-codec=snappy -treedb-vlog-auto-policy=balanced \
  <index flags> -profile-dir=<case-dir>
./bin/benchprof -profiles-dir <case-dir>
```

Throughput is ops/sec from `benchprof_results.json`:

| case | keys | outer leaves | aggregate result | internal base-delta | index.db | leaf_vlog | sorted write | batch write | batch random | parallel read | full scan | prefix scan |
|---|---:|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|
| native_aggregate_off | 1,000,000 | true | false | false | 9 MiB | 126 MiB | 2,228,791 | 5,904,193 | 2,301,382 | 1,074,291 | 4,066,718 | 567,892 |
| native_aggregate_on | 1,000,000 | true | false | false | 9 MiB | 91 MiB | 2,464,819 | 2,774,796 | 1,695,524 | 1,800,924 | 2,264,561 | 1,098,912 |
| native_internal_off | 1,000,000 | true | false | false | 9 MiB | 88 MiB | 2,557,402 | 6,150,273 | 2,462,836 | 2,672,713 | 1,623,467 | 834,565 |
| native_internal_on | 1,000,000 | true | false | false | 9 MiB | 99 MiB | 593,915 | 3,956,635 | 1,243,613 | 2,627,074 | 5,846,655 | 1,522,822 |
| pager_internal_off | 300,000 | false | false | false | 125 MiB | n/a | 4,378,451 | 5,941,521 | 2,653,100 | 13,205,890 | 6,278,519 | 1,161,770 |
| pager_internal_on | 300,000 | false | true | true | 124 MiB | n/a | 4,429,305 | 5,765,710 | 3,913,839 | 5,922,339 | 3,608,295 | 927,300 |

Profile attribution summary is in `artifacts/2196/index_base_delta_evaluation.md` and the local case directories. Key signal: native outer-leaf-vlog explicit base-delta on/off resolves to the same effective format; pager-leaf control shows base-delta truly enabled but regresses random-read/scan while saving only ~1 MiB at this scale.

## Rollout / Toggle Plan

No rollout change. Existing behavior remains: outer-leaf-vlog mode disables internal base-delta; pager-leaf mode can still explicitly enable it.

## CI / AI Review / Merge Status

- Latest-head CI: running for `c4023b053c1a4577af51b0d12c7633840e60b7d5`; early checks include `gofmt`, `bench (linux)`, `windows-latest`, `macos-latest`, and `profiles (linux) (balanced)` passing.
- Codex latest-head review: requested via `@codex review`.
- Copilot latest-head review: requested via `@copilot review`.
- CodeRabbit latest-head review: auto-completed once and re-requested via `@coderabbitai review` after PR body/evidence was current.
- Merge status: manager handoff only; coordinator owns final review/merge.
