### PR TITLE
TreeDB: add batch DeleteRange command WAL support

### DIFF
--- a/TreeDB/batch/batch.go
+++ b/TreeDB/batch/batch.go
@@ -17,21 +17,29 @@ var (
 	ErrMissingValueReader = errors.New("value reader unavailable")
 )
 
-// OpType represents the type of operation (Put or Delete).
+// OpType represents the type of operation recorded in a batch.
 type OpType uint8
 
 const (
 	OpPut OpType = iota
 	OpDelete
+	OpDeleteRange
 )
 
 // Entry represents a single operation in the batch.
 type Entry struct {
 	Type     OpType
-	Key      []byte
-	Value    []byte        // For inline values
+	Key      []byte        // Put/Delete key, or DeleteRange start bound (nil means unbounded)
+	Value    []byte        // Inline value, or DeleteRange exclusive end bound (nil means unbounded)
 	ValuePtr page.ValuePtr // For large values
 	IsPtr    bool          // True if ValuePtr is valid
+}
+
+// DeleteRange describes a half-open range delete [Start, End). Nil Start or
+// End are unbounded on that side.
+type DeleteRange struct {
+	Start []byte
+	End   []byte
 }
 
 // ValueReader resolves value pointers for Replay callers that require full values.
@@ -44,6 +52,7 @@ type ValueReader interface {
 type Interface interface {
 	Set(key, value []byte) error
 	Delete(key []byte) error
+	DeleteRange(start, end []byte) error
 	SetOps(ops []Entry) error
 	Write() error
 	WriteSync() error
@@ -66,6 +75,7 @@ type Batch struct {
 	touchedValueLogSmallLen int
 	touchedValueLog         map[uint32]struct{}
 	hasValueLogPointers     bool
+	hasDeleteRanges         bool
 	sorted                  bool
 	compacted               bool
 	lastKey                 []byte
@@ -170,6 +180,14 @@ func (b *Batch) IsEmpty() bool {
 	return b == nil || len(b.entries) == 0
 }
 
+// Len returns the number of queued logical operations.
+func (b *Batch) Len() int {
+	if b == nil {
+		return 0
+	}
+	return len(b.entries)
+}
+
 func (b *Batch) resetLocked() {
 	if b.entries != nil {
 		// Avoid holding onto key/value copies from previous uses.
@@ -182,6 +200,7 @@ func (b *Batch) resetLocked() {
 	b.touchedValueLog = nil
 	b.touchedValueLogSmallLen = 0
 	b.hasValueLogPointers = false
+	b.hasDeleteRanges = false
 	b.byteSize = 0
 	b.sorted = true
 	b.compacted = true
@@ -214,6 +233,7 @@ func (b *Batch) resetForPool() {
 	b.touchedValueLog = nil
 	b.touchedValueLogSmallLen = 0
 	b.hasValueLogPointers = false
+	b.hasDeleteRanges = false
 	b.sorted = true
 	b.compacted = true
 	b.lastKey = nil
@@ -684,6 +704,55 @@ func (b *Batch) Delete(key []byte) error {
 	return nil
 }
 
+// DeleteRange records a half-open range delete [start, end). Nil bounds are
+// unbounded. Empty or reversed bounded ranges are no-ops.
+func (b *Batch) DeleteRange(start, end []byte) error {
+	if err := b.ensureOpen(); err != nil {
+		return err
+	}
+	if IsDeleteRangeNoop(start, end) {
+		return nil
+	}
+	return b.deleteRangeInternal(start, end, true)
+}
+
+// DeleteRangeView records a range delete without copying bound bytes. Callers
+// must treat start/end as immutable until the batch is committed or closed.
+func (b *Batch) DeleteRangeView(start, end []byte) error {
+	if err := b.ensureOpen(); err != nil {
+		return err
+	}
+	if IsDeleteRangeNoop(start, end) {
+		return nil
+	}
+	return b.deleteRangeInternal(start, end, false)
+}
+
+func (b *Batch) deleteRangeInternal(start, end []byte, copyBounds bool) error {
+	var startCopy, endCopy []byte
+	if copyBounds {
+		if start != nil {
+			startCopy = b.arenaCopy(start)
+		}
+		if end != nil {
+			endCopy = b.arenaCopy(end)
+		}
+	} else {
+		startCopy = start
+		endCopy = end
+	}
+	b.entries = append(b.entries, Entry{
+		Type:  OpDeleteRange,
+		Key:   startCopy,
+		Value: endCopy,
+	})
+	b.byteSize += len(startCopy) + len(endCopy)
+	b.hasDeleteRanges = true
+	// Keep the point-entry sorted/compacted state intact for point-only batches;
+	// range batches use OrderedEntries/ApplyPlan instead of mutating this slice.
+	return nil
+}
+
 // Replay iterates over the batch entries.
 func (b *Batch) Replay(fn func(Entry) error) error {
 	for _, entry := range b.entries {
@@ -725,6 +794,15 @@ func (b *Batch) SetOps(ops []Entry) error {
 		b.compacted = false
 	}
 	for _, op := range ops {
+		if op.Type == OpDeleteRange {
+			if IsDeleteRangeNoop(op.Key, op.Value) {
+				continue
+			}
+			b.hasDeleteRanges = true
+			b.entries = append(b.entries, op)
+			b.byteSize += len(op.Key) + len(op.Value)
+			continue
+		}
 		if op.IsPtr {
 			if !page.IsValueLogFileID(op.ValuePtr.FileID) {
 				return fmt.Errorf("invalid value-log pointer in SetOps: file %d", op.ValuePtr.FileID)
@@ -746,6 +824,10 @@ func (b *Batch) SetOps(ops []Entry) error {
 // read-only. It remains valid only until the batch is mutated, reset, released,
 // or closed.
 func (b *Batch) SortedEntries() []Entry {
+	if b.hasDeleteRanges {
+		points, _ := b.ApplyPlan()
+		return points
+	}
 	if len(b.entries) == 0 {
 		b.sorted = true
 		b.compacted = true
@@ -790,6 +872,9 @@ func (b *Batch) SortedEntries() []Entry {
 func (b *Batch) Ops() map[string]Entry {
 	ops := make(map[string]Entry, len(b.entries))
 	for _, e := range b.entries {
+		if e.Type == OpDeleteRange {
+			continue
+		}
 		ops[string(e.Key)] = e
 	}
 	return ops
@@ -807,6 +892,99 @@ func (b *Batch) HasValueLogPointers() bool {
 		return false
 	}
 	return b.hasValueLogPointers
+}
+
+// HasDeleteRanges reports whether this batch contains any non-empty range
+// deletes. Point-only callers can keep using SortedEntries' compacted fast path.
+func (b *Batch) HasDeleteRanges() bool {
+	return b != nil && b.hasDeleteRanges
+}
+
+// OrderedEntries returns the submission-order operation stream. The returned
+// slice aliases batch-owned storage and must be treated as read-only.
+func (b *Batch) OrderedEntries() []Entry {
+	if b == nil || len(b.entries) == 0 {
+		return nil
+	}
+	return b.entries
+}
+
+// ApplyPlan canonicalizes an ordered mixed batch into sorted final point ops and
+// merged range tombstones over the base tree. The point-only SortedEntries path
+// remains allocation-free and is preferred when HasDeleteRanges is false.
+func (b *Batch) ApplyPlan() ([]Entry, []DeleteRange) {
+	if b == nil || len(b.entries) == 0 {
+		return nil, nil
+	}
+	if !b.hasDeleteRanges {
+		return b.SortedEntries(), nil
+	}
+	return BuildApplyPlanFromEntries(b.entries, true)
+}
+
+// BuildApplyPlanFromEntries canonicalizes an ordered mixed operation stream into
+// sorted final point ops and merged range tombstones over the base tree.
+func BuildApplyPlanFromEntries(entries []Entry, hasDeleteRanges bool) ([]Entry, []DeleteRange) {
+	if len(entries) == 0 {
+		return nil, nil
+	}
+	if !hasDeleteRanges {
+		points := append([]Entry(nil), entries...)
+		sort.SliceStable(points, func(i, j int) bool {
+			return bytes.Compare(points[i].Key, points[j].Key) < 0
+		})
+		out := points[:0]
+		for i := 0; i < len(points); i++ {
+			if i+1 < len(points) && bytes.Equal(points[i].Key, points[i+1].Key) {
+				continue
+			}
+			out = append(out, points[i])
+		}
+		return out, nil
+	}
+	type pointCandidate struct {
+		entry Entry
+		seq   int
+	}
+	type sequencedRange struct {
+		rangeOp DeleteRange
+		seq     int
+	}
+	pointsByKey := make(map[string]pointCandidate)
+	ranges := make([]sequencedRange, 0, 4)
+	for seq, entry := range entries {
+		switch entry.Type {
+		case OpPut, OpDelete:
+			pointsByKey[string(entry.Key)] = pointCandidate{entry: entry, seq: seq}
+		case OpDeleteRange:
+			if IsDeleteRangeNoop(entry.Key, entry.Value) {
+				continue
+			}
+			ranges = append(ranges, sequencedRange{rangeOp: DeleteRange{Start: entry.Key, End: entry.Value}, seq: seq})
+		}
+	}
+	points := make([]Entry, 0, len(pointsByKey))
+	for _, point := range pointsByKey {
+		shadowed := false
+		for _, r := range ranges {
+			if r.seq > point.seq && DeleteRangeContainsKey(r.rangeOp, point.entry.Key) {
+				shadowed = true
+				break
+			}
+		}
+		if !shadowed {
+			points = append(points, point.entry)
+		}
+	}
+	sort.Slice(points, func(i, j int) bool {
+		return bytes.Compare(points[i].Key, points[j].Key) < 0
+	})
+	merged := make([]DeleteRange, 0, len(ranges))
+	for _, r := range ranges {
+		merged = append(merged, r.rangeOp)
+	}
+	merged = MergeDeleteRanges(merged)
+	return points, merged
 }
 
 // TouchedValueLogSegments reports the value-log segments that were touched by
@@ -865,4 +1043,121 @@ func (b *Batch) noteTouchedValueLogFileID(id uint32) {
 		b.touchedValueLogSmallLen = 0
 	}
 	b.touchedValueLog[id] = struct{}{}
+}
+
+// IsDeleteRangeNoop reports whether [start,end) cannot delete any valid TreeDB
+// key. Nil means unbounded; a non-nil end <= non-nil start is empty/reversed.
+func IsDeleteRangeNoop(start, end []byte) bool {
+	if start != nil && end != nil && bytes.Compare(start, end) >= 0 {
+		return true
+	}
+	// TreeDB point keys cannot be empty. An unbounded-lower range ending at the
+	// empty byte string contains no valid keys.
+	return start == nil && end != nil && len(end) == 0
+}
+
+// DeleteRangeContainsKey reports whether key is inside r's half-open range.
+func DeleteRangeContainsKey(r DeleteRange, key []byte) bool {
+	if key == nil {
+		return false
+	}
+	if r.Start != nil && bytes.Compare(key, r.Start) < 0 {
+		return false
+	}
+	if r.End != nil && bytes.Compare(key, r.End) >= 0 {
+		return false
+	}
+	return true
+}
+
+// DeleteRangesContainKey reports whether key is covered by any merged or
+// unmerged range in ranges.
+func DeleteRangesContainKey(ranges []DeleteRange, key []byte) bool {
+	for _, r := range ranges {
+		if DeleteRangeContainsKey(r, key) {
+			return true
+		}
+	}
+	return false
+}
+
+// MergeDeleteRanges returns sorted, non-overlapping ranges equivalent to the
+// union of ranges. It does not copy bound bytes; callers must keep them alive.
+func MergeDeleteRanges(ranges []DeleteRange) []DeleteRange {
+	if len(ranges) <= 1 {
+		if len(ranges) == 1 && IsDeleteRangeNoop(ranges[0].Start, ranges[0].End) {
+			return nil
+		}
+		return ranges
+	}
+	out := ranges[:0]
+	for _, r := range ranges {
+		if !IsDeleteRangeNoop(r.Start, r.End) {
+			out = append(out, r)
+		}
+	}
+	if len(out) <= 1 {
+		return out
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return compareRangeStarts(out[i].Start, out[j].Start) < 0
+	})
+	merged := out[:0]
+	cur := out[0]
+	for i := 1; i < len(out); i++ {
+		next := out[i]
+		if deleteRangesOverlapOrTouch(cur, next) {
+			cur.End = maxRangeEnd(cur.End, next.End)
+			continue
+		}
+		merged = append(merged, cur)
+		cur = next
+	}
+	merged = append(merged, cur)
+	return merged
+}
+
+func compareRangeStarts(a, b []byte) int {
+	if a == nil {
+		if b == nil {
+			return 0
+		}
+		return -1
+	}
+	if b == nil {
+		return 1
+	}
+	return bytes.Compare(a, b)
+}
+
+func deleteRangesOverlapOrTouch(a, b DeleteRange) bool {
+	if a.End == nil || b.Start == nil {
+		return true
+	}
+	return bytes.Compare(b.Start, a.End) <= 0
+}
+
+func maxRangeEnd(a, b []byte) []byte {
+	if a == nil || b == nil {
+		return nil
+	}
+	if bytes.Compare(a, b) >= 0 {
+		return a
+	}
+	return b
+}
+
+// DeleteRangeOverlapsSpan reports whether r intersects the half-open child span
+// [low, high). Nil high means unbounded upper; nil r bounds are unbounded.
+func DeleteRangeOverlapsSpan(r DeleteRange, low, high []byte) bool {
+	if IsDeleteRangeNoop(r.Start, r.End) {
+		return false
+	}
+	if r.End != nil && low != nil && bytes.Compare(r.End, low) <= 0 {
+		return false
+	}
+	if high != nil && r.Start != nil && bytes.Compare(r.Start, high) >= 0 {
+		return false
+	}
+	return true
 }

--- a/TreeDB/batch/delete_range_test.go
+++ b/TreeDB/batch/delete_range_test.go
@@ -1,0 +1,96 @@
+package batch
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestBatchDeleteRangeReplayPreservesOrderAndNilBounds(t *testing.T) {
+	b := New(nil, -1)
+	defer b.Close()
+	if err := b.Set([]byte("b"), []byte("before")); err != nil {
+		t.Fatalf("Set before: %v", err)
+	}
+	if err := b.DeleteRange(nil, []byte("c")); err != nil {
+		t.Fatalf("DeleteRange: %v", err)
+	}
+	if err := b.Set([]byte("b"), []byte("after")); err != nil {
+		t.Fatalf("Set after: %v", err)
+	}
+	if err := b.DeleteRange([]byte("z"), []byte("a")); err != nil {
+		t.Fatalf("reversed DeleteRange: %v", err)
+	}
+
+	var got []Entry
+	if err := b.Replay(func(e Entry) error {
+		got = append(got, e)
+		return nil
+	}); err != nil {
+		t.Fatalf("Replay: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("Replay entries=%d want 3: %+v", len(got), got)
+	}
+	if got[1].Type != OpDeleteRange || got[1].Key != nil || !bytes.Equal(got[1].Value, []byte("c")) {
+		t.Fatalf("range entry mismatch: %+v", got[1])
+	}
+}
+
+func TestBatchDeleteRangeApplyPlanOverlappingRangesKeepOnlyLaterShadowedPoints(t *testing.T) {
+	b := New(nil, -1)
+	defer b.Close()
+	must := func(err error) {
+		t.Helper()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	must(b.DeleteRange([]byte("a"), []byte("d")))
+	must(b.Set([]byte("b"), []byte("after-first-range")))
+	must(b.Set([]byte("e"), []byte("shadowed-by-second-range")))
+	must(b.DeleteRange([]byte("c"), []byte("f")))
+	must(b.Set([]byte("g"), []byte("after-ranges")))
+
+	points, ranges := b.ApplyPlan()
+	if len(ranges) != 1 || !bytes.Equal(ranges[0].Start, []byte("a")) || !bytes.Equal(ranges[0].End, []byte("f")) {
+		t.Fatalf("ranges mismatch: %+v", ranges)
+	}
+	if len(points) != 2 {
+		t.Fatalf("points=%d want 2: %+v", len(points), points)
+	}
+	if points[0].Type != OpPut || !bytes.Equal(points[0].Key, []byte("b")) || !bytes.Equal(points[0].Value, []byte("after-first-range")) {
+		t.Fatalf("point[0] mismatch: %+v", points[0])
+	}
+	if points[1].Type != OpPut || !bytes.Equal(points[1].Key, []byte("g")) || !bytes.Equal(points[1].Value, []byte("after-ranges")) {
+		t.Fatalf("point[1] mismatch: %+v", points[1])
+	}
+}
+
+func TestBatchDeleteRangeApplyPlanHonorsOrderedPointInteractions(t *testing.T) {
+	b := New(nil, -1)
+	defer b.Close()
+	must := func(err error) {
+		t.Helper()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	must(b.Set([]byte("b"), []byte("shadowed")))
+	must(b.DeleteRange([]byte("a"), []byte("d")))
+	must(b.Set([]byte("c"), []byte("survives")))
+	must(b.Delete([]byte("e")))
+
+	points, ranges := b.ApplyPlan()
+	if len(ranges) != 1 || !bytes.Equal(ranges[0].Start, []byte("a")) || !bytes.Equal(ranges[0].End, []byte("d")) {
+		t.Fatalf("ranges mismatch: %+v", ranges)
+	}
+	if len(points) != 2 {
+		t.Fatalf("points=%d want 2: %+v", len(points), points)
+	}
+	if points[0].Type != OpPut || !bytes.Equal(points[0].Key, []byte("c")) || !bytes.Equal(points[0].Value, []byte("survives")) {
+		t.Fatalf("point[0] mismatch: %+v", points[0])
+	}
+	if points[1].Type != OpDelete || !bytes.Equal(points[1].Key, []byte("e")) {
+		t.Fatalf("point[1] mismatch: %+v", points[1])
+	}
+}

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -51,6 +51,7 @@ var ErrValueNil = fmt.Errorf("value cannot be nil")
 var ErrBatchClosed = fmt.Errorf("batch has been written or closed")
 var ErrUnsafeOptions = fmt.Errorf("unsafe options require AllowUnsafe")
 var ErrMemtableFull = fmt.Errorf("memtable full")
+var ErrBatchDeleteRangeTooLarge = errors.New("cachingdb: batch DeleteRange materialization limit exceeded")
 var errWALClosed = errors.New("cachingdb: wal writer closed")
 var errWALUnavailable = errors.New("cachingdb: wal unavailable")
 
@@ -29256,8 +29257,11 @@ const (
 	// Keep retained batch-copy chunks bounded to 1MiB. Larger chunks are often
 	// underfilled in restore-heavy traffic and can disproportionately inflate
 	// peak RSS when multiple memtable views pin retired arenas.
-	batchCopyArenaMaxRetain     = 1 << 20
-	batchArenaTailCompactMinCap = 256 << 10
+	batchCopyArenaMaxRetain = 1 << 20
+
+	defaultCachedBatchDeleteRangeMaterializeMaxEntries  = 1 << 20
+	defaultCachedBatchDeleteRangeMaterializeMaxKeyBytes = 64 << 20
+	batchArenaTailCompactMinCap                         = 256 << 10
 	// Only compact tails with meaningful waste so we avoid churn on tiny chunks.
 	batchArenaTailCompactMinWaste = 256 << 10
 	// Under deferred-view pressure, compact earlier so retired memtable leases
@@ -29277,6 +29281,11 @@ const (
 	// batch-arena headroom to limit extra lease growth under that pressure.
 	batchArenaDeferredPressureThresholdBytes = int64(512 << 20)
 	batchArenaDeferredPressureHardCapDivisor = int64(2)
+)
+
+var (
+	cachedBatchDeleteRangeMaterializeMaxEntries  = defaultCachedBatchDeleteRangeMaterializeMaxEntries
+	cachedBatchDeleteRangeMaterializeMaxKeyBytes = defaultCachedBatchDeleteRangeMaterializeMaxKeyBytes
 )
 
 func batchCopyArenaInitCapForEntries(entries int) int {
@@ -29486,7 +29495,22 @@ func (b *Batch) writeRangeBatch(sync bool) error {
 		return nil
 	}
 
+	// Hold the writer gate across snapshot enumeration and publish. Without this,
+	// a concurrent cached write can slip between the scan and the materialized
+	// point-delete batch, producing a non-serializable mix of range-deleted old
+	// keys and surviving newly inserted keys.
+	b.db.writeMu.Lock()
+	writeMuHeld := true
+	unlockWriteMu := func() {
+		if writeMuHeld {
+			writeMuHeld = false
+			b.db.writeMu.Unlock()
+		}
+	}
+	defer unlockWriteMu()
+
 	materialized := make([]batch.Entry, 0, len(points))
+	deleteKeyBytes := 0
 	for _, r := range ranges {
 		it, err := b.db.Iterator(r.Start, r.End)
 		if err != nil {
@@ -29494,6 +29518,15 @@ func (b *Batch) writeRangeBatch(sync bool) error {
 		}
 		for it.Valid() {
 			key := it.Key()
+			if cachedBatchDeleteRangeMaterializeMaxEntries >= 0 && len(materialized) >= cachedBatchDeleteRangeMaterializeMaxEntries {
+				_ = it.Close()
+				return fmt.Errorf("%w: keys=%d limit=%d", ErrBatchDeleteRangeTooLarge, len(materialized)+1, cachedBatchDeleteRangeMaterializeMaxEntries)
+			}
+			deleteKeyBytes += len(key)
+			if cachedBatchDeleteRangeMaterializeMaxKeyBytes >= 0 && deleteKeyBytes > cachedBatchDeleteRangeMaterializeMaxKeyBytes {
+				_ = it.Close()
+				return fmt.Errorf("%w: key_bytes=%d limit=%d", ErrBatchDeleteRangeTooLarge, deleteKeyBytes, cachedBatchDeleteRangeMaterializeMaxKeyBytes)
+			}
 			materialized = append(materialized, batch.Entry{Type: batch.OpDelete, Key: append([]byte(nil), key...)})
 			it.Next()
 		}
@@ -29513,7 +29546,7 @@ func (b *Batch) writeRangeBatch(sync bool) error {
 	b.entries = materialized
 	b.hasDeleteRanges = false
 	b.streamEligible = false
-	err := b.write(sync)
+	err := b.writeRegularLocked(sync, unlockWriteMu)
 	if err != nil {
 		b.entries = origEntries
 		b.hasDeleteRanges = origHasRanges
@@ -29618,6 +29651,10 @@ func (b *Batch) tryWriteWALOffStreamBypass(sync bool) (bool, error) {
 
 func (b *Batch) writeRegular(syncWrite bool) error {
 	b.db.writeMu.RLock()
+	return b.writeRegularLocked(syncWrite, b.db.writeMu.RUnlock)
+}
+
+func (b *Batch) writeRegularLocked(syncWrite bool, unlockWriteMu func()) error {
 	needRotate := false
 	needSyncBarrier := false
 	commandWALAppended := false
@@ -29713,7 +29750,7 @@ func (b *Batch) writeRegular(syncWrite bool) error {
 		over := b.db.shardExceedsLimit(shard, add)
 		shard.mu.Unlock()
 		if over {
-			b.db.writeMu.RUnlock()
+			unlockWriteMu()
 			return ErrMemtableFull
 		}
 	}
@@ -29824,7 +29861,7 @@ func (b *Batch) writeRegular(syncWrite bool) error {
 	if needLaneForPointers || needLaneForJournal {
 		l, err := b.db.pickLane(durability == journalDurabilitySync, -1)
 		if err != nil {
-			b.db.writeMu.RUnlock()
+			unlockWriteMu()
 			return err
 		}
 		lane = l
@@ -29921,7 +29958,7 @@ func (b *Batch) writeRegular(syncWrite bool) error {
 			for _, laneID := range activeLaneIDs {
 				lb := &laneBatches[laneID]
 				if lb.err != nil {
-					b.db.writeMu.RUnlock()
+					unlockWriteMu()
 					return lb.err
 				}
 			}
@@ -29970,13 +30007,13 @@ func (b *Batch) writeRegular(syncWrite bool) error {
 			)
 			valueRecords, groups, outerArena, buildErr := b.db.buildOuterLeafValueRecords(keys, values)
 			if buildErr != nil {
-				b.db.writeMu.RUnlock()
+				unlockWriteMu()
 				return buildErr
 			}
 			if len(valueRecords) == 0 {
 				putValueLogRecordsNoClear(valueRecords)
 				putOuterLeafArena(outerArena)
-				b.db.writeMu.RUnlock()
+				unlockWriteMu()
 				return fmt.Errorf("cachingdb: empty value-log record set for %d eligible ops", eligibleCount)
 			}
 			defer putValueLogRecordsNoClear(valueRecords)
@@ -29988,7 +30025,7 @@ func (b *Batch) writeRegular(syncWrite bool) error {
 				if rids != nil {
 					group := groups[i]
 					if group.start < 0 || group.end < group.start || group.end > len(eligibleIdxs) {
-						b.db.writeMu.RUnlock()
+						unlockWriteMu()
 						return fmt.Errorf("cachingdb: value-log group out of range [%d,%d) len=%d", group.start, group.end, len(eligibleIdxs))
 					}
 					for srcPos := group.start; srcPos < group.end; srcPos++ {
@@ -29999,12 +30036,12 @@ func (b *Batch) writeRegular(syncWrite bool) error {
 			}
 			ptrs, buildErr = b.db.appendValueLogForRecords(lane, valueRecords, durability)
 			if buildErr != nil {
-				b.db.writeMu.RUnlock()
+				unlockWriteMu()
 				return buildErr
 			}
 			if len(ptrs) != len(groups) {
 				putValueLogPtrs(ptrs)
-				b.db.writeMu.RUnlock()
+				unlockWriteMu()
 				return fmt.Errorf("cachingdb: value-log pointer group count mismatch expected=%d got=%d", len(groups), len(ptrs))
 			}
 			defer putValueLogPtrs(ptrs)
@@ -30014,7 +30051,7 @@ func (b *Batch) writeRegular(syncWrite bool) error {
 				ptr := ptrs[i]
 				group := groups[i]
 				if group.start < 0 || group.end < group.start || group.end > len(eligibleIdxs) {
-					b.db.writeMu.RUnlock()
+					unlockWriteMu()
 					return fmt.Errorf("cachingdb: value-log pointer group out of range [%d,%d) len=%d", group.start, group.end, len(eligibleIdxs))
 				}
 				for srcPos := group.start; srcPos < group.end; srcPos++ {
@@ -30045,7 +30082,7 @@ func (b *Batch) writeRegular(syncWrite bool) error {
 			var err error
 			handledZeroInline, err = b.db.appendWALZeroInlineEntries(lane, b.entries, seq, zeroInlineValueLen, durability)
 			if err != nil {
-				b.db.writeMu.RUnlock()
+				unlockWriteMu()
 				return err
 			}
 			if handledZeroInline {
@@ -30072,7 +30109,7 @@ func (b *Batch) writeRegular(syncWrite bool) error {
 			}
 			b.walBuf = records
 			if err := b.db.appendWALAssigned(lane, records, durability); err != nil {
-				b.db.writeMu.RUnlock()
+				unlockWriteMu()
 				return err
 			}
 		}
@@ -30080,7 +30117,7 @@ func (b *Batch) writeRegular(syncWrite bool) error {
 
 	if b.commandWALAppend != nil {
 		if err := b.commandWALAppend(); err != nil {
-			b.db.writeMu.RUnlock()
+			unlockWriteMu()
 			return err
 		}
 		commandWALAppended = true
@@ -30319,7 +30356,7 @@ func (b *Batch) writeRegular(syncWrite bool) error {
 	if allowBatchArenaBorrow && len(b.ptrValueIdxs) > 0 {
 		for _, idx := range b.ptrValueIdxs {
 			if idx < 0 || idx >= len(b.entries) || idx >= len(shardIdxs) {
-				b.db.writeMu.RUnlock()
+				unlockWriteMu()
 				return fmt.Errorf("cachingdb: ptr value entry index %d out of range", idx)
 			}
 			if b.entries[idx].Value == nil {
@@ -30328,7 +30365,7 @@ func (b *Batch) writeRegular(syncWrite bool) error {
 			retainPtrArena = true
 			shardIdx := shardIdxs[idx]
 			if shardIdx < 0 || shardIdx >= len(b.db.mutableShards) {
-				b.db.writeMu.RUnlock()
+				unlockWriteMu()
 				return fmt.Errorf("cachingdb: ptr value shard index %d out of range for entry %d", shardIdx, idx)
 			}
 			mt := b.db.mutableShards[shardIdx].mem
@@ -30348,7 +30385,7 @@ func (b *Batch) writeRegular(syncWrite bool) error {
 	} else {
 		putBatchArenas(ptrChunks)
 	}
-	b.db.writeMu.RUnlock()
+	unlockWriteMu()
 
 	if needRotate {
 		if err := b.db.maybeRotateMemtable(true); err != nil {

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -29105,10 +29105,12 @@ func (b *Batch) DeleteRange(start, end []byte) error {
 		endCopy = b.cloneKey(end)
 	}
 	if b.backend != nil {
-		if ranged, ok := b.backend.(interface{ DeleteRange(start, end []byte) error }); ok {
-			b.size += len(startCopy) + len(endCopy)
-			return ranged.DeleteRange(startCopy, endCopy)
+		single := [1]batch.Entry{{Type: batch.OpDeleteRange, Key: startCopy, Value: endCopy}}
+		if err := b.backend.SetOps(single[:]); err != nil {
+			return err
 		}
+		b.size += len(startCopy) + len(endCopy)
+		return nil
 	}
 	b.entries = append(b.entries, batch.Entry{Type: batch.OpDeleteRange, Key: startCopy, Value: endCopy})
 	b.noteEntryAppend()
@@ -29543,14 +29545,20 @@ func (b *Batch) writeRangeBatch(sync bool) error {
 	origEntries := b.entries
 	origHasRanges := b.hasDeleteRanges
 	origStreamEligible := b.streamEligible
+	origHasViewOps := b.hasViewOps
 	b.entries = materialized
 	b.hasDeleteRanges = false
 	b.streamEligible = false
+	// Materialization reallocates and reorders entries, so any ptrValueIdxs still
+	// refer to the original entry indexes. Force the safe copy path for this write
+	// instead of retaining batch arenas by stale indexes.
+	b.hasViewOps = true
 	err := b.writeRegularLocked(sync, unlockWriteMu)
 	if err != nil {
 		b.entries = origEntries
 		b.hasDeleteRanges = origHasRanges
 		b.streamEligible = origStreamEligible
+		b.hasViewOps = origHasViewOps
 	}
 	return err
 }

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -28044,6 +28044,7 @@ type Batch struct {
 	firstKey         []byte
 	lastKey          []byte
 	batchRange       keyRange
+	hasDeleteRanges  bool
 	commandWALAppend func() error
 }
 
@@ -28572,6 +28573,7 @@ func (b *Batch) Reset() {
 	b.firstKey = nil
 	b.lastKey = nil
 	b.batchRange = keyRange{}
+	b.hasDeleteRanges = false
 	b.maxEntries = 0
 	b.commandWALAppend = nil
 	if b.ptrValueIdxs != nil {
@@ -29087,6 +29089,34 @@ func (b *Batch) Delete(key []byte) error {
 	return nil
 }
 
+func (b *Batch) DeleteRange(start, end []byte) error {
+	if b.closed {
+		return ErrBatchClosed
+	}
+	if batch.IsDeleteRangeNoop(start, end) {
+		return nil
+	}
+	var startCopy, endCopy []byte
+	if start != nil {
+		startCopy = b.cloneKey(start)
+	}
+	if end != nil {
+		endCopy = b.cloneKey(end)
+	}
+	if b.backend != nil {
+		if ranged, ok := b.backend.(interface{ DeleteRange(start, end []byte) error }); ok {
+			b.size += len(startCopy) + len(endCopy)
+			return ranged.DeleteRange(startCopy, endCopy)
+		}
+	}
+	b.entries = append(b.entries, batch.Entry{Type: batch.OpDeleteRange, Key: startCopy, Value: endCopy})
+	b.noteEntryAppend()
+	b.size += len(startCopy) + len(endCopy)
+	b.hasDeleteRanges = true
+	b.streamEligible = false
+	return nil
+}
+
 // DeleteView records a Delete without copying key bytes. Callers must treat
 // key as immutable until the batch is written or closed.
 func (b *Batch) DeleteView(key []byte) error {
@@ -29139,14 +29169,28 @@ func (b *Batch) SetOps(ops []batch.Entry) error {
 		return ErrBatchClosed
 	}
 	if b.backend != nil {
-		copied := make([]batch.Entry, len(ops))
-		for i, op := range ops {
+		copied := make([]batch.Entry, 0, len(ops))
+		for _, op := range ops {
 			copiedOp := op
+			if op.Type == batch.OpDeleteRange {
+				if batch.IsDeleteRangeNoop(op.Key, op.Value) {
+					continue
+				}
+				if op.Key != nil {
+					copiedOp.Key = b.cloneKey(op.Key)
+				}
+				if op.Value != nil {
+					copiedOp.Value = b.cloneKey(op.Value)
+				}
+				copied = append(copied, copiedOp)
+				b.size += len(copiedOp.Key) + len(copiedOp.Value)
+				continue
+			}
 			copiedOp.Key = b.cloneKey(op.Key)
 			if op.Value != nil {
 				copiedOp.Value = b.cloneValue(op.Value)
 			}
-			copied[i] = copiedOp
+			copied = append(copied, copiedOp)
 			b.size += len(copiedOp.Key) + len(copiedOp.Value)
 			b.batchRange.add(copiedOp.Key)
 		}
@@ -29154,6 +29198,23 @@ func (b *Batch) SetOps(ops []batch.Entry) error {
 	}
 	for _, op := range ops {
 		copied := op
+		if op.Type == batch.OpDeleteRange {
+			if batch.IsDeleteRangeNoop(op.Key, op.Value) {
+				continue
+			}
+			if op.Key != nil {
+				copied.Key = b.cloneKey(op.Key)
+			}
+			if op.Value != nil {
+				copied.Value = b.cloneKey(op.Value)
+			}
+			b.entries = append(b.entries, copied)
+			b.noteEntryAppend()
+			b.size += len(copied.Key) + len(copied.Value)
+			b.hasDeleteRanges = true
+			b.streamEligible = false
+			continue
+		}
 		if op.Value != nil {
 			copied.Key, copied.Value = b.cloneKeyValue(op.Key, op.Value)
 		} else {
@@ -29341,6 +29402,9 @@ func (b *Batch) WriteAfterCommandWALAppend(sync bool, appendCommand func() error
 	defer func() {
 		b.commandWALAppend = prevAppend
 	}()
+	if b.hasDeleteRanges {
+		return b.writeRangeBatch(sync)
+	}
 	return b.writeRegular(sync)
 }
 
@@ -29349,6 +29413,10 @@ func (b *Batch) write(sync bool) error {
 		return ErrBatchClosed
 	}
 	b.db.waitForCheckpoint()
+
+	if b.hasDeleteRanges {
+		return b.writeRangeBatch(sync)
+	}
 
 	if b.backend != nil {
 		var err error
@@ -29401,6 +29469,57 @@ func (b *Batch) write(sync bool) error {
 		return b.writeBypass(sync)
 	}
 	return b.writeRegular(sync)
+}
+
+func (b *Batch) writeRangeBatch(sync bool) error {
+	if b == nil || b.db == nil {
+		return backenddb.ErrClosed
+	}
+	if !b.hasDeleteRanges {
+		return b.write(sync)
+	}
+	points, ranges := batch.BuildApplyPlanFromEntries(b.entries, true)
+	if len(points) == 0 && len(ranges) == 0 {
+		b.updateBatchEntryHint()
+		b.updateBatchCopyHint()
+		b.Reset()
+		return nil
+	}
+
+	materialized := make([]batch.Entry, 0, len(points))
+	for _, r := range ranges {
+		it, err := b.db.Iterator(r.Start, r.End)
+		if err != nil {
+			return err
+		}
+		for it.Valid() {
+			key := it.Key()
+			materialized = append(materialized, batch.Entry{Type: batch.OpDelete, Key: append([]byte(nil), key...)})
+			it.Next()
+		}
+		if err := it.Error(); err != nil {
+			_ = it.Close()
+			return err
+		}
+		if err := it.Close(); err != nil {
+			return err
+		}
+	}
+	materialized = append(materialized, points...)
+
+	origEntries := b.entries
+	origHasRanges := b.hasDeleteRanges
+	origStreamEligible := b.streamEligible
+	b.entries = materialized
+	b.hasDeleteRanges = false
+	b.streamEligible = false
+	err := b.write(sync)
+	if err != nil {
+		b.entries = origEntries
+		b.hasDeleteRanges = origHasRanges
+		b.streamEligible = origStreamEligible
+	}
+	return err
 }
 
 func (b *Batch) tryWriteWALOffStreamBypass(sync bool) (bool, error) {

--- a/TreeDB/caching/db_test.go
+++ b/TreeDB/caching/db_test.go
@@ -694,6 +694,17 @@ func (b *MockBatch) Delete(key []byte) error {
 	b.mb.mu.Unlock()
 	return nil
 }
+func (b *MockBatch) DeleteRange(start, end []byte) error {
+	b.mb.mu.Lock()
+	defer b.mb.mu.Unlock()
+	for k := range b.mb.data {
+		kb := []byte(k)
+		if batch.DeleteRangeContainsKey(batch.DeleteRange{Start: start, End: end}, kb) {
+			delete(b.mb.data, k)
+		}
+	}
+	return nil
+}
 func (b *MockBatch) SetOps(ops []batch.Entry) error {
 	if err := b.mb.getSetOpsErr(); err != nil {
 		return err
@@ -705,7 +716,13 @@ func (b *MockBatch) SetOps(ops []batch.Entry) error {
 		if b.mb.setOpsInlineValueLimit > 0 && op.Type == batch.OpPut && !op.IsPtr && len(op.Value) > b.mb.setOpsInlineValueLimit {
 			return batch.ErrValueTooLarge
 		}
-		if op.Type == batch.OpDelete {
+		if op.Type == batch.OpDeleteRange {
+			for k := range b.mb.data {
+				if batch.DeleteRangeContainsKey(batch.DeleteRange{Start: op.Key, End: op.Value}, []byte(k)) {
+					delete(b.mb.data, k)
+				}
+			}
+		} else if op.Type == batch.OpDelete {
 			delete(b.mb.data, string(op.Key))
 		} else {
 			valCopy := make([]byte, len(op.Value))

--- a/TreeDB/caching/delete_range_test.go
+++ b/TreeDB/caching/delete_range_test.go
@@ -3,6 +3,7 @@ package caching
 import (
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/snissn/gomap/TreeDB/internal/commitlog"
 	"github.com/snissn/gomap/TreeDB/internal/memtable"
@@ -291,6 +292,119 @@ func TestCachingDB_DeleteRange_WALFlushesOnlySelectedLane(t *testing.T) {
 	}
 	if totalSyncs != 0 {
 		t.Fatalf("expected no WAL sync calls for non-sync DeleteRange, got %d", totalSyncs)
+	}
+}
+
+func TestCachingBatchDeleteRangeSerializesScanAndPublish(t *testing.T) {
+	dir := t.TempDir()
+	backend := NewMockBackend()
+	backend.Set([]byte("b"), []byte("old"))
+	db, err := Open(dir, backend, Options{FlushThreshold: 1 << 20, JournalLanes: 1})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer db.Close()
+
+	backend.iteratorStartedCh = make(chan struct{})
+	backend.iteratorBlockCh = make(chan struct{})
+
+	rangeBatch := db.NewBatch()
+	if err := rangeBatch.DeleteRange([]byte("a"), []byte("d")); err != nil {
+		t.Fatalf("DeleteRange: %v", err)
+	}
+	rangeDone := make(chan error, 1)
+	go func() {
+		rangeDone <- rangeBatch.Write()
+		_ = rangeBatch.Close()
+	}()
+
+	select {
+	case <-backend.iteratorStartedCh:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("range batch did not start backend iterator")
+	}
+
+	writerDone := make(chan error, 1)
+	go func() {
+		b := db.NewBatch()
+		defer b.Close()
+		if err := b.Set([]byte("b"), []byte("updated")); err != nil {
+			writerDone <- err
+			return
+		}
+		if err := b.Set([]byte("c"), []byte("new")); err != nil {
+			writerDone <- err
+			return
+		}
+		writerDone <- b.Write()
+	}()
+
+	select {
+	case err := <-writerDone:
+		t.Fatalf("concurrent writer completed before blocked range scan published: %v", err)
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	close(backend.iteratorBlockCh)
+	select {
+	case err := <-rangeDone:
+		if err != nil {
+			t.Fatalf("range batch Write: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatalf("timed out waiting for range batch")
+	}
+	select {
+	case err := <-writerDone:
+		if err != nil {
+			t.Fatalf("concurrent writer: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatalf("timed out waiting for concurrent writer")
+	}
+
+	if val, err := db.Get([]byte("b")); err != nil || string(val) != "updated" {
+		t.Fatalf("b=(%q,%v), want updated", val, err)
+	}
+	if val, err := db.Get([]byte("c")); err != nil || string(val) != "new" {
+		t.Fatalf("c=(%q,%v), want new", val, err)
+	}
+}
+
+func TestCachingBatchDeleteRangeMaterializationCapFailsClosed(t *testing.T) {
+	oldEntries := cachedBatchDeleteRangeMaterializeMaxEntries
+	oldBytes := cachedBatchDeleteRangeMaterializeMaxKeyBytes
+	cachedBatchDeleteRangeMaterializeMaxEntries = 2
+	cachedBatchDeleteRangeMaterializeMaxKeyBytes = defaultCachedBatchDeleteRangeMaterializeMaxKeyBytes
+	defer func() {
+		cachedBatchDeleteRangeMaterializeMaxEntries = oldEntries
+		cachedBatchDeleteRangeMaterializeMaxKeyBytes = oldBytes
+	}()
+
+	dir := t.TempDir()
+	backend := NewMockBackend()
+	for _, kv := range []struct{ k, v string }{{"a", "1"}, {"b", "2"}, {"c", "3"}} {
+		backend.Set([]byte(kv.k), []byte(kv.v))
+	}
+	db, err := Open(dir, backend, Options{FlushThreshold: 1 << 20, JournalLanes: 1})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer db.Close()
+
+	b := db.NewBatch()
+	defer b.Close()
+	if err := b.DeleteRange([]byte("a"), []byte("z")); err != nil {
+		t.Fatalf("DeleteRange: %v", err)
+	}
+	if err := b.Write(); !errors.Is(err, ErrBatchDeleteRangeTooLarge) {
+		t.Fatalf("Write err=%v, want ErrBatchDeleteRangeTooLarge", err)
+	}
+	for _, kv := range []struct{ k, v string }{{"a", "1"}, {"b", "2"}, {"c", "3"}} {
+		val, err := db.Get([]byte(kv.k))
+		if err != nil || string(val) != kv.v {
+			t.Fatalf("%s=(%q,%v), want %q", kv.k, val, err, kv.v)
+		}
 	}
 }
 

--- a/TreeDB/caching/delete_range_test.go
+++ b/TreeDB/caching/delete_range_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/snissn/gomap/TreeDB/batch"
 	"github.com/snissn/gomap/TreeDB/internal/commitlog"
 	"github.com/snissn/gomap/TreeDB/internal/memtable"
 )
@@ -405,6 +406,53 @@ func TestCachingBatchDeleteRangeMaterializationCapFailsClosed(t *testing.T) {
 		if err != nil || string(val) != kv.v {
 			t.Fatalf("%s=(%q,%v), want %q", kv.k, val, err, kv.v)
 		}
+	}
+}
+
+func TestCachingBatchDeleteRangeBackendBatchUsesSetOpsBridge(t *testing.T) {
+	dir := t.TempDir()
+	backend := NewMockBackend()
+	backend.Set([]byte("a"), []byte("1"))
+	backend.Set([]byte("b"), []byte("2"))
+	db, err := Open(dir, backend, Options{DisableWAL: true, AllowUnsafe: true})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer db.Close()
+
+	b := db.NewBatch()
+	defer b.Close()
+	b.backend = backend.NewBatch()
+	if err := b.Set([]byte("c"), []byte("3")); err != nil {
+		t.Fatalf("backend Set: %v", err)
+	}
+	if err := b.DeleteRange([]byte("a"), []byte("c")); err != nil {
+		t.Fatalf("DeleteRange: %v", err)
+	}
+	if b.hasDeleteRanges {
+		t.Fatalf("backend-backed DeleteRange should not switch to cached materialization")
+	}
+	if len(b.entries) != 0 {
+		t.Fatalf("backend-backed DeleteRange queued %d cached entries", len(b.entries))
+	}
+
+	backend.mu.RLock()
+	lastOps := append([]batch.Entry(nil), backend.lastOps...)
+	backend.mu.RUnlock()
+	if len(lastOps) != 1 || lastOps[0].Type != batch.OpDeleteRange || string(lastOps[0].Key) != "a" || string(lastOps[0].Value) != "c" {
+		t.Fatalf("last backend SetOps=%+v, want single DeleteRange [a,c)", lastOps)
+	}
+
+	if err := b.Write(); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	backend.mu.RLock()
+	_, hasA := backend.data["a"]
+	_, hasB := backend.data["b"]
+	gotC := string(backend.data["c"])
+	backend.mu.RUnlock()
+	if hasA || hasB || gotC != "3" {
+		t.Fatalf("backend data after bridged range: hasA=%t hasB=%t c=%q, want only c=3", hasA, hasB, gotC)
 	}
 }
 

--- a/TreeDB/caching/delete_range_test.go
+++ b/TreeDB/caching/delete_range_test.go
@@ -293,3 +293,46 @@ func TestCachingDB_DeleteRange_WALFlushesOnlySelectedLane(t *testing.T) {
 		t.Fatalf("expected no WAL sync calls for non-sync DeleteRange, got %d", totalSyncs)
 	}
 }
+
+func TestCachingBatchDeleteRangeMixedOrder(t *testing.T) {
+	dir := t.TempDir()
+	backend := NewMockBackend()
+	db, err := Open(dir, backend, Options{FlushThreshold: 1 << 20, JournalLanes: 1})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer db.Close()
+	for _, kv := range []struct{ k, v string }{{"a", "va"}, {"b", "vb"}, {"c", "vc"}, {"d", "vd"}} {
+		if err := db.Set([]byte(kv.k), []byte(kv.v)); err != nil {
+			t.Fatalf("Set %s: %v", kv.k, err)
+		}
+	}
+
+	b := db.NewBatch()
+	if err := b.Set([]byte("b"), []byte("shadowed")); err != nil {
+		t.Fatalf("batch Set shadowed: %v", err)
+	}
+	if err := b.DeleteRange([]byte("a"), []byte("d")); err != nil {
+		t.Fatalf("batch DeleteRange: %v", err)
+	}
+	if err := b.Set([]byte("c"), []byte("after")); err != nil {
+		t.Fatalf("batch Set after: %v", err)
+	}
+	if err := b.Write(); err != nil {
+		t.Fatalf("batch Write: %v", err)
+	}
+	_ = b.Close()
+
+	if val, err := db.Get([]byte("a")); err != nil || val != nil {
+		t.Fatalf("a=(%q,%v), want missing", val, err)
+	}
+	if val, err := db.Get([]byte("b")); err != nil || val != nil {
+		t.Fatalf("b=(%q,%v), want missing", val, err)
+	}
+	if val, err := db.Get([]byte("c")); err != nil || string(val) != "after" {
+		t.Fatalf("c=(%q,%v), want after", val, err)
+	}
+	if val, err := db.Get([]byte("d")); err != nil || string(val) != "vd" {
+		t.Fatalf("d=(%q,%v), want vd", val, err)
+	}
+}

--- a/TreeDB/caching/flush_pool_helpers_test.go
+++ b/TreeDB/caching/flush_pool_helpers_test.go
@@ -84,6 +84,11 @@ func (b *pointerBatch) Delete(key []byte) error {
 	return nil
 }
 
+func (b *pointerBatch) DeleteRange(start, end []byte) error {
+	b.entries = append(b.entries, batch.Entry{Type: batch.OpDeleteRange, Key: start, Value: end})
+	return nil
+}
+
 func (b *pointerBatch) DeleteView(key []byte) error {
 	b.deleteViewCalls++
 	b.entries = append(b.entries, batch.Entry{Type: batch.OpDelete, Key: key})

--- a/TreeDB/caching/rcu_snapshot_test.go
+++ b/TreeDB/caching/rcu_snapshot_test.go
@@ -642,6 +642,8 @@ func (b *noAllocBatch) Set(key, value []byte) error { return nil }
 
 func (b *noAllocBatch) Delete(key []byte) error { return nil }
 
+func (b *noAllocBatch) DeleteRange(start, end []byte) error { return nil }
+
 func (b *noAllocBatch) SetOps(ops []batch.Entry) error { return nil }
 
 func (b *noAllocBatch) Write() error { return nil }

--- a/TreeDB/command_wal_public_cached.go
+++ b/TreeDB/command_wal_public_cached.go
@@ -348,6 +348,26 @@ func (b *commandWALPublicBatch) DeleteView(key []byte) error {
 	return nil
 }
 
+func (b *commandWALPublicBatch) DeleteRange(start, end []byte) error {
+	if b == nil || b.inner == nil {
+		return ErrClosed
+	}
+	if batch.IsDeleteRangeNoop(start, end) {
+		return nil
+	}
+	oldLen, oldCount := b.payload.Len(), b.payload.Count()
+	if _, err := b.payload.AppendDeleteRange(start, end); err != nil {
+		return err
+	}
+	if err := b.inner.DeleteRange(start, end); err != nil {
+		b.payload.Truncate(oldLen, oldCount)
+		return err
+	}
+	b.opCount++
+	b.dirty = true
+	return nil
+}
+
 func (b *commandWALPublicBatch) innerSetView(key, value []byte) error {
 	if b.innerSetViewFn != nil {
 		return b.innerSetViewFn(key, value)
@@ -458,6 +478,11 @@ func (b *commandWALPublicBatch) commandWALPayload() ([]byte, error) {
 	return commitlog.EncodeRawKVBatchPayloadScanWithHint(func(emit func(commitlog.RawKVOperation) error) error {
 		return b.inner.Replay(func(entry batch.Entry) error {
 			switch entry.Type {
+			case batch.OpDeleteRange:
+				if batch.IsDeleteRangeNoop(entry.Key, entry.Value) {
+					return nil
+				}
+				return emit(commitlog.RawKVOperation{Op: commitlog.RawKVOpDeleteRange, Key: entry.Key, Value: entry.Value})
 			case batch.OpDelete:
 				return emit(commitlog.RawKVOperation{Op: commitlog.RawKVOpDelete, Key: entry.Key})
 			case batch.OpPut:

--- a/TreeDB/command_wal_public_test.go
+++ b/TreeDB/command_wal_public_test.go
@@ -891,6 +891,18 @@ func (b *commandWALNoResetBatch) Delete(key []byte) error {
 	return nil
 }
 
+func (b *commandWALNoResetBatch) DeleteRange(start, end []byte) error {
+	var startCopy, endCopy []byte
+	if start != nil {
+		startCopy = append([]byte(nil), start...)
+	}
+	if end != nil {
+		endCopy = append([]byte(nil), end...)
+	}
+	b.entries = append(b.entries, batch.Entry{Type: batch.OpDeleteRange, Key: startCopy, Value: endCopy})
+	return nil
+}
+
 func (b *commandWALNoResetBatch) Write() error { return nil }
 
 func (b *commandWALNoResetBatch) WriteSync() error { return nil }
@@ -1002,5 +1014,52 @@ func assertPublicCommandWALFramesB(b *testing.B, db *DB, minFrames uint64) {
 	}
 	if frames < minFrames {
 		b.Fatalf("command_wal.frames=%d, want at least %d", frames, minFrames)
+	}
+}
+
+func TestPublicCommandWALBatchDeleteRangeCachedReopen(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(Options{Dir: dir, Durability: DurabilityWALOnRelaxed, CommandWAL: true})
+	if err != nil {
+		t.Fatalf("Open command WAL: %v", err)
+	}
+	for _, kv := range []struct{ k, v string }{{"a", "va"}, {"b", "vb"}, {"c", "vc"}, {"d", "vd"}} {
+		if err := db.Set([]byte(kv.k), []byte(kv.v)); err != nil {
+			t.Fatalf("Set %s: %v", kv.k, err)
+		}
+	}
+	b := db.NewBatch()
+	if err := b.DeleteRange([]byte("a"), []byte("d")); err != nil {
+		t.Fatalf("batch DeleteRange: %v", err)
+	}
+	if err := b.Set([]byte("b"), []byte("after")); err != nil {
+		t.Fatalf("batch Set: %v", err)
+	}
+	if err := b.WriteSync(); err != nil {
+		t.Fatalf("batch WriteSync: %v", err)
+	}
+	_ = b.Close()
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	reopen, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("Reopen: %v", err)
+	}
+	defer reopen.Close()
+	for _, key := range []string{"a", "c"} {
+		has, err := reopen.Has([]byte(key))
+		if err != nil || has {
+			t.Fatalf("Has(%s)=(%t,%v), want false,nil", key, has, err)
+		}
+	}
+	got, err := reopen.Get([]byte("b"))
+	if err != nil || string(got) != "after" {
+		t.Fatalf("Get(b)=(%q,%v), want after,nil", got, err)
+	}
+	got, err = reopen.Get([]byte("d"))
+	if err != nil || string(got) != "vd" {
+		t.Fatalf("Get(d)=(%q,%v), want vd,nil", got, err)
 	}
 }

--- a/TreeDB/db/batch.go
+++ b/TreeDB/db/batch.go
@@ -170,6 +170,10 @@ func (b *Batch) Delete(key []byte) error {
 	return b.batch.Delete(key)
 }
 
+func (b *Batch) DeleteRange(start, end []byte) error {
+	return b.batch.DeleteRange(start, end)
+}
+
 // DeleteView records a Delete without copying the key bytes. Callers must treat
 // key as immutable until the batch is written or closed.
 func (b *Batch) DeleteView(key []byte) error {
@@ -213,7 +217,7 @@ func (b *Batch) write(sync bool) error {
 	if b.db.readOnly {
 		return ErrReadOnly
 	}
-	if sync && b.batch != nil && len(b.batch.SortedEntries()) == 0 && b.commandWALPublishIntent == nil {
+	if sync && b.batch != nil && b.batch.Len() == 0 && b.commandWALPublishIntent == nil {
 		return b.db.Checkpoint()
 	}
 	intent := b.commandWALPublishIntent
@@ -280,8 +284,8 @@ func (b *Batch) writeOptimistic(sync bool, intent *commandWALBatchIntent) (bool,
 		}
 		return false, err
 	}
-	entries := b.batch.SortedEntries()
-	vlogRefDelta, err := b.db.buildValueLogRefDelta(idx.pager, rootID, baseSeq, entries)
+	entries, ranges := b.batch.ApplyPlan()
+	vlogRefDelta, err := b.db.buildValueLogRefDelta(idx.pager, rootID, baseSeq, entries, ranges)
 	if err != nil {
 		freeErr := tracker.FreeAll()
 		b.db.writeMu.RUnlock()
@@ -340,7 +344,7 @@ func (b *Batch) writeOptimistic(sync bool, intent *commandWALBatchIntent) (bool,
 	b.db.invalidateLeafGenerationSubtreeStats(tracker.Pages())
 	b.db.finalizeCommitPostWork(post)
 	if b.db.vacuum.Active() {
-		b.db.vacuum.RecordEntries(entries)
+		b.db.vacuum.RecordApplyPlan(entries, ranges)
 	}
 	b.db.writeMu.RUnlock()
 	return true, nil
@@ -369,8 +373,8 @@ func (b *Batch) writeSerialized(sync bool, intent *commandWALBatchIntent) error 
 	if err != nil {
 		return err
 	}
-	entries := b.batch.SortedEntries()
-	vlogRefDelta, err := b.db.buildValueLogRefDelta(idx.pager, rootID, baseSeq, entries)
+	entries, ranges := b.batch.ApplyPlan()
+	vlogRefDelta, err := b.db.buildValueLogRefDelta(idx.pager, rootID, baseSeq, entries, ranges)
 	if err != nil {
 		return err
 	}
@@ -410,7 +414,7 @@ func (b *Batch) writeSerialized(sync bool, intent *commandWALBatchIntent) error 
 	b.db.finalizeCommitPostWork(post)
 	b.db.clearLeafGenerationReachabilityCaches()
 	if b.db.vacuum.Active() {
-		b.db.vacuum.RecordEntries(entries)
+		b.db.vacuum.RecordApplyPlan(entries, ranges)
 	}
 	return nil
 }
@@ -440,7 +444,10 @@ func (b *Batch) Replay(fn func(batch.Entry) error) error {
 	if b == nil || b.batch == nil {
 		return nil
 	}
-	entries := b.batch.SortedEntries()
+	entries := b.batch.OrderedEntries()
+	if !b.batch.HasDeleteRanges() {
+		entries = b.batch.SortedEntries()
+	}
 	for _, entry := range entries {
 		if entry.IsPtr && entry.Value == nil {
 			ptr := entry.ValuePtr

--- a/TreeDB/db/batch_delete_range_bench_test.go
+++ b/TreeDB/db/batch_delete_range_bench_test.go
@@ -1,0 +1,113 @@
+package db
+
+import (
+	"fmt"
+	"testing"
+)
+
+func benchmarkDeleteRangeKeys(n int) [][]byte {
+	keys := make([][]byte, n)
+	for i := range keys {
+		keys[i] = []byte(fmt.Sprintf("k%09d", i))
+	}
+	return keys
+}
+
+func benchmarkSeedKeys(b *testing.B, d *DB, keys [][]byte, value []byte) {
+	b.Helper()
+	batch := d.NewBatch()
+	for _, key := range keys {
+		if err := batch.Set(key, value); err != nil {
+			_ = batch.Close()
+			b.Fatalf("seed Set: %v", err)
+		}
+	}
+	if err := batch.Write(); err != nil {
+		_ = batch.Close()
+		b.Fatalf("seed Write: %v", err)
+	}
+	_ = batch.Close()
+}
+
+func BenchmarkBatchDeleteRangeDense(b *testing.B) {
+	const count = 4096
+	keys := benchmarkDeleteRangeKeys(count)
+	value := []byte("value")
+	rangeStart := keys[0]
+	rangeEnd := []byte("k999999999")
+
+	b.Run("range_delete_4096", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ReportMetric(float64(count), "affected_keys/op")
+		b.StopTimer()
+		for i := 0; i < b.N; i++ {
+			d, err := Open(Options{Dir: b.TempDir(), DisableBackgroundPrune: true})
+			if err != nil {
+				b.Fatalf("Open: %v", err)
+			}
+			benchmarkSeedKeys(b, d, keys, value)
+			batch := d.NewBatch()
+			b.StartTimer()
+			if err := batch.DeleteRange(rangeStart, rangeEnd); err != nil {
+				b.Fatalf("DeleteRange: %v", err)
+			}
+			if err := batch.Write(); err != nil {
+				b.Fatalf("Write: %v", err)
+			}
+			b.StopTimer()
+			_ = batch.Close()
+			_ = d.Close()
+		}
+	})
+
+	b.Run("point_delete_4096", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ReportMetric(float64(count), "affected_keys/op")
+		b.StopTimer()
+		for i := 0; i < b.N; i++ {
+			d, err := Open(Options{Dir: b.TempDir(), DisableBackgroundPrune: true})
+			if err != nil {
+				b.Fatalf("Open: %v", err)
+			}
+			benchmarkSeedKeys(b, d, keys, value)
+			batch := d.NewBatch()
+			b.StartTimer()
+			for _, key := range keys {
+				if err := batch.Delete(key); err != nil {
+					b.Fatalf("Delete: %v", err)
+				}
+			}
+			if err := batch.Write(); err != nil {
+				b.Fatalf("Write: %v", err)
+			}
+			b.StopTimer()
+			_ = batch.Close()
+			_ = d.Close()
+		}
+	})
+
+	b.Run("batch_write_4096", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ReportMetric(float64(count), "affected_keys/op")
+		b.StopTimer()
+		for i := 0; i < b.N; i++ {
+			d, err := Open(Options{Dir: b.TempDir(), DisableBackgroundPrune: true})
+			if err != nil {
+				b.Fatalf("Open: %v", err)
+			}
+			batch := d.NewBatch()
+			b.StartTimer()
+			for _, key := range keys {
+				if err := batch.Set(key, value); err != nil {
+					b.Fatalf("Set: %v", err)
+				}
+			}
+			if err := batch.Write(); err != nil {
+				b.Fatalf("Write: %v", err)
+			}
+			b.StopTimer()
+			_ = batch.Close()
+			_ = d.Close()
+		}
+	})
+}

--- a/TreeDB/db/batch_delete_range_test.go
+++ b/TreeDB/db/batch_delete_range_test.go
@@ -1,0 +1,302 @@
+package db
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/internal/commitlog"
+	"github.com/snissn/gomap/TreeDB/internal/iterator"
+)
+
+func seedBatchDeleteRangeDB(t *testing.T, d *DB, n int) {
+	t.Helper()
+	b := d.NewBatch()
+	defer b.Close()
+	for i := 0; i < n; i++ {
+		key := []byte(fmt.Sprintf("k%03d", i))
+		val := []byte(fmt.Sprintf("v%03d", i))
+		if err := b.Set(key, val); err != nil {
+			t.Fatalf("seed Set(%q): %v", key, err)
+		}
+	}
+	if err := b.Write(); err != nil {
+		t.Fatalf("seed Write: %v", err)
+	}
+}
+
+func assertHasValue(t *testing.T, d *DB, key, want string) {
+	t.Helper()
+	got, err := d.Get([]byte(key))
+	if err != nil {
+		t.Fatalf("Get(%s): %v", key, err)
+	}
+	if !bytes.Equal(got, []byte(want)) {
+		t.Fatalf("Get(%s)=%q want %q", key, got, want)
+	}
+}
+
+func assertMissing(t *testing.T, d *DB, key string) {
+	t.Helper()
+	ok, err := d.Has([]byte(key))
+	if err != nil {
+		t.Fatalf("Has(%s): %v", key, err)
+	}
+	if ok {
+		t.Fatalf("Has(%s)=true, want false", key)
+	}
+}
+
+func assertIteratorKVs(t *testing.T, it iterator.UnsafeIterator, want []string) {
+	t.Helper()
+	defer func() { _ = it.Close() }()
+	var got []string
+	for it.Valid() {
+		got = append(got, fmt.Sprintf("%s=%s", it.Key(), it.Value()))
+		it.Next()
+	}
+	if err := it.Error(); err != nil {
+		t.Fatalf("iterator error: %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("iterator KVs=%v want %v", got, want)
+	}
+}
+
+func TestBatchDeleteRangeMixedOrderedSemantics(t *testing.T) {
+	d, err := Open(Options{Dir: t.TempDir(), DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer d.Close()
+	seedBatchDeleteRangeDB(t, d, 8)
+
+	snap := d.AcquireSnapshot()
+	defer snap.Close()
+
+	b := d.NewBatch()
+	defer b.Close()
+	if err := b.Set([]byte("k002"), []byte("shadowed")); err != nil {
+		t.Fatalf("Set shadowed: %v", err)
+	}
+	if err := b.DeleteRange([]byte("k001"), []byte("k006")); err != nil {
+		t.Fatalf("DeleteRange: %v", err)
+	}
+	if err := b.Set([]byte("k003"), []byte("after-range")); err != nil {
+		t.Fatalf("Set after range: %v", err)
+	}
+	if err := b.Delete([]byte("k007")); err != nil {
+		t.Fatalf("Delete point: %v", err)
+	}
+	if err := b.Write(); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	// Snapshot acquired before the batch sees the old state.
+	if got, err := snap.Get([]byte("k002")); err != nil || !bytes.Equal(got, []byte("v002")) {
+		t.Fatalf("snapshot k002=(%q,%v), want old v002", got, err)
+	}
+
+	assertHasValue(t, d, "k000", "v000")
+	assertMissing(t, d, "k001")
+	assertMissing(t, d, "k002")
+	assertHasValue(t, d, "k003", "after-range")
+	assertMissing(t, d, "k004")
+	assertMissing(t, d, "k005")
+	assertHasValue(t, d, "k006", "v006")
+	assertMissing(t, d, "k007")
+}
+
+func TestBatchDeleteRangeIteratorVisibilityMixedBatch(t *testing.T) {
+	d, err := Open(Options{Dir: t.TempDir(), DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer d.Close()
+	seedBatchDeleteRangeDB(t, d, 6)
+
+	snap := d.AcquireSnapshot()
+	defer snap.Close()
+
+	b := d.NewBatch()
+	defer b.Close()
+	if err := b.Set([]byte("k002"), []byte("shadowed")); err != nil {
+		t.Fatalf("Set shadowed: %v", err)
+	}
+	if err := b.DeleteRange([]byte("k001"), []byte("k005")); err != nil {
+		t.Fatalf("DeleteRange: %v", err)
+	}
+	if err := b.Set([]byte("k003"), []byte("after")); err != nil {
+		t.Fatalf("Set after: %v", err)
+	}
+	if err := b.Write(); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	it, err := d.Iterator(nil, nil)
+	if err != nil {
+		t.Fatalf("Iterator: %v", err)
+	}
+	assertIteratorKVs(t, it, []string{"k000=v000", "k003=after", "k005=v005"})
+
+	snapIt, err := snap.Iterator(nil, nil)
+	if err != nil {
+		t.Fatalf("snapshot Iterator: %v", err)
+	}
+	assertIteratorKVs(t, snapIt, []string{"k000=v000", "k001=v001", "k002=v002", "k003=v003", "k004=v004", "k005=v005"})
+}
+
+func TestBatchDeleteRangeValueLogPointerRefsAndGC(t *testing.T) {
+	dir := t.TempDir()
+	d, err := Open(Options{Dir: dir, DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer d.Close()
+
+	valueDrop := bytes.Repeat([]byte("drop-one|"), 32)
+	valueOldReplace := bytes.Repeat([]byte("old-replace|"), 32)
+	valueKeep := bytes.Repeat([]byte("keep|"), 32)
+	valueNewReplace := bytes.Repeat([]byte("new-replace|"), 32)
+	fileDrop, ptrDrop := writeValueLogRecord(t, dir, 0, 1, valueDrop, 1)
+	fileOldReplace, ptrOldReplace := writeValueLogRecord(t, dir, 0, 2, valueOldReplace, 2)
+	fileKeep, ptrKeep := writeValueLogRecord(t, dir, 0, 3, valueKeep, 3)
+	fileNewReplace, ptrNewReplace := writeValueLogRecord(t, dir, 0, 4, valueNewReplace, 4)
+
+	seed := d.NewBatch().(*Batch)
+	if err := seed.SetPointer([]byte("k1"), ptrDrop); err != nil {
+		t.Fatalf("seed k1: %v", err)
+	}
+	if err := seed.SetPointer([]byte("k2"), ptrOldReplace); err != nil {
+		t.Fatalf("seed k2: %v", err)
+	}
+	if err := seed.SetPointer([]byte("k3"), ptrKeep); err != nil {
+		t.Fatalf("seed k3: %v", err)
+	}
+	if err := seed.Write(); err != nil {
+		t.Fatalf("seed Write: %v", err)
+	}
+	_ = seed.Close()
+
+	b := d.NewBatch().(*Batch)
+	if err := b.DeleteRange([]byte("k1"), []byte("k3")); err != nil {
+		t.Fatalf("DeleteRange: %v", err)
+	}
+	if err := b.SetPointer([]byte("k2"), ptrNewReplace); err != nil {
+		t.Fatalf("SetPointer replacement: %v", err)
+	}
+	if err := b.Write(); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	_ = b.Close()
+
+	assertMissing(t, d, "k1")
+	if got, err := d.Get([]byte("k2")); err != nil || !bytes.Equal(got, valueNewReplace) {
+		t.Fatalf("Get(k2)=(%d bytes,%v), want replacement", len(got), err)
+	}
+	if got, err := d.Get([]byte("k3")); err != nil || !bytes.Equal(got, valueKeep) {
+		t.Fatalf("Get(k3)=(%d bytes,%v), want keep", len(got), err)
+	}
+
+	stats, err := d.ValueLogGC(context.Background(), ValueLogGCOptions{})
+	if err != nil {
+		t.Fatalf("ValueLogGC: %v", err)
+	}
+	if stats.SegmentsDeleted < 2 {
+		t.Fatalf("ValueLogGC deleted %d segments, want at least 2: %+v", stats.SegmentsDeleted, stats)
+	}
+
+	pathForFile := func(seq uint32) string {
+		return filepath.Join(dir, "value_vlog", fmt.Sprintf("value-l0-%06d.log", seq))
+	}
+	for _, tc := range []struct {
+		name   string
+		fileID uint32
+		seq    uint32
+		dead   bool
+	}{
+		{"range-deleted", fileDrop, 1, true},
+		{"range-deleted-before-replace", fileOldReplace, 2, true},
+		{"retained-outside-range", fileKeep, 3, false},
+		{"replacement-after-range", fileNewReplace, 4, false},
+	} {
+		_, err := os.Stat(pathForFile(tc.seq))
+		if tc.dead {
+			if !os.IsNotExist(err) {
+				t.Fatalf("%s segment %d stat err=%v, want removed", tc.name, tc.fileID, err)
+			}
+			continue
+		}
+		if err != nil {
+			t.Fatalf("%s segment %d stat err=%v, want retained", tc.name, tc.fileID, err)
+		}
+	}
+}
+
+func TestBatchDeleteRangeNilEndReopenCommandWAL(t *testing.T) {
+	dir := t.TempDir()
+	d, err := Open(Options{Dir: dir, CommandWAL: true, DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	seedBatchDeleteRangeDB(t, d, 5)
+	b := d.NewBatch()
+	if err := b.DeleteRange([]byte("k002"), nil); err != nil {
+		t.Fatalf("DeleteRange: %v", err)
+	}
+	if err := b.Set([]byte("k003"), []byte("later")); err != nil {
+		t.Fatalf("Set later: %v", err)
+	}
+	if err := b.WriteSync(); err != nil {
+		t.Fatalf("WriteSync: %v", err)
+	}
+	_ = b.Close()
+	if err := d.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	reopen, err := Open(Options{Dir: dir, CommandWAL: true, DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatalf("Reopen: %v", err)
+	}
+	defer reopen.Close()
+	assertHasValue(t, reopen, "k000", "v000")
+	assertHasValue(t, reopen, "k001", "v001")
+	assertMissing(t, reopen, "k002")
+	assertHasValue(t, reopen, "k003", "later")
+	assertMissing(t, reopen, "k004")
+}
+
+func TestCommandWALRawDeleteRangeReplayFrame(t *testing.T) {
+	dir := t.TempDir()
+	d, err := Open(Options{Dir: dir, DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatalf("Open bootstrap: %v", err)
+	}
+	seedBatchDeleteRangeDB(t, d, 5)
+	if err := d.Close(); err != nil {
+		t.Fatalf("Close bootstrap: %v", err)
+	}
+	enableCommandWALFormat(t, dir)
+	writeCommandWALRawKVFrame(t, dir, 1, 1, []commitlog.RawKVOperation{
+		{Op: commitlog.RawKVOpDeleteRange, Key: []byte("k001"), Value: []byte("k004")},
+		{Op: commitlog.RawKVOpSet, Key: []byte("k002"), Value: []byte("after")},
+	})
+	reopen, err := Open(Options{Dir: dir, DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatalf("Open replay: %v", err)
+	}
+	defer reopen.Close()
+	assertHasValue(t, reopen, "k000", "v000")
+	assertMissing(t, reopen, "k001")
+	assertHasValue(t, reopen, "k002", "after")
+	assertMissing(t, reopen, "k003")
+	assertHasValue(t, reopen, "k004", "v004")
+	if got := reopen.State().AppliedCommandLSN; got != 1 {
+		t.Fatalf("AppliedCommandLSN=%d want 1", got)
+	}
+}

--- a/TreeDB/db/command_wal_raw.go
+++ b/TreeDB/db/command_wal_raw.go
@@ -228,9 +228,12 @@ func (db *DB) prepareRawKVCommandWALIntent(b *Batch) (*commandWALBatchIntent, er
 	if b == nil || b.batch == nil {
 		return nil, nil
 	}
-	// SortedEntries is idempotent after the first sort/compaction; later write
-	// paths reuse the sorted+compacted batch-owned slice without resorting.
-	entries := b.batch.SortedEntries()
+	entries := b.batch.OrderedEntries()
+	if !b.batch.HasDeleteRanges() {
+		// SortedEntries is idempotent after the first sort/compaction; point-only
+		// batches keep the existing compacted command-WAL fast path.
+		entries = b.batch.SortedEntries()
+	}
 	if len(entries) == 0 {
 		return nil, nil
 	}
@@ -244,6 +247,11 @@ func (db *DB) prepareRawKVCommandWALIntent(b *Batch) (*commandWALBatchIntent, er
 	for i := range entries {
 		entry := entries[i]
 		switch entry.Type {
+		case batchpkg.OpDeleteRange:
+			if batchpkg.IsDeleteRangeNoop(entry.Key, entry.Value) {
+				continue
+			}
+			ops = append(ops, commitlog.RawKVOperation{Op: commitlog.RawKVOpDeleteRange, Key: entry.Key, Value: entry.Value})
 		case batchpkg.OpDelete:
 			ops = append(ops, commitlog.RawKVOperation{Op: commitlog.RawKVOpDelete, Key: entry.Key})
 		case batchpkg.OpPut:
@@ -816,6 +824,10 @@ func applyRawKVCommandWALFrame(db *DB, env commitlog.CommandEnvelope, ridMap map
 			}
 		case commitlog.RawKVOpDelete:
 			if err := b.Delete(entry.Key); err != nil {
+				return err
+			}
+		case commitlog.RawKVOpDeleteRange:
+			if err := b.DeleteRange(entry.Key, entry.Value); err != nil {
 				return err
 			}
 		case commitlog.RawKVOpSetRID:

--- a/TreeDB/db/command_wal_raw_test.go
+++ b/TreeDB/db/command_wal_raw_test.go
@@ -80,6 +80,50 @@ func TestTrustedCommandWALIntentAppendsCanonicalCollectionPayload(t *testing.T) 
 	}
 }
 
+func TestAppendRawKVSingleCommandWALSupportsDeleteRange(t *testing.T) {
+	dir := t.TempDir()
+	d, err := Open(Options{Dir: dir, CommandWAL: true, DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	lsn, err := d.AppendRawKVSingleCommandWAL(commitlog.RawKVOperation{
+		Op:    commitlog.RawKVOpDeleteRange,
+		Key:   nil,
+		Value: []byte("m"),
+	}, true)
+	if err != nil {
+		_ = d.Close()
+		t.Fatalf("AppendRawKVSingleCommandWAL DeleteRange: %v", err)
+	}
+	if lsn == 0 {
+		_ = d.Close()
+		t.Fatalf("AppendRawKVSingleCommandWAL DeleteRange lsn=0")
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	r, err := commitlog.NewReader(filepath.Join(WALDirPath(dir), "commit-l0-000001.log"))
+	if err != nil {
+		t.Fatalf("NewReader: %v", err)
+	}
+	defer r.Close()
+	env, err := r.ReadCommandFrame()
+	if err != nil {
+		t.Fatalf("ReadCommandFrame: %v", err)
+	}
+	if env.LSN != lsn || env.Kind != commitlog.CommandKindRawKVBatch || env.Scope != commitlog.CommandScopeRawKV || env.PayloadFormat != commitlog.PayloadFormatRawKVBatchV1 {
+		t.Fatalf("decoded DeleteRange command identity mismatch: %+v", env)
+	}
+	ops, err := commitlog.DecodeRawKVBatchPayload(env.Payload)
+	if err != nil {
+		t.Fatalf("DecodeRawKVBatchPayload: %v", err)
+	}
+	if len(ops) != 1 || ops[0].Op != commitlog.RawKVOpDeleteRange || ops[0].Key != nil || string(ops[0].Value) != "m" {
+		t.Fatalf("decoded DeleteRange ops=%+v, want single [nil,m)", ops)
+	}
+}
+
 func TestCommandWALReplayIntentZeroLSNFailsClosedM10C(t *testing.T) {
 	intent := newCommandWALReplayIntent(commitlog.CommandEnvelope{
 		Kind:          commitlog.CommandKindCollectionInsertBatchByID,

--- a/TreeDB/db/vacuum_online.go
+++ b/TreeDB/db/vacuum_online.go
@@ -38,6 +38,7 @@ type vacuumRecorder struct {
 	active atomic.Bool
 	mu     sync.Mutex
 	ops    map[string]batch.Entry
+	ranges []batch.DeleteRange
 }
 
 func (r *vacuumRecorder) Active() bool {
@@ -47,6 +48,7 @@ func (r *vacuumRecorder) Active() bool {
 func (r *vacuumRecorder) Start() {
 	r.mu.Lock()
 	r.ops = make(map[string]batch.Entry, 1024)
+	r.ranges = nil
 	r.mu.Unlock()
 	r.active.Store(true)
 }
@@ -64,6 +66,19 @@ func vacuumRecordCopyEntry(entry batch.Entry) batch.Entry {
 		out.Value = nil
 	}
 	return out
+}
+
+func vacuumRecordCopyRange(r batch.DeleteRange) batch.DeleteRange {
+	cloneBound := func(bound []byte) []byte {
+		if bound == nil {
+			return nil
+		}
+		return append([]byte{}, bound...)
+	}
+	return batch.DeleteRange{
+		Start: cloneBound(r.Start),
+		End:   cloneBound(r.End),
+	}
 }
 
 func (r *vacuumRecorder) RecordOps(ops map[string]batch.Entry) {
@@ -84,7 +99,11 @@ func (r *vacuumRecorder) RecordOps(ops map[string]batch.Entry) {
 }
 
 func (r *vacuumRecorder) RecordEntries(entries []batch.Entry) {
-	if !r.active.Load() || len(entries) == 0 {
+	r.RecordApplyPlan(entries, nil)
+}
+
+func (r *vacuumRecorder) RecordApplyPlan(entries []batch.Entry, ranges []batch.DeleteRange) {
+	if !r.active.Load() || (len(entries) == 0 && len(ranges) == 0) {
 		return
 	}
 	r.mu.Lock()
@@ -92,27 +111,60 @@ func (r *vacuumRecorder) RecordEntries(entries []batch.Entry) {
 	if !r.active.Load() {
 		return
 	}
-	if r.ops == nil {
+	if r.ops == nil && len(entries) > 0 {
 		r.ops = make(map[string]batch.Entry, len(entries))
+	}
+	for _, rg := range ranges {
+		if batch.IsDeleteRangeNoop(rg.Start, rg.End) {
+			continue
+		}
+		copied := vacuumRecordCopyRange(rg)
+		r.ranges = append(r.ranges, copied)
+		if len(r.ops) == 0 {
+			continue
+		}
+		start, end := string(copied.Start), string(copied.End)
+		for key := range r.ops {
+			if copied.Start != nil && key < start {
+				continue
+			}
+			if copied.End != nil && key >= end {
+				continue
+			}
+			delete(r.ops, key)
+		}
 	}
 	for i := range entries {
 		entry := entries[i]
 		if len(entry.Key) == 0 {
 			continue
 		}
+		if r.ops == nil {
+			r.ops = make(map[string]batch.Entry, len(entries)-i)
+		}
 		r.ops[string(entry.Key)] = vacuumRecordCopyEntry(entry)
 	}
 }
 
 func (r *vacuumRecorder) Drain() map[string]batch.Entry {
+	ops, _ := r.DrainApplyPlan()
+	return ops
+}
+
+func (r *vacuumRecorder) DrainApplyPlan() (map[string]batch.Entry, []batch.DeleteRange) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	if len(r.ops) == 0 {
-		return nil
+	if len(r.ops) == 0 && len(r.ranges) == 0 {
+		return nil, nil
 	}
-	out := r.ops
+	outOps := r.ops
+	if len(outOps) == 0 {
+		outOps = nil
+	}
+	outRanges := r.ranges
 	r.ops = make(map[string]batch.Entry, 1024)
-	return out
+	r.ranges = nil
+	return outOps, outRanges
 }
 
 // VacuumIndexOnline rebuilds the index into a new file and swaps it in with a
@@ -294,12 +346,12 @@ func (db *DB) vacuumIndexOnline(ctx context.Context, lockMaintenance bool) error
 			cleanupNewPager()
 			return err
 		}
-		opsMap := db.vacuum.Drain()
-		if len(opsMap) == 0 {
+		opsMap, ranges := db.vacuum.DrainApplyPlan()
+		if len(opsMap) == 0 && len(ranges) == 0 {
 			break
 		}
 		var retired []uint64
-		newRoot, retired, err = db.applyVacuumDelta(newRoot, opsMap, newZ, nil)
+		newRoot, retired, err = db.applyVacuumDelta(newRoot, opsMap, ranges, newZ, nil)
 		if err != nil {
 			cleanupNewPager()
 			return err
@@ -331,14 +383,14 @@ func (db *DB) vacuumIndexOnline(ctx context.Context, lockMaintenance bool) error
 
 		db.writeMu.Lock()
 		db.vacuum.Stop()
-		finalOps := db.vacuum.Drain()
-		if len(finalOps) > vacuumCutoverMaxKeys && defers < vacuumCutoverMaxDefers {
+		finalOps, finalRanges := db.vacuum.DrainApplyPlan()
+		if len(finalOps) > vacuumCutoverMaxKeys && len(finalRanges) == 0 && defers < vacuumCutoverMaxDefers {
 			db.vacuum.Start()
 			db.writeMu.Unlock()
 			defers++
 
 			var retired []uint64
-			newRoot, retired, err = db.applyVacuumDelta(newRoot, finalOps, newZ, nil)
+			newRoot, retired, err = db.applyVacuumDelta(newRoot, finalOps, finalRanges, newZ, nil)
 			if err != nil {
 				cleanupNewPager()
 				return err
@@ -357,9 +409,9 @@ func (db *DB) vacuumIndexOnline(ctx context.Context, lockMaintenance bool) error
 			continue
 		}
 
-		if len(finalOps) > 0 {
+		if len(finalOps) > 0 || len(finalRanges) > 0 {
 			var retired []uint64
-			newRoot, retired, err = db.applyVacuumDelta(newRoot, finalOps, newZ, nil)
+			newRoot, retired, err = db.applyVacuumDelta(newRoot, finalOps, finalRanges, newZ, nil)
 			if err != nil {
 				db.writeMu.Unlock()
 				cleanupNewPager()
@@ -597,9 +649,28 @@ func (db *DB) vacuumIndexOnline(ctx context.Context, lockMaintenance bool) error
 	}
 }
 
-func (db *DB) applyVacuumDelta(root uint64, opsMap map[string]batch.Entry, z *zipper.Zipper, retired []uint64) (uint64, []uint64, error) {
-	if len(opsMap) == 0 {
+func (db *DB) applyVacuumDelta(root uint64, opsMap map[string]batch.Entry, ranges []batch.DeleteRange, z *zipper.Zipper, retired []uint64) (uint64, []uint64, error) {
+	if len(opsMap) == 0 && len(ranges) == 0 {
 		return root, retired, nil
+	}
+
+	if len(ranges) > 0 {
+		b := batch.New(db.valueLogManager, vacuumInlineThresholdMax)
+		for _, r := range ranges {
+			if err := b.DeleteRange(r.Start, r.End); err != nil {
+				_ = b.Close()
+				return 0, nil, err
+			}
+		}
+		newRoot, newRetired, _, err := z.Apply(root, b)
+		_ = b.Close()
+		if err != nil {
+			return 0, nil, err
+		}
+		root = newRoot
+		if len(newRetired) > 0 {
+			retired = append(retired, newRetired...)
+		}
 	}
 
 	keys := make([]string, 0, len(opsMap))

--- a/TreeDB/db/vacuum_online.go
+++ b/TreeDB/db/vacuum_online.go
@@ -649,20 +649,32 @@ func (db *DB) vacuumIndexOnline(ctx context.Context, lockMaintenance bool) error
 	}
 }
 
-func (db *DB) applyVacuumDelta(root uint64, opsMap map[string]batch.Entry, ranges []batch.DeleteRange, z *zipper.Zipper, retired []uint64) (uint64, []uint64, error) {
-	if len(opsMap) == 0 && len(ranges) == 0 {
+type vacuumRangeDeltaApplier func(root uint64, b *batch.Batch) (newRoot uint64, retired []uint64, err error)
+
+func applyVacuumRangeDeltaBatches(root uint64, ranges []batch.DeleteRange, retired []uint64, reader batch.ValueReader, apply vacuumRangeDeltaApplier) (uint64, []uint64, error) {
+	if len(ranges) == 0 {
 		return root, retired, nil
 	}
-
-	if len(ranges) > 0 {
-		b := batch.New(db.valueLogManager, vacuumInlineThresholdMax)
-		for _, r := range ranges {
+	if apply == nil {
+		return 0, nil, errors.New("vacuum: missing range delta applier")
+	}
+	for start := 0; start < len(ranges); start += vacuumDeltaBatchSize {
+		end := start + vacuumDeltaBatchSize
+		if end > len(ranges) {
+			end = len(ranges)
+		}
+		b := batch.New(reader, vacuumInlineThresholdMax)
+		for _, r := range ranges[start:end] {
 			if err := b.DeleteRange(r.Start, r.End); err != nil {
 				_ = b.Close()
 				return 0, nil, err
 			}
 		}
-		newRoot, newRetired, _, err := z.Apply(root, b)
+		if b.Len() == 0 {
+			_ = b.Close()
+			continue
+		}
+		newRoot, newRetired, err := apply(root, b)
 		_ = b.Close()
 		if err != nil {
 			return 0, nil, err
@@ -671,6 +683,22 @@ func (db *DB) applyVacuumDelta(root uint64, opsMap map[string]batch.Entry, range
 		if len(newRetired) > 0 {
 			retired = append(retired, newRetired...)
 		}
+	}
+	return root, retired, nil
+}
+
+func (db *DB) applyVacuumDelta(root uint64, opsMap map[string]batch.Entry, ranges []batch.DeleteRange, z *zipper.Zipper, retired []uint64) (uint64, []uint64, error) {
+	if len(opsMap) == 0 && len(ranges) == 0 {
+		return root, retired, nil
+	}
+
+	var err error
+	root, retired, err = applyVacuumRangeDeltaBatches(root, ranges, retired, db.valueLogManager, func(root uint64, b *batch.Batch) (uint64, []uint64, error) {
+		newRoot, newRetired, _, err := z.Apply(root, b)
+		return newRoot, newRetired, err
+	})
+	if err != nil {
+		return 0, nil, err
 	}
 
 	keys := make([]string, 0, len(opsMap))

--- a/TreeDB/db/vacuum_recorder_test.go
+++ b/TreeDB/db/vacuum_recorder_test.go
@@ -93,6 +93,41 @@ func TestVacuumRecorder_RecordApplyPlan_RangesShadowEarlierPoints(t *testing.T) 
 	}
 }
 
+func TestApplyVacuumRangeDeltaBatches_ChunksRanges(t *testing.T) {
+	ranges := make([]batch.DeleteRange, vacuumDeltaBatchSize+1)
+	for i := range ranges {
+		start := []byte(fmt.Sprintf("k%05d", i))
+		end := []byte(fmt.Sprintf("k%05d~", i))
+		ranges[i] = batch.DeleteRange{Start: start, End: end}
+	}
+
+	var batchLens []int
+	var roots []uint64
+	root, retired, err := applyVacuumRangeDeltaBatches(10, ranges, []uint64{1}, nil, func(root uint64, b *batch.Batch) (uint64, []uint64, error) {
+		roots = append(roots, root)
+		batchLens = append(batchLens, b.Len())
+		if b.Len() > vacuumDeltaBatchSize {
+			t.Fatalf("range batch len=%d exceeds chunk size %d", b.Len(), vacuumDeltaBatchSize)
+		}
+		return root + uint64(b.Len()), []uint64{uint64(100 + len(batchLens))}, nil
+	})
+	if err != nil {
+		t.Fatalf("apply range deltas: %v", err)
+	}
+	if len(batchLens) != 2 || batchLens[0] != vacuumDeltaBatchSize || batchLens[1] != 1 {
+		t.Fatalf("batch lens=%v, want [%d 1]", batchLens, vacuumDeltaBatchSize)
+	}
+	if len(roots) != 2 || roots[0] != 10 || roots[1] != 10+uint64(vacuumDeltaBatchSize) {
+		t.Fatalf("apply roots=%v, want [10 %d]", roots, 10+uint64(vacuumDeltaBatchSize))
+	}
+	if want := uint64(10 + len(ranges)); root != want {
+		t.Fatalf("root=%d want=%d", root, want)
+	}
+	if len(retired) != 3 || retired[0] != 1 || retired[1] != 101 || retired[2] != 102 {
+		t.Fatalf("retired=%v want [1 101 102]", retired)
+	}
+}
+
 func TestVacuumRecorder_RecordEntries_LastWriteWinsAndCopies(t *testing.T) {
 	var r vacuumRecorder
 	r.Start()

--- a/TreeDB/db/vacuum_recorder_test.go
+++ b/TreeDB/db/vacuum_recorder_test.go
@@ -64,6 +64,35 @@ func TestVacuumRecorder_DoesNotRecordUncommittedWrites(t *testing.T) {
 	}
 }
 
+func TestVacuumRecorder_RecordApplyPlan_RangesShadowEarlierPoints(t *testing.T) {
+	var r vacuumRecorder
+	r.Start()
+	defer r.Stop()
+
+	r.RecordApplyPlan([]batch.Entry{
+		{Type: batch.OpPut, Key: []byte("a"), Value: []byte("old-a")},
+		{Type: batch.OpPut, Key: []byte("b"), Value: []byte("old-b")},
+	}, nil)
+	r.RecordApplyPlan([]batch.Entry{
+		{Type: batch.OpPut, Key: []byte("b"), Value: []byte("new-b")},
+	}, []batch.DeleteRange{{Start: []byte("a"), End: []byte("c")}})
+
+	ops, ranges := r.DrainApplyPlan()
+	if len(ranges) != 1 || string(ranges[0].Start) != "a" || string(ranges[0].End) != "c" {
+		t.Fatalf("ranges=%+v want [a,c)", ranges)
+	}
+	if len(ops) != 1 {
+		t.Fatalf("ops len=%d want 1: %v", len(ops), ops)
+	}
+	got, ok := ops["b"]
+	if !ok || got.Type != batch.OpPut || string(got.Value) != "new-b" {
+		t.Fatalf("recorded b=%+v ok=%t, want later put", got, ok)
+	}
+	if _, ok := ops["a"]; ok {
+		t.Fatalf("range did not remove earlier point a: %v", ops)
+	}
+}
+
 func TestVacuumRecorder_RecordEntries_LastWriteWinsAndCopies(t *testing.T) {
 	var r vacuumRecorder
 	r.Start()

--- a/TreeDB/db/vlog_gc_incremental.go
+++ b/TreeDB/db/vlog_gc_incremental.go
@@ -497,7 +497,7 @@ func collectValueLogRefCounts(ctx context.Context, db *DB, it iterator.UnsafeIte
 	return it.Error()
 }
 
-func (db *DB) buildValueLogRefDelta(p *pager.Pager, rootID uint64, baseSeq uint64, entries []batchpkg.Entry) (*valueLogRefDelta, error) {
+func (db *DB) buildValueLogRefDelta(p *pager.Pager, rootID uint64, baseSeq uint64, entries []batchpkg.Entry, ranges []batchpkg.DeleteRange) (*valueLogRefDelta, error) {
 	if db == nil || db.valueLogRefTracker == nil || !db.valueLogRefTracker.canTrack(baseSeq) {
 		return nil, nil
 	}
@@ -509,13 +509,32 @@ func (db *DB) buildValueLogRefDelta(p *pager.Pager, rootID uint64, baseSeq uint6
 		return delta, nil
 	}
 	tr := tree.New(p, nil, rootID)
-	for i := range entries {
-		oldFileID, oldRef, err := lookupValueLogRefAtKey(tr, entries[i].Key)
-		if err != nil {
+	for _, r := range ranges {
+		it := tr.IteratorWithOptions(r.Start, r.End, tree.IteratorOptions{Mode: tree.IteratorModePointerProjection})
+		for it.Valid() {
+			_, ptr, flags := it.UnsafeEntry()
+			if flags&node.FlagPointer != 0 && page.IsValueLogFileID(ptr.FileID) {
+				delta.add(ptr.FileID, -1)
+			}
+			it.Next()
+		}
+		if err := it.Error(); err != nil {
+			_ = it.Close()
 			return nil, err
 		}
-		if oldRef {
-			delta.add(oldFileID, -1)
+		if err := it.Close(); err != nil {
+			return nil, err
+		}
+	}
+	for i := range entries {
+		if !batchpkg.DeleteRangesContainKey(ranges, entries[i].Key) {
+			oldFileID, oldRef, err := lookupValueLogRefAtKey(tr, entries[i].Key)
+			if err != nil {
+				return nil, err
+			}
+			if oldRef {
+				delta.add(oldFileID, -1)
+			}
 		}
 		if entries[i].Type == batchpkg.OpPut && entries[i].IsPtr && page.IsValueLogFileID(entries[i].ValuePtr.FileID) {
 			delta.add(entries[i].ValuePtr.FileID, 1)

--- a/TreeDB/docs/spec/contracts.md
+++ b/TreeDB/docs/spec/contracts.md
@@ -84,6 +84,9 @@ When the cached layer is enabled (default `treedb.Open` behavior):
 - Batch `Set`, `Delete`, and `DeleteRange(start,end)` are applied in submission
   order as one atomic write unit; range bounds are half-open `[start,end)`, with
   nil bounds unbounded and empty/reversed bounded ranges treated as no-ops.
+- Cached batch `DeleteRange` uses a serialized materialization fallback and
+  fails closed with `ErrBatchDeleteRangeTooLarge` if the bounded fallback cap is
+  exceeded; the backend TreeDB path applies range deletes natively.
 - `Write` commits without strict sync guarantee.
 - `WriteSync` commits with sync guarantee only in durable mode.
 

--- a/TreeDB/docs/spec/contracts.md
+++ b/TreeDB/docs/spec/contracts.md
@@ -81,6 +81,9 @@ When the cached layer is enabled (default `treedb.Open` behavior):
 ### 3.2 Batches
 
 - `NewBatch` accumulates operations.
+- Batch `Set`, `Delete`, and `DeleteRange(start,end)` are applied in submission
+  order as one atomic write unit; range bounds are half-open `[start,end)`, with
+  nil bounds unbounded and empty/reversed bounded ranges treated as no-ops.
 - `Write` commits without strict sync guarantee.
 - `WriteSync` commits with sync guarantee only in durable mode.
 

--- a/TreeDB/docs/spec/storage-format.md
+++ b/TreeDB/docs/spec/storage-format.md
@@ -937,16 +937,21 @@ u32 OpCount
 Op[OpCount]
 
 Op:
-u8  Op             // 1=set, 2=delete
-u32 KeyLen
-u32 ValueLen
-bytes Key[KeyLen]
-bytes Value[ValueLen]
+u8  Op             // 1=set, 2=delete, 3=set-by-value-log-RID, 4=delete-range
+u32 KeyLen          // for delete-range: StartLen, or 0xffffffff for nil/unbounded
+u32 ValueLen        // for delete-range: EndLen, or 0xffffffff for nil/unbounded
+bytes Key[KeyLen]   // omitted when delete-range StartLen is 0xffffffff
+bytes Value[ValueLen] // omitted when delete-range EndLen is 0xffffffff
 ```
 
 A `RawKVBatch` command frame is one atomic command: one frame, one `LSN`, and
 all contained operations decode as one batch. Delete operations require
-`ValueLen=0`.
+`ValueLen=0`. Delete-range operations use half-open `[start,end)` semantics;
+nil start/end bounds are unbounded and are encoded with the `0xffffffff` length
+sentinel. Malformed delete-range payloads (for example bounded `start >= end` or
+extra bytes after a nil-bound sentinel) fail closed as corrupt. Public APIs treat
+empty or reversed range deletes as no-ops and do not emit dangerous command-WAL
+mutations for them.
 
 Writers may use compact all-zero set payload variants when every operation is a
 set with the same non-empty zero-filled value length:

--- a/TreeDB/errors.go
+++ b/TreeDB/errors.go
@@ -11,6 +11,9 @@ var (
 	ErrLocked = db.ErrLocked
 	// ErrMemtableFull indicates the cached memtable has reached its hard cap.
 	ErrMemtableFull = caching.ErrMemtableFull
+	// ErrBatchDeleteRangeTooLarge indicates the cached batch DeleteRange fallback
+	// exceeded its bounded materialization cap before publishing any mutation.
+	ErrBatchDeleteRangeTooLarge = caching.ErrBatchDeleteRangeTooLarge
 
 	// ErrClosed indicates the DB handle has been closed.
 	ErrClosed = db.ErrClosed

--- a/TreeDB/internal/commitlog/command_frame.go
+++ b/TreeDB/internal/commitlog/command_frame.go
@@ -1047,7 +1047,18 @@ func encodeRawKVSingleCommandFrameTo(dst []byte, lsn, baseAppliedLSN uint64, op 
 		return nil, err
 	}
 	if op.Op == RawKVOpDeleteRange {
-		return nil, fmt.Errorf("commitlog: raw kv DeleteRange requires batch payload encoder")
+		payload, err := EncodeRawKVSingleOperationPayload(op)
+		if err != nil {
+			return nil, err
+		}
+		return encodeCommandFrameTo(dst, CommandEnvelope{
+			LSN:            lsn,
+			Kind:           CommandKindRawKVBatch,
+			Scope:          CommandScopeRawKV,
+			BaseAppliedLSN: baseAppliedLSN,
+			PayloadFormat:  PayloadFormatRawKVBatchV1,
+			Payload:        payload,
+		})
 	}
 	valueLen := len(op.Value)
 	if op.Op == RawKVOpSetRID {

--- a/TreeDB/internal/commitlog/command_frame.go
+++ b/TreeDB/internal/commitlog/command_frame.go
@@ -16,15 +16,16 @@ const (
 
 	CommandWALNonCriticalFlagStart uint64 = 1 << 32
 
-	commandFrameHeaderSize   = 4 + 2 + 2 + 2 + 2 + 8 + 8 + 8 + 8 + 8 + 2 + 2 + 4 + 4 + 4 + 4
-	rawKVBatchPayloadVersion = uint16(1)
-	rawKVZeroBatchPayloadV2  = uint16(2)
-	rawKVZeroBatchPayloadV3  = uint16(3)
-	rawKVBatchHeaderSize     = 2 + 4
-	rawKVZeroBatchHeaderSize = 2 + 4 + 4
-	rawKVOpHeaderSize        = 1 + 4 + 4
-	rawKVZeroOpHeaderSize    = 4
-	rawKVZeroOpHeaderSizeV3  = 2
+	commandFrameHeaderSize      = 4 + 2 + 2 + 2 + 2 + 8 + 8 + 8 + 8 + 8 + 2 + 2 + 4 + 4 + 4 + 4
+	rawKVBatchPayloadVersion    = uint16(1)
+	rawKVZeroBatchPayloadV2     = uint16(2)
+	rawKVZeroBatchPayloadV3     = uint16(3)
+	rawKVBatchHeaderSize        = 2 + 4
+	rawKVZeroBatchHeaderSize    = 2 + 4 + 4
+	rawKVOpHeaderSize           = 1 + 4 + 4
+	rawKVZeroOpHeaderSize       = 4
+	rawKVZeroOpHeaderSizeV3     = 2
+	rawKVNilRangeBoundLenUint32 = uint32(^uint32(0))
 
 	collectionRebuildVectorIndexPayloadVersion      = uint16(1)
 	collectionRebuildVectorIndexVersionEnd          = 2
@@ -102,6 +103,7 @@ const (
 	RawKVOpSet RawKVOp = iota + 1
 	RawKVOpDelete
 	RawKVOpSetRID
+	RawKVOpDeleteRange
 )
 
 // RawKVOperation represents a single operation in a RawKVBatch command frame.
@@ -111,6 +113,9 @@ const (
 //   - RawKVOpDelete: Key is set; Value must be empty; RID must be zero.
 //   - RawKVOpSetRID: Key is set; Value MUST be empty (the RID is encoded
 //     separately as an 8-byte payload); RID must be non-zero.
+//   - RawKVOpDeleteRange: Key is the start bound and Value is the exclusive
+//     end bound. Nil bounds are unbounded and are encoded with a sentinel
+//     length; bounded empty/reversed ranges are invalid in command frames.
 type RawKVOperation struct {
 	Op    RawKVOp
 	Key   []byte
@@ -262,6 +267,10 @@ func (b *RawKVBatchPayloadBuilder) Append(op RawKVOperation) (keyView, valueView
 	if err := validateRawKVOperation(&op); err != nil {
 		return nil, nil, err
 	}
+	if op.Op == RawKVOpDeleteRange {
+		keyView, err := b.AppendDeleteRange(op.Key, op.Value)
+		return keyView, nil, err
+	}
 	valueLen := len(op.Value)
 	if op.Op == RawKVOpSetRID {
 		valueLen = 8
@@ -372,6 +381,58 @@ func (b *RawKVBatchPayloadBuilder) AppendDelete(key []byte) (keyView []byte, err
 	b.count++
 	b.disableZeroSetCandidate()
 	return b.payload[keyStart:off:off], nil
+}
+
+// AppendDeleteRange appends a validated RawKV DeleteRange operation. Nil start
+// or end bounds are encoded as unbounded sentinels and returned as nil views.
+func (b *RawKVBatchPayloadBuilder) AppendDeleteRange(start, end []byte) (startView []byte, err error) {
+	if b == nil {
+		return nil, ErrCorrupt
+	}
+	if err := validateRawKVDeleteRangeBounds(start, end); err != nil {
+		return nil, err
+	}
+	if b.payload == nil {
+		_ = b.ResetWithHint(0, 0)
+	}
+	if commandFrameIntExceedsUint32(b.count + 1) {
+		return nil, ErrRecordTooLarge
+	}
+	startLen, startBytes, err := rawKVRangeBoundEncodedLen(start)
+	if err != nil {
+		return nil, err
+	}
+	endLen, endBytes, err := rawKVRangeBoundEncodedLen(end)
+	if err != nil {
+		return nil, err
+	}
+	if b.zeroSetCompactOnly {
+		if err := b.materializeCompactZeroSetPayload(); err != nil {
+			return nil, err
+		}
+		b.zeroSetCompactOnly = false
+	}
+	off, err := b.appendRawKVPayloadSpace(rawKVOpHeaderSize + startBytes + endBytes)
+	if err != nil {
+		return nil, err
+	}
+	b.payload[off] = byte(RawKVOpDeleteRange)
+	binary.LittleEndian.PutUint32(b.payload[off+1:off+5], startLen)
+	binary.LittleEndian.PutUint32(b.payload[off+5:off+9], endLen)
+	off += rawKVOpHeaderSize
+	if startBytes > 0 {
+		startStart := off
+		copy(b.payload[off:], start)
+		off += startBytes
+		startView = b.payload[startStart:off:off]
+	}
+	if endBytes > 0 {
+		copy(b.payload[off:], end)
+		off += endBytes
+	}
+	b.count++
+	b.disableZeroSetCandidate()
+	return startView, nil
 }
 
 func (b *RawKVBatchPayloadBuilder) appendRawKVPayloadSpace(needed int) (int, error) {
@@ -985,6 +1046,9 @@ func encodeRawKVSingleCommandFrameTo(dst []byte, lsn, baseAppliedLSN uint64, op 
 	if err := validateRawKVOperation(&op); err != nil {
 		return nil, err
 	}
+	if op.Op == RawKVOpDeleteRange {
+		return nil, fmt.Errorf("commitlog: raw kv DeleteRange requires batch payload encoder")
+	}
 	valueLen := len(op.Value)
 	if op.Op == RawKVOpSetRID {
 		valueLen = 8
@@ -1350,14 +1414,26 @@ func EncodeRawKVBatchPayload(ops []RawKVOperation) ([]byte, error) {
 		if err := validateRawKVOperation(op); err != nil {
 			return nil, err
 		}
+		keyBytes := len(op.Key)
 		valueLen := len(op.Value)
 		if op.Op == RawKVOpSetRID {
 			valueLen = 8
+		} else if op.Op == RawKVOpDeleteRange {
+			_, startBytes, err := rawKVRangeBoundEncodedLen(op.Key)
+			if err != nil {
+				return nil, err
+			}
+			_, endBytes, err := rawKVRangeBoundEncodedLen(op.Value)
+			if err != nil {
+				return nil, err
+			}
+			keyBytes = startBytes
+			valueLen = endBytes
 		}
-		if commandFrameIntExceedsUint32(len(op.Key)) || commandFrameIntExceedsUint32(valueLen) {
+		if commandFrameIntExceedsUint32(keyBytes) || commandFrameIntExceedsUint32(valueLen) {
 			return nil, ErrRecordTooLarge
 		}
-		total += rawKVOpHeaderSize + len(op.Key) + valueLen
+		total += rawKVOpHeaderSize + keyBytes + valueLen
 	}
 	payload := make([]byte, total)
 	binary.LittleEndian.PutUint16(payload[0:2], rawKVBatchPayloadVersion)
@@ -1365,18 +1441,32 @@ func EncodeRawKVBatchPayload(ops []RawKVOperation) ([]byte, error) {
 	off := rawKVBatchHeaderSize
 	for i := range ops {
 		op := &ops[i]
+		key := op.Key
 		value := op.Value
+		keyLen := uint32(len(key))
+		valueLen := uint32(len(value))
 		var ridBuf [8]byte
 		if op.Op == RawKVOpSetRID {
 			binary.LittleEndian.PutUint64(ridBuf[:], op.RID)
 			value = ridBuf[:]
+			valueLen = uint32(len(value))
+		} else if op.Op == RawKVOpDeleteRange {
+			var err error
+			keyLen, _, err = rawKVRangeBoundEncodedLen(key)
+			if err != nil {
+				return nil, err
+			}
+			valueLen, _, err = rawKVRangeBoundEncodedLen(value)
+			if err != nil {
+				return nil, err
+			}
 		}
 		payload[off] = byte(op.Op)
-		binary.LittleEndian.PutUint32(payload[off+1:off+5], uint32(len(op.Key)))
-		binary.LittleEndian.PutUint32(payload[off+5:off+9], uint32(len(value)))
+		binary.LittleEndian.PutUint32(payload[off+1:off+5], keyLen)
+		binary.LittleEndian.PutUint32(payload[off+5:off+9], valueLen)
 		off += rawKVOpHeaderSize
-		copy(payload[off:], op.Key)
-		off += len(op.Key)
+		copy(payload[off:], key)
+		off += len(key)
 		copy(payload[off:], value)
 		off += len(value)
 	}
@@ -1386,35 +1476,7 @@ func EncodeRawKVBatchPayload(ops []RawKVOperation) ([]byte, error) {
 // EncodeRawKVSingleOperationPayload encodes the common one-op RawKVBatch
 // command without forcing callers to materialize a single-entry operation slice.
 func EncodeRawKVSingleOperationPayload(op RawKVOperation) ([]byte, error) {
-	if err := validateRawKVOperation(&op); err != nil {
-		return nil, err
-	}
-	valueLen := len(op.Value)
-	if op.Op == RawKVOpSetRID {
-		valueLen = 8
-	}
-	if commandFrameIntExceedsUint32(len(op.Key)) || commandFrameIntExceedsUint32(valueLen) {
-		return nil, ErrRecordTooLarge
-	}
-	total := rawKVBatchHeaderSize + rawKVOpHeaderSize + len(op.Key) + valueLen
-	payload := make([]byte, total)
-	binary.LittleEndian.PutUint16(payload[0:2], rawKVBatchPayloadVersion)
-	binary.LittleEndian.PutUint32(payload[2:6], 1)
-	value := op.Value
-	var ridBuf [8]byte
-	if op.Op == RawKVOpSetRID {
-		binary.LittleEndian.PutUint64(ridBuf[:], op.RID)
-		value = ridBuf[:]
-	}
-	off := rawKVBatchHeaderSize
-	payload[off] = byte(op.Op)
-	binary.LittleEndian.PutUint32(payload[off+1:off+5], uint32(len(op.Key)))
-	binary.LittleEndian.PutUint32(payload[off+5:off+9], uint32(len(value)))
-	off += rawKVOpHeaderSize
-	copy(payload[off:], op.Key)
-	off += len(op.Key)
-	copy(payload[off:], value)
-	return payload, nil
+	return EncodeRawKVBatchPayload([]RawKVOperation{op})
 }
 
 func rawKVBatchPayloadSizeHint(opHint, byteHint int) (int, error) {
@@ -1488,28 +1550,17 @@ func DecodeRawKVBatchPayload(payload []byte) ([]RawKVOperation, error) {
 	}
 	count := binary.LittleEndian.Uint32(payload[2:6])
 	ops := make([]RawKVOperation, 0, count)
-	off := rawKVBatchHeaderSize
-	for i := uint32(0); i < count; i++ {
-		op := RawKVOp(payload[off])
-		keyLen := binary.LittleEndian.Uint32(payload[off+1 : off+5])
-		valueLen := binary.LittleEndian.Uint32(payload[off+5 : off+9])
-		off += rawKVOpHeaderSize
-		entry := RawKVOperation{Op: op}
-		entry.Key = cloneBytesPreserveEmpty(payload[off : off+int(keyLen)])
-		off += int(keyLen)
+	if err := ScanRawKVBatchPayload(payload, func(op RawKVOp, key, value []byte) error {
+		entry := RawKVOperation{Op: op, Key: cloneBytesPreserveEmpty(key)}
 		if op == RawKVOpSetRID {
-			if valueLen != 8 {
-				return nil, ErrCorrupt
-			}
-			entry.RID = binary.LittleEndian.Uint64(payload[off : off+8])
-			if entry.RID == 0 {
-				return nil, ErrCorrupt
-			}
+			entry.RID = binary.LittleEndian.Uint64(value)
 		} else {
-			entry.Value = cloneBytesPreserveEmpty(payload[off : off+int(valueLen)])
+			entry.Value = cloneBytesPreserveEmpty(value)
 		}
-		off += int(valueLen)
 		ops = append(ops, entry)
+		return nil
+	}); err != nil {
+		return nil, err
 	}
 	return ops, nil
 }
@@ -1546,16 +1597,40 @@ func ScanRawKVBatchPayload(payload []byte, visit func(op RawKVOp, key, value []b
 		keyLen := binary.LittleEndian.Uint32(payload[off+1 : off+5])
 		valueLen := binary.LittleEndian.Uint32(payload[off+5 : off+9])
 		off += rawKVOpHeaderSize
-		need := uint64(keyLen) + uint64(valueLen)
+		keyBytes := keyLen
+		valueBytes := valueLen
+		keyNil := false
+		valueNil := false
+		if op == RawKVOpDeleteRange {
+			if keyLen == rawKVNilRangeBoundLenUint32 {
+				keyBytes = 0
+				keyNil = true
+			}
+			if valueLen == rawKVNilRangeBoundLenUint32 {
+				valueBytes = 0
+				valueNil = true
+			}
+		}
+		need := uint64(keyBytes) + uint64(valueBytes)
 		if need > uint64(len(payload)-off) || need > uint64(^uint(0)>>1) {
 			return ErrCorrupt
 		}
-		key := payload[off : off+int(keyLen)]
-		off += int(keyLen)
-		if err := validateRawKVOperationShape(op, key, int(valueLen)); err != nil {
+		var key []byte
+		if !keyNil {
+			key = payload[off : off+int(keyBytes)]
+		}
+		off += int(keyBytes)
+		valueLenForShape := int(valueBytes)
+		if valueNil {
+			valueLenForShape = -1
+		}
+		if err := validateRawKVOperationShape(op, key, valueLenForShape); err != nil {
 			return err
 		}
-		value := payload[off : off+int(valueLen)]
+		var value []byte
+		if !valueNil {
+			value = payload[off : off+int(valueBytes)]
+		}
 		if op == RawKVOpSetRID {
 			// validateRawKVOperationShape already enforces valueLen == 8 for
 			// RawKVOpSetRID, so len(value) == 8 is guaranteed here. Only
@@ -1564,12 +1639,17 @@ func ScanRawKVBatchPayload(payload []byte, visit func(op RawKVOp, key, value []b
 				return ErrCorrupt
 			}
 		}
+		if op == RawKVOpDeleteRange {
+			if err := validateRawKVDeleteRangeBounds(key, value); err != nil {
+				return err
+			}
+		}
 		if visit != nil {
 			if err := visit(op, key, value); err != nil {
 				return err
 			}
 		}
-		off += int(valueLen)
+		off += int(valueBytes)
 	}
 	if off != len(payload) {
 		return ErrCorrupt
@@ -1626,7 +1706,13 @@ func scanRawKVZeroBatchPayload(payload []byte, visit func(op RawKVOp, key, value
 }
 
 func validateRawKVOperation(op *RawKVOperation) error {
-	if op == nil || op.Key == nil {
+	if op == nil {
+		return ErrCorrupt
+	}
+	if op.Op == RawKVOpDeleteRange {
+		return validateRawKVDeleteRangeBounds(op.Key, op.Value)
+	}
+	if op.Key == nil {
 		return ErrCorrupt
 	}
 	valueLen := len(op.Value)
@@ -1643,25 +1729,57 @@ func validateRawKVOperation(op *RawKVOperation) error {
 }
 
 func validateRawKVOperationShape(op RawKVOp, key []byte, valueLen int) error {
-	if key == nil {
-		return ErrCorrupt
-	}
 	switch op {
 	case RawKVOpSet:
+		if key == nil {
+			return ErrCorrupt
+		}
 		return nil
 	case RawKVOpDelete:
-		if valueLen != 0 {
+		if key == nil || valueLen != 0 {
 			return ErrCorrupt
 		}
 		return nil
 	case RawKVOpSetRID:
-		if valueLen != 8 {
+		if key == nil || valueLen != 8 {
+			return ErrCorrupt
+		}
+		return nil
+	case RawKVOpDeleteRange:
+		// valueLen == -1 is the scanner's sentinel for a nil/unbounded end.
+		if valueLen < -1 {
 			return ErrCorrupt
 		}
 		return nil
 	default:
 		return ErrCorrupt
 	}
+}
+
+func validateRawKVDeleteRangeBounds(start, end []byte) error {
+	if start != nil && commandFrameIntExceedsUint32(len(start)) {
+		return ErrRecordTooLarge
+	}
+	if end != nil && commandFrameIntExceedsUint32(len(end)) {
+		return ErrRecordTooLarge
+	}
+	if start != nil && end != nil && bytes.Compare(start, end) >= 0 {
+		return ErrCorrupt
+	}
+	if start == nil && end != nil && len(end) == 0 {
+		return ErrCorrupt
+	}
+	return nil
+}
+
+func rawKVRangeBoundEncodedLen(bound []byte) (encoded uint32, bytesLen int, err error) {
+	if bound == nil {
+		return rawKVNilRangeBoundLenUint32, 0, nil
+	}
+	if commandFrameIntExceedsUint32(len(bound)) || uint32(len(bound)) == rawKVNilRangeBoundLenUint32 {
+		return 0, 0, ErrRecordTooLarge
+	}
+	return uint32(len(bound)), len(bound), nil
 }
 
 func EncodeCollectionInsertBatchByIDPayload(collection string, docs []CollectionDocument) ([]byte, error) {

--- a/TreeDB/internal/commitlog/command_frame_test.go
+++ b/TreeDB/internal/commitlog/command_frame_test.go
@@ -1046,6 +1046,7 @@ func TestEncodeRawKVSingleOperationPayloadMatchesSliceEncoder(t *testing.T) {
 		{Op: RawKVOpSet, Key: []byte("alpha"), Value: []byte("one")},
 		{Op: RawKVOpDelete, Key: []byte("bravo")},
 		{Op: RawKVOpSetRID, Key: []byte("charlie"), RID: 42},
+		{Op: RawKVOpDeleteRange, Key: nil, Value: []byte("delta")},
 	} {
 		want, err := EncodeRawKVBatchPayload([]RawKVOperation{op})
 		if err != nil {
@@ -1065,6 +1066,7 @@ func TestEncodeRawKVSingleCommandFrameMatchesEnvelopeEncoder(t *testing.T) {
 	for _, op := range []RawKVOperation{
 		{Op: RawKVOpSet, Key: []byte("alpha"), Value: []byte("one")},
 		{Op: RawKVOpDelete, Key: []byte("bravo")},
+		{Op: RawKVOpDeleteRange, Key: []byte("charlie"), Value: nil},
 	} {
 		payload, err := EncodeRawKVSingleOperationPayload(op)
 		if err != nil {

--- a/TreeDB/internal/commitlog/command_frame_test.go
+++ b/TreeDB/internal/commitlog/command_frame_test.go
@@ -1471,3 +1471,80 @@ func assertGoldenHex(t *testing.T, name string, got []byte) {
 		t.Fatalf("golden %s mismatch\ngot  %s\nwant %s", name, hex.EncodeToString(got), hex.EncodeToString(want))
 	}
 }
+
+func TestCommandWALRawKVBatchDeleteRangeEncodeDecodeScan(t *testing.T) {
+	payload, err := EncodeRawKVBatchPayload([]RawKVOperation{
+		{Op: RawKVOpSet, Key: []byte("a"), Value: []byte("1")},
+		{Op: RawKVOpDeleteRange, Key: nil, Value: []byte("c")},
+		{Op: RawKVOpDeleteRange, Key: []byte("x"), Value: nil},
+	})
+	if err != nil {
+		t.Fatalf("EncodeRawKVBatchPayload: %v", err)
+	}
+	var scanned []RawKVOperation
+	if err := ScanRawKVBatchPayload(payload, func(op RawKVOp, key, value []byte) error {
+		scanned = append(scanned, RawKVOperation{Op: op, Key: cloneBytesPreserveEmpty(key), Value: cloneBytesPreserveEmpty(value)})
+		return nil
+	}); err != nil {
+		t.Fatalf("ScanRawKVBatchPayload: %v", err)
+	}
+	decoded, err := DecodeRawKVBatchPayload(payload)
+	if err != nil {
+		t.Fatalf("DecodeRawKVBatchPayload: %v", err)
+	}
+	for name, ops := range map[string][]RawKVOperation{"scanned": scanned, "decoded": decoded} {
+		if len(ops) != 3 {
+			t.Fatalf("%s ops=%d want 3", name, len(ops))
+		}
+		if ops[1].Op != RawKVOpDeleteRange || ops[1].Key != nil || !bytes.Equal(ops[1].Value, []byte("c")) {
+			t.Fatalf("%s op[1]=%+v", name, ops[1])
+		}
+		if ops[2].Op != RawKVOpDeleteRange || !bytes.Equal(ops[2].Key, []byte("x")) || ops[2].Value != nil {
+			t.Fatalf("%s op[2]=%+v", name, ops[2])
+		}
+	}
+}
+
+func TestCommandWALRawKVBatchDeleteRangeRejectsEmptyReversed(t *testing.T) {
+	bad := []RawKVOperation{
+		{Op: RawKVOpDeleteRange, Key: []byte("b"), Value: []byte("b")},
+		{Op: RawKVOpDeleteRange, Key: []byte("z"), Value: []byte("a")},
+		{Op: RawKVOpDeleteRange, Key: nil, Value: []byte{}},
+	}
+	for _, op := range bad {
+		if _, err := EncodeRawKVBatchPayload([]RawKVOperation{op}); !errors.Is(err, ErrCorrupt) {
+			t.Fatalf("EncodeRawKVBatchPayload(%+v) err=%v want ErrCorrupt", op, err)
+		}
+	}
+}
+
+func TestCommandWALRawKVBatchDeleteRangeMalformedDecodeFailsClosed(t *testing.T) {
+	makePayload := func(startLen, endLen uint32, startBytes, endBytes []byte) []byte {
+		payload := make([]byte, rawKVBatchHeaderSize+rawKVOpHeaderSize+len(startBytes)+len(endBytes))
+		binary.LittleEndian.PutUint16(payload[0:2], rawKVBatchPayloadVersion)
+		binary.LittleEndian.PutUint32(payload[2:6], 1)
+		off := rawKVBatchHeaderSize
+		payload[off] = byte(RawKVOpDeleteRange)
+		binary.LittleEndian.PutUint32(payload[off+1:off+5], startLen)
+		binary.LittleEndian.PutUint32(payload[off+5:off+9], endLen)
+		off += rawKVOpHeaderSize
+		copy(payload[off:], startBytes)
+		off += len(startBytes)
+		copy(payload[off:], endBytes)
+		return payload
+	}
+
+	cases := map[string][]byte{
+		"nil-start-empty-end":  makePayload(rawKVNilRangeBoundLenUint32, 0, nil, nil),
+		"reversed-bounds":      makePayload(1, 1, []byte("z"), []byte("a")),
+		"sentinel-extra-bytes": makePayload(rawKVNilRangeBoundLenUint32, rawKVNilRangeBoundLenUint32, []byte("x"), nil),
+	}
+	for name, payload := range cases {
+		if err := ScanRawKVBatchPayload(payload, nil); !errors.Is(err, ErrCorrupt) {
+			t.Fatalf("%s ScanRawKVBatchPayload err=%v want ErrCorrupt", name, err)
+		}
+		if _, err := DecodeRawKVBatchPayload(payload); !errors.Is(err, ErrCorrupt) {
+			t.Fatalf("%s DecodeRawKVBatchPayload err=%v want ErrCorrupt", name, err)
+		}
+	}
+}

--- a/TreeDB/public.go
+++ b/TreeDB/public.go
@@ -75,6 +75,7 @@ type Iterator interface {
 type Batch interface {
 	Set(key, value []byte) error
 	Delete(key []byte) error
+	DeleteRange(start, end []byte) error
 	Write() error
 	WriteSync() error
 	Close() error

--- a/TreeDB/zipper/zipper.go
+++ b/TreeDB/zipper/zipper.go
@@ -1183,18 +1183,29 @@ func validateLoadedLeafLogNodeFrom(source string, data []byte) (node.Node, error
 // Returns the new root page ID, list of retired pages, and commit metrics.
 func (z *Zipper) Apply(rootID uint64, b *batch.Batch) (uint64, []uint64, adaptive.Metrics, error) {
 	var metrics adaptive.Metrics
-	ops := b.SortedEntries()
-	if len(ops) == 0 {
+	var ops []batch.Entry
+	var ranges []batch.DeleteRange
+	if b != nil && b.HasDeleteRanges() {
+		ops, ranges = b.ApplyPlan()
+	} else if b != nil {
+		ops = b.SortedEntries()
+	}
+	if len(ops) == 0 && len(ranges) == 0 {
 		return rootID, nil, metrics, nil
 	}
-	metrics.ZipperApplyOps = len(ops)
+	metrics.ZipperApplyOps = len(ops) + len(ranges)
 
 	scratch := z.acquireApplyScratch()
 	defer z.releaseApplyScratch(scratch)
 
 	// Underfull merge/rebalance maintenance is only beneficial when the batch
-	// includes deletes (can create empty/underfull pages).
+	// includes point deletes. Range deletes are applied by streaming affected
+	// spans without materializing point tombstones.
 	maintenance, deleteCount := z.shouldRunMaintenance(ops)
+	if len(ranges) > 0 {
+		maintenance = false
+		deleteCount = 0
+	}
 	var budget *maintenanceBudget
 	if maintenance && z.maintenanceOpsPerCoalesce > 0 {
 		budget = newMaintenanceBudget(len(ops), deleteCount, z.maintenanceOpsPerCoalesce)
@@ -1216,7 +1227,7 @@ func (z *Zipper) Apply(rootID uint64, b *batch.Batch) (uint64, []uint64, adaptiv
 	}
 
 	var retired []uint64
-	newRootRef, splits, err := z.writeRecursive(page.PageChildRef(rootID), ops, maintenance, budget, &metrics, nil, nil, &retired, scratch)
+	newRootRef, splits, err := z.writeRecursive(page.PageChildRef(rootID), ops, ranges, maintenance, budget, &metrics, nil, nil, &retired, scratch)
 	if err != nil {
 		return 0, nil, metrics, err
 	}
@@ -1558,7 +1569,7 @@ func (z *Zipper) ensureRootPage(key []byte, ref page.ChildRef, metrics *adaptive
 
 // writeRecursive handles the COW merge.
 // Returns: newPageID, splits, error.
-func (z *Zipper) writeRecursive(ref page.ChildRef, ops []batch.Entry, maintenance bool, budget *maintenanceBudget, metrics *adaptive.Metrics, low, high []byte, retired *[]uint64, scratch *mergeScratch) (page.ChildRef, []Split, error) {
+func (z *Zipper) writeRecursive(ref page.ChildRef, ops []batch.Entry, ranges []batch.DeleteRange, maintenance bool, budget *maintenanceBudget, metrics *adaptive.Metrics, low, high []byte, retired *[]uint64, scratch *mergeScratch) (page.ChildRef, []Split, error) {
 	oldNode, oldFromPager, leafScratch, leafScratchRef, loadSource, err := z.loadNodeRef(ref, scratch)
 	if err != nil {
 		return page.ChildRef{}, nil, err
@@ -1596,7 +1607,7 @@ func (z *Zipper) writeRecursive(ref page.ChildRef, ops []batch.Entry, maintenanc
 				}
 			}()
 			builder.SetPageID(0)
-			return z.mergeLeaf(&oldNode, builder, ops, metrics, scratch, reuseOuterLeafPages)
+			return z.mergeLeaf(&oldNode, builder, ops, ranges, metrics, scratch, reuseOuterLeafPages)
 		}
 
 		// Pager-backed leaf.
@@ -1611,7 +1622,7 @@ func (z *Zipper) writeRecursive(ref page.ChildRef, ops []batch.Entry, maintenanc
 		builder := z.newPooledLeafBuilder(newData, ops)
 		defer releasePooledBuilder(builder)
 		builder.SetPageID(newPageID)
-		return z.mergeLeaf(&oldNode, builder, ops, metrics, scratch, false)
+		return z.mergeLeaf(&oldNode, builder, ops, ranges, metrics, scratch, false)
 
 	case page.PageTypeInternal:
 		// Internal merge is always pager-backed.
@@ -1627,7 +1638,7 @@ func (z *Zipper) writeRecursive(ref page.ChildRef, ops []batch.Entry, maintenanc
 		defer releasePooledBuilder(builder)
 		builder.SetPageID(newPageID)
 		builder.SetInternalFenceBounds(low, high)
-		nr, splits, err := z.mergeInternal(&oldNode, builder, ops, maintenance, budget, metrics, retired, low, high, scratch)
+		nr, splits, err := z.mergeInternal(&oldNode, builder, ops, ranges, maintenance, budget, metrics, retired, low, high, scratch)
 		if err != nil {
 			return page.ChildRef{}, nil, err
 		}
@@ -1654,7 +1665,7 @@ func (z *Zipper) writeRecursive(ref page.ChildRef, ops []batch.Entry, maintenanc
 	return page.ChildRef{}, nil, page.ErrInvalidPageType
 }
 
-func (z *Zipper) mergeLeaf(oldNode *node.Node, builder *node.Builder, ops []batch.Entry, metrics *adaptive.Metrics, scratch *mergeScratch, reuseOuterLeafPages bool) (page.ChildRef, []Split, error) {
+func (z *Zipper) mergeLeaf(oldNode *node.Node, builder *node.Builder, ops []batch.Entry, ranges []batch.DeleteRange, metrics *adaptive.Metrics, scratch *mergeScratch, reuseOuterLeafPages bool) (page.ChildRef, []Split, error) {
 	if metrics != nil {
 		metrics.ZipperLeafMerges++
 	}
@@ -1762,6 +1773,17 @@ func (z *Zipper) mergeLeaf(oldNode *node.Node, builder *node.Builder, ops []batc
 		return nodeRef, nil
 	}
 
+	recordDeadPointer := func(flags byte, ptr page.ValuePtr) {
+		if flags&node.FlagPointer == 0 {
+			return
+		}
+		metrics.SlabDeadBytes += int(ptr.Length)
+		if metrics.SlabDeadBytesByFile == nil {
+			metrics.SlabDeadBytesByFile = make(map[uint32]int64, 4)
+		}
+		metrics.SlabDeadBytesByFile[ptr.FileID] += int64(ptr.Length)
+	}
+
 	for {
 		// Pick next key: min(oldNode[oldIdx], ops[opIdx])
 		var useBatch bool
@@ -1799,16 +1821,9 @@ func (z *Zipper) mergeLeaf(oldNode *node.Node, builder *node.Builder, ops []batc
 			} else if cmp > 0 {
 				useBatch = true
 			} else {
-				// Equal: Update (Batch wins)
-				// The old entry is being overwritten or deleted.
-				// If it was a pointer, track it as dead bytes.
-				if f&node.FlagPointer != 0 {
-					metrics.SlabDeadBytes += int(ptr.Length)
-					if metrics.SlabDeadBytesByFile == nil {
-						metrics.SlabDeadBytesByFile = make(map[uint32]int64, 4)
-					}
-					metrics.SlabDeadBytesByFile[ptr.FileID] += int64(ptr.Length)
-				}
+				// Equal: Update (Batch wins). The old entry is being overwritten
+				// or deleted; if it was a pointer, track it as dead bytes.
+				recordDeadPointer(f, ptr)
 
 				useBatch = true
 				oldIdx++ // Skip old
@@ -1863,6 +1878,10 @@ func (z *Zipper) mergeLeaf(oldNode *node.Node, builder *node.Builder, ops []batc
 			oldIdx++
 			if flags&node.FlagTombstone != 0 {
 				continue // Skip tombstones
+			}
+			if batch.DeleteRangesContainKey(ranges, key) {
+				recordDeadPointer(flags, valPtr)
+				continue
 			}
 		}
 
@@ -2024,7 +2043,7 @@ func (z *Zipper) mergeLeaf(oldNode *node.Node, builder *node.Builder, ops []batc
 	return rootNodeRef, splits, nil
 }
 
-func (z *Zipper) mergeInternal(oldNode *node.Node, builder *node.Builder, ops []batch.Entry, maintenance bool, budget *maintenanceBudget, metrics *adaptive.Metrics, retired *[]uint64, low, high []byte, scratch *mergeScratch) (page.ChildRef, []Split, error) {
+func (z *Zipper) mergeInternal(oldNode *node.Node, builder *node.Builder, ops []batch.Entry, ranges []batch.DeleteRange, maintenance bool, budget *maintenanceBudget, metrics *adaptive.Metrics, retired *[]uint64, low, high []byte, scratch *mergeScratch) (page.ChildRef, []Split, error) {
 	if metrics != nil {
 		metrics.ZipperInternalMerges++
 	}
@@ -2037,7 +2056,7 @@ func (z *Zipper) mergeInternal(oldNode *node.Node, builder *node.Builder, ops []
 	opIdx := 0
 
 	gomaxprocs := runtime.GOMAXPROCS(0)
-	useParallel := shouldUseParallelInternalMerge(int(count), len(ops), gomaxprocs, maintenance, ParallelMergePressureNormal)
+	useParallel := len(ranges) == 0 && shouldUseParallelInternalMerge(int(count), len(ops), gomaxprocs, maintenance, ParallelMergePressureNormal)
 	if useParallel && !maintenance {
 		pressure := z.parallelMergePressureLevel()
 		if pressure != ParallelMergePressureNormal {
@@ -2160,17 +2179,18 @@ func (z *Zipper) mergeInternal(oldNode *node.Node, builder *node.Builder, ops []
 				break
 			}
 			childOps := ops[startOpIdx:opIdx]
+			childRanges := deleteRangesForSpan(ranges, lowKey, childHigh)
 
 			newChildRef := curChild
 			var childSplits []Split
-			if len(childOps) > 0 {
-				newChildRef, childSplits, err = z.writeRecursive(curChild, childOps, maintenance, budget, metrics, lowKey, childHigh, retired, scratch)
+			if len(childOps) > 0 || len(childRanges) > 0 {
+				newChildRef, childSplits, err = z.writeRecursive(curChild, childOps, childRanges, maintenance, budget, metrics, lowKey, childHigh, retired, scratch)
 				if err != nil {
 					return page.ChildRef{}, nil, err
 				}
 			}
 
-			if len(childOps) == 0 {
+			if len(childOps) == 0 && len(childRanges) == 0 {
 				if err := appendExistingInternal(i, lowKey, newChildRef, firstEntry); err != nil {
 					return page.ChildRef{}, nil, err
 				}
@@ -2299,7 +2319,7 @@ func (z *Zipper) mergeInternal(oldNode *node.Node, builder *node.Builder, ops []
 				}
 				var childMetrics adaptive.Metrics
 				childRet := children[i].retired[:0]
-				ncID, cs, err := z.writeRecursive(children[i].child, children[i].ops, maintenance, budget, &childMetrics, children[i].low, children[i].high, &childRet, scratch)
+				ncID, cs, err := z.writeRecursive(children[i].child, children[i].ops, nil, maintenance, budget, &childMetrics, children[i].low, children[i].high, &childRet, scratch)
 				if err != nil {
 					errOnce.Do(func() { firstErr = err })
 					continue
@@ -2330,7 +2350,7 @@ func (z *Zipper) mergeInternal(oldNode *node.Node, builder *node.Builder, ops []
 	} else {
 		for i := range children {
 			if len(children[i].ops) > 0 {
-				ncID, cs, err := z.writeRecursive(children[i].child, children[i].ops, maintenance, budget, metrics, children[i].low, children[i].high, retired, scratch)
+				ncID, cs, err := z.writeRecursive(children[i].child, children[i].ops, nil, maintenance, budget, metrics, children[i].low, children[i].high, retired, scratch)
 				if err != nil {
 					return page.ChildRef{}, nil, err
 				}
@@ -2421,6 +2441,33 @@ func (z *Zipper) mergeInternal(oldNode *node.Node, builder *node.Builder, ops []
 
 	// builder finalized by caller.
 	return page.PageChildRef(builder.PageID()), splits, nil
+}
+
+func deleteRangesForSpan(ranges []batch.DeleteRange, low, high []byte) []batch.DeleteRange {
+	if len(ranges) == 0 {
+		return nil
+	}
+	start := -1
+	end := -1
+	for i, r := range ranges {
+		if batch.DeleteRangeOverlapsSpan(r, low, high) {
+			if start < 0 {
+				start = i
+			}
+			end = i + 1
+			continue
+		}
+		if start >= 0 {
+			break
+		}
+		if high != nil && r.Start != nil && bytes.Compare(r.Start, high) >= 0 {
+			break
+		}
+	}
+	if start < 0 {
+		return nil
+	}
+	return ranges[start:end]
 }
 
 func mergeMetrics(dst, src *adaptive.Metrics) {

--- a/TreeDB/zipper/zipper_test.go
+++ b/TreeDB/zipper/zipper_test.go
@@ -849,7 +849,7 @@ func TestMergeLeaf_SplitKeysDoNotAliasBatchKeys(t *testing.T) {
 	scratch := newMergeScratch()
 
 	var metrics adaptive.Metrics
-	_, splits, err := z.mergeLeaf(oldNode, builder, ops, &metrics, scratch, false)
+	_, splits, err := z.mergeLeaf(oldNode, builder, ops, nil, &metrics, scratch, false)
 	if err != nil {
 		t.Fatalf("mergeLeaf failed: %v", err)
 	}
@@ -1117,7 +1117,7 @@ func BenchmarkMergeLeafOuterLeafBatchScratch(b *testing.B) {
 		builder.SetPageID(0)
 		scratch := z.acquireApplyScratch()
 		var metrics adaptive.Metrics
-		_, _, err := z.mergeLeaf(oldNode, builder, ops, &metrics, scratch, true)
+		_, _, err := z.mergeLeaf(oldNode, builder, ops, nil, &metrics, scratch, true)
 		z.releaseApplyScratch(scratch)
 		if err != nil {
 			b.Fatalf("mergeLeaf: %v", err)

--- a/kvstore/adapters/treedb/treedb_batch_view_test.go
+++ b/kvstore/adapters/treedb/treedb_batch_view_test.go
@@ -22,6 +22,8 @@ func (s *stubBatch) Delete(_ []byte) error {
 	return nil
 }
 
+func (s *stubBatch) DeleteRange(_, _ []byte) error { return nil }
+
 func (s *stubBatch) Write() error                             { return nil }
 func (s *stubBatch) WriteSync() error                         { return nil }
 func (s *stubBatch) Close() error                             { return nil }


### PR DESCRIPTION
## Summary

Closes #2285. Part of #2284.

- Adds TreeDB batch `DeleteRange(start,end)` to public/backend/cached batch APIs.
- Preserves point-only sorted/compacted batch fast path; mixed range batches keep an ordered logical stream and build a range-aware apply plan.
- Applies backend range deletes natively in zipper without materializing per-key backend tombstones, including value-log ref delta accounting and online-vacuum catch-up recording.
- Extends RawKV command-WAL batch payloads with `RawKVOpDeleteRange`, nil-bound sentinel encoding, decode fail-closed checks, replay/reopen coverage, and storage-format docs.
- Fixes cached fallback correctness by serializing scan+publish against normal cached writers; bounds fallback materialization with `ErrBatchDeleteRangeTooLarge` fail-closed behavior.
- Adds focused backend/cached/command-WAL tests and a dense DeleteRange benchmark.

Non-goals: no geth adapter and no unified-bench DeleteRange workload here; #2286 remains the follow-up for TreeDB/Pebble/LevelDB unified-bench coverage.

## Tests

Latest local head: `fe7ca11daafb15c261a3c526f01cdd32a6279c48`.

- `go test ./TreeDB/zipper -count=1`
- `go test ./TreeDB/caching -run 'BatchDeleteRange|DeleteRange|Mock' -count=1`
- `go test ./TreeDB/db -run 'Vacuum|BatchDeleteRange|DeleteRange' -count=1`
- `go test ./TreeDB/batch ./TreeDB/db ./TreeDB/caching -run 'Batch|DeleteRange|CommandWAL' -count=1`
- `go test ./TreeDB/internal/commitlog -run 'RawKVSingle|DeleteRange|CommandFrame' -count=1`
- `go test ./TreeDB/db -run 'AppendRawKVSingleCommandWALSupportsDeleteRange|BatchDeleteRange|DeleteRange|Vacuum' -count=1`
- `go test ./TreeDB/internal/commitlog ./TreeDB -run 'RawKV|Batch|DeleteRange|CommandWAL' -count=1`
- `go test ./TreeDB/... -count=1`
- `go test ./TreeDB/mongo_gateway -run '^TestStandaloneServerCommandWALBSONInsertReadUpdateVisibility$' -count=1`

Additional full-repo signal: `go test ./... -count=1` hit a transient mongo gateway client timeout in `TestStandaloneServerCommandWALBSONInsertReadUpdateVisibility/command_wal_relaxed`; the focused test rerun above passed. Latest-head CI is the merge gate for full cross-package coverage.

## Benchmarks

Machine/context: darwin/arm64, Apple M3. Current branch head `3731cebb`; base `187a40c6`.

Point-only batch comparator:

Command: `go test ./TreeDB/db -run '^$' -bench '^BenchmarkBatch$' -benchmem -benchtime=100x -count=5`

| Version | ns/op median | ops/sec | B/op median | allocs/op | Result |
|---|---:|---:|---:|---:|---|
| base `187a40c6` | 5,973,000 | 167 | 392.0 KiB | 53 | baseline |
| PR `3731cebb` | 5,938,000 | 168 | 389.0 KiB | 53 | no material regression (`benchstat` p=0.690) |

Dense range benchmark:

Command: `go test ./TreeDB/db -run '^$' -bench '^BenchmarkBatchDeleteRangeDense$' -benchmem -benchtime=1x -count=5`

| Benchmark | ns/op median | ops/sec | affected keys/sec | B/op median | allocs/op median |
|---|---:|---:|---:|---:|---:|
| `range_delete_4096` | 265,084 | 3,772 | 15.5M | 7.633 KiB | 36 |
| `point_delete_4096` | 742,124 | 1,348 | 5.52M | 25.91 KiB | 47 |
| `batch_write_4096` | 324,167 | 3,085 | 12.6M | 1.467 MiB | 47 |

Range delete is ~2.8x faster than equivalent point deletes per affected key and in the same performance class as sequential batch writes for this dense shape.

## Notes / caveats

- Backend TreeDB batch DeleteRange is the native performance path.
- Cached batch DeleteRange uses a serialized materializing fallback for currently visible keys. The fallback is capped (`1,048,576` keys / `64 MiB` key bytes by default) and fails closed with `ErrBatchDeleteRangeTooLarge` before publishing logical mutations if the cap is exceeded.
- Command-WAL payload format is pre-alpha and now documents op `4=delete-range` with nil-bound sentinel lengths.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `DeleteRange(start, end)` method to batches for atomic deletion of key ranges.
  * Range deletes support half-open `[start,end)` semantics with nil bounds for unbounded ranges.
  * New `ErrBatchDeleteRangeTooLarge` error returned when range-delete materialization exceeds limits.

* **Documentation**
  * Updated batch operation contracts and storage format specification for range-delete semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


