### PR TITLE
TreeDB: bound CompactStorage leaf-pack debt

### DIFF
--- a/TreeDB/db/compact_storage.go
+++ b/TreeDB/db/compact_storage.go
@@ -276,18 +276,7 @@ func (db *DB) compactStorage(ctx context.Context, opts CompactStorageOptions) (C
 		if err := db.runCompactStoragePhase(&stats, phaseName, func() error {
 			var err error
 			protectedRootIDs, protectedSystemRootIDs := db.compactStorageLeafGenerationProtectedRootIDPair(opts)
-			pack, err = db.leafGenerationPackRunOnce(ctx, LeafGenerationPackFromPlanOptions{
-				Sync:                       opts.SyncEachPhase,
-				MinExpectedReclaimBytes:    opts.LeafPackMinExpectedReclaimBytes,
-				MinExpectedReclaimRatioPPM: opts.LeafPackMinExpectedReclaimRatioPPM,
-				MinReclaimPerByteCopiedPPM: opts.LeafPackMinReclaimPerCopyPPM,
-				MaxGenerations:             opts.LeafPackMaxGenerationsPerPass,
-				MaxBytesToCopy:             opts.LeafPackMaxBytesToCopyPerPass,
-				ReserveRIDs:                opts.ReserveRIDs,
-				LeafFrameK:                 opts.LeafPackLeafFrameK,
-				ProtectedRootIDs:           protectedRootIDs,
-				ProtectedSystemRootIDs:     protectedSystemRootIDs,
-			}, !maintenanceLocked)
+			pack, err = db.leafGenerationPackRunOnce(ctx, compactStorageLeafPackFromPlanOptions(opts, protectedRootIDs, protectedSystemRootIDs), !maintenanceLocked)
 			return err
 		}); err != nil {
 			return stats, err
@@ -528,6 +517,43 @@ func compactStorageRewritePlanOptions(protectedPaths []string) ValueLogRewriteOn
 	}
 }
 
