### PR TITLE
Make cached TreeDB snapshots allocation-light

### DIFF
--- a/TreeDB/caching/snapshot.go
+++ b/TreeDB/caching/snapshot.go
@@ -138,7 +138,19 @@ func (db *DB) AcquireBackendSnapshotFastPath() *backenddb.Snapshot {
 	if !ok {
 		return nil
 	}
-	return provider.AcquireSnapshot()
+	backendSnap := provider.AcquireSnapshot()
+	if backendSnap == nil {
+		return nil
+	}
+	// A durability-none value-log flush can race between the clean check above
+	// and the backend snapshot acquisition. If that happens, the raw backend
+	// snapshot may see a newly-published pointer whose value-log tail still needs
+	// the cached read barrier. Fail closed to the cached Snapshot wrapper.
+	if !db.backendReadValueLogCleanForSnapshotFastPath() {
+		_ = backendSnap.Close()
+		return nil
+	}
+	return backendSnap
 }
 
 // AcquireSnapshot returns a cached snapshot that includes queued memtable writes.

--- a/TreeDB/caching/snapshot.go
+++ b/TreeDB/caching/snapshot.go
@@ -75,10 +75,88 @@ type backendSnapshotProvider interface {
 	AcquireSnapshot() *backenddb.Snapshot
 }
 
