### PR TITLE
TreeDB: eliminate key update lock closure allocations

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -20543,8 +20543,8 @@ func (db *DB) Set(key, value []byte) error {
 		return ErrValueNil
 	}
 	db.waitForCheckpoint()
-	unlock := db.lockUpdateKey(key)
-	defer unlock()
+	guard := db.lockUpdateKey(key)
+	defer guard.Unlock()
 	return db.set(key, value, false)
 }
 
@@ -20556,8 +20556,8 @@ func (db *DB) SetSync(key, value []byte) error {
 		return ErrValueNil
 	}
 	db.waitForCheckpoint()
-	unlock := db.lockUpdateKey(key)
-	defer unlock()
+	guard := db.lockUpdateKey(key)
+	defer guard.Unlock()
 	return db.set(key, value, true)
 }
 
@@ -20577,8 +20577,8 @@ func (db *DB) SetAfterCommandWALAppend(key, value []byte, appendCommand func() e
 		return fmt.Errorf("cachingdb: missing command wal append callback")
 	}
 	db.waitForCheckpoint()
-	unlock := db.lockUpdateKey(key)
-	defer unlock()
+	guard := db.lockUpdateKey(key)
+	defer guard.Unlock()
 	return db.setDirectAfterCommandWALAppend(key, value, appendCommand)
 }
 
@@ -20604,9 +20604,9 @@ func (db *DB) update(key []byte, fn backenddb.UpdateFunc, syncWrite bool) error 
 	db.waitForCheckpoint()
 
 	for {
-		unlock := db.lockUpdateKey(key)
+		guard := db.lockUpdateKey(key)
 		old, err := db.getForUpdate(key)
-		unlock()
+		guard.Unlock()
 		if err != nil {
 			return err
 		}
@@ -20623,31 +20623,31 @@ func (db *DB) update(key []byte, fn backenddb.UpdateFunc, syncWrite bool) error 
 			return fmt.Errorf("treedb: unknown update op %d", result.Op)
 		}
 
-		unlock = db.lockUpdateKey(key)
+		guard = db.lockUpdateKey(key)
 		latest, err := db.getForUpdate(key)
 		if err != nil {
-			unlock()
+			guard.Unlock()
 			return err
 		}
 		if !sameUpdateValue(observed, latest) {
-			unlock()
+			guard.Unlock()
 			continue
 		}
 
 		switch result.Op {
 		case backenddb.UpdateNoop:
-			unlock()
+			guard.Unlock()
 			return nil
 		case backenddb.UpdateSet:
 			err = db.set(key, result.Value, syncWrite)
-			unlock()
+			guard.Unlock()
 			return err
 		case backenddb.UpdateDelete:
 			err = db.delete(key, syncWrite)
-			unlock()
+			guard.Unlock()
 			return err
 		default:
-			unlock()
+			guard.Unlock()
 			return fmt.Errorf("treedb: unknown update op %d", result.Op)
 		}
 	}
@@ -21056,8 +21056,8 @@ func (db *DB) Delete(key []byte) error {
 		return ErrKeyEmpty
 	}
 	db.waitForCheckpoint()
-	unlock := db.lockUpdateKey(key)
-	defer unlock()
+	guard := db.lockUpdateKey(key)
+	defer guard.Unlock()
 	return db.delete(key, false)
 }
 
@@ -21670,8 +21670,8 @@ func (db *DB) DeleteSync(key []byte) error {
 		return ErrKeyEmpty
 	}
 	db.waitForCheckpoint()
-	unlock := db.lockUpdateKey(key)
-	defer unlock()
+	guard := db.lockUpdateKey(key)
+	defer guard.Unlock()
 	return db.delete(key, true)
 }
 
@@ -21685,14 +21685,14 @@ func (db *DB) DeleteAfterCommandWALAppend(key []byte, appendCommand func() error
 		return fmt.Errorf("cachingdb: missing command wal append callback")
 	}
 	db.waitForCheckpoint()
-	unlock := db.lockUpdateKey(key)
-	defer unlock()
+	guard := db.lockUpdateKey(key)
+	defer guard.Unlock()
 	return db.deleteDirectAfterCommandWALAppend(key, appendCommand)
 }
 