+func compactStorageLeafPackFromPlanOptions(opts CompactStorageOptions, protectedRootIDs, protectedSystemRootIDs []uint64) LeafGenerationPackFromPlanOptions {
+	out := LeafGenerationPackFromPlanOptions{
+		Sync:                       opts.SyncEachPhase,
+		MinExpectedReclaimBytes:    opts.LeafPackMinExpectedReclaimBytes,
+		MinExpectedReclaimRatioPPM: opts.LeafPackMinExpectedReclaimRatioPPM,
+		MinReclaimPerByteCopiedPPM: opts.LeafPackMinReclaimPerCopyPPM,
+		MaxGenerations:             opts.LeafPackMaxGenerationsPerPass,
+		MaxBytesToCopy:             opts.LeafPackMaxBytesToCopyPerPass,
+		ReserveRIDs:                opts.ReserveRIDs,
+		LeafFrameK:                 normalizeLeafGenerationPackLeafFrameK(opts.LeafPackLeafFrameK),
+		ProtectedRootIDs:           protectedRootIDs,
+		ProtectedSystemRootIDs:     protectedSystemRootIDs,
+	}
+	if out.MinExpectedReclaimBytes == 0 && out.MinExpectedReclaimRatioPPM == 0 && out.MinReclaimPerByteCopiedPPM == 0 {
+		out.MinReclaimPerByteCopiedPPM = leafGenerationPackDefaultMinReclaimPerByteCopiedPPM
+	}
+	return out
+}
+
+func compactStorageLeafPackDebtFromPlan(plan LeafGenerationPlan, opts LeafGenerationPackFromPlanOptions) (int, int64, error) {
+	if plan.Admission != leafGenerationPlanAdmissionEligible || len(plan.Candidates) == 0 {
+		return 0, 0, nil
+	}
+	selection, err := SelectLeafGenerationPackCandidates(plan, leafGenerationPackFromPlanSelectOptions(opts))
+	if err != nil {
+		if compactStorageLeafPackSelectionErrorMeansNoDebt(err) {
+			return 0, 0, nil
+		}
+		return len(plan.Candidates), plan.ExpectedReclaimBytes, nil
+	}
+	return len(selection.GenerationIDs), selection.ExpectedReclaimBytes, nil
+}
+
+func compactStorageLeafPackSelectionErrorMeansNoDebt(err error) bool {
+	return errors.Is(err, errLeafGenerationPackSelectionThreshold)
+}
+
 func (db *DB) populateCompactStorageAudit(ctx context.Context, opts CompactStorageOptions, stats *CompactStorageStats, lockMaintenance bool, fencedIDsOut *[]uint32) (CompactStorageDebt, error) {
 	var debt CompactStorageDebt
 	protectedPaths := compactStorageFencedValueLogProtectedPaths(opts)
@@ -560,21 +586,18 @@ func (db *DB) populateCompactStorageAudit(ctx context.Context, opts CompactStora
 	debt.ValueLogGCBytes += fencedValueLogBytes
 
 	protectedRootIDs, protectedSystemRootIDs := db.compactStorageLeafGenerationProtectedRootIDPair(opts)
-	leafPlan, err := db.LeafGenerationPlan(ctx, LeafGenerationPlanOptions{
-		MinExpectedReclaimBytes:    opts.LeafPackMinExpectedReclaimBytes,
-		MinExpectedReclaimRatioPPM: opts.LeafPackMinExpectedReclaimRatioPPM,
-		MinReclaimPerByteCopiedPPM: opts.LeafPackMinReclaimPerCopyPPM,
-		ProtectedRootIDs:           protectedRootIDs,
-		ProtectedSystemRootIDs:     protectedSystemRootIDs,
-	})
+	leafPackOpts := compactStorageLeafPackFromPlanOptions(opts, protectedRootIDs, protectedSystemRootIDs)
+	leafPlan, err := db.LeafGenerationPlan(ctx, leafGenerationPackFromPlanPlanOptions(leafPackOpts))
 	if err != nil {
 		return debt, err
 	}
 	stats.LeafGenerationPlan = leafPlan
-	if leafPlan.Admission == leafGenerationPlanAdmissionEligible {
-		debt.LeafPackGenerations = len(leafPlan.Candidates)
-		debt.LeafPackBytes = leafPlan.ExpectedReclaimBytes
+	leafPackGenerations, leafPackBytes, err := compactStorageLeafPackDebtFromPlan(leafPlan, leafPackOpts)
+	if err != nil {
+		return debt, err
 	}
+	debt.LeafPackGenerations = leafPackGenerations
+	debt.LeafPackBytes = leafPackBytes
 
 	protectedRootIDs, protectedSystemRootIDs = db.compactStorageLeafGenerationProtectedRootIDPair(opts)
 	leafGC, err := db.leafGenerationGC(ctx, LeafGenerationGCOptions{

--- a/TreeDB/db/compact_storage_test.go
+++ b/TreeDB/db/compact_storage_test.go
@@ -1091,6 +1091,182 @@ func TestCompactStorageLeafGenerationProtectedRootIDPairMergesSourcesOnce(t *tes
 	}
 }
 
+func TestCompactStorageReportsAndCompactsSelectableLeafPackDebt(t *testing.T) {
+	d, leafLog, _ := openLeafGenerationPackTestDB(t)
+
+	writeLeafGenerationKeys(t, d, "k", 2048, 'a')
+	if err := leafLog.rotateLeaf(); err != nil {
+		t.Fatalf("rotateLeaf: %v", err)
+	}
+	writeLeafGenerationKeyRange(t, d, "k", 0, 1024, 'b')
+	writeLeafGenerationKeys(t, d, "z", 32, 'z')
+	d.SetLeafPageLog(nil)
+
+	plan, err := d.CompactStoragePlan(context.Background(), CompactStorageOptions{})
+	if err != nil {
+		t.Fatalf("CompactStoragePlan: %v", err)
+	}
+	if got := plan.RemainingDebt.LeafPackGenerations; got == 0 {
+		t.Fatalf("LeafPackGenerations=%d want selectable debt, plan=%+v debt=%+v", got, plan.LeafGenerationPlan, plan.RemainingDebt)
+	}
+	if got := plan.LeafGenerationPlan.ExpectedReclaimPerByteCopiedPPM; got < leafGenerationPackDefaultMinReclaimPerByteCopiedPPM {
+		t.Fatalf("test setup produced low-yield plan per-copy=%d, want >= %d", got, leafGenerationPackDefaultMinReclaimPerByteCopiedPPM)
+	}
+
+	stats, err := d.CompactStorage(context.Background(), CompactStorageOptions{LeafPackMaxPasses: 4})
+	if err != nil {
+		t.Fatalf("CompactStorage: %v", err)
+	}
+	if len(stats.LeafGenerationPacks) == 0 || !stats.LeafGenerationPacks[0].Ran {
+		t.Fatalf("expected first leaf-generation pack to run, packs=%+v", stats.LeafGenerationPacks)
+	}
+	if stats.RemainingDebt.LeafPackGenerations != 0 || stats.RemainingDebt.LeafPackBytes != 0 {
+		t.Fatalf("remaining leaf-pack debt=%+v, want none", stats.RemainingDebt)
+	}
+	if !stats.FullyCompacted {
+		t.Fatalf("FullyCompacted=false remaining debt=%+v", stats.RemainingDebt)
+	}
+}
+
+func TestCompactStoragePlanSkipsLowYieldLeafPackDebtByDefault(t *testing.T) {
+	d, leafLog, _ := openLeafGenerationPackTestDB(t)
+
+	writeLeafGenerationKeys(t, d, "k", 32768, 'a')
+	if err := leafLog.rotateLeaf(); err != nil {
+		t.Fatalf("rotateLeaf: %v", err)
+	}
+	writeLeafGenerationKeyRange(t, d, "k", 0, 1, 'b')
+	d.SetLeafPageLog(nil)
+
+	plan, err := d.CompactStoragePlan(context.Background(), CompactStorageOptions{})
+	if err != nil {
+		t.Fatalf("CompactStoragePlan: %v", err)
+	}
+	if plan.LeafGenerationPlan.ExpectedReclaimBytes <= 0 || len(plan.LeafGenerationPlan.Candidates) == 0 {
+		t.Fatalf("test setup produced no raw leaf-pack candidate: plan=%+v", plan.LeafGenerationPlan)
+	}
+	if got := plan.LeafGenerationPlan.ExpectedReclaimPerByteCopiedPPM; got >= leafGenerationPackDefaultMinReclaimPerByteCopiedPPM {
+		t.Fatalf("test setup per-copy=%d, want below default %d", got, leafGenerationPackDefaultMinReclaimPerByteCopiedPPM)
+	}
+	if got := plan.RemainingDebt.LeafPackGenerations; got != 0 {
+		t.Fatalf("low-yield LeafPackGenerations=%d want 0, plan=%+v debt=%+v", got, plan.LeafGenerationPlan, plan.RemainingDebt)
+	}
+	if got := plan.RemainingDebt.LeafPackBytes; got != 0 {
+		t.Fatalf("low-yield LeafPackBytes=%d want 0, plan=%+v debt=%+v", got, plan.LeafGenerationPlan, plan.RemainingDebt)
+	}
+
+	stats, err := d.CompactStorage(context.Background(), CompactStorageOptions{LeafPackMaxPasses: 1})
+	if err != nil {
+		t.Fatalf("CompactStorage: %v", err)
+	}
+	if len(stats.LeafGenerationPacks) == 0 || stats.LeafGenerationPacks[0].Ran {
+		t.Fatalf("expected low-yield leaf pack to skip, packs=%+v", stats.LeafGenerationPacks)
+	}
+	if !stats.FullyCompacted {
+		t.Fatalf("FullyCompacted=false for low-yield residual, remaining debt=%+v", stats.RemainingDebt)
+	}
+}
+
+func TestCompactStoragePlanLeafPackDebtUsesBoundedSelection(t *testing.T) {
+	d, leafLog, _ := openLeafGenerationPackTestDB(t)
+
+	writeLeafGenerationKeys(t, d, "dense", 32768, 'a')
+	if err := leafLog.rotateLeaf(); err != nil {
+		t.Fatalf("rotateLeaf dense: %v", err)
+	}
+	writeLeafGenerationKeyRange(t, d, "dense", 0, 1, 'b')
+
+	writeLeafGenerationKeys(t, d, "sparse", 2048, 'c')
+	if err := leafLog.rotateLeaf(); err != nil {
+		t.Fatalf("rotateLeaf sparse: %v", err)
+	}
+	writeLeafGenerationKeyRange(t, d, "sparse", 0, 1024, 'd')
+	d.SetLeafPageLog(nil)
+
+	const minPerCopy = 200000
+	plan, err := d.CompactStoragePlan(context.Background(), CompactStorageOptions{
+		LeafPackMaxGenerationsPerPass: 1,
+		LeafPackMinReclaimPerCopyPPM:  minPerCopy,
+	})
+	if err != nil {
+		t.Fatalf("CompactStoragePlan: %v", err)
+	}
+	if got := plan.LeafGenerationPlan.ExpectedReclaimPerByteCopiedPPM; got >= minPerCopy {
+		t.Fatalf("test setup whole-plan per-copy=%d, want below %d to prove bounded selection", got, minPerCopy)
+	}
+	if got := plan.RemainingDebt.LeafPackGenerations; got != 1 {
+		t.Fatalf("bounded selection LeafPackGenerations=%d want 1, plan=%+v debt=%+v", got, plan.LeafGenerationPlan, plan.RemainingDebt)
+	}
+	if got := plan.RemainingDebt.LeafPackBytes; got <= 0 {
+		t.Fatalf("bounded selection LeafPackBytes=%d want >0, debt=%+v", got, plan.RemainingDebt)
+	}
+}
+
+func TestCompactStorageStopsLeafPackOnLowYieldResidualWithinPassBudget(t *testing.T) {
+	d, leafLog, _ := openLeafGenerationPackTestDB(t)
+
+	writeLeafGenerationKeys(t, d, "dense", 32768, 'a')
+	if err := leafLog.rotateLeaf(); err != nil {
+		t.Fatalf("rotateLeaf dense: %v", err)
+	}
+	writeLeafGenerationKeyRange(t, d, "dense", 0, 1, 'b')
+
+	writeLeafGenerationKeys(t, d, "sparse", 2048, 'c')
+	if err := leafLog.rotateLeaf(); err != nil {
+		t.Fatalf("rotateLeaf sparse: %v", err)
+	}
+	writeLeafGenerationKeyRange(t, d, "sparse", 0, 1024, 'd')
+	d.SetLeafPageLog(nil)
+
+	stats, err := d.CompactStorage(context.Background(), CompactStorageOptions{
+		LeafPackMaxPasses:             4,
+		LeafPackMaxGenerationsPerPass: 1,
+		LeafPackMinReclaimPerCopyPPM:  200000,
+	})
+	if err != nil {
+		t.Fatalf("CompactStorage: %v", err)
+	}
+	if len(stats.LeafGenerationPacks) < 2 {
+		t.Fatalf("expected run plus bounded low-yield skip, packs=%+v", stats.LeafGenerationPacks)
+	}
+	if !stats.LeafGenerationPacks[0].Ran {
+		t.Fatalf("first pack did not run: %+v", stats.LeafGenerationPacks[0])
+	}
+	if stats.LeafGenerationPacks[1].Ran || stats.LeafGenerationPacks[1].SkipReason == "" {
+		t.Fatalf("second pack should stop on low-yield residual, packs=%+v", stats.LeafGenerationPacks)
+	}
+	if len(stats.LeafGenerationPacks) > 2 {
+		t.Fatalf("leaf pack did not stop after low-yield residual, packs=%+v", stats.LeafGenerationPacks)
+	}
+	if !stats.FullyCompacted || stats.RemainingDebt.LeafPackGenerations != 0 || stats.RemainingDebt.LeafPackBytes != 0 {
+		t.Fatalf("expected bounded full compaction after low-yield residual, fully=%t debt=%+v", stats.FullyCompacted, stats.RemainingDebt)
+	}
+}
+
+func TestCompactStoragePlanIgnoresEmptyAndCurrentLeafGenerations(t *testing.T) {
+	d, leafLog, _ := openLeafGenerationPackTestDB(t)
+	d.SetLeafPageLog(nil)
+
+	empty, err := d.CompactStoragePlan(context.Background(), CompactStorageOptions{})
+	if err != nil {
+		t.Fatalf("CompactStoragePlan empty: %v", err)
+	}
+	if empty.RemainingDebt.LeafPackGenerations != 0 || empty.RemainingDebt.LeafGCGenerations != 0 {
+		t.Fatalf("empty leaf generation reported debt=%+v", empty.RemainingDebt)
+	}
+
+	d.SetLeafPageLog(leafLog)
+	writeLeafGenerationKeys(t, d, "current", 64, 'z')
+	d.SetLeafPageLog(nil)
+	current, err := d.CompactStoragePlan(context.Background(), CompactStorageOptions{})
+	if err != nil {
+		t.Fatalf("CompactStoragePlan current: %v", err)
+	}
+	if current.RemainingDebt.LeafPackGenerations != 0 || current.RemainingDebt.LeafGCGenerations != 0 {
+		t.Fatalf("current writable leaf generation reported debt=%+v plan=%+v", current.RemainingDebt, current.LeafGenerationPlan)
+	}
+}
+
 func compactStoragePhaseSeen(phases []CompactStoragePhaseStats, name string) bool {
 	for _, phase := range phases {
 		if phase.Name == name {

--- a/TreeDB/db/leaf_generation_pack_from_plan.go
+++ b/TreeDB/db/leaf_generation_pack_from_plan.go
@@ -31,6 +31,17 @@ func leafGenerationPackFromPlanPlanOptions(opts LeafGenerationPackFromPlanOption
 	}
 }
 
+func leafGenerationPackFromPlanSelectOptions(opts LeafGenerationPackFromPlanOptions) LeafGenerationPackSelectOptions {
+	return LeafGenerationPackSelectOptions{
+		Force:                      opts.Force,
+		MinExpectedReclaimBytes:    opts.MinExpectedReclaimBytes,
+		MinExpectedReclaimRatioPPM: opts.MinExpectedReclaimRatioPPM,
+		MaxGenerations:             opts.MaxGenerations,
+		MaxBytesToCopy:             opts.MaxBytesToCopy,
+		MinReclaimPerByteCopiedPPM: opts.MinReclaimPerByteCopiedPPM,
+	}
+}
+
 func leafGenerationPackFromPlanPackOptions(opts LeafGenerationPackFromPlanOptions, generationIDs []uint64) LeafGenerationPackOptions {
 	return LeafGenerationPackOptions{
 		GenerationIDs:              generationIDs,
@@ -54,14 +65,7 @@ func (db *DB) LeafGenerationPackFromPlan(ctx context.Context, opts LeafGeneratio
 	if err != nil {
 		return LeafGenerationPackStats{}, err
 	}
-	selection, err := SelectLeafGenerationPackCandidates(plan, LeafGenerationPackSelectOptions{
-		Force:                      opts.Force,
-		MinExpectedReclaimBytes:    opts.MinExpectedReclaimBytes,
-		MinExpectedReclaimRatioPPM: opts.MinExpectedReclaimRatioPPM,
-		MaxGenerations:             opts.MaxGenerations,
-		MaxBytesToCopy:             opts.MaxBytesToCopy,
-		MinReclaimPerByteCopiedPPM: opts.MinReclaimPerByteCopiedPPM,
-	})
+	selection, err := SelectLeafGenerationPackCandidates(plan, leafGenerationPackFromPlanSelectOptions(opts))
 	if err != nil {
 		return LeafGenerationPackStats{}, err
 	}

--- a/TreeDB/db/leaf_generation_pack_run_once.go
+++ b/TreeDB/db/leaf_generation_pack_run_once.go
@@ -32,13 +32,7 @@ func (db *DB) leafGenerationPackRunOnce(ctx context.Context, opts LeafGeneration
 		stats.SkipReason = fmt.Sprintf("plan_admission:%s", plan.Admission)
 		return stats, nil
 	}
-	selection, err := SelectLeafGenerationPackCandidates(plan, LeafGenerationPackSelectOptions{
-		MinExpectedReclaimBytes:    opts.MinExpectedReclaimBytes,
-		MinExpectedReclaimRatioPPM: opts.MinExpectedReclaimRatioPPM,
-		MaxGenerations:             opts.MaxGenerations,
-		MaxBytesToCopy:             opts.MaxBytesToCopy,
-		MinReclaimPerByteCopiedPPM: opts.MinReclaimPerByteCopiedPPM,
-	})
+	selection, err := SelectLeafGenerationPackCandidates(plan, leafGenerationPackFromPlanSelectOptions(opts))
 	if err != nil {
 		stats.SkipReason = fmt.Sprintf("selection:%v", err)
 		return stats, nil

--- a/TreeDB/db/leaf_generation_pack_select.go
+++ b/TreeDB/db/leaf_generation_pack_select.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 )
@@ -136,6 +137,23 @@ func selectLeafGenerationPackCandidatesBounded(plan LeafGenerationPlan, opts Lea
 	return finalizeLeafGenerationPackSelection(out, opts, rejectedOversize, rejected)
 }
 
+var errLeafGenerationPackSelectionThreshold = errors.New("leaf generation pack selection threshold")
+
+type leafGenerationPackSelectionThresholdErr struct {
+	err error
+}
+
+func (e leafGenerationPackSelectionThresholdErr) Error() string {
+	if e.err == nil {
+		return errLeafGenerationPackSelectionThreshold.Error()
+	}
+	return e.err.Error()
+}
+
+func (e leafGenerationPackSelectionThresholdErr) Unwrap() error {
+	return errLeafGenerationPackSelectionThreshold
+}
+
 type leafGenerationPackSelectionThresholdRejections struct {
 	minBytes   bool
 	minRatio   bool
@@ -169,16 +187,19 @@ func leafGenerationPackSelectionThresholdError(opts LeafGenerationPackSelectOpti
 	if opts.Force {
 		return nil
 	}
+	var err error
 	switch {
 	case opts.MinExpectedReclaimBytes > 0 && rejected.minBytes:
-		return fmt.Errorf("leaf generation pack selection: no candidate generations satisfy min-expected-reclaim-bytes=%d", opts.MinExpectedReclaimBytes)
+		err = fmt.Errorf("leaf generation pack selection: no candidate generations satisfy min-expected-reclaim-bytes=%d", opts.MinExpectedReclaimBytes)
 	case opts.MinExpectedReclaimRatioPPM > 0 && rejected.minRatio:
-		return fmt.Errorf("leaf generation pack selection: no candidate generations satisfy min-expected-reclaim-ratio-ppm=%d", opts.MinExpectedReclaimRatioPPM)
+		err = fmt.Errorf("leaf generation pack selection: no candidate generations satisfy min-expected-reclaim-ratio-ppm=%d", opts.MinExpectedReclaimRatioPPM)
 	case opts.MinReclaimPerByteCopiedPPM > 0 && rejected.minPerCopy:
-		return fmt.Errorf("leaf generation pack selection: no candidate generations satisfy min-reclaim-per-byte-copied-ppm=%d", opts.MinReclaimPerByteCopiedPPM)
-	default:
+		err = fmt.Errorf("leaf generation pack selection: no candidate generations satisfy min-reclaim-per-byte-copied-ppm=%d", opts.MinReclaimPerByteCopiedPPM)
+	}
+	if err == nil {
 		return nil
 	}
+	return leafGenerationPackSelectionThresholdErr{err: err}
 }
 
 func finalizeLeafGenerationPackSelection(out LeafGenerationPackSelection, opts LeafGenerationPackSelectOptions, rejectedOversize bool, rejected leafGenerationPackSelectionThresholdRejections) (LeafGenerationPackSelection, error) {

--- a/TreeDB/db/leaf_generation_pack_select.go
+++ b/TreeDB/db/leaf_generation_pack_select.go
@@ -56,14 +56,18 @@ func SelectLeafGenerationPackCandidates(plan LeafGenerationPlan, opts LeafGenera
 
 func selectLeafGenerationPackCandidatesGreedy(plan LeafGenerationPlan, opts LeafGenerationPackSelectOptions) (LeafGenerationPackSelection, error) {
 	var out LeafGenerationPackSelection
-	rejectedOversize := false
+	rejectedOversizeActionable := false
 	var rejected leafGenerationPackSelectionThresholdRejections
 	for _, gen := range plan.Candidates {
 		if opts.MaxGenerations > 0 && len(out.GenerationIDs) >= opts.MaxGenerations {
 			break
 		}
 		if opts.MaxBytesToCopy > 0 && gen.BytesToCopy > 0 && out.BytesToCopy+gen.BytesToCopy > opts.MaxBytesToCopy {
-			rejectedOversize = true
+			if ok, flags := leafGenerationPackSelectionThresholdsOK(out.BytesDead+gen.BytesDead, out.BytesToCopy+gen.BytesToCopy, opts); ok {
+				rejectedOversizeActionable = true
+			} else {
+				rejected.merge(flags)
+			}
 			continue
 		}
 		if !opts.Force && opts.MinReclaimPerByteCopiedPPM > 0 {
@@ -76,7 +80,7 @@ func selectLeafGenerationPackCandidatesGreedy(plan LeafGenerationPlan, opts Leaf
 		}
 		appendLeafGenerationPackSelection(&out, gen)
 	}
-	return finalizeLeafGenerationPackSelection(out, opts, rejectedOversize, rejected)
+	return finalizeLeafGenerationPackSelection(out, opts, rejectedOversizeActionable, rejected)
 }
 
 func selectLeafGenerationPackCandidatesBounded(plan LeafGenerationPlan, opts LeafGenerationPackSelectOptions) (LeafGenerationPackSelection, error) {
@@ -86,7 +90,8 @@ func selectLeafGenerationPackCandidatesBounded(plan LeafGenerationPlan, opts Lea
 	}
 	frontiers := make([][]leafGenerationPackSelectionState, maxGenerations+1)
 	frontiers[0] = []leafGenerationPackSelectionState{{}}
-	rejectedOversize := false
+	rejectedOversizeActionable := false
+	var rejected leafGenerationPackSelectionThresholdRejections
 	for idx, gen := range plan.Candidates {
 		for selected := maxGenerations - 1; selected >= 0; selected-- {
 			if len(frontiers[selected]) == 0 {
@@ -96,7 +101,11 @@ func selectLeafGenerationPackCandidatesBounded(plan LeafGenerationPlan, opts Lea
 			for _, state := range frontiers[selected] {
 				tentativeCopy := state.bytesToCopy + gen.BytesToCopy
 				if opts.MaxBytesToCopy > 0 && tentativeCopy > opts.MaxBytesToCopy {
-					rejectedOversize = true
+					if ok, flags := leafGenerationPackSelectionThresholdsOK(state.bytesDead+gen.BytesDead, tentativeCopy, opts); ok {
+						rejectedOversizeActionable = true
+					} else {
+						rejected.merge(flags)
+					}
 					continue
 				}
 				indices := append(append([]int(nil), state.indices...), idx)
@@ -113,7 +122,6 @@ func selectLeafGenerationPackCandidatesBounded(plan LeafGenerationPlan, opts Lea
 	var (
 		bestState leafGenerationPackSelectionState
 		haveBest  bool
-		rejected  leafGenerationPackSelectionThresholdRejections
 	)
 	for selected := 1; selected <= maxGenerations; selected++ {
 		for _, state := range frontiers[selected] {
@@ -128,13 +136,13 @@ func selectLeafGenerationPackCandidatesBounded(plan LeafGenerationPlan, opts Lea
 		}
 	}
 	if !haveBest {
-		return finalizeLeafGenerationPackSelection(LeafGenerationPackSelection{}, opts, rejectedOversize, rejected)
+		return finalizeLeafGenerationPackSelection(LeafGenerationPackSelection{}, opts, rejectedOversizeActionable, rejected)
 	}
 	var out LeafGenerationPackSelection
 	for _, idx := range bestState.indices {
 		appendLeafGenerationPackSelection(&out, plan.Candidates[idx])
 	}
-	return finalizeLeafGenerationPackSelection(out, opts, rejectedOversize, rejected)
+	return finalizeLeafGenerationPackSelection(out, opts, rejectedOversizeActionable, rejected)
 }
 
 var errLeafGenerationPackSelectionThreshold = errors.New("leaf generation pack selection threshold")
@@ -206,9 +214,9 @@ func leafGenerationPackSelectionThresholdError(opts LeafGenerationPackSelectOpti
 	return leafGenerationPackSelectionThresholdErr{err: err}
 }
 
-func finalizeLeafGenerationPackSelection(out LeafGenerationPackSelection, opts LeafGenerationPackSelectOptions, rejectedOversize bool, rejected leafGenerationPackSelectionThresholdRejections) (LeafGenerationPackSelection, error) {
+func finalizeLeafGenerationPackSelection(out LeafGenerationPackSelection, opts LeafGenerationPackSelectOptions, rejectedOversizeActionable bool, rejected leafGenerationPackSelectionThresholdRejections) (LeafGenerationPackSelection, error) {
 	if len(out.GenerationIDs) == 0 {
-		if opts.MaxBytesToCopy > 0 && rejectedOversize {
+		if opts.MaxBytesToCopy > 0 && rejectedOversizeActionable {
 			return out, fmt.Errorf("leaf generation pack selection: no candidate generations fit max-bytes-to-copy=%d", opts.MaxBytesToCopy)
 		}
 		if err := leafGenerationPackSelectionThresholdError(opts, rejected); err != nil {
@@ -217,7 +225,7 @@ func finalizeLeafGenerationPackSelection(out LeafGenerationPackSelection, opts L
 		return out, fmt.Errorf("leaf generation pack selection: plan produced no candidate generations within limits")
 	}
 	if ok, thresholdRejected := leafGenerationPackSelectionThresholdsOK(out.BytesDead, out.BytesToCopy, opts); !ok {
-		if opts.MaxBytesToCopy > 0 && rejectedOversize {
+		if opts.MaxBytesToCopy > 0 && rejectedOversizeActionable {
 			return out, fmt.Errorf("leaf generation pack selection: no candidate generations fit max-bytes-to-copy=%d", opts.MaxBytesToCopy)
 		}
 		return out, leafGenerationPackSelectionThresholdError(opts, thresholdRejected)

--- a/TreeDB/db/leaf_generation_pack_select.go
+++ b/TreeDB/db/leaf_generation_pack_select.go
@@ -151,7 +151,11 @@ func (e leafGenerationPackSelectionThresholdErr) Error() string {
 }
 
 func (e leafGenerationPackSelectionThresholdErr) Unwrap() error {
-	return errLeafGenerationPackSelectionThreshold
+	return e.err
+}
+
+func (e leafGenerationPackSelectionThresholdErr) Is(target error) bool {
+	return target == errLeafGenerationPackSelectionThreshold
 }
 
 type leafGenerationPackSelectionThresholdRejections struct {
@@ -204,15 +208,18 @@ func leafGenerationPackSelectionThresholdError(opts LeafGenerationPackSelectOpti
 
 func finalizeLeafGenerationPackSelection(out LeafGenerationPackSelection, opts LeafGenerationPackSelectOptions, rejectedOversize bool, rejected leafGenerationPackSelectionThresholdRejections) (LeafGenerationPackSelection, error) {
 	if len(out.GenerationIDs) == 0 {
-		if err := leafGenerationPackSelectionThresholdError(opts, rejected); err != nil {
-			return out, err
-		}
 		if opts.MaxBytesToCopy > 0 && rejectedOversize {
 			return out, fmt.Errorf("leaf generation pack selection: no candidate generations fit max-bytes-to-copy=%d", opts.MaxBytesToCopy)
+		}
+		if err := leafGenerationPackSelectionThresholdError(opts, rejected); err != nil {
+			return out, err
 		}
 		return out, fmt.Errorf("leaf generation pack selection: plan produced no candidate generations within limits")
 	}
 	if ok, thresholdRejected := leafGenerationPackSelectionThresholdsOK(out.BytesDead, out.BytesToCopy, opts); !ok {
+		if opts.MaxBytesToCopy > 0 && rejectedOversize {
+			return out, fmt.Errorf("leaf generation pack selection: no candidate generations fit max-bytes-to-copy=%d", opts.MaxBytesToCopy)
+		}
 		return out, leafGenerationPackSelectionThresholdError(opts, thresholdRejected)
 	}
 	out.ExpectedReclaimBytes = out.BytesDead

--- a/TreeDB/db/leaf_generation_pack_select_test.go
+++ b/TreeDB/db/leaf_generation_pack_select_test.go
@@ -1,6 +1,9 @@
 package db
 
-import "testing"
+import (
+	"errors"
+	"testing"
+)
 
 func TestSelectLeafGenerationPackCandidates(t *testing.T) {
 	plan := LeafGenerationPlan{
@@ -128,7 +131,7 @@ func TestSelectLeafGenerationPackCandidates_RejectsNonEligiblePlan(t *testing.T)
 	}
 }
 
-func TestSelectLeafGenerationPackCandidates_PrioritizesLowYieldErrorWhenOversizeCandidateWasSkipped(t *testing.T) {
+func TestSelectLeafGenerationPackCandidates_PreservesOversizeDebtWhenRemainingCandidateLowYield(t *testing.T) {
 	plan := LeafGenerationPlan{
 		Admission: leafGenerationPlanAdmissionEligible,
 		Candidates: []LeafGenerationPlanGeneration{
@@ -141,10 +144,35 @@ func TestSelectLeafGenerationPackCandidates_PrioritizesLowYieldErrorWhenOversize
 		MinReclaimPerByteCopiedPPM: 200000,
 	})
 	if err == nil {
+		t.Fatal("expected oversize selection error")
+	}
+	if errors.Is(err, errLeafGenerationPackSelectionThreshold) {
+		t.Fatalf("errors.Is(threshold)=true for mixed oversize/threshold rejection: %v", err)
+	}
+	if got := err.Error(); got != "leaf generation pack selection: no candidate generations fit max-bytes-to-copy=50" {
+		t.Fatalf("error=%q, want oversize no-fit error", got)
+	}
+}
+
+func TestSelectLeafGenerationPackCandidates_ThresholdErrorIsSentinelAndUnwrapsDetail(t *testing.T) {
+	plan := LeafGenerationPlan{
+		Admission: leafGenerationPlanAdmissionEligible,
+		Candidates: []LeafGenerationPlanGeneration{
+			{GenerationID: 7, BytesDead: 5, BytesLive: 95, BytesToCopy: 95},
+		},
+	}
+	_, err := SelectLeafGenerationPackCandidates(plan, LeafGenerationPackSelectOptions{MinReclaimPerByteCopiedPPM: 100000})
+	if err == nil {
 		t.Fatal("expected low-yield selection error")
 	}
-	if got := err.Error(); got != "leaf generation pack selection: no candidate generations satisfy min-reclaim-per-byte-copied-ppm=200000" {
-		t.Fatalf("error=%q, want low-yield selection error", got)
+	if !errors.Is(err, errLeafGenerationPackSelectionThreshold) {
+		t.Fatalf("errors.Is(threshold)=false for %T %v", err, err)
+	}
+	if unwrapped := errors.Unwrap(err); unwrapped == nil || unwrapped == errLeafGenerationPackSelectionThreshold {
+		t.Fatalf("Unwrap()=%v, want underlying detail error", unwrapped)
+	}
+	if got := err.Error(); got != "leaf generation pack selection: no candidate generations satisfy min-reclaim-per-byte-copied-ppm=100000" {
+		t.Fatalf("error=%q, want detailed threshold error", got)
 	}
 }
 

--- a/TreeDB/db/leaf_generation_pack_select_test.go
+++ b/TreeDB/db/leaf_generation_pack_select_test.go
@@ -176,6 +176,46 @@ func TestSelectLeafGenerationPackCandidates_ThresholdErrorIsSentinelAndUnwrapsDe
 	}
 }
 
+func TestSelectLeafGenerationPackCandidates_OversizeLowYieldCandidateIsThresholdDebt(t *testing.T) {
+	plan := LeafGenerationPlan{
+		Admission: leafGenerationPlanAdmissionEligible,
+		Candidates: []LeafGenerationPlanGeneration{
+			{GenerationID: 40, BytesDead: 5, BytesLive: 95, BytesToCopy: 95},
+		},
+	}
+	_, err := SelectLeafGenerationPackCandidates(plan, LeafGenerationPackSelectOptions{
+		MaxBytesToCopy:             50,
+		MinReclaimPerByteCopiedPPM: 100000,
+	})
+	if err == nil {
+		t.Fatal("expected low-yield threshold error")
+	}
+	if !errors.Is(err, errLeafGenerationPackSelectionThreshold) {
+		t.Fatalf("errors.Is(threshold)=false for oversize low-yield candidate: %v", err)
+	}
+}
+
+func TestSelectLeafGenerationPackCandidates_BoundedLowYieldCombinationsRemainThresholdDebt(t *testing.T) {
+	plan := LeafGenerationPlan{
+		Admission: leafGenerationPlanAdmissionEligible,
+		Candidates: []LeafGenerationPlanGeneration{
+			{GenerationID: 41, BytesDead: 5, BytesLive: 45, BytesToCopy: 45},
+			{GenerationID: 42, BytesDead: 5, BytesLive: 45, BytesToCopy: 45},
+		},
+	}
+	_, err := SelectLeafGenerationPackCandidates(plan, LeafGenerationPackSelectOptions{
+		MaxGenerations:             2,
+		MaxBytesToCopy:             50,
+		MinReclaimPerByteCopiedPPM: 500000,
+	})
+	if err == nil {
+		t.Fatal("expected low-yield threshold error")
+	}
+	if !errors.Is(err, errLeafGenerationPackSelectionThreshold) {
+		t.Fatalf("errors.Is(threshold)=false for bounded low-yield copy-bound combinations: %v", err)
+	}
+}
+
 func TestSelectLeafGenerationPackCandidates_PrioritizesOversizeErrorWhenNothingFits(t *testing.T) {
 	plan := LeafGenerationPlan{
 		Admission: leafGenerationPlanAdmissionEligible,


### PR DESCRIPTION
## Objective

Fix #2211 by making TreeDB `CompactStorage` leaf-pack debt reporting match the bounded leaf-pack selection it can actually execute, so tiny low-yield residual leaf-generation candidates do not keep `FullyCompacted` false after compaction has no eligible/profitable leaf-pack work left.

## Context

The 1M full-data JSONBench compacted run could finish load/reconstruction but failed strict compact completion with one tiny residual leaf-pack generation (`861` bytes). Inspection showed this residual is below the default leaf-pack reclaim-per-copy threshold and is not actionable compact debt.

## Non-goals

- No value-log/leaf_vlog deletion by age.
- No public API or on-disk format promotion.
- No default compression changes, #730 gating, or broad lifecycle rewrite.
- No change to value-only `leaf_vlog` vs `value_vlog` lane filtering (#2209).

## Design

- `CompactStorage` now builds one normalized leaf-pack-from-plan option set for both pack execution and audit.
- The compact-only default keeps the existing leaf pack min reclaim-per-copy threshold (`10000` ppm) when no explicit compact leaf-pack threshold is supplied.
- Remaining debt is computed from the bounded selectable leaf-pack window.
- Threshold failures are treated as no actionable compact debt.
- Copy-bound/oversize rejections remain fail-closed as debt only when the rejected candidate/window would satisfy reclaim thresholds; oversize low-yield candidates stay threshold-classified.
- Manual/public `LeafGenerationPackRunOnce` / `LeafGenerationPackFromPlan` zero-value semantics are not broadened; the default threshold is scoped to `CompactStorage`.

## Correctness

Tests run locally:

```sh
GOWORK=off go test ./TreeDB/db -run 'Leaf.*Pack|CompactStorage|ValueOnlyValueLogFiles|ValueLogGC_IgnoresInlineLeafLog' -count=1
GOWORK=off go test ./TreeDB/db -count=1
```

Additional focused review-fix validation:

```sh
GOWORK=off go test ./TreeDB/db -run 'TestSelectLeafGenerationPackCandidates|TestCompactStorage(StopsLeafPackOnLowYieldResidualWithinPassBudget|PlanSkipsLowYieldLeafPackDebtByDefault|ReportsAndCompactsSelectableLeafPackDebt|PlanLeafPackDebtUsesBoundedSelection)|TestValueOnlyValueLogFiles_KeepsReservedLaneInPrimaryValueLog|TestValueLogGC_IgnoresInlineLeafLogWhenDBDefaultUsesPagerLeaves' -count=1
```

## JSONBench evidence

100k compacted smoke/integration passed:

- `/tmp/orca_issue_graph_1945_1955/2211_leafpack_debt/fixed_100k_compacted_20260603_050205/report.json`

1M compacted closeout evidence now passes on latest PR head `92add7fa0`:

```sh
DATA_DIR=$HOME/data/bluesky ROWS=1000000 TRIES=1 PROFILE=durable \
  GOMAP_REPLACE=/Users/michaelseiler/orca/workspaces/gomap/2211-leafpack-debt-manager \
  STORAGE_LAYOUTS=column-store-full-prepared SUITE=full \
  COMPACT_AFTER_LOAD=1 VALIDATE_RECONSTRUCTION=1 \
  OUT_DIR=/tmp/orca_issue_graph_1945_1955/2211_leafpack_debt/fixed_1m_compacted_after_92add7_20260603_061230 \
  ./run_columnstore_benchmark.sh
```

Artifact:

- `/tmp/orca_issue_graph_1945_1955/2211_leafpack_debt/fixed_1m_compacted_after_92add7_20260603_061230/report.json`

Result:

- `storage_measurement_phase=post_maintenance`
- `reconstruction_status=valid`
- `document_scan_fallback=false`
- WAL-excluded durable storage `332,677,034` bytes with `leaf_vlog=166,765,206` bytes counted

## Review / CI

- Codex review findings resolved on latest head.
- Copilot review findings resolved on latest head.
- CodeRabbit: skipped previous draft review; PR is now ready for review.
- GitHub CI passed on head `92add7fa0` before marking ready.

## Rollout / Toggle Plan

Default behavior is conservative: only `CompactStorage` uses the existing 1% leaf-pack reclaim-per-copy floor when no compact-specific threshold is provided. Callers can override `LeafPackMinReclaimPerCopyPPM` in `CompactStorageOptions`.
