### PR TITLE
Optimize TreeDB prepared scalar graph scoring

### DIFF
--- a/TreeDB/collections/column_vector_graph_prepared_indexed_scoring_2098_test.go
+++ b/TreeDB/collections/column_vector_graph_prepared_indexed_scoring_2098_test.go
@@ -18,8 +18,11 @@ func TestColumnVectorGraphPreparedExactIndexedScoringEquivalence2098(t *testing.
 		t.Fatal(mismatch)
 	}
 	assertColumnVectorGraphPreparedExactIndexedWorkStatsEqual2098(t, scalarStats, indexedStats)
-	if indexedStats.ScoreBatchMaxTileSize < 2 || indexedStats.ScoreBatchCalls >= scalarStats.ScoreBatchCalls {
-		t.Fatalf("indexed stats=%+v scalar stats=%+v want exact prepared indexed scoring to preserve work while grouping score batches", indexedStats, scalarStats)
+	if indexedStats.ScoreBatchMaxTileSize < 2 || scalarStats.ScoreBatchMaxTileSize != indexedStats.ScoreBatchMaxTileSize || scalarStats.ScoreBatchCalls != indexedStats.ScoreBatchCalls {
+		t.Fatalf("indexed stats=%+v scalar stats=%+v want exact prepared scoring modes to preserve neighbor-tile topology", indexedStats, scalarStats)
+	}
+	if scalarStats.ScoreBatchOptimizedCalls != 0 || scalarStats.ScoreBatchScalarFallbackCalls != scalarStats.ScoreBatchCalls {
+		t.Fatalf("indexed stats=%+v scalar stats=%+v want scalar mode to use tile fallback backend", indexedStats, scalarStats)
 	}
 	assertColumnVectorGraphPreparedIndexedBackendCounters2125(t, indexedStats.ScoreBatchOptimizedCalls, indexedStats.ScoreBatchScalarFallbackCalls, int(indexedStats.ScoreBatchMaxTileSize), shape.dims)
 }

--- a/TreeDB/collections/column_vector_graph_prepared_search.go
+++ b/TreeDB/collections/column_vector_graph_prepared_search.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 
+	"github.com/snissn/gomap/TreeDB/internal/typeddecode"
 	"github.com/snissn/gomap/TreeDB/internal/vectorops"
 )
 
