### PR TITLE
TreeDB: reduce cached snapshot acquire churn

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -7805,6 +7805,11 @@ type memtableView struct {
 	retiredMems              []memtable.Table
 	deferredRetiredMemtables atomic.Int64
 	deferredRetiredBytes     atomic.Int64
+	// readerRefs coalesces tracked external readers for this immutable view.
+	// The first reader registers the view in DB.retainedMemtableViews under
+	// retiredMemtablesMu; overlapping readers only bump this atomic and avoid
+	// per-snapshot registry lock traffic. The last reader unregisters the view.
+	readerRefs atomic.Int64
 }
 
 // appendOnlyEstimatedBytesPerEntryDefault tunes initial append-only memtable
@@ -8050,30 +8055,55 @@ func (db *DB) registerMemtableViewReader(view *memtableView) {
 	if db == nil || view == nil {
 		return
 	}
-	db.retiredMemtablesMu.Lock()
-	if db.retainedMemtableViews == nil {
-		db.retainedMemtableViews = make(map[*memtableView]int)
+	for {
+		refs := view.readerRefs.Load()
+		if refs > 0 {
+			if view.readerRefs.CompareAndSwap(refs, refs+1) {
+				return
+			}
+			continue
+		}
+
+		db.retiredMemtablesMu.Lock()
+		refs = view.readerRefs.Load()
+		if refs == 0 {
+			view.readerRefs.Store(1)
+			if db.retainedMemtableViews == nil {
+				db.retainedMemtableViews = make(map[*memtableView]int)
+			}
+			db.retainedMemtableViews[view] = 1
+			db.memtableViewReaders.Add(1)
+			db.retiredMemtablesMu.Unlock()
+			return
+		}
+		db.retiredMemtablesMu.Unlock()
 	}
-	db.retainedMemtableViews[view]++
-	db.memtableViewReaders.Add(1)
-	db.retiredMemtablesMu.Unlock()
 }
 
 func (db *DB) unregisterMemtableViewReader(view *memtableView) {
-	if db == nil {
+	if db == nil || view == nil {
 		return
 	}
+	refs := view.readerRefs.Add(-1)
+	if refs > 0 {
+		return
+	}
+	if refs < 0 {
+		// Defensive self-heal for tests or future callers that accidentally pair an
+		// unregister without a tracked register. Production retain/release paths are
+		// balanced, so this should not happen.
+		view.readerRefs.Store(0)
+		return
+	}
+
 	var reclaim []memtable.Table
 	released := false
 	db.retiredMemtablesMu.Lock()
-	if view != nil && db.retainedMemtableViews != nil {
-		if refs := db.retainedMemtableViews[view]; refs > 1 {
-			db.retainedMemtableViews[view] = refs - 1
-			released = true
-		} else {
+	if view.readerRefs.Load() == 0 && db.retainedMemtableViews != nil {
+		if _, ok := db.retainedMemtableViews[view]; ok {
 			delete(db.retainedMemtableViews, view)
 			reclaim = append(reclaim, db.releaseDeferredRetiredMemtablesForViewLocked(view)...)
-			released = refs == 1
+			released = true
 		}
 	}
 	if released {

--- a/TreeDB/caching/snapshot.go
+++ b/TreeDB/caching/snapshot.go
@@ -54,6 +54,40 @@ var ownedReadScratchPool = sync.Pool{
 	},
 }
 
+// snapshotPool keeps the cached Snapshot wrapper off the heap-heavy per-key
+// read path. Snapshot.Close returns objects here after releasing backend and
+// memtable-view references; callers must not use a Snapshot after Close.
+var snapshotPool = sync.Pool{
+	New: func() any { return &Snapshot{} },
+}
+
+func getSnapshot() *Snapshot {
+	snap, _ := snapshotPool.Get().(*Snapshot)
+	if snap == nil {
+		snap = &Snapshot{}
+	}
+	snap.closed.Store(false)
+	return snap
+}
+
+func putSnapshot(snap *Snapshot) {
+	if snap == nil {
+		return
+	}
+	snap.db = nil
+	snap.view = nil
+	snap.backend = nil
+	snap.backendRootID = 0
+	snap.backendFallback = backendSnapshotLookup{}
+	snap.rootVersion = 0
+	snap.rootPointShards = nil
+	snap.rootSystem = rootDomainSnapshot{}
+	snap.rootIterator = rootDomainSnapshot{}
+	snap.publishedRoots = nil
+	snap.closed.Store(true)
+	snapshotPool.Put(snap)
+}
+
 func getOwnedReadScratch() *ownedReadScratch {
 	scratch, _ := ownedReadScratchPool.Get().(*ownedReadScratch)
 	if scratch == nil || cap(scratch.buf) != page.PageSize {
@@ -163,12 +197,12 @@ func (db *DB) AcquireSnapshot() *Snapshot {
 		if state := backendSnap.State(); state != nil {
 			backendRootID = state.RootPageID
 		}
-		return &Snapshot{
-			db:              db,
-			backend:         backendSnap,
-			backendRootID:   backendRootID,
-			backendFallback: backendSnapshotLookup{db: db, snapshot: backendSnap, rootID: backendRootID},
-		}
+		snap := getSnapshot()
+		snap.db = db
+		snap.backend = backendSnap
+		snap.backendRootID = backendRootID
+		snap.backendFallback = backendSnapshotLookup{db: db, snapshot: backendSnap, rootID: backendRootID}
+		return snap
 	}
 
 	view := db.retainMemtableView()
@@ -255,13 +289,12 @@ func (db *DB) AcquireSnapshot() *Snapshot {
 	if state := backendSnap.State(); state != nil {
 		backendRootID = state.RootPageID
 	}
-	snap := &Snapshot{
-		db:              db,
-		view:            view,
-		backend:         backendSnap,
-		backendRootID:   backendRootID,
-		backendFallback: backendSnapshotLookup{db: db, snapshot: backendSnap, rootID: backendRootID},
-	}
+	snap := getSnapshot()
+	snap.db = db
+	snap.view = view
+	snap.backend = backendSnap
+	snap.backendRootID = backendRootID
+	snap.backendFallback = backendSnapshotLookup{db: db, snapshot: backendSnap, rootID: backendRootID}
 	snap.rootVersion = viewRootVersion
 	snap.rootPointShards = viewRootPointShards
 	snap.rootSystem = viewRootSystem
@@ -298,18 +331,11 @@ func (s *Snapshot) Close() error {
 	var err error
 	if s.backend != nil {
 		err = s.backend.Close()
-		s.backend = nil
 	}
 	if s.view != nil && s.db != nil {
 		s.db.releaseMemtableView(s.view)
-		s.view = nil
 	}
-	s.rootPointShards = nil
-	s.rootSystem = rootDomainSnapshot{}
-	s.rootIterator = rootDomainSnapshot{}
-	s.publishedRoots = nil
-	s.rootVersion = 0
-	s.db = nil
+	putSnapshot(s)
 	return err
 }
 

--- a/TreeDB/caching/snapshot_pool_test.go
+++ b/TreeDB/caching/snapshot_pool_test.go
@@ -1,0 +1,186 @@
+package caching
+
+import (
+	"bytes"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+)
+
+func newCachedSnapshotPoolTestDB(t *testing.T) (*DB, *backenddb.DB) {
+	t.Helper()
+	dir := t.TempDir()
+	backend, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("backend open: %v", err)
+	}
+	cached, err := Open(dir, backend, Options{DisableWAL: true, AllowUnsafe: true, FlushThreshold: 1 << 30})
+	if err != nil {
+		_ = backend.Close()
+		t.Fatalf("cached open: %v", err)
+	}
+	return cached, backend
+}
+
+func TestAcquireSnapshot_CachedPathAllocsAfterWarm(t *testing.T) {
+	cached, backend := newCachedSnapshotPoolTestDB(t)
+	defer func() {
+		_ = cached.Close()
+		_ = backend.Close()
+	}()
+
+	if err := cached.Set([]byte("alloc-key"), []byte("alloc-value")); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	warm := cached.AcquireSnapshot()
+	if warm == nil {
+		t.Fatal("warm AcquireSnapshot=nil")
+	}
+	if warm.view == nil {
+		_ = warm.Close()
+		t.Fatal("warm snapshot used backend fast path; want cached path")
+	}
+	if err := warm.Close(); err != nil {
+		t.Fatalf("warm Close: %v", err)
+	}
+
+	allocs := testing.AllocsPerRun(1000, func() {
+		snap := cached.AcquireSnapshot()
+		if snap == nil {
+			panic("AcquireSnapshot=nil")
+		}
+		if snap.view == nil {
+			panic("AcquireSnapshot did not retain queued cached view")
+		}
+		if err := snap.Close(); err != nil {
+			panic(err)
+		}
+	})
+	if allocs > 0.1 {
+		t.Fatalf("cached AcquireSnapshot allocs/run=%f want <= 0.1", allocs)
+	}
+}
+
+func TestAcquireSnapshot_CachedPathSnapshotIsolationAcrossReuse(t *testing.T) {
+	cached, backend := newCachedSnapshotPoolTestDB(t)
+	defer func() {
+		_ = cached.Close()
+		_ = backend.Close()
+	}()
+
+	key := []byte("snapshot-reuse-isolation")
+	if err := cached.Set(key, []byte("old")); err != nil {
+		t.Fatalf("Set old: %v", err)
+	}
+	oldSnap := cached.AcquireSnapshot()
+	if oldSnap == nil {
+		t.Fatal("old AcquireSnapshot=nil")
+	}
+	defer func() { _ = oldSnap.Close() }()
+
+	if err := cached.Set(key, []byte("new")); err != nil {
+		t.Fatalf("Set new: %v", err)
+	}
+	newSnap := cached.AcquireSnapshot()
+	if newSnap == nil {
+		t.Fatal("new AcquireSnapshot=nil")
+	}
+	defer func() { _ = newSnap.Close() }()
+
+	gotOld, err := oldSnap.GetAppend(key, nil)
+	if err != nil {
+		t.Fatalf("old snapshot GetAppend: %v", err)
+	}
+	if !bytes.Equal(gotOld, []byte("old")) {
+		t.Fatalf("old snapshot value=%q want old", string(gotOld))
+	}
+	gotNew, err := newSnap.GetAppend(key, nil)
+	if err != nil {
+		t.Fatalf("new snapshot GetAppend: %v", err)
+	}
+	if !bytes.Equal(gotNew, []byte("new")) {
+		t.Fatalf("new snapshot value=%q want new", string(gotNew))
+	}
+}
+
+func TestAcquireSnapshot_CachedPathConcurrentAcquireCloseWithWrites(t *testing.T) {
+	cached, backend := newCachedSnapshotPoolTestDB(t)
+	defer func() {
+		_ = cached.Close()
+		_ = backend.Close()
+	}()
+
+	key := []byte("snapshot-concurrent-cached-key")
+	if err := cached.Set(key, []byte("v00")); err != nil {
+		t.Fatalf("Set seed: %v", err)
+	}
+	seed := cached.AcquireSnapshot()
+	if seed == nil {
+		t.Fatal("seed AcquireSnapshot=nil")
+	}
+	if err := seed.Close(); err != nil {
+		t.Fatalf("seed Close: %v", err)
+	}
+
+	var stop atomic.Bool
+	errCh := make(chan error, 1)
+	publishErr := func(err error) {
+		if err == nil {
+			return
+		}
+		if stop.CompareAndSwap(false, true) {
+			errCh <- err
+		}
+	}
+
+	var wg sync.WaitGroup
+	for worker := 0; worker < 4; worker++ {
+		wg.Add(1)
+		go func(worker int) {
+			defer wg.Done()
+			for i := 0; i < 250 && !stop.Load(); i++ {
+				snap := cached.AcquireSnapshot()
+				if snap == nil {
+					publishErr(fmt.Errorf("worker %d acquire %d: nil snapshot", worker, i))
+					return
+				}
+				got, err := snap.GetAppend(key, nil)
+				closeErr := snap.Close()
+				if err != nil {
+					publishErr(fmt.Errorf("worker %d get %d: %w", worker, i, err))
+					return
+				}
+				if len(got) == 0 {
+					publishErr(fmt.Errorf("worker %d get %d: empty value", worker, i))
+					return
+				}
+				if closeErr != nil {
+					publishErr(fmt.Errorf("worker %d close %d: %w", worker, i, closeErr))
+					return
+				}
+			}
+		}(worker)
+	}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 1; i <= 25 && !stop.Load(); i++ {
+			value := []byte(fmt.Sprintf("v%02d", i))
+			if err := cached.Set(key, value); err != nil {
+				publishErr(fmt.Errorf("writer set %d: %w", i, err))
+				return
+			}
+		}
+	}()
+
+	wg.Wait()
+	select {
+	case err := <-errCh:
+		t.Fatal(err)
+	default:
+	}
+}


### PR DESCRIPTION
## Objective

Reduce TreeDB cached snapshot-per-key acquire/close churn for parallel read workloads while preserving snapshot isolation and memtable/value-log lifetime safety.

Fixes #2241.

## Context

The durable 1M-key snapshot-per-key read path spent a large share of allocation space in `caching.(*DB).AcquireSnapshot` and repeatedly took the memtable-view reader registry mutex during acquire/close.

## Non-goals

- No on-disk format changes.
- No WAL/sync, read-integrity, value-log persistence, or mmap default/budget changes.
- No public API semantic changes.
- No collection throughput claim; `TreeDB/collections` code is unchanged.

## Design

- Pool cached `TreeDB/caching.Snapshot` wrappers and return them from `Snapshot.Close` after backend and memtable-view references are released.
- Coalesce tracked memtable-view reader registration per immutable view:
  - first overlapping reader registers the view under `retiredMemtablesMu`;
  - overlapping readers only bump `memtableView.readerRefs` atomically;
  - last reader unregisters and releases any deferred retired memtables.
- Snapshot isolation remains unchanged: mutable writes are still rotated/frozen before cached snapshots, and queued/root/published/dirty-vlog fallback behavior remains fail-closed.

## Scope

Includes:
- `TreeDB/caching/snapshot.go`: cached snapshot pooling.
- `TreeDB/caching/db.go`: per-view coalesced reader registration.
- `TreeDB/caching/snapshot_pool_test.go`: allocation, isolation, and concurrent acquire/close coverage.

Excludes:
- `TreeDB/collections` code changes.
- `TreeDB/db` backend snapshot internals.
- benchmark harness changes.

## Correctness

Tests run:

```sh
GOWORK=off go test ./TreeDB/caching ./TreeDB/db ./kvstore/adapters/treedb -count=1
GOWORK=off go test ./TreeDB/collections -run '^$' -count=1
GOWORK=off go test -race ./TreeDB/caching -run 'TestAcquireSnapshot_CachedPathConcurrentAcquireCloseWithWrites' -count=1
GOWORK=off go test ./TreeDB -run 'TestAcquireSnapshot_|TestSnapshot|TestReadAfterWriteSnapshot' -count=1
```

Added coverage:
- cached-path `AcquireSnapshot`/`Close` allocs-after-warm guard;
- cached snapshot isolation across pooled object reuse;
- concurrent cached acquire/close while writes are rotating mutable memtables;
- existing retired memtable tracked/untracked retain tests remain green.

## Collection impact audit

Production `TreeDB/collections` `AcquireSnapshot` sites were audited. No in-scope repeated-snapshot row/key loop was found:

- index range/document scans acquire one snapshot before iterator/result loops;
- vector search hydration acquires one snapshot before iterating ranked results;
- column physical scan/query paths acquire one snapshot/view per top-level operation;
- `NewStoredDocumentJSONMaterializer` already pins a reusable snapshot for template-v1 materializer lifetime;
- write/update/delete planning acquires snapshots per top-level attempt, not per row loop.

No collection code changed; collection throughput is expected to be neutral and no collection improvement is claimed.

## Performance

Host: `mikers@192.168.0.185` (`mikers-B560-DS3H-AC-Y1`).

Command for both runs:

```sh
./bin/unified-bench -dbs=treedb -keys=1000000 -profile=durable \
  -profile-dir="$OUT" -path-label=native-fastpath -format=markdown -progress=false \
  -test=random_read_parallel_acquire_snapshot,random_read_parallel,random_read
./bin/benchprof -profiles-dir "$OUT"
```

Before: `/home/mikers/tmp/treedb_1m_durable_2241_before_20260603_093652`, commit `c074c52c74dc52eac31c74d952e9c736bd67285e`.
After: `/home/mikers/tmp/treedb_1m_durable_2241_after_20260603_093821`, commit `94c37cbd97e1d786e1f06b4e4ee2516151c60d23`.

| Metric | Before | After | Delta |
| --- | ---: | ---: | ---: |
| random_read_parallel_acquire_snapshot ops/sec | 391,403 | 413,975 | +5.8% |
| random_read_parallel ops/sec | 380,737 | 408,535 | +7.3% |
| random_read ops/sec | 162,793 | 165,197 | +1.5% |
| snapshot.acquire.calls | 12,000,000 | 12,000,000 | unchanged |
| snapshot.acquire total_ms | 9,346.405 | 8,315.164 | -11.0% |
| snapshot.close total_ms | 3,735.847 | 2,259.352 | -39.5% |
| alloc profile total alloc_space | 471.96 MiB | 74.23 MiB | -84.3% |
| `caching.(*DB).AcquireSnapshot` alloc_space | 394.59 MiB | below pprof top threshold / no flat top entry | eliminated from top allocators |
| mutex profile total delay | 241.53 s | 231.95 s | -4.0% |
| block profile total delay | 579.36 s | 526.84 s | -9.1% |
| mmap fallback_readat delta | 0 | 0 | unchanged |
| mmap hit_ratio delta | 1.000000 | 1.000000 | unchanged |

Profile-top files were written in each profile dir as:
- `allocs_random_read_parallel_acquire_snapshot_top.txt`
- `mutex_random_read_parallel_acquire_snapshot_top.txt`
- `block_random_read_parallel_acquire_snapshot_top.txt`

## Rollout / Toggle Plan

No new runtime knob. The change is local to cached snapshot object/reader-registry lifetime management and can be reverted by reverting this PR.

## Follow-ups

- Downstream #2243 does not need to wait for a new snapshot/read-cache contract from this PR; no API or snapshot semantics changed.
- Parallel siblings #2242/#2244/#2246 may proceed independently.

## AI Review Loop

- Codex latest-head review: completed on `94c37cbd97`; one P2 use-after-close/idempotency comment was answered with the documented single-use snapshot contract and the thread was resolved.
- Copilot latest-head review: requested via `@copilot review` and `copilot-pull-request-reviewer`; no review output was emitted by the bot.
- CodeRabbit latest-head review: completed automatically on `94c37cbd97`; no actionable comments. Docstring coverage warning is non-blocking for this Go package.
- Review comments/threads: all threads resolved.

---

## Optimization PR Checklist (TreeDB)

### Scope
- [x] Single, clear objective for this PR.
- [x] Explicit include/exclude list.
- [x] No unwanted feature reintroduction.

### Safety / Correctness
- [x] No `*Sync` path semantics changed.
- [x] No new mmap usage on mutable/truncating files.
- [x] No format/parsing allocation changes.
- [x] No CRC/checksum behavior changes.
- [x] Concurrency change has stated reader-ref invariants.

### Tests
- [x] Added deterministic regression tests for targeted churn/lifetime behavior.
- [x] Added concurrency/race coverage.
- [x] Ran targeted packages and benchmarks above.

### Benchmarks / Measurements
- [x] Reported before/after benchmark/profile evidence.

### Docs
- [x] PR description documents scope, invariants, collection audit, and evidence.