+func snapshotRootDomainBlocksBackendFastPath(snap rootDomainSnapshot) bool {
+	return rootDomainSnapshotHasInMemoryState(snap) || rootDomainSnapshotHasPublishedState(snap)
+}
+
+func snapshotRootDomainStaticBlocksBackendFastPath(snap rootDomainSnapshot) bool {
+	return len(snap.immutables) != 0 || rootDomainSnapshotHasPublishedState(snap)
+}
+
+func memtableViewAllowsBackendSnapshotFastPath(view *memtableView) bool {
+	if view == nil {
+		return false
+	}
+	if len(view.queue) != 0 || view.publishedRoots != nil {
+		return false
+	}
+	for _, mt := range view.mutables {
+		if mt != nil && mt.Len() != 0 {
+			return false
+		}
+	}
+	pointSnapshots := view.rootSnapshotShards
+	if len(pointSnapshots) == 0 {
+		pointSnapshots = view.rootPointShards
+	}
+	for i := range pointSnapshots {
+		if snapshotRootDomainStaticBlocksBackendFastPath(pointSnapshots[i]) {
+			return false
+		}
+	}
+	return !snapshotRootDomainBlocksBackendFastPath(view.rootSystem) &&
+		!snapshotRootDomainBlocksBackendFastPath(view.rootIterator)
+}
+
+func (db *DB) backendReadValueLogCleanForSnapshotFastPath() bool {
+	if db == nil || !db.valueLogEnabled() {
+		return true
+	}
+	dirtySeq := db.backendReadVlogDirtySeq.Load()
+	return dirtySeq == 0 || dirtySeq == db.backendReadVlogFlushedSeq.Load()
+}
+
+// AcquireBackendSnapshotFastPath returns a backend snapshot when the cached
+// layer has no mutable, queued, root-domain, or pending value-log state that the
+// cached Snapshot wrapper must preserve. The returned snapshot has the normal
+// backend snapshot lifetime and must be closed by the caller.
+func (db *DB) AcquireBackendSnapshotFastPath() *backenddb.Snapshot {
+	if db == nil || db.backend == nil || db.closing.Load() {
+		return nil
+	}
+	if !db.backendReadValueLogCleanForSnapshotFastPath() {
+		return nil
+	}
+	view := db.retainMemtableViewUntracked()
+	if !memtableViewAllowsBackendSnapshotFastPath(view) {
+		db.releaseUntrackedMemtableView(view)
+		return nil
+	}
+	db.releaseUntrackedMemtableView(view)
+
+	provider, ok := db.backend.(backendSnapshotProvider)
+	if !ok {
+		return nil
+	}
+	return provider.AcquireSnapshot()
+}
+
 // AcquireSnapshot returns a cached snapshot that includes queued memtable writes.
 func (db *DB) AcquireSnapshot() *Snapshot {
 	if db == nil || db.backend == nil || db.closing.Load() {
 		return nil
+	}
+	if backendSnap := db.AcquireBackendSnapshotFastPath(); backendSnap != nil {
+		var backendRootID uint64
+		if state := backendSnap.State(); state != nil {
+			backendRootID = state.RootPageID
+		}
+		return &Snapshot{
+			db:              db,
+			backend:         backendSnap,
+			backendRootID:   backendRootID,
+			backendFallback: backendSnapshotLookup{db: db, snapshot: backendSnap, rootID: backendRootID},
+		}
 	}
 
 	view := db.retainMemtableView()
@@ -140,9 +218,6 @@ func (db *DB) AcquireSnapshot() *Snapshot {
 				viewRootPointShards = nil
 				viewRootSystem = rootDomainSnapshot{}
 				viewRootIterator = rootDomainSnapshot{}
-			} else {
-				viewRootPointShards = append([]rootDomainSnapshot(nil), view.rootSnapshotShards...)
-				viewPublishedRoots = clonePublishedRootSet(view.publishedRoots)
 			}
 			db.releaseMemtableView(view)
 			view = nil

--- a/TreeDB/caching/snapshot_test.go
+++ b/TreeDB/caching/snapshot_test.go
@@ -428,6 +428,57 @@ func TestAcquireBackendSnapshotFastPath_RejectsDirtyBackendValueLogState(t *test
 	defer snap.Close()
 }
 
+type dirtyDuringAcquireBackend struct {
+	BackendDB
+	snapper   backendSnapshotProvider
+	onAcquire func()
+}
+
+func (b *dirtyDuringAcquireBackend) AcquireSnapshot() *db.Snapshot {
+	if b.onAcquire != nil {
+		b.onAcquire()
+	}
+	return b.snapper.AcquireSnapshot()
+}
+
+func TestAcquireBackendSnapshotFastPath_RejectsValueLogDirtyRace(t *testing.T) {
+	dir := t.TempDir()
+	backend, err := db.Open(db.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open backend: %v", err)
+	}
+	defer backend.Close()
+
+	cached, err := Open(dir, backend, Options{DisableWAL: true, AllowUnsafe: true, FlushThreshold: 1 << 30})
+	if err != nil {
+		t.Fatalf("open cached: %v", err)
+	}
+	defer cached.Close()
+
+	cached.backendReadVlogDirtySeq.Store(1)
+	cached.backendReadVlogFlushedSeq.Store(1)
+	wrapped := &dirtyDuringAcquireBackend{
+		BackendDB: cached.backend,
+		snapper:   backend,
+		onAcquire: func() {
+			cached.backendReadVlogDirtySeq.Add(1)
+		},
+	}
+	cached.backend = wrapped
+	if snap := cached.AcquireBackendSnapshotFastPath(); snap != nil {
+		_ = snap.Close()
+		t.Fatal("AcquireBackendSnapshotFastPath returned snapshot after value-log state became dirty during backend acquire")
+	}
+
+	cached.backendReadVlogFlushedSeq.Store(cached.backendReadVlogDirtySeq.Load())
+	wrapped.onAcquire = nil
+	snap := cached.AcquireBackendSnapshotFastPath()
+	if snap == nil {
+		t.Fatal("AcquireBackendSnapshotFastPath=nil after dirty race was marked flushed")
+	}
+	defer snap.Close()
+}
+
 func TestAcquireBackendSnapshotFastPath_RejectsPublishedRootState(t *testing.T) {
 	dir := t.TempDir()
 	backend, err := db.Open(db.Options{Dir: dir})

--- a/TreeDB/caching/snapshot_test.go
+++ b/TreeDB/caching/snapshot_test.go
@@ -326,6 +326,152 @@ func TestAcquireSnapshot_AllocsBoundedAfterWarmPath(t *testing.T) {
 	}
 }
 
+func TestAcquireBackendSnapshotFastPath_AvailableAfterCheckpoint(t *testing.T) {
+	dir := t.TempDir()
+	backend, err := db.Open(db.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open backend: %v", err)
+	}
+	defer backend.Close()
+
+	cached, err := Open(dir, backend, Options{DisableWAL: true, AllowUnsafe: true, FlushThreshold: 1 << 30})
+	if err != nil {
+		t.Fatalf("open cached: %v", err)
+	}
+	defer cached.Close()
+
+	key := []byte("fast-path-key")
+	if err := cached.Set(key, []byte("persisted")); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	if err := cached.Checkpoint(); err != nil {
+		t.Fatalf("checkpoint: %v", err)
+	}
+
+	snap := cached.AcquireBackendSnapshotFastPath()
+	if snap == nil {
+		t.Fatal("AcquireBackendSnapshotFastPath=nil after checkpointed empty cached state")
+	}
+	defer snap.Close()
+	got, err := snap.GetAppend(key, nil)
+	if err != nil {
+		t.Fatalf("backend fast-path GetAppend: %v", err)
+	}
+	if string(got) != "persisted" {
+		t.Fatalf("backend fast-path value=%q want persisted", string(got))
+	}
+}
+
+func TestAcquireBackendSnapshotFastPath_RejectsMutableCachedWrites(t *testing.T) {
+	dir := t.TempDir()
+	backend, err := db.Open(db.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open backend: %v", err)
+	}
+	defer backend.Close()
+
+	cached, err := Open(dir, backend, Options{DisableWAL: true, AllowUnsafe: true, FlushThreshold: 1 << 30})
+	if err != nil {
+		t.Fatalf("open cached: %v", err)
+	}
+	defer cached.Close()
+
+	key := []byte("mutable-key")
+	if err := cached.Set(key, []byte("cached")); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	if snap := cached.AcquireBackendSnapshotFastPath(); snap != nil {
+		_ = snap.Close()
+		t.Fatal("AcquireBackendSnapshotFastPath returned snapshot with mutable cached write")
+	}
+
+	snap := cached.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("AcquireSnapshot=nil")
+	}
+	defer snap.Close()
+	got, err := snap.GetAppend(key, nil)
+	if err != nil {
+		t.Fatalf("cached snapshot GetAppend: %v", err)
+	}
+	if string(got) != "cached" {
+		t.Fatalf("cached snapshot value=%q want cached", string(got))
+	}
+}
+
+func TestAcquireBackendSnapshotFastPath_RejectsDirtyBackendValueLogState(t *testing.T) {
+	dir := t.TempDir()
+	backend, err := db.Open(db.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open backend: %v", err)
+	}
+	defer backend.Close()
+
+	cached, err := Open(dir, backend, Options{DisableWAL: true, AllowUnsafe: true, FlushThreshold: 1 << 30})
+	if err != nil {
+		t.Fatalf("open cached: %v", err)
+	}
+	defer cached.Close()
+
+	cached.backendReadVlogFlushedSeq.Store(1)
+	cached.backendReadVlogDirtySeq.Store(2)
+	if snap := cached.AcquireBackendSnapshotFastPath(); snap != nil {
+		_ = snap.Close()
+		t.Fatal("AcquireBackendSnapshotFastPath returned snapshot with dirty backend value-log state")
+	}
+
+	cached.backendReadVlogFlushedSeq.Store(2)
+	snap := cached.AcquireBackendSnapshotFastPath()
+	if snap == nil {
+		t.Fatal("AcquireBackendSnapshotFastPath=nil after dirty value-log state marked flushed")
+	}
+	defer snap.Close()
+}
+
+func TestAcquireBackendSnapshotFastPath_RejectsPublishedRootState(t *testing.T) {
+	dir := t.TempDir()
+	backend, err := db.Open(db.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open backend: %v", err)
+	}
+	defer backend.Close()
+
+	cached, err := Open(dir, backend, Options{DisableWAL: true, AllowUnsafe: true, FlushThreshold: 1 << 30, MemtableShards: 1})
+	if err != nil {
+		t.Fatalf("open cached: %v", err)
+	}
+	defer cached.Close()
+
+	published := newRootDomainTestTable(t, rootDomainTestOp{key: "root-key", value: "published"})
+	cached.mu.Lock()
+	ok := cached.installPublishedRootSetLocked(&publishedRootSet{
+		generation: 1,
+		pointShards: []publishedRootRef{
+			{lookup: published, rootID: 101},
+		},
+	})
+	cached.mu.Unlock()
+	if !ok {
+		t.Fatal("installPublishedRootSetLocked=false")
+	}
+
+	if snap := cached.AcquireBackendSnapshotFastPath(); snap != nil {
+		_ = snap.Close()
+		t.Fatal("AcquireBackendSnapshotFastPath returned snapshot with published root state")
+	}
+
+	snap := cached.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("AcquireSnapshot=nil")
+	}
+	defer snap.Close()
+	if snap.view != nil {
+		t.Fatal("published-root snapshot should not retain empty memtable view")
+	}
+	rootSnap := rootDomainSnapshotFromCachedSnapshot(snap, []byte("root-key"))
+	assertRootDomainVisibleValue(t, rootSnap, "root-key", "published")
+}
+
 func TestSnapshotClose_Idempotent(t *testing.T) {
 	dir, err := os.MkdirTemp("", "treedb-snapshot-close-idempotent-")
 	if err != nil {

--- a/TreeDB/public.go
+++ b/TreeDB/public.go
@@ -1695,6 +1695,9 @@ func (db *DB) AcquireSnapshot() Snapshot {
 		return nil
 	}
 	if db.cached != nil {
+		if snap := db.cached.AcquireBackendSnapshotFastPath(); snap != nil {
+			return snap
+		}
 		return db.cached.AcquireSnapshot()
 	}
 	if db.backend == nil {

--- a/TreeDB/snapshot_fastpath_test.go
+++ b/TreeDB/snapshot_fastpath_test.go
@@ -1,0 +1,220 @@
+package treedb
+
+import (
+	"bytes"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/caching"
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+)
+
+func TestAcquireSnapshot_BackendFastPathAfterCheckpointIsStable(t *testing.T) {
+	d, err := Open(Options{Dir: t.TempDir(), FlushThreshold: 1 << 30})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer d.Close()
+
+	key := []byte("snapshot-fast-path-key")
+	if err := d.SetSync(key, []byte("old")); err != nil {
+		t.Fatalf("SetSync old: %v", err)
+	}
+	if err := d.Checkpoint(); err != nil {
+		t.Fatalf("checkpoint old: %v", err)
+	}
+
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("AcquireSnapshot=nil")
+	}
+	if _, ok := snap.(*backenddb.Snapshot); !ok {
+		_ = snap.Close()
+		t.Fatalf("AcquireSnapshot type=%T want backend fast-path snapshot", snap)
+	}
+
+	if err := d.SetSync(key, []byte("new")); err != nil {
+		_ = snap.Close()
+		t.Fatalf("SetSync new: %v", err)
+	}
+	if err := d.Checkpoint(); err != nil {
+		_ = snap.Close()
+		t.Fatalf("checkpoint new: %v", err)
+	}
+
+	got, err := snap.GetAppend(key, nil)
+	if err != nil {
+		_ = snap.Close()
+		t.Fatalf("old snapshot GetAppend: %v", err)
+	}
+	if !bytes.Equal(got, []byte("old")) {
+		_ = snap.Close()
+		t.Fatalf("old snapshot value=%q want old", string(got))
+	}
+	if err := snap.Close(); err != nil {
+		t.Fatalf("first Close: %v", err)
+	}
+	if err := snap.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+
+	next := d.AcquireSnapshot()
+	if next == nil {
+		t.Fatal("next AcquireSnapshot=nil")
+	}
+	defer next.Close()
+	got, err = next.GetAppend(key, nil)
+	if err != nil {
+		t.Fatalf("next snapshot GetAppend: %v", err)
+	}
+	if !bytes.Equal(got, []byte("new")) {
+		t.Fatalf("next snapshot value=%q want new", string(got))
+	}
+}
+
+func TestAcquireSnapshot_BackendFastPathAllocsAfterWarm(t *testing.T) {
+	d, err := Open(Options{Dir: t.TempDir(), FlushThreshold: 1 << 30})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer d.Close()
+
+	if err := d.SetSync([]byte("alloc-key"), []byte("alloc-value")); err != nil {
+		t.Fatalf("SetSync: %v", err)
+	}
+	if err := d.Checkpoint(); err != nil {
+		t.Fatalf("checkpoint: %v", err)
+	}
+	warm := d.AcquireSnapshot()
+	if warm == nil {
+		t.Fatal("warm AcquireSnapshot=nil")
+	}
+	if err := warm.Close(); err != nil {
+		t.Fatalf("warm Close: %v", err)
+	}
+
+	allocs := testing.AllocsPerRun(1000, func() {
+		snap := d.AcquireSnapshot()
+		if snap == nil {
+			panic("AcquireSnapshot=nil")
+		}
+		if _, ok := snap.(*backenddb.Snapshot); !ok {
+			panic("AcquireSnapshot did not use backend fast path")
+		}
+		if err := snap.Close(); err != nil {
+			panic(err)
+		}
+	})
+	if allocs > 0.1 {
+		t.Fatalf("backend fast-path AcquireSnapshot allocs/run=%f want <= 0.1", allocs)
+	}
+}
+
+func TestAcquireSnapshot_ConcurrentFastPathAcquireCloseWithCheckpoints(t *testing.T) {
+	d, err := Open(Options{Dir: t.TempDir(), FlushThreshold: 1 << 30})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer d.Close()
+
+	key := []byte("snapshot-concurrent-key")
+	if err := d.SetSync(key, []byte("v00")); err != nil {
+		t.Fatalf("SetSync seed: %v", err)
+	}
+	if err := d.Checkpoint(); err != nil {
+		t.Fatalf("checkpoint seed: %v", err)
+	}
+
+	var stop atomic.Bool
+	errCh := make(chan error, 1)
+	publishErr := func(err error) {
+		if err == nil {
+			return
+		}
+		if stop.CompareAndSwap(false, true) {
+			errCh <- err
+		}
+	}
+
+	var wg sync.WaitGroup
+	for worker := 0; worker < 4; worker++ {
+		wg.Add(1)
+		go func(worker int) {
+			defer wg.Done()
+			for i := 0; i < 250 && !stop.Load(); i++ {
+				snap := d.AcquireSnapshot()
+				if snap == nil {
+					publishErr(fmt.Errorf("worker %d acquire %d: nil snapshot", worker, i))
+					return
+				}
+				got, err := snap.GetAppend(key, nil)
+				closeErr := snap.Close()
+				if err != nil {
+					publishErr(fmt.Errorf("worker %d get %d: %w", worker, i, err))
+					return
+				}
+				if len(got) == 0 {
+					publishErr(fmt.Errorf("worker %d get %d: empty value", worker, i))
+					return
+				}
+				if closeErr != nil {
+					publishErr(fmt.Errorf("worker %d close %d: %w", worker, i, closeErr))
+					return
+				}
+			}
+		}(worker)
+	}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 1; i <= 25 && !stop.Load(); i++ {
+			value := []byte(fmt.Sprintf("v%02d", i))
+			if err := d.SetSync(key, value); err != nil {
+				publishErr(fmt.Errorf("writer set %d: %w", i, err))
+				return
+			}
+			if err := d.Checkpoint(); err != nil {
+				publishErr(fmt.Errorf("writer checkpoint %d: %w", i, err))
+				return
+			}
+		}
+	}()
+
+	wg.Wait()
+	select {
+	case err := <-errCh:
+		t.Fatal(err)
+	default:
+	}
+}
+
+func TestAcquireSnapshot_MutableCachedWritesUseCachedSnapshot(t *testing.T) {
+	d, err := Open(Options{Dir: t.TempDir(), FlushThreshold: 1 << 30})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer d.Close()
+
+	key := []byte("snapshot-mutable-key")
+	if err := d.Set(key, []byte("cached")); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("AcquireSnapshot=nil")
+	}
+	defer snap.Close()
+	if _, ok := snap.(*caching.Snapshot); !ok {
+		t.Fatalf("AcquireSnapshot type=%T want cached snapshot while mutable write is pending", snap)
+	}
+	got, err := snap.GetAppend(key, nil)
+	if err != nil {
+		t.Fatalf("snapshot GetAppend: %v", err)
+	}
+	if !bytes.Equal(got, []byte("cached")) {
+		t.Fatalf("snapshot value=%q want cached", string(got))
+	}
+}


