### PR TITLE
TreeDB: add production USearch vector comparison

### DIFF
--- a/TreeDB/README.md
+++ b/TreeDB/README.md
@@ -191,13 +191,26 @@ External comparison benchmark with local USearch bootstrap:
 scripts/bench_vector_search_compare.sh
 ```
 
-The script downloads and extracts the USearch Linux release package into `/tmp`,
-sets `CGO_CFLAGS`, `CGO_LDFLAGS`, and `LD_LIBRARY_PATH`, and writes results under
-`/tmp/gomap_vector_search_compare_*`. Override `USEARCH_VERSION`,
-`TREEDB_VECTOR_BENCH_DOCS`, `TREEDB_VECTOR_BENCH_DIMS`, `BENCHTIME`, and `COUNT`
-to change the comparison shape. The USearch filtered Go binding currently trips
-Go's cgo pointer checks on this toolchain; set `RUN_UNSAFE_USEARCH_FILTERED=true`
-only when you explicitly want that benchmark with `GODEBUG=cgocheck=0`.
+The script downloads and extracts a USearch Linux or macOS release package into
+`/tmp` when `USEARCH_ROOT` is not set, configures cgo include/library paths, and
+writes results under `/tmp/gomap_vector_search_compare_*`. The canonical current
+production rows are
+`BenchmarkCollectionVectorUSearchProductionCompare/TreeDB_SearchWithBuffer*`
+versus `.../USearch_Search*`: TreeDB uses persisted `column_graph` through
+`Collection.OpenVectorIndexSearcher` plus `VectorIndexSearcher.SearchWithBuffer`
+with one searcher and one reusable buffer per worker, while USearch is a pure
+in-memory cosine/f32 HNSW baseline. Use `CPU_LIST=1,8` for c=1/c=8 evidence.
+Older `BenchmarkCollectionVectorIndex*` rows are historical controls, not the
+current high-QPS production fast path; one-shot `Collection.SearchVectorIndex`
+benchmarks include setup/open cost and should not be presented as that fast path.
+Override `USEARCH_VERSION`, `USEARCH_ROOT`, `TREEDB_VECTOR_BENCH_DOCS`,
+`TREEDB_VECTOR_BENCH_DIMS`, `TREEDB_VECTOR_BENCH_M`,
+`TREEDB_VECTOR_BENCH_EF_CONSTRUCTION`, `TREEDB_VECTOR_BENCH_EF_SEARCH`,
+`TREEDB_VECTOR_BENCH_TOPK`, `TREEDB_VECTOR_BENCH_QUERIES`, `BENCHTIME`, `COUNT`,
+and `CPU_LIST` to change the comparison shape. The USearch filtered Go binding
+currently trips Go's cgo pointer checks on this toolchain; set
+`RUN_UNSAFE_USEARCH_FILTERED=true` only when you explicitly want that benchmark
+with `GODEBUG=cgocheck=0`.
 
 The tiny BERT embedding demo in `../examples/vector_search/tiny_bert/` is a
 caller-side fixture/demo; TreeDB core does not generate embeddings. Export it
@@ -205,18 +218,23 @@ with `--output-jsonl` and set `TREEDB_VECTOR_BENCH_JSONL` to run
 `BenchmarkCollectionVectorTinyBERTFixture`.
 
 Optional external engine baseline: build with `-tags usearch_bench` after
-installing the USearch C library and headers for the host. This runs the same
-synthetic vectors against USearch's Go bindings with cosine/f32 HNSW and matching
-`M`, `efConstruction`, and `efSearch` knobs:
+installing the USearch C library and headers for the host. The current comparison
+benchmark runs the same deterministic synthetic vector/query generator through
+TreeDB's persisted `column_graph` reusable-buffer path and through USearch's Go
+bindings with cosine/f32 HNSW and matching `M`, `efConstruction`, `efSearch`,
+`topK`, docs, dims, and `-cpu`/concurrency knobs:
 
 The Go binding is intentionally kept as an indirect module dependency because it
 is only imported by the optional `usearch_bench` build tag.
 
 ```sh
