### PR TITLE
TreeDB: reuse append-only sorted-run state

### DIFF
--- a/TreeDB/caching/append_only_batch_direct_arena_test.go
+++ b/TreeDB/caching/append_only_batch_direct_arena_test.go
@@ -1,0 +1,93 @@
+package caching
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestAppendOnlyBatchSetViewCopiesValuesToDirectArenaAcrossMutationAndCheckpoint(t *testing.T) {
+	db, err := Open(t.TempDir(), NewMockBackend(), Options{
+		AllowUnsafe:    true,
+		DisableWAL:     true,
+		MemtableMode:   "append_only",
+		MemtableShards: 1,
+		FlushThreshold: 1 << 30,
+	})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	keyA := []byte("a")
+	keyB := []byte("b")
+	valueA := bytes.Repeat([]byte("A"), 96)
+	valueB := bytes.Repeat([]byte("B"), 96)
+
+	b := db.NewBatchWithSize(2)
+	if err := b.SetView(keyA, valueA); err != nil {
+		t.Fatalf("set view a: %v", err)
+	}
+	if err := b.SetView(keyB, valueB); err != nil {
+		t.Fatalf("set view b: %v", err)
+	}
+	if err := b.Write(); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := b.Close(); err != nil {
+		t.Fatalf("batch close: %v", err)
+	}
+
+	// SetView callers only promise stability until Write/Close returns. The
+	// append-only memtable must own keys and values after that point.
+	keyA[0] = 'x'
+	keyB[0] = 'y'
+	valueA[0] = 'x'
+	valueB[0] = 'y'
+
+	if got := countMutableAppendOnlyDirectArenaActiveChunks(&db.mutableShards[0]); got == 0 {
+		t.Fatalf("expected direct append-only arena chunks for SetView value copies")
+	}
+	gotA, err := db.Get([]byte("a"))
+	if err != nil {
+		t.Fatalf("get a: %v", err)
+	}
+	if !bytes.Equal(gotA, bytes.Repeat([]byte("A"), 96)) {
+		t.Fatalf("mutable value a changed after source mutation: got prefix=%q", gotA[:1])
+	}
+
+	it, err := db.Iterator(nil, nil)
+	if err != nil {
+		t.Fatalf("iterator: %v", err)
+	}
+	iteratorClosed := false
+	defer func() {
+		if !iteratorClosed {
+			_ = it.Close()
+		}
+	}()
+
+	if err := db.Checkpoint(); err != nil {
+		t.Fatalf("checkpoint while iterator open: %v", err)
+	}
+
+	seen := map[string]string{}
+	for it.Valid() {
+		seen[string(it.Key())] = string(it.Value())
+		it.Next()
+	}
+	if seen["a"] != string(bytes.Repeat([]byte("A"), 96)) || seen["b"] != string(bytes.Repeat([]byte("B"), 96)) {
+		t.Fatalf("iterator saw mutated values after checkpoint: %#v", seen)
+	}
+	if err := it.Close(); err != nil {
+		t.Fatalf("iterator close: %v", err)
+	}
+	iteratorClosed = true
+
+	gotB, err := db.Get([]byte("b"))
+	if err != nil {
+		t.Fatalf("get b after checkpoint: %v", err)
+	}
+	if !bytes.Equal(gotB, bytes.Repeat([]byte("B"), 96)) {
+		t.Fatalf("checkpoint value b changed after source mutation: got prefix=%q", gotB[:1])
+	}
+}

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -29836,11 +29836,28 @@ func (b *Batch) writeRegular(syncWrite bool) error {
 						}
 					}
 					appliedSortedRun = true