-func (db *DB) lockUpdateKey(key []byte) func() {
+func (db *DB) lockUpdateKey(key []byte) keyupdate.Guard {
 	if db == nil {
-		return func() {}
+		return keyupdate.Guard{}
 	}
 	return db.updateLocks.Lock(key)
 }

--- a/TreeDB/caching/update_lock_alloc_test.go
+++ b/TreeDB/caching/update_lock_alloc_test.go
@@ -1,0 +1,50 @@
+package caching
+
+import "testing"
+
+func TestLockUpdateKeyNoAlloc(t *testing.T) {
+	var db DB
+	key := []byte("hot-key")
+	allocs := testing.AllocsPerRun(1000, func() {
+		guard := db.lockUpdateKey(key)
+		guard.Unlock()
+	})
+	if allocs != 0 {
+		t.Fatalf("lockUpdateKey allocs = %v, want 0", allocs)
+	}
+}
+
+func TestLockUpdateKeyWithDeferNoAlloc(t *testing.T) {
+	var db DB
+	key := []byte("hot-key")
+	allocs := testing.AllocsPerRun(1000, func() {
+		lockUpdateKeyWithDefer(&db, key)
+	})
+	if allocs != 0 {
+		t.Fatalf("deferred lockUpdateKey allocs = %v, want 0", allocs)
+	}
+}
+
+func lockUpdateKeyWithDefer(db *DB, key []byte) {
+	guard := db.lockUpdateKey(key)
+	defer guard.Unlock()
+}
+
+func BenchmarkLockUpdateKey(b *testing.B) {
+	var db DB
+	key := []byte("hot-key")
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		guard := db.lockUpdateKey(key)
+		guard.Unlock()
+	}
+}
+
+func BenchmarkLockUpdateKeyWithDefer(b *testing.B) {
+	var db DB
+	key := []byte("hot-key")
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		lockUpdateKeyWithDefer(&db, key)
+	}
+}

