### PR TITLE
Coalesce TreeDB durable WAL point appends

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -12531,6 +12531,7 @@ func (db *DB) flushWALRequests(l *lane, requests []walWriteRequest) error {
 		l.walMu.Unlock()
 		return errWALUnavailable
 	}
+	l.walCoalesceSeq = 0
 	beforeSize := w.Size()
 	for i := range requests {
 		req := &requests[i]
@@ -13435,6 +13436,7 @@ func (db *DB) appendWALZeroInlineEntries(l *lane, entries []batch.Entry, seq uin
 		l.walMu.Unlock()
 		return true, errWALUnavailable
 	}
+	l.walCoalesceSeq = 0
 	beforeSize := w.Size()
 	zw, ok := w.(zeroInlineBatchCommitWriter)
 	if !ok {
@@ -13494,14 +13496,33 @@ func (db *DB) appendWALOne(l *lane, record logRecord, durability journalDurabili
 	return db.appendWALOneChecked(l, record, durability)
 }
 
+func canCoalesceWALPointRecord(record logRecord) bool {
+	return record.Op == logOpSetInline || record.Op == logOpDelete
+}
+
+// nextWALCoalesceSeqLocked returns the shared commit-fence sequence for an
+// adjacent run of unsynced inline/delete point records. Callers must hold
+// l.walMu. RID-backed records are intentionally excluded from this coalescing
+// path so their value-log reachability fence remains per explicit write/batch.
+func (db *DB) nextWALCoalesceSeqLocked(l *lane) uint64 {
+	if l.walCoalesceSeq == 0 {
+		l.walCoalesceSeq = db.nextCommitSeq.Add(1)
+	}
+	return l.walCoalesceSeq
+}
+
 func (db *DB) appendWALOneChecked(l *lane, record logRecord, durability journalDurability) error {
-	record.Seq = db.nextCommitSeq.Add(1)
 	switch durability {
 	case journalDurabilitySync:
+		record.Seq = db.nextCommitSeq.Add(1)
 		return db.appendWALDirect(l, []logRecord{record}, true)
 	case journalDurabilityFlush:
+		record.Seq = db.nextCommitSeq.Add(1)
 		return db.appendWALInlineOne(l, record, true)
 	default:
+		if !canCoalesceWALPointRecord(record) {
+			record.Seq = db.nextCommitSeq.Add(1)
+		}
 		return db.appendWALInlineOne(l, record, false)
 	}
 }
@@ -14967,6 +14988,7 @@ func (db *DB) appendWALInline(l *lane, records []logRecord, flush bool) error {
 		l.walMu.Unlock()
 		return errWALUnavailable
 	}
+	l.walCoalesceSeq = 0
 	beforeSize := w.Size()
 	if len(records) == 1 {
 		rec := records[0]
@@ -15008,6 +15030,16 @@ func (db *DB) appendWALInlineOne(l *lane, record logRecord, flush bool) error {
 		l.walMu.Unlock()
 		return errWALUnavailable
 	}
+	if flush {
+		l.walCoalesceSeq = 0
+	} else if record.Seq == 0 && canCoalesceWALPointRecord(record) {
+		record.Seq = db.nextWALCoalesceSeqLocked(l)
+	} else {
+		l.walCoalesceSeq = 0
+		if record.Seq == 0 {
+			record.Seq = db.nextCommitSeq.Add(1)
+		}
+	}
 	beforeSize := w.Size()
 	err := w.Append(record)
 	if err == nil && flush {
@@ -15048,6 +15080,7 @@ func (db *DB) flushWALLane(l *lane) error {
 		l.walMu.Unlock()
 		return errWALUnavailable
 	}
+	l.walCoalesceSeq = 0
 	err := w.Flush()
 	l.walMu.Unlock()
 
@@ -22289,6 +22322,7 @@ func (db *DB) rotateWALLockedWithOptions(l *lane, rotateValueLog bool) error {
 	name := commitLogName(l.id, nextSeq)
 	path := filepath.Join(db.dir, name)
 
+	l.walCoalesceSeq = 0
 	if l.wal != nil {
 		oldPath := l.walPath
 		oldSize := l.wal.Size()

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -13497,13 +13497,14 @@ func (db *DB) appendWALOne(l *lane, record logRecord, durability journalDurabili
 }
 
 func canCoalesceWALPointRecord(record logRecord) bool {
-	return record.Op == logOpSetInline || record.Op == logOpDelete
+	return record.Op == logOpSetInline
 }
 
 // nextWALCoalesceSeqLocked returns the shared commit-fence sequence for an
-// adjacent run of unsynced inline/delete point records. Callers must hold
-// l.walMu. RID-backed records are intentionally excluded from this coalescing
-// path so their value-log reachability fence remains per explicit write/batch.
+// adjacent run of unsynced inline point records. Callers must hold l.walMu.
+// Deletes and RID-backed records stay on explicit write/batch fences: deletes
+// must preserve overwrite/delete ordering for same-key WAL replay, while RID
+// records must preserve value-log reachability fences.
 func (db *DB) nextWALCoalesceSeqLocked(l *lane) uint64 {
 	if l.walCoalesceSeq == 0 {
 		l.walCoalesceSeq = db.nextCommitSeq.Add(1)

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -13536,7 +13536,7 @@ func canCoalesceWALPointRecord(record logRecord) bool {
 // must preserve overwrite/delete ordering for same-key WAL replay, while RID
 // records must preserve value-log reachability fences.
 func (db *DB) nextWALCoalesceSeqLocked(l *lane) uint64 {
-	if l.walCoalesceSeq == 0 {
+	if l.walCoalesceSeq == 0 || db.nextCommitSeq.Load() != l.walCoalesceSeq {
 		l.walCoalesceSeq = db.nextCommitSeq.Add(1)
 	}
 	return l.walCoalesceSeq

--- a/TreeDB/caching/lane.go
+++ b/TreeDB/caching/lane.go
@@ -27,6 +27,9 @@ type lane struct {
 	walLiveBytes   atomic.Int64
 	walClosedBytes atomic.Int64
 	walClosedSizes map[string]int64
+	// walCoalesceSeq is protected by walMu and groups adjacent unsynced
+	// inline/delete point records into one recovery commit-fence sequence.
+	walCoalesceSeq uint64
 
 	vlog                           valueWriter
 	vlogPath                       string

--- a/TreeDB/caching/lane.go
+++ b/TreeDB/caching/lane.go
@@ -28,7 +28,7 @@ type lane struct {
 	walClosedBytes atomic.Int64
 	walClosedSizes map[string]int64
 	// walCoalesceSeq is protected by walMu and groups adjacent unsynced
-	// inline/delete point records into one recovery commit-fence sequence.
+	// inline point records into one recovery commit-fence sequence.
 	walCoalesceSeq uint64
 
 	vlog                           valueWriter

--- a/TreeDB/caching/wal_coalesce_seq_test.go
+++ b/TreeDB/caching/wal_coalesce_seq_test.go
@@ -1,0 +1,32 @@
+package caching
+
+import "testing"
+
+func TestNextWALCoalesceSeqResetsAfterGlobalCommitSeqAdvance(t *testing.T) {
+	var db DB
+	var l lane
+
+	l.walMu.Lock()
+	seq := db.nextWALCoalesceSeqLocked(&l)
+	if seq == 0 {
+		l.walMu.Unlock()
+		t.Fatalf("initial coalesce seq is zero")
+	}
+	if got := db.nextWALCoalesceSeqLocked(&l); got != seq {
+		l.walMu.Unlock()
+		t.Fatalf("same uninterrupted lane run got seq=%d want %d", got, seq)
+	}
+	l.walMu.Unlock()
+
+	// Simulate any other lane or explicit batch issuing a global commit fence.
+	otherSeq := db.nextCommitSeq.Add(1)
+	if otherSeq <= seq {
+		t.Fatalf("simulated global seq=%d want > %d", otherSeq, seq)
+	}
+
+	l.walMu.Lock()
+	defer l.walMu.Unlock()
+	if got := db.nextWALCoalesceSeqLocked(&l); got <= otherSeq {
+		t.Fatalf("coalesce seq after global advance=%d want > %d", got, otherSeq)
+	}
+}

--- a/TreeDB/internal/commitlog/commitlog_test.go
+++ b/TreeDB/internal/commitlog/commitlog_test.go
@@ -75,6 +75,224 @@ func TestCommitLogWriteReadBatch(t *testing.T) {
 	_ = reader.Close()
 }
 
+func TestCommitLogAppendCoalescesSameSeqSmallRecords(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "commit.log")
+
+	writer, err := NewWriterWithOptions(path, Options{Compress: false})
+	if err != nil {
+		t.Fatalf("new writer: %v", err)
+	}
+	records := []Record{
+		{Op: OpSetInline, Key: []byte("k1"), Value: []byte("v1"), Seq: 42},
+		{Op: OpDelete, Key: []byte("k2"), Seq: 42},
+		{Op: OpSetInline, Key: []byte("k3"), Value: bytes.Repeat([]byte("v"), 64), Seq: 42},
+	}
+	for _, rec := range records {
+		if err := writer.Append(rec); err != nil {
+			_ = writer.Close()
+			t.Fatalf("append: %v", err)
+		}
+	}
+	if got := writer.Size(); got <= int64(segmentHeaderSize+batchHeaderSize) {
+		_ = writer.Close()
+		t.Fatalf("logical size before flush=%d, want pending bytes included", got)
+	}
+	if err := writer.Flush(); err != nil {
+		_ = writer.Close()
+		t.Fatalf("flush: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	if len(data) < segmentHeaderSize+batchHeaderSize {
+		t.Fatalf("coalesced segment too small: %d", len(data))
+	}
+	payloadLen := int(binary.LittleEndian.Uint32(data[0:4]) & segmentLenMask)
+	if gotCRC, wantCRC := binary.LittleEndian.Uint32(data[4:8]), crc.Checksum(data[segmentHeaderSize:segmentHeaderSize+payloadLen]); gotCRC != wantCRC {
+		t.Fatalf("coalesced crc=%08x want %08x", gotCRC, wantCRC)
+	}
+	if count := binary.LittleEndian.Uint32(data[segmentHeaderSize+1 : segmentHeaderSize+5]); count != uint32(len(records)) {
+		t.Fatalf("coalesced count=%d want %d", count, len(records))
+	}
+
+	reader, err := NewReader(path)
+	if err != nil {
+		t.Fatalf("new reader: %v", err)
+	}
+	got, err := reader.ReadBatch()
+	if err != nil {
+		_ = reader.Close()
+		t.Fatalf("read batch: %v", err)
+	}
+	if len(got) != len(records) {
+		_ = reader.Close()
+		t.Fatalf("record count: got %d want %d", len(got), len(records))
+	}
+	for i := range records {
+		if got[i].Op != records[i].Op || got[i].Seq != records[i].Seq || got[i].RID != records[i].RID || !bytes.Equal(got[i].Key, records[i].Key) || !bytes.Equal(got[i].Value, records[i].Value) {
+			_ = reader.Close()
+			t.Fatalf("record %d mismatch: got=%+v want=%+v", i, got[i], records[i])
+		}
+	}
+	if _, err := reader.ReadBatch(); !errors.Is(err, io.EOF) {
+		_ = reader.Close()
+		t.Fatalf("expected EOF, got %v", err)
+	}
+	_ = reader.Close()
+}
+
+func TestCommitLogAppendFlushesCoalescedBatchOnSeqChange(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "commit.log")
+
+	writer, err := NewWriterWithOptions(path, Options{Compress: false})
+	if err != nil {
+		t.Fatalf("new writer: %v", err)
+	}
+	if err := writer.Append(Record{Op: OpSetInline, Key: []byte("k1"), Value: []byte("v1"), Seq: 1}); err != nil {
+		_ = writer.Close()
+		t.Fatalf("append seq1: %v", err)
+	}
+	if err := writer.Append(Record{Op: OpSetInline, Key: []byte("k2"), Value: []byte("v2"), Seq: 2}); err != nil {
+		_ = writer.Close()
+		t.Fatalf("append seq2: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	reader, err := NewReader(path)
+	if err != nil {
+		t.Fatalf("new reader: %v", err)
+	}
+	first, err := reader.ReadBatch()
+	if err != nil {
+		_ = reader.Close()
+		t.Fatalf("read first: %v", err)
+	}
+	second, err := reader.ReadBatch()
+	if err != nil {
+		_ = reader.Close()
+		t.Fatalf("read second: %v", err)
+	}
+	if len(first) != 1 || first[0].Seq != 1 || string(first[0].Key) != "k1" {
+		_ = reader.Close()
+		t.Fatalf("first batch=%+v, want seq1/k1", first)
+	}
+	if len(second) != 1 || second[0].Seq != 2 || string(second[0].Key) != "k2" {
+		_ = reader.Close()
+		t.Fatalf("second batch=%+v, want seq2/k2", second)
+	}
+	if _, err := reader.ReadBatch(); !errors.Is(err, io.EOF) {
+		_ = reader.Close()
+		t.Fatalf("expected EOF, got %v", err)
+	}
+	_ = reader.Close()
+}
+
+func TestCommitLogCoalescedBatchChecksumMismatchFailsClosed(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "commit.log")
+
+	writer, err := NewWriterWithOptions(path, Options{Compress: false})
+	if err != nil {
+		t.Fatalf("new writer: %v", err)
+	}
+	for _, key := range []string{"k1", "k2"} {
+		if err := writer.Append(Record{Op: OpSetInline, Key: []byte(key), Value: []byte("value"), Seq: 9}); err != nil {
+			_ = writer.Close()
+			t.Fatalf("append %s: %v", key, err)
+		}
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	f, err := os.OpenFile(path, os.O_RDWR, 0)
+	if err != nil {
+		t.Fatalf("open for corrupt: %v", err)
+	}
+	var b [1]byte
+	if _, err := f.ReadAt(b[:], int64(segmentHeaderSize+batchHeaderSize)); err != nil {
+		_ = f.Close()
+		t.Fatalf("read corrupt byte: %v", err)
+	}
+	b[0] ^= 0xff
+	if _, err := f.WriteAt(b[:], int64(segmentHeaderSize+batchHeaderSize)); err != nil {
+		_ = f.Close()
+		t.Fatalf("write corrupt byte: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("close corrupt file: %v", err)
+	}
+
+	reader, err := NewReader(path)
+	if err != nil {
+		t.Fatalf("new reader: %v", err)
+	}
+	if _, err := reader.ReadBatch(); !errors.Is(err, ErrCorrupt) {
+		_ = reader.Close()
+		t.Fatalf("ReadBatch error=%v, want ErrCorrupt", err)
+	}
+	_ = reader.Close()
+}
+
+func TestCommitLogCoalescedBatchTruncatedTailKeepsPriorBatchReadable(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "commit.log")
+
+	writer, err := NewWriterWithOptions(path, Options{Compress: false})
+	if err != nil {
+		t.Fatalf("new writer: %v", err)
+	}
+	if err := writer.Append(Record{Op: OpSetInline, Key: []byte("first"), Value: []byte("value"), Seq: 1}); err != nil {
+		_ = writer.Close()
+		t.Fatalf("append first: %v", err)
+	}
+	if err := writer.Flush(); err != nil {
+		_ = writer.Close()
+		t.Fatalf("flush first: %v", err)
+	}
+	if err := writer.Append(Record{Op: OpSetInline, Key: []byte("second"), Value: bytes.Repeat([]byte("x"), 32), Seq: 2}); err != nil {
+		_ = writer.Close()
+		t.Fatalf("append second: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if err := os.Truncate(path, info.Size()-3); err != nil {
+		t.Fatalf("truncate tail: %v", err)
+	}
+
+	reader, err := NewReader(path)
+	if err != nil {
+		t.Fatalf("new reader: %v", err)
+	}
+	first, err := reader.ReadBatch()
+	if err != nil {
+		_ = reader.Close()
+		t.Fatalf("read first: %v", err)
+	}
+	if len(first) != 1 || string(first[0].Key) != "first" || first[0].Seq != 1 {
+		_ = reader.Close()
+		t.Fatalf("first batch=%+v, want first seq1", first)
+	}
+	if _, err := reader.ReadBatch(); !errors.Is(err, io.ErrUnexpectedEOF) && !errors.Is(err, io.EOF) {
+		_ = reader.Close()
+		t.Fatalf("truncated tail error=%v, want EOF/UnexpectedEOF", err)
+	}
+	_ = reader.Close()
+}
+
 func TestCommitLogWriteReadLargeRawBatch(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "commit.log")

--- a/TreeDB/internal/commitlog/writer.go
+++ b/TreeDB/internal/commitlog/writer.go
@@ -16,13 +16,14 @@ import (
 )
 
 const (
-	defaultBufferSize            = 4 << 20
-	defaultMaxSegmentSize        = 64 * 1024 * 1024
-	defaultCompressMinLen        = 64 << 10
-	directSegmentPayloadMinLen   = 128 << 10
-	directCommandPayloadMinLen   = 64 << 10
-	batchChecksumChunkBytes      = 64 << 10
-	pendingAppendBatchMaxPayload = defaultBufferSize - segmentHeaderSize
+	defaultBufferSize                = 4 << 20
+	defaultMaxSegmentSize            = 64 * 1024 * 1024
+	defaultCompressMinLen            = 64 << 10
+	directSegmentPayloadMinLen       = 128 << 10
+	directCommandPayloadMinLen       = 64 << 10
+	batchChecksumChunkBytes          = 64 << 10
+	pendingAppendBatchInitialPayload = 64 << 10
+	pendingAppendBatchMaxPayload     = defaultBufferSize - segmentHeaderSize
 )
 
 var syncDirFn = syncDir
@@ -187,12 +188,12 @@ func (w *Writer) appendPendingRecord(record Record, keyLen uint16, valLen uint32
 	}
 	if w.pendingBatchRecs == 0 {
 		need := batchHeaderSize + recLen
-		capHint := limit
-		if capHint > pendingAppendBatchMaxPayload {
-			capHint = pendingAppendBatchMaxPayload
-		}
+		capHint := pendingAppendBatchInitialPayload
 		if capHint < need {
 			capHint = need
+		}
+		if capHint > limit {
+			capHint = limit
 		}
 		if cap(w.pendingBatch) < need {
 			w.pendingBatch = make([]byte, batchHeaderSize, capHint)

--- a/TreeDB/internal/commitlog/writer.go
+++ b/TreeDB/internal/commitlog/writer.go
@@ -284,8 +284,10 @@ func (w *Writer) RotateToWithSync(path string, syncCurrent bool) error {
 		return nil
 	}
 
-	if err := w.flushPendingBatch(); err != nil {
-		return err
+	if w.pendingBatchRecs != 0 {
+		if err := w.flushPendingBatch(); err != nil {
+			return err
+		}
 	}
 	if err := w.flushBufferedCommandFrames(); err != nil {
 		return err
@@ -698,8 +700,10 @@ func (w *Writer) AppendRawKVSingleCommandDirect(lsn, baseAppliedLSN uint64, op R
 	if size > int(segmentLenMask) {
 		return ErrRecordTooLarge
 	}
-	if err := w.flushPendingBatch(); err != nil {
-		return err
+	if w.pendingBatchRecs != 0 {
+		if err := w.flushPendingBatch(); err != nil {
+			return err
+		}
 	}
 	if err := w.flushBufferedCommandFrames(); err != nil {
 		return err
@@ -748,8 +752,10 @@ func (w *Writer) AppendRawKVPointCommandDirectTrusted(lsn, baseAppliedLSN uint64
 }
 
 func (w *Writer) appendRawKVPointCommandDirectTrustedSized(lsn, baseAppliedLSN uint64, op RawKVOp, key, value []byte, valueLen, payloadLen, size int) error {
-	if err := w.flushPendingBatch(); err != nil {
-		return err
+	if w.pendingBatchRecs != 0 {
+		if err := w.flushPendingBatch(); err != nil {
+			return err
+		}
 	}
 	total := segmentHeaderSize + size
 	if !w.canBufferCommandFrame(total) {
@@ -807,8 +813,10 @@ func (w *Writer) AppendRawKVBatchPayloadCommandDirectTrusted(lsn, baseAppliedLSN
 	if size > int(segmentLenMask) {
 		return ErrRecordTooLarge
 	}
-	if err := w.flushPendingBatch(); err != nil {
-		return err
+	if w.pendingBatchRecs != 0 {
+		if err := w.flushPendingBatch(); err != nil {
+			return err
+		}
 	}
 	total := segmentHeaderSize + size
 	if len(payload) >= directCommandPayloadMinLen {
@@ -860,8 +868,10 @@ func (w *Writer) AppendCommandPayloadDirectTrusted(lsn, baseAppliedLSN uint64, k
 	if size > int(segmentLenMask) {
 		return ErrRecordTooLarge
 	}
-	if err := w.flushPendingBatch(); err != nil {
-		return err
+	if w.pendingBatchRecs != 0 {
+		if err := w.flushPendingBatch(); err != nil {
+			return err
+		}
 	}
 	total := segmentHeaderSize + size
 	if len(payload) >= directCommandPayloadMinLen {
@@ -884,8 +894,10 @@ func (w *Writer) AppendCommandPayloadDirectTrusted(lsn, baseAppliedLSN uint64, k
 }
 
 func (w *Writer) appendRawKVBatchPayloadCommandDirect(lsn, baseAppliedLSN uint64, payload []byte, size int) error {
-	if err := w.flushPendingBatch(); err != nil {
-		return err
+	if w.pendingBatchRecs != 0 {
+		if err := w.flushPendingBatch(); err != nil {
+			return err
+		}
 	}
 	if err := w.flushBufferedCommandFrames(); err != nil {
 		return err
@@ -920,8 +932,10 @@ func (w *Writer) appendRawKVBatchPayloadCommandDirect(lsn, baseAppliedLSN uint64
 }
 
 func (w *Writer) appendCommandPayloadDirectTrusted(lsn, baseAppliedLSN uint64, kind CommandKind, scope CommandScope, format PayloadFormat, payload []byte, size int) error {
-	if err := w.flushPendingBatch(); err != nil {
-		return err
+	if w.pendingBatchRecs != 0 {
+		if err := w.flushPendingBatch(); err != nil {
+			return err
+		}
 	}
 	if err := w.flushBufferedCommandFrames(); err != nil {
 		return err
@@ -1091,8 +1105,10 @@ func (w *Writer) poisonCommandBuffer(err error) error {
 }
 
 func (w *Writer) writeSegment(payload []byte) error {
-	if err := w.flushPendingBatch(); err != nil {
-		return err
+	if w.pendingBatchRecs != 0 {
+		if err := w.flushPendingBatch(); err != nil {
+			return err
+		}
 	}
 	if err := w.flushBufferedCommandFrames(); err != nil {
 		return err
@@ -1156,8 +1172,10 @@ func (w *Writer) writeSegment(payload []byte) error {
 }
 
 func (w *Writer) writeRawSegmentWithChecksum(payload []byte, wantCRC uint32) error {
-	if err := w.flushPendingBatch(); err != nil {
-		return err
+	if w.pendingBatchRecs != 0 {
+		if err := w.flushPendingBatch(); err != nil {
+			return err
+		}
 	}
 	return w.writeRawSegmentWithChecksumNoPending(payload, wantCRC)
 }
@@ -1230,8 +1248,10 @@ func (w *Writer) Flush() error {
 	if w == nil || w.f == nil {
 		return nil
 	}
-	if err := w.flushPendingBatch(); err != nil {
-		return err
+	if w.pendingBatchRecs != 0 {
+		if err := w.flushPendingBatch(); err != nil {
+			return err
+		}
 	}
 	if err := w.flushBufferedCommandFrames(); err != nil {
 		return err
@@ -1243,8 +1263,10 @@ func (w *Writer) Sync() error {
 	if w == nil || w.f == nil {
 		return nil
 	}
-	if err := w.flushPendingBatch(); err != nil {
-		return err
+	if w.pendingBatchRecs != 0 {
+		if err := w.flushPendingBatch(); err != nil {
+			return err
+		}
 	}
 	if err := w.flushBufferedCommandFrames(); err != nil {
 		return err

--- a/TreeDB/internal/commitlog/writer.go
+++ b/TreeDB/internal/commitlog/writer.go
@@ -16,12 +16,13 @@ import (
 )
 
 const (
-	defaultBufferSize          = 4 << 20
-	defaultMaxSegmentSize      = 64 * 1024 * 1024
-	defaultCompressMinLen      = 64 << 10
-	directSegmentPayloadMinLen = 128 << 10
-	directCommandPayloadMinLen = 64 << 10
-	batchChecksumChunkBytes    = 64 << 10
+	defaultBufferSize            = 4 << 20
+	defaultMaxSegmentSize        = 64 * 1024 * 1024
+	defaultCompressMinLen        = 64 << 10
+	directSegmentPayloadMinLen   = 128 << 10
+	directCommandPayloadMinLen   = 64 << 10
+	batchChecksumChunkBytes      = 64 << 10
+	pendingAppendBatchMaxPayload = defaultBufferSize - segmentHeaderSize
 )
 
 var syncDirFn = syncDir
@@ -65,20 +66,23 @@ func sameNonEmptyBytesData(a, b []byte) bool {
 }
 
 type Writer struct {
-	f               *os.File
-	bw              *bufio.Writer
-	scratch         []byte
-	encScratch      []byte
-	commandBuf      []byte
-	commandBufLimit int
-	commandErr      error
-	headerBuf       [segmentHeaderSize]byte
-	rawLenPrefix    [4]byte
-	size            int64
-	maxSegmentSize  int64
-	compress        bool
-	enc             *zstd.Encoder
-	syncFn          func(*os.File) error
+	f                *os.File
+	bw               *bufio.Writer
+	scratch          []byte
+	encScratch       []byte
+	commandBuf       []byte
+	commandBufLimit  int
+	commandErr       error
+	pendingBatch     []byte
+	pendingBatchSeq  uint64
+	pendingBatchRecs uint32
+	headerBuf        [segmentHeaderSize]byte
+	rawLenPrefix     [4]byte
+	size             int64
+	maxSegmentSize   int64
+	compress         bool
+	enc              *zstd.Encoder
+	syncFn           func(*os.File) error
 }
 
 func NewWriter(path string) (*Writer, error) {
@@ -143,6 +147,106 @@ func (w *Writer) ensureEncoder() error {
 	return nil
 }
 
+func (w *Writer) pendingBatchBytes() int64 {
+	if w == nil || w.pendingBatchRecs == 0 {
+		return 0
+	}
+	return int64(segmentHeaderSize + len(w.pendingBatch))
+}
+
+func (w *Writer) pendingAppendBatchLimit(recLen int) int {
+	limit := pendingAppendBatchMaxPayload
+	if w != nil && w.maxSegmentSize > 0 && int64(limit) > w.maxSegmentSize {
+		limit = int(w.maxSegmentSize)
+	}
+	if limit > int(segmentLenMask) {
+		limit = int(segmentLenMask)
+	}
+	minNeed := batchHeaderSize + recLen
+	if limit < minNeed {
+		limit = minNeed
+	}
+	return limit
+}
+
+func (w *Writer) appendPendingRecord(record Record, keyLen uint16, valLen uint32) error {
+	if err := w.flushBufferedCommandFrames(); err != nil {
+		return err
+	}
+	recLen := recordHeaderSize + len(record.Key) + len(record.Value)
+	limit := w.pendingAppendBatchLimit(recLen)
+	if w.pendingBatchRecs > 0 && w.pendingBatchSeq != record.Seq {
+		if err := w.flushPendingBatch(); err != nil {
+			return err
+		}
+	}
+	if w.pendingBatchRecs > 0 && (w.pendingBatchRecs == ^uint32(0) || len(w.pendingBatch)+recLen > limit) {
+		if err := w.flushPendingBatch(); err != nil {
+			return err
+		}
+	}
+	if w.pendingBatchRecs == 0 {
+		need := batchHeaderSize + recLen
+		capHint := limit
+		if capHint > pendingAppendBatchMaxPayload {
+			capHint = pendingAppendBatchMaxPayload
+		}
+		if capHint < need {
+			capHint = need
+		}
+		if cap(w.pendingBatch) < need {
+			w.pendingBatch = make([]byte, batchHeaderSize, capHint)
+		} else {
+			w.pendingBatch = w.pendingBatch[:batchHeaderSize]
+		}
+		w.pendingBatch[0] = Version
+		binary.LittleEndian.PutUint32(w.pendingBatch[1:5], 0)
+		w.pendingBatchSeq = record.Seq
+	}
+
+	off := len(w.pendingBatch)
+	next := off + recLen
+	if next > cap(w.pendingBatch) {
+		newCap := cap(w.pendingBatch) * 2
+		if newCap < next {
+			newCap = next
+		}
+		if newCap > limit {
+			newCap = limit
+		}
+		nextBuf := make([]byte, next, newCap)
+		copy(nextBuf, w.pendingBatch)
+		w.pendingBatch = nextBuf
+	} else {
+		w.pendingBatch = w.pendingBatch[:next]
+	}
+	buf := w.pendingBatch
+	buf[off] = record.Op
+	binary.LittleEndian.PutUint16(buf[off+1:off+3], keyLen)
+	binary.LittleEndian.PutUint32(buf[off+3:off+7], valLen)
+	binary.LittleEndian.PutUint64(buf[off+7:off+15], record.RID)
+	binary.LittleEndian.PutUint64(buf[off+15:off+23], record.Seq)
+	copy(buf[off+recordHeaderSize:], record.Key)
+	copy(buf[off+recordHeaderSize+len(record.Key):], record.Value)
+	w.pendingBatchRecs++
+	binary.LittleEndian.PutUint32(buf[1:5], w.pendingBatchRecs)
+	return nil
+}
+
+func (w *Writer) flushPendingBatch() error {
+	if w == nil || w.pendingBatchRecs == 0 {
+		return nil
+	}
+	payload := w.pendingBatch
+	if err := w.writeRawSegmentWithChecksumNoPending(payload, crc.Checksum(payload)); err != nil {
+		return err
+	}
+	w.pendingBatch = w.pendingBatch[:0]
+	w.pendingBatchSeq = 0
+	w.pendingBatchRecs = 0
+	return nil
+}
+
 // RotateTo flushes and closes the current file, then opens (or creates) the
 // provided path and reuses the writer's buffers for future appends.
 func (w *Writer) RotateTo(path string) error {
@@ -180,6 +284,9 @@ func (w *Writer) RotateToWithSync(path string, syncCurrent bool) error {
 		return nil
 	}
 
+	if err := w.flushPendingBatch(); err != nil {
+		return err
+	}
 	if err := w.flushBufferedCommandFrames(); err != nil {
 		return err
 	}
@@ -272,35 +379,7 @@ func (w *Writer) Append(record Record) error {
 		return ErrRecordTooLarge
 	}
 	if !w.compress && segmentHeaderSize+payloadLen < directSegmentPayloadMinLen {
-		if err := w.flushBufferedCommandFrames(); err != nil {
-			return err
-		}
-		totalLen := segmentHeaderSize + payloadLen
-		if cap(w.scratch) < totalLen {
-			w.scratch = make([]byte, totalLen)
-		}
-		buf := w.scratch[:totalLen]
-		payload := buf[segmentHeaderSize:]
-
-		payload[0] = Version
-		binary.LittleEndian.PutUint32(payload[1:5], 1)
-
-		off := batchHeaderSize
-		payload[off] = record.Op
-		binary.LittleEndian.PutUint16(payload[off+1:off+3], keyLen)
-		binary.LittleEndian.PutUint32(payload[off+3:off+7], valLen)
-		binary.LittleEndian.PutUint64(payload[off+7:off+15], record.RID)
-		binary.LittleEndian.PutUint64(payload[off+15:off+23], record.Seq)
-		copy(payload[off+recordHeaderSize:], record.Key)
-		copy(payload[off+recordHeaderSize+len(record.Key):], record.Value)
-
-		binary.LittleEndian.PutUint32(buf[0:4], uint32(payloadLen))
-		binary.LittleEndian.PutUint32(buf[4:8], crc.ChecksumParts(payload[:batchHeaderSize], payload[batchHeaderSize:]))
-		if _, err := w.bw.Write(buf); err != nil {
-			return err
-		}
-		w.size += int64(totalLen)
-		return nil
+		return w.appendPendingRecord(record, keyLen, valLen)
 	}
 
 	if cap(w.scratch) < payloadLen {
@@ -619,6 +698,9 @@ func (w *Writer) AppendRawKVSingleCommandDirect(lsn, baseAppliedLSN uint64, op R
 	if size > int(segmentLenMask) {
 		return ErrRecordTooLarge
 	}
+	if err := w.flushPendingBatch(); err != nil {
+		return err
+	}
 	if err := w.flushBufferedCommandFrames(); err != nil {
 		return err
 	}
@@ -666,6 +748,9 @@ func (w *Writer) AppendRawKVPointCommandDirectTrusted(lsn, baseAppliedLSN uint64
 }
 
 func (w *Writer) appendRawKVPointCommandDirectTrustedSized(lsn, baseAppliedLSN uint64, op RawKVOp, key, value []byte, valueLen, payloadLen, size int) error {
+	if err := w.flushPendingBatch(); err != nil {
+		return err
+	}
 	total := segmentHeaderSize + size
 	if !w.canBufferCommandFrame(total) {
 		if cap(w.scratch) < total {
@@ -722,6 +807,9 @@ func (w *Writer) AppendRawKVBatchPayloadCommandDirectTrusted(lsn, baseAppliedLSN
 	if size > int(segmentLenMask) {
 		return ErrRecordTooLarge
 	}
+	if err := w.flushPendingBatch(); err != nil {
+		return err
+	}
 	total := segmentHeaderSize + size
 	if len(payload) >= directCommandPayloadMinLen {
 		return w.appendRawKVBatchPayloadCommandDirect(lsn, baseAppliedLSN, payload, size)
@@ -772,6 +860,9 @@ func (w *Writer) AppendCommandPayloadDirectTrusted(lsn, baseAppliedLSN uint64, k
 	if size > int(segmentLenMask) {
 		return ErrRecordTooLarge
 	}
+	if err := w.flushPendingBatch(); err != nil {
+		return err
+	}
 	total := segmentHeaderSize + size
 	if len(payload) >= directCommandPayloadMinLen {
 		return w.appendCommandPayloadDirectTrusted(lsn, baseAppliedLSN, kind, scope, format, payload, size)
@@ -793,6 +884,9 @@ func (w *Writer) AppendCommandPayloadDirectTrusted(lsn, baseAppliedLSN uint64, k
 }
 
 func (w *Writer) appendRawKVBatchPayloadCommandDirect(lsn, baseAppliedLSN uint64, payload []byte, size int) error {
+	if err := w.flushPendingBatch(); err != nil {
+		return err
+	}
 	if err := w.flushBufferedCommandFrames(); err != nil {
 		return err
 	}
@@ -826,6 +920,9 @@ func (w *Writer) appendRawKVBatchPayloadCommandDirect(lsn, baseAppliedLSN uint64
 }
 
 func (w *Writer) appendCommandPayloadDirectTrusted(lsn, baseAppliedLSN uint64, kind CommandKind, scope CommandScope, format PayloadFormat, payload []byte, size int) error {
+	if err := w.flushPendingBatch(); err != nil {
+		return err
+	}
 	if err := w.flushBufferedCommandFrames(); err != nil {
 		return err
 	}
@@ -994,6 +1091,9 @@ func (w *Writer) poisonCommandBuffer(err error) error {
 }
 
 func (w *Writer) writeSegment(payload []byte) error {
+	if err := w.flushPendingBatch(); err != nil {
+		return err
+	}
 	if err := w.flushBufferedCommandFrames(); err != nil {
 		return err
 	}
@@ -1056,6 +1156,13 @@ func (w *Writer) writeSegment(payload []byte) error {
 }
 
 func (w *Writer) writeRawSegmentWithChecksum(payload []byte, wantCRC uint32) error {
+	if err := w.flushPendingBatch(); err != nil {
+		return err
+	}
+	return w.writeRawSegmentWithChecksumNoPending(payload, wantCRC)
+}
+
+func (w *Writer) writeRawSegmentWithChecksumNoPending(payload []byte, wantCRC uint32) error {
 	if err := w.flushBufferedCommandFrames(); err != nil {
 		return err
 	}
@@ -1116,12 +1223,15 @@ func (w *Writer) Size() int64 {
 	if w == nil {
 		return 0
 	}
-	return w.size
+	return w.size + w.pendingBatchBytes()
 }
 
 func (w *Writer) Flush() error {
 	if w == nil || w.f == nil {
 		return nil
+	}
+	if err := w.flushPendingBatch(); err != nil {
+		return err
 	}
 	if err := w.flushBufferedCommandFrames(); err != nil {
 		return err
@@ -1132,6 +1242,9 @@ func (w *Writer) Flush() error {
 func (w *Writer) Sync() error {
 	if w == nil || w.f == nil {
 		return nil
+	}
+	if err := w.flushPendingBatch(); err != nil {
+		return err
 	}
 	if err := w.flushBufferedCommandFrames(); err != nil {
 		return err
@@ -1149,6 +1262,10 @@ func (w *Writer) Close() error {
 	if w.enc != nil {
 		w.enc.Close()
 		w.enc = nil
+	}
+	if err := w.flushPendingBatch(); err != nil {
+		_ = w.f.Close()
+		return err
 	}
 	if err := w.flushBufferedCommandFrames(); err != nil {
 		_ = w.f.Close()

--- a/TreeDB/wal_coalesce_reopen_test.go
+++ b/TreeDB/wal_coalesce_reopen_test.go
@@ -49,6 +49,48 @@ func TestReopenVerify_DurableWALCoalescedInlineWrites(t *testing.T) {
 	}
 }
 
+func TestReopenVerify_DurableWALForcedValueLogPointers(t *testing.T) {
+	dir := t.TempDir()
+	opts := treedb.OptionsFor(treedb.ProfileDurable, dir)
+	opts.BackgroundCheckpointInterval = -1
+	opts.BackgroundCheckpointIdleDuration = -1
+	opts.MaxWALBytes = -1
+	opts.ValueLog.PointerThreshold = 1
+
+	db, err := treedb.Open(opts)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	want := map[string][]byte{}
+	for i := 0; i < 128; i++ {
+		key := []byte(fmt.Sprintf("forced-pointer-%04d", i))
+		value := bytes.Repeat([]byte{byte(i)}, 128)
+		if err := db.SetSync(key, value); err != nil {
+			_ = db.Close()
+			t.Fatalf("set sync %q: %v", key, err)
+		}
+		want[string(key)] = bytes.Clone(value)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	reopened, err := treedb.Open(opts)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer reopened.Close()
+	for key, value := range want {
+		got, err := reopened.Get([]byte(key))
+		if err != nil {
+			t.Fatalf("get %q after reopen: %v", key, err)
+		}
+		if !bytes.Equal(got, value) {
+			t.Fatalf("get %q mismatch: got %d bytes want %d", key, len(got), len(value))
+		}
+	}
+}
+
 func TestReopenVerify_DurableWALCoalescedInlineAroundPointerRecords(t *testing.T) {
 	dir := t.TempDir()
 	opts := treedb.OptionsFor(treedb.ProfileDurable, dir)

--- a/TreeDB/wal_coalesce_reopen_test.go
+++ b/TreeDB/wal_coalesce_reopen_test.go
@@ -1,0 +1,99 @@
+package treedb_test
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	treedb "github.com/snissn/gomap/TreeDB"
+)
+
+func TestReopenVerify_DurableWALCoalescedInlineWrites(t *testing.T) {
+	dir := t.TempDir()
+	opts := treedb.OptionsFor(treedb.ProfileDurable, dir)
+	opts.BackgroundCheckpointInterval = -1
+	opts.BackgroundCheckpointIdleDuration = -1
+	opts.MaxWALBytes = -1
+
+	db, err := treedb.Open(opts)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	want := make(map[string][]byte)
+	for i := 0; i < 2048; i++ {
+		key := []byte(fmt.Sprintf("inline-%04d", i))
+		value := []byte(fmt.Sprintf("value-%04d", i))
+		if err := db.Set(key, value); err != nil {
+			_ = db.Close()
+			t.Fatalf("set %q: %v", key, err)
+		}
+		want[string(key)] = bytes.Clone(value)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	reopened, err := treedb.Open(opts)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer reopened.Close()
+	for key, value := range want {
+		got, err := reopened.Get([]byte(key))
+		if err != nil {
+			t.Fatalf("get %q after reopen: %v", key, err)
+		}
+		if !bytes.Equal(got, value) {
+			t.Fatalf("get %q mismatch: got %q want %q", key, got, value)
+		}
+	}
+}
+
+func TestReopenVerify_DurableWALCoalescedInlineAroundPointerRecords(t *testing.T) {
+	dir := t.TempDir()
+	opts := treedb.OptionsFor(treedb.ProfileDurable, dir)
+	opts.BackgroundCheckpointInterval = -1
+	opts.BackgroundCheckpointIdleDuration = -1
+	opts.MaxWALBytes = -1
+	opts.ValueLog.PointerThreshold = 64
+
+	db, err := treedb.Open(opts)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	want := map[string][]byte{}
+	for i := 0; i < 256; i++ {
+		smallKey := []byte(fmt.Sprintf("mixed-small-%04d", i))
+		smallValue := []byte(fmt.Sprintf("small-%04d", i))
+		largeKey := []byte(fmt.Sprintf("mixed-large-%04d", i))
+		largeValue := bytes.Repeat([]byte{byte(i)}, 256)
+		if err := db.Set(smallKey, smallValue); err != nil {
+			_ = db.Close()
+			t.Fatalf("set small %q: %v", smallKey, err)
+		}
+		if err := db.Set(largeKey, largeValue); err != nil {
+			_ = db.Close()
+			t.Fatalf("set large %q: %v", largeKey, err)
+		}
+		want[string(smallKey)] = bytes.Clone(smallValue)
+		want[string(largeKey)] = bytes.Clone(largeValue)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	reopened, err := treedb.Open(opts)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer reopened.Close()
+	for key, value := range want {
+		got, err := reopened.Get([]byte(key))
+		if err != nil {
+			t.Fatalf("get %q after reopen: %v", key, err)
+		}
+		if !bytes.Equal(got, value) {
+			t.Fatalf("get %q mismatch: got %d bytes want %d", key, len(got), len(value))
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Closes #2246.

This PR reduces durable TreeDB point-write WAL append overhead by coalescing adjacent unsynced inline WAL appends into existing commitlog batch frames, so the hot path pays fewer per-record syscalls/checksums while preserving recovery fences.

Key changes:

- Add per-lane WAL coalescing state guarded by `walMu` for adjacent unsynced inline point records.
- Keep sync/flush records, delete records, RID/value-log-pointer records, explicit batches, and rotation/checkpoint boundaries on explicit commit fences.
- Add a commitlog pending batch buffer for small uncompressed `Writer.Append` records, flushed on seq change, size cap, `Flush`/`Sync`/`Close`, rotation, and raw/direct command segment paths.
- Make `Writer.Size()` include pending batch bytes for existing accounting.
- Avoid command-WAL hot-path overhead by only flushing pending WAL batches from command paths when one actually exists.
- Keep the pending batch initial allocation modest (64 KiB) and grow as needed.

No new WAL on-disk format is introduced; this writes the existing batch frame format with more than one record when adjacent appends share the same seq.

## Safety / recovery notes

- `SetSync`/flush durability continues to force a fresh seq and flush/sync path.
- RID-backed records are not coalesced with inline records so value-log reachability fences remain explicit.
- Delete records are not coalesced by the DB-level point-write seam; this preserves same-key set/delete ordering across WAL replay and avoids changing delete semantics.
- Pending batches flush before explicit batches, direct/raw segments, command frames, rotation, `Flush`, `Sync`, and `Close`.

## Tests

Local:

- `GOWORK=off go test ./TreeDB/internal/commitlog ./TreeDB -run 'ReopenVerify_DurableWALCoalesced|CommitLog' -count=1`
- `GOWORK=off go test ./TreeDB/caching ./TreeDB/db ./TreeDB/internal/commitlog ./TreeDB/... -run 'WAL|CommitLog|Recovery|Checksum|WriteSync|Reopen' -count=1`
- `GOWORK=off go test ./...`
  - First full-suite attempt hit a transient `TreeDB/mongo_gateway` localhost timeout; targeted rerun passed.
  - Second full-suite run passed.

Added coverage:

- Commitlog coalesced same-seq small records read/checksum test.
- Flush-on-seq-change test.
- Checksum mismatch fail-closed test.
- Truncated tail keeps prior batch readable test.
- TreeDB durable reopen tests for coalesced inline writes and mixed inline/large pointer records.

## Core durable benchmark evidence

Host: `mikers@192.168.0.185`  
Summary: `/home/mikers/tmp/gomap_2246_core_summary.md`

Before: `/home/mikers/tmp/treedb_2246_before_core_20260603_105627` @ `c074c52c74dc52eac31c74d952e9c736bd67285e`  
After: `/home/mikers/tmp/treedb_2246_after_core_20260603_111757` @ `3bb8eb4d0ece1c856659dcb86a1d8e5245876ad8`

| test | before ops/s | after ops/s | delta |
|---|---:|---:|---:|
| sequential_write | 1,823,539 | 2,520,921 | +38.2% |
| random_write | 1,478,810 | 1,981,981 | +34.0% |
| dataset_write_random | 1,204,994 | 1,480,655 | +22.9% |
| dataset_write_sorted | 1,216,691 | 1,664,950 | +36.8% |
| batch_write | 5,477,403 | 6,254,776 | +14.2% |
| batch_write_steady | 335,526 | 382,071 | +13.9% |

Selected CPU hotspot deltas from pprof summary:

| profile/function | before | after |
|---|---:|---:|
| sequential `commitlog.Writer.Append` cum | 19.23% | 10.84% |
| sequential `appendWALOneChecked` cum | 22.12% | 15.66% |
| sequential `crc.ChecksumParts` cum | 5.77% | 0.00% |
| random `commitlog.Writer.Append` cum | 11.34% | 4.49% |
| random `Syscall6` flat | 4.64% | 3.21% |
| sorted `Syscall6` flat | 6.08% | 3.37% |
| batch_write `Syscall6` flat | 2.61% | 0.00% |

## Collection benchmark evidence

Host: `mikers@192.168.0.185`  
Summary: `/home/mikers/tmp/gomap_2246_collections_summary.md`

Before: `/home/mikers/tmp/treedb_2246_before_collections_20260603_093718` @ `c074c52c74dc52eac31c74d952e9c736bd67285e`  
After: `/home/mikers/tmp/treedb_2246_after_collections_20260603_115458` @ `3bb8eb4d0ece1c856659dcb86a1d8e5245876ad8`

Durable/checkpointed collection inserts, median ns/op:

| benchmark | before | after | delta |
|---|---:|---:|---:|
| InsertBatchCheckpointWithSecondaryIndexes | 5,444 | 5,139 | -5.6% |
| ShapeInsertBatchCheckpoint indexes_0 | 1,283 | 1,124 | -12.4% |
| ShapeInsertBatchCheckpoint indexes_1 | 3,801 | 3,159 | -16.9% |
| ShapeInsertBatchCheckpoint indexes_2 | 4,406 | 3,827 | -13.1% |
| ShapeInsertBatchCheckpoint indexes_3 | 5,052 | 4,319 | -14.5% |

Command-WAL collection mutators, median docs/s:

| benchmark | before | after | delta |
|---|---:|---:|---:|
| Insert indexed=true | 374,698 | 547,471 | +46.1% |
| Update indexed=false | 353,528 | 472,151 | +33.6% |
| Update indexed=true | 294,154 | 337,014 | +14.6% |
| Delete indexed=false | 186,894 | 225,080 | +20.4% |
| Delete indexed=true | 137,283 | 182,094 | +32.6% |

Non-checkpointed controls, median ns/op:

| benchmark | before | after | delta |
|---|---:|---:|---:|
| InsertBatchWithSecondaryIndexes | 7,281 | 7,106 | -2.4% |
| ShapeInsertBatch indexes_0 | 1,119 | 1,049 | -6.3% |
| ShapeInsertBatch indexes_1 | 6,823 | 6,575 | -3.6% |
| ShapeInsertBatch indexes_2 | 6,412 | 6,616 | +3.2% |
| ShapeInsertBatch indexes_3 | 6,591 | 6,194 | -6.0% |

Caveat: the checkpointed collection command benchmark exits non-zero both before and after due an existing benchmark failure in `BenchmarkCollectionCommandWALInsertBatchByID/indexed=false/command_wal=true` (`AppliedCommandLSN=0, want at least 1`). The remaining benchmark lines above are still emitted and were used for comparison.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented WAL record coalescing mechanism for adjacent inline records to optimize write batching.
  * Added pending batch buffering for small record appends in the commit log.

* **Tests**
  * Added comprehensive tests validating WAL coalescing sequence behavior and resets.
  * Added commit log tests for batch coalescing, flushing, and data integrity.
  * Added integration tests verifying data consistency after database restart with coalesced writes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->