### PR TITLE
docs: refresh README benchmark highlights

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,33 +30,34 @@ benchmark suite.
 External `go-ycsb`, local loopback TCP, `recordcount=100000`,
 `operationcount=10000`, `threadcount=16`, BSON document format, and zero YCSB
 operation errors. Run rows use the median total-throughput repeat from the
-June 2, 2026 report.
+latest-main June 3 HST / June 4 UTC report.
 
 | target | profile | load ops/sec | run ops/sec | run avg us | run p99 us |
 | --- | --- | ---: | ---: | ---: | ---: |
-| MongoDB 8 | baseline | 33,255.6 | 26,102.5 | 601.0 | 1,461.0 |
-| TreeDB nativewire | `command_wal_durable` | 77,065.3 | 120,500.7 | 128.0 | 477.0 |
-| TreeDB Mongo gateway | `command_wal_durable` | 57,370.1 | 74,544.7 | 206.0 | 649.0 |
+| MongoDB 8 | baseline | 38,755.4 | 26,494.1 | 595.0 | 1,275.0 |
+| TreeDB nativewire | `command_wal_durable` | 83,217.0 | 135,318.6 | 113.0 | 367.0 |
+| TreeDB Mongo gateway | `command_wal_durable` | 68,218.2 | 80,628.4 | 199.0 | 649.0 |
 
 Full report, commands, host context, run repeats, and artifact paths:
-[June 2 YCSB report](docs/benchmarks/ycsb_post_update_stack_2026-06-02.md).
+[June 3 latest-main YCSB report](docs/benchmarks/ycsb_latest_main_2026-06-03.md).
 
 ### Indexed Collection Insert Workload
 
-Two secondary indexes, June 2 current-code rerun, `100000` documents, batch
-size `16000`, and `command_wal_relaxed` for TreeDB. `docs/sec` is the timed
-insert measurement for the value-log outer-leaf layout; B/doc uses the fully
-compacted storage phase for the same TreeDB layout and SQLite after `VACUUM`.
+Two secondary indexes, latest-main June 3 HST / June 4 UTC rerun, `100000`
+documents, batch size `16000`, and `command_wal_relaxed` for TreeDB. `docs/sec`
+is the timed insert measurement for the value-log outer-leaf layout; B/doc uses
+the fully compacted storage phase for the same TreeDB layout and SQLite after
+`VACUUM`.
 
 | engine / format | layout | docs/sec | fully compacted B/doc |
 | --- | --- | ---: | ---: |
-| TreeDB template-v1 | data and index outer leaves in value log | 626,959 | 22.2 |
-| TreeDB JSON | data and index outer leaves in value log | 419,463 | 30.4 |
-| SQLite native columns | WAL normal | 330,797 | 156.7 |
-| SQLite JSON | WAL normal | 302,115 | 231.7 |
+| TreeDB template-v1 | data and index outer leaves in value log | 600,962 | 27.8 |
+| TreeDB JSON | data and index outer leaves in value log | 450,857 | 33.7 |
+| SQLite native columns | WAL normal | 344,353 | 156.7 |
+| SQLite JSON | WAL normal | 296,912 | 231.7 |
 
 Source:
-[June 2 two-index insert rerun](docs/benchmarks/collections_insert_two_index_current_2026-06-02.md).
+[June 3 latest-main two-index insert rerun](docs/benchmarks/collections_insert_two_index_latest_main_2026-06-03.md).
 
 ### Collection Read And Lookup Workload
 
@@ -178,12 +179,12 @@ More detail: `docs/TREEDB_PROFILES.md` and `docs/TREEDB_WRITE_PATHS.md`.
 Current YCSB status and rerun commands:
 
 - `docs/benchmarks/ycsb_mongodb_treedb_current.md`
-- `docs/benchmarks/ycsb_post_update_stack_2026-06-02.md`
+- `docs/benchmarks/ycsb_latest_main_2026-06-03.md`
 - `scripts/ycsb_compare_mongodb_treedb.sh`
 
 Collection and engine benchmark runbooks:
 
-- `docs/benchmarks/collections_insert_two_index_current_2026-06-02.md`
+- `docs/benchmarks/collections_insert_two_index_latest_main_2026-06-03.md`
 - `docs/benchmarks/treedb_canonical_benchmark_runbook.md`
 - `docs/benchmarks/collections_canonical_benchmark.md`
 - `cmd/unified_bench/README.md`

--- a/docs/README.md
+++ b/docs/README.md
@@ -48,7 +48,7 @@ Behavioral guarantees for downstream systems (e.g., replication layers).
 - **[TreeDB Canonical Benchmark Runbook](benchmarks/treedb_canonical_benchmark_runbook.md)**: Standard TreeDB engine, collections, Mongo gateway, profiling, and reporting workflows.
 - **[YCSB MongoDB / TreeDB Status](benchmarks/ycsb_mongodb_treedb_current.md)**: Current report index and rerun plan for MongoDB, `treedb-native`, and TreeDB Mongo gateway.
 - **[TreeDB Collections Canonical Benchmark](benchmarks/collections_canonical_benchmark.md)**: Canonical TreeDB-vs-SQLite collection benchmark and maintenance-phase semantics.
