### PR TITLE
TreeDB: cache scalar_u8 quantized code rows

### DIFF
--- a/TreeDB/collections/column_vector_graph_quantized_scorer.go
+++ b/TreeDB/collections/column_vector_graph_quantized_scorer.go
@@ -12,7 +12,7 @@ const columnVectorGraphScalarU8CodeScale = 255.0 * 255.0
 type columnVectorGraphScalarU8QuantizedScorer struct {
 	indexName string
 	dims      int
-	prepared  *quantizedasset.Prepared
+	codeRows  quantizedasset.CodeRowView
 	queryCode []byte
 }
 
@@ -50,25 +50,32 @@ func (r *columnVectorGraphPhysicalRowReader) prepareScalarU8QuantizedScorer(mode
 	if prepared.Rows() != r.RowCount() {
 		return columnVectorGraphScalarU8QuantizedScorer{}, fmt.Errorf("%w: column_graph %q query_mode=%s quantized index %q prepared rows=%d want graph rows=%d", ErrVectorIndexSearchUnavailable, r.def.Name, mode.String(), indexName, prepared.Rows(), r.RowCount())
 	}
-	if bytesPerRow, ok := prepared.BytesPerRow(quantizedasset.RoleCodes); !ok || bytesPerRow != r.def.Dimensions {
-		return columnVectorGraphScalarU8QuantizedScorer{}, fmt.Errorf("%w: column_graph %q query_mode=%s quantized index %q code bytes_per_row=%d ok=%v want dimensions=%d", ErrVectorIndexSearchUnavailable, r.def.Name, mode.String(), indexName, bytesPerRow, ok, r.def.Dimensions)
+	codeRows, ok := prepared.CodeRowView(quantizedasset.RoleCodes)
+	if !ok {
+		return columnVectorGraphScalarU8QuantizedScorer{}, fmt.Errorf("%w: column_graph %q query_mode=%s quantized index %q code row view unavailable", ErrVectorIndexSearchUnavailable, r.def.Name, mode.String(), indexName)
 	}
-	if elements, ok := prepared.ElementsPerRow(quantizedasset.RoleCodes); !ok || elements != r.def.Dimensions {
-		return columnVectorGraphScalarU8QuantizedScorer{}, fmt.Errorf("%w: column_graph %q query_mode=%s quantized index %q code elements_per_row=%d ok=%v want dimensions=%d", ErrVectorIndexSearchUnavailable, r.def.Name, mode.String(), indexName, elements, ok, r.def.Dimensions)
+	if codeRows.Rows() != r.RowCount() {
+		return columnVectorGraphScalarU8QuantizedScorer{}, fmt.Errorf("%w: column_graph %q query_mode=%s quantized index %q code row view rows=%d want graph rows=%d", ErrVectorIndexSearchUnavailable, r.def.Name, mode.String(), indexName, codeRows.Rows(), r.RowCount())
+	}
+	if bytesPerRow := codeRows.BytesPerRow(); bytesPerRow != r.def.Dimensions {
+		return columnVectorGraphScalarU8QuantizedScorer{}, fmt.Errorf("%w: column_graph %q query_mode=%s quantized index %q code bytes_per_row=%d want dimensions=%d", ErrVectorIndexSearchUnavailable, r.def.Name, mode.String(), indexName, bytesPerRow, r.def.Dimensions)
+	}
+	if elements := codeRows.ElementsPerRow(); elements != r.def.Dimensions {
+		return columnVectorGraphScalarU8QuantizedScorer{}, fmt.Errorf("%w: column_graph %q query_mode=%s quantized index %q code elements_per_row=%d want dimensions=%d", ErrVectorIndexSearchUnavailable, r.def.Name, mode.String(), indexName, elements, r.def.Dimensions)
 	}
 	queryCode := resizeColumnVectorGraphNativeByteScratch(scratch.quantizedQueryCodes, r.def.Dimensions)
 	for _, value := range query {
 		queryCode = append(queryCode, columnVectorGraphScalarU8Code(value*queryInvNorm))
 	}
 	scratch.quantizedQueryCodes = queryCode
-	return columnVectorGraphScalarU8QuantizedScorer{indexName: indexName, dims: r.def.Dimensions, prepared: prepared, queryCode: queryCode}, nil
+	return columnVectorGraphScalarU8QuantizedScorer{indexName: indexName, dims: r.def.Dimensions, codeRows: codeRows, queryCode: queryCode}, nil
 }
 
 func (s *columnVectorGraphScalarU8QuantizedScorer) scoreOrdinal(ordinal int, stats *columnVectorGraphNativeSearchStats) (float64, error) {
-	if s == nil || s.prepared == nil || s.dims <= 0 || len(s.queryCode) != s.dims {
+	if s == nil || !s.codeRows.Valid() || s.dims <= 0 || len(s.queryCode) != s.dims {
 		return 0, fmt.Errorf("%w: column_graph quantized scalar_u8 scorer is unavailable", ErrVectorIndexSearchUnavailable)
 	}
-	row, ok := s.prepared.CodeRowBytes(quantizedasset.RoleCodes, ordinal)
+	row, ok := s.codeRows.RowBytes(ordinal)
 	if !ok || len(row) != s.dims {
 		return 0, fmt.Errorf("%w: column_graph quantized index %q code row ordinal=%d unavailable len=%d ok=%v want %d", ErrVectorIndexSearchUnavailable, s.indexName, ordinal, len(row), ok, s.dims)
 	}
@@ -92,7 +99,7 @@ func (s *columnVectorGraphScalarU8QuantizedScorer) scoreOrdinals(ordinals []int,
 	if len(ordinals) == 0 {
 		return dst, nil
 	}
-	if s == nil || s.prepared == nil || s.dims <= 0 || len(s.queryCode) != s.dims {
+	if s == nil || !s.codeRows.Valid() || s.dims <= 0 || len(s.queryCode) != s.dims {
 		return dst[:0], fmt.Errorf("%w: column_graph quantized scalar_u8 scorer is unavailable", ErrVectorIndexSearchUnavailable)
 	}
 	if stats != nil {
@@ -100,7 +107,7 @@ func (s *columnVectorGraphScalarU8QuantizedScorer) scoreOrdinals(ordinals []int,
 	}
 	successCount := 0
 	for i, ordinal := range ordinals {
-		row, ok := s.prepared.CodeRowBytes(quantizedasset.RoleCodes, ordinal)
+		row, ok := s.codeRows.RowBytes(ordinal)
 		if !ok || len(row) != s.dims {
 			s.recordScoreStats(stats, successCount)
 			return dst[:i], fmt.Errorf("%w: column_graph quantized index %q code row ordinal=%d unavailable len=%d ok=%v want %d", ErrVectorIndexSearchUnavailable, s.indexName, ordinal, len(row), ok, s.dims)

--- a/TreeDB/internal/quantizedasset/quantized_asset.go
+++ b/TreeDB/internal/quantizedasset/quantized_asset.go
@@ -152,6 +152,18 @@ type Prepared struct {
 	footprint Footprint
 }
 
+// CodeRowView is an immutable, zero-copy fixed-width row view over a prepared
+// code role. RowBytes slices the validated payload directly, avoiding per-row
+// role-map lookups. The returned row slices alias prepared image bytes and must
+// be treated as read-only.
+type CodeRowView struct {
+	role           Role
+	rows           int
+	payload        []byte
+	bytesPerRow    int
+	elementsPerRow int
+}
+
 type preparedColumnKind uint8
 
 const (
@@ -811,6 +823,22 @@ func (p *Prepared) Footprint() Footprint {
 	return out
 }
 
+// CodeRowView returns a zero-copy fixed-width row view for fixed-byte,
+// packed-code, and dense unsigned code-vector roles. Role/kind/shape/payload
+// checks happen once when the view is created; per-row access only validates the
+// ordinal before slicing the immutable prepared payload.
+func (p *Prepared) CodeRowView(role Role) (CodeRowView, bool) {
+	col, ok := p.preparedColumn(role)
+	if !ok || !col.isCode() || col.rows < 0 || col.bytesPerRow <= 0 {
+		return CodeRowView{}, false
+	}
+	wantBytes, err := checkedMul(col.rows, col.bytesPerRow)
+	if err != nil || len(col.payload) != wantBytes {
+		return CodeRowView{}, false
+	}
+	return CodeRowView{role: role, rows: col.rows, payload: col.payload, bytesPerRow: col.bytesPerRow, elementsPerRow: col.elementsPerRow}, true
+}
+
 // CodeRowBytes returns a zero-copy row byte view for fixed-byte, packed-code,
 // and dense unsigned code-vector roles. The slice aliases the prepared image.
 func (p *Prepared) CodeRowBytes(role Role, ordinal int) ([]byte, bool) {
@@ -943,6 +971,50 @@ func (p *Prepared) DenseUint32Row(role Role, ordinal int, scratch []uint32) ([]u
 		scratch[i] = binary.LittleEndian.Uint32(row[off : off+4])
 	}
 	return scratch, true
+}
+
+// Role returns the code role validated for this view.
+func (v CodeRowView) Role() Role {
+	return v.role
+}
+
+// Valid reports whether the view was produced by Prepared.CodeRowView.
+func (v CodeRowView) Valid() bool {
+	return v.rows >= 0 && v.bytesPerRow > 0 && len(v.payload) == v.rows*v.bytesPerRow
+}
+
+// Rows returns the number of graph/vector ordinal rows covered by the view.
+func (v CodeRowView) Rows() int {
+	if !v.Valid() {
+		return 0
+	}
+	return v.rows
+}
+
+// BytesPerRow returns the validated physical bytes per code row.
+func (v CodeRowView) BytesPerRow() int {
+	if !v.Valid() {
+		return 0
+	}
+	return v.bytesPerRow
+}
+
+// ElementsPerRow returns the validated code elements per row.
+func (v CodeRowView) ElementsPerRow() int {
+	if !v.Valid() {
+		return 0
+	}
+	return v.elementsPerRow
+}
+
+// RowBytes returns a zero-copy row byte slice by graph/vector ordinal. The
+// slice aliases immutable prepared image bytes and must be treated as read-only.
+func (v CodeRowView) RowBytes(ordinal int) ([]byte, bool) {
+	if ordinal < 0 || ordinal >= v.rows || v.bytesPerRow <= 0 {
+		return nil, false
+	}
+	start := ordinal * v.bytesPerRow
+	return v.payload[start : start+v.bytesPerRow], true
 }
 
 // ElementsPerRow returns the fixed vector/code elements per row for role.

--- a/TreeDB/internal/quantizedasset/quantized_asset_test.go
+++ b/TreeDB/internal/quantizedasset/quantized_asset_test.go
@@ -217,6 +217,74 @@ func TestPreparedRandomOrdinalLookupAndScratchAllocs1932(t *testing.T) {
 	}
 }
 
+func TestPreparedCodeRowViewValidatesOnceAndSlicesRows2256(t *testing.T) {
+	fixture := buildFixedQuantizedFixture1932(t)
+	prepared, err := Prepare(fixture.prepareRequest())
+	if err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+
+	view, ok := prepared.CodeRowView(RoleCodes)
+	if !ok || !view.Valid() {
+		t.Fatalf("CodeRowView(RoleCodes) ok=%v valid=%v", ok, view.Valid())
+	}
+	if got := view.Role(); got != RoleCodes {
+		t.Fatalf("view role=%q want %q", got, RoleCodes)
+	}
+	if got := view.Rows(); got != fixture.rows {
+		t.Fatalf("view rows=%d want %d", got, fixture.rows)
+	}
+	if got := view.BytesPerRow(); got != fixture.schema.CodeDimensions {
+		t.Fatalf("view bytes_per_row=%d want %d", got, fixture.schema.CodeDimensions)
+	}
+	if got := view.ElementsPerRow(); got != fixture.schema.CodeDimensions {
+		t.Fatalf("view elements_per_row=%d want %d", got, fixture.schema.CodeDimensions)
+	}
+
+	for ordinal, want := range fixture.fixedRows {
+		row, ok := view.RowBytes(ordinal)
+		if !ok || !bytes.Equal(row, want) {
+			t.Fatalf("view row ordinal=%d row=%x ok=%v want %x", ordinal, row, ok, want)
+		}
+		generic, ok := prepared.CodeRowBytes(RoleCodes, ordinal)
+		if !ok || !bytes.Equal(generic, row) {
+			t.Fatalf("generic row ordinal=%d row=%x ok=%v want view row %x", ordinal, generic, ok, row)
+		}
+	}
+	for _, ordinal := range []int{-1, fixture.rows} {
+		if row, ok := view.RowBytes(ordinal); ok || row != nil {
+			t.Fatalf("view RowBytes(%d) row=%x ok=%v want fail-closed", ordinal, row, ok)
+		}
+	}
+	if view, ok := prepared.CodeRowView(RoleNorm); ok || view.Valid() {
+		t.Fatalf("CodeRowView(RoleNorm) ok=%v valid=%v want scalar role rejected", ok, view.Valid())
+	}
+	if view, ok := prepared.CodeRowView(RolePackedCodes); ok || view.Valid() {
+		t.Fatalf("CodeRowView(missing RolePackedCodes) ok=%v valid=%v want missing role rejected", ok, view.Valid())
+	}
+	var nilPrepared *Prepared
+	if view, ok := nilPrepared.CodeRowView(RoleCodes); ok || view.Valid() {
+		t.Fatalf("nil Prepared CodeRowView ok=%v valid=%v want rejected", ok, view.Valid())
+	}
+	var zero CodeRowView
+	if zero.Valid() {
+		t.Fatal("zero CodeRowView valid=true want false")
+	}
+	if row, ok := zero.RowBytes(0); ok || row != nil {
+		t.Fatalf("zero RowBytes row=%x ok=%v want fail-closed", row, ok)
+	}
+
+	allocs := testing.AllocsPerRun(1000, func() {
+		for ordinal := range fixture.fixedRows {
+			row, _ := view.RowBytes(ordinal)
+			quantizedAssetByteSink ^= row[0]
+		}
+	})
+	if allocs != 0 {
+		t.Fatalf("CodeRowView RowBytes allocs/run=%v want 0", allocs)
+	}
+}
+
 func TestPrepareFailsClosedPackedCodeLogicalTypeMatchesPhysical1932(t *testing.T) {
 	rows := 1
 	unpacked := []uint8{1, 0, 1, 1, 0, 0, 1, 0, 1, 0}


### PR DESCRIPTION
## Objective

Optimize the TreeDB `column_graph` `scalar_u8` quantized scorer hot path by caching a validated direct code-row view instead of calling the generic `Prepared.CodeRowBytes(RoleCodes, ordinal)` helper for every scored candidate.

Closes #2256. Refs #2169.

## Context

Coordinator profiling showed `quantized_only` spending avoidable CPU in `quantizedasset.Prepared.CodeRowBytes` and its per-candidate role-map lookup. The asset format already stores fixed-width contiguous code rows, so the scorer can validate the row view once at prepare time and slice rows directly in the scoring loop.

## Non-goals

- No on-disk/storage-format change.
- No exact/default search behavior change.
- No hidden exact fallback for quantized modes.
- No pgvector or benchmark harness behavior changes.
- No SIMD/batched byte-dot implementation; scalar byte-dot remains a follow-up.

## Design

- Added `quantizedasset.CodeRowView`, an immutable zero-copy fixed-width code-row view over prepared payload bytes.
- Added `(*Prepared).CodeRowView(role)` to validate role, code kind, rows, bytes-per-row, and payload size once.
- Kept generic `(*Prepared).CodeRowBytes` available for non-hot callers.
- Updated `columnVectorGraphScalarU8QuantizedScorer` to cache the `RoleCodes` view during scorer preparation and call `CodeRowView.RowBytes(ordinal)` in `scoreOrdinal` / `scoreOrdinals`.
- Existing prepare-time asset identity/shape validation still fails closed; scorer preparation returns `ErrVectorIndexSearchUnavailable` if the view is missing or mismatched.

## Scope

- Includes:
  - `TreeDB/internal/quantizedasset/quantized_asset.go`
  - `TreeDB/internal/quantizedasset/quantized_asset_test.go`
  - `TreeDB/collections/column_vector_graph_quantized_scorer.go`
- Excludes: storage format, exact scorer, traversal/windowing, SIMD/NEON byte-dot, pgvector harness.

## Correctness

Tests run on head `dad4653956f521c47a83c66cb7bcbd2ba995ee82`:

```sh
GOWORK=off go test ./TreeDB/internal/quantizedasset -count=1
GOWORK=off go test ./TreeDB/collections -run 'TestColumnGraphScalarU8|TestSearchVectorIndexQuantized|TestVectorIndexSearcherQuantized' -count=1
GOWORK=off go test ./TreeDB/collections ./TreeDB/internal/quantizedasset -count=1
```

Test artifact path: `/tmp/gomap_2256_tests_dad465_20260603_141455`.

Added focused unit coverage for `CodeRowView` success, scalar/missing-role rejection, ordinal bounds, nil/zero fail-closed behavior, generic `CodeRowBytes` parity, and zero-allocation row slicing.

## Performance

Initial baseline before code changes was captured at old latest `origin/main` `7f873ffd9a00bfa1fde9915b82675158efbb6f55`: `/tmp/gomap_2256_baseline_20260603_135422`.

`origin/main` advanced during the work, so final before/after evidence uses:

- Baseline clean temp worktree at `origin/main` `af2988ad74127046b3607f32c49cbee8bc74a51a`: `/tmp/gomap_2256_baseline_af2988_20260603_140706`
- Candidate head `dad4653956f521c47a83c66cb7bcbd2ba995ee82`: `/tmp/gomap_2256_candidate_dad465_20260603_141358`

Benchmark commands:

```sh
GOWORK=off go test ./TreeDB/collections -run '^$' \
  -bench '^BenchmarkColumnGraphScalarU8QuantizedScorePlanes1926/mode=(exact|quantized_only|quantized_rerank/candidates=32)$' \
  -benchmem -benchtime=3s -count=3

# Go's slash-split benchmark matcher requires an explicit rerank row command too.
GOWORK=off go test ./TreeDB/collections -run '^$' \
  -bench '^BenchmarkColumnGraphScalarU8QuantizedScorePlanes1926/mode=quantized_rerank/candidates=32$' \
  -benchmem -benchtime=3s -count=3
```

Mean of count=3, Apple M3/darwin-arm64. Exact/default code path is unchanged; exact row is included as a counter/parity sanity check, not an optimization claim.

| Mode | Baseline ns/op | Candidate ns/op | Δ ns/op | Baseline ops/sec | Candidate ops/sec | B/op | allocs/op | Quantized score calls/search | Quantized code B/search |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| `exact` | 19,183 | 16,128 | -15.9% | 52,243 | 62,010 | 0 | 0 | 0 | 0 |
| `quantized_only` | 32,053 | 26,180 | -18.3% | 31,224 | 38,226 | 0 | 0 | 169 | 21,632 |
| `quantized_rerank/candidates=32` | 30,464 | 25,932 | -14.9% | 32,828 | 38,621 | 0 | 0 | 169 | 21,632 |

Counter sanity:

- `exact`: `prepared_score_calls/search` 169 -> 169, `vector_B/search` 86,528 -> 86,528, `norm_B/search` 676 -> 676.
- `quantized_only`: `prepared_score_calls/search` 0 -> 0, `vector_B/search` 0 -> 0, `norm_B/search` 0 -> 0.
- `quantized_rerank/candidates=32`: `prepared_score_calls/search` 32 -> 32, `vector_B/search` 16,384 -> 16,384, `norm_B/search` 128 -> 128, rerank candidates 32 -> 32.

CPU profile commands/artifacts:

```sh
GOWORK=off go test ./TreeDB/collections -run '^$' \
  -bench '^BenchmarkColumnGraphScalarU8QuantizedScorePlanes1926/mode=quantized_only$' \
  -benchmem -benchtime=5s -count=1 \
  -cpuprofile <artifact>/cpu_quantized_only.pprof
```

| Function | Baseline quantized_only CPU | Candidate quantized_only CPU | Delta |
| --- | ---: | ---: | --- |
| `quantizedasset.(*Prepared).CodeRowBytes` | 0.06s flat / 0.84s cum (13.95%) | absent from top/key functions | removed from scorer hot path |
| `quantizedasset.(*Prepared).preparedColumn` | 0.01s flat / 0.29s cum (4.82%) | absent from top/key functions | per-candidate role-map lookup removed |
| `columnVectorGraphScalarU8QuantizedScorer.scoreOrdinals` | 2.80s cum (46.51%) | 1.99s cum (40.70%) | lower scorer wrapper cost |
| `scalarU8QuantizedCosineScore` | 2.02s flat/cum (33.55%) | 1.93s flat / 1.94s cum (39.67%) | now the dominant remaining scalar loop |

Profile benchmark row: baseline `30,679 ns/op` / `32,595 ops/sec`; candidate `24,878 ns/op` / `40,197 ops/sec`; both `0 B/op`, `0 allocs/op`.

## Regressions

No allocation regressions. Quantized search counters, result recall counter, exact/rerank score-call counters, and score bytes/search remain unchanged. Exact/default behavior is not touched.

## Rollout / Toggle Plan

No user-facing toggle or format migration. If needed, revert this PR to return the scalar_u8 scorer to generic `Prepared.CodeRowBytes` access.

## Follow-ups

- SIMD/batched scalar_u8 byte-dot kernel.
- Broader HNSW traversal/windowing/control-flow optimizations remain out of scope.

## AI Review Loop

- Codex latest-head review: requested after PR creation and CI start; result: no major issues.
- Copilot latest-head review: requested after PR creation and CI start; no comments/threads posted.
- CodeRabbit latest-head review: initial automatic comment reported review-credit/rate-limit state; a mature latest-head `@coderabbitai review` request then completed with no findings/open threads.
- Review comments/threads resolved or explicitly dismissed: zero unresolved non-outdated review threads.


## Coordinator Final Validation

Coordinator validation on latest head `dad4653956f521c47a83c66cb7bcbd2ba995ee82`:

```sh
GOWORK=off go test ./TreeDB/internal/quantizedasset -count=1
GOWORK=off go test ./TreeDB/collections -run 'TestColumnGraphScalarU8|TestSearchVectorIndexQuantized|TestVectorIndexSearcherQuantized' -count=1
GOWORK=off go test ./TreeDB/collections ./TreeDB/internal/quantizedasset -count=1
git diff --check origin/main...HEAD
```

All passed. Latest-head GitHub CI is green, merge state is `CLEAN`, mergeable is `MERGEABLE`, and unresolved non-outdated review threads are 0.
