### PR TITLE
TreeDB: add GetManyView callback reads

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -24540,23 +24540,17 @@ func (db *DB) getManyViewFromPublishedRootPointShards(view *memtableView, keys [
 		return nil
 	}
 	db.noteRootDomainGetManyBackendFallback(len(backendKeys))
-	backendVals, err := db.backendGetMany(backendKeys)
-	if err != nil {
-		return err
-	}
-	if len(backendVals) != len(backendKeys) {
-		return fmt.Errorf("cachingdb: backend GetMany returned %d values for %d keys", len(backendVals), len(backendKeys))
-	}
-	for i, uniqueIdx := range backendIdx {
+	return db.backendGetManyView(backendKeys, func(i int, _ []byte, value []byte, found bool) error {
+		if i < 0 || i >= len(backendIdx) {
+			return fmt.Errorf("cachingdb: backend GetManyView callback index %d out of range for %d keys", i, len(backendIdx))
+		}
+		uniqueIdx := backendIdx[i]
 		groupEnd := len(refs)
 		if uniqueIdx+1 < len(groupStarts) {
 			groupEnd = groupStarts[uniqueIdx+1]
 		}
-		if err := visitGetManyValueRefs(refs[groupStarts[uniqueIdx]:groupEnd], backendVals[i], backendVals[i] != nil, fn); err != nil {
-			return err
-		}
-	}
-	return nil
+		return visitGetManyValueRefs(refs[groupStarts[uniqueIdx]:groupEnd], value, found, fn)
+	})
 }
 
 func (db *DB) getMemtable(key []byte) ([]byte, bool, error) {
@@ -24924,19 +24918,7 @@ func (db *DB) GetManyView(keys [][]byte, fn tree.GetManyViewFunc) error {
 			db.releaseMemtableView(view)
 			view = nil
 		}
-		backendVals, err := db.backendGetMany(keys)
-		if err != nil {
-			return err
-		}
-		if len(backendVals) != len(keys) {
-			return fmt.Errorf("cachingdb: backend GetMany returned %d values for %d keys", len(backendVals), len(keys))
-		}
-		for i, val := range backendVals {
-			if err := fn(i, keys[i], val, val != nil); err != nil {
-				return err
-			}
-		}
-		return nil
+		return db.backendGetManyView(keys, fn)
 	}
 	if view != nil {
 		defer db.releaseMemtableView(view)
@@ -24978,19 +24960,12 @@ func (db *DB) GetManyView(keys [][]byte, fn tree.GetManyViewFunc) error {
 	if len(backendKeys) == 0 {
 		return nil
 	}
-	backendVals, err := db.backendGetMany(backendKeys)
-	if err != nil {
-		return err
-	}
-	if len(backendVals) != len(backendKeys) {
-		return fmt.Errorf("cachingdb: backend GetMany returned %d values for %d keys", len(backendVals), len(backendKeys))
-	}
-	for i, outIdx := range backendIdx {
-		if err := fn(outIdx, backendKeys[i], backendVals[i], backendVals[i] != nil); err != nil {
-			return err
+	return db.backendGetManyView(backendKeys, func(i int, key []byte, value []byte, found bool) error {
+		if i < 0 || i >= len(backendIdx) {
+			return fmt.Errorf("cachingdb: backend GetManyView callback index %d out of range for %d keys", i, len(backendIdx))
 		}
-	}
-	return nil
+		return fn(backendIdx[i], key, value, found)
+	})
 }
 
 // GetAppend appends the value for the key to dst and returns the new slice.

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -24510,17 +24510,23 @@ func (db *DB) getManyViewFromPublishedRootPointShards(view *memtableView, keys [
 		return nil
 	}
 	db.noteRootDomainGetManyBackendFallback(len(backendKeys))
-	return db.backendGetManyView(backendKeys, func(i int, _ []byte, val []byte, found bool) error {
-		if i < 0 || i >= len(backendIdx) {
-			return fmt.Errorf("cachingdb: backend GetManyView callback index %d out of range for %d keys", i, len(backendIdx))
-		}
-		uniqueIdx := backendIdx[i]
+	backendVals, err := db.backendGetMany(backendKeys)
+	if err != nil {
+		return err
+	}
+	if len(backendVals) != len(backendKeys) {
+		return fmt.Errorf("cachingdb: backend GetMany returned %d values for %d keys", len(backendVals), len(backendKeys))
+	}
+	for i, uniqueIdx := range backendIdx {
 		groupEnd := len(refs)
 		if uniqueIdx+1 < len(groupStarts) {
 			groupEnd = groupStarts[uniqueIdx+1]
 		}
-		return visitGetManyValueRefs(refs[groupStarts[uniqueIdx]:groupEnd], val, found, fn)
-	})
+		if err := visitGetManyValueRefs(refs[groupStarts[uniqueIdx]:groupEnd], backendVals[i], backendVals[i] != nil, fn); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (db *DB) getMemtable(key []byte) ([]byte, bool, error) {
@@ -24869,8 +24875,7 @@ func (db *DB) GetMany(keys [][]byte) ([][]byte, error) {
 }
 
 // GetManyView calls fn once for each key with a read-only value view. The
-// callback may be invoked in any order and may be invoked concurrently when
-// backend fallback reads are parallelized. The value is valid only until fn
+// callback may be invoked in any order. The value is valid only until fn
 // returns; callers must copy values they retain. Missing keys are reported with
 // found=false and value=nil.
 func (db *DB) GetManyView(keys [][]byte, fn tree.GetManyViewFunc) error {
@@ -24889,7 +24894,19 @@ func (db *DB) GetManyView(keys [][]byte, fn tree.GetManyViewFunc) error {
 			db.releaseMemtableView(view)
 			view = nil
 		}
-		return db.backendGetManyView(keys, fn)
+		backendVals, err := db.backendGetMany(keys)
+		if err != nil {
+			return err
+		}
+		if len(backendVals) != len(keys) {
+			return fmt.Errorf("cachingdb: backend GetMany returned %d values for %d keys", len(backendVals), len(keys))
+		}
+		for i, val := range backendVals {
+			if err := fn(i, keys[i], val, val != nil); err != nil {
+				return err
+			}
+		}
+		return nil
 	}
 	if view != nil {
 		defer db.releaseMemtableView(view)
@@ -24931,12 +24948,19 @@ func (db *DB) GetManyView(keys [][]byte, fn tree.GetManyViewFunc) error {
 	if len(backendKeys) == 0 {
 		return nil
 	}
-	return db.backendGetManyView(backendKeys, func(i int, key []byte, val []byte, found bool) error {
-		if i < 0 || i >= len(backendIdx) {
-			return fmt.Errorf("cachingdb: backend GetManyView callback index %d out of range for %d keys", i, len(backendIdx))
+	backendVals, err := db.backendGetMany(backendKeys)
+	if err != nil {
+		return err
+	}
+	if len(backendVals) != len(backendKeys) {
+		return fmt.Errorf("cachingdb: backend GetMany returned %d values for %d keys", len(backendVals), len(backendKeys))
+	}
+	for i, outIdx := range backendIdx {
+		if err := fn(outIdx, backendKeys[i], backendVals[i], backendVals[i] != nil); err != nil {
+			return err
 		}
-		return fn(backendIdx[i], key, val, found)
-	})
+	}
+	return nil
 }
 
 // GetAppend appends the value for the key to dst and returns the new slice.

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -24510,17 +24510,23 @@ func (db *DB) getManyViewFromPublishedRootPointShards(view *memtableView, keys [
 		return nil
 	}
 	db.noteRootDomainGetManyBackendFallback(len(backendKeys))
-	return db.backendGetManyView(backendKeys, func(backendOutIdx int, key []byte, val []byte, found bool) error {
-		if backendOutIdx < 0 || backendOutIdx >= len(backendIdx) {
-			return fmt.Errorf("cachingdb: backend GetManyView callback index %d outside %d keys", backendOutIdx, len(backendIdx))
-		}
-		uniqueIdx := backendIdx[backendOutIdx]
+	backendVals, err := db.backendGetMany(backendKeys)
+	if err != nil {
+		return err
+	}
+	if len(backendVals) != len(backendKeys) {
+		return fmt.Errorf("cachingdb: backend GetMany returned %d values for %d keys", len(backendVals), len(backendKeys))
+	}
+	for i, uniqueIdx := range backendIdx {
 		groupEnd := len(refs)
 		if uniqueIdx+1 < len(groupStarts) {
 			groupEnd = groupStarts[uniqueIdx+1]
 		}
-		return visitGetManyValueRefs(refs[groupStarts[uniqueIdx]:groupEnd], val, found, fn)
-	})
+		if err := visitGetManyValueRefs(refs[groupStarts[uniqueIdx]:groupEnd], backendVals[i], backendVals[i] != nil, fn); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (db *DB) getMemtable(key []byte) ([]byte, bool, error) {
@@ -24887,7 +24893,19 @@ func (db *DB) GetManyView(keys [][]byte, fn tree.GetManyViewFunc) error {
 			db.releaseMemtableView(view)
 			view = nil
 		}
-		return db.backendGetManyView(keys, fn)
+		backendVals, err := db.backendGetMany(keys)
+		if err != nil {
+			return err
+		}
+		if len(backendVals) != len(keys) {
+			return fmt.Errorf("cachingdb: backend GetMany returned %d values for %d keys", len(backendVals), len(keys))
+		}
+		for i, val := range backendVals {
+			if err := fn(i, keys[i], val, val != nil); err != nil {
+				return err
+			}
+		}
+		return nil
 	}
 	if view != nil {
 		defer db.releaseMemtableView(view)
@@ -24929,12 +24947,19 @@ func (db *DB) GetManyView(keys [][]byte, fn tree.GetManyViewFunc) error {
 	if len(backendKeys) == 0 {
 		return nil
 	}
-	return db.backendGetManyView(backendKeys, func(backendOutIdx int, key []byte, val []byte, found bool) error {
-		if backendOutIdx < 0 || backendOutIdx >= len(backendIdx) {
-			return fmt.Errorf("cachingdb: backend GetManyView callback index %d outside %d keys", backendOutIdx, len(backendIdx))
+	backendVals, err := db.backendGetMany(backendKeys)
+	if err != nil {
+		return err
+	}
+	if len(backendVals) != len(backendKeys) {
+		return fmt.Errorf("cachingdb: backend GetMany returned %d values for %d keys", len(backendVals), len(backendKeys))
+	}
+	for i, outIdx := range backendIdx {
+		if err := fn(outIdx, backendKeys[i], backendVals[i], backendVals[i] != nil); err != nil {
+			return err
 		}
-		return fn(backendIdx[backendOutIdx], key, val, found)
-	})
+	}
+	return nil
 }
 
 // GetAppend appends the value for the key to dst and returns the new slice.

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -24510,23 +24510,17 @@ func (db *DB) getManyViewFromPublishedRootPointShards(view *memtableView, keys [
 		return nil
 	}
 	db.noteRootDomainGetManyBackendFallback(len(backendKeys))
-	backendVals, err := db.backendGetMany(backendKeys)
-	if err != nil {
-		return err
-	}
-	if len(backendVals) != len(backendKeys) {
-		return fmt.Errorf("cachingdb: backend GetMany returned %d values for %d keys", len(backendVals), len(backendKeys))
-	}
-	for i, uniqueIdx := range backendIdx {
+	return db.backendGetManyView(backendKeys, func(i int, _ []byte, val []byte, found bool) error {
+		if i < 0 || i >= len(backendIdx) {
+			return fmt.Errorf("cachingdb: backend GetManyView callback index %d out of range for %d keys", i, len(backendIdx))
+		}
+		uniqueIdx := backendIdx[i]
 		groupEnd := len(refs)
 		if uniqueIdx+1 < len(groupStarts) {
 			groupEnd = groupStarts[uniqueIdx+1]
 		}
-		if err := visitGetManyValueRefs(refs[groupStarts[uniqueIdx]:groupEnd], backendVals[i], backendVals[i] != nil, fn); err != nil {
-			return err
-		}
-	}
-	return nil
+		return visitGetManyValueRefs(refs[groupStarts[uniqueIdx]:groupEnd], val, found, fn)
+	})
 }
 
 func (db *DB) getMemtable(key []byte) ([]byte, bool, error) {
@@ -24893,19 +24887,7 @@ func (db *DB) GetManyView(keys [][]byte, fn tree.GetManyViewFunc) error {
 			db.releaseMemtableView(view)
 			view = nil
 		}
-		backendVals, err := db.backendGetMany(keys)
-		if err != nil {
-			return err
-		}
-		if len(backendVals) != len(keys) {
-			return fmt.Errorf("cachingdb: backend GetMany returned %d values for %d keys", len(backendVals), len(keys))
-		}
-		for i, val := range backendVals {
-			if err := fn(i, keys[i], val, val != nil); err != nil {
-				return err
-			}
-		}
-		return nil
+		return db.backendGetManyView(keys, fn)
 	}
 	if view != nil {
 		defer db.releaseMemtableView(view)
@@ -24947,19 +24929,12 @@ func (db *DB) GetManyView(keys [][]byte, fn tree.GetManyViewFunc) error {
 	if len(backendKeys) == 0 {
 		return nil
 	}
-	backendVals, err := db.backendGetMany(backendKeys)
-	if err != nil {
-		return err
-	}
-	if len(backendVals) != len(backendKeys) {
-		return fmt.Errorf("cachingdb: backend GetMany returned %d values for %d keys", len(backendVals), len(backendKeys))
-	}
-	for i, outIdx := range backendIdx {
-		if err := fn(outIdx, backendKeys[i], backendVals[i], backendVals[i] != nil); err != nil {
-			return err
+	return db.backendGetManyView(backendKeys, func(i int, key []byte, val []byte, found bool) error {
+		if i < 0 || i >= len(backendIdx) {
+			return fmt.Errorf("cachingdb: backend GetManyView callback index %d out of range for %d keys", i, len(backendIdx))
 		}
-	}
-	return nil
+		return fn(backendIdx[i], key, val, found)
+	})
 }
 
 // GetAppend appends the value for the key to dst and returns the new slice.

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -24869,8 +24869,10 @@ func (db *DB) GetMany(keys [][]byte) ([][]byte, error) {
 }
 
 // GetManyView calls fn once for each key with a read-only value view. The
-// value is valid only until fn returns; callers must copy values they retain.
-// Missing keys are reported with found=false and value=nil.
+// callback may be invoked in any order and may be invoked concurrently when
+// backend fallback reads are parallelized. The value is valid only until fn
+// returns; callers must copy values they retain. Missing keys are reported with
+// found=false and value=nil.
 func (db *DB) GetManyView(keys [][]byte, fn tree.GetManyViewFunc) error {
 	if fn == nil {
 		return errors.New("cachingdb: GetManyView nil callback")

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -24899,7 +24899,8 @@ func (db *DB) GetMany(keys [][]byte) ([][]byte, error) {
 }
 
 // GetManyView calls fn once for each key with a read-only value view. The
-// callback may be invoked in any order. The value is valid only until fn
+// callback may be invoked in any order and may be invoked concurrently when
+// backend fallback reads are parallelized. The value is valid only until fn
 // returns; callers must copy values they retain. Missing keys are reported with
 // found=false and value=nil.
 func (db *DB) GetManyView(keys [][]byte, fn tree.GetManyViewFunc) error {

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -3805,6 +3805,21 @@ func (db *DB) readValueLog(key []byte, ptr page.ValuePtr) ([]byte, error) {
 	return db.valueLogReader.Read(ptr)
 }
 
+func (db *DB) readValueLogUnsafe(key []byte, ptr page.ValuePtr) ([]byte, error) {
+	if db.valueLogReader == nil {
+		return nil, errors.New("cachingdb: value-log reader unavailable")
+	}
+	if !page.IsValueLogFileID(ptr.FileID) {
+		return nil, fmt.Errorf("cachingdb: non value-log pointer %#x", ptr.FileID)
+	}
+	if db.valueLogEnabled() {
+		if err := db.flushValueLogForPtr(ptr); err != nil {
+			return nil, err
+		}
+	}
+	return db.valueLogReader.ReadUnsafe(ptr)
+}
+
 func (db *DB) readValueLogAppend(key []byte, ptr page.ValuePtr, dst []byte) ([]byte, error) {
 	if db.valueLogReader == nil {
 		return nil, errors.New("cachingdb: value-log reader unavailable")
@@ -24278,6 +24293,21 @@ func copyGetManyValueToRefs(out [][]byte, refs []getManyProbeRef, val []byte, ar
 	}
 }
 
+func visitGetManyValueRefs(refs []getManyProbeRef, val []byte, found bool, fn tree.GetManyViewFunc) error {
+	if found && len(val) == 0 {
+		val = rootDomainGetManyEmptyValue
+	}
+	if !found {
+		val = nil
+	}
+	for _, ref := range refs {
+		if err := fn(ref.idx, ref.key, val, found); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (db *DB) getManyFromPublishedRootPointShards(view *memtableView, keys [][]byte) ([][]byte, error) {
 	out := make([][]byte, len(keys))
 	if view == nil || len(view.rootPointShards) == 0 {
@@ -24383,6 +24413,114 @@ func (db *DB) getManyFromPublishedRootPointShards(view *memtableView, keys [][]b
 		}
 	}
 	return out, nil
+}
+
+func (db *DB) getManyViewFromPublishedRootPointShards(view *memtableView, keys [][]byte, fn tree.GetManyViewFunc) error {
+	if fn == nil {
+		return errors.New("cachingdb: GetManyView nil callback")
+	}
+	if view == nil || len(view.rootPointShards) == 0 {
+		for i, key := range keys {
+			if err := fn(i, key, nil, false); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	refs := make([]getManyProbeRef, len(keys))
+	for i, key := range keys {
+		shard := 0
+		if len(view.rootPointShards) > 1 {
+			shard = db.shardIndex(key)
+		}
+		refs[i] = getManyProbeRef{key: key, idx: i, shard: shard}
+	}
+	sort.Slice(refs, func(i, j int) bool {
+		if refs[i].shard != refs[j].shard {
+			return refs[i].shard < refs[j].shard
+		}
+		return bytes.Compare(refs[i].key, refs[j].key) < 0
+	})
+
+	unique := make([]getManyProbeRef, 0, len(refs))
+	groupStarts := make([]int, 0, len(refs))
+	for i, ref := range refs {
+		if len(unique) == 0 || ref.shard != unique[len(unique)-1].shard || !bytes.Equal(ref.key, unique[len(unique)-1].key) {
+			unique = append(unique, ref)
+			groupStarts = append(groupStarts, i)
+		}
+	}
+	db.noteRootDomainGetManyNative(len(keys), len(unique))
+
+	results := make([]rootDomainProbeResult, len(unique))
+	start := 0
+	for start < len(unique) {
+		end := start + 1
+		shard := unique[start].shard
+		for end < len(unique) && unique[end].shard == shard {
+			end++
+		}
+		if shard >= 0 && shard < len(view.rootPointShards) {
+			if err := view.rootPointShards[shard].getManySortedRefs(unique[start:end], results[start:end]); err != nil {
+				return err
+			}
+		}
+		start = end
+	}
+
+	backendIdx := make([]int, 0, len(unique))
+	backendKeys := make([][]byte, 0, len(unique))
+	for i, res := range results {
+		groupEnd := len(refs)
+		if i+1 < len(groupStarts) {
+			groupEnd = groupStarts[i+1]
+		}
+		groupRefs := refs[groupStarts[i]:groupEnd]
+		switch {
+		case !res.found:
+			backendIdx = append(backendIdx, i)
+			backendKeys = append(backendKeys, unique[i].key)
+		case res.flags&node.FlagTombstone != 0:
+			if err := visitGetManyValueRefs(groupRefs, nil, false, fn); err != nil {
+				return err
+			}
+		case res.flags&node.FlagPointer != 0:
+			val := res.val
+			if val == nil {
+				var err error
+				val, err = db.readValueLogUnsafe(unique[i].key, res.ptr)
+				if err != nil {
+					return err
+				}
+			}
+			if err := visitGetManyValueRefs(groupRefs, val, true, fn); err != nil {
+				return err
+			}
+		case res.val == nil:
+			if err := visitGetManyValueRefs(groupRefs, rootDomainGetManyEmptyValue, true, fn); err != nil {
+				return err
+			}
+		default:
+			if err := visitGetManyValueRefs(groupRefs, res.val, true, fn); err != nil {
+				return err
+			}
+		}
+	}
+	if len(backendKeys) == 0 {
+		return nil
+	}
+	db.noteRootDomainGetManyBackendFallback(len(backendKeys))
+	return db.backendGetManyView(backendKeys, func(backendOutIdx int, key []byte, val []byte, found bool) error {
+		if backendOutIdx < 0 || backendOutIdx >= len(backendIdx) {
+			return fmt.Errorf("cachingdb: backend GetManyView callback index %d outside %d keys", backendOutIdx, len(backendIdx))
+		}
+		uniqueIdx := backendIdx[backendOutIdx]
+		groupEnd := len(refs)
+		if uniqueIdx+1 < len(groupStarts) {
+			groupEnd = groupStarts[uniqueIdx+1]
+		}
+		return visitGetManyValueRefs(refs[groupStarts[uniqueIdx]:groupEnd], val, found, fn)
+	})
 }
 
 func (db *DB) getMemtable(key []byte) ([]byte, bool, error) {
@@ -24499,6 +24637,10 @@ type backendManyGetter interface {
 	GetMany(keys [][]byte) ([][]byte, error)
 }
 
+type backendManyViewer interface {
+	GetManyView(keys [][]byte, fn tree.GetManyViewFunc) error
+}
+
 type backendManyPlanner interface {
 	GetManyParallelPlan(keyCount int) (workers int, parallel bool)
 }
@@ -24541,6 +24683,35 @@ func (db *DB) backendGetMany(keys [][]byte) ([][]byte, error) {
 		out[i] = val
 	}
 	return out, nil
+}
+
+func (db *DB) backendGetManyView(keys [][]byte, fn tree.GetManyViewFunc) error {
+	if fn == nil {
+		return errors.New("cachingdb: GetManyView nil callback")
+	}
+	if err := db.flushValueLogForBackendRead(); err != nil {
+		return err
+	}
+	if viewer, ok := db.backend.(backendManyViewer); ok {
+		return viewer.GetManyView(keys, fn)
+	}
+	vals, err := db.backendGetMany(keys)
+	if err != nil {
+		return err
+	}
+	if len(vals) != len(keys) {
+		return fmt.Errorf("cachingdb: backend GetMany returned %d values for %d keys", len(vals), len(keys))
+	}
+	for i, val := range vals {
+		found := val != nil
+		if found && len(val) == 0 {
+			val = rootDomainGetManyEmptyValue
+		}
+		if err := fn(i, keys[i], val, found); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // GetUnsafe returns a safe copy of the value.
@@ -24695,6 +24866,75 @@ func (db *DB) GetMany(keys [][]byte) ([][]byte, error) {
 		out[outIdx] = backendVals[i]
 	}
 	return out, nil
+}
+
+// GetManyView calls fn once for each key with a read-only value view. The
+// value is valid only until fn returns; callers must copy values they retain.
+// Missing keys are reported with found=false and value=nil.
+func (db *DB) GetManyView(keys [][]byte, fn tree.GetManyViewFunc) error {
+	if fn == nil {
+		return errors.New("cachingdb: GetManyView nil callback")
+	}
+	if len(keys) == 0 {
+		return nil
+	}
+	db.noteRead()
+
+	view := db.retainMemtableView()
+	bypass := db.canBypassMemtableReadMany(view, keys)
+	if bypass {
+		if view != nil {
+			db.releaseMemtableView(view)
+			view = nil
+		}
+		return db.backendGetManyView(keys, fn)
+	}
+	if view != nil {
+		defer db.releaseMemtableView(view)
+	}
+	if view != nil && len(view.rootPointShards) > 0 {
+		return db.getManyViewFromPublishedRootPointShards(view, keys, fn)
+	}
+	db.noteRootDomainGetManyFallback(len(keys))
+
+	backendIdx := make([]int, 0, len(keys))
+	backendKeys := make([][]byte, 0, len(keys))
+	arena := make([]byte, 0, min(len(keys)*128, 1<<20))
+	for i, key := range keys {
+		start := len(arena)
+		nextArena, found, err := db.getMemtableAppend(key, arena)
+		if err != nil {
+			if err == tree.ErrKeyNotFound && found {
+				if err := fn(i, key, nil, false); err != nil {
+					return err
+				}
+				continue
+			}
+			return err
+		}
+		if found {
+			arena = nextArena
+			val := arena[start:len(arena):len(arena)]
+			if len(val) == 0 {
+				val = rootDomainGetManyEmptyValue
+			}
+			if err := fn(i, key, val, true); err != nil {
+				return err
+			}
+			continue
+		}
+		backendIdx = append(backendIdx, i)
+		backendKeys = append(backendKeys, key)
+	}
+	if len(backendKeys) == 0 {
+		return nil
+	}
+	return db.backendGetManyView(backendKeys, func(backendOutIdx int, key []byte, val []byte, found bool) error {
+		if backendOutIdx < 0 || backendOutIdx >= len(backendIdx) {
+			return fmt.Errorf("cachingdb: backend GetManyView callback index %d outside %d keys", backendOutIdx, len(backendIdx))
+		}
+		return fn(backendIdx[backendOutIdx], key, val, found)
+	})
 }
 
 // GetAppend appends the value for the key to dst and returns the new slice.

--- a/TreeDB/caching/getmany_view_test.go
+++ b/TreeDB/caching/getmany_view_test.go
@@ -1,0 +1,167 @@
+package caching
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/batch"
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/internal/iterator"
+	"github.com/snissn/gomap/TreeDB/tree"
+)
+
+type getManyViewBackendStub struct {
+	values           map[string][]byte
+	getManyCalls     int
+	getManyViewCalls int
+	getCalls         int
+}
+
+func (b *getManyViewBackendStub) Get(key []byte) ([]byte, error) {
+	b.getCalls++
+	if val, ok := b.values[string(key)]; ok {
+		return val, nil
+	}
+	return nil, nil
+}
+
+func (b *getManyViewBackendStub) GetUnsafe(key []byte) ([]byte, error) { return b.Get(key) }
+
+func (b *getManyViewBackendStub) GetAppend(key, dst []byte) ([]byte, error) {
+	if val, ok := b.values[string(key)]; ok {
+		return append(dst, val...), nil
+	}
+	return dst, tree.ErrKeyNotFound
+}
+
+func (b *getManyViewBackendStub) GetMany(keys [][]byte) ([][]byte, error) {
+	b.getManyCalls++
+	return nil, errors.New("backend GetMany should not be used by cached GetManyView")
+}
+
+func (b *getManyViewBackendStub) GetManyView(keys [][]byte, fn tree.GetManyViewFunc) error {
+	b.getManyViewCalls++
+	for i, key := range keys {
+		val, found := b.values[string(key)]
+		if err := fn(i, key, val, found); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (b *getManyViewBackendStub) Has(key []byte) (bool, error) {
+	_, ok := b.values[string(key)]
+	return ok, nil
+}
+
+func (b *getManyViewBackendStub) Iterator(start, end []byte) (iterator.UnsafeIterator, error) {
+	return nil, backenddb.ErrClosed
+}
+
+func (b *getManyViewBackendStub) ReverseIterator(start, end []byte) (iterator.UnsafeIterator, error) {
+	return nil, backenddb.ErrClosed
+}
+
+func (b *getManyViewBackendStub) NewBatch() batch.Interface { return nil }
+func (b *getManyViewBackendStub) Close() error              { return nil }
+func (b *getManyViewBackendStub) Print() error              { return nil }
+func (b *getManyViewBackendStub) Stats() map[string]string  { return nil }
+
+func collectGetManyViewResults(t *testing.T, keys [][]byte, call func(tree.GetManyViewFunc) error) (seen []int, found []bool, values [][]byte) {
+	t.Helper()
+	seen = make([]int, len(keys))
+	found = make([]bool, len(keys))
+	values = make([][]byte, len(keys))
+	err := call(func(index int, key []byte, value []byte, ok bool) error {
+		if index < 0 || index >= len(keys) {
+			return fmt.Errorf("callback index %d outside %d keys", index, len(keys))
+		}
+		if !bytes.Equal(key, keys[index]) {
+			return fmt.Errorf("callback key[%d]=%q want %q", index, key, keys[index])
+		}
+		seen[index]++
+		found[index] = ok
+		if ok {
+			values[index] = append([]byte(nil), value...)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("GetManyView: %v", err)
+	}
+	return seen, found, values
+}
+
+func assertGetManyViewResults(t *testing.T, keys [][]byte, seen []int, found []bool, values [][]byte) {
+	t.Helper()
+	want := map[int][]byte{
+		0: []byte("value-a"),
+		1: []byte("value-b"),
+		2: []byte("value-a"),
+		4: []byte{},
+	}
+	for i := range keys {
+		if seen[i] != 1 {
+			t.Fatalf("callback count for index %d = %d, want 1", i, seen[i])
+		}
+		wantVal, wantFound := want[i]
+		if found[i] != wantFound {
+			t.Fatalf("found[%d]=%v want %v", i, found[i], wantFound)
+		}
+		if wantFound && !bytes.Equal(values[i], wantVal) {
+			t.Fatalf("value[%d]=%q want %q", i, values[i], wantVal)
+		}
+		if !wantFound && values[i] != nil {
+			t.Fatalf("missing value[%d]=%q want nil", i, values[i])
+		}
+	}
+}
+
+func TestGetManyViewBypassUsesBackendView(t *testing.T) {
+	backend := &getManyViewBackendStub{values: map[string][]byte{
+		"a":     []byte("value-a"),
+		"b":     []byte("value-b"),
+		"empty": []byte{},
+	}}
+	db := &DB{backend: backend}
+	view := &memtableView{}
+	view.refs.Store(1)
+	db.memtables.Store(view)
+
+	keys := [][]byte{[]byte("a"), []byte("b"), []byte("a"), []byte("missing"), []byte("empty")}
+	seen, found, values := collectGetManyViewResults(t, keys, func(fn tree.GetManyViewFunc) error {
+		return db.GetManyView(keys, fn)
+	})
+	assertGetManyViewResults(t, keys, seen, found, values)
+	if backend.getManyViewCalls != 1 {
+		t.Fatalf("backend GetManyView calls=%d want 1", backend.getManyViewCalls)
+	}
+	if backend.getManyCalls != 0 || backend.getCalls != 0 {
+		t.Fatalf("backend safe-copy reads used: GetMany=%d Get=%d", backend.getManyCalls, backend.getCalls)
+	}
+}
+
+func TestGetManyViewBackendFallbackUsesBackendView(t *testing.T) {
+	backend := &getManyViewBackendStub{values: map[string][]byte{
+		"a":     []byte("value-a"),
+		"b":     []byte("value-b"),
+		"empty": []byte{},
+	}}
+	db := &DB{backend: backend}
+	view := &memtableView{rootPointShards: []rootDomainSnapshot{{}}}
+
+	keys := [][]byte{[]byte("a"), []byte("b"), []byte("a"), []byte("missing"), []byte("empty")}
+	seen, found, values := collectGetManyViewResults(t, keys, func(fn tree.GetManyViewFunc) error {
+		return db.getManyViewFromPublishedRootPointShards(view, keys, fn)
+	})
+	assertGetManyViewResults(t, keys, seen, found, values)
+	if backend.getManyViewCalls != 1 {
+		t.Fatalf("backend GetManyView calls=%d want 1", backend.getManyViewCalls)
+	}
+	if backend.getManyCalls != 0 || backend.getCalls != 0 {
+		t.Fatalf("backend safe-copy reads used: GetMany=%d Get=%d", backend.getManyCalls, backend.getCalls)
+	}
+}

--- a/TreeDB/caching/snapshot.go
+++ b/TreeDB/caching/snapshot.go
@@ -752,6 +752,39 @@ func (s *Snapshot) GetUnsafe(key []byte) ([]byte, error) {
 	return s.backend.GetUnsafe(key)
 }
 
+// GetManyView calls fn once for each key with a read-only value view. Values
+// are valid only until fn returns and must be copied before retaining.
+func (s *Snapshot) GetManyView(keys [][]byte, fn tree.GetManyViewFunc) error {
+	if fn == nil {
+		return errors.New("caching snapshot: GetManyView nil callback")
+	}
+	if len(keys) == 0 {
+		return nil
+	}
+	if s == nil || s.closed.Load() || s.backend == nil {
+		return backenddb.ErrClosed
+	}
+	for i, key := range keys {
+		val, err := s.GetUnsafe(key)
+		if err == tree.ErrKeyNotFound {
+			if err := fn(i, key, nil, false); err != nil {
+				return err
+			}
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		if len(val) == 0 {
+			val = rootDomainGetManyEmptyValue
+		}
+		if err := fn(i, key, val, true); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (s *Snapshot) Has(key []byte) (bool, error) {
 	_, _, flags, found := s.lookupCachedRootDomainEntry(key)
 	if found {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -19667,6 +19667,62 @@ func collectionGetAppendAtCatalogRoot(snap *backenddb.Snapshot, catalog *collect
 	return out, true, nil
 }
 
+func collectionGetManyViewAtCatalogRoot(snap *backenddb.Snapshot, catalog *collectionCatalog, rootName string, keys [][]byte, fn backenddb.GetManyViewFunc) error {
+	if fn == nil {
+		return errors.New("collections: GetManyView nil callback")
+	}
+	if snap == nil {
+		return backenddb.ErrClosed
+	}
+	if len(keys) == 0 {
+		return nil
+	}
+	if len(catalog.overlayRootIDs(rootName)) == 0 {
+		rootID := catalog.rootID(rootName)
+		if rootID == 0 {
+			for i, key := range keys {
+				if err := fn(i, key, nil, false); err != nil {
+					return err
+				}
+			}
+			return nil
+		}
+		err := snap.GetManyViewAtRoot(rootID, keys, fn)
+		if errors.Is(err, tree.ErrKeyNotFound) {
+			for i, key := range keys {
+				if err := fn(i, key, nil, false); err != nil {
+					return err
+				}
+			}
+			return nil
+		}
+		return err
+	}
+
+	var scratch []byte
+	for i, key := range keys {
+		value, found, err := collectionGetAppendAtCatalogRoot(snap, catalog, rootName, key, scratch[:0])
+		if err != nil {
+			return err
+		}
+		if !found {
+			if err := fn(i, key, nil, false); err != nil {
+				return err
+			}
+			continue
+		}
+		if err := fn(i, key, value, true); err != nil {
+			return err
+		}
+		if cap(value) <= 64<<10 {
+			scratch = value[:0]
+		} else {
+			scratch = nil
+		}
+	}
+	return nil
+}
+
 func collectionGetAppendAtCatalogOverlayRoot(snap *backenddb.Snapshot, catalog *collectionCatalog, rootName string, key, dst []byte) ([]byte, bool, bool, error) {
 	if snap == nil {
 		return dst[:0], false, false, backenddb.ErrClosed

--- a/TreeDB/collections/document_materializer.go
+++ b/TreeDB/collections/document_materializer.go
@@ -862,7 +862,7 @@ func (v *CollectionReadView) fetchRetainedPayloadsByID(ids [][]byte) (DocumentFe
 	}
 
 	foundCount := 0
-	retainedArena := make([]byte, 0, min(len(ids)*128, 1<<20))
+	var retainedArena []byte
 	err := collectionGetManyViewAtCatalogRoot(v.snapshot, v.catalog, collectionPrimaryRootName(v.catalog.meta.Name), ids, func(i int, _ []byte, value []byte, found bool) error {
 		if i < 0 || i >= len(ids) {
 			return fmt.Errorf("collections: GetManyView callback index %d outside %d ids", i, len(ids))

--- a/TreeDB/collections/document_materializer.go
+++ b/TreeDB/collections/document_materializer.go
@@ -828,8 +828,12 @@ func (v *CollectionReadView) fetchDocumentsByID(ids [][]byte, expected []*Docume
 				if err != nil {
 					return response, err
 				}
+				documentArena = appendDocumentFetchOwnedBytes(documentArena, document, &response.Results[i])
+			} else if len(document) == 0 {
+				response.Results[i].Document = []byte{}
+			} else {
+				response.Results[i].Document = document[:len(document):len(document)]
 			}
-			documentArena = appendDocumentFetchOwnedBytes(documentArena, document, &response.Results[i])
 			response.Stats.DocumentsFetched++
 			response.Stats.DocumentBytes += uint64(len(response.Results[i].Document))
 			response.Stats.OutputBytes += uint64(len(response.Results[i].Document))
@@ -848,28 +852,40 @@ func (v *CollectionReadView) fetchRetainedPayloadsByID(ids [][]byte) (DocumentFe
 	}
 	var idArena []byte
 	retained := make([][]byte, len(ids))
-	foundCount := 0
 	for i, id := range ids {
 		if len(id) == 0 {
-			return response, retained, foundCount, fmt.Errorf("collections: document id at position %d cannot be empty", i)
+			return response, retained, 0, fmt.Errorf("collections: document id at position %d cannot be empty", i)
 		}
 		idStart := len(idArena)
 		idArena = append(idArena, id...)
-		ownedID := idArena[idStart:len(idArena):len(idArena)]
-		response.Results[i].ID = ownedID
-		value, found, err := collectionGetAppendAtCatalogRoot(v.snapshot, v.catalog, collectionPrimaryRootName(v.catalog.meta.Name), id, nil)
-		if err != nil {
-			return response, retained, foundCount, err
+		response.Results[i].ID = idArena[idStart:len(idArena):len(idArena)]
+	}
+
+	foundCount := 0
+	retainedArena := make([]byte, 0, min(len(ids)*128, 1<<20))
+	err := collectionGetManyViewAtCatalogRoot(v.snapshot, v.catalog, collectionPrimaryRootName(v.catalog.meta.Name), ids, func(i int, _ []byte, value []byte, found bool) error {
+		if i < 0 || i >= len(ids) {
+			return fmt.Errorf("collections: GetManyView callback index %d outside %d ids", i, len(ids))
 		}
 		if !found {
 			response.Stats.DocumentsMissing++
-			continue
+			return nil
 		}
 		response.Results[i].Found = true
-		retained[i] = value
+		if len(value) == 0 {
+			retained[i] = []byte{}
+		} else {
+			start := len(retainedArena)
+			retainedArena = append(retainedArena, value...)
+			retained[i] = retainedArena[start:len(retainedArena):len(retainedArena)]
+		}
 		foundCount++
 		response.Stats.RetainedPayloadFetches++
 		response.Stats.RetainedPayloadBytes += uint64(len(value))
+		return nil
+	})
+	if err != nil {
+		return response, retained, foundCount, err
 	}
 	return response, retained, foundCount, nil
 }

--- a/TreeDB/collections/document_materializer_test.go
+++ b/TreeDB/collections/document_materializer_test.go
@@ -13,6 +13,64 @@ import (
 	"go.mongodb.org/mongo-driver/v2/bson"
 )
 
+func TestCollectionReadViewFetchDocumentsByIDUsesBatchViewForOwnedRetainedPayloads2242(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{
+		Dir: t.TempDir(),
+		ValueLog: backenddb.ValueLogOptions{
+			PointerThreshold: 1,
+			ForcePointers:    true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "docs", Options: CollectionOptions{DocumentFormat: DocumentFormatJSON}}); err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	col, err := mgr.OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("OpenCollection: %v", err)
+	}
+	docA := []byte(`{"kind":"alpha","payload":"` + strings.Repeat("a", 128) + `"}`)
+	docB := []byte(`{}`)
+	if _, err := col.InsertBatch([][]byte{[]byte("a"), []byte("b")}, [][]byte{docA, docB}); err != nil {
+		t.Fatalf("InsertBatch: %v", err)
+	}
+	view, err := col.OpenCollectionReadView()
+	if err != nil {
+		t.Fatalf("OpenCollectionReadView: %v", err)
+	}
+	got, err := view.FetchDocumentsByID([][]byte{[]byte("a"), []byte("missing"), []byte("b"), []byte("a")}, DocumentFetchOptions{})
+	if err != nil {
+		_ = view.Close()
+		t.Fatalf("FetchDocumentsByID: %v", err)
+	}
+	if err := view.Close(); err != nil {
+		t.Fatalf("Close view: %v", err)
+	}
+	if len(got.Results) != 4 {
+		t.Fatalf("results=%d want 4", len(got.Results))
+	}
+	if !got.Results[0].Found || !bytes.Equal(got.Results[0].Document, docA) || got.Results[1].Found || got.Results[1].Document != nil || !got.Results[2].Found || !bytes.Equal(got.Results[2].Document, docB) || !got.Results[3].Found || !bytes.Equal(got.Results[3].Document, docA) {
+		t.Fatalf("unexpected results: %+v", got.Results)
+	}
+	if got.Stats.DocumentsRequested != 4 || got.Stats.DocumentsFetched != 3 || got.Stats.DocumentsMissing != 1 || got.Stats.RetainedPayloadFetches != 3 {
+		t.Fatalf("stats=%+v want requested=4 fetched=3 missing=1 retained=3", got.Stats)
+	}
+	if len(got.Results[0].Document) > 0 {
+		got.Results[0].Document[0] = '['
+	}
+	fresh, err := col.Get([]byte("a"))
+	if err != nil {
+		t.Fatalf("Get after response mutation: %v", err)
+	}
+	if !bytes.Equal(fresh, docA) {
+		t.Fatalf("mutating response affected stored document: got=%s want=%s", fresh, docA)
+	}
+}
+
 func TestCollectionReadViewFetchDocumentsByIDColumnReconstructionParity(t *testing.T) {
 	d, col := newDocumentMaterializerTestCollection(t)
 	defer func() { _ = d.Close() }()

--- a/TreeDB/db/api.go
+++ b/TreeDB/db/api.go
@@ -24,10 +24,12 @@ const (
 
 var getManyEmptyValue = []byte{}
 
-// GetManyViewFunc receives one GetManyView result. The value slice is a
-// read-only view that is valid only until the callback returns; callers must
-// copy it before retaining it. Missing/tombstoned keys are reported with
-// found=false and value=nil.
+// GetManyViewFunc receives one GetManyView result. DB-level GetManyView may
+// invoke callbacks in any order and may invoke them concurrently for large
+// batches; callers that mutate shared state must synchronize it. The value
+// slice is a read-only view that is valid only until the callback returns;
+// callers must copy it before retaining it. Missing/tombstoned keys are
+// reported with found=false and value=nil.
 type GetManyViewFunc = tree.GetManyViewFunc
 
 func getManyArenaCap(keyCount int) int {
@@ -227,9 +229,10 @@ func (db *DB) getManyOnce(keys [][]byte) ([][]byte, error) {
 
 // GetManyView calls fn once for each key with a read-only value view.
 // Missing keys are reported with found=false and value=nil. Callback values are
-// valid only until fn returns and must be copied before retaining. If fn returns
-// an error, iteration stops and that error is returned; callbacks already
-// invoked are not retried.
+// valid only until fn returns and must be copied before retaining. Large batches
+// may invoke callbacks concurrently; callers that mutate shared state must
+// synchronize it. If fn returns an error, iteration stops best-effort and that
+// error is returned; callbacks already invoked are not retried.
 func (db *DB) GetManyView(keys [][]byte, fn GetManyViewFunc) error {
 	if fn == nil {
 		return errors.New("GetManyView: nil callback")
@@ -270,9 +273,26 @@ func (db *DB) getManyViewParallel(snap *Snapshot, keys [][]byte, fn GetManyViewF
 	var (
 		wg       sync.WaitGroup
 		stop     atomic.Bool
-		cbMu     sync.Mutex
+		errMu    sync.Mutex
 		firstErr error
 	)
+	setErr := func(err error) {
+		if err == nil {
+			return
+		}
+		errMu.Lock()
+		if firstErr == nil {
+			firstErr = err
+			stop.Store(true)
+		}
+		errMu.Unlock()
+	}
+	getErr := func() error {
+		errMu.Lock()
+		err := firstErr
+		errMu.Unlock()
+		return err
+	}
 	for worker := 0; worker < workers; worker++ {
 		start, end := getManyChunkBounds(worker, workers, len(keys))
 		if start >= end {
@@ -283,40 +303,19 @@ func (db *DB) getManyViewParallel(snap *Snapshot, keys [][]byte, fn GetManyViewF
 			defer wg.Done()
 			err := snap.tree.GetManyView(keys[start:end], func(index int, key []byte, value []byte, found bool) error {
 				if stop.Load() {
-					cbMu.Lock()
-					err := firstErr
-					cbMu.Unlock()
-					if err != nil {
-						return err
-					}
-					return nil
-				}
-				cbMu.Lock()
-				defer cbMu.Unlock()
-				if firstErr != nil {
-					return firstErr
+					return getErr()
 				}
 				err := fn(start+index, key, value, found)
 				if err != nil {
-					firstErr = err
-					stop.Store(true)
+					setErr(err)
 				}
 				return err
 			})
-			if err != nil {
-				cbMu.Lock()
-				if firstErr == nil {
-					firstErr = err
-					stop.Store(true)
-				}
-				cbMu.Unlock()
-			}
+			setErr(err)
 		}(start, end)
 	}
 	wg.Wait()
-	cbMu.Lock()
-	defer cbMu.Unlock()
-	return firstErr
+	return getErr()
 }
 
 func (db *DB) getManySequential(snap *Snapshot, keys [][]byte, out [][]byte) error {

--- a/TreeDB/db/api.go
+++ b/TreeDB/db/api.go
@@ -235,12 +235,12 @@ func (db *DB) GetManyView(keys [][]byte, fn GetManyViewFunc) error {
 		return errors.New("GetManyView: nil callback")
 	}
 	retryEpoch := db.readRetryRefreshEpoch.Load()
-	called := false
+	var called atomic.Bool
 	err := db.getManyViewOnce(keys, func(index int, key []byte, value []byte, found bool) error {
-		called = true
+		called.Store(true)
 		return fn(index, key, value, found)
 	})
-	if db.refreshOnValueLogFileNotFound(err) && !called {
+	if db.refreshOnValueLogFileNotFound(err) && !called.Load() {
 		if refreshErr := db.refreshValueLogSetForReadRetry(retryEpoch); refreshErr != nil {
 			return refreshErr
 		}
@@ -258,7 +258,65 @@ func (db *DB) getManyViewOnce(keys [][]byte, fn GetManyViewFunc) error {
 		return err
 	}
 	defer snap.Close()
+
+	workers := getManyWorkerCount(len(keys))
+	if getManyCanParallelize(len(keys), workers) {
+		return db.getManyViewParallel(snap, keys, fn, workers)
+	}
 	return snap.GetManyView(keys, fn)
+}
+
+func (db *DB) getManyViewParallel(snap *Snapshot, keys [][]byte, fn GetManyViewFunc, workers int) error {
+	var (
+		wg       sync.WaitGroup
+		stop     atomic.Bool
+		cbMu     sync.Mutex
+		firstErr error
+	)
+	for worker := 0; worker < workers; worker++ {
+		start, end := getManyChunkBounds(worker, workers, len(keys))
+		if start >= end {
+			continue
+		}
+		wg.Add(1)
+		go func(start, end int) {
+			defer wg.Done()
+			err := snap.tree.GetManyView(keys[start:end], func(index int, key []byte, value []byte, found bool) error {
+				if stop.Load() {
+					cbMu.Lock()
+					err := firstErr
+					cbMu.Unlock()
+					if err != nil {
+						return err
+					}
+					return nil
+				}
+				cbMu.Lock()
+				defer cbMu.Unlock()
+				if firstErr != nil {
+					return firstErr
+				}
+				err := fn(start+index, key, value, found)
+				if err != nil {
+					firstErr = err
+					stop.Store(true)
+				}
+				return err
+			})
+			if err != nil {
+				cbMu.Lock()
+				if firstErr == nil {
+					firstErr = err
+					stop.Store(true)
+				}
+				cbMu.Unlock()
+			}
+		}(start, end)
+	}
+	wg.Wait()
+	cbMu.Lock()
+	defer cbMu.Unlock()
+	return firstErr
 }
 
 func (db *DB) getManySequential(snap *Snapshot, keys [][]byte, out [][]byte) error {

--- a/TreeDB/db/api.go
+++ b/TreeDB/db/api.go
@@ -227,9 +227,10 @@ func (db *DB) getManyOnce(keys [][]byte) ([][]byte, error) {
 
 // GetManyView calls fn once for each key with a read-only value view.
 // Missing keys are reported with found=false and value=nil. Callback values are
-// valid only until fn returns and must be copied before retaining. If fn returns
-// an error, iteration stops and that error is returned; callbacks already
-// invoked are not retried.
+// valid only until fn returns and must be copied before retaining. Large batches
+// may invoke callbacks concurrently; callers that mutate shared state must
+// synchronize it. If fn returns an error, iteration stops best-effort and that
+// error is returned; callbacks already invoked are not retried.
 func (db *DB) GetManyView(keys [][]byte, fn GetManyViewFunc) error {
 	if fn == nil {
 		return errors.New("GetManyView: nil callback")
@@ -258,7 +259,61 @@ func (db *DB) getManyViewOnce(keys [][]byte, fn GetManyViewFunc) error {
 		return err
 	}
 	defer snap.Close()
+
+	workers := getManyWorkerCount(len(keys))
+	if getManyCanParallelize(len(keys), workers) {
+		return db.getManyViewParallel(snap, keys, fn, workers)
+	}
 	return snap.GetManyView(keys, fn)
+}
+
+func (db *DB) getManyViewParallel(snap *Snapshot, keys [][]byte, fn GetManyViewFunc, workers int) error {
+	var (
+		wg       sync.WaitGroup
+		stop     atomic.Bool
+		errMu    sync.Mutex
+		firstErr error
+	)
+	setErr := func(err error) {
+		if err == nil {
+			return
+		}
+		errMu.Lock()
+		if firstErr == nil {
+			firstErr = err
+			stop.Store(true)
+		}
+		errMu.Unlock()
+	}
+	getErr := func() error {
+		errMu.Lock()
+		err := firstErr
+		errMu.Unlock()
+		return err
+	}
+	for worker := 0; worker < workers; worker++ {
+		start, end := getManyChunkBounds(worker, workers, len(keys))
+		if start >= end {
+			continue
+		}
+		wg.Add(1)
+		go func(start, end int) {
+			defer wg.Done()
+			err := snap.tree.GetManyView(keys[start:end], func(index int, key []byte, value []byte, found bool) error {
+				if stop.Load() {
+					return getErr()
+				}
+				err := fn(start+index, key, value, found)
+				if err != nil {
+					setErr(err)
+				}
+				return err
+			})
+			setErr(err)
+		}(start, end)
+	}
+	wg.Wait()
+	return getErr()
 }
 
 func (db *DB) getManySequential(snap *Snapshot, keys [][]byte, out [][]byte) error {

--- a/TreeDB/db/api.go
+++ b/TreeDB/db/api.go
@@ -24,6 +24,12 @@ const (
 
 var getManyEmptyValue = []byte{}
 
+// GetManyViewFunc receives one GetManyView result. The value slice is a
+// read-only view that is valid only until the callback returns; callers must
+// copy it before retaining it. Missing/tombstoned keys are reported with
+// found=false and value=nil.
+type GetManyViewFunc = tree.GetManyViewFunc
+
 func getManyArenaCap(keyCount int) int {
 	if keyCount <= 0 {
 		return 0
@@ -217,6 +223,42 @@ func (db *DB) getManyOnce(keys [][]byte) ([][]byte, error) {
 		return nil, err
 	}
 	return out, nil
+}
+
+// GetManyView calls fn once for each key with a read-only value view.
+// Missing keys are reported with found=false and value=nil. Callback values are
+// valid only until fn returns and must be copied before retaining. If fn returns
+// an error, iteration stops and that error is returned; callbacks already
+// invoked are not retried.
+func (db *DB) GetManyView(keys [][]byte, fn GetManyViewFunc) error {
+	if fn == nil {
+		return errors.New("GetManyView: nil callback")
+	}
+	retryEpoch := db.readRetryRefreshEpoch.Load()
+	called := false
+	err := db.getManyViewOnce(keys, func(index int, key []byte, value []byte, found bool) error {
+		called = true
+		return fn(index, key, value, found)
+	})
+	if db.refreshOnValueLogFileNotFound(err) && !called {
+		if refreshErr := db.refreshValueLogSetForReadRetry(retryEpoch); refreshErr != nil {
+			return refreshErr
+		}
+		return db.getManyViewOnce(keys, fn)
+	}
+	return err
+}
+
+func (db *DB) getManyViewOnce(keys [][]byte, fn GetManyViewFunc) error {
+	if len(keys) == 0 {
+		return nil
+	}
+	snap, err := db.acquireSnapshotOrErr()
+	if err != nil {
+		return err
+	}
+	defer snap.Close()
+	return snap.GetManyView(keys, fn)
 }
 
 func (db *DB) getManySequential(snap *Snapshot, keys [][]byte, out [][]byte) error {

--- a/TreeDB/db/api.go
+++ b/TreeDB/db/api.go
@@ -24,12 +24,10 @@ const (
 
 var getManyEmptyValue = []byte{}
 
-// GetManyViewFunc receives one GetManyView result. DB-level GetManyView may
-// invoke callbacks in any order and may invoke them concurrently for large
-// batches; callers that mutate shared state must synchronize it. The value
-// slice is a read-only view that is valid only until the callback returns;
-// callers must copy it before retaining it. Missing/tombstoned keys are
-// reported with found=false and value=nil.
+// GetManyViewFunc receives one GetManyView result. The value slice is a
+// read-only view that is valid only until the callback returns; callers must
+// copy it before retaining it. Missing/tombstoned keys are reported with
+// found=false and value=nil.
 type GetManyViewFunc = tree.GetManyViewFunc
 
 func getManyArenaCap(keyCount int) int {
@@ -229,10 +227,9 @@ func (db *DB) getManyOnce(keys [][]byte) ([][]byte, error) {
 
 // GetManyView calls fn once for each key with a read-only value view.
 // Missing keys are reported with found=false and value=nil. Callback values are
-// valid only until fn returns and must be copied before retaining. Large batches
-// may invoke callbacks concurrently; callers that mutate shared state must
-// synchronize it. If fn returns an error, iteration stops best-effort and that
-// error is returned; callbacks already invoked are not retried.
+// valid only until fn returns and must be copied before retaining. If fn returns
+// an error, iteration stops and that error is returned; callbacks already
+// invoked are not retried.
 func (db *DB) GetManyView(keys [][]byte, fn GetManyViewFunc) error {
 	if fn == nil {
 		return errors.New("GetManyView: nil callback")
@@ -261,61 +258,7 @@ func (db *DB) getManyViewOnce(keys [][]byte, fn GetManyViewFunc) error {
 		return err
 	}
 	defer snap.Close()
-
-	workers := getManyWorkerCount(len(keys))
-	if getManyCanParallelize(len(keys), workers) {
-		return db.getManyViewParallel(snap, keys, fn, workers)
-	}
 	return snap.GetManyView(keys, fn)
-}
-
-func (db *DB) getManyViewParallel(snap *Snapshot, keys [][]byte, fn GetManyViewFunc, workers int) error {
-	var (
-		wg       sync.WaitGroup
-		stop     atomic.Bool
-		errMu    sync.Mutex
-		firstErr error
-	)
-	setErr := func(err error) {
-		if err == nil {
-			return
-		}
-		errMu.Lock()
-		if firstErr == nil {
-			firstErr = err
-			stop.Store(true)
-		}
-		errMu.Unlock()
-	}
-	getErr := func() error {
-		errMu.Lock()
-		err := firstErr
-		errMu.Unlock()
-		return err
-	}
-	for worker := 0; worker < workers; worker++ {
-		start, end := getManyChunkBounds(worker, workers, len(keys))
-		if start >= end {
-			continue
-		}
-		wg.Add(1)
-		go func(start, end int) {
-			defer wg.Done()
-			err := snap.tree.GetManyView(keys[start:end], func(index int, key []byte, value []byte, found bool) error {
-				if stop.Load() {
-					return getErr()
-				}
-				err := fn(start+index, key, value, found)
-				if err != nil {
-					setErr(err)
-				}
-				return err
-			})
-			setErr(err)
-		}(start, end)
-	}
-	wg.Wait()
-	return getErr()
 }
 
 func (db *DB) getManySequential(snap *Snapshot, keys [][]byte, out [][]byte) error {

--- a/TreeDB/db/closed_db_public_methods_test.go
+++ b/TreeDB/db/closed_db_public_methods_test.go
@@ -174,6 +174,15 @@ func TestClosedDB_GetMany(t *testing.T) {
 	})
 }
 
+func TestClosedDB_GetManyView(t *testing.T) {
+	runClosedDBMethod(t, "GetManyView", func(d *DB) {
+		err := d.GetManyView([][]byte{[]byte("k")}, func(int, []byte, []byte, bool) error { return nil })
+		if !errors.Is(err, ErrClosed) {
+			t.Fatalf("GetManyView err=%v want %v", err, ErrClosed)
+		}
+	})
+}
+
 func TestClosedDB_GetUnsafe(t *testing.T) {
 	runClosedDBMethod(t, "GetUnsafe", func(d *DB) {
 		_, err := d.GetUnsafe([]byte("k"))

--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -2579,6 +2579,15 @@ func (s *Snapshot) GetAppend(key, dst []byte) ([]byte, error) {
 	return s.tree.GetAppend(key, dst)
 }
 
+// GetManyView calls fn once for each key with a read-only value view.
+// Values are valid until fn returns and must be copied before retaining.
+func (s *Snapshot) GetManyView(keys [][]byte, fn GetManyViewFunc) error {
+	if s == nil || s.closed.Load() {
+		return ErrClosed
+	}
+	return s.tree.GetManyView(keys, fn)
+}
+
 // GetUnsafe returns a zero-copy view of the value from the snapshot.
 // The slice is valid until the snapshot is closed.
 func (s *Snapshot) GetUnsafe(key []byte) ([]byte, error) {

--- a/TreeDB/db/root_snapshot.go
+++ b/TreeDB/db/root_snapshot.go
@@ -53,6 +53,13 @@ func (r *SnapshotRootReader) GetAppend(key, dst []byte) ([]byte, error) {
 	return r.tree.GetAppend(key, dst)
 }
 
+func (r *SnapshotRootReader) GetManyView(keys [][]byte, fn GetManyViewFunc) error {
+	if r == nil || !r.ok {
+		return tree.ErrKeyNotFound
+	}
+	return r.tree.GetManyView(keys, fn)
+}
+
 func (s *Snapshot) GetEntryAtRoot(rootID uint64, key []byte) (node.LeafEntry, error) {
 	tr, err := s.treeAtRoot(rootID)
 	if err != nil {
@@ -75,6 +82,14 @@ func (s *Snapshot) GetAppendAtRoot(rootID uint64, key, dst []byte) ([]byte, erro
 		return dst, err
 	}
 	return tr.GetAppend(key, dst)
+}
+
+func (s *Snapshot) GetManyViewAtRoot(rootID uint64, keys [][]byte, fn GetManyViewFunc) error {
+	tr, err := s.treeAtRoot(rootID)
+	if err != nil {
+		return err
+	}
+	return tr.GetManyView(keys, fn)
 }
 
 func (s *Snapshot) GetUnsafeAtRoot(rootID uint64, key []byte) ([]byte, error) {

--- a/TreeDB/docs/spec/contracts.md
+++ b/TreeDB/docs/spec/contracts.md
@@ -30,16 +30,14 @@ Status:
 - `GetMany(keys)` returns one entry per input key. Missing keys are returned as
   `nil` entries with no error. Returned value bytes are safe copies.
 - `GetManyView(keys, fn)` calls `fn(index, key, value, found)` once for each
-  input key unless an error stops the call. The callback order is unspecified,
-  and DB-level implementations may invoke callbacks concurrently for large
-  batches; callers that mutate shared state in the callback must synchronize it.
+  input key unless an error stops the call. The callback order is unspecified;
   `index` identifies the input key.
 - `GetManyView` reports missing or tombstoned keys with `found=false` and
   `value=nil`. Present empty values have `found=true` and `len(value)==0`.
 - `GetManyView` value slices are read-only views valid only until the callback
-  returns. Callers must copy a value before retaining it, mutating it, passing
-  the view itself to another goroutine, or using it after the owning
-  DB/snapshot/view operation advances or closes.
+  returns. Callers must copy a value before retaining it, mutating it, passing it
+  to another goroutine, or using it after the owning DB/snapshot/view operation
+  advances or closes.
 - `GetManyView` must not weaken `GetMany`: callers that need stable ownership
   must continue to use `GetMany` or copy inside the callback.
 

--- a/TreeDB/docs/spec/contracts.md
+++ b/TreeDB/docs/spec/contracts.md
@@ -25,17 +25,34 @@ Status:
 - `Get(key)` returns `(nil, nil)` when key is absent.
 - Returned bytes are safe copies.
 
-### 2.2 `GetUnsafe`
+### 2.2 `GetMany` and `GetManyView`
+
+- `GetMany(keys)` returns one entry per input key. Missing keys are returned as
+  `nil` entries with no error. Returned value bytes are safe copies.
+- `GetManyView(keys, fn)` calls `fn(index, key, value, found)` once for each
+  input key unless an error stops the call. The callback order is unspecified;
+  `index` identifies the input key.
+- `GetManyView` reports missing or tombstoned keys with `found=false` and
+  `value=nil`. Present empty values have `found=true` and `len(value)==0`.
+- `GetManyView` value slices are read-only views valid only until the callback
+  returns. Callers must copy a value before retaining it, mutating it, passing it
+  to another goroutine, or using it after the owning DB/snapshot/view operation
+  advances or closes.
+- `GetManyView` must not weaken `GetMany`: callers that need stable ownership
+  must continue to use `GetMany` or copy inside the callback.
+
+### 2.3 `GetUnsafe`
 
 - Public `DB.GetUnsafe` currently aliases `Get` behavior (safe copy).
-- Zero-copy reads are available through snapshot/iterator internals, not through this API.
+- Zero-copy reads are available through snapshot/iterator internals and the
+  callback-scoped `GetManyView` API.
 
-### 2.3 `Has`
+### 2.4 `Has`
 
 - `Has(key)` returns `(true, nil)` only for a visible non-deleted key.
 - Deleted/missing keys return `(false, nil)`.
 
-### 2.4 Cached-mode visibility
+### 2.5 Cached-mode visibility
 
 When the cached layer is enabled (default `treedb.Open` behavior):
 

--- a/TreeDB/docs/spec/contracts.md
+++ b/TreeDB/docs/spec/contracts.md
@@ -30,14 +30,16 @@ Status:
 - `GetMany(keys)` returns one entry per input key. Missing keys are returned as
   `nil` entries with no error. Returned value bytes are safe copies.
 - `GetManyView(keys, fn)` calls `fn(index, key, value, found)` once for each
-  input key unless an error stops the call. The callback order is unspecified;
+  input key unless an error stops the call. The callback order is unspecified,
+  and DB-level implementations may invoke callbacks concurrently for large
+  batches; callers that mutate shared state in the callback must synchronize it.
   `index` identifies the input key.
 - `GetManyView` reports missing or tombstoned keys with `found=false` and
   `value=nil`. Present empty values have `found=true` and `len(value)==0`.
 - `GetManyView` value slices are read-only views valid only until the callback
-  returns. Callers must copy a value before retaining it, mutating it, passing it
-  to another goroutine, or using it after the owning DB/snapshot/view operation
-  advances or closes.
+  returns. Callers must copy a value before retaining it, mutating it, passing
+  the view itself to another goroutine, or using it after the owning
+  DB/snapshot/view operation advances or closes.
 - `GetManyView` must not weaken `GetMany`: callers that need stable ownership
   must continue to use `GetMany` or copy inside the callback.
 

--- a/TreeDB/docs/spec/contracts.md
+++ b/TreeDB/docs/spec/contracts.md
@@ -30,7 +30,9 @@ Status:
 - `GetMany(keys)` returns one entry per input key. Missing keys are returned as
   `nil` entries with no error. Returned value bytes are safe copies.
 - `GetManyView(keys, fn)` calls `fn(index, key, value, found)` once for each
-  input key unless an error stops the call. The callback order is unspecified;
+  input key unless an error stops the call. The callback order is unspecified,
+  and DB-level implementations may invoke callbacks concurrently for large
+  batches; callers that mutate shared state in the callback must synchronize it.
   `index` identifies the input key.
 - `GetManyView` reports missing or tombstoned keys with `found=false` and
   `value=nil`. Present empty values have `found=true` and `len(value)==0`.

--- a/TreeDB/getmany_view_test.go
+++ b/TreeDB/getmany_view_test.go
@@ -161,7 +161,7 @@ func TestGetManyViewCallbackErrorStops(t *testing.T) {
 	}
 }
 
-func TestGetManyViewParallelCallbackErrorStops(t *testing.T) {
+func TestGetManyViewLargeBatchCallbackErrorStops(t *testing.T) {
 	db, err := Open(Options{Dir: t.TempDir()})
 	if err != nil {
 		t.Fatalf("Open: %v", err)

--- a/TreeDB/getmany_view_test.go
+++ b/TreeDB/getmany_view_test.go
@@ -3,6 +3,7 @@ package treedb
 import (
 	"bytes"
 	"errors"
+	"sync/atomic"
 	"testing"
 )
 
@@ -177,15 +178,15 @@ func TestGetManyViewParallelCallbackErrorStops(t *testing.T) {
 		t.Fatalf("Checkpoint: %v", err)
 	}
 	want := errors.New("stop")
-	calls := 0
+	var calls atomic.Int64
 	err = db.GetManyView(keys, func(int, []byte, []byte, bool) error {
-		calls++
+		calls.Add(1)
 		return want
 	})
 	if !errors.Is(err, want) {
 		t.Fatalf("GetManyView err=%v want %v", err, want)
 	}
-	if calls != 1 {
-		t.Fatalf("callbacks after error=%d want 1", calls)
+	if got := calls.Load(); got == 0 || got > int64(len(keys)) {
+		t.Fatalf("callbacks after error=%d, want at least 1 and at most %d", got, len(keys))
 	}
 }

--- a/TreeDB/getmany_view_test.go
+++ b/TreeDB/getmany_view_test.go
@@ -1,0 +1,161 @@
+package treedb
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+)
+
+func TestGetManyViewDuplicateMissingEmptyPointerBacked(t *testing.T) {
+	opts := Options{Dir: t.TempDir()}
+	opts.ValueLog.PointerThreshold = 1
+	opts.ValueLog.ForcePointers = true
+	db, err := Open(opts)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	pointerValue := bytes.Repeat([]byte("p"), 257)
+	if err := db.Set([]byte("inline"), []byte("value-inline")); err != nil {
+		t.Fatalf("Set inline: %v", err)
+	}
+	if err := db.Set([]byte("empty"), []byte{}); err != nil {
+		t.Fatalf("Set empty: %v", err)
+	}
+	if err := db.Set([]byte("pointer"), pointerValue); err != nil {
+		t.Fatalf("Set pointer: %v", err)
+	}
+	if err := db.Set([]byte("deleted"), []byte("gone")); err != nil {
+		t.Fatalf("Set deleted: %v", err)
+	}
+	if err := db.Delete([]byte("deleted")); err != nil {
+		t.Fatalf("Delete deleted: %v", err)
+	}
+
+	keys := [][]byte{
+		[]byte("pointer"),
+		[]byte("missing"),
+		[]byte("empty"),
+		[]byte("pointer"),
+		[]byte("deleted"),
+		[]byte("inline"),
+	}
+	assertView := func(label string) {
+		t.Helper()
+		seen := make([]bool, len(keys))
+		found := make([]bool, len(keys))
+		values := make([][]byte, len(keys))
+		err := db.GetManyView(keys, func(index int, key []byte, value []byte, ok bool) error {
+			if index < 0 || index >= len(keys) {
+				return errors.New("callback index out of range")
+			}
+			if !bytes.Equal(key, keys[index]) {
+				t.Fatalf("%s callback key[%d]=%q want %q", label, index, key, keys[index])
+			}
+			seen[index] = true
+			found[index] = ok
+			if ok {
+				values[index] = append([]byte(nil), value...)
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("%s GetManyView: %v", label, err)
+		}
+		for i, ok := range seen {
+			if !ok {
+				t.Fatalf("%s callback for index %d was not invoked", label, i)
+			}
+		}
+		if !found[0] || !bytes.Equal(values[0], pointerValue) {
+			t.Fatalf("%s pointer[0] found=%v len=%d", label, found[0], len(values[0]))
+		}
+		if found[1] || values[1] != nil {
+			t.Fatalf("%s missing found=%v value=%q", label, found[1], values[1])
+		}
+		if !found[2] || len(values[2]) != 0 {
+			t.Fatalf("%s empty found=%v value=%q", label, found[2], values[2])
+		}
+		if !found[3] || !bytes.Equal(values[3], pointerValue) {
+			t.Fatalf("%s duplicate pointer found=%v len=%d", label, found[3], len(values[3]))
+		}
+		if found[4] || values[4] != nil {
+			t.Fatalf("%s deleted found=%v value=%q", label, found[4], values[4])
+		}
+		if !found[5] || !bytes.Equal(values[5], []byte("value-inline")) {
+			t.Fatalf("%s inline found=%v value=%q", label, found[5], values[5])
+		}
+	}
+
+	assertView("memtable")
+	if err := db.Checkpoint(); err != nil {
+		t.Fatalf("Checkpoint: %v", err)
+	}
+	assertView("checkpointed")
+
+	safe, err := db.GetMany(keys)
+	if err != nil {
+		t.Fatalf("GetMany: %v", err)
+	}
+	if len(safe) != len(keys) || !bytes.Equal(safe[0], pointerValue) || safe[1] != nil || len(safe[2]) != 0 || !bytes.Equal(safe[3], pointerValue) || safe[4] != nil || !bytes.Equal(safe[5], []byte("value-inline")) {
+		t.Fatalf("safe GetMany results mismatch: %#v", safe)
+	}
+	if len(safe[0]) > 0 {
+		safe[0][0] = 'X'
+		again, err := db.GetMany([][]byte{[]byte("pointer")})
+		if err != nil {
+			t.Fatalf("GetMany again: %v", err)
+		}
+		if bytes.Equal(again[0], safe[0]) || !bytes.Equal(again[0], pointerValue) {
+			t.Fatalf("mutating safe GetMany result affected storage: again prefix=%q", again[0][:1])
+		}
+	}
+}
+
+func TestSnapshotGetManyViewClosedSnapshotBoundary(t *testing.T) {
+	db, err := Open(Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	if err := db.Set([]byte("k"), []byte("v")); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	snap := db.AcquireSnapshot()
+	if snap == nil {
+		t.Fatalf("AcquireSnapshot returned nil")
+	}
+	if err := snap.Close(); err != nil {
+		t.Fatalf("Close snapshot: %v", err)
+	}
+	called := false
+	err = snap.GetManyView([][]byte{[]byte("k")}, func(int, []byte, []byte, bool) error {
+		called = true
+		return nil
+	})
+	if !errors.Is(err, ErrClosed) {
+		t.Fatalf("closed snapshot GetManyView err=%v want ErrClosed", err)
+	}
+	if called {
+		t.Fatalf("closed snapshot GetManyView invoked callback")
+	}
+}
+
+func TestGetManyViewCallbackErrorStops(t *testing.T) {
+	db, err := Open(Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	if err := db.Set([]byte("k"), []byte("v")); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	want := errors.New("stop")
+	err = db.GetManyView([][]byte{[]byte("k"), []byte("missing")}, func(int, []byte, []byte, bool) error {
+		return want
+	})
+	if !errors.Is(err, want) {
+		t.Fatalf("GetManyView err=%v want %v", err, want)
+	}
+}

--- a/TreeDB/getmany_view_test.go
+++ b/TreeDB/getmany_view_test.go
@@ -159,3 +159,33 @@ func TestGetManyViewCallbackErrorStops(t *testing.T) {
 		t.Fatalf("GetManyView err=%v want %v", err, want)
 	}
 }
+
+func TestGetManyViewParallelCallbackErrorStops(t *testing.T) {
+	db, err := Open(Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	keys := make([][]byte, 256)
+	for i := range keys {
+		keys[i] = []byte{byte(i >> 8), byte(i)}
+		if err := db.Set(keys[i], []byte("v")); err != nil {
+			t.Fatalf("Set %d: %v", i, err)
+		}
+	}
+	if err := db.Checkpoint(); err != nil {
+		t.Fatalf("Checkpoint: %v", err)
+	}
+	want := errors.New("stop")
+	calls := 0
+	err = db.GetManyView(keys, func(int, []byte, []byte, bool) error {
+		calls++
+		return want
+	})
+	if !errors.Is(err, want) {
+		t.Fatalf("GetManyView err=%v want %v", err, want)
+	}
+	if calls != 1 {
+		t.Fatalf("callbacks after error=%d want 1", calls)
+	}
+}

--- a/TreeDB/public.go
+++ b/TreeDB/public.go
@@ -86,9 +86,7 @@ type getManyPlanner interface {
 	GetManyParallelPlan(keyCount int) (workers int, parallel bool)
 }
 
-// GetManyViewFunc receives one GetManyView result. DB-level callbacks may be
-// invoked in any order and may be invoked concurrently for large batches;
-// callers that mutate shared state must synchronize it. The value slice is a
+// GetManyViewFunc receives one GetManyView result. The value slice is a
 // read-only view that is valid only until the callback returns (or until a
 // snapshot/view boundary documented by the caller closes, whichever comes
 // first). Copy value before retaining it. Missing/tombstoned keys are reported
@@ -1399,11 +1397,10 @@ func (db *DB) GetMany(keys [][]byte) ([][]byte, error) {
 }
 
 // GetManyView calls fn once for each key with a read-only value view. The
-// callback may be invoked in any order and may be invoked concurrently for
-// large batches; the index argument identifies the input key. Values are valid
-// only until fn returns and must be copied before retaining. Missing keys are
-// reported with found=false and value=nil. Existing safe-copy GetMany semantics
-// are unchanged.
+// callback may be invoked in any order; the index argument identifies the input
+// key. Values are valid only until fn returns and must be copied before
+// retaining. Missing keys are reported with found=false and value=nil. Existing
+// safe-copy GetMany semantics are unchanged.
 func (db *DB) GetManyView(keys [][]byte, fn GetManyViewFunc) error {
 	if err := db.ensureOpen(); err != nil {
 		return err

--- a/TreeDB/public.go
+++ b/TreeDB/public.go
@@ -86,6 +86,13 @@ type getManyPlanner interface {
 	GetManyParallelPlan(keyCount int) (workers int, parallel bool)
 }
 
+// GetManyViewFunc receives one GetManyView result. The value slice is a
+// read-only view that is valid only until the callback returns (or until a
+// snapshot/view boundary documented by the caller closes, whichever comes
+// first). Copy value before retaining it. Missing/tombstoned keys are reported
+// with found=false and value=nil.
+type GetManyViewFunc = db.GetManyViewFunc
+
 // UpdateOp describes the write produced by an Update callback.
 type UpdateOp = db.UpdateOp
 
@@ -1387,6 +1394,21 @@ func (db *DB) GetMany(keys [][]byte) ([][]byte, error) {
 		return db.cached.GetMany(keys)
 	}
 	return db.backend.GetMany(keys)
+}
+
+// GetManyView calls fn once for each key with a read-only value view. The
+// callback may be invoked in any order; the index argument identifies the input
+// key. Values are valid only until fn returns and must be copied before
+// retaining. Missing keys are reported with found=false and value=nil. Existing
+// safe-copy GetMany semantics are unchanged.
+func (db *DB) GetManyView(keys [][]byte, fn GetManyViewFunc) error {
+	if err := db.ensureOpen(); err != nil {
+		return err
+	}
+	if db.cached != nil {
+		return db.cached.GetManyView(keys, fn)
+	}
+	return db.backend.GetManyView(keys, fn)
 }
 
 // GetManyParallelPlan reports how TreeDB would schedule GetMany for the given

--- a/TreeDB/public.go
+++ b/TreeDB/public.go
@@ -86,7 +86,9 @@ type getManyPlanner interface {
 	GetManyParallelPlan(keyCount int) (workers int, parallel bool)
 }
 
-// GetManyViewFunc receives one GetManyView result. The value slice is a
+// GetManyViewFunc receives one GetManyView result. DB-level callbacks may be
+// invoked in any order and may be invoked concurrently for large batches;
+// callers that mutate shared state must synchronize it. The value slice is a
 // read-only view that is valid only until the callback returns (or until a
 // snapshot/view boundary documented by the caller closes, whichever comes
 // first). Copy value before retaining it. Missing/tombstoned keys are reported
@@ -1397,10 +1399,11 @@ func (db *DB) GetMany(keys [][]byte) ([][]byte, error) {
 }
 
 // GetManyView calls fn once for each key with a read-only value view. The
-// callback may be invoked in any order; the index argument identifies the input
-// key. Values are valid only until fn returns and must be copied before
-// retaining. Missing keys are reported with found=false and value=nil. Existing
-// safe-copy GetMany semantics are unchanged.
+// callback may be invoked in any order and may be invoked concurrently for
+// large batches; the index argument identifies the input key. Values are valid
+// only until fn returns and must be copied before retaining. Missing keys are
+// reported with found=false and value=nil. Existing safe-copy GetMany semantics
+// are unchanged.
 func (db *DB) GetManyView(keys [][]byte, fn GetManyViewFunc) error {
 	if err := db.ensureOpen(); err != nil {
 		return err

--- a/TreeDB/snapshot.go
+++ b/TreeDB/snapshot.go
@@ -17,6 +17,7 @@ type Snapshot interface {
 
 	Get(key []byte) ([]byte, error)
 	GetAppend(key, dst []byte) ([]byte, error)
+	GetManyView(keys [][]byte, fn GetManyViewFunc) error
 	GetUnsafe(key []byte) ([]byte, error)
 	Has(key []byte) (bool, error)
 	HasMany(keys [][]byte) ([]bool, error)

--- a/TreeDB/tree/tree.go
+++ b/TreeDB/tree/tree.go
@@ -1107,8 +1107,9 @@ func (t *Tree) GetManyView(keys [][]byte, fn GetManyViewFunc) error {
 }
 
 func (t *Tree) getManyViewFallback(keys [][]byte, fn GetManyViewFunc) error {
+	var scratch []byte
 	for i, key := range keys {
-		val, err := t.GetUnsafe(key)
+		out, err := t.GetAppend(key, scratch[:0])
 		if err == ErrKeyNotFound {
 			if err := fn(i, key, nil, false); err != nil {
 				return err
@@ -1118,11 +1119,17 @@ func (t *Tree) getManyViewFallback(keys [][]byte, fn GetManyViewFunc) error {
 		if err != nil {
 			return err
 		}
+		val := out
 		if len(val) == 0 {
 			val = treeGetManyEmptyValue
 		}
 		if err := fn(i, key, val, true); err != nil {
 			return err
+		}
+		if cap(out) <= 1<<20 {
+			scratch = out[:0]
+		} else {
+			scratch = nil
 		}
 	}
 	return nil

--- a/TreeDB/tree/tree.go
+++ b/TreeDB/tree/tree.go
@@ -196,6 +196,12 @@ type slabKeyAwareCapability interface {
 	KeyAwareEnabled() bool
 }
 
+// GetManyViewFunc receives one GetManyView result. The value slice is a
+// read-only view that is valid only until the callback returns; callers must
+// copy it before retaining it. Missing/tombstoned keys are reported with
+// found=false and value=nil.
+type GetManyViewFunc func(index int, key []byte, value []byte, found bool) error
+
 // Optional capability gate for slab/leaf-ref checksum verification.
 //
 // Returning false allows tree leaf-ref readers to skip per-page checksum
@@ -845,6 +851,7 @@ type getManyLeafNodeLease struct {
 type getManyScratch struct {
 	probes        []getManyLeafProbe
 	groups        []getManyLeafGroup
+	present       []bool
 	groupByRef    map[page.ChildRef]int
 	groupByRefCap int
 }
@@ -877,6 +884,12 @@ func getGetManyScratch(keyCount int) *getManyScratch {
 	} else {
 		scratch.groups = scratch.groups[:0]
 	}
+	if cap(scratch.present) < keyCount || cap(scratch.present) > getManyScratchMaxReuseKeys {
+		scratch.present = make([]bool, keyCount)
+	} else {
+		scratch.present = scratch.present[:keyCount]
+		clear(scratch.present)
+	}
 	if scratch.groupByRef == nil || keyCount > getManyScratchMaxReuseKeys || scratch.groupByRefCap < keyCount {
 		scratch.groupByRef = make(map[page.ChildRef]int, keyCount)
 		scratch.groupByRefCap = keyCount
@@ -896,14 +909,18 @@ func putGetManyScratch(scratch *getManyScratch) {
 	if len(scratch.groups) > 0 {
 		clear(scratch.groups)
 	}
+	if len(scratch.present) > 0 {
+		clear(scratch.present)
+	}
 	if scratch.groupByRef != nil {
 		clear(scratch.groupByRef)
 	}
-	if cap(scratch.probes) > getManyScratchMaxReuseKeys || cap(scratch.groups) > getManyScratchMaxReuseKeys {
+	if cap(scratch.probes) > getManyScratchMaxReuseKeys || cap(scratch.groups) > getManyScratchMaxReuseKeys || cap(scratch.present) > getManyScratchMaxReuseKeys {
 		return
 	}
 	scratch.probes = scratch.probes[:0]
 	scratch.groups = scratch.groups[:0]
+	scratch.present = scratch.present[:0]
 	getManyScratchPool.Put(scratch)
 }
 
@@ -992,6 +1009,123 @@ func (t *Tree) GetManyAppend(keys [][]byte, out [][]byte, arena []byte) ([]byte,
 		lease.Release()
 	}
 	return arena, nil
+}
+
+// GetManyView resolves keys and calls fn once per input key with a read-only
+// value view. The callback may be invoked in any order, but the index argument
+// always identifies the input key. Value views are valid only until fn returns;
+// callers must copy values they need after the callback. Missing or tombstoned
+// keys are reported with found=false and value=nil.
+func (t *Tree) GetManyView(keys [][]byte, fn GetManyViewFunc) error {
+	treeGetManyCallsTotal.Add(1)
+	if fn == nil {
+		return errors.New("GetManyView: nil callback")
+	}
+	if len(keys) == 0 {
+		return nil
+	}
+	if t == nil {
+		return errors.New("missing tree")
+	}
+	if len(keys) < getManyLeafGroupMinKeys {
+		treeGetManyFallbackCallsTotal.Add(1)
+		return t.getManyViewFallback(keys, fn)
+	}
+	verifyAlways := false
+	if t.pager != nil {
+		verifyAlways = t.pager.VerifyOnRead()
+	}
+
+	scratch := getGetManyScratch(len(keys))
+	defer putGetManyScratch(scratch)
+	for i, key := range keys {
+		ref, groupable, err := t.findLeafRefForGetMany(key, verifyAlways)
+		if err == ErrKeyNotFound {
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		if !groupable {
+			treeGetManyFallbackCallsTotal.Add(1)
+			return t.getManyViewFallback(keys, fn)
+		}
+
+		groupIdx, ok := scratch.groupByRef[ref]
+		if !ok {
+			groupIdx = len(scratch.groups)
+			scratch.groupByRef[ref] = groupIdx
+			scratch.groups = append(scratch.groups, getManyLeafGroup{ref: ref, first: -1})
+		}
+		probeIdx := len(scratch.probes)
+		scratch.probes = append(scratch.probes, getManyLeafProbe{
+			key:      key,
+			outIndex: i,
+			next:     scratch.groups[groupIdx].first,
+		})
+		scratch.groups[groupIdx].first = probeIdx
+		scratch.groups[groupIdx].count++
+		scratch.present[i] = true
+	}
+
+	if len(scratch.groups) > 0 {
+		treeGetManyGroupedCallsTotal.Add(1)
+		treeGetManyLeafGroupsTotal.Add(uint64(len(scratch.groups)))
+		treeGetManyLeafGroupItemsTotal.Add(uint64(len(scratch.probes)))
+		if saved := len(scratch.probes) - len(scratch.groups); saved > 0 {
+			treeGetManyLeafLoadsSavedTotal.Add(uint64(saved))
+		}
+
+		for i := range scratch.groups {
+			g := &scratch.groups[i]
+			var n node.Node
+			lease, err := t.loadLeafNodeForGetMany(&n, g.ref, verifyAlways)
+			if err != nil {
+				lease.Release()
+				return err
+			}
+			for probeIdx := g.first; probeIdx >= 0; probeIdx = scratch.probes[probeIdx].next {
+				probe := scratch.probes[probeIdx]
+				if err := t.visitLeafValueFromNode(&n, probe.key, probe.outIndex, fn); err != nil {
+					lease.Release()
+					return err
+				}
+			}
+			lease.Release()
+		}
+	}
+
+	for i, key := range keys {
+		if scratch.present[i] {
+			continue
+		}
+		if err := fn(i, key, nil, false); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (t *Tree) getManyViewFallback(keys [][]byte, fn GetManyViewFunc) error {
+	for i, key := range keys {
+		val, err := t.GetUnsafe(key)
+		if err == ErrKeyNotFound {
+			if err := fn(i, key, nil, false); err != nil {
+				return err
+			}
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		if len(val) == 0 {
+			val = treeGetManyEmptyValue
+		}
+		if err := fn(i, key, val, true); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (t *Tree) getManyAppendFallback(keys [][]byte, out [][]byte, arena []byte) ([]byte, error) {
@@ -1148,6 +1282,47 @@ func (t *Tree) loadLeafNodeForGetMany(dst *node.Node, ref page.ChildRef, verifyA
 		return getManyLeafNodeLease{}, err
 	}
 	return lease, nil
+}
+
+func (t *Tree) pointerValueViewForKey(key []byte, ptr page.ValuePtr) ([]byte, error) {
+	if t.slabKeyReader != nil {
+		return t.slabKeyReader.ReadUnsafeForKey(ptr, key)
+	}
+	if t.slabReader == nil {
+		return nil, errors.New("missing slab reader")
+	}
+	return t.slabReader.ReadUnsafe(ptr)
+}
+
+func (t *Tree) visitLeafValueFromNode(n *node.Node, key []byte, outIndex int, fn GetManyViewFunc) error {
+	idx, found, err := n.SearchLeaf(key)
+	if err != nil {
+		return err
+	}
+	if !found {
+		return fn(outIndex, key, nil, false)
+	}
+	val, ptr, flags, err := n.GetLeafValueView(idx)
+	if err != nil {
+		return err
+	}
+	if flags&node.FlagTombstone != 0 {
+		return fn(outIndex, key, nil, false)
+	}
+	if flags&node.FlagPointer != 0 {
+		val, err = t.pointerValueViewForKey(key, ptr)
+		if err != nil {
+			return err
+		}
+		if len(val) == 0 {
+			val = treeGetManyEmptyValue
+		}
+		return fn(outIndex, key, val, true)
+	}
+	if val == nil {
+		val = treeGetManyEmptyValue
+	}
+	return fn(outIndex, key, val, true)
 }
 
 func (t *Tree) appendLeafValueFromNode(n *node.Node, key []byte, out [][]byte, outIndex int, arena []byte) ([]byte, error) {

--- a/cmd/unified_bench/main.go
+++ b/cmd/unified_bench/main.go
@@ -3550,6 +3550,7 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 			for i := 0; i < batchSize; i++ {
 				keys[i] = keyBuf[i*8 : (i+1)*8]
 			}
+			mgv, hasManyView := db.(kvstore.MultiGetterView)
 			mg, hasMany := db.(kvstore.MultiGetter)
 			nextGuard := 0
 			for i := 0; i < cfg.Keys; {
@@ -3566,7 +3567,30 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 				for j := 0; j < n; j++ {
 					encodeKey(keys[j], uint64(rng.Intn(cfg.Keys)))
 				}
-				if hasMany {
+				if hasManyView {
+					seen := 0
+					err := mgv.GetManyView(keys[:n], func(index int, _ []byte, value []byte, found bool) error {
+						seen++
+						if index < 0 || index >= n {
+							return fmt.Errorf("GetManyView callback index %d outside %d keys", index, n)
+						}
+						if cfg.ReadRequireHit {
+							if !found {
+								return fmt.Errorf("value missing at index %d", index)
+							}
+							if len(value) != cfg.ValueSize {
+								return fmt.Errorf("value length mismatch: got=%d want=%d", len(value), cfg.ValueSize)
+							}
+						}
+						return nil
+					})
+					if err != nil {
+						return 0, fmt.Errorf("random_read_batch: %w", err)
+					}
+					if cfg.ReadRequireHit && seen != n {
+						return 0, fmt.Errorf("random_read_batch: GetManyView returned %d callbacks for %d keys", seen, n)
+					}
+				} else if hasMany {
 					vals, err := mg.GetMany(keys[:n])
 					if err != nil {
 						return 0, fmt.Errorf("random_read_batch: %w", err)

--- a/cmd/unified_bench/main.go
+++ b/cmd/unified_bench/main.go
@@ -3568,9 +3568,9 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 					encodeKey(keys[j], uint64(rng.Intn(cfg.Keys)))
 				}
 				if hasManyView {
-					seen := 0
+					var seen atomic.Int64
 					err := mgv.GetManyView(keys[:n], func(index int, _ []byte, value []byte, found bool) error {
-						seen++
+						seen.Add(1)
 						if index < 0 || index >= n {
 							return fmt.Errorf("GetManyView callback index %d outside %d keys", index, n)
 						}
@@ -3587,8 +3587,8 @@ func runBenchmark(cfg BenchConfig) (BenchRun, error) {
 					if err != nil {
 						return 0, fmt.Errorf("random_read_batch: %w", err)
 					}
-					if cfg.ReadRequireHit && seen != n {
-						return 0, fmt.Errorf("random_read_batch: GetManyView returned %d callbacks for %d keys", seen, n)
+					if cfg.ReadRequireHit && int(seen.Load()) != n {
+						return 0, fmt.Errorf("random_read_batch: GetManyView returned %d callbacks for %d keys", seen.Load(), n)
 					}
 				} else if hasMany {
 					vals, err := mg.GetMany(keys[:n])

--- a/cmd/unified_bench/main_test.go
+++ b/cmd/unified_bench/main_test.go
@@ -95,6 +95,10 @@ type errorGetManyDB struct {
 	err error
 }
 
+type errorGetManyViewDB struct {
+	err error
+}
+
 func (d *errorGetManyDB) Name() string {
 	return "ErrGetMany"
 }
@@ -117,6 +121,30 @@ func (d *errorGetManyDB) Delete(key []byte) error {
 
 func (d *errorGetManyDB) GetMany(keys [][]byte) ([][]byte, error) {
 	return nil, d.err
+}
+
+func (d *errorGetManyViewDB) Name() string {
+	return "ErrGetManyView"
+}
+
+func (d *errorGetManyViewDB) Close() error {
+	return nil
+}
+
+func (d *errorGetManyViewDB) Get(key []byte) ([]byte, error) {
+	return nil, nil
+}
+
+func (d *errorGetManyViewDB) Set(key, value []byte) error {
+	return nil
+}
+
+func (d *errorGetManyViewDB) Delete(key []byte) error {
+	return nil
+}
+
+func (d *errorGetManyViewDB) GetManyView(keys [][]byte, fn kvstore.MultiGetViewFunc) error {
+	return d.err
 }
 
 type errorGetDB struct {
@@ -254,6 +282,12 @@ func (d *settleProbeDB) Delete(key []byte) error { return nil }
 type preferGetManyDB struct {
 	getCalls     int
 	getManyCalls int
+}
+
+type preferGetManyViewDB struct {
+	getCalls         int
+	getManyCalls     int
+	getManyViewCalls int
 }
 
 type scanViewOnlyDB struct {
@@ -406,6 +440,42 @@ func (d *preferGetManyDB) Delete(key []byte) error {
 func (d *preferGetManyDB) GetMany(keys [][]byte) ([][]byte, error) {
 	d.getManyCalls++
 	return make([][]byte, len(keys)), nil
+}
+
+func (d *preferGetManyViewDB) Name() string {
+	return "PreferGetManyView"
+}
+
+func (d *preferGetManyViewDB) Close() error {
+	return nil
+}
+
+func (d *preferGetManyViewDB) Get(key []byte) ([]byte, error) {
+	d.getCalls++
+	return nil, errors.New("get should not be called when GetManyView is available")
+}
+
+func (d *preferGetManyViewDB) Set(key, value []byte) error {
+	return nil
+}
+
+func (d *preferGetManyViewDB) Delete(key []byte) error {
+	return nil
+}
+
+func (d *preferGetManyViewDB) GetMany(keys [][]byte) ([][]byte, error) {
+	d.getManyCalls++
+	return nil, errors.New("GetMany should not be called when GetManyView is available")
+}
+
+func (d *preferGetManyViewDB) GetManyView(keys [][]byte, fn kvstore.MultiGetViewFunc) error {
+	d.getManyViewCalls++
+	for i, key := range keys {
+		if err := fn(i, key, nil, false); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func runRandomReadBatchErrorCase(t *testing.T, dbName string, factory DBFactory, want error) {
@@ -623,6 +693,51 @@ func TestRunBenchmark_RandomReadBatch_PrefersGetManyOverGet(t *testing.T) {
 	if math.IsNaN(got) || got <= 0 {
 		t.Fatalf("expected random_read_batch > 0 for %s, got %v", db.Name(), got)
 	}
+}
+
+func TestRunBenchmark_RandomReadBatch_PrefersGetManyViewOverGetMany(t *testing.T) {
+	var db *preferGetManyViewDB
+	const dbName = "random_read_batch_prefer_getmanyview"
+	RegisterHiddenDB(dbName, func(_ string) (kvstore.DB, error) {
+		db = &preferGetManyViewDB{}
+		return db, nil
+	})
+
+	run, err := runBenchmark(BenchConfig{
+		Keys:         257,
+		ValueSize:    16,
+		BatchSize:    64,
+		RangeQueries: 0,
+		RangeSpan:    0,
+		DBsArg:       dbName,
+		TestsArg:     "random_read_batch",
+		KeepDir:      false,
+		Progress:     false,
+		SeedUsed:     1,
+	})
+	if err != nil {
+		t.Fatalf("runBenchmark: %v", err)
+	}
+	if db == nil {
+		t.Fatalf("expected test DB instance")
+	}
+	if db.getCalls != 0 || db.getManyCalls != 0 {
+		t.Fatalf("expected Get/GetMany to be unused when GetManyView is implemented, get=%d getmany=%d", db.getCalls, db.getManyCalls)
+	}
+	if db.getManyViewCalls == 0 {
+		t.Fatalf("expected GetManyView to be called at least once")
+	}
+	got := run.Results["random_read_batch"][db.Name()]
+	if math.IsNaN(got) || got <= 0 {
+		t.Fatalf("expected random_read_batch > 0 for %s, got %v", db.Name(), got)
+	}
+}
+
+func TestRunBenchmark_RandomReadBatch_PropagatesGetManyViewError(t *testing.T) {
+	want := errors.New("getmanyview forced failure")
+	runRandomReadBatchErrorCase(t, "random_read_batch_error_db_getmanyview", func(_ string) (kvstore.DB, error) {
+		return &errorGetManyViewDB{err: want}, nil
+	}, want)
 }
 
 func TestRunBenchmark_RandomReadBatch_PropagatesGetManyError(t *testing.T) {

--- a/kvstore/adapters/treedb/treedb.go
+++ b/kvstore/adapters/treedb/treedb.go
@@ -125,6 +125,22 @@ func (d *DB) GetMany(keys [][]byte) ([][]byte, error) {
 	return vals, err
 }
 
+func (d *DB) GetManyView(keys [][]byte, fn kvstore.MultiGetViewFunc) error {
+	if d == nil || d.DB == nil {
+		return kvstore.ErrUnsupported
+	}
+	if fn == nil {
+		return errors.New("treedb adapter: GetManyView nil callback")
+	}
+	err := d.DB.GetManyView(keys, func(index int, key []byte, value []byte, found bool) error {
+		return fn(index, key, value, found)
+	})
+	if errors.Is(err, treedb.ErrClosed) {
+		return nil
+	}
+	return err
+}
+
 func (d *DB) ReadBatch(keys [][]byte) (retErr error) {
 	if len(keys) == 0 {
 		return nil

--- a/kvstore/kvstore.go
+++ b/kvstore/kvstore.go
@@ -22,10 +22,11 @@ type MultiGetter interface {
 }
 
 // MultiGetViewFunc receives one MultiGetterView result. The callback order is
-// unspecified; the index argument identifies the input key. The value slice is
-// a read-only view that is valid only until the callback returns; callers must
-// copy it before retaining. Missing keys are reported with found=false and
-// value=nil.
+// unspecified and implementations may invoke callbacks concurrently; callers
+// that mutate shared state must synchronize it. The index argument identifies
+// the input key. The value slice is a read-only view that is valid only until
+// the callback returns; callers must copy it before retaining. Missing keys are
+// reported with found=false and value=nil.
 type MultiGetViewFunc func(index int, key []byte, value []byte, found bool) error
 
 // MultiGetterView is an optional lower-allocation batched point-read capability

--- a/kvstore/kvstore.go
+++ b/kvstore/kvstore.go
@@ -21,6 +21,18 @@ type MultiGetter interface {
 	GetMany(keys [][]byte) ([][]byte, error)
 }
 
+// MultiGetViewFunc receives one MultiGetterView result. The value slice is a
+// read-only view that is valid only until the callback returns; callers must
+// copy it before retaining. Missing keys are reported with found=false and
+// value=nil.
+type MultiGetViewFunc func(index int, key []byte, value []byte, found bool) error
+
+// MultiGetterView is an optional lower-allocation batched point-read capability
+// for callers that can consume each value before the callback returns.
+type MultiGetterView interface {
+	GetManyView(keys [][]byte, fn MultiGetViewFunc) error
+}
+
 // BatchReader is an optional capability for batched read execution where
 // callers only need completion/error, not materialized values.
 //

--- a/kvstore/kvstore.go
+++ b/kvstore/kvstore.go
@@ -21,10 +21,12 @@ type MultiGetter interface {
 	GetMany(keys [][]byte) ([][]byte, error)
 }
 
-// MultiGetViewFunc receives one MultiGetterView result. The value slice is a
-// read-only view that is valid only until the callback returns; callers must
-// copy it before retaining. Missing keys are reported with found=false and
-// value=nil.
+// MultiGetViewFunc receives one MultiGetterView result. Callbacks may be
+// invoked in any order and may be invoked concurrently by parallel
+// implementations; callers that mutate shared state must synchronize it. The
+// value slice is a read-only view that is valid only until the callback
+// returns; callers must copy it before retaining. Missing keys are reported
+// with found=false and value=nil.
 type MultiGetViewFunc func(index int, key []byte, value []byte, found bool) error
 
 // MultiGetterView is an optional lower-allocation batched point-read capability

--- a/kvstore/kvstore.go
+++ b/kvstore/kvstore.go
@@ -21,12 +21,11 @@ type MultiGetter interface {
 	GetMany(keys [][]byte) ([][]byte, error)
 }
 
-// MultiGetViewFunc receives one MultiGetterView result. Callbacks may be
-// invoked in any order and may be invoked concurrently by parallel
-// implementations; callers that mutate shared state must synchronize it. The
-// value slice is a read-only view that is valid only until the callback
-// returns; callers must copy it before retaining. Missing keys are reported
-// with found=false and value=nil.
+// MultiGetViewFunc receives one MultiGetterView result. The callback order is
+// unspecified; the index argument identifies the input key. The value slice is
+// a read-only view that is valid only until the callback returns; callers must
+// copy it before retaining. Missing keys are reported with found=false and
+// value=nil.
 type MultiGetViewFunc func(index int, key []byte, value []byte, found bool) error
 
 // MultiGetterView is an optional lower-allocation batched point-read capability


### PR DESCRIPTION
## Summary

- Adds TreeDB `GetManyView` callback/view APIs through tree, backend DB/snapshot/root-reader, cached DB/snapshot, public TreeDB, and the TreeDB kvstore adapter.
- Keeps existing safe-copy `GetMany` behavior unchanged, with explicit view lifetime docs for callback values.
- Updates `random_read_batch` to prefer `MultiGetterView` and updates collection retained document payload fetch to copy callback views into its owned materialization arena.
- Routes cached `GetManyView` backend-only/bypass and backend-fallback branches through `backendGetManyView`; backend DB `GetManyView` uses the existing parallel chunk plan for large batches so the view path avoids backend result-copy materialization without a material throughput regression.
- Preserves #2241 snapshot pooling / backend-snapshot fast-path reader-ref behavior and is current with latest `origin/main` (`b9494fd89`, #2244/#2252) via head `d268c6173`.
- Adds coverage for duplicate/missing/empty/pointer-backed values, callback errors, closed snapshots/DBs, benchmark adapter selection, collection ownership, cached backend-view fallback selection, and #2241/#2244 adjacent cache/snapshot behavior.

Closes #2242

## Tests

Latest head `d268c6173c88f685002539523fe600db7e8c8033` after syncing `origin/main` (`b9494fd89`):

```sh
GOWORK=off go test ./TreeDB/caching ./TreeDB/db ./TreeDB/tree ./kvstore/adapters/treedb ./cmd/unified_bench ./TreeDB/collections ./TreeDB -run 'GetMany|RandomReadBatch|View|Append|Pointer|Duplicate|Missing|SnapshotPool|AcquireSnapshot|appendOnly|AppendOnly|SortedRun|DirectArena' -count=1
GOWORK=off go test -race ./TreeDB/caching -run 'TestAcquireSnapshot_CachedPathConcurrentAcquireCloseWithWrites|GetManyView' -count=1
```

Prior full affected-package validation at head `3488acd32` before the #2244 sync:

```sh
GOWORK=off go test ./TreeDB ./TreeDB/tree ./TreeDB/db ./TreeDB/caching ./TreeDB/collections ./kvstore ./kvstore/adapters/treedb ./cmd/unified_bench -count=1
```

## Benchmark evidence after backend-view fallback fix (`mikers@192.168.0.185`)

Core durable 1M-key unified bench on #2241-synced base vs backend-view fixed head:

- Before (`origin/main` at #2241 = `d9f4c2ae2`): `/home/mikers/tmp/treedb_2242_rebase_before_6yRm7eeX`
- After (`3488acd32`): `/home/mikers/tmp/treedb_2242_backendview_parallel_after_3Jv9eQDm`

| Test | Before | After |
| --- | ---: | ---: |
| Random Read (Batch) | 456,687 ops/sec | 446,960 ops/sec |
| Random Read (Parallel) | 451,466 ops/sec | 438,576 ops/sec |
| Random Read | 187,829 ops/sec | 181,389 ops/sec |

`allocs_random_read_batch_treedb.pprof`:

| Metric | Before | After |
| --- | ---: | ---: |
| Total alloc_space | 456.38 MB | 227.10 MB |
| Root-domain GetMany path | 300.03 MB flat / 315.74 MB cum (`getManyFromPublishedRootPointShards`) | 158.97 MB flat / 158.97 MB cum (`getManyViewFromPublishedRootPointShards`) |
| mmap hit ratio | 1.000000 | 1.000000 |
| fallback ReadAt | 0 | 0 |

The backend-view fix is specifically covered by focused tests that fail if cached `GetManyView` calls backend safe-copy `GetMany` instead of backend `GetManyView`.

Collection materialization benchmark on #2241-synced base vs the earlier post-sync head (`-benchtime=5000x -count=6`; collection path unchanged by the backend-view fallback fix and by the #2244 append-only sync):

- Before: `/home/mikers/tmp/treedb_2242_rebase_collections_before_20260603_110218.txt`
- After: `/home/mikers/tmp/treedb_2242_rebase_collections_after_20260603_110239.txt`
- Benchstat: `/home/mikers/tmp/treedb_2242_rebase_collections_benchstat.txt`

Highlights: geomean `sec/op` -0.72%, geomean `allocs/op` -1.47%, `asset_mmap_hits/fetch=1.000`, `asset_readat_fallbacks/fetch=0`.

Note: #2244/#2252 touched append-only memtable reuse and adjacent cached write/memtable setup code, not the `GetManyView` read API, unified-bench random-read-batch read loop, backend-view fallback routing, or retained-document materialization path measured above. I reran focused GetManyView/snapshot/append-only tests after the sync; a new performance rerun is not required for the read-path claims.