### PR TITLE
Reduce TreeDB column_graph frontier scratch churn

### DIFF
--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -15,6 +15,12 @@ import (
 // probes.
 const columnVectorGraphNativeScratchOversizeSlack = 16
 
+// Layer-0 frontier pushes can exceed efSearch because every candidate admitted
+// into the retained top set is also queued for expansion, including candidates
+// later displaced from that top set. Seed frontier capacity from efSearch*M to
+// avoid repeated grow/shrink churn while keeping retention capped by row count.
+const columnVectorGraphNativeFrontierCapacityDegreeFloor = 1
+
 // Default TopK values are small; insertion order avoids sort overhead there.
 // Larger result sets switch to sort.Slice so result ordering does not go O(k^2).
 const columnVectorGraphNativeResultOrderInsertionSortLimit = 32
@@ -899,13 +905,7 @@ func (s *columnVectorGraphNativeSearchScratch) prepare(rowCount, dimensions, deg
 		clear(s.visitMarks)
 		s.visitEpoch = 1
 	}
-	frontierCap := efSearch
-	if frontierCap > rowCount {
-		frontierCap = rowCount
-	}
-	if frontierCap < topK {
-		frontierCap = topK
-	}
+	frontierCap := columnVectorGraphNativeSearchFrontierCapacity(rowCount, degree, topK, efSearch)
 	s.frontier = resizeColumnVectorGraphNativeCandidateScratch(s.frontier, frontierCap)
 	topCandidateCap := efSearch
 	if topCandidateCap > rowCount {
@@ -953,6 +953,39 @@ func resizeColumnVectorGraphNativeCandidateScratch(dst []columnVectorGraphSearch
 		return make([]columnVectorGraphSearchCandidate, 0, target)
 	}
 	return dst[:0]
+}
+
+func columnVectorGraphNativeSearchFrontierCapacity(rowCount, degree, topK, efSearch int) int {
+	if rowCount < 0 {
+		rowCount = 0
+	}
+	if topK < 0 {
+		topK = 0
+	}
+	if topK > rowCount {
+		topK = rowCount
+	}
+	if degree < columnVectorGraphNativeFrontierCapacityDegreeFloor {
+		degree = columnVectorGraphNativeFrontierCapacityDegreeFloor
+	}
+	frontierCap := efSearch
+	if frontierCap < 0 {
+		frontierCap = 0
+	}
+	if frontierCap > 0 && degree > 1 {
+		if rowCount > 0 && frontierCap <= rowCount/degree {
+			frontierCap *= degree
+		} else {
+			frontierCap = rowCount
+		}
+	}
+	if frontierCap > rowCount {
+		frontierCap = rowCount
+	}
+	if frontierCap < topK {
+		frontierCap = topK
+	}
+	return frontierCap
 }
 
 func resizeColumnVectorGraphNativeResultScratch(dst []columnVectorGraphNativeSearchResult, target int) []columnVectorGraphNativeSearchResult {

--- a/TreeDB/collections/column_vector_graph_search_test.go
+++ b/TreeDB/collections/column_vector_graph_search_test.go
@@ -598,6 +598,135 @@ func TestColumnVectorGraphNativeSearchScratchVisitMarksShrinkV3(t *testing.T) {
 	}
 }
 
+func TestColumnVectorGraphNativeSearchScratchFrontierCapacityPolicyV3(t *testing.T) {
+	const (
+		rowCount = 4096
+		degree   = 16
+		topK     = 10
+		efSearch = 128
+	)
+	var scratch columnVectorGraphNativeSearchScratch
+	if err := scratch.prepare(rowCount, 32, degree, topK, efSearch, degree, 0); err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+	wantFrontierCap := columnVectorGraphNativeSearchFrontierCapacity(rowCount, degree, topK, efSearch)
+	if wantFrontierCap != efSearch*degree {
+		t.Fatalf("frontier policy target=%d want %d", wantFrontierCap, efSearch*degree)
+	}
+	if cap(scratch.frontier) != wantFrontierCap {
+		t.Fatalf("frontier cap=%d want %d", cap(scratch.frontier), wantFrontierCap)
+	}
+	if cap(scratch.top) != efSearch {
+		t.Fatalf("top cap=%d want efSearch cap %d unchanged", cap(scratch.top), efSearch)
+	}
+	if !scratch.markVisited(7) {
+		t.Fatal("initial markVisited failed")
+	}
+	scratch.frontier = scratch.frontier[:cap(scratch.frontier)]
+	frontierBacking := columnVectorGraphCandidateBackingPtrForTest(scratch.frontier)
+	visitEpoch := scratch.visitEpoch
+	if err := scratch.prepare(rowCount, 32, degree, topK, efSearch, degree, 0); err != nil {
+		t.Fatalf("prepare repeated: %v", err)
+	}
+	if len(scratch.frontier) != 0 {
+		t.Fatalf("repeated prepare frontier len=%d want 0", len(scratch.frontier))
+	}
+	if cap(scratch.frontier) != wantFrontierCap || columnVectorGraphCandidateBackingPtrForTest(scratch.frontier) != frontierBacking {
+		t.Fatalf("repeated prepare frontier cap=%d ptr=%#x want cap=%d ptr=%#x", cap(scratch.frontier), columnVectorGraphCandidateBackingPtrForTest(scratch.frontier), wantFrontierCap, frontierBacking)
+	}
+	if scratch.visitEpoch != visitEpoch+1 {
+		t.Fatalf("visitEpoch=%d want %d", scratch.visitEpoch, visitEpoch+1)
+	}
+	if !scratch.markVisited(7) {
+		t.Fatal("markVisited after prepare should see prior epoch as reset")
+	}
+
+	scratch.frontier = make([]columnVectorGraphSearchCandidate, 0, rowCount)
+	if err := scratch.prepare(8, 32, degree, 1, efSearch, degree, 0); err != nil {
+		t.Fatalf("prepare small rowCount: %v", err)
+	}
+	if cap(scratch.frontier) > 8+columnVectorGraphNativeScratchOversizeSlack {
+		t.Fatalf("small rowCount frontier cap=%d want bounded by row count/slack", cap(scratch.frontier))
+	}
+	if got := columnVectorGraphNativeSearchFrontierCapacity(8, degree, 32, efSearch); got != 8 {
+		t.Fatalf("frontier target with topK above rowCount=%d want rowCount cap 8", got)
+	}
+}
+
+func TestColumnVectorGraphNativeSearchRepeatedSearchRetainsFrontierCapacityV3(t *testing.T) {
+	const (
+		rows     = 256
+		dims     = 16
+		m        = 16
+		topK     = 10
+		efSearch = 16
+	)
+	input := columnGraphRebuildSyntheticRowsV2A(rows, dims)
+	_, d, col, def := openColumnGraphRebuildTestCollectionV2A(t, dims, m, input)
+	defer func() { _ = d.Close() }()
+	status, err := col.RebuildVectorIndex(def.Name)
+	if err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	assertColumnGraphRebuildLoadedStatusV2A(t, status, def.Name)
+	reader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("openColumnVectorGraphPhysicalRowReader: %v", err)
+	}
+	defer reader.Close()
+
+	query := append([]float32(nil), input[17].vector...)
+	opts := columnVectorGraphNativeSearchOptions{TopK: topK, EfSearch: efSearch}
+	var scratch columnVectorGraphNativeSearchScratch
+	first, _, err := reader.SearchCosine(query, opts, &scratch)
+	if err != nil {
+		t.Fatalf("first SearchCosine: %v", err)
+	}
+	if len(first) == 0 {
+		t.Fatal("first SearchCosine returned no results")
+	}
+	firstOrdinals := make([]int, len(first))
+	firstScores := make([]float64, len(first))
+	for i := range first {
+		firstOrdinals[i] = first[i].Ordinal
+		firstScores[i] = first[i].Score
+	}
+	wantFrontierCap := columnVectorGraphNativeSearchFrontierCapacity(reader.RowCount(), reader.def.M, topK, efSearch)
+	if cap(scratch.frontier) < wantFrontierCap || cap(scratch.frontier) > reader.RowCount() {
+		t.Fatalf("frontier cap after first search=%d want [%d,%d]", cap(scratch.frontier), wantFrontierCap, reader.RowCount())
+	}
+	frontierCap := cap(scratch.frontier)
+	frontierBacking := columnVectorGraphCandidateBackingPtrForTest(scratch.frontier)
+	visitEpoch := scratch.visitEpoch
+
+	second, _, err := reader.SearchCosine(query, opts, &scratch)
+	if err != nil {
+		t.Fatalf("second SearchCosine: %v", err)
+	}
+	if len(second) != len(first) {
+		t.Fatalf("second results len=%d want %d", len(second), len(first))
+	}
+	for i := range firstOrdinals {
+		if firstOrdinals[i] != second[i].Ordinal || firstScores[i] != second[i].Score {
+			t.Fatalf("result[%d]=%+v want ordinal=%d score=%v", i, second[i], firstOrdinals[i], firstScores[i])
+		}
+	}
+	if cap(scratch.frontier) != frontierCap || columnVectorGraphCandidateBackingPtrForTest(scratch.frontier) != frontierBacking {
+		t.Fatalf("frontier reallocated across repeated search: cap=%d ptr=%#x want cap=%d ptr=%#x", cap(scratch.frontier), columnVectorGraphCandidateBackingPtrForTest(scratch.frontier), frontierCap, frontierBacking)
+	}
+	if scratch.visitEpoch != visitEpoch+1 {
+		t.Fatalf("visitEpoch after repeated search=%d want %d", scratch.visitEpoch, visitEpoch+1)
+	}
+}
+
+func columnVectorGraphCandidateBackingPtrForTest(candidates []columnVectorGraphSearchCandidate) uintptr {
+	if cap(candidates) == 0 {
+		return 0
+	}
+	backing := candidates[:cap(candidates)]
+	return uintptr(unsafe.Pointer(&backing[0]))
+}
+
 func TestColumnVectorGraphNativeScratchCapOversizedOverflowSafeV3(t *testing.T) {
 	if !columnVectorGraphNativeScratchCapOversized(64, 1) {
 		t.Fatalf("expected oversized scratch cap for small target")


### PR DESCRIPTION
## Objective

Reduce TreeDB `column_graph` search frontier scratch allocation churn without changing exact/default search semantics.

Fixes #2236. Part of tracker #2234.

## Context

#2236 hypothesized that `columnVectorGraphNativeSearchScratch.prepare` pre-sized the layer-0 frontier only to `efSearch`, while a search can push more than `efSearch` accepted candidates into the expansion frontier. The next search then oversize-shrank back to `efSearch`, causing repeated `growslice`/`memclr` churn in the hot `scoreAndPushFrontierVisitedTile` path.

## Non-goals

- No traversal order, stop condition, top-k/result ordering, recall, or public/default behavior changes.
- No efSearch default/validation tuning (#2235 scope).
- No multipart scorer locality or indexed-scoring changes (#2237/#2238 scope).
- No unbounded scratch retention.

## Design

- Formats/flags/APIs changed: none.
- Invariants that must hold:
  - Per-search logical lengths still reset to zero.
  - Visit epoch behavior is unchanged.
  - Frontier capacity is bounded before allocation.
- Fail-closed behavior: the frontier target is `min(rowCount, efSearch * max(M, 1))`, then clamped by normalized `topK`; multiplication is row-count guarded to avoid overflow. Existing oversize slack still releases much larger scratch after small searches.

## Scope

- Includes (files/symbols):
  - `TreeDB/collections/column_vector_graph_search.go`
  - `columnVectorGraphNativeSearchScratch.prepare`
  - new `columnVectorGraphNativeSearchFrontierCapacity`
  - focused scratch/frontier tests in `TreeDB/collections/column_vector_graph_search_test.go`
- Excludes (files/symbols): prepared scoring helpers, traversal logic, wavefront search, public defaults, docs/default tuning.

## Correctness

- Tests run (exact commands):
  - `GOWORK=off go test ./TreeDB/collections -run 'TestColumnVectorGraphNativeSearch(ScratchFrontierCapacityPolicy|RepeatedSearchRetainsFrontierCapacity)V3|TestColumnVectorGraphNativeSearchScratchVisitMarksShrinkV3' -count=1`
  - `GOWORK=off go test ./TreeDB/collections ./cmd/treedb_vector_search_demo -count=1`
- Corruption/edge cases covered: no format/parser change. Focused tests cover small-rowCount oversize release and `topK > rowCount` frontier cap.
- Concurrency/race coverage: no shared-state/concurrency behavior change; scratch remains caller/searcher-owned.

## Performance

- Hardware/context: Apple M3, 16 GiB RAM, Darwin arm64; `go version go1.25.5 darwin/arm64`.
- Dataset/search shape: 100,000 docs, 128 dims, topK=10, M=16, efConstruction=128, efSearch=128, 5,000 buffered `SearchWithBuffer` queries, no document fetch, same DB built once from baseline.
- Baseline: `origin/main` `c074c52c74dc52eac31c74d952e9c736bd67285e`.
- Candidate: `5f1b385ba`.
- Artifact dir: `/tmp/treedb2236_frontier_scratch_20260603_100439`.

### Commands

DB build baseline:

```sh
BASE_DB=/tmp/treedb2236_base_db
rm -rf "$BASE_DB"
GOWORK=off go run ./cmd/treedb_vector_search_demo \
  -matrix=false \
  -vector-index-strategy=column_graph \
  -dir "$BASE_DB" \
  -docs 100000 \
  -dims 128 \
  -queries 1 \
  -search-concurrency 8 \
  -validate-queries 0 \
  -validate-docs 0 \
  -min-recall 0 \
  -top-k 10 \
  -m 16 \
  -ef-construction 128 \
  -ef-search 128 \
  -compact=false \
  -disable-exact-fallback=true \
  -json
```

Buffered benchmark/profile harness: `/tmp/treedb2236_frontier_scratch_20260603_100439/treedb_buffered_search_bench.go`.

```sh
GOWORK=off go run /tmp/treedb_buffered_search_bench.go \
  -dir /tmp/treedb2236_base_db -docs 100000 -dims 128 \
  -queries 5000 -concurrency 1 -top-k 10 -ef-search 128 \
  -cpuprofile /tmp/treedb2236_${LABEL}_c1_cpu.pprof

GOWORK=off go run /tmp/treedb_buffered_search_bench.go \
  -dir /tmp/treedb2236_base_db -docs 100000 -dims 128 \
  -queries 5000 -concurrency 8 -top-k 10 -ef-search 128 \
  -cpuprofile /tmp/treedb2236_${LABEL}_c8_cpu.pprof

go tool pprof -top -nodecount=25 <profile>
go tool pprof -tree -nodecount=80 <profile>
```

### Results

| concurrency | commit | avg us | p50 us | p95 us | p99 us | ops/sec | avg candidates | B/op | allocs/op | CPU profile memclr/span-init note |
| ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| 1 | baseline c074c52 | 696.86 | 609.46 | 1080.50 | 1690.38 | 1434.4 | 2362.3 | 2808.5 | 0.664 | `runtime.memclrNoHeapPointers` 0.51s / 17.41% flat; tree shows `runtime.growslice` under `scoreAndPushFrontierVisitedTile`/`pushFrontier` |
| 1 | candidate 5f1b385 | 576.73 | 484.33 | 887.67 | 1572.62 | 1733.3 | 2362.3 | 540.2 | 0.188 | `memclr` no longer in top/tree output (below reporting threshold) |
| 8 | baseline c074c52 | 1556.23 | 713.54 | 5630.96 | 15557.92 | 5136.2 | 2362.3 | 2798.6 | 0.688 | `runtime.memclrNoHeapPointers` 0.09s / 3.12% flat |
| 8 | candidate 5f1b385 | 1391.83 | 719.42 | 5322.88 | 12258.00 | 5711.5 | 2362.3 | 529.1 | 0.193 | `memclr` no longer in top output (below reporting threshold) |

Regressions: none material. c=8 p50 moved by ~0.8% in a noisy concurrent run while avg, p95, p99, throughput, B/op, allocs/op, and profile attribution all improved.

Memory/capacity note: for the representative shape, frontier target is `efSearch*M = 2048` candidates. `columnVectorGraphSearchCandidate` is 16 bytes, so the target is ~32 KiB per searcher; the existing oversize policy retains up to roughly `target*2+16` candidates (~64 KiB) before shrinking, and row count is the hard cap. Latest candidate harness HeapSys stayed flat over each run (`258703360 -> 258703360` for c=1, `262897664 -> 262864896` for c=8); RSS was not separately sampled.

## Latest-head CI

All GitHub checks are passing on head `5f1b385baaa626072d3616f5a791146b23058c7f` (Format, Root, TreeDB, HashDB, read-snapshot guardrail, redis bench, unified bench/test suites, CodeRabbit).

## Rollout / Toggle Plan

- Default setting: this is the default internal scratch sizing for exact/default column_graph search.
- How to disable quickly: revert this PR; no format or API migration needed.

## Follow-ups

- #2237 can start after this merges; this PR does not touch multipart scoring/helper semantics.

## Column Graph Native Workstream (#1646, if applicable)

### Copied/Adapted From Old Stack

- Copied: none.
- Adapted: none.
- Oracle/comparator only: none.
- Quarantined/not copied: none.

### Path Identity

- Native reader: unchanged exact/default `column_graph_native_reader` path.
- Decoded comparator: unchanged.
- Legacy/native vector index: unchanged.
- Unsupported/fail-closed: unchanged.

### Base And Dependency State

- Base branch: `origin/main`.
- Base commit: `c074c52c74dc52eac31c74d952e9c736bd67285e`.
- Base PR/head: none; no unmerged predecessors.
- #1621/#1634 assumptions: not applicable.
- Missing generic column-store primitives: none.
- Parent review fixes propagated: not applicable.

### Evidence

- Tests: listed above.
- Benchmarks: listed above.
- Status/fallback proof: benchmark response path remains `column_graph_native_reader`; avg candidates unchanged at 2362.3.
- Performance attribution: baseline memclr/growslice under `scoreAndPushFrontierVisitedTile` removed from latest candidate profile top/tree.
- Local regressions found/fixed: reviewer requested helper-level rowCount cap and visible evidence; rowCount cap added and evidence included here.

### Test Plan Start

- Milestone tasks targeted: #2236 M0/M1/M2.
- Tests to add before or with implementation: scratch frontier capacity policy and repeated `SearchCosine` reuse.
- Existing tests to preserve: scratch oversize shrink, warm zero-alloc path, column_graph search correctness.
- #1646 test-list changes made before implementation: none.

### Performance Plan Start

- Relevant benchmarks/metrics for this PR: 100k buffered c=1/c=8 latency, throughput, candidates/search, B/op, allocs/op, CPU profile top/tree.
- Baseline/comparator command or reason not applicable: baseline command above.
- Expected setup/search/materialization boundary: no-document buffered `SearchWithBuffer`; setup/rebuild/open excluded.
- Upstream costs explicitly out of scope: scoring math, multipart locality, efSearch defaults.
- Local performance risks to watch: retained frontier capacity and c=8 tail latency.

### Test Plan Close

- Additional tests found during implementation/review: topK-above-rowCount frontier cap hardening.
- Tests added or changed: `TestColumnVectorGraphNativeSearchScratchFrontierCapacityPolicyV3`, `TestColumnVectorGraphNativeSearchRepeatedSearchRetainsFrontierCapacityV3`.
- Failing tests fixed: none.
- #1646 test-list changes made at close: none.
- Residual untested gaps, if any: none identified for scratch policy; no public behavior change.

### Performance Plan Close

- Benchmark commands run: listed above.
- Results summary with throughput/latency/allocations: table above.
- Before/after or baseline comparison: baseline c074c52 vs candidate 5f1b385.
- Local slow/heavy code found and fixed: repeated frontier `growslice`/`memclr` from efSearch-sized frontier target.
- Remaining upstream or deferred costs: scoring dominates after fix; multipart scorer locality remains #2237/#2238.

### AI Review Loop

- Codex latest-head review: passed via `chatgpt-codex-connector` comment at 2026-06-03T20:24:09Z ("Didn't find any major issues").
- Copilot latest-head review: requested with `@copilot review` at 2026-06-03T20:13:37Z; no Copilot bot response appeared, and `gh pr edit --add-reviewer copilot` / `github-copilot` could not resolve a reviewer login, so Copilot appears unavailable for this repo path.
- CodeRabbit latest-head review: passed/no actionable comments after `@coderabbitai review` re-request; latest run `ba9b3c5d-1910-4201-80a7-2f63b4d52539`.
- Review comments/threads resolved or explicitly dismissed: no unresolved review threads; internal reviewer PASS after prior evidence blocker was resolved.
- Re-requested after final meaningful push: yes for Codex/CodeRabbit; no code pushes after reviews.

---

## Optimization PR Checklist (TreeDB)

### Scope
- [x] Single, clear objective for this PR (not a bundle)
- [x] Explicit include list (files/symbols touched): see Scope
- [x] Explicit exclude list (files/symbols NOT touched): see Scope
- [x] No unwanted feature reintroduction (e.g. async slab writer, hard zones, ValueIndex) unless explicitly stated in the PR objective

### Safety / Correctness
- [x] Clear written-vs-durable semantics for any `*Sync` path touched (not applicable; no write path)
- [x] No new mmap usage on mutable/truncating files
- [x] All new length fields are capped before allocation (OOM-safe)
- [x] CRC/checksum behavior is fail-closed (not applicable; no parsing/format change)
- [x] Any concurrency change has a defined state machine and invariants (not applicable)

### Tests
- [x] Added deterministic regression tests for the targeted failure mode
- [x] Tests avoid sleeps where possible (use latches/hooks)
- [x] Added corruption/edge-case tests (truncation, bad headers, invalid lengths) when format/parsing changes (not applicable)
- [ ] Ran locally:
  - [ ] `go test ./... -count=1`
  - [x] Any targeted packages/benchmarks: see tests and performance sections

### Benchmarks / Measurements
- [x] Added or updated a benchmark relevant to the change (used local focused harness; no committed default-heavy benchmark)
- [x] Reported results in PR description (before/after, command, machine)
- [x] Included “incompressible” (worst-case) results if compression is involved (not applicable)

### Docs
- [x] Updated `docs/OPT_SPRINT_NEXT.md` milestone status (not applicable)
- [x] Documented any new config knobs + defaults (not applicable)
- [x] Called out any format change in PR description (none)

### Rollout / Toggle Plan (if behavior-affecting)
- [x] Safe defaults (feature off or conservative threshold)
- [x] Clear knobs to disable/revert behavior quickly
- [x] Observability: counters/logs to verify effectiveness (existing benchmark stats/profiles)
