### PR TITLE
treedb: trim value-log pointerization allocations

### DIFF
--- a/TreeDB/caching/value_log_appender.go
+++ b/TreeDB/caching/value_log_appender.go
@@ -30,7 +30,8 @@ func (a *cachingValueLogAppender) AppendValues(values [][]byte) ([]page.ValuePtr
 	if err != nil {
 		return nil, err
 	}
-	records := make([]valuelog.Record, len(values))
+	records := getValueLogRecords(len(values))
+	defer putValueLogRecordsNoClear(records)
 	for i := range values {
 		records[i] = valuelog.Record{
 			RID:   startRID + uint64(i),

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -4977,6 +4977,11 @@ const (
 	collectionPointerizeBatchMaxBytes  = 4 << 20
 )
 
+func collectionRunTableHasStableUnsafeSlices(table memtable.Table) bool {
+	stable, ok := table.(memtable.StableUnsafeIteratorTable)
+	return ok && stable.StableUnsafeIteratorSlices()
+}
+
 func pointerizeCollectionRunTableValues(db *backenddb.DB, table memtable.Table) (memtable.Table, bool, error) {
 	if db == nil || table == nil || !db.HasValueLogAppender() {
 		return table, false, nil
@@ -5003,6 +5008,11 @@ func pointerizeCollectionRunTableValues(db *backenddb.DB, table memtable.Table) 
 	}
 
 	entries := make([]collectionPointerizedRunEntry, 0, table.Len())
+	// AppendValueLogValues completes the append before returning. For run tables
+	// that promise immutable iterator values across Next/Close, borrow those
+	// slices for the synchronous append and avoid a per-value clone; unstable
+	// iterator tables keep the defensive copy below.
+	borrowPointerValues := collectionRunTableHasStableUnsafeSlices(table)
 	batchValues := make([][]byte, 0, collectionPointerizeBatchMaxValues)
 	batchEntryIndexes := make([]int, 0, collectionPointerizeBatchMaxValues)
 	batchBytes := 0
@@ -5046,10 +5056,13 @@ func pointerizeCollectionRunTableValues(db *backenddb.DB, table memtable.Table) 
 			flags&node.FlagPointer == 0 &&
 			len(value) > db.InlineThresholdForKey(entry.key) {
 			entries = append(entries, entry)
-			valueCopy := bytes.Clone(value)
-			batchValues = append(batchValues, valueCopy)
+			appendValue := value
+			if !borrowPointerValues {
+				appendValue = bytes.Clone(value)
+			}
+			batchValues = append(batchValues, appendValue)
 			batchEntryIndexes = append(batchEntryIndexes, len(entries)-1)
-			batchBytes += len(valueCopy)
+			batchBytes += len(appendValue)
 			if len(batchValues) >= collectionPointerizeBatchMaxValues || batchBytes >= collectionPointerizeBatchMaxBytes {
 				if err := flushBatch(); err != nil {
 					return table, false, err

--- a/TreeDB/collections/api_test.go
+++ b/TreeDB/collections/api_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -717,8 +718,15 @@ func TestCollectionFastJSONLargeDocumentsUseValueLogPointers(t *testing.T) {
 		ids[i] = []byte(fmt.Sprintf("at://did:example:%06d", i))
 		docs[i] = collectionLargeJSONDocumentForTest(i, 8<<10)
 	}
+	wantFirst := bytes.Clone(docs[0])
+	wantLast := bytes.Clone(docs[documents-1])
 	if _, err := col.InsertBatch(ids, docs); err != nil {
 		t.Fatalf("insert large JSON batch: %v", err)
+	}
+	for i := range docs {
+		for j := range docs[i] {
+			docs[i][j] ^= 0xff
+		}
 	}
 	if err := col.Flush(); err != nil {
 		t.Fatalf("flush large JSON batch: %v", err)
@@ -731,8 +739,8 @@ func TestCollectionFastJSONLargeDocumentsUseValueLogPointers(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get large JSON doc: %v", err)
 	}
-	if !bytes.Equal(got, docs[documents-1]) {
-		t.Fatalf("large JSON doc mismatch: got %d bytes want %d", len(got), len(docs[documents-1]))
+	if !bytes.Equal(got, wantLast) {
+		t.Fatalf("large JSON doc mismatch: got %d bytes want %d", len(got), len(wantLast))
 	}
 	requireCollectionPrimaryEntryPointer(t, d, "bluesky", ids[documents-1])
 
@@ -752,8 +760,8 @@ func TestCollectionFastJSONLargeDocumentsUseValueLogPointers(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get reopened large JSON doc: %v", err)
 	}
-	if !bytes.Equal(reopenedDoc, docs[0]) {
-		t.Fatalf("reopened large JSON doc mismatch: got %d bytes want %d", len(reopenedDoc), len(docs[0]))
+	if !bytes.Equal(reopenedDoc, wantFirst) {
+		t.Fatalf("reopened large JSON doc mismatch: got %d bytes want %d", len(reopenedDoc), len(wantFirst))
 	}
 }
 
@@ -978,6 +986,66 @@ func collectionLargeJSONDocumentForTest(i, payloadBytes int) []byte {
 		i,
 		strings.Repeat("x", payloadBytes),
 	))
+}
+
+func BenchmarkCollectionLargeDocumentPointerizedInsertBatchFlush(b *testing.B) {
+	prevLog := log.Writer()
+	log.SetOutput(io.Discard)
+	b.Cleanup(func() { log.SetOutput(prevLog) })
+
+	opts := treedb.OptionsFor(treedb.ProfileFast, b.TempDir())
+	d, cleanup, err := treedb.OpenBackendWithCachedLeafLog(opts)
+	if err != nil {
+		b.Fatalf("open db: %v", err)
+	}
+	b.Cleanup(func() {
+		if err := cleanup(); err != nil {
+			b.Errorf("close db: %v", err)
+		}
+	})
+
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "bluesky",
+		Options: CollectionOptions{
+			DocumentFormat:        DocumentFormatJSON,
+			DataRootStoragePolicy: RootStorageFast,
+		},
+	}); err != nil {
+		b.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("bluesky")
+	if err != nil {
+		b.Fatalf("open collection: %v", err)
+	}
+
+	const targetBatchSize = 256
+	b.ReportAllocs()
+	b.ResetTimer()
+	for inserted := 0; inserted < b.N; {
+		b.StopTimer()
+		batchSize := targetBatchSize
+		if remaining := b.N - inserted; remaining < batchSize {
+			batchSize = remaining
+		}
+		ids := make([][]byte, batchSize)
+		docs := make([][]byte, batchSize)
+		for i := 0; i < batchSize; i++ {
+			docNum := inserted + i
+			ids[i] = []byte(fmt.Sprintf("at://did:example:%06d", docNum))
+			docs[i] = collectionLargeJSONDocumentForTest(docNum, 8<<10)
+		}
+		b.StartTimer()
+		if _, err := col.InsertBatch(ids, docs); err != nil {
+			b.Fatalf("insert large JSON batch: %v", err)
+		}
+		if err := col.Flush(); err != nil {
+			b.Fatalf("flush large JSON batch: %v", err)
+		}
+		inserted += batchSize
+	}
+	b.StopTimer()
+	b.ReportMetric(float64(targetBatchSize), "target_docs/batch")
 }
 
 func requireCollectionPrimaryEntryPointer(t *testing.T, d *backenddb.DB, collectionName string, id []byte) {

--- a/TreeDB/db/value_log_appender.go
+++ b/TreeDB/db/value_log_appender.go
@@ -10,6 +10,9 @@ var ErrValueLogAppenderUnavailable = errors.New("value-log appender unavailable"
 
 // ValueLogAppender appends user values to the persistent value log and returns
 // stable ValuePtr references that may be stored by native-root callers.
+//
+// AppendValues must finish reading each values element before returning; callers
+// may reuse or release the backing buffers once the call completes.
 type ValueLogAppender interface {
 	AppendValues(values [][]byte) ([]page.ValuePtr, error)
 	Flush() error

--- a/TreeDB/internal/valuelog/block_compression_bench_test.go
+++ b/TreeDB/internal/valuelog/block_compression_bench_test.go
@@ -1,0 +1,52 @@
+package valuelog
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+func BenchmarkWriterBlockCompressionSingleRecord4096(b *testing.B) {
+	writer := NewWriterWithSink(io.Discard, page.ValueLogFileID(1))
+	writer.SetBlockCompression(BlockCodecSnappy, true)
+	writer.SetEncodeSampleStride(0)
+	value := bytes.Repeat([]byte("a"), 4096)
+	records := []Record{{RID: 1, Value: value}}
+	dst := make([]page.ValuePtr, 1)
+	if _, _, err := writer.AppendFrameWithStatsInto(0, nil, records, dst); err != nil {
+		b.Fatalf("warm AppendFrameWithStatsInto: %v", err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		records[0].RID = uint64(i + 2)
+		if _, _, err := writer.AppendFrameWithStatsInto(0, nil, records, dst); err != nil {
+			b.Fatalf("AppendFrameWithStatsInto: %v", err)
+		}
+	}
+}
+
+func BenchmarkFramePreparerBlockCompressionSingleRecord4096(b *testing.B) {
+	prep := NewFramePreparer()
+	prep.SetBlockCompression(BlockCodecSnappy, true)
+	prep.SetEncodeSampleStride(0)
+	value := bytes.Repeat([]byte("a"), 4096)
+	records := []Record{{RID: 1, Value: value}}
+	buf, _, err := prep.PrepareFrameInto(nil, 0, nil, records)
+	if err != nil {
+		b.Fatalf("warm PrepareFrameInto: %v", err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		records[0].RID = uint64(i + 2)
+		buf, _, err = prep.PrepareFrameInto(buf[:0], 0, nil, records)
+		if err != nil {
+			b.Fatalf("PrepareFrameInto: %v", err)
+		}
+	}
+}

--- a/TreeDB/internal/valuelog/frame_preparer.go
+++ b/TreeDB/internal/valuelog/frame_preparer.go
@@ -326,13 +326,16 @@ func (p *FramePreparer) prepareBlockFrameBody(dst []byte, records []Record, offs
 		p.skipRemain--
 		return p.buildRawFrameBody(dst, 0, records, offsets, rawPayloadBytes, false, 0)
 	}
-	if cap(p.rawScratch) < rawPayloadBytes {
-		p.rawScratch = make([]byte, rawPayloadBytes)
-	}
-	payload := p.rawScratch[:rawPayloadBytes]
-	off := 0
-	for i := range records {
-		off += copy(payload[off:], records[i].Value)
+	payload := records[0].Value
+	if len(records) > 1 {
+		if cap(p.rawScratch) < rawPayloadBytes {
+			p.rawScratch = make([]byte, rawPayloadBytes)
+		}
+		payload = p.rawScratch[:rawPayloadBytes]
+		off := 0
+		for i := range records {
+			off += copy(payload[off:], records[i].Value)
+		}
 	}
 	encodeStart := p.sampleEncodeStart()
 	encoded, encodeErr := encodeBlockPayload(p.blockCodec, payload, p.blockScratch[:0])

--- a/TreeDB/internal/valuelog/writer.go
+++ b/TreeDB/internal/valuelog/writer.go
@@ -1916,13 +1916,16 @@ func (w *Writer) appendBlockFrameWithStats(records []Record, rawPayloadBytes int
 		return writeRaw(false, 0)
 	}
 
-	if cap(w.rawScratch) < rawPayloadBytes {
-		w.rawScratch = make([]byte, rawPayloadBytes)
-	}
-	payload := w.rawScratch[:rawPayloadBytes]
-	off := 0
-	for i := 0; i < k; i++ {
-		off += copy(payload[off:], records[i].Value)
+	payload := records[0].Value
+	if k > 1 {
+		if cap(w.rawScratch) < rawPayloadBytes {
+			w.rawScratch = make([]byte, rawPayloadBytes)
+		}
+		payload = w.rawScratch[:rawPayloadBytes]
+		off := 0
+		for i := 0; i < k; i++ {
+			off += copy(payload[off:], records[i].Value)
+		}
 	}
 
 	encodeStart := w.sampleEncodeStart()

--- a/TreeDB/internal/valuelog/writer_memory_test.go
+++ b/TreeDB/internal/valuelog/writer_memory_test.go
@@ -295,3 +295,45 @@ func TestWriterClose_ReleasesScratchBuffers(t *testing.T) {
 		t.Fatalf("encLimiter not cleared on Close: buf=%v limit=%d", writer.encLimiter.buf != nil, writer.encLimiter.limit)
 	}
 }
+
+func TestWriterBlockCompressionSingleRecordAvoidsRawConcatScratch(t *testing.T) {
+	writer := NewWriterWithSink(io.Discard, page.ValueLogFileID(1))
+	writer.SetBlockCompression(BlockCodecSnappy, true)
+
+	value := bytes.Repeat([]byte("a"), 4096)
+	wantValue := bytes.Clone(value)
+	_, stats, err := writer.AppendFrameWithStatsInto(0, nil, []Record{{RID: 1, Value: value}}, make([]page.ValuePtr, 1))
+	if err != nil {
+		t.Fatalf("AppendFrameWithStatsInto: %v", err)
+	}
+	if !stats.Kept {
+		t.Fatalf("expected single-record block compression to be kept, stats=%+v", stats)
+	}
+	if cap(writer.rawScratch) != 0 {
+		t.Fatalf("rawScratch cap=%d want 0 for single-record block compression", cap(writer.rawScratch))
+	}
+	if !bytes.Equal(value, wantValue) {
+		t.Fatal("single-record block compression mutated source value")
+	}
+}
+
+func TestFramePreparerBlockCompressionSingleRecordAvoidsRawConcatScratch(t *testing.T) {
+	prep := NewFramePreparer()
+	prep.SetBlockCompression(BlockCodecSnappy, true)
+
+	value := bytes.Repeat([]byte("b"), 4096)
+	wantValue := bytes.Clone(value)
+	_, stats, err := prep.PrepareFrameInto(nil, 0, nil, []Record{{RID: 1, Value: value}})
+	if err != nil {
+		t.Fatalf("PrepareFrameInto: %v", err)
+	}
+	if !stats.Kept {
+		t.Fatalf("expected single-record block compression to be kept, stats=%+v", stats)
+	}
+	if cap(prep.rawScratch) != 0 {
+		t.Fatalf("rawScratch cap=%d want 0 for single-record block compression", cap(prep.rawScratch))
+	}
+	if !bytes.Equal(value, wantValue) {
+		t.Fatal("single-record block compression mutated source value")
+	}
+}


### PR DESCRIPTION
## Summary

- avoid cloning stable collection run-table values before synchronous value-log pointerization
- pool value-log appender `Record` slices and document that appender inputs are consumed before return
- skip raw-concat scratch for single-record block-compressed frames in `Writer`/`FramePreparer`
- add buffer-lifetime tests and focused benchmarks for pointerized collection flush and single-record block compression

Links #2191, fixes #2195.

## Scope boundaries

This PR is allocation cleanup only. It does not change codec defaults, mmap budgets, leaf frame grouping, indexes, maintenance policy, storage format, or persistent value-log semantics.

## Tests

- `GOWORK=off go test ./TreeDB/internal/valuelog ./TreeDB/collections ./TreeDB/caching -count=1`
- `GOWORK=off go test ./TreeDB -run 'TestReopenVerify_WALOn_(Checkpoint|WriteSync)' -count=1`
- `GOWORK=off go test ./TreeDB/internal/valuelog -run 'Test(WriterBlockCompressionSingleRecordAvoidsRawConcatScratch|FramePreparerBlockCompressionSingleRecordAvoidsRawConcatScratch)' -count=1`
- `GOWORK=off go test ./TreeDB/collections -run 'TestCollectionFastJSONLargeDocumentsUseValueLogPointers' -count=1`
- `GOWORK=off go test ./TreeDB/db -run '^$' -count=1`
- `git diff --check`
- smoke harness: `RUN_DIR=/tmp/gomap-2191-handoffs/2195-artifacts/insert-compression-smoke-current COUNT=1 BENCHTIME=1000x RUN_COMPRESSION_OFF=false RUN_TIMED_CPU=false scripts/treedb_insert_compression_profile.sh`

## Benchmarks and profiles

Baseline: `origin/main` / `94e322a0727f7a0d07154a006e9fa4ec4e3936f4` (with new benchmark files injected where main did not have them).  
Candidate: `99a98cd70`.

### Collection large-document pointerized flush

Command:

```sh
GOWORK=off go test ./TreeDB/collections \
  -run '^$' \
  -bench '^BenchmarkCollectionLargeDocumentPointerizedInsertBatchFlush$' \
  -benchmem -benchtime=8192x -count=10
```

Artifact: `/tmp/gomap-2191-handoffs/2195-artifacts/benchstat-collection-large-doc-flush-final-8192-10x.txt`

| Metric | Baseline | Candidate | Delta |
| --- | ---: | ---: | ---: |
| ns/op | 15.16µ ±45% | 10.37µ ±19% | -31.63% |
| B/op | 26.48Ki ±4% | 17.35Ki ±2% | -34.48% |
| allocs/op | 5.000 ±0% | 4.000 ±0% | -20.00% |

CPU-only profile command (`-benchtime=65536x -count=1 -cpuprofile`) showed candidate 17,057 ns/op vs baseline 22,956 ns/op. Top profiles did not show allocation cleanup moving cost into encode/decode, locks, or syscalls. Artifacts: `/tmp/gomap-2191-handoffs/2195-artifacts/profiles-collection-flush-cpu-only`.

Allocation profile command (`-memprofile -memprofilerate=1`) shows pointerization `bytes.Clone` pressure removed from the benchmarked flush path: `pointerizeCollectionRunTableValues` alloc-space cumulative fell from ~319,048 KiB to ~14,556 KiB, and alloc-object cumulative from 67,212 to 34,445. Artifacts: `/tmp/gomap-2191-handoffs/2195-artifacts/profiles-collection-flush`.

### Single-record block compression microbench

Command:

```sh
GOWORK=off GOMAXPROCS=1 go test ./TreeDB/internal/valuelog \
  -run '^$' \
  -bench 'Benchmark(Writer|FramePreparer)BlockCompressionSingleRecord4096$' \
  -benchmem -benchtime=200000x -count=10 -cpu=1
```

Artifact: `/tmp/gomap-2191-handoffs/2195-artifacts/benchstat-valuelog-single-record-final-gmp1-10x.txt`

| Benchmark | Baseline ns/op | Candidate ns/op | Delta | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: | ---: |
| WriterBlockCompressionSingleRecord4096 | 400.2n ±4% | 340.5n ±1% | -14.92% | 0 | 0 |
| FramePreparerBlockCompressionSingleRecord4096 | 349.0n ±1% | 302.0n ±4% | -13.47% | 0 | 0 |

## Safety notes

- Borrowing collection run-table values is gated on `StableUnsafeIteratorSlices()` and only used for the synchronous `AppendValueLogValues` call.
- Unstable iterator tables still clone defensively.
- Tests mutate caller document buffers after `InsertBatch` and verify reads before/after reopen still return the original persisted bytes.
- Single-record block-compression tests assert no raw concat scratch is retained and the source value is not mutated.
