### PR TITLE
TreeDB: center scalar_u8 query codes

### DIFF
--- a/TreeDB/collections/column_vector_graph_quantized_asset_test.go
+++ b/TreeDB/collections/column_vector_graph_quantized_asset_test.go
@@ -11,6 +11,7 @@ import (
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 	"github.com/snissn/gomap/TreeDB/internal/quantizedasset"
 	"github.com/snissn/gomap/TreeDB/internal/typedcolumn"
+	"github.com/snissn/gomap/TreeDB/internal/vectorops"
 )
 
 func TestColumnGraphScalarU8QuantizedAssetRebuildPrepareReopen1926(t *testing.T) {
@@ -176,6 +177,89 @@ func TestColumnGraphScalarU8QuantizedOnlyUsesPreparedCodes1926(t *testing.T) {
 	}
 	if quantized.Stats.QuantizedScoreCalls == 0 || quantized.Stats.PreparedScoreCalls != 0 || quantized.Stats.VectorBytesRead != 0 || quantized.Stats.NormBytesRead != 0 {
 		t.Fatalf("quantized stats=%+v want prepared scalar_u8 code scoring without exact vector/norm scoring", quantized.Stats)
+	}
+}
+
+func TestColumnGraphScalarU8CenteredQueryScratch2258(t *testing.T) {
+	rows := []columnGraphRebuildInputRowV2A{
+		{id: "doc-a", vector: []float32{1, 0, -1}},
+		{id: "doc-b", vector: []float32{0.25, -0.5, 0.75}},
+		{id: "doc-c", vector: []float32{-0.75, 0.25, 0.5}},
+	}
+	query := []float32{0.2, -0.4, 0.9}
+	_, d, col, def := openColumnGraphQuantizedGuardrailTestCollection1926(t, rows)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	reader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("open reader: %v", err)
+	}
+	defer func() { _ = reader.Close() }()
+	queryInvNorm, err := columnVectorGraphInvNorm(query)
+	if err != nil {
+		t.Fatalf("columnVectorGraphInvNorm query: %v", err)
+	}
+
+	if _, err := reader.prepareScalarU8QuantizedScorer(columnVectorGraphNativeSearchQueryModeQuantizedOnly, def.QuantizedIndexes[0].Name, query[:2], queryInvNorm, &columnVectorGraphNativeSearchScratch{}); !errors.Is(err, errColumnVectorGraphNativeSearchQueryDimensionMismatch) {
+		t.Fatalf("prepare short query err=%v want dimension mismatch", err)
+	}
+	if _, err := reader.prepareScalarU8QuantizedScorer(columnVectorGraphNativeSearchQueryModeQuantizedOnly, def.QuantizedIndexes[0].Name, query, queryInvNorm, nil); !errors.Is(err, errColumnVectorGraphNativeSearchScratchRequired) {
+		t.Fatalf("prepare nil scratch err=%v want scratch required", err)
+	}
+
+	var scratch columnVectorGraphNativeSearchScratch
+	scorer, err := reader.prepareScalarU8QuantizedScorer(columnVectorGraphNativeSearchQueryModeQuantizedOnly, def.QuantizedIndexes[0].Name, query, queryInvNorm, &scratch)
+	if err != nil {
+		t.Fatalf("prepare scorer: %v", err)
+	}
+	if len(scorer.queryCode) != def.Dimensions || !scorer.centeredQuery.ValidForDims(def.Dimensions) {
+		t.Fatalf("scorer query_code_len=%d centered=%+v dims=%d", len(scorer.queryCode), scorer.centeredQuery, def.Dimensions)
+	}
+	for i, code := range scorer.queryCode {
+		want := vectorops.ScalarU8CenteredValue(code)
+		if got := scorer.centeredQuery.Values[i]; got != want {
+			t.Fatalf("centered query[%d]=%d want %d from code %d", i, got, want, code)
+		}
+	}
+	row, ok := scorer.codeRows.RowBytes(1)
+	if !ok {
+		t.Fatal("row 1 code bytes unavailable")
+	}
+	got, err := scorer.scoreOrdinal(1, nil)
+	if err != nil {
+		t.Fatalf("scoreOrdinal: %v", err)
+	}
+	var legacyDot int64
+	for i, qc := range scorer.queryCode {
+		q := int64(2*int(qc) - 255)
+		c := int64(2*int(row[i]) - 255)
+		legacyDot += q * c
+	}
+	want := float64(legacyDot) / columnVectorGraphScalarU8CodeScale
+	if math.Abs(got-want) > 1e-12 {
+		t.Fatalf("centered score=%v want legacy=%v", got, want)
+	}
+
+	_, err = reader.prepareScalarU8QuantizedScorer(columnVectorGraphNativeSearchQueryModeQuantizedOnly, def.QuantizedIndexes[0].Name, query, queryInvNorm, &scratch)
+	if err != nil {
+		t.Fatalf("warm prepare scorer: %v", err)
+	}
+	var stats columnVectorGraphNativeSearchStats
+	allocs := testing.AllocsPerRun(1000, func() {
+		scorer, err := reader.prepareScalarU8QuantizedScorer(columnVectorGraphNativeSearchQueryModeQuantizedOnly, def.QuantizedIndexes[0].Name, query, queryInvNorm, &scratch)
+		if err != nil {
+			panic(err)
+		}
+		score, err := scorer.scoreOrdinal(1, &stats)
+		if err != nil {
+			panic(err)
+		}
+		columnPhysicalScanBenchSum += int64(score * 1_000_000)
+	})
+	if allocs != 0 {
+		t.Fatalf("steady-state centered scalar_u8 prepare+score allocs/run=%v want 0", allocs)
 	}
 }
 
