### PR TITLE
Fix TreeDB leaf vlog GC snapshot misses

### DIFF
--- a/TreeDB/db/vlog_gc_test.go
+++ b/TreeDB/db/vlog_gc_test.go
@@ -32,6 +32,107 @@ func TestValueLogGC_EmptySet_NoValueLogSegments(t *testing.T) {
 	}
 }
 
+func TestValueLogGC_IgnoresInlineLeafLogWhenDBDefaultUsesPagerLeaves(t *testing.T) {
+	dir := t.TempDir()
+
+	db, err := Open(Options{
+		Dir:                    dir,
+		DisableBackgroundPrune: true,
+	})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	if db.indexOuterLeavesInValueLog {
+		t.Fatalf("indexOuterLeavesInValueLog=true, want false for this regression")
+	}
+	inlineAppender, err := newReplayInlineAppender(db, nil, nil)
+	if err != nil {
+		t.Fatalf("new replay inline appender: %v", err)
+	}
+	defer func() { _ = inlineAppender.close() }()
+	db.SetValueLogAppender(inlineAppender)
+	db.SetLeafPageLog(replayInlineLeafPageLog{appender: inlineAppender})
+	defer db.SetValueLogAppender(nil)
+	defer db.SetLeafPageLog(nil)
+	if db.leafPageLog == nil {
+		t.Fatalf("inline appender did not install a leaf page log")
+	}
+
+	if _, err := db.AppendValueLogValues([][]byte{bytes.Repeat([]byte("ordinary-value|"), 32)}); err != nil {
+		t.Fatalf("append ordinary value-log value: %v", err)
+	}
+	appender := db.currentValueLogAppender()
+	if appender == nil {
+		t.Fatalf("missing value-log appender")
+	}
+	primaryPath, primaryFileID, ok := appender.CurrentValueLogSegment()
+	if !ok || primaryPath == "" || primaryFileID == 0 {
+		t.Fatalf("ordinary value-log segment not opened: path=%q id=%d ok=%t", primaryPath, primaryFileID, ok)
+	}
+
+	table := mustFrozenSystemMemtable(t, "doc/u1", "document")
+	_, rootIDs, err := db.PublishOrderedRootGroup(nil, []OrderedRootPublishInput{{
+		BaseRoot:      0,
+		Iter:          table.NewIterator(nil, nil),
+		StoragePolicy: OrderedRootStorageValueLogLeaves,
+	}})
+	if err != nil {
+		t.Fatalf("publish value-log leaf root: %v", err)
+	}
+	if len(rootIDs) != 1 {
+		t.Fatalf("rootIDs=%d want 1", len(rootIDs))
+	}
+	leafPtrs := requireLeafLogRootChildren(t, db, rootIDs[0])
+	leafFileID := page.ValueLogFileID(leafPtrs[0].FileID)
+
+	preSet := db.valueLogManager.CurrentSetNoRefresh()
+	if preSet == nil {
+		t.Fatalf("missing value-log set before GC")
+	}
+	if _, ok := preSet.Files[primaryFileID]; !ok {
+		_ = db.valueLogManager.Release(preSet)
+		t.Fatalf("ordinary value-log segment %d missing before GC", primaryFileID)
+	}
+	if _, ok := preSet.Files[leafFileID]; !ok {
+		_ = db.valueLogManager.Release(preSet)
+		t.Fatalf("leaf-log segment %d missing before GC", leafFileID)
+	}
+	_ = db.valueLogManager.Release(preSet)
+
+	stats, err := db.ValueLogGC(context.Background(), ValueLogGCOptions{ProtectedPaths: []string{primaryPath}})
+	if err != nil {
+		t.Fatalf("ValueLogGC: %v", err)
+	}
+	if stats.SegmentsEligible != 0 || stats.SegmentsDeleted != 0 {
+		t.Fatalf("leaf-log segment was considered ordinary GC work: %+v", stats)
+	}
+
+	postSet := db.valueLogManager.CurrentSetNoRefresh()
+	if postSet == nil {
+		t.Fatalf("missing value-log set after GC")
+	}
+	if _, ok := postSet.Files[leafFileID]; !ok {
+		_ = db.valueLogManager.Release(postSet)
+		t.Fatalf("leaf-log segment %d missing from current set after GC", leafFileID)
+	}
+	_ = db.valueLogManager.Release(postSet)
+
+	snap := db.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("expected snapshot")
+	}
+	defer snap.Close()
+	entry, err := snap.GetEntryAtRoot(rootIDs[0], []byte("doc/u1"))
+	if err != nil {
+		t.Fatalf("read value-log leaf root after GC: %v", err)
+	}
+	if got := string(entry.Value); got != "document" {
+		t.Fatalf("value after GC=%q want document", got)
+	}
+}
+
 func TestValueLogGC_RemovesUnreferencedSegment(t *testing.T) {
 	dir := t.TempDir()
 

--- a/TreeDB/db/vlog_gc_test.go
+++ b/TreeDB/db/vlog_gc_test.go
@@ -32,6 +32,31 @@ func TestValueLogGC_EmptySet_NoValueLogSegments(t *testing.T) {
 	}
 }
 
