### PR TITLE
TreeDB: optimize HNSW frontier queues

### DIFF
--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -28,6 +28,8 @@ const columnVectorGraphNativeResultOrderInsertionSortLimit = 32
 
 // Frontier traversal uses a max-heap ordered by score/ordinal. A modest fanout
 // lowers sift depth while preserving the same total comparator and pop order.
+// frontierSiftDown has a fanout-4 child scan unrolled for the hot path; update
+// that scan if this fanout changes.
 const columnVectorGraphNativeFrontierHeapFanout = 4
 
 var (
@@ -2619,15 +2621,17 @@ func (s *columnVectorGraphNativeSearchScratch) frontierSiftDown(idx int, candida
 		}
 		child := firstChild
 		childCandidate := frontier[firstChild]
-		lastChild := firstChild + columnVectorGraphNativeFrontierHeapFanout
-		if lastChild > n {
-			lastChild = n
+		if next := firstChild + 1; next < n && columnVectorGraphSearchCandidateBetter(frontier[next], childCandidate) {
+			child = next
+			childCandidate = frontier[next]
 		}
-		for next := firstChild + 1; next < lastChild; next++ {
-			if columnVectorGraphSearchCandidateBetter(frontier[next], childCandidate) {
-				child = next
-				childCandidate = frontier[next]
-			}
+		if next := firstChild + 2; next < n && columnVectorGraphSearchCandidateBetter(frontier[next], childCandidate) {
+			child = next
+			childCandidate = frontier[next]
+		}
+		if next := firstChild + 3; next < n && columnVectorGraphSearchCandidateBetter(frontier[next], childCandidate) {
+			child = next
+			childCandidate = frontier[next]
 		}
 		if !columnVectorGraphSearchCandidateBetter(childCandidate, candidate) {
 			break
@@ -2650,11 +2654,21 @@ func (s *columnVectorGraphNativeSearchScratch) frontierSiftDownDebug(idx int, ca
 		}
 		child := firstChild
 		childCandidate := frontier[firstChild]
-		lastChild := firstChild + columnVectorGraphNativeFrontierHeapFanout
-		if lastChild > n {
-			lastChild = n
+		if next := firstChild + 1; next < n {
+			debugCounters.recordCandidateComparison(true)
+			if columnVectorGraphSearchCandidateBetter(frontier[next], childCandidate) {
+				child = next
+				childCandidate = frontier[next]
+			}
 		}
-		for next := firstChild + 1; next < lastChild; next++ {
+		if next := firstChild + 2; next < n {
+			debugCounters.recordCandidateComparison(true)
+			if columnVectorGraphSearchCandidateBetter(frontier[next], childCandidate) {
+				child = next
+				childCandidate = frontier[next]
+			}
+		}
+		if next := firstChild + 3; next < n {
 			debugCounters.recordCandidateComparison(true)
 			if columnVectorGraphSearchCandidateBetter(frontier[next], childCandidate) {
 				child = next
@@ -2677,18 +2691,22 @@ func (s *columnVectorGraphNativeSearchScratch) insertTop(limit int, candidate co
 	if limit <= 0 {
 		return false
 	}
-	pos := len(s.top)
-	for pos > 0 && columnVectorGraphSearchCandidateBetter(candidate, s.top[pos-1]) {
+	top := s.top
+	pos := len(top)
+	for pos > 0 && columnVectorGraphSearchCandidateBetter(candidate, top[pos-1]) {
 		pos--
 	}
 	if pos >= limit {
 		return false
 	}
-	if len(s.top) < limit {
-		s.top = append(s.top, columnVectorGraphSearchCandidate{})
+	if len(top) < limit {
+		top = append(top, columnVectorGraphSearchCandidate{})
+		s.top = top
 	}
-	copy(s.top[pos+1:], s.top[pos:len(s.top)-1])
-	s.top[pos] = candidate
+	for shift := len(top) - 1; shift > pos; shift-- {
+		top[shift] = top[shift-1]
+	}
+	top[pos] = candidate
 	return true
 }
 
@@ -2698,10 +2716,11 @@ func (s *columnVectorGraphNativeSearchScratch) insertTopDebug(limit int, candida
 		debugCounters.stats.TopKInsertRejections++
 		return false
 	}
-	pos := len(s.top)
+	top := s.top
+	pos := len(top)
 	for pos > 0 {
 		debugCounters.recordCandidateComparison(false)
-		if !columnVectorGraphSearchCandidateBetter(candidate, s.top[pos-1]) {
+		if !columnVectorGraphSearchCandidateBetter(candidate, top[pos-1]) {
 			break
 		}
 		pos--
@@ -2711,16 +2730,19 @@ func (s *columnVectorGraphNativeSearchScratch) insertTopDebug(limit int, candida
 		return false
 	}
 	debugCounters.stats.TopKInsertSuccesses++
-	shiftSteps := len(s.top) - pos
-	if len(s.top) >= limit && shiftSteps > 0 {
+	shiftSteps := len(top) - pos
+	if len(top) >= limit && shiftSteps > 0 {
 		shiftSteps--
 	}
 	debugCounters.stats.TopKShiftSteps += uint64(shiftSteps)
-	if len(s.top) < limit {
-		s.top = append(s.top, columnVectorGraphSearchCandidate{})
+	if len(top) < limit {
+		top = append(top, columnVectorGraphSearchCandidate{})
+		s.top = top
 	}
-	copy(s.top[pos+1:], s.top[pos:len(s.top)-1])
-	s.top[pos] = candidate
+	for shift := len(top) - 1; shift > pos; shift-- {
+		top[shift] = top[shift-1]
+	}
+	top[pos] = candidate
 	return true
 }
 

--- a/TreeDB/collections/column_vector_graph_search_test.go
+++ b/TreeDB/collections/column_vector_graph_search_test.go
@@ -51,6 +51,12 @@ func TestColumnVectorGraphAdjacencySourceStatsSkipEmptyNoopV3(t *testing.T) {
 	}
 }
 
+func TestColumnVectorGraphNativeSearchFrontierHeapFanout2272(t *testing.T) {
+	if columnVectorGraphNativeFrontierHeapFanout != 4 {
+		t.Fatalf("frontier heap fanout=%d; update unrolled frontierSiftDown child scan before changing fanout", columnVectorGraphNativeFrontierHeapFanout)
+	}
+}
+
 func TestColumnVectorGraphNativeSearchFrontierHeapOrder1980(t *testing.T) {
 	candidates := []columnVectorGraphSearchCandidate{
 		{ordinal: 7, score: 0.70},
@@ -139,6 +145,64 @@ func assertColumnVectorGraphFrontierPopOrderDebug1980(t *testing.T, scratch *col
 	if got, ok := scratch.popFrontierDebug(debugCounters); ok {
 		t.Fatalf("debug frontier pop after drain=%+v, want empty", got)
 	}
+}
+
+func TestColumnVectorGraphNativeSearchTopInsertOrder2272(t *testing.T) {
+	candidates := []columnVectorGraphSearchCandidate{
+		{ordinal: 7, score: 0.70},
+		{ordinal: 3, score: 0.70},
+		{ordinal: 11, score: -0.10},
+		{ordinal: 1, score: 0.95},
+		{ordinal: 9, score: 0.20},
+		{ordinal: 5, score: 0.95},
+		{ordinal: 4, score: 0.20},
+		{ordinal: 2, score: -0.10},
+	}
+	const limit = 4
+	var scratch columnVectorGraphNativeSearchScratch
+	var debugScratch columnVectorGraphNativeSearchScratch
+	var stats columnVectorGraphNativeSearchStats
+	debugCounters := &columnVectorGraphNativeSearchDebugCounters{stats: &stats}
+	var want []columnVectorGraphSearchCandidate
+	var successes uint64
+	for i, candidate := range candidates {
+		before := append([]columnVectorGraphSearchCandidate(nil), want...)
+		want = insertColumnGraphTopForTest(want, limit, candidate)
+		wantAccepted := !columnVectorGraphCandidateSlicesEqual2272(before, want)
+		if gotAccepted := scratch.insertTop(limit, candidate); gotAccepted != wantAccepted {
+			t.Fatalf("insertTop[%d] accepted=%v want %v", i, gotAccepted, wantAccepted)
+		}
+		if !columnVectorGraphCandidateSlicesEqual2272(scratch.top, want) {
+			t.Fatalf("insertTop[%d] top=%+v want %+v", i, scratch.top, want)
+		}
+		if gotAccepted := debugScratch.insertTopDebug(limit, candidate, debugCounters); gotAccepted != wantAccepted {
+			t.Fatalf("debug insertTop[%d] accepted=%v want %v", i, gotAccepted, wantAccepted)
+		}
+		if !columnVectorGraphCandidateSlicesEqual2272(debugScratch.top, want) {
+			t.Fatalf("debug insertTop[%d] top=%+v want %+v", i, debugScratch.top, want)
+		}
+		if wantAccepted {
+			successes++
+		}
+	}
+	if stats.TopKInsertAttempts != uint64(len(candidates)) || stats.TopKInsertSuccesses != successes || stats.TopKInsertRejections != uint64(len(candidates))-successes {
+		t.Fatalf("debug top-k stats=%+v want attempts=%d successes=%d", stats, len(candidates), successes)
+	}
+	if stats.TopKComparisons == 0 || stats.TopKShiftSteps == 0 {
+		t.Fatalf("debug top-k comparison/shift stats=%+v want non-zero", stats)
+	}
+}
+
+func columnVectorGraphCandidateSlicesEqual2272(left, right []columnVectorGraphSearchCandidate) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func columnVectorGraphNativeSearchSmallBenchShapeV3() columnVectorGraphNativeSearchBenchShapeV3 {


### PR DESCRIPTION
## Summary

Fixes #2272. Parent tracker: #2169. Depends on merged #2271 / PR #2281 (`f9cfecc871684c8d52344c3c33e3be937514fc9a`).

- Unroll the fanout-4 child scan in the HNSW layer-0 frontier heap `siftDown` hot path.
- Keep the debug/instrumented heap path counter-equivalent to #2271.
- Replace the retained top-k small shift with a local slice/manual shift to avoid the generic `copy` path in this tiny fixed-k queue.
- Add focused ordering/debug-counter tests for the frontier fanout guard and top-k insertion path.

## Scope / non-goals

In scope: local frontier/top candidate queue mechanics in `TreeDB/collections/column_vector_graph_search.go`.

Non-goals / unchanged:

- No graph topology, traversal stop-condition, `ef_search`, candidate ordering, or recall-policy changes.
- No exact/default behavior changes.
- No quantized mode policy changes: quantized modes still fail closed, `quantized_only` does not read exact vector/norm data, and `quantized_rerank` exact-ranks only the trimmed shortlist.
- No visited-set or adjacency iteration rewrites (#2273/#2274).
- No on-disk format changes.

## Tests

Latest local validation on Apple M3 / darwin-arm64, branch `snissn/2272-manager`:

```sh
GOWORK=off go test ./TreeDB/collections -run 'TestColumnGraph|TestVectorIndexSearcher|TestSearchVectorIndexQuantized' -count=1
GOWORK=off go test ./TreeDB/collections -count=1
```

Both passed after the final commit. Focused queue/order coverage added:

- `TestColumnVectorGraphNativeSearchFrontierHeapFanout2272`
- `TestColumnVectorGraphNativeSearchTopInsertOrder2272`
- Existing `TestColumnVectorGraphNativeSearchFrontierHeapOrder1980`

## Benchmark/profile artifacts

Baseline artifacts: `/tmp/gomap_2272_before_20260604_064237`
Candidate artifacts: `/tmp/gomap_2272_after_20260604_065815`

Key files:

- `standard_exact_quantized_only_before.txt` / `standard_exact_quantized_only_after.txt`
- `standard_rerank32_before.txt` / `standard_rerank32_after.txt`
- `traversal_counters_exact_quantized_only_before.txt` / `traversal_counters_exact_quantized_only_after.txt`
- `traversal_counters_rerank32_before.txt` / `traversal_counters_rerank32_after.txt`
- `frontier_microbench_before.txt` / `frontier_microbench_after.txt`
- `benchstat_exact_quantized_only_before_after.txt`
- `benchstat_rerank32_before_after.txt`
- `benchstat_frontier_microbench_before_after.txt`
- `cpu_quantized_only_before.pprof`, `cpu_quantized_only_before_top.txt`
- `cpu_quantized_only_after.pprof`, `cpu_quantized_only_after_top.txt`

Experimental fanout sweep artifacts (not selected): `/tmp/gomap_2272_fanout_experiments_20260604_064531`.

Commands:

```sh
GOWORK=off go test ./TreeDB/collections -run '^$' \
  -bench '^BenchmarkColumnGraphScalarU8QuantizedScorePlanes1926/mode=(exact|quantized_only)$' \
  -benchmem -benchtime=3s -count=5

GOWORK=off go test ./TreeDB/collections -run '^$' \
  -bench '^BenchmarkColumnGraphScalarU8QuantizedScorePlanes1926/mode=quantized_rerank/candidates=32$' \
  -benchmem -benchtime=3s -count=5

GOWORK=off go test ./TreeDB/collections -run '^$' \
  -bench '^BenchmarkColumnGraphScalarU8QuantizedTraversalCounters2271/(mode=exact|mode=quantized_only)$' \
  -benchmem -benchtime=3s -count=1

GOWORK=off go test ./TreeDB/collections -run '^$' \
  -bench '^BenchmarkColumnGraphScalarU8QuantizedTraversalCounters2271/mode=quantized_rerank/candidates=32$' \
  -benchmem -benchtime=3s -count=1

GOWORK=off go test ./TreeDB/collections -run '^$' \
  -bench '^BenchmarkColumnVectorGraphFrontierHeapOperations2271$' \
  -benchmem -benchtime=3s -count=5

GOWORK=off go test ./TreeDB/collections -run '^$' \
  -bench '^BenchmarkColumnGraphScalarU8QuantizedScorePlanes1926/mode=quantized_only$' \
  -benchmem -benchtime=5s -count=1 -cpuprofile <cpu.pprof>
```

## Benchmark summary

Apple M3/darwin-arm64, 1024 rows, 128 dims, `M=16`, `top_k=10`, `ef_search=128`.

| row | before | after | delta | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: | ---: |
| exact/default | 16.30 µs/op | 15.34 µs/op | -5.84% | 0 | 0 |
| `quantized_only` | 16.10 µs/op | 15.18 µs/op | -5.72% | 0 | 0 |
| `quantized_rerank/candidates=32` | 16.68 µs/op | 15.78 µs/op | -5.42% | 0 | 0 |
| frontier heap microbench | 5.464 µs/op | 4.851 µs/op | -11.22% | 0 | 0 |

`benchstat` reports p=0.008 for all four runtime improvements (n=5). All reported steady-state rows preserve `0 B/op` and `0 allocs/op`.

Quantized invariant counters stayed fixed:

- `quantized_only`: `0 vector_B/search`, `0 norm_B/search`, `0 prepared_score_calls/search`.
- `quantized_rerank/candidates=32`: `32 quantized_rerank_candidates/search`, `32 quantized_rerank_exact_score_calls/search`, exact vector/norm bytes only for those 32 rerank candidates.
- `recall_at_k_pct`: 100 for all standard rows in this fixed benchmark shape.

CPU profiles were captured before/after for `quantized_only`. The frontier microbench and end-to-end rows show the queue optimization benefit; the profile still identifies `frontierSiftDown` as the largest queue-local site, which is expected because this PR keeps traversal semantics/counters unchanged rather than reducing frontier operation counts.

## Traversal/frontier counter table

Per-search #2271 benchmark-debug counters for the fixed shape stayed unchanged, confirming no traversal/order/recall-policy drift:

| counter | before | after |
| --- | ---: | ---: |
| candidates/search | 133 | 133 |
| candidate_comparisons/search | 1,118 | 1,118 |
| frontier_comparisons/search | 916 | 916 |
| top_k_comparisons/search | 202 | 202 |
| frontier_pushes/search | 128 | 128 |
| frontier_pops/search | 128 | 128 |
| frontier_pop_misses/search | 4 | 4 |
| frontier_sift_up_calls/search | 128 | 128 |
| frontier_sift_up_steps/search | 9 | 9 |
| frontier_sift_down_calls/search | 120 | 120 |
| frontier_sift_down_steps/search | 199 | 199 |
| top_k_insert_attempts/search | 133 | 133 |
| top_k_insert_successes/search | 128 | 128 |
| top_k_insert_rejections/search | 5 | 5 |
| top_k_shift_steps/search | 70 | 70 |
| visited_mark_checks/search | 4,096 | 4,096 |
| layer0_stop_checks/search | 128 | 128 |
| B/op | 0 | 0 |
| allocs/op | 0 | 0 |

The same frontier/top-k counter values were observed for exact, `quantized_only`, and `quantized_rerank/candidates=32`.

## Regression assessment

- No semantic/counter drift: traversal counters, candidate counts, recall, exact/quantized byte counters, and rerank counters are unchanged.
- No allocation regression: all required benchmark rows remain `0 B/op`, `0 allocs/op`.
- No scope drift: only queue-local search code and queue/order tests changed.
- No on-disk or public API changes.

## Review / CI status

- Internal high-thinking Orca review: PASS after addressing the fanout guard nit.
- Latest-head CI for `b7f5b46aba3598e54444d4551ab39bb2f18f5554`: all checks passing.
- Merge state: `CLEAN`; mergeable: `MERGEABLE`.
- Review threads: 0 unresolved/non-outdated threads (GraphQL reviewThreads returned no nodes).
- Codex: requested after PR maturity; latest response found no major issues.
- Copilot: requested after PR maturity; no comments/threads posted.
- CodeRabbit: requested after PR maturity; status is passing/review finished after an initial rate-limit notice; no threads posted.
- Coordinator owns merge; this PR should not be self-merged.



## Coordinator final validation

Coordinator validation on latest head `b7f5b46aba3598e54444d4551ab39bb2f18f5554`:

```sh
GOWORK=off go test ./TreeDB/collections -run 'TestColumnGraph|TestVectorIndexSearcher|TestSearchVectorIndexQuantized' -count=1
GOWORK=off go test ./TreeDB/collections -count=1
git diff --check origin/main...HEAD
```

All passed. Latest-head CI is green, merge state is `CLEAN`, mergeable is `MERGEABLE`, and unresolved non-outdated review threads are 0. Codex reported no major issues. CodeRabbit was requested; current status context is pass/review skipped after its review action completed, with no unresolved threads.