@@ -367,19 +368,42 @@ func (v *columnVectorGraphPreparedSearchView) scoreOrdinal(plan *columnVectorGra
 	if len(query) != v.dims {
 		return 0, fmt.Errorf("collections: column_graph candidate ordinal=%d vector dims=%d want %d: %w", ordinal, v.dims, len(query), errColumnVectorGraphNativeSearchCandidateDimensionMismatch)
 	}
-	vector, reason, ok := v.vector.vectorForOrdinal(ordinal)
-	if !ok {
-		return 0, fmt.Errorf("collections: column_graph prepared vector ordinal=%d unavailable reason=%s", ordinal, reason)
+	if ordinal < 0 || ordinal >= v.rows || ordinal >= len(v.norm.values) {
+		return 0, fmt.Errorf("collections: column_graph prepared vector ordinal=%d unavailable reason=%s", ordinal, typeddecode.ReasonRowCountMismatch)
 	}
-	invNorm, reason, ok := v.norm.valueForOrdinal(ordinal)
+	if v.norm.source == nil || v.norm.source.closed || (v.norm.source.handle != nil && v.norm.source.handle.Released()) {
+		return 0, fmt.Errorf("collections: column_graph prepared inverse-norm ordinal=%d unavailable reason=%s", ordinal, typeddecode.ReasonStaleHandle)
+	}
+	vector, ok := v.vectorForOrdinalFast(ordinal)
 	if !ok {
-		return 0, fmt.Errorf("collections: column_graph prepared inverse-norm ordinal=%d unavailable reason=%s", ordinal, reason)
+		return 0, fmt.Errorf("collections: column_graph prepared vector ordinal=%d unavailable reason=%s", ordinal, typeddecode.ReasonStaleHandle)
+	}
+	score, err := columnVectorGraphPreparedCosineScore(query, queryInvNorm, ordinal, vector, v.norm.values[ordinal], stats)
+	if err != nil {
+		return 0, err
 	}
 	if stats != nil {
 		recordColumnVectorGraphScoreBatchStats(stats, 1, false, true)
 		v.recordScoreStats(stats, plan, 1)
 		v.recordMappingStats(stats, ordinal)
 	}
+	return score, nil
+}
+
+func (v *columnVectorGraphPreparedSearchView) checkScalarScoreInputs(query []float32, ordinal int) error {
+	if v == nil || !v.ready() {
+		return errors.New("collections: column_graph prepared graph-search view is unavailable")
+	}
+	if len(query) != v.dims {
+		return fmt.Errorf("collections: column_graph candidate ordinal=%d vector dims=%d want %d: %w", ordinal, v.dims, len(query), errColumnVectorGraphNativeSearchCandidateDimensionMismatch)
+	}
+	if v.norm.source == nil || v.norm.source.closed || (v.norm.source.handle != nil && v.norm.source.handle.Released()) {
+		return fmt.Errorf("collections: column_graph prepared inverse-norm ordinal=%d unavailable reason=%s", ordinal, typeddecode.ReasonStaleHandle)
+	}
+	return nil
+}
+
+func columnVectorGraphPreparedCosineScore(query []float32, queryInvNorm float32, ordinal int, vector []float32, invNorm float32, stats *columnVectorGraphNativeSearchStats) (float64, error) {
 	dot := float64(vectorDotProductFloat32(query, vector))
 	if math.IsInf(dot, 0) || math.IsNaN(dot) {
 		if stats != nil {
@@ -392,6 +416,45 @@ func (v *columnVectorGraphPreparedSearchView) scoreOrdinal(plan *columnVectorGra
 		return 0, fmt.Errorf("collections: column_graph candidate ordinal=%d cosine score is not finite", ordinal)
 	}
 	return score, nil
+}
+
+func (v *columnVectorGraphPreparedSearchView) vectorForOrdinalFast(ordinal int) ([]float32, bool) {
+	vector := &v.vector
+	dims := vector.dims
+	if vector.singlePart != nil {
+		part := vector.singlePart
+		if part.handle == nil || part.handle.Released() {
+			return nil, false
+		}
+		row := ordinal
+		if vector.rowIndexByOrdinal != nil {
+			row = int(vector.rowIndexByOrdinal[ordinal])
+		}
+		start := row * dims
+		end := start + dims
+		if row < 0 || row >= part.rows || start < 0 || end < start || end > len(part.values) {
+			return nil, false
+		}
+		return part.values[start:end], true
+	}
+	if ordinal >= len(vector.partIndexByOrdinal) || ordinal >= len(vector.rowIndexByOrdinal) {
+		return nil, false
+	}
+	partIndex := int(vector.partIndexByOrdinal[ordinal])
+	if partIndex < 0 || partIndex >= len(vector.parts) {
+		return nil, false
+	}
+	part := vector.parts[partIndex]
+	if part == nil || part.handle == nil || part.handle.Released() {
+		return nil, false
+	}
+	row := int(vector.rowIndexByOrdinal[ordinal])
+	start := row * dims
+	end := start + dims
+	if row < 0 || row >= part.rows || start < 0 || end < start || end > len(part.values) {
+		return nil, false
+	}
+	return part.values[start:end], true
 }
 
 func (v *columnVectorGraphPreparedSearchView) scoreOrdinals(plan *columnVectorGraphSearchPlan, query []float32, queryInvNorm float32, ordinals []int, dst []float64, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) ([]float64, error) {
@@ -410,12 +473,72 @@ func (v *columnVectorGraphPreparedSearchView) scoreOrdinalsScalar(plan *columnVe
 	} else {
 		dst = dst[:len(ordinals)]
 	}
-	for i, ordinal := range ordinals {
-		score, err := v.scoreOrdinal(plan, query, queryInvNorm, ordinal, stats)
-		if err != nil {
-			return dst[:i], err
+	if len(ordinals) == 0 {
+		return dst, nil
+	}
+	if err := v.checkScalarScoreInputs(query, ordinals[0]); err != nil {
+		return dst[:0], err
+	}
+	vectorView := &v.vector
+	dims := v.dims
+	normValues := v.norm.values
+	if part := vectorView.singlePart; part != nil {
+		if part.handle == nil || part.handle.Released() {
+			return dst[:0], fmt.Errorf("collections: column_graph prepared vector ordinal=%d unavailable reason=%s", ordinals[0], typeddecode.ReasonStaleHandle)
 		}
-		dst[i] = score
+		rowIndexByOrdinal := vectorView.rowIndexByOrdinal
+		for i, ordinal := range ordinals {
+			if ordinal < 0 || ordinal >= v.rows || ordinal >= len(normValues) {
+				return dst[:i], fmt.Errorf("collections: column_graph prepared vector ordinal=%d unavailable reason=%s", ordinal, typeddecode.ReasonRowCountMismatch)
+			}
+			row := ordinal
+			if rowIndexByOrdinal != nil {
+				row = int(rowIndexByOrdinal[ordinal])
+			}
+			start := row * dims
+			end := start + dims
+			if row < 0 || row >= part.rows || start < 0 || end < start || end > len(part.values) {
+				return dst[:i], fmt.Errorf("collections: column_graph prepared vector ordinal=%d unavailable reason=%s", ordinal, typeddecode.ReasonStaleHandle)
+			}
+			score, err := columnVectorGraphPreparedCosineScore(query, queryInvNorm, ordinal, part.values[start:end], normValues[ordinal], stats)
+			if err != nil {
+				return dst[:i], err
+			}
+			dst[i] = score
+		}
+	} else {
+		parts := vectorView.parts
+		partIndexByOrdinal := vectorView.partIndexByOrdinal
+		rowIndexByOrdinal := vectorView.rowIndexByOrdinal
+		for i, ordinal := range ordinals {
+			if ordinal < 0 || ordinal >= v.rows || ordinal >= len(normValues) || ordinal >= len(partIndexByOrdinal) || ordinal >= len(rowIndexByOrdinal) {
+				return dst[:i], fmt.Errorf("collections: column_graph prepared vector ordinal=%d unavailable reason=%s", ordinal, typeddecode.ReasonRowCountMismatch)
+			}
+			partIndex := int(partIndexByOrdinal[ordinal])
+			if partIndex < 0 || partIndex >= len(parts) {
+				return dst[:i], fmt.Errorf("collections: column_graph prepared vector ordinal=%d unavailable reason=%s", ordinal, typeddecode.ReasonStaleHandle)
+			}
+			part := parts[partIndex]
+			if part == nil || part.handle == nil || part.handle.Released() {
+				return dst[:i], fmt.Errorf("collections: column_graph prepared vector ordinal=%d unavailable reason=%s", ordinal, typeddecode.ReasonStaleHandle)
+			}
+			row := int(rowIndexByOrdinal[ordinal])
+			start := row * dims
+			end := start + dims
+			if row < 0 || row >= part.rows || start < 0 || end < start || end > len(part.values) {
+				return dst[:i], fmt.Errorf("collections: column_graph prepared vector ordinal=%d unavailable reason=%s", ordinal, typeddecode.ReasonStaleHandle)
+			}
+			score, err := columnVectorGraphPreparedCosineScore(query, queryInvNorm, ordinal, part.values[start:end], normValues[ordinal], stats)
+			if err != nil {
+				return dst[:i], err
+			}
+			dst[i] = score
+		}
+	}
+	if stats != nil {
+		recordColumnVectorGraphScoreBatchStats(stats, len(ordinals), false, true)
+		v.recordScoreStats(stats, plan, len(ordinals))
+		v.recordMappingStatsCount(stats, len(ordinals))
 	}
 	return dst, nil
 }

--- a/TreeDB/collections/column_vector_graph_promotion_2103_test.go
+++ b/TreeDB/collections/column_vector_graph_promotion_2103_test.go
@@ -214,9 +214,10 @@ func assertColumnVectorGraphDefaultIndexedScoreBatches2103(tb testing.TB, defaul
 	if defaultStats.ScoreBatchCalls != indexedStats.ScoreBatchCalls || defaultStats.ScoreBatchCandidates != indexedStats.ScoreBatchCandidates || defaultStats.ScoreBatchMaxTileSize != indexedStats.ScoreBatchMaxTileSize || defaultStats.ScoreBatchOptimizedCalls != indexedStats.ScoreBatchOptimizedCalls || defaultStats.ScoreBatchScalarFallbackCalls != indexedStats.ScoreBatchScalarFallbackCalls {
 		tb.Fatalf("default stats=%+v indexed stats=%+v want default to select identical indexed prepared score batching", defaultStats, indexedStats)
 	}
-	if defaultStats.ScoreBatchCalls >= scalarStats.ScoreBatchCalls || defaultStats.ScoreBatchMaxTileSize < 2 {
-		tb.Fatalf("default stats=%+v scalar stats=%+v want default indexed grouping", defaultStats, scalarStats)
+	if defaultStats.ScoreBatchCalls != scalarStats.ScoreBatchCalls || defaultStats.ScoreBatchCandidates != scalarStats.ScoreBatchCandidates || defaultStats.ScoreBatchMaxTileSize != scalarStats.ScoreBatchMaxTileSize || defaultStats.ScoreBatchMaxTileSize < 2 {
+		tb.Fatalf("default stats=%+v scalar stats=%+v want prepared scalar and indexed modes to share neighbor-tile grouping", defaultStats, scalarStats)
 	}
+	assertColumnVectorGraphPreparedScalarScoreBatches2103(tb, scalarStats)
 	if defaultStats.ScoreBatchSingletons+defaultStats.ScoreBatchSize2To4+defaultStats.ScoreBatchSize5To8+defaultStats.ScoreBatchSize9To16+defaultStats.ScoreBatchSize17Plus != defaultStats.ScoreBatchCalls {
 		tb.Fatalf("default stats=%+v want score-batch histogram to reconcile", defaultStats)
 	}
@@ -246,14 +247,27 @@ func assertColumnVectorGraphScalarScoreBatches2103(tb testing.TB, stats columnVe
 	}
 }
 
+func assertColumnVectorGraphPreparedScalarScoreBatches2103(tb testing.TB, stats columnVectorGraphNativeSearchStats) {
+	tb.Helper()
+	if stats.ScoreBatchCalls == 0 || stats.ScoreBatchCalls >= stats.ScoreBatchCandidates || stats.ScoreBatchMaxTileSize < 2 || stats.ScoreBatchOptimizedCalls != 0 || stats.ScoreBatchScalarFallbackCalls != stats.ScoreBatchCalls {
+		tb.Fatalf("stats=%+v want prepared scalar neighbor-tile batches with scalar fallback backend", stats)
+	}
+}
+
 func assertColumnVectorGraphSearchPromotionScoreStats2103(tb testing.TB, mode columnVectorGraphSearchTopologyParityMode2091, scoreName string, stats columnVectorGraphNativeSearchStats, dims int) {
 	tb.Helper()
-	if mode == columnVectorGraphSearchTopologyParityModeCurrentPrepared2091 && (scoreName == "default" || scoreName == "indexed") {
-		if stats.ScoreBatchCalls >= stats.ScoreBatchCandidates || stats.ScoreBatchMaxTileSize < 2 {
-			tb.Fatalf("mode=%s score=%s stats=%+v want grouped prepared indexed score batches", mode, scoreName, stats)
+	if mode == columnVectorGraphSearchTopologyParityModeCurrentPrepared2091 {
+		if scoreName == "scalar" {
+			assertColumnVectorGraphPreparedScalarScoreBatches2103(tb, stats)
+			return
 		}
-		assertColumnVectorGraphPreparedIndexedBackendCounters2125(tb, stats.ScoreBatchOptimizedCalls, stats.ScoreBatchScalarFallbackCalls, int(stats.ScoreBatchMaxTileSize), dims)
-		return
+		if scoreName == "default" || scoreName == "indexed" {
+			if stats.ScoreBatchCalls >= stats.ScoreBatchCandidates || stats.ScoreBatchMaxTileSize < 2 {
+				tb.Fatalf("mode=%s score=%s stats=%+v want grouped prepared indexed score batches", mode, scoreName, stats)
+			}
+			assertColumnVectorGraphPreparedIndexedBackendCounters2125(tb, stats.ScoreBatchOptimizedCalls, stats.ScoreBatchScalarFallbackCalls, int(stats.ScoreBatchMaxTileSize), dims)
+			return
+		}
 	}
 	assertColumnVectorGraphScalarScoreBatches2103(tb, stats)
 }

--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -1280,7 +1280,7 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 			if err != nil {
 				return nil, stats, err
 			}
-			if plan.scoreBatchMode.indexedEnabled() {
+			if plan != nil && (plan.preparedSearch != nil || plan.scoreBatchMode.indexedEnabled()) {
 				for i := 0; i < len(adjacency); {
 					tileCap := len(adjacency) - i
 					scratch.scoreTileOrdinals = ensureColumnVectorGraphNativeIntScratch(scratch.scoreTileOrdinals, tileCap)
@@ -1612,7 +1612,7 @@ func (r *columnVectorGraphPhysicalRowReader) greedyNearestAtLayer(plan *columnVe
 		if err != nil {
 			return 0, err
 		}
-		if plan.scoreBatchMode.indexedEnabled() {
+		if plan != nil && (plan.preparedSearch != nil || plan.scoreBatchMode.indexedEnabled()) {
 			scratch.scoreTileOrdinals = ensureColumnVectorGraphNativeIntScratch(scratch.scoreTileOrdinals, len(adjacency))
 			tile := scratch.scoreTileOrdinals[:0]
 			for i, neighbor := range adjacency {

--- a/TreeDB/collections/column_vector_graph_topology_parity_2091_test.go
+++ b/TreeDB/collections/column_vector_graph_topology_parity_2091_test.go
@@ -386,7 +386,6 @@ func assertColumnVectorGraphSearchTopologyParityWork2091(tb testing.TB, boundary
 		{name: "candidate_fetches", legacyValue: legacy.CandidateFetches, currentValue: current.CandidateFetches},
 		{name: "expansion_fetches", legacyValue: legacy.ExpansionFetches, currentValue: current.ExpansionFetches},
 		{name: "result_fetches", legacyValue: legacy.ResultFetches, currentValue: current.ResultFetches},
-		{name: "score_batch_calls", legacyValue: legacy.ScoreBatchCalls, currentValue: current.ScoreBatchCalls},
 		{name: "score_batch_candidates", legacyValue: legacy.ScoreBatchCandidates, currentValue: current.ScoreBatchCandidates},
 		{name: "vector_bytes", legacyValue: legacy.VectorBytesRead, currentValue: current.VectorBytesRead},
 		{name: "norm_bytes", legacyValue: legacy.NormBytesRead, currentValue: current.NormBytesRead},
@@ -399,6 +398,9 @@ func assertColumnVectorGraphSearchTopologyParityWork2091(tb testing.TB, boundary
 		if check.legacyValue != check.currentValue {
 			tb.Fatalf("%s %s legacy=%d current=%d legacyStats=%+v currentStats=%+v", boundary, check.name, check.legacyValue, check.currentValue, legacy, current)
 		}
+	}
+	if current.ScoreBatchCalls == 0 || current.ScoreBatchCalls > legacy.ScoreBatchCalls || current.ScoreBatchMaxTileSize == 0 {
+		tb.Fatalf("%s current score batches calls=%d max_tile=%d legacy_calls=%d currentStats=%+v legacyStats=%+v want prepared path to preserve candidates while allowing scalar neighbor-tile grouping", boundary, current.ScoreBatchCalls, current.ScoreBatchMaxTileSize, legacy.ScoreBatchCalls, current, legacy)
 	}
 }
 

--- a/TreeDB/collections/vector_index_search_promotion_2105_test.go
+++ b/TreeDB/collections/vector_index_search_promotion_2105_test.go
@@ -315,9 +315,10 @@ func assertVectorIndexSearchDefaultIndexedScoreBatches2105(tb testing.TB, defaul
 	if defaultStats.ScoreBatchCalls != indexedStats.ScoreBatchCalls || defaultStats.ScoreBatchCandidates != indexedStats.ScoreBatchCandidates || defaultStats.ScoreBatchMaxTileSize != indexedStats.ScoreBatchMaxTileSize || defaultStats.ScoreBatchOptimizedCalls != indexedStats.ScoreBatchOptimizedCalls || defaultStats.ScoreBatchScalarFallbackCalls != indexedStats.ScoreBatchScalarFallbackCalls {
 		tb.Fatalf("default stats=%+v indexed stats=%+v want default to select identical indexed prepared score batching", defaultStats, indexedStats)
 	}
-	if defaultStats.ScoreBatchCalls >= scalarStats.ScoreBatchCalls || defaultStats.ScoreBatchMaxTileSize < 2 {
-		tb.Fatalf("default stats=%+v scalar stats=%+v want default indexed grouping", defaultStats, scalarStats)
+	if defaultStats.ScoreBatchCalls != scalarStats.ScoreBatchCalls || defaultStats.ScoreBatchCandidates != scalarStats.ScoreBatchCandidates || defaultStats.ScoreBatchMaxTileSize != scalarStats.ScoreBatchMaxTileSize || defaultStats.ScoreBatchMaxTileSize < 2 {
+		tb.Fatalf("default stats=%+v scalar stats=%+v want prepared scalar and indexed modes to share neighbor-tile grouping", defaultStats, scalarStats)
 	}
+	assertVectorIndexSearchPreparedScalarScoreBatches2105(tb, scalarStats)
 	if defaultStats.ScoreBatchSingletons+defaultStats.ScoreBatchSize2To4+defaultStats.ScoreBatchSize5To8+defaultStats.ScoreBatchSize9To16+defaultStats.ScoreBatchSize17Plus != defaultStats.ScoreBatchCalls {
 		tb.Fatalf("default stats=%+v want score-batch histogram to reconcile", defaultStats)
 	}
@@ -334,14 +335,27 @@ func assertVectorIndexSearchScalarScoreBatches2105(tb testing.TB, stats VectorIn
 	}
 }
 
+func assertVectorIndexSearchPreparedScalarScoreBatches2105(tb testing.TB, stats VectorIndexSearchStats) {
+	tb.Helper()
+	if stats.ScoreBatchCalls == 0 || stats.ScoreBatchCalls >= stats.ScoreBatchCandidates || stats.ScoreBatchMaxTileSize < 2 || stats.ScoreBatchOptimizedCalls != 0 || stats.ScoreBatchScalarFallbackCalls != stats.ScoreBatchCalls {
+		tb.Fatalf("stats=%+v want prepared scalar neighbor-tile batches with scalar fallback backend", stats)
+	}
+}
+
 func assertVectorIndexSearchPromotionScoreStats2105(tb testing.TB, mode columnVectorGraphSearchTopologyParityMode2091, scoreName string, stats VectorIndexSearchStats, dims int) {
 	tb.Helper()
-	if mode == columnVectorGraphSearchTopologyParityModeCurrentPrepared2091 && (scoreName == "default" || scoreName == "indexed") {
-		if stats.ScoreBatchCalls >= stats.ScoreBatchCandidates || stats.ScoreBatchMaxTileSize < 2 {
-			tb.Fatalf("mode=%s score=%s stats=%+v want grouped prepared indexed score batches", mode, scoreName, stats)
+	if mode == columnVectorGraphSearchTopologyParityModeCurrentPrepared2091 {
+		if scoreName == "scalar" {
+			assertVectorIndexSearchPreparedScalarScoreBatches2105(tb, stats)
+			return
 		}
-		assertColumnVectorGraphPreparedIndexedBackendCounters2125(tb, stats.ScoreBatchOptimizedCalls, stats.ScoreBatchScalarFallbackCalls, int(stats.ScoreBatchMaxTileSize), dims)
-		return
+		if scoreName == "default" || scoreName == "indexed" {
+			if stats.ScoreBatchCalls >= stats.ScoreBatchCandidates || stats.ScoreBatchMaxTileSize < 2 {
+				tb.Fatalf("mode=%s score=%s stats=%+v want grouped prepared indexed score batches", mode, scoreName, stats)
+			}
+			assertColumnVectorGraphPreparedIndexedBackendCounters2125(tb, stats.ScoreBatchOptimizedCalls, stats.ScoreBatchScalarFallbackCalls, int(stats.ScoreBatchMaxTileSize), dims)
+			return
+		}
 	}
 	assertVectorIndexSearchScalarScoreBatches2105(tb, stats)
 }


### PR DESCRIPTION
## Summary
- Batch prepared `column_graph` scalar scoring at each expanded neighbor tile, preserving exact candidate application order while reducing per-candidate scoring/control-flow overhead on multipart prepared views.
- Add a fast prepared vector/norm lookup path for scalar scoring and aggregate scalar tile score stats once per tile.
- Update topology/promotion tests to expect prepared scalar tile grouping while keeping non-prepared/legacy scalar singleton behavior.

## Correctness
- Default/exact traversal semantics are unchanged: neighbors are still applied in adjacency order after scoring the same tile.
- Indexed/default and scalar modes still return equivalent results; stats now distinguish shared tile topology from indexed vs scalar backend execution.

## Tests
- `GOWORK=off go test ./TreeDB/collections ./cmd/treedb_vector_search_demo -count=1`

## Benchmark / profile evidence
Large 100k docs / 128 dims / 10k queries, column_graph, efSearch=128, SearchWithBuffer profile harness:

- Baseline (`/tmp/vector_search_large_profile_baseline_single_20260602_190945`):
  - c=1 avg `522.765us`, `1912.5 ops/s`
  - c=8 avg `860.062us`, `9292.3 ops/s`
- This branch (`/tmp/vector_search_large_profile_after_scalar_tile_direct_20260602_195357`):
  - c=1 avg `386.637us`, `2585.5 ops/s`
  - c=8 avg `786.955us`, `10152.4 ops/s`

Recall smoke, 100k docs / 128 dims / 1k queries, 8 exact validations:
- `/tmp/vector_search_large_recall_after_scalar_tile_20260602_200126`: recall@10 `0.9875`.

Small single-part indexed microbench remains in-noise and zero-alloc:
- `/tmp/vector_search_small_changed_profile_20260602_195322`: `16862 ns/op`, `0 B/op`, `0 allocs/op`.
