### PR TITLE
TreeDB: specialize sorted cached batch writes

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -29628,28 +29628,34 @@ func (b *Batch) writeRegular(syncWrite bool) error {
 				}
 			}
 			storeInlinePtrValues := !b.db.memtableValueLogPointers
-			if useStream && useSteal {
-				if applier, ok := shard.mem.(memtable.TrustedSortedBatchApplier); ok {
-					applier.ApplyStealSortedBatchTrusted(entries, nil)
-				} else if applier, ok := shard.mem.(memtable.SortedBatchApplier); ok {
-					applier.ApplyStealSortedBatch(entries, nil)
-				} else {
-					for _, op := range entries {
-						if op.Type == batch.OpDelete {
-							memtableBatchDelete(shard.mem, true, op.Key)
-						} else {
-							memtableBatchSet(shard.mem, true, allowBatchArenaBorrow, storeInlinePtrValues, op)
+			appliedSortedRun := false
+			if useStream {
+				if useSteal {
+					if applier, ok := shard.mem.(memtable.TrustedSortedBatchApplier); ok {
+						applier.ApplyStealSortedBatchTrusted(entries, nil)
+					} else if applier, ok := shard.mem.(memtable.SortedBatchApplier); ok {
+						applier.ApplyStealSortedBatch(entries, nil)
+					} else {
+						for _, op := range entries {
+							if op.Type == batch.OpDelete {
+								memtableBatchDelete(shard.mem, true, op.Key)
+							} else {
+								memtableBatchSet(shard.mem, true, allowBatchArenaBorrow, storeInlinePtrValues, op)
+							}
 						}
 					}
+					appliedSortedRun = true
+				} else if applier, ok := shard.mem.(memtable.CopySortedBatchApplier); ok {
+					if borrowed := applier.ApplyCopySortedBatchTrusted(entries, allowBatchArenaBorrow, storeInlinePtrValues, nil); borrowed {
+						if _, ok := retainMainSeen[shard.mem]; !ok {
+							retainMainSeen[shard.mem] = struct{}{}
+							retainMainMems = append(retainMainMems, shard.mem)
+						}
+					}
+					appliedSortedRun = true
 				}
-				first := entries[0].Key
-				last := entries[len(entries)-1].Key
-				shard.rng.add(first)
-				if len(entries) > 1 {
-					shard.rng.add(last)
-				}
-				b.db.noteWriteSortedRun(first, last, len(entries))
-			} else {
+			}
+			if !appliedSortedRun {
 				for _, op := range entries {
 					if op.Type == batch.OpDelete {
 						memtableBatchDelete(shard.mem, useSteal, op.Key)
@@ -29673,21 +29679,21 @@ func (b *Batch) writeRegular(syncWrite bool) error {
 						}
 					}
 					if useStream {
-						// Preserve sorted-run accounting even when we avoid Steal.
+						// Preserve sorted-run accounting even when no sorted batch applier is available.
 						continue
 					}
 					shard.rng.add(op.Key)
 					b.db.noteWriteKey(op.Key)
 				}
-				if useStream {
-					first := entries[0].Key
-					last := entries[len(entries)-1].Key
-					shard.rng.add(first)
-					if len(entries) > 1 {
-						shard.rng.add(last)
-					}
-					b.db.noteWriteSortedRun(first, last, len(entries))
+			}
+			if useStream {
+				first := entries[0].Key
+				last := entries[len(entries)-1].Key
+				shard.rng.add(first)
+				if len(entries) > 1 {
+					shard.rng.add(last)
 				}
+				b.db.noteWriteSortedRun(first, last, len(entries))
 			}
 			newBytes := shard.mem.Size()
 			delta := newBytes - shard.bytes

--- a/TreeDB/caching/sorted_write_fastpath_test.go
+++ b/TreeDB/caching/sorted_write_fastpath_test.go
@@ -1,0 +1,140 @@
+package caching
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/batch"
+	"github.com/snissn/gomap/TreeDB/internal/memtable"
+	"github.com/snissn/gomap/TreeDB/node"
+)
+
+type recordingCopySortedMem struct {
+	memtable.Table
+	calls int
+}
+
+func (m *recordingCopySortedMem) ApplyCopySortedBatchTrusted(entries []batch.Entry, borrowValues bool, storeInlinePtrValues bool, onKey func(key []byte)) bool {
+	m.calls++
+	if applier, ok := m.Table.(memtable.CopySortedBatchApplier); ok {
+		return applier.ApplyCopySortedBatchTrusted(entries, borrowValues, storeInlinePtrValues, onKey)
+	}
+	for _, op := range entries {
+		if op.Type == batch.OpDelete {
+			m.Table.Delete(op.Key)
+		} else if op.IsPtr {
+			m.Table.SetEntry(op.Key, op.Value, op.ValuePtr, node.FlagPointer)
+		} else {
+			m.Table.Set(op.Key, op.Value)
+		}
+		if onKey != nil {
+			onKey(op.Key)
+		}
+	}
+	return false
+}
+
+func newSortedWriteFastPathDB(t *testing.T) (*DB, *recordingCopySortedMem) {
+	t.Helper()
+	db, err := Open(t.TempDir(), NewMockBackend(), Options{
+		FlushThreshold: 8 << 20,
+		MemtableMode:   "append_only",
+		MemtableShards: 1,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	shard := &db.mutableShards[0]
+	shard.mu.Lock()
+	rec := &recordingCopySortedMem{Table: shard.mem}
+	shard.mem = rec
+	shard.mu.Unlock()
+	db.mu.Lock()
+	db.publishMemtablesLocked()
+	db.mu.Unlock()
+	return db, rec
+}
+
+func requireCachedValue(t *testing.T, db *DB, key, want []byte) {
+	t.Helper()
+	got, err := db.Get(key)
+	if err != nil {
+		t.Fatalf("Get(%q): %v", key, err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("Get(%q)=%q want %q", key, got, want)
+	}
+}
+
+func TestBatchWriteSortedUniqueUsesCopySortedFastPath(t *testing.T) {
+	db, rec := newSortedWriteFastPathDB(t)
+	defer db.Close()
+
+	b := db.NewBatchWithSize(3)
+	if err := b.Set([]byte("a"), []byte("va")); err != nil {
+		t.Fatalf("Set(a): %v", err)
+	}
+	if err := b.Set([]byte("b"), []byte("vb")); err != nil {
+		t.Fatalf("Set(b): %v", err)
+	}
+	if err := b.Set([]byte("c"), []byte("vc")); err != nil {
+		t.Fatalf("Set(c): %v", err)
+	}
+	if err := b.Write(); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	if rec.calls != 1 {
+		t.Fatalf("copy sorted fast path calls=%d want 1", rec.calls)
+	}
+	requireCachedValue(t, db, []byte("a"), []byte("va"))
+	requireCachedValue(t, db, []byte("b"), []byte("vb"))
+	requireCachedValue(t, db, []byte("c"), []byte("vc"))
+}
+
+func TestBatchWriteSortedDuplicateFallsBackToGenericLatestWins(t *testing.T) {
+	db, rec := newSortedWriteFastPathDB(t)
+	defer db.Close()
+
+	b := db.NewBatchWithSize(3)
+	if err := b.Set([]byte("a"), []byte("old")); err != nil {
+		t.Fatalf("Set(a old): %v", err)
+	}
+	if err := b.Set([]byte("a"), []byte("new")); err != nil {
+		t.Fatalf("Set(a new): %v", err)
+	}
+	if err := b.Set([]byte("b"), []byte("vb")); err != nil {
+		t.Fatalf("Set(b): %v", err)
+	}
+	if err := b.Write(); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	if rec.calls != 0 {
+		t.Fatalf("copy sorted fast path used for duplicate-key batch: calls=%d", rec.calls)
+	}
+	requireCachedValue(t, db, []byte("a"), []byte("new"))
+	requireCachedValue(t, db, []byte("b"), []byte("vb"))
+}
+
+func TestBatchWriteOutOfOrderFallsBackToGeneric(t *testing.T) {
+	db, rec := newSortedWriteFastPathDB(t)
+	defer db.Close()
+
+	b := db.NewBatchWithSize(2)
+	if err := b.Set([]byte("b"), []byte("vb")); err != nil {
+		t.Fatalf("Set(b): %v", err)
+	}
+	if err := b.Set([]byte("a"), []byte("va")); err != nil {
+		t.Fatalf("Set(a): %v", err)
+	}
+	if err := b.Write(); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	if rec.calls != 0 {
+		t.Fatalf("copy sorted fast path used for out-of-order batch: calls=%d", rec.calls)
+	}
+	requireCachedValue(t, db, []byte("a"), []byte("va"))
+	requireCachedValue(t, db, []byte("b"), []byte("vb"))
+}

--- a/TreeDB/caching/sorted_write_fastpath_test.go
+++ b/TreeDB/caching/sorted_write_fastpath_test.go
@@ -7,31 +7,95 @@ import (
 	"github.com/snissn/gomap/TreeDB/batch"
 	"github.com/snissn/gomap/TreeDB/internal/memtable"
 	"github.com/snissn/gomap/TreeDB/node"
+	"github.com/snissn/gomap/TreeDB/page"
 )
 
 type recordingCopySortedMem struct {
 	memtable.Table
-	calls int
+	calls  int
+	hasMax bool
+	maxKey []byte
+}
+
+func (m *recordingCopySortedMem) noteKey(key []byte) {
+	if key == nil {
+		return
+	}
+	if !m.hasMax || bytes.Compare(key, m.maxKey) > 0 {
+		m.maxKey = append(m.maxKey[:0], key...)
+		m.hasMax = true
+	}
+}
+
+func (m *recordingCopySortedMem) noteEntries(entries []batch.Entry) {
+	for i := range entries {
+		m.noteKey(entries[i].Key)
+	}
+}
+
+func (m *recordingCopySortedMem) canRecordOrderedAppend(entries []batch.Entry) bool {
+	if len(entries) == 0 || entries[0].Key == nil {
+		return false
+	}
+	return !m.hasMax || bytes.Compare(entries[0].Key, m.maxKey) > 0
+}
+
+func (m *recordingCopySortedMem) Set(key, value []byte) {
+	m.noteKey(key)
+	m.Table.Set(key, value)
+}
+
+func (m *recordingCopySortedMem) SetSteal(key, value []byte) {
+	m.noteKey(key)
+	m.Table.SetSteal(key, value)
+}
+
+func (m *recordingCopySortedMem) SetEntry(key, value []byte, ptr page.ValuePtr, flags byte) {
+	m.noteKey(key)
+	m.Table.SetEntry(key, value, ptr, flags)
+}
+
+func (m *recordingCopySortedMem) SetEntrySteal(key, value []byte, ptr page.ValuePtr, flags byte) {
+	m.noteKey(key)
+	m.Table.SetEntrySteal(key, value, ptr, flags)
+}
+
+func (m *recordingCopySortedMem) Delete(key []byte) {
+	m.noteKey(key)
+	m.Table.Delete(key)
+}
+
+func (m *recordingCopySortedMem) DeleteSteal(key []byte) {
+	m.noteKey(key)
+	m.Table.DeleteSteal(key)
 }
 
 func (m *recordingCopySortedMem) ApplyCopySortedBatchTrusted(entries []batch.Entry, borrowValues bool, storeInlinePtrValues bool, onKey func(key []byte)) bool {
-	m.calls++
+	orderedAppend := m.canRecordOrderedAppend(entries)
+	appliedWithSortedApplier := false
+	borrowed := false
 	if applier, ok := m.Table.(memtable.CopySortedBatchApplier); ok {
-		return applier.ApplyCopySortedBatchTrusted(entries, borrowValues, storeInlinePtrValues, onKey)
-	}
-	for _, op := range entries {
-		if op.Type == batch.OpDelete {
-			m.Table.Delete(op.Key)
-		} else if op.IsPtr {
-			m.Table.SetEntry(op.Key, op.Value, op.ValuePtr, node.FlagPointer)
-		} else {
-			m.Table.Set(op.Key, op.Value)
+		borrowed = applier.ApplyCopySortedBatchTrusted(entries, borrowValues, storeInlinePtrValues, onKey)
+		appliedWithSortedApplier = true
+	} else {
+		for _, op := range entries {
+			if op.Type == batch.OpDelete {
+				m.Table.Delete(op.Key)
+			} else if op.IsPtr {
+				m.Table.SetEntry(op.Key, op.Value, op.ValuePtr, node.FlagPointer)
+			} else {
+				m.Table.Set(op.Key, op.Value)
+			}
+			if onKey != nil {
+				onKey(op.Key)
+			}
 		}
-		if onKey != nil {
-			onKey(op.Key)
-		}
 	}
-	return false
+	if orderedAppend && appliedWithSortedApplier {
+		m.calls++
+	}
+	m.noteEntries(entries)
+	return borrowed
 }
 
 func newSortedWriteFastPathDB(t *testing.T) (*DB, *recordingCopySortedMem) {
@@ -143,6 +207,32 @@ func TestBatchWriteSortedDuplicateFallsBackToGenericLatestWins(t *testing.T) {
 	}
 	requireCachedValue(t, db, []byte("a"), []byte("new"))
 	requireCachedValue(t, db, []byte("b"), []byte("vb"))
+}
+
+func TestBatchWriteSortedOverlappingExistingKeyFallsBackToGeneric(t *testing.T) {
+	db, rec := newSortedWriteFastPathDB(t)
+	defer db.Close()
+
+	if err := db.Set([]byte("a"), []byte("original")); err != nil {
+		t.Fatalf("Set existing: %v", err)
+	}
+
+	b := db.NewBatchWithSize(2)
+	if err := b.Set([]byte("a"), []byte("updated")); err != nil {
+		t.Fatalf("Set(a updated): %v", err)
+	}
+	if err := b.Set([]byte("b"), []byte("new")); err != nil {
+		t.Fatalf("Set(b new): %v", err)
+	}
+	if err := b.Write(); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	if rec.calls != 0 {
+		t.Fatalf("copy sorted fast path used for overlapping-key batch: calls=%d", rec.calls)
+	}
+	requireCachedValue(t, db, []byte("a"), []byte("updated"))
+	requireCachedValue(t, db, []byte("b"), []byte("new"))
 }
 
 func TestBatchWriteOutOfOrderFallsBackToGeneric(t *testing.T) {

--- a/TreeDB/caching/sorted_write_fastpath_test.go
+++ b/TreeDB/caching/sorted_write_fastpath_test.go
@@ -92,6 +92,34 @@ func TestBatchWriteSortedUniqueUsesCopySortedFastPath(t *testing.T) {
 	requireCachedValue(t, db, []byte("c"), []byte("vc"))
 }
 
+func TestBatchWriteSortedSetViewCopiesExternalValues(t *testing.T) {
+	db, rec := newSortedWriteFastPathDB(t)
+	defer db.Close()
+
+	keyA := []byte("a")
+	valA := []byte("va")
+	keyB := []byte("b")
+	valB := []byte("vb")
+	b := db.NewBatchWithSize(2)
+	if err := b.SetView(keyA, valA); err != nil {
+		t.Fatalf("SetView(a): %v", err)
+	}
+	if err := b.SetView(keyB, valB); err != nil {
+		t.Fatalf("SetView(b): %v", err)
+	}
+	if err := b.Write(); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	valA[0] = 'z'
+	valB[0] = 'z'
+
+	if rec.calls != 1 {
+		t.Fatalf("copy sorted fast path calls=%d want 1", rec.calls)
+	}
+	requireCachedValue(t, db, []byte("a"), []byte("va"))
+	requireCachedValue(t, db, []byte("b"), []byte("vb"))
+}
+
 func TestBatchWriteSortedDuplicateFallsBackToGenericLatestWins(t *testing.T) {
 	db, rec := newSortedWriteFastPathDB(t)
 	defer db.Close()

--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -331,6 +331,32 @@ func appendOnlyEntryInlineKeyU64(ent *appendOnlyEntry) (uint64, bool) {
 	return binary.BigEndian.Uint64(ent.inlineKey[:]), true
 }
 
+func appendOnlyEntryKeyU64(ent *appendOnlyEntry) (uint64, bool) {
+	if ent == nil {
+		return 0, false
+	}
+	if ent.keyInline {
+		return binary.BigEndian.Uint64(ent.inlineKey[:]), true
+	}
+	return appendOnlyKeyU64(ent.key)
+}
+
+func appendOnlyCompareKeyWithEntry(key []byte, ent *appendOnlyEntry) int {
+	if key64, ok := appendOnlyKeyU64(key); ok {
+		if ent64, ok := appendOnlyEntryKeyU64(ent); ok {
+			switch {
+			case key64 > ent64:
+				return 1
+			case key64 < ent64:
+				return -1
+			default:
+				return 0
+			}
+		}
+	}
+	return bytes.Compare(key, appendOnlyEntryKey(ent))
+}
+
 func cloneBytes(src []byte) []byte {
 	if len(src) == 0 {
 		return nil
@@ -667,6 +693,10 @@ func (m *AppendOnly) updateLatestIndexLocked(key []byte, idx int) {
 }
 
 func (m *AppendOnly) appendEntryLocked(key, value []byte, ptr page.ValuePtr, flags byte, steal bool, borrowValue bool) *appendOnlyEntry {
+	return m.appendEntryLockedWithOrder(key, value, ptr, flags, steal, borrowValue, false)
+}
+
+func (m *AppendOnly) appendEntryLockedWithOrder(key, value []byte, ptr page.ValuePtr, flags byte, steal bool, borrowValue bool, trustedOrdered bool) *appendOnlyEntry {
 	if m.count == len(m.entries) {
 		nextCap := appendOnlyNextCapacity(len(m.entries))
 		prev := m.entries
@@ -716,14 +746,18 @@ func (m *AppendOnly) appendEntryLocked(key, value []byte, ptr page.ValuePtr, fla
 	k := appendOnlyEntryKey(ent)
 	m.sizeBytes += int64(len(k) + entryValueSize(flags, ent.value))
 
+	if trustedOrdered && m.ordered {
+		m.lastIdx = idx
+		m.hasLast = true
+		return ent
+	}
 	if !m.hasLast {
 		m.lastIdx = idx
 		m.hasLast = true
 		return ent
 	}
 	if m.ordered {
-		prev := appendOnlyEntryKey(&m.entries[m.lastIdx])
-		cmp := bytes.Compare(k, prev)
+		cmp := appendOnlyCompareKeyWithEntry(k, &m.entries[m.lastIdx])
 		if cmp > 0 {
 			m.lastIdx = idx
 			return ent
@@ -839,11 +873,58 @@ func (m *AppendOnly) DeleteWithCallback(key []byte, cb func(k, v []byte) error) 
 }
 
 func (m *AppendOnly) ApplyStealSortedBatch(entries []batchpkg.Entry, onKey func(key []byte)) {
-	m.applyStealBatch(entries, onKey)
+	m.applyStealBatch(entries, onKey, false)
 }
 
 func (m *AppendOnly) ApplyStealSortedBatchTrusted(entries []batchpkg.Entry, onKey func(key []byte)) {
-	m.applyStealBatch(entries, onKey)
+	m.applyStealBatch(entries, onKey, true)
+}
+
+func appendOnlyBatchEntryPayload(op batchpkg.Entry, storeInlinePtrValues bool) (value []byte, ptr page.ValuePtr, flags byte) {
+	switch {
+	case op.Type == batchpkg.OpDelete:
+		return nil, page.ValuePtr{}, node.FlagTombstone
+	case op.IsPtr:
+		if storeInlinePtrValues {
+			return op.Value, op.ValuePtr, node.FlagPointer
+		}
+		return nil, op.ValuePtr, node.FlagPointer
+	default:
+		return op.Value, page.ValuePtr{}, node.FlagInline
+	}
+}
+
+func (m *AppendOnly) canAppendTrustedSortedBatchLocked(entries []batchpkg.Entry) bool {
+	if len(entries) == 0 || len(entries[0].Key) == 0 || !m.ordered {
+		return false
+	}
+	if m.count == 0 || !m.hasLast {
+		return true
+	}
+	return appendOnlyCompareKeyWithEntry(entries[0].Key, &m.entries[m.lastIdx]) > 0
+}
+
+func (m *AppendOnly) ApplyCopySortedBatchTrusted(entries []batchpkg.Entry, borrowValues bool, storeInlinePtrValues bool, onKey func(key []byte)) bool {
+	if len(entries) == 0 {
+		return false
+	}
+	borrowedValues := false
+	m.mu.Lock()
+	trustedOrdered := m.canAppendTrustedSortedBatchLocked(entries)
+	for i := range entries {
+		op := entries[i]
+		value, ptr, flags := appendOnlyBatchEntryPayload(op, storeInlinePtrValues)
+		borrowValue := borrowValues && len(value) > 0
+		if borrowValue {
+			borrowedValues = true
+		}
+		m.appendEntryLockedWithOrder(op.Key, value, ptr, flags, false, borrowValue, trustedOrdered)
+		if onKey != nil {
+			onKey(op.Key)
+		}
+	}
+	m.mu.Unlock()
+	return borrowedValues
 }
 
 func (m *AppendOnly) ApplyStealEntryFunc(count int, emit func(i int) (key, value []byte, ptr page.ValuePtr, flags byte, err error)) error {
@@ -865,17 +946,18 @@ func (m *AppendOnly) ApplyStealEntryFunc(count int, emit func(i int) (key, value
 	return nil
 }
 
-func (m *AppendOnly) applyStealBatch(entries []batchpkg.Entry, onKey func(key []byte)) {
+func (m *AppendOnly) applyStealBatch(entries []batchpkg.Entry, onKey func(key []byte), trustedOrder bool) {
 	m.mu.Lock()
+	trustedOrdered := trustedOrder && m.canAppendTrustedSortedBatchLocked(entries)
 	for i := range entries {
 		op := entries[i]
 		switch {
 		case op.Type == batchpkg.OpDelete:
-			m.appendEntryLocked(op.Key, nil, page.ValuePtr{}, node.FlagTombstone, true, false)
+			m.appendEntryLockedWithOrder(op.Key, nil, page.ValuePtr{}, node.FlagTombstone, true, false, trustedOrdered)
 		case op.IsPtr:
-			m.appendEntryLocked(op.Key, op.Value, op.ValuePtr, node.FlagPointer, true, false)
+			m.appendEntryLockedWithOrder(op.Key, op.Value, op.ValuePtr, node.FlagPointer, true, false, trustedOrdered)
 		default:
-			m.appendEntryLocked(op.Key, op.Value, page.ValuePtr{}, node.FlagInline, true, false)
+			m.appendEntryLockedWithOrder(op.Key, op.Value, page.ValuePtr{}, node.FlagInline, true, false, trustedOrdered)
 		}
 		if onKey != nil {
 			onKey(op.Key)

--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -666,7 +666,7 @@ func (m *AppendOnly) updateLatestIndexLocked(key []byte, idx int) {
 	m.latest[appendOnlyKeyString(key)] = idx
 }
 
-func (m *AppendOnly) appendEntryLocked(key, value []byte, ptr page.ValuePtr, flags byte, steal bool, borrowValue bool) *appendOnlyEntry {
+func (m *AppendOnly) appendEntryCoreLocked(key, value []byte, ptr page.ValuePtr, flags byte, steal bool, borrowValue bool) (idx int, ent *appendOnlyEntry, storedKey []byte) {
 	if m.count == len(m.entries) {
 		nextCap := appendOnlyNextCapacity(len(m.entries))
 		prev := m.entries
@@ -675,9 +675,9 @@ func (m *AppendOnly) appendEntryLocked(key, value []byte, ptr page.ValuePtr, fla
 		m.entries = grown
 		putAppendOnlyEntries(prev)
 	}
-	idx := m.count
+	idx = m.count
 	m.count++
-	ent := &m.entries[idx]
+	ent = &m.entries[idx]
 	ent.ptr = ptr
 	ent.flags = flags
 	ent.keyInline = false
@@ -713,8 +713,13 @@ func (m *AppendOnly) appendEntryLocked(key, value []byte, ptr page.ValuePtr, fla
 		ent.valueOwned = false
 		ent.ptr = page.ValuePtr{}
 	}
-	k := appendOnlyEntryKey(ent)
-	m.sizeBytes += int64(len(k) + entryValueSize(flags, ent.value))
+	storedKey = appendOnlyEntryKey(ent)
+	m.sizeBytes += int64(len(storedKey) + entryValueSize(flags, ent.value))
+	return idx, ent, storedKey
+}
+
+func (m *AppendOnly) appendEntryLocked(key, value []byte, ptr page.ValuePtr, flags byte, steal bool, borrowValue bool) *appendOnlyEntry {
+	idx, ent, k := m.appendEntryCoreLocked(key, value, ptr, flags, steal, borrowValue)
 
 	if !m.hasLast {
 		m.lastIdx = idx
@@ -746,54 +751,7 @@ func (m *AppendOnly) appendEntryLocked(key, value []byte, ptr page.ValuePtr, fla
 }
 
 func (m *AppendOnly) appendEntryTrustedOrderedLocked(key, value []byte, ptr page.ValuePtr, flags byte, steal bool, borrowValue bool) *appendOnlyEntry {
-	if m.count == len(m.entries) {
-		nextCap := appendOnlyNextCapacity(len(m.entries))
-		prev := m.entries
-		grown := getAppendOnlyEntries(nextCap)
-		copy(grown, m.entries[:m.count])
-		m.entries = grown
-		putAppendOnlyEntries(prev)
-	}
-	idx := m.count
-	m.count++
-	ent := &m.entries[idx]
-	ent.ptr = ptr
-	ent.flags = flags
-	ent.keyInline = false
-	ent.keyArena = false
-	ent.keyReusable = false
-	ent.valueOwned = false
-	if steal {
-		ent.key = key
-		ent.value = value
-	} else {
-		if len(key) == appendOnlyInlineKeyLen {
-			copy(ent.inlineKey[:], key)
-			ent.keyInline = true
-			ent.key = nil
-		} else {
-			ent.key = cloneOrReuseBytes(ent.key, key, appendOnlyReusableKeyMaxCap)
-			ent.keyReusable = true
-		}
-		if len(value) > 0 {
-			if borrowValue {
-				ent.value = value
-			} else {
-				ent.value = m.valueArena.alloc(len(value))
-				copy(ent.value, value)
-				ent.valueOwned = true
-			}
-		} else {
-			ent.value = nil
-		}
-	}
-	if flags&node.FlagTombstone != 0 {
-		ent.value = nil
-		ent.valueOwned = false
-		ent.ptr = page.ValuePtr{}
-	}
-	k := appendOnlyEntryKey(ent)
-	m.sizeBytes += int64(len(k) + entryValueSize(flags, ent.value))
+	idx, ent, _ := m.appendEntryCoreLocked(key, value, ptr, flags, steal, borrowValue)
 	m.lastIdx = idx
 	m.hasLast = true
 	return ent
@@ -901,17 +859,7 @@ func (m *AppendOnly) ApplyStealSortedBatchTrusted(entries []batchpkg.Entry, onKe
 }
 
 func appendOnlyBatchEntryPayload(op batchpkg.Entry, storeInlinePtrValues bool) (value []byte, ptr page.ValuePtr, flags byte) {
-	switch {
-	case op.Type == batchpkg.OpDelete:
-		return nil, page.ValuePtr{}, node.FlagTombstone
-	case op.IsPtr:
-		if storeInlinePtrValues {
-			return op.Value, op.ValuePtr, node.FlagPointer
-		}
-		return nil, op.ValuePtr, node.FlagPointer
-	default:
-		return op.Value, page.ValuePtr{}, node.FlagInline
-	}
+	return batchEntryPayload(op, storeInlinePtrValues)
 }
 
 func (m *AppendOnly) canAppendTrustedSortedBatchLocked(entries []batchpkg.Entry) bool {

--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -331,32 +331,6 @@ func appendOnlyEntryInlineKeyU64(ent *appendOnlyEntry) (uint64, bool) {
 	return binary.BigEndian.Uint64(ent.inlineKey[:]), true
 }
 
-func appendOnlyEntryKeyU64(ent *appendOnlyEntry) (uint64, bool) {
-	if ent == nil {
-		return 0, false
-	}
-	if ent.keyInline {
-		return binary.BigEndian.Uint64(ent.inlineKey[:]), true
-	}
-	return appendOnlyKeyU64(ent.key)
-}
-
-func appendOnlyCompareKeyWithEntry(key []byte, ent *appendOnlyEntry) int {
-	if key64, ok := appendOnlyKeyU64(key); ok {
-		if ent64, ok := appendOnlyEntryKeyU64(ent); ok {
-			switch {
-			case key64 > ent64:
-				return 1
-			case key64 < ent64:
-				return -1
-			default:
-				return 0
-			}
-		}
-	}
-	return bytes.Compare(key, appendOnlyEntryKey(ent))
-}
-
 func cloneBytes(src []byte) []byte {
 	if len(src) == 0 {
 		return nil
@@ -693,10 +667,6 @@ func (m *AppendOnly) updateLatestIndexLocked(key []byte, idx int) {
 }
 
 func (m *AppendOnly) appendEntryLocked(key, value []byte, ptr page.ValuePtr, flags byte, steal bool, borrowValue bool) *appendOnlyEntry {
-	return m.appendEntryLockedWithOrder(key, value, ptr, flags, steal, borrowValue, false)
-}
-
-func (m *AppendOnly) appendEntryLockedWithOrder(key, value []byte, ptr page.ValuePtr, flags byte, steal bool, borrowValue bool, trustedOrdered bool) *appendOnlyEntry {
 	if m.count == len(m.entries) {
 		nextCap := appendOnlyNextCapacity(len(m.entries))
 		prev := m.entries
@@ -746,18 +716,14 @@ func (m *AppendOnly) appendEntryLockedWithOrder(key, value []byte, ptr page.Valu
 	k := appendOnlyEntryKey(ent)
 	m.sizeBytes += int64(len(k) + entryValueSize(flags, ent.value))
 
-	if trustedOrdered && m.ordered {
-		m.lastIdx = idx
-		m.hasLast = true
-		return ent
-	}
 	if !m.hasLast {
 		m.lastIdx = idx
 		m.hasLast = true
 		return ent
 	}
 	if m.ordered {
-		cmp := appendOnlyCompareKeyWithEntry(k, &m.entries[m.lastIdx])
+		prev := appendOnlyEntryKey(&m.entries[m.lastIdx])
+		cmp := bytes.Compare(k, prev)
 		if cmp > 0 {
 			m.lastIdx = idx
 			return ent
@@ -776,6 +742,60 @@ func (m *AppendOnly) appendEntryLockedWithOrder(key, value []byte, ptr page.Valu
 		m.updateLatestIndexLocked(k, idx)
 	}
 	m.clearSnapshotLocked()
+	return ent
+}
+
+func (m *AppendOnly) appendEntryTrustedOrderedLocked(key, value []byte, ptr page.ValuePtr, flags byte, steal bool, borrowValue bool) *appendOnlyEntry {
+	if m.count == len(m.entries) {
+		nextCap := appendOnlyNextCapacity(len(m.entries))
+		prev := m.entries
+		grown := getAppendOnlyEntries(nextCap)
+		copy(grown, m.entries[:m.count])
+		m.entries = grown
+		putAppendOnlyEntries(prev)
+	}
+	idx := m.count
+	m.count++
+	ent := &m.entries[idx]
+	ent.ptr = ptr
+	ent.flags = flags
+	ent.keyInline = false
+	ent.keyArena = false
+	ent.keyReusable = false
+	ent.valueOwned = false
+	if steal {
+		ent.key = key
+		ent.value = value
+	} else {
+		if len(key) == appendOnlyInlineKeyLen {
+			copy(ent.inlineKey[:], key)
+			ent.keyInline = true
+			ent.key = nil
+		} else {
+			ent.key = cloneOrReuseBytes(ent.key, key, appendOnlyReusableKeyMaxCap)
+			ent.keyReusable = true
+		}
+		if len(value) > 0 {
+			if borrowValue {
+				ent.value = value
+			} else {
+				ent.value = m.valueArena.alloc(len(value))
+				copy(ent.value, value)
+				ent.valueOwned = true
+			}
+		} else {
+			ent.value = nil
+		}
+	}
+	if flags&node.FlagTombstone != 0 {
+		ent.value = nil
+		ent.valueOwned = false
+		ent.ptr = page.ValuePtr{}
+	}
+	k := appendOnlyEntryKey(ent)
+	m.sizeBytes += int64(len(k) + entryValueSize(flags, ent.value))
+	m.lastIdx = idx
+	m.hasLast = true
 	return ent
 }
 
@@ -901,7 +921,7 @@ func (m *AppendOnly) canAppendTrustedSortedBatchLocked(entries []batchpkg.Entry)
 	if m.count == 0 || !m.hasLast {
 		return true
 	}
-	return appendOnlyCompareKeyWithEntry(entries[0].Key, &m.entries[m.lastIdx]) > 0
+	return bytes.Compare(entries[0].Key, appendOnlyEntryKey(&m.entries[m.lastIdx])) > 0
 }
 
 func (m *AppendOnly) ApplyCopySortedBatchTrusted(entries []batchpkg.Entry, borrowValues bool, storeInlinePtrValues bool, onKey func(key []byte)) bool {
@@ -918,7 +938,11 @@ func (m *AppendOnly) ApplyCopySortedBatchTrusted(entries []batchpkg.Entry, borro
 		if borrowValue {
 			borrowedValues = true
 		}
-		m.appendEntryLockedWithOrder(op.Key, value, ptr, flags, false, borrowValue, trustedOrdered)
+		if trustedOrdered {
+			m.appendEntryTrustedOrderedLocked(op.Key, value, ptr, flags, false, borrowValue)
+		} else {
+			m.appendEntryLocked(op.Key, value, ptr, flags, false, borrowValue)
+		}
 		if onKey != nil {
 			onKey(op.Key)
 		}
@@ -953,11 +977,23 @@ func (m *AppendOnly) applyStealBatch(entries []batchpkg.Entry, onKey func(key []
 		op := entries[i]
 		switch {
 		case op.Type == batchpkg.OpDelete:
-			m.appendEntryLockedWithOrder(op.Key, nil, page.ValuePtr{}, node.FlagTombstone, true, false, trustedOrdered)
+			if trustedOrdered {
+				m.appendEntryTrustedOrderedLocked(op.Key, nil, page.ValuePtr{}, node.FlagTombstone, true, false)
+			} else {
+				m.appendEntryLocked(op.Key, nil, page.ValuePtr{}, node.FlagTombstone, true, false)
+			}
 		case op.IsPtr:
-			m.appendEntryLockedWithOrder(op.Key, op.Value, op.ValuePtr, node.FlagPointer, true, false, trustedOrdered)
+			if trustedOrdered {
+				m.appendEntryTrustedOrderedLocked(op.Key, op.Value, op.ValuePtr, node.FlagPointer, true, false)
+			} else {
+				m.appendEntryLocked(op.Key, op.Value, op.ValuePtr, node.FlagPointer, true, false)
+			}
 		default:
-			m.appendEntryLockedWithOrder(op.Key, op.Value, page.ValuePtr{}, node.FlagInline, true, false, trustedOrdered)
+			if trustedOrdered {
+				m.appendEntryTrustedOrderedLocked(op.Key, op.Value, page.ValuePtr{}, node.FlagInline, true, false)
+			} else {
+				m.appendEntryLocked(op.Key, op.Value, page.ValuePtr{}, node.FlagInline, true, false)
+			}
 		}
 		if onKey != nil {
 			onKey(op.Key)

--- a/TreeDB/internal/memtable/append_only_sorted_batch_test.go
+++ b/TreeDB/internal/memtable/append_only_sorted_batch_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	batchpkg "github.com/snissn/gomap/TreeDB/batch"
+	"github.com/snissn/gomap/TreeDB/node"
+	"github.com/snissn/gomap/TreeDB/page"
 )
 
 func TestAppendOnlyApplyCopySortedBatchTrusted_AppendKeepsOrderedAndCopiesKeys(t *testing.T) {
@@ -43,6 +45,34 @@ func TestAppendOnlyApplyCopySortedBatchTrusted_AppendKeepsOrderedAndCopiesKeys(t
 	}
 	if count != 2 {
 		t.Fatalf("count=%d want 2", count)
+	}
+}
+
+func TestAppendOnlyApplyCopySortedBatchTrusted_PointerInlinePolicy(t *testing.T) {
+	ptr := page.ValuePtr{FileID: 42, Offset: 7, Length: 3}
+
+	m := NewAppendOnlyWithCapacity(0)
+	m.ApplyCopySortedBatchTrusted([]batchpkg.Entry{{
+		Type:     batchpkg.OpPut,
+		Key:      []byte("a"),
+		Value:    []byte("raw"),
+		ValuePtr: ptr,
+		IsPtr:    true,
+	}}, false, false, nil)
+	if got, gotPtr, flags, ok := m.GetEntry([]byte("a")); !ok || got != nil || gotPtr != ptr || flags != node.FlagPointer {
+		t.Fatalf("GetEntry without inline ptr value=(%q,%+v,%d,%v), want nil,%+v,%d,true", string(got), gotPtr, flags, ok, ptr, node.FlagPointer)
+	}
+
+	withInline := NewAppendOnlyWithCapacity(0)
+	withInline.ApplyCopySortedBatchTrusted([]batchpkg.Entry{{
+		Type:     batchpkg.OpPut,
+		Key:      []byte("a"),
+		Value:    []byte("raw"),
+		ValuePtr: ptr,
+		IsPtr:    true,
+	}}, false, true, nil)
+	if got, gotPtr, flags, ok := withInline.GetEntry([]byte("a")); !ok || string(got) != "raw" || gotPtr != ptr || flags != node.FlagPointer {
+		t.Fatalf("GetEntry with inline ptr value=(%q,%+v,%d,%v), want raw,%+v,%d,true", string(got), gotPtr, flags, ok, ptr, node.FlagPointer)
 	}
 }
 

--- a/TreeDB/internal/memtable/append_only_sorted_batch_test.go
+++ b/TreeDB/internal/memtable/append_only_sorted_batch_test.go
@@ -1,0 +1,113 @@
+package memtable
+
+import (
+	"encoding/binary"
+	"testing"
+
+	batchpkg "github.com/snissn/gomap/TreeDB/batch"
+)
+
+func TestAppendOnlyApplyCopySortedBatchTrusted_AppendKeepsOrderedAndCopiesKeys(t *testing.T) {
+	m := NewAppendOnlyWithCapacity(0)
+
+	keyA := []byte("a")
+	keyB := []byte("b")
+	entries := []batchpkg.Entry{
+		{Type: batchpkg.OpPut, Key: keyA, Value: []byte("va")},
+		{Type: batchpkg.OpPut, Key: keyB, Value: []byte("vb")},
+	}
+	if borrowed := m.ApplyCopySortedBatchTrusted(entries, true, true, nil); !borrowed {
+		t.Fatalf("ApplyCopySortedBatchTrusted borrowed=false, want true for inline values")
+	}
+
+	// Keys must be table-owned even when values are borrowed from the caller.
+	keyA[0] = 'z'
+	if got, deleted, ok := m.Get([]byte("a")); !ok || deleted || string(got) != "va" {
+		t.Fatalf("Get(a)=(%q,%v,%v), want (va,false,true)", string(got), deleted, ok)
+	}
+	if got, deleted, ok := m.Get([]byte("b")); !ok || deleted || string(got) != "vb" {
+		t.Fatalf("Get(b)=(%q,%v,%v), want (vb,false,true)", string(got), deleted, ok)
+	}
+
+	m.mu.RLock()
+	ordered := m.ordered
+	latestDirty := m.latestDirty
+	latestLen := len(m.latest) + len(m.latest64)
+	count := m.count
+	m.mu.RUnlock()
+	if !ordered {
+		t.Fatalf("ordered=false after trusted sorted unique append")
+	}
+	if latestDirty || latestLen != 0 {
+		t.Fatalf("latest index built for ordered append: dirty=%v len=%d", latestDirty, latestLen)
+	}
+	if count != 2 {
+		t.Fatalf("count=%d want 2", count)
+	}
+}
+
+func TestAppendOnlyApplyCopySortedBatchTrusted_OverlappingSortedRunFallsBack(t *testing.T) {
+	m := NewAppendOnlyWithCapacity(0)
+	m.Set([]byte("m"), []byte("old"))
+
+	entries := []batchpkg.Entry{
+		{Type: batchpkg.OpPut, Key: []byte("a"), Value: []byte("va")},
+		{Type: batchpkg.OpPut, Key: []byte("m"), Value: []byte("new")},
+	}
+	m.ApplyCopySortedBatchTrusted(entries, false, true, nil)
+
+	if got, deleted, ok := m.Get([]byte("a")); !ok || deleted || string(got) != "va" {
+		t.Fatalf("Get(a)=(%q,%v,%v), want (va,false,true)", string(got), deleted, ok)
+	}
+	if got, deleted, ok := m.Get([]byte("m")); !ok || deleted || string(got) != "new" {
+		t.Fatalf("Get(m)=(%q,%v,%v), want (new,false,true)", string(got), deleted, ok)
+	}
+
+	m.mu.RLock()
+	ordered := m.ordered
+	latestDirty := m.latestDirty
+	m.mu.RUnlock()
+	if ordered {
+		t.Fatalf("ordered=true after sorted run overlapped existing max key")
+	}
+	if latestDirty {
+		t.Fatalf("latestDirty=true after fallback; latest index should be immediately usable")
+	}
+}
+
+func TestAppendOnlyKey64MonotonicOrderingMatchesLexicographic(t *testing.T) {
+	m := NewAppendOnlyWithCapacity(0)
+	var lo, hi [8]byte
+	binary.BigEndian.PutUint64(lo[:], 0x00ff)
+	binary.BigEndian.PutUint64(hi[:], 0x0100)
+
+	m.Set(lo[:], []byte("lo"))
+	m.Set(hi[:], []byte("hi"))
+
+	m.mu.RLock()
+	ordered := m.ordered
+	latestLen := len(m.latest) + len(m.latest64)
+	m.mu.RUnlock()
+	if !ordered {
+		t.Fatalf("ordered=false for lexicographically increasing 8-byte keys")
+	}
+	if latestLen != 0 {
+		t.Fatalf("latest index len=%d want 0 while key64 run remains ordered", latestLen)
+	}
+
+	m.Set(lo[:], []byte("lo2"))
+	if got, deleted, ok := m.Get(lo[:]); !ok || deleted || string(got) != "lo2" {
+		t.Fatalf("Get(lo)=(%q,%v,%v), want (lo2,false,true)", string(got), deleted, ok)
+	}
+	m.mu.RLock()
+	ordered = m.ordered
+	latestDirty := m.latestDirty
+	_, latest64OK := m.latest64[binary.BigEndian.Uint64(lo[:])]
+	m.mu.RUnlock()
+	if ordered {
+		t.Fatalf("ordered=true after lower 8-byte key append")
+	}
+	if latestDirty || !latest64OK {
+		t.Fatalf("latest64 not ready after key64 order break: dirty=%v ok=%v", latestDirty, latest64OK)
+	}
+}

--- a/TreeDB/internal/memtable/batch_helpers.go
+++ b/TreeDB/internal/memtable/batch_helpers.go
@@ -1,0 +1,21 @@
+package memtable
+
+import (
+	batchpkg "github.com/snissn/gomap/TreeDB/batch"
+	"github.com/snissn/gomap/TreeDB/node"
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+func batchEntryPayload(op batchpkg.Entry, storeInlinePtrValues bool) (value []byte, ptr page.ValuePtr, flags byte) {
+	switch {
+	case op.Type == batchpkg.OpDelete:
+		return nil, page.ValuePtr{}, node.FlagTombstone
+	case op.IsPtr:
+		if storeInlinePtrValues {
+			return op.Value, op.ValuePtr, node.FlagPointer
+		}
+		return nil, op.ValuePtr, node.FlagPointer
+	default:
+		return op.Value, page.ValuePtr{}, node.FlagInline
+	}
+}

--- a/TreeDB/internal/memtable/hash_sorted.go
+++ b/TreeDB/internal/memtable/hash_sorted.go
@@ -92,11 +92,12 @@ type HashSorted struct {
 	// Incremental ordering:
 	// We record first-seen keys into pendingKeys and seal them into chunk slices.
 	// A global background worker sorts those chunks and stores them as sorted runs.
-	pendingKeys  []string
-	pendingBytes int
-	nextSeq      uint64
-	index        hashSortedIndex
-	indexer      *HashSortedIndexer
+	pendingKeys   []string
+	pendingBytes  int
+	pendingSorted bool
+	nextSeq       uint64
+	index         hashSortedIndex
+	indexer       *HashSortedIndexer
 
 	finalizeOnce sync.Once
 	finalizeDone chan struct{}
@@ -201,6 +202,7 @@ func (m *HashSorted) Reset() {
 	m.hasMaxKey = false
 	m.pendingKeys = nil
 	m.pendingBytes = 0
+	m.pendingSorted = false
 	m.nextSeq = 0
 	m.index.reset()
 	m.finalizeOnce = sync.Once{}
@@ -234,8 +236,8 @@ func (m *HashSorted) ApplyCopySortedBatchTrusted(entries []batchpkg.Entry, borro
 				onKey(op.Key)
 			}
 		}
-		if chunk, seq := m.noteNewKeysBatchLocked(keys, keyBytes); seq != 0 {
-			chunks = append(chunks, hashSortedIndexWork{mt: m, seq: seq, keys: chunk, sorted: true})
+		if chunk, seq, sorted := m.noteNewKeysBatchLocked(keys, keyBytes, true); seq != 0 {
+			chunks = append(chunks, hashSortedIndexWork{mt: m, seq: seq, keys: chunk, sorted: sorted})
 		}
 	} else {
 		for _, op := range entries {
@@ -278,8 +280,8 @@ func (m *HashSorted) applyStealSortedBatch(entries []batchpkg.Entry, onKey func(
 				onKey(op.Key)
 			}
 		}
-		if chunk, seq := m.noteNewKeysBatchLocked(keys, keyBytes); seq != 0 {
-			chunks = append(chunks, hashSortedIndexWork{mt: m, seq: seq, keys: chunk, sorted: true})
+		if chunk, seq, sorted := m.noteNewKeysBatchLocked(keys, keyBytes, true); seq != 0 {
+			chunks = append(chunks, hashSortedIndexWork{mt: m, seq: seq, keys: chunk, sorted: sorted})
 		}
 	} else {
 		for _, op := range entries {
@@ -741,9 +743,11 @@ func (m *HashSorted) ensureIndexFrozen() {
 	}
 	target := m.nextSeq
 	pending := m.pendingKeys
+	pendingSorted := m.pendingSorted
 	dst := m.sortedKeys
 	m.pendingKeys = nil
 	m.pendingBytes = 0
+	m.pendingSorted = false
 	m.mu.Unlock()
 
 	m.index.wait(target)
@@ -751,7 +755,9 @@ func (m *HashSorted) ensureIndexFrozen() {
 	// Seal any remaining keys locally as a final chunk after prior chunks have
 	// completed to preserve the seq->run mapping.
 	if len(pending) > 0 {
-		sort.Strings(pending)
+		if !pendingSorted {
+			sort.Strings(pending)
+		}
 		finalSeq := target + 1
 		m.index.apply(finalSeq, pending)
 		target = finalSeq
@@ -886,11 +892,23 @@ func (m *HashSorted) startFinalize() {
 	})
 }
 
+func (m *HashSorted) notePendingKeyOrderLocked(key string) {
+	if len(m.pendingKeys) == 0 {
+		m.pendingSorted = true
+		return
+	}
+	if m.pendingSorted && strings.Compare(m.pendingKeys[len(m.pendingKeys)-1], key) < 0 {
+		return
+	}
+	m.pendingSorted = false
+}
+
 func (m *HashSorted) noteNewKeyLocked(key string) (chunk []string, seq uint64) {
 	m.sortedValid = false
 	if m.pendingKeys == nil {
 		m.pendingKeys = make([]string, 0, hashSortedSealKeysThreshold)
 	}
+	m.notePendingKeyOrderLocked(key)
 	m.pendingKeys = append(m.pendingKeys, key)
 	m.pendingBytes += len(key)
 	if m.pendingBytes < hashSortedSealBytesThreshold && len(m.pendingKeys) < hashSortedSealKeysThreshold {
@@ -900,13 +918,14 @@ func (m *HashSorted) noteNewKeyLocked(key string) (chunk []string, seq uint64) {
 	chunk = m.pendingKeys
 	m.pendingKeys = nil
 	m.pendingBytes = 0
+	m.pendingSorted = false
 	m.nextSeq++
 	return chunk, m.nextSeq
 }
 
-func (m *HashSorted) noteNewKeysBatchLocked(keys []string, keyBytes int) (chunk []string, seq uint64) {
+func (m *HashSorted) noteNewKeysBatchLocked(keys []string, keyBytes int, keysSorted bool) (chunk []string, seq uint64, sorted bool) {
 	if len(keys) == 0 {
-		return nil, 0
+		return nil, 0, false
 	}
 	m.sortedValid = false
 	if m.pendingKeys == nil {
@@ -916,17 +935,24 @@ func (m *HashSorted) noteNewKeysBatchLocked(keys []string, keyBytes int) (chunk 
 		}
 		m.pendingKeys = make([]string, 0, c)
 	}
+	if len(m.pendingKeys) == 0 {
+		m.pendingSorted = keysSorted
+	} else if !(m.pendingSorted && keysSorted && strings.Compare(m.pendingKeys[len(m.pendingKeys)-1], keys[0]) < 0) {
+		m.pendingSorted = false
+	}
 	m.pendingKeys = append(m.pendingKeys, keys...)
 	m.pendingBytes += keyBytes
 	if m.pendingBytes < hashSortedSealBytesThreshold && len(m.pendingKeys) < hashSortedSealKeysThreshold {
-		return nil, 0
+		return nil, 0, false
 	}
 
 	chunk = m.pendingKeys
+	sorted = m.pendingSorted
 	m.pendingKeys = nil
 	m.pendingBytes = 0
+	m.pendingSorted = false
 	m.nextSeq++
-	return chunk, m.nextSeq
+	return chunk, m.nextSeq, sorted
 }
 
 func (m *HashSorted) setEntryLocked(key, value []byte, ptr page.ValuePtr, flags byte, steal bool) ([]string, uint64) {
@@ -973,17 +999,7 @@ func (m *HashSorted) setEntryLocked(key, value []byte, ptr page.ValuePtr, flags 
 }
 
 func hashSortedBatchEntryPayload(op batchpkg.Entry, storeInlinePtrValues bool) (value []byte, ptr page.ValuePtr, flags byte) {
-	switch {
-	case op.Type == batchpkg.OpDelete:
-		return nil, page.ValuePtr{}, node.FlagTombstone
-	case op.IsPtr:
-		if storeInlinePtrValues {
-			return op.Value, op.ValuePtr, node.FlagPointer
-		}
-		return nil, op.ValuePtr, node.FlagPointer
-	default:
-		return op.Value, page.ValuePtr{}, node.FlagInline
-	}
+	return batchEntryPayload(op, storeInlinePtrValues)
 }
 
 func (m *HashSorted) setEntryNewCopyNoChunkLocked(op batchpkg.Entry, storeInlinePtrValues bool) (string, int, bool) {

--- a/TreeDB/internal/memtable/hash_sorted.go
+++ b/TreeDB/internal/memtable/hash_sorted.go
@@ -217,6 +217,45 @@ func (m *HashSorted) ApplyStealSortedBatchTrusted(entries []batchpkg.Entry, onKe
 	m.applyStealSortedBatch(entries, onKey, true)
 }
 
+func (m *HashSorted) ApplyCopySortedBatchTrusted(entries []batchpkg.Entry, borrowValues bool, storeInlinePtrValues bool, onKey func(key []byte)) bool {
+	_ = borrowValues // HashSorted owns values in its arena; it never borrows batch value storage.
+	var chunks []hashSortedIndexWork
+
+	m.mu.Lock()
+	if m.canAppendAfterMaxLocked(entries) {
+		keys := make([]string, 0, len(entries))
+		keyBytes := 0
+		for _, op := range entries {
+			if keyStored, n, ok := m.setEntryNewCopyNoChunkLocked(op, storeInlinePtrValues); ok {
+				keys = append(keys, keyStored)
+				keyBytes += n
+			}
+			if onKey != nil {
+				onKey(op.Key)
+			}
+		}
+		if chunk, seq := m.noteNewKeysBatchLocked(keys, keyBytes); seq != 0 {
+			chunks = append(chunks, hashSortedIndexWork{mt: m, seq: seq, keys: chunk, sorted: true})
+		}
+	} else {
+		for _, op := range entries {
+			value, ptr, flags := hashSortedBatchEntryPayload(op, storeInlinePtrValues)
+			if chunk, seq := m.setEntryLocked(op.Key, value, ptr, flags, false); seq != 0 {
+				chunks = append(chunks, hashSortedIndexWork{mt: m, seq: seq, keys: chunk})
+			}
+			if onKey != nil {
+				onKey(op.Key)
+			}
+		}
+	}
+	m.mu.Unlock()
+
+	for _, c := range chunks {
+		c.mt.indexer.enqueue(c.mt, c.seq, c.keys, c.sorted)
+	}
+	return false
+}
+
 func (m *HashSorted) applyStealSortedBatch(entries []batchpkg.Entry, onKey func(key []byte), trustedOrder bool) {
 	var chunks []hashSortedIndexWork
 
@@ -931,6 +970,44 @@ func (m *HashSorted) setEntryLocked(key, value []byte, ptr page.ValuePtr, flags 
 	}
 	m.updateMaxKeyLocked(keyStored)
 	return m.noteNewKeyLocked(keyStored)
+}
+
+func hashSortedBatchEntryPayload(op batchpkg.Entry, storeInlinePtrValues bool) (value []byte, ptr page.ValuePtr, flags byte) {
+	switch {
+	case op.Type == batchpkg.OpDelete:
+		return nil, page.ValuePtr{}, node.FlagTombstone
+	case op.IsPtr:
+		if storeInlinePtrValues {
+			return op.Value, op.ValuePtr, node.FlagPointer
+		}
+		return nil, op.ValuePtr, node.FlagPointer
+	default:
+		return op.Value, page.ValuePtr{}, node.FlagInline
+	}
+}
+
+func (m *HashSorted) setEntryNewCopyNoChunkLocked(op batchpkg.Entry, storeInlinePtrValues bool) (string, int, bool) {
+	if op.Key == nil {
+		return "", 0, false
+	}
+	keyCopy := m.arena.copyBytes(op.Key)
+	keyStored := bytesToStringNoCopy(keyCopy)
+	value, ptr, flags := hashSortedBatchEntryPayload(op, storeInlinePtrValues)
+	valCopy := m.encodeEntryValueLocked(value, ptr, flags, false)
+	ent := hashEntry{value: valCopy, flags: flags}
+	if flags&node.FlagPointer != 0 {
+		ent.ptr = ptr
+	}
+	m.entries = append(m.entries, ent)
+	m.items[keyStored] = uint32(len(m.entries) - 1)
+	m.sizeBytes += int64(len(keyCopy) + hashEntryValueSize(flags, valCopy))
+	if flags&node.FlagTombstone != 0 {
+		m.hasDeletes = true
+	}
+	// The fast path is append-only and entries are strictly increasing.
+	m.maxKey = keyStored
+	m.hasMaxKey = true
+	return keyStored, len(keyCopy), true
 }
 
 func (m *HashSorted) setEntryNewStealNoChunkLocked(op batchpkg.Entry) (string, int, bool) {

--- a/TreeDB/internal/memtable/hash_sorted_fastpath_test.go
+++ b/TreeDB/internal/memtable/hash_sorted_fastpath_test.go
@@ -38,6 +38,41 @@ func TestHashSortedApplyStealSortedBatch_AppendAndFallback(t *testing.T) {
 	}
 }
 
+func TestHashSortedApplyCopySortedBatchTrusted_AppendAndFallback(t *testing.T) {
+	m := NewHashSorted()
+	m.Set([]byte("b"), []byte("v1"))
+
+	keyC := []byte("c")
+	entries := []batchpkg.Entry{
+		{Type: batchpkg.OpPut, Key: keyC, Value: []byte("v2")},
+		{Type: batchpkg.OpDelete, Key: []byte("d")},
+	}
+	if borrowed := m.ApplyCopySortedBatchTrusted(entries, true, true, nil); borrowed {
+		t.Fatalf("HashSorted reported borrowed values")
+	}
+	keyC[0] = 'z'
+
+	if got, del, ok := m.Get([]byte("c")); !ok || del || string(got) != "v2" {
+		t.Fatalf("key c mismatch: ok=%v del=%v val=%q", ok, del, string(got))
+	}
+	if got, del, ok := m.Get([]byte("d")); !ok || !del || got != nil {
+		t.Fatalf("key d tombstone mismatch: ok=%v del=%v val=%v", ok, del, got)
+	}
+
+	fallbackEntries := []batchpkg.Entry{
+		{Type: batchpkg.OpPut, Key: []byte("a"), Value: []byte("va")},
+		{Type: batchpkg.OpPut, Key: []byte("b"), Value: []byte("vb")},
+	}
+	m.ApplyCopySortedBatchTrusted(fallbackEntries, true, true, nil)
+
+	if got, del, ok := m.Get([]byte("a")); !ok || del || string(got) != "va" {
+		t.Fatalf("key a mismatch: ok=%v del=%v val=%q", ok, del, string(got))
+	}
+	if got, del, ok := m.Get([]byte("b")); !ok || del || string(got) != "vb" {
+		t.Fatalf("key b mismatch after update: ok=%v del=%v val=%q", ok, del, string(got))
+	}
+}
+
 func TestHashSortedApplyStealSortedBatch_DuplicateKeyForcesFallback(t *testing.T) {
 	m := NewHashSorted()
 	m.SetSteal([]byte("b"), []byte("v0"))

--- a/TreeDB/internal/memtable/hash_sorted_fastpath_test.go
+++ b/TreeDB/internal/memtable/hash_sorted_fastpath_test.go
@@ -1,6 +1,8 @@
 package memtable
 
 import (
+	"fmt"
+	"sort"
 	"testing"
 
 	batchpkg "github.com/snissn/gomap/TreeDB/batch"
@@ -88,5 +90,67 @@ func TestHashSortedApplyStealSortedBatch_DuplicateKeyForcesFallback(t *testing.T
 	}
 	if got := m.Len(); got != 2 {
 		t.Fatalf("len=%d want 2", got)
+	}
+}
+
+func TestHashSortedApplyCopySortedBatchTrusted_MixedPendingChunkNotMarkedSorted(t *testing.T) {
+	indexer := &HashSortedIndexer{ch: make(chan hashSortedIndexWork, 1)}
+	m := NewHashSortedWithCapacityAndIndexer(0, indexer)
+
+	// Prior generic inserts leave an unsealed, unsorted pending chunk.
+	m.Set([]byte("m"), []byte("vm"))
+	m.Set([]byte("a"), []byte("va"))
+
+	entries := make([]batchpkg.Entry, hashSortedSealKeysThreshold-2)
+	for i := range entries {
+		entries[i] = batchpkg.Entry{
+			Type:  batchpkg.OpPut,
+			Key:   []byte(fmt.Sprintf("n%05d", i)),
+			Value: []byte("v"),
+		}
+	}
+	m.ApplyCopySortedBatchTrusted(entries, false, true, nil)
+
+	select {
+	case work := <-indexer.ch:
+		if work.sorted {
+			t.Fatalf("mixed pending chunk marked sorted")
+		}
+		if len(work.keys) != hashSortedSealKeysThreshold {
+			t.Fatalf("chunk len=%d want %d", len(work.keys), hashSortedSealKeysThreshold)
+		}
+		if sort.StringsAreSorted(work.keys) {
+			t.Fatalf("test setup expected mixed chunk to require sorting")
+		}
+	default:
+		t.Fatalf("expected sealed mixed pending chunk")
+	}
+}
+
+func TestHashSortedApplyCopySortedBatchTrusted_ConsecutiveSortedPendingChunkMarkedSorted(t *testing.T) {
+	indexer := &HashSortedIndexer{ch: make(chan hashSortedIndexWork, 1)}
+	m := NewHashSortedWithCapacityAndIndexer(0, indexer)
+
+	entries := make([]batchpkg.Entry, hashSortedSealKeysThreshold)
+	for i := range entries {
+		entries[i] = batchpkg.Entry{
+			Type:  batchpkg.OpPut,
+			Key:   []byte(fmt.Sprintf("n%05d", i)),
+			Value: []byte("v"),
+		}
+	}
+	m.ApplyCopySortedBatchTrusted(entries[:hashSortedSealKeysThreshold/2], false, true, nil)
+	m.ApplyCopySortedBatchTrusted(entries[hashSortedSealKeysThreshold/2:], false, true, nil)
+
+	select {
+	case work := <-indexer.ch:
+		if !work.sorted {
+			t.Fatalf("pure sorted pending chunk not marked sorted")
+		}
+		if !sort.StringsAreSorted(work.keys) {
+			t.Fatalf("pure sorted chunk is not sorted")
+		}
+	default:
+		t.Fatalf("expected sealed sorted pending chunk")
 	}
 }

--- a/TreeDB/internal/memtable/memtable.go
+++ b/TreeDB/internal/memtable/memtable.go
@@ -130,6 +130,16 @@ type TrustedSortedBatchApplier interface {
 	ApplyStealSortedBatchTrusted(entries []batchpkg.Entry, onKey func(key []byte))
 }
 
+// CopySortedBatchApplier is an optional fast path for callers that already
+// guarantee strictly increasing keys but cannot transfer key ownership to the
+// memtable. Implementations must copy keys into table-owned storage. When
+// borrowValues is true, implementations may retain non-key value slices until
+// the memtable is retired and must return true if they did so. Pointer entries
+// receive inline value bytes only when storeInlinePtrValues is true.
+type CopySortedBatchApplier interface {
+	ApplyCopySortedBatchTrusted(entries []batchpkg.Entry, borrowValues bool, storeInlinePtrValues bool, onKey func(key []byte)) (borrowedValues bool)
+}
+
 type Memtable struct {
 	sl *skiplist.SkipList
 	mu sync.RWMutex


### PR DESCRIPTION
## Summary

Fixes #2220. Part of #2216.

This adds a narrow cached-write fast path for already-sorted unique batch input:

- adds internal `memtable.CopySortedBatchApplier` for sorted batches that cannot transfer key ownership;
- lets cached batch writes use the sorted applier for append-only/hash-sorted memtables when `Batch` has proven strictly increasing keys;
- keeps duplicate, out-of-order, mixed unsupported, and existing-key-overlap cases on the generic path;
- preserves generic/direct `AppendOnly.appendEntryLocked` behavior after benchmarking found a direct-write regression in an earlier draft;
- adds tests for sorted unique, duplicate fallback, out-of-order fallback, SetView non-borrowing, pointer inline policy, and key64 monotonic ordering.

No WAL/value-log append/sync ordering changes. No on-disk format changes.

## Ordered-input invariant

Fast path is used only when cached `Batch` has tracked a strictly increasing key stream (`bytes.Compare(prev, key) < 0`). Per-shard subsequences preserve that order. Memtable appliers also require the run to append after the current max key; otherwise they fall back to generic latest-wins append/update handling.

Value ownership:

- keys are always copied into memtable-owned storage for `CopySortedBatchApplier`;
- values may be borrowed only when the cached batch arena can be retained, and the applier returns whether it borrowed;
- `SetView` disables value borrowing and is covered by test.

## Tests

```sh
GOWORK=off go test ./TreeDB/internal/memtable ./TreeDB/caching -run 'TestAppendOnlyApplyCopySortedBatchTrusted|TestAppendOnlyKey64MonotonicOrderingMatchesLexicographic|TestHashSortedApply|TestBatchWriteSorted|TestBatchWriteOutOfOrder|TestBatchSetOps_StreamEligible' -count=1
GOWORK=off go test ./TreeDB/internal/memtable ./TreeDB/caching -count=1
GOWORK=off go test ./TreeDB/... -count=1
```

## Benchmark evidence

Host: `mikers@192.168.0.185`, 1M keys, durable profile, native fast path.

Command for each before/after run:

```sh
./bin/unified-bench -dbs=treedb -keys=1000000 -profile=durable \
  -profile-dir="$OUT" -path-label=native-fastpath -format=markdown -progress=false \
  -test=sequential_write,dataset_write_sorted,batch_small_seq,random_write,random_delete
```

Artifacts root: `/home/mikers/tmp/gomap_2220_bench_20260602_231318`

- baseline dirs: `profiles_before_1m`, `profiles_before_1m_r2`, `profiles_before_1m_after_latest`
- after dirs: `profiles_after_final_1m`, `profiles_after_final_1m_r2`, `profiles_after_latest_1m`

Three-run average ops/sec:

| Test | Before avg | After avg | Delta |
| --- | ---: | ---: | ---: |
| Sequential Write | 2,154,103 | 2,132,675 | -0.99% |
| Dataset Write (Sorted) | 1,699,818 | 1,693,900 | -0.35% |
| Batch Small Seq | 2,370,185 | 2,769,789 | +16.86% |
| Random Write | 1,645,326 | 1,675,626 | +1.84% |
| Random Delete | 2,021,956 | 1,986,621 | -1.75% |

Latest-head paired sanity (`profiles_after_latest_1m` then `profiles_before_1m_after_latest`):

| Test | Before | After @ `3e17b7c2` | Delta |
| --- | ---: | ---: | ---: |
| Sequential Write | 2,094,476 | 2,084,264 | -0.49% |
| Dataset Write (Sorted) | 1,629,792 | 1,638,563 | +0.54% |
| Batch Small Seq | 2,361,206 | 2,743,878 | +16.20% |
| Random Write | 1,669,100 | 1,686,287 | +1.03% |
| Random Delete | 2,062,142 | 1,978,414 | -4.06% |

Assessment: targeted small sorted batches improve materially. Direct Set-style sorted/sequential numbers are noisy and are not claimed as improved; final code keeps the generic direct append path unchanged relative to `origin/main`. Random write/delete sanity is within observed run-to-run noise on the multi-run average; no WAL, mmap fallback, storage footprint, or value-log durability counters regressed materially.

## Review / CI / AI status

- Internal high-thinking review: PASS, no blocking findings.
- CI: pending for PR head.
- AI reviews: not requested yet; will request after PR is mature and CI is running/green per tracker policy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced optimized fast path for sorted, unique batch writes.
  * Added support for copy-based batch operations when external data cannot transfer ownership.

* **Improvements**
  * Enhanced streaming batch write path to maintain sorted-run accounting across all execution paths.

* **Tests**
  * Added comprehensive test coverage for sorted batch write optimization paths and fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->