### PR TITLE
Add vector search profiling harness knobs

### DIFF
--- a/benchmarks/vector_db_compare/README.md
+++ b/benchmarks/vector_db_compare/README.md
@@ -62,6 +62,13 @@ Configuration:
 - `DOCS`, `DIMS`, `QUERIES`, `VALIDATE_QUERIES`, `TOP_K`: dataset and validation sizes.
 - `SEARCH_CONCURRENCY`: comma-separated search concurrency levels.
 - `M`, `EF_CONSTRUCTION`, `EF_SEARCH`, `MIN_RECALL`: HNSW and recall parameters.
+- `TREEDB_SEARCH_CPU_PROFILE_DIR`: optional directory for TreeDB search-only CPU
+  profiles. The runner writes backend-specific subdirectories such as
+  `treedb_column_graph/cpu_treedb_column_graph_concurrency_1.pprof`.
+- `TREEDB_SEARCH_WITH_BUFFER=true`: use TreeDB column-graph
+  `VectorIndexSearcher.SearchWithBuffer` for the no-document search benchmark,
+  separating reusable response-buffer performance from response-owned result
+  allocation overhead.
 - `PGVECTOR_DSN`: external PostgreSQL DSN. If empty and `pgvector` is enabled,
   the runner starts Docker unless `PGVECTOR_DOCKER=false`.
 - `PGVECTOR_DOCKER`, `PGVECTOR_IMAGE`, `PGVECTOR_MAX_CONNECTIONS`: automatic
@@ -85,6 +92,7 @@ The runner writes:
 - `pgvector.json`: PostgreSQL+pgvector benchmark result when enabled
 - `mongodb.json`: MongoDB Vector Search benchmark result when enabled
 - `comparison.md`: normalized comparison table
+- TreeDB search CPU profiles under `TREEDB_SEARCH_CPU_PROFILE_DIR` when set
 
 The TreeDB dataset exporter writes row-major little-endian `float32` vector
 files plus JSONL convenience files. TreeDB loads documents from the exported

--- a/cmd/treedb_vector_search_demo/README.md
+++ b/cmd/treedb_vector_search_demo/README.md
@@ -24,7 +24,10 @@ serial and parallel search metrics return IDs/scores and do not time final
 document fetch, reconstruction, projection, or serialization. Document reads in
 validation are correctness checks, not the preferred vector response-shape
 evidence; use `ProjectionOrientedVectorDocumentFetchPreset` in collection/vector
-APIs when timing projected documents without embeddings.
+APIs when timing projected documents without embeddings. For TreeDB column-graph
+search, `-search-with-buffer` switches this no-document phase to
+`VectorIndexSearcher.SearchWithBuffer`, which is useful when profiling the
+retrieval/scoring path without response-owned result allocation overhead.
 
 `CompactStorageFull` is intentionally used instead of manually chaining
 maintenance calls. It is TreeDB's canonical full storage compaction path:
@@ -102,6 +105,12 @@ Useful flags:
   run.
 - `-disable-exact-fallback=false`: allow exact fallback during benchmark
   searches.
+- `-search-cpu-profile-dir PATH`: emit search-only Go CPU profiles for each
+  backend/concurrency benchmark, excluding insert, rebuild, validation, and
+  reopen setup. If multiple cases share the same backend/concurrency label, the
+  harness appends a numeric suffix instead of overwriting earlier profiles.
+- `-search-with-buffer`: for column-graph no-document searches, use the reusable
+  `VectorIndexSearchBuffer` API instead of response-owned results.
 - `-validate-queries N` and `-min-recall R`: run recall validation for `N`
   queries; set `-min-recall=0` when disabling validation with
   `-validate-queries=0`.

--- a/cmd/treedb_vector_search_demo/main.go
+++ b/cmd/treedb_vector_search_demo/main.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"runtime/pprof"
 	"sort"
 	"strconv"
 	"strings"
