### PR TITLE
TreeDB: reduce single-record WAL append checksum overhead

### DIFF
--- a/TreeDB/internal/commitlog/commitlog_test.go
+++ b/TreeDB/internal/commitlog/commitlog_test.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/snissn/gomap/TreeDB/internal/crc"
 )
 
 func TestCommitLogWriteReadBatch(t *testing.T) {
@@ -499,6 +501,70 @@ func TestCommitLogCorruptCRC(t *testing.T) {
 	reader, err := NewReader(path)
 	if err != nil {
 		t.Fatalf("new reader: %v", err)
+	}
+	_, err = reader.ReadBatch()
+	if !errors.Is(err, ErrCorrupt) {
+		_ = reader.Close()
+		t.Fatalf("expected corrupt error, got %v", err)
+	}
+	_ = reader.Close()
+}
+
+func TestCommitLogAppendSingleCRCMatchesPayloadBytes(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "commit.log")
+
+	writer, err := NewWriterWithOptions(path, Options{Compress: false})
+	if err != nil {
+		t.Fatalf("new writer: %v", err)
+	}
+	record := Record{Op: OpSetInline, Key: []byte("single-key"), Value: []byte("single-value"), Seq: 7}
+	if err := writer.Append(record); err != nil {
+		_ = writer.Close()
+		t.Fatalf("append single: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	if len(data) <= segmentHeaderSize {
+		t.Fatalf("unexpected segment size %d", len(data))
+	}
+	payloadLen := int(binary.LittleEndian.Uint32(data[0:4]) & segmentLenMask)
+	if payloadLen != len(data)-segmentHeaderSize {
+		t.Fatalf("payload len=%d want %d", payloadLen, len(data)-segmentHeaderSize)
+	}
+	gotCRC := binary.LittleEndian.Uint32(data[4:8])
+	if wantCRC := crc.Checksum(data[segmentHeaderSize:]); gotCRC != wantCRC {
+		t.Fatalf("stored crc=%08x want payload checksum=%08x", gotCRC, wantCRC)
+	}
+
+	reader, err := NewReader(path)
+	if err != nil {
+		t.Fatalf("new reader: %v", err)
+	}
+	got, err := reader.ReadBatch()
+	if err != nil {
+		_ = reader.Close()
+		t.Fatalf("read batch: %v", err)
+	}
+	if len(got) != 1 || got[0].Op != record.Op || got[0].Seq != record.Seq || !bytes.Equal(got[0].Key, record.Key) || !bytes.Equal(got[0].Value, record.Value) {
+		_ = reader.Close()
+		t.Fatalf("decoded single record mismatch: %+v", got)
+	}
+	_ = reader.Close()
+
+	data[segmentHeaderSize] ^= 0x80
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		t.Fatalf("write corrupt file: %v", err)
+	}
+	reader, err = NewReader(path)
+	if err != nil {
+		t.Fatalf("new corrupt reader: %v", err)
 	}
 	_, err = reader.ReadBatch()
 	if !errors.Is(err, ErrCorrupt) {

--- a/TreeDB/internal/commitlog/commitlog_test.go
+++ b/TreeDB/internal/commitlog/commitlog_test.go
@@ -511,67 +511,94 @@ func TestCommitLogCorruptCRC(t *testing.T) {
 }
 
 func TestCommitLogAppendSingleCRCMatchesPayloadBytes(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "commit.log")
-
-	writer, err := NewWriterWithOptions(path, Options{Compress: false})
-	if err != nil {
-		t.Fatalf("new writer: %v", err)
-	}
-	record := Record{Op: OpSetInline, Key: []byte("single-key"), Value: []byte("single-value"), Seq: 7}
-	if err := writer.Append(record); err != nil {
-		_ = writer.Close()
-		t.Fatalf("append single: %v", err)
-	}
-	if err := writer.Close(); err != nil {
-		t.Fatalf("close: %v", err)
-	}
-
-	data, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("read file: %v", err)
-	}
-	if len(data) <= segmentHeaderSize {
-		t.Fatalf("unexpected segment size %d", len(data))
-	}
-	payloadLen := int(binary.LittleEndian.Uint32(data[0:4]) & segmentLenMask)
-	if payloadLen != len(data)-segmentHeaderSize {
-		t.Fatalf("payload len=%d want %d", payloadLen, len(data)-segmentHeaderSize)
-	}
-	gotCRC := binary.LittleEndian.Uint32(data[4:8])
-	if wantCRC := crc.Checksum(data[segmentHeaderSize:]); gotCRC != wantCRC {
-		t.Fatalf("stored crc=%08x want payload checksum=%08x", gotCRC, wantCRC)
+	tests := []struct {
+		name     string
+		record   Record
+		wantLong bool
+	}{
+		{
+			name:   "small-direct-segment",
+			record: Record{Op: OpSetInline, Key: []byte("single-key"), Value: []byte("single-value"), Seq: 7},
+		},
+		{
+			name: "large-raw-segment",
+			record: Record{
+				Op:    OpSetInline,
+				Key:   []byte("single-large-key"),
+				Value: bytes.Repeat([]byte("large-value"), directSegmentPayloadMinLen/len("large-value")),
+				Seq:   8,
+			},
+			wantLong: true,
+		},
 	}
 
-	reader, err := NewReader(path)
-	if err != nil {
-		t.Fatalf("new reader: %v", err)
-	}
-	got, err := reader.ReadBatch()
-	if err != nil {
-		_ = reader.Close()
-		t.Fatalf("read batch: %v", err)
-	}
-	if len(got) != 1 || got[0].Op != record.Op || got[0].Seq != record.Seq || !bytes.Equal(got[0].Key, record.Key) || !bytes.Equal(got[0].Value, record.Value) {
-		_ = reader.Close()
-		t.Fatalf("decoded single record mismatch: %+v", got)
-	}
-	_ = reader.Close()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "commit.log")
 
-	data[segmentHeaderSize] ^= 0x80
-	if err := os.WriteFile(path, data, 0600); err != nil {
-		t.Fatalf("write corrupt file: %v", err)
+			writer, err := NewWriterWithOptions(path, Options{Compress: false})
+			if err != nil {
+				t.Fatalf("new writer: %v", err)
+			}
+			if err := writer.Append(tt.record); err != nil {
+				_ = writer.Close()
+				t.Fatalf("append single: %v", err)
+			}
+			if err := writer.Close(); err != nil {
+				t.Fatalf("close: %v", err)
+			}
+
+			data, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read file: %v", err)
+			}
+			if len(data) <= segmentHeaderSize {
+				t.Fatalf("unexpected segment size %d", len(data))
+			}
+			payloadLen := int(binary.LittleEndian.Uint32(data[0:4]) & segmentLenMask)
+			if payloadLen != len(data)-segmentHeaderSize {
+				t.Fatalf("payload len=%d want %d", payloadLen, len(data)-segmentHeaderSize)
+			}
+			if tt.wantLong && segmentHeaderSize+payloadLen < directSegmentPayloadMinLen {
+				t.Fatalf("large append did not cover raw segment threshold: total=%d threshold=%d", segmentHeaderSize+payloadLen, directSegmentPayloadMinLen)
+			}
+			gotCRC := binary.LittleEndian.Uint32(data[4:8])
+			if wantCRC := crc.Checksum(data[segmentHeaderSize:]); gotCRC != wantCRC {
+				t.Fatalf("stored crc=%08x want payload checksum=%08x", gotCRC, wantCRC)
+			}
+
+			reader, err := NewReader(path)
+			if err != nil {
+				t.Fatalf("new reader: %v", err)
+			}
+			got, err := reader.ReadBatch()
+			if err != nil {
+				_ = reader.Close()
+				t.Fatalf("read batch: %v", err)
+			}
+			if len(got) != 1 || got[0].Op != tt.record.Op || got[0].Seq != tt.record.Seq || !bytes.Equal(got[0].Key, tt.record.Key) || !bytes.Equal(got[0].Value, tt.record.Value) {
+				_ = reader.Close()
+				t.Fatalf("decoded single record mismatch: %+v", got)
+			}
+			_ = reader.Close()
+
+			data[segmentHeaderSize] ^= 0x80
+			if err := os.WriteFile(path, data, 0600); err != nil {
+				t.Fatalf("write corrupt file: %v", err)
+			}
+			reader, err = NewReader(path)
+			if err != nil {
+				t.Fatalf("new corrupt reader: %v", err)
+			}
+			_, err = reader.ReadBatch()
+			if !errors.Is(err, ErrCorrupt) {
+				_ = reader.Close()
+				t.Fatalf("expected corrupt error, got %v", err)
+			}
+			_ = reader.Close()
+		})
 	}
