### PR TITLE
Fix dataset write profiling boundaries

### DIFF
--- a/cmd/unified_bench/README.md
+++ b/cmd/unified_bench/README.md
@@ -83,7 +83,7 @@ GOWORK=off GOMEMLIMIT=4GiB GOMAXPROCS=2 go test -json -p 1 . \
 - `-keyscale` generate keycounts by scale: `log10` or `doubling` (uses `-keys-min` / `-keys-max`)
 - `-valsize` value size in bytes (default 128)
 - `-val-pattern` value pattern for write tests (including `dataset_write_*`) (`zero|repeat|repeat_tail64|ultra_compressible_repeat|highly_compressible_notail|half_repeat_half_random|medium_compressible_sparse|celestia_height_prefix_fill|random`)
-  - Note: dataset-write generation now uses the same normalized behavior as other write tests (legacy pattern names are accepted as aliases, but generation is unified under `makeValuePool`). Reusable dataset-write key/value fixtures are materialized before per-test CPU/allocation/contention profiles and runtime traces start, so those artifacts represent the measured DB write loops rather than fixture setup.
+  - Note: dataset-write generation now uses the same normalized behavior as other write tests (legacy pattern names are accepted as aliases, but generation is unified under `makeValuePool`). Reusable dataset key/value fixtures for `dataset_write_*` and `dataset_read_random` are materialized before per-test CPU/allocation/contention profiles and runtime traces start, so those artifacts represent the measured DB loops rather than fixture setup.
 - `-val-pool-size` number of distinct values to cycle through for `-val-pattern` (`0` = auto)
 - `-batchsize` batch size (default 8000)
 - `-read-workers` number of goroutines for `random_read_parallel` and `random_read_parallel_acquire_snapshot` (default `GOMAXPROCS`)

--- a/cmd/unified_bench/README.md
+++ b/cmd/unified_bench/README.md
@@ -83,7 +83,7 @@ GOWORK=off GOMEMLIMIT=4GiB GOMAXPROCS=2 go test -json -p 1 . \
 - `-keyscale` generate keycounts by scale: `log10` or `doubling` (uses `-keys-min` / `-keys-max`)
 - `-valsize` value size in bytes (default 128)
 - `-val-pattern` value pattern for write tests (including `dataset_write_*`) (`zero|repeat|repeat_tail64|ultra_compressible_repeat|highly_compressible_notail|half_repeat_half_random|medium_compressible_sparse|celestia_height_prefix_fill|random`)
-  - Note: dataset-write generation now uses the same normalized behavior as other write tests (legacy pattern names are accepted as aliases, but generation is unified under `makeValuePool`).
+  - Note: dataset-write generation now uses the same normalized behavior as other write tests (legacy pattern names are accepted as aliases, but generation is unified under `makeValuePool`). Reusable dataset-write key/value fixtures are materialized before per-test CPU/allocation/contention profiles and runtime traces start, so those artifacts represent the measured DB write loops rather than fixture setup.
 - `-val-pool-size` number of distinct values to cycle through for `-val-pattern` (`0` = auto)
 - `-batchsize` batch size (default 8000)
 - `-read-workers` number of goroutines for `random_read_parallel` and `random_read_parallel_acquire_snapshot` (default `GOMAXPROCS`)

--- a/cmd/unified_bench/main.go
+++ b/cmd/unified_bench/main.go
@@ -3986,6 +3986,16 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 		prefixScanBase = cfg.Keys
 	}
 
+	// Materialize reusable dataset fixtures before profiling starts. The
+	// dataset_write_* timers already exclude this setup; keeping it outside CPU,
+	// allocation, contention, and trace profiles makes those artifacts represent
+	// the DB hot path instead of fixture generation.
+	if containsAny(finalTestOrder, "dataset_write_random", "dataset_write_sorted", "dataset_read_random") {
+		if err := ensureWriteDatasets(); err != nil {
+			return BenchRun{}, fmt.Errorf("dataset fixture setup: %w", err)
+		}
+	}
+
 	settledBeforeScans := false
 	blockProfilePath := strings.TrimSpace(cfg.BlockProfile)
 	mutexProfilePath := strings.TrimSpace(cfg.MutexProfile)

--- a/cmd/unified_bench/main_test.go
+++ b/cmd/unified_bench/main_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"math"
 	"os"
@@ -2498,41 +2499,45 @@ func TestRunBenchmark_ContentionAfterSnapshotsBeforeAllocsPostProcessing(t *test
 	}
 }
 
