### PR TITLE
TreeDB: streamline HNSW visited checks

### DIFF
--- a/TreeDB/collections/column_vector_graph_quantized_bench_test.go
+++ b/TreeDB/collections/column_vector_graph_quantized_bench_test.go
@@ -467,6 +467,8 @@ func reportColumnGraphScalarU8QuantizedTraversalCounterMetrics2271(b *testing.B,
 	b.ReportMetric(float64(stats.Layer0AdjacencyLoads)/denom, "layer0_adjacency_loads/search")
 	b.ReportMetric(float64(stats.Layer0AdjacencyNeighbors)/denom, "layer0_adjacency_neighbors/search")
 	b.ReportMetric(float64(stats.Layer0EdgeVisits)/denom, "layer0_neighbors_iterated/search")
+	b.ReportMetric(float64(stats.AlreadyVisitedSkips)/denom, "already_visited_skips/search")
+	b.ReportMetric(float64(stats.Layer0AlreadyVisitedSkips)/denom, "layer0_already_visited_skips/search")
 	b.ReportMetric(float64(stats.UpperLayerScoreTiles)/denom, "upper_layer_score_tiles/search")
 	b.ReportMetric(float64(stats.UpperLayerScoreTileCandidates)/denom, "upper_layer_score_tile_candidates/search")
 	b.ReportMetric(float64(stats.UpperLayerScoreTileMaxSize), "upper_layer_score_tile_max_size")

--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -1492,47 +1492,74 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 					tileCap := len(adjacency) - i
 					scratch.scoreTileOrdinals = ensureColumnVectorGraphNativeIntScratch(scratch.scoreTileOrdinals, tileCap)
 					tile := scratch.scoreTileOrdinals[:0]
-					for i < len(adjacency) && len(tile) < tileCap {
-						neighborIndex := i
-						neighbor := adjacency[i]
-						i++
-						if countLoopEdges {
-							loopEdgeVisits++
+					if debugStats == nil && debugCounters == nil {
+						// Keep the steady-state visited check/mark loop free of
+						// benchmark-debug counter branches; the debug path below
+						// preserves the #2271 counter contract.
+						for i < len(adjacency) && len(tile) < tileCap {
+							neighborIndex := i
+							neighbor := adjacency[i]
+							i++
+							if countLoopEdges {
+								loopEdgeVisits++
+							}
+							if uint64(neighbor) >= uint64(rowCount) {
+								return nil, stats, fmt.Errorf("collections: column_graph %q ordinal=%d adjacency[%d]=%d outside row_count=%d: %w", r.def.Name, candidate.ordinal, neighborIndex, neighbor, rowCount, errColumnVectorGraphAdjacencyOrdinalOutOfBounds)
+							}
+							neighborOrdinal := int(neighbor)
+							if visitMarks[neighborOrdinal] == visitEpoch {
+								continue
+							}
+							if !columnVectorGraphCandidateRowAllowed(candidateRows, hasCandidateRows, neighborOrdinal) {
+								visitMarks[neighborOrdinal] = visitEpoch
+								continue
+							}
+							visitMarks[neighborOrdinal] = visitEpoch
+							tile = append(tile, neighborOrdinal)
 						}
-						if debugStats != nil {
-							debugStats.Layer0EdgeVisits++
-						}
-						if uint64(neighbor) >= uint64(rowCount) {
-							return nil, stats, fmt.Errorf("collections: column_graph %q ordinal=%d adjacency[%d]=%d outside row_count=%d: %w", r.def.Name, candidate.ordinal, neighborIndex, neighbor, rowCount, errColumnVectorGraphAdjacencyOrdinalOutOfBounds)
-						}
-						neighborOrdinal := int(neighbor)
-						if visitMarks[neighborOrdinal] == visitEpoch {
+					} else {
+						for i < len(adjacency) && len(tile) < tileCap {
+							neighborIndex := i
+							neighbor := adjacency[i]
+							i++
+							if countLoopEdges {
+								loopEdgeVisits++
+							}
+							if debugStats != nil {
+								debugStats.Layer0EdgeVisits++
+							}
+							if uint64(neighbor) >= uint64(rowCount) {
+								return nil, stats, fmt.Errorf("collections: column_graph %q ordinal=%d adjacency[%d]=%d outside row_count=%d: %w", r.def.Name, candidate.ordinal, neighborIndex, neighbor, rowCount, errColumnVectorGraphAdjacencyOrdinalOutOfBounds)
+							}
+							neighborOrdinal := int(neighbor)
+							if visitMarks[neighborOrdinal] == visitEpoch {
+								if debugStats != nil {
+									debugStats.VisitedMarkChecks++
+									debugStats.VisitedMarkHits++
+									debugStats.AlreadyVisitedSkips++
+									debugStats.SkippedNeighbors++
+									debugStats.Layer0AlreadyVisitedSkips++
+								}
+								continue
+							}
 							if debugStats != nil {
 								debugStats.VisitedMarkChecks++
-								debugStats.VisitedMarkHits++
-								debugStats.AlreadyVisitedSkips++
-								debugStats.SkippedNeighbors++
-								debugStats.Layer0AlreadyVisitedSkips++
+								debugStats.VisitedMarkMisses++
 							}
-							continue
-						}
-						if debugStats != nil {
-							debugStats.VisitedMarkChecks++
-							debugStats.VisitedMarkMisses++
-						}
-						if !columnVectorGraphCandidateRowAllowed(candidateRows, hasCandidateRows, neighborOrdinal) {
+							if !columnVectorGraphCandidateRowAllowed(candidateRows, hasCandidateRows, neighborOrdinal) {
+								if debugCounters != nil {
+									debugCounters.recordFilterSkip(true)
+									debugCounters.recordVisitedInsert()
+								}
+								visitMarks[neighborOrdinal] = visitEpoch
+								continue
+							}
 							if debugCounters != nil {
-								debugCounters.recordFilterSkip(true)
 								debugCounters.recordVisitedInsert()
 							}
 							visitMarks[neighborOrdinal] = visitEpoch
-							continue
+							tile = append(tile, neighborOrdinal)
 						}
-						if debugCounters != nil {
-							debugCounters.recordVisitedInsert()
-						}
-						visitMarks[neighborOrdinal] = visitEpoch
-						tile = append(tile, neighborOrdinal)
 					}
 					if len(tile) == 0 {
 						continue

--- a/TreeDB/collections/column_vector_graph_search_test.go
+++ b/TreeDB/collections/column_vector_graph_search_test.go
@@ -57,6 +57,61 @@ func TestColumnVectorGraphNativeSearchFrontierHeapFanout2272(t *testing.T) {
 	}
 }
 
+func TestColumnVectorGraphNativeSearchVisitedEpochReuseGrowthWrap2273(t *testing.T) {
+	var scratch columnVectorGraphNativeSearchScratch
+	prepare := func(rows int) {
+		t.Helper()
+		if err := scratch.prepare(rows, 4, 2, 2, 4, 4, 0); err != nil {
+			t.Fatalf("prepare rows=%d: %v", rows, err)
+		}
+	}
+
+	prepare(3)
+	firstEpoch := scratch.visitEpoch
+	if firstEpoch == 0 || len(scratch.visitMarks) != 3 {
+		t.Fatalf("first prepare epoch=%d marks=%d", firstEpoch, len(scratch.visitMarks))
+	}
+	if !scratch.markVisited(1) || scratch.markVisited(1) {
+		t.Fatalf("markVisited did not report first mark then duplicate for epoch=%d marks=%v", scratch.visitEpoch, scratch.visitMarks)
+	}
+	if seed, ok := columnVectorGraphNextCandidateSeed(1, 3, typedcolumn.RowSelection{}, false, scratch.visitMarks, scratch.visitEpoch); !ok || seed != 2 {
+		t.Fatalf("seed after visited mark=(%d,%v), want (2,true)", seed, ok)
+	}
+
+	prepare(3)
+	if scratch.visitEpoch != firstEpoch+1 {
+		t.Fatalf("reuse prepare epoch=%d want %d", scratch.visitEpoch, firstEpoch+1)
+	}
+	if !scratch.markVisited(1) {
+		t.Fatalf("reused scratch treated prior epoch mark as current: epoch=%d marks=%v", scratch.visitEpoch, scratch.visitMarks)
+	}
+
+	prepare(5)
+	if len(scratch.visitMarks) != 5 {
+		t.Fatalf("grown marks len=%d want 5", len(scratch.visitMarks))
+	}
+	if !scratch.markVisited(4) || !scratch.markVisited(2) {
+		t.Fatalf("grown scratch did not accept first marks: epoch=%d marks=%v", scratch.visitEpoch, scratch.visitMarks)
+	}
+
+	for i := range scratch.visitMarks {
+		scratch.visitMarks[i] = math.MaxUint64
+	}
+	scratch.visitEpoch = math.MaxUint64
+	prepare(5)
+	if scratch.visitEpoch != 1 {
+		t.Fatalf("wrap prepare epoch=%d want 1", scratch.visitEpoch)
+	}
+	for i, mark := range scratch.visitMarks {
+		if mark != 0 {
+			t.Fatalf("wrap mark[%d]=%d want cleared 0; marks=%v", i, mark, scratch.visitMarks)
+		}
+	}
+	if !scratch.markVisited(3) || scratch.markVisited(3) {
+		t.Fatalf("markVisited after wrap did not report first mark then duplicate: epoch=%d marks=%v", scratch.visitEpoch, scratch.visitMarks)
+	}
+}
+
 func TestColumnVectorGraphNativeSearchFrontierHeapOrder1980(t *testing.T) {
 	candidates := []columnVectorGraphSearchCandidate{
 		{ordinal: 7, score: 0.70},


### PR DESCRIPTION
## Summary

Closes #2273. Parent tracker: #2169.

Optimizes the TreeDB `column_graph` HNSW layer-0 visited check/mark hot path by splitting the steady-state non-debug loop away from the benchmark-debug counter path. This removes per-neighbor debug-counter nil branches from normal exact / quantized searches while preserving the #2271 traversal counter contract in benchmark-debug mode.

Also adds:
- focused visited scratch reuse/growth/epoch-wrap coverage;
- traversal benchmark reporting for `already_visited_skips/search` and `layer0_already_visited_skips/search`.

## Scope / non-goals

In scope:
- visited-state check/mark branch structure only;
- scratch epoch reuse/growth/wrap test;
- tiny benchmark counter reporting support.

Non-goals preserved:
- no graph topology, traversal stop-condition, `ef_search`, candidate ordering, or recall-policy changes;
- no exact/default or quantized mode behavior changes;
- no on-disk format changes;
- no shared/global visited cache; scratch remains per-search/per-caller.

## Tests

Artifacts: `/tmp/gomap_2273_final_20260604_074645`

- `GOWORK=off go test ./TreeDB/collections -run 'TestColumnVectorGraphNativeSearchVisitedEpochReuseGrowthWrap2273' -count=1`
- `GOWORK=off go test ./TreeDB/collections -run 'TestColumnGraph|TestVectorIndexSearcher|TestSearchVectorIndexQuantized' -count=1`
- `GOWORK=off go test ./TreeDB/collections -count=1`
- `GOWORK=off go test -race ./TreeDB/collections -run 'TestColumnGraphScalarU8QuantizedModesConcurrentSearch1926|TestVectorIndexSearcherQuantizedSearchWithBufferSuccessAndErrorReset1926' -count=1`

Internal high-thinking review: PASS (`internal_review_final.txt`).

## Benchmark evidence

Baseline: #2272 artifacts at `/tmp/gomap_2272_after_20260604_065815` (`origin/main` `e5e1b8b0ff100f238d4fe8d17ba8906455f74ddd`).
Candidate: `/tmp/gomap_2273_final_20260604_074645`.

Command:

```sh
GOWORK=off go test ./TreeDB/collections -run '^$' \
  -bench '^BenchmarkColumnGraphScalarU8QuantizedScorePlanes1926/mode=(exact|quantized_only)$' \
  -benchmem -benchtime=3s -count=5
GOWORK=off go test ./TreeDB/collections -run '^$' \
  -bench '^BenchmarkColumnGraphScalarU8QuantizedScorePlanes1926/mode=quantized_rerank/candidates=32$' \
  -benchmem -benchtime=3s -count=5
```

| mode | before ns/op | after ns/op | delta | before ops/sec | after ops/sec | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| exact | 15,340 | 14,400 | -6.13% | 65.17k | 69.43k | 0 | 0 |
| quantized_only | 15,180 | 14,220 | -6.30% | 65.90k | 70.33k | 0 | 0 |
| quantized_rerank/candidates=32 | 15,780 | 14,700 | -6.85% | 63.38k | 68.03k | 0 | 0 |

## Traversal / visited counters

Traversal-counter command used the #2271 benchmark-debug rows with the same shape. Counters are unchanged; the new explicit already-visited metrics match `visited_mark_hits`.

| mode | phase | visited_mark_checks | hits | misses | inserts | reset_epoch_advances | reset_cleared_rows | already_visited_skips | layer0_neighbors_iterated |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| exact | before | 4,096 | 3,967 | 129 | 133 | 1 | 0 | 3,967 | 4,096 |
| exact | after | 4,096 | 3,967 | 129 | 133 | 1 | 0 | 3,967 | 4,096 |
| quantized_only | before | 4,096 | 3,967 | 129 | 133 | 1 | 0 | 3,967 | 4,096 |
| quantized_only | after | 4,096 | 3,967 | 129 | 133 | 1 | 0 | 3,967 | 4,096 |
| quantized_rerank/candidates=32 | before | 4,096 | 3,967 | 129 | 133 | 1 | 0 | 3,967 | 4,096 |
| quantized_rerank/candidates=32 | after | 4,096 | 3,967 | 129 | 133 | 1 | 0 | 3,967 | 4,096 |

## CPU profile

Quantized-only CPU profile command:

```sh
GOWORK=off go test ./TreeDB/collections -run '^$' \
  -bench '^BenchmarkColumnGraphScalarU8QuantizedScorePlanes1926/mode=quantized_only$' \
  -benchmem -benchtime=5s -count=1 -cpuprofile cpu_quantized_only_final.pprof
```

Artifacts:
- before: `/tmp/gomap_2272_after_20260604_065815/cpu_quantized_only_after.pprof`, `cpu_quantized_only_after_top.txt`
- after: `/tmp/gomap_2273_final_20260604_074645/cpu_quantized_only_final.pprof`, `cpu_quantized_only_final_top.txt`

Profile highlights:
- `SearchCosine`: before `2.20s flat / 4.80s cum`; after `1.81s flat / 4.36s cum`.
- `frontierSiftDown`: before `0.50s flat / 0.66s cum`; after `0.40s flat / 0.47s cum`.

## Regression assessment

- Exact/default behavior unchanged by design; only the non-debug visited check/mark branch structure changed.
- Quantized modes remain explicit/fail-closed; this PR does not touch quantized scorer selection, exact vector/norm reads, or rerank shortlist handling.
- Candidate/traversal/visited/adjacency counters are unchanged.
- Steady-state `0 B/op`, `0 allocs/op` preserved.
- No on-disk or asset format changes.

## CI / review status

- Local tests and benchmarks above passed on latest local head `b5926379c`.
- Latest-head CI is green at `b5926379cb90e25a75d7394cdd676372e07a895d` (`gh pr checks` all pass; merge state `CLEAN`).
- AI review requested after mature PR creation: Codex returned no major issues; CodeRabbit reported no actionable comments / check pass; Copilot was requested via comment and reviewer request with no findings surfaced.
- Review threads: 0 unresolved.



## Coordinator final validation

Coordinator validation on latest head `b5926379cb90e25a75d7394cdd676372e07a895d`:

```sh
GOWORK=off go test ./TreeDB/collections -run 'TestColumnVectorGraphNativeSearchVisitedEpochReuseGrowthWrap2273' -count=1
GOWORK=off go test ./TreeDB/collections -run 'TestColumnGraph|TestVectorIndexSearcher|TestSearchVectorIndexQuantized' -count=1
GOWORK=off go test ./TreeDB/collections -count=1
GOWORK=off go test -race ./TreeDB/collections -run 'TestColumnGraphScalarU8QuantizedModesConcurrentSearch1926|TestVectorIndexSearcherQuantizedSearchWithBufferSuccessAndErrorReset1926' -count=1
git diff --check origin/main...HEAD
```

All passed. Latest-head CI is green, merge state is `CLEAN`, mergeable is `MERGEABLE`, unresolved non-outdated review threads are 0, Codex reported no major issues, and CodeRabbit latest-head review completed/pass with no actionable threads.
