### PR TITLE
TreeDB: add exhaustive compact storage mode

### DIFF
--- a/TreeDB/README.md
+++ b/TreeDB/README.md
@@ -245,7 +245,7 @@ done
 - CRC checksums detect accidental corruption, not malicious tampering; use filesystem encryption/HMAC if your threat model includes adversarial disk access.
 - `GetUnsafe` on a `Snapshot` and iterator `Key()`/`Value()` return short-lived views; use `Get`, `KeyCopy`, or `ValueCopy` for stable bytes.
 - TreeDB does not provide encryption-at-rest or secure deletion; deleted data may remain on disk until compacted. Use OS/disk encryption for confidentiality.
-- For final disk footprint, use `db.CompactStorage(ctx, treedb.CompactStorageOptions{Mode: treedb.CompactStorageFull})` or `treemap compact <db-dir> -rw`. This is the best-practice path across `index.db`, `value_vlog`, `leaf_vlog`, and empty segment cleanup; platforms without online index vacuum report that phase as skipped while still compacting the value-log domains.
+- For production final disk footprint, use `db.CompactStorage(ctx, treedb.CompactStorageOptions{Mode: treedb.CompactStorageFull})` or `treemap compact <db-dir> -rw`. This is the best-practice policy path across `index.db`, `value_vlog`, `leaf_vlog`, and empty segment cleanup; platforms without online index vacuum report that phase as skipped while still compacting the value-log domains. For byte-minimized benchmark/VACUUM-equivalent claims, use `CompactStorageExhaustive` or `treemap compact <db-dir> -rw -mode exhaustive`, which also seals the current leaf generation and bypasses production leaf-pack yield thresholds.
 - Low-level APIs such as `ValueLogGC`, `ValueLogRewriteOffline`, `LeafGenerationPack*`, and `VacuumIndex*` are maintenance building blocks. Do not manually chain them for benchmark storage numbers unless you are working on TreeDB internals.
 - Optional guardrail: `Options.ValueLog.MaxRetainedBytes` emits a warning when retained value-log bytes exceed the threshold.
 - Optional hard cap: `Options.ValueLog.MaxRetainedBytesHard` disables value-log pointers for new large values once retained bytes exceed the threshold.
@@ -277,7 +277,7 @@ after the collection WAL gate, not current behavior.
 - Optional piggyback compaction toggle: `DisablePiggybackCompaction`
 - Value-log retention guardrails: `ValueLog.MaxRetainedBytes`, `ValueLog.MaxRetainedBytesHard`
 - Value-log compression mode: `ValueLog.Compression` (`off|block|dict|auto`) and `ValueLog.BlockCodec` (`snappy|lz4`)
-- Full storage compaction: `db.CompactStorage(ctx, treedb.CompactStorageOptions{Mode: treedb.CompactStorageFull})` or `treemap compact <db-dir> -rw`
+- Full storage compaction: `db.CompactStorage(ctx, treedb.CompactStorageOptions{Mode: treedb.CompactStorageFull})` or `treemap compact <db-dir> -rw`; benchmark byte-minimized compaction: `CompactStorageExhaustive` or `treemap compact <db-dir> -rw -mode exhaustive`
 - Index-only rebuild: `treedb.CompactIndex()` or `treedb.VacuumIndexOffline(opts)` when you explicitly want only `index.db` maintenance
 
 `ValueLog.Compression` defaults to `auto` when unset.