-func TestRunBenchmarkDatasetWriteRandomAllocsProfileExcludesFixtureSetup(t *testing.T) {
-	outDir := t.TempDir()
-	allocPrefix := filepath.Join(outDir, "allocs")
+func TestRunBenchmarkDatasetWriteAllocsProfilesExcludeFixtureSetup(t *testing.T) {
+	for _, testName := range []string{"dataset_write_random", "dataset_write_sorted"} {
+		t.Run(testName, func(t *testing.T) {
+			outDir := t.TempDir()
+			allocPrefix := filepath.Join(outDir, "allocs")
 
-	_, err := runBenchmark(BenchConfig{
-		Keys:              2048,
-		ValueSize:         256,
-		ValuePattern:      "random",
-		BatchSize:         256,
-		RangeQueries:      0,
-		RangeSpan:         0,
-		DBsArg:            "treedb",
-		TestsArg:          "dataset_write_random",
-		KeepDir:           false,
-		Progress:          false,
-		SeedUsed:          1,
-		AllocsProfile:     allocPrefix,
-		AllocsProfileRate: 1,
-	})
-	if err != nil {
-		t.Fatalf("runBenchmark: %v", err)
-	}
+			_, err := runBenchmark(BenchConfig{
+				Keys:              2048,
+				ValueSize:         256,
+				ValuePattern:      "random",
+				BatchSize:         256,
+				RangeQueries:      0,
+				RangeSpan:         0,
+				DBsArg:            "treedb",
+				TestsArg:          testName,
+				KeepDir:           false,
+				Progress:          false,
+				SeedUsed:          1,
+				AllocsProfile:     allocPrefix,
+				AllocsProfileRate: 1,
+			})
+			if err != nil {
+				t.Fatalf("runBenchmark: %v", err)
+			}
 
-	profilePath := allocPrefix + "_dataset_write_random_treedb.pprof"
-	if _, err := os.Stat(profilePath); err != nil {
-		t.Fatalf("expected allocs profile %q: %v", profilePath, err)
-	}
+			profilePath := fmt.Sprintf("%s_%s_treedb.pprof", allocPrefix, testName)
+			if _, err := os.Stat(profilePath); err != nil {
+				t.Fatalf("expected allocs profile %q: %v", profilePath, err)
+			}
 
-	cmd := exec.Command(goToolExecutable(), "tool", "pprof", "-top", "-sample_index=alloc_objects", profilePath)
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("pprof top: %v\n%s", err, out)
-	}
-	if strings.Contains(string(out), "main.makeValuePool") {
-		t.Fatalf("dataset fixture generation leaked into dataset_write_random allocs profile:\n%s", out)
+			cmd := exec.Command(goToolExecutable(), "tool", "pprof", "-top", "-nodecount=0", "-sample_index=alloc_objects", profilePath)
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("pprof top: %v\n%s", err, out)
+			}
+			if strings.Contains(string(out), "main.makeValuePool") {
+				t.Fatalf("dataset fixture generation leaked into %s allocs profile:\n%s", testName, out)
+			}
+		})
 	}
 }
 