### PR DESCRIPTION
## Objective

Reduce cached-mode `AcquireSnapshot`/`Snapshot.Close` allocation and contention for high-frequency read users, especially `random_read_parallel_acquire_snapshot`.

Fixes #2222. Part of #2216.

## Context / start plan

Subtask plan used for this PR:

| Chunk | Scope | Tests / evidence | Thinking |
| --- | --- | --- | --- |
| Contract inventory | Snapshot isolation, mutable rotation, root-domain published state, backend snapshot lifetime, close idempotence | Existing snapshot/root-group/read-after-write tests plus focused additions | xhigh manager |
| Implementation | Small safe backend-only acquisition seam; no top-level cached snapshot pooling because stale/double-close reuse is not provably safe | Focused unit tests and local deep review | xhigh manager |
| Review/perf | Internal high-thinking review, focused tests, durable before/after profile | pprof alloc/mutex/block and unified-bench table below | high reviewer + xhigh manager |

## Design

- Adds `caching.DB.AcquireBackendSnapshotFastPath()`.
- Public cached `TreeDB.DB.AcquireSnapshot()` returns a backend snapshot directly only when the cached layer has no mutable writes, no queued memtables, no root-domain in-memory/published state, and no dirty backend value-log read state.
- `caching.DB.AcquireSnapshot()` also uses the same backend-only eligibility to avoid tracked memtable-view reader registration for backend-only cached snapshots.
- If any cached/root/vlog state is present, acquisition falls back to the existing cached snapshot path, including mutable rotation for snapshot isolation.
- No unsafe cached `Snapshot` object pooling was added.
- Empty-view published root snapshots share immutable published-root/snapshot slices rather than cloning them per acquisition.