--- a/TreeDB/cmd/treemap/main.go
+++ b/TreeDB/cmd/treemap/main.go
@@ -487,7 +487,7 @@ func runCompact(dir string, args []string) {
 	rw := fs.Bool("rw", false, "Open read-write (required; may replay WAL or repair files)")
 	jsonOut := fs.Bool("json", false, "Emit JSON report")
 	scope := fs.String("scope", "all", "Compaction scope: all|index")
-	mode := fs.String("mode", "full", "Compaction mode: full|quick")
+	mode := fs.String("mode", "full", "Compaction mode: full|quick|exhaustive")
 	syncEachPhase := fs.Bool("sync-each-phase", false, "Force fsync boundaries for rewrite/pack batches")
 	batchSize := fs.Int("rewrite-batch-size", 0, "Value-log rewrite pointer-swap batch size (0=default)")
 	maxSegmentBytes := fs.Int64("rewrite-max-segment-bytes", 0, "Maximum value-log segment bytes during rewrite (0=default)")
@@ -531,7 +531,7 @@ func runCompact(dir string, args []string) {
 func runCompactPlan(dir string, args []string) {
 	fs := flag.NewFlagSet("compact-plan", flag.ExitOnError)
 	jsonOut := fs.Bool("json", false, "Emit JSON report")
-	mode := fs.String("mode", "full", "Compaction mode: full|quick")
+	mode := fs.String("mode", "full", "Compaction mode: full|quick|exhaustive")
 	_ = fs.Parse(args)
 
 	opts := treedb.Options{Dir: dir, ReadOnly: true}
@@ -553,8 +553,10 @@ func parseCompactStorageModeFlag(command, raw string) treedbdb.CompactStorageMod
 		return treedbdb.CompactStorageFull
 	case "quick":
 		return treedbdb.CompactStorageQuick
+	case "exhaustive":
+		return treedbdb.CompactStorageExhaustive
 	default:
-		fatalf("%s -mode must be full or quick", command)
+		fatalf("%s -mode must be full, quick, or exhaustive", command)
 		return treedbdb.CompactStorageFull
 	}
 }
@@ -574,9 +576,11 @@ func printCompactStorageStats(stats treedb.CompactStorageStats, jsonOut bool) {
 	}
 	beforeTotal := compactStorageUsageBytes(stats.Before, "total")
 	afterTotal := compactStorageUsageBytes(stats.After, "total")
-	fmt.Printf("compact-storage (%s): fully_compacted=%t before_bytes=%d after_bytes=%d\n",
+	fmt.Printf("compact-storage (%s): fully_compacted=%t policy_fully_compacted=%t byte_minimized=%t before_bytes=%d after_bytes=%d\n",
 		mode,
 		stats.FullyCompacted,
+		stats.PolicyFullyCompacted,
+		stats.ByteMinimized,
 		beforeTotal,
 		afterTotal,
 	)

--- a/TreeDB/compact_storage.go
+++ b/TreeDB/compact_storage.go
@@ -11,9 +11,10 @@ import (
 type CompactStorageMode = treedbdb.CompactStorageMode
 
 const (
-	CompactStorageDefault = treedbdb.CompactStorageDefault
-	CompactStorageFull    = treedbdb.CompactStorageFull
-	CompactStorageQuick   = treedbdb.CompactStorageQuick
+	CompactStorageDefault    = treedbdb.CompactStorageDefault
+	CompactStorageFull       = treedbdb.CompactStorageFull
+	CompactStorageQuick      = treedbdb.CompactStorageQuick
+	CompactStorageExhaustive = treedbdb.CompactStorageExhaustive
 )
 
 // CompactStorageOptions controls full storage compaction across TreeDB storage

--- a/TreeDB/db/compact_storage.go
+++ b/TreeDB/db/compact_storage.go
@@ -247,6 +247,9 @@ func (db *DB) compactStorage(ctx context.Context, opts CompactStorageOptions) (C
 		return stats, err
 	}
 	defer cleanupLeafLog()
+	if opts.Mode == CompactStorageExhaustive && db.indexOuterLeavesInValueLog && compactLeafLog == nil && db.leafPageLog != nil {
+		return stats, fmt.Errorf("treedb: exhaustive compact requires an internally-owned leaf page log; close or clear the installed leaf page log before compacting")
+	}
 	if err := db.runCompactStoragePhase(&stats, "value-log-rewrite", func() error {
 		protectedPaths := compactStorageOnlineRewriteProtectedPaths(opts)
 		protectedRootIDs, protectedSystemRootIDs := db.compactStorageLeafGenerationProtectedRootIDPair(opts)

--- a/TreeDB/db/compact_storage.go
+++ b/TreeDB/db/compact_storage.go
@@ -19,9 +19,10 @@ import (
 type CompactStorageMode string
 
 const (
-	CompactStorageDefault CompactStorageMode = ""
-	CompactStorageFull    CompactStorageMode = "full"
-	CompactStorageQuick   CompactStorageMode = "quick"
+	CompactStorageDefault    CompactStorageMode = ""
+	CompactStorageFull       CompactStorageMode = "full"
+	CompactStorageQuick      CompactStorageMode = "quick"
+	CompactStorageExhaustive CompactStorageMode = "exhaustive"
 )
 
 // CompactStorageOptions controls full storage compaction across TreeDB storage
@@ -75,7 +76,12 @@ type CompactStorageOptions struct {
 	LeafPackMinExpectedReclaimBytes       int64
 	LeafPackMinExpectedReclaimRatioPPM    int
 	LeafPackMinReclaimPerCopyPPM          int
-	LeafPackLeafFrameK                    int
+	// LeafPackForce bypasses leaf-pack admission thresholds. It is enabled by
+	// CompactStorageExhaustive so benchmark/VACUUM-equivalent compaction can
+	// drain low-yield physical debt instead of stopping at production policy
+	// thresholds.
+	LeafPackForce      bool
+	LeafPackLeafFrameK int
 
 	// ReserveRIDs lets cached-mode callers share the live RID allocator with
 	// foreground writers.
@@ -157,8 +163,13 @@ type CompactStorageStats struct {
 
 	ZeroByteValueLogFilesDeleted int `json:"zero_byte_value_log_files_deleted,omitempty"`
 
-	RemainingDebt  CompactStorageDebt `json:"remaining_debt"`
-	FullyCompacted bool               `json:"fully_compacted"`
+	RemainingDebt CompactStorageDebt `json:"remaining_debt"`
+
+	// FullyCompacted is the legacy policy-oriented compacted flag. For
+	// exhaustive mode, ByteMinimized reports the stricter benchmark contract.
+	FullyCompacted       bool `json:"fully_compacted"`
+	PolicyFullyCompacted bool `json:"policy_fully_compacted"`
+	ByteMinimized        bool `json:"byte_minimized"`
 }
 
 // CompactStoragePlan reports full storage compaction debt without mutating the
@@ -217,6 +228,8 @@ func (db *DB) compactStorage(ctx context.Context, opts CompactStorageOptions) (C
 	if opts.DryRun {
 		stats.After = before
 		stats.FullyCompacted = initialDebt.Empty()
+		stats.PolicyFullyCompacted = stats.FullyCompacted
+		stats.ByteMinimized = false
 		return stats, nil
 	}
 
@@ -268,6 +281,21 @@ func (db *DB) compactStorage(ctx context.Context, opts CompactStorageOptions) (C
 		return db.Checkpoint()
 	}); err != nil {
 		return stats, err
+	}
+
+	if opts.Mode == CompactStorageExhaustive {
+		sealedCurrent := false
+		if err := db.runCompactStoragePhase(&stats, "seal-current-leaf-generation", func() error {
+			var err error
+			sealedCurrent, err = db.sealCompactStorageCurrentLeafGeneration(compactLeafLog)
+			return err
+		}); err != nil {
+			return stats, err
+		}
+		if !sealedCurrent && len(stats.Phases) > 0 {
+			stats.Phases[len(stats.Phases)-1].Skipped = true
+			stats.Phases[len(stats.Phases)-1].SkipReason = "no current leaf generation files"
+		}
 	}
 
 	for pass := 0; pass < opts.LeafPackMaxPasses; pass++ {
@@ -374,7 +402,67 @@ func (db *DB) compactStorage(ctx context.Context, opts CompactStorageOptions) (C
 	stats.LeafGenerationPlan = finalAudit.LeafGenerationPlan
 	stats.RemainingDebt = finalDebt
 	stats.FullyCompacted = finalDebt.Empty()
+	stats.PolicyFullyCompacted = stats.FullyCompacted
+	stats.ByteMinimized = opts.Mode == CompactStorageExhaustive && finalDebt.Empty()
 	return stats, nil
+}
+
+func (db *DB) sealCompactStorageCurrentLeafGeneration(compactLeafLog *rewriteWriter) (bool, error) {
+	if db == nil || db.leafGenerationManifest == nil {
+		return false, nil
+	}
+	commitSeq := uint64(1)
+	if state := db.State(); state != nil && state.CommitSeq != 0 {
+		commitSeq = state.CommitSeq
+	}
+	db.mu.Lock()
+	if db.leafGenerationManifest == nil {
+		db.mu.Unlock()
+		return false, nil
+	}
+	nextManifest := db.leafGenerationManifest.clone()
+	db.mu.Unlock()
+
+	rawFileIDs, changed, err := nextManifest.sealCurrentGeneration(commitSeq)
+	if err != nil {
+		return false, err
+	}
+	if !changed {
+		return false, nil
+	}
+
+	if compactLeafLog != nil {
+		if _, currentFileID, ok := compactLeafLog.CurrentValueLogSegment(); ok {
+			if currentRawFileID, ok := rawLeafGenerationFileID(currentFileID); ok {
+				for _, sealedRawFileID := range rawFileIDs {
+					if sealedRawFileID == currentRawFileID {
+						if err := compactLeafLog.rotateLeaf(); err != nil {
+							return false, err
+						}
+						if db.valueLogManager != nil {
+							if rotatedPath, rotatedFileID, ok := compactLeafLog.CurrentValueLogSegment(); ok {
+								if err := db.valueLogManager.RegisterSegment(rotatedPath, rotatedFileID); err != nil {
+									return false, err
+								}
+							}
+						}
+						break
+					}
+				}
+			}
+		}
+	}
+
+	if err := db.persistLeafGenerationManifestAndRecordLengthIndexes(nextManifest, rawFileIDs); err != nil {
+		return false, err
+	}
+	db.mu.Lock()
+	db.leafGenerationManifest = nextManifest
+	db.mu.Unlock()
+	if err := db.publishLeafGenerationState(false); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 func (db *DB) settleCompactStorageGC(ctx context.Context, opts CompactStorageOptions, stats *CompactStorageStats, lockMaintenance bool) error {
@@ -473,17 +561,23 @@ func normalizeCompactStorageOptions(opts CompactStorageOptions) CompactStorageOp
 	switch opts.Mode {
 	case CompactStorageDefault:
 		opts.Mode = CompactStorageFull
-	case CompactStorageFull, CompactStorageQuick:
+	case CompactStorageFull, CompactStorageQuick, CompactStorageExhaustive:
 	default:
 		opts.Mode = CompactStorageFull
 	}
 	if opts.ValueLogRewriteBatchSize < 0 {
 		opts.ValueLogRewriteBatchSize = 0
 	}
+	if opts.Mode == CompactStorageExhaustive {
+		opts.LeafPackForce = true
+	}
 	if opts.LeafPackMaxPasses <= 0 {
-		if opts.Mode == CompactStorageQuick {
+		switch opts.Mode {
+		case CompactStorageQuick:
 			opts.LeafPackMaxPasses = 1
-		} else {
+		case CompactStorageExhaustive:
+			opts.LeafPackMaxPasses = 256
+		default:
 			opts.LeafPackMaxPasses = 32
 		}
 	}
@@ -491,9 +585,12 @@ func normalizeCompactStorageOptions(opts CompactStorageOptions) CompactStorageOp
 		opts.LeafPackMaxGenerationsPerPass = 0
 	}
 	if opts.LeafPackMaxGenerationsPerPass == 0 {
-		if opts.Mode == CompactStorageQuick {
+		switch opts.Mode {
+		case CompactStorageQuick:
 			opts.LeafPackMaxGenerationsPerPass = 8
-		} else {
+		case CompactStorageExhaustive:
+			opts.LeafPackMaxGenerationsPerPass = 0
+		default:
 			opts.LeafPackMaxGenerationsPerPass = 64
 		}
 	}
@@ -501,9 +598,12 @@ func normalizeCompactStorageOptions(opts CompactStorageOptions) CompactStorageOp
 		opts.LeafPackMaxBytesToCopyPerPass = 0
 	}
 	if opts.LeafPackMaxBytesToCopyPerPass == 0 {
-		if opts.Mode == CompactStorageQuick {
+		switch opts.Mode {
+		case CompactStorageQuick:
 			opts.LeafPackMaxBytesToCopyPerPass = 256 << 20
-		} else {
+		case CompactStorageExhaustive:
+			opts.LeafPackMaxBytesToCopyPerPass = 0
+		default:
 			opts.LeafPackMaxBytesToCopyPerPass = 1 << 30
 		}
 	}
@@ -520,6 +620,7 @@ func compactStorageRewritePlanOptions(protectedPaths []string) ValueLogRewriteOn
 func compactStorageLeafPackFromPlanOptions(opts CompactStorageOptions, protectedRootIDs, protectedSystemRootIDs []uint64) LeafGenerationPackFromPlanOptions {
 	out := LeafGenerationPackFromPlanOptions{
 		Sync:                       opts.SyncEachPhase,
+		Force:                      opts.LeafPackForce,
 		MinExpectedReclaimBytes:    opts.LeafPackMinExpectedReclaimBytes,
 		MinExpectedReclaimRatioPPM: opts.LeafPackMinExpectedReclaimRatioPPM,
 		MinReclaimPerByteCopiedPPM: opts.LeafPackMinReclaimPerCopyPPM,
@@ -530,7 +631,7 @@ func compactStorageLeafPackFromPlanOptions(opts CompactStorageOptions, protected
 		ProtectedRootIDs:           protectedRootIDs,
 		ProtectedSystemRootIDs:     protectedSystemRootIDs,
 	}
-	if out.MinExpectedReclaimBytes == 0 && out.MinExpectedReclaimRatioPPM == 0 && out.MinReclaimPerByteCopiedPPM == 0 {
+	if !out.Force && out.MinExpectedReclaimBytes == 0 && out.MinExpectedReclaimRatioPPM == 0 && out.MinReclaimPerByteCopiedPPM == 0 {
 		out.MinReclaimPerByteCopiedPPM = leafGenerationPackDefaultMinReclaimPerByteCopiedPPM
 	}
 	return out

--- a/TreeDB/db/compact_storage_test.go
+++ b/TreeDB/db/compact_storage_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -1306,6 +1307,16 @@ func TestCompactStorageExhaustiveSealsCurrentLeafGeneration(t *testing.T) {
 				}
 			}
 		}
+	}
+}
+
+func TestCompactStorageExhaustiveRefusesExternalLeafPageLog(t *testing.T) {
+	d, _, _ := openLeafGenerationPackTestDB(t)
+	writeLeafGenerationKeys(t, d, "current", 8, 'x')
+
+	_, err := d.CompactStorage(context.Background(), CompactStorageOptions{Mode: CompactStorageExhaustive})
+	if err == nil || !strings.Contains(err.Error(), "internally-owned leaf page log") {
+		t.Fatalf("CompactStorage exhaustive with external leaf log error=%v, want ownership error", err)
 	}
 }
 

--- a/TreeDB/db/compact_storage_test.go
+++ b/TreeDB/db/compact_storage_test.go
@@ -1267,6 +1267,64 @@ func TestCompactStoragePlanIgnoresEmptyAndCurrentLeafGenerations(t *testing.T) {
 	}
 }
 
+func TestCompactStorageExhaustiveSealsCurrentLeafGeneration(t *testing.T) {
+	d, leafLog, dir := openLeafGenerationPackTestDB(t)
+
+	writeLeafGenerationKeys(t, d, "current", 64, 'z')
+	_, fileID := currentLeafSegmentOrFatal(t, leafLog)
+	rawFileID := page.ValueLogSegmentID(fileID)
+	d.SetLeafPageLog(nil)
+
+	fullPlan, err := d.CompactStoragePlan(context.Background(), CompactStorageOptions{})
+	if err != nil {
+		t.Fatalf("CompactStoragePlan full: %v", err)
+	}
+	if fullPlan.RemainingDebt.LeafPackGenerations != 0 {
+		t.Fatalf("full mode should ignore current writable generation debt=%+v", fullPlan.RemainingDebt)
+	}
+
+	stats, err := d.CompactStorage(context.Background(), CompactStorageOptions{Mode: CompactStorageExhaustive})
+	if err != nil {
+		t.Fatalf("CompactStorage exhaustive: %v", err)
+	}
+	if !compactStoragePhaseSeen(stats.Phases, "seal-current-leaf-generation") {
+		t.Fatalf("missing seal-current-leaf-generation phase: %+v", stats.Phases)
+	}
+	if !stats.ByteMinimized || !stats.FullyCompacted || !stats.PolicyFullyCompacted {
+		t.Fatalf("unexpected compacted flags: byte=%t fully=%t policy=%t debt=%+v", stats.ByteMinimized, stats.FullyCompacted, stats.PolicyFullyCompacted, stats.RemainingDebt)
+	}
+	if len(stats.LeafGenerationPacks) == 0 || !stats.LeafGenerationPacks[0].Ran {
+		t.Fatalf("expected exhaustive leaf pack to run after sealing current generation: %+v", stats.LeafGenerationPacks)
+	}
+
+	manifest := loadLeafGenerationManifestOrFatal(t, dir)
+	for _, gen := range manifest.Generations {
+		if gen.State == leafGenerationStateWritable {
+			for _, got := range gen.FileIDs {
+				if got == rawFileID {
+					t.Fatalf("original current raw file %d remained writable after exhaustive compact: %+v", rawFileID, manifest.Generations)
+				}
+			}
+		}
+	}
+}
+
+func TestCompactStorageNormalizeExhaustiveForcesUnboundedLeafPack(t *testing.T) {
+	opts := normalizeCompactStorageOptions(CompactStorageOptions{Mode: CompactStorageExhaustive})
+	if opts.Mode != CompactStorageExhaustive {
+		t.Fatalf("Mode=%q want exhaustive", opts.Mode)
+	}
+	if !opts.LeafPackForce {
+		t.Fatal("exhaustive mode should force leaf pack thresholds")
+	}
+	if opts.LeafPackMaxPasses < 256 {
+		t.Fatalf("LeafPackMaxPasses=%d want at least 256", opts.LeafPackMaxPasses)
+	}
+	if opts.LeafPackMaxGenerationsPerPass != 0 || opts.LeafPackMaxBytesToCopyPerPass != 0 {
+		t.Fatalf("exhaustive leaf pack limits gens=%d bytes=%d want unbounded", opts.LeafPackMaxGenerationsPerPass, opts.LeafPackMaxBytesToCopyPerPass)
+	}
+}
+
 func compactStoragePhaseSeen(phases []CompactStoragePhaseStats, name string) bool {
 	for _, phase := range phases {
 		if phase.Name == name {

--- a/TreeDB/db/leaf_generation_manifest.go
+++ b/TreeDB/db/leaf_generation_manifest.go
@@ -132,6 +132,49 @@ func (m *leafGenerationManifest) registerCurrentGenerationFileID(fileID uint32, 
 	return true, nil
 }
 
+func (m *leafGenerationManifest) sealCurrentGeneration(commitSeq uint64) ([]uint32, bool, error) {
+	if m == nil {
+		return nil, false, errors.New("treedb: leaf generation manifest is nil")
+	}
+	idx := m.currentGenerationIndex()
+	if idx < 0 {
+		return nil, false, fmt.Errorf("treedb: %s current_generation_id %d not found in generations", leafGenerationManifestFileName, m.CurrentGenerationID)
+	}
+	gen := &m.Generations[idx]
+	if gen.State != leafGenerationStateWritable {
+		return nil, false, fmt.Errorf("treedb: current generation %d is not writable (state=%q)", gen.GenerationID, gen.State)
+	}
+	if len(gen.FileIDs) == 0 {
+		return nil, false, nil
+	}
+	maxID := uint64(0)
+	for i := range m.Generations {
+		if m.Generations[i].GenerationID > maxID {
+			maxID = m.Generations[i].GenerationID
+		}
+	}
+	if m.NextGenerationID <= maxID {
+		m.NextGenerationID = maxID + 1
+	}
+	newID := m.NextGenerationID
+	m.NextGenerationID++
+	gen.State = leafGenerationStateSealed
+	if commitSeq > gen.SealedCommitSeq {
+		gen.SealedCommitSeq = commitSeq
+	}
+	if commitSeq > gen.PublishedCommitSeq {
+		gen.PublishedCommitSeq = commitSeq
+	}
+	m.CurrentGenerationID = newID
+	m.Generations = append(m.Generations, leafGenerationRecord{
+		GenerationID:       newID,
+		State:              leafGenerationStateWritable,
+		CreatedCommitSeq:   commitSeq,
+		PublishedCommitSeq: commitSeq,
+	})
+	return append([]uint32(nil), gen.FileIDs...), true, nil
+}
+
 func (m *leafGenerationManifest) appendRecoveredSealedGenerationFileID(fileID uint32, commitSeq uint64) (bool, error) {
 	if m == nil {
 		return false, errors.New("treedb: leaf generation manifest is nil")

--- a/docs/TREEDB_CONCEPTS.md
+++ b/docs/TREEDB_CONCEPTS.md
@@ -67,9 +67,19 @@ or:
 treemap compact <db-dir> -rw
 ```
 
+For byte-minimized benchmark/VACUUM-equivalent storage claims, use exhaustive
+mode instead:
+
+```sh
+treemap compact <db-dir> -rw -mode exhaustive
+```
+
+Exhaustive mode seals the current leaf generation and forces low-yield leaf-pack
+work that production `full` mode can intentionally skip.
+
 `vlog-gc`, `vlog-rewrite`, `leafgen-pack`, `leafgen-gc`, and index `vacuum`
 are domain-specific internals. They are useful for diagnostics, but they are
-not the recommended user-facing way to obtain a fully compacted storage number.
+not the recommended user-facing way to obtain a compacted storage number.
 
 ### Inline vs value-log values
 


### PR DESCRIPTION
## Summary

- Link #2290 / parent #2288.
- Add `CompactStorageExhaustive` and `treemap compact <db-dir> -rw -mode exhaustive`.
- Exhaustive mode seals the current leaf generation before leaf-pack, forces leaf-pack admission/selection thresholds, and defaults to unbounded per-pass generation/byte limits with a high pass cap.
- Add `policy_fully_compacted` and `byte_minimized` compact report fields.
- Document production `full` vs benchmark/VACUUM-equivalent `exhaustive` semantics.

## Why

`CompactStorageFull` is a production policy compaction path and may intentionally skip low-yield or current writable leaf-generation bytes. Public benchmark density/storage-floor claims need a stronger, explicit byte-minimized contract instead of relying on low-level `full_leafgen_pack_gc` diagnostics.

## Validation

- `GOWORK=off go test ./TreeDB/db -run 'TestCompactStorageExhaustiveSealsCurrentLeafGeneration|TestCompactStorageNormalizeExhaustiveForcesUnboundedLeafPack' -count=1`
- `GOWORK=off go test ./TreeDB/cmd/treemap -count=1`
- `GOWORK=off go test ./TreeDB/db -run 'TestCompactStorage|TestRegisterLeafPageLogSegmentsForPublish' -count=1`
- `git diff --check`

## Benchmark/storage probe

On a copy of the latest collection artifact:

- source: `/tmp/collections_insert_latest_main_20260603_210058/full_leafgen_pack_gc/treedb_template_v1_collection_2_indexes`
- copy: `/tmp/exhaustive_probe_2290_094236`
- command: `GOWORK=off go run ./TreeDB/cmd/treemap compact "$TMP" -rw -mode exhaustive -json`
- directory bytes: `2,829,616 -> 2,319,517`
- report: `mode=exhaustive fully_compacted=true policy_fully_compacted=true byte_minimized=true`
- remaining debt: all zero

This corresponds to about `23.2 B/doc` for the 100k-doc fixture copy.

## AI review status

Requested after PR creation.
