### PR TITLE
TreeDB: expose iterator views for scans

### DIFF
--- a/TreeDB/db/api.go
+++ b/TreeDB/db/api.go
@@ -414,12 +414,18 @@ func (it *DBIterator) Valid() bool {
 	return it.iter.Valid() && it.err == nil
 }
 
+// Key returns a read-only view of the current key. The view is valid only
+// until the next Next()/Seek()/Close() on this iterator; use KeyCopy for
+// stable bytes.
 func (it *DBIterator) Key() []byte {
-	return it.KeyCopy(nil)
+	return it.UnsafeKey()
 }
 
+// Value returns a read-only view of the current value. The view is valid only
+// until the next Next()/Seek()/Close() on this iterator; use ValueCopy for
+// stable bytes.
 func (it *DBIterator) Value() []byte {
-	return it.ValueCopy(nil)
+	return it.UnsafeValue()
 }
 
 func (it *DBIterator) KeyCopy(dst []byte) []byte {

--- a/TreeDB/db/api_test.go
+++ b/TreeDB/db/api_test.go
@@ -219,7 +219,7 @@ func TestSnapshotGet_ReturnsSafeCopyForValueLogPointer(t *testing.T) {
 	}
 }
 
-func TestIteratorKeyValueAreDefensiveCopies(t *testing.T) {
+func TestIteratorKeyValueViewsAndCopyOwnership(t *testing.T) {
 	dir := t.TempDir()
 	db, err := Open(Options{Dir: dir})
 	if err != nil {
@@ -240,29 +240,31 @@ func TestIteratorKeyValueAreDefensiveCopies(t *testing.T) {
 		t.Fatalf("iterator invalid")
 	}
 
-	unsafeKeyBefore := append([]byte(nil), it.UnsafeKey()...)
-	unsafeValBefore := append([]byte(nil), it.UnsafeValue()...)
-	key := it.Key()
-	val := it.Value()
-
-	if len(key) > 0 && len(it.UnsafeKey()) > 0 && &key[0] == &it.UnsafeKey()[0] {
-		t.Fatalf("Key returned unsafe alias")
+	keyView := it.Key()
+	valueView := it.Value()
+	if !sameBacking(keyView, it.UnsafeKey()) {
+		t.Fatalf("Key() should return the current iterator view")
 	}
-	if len(val) > 0 && len(it.UnsafeValue()) > 0 && &val[0] == &it.UnsafeValue()[0] {
-		t.Fatalf("Value returned unsafe alias")
+	if !sameBacking(valueView, it.UnsafeValue()) {
+		t.Fatalf("Value() should return the current iterator view")
 	}
 
-	if len(key) > 0 {
-		key[0] ^= 0x1
+	keyCopy := it.KeyCopy(make([]byte, 0, 16))
+	valueCopy := it.ValueCopy(make([]byte, 0, 16))
+	if sameBacking(keyCopy, keyView) {
+		t.Fatalf("KeyCopy() must return caller-owned bytes")
 	}
-	if len(val) > 0 {
-		val[0] ^= 0x1
+	if sameBacking(valueCopy, valueView) {
+		t.Fatalf("ValueCopy() must return caller-owned bytes")
 	}
-	if !bytes.Equal(it.UnsafeKey(), unsafeKeyBefore) {
-		t.Fatalf("mutating Key() changed iterator state")
+
+	keyCopy[0] ^= 0x1
+	valueCopy[0] ^= 0x1
+	if !bytes.Equal(it.UnsafeKey(), []byte("k1")) {
+		t.Fatalf("mutating KeyCopy() changed iterator key view")
 	}
-	if !bytes.Equal(it.UnsafeValue(), unsafeValBefore) {
-		t.Fatalf("mutating Value() changed iterator state")
+	if !bytes.Equal(it.UnsafeValue(), []byte("value1")) {
+		t.Fatalf("mutating ValueCopy() changed iterator value view")
 	}
 }
 

--- a/TreeDB/db/iterator_view_test.go
+++ b/TreeDB/db/iterator_view_test.go
@@ -1,0 +1,155 @@
+package db
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+	"unsafe"
+
+	"github.com/snissn/gomap/TreeDB/internal/valuelog"
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+func sameBacking(a, b []byte) bool {
+	if len(a) == 0 || len(b) == 0 {
+		return len(a) == len(b)
+	}
+	return unsafe.Pointer(&a[0]) == unsafe.Pointer(&b[0])
+}
+
+func TestDBIteratorKeyValueReturnViewsAndCopiesRemainOwned(t *testing.T) {
+	dir := t.TempDir()
+	d, err := Open(Options{
+		Dir:        dir,
+		Durability: DurabilityWALOffRelaxed,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer d.Close()
+
+	keyA := []byte("scan/a")
+	valA := []byte("value-log-backed-value-a")
+	keyB := []byte("scan/b")
+	valB := []byte("value-log-backed-value-b")
+	valueLogDir := ValueLogDirPath(dir)
+	if err := os.MkdirAll(valueLogDir, 0o755); err != nil {
+		t.Fatalf("mkdir value log: %v", err)
+	}
+	fileID, err := valuelog.EncodeFileID(0, 1)
+	if err != nil {
+		t.Fatalf("encode file id: %v", err)
+	}
+	vw, err := valuelog.NewWriter(filepath.Join(valueLogDir, "value-l0-000001.log"), fileID)
+	if err != nil {
+		t.Fatalf("new value log writer: %v", err)
+	}
+	ptrA, err := vw.Append(0, keyA, 1, valA)
+	if err != nil {
+		_ = vw.Close()
+		t.Fatalf("append value A: %v", err)
+	}
+	ptrB, err := vw.Append(0, keyB, 2, valB)
+	if err != nil {
+		_ = vw.Close()
+		t.Fatalf("append value B: %v", err)
+	}
+	if err := vw.Close(); err != nil {
+		t.Fatalf("close value log writer: %v", err)
+	}
+
+	rawBatch := d.NewBatch()
+	type pointerBatch interface {
+		SetPointer(key []byte, ptr page.ValuePtr) error
+		Write() error
+		Close() error
+	}
+	b, ok := rawBatch.(pointerBatch)
+	if !ok {
+		if rawBatch != nil {
+			_ = rawBatch.Close()
+		}
+		t.Fatalf("NewBatch() returned %T, want SetPointer support", rawBatch)
+	}
+	defer b.Close()
+	if err := b.SetPointer(keyA, ptrA); err != nil {
+		t.Fatalf("SetPointer A: %v", err)
+	}
+	if err := b.SetPointer(keyB, ptrB); err != nil {
+		t.Fatalf("SetPointer B: %v", err)
+	}
+	if err := b.Write(); err != nil {
+		t.Fatalf("Write pointer batch: %v", err)
+	}
+
+	it, err := d.Iterator(nil, nil)
+	if err != nil {
+		t.Fatalf("Iterator: %v", err)
+	}
+	defer it.Close()
+	if !it.Valid() {
+		t.Fatalf("expected iterator to be valid")
+	}
+
+	keyView := it.Key()
+	unsafeKey := it.UnsafeKey()
+	if !bytes.Equal(keyView, keyA) {
+		t.Fatalf("Key()=%q want %q", keyView, keyA)
+	}
+	if !sameBacking(keyView, unsafeKey) {
+		t.Fatalf("Key() should return the current UnsafeKey view")
+	}
+
+	valueView := it.Value()
+	unsafeValue := it.UnsafeValue()
+	if err := it.Error(); err != nil {
+		t.Fatalf("Value error: %v", err)
+	}
+	if !bytes.Equal(valueView, valA) {
+		t.Fatalf("Value()=%q want %q", valueView, valA)
+	}
+	if !sameBacking(valueView, unsafeValue) {
+		t.Fatalf("Value() should return the current UnsafeValue view")
+	}
+
+	keyCopyBuf := make([]byte, 0, 64)
+	valueCopyBuf := make([]byte, 0, 64)
+	keyCopy := it.KeyCopy(keyCopyBuf)
+	valueCopy := it.ValueCopy(valueCopyBuf)
+	if !bytes.Equal(keyCopy, keyA) {
+		t.Fatalf("KeyCopy()=%q want %q", keyCopy, keyA)
+	}
+	if !bytes.Equal(valueCopy, valA) {
+		t.Fatalf("ValueCopy()=%q want %q", valueCopy, valA)
+	}
+	if sameBacking(keyCopy, keyView) {
+		t.Fatalf("KeyCopy() must return caller-owned bytes, not the iterator view")
+	}
+	if sameBacking(valueCopy, valueView) {
+		t.Fatalf("ValueCopy() must return caller-owned bytes, not the iterator view")
+	}
+
+	it.Next()
+	if !it.Valid() {
+		t.Fatalf("expected second iterator item")
+	}
+	if !bytes.Equal(it.Key(), keyB) {
+		t.Fatalf("second Key()=%q want %q", it.Key(), keyB)
+	}
+	if !bytes.Equal(it.Value(), valB) {
+		t.Fatalf("second Value()=%q want %q", it.Value(), valB)
+	}
+	if err := it.Error(); err != nil {
+		t.Fatalf("second Value error: %v", err)
+	}
+
+	// Views from Key()/Value() are only valid until iterator movement. Copies are
+	// caller-owned and must remain stable after movement.
+	if !bytes.Equal(keyCopy, keyA) {
+		t.Fatalf("KeyCopy changed after Next: got %q want %q", keyCopy, keyA)
+	}
+	if !bytes.Equal(valueCopy, valA) {
+		t.Fatalf("ValueCopy changed after Next: got %q want %q", valueCopy, valA)
+	}
+}

--- a/TreeDB/docs/spec/contracts.md
+++ b/TreeDB/docs/spec/contracts.md
@@ -84,8 +84,9 @@ For WAL replay, commit-log batches are treated atomically at replay boundaries.
 ### 4.3 Iterator lifetime
 
 - Iterators are point-in-time views.
-- `Key()`/`Value()` data is valid until next movement/close.
-- `KeyCopy`/`ValueCopy` provide stable copies.
+- `Key()`/`Value()` data is a read-only view valid only until next movement/close.
+- Callers must not retain or mutate `Key()`/`Value()` views across iterator movement.
+- `KeyCopy`/`ValueCopy` provide caller-owned stable copies that may be retained after movement/close.
 - Iterator must be closed.
 
 ### 4.4 Cached-mode iterator semantics

--- a/TreeDB/internal/iterator/iterator.go
+++ b/TreeDB/internal/iterator/iterator.go
@@ -17,7 +17,8 @@ type UnsafeIterator interface {
 	// same lifetime rules as UnsafeKey/UnsafeValue.
 	Key() []byte
 	Value() []byte
-	// KeyCopy/ValueCopy append the current key/value into dst and return it.
+	// KeyCopy/ValueCopy copy the current key/value into dst[:0] and return
+	// caller-owned bytes that remain stable after iterator movement/close.
 	KeyCopy(dst []byte) []byte
 	ValueCopy(dst []byte) []byte
 	IsDeleted() bool // True if the current item is a tombstone

--- a/TreeDB/public.go
+++ b/TreeDB/public.go
@@ -52,9 +52,13 @@ const (
 
 // Iterator is the public iterator contract returned by TreeDB.
 //
-// Semantics (performance-first; callers must treat slices as read-only):
-//   - Key() and Value() return views valid until the next Next()/Close().
-//   - Use KeyCopy/ValueCopy if you need stable bytes.
+// Semantics (performance-first; callers must treat returned slices as
+// read-only):
+//   - Key() and Value() return views valid only until the next Next()/Close()
+//     on the same iterator.
+//   - Do not retain or mutate Key()/Value() views across iterator movement.
+//   - KeyCopy/ValueCopy return caller-owned stable bytes, reusing dst capacity
+//     when possible.
 type Iterator interface {
 	Valid() bool
 	Next()

--- a/cmd/unified_bench/main_test.go
+++ b/cmd/unified_bench/main_test.go
@@ -256,6 +256,77 @@ type preferGetManyDB struct {
 	getManyCalls int
 }
 
+type scanViewOnlyDB struct {
+	fixedNameDB
+	entries        []scanViewEntry
+	keyCalls       int
+	valueCalls     int
+	keyCopyCalls   int
+	valueCopyCalls int
+}
+
+type scanViewEntry struct {
+	key   []byte
+	value []byte
+}
+
+type scanViewOnlyIterator struct {
+	db      *scanViewOnlyDB
+	entries []scanViewEntry
+	idx     int
+}
+
+func (d *scanViewOnlyDB) Set(key, value []byte) error {
+	d.entries = append(d.entries, scanViewEntry{
+		key:   append([]byte(nil), key...),
+		value: append([]byte(nil), value...),
+	})
+	return nil
+}
+
+func (d *scanViewOnlyDB) Iterator(start, end []byte) (kvstore.Iterator, error) {
+	sorted := append([]scanViewEntry(nil), d.entries...)
+	sort.Slice(sorted, func(i, j int) bool {
+		return bytes.Compare(sorted[i].key, sorted[j].key) < 0
+	})
+	filtered := sorted[:0]
+	for _, entry := range sorted {
+		if start != nil && bytes.Compare(entry.key, start) < 0 {
+			continue
+		}
+		if end != nil && bytes.Compare(entry.key, end) >= 0 {
+			continue
+		}
+		filtered = append(filtered, entry)
+	}
+	return &scanViewOnlyIterator{db: d, entries: filtered}, nil
+}
+
+func (d *scanViewOnlyDB) ReverseIterator(start, end []byte) (kvstore.Iterator, error) {
+	return nil, kvstore.ErrUnsupported
+}
+
+func (it *scanViewOnlyIterator) Valid() bool { return it.idx < len(it.entries) }
+func (it *scanViewOnlyIterator) Next()       { it.idx++ }
+func (it *scanViewOnlyIterator) Key() []byte {
+	it.db.keyCalls++
+	return it.entries[it.idx].key
+}
+func (it *scanViewOnlyIterator) Value() []byte {
+	it.db.valueCalls++
+	return it.entries[it.idx].value
+}
+func (it *scanViewOnlyIterator) KeyCopy(dst []byte) []byte {
+	it.db.keyCopyCalls++
+	return append(dst[:0], it.entries[it.idx].key...)
+}
+func (it *scanViewOnlyIterator) ValueCopy(dst []byte) []byte {
+	it.db.valueCopyCalls++
+	return append(dst[:0], it.entries[it.idx].value...)
+}
+func (it *scanViewOnlyIterator) Error() error { return nil }
+func (it *scanViewOnlyIterator) Close() error { return nil }
+
 type countingReadSnapshotDB struct {
 	getCalls               atomic.Int64
 	setCalls               atomic.Int64
@@ -388,6 +459,46 @@ func TestRunBenchmark_PreloadsForReadAndScanOnly(t *testing.T) {
 	}
 	if math.IsNaN(prefix) || prefix <= 0 {
 		t.Fatalf("expected prefix_scan > 0, got %v", prefix)
+	}
+}
+
+func TestRunBenchmark_ScansUseIteratorViewsNotCopies(t *testing.T) {
+	var db *scanViewOnlyDB
+	const dbName = "scan_view_only"
+	RegisterHiddenDB(dbName, func(_ string) (kvstore.DB, error) {
+		db = &scanViewOnlyDB{fixedNameDB: fixedNameDB{name: "ScanViewOnly"}}
+		return db, nil
+	})
+
+	run, err := runBenchmark(BenchConfig{
+		Keys:         64,
+		ValueSize:    16,
+		BatchSize:    16,
+		RangeQueries: 8,
+		RangeSpan:    4,
+		DBsArg:       dbName,
+		TestsArg:     "full_scan,prefix_scan",
+		KeepDir:      false,
+		Progress:     false,
+		SeedUsed:     1,
+	})
+	if err != nil {
+		t.Fatalf("runBenchmark: %v", err)
+	}
+	if db == nil {
+		t.Fatalf("expected test DB instance")
+	}
+	if db.keyCopyCalls != 0 || db.valueCopyCalls != 0 {
+		t.Fatalf("scan benchmarks should use Key()/Value() views, got KeyCopy=%d ValueCopy=%d", db.keyCopyCalls, db.valueCopyCalls)
+	}
+	if db.keyCalls == 0 || db.valueCalls == 0 {
+		t.Fatalf("expected Key()/Value() view calls, got Key=%d Value=%d", db.keyCalls, db.valueCalls)
+	}
+	if got := run.Results["full_scan"][db.Name()]; math.IsNaN(got) || got <= 0 {
+		t.Fatalf("expected full_scan > 0, got %v", got)
+	}
+	if got := run.Results["prefix_scan"][db.Name()]; math.IsNaN(got) || got <= 0 {
+		t.Fatalf("expected prefix_scan > 0, got %v", got)
 	}
 }
 

--- a/kvstore/doc.go
+++ b/kvstore/doc.go
@@ -4,5 +4,6 @@
 // Iterator semantics (performance-first):
 //   - Key() and Value() may return read-only views into underlying storage.
 //   - Returned slices are valid until the next Next()/Close() call on that iterator.
-//   - Callers must not modify returned slices; use KeyCopy/ValueCopy for stable bytes.
+//   - Callers must not retain or modify returned views across iterator movement.
+//   - Use KeyCopy/ValueCopy for caller-owned stable bytes.
 package kvstore

--- a/kvstore/kvstore.go
+++ b/kvstore/kvstore.go
@@ -71,6 +71,10 @@ type Printer interface {
 }
 
 // Iterator is a forward-only iterator over key/value pairs.
+//
+// Key()/Value() may return read-only views that are valid only until the next
+// Next()/Close() on the same iterator. KeyCopy()/ValueCopy() return
+// caller-owned stable bytes, reusing dst capacity when possible.
 type Iterator interface {
 	Valid() bool
 	Next()


### PR DESCRIPTION
## Objective

Close #2224 by removing the per-row `DBIterator.KeyCopy` / `ValueCopy` copy path from TreeDB scan iteration when callers use the performance-first `Key()` / `Value()` view APIs.

Links: #2224, parent tracker #2216.

## Context

Full and prefix scan hot loops in unified-bench consume keys/values before advancing the iterator. The public TreeDB/kvstore iterator contracts already allow `Key()` / `Value()` to return read-only views valid until iterator movement; the backend `DBIterator` was still defensively copying through `KeyCopy(nil)` / `ValueCopy(nil)`. This PR aligns the backend wrapper with the view contract while preserving the copy APIs.

## Non-goals

- No on-disk format changes.
- No WAL/durability/read-integrity changes.
- No mmap budget/default changes.
- No value-log pointer lifetime changes.
- No changes to `KeyCopy` / `ValueCopy` stable-copy semantics.
- No #2221 batch/flush allocation work.

## Design

- `TreeDB/db.DBIterator.Key()` now returns `UnsafeKey()`.
- `TreeDB/db.DBIterator.Value()` now returns `UnsafeValue()` and preserves the existing iterator error propagation through that path.
- `KeyCopy(dst)` / `ValueCopy(dst)` continue to copy into caller-owned buffers.
- Docs clarify that `Key()` / `Value()` views are read-only and invalid after `Next()` / `Seek()` / `Close()`, while `KeyCopy` / `ValueCopy` are caller-owned/stable.
- unified-bench scan paths already use `Key()` / `Value()` only inside the current iteration; a new harness test locks that in so scan benchmarks do not fall back to copy APIs.

## Scope

Includes:
- `TreeDB/db/api.go` iterator view implementation.
- Ownership/lifetime docs in `TreeDB/public.go`, `TreeDB/internal/iterator/iterator.go`, `TreeDB/docs/spec/contracts.md`, and `kvstore` docs/interface comments.
- Iterator ownership tests in `TreeDB/db`.
- unified-bench scan adapter test proving full/prefix scans use iterator views, not `KeyCopy` / `ValueCopy`.

Excludes:
- `TreeDB/caching/db.go` and leaf-log scratch pooling behavior (only merged from latest `origin/main` / #2221, not changed by this PR).
- On-disk storage, WAL, mmap, and value-log lifecycle.

## Correctness

Tests run locally at head `6b2f080369d9ea66d6f8de733c15ff0c183ef949`:

```sh
GOWORK=off go test ./TreeDB/db ./TreeDB/tree ./cmd/unified_bench -run 'Scan|Iterator|Prefix' -count=1
GOWORK=off go test ./TreeDB/db ./TreeDB/tree ./cmd/unified_bench ./kvstore/... -count=1
GOWORK=off go test ./TreeDB -count=1
```

Coverage added/updated:
- `TestDBIteratorKeyValueReturnViewsAndCopiesRemainOwned`: pointer-backed values; `Key()` / `Value()` are current-entry views; `KeyCopy` / `ValueCopy` remain stable after `Next()`.
- `TestIteratorKeyValueViewsAndCopyOwnership`: backend iterator view semantics plus copy ownership.
- `TestRunBenchmark_ScansUseIteratorViewsNotCopies`: full/prefix scan benchmark paths use `Key()` / `Value()` and never call copy APIs.

## Performance

Host: `mikers@192.168.0.185`, 1M keys, durable profile, `native-fastpath`, TreeDB only.

### Primary identical before/after command

```sh
./bin/unified-bench -dbs=treedb -keys=1000000 -profile=durable \
  -profile-dir="$OUT" -path-label=native-fastpath -format=markdown \
  -progress=false -test=full_scan,prefix_scan
./bin/benchprof -profiles-dir "$OUT"
```

Artifacts:
- before (`origin/main` `3856082543fe219abd84a199bab9b09d6e4483e5`): `/home/mikers/tmp/gomap_2224_scan_latest_20260603_014249/before`
- after (`6b2f080369d9ea66d6f8de733c15ff0c183ef949`): `/home/mikers/tmp/gomap_2224_scan_latest_20260603_014249/after`

| Test | Before ops/sec | After ops/sec | Δ |
| --- | ---: | ---: | ---: |
| Full Scan | 5,051,785 | 5,231,150 | +3.6% |
| Prefix Scan | 4,726,145 | 4,972,632 | +5.2% |

Mmap/counter health for both before/after primary runs:
- `vlog_mmap.read.hit_ratio.delta=1.000000`
- `vlog_mmap.read.fallback_readat.delta=0`
- `leaf_generation.generations.pinned.after=0`
- `leaf_generation.pins.total.after=0`

### Allocation attribution sanity (settled scans)

Command is identical except `-settle-before-scans=true`, to remove first-iterator memtable rotation noise and show scan allocation attribution.

Artifacts:
- before: `/home/mikers/tmp/gomap_2224_scan_latest_settled_20260603_014336/before`
- after: `/home/mikers/tmp/gomap_2224_scan_latest_settled_20260603_014336/after`

| Test | Before ops/sec | After ops/sec | Δ | Before alloc top | After alloc top |
| --- | ---: | ---: | ---: | --- | --- |
| Full Scan | 5,502,846 | 7,458,348 | +35.5% | `DBIterator.ValueCopy` 127.02MB; `DBIterator.KeyCopy` 8.00MB; total 191.47MB | no `DBIterator.{Key,Value}Copy` in top; total 50.77MB (-73.5%) |
| Prefix Scan | 4,499,152 | 4,825,820 | +7.3% | `DBIterator.KeyCopy` 1024.02KB; total 13,421.50KB | no `DBIterator.KeyCopy` in top; total 6,774.56KB (-49.5%) |

Settled mmap/counter health:
- `vlog_mmap.read.hit_ratio.delta=1.000000`
- `vlog_mmap.read.fallback_readat.delta=0`
- `leaf_generation.generations.pinned.after=0`
- `leaf_generation.pins.total.after=0`

## Rollout / Toggle Plan

No runtime toggle. This aligns implementation with the documented iterator view contract. Callers that need ownership continue to use `KeyCopy` / `ValueCopy`.

## Follow-ups

None required for #2224. Further batch/flush allocation work remains in separate tracker scope.

## CI / AI Review Loop

- Latest-head CI: green for head `6b2f080369d9ea66d6f8de733c15ff0c183ef949` (`gh pr checks 2233`).
- Codex latest-head review: requested; `chatgpt-codex-connector` reported no major issues.
- Copilot latest-head review: requested via `@copilot review`; no findings posted at closeout (comment has bot eyes reaction).
- CodeRabbit latest-head review: status context success, but PR comment says rate limit/usage credits prevented a full comment review; no actionable findings/threads posted.
- Review comments/threads resolved: no review threads present.