## Invariants / contract

- Mutable or queued cached writes remain visible through cached snapshots; backend fast path is rejected until they are absent.
- Root-domain published state remains pinned by cached snapshots; backend fast path is rejected when root-domain published/in-memory state exists.
- Backend fast-path snapshots use the normal backend snapshot lifetime and `Close` contract.
- Close idempotence is preserved for the supported snapshot lifetime; tests cover cached and backend fast-path immediate double close.
- Dirty value-log read state rejects backend fast path before and after backend snapshot acquisition so backend-only snapshots do not bypass required value-log visibility barriers.

## Scope

Includes:
- `TreeDB/caching/snapshot.go`
- `TreeDB/public.go`
- focused snapshot fast-path/isolation/lifetime tests

Excludes:
- mmap defaults/budgets
- on-disk format changes
- cached `Snapshot` pooling or new unsafe borrowed-lifetime APIs

## Correctness

Synced with latest `origin/main` after #2218/#2226 and #2217/#2227 (`origin/main` at `cfa13af7e97224088be030acce11641740f10734`). Current PR head is `9e0935526efa98065880ece72778c8fb041b5f90`.

Tests run on the synced head:

```sh
GOWORK=off go test ./TreeDB/caching ./TreeDB -run 'Snapshot|Acquire|Close|Isolation' -count=1
GOWORK=off go test ./TreeDB/caching ./TreeDB -count=1
GOWORK=off go test -race ./TreeDB -run '^TestAcquireSnapshot_ConcurrentFastPathAcquireCloseWithCheckpoints$' -count=1
```

