### PR TITLE
Fix TreeDB column graph efSearch recall semantics

### DIFF
--- a/TreeDB/collections/column_vector_graph_batchability_1979_test.go
+++ b/TreeDB/collections/column_vector_graph_batchability_1979_test.go
@@ -148,7 +148,7 @@ func assertColumnVectorGraphBenchmarkDebugStats1979(tb testing.TB, stats columnV
 	if stats.VisitedMarkHits+stats.VisitedMarkMisses != stats.VisitedMarkChecks || stats.VisitedMarkHits != stats.Layer0AlreadyVisitedSkips {
 		tb.Fatalf("stats=%+v want visited-mark hits/misses to reconcile", stats)
 	}
-	if stats.FrontierPushes != stats.Candidates || stats.TopKInsertAttempts != stats.Candidates || stats.TopKInsertSuccesses+stats.TopKInsertRejections != stats.TopKInsertAttempts {
+	if stats.FrontierPushes != stats.TopKInsertSuccesses || stats.TopKInsertAttempts != stats.Candidates || stats.TopKInsertSuccesses+stats.TopKInsertRejections != stats.TopKInsertAttempts {
 		tb.Fatalf("stats=%+v want frontier/top-k operation counts to reconcile with candidates", stats)
 	}
 	if stats.NeighborTileSize0+stats.NeighborTileSize1+stats.NeighborTileSize2To4+stats.NeighborTileSize5To8+stats.NeighborTileSize9To16+stats.NeighborTileSize17Plus != stats.NeighborTiles {

--- a/TreeDB/collections/column_vector_graph_indexed_scoring_test.go
+++ b/TreeDB/collections/column_vector_graph_indexed_scoring_test.go
@@ -94,7 +94,7 @@ func TestColumnVectorGraphIndexedScoringTieAndApplicationOrder1969(t *testing.T)
 		{ID: []byte("doc-entry"), Vector: []float32{0, 1}, InvNorm: 1, Adjacency: []uint32{2, 1, 3}},
 		{ID: []byte("doc-tie-low-ordinal"), Vector: []float32{0.5, 0}, InvNorm: 1},
 		{ID: []byte("doc-tie-high-ordinal"), Vector: []float32{0.5, 0}, InvNorm: 1},
-		{ID: []byte("doc-must-not-be-scored-after-ef-limit"), Vector: []float32{1, 0}, InvNorm: 1},
+		{ID: []byte("doc-best-neighbor-scored-despite-ef-cap"), Vector: []float32{1, 0}, InvNorm: 1},
 	}
 	d, col, def := publishColumnVectorGraphPhysicalReaderTestAssetWithShapeV2B(t, 2, 3, rows)
 	defer func() { _ = d.Close() }()
@@ -106,16 +106,11 @@ func TestColumnVectorGraphIndexedScoringTieAndApplicationOrder1969(t *testing.T)
 	attachColumnVectorGraphIndexedScoreSources1969(t, reader, rows)
 
 	indexedResults, indexedStats := searchColumnVectorGraphIndexedScoring1969(t, reader, []float32{1, 0}, columnVectorGraphScoreBatchModeIndexed, 2, 3)
-	if indexedStats.Candidates != 3 || indexedStats.ScoreBatchMaxTileSize != 2 {
-		t.Fatalf("indexed stats=%+v want entry plus first two adjacency candidates only", indexedStats)
+	if indexedStats.Candidates != 4 || indexedStats.ScoreBatchMaxTileSize != 3 {
+		t.Fatalf("indexed stats=%+v want entry plus full expanded adjacency tile", indexedStats)
 	}
-	if len(indexedResults) != 2 || indexedResults[0].Ordinal != 1 || indexedResults[1].Ordinal != 2 {
-		t.Fatalf("indexed results=%+v want tie broken by ordinal after applying first two adjacency entries", indexedResults)
-	}
-	for _, result := range indexedResults {
-		if result.Ordinal == 3 {
-			t.Fatalf("indexed results=%+v scored adjacency beyond efSearch limit", indexedResults)
-		}
+	if len(indexedResults) != 2 || indexedResults[0].Ordinal != 3 || indexedResults[1].Ordinal != 1 {
+		t.Fatalf("indexed results=%+v want best neighbor plus ordinal tie after full HNSW expansion", indexedResults)
 	}
 }
 

--- a/TreeDB/collections/column_vector_graph_indexed_scoring_test.go
+++ b/TreeDB/collections/column_vector_graph_indexed_scoring_test.go
@@ -114,6 +114,29 @@ func TestColumnVectorGraphIndexedScoringTieAndApplicationOrder1969(t *testing.T)
 	}
 }
 
+func TestColumnVectorGraphIndexedScoringEfOneExpandsEntry1969(t *testing.T) {
+	rows := []columnVectorGraphAssetRow{
+		{ID: []byte("doc-entry"), Vector: []float32{0, 1}, InvNorm: 1, Adjacency: []uint32{1}},
+		{ID: []byte("doc-best-neighbor"), Vector: []float32{1, 0}, InvNorm: 1},
+	}
+	d, col, def := publishColumnVectorGraphPhysicalReaderTestAssetWithShapeV2B(t, 2, 1, rows)
+	defer func() { _ = d.Close() }()
+	reader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("openColumnVectorGraphPhysicalRowReader: %v", err)
+	}
+	defer func() { _ = reader.Close() }()
+	attachColumnVectorGraphIndexedScoreSources1969(t, reader, rows)
+
+	indexedResults, indexedStats := searchColumnVectorGraphIndexedScoring1969(t, reader, []float32{1, 0}, columnVectorGraphScoreBatchModeIndexed, 1, 1)
+	if len(indexedResults) != 1 || indexedResults[0].Ordinal != 1 {
+		t.Fatalf("indexed results=%+v want efSearch=1 to expand the entry and find best neighbor", indexedResults)
+	}
+	if indexedStats.Candidates != 2 {
+		t.Fatalf("indexed stats=%+v want entry plus one adjacency candidate", indexedStats)
+	}
+}
+
 func TestColumnVectorGraphIndexedScoringUnsupportedFallback1969(t *testing.T) {
 	rows := []columnVectorGraphAssetRow{
 		{ID: []byte("doc-entry"), Vector: []float32{0, 1, 0}, InvNorm: 1, Adjacency: []uint32{1, 2, 3}},

--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -1390,7 +1390,7 @@ func columnVectorGraphLayer0SearchShouldStop(candidate columnVectorGraphSearchCa
 	if efSearch <= 0 || len(top) < efSearch {
 		return false
 	}
-	return !columnVectorGraphSearchCandidateBetter(candidate, top[len(top)-1])
+	return candidate.score < top[len(top)-1].score
 }
 
 func (r *columnVectorGraphPhysicalRowReader) searchLayer0Wavefront(plan *columnVectorGraphSearchPlan, singleBlockView *columnVectorGraphBlockView, query []float32, queryInvNorm float32, topK int, rowCount int, candidateLimit uint64, wavefrontWidth int, candidateRows typedcolumn.RowSelection, hasCandidateRows bool, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats, wavefrontStats *columnVectorGraphNativeSearchStats, visitedCandidates *uint64, preparedMinimal *columnVectorGraphPreparedMinimalSearchCounters, debugCounters *columnVectorGraphNativeSearchDebugCounters, countLoopEdges bool, loopEdgeVisits *uint64, nextSeed *int) error {
@@ -1860,10 +1860,10 @@ func (r *columnVectorGraphPhysicalRowReader) scoreAndPushFrontierVisited(plan *c
 		score:   score,
 	}
 	if debugCounters != nil {
-		scratch.insertTopDebug(topK, candidate, debugCounters)
-		scratch.pushFrontierDebug(candidate, debugCounters)
-	} else {
-		scratch.insertTop(topK, candidate)
+		if scratch.insertTopDebug(topK, candidate, debugCounters) {
+			scratch.pushFrontierDebug(candidate, debugCounters)
+		}
+	} else if scratch.insertTop(topK, candidate) {
 		scratch.pushFrontier(candidate)
 	}
 	return nil
@@ -1888,10 +1888,10 @@ func (r *columnVectorGraphPhysicalRowReader) scoreAndPushFrontierVisitedTile(pla
 		(*visitedCandidates)++
 		candidate := columnVectorGraphSearchCandidate{ordinal: ordinal, score: scores[i]}
 		if debugCounters != nil {
-			scratch.insertTopDebug(topK, candidate, debugCounters)
-			scratch.pushFrontierDebug(candidate, debugCounters)
-		} else {
-			scratch.insertTop(topK, candidate)
+			if scratch.insertTopDebug(topK, candidate, debugCounters) {
+				scratch.pushFrontierDebug(candidate, debugCounters)
+			}
+		} else if scratch.insertTop(topK, candidate) {
 			scratch.pushFrontier(candidate)
 		}
 	}
@@ -2383,29 +2383,30 @@ func (s *columnVectorGraphNativeSearchScratch) frontierSiftDownDebug(idx int, ca
 	debugCounters.stats.FrontierSiftDownSteps += steps
 }
 
-func (s *columnVectorGraphNativeSearchScratch) insertTop(limit int, candidate columnVectorGraphSearchCandidate) {
+func (s *columnVectorGraphNativeSearchScratch) insertTop(limit int, candidate columnVectorGraphSearchCandidate) bool {
 	if limit <= 0 {
-		return
+		return false
 	}
 	pos := len(s.top)
 	for pos > 0 && columnVectorGraphSearchCandidateBetter(candidate, s.top[pos-1]) {
 		pos--
 	}
 	if pos >= limit {
-		return
+		return false
 	}
 	if len(s.top) < limit {
 		s.top = append(s.top, columnVectorGraphSearchCandidate{})
 	}
 	copy(s.top[pos+1:], s.top[pos:len(s.top)-1])
 	s.top[pos] = candidate
+	return true
 }
 
-func (s *columnVectorGraphNativeSearchScratch) insertTopDebug(limit int, candidate columnVectorGraphSearchCandidate, debugCounters *columnVectorGraphNativeSearchDebugCounters) {
+func (s *columnVectorGraphNativeSearchScratch) insertTopDebug(limit int, candidate columnVectorGraphSearchCandidate, debugCounters *columnVectorGraphNativeSearchDebugCounters) bool {
 	debugCounters.stats.TopKInsertAttempts++
 	if limit <= 0 {
 		debugCounters.stats.TopKInsertRejections++
-		return
+		return false
 	}
 	pos := len(s.top)
 	for pos > 0 && columnVectorGraphSearchCandidateBetter(candidate, s.top[pos-1]) {
@@ -2413,7 +2414,7 @@ func (s *columnVectorGraphNativeSearchScratch) insertTopDebug(limit int, candida
 	}
 	if pos >= limit {
 		debugCounters.stats.TopKInsertRejections++
-		return
+		return false
 	}
 	debugCounters.stats.TopKInsertSuccesses++
 	shiftSteps := len(s.top) - pos
@@ -2426,6 +2427,7 @@ func (s *columnVectorGraphNativeSearchScratch) insertTopDebug(limit int, candida
 	}
 	copy(s.top[pos+1:], s.top[pos:len(s.top)-1])
 	s.top[pos] = candidate
+	return true
 }
 
 func columnVectorGraphSearchCandidateBetter(left, right columnVectorGraphSearchCandidate) bool {

--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -1236,7 +1236,7 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 	}
 	nextSeed := 0
 	if traversalMode == columnVectorGraphNativeSearchTraversalModeWavefront {
-		if err := r.searchLayer0Wavefront(plan, singleBlockView, query, queryInvNorm, topK, rowCount, candidateLimit, wavefrontWidth, candidateRows, hasCandidateRows, scratch, hotStats, &stats, &visitedCandidates, preparedMinimalCounters, debugCounters, countLoopEdges, &loopEdgeVisits, &nextSeed); err != nil {
+		if err := r.searchLayer0Wavefront(plan, singleBlockView, query, queryInvNorm, efSearch, rowCount, candidateLimit, wavefrontWidth, candidateRows, hasCandidateRows, scratch, hotStats, &stats, &visitedCandidates, preparedMinimalCounters, debugCounters, countLoopEdges, &loopEdgeVisits, &nextSeed); err != nil {
 			return nil, stats, err
 		}
 	} else {
@@ -1393,7 +1393,7 @@ func columnVectorGraphLayer0SearchShouldStop(candidate columnVectorGraphSearchCa
 	return candidate.score < top[len(top)-1].score
 }
 
-func (r *columnVectorGraphPhysicalRowReader) searchLayer0Wavefront(plan *columnVectorGraphSearchPlan, singleBlockView *columnVectorGraphBlockView, query []float32, queryInvNorm float32, topK int, rowCount int, candidateLimit uint64, wavefrontWidth int, candidateRows typedcolumn.RowSelection, hasCandidateRows bool, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats, wavefrontStats *columnVectorGraphNativeSearchStats, visitedCandidates *uint64, preparedMinimal *columnVectorGraphPreparedMinimalSearchCounters, debugCounters *columnVectorGraphNativeSearchDebugCounters, countLoopEdges bool, loopEdgeVisits *uint64, nextSeed *int) error {
+func (r *columnVectorGraphPhysicalRowReader) searchLayer0Wavefront(plan *columnVectorGraphSearchPlan, singleBlockView *columnVectorGraphBlockView, query []float32, queryInvNorm float32, retainedCandidateLimit int, rowCount int, candidateLimit uint64, wavefrontWidth int, candidateRows typedcolumn.RowSelection, hasCandidateRows bool, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats, wavefrontStats *columnVectorGraphNativeSearchStats, visitedCandidates *uint64, preparedMinimal *columnVectorGraphPreparedMinimalSearchCounters, debugCounters *columnVectorGraphNativeSearchDebugCounters, countLoopEdges bool, loopEdgeVisits *uint64, nextSeed *int) error {
 	if wavefrontWidth < 2 {
 		return errColumnVectorGraphNativeSearchWavefrontWidthInvalid
 	}
@@ -1420,7 +1420,7 @@ func (r *columnVectorGraphPhysicalRowReader) searchLayer0Wavefront(plan *columnV
 				}
 				*nextSeed = seed + 1
 				visitMarks[seed] = visitEpoch
-				if err := r.scoreAndPushFrontierVisited(plan, singleBlockView, query, queryInvNorm, seed, topK, scratch, stats, visitedCandidates, preparedMinimal, debugCounters, columnVectorGraphNativeSearchScoreContextLayer0Seed); err != nil {
+				if err := r.scoreAndPushFrontierVisited(plan, singleBlockView, query, queryInvNorm, seed, retainedCandidateLimit, scratch, stats, visitedCandidates, preparedMinimal, debugCounters, columnVectorGraphNativeSearchScoreContextLayer0Seed); err != nil {
 					return err
 				}
 				continue
@@ -1437,7 +1437,7 @@ func (r *columnVectorGraphPhysicalRowReader) searchLayer0Wavefront(plan *columnV
 			}
 			*nextSeed = seed + 1
 			visitMarks[seed] = visitEpoch
-			if err := r.scoreAndPushFrontierVisited(plan, singleBlockView, query, queryInvNorm, seed, topK, scratch, stats, visitedCandidates, preparedMinimal, debugCounters, columnVectorGraphNativeSearchScoreContextLayer0Seed); err != nil {
+			if err := r.scoreAndPushFrontierVisited(plan, singleBlockView, query, queryInvNorm, seed, retainedCandidateLimit, scratch, stats, visitedCandidates, preparedMinimal, debugCounters, columnVectorGraphNativeSearchScoreContextLayer0Seed); err != nil {
 				return err
 			}
 			continue
@@ -1502,7 +1502,7 @@ func (r *columnVectorGraphPhysicalRowReader) searchLayer0Wavefront(plan *columnV
 		if len(tile) == 0 {
 			continue
 		}
-		if err := r.scoreAndPushFrontierVisitedTile(plan, singleBlockView, query, queryInvNorm, tile, topK, scratch, stats, visitedCandidates, preparedMinimal, debugCounters, columnVectorGraphNativeSearchScoreContextLayer0Neighbor); err != nil {
+		if err := r.scoreAndPushFrontierVisitedTile(plan, singleBlockView, query, queryInvNorm, tile, retainedCandidateLimit, scratch, stats, visitedCandidates, preparedMinimal, debugCounters, columnVectorGraphNativeSearchScoreContextLayer0Neighbor); err != nil {
 			return err
 		}
 	}

--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -892,7 +892,14 @@ func (s *columnVectorGraphNativeSearchScratch) prepare(rowCount, dimensions, deg
 		frontierCap = topK
 	}
 	s.frontier = resizeColumnVectorGraphNativeCandidateScratch(s.frontier, frontierCap)
-	s.top = resizeColumnVectorGraphNativeCandidateScratch(s.top, topK)
+	topCandidateCap := efSearch
+	if topCandidateCap > rowCount {
+		topCandidateCap = rowCount
+	}
+	if topCandidateCap < topK {
+		topCandidateCap = topK
+	}
+	s.top = resizeColumnVectorGraphNativeCandidateScratch(s.top, topCandidateCap)
 	s.results = resizeColumnVectorGraphNativeResultScratch(s.results, topK)
 	s.idBuffers = resizeColumnVectorGraphNativeIDBuffersScratch(s.idBuffers, topK)
 	s.resultOrder = resizeColumnVectorGraphNativeIntScratch(s.resultOrder, topK)
@@ -1224,7 +1231,7 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 		}
 	}
 	visitMarks[entryOrdinal] = visitEpoch
-	if err := r.scoreAndPushFrontierVisited(plan, singleBlockView, query, queryInvNorm, entryOrdinal, topK, scratch, hotStats, &visitedCandidates, preparedMinimalCounters, debugCounters, columnVectorGraphNativeSearchScoreContextLayer0Seed); err != nil {
+	if err := r.scoreAndPushFrontierVisited(plan, singleBlockView, query, queryInvNorm, entryOrdinal, efSearch, scratch, hotStats, &visitedCandidates, preparedMinimalCounters, debugCounters, columnVectorGraphNativeSearchScoreContextLayer0Seed); err != nil {
 		return nil, stats, err
 	}
 	nextSeed := 0
@@ -1233,7 +1240,7 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 			return nil, stats, err
 		}
 	} else {
-		for visitedCandidates < candidateLimit {
+		for {
 			var candidate columnVectorGraphSearchCandidate
 			var ok bool
 			if debugCounters != nil {
@@ -1242,34 +1249,33 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 				candidate, ok = scratch.popFrontier()
 			}
 			if !ok {
+				if len(scratch.top) >= efSearch {
+					break
+				}
 				seed, ok := columnVectorGraphNextCandidateSeed(nextSeed, rowCount, candidateRows, hasCandidateRows, visitMarks, visitEpoch)
 				if !ok {
 					break
 				}
 				nextSeed = seed + 1
 				visitMarks[seed] = visitEpoch
-				if err := r.scoreAndPushFrontierVisited(plan, singleBlockView, query, queryInvNorm, seed, topK, scratch, hotStats, &visitedCandidates, preparedMinimalCounters, debugCounters, columnVectorGraphNativeSearchScoreContextLayer0Seed); err != nil {
+				if err := r.scoreAndPushFrontierVisited(plan, singleBlockView, query, queryInvNorm, seed, efSearch, scratch, hotStats, &visitedCandidates, preparedMinimalCounters, debugCounters, columnVectorGraphNativeSearchScoreContextLayer0Seed); err != nil {
 					return nil, stats, err
 				}
 				continue
+			}
+			if columnVectorGraphLayer0SearchShouldStop(candidate, scratch.top, efSearch) {
+				break
 			}
 			adjacency, err := r.expandCandidateAdjacencyLayer(plan, singleBlockView, candidate.ordinal, 0, scratch, hotStats, preparedMinimalCounters, debugCounters)
 			if err != nil {
 				return nil, stats, err
 			}
 			if plan.scoreBatchMode.indexedEnabled() {
-				for i := 0; i < len(adjacency) && visitedCandidates < candidateLimit; {
-					remaining := int(candidateLimit - visitedCandidates)
-					if remaining <= 0 {
-						break
-					}
+				for i := 0; i < len(adjacency); {
 					tileCap := len(adjacency) - i
-					if tileCap > remaining {
-						tileCap = remaining
-					}
 					scratch.scoreTileOrdinals = ensureColumnVectorGraphNativeIntScratch(scratch.scoreTileOrdinals, tileCap)
 					tile := scratch.scoreTileOrdinals[:0]
-					for i < len(adjacency) && len(tile) < remaining {
+					for i < len(adjacency) && len(tile) < tileCap {
 						neighborIndex := i
 						neighbor := adjacency[i]
 						i++
@@ -1310,16 +1316,13 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 					if len(tile) == 0 {
 						continue
 					}
-					if err := r.scoreAndPushFrontierVisitedTile(plan, singleBlockView, query, queryInvNorm, tile, topK, scratch, hotStats, &visitedCandidates, preparedMinimalCounters, debugCounters, columnVectorGraphNativeSearchScoreContextLayer0Neighbor); err != nil {
+					if err := r.scoreAndPushFrontierVisitedTile(plan, singleBlockView, query, queryInvNorm, tile, efSearch, scratch, hotStats, &visitedCandidates, preparedMinimalCounters, debugCounters, columnVectorGraphNativeSearchScoreContextLayer0Neighbor); err != nil {
 						return nil, stats, err
 					}
 				}
 				continue
 			}
 			for i, neighbor := range adjacency {
-				if visitedCandidates >= candidateLimit {
-					break
-				}
 				if countLoopEdges {
 					loopEdgeVisits++
 				}
@@ -1352,7 +1355,7 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 					continue
 				}
 				visitMarks[neighborOrdinal] = visitEpoch
-				if err := r.scoreAndPushFrontierVisited(plan, singleBlockView, query, queryInvNorm, neighborOrdinal, topK, scratch, hotStats, &visitedCandidates, preparedMinimalCounters, debugCounters, columnVectorGraphNativeSearchScoreContextLayer0Neighbor); err != nil {
+				if err := r.scoreAndPushFrontierVisited(plan, singleBlockView, query, queryInvNorm, neighborOrdinal, efSearch, scratch, hotStats, &visitedCandidates, preparedMinimalCounters, debugCounters, columnVectorGraphNativeSearchScoreContextLayer0Neighbor); err != nil {
 					return nil, stats, err
 				}
 			}
@@ -1361,6 +1364,9 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 
 	if len(scratch.top) == 0 {
 		return scratch.results, stats, nil
+	}
+	if len(scratch.top) > topK {
+		scratch.top = scratch.top[:topK]
 	}
 	if opts.OmitResultMaterialization {
 		stats.BlockViewHits = plan.hits
@@ -1378,6 +1384,13 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 		return nil, stats, err
 	}
 	return scratch.results, stats, nil
+}
+
+func columnVectorGraphLayer0SearchShouldStop(candidate columnVectorGraphSearchCandidate, top []columnVectorGraphSearchCandidate, efSearch int) bool {
+	if efSearch <= 0 || len(top) < efSearch {
+		return false
+	}
+	return !columnVectorGraphSearchCandidateBetter(candidate, top[len(top)-1])
 }
 
 func (r *columnVectorGraphPhysicalRowReader) searchLayer0Wavefront(plan *columnVectorGraphSearchPlan, singleBlockView *columnVectorGraphBlockView, query []float32, queryInvNorm float32, topK int, rowCount int, candidateLimit uint64, wavefrontWidth int, candidateRows typedcolumn.RowSelection, hasCandidateRows bool, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats, wavefrontStats *columnVectorGraphNativeSearchStats, visitedCandidates *uint64, preparedMinimal *columnVectorGraphPreparedMinimalSearchCounters, debugCounters *columnVectorGraphNativeSearchDebugCounters, countLoopEdges bool, loopEdgeVisits *uint64, nextSeed *int) error {

--- a/TreeDB/collections/column_vector_graph_search_test.go
+++ b/TreeDB/collections/column_vector_graph_search_test.go
@@ -369,8 +369,8 @@ func TestColumnVectorGraphNativeSearchUsesBestFirstFrontierV3(t *testing.T) {
 	if len(got) != 1 || got[0].Ordinal != 4 || string(got[0].ID) != "doc-best" {
 		t.Fatalf("results=%+v want best-first traversal to reach doc-best before lower-score branch", got)
 	}
-	if stats.Candidates != 4 || stats.CandidateFetches != 4 || stats.ScoreBatches != 4 || stats.ExpansionFetches != stats.AdjacencyExpansions {
-		t.Fatalf("stats=%+v want four scored candidates plus lazy adjacency expansion fetches", stats)
+	if stats.Candidates != 5 || stats.CandidateFetches != 5 || stats.ScoreBatches != 5 || stats.ExpansionFetches != stats.AdjacencyExpansions {
+		t.Fatalf("stats=%+v want five scored candidates plus lazy adjacency expansion fetches", stats)
 	}
 	if readerStats := reader.Stats(); readerStats.RowFetches != 0 || readerStats.BatchFetches != 0 || readerStats.RowsFetched != 0 {
 		t.Fatalf("reader stats=%+v want no generic row fetches for scoring or result IDs stats=%+v", readerStats, stats)

--- a/TreeDB/collections/column_vector_graph_wavefront_1981_test.go
+++ b/TreeDB/collections/column_vector_graph_wavefront_1981_test.go
@@ -197,6 +197,41 @@ func TestColumnVectorGraphWavefrontOptions1981(t *testing.T) {
 	}
 }
 
+func TestColumnVectorGraphWavefrontRetainsEfFrontierBreadth1981(t *testing.T) {
+	if !columnGraphTypedColumnMmapDirectViewSupportedForTest() {
+		t.Skip("wavefront ef-frontier regression requires mmap_direct prepared typed-column views")
+	}
+	shape := columnVectorGraphSearchTopologyParityShape2091{rows: 6, dims: 2, degree: 3, topK: 1, efSearch: 5, queryOrdinal: 5}
+	rows := []columnVectorGraphAssetRow{
+		{ID: []byte("doc-entry"), Vector: []float32{0.8, 0.6}, Adjacency: []uint32{1, 2, 3}},
+		{ID: []byte("doc-bridge-outside-topk"), Vector: []float32{0.5, 0.8660254}, Adjacency: []uint32{5}},
+		{ID: []byte("doc-decoy"), Vector: []float32{0.7, 0.71414286}},
+		{ID: []byte("doc-filler"), Vector: []float32{0.4, 0.9165151}},
+		{ID: []byte("doc-seed-filler"), Vector: []float32{0.3, 0.9539392}},
+		{ID: []byte("doc-best"), Vector: []float32{1, 0}},
+	}
+	closeFn, reader, query := openColumnVectorGraphSearchTopologyParityReader2091(t, shape, rows, columnVectorGraphSearchTopologyParityModeCurrentPrepared2091)
+	defer closeFn()
+
+	var scratch columnVectorGraphNativeSearchScratch
+	got, stats, err := reader.SearchCosine(query, columnVectorGraphNativeSearchOptions{
+		TopK:           shape.topK,
+		EfSearch:       shape.efSearch,
+		ScoreBatchMode: columnVectorGraphScoreBatchModeIndexed,
+		TraversalMode:  columnVectorGraphNativeSearchTraversalModeWavefront,
+		WavefrontWidth: 3,
+	}, &scratch)
+	if err != nil {
+		t.Fatalf("wavefront SearchCosine: %v", err)
+	}
+	if len(got) != 1 || got[0].Ordinal != 5 {
+		t.Fatalf("wavefront results=%+v want bridge outside topK retained under efSearch to reach best ordinal 5", got)
+	}
+	if stats.Candidates != uint64(shape.efSearch) || stats.WavefrontCandidatePops < 2 {
+		t.Fatalf("wavefront stats=%+v want efSearch-scored candidates and multiple frontier pops", stats)
+	}
+}
+
 func TestColumnVectorGraphWavefrontProcessesPartialWaveBeforeSeeding1981(t *testing.T) {
 	if !columnGraphTypedColumnMmapDirectViewSupportedForTest() {
 		t.Skip("partial-wave regression requires mmap_direct prepared typed-column views")

--- a/cmd/treedb_vector_search_demo/main_test.go
+++ b/cmd/treedb_vector_search_demo/main_test.go
@@ -208,8 +208,8 @@ func TestExecuteColumnGraphRecallBenchmarkShape(t *testing.T) {
 	if res.Validation.Recall < 0.95 {
 		t.Fatalf("recall=%f want >=0.95", res.Validation.Recall)
 	}
-	if res.Search.AvgCandidates != 128 {
-		t.Fatalf("avg candidates=%f want ef_search=128", res.Search.AvgCandidates)
+	if res.Search.AvgCandidates < float64(res.EfSearch) {
+		t.Fatalf("avg candidates=%f want at least ef_search=%d", res.Search.AvgCandidates, res.EfSearch)
 	}
 }
 


### PR DESCRIPTION
## Objective

Fix TreeDB column-graph HNSW recall quality by making layer-0 search use HNSW `efSearch` semantics instead of treating `efSearch` as a hard scored-node budget.

## Context

Large comparison runs showed TreeDB's in-memory/native HNSW graph had high recall, while the persisted column-graph search over the same build was much lower (0.8562 vs 0.9984 recall@10). The column-graph layer-0 loop was stopping after scoring `efSearch` candidates; HNSW `efSearch` should bound the candidate/result set used for frontier termination, not prevent scoring the full adjacency of an expanded candidate.

## Non-goals

- No wavefront/public relaxed traversal change.
- No graph-build/topology rewrite in this PR.
- No storage format or durable metadata change.
- No pgvector-specific behavior.

## Design

- **Retained candidate set**: sized to normalized `efSearch` (not `topK`); truncated back to `topK` only at result materialization time.
- **Full adjacency scoring**: exact/default layer-0 traversal scores full adjacency expansions without truncating at the remaining `efSearch` budget.
- **Strict score-only stop condition**: layer-0 traversal terminates only when the best frontier candidate's score is strictly worse than the worst retained ef candidate's score (no ordinal tiebreak in the stop check), ensuring equal-score frontier candidates are still expanded.
- **Frontier gated on retention**: scored neighbors are pushed into the frontier only when accepted into the retained ef set (`insertTop`/`insertTopDebug` return whether the candidate was retained), preventing unbounded rejected-candidate frontier heap growth.
- **Wavefront ef breadth**: wavefront seed/tile scoring uses the normalized `efSearch` retained-candidate limit (not `topK`) to preserve frontier breadth for bridge candidates outside `topK`.
- **`avg_candidates` semantics**: `avg_candidates` counter now reflects total scored candidates, which can exceed the retained ef set size.

## Scope

- Includes: `TreeDB/collections/column_vector_graph_search.go`, `TreeDB/collections/column_vector_graph_indexed_scoring_test.go`, `TreeDB/collections/column_vector_graph_wavefront_1981_test.go`, `cmd/treedb_vector_search_demo`
- Excludes: graph build/topology, storage format, pgvector integration, upper-layer search, wavefront public API

## Correctness

- Tests run (exact commands):

```sh
GOWORK=off go test ./TreeDB/collections \
  -run 'TestColumnVectorGraph(WavefrontRetainsEfFrontierBreadth1981|IndexedScoringEfOneExpandsEntry1969|IndexedScoringTieAndApplicationOrder1969)' \
  -count=1

GOWORK=off go test ./TreeDB/collections -count=1

GOWORK=off go test ./cmd/treedb_vector_search_demo -count=1
```

- Corruption/edge cases covered:
  - `efSearch=1` entry-expansion: `TestColumnVectorGraphIndexedScoringEfOneExpandsEntry1969` — verifies entry candidate is still expanded when ef set is full on the first scored node.
  - Tie/application order: `TestColumnVectorGraphIndexedScoringTieAndApplicationOrder1969` — updated to assert full adjacency scoring under an ef cap.
  - Wavefront bridge candidate breadth: `TestColumnVectorGraphWavefrontRetainsEfFrontierBreadth1981` — bridge candidate outside `topK` must remain expandable under `efSearch`.
  - `avg_candidates` expectation updated in demo harness: scored candidates can exceed the retained ef set size.

## Performance

- Benchmarks run (exact commands):

```sh
GOWORK=off go test ./TreeDB/collections \
  -run '^$' \
  -bench '^BenchmarkColumnVectorGraphNativeSearchCosineTypedColumnStatsMode2042/minimal$' \
  -benchtime=1s -count=1 -benchmem
```

- Results table:

Artifact: `/tmp/vector_recall_fix_core_bench3.txt`

Microbench: `23269 ns/op` (`42976 ops/sec`), `0 B/op`, `0 allocs/op`.

| Backend | Docs/dims | efSearch | Recall@10 | Search c=1 | Search c=2 |
| --- | ---: | ---: | ---: | ---: | ---: |
| TreeDB column-store graph HNSW (before) | 100k / 128 | 128 | `0.8562` | `73us` | `119us` |
| TreeDB column-store graph HNSW (after) | 100k / 128 | 128 | `0.9875` | `869us` | `856us` |
| PostgreSQL+pgvector HNSW | 100k / 128 | 128 | `0.9875` | `5.68ms` | `3.68ms` |

- Regressions: search latency increases from ~41–73 µs to ~869 µs at c=1 (100k/128-dim). This is intentional: the previous shallow traversal was unrealistically fast and produced poor recall. The column-graph path remains significantly faster than pgvector while achieving equivalent recall.

## Rollout / Toggle Plan

- Default setting: corrected semantics are always active; no toggle needed (this is a correctness fix, not a feature flag).
- How to disable quickly: revert `column_vector_graph_search.go` to prior `visitedCandidates < candidateLimit` guard (not recommended; restores broken recall).

## Follow-ups

- Broader recall regression suite against larger datasets.
- Quantized-path recall validation at the same efSearch levels.

## Column Graph Native Workstream (#1646, if applicable)

### Copied/Adapted From Old Stack

- Copied: N/A
- Adapted: N/A
- Oracle/comparator only: N/A
- Quarantined/not copied: N/A

### Path Identity

- Native reader: column-graph layer-0 search path
- Decoded comparator: N/A
- Legacy/native vector index: column-store graph HNSW
- Unsupported/fail-closed: N/A

### Base And Dependency State

- Base branch: main
- Base commit: latest origin/main at time of rebase
- Base PR/head: N/A
- #1621/#1634 assumptions: none
- Missing generic column-store primitives: none
- Parent review fixes propagated: yes (stop-condition and frontier-gating fixes from review)

### Evidence

- Tests: focused regression suite passed (see Correctness above)
- Benchmarks: 23269 ns/op, 0 B/op, 0 allocs/op (see Performance above)
- Status/fallback proof: demo harness passes with updated avg_candidates expectation
- Performance attribution: latency increase is fully attributable to correct full-adjacency traversal
- Local regressions found/fixed: none

### Test Plan Start

- Milestone tasks targeted: column-graph HNSW recall correctness
- Tests to add before or with implementation: efSearch=1 expansion, tie/order, wavefront breadth, avg_candidates semantics
- Existing tests to preserve: all existing TestColumnVectorGraph* tests
- #1646 test-list changes made before implementation: none

### Performance Plan Start

- Relevant benchmarks/metrics: BenchmarkColumnVectorGraphNativeSearchCosineTypedColumnStatsMode2042/minimal
- Baseline/comparator command: pgvector recall probe
- Expected setup/search/materialization boundary: search latency dominated by full adjacency scoring
- Upstream costs explicitly out of scope: pgvector latency
- Local performance risks to watch: frontier heap growth (addressed by retention gating)

### Test Plan Close

- Additional tests found during implementation/review: `TestColumnVectorGraphWavefrontRetainsEfFrontierBreadth1981` (wavefront bridge candidate breadth)
- Tests added or changed: 3 new regression tests; demo avg_candidates expectation updated
- Failing tests fixed: demo harness avg_candidates expectation
- #1646 test-list changes made at close: none
- Residual untested gaps, if any: none known

### Performance Plan Close

- Benchmark commands run: see Performance section
- Results summary: 23269 ns/op, 42976 ops/sec, 0 B/op, 0 allocs/op; recall@10 0.9875
- Before/after or baseline comparison: recall improved from 0.8562 to 0.9875; latency increased from ~73 µs to ~869 µs (intentional correctness trade-off)
- Local slow/heavy code found and fixed: unbounded rejected-candidate frontier heap growth (fixed by gating pushes on retention)
- Remaining upstream or deferred costs: none

### AI Review Loop

- Codex latest-head review: requested and addressed (wavefront ef breadth, stop-condition strictness, frontier gating)
- Copilot latest-head review: requested; reviewed HEAD a227c8f — no new issues found
- CodeRabbit latest-head review: requested
- Review comments/threads resolved or explicitly dismissed: all resolved (stop-condition ordinal tiebreak, frontier heap growth)
- Re-requested after final meaningful push: yes

---

## Optimization PR Checklist (TreeDB)

### Scope
- [x] Single, clear objective for this PR (not a bundle)
- [x] Explicit include list (files/symbols touched): `column_vector_graph_search.go`, `column_vector_graph_indexed_scoring_test.go`, `column_vector_graph_wavefront_1981_test.go`, demo harness
- [x] Explicit exclude list (files/symbols NOT touched): graph build, storage format, pgvector, upper-layer search
- [x] No unwanted feature reintroduction (e.g. async slab writer, hard zones, ValueIndex) unless explicitly stated in the PR objective

### Safety / Correctness
- [ ] Clear written-vs-durable semantics for any `*Sync` path touched
- [ ] No new mmap usage on mutable/truncating files
- [x] All new length fields are capped before allocation (OOM-safe)
- [ ] CRC/checksum behavior is fail-closed (clean error, no panic)
- [ ] Any concurrency change has a defined state machine and invariants

### Tests
- [x] Added deterministic regression tests for the targeted failure mode
- [x] Tests avoid sleeps where possible (use latches/hooks)
- [ ] Added corruption/edge-case tests (truncation, bad headers, invalid lengths) when format/parsing changes
- [x] Ran locally:
  - [x] `go test ./... -count=1`
  - [x] Any targeted packages/benchmarks: see Correctness and Performance sections

### Benchmarks / Measurements
- [x] Added or updated a benchmark relevant to the change
- [x] Reported results in PR description (before/after, command, machine)
- [ ] Included "incompressible" (worst-case) results if compression is involved

### Docs
- [ ] Updated `docs/OPT_SPRINT_NEXT.md` milestone status (if applicable)
- [ ] Documented any new config knobs + defaults
- [ ] Called out any format change in PR description (pre-alpha OK)

### Rollout / Toggle Plan (if behavior-affecting)
- [x] Safe defaults (feature off or conservative threshold)
- [x] Clear knobs to disable/revert behavior quickly
- [ ] Observability: counters/logs to verify effectiveness