### PR TITLE
Add fail-closed quantized vector query modes

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -864,16 +864,27 @@ type IndexDefinition struct {
 // collection index. PRs after the metadata/API step persist and maintain the
 // HNSW graph through collection index roots.
 type VectorIndexDefinition struct {
-	Name             string              `json:"name"`
-	Field            string              `json:"field"`
-	Metric           VectorMetric        `json:"metric"`
-	Dimensions       int                 `json:"dimensions"`
-	M                int                 `json:"m,omitempty"`
-	EfConstruction   int                 `json:"ef_construction,omitempty"`
-	EfSearch         int                 `json:"ef_search,omitempty"`
-	Encoding         VectorIndexEncoding `json:"encoding,omitempty"`
-	Strategy         VectorIndexStrategy `json:"strategy,omitempty"`
-	SchemaGeneration uint64              `json:"schema_generation,omitempty"`
+	Name             string                           `json:"name"`
+	Field            string                           `json:"field"`
+	Metric           VectorMetric                     `json:"metric"`
+	Dimensions       int                              `json:"dimensions"`
+	M                int                              `json:"m,omitempty"`
+	EfConstruction   int                              `json:"ef_construction,omitempty"`
+	EfSearch         int                              `json:"ef_search,omitempty"`
+	Encoding         VectorIndexEncoding              `json:"encoding,omitempty"`
+	Strategy         VectorIndexStrategy              `json:"strategy,omitempty"`
+	SchemaGeneration uint64                           `json:"schema_generation,omitempty"`
+	QuantizedIndexes []QuantizedVectorIndexDefinition `json:"quantized_indexes,omitempty"`
+}
+
+// QuantizedVectorIndexDefinition declares a named derived score plane attached
+// to a column_graph vector index. Query modes must still select these indexes
+// explicitly, and search must fail closed until matching prepared assets are
+// loaded and scored.
+type QuantizedVectorIndexDefinition struct {
+	Name    string `json:"name"`
+	Codec   string `json:"codec"`
+	Version uint32 `json:"version,omitempty"`
 }
 
 type CollectionMeta struct {
@@ -20155,6 +20166,14 @@ func normalizeVectorIndexDefinition(def VectorIndexDefinition) (VectorIndexDefin
 	def.Metric = metric
 	def.Encoding = encoding
 	def.Strategy = strategy
+	quantized, err := normalizeQuantizedVectorIndexDefinitions(def)
+	if err != nil {
+		return VectorIndexDefinition{}, err
+	}
+	def.QuantizedIndexes = quantized
+	if len(def.QuantizedIndexes) > 0 && def.Strategy != VectorIndexStrategyColumnGraph {
+		return VectorIndexDefinition{}, fmt.Errorf("collections: quantized vector indexes require strategy %q", VectorIndexStrategyColumnGraph)
+	}
 	if def.Strategy == VectorIndexStrategyColumnGraph {
 		if def.Metric != VectorMetricCosine {
 			return VectorIndexDefinition{}, fmt.Errorf("collections: column_graph vector index %q supports only metric %q", def.Name, VectorMetricCosine)
@@ -20198,13 +20217,67 @@ func normalizeVectorIndexStrategy(strategy VectorIndexStrategy) (VectorIndexStra
 	}
 }
 
+const QuantizedVectorCodecScalarU8 = "scalar_u8"
+
+func normalizeQuantizedVectorIndexDefinitions(def VectorIndexDefinition) ([]QuantizedVectorIndexDefinition, error) {
+	if len(def.QuantizedIndexes) == 0 {
+		return nil, nil
+	}
+	out := make([]QuantizedVectorIndexDefinition, len(def.QuantizedIndexes))
+	seen := make(map[string]struct{}, len(def.QuantizedIndexes))
+	for i, q := range def.QuantizedIndexes {
+		if q.Name == "" {
+			return nil, fmt.Errorf("collections: vector index %q quantized index[%d] name is required", def.Name, i)
+		}
+		if err := ValidateIndexName(q.Name); err != nil {
+			return nil, fmt.Errorf("collections: vector index %q quantized index[%d] name: %w", def.Name, i, err)
+		}
+		if _, ok := seen[q.Name]; ok {
+			return nil, fmt.Errorf("collections: vector index %q duplicate quantized index %q", def.Name, q.Name)
+		}
+		seen[q.Name] = struct{}{}
+		switch q.Codec {
+		case "":
+			q.Codec = QuantizedVectorCodecScalarU8
+		case QuantizedVectorCodecScalarU8:
+		default:
+			return nil, fmt.Errorf("collections: vector index %q quantized index %q codec %q is unsupported", def.Name, q.Name, q.Codec)
+		}
+		if q.Version == 0 {
+			q.Version = 1
+		}
+		if q.Version != 1 {
+			return nil, fmt.Errorf("collections: vector index %q quantized index %q scalar_u8 version=%d is unsupported", def.Name, q.Name, q.Version)
+		}
+		out[i] = q
+	}
+	return out, nil
+}
+
+func findQuantizedVectorIndex(def VectorIndexDefinition, name string) (QuantizedVectorIndexDefinition, bool) {
+	for _, q := range def.QuantizedIndexes {
+		if q.Name == name {
+			return q, true
+		}
+	}
+	return QuantizedVectorIndexDefinition{}, false
+}
+
 func (m CollectionMeta) copy() *CollectionMeta {
 	return &CollectionMeta{
 		Name:          m.Name,
 		Options:       copyCollectionOptions(m.Options),
 		Indexes:       append([]IndexDefinition(nil), m.Indexes...),
-		VectorIndexes: append([]VectorIndexDefinition(nil), m.VectorIndexes...),
+		VectorIndexes: copyVectorIndexDefinitions(m.VectorIndexes),
 	}
+}
+
+func copyVectorIndexDefinitions(in []VectorIndexDefinition) []VectorIndexDefinition {
+	out := append([]VectorIndexDefinition(nil), in...)
+	for i := range out {
+		out[i].QuantizedIndexes = append([]QuantizedVectorIndexDefinition(nil), out[i].QuantizedIndexes...)
+	}
+	return out
 }
 
 func copyCollectionMeta(meta CollectionMeta) CollectionMeta {
@@ -20242,7 +20315,29 @@ func collectionMetaValuesEqual(a, b CollectionMeta) bool {
 		}
 	}
 	for i := range a.VectorIndexes {
-		if a.VectorIndexes[i] != b.VectorIndexes[i] {
+		if !vectorIndexDefinitionValuesEqual(a.VectorIndexes[i], b.VectorIndexes[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func vectorIndexDefinitionValuesEqual(a, b VectorIndexDefinition) bool {
+	if a.Name != b.Name ||
+		a.Field != b.Field ||
+		a.Metric != b.Metric ||
+		a.Dimensions != b.Dimensions ||
+		a.M != b.M ||
+		a.EfConstruction != b.EfConstruction ||
+		a.EfSearch != b.EfSearch ||
+		a.Encoding != b.Encoding ||
+		a.Strategy != b.Strategy ||
+		a.SchemaGeneration != b.SchemaGeneration ||
+		len(a.QuantizedIndexes) != len(b.QuantizedIndexes) {
+		return false
+	}
+	for i := range a.QuantizedIndexes {
+		if a.QuantizedIndexes[i] != b.QuantizedIndexes[i] {
 			return false
 		}
 	}

--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -34,6 +34,8 @@ var (
 	errColumnVectorGraphNativeSearchWavefrontWidthInvalid      = errors.New("collections: column_graph native search wavefront width invalid")
 	errColumnVectorGraphNativeSearchWavefrontRequiresPrepared  = errors.New("collections: column_graph native search wavefront requires prepared typed-column graph search")
 	errColumnVectorGraphNativeSearchWavefrontWidthWithoutMode  = errors.New("collections: column_graph native search wavefront width requires wavefront traversal mode")
+	errColumnVectorGraphNativeSearchQueryModeInvalid           = errors.New("collections: column_graph native search query mode invalid")
+	errColumnVectorGraphNativeSearchQuantizedRerankLimit       = errors.New("collections: column_graph quantized rerank candidate limit invalid")
 )
 
 type columnVectorGraphScoreBatchMode uint8
@@ -41,6 +43,8 @@ type columnVectorGraphScoreBatchMode uint8
 type columnVectorGraphNativeSearchTraversalMode uint8
 
 type columnVectorGraphNativeSearchStatsMode uint8
+
+type columnVectorGraphNativeSearchQueryMode uint8
 
 const (
 	columnVectorGraphScoreBatchModeDefault columnVectorGraphScoreBatchMode = iota
@@ -59,6 +63,12 @@ const (
 	columnVectorGraphNativeSearchStatsModeMinimal
 	columnVectorGraphNativeSearchStatsModeFullDiagnostics
 	columnVectorGraphNativeSearchStatsModeBenchmarkDebug
+)
+
+const (
+	columnVectorGraphNativeSearchQueryModeExact columnVectorGraphNativeSearchQueryMode = iota
+	columnVectorGraphNativeSearchQueryModeQuantizedOnly
+	columnVectorGraphNativeSearchQueryModeQuantizedRerank
 )
 
 func (m columnVectorGraphScoreBatchMode) indexedEnabled() bool {
@@ -165,11 +175,46 @@ func (m columnVectorGraphNativeSearchStatsMode) String() string {
 	}
 }
 
+func (m columnVectorGraphNativeSearchQueryMode) normalized() (columnVectorGraphNativeSearchQueryMode, error) {
+	switch m {
+	case columnVectorGraphNativeSearchQueryModeExact:
+		return columnVectorGraphNativeSearchQueryModeExact, nil
+	case columnVectorGraphNativeSearchQueryModeQuantizedOnly:
+		return columnVectorGraphNativeSearchQueryModeQuantizedOnly, nil
+	case columnVectorGraphNativeSearchQueryModeQuantizedRerank:
+		return columnVectorGraphNativeSearchQueryModeQuantizedRerank, nil
+	default:
+		return columnVectorGraphNativeSearchQueryModeExact, errColumnVectorGraphNativeSearchQueryModeInvalid
+	}
+}
+
+func (m columnVectorGraphNativeSearchQueryMode) quantized() bool {
+	return m == columnVectorGraphNativeSearchQueryModeQuantizedOnly || m == columnVectorGraphNativeSearchQueryModeQuantizedRerank
+}
+
+func (m columnVectorGraphNativeSearchQueryMode) String() string {
+	switch m {
+	case columnVectorGraphNativeSearchQueryModeQuantizedOnly:
+		return "quantized_only"
+	case columnVectorGraphNativeSearchQueryModeQuantizedRerank:
+		return "quantized_rerank"
+	default:
+		return "exact"
+	}
+}
+
 type columnVectorGraphNativeSearchOptions struct {
 	TopK     int
 	EfSearch int
 
 	ScoreBatchMode columnVectorGraphScoreBatchMode
+	QueryMode      columnVectorGraphNativeSearchQueryMode
+	// QuantizedIndexName selects a named derived score plane for quantized query
+	// modes. Exact mode must leave it empty.
+	QuantizedIndexName string
+	// QuantizedRerankCandidates bounds the candidate set exact-reranked after
+	// quantized traversal. Zero means TopK.
+	QuantizedRerankCandidates int
 	// TraversalMode selects the layer-0 traversal scheduler. The default and
 	// explicit exact modes preserve current HNSW candidate order. Wavefront is an
 	// internal, non-default relaxed traversal experiment that stages candidates
@@ -195,6 +240,36 @@ type columnVectorGraphNativeSearchOptions struct {
 	// visibility masks through typedcolumn.ComposeRowSelections first.
 	CandidateRows    typedcolumn.RowSelection
 	HasCandidateRows bool
+}
+
+func (r *columnVectorGraphPhysicalRowReader) validateQuantizedNativeSearchOptions(mode columnVectorGraphNativeSearchQueryMode, opts columnVectorGraphNativeSearchOptions) error {
+	if mode == columnVectorGraphNativeSearchQueryModeExact {
+		if opts.QuantizedIndexName != "" {
+			return errors.New("collections: exact column_graph search cannot select a quantized index")
+		}
+		if opts.QuantizedRerankCandidates != 0 {
+			return errors.New("collections: exact column_graph search cannot set quantized rerank candidates")
+		}
+		return nil
+	}
+	if opts.QuantizedIndexName == "" {
+		return errors.New("collections: column_graph quantized search requires a quantized index name")
+	}
+	if _, ok := findQuantizedVectorIndex(r.def, opts.QuantizedIndexName); !ok {
+		return fmt.Errorf("%w: column_graph %q quantized index %q is not declared", ErrVectorIndexSearchUnavailable, r.def.Name, opts.QuantizedIndexName)
+	}
+	if mode == columnVectorGraphNativeSearchQueryModeQuantizedOnly && opts.QuantizedRerankCandidates != 0 {
+		return errors.New("collections: column_graph quantized_only search cannot set rerank candidates")
+	}
+	if mode == columnVectorGraphNativeSearchQueryModeQuantizedRerank {
+		if opts.QuantizedRerankCandidates < 0 {
+			return errColumnVectorGraphNativeSearchQuantizedRerankLimit
+		}
+		if opts.QuantizedRerankCandidates != 0 && opts.TopK > 0 && opts.QuantizedRerankCandidates < opts.TopK {
+			return errColumnVectorGraphNativeSearchQuantizedRerankLimit
+		}
+	}
+	return fmt.Errorf("%w: column_graph %q query_mode=%s quantized index %q has no loaded quantized score-plane asset", ErrVectorIndexSearchUnavailable, r.def.Name, mode.String(), opts.QuantizedIndexName)
 }
 
 type columnVectorGraphAdjacencySourceCounterSnapshot struct {
@@ -995,6 +1070,13 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 	}
 	if len(query) != r.def.Dimensions {
 		return nil, columnVectorGraphNativeSearchStats{}, fmt.Errorf("collections: column_graph %q query dims=%d want %d: %w", r.def.Name, len(query), r.def.Dimensions, errColumnVectorGraphNativeSearchQueryDimensionMismatch)
+	}
+	queryMode, err := opts.QueryMode.normalized()
+	if err != nil {
+		return nil, columnVectorGraphNativeSearchStats{}, fmt.Errorf("collections: column_graph %q native search query mode: %w", r.def.Name, err)
+	}
+	if err := r.validateQuantizedNativeSearchOptions(queryMode, opts); err != nil {
+		return nil, columnVectorGraphNativeSearchStats{}, err
 	}
 	rowCount := r.RowCount()
 	topK := opts.TopK

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -452,7 +452,7 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/vector_index_metadata_test.go", classification: typedStorageLegacyDerived, matchingLines: 9, occurrences: 11},
 	{path: "TreeDB/collections/vector_document_fetch_preset_1903_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 4, occurrences: 5},
 	{path: "TreeDB/collections/vector_index_retained_payload_policy_1876_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 5, occurrences: 5},
-	{path: "TreeDB/collections/vector_index_search_test.go", classification: typedStorageLegacyDerived, matchingLines: 2, occurrences: 2},
+	{path: "TreeDB/collections/vector_index_search_test.go", classification: typedStorageLegacyDerived, matchingLines: 3, occurrences: 4},
 	{path: "TreeDB/collections/vector_index_rebuild.go", classification: typedStorageLegacyDerived, matchingLines: 16, occurrences: 18},
 	{path: "TreeDB/collections/vector_index_rebuild_test.go", classification: typedStorageLegacyDerived, matchingLines: 46, occurrences: 54},
 	{path: "TreeDB/docs/guides/collections-quickstart.md", classification: typedStorageLegacyCompatibility, matchingLines: 18, occurrences: 22},

--- a/TreeDB/collections/vector_index.go
+++ b/TreeDB/collections/vector_index.go
@@ -155,19 +155,39 @@ type VectorIndexOptions struct {
 	schemaGeneration    uint64
 }
 
+// VectorIndexQueryMode selects the score plane used by column_graph search.
+// The zero value is exact to preserve existing search behavior. Quantized modes
+// must be selected explicitly with a named quantized index and fail closed until
+// matching assets and scorers are available.
+type VectorIndexQueryMode string
+
+const (
+	VectorIndexQueryModeExact           VectorIndexQueryMode = "exact"
+	VectorIndexQueryModeQuantizedOnly   VectorIndexQueryMode = "quantized_only"
+	VectorIndexQueryModeQuantizedRerank VectorIndexQueryMode = "quantized_rerank"
+)
+
 // VectorIndexSearchOptions configures one in-memory vector index search.
 type VectorIndexSearchOptions struct {
 	// IndexName is used by collection-level physical column_graph search.
 	IndexName string
 	// Query is used by collection-level physical column_graph search.
-	Query                []float32
-	TopK                 int
-	EfSearch             int
-	FetchMultiplier      int
-	Filter               func(DocumentRecord) (bool, error)
-	IndexRangeFilter     *VectorIndexRangeFilter
-	ExactFilterMaxDocs   int
-	DisableExactFallback bool
+	Query []float32
+	// QueryMode selects exact, quantized-only, or quantized-rerank search for
+	// collection column_graph APIs. The zero value is exact.
+	QueryMode VectorIndexQueryMode
+	// QuantizedIndexName selects the named derived score plane for quantized modes.
+	QuantizedIndexName string
+	// QuantizedRerankCandidates bounds the quantized candidate set reranked by
+	// exact float32 vectors in quantized_rerank mode. Zero uses TopK.
+	QuantizedRerankCandidates int
+	TopK                      int
+	EfSearch                  int
+	FetchMultiplier           int
+	Filter                    func(DocumentRecord) (bool, error)
+	IndexRangeFilter          *VectorIndexRangeFilter
+	ExactFilterMaxDocs        int
+	DisableExactFallback      bool
 	// IncludeDocuments materializes documents after column_graph top-k selection.
 	IncludeDocuments bool
 	// DocumentFetchOptions controls optional projected final-fetch materialization.
@@ -1403,6 +1423,13 @@ func (idx *VectorIndex) Search(query []float32, opts VectorIndexSearchOptions) (
 	if idx == nil {
 		return nil, trace, errors.New("collections: vector index is nil")
 	}
+	queryMode, err := normalizeVectorIndexSearchQueryMode(opts.QueryMode, opts.QuantizedIndexName, opts.QuantizedRerankCandidates, opts.TopK)
+	if err != nil {
+		return nil, trace, err
+	}
+	if queryMode != columnVectorGraphNativeSearchQueryModeExact {
+		return nil, trace, fmt.Errorf("%w: native_runtime vector index %q does not support quantized query mode %q", ErrVectorIndexSearchUnavailable, idx.name, opts.QueryMode)
+	}
 	if opts.TopK <= 0 {
 		return nil, trace, errors.New("collections: vector search TopK must be positive")
 	}
@@ -1507,7 +1534,6 @@ func (idx *VectorIndex) Search(query []float32, opts VectorIndexSearchOptions) (
 	var resultNodeIDs []int
 	var resultNodeIDStack [64]int
 	var candidateIDs [][]byte
-	var err error
 	if fastRerank {
 		rerankLimit := len(candidates)
 		resultNodeIDs = resultNodeIDStack[:0]

--- a/TreeDB/collections/vector_index_search.go
+++ b/TreeDB/collections/vector_index_search.go
@@ -69,6 +69,15 @@ type VectorIndexSearcherOptions struct {
 type VectorIndexSearcherSearchOptions struct {
 	// Query is the query vector. V4 column_graph search supports cosine indexes.
 	Query []float32
+	// QueryMode selects exact, quantized-only, or quantized-rerank search. The
+	// zero value is exact; quantized modes require QuantizedIndexName and fail
+	// closed until matching assets/scorers are available.
+	QueryMode VectorIndexQueryMode
+	// QuantizedIndexName selects the named derived score plane for quantized modes.
+	QuantizedIndexName string
+	// QuantizedRerankCandidates bounds the quantized candidate set reranked by
+	// exact float32 vectors in quantized_rerank mode. Zero uses TopK.
+	QuantizedRerankCandidates int
 	// TopK is the maximum number of nearest results to return.
 	TopK int
 	// EfSearch bounds graph exploration. Zero uses the persisted index default.
@@ -529,13 +538,16 @@ func (c *Collection) SearchVectorIndex(opts VectorIndexSearchOptions) (VectorInd
 		return response, err
 	}
 	response, err = searcher.Search(VectorIndexSearcherSearchOptions{
-		Query:                opts.Query,
-		TopK:                 opts.TopK,
-		EfSearch:             opts.EfSearch,
-		IncludeDocuments:     opts.IncludeDocuments,
-		DocumentFetchOptions: opts.DocumentFetchOptions,
-		StatsMode:            opts.StatsMode,
-		scoreBatchMode:       opts.scoreBatchMode,
+		Query:                     opts.Query,
+		QueryMode:                 opts.QueryMode,
+		QuantizedIndexName:        opts.QuantizedIndexName,
+		QuantizedRerankCandidates: opts.QuantizedRerankCandidates,
+		TopK:                      opts.TopK,
+		EfSearch:                  opts.EfSearch,
+		IncludeDocuments:          opts.IncludeDocuments,
+		DocumentFetchOptions:      opts.DocumentFetchOptions,
+		StatsMode:                 opts.StatsMode,
+		scoreBatchMode:            opts.scoreBatchMode,
 	})
 	documentView := searcher.documentView
 	if closeErr := searcher.Close(); err == nil && closeErr != nil {
@@ -706,12 +718,19 @@ func (s *VectorIndexSearcher) Search(opts VectorIndexSearcherSearchOptions) (Vec
 	if err != nil {
 		return response, err
 	}
+	queryMode, err := normalizeVectorIndexSearchQueryMode(opts.QueryMode, opts.QuantizedIndexName, opts.QuantizedRerankCandidates, opts.TopK)
+	if err != nil {
+		return response, err
+	}
 	readerStatsBefore := s.readerLast
 	results, searchStats, err := s.reader.SearchCosine(opts.Query, columnVectorGraphNativeSearchOptions{
-		TopK:           opts.TopK,
-		EfSearch:       opts.EfSearch,
-		ScoreBatchMode: opts.scoreBatchMode,
-		StatsMode:      statsMode,
+		TopK:                      opts.TopK,
+		EfSearch:                  opts.EfSearch,
+		ScoreBatchMode:            opts.scoreBatchMode,
+		StatsMode:                 statsMode,
+		QueryMode:                 queryMode,
+		QuantizedIndexName:        opts.QuantizedIndexName,
+		QuantizedRerankCandidates: opts.QuantizedRerankCandidates,
 	}, &s.scratch)
 	readerStatsAfter := s.reader.Stats()
 	s.readerLast = readerStatsAfter
@@ -863,12 +882,20 @@ func (s *VectorIndexSearcher) SearchWithBuffer(opts VectorIndexSearcherSearchOpt
 		clear(previousResults)
 		return response, err
 	}
+	queryMode, err := normalizeVectorIndexSearchQueryMode(opts.QueryMode, opts.QuantizedIndexName, opts.QuantizedRerankCandidates, opts.TopK)
+	if err != nil {
+		clear(previousResults)
+		return response, err
+	}
 	readerStatsBefore := s.readerLast
 	results, searchStats, err := s.reader.SearchCosine(opts.Query, columnVectorGraphNativeSearchOptions{
-		TopK:           opts.TopK,
-		EfSearch:       opts.EfSearch,
-		ScoreBatchMode: opts.scoreBatchMode,
-		StatsMode:      statsMode,
+		TopK:                      opts.TopK,
+		EfSearch:                  opts.EfSearch,
+		ScoreBatchMode:            opts.scoreBatchMode,
+		StatsMode:                 statsMode,
+		QueryMode:                 queryMode,
+		QuantizedIndexName:        opts.QuantizedIndexName,
+		QuantizedRerankCandidates: opts.QuantizedRerankCandidates,
 	}, &s.scratch)
 	readerStatsAfter := s.reader.Stats()
 	s.readerLast = readerStatsAfter
@@ -933,6 +960,50 @@ func validateVectorIndexSearchRequest(topK, efSearch int) error {
 	}
 	if efSearch < 0 {
 		return errors.New("collections: vector index search ef_search cannot be negative")
+	}
+	return nil
+}
+
+func normalizeVectorIndexSearchQueryMode(mode VectorIndexQueryMode, quantizedIndexName string, quantizedRerankCandidates, topK int) (columnVectorGraphNativeSearchQueryMode, error) {
+	switch mode {
+	case "", VectorIndexQueryModeExact:
+		if quantizedIndexName != "" {
+			return columnVectorGraphNativeSearchQueryModeExact, errors.New("collections: exact vector index search cannot select a quantized index")
+		}
+		if quantizedRerankCandidates != 0 {
+			return columnVectorGraphNativeSearchQueryModeExact, errors.New("collections: exact vector index search cannot set quantized rerank candidates")
+		}
+		return columnVectorGraphNativeSearchQueryModeExact, nil
+	case VectorIndexQueryModeQuantizedOnly:
+		if err := validateSelectedQuantizedVectorIndexName(quantizedIndexName); err != nil {
+			return columnVectorGraphNativeSearchQueryModeExact, err
+		}
+		if quantizedRerankCandidates != 0 {
+			return columnVectorGraphNativeSearchQueryModeExact, errors.New("collections: quantized_only vector index search cannot set quantized rerank candidates")
+		}
+		return columnVectorGraphNativeSearchQueryModeQuantizedOnly, nil
+	case VectorIndexQueryModeQuantizedRerank:
+		if err := validateSelectedQuantizedVectorIndexName(quantizedIndexName); err != nil {
+			return columnVectorGraphNativeSearchQueryModeExact, err
+		}
+		if quantizedRerankCandidates < 0 {
+			return columnVectorGraphNativeSearchQueryModeExact, errors.New("collections: quantized vector index rerank candidates cannot be negative")
+		}
+		if quantizedRerankCandidates != 0 && topK > 0 && quantizedRerankCandidates < topK {
+			return columnVectorGraphNativeSearchQueryModeExact, errors.New("collections: quantized vector index rerank candidates cannot be less than top_k")
+		}
+		return columnVectorGraphNativeSearchQueryModeQuantizedRerank, nil
+	default:
+		return columnVectorGraphNativeSearchQueryModeExact, fmt.Errorf("collections: vector index query mode %q is unsupported", mode)
+	}
+}
+
+func validateSelectedQuantizedVectorIndexName(name string) error {
+	if name == "" {
+		return errors.New("collections: quantized vector index name is required for quantized query mode")
+	}
+	if err := ValidateIndexName(name); err != nil {
+		return fmt.Errorf("collections: quantized vector index name: %w", err)
 	}
 	return nil
 }

--- a/TreeDB/collections/vector_index_search_test.go
+++ b/TreeDB/collections/vector_index_search_test.go
@@ -44,6 +44,272 @@ func TestVectorIndexSearchStatsModePublicMapping2126(t *testing.T) {
 	}
 }
 
+func TestVectorIndexQuantizedDefinitionNormalization1926(t *testing.T) {
+	def, err := normalizeVectorIndexDefinition(VectorIndexDefinition{
+		Name:       "embedding_graph",
+		Field:      "embedding",
+		Metric:     VectorMetricCosine,
+		Dimensions: 3,
+		Strategy:   VectorIndexStrategyColumnGraph,
+		QuantizedIndexes: []QuantizedVectorIndexDefinition{{
+			Name: "embedding.scalar_u8.fast",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("normalizeVectorIndexDefinition: %v", err)
+	}
+	if got := def.QuantizedIndexes; len(got) != 1 || got[0].Name != "embedding.scalar_u8.fast" || got[0].Codec != QuantizedVectorCodecScalarU8 || got[0].Version != 1 {
+		t.Fatalf("QuantizedIndexes=%+v want normalized scalar_u8 v1", got)
+	}
+	if _, ok := findQuantizedVectorIndex(def, "embedding.scalar_u8.fast"); !ok {
+		t.Fatalf("findQuantizedVectorIndex did not find normalized quantized index")
+	}
+
+	rejects := []struct {
+		name string
+		def  VectorIndexDefinition
+		want string
+	}{
+		{
+			name: "non_column_graph",
+			def: VectorIndexDefinition{
+				Name:       "embedding_graph",
+				Field:      "embedding",
+				Metric:     VectorMetricCosine,
+				Dimensions: 3,
+				QuantizedIndexes: []QuantizedVectorIndexDefinition{{
+					Name: "q",
+				}},
+			},
+			want: "require strategy",
+		},
+		{
+			name: "duplicate_name",
+			def: VectorIndexDefinition{
+				Name:       "embedding_graph",
+				Field:      "embedding",
+				Metric:     VectorMetricCosine,
+				Dimensions: 3,
+				Strategy:   VectorIndexStrategyColumnGraph,
+				QuantizedIndexes: []QuantizedVectorIndexDefinition{
+					{Name: "q"},
+					{Name: "q"},
+				},
+			},
+			want: "duplicate quantized index",
+		},
+		{
+			name: "unsupported_codec",
+			def: VectorIndexDefinition{
+				Name:       "embedding_graph",
+				Field:      "embedding",
+				Metric:     VectorMetricCosine,
+				Dimensions: 3,
+				Strategy:   VectorIndexStrategyColumnGraph,
+				QuantizedIndexes: []QuantizedVectorIndexDefinition{{
+					Name:  "q",
+					Codec: "brq_1bit",
+				}},
+			},
+			want: "unsupported",
+		},
+	}
+	for _, tt := range rejects {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := normalizeVectorIndexDefinition(tt.def)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("normalizeVectorIndexDefinition err=%v want containing %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestSearchVectorIndexQuantizedModesFailClosed1926(t *testing.T) {
+	rows := []columnGraphRebuildInputRowV2A{
+		{id: "doc-a", vector: []float32{1, 0, 0}},
+		{id: "doc-b", vector: []float32{0.9, 0.1, 0}},
+		{id: "doc-c", vector: []float32{0, 1, 0}},
+		{id: "doc-d", vector: []float32{0, 0, 1}},
+	}
+	dir, d, col, def := openColumnGraphQuantizedGuardrailTestCollection1926(t, rows)
+	status, err := col.RebuildVectorIndex(def.Name)
+	if err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	assertColumnGraphRebuildLoadedStatusV2A(t, status, def.Name)
+
+	query := []float32{1, 0, 0}
+	exactOpts := VectorIndexSearchOptions{IndexName: def.Name, Query: query, TopK: 2, EfSearch: len(rows), MaxDecodedBlocks: 1}
+	exact, err := col.SearchVectorIndex(exactOpts)
+	if err != nil {
+		t.Fatalf("exact SearchVectorIndex: %v", err)
+	}
+	assertColumnGraphSearchResponseLoadedV4(t, exact, def.Name, 2)
+	assertVectorIndexSearchResultsV4(t, exact.Results, exactColumnGraphTopKForTest(t, rows, query, 2), false)
+	explicitExact, err := col.SearchVectorIndex(VectorIndexSearchOptions{IndexName: def.Name, Query: query, QueryMode: VectorIndexQueryModeExact, TopK: 2, EfSearch: len(rows), MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("explicit exact SearchVectorIndex: %v", err)
+	}
+	assertVectorIndexSearchResultsV4(t, explicitExact.Results, exactColumnGraphTopKForTest(t, rows, query, 2), false)
+
+	for _, tc := range []struct {
+		name       string
+		mode       VectorIndexQueryMode
+		rerankCand int
+	}{
+		{name: "quantized_only", mode: VectorIndexQueryModeQuantizedOnly},
+		{name: "quantized_rerank", mode: VectorIndexQueryModeQuantizedRerank, rerankCand: 2},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := col.SearchVectorIndex(VectorIndexSearchOptions{
+				IndexName:                 def.Name,
+				Query:                     query,
+				QueryMode:                 tc.mode,
+				QuantizedIndexName:        def.QuantizedIndexes[0].Name,
+				QuantizedRerankCandidates: tc.rerankCand,
+				TopK:                      2,
+				EfSearch:                  len(rows),
+				IncludeDocuments:          true,
+				MaxDecodedBlocks:          1,
+			})
+			if !errors.Is(err, ErrVectorIndexSearchUnavailable) {
+				t.Fatalf("SearchVectorIndex err=%v want ErrVectorIndexSearchUnavailable", err)
+			}
+			if !strings.Contains(err.Error(), string(tc.mode)) || !strings.Contains(err.Error(), def.QuantizedIndexes[0].Name) {
+				t.Fatalf("SearchVectorIndex err=%v want mode and selected quantized index", err)
+			}
+			if len(got.Results) != 0 {
+				t.Fatalf("quantized fail-closed returned %d results: %+v", len(got.Results), got.Results)
+			}
+			if got.Stats.Candidates != 0 || got.Stats.CandidateFetches != 0 || got.Stats.DocumentsFetched != 0 || got.Stats.DocumentJSONReconstructionRows != 0 {
+				t.Fatalf("quantized fail-closed stats=%+v want no scoring or document materialization", got.Stats)
+			}
+		})
+	}
+
+	if _, err := col.SearchVectorIndex(VectorIndexSearchOptions{IndexName: def.Name, Query: query, QueryMode: VectorIndexQueryModeQuantizedOnly, QuantizedIndexName: "missing.scalar_u8", TopK: 1, EfSearch: len(rows), MaxDecodedBlocks: 1}); !errors.Is(err, ErrVectorIndexSearchUnavailable) || !strings.Contains(err.Error(), "is not declared") {
+		t.Fatalf("undeclared quantized index err=%v want unavailable declared-name failure", err)
+	}
+	if _, err := col.SearchVectorIndex(VectorIndexSearchOptions{IndexName: def.Name, Query: query, QueryMode: VectorIndexQueryModeExact, QuantizedIndexName: def.QuantizedIndexes[0].Name, TopK: 1, EfSearch: len(rows), MaxDecodedBlocks: 1}); err == nil || !strings.Contains(err.Error(), "exact") {
+		t.Fatalf("exact with quantized index err=%v want validation failure", err)
+	}
+
+	if err := d.Checkpoint(); err != nil {
+		t.Fatalf("Checkpoint: %v", err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	reopened := openCollectionCommandWALDB(t, dir)
+	defer func() { _ = reopened.Close() }()
+	reopenedCol, err := NewCollectionManager(reopened).OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("OpenCollection reopen: %v", err)
+	}
+	reopenedMeta := reopenedCol.Meta()
+	if got := reopenedMeta.VectorIndexes[0].QuantizedIndexes; len(got) != 1 || got[0] != def.QuantizedIndexes[0] {
+		t.Fatalf("reopened QuantizedIndexes=%+v want %+v", got, def.QuantizedIndexes)
+	}
+}
+
+func TestVectorIndexSearcherQuantizedFailClosedResetsBuffer1926(t *testing.T) {
+	rows := []columnGraphRebuildInputRowV2A{
+		{id: "doc-a", vector: []float32{1, 0, 0}},
+		{id: "doc-b", vector: []float32{0, 1, 0}},
+		{id: "doc-c", vector: []float32{0, 0, 1}},
+	}
+	_, d, col, def := openColumnGraphQuantizedGuardrailTestCollection1926(t, rows)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	searcher, err := col.OpenVectorIndexSearcher(VectorIndexSearcherOptions{IndexName: def.Name, MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("OpenVectorIndexSearcher: %v", err)
+	}
+	defer func() { _ = searcher.Close() }()
+
+	var buffer VectorIndexSearchBuffer
+	validOpts := VectorIndexSearcherSearchOptions{Query: []float32{1, 0, 0}, TopK: 2, EfSearch: len(rows)}
+	valid, err := searcher.SearchWithBuffer(validOpts, &buffer)
+	if err != nil || len(valid.Results) != 2 || len(buffer.results) != 2 {
+		t.Fatalf("initial SearchWithBuffer results=%d buffer=%d err=%v want 2,2,nil", len(valid.Results), len(buffer.results), err)
+	}
+	got, err := searcher.SearchWithBuffer(VectorIndexSearcherSearchOptions{
+		Query:              []float32{1, 0, 0},
+		QueryMode:          VectorIndexQueryModeQuantizedOnly,
+		QuantizedIndexName: def.QuantizedIndexes[0].Name,
+		TopK:               2,
+		EfSearch:           len(rows),
+	}, &buffer)
+	if !errors.Is(err, ErrVectorIndexSearchUnavailable) {
+		t.Fatalf("SearchWithBuffer err=%v want ErrVectorIndexSearchUnavailable", err)
+	}
+	if len(got.Results) != 0 || len(buffer.results) != 0 || len(buffer.idBytes) != 0 {
+		t.Fatalf("quantized error results=%d buffer.results=%d idBytes=%d want reset empty views", len(got.Results), len(buffer.results), len(buffer.idBytes))
+	}
+	validAgain, err := searcher.SearchWithBuffer(validOpts, &buffer)
+	if err != nil || len(validAgain.Results) != 2 {
+		t.Fatalf("valid SearchWithBuffer after quantized error results=%d err=%v", len(validAgain.Results), err)
+	}
+}
+
+func TestNativeRuntimeVectorIndexRejectsQuantizedQueryMode1926(t *testing.T) {
+	idx, err := newVectorIndex(nil, VectorIndexOptions{Name: "embedding_idx", Field: "embedding", Metric: VectorMetricCosine, Dimensions: 2})
+	if err != nil {
+		t.Fatalf("newVectorIndex: %v", err)
+	}
+	_, _, err = idx.Search([]float32{1, 0}, VectorIndexSearchOptions{TopK: 1, QueryMode: VectorIndexQueryModeQuantizedOnly, QuantizedIndexName: "q"})
+	if !errors.Is(err, ErrVectorIndexSearchUnavailable) {
+		t.Fatalf("VectorIndex.Search err=%v want ErrVectorIndexSearchUnavailable", err)
+	}
+}
+
+func openColumnGraphQuantizedGuardrailTestCollection1926(tb testing.TB, rows []columnGraphRebuildInputRowV2A) (string, *backenddb.DB, *Collection, VectorIndexDefinition) {
+	tb.Helper()
+	dir := tb.TempDir()
+	if err := backenddb.SaveFormatConfig(dir, backenddb.FormatConfig{RequiredFeatures: []string{backenddb.RequiredFeatureCommandWALV1}}); err != nil {
+		tb.Fatalf("SaveFormatConfig: %v", err)
+	}
+	d := openCollectionCommandWALDB(tb, dir)
+	def, err := normalizeVectorIndexDefinition(VectorIndexDefinition{
+		Name:       "embedding_graph",
+		Field:      "embedding",
+		Metric:     VectorMetricCosine,
+		Dimensions: 3,
+		M:          3,
+		Strategy:   VectorIndexStrategyColumnGraph,
+		QuantizedIndexes: []QuantizedVectorIndexDefinition{{
+			Name: "embedding.scalar_u8.fast",
+		}},
+	})
+	if err != nil {
+		_ = d.Close()
+		tb.Fatalf("normalizeVectorIndexDefinition: %v", err)
+	}
+	meta := CollectionMeta{
+		Name: "docs",
+		Options: CollectionOptions{
+			DocumentFormat: DocumentFormatJSON,
+			ColumnStore:    columnGraphRebuildColumnStoreConfigV2A(3),
+		},
+		VectorIndexes: []VectorIndexDefinition{def},
+	}
+	if _, err := NewCollectionManager(d).CreateCollection(&meta); err != nil {
+		_ = d.Close()
+		tb.Fatalf("CreateCollection: %v", err)
+	}
+	col, err := NewCollectionManager(d).OpenCollection("docs")
+	if err != nil {
+		_ = d.Close()
+		tb.Fatalf("OpenCollection: %v", err)
+	}
+	if len(rows) != 0 {
+		insertColumnGraphRebuildRowsV2A(tb, col, rows)
+	}
+	return dir, d, col, def
+}
+
 func TestSearchVectorIndexColumnGraphNativeReaderReopenV4(t *testing.T) {
 	rows := []columnGraphRebuildInputRowV2A{
 		{id: "doc-a", vector: []float32{1, 0, 0}},
@@ -1467,7 +1733,7 @@ func assertVectorIndexSearchResultsV4(tb testing.TB, got []VectorIndexSearchResu
 
 func assertVectorIndexSearchResponsesEquivalentNoDocs2124(tb testing.TB, got, want VectorIndexSearchResponse) {
 	tb.Helper()
-	if got.IndexName != want.IndexName || got.Strategy != want.Strategy || got.Path != want.Path || got.Status != want.Status {
+	if got.IndexName != want.IndexName || got.Strategy != want.Strategy || got.Path != want.Path || !vectorIndexStatusEquivalentForSearchResponse2124(got.Status, want.Status) {
 		tb.Fatalf("response metadata got=%+v status=%+v want=%+v status=%+v", got, got.Status, want, want.Status)
 	}
 	if len(got.Results) != len(want.Results) {
@@ -1481,6 +1747,24 @@ func assertVectorIndexSearchResponsesEquivalentNoDocs2124(tb testing.TB, got, wa
 			tb.Fatalf("result[%d] document len=%d want no-document reusable response", i, len(got.Results[i].Document))
 		}
 	}
+}
+
+func vectorIndexStatusEquivalentForSearchResponse2124(a, b VectorIndexStatus) bool {
+	return vectorIndexDefinitionValuesEqual(a.Definition, b.Definition) &&
+		a.Name == b.Name &&
+		a.Strategy == b.Strategy &&
+		a.State == b.State &&
+		a.Reason == b.Reason &&
+		a.Loaded == b.Loaded &&
+		a.RootName == b.RootName &&
+		a.RootID == b.RootID &&
+		a.NativeRootLoaded == b.NativeRootLoaded &&
+		a.NativeRootBytes == b.NativeRootBytes &&
+		a.ExactFallbackReason == b.ExactFallbackReason &&
+		a.Registered == b.Registered &&
+		a.Stats == b.Stats &&
+		a.RebuildNeeded == b.RebuildNeeded &&
+		a.Duration == b.Duration
 }
 
 func assertVectorIndexSearchResultIDStatsContract2124(tb testing.TB, got, want VectorIndexSearchStats) {

--- a/TreeDB/docs/spec/quantized-asset-schema.md
+++ b/TreeDB/docs/spec/quantized-asset-schema.md
@@ -23,6 +23,19 @@ padding already certified by typed-column layout validation. Float side arrays a
 non-null `float32` / `raw_float32`; integer side arrays are non-null `uint32` /
 `raw_uint32` or `uint64` / `raw_uint64` where a wider identifier is required.
 
+## Query-mode guardrail
+
+Collection vector-index metadata can declare named `scalar_u8` v1 quantized
+score planes under `VectorIndexDefinition.QuantizedIndexes`. Public search
+options expose explicit `exact`, `quantized_only`, and `quantized_rerank` query
+modes. The zero/default mode remains exact.
+
+Until a later #1926 slice builds and loads matching quantized typed-column
+assets, quantized modes validate the selected name/options and then fail closed
+with search-unavailable status before graph traversal/scoring. They must not
+silently return exact results. Exact mode rejects quantized-only fields so future
+callers do not accidentally rely on no-op options.
+
 ## Fail-closed validation
 
 `TreeDB/internal/quantizedasset` prepares immutable readers from typed-column part

--- a/TreeDB/docs/spec/storage-format.md
+++ b/TreeDB/docs/spec/storage-format.md
@@ -992,6 +992,12 @@ The payload name and decoded metadata name must match. Replay is idempotent only
 when an existing catalog entry has identical normalized metadata; incompatible
 metadata fails closed before advancing `AppliedCommandLSN`.
 
+Collection vector-index declarations are stored in the canonical collection
+metadata JSON under top-level `vector_indexes`. Quantized score-plane
+declarations, when present, live under `vector_indexes[].quantized_indexes` and
+are declarations only until matching derived assets are built and loaded; explicit
+quantized query modes must fail closed when those assets are absent or stale.
+
 Column-enabled collection metadata is stored inside the canonical collection
 metadata JSON under `options.column_store`. It is production-facing
 control-plane state, not a sidecar hint. Current normalized fields are:

--- a/TreeDB/nativewire/metadata.go
+++ b/TreeDB/nativewire/metadata.go
@@ -51,7 +51,7 @@ func appendCollectionHandleRefPayload(dst []byte, handle CollectionHandle) []byt
 }
 
 func encodeCollectionMeta(meta collections.CollectionMeta) []byte {
-	dst := binary.AppendUvarint(nil, 2)
+	dst := binary.AppendUvarint(nil, 3)
 	dst = appendString(dst, meta.Name)
 	dst = binary.AppendUvarint(dst, uint64(encodeDocumentFormat(meta.Options.DocumentFormat)))
 	dst = binary.AppendUvarint(dst, uint64(encodeRootStorage(meta.Options.DataRootStoragePolicy)))
@@ -71,7 +71,7 @@ func encodeCollectionMeta(meta collections.CollectionMeta) []byte {
 	}
 	dst = binary.AppendUvarint(dst, uint64(len(meta.VectorIndexes)))
 	for _, def := range meta.VectorIndexes {
-		dst = appendVectorIndexDefinition(dst, def, false)
+		dst = appendVectorIndexDefinitionForCollectionMeta(dst, def, 3)
 	}
 	return dst
 }
@@ -81,7 +81,7 @@ func decodeCollectionMeta(src []byte) (collections.CollectionMeta, error) {
 	if err != nil {
 		return collections.CollectionMeta{}, err
 	}
-	if version != 1 && version != 2 {
+	if version != 1 && version != 2 && version != 3 {
 		return collections.CollectionMeta{}, protocolError(iwire.ErrUnsupportedVersion, "collection_meta version %d", version)
 	}
 	name, err := readString(src, &off)
@@ -215,7 +215,7 @@ func decodeCollectionMeta(src []byte) (collections.CollectionMeta, error) {
 		}
 		meta.VectorIndexes = make([]collections.VectorIndexDefinition, 0, int(vectorIndexCount))
 		for i := uint64(0); i < vectorIndexCount; i++ {
-			def, next, err := decodeVectorIndexDefinitionAt(src, off, false)
+			def, next, err := decodeVectorIndexDefinitionForCollectionMeta(src, off, version)
 			if err != nil {
 				return collections.CollectionMeta{}, err
 			}
@@ -314,6 +314,24 @@ func appendVectorIndexDefinition(dst []byte, def collections.VectorIndexDefiniti
 	if withVersion && len(dst) == 0 {
 		dst = binary.AppendUvarint(dst, 1)
 	}
+	return appendVectorIndexDefinitionFields(dst, def)
+}
+
+func appendVectorIndexDefinitionForCollectionMeta(dst []byte, def collections.VectorIndexDefinition, collectionMetaVersion uint64) []byte {
+	dst = appendVectorIndexDefinitionFields(dst, def)
+	if collectionMetaVersion >= 3 {
+		dst = binary.AppendUvarint(dst, encodeVectorIndexStrategy(def.Strategy))
+		dst = binary.AppendUvarint(dst, uint64(len(def.QuantizedIndexes)))
+		for _, q := range def.QuantizedIndexes {
+			dst = appendString(dst, q.Name)
+			dst = appendString(dst, q.Codec)
+			dst = binary.AppendUvarint(dst, uint64(q.Version))
+		}
+	}
+	return dst
+}
+
+func appendVectorIndexDefinitionFields(dst []byte, def collections.VectorIndexDefinition) []byte {
 	dst = appendString(dst, def.Name)
 	dst = appendString(dst, def.Field)
 	dst = binary.AppendUvarint(dst, encodeVectorMetric(def.Metric))
@@ -398,6 +416,60 @@ func decodeVectorIndexDefinitionAt(src []byte, off int, withVersion bool) (colle
 		EfSearch:       int(efSearch),
 		Encoding:       decodedEncoding,
 	}, off, nil
+}
+
+func decodeVectorIndexDefinitionForCollectionMeta(src []byte, off int, collectionMetaVersion uint64) (collections.VectorIndexDefinition, int, error) {
+	def, off, err := decodeVectorIndexDefinitionAt(src, off, false)
+	if err != nil {
+		return collections.VectorIndexDefinition{}, 0, err
+	}
+	if collectionMetaVersion < 3 {
+		return def, off, nil
+	}
+	strategy, err := readEnum(src, &off)
+	if err != nil {
+		return collections.VectorIndexDefinition{}, 0, err
+	}
+	decodedStrategy, err := decodeVectorIndexStrategyStrict(strategy)
+	if err != nil {
+		return collections.VectorIndexDefinition{}, 0, err
+	}
+	quantizedCount, err := readUvarintField(src, &off, "quantized_index_count")
+	if err != nil {
+		return collections.VectorIndexDefinition{}, 0, err
+	}
+	if quantizedCount > uint64(maxInt) {
+		return collections.VectorIndexDefinition{}, 0, protocolError(iwire.ErrResourceExhausted, "quantized vector index count exceeds int capacity")
+	}
+	if quantizedCount > maxCollectionMetaIndexDefinitions {
+		return collections.VectorIndexDefinition{}, 0, protocolError(iwire.ErrResourceExhausted, "quantized vector index count %d exceeds limit %d", quantizedCount, maxCollectionMetaIndexDefinitions)
+	}
+	quantized := make([]collections.QuantizedVectorIndexDefinition, 0, int(quantizedCount))
+	for i := uint64(0); i < quantizedCount; i++ {
+		name, err := readString(src, &off)
+		if err != nil {
+			return collections.VectorIndexDefinition{}, 0, err
+		}
+		codec, err := readString(src, &off)
+		if err != nil {
+			return collections.VectorIndexDefinition{}, 0, err
+		}
+		codecVersion, err := readUvarintField(src, &off, "quantized_index_version")
+		if err != nil {
+			return collections.VectorIndexDefinition{}, 0, err
+		}
+		if codecVersion > uint64(^uint32(0)) {
+			return collections.VectorIndexDefinition{}, 0, protocolError(iwire.ErrResourceExhausted, "quantized vector index version %d exceeds uint32 capacity", codecVersion)
+		}
+		quantized = append(quantized, collections.QuantizedVectorIndexDefinition{
+			Name:    name,
+			Codec:   codec,
+			Version: uint32(codecVersion),
+		})
+	}
+	def.Strategy = decodedStrategy
+	def.QuantizedIndexes = quantized
+	return def, off, nil
 }
 
 func encodeCollectionMetaVector(metas []collections.CollectionMeta) []byte {
@@ -669,6 +741,28 @@ func decodeVectorIndexEncodingStrict(encoding uint64) (collections.VectorIndexEn
 		return collections.VectorIndexEncodingInt8, nil
 	default:
 		return collections.VectorIndexEncodingFloat32, protocolError(iwire.ErrInvalidCommand, "unsupported vector_index_encoding enum %d", encoding)
+	}
+}
+
+func encodeVectorIndexStrategy(strategy collections.VectorIndexStrategy) uint64 {
+	switch strategy {
+	case "", collections.VectorIndexStrategyNativeRuntime:
+		return 1
+	case collections.VectorIndexStrategyColumnGraph:
+		return 2
+	default:
+		return 0
+	}
+}
+
+func decodeVectorIndexStrategyStrict(strategy uint64) (collections.VectorIndexStrategy, error) {
+	switch strategy {
+	case 1:
+		return collections.VectorIndexStrategyNativeRuntime, nil
+	case 2:
+		return collections.VectorIndexStrategyColumnGraph, nil
+	default:
+		return "", protocolError(iwire.ErrInvalidCommand, "unsupported vector_index_strategy enum %d", strategy)
 	}
 }
 

--- a/TreeDB/nativewire/metadata_test.go
+++ b/TreeDB/nativewire/metadata_test.go
@@ -3,6 +3,7 @@ package nativewire
 import (
 	"context"
 	"encoding/binary"
+	"reflect"
 	"testing"
 	"time"
 
@@ -141,12 +142,15 @@ func TestMetadataCommandsPreserveVectorIndexes(t *testing.T) {
 		VectorIndexes: []collections.VectorIndexDefinition{{
 			Name:           "embedding",
 			Field:          "embedding",
-			Metric:         collections.VectorMetricL2,
+			Metric:         collections.VectorMetricCosine,
 			Dimensions:     64,
 			M:              12,
 			EfConstruction: 96,
 			EfSearch:       48,
-			Encoding:       collections.VectorIndexEncodingInt8,
+			Strategy:       collections.VectorIndexStrategyColumnGraph,
+			QuantizedIndexes: []collections.QuantizedVectorIndexDefinition{{
+				Name: "embedding.scalar_u8.fast",
+			}},
 		}},
 	})
 	if err != nil {
@@ -156,8 +160,11 @@ func TestMetadataCommandsPreserveVectorIndexes(t *testing.T) {
 		t.Fatalf("created vector indexes=%+v", meta.VectorIndexes)
 	}
 	got := meta.VectorIndexes[0]
-	if got.Name != "embedding" || got.Field != "embedding" || got.Metric != collections.VectorMetricL2 || got.Dimensions != 64 || got.Encoding != collections.VectorIndexEncodingInt8 {
+	if got.Name != "embedding" || got.Field != "embedding" || got.Metric != collections.VectorMetricCosine || got.Dimensions != 64 || got.Encoding != collections.VectorIndexEncodingFloat32 || got.Strategy != collections.VectorIndexStrategyColumnGraph {
 		t.Fatalf("created vector index=%+v", got)
+	}
+	if len(got.QuantizedIndexes) != 1 || got.QuantizedIndexes[0].Name != "embedding.scalar_u8.fast" || got.QuantizedIndexes[0].Codec != collections.QuantizedVectorCodecScalarU8 || got.QuantizedIndexes[0].Version != 1 {
+		t.Fatalf("created quantized vector indexes=%+v", got.QuantizedIndexes)
 	}
 
 	metas, err := client.ListCollections(ctx)
@@ -167,7 +174,7 @@ func TestMetadataCommandsPreserveVectorIndexes(t *testing.T) {
 	if len(metas) != 1 || len(metas[0].VectorIndexes) != 1 {
 		t.Fatalf("listed collections=%+v", metas)
 	}
-	if metas[0].VectorIndexes[0] != got {
+	if !reflect.DeepEqual(metas[0].VectorIndexes[0], got) {
 		t.Fatalf("listed vector index=%+v want %+v", metas[0].VectorIndexes[0], got)
 	}
 }


### PR DESCRIPTION
## Summary

Part of #1926 (does **not** close #1926).

This PR lands the first, fail-closed query-mode guardrail for quantized TreeDB `column_graph` search:

- Adds named `VectorIndexDefinition.QuantizedIndexes` metadata declarations for scalar_u8 v1 score planes.
- Adds explicit public query modes: `exact`, `quantized_only`, and `quantized_rerank`.
- Keeps zero/default mode exact and rejects quantized-only fields in exact mode.
- Makes quantized modes validate the selected declaration and then fail closed with `ErrVectorIndexSearchUnavailable` until durable quantized assets/scorers land in later #1926 work.
- Preserves quantized metadata in collection JSON and nativewire metadata commands.
- Documents the guardrail and absent/stale-asset fail-closed contract.

Out of scope for this PR: building/loading scalar_u8 assets, quantized scoring, exact rerank, default-mode changes, and batch/control-flow/windowing speedups.

## Validation

```sh
GOWORK=off go test ./TreeDB/collections -run 'Quantized|SearchVectorIndexColumnGraph|OpenVectorIndexSearcher|SearchWithBuffer|TypedStorageLegacyNameAllowlist' -count=1
GOWORK=off go test ./TreeDB/nativewire -count=1
GOWORK=off go test ./TreeDB/collections ./TreeDB/nativewire ./TreeDB/docs -count=1
GOWORK=off go test ./TreeDB/collections -run '^$' -bench 'BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderReusableBufferV4$' -benchmem -count=1
```

Benchmark on Apple M3 / darwin-arm64:

- `BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderReusableBufferV4`: `13433 ns/op`, `74444 ops/sec`, `0 B/op`, `0 allocs/op`.