--- a/TreeDB/db/api.go
+++ b/TreeDB/db/api.go
@@ -374,8 +374,8 @@ func (db *DB) Has(key []byte) (bool, error) {
 
 // Set sets the value for a key.
 func (db *DB) Set(key, value []byte) error {
-	unlock := db.lockUpdateKey(key)
-	defer unlock()
+	guard := db.lockUpdateKey(key)
+	defer guard.Unlock()
 	return db.setPoint(key, value, false)
 }
 
@@ -388,15 +388,15 @@ func (db *DB) setPoint(key, value []byte, sync bool) error {
 
 // SetSync sets the value and syncs to disk.
 func (db *DB) SetSync(key, value []byte) error {
-	unlock := db.lockUpdateKey(key)
-	defer unlock()
+	guard := db.lockUpdateKey(key)
+	defer guard.Unlock()
 	return db.setPoint(key, value, true)
 }
 
 // Delete removes a key.
 func (db *DB) Delete(key []byte) error {
-	unlock := db.lockUpdateKey(key)
-	defer unlock()
+	guard := db.lockUpdateKey(key)
+	defer guard.Unlock()
 	return db.deletePoint(key, false)
 }
 
@@ -409,8 +409,8 @@ func (db *DB) deletePoint(key []byte, sync bool) error {
 
 // DeleteSync removes a key and syncs.
 func (db *DB) DeleteSync(key []byte) error {
-	unlock := db.lockUpdateKey(key)
-	defer unlock()
+	guard := db.lockUpdateKey(key)
+	defer guard.Unlock()
 	return db.deletePoint(key, true)
 }
 

--- a/TreeDB/db/bench_test.go
+++ b/TreeDB/db/bench_test.go
@@ -427,7 +427,7 @@ func BenchmarkLargeVal(b *testing.B) {
 				continue
 			}
 
-			unlock := d.lockUpdateKey(key)
+			guard := d.lockUpdateKey(key)
 			wb := d.NewBatch().(*Batch)
 			err = wb.SetPointer(key, ptr)
 			if err == nil {
@@ -436,7 +436,7 @@ func BenchmarkLargeVal(b *testing.B) {
 			if closeErr := wb.Close(); err == nil {
 				err = closeErr
 			}
-			unlock()
+			guard.Unlock()
 			if err != nil {
 				b.Errorf("SetPointer failed: %v", err)
 			}

--- a/TreeDB/db/update.go
+++ b/TreeDB/db/update.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	batchpkg "github.com/snissn/gomap/TreeDB/batch"
+	"github.com/snissn/gomap/TreeDB/internal/keyupdate"
 	"github.com/snissn/gomap/TreeDB/tree"
 )
 
@@ -80,9 +81,9 @@ func (db *DB) update(key []byte, fn UpdateFunc, syncWrite bool) error {
 	}
 
 	for {
-		unlock := db.lockUpdateKey(key)
+		guard := db.lockUpdateKey(key)
 		old, err := db.getForUpdate(key)
-		unlock()
+		guard.Unlock()
 		if err != nil {
 			return err
 		}
@@ -99,39 +100,39 @@ func (db *DB) update(key []byte, fn UpdateFunc, syncWrite bool) error {
 			return fmt.Errorf("treedb: unknown update op %d", result.Op)
 		}
 
-		unlock = db.lockUpdateKey(key)
+		guard = db.lockUpdateKey(key)
 		latest, err := db.getForUpdate(key)
 		if err != nil {
-			unlock()
+			guard.Unlock()
 			return err
 		}
 		if !sameUpdateValue(observed, latest) {
-			unlock()
+			guard.Unlock()
 			continue
 		}
 
 		switch result.Op {
 		case UpdateNoop:
-			unlock()
+			guard.Unlock()
 			return nil
 		case UpdateSet:
 			err = db.setPoint(key, result.Value, syncWrite)
-			unlock()
+			guard.Unlock()
 			return err
 		case UpdateDelete:
 			err = db.deletePoint(key, syncWrite)
-			unlock()
+			guard.Unlock()
 			return err
 		default:
-			unlock()
+			guard.Unlock()
 			return fmt.Errorf("treedb: unknown update op %d", result.Op)
 		}
 	}
 }
 
-func (db *DB) lockUpdateKey(key []byte) func() {
+func (db *DB) lockUpdateKey(key []byte) keyupdate.Guard {
 	if db == nil {
-		return func() {}
+		return keyupdate.Guard{}
 	}
 	return db.updateLocks.Lock(key)
 }

--- a/TreeDB/db/update_lock_alloc_test.go
+++ b/TreeDB/db/update_lock_alloc_test.go
@@ -1,0 +1,50 @@
+package db
+
+import "testing"
+
+func TestLockUpdateKeyNoAlloc(t *testing.T) {
+	var d DB
+	key := []byte("hot-key")
+	allocs := testing.AllocsPerRun(1000, func() {
+		guard := d.lockUpdateKey(key)
+		guard.Unlock()
+	})
+	if allocs != 0 {
+		t.Fatalf("lockUpdateKey allocs = %v, want 0", allocs)
+	}
+}
+
+func TestLockUpdateKeyWithDeferNoAlloc(t *testing.T) {
+	var d DB
+	key := []byte("hot-key")
+	allocs := testing.AllocsPerRun(1000, func() {
+		lockUpdateKeyWithDefer(&d, key)
+	})
+	if allocs != 0 {
+		t.Fatalf("deferred lockUpdateKey allocs = %v, want 0", allocs)
+	}
+}
+
+func lockUpdateKeyWithDefer(d *DB, key []byte) {
+	guard := d.lockUpdateKey(key)
+	defer guard.Unlock()
+}
+
+func BenchmarkLockUpdateKey(b *testing.B) {
+	var d DB
+	key := []byte("hot-key")
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		guard := d.lockUpdateKey(key)
+		guard.Unlock()
+	}
+}
+
+func BenchmarkLockUpdateKeyWithDefer(b *testing.B) {
+	var d DB
+	key := []byte("hot-key")
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		lockUpdateKeyWithDefer(&d, key)
+	}
+}

--- a/TreeDB/internal/keyupdate/locks.go
+++ b/TreeDB/internal/keyupdate/locks.go
@@ -14,11 +14,25 @@ type Locks struct {
 	stripes [stripes]sync.Mutex
 }
 
-// Lock locks the stripe for key and returns its unlock function. Hash collisions
-// only reduce concurrency; they do not affect correctness.
-func (l *Locks) Lock(key []byte) func() {
+// Guard holds a locked update stripe. It is returned by value so callers can
+// preserve defer-based panic safety without allocating an unlock closure.
+type Guard struct {
+	locks *Locks
+	index uint64
+}
+
+// Unlock releases the stripe held by g. The zero value is a no-op guard.
+func (g Guard) Unlock() {
+	if g.locks == nil {
+		return
+	}
+	g.locks.stripes[g.index].Unlock()
+}
+
+// Lock locks the stripe for key and returns a guard that unlocks it. Hash
+// collisions only reduce concurrency; they do not affect correctness.
+func (l *Locks) Lock(key []byte) Guard {
 	idx := xxhash.Sum64(key) & (stripes - 1)
-	mu := &l.stripes[idx]
-	mu.Lock()
-	return mu.Unlock
+	l.stripes[idx].Lock()
+	return Guard{locks: l, index: idx}
 }

--- a/TreeDB/internal/keyupdate/locks_test.go
+++ b/TreeDB/internal/keyupdate/locks_test.go
@@ -1,0 +1,79 @@
+package keyupdate
+
+import (
+	"testing"
+
+	"github.com/cespare/xxhash/v2"
+)
+
+func TestGuardUnlockZeroValueNoop(t *testing.T) {
+	var guard Guard
+	guard.Unlock()
+}
+
+func TestLockSerializesSameKey(t *testing.T) {
+	var locks Locks
+	key := []byte("same-key")
+
+	first := locks.Lock(key)
+	idx := xxhash.Sum64(key) & (stripes - 1)
+	if locks.stripes[idx].TryLock() {
+		locks.stripes[idx].Unlock()
+		first.Unlock()
+		t.Fatal("stripe for same key was not locked")
+	}
+	first.Unlock()
+
+	second := locks.Lock(key)
+	second.Unlock()
+}
+
+func TestLockUnlockNoAlloc(t *testing.T) {
+	var locks Locks
+	key := []byte("hot-key")
+	allocs := testing.AllocsPerRun(1000, func() {
+		guard := locks.Lock(key)
+		guard.Unlock()
+	})
+	if allocs != 0 {
+		t.Fatalf("Lock/Unlock allocs = %v, want 0", allocs)
+	}
+}
+
+func TestLockUnlockWithDeferNoAlloc(t *testing.T) {
+	var locks Locks
+	key := []byte("hot-key")
+	allocs := testing.AllocsPerRun(1000, func() {
+		lockUnlockWithDefer(&locks, key)
+	})
+	if allocs != 0 {
+		t.Fatalf("deferred Lock/Unlock allocs = %v, want 0", allocs)
+	}
+}
+
+func lockUnlockWithDefer(locks *Locks, key []byte) {
+	guard := locks.Lock(key)
+	defer guard.Unlock()
+}
+
+func BenchmarkLockUnlock(b *testing.B) {
+	var locks Locks
+	key := []byte("hot-key")
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		guard := locks.Lock(key)
+		guard.Unlock()
+	}
+}
+
+func BenchmarkLockUnlockParallel(b *testing.B) {
+	var locks Locks
+	key := []byte("hot-key")
+	b.ReportAllocs()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			guard := locks.Lock(key)
+			guard.Unlock()
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Fixes #2218. Part of #2216.

- Replaces `TreeDB/internal/keyupdate.(*Locks).Lock`'s closure-returning API with a small value `Guard` and explicit `Guard.Unlock()`.
- Updates TreeDB backend and cached single-key set/delete/update/command-WAL point mutation call sites without changing lock scope; RMW callbacks still run outside the per-key lock.
- Adds zero-allocation tests/benchmarks for lock/unlock and backend/cached lock wrappers.

## API / call-site contract

- `keyupdate.Locks.Lock(key []byte) keyupdate.Guard` locks the same xxhash stripe as before.
- `keyupdate.Guard.Unlock()` releases the held stripe; callers must unlock exactly once for guards returned by `Locks.Lock`.
- `keyupdate.Guard{}` is a no-op unlock guard, used only by nil-DB wrappers that previously returned a no-op closure.
- `Locks.Lock` itself preserves fail-fast behavior for a nil `*Locks` receiver.
- Updated call sites keep the same lock extent:
  - backend `Set`, `SetSync`, `Delete`, `DeleteSync`, `Update` retry/commit phases, and pointer-write benchmark helper;
  - cached `Set`, `SetSync`, `SetAfterCommandWALAppend`, `Update` retry/commit phases, `Delete`, `DeleteSync`, `DeleteAfterCommandWALAppend`.
- No WAL, snapshot, persistence, key ordering, or on-disk semantics changed.

## Tests

Passed locally on Apple M3:

```sh
GOWORK=off go test ./TreeDB/internal/keyupdate ./TreeDB/caching ./TreeDB -count=1
GOWORK=off go test ./TreeDB/db -count=1
GOWORK=off go test ./TreeDB -run 'Test(Update|PublicCommandWALPointWritesSerializeLSNWithCachedMutation|ReopenVerify_WALOn_(Checkpoint|WriteSync))' -count=1
```

## Microbenchmarks / allocation checks

```sh
GOWORK=off go test ./TreeDB/internal/keyupdate -bench='BenchmarkLockUnlock' -benchmem -run='^$' -count=5
GOWORK=off go test ./TreeDB/db ./TreeDB/caching -bench='BenchmarkLockUpdateKey' -benchmem -run='^$' -count=5
```

Representative latest results: `Lock/Unlock`, backend wrapper, and cached wrapper all report `0 B/op` and `0 allocs/op`; deferred wrapper benchmarks also report `0 B/op` and `0 allocs/op`.

## Durable before/after benchmark evidence

Local 1M-key durable focused run, identical host/command, base `8e89691b` vs head `385faeb99`:

```sh
GOMAXPROCS=8 ./unified-bench \
  -dbs=treedb \
  -keys=1000000 \
  -profile=durable \
  -path-label=native-fastpath \
  -format=markdown \
  -progress=false \
  -test=sequential_write,random_write,random_delete,dataset_write_sorted \
  -profile-dir=<out>
```

Artifacts:

- base: `/tmp/gomap_2218_bench_20260602_212451/base/profiles_rerun`
- head: `/tmp/gomap_2218_bench_20260602_212451/head/profiles_rerun`

| Test | Base ops/sec | Head ops/sec | Delta |
| --- | ---: | ---: | ---: |
| Sequential Write | 2,096,231 | 2,028,399 | -3.2% |
| Random Write | 1,137,516 | 1,147,251 | +0.9% |
| Random Delete | 1,115,791 | 1,132,120 | +1.5% |
| Dataset Write (Sorted) | 529,580 | 682,696 | +28.9% |

The local Mac profile-dir runs were noisy/throttled after prolonged validation. An isolated latest-head sequential-write check on the same binaries/host was positive (`2,388,193` base vs `2,686,616` head, `+12.5%`; artifacts under `profiles_seq_check`). I do not see a material write/delete throughput regression.

Allocation pprof (`alloc_objects`) from the paired durable run shows the targeted closure allocation removed:

| Test | Base total alloc objects | Head total alloc objects | Delta | Base `keyupdate.Lock` objects | Head `keyupdate.Lock` objects |
| --- | ---: | ---: | ---: | ---: | ---: |
| Sequential Write | 1,204,130 | 67,840 | -94.4% | 1,179,666 | absent from top |
| Random Write | 1,133,964 | 136,267 | -88.0% | 917,518 | absent from top |
| Random Delete | 978,159 | 10,859 | -98.9% | 884,749 | absent from top |
| Dataset Write (Sorted) | 6,140,727 | 5,443,236 | -11.4% | 917,518 | absent from top |

## Risks / non-goals

- Internal API change only; no public API or persistent format change.
- Hash striping policy is unchanged.
- Dependent issues (#2219/#2220/#2221) can use the contract above once this branch is dependency-ready.

## Status

- Local tests and benchmark evidence complete.
- Internal review/fix loop complete.
- CI and AI review status will be updated after PR creation/latest-head checks start.