--- a/cmd/unified_bench/main_test.go
+++ b/cmd/unified_bench/main_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"math"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"sort"
@@ -2494,6 +2495,44 @@ func TestRunBenchmark_ContentionAfterSnapshotsBeforeAllocsPostProcessing(t *test
 	}
 	if mutexAfterIdx > allocAfterIdx {
 		t.Fatalf("expected mutex_after before allocs_after, events=%v", events)
+	}
+}
+
+func TestRunBenchmarkDatasetWriteRandomAllocsProfileExcludesFixtureSetup(t *testing.T) {
+	outDir := t.TempDir()
+	allocPrefix := filepath.Join(outDir, "allocs")
+
+	_, err := runBenchmark(BenchConfig{
+		Keys:              2048,
+		ValueSize:         256,
+		ValuePattern:      "random",
+		BatchSize:         256,
+		RangeQueries:      0,
+		RangeSpan:         0,
+		DBsArg:            "treedb",
+		TestsArg:          "dataset_write_random",
+		KeepDir:           false,
+		Progress:          false,
+		SeedUsed:          1,
+		AllocsProfile:     allocPrefix,
+		AllocsProfileRate: 1,
+	})
+	if err != nil {
+		t.Fatalf("runBenchmark: %v", err)
+	}
+
+	profilePath := allocPrefix + "_dataset_write_random_treedb.pprof"
+	if _, err := os.Stat(profilePath); err != nil {
+		t.Fatalf("expected allocs profile %q: %v", profilePath, err)
+	}
+
+	cmd := exec.Command(goToolExecutable(), "tool", "pprof", "-top", "-sample_index=alloc_objects", profilePath)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("pprof top: %v\n%s", err, out)
+	}
+	if strings.Contains(string(out), "main.makeValuePool") {
+		t.Fatalf("dataset fixture generation leaked into dataset_write_random allocs profile:\n%s", out)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Pre-materialize reusable dataset key/value fixtures for `dataset_write_random`, `dataset_write_sorted`, and `dataset_read_random` before unified-bench profiling starts.
- Preserve dataset write `Set` loop timing and all profile artifact filenames while excluding fixture setup from CPU, allocation, per-test contention, and trace artifacts.
- Add an allocation-profile regression test that fails if `main.makeValuePool` appears in either dataset write alloc profile.

Links: fixes #2217; part of #2216.

## Boundary / scope

This changes benchmark harness profiling boundaries only. TreeDB behavior, storage formats, and durable profile semantics are unchanged. Artifact names remain `cpu_<test>_<db>.pprof`, `allocs_<test>_<db>.pprof`, `block_<test>_<db>.pprof`, `mutex_<test>_<db>.pprof`, `trace.out`, and existing benchprof result names.

## Tests

- `GOWORK=off go test ./cmd/unified_bench -run TestRunBenchmarkDatasetWriteAllocsProfilesExcludeFixtureSetup -count=1`
- `GOWORK=off go test ./cmd/unified_bench -run 'TestRunBenchmarkDatasetWriteAllocsProfilesExcludeFixtureSetup|TestApplyProfileArtifactDir|TestCollectionStorageProfileArtifactPaths|TestContentionProfilePath|TestRunBenchmark_ContentionAfterSnapshotsBeforeAllocsPostProcessing' -count=1`
- `GOWORK=off go test ./cmd/unified_bench ./internal/benchprof ./cmd/benchprof -count=1`
- Internal reviewer re-ran: `GOWORK=off go test ./cmd/unified_bench -run '^TestRunBenchmarkDatasetWriteAllocsProfilesExcludeFixtureSetup$' -count=1`

## Benchmark evidence

Remote host: `mikers@192.168.0.185`

Command shape for both before and after:

```sh
GOWORK=off go build -o bin/unified-bench ./cmd/unified_bench
OUT=/home/mikers/tmp/<run>
./bin/unified-bench -dbs=treedb -keys=1000000 -profile=durable -profile-dir="$OUT" -path-label=native-fastpath -format=markdown -progress=false -test=dataset_write_random,dataset_write_sorted
./bin/benchprof -profiles-dir "$OUT"
```

| Run | Commit | Artifact dir |
| --- | --- | --- |
| before | `8e89691bdaaf5bd9278a759cfb31ca9bb749d4d7` | `/home/mikers/tmp/gomap_2217_before_1m_20260602_212526` |
| after | `d05d801c46996f374dffc23a54f0cb149c0c09e4` | `/home/mikers/tmp/gomap_2217_after_final_1m_20260602_213543` |

| Test | Before ops/sec | After ops/sec | Delta |
| --- | ---: | ---: | ---: |
| `dataset_write_random` | 1,033,834 | 1,017,495 | -1.58% |
| `dataset_write_sorted` | 918,773 | 935,075 | +1.77% |

Allocation profile boundary check for `allocs_dataset_write_random_treedb.pprof`:

| Run | `alloc_objects` `main.makeValuePool` | `alloc_space` `main.makeValuePool` |
| --- | --- | --- |
| before | `1,937,646` objects, `37.78%` flat | `282.31MB`, `22.62%` flat |
| after | absent | absent |

Performance assessment: no material throughput regression; observed deltas are small and consistent with run noise while profile attribution is corrected.

## Review / CI / AI status

- Internal high-thinking review: PASS, no blocking findings after nits addressed in `d05d801c`.
- Latest-head CI: green for `d05d801c46996f374dffc23a54f0cb149c0c09e4`.
- AI reviews: requested Codex, Copilot, and CodeRabbit after code/tests/benchmark evidence were in the PR and CI was running. Codex reported no major issues; CodeRabbit returned pass/skipped due review limit with no findings; Copilot was requested and no findings/comments were present at the time of this update.

## Risks / caveats

- Benchmark setup still consumes wall time and memory before profiling starts; this is intentional so hot-path artifacts map to measured DB loops.
- `dataset_update_fork_choice` has separate workload-local setup and is not changed by this PR.
