### PR TITLE
TreeDB: add SIMD scalar_u8 indexed dot kernels

### DIFF
--- a/TreeDB/collections/column_vector_graph_quantized_asset_test.go
+++ b/TreeDB/collections/column_vector_graph_quantized_asset_test.go
@@ -219,8 +219,9 @@ func TestColumnGraphScalarU8CenteredQueryScratch2258(t *testing.T) {
 	}
 	for i, code := range scorer.queryCode {
 		want := vectorops.ScalarU8CenteredValue(code)
-		if got := scorer.centeredQuery.Values[i]; got != want {
-			t.Fatalf("centered query[%d]=%d want %d from code %d", i, got, want, code)
+		got, ok := scorer.centeredQuery.Value(i)
+		if !ok || got != want {
+			t.Fatalf("centered query[%d]=%d ok=%v want %d from code %d", i, got, ok, want, code)
 		}
 	}
 	row, ok := scorer.codeRows.RowBytes(1)

--- a/TreeDB/internal/vectorops/doc.go
+++ b/TreeDB/internal/vectorops/doc.go
@@ -7,5 +7,6 @@
 // tiles directly. They validate full-row shapes, leave dst unchanged for invalid
 // shapes, and report whether a platform batch SIMD kernel or a non-batch
 // fallback handled the call. Scalar_u8 helpers expose centered int16 query
-// layouts for future indexed u8 kernels while keeping callers allocation-free.
+// layouts and indexed row-major byte-code dot kernels while keeping callers
+// allocation-free.
 package vectorops

--- a/TreeDB/internal/vectorops/scalar_u8.go
+++ b/TreeDB/internal/vectorops/scalar_u8.go
@@ -10,10 +10,15 @@ const scalarU8CenterOffset = 255
 type ScalarU8CenteredCode = int16
 
 // ScalarU8CenteredQuery is a validated, allocation-free view over centered
-// scalar_u8 query codes. Values aliases caller-owned scratch and remains valid
-// until that scratch is reused.
+// scalar_u8 query codes. Values aliases caller-owned scratch, must be treated as
+// immutable while the query is in use, and remains valid until that scratch is
+// reused. Mutating Values after preparation invalidates cached query metadata
+// consumed by batch kernels.
 type ScalarU8CenteredQuery struct {
 	Values []ScalarU8CenteredCode
+
+	sum      int64
+	sumValid bool
 }
 
 // Dims returns the number of centered query dimensions.
@@ -25,6 +30,17 @@ func (q ScalarU8CenteredQuery) Valid() bool { return len(q.Values) > 0 }
 // ValidForDims reports whether q is valid for exactly dims dimensions.
 func (q ScalarU8CenteredQuery) ValidForDims(dims int) bool {
 	return dims > 0 && len(q.Values) == dims
+}
+
+// CenteredSum returns sum(q.Values). Queries returned by
+// PrepareScalarU8CenteredQuery carry this value so batch kernels can reuse it
+// without rescanning the query per call. Manually constructed queries still
+// return the correct sum by scanning Values.
+func (q ScalarU8CenteredQuery) CenteredSum() int64 {
+	if q.sumValid {
+		return q.sum
+	}
+	return scalarU8CenteredQuerySum(q.Values)
 }
 
 // ScalarU8CenteredValue returns the centered scalar_u8 value 2*code-255.
@@ -41,10 +57,13 @@ func PrepareScalarU8CenteredQuery(dst []ScalarU8CenteredCode, codes []byte, dims
 		return ScalarU8CenteredQuery{}, dst[:0], false
 	}
 	dst = dst[:dims]
+	var sum int64
 	for i, code := range codes {
-		dst[i] = ScalarU8CenteredValue(code)
+		centered := ScalarU8CenteredValue(code)
+		dst[i] = centered
+		sum += int64(centered)
 	}
-	return ScalarU8CenteredQuery{Values: dst}, dst, true
+	return ScalarU8CenteredQuery{Values: dst, sum: sum, sumValid: true}, dst, true
 }
 
 // ScalarU8CenteredDot computes the integer dot product between a centered query

--- a/TreeDB/internal/vectorops/scalar_u8.go
+++ b/TreeDB/internal/vectorops/scalar_u8.go
@@ -18,6 +18,7 @@ type ScalarU8CenteredQuery struct {
 	Values []ScalarU8CenteredCode
 
 	sum      int64
+	sumDims  int
 	sumValid bool
 }
 