-				} else if applier, ok := shard.mem.(memtable.CopySortedBatchApplier); ok {
-					if borrowed := applier.ApplyCopySortedBatchTrusted(entries, allowBatchArenaBorrow, storeInlinePtrValues, nil); borrowed {
-						retainMainMems = appendUniqueMemtable(retainMainMems, shard.mem)
+				} else {
+					if !allowBatchArenaBorrow {
+						if applier, ok := shard.mem.(memtable.CopySortedBatchValueCopier); ok {
+							applier.ApplyCopySortedBatchWithValueCopierTrusted(entries, func(value []byte) []byte {
+								if len(value) == 0 {
+									return nil
+								}
+								owned := shard.appendOnlyDirectValueArena.alloc(len(value))
+								copy(owned, value)
+								return owned
+							}, storeInlinePtrValues, nil)
+							appliedSortedRun = true
+						}
 					}
-					appliedSortedRun = true
+					if !appliedSortedRun {
+						if applier, ok := shard.mem.(memtable.CopySortedBatchApplier); ok {
+							if borrowed := applier.ApplyCopySortedBatchTrusted(entries, allowBatchArenaBorrow, storeInlinePtrValues, nil); borrowed {
+								retainMainMems = appendUniqueMemtable(retainMainMems, shard.mem)
+							}
+							appliedSortedRun = true
+						}
+					}
 				}
 			}
 			if !appliedSortedRun {

--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -2,7 +2,6 @@ package memtable
 
 import (
 	"bytes"
-	"container/heap"
 	"encoding/binary"
 	"errors"
 	"math/bits"
@@ -602,35 +601,62 @@ func appendOnlySortedRunValid(run appendOnlySortedRun, count int) bool {
 	return run.start >= 0 && run.start < run.end && run.end <= count
 }
 
-type appendOnlySortedRunHeap struct {
-	active  []appendOnlyEntry
-	cursors []appendOnlySortedRunCursor
-}
-
-func (h appendOnlySortedRunHeap) Len() int { return len(h.cursors) }
-
-func (h appendOnlySortedRunHeap) Less(i, j int) bool {
+func appendOnlySortedRunCursorLess(active []appendOnlyEntry, cursors []appendOnlySortedRunCursor, i, j int) bool {
 	return bytes.Compare(
-		appendOnlyEntryKey(&h.active[h.cursors[i].idx]),
-		appendOnlyEntryKey(&h.active[h.cursors[j].idx]),
+		appendOnlyEntryKey(&active[cursors[i].idx]),
+		appendOnlyEntryKey(&active[cursors[j].idx]),
 	) < 0
 }
 
-func (h appendOnlySortedRunHeap) Swap(i, j int) {
-	h.cursors[i], h.cursors[j] = h.cursors[j], h.cursors[i]
+func appendOnlySortedRunCursorDown(active []appendOnlyEntry, cursors []appendOnlySortedRunCursor, i, n int) bool {
+	orig := i
+	for {
+		child := 2*i + 1
+		if child >= n || child < 0 {
+			break
+		}
+		if right := child + 1; right < n && appendOnlySortedRunCursorLess(active, cursors, right, child) {
+			child = right
+		}
+		if !appendOnlySortedRunCursorLess(active, cursors, child, i) {
+			break
+		}
+		cursors[i], cursors[child] = cursors[child], cursors[i]
+		i = child
+	}
+	return i > orig
 }
 
-func (h *appendOnlySortedRunHeap) Push(x any) {
-	h.cursors = append(h.cursors, x.(appendOnlySortedRunCursor))
+func appendOnlySortedRunCursorUp(active []appendOnlyEntry, cursors []appendOnlySortedRunCursor, i int) {
+	for i > 0 {
+		parent := (i - 1) / 2
+		if !appendOnlySortedRunCursorLess(active, cursors, i, parent) {
+			break
+		}
+		cursors[parent], cursors[i] = cursors[i], cursors[parent]
+		i = parent
+	}
 }
 
-func (h *appendOnlySortedRunHeap) Pop() any {
-	old := h.cursors
-	n := len(old)
-	out := old[n-1]
-	old[n-1] = appendOnlySortedRunCursor{}
-	h.cursors = old[:n-1]
-	return out
+func appendOnlySortedRunCursorHeapInit(active []appendOnlyEntry, cursors []appendOnlySortedRunCursor) {
+	for i := len(cursors)/2 - 1; i >= 0; i-- {
+		appendOnlySortedRunCursorDown(active, cursors, i, len(cursors))
+	}
+}
+
+func appendOnlySortedRunCursorHeapPop(active []appendOnlyEntry, cursors []appendOnlySortedRunCursor) (appendOnlySortedRunCursor, []appendOnlySortedRunCursor) {
+	n := len(cursors) - 1
+	cursors[0], cursors[n] = cursors[n], cursors[0]
+	appendOnlySortedRunCursorDown(active, cursors, 0, n)
+	out := cursors[n]
+	cursors[n] = appendOnlySortedRunCursor{}
+	return out, cursors[:n]
+}
+
+func appendOnlySortedRunCursorHeapPush(active []appendOnlyEntry, cursors []appendOnlySortedRunCursor, cursor appendOnlySortedRunCursor) []appendOnlySortedRunCursor {
+	cursors = append(cursors, cursor)
+	appendOnlySortedRunCursorUp(active, cursors, len(cursors)-1)
+	return cursors
 }
 
 func entryValueSize(flags byte, value []byte) int {
@@ -740,20 +766,20 @@ func (m *AppendOnly) forEachSortedRunLatestLocked(visit func(*appendOnlyEntry)) 
 		m.runCursorBuf = cursors[:0]
 		return
 	}
-	h := appendOnlySortedRunHeap{active: active, cursors: cursors}
-	heap.Init(&h)
+	appendOnlySortedRunCursorHeapInit(active, cursors)
 	popped := m.runMergeBuf[:0]
-	for h.Len() > 0 {
-		first := heap.Pop(&h).(appendOnlySortedRunCursor)
+	for len(cursors) > 0 {
+		var first appendOnlySortedRunCursor
+		first, cursors = appendOnlySortedRunCursorHeapPop(active, cursors)
 		key := appendOnlyEntryKey(&active[first.idx])
 		chosen := first
 		popped = append(popped[:0], first)
-		for h.Len() > 0 {
-			next := h.cursors[0]
+		for len(cursors) > 0 {
+			next := cursors[0]
 			if !bytes.Equal(appendOnlyEntryKey(&active[next.idx]), key) {
 				break
 			}
-			next = heap.Pop(&h).(appendOnlySortedRunCursor)
+			next, cursors = appendOnlySortedRunCursorHeapPop(active, cursors)
 			if next.run > chosen.run {
 				chosen = next
 			}
@@ -763,11 +789,11 @@ func (m *AppendOnly) forEachSortedRunLatestLocked(visit func(*appendOnlyEntry)) 
 		for _, cursor := range popped {
 			cursor.idx++
 			if cursor.idx < cursor.end {
-				heap.Push(&h, cursor)
+				cursors = appendOnlySortedRunCursorHeapPush(active, cursors, cursor)
 			}
 		}
 	}
-	m.runCursorBuf = h.cursors[:0]
+	m.runCursorBuf = cursors[:0]
 	m.runMergeBuf = popped[:0]
 }
 

--- a/TreeDB/internal/memtable/append_only.go
+++ b/TreeDB/internal/memtable/append_only.go
@@ -2,6 +2,7 @@ package memtable
 
 import (
 	"bytes"
+	"container/heap"
 	"encoding/binary"
 	"errors"
 	"math/bits"
@@ -41,6 +42,7 @@ const (
 	appendOnlyValueArenaPoolMaxCap      = 1 << appendOnlyValueArenaMaxShift
 	appendOnlyValueArenaRetainMaxCap    = 4 << 20
 	appendOnlyValueArenaRetainChunks    = 128
+	appendOnlySortedRunMaxCount         = 256
 	appendOnlyReuseOversizeFactor       = 4
 	appendOnlyResetDropThresholdEntries = 1 << 15
 	appendOnlyAggressiveGrowCutoff      = appendOnlyResetDropThresholdEntries * 2
@@ -71,6 +73,17 @@ type appendOnlyValueArena struct {
 	curPos    int
 }
 
+type appendOnlySortedRun struct {
+	start int
+	end   int
+}
+
+type appendOnlySortedRunCursor struct {
+	run int
+	idx int
+	end int
+}
+
 type appendOnlyKeyArena struct {
 	chunks [][]byte
 	cur    []byte
@@ -85,6 +98,9 @@ type AppendOnly struct {
 	orderedKey64   []uint64
 	latest         map[string]int
 	latest64       map[uint64]int
+	sortedRuns     []appendOnlySortedRun
+	runCursorBuf   []appendOnlySortedRunCursor
+	runMergeBuf    []appendOnlySortedRunCursor
 	snapshot       []*appendOnlyEntry
 	indexBuf       []int
 	keyArena       appendOnlyKeyArena
@@ -582,6 +598,41 @@ func appendOnlyKeyU64(key []byte) (uint64, bool) {
 	return binary.BigEndian.Uint64(key), true
 }
 
+func appendOnlySortedRunValid(run appendOnlySortedRun, count int) bool {
+	return run.start >= 0 && run.start < run.end && run.end <= count
+}
+
+type appendOnlySortedRunHeap struct {
+	active  []appendOnlyEntry
+	cursors []appendOnlySortedRunCursor
+}
+
+func (h appendOnlySortedRunHeap) Len() int { return len(h.cursors) }
+
+func (h appendOnlySortedRunHeap) Less(i, j int) bool {
+	return bytes.Compare(
+		appendOnlyEntryKey(&h.active[h.cursors[i].idx]),
+		appendOnlyEntryKey(&h.active[h.cursors[j].idx]),
+	) < 0
+}
+
+func (h appendOnlySortedRunHeap) Swap(i, j int) {
+	h.cursors[i], h.cursors[j] = h.cursors[j], h.cursors[i]
+}
+
+func (h *appendOnlySortedRunHeap) Push(x any) {
+	h.cursors = append(h.cursors, x.(appendOnlySortedRunCursor))
+}
+
+func (h *appendOnlySortedRunHeap) Pop() any {
+	old := h.cursors
+	n := len(old)
+	out := old[n-1]
+	old[n-1] = appendOnlySortedRunCursor{}
+	h.cursors = old[:n-1]
+	return out
+}
+
 func entryValueSize(flags byte, value []byte) int {
 	if flags&node.FlagPointer != 0 {
 		return page.ValuePtrSize + len(value)
@@ -599,9 +650,171 @@ func (m *AppendOnly) clearSnapshotLocked() {
 	m.snapCount = 0
 }
 
+func (m *AppendOnly) clearSortedRunsLocked() {
+	if m.sortedRuns != nil {
+		m.sortedRuns = m.sortedRuns[:0]
+	}
+	if m.runCursorBuf != nil {
+		m.runCursorBuf = m.runCursorBuf[:0]
+	}
+	if m.runMergeBuf != nil {
+		m.runMergeBuf = m.runMergeBuf[:0]
+	}
+}
+
+func (m *AppendOnly) initSortedRunsAfterOrderBreakLocked(idx int) {
+	m.clearSortedRunsLocked()
+	if idx > 0 {
+		m.sortedRuns = append(m.sortedRuns, appendOnlySortedRun{start: 0, end: idx})
+	}
+	m.sortedRuns = append(m.sortedRuns, appendOnlySortedRun{start: idx, end: idx + 1})
+	m.latestDirty = false
+	m.clearSnapshotLocked()
+}
+
+func (m *AppendOnly) extendSortedRunsLocked(idx int, key []byte) {
+	if len(m.sortedRuns) == 0 {
+		return
+	}
+	last := &m.sortedRuns[len(m.sortedRuns)-1]
+	if appendOnlySortedRunValid(*last, idx) {
+		prev := appendOnlyEntryKey(&m.entries[last.end-1])
+		if bytes.Compare(key, prev) > 0 && last.end == idx {
+			last.end = idx + 1
+			m.latestDirty = false
+			m.clearSnapshotLocked()
+			return
+		}
+	}
+	m.sortedRuns = append(m.sortedRuns, appendOnlySortedRun{start: idx, end: idx + 1})
+	m.latestDirty = false
+	m.clearSnapshotLocked()
+	if len(m.sortedRuns) > appendOnlySortedRunMaxCount {
+		// Arbitrary point-write streams can create one run per write. Fall back to
+		// the hash latest-index once the run table stops being a compact sorted-run
+		// description; sorted batch workloads normally stay at one or two runs and
+		// avoid this rebuild on the ingest path.
+		m.rebuildLatestIndexLocked()
+	}
+}
+
+func (m *AppendOnly) lookupSortedRunsEntryLocked(key []byte) *appendOnlyEntry {
+	if len(m.sortedRuns) == 0 || m.count == 0 {
+		return nil
+	}
+	active := m.entries[:m.count]
+	for runIdx := len(m.sortedRuns) - 1; runIdx >= 0; runIdx-- {
+		run := m.sortedRuns[runIdx]
+		if !appendOnlySortedRunValid(run, len(active)) {
+			continue
+		}
+		base := run.start
+		n := run.end - run.start
+		pos := sort.Search(n, func(i int) bool {
+			return bytes.Compare(appendOnlyEntryKey(&active[base+i]), key) >= 0
+		})
+		if pos >= n {
+			continue
+		}
+		ent := &active[base+pos]
+		if bytes.Equal(appendOnlyEntryKey(ent), key) {
+			return ent
+		}
+	}
+	return nil
+}
+
+func (m *AppendOnly) forEachSortedRunLatestLocked(visit func(*appendOnlyEntry)) {
+	if len(m.sortedRuns) == 0 || m.count == 0 || visit == nil {
+		return
+	}
+	active := m.entries[:m.count]
+	cursors := m.runCursorBuf[:0]
+	for runIdx, run := range m.sortedRuns {
+		if !appendOnlySortedRunValid(run, len(active)) {
+			continue
+		}
+		cursors = append(cursors, appendOnlySortedRunCursor{run: runIdx, idx: run.start, end: run.end})
+	}
+	if len(cursors) == 0 {
+		m.runCursorBuf = cursors[:0]
+		return
+	}
+	h := appendOnlySortedRunHeap{active: active, cursors: cursors}
+	heap.Init(&h)
+	popped := m.runMergeBuf[:0]
+	for h.Len() > 0 {
+		first := heap.Pop(&h).(appendOnlySortedRunCursor)
+		key := appendOnlyEntryKey(&active[first.idx])
+		chosen := first
+		popped = append(popped[:0], first)
+		for h.Len() > 0 {
+			next := h.cursors[0]
+			if !bytes.Equal(appendOnlyEntryKey(&active[next.idx]), key) {
+				break
+			}
+			next = heap.Pop(&h).(appendOnlySortedRunCursor)
+			if next.run > chosen.run {
+				chosen = next
+			}
+			popped = append(popped, next)
+		}
+		visit(&active[chosen.idx])
+		for _, cursor := range popped {
+			cursor.idx++
+			if cursor.idx < cursor.end {
+				heap.Push(&h, cursor)
+			}
+		}
+	}
+	m.runCursorBuf = h.cursors[:0]
+	m.runMergeBuf = popped[:0]
+}
+
+func (m *AppendOnly) buildSortedRunLatestSnapshotLocked() []*appendOnlyEntry {
+	if len(m.sortedRuns) == 0 || m.count == 0 {
+		return nil
+	}
+	if m.snapshot != nil && m.snapCount == m.count {
+		return m.snapshot
+	}
+	snapshot := m.snapshot
+	if cap(snapshot) < m.count {
+		snapshot = make([]*appendOnlyEntry, m.count)
+	} else {
+		snapshot = snapshot[:m.count]
+	}
+	used := 0
+	m.forEachSortedRunLatestLocked(func(ent *appendOnlyEntry) {
+		snapshot[used] = ent
+		used++
+	})
+	clear(snapshot[used:])
+	snapshot = snapshot[:used]
+	m.snapshot = snapshot
+	m.snapCount = m.count
+	return snapshot
+}
+
+func (m *AppendOnly) buildSortedRunIteratorEntriesLocked() []appendOnlyEntry {
+	if len(m.sortedRuns) == 0 || m.count == 0 {
+		return getAppendOnlyIteratorEntries(0)
+	}
+	entries := getAppendOnlyIteratorEntries(m.count)
+	used := 0
+	m.forEachSortedRunLatestLocked(func(ent *appendOnlyEntry) {
+		entries[used] = *ent
+		used++
+	})
+	return entries[:used]
+}
+
 func (m *AppendOnly) buildSortedLatestIndicesLocked() []int {
 	if m.count == 0 || m.ordered {
 		return nil
+	}
+	if len(m.sortedRuns) > 0 {
+		m.rebuildLatestIndexLocked()
 	}
 	if m.latestDirty || (len(m.latest) == 0 && len(m.latest64) == 0) {
 		m.rebuildLatestIndexLocked()
@@ -634,6 +847,7 @@ func (m *AppendOnly) buildSortedLatestIndicesLocked() []int {
 }
 
 func (m *AppendOnly) rebuildLatestIndexLocked() {
+	m.clearSortedRunsLocked()
 	if m.count == 0 {
 		if m.latest != nil {
 			clear(m.latest)
@@ -756,13 +970,11 @@ func (m *AppendOnly) appendEntryLocked(key, value []byte, ptr page.ValuePtr, fla
 			return ent
 		}
 		m.ordered = false
-		// Once order breaks, invalidate the cached snapshot state and
-		// materialize the latest-key index immediately so subsequent unordered
-		// appends can maintain it incrementally instead of forcing the next
-		// iterator/lookup to rebuild the full map from scratch.
-		// rebuildLatestIndexLocked clears the cached snapshot as part of the
-		// transition.
-		m.rebuildLatestIndexLocked()
+		m.initSortedRunsAfterOrderBreakLocked(idx)
+		return ent
+	}
+	if len(m.sortedRuns) > 0 {
+		m.extendSortedRunsLocked(idx, k)
 		return ent
 	}
 	if !m.latestDirty {
@@ -921,6 +1133,37 @@ func (m *AppendOnly) ApplyCopySortedBatchTrusted(entries []batchpkg.Entry, borro
 	return borrowedValues
 }
 
+func (m *AppendOnly) ApplyCopySortedBatchWithValueCopierTrusted(entries []batchpkg.Entry, copyValue func(value []byte) []byte, storeInlinePtrValues bool, onKey func(key []byte)) bool {
+	if len(entries) == 0 {
+		return false
+	}
+	copiedValues := false
+	m.mu.Lock()
+	trustedOrdered := m.canAppendTrustedSortedBatchLocked(entries)
+	for i := range entries {
+		op := entries[i]
+		value, ptr, flags := appendOnlyBatchEntryPayload(op, storeInlinePtrValues)
+		borrowValue := false
+		if len(value) > 0 && copyValue != nil {
+			if copied := copyValue(value); len(copied) == len(value) {
+				value = copied
+				borrowValue = true
+				copiedValues = true
+			}
+		}
+		if trustedOrdered {
+			m.appendEntryTrustedOrderedLocked(op.Key, value, ptr, flags, false, borrowValue)
+		} else {
+			m.appendEntryLocked(op.Key, value, ptr, flags, false, borrowValue)
+		}
+		if onKey != nil {
+			onKey(op.Key)
+		}
+	}
+	m.mu.Unlock()
+	return copiedValues
+}
+
 func (m *AppendOnly) ApplyStealEntryFunc(count int, emit func(i int) (key, value []byte, ptr page.ValuePtr, flags byte, err error)) error {
 	if count <= 0 {
 		return nil
@@ -1032,6 +1275,13 @@ func (m *AppendOnly) getEntryFrozen(key []byte) ([]byte, page.ValuePtr, byte, bo
 		}
 		return ent.value, ent.ptr, ent.flags, true, true
 	}
+	if len(m.sortedRuns) > 0 {
+		ent := m.lookupSortedRunsEntryLocked(key)
+		if ent == nil {
+			return nil, page.ValuePtr{}, 0, false, true
+		}
+		return ent.value, ent.ptr, ent.flags, true, true
+	}
 	if m.latestDirty {
 		return nil, page.ValuePtr{}, 0, false, false
 	}
@@ -1079,6 +1329,20 @@ func (m *AppendOnly) Get(key []byte) ([]byte, bool, bool) {
 			return val, false, true
 		}
 		if m.ordered {
+			m.mu.RUnlock()
+			return nil, false, false
+		}
+
+		if len(m.sortedRuns) > 0 {
+			if ent := m.lookupSortedRunsEntryLocked(key); ent != nil {
+				deleted := ent.flags&node.FlagTombstone != 0
+				val := ent.value
+				m.mu.RUnlock()
+				if deleted {
+					return nil, true, true
+				}
+				return val, false, true
+			}
 			m.mu.RUnlock()
 			return nil, false, false
 		}
@@ -1143,6 +1407,18 @@ func (m *AppendOnly) GetEntry(key []byte) ([]byte, page.ValuePtr, byte, bool) {
 			return val, ptr, flags, true
 		}
 		if m.ordered {
+			m.mu.RUnlock()
+			return nil, page.ValuePtr{}, 0, false
+		}
+
+		if len(m.sortedRuns) > 0 {
+			if ent := m.lookupSortedRunsEntryLocked(key); ent != nil {
+				val := ent.value
+				ptr := ent.ptr
+				flags := ent.flags
+				m.mu.RUnlock()
+				return val, ptr, flags, true
+			}
 			m.mu.RUnlock()
 			return nil, page.ValuePtr{}, 0, false
 		}
@@ -1286,6 +1562,9 @@ func (m *AppendOnly) Release() {
 	m.orderedKey64 = nil
 	m.latest = nil
 	m.latest64 = nil
+	m.sortedRuns = nil
+	m.runCursorBuf = nil
+	m.runMergeBuf = nil
 	m.snapshot = nil
 	m.indexBuf = nil
 	m.keyArena.reset()
@@ -1380,6 +1659,7 @@ func (m *AppendOnly) resetLockedWithPolicy(capacity, estimatedBytesPerEntry int,
 		clear(m.latest)
 		clear(m.latest64)
 	}
+	m.clearSortedRunsLocked()
 	// Snapshot/index buffers are only needed for unordered memtables; drop large
 	// ones on reset to keep post-spike memory bounded.
 	if !retainObserved || (cap(m.snapshot) > 0 && cap(m.snapshot) >= appendOnlyResetDropThresholdEntries) {
@@ -1441,6 +1721,9 @@ func (m *AppendOnly) buildSortedLatestSnapshotLocked() []*appendOnlyEntry {
 	if m.ordered {
 		return nil
 	}
+	if len(m.sortedRuns) > 0 {
+		return m.buildSortedRunLatestSnapshotLocked()
+	}
 	if m.snapshot != nil && m.snapCount == m.count {
 		return m.snapshot
 	}
@@ -1465,6 +1748,11 @@ func (m *AppendOnly) buildMutableSortedIteratorEntriesLocked() []appendOnlyEntry
 	if m.count == 0 {
 		m.clearSnapshotLocked()
 		return getAppendOnlyIteratorEntries(0)
+	}
+	if len(m.sortedRuns) > 0 {
+		entries := m.buildSortedRunIteratorEntriesLocked()
+		m.clearSnapshotLocked()
+		return entries
 	}
 	indices := m.buildSortedLatestIndicesLocked()
 	active := m.entries[:m.count]

--- a/TreeDB/internal/memtable/append_only_pool_test.go
+++ b/TreeDB/internal/memtable/append_only_pool_test.go
@@ -366,7 +366,7 @@ func TestAppendOnlyResetRetainedArenaBounded(t *testing.T) {
 	}
 }
 
-func TestAppendOnlyUnorderedAppendBuildsLatestIndexImmediately(t *testing.T) {
+func TestAppendOnlyUnorderedAppendUsesSortedRunIndexBeforeHashFallback(t *testing.T) {
 	m := NewAppendOnlyWithCapacity(0)
 	m.Set([]byte("b"), []byte("v1"))
 	m.Set([]byte("a"), []byte("v2")) // force unordered path
@@ -374,7 +374,13 @@ func TestAppendOnlyUnorderedAppendBuildsLatestIndexImmediately(t *testing.T) {
 		t.Fatalf("expected unordered memtable")
 	}
 	if m.latestDirty {
-		t.Fatalf("expected latest index to stay clean after order break")
+		t.Fatalf("expected sorted-run index to keep latest lookups clean after order break")
+	}
+	if got := len(m.sortedRuns); got != 2 {
+		t.Fatalf("sorted run count after order break=%d want=2", got)
+	}
+	if got := len(m.latest) + len(m.latest64); got != 0 {
+		t.Fatalf("hash latest index len after order break=%d want=0", got)
 	}
 
 	it := m.NewIterator(nil, nil)
@@ -382,7 +388,7 @@ func TestAppendOnlyUnorderedAppendBuildsLatestIndexImmediately(t *testing.T) {
 		t.Fatalf("iterator close: %v", err)
 	}
 	if m.latestDirty {
-		t.Fatalf("expected iterator snapshot build to refresh latest index")
+		t.Fatalf("expected iterator snapshot build to keep sorted-run index clean")
 	}
 	if m.snapCount != 0 {
 		t.Fatalf("expected mutable unordered iterator to avoid caching snapshot; got snapCount=%d", m.snapCount)
@@ -393,7 +399,7 @@ func TestAppendOnlyUnorderedAppendBuildsLatestIndexImmediately(t *testing.T) {
 
 	m.Set([]byte("b"), []byte("v3"))
 	if m.latestDirty {
-		t.Fatalf("expected unordered append to keep latest index clean")
+		t.Fatalf("expected unordered append to keep sorted-run index clean")
 	}
 	if m.snapCount != 0 {
 		t.Fatalf("expected snapshot invalidation after append; got snapCount=%d", m.snapCount)
@@ -412,17 +418,16 @@ func TestAppendOnlyUnorderedAppendBuildsLatestIndexImmediately(t *testing.T) {
 		t.Fatalf("iterator close after append: %v", err)
 	}
 	if m.latestDirty {
-		t.Fatalf("expected latest index rebuild on second iterator snapshot")
+		t.Fatalf("expected second iterator snapshot to keep sorted-run index clean")
 	}
 	if m.snapCount != 0 {
 		t.Fatalf("expected mutable unordered iterator to keep shared snapshot uncached after rebuild; got snapCount=%d", m.snapCount)
 	}
-	idx, ok := m.latest[appendOnlyKeyString([]byte("b"))]
-	if !ok {
-		t.Fatalf("missing latest index entry for key b")
+	if got := len(m.latest) + len(m.latest64); got != 0 {
+		t.Fatalf("hash latest index len after sorted-run iterator=%d want=0", got)
 	}
-	if idx != 2 {
-		t.Fatalf("latest index for key b=%d want=2", idx)
+	if got := len(m.sortedRuns); got != 2 {
+		t.Fatalf("sorted run count after append=%d want=2", got)
 	}
 }
 
@@ -434,7 +439,7 @@ func TestAppendOnlyUnorderedReverseIteratorDoesNotCacheSharedSnapshot(t *testing
 		t.Fatalf("expected unordered memtable")
 	}
 	if m.latestDirty {
-		t.Fatalf("expected latest index to stay clean after order break")
+		t.Fatalf("expected sorted-run index to stay clean after order break")
 	}
 
 	it := m.NewReverseIterator(nil, nil)
@@ -442,7 +447,7 @@ func TestAppendOnlyUnorderedReverseIteratorDoesNotCacheSharedSnapshot(t *testing
 		t.Fatalf("reverse iterator close: %v", err)
 	}
 	if m.latestDirty {
-		t.Fatalf("expected reverse iterator snapshot build to refresh latest index")
+		t.Fatalf("expected reverse iterator snapshot build to keep sorted-run index clean")
 	}
 	if m.snapCount != 0 {
 		t.Fatalf("expected mutable unordered reverse iterator to avoid caching snapshot; got snapCount=%d", m.snapCount)
@@ -453,7 +458,7 @@ func TestAppendOnlyUnorderedReverseIteratorDoesNotCacheSharedSnapshot(t *testing
 
 	m.Set([]byte("b"), []byte("v3"))
 	if m.latestDirty {
-		t.Fatalf("expected unordered append to keep latest index clean")
+		t.Fatalf("expected unordered append to keep sorted-run index clean")
 	}
 	if m.snapCount != 0 {
 		t.Fatalf("expected snapshot invalidation after append; got snapCount=%d", m.snapCount)
@@ -464,13 +469,16 @@ func TestAppendOnlyUnorderedReverseIteratorDoesNotCacheSharedSnapshot(t *testing
 		t.Fatalf("reverse iterator close after append: %v", err)
 	}
 	if m.latestDirty {
-		t.Fatalf("expected latest index rebuild on second reverse iterator snapshot")
+		t.Fatalf("expected second reverse iterator snapshot to keep sorted-run index clean")
 	}
 	if m.snapCount != 0 {
 		t.Fatalf("expected mutable unordered reverse iterator to keep shared snapshot uncached after rebuild; got snapCount=%d", m.snapCount)
 	}
 	if m.snapshot != nil {
 		t.Fatalf("expected mutable unordered reverse iterator to keep shared snapshot nil after rebuild")
+	}
+	if got := len(m.latest) + len(m.latest64); got != 0 {
+		t.Fatalf("hash latest index len after reverse sorted-run iterator=%d want=0", got)
 	}
 }
 

--- a/TreeDB/internal/memtable/append_only_sorted_batch_test.go
+++ b/TreeDB/internal/memtable/append_only_sorted_batch_test.go
@@ -48,6 +48,33 @@ func TestAppendOnlyApplyCopySortedBatchTrusted_AppendKeepsOrderedAndCopiesKeys(t
 	}
 }
 
+func TestAppendOnlyApplyCopySortedBatchWithValueCopierOwnsValues(t *testing.T) {
+	m := NewAppendOnlyWithCapacity(0)
+	key := []byte("a")
+	value := []byte("mutable-value")
+	var copiedBacking [][]byte
+	copied := m.ApplyCopySortedBatchWithValueCopierTrusted([]batchpkg.Entry{{
+		Type:  batchpkg.OpPut,
+		Key:   key,
+		Value: value,
+	}}, func(src []byte) []byte {
+		dst := append([]byte(nil), src...)
+		copiedBacking = append(copiedBacking, dst)
+		return dst
+	}, true, nil)
+	if !copied {
+		t.Fatalf("copied=false, want true")
+	}
+	key[0] = 'z'
+	value[0] = 'X'
+	if len(copiedBacking) != 1 || string(copiedBacking[0]) != "mutable-value" {
+		t.Fatalf("copied backing mutated or missing: %q", copiedBacking)
+	}
+	if got, deleted, ok := m.Get([]byte("a")); !ok || deleted || string(got) != "mutable-value" {
+		t.Fatalf("Get(a)=(%q,%v,%v), want copied immutable value", string(got), deleted, ok)
+	}
+}
+
 func TestAppendOnlyApplyCopySortedBatchTrusted_PointerInlinePolicy(t *testing.T) {
 	ptr := page.ValuePtr{FileID: 42, Offset: 7, Length: 3}
 
@@ -76,7 +103,7 @@ func TestAppendOnlyApplyCopySortedBatchTrusted_PointerInlinePolicy(t *testing.T)
 	}
 }
 
-func TestAppendOnlyApplyCopySortedBatchTrusted_OverlappingSortedRunFallsBack(t *testing.T) {
+func TestAppendOnlyApplyCopySortedBatchTrusted_OverlappingSortedRunUsesRunIndex(t *testing.T) {
 	m := NewAppendOnlyWithCapacity(0)
 	m.Set([]byte("m"), []byte("old"))
 
@@ -96,12 +123,20 @@ func TestAppendOnlyApplyCopySortedBatchTrusted_OverlappingSortedRunFallsBack(t *
 	m.mu.RLock()
 	ordered := m.ordered
 	latestDirty := m.latestDirty
+	runCount := len(m.sortedRuns)
+	latestLen := len(m.latest) + len(m.latest64)
 	m.mu.RUnlock()
 	if ordered {
 		t.Fatalf("ordered=true after sorted run overlapped existing max key")
 	}
 	if latestDirty {
-		t.Fatalf("latestDirty=true after fallback; latest index should be immediately usable")
+		t.Fatalf("latestDirty=true after sorted-run index; latest lookup should be immediately usable")
+	}
+	if runCount != 2 {
+		t.Fatalf("sorted run count=%d want 2", runCount)
+	}
+	if latestLen != 0 {
+		t.Fatalf("hash latest index len=%d want 0 before fallback", latestLen)
 	}
 }
 
@@ -132,12 +167,19 @@ func TestAppendOnlyKey64MonotonicOrderingMatchesLexicographic(t *testing.T) {
 	m.mu.RLock()
 	ordered = m.ordered
 	latestDirty := m.latestDirty
-	_, latest64OK := m.latest64[binary.BigEndian.Uint64(lo[:])]
+	runCount := len(m.sortedRuns)
+	latestLen = len(m.latest) + len(m.latest64)
 	m.mu.RUnlock()
 	if ordered {
 		t.Fatalf("ordered=true after lower 8-byte key append")
 	}
-	if latestDirty || !latest64OK {
-		t.Fatalf("latest64 not ready after key64 order break: dirty=%v ok=%v", latestDirty, latest64OK)
+	if latestDirty {
+		t.Fatalf("latestDirty=true after key64 sorted-run order break")
+	}
+	if runCount != 2 {
+		t.Fatalf("sorted run count=%d want 2", runCount)
+	}
+	if latestLen != 0 {
+		t.Fatalf("hash latest index len=%d want 0 before fallback", latestLen)
 	}
 }

--- a/TreeDB/internal/memtable/append_only_test.go
+++ b/TreeDB/internal/memtable/append_only_test.go
@@ -257,6 +257,90 @@ func TestAppendOnlyIteratorSortedLatest(t *testing.T) {
 	}
 }
 
+func TestAppendOnlySortedRunsFrozenLookupsIteratorDuplicatesAndTombstones(t *testing.T) {
+	m := NewAppendOnlyWithCapacity(0)
+	m.Set([]byte("k3"), []byte("old3"))
+	m.Set([]byte("k1"), []byte("old1")) // order break: [k3], [k1]
+	m.Set([]byte("k2"), []byte("v2"))   // extends second sorted run
+	m.Set([]byte("k1"), []byte("new1")) // duplicate starts a newer run
+	m.Delete([]byte("k3"))              // tombstone extends duplicate run
+
+	if m.ordered {
+		t.Fatalf("expected unordered sorted-run state")
+	}
+	if got := len(m.sortedRuns); got != 3 {
+		t.Fatalf("sorted run count=%d want=3", got)
+	}
+	if got := len(m.latest) + len(m.latest64); got != 0 {
+		t.Fatalf("hash latest index len=%d want 0 before fallback", got)
+	}
+
+	m.Freeze()
+	if got, del, ok := m.Get([]byte("k1")); !ok || del || string(got) != "new1" {
+		t.Fatalf("frozen Get(k1)=(%q,%v,%v), want (new1,false,true)", string(got), del, ok)
+	}
+	if got, del, ok := m.Get([]byte("k3")); !ok || !del || got != nil {
+		t.Fatalf("frozen Get(k3)=(%v,%v,%v), want tombstone", got, del, ok)
+	}
+	if got, ptr, flags, ok := m.GetEntry([]byte("k2")); !ok || string(got) != "v2" || ptr != (page.ValuePtr{}) || flags != node.FlagInline {
+		t.Fatalf("frozen GetEntry(k2)=(%q,%+v,%d,%v), want (v2,zero,%d,true)", string(got), ptr, flags, ok, node.FlagInline)
+	}
+
+	it := m.NewIterator(nil, nil)
+	defer func() { _ = it.Close() }()
+	want := []struct {
+		key     string
+		value   string
+		deleted bool
+	}{
+		{key: "k1", value: "new1"},
+		{key: "k2", value: "v2"},
+		{key: "k3", deleted: true},
+	}
+	for i, w := range want {
+		if !it.Valid() {
+			t.Fatalf("iterator ended at %d", i)
+		}
+		if got := string(it.Key()); got != w.key {
+			t.Fatalf("iterator key[%d]=%q want %q", i, got, w.key)
+		}
+		if got := it.IsDeleted(); got != w.deleted {
+			t.Fatalf("iterator deleted[%d]=%v want %v", i, got, w.deleted)
+		}
+		if !w.deleted && string(it.Value()) != w.value {
+			t.Fatalf("iterator value[%d]=%q want %q", i, string(it.Value()), w.value)
+		}
+		it.Next()
+	}
+	if it.Valid() {
+		t.Fatalf("iterator has extra key %q", string(it.Key()))
+	}
+}
+
+func TestAppendOnlySortedRunsFallbackBuildsHashIndexAfterRunCap(t *testing.T) {
+	m := NewAppendOnlyWithCapacity(0)
+	for i := 0; i < appendOnlySortedRunMaxCount+2; i++ {
+		v := appendOnlySortedRunMaxCount + 2 - i
+		key := []byte{byte(v >> 8), byte(v)}
+		m.Set(key, []byte{byte(i)})
+	}
+	m.mu.RLock()
+	runCount := len(m.sortedRuns)
+	latestDirty := m.latestDirty
+	latestLen := len(m.latest) + len(m.latest64)
+	count := m.count
+	m.mu.RUnlock()
+	if runCount != 0 {
+		t.Fatalf("sorted run count after cap fallback=%d want 0", runCount)
+	}
+	if latestDirty {
+		t.Fatalf("latestDirty=true after cap fallback")
+	}
+	if latestLen != count {
+		t.Fatalf("latest index len=%d want count=%d", latestLen, count)
+	}
+}
+
 func TestAppendOnlyResetClearsLatestIndex(t *testing.T) {
 	m := NewAppendOnlyWithCapacity(0)
 	m.Set([]byte("k1"), []byte("v1"))
@@ -432,30 +516,15 @@ func TestAppendOnlyPreferSortedPointProbesForSparseFrozenBatches(t *testing.T) {
 	}
 }
 
-func TestAppendOnlyGetBuildsLatestIndexOnFirstPointRead(t *testing.T) {
+func TestAppendOnlyGetUsesSortedRunsAfterOrderBreak(t *testing.T) {
 	keyKinds := []struct {
-		name       string
-		makeKey    func(v uint64) []byte
-		latestIdx  func(m *AppendOnly, key []byte) (idx int, ok bool)
-		latestSize func(m *AppendOnly) int
+		name    string
+		makeKey func(v uint64) []byte
 	}{
 		{
 			name: "non-8-byte",
 			makeKey: func(v uint64) []byte {
 				return []byte{byte('a' + v)}
-			},
-			latestIdx: func(m *AppendOnly, key []byte) (int, bool) {
-				if m.latest == nil {
-					return 0, false
-				}
-				idx, ok := m.latest[appendOnlyKeyString(key)]
-				return idx, ok
-			},
-			latestSize: func(m *AppendOnly) int {
-				if m.latest == nil {
-					return 0
-				}
-				return len(m.latest)
 			},
 		},
 		{
@@ -464,20 +533,6 @@ func TestAppendOnlyGetBuildsLatestIndexOnFirstPointRead(t *testing.T) {
 				k := make([]byte, 8)
 				binary.BigEndian.PutUint64(k, v)
 				return k
-			},
-			latestIdx: func(m *AppendOnly, key []byte) (int, bool) {
-				k64, ok := appendOnlyKeyU64(key)
-				if !ok || m.latest64 == nil {
-					return 0, false
-				}
-				idx, ok := m.latest64[k64]
-				return idx, ok
-			},
-			latestSize: func(m *AppendOnly) int {
-				if m.latest64 == nil {
-					return 0
-				}
-				return len(m.latest64)
 			},
 		},
 	}
@@ -496,58 +551,41 @@ func TestAppendOnlyGetBuildsLatestIndexOnFirstPointRead(t *testing.T) {
 			m.mu.RLock()
 			ordered := m.ordered
 			dirty := m.latestDirty
+			runCount := len(m.sortedRuns)
+			latestSize := len(m.latest) + len(m.latest64)
 			m.mu.RUnlock()
 			if ordered {
 				t.Fatalf("expected memtable to become unordered")
 			}
 			if dirty {
-				t.Fatalf("expected latest index to stay clean after order break")
+				t.Fatalf("expected sorted-run index to stay clean after order break")
 			}
-			m.mu.RLock()
-			latestSizeBeforeGet := kk.latestSize(m)
-			idxBeforeGet, okBeforeGet := kk.latestIdx(m, lo)
-			countBeforeGet := m.count
-			m.mu.RUnlock()
-			if latestSizeBeforeGet < 2 {
-				t.Fatalf("expected latest index to be materialized on order break, size=%d", latestSizeBeforeGet)
+			if runCount != 2 {
+				t.Fatalf("sorted run count after order break=%d want=2", runCount)
 			}
-			if !okBeforeGet {
-				t.Fatalf("expected latest index lookup to succeed immediately after order break")
-			}
-			if idxBeforeGet != countBeforeGet-1 {
-				t.Fatalf("latest index before Get=%d want %d", idxBeforeGet, countBeforeGet-1)
+			if latestSize != 0 {
+				t.Fatalf("hash latest index size after order break=%d want=0", latestSize)
 			}
 
 			if got, del, ok := m.Get(lo); !ok || del || string(got) != "lo" {
 				t.Fatalf("Get(lo) = (%q,%v,%v), want (lo,false,true)", string(got), del, ok)
 			}
 
-			m.mu.RLock()
-			dirty = m.latestDirty
-			latestSize := kk.latestSize(m)
-			m.mu.RUnlock()
-			if dirty {
-				t.Fatalf("expected point read to keep latest index clean (latestDirty=false)")
-			}
-			if latestSize < 2 {
-				t.Fatalf("expected latest index to be populated, size=%d", latestSize)
-			}
-
 			m.Set(lo, []byte("lo2"))
 
 			m.mu.RLock()
 			dirty = m.latestDirty
-			count := m.count
-			idx, ok := kk.latestIdx(m, lo)
+			runCount = len(m.sortedRuns)
+			latestSize = len(m.latest) + len(m.latest64)
 			m.mu.RUnlock()
 			if dirty {
-				t.Fatalf("expected writes to keep latest index clean after rebuild")
+				t.Fatalf("expected duplicate write to keep sorted-run index clean")
 			}
-			if !ok {
-				t.Fatalf("expected latest index lookup to succeed after rebuild")
+			if runCount != 3 {
+				t.Fatalf("sorted run count after duplicate write=%d want=3", runCount)
 			}
-			if idx != count-1 {
-				t.Fatalf("latest index points at %d, want %d", idx, count-1)
+			if latestSize != 0 {
+				t.Fatalf("hash latest index size after duplicate write=%d want=0", latestSize)
 			}
 			if got, del, ok := m.Get(lo); !ok || del || string(got) != "lo2" {
 				t.Fatalf("Get(lo after overwrite) = (%q,%v,%v), want (lo2,false,true)", string(got), del, ok)
@@ -557,17 +595,17 @@ func TestAppendOnlyGetBuildsLatestIndexOnFirstPointRead(t *testing.T) {
 
 			m.mu.RLock()
 			dirty = m.latestDirty
-			count = m.count
-			idx, ok = kk.latestIdx(m, lo)
+			runCount = len(m.sortedRuns)
+			latestSize = len(m.latest) + len(m.latest64)
 			m.mu.RUnlock()
 			if dirty {
-				t.Fatalf("expected deletes to keep latest index clean after rebuild")
+				t.Fatalf("expected delete to keep sorted-run index clean")
 			}
-			if !ok {
-				t.Fatalf("expected latest index lookup to succeed after delete")
+			if runCount != 4 {
+				t.Fatalf("sorted run count after delete=%d want=4", runCount)
 			}
-			if idx != count-1 {
-				t.Fatalf("latest index points at %d after delete, want %d", idx, count-1)
+			if latestSize != 0 {
+				t.Fatalf("hash latest index size after delete=%d want=0", latestSize)
 			}
 			if got, del, ok := m.Get(lo); !ok || !del || got != nil {
 				t.Fatalf("Get(lo after delete) = (%v,%v,%v), want (nil,true,true)", got, del, ok)
@@ -579,12 +617,12 @@ func TestAppendOnlyGetBuildsLatestIndexOnFirstPointRead(t *testing.T) {
 func TestAppendOnlyGet_EmptyKey_IncrementalLatestIndex(t *testing.T) {
 	m := NewAppendOnlyWithCapacity(0)
 
-	// Force the memtable into the unordered path so it uses the latest-index maps.
+	// Force the memtable into the unordered path so it uses the sorted-run latest
+	// index before adding a smaller empty-key run.
 	m.Set([]byte("b"), []byte("1"))
 	m.Set([]byte("a"), []byte("2"))
 
-	// Trigger a point read to build the latest index (latestDirty=false) before
-	// adding the empty key.
+	// Trigger a point read against the sorted-run index before adding the empty key.
 	if got, del, ok := m.Get([]byte("a")); !ok || del || string(got) != "2" {
 		t.Fatalf("precondition Get(a) = (%q,%v,%v), want (2,false,true)", string(got), del, ok)
 	}

--- a/TreeDB/internal/memtable/memtable.go
+++ b/TreeDB/internal/memtable/memtable.go
@@ -140,6 +140,14 @@ type CopySortedBatchApplier interface {
 	ApplyCopySortedBatchTrusted(entries []batchpkg.Entry, borrowValues bool, storeInlinePtrValues bool, onKey func(key []byte)) (borrowedValues bool)
 }
 
+// CopySortedBatchValueCopier is an optional fast path for sorted batch callers
+// that cannot retain caller-owned values but can provide an owner/lifetime-aware
+// value copier. Implementations must still copy keys into table-owned storage.
+// The copied value slices may be retained by the memtable until it is retired.
+type CopySortedBatchValueCopier interface {
+	ApplyCopySortedBatchWithValueCopierTrusted(entries []batchpkg.Entry, copyValue func(value []byte) []byte, storeInlinePtrValues bool, onKey func(key []byte)) (copiedValues bool)
+}
+
 type Memtable struct {
 	sl *skiplist.SkipList
 	mu sync.RWMutex


### PR DESCRIPTION
## Objective

Reduce TreeDB AppendOnly/memtable allocation churn for sorted batch writes by reusing append-only sorted-run state instead of rebuilding the hash latest-index immediately on the first global order break, while preserving latest-wins/tombstone and iterator/snapshot safety.

Closes #2244.

## Context

AppendOnly profiles showed allocation in entry/value arenas and latest-index rebuilds on durable write/batch paths. This PR keeps compact sorted-run metadata for sorted batches that are not globally ordered, services lookups/iterators from those runs, and falls back to the existing hash latest-index when the run table stops being compact.

The branch was rebased after #2241 landed (`d9f4c2ae`) and onto latest `origin/main` (`7022edb4`, #2248). Final head for this update: `e858c00caa7651e8ad1b87f5113a19198a8d0826`.

## Non-goals

- No on-disk format, WAL/sync, read-integrity, value-log, or mmap-budget changes.
- No change to latest-wins, tombstone visibility, collection semantics, or flush durability.
- No #2245 zipper/buildOpRuns merge-sort work in this PR.

## Design

- Add AppendOnly sorted-run tracking after an order break:
  - ordered memtables stay on the existing ordered lookup/iterator path;
  - compact sorted-run tables answer latest-wins point lookups and iterators without building the hash latest-index;
  - run count is capped (`appendOnlySortedRunMaxCount`), then falls back to `rebuildLatestIndexLocked`.
- Add `memtable.CopySortedBatchValueCopier` so callers that cannot borrow caller-owned values can supply an owner/lifetime-aware value copier while AppendOnly still owns/copies keys.
- Keep entry/value reuse bounded by existing reset/release/lease rules; frozen iterators retain leases and reset waits for them before recycling buffers.
- Follow-up fix in `e858c00`: replace `container/heap` interface push/pop in sorted-run latest merge with typed heap helpers to remove boxing allocations seen in `batch_write_steady` profiles.

## Scope

Includes:

- `TreeDB/internal/memtable/append_only.go`
- `TreeDB/internal/memtable/memtable.go`
- `TreeDB/caching/db.go`
- AppendOnly/caching ownership and sorted-run tests

Excludes:

- `TreeDB/zipper`, page layout, WAL/vlog formats, public collection APIs.

## Correctness

Tests run on final head `e858c00caa7651e8ad1b87f5113a19198a8d0826`:

```sh
GOWORK=off go test ./TreeDB/internal/memtable ./TreeDB/caching ./TreeDB/db -run 'AppendOnly|Memtable|Snapshot|Iterator|Tombstone|Duplicate|Sorted|Arena|Reuse' -count=1
go test -race ./TreeDB/internal/memtable ./TreeDB/caching -run 'TestAppendOnlySortedRuns|TestAppendOnlyBatchSetViewCopiesValuesToDirectArenaAcrossMutationAndCheckpoint|TestAppendOnlyGetUsesSortedRunsAfterOrderBreak|TestAppendOnlyApplyCopySortedBatch' -count=1
go test ./TreeDB/internal/memtable ./TreeDB/caching ./TreeDB/db ./TreeDB/collections -count=1
go test ./cmd/unified_bench ./cmd/benchprof -count=1
```

Covered by added/updated tests:

- sorted-run frozen lookups after order breaks;
- duplicate latest-wins and tombstone behavior across runs;
- sorted/unordered keys and 8-byte key fast paths;
- iterator ordering and snapshot/frozen safety;
- hash latest-index fallback after too many runs;
- `CopySortedBatchValueCopier` ownership;
- caching SetView/direct-arena mutation plus checkpoint safety.

## Performance

Host: `mikers@192.168.0.185`.

### Blocker rerun: core batch shapes

Command:

```sh
./bin/unified-bench -dbs=treedb -keys=1000000 -profile=durable \
  -profile-dir="$OUT" -path-label=native-fastpath -format=markdown -progress=false \
  -test=batch_write_steady,batch_write,batch_small_seq
./bin/benchprof -profiles-dir "$OUT"
```

Artifacts (three identical before/after reruns):

1. Base `/home/mikers/tmp/treedb_2244_rerun_base_20260603_115319`; candidate `/home/mikers/tmp/treedb_2244_rerun_candidate_20260603_115336`
2. Base `/home/mikers/tmp/treedb_2244_rerun2_base_20260603_115423`; candidate `/home/mikers/tmp/treedb_2244_rerun2_candidate_20260603_115428`
3. Base `/home/mikers/tmp/treedb_2244_rerun3_base_20260603_115433`; candidate `/home/mikers/tmp/treedb_2244_rerun3_candidate_20260603_115438`

| Test | base runs ops/s | candidate runs ops/s | base median | candidate median | delta |
|---|---:|---:|---:|---:|---:|
| Batch Write (Steady) | 1,331,446, 1,274,305, 1,385,480 | 1,390,577, 1,253,092, 1,367,888 | 1,331,446 | 1,367,888 | +2.74% |
| Batch Write | 7,905,209, 7,874,662, 8,751,040 | 7,743,850, 7,954,547, 8,534,473 | 7,905,209 | 7,954,547 | +0.62% |
| Batch Small Seq | 1,863,201, 1,775,213, 1,714,388 | 2,029,108, 2,187,754, 2,061,015 | 1,775,213 | 2,061,015 | +16.10% |

`batch_write_steady` allocation/CPU top deltas from rerun #1:

| Metric / hotspot | base | candidate | delta / note |
|---|---:|---:|---|
| total alloc-space | 425.15 MB | 427.46 MB | +0.58%, no material allocation regression |
| `getAppendOnlyEntries` | 124.92 MB | 127.61 MB | +2.69 MB |
| value-copy arena | `getAppendOnlyValueArenaChunk` 72.21 MB | `getAppendOnlyDirectValueArenaChunk` 62.41 MB | -9.80 MB on value arena allocation site |
| `getEntrySlice` | 64.82 MB | 70.08 MB | +5.26 MB |
| leaf read-cache `storeLocked` | 82.32 MB | 76.80 MB | -5.52 MB |
| sorted-run heap boxing | absent in latest top output | absent in latest top output | previous `forEachSortedRunLatestLocked`/heap boxing allocation removed by `e858c00` |
| CPU total samples | 680 ms | 630 ms | candidate lower samples in same ~904 ms profile window |
| `flushLaneOnceWithCommandPublish` cum CPU | 380 ms | 350 ms | -30 ms |
| `buildOpRuns` cum CPU | 80 ms | 70 ms | -10 ms |
| memtable sorted batch apply cum CPU | `ApplyCopySortedBatchTrusted` 40 ms | `ApplyCopySortedBatchWithValueCopierTrusted` 80 ms | value-copier path visible but not a throughput/alloc regression in the focused rerun |

The earlier single full-suite artifact showed `batch_write_steady` -3.12% and +36% alloc-space. After removing sorted-run heap boxing allocations and rerunning the required focused matrix three times on latest base/head, that material regression is not reproduced. No residual `batch_write_steady` regression is being requested for acceptance.

### Collection benchmarks

Full latest-head collection matrix command:

```sh
GOWORK=off go test ./TreeDB/collections -run '^$' -bench 'BenchmarkCollectionShapeInsertBatch|BenchmarkCollectionShapeInsertBatchCheckpoint|BenchmarkCollectionShapeInsertBatchSingleStringJSON|BenchmarkCollectionShapeInsertBatchCheckpointSingleStringJSON|BenchmarkCollectionTimedProfileInsertBatchWithSecondaryIndexes|BenchmarkCollectionTimedProfileInsertBatchCheckpointWithSecondaryIndexes|BenchmarkCollectionMixedReadWritePrimary|BenchmarkCollectionMixedReadWriteSecondaryUnique' -benchmem -count=3
```

Artifacts:

- Base: `/home/mikers/tmp/collections_2244_latest_full_base_20260603_120548.txt`
- Candidate: `/home/mikers/tmp/collections_2244_latest_full_candidate_20260603_120843.txt`

Median highlights:

| Benchmark | base ns/op | candidate ns/op | delta | base B/op | candidate B/op | allocs |
|---|---:|---:|---:|---:|---:|---:|
| MixedReadWritePrimary | 834 | 859 | +2.96% | 1,317 | 1,425 | 5->5 |
| MixedReadWriteSecondaryUnique | 1,165,794 | 1,179,114 | +1.14% | 3,817,888 | 3,911,245 | 63->64 |
| ShapeInsertBatch/indexes_0 | 1,065 | 1,082 | +1.60% | 1,139 | 1,138 | 1->1 |
| ShapeInsertBatch/indexes_1 | 6,445 | 5,627 | -12.69% | 5,361 | 4,782 | 3->2 |
| ShapeInsertBatch/indexes_2 | 5,805 | 5,855 | +0.86% | 5,222 | 5,227 | 2->2 |
| ShapeInsertBatch/indexes_3 | 5,901 | 5,879 | -0.37% | 5,818 | 5,779 | 2->2 |
| ShapeInsertBatchCheckpoint/indexes_0 | 1,097 | 1,148 | +4.65% | 1,053 | 1,055 | 1->1 |
| ShapeInsertBatchCheckpoint/indexes_1 | 3,114 | 3,212 | +3.15% | 1,588 | 1,586 | 1->1 |
| ShapeInsertBatchCheckpoint/indexes_2 | 3,708 | 3,665 | -1.16% | 1,781 | 1,783 | 1->1 |
| ShapeInsertBatchCheckpoint/indexes_3 | 4,209 | 4,374 | +3.92% | 1,958 | 1,967 | 1->1 |
| SingleString InsertBatch/indexes_1 | 6,520 | 6,509 | -0.17% | 4,905 | 4,904 | 2->2 |
| SingleString Checkpoint/indexes_1 | 5,017 | 4,738 | -5.56% | 3,908 | 3,890 | 2->2 |

For the coordinator-highlighted `ShapeInsertBatch/indexes_0` row, latest focused fixed-iteration benchstat was neutral:

```sh
GOWORK=off go test ./TreeDB/collections -run '^$' \
  -bench '^BenchmarkCollectionShapeInsertBatch$/^indexes_0$' \
  -benchmem -benchtime=100000x -count=30
benchstat base.txt candidate.txt
```

Artifacts:

- Base: `/home/mikers/tmp/collections_2244_idx0c_base_20260603_120154.txt`
- Candidate: `/home/mikers/tmp/collections_2244_idx0c_candidate_20260603_120203.txt`
- Benchstat: `/home/mikers/tmp/benchstat_idx0c.txt`

Benchstat result:

```text
CollectionShapeInsertBatch/indexes_0-12  823.5n ± 1%  820.8n ± 1%  ~ (p=0.865 n=30)
B/op                                         889.0 ± 0%  889.0 ± 0%  ~ (p=1.000 n=30)
allocs/op                                     1.000 ± 0%  1.000 ± 0%  ~ (p=1.000 n=30)
```

No collection allocation regression is observed in the focused rerun; the earlier +5.59% fixed-iteration result is treated as noise after the n=30 neutral benchstat rerun.

## Memtable contract for #2245

Dependency-ready contract for #2245 batch merge/sort work:

1. AppendOnly owns entry records and keys after apply. 8-byte keys may be inlined; non-stolen keys are copied into table-owned key storage/reusable key buffers.
2. Values may only be retained beyond the apply call when the caller explicitly uses a borrow/steal/copy contract:
   - `ApplyCopySortedBatchTrusted(..., borrowValues=true, ...)` means the caller must keep the source value arena alive until the memtable is retired; the method returns whether values were borrowed.
   - `ApplyCopySortedBatchTrusted(..., borrowValues=false, ...)` copies values into AppendOnly-owned storage.
   - `CopySortedBatchValueCopier` lets the caller supply an owner/lifetime-aware copy destination; returned slices must remain immutable and valid until the memtable is retired.
   - steal APIs transfer key/value ownership to the memtable.
3. Sorted-run state is an internal lookup/iterator acceleration only. #2245 may rely on logical latest-wins/tombstone semantics, but must not depend on the physical presence of `latest` maps for compact sorted-run memtables.
4. Frozen iterators can alias stable AppendOnly entry slices or cached entry pointers under the iterator lease. Reset/recycle waits for leases before mutating/reusing buffers.
5. #2245 scratch/key metadata must not retain pointers into transient batch/run-building buffers beyond the synchronous apply/merge phase unless it uses one of the explicit contracts above.

This contract was also posted to #2245: https://github.com/snissn/gomap/issues/2245#issuecomment-4616947835

## Latest-head CI / AI review status

- Latest PR head: `e858c00caa7651e8ad1b87f5113a19198a8d0826`.
- CI/checks for latest head are green, including TreeDB vet/test, race shards, unified_bench gates, root tests, format, HashDB Windows, and read-snapshot guardrail.
- CodeRabbit reviewed latest head and posted two comments. Both were reviewed, explicitly dispositioned with rationale, and marked resolved. Current unresolved review threads: 0.
- Codex: previous review reported no major issues; latest-head re-request was posted after `e858c00` (`@codex review`) and has not produced a new finding as of this update.
- Copilot: latest-head re-request was posted (`@copilot review`); no Copilot response is visible as of this update.
- Residual regressions needing explicit coordinator/user acceptance: none known from latest focused blocker reruns. Coordinator should still make the final acceptance call.

## Rollout / Toggle Plan

No user-facing toggle or format migration. Revert is scoped to this PR's AppendOnly sorted-run/value-copier changes.

## Follow-ups

- #2245: use the memtable contract above while reducing batch steady merge/sort and zipper scratch overhead.