-- **[Two-Index Collection Insert Rerun](benchmarks/collections_insert_two_index_current_2026-06-02.md)**: Current TreeDB-vs-SQLite two-index insert throughput and compacted storage rows.
+- **[Two-Index Collection Insert Rerun](benchmarks/collections_insert_two_index_latest_main_2026-06-03.md)**: Current TreeDB-vs-SQLite two-index insert throughput and compacted storage rows.
 - **[Unified Bench](../cmd/unified_bench/README.md)**: Usage guide for benchmark execution and artifact capture.
 - **[BenchProf](../cmd/benchprof/README.md)**: Analysis tool for CPU/alloc/block/mutex profiles and ops/sec outputs.
 - **[Redis Protocol Benchmarking](REDIS_PROTOCOL_BENCHMARKING.md)**: Preferred way to measure Redis wrapper throughput.

--- a/docs/benchmarks/collections_insert_two_index_latest_main_2026-06-03.md
+++ b/docs/benchmarks/collections_insert_two_index_latest_main_2026-06-03.md
@@ -1,0 +1,132 @@
+# Two-Index Collection Insert Latest Main Rerun
+
+Date: 2026-06-03 HST / 2026-06-04 UTC
+
+This rerun refreshes the README benchmark claim for the two-index collection
+insert workload on latest `origin/main` after the June 3 optimization stack. It
+uses the canonical collection benchmark entry point with the same high-level
+shape as the June 2 report.
+
+These are developer-machine results. Treat them as current local engineering
+evidence, not a formal product benchmark.
+
+## Command
+
+```sh
+OUT=/tmp/collections_insert_latest_main_$(date +%Y%m%d_%H%M%S)
+GOWORK=off USE_BUILT_BIN=1 ./scripts/bench_collections_canonical.sh \
+  -out-dir "$OUT" \
+  -formats template-v1,json \
+  -indexes 2 \
+  -docs 100000 \
+  -batch-size 16000 \
+  -count 1 \
+  2>&1 | tee "$OUT.stdout.log"
+```
+
+Measured run:
+
+```text
+/tmp/collections_insert_latest_main_20260603_210058
+```
+
+Measured code:
+
+```text
+branch: main
+commit: d7407b81cc5712374ca8c1588cfb05f6f7d8490d
+```
+
+Generated artifacts:
+
+- `/tmp/collections_insert_latest_main_20260603_210058/benchmark_summary.md`
+- `/tmp/collections_insert_latest_main_20260603_210058/benchmark_results.json`
+- `/tmp/collections_insert_latest_main_20260603_210058/benchmark_matrix.csv`
+- `/tmp/collections_insert_latest_main_20260603_210058/timed_matrix/collections_matrix_summary.md`
+
+## Timed Insert Rows
+
+These rows are benchmark-timed post-insert measurements for two secondary
+indexes, `100000` documents, batch size `16000`, and `command_wal_relaxed` for
+TreeDB. The B/doc column in this section is the post-insert footprint after the
+benchmark flush or checkpoint. It is not a compacted-state number.
+
+The canonical runner uses `storage-cells=index-vlog`, which is the TreeDB layout
+that writes data and index outer leaves to the value log.
+
+| engine / format | layout | ns/doc | docs/sec | post-insert B/doc |
+| --- | --- | ---: | ---: | ---: |
+| TreeDB template-v1 | data and index outer leaves in value log | 1,664 | 600,962 | 211.6 |
+| TreeDB JSON | data and index outer leaves in value log | 2,218 | 450,857 | 224.5 |
+| SQLite native columns | WAL normal | 2,904 | 344,353 | 176.1 |
+| SQLite JSON | WAL normal | 3,368 | 296,912 | 262.6 |
+
+## Compacted Storage Rows
+
+These rows use the canonical compacted-state comparison basis: TreeDB compacted
+phases are compared with SQLite after `VACUUM`.
+
+| engine / format | phase | B/doc | comparison basis |
+| --- | --- | ---: | --- |
+| TreeDB template-v1 | `full_leafgen_pack_gc` | 27.8 | full leaf generation pack/GC plus offline index vacuum |
+| TreeDB JSON | `full_leafgen_pack_gc` | 33.7 | full leaf generation pack/GC plus offline index vacuum |
+| TreeDB template-v1 | `offline_compact` | 46.7 | high-level `treemap compact <dir> -rw` |
+| SQLite native columns | `sqlite_vacuum` | 156.7 | SQLite `VACUUM` |
+| SQLite JSON | `sqlite_vacuum` | 231.7 | SQLite `VACUUM` |
+
+Derived comparison ratios from `benchmark_results.json`:
+
+| TreeDB row | vs SQLite native columns after `VACUUM` | vs SQLite JSON after `VACUUM` |
+| --- | ---: | ---: |
+| template-v1 `offline_compact` | 3.4x smaller | 5.0x smaller |
+| template-v1 `full_leafgen_pack_gc` | 5.6x smaller | 8.3x smaller |
+| JSON `full_leafgen_pack_gc` | 4.7x smaller | 6.9x smaller |
+
+## Comparison With June 2 Current Report
+
+Previous checked-in report:
+`docs/benchmarks/collections_insert_two_index_current_2026-06-02.md`.
+
+| engine / format | previous docs/sec | current docs/sec | docs/sec delta | previous compacted B/doc | current compacted B/doc | B/doc delta |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| TreeDB template-v1 | 626,959 | 600,962 | -4.1% | 22.2 | 27.8 | +25.2% |
+| TreeDB JSON | 419,463 | 450,857 | +7.5% | 30.4 | 33.7 | +10.9% |
+| SQLite native columns | 330,797 | 344,353 | +4.1% | 156.7 | 156.7 | +0.0% |
+| SQLite JSON | 302,115 | 296,912 | -1.7% | 231.7 | 231.7 | +0.0% |
+
+The latest-main collection insert rerun is broadly in the same range as the June
+2 evidence. It does not show the same clear improvement that the YCSB server
+workload shows: template-v1 throughput is slightly lower, JSON throughput is
+higher, and compacted TreeDB B/doc is somewhat larger in this run while still
+materially smaller than SQLite after `VACUUM`.
+
+## Additional Layout Probe
+
+A separate current-main layout probe was also run to keep the README context
+honest when comparing TreeDB outer-leaf placement choices:
+
+```text
+/tmp/collections_insert_layout_latest_main_20260603_210000
+```
+
+That probe included both TreeDB layout cells and showed:
+
+| engine / format | layout | ns/doc | docs/sec | post-insert B/doc |
+| --- | --- | ---: | ---: | ---: |
+| TreeDB template-v1 | data outer leaves in value log, index outer leaves in pager | 1,413 | 707,714 | 232.7 |
+| TreeDB template-v1 | data and index outer leaves in value log | 1,455 | 687,285 | 211.6 |
+| TreeDB JSON | data outer leaves in value log, index outer leaves in pager | 1,980 | 505,051 | 243.2 |
+| TreeDB JSON | data and index outer leaves in value log | 2,060 | 485,437 | 224.5 |
+| SQLite JSON | WAL normal | 3,206 | 311,915 | 262.6 |
+| SQLite native columns | WAL normal | 3,376 | 296,209 | 176.1 |
+
+The root README keeps using the canonical run rows for its compact highlight.
+
+## Guardrail Notes
+
+The canonical runner emitted the same non-blocking notes as the June 2 report:
+
+- `phase.online_one_pass.partial`: online one-pass maintenance is partial and
+  should not be described as full compaction.
+- `raw_shape_labeled`: raw TreeDB rows are labeled separately and should not be
+  mixed with collection rows.

