### PR TITLE
TreeDB: integrate SIMD scalar_u8 quantized scoring

### DIFF
--- a/TreeDB/collections/column_vector_graph_quantized_asset_test.go
+++ b/TreeDB/collections/column_vector_graph_quantized_asset_test.go
@@ -228,7 +228,7 @@ func TestColumnGraphScalarU8CenteredQueryScratch2258(t *testing.T) {
 	if !ok {
 		t.Fatal("row 1 code bytes unavailable")
 	}
-	got, err := scorer.scoreOrdinal(1, nil)
+	got, err := scorer.scoreOrdinal(1, &scratch, nil)
 	if err != nil {
 		t.Fatalf("scoreOrdinal: %v", err)
 	}
@@ -243,9 +243,12 @@ func TestColumnGraphScalarU8CenteredQueryScratch2258(t *testing.T) {
 		t.Fatalf("centered score=%v want legacy=%v", got, want)
 	}
 
-	_, err = reader.prepareScalarU8QuantizedScorer(columnVectorGraphNativeSearchQueryModeQuantizedOnly, def.QuantizedIndexes[0].Name, query, queryInvNorm, &scratch)
+	scorer, err = reader.prepareScalarU8QuantizedScorer(columnVectorGraphNativeSearchQueryModeQuantizedOnly, def.QuantizedIndexes[0].Name, query, queryInvNorm, &scratch)
 	if err != nil {
 		t.Fatalf("warm prepare scorer: %v", err)
+	}
+	if _, err := scorer.scoreOrdinal(1, &scratch, nil); err != nil {
+		t.Fatalf("warm scoreOrdinal: %v", err)
 	}
 	var stats columnVectorGraphNativeSearchStats
 	allocs := testing.AllocsPerRun(1000, func() {
@@ -253,7 +256,7 @@ func TestColumnGraphScalarU8CenteredQueryScratch2258(t *testing.T) {
 		if err != nil {
 			panic(err)
 		}
-		score, err := scorer.scoreOrdinal(1, &stats)
+		score, err := scorer.scoreOrdinal(1, &scratch, &stats)
 		if err != nil {
 			panic(err)
 		}
@@ -262,6 +265,118 @@ func TestColumnGraphScalarU8CenteredQueryScratch2258(t *testing.T) {
 	if allocs != 0 {
 		t.Fatalf("steady-state centered scalar_u8 prepare+score allocs/run=%v want 0", allocs)
 	}
+}
+
+func TestColumnGraphScalarU8QuantizedScoreOrdinalsUsesScalarU8BatchKernel2260(t *testing.T) {
+	shape := columnGraphScalarU8QuantizedBenchShape1926{rows: 8, dims: 32, m: 4, topK: 2, efSearch: 8, queryOrdinal: 3}
+	_, d, col, def, rows := openColumnGraphScalarU8QuantizedBenchCollection1926(t, shape, true)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	reader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("open reader: %v", err)
+	}
+	defer func() { _ = reader.Close() }()
+	query := rows[shape.queryOrdinal].vector
+	queryInvNorm, err := columnVectorGraphInvNorm(query)
+	if err != nil {
+		t.Fatalf("columnVectorGraphInvNorm query: %v", err)
+	}
+	var scratch columnVectorGraphNativeSearchScratch
+	scorer, err := reader.prepareScalarU8QuantizedScorer(columnVectorGraphNativeSearchQueryModeQuantizedOnly, def.QuantizedIndexes[0].Name, query, queryInvNorm, &scratch)
+	if err != nil {
+		t.Fatalf("prepare scorer: %v", err)
+	}
+	if payload, ok := scorer.codeRows.PayloadBytes(); !ok || !bytes.Equal(payload, scorer.codePayload) {
+		t.Fatalf("scorer code payload ok=%v len=%d want direct CodeRowView payload", ok, len(payload))
+	}
+
+	ordinals := []int{0, 1, 2, 3, 4, 5, 6, 7}
+	scores := make([]float64, 0, len(ordinals))
+	var stats columnVectorGraphNativeSearchStats
+	scores, err = scorer.scoreOrdinals(ordinals, scores, &scratch, &stats)
+	if err != nil {
+		t.Fatalf("scoreOrdinals batch: %v", err)
+	}
+	if len(scores) != len(ordinals) {
+		t.Fatalf("scoreOrdinals len=%d want %d", len(scores), len(ordinals))
+	}
+	for i, ordinal := range ordinals {
+		row, ok := scorer.codeRows.RowBytes(ordinal)
+		if !ok {
+			t.Fatalf("row %d unavailable", ordinal)
+		}
+		want, ok := scalarU8CenteredQuantizedCosineScore(scorer.centeredQuery, row)
+		if !ok {
+			t.Fatalf("scalar score row %d unavailable", ordinal)
+		}
+		if math.Abs(scores[i]-want) > 1e-12 {
+			t.Fatalf("batch score ordinal=%d got=%v want scalar=%v", ordinal, scores[i], want)
+		}
+	}
+	if stats.QuantizedScoreCalls != uint64(len(ordinals)) || stats.QuantizedCodeBytesRead != uint64(len(ordinals)*shape.dims) || stats.ScoreBatchCalls != 1 || stats.ScoreBatchCandidates != uint64(len(ordinals)) || stats.ScoreBatchMaxTileSize != uint64(len(ordinals)) {
+		t.Fatalf("batch stats=%+v want one quantized batch over all ordinals", stats)
+	}
+	if vectorops.DotScalarU8CenteredIndexedOptimizedEligible(len(ordinals), shape.dims) {
+		if stats.ScoreBatchOptimizedCalls != 1 || stats.ScoreBatchScalarFallbackCalls != 0 {
+			t.Fatalf("batch stats=%+v want optimized scalar_u8 batch status", stats)
+		}
+	} else if stats.ScoreBatchOptimizedCalls != 0 || stats.ScoreBatchScalarFallbackCalls != 1 {
+		t.Fatalf("batch stats=%+v want fallback scalar_u8 batch status", stats)
+	}
+
+	singleStats := columnVectorGraphNativeSearchStats{}
+	single, err := scorer.scoreOrdinals(ordinals[:1], scores[:0], &scratch, &singleStats)
+	if err != nil {
+		t.Fatalf("scoreOrdinals single fallback: %v", err)
+	}
+	wantSingle, ok := scalarU8CenteredQuantizedCosineScore(scorer.centeredQuery, mustColumnGraphQuantizedCodeRowForTest2260(t, scorer, ordinals[0]))
+	if !ok || len(single) != 1 || math.Abs(single[0]-wantSingle) > 1e-12 {
+		t.Fatalf("single score=%v ok=%v want %v", single, ok, wantSingle)
+	}
+	if vectorops.DotScalarU8CenteredIndexedOptimizedEligible(1, shape.dims) {
+		if singleStats.ScoreBatchOptimizedCalls != 1 || singleStats.ScoreBatchScalarFallbackCalls != 0 || singleStats.QuantizedScoreCalls != 1 {
+			t.Fatalf("single stats=%+v want optimized scalar_u8 single-row status", singleStats)
+		}
+	} else if singleStats.ScoreBatchOptimizedCalls != 0 || singleStats.ScoreBatchScalarFallbackCalls != 1 || singleStats.QuantizedScoreCalls != 1 {
+		t.Fatalf("single stats=%+v want scalar_u8 fallback status", singleStats)
+	}
+
+	_, err = scorer.scoreOrdinals([]int{0, len(ordinals)}, scores[:0], &scratch, &columnVectorGraphNativeSearchStats{})
+	if !errors.Is(err, ErrVectorIndexSearchUnavailable) || !strings.Contains(err.Error(), "ordinal=8") {
+		t.Fatalf("invalid ordinal err=%v want fail-closed unavailable", err)
+	}
+	if _, err = scorer.scoreOrdinals(ordinals, scores[:0], nil, &columnVectorGraphNativeSearchStats{}); !errors.Is(err, errColumnVectorGraphNativeSearchScratchRequired) {
+		t.Fatalf("nil scratch err=%v want scratch required", err)
+	}
+
+	_, err = scorer.scoreOrdinals(ordinals, scores[:0], &scratch, &columnVectorGraphNativeSearchStats{})
+	if err != nil {
+		t.Fatalf("warm scoreOrdinals: %v", err)
+	}
+	var allocStats columnVectorGraphNativeSearchStats
+	allocs := testing.AllocsPerRun(1000, func() {
+		allocStats = columnVectorGraphNativeSearchStats{}
+		got, err := scorer.scoreOrdinals(ordinals, scores[:0], &scratch, &allocStats)
+		if err != nil {
+			panic(err)
+		}
+		columnPhysicalScanBenchSum += int64(got[0] * 1_000_000)
+	})
+	if allocs != 0 {
+		t.Fatalf("steady-state scalar_u8 batch scoreOrdinals allocs/run=%v want 0", allocs)
+	}
+}
+
+func mustColumnGraphQuantizedCodeRowForTest2260(tb testing.TB, scorer columnVectorGraphScalarU8QuantizedScorer, ordinal int) []byte {
+	tb.Helper()
+	row, ok := scorer.codeRows.RowBytes(ordinal)
+	if !ok {
+		tb.Fatalf("row %d unavailable", ordinal)
+	}
+	return row
 }
 
 func TestColumnGraphScalarU8QuantizedRerankExactRanksCandidateSet1926(t *testing.T) {

--- a/TreeDB/collections/column_vector_graph_quantized_bench_test.go
+++ b/TreeDB/collections/column_vector_graph_quantized_bench_test.go
@@ -244,6 +244,13 @@ func addColumnGraphScalarU8QuantizedBenchmarkStats1926(dst *VectorIndexSearchSta
 	dst.CandidateFetches += src.CandidateFetches
 	dst.ExpansionFetches += src.ExpansionFetches
 	dst.ResultFetches += src.ResultFetches
+	dst.ScoreBatchCalls += src.ScoreBatchCalls
+	dst.ScoreBatchCandidates += src.ScoreBatchCandidates
+	if src.ScoreBatchMaxTileSize > dst.ScoreBatchMaxTileSize {
+		dst.ScoreBatchMaxTileSize = src.ScoreBatchMaxTileSize
+	}
+	dst.ScoreBatchOptimizedCalls += src.ScoreBatchOptimizedCalls
+	dst.ScoreBatchScalarFallbackCalls += src.ScoreBatchScalarFallbackCalls
 	dst.PreparedScoreCalls += src.PreparedScoreCalls
 	dst.QuantizedScoreCalls += src.QuantizedScoreCalls
 	dst.QuantizedCodeBytesRead += src.QuantizedCodeBytesRead
@@ -292,6 +299,11 @@ func reportColumnGraphScalarU8QuantizedScorePlaneMetrics1926(b *testing.B, fixtu
 	b.ReportMetric(float64(stats.VectorBytesRead)/denom, "vector_B/search")
 	b.ReportMetric(float64(stats.NormBytesRead)/denom, "norm_B/search")
 	b.ReportMetric(float64(stats.AdjacencyBytesRead)/denom, "adjacency_B/search")
+	b.ReportMetric(float64(stats.ScoreBatchCalls)/denom, "score_batch_calls/search")
+	b.ReportMetric(float64(stats.ScoreBatchCandidates)/denom, "score_batch_candidates/search")
+	b.ReportMetric(float64(stats.ScoreBatchMaxTileSize), "score_batch_max_tile_size")
+	b.ReportMetric(float64(stats.ScoreBatchOptimizedCalls)/denom, "score_batch_optimized/search")
+	b.ReportMetric(float64(stats.ScoreBatchScalarFallbackCalls)/denom, "score_batch_fallback/search")
 	b.ReportMetric(float64(stats.PreparedScoreCalls)/denom, "prepared_score_calls/search")
 	b.ReportMetric(float64(stats.QuantizedScoreCalls)/denom, "quantized_score_calls/search")
 	b.ReportMetric(float64(stats.QuantizedCodeBytesRead)/denom, "quantized_code_B/search")

--- a/TreeDB/collections/column_vector_graph_quantized_scorer.go
+++ b/TreeDB/collections/column_vector_graph_quantized_scorer.go
@@ -2,7 +2,6 @@ package collections
 
 import (
 	"fmt"
-	"math"
 
 	"github.com/snissn/gomap/TreeDB/internal/quantizedasset"
 	"github.com/snissn/gomap/TreeDB/internal/vectorops"
@@ -11,9 +10,10 @@ import (
 const columnVectorGraphScalarU8CodeScale = 255.0 * 255.0
 
 type columnVectorGraphScalarU8QuantizedScorer struct {
-	indexName string
-	dims      int
-	codeRows  quantizedasset.CodeRowView
+	indexName   string
+	dims        int
+	codeRows    quantizedasset.CodeRowView
+	codePayload []byte
 	// queryCode and centeredQuery alias caller-owned search scratch.
 	queryCode     []byte
 	centeredQuery vectorops.ScalarU8CenteredQuery
@@ -69,6 +69,10 @@ func (r *columnVectorGraphPhysicalRowReader) prepareScalarU8QuantizedScorer(mode
 	if elements := codeRows.ElementsPerRow(); elements != r.def.Dimensions {
 		return columnVectorGraphScalarU8QuantizedScorer{}, fmt.Errorf("%w: column_graph %q query_mode=%s quantized index %q code elements_per_row=%d want dimensions=%d", ErrVectorIndexSearchUnavailable, r.def.Name, mode.String(), indexName, elements, r.def.Dimensions)
 	}
+	codePayload, ok := codeRows.PayloadBytes()
+	if !ok || len(codePayload) != r.RowCount()*r.def.Dimensions {
+		return columnVectorGraphScalarU8QuantizedScorer{}, fmt.Errorf("%w: column_graph %q query_mode=%s quantized index %q code row payload bytes=%d ok=%v want %d", ErrVectorIndexSearchUnavailable, r.def.Name, mode.String(), indexName, len(codePayload), ok, r.RowCount()*r.def.Dimensions)
+	}
 	queryCode := resizeColumnVectorGraphNativeByteScratch(scratch.quantizedQueryCodes, r.def.Dimensions)
 	for _, value := range query {
 		queryCode = append(queryCode, columnVectorGraphScalarU8Code(value*queryInvNorm))
@@ -80,29 +84,38 @@ func (r *columnVectorGraphPhysicalRowReader) prepareScalarU8QuantizedScorer(mode
 		return columnVectorGraphScalarU8QuantizedScorer{}, fmt.Errorf("%w: column_graph %q query_mode=%s quantized index %q centered scalar_u8 query unavailable", ErrVectorIndexSearchUnavailable, r.def.Name, mode.String(), indexName)
 	}
 	scratch.quantizedQueryCentered = centeredScratch
-	return columnVectorGraphScalarU8QuantizedScorer{indexName: indexName, dims: r.def.Dimensions, codeRows: codeRows, queryCode: queryCode, centeredQuery: centeredQuery}, nil
+	return columnVectorGraphScalarU8QuantizedScorer{indexName: indexName, dims: r.def.Dimensions, codeRows: codeRows, codePayload: codePayload, queryCode: queryCode, centeredQuery: centeredQuery}, nil
 }
 
-func (s *columnVectorGraphScalarU8QuantizedScorer) scoreOrdinal(ordinal int, stats *columnVectorGraphNativeSearchStats) (float64, error) {
-	if s == nil || !s.codeRows.Valid() || s.dims <= 0 || len(s.queryCode) != s.dims || !s.centeredQuery.ValidForDims(s.dims) {
+func (s *columnVectorGraphScalarU8QuantizedScorer) scoreOrdinal(ordinal int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) (float64, error) {
+	if s == nil || !s.codeRows.Valid() || s.dims <= 0 || len(s.codePayload) != s.codeRows.Rows()*s.dims || len(s.queryCode) != s.dims || !s.centeredQuery.ValidForDims(s.dims) {
 		return 0, fmt.Errorf("%w: column_graph quantized scalar_u8 scorer is unavailable", ErrVectorIndexSearchUnavailable)
 	}
-	row, ok := s.codeRows.RowBytes(ordinal)
-	if !ok || len(row) != s.dims {
-		return 0, fmt.Errorf("%w: column_graph quantized index %q code row ordinal=%d unavailable len=%d ok=%v want %d", ErrVectorIndexSearchUnavailable, s.indexName, ordinal, len(row), ok, s.dims)
+	if scratch == nil {
+		return 0, fmt.Errorf("collections: column_graph quantized scalar_u8 scorer: %w", errColumnVectorGraphNativeSearchScratchRequired)
 	}
+	rows := s.codeRows.Rows()
+	if ordinal < 0 || ordinal >= rows || uint64(ordinal) > uint64(^uint32(0)) {
+		return 0, fmt.Errorf("%w: column_graph quantized index %q code row ordinal=%d unavailable len=0 ok=false want %d", ErrVectorIndexSearchUnavailable, s.indexName, ordinal, s.dims)
+	}
+	scratch.scoreTileRowIDs = ensureColumnVectorGraphNativeUint32Scratch(scratch.scoreTileRowIDs, 1)
+	rowIDs := scratch.scoreTileRowIDs[:1]
+	rowIDs[0] = uint32(ordinal)
+	scratch.scoreTileQuantizedDots = ensureColumnVectorGraphNativeInt64Scratch(scratch.scoreTileQuantizedDots, 1)
+	dots := scratch.scoreTileQuantizedDots[:1]
+	status := vectorops.DotScalarU8CenteredIndexed(dots, s.codePayload, s.centeredQuery, rowIDs, s.dims)
+	if status.Invalid || status.Rows != 1 {
+		return 0, fmt.Errorf("%w: column_graph quantized index %q scalar_u8 score invalid status=%+v rows=%d want 1", ErrVectorIndexSearchUnavailable, s.indexName, status, status.Rows)
+	}
+	score := scalarU8QuantizedCosineScoreFromDot(dots[0])
 	if stats != nil {
-		recordColumnVectorGraphScoreBatchStats(stats, 1, false, true)
-		s.recordScoreStats(stats, 1)
-	}
-	score, ok := scalarU8CenteredQuantizedCosineScore(s.centeredQuery, row)
-	if !ok || math.IsNaN(score) || math.IsInf(score, 0) {
-		return 0, fmt.Errorf("collections: column_graph quantized index %q candidate ordinal=%d scalar_u8 score is not finite", s.indexName, ordinal)
+		recordColumnVectorGraphScoreBatchStats(stats, status.Rows, status.Optimized, status.Fallback)
+		s.recordScoreStats(stats, status.Rows)
 	}
 	return score, nil
 }
 
-func (s *columnVectorGraphScalarU8QuantizedScorer) scoreOrdinals(ordinals []int, dst []float64, stats *columnVectorGraphNativeSearchStats) ([]float64, error) {
+func (s *columnVectorGraphScalarU8QuantizedScorer) scoreOrdinals(ordinals []int, dst []float64, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) ([]float64, error) {
 	if cap(dst) < len(ordinals) {
 		dst = make([]float64, len(ordinals))
 	} else {
@@ -111,28 +124,34 @@ func (s *columnVectorGraphScalarU8QuantizedScorer) scoreOrdinals(ordinals []int,
 	if len(ordinals) == 0 {
 		return dst, nil
 	}
-	if s == nil || !s.codeRows.Valid() || s.dims <= 0 || len(s.queryCode) != s.dims || !s.centeredQuery.ValidForDims(s.dims) {
+	if s == nil || !s.codeRows.Valid() || s.dims <= 0 || len(s.codePayload) != s.codeRows.Rows()*s.dims || len(s.queryCode) != s.dims || !s.centeredQuery.ValidForDims(s.dims) {
 		return dst[:0], fmt.Errorf("%w: column_graph quantized scalar_u8 scorer is unavailable", ErrVectorIndexSearchUnavailable)
 	}
-	if stats != nil {
-		recordColumnVectorGraphScoreBatchStats(stats, len(ordinals), false, true)
+	if scratch == nil {
+		return dst[:0], fmt.Errorf("collections: column_graph quantized scalar_u8 scorer: %w", errColumnVectorGraphNativeSearchScratchRequired)
 	}
-	successCount := 0
+	scratch.scoreTileRowIDs = ensureColumnVectorGraphNativeUint32Scratch(scratch.scoreTileRowIDs, len(ordinals))
+	rowIDs := scratch.scoreTileRowIDs[:len(ordinals)]
+	rows := s.codeRows.Rows()
 	for i, ordinal := range ordinals {
-		row, ok := s.codeRows.RowBytes(ordinal)
-		if !ok || len(row) != s.dims {
-			s.recordScoreStats(stats, successCount)
-			return dst[:i], fmt.Errorf("%w: column_graph quantized index %q code row ordinal=%d unavailable len=%d ok=%v want %d", ErrVectorIndexSearchUnavailable, s.indexName, ordinal, len(row), ok, s.dims)
+		if ordinal < 0 || ordinal >= rows || uint64(ordinal) > uint64(^uint32(0)) {
+			return dst[:0], fmt.Errorf("%w: column_graph quantized index %q code row ordinal=%d unavailable len=0 ok=false want %d", ErrVectorIndexSearchUnavailable, s.indexName, ordinal, s.dims)
 		}
-		score, ok := scalarU8CenteredQuantizedCosineScore(s.centeredQuery, row)
-		if !ok || math.IsNaN(score) || math.IsInf(score, 0) {
-			s.recordScoreStats(stats, successCount)
-			return dst[:i], fmt.Errorf("collections: column_graph quantized index %q candidate ordinal=%d scalar_u8 score is not finite", s.indexName, ordinal)
-		}
-		dst[i] = score
-		successCount++
+		rowIDs[i] = uint32(ordinal)
 	}
-	s.recordScoreStats(stats, successCount)
+	scratch.scoreTileQuantizedDots = ensureColumnVectorGraphNativeInt64Scratch(scratch.scoreTileQuantizedDots, len(ordinals))
+	dots := scratch.scoreTileQuantizedDots[:len(ordinals)]
+	status := vectorops.DotScalarU8CenteredIndexed(dots, s.codePayload, s.centeredQuery, rowIDs, s.dims)
+	if status.Invalid || status.Rows != len(ordinals) {
+		return dst[:0], fmt.Errorf("%w: column_graph quantized index %q scalar_u8 batch score invalid status=%+v rows=%d want %d", ErrVectorIndexSearchUnavailable, s.indexName, status, status.Rows, len(ordinals))
+	}
+	for i, dot := range dots {
+		dst[i] = scalarU8QuantizedCosineScoreFromDot(dot)
+	}
+	if stats != nil {
+		recordColumnVectorGraphScoreBatchStats(stats, status.Rows, status.Optimized, status.Fallback)
+	}
+	s.recordScoreStats(stats, status.Rows)
 	return dst, nil
 }
 
@@ -152,5 +171,9 @@ func scalarU8CenteredQuantizedCosineScore(query vectorops.ScalarU8CenteredQuery,
 	if !ok {
 		return 0, false
 	}
-	return float64(dot) / columnVectorGraphScalarU8CodeScale, true
+	return scalarU8QuantizedCosineScoreFromDot(dot), true
+}
+
+func scalarU8QuantizedCosineScoreFromDot(dot int64) float64 {
+	return float64(dot) / columnVectorGraphScalarU8CodeScale
 }

--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -882,6 +882,7 @@ type columnVectorGraphNativeSearchScratch struct {
 	scoreTileScores        []float64
 	scoreTileRowIDs        []uint32
 	scoreTileDots          []float32
+	scoreTileQuantizedDots []int64
 	quantizedQueryCodes    []byte
 	quantizedQueryCentered []vectorops.ScalarU8CenteredCode
 	wavefrontCandidates    []columnVectorGraphSearchCandidate
@@ -927,6 +928,7 @@ func (s *columnVectorGraphNativeSearchScratch) prepare(rowCount, dimensions, deg
 	s.scoreTileScores = resizeColumnVectorGraphNativeFloat64Scratch(s.scoreTileScores, scoreTileCapacity)
 	s.scoreTileRowIDs = resizeColumnVectorGraphNativeUint32Scratch(s.scoreTileRowIDs, scoreTileCapacity)
 	s.scoreTileDots = resizeColumnVectorGraphNativeFloat32Scratch(s.scoreTileDots, scoreTileCapacity)
+	s.scoreTileQuantizedDots = resizeColumnVectorGraphNativeInt64Scratch(s.scoreTileQuantizedDots, scoreTileCapacity)
 	s.wavefrontCandidates = resizeColumnVectorGraphNativeCandidateScratch(s.wavefrontCandidates, wavefrontWidth)
 	return nil
 }
@@ -1029,6 +1031,13 @@ func resizeColumnVectorGraphNativeFloat32Scratch(dst []float32, target int) []fl
 	return dst[:0]
 }
 
+func resizeColumnVectorGraphNativeInt64Scratch(dst []int64, target int) []int64 {
+	if cap(dst) < target || columnVectorGraphNativeScratchCapOversized(cap(dst), target) {
+		return make([]int64, 0, target)
+	}
+	return dst[:0]
+}
+
 func resizeColumnVectorGraphNativeFloat64Scratch(dst []float64, target int) []float64 {
 	if cap(dst) < target || columnVectorGraphNativeScratchCapOversized(cap(dst), target) {
 		return make([]float64, 0, target)
@@ -1067,6 +1076,13 @@ func ensureColumnVectorGraphNativeUint32Scratch(dst []uint32, target int) []uint
 func ensureColumnVectorGraphNativeFloat32Scratch(dst []float32, target int) []float32 {
 	if cap(dst) < target {
 		return make([]float32, 0, target)
+	}
+	return dst[:0]
+}
+
+func ensureColumnVectorGraphNativeInt64Scratch(dst []int64, target int) []int64 {
+	if cap(dst) < target {
+		return make([]int64, 0, target)
 	}
 	return dst[:0]
 }
@@ -1358,7 +1374,7 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 			if err != nil {
 				return nil, stats, err
 			}
-			if plan != nil && (plan.preparedSearch != nil || plan.scoreBatchMode.indexedEnabled()) {
+			if plan != nil && (plan.quantizedScorerActive || plan.preparedSearch != nil || plan.scoreBatchMode.indexedEnabled()) {
 				for i := 0; i < len(adjacency); {
 					tileCap := len(adjacency) - i
 					scratch.scoreTileOrdinals = ensureColumnVectorGraphNativeIntScratch(scratch.scoreTileOrdinals, tileCap)
@@ -1736,7 +1752,7 @@ func (r *columnVectorGraphPhysicalRowReader) greedyNearestAtLayer(plan *columnVe
 		if err != nil {
 			return 0, err
 		}
-		if plan != nil && (plan.preparedSearch != nil || plan.scoreBatchMode.indexedEnabled()) {
+		if plan != nil && (plan.quantizedScorerActive || plan.preparedSearch != nil || plan.scoreBatchMode.indexedEnabled()) {
 			scratch.scoreTileOrdinals = ensureColumnVectorGraphNativeIntScratch(scratch.scoreTileOrdinals, len(adjacency))
 			tile := scratch.scoreTileOrdinals[:0]
 			for i, neighbor := range adjacency {
@@ -2034,7 +2050,7 @@ func (r *columnVectorGraphPhysicalRowReader) scoreAndPushFrontierVisitedTile(pla
 
 func (r *columnVectorGraphPhysicalRowReader) scoreOrdinal(plan *columnVectorGraphSearchPlan, singleBlockView *columnVectorGraphBlockView, query []float32, queryInvNorm float32, ordinal int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) (float64, error) {
 	if plan != nil && plan.quantizedScorerActive {
-		return plan.quantizedScorer.scoreOrdinal(ordinal, stats)
+		return plan.quantizedScorer.scoreOrdinal(ordinal, scratch, stats)
 	}
 	if plan != nil && plan.preparedSearch != nil {
 		return plan.preparedSearch.scoreOrdinal(plan, query, queryInvNorm, ordinal, stats)
@@ -2047,7 +2063,7 @@ func (r *columnVectorGraphPhysicalRowReader) scoreOrdinal(plan *columnVectorGrap
 
 func (r *columnVectorGraphPhysicalRowReader) scoreOrdinals(plan *columnVectorGraphSearchPlan, singleBlockView *columnVectorGraphBlockView, query []float32, queryInvNorm float32, ordinals []int, dst []float64, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) ([]float64, error) {
 	if plan != nil && plan.quantizedScorerActive {
-		return plan.quantizedScorer.scoreOrdinals(ordinals, dst, stats)
+		return plan.quantizedScorer.scoreOrdinals(ordinals, dst, scratch, stats)
 	}
 	if plan != nil && plan.preparedSearch != nil {
 		return plan.preparedSearch.scoreOrdinals(plan, query, queryInvNorm, ordinals, dst, scratch, stats)

--- a/TreeDB/internal/quantizedasset/quantized_asset.go
+++ b/TreeDB/internal/quantizedasset/quantized_asset.go
@@ -1007,6 +1007,15 @@ func (v CodeRowView) ElementsPerRow() int {
 	return v.elementsPerRow
 }
 
+// PayloadBytes returns the validated row-major payload backing this view. The
+// slice aliases immutable prepared image bytes and must be treated as read-only.
+func (v CodeRowView) PayloadBytes() ([]byte, bool) {
+	if !v.Valid() {
+		return nil, false
+	}
+	return v.payload, true
+}
+
 // RowBytes returns a zero-copy row byte slice by graph/vector ordinal. The
 // slice aliases immutable prepared image bytes and must be treated as read-only.
 func (v CodeRowView) RowBytes(ordinal int) ([]byte, bool) {

--- a/TreeDB/internal/quantizedasset/quantized_asset_test.go
+++ b/TreeDB/internal/quantizedasset/quantized_asset_test.go
@@ -240,6 +240,10 @@ func TestPreparedCodeRowViewValidatesOnceAndSlicesRows2256(t *testing.T) {
 	if got := view.ElementsPerRow(); got != fixture.schema.CodeDimensions {
 		t.Fatalf("view elements_per_row=%d want %d", got, fixture.schema.CodeDimensions)
 	}
+	payload, ok := view.PayloadBytes()
+	if !ok || !bytes.Equal(payload, bytes.Join(fixture.fixedRows, nil)) {
+		t.Fatalf("view payload=%x ok=%v want row-major fixed rows", payload, ok)
+	}
 
 	for ordinal, want := range fixture.fixedRows {
 		row, ok := view.RowBytes(ordinal)
@@ -269,6 +273,9 @@ func TestPreparedCodeRowViewValidatesOnceAndSlicesRows2256(t *testing.T) {
 	var zero CodeRowView
 	if zero.Valid() {
 		t.Fatal("zero CodeRowView valid=true want false")
+	}
+	if payload, ok := zero.PayloadBytes(); ok || payload != nil {
+		t.Fatalf("zero PayloadBytes payload=%x ok=%v want fail-closed", payload, ok)
 	}
 	if row, ok := zero.RowBytes(0); ok || row != nil {
 		t.Fatalf("zero RowBytes row=%x ok=%v want fail-closed", row, ok)

--- a/TreeDB/internal/vectorops/scalar_u8_dot_batch_amd64.go
+++ b/TreeDB/internal/vectorops/scalar_u8_dot_batch_amd64.go
@@ -8,7 +8,7 @@ const scalarU8DotBatchOptimizedAvailable = true
 
 const (
 	dotScalarU8CenteredIndexedAMD64MinDims = 16
-	dotScalarU8CenteredIndexedAMD64MinRows = 2
+	dotScalarU8CenteredIndexedAMD64MinRows = 1
 	// The SSE2 kernel accumulates into signed 32-bit vector lanes and reduces once
 	// per row. At 32,768 dimensions, the worst-case full-row scalar_u8 dot product
 	// is 65,025*32,768 = 2,130,739,200, which still fits int32. Larger dimensions

--- a/TreeDB/internal/vectorops/scalar_u8_dot_batch_arm64.go
+++ b/TreeDB/internal/vectorops/scalar_u8_dot_batch_arm64.go
@@ -8,7 +8,7 @@ const scalarU8DotBatchOptimizedAvailable = true
 
 const (
 	dotScalarU8CenteredIndexedARM64MinDims = 16
-	dotScalarU8CenteredIndexedARM64MinRows = 2
+	dotScalarU8CenteredIndexedARM64MinRows = 1
 )
 
 func dotScalarU8CenteredIndexedOptimizedEligible(rows, dims int) bool {

--- a/TreeDB/internal/vectorops/scalar_u8_dot_batch_test.go
+++ b/TreeDB/internal/vectorops/scalar_u8_dot_batch_test.go
@@ -97,7 +97,14 @@ func TestDotScalarU8CenteredIndexedOptimizedStatusAndFallback(t *testing.T) {
 
 	singleDst := make([]int64, 1)
 	singleStatus := DotScalarU8CenteredIndexed(singleDst, codes, query, rowIDs[:1], 64)
-	if singleStatus.Invalid || singleStatus.Rows != 1 || singleStatus.Optimized || !singleStatus.Fallback {
+	if singleStatus.Invalid || singleStatus.Rows != 1 {
+		t.Fatalf("single-row status=%+v want valid row", singleStatus)
+	}
+	if DotScalarU8CenteredIndexedOptimizedEligible(1, 64) {
+		if !singleStatus.Optimized || singleStatus.Fallback {
+			t.Fatalf("single-row status=%+v want optimized indexed backend", singleStatus)
+		}
+	} else if singleStatus.Optimized || !singleStatus.Fallback {
 		t.Fatalf("single-row status=%+v want scalar fallback", singleStatus)
 	}
 	singleWant := make([]int64, 1)


### PR DESCRIPTION
## Summary

Closes #2260. Parent: #2169.

- Wires `columnVectorGraphScalarU8QuantizedScorer` into `vectorops.DotScalarU8CenteredIndexed` for scalar_u8 quantized tile and singleton scoring.
- Uses prepared centered scalar_u8 query codes plus scratch row IDs / int64 dot buffers; no steady-state search allocations.
- Adds a read-only `quantizedasset.CodeRowView.PayloadBytes()` row-major view for batch kernels.
- Reports existing score-batch optimized/fallback counters in the TreeDB quantized score-plane benchmark.

## Scope / non-goals

- Exact/default search semantics unchanged.
- Quantized modes still fail closed; no hidden exact fallback.
- `quantized_only` uses only quantized code rows for traversal/scoring; exact vector/norm reads remain 0.
- `quantized_rerank` uses SIMD quantized traversal, then exact-ranks only the trimmed shortlist.
- No on-disk format changes.
- No pgvector comparison harness changes and no unrelated HNSW traversal/window/control-flow changes.

## Tests

```sh
GOWORK=off go test ./TreeDB/collections -run 'TestColumnGraphScalarU8|TestSearchVectorIndexQuantized|TestVectorIndexSearcherQuantized' -count=1
GOWORK=off go test ./TreeDB/internal/vectorops -run 'Test.*ScalarU8' -count=1
GOWORK=off go test ./TreeDB/collections ./TreeDB/internal/quantizedasset ./TreeDB/internal/vectorops -count=1
GOWORK=off go test -race ./TreeDB/collections -run 'TestColumnGraphScalarU8QuantizedModesConcurrentSearch1926|TestVectorIndexSearcherQuantizedSearchWithBufferSuccessAndErrorReset1926' -count=1
```

All passed locally on Apple M3/darwin-arm64.

Internal Orca review: PASS, no blocking findings, no non-blocking nits.

## Benchmark/profile artifacts

- Baseline (`origin/main` / `dd19a6822ddcc2e0607c09db52e6c3f2bd7032d8`): `/tmp/gomap_2260_baseline_20260603_173055`
- Candidate (`3094cdeaeef417908cca707df96acfa674f208a8`): `/tmp/gomap_2260_candidate_final_20260603_174337`
- Candidate CPU profile: `/tmp/gomap_2260_candidate_final_20260603_174337/cpu_quantized_only.pprof`
- Top output: `/tmp/gomap_2260_candidate_final_20260603_174337/cpu_quantized_only_top.txt`

Commands:

```sh
GOWORK=off go test ./TreeDB/collections -run '^$' \
  -bench '^BenchmarkColumnGraphScalarU8QuantizedScorePlanes1926/mode=(exact|quantized_only|quantized_rerank/candidates=32)$' \
  -benchmem -benchtime=3s -count=5

# separate rerank row because slash matching excluded it from the combined regex on this Go toolchain
GOWORK=off go test ./TreeDB/collections -run '^$' \
  -bench '^BenchmarkColumnGraphScalarU8QuantizedScorePlanes1926/mode=quantized_rerank/candidates=32$' \
  -benchmem -benchtime=3s -count=5

GOWORK=off go test ./TreeDB/collections -run '^$' \
  -bench '^BenchmarkColumnGraphScalarU8QuantizedScorePlanes1926/mode=quantized_only$' \
  -benchmem -benchtime=5s -count=1 \
  -cpuprofile /tmp/gomap_2260_candidate_final_20260603_174337/cpu_quantized_only.pprof
```

## Benchmark summary (means, 1024 rows / 128 dims / M=16 / top_k=10 / ef_search=128)

| mode | baseline ns/op | candidate ns/op | baseline ops/sec | candidate ops/sec | B/op | allocs/op | quantized scores/search | quantized code B/search | optimized batches/search | fallback batches/search | vector B/search | norm B/search | rerank exact scores/search |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| exact | 15,645 | 16,325 | 63,922 | 61,293 | 0 | 0 | 0 | 0 | 7 | 7 | 86,528 | 676 | 0 |
| quantized_only | 23,077 | 15,866 | 43,335 | 63,037 | 0 | 0 | 169 | 21,632 | 14 | 0 | 0 | 0 | 0 |
| quantized_rerank/candidates=32 | 23,654 | 16,582 | 42,276 | 60,332 | 0 | 0 | 169 | 21,632 | 15 | 0 | 16,384 | 128 | 32 |

`quantized_only` is faster than candidate exact/default in this standard run (15,866 ns/op vs 16,325 ns/op), with 0 B/op, 0 allocs/op, and 0 vector/norm bytes/search.

## CPU profile key functions (`quantized_only`, candidate)

From `go tool pprof -top`:

| function | flat | cum |
| --- | ---: | ---: |
| `columnVectorGraphPhysicalRowReader.SearchCosine` | 2.11s (37.54%) | 4.70s (83.63%) |
| `columnVectorGraphNativeSearchScratch.frontierSiftDown` | 0.70s (12.46%) | 0.79s (14.06%) |
| `vectorops.dotScalarU8CenteredIndexedARM64` | 0.40s (7.12%) | 0.40s (7.12%) |
| `columnVectorGraphScalarU8QuantizedScorer.scoreOrdinals` | 0.07s (1.25%) | 0.50s (8.90%) |
| `vectorops.DotScalarU8CenteredIndexed` | 0.02s (0.36%) | 0.45s (8.01%) |

The old scalar byte-dot scorer is no longer a dominant hot function; scoring routes through the SIMD scalar_u8 indexed kernel.

## CI / AI review status

- CI: latest head `3094cdeaeef417908cca707df96acfa674f208a8` green; merge state `CLEAN`.
- AI reviews: Codex and Copilot requested; no findings received as of this update. CodeRabbit completed with no actionable comments. Review threads: 0 unresolved.

## Risks / deferrals

- SIMD single-row eligibility is enabled for supported ARM64/AMD64 scalar_u8 kernels; portable/purego remains fallback.
- Broader HNSW traversal/windowing/control-flow improvements remain deferred outside #2260.



## Coordinator final validation

Coordinator validation on latest head `3094cdeaeef417908cca707df96acfa674f208a8`:

```sh
GOWORK=off go test ./TreeDB/collections -run 'TestColumnGraphScalarU8|TestSearchVectorIndexQuantized|TestVectorIndexSearcherQuantized' -count=1
GOWORK=off go test ./TreeDB/internal/vectorops -run 'Test.*ScalarU8' -count=1
GOWORK=off go test ./TreeDB/collections ./TreeDB/internal/quantizedasset ./TreeDB/internal/vectorops -count=1
GOWORK=off go test -race ./TreeDB/collections -run 'TestColumnGraphScalarU8QuantizedModesConcurrentSearch1926|TestVectorIndexSearcherQuantizedSearchWithBufferSuccessAndErrorReset1926' -count=1
git diff --check origin/main...HEAD
```

All passed. Latest-head CI is green, merge state is `CLEAN`, mergeable is `MERGEABLE`, and unresolved non-outdated review threads are 0.