@@ -439,6 +523,10 @@ func scalarU8QuantizedTopKForTest1926(tb testing.TB, rows []columnGraphRebuildIn
 	for i, value := range query {
 		queryCodes[i] = columnVectorGraphScalarU8Code(value * queryInvNorm)
 	}
+	queryCentered, _, ok := vectorops.PrepareScalarU8CenteredQuery(make([]vectorops.ScalarU8CenteredCode, 0, len(queryCodes)), queryCodes, len(queryCodes))
+	if !ok {
+		tb.Fatalf("PrepareScalarU8CenteredQuery query dims=%d", len(queryCodes))
+	}
 	var top []columnVectorGraphSearchCandidate
 	rowCodes := make([]byte, len(query))
 	for ordinal, row := range rows {
@@ -449,7 +537,10 @@ func scalarU8QuantizedTopKForTest1926(tb testing.TB, rows []columnGraphRebuildIn
 		for i, value := range row.vector {
 			rowCodes[i] = columnVectorGraphScalarU8Code(value * invNorm)
 		}
-		score := scalarU8QuantizedCosineScore(queryCodes, rowCodes)
+		score, ok := scalarU8CenteredQuantizedCosineScore(queryCentered, rowCodes)
+		if !ok {
+			tb.Fatalf("scalarU8CenteredQuantizedCosineScore row %d", ordinal)
+		}
 		top = insertColumnGraphTopForTest(top, topK, columnVectorGraphSearchCandidate{ordinal: ordinal, score: score})
 	}
 	out := make([]columnVectorGraphNativeSearchResult, len(top))

--- a/TreeDB/collections/column_vector_graph_quantized_scorer.go
+++ b/TreeDB/collections/column_vector_graph_quantized_scorer.go
@@ -5,6 +5,7 @@ import (
 	"math"
 
 	"github.com/snissn/gomap/TreeDB/internal/quantizedasset"
+	"github.com/snissn/gomap/TreeDB/internal/vectorops"
 )
 
 const columnVectorGraphScalarU8CodeScale = 255.0 * 255.0
@@ -13,7 +14,9 @@ type columnVectorGraphScalarU8QuantizedScorer struct {
 	indexName string
 	dims      int
 	codeRows  quantizedasset.CodeRowView
-	queryCode []byte
+	// queryCode and centeredQuery alias caller-owned search scratch.
+	queryCode     []byte
+	centeredQuery vectorops.ScalarU8CenteredQuery
 }
 
 func (r *columnVectorGraphPhysicalRowReader) prepareScalarU8QuantizedScorer(mode columnVectorGraphNativeSearchQueryMode, indexName string, query []float32, queryInvNorm float32, scratch *columnVectorGraphNativeSearchScratch) (columnVectorGraphScalarU8QuantizedScorer, error) {
@@ -46,6 +49,9 @@ func (r *columnVectorGraphPhysicalRowReader) prepareScalarU8QuantizedScorer(mode
 	if len(query) != r.def.Dimensions {
 		return columnVectorGraphScalarU8QuantizedScorer{}, fmt.Errorf("collections: column_graph %q query dims=%d want %d: %w", r.def.Name, len(query), r.def.Dimensions, errColumnVectorGraphNativeSearchQueryDimensionMismatch)
 	}
+	if scratch == nil {
+		return columnVectorGraphScalarU8QuantizedScorer{}, fmt.Errorf("collections: column_graph %q: %w", r.def.Name, errColumnVectorGraphNativeSearchScratchRequired)
+	}
 	prepared := status.Prepared
 	if prepared.Rows() != r.RowCount() {
 		return columnVectorGraphScalarU8QuantizedScorer{}, fmt.Errorf("%w: column_graph %q query_mode=%s quantized index %q prepared rows=%d want graph rows=%d", ErrVectorIndexSearchUnavailable, r.def.Name, mode.String(), indexName, prepared.Rows(), r.RowCount())
@@ -68,11 +74,17 @@ func (r *columnVectorGraphPhysicalRowReader) prepareScalarU8QuantizedScorer(mode
 		queryCode = append(queryCode, columnVectorGraphScalarU8Code(value*queryInvNorm))
 	}
 	scratch.quantizedQueryCodes = queryCode
-	return columnVectorGraphScalarU8QuantizedScorer{indexName: indexName, dims: r.def.Dimensions, codeRows: codeRows, queryCode: queryCode}, nil
+	centeredScratch := resizeColumnVectorGraphNativeScalarU8CenteredScratch(scratch.quantizedQueryCentered, r.def.Dimensions)
+	centeredQuery, centeredScratch, ok := vectorops.PrepareScalarU8CenteredQuery(centeredScratch, queryCode, r.def.Dimensions)
+	if !ok {
+		return columnVectorGraphScalarU8QuantizedScorer{}, fmt.Errorf("%w: column_graph %q query_mode=%s quantized index %q centered scalar_u8 query unavailable", ErrVectorIndexSearchUnavailable, r.def.Name, mode.String(), indexName)
+	}
+	scratch.quantizedQueryCentered = centeredScratch
+	return columnVectorGraphScalarU8QuantizedScorer{indexName: indexName, dims: r.def.Dimensions, codeRows: codeRows, queryCode: queryCode, centeredQuery: centeredQuery}, nil
 }
 
 func (s *columnVectorGraphScalarU8QuantizedScorer) scoreOrdinal(ordinal int, stats *columnVectorGraphNativeSearchStats) (float64, error) {
-	if s == nil || !s.codeRows.Valid() || s.dims <= 0 || len(s.queryCode) != s.dims {
+	if s == nil || !s.codeRows.Valid() || s.dims <= 0 || len(s.queryCode) != s.dims || !s.centeredQuery.ValidForDims(s.dims) {
 		return 0, fmt.Errorf("%w: column_graph quantized scalar_u8 scorer is unavailable", ErrVectorIndexSearchUnavailable)
 	}
 	row, ok := s.codeRows.RowBytes(ordinal)
@@ -83,8 +95,8 @@ func (s *columnVectorGraphScalarU8QuantizedScorer) scoreOrdinal(ordinal int, sta
 		recordColumnVectorGraphScoreBatchStats(stats, 1, false, true)
 		s.recordScoreStats(stats, 1)
 	}
-	score := scalarU8QuantizedCosineScore(s.queryCode, row)
-	if math.IsNaN(score) || math.IsInf(score, 0) {
+	score, ok := scalarU8CenteredQuantizedCosineScore(s.centeredQuery, row)
+	if !ok || math.IsNaN(score) || math.IsInf(score, 0) {
 		return 0, fmt.Errorf("collections: column_graph quantized index %q candidate ordinal=%d scalar_u8 score is not finite", s.indexName, ordinal)
 	}
 	return score, nil
@@ -99,7 +111,7 @@ func (s *columnVectorGraphScalarU8QuantizedScorer) scoreOrdinals(ordinals []int,
 	if len(ordinals) == 0 {
 		return dst, nil
 	}
-	if s == nil || !s.codeRows.Valid() || s.dims <= 0 || len(s.queryCode) != s.dims {
+	if s == nil || !s.codeRows.Valid() || s.dims <= 0 || len(s.queryCode) != s.dims || !s.centeredQuery.ValidForDims(s.dims) {
 		return dst[:0], fmt.Errorf("%w: column_graph quantized scalar_u8 scorer is unavailable", ErrVectorIndexSearchUnavailable)
 	}
 	if stats != nil {
@@ -112,8 +124,8 @@ func (s *columnVectorGraphScalarU8QuantizedScorer) scoreOrdinals(ordinals []int,
 			s.recordScoreStats(stats, successCount)
 			return dst[:i], fmt.Errorf("%w: column_graph quantized index %q code row ordinal=%d unavailable len=%d ok=%v want %d", ErrVectorIndexSearchUnavailable, s.indexName, ordinal, len(row), ok, s.dims)
 		}
-		score := scalarU8QuantizedCosineScore(s.queryCode, row)
-		if math.IsNaN(score) || math.IsInf(score, 0) {
+		score, ok := scalarU8CenteredQuantizedCosineScore(s.centeredQuery, row)
+		if !ok || math.IsNaN(score) || math.IsInf(score, 0) {
 			s.recordScoreStats(stats, successCount)
 			return dst[:i], fmt.Errorf("collections: column_graph quantized index %q candidate ordinal=%d scalar_u8 score is not finite", s.indexName, ordinal)
 		}
@@ -135,12 +147,10 @@ func (s *columnVectorGraphScalarU8QuantizedScorer) recordScoreStats(stats *colum
 	stats.QuantizedCodeBytesRead += count64 * uint64(s.dims)
 }
 
-func scalarU8QuantizedCosineScore(queryCode, row []byte) float64 {
-	var dot int64
-	for i, qc := range queryCode {
-		q := int64(2*int(qc) - 255)
-		c := int64(2*int(row[i]) - 255)
-		dot += q * c
+func scalarU8CenteredQuantizedCosineScore(query vectorops.ScalarU8CenteredQuery, row []byte) (float64, bool) {
+	dot, ok := vectorops.ScalarU8CenteredDot(query, row)
+	if !ok {
+		return 0, false
 	}
-	return float64(dot) / columnVectorGraphScalarU8CodeScale
+	return float64(dot) / columnVectorGraphScalarU8CodeScale, true
 }

--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/snissn/gomap/TreeDB/internal/typedcolumn"
 	"github.com/snissn/gomap/TreeDB/internal/typeddecode"
+	"github.com/snissn/gomap/TreeDB/internal/vectorops"
 )
 
 // Keep modest scratch overgrowth to avoid realloc churn when callers vary
@@ -864,26 +865,27 @@ type columnVectorGraphSearchCandidate struct {
 // It is not concurrency-safe. Parallel searches over immutable graph assets are
 // valid with one reader and one scratch per worker.
 type columnVectorGraphNativeSearchScratch struct {
-	scoreScratch        columnPhysicalRowReaderScratch
-	expandScratch       columnPhysicalRowReaderScratch
-	resultScratch       columnPhysicalRowReaderScratch
-	visitMarks          []uint64
-	visitEpoch          uint64
-	frontier            []columnVectorGraphSearchCandidate
-	top                 []columnVectorGraphSearchCandidate
-	results             []columnVectorGraphNativeSearchResult
-	idBuffers           [][]byte
-	resultOrder         []int
-	resultOrdinals      []int
-	resultRowRefs       []DocumentRowRef
-	resultHasRefs       []bool
-	scoreTileOrdinals   []int
-	scoreTileScores     []float64
-	scoreTileRowIDs     []uint32
-	scoreTileDots       []float32
-	quantizedQueryCodes []byte
-	wavefrontCandidates []columnVectorGraphSearchCandidate
-	searchPlan          columnVectorGraphSearchPlan
+	scoreScratch           columnPhysicalRowReaderScratch
+	expandScratch          columnPhysicalRowReaderScratch
+	resultScratch          columnPhysicalRowReaderScratch
+	visitMarks             []uint64
+	visitEpoch             uint64
+	frontier               []columnVectorGraphSearchCandidate
+	top                    []columnVectorGraphSearchCandidate
+	results                []columnVectorGraphNativeSearchResult
+	idBuffers              [][]byte
+	resultOrder            []int
+	resultOrdinals         []int
+	resultRowRefs          []DocumentRowRef
+	resultHasRefs          []bool
+	scoreTileOrdinals      []int
+	scoreTileScores        []float64
+	scoreTileRowIDs        []uint32
+	scoreTileDots          []float32
+	quantizedQueryCodes    []byte
+	quantizedQueryCentered []vectorops.ScalarU8CenteredCode
+	wavefrontCandidates    []columnVectorGraphSearchCandidate
+	searchPlan             columnVectorGraphSearchPlan
 }
 
 func (s *columnVectorGraphNativeSearchScratch) prepare(rowCount, dimensions, degree, topK, efSearch, scoreTileCapacity, wavefrontWidth int) error {
@@ -1037,6 +1039,13 @@ func resizeColumnVectorGraphNativeFloat64Scratch(dst []float64, target int) []fl
 func resizeColumnVectorGraphNativeByteScratch(dst []byte, target int) []byte {
 	if cap(dst) < target || columnVectorGraphNativeScratchCapOversized(cap(dst), target) {
 		return make([]byte, 0, target)
+	}
+	return dst[:0]
+}
+
+func resizeColumnVectorGraphNativeScalarU8CenteredScratch(dst []vectorops.ScalarU8CenteredCode, target int) []vectorops.ScalarU8CenteredCode {
+	if cap(dst) < target || columnVectorGraphNativeScratchCapOversized(cap(dst), target) {
+		return make([]vectorops.ScalarU8CenteredCode, 0, target)
 	}
 	return dst[:0]
 }

--- a/TreeDB/internal/vectorops/doc.go
+++ b/TreeDB/internal/vectorops/doc.go
@@ -6,5 +6,6 @@
 // Row-major batch dot wrappers accept flat []float32 payloads and ordinal/row-id
 // tiles directly. They validate full-row shapes, leave dst unchanged for invalid
 // shapes, and report whether a platform batch SIMD kernel or a non-batch
-// fallback handled the call.
+// fallback handled the call. Scalar_u8 helpers expose centered int16 query
+// layouts for future indexed u8 kernels while keeping callers allocation-free.
 package vectorops

--- a/TreeDB/internal/vectorops/scalar_u8.go
+++ b/TreeDB/internal/vectorops/scalar_u8.go
@@ -1,0 +1,63 @@
+package vectorops
+
+const scalarU8CenterOffset = 255
+
+// ScalarU8CenteredCode is the stable element type for centered scalar_u8 query
+// codes. Each value is 2*code-255, so the valid range is [-255, 255]. The
+// slice layout is contiguous native-endian int16 values with ordinary Go slice
+// alignment; SIMD backends that consume this layout must tolerate unaligned
+// loads.
+type ScalarU8CenteredCode = int16
+
+// ScalarU8CenteredQuery is a validated, allocation-free view over centered
+// scalar_u8 query codes. Values aliases caller-owned scratch and remains valid
+// until that scratch is reused.
+type ScalarU8CenteredQuery struct {
+	Values []ScalarU8CenteredCode
+}
+
+// Dims returns the number of centered query dimensions.
+func (q ScalarU8CenteredQuery) Dims() int { return len(q.Values) }
+
+// Valid reports whether q has a positive-dimension centered-code layout.
+func (q ScalarU8CenteredQuery) Valid() bool { return len(q.Values) > 0 }
+
+// ValidForDims reports whether q is valid for exactly dims dimensions.
+func (q ScalarU8CenteredQuery) ValidForDims(dims int) bool {
+	return dims > 0 && len(q.Values) == dims
+}
+
+// ScalarU8CenteredValue returns the centered scalar_u8 value 2*code-255.
+func ScalarU8CenteredValue(code byte) ScalarU8CenteredCode {
+	return ScalarU8CenteredCode(2*int(code) - scalarU8CenterOffset)
+}
+
+// PrepareScalarU8CenteredQuery fills dst with centered values for codes and
+// returns a validated query view. The function never allocates: callers must
+// provide scratch capacity for dims values. Invalid dimensions or insufficient
+// scratch return ok=false and leave dst contents unspecified.
+func PrepareScalarU8CenteredQuery(dst []ScalarU8CenteredCode, codes []byte, dims int) (query ScalarU8CenteredQuery, scratch []ScalarU8CenteredCode, ok bool) {
+	if dims <= 0 || len(codes) != dims || cap(dst) < dims {
+		return ScalarU8CenteredQuery{}, dst[:0], false
+	}
+	dst = dst[:dims]
+	for i, code := range codes {
+		dst[i] = ScalarU8CenteredValue(code)
+	}
+	return ScalarU8CenteredQuery{Values: dst}, dst, true
+}
+
+// ScalarU8CenteredDot computes the integer dot product between a centered query
+// and a raw scalar_u8 row. The row is centered as 2*row_code-255 while the query
+// is consumed from its pre-centered layout.
+func ScalarU8CenteredDot(query ScalarU8CenteredQuery, row []byte) (int64, bool) {
+	if !query.Valid() || len(row) != len(query.Values) {
+		return 0, false
+	}
+	var dot int64
+	for i, q := range query.Values {
+		c := ScalarU8CenteredValue(row[i])
+		dot += int64(q) * int64(c)
+	}
+	return dot, true
+}

--- a/TreeDB/internal/vectorops/scalar_u8_test.go
+++ b/TreeDB/internal/vectorops/scalar_u8_test.go
@@ -1,0 +1,108 @@
+package vectorops
+
+import "testing"
+
+var (
+	scalarU8CenteredQuerySink ScalarU8CenteredQuery
+	scalarU8CenteredDotSink   int64
+)
+
+func TestScalarU8CenteredQueryParity2258(t *testing.T) {
+	codes := []byte{0, 1, 127, 128, 254, 255}
+	row := []byte{255, 254, 128, 127, 1, 0}
+	dst := make([]ScalarU8CenteredCode, 0, len(codes))
+
+	query, scratch, ok := PrepareScalarU8CenteredQuery(dst, codes, len(codes))
+	if !ok || !query.ValidForDims(len(codes)) || len(scratch) != len(codes) {
+		t.Fatalf("PrepareScalarU8CenteredQuery ok=%v query=%+v scratch_len=%d", ok, query, len(scratch))
+	}
+	wantCentered := []ScalarU8CenteredCode{-255, -253, -1, 1, 253, 255}
+	for i, want := range wantCentered {
+		if got := query.Values[i]; got != want {
+			t.Fatalf("centered[%d]=%d want %d", i, got, want)
+		}
+		if got := ScalarU8CenteredValue(codes[i]); got != want {
+			t.Fatalf("ScalarU8CenteredValue(%d)=%d want %d", codes[i], got, want)
+		}
+	}
+
+	gotDot, ok := ScalarU8CenteredDot(query, row)
+	if !ok {
+		t.Fatal("ScalarU8CenteredDot rejected valid query/row")
+	}
+	var wantDot int64
+	for i, qc := range codes {
+		q := int64(2*int(qc) - 255)
+		c := int64(2*int(row[i]) - 255)
+		wantDot += q * c
+	}
+	if gotDot != wantDot {
+		t.Fatalf("centered dot=%d want legacy dot=%d", gotDot, wantDot)
+	}
+}
+
+func TestScalarU8CenteredQueryRejectsInvalidShapes2258(t *testing.T) {
+	codes := []byte{1, 2, 3}
+	validScratch := make([]ScalarU8CenteredCode, 0, len(codes))
+	cases := []struct {
+		name  string
+		dst   []ScalarU8CenteredCode
+		codes []byte
+		dims  int
+	}{
+		{name: "zero_dims", dst: validScratch, codes: codes, dims: 0},
+		{name: "negative_dims", dst: validScratch, codes: codes, dims: -1},
+		{name: "short_codes", dst: validScratch, codes: codes[:2], dims: 3},
+		{name: "long_codes", dst: validScratch, codes: append(append([]byte(nil), codes...), 4), dims: 3},
+		{name: "nil_scratch", dst: nil, codes: codes, dims: 3},
+		{name: "short_scratch", dst: make([]ScalarU8CenteredCode, 0, 2), codes: codes, dims: 3},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			query, scratch, ok := PrepareScalarU8CenteredQuery(tc.dst, tc.codes, tc.dims)
+			if ok || query.Valid() || len(scratch) != 0 {
+				t.Fatalf("PrepareScalarU8CenteredQuery ok=%v query=%+v scratch_len=%d want invalid", ok, query, len(scratch))
+			}
+		})
+	}
+
+	query, _, ok := PrepareScalarU8CenteredQuery(validScratch, codes, len(codes))
+	if !ok {
+		t.Fatal("valid centered query rejected")
+	}
+	if dot, ok := ScalarU8CenteredDot(ScalarU8CenteredQuery{}, codes); ok || dot != 0 {
+		t.Fatalf("zero query dot=%d ok=%v want invalid", dot, ok)
+	}
+	if dot, ok := ScalarU8CenteredDot(query, codes[:2]); ok || dot != 0 {
+		t.Fatalf("short row dot=%d ok=%v want invalid", dot, ok)
+	}
+}
+
+func TestScalarU8CenteredQueryZeroAllocs2258(t *testing.T) {
+	codes := make([]byte, 128)
+	row := make([]byte, 128)
+	for i := range codes {
+		codes[i] = byte((i*17 + 3) & 0xff)
+		row[i] = byte((255 - i*11) & 0xff)
+	}
+	dst := make([]ScalarU8CenteredCode, 0, len(codes))
+
+	allocs := testing.AllocsPerRun(1000, func() {
+		query, scratch, ok := PrepareScalarU8CenteredQuery(dst, codes, len(codes))
+		if !ok {
+			panic("valid centered query rejected")
+		}
+		dot, ok := ScalarU8CenteredDot(query, row)
+		if !ok {
+			panic("valid centered dot rejected")
+		}
+		scalarU8CenteredQuerySink = query
+		scalarU8CenteredDotSink += dot + int64(len(scratch))
+	})
+	if allocs != 0 {
+		t.Fatalf("centered scalar_u8 query allocs/run=%v want 0", allocs)
+	}
+	if !scalarU8CenteredQuerySink.ValidForDims(len(codes)) || scalarU8CenteredDotSink == 0 {
+		t.Fatalf("unexpected zero sinks: query=%+v dot=%d", scalarU8CenteredQuerySink, scalarU8CenteredDotSink)
+	}
+}


### PR DESCRIPTION
Closes #2258. Parent tracker: #2169.

## Scope

- Adds a SIMD-ready centered scalar_u8 query layout in `TreeDB/internal/vectorops`:
  - `ScalarU8CenteredCode = int16`
  - `ScalarU8CenteredQuery{Values []int16}` over contiguous scratch-owned values
  - preparation computes `2*qcode-255` once from query scalar_u8 bytes.
- Stores centered query scratch in `columnVectorGraphNativeSearchScratch` and carries the validated view in `columnVectorGraphScalarU8QuantizedScorer`.
- Updates scalar_u8 quantized scoring to consume the centered query values so the per-candidate/per-dimension loop no longer recomputes query centering.
- Adds parity, invalid-shape/nil-scratch, and zero-allocation tests for vectorops/scorer preparation.

## Non-goals / invariants

- No exact/default TreeDB vector search behavior change.
- No hidden exact fallback in quantized modes; unsupported/malformed quantized paths still fail closed.
- No on-disk format changes.
- No pgvector/harness changes.
- No full SIMD kernels here; this only lands the reusable centered-query layout and scalar consumption needed by #2259/#2260.

## Local review

- Read-only high-thinking Pi reviewer: PASS, no blocking findings.

## Tests

Artifacts: `/tmp/gomap_2258_final_tests_20260603_151920`

```sh
GOWORK=off go test ./TreeDB/collections -run 'TestColumnGraphScalarU8|TestSearchVectorIndexQuantized|TestVectorIndexSearcherQuantized' -count=1
GOWORK=off go test ./TreeDB/collections ./TreeDB/internal/quantizedasset ./TreeDB/internal/vectorops -count=1
GOWORK=off go test ./TreeDB/internal/vectorops -count=1
```

Results: all passed.

## Benchmarks / profiles

Baseline artifact: `/tmp/gomap_2258_baseline_20260603_150412`  
Candidate artifact: `/tmp/gomap_2258_candidate_20260603_151006`

Commands used:

```sh
# Requested grouped command (Go sub-benchmark path matching emitted exact + quantized_only rows in bench.txt.)
GOWORK=off go test ./TreeDB/collections -run '^$' \
  -bench '^BenchmarkColumnGraphScalarU8QuantizedScorePlanes1926/mode=(exact|quantized_only|quantized_rerank/candidates=32)$' \
  -benchmem -benchtime=3s -count=5

# Separate rerank row capture for the slash-separated sub-benchmark.
GOWORK=off go test ./TreeDB/collections -run '^$' \
  -bench '^BenchmarkColumnGraphScalarU8QuantizedScorePlanes1926/mode=quantized_rerank/candidates=32$' \
  -benchmem -benchtime=3s -count=5

# Quantized-only CPU profile before/after.
GOWORK=off go test ./TreeDB/collections -run '^$' \
  -bench '^BenchmarkColumnGraphScalarU8QuantizedScorePlanes1926/mode=quantized_only$' \
  -benchmem -benchtime=5s -count=1 \
  -cpuprofile <artifact>/cpu_quantized_only.pprof
```

Mean table (Apple M3 / darwin-arm64):

| Mode | Baseline ns/op | Candidate ns/op | Δ ns/op | Baseline ops/sec | Candidate ops/sec | Δ ops/sec | B/op | allocs/op | quantized_score_calls/search | quantized_code_B/search | rerank candidates/search | rerank exact calls/search |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| exact/default | 16,482 | 16,006 | -2.89% | 60,710 | 62,487 | +2.93% | 0 | 0 | 0 | 0 | 0 | 0 |
| quantized_only | 24,846 | 23,420 | -5.74% | 40,252 | 42,713 | +6.11% | 0 | 0 | 169 | 21,632 | 0 | 0 |
| quantized_rerank/candidates=32 | 25,748 | 24,281 | -5.70% | 38,838 | 41,191 | +6.06% | 0 | 0 | 169 | 21,632 | 32 | 32 |

Profile deltas (`cpu_quantized_only.pprof`, top files and diff in candidate artifact):

| Profile item | Baseline | Candidate | Delta / note |
| --- | ---: | ---: | --- |
| Old scorer callee | `scalarU8QuantizedCosineScore`: 2.09s flat / 2.10s cum | removed | per-candidate query centering is gone |
| New centered dot | n/a | `vectorops.ScalarU8CenteredDot`: 1.60s flat / 1.66s cum | consumes pre-centered query values |
| Wrapper callee work | n/a | `scalarU8CenteredQuantizedCosineScore`: 1.88s cum | ~0.22s less than old scorer callee in sampled run |
| `scoreOrdinals` cum | 2.14s | 2.04s | ~4.7% lower cum in sampled run |

Allocation/counter check: search remains `0 B/op`, `0 allocs/op`; quantized score calls and code bytes/search are unchanged.

## CI / AI review status

- CI: latest head `ebb0fd7761529db63786f37659f95747ea5c45f9` green; merge state `CLEAN` / `MERGEABLE` at closeout.
- Codex: requested after mature PR creation (`@codex review`); result: no major issues.
- Copilot: requested after mature PR creation (`@copilot review`); no response/findings observed.
- CodeRabbit: auto-triggered on PR creation but rate-limited/usage-limited; status context passed as review skipped, no actionable findings.
- Merge: coordinator-owned; this PR is handed off, not self-merged.

## Risks / deferrals

- This is scalar consumption of a SIMD-ready layout only; #2259 owns SIMD kernels and #2260 owns batch integration.
- The centered query view aliases caller-owned search scratch and is valid only until that scratch is reused, matching existing search scratch lifetime.



## Coordinator Final Validation

Coordinator validation on latest head `ebb0fd7761529db63786f37659f95747ea5c45f9`:

```sh
GOWORK=off go test ./TreeDB/internal/vectorops -count=1
GOWORK=off go test ./TreeDB/collections -run 'TestColumnGraphScalarU8|TestSearchVectorIndexQuantized|TestVectorIndexSearcherQuantized' -count=1
GOWORK=off go test ./TreeDB/collections ./TreeDB/internal/quantizedasset ./TreeDB/internal/vectorops -count=1
git diff --check origin/main...HEAD
```

All passed. Latest-head CI is green, merge state is `CLEAN`, mergeable is `MERGEABLE`, and unresolved non-outdated review threads are 0.