+func TestValueOnlyValueLogFiles_KeepsReservedLaneInPrimaryValueLog(t *testing.T) {
+	dir := t.TempDir()
+	id, err := valuelog.EncodeFileID(rewriteLeafLogLaneID, 1)
+	if err != nil {
+		t.Fatalf("fileid: %v", err)
+	}
+	db := &DB{dir: dir, leafPageLog: replayInlineLeafPageLog{}}
+
+	valuePath := filepath.Join(ValueLogDirPath(dir), "value-l255-000001.log")
+	valueFiles := db.valueOnlyValueLogFiles(map[uint32]*valuelog.File{
+		id: {Path: valuePath},
+	})
+	if _, ok := valueFiles[id]; !ok {
+		t.Fatalf("primary value_vlog reserved-lane segment was filtered")
+	}
+
+	leafPath := filepath.Join(LeafLogDirPath(dir), "value-l255-000001.log")
+	leafFiles := db.valueOnlyValueLogFiles(map[uint32]*valuelog.File{
+		id: {Path: leafPath},
+	})
+	if _, ok := leafFiles[id]; ok {
+		t.Fatalf("leaf_vlog reserved-lane segment was not filtered")
+	}
+}
+
 func TestValueLogGC_IgnoresInlineLeafLogWhenDBDefaultUsesPagerLeaves(t *testing.T) {
 	dir := t.TempDir()
 

--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -844,26 +844,35 @@ func selectSingleExplicitRewriteSourceID(sourceFileIDs []uint32, files map[uint3
 }
 
 func (db *DB) isLeafLogValueFileID(fileID uint32) bool {
-	if db == nil || !db.indexOuterLeavesInValueLog {
-		return false
-	}
 	lane, _ := valuelog.DecodeFileID(fileID)
 	return lane == rewriteLeafLogLaneID
+}
+
+func (db *DB) isLeafLogValueFile(id uint32, f *valuelog.File) bool {
+	// Per-root value-log leaf storage can be wired by the command-WAL inline
+	// appender even when the DB-level default keeps outer leaves in pager pages.
+	// Ordinary value-log maintenance must still exclude those leaf_vlog files.
+	if f != nil && f.Path != "" && db != nil && db.dir != "" {
+		if filepath.Clean(filepath.Dir(f.Path)) == filepath.Clean(LeafLogDirPath(db.dir)) {
+			return true
+		}
+	}
+	if db == nil || (db.leafPageLog == nil && db.leafGenerationManifest == nil && !db.indexOuterLeavesInValueLog) {
+		return false
+	}
+	return db.isLeafLogValueFileID(id)
 }
 
 func (db *DB) valueOnlyValueLogFiles(files map[uint32]*valuelog.File) map[uint32]*valuelog.File {
 	if len(files) == 0 {
 		return nil
 	}
-	if db == nil || !db.indexOuterLeavesInValueLog {
-		return files
-	}
 	filtered := make(map[uint32]*valuelog.File, len(files))
 	for id, f := range files {
 		if f == nil {
 			continue
 		}
-		if db.isLeafLogValueFileID(id) {
+		if db.isLeafLogValueFile(id, f) {
 			continue
 		}
 		filtered[id] = f
@@ -5258,7 +5267,7 @@ func (db *DB) valueLogSegmentStatsValueOnly(dir string) (count int, bytes int64,
 		if !seg.valueLog {
 			continue
 		}
-		if db != nil && db.isLeafLogValueFileID(uint32(seg.fileID)) {
+		if db != nil && db.isLeafLogValueFile(uint32(seg.fileID), &valuelog.File{Path: seg.path}) {
 			continue
 		}
 		if seg.size > 0 {

--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -853,8 +853,12 @@ func (db *DB) isLeafLogValueFile(id uint32, f *valuelog.File) bool {
 	// appender even when the DB-level default keeps outer leaves in pager pages.
 	// Ordinary value-log maintenance must still exclude those leaf_vlog files.
 	if f != nil && f.Path != "" && db != nil && db.dir != "" {
-		if filepath.Clean(filepath.Dir(f.Path)) == filepath.Clean(LeafLogDirPath(db.dir)) {
+		dir := filepath.Clean(filepath.Dir(f.Path))
+		if dir == filepath.Clean(LeafLogDirPath(db.dir)) {
 			return true
+		}
+		if dir == filepath.Clean(ValueLogDirPath(db.dir)) {
+			return false
 		}
 	}
 	if db == nil || (db.leafPageLog == nil && db.leafGenerationManifest == nil && !db.indexOuterLeavesInValueLog) {


### PR DESCRIPTION
## Summary

Fixes #2207.

TreeDB value-log GC/rewrite filtering now treats `leaf_vlog` files as leaf-log storage even when the DB-level default keeps outer leaves in pager pages. This covers command-WAL/native-root flows where the inline appender installs a leaf page log for per-root `OrderedRootStorageValueLogLeaves` while `IndexOuterLeavesInValueLog` remains false.

## Root cause

The failing file ID `4286578689` decodes to reserved leaf-log lane 255, seq 1 (`leaf_vlog/value-l255-000001.log`). Background value-log generation GC was classifying that live leaf-log segment as an ordinary unreferenced value-log segment when protected primary value-log paths were present, marking it zombie. The next published snapshot omitted the file, causing collection insert preflight to fail with `valuelog file 4286578689 not found in snapshot`.

## Changes

- Exclude leaf-log segments from value-only maintenance by `leaf_vlog` path.
- Use reserved leaf-lane fallback only when leaf-log state is active and the path is unavailable/unknown; keep `value_vlog/value-l255-*` as ordinary primary value-log storage.
- Add focused regressions for:
  - inline-appender + DB-default-pager-leaves leaf-log GC, and
  - primary `value_vlog` lane-255 filtering safety.

## Validation

- `go test ./TreeDB/db -run 'TestValueOnlyValueLogFiles_KeepsReservedLaneInPrimaryValueLog|TestValueLogGC_IgnoresInlineLeafLogWhenDBDefaultUsesPagerLeaves' -count=1`
- `go test ./TreeDB/db -count=1`
- `go test ./TreeDB/... -count=1`
- JSONBench 1M fixed rerun:
  - `ROWS=1000000 TRIES=1 PROFILE=durable STORAGE_LAYOUTS=column-store-full-prepared SUITE=full VALIDATE_RECONSTRUCTION=0 ... ./run_columnstore_benchmark.sh`
  - artifact: `/tmp/orca_issue_graph_1945_1955/2207_valuelog_snapshot/fixed_final2_1m_20260603_023822/`

## Handoff artifacts

- `/tmp/orca_issue_graph_1945_1955/2207_valuelog_snapshot/handoff.md`
- `/tmp/orca_issue_graph_1945_1955/2207_valuelog_snapshot/repro_300k_zombie_20260603_015521.log`
- `/tmp/orca_issue_graph_1945_1955/2207_valuelog_snapshot/fixed_final2_1m_20260603_023822/report.md`