Added coverage:
- backend-only fast path after checkpoint
- mutable cached write rejection/fallback
- dirty backend value-log state rejection, including dirty-after-clean-check race
- published root state rejection
- public backend fast-path isolation across later writes/checkpoints
- public fast-path allocs after warm
- concurrent acquire/read/close while writes/checkpoints run

Internal review:
- High-thinking Orca reviewer inspected the diff and ran focused snapshot tests plus a caching race smoke; no blocking findings. Non-blocking dirty-vlog coverage nit was addressed.
- Codex P2 on the raw backend snapshot value-log barrier race was fixed by rechecking dirty value-log state after backend snapshot acquisition and failing closed to cached snapshot fallback.

## Performance

Command (before on synced `origin/main`, after on current PR head; same local machine/environment):

```sh
./bin/unified-bench -dbs=treedb -keys=1000000 -profile=durable \
  -profile-dir="$OUT" -path-label=native-fastpath -format=markdown -progress=false \
  -test=random_read_parallel_acquire_snapshot,random_read_parallel,random_read
./bin/benchprof -profiles-dir "$OUT"
```

Final-base artifacts:
- Before (`origin/main` `cfa13af7e97224088be030acce11641740f10734`): `/tmp/gomap_2222_base_cfa13_20260602_220650`
- After (PR head `9e0935526efa98065880ece72778c8fb041b5f90`): `/tmp/gomap_2222_after_vlog_race_guard_20260602_223906`