-TREEDB_VECTOR_BENCH_DOCS=1000 TREEDB_VECTOR_BENCH_DIMS=32 \
-  go test -tags usearch_bench ./TreeDB/collections -run '^$' \
-  -bench 'BenchmarkCollectionVector(USearch|SearchExact|Index(Search|SearchInt8|FilteredSearch))' \
-  -benchtime=1x -count=1
+for cpu in 1 8; do
+  TREEDB_VECTOR_BENCH_DOCS=10000 TREEDB_VECTOR_BENCH_DIMS=64 \
+    TREEDB_VECTOR_BENCH_EF_SEARCH=128 \
+    go test -tags usearch_bench ./TreeDB/collections -run '^$' \
+    -bench '^BenchmarkCollectionVectorUSearchProductionCompare$' \
+    -benchmem -benchtime=1x -count=1 -cpu="$cpu"
+done
 ```
 
 ## Durability & Safety Notes

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -453,6 +453,7 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/vector_index.go", classification: typedStorageLegacyDerived, matchingLines: 1, occurrences: 1},
 	{path: "TreeDB/collections/column_vector_graph_quantized_asset.go", classification: typedStorageLegacyDerived, matchingLines: 26, occurrences: 30},
 	{path: "TreeDB/collections/vector_index_metadata_test.go", classification: typedStorageLegacyDerived, matchingLines: 9, occurrences: 11},
+	{path: "TreeDB/collections/vector_usearch_bench_test.go", classification: typedStorageLegacyDerived, matchingLines: 1, occurrences: 2},
 	{path: "TreeDB/collections/vector_document_fetch_preset_1903_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 4, occurrences: 5},
 	{path: "TreeDB/collections/vector_index_retained_payload_policy_1876_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 5, occurrences: 5},
 	{path: "TreeDB/collections/vector_index_search_test.go", classification: typedStorageLegacyDerived, matchingLines: 4, occurrences: 6},

--- a/TreeDB/collections/vector_usearch_bench_test.go
+++ b/TreeDB/collections/vector_usearch_bench_test.go
@@ -151,7 +151,7 @@ func BenchmarkCollectionVectorUSearchProductionCompare(b *testing.B) {
 			if err != nil {
 				b.Fatalf("OpenVectorIndexSearcher worker %d: %v", i, err)
 			}
-			defer func() { _ = searcher.Close() }()
+			defer func(searcher *VectorIndexSearcher) { _ = searcher.Close() }(searcher)
 			benchWorkers[i].searcher = searcher
 			opts.Query = queries[i%len(queries)]
 			warm, err := searcher.SearchWithBuffer(opts, &benchWorkers[i].buffer)

--- a/TreeDB/collections/vector_usearch_bench_test.go
+++ b/TreeDB/collections/vector_usearch_bench_test.go
@@ -3,10 +3,14 @@
 package collections
 
 import (
+	"encoding/json"
+	"fmt"
 	"os"
 	"runtime"
+	"sync/atomic"
 	"testing"
 
+	backenddb "github.com/snissn/gomap/TreeDB/db"
 	usearch "github.com/unum-cloud/usearch/golang"
 )
 
@@ -65,6 +69,255 @@ func BenchmarkCollectionVectorUSearchIncrementalWrite(b *testing.B) {
 			b.Fatalf("destroy usearch index: %v", err)
 		}
 	}
+}
+
+func BenchmarkCollectionVectorUSearchProductionCompare(b *testing.B) {
+	docs := vectorBenchmarkDocs(b)
+	dims := vectorBenchmarkDims(b)
+	params := vectorUSearchProductionCompareParamsFromEnv(b, docs)
+	queries, queryDocIndexes := vectorUSearchProductionQueries(docs, dims, params.queries)
+
+	d, col, def, status := openVectorUSearchProductionTreeDBCollection(b, docs, dims, params)
+	defer func() { _ = d.Close() }()
+	index := openVectorUSearchBenchmarkIndex(b, docs, dims, params.m, params.efConstruction, params.efSearch)
+	defer func() {
+		if err := index.Destroy(); err != nil {
+			b.Fatalf("destroy usearch index: %v", err)
+		}
+	}()
+	memory, _ := index.MemoryUsage()
+
+	b.Run("TreeDB_SearchWithBuffer", func(b *testing.B) {
+		searcher, err := col.OpenVectorIndexSearcher(VectorIndexSearcherOptions{IndexName: def.Name, MaxDecodedBlocks: 1})
+		if err != nil {
+			b.Fatalf("OpenVectorIndexSearcher: %v", err)
+		}
+		defer func() { _ = searcher.Close() }()
+		timedOpts := VectorIndexSearcherSearchOptions{Query: queries[0], TopK: params.topK, EfSearch: params.efSearch, StatsMode: VectorIndexSearchStatsModeProduction}
+		var buffer VectorIndexSearchBuffer
+		warm, err := searcher.SearchWithBuffer(timedOpts, &buffer)
+		if err != nil {
+			b.Fatalf("warm SearchWithBuffer: %v", err)
+		}
+		if len(warm.Results) == 0 {
+			b.Fatal("warm SearchWithBuffer returned no results")
+		}
+		top1Got, top1Want := string(warm.Results[0].ID), vectorUSearchProductionDocID(queryDocIndexes[0])
+		statsOpts := timedOpts
+		statsOpts.StatsMode = VectorIndexSearchStatsModeFullDiagnostics
+		measured, err := searcher.SearchWithBuffer(statsOpts, &buffer)
+		if err != nil {
+			b.Fatalf("measure SearchWithBuffer stats: %v", err)
+		}
+		stats := measured.Stats
+		if stats.TypedColumnFallbacks != 0 || stats.VectorMmapDirectViews+stats.VectorHeapCopyTypedViews+stats.VectorScratchDecodes == 0 {
+			b.Fatalf("TreeDB production comparison stats=%+v want active typed-column vector source counters", stats)
+		}
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			timedOpts.Query = queries[i%len(queries)]
+			got, err := searcher.SearchWithBuffer(timedOpts, &buffer)
+			if err != nil {
+				b.Fatalf("SearchWithBuffer: %v", err)
+			}
+			if len(got.Results) == 0 {
+				b.Fatal("SearchWithBuffer returned no results")
+			}
+			vectorSearchBenchSinkOrdinalV4 += got.Results[0].Ordinal
+		}
+		b.StopTimer()
+		reportVectorUSearchProductionTop1Metric(b, top1Got, top1Want)
+		reportVectorUSearchProductionCommonMetrics(b, docs, dims, params, len(queries))
+		reportVectorUSearchProductionTreeDBFootprintMetrics(b, status)
+		reportVectorIndexSearchStatsModeBenchMetric2126(b, params.statsMode())
+		b.ReportMetric(1, "reported_stats_mode_full_diagnostics")
+		reportVectorIndexSearchBenchMetricsV4(b, b.N, stats, false)
+	})
+
+	b.Run("TreeDB_SearchWithBufferParallel", func(b *testing.B) {
+		workers := runtime.GOMAXPROCS(0)
+		if workers < 1 {
+			workers = 1
+		}
+		type preparedWorker struct {
+			searcher *VectorIndexSearcher
+			buffer   VectorIndexSearchBuffer
+		}
+		benchWorkers := make([]preparedWorker, workers)
+		opts := VectorIndexSearcherSearchOptions{TopK: params.topK, EfSearch: params.efSearch, StatsMode: VectorIndexSearchStatsModeProduction}
+		for i := range benchWorkers {
+			searcher, err := col.OpenVectorIndexSearcher(VectorIndexSearcherOptions{IndexName: def.Name, MaxDecodedBlocks: 1})
+			if err != nil {
+				b.Fatalf("OpenVectorIndexSearcher worker %d: %v", i, err)
+			}
+			defer func() { _ = searcher.Close() }()
+			benchWorkers[i].searcher = searcher
+			opts.Query = queries[i%len(queries)]
+			warm, err := searcher.SearchWithBuffer(opts, &benchWorkers[i].buffer)
+			if err != nil {
+				b.Fatalf("warm SearchWithBuffer worker %d: %v", i, err)
+			}
+			if len(warm.Results) == 0 {
+				b.Fatalf("warm SearchWithBuffer worker %d returned no results", i)
+			}
+		}
+		opts.Query = queries[0]
+		statsOpts := opts
+		statsOpts.StatsMode = VectorIndexSearchStatsModeFullDiagnostics
+		measured, err := benchWorkers[0].searcher.SearchWithBuffer(statsOpts, &benchWorkers[0].buffer)
+		if err != nil {
+			b.Fatalf("measure SearchWithBuffer stats: %v", err)
+		}
+		stats := measured.Stats
+		if stats.TypedColumnFallbacks != 0 || stats.VectorMmapDirectViews+stats.VectorHeapCopyTypedViews+stats.VectorScratchDecodes == 0 {
+			b.Fatalf("TreeDB production parallel comparison stats=%+v want active typed-column vector source counters", stats)
+		}
+		top1Got, top1Want := string(measured.Results[0].ID), vectorUSearchProductionDocID(queryDocIndexes[0])
+		var nextWorker atomic.Uint64
+		var sink atomic.Int64
+		var firstErr atomic.Value
+		var failed atomic.Bool
+		recordParallelErr := func(format string, args ...any) {
+			if failed.CompareAndSwap(false, true) {
+				firstErr.Store(fmt.Sprintf(format, args...))
+			}
+		}
+		b.SetParallelism(1)
+		b.ReportAllocs()
+		b.ResetTimer()
+		b.RunParallel(func(pb *testing.PB) {
+			workerIndex := int(nextWorker.Add(1)) - 1
+			if workerIndex < 0 || workerIndex >= len(benchWorkers) {
+				recordParallelErr("parallel worker requested more than %d prepared searchers", workers)
+				for pb.Next() {
+				}
+				return
+			}
+			worker := &benchWorkers[workerIndex]
+			localOpts := opts
+			localSink := int64(0)
+			queryIndex := workerIndex
+			for pb.Next() {
+				if failed.Load() {
+					continue
+				}
+				localOpts.Query = queries[queryIndex%len(queries)]
+				queryIndex++
+				got, err := worker.searcher.SearchWithBuffer(localOpts, &worker.buffer)
+				if err != nil {
+					recordParallelErr("SearchWithBuffer: %v", err)
+					continue
+				}
+				if len(got.Results) == 0 {
+					recordParallelErr("SearchWithBuffer returned no results")
+					continue
+				}
+				localSink += int64(got.Results[0].Ordinal)
+			}
+			sink.Add(localSink)
+		})
+		b.StopTimer()
+		reportVectorUSearchProductionTop1Metric(b, top1Got, top1Want)
+		reportVectorUSearchProductionCommonMetrics(b, docs, dims, params, len(queries))
+		reportVectorUSearchProductionTreeDBFootprintMetrics(b, status)
+		reportVectorIndexSearchStatsModeBenchMetric2126(b, params.statsMode())
+		b.ReportMetric(1, "reported_stats_mode_full_diagnostics")
+		b.ReportMetric(float64(workers), "parallel_workers")
+		reportColumnVectorGraphSharedPreparedSearchBenchMetrics1735(b, col.columnVectorGraphSharedPreparedSearchCacheSnapshot(), workers)
+		if errValue := firstErr.Load(); errValue != nil {
+			b.Fatalf("%s", errValue.(string))
+		}
+		vectorSearchBenchSinkOrdinalV4 += int(sink.Load())
+		reportVectorIndexSearchBenchMetricsV4(b, b.N, stats, false)
+	})
+
+	b.Run("USearch_Search", func(b *testing.B) {
+		keys, _, err := index.Search(queries[0], uint(params.topK))
+		if err != nil {
+			b.Fatalf("warm usearch search: %v", err)
+		}
+		if len(keys) == 0 {
+			b.Fatal("warm usearch search returned no results")
+		}
+		top1Got, top1Want := fmt.Sprintf("%d", keys[0]), fmt.Sprintf("%d", queryDocIndexes[0])
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			keys, _, err := index.Search(queries[i%len(queries)], uint(params.topK))
+			if err != nil {
+				b.Fatalf("usearch search: %v", err)
+			}
+			if len(keys) == 0 {
+				b.Fatal("usearch search returned no results")
+			}
+			vectorSearchBenchSinkOrdinalV4 += int(keys[0])
+		}
+		b.StopTimer()
+		reportVectorUSearchProductionTop1Metric(b, top1Got, top1Want)
+		reportVectorUSearchProductionCommonMetrics(b, docs, dims, params, len(queries))
+		b.ReportMetric(float64(memory), "index_bytes")
+		reportVectorUSearchOpsMetric(b, b.N)
+	})
+
+	b.Run("USearch_SearchParallel", func(b *testing.B) {
+		workers := runtime.GOMAXPROCS(0)
+		if workers < 1 {
+			workers = 1
+		}
+		keys, _, err := index.Search(queries[0], uint(params.topK))
+		if err != nil {
+			b.Fatalf("warm parallel usearch search: %v", err)
+		}
+		if len(keys) == 0 {
+			b.Fatal("warm parallel usearch search returned no results")
+		}
+		top1Got, top1Want := fmt.Sprintf("%d", keys[0]), fmt.Sprintf("%d", queryDocIndexes[0])
+		var nextWorker atomic.Uint64
+		var sink atomic.Int64
+		var firstErr atomic.Value
+		var failed atomic.Bool
+		recordParallelErr := func(format string, args ...any) {
+			if failed.CompareAndSwap(false, true) {
+				firstErr.Store(fmt.Sprintf(format, args...))
+			}
+		}
+		b.SetParallelism(1)
+		b.ReportAllocs()
+		b.ResetTimer()
+		b.RunParallel(func(pb *testing.PB) {
+			workerIndex := int(nextWorker.Add(1)) - 1
+			queryIndex := workerIndex
+			localSink := int64(0)
+			for pb.Next() {
+				if failed.Load() {
+					continue
+				}
+				keys, _, err := index.Search(queries[queryIndex%len(queries)], uint(params.topK))
+				queryIndex++
+				if err != nil {
+					recordParallelErr("usearch search: %v", err)
+					continue
+				}
+				if len(keys) == 0 {
+					recordParallelErr("usearch search returned no results")
+					continue
+				}
+				localSink += int64(keys[0])
+			}
+			sink.Add(localSink)
+		})
+		b.StopTimer()
+		reportVectorUSearchProductionTop1Metric(b, top1Got, top1Want)
+		reportVectorUSearchProductionCommonMetrics(b, docs, dims, params, len(queries))
+		b.ReportMetric(float64(memory), "index_bytes")
+		b.ReportMetric(float64(workers), "parallel_workers")
+		if errValue := firstErr.Load(); errValue != nil {
+			b.Fatalf("%s", errValue.(string))
+		}
+		vectorSearchBenchSinkOrdinalV4 += int(sink.Load())
+		reportVectorUSearchOpsMetric(b, b.N)
+	})
 }
 
 func BenchmarkCollectionVectorUSearchBaseline(b *testing.B) {
@@ -184,6 +437,190 @@ func BenchmarkCollectionVectorTinyBERTUSearchBaseline(b *testing.B) {
 		if len(keys) == 0 {
 			b.Fatal("tiny BERT usearch search returned no results")
 		}
+	}
+}
+
+type vectorUSearchProductionCompareParams struct {
+	m              int
+	efConstruction int
+	efSearch       int
+	topK           int
+	queries        int
+}
+
+func (p vectorUSearchProductionCompareParams) statsMode() VectorIndexSearchStatsMode {
+	return VectorIndexSearchStatsModeProduction
+}
+
+func vectorUSearchProductionCompareParamsFromEnv(tb testing.TB, docs int) vectorUSearchProductionCompareParams {
+	tb.Helper()
+	params := vectorUSearchProductionCompareParams{
+		m:              vectorBenchmarkPositiveEnvInt(tb, "TREEDB_VECTOR_BENCH_M", 16),
+		efConstruction: vectorBenchmarkPositiveEnvInt(tb, "TREEDB_VECTOR_BENCH_EF_CONSTRUCTION", 128),
+		efSearch:       vectorBenchmarkPositiveEnvInt(tb, "TREEDB_VECTOR_BENCH_EF_SEARCH", 128),
+		topK:           vectorBenchmarkPositiveEnvInt(tb, "TREEDB_VECTOR_BENCH_TOPK", vectorBenchmarkTopK),
+		queries:        vectorBenchmarkPositiveEnvInt(tb, "TREEDB_VECTOR_BENCH_QUERIES", minInt(16, docs)),
+	}
+	if params.queries > docs {
+		params.queries = docs
+	}
+	if params.topK > docs {
+		params.topK = docs
+	}
+	if params.efConstruction < params.m {
+		tb.Fatalf("TREEDB_VECTOR_BENCH_EF_CONSTRUCTION=%d must be >= TREEDB_VECTOR_BENCH_M=%d", params.efConstruction, params.m)
+	}
+	return params
+}
+
+func vectorUSearchProductionQueries(docs, dims, queryCount int) ([][]float32, []int) {
+	queries := make([][]float32, queryCount)
+	docIndexes := make([]int, queryCount)
+	for i := 0; i < queryCount; i++ {
+		docIndex := 0
+		if docs > 1 {
+			docIndex = (docs/3 + i*7919) % docs
+		}
+		docIndexes[i] = docIndex
+		queries[i] = vectorBenchmarkEmbedding(docIndex, dims)
+	}
+	return queries, docIndexes
+}
+
+func vectorUSearchProductionDocID(doc int) string {
+	return fmt.Sprintf("doc-%06d", doc)
+}
+
+func openVectorUSearchProductionTreeDBCollection(tb testing.TB, docs, dims int, params vectorUSearchProductionCompareParams) (*backenddb.DB, *Collection, VectorIndexDefinition, VectorIndexStatus) {
+	tb.Helper()
+	dir := tb.TempDir()
+	if err := backenddb.SaveFormatConfig(dir, backenddb.FormatConfig{RequiredFeatures: []string{backenddb.RequiredFeatureCommandWALV1}}); err != nil {
+		tb.Fatalf("SaveFormatConfig: %v", err)
+	}
+	d := openCollectionCommandWALDB(tb, dir)
+	def, err := normalizeVectorIndexDefinition(VectorIndexDefinition{
+		Name:           "embedding_graph_production",
+		Field:          "embedding",
+		Metric:         VectorMetricCosine,
+		Dimensions:     dims,
+		M:              params.m,
+		EfConstruction: params.efConstruction,
+		EfSearch:       params.efSearch,
+		Strategy:       VectorIndexStrategyColumnGraph,
+	})
+	if err != nil {
+		_ = d.Close()
+		tb.Fatalf("normalize vector index definition: %v", err)
+	}
+	meta := CollectionMeta{
+		Name: "docs",
+		Options: CollectionOptions{
+			DocumentFormat: DocumentFormatJSON,
+			ColumnStore:    columnGraphRebuildColumnStoreConfigV2A(dims),
+		},
+		VectorIndexes: []VectorIndexDefinition{def},
+	}
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&meta); err != nil {
+		_ = d.Close()
+		tb.Fatalf("CreateCollection: %v", err)
+	}
+	col, err := mgr.OpenCollection("docs")
+	if err != nil {
+		_ = d.Close()
+		tb.Fatalf("OpenCollection: %v", err)
+	}
+	insertVectorUSearchProductionTreeDBRows(tb, col, docs, dims, 512)
+	status, err := col.RebuildVectorIndex(def.Name)
+	if err != nil {
+		_ = d.Close()
+		tb.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	if status.Name != def.Name || status.Strategy != VectorIndexStrategyColumnGraph || status.State != VectorIndexStateColumnGraphLoaded || !status.Loaded || status.RebuildNeeded {
+		_ = d.Close()
+		tb.Fatalf("RebuildVectorIndex status=%+v want loaded column_graph index", status)
+	}
+	return d, col, def, status
+}
+
+func insertVectorUSearchProductionTreeDBRows(tb testing.TB, col *Collection, docs, dims, batchSize int) {
+	tb.Helper()
+	ids := make([][]byte, 0, batchSize)
+	documents := make([][]byte, 0, batchSize)
+	flush := func() {
+		if len(ids) == 0 {
+			return
+		}
+		if _, err := col.InsertBatch(ids, documents); err != nil {
+			tb.Fatalf("InsertBatch: %v", err)
+		}
+		ids = ids[:0]
+		documents = documents[:0]
+	}
+	for i := 0; i < docs; i++ {
+		docID := vectorUSearchProductionDocID(i)
+		raw, err := json.Marshal(map[string]any{
+			"time_us":   int64(i + 1),
+			"kind":      "vector",
+			"did":       docID,
+			"embedding": vectorBenchmarkEmbedding(i, dims),
+		})
+		if err != nil {
+			tb.Fatalf("json.Marshal row %q: %v", docID, err)
+		}
+		ids = append(ids, []byte(docID))
+		documents = append(documents, raw)
+		if len(ids) == batchSize {
+			flush()
+		}
+	}
+	flush()
+	if err := col.Flush(); err != nil {
+		tb.Fatalf("Flush: %v", err)
+	}
+}
+
+func reportVectorUSearchProductionCommonMetrics(b *testing.B, docs, dims int, params vectorUSearchProductionCompareParams, queries int) {
+	b.Helper()
+	b.ReportMetric(float64(docs), "docs/index")
+	b.ReportMetric(float64(dims), "dims")
+	b.ReportMetric(float64(params.m), "hnsw_m")
+	b.ReportMetric(float64(params.efConstruction), "ef_construction")
+	b.ReportMetric(float64(params.efSearch), "ef_search")
+	b.ReportMetric(float64(params.topK), "top_k")
+	b.ReportMetric(float64(queries), "queries")
+}
+
+func reportVectorUSearchProductionTreeDBFootprintMetrics(b *testing.B, status VectorIndexStatus) {
+	b.Helper()
+	b.ReportMetric(float64(status.Stats.BytesDisk), "index_bytes_disk")
+	if status.NativeRootBytes > 0 {
+		b.ReportMetric(float64(status.NativeRootBytes), "native_root_bytes")
+	}
+	if status.Stats.BytesMemory > 0 {
+		b.ReportMetric(float64(status.Stats.BytesMemory), "index_bytes_memory")
+	}
+	if status.Duration > 0 {
+		b.ReportMetric(float64(status.Duration.Nanoseconds()), "rebuild_ns")
+	}
+}
+
+func reportVectorUSearchProductionTop1Metric(b *testing.B, got, want string) {
+	b.Helper()
+	if got == want {
+		b.ReportMetric(1, "top1_hit")
+		return
+	}
+	b.ReportMetric(0, "top1_hit")
+}
+
+func reportVectorUSearchOpsMetric(b *testing.B, n int) {
+	b.Helper()
+	if n <= 0 {
+		return
+	}
+	if elapsed := b.Elapsed(); elapsed > 0 {
+		b.ReportMetric(float64(n)/elapsed.Seconds(), "ops/sec")
 	}
 }
 

--- a/TreeDB/docs/guides/vector-search-typed-column.md
+++ b/TreeDB/docs/guides/vector-search-typed-column.md
@@ -343,6 +343,40 @@ already-visited optimization if future profiles continue to justify it, and keep
 #1977 normalized vectors deferred until a prototype beats raw vectors plus
 inverse norms including storage/rebuild cost.
 
+## USearch comparison boundary
+
+Use `scripts/bench_vector_search_compare.sh` for the optional external ANN
+baseline. Its current production comparison benchmark is
+`BenchmarkCollectionVectorUSearchProductionCompare`:
+
+- `TreeDB_SearchWithBuffer` / `TreeDB_SearchWithBufferParallel` time persisted
+  `column_graph` search through `Collection.OpenVectorIndexSearcher` and
+  `VectorIndexSearcher.SearchWithBuffer`; setup, inserts, rebuild, open, and
+  warmup are outside the timed loop. Parallel rows use one searcher and one
+  `VectorIndexSearchBuffer` per worker.
+- `USearch_Search` / `USearch_SearchParallel` time the pure in-memory USearch Go
+  binding with cosine/f32 HNSW.
+- Both sides use the same deterministic synthetic vector/query generator and the
+  same docs, dims, `M`, `efConstruction`, `efSearch`, `topK`, and `-cpu` list.
+  TreeDB vectors cross the collection JSON insert/rebuild boundary; USearch is
+  built directly from generated float32 vectors, so describe that data boundary
+  when publishing numbers.
+
+Quick c=1/c=8 smoke (the script runs one `go test -cpu=<n>` block per
+`CPU_LIST` entry so worker counts stay explicit):
+
+```sh
+TREEDB_VECTOR_BENCH_DOCS=10000 TREEDB_VECTOR_BENCH_DIMS=64 \
+  TREEDB_VECTOR_BENCH_EF_SEARCH=128 CPU_LIST=1,8 COUNT=1 BENCHTIME=1x \
+  scripts/bench_vector_search_compare.sh
+```
+
+Older `BenchmarkCollectionVectorIndex*` and graph-only rows remain useful
+historical controls, but they are not the current persisted production
+no-document fast path. One-shot `Collection.SearchVectorIndex` rows include
+setup/open cost per operation; do not use them as the high-QPS production
+comparator.
+
 The broader legacy/canonical matrix remains useful when comparing with older
 artifacts or when you also need one-shot open/setup names:
 

--- a/scripts/bench_vector_search_compare.sh
+++ b/scripts/bench_vector_search_compare.sh
@@ -93,6 +93,10 @@ ensure_usearch() {
 		linux)
 			local deb="usearch_linux_${USEARCH_LINUX_ARCH}_${USEARCH_VERSION}.deb"
 			local url="https://github.com/unum-cloud/usearch/releases/download/v${USEARCH_VERSION}/${deb}"
+			if ! command -v dpkg-deb >/dev/null 2>&1; then
+				echo "USearch Linux bootstrap requires dpkg-deb to extract $deb; install dpkg/dpkg-deb or set USEARCH_ROOT to an existing USearch install containing usearch.h and $USEARCH_LIB." >&2
+				exit 1
+			fi
 			if [[ ! -f "$USEARCH_CACHE/$deb" ]]; then
 				if command -v gh >/dev/null 2>&1; then
 					gh release download "v${USEARCH_VERSION}" --repo unum-cloud/usearch --pattern "$deb" --dir "$USEARCH_CACHE"

--- a/scripts/bench_vector_search_compare.sh
+++ b/scripts/bench_vector_search_compare.sh
@@ -6,51 +6,127 @@ cd "$ROOT"
 
 USEARCH_VERSION="${USEARCH_VERSION:-2.25.2}"
 USEARCH_ARCH="${USEARCH_ARCH:-}"
+USER_USEARCH_ROOT="${USEARCH_ROOT:-}"
 USEARCH_ROOT="${USEARCH_ROOT:-}"
 RUN_DIR="${RUN_DIR:-/tmp/gomap_vector_search_compare_$(date +%Y%m%d_%H%M%S)}"
-COUNT="${COUNT:-3}"
+COUNT="${COUNT:-1}"
 BENCHTIME="${BENCHTIME:-1x}"
+CPU_LIST="${CPU_LIST:-1,8}"
 RUN_UNSAFE_USEARCH_FILTERED="${RUN_UNSAFE_USEARCH_FILTERED:-false}"
-BENCH_REGEX="${BENCH_REGEX:-BenchmarkCollectionVector(SearchExact|IndexSearch(Int8)?|IndexGraphOnlySearch(Int8)?|IndexFilteredSearch|USearchBaseline)$}"
+BENCH_REGEX="${BENCH_REGEX:-BenchmarkCollectionVector(SearchExact|IndexSearch(Int8)?|IndexGraphOnlySearch(Int8)?|IndexFilteredSearch|USearchBaseline|USearchProductionCompare)$}"
 BUILD_BENCH_REGEX="${BUILD_BENCH_REGEX:-BenchmarkCollectionVector(IndexBuild(Int8)?|USearchBuild)$}"
 WRITE_BENCH_REGEX="${WRITE_BENCH_REGEX:-BenchmarkCollectionVector(IndexIncrementalWrite|USearchIncrementalWrite)$}"
 RUN_BUILD_BENCH="${RUN_BUILD_BENCH:-false}"
 RUN_WRITE_BENCH="${RUN_WRITE_BENCH:-false}"
-TREEDB_VECTOR_BENCH_DOCS="${TREEDB_VECTOR_BENCH_DOCS:-1000}"
-TREEDB_VECTOR_BENCH_DIMS="${TREEDB_VECTOR_BENCH_DIMS:-32}"
+TREEDB_VECTOR_BENCH_DOCS="${TREEDB_VECTOR_BENCH_DOCS:-10000}"
+TREEDB_VECTOR_BENCH_DIMS="${TREEDB_VECTOR_BENCH_DIMS:-64}"
+TREEDB_VECTOR_BENCH_M="${TREEDB_VECTOR_BENCH_M:-16}"
+TREEDB_VECTOR_BENCH_EF_CONSTRUCTION="${TREEDB_VECTOR_BENCH_EF_CONSTRUCTION:-128}"
+TREEDB_VECTOR_BENCH_EF_SEARCH="${TREEDB_VECTOR_BENCH_EF_SEARCH:-128}"
+TREEDB_VECTOR_BENCH_TOPK="${TREEDB_VECTOR_BENCH_TOPK:-10}"
+TREEDB_VECTOR_BENCH_QUERIES="${TREEDB_VECTOR_BENCH_QUERIES:-16}"
 
-case "${USEARCH_ARCH:-$(uname -m)}" in
-	x86_64|amd64) USEARCH_ARCH=amd64 ;;
-	aarch64|arm64) USEARCH_ARCH=arm64 ;;
-	*) echo "unsupported USearch arch: ${USEARCH_ARCH:-$(uname -m)}" >&2; exit 1 ;;
+case "$(uname -s)" in
+	Linux) USEARCH_OS=linux; USEARCH_LIB=libusearch_c.so ;;
+	Darwin) USEARCH_OS=macos; USEARCH_LIB=libusearch_c.dylib ;;
+	*) echo "unsupported USearch OS: $(uname -s)" >&2; exit 1 ;;
 esac
 
-if [[ -z "$USEARCH_ROOT" ]]; then
-	USEARCH_CACHE="/tmp/usearch_${USEARCH_VERSION}_${USEARCH_ARCH}"
-	USEARCH_ROOT="$USEARCH_CACHE/root/usr/local"
+case "${USEARCH_ARCH:-$(uname -m)}" in
+	x86_64|amd64) USEARCH_LINUX_ARCH=amd64; USEARCH_MACOS_ARCH=x86_64 ;;
+	aarch64|arm64) USEARCH_LINUX_ARCH=arm64; USEARCH_MACOS_ARCH=arm64 ;;
+	*) echo "unsupported USearch arch: ${USEARCH_ARCH:-$(uname -m)}" >&2; exit 1 ;;
+esac
+if [[ "$USEARCH_OS" == "macos" ]]; then
+	USEARCH_PACKAGE_ARCH="$USEARCH_MACOS_ARCH"
 else
-	USEARCH_CACHE=$(dirname "$(dirname "$USEARCH_ROOT")")
+	USEARCH_PACKAGE_ARCH="$USEARCH_LINUX_ARCH"
 fi
 
+if [[ -z "$USEARCH_ROOT" ]]; then
+	case "$USEARCH_OS" in
+		linux)
+			USEARCH_CACHE="/tmp/usearch_${USEARCH_VERSION}_linux_${USEARCH_LINUX_ARCH}"
+			USEARCH_ROOT="$USEARCH_CACHE/root/usr/local"
+			;;
+		macos)
+			USEARCH_CACHE="/tmp/usearch_${USEARCH_VERSION}_macos_${USEARCH_MACOS_ARCH}"
+			USEARCH_ROOT="$USEARCH_CACHE/root"
+			;;
+	esac
+else
+	USEARCH_CACHE=$(dirname "$USEARCH_ROOT")
+fi
+
+find_usearch_include_dir() {
+	local dir
+	for dir in "$USEARCH_ROOT/include" "$USEARCH_ROOT"; do
+		if [[ -f "$dir/usearch.h" ]]; then
+			printf '%s\n' "$dir"
+			return 0
+		fi
+	done
+	return 1
+}
+
+find_usearch_lib_dir() {
+	local dir
+	for dir in "$USEARCH_ROOT/lib" "$USEARCH_ROOT"; do
+		if [[ -f "$dir/$USEARCH_LIB" ]]; then
+			printf '%s\n' "$dir"
+			return 0
+		fi
+	done
+	return 1
+}
+
 ensure_usearch() {
-	if [[ -f "$USEARCH_ROOT/include/usearch.h" && -f "$USEARCH_ROOT/lib/libusearch_c.so" ]]; then
+	if find_usearch_include_dir >/dev/null 2>&1 && find_usearch_lib_dir >/dev/null 2>&1; then
 		return
 	fi
-	local deb="usearch_linux_${USEARCH_ARCH}_${USEARCH_VERSION}.deb"
-	local url="https://github.com/unum-cloud/usearch/releases/download/v${USEARCH_VERSION}/${deb}"
-	mkdir -p "$USEARCH_CACHE"
-	if [[ ! -f "$USEARCH_CACHE/$deb" ]]; then
-		if command -v gh >/dev/null 2>&1; then
-			gh release download "v${USEARCH_VERSION}" --repo unum-cloud/usearch --pattern "$deb" --dir "$USEARCH_CACHE"
-		else
-			curl -L --fail "$url" -o "$USEARCH_CACHE/$deb"
-		fi
+	if [[ -n "$USER_USEARCH_ROOT" ]]; then
+		echo "USEARCH_ROOT=$USER_USEARCH_ROOT does not contain usearch.h and $USEARCH_LIB" >&2
+		exit 1
 	fi
-	rm -rf "$USEARCH_CACHE/root"
-	dpkg-deb -x "$USEARCH_CACHE/$deb" "$USEARCH_CACHE/root"
+	mkdir -p "$USEARCH_CACHE"
+	case "$USEARCH_OS" in
+		linux)
+			local deb="usearch_linux_${USEARCH_LINUX_ARCH}_${USEARCH_VERSION}.deb"
+			local url="https://github.com/unum-cloud/usearch/releases/download/v${USEARCH_VERSION}/${deb}"
+			if [[ ! -f "$USEARCH_CACHE/$deb" ]]; then
+				if command -v gh >/dev/null 2>&1; then
+					gh release download "v${USEARCH_VERSION}" --repo unum-cloud/usearch --pattern "$deb" --dir "$USEARCH_CACHE"
+				else
+					curl -L --fail "$url" -o "$USEARCH_CACHE/$deb"
+				fi
+			fi
+			rm -rf "$USEARCH_CACHE/root"
+			dpkg-deb -x "$USEARCH_CACHE/$deb" "$USEARCH_CACHE/root"
+			;;
+		macos)
+			local zip="usearch_macos_${USEARCH_MACOS_ARCH}_${USEARCH_VERSION}.zip"
+			local url="https://github.com/unum-cloud/usearch/releases/download/v${USEARCH_VERSION}/${zip}"
+			if [[ ! -f "$USEARCH_CACHE/$zip" ]]; then
+				if command -v gh >/dev/null 2>&1; then
+					gh release download "v${USEARCH_VERSION}" --repo unum-cloud/usearch --pattern "$zip" --dir "$USEARCH_CACHE"
+				else
+					curl -L --fail "$url" -o "$USEARCH_CACHE/$zip"
+				fi
+			fi
+			rm -rf "$USEARCH_CACHE/root"
+			mkdir -p "$USEARCH_CACHE/root"
+			unzip -q "$USEARCH_CACHE/$zip" -d "$USEARCH_CACHE/root"
+			;;
+	esac
+	if ! find_usearch_include_dir >/dev/null 2>&1 || ! find_usearch_lib_dir >/dev/null 2>&1; then
+		echo "USearch bootstrap did not produce usearch.h and $USEARCH_LIB under $USEARCH_ROOT" >&2
+		exit 1
+	fi
 }
 
 ensure_usearch
+USEARCH_INCLUDE_DIR=$(find_usearch_include_dir)
+USEARCH_LIB_DIR=$(find_usearch_lib_dir)
 mkdir -p "$RUN_DIR"
 
 cat >"$RUN_DIR/README.md" <<EOF
@@ -60,9 +136,18 @@ cat >"$RUN_DIR/README.md" <<EOF
 - branch: \`$(git rev-parse --abbrev-ref HEAD)\`
 - commit: \`$(git rev-parse --short HEAD)\`
 - USearch version: \`$USEARCH_VERSION\`
+- USearch OS/arch: \`$USEARCH_OS\` / \`$USEARCH_PACKAGE_ARCH\`
 - USearch root: \`$USEARCH_ROOT\`
+- USearch include dir: \`$USEARCH_INCLUDE_DIR\`
+- USearch lib dir: \`$USEARCH_LIB_DIR\`
 - docs: \`$TREEDB_VECTOR_BENCH_DOCS\`
 - dims: \`$TREEDB_VECTOR_BENCH_DIMS\`
+- M: \`$TREEDB_VECTOR_BENCH_M\`
+- efConstruction: \`$TREEDB_VECTOR_BENCH_EF_CONSTRUCTION\`
+- efSearch: \`$TREEDB_VECTOR_BENCH_EF_SEARCH\`
+- topK: \`$TREEDB_VECTOR_BENCH_TOPK\`
+- query stream length: \`$TREEDB_VECTOR_BENCH_QUERIES\`
+- cpu/concurrency list: \`$CPU_LIST\`
 - benchtime: \`$BENCHTIME\`
 - count: \`$COUNT\`
 - benchmark regex: \`$BENCH_REGEX\`
@@ -72,10 +157,40 @@ cat >"$RUN_DIR/README.md" <<EOF
 - run write benchmarks: \`$RUN_WRITE_BENCH\`
 - unsafe USearch filtered benchmark: \`$RUN_UNSAFE_USEARCH_FILTERED\`
 
-The harness compares TreeDB exact scan, TreeDB in-memory ANN, TreeDB int8 ANN,
-and USearch cosine/f32 HNSW using the same synthetic vector generator.
+## Benchmark boundaries
 
-With \`RUN_WRITE_BENCH=true\`, it also compares TreeDB incremental
+Canonical current production comparison:
+
+- \`BenchmarkCollectionVectorUSearchProductionCompare/TreeDB_SearchWithBuffer\`
+  and \`.../TreeDB_SearchWithBufferParallel\` time the persisted TreeDB
+  \`column_graph\` path through \`Collection.OpenVectorIndexSearcher\` plus
+  \`VectorIndexSearcher.SearchWithBuffer\`. Setup, inserts, rebuild, open, and
+  warmup are outside the timed loop. Parallel runs use one searcher and one
+  caller-owned buffer per Go worker; use \`CPU_LIST=1,8\` for c=1/c=8 evidence.
+  The script emits a separate \`## search benchmarks cpu=<n>\` block for each
+  requested concurrency so worker counts stay unambiguous.
+  The timed loop uses production stats mode; a full-diagnostics sample is taken
+  outside the timed loop to report candidates/search and edge counters.
+- \`.../USearch_Search\` and \`.../USearch_SearchParallel\` time the pure
+  in-memory USearch Go binding baseline with cosine/f32 HNSW and the same
+  synthetic vector/query generator, M, efConstruction, efSearch, topK, docs,
+  dims, and CPU/concurrency list.
+
+Legacy/control rows:
+
+- \`BenchmarkCollectionVectorIndex*\` rows are older TreeDB in-memory/native-root
+  vector-index controls. They are useful historical comparators but are not the
+  current production no-document fast path.
+- \`BenchmarkCollectionVectorSearchExact\` is an exact scan control.
+- One-shot \`Collection.SearchVectorIndex\` benchmarks, when run separately, pay
+  setup/open costs per operation and should not be presented as the high-QPS
+  production fast path.
+
+Data boundary: TreeDB stores generated float32 vectors through JSON collection
+inserts and rebuilds the persisted \`column_graph\`; USearch is built directly
+from the generated float32 vectors as a pure in-memory external ANN baseline.
+
+With \`RUN_WRITE_BENCH=true\`, the script also compares TreeDB incremental
 \`InsertBatch\` with a registered in-memory vector index against USearch
 incremental \`Add\` on the same synthetic vector stream. The TreeDB benchmark
 includes collection document writes and vector-index update notifications; the
@@ -83,22 +198,43 @@ USearch benchmark is in-memory index insertion only.
 EOF
 
 echo "USearch root: $USEARCH_ROOT"
+echo "USearch include dir: $USEARCH_INCLUDE_DIR"
+echo "USearch lib dir: $USEARCH_LIB_DIR"
 echo "run dir: $RUN_DIR"
 (
 	if [[ "$RUN_UNSAFE_USEARCH_FILTERED" == "true" ]]; then
-		export BENCH_REGEX="BenchmarkCollectionVector(SearchExact|IndexSearch(Int8)?|IndexGraphOnlySearch(Int8)?|IndexFilteredSearch|USearchBaseline|USearchFilteredBaseline)$"
+		export BENCH_REGEX="BenchmarkCollectionVector(SearchExact|IndexSearch(Int8)?|IndexGraphOnlySearch(Int8)?|IndexFilteredSearch|USearchBaseline|USearchFilteredBaseline|USearchProductionCompare)$"
 		export GODEBUG="cgocheck=0${GODEBUG:+,$GODEBUG}"
 	fi
-	export CGO_CFLAGS="-I$USEARCH_ROOT/include ${CGO_CFLAGS:-}"
-	export CGO_LDFLAGS="-L$USEARCH_ROOT/lib ${CGO_LDFLAGS:-}"
-	export LD_LIBRARY_PATH="$USEARCH_ROOT/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+	export CGO_CFLAGS="-I$USEARCH_INCLUDE_DIR ${CGO_CFLAGS:-}"
+	if [[ "$USEARCH_OS" == "macos" ]]; then
+		export CGO_LDFLAGS="-L$USEARCH_LIB_DIR -Wl,-rpath,$USEARCH_LIB_DIR ${CGO_LDFLAGS:-}"
+		export DYLD_LIBRARY_PATH="$USEARCH_LIB_DIR${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}"
+	else
+		export CGO_LDFLAGS="-L$USEARCH_LIB_DIR ${CGO_LDFLAGS:-}"
+		export LD_LIBRARY_PATH="$USEARCH_LIB_DIR${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+	fi
 	export TREEDB_VECTOR_BENCH_DOCS
 	export TREEDB_VECTOR_BENCH_DIMS
-	go test -tags usearch_bench ./TreeDB/collections -run '^$' -bench "$BENCH_REGEX" -benchtime="$BENCHTIME" -count="$COUNT"
+	export TREEDB_VECTOR_BENCH_M
+	export TREEDB_VECTOR_BENCH_EF_CONSTRUCTION
+	export TREEDB_VECTOR_BENCH_EF_SEARCH
+	export TREEDB_VECTOR_BENCH_TOPK
+	export TREEDB_VECTOR_BENCH_QUERIES
+	for cpu in ${CPU_LIST//,/ }; do
+		echo "## search benchmarks cpu=$cpu"
+		go test -tags usearch_bench ./TreeDB/collections -run '^$' -bench "$BENCH_REGEX" -benchmem -benchtime="$BENCHTIME" -count="$COUNT" -cpu="$cpu"
+	done
 	if [[ "$RUN_BUILD_BENCH" == "true" ]]; then
-		go test -tags usearch_bench ./TreeDB/collections -run '^$' -bench "$BUILD_BENCH_REGEX" -benchtime="$BENCHTIME" -count="$COUNT"
+		for cpu in ${CPU_LIST//,/ }; do
+			echo "## build benchmarks cpu=$cpu"
+			go test -tags usearch_bench ./TreeDB/collections -run '^$' -bench "$BUILD_BENCH_REGEX" -benchmem -benchtime="$BENCHTIME" -count="$COUNT" -cpu="$cpu"
+		done
 	fi
 	if [[ "$RUN_WRITE_BENCH" == "true" ]]; then
-		go test -tags usearch_bench ./TreeDB/collections -run '^$' -bench "$WRITE_BENCH_REGEX" -benchtime="$BENCHTIME" -count="$COUNT"
+		for cpu in ${CPU_LIST//,/ }; do
+			echo "## write benchmarks cpu=$cpu"
+			go test -tags usearch_bench ./TreeDB/collections -run '^$' -bench "$WRITE_BENCH_REGEX" -benchmem -benchtime="$BENCHTIME" -count="$COUNT" -cpu="$cpu"
+		done
 	fi
 ) 2>&1 | tee "$RUN_DIR/bench.txt"


### PR DESCRIPTION
## Objective

Land a current optional USearch comparison for TreeDB vector search that includes the production no-document steady-state path: `Collection.OpenVectorIndexSearcher` + `VectorIndexSearcher.SearchWithBuffer`.

Closes #2269.

## Context

The existing optional USearch harness compared USearch mostly against older TreeDB `VectorIndex` / graph-only controls. This PR adds a clearly labeled persisted `column_graph` reusable-buffer comparator and updates docs/script output so old controls, current production SearchWithBuffer, pure in-memory USearch, and one-shot convenience APIs are not conflated.

## Non-goals

- No TreeDB vector search semantic changes.
- No `efSearch` correctness/default behavior changes.
- No on-disk format changes.
- No TreeDB hot-path optimization work.
- No required USearch dependency for normal builds.

## Design

- Adds `BenchmarkCollectionVectorUSearchProductionCompare` behind `usearch_bench && cgo`.
  - `TreeDB_SearchWithBuffer`: persisted `column_graph`, opened reusable searcher, caller-owned buffer, no documents.
  - `TreeDB_SearchWithBufferParallel`: one reusable searcher + one buffer per Go worker.
  - `USearch_Search` / `USearch_SearchParallel`: pure in-memory USearch Go binding baseline.
- Adds env knobs for the comparison shape: docs, dims, M, efConstruction, efSearch, topK, query count.
- Script now supports Linux and macOS USearch roots/packages, emits c=1/c=8 as separate `go test -cpu=<n>` blocks, and records the benchmark boundary in its generated README.
- TreeDB timed loops use production stats mode; a full-diagnostics sample is taken outside the timer for candidates/search and edge counters.

## Scope

- Includes:
  - `TreeDB/collections/vector_usearch_bench_test.go`
  - `scripts/bench_vector_search_compare.sh`
  - `TreeDB/README.md`
  - `TreeDB/docs/guides/vector-search-typed-column.md`
  - typed-storage naming allowlist update for the new benchmark file
- Excludes:
  - production search algorithms/scoring semantics
  - public API behavior
  - format/migration changes

## Correctness

- Tests run:
  - `go test ./TreeDB/collections -run 'TestTypedStorageLegacyNameAllowlistIsComplete|TestLoadVectorBenchmarkFixtureJSONL|TestVectorIndexSearcherSearchWithBufferResultEquivalenceAndZeroAllocs2124|TestVectorIndexSearcherSearchWithBufferParallelIndependentBuffers1961' -count=1`
  - `go test ./TreeDB/collections -count=1`
  - `git diff --check`
  - `bash -n scripts/bench_vector_search_compare.sh`
- Script behavior validation: no dedicated shell parser test harness exists for `scripts/`; validated with `bash -n` plus real local USearch smoke/benchmark runs that exercised c=1/c=8 block emission and generated README metadata.

## Performance

Bench host/context: Apple M3, darwin/arm64, Go 1.25.5, local USearch 2.25.2 root `/tmp/usearch_2.25.2_macos_arm64/root`. TreeDB vectors cross JSON collection insert/rebuild; USearch is pure in-memory from generated float32 vectors.

100k docs / 128 dims / M=16 / efConstruction=128 / efSearch=128 / topK=10 / query stream=16:

Command/artifact:

```sh
RUN_DIR=/tmp/gomap_vector_search_compare_100k128_1s_20260603_221718 \
USEARCH_ROOT=/tmp/usearch_2.25.2_macos_arm64/root \
TREEDB_VECTOR_BENCH_DOCS=100000 TREEDB_VECTOR_BENCH_DIMS=128 \
TREEDB_VECTOR_BENCH_QUERIES=16 TREEDB_VECTOR_BENCH_EF_SEARCH=128 \
BENCH_REGEX='^BenchmarkCollectionVectorUSearchProductionCompare$' \
BENCHTIME=1s COUNT=1 CPU_LIST=1,8 \
scripts/bench_vector_search_compare.sh
```

| c | Engine/row | ns/op | ops/sec | approx per-worker latency | B/op | allocs/op | TreeDB candidates/search | TreeDB candidate_fetches/search | top1 smoke |
| ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 1 | TreeDB `SearchWithBuffer` | 337,929 | 2,959 | 337.9us | 0 | 0 | 2,496 | 2,595 | 1 |
| 1 | USearch `Search` | 174,223 | 5,740 | 174.2us | 136 | 3 | n/a | n/a | 1 |
| 8 | TreeDB `SearchWithBufferParallel` | 69,396 | 14,410 | ~555us | 0 | 0 | 2,496 | 2,595 | 1 |
| 8 | USearch `SearchParallel` | 30,262 | 33,045 | ~242us | 136 | 3 | n/a | n/a | 1 |

Notes:

- Go parallel `ns/op` is aggregate wall time per operation; approx per-worker latency is `ns/op * workers`.
- TreeDB candidate/edge counters are from the untimed full-diagnostics sample; timed search uses production stats mode.
- TreeDB index bytes reported by the benchmark: `index_bytes_disk=68,315,064`; USearch `index_bytes=92,276,096`.
- TreeDB healthy-path counters in the same run: `docs_fetched/search=0`, `typed_column_vector_source_mmap=1`, `vector_scratch_decodes/search=0`, `graph_row_fallbacks/search=0`.

Quick 10k smoke artifact:
`/tmp/gomap_vector_search_compare_10k64_final_20260603_221303` (10k docs / 64 dims / same M/ef/topK/query count, `BENCHTIME=100x`). Highlights: c=1 TreeDB 94.5us vs USearch 42.1us; c=8 aggregate TreeDB 18.6us/op vs USearch 8.36us/op; TreeDB candidates/search 1,436; TreeDB 0 B/op, 0 allocs/op.

Manual investigation artifacts also remain at `/tmp/treedb_usearch_review_20260603_175047` and `/tmp/treedb_usearch_investigation_report.md` for the earlier independent 100k/128 comparison.

## Rollout / Toggle Plan

- Default builds/tests do not require USearch.
- USearch comparison remains opt-in behind `-tags usearch_bench` and cgo.
- Disable by not passing the tag or by not running `scripts/bench_vector_search_compare.sh`.

## Follow-ups

- None required for this harness/docs PR. TreeDB ANN optimization/tuning should stay in follow-up issues, not this PR.

### AI Review Loop

- Codex latest-head review: pending request after PR opens and CI starts.
- Copilot latest-head review: pending request after PR opens and CI starts.
- CodeRabbit latest-head review: pending request after PR opens and CI starts.
- Review comments/threads resolved or explicitly dismissed: pending.


### Latest review-fix update (head e5334a03623fe2ae345744a62f78a4696af718bd)

Fixed CodeRabbit blockers:

- Added Linux `dpkg-deb` preflight with a clear error suggesting installing dpkg/dpkg-deb or setting `USEARCH_ROOT`.
- Captured the per-iteration `SearchWithBufferParallel` searcher explicitly in the deferred close.

Focused validation after fixes:

```sh
go test ./TreeDB/collections -run 'TestTypedStorageLegacyNameAllowlistIsComplete|TestLoadVectorBenchmarkFixtureJSONL|TestVectorIndexSearcherSearchWithBufferParallelIndependentBuffers1961' -count=1
USEARCH_ROOT=/tmp/usearch_2.25.2_macos_arm64/root \
  CGO_CFLAGS='-I/tmp/usearch_2.25.2_macos_arm64/root' \
  CGO_LDFLAGS='-L/tmp/usearch_2.25.2_macos_arm64/root -Wl,-rpath,/tmp/usearch_2.25.2_macos_arm64/root' \
  DYLD_LIBRARY_PATH='/tmp/usearch_2.25.2_macos_arm64/root' \
  TREEDB_VECTOR_BENCH_DOCS=64 TREEDB_VECTOR_BENCH_DIMS=8 TREEDB_VECTOR_BENCH_QUERIES=2 \
  go test -tags usearch_bench ./TreeDB/collections -run '^$' \
  -bench '^BenchmarkCollectionVectorUSearchProductionCompare/TreeDB_SearchWithBufferParallel$' \
  -benchmem -benchtime=1x -count=1 -cpu=1
bash -n scripts/bench_vector_search_compare.sh
git diff --check
```

AI status update: Codex had no major issues on the prior head; CodeRabbit blockers were fixed on this head and CodeRabbit was re-requested after the coherent fix push; Copilot was requested and had no visible response at the time of this update.

### Final mergeability status (latest head e5334a03623fe2ae345744a62f78a4696af718bd)

- CI: latest-head GitHub checks are green.
- Codex: reviewed latest mature PR; no major issues.
- CodeRabbit: blocking findings fixed; latest check passed/review completed; GraphQL review-thread inventory shows no unresolved threads.
- Copilot: requested; no visible response at final handoff.
- Merge status: mergeable-candidate; awaiting human/coordinator merge decision.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced vector search comparison documentation with detailed benchmarking guidance, including environment setup, parameter configuration, and performance metric interpretation.

* **Tests**
  * Added production-style vector search performance benchmarks comparing sequential and parallel search operations with comprehensive metrics collection.

* **Chores**
  * Improved benchmarking automation script with automatic platform detection, configurable parameters, dynamic library path discovery, and comprehensive performance metrics reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