@@ -34,10 +35,10 @@ func (q ScalarU8CenteredQuery) ValidForDims(dims int) bool {
 
 // CenteredSum returns sum(q.Values). Queries returned by
 // PrepareScalarU8CenteredQuery carry this value so batch kernels can reuse it
-// without rescanning the query per call. Manually constructed queries still
-// return the correct sum by scanning Values.
+// without rescanning the query per call. Manually constructed or resliced
+// queries still return the correct sum by scanning Values.
 func (q ScalarU8CenteredQuery) CenteredSum() int64 {
-	if q.sumValid {
+	if q.sumValid && q.sumDims == len(q.Values) {
 		return q.sum
 	}
 	return scalarU8CenteredQuerySum(q.Values)
@@ -63,7 +64,7 @@ func PrepareScalarU8CenteredQuery(dst []ScalarU8CenteredCode, codes []byte, dims
 		dst[i] = centered
 		sum += int64(centered)
 	}
-	return ScalarU8CenteredQuery{Values: dst, sum: sum, sumValid: true}, dst, true
+	return ScalarU8CenteredQuery{Values: dst, sum: sum, sumDims: dims, sumValid: true}, dst, true
 }
 
 // ScalarU8CenteredDot computes the integer dot product between a centered query

--- a/TreeDB/internal/vectorops/scalar_u8.go
+++ b/TreeDB/internal/vectorops/scalar_u8.go
@@ -10,12 +10,12 @@ const scalarU8CenterOffset = 255
 type ScalarU8CenteredCode = int16
 
 // ScalarU8CenteredQuery is a validated, allocation-free view over centered
-// scalar_u8 query codes. Values aliases caller-owned scratch, must be treated as
-// immutable while the query is in use, and remains valid until that scratch is
-// reused. Mutating Values after preparation invalidates cached query metadata
-// consumed by batch kernels.
+// scalar_u8 query codes. Centered values alias caller-owned scratch, must be
+// treated as immutable while the query is in use, and remain valid until that
+// scratch is reused. The values slice is intentionally unexported so callers
+// cannot mutate cached query metadata through the query handle.
 type ScalarU8CenteredQuery struct {
-	Values []ScalarU8CenteredCode
+	values []ScalarU8CenteredCode
 
 	sum      int64
 	sumDims  int
@@ -23,25 +23,34 @@ type ScalarU8CenteredQuery struct {
 }
 
 // Dims returns the number of centered query dimensions.
-func (q ScalarU8CenteredQuery) Dims() int { return len(q.Values) }
+func (q ScalarU8CenteredQuery) Dims() int { return len(q.values) }
 
 // Valid reports whether q has a positive-dimension centered-code layout.
-func (q ScalarU8CenteredQuery) Valid() bool { return len(q.Values) > 0 }
+func (q ScalarU8CenteredQuery) Valid() bool { return len(q.values) > 0 }
 
 // ValidForDims reports whether q is valid for exactly dims dimensions.
 func (q ScalarU8CenteredQuery) ValidForDims(dims int) bool {
-	return dims > 0 && len(q.Values) == dims
+	return dims > 0 && len(q.values) == dims
 }
 
-// CenteredSum returns sum(q.Values). Queries returned by
+// Value returns the centered value at i for tests and diagnostics without
+// exposing the mutable backing slice.
+func (q ScalarU8CenteredQuery) Value(i int) (ScalarU8CenteredCode, bool) {
+	if i < 0 || i >= len(q.values) {
+		return 0, false
+	}
+	return q.values[i], true
+}
+
+// CenteredSum returns sum(q.values). Queries returned by
 // PrepareScalarU8CenteredQuery carry this value so batch kernels can reuse it
 // without rescanning the query per call. Manually constructed or resliced
-// queries still return the correct sum by scanning Values.
+// queries still return the correct sum by scanning values.
 func (q ScalarU8CenteredQuery) CenteredSum() int64 {
-	if q.sumValid && q.sumDims == len(q.Values) {
+	if q.sumValid && q.sumDims == len(q.values) {
 		return q.sum
 	}
-	return scalarU8CenteredQuerySum(q.Values)
+	return scalarU8CenteredQuerySum(q.values)
 }
 
 // ScalarU8CenteredValue returns the centered scalar_u8 value 2*code-255.
@@ -64,18 +73,18 @@ func PrepareScalarU8CenteredQuery(dst []ScalarU8CenteredCode, codes []byte, dims
 		dst[i] = centered
 		sum += int64(centered)
 	}
-	return ScalarU8CenteredQuery{Values: dst, sum: sum, sumDims: dims, sumValid: true}, dst, true
+	return ScalarU8CenteredQuery{values: dst, sum: sum, sumDims: dims, sumValid: true}, dst, true
 }
 
 // ScalarU8CenteredDot computes the integer dot product between a centered query
 // and a raw scalar_u8 row. The row is centered as 2*row_code-255 while the query
 // is consumed from its pre-centered layout.
 func ScalarU8CenteredDot(query ScalarU8CenteredQuery, row []byte) (int64, bool) {
-	if !query.Valid() || len(row) != len(query.Values) {
+	if !query.Valid() || len(row) != len(query.values) {
 		return 0, false
 	}
 	var dot int64
-	for i, q := range query.Values {
+	for i, q := range query.values {
 		c := ScalarU8CenteredValue(row[i])
 		dot += int64(q) * int64(c)
 	}

--- a/TreeDB/internal/vectorops/scalar_u8_dot_batch.go
+++ b/TreeDB/internal/vectorops/scalar_u8_dot_batch.go
@@ -1,0 +1,93 @@
+package vectorops
+
+// ScalarU8DotBatchStatus reports how a row-major scalar_u8 centered dot batch
+// wrapper handled a call. Rows is the number of dst entries written. Optimized
+// is true only when the active platform backend reports that a batch SIMD
+// kernel handled the call. Fallback is true when valid rows were written without
+// a batch SIMD kernel. Invalid is true when the wrapper rejected the shape and
+// left dst unchanged.
+//
+// Status is call-level: Optimized and Fallback are mutually exclusive. A call
+// can be valid and non-optimized on unsupported platforms, purego builds, tiny
+// row counts, short dimensions, or backend-specific overflow guard thresholds.
+type ScalarU8DotBatchStatus struct {
+	Rows      int
+	Optimized bool
+	Fallback  bool
+	Invalid   bool
+}
+
+// ScalarU8DotBatchImplementation identifies the active scalar_u8 centered
+// indexed batch dot backend. Per-call status is still authoritative because
+// optimized backends may fall back for individual shapes.
+func ScalarU8DotBatchImplementation() string { return scalarU8DotBatchImplementation }
+
+// ScalarU8DotBatchOptimizedAvailable reports whether this build includes a
+// platform scalar_u8 batch SIMD backend. A true value does not guarantee that a
+// given call uses SIMD; callers must inspect ScalarU8DotBatchStatus.Optimized.
+func ScalarU8DotBatchOptimizedAvailable() bool { return scalarU8DotBatchOptimizedAvailable }
+
+// DotScalarU8CenteredIndexedOptimizedEligible reports whether this build's
+// indexed-row scalar_u8 backend is expected to use optimized execution for a
+// valid rows/dims shape. Callers must still inspect ScalarU8DotBatchStatus
+// because invalid shapes are rejected before backend selection.
+func DotScalarU8CenteredIndexedOptimizedEligible(rows, dims int) bool {
+	return dotScalarU8CenteredIndexedOptimizedEligible(rows, dims)
+}
+
+func scalarU8DotBatchStatus(rows int, optimized bool) ScalarU8DotBatchStatus {
+	return ScalarU8DotBatchStatus{
+		Rows:      rows,
+		Optimized: optimized,
+		Fallback:  rows > 0 && !optimized,
+	}
+}
+
+func scalarU8DotBatchInvalidStatus() ScalarU8DotBatchStatus {
+	return ScalarU8DotBatchStatus{Invalid: true}
+}
+
+func dotScalarU8CenteredIndexedRows(dst []int64, rowIDs []uint32) int {
+	rows := len(rowIDs)
+	if len(dst) < rows {
+		rows = len(dst)
+	}
+	return rows
+}
+
+func dotScalarU8CenteredIndexedShapeOK(codes []byte, query ScalarU8CenteredQuery, rowIDs []uint32, dims, rows int) bool {
+	if rows == 0 {
+		return true
+	}
+	if dims <= 0 || !query.ValidForDims(dims) || len(codes) < dims {
+		return false
+	}
+	maxRow := uint64((len(codes) - dims) / dims)
+	for i := 0; i < rows; i++ {
+		if uint64(rowIDs[i]) > maxRow {
+			return false
+		}
+	}
+	return true
+}
+
+func scalarU8CenteredQuerySum(values []ScalarU8CenteredCode) int64 {
+	var sum int64
+	for _, v := range values {
+		sum += int64(v)
+	}
+	return sum
+}
+
+func dotScalarU8CenteredIndexedScalar(dst []int64, codes []byte, query ScalarU8CenteredQuery, rowIDs []uint32, dims, rows int) {
+	queryValues := query.Values[:dims]
+	for i := 0; i < rows; i++ {
+		start := int(rowIDs[i]) * dims
+		row := codes[start : start+dims]
+		var dot int64
+		for j, q := range queryValues {
+			dot += int64(q) * int64(ScalarU8CenteredValue(row[j]))
+		}
+		dst[i] = dot
+	}
+}

--- a/TreeDB/internal/vectorops/scalar_u8_dot_batch.go
+++ b/TreeDB/internal/vectorops/scalar_u8_dot_batch.go
@@ -80,7 +80,7 @@ func scalarU8CenteredQuerySum(values []ScalarU8CenteredCode) int64 {
 }
 
 func dotScalarU8CenteredIndexedScalar(dst []int64, codes []byte, query ScalarU8CenteredQuery, rowIDs []uint32, dims, rows int) {
-	queryValues := query.Values[:dims]
+	queryValues := query.values[:dims]
 	for i := 0; i < rows; i++ {
 		start := int(rowIDs[i]) * dims
 		row := codes[start : start+dims]

--- a/TreeDB/internal/vectorops/scalar_u8_dot_batch_amd64.go
+++ b/TreeDB/internal/vectorops/scalar_u8_dot_batch_amd64.go
@@ -38,7 +38,7 @@ func DotScalarU8CenteredIndexed(dst []int64, codes []byte, query ScalarU8Centere
 		dotScalarU8CenteredIndexedScalar(dst, codes, query, rowIDs, dims, rows)
 		return scalarU8DotBatchStatus(rows, false)
 	}
-	queryValues := query.Values[:dims]
+	queryValues := query.values[:dims]
 	dotScalarU8CenteredIndexedAMD64(dst, codes, queryValues, rowIDs, dims, rows, query.CenteredSum())
 	return scalarU8DotBatchStatus(rows, true)
 }

--- a/TreeDB/internal/vectorops/scalar_u8_dot_batch_amd64.go
+++ b/TreeDB/internal/vectorops/scalar_u8_dot_batch_amd64.go
@@ -1,0 +1,50 @@
+//go:build amd64 && !purego
+
+package vectorops
+
+const scalarU8DotBatchImplementation = "indexed_amd64_sse2"
+
+const scalarU8DotBatchOptimizedAvailable = true
+
+const (
+	dotScalarU8CenteredIndexedAMD64MinDims = 16
+	dotScalarU8CenteredIndexedAMD64MinRows = 2
+	// The SSE2 kernel accumulates into signed 32-bit vector lanes and reduces once
+	// per row. At 32,768 dimensions, the worst-case full-row scalar_u8 dot product
+	// is 65,025*32,768 = 2,130,739,200, which still fits int32. Larger dimensions
+	// use the portable int64 scalar fallback to keep accumulation overflow-safe.
+	dotScalarU8CenteredIndexedAMD64MaxSIMDDims = 32768
+)
+
+func dotScalarU8CenteredIndexedOptimizedEligible(rows, dims int) bool {
+	return rows >= dotScalarU8CenteredIndexedAMD64MinRows && dims >= dotScalarU8CenteredIndexedAMD64MinDims && dims <= dotScalarU8CenteredIndexedAMD64MaxSIMDDims
+}
+
+// DotScalarU8CenteredIndexed writes integer dot products for row-major scalar_u8
+// code rows selected by rowIDs against a pre-centered scalar_u8 query. Supported
+// amd64 builds use an SSE2-backed indexed-row kernel for sufficiently large
+// overflow-safe tiles. Tiny/short or very high-dimensional shapes use the
+// portable scalar fallback. Invalid shapes leave dst unchanged and return
+// Invalid=true.
+func DotScalarU8CenteredIndexed(dst []int64, codes []byte, query ScalarU8CenteredQuery, rowIDs []uint32, dims int) ScalarU8DotBatchStatus {
+	rows := dotScalarU8CenteredIndexedRows(dst, rowIDs)
+	if rows == 0 {
+		return ScalarU8DotBatchStatus{}
+	}
+	if !dotScalarU8CenteredIndexedShapeOK(codes, query, rowIDs, dims, rows) {
+		return scalarU8DotBatchInvalidStatus()
+	}
+	if !dotScalarU8CenteredIndexedOptimizedEligible(rows, dims) {
+		dotScalarU8CenteredIndexedScalar(dst, codes, query, rowIDs, dims, rows)
+		return scalarU8DotBatchStatus(rows, false)
+	}
+	queryValues := query.Values[:dims]
+	dotScalarU8CenteredIndexedAMD64(dst, codes, queryValues, rowIDs, dims, rows, query.CenteredSum())
+	return scalarU8DotBatchStatus(rows, true)
+}
+
+// dotScalarU8CenteredIndexedAMD64 computes rows indexed scalar_u8 centered dot
+// products. The Go wrapper must validate all slice lengths, row IDs, dims, and
+// rows before calling. querySum is sum(query[:dims]); the kernel computes
+// sum(q*(2*row-255)) as 2*sum(q*row)-255*querySum.
+func dotScalarU8CenteredIndexedAMD64(dst []int64, codes []byte, query []ScalarU8CenteredCode, rowIDs []uint32, dims int, rows int, querySum int64)

--- a/TreeDB/internal/vectorops/scalar_u8_dot_batch_amd64.s
+++ b/TreeDB/internal/vectorops/scalar_u8_dot_batch_amd64.s
@@ -1,0 +1,95 @@
+//go:build amd64 && !purego
+
+#include "textflag.h"
+
+// func dotScalarU8CenteredIndexedAMD64(dst []int64, codes []byte, query []ScalarU8CenteredCode, rowIDs []uint32, dims int, rows int, querySum int64)
+//
+// Preconditions are checked by the Go wrapper: rows <= len(dst,rowIDs), dims > 0,
+// len(query) >= dims, and every row ID addresses a full row in codes. querySum
+// is sum(query[:dims]). The SSE2 kernel is called only for dims <= 32768 so its
+// signed 32-bit vector accumulation cannot overflow. It computes centered scores
+// as:
+//   sum(q * (2*row - 255)) == 2*sum(q*row) - 255*querySum.
+TEXT ·dotScalarU8CenteredIndexedAMD64(SB), NOSPLIT, $0-120
+	MOVQ dst_base+0(FP), DI
+	MOVQ codes_base+24(FP), SI
+	MOVQ query_base+48(FP), R8
+	MOVQ rowIDs_base+72(FP), R9
+	MOVQ dims+96(FP), R10
+	MOVQ rows+104(FP), R11
+	MOVQ querySum+112(FP), R12
+
+	PXOR X7, X7                  // zero vector for byte->word widening
+
+scalaru8_amd64_row_loop:
+	TESTQ R11, R11
+	JZ scalaru8_amd64_done
+
+	MOVL (R9), AX                // row ID; MOVL zero-extends on amd64
+	ADDQ $4, R9
+	IMULQ R10, AX                // byte offset = rowID*dims
+	LEAQ (SI)(AX*1), BX          // row pointer
+	MOVQ R8, CX                  // query pointer
+	MOVQ R10, DX                 // remaining dims for scalar tail mask
+	XORQ R13, R13                // raw scalar accumulator after vector reduction
+	PXOR X0, X0                  // packed int32 accumulator
+
+	MOVQ DX, AX
+	SHRQ $4, AX                  // 16 dimensions per SSE2 iteration
+	JZ scalaru8_amd64_reduce
+
+scalaru8_amd64_loop16:
+	MOVOU (BX), X1               // 16 row bytes
+	MOVOU X1, X2
+	PUNPCKLBW X7, X1             // low 8 bytes -> uint16 words
+	PUNPCKHBW X7, X2             // high 8 bytes -> uint16 words
+	MOVOU (CX), X3               // low 8 int16 centered query values
+	MOVOU 16(CX), X4             // high 8 int16 centered query values
+	PMADDWL X3, X1               // adjacent int16 products -> int32 sums
+	PMADDWL X4, X2
+	PADDL X1, X0
+	PADDL X2, X0
+	ADDQ $16, BX
+	ADDQ $32, CX
+	DECQ AX
+	JNZ scalaru8_amd64_loop16
+
+scalaru8_amd64_reduce:
+	// Horizontal signed int32 reduction of X0 into R13.
+	MOVOU X0, X1
+	PSRLO $8, X1
+	PADDL X1, X0
+	MOVOU X0, X1
+	PSRLO $4, X1
+	PADDL X1, X0
+	MOVQ X0, AX
+	MOVLQSX AX, AX
+	ADDQ AX, R13
+
+	ANDQ $15, DX
+	JZ scalaru8_amd64_store
+
+scalaru8_amd64_scalar_tail:
+	MOVBQZX (BX), AX
+	MOVWQSX (CX), R14
+	IMULQ R14, AX
+	ADDQ AX, R13
+	INCQ BX
+	ADDQ $2, CX
+	DECQ DX
+	JNZ scalaru8_amd64_scalar_tail
+
+scalaru8_amd64_store:
+	// centeredScore = 2*rawSum - 255*querySum.
+	LEAQ (R13)(R13*1), AX
+	MOVQ R12, R14
+	SHLQ $8, R14
+	SUBQ R12, R14
+	SUBQ R14, AX
+	MOVQ AX, (DI)
+	ADDQ $8, DI
+	DECQ R11
+	JMP scalaru8_amd64_row_loop
+
+scalaru8_amd64_done:
+	RET

--- a/TreeDB/internal/vectorops/scalar_u8_dot_batch_arm64.go
+++ b/TreeDB/internal/vectorops/scalar_u8_dot_batch_arm64.go
@@ -32,7 +32,7 @@ func DotScalarU8CenteredIndexed(dst []int64, codes []byte, query ScalarU8Centere
 		dotScalarU8CenteredIndexedScalar(dst, codes, query, rowIDs, dims, rows)
 		return scalarU8DotBatchStatus(rows, false)
 	}
-	queryValues := query.Values[:dims]
+	queryValues := query.values[:dims]
 	dotScalarU8CenteredIndexedARM64(dst, codes, queryValues, rowIDs, dims, rows, query.CenteredSum())
 	return scalarU8DotBatchStatus(rows, true)
 }

--- a/TreeDB/internal/vectorops/scalar_u8_dot_batch_arm64.go
+++ b/TreeDB/internal/vectorops/scalar_u8_dot_batch_arm64.go
@@ -1,0 +1,44 @@
+//go:build arm64 && !purego
+
+package vectorops
+
+const scalarU8DotBatchImplementation = "indexed_arm64_neon"
+
+const scalarU8DotBatchOptimizedAvailable = true
+
+const (
+	dotScalarU8CenteredIndexedARM64MinDims = 16
+	dotScalarU8CenteredIndexedARM64MinRows = 2
+)
+
+func dotScalarU8CenteredIndexedOptimizedEligible(rows, dims int) bool {
+	return rows >= dotScalarU8CenteredIndexedARM64MinRows && dims >= dotScalarU8CenteredIndexedARM64MinDims
+}
+
+// DotScalarU8CenteredIndexed writes integer dot products for row-major scalar_u8
+// code rows selected by rowIDs against a pre-centered scalar_u8 query. Supported
+// arm64 builds use a NEON-backed indexed-row kernel for sufficiently large
+// tiles. Tiny/short shapes use the portable scalar fallback. Invalid shapes
+// leave dst unchanged and return Invalid=true.
+func DotScalarU8CenteredIndexed(dst []int64, codes []byte, query ScalarU8CenteredQuery, rowIDs []uint32, dims int) ScalarU8DotBatchStatus {
+	rows := dotScalarU8CenteredIndexedRows(dst, rowIDs)
+	if rows == 0 {
+		return ScalarU8DotBatchStatus{}
+	}
+	if !dotScalarU8CenteredIndexedShapeOK(codes, query, rowIDs, dims, rows) {
+		return scalarU8DotBatchInvalidStatus()
+	}
+	if !dotScalarU8CenteredIndexedOptimizedEligible(rows, dims) {
+		dotScalarU8CenteredIndexedScalar(dst, codes, query, rowIDs, dims, rows)
+		return scalarU8DotBatchStatus(rows, false)
+	}
+	queryValues := query.Values[:dims]
+	dotScalarU8CenteredIndexedARM64(dst, codes, queryValues, rowIDs, dims, rows, query.CenteredSum())
+	return scalarU8DotBatchStatus(rows, true)
+}
+
+// dotScalarU8CenteredIndexedARM64 computes rows indexed scalar_u8 centered dot
+// products. The Go wrapper must validate all slice lengths, row IDs, dims, and
+// rows before calling. querySum is sum(query[:dims]); the kernel computes
+// sum(q*(2*row-255)) as 2*sum(q*row)-255*querySum.
+func dotScalarU8CenteredIndexedARM64(dst []int64, codes []byte, query []ScalarU8CenteredCode, rowIDs []uint32, dims int, rows int, querySum int64)

--- a/TreeDB/internal/vectorops/scalar_u8_dot_batch_arm64.s
+++ b/TreeDB/internal/vectorops/scalar_u8_dot_batch_arm64.s
@@ -1,0 +1,150 @@
+//go:build arm64 && !purego
+
+#include "textflag.h"
+
+// func dotScalarU8CenteredIndexedARM64(dst []int64, codes []byte, query []ScalarU8CenteredCode, rowIDs []uint32, dims int, rows int, querySum int64)
+//
+// Preconditions are checked by the Go wrapper: rows <= len(dst,rowIDs), dims > 0,
+// len(query) >= dims, and every row ID addresses a full row in codes. querySum
+// is sum(query[:dims]). The kernel computes centered scores as:
+//   sum(q * (2*row - 255)) == 2*sum(q*row) - 255*querySum.
+TEXT ·dotScalarU8CenteredIndexedARM64(SB), NOSPLIT, $0-120
+	MOVD dst_base+0(FP), R0
+	MOVD codes_base+24(FP), R1
+	MOVD query_base+48(FP), R2
+	MOVD rowIDs_base+72(FP), R3
+	MOVD dims+96(FP), R4
+	MOVD rows+104(FP), R5
+	MOVD querySum+112(FP), R6
+
+scalaru8_arm64_row_loop:
+	CBZ R5, scalaru8_arm64_done
+	MOVWU (R3), R7               // row ID
+	ADD $4, R3
+	MUL R4, R7, R8               // row offset in bytes (dims is byte width)
+	ADD R1, R8, R9               // row pointer
+	MOVD R2, R10                 // query pointer
+	MOVD R4, R11                 // remaining dims
+
+	// Initialize eight int64 vector accumulators. Products are accumulated as
+	// int64 via SMULL+SADDLP, so SIMD accumulation is overflow-safe for all
+	// practical Go slice-backed dimensions.
+	VEOR V0.B16, V0.B16, V0.B16
+	VEOR V1.B16, V1.B16, V1.B16
+	VEOR V2.B16, V2.B16, V2.B16
+	VEOR V3.B16, V3.B16, V3.B16
+	VEOR V4.B16, V4.B16, V4.B16
+	VEOR V5.B16, V5.B16, V5.B16
+	VEOR V6.B16, V6.B16, V6.B16
+	VEOR V7.B16, V7.B16, V7.B16
+
+	CMP $32, R11
+	BLT scalaru8_arm64_tail16
+
+scalaru8_arm64_loop32:
+	// Load 32 row bytes and 32 int16 centered query values.
+	VLD1.P 16(R9), [V16.B16]
+	VLD1.P 16(R9), [V17.B16]
+	VLD1.P 32(R10), [V20.H8, V21.H8]
+	VLD1.P 32(R10), [V22.H8, V23.H8]
+
+	// Zero-extend row bytes to int16 lanes: V16 -> V24,V25; V17 -> V26,V27.
+	VUXTL V16.B8, V24.H8
+	VUXTL2 V16.B16, V25.H8
+	VUXTL V17.B8, V26.H8
+	VUXTL2 V17.B16, V27.H8
+
+	// q(int16) * row(uint8 widened to positive int16) -> int32 products.
+	WORD $0x0E78C29C              // SMULL V28.4S, V20.4H, V24.4H
+	WORD $0x4E78C29D              // SMULL2 V29.4S, V20.8H, V24.8H
+	WORD $0x0E79C2BE              // SMULL V30.4S, V21.4H, V25.4H
+	WORD $0x4E79C2BF              // SMULL2 V31.4S, V21.8H, V25.8H
+	WORD $0x4EA02B9C              // SADDLP V28.2D, V28.4S
+	WORD $0x4EA02BBD              // SADDLP V29.2D, V29.4S
+	WORD $0x4EA02BDE              // SADDLP V30.2D, V30.4S
+	WORD $0x4EA02BFF              // SADDLP V31.2D, V31.4S
+	WORD $0x4EFC8400              // ADD V0.2D, V0.2D, V28.2D
+	WORD $0x4EFD8421              // ADD V1.2D, V1.2D, V29.2D
+	WORD $0x4EFE8442              // ADD V2.2D, V2.2D, V30.2D
+	WORD $0x4EFF8463              // ADD V3.2D, V3.2D, V31.2D
+
+	WORD $0x0E7AC2DC              // SMULL V28.4S, V22.4H, V26.4H
+	WORD $0x4E7AC2DD              // SMULL2 V29.4S, V22.8H, V26.8H
+	WORD $0x0E7BC2FE              // SMULL V30.4S, V23.4H, V27.4H
+	WORD $0x4E7BC2FF              // SMULL2 V31.4S, V23.8H, V27.8H
+	WORD $0x4EA02B9C              // SADDLP V28.2D, V28.4S
+	WORD $0x4EA02BBD              // SADDLP V29.2D, V29.4S
+	WORD $0x4EA02BDE              // SADDLP V30.2D, V30.4S
+	WORD $0x4EA02BFF              // SADDLP V31.2D, V31.4S
+	WORD $0x4EFC8484              // ADD V4.2D, V4.2D, V28.2D
+	WORD $0x4EFD84A5              // ADD V5.2D, V5.2D, V29.2D
+	WORD $0x4EFE84C6              // ADD V6.2D, V6.2D, V30.2D
+	WORD $0x4EFF84E7              // ADD V7.2D, V7.2D, V31.2D
+
+	SUB $32, R11
+	CMP $32, R11
+	BGE scalaru8_arm64_loop32
+
+scalaru8_arm64_tail16:
+	CMP $16, R11
+	BLT scalaru8_arm64_reduce
+
+	VLD1.P 16(R9), [V16.B16]
+	VLD1.P 32(R10), [V20.H8, V21.H8]
+	VUXTL V16.B8, V24.H8
+	VUXTL2 V16.B16, V25.H8
+
+	WORD $0x0E78C29C              // SMULL V28.4S, V20.4H, V24.4H
+	WORD $0x4E78C29D              // SMULL2 V29.4S, V20.8H, V24.8H
+	WORD $0x0E79C2BE              // SMULL V30.4S, V21.4H, V25.4H
+	WORD $0x4E79C2BF              // SMULL2 V31.4S, V21.8H, V25.8H
+	WORD $0x4EA02B9C              // SADDLP V28.2D, V28.4S
+	WORD $0x4EA02BBD              // SADDLP V29.2D, V29.4S
+	WORD $0x4EA02BDE              // SADDLP V30.2D, V30.4S
+	WORD $0x4EA02BFF              // SADDLP V31.2D, V31.4S
+	WORD $0x4EFC8400              // ADD V0.2D, V0.2D, V28.2D
+	WORD $0x4EFD8421              // ADD V1.2D, V1.2D, V29.2D
+	WORD $0x4EFE8442              // ADD V2.2D, V2.2D, V30.2D
+	WORD $0x4EFF8463              // ADD V3.2D, V3.2D, V31.2D
+	SUB $16, R11
+
+scalaru8_arm64_reduce:
+	// Tree reduction of vector int64 accumulators to R12.
+	WORD $0x4EE48400              // ADD V0.2D, V0.2D, V4.2D
+	WORD $0x4EE58421              // ADD V1.2D, V1.2D, V5.2D
+	WORD $0x4EE68442              // ADD V2.2D, V2.2D, V6.2D
+	WORD $0x4EE78463              // ADD V3.2D, V3.2D, V7.2D
+	WORD $0x4EE28400              // ADD V0.2D, V0.2D, V2.2D
+	WORD $0x4EE38421              // ADD V1.2D, V1.2D, V3.2D
+	WORD $0x4EE18400              // ADD V0.2D, V0.2D, V1.2D
+	VMOV V0.D[0], R12
+	VMOV V0.D[1], R13
+	ADD R13, R12, R12
+
+scalaru8_arm64_scalar_tail:
+	CBZ R11, scalaru8_arm64_store
+	MOVBU (R9), R13
+	MOVH (R10), R14
+	SXTH R14, R14
+	MUL R13, R14, R13
+	ADD R13, R12, R12
+	ADD $1, R9
+	ADD $2, R10
+	SUB $1, R11
+	B scalaru8_arm64_scalar_tail
+
+scalaru8_arm64_store:
+	// centeredScore = 2*rawSum - 255*querySum.
+	MOVD R12, R13
+	LSL $1, R13
+	MOVD R6, R14
+	LSL $8, R14
+	SUB R6, R14, R14
+	SUB R14, R13, R13
+	MOVD R13, (R0)
+	ADD $8, R0
+	SUB $1, R5
+	B scalaru8_arm64_row_loop
+
+scalaru8_arm64_done:
+	RET

--- a/TreeDB/internal/vectorops/scalar_u8_dot_batch_fallback.go
+++ b/TreeDB/internal/vectorops/scalar_u8_dot_batch_fallback.go
@@ -1,0 +1,25 @@
+//go:build purego || (!amd64 && !arm64)
+
+package vectorops
+
+const scalarU8DotBatchImplementation = "scalar_portable"
+
+const scalarU8DotBatchOptimizedAvailable = false
+
+func dotScalarU8CenteredIndexedOptimizedEligible(rows, dims int) bool { return false }
+
+// DotScalarU8CenteredIndexed writes integer dot products for row-major scalar_u8
+// code rows selected by rowIDs against a pre-centered scalar_u8 query. The
+// portable fallback writes min(len(dst), len(rowIDs)) scores for valid full-row
+// shapes. Invalid shapes leave dst unchanged and return Invalid=true.
+func DotScalarU8CenteredIndexed(dst []int64, codes []byte, query ScalarU8CenteredQuery, rowIDs []uint32, dims int) ScalarU8DotBatchStatus {
+	rows := dotScalarU8CenteredIndexedRows(dst, rowIDs)
+	if rows == 0 {
+		return ScalarU8DotBatchStatus{}
+	}
+	if !dotScalarU8CenteredIndexedShapeOK(codes, query, rowIDs, dims, rows) {
+		return scalarU8DotBatchInvalidStatus()
+	}
+	dotScalarU8CenteredIndexedScalar(dst, codes, query, rowIDs, dims, rows)
+	return scalarU8DotBatchStatus(rows, false)
+}

--- a/TreeDB/internal/vectorops/scalar_u8_dot_batch_test.go
+++ b/TreeDB/internal/vectorops/scalar_u8_dot_batch_test.go
@@ -1,0 +1,326 @@
+package vectorops
+
+import (
+	"fmt"
+	"testing"
+)
+
+var (
+	scalarU8DotBatchStatusSink ScalarU8DotBatchStatus
+	scalarU8DotBatchIntSink    int64
+)
+
+func TestDotScalarU8CenteredIndexedParity(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		dims   int
+		rowIDs []uint32
+	}{
+		{name: "zero_rows", dims: 32, rowIDs: nil},
+		{name: "short_dims_single", dims: 1, rowIDs: []uint32{0}},
+		{name: "short_dims_tail", dims: 7, rowIDs: []uint32{0, 1, 2, 3, 4}},
+		{name: "below_simd_width", dims: 15, rowIDs: []uint32{0, 2, 1}},
+		{name: "exact_simd_width", dims: 16, rowIDs: []uint32{0, 1, 2, 3}},
+		{name: "tail17", dims: 17, rowIDs: []uint32{0, 3, 1, 2}},
+		{name: "tail31", dims: 31, rowIDs: []uint32{5, 1, 5, 0, 3}},
+		{name: "dims32_shuffled_repeated", dims: 32, rowIDs: []uint32{7, 0, 3, 7, 1, 6, 2, 5, 4, 0}},
+		{name: "tail33", dims: 33, rowIDs: []uint32{2, 9, 0, 7, 3, 11, 1, 6, 10, 4, 8, 5}},
+		{name: "dims64", dims: 64, rowIDs: []uint32{12, 2, 9, 0, 7, 3, 15, 1, 6, 10, 4, 14, 5}},
+		{name: "tail65", dims: 65, rowIDs: []uint32{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}},
+		{name: "dims128_larger", dims: 128, rowIDs: scalarU8DotBatchTestRowIDs(64, 97)},
+		{name: "dims256", dims: 256, rowIDs: scalarU8DotBatchTestRowIDs(16, 41)},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			baseRows := maxScalarU8RowID(tc.rowIDs) + 1
+			codes := scalarU8DotBatchTestCodes(baseRows, tc.dims)
+			query := scalarU8DotBatchTestQuery(t, tc.dims, 17)
+			got := make([]int64, len(tc.rowIDs))
+
+			status := DotScalarU8CenteredIndexed(got, codes, query, tc.rowIDs, tc.dims)
+			if status.Invalid {
+				t.Fatalf("DotScalarU8CenteredIndexed rejected valid shape: %+v", status)
+			}
+			if status.Rows != len(tc.rowIDs) {
+				t.Fatalf("status.Rows=%d want %d", status.Rows, len(tc.rowIDs))
+			}
+			if status.Rows > 0 && status.Optimized == status.Fallback {
+				t.Fatalf("optimized/fallback status mismatch: %+v", status)
+			}
+			if status.Optimized && !ScalarU8DotBatchOptimizedAvailable() {
+				t.Fatalf("optimized status on backend without optimized batch support: %+v impl=%s", status, ScalarU8DotBatchImplementation())
+			}
+			if DotScalarU8CenteredIndexedOptimizedEligible(status.Rows, tc.dims) && status.Rows > 0 && !status.Optimized {
+				t.Fatalf("status=%+v want optimized eligible backend impl=%s", status, ScalarU8DotBatchImplementation())
+			}
+
+			want := make([]int64, len(tc.rowIDs))
+			dotScalarU8CenteredIndexedScalar(want, codes, query, tc.rowIDs, tc.dims, len(tc.rowIDs))
+			assertInt64SliceExact(t, got, want)
+		})
+	}
+}
+
+func TestDotScalarU8CenteredIndexedOptimizedStatusAndFallback(t *testing.T) {
+	t.Parallel()
+
+	codes := scalarU8DotBatchTestCodes(4, 64)
+	query := scalarU8DotBatchTestQuery(t, 64, 23)
+	rowIDs := []uint32{0, 1, 2, 3}
+	dst := make([]int64, len(rowIDs))
+	status := DotScalarU8CenteredIndexed(dst, codes, query, rowIDs, 64)
+	if status.Invalid || status.Rows != len(rowIDs) {
+		t.Fatalf("status=%+v want valid rows=%d", status, len(rowIDs))
+	}
+	if DotScalarU8CenteredIndexedOptimizedEligible(len(rowIDs), 64) {
+		if !status.Optimized || status.Fallback {
+			t.Fatalf("status=%+v want optimized indexed backend", status)
+		}
+	} else if status.Optimized || !status.Fallback {
+		t.Fatalf("status=%+v want platform fallback", status)
+	}
+	want := make([]int64, len(rowIDs))
+	dotScalarU8CenteredIndexedScalar(want, codes, query, rowIDs, 64, len(rowIDs))
+	assertInt64SliceExact(t, dst, want)
+
+	tinyDst := make([]int64, len(rowIDs))
+	tinyStatus := DotScalarU8CenteredIndexed(tinyDst, codes, ScalarU8CenteredQuery{Values: query.Values[:15]}, rowIDs, 15)
+	if tinyStatus.Invalid || tinyStatus.Rows != len(rowIDs) || tinyStatus.Optimized || !tinyStatus.Fallback {
+		t.Fatalf("tiny status=%+v want scalar fallback", tinyStatus)
+	}
+	tinyWant := make([]int64, len(rowIDs))
+	dotScalarU8CenteredIndexedScalar(tinyWant, codes, ScalarU8CenteredQuery{Values: query.Values[:15]}, rowIDs, 15, len(rowIDs))
+	assertInt64SliceExact(t, tinyDst, tinyWant)
+
+	singleDst := make([]int64, 1)
+	singleStatus := DotScalarU8CenteredIndexed(singleDst, codes, query, rowIDs[:1], 64)
+	if singleStatus.Invalid || singleStatus.Rows != 1 || singleStatus.Optimized || !singleStatus.Fallback {
+		t.Fatalf("single-row status=%+v want scalar fallback", singleStatus)
+	}
+	singleWant := make([]int64, 1)
+	dotScalarU8CenteredIndexedScalar(singleWant, codes, query, rowIDs[:1], 64, 1)
+	assertInt64SliceExact(t, singleDst, singleWant)
+}
+
+func TestDotScalarU8CenteredIndexedMinRows(t *testing.T) {
+	t.Parallel()
+
+	codes := scalarU8DotBatchTestCodes(2, 4)
+	query := scalarU8DotBatchTestQuery(t, 4, 29)
+	dst := []int64{-1, -1}
+	status := DotScalarU8CenteredIndexed(dst, codes, query, []uint32{0, 1, 99}, 4)
+	if status.Invalid {
+		t.Fatalf("row IDs beyond min(dst,rowIDs) should be ignored: %+v", status)
+	}
+	if status.Rows != len(dst) {
+		t.Fatalf("rows=%d want %d", status.Rows, len(dst))
+	}
+	want := make([]int64, len(dst))
+	dotScalarU8CenteredIndexedScalar(want, codes, query, []uint32{0, 1}, 4, len(dst))
+	assertInt64SliceExact(t, dst, want)
+}
+
+func TestDotScalarU8CenteredIndexedInvalidShapesLeaveDestinationUnchanged(t *testing.T) {
+	t.Parallel()
+
+	codes := scalarU8DotBatchTestCodes(2, 4)
+	query := scalarU8DotBatchTestQuery(t, 4, 31)
+	wrongDimsQuery := scalarU8DotBatchTestQuery(t, 3, 37)
+
+	cases := []struct {
+		name   string
+		codes  []byte
+		query  ScalarU8CenteredQuery
+		rowIDs []uint32
+		dims   int
+	}{
+		{name: "zero_dims", codes: codes, query: query, rowIDs: []uint32{0, 1}, dims: 0},
+		{name: "invalid_query", codes: codes, query: ScalarU8CenteredQuery{}, rowIDs: []uint32{0}, dims: 4},
+		{name: "wrong_query_dims", codes: codes, query: wrongDimsQuery, rowIDs: []uint32{0}, dims: 4},
+		{name: "short_codes", codes: codes[:3], query: query, rowIDs: []uint32{0}, dims: 4},
+		{name: "row_out_of_range", codes: codes, query: query, rowIDs: []uint32{0, 2}, dims: 4},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dst := []int64{-11, -12, -13}
+			before := append([]int64(nil), dst...)
+			status := DotScalarU8CenteredIndexed(dst, tc.codes, tc.query, tc.rowIDs, tc.dims)
+			if !status.Invalid || status.Rows != 0 || status.Optimized || status.Fallback {
+				t.Fatalf("status=%+v want invalid without writes", status)
+			}
+			assertInt64SliceExact(t, dst, before)
+		})
+	}
+}
+
+func TestDotScalarU8CenteredIndexedZeroAllocs(t *testing.T) {
+	codes := scalarU8DotBatchTestCodes(32, 128)
+	query := scalarU8DotBatchTestQuery(t, 128, 41)
+	rowIDs := []uint32{12, 2, 9, 0, 7, 3, 15, 1, 6, 10, 4, 14, 5}
+	dst := make([]int64, len(rowIDs))
+
+	allocs := testing.AllocsPerRun(1000, func() {
+		status := DotScalarU8CenteredIndexed(dst, codes, query, rowIDs, 128)
+		scalarU8DotBatchStatusSink = status
+		scalarU8DotBatchIntSink += dst[0]
+	})
+	if allocs != 0 {
+		t.Fatalf("DotScalarU8CenteredIndexed allocs/run=%v want 0", allocs)
+	}
+	if scalarU8DotBatchIntSink == 0 && scalarU8DotBatchStatusSink.Rows == 0 {
+		t.Fatalf("unexpected zero sinks")
+	}
+}
+
+func TestDotScalarU8CenteredIndexedOverflowSensitiveDims(t *testing.T) {
+	t.Parallel()
+
+	const dims = 40000
+	queryCodes := make([]byte, dims)
+	for i := range queryCodes {
+		queryCodes[i] = 255
+	}
+	scratch := make([]ScalarU8CenteredCode, 0, dims)
+	query, _, ok := PrepareScalarU8CenteredQuery(scratch, queryCodes, dims)
+	if !ok {
+		t.Fatal("PrepareScalarU8CenteredQuery rejected overflow-sensitive query")
+	}
+	codes := make([]byte, 2*dims)
+	for i := 0; i < dims; i++ {
+		codes[i] = 255
+		codes[dims+i] = 0
+	}
+	dst := make([]int64, 2)
+	status := DotScalarU8CenteredIndexed(dst, codes, query, []uint32{0, 1}, dims)
+	if status.Invalid || status.Rows != 2 {
+		t.Fatalf("status=%+v want valid overflow-sensitive rows", status)
+	}
+	want := []int64{int64(65025 * dims), -int64(65025 * dims)}
+	assertInt64SliceExact(t, dst, want)
+}
+
+func BenchmarkDotScalarU8CenteredIndexed(b *testing.B) {
+	benchmarkDotScalarU8CenteredIndexedMatrix(b, "optimized_or_fallback", func(dst []int64, codes []byte, query ScalarU8CenteredQuery, rowIDs []uint32, dims, rows int) ScalarU8DotBatchStatus {
+		return DotScalarU8CenteredIndexed(dst, codes, query, rowIDs, dims)
+	})
+}
+
+func BenchmarkDotScalarU8CenteredIndexedScalar(b *testing.B) {
+	benchmarkDotScalarU8CenteredIndexedMatrix(b, "scalar_reference", func(dst []int64, codes []byte, query ScalarU8CenteredQuery, rowIDs []uint32, dims, rows int) ScalarU8DotBatchStatus {
+		dotScalarU8CenteredIndexedScalar(dst, codes, query, rowIDs, dims, rows)
+		return scalarU8DotBatchStatus(rows, false)
+	})
+}
+
+func benchmarkDotScalarU8CenteredIndexedMatrix(b *testing.B, impl string, call func(dst []int64, codes []byte, query ScalarU8CenteredQuery, rowIDs []uint32, dims, rows int) ScalarU8DotBatchStatus) {
+	b.Helper()
+	dimsCases := []int{32, 64, 128, 256, 768}
+	rowCases := []int{1, 2, 8, 16, 64}
+	for _, dims := range dimsCases {
+		for _, rows := range rowCases {
+			name := fmt.Sprintf("impl=%s/dims=%d/rows=%d/indexed", impl, dims, rows)
+			b.Run(name, func(b *testing.B) {
+				baseRows := rows*3 + 17
+				codes := scalarU8DotBatchTestCodes(baseRows, dims)
+				query := scalarU8DotBatchTestQuery(b, dims, 43)
+				rowIDs := scalarU8DotBatchTestRowIDs(rows, baseRows)
+				dst := make([]int64, rows)
+				benchmarkDotScalarU8CenteredIndexedCall(b, dims, rows, func() ScalarU8DotBatchStatus {
+					return call(dst, codes, query, rowIDs, dims, rows)
+				}, dst)
+			})
+		}
+	}
+}
+
+func benchmarkDotScalarU8CenteredIndexedCall(b *testing.B, dims, rows int, call func() ScalarU8DotBatchStatus, dst []int64) {
+	b.Helper()
+	b.ReportAllocs()
+
+	var optimizedCalls, fallbackCalls, invalidCalls int
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		status := call()
+		if status.Optimized {
+			optimizedCalls++
+		}
+		if status.Fallback {
+			fallbackCalls++
+		}
+		if status.Invalid {
+			invalidCalls++
+		}
+		scalarU8DotBatchStatusSink = status
+		scalarU8DotBatchIntSink += dst[0]
+	}
+	elapsed := b.Elapsed().Seconds()
+	b.StopTimer()
+
+	b.ReportMetric(float64(dims), "dims")
+	b.ReportMetric(float64(rows), "rows/tile")
+	if elapsed > 0 {
+		b.ReportMetric(float64(b.N)/elapsed, "ops/sec")
+		b.ReportMetric(float64(b.N*rows)/elapsed, "scores/sec")
+	}
+	if b.N > 0 {
+		b.ReportMetric(float64(optimizedCalls)/float64(b.N), "optimized/call")
+		b.ReportMetric(float64(fallbackCalls)/float64(b.N), "fallback/call")
+		b.ReportMetric(float64(invalidCalls)/float64(b.N), "invalid/call")
+	}
+}
+
+func scalarU8DotBatchTestQuery(tb testing.TB, dims int, salt int) ScalarU8CenteredQuery {
+	tb.Helper()
+	codes := make([]byte, dims)
+	for i := range codes {
+		codes[i] = byte((i*salt + 5) & 0xff)
+	}
+	scratch := make([]ScalarU8CenteredCode, 0, dims)
+	query, _, ok := PrepareScalarU8CenteredQuery(scratch, codes, dims)
+	if !ok {
+		tb.Fatalf("PrepareScalarU8CenteredQuery dims=%d failed", dims)
+	}
+	return query
+}
+
+func scalarU8DotBatchTestCodes(rows, dims int) []byte {
+	if rows <= 0 || dims <= 0 {
+		return nil
+	}
+	codes := make([]byte, rows*dims)
+	for row := 0; row < rows; row++ {
+		start := row * dims
+		for col := 0; col < dims; col++ {
+			codes[start+col] = byte((row*37 + col*17 + row*col*3 + 11) & 0xff)
+		}
+	}
+	return codes
+}
+
+func scalarU8DotBatchTestRowIDs(rows, baseRows int) []uint32 {
+	rowIDs := make([]uint32, rows)
+	for i := range rowIDs {
+		rowIDs[i] = uint32((i*7 + 3) % baseRows)
+	}
+	return rowIDs
+}
+
+func maxScalarU8RowID(rowIDs []uint32) int {
+	maxID := 0
+	for _, rowID := range rowIDs {
+		if int(rowID) > maxID {
+			maxID = int(rowID)
+		}
+	}
+	return maxID
+}
+
+func assertInt64SliceExact(t *testing.T, got, want []int64) {
+	t.Helper()
+	if fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("got=%v want=%v", got, want)
+	}
+}