@@ -69,6 +70,8 @@ type config struct {
 	requireValueLogBytes  bool
 	requireLeafVLogBytes  bool
 	jsonOut               bool
+	searchCPUProfileDir   string
+	searchWithBuffer      bool
 
 	indexOuterLeavesInValueLog *bool
 	vectorIndexStrategy        collections.VectorIndexStrategy
@@ -99,6 +102,8 @@ type result struct {
 	Compact               bool                              `json:"compact"`
 	CompactSyncEachPhase  bool                              `json:"compact_sync_each_phase"`
 	DisableExactFallback  bool                              `json:"disable_exact_fallback"`
+	SearchWithBuffer      bool                              `json:"search_with_buffer"`
+	SearchCPUProfileDir   string                            `json:"search_cpu_profile_dir,omitempty"`
 	Insert                phaseResult                       `json:"insert"`
 	Rebuild               phaseResult                       `json:"rebuild"`
 	CompactPhase          phaseResult                       `json:"compact_phase"`
@@ -122,15 +127,17 @@ type result struct {
 }
 
 type matrixResult struct {
-	Dir               string             `json:"dir"`
-	KeptDir           bool               `json:"kept_dir"`
-	Profile           string             `json:"profile"`
-	Docs              int                `json:"docs"`
-	Dimensions        int                `json:"dimensions"`
-	Queries           int                `json:"queries"`
-	SearchConcurrency []int              `json:"search_concurrency"`
-	TopK              int                `json:"top_k"`
-	Cases             []matrixCaseResult `json:"cases"`
+	Dir                 string             `json:"dir"`
+	KeptDir             bool               `json:"kept_dir"`
+	Profile             string             `json:"profile"`
+	Docs                int                `json:"docs"`
+	Dimensions          int                `json:"dimensions"`
+	Queries             int                `json:"queries"`
+	SearchConcurrency   []int              `json:"search_concurrency"`
+	TopK                int                `json:"top_k"`
+	SearchWithBuffer    bool               `json:"search_with_buffer"`
+	SearchCPUProfileDir string             `json:"search_cpu_profile_dir,omitempty"`
+	Cases               []matrixCaseResult `json:"cases"`
 }
 
 type matrixCaseResult struct {
@@ -314,6 +321,8 @@ func parseConfig(args []string) (config, error) {
 	fs.BoolVar(&cfg.disableExactFallback, "disable-exact-fallback", cfg.disableExactFallback, "Disable exact fallback during ANN benchmark queries")
 	fs.BoolVar(&cfg.requireValueLogBytes, "require-value-log-bytes", false, "Fail if compacted storage has no value-log bytes")
 	fs.BoolVar(&cfg.requireLeafVLogBytes, "require-leaf-vlog-bytes", false, "Fail if compacted storage has no leaf value-log bytes")
+	fs.StringVar(&cfg.searchCPUProfileDir, "search-cpu-profile-dir", "", "Optional directory for search-only CPU profiles, one per backend/concurrency")
+	fs.BoolVar(&cfg.searchWithBuffer, "search-with-buffer", false, "Use VectorIndexSearcher.SearchWithBuffer for no-document column_graph search benchmarks")
 	fs.BoolVar(&cfg.jsonOut, "json", false, "Emit JSON instead of text")
 	if err := fs.Parse(args); err != nil {
 		return config{}, err
@@ -668,6 +677,8 @@ func execute(ctx context.Context, cfg config) (result, error) {
 		Compact:               cfg.compact,
 		CompactSyncEachPhase:  cfg.compactSyncEachPhase,
 		DisableExactFallback:  cfg.disableExactFallback,
+		SearchWithBuffer:      cfg.searchWithBuffer,
+		SearchCPUProfileDir:   cfg.searchCPUProfileDir,
 	}
 
 	if def.Strategy == collections.VectorIndexStrategyColumnGraph {
@@ -1025,15 +1036,17 @@ func executeMatrix(ctx context.Context, cfg config) (matrixResult, error) {
 		},
 	}
 	out := matrixResult{
-		Dir:               root,
-		KeptDir:           cfg.keepDir || explicitRoot,
-		Profile:           string(cfg.profile),
-		Docs:              cfg.docs,
-		Dimensions:        cfg.dimensions,
-		Queries:           cfg.queries,
-		SearchConcurrency: append([]int(nil), cfg.searchConcurrency...),
-		TopK:              cfg.topK,
-		Cases:             make([]matrixCaseResult, 0, len(cases)),
+		Dir:                 root,
+		KeptDir:             cfg.keepDir || explicitRoot,
+		Profile:             string(cfg.profile),
+		Docs:                cfg.docs,
+		Dimensions:          cfg.dimensions,
+		Queries:             cfg.queries,
+		SearchConcurrency:   append([]int(nil), cfg.searchConcurrency...),
+		TopK:                cfg.topK,
+		SearchWithBuffer:    cfg.searchWithBuffer,
+		SearchCPUProfileDir: cfg.searchCPUProfileDir,
+		Cases:               make([]matrixCaseResult, 0, len(cases)),
 	}
 	for _, testCase := range cases {
 		caseCfg := cfg
@@ -1499,6 +1512,42 @@ func datasetDocuments(docIndexes []int, work workload, visit func(docIndex int, 
 	return fmt.Errorf("dataset document %d not found", missing[0])
 }
 
+func startSearchCPUProfile(cfg config, backend string, concurrency int) (func(), error) {
+	if cfg.searchCPUProfileDir == "" {
+		return func() {}, nil
+	}
+	if err := os.MkdirAll(cfg.searchCPUProfileDir, 0o755); err != nil {
+		return nil, err
+	}
+	f, err := createSearchCPUProfileFile(cfg.searchCPUProfileDir, backend, concurrency)
+	if err != nil {
+		return nil, err
+	}
+	if err := pprof.StartCPUProfile(f); err != nil {
+		_ = f.Close()
+		return nil, err
+	}
+	return func() {
+		pprof.StopCPUProfile()
+		_ = f.Close()
+	}, nil
+}
+
+func createSearchCPUProfileFile(dir, backend string, concurrency int) (*os.File, error) {
+	stem := fmt.Sprintf("cpu_%s_concurrency_%d", backend, concurrency)
+	for i := 0; ; i++ {
+		name := stem + ".pprof"
+		if i > 0 {
+			name = fmt.Sprintf("%s_%d.pprof", stem, i+1)
+		}
+		f, err := os.OpenFile(filepath.Join(dir, name), os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
+		if errors.Is(err, os.ErrExist) {
+			continue
+		}
+		return f, err
+	}
+}
+
 func benchmarkSearch(idx *collections.VectorIndex, cfg config, work workload) (searchBenchmarkResult, error) {
 	return benchmarkSearchConcurrent(idx, cfg, work, 1)
 }
@@ -1537,6 +1586,11 @@ func benchmarkSearchLoadedConcurrent(idx *collections.VectorIndex, cfg config, q
 	if concurrency <= 0 {
 		return searchBenchmarkResult{}, errors.New("search concurrency must be positive")
 	}
+	stopProfile, err := startSearchCPUProfile(cfg, resultBackendForStrategy(cfg.vectorIndexStrategy), concurrency)
+	if err != nil {
+		return searchBenchmarkResult{}, err
+	}
+	defer stopProfile()
 	latencies := make([]int64, len(queries))
 	var next atomic.Int64
 	var candidatesTotal int64
@@ -1647,6 +1701,11 @@ func benchmarkColumnGraphSearchLoadedConcurrent(col *collections.Collection, ind
 	if concurrency <= 0 {
 		return searchBenchmarkResult{}, errors.New("search concurrency must be positive")
 	}
+	stopProfile, err := startSearchCPUProfile(cfg, resultBackendForStrategy(cfg.vectorIndexStrategy), concurrency)
+	if err != nil {
+		return searchBenchmarkResult{}, err
+	}
+	defer stopProfile()
 	searchers := make([]*collections.VectorIndexSearcher, concurrency)
 	for i := range searchers {
 		searcher, err := col.OpenVectorIndexSearcher(collections.VectorIndexSearcherOptions{IndexName: indexName})
@@ -1677,17 +1736,25 @@ func benchmarkColumnGraphSearchLoadedConcurrent(col *collections.Collection, ind
 		}
 	}
 	worker := func(searcher *collections.VectorIndexSearcher) {
+		var buffer collections.VectorIndexSearchBuffer
 		for {
 			i := int(next.Add(1) - 1)
 			if i >= len(queries) {
 				return
 			}
 			start := time.Now()
-			response, err := searcher.Search(collections.VectorIndexSearcherSearchOptions{
+			opts := collections.VectorIndexSearcherSearchOptions{
 				Query:    queries[i],
 				TopK:     cfg.topK,
 				EfSearch: cfg.efSearch,
-			})
+			}
+			var response collections.VectorIndexSearchResponse
+			var err error
+			if cfg.searchWithBuffer {
+				response, err = searcher.SearchWithBuffer(opts, &buffer)
+			} else {
+				response, err = searcher.Search(opts)
+			}
 			if err != nil {
 				setErr(err)
 				return
@@ -2007,8 +2074,8 @@ func percentile(sorted []int64, p float64) int64 {
 
 func printText(w io.Writer, res result) {
 	fmt.Fprintf(w, "TreeDB vector search demo\n")
-	fmt.Fprintf(w, "dir=%s kept=%t profile=%s backend=%s vector_index_strategy=%s vector_index_search_path=%s docs=%d dims=%d queries=%d top_k=%d m=%d ef_construction=%d ef_search=%d value_pointer_threshold=%d leaf_generation_segment_target=%d\n",
-		res.Dir, res.KeptDir, res.Profile, resultBackend(res), resultStrategy(res), resultSearchPath(res), res.Docs, res.Dimensions, res.Queries, res.TopK, res.M, res.EfConstruction, res.EfSearch, res.ValuePointerThreshold, res.LeafGenerationTarget)
+	fmt.Fprintf(w, "dir=%s kept=%t profile=%s backend=%s vector_index_strategy=%s vector_index_search_path=%s docs=%d dims=%d queries=%d top_k=%d m=%d ef_construction=%d ef_search=%d value_pointer_threshold=%d leaf_generation_segment_target=%d search_with_buffer=%t search_cpu_profile_dir=%s\n",
+		res.Dir, res.KeptDir, res.Profile, resultBackend(res), resultStrategy(res), resultSearchPath(res), res.Docs, res.Dimensions, res.Queries, res.TopK, res.M, res.EfConstruction, res.EfSearch, res.ValuePointerThreshold, res.LeafGenerationTarget, res.SearchWithBuffer, res.SearchCPUProfileDir)
 	fmt.Fprintf(w, "\nPhases\n")
 	fmt.Fprintf(w, "insert: %.3fs\n", res.Insert.Seconds)
 	fmt.Fprintf(w, "rebuild_vector_index strategy=%s: %.3fs native_root_bytes=%d\n", resultStrategy(res), res.Rebuild.Seconds, res.NativeRootBytes)
@@ -2068,8 +2135,8 @@ func printText(w io.Writer, res result) {
 
 func printMatrixText(w io.Writer, res matrixResult) {
 	fmt.Fprintf(w, "TreeDB vector search matrix\n")
-	fmt.Fprintf(w, "dir=%s kept=%t profile=%s docs=%d dims=%d queries=%d top_k=%d search_concurrency=%s\n",
-		res.Dir, res.KeptDir, res.Profile, res.Docs, res.Dimensions, res.Queries, res.TopK, joinInts(res.SearchConcurrency))
+	fmt.Fprintf(w, "dir=%s kept=%t profile=%s docs=%d dims=%d queries=%d top_k=%d search_concurrency=%s search_with_buffer=%t search_cpu_profile_dir=%s\n",
+		res.Dir, res.KeptDir, res.Profile, res.Docs, res.Dimensions, res.Queries, res.TopK, joinInts(res.SearchConcurrency), res.SearchWithBuffer, res.SearchCPUProfileDir)
 	for _, testCase := range res.Cases {
 		fmt.Fprintf(w, "\nCase %s\n", testCase.Name)
 		fmt.Fprintf(w, "%s\n", testCase.Description)

--- a/cmd/treedb_vector_search_demo/main_test.go
+++ b/cmd/treedb_vector_search_demo/main_test.go
@@ -403,6 +403,19 @@ func TestParseConfigValuePointerThreshold(t *testing.T) {
 	}
 }
 
+func TestParseConfigSearchProfilingFlags(t *testing.T) {
+	cfg, err := parseConfig([]string{"-search-cpu-profile-dir", "/tmp/search-profiles", "-search-with-buffer"})
+	if err != nil {
+		t.Fatalf("parseConfig: %v", err)
+	}
+	if cfg.searchCPUProfileDir != "/tmp/search-profiles" {
+		t.Fatalf("search CPU profile dir=%q want /tmp/search-profiles", cfg.searchCPUProfileDir)
+	}
+	if !cfg.searchWithBuffer {
+		t.Fatal("searchWithBuffer=false want true")
+	}
+}
+
 func TestParseConfigLeafGenerationSegmentTarget(t *testing.T) {
 	cfg, err := parseConfig([]string{"-leaf-generation-segment-target", "8388608"})
 	if err != nil {

--- a/scripts/bench_vector_db_compare.sh
+++ b/scripts/bench_vector_db_compare.sh
@@ -18,6 +18,8 @@ M="${M:-16}"
 EF_CONSTRUCTION="${EF_CONSTRUCTION:-128}"
 EF_SEARCH="${EF_SEARCH:-128}"
 TREEDB_COLUMN_GRAPH_EF_SEARCH="${TREEDB_COLUMN_GRAPH_EF_SEARCH:-}"
+TREEDB_SEARCH_CPU_PROFILE_DIR="${TREEDB_SEARCH_CPU_PROFILE_DIR:-}"
+TREEDB_SEARCH_WITH_BUFFER="${TREEDB_SEARCH_WITH_BUFFER:-false}"
 MIN_RECALL="${MIN_RECALL:-0.95}"
 NUMPY_PACKAGE="${NUMPY_PACKAGE:-numpy==2.0.2}"
 VECTORLITE_PACKAGE="${VECTORLITE_PACKAGE:-vectorlite-py==0.2.0}"
@@ -159,6 +161,8 @@ cat >"$RUN_DIR/README.md" <<EOF
 - concurrency: \`$SEARCH_CONCURRENCY\`
 - M / efConstruction / efSearch: \`$M / $EF_CONSTRUCTION / $EF_SEARCH\`
 - TreeDB column_graph efSearch: \`$TREEDB_COLUMN_GRAPH_EF_SEARCH\`
+- TreeDB search CPU profile dir: \`$TREEDB_SEARCH_CPU_PROFILE_DIR\`
+- TreeDB column_graph SearchWithBuffer: \`$TREEDB_SEARCH_WITH_BUFFER\`
 - Python packages: \`$NUMPY_PACKAGE\`, \`$VECTORLITE_PACKAGE\`
 
 This run compares persistent database-tier ANN search:
@@ -210,46 +214,59 @@ result_args=()
 
 if contains_backend treedb; then
 	echo "running TreeDB benchmark"
-	GOWORK=off go run ./cmd/treedb_vector_search_demo \
-		-matrix=false \
-		-dataset-dir "$RUN_DIR/dataset" \
-		-dir "$RUN_DIR/treedb" \
-		-keep-dir \
-		-docs "$DOCS" \
-		-dims "$DIMS" \
-		-queries "$QUERIES" \
-		-search-concurrency "$SEARCH_CONCURRENCY" \
-		-validate-queries "$VALIDATE_QUERIES" \
-		-validate-docs 16 \
-		-top-k "$TOP_K" \
-		-m "$M" \
-		-ef-construction "$EF_CONSTRUCTION" \
-		-ef-search "$EF_SEARCH" \
-		-min-recall "$MIN_RECALL" \
-		-json >"$RUN_DIR/treedb.json"
+	treedb_args=(
+		-matrix=false
+		-dataset-dir "$RUN_DIR/dataset"
+		-dir "$RUN_DIR/treedb"
+		-keep-dir
+		-docs "$DOCS"
+		-dims "$DIMS"
+		-queries "$QUERIES"
+		-search-concurrency "$SEARCH_CONCURRENCY"
+		-validate-queries "$VALIDATE_QUERIES"
+		-validate-docs 16
+		-top-k "$TOP_K"
+		-m "$M"
+		-ef-construction "$EF_CONSTRUCTION"
+		-ef-search "$EF_SEARCH"
+		-min-recall "$MIN_RECALL"
+		-json
+	)
+	if [[ -n "$TREEDB_SEARCH_CPU_PROFILE_DIR" ]]; then
+		treedb_args+=(-search-cpu-profile-dir "$TREEDB_SEARCH_CPU_PROFILE_DIR/treedb")
+	fi
+	GOWORK=off go run ./cmd/treedb_vector_search_demo "${treedb_args[@]}" >"$RUN_DIR/treedb.json"
 	result_args+=(--result "$RUN_DIR/treedb.json")
 fi
 
 if contains_backend treedb_column_graph; then
 	echo "running TreeDB column-store graph benchmark"
-	GOWORK=off go run ./cmd/treedb_vector_search_demo \
-		-matrix=false \
-		-vector-index-strategy column_graph \
-		-dataset-dir "$RUN_DIR/dataset" \
-		-dir "$RUN_DIR/treedb_column_graph" \
-		-keep-dir \
-		-docs "$DOCS" \
-		-dims "$DIMS" \
-		-queries "$QUERIES" \
-		-search-concurrency "$SEARCH_CONCURRENCY" \
-		-validate-queries "$VALIDATE_QUERIES" \
-		-validate-docs 16 \
-		-top-k "$TOP_K" \
-		-m "$M" \
-		-ef-construction "$EF_CONSTRUCTION" \
-		-ef-search "$TREEDB_COLUMN_GRAPH_EF_SEARCH" \
-		-min-recall "$MIN_RECALL" \
-		-json >"$RUN_DIR/treedb_column_graph.json"
+	treedb_column_graph_args=(
+		-matrix=false
+		-vector-index-strategy column_graph
+		-dataset-dir "$RUN_DIR/dataset"
+		-dir "$RUN_DIR/treedb_column_graph"
+		-keep-dir
+		-docs "$DOCS"
+		-dims "$DIMS"
+		-queries "$QUERIES"
+		-search-concurrency "$SEARCH_CONCURRENCY"
+		-validate-queries "$VALIDATE_QUERIES"
+		-validate-docs 16
+		-top-k "$TOP_K"
+		-m "$M"
+		-ef-construction "$EF_CONSTRUCTION"
+		-ef-search "$TREEDB_COLUMN_GRAPH_EF_SEARCH"
+		-min-recall "$MIN_RECALL"
+		-json
+	)
+	if [[ -n "$TREEDB_SEARCH_CPU_PROFILE_DIR" ]]; then
+		treedb_column_graph_args+=(-search-cpu-profile-dir "$TREEDB_SEARCH_CPU_PROFILE_DIR/treedb_column_graph")
+	fi
+	if [[ "$TREEDB_SEARCH_WITH_BUFFER" == "true" ]]; then
+		treedb_column_graph_args+=(-search-with-buffer)
+	fi
+	GOWORK=off go run ./cmd/treedb_vector_search_demo "${treedb_column_graph_args[@]}" >"$RUN_DIR/treedb_column_graph.json"
 	result_args+=(--result "$RUN_DIR/treedb_column_graph.json")
 fi
 


### PR DESCRIPTION
## Objective

Add benchmark-harness knobs for the next TreeDB vector-search profiling round:

- emit search-only Go CPU profiles from `treedb_vector_search_demo`;
- optionally run column-graph no-document search through `SearchWithBuffer` so profiling can separate retrieval/scoring work from response-owned result allocation;
- expose both knobs through `scripts/bench_vector_db_compare.sh` and document them.

## Why

The next vector-search investigation needs small/large TreeDB-vs-pgvector runs with correctness/recall validation and profiles focused on the steady search phase, not insert/rebuild/reopen/validation setup. This PR keeps that harness support separate from any actual search-path optimization.

## Changes

- Adds `-search-cpu-profile-dir PATH` to `cmd/treedb_vector_search_demo`.
  - Profiles are scoped around each search benchmark concurrency lane.
  - Repeated backend/concurrency labels get numeric suffixes instead of overwriting.
- Adds `-search-with-buffer` for column-graph no-document search benchmarks.
  - Uses `VectorIndexSearcher.SearchWithBuffer` per worker with a worker-local buffer.
  - JSON/text output records `search_with_buffer` and `search_cpu_profile_dir`.
- Adds vector-compare script env knobs:
  - `TREEDB_SEARCH_CPU_PROFILE_DIR`
  - `TREEDB_SEARCH_WITH_BUFFER=true`
- Updates docs for both the command and comparison harness.

## Non-goals

- No search algorithm/topology change.
- No default benchmark mode change.
- No public API change; this only consumes the existing reusable-buffer search API.
- No claim of an optimization win from this PR itself.

## Validation

```sh
GOWORK=off go test ./cmd/treedb_vector_search_demo -count=1
bash -n scripts/bench_vector_db_compare.sh
```

Smoke run with both new knobs:

```sh
SMOKE=/tmp/treedb_vector_search_profile_flag_smoke_20260602_143820
GOWORK=off go run ./cmd/treedb_vector_search_demo \
  -matrix=false \
  -vector-index-strategy column_graph \
  -dir "$SMOKE/db" \
  -keep-dir \
  -docs 64 \
  -dims 8 \
  -queries 4 \
  -search-concurrency 2 \
  -validate-queries 1 \
  -validate-docs 1 \
  -top-k 3 \
  -m 4 \
  -ef-construction 16 \
  -ef-search 16 \
  -min-recall 0 \
  -search-with-buffer \
  -search-cpu-profile-dir "$SMOKE/profiles" \
  -json > "$SMOKE/result.json"
```

Confirmed JSON records the knobs and profiles are emitted:

- `/tmp/treedb_vector_search_profile_flag_smoke_20260602_143820/profiles/cpu_treedb_column_graph_concurrency_1.pprof`
- `/tmp/treedb_vector_search_profile_flag_smoke_20260602_143820/profiles/cpu_treedb_column_graph_concurrency_2.pprof`

## Related profiling artifacts from this investigation

These are context/evidence for why the harness knobs are useful, not acceptance criteria for this PR:

- Small TreeDB column-graph vs pgvector run: `/tmp/vector_compare_small_20260602_140006`
- Large TreeDB column-graph vs pgvector run: `/tmp/vector_compare_large_20260602_140452`
- Large TreeDB search-only profile, response-owned results: `/tmp/vector_large_search_profile_20260602_142810`
- Large TreeDB search-only profile, reusable buffer: `/tmp/vector_large_search_profile_buffer_20260602_143145`

Initial read from those artifacts: the reusable-buffer path materially reduces measured TreeDB column-graph no-document search latency in the large harness, and the large comparison also exposes recall differences that need follow-up tuning/profiling. This PR only makes those measurements easy and repeatable.