-	reader, err = NewReader(path)
-	if err != nil {
-		t.Fatalf("new corrupt reader: %v", err)
-	}
-	_, err = reader.ReadBatch()
-	if !errors.Is(err, ErrCorrupt) {
-		_ = reader.Close()
-		t.Fatalf("expected corrupt error, got %v", err)
-	}
-	_ = reader.Close()
 }
 
 func TestCommitLogAppendBatchRejectsMixedSequence(t *testing.T) {

--- a/TreeDB/internal/commitlog/writer.go
+++ b/TreeDB/internal/commitlog/writer.go
@@ -21,6 +21,7 @@ const (
 	defaultCompressMinLen      = 64 << 10
 	directSegmentPayloadMinLen = 128 << 10
 	directCommandPayloadMinLen = 64 << 10
+	batchChecksumChunkBytes    = 64 << 10
 )
 
 var syncDirFn = syncDir
@@ -350,6 +351,8 @@ func (w *Writer) AppendBatch(records []Record) error {
 	binary.LittleEndian.PutUint32(buf[1:5], uint32(len(records)))
 
 	off := batchHeaderSize
+	checksum := uint32(0)
+	checksumStart := 0
 	var zeroValueRef []byte
 	for i := range records {
 		r := &records[i]
@@ -418,11 +421,16 @@ func (w *Writer) AppendBatch(records []Record) error {
 			copy(buf[valueStart:valueEnd], r.Value)
 		}
 		off = next
+		if !w.compress && off-checksumStart >= batchChecksumChunkBytes {
+			checksum = crc.Update(checksum, buf[checksumStart:off])
+			checksumStart = off
+		}
 	}
 
 	w.scratch = buf[:off]
 	if !w.compress {
-		return w.writeRawSegmentWithChecksum(w.scratch, crc.ChecksumParts(w.scratch[:batchHeaderSize], w.scratch[batchHeaderSize:]))
+		checksum = crc.Update(checksum, w.scratch[checksumStart:])
+		return w.writeRawSegmentWithChecksum(w.scratch, checksum)
 	}
 	return w.writeSegment(w.scratch)
 }
@@ -490,6 +498,8 @@ func (w *Writer) appendZeroInlineBatchIfCompact(records []Record, batchSeq uint6
 	binary.LittleEndian.PutUint32(buf[13:17], uint32(valueLen))
 
 	off := zeroInlineBatchHeaderSize
+	checksum := uint32(0)
+	checksumStart := 0
 	for i := range records {
 		r := &records[i]
 		keyLen := uint16(len(r.Key))
@@ -497,9 +507,14 @@ func (w *Writer) appendZeroInlineBatchIfCompact(records []Record, batchSeq uint6
 		off += zeroInlineRecordHeaderSize
 		copy(buf[off:off+len(r.Key)], r.Key)
 		off += len(r.Key)
+		if off-checksumStart >= batchChecksumChunkBytes {
+			checksum = crc.Update(checksum, buf[checksumStart:off])
+			checksumStart = off
+		}
 	}
+	checksum = crc.Update(checksum, buf[checksumStart:])
 	w.scratch = buf
-	return true, w.writeRawSegmentWithChecksum(buf, crc.ChecksumParts(buf[:zeroInlineBatchHeaderSize], buf[zeroInlineBatchHeaderSize:]))
+	return true, w.writeRawSegmentWithChecksum(buf, checksum)
 }
 
 func (w *Writer) AppendZeroInlineBatchFunc(count int, seq uint64, valueLen int, keyAt func(int) []byte) error {
@@ -522,6 +537,8 @@ func (w *Writer) AppendZeroInlineBatchFunc(count int, seq uint64, valueLen int, 
 	binary.LittleEndian.PutUint32(buf[13:17], uint32(valueLen))
 
 	off := zeroInlineBatchHeaderSize
+	checksum := uint32(0)
+	checksumStart := 0
 	for i := 0; i < count; i++ {
 		key := keyAt(i)
 		if len(key) > int(^uint16(0)) {
@@ -557,9 +574,14 @@ func (w *Writer) AppendZeroInlineBatchFunc(count int, seq uint64, valueLen int, 
 		off += zeroInlineRecordHeaderSize
 		copy(buf[off:off+len(key)], key)
 		off += len(key)
+		if off-checksumStart >= batchChecksumChunkBytes {
+			checksum = crc.Update(checksum, buf[checksumStart:off])
+			checksumStart = off
+		}
 	}
+	checksum = crc.Update(checksum, buf[checksumStart:])
 	w.scratch = buf[:off]
-	return w.writeRawSegmentWithChecksum(w.scratch, crc.ChecksumParts(w.scratch[:zeroInlineBatchHeaderSize], w.scratch[zeroInlineBatchHeaderSize:]))
+	return w.writeRawSegmentWithChecksum(w.scratch, checksum)
 }
 
 func (w *Writer) AppendCommand(env CommandEnvelope) error {

--- a/TreeDB/internal/commitlog/writer.go
+++ b/TreeDB/internal/commitlog/writer.go
@@ -21,7 +21,6 @@ const (
 	defaultCompressMinLen      = 64 << 10
 	directSegmentPayloadMinLen = 128 << 10
 	directCommandPayloadMinLen = 64 << 10
-	batchChecksumChunkBytes    = 64 << 10
 )
 
 var syncDirFn = syncDir
@@ -267,10 +266,46 @@ func (w *Writer) Append(record Record) error {
 		return ErrRecordTooLarge
 	}
 
-	if cap(w.scratch) < int(total) {
-		w.scratch = make([]byte, int(total))
+	payloadLen := int(total)
+	if payloadLen > int(segmentLenMask) {
+		return ErrRecordTooLarge
 	}
-	buf := w.scratch[:int(total)]
+	if !w.compress && segmentHeaderSize+payloadLen < directSegmentPayloadMinLen {
+		if err := w.flushBufferedCommandFrames(); err != nil {
+			return err
+		}
+		totalLen := segmentHeaderSize + payloadLen
+		if cap(w.scratch) < totalLen {
+			w.scratch = make([]byte, totalLen)
+		}
+		buf := w.scratch[:totalLen]
+		payload := buf[segmentHeaderSize:]
+
+		payload[0] = Version
+		binary.LittleEndian.PutUint32(payload[1:5], 1)
+
+		off := batchHeaderSize
+		payload[off] = record.Op
+		binary.LittleEndian.PutUint16(payload[off+1:off+3], keyLen)
+		binary.LittleEndian.PutUint32(payload[off+3:off+7], valLen)
+		binary.LittleEndian.PutUint64(payload[off+7:off+15], record.RID)
+		binary.LittleEndian.PutUint64(payload[off+15:off+23], record.Seq)
+		copy(payload[off+recordHeaderSize:], record.Key)
+		copy(payload[off+recordHeaderSize+len(record.Key):], record.Value)
+
+		binary.LittleEndian.PutUint32(buf[0:4], uint32(payloadLen))
+		binary.LittleEndian.PutUint32(buf[4:8], crc.Checksum(payload))
+		if _, err := w.bw.Write(buf); err != nil {
+			return err
+		}
+		w.size += int64(totalLen)
+		return nil
+	}
+
+	if cap(w.scratch) < payloadLen {
+		w.scratch = make([]byte, payloadLen)
+	}
+	buf := w.scratch[:payloadLen]
 
 	buf[0] = Version
 	binary.LittleEndian.PutUint32(buf[1:5], 1)
@@ -312,8 +347,6 @@ func (w *Writer) AppendBatch(records []Record) error {
 	binary.LittleEndian.PutUint32(buf[1:5], uint32(len(records)))
 
 	off := batchHeaderSize
-	checksum := uint32(0)
-	checksumStart := 0
 	var zeroValueRef []byte
 	for i := range records {
 		r := &records[i]
@@ -382,16 +415,11 @@ func (w *Writer) AppendBatch(records []Record) error {
 			copy(buf[valueStart:valueEnd], r.Value)
 		}
 		off = next
-		if !w.compress && off-checksumStart >= batchChecksumChunkBytes {
-			checksum = crc.Update(checksum, buf[checksumStart:off])
-			checksumStart = off
-		}
 	}
 
 	w.scratch = buf[:off]
 	if !w.compress {
-		checksum = crc.Update(checksum, w.scratch[checksumStart:])
-		return w.writeRawSegmentWithChecksum(w.scratch, checksum)
+		return w.writeRawSegmentWithChecksum(w.scratch, crc.Checksum(w.scratch))
 	}
 	return w.writeSegment(w.scratch)
 }
@@ -459,8 +487,6 @@ func (w *Writer) appendZeroInlineBatchIfCompact(records []Record, batchSeq uint6
 	binary.LittleEndian.PutUint32(buf[13:17], uint32(valueLen))
 
 	off := zeroInlineBatchHeaderSize
-	checksum := uint32(0)
-	checksumStart := 0
 	for i := range records {
 		r := &records[i]
 		keyLen := uint16(len(r.Key))
@@ -468,14 +494,9 @@ func (w *Writer) appendZeroInlineBatchIfCompact(records []Record, batchSeq uint6
 		off += zeroInlineRecordHeaderSize
 		copy(buf[off:off+len(r.Key)], r.Key)
 		off += len(r.Key)
-		if off-checksumStart >= batchChecksumChunkBytes {
-			checksum = crc.Update(checksum, buf[checksumStart:off])
-			checksumStart = off
-		}
 	}
-	checksum = crc.Update(checksum, buf[checksumStart:])
 	w.scratch = buf
-	return true, w.writeRawSegmentWithChecksum(buf, checksum)
+	return true, w.writeRawSegmentWithChecksum(buf, crc.Checksum(buf))
 }
 
 func (w *Writer) AppendZeroInlineBatchFunc(count int, seq uint64, valueLen int, keyAt func(int) []byte) error {
@@ -498,8 +519,6 @@ func (w *Writer) AppendZeroInlineBatchFunc(count int, seq uint64, valueLen int, 
 	binary.LittleEndian.PutUint32(buf[13:17], uint32(valueLen))
 
 	off := zeroInlineBatchHeaderSize
-	checksum := uint32(0)
-	checksumStart := 0
 	for i := 0; i < count; i++ {
 		key := keyAt(i)
 		if len(key) > int(^uint16(0)) {
@@ -535,14 +554,9 @@ func (w *Writer) AppendZeroInlineBatchFunc(count int, seq uint64, valueLen int, 
 		off += zeroInlineRecordHeaderSize
 		copy(buf[off:off+len(key)], key)
 		off += len(key)
-		if off-checksumStart >= batchChecksumChunkBytes {
-			checksum = crc.Update(checksum, buf[checksumStart:off])
-			checksumStart = off
-		}
 	}
-	checksum = crc.Update(checksum, buf[checksumStart:])
 	w.scratch = buf[:off]
-	return w.writeRawSegmentWithChecksum(w.scratch, checksum)
+	return w.writeRawSegmentWithChecksum(w.scratch, crc.Checksum(w.scratch))
 }
 
 func (w *Writer) AppendCommand(env CommandEnvelope) error {

--- a/TreeDB/internal/commitlog/writer.go
+++ b/TreeDB/internal/commitlog/writer.go
@@ -294,7 +294,7 @@ func (w *Writer) Append(record Record) error {
 		copy(payload[off+recordHeaderSize+len(record.Key):], record.Value)
 
 		binary.LittleEndian.PutUint32(buf[0:4], uint32(payloadLen))
-		binary.LittleEndian.PutUint32(buf[4:8], crc.Checksum(payload))
+		binary.LittleEndian.PutUint32(buf[4:8], crc.ChecksumParts(payload[:batchHeaderSize], payload[batchHeaderSize:]))
 		if _, err := w.bw.Write(buf); err != nil {
 			return err
 		}
@@ -319,6 +319,9 @@ func (w *Writer) Append(record Record) error {
 	copy(buf[off+recordHeaderSize:], record.Key)
 	copy(buf[off+recordHeaderSize+len(record.Key):], record.Value)
 
+	if !w.compress {
+		return w.writeRawSegmentWithChecksum(buf, crc.ChecksumParts(buf[:batchHeaderSize], buf[batchHeaderSize:]))
+	}
 	return w.writeSegment(buf)
 }
 
@@ -419,7 +422,7 @@ func (w *Writer) AppendBatch(records []Record) error {
 
 	w.scratch = buf[:off]
 	if !w.compress {
-		return w.writeRawSegmentWithChecksum(w.scratch, crc.Checksum(w.scratch))
+		return w.writeRawSegmentWithChecksum(w.scratch, crc.ChecksumParts(w.scratch[:batchHeaderSize], w.scratch[batchHeaderSize:]))
 	}
 	return w.writeSegment(w.scratch)
 }
@@ -496,7 +499,7 @@ func (w *Writer) appendZeroInlineBatchIfCompact(records []Record, batchSeq uint6
 		off += len(r.Key)
 	}
 	w.scratch = buf
-	return true, w.writeRawSegmentWithChecksum(buf, crc.Checksum(buf))
+	return true, w.writeRawSegmentWithChecksum(buf, crc.ChecksumParts(buf[:zeroInlineBatchHeaderSize], buf[zeroInlineBatchHeaderSize:]))
 }
 
 func (w *Writer) AppendZeroInlineBatchFunc(count int, seq uint64, valueLen int, keyAt func(int) []byte) error {
@@ -556,7 +559,7 @@ func (w *Writer) AppendZeroInlineBatchFunc(count int, seq uint64, valueLen int, 
 		off += len(key)
 	}
 	w.scratch = buf[:off]
-	return w.writeRawSegmentWithChecksum(w.scratch, crc.Checksum(w.scratch))
+	return w.writeRawSegmentWithChecksum(w.scratch, crc.ChecksumParts(w.scratch[:zeroInlineBatchHeaderSize], w.scratch[zeroInlineBatchHeaderSize:]))
 }
 
 func (w *Writer) AppendCommand(env CommandEnvelope) error {

--- a/TreeDB/internal/valuelog/valuelog_test.go
+++ b/TreeDB/internal/valuelog/valuelog_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/golang/snappy"
 	"github.com/snissn/compress/zstd"
+	"github.com/snissn/gomap/TreeDB/internal/crc"
 	"github.com/snissn/gomap/TreeDB/page"
 	templ "github.com/snissn/gomap/TreeDB/template"
 )
@@ -1826,6 +1827,105 @@ func TestValueLogCorruptCRC(t *testing.T) {
 	if !errors.Is(err, ErrCorrupt) {
 		_ = reader.Close()
 		t.Fatalf("expected corrupt error, got %v", err)
+	}
+	_ = reader.Close()
+}
+
+func TestValueLogGroupedFrameCRCMatchesContiguousRecordBytes(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "value-000001.log")
+	fileID := page.ValueLogFileID(1)
+
+	writer, err := NewWriter(path, fileID)
+	if err != nil {
+		t.Fatalf("new writer: %v", err)
+	}
+	records := []Record{
+		{RID: 1, Value: []byte("alpha")},
+		{RID: 2, Value: []byte("bravo-bravo")},
+	}
+	if _, _, err := writer.AppendFrameWithStatsInto(0, nil, records, make([]page.ValuePtr, len(records))); err != nil {
+		_ = writer.Close()
+		t.Fatalf("append grouped frame: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	if len(data) <= HeaderSize {
+		t.Fatalf("unexpected record size %d", len(data))
+	}
+	got := binary.LittleEndian.Uint32(data[0:4])
+	if want := crc.Checksum(data[4:]); got != want {
+		t.Fatalf("stored crc=%08x want contiguous checksum=%08x", got, want)
+	}
+
+	data[5] ^= 0x40 // mutate grouped header bytes that are covered by the CRC.
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		t.Fatalf("write corrupt file: %v", err)
+	}
+	reader, err := NewReader(path, fileID)
+	if err != nil {
+		t.Fatalf("new reader: %v", err)
+	}
+	_, _, _, err = reader.ReadNext()
+	if !errors.Is(err, ErrCorrupt) {
+		_ = reader.Close()
+		t.Fatalf("expected corrupt header error, got %v", err)
+	}
+	_ = reader.Close()
+}
+
+func TestValueLogCompressedGroupedFrameCRCMatchesContiguousRecordBytes(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "value-000001.log")
+	fileID := page.ValueLogFileID(1)
+
+	writer, err := NewWriter(path, fileID)
+	if err != nil {
+		t.Fatalf("new writer: %v", err)
+	}
+	writer.SetBlockCompression(BlockCodecSnappy, true)
+	records := []Record{{RID: 1, Value: bytes.Repeat([]byte("A"), 4096)}}
+	if _, stats, err := writer.AppendFrameWithStatsInto(0, nil, records, make([]page.ValuePtr, len(records))); err != nil {
+		_ = writer.Close()
+		t.Fatalf("append compressed grouped frame: %v", err)
+	} else if !stats.Kept {
+		_ = writer.Close()
+		t.Fatalf("expected block-compressed frame to be kept: %+v", stats)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	if len(data) <= HeaderSize {
+		t.Fatalf("unexpected record size %d", len(data))
+	}
+	got := binary.LittleEndian.Uint32(data[0:4])
+	if want := crc.Checksum(data[4:]); got != want {
+		t.Fatalf("stored crc=%08x want contiguous checksum=%08x", got, want)
+	}
+
+	data[len(data)-1] ^= 0x01
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		t.Fatalf("write corrupt file: %v", err)
+	}
+	reader, err := NewReader(path, fileID)
+	if err != nil {
+		t.Fatalf("new reader: %v", err)
+	}
+	_, _, _, err = reader.ReadNext()
+	if !errors.Is(err, ErrCorrupt) {
+		_ = reader.Close()
+		t.Fatalf("expected corrupt compressed payload error, got %v", err)
 	}
 	_ = reader.Close()
 }

--- a/TreeDB/internal/valuelog/writer.go
+++ b/TreeDB/internal/valuelog/writer.go
@@ -909,7 +909,7 @@ func (w *Writer) Append(dictID uint64, dict []byte, rid uint64, value []byte) (p
 			off += 8
 			copy(buf[off:], value)
 
-			sum := crc.ChecksumParts(buf[4:HeaderSize], buf[HeaderSize:])
+			sum := crc.Checksum(buf[4:])
 			binary.LittleEndian.PutUint32(buf[0:4], sum)
 			w.size += int64(recordLen)
 
@@ -957,7 +957,7 @@ func (w *Writer) Append(dictID uint64, dict []byte, rid uint64, value []byte) (p
 		off += 8
 		copy(buf[off:], value)
 
-		sum := crc.ChecksumParts(buf[4:HeaderSize], buf[HeaderSize:])
+		sum := crc.Checksum(buf[4:])
 		binary.LittleEndian.PutUint32(buf[0:4], sum)
 
 		if err := w.writeBytes(buf); err != nil {
@@ -1093,7 +1093,7 @@ func (w *Writer) AppendEncodedFrameInto(body []byte, k int, dst []page.ValuePtr)
 	binary.LittleEndian.PutUint32(buf[16:20], bodyLen)
 	copy(buf[HeaderSize:], body)
 
-	sum := crc.ChecksumParts(buf[4:HeaderSize], body)
+	sum := crc.Checksum(buf[4:])
 	binary.LittleEndian.PutUint32(buf[0:4], sum)
 
 	if err := w.writeBytes(buf); err != nil {
@@ -1173,7 +1173,7 @@ func (w *Writer) AppendFrameWithStatsInto(dictID uint64, dict []byte, records []
 		off += 8
 		copy(buf[off:], rec.Value)
 
-		sum := crc.ChecksumParts(buf[4:HeaderSize], buf[HeaderSize:])
+		sum := crc.Checksum(buf[4:])
 		binary.LittleEndian.PutUint32(buf[0:4], sum)
 
 		if err := w.writeBytes(buf); err != nil {
@@ -1299,7 +1299,7 @@ func (w *Writer) AppendFrameWithStatsInto(dictID uint64, dict []byte, records []
 				off += len(records[i].Value)
 			}
 
-			sum := crc.ChecksumParts(frame[4:HeaderSize], frame[HeaderSize:])
+			sum := crc.Checksum(frame[4:])
 			binary.LittleEndian.PutUint32(frame[0:4], sum)
 			w.size += int64(HeaderSize + bodyLen)
 
@@ -1359,7 +1359,7 @@ func (w *Writer) AppendFrameWithStatsInto(dictID uint64, dict []byte, records []
 				copy(frame[off:], records[i].Value)
 				off += len(records[i].Value)
 			}
-			sum := crc.ChecksumParts(frame[4:HeaderSize], frame[HeaderSize:])
+			sum := crc.Checksum(frame[4:])
 			binary.LittleEndian.PutUint32(frame[0:4], sum)
 			if err := w.writeFrameBatch(frame); err != nil {
 				return nil, FrameStats{}, err
@@ -1598,8 +1598,7 @@ func (w *Writer) AppendFrameWithStatsInto(dictID uint64, dict []byte, records []
 			binary.LittleEndian.PutUint64(header[8:16], 0)
 			binary.LittleEndian.PutUint32(header[16:20], uint32(bodyLen))
 
-			encoded := w.appendBuf[encodedStart:]
-			sum := crc.ChecksumParts(header[4:HeaderSize], prefix, encoded)
+			sum := crc.Checksum(w.appendBuf[recordStart+4:])
 			binary.LittleEndian.PutUint32(header[0:4], sum)
 
 			w.size += int64(HeaderSize + bodyLen)
@@ -1815,7 +1814,7 @@ func (w *Writer) AppendFrameWithStatsInto(dictID uint64, dict []byte, records []
 	binary.LittleEndian.PutUint32(buf[16:20], bodyLen)
 	copy(buf[HeaderSize:], body)
 
-	sum := crc.ChecksumParts(buf[4:HeaderSize], body)
+	sum := crc.Checksum(buf[4:])
 	binary.LittleEndian.PutUint32(buf[0:4], sum)
 
 	if err := w.writeBytes(buf); err != nil {
@@ -1996,7 +1995,7 @@ func (w *Writer) appendBlockFrameWithStats(records []Record, rawPayloadBytes int
 	}
 	copy(buf[frameOff:], encoded)
 
-	sum := crc.ChecksumParts(buf[4:HeaderSize], buf[HeaderSize:])
+	sum := crc.Checksum(buf[4:])
 	binary.LittleEndian.PutUint32(buf[0:4], sum)
 	if err := w.writeBytes(buf); err != nil {
 		return nil, FrameStats{}, err
@@ -2107,7 +2106,7 @@ func (w *Writer) appendRawFrameWithDictID(dictID uint64, records []Record, offse
 			off += len(records[i].Value)
 		}
 
-		sum := crc.ChecksumParts(frame[4:HeaderSize], frame[HeaderSize:])
+		sum := crc.Checksum(frame[4:])
 		binary.LittleEndian.PutUint32(frame[0:4], sum)
 		w.size += int64(HeaderSize + bodyLen)
 
@@ -2167,7 +2166,7 @@ func (w *Writer) appendRawFrameWithDictID(dictID uint64, records []Record, offse
 			copy(frame[off:], records[i].Value)
 			off += len(records[i].Value)
 		}
-		sum := crc.ChecksumParts(frame[4:HeaderSize], frame[HeaderSize:])
+		sum := crc.Checksum(frame[4:])
 		binary.LittleEndian.PutUint32(frame[0:4], sum)
 		if err := w.writeFrameBatch(frame); err != nil {
 			return nil, FrameStats{}, err

--- a/TreeDB/internal/valuelog/writer.go
+++ b/TreeDB/internal/valuelog/writer.go
@@ -909,7 +909,7 @@ func (w *Writer) Append(dictID uint64, dict []byte, rid uint64, value []byte) (p
 			off += 8
 			copy(buf[off:], value)
 
-			sum := crc.Checksum(buf[4:])
+			sum := crc.ChecksumParts(buf[4:HeaderSize], buf[HeaderSize:])
 			binary.LittleEndian.PutUint32(buf[0:4], sum)
 			w.size += int64(recordLen)
 
@@ -957,7 +957,7 @@ func (w *Writer) Append(dictID uint64, dict []byte, rid uint64, value []byte) (p
 		off += 8
 		copy(buf[off:], value)
 
-		sum := crc.Checksum(buf[4:])
+		sum := crc.ChecksumParts(buf[4:HeaderSize], buf[HeaderSize:])
 		binary.LittleEndian.PutUint32(buf[0:4], sum)
 
 		if err := w.writeBytes(buf); err != nil {
@@ -1093,7 +1093,7 @@ func (w *Writer) AppendEncodedFrameInto(body []byte, k int, dst []page.ValuePtr)
 	binary.LittleEndian.PutUint32(buf[16:20], bodyLen)
 	copy(buf[HeaderSize:], body)
 
-	sum := crc.Checksum(buf[4:])
+	sum := crc.ChecksumParts(buf[4:HeaderSize], body)
 	binary.LittleEndian.PutUint32(buf[0:4], sum)
 
 	if err := w.writeBytes(buf); err != nil {
@@ -1173,7 +1173,7 @@ func (w *Writer) AppendFrameWithStatsInto(dictID uint64, dict []byte, records []
 		off += 8
 		copy(buf[off:], rec.Value)
 
-		sum := crc.Checksum(buf[4:])
+		sum := crc.ChecksumParts(buf[4:HeaderSize], buf[HeaderSize:])
 		binary.LittleEndian.PutUint32(buf[0:4], sum)
 
 		if err := w.writeBytes(buf); err != nil {
@@ -1299,7 +1299,7 @@ func (w *Writer) AppendFrameWithStatsInto(dictID uint64, dict []byte, records []
 				off += len(records[i].Value)
 			}
 
-			sum := crc.Checksum(frame[4:])
+			sum := crc.ChecksumParts(frame[4:HeaderSize], frame[HeaderSize:])
 			binary.LittleEndian.PutUint32(frame[0:4], sum)
 			w.size += int64(HeaderSize + bodyLen)
 
@@ -1359,7 +1359,7 @@ func (w *Writer) AppendFrameWithStatsInto(dictID uint64, dict []byte, records []
 				copy(frame[off:], records[i].Value)
 				off += len(records[i].Value)
 			}
-			sum := crc.Checksum(frame[4:])
+			sum := crc.ChecksumParts(frame[4:HeaderSize], frame[HeaderSize:])
 			binary.LittleEndian.PutUint32(frame[0:4], sum)
 			if err := w.writeFrameBatch(frame); err != nil {
 				return nil, FrameStats{}, err
@@ -1598,7 +1598,8 @@ func (w *Writer) AppendFrameWithStatsInto(dictID uint64, dict []byte, records []
 			binary.LittleEndian.PutUint64(header[8:16], 0)
 			binary.LittleEndian.PutUint32(header[16:20], uint32(bodyLen))
 
-			sum := crc.Checksum(w.appendBuf[recordStart+4:])
+			encoded := w.appendBuf[encodedStart:]
+			sum := crc.ChecksumParts(header[4:HeaderSize], prefix, encoded)
 			binary.LittleEndian.PutUint32(header[0:4], sum)
 
 			w.size += int64(HeaderSize + bodyLen)
@@ -1814,7 +1815,7 @@ func (w *Writer) AppendFrameWithStatsInto(dictID uint64, dict []byte, records []
 	binary.LittleEndian.PutUint32(buf[16:20], bodyLen)
 	copy(buf[HeaderSize:], body)
 
-	sum := crc.Checksum(buf[4:])
+	sum := crc.ChecksumParts(buf[4:HeaderSize], body)
 	binary.LittleEndian.PutUint32(buf[0:4], sum)
 
 	if err := w.writeBytes(buf); err != nil {
@@ -1995,7 +1996,7 @@ func (w *Writer) appendBlockFrameWithStats(records []Record, rawPayloadBytes int
 	}
 	copy(buf[frameOff:], encoded)
 
-	sum := crc.Checksum(buf[4:])
+	sum := crc.ChecksumParts(buf[4:HeaderSize], buf[HeaderSize:])
 	binary.LittleEndian.PutUint32(buf[0:4], sum)
 	if err := w.writeBytes(buf); err != nil {
 		return nil, FrameStats{}, err
@@ -2106,7 +2107,7 @@ func (w *Writer) appendRawFrameWithDictID(dictID uint64, records []Record, offse
 			off += len(records[i].Value)
 		}
 
-		sum := crc.Checksum(frame[4:])
+		sum := crc.ChecksumParts(frame[4:HeaderSize], frame[HeaderSize:])
 		binary.LittleEndian.PutUint32(frame[0:4], sum)
 		w.size += int64(HeaderSize + bodyLen)
 
@@ -2166,7 +2167,7 @@ func (w *Writer) appendRawFrameWithDictID(dictID uint64, records []Record, offse
 			copy(frame[off:], records[i].Value)
 			off += len(records[i].Value)
 		}
-		sum := crc.Checksum(frame[4:])
+		sum := crc.ChecksumParts(frame[4:HeaderSize], frame[HeaderSize:])
 		binary.LittleEndian.PutUint32(frame[0:4], sum)
 		if err := w.writeFrameBatch(frame); err != nil {
 			return nil, FrameStats{}, err


### PR DESCRIPTION
Closes #2219
Refs #2216

## Summary

This narrows the #2219 durable write-path optimization to the TreeDB commitlog single-record WAL append path:

- Prebuild small uncompressed single-record commitlog segments as `segment-header + payload` in one contiguous scratch buffer and write that directly to the buffered WAL writer.
- Use the raw segment writer for large uncompressed single-record appends with an explicit checksum over the same payload bytes.
- Keep compressed append behavior unchanged.
- Restore/keep batch WAL checksum streaming and zero-inline batch behavior unchanged vs `origin/main` to avoid `batch_write_steady` risk.
- No net `TreeDB/internal/valuelog/writer.go` change; value-log writer behavior is unchanged.
- Add focused CRC coverage for the new commitlog single-append path and grouped value-log frame CRC coverage.

## Semantics / contract

- WAL remains enabled in durable mode.
- No sync/fsync policy changes.
- No recovery ordering changes.
- Commitlog CRC coverage remains over the exact segment payload bytes read by the existing reader.
- Batch WAL paths and value-log writer paths are unchanged vs current `origin/main`.

## Correctness tests

Passed locally on head `ff4185868` (final commit is test-only vs benchmarked code `3cd64e4e0`):

```sh
GOWORK=off go test ./TreeDB/internal/commitlog ./TreeDB/internal/valuelog -count=1
GOWORK=off go test ./TreeDB ./TreeDB/caching ./TreeDB/db -run 'WAL|Reopen|Recovery|Checkpoint|WriteSync' -count=1
GOWORK=off go test ./TreeDB/... -count=1
```

## Durable write benchmarks

Remote host/repo:

```text
mikers@192.168.0.185:/home/mikers/tmp/gomap_2219_bench_repo
```

Command shape:

```sh
./bin/unified-bench \
  -dbs=treedb \
  -keys=1000000 \
  -profile=durable \
  -profile-dir="$OUT" \
  -path-label=native-fastpath \
  -format=markdown \
  -progress=false \
  -test=sequential_write,random_write,dataset_write_random,dataset_write_sorted,batch_write_steady
./bin/benchprof -profiles-dir "$OUT"
```

Artifacts:

- Baseline (`origin/main` at `cfa13af7e97224088be030acce11641740f10734`): `/home/mikers/tmp/gomap_2219_baseline2_matrix_20260602_221423`
- After code head (`3cd64e4e0`; final `ff4185868` is test-only): `/home/mikers/tmp/gomap_2219_after_3cd64e4_matrix_20260602_221706`

| Test | Baseline ops/s | After ops/s | Delta |
| --- | ---: | ---: | ---: |
| sequential_write | 1,589,945 | 2,177,471 | +36.95% |
| random_write | 1,286,510 | 1,645,979 | +27.94% |
| dataset_write_random | 1,042,672 | 1,252,737 | +20.15% |
| dataset_write_sorted | 1,211,197 | 1,541,767 | +27.29% |
| batch_write_steady | 438,382 | 429,427 | -2.04% |

`batch_write_steady` is not claimed as improved. The final patch restores batch checksum streaming; the repeated full-matrix result is within the observed noise band and the focused batch-only sanity runs were also noisy:

- Baseline focused: `1,328,900`, `1,369,480` ops/s
- After focused: `1,346,355`, `1,228,762` ops/s

## CPU/profile evidence

Representative sequential-write cumulative CPU profile snippets:

Baseline artifact:

```text
/home/mikers/tmp/gomap_2219_baseline2_matrix_20260602_221423/cpu_sequential_write_treedb.pprof
Duration: 803.80ms, Total samples = 1.12s
appendWALOne                0.33s 29.46% cum
commitlog.(*Writer).Append  0.30s 26.79% cum
commitlog.(*Writer).writeSegment 0.30s 26.79% cum
crc.Checksum / asm.Update   0.20s 17.86% cum
combineCached               0.13s 11.61% cum
bufio.(*Writer).Write       0.12s 10.71% cum
```

After artifact:

```text
/home/mikers/tmp/gomap_2219_after_3cd64e4_matrix_20260602_221706/cpu_sequential_write_treedb.pprof
Duration: 703.54ms, Total samples = 950ms
appendWALOne                120ms 12.63% cum
commitlog.(*Writer).Append  110ms 11.58% cum
crc.ChecksumParts            60ms  6.32% cum
bufio.(*Writer).Write        50ms  5.26% cum
```

benchprof outputs are in each artifact directory (`benchprof_results.md`, `benchprof_results.json`, `insights.md`, `insights.json`, `insights.html`).