--- a/docs/benchmarks/collections_insert_two_index_latest_main_2026-06-03.md
+++ b/docs/benchmarks/collections_insert_two_index_latest_main_2026-06-03.md
@@ -14,6 +14,7 @@ evidence, not a formal product benchmark.
 
 ```sh
 OUT=/tmp/collections_insert_latest_main_$(date +%Y%m%d_%H%M%S)
+mkdir -p "$OUT"
 GOWORK=off USE_BUILT_BIN=1 ./scripts/bench_collections_canonical.sh \
   -out-dir "$OUT" \
   -formats template-v1,json \

--- a/docs/benchmarks/ycsb_latest_main_2026-06-03.md
+++ b/docs/benchmarks/ycsb_latest_main_2026-06-03.md
@@ -1,0 +1,259 @@
+# YCSB MongoDB / TreeDB Latest Main Rerun
+
+Status: current checked-in external `go-ycsb` evidence for MongoDB, TreeDB
+nativewire, and TreeDB Mongo gateway after rerunning the standard YCSB matrix on
+latest `origin/main` merge commit `d7407b81cc5712374ca8c1588cfb05f6f7d8490d`.
+
+This report refreshes `docs/benchmarks/ycsb_post_update_stack_2026-06-02.md` on
+the same developer machine. The commit range since that report includes TreeDB
+leaf-cache, key-compare, batch-merge, scratch, and vector/scoring work; this
+YCSB run measures whether those latest `main` changes also moved the standard
+nativewire and Mongo-gateway YCSB shape.
+
+These are developer-machine results. Treat them as current local engineering
+evidence, not a formal product benchmark.
+
+## Benchmark Boundary
+
+Workload:
+
+- `recordcount=100000`
+- `operationcount=10000`
+- `threadcount=16`
+- load phase: 100,000 inserts
+- run phase: 10,000 operations, approximately 95% reads and 5% updates
+- all clients used local loopback TCP
+- TreeDB Mongo gateway document format: `bson`
+
+Targets:
+
+- MongoDB 8 through the `go-ycsb mongodb` binding
+- `treedb-native` through the `go-ycsb treedb-native` binding
+- TreeDB Mongo gateway through the `go-ycsb mongodb` binding
+
+Profiles:
+
+- `command_wal_durable`
+- `command_wal_relaxed`
+- `bench`, as the explicit no-WAL benchmark-only ceiling
+
+Validity:
+
+- Every parsed YCSB phase had zero `*_ERROR` operation counts.
+- MongoDB was run once in the durable artifact directory with three run repeats.
+- TreeDB profiles were run with three run repeats each.
+- Headline run rows use the median run throughput repeat for that target/profile.
+
+Compatibility note:
+
+- The checked-out `go-ycsb` master at `00a49395a30a4c1b9671200b8f0ec81a59c98546`
+  failed against latest gomap before the run because TreeDB now returns
+  `collection_meta` version 3. The benchmark used a local one-line compatibility
+  patch in the external `go-ycsb` checkout to let the treedb-native decoder
+  accept version 3 metadata. That patch only affects benchmark-client metadata
+  decoding and does not change the measured gomap server binaries. Upstream
+  `go-ycsb` should be updated before the next clean rerun.
+
+## Host Context
+
+Captured on 2026-06-03 HST / 2026-06-04 UTC.
+
+```text
+host: mikers-B560-DS3H-AC-Y1
+kernel: Linux 6.8.0-111-generic x86_64
+go: go version go1.25.0 linux/amd64
+cpu: 11th Gen Intel(R) Core(TM) i5-11400F @ 2.60GHz
+logical CPUs: 12
+memory: 31Gi
+clocksource: tsc
+```
+
+Source versions:
+
+```text
+gomap: d7407b81cc5712374ca8c1588cfb05f6f7d8490d
+gomap branch: main
+go-ycsb: 00a49395a30a4c1b9671200b8f0ec81a59c98546
+go-ycsb branch: master + local collection_meta v3 decoder compatibility patch
+MongoDB image: mongo:8
+MongoDB image id: sha256:690f1371c118a8389ecd6c82c9a7f0e37320732b1d56935a24b29dfca6933f54
+MongoDB image digest: mongo@sha256:7abfba0d07c9330373f8173981ea4d09cd8a82cdf0e86ccaf7008848d1d24f62
+```
+
+Primary artifact root:
+
+```text
+/tmp/treedb_ycsb_current_20260603_205329
+```
+
+Artifact directories:
+
+```text
+/tmp/treedb_ycsb_current_20260603_205329/command_wal_durable
+/tmp/treedb_ycsb_current_20260603_205329/command_wal_relaxed
+/tmp/treedb_ycsb_current_20260603_205329/bench
+/tmp/treedb_ycsb_current_20260603_205329/go-ycsb-local-compat.patch
+```
+
+## Reproduction
+
+The sweep used the checked-in comparison script from this repo plus a temporary
+external `go-ycsb` checkout with this compatibility patch:
+
+```diff
+diff --git a/db/treedbnative/nativewire.go b/db/treedbnative/nativewire.go
+index 93370ae..6d82c66 100644
+--- a/db/treedbnative/nativewire.go
++++ b/db/treedbnative/nativewire.go
+@@ -1584,7 +1584,7 @@ func decodeCollectionMeta(src []byte) (wireCollectionMeta, error) {
+     if err != nil {
+         return wireCollectionMeta{}, err
+     }
+-    if version != 1 && version != 2 {
++    if version != 1 && version != 2 && version != 3 {
+         return wireCollectionMeta{}, wireError(wireErrUnsupportedVersion, "collection_meta version %d", version)
+     }
+     off += n
+```
+
+Commands:
+
+```sh
+cd /home/mikers/dev/snissn/gomap
+
+GOYCSB_DIR=/tmp/go-ycsb_treedb_meta_v3_20260603_205317
+RUN_ROOT=/tmp/treedb_ycsb_current_$(date +%Y%m%d_%H%M%S)
+mkdir -p "$RUN_ROOT"
+
+GOWORK=off GOYCSB_DIR="$GOYCSB_DIR" OUT_DIR="$RUN_ROOT/command_wal_durable" \
+TREEDB_PROFILE=command_wal_durable \
+MONGODB_MODE=docker \
+MONGODB_ADDR=127.0.0.1:27018 \
+NATIVE_ADDR=127.0.0.1:17130 \
+TREEDB_MONGO_ADDR=127.0.0.1:27130 \
+TREEDB_MONGO_DOCUMENT_FORMAT=bson \
+RUN_REPEATS=3 \
+BUILD=true \
+BUILD_GOYCSB=true \
+scripts/ycsb_compare_mongodb_treedb.sh
+
+GOWORK=off GOYCSB_DIR="$GOYCSB_DIR" OUT_DIR="$RUN_ROOT/command_wal_relaxed" \
+TREEDB_PROFILE=command_wal_relaxed \
+MONGODB_MODE=skip \
+NATIVE_ADDR=127.0.0.1:17131 \
+TREEDB_MONGO_ADDR=127.0.0.1:27131 \
+TREEDB_MONGO_DOCUMENT_FORMAT=bson \
+RUN_REPEATS=3 \
+BUILD=false \
+BUILD_GOYCSB=false \
+scripts/ycsb_compare_mongodb_treedb.sh
+
+GOWORK=off GOYCSB_DIR="$GOYCSB_DIR" OUT_DIR="$RUN_ROOT/bench" \
+TREEDB_PROFILE=bench \
+MONGODB_MODE=skip \
+NATIVE_ADDR=127.0.0.1:17132 \
+TREEDB_MONGO_ADDR=127.0.0.1:27132 \
+TREEDB_MONGO_DOCUMENT_FORMAT=bson \
+RUN_REPEATS=3 \
+BUILD=false \
+BUILD_GOYCSB=false \
+scripts/ycsb_compare_mongodb_treedb.sh
+```
+
+`GOWORK=off` was needed in this local checkout because a parent-directory
+`go.work` did not include this gomap clone.
+
+Each artifact directory includes `host.txt`, `commands.txt`, `summary.tsv`,
+`summary.md`, raw YCSB outputs, server logs, and DB directories.
+
+## Headline Results
+
+Run rows use the median total-throughput repeat for each target/profile.
+
+| target | profile | load ops/sec | median run repeat | run ops/sec | run avg us | run p95 us | run p99 us | run max us | errors |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| MongoDB | baseline | 38,755.4 | 2 | 26,494.1 | 595.0 | 984.0 | 1,275.0 | 2,389.0 | 0 |
+| TreeDB nativewire | `command_wal_durable` | 83,217.0 | 1 | 135,318.6 | 113.0 | 203.0 | 367.0 | 1,211.0 | 0 |
+| TreeDB Mongo gateway | `command_wal_durable` | 68,218.2 | 1 | 80,628.4 | 199.0 | 388.0 | 649.0 | 6,623.0 | 0 |
+| TreeDB nativewire | `command_wal_relaxed` | 84,102.6 | 2 | 141,333.5 | 108.0 | 191.0 | 312.0 | 1,429.0 | 0 |
+| TreeDB Mongo gateway | `command_wal_relaxed` | 68,372.2 | 1 | 76,859.7 | 212.0 | 426.0 | 757.0 | 7,751.0 | 0 |
+| TreeDB nativewire | `bench` no-WAL | 92,884.1 | 3 | 141,857.8 | 108.0 | 189.0 | 322.0 | 1,133.0 | 0 |
+| TreeDB Mongo gateway | `bench` no-WAL | 83,561.3 | 1 | 87,343.1 | 175.0 | 352.0 | 534.0 | 1,114.0 | 0 |
+
+## Run Repeats
+
+| target | profile | repeat 1 ops/sec | repeat 2 ops/sec | repeat 3 ops/sec | selected median |
+| --- | --- | ---: | ---: | ---: | ---: |
+| MongoDB | baseline | 26,644.2 | 26,494.1 | 26,358.7 | 26,494.1 |
+| TreeDB nativewire | `command_wal_durable` | 135,318.6 | 130,636.2 | 139,747.1 | 135,318.6 |
+| TreeDB Mongo gateway | `command_wal_durable` | 80,628.4 | 85,137.8 | 80,258.1 | 80,628.4 |
+| TreeDB nativewire | `command_wal_relaxed` | 138,637.9 | 141,333.5 | 141,334.5 | 141,333.5 |
+| TreeDB Mongo gateway | `command_wal_relaxed` | 76,859.7 | 86,600.2 | 73,369.3 | 76,859.7 |
+| TreeDB nativewire | `bench` no-WAL | 145,263.2 | 137,604.7 | 141,857.8 | 141,857.8 |
+| TreeDB Mongo gateway | `bench` no-WAL | 87,343.1 | 89,017.3 | 86,660.5 | 87,343.1 |
+
+The Mongo gateway `command_wal_relaxed` repeats are noisier than the durable and
+bench cells, and both gateway command-WAL cells include one max-latency outlier
+above 6 ms. The median throughput still remains above the June 2 rows.
+
+## Selected Run Detail
+
+The rows below show the operation mix for each selected median repeat.
+
+| target | profile | op | count | ops/sec | avg us | p50 us | p95 us | p99 us | max us |
+| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| MongoDB | baseline | READ | 9,493 | 25,149.3 | 603.0 | 572.0 | 991.0 | 1,283.0 | 2,389.0 |
+| MongoDB | baseline | UPDATE | 507 | 1,349.7 | 440.0 | 410.0 | 805.0 | 1,055.0 | 1,367.0 |
+| MongoDB | baseline | TOTAL | 10,000 | 26,494.1 | 595.0 | 564.0 | 984.0 | 1,275.0 | 2,389.0 |
+| TreeDB nativewire | `command_wal_durable` | READ | 9,472 | 128,220.5 | 109.0 | 103.0 | 188.0 | 337.0 | 748.0 |
+| TreeDB nativewire | `command_wal_durable` | UPDATE | 528 | 7,230.1 | 186.0 | 151.0 | 393.0 | 886.0 | 1,211.0 |
+| TreeDB nativewire | `command_wal_durable` | TOTAL | 10,000 | 135,318.6 | 113.0 | 105.0 | 203.0 | 367.0 | 1,211.0 |
+| TreeDB Mongo gateway | `command_wal_durable` | READ | 9,481 | 76,317.7 | 195.0 | 155.0 | 371.0 | 633.0 | 6,623.0 |
+| TreeDB Mongo gateway | `command_wal_durable` | UPDATE | 519 | 4,208.9 | 282.0 | 242.0 | 559.0 | 783.0 | 2,805.0 |
+| TreeDB Mongo gateway | `command_wal_durable` | TOTAL | 10,000 | 80,628.4 | 199.0 | 158.0 | 388.0 | 649.0 | 6,623.0 |
+| TreeDB nativewire | `command_wal_relaxed` | READ | 9,515 | 134,501.6 | 104.0 | 99.0 | 176.0 | 298.0 | 741.0 |
+| TreeDB nativewire | `command_wal_relaxed` | UPDATE | 485 | 6,922.4 | 179.0 | 141.0 | 340.0 | 832.0 | 1,429.0 |
+| TreeDB nativewire | `command_wal_relaxed` | TOTAL | 10,000 | 141,333.5 | 108.0 | 101.0 | 191.0 | 312.0 | 1,429.0 |
+| TreeDB Mongo gateway | `command_wal_relaxed` | READ | 9,502 | 73,061.5 | 206.0 | 164.0 | 410.0 | 718.0 | 7,295.0 |
+| TreeDB Mongo gateway | `command_wal_relaxed` | UPDATE | 498 | 3,843.3 | 321.0 | 252.0 | 579.0 | 1,093.0 | 7,751.0 |
+| TreeDB Mongo gateway | `command_wal_relaxed` | TOTAL | 10,000 | 76,859.7 | 212.0 | 167.0 | 426.0 | 757.0 | 7,751.0 |
+| TreeDB nativewire | `bench` no-WAL | READ | 9,541 | 135,220.6 | 105.0 | 99.0 | 184.0 | 303.0 | 707.0 |
+| TreeDB nativewire | `bench` no-WAL | UPDATE | 459 | 6,617.0 | 160.0 | 126.0 | 291.0 | 905.0 | 1,133.0 |
+| TreeDB nativewire | `bench` no-WAL | TOTAL | 10,000 | 141,857.8 | 108.0 | 101.0 | 189.0 | 322.0 | 1,133.0 |
+| TreeDB Mongo gateway | `bench` no-WAL | READ | 9,474 | 82,702.7 | 174.0 | 153.0 | 350.0 | 530.0 | 1,114.0 |
+| TreeDB Mongo gateway | `bench` no-WAL | UPDATE | 526 | 4,642.2 | 194.0 | 176.0 | 395.0 | 586.0 | 806.0 |
+| TreeDB Mongo gateway | `bench` no-WAL | TOTAL | 10,000 | 87,343.1 | 175.0 | 154.0 | 352.0 | 534.0 | 1,114.0 |
+
+## Comparison With June 2 Current Report
+
+Previous checked-in report:
+`docs/benchmarks/ycsb_post_update_stack_2026-06-02.md`.
+
+| target | profile | previous load | current load | load delta | previous run | current run | run delta |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| MongoDB | baseline | 33,255.6 | 38,755.4 | +16.5% | 26,102.5 | 26,494.1 | +1.5% |
+| TreeDB nativewire | `command_wal_durable` | 77,065.3 | 83,217.0 | +8.0% | 120,500.7 | 135,318.6 | +12.3% |
+| TreeDB Mongo gateway | `command_wal_durable` | 57,370.1 | 68,218.2 | +18.9% | 74,544.7 | 80,628.4 | +8.2% |
+| TreeDB nativewire | `command_wal_relaxed` | 76,411.7 | 84,102.6 | +10.1% | 126,762.5 | 141,333.5 | +11.5% |
+| TreeDB Mongo gateway | `command_wal_relaxed` | 62,444.0 | 68,372.2 | +9.5% | 75,371.9 | 76,859.7 | +2.0% |
+| TreeDB nativewire | `bench` no-WAL | 85,201.7 | 92,884.1 | +9.0% | 134,415.5 | 141,857.8 | +5.5% |
+| TreeDB Mongo gateway | `bench` no-WAL | 75,033.3 | 83,561.3 | +11.4% | 79,357.6 | 87,343.1 | +10.1% |
+
+## Summary
+
+The latest `origin/main` rerun is materially faster in the nativewire run phase:
+`command_wal_durable` rose from about 120.5k OPS to 135.3k OPS (+12.3%), and
+`command_wal_relaxed` rose from about 126.8k OPS to 141.3k OPS (+11.5%). The
+no-WAL `bench` nativewire ceiling improved more modestly, from 134.4k OPS to
+141.9k OPS (+5.5%).
+
+TreeDB Mongo gateway also improved in this rerun, but less uniformly: durable
+run throughput rose about 8.2%, relaxed was effectively near the old range at
++2.0%, and no-WAL `bench` rose about 10.1%. The MongoDB run baseline was nearly
+flat (+1.5%), while MongoDB load throughput moved enough (+16.5%) to treat load
+rows as more host/noise-sensitive than run rows.
+
+Net: the latest main changes do appear to move the standard YCSB numbers on this
+hardware, especially for TreeDB nativewire command-WAL runs. The remaining
+Mongo-gateway command-WAL shape still shows gateway/request overhead and some
+repeat-to-repeat tail noise.

--- a/docs/benchmarks/ycsb_mongodb_treedb_current.md
+++ b/docs/benchmarks/ycsb_mongodb_treedb_current.md
@@ -11,7 +11,7 @@ which cells should be rerun next.
 
 ## Current Canonical Report
 
-Use `docs/benchmarks/ycsb_post_update_stack_2026-06-02.md` as the current
+Use `docs/benchmarks/ycsb_latest_main_2026-06-03.md` as the current
 checked-in external YCSB evidence for MongoDB, TreeDB nativewire, and TreeDB
 Mongo gateway.
 
@@ -21,33 +21,36 @@ That report covers the intended public TreeDB profile surface:
 - `command_wal_relaxed`
 - `bench`, as the explicit no-WAL benchmark-only ceiling
 
-It also records zero YCSB operation errors, uses three run repeats per target
-or profile, and refreshes the earlier pre-update-stack numbers after the
-nativewire BSON `$set` update path and collection update-path optimizations
-landed.
+It records zero YCSB operation errors, uses three run repeats per target or
+profile, and refreshes the June 2 post-update-path-stack numbers on latest
+`origin/main` commit `d7407b81cc5712374ca8c1588cfb05f6f7d8490d`. Note that
+this rerun used a temporary external `go-ycsb` compatibility patch so the
+`treedb-native` binding accepts TreeDB `collection_meta` version 3.
 
 ## Current Headline
 
-Run rows use the median total-throughput repeat from the June 2 report.
+Run rows use the median total-throughput repeat from the June 3 HST / June 4
+UTC latest-main report.
 
 | target | profile | load ops/sec | run ops/sec | run avg us | run p99 us | run max us | errors |
 | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
-| MongoDB | baseline | 33,255.6 | 26,102.5 | 601.0 | 1,461.0 | 3,401.0 | 0 |
-| TreeDB nativewire | `command_wal_durable` | 77,065.3 | 120,500.7 | 128.0 | 477.0 | 1,475.0 | 0 |
-| TreeDB Mongo gateway | `command_wal_durable` | 57,370.1 | 74,544.7 | 206.0 | 649.0 | 1,331.0 | 0 |
-| TreeDB nativewire | `command_wal_relaxed` | 76,411.7 | 126,762.5 | 121.0 | 374.0 | 1,687.0 | 0 |
-| TreeDB Mongo gateway | `command_wal_relaxed` | 62,444.0 | 75,371.9 | 203.0 | 629.0 | 1,674.0 | 0 |
-| TreeDB nativewire | `bench` no-WAL | 85,201.7 | 134,415.5 | 114.0 | 365.0 | 969.0 | 0 |
-| TreeDB Mongo gateway | `bench` no-WAL | 75,033.3 | 79,357.6 | 192.0 | 729.0 | 3,035.0 | 0 |
+| MongoDB | baseline | 38,755.4 | 26,494.1 | 595.0 | 1,275.0 | 2,389.0 | 0 |
+| TreeDB nativewire | `command_wal_durable` | 83,217.0 | 135,318.6 | 113.0 | 367.0 | 1,211.0 | 0 |
+| TreeDB Mongo gateway | `command_wal_durable` | 68,218.2 | 80,628.4 | 199.0 | 649.0 | 6,623.0 | 0 |
+| TreeDB nativewire | `command_wal_relaxed` | 84,102.6 | 141,333.5 | 108.0 | 312.0 | 1,429.0 | 0 |
+| TreeDB Mongo gateway | `command_wal_relaxed` | 68,372.2 | 76,859.7 | 212.0 | 757.0 | 7,751.0 | 0 |
+| TreeDB nativewire | `bench` no-WAL | 92,884.1 | 141,857.8 | 108.0 | 322.0 | 1,133.0 | 0 |
+| TreeDB Mongo gateway | `bench` no-WAL | 83,561.3 | 87,343.1 | 175.0 | 534.0 | 1,114.0 | 0 |
 
 ## Report Inventory
 
 | report | status | use |
 | --- | --- | --- |
-| `docs/benchmarks/ycsb_post_update_stack_2026-06-02.md` | Current external YCSB report. | Use for current headline MongoDB / TreeDB nativewire / TreeDB Mongo gateway results after the June 2 update-path stack. |
+| `docs/benchmarks/ycsb_latest_main_2026-06-03.md` | Current external YCSB report. | Use for current headline MongoDB / TreeDB nativewire / TreeDB Mongo gateway results on latest `origin/main` after the June 3 rerun. |
+| `docs/benchmarks/ycsb_post_update_stack_2026-06-02.md` | Superseded latest-current report. | Keep for post-update-path-stack evidence before the latest main rerun and for comparison deltas. |
 | `docs/benchmarks/ycsb_mongodb_treedb_2026-05-31.md` | Historical legacy-profile report. | Keep for the original MongoDB / TreeDB native / TreeDB Mongo comparison and the post-load Mongo-gateway cliff attribution. Do not use its `fast` rows as current public-profile guidance. |
-| `docs/benchmarks/ycsb_treedb_profile_sweep_2026-06-01.md` | Superseded initial command-WAL sweep. | Keep as prior-run evidence. Prefer the June 2 report for current performance and the closeout report only for profile-surface conclusions. |
-| `docs/benchmarks/ycsb_profile_closeout_2026-06-01.md` | Superseded profile-surface closeout. | Keep for profile-surface closeout evidence. Do not use as current headline performance after the June 2 update-path stack. |
+| `docs/benchmarks/ycsb_treedb_profile_sweep_2026-06-01.md` | Superseded initial command-WAL sweep. | Keep as prior-run evidence. Prefer the current report for headline performance and the closeout report only for profile-surface conclusions. |
+| `docs/benchmarks/ycsb_profile_closeout_2026-06-01.md` | Superseded profile-surface closeout. | Keep for profile-surface closeout evidence. Do not use as current headline performance after the latest main rerun. |
 | `docs/benchmarks/mongo_gateway_compare_2026-04-29/` | Historical non-YCSB Mongo-gateway microbenchmark. | Useful for gateway-specific attribution, but not a substitute for external YCSB comparisons. |
 
 ## Standard Benchmark Boundary
@@ -75,6 +78,12 @@ The harness writes host metadata, exact commands, raw `go-ycsb` output,
 Any nonzero YCSB operation error counter such as `INSERT_ERROR`, `READ_ERROR`,
 or `UPDATE_ERROR` invalidates that phase unless the report explicitly marks it
 as exploratory known-bad evidence.
+
+As of gomap `d7407b81cc5712374ca8c1588cfb05f6f7d8490d`, the external
+`go-ycsb` `treedb-native` binding must understand `collection_meta` version 3.
+If upstream `go-ycsb` has not yet been updated, apply the one-line compatibility
+patch recorded in `docs/benchmarks/ycsb_latest_main_2026-06-03.md` before
+rerunning the nativewire cells.
 
 ## Standard Full Rerun Matrix
 


### PR DESCRIPTION
## Summary

- Refresh the root README benchmark highlights with latest `origin/main` YCSB data.
- Add a latest-main YCSB report with commands, artifacts, host context, median repeat rows, and June 2 deltas.
- Add a latest-main two-index collection insert report and update docs index/current YCSB pointers.

## Scope / non-goals

- Docs-only benchmark evidence refresh.
- No engine or benchmark-harness code changes.
- Did not rerun the large `application.db` density workload; the README keeps the existing June 2 density row.

## Benchmarks rerun

### YCSB server workload

Command shape: `scripts/ycsb_compare_mongodb_treedb.sh`, `recordcount=100000`, `operationcount=10000`, `threadcount=16`, `RUN_REPEATS=3`, BSON document format.

Artifacts: `/tmp/treedb_ycsb_current_20260603_205329`

| target | profile | previous run ops/sec | latest-main run ops/sec | delta |
| --- | --- | ---: | ---: | ---: |
| MongoDB | baseline | 26,102.5 | 26,494.1 | +1.5% |
| TreeDB nativewire | `command_wal_durable` | 120,500.7 | 135,318.6 | +12.3% |
| TreeDB nativewire | `command_wal_relaxed` | 126,762.5 | 141,333.5 | +11.5% |
| TreeDB nativewire | `bench` no-WAL | 134,415.5 | 141,857.8 | +5.5% |
| TreeDB Mongo gateway | `command_wal_durable` | 74,544.7 | 80,628.4 | +8.2% |
| TreeDB Mongo gateway | `command_wal_relaxed` | 75,371.9 | 76,859.7 | +2.0% |
| TreeDB Mongo gateway | `bench` no-WAL | 79,357.6 | 87,343.1 | +10.1% |

All parsed YCSB phases had zero `*_ERROR` counts.

Note: current external `go-ycsb` needed a temporary one-line client compatibility patch to accept TreeDB `collection_meta` version 3; the patch is documented in the new report.

### Two-index collection insert workload

Command shape: `scripts/bench_collections_canonical.sh`, `docs=100000`, `batch-size=16000`, `indexes=2`, `count=1`, TreeDB `command_wal_relaxed`.

Artifacts: `/tmp/collections_insert_latest_main_20260603_210058`

| engine / format | previous docs/sec | latest-main docs/sec | previous compacted B/doc | latest-main compacted B/doc |
| --- | ---: | ---: | ---: | ---: |
| TreeDB template-v1 | 626,959 | 600,962 | 22.2 | 27.8 |
| TreeDB JSON | 419,463 | 450,857 | 30.4 | 33.7 |
| SQLite native columns | 330,797 | 344,353 | 156.7 | 156.7 |
| SQLite JSON | 302,115 | 296,912 | 231.7 | 231.7 |

A separate current-main layout probe was also captured at `/tmp/collections_insert_layout_latest_main_20260603_210000` and documented in the collection report.

## Tests / validation

- `python3` docs link smoke for the new benchmark report paths
- `GOWORK=off go test ./cmd/collection_bench_matrix_summary ./cmd/collection_canonical_bench`
- `git diff --cached --check`

## AI review status

- Codex: requested after PR creation.
- Copilot: requested after PR creation.
- CodeRabbit: requested after PR creation.