--- a/TreeDB/internal/vectorops/scalar_u8_dot_batch_test.go
+++ b/TreeDB/internal/vectorops/scalar_u8_dot_batch_test.go
@@ -87,12 +87,12 @@ func TestDotScalarU8CenteredIndexedOptimizedStatusAndFallback(t *testing.T) {
 	assertInt64SliceExact(t, dst, want)
 
 	tinyDst := make([]int64, len(rowIDs))
-	tinyStatus := DotScalarU8CenteredIndexed(tinyDst, codes, ScalarU8CenteredQuery{Values: query.Values[:15]}, rowIDs, 15)
+	tinyStatus := DotScalarU8CenteredIndexed(tinyDst, codes, ScalarU8CenteredQuery{values: query.values[:15]}, rowIDs, 15)
 	if tinyStatus.Invalid || tinyStatus.Rows != len(rowIDs) || tinyStatus.Optimized || !tinyStatus.Fallback {
 		t.Fatalf("tiny status=%+v want scalar fallback", tinyStatus)
 	}
 	tinyWant := make([]int64, len(rowIDs))
-	dotScalarU8CenteredIndexedScalar(tinyWant, codes, ScalarU8CenteredQuery{Values: query.Values[:15]}, rowIDs, 15, len(rowIDs))
+	dotScalarU8CenteredIndexedScalar(tinyWant, codes, ScalarU8CenteredQuery{values: query.values[:15]}, rowIDs, 15, len(rowIDs))
 	assertInt64SliceExact(t, tinyDst, tinyWant)
 
 	singleDst := make([]int64, 1)
@@ -172,7 +172,7 @@ func TestDotScalarU8CenteredIndexedUsesReslicedQuerySum(t *testing.T) {
 	if !ok {
 		t.Fatal("PrepareScalarU8CenteredQuery rejected resliced query")
 	}
-	query.Values = query.Values[:dims]
+	query.values = query.values[:dims]
 
 	codes := make([]byte, 2*dims)
 	for i := 0; i < dims; i++ {

--- a/TreeDB/internal/vectorops/scalar_u8_dot_batch_test.go
+++ b/TreeDB/internal/vectorops/scalar_u8_dot_batch_test.go
@@ -156,6 +156,38 @@ func TestDotScalarU8CenteredIndexedInvalidShapesLeaveDestinationUnchanged(t *tes
 	}
 }
 
+func TestDotScalarU8CenteredIndexedUsesReslicedQuerySum(t *testing.T) {
+	t.Parallel()
+
+	const (
+		preparedDims = 32
+		dims         = 16
+	)
+	queryCodes := make([]byte, preparedDims)
+	for i := 0; i < dims; i++ {
+		queryCodes[i] = 255
+	}
+	scratch := make([]ScalarU8CenteredCode, 0, preparedDims)
+	query, _, ok := PrepareScalarU8CenteredQuery(scratch, queryCodes, preparedDims)
+	if !ok {
+		t.Fatal("PrepareScalarU8CenteredQuery rejected resliced query")
+	}
+	query.Values = query.Values[:dims]
+
+	codes := make([]byte, 2*dims)
+	for i := 0; i < dims; i++ {
+		codes[i] = 255
+		codes[dims+i] = 0
+	}
+	dst := make([]int64, 2)
+	status := DotScalarU8CenteredIndexed(dst, codes, query, []uint32{0, 1}, dims)
+	if status.Invalid || status.Rows != 2 {
+		t.Fatalf("status=%+v want valid resliced query rows", status)
+	}
+	want := []int64{int64(65025 * dims), -int64(65025 * dims)}
+	assertInt64SliceExact(t, dst, want)
+}
+
 func TestDotScalarU8CenteredIndexedZeroAllocs(t *testing.T) {
 	codes := scalarU8DotBatchTestCodes(32, 128)
 	query := scalarU8DotBatchTestQuery(t, 128, 41)
@@ -198,6 +230,8 @@ func TestDotScalarU8CenteredIndexedOverflowSensitiveDims(t *testing.T) {
 	if status.Invalid || status.Rows != 2 {
 		t.Fatalf("status=%+v want valid overflow-sensitive rows", status)
 	}
+	// Scalar_u8 centering maps both all-255 query codes and all-255 row codes to
+	// +255, and all-0 row codes to -255, so each dimension contributes +/-65025.
 	want := []int64{int64(65025 * dims), -int64(65025 * dims)}
 	assertInt64SliceExact(t, dst, want)
 }

--- a/TreeDB/internal/vectorops/scalar_u8_test.go
+++ b/TreeDB/internal/vectorops/scalar_u8_test.go
@@ -17,13 +17,21 @@ func TestScalarU8CenteredQueryParity2258(t *testing.T) {
 		t.Fatalf("PrepareScalarU8CenteredQuery ok=%v query=%+v scratch_len=%d", ok, query, len(scratch))
 	}
 	wantCentered := []ScalarU8CenteredCode{-255, -253, -1, 1, 253, 255}
+	var wantSum int64
 	for i, want := range wantCentered {
+		wantSum += int64(want)
 		if got := query.Values[i]; got != want {
 			t.Fatalf("centered[%d]=%d want %d", i, got, want)
 		}
 		if got := ScalarU8CenteredValue(codes[i]); got != want {
 			t.Fatalf("ScalarU8CenteredValue(%d)=%d want %d", codes[i], got, want)
 		}
+	}
+	if got := query.CenteredSum(); got != wantSum {
+		t.Fatalf("query.CenteredSum()=%d want %d", got, wantSum)
+	}
+	if got := (ScalarU8CenteredQuery{Values: wantCentered}).CenteredSum(); got != wantSum {
+		t.Fatalf("manual query CenteredSum()=%d want %d", got, wantSum)
 	}
 
 	gotDot, ok := ScalarU8CenteredDot(query, row)

--- a/TreeDB/internal/vectorops/scalar_u8_test.go
+++ b/TreeDB/internal/vectorops/scalar_u8_test.go
@@ -34,6 +34,16 @@ func TestScalarU8CenteredQueryParity2258(t *testing.T) {
 		t.Fatalf("manual query CenteredSum()=%d want %d", got, wantSum)
 	}
 
+	resliced := query
+	resliced.Values = resliced.Values[:3]
+	var wantReslicedSum int64
+	for _, v := range wantCentered[:3] {
+		wantReslicedSum += int64(v)
+	}
+	if got := resliced.CenteredSum(); got != wantReslicedSum {
+		t.Fatalf("resliced query CenteredSum()=%d want %d", got, wantReslicedSum)
+	}
+
 	gotDot, ok := ScalarU8CenteredDot(query, row)
 	if !ok {
 		t.Fatal("ScalarU8CenteredDot rejected valid query/row")

--- a/TreeDB/internal/vectorops/scalar_u8_test.go
+++ b/TreeDB/internal/vectorops/scalar_u8_test.go
@@ -20,8 +20,9 @@ func TestScalarU8CenteredQueryParity2258(t *testing.T) {
 	var wantSum int64
 	for i, want := range wantCentered {
 		wantSum += int64(want)
-		if got := query.Values[i]; got != want {
-			t.Fatalf("centered[%d]=%d want %d", i, got, want)
+		got, ok := query.Value(i)
+		if !ok || got != want {
+			t.Fatalf("centered[%d]=%d ok=%v want %d", i, got, ok, want)
 		}
 		if got := ScalarU8CenteredValue(codes[i]); got != want {
 			t.Fatalf("ScalarU8CenteredValue(%d)=%d want %d", codes[i], got, want)
@@ -30,12 +31,12 @@ func TestScalarU8CenteredQueryParity2258(t *testing.T) {
 	if got := query.CenteredSum(); got != wantSum {
 		t.Fatalf("query.CenteredSum()=%d want %d", got, wantSum)
 	}
-	if got := (ScalarU8CenteredQuery{Values: wantCentered}).CenteredSum(); got != wantSum {
+	if got := (ScalarU8CenteredQuery{values: wantCentered}).CenteredSum(); got != wantSum {
 		t.Fatalf("manual query CenteredSum()=%d want %d", got, wantSum)
 	}
 
 	resliced := query
-	resliced.Values = resliced.Values[:3]
+	resliced.values = resliced.values[:3]
 	var wantReslicedSum int64
 	for _, v := range wantCentered[:3] {
 		wantReslicedSum += int64(v)


### PR DESCRIPTION
## Summary

Closes #2259. Parent tracker: #2169. Builds on #2258 / PR #2261 (`a45e32b3ba3026adabbbdfff6a3808145df68eea`).

Adds TreeDB `vectorops` scalar_u8 centered indexed batch dot kernels:

- `DotScalarU8CenteredIndexed(dst []int64, codes []byte, query ScalarU8CenteredQuery, rowIDs []uint32, dims int)` with status/helper APIs analogous to `DotFloat32Indexed`.
- Portable scalar fallback for purego/unsupported platforms.
- ARM64 NEON indexed batch assembly backend (`indexed_arm64_neon`).
- AMD64 SSE2 indexed batch assembly backend (`indexed_amd64_sse2`).
- Cached `ScalarU8CenteredQuery.CenteredSum()` metadata so SIMD kernels consume #2258 centered query values without per-row query centering or per-call query rescans for prepared queries.
- `ScalarU8CenteredQuery` now keeps its backing values slice unexported and exposes non-mutating `Value(i)` diagnostics access. This addresses the CodeRabbit mutable-exported-field thread without allocating immutable copies; the query still aliases caller scratch for zero-allocation #2258/#2259 paths, and callers must not reuse/mutate that scratch while the query is in use.

## Scope / non-goals

In scope: `TreeDB/internal/vectorops` API, SIMD/fallback kernels, tests, and microbenchmarks.

Out of scope and unchanged:

- no `column_graph` integration (owned by #2260),
- no exact/default TreeDB search behavior changes,
- no quantized-mode fallback behavior changes,
- no on-disk format changes,
- no pgvector or benchmark harness changes.

## Backend behavior

| Platform/build | Backend | Optimized eligibility |
| --- | --- | --- |
| arm64, non-purego | NEON Plan 9 assembly | rows >= 2 and dims >= 16 |
| amd64, non-purego | SSE2 Plan 9 assembly | rows >= 2, dims >= 16, dims <= 32,768 |
| purego or unsupported | portable scalar Go | fallback only |

The AMD64 max-dims SIMD guard keeps signed int32 vector-lane accumulation overflow-safe; larger dimensions fall back to the int64 scalar implementation. ARM64 widens products into int64 vector accumulators. Tail dimensions are handled by scalar tails after SIMD blocks.

## Tests

Latest head: `4f863241cbf532804dae59b7669b25c0e97e2b78`.

- `GOWORK=off go test ./TreeDB/internal/vectorops -run 'Test.*ScalarU8|TestDotScalarU8' -count=1` ✅
- `GOWORK=off go test -tags purego ./TreeDB/internal/vectorops -run 'Test.*ScalarU8|TestDotScalarU8' -count=1` ✅
- `GOWORK=off go test ./TreeDB/internal/vectorops -count=1` ✅
- `GOWORK=off go test -tags purego ./TreeDB/internal/vectorops -count=1` ✅
- `GOWORK=off GOOS=linux GOARCH=amd64 go test -c ./TreeDB/internal/vectorops -o /tmp/vectorops_amd64_unexported_values_head.test` ✅
- `GOWORK=off GOOS=linux GOARCH=arm64 go test -c ./TreeDB/internal/vectorops -o /tmp/vectorops_arm64_unexported_values_head.test` ✅
- `GOWORK=off go test ./TreeDB/collections -run TestColumnGraphScalarU8CenteredQueryScratch2258 -count=1` ✅

Coverage added for optimized/scalar parity, dims below/equal/above SIMD width, non-multiple tails, row counts 0/1/small/large, shuffled/repeated rowIDs, invalid shapes leaving `dst` unchanged, zero allocations, overflow-sensitive high dimensions, resliced/internal cache length correctness, and non-mutating query inspection.

## Benchmarks

Command:

```sh
GOWORK=off go test ./TreeDB/internal/vectorops -run '^$' \
  -bench 'Benchmark.*ScalarU8.*(Indexed|Batch)' \
  -benchmem -benchtime=3s -count=5
```

Artifact: `/tmp/gomap_2259_vectorops_bench_20260603_165422.txt`  
Machine: Apple M3 / darwin-arm64. Backend rows below are `indexed_arm64_neon` except row-count-1 cases, which intentionally use scalar fallback due tiny-row threshold. All rows report `0 B/op`, `0 allocs/op`.

| dims | rows | backend ns/op | backend scores/sec | scalar ns/op | scalar scores/sec | delta | B/op | allocs/op |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 32 | 2 | 13.7 | 146,054,196 | 27.2 | 73,602,165 | 1.98x faster | 0 | 0 |
| 32 | 64 | 229.6 | 278,737,068 | 757.6 | 84,499,855 | 3.30x faster | 0 | 0 |
| 64 | 2 | 17.8 | 112,459,597 | 54.6 | 36,915,248 | 3.07x faster | 0 | 0 |
| 64 | 64 | 375.5 | 170,774,013 | 1,557.2 | 41,100,254 | 4.15x faster | 0 | 0 |
| 128 | 2 | 24.4 | 81,886,533 | 112.3 | 17,813,092 | 4.60x faster | 0 | 0 |
| 128 | 64 | 584.0 | 109,591,738 | 3,150.0 | 20,317,199 | 5.39x faster | 0 | 0 |
| 256 | 2 | 39.6 | 50,525,676 | 200.6 | 9,969,638 | 5.07x faster | 0 | 0 |
| 256 | 64 | 1,088.6 | 58,794,344 | 5,861.4 | 10,918,979 | 5.38x faster | 0 | 0 |
| 768 | 2 | 100.7 | 19,866,198 | 558.9 | 3,578,755 | 5.55x faster | 0 | 0 |
| 768 | 64 | 3,035.0 | 21,089,644 | 17,200.8 | 3,721,241 | 5.67x faster | 0 | 0 |

## Review / CI status

- Internal high-thinking Orca review: PASS before PR creation; original reviewer risk about stale metadata is now addressed by length-checked cache reuse plus unexported query backing slice.
- CodeRabbit blocking thread addressed in `4f863241cbf532804dae59b7669b25c0e97e2b78` without adding immutable-copy allocations.
- CI: all checks pass on latest PR head `4f863241cbf532804dae59b7669b25c0e97e2b78`.
- Codex/Copilot/CodeRabbit reviews were requested after PR maturity gate; no merge by agent.
