### PR TITLE
TreeDB: instrument HNSW traversal counters

### DIFF
--- a/TreeDB/collections/column_vector_graph_batchability_1979_test.go
+++ b/TreeDB/collections/column_vector_graph_batchability_1979_test.go
@@ -145,17 +145,29 @@ func assertColumnVectorGraphBenchmarkDebugStats1979(tb testing.TB, stats columnV
 	if stats.ScoredNeighbors+stats.SkippedNeighbors != stats.VisitedEdges {
 		tb.Fatalf("stats=%+v want scored+skipped neighbor buckets to reconcile with visited_edges", stats)
 	}
-	if stats.VisitedMarkHits+stats.VisitedMarkMisses != stats.VisitedMarkChecks || stats.VisitedMarkHits != stats.Layer0AlreadyVisitedSkips {
-		tb.Fatalf("stats=%+v want visited-mark hits/misses to reconcile", stats)
+	if stats.VisitedMarkHits+stats.VisitedMarkMisses != stats.VisitedMarkChecks || stats.VisitedMarkHits != stats.Layer0AlreadyVisitedSkips || stats.VisitedMarkInserts < stats.VisitedMarkMisses || stats.VisitedResetEpochAdvances != 1 {
+		tb.Fatalf("stats=%+v want visited-mark hits/misses/inserts/reset work to reconcile", stats)
 	}
 	if stats.FrontierPushes != stats.TopKInsertSuccesses || stats.TopKInsertAttempts != stats.Candidates || stats.TopKInsertSuccesses+stats.TopKInsertRejections != stats.TopKInsertAttempts {
 		tb.Fatalf("stats=%+v want frontier/top-k operation counts to reconcile with candidates", stats)
 	}
+	if stats.FrontierSiftUpCalls != stats.FrontierPushes || stats.FrontierSiftDownCalls > stats.FrontierPops || stats.CandidateComparisons != stats.FrontierComparisons+stats.TopKComparisons {
+		tb.Fatalf("stats=%+v want frontier/top-k comparison and sift counters to reconcile", stats)
+	}
+	if stats.Layer0StopTrue+stats.Layer0StopFalse != stats.Layer0StopChecks || (stats.Layer0StopChecks == 0 && stats.WavefrontSearches == 0) {
+		tb.Fatalf("stats=%+v want layer0 stop checks to reconcile", stats)
+	}
 	if stats.NeighborTileSize0+stats.NeighborTileSize1+stats.NeighborTileSize2To4+stats.NeighborTileSize5To8+stats.NeighborTileSize9To16+stats.NeighborTileSize17Plus != stats.NeighborTiles {
 		tb.Fatalf("stats=%+v want neighbor tile histogram to sum to neighbor_tiles", stats)
 	}
+	if stats.UpperLayerAdjacencyLoads+stats.Layer0AdjacencyLoads != stats.NeighborTiles || stats.UpperLayerAdjacencyNeighbors+stats.Layer0AdjacencyNeighbors != stats.NeighborTileNeighbors {
+		tb.Fatalf("stats=%+v want phase adjacency load counters to reconcile", stats)
+	}
 	if stats.ScoreBatchSingletons+stats.ScoreBatchSize2To4+stats.ScoreBatchSize5To8+stats.ScoreBatchSize9To16+stats.ScoreBatchSize17Plus != stats.ScoreBatchCalls {
 		tb.Fatalf("stats=%+v want score batch histogram to sum to score_batch_calls", stats)
+	}
+	if stats.UpperLayerScoreTileCandidates != stats.UpperLayerScores || stats.Layer0ScoreTileCandidates != stats.Layer0Scores || stats.UpperLayerScoreTiles+stats.Layer0ScoreTiles == 0 {
+		tb.Fatalf("stats=%+v want phase score tile counters to reconcile", stats)
 	}
 	if exactMode {
 		if stats.ExactModeSearches != 1 || stats.ExactCandidateOrderObservations != stats.Candidates {
@@ -199,19 +211,41 @@ func addColumnVectorGraphNativeSearchDebugStats1979(dst *columnVectorGraphNative
 	dst.UpperLayerScores += src.UpperLayerScores
 	dst.UpperLayerEntryScores += src.UpperLayerEntryScores
 	dst.UpperLayerNeighborScores += src.UpperLayerNeighborScores
+	dst.UpperLayerScoreTiles += src.UpperLayerScoreTiles
+	dst.UpperLayerScoreTileCandidates += src.UpperLayerScoreTileCandidates
+	if src.UpperLayerScoreTileMaxSize > dst.UpperLayerScoreTileMaxSize {
+		dst.UpperLayerScoreTileMaxSize = src.UpperLayerScoreTileMaxSize
+	}
+	dst.UpperLayerAdjacencyLoads += src.UpperLayerAdjacencyLoads
+	dst.UpperLayerAdjacencyNeighbors += src.UpperLayerAdjacencyNeighbors
 	dst.UpperLayerEdgeVisits += src.UpperLayerEdgeVisits
 	dst.UpperLayerScoredNeighbors += src.UpperLayerScoredNeighbors
 	dst.UpperLayerFilterSkips += src.UpperLayerFilterSkips
 	dst.Layer0Scores += src.Layer0Scores
 	dst.Layer0SeedScores += src.Layer0SeedScores
 	dst.Layer0NeighborScores += src.Layer0NeighborScores
+	dst.Layer0ScoreTiles += src.Layer0ScoreTiles
+	dst.Layer0ScoreTileCandidates += src.Layer0ScoreTileCandidates
+	if src.Layer0ScoreTileMaxSize > dst.Layer0ScoreTileMaxSize {
+		dst.Layer0ScoreTileMaxSize = src.Layer0ScoreTileMaxSize
+	}
+	dst.Layer0AdjacencyLoads += src.Layer0AdjacencyLoads
+	dst.Layer0AdjacencyNeighbors += src.Layer0AdjacencyNeighbors
 	dst.Layer0EdgeVisits += src.Layer0EdgeVisits
 	dst.Layer0ScoredNeighbors += src.Layer0ScoredNeighbors
 	dst.Layer0AlreadyVisitedSkips += src.Layer0AlreadyVisitedSkips
 	dst.Layer0FilterSkips += src.Layer0FilterSkips
+	dst.Layer0StopChecks += src.Layer0StopChecks
+	dst.Layer0StopTrue += src.Layer0StopTrue
+	dst.Layer0StopFalse += src.Layer0StopFalse
+	dst.CandidateComparisons += src.CandidateComparisons
+	dst.FrontierComparisons += src.FrontierComparisons
+	dst.TopKComparisons += src.TopKComparisons
 	dst.FrontierPushes += src.FrontierPushes
 	dst.FrontierPops += src.FrontierPops
 	dst.FrontierPopMisses += src.FrontierPopMisses
+	dst.FrontierSiftUpCalls += src.FrontierSiftUpCalls
+	dst.FrontierSiftDownCalls += src.FrontierSiftDownCalls
 	dst.FrontierSiftUpSteps += src.FrontierSiftUpSteps
 	dst.FrontierSiftDownSteps += src.FrontierSiftDownSteps
 	dst.TopKInsertAttempts += src.TopKInsertAttempts
@@ -221,6 +255,9 @@ func addColumnVectorGraphNativeSearchDebugStats1979(dst *columnVectorGraphNative
 	dst.VisitedMarkChecks += src.VisitedMarkChecks
 	dst.VisitedMarkHits += src.VisitedMarkHits
 	dst.VisitedMarkMisses += src.VisitedMarkMisses
+	dst.VisitedMarkInserts += src.VisitedMarkInserts
+	dst.VisitedResetEpochAdvances += src.VisitedResetEpochAdvances
+	dst.VisitedResetClearedRows += src.VisitedResetClearedRows
 	dst.ExactModeSearches += src.ExactModeSearches
 	dst.ExactCandidateOrderObservations += src.ExactCandidateOrderObservations
 	dst.ExactCandidateOrderTransitions += src.ExactCandidateOrderTransitions
@@ -263,19 +300,37 @@ func reportColumnVectorGraphNativeSearchDebugMetrics1979(b *testing.B, n int, st
 	b.ReportMetric(float64(stats.UpperLayerScores)/denom, "upper_layer_scores/search")
 	b.ReportMetric(float64(stats.UpperLayerEntryScores)/denom, "upper_layer_entry_scores/search")
 	b.ReportMetric(float64(stats.UpperLayerNeighborScores)/denom, "upper_layer_neighbor_scores/search")
+	b.ReportMetric(float64(stats.UpperLayerScoreTiles)/denom, "upper_layer_score_tiles/search")
+	b.ReportMetric(float64(stats.UpperLayerScoreTileCandidates)/denom, "upper_layer_score_tile_candidates/search")
+	b.ReportMetric(float64(stats.UpperLayerScoreTileMaxSize), "upper_layer_score_tile_max_size")
+	b.ReportMetric(float64(stats.UpperLayerAdjacencyLoads)/denom, "upper_layer_adjacency_loads/search")
+	b.ReportMetric(float64(stats.UpperLayerAdjacencyNeighbors)/denom, "upper_layer_adjacency_neighbors/search")
 	b.ReportMetric(float64(stats.UpperLayerEdgeVisits)/denom, "upper_layer_edge_visits/search")
 	b.ReportMetric(float64(stats.UpperLayerScoredNeighbors)/denom, "upper_layer_scored_neighbors/search")
 	b.ReportMetric(float64(stats.UpperLayerFilterSkips)/denom, "upper_layer_filter_skips/search")
 	b.ReportMetric(float64(stats.Layer0Scores)/denom, "layer0_scores/search")
 	b.ReportMetric(float64(stats.Layer0SeedScores)/denom, "layer0_seed_scores/search")
 	b.ReportMetric(float64(stats.Layer0NeighborScores)/denom, "layer0_neighbor_scores/search")
+	b.ReportMetric(float64(stats.Layer0ScoreTiles)/denom, "layer0_score_tiles/search")
+	b.ReportMetric(float64(stats.Layer0ScoreTileCandidates)/denom, "layer0_score_tile_candidates/search")
+	b.ReportMetric(float64(stats.Layer0ScoreTileMaxSize), "layer0_score_tile_max_size")
+	b.ReportMetric(float64(stats.Layer0AdjacencyLoads)/denom, "layer0_adjacency_loads/search")
+	b.ReportMetric(float64(stats.Layer0AdjacencyNeighbors)/denom, "layer0_adjacency_neighbors/search")
 	b.ReportMetric(float64(stats.Layer0EdgeVisits)/denom, "layer0_edge_visits/search")
 	b.ReportMetric(float64(stats.Layer0ScoredNeighbors)/denom, "layer0_scored_neighbors/search")
 	b.ReportMetric(float64(stats.Layer0AlreadyVisitedSkips)/denom, "layer0_already_visited_skips/search")
 	b.ReportMetric(float64(stats.Layer0FilterSkips)/denom, "layer0_filter_skips/search")
+	b.ReportMetric(float64(stats.Layer0StopChecks)/denom, "layer0_stop_checks/search")
+	b.ReportMetric(float64(stats.Layer0StopTrue)/denom, "layer0_stop_true/search")
+	b.ReportMetric(float64(stats.Layer0StopFalse)/denom, "layer0_stop_false/search")
+	b.ReportMetric(float64(stats.CandidateComparisons)/denom, "candidate_comparisons/search")
+	b.ReportMetric(float64(stats.FrontierComparisons)/denom, "frontier_comparisons/search")
+	b.ReportMetric(float64(stats.TopKComparisons)/denom, "top_k_comparisons/search")
 	b.ReportMetric(float64(stats.FrontierPushes)/denom, "frontier_pushes/search")
 	b.ReportMetric(float64(stats.FrontierPops)/denom, "frontier_pops/search")
 	b.ReportMetric(float64(stats.FrontierPopMisses)/denom, "frontier_pop_misses/search")
+	b.ReportMetric(float64(stats.FrontierSiftUpCalls)/denom, "frontier_sift_up_calls/search")
+	b.ReportMetric(float64(stats.FrontierSiftDownCalls)/denom, "frontier_sift_down_calls/search")
 	b.ReportMetric(float64(stats.FrontierSiftUpSteps)/denom, "frontier_sift_up_steps/search")
 	b.ReportMetric(float64(stats.FrontierSiftDownSteps)/denom, "frontier_sift_down_steps/search")
 	b.ReportMetric(float64(stats.TopKInsertAttempts)/denom, "top_k_insert_attempts/search")
@@ -285,6 +340,9 @@ func reportColumnVectorGraphNativeSearchDebugMetrics1979(b *testing.B, n int, st
 	b.ReportMetric(float64(stats.VisitedMarkChecks)/denom, "visited_mark_checks/search")
 	b.ReportMetric(float64(stats.VisitedMarkHits)/denom, "visited_mark_hits/search")
 	b.ReportMetric(float64(stats.VisitedMarkMisses)/denom, "visited_mark_misses/search")
+	b.ReportMetric(float64(stats.VisitedMarkInserts)/denom, "visited_mark_inserts/search")
+	b.ReportMetric(float64(stats.VisitedResetEpochAdvances)/denom, "visited_reset_epoch_advances/search")
+	b.ReportMetric(float64(stats.VisitedResetClearedRows)/denom, "visited_reset_cleared_rows/search")
 	b.ReportMetric(float64(stats.ExactModeSearches)/denom, "exact_mode_searches/search")
 	b.ReportMetric(float64(stats.ExactCandidateOrderObservations)/denom, "exact_candidate_order_observations/search")
 	b.ReportMetric(float64(stats.ExactCandidateOrderTransitions)/denom, "exact_candidate_order_transitions/search")

--- a/TreeDB/collections/column_vector_graph_prepared_search_test.go
+++ b/TreeDB/collections/column_vector_graph_prepared_search_test.go
@@ -515,21 +515,21 @@ func assertColumnVectorGraphBenchmarkDebugStats2126(tb testing.TB, stats columnV
 	if stats.Candidates == 0 || stats.Edges == 0 || stats.VisitedEdges != stats.Edges {
 		tb.Fatalf("benchmark debug stats=%+v want full traversal counters", stats)
 	}
-	if stats.BenchmarkDebugSearches != 1 || stats.NeighborTiles == 0 || stats.Layer0EdgeVisits == 0 || stats.FrontierPushes == 0 || stats.TopKInsertAttempts == 0 || stats.VisitedMarkChecks == 0 || stats.ExactModeSearches != 1 || stats.ExactCandidateOrderObservations == 0 {
+	if stats.BenchmarkDebugSearches != 1 || stats.NeighborTiles == 0 || stats.Layer0AdjacencyLoads == 0 || stats.Layer0EdgeVisits == 0 || stats.Layer0StopChecks == 0 || stats.Layer0ScoreTiles == 0 || stats.FrontierPushes == 0 || stats.FrontierSiftUpCalls == 0 || stats.CandidateComparisons == 0 || stats.TopKInsertAttempts == 0 || stats.VisitedMarkChecks == 0 || stats.VisitedMarkInserts == 0 || stats.VisitedResetEpochAdvances != 1 || stats.ExactModeSearches != 1 || stats.ExactCandidateOrderObservations == 0 {
 		tb.Fatalf("benchmark debug stats=%+v want tile/frontier/top-k/visited/exact-order counters", stats)
 	}
 }
 
 func assertColumnVectorGraphDebugCountersZero2126(tb testing.TB, stats columnVectorGraphNativeSearchStats) {
 	tb.Helper()
-	if stats.BenchmarkDebugSearches != 0 || stats.NeighborTiles != 0 || stats.Layer0EdgeVisits != 0 || stats.FrontierPushes != 0 || stats.TopKInsertAttempts != 0 || stats.VisitedMarkChecks != 0 || stats.ExactCandidateOrderObservations != 0 {
+	if stats.BenchmarkDebugSearches != 0 || stats.NeighborTiles != 0 || stats.Layer0AdjacencyLoads != 0 || stats.Layer0EdgeVisits != 0 || stats.Layer0StopChecks != 0 || stats.Layer0ScoreTiles != 0 || stats.FrontierPushes != 0 || stats.FrontierSiftUpCalls != 0 || stats.CandidateComparisons != 0 || stats.TopKInsertAttempts != 0 || stats.VisitedMarkChecks != 0 || stats.VisitedMarkInserts != 0 || stats.VisitedResetEpochAdvances != 0 || stats.ExactCandidateOrderObservations != 0 {
 		tb.Fatalf("stats=%+v want benchmark/debug counters suppressed", stats)
 	}
 }
 
 func assertVectorIndexSearchDebugCountersZero2126(tb testing.TB, stats VectorIndexSearchStats) {
 	tb.Helper()
-	if stats.BenchmarkDebugSearches != 0 || stats.NeighborTiles != 0 || stats.Layer0EdgeVisits != 0 || stats.FrontierPushes != 0 || stats.TopKInsertAttempts != 0 || stats.VisitedMarkChecks != 0 || stats.ExactCandidateOrderObservations != 0 {
+	if stats.BenchmarkDebugSearches != 0 || stats.NeighborTiles != 0 || stats.Layer0AdjacencyLoads != 0 || stats.Layer0EdgeVisits != 0 || stats.Layer0StopChecks != 0 || stats.Layer0ScoreTiles != 0 || stats.FrontierPushes != 0 || stats.FrontierSiftUpCalls != 0 || stats.CandidateComparisons != 0 || stats.TopKInsertAttempts != 0 || stats.VisitedMarkChecks != 0 || stats.VisitedMarkInserts != 0 || stats.VisitedResetEpochAdvances != 0 || stats.ExactCandidateOrderObservations != 0 {
 		tb.Fatalf("stats=%+v want benchmark/debug counters suppressed", stats)
 	}
 }

--- a/TreeDB/collections/column_vector_graph_quantized_bench_test.go
+++ b/TreeDB/collections/column_vector_graph_quantized_bench_test.go
@@ -91,6 +91,67 @@ func BenchmarkColumnGraphScalarU8QuantizedScorePlanes1926(b *testing.B) {
 	}
 }
 
+func BenchmarkColumnGraphScalarU8QuantizedTraversalCounters2271(b *testing.B) {
+	shape := columnGraphScalarU8QuantizedBenchShape1926{rows: 1024, dims: 128, m: 16, topK: 10, efSearch: 128, queryOrdinal: 37}
+	fixture := openColumnGraphScalarU8QuantizedBenchFixture1926(b, shape, true)
+	defer fixture.close()
+
+	cases := []struct {
+		name               string
+		mode               VectorIndexQueryMode
+		rerankCandidates   int
+		quantizedIndexName string
+	}{
+		{name: "mode=exact", mode: VectorIndexQueryModeExact},
+		{name: "mode=quantized_only", mode: VectorIndexQueryModeQuantizedOnly, quantizedIndexName: columnGraphScalarU8QuantizedBenchIndexName1926},
+		{name: "mode=quantized_rerank/candidates=32", mode: VectorIndexQueryModeQuantizedRerank, quantizedIndexName: columnGraphScalarU8QuantizedBenchIndexName1926, rerankCandidates: 32},
+	}
+	for _, tc := range cases {
+		tc := tc
+		b.Run(tc.name, func(b *testing.B) {
+			searcher, err := fixture.collection.OpenVectorIndexSearcher(VectorIndexSearcherOptions{IndexName: fixture.definition.Name, MaxDecodedBlocks: 1})
+			if err != nil {
+				b.Fatalf("OpenVectorIndexSearcher: %v", err)
+			}
+			defer func() { _ = searcher.Close() }()
+			opts := VectorIndexSearcherSearchOptions{
+				Query:                     fixture.query,
+				QueryMode:                 tc.mode,
+				QuantizedIndexName:        tc.quantizedIndexName,
+				QuantizedRerankCandidates: tc.rerankCandidates,
+				TopK:                      fixture.shape.topK,
+				EfSearch:                  fixture.shape.efSearch,
+				StatsMode:                 VectorIndexSearchStatsModeBenchmarkDebug,
+			}
+			var buffer VectorIndexSearchBuffer
+			warm, err := searcher.SearchWithBuffer(opts, &buffer)
+			if err != nil {
+				b.Fatalf("warm SearchWithBuffer: %v", err)
+			}
+			if len(warm.Results) == 0 || warm.Stats.BenchmarkDebugSearches != 1 {
+				b.Fatalf("warm response results=%d stats=%+v want benchmark_debug counters", len(warm.Results), warm.Stats)
+			}
+
+			var stats VectorIndexSearchStats
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				response, err := searcher.SearchWithBuffer(opts, &buffer)
+				if err != nil {
+					b.Fatalf("SearchWithBuffer: %v", err)
+				}
+				if len(response.Results) == 0 {
+					b.Fatalf("SearchWithBuffer returned no results")
+				}
+				columnPhysicalScanBenchSum += int64(response.Results[0].Ordinal)
+				addColumnGraphScalarU8QuantizedBenchmarkStats1926(&stats, response.Stats)
+			}
+			b.StopTimer()
+			reportColumnGraphScalarU8QuantizedTraversalCounterMetrics2271(b, fixture, stats)
+		})
+	}
+}
+
 func BenchmarkColumnGraphScalarU8QuantizedRebuildStorage1926(b *testing.B) {
 	shape := columnGraphScalarU8QuantizedBenchShape1926{rows: 256, dims: 128, m: 16, topK: 10, efSearch: 128, queryOrdinal: 37}
 	for _, tc := range []struct {
@@ -266,6 +327,60 @@ func addColumnGraphScalarU8QuantizedBenchmarkStats1926(dst *VectorIndexSearchSta
 	dst.ResultIDTypedBytesState += src.ResultIDTypedBytesState
 	dst.RowRefVectorSourceState += src.RowRefVectorSourceState
 	dst.RowRefVectorSourceLegacyGraphIDs += src.RowRefVectorSourceLegacyGraphIDs
+	dst.BenchmarkDebugSearches += src.BenchmarkDebugSearches
+	dst.NeighborTiles += src.NeighborTiles
+	dst.NeighborTileNeighbors += src.NeighborTileNeighbors
+	if src.NeighborTileMaxSize > dst.NeighborTileMaxSize {
+		dst.NeighborTileMaxSize = src.NeighborTileMaxSize
+	}
+	dst.ScoredNeighbors += src.ScoredNeighbors
+	dst.SkippedNeighbors += src.SkippedNeighbors
+	dst.AlreadyVisitedSkips += src.AlreadyVisitedSkips
+	dst.FilterSkips += src.FilterSkips
+	dst.UpperLayerScores += src.UpperLayerScores
+	dst.UpperLayerScoreTiles += src.UpperLayerScoreTiles
+	dst.UpperLayerScoreTileCandidates += src.UpperLayerScoreTileCandidates
+	if src.UpperLayerScoreTileMaxSize > dst.UpperLayerScoreTileMaxSize {
+		dst.UpperLayerScoreTileMaxSize = src.UpperLayerScoreTileMaxSize
+	}
+	dst.UpperLayerAdjacencyLoads += src.UpperLayerAdjacencyLoads
+	dst.UpperLayerAdjacencyNeighbors += src.UpperLayerAdjacencyNeighbors
+	dst.UpperLayerEdgeVisits += src.UpperLayerEdgeVisits
+	dst.Layer0Scores += src.Layer0Scores
+	dst.Layer0ScoreTiles += src.Layer0ScoreTiles
+	dst.Layer0ScoreTileCandidates += src.Layer0ScoreTileCandidates
+	if src.Layer0ScoreTileMaxSize > dst.Layer0ScoreTileMaxSize {
+		dst.Layer0ScoreTileMaxSize = src.Layer0ScoreTileMaxSize
+	}
+	dst.Layer0AdjacencyLoads += src.Layer0AdjacencyLoads
+	dst.Layer0AdjacencyNeighbors += src.Layer0AdjacencyNeighbors
+	dst.Layer0EdgeVisits += src.Layer0EdgeVisits
+	dst.Layer0ScoredNeighbors += src.Layer0ScoredNeighbors
+	dst.Layer0AlreadyVisitedSkips += src.Layer0AlreadyVisitedSkips
+	dst.Layer0FilterSkips += src.Layer0FilterSkips
+	dst.Layer0StopChecks += src.Layer0StopChecks
+	dst.Layer0StopTrue += src.Layer0StopTrue
+	dst.Layer0StopFalse += src.Layer0StopFalse
+	dst.CandidateComparisons += src.CandidateComparisons
+	dst.FrontierComparisons += src.FrontierComparisons
+	dst.TopKComparisons += src.TopKComparisons
+	dst.FrontierPushes += src.FrontierPushes
+	dst.FrontierPops += src.FrontierPops
+	dst.FrontierPopMisses += src.FrontierPopMisses
+	dst.FrontierSiftUpCalls += src.FrontierSiftUpCalls
+	dst.FrontierSiftDownCalls += src.FrontierSiftDownCalls
+	dst.FrontierSiftUpSteps += src.FrontierSiftUpSteps
+	dst.FrontierSiftDownSteps += src.FrontierSiftDownSteps
+	dst.TopKInsertAttempts += src.TopKInsertAttempts
+	dst.TopKInsertSuccesses += src.TopKInsertSuccesses
+	dst.TopKInsertRejections += src.TopKInsertRejections
+	dst.TopKShiftSteps += src.TopKShiftSteps
+	dst.VisitedMarkChecks += src.VisitedMarkChecks
+	dst.VisitedMarkHits += src.VisitedMarkHits
+	dst.VisitedMarkMisses += src.VisitedMarkMisses
+	dst.VisitedMarkInserts += src.VisitedMarkInserts
+	dst.VisitedResetEpochAdvances += src.VisitedResetEpochAdvances
+	dst.VisitedResetClearedRows += src.VisitedResetClearedRows
 }
 
 func reportColumnGraphScalarU8QuantizedBenchShapeMetrics1926(b *testing.B, shape columnGraphScalarU8QuantizedBenchShape1926) {
@@ -326,6 +441,63 @@ func reportColumnGraphScalarU8QuantizedScorePlaneMetrics1926(b *testing.B, fixtu
 	b.ReportMetric(float64(fixture.quantizedAssetBytes), "quantized_asset_B_total")
 	if fixture.shape.rows > 0 {
 		b.ReportMetric(float64(fixture.quantizedAssetBytes)/float64(fixture.shape.rows), "quantized_asset_B/vector")
+	}
+}
+
+func reportColumnGraphScalarU8QuantizedTraversalCounterMetrics2271(b *testing.B, fixture columnGraphScalarU8QuantizedBenchFixture1926, stats VectorIndexSearchStats) {
+	b.Helper()
+	reportColumnGraphScalarU8QuantizedBenchShapeMetrics1926(b, fixture.shape)
+	if elapsed := b.Elapsed().Seconds(); elapsed > 0 {
+		b.ReportMetric(float64(b.N)/elapsed, "ops/sec")
+	}
+	denom := float64(b.N)
+	if denom == 0 {
+		denom = 1
+	}
+	b.ReportMetric(2271, "traversal_counter_issue")
+	b.ReportMetric(float64(stats.BenchmarkDebugSearches)/denom, "benchmark_debug_searches/search")
+	b.ReportMetric(float64(stats.Candidates)/denom, "candidates/search")
+	b.ReportMetric(float64(stats.VisitedEdges)/denom, "visited_edges/search")
+	b.ReportMetric(float64(stats.NeighborTiles)/denom, "adjacency_layer_loads/search")
+	b.ReportMetric(float64(stats.NeighborTileNeighbors)/denom, "adjacency_loaded_neighbors/search")
+	b.ReportMetric(float64(stats.NeighborTileMaxSize), "adjacency_layer_max_neighbors")
+	b.ReportMetric(float64(stats.UpperLayerAdjacencyLoads)/denom, "upper_layer_adjacency_loads/search")
+	b.ReportMetric(float64(stats.UpperLayerAdjacencyNeighbors)/denom, "upper_layer_adjacency_neighbors/search")
+	b.ReportMetric(float64(stats.UpperLayerEdgeVisits)/denom, "upper_layer_neighbors_iterated/search")
+	b.ReportMetric(float64(stats.Layer0AdjacencyLoads)/denom, "layer0_adjacency_loads/search")
+	b.ReportMetric(float64(stats.Layer0AdjacencyNeighbors)/denom, "layer0_adjacency_neighbors/search")
+	b.ReportMetric(float64(stats.Layer0EdgeVisits)/denom, "layer0_neighbors_iterated/search")
+	b.ReportMetric(float64(stats.UpperLayerScoreTiles)/denom, "upper_layer_score_tiles/search")
+	b.ReportMetric(float64(stats.UpperLayerScoreTileCandidates)/denom, "upper_layer_score_tile_candidates/search")
+	b.ReportMetric(float64(stats.UpperLayerScoreTileMaxSize), "upper_layer_score_tile_max_size")
+	b.ReportMetric(float64(stats.Layer0ScoreTiles)/denom, "layer0_score_tiles/search")
+	b.ReportMetric(float64(stats.Layer0ScoreTileCandidates)/denom, "layer0_score_tile_candidates/search")
+	b.ReportMetric(float64(stats.Layer0ScoreTileMaxSize), "layer0_score_tile_max_size")
+	b.ReportMetric(float64(stats.CandidateComparisons)/denom, "candidate_comparisons/search")
+	b.ReportMetric(float64(stats.FrontierComparisons)/denom, "frontier_comparisons/search")
+	b.ReportMetric(float64(stats.TopKComparisons)/denom, "top_k_comparisons/search")
+	b.ReportMetric(float64(stats.FrontierPushes)/denom, "frontier_pushes/search")
+	b.ReportMetric(float64(stats.FrontierPops)/denom, "frontier_pops/search")
+	b.ReportMetric(float64(stats.FrontierPopMisses)/denom, "frontier_pop_misses/search")
+	b.ReportMetric(float64(stats.FrontierSiftUpCalls)/denom, "frontier_sift_up_calls/search")
+	b.ReportMetric(float64(stats.FrontierSiftDownCalls)/denom, "frontier_sift_down_calls/search")
+	b.ReportMetric(float64(stats.FrontierSiftUpSteps)/denom, "frontier_sift_up_steps/search")
+	b.ReportMetric(float64(stats.FrontierSiftDownSteps)/denom, "frontier_sift_down_steps/search")
+	b.ReportMetric(float64(stats.TopKInsertAttempts)/denom, "top_k_insert_attempts/search")
+	b.ReportMetric(float64(stats.TopKInsertSuccesses)/denom, "top_k_insert_successes/search")
+	b.ReportMetric(float64(stats.TopKInsertRejections)/denom, "top_k_insert_rejections/search")
+	b.ReportMetric(float64(stats.TopKShiftSteps)/denom, "top_k_shift_steps/search")
+	b.ReportMetric(float64(stats.VisitedMarkChecks)/denom, "visited_mark_checks/search")
+	b.ReportMetric(float64(stats.VisitedMarkHits)/denom, "visited_mark_hits/search")
+	b.ReportMetric(float64(stats.VisitedMarkMisses)/denom, "visited_mark_misses/search")
+	b.ReportMetric(float64(stats.VisitedMarkInserts)/denom, "visited_mark_inserts/search")
+	b.ReportMetric(float64(stats.VisitedResetEpochAdvances)/denom, "visited_reset_epoch_advances/search")
+	b.ReportMetric(float64(stats.VisitedResetClearedRows)/denom, "visited_reset_cleared_rows/search")
+	b.ReportMetric(float64(stats.Layer0StopChecks)/denom, "layer0_stop_checks/search")
+	b.ReportMetric(float64(stats.Layer0StopTrue)/denom, "layer0_stop_true/search")
+	b.ReportMetric(float64(stats.Layer0StopFalse)/denom, "layer0_stop_false/search")
+	if stats.VisitedNodes > 0 {
+		b.ReportMetric(float64(stats.VisitedEdges)/float64(stats.VisitedNodes), "edges_per_visited_node")
 	}
 }
 

--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -455,32 +455,50 @@ type columnVectorGraphNativeSearchStats struct {
 	NeighborTileSize9To16  uint64
 	NeighborTileSize17Plus uint64
 
-	ScoreBatchSingletons      uint64
-	ScoreBatchSize2To4        uint64
-	ScoreBatchSize5To8        uint64
-	ScoreBatchSize9To16       uint64
-	ScoreBatchSize17Plus      uint64
-	ScoredNeighbors           uint64
-	SkippedNeighbors          uint64
-	AlreadyVisitedSkips       uint64
-	FilterSkips               uint64
-	UpperLayerScores          uint64
-	UpperLayerEntryScores     uint64
-	UpperLayerNeighborScores  uint64
-	UpperLayerEdgeVisits      uint64
-	UpperLayerScoredNeighbors uint64
-	UpperLayerFilterSkips     uint64
-	Layer0Scores              uint64
-	Layer0SeedScores          uint64
-	Layer0NeighborScores      uint64
-	Layer0EdgeVisits          uint64
-	Layer0ScoredNeighbors     uint64
-	Layer0AlreadyVisitedSkips uint64
-	Layer0FilterSkips         uint64
+	ScoreBatchSingletons          uint64
+	ScoreBatchSize2To4            uint64
+	ScoreBatchSize5To8            uint64
+	ScoreBatchSize9To16           uint64
+	ScoreBatchSize17Plus          uint64
+	ScoredNeighbors               uint64
+	SkippedNeighbors              uint64
+	AlreadyVisitedSkips           uint64
+	FilterSkips                   uint64
+	UpperLayerScores              uint64
+	UpperLayerEntryScores         uint64
+	UpperLayerNeighborScores      uint64
+	UpperLayerScoreTiles          uint64
+	UpperLayerScoreTileCandidates uint64
+	UpperLayerScoreTileMaxSize    uint64
+	UpperLayerAdjacencyLoads      uint64
+	UpperLayerAdjacencyNeighbors  uint64
+	UpperLayerEdgeVisits          uint64
+	UpperLayerScoredNeighbors     uint64
+	UpperLayerFilterSkips         uint64
+	Layer0Scores                  uint64
+	Layer0SeedScores              uint64
+	Layer0NeighborScores          uint64
+	Layer0ScoreTiles              uint64
+	Layer0ScoreTileCandidates     uint64
+	Layer0ScoreTileMaxSize        uint64
+	Layer0AdjacencyLoads          uint64
+	Layer0AdjacencyNeighbors      uint64
+	Layer0EdgeVisits              uint64
+	Layer0ScoredNeighbors         uint64
+	Layer0AlreadyVisitedSkips     uint64
+	Layer0FilterSkips             uint64
+	Layer0StopChecks              uint64
+	Layer0StopTrue                uint64
+	Layer0StopFalse               uint64
 
+	CandidateComparisons  uint64
+	FrontierComparisons   uint64
+	TopKComparisons       uint64
 	FrontierPushes        uint64
 	FrontierPops          uint64
 	FrontierPopMisses     uint64
+	FrontierSiftUpCalls   uint64
+	FrontierSiftDownCalls uint64
 	FrontierSiftUpSteps   uint64
 	FrontierSiftDownSteps uint64
 
@@ -489,9 +507,12 @@ type columnVectorGraphNativeSearchStats struct {
 	TopKInsertRejections uint64
 	TopKShiftSteps       uint64
 
-	VisitedMarkChecks uint64
-	VisitedMarkHits   uint64
-	VisitedMarkMisses uint64
+	VisitedMarkChecks         uint64
+	VisitedMarkHits           uint64
+	VisitedMarkMisses         uint64
+	VisitedMarkInserts        uint64
+	VisitedResetEpochAdvances uint64
+	VisitedResetClearedRows   uint64
 
 	ExactModeSearches                     uint64
 	ExactCandidateOrderObservations       uint64
@@ -545,7 +566,7 @@ func newColumnVectorGraphNativeSearchDebugCounters(stats *columnVectorGraphNativ
 	return &columnVectorGraphNativeSearchDebugCounters{stats: stats, exactMode: exactMode}
 }
 
-func (d *columnVectorGraphNativeSearchDebugCounters) recordNeighborTile(size int) {
+func (d *columnVectorGraphNativeSearchDebugCounters) recordAdjacencyLayerLoad(layer int, size int) {
 	if d == nil || d.stats == nil {
 		return
 	}
@@ -553,10 +574,18 @@ func (d *columnVectorGraphNativeSearchDebugCounters) recordNeighborTile(size int
 		size = 0
 	}
 	s := d.stats
+	size64 := uint64(size)
 	s.NeighborTiles++
-	s.NeighborTileNeighbors += uint64(size)
-	if uint64(size) > s.NeighborTileMaxSize {
-		s.NeighborTileMaxSize = uint64(size)
+	s.NeighborTileNeighbors += size64
+	if size64 > s.NeighborTileMaxSize {
+		s.NeighborTileMaxSize = size64
+	}
+	if layer == 0 {
+		s.Layer0AdjacencyLoads++
+		s.Layer0AdjacencyNeighbors += size64
+	} else {
+		s.UpperLayerAdjacencyLoads++
+		s.UpperLayerAdjacencyNeighbors += size64
 	}
 	switch {
 	case size == 0:
@@ -572,6 +601,49 @@ func (d *columnVectorGraphNativeSearchDebugCounters) recordNeighborTile(size int
 	default:
 		s.NeighborTileSize17Plus++
 	}
+}
+
+func (d *columnVectorGraphNativeSearchDebugCounters) recordCandidateComparison(frontier bool) {
+	if d == nil || d.stats == nil {
+		return
+	}
+	d.stats.CandidateComparisons++
+	if frontier {
+		d.stats.FrontierComparisons++
+		return
+	}
+	d.stats.TopKComparisons++
+}
+
+func (d *columnVectorGraphNativeSearchDebugCounters) recordVisitedInsert() {
+	if d == nil || d.stats == nil {
+		return
+	}
+	d.stats.VisitedMarkInserts++
+}
+
+func (d *columnVectorGraphNativeSearchDebugCounters) recordVisitedReset(clearedRows int) {
+	if d == nil || d.stats == nil {
+		return
+	}
+	d.stats.VisitedResetEpochAdvances++
+	if clearedRows > 0 {
+		d.stats.VisitedResetClearedRows += uint64(clearedRows)
+	}
+}
+
+func (d *columnVectorGraphNativeSearchDebugCounters) recordLayer0StopCheck(candidate columnVectorGraphSearchCandidate, top []columnVectorGraphSearchCandidate, efSearch int) bool {
+	stop := columnVectorGraphLayer0SearchShouldStop(candidate, top, efSearch)
+	if d == nil || d.stats == nil {
+		return stop
+	}
+	d.stats.Layer0StopChecks++
+	if stop {
+		d.stats.Layer0StopTrue++
+		return true
+	}
+	d.stats.Layer0StopFalse++
+	return false
 }
 
 func recordColumnVectorGraphScoreBatchDebugStats(stats *columnVectorGraphNativeSearchStats, tileSize int) {
@@ -674,17 +746,37 @@ func (d *columnVectorGraphNativeSearchDebugCounters) recordScoresCount(context c
 	case columnVectorGraphNativeSearchScoreContextUpperEntry:
 		s.UpperLayerScores += count64
 		s.UpperLayerEntryScores += count64
+		s.UpperLayerScoreTiles++
+		s.UpperLayerScoreTileCandidates += count64
+		if count64 > s.UpperLayerScoreTileMaxSize {
+			s.UpperLayerScoreTileMaxSize = count64
+		}
 	case columnVectorGraphNativeSearchScoreContextUpperNeighbor:
 		s.UpperLayerScores += count64
 		s.UpperLayerNeighborScores += count64
+		s.UpperLayerScoreTiles++
+		s.UpperLayerScoreTileCandidates += count64
+		if count64 > s.UpperLayerScoreTileMaxSize {
+			s.UpperLayerScoreTileMaxSize = count64
+		}
 		s.UpperLayerScoredNeighbors += count64
 		s.ScoredNeighbors += count64
 	case columnVectorGraphNativeSearchScoreContextLayer0Seed:
 		s.Layer0Scores += count64
 		s.Layer0SeedScores += count64
+		s.Layer0ScoreTiles++
+		s.Layer0ScoreTileCandidates += count64
+		if count64 > s.Layer0ScoreTileMaxSize {
+			s.Layer0ScoreTileMaxSize = count64
+		}
 	case columnVectorGraphNativeSearchScoreContextLayer0Neighbor:
 		s.Layer0Scores += count64
 		s.Layer0NeighborScores += count64
+		s.Layer0ScoreTiles++
+		s.Layer0ScoreTileCandidates += count64
+		if count64 > s.Layer0ScoreTileMaxSize {
+			s.Layer0ScoreTileMaxSize = count64
+		}
 		s.Layer0ScoredNeighbors += count64
 		s.ScoredNeighbors += count64
 	}
@@ -1237,11 +1329,19 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 	if queryMode == columnVectorGraphNativeSearchQueryModeQuantizedRerank && scoreTileCapacity < retainedCandidateLimit {
 		scoreTileCapacity = retainedCandidateLimit
 	}
+	statsMode := opts.StatsMode.normalized()
+	visitEpochBeforePrepare := uint64(0)
+	if statsMode == columnVectorGraphNativeSearchStatsModeBenchmarkDebug {
+		visitEpochBeforePrepare = scratch.visitEpoch
+	}
 	if err := scratch.prepare(rowCount, r.def.Dimensions, degree, topK, efSearch, scoreTileCapacity, wavefrontWidth); err != nil {
 		return nil, columnVectorGraphNativeSearchStats{}, fmt.Errorf("collections: column_graph %q native search scratch prepare: %w", r.def.Name, err)
 	}
+	visitResetClearedRows := 0
+	if statsMode == columnVectorGraphNativeSearchStatsModeBenchmarkDebug && visitEpochBeforePrepare == math.MaxUint64 {
+		visitResetClearedRows = rowCount
+	}
 
-	statsMode := opts.StatsMode.normalized()
 	candidateLimit := uint64(efSearch)
 	var visitedCandidates uint64
 	var loopEdgeVisits uint64
@@ -1257,6 +1357,7 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 		exactTraversalForDebug := traversalMode == columnVectorGraphNativeSearchTraversalModeExact && candidateLimit == uint64(candidateRowCount)
 		debugCounters = newColumnVectorGraphNativeSearchDebugCounters(&stats, exactTraversalForDebug)
 		if debugCounters != nil {
+			debugCounters.recordVisitedReset(visitResetClearedRows)
 			debugStats = debugCounters.stats
 		}
 	}
@@ -1335,6 +1436,9 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 		}
 	}
 	visitMarks[entryOrdinal] = visitEpoch
+	if debugCounters != nil {
+		debugCounters.recordVisitedInsert()
+	}
 	if err := r.scoreAndPushFrontierVisited(plan, singleBlockView, query, queryInvNorm, entryOrdinal, retainedCandidateLimit, scratch, hotStats, &visitedCandidates, preparedMinimalCounters, debugCounters, columnVectorGraphNativeSearchScoreContextLayer0Seed); err != nil {
 		return nil, stats, err
 	}
@@ -1362,12 +1466,19 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 				}
 				nextSeed = seed + 1
 				visitMarks[seed] = visitEpoch
+				if debugCounters != nil {
+					debugCounters.recordVisitedInsert()
+				}
 				if err := r.scoreAndPushFrontierVisited(plan, singleBlockView, query, queryInvNorm, seed, retainedCandidateLimit, scratch, hotStats, &visitedCandidates, preparedMinimalCounters, debugCounters, columnVectorGraphNativeSearchScoreContextLayer0Seed); err != nil {
 					return nil, stats, err
 				}
 				continue
 			}
-			if columnVectorGraphLayer0SearchShouldStop(candidate, scratch.top, retainedCandidateLimit) {
+			if debugCounters != nil {
+				if debugCounters.recordLayer0StopCheck(candidate, scratch.top, retainedCandidateLimit) {
+					break
+				}
+			} else if columnVectorGraphLayer0SearchShouldStop(candidate, scratch.top, retainedCandidateLimit) {
 				break
 			}
 			adjacency, err := r.expandCandidateAdjacencyLayer(plan, singleBlockView, candidate.ordinal, 0, scratch, hotStats, preparedMinimalCounters, debugCounters)
@@ -1410,9 +1521,13 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 						if !columnVectorGraphCandidateRowAllowed(candidateRows, hasCandidateRows, neighborOrdinal) {
 							if debugCounters != nil {
 								debugCounters.recordFilterSkip(true)
+								debugCounters.recordVisitedInsert()
 							}
 							visitMarks[neighborOrdinal] = visitEpoch
 							continue
+						}
+						if debugCounters != nil {
+							debugCounters.recordVisitedInsert()
 						}
 						visitMarks[neighborOrdinal] = visitEpoch
 						tile = append(tile, neighborOrdinal)
@@ -1454,9 +1569,13 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 				if !columnVectorGraphCandidateRowAllowed(candidateRows, hasCandidateRows, neighborOrdinal) {
 					if debugCounters != nil {
 						debugCounters.recordFilterSkip(true)
+						debugCounters.recordVisitedInsert()
 					}
 					visitMarks[neighborOrdinal] = visitEpoch
 					continue
+				}
+				if debugCounters != nil {
+					debugCounters.recordVisitedInsert()
 				}
 				visitMarks[neighborOrdinal] = visitEpoch
 				if err := r.scoreAndPushFrontierVisited(plan, singleBlockView, query, queryInvNorm, neighborOrdinal, retainedCandidateLimit, scratch, hotStats, &visitedCandidates, preparedMinimalCounters, debugCounters, columnVectorGraphNativeSearchScoreContextLayer0Neighbor); err != nil {
@@ -1570,6 +1689,9 @@ func (r *columnVectorGraphPhysicalRowReader) searchLayer0Wavefront(plan *columnV
 				}
 				*nextSeed = seed + 1
 				visitMarks[seed] = visitEpoch
+				if debugCounters != nil {
+					debugCounters.recordVisitedInsert()
+				}
 				if err := r.scoreAndPushFrontierVisited(plan, singleBlockView, query, queryInvNorm, seed, retainedCandidateLimit, scratch, stats, visitedCandidates, preparedMinimal, debugCounters, columnVectorGraphNativeSearchScoreContextLayer0Seed); err != nil {
 					return err
 				}
@@ -1587,6 +1709,9 @@ func (r *columnVectorGraphPhysicalRowReader) searchLayer0Wavefront(plan *columnV
 			}
 			*nextSeed = seed + 1
 			visitMarks[seed] = visitEpoch
+			if debugCounters != nil {
+				debugCounters.recordVisitedInsert()
+			}
 			if err := r.scoreAndPushFrontierVisited(plan, singleBlockView, query, queryInvNorm, seed, retainedCandidateLimit, scratch, stats, visitedCandidates, preparedMinimal, debugCounters, columnVectorGraphNativeSearchScoreContextLayer0Seed); err != nil {
 				return err
 			}
@@ -1633,9 +1758,13 @@ func (r *columnVectorGraphPhysicalRowReader) searchLayer0Wavefront(plan *columnV
 				if !columnVectorGraphCandidateRowAllowed(candidateRows, hasCandidateRows, neighborOrdinal) {
 					if debugCounters != nil {
 						debugCounters.recordFilterSkip(true)
+						debugCounters.recordVisitedInsert()
 					}
 					visitMarks[neighborOrdinal] = visitEpoch
 					continue
+				}
+				if debugCounters != nil {
+					debugCounters.recordVisitedInsert()
 				}
 				visitMarks[neighborOrdinal] = visitEpoch
 				tile = append(tile, neighborOrdinal)
@@ -2150,7 +2279,7 @@ func (r *columnVectorGraphPhysicalRowReader) expandCandidateAdjacencyLayer(plan 
 			return nil, err
 		}
 		if debugCounters != nil {
-			debugCounters.recordNeighborTile(len(layerAdjacency))
+			debugCounters.recordAdjacencyLayerLoad(layer, len(layerAdjacency))
 		}
 		if preparedMinimal != nil {
 			preparedMinimal.recordPreparedAdjacency(len(layerAdjacency))
@@ -2166,7 +2295,7 @@ func (r *columnVectorGraphPhysicalRowReader) expandCandidateAdjacencyLayer(plan 
 	}
 	if layerAdjacency, outcome, fallbackReason, ok := r.directAdjacencyLayerForOrdinal(ordinal, layer); ok {
 		if debugCounters != nil {
-			debugCounters.recordNeighborTile(len(layerAdjacency))
+			debugCounters.recordAdjacencyLayerLoad(layer, len(layerAdjacency))
 		}
 		if stats != nil {
 			stats.ExpansionFetches++
@@ -2192,7 +2321,7 @@ func (r *columnVectorGraphPhysicalRowReader) expandCandidateAdjacencyLayer(plan 
 		return nil, fmt.Errorf("collections: column_graph %q ordinal=%d malformed adjacency layer=%d: %w", r.def.Name, ordinal, layer, err)
 	}
 	if debugCounters != nil {
-		debugCounters.recordNeighborTile(len(layerAdjacency))
+		debugCounters.recordAdjacencyLayerLoad(layer, len(layerAdjacency))
 	}
 	if stats != nil {
 		stats.ExpansionFetches++
@@ -2464,9 +2593,11 @@ func (s *columnVectorGraphNativeSearchScratch) frontierSiftUp(idx int, candidate
 func (s *columnVectorGraphNativeSearchScratch) frontierSiftUpDebug(idx int, candidate columnVectorGraphSearchCandidate, debugCounters *columnVectorGraphNativeSearchDebugCounters) {
 	frontier := s.frontier
 	var steps uint64
+	debugCounters.stats.FrontierSiftUpCalls++
 	for idx > 0 {
 		parent := (idx - 1) / columnVectorGraphNativeFrontierHeapFanout
 		parentCandidate := frontier[parent]
+		debugCounters.recordCandidateComparison(true)
 		if !columnVectorGraphSearchCandidateBetter(candidate, parentCandidate) {
 			break
 		}
@@ -2511,6 +2642,7 @@ func (s *columnVectorGraphNativeSearchScratch) frontierSiftDownDebug(idx int, ca
 	frontier := s.frontier
 	n := len(frontier)
 	var steps uint64
+	debugCounters.stats.FrontierSiftDownCalls++
 	for {
 		firstChild := idx*columnVectorGraphNativeFrontierHeapFanout + 1
 		if firstChild >= n {
@@ -2523,11 +2655,13 @@ func (s *columnVectorGraphNativeSearchScratch) frontierSiftDownDebug(idx int, ca
 			lastChild = n
 		}
 		for next := firstChild + 1; next < lastChild; next++ {
+			debugCounters.recordCandidateComparison(true)
 			if columnVectorGraphSearchCandidateBetter(frontier[next], childCandidate) {
 				child = next
 				childCandidate = frontier[next]
 			}
 		}
+		debugCounters.recordCandidateComparison(true)
 		if !columnVectorGraphSearchCandidateBetter(childCandidate, candidate) {
 			break
 		}
@@ -2565,7 +2699,11 @@ func (s *columnVectorGraphNativeSearchScratch) insertTopDebug(limit int, candida
 		return false
 	}
 	pos := len(s.top)
-	for pos > 0 && columnVectorGraphSearchCandidateBetter(candidate, s.top[pos-1]) {
+	for pos > 0 {
+		debugCounters.recordCandidateComparison(false)
+		if !columnVectorGraphSearchCandidateBetter(candidate, s.top[pos-1]) {
+			break
+		}
 		pos--
 	}
 	if pos >= limit {

--- a/TreeDB/collections/column_vector_graph_traversal_microbench_2271_test.go
+++ b/TreeDB/collections/column_vector_graph_traversal_microbench_2271_test.go
@@ -1,0 +1,63 @@
+package collections
+
+import "testing"
+
+func BenchmarkColumnVectorGraphFrontierHeapOperations2271(b *testing.B) {
+	const heapSize = 128
+	var scratch columnVectorGraphNativeSearchScratch
+	scratch.frontier = make([]columnVectorGraphSearchCandidate, 0, heapSize)
+	var checksum int64
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		scratch.frontier = scratch.frontier[:0]
+		seed := uint32(i + 1)
+		for j := 0; j < heapSize; j++ {
+			seed = seed*1664525 + 1013904223
+			scratch.pushFrontier(columnVectorGraphSearchCandidate{ordinal: j, score: float64(seed & 0xffff)})
+		}
+		for {
+			candidate, ok := scratch.popFrontier()
+			if !ok {
+				break
+			}
+			checksum += int64(candidate.ordinal)
+		}
+	}
+	b.StopTimer()
+	columnPhysicalScanBenchSum += checksum
+	b.ReportMetric(2271, "traversal_microbench_issue")
+	b.ReportMetric(float64(columnVectorGraphNativeFrontierHeapFanout), "frontier_heap_fanout")
+	b.ReportMetric(float64(heapSize), "frontier_heap_items_per_iteration")
+}
+
+func BenchmarkColumnVectorGraphAdjacencyIteration2271(b *testing.B) {
+	if !columnGraphTypedColumnMmapDirectViewSupportedForTest() {
+		b.Skip("adjacency iteration benchmark requires mmap_direct prepared typed-column views")
+	}
+	shape := columnVectorGraphSearchTopologyParityProductionShape2091()
+	rows := columnVectorGraphSearchTopologyParityRows2091(b, shape)
+	closeFn, reader, _ := openColumnVectorGraphSearchTopologyParityReader2091(b, shape, rows, columnVectorGraphSearchTopologyParityModeCurrentPrepared2091)
+	defer closeFn()
+	if reader.adjacencyLayerSources == nil {
+		b.Fatalf("reader missing prepared adjacency layer sources")
+	}
+	var checksum uint64
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		ordinal := i % shape.rows
+		neighbors, _, reason, ok := reader.directAdjacencyLayerForOrdinal(ordinal, 0)
+		if !ok {
+			b.Fatalf("directAdjacencyLayerForOrdinal ordinal=%d unavailable reason=%s", ordinal, reason)
+		}
+		for _, neighbor := range neighbors {
+			checksum += uint64(neighbor)
+		}
+	}
+	b.StopTimer()
+	columnPhysicalScanBenchSum += int64(checksum)
+	b.ReportMetric(2271, "traversal_microbench_issue")
+	b.ReportMetric(float64(shape.rows), "rows")
+	b.ReportMetric(float64(shape.degree), "degree")
+}

--- a/TreeDB/collections/vector_index_search.go
+++ b/TreeDB/collections/vector_index_search.go
@@ -424,19 +424,37 @@ type VectorIndexSearchStats struct {
 	UpperLayerScores                      uint64 `json:"upper_layer_scores,omitempty"`
 	UpperLayerEntryScores                 uint64 `json:"upper_layer_entry_scores,omitempty"`
 	UpperLayerNeighborScores              uint64 `json:"upper_layer_neighbor_scores,omitempty"`
+	UpperLayerScoreTiles                  uint64 `json:"upper_layer_score_tiles,omitempty"`
+	UpperLayerScoreTileCandidates         uint64 `json:"upper_layer_score_tile_candidates,omitempty"`
+	UpperLayerScoreTileMaxSize            uint64 `json:"upper_layer_score_tile_max_size,omitempty"`
+	UpperLayerAdjacencyLoads              uint64 `json:"upper_layer_adjacency_loads,omitempty"`
+	UpperLayerAdjacencyNeighbors          uint64 `json:"upper_layer_adjacency_neighbors,omitempty"`
 	UpperLayerEdgeVisits                  uint64 `json:"upper_layer_edge_visits,omitempty"`
 	UpperLayerScoredNeighbors             uint64 `json:"upper_layer_scored_neighbors,omitempty"`
 	UpperLayerFilterSkips                 uint64 `json:"upper_layer_filter_skips,omitempty"`
 	Layer0Scores                          uint64 `json:"layer0_scores,omitempty"`
 	Layer0SeedScores                      uint64 `json:"layer0_seed_scores,omitempty"`
 	Layer0NeighborScores                  uint64 `json:"layer0_neighbor_scores,omitempty"`
+	Layer0ScoreTiles                      uint64 `json:"layer0_score_tiles,omitempty"`
+	Layer0ScoreTileCandidates             uint64 `json:"layer0_score_tile_candidates,omitempty"`
+	Layer0ScoreTileMaxSize                uint64 `json:"layer0_score_tile_max_size,omitempty"`
+	Layer0AdjacencyLoads                  uint64 `json:"layer0_adjacency_loads,omitempty"`
+	Layer0AdjacencyNeighbors              uint64 `json:"layer0_adjacency_neighbors,omitempty"`
 	Layer0EdgeVisits                      uint64 `json:"layer0_edge_visits,omitempty"`
 	Layer0ScoredNeighbors                 uint64 `json:"layer0_scored_neighbors,omitempty"`
 	Layer0AlreadyVisitedSkips             uint64 `json:"layer0_already_visited_skips,omitempty"`
 	Layer0FilterSkips                     uint64 `json:"layer0_filter_skips,omitempty"`
+	Layer0StopChecks                      uint64 `json:"layer0_stop_checks,omitempty"`
+	Layer0StopTrue                        uint64 `json:"layer0_stop_true,omitempty"`
+	Layer0StopFalse                       uint64 `json:"layer0_stop_false,omitempty"`
+	CandidateComparisons                  uint64 `json:"candidate_comparisons,omitempty"`
+	FrontierComparisons                   uint64 `json:"frontier_comparisons,omitempty"`
+	TopKComparisons                       uint64 `json:"top_k_comparisons,omitempty"`
 	FrontierPushes                        uint64 `json:"frontier_pushes,omitempty"`
 	FrontierPops                          uint64 `json:"frontier_pops,omitempty"`
 	FrontierPopMisses                     uint64 `json:"frontier_pop_misses,omitempty"`
+	FrontierSiftUpCalls                   uint64 `json:"frontier_sift_up_calls,omitempty"`
+	FrontierSiftDownCalls                 uint64 `json:"frontier_sift_down_calls,omitempty"`
 	FrontierSiftUpSteps                   uint64 `json:"frontier_sift_up_steps,omitempty"`
 	FrontierSiftDownSteps                 uint64 `json:"frontier_sift_down_steps,omitempty"`
 	TopKInsertAttempts                    uint64 `json:"top_k_insert_attempts,omitempty"`
@@ -446,6 +464,9 @@ type VectorIndexSearchStats struct {
 	VisitedMarkChecks                     uint64 `json:"visited_mark_checks,omitempty"`
 	VisitedMarkHits                       uint64 `json:"visited_mark_hits,omitempty"`
 	VisitedMarkMisses                     uint64 `json:"visited_mark_misses,omitempty"`
+	VisitedMarkInserts                    uint64 `json:"visited_mark_inserts,omitempty"`
+	VisitedResetEpochAdvances             uint64 `json:"visited_reset_epoch_advances,omitempty"`
+	VisitedResetClearedRows               uint64 `json:"visited_reset_cleared_rows,omitempty"`
 	ExactModeSearches                     uint64 `json:"exact_mode_searches,omitempty"`
 	ExactCandidateOrderObservations       uint64 `json:"exact_candidate_order_observations,omitempty"`
 	ExactCandidateOrderTransitions        uint64 `json:"exact_candidate_order_transitions,omitempty"`
@@ -1243,19 +1264,37 @@ func vectorIndexSearchStatsFromInternal(searchStats columnVectorGraphNativeSearc
 		UpperLayerScores:                      searchStats.UpperLayerScores,
 		UpperLayerEntryScores:                 searchStats.UpperLayerEntryScores,
 		UpperLayerNeighborScores:              searchStats.UpperLayerNeighborScores,
+		UpperLayerScoreTiles:                  searchStats.UpperLayerScoreTiles,
+		UpperLayerScoreTileCandidates:         searchStats.UpperLayerScoreTileCandidates,
+		UpperLayerScoreTileMaxSize:            searchStats.UpperLayerScoreTileMaxSize,
+		UpperLayerAdjacencyLoads:              searchStats.UpperLayerAdjacencyLoads,
+		UpperLayerAdjacencyNeighbors:          searchStats.UpperLayerAdjacencyNeighbors,
 		UpperLayerEdgeVisits:                  searchStats.UpperLayerEdgeVisits,
 		UpperLayerScoredNeighbors:             searchStats.UpperLayerScoredNeighbors,
 		UpperLayerFilterSkips:                 searchStats.UpperLayerFilterSkips,
 		Layer0Scores:                          searchStats.Layer0Scores,
 		Layer0SeedScores:                      searchStats.Layer0SeedScores,
 		Layer0NeighborScores:                  searchStats.Layer0NeighborScores,
+		Layer0ScoreTiles:                      searchStats.Layer0ScoreTiles,
+		Layer0ScoreTileCandidates:             searchStats.Layer0ScoreTileCandidates,
+		Layer0ScoreTileMaxSize:                searchStats.Layer0ScoreTileMaxSize,
+		Layer0AdjacencyLoads:                  searchStats.Layer0AdjacencyLoads,
+		Layer0AdjacencyNeighbors:              searchStats.Layer0AdjacencyNeighbors,
 		Layer0EdgeVisits:                      searchStats.Layer0EdgeVisits,
 		Layer0ScoredNeighbors:                 searchStats.Layer0ScoredNeighbors,
 		Layer0AlreadyVisitedSkips:             searchStats.Layer0AlreadyVisitedSkips,
 		Layer0FilterSkips:                     searchStats.Layer0FilterSkips,
+		Layer0StopChecks:                      searchStats.Layer0StopChecks,
+		Layer0StopTrue:                        searchStats.Layer0StopTrue,
+		Layer0StopFalse:                       searchStats.Layer0StopFalse,
+		CandidateComparisons:                  searchStats.CandidateComparisons,
+		FrontierComparisons:                   searchStats.FrontierComparisons,
+		TopKComparisons:                       searchStats.TopKComparisons,
 		FrontierPushes:                        searchStats.FrontierPushes,
 		FrontierPops:                          searchStats.FrontierPops,
 		FrontierPopMisses:                     searchStats.FrontierPopMisses,
+		FrontierSiftUpCalls:                   searchStats.FrontierSiftUpCalls,
+		FrontierSiftDownCalls:                 searchStats.FrontierSiftDownCalls,
 		FrontierSiftUpSteps:                   searchStats.FrontierSiftUpSteps,
 		FrontierSiftDownSteps:                 searchStats.FrontierSiftDownSteps,
 		TopKInsertAttempts:                    searchStats.TopKInsertAttempts,
@@ -1265,6 +1304,9 @@ func vectorIndexSearchStatsFromInternal(searchStats columnVectorGraphNativeSearc
 		VisitedMarkChecks:                     searchStats.VisitedMarkChecks,
 		VisitedMarkHits:                       searchStats.VisitedMarkHits,
 		VisitedMarkMisses:                     searchStats.VisitedMarkMisses,
+		VisitedMarkInserts:                    searchStats.VisitedMarkInserts,
+		VisitedResetEpochAdvances:             searchStats.VisitedResetEpochAdvances,
+		VisitedResetClearedRows:               searchStats.VisitedResetClearedRows,
 		ExactModeSearches:                     searchStats.ExactModeSearches,
 		ExactCandidateOrderObservations:       searchStats.ExactCandidateOrderObservations,
 		ExactCandidateOrderTransitions:        searchStats.ExactCandidateOrderTransitions,

--- a/TreeDB/collections/vector_index_search_promotion_2105_test.go
+++ b/TreeDB/collections/vector_index_search_promotion_2105_test.go
@@ -383,17 +383,29 @@ func assertVectorIndexSearchBenchmarkDebugStats2105(tb testing.TB, stats VectorI
 	if stats.ScoredNeighbors+stats.SkippedNeighbors != stats.VisitedEdges {
 		tb.Fatalf("stats=%+v want scored+skipped neighbor buckets to reconcile", stats)
 	}
-	if stats.VisitedMarkHits+stats.VisitedMarkMisses != stats.VisitedMarkChecks || stats.VisitedMarkHits != stats.Layer0AlreadyVisitedSkips {
-		tb.Fatalf("stats=%+v want visited-mark hits/misses to reconcile", stats)
+	if stats.VisitedMarkHits+stats.VisitedMarkMisses != stats.VisitedMarkChecks || stats.VisitedMarkHits != stats.Layer0AlreadyVisitedSkips || stats.VisitedMarkInserts < stats.VisitedMarkMisses || stats.VisitedResetEpochAdvances != 1 {
+		tb.Fatalf("stats=%+v want visited-mark hits/misses/inserts/reset work to reconcile", stats)
 	}
 	if stats.FrontierPushes != stats.Candidates || stats.TopKInsertAttempts != stats.Candidates || stats.TopKInsertSuccesses+stats.TopKInsertRejections != stats.TopKInsertAttempts {
 		tb.Fatalf("stats=%+v want frontier/top-k operation counts to reconcile with candidates", stats)
 	}
+	if stats.FrontierSiftUpCalls != stats.FrontierPushes || stats.FrontierSiftDownCalls > stats.FrontierPops || stats.CandidateComparisons != stats.FrontierComparisons+stats.TopKComparisons {
+		tb.Fatalf("stats=%+v want frontier/top-k comparison and sift counters to reconcile", stats)
+	}
+	if stats.Layer0StopTrue+stats.Layer0StopFalse != stats.Layer0StopChecks || stats.Layer0StopChecks == 0 {
+		tb.Fatalf("stats=%+v want layer0 stop checks to reconcile", stats)
+	}
 	if stats.NeighborTileSize0+stats.NeighborTileSize1+stats.NeighborTileSize2To4+stats.NeighborTileSize5To8+stats.NeighborTileSize9To16+stats.NeighborTileSize17Plus != stats.NeighborTiles {
 		tb.Fatalf("stats=%+v want neighbor tile histogram to sum to neighbor_tiles", stats)
 	}
+	if stats.UpperLayerAdjacencyLoads+stats.Layer0AdjacencyLoads != stats.NeighborTiles || stats.UpperLayerAdjacencyNeighbors+stats.Layer0AdjacencyNeighbors != stats.NeighborTileNeighbors {
+		tb.Fatalf("stats=%+v want phase adjacency load counters to reconcile", stats)
+	}
 	if stats.ScoreBatchSingletons+stats.ScoreBatchSize2To4+stats.ScoreBatchSize5To8+stats.ScoreBatchSize9To16+stats.ScoreBatchSize17Plus != stats.ScoreBatchCalls {
 		tb.Fatalf("stats=%+v want score batch histogram to sum to score_batch_calls", stats)
+	}
+	if stats.UpperLayerScoreTileCandidates != stats.UpperLayerScores || stats.Layer0ScoreTileCandidates != stats.Layer0Scores || stats.UpperLayerScoreTiles+stats.Layer0ScoreTiles == 0 {
+		tb.Fatalf("stats=%+v want phase score tile counters to reconcile", stats)
 	}
 	if exactMode {
 		if stats.ExactModeSearches != 1 || stats.ExactCandidateOrderObservations != stats.Candidates {
@@ -435,19 +447,37 @@ func reportVectorIndexSearchBenchmarkDebugMetrics2105(b *testing.B, stats Vector
 	b.ReportMetric(float64(stats.UpperLayerScores), "upper_layer_scores/search")
 	b.ReportMetric(float64(stats.UpperLayerEntryScores), "upper_layer_entry_scores/search")
 	b.ReportMetric(float64(stats.UpperLayerNeighborScores), "upper_layer_neighbor_scores/search")
+	b.ReportMetric(float64(stats.UpperLayerScoreTiles), "upper_layer_score_tiles/search")
+	b.ReportMetric(float64(stats.UpperLayerScoreTileCandidates), "upper_layer_score_tile_candidates/search")
+	b.ReportMetric(float64(stats.UpperLayerScoreTileMaxSize), "upper_layer_score_tile_max_size")
+	b.ReportMetric(float64(stats.UpperLayerAdjacencyLoads), "upper_layer_adjacency_loads/search")
+	b.ReportMetric(float64(stats.UpperLayerAdjacencyNeighbors), "upper_layer_adjacency_neighbors/search")
 	b.ReportMetric(float64(stats.UpperLayerEdgeVisits), "upper_layer_edge_visits/search")
 	b.ReportMetric(float64(stats.UpperLayerScoredNeighbors), "upper_layer_scored_neighbors/search")
 	b.ReportMetric(float64(stats.UpperLayerFilterSkips), "upper_layer_filter_skips/search")
 	b.ReportMetric(float64(stats.Layer0Scores), "layer0_scores/search")
 	b.ReportMetric(float64(stats.Layer0SeedScores), "layer0_seed_scores/search")
 	b.ReportMetric(float64(stats.Layer0NeighborScores), "layer0_neighbor_scores/search")
+	b.ReportMetric(float64(stats.Layer0ScoreTiles), "layer0_score_tiles/search")
+	b.ReportMetric(float64(stats.Layer0ScoreTileCandidates), "layer0_score_tile_candidates/search")
+	b.ReportMetric(float64(stats.Layer0ScoreTileMaxSize), "layer0_score_tile_max_size")
+	b.ReportMetric(float64(stats.Layer0AdjacencyLoads), "layer0_adjacency_loads/search")
+	b.ReportMetric(float64(stats.Layer0AdjacencyNeighbors), "layer0_adjacency_neighbors/search")
 	b.ReportMetric(float64(stats.Layer0EdgeVisits), "layer0_edge_visits/search")
 	b.ReportMetric(float64(stats.Layer0ScoredNeighbors), "layer0_scored_neighbors/search")
 	b.ReportMetric(float64(stats.Layer0AlreadyVisitedSkips), "layer0_already_visited_skips/search")
 	b.ReportMetric(float64(stats.Layer0FilterSkips), "layer0_filter_skips/search")
+	b.ReportMetric(float64(stats.Layer0StopChecks), "layer0_stop_checks/search")
+	b.ReportMetric(float64(stats.Layer0StopTrue), "layer0_stop_true/search")
+	b.ReportMetric(float64(stats.Layer0StopFalse), "layer0_stop_false/search")
+	b.ReportMetric(float64(stats.CandidateComparisons), "candidate_comparisons/search")
+	b.ReportMetric(float64(stats.FrontierComparisons), "frontier_comparisons/search")
+	b.ReportMetric(float64(stats.TopKComparisons), "top_k_comparisons/search")
 	b.ReportMetric(float64(stats.FrontierPushes), "frontier_pushes/search")
 	b.ReportMetric(float64(stats.FrontierPops), "frontier_pops/search")
 	b.ReportMetric(float64(stats.FrontierPopMisses), "frontier_pop_misses/search")
+	b.ReportMetric(float64(stats.FrontierSiftUpCalls), "frontier_sift_up_calls/search")
+	b.ReportMetric(float64(stats.FrontierSiftDownCalls), "frontier_sift_down_calls/search")
 	b.ReportMetric(float64(stats.FrontierSiftUpSteps), "frontier_sift_up_steps/search")
 	b.ReportMetric(float64(stats.FrontierSiftDownSteps), "frontier_sift_down_steps/search")
 	b.ReportMetric(float64(stats.TopKInsertAttempts), "top_k_insert_attempts/search")
@@ -457,6 +487,9 @@ func reportVectorIndexSearchBenchmarkDebugMetrics2105(b *testing.B, stats Vector
 	b.ReportMetric(float64(stats.VisitedMarkChecks), "visited_mark_checks/search")
 	b.ReportMetric(float64(stats.VisitedMarkHits), "visited_mark_hits/search")
 	b.ReportMetric(float64(stats.VisitedMarkMisses), "visited_mark_misses/search")
+	b.ReportMetric(float64(stats.VisitedMarkInserts), "visited_mark_inserts/search")
+	b.ReportMetric(float64(stats.VisitedResetEpochAdvances), "visited_reset_epoch_advances/search")
+	b.ReportMetric(float64(stats.VisitedResetClearedRows), "visited_reset_cleared_rows/search")
 	b.ReportMetric(float64(stats.ExactModeSearches), "exact_mode_searches/search")
 	b.ReportMetric(float64(stats.ExactCandidateOrderObservations), "exact_candidate_order_observations/search")
 	b.ReportMetric(float64(stats.ExactCandidateOrderTransitions), "exact_candidate_order_transitions/search")


### PR DESCRIPTION
## Linked issues

- Closes #2271
- Parent tracker: #2169

## Scope

Adds benchmark/debug-only instrumentation for TreeDB `column_graph` HNSW traversal hot paths so the serialized follow-up stack can measure frontier, visited-state, adjacency, stop-predicate, comparison, and score-tile costs before optimizing them.

What changed:

- Extends `benchmark_debug` search stats with:
  - frontier push/pop/sift call/step counters;
  - frontier/top-k candidate comparison counters;
  - visited mark checks/hits/misses/inserts plus epoch-reset work;
  - phase-split adjacency layer loads and neighbor iteration counters;
  - exact layer-0 stop-predicate checks/outcomes;
  - phase-split score tile counts/candidates/max sizes.
- Surfaces the new debug counters through public `VectorIndexSearchStats` for benchmark/debug consumers.
- Adds `BenchmarkColumnGraphScalarU8QuantizedTraversalCounters2271` for the fixed #1926 score-plane shape.
- Adds focused microbenchmarks for frontier heap operations and direct adjacency iteration.

## Non-goals / invariants

- No traversal ordering, recall, candidate ordering, graph topology, query-mode, or scorer semantics changes.
- No on-disk format changes.
- No pgvector or comparison-harness changes.
- Quantized modes remain fail-closed.
- `quantized_only` still does not read exact vector/norm payloads.
- `quantized_rerank` still exact-ranks only the trimmed shortlist.
- Production/minimal/default stats overhead is unchanged in intent: these new detailed counters are only populated in `benchmark_debug` mode.

## Tests

```sh
GOWORK=off go test ./TreeDB/collections -run 'TestColumnGraph|TestVectorIndexSearcher|TestSearchVectorIndexQuantized' -count=1
GOWORK=off go test ./TreeDB/collections -count=1
```

Both passed at head `f6ab01afd1378e2a7536e071a168615cbc7e203d`.

## Benchmark/profile artifacts

Before artifacts: `/tmp/gomap_2271_before_20260604_054837`
After artifacts: `/tmp/gomap_2271_after_20260604_060426`

Key after files:

- `standard_bench_after_latest.txt`
- `standard_bench_rerank32_after_latest.txt`
- `benchstat_exact_quantized_only_before_after_latest.txt`
- `benchstat_rerank32_before_after_latest.txt`
- `cpu_exact_after_latest.pprof`, `cpu_exact_after_latest_top.txt`
- `cpu_quantized_only_after_latest.pprof`, `cpu_quantized_only_after_latest_top.txt`
- `traversal_counters_exact_quantized_only_latest.txt`
- `traversal_counters_rerank32_latest.txt`
- `traversal_microbenches_2271.txt`
- `counter_definitions.md`

Commands:

```sh
GOWORK=off go test ./TreeDB/collections -run '^$' \
  -bench '^BenchmarkColumnGraphScalarU8QuantizedScorePlanes1926/mode=(exact|quantized_only|quantized_rerank/candidates=32)$' \
  -benchmem -benchtime=3s -count=5

# Separate rerank row because slash matching excludes it from the grouped regex.
GOWORK=off go test ./TreeDB/collections -run '^$' \
  -bench '^BenchmarkColumnGraphScalarU8QuantizedScorePlanes1926/mode=quantized_rerank/candidates=32$' \
  -benchmem -benchtime=3s -count=5

GOWORK=off go test ./TreeDB/collections -run '^$' \
  -bench '^BenchmarkColumnGraphScalarU8QuantizedTraversalCounters2271/(mode=exact|mode=quantized_only)$' \
  -benchmem -benchtime=3s -count=1

GOWORK=off go test ./TreeDB/collections -run '^$' \
  -bench '^BenchmarkColumnGraphScalarU8QuantizedTraversalCounters2271/mode=quantized_rerank/candidates=32$' \
  -benchmem -benchtime=3s -count=1

GOWORK=off go test ./TreeDB/collections -run '^$' \
  -bench '^BenchmarkColumnVectorGraph(FrontierHeapOperations|AdjacencyIteration)2271$' \
  -benchmem -benchtime=3s -count=3
```

## Standard benchmark regression assessment

Apple M3/darwin-arm64, 1024 rows, 128 dims, `M=16`, `top_k=10`, `ef_search=128`.

| mode | before | after | delta | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: | ---: |
| exact/default | 16.20 µs/op | 15.84 µs/op | -2.18% | 0 | 0 |
| `quantized_only` | 15.99 µs/op | 15.60 µs/op | -2.41% | 0 | 0 |
| `quantized_rerank/candidates=32` | 16.51 µs/op | 16.14 µs/op | -2.25% | 0 | 0 |

No material regression observed. Counter semantics that matter for quantized invariants stayed fixed: `quantized_only` reports `0 vector_B/search`, `0 norm_B/search`, `0 prepared_score_calls/search`; rerank reports `32 quantized_rerank_exact_score_calls/search` and exact vector/norm bytes for only those 32 candidates.

CPU profiles still show traversal/frontier/adjacency as the next target. Latest `quantized_only` top highlights:

- `SearchCosine`: 1.94s flat / 4.62s cum
- `frontierSiftDown`: 0.56s flat / 0.65s cum
- `dotScalarU8CenteredIndexedARM64`: 0.53s flat / 0.53s cum
- `insertTop`: 0.15s flat / 0.19s cum
- `expandCandidateAdjacencyLayer`: 0.10s flat / 0.40s cum

## Counter baseline / contract

Full definitions and raw table are in `/tmp/gomap_2271_after_20260604_060426/counter_definitions.md`.

Representative per-search baseline for the fixed 1024-row shape (same traversal in exact, `quantized_only`, and `quantized_rerank/candidates=32`):

| counter | value/search |
| --- | ---: |
| candidates | 133 |
| visited_edges | 4,130 |
| adjacency_layer_loads | 131 |
| layer0_adjacency_loads | 128 |
| upper_layer_adjacency_loads | 3 |
| layer0_neighbors_iterated | 4,096 |
| upper_layer_neighbors_iterated | 34 |
| layer0_score_tiles | 9 |
| upper_layer_score_tiles | 5 |
| candidate_comparisons | 1,118 |
| frontier_comparisons | 916 |
| top_k_comparisons | 202 |
| frontier_pushes / pops | 128 / 128 |
| frontier_sift_up_calls / steps | 128 / 9 |
| frontier_sift_down_calls / steps | 120 / 199 |
| visited_mark_checks / hits / misses | 4,096 / 3,967 / 129 |
| visited_mark_inserts | 133 |
| visited_reset_epoch_advances / cleared_rows | 1 / 0 |
| layer0_stop_checks / true / false | 128 / 0 / 128 |

The intended downstream contract is these `benchmark_debug` field names and definitions, not their exact numeric values across topology/query changes.

## CI / AI review status

- CI: pending after PR creation.
- AI reviews: not requested until this PR is open with this mature body and latest local tests/benchmarks attached.
- Unresolved review threads: none known at creation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced performance diagnostics with expanded traversal and counter metrics for vector graph search.
  * Added new benchmarks for frontier heap and adjacency iteration operations.
  * Extended search statistics reporting with layer-specific metrics and detailed operation counts.

* **Tests**
  * Expanded benchmark assertions to validate additional performance counters.
  * Improved debug statistics validation for search operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Coordinator final validation

Coordinator validation on latest head `f6ab01afd1378e2a7536e071a168615cbc7e203d`:

```sh
GOWORK=off go test ./TreeDB/collections -run 'TestColumnGraph|TestVectorIndexSearcher|TestSearchVectorIndexQuantized' -count=1
GOWORK=off go test ./TreeDB/collections -count=1
git diff --check origin/main...HEAD
```

All passed. Latest-head CI is green, merge state is `CLEAN`, mergeable is `MERGEABLE`, unresolved non-outdated review threads are 0, Codex reported no major issues, and CodeRabbit latest-head status is pass/review skipped after review finished with no unresolved threads.
