### PR TITLE
Optimize TreeDB column_graph prepared adjacency iteration

### DIFF
--- a/TreeDB/collections/column_vector_graph_adjacency_direct_source.go
+++ b/TreeDB/collections/column_vector_graph_adjacency_direct_source.go
@@ -368,6 +368,19 @@ func (g *columnVectorGraphAdjacencyDirectSources) Neighbors(layer, ordinal int) 
 	return g.sources[layer].Neighbors(ordinal)
 }
 
+func (g *columnVectorGraphAdjacencyDirectSources) preparedCSRNeighbors(layer, ordinal int) ([]uint32, typeddecode.Reason, bool) {
+	if g == nil {
+		return nil, "", false
+	}
+	if g.closed {
+		return nil, typeddecode.ReasonStaleHandle, false
+	}
+	if layer < 0 || layer >= len(g.sources) || g.sources[layer] == nil {
+		return nil, typeddecode.ReasonRowCountMismatch, false
+	}
+	return g.sources[layer].preparedCSRNeighbors(ordinal)
+}
+
 func (g *columnVectorGraphAdjacencyDirectSources) MaxLayerForOrdinal(ordinal int) (int, []uint32, columnVectorGraphAdjacencySourceCounterSnapshot, typeddecode.Reason, bool) {
 	if g == nil || g.closed || len(g.sources) == 0 {
 		return 0, nil, columnVectorGraphAdjacencySourceCounterSnapshot{}, "", false
@@ -433,6 +446,34 @@ func (s *columnVectorGraphLayer0AdjacencyDirectSource) Neighbors(ordinal int) ([
 		return nil, columnVectorGraphLayer0AdjacencySourceOutcomeUnknown, typeddecode.ReasonValuesLengthMismatch, false
 	}
 	return s.values[int(start64):int(end64)], s.outcome, "", true
+}
+
+func (s *columnVectorGraphLayer0AdjacencyDirectSource) preparedCSRNeighbors(ordinal int) ([]uint32, typeddecode.Reason, bool) {
+	if s == nil {
+		return nil, "", false
+	}
+	if s.closed {
+		return nil, typeddecode.ReasonStaleHandle, false
+	}
+	if s.outcome != columnVectorGraphLayer0AdjacencySourceOutcomePreparedCSRMmapDirect {
+		return nil, typeddecode.ReasonHandleSourceUnsupported, false
+	}
+	if !s.owned && (s.offsetsHandle == nil || s.valuesHandle == nil || s.offsetsHandle.Released() || s.valuesHandle.Released()) {
+		return nil, typeddecode.ReasonStaleHandle, false
+	}
+	return s.neighborsUncheckedHandle(ordinal)
+}
+
+func (s *columnVectorGraphLayer0AdjacencyDirectSource) neighborsUncheckedHandle(ordinal int) ([]uint32, typeddecode.Reason, bool) {
+	if ordinal < 0 || ordinal >= s.rows || ordinal+1 >= len(s.offsets) {
+		return nil, typeddecode.ReasonRowCountMismatch, false
+	}
+	start64 := s.offsets[ordinal]
+	end64 := s.offsets[ordinal+1]
+	if end64 < start64 || end64 > uint64(len(s.values)) || end64 > uint64(math.MaxInt) {
+		return nil, typeddecode.ReasonValuesLengthMismatch, false
+	}
+	return s.values[int(start64):int(end64)], "", true
 }
 
 func (s *columnVectorGraphLayer0AdjacencyDirectSource) captureResourceStats() {

--- a/TreeDB/collections/column_vector_graph_adjacency_direct_source_test.go
+++ b/TreeDB/collections/column_vector_graph_adjacency_direct_source_test.go
@@ -481,6 +481,58 @@ func TestColumnVectorGraphAllLayerAdjacencyDirectSourcesSearchParity1921(t *test
 	}
 }
 
+func TestColumnVectorGraphPreparedCSRAdjacencyNeighborsFastPath2274(t *testing.T) {
+	source := &columnVectorGraphLayer0AdjacencyDirectSource{
+		layer:   0,
+		rows:    3,
+		offsets: []uint64{0, 2, 2, 3},
+		values:  []uint32{7, 11, 13},
+		outcome: columnVectorGraphLayer0AdjacencySourceOutcomePreparedCSRMmapDirect,
+		owned:   true,
+	}
+	group := &columnVectorGraphAdjacencyDirectSources{sources: []*columnVectorGraphLayer0AdjacencyDirectSource{source}, allLayers: true}
+	got, reason, ok := group.preparedCSRNeighbors(0, 0)
+	if !ok || reason != "" || len(got) != 2 || got[0] != 7 || got[1] != 11 {
+		t.Fatalf("row 0 prepared neighbors=%v reason=%s ok=%v, want [7 11]", got, reason, ok)
+	}
+	got, reason, ok = group.preparedCSRNeighbors(0, 1)
+	if !ok || reason != "" || len(got) != 0 {
+		t.Fatalf("row 1 prepared neighbors=%v reason=%s ok=%v, want empty direct slice", got, reason, ok)
+	}
+	_, reason, ok = group.preparedCSRNeighbors(0, 3)
+	if ok || reason != typeddecode.ReasonRowCountMismatch {
+		t.Fatalf("out-of-range prepared neighbors reason=%s ok=%v, want row-count mismatch", reason, ok)
+	}
+	badOffsets := &columnVectorGraphLayer0AdjacencyDirectSource{
+		rows:    1,
+		offsets: []uint64{0, 2},
+		values:  []uint32{1},
+		outcome: columnVectorGraphLayer0AdjacencySourceOutcomePreparedCSRMmapDirect,
+		owned:   true,
+	}
+	_, reason, ok = badOffsets.preparedCSRNeighbors(0)
+	if ok || reason != typeddecode.ReasonValuesLengthMismatch {
+		t.Fatalf("malformed prepared neighbors reason=%s ok=%v, want values-length mismatch", reason, ok)
+	}
+	source.outcome = columnVectorGraphLayer0AdjacencySourceOutcomeTypedListMmapDirect
+	_, reason, ok = group.preparedCSRNeighbors(0, 0)
+	if ok || reason != typeddecode.ReasonHandleSourceUnsupported {
+		t.Fatalf("non-prepared outcome reason=%s ok=%v, want handle-source unsupported", reason, ok)
+	}
+	source.outcome = columnVectorGraphLayer0AdjacencySourceOutcomePreparedCSRMmapDirect
+	source.owned = false
+	_, reason, ok = group.preparedCSRNeighbors(0, 0)
+	if ok || reason != typeddecode.ReasonStaleHandle {
+		t.Fatalf("nil handle prepared neighbors reason=%s ok=%v, want stale handle", reason, ok)
+	}
+	source.owned = true
+	source.closed = true
+	_, reason, ok = group.preparedCSRNeighbors(0, 0)
+	if ok || reason != typeddecode.ReasonStaleHandle {
+		t.Fatalf("closed prepared neighbors reason=%s ok=%v, want stale handle", reason, ok)
+	}
+}
+
 func TestColumnVectorGraphAllLayerAdjacencyDirectSourcesEmptyUpperLayers1921(t *testing.T) {
 	d, col, def, _, rows := openManualColumnGraphAllLayerSourceSearchFixture1921(t, nil)
 	defer func() { _ = d.Close() }()

--- a/TreeDB/collections/column_vector_graph_prepared_search.go
+++ b/TreeDB/collections/column_vector_graph_prepared_search.go
@@ -826,11 +826,11 @@ func (v *columnVectorGraphPreparedSearchView) adjacencyLayerForOrdinal(ordinal i
 	if v == nil || v.adjacency == nil {
 		return nil, columnVectorGraphLayer0AdjacencySourceOutcomeUnknown, errors.New("collections: column_graph prepared adjacency view is unavailable")
 	}
-	neighbors, outcome, reason, ok := v.adjacency.Neighbors(layer, ordinal)
+	neighbors, reason, ok := v.adjacency.preparedCSRNeighbors(layer, ordinal)
 	if !ok {
-		return nil, outcome, fmt.Errorf("collections: column_graph prepared adjacency ordinal=%d layer=%d unavailable reason=%s", ordinal, layer, reason)
+		return nil, columnVectorGraphLayer0AdjacencySourceOutcomeUnknown, fmt.Errorf("collections: column_graph prepared adjacency ordinal=%d layer=%d unavailable reason=%s", ordinal, layer, reason)
 	}
-	return neighbors, outcome, nil
+	return neighbors, columnVectorGraphLayer0AdjacencySourceOutcomePreparedCSRMmapDirect, nil
 }
 
 func (v *columnVectorGraphPreparedSearchView) documentIDForOrdinal(ordinal int) ([]byte, bool) {

--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -1423,6 +1423,7 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 	}
 	visitMarks := scratch.visitMarks
 	visitEpoch := scratch.visitEpoch
+	rowCount64 := uint64(rowCount)
 	entryOrdinal, ok := columnVectorGraphNextCandidateSeed(0, rowCount, candidateRows, hasCandidateRows, visitMarks, visitEpoch)
 	if !ok {
 		return scratch.results, stats, nil
@@ -1488,82 +1489,92 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 				return nil, stats, err
 			}
 			if plan != nil && (plan.quantizedScorerActive || plan.preparedSearch != nil || plan.scoreBatchMode.indexedEnabled()) {
-				for i := 0; i < len(adjacency); {
-					tileCap := len(adjacency) - i
-					scratch.scoreTileOrdinals = ensureColumnVectorGraphNativeIntScratch(scratch.scoreTileOrdinals, tileCap)
-					tile := scratch.scoreTileOrdinals[:0]
-					if debugStats == nil && debugCounters == nil {
-						// Keep the steady-state visited check/mark loop free of
-						// benchmark-debug counter branches; the debug path below
-						// preserves the #2271 counter contract.
-						for i < len(adjacency) && len(tile) < tileCap {
-							neighborIndex := i
-							neighbor := adjacency[i]
-							i++
+				if len(adjacency) == 0 {
+					continue
+				}
+				scratch.scoreTileOrdinals = ensureColumnVectorGraphNativeIntScratch(scratch.scoreTileOrdinals, len(adjacency))
+				tile := scratch.scoreTileOrdinals[:0]
+				if debugStats == nil && debugCounters == nil {
+					// Keep the steady-state visited check/mark loop free of
+					// benchmark-debug counter branches; the debug path below
+					// preserves the #2271 counter contract.
+					if !hasCandidateRows {
+						for i, neighbor := range adjacency {
 							if countLoopEdges {
 								loopEdgeVisits++
 							}
-							if uint64(neighbor) >= uint64(rowCount) {
-								return nil, stats, fmt.Errorf("collections: column_graph %q ordinal=%d adjacency[%d]=%d outside row_count=%d: %w", r.def.Name, candidate.ordinal, neighborIndex, neighbor, rowCount, errColumnVectorGraphAdjacencyOrdinalOutOfBounds)
+							if uint64(neighbor) >= rowCount64 {
+								return nil, stats, fmt.Errorf("collections: column_graph %q ordinal=%d adjacency[%d]=%d outside row_count=%d: %w", r.def.Name, candidate.ordinal, i, neighbor, rowCount, errColumnVectorGraphAdjacencyOrdinalOutOfBounds)
 							}
 							neighborOrdinal := int(neighbor)
 							if visitMarks[neighborOrdinal] == visitEpoch {
-								continue
-							}
-							if !columnVectorGraphCandidateRowAllowed(candidateRows, hasCandidateRows, neighborOrdinal) {
-								visitMarks[neighborOrdinal] = visitEpoch
 								continue
 							}
 							visitMarks[neighborOrdinal] = visitEpoch
 							tile = append(tile, neighborOrdinal)
 						}
 					} else {
-						for i < len(adjacency) && len(tile) < tileCap {
-							neighborIndex := i
-							neighbor := adjacency[i]
-							i++
+						for i, neighbor := range adjacency {
 							if countLoopEdges {
 								loopEdgeVisits++
 							}
-							if debugStats != nil {
-								debugStats.Layer0EdgeVisits++
-							}
-							if uint64(neighbor) >= uint64(rowCount) {
-								return nil, stats, fmt.Errorf("collections: column_graph %q ordinal=%d adjacency[%d]=%d outside row_count=%d: %w", r.def.Name, candidate.ordinal, neighborIndex, neighbor, rowCount, errColumnVectorGraphAdjacencyOrdinalOutOfBounds)
+							if uint64(neighbor) >= rowCount64 {
+								return nil, stats, fmt.Errorf("collections: column_graph %q ordinal=%d adjacency[%d]=%d outside row_count=%d: %w", r.def.Name, candidate.ordinal, i, neighbor, rowCount, errColumnVectorGraphAdjacencyOrdinalOutOfBounds)
 							}
 							neighborOrdinal := int(neighbor)
 							if visitMarks[neighborOrdinal] == visitEpoch {
-								if debugStats != nil {
-									debugStats.VisitedMarkChecks++
-									debugStats.VisitedMarkHits++
-									debugStats.AlreadyVisitedSkips++
-									debugStats.SkippedNeighbors++
-									debugStats.Layer0AlreadyVisitedSkips++
-								}
 								continue
 							}
-							if debugStats != nil {
-								debugStats.VisitedMarkChecks++
-								debugStats.VisitedMarkMisses++
-							}
-							if !columnVectorGraphCandidateRowAllowed(candidateRows, hasCandidateRows, neighborOrdinal) {
-								if debugCounters != nil {
-									debugCounters.recordFilterSkip(true)
-									debugCounters.recordVisitedInsert()
-								}
+							if !columnVectorGraphCandidateRowAllowed(candidateRows, true, neighborOrdinal) {
 								visitMarks[neighborOrdinal] = visitEpoch
 								continue
-							}
-							if debugCounters != nil {
-								debugCounters.recordVisitedInsert()
 							}
 							visitMarks[neighborOrdinal] = visitEpoch
 							tile = append(tile, neighborOrdinal)
 						}
 					}
-					if len(tile) == 0 {
-						continue
+				} else {
+					for i, neighbor := range adjacency {
+						if countLoopEdges {
+							loopEdgeVisits++
+						}
+						if debugStats != nil {
+							debugStats.Layer0EdgeVisits++
+						}
+						if uint64(neighbor) >= rowCount64 {
+							return nil, stats, fmt.Errorf("collections: column_graph %q ordinal=%d adjacency[%d]=%d outside row_count=%d: %w", r.def.Name, candidate.ordinal, i, neighbor, rowCount, errColumnVectorGraphAdjacencyOrdinalOutOfBounds)
+						}
+						neighborOrdinal := int(neighbor)
+						if visitMarks[neighborOrdinal] == visitEpoch {
+							if debugStats != nil {
+								debugStats.VisitedMarkChecks++
+								debugStats.VisitedMarkHits++
+								debugStats.AlreadyVisitedSkips++
+								debugStats.SkippedNeighbors++
+								debugStats.Layer0AlreadyVisitedSkips++
+							}
+							continue
+						}
+						if debugStats != nil {
+							debugStats.VisitedMarkChecks++
+							debugStats.VisitedMarkMisses++
+						}
+						if !columnVectorGraphCandidateRowAllowed(candidateRows, hasCandidateRows, neighborOrdinal) {
+							if debugCounters != nil {
+								debugCounters.recordFilterSkip(true)
+								debugCounters.recordVisitedInsert()
+							}
+							visitMarks[neighborOrdinal] = visitEpoch
+							continue
+						}
+						if debugCounters != nil {
+							debugCounters.recordVisitedInsert()
+						}
+						visitMarks[neighborOrdinal] = visitEpoch
+						tile = append(tile, neighborOrdinal)
 					}
+				}
+				if len(tile) != 0 {
 					if err := r.scoreAndPushFrontierVisitedTile(plan, singleBlockView, query, queryInvNorm, tile, retainedCandidateLimit, scratch, hotStats, &visitedCandidates, preparedMinimalCounters, debugCounters, columnVectorGraphNativeSearchScoreContextLayer0Neighbor); err != nil {
 						return nil, stats, err
 					}
@@ -2303,7 +2314,7 @@ func (r *columnVectorGraphPhysicalRowReader) scoreOrdinalLegacy(plan *columnVect
 
 func (r *columnVectorGraphPhysicalRowReader) expandCandidateAdjacencyLayer(plan *columnVectorGraphSearchPlan, singleBlockView *columnVectorGraphBlockView, ordinal int, layer int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats, preparedMinimal *columnVectorGraphPreparedMinimalSearchCounters, debugCounters *columnVectorGraphNativeSearchDebugCounters) ([]uint32, error) {
 	if plan != nil && plan.preparedSearch != nil {
-		layerAdjacency, outcome, err := plan.preparedSearch.adjacencyLayerForOrdinal(ordinal, layer)
+		layerAdjacency, _, err := plan.preparedSearch.adjacencyLayerForOrdinal(ordinal, layer)
 		if err != nil {
 			return nil, err
 		}
@@ -2315,7 +2326,7 @@ func (r *columnVectorGraphPhysicalRowReader) expandCandidateAdjacencyLayer(plan 
 		} else if stats != nil {
 			stats.ExpansionFetches++
 			stats.AdjacencyExpansions++
-			recordColumnVectorGraphAdjacencySourceOutcomeStats(stats, len(layerAdjacency), outcome)
+			recordColumnVectorGraphPreparedCSRAdjacencyStats(stats, len(layerAdjacency))
 			stats.BlockViewHits = plan.hits
 			stats.BlockViewMisses = plan.misses
 			stats.BlockViewBuilds = plan.builds
@@ -2448,6 +2459,17 @@ func recordColumnVectorGraphAdjacencySourceStats(stats *columnVectorGraphNativeS
 	stats.AdjacencyScratchDecodes++
 }
 
+func recordColumnVectorGraphPreparedCSRAdjacencyStats(stats *columnVectorGraphNativeSearchStats, adjacencyLen int) {
+	if stats == nil {
+		return
+	}
+	stats.AdjacencyBytesRead += uint64(adjacencyLen) * 4
+	stats.AdjacencyDirectViews++
+	stats.AdjacencyMmapDirectViews++
+	stats.AdjacencyPreparedCSRDirectViews++
+	stats.AdjacencyPreparedCSRMmapDirectViews++
+}
+
 func recordColumnVectorGraphAdjacencySourceOutcomeStats(stats *columnVectorGraphNativeSearchStats, adjacencyLen int, outcome columnVectorGraphLayer0AdjacencySourceOutcome) {
 	var counters columnVectorGraphAdjacencySourceCounterSnapshot
 	counters.addOutcome(adjacencyLen, outcome)
@@ -2500,8 +2522,11 @@ func (r *columnVectorGraphPhysicalRowReader) directAdjacencyLayerForOrdinal(ordi
 	if r == nil {
 		return nil, columnVectorGraphLayer0AdjacencySourceOutcomeUnknown, "", false
 	}
-	if r.adjacencyLayerSources != nil {
-		return r.adjacencyLayerSources.Neighbors(layer, ordinal)
+	if group := r.adjacencyLayerSources; group != nil {
+		if group.closed || layer < 0 || layer >= len(group.sources) || group.sources[layer] == nil {
+			return nil, columnVectorGraphLayer0AdjacencySourceOutcomeUnknown, "", false
+		}
+		return group.sources[layer].Neighbors(ordinal)
 	}
 	if layer == 0 && r.layer0AdjacencySource != nil {
 		return r.layer0AdjacencySource.Neighbors(ordinal)


### PR DESCRIPTION
## Summary

Closes #2274.

Optimizes the TreeDB `column_graph` prepared CSR adjacency hot path without changing on-disk format, topology/traversal order, exact/quantized scoring semantics, or allocation behavior.

- Adds a prepared-CSR-only neighbor accessor that preserves stale/malformed/ineligible checks.
- Uses the prepared-CSR accessor from the combined prepared search view, avoiding the generic adjacency outcome/counter routing in the prepared path.
- Replaces the layer-0 optimized neighbor loop with a single-tile fast path and keeps the benchmark-debug counter path separate for #2271 counter parity.
- Adds a small direct-dispatch fast path for `directAdjacencyLayerForOrdinal` so the adjacency iteration microbench does not regress.
- Adds coverage for valid, empty, out-of-range, malformed, ineligible, and stale prepared CSR neighbor paths.

## Benchmark evidence

Baseline artifact: `/tmp/gomap_2274_before_20260604_082236`  
Final candidate artifact: `/tmp/gomap_2274_final_bench_20260604_090425`

Final `benchstat` highlights:

```text
BenchmarkColumnGraphScalarU8QuantizedScorePlanes1926/mode=exact      14.52µ -> 13.77µ  -5.18% (p=0.008 n=5)
BenchmarkColumnGraphScalarU8QuantizedScorePlanes1926/mode=quantized_only 14.28µ -> 13.91µ  directionally lower (p=0.095 n=5)
geomean exact+quantized_only: 14.40µ -> 13.84µ  -3.89%
BenchmarkColumnGraphScalarU8QuantizedScorePlanes1926/mode=quantized_rerank/candidates=32 14.84µ -> 13.81µ -6.95% (p=0.008 n=5)
BenchmarkColumnVectorGraphAdjacencyIteration2271 9.757ns -> 9.550ns, 0 allocs/op, no significant regression (p=0.690 n=5)
```

Invariant checks from final benchstat/output:

- `B/op=0`, `allocs/op=0` unchanged for exact, quantized-only, rerank, and adjacency iteration.
- `adjacency_B/search`, visited nodes/edges, candidates, score calls, result fetches, and recall remain unchanged.
- `adjacency_legacy_fallbacks/search=0` and `adjacency_source_fallbacks/search=0` remain unchanged.
- Quantized-only keeps `vector_B/search=0` and `norm_B/search=0`.

CPU profiles captured in the final artifact:

- `/tmp/gomap_2274_final_bench_20260604_090425/cpu_exact_after.pprof`
- `/tmp/gomap_2274_final_bench_20260604_090425/cpu_quantized_only_after.pprof`

## Tests

```text
GOWORK=off go test ./TreeDB/collections -run 'TestColumnVectorGraphPreparedCSRAdjacencyNeighborsFastPath2274|TestColumnVectorGraphPreparedSearch|TestColumnVectorGraphAllLayerAdjacencyDirectSourcesSearchParity1921' -count=1
GOWORK=off go test ./TreeDB/collections -count=1
GOWORK=off go test ./TreeDB/... -count=1
```

Additional focused stale/direct-source tests were run during development, including `TestColumnVectorGraphLayer0AdjacencySourceStaleHandlesFallback1919`.

## Merge policy

Do not merge from this manager branch without coordinator approval.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized adjacency neighbor retrieval for faster graph search operations
  * Implemented caching to improve search efficiency

* **Improvements**
  * Strengthened validation and bounds checking in adjacency layer operations
  * Enhanced error handling in graph search scenarios

* **Tests**
  * Added comprehensive test coverage for optimized adjacency retrieval functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Coordinator final validation

Coordinator validation on latest head `4dc23d1ee90cbb93ab5e585c98df4036498c1f07`:

```sh
GOWORK=off go test ./TreeDB/collections -run 'TestColumnGraph|TestVectorIndexSearcher|TestSearchVectorIndexQuantized|TestColumnVectorGraph.*Adjacency' -count=1
GOWORK=off go test ./TreeDB/collections -count=1
GOWORK=off go test ./TreeDB/... -count=1
git diff --check origin/main...HEAD
```

All passed. Latest-head CI is green, merge state is `CLEAN`, mergeable is `MERGEABLE`, unresolved non-outdated review threads are 0, Codex reported no major issues, and CodeRabbit latest-head review completed/pass with no actionable threads.
