### PR TITLE
bench: add exhaustive compact collection phase

### DIFF
--- a/TreeDB/cmd/treemap/main.go
+++ b/TreeDB/cmd/treemap/main.go
@@ -512,10 +512,18 @@ func runCompact(dir string, args []string) {
 		fatalf("compact -scope must be all or index")
 	}
 
-	db := openTreeDB(dir, true)
-	defer closeTreeDB(db)
+	rootDir := resolveTreeDBRootDir(dir)
+	backend, cleanupBackend, err := treedb.OpenBackend(treedb.Options{Dir: rootDir})
+	if err != nil {
+		fatalf("Failed to open DB backend: %v", err)
+	}
+	defer func() {
+		if err := cleanupBackend(); err != nil {
+			fatalf("Close DB backend: %v", err)
+		}
+	}()
 
-	stats, err := db.CompactStorage(context.Background(), treedb.CompactStorageOptions{
+	stats, err := backend.CompactStorage(context.Background(), treedb.CompactStorageOptions{
 		Mode:                           treedb.CompactStorageMode(parseCompactStorageModeFlag("compact", *mode)),
 		SyncEachPhase:                  *syncEachPhase,
 		ValueLogRewriteBatchSize:       *batchSize,

--- a/TreeDB/db/compact_storage.go
+++ b/TreeDB/db/compact_storage.go
@@ -1234,8 +1234,14 @@ func compactStorageValueLogFileID(name string) (uint32, bool) {
 }
 
 func (db *DB) installCompactStorageLeafPageLog(opts CompactStorageOptions) (*rewriteWriter, func(), error) {
-	if db == nil || !db.indexOuterLeavesInValueLog || db.leafPageLog != nil {
+	if db == nil || !db.indexOuterLeavesInValueLog {
 		return nil, func() {}, nil
+	}
+	previousLeafPageLog := db.leafPageLog
+	if previousLeafPageLog != nil {
+		if opts.Mode != CompactStorageExhaustive || !compactStorageReplaceableLeafPageLog(previousLeafPageLog) {
+			return nil, func() {}, nil
+		}
 	}
 	segments, err := listValueLogSegments(db.dir)
 	if err != nil {
@@ -1270,9 +1276,17 @@ func (db *DB) installCompactStorageLeafPageLog(opts CompactStorageOptions) (*rew
 	}
 	db.SetLeafPageLog(writer)
 	return writer, func() {
-		db.SetLeafPageLog(nil)
+		db.SetLeafPageLog(previousLeafPageLog)
 		_ = writer.Close()
 	}, nil
+}
+
+func compactStorageReplaceableLeafPageLog(log LeafPageLog) bool {
+	if wrapped, ok := log.(*leafPageLogWithRecordLengthHints); ok {
+		log = wrapped.inner
+	}
+	_, ok := log.(replayInlineLeafPageLog)
+	return ok
 }
 
 func (db *DB) refreshCompactStorageLeafPageLog(writer *rewriteWriter) error {

--- a/cmd/benchmark_run_report/main.go
+++ b/cmd/benchmark_run_report/main.go
@@ -1798,8 +1798,8 @@ func collectionRowsForIndex(rows []collectionRow, idx int) []collectionRow {
 }
 
 func collectionLifecycleRows(rows []collectionRow) collectionChartRows {
-	phases := []string{"post_insert", "online_one_pass_maintenance", "offline_compact", "offline_rewrite", "full_leafgen_pack_gc", "sqlite_vacuum"}
-	phaseLabels := []string{"post insert", "online maint", "offline compact", "offline rewrite", "leafgen GC", "SQLite VACUUM"}
+	phases := []string{"post_insert", "online_one_pass_maintenance", "offline_compact", "offline_rewrite", "exhaustive_compact", "full_leafgen_pack_gc", "sqlite_vacuum"}
+	phaseLabels := []string{"post insert", "online maint", "offline compact", "offline rewrite", "exhaustive", "leafgen GC", "SQLite VACUUM"}
 	values := make(map[string][]float64)
 	phasePresent := make([]bool, len(phases))
 	for _, row := range rows {
@@ -2045,7 +2045,7 @@ func collectionChartPhase(family, kind string) (string, bool) {
 		return "", false
 	}
 	if family == "TreeDB" {
-		return "full_leafgen_pack_gc", true
+		return "exhaustive_compact", true
 	}
 	if family == "SQLite" {
 		return "sqlite_vacuum", true
@@ -2056,7 +2056,8 @@ func collectionChartPhase(family, kind string) (string, bool) {
 func collectionChartPhaseMatches(family, kind, phase string) bool {
 	if kind == "bytes" {
 		if family == "TreeDB" {
-			return phase == "full_leafgen_pack_gc" ||
+			return phase == "exhaustive_compact" ||
+				phase == "full_leafgen_pack_gc" ||
 				phase == "offline_compact" ||
 				phase == "offline_rewrite" ||
 				phase == "online_one_pass_maintenance"

--- a/cmd/collection_canonical_bench/main.go
+++ b/cmd/collection_canonical_bench/main.go
@@ -27,6 +27,7 @@ const (
 	phasePostInsert               = "post_insert"
 	phaseOnlineOnePassMaintenance = "online_one_pass_maintenance"
 	phaseOfflineCompact           = "offline_compact"
+	phaseExhaustiveCompact        = "exhaustive_compact"
 	phaseFullLeafgenPackGC        = "full_leafgen_pack_gc"
 	phaseSQLiteVacuum             = "sqlite_vacuum"
 )
@@ -342,7 +343,10 @@ func run(argv []string) error {
 		}
 	}
 	if !cfg.SkipOfflineRewrite {
-		if err := runOfflineRewriteMatrix(cfg, canon); err != nil {
+		if err := runOfflineRewriteMatrix(cfg, canon, "offline_compact", phaseOfflineCompact, "full"); err != nil {
+			return err
+		}
+		if err := runOfflineRewriteMatrix(cfg, canon, "exhaustive_compact", phaseExhaustiveCompact, "exhaustive"); err != nil {
 			return err
 		}
 	}
@@ -384,6 +388,7 @@ func prepareRunDir(cfg config) error {
 		"logs",
 		"timed_matrix",
 		"offline_compact",
+		"exhaustive_compact",
 		"full_leafgen_pack_gc",
 		"benchmark_results.json",
 		"benchmark_summary.md",
@@ -553,21 +558,23 @@ func runTimedMatrix(cfg config, canon *canonicalRun) error {
 	return parseTimedMatrixReports(canon, matrixDir, cfg)
 }
 
-func runOfflineRewriteMatrix(cfg config, canon *canonicalRun) error {
-	rewriteDir := filepath.Join(cfg.OutDir, "offline_compact")
+func runOfflineRewriteMatrix(cfg config, canon *canonicalRun, dirName, compactPhase, compactMode string) error {
+	rewriteDir := filepath.Join(cfg.OutDir, dirName)
 	env := map[string]string{
 		"RUN_DIR":            rewriteDir,
 		"DOCS":               strconv.Itoa(cfg.Docs),
 		"BATCH":              strconv.Itoa(cfg.BatchSize),
 		"PROFILE":            cfg.Profile,
 		"COLLECTION_INDEXES": strings.Join(offlineRewriteIndexArgs(cfg.Indexes), " "),
+		"COMPACT_MODE":       compactMode,
 	}
-	if err := runLoggedCommand(cfg, canon, "offline_compact_matrix", env, "bash", "./scripts/treedb_collection_compression_matrix.sh"); err != nil {
+	commandName := dirName + "_matrix"
+	if err := runLoggedCommand(cfg, canon, commandName, env, "bash", "./scripts/treedb_collection_compression_matrix.sh"); err != nil {
 		return err
 	}
-	canon.Artifacts["offline_compact_dir"] = rewriteDir
-	canon.Artifacts["offline_compact_tsv"] = filepath.Join(rewriteDir, "compression_matrix.tsv")
-	return parseOfflineRewriteTSV(canon, filepath.Join(rewriteDir, "compression_matrix.tsv"), cfg)
+	canon.Artifacts[dirName+"_dir"] = rewriteDir
+	canon.Artifacts[dirName+"_tsv"] = filepath.Join(rewriteDir, "compression_matrix.tsv")
+	return parseOfflineRewriteTSV(canon, filepath.Join(rewriteDir, "compression_matrix.tsv"), cfg, compactPhase, compactMode)
 }
 
 func runFullLeafgenFixture(cfg config, canon *canonicalRun, formats []string) error {
@@ -866,7 +873,7 @@ func addSQLiteTimedRows(canon *canonicalRun, report collectionReport, bench repo
 	canon.Results = append(canon.Results, row)
 }
 
-func parseOfflineRewriteTSV(canon *canonicalRun, path string, cfg config) error {
+func parseOfflineRewriteTSV(canon *canonicalRun, path string, cfg config, compactPhase, compactMode string) error {
 	f, err := os.Open(path)
 	if err != nil {
 		return err
@@ -910,11 +917,11 @@ func parseOfflineRewriteTSV(canon *canonicalRun, path string, cfg config) error 
 		note := "offline compact matrix before-compact size; not compacted"
 		flags := map[string]string(nil)
 		if row["phase"] == "after_compact" || row["phase"] == "after_rewrite" {
-			phase = phaseOfflineCompact
-			maintenance = "treemap_compact_rw"
-			note = "High-level CompactStorage path using treemap compact -rw"
+			phase = compactPhase
+			maintenance = "treemap_compact_rw_" + compactMode
+			note = "High-level CompactStorage path using treemap compact -rw -mode " + compactMode
 			flags = map[string]string{
-				"treemap":                   "compact -rw",
+				"treemap":                   "compact -rw -mode " + compactMode,
 				"template-mode":             "off",
 				"leaf-segment-target-bytes": "persisted/default",
 				"index-vacuum":              "via CompactStorage/offline vacuum path",
@@ -1062,7 +1069,7 @@ func validateCanonicalRun(canon *canonicalRun) []guardrailCheck {
 		if r.Shape != "collection" && r.Shape != "raw" {
 			add("error", "missing_shape_label", fmt.Sprintf("%s/%s has non-canonical shape label %q", r.ConfigName, r.Phase, r.Shape))
 		}
-		if (r.Phase == phaseOfflineCompact || r.Phase == phaseFullLeafgenPackGC || r.Phase == phaseSQLiteVacuum) && len(r.CompactionFlags) == 0 {
+		if (isTreeDBCompactedPhase(r.Phase) || r.Phase == phaseSQLiteVacuum) && len(r.CompactionFlags) == 0 {
 			add("error", "missing_compaction_flags", fmt.Sprintf("%s/%s is missing compaction flags", r.ConfigName, r.Phase))
 		}
 	}
@@ -1100,7 +1107,7 @@ func validateCanonicalRun(canon *canonicalRun) []guardrailCheck {
 	}
 	if !sqliteSkipped {
 		for _, treeDBConfig := range compactedTreeDBConfigNames(canon) {
-			for _, treedbPhase := range []string{phaseOfflineCompact, phaseFullLeafgenPackGC} {
+			for _, treedbPhase := range compactedTreeDBPhases() {
 				if findResult(canon.Results, treeDBConfig, treedbPhase) == nil {
 					continue
 				}
@@ -1153,7 +1160,7 @@ func buildCompactedComparisons(canon *canonicalRun) []comparisonRow {
 	var comparisons []comparisonRow
 	sqliteConfigs := []string{sqliteNativeConfigName(canon), sqliteJSONConfigName(canon)}
 	for _, treeDBConfig := range compactedTreeDBConfigNames(canon) {
-		for _, treedbPhase := range []string{phaseOfflineCompact, phaseFullLeafgenPackGC} {
+		for _, treedbPhase := range compactedTreeDBPhases() {
 			treeRow := findResult(canon.Results, treeDBConfig, treedbPhase)
 			if !hasPositiveBytesPerDoc(treeRow) {
 				continue
@@ -1203,7 +1210,16 @@ func findComparison(comparisons []comparisonRow, treeConfig, treePhase, sqliteCo
 }
 
 func isTreeDBCompactedPhase(phase string) bool {
-	return phase == phaseOfflineCompact || phase == phaseFullLeafgenPackGC
+	for _, compactedPhase := range compactedTreeDBPhases() {
+		if phase == compactedPhase {
+			return true
+		}
+	}
+	return false
+}
+
+func compactedTreeDBPhases() []string {
+	return []string{phaseOfflineCompact, phaseExhaustiveCompact, phaseFullLeafgenPackGC}
 }
 
 func writeOutputs(canon *canonicalRun) error {
@@ -1283,7 +1299,7 @@ func renderMarkdownReport(canon *canonicalRun) string {
 	sb.WriteString("\n")
 
 	sb.WriteString("## Fair Compacted-State Comparison\n\n")
-	sb.WriteString("TreeDB fully compacted rows are compared with SQLite after `VACUUM`. Do not compare TreeDB `offline_compact` or `full_leafgen_pack_gc` only against SQLite `post_insert` rows.\n\n")
+	sb.WriteString("TreeDB compacted rows are compared with SQLite after `VACUUM`. Use `exhaustive_compact` for byte-minimized benchmark/VACUUM-equivalent claims; do not compare TreeDB compacted rows only against SQLite `post_insert` rows.\n\n")
 	writeFairComparison(&sb, canon)
 	sb.WriteString("\n")
 
@@ -1292,8 +1308,9 @@ func renderMarkdownReport(canon *canonicalRun) string {
 	sb.WriteString("| --- | --- | --- |\n")
 	sb.WriteString("| `post_insert` | Size after insert benchmark/fixture and correctness flush/checkpoint. | Compare with other post-insert rows only. |\n")
 	sb.WriteString("| `online_one_pass_maintenance` | Partial online maintenance from benchmark harness; currently one online rewrite/GC path and one leafgen-pack pass. | Do not present as full compaction. |\n")
-	sb.WriteString("| `offline_compact` | High-level `treemap compact <dir> -rw` path. | Compare with SQLite `sqlite_vacuum`. |\n")
-	sb.WriteString("| `full_leafgen_pack_gc` | Forced/full leaf generation pack/GC with explicit knobs and configured index vacuum. | Compare with SQLite `sqlite_vacuum`. |\n")
+	sb.WriteString("| `offline_compact` | Production high-level `treemap compact <dir> -rw -mode full` path. | Compare with SQLite `sqlite_vacuum`; not the byte-minimized headline. |\n")
+	sb.WriteString("| `exhaustive_compact` | Benchmark/VACUUM-equivalent `treemap compact <dir> -rw -mode exhaustive` path. | Preferred TreeDB compacted-size headline versus SQLite `sqlite_vacuum`. |\n")
+	sb.WriteString("| `full_leafgen_pack_gc` | Diagnostic forced/full leaf generation pack/GC with explicit knobs and configured index vacuum. | Diagnostic only; compare with SQLite `sqlite_vacuum` if reported. |\n")
 	sb.WriteString("| `sqlite_vacuum` | SQLite compacted baseline after `VACUUM`. | Required baseline for compacted-state comparison. |\n\n")
 	sb.WriteString("Full leafgen knobs recorded for this run:\n\n")
 	writeKVTable(&sb, [][2]string{
@@ -1354,23 +1371,23 @@ func renderMarkdownReport(canon *canonicalRun) string {
 func renderExecutiveSummary(canon *canonicalRun) string {
 	fastest := fastestThroughput(canon.Results)
 	offline := findResult(canon.Results, compactedTreeDBConfigName(canon), phaseOfflineCompact)
-	full := findResult(canon.Results, compactedTreeDBConfigName(canon), phaseFullLeafgenPackGC)
+	exhaustive := findResult(canon.Results, compactedTreeDBConfigName(canon), phaseExhaustiveCompact)
 	sqliteJSON := findResult(canon.Results, sqliteJSONConfigName(canon), phaseSQLiteVacuum)
 	sqliteNative := findResult(canon.Results, sqliteNativeConfigName(canon), phaseSQLiteVacuum)
-	if hasPositiveBytesPerDoc(offline) && hasPositiveBytesPerDoc(full) &&
+	if hasPositiveBytesPerDoc(offline) && hasPositiveBytesPerDoc(exhaustive) &&
 		hasPositiveBytesPerDoc(sqliteJSON) && hasPositiveBytesPerDoc(sqliteNative) {
 		engine := "TreeDB"
 		if fastest != nil {
 			engine = fastest.ConfigName
 		}
 		offlineNative := *sqliteNative.BytesPerDoc / *offline.BytesPerDoc
-		fullNative := *sqliteNative.BytesPerDoc / *full.BytesPerDoc
+		exhaustiveNative := *sqliteNative.BytesPerDoc / *exhaustive.BytesPerDoc
 		offlineJSON := *sqliteJSON.BytesPerDoc / *offline.BytesPerDoc
-		fullJSON := *sqliteJSON.BytesPerDoc / *full.BytesPerDoc
-		return fmt.Sprintf("`%s` is the fastest indexed ingest row in this run. TreeDB fully compacted %s %s collection storage is %.1f B/doc via high-level offline compact and %.1f B/doc via full leafgen pack/GC. Compared with SQLite after `VACUUM`, offline compact is about %.1fx smaller than SQLite native columns and %.1fx smaller than SQLite JSON; full leafgen pack/GC is about %.1fx and %.1fx smaller, respectively.",
-			engine, indexCountLabel(canonicalIndexCount(canon)), primaryFormat(canon), *offline.BytesPerDoc, *full.BytesPerDoc, offlineNative, offlineJSON, fullNative, fullJSON)
+		exhaustiveJSON := *sqliteJSON.BytesPerDoc / *exhaustive.BytesPerDoc
+		return fmt.Sprintf("`%s` is the fastest indexed ingest row in this run. TreeDB byte-minimized %s %s collection storage is %.1f B/doc via exhaustive compact; production offline compact is %.1f B/doc. Compared with SQLite after `VACUUM`, exhaustive compact is about %.1fx smaller than SQLite native columns and %.1fx smaller than SQLite JSON; production offline compact is about %.1fx and %.1fx smaller, respectively.",
+			engine, indexCountLabel(canonicalIndexCount(canon)), primaryFormat(canon), *exhaustive.BytesPerDoc, *offline.BytesPerDoc, exhaustiveNative, exhaustiveJSON, offlineNative, offlineJSON)
 	}
-	return "This report separates post-insert, partial online maintenance, offline compact, full leafgen pack/GC, and SQLite VACUUM states. Some compacted-state rows are missing, so the fair compacted-state headline could not be generated."
+	return "This report separates post-insert, partial online maintenance, production offline compact, exhaustive compact, full leafgen pack/GC diagnostics, and SQLite VACUUM states. Some compacted-state rows are missing, so the fair compacted-state headline could not be generated."
 }
 
 func writeFairComparison(sb *strings.Builder, canon *canonicalRun) {
@@ -1392,7 +1409,7 @@ func writeFairComparison(sb *strings.Builder, canon *canonicalRun) {
 	sb.WriteString("| TreeDB config | Phase | B/doc | vs SQLite native-columns VACUUM | vs SQLite JSON VACUUM |\n")
 	sb.WriteString("| --- | --- | ---: | ---: | ---: |\n")
 	for _, treeDBConfig := range compactedTreeDBConfigNames(canon) {
-		for _, phase := range []string{phaseOfflineCompact, phaseFullLeafgenPackGC} {
+		for _, phase := range compactedTreeDBPhases() {
 			nativeCmp := findComparison(comparisons, treeDBConfig, phase, sqliteNativeConfig, phaseSQLiteVacuum)
 			jsonCmp := findComparison(comparisons, treeDBConfig, phase, sqliteJSONConfig, phaseSQLiteVacuum)
 			if nativeCmp == nil && jsonCmp == nil {

--- a/cmd/collection_canonical_bench/main_test.go
+++ b/cmd/collection_canonical_bench/main_test.go
@@ -14,12 +14,13 @@ func TestCanonicalReportKnownCompressionShape(t *testing.T) {
 
 	required := []string{
 		"| `command_line` | `./scripts/bench_collections_canonical.sh -docs 100000` |",
-		"44.3 B/doc via high-level offline compact and 31.7 B/doc via full leafgen pack/GC",
-		"offline compact is about 3.5x smaller than SQLite native columns and 5.2x smaller than SQLite JSON",
-		"full leafgen pack/GC is about 4.9x and 7.3x smaller, respectively",
+		"23.2 B/doc via exhaustive compact; production offline compact is 44.3 B/doc",
+		"exhaustive compact is about 6.8x smaller than SQLite native columns and 10.0x smaller than SQLite JSON",
+		"production offline compact is about 3.5x and 5.2x smaller, respectively",
 		"`online_one_pass_maintenance`",
-		"Do not compare TreeDB `offline_compact` or `full_leafgen_pack_gc` only against SQLite `post_insert` rows.",
+		"Use `exhaustive_compact` for byte-minimized benchmark/VACUUM-equivalent claims",
 		"`treedb_template_v1_collection_2_indexes` | `offline_compact` | 44.3",
+		"`treedb_template_v1_collection_2_indexes` | `exhaustive_compact` | 23.2",
 		"`treedb_template_v1_collection_2_indexes` | `full_leafgen_pack_gc` | 31.7",
 		"make bench-collections-canonical",
 	}
@@ -256,6 +257,8 @@ func TestCanonicalDerivedCompactedComparisonsUseConfiguredIndexCount(t *testing.
 	canon.Results = append(canon.Results,
 		testStorageRow("sqlite_json_1_indexes", "sqlite_wal_normal", "json", "collection", phaseSQLiteVacuum, 1, 18000000, 180.0),
 		testStorageRow("sqlite_native_columns_1_indexes", "sqlite_wal_normal", "native-columns", "collection", phaseSQLiteVacuum, 1, 12000000, 120.0),
+		testStorageRow("treedb_template_v1_collection_1_indexes", "treedb_fast", "template-v1", "collection", phaseOfflineCompact, 1, 3600000, 36.0),
+		testStorageRow("treedb_template_v1_collection_1_indexes", "treedb_fast", "template-v1", "collection", phaseExhaustiveCompact, 1, 2400000, 24.0),
 		testStorageRow("treedb_template_v1_collection_1_indexes", "treedb_fast", "template-v1", "collection", phaseFullLeafgenPackGC, 1, 2800000, 28.0),
 	)
 	finalizeRunMetadata(canon)
@@ -306,12 +309,14 @@ func TestExecutiveSummaryUsesConfiguredIndexCountLabel(t *testing.T) {
 	canon.Results = append(canon.Results,
 		testStorageRow("sqlite_json_1_indexes", "sqlite_wal_normal", "json", "collection", phaseSQLiteVacuum, 1, 18000000, 180.0),
 		testStorageRow("sqlite_native_columns_1_indexes", "sqlite_wal_normal", "native-columns", "collection", phaseSQLiteVacuum, 1, 12000000, 120.0),
+		testStorageRow("treedb_template_v1_collection_1_indexes", "treedb_fast", "template-v1", "collection", phaseOfflineCompact, 1, 3600000, 36.0),
+		testStorageRow("treedb_template_v1_collection_1_indexes", "treedb_fast", "template-v1", "collection", phaseExhaustiveCompact, 1, 2400000, 24.0),
 		testStorageRow("treedb_template_v1_collection_1_indexes", "treedb_fast", "template-v1", "collection", phaseFullLeafgenPackGC, 1, 2800000, 28.0),
 	)
 	finalizeRunMetadata(canon)
 
 	summary := renderExecutiveSummary(canon)
-	if !strings.Contains(summary, "fully compacted one-index template-v1 collection storage") {
+	if !strings.Contains(summary, "byte-minimized one-index template-v1 collection storage") {
 		t.Fatalf("summary did not use configured index count: %s", summary)
 	}
 	if strings.Contains(summary, "two-index") {
@@ -567,6 +572,7 @@ func knownExampleRun() *canonicalRun {
 			row("treedb_template_v1_collection_0_indexes", "treedb_fast", "template-v1", "collection", phaseOfflineCompact, 0, 1948075, 19.5),
 			row("treedb_template_v1_collection_1_indexes", "treedb_fast", "template-v1", "collection", phaseOfflineCompact, 1, 3751406, 37.5),
 			row("treedb_template_v1_collection_2_indexes", "treedb_fast", "template-v1", "collection", phaseOfflineCompact, 2, 4434451, 44.3),
+			row("treedb_template_v1_collection_2_indexes", "treedb_fast", "template-v1", "collection", phaseExhaustiveCompact, 2, 2319517, 23.2),
 			row("treedb_template_v1_collection_2_indexes", "treedb_fast", "template-v1", "collection", phaseFullLeafgenPackGC, 2, 3174681, 31.7),
 			row("sqlite_json_2_indexes", "sqlite_wal_normal", "json", "collection", phaseSQLiteVacuum, 2, 23166976, 231.7),
 			row("sqlite_native_columns_2_indexes", "sqlite_wal_normal", "native-columns", "collection", phaseSQLiteVacuum, 2, 15671296, 156.7),

--- a/docs/benchmarks/collections_canonical_benchmark.md
+++ b/docs/benchmarks/collections_canonical_benchmark.md
@@ -60,14 +60,26 @@ maintenance and must not be described as full compaction.
 
 `offline_compact`
 
-The high-level TreeDB compaction path:
+The production high-level TreeDB compaction path:
 
 ```bash
-treemap compact <dir> -rw
+treemap compact <dir> -rw -mode full
 ```
 
-This is the preferred full/offline compaction comparison point. Compare it with
-SQLite after `VACUUM`, not SQLite post-insert.
+This is a policy/full compaction comparison point. Compare it with SQLite after
+`VACUUM`, not SQLite post-insert, but do not use it as the byte-minimized public
+storage-floor headline.
+
+`exhaustive_compact`
+
+The benchmark/VACUUM-equivalent TreeDB compaction path:
+
+```bash
+treemap compact <dir> -rw -mode exhaustive
+```
+
+This is the preferred TreeDB byte-minimized compacted-size headline. Compare it
+with SQLite after `VACUUM`.
 
 `full_leafgen_pack_gc`
 
@@ -81,8 +93,9 @@ the exact knobs:
 - `leafgen-pack-frame-k`
 - `index-vacuum`
 
-This is also a full compacted TreeDB comparison point. Compare it with SQLite
-after `VACUUM`.
+This is a diagnostic compacted TreeDB comparison point. Compare it with SQLite
+after `VACUUM` if reported, but prefer `exhaustive_compact` for public
+byte-minimized storage-floor claims.
 
 `sqlite_vacuum`
 

--- a/scripts/treedb_collection_compression_matrix.sh
+++ b/scripts/treedb_collection_compression_matrix.sh
@@ -8,6 +8,7 @@ BATCH="${BATCH:-16000}"
 RUN_DIR="${RUN_DIR:-/tmp/treedb_collection_compression_$(date +%Y%m%d_%H%M%S)}"
 PROFILE="${PROFILE:-bench}"
 COLLECTION_INDEXES="${COLLECTION_INDEXES:-0 1 2}"
+COMPACT_MODE="${COMPACT_MODE:-full}"
 
 mkdir -p "$RUN_DIR"/{dbs,logs}
 
@@ -243,7 +244,7 @@ measure_tsv_row() {
 	run_compact() {
 		local case_name="$1"
 		local db_dir="$2"
-		"$treemap" compact "$db_dir" -rw >"$RUN_DIR/logs/${case_name}.compact.log" 2>&1
+		"$treemap" compact "$db_dir" -rw -mode "$COMPACT_MODE" >"$RUN_DIR/logs/${case_name}.compact.log" 2>&1
 	}
 
 run_raw_case() {
@@ -307,7 +308,7 @@ done
 	printf -- '- Document shape: template-v1 fixture fields `name`, `email`, `city`, `pad`\n'
 	printf -- '- Raw TreeDB case: generated template-v1 payloads stored directly by key\n'
 	printf -- '- Collection cases: generated template-v1 payloads inserted through collection mode with indexes `%s`\n' "$COLLECTION_INDEXES"
-		printf -- '- Compaction: `treemap compact <dir> -rw`\n'
+		printf -- '- Compaction: `treemap compact <dir> -rw -mode %s`\n' "$COMPACT_MODE"
 		printf -- '- Gzip ratio is `bytes/gzip_bytes`; lower is closer to gzip-compressed density already being present on disk.\n\n'
 		printf '| Mode | Indexes | Before bytes | Before gzip | Before bytes/gzip | After compact bytes | After compact gzip | After bytes/gzip | Disk delta | Gzip delta | After leaf_vlog bytes | After leaf bytes/gzip | After index.db bytes | After value_vlog bytes |\n'
 		printf '| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |\n'


### PR DESCRIPTION
## Summary

- Link #2291 / parent #2288.
- Add canonical collection benchmark `exhaustive_compact` rows using `treemap compact -rw -mode exhaustive`.
- Keep `offline_compact` as production `-mode full` and keep `full_leafgen_pack_gc` as diagnostic.
- Update canonical summary/report language to use `exhaustive_compact` as the byte-minimized headline phase.
- Make `treemap compact` use direct backend maintenance opens so exhaustive mode can own/rotate the leaf page log during offline CLI compaction.

## Validation

- `GOWORK=off go test ./TreeDB/db -run 'TestCompactStorageExhaustive|TestCompactStorageNormalizeExhaustive' -count=1`
- `GOWORK=off go test ./TreeDB/cmd/treemap ./cmd/collection_canonical_bench`
- Smoke canonical run:
  - `OUT=/tmp/canonical_exhaustive_smoke3_103929`
  - `GOWORK=off go run ./cmd/collection_canonical_bench -out-dir "$OUT" -docs 20 -batch-size 10 -indexes 1 -formats template-v1 -skip-timed-matrix -skip-full-leafgen -skip-sqlite -allow-incomplete`
  - verified `exhaustive_compact` rows and `COMPACT_MODE=exhaustive` command record in report JSON/Markdown.

## Notes

No full benchmark rerun in this PR. #2292 will rerun the canonical collection benchmark and refresh README/report numbers using the new exhaustive rows.

## AI review status

Requested after PR creation.