| Metric | Before | After | Delta |
| --- | ---: | ---: | ---: |
| random_read_parallel_acquire_snapshot ops/sec | 450,732 | 462,038 | +2.5% |
| snapshot acquire avg_us | 4.280 | 1.109 | -74.1% |
| snapshot close avg_us | 0.338 | 0.292 | -13.6% |
| alloc profile total bytes | 1,892.19 MB | 79.64 MB | -95.8% |
| alloc profile total objects | 7,975,118 | 139,511 | -98.3% |
| `caching.(*DB).AcquireSnapshot` alloc bytes | 1,818.42 MB | 20.00 MB | -98.9% |
| `caching.(*DB).AcquireSnapshot` alloc objects | 7,944,781 | 87,401 | -98.9% |
| acquire-focused mutex delay | 3.46 s | 0.17 s | -95.1% |
| acquire-focused block delay | 3.09 s | 0.055 s | -98.2% |
| random_read_parallel ops/sec | 515,374 | 520,643 | +1.0% |
| random_read ops/sec | 272,719 | 301,090 | +10.4% |

Regression assessment: the targeted allocation/latency/contention metrics remain strongly improved on the final base. In the final-base run, mmap hit ratio stayed `1.000000` with `fallback_readat=0`.

Earlier pre-sync evidence on the original base showed the same direction with `random_read_parallel_acquire_snapshot` throughput `337,635 -> 484,524` ops/sec and `caching.(*DB).AcquireSnapshot` alloc bytes `1,877.43 MB -> 14.50 MB`.

## AI Review Loop

- Codex: initial review found no major issues; latest-main re-review found the value-log dirty race, fixed in `9e0935526efa98065880ece72778c8fb041b5f90`; final re-review on that head reported no major issues.
- Copilot: requested on PR #2228 after local tests/benchmark evidence and re-requested after latest-main sync/fix; no blocking Copilot comments observed as of the latest check.
- CodeRabbit: auto-triggered but org/review rate limit prevented a full review; status/comment documented on PR.
- CI: latest-head CI is green for `9e0935526efa98065880ece72778c8fb041b5f90`.

## Rollout / toggle

No new user-facing knob. Fast path fails closed to the existing cached snapshot path whenever cached/root/vlog state is present.

