### PR TITLE
Add TreeDB storage knobs to vector DB compare harness

### DIFF
--- a/benchmarks/vector_db_compare/README.md
+++ b/benchmarks/vector_db_compare/README.md
@@ -95,13 +95,21 @@ Configuration:
 
 - `RUN_DIR`: output directory. Defaults to a timestamped directory under `/tmp`.
 - `BACKENDS`: comma-separated backend list. Defaults to `treedb,vectorlite`.
-- `DOCS`, `DIMS`, `QUERIES`, `VALIDATE_QUERIES`, `TOP_K`: dataset and validation sizes.
+- `DOCS`, `DIMS`, `QUERIES`, `VALIDATE_QUERIES`, `VALIDATE_DOCS`,
+  `TOP_K`: dataset and validation sizes. `VALIDATE_DOCS` applies only to TreeDB
+  rows and defaults to `16`.
 - `SEARCH_CONCURRENCY`: comma-separated search concurrency levels.
 - `M`, `EF_CONSTRUCTION`, `EF_SEARCH`: HNSW parameters.
 - `MIN_RECALL`: recall gate for full-vector rows such as TreeDB exact/default,
   Vectorlite, pgvector, and MongoDB. Defaults to `0.95`.
 - `TREEDB_COLUMN_GRAPH_EF_SEARCH`: optional efSearch override for TreeDB
   `column_graph` rows; defaults to `EF_SEARCH`.
+- `TREEDB_COMPACT`, `TREEDB_COMPACT_SYNC_EACH_PHASE`,
+  `TREEDB_VALUE_POINTER_THRESHOLD`, `TREEDB_LEAF_GENERATION_SEGMENT_TARGET`,
+  `TREEDB_REQUIRE_VALUE_LOG_BYTES`, and `TREEDB_REQUIRE_LEAF_VLOG_BYTES`:
+  optional passthroughs to the matching `cmd/treedb_vector_search_demo` storage
+  flags for every TreeDB row. Unset variables are not passed, so demo defaults
+  are preserved.
 - `TREEDB_QUANTIZED_INDEX_NAME`: scalar_u8 TreeDB quantized score-plane name.
   Defaults to `embedding.scalar_u8.fast`.
 - `TREEDB_QUANTIZED_RERANK_CANDIDATES`: TreeDB quantized-rerank exact rerank

--- a/scripts/bench_vector_db_compare.sh
+++ b/scripts/bench_vector_db_compare.sh
@@ -28,6 +28,13 @@ MIN_RECALL="${MIN_RECALL:-0.95}"
 TREEDB_QUANTIZED_MIN_RECALL="${TREEDB_QUANTIZED_MIN_RECALL:-0}"
 TREEDB_QUANTIZED_ONLY_MIN_RECALL="${TREEDB_QUANTIZED_ONLY_MIN_RECALL:-$TREEDB_QUANTIZED_MIN_RECALL}"
 TREEDB_QUANTIZED_RERANK_MIN_RECALL="${TREEDB_QUANTIZED_RERANK_MIN_RECALL:-$TREEDB_QUANTIZED_MIN_RECALL}"
+VALIDATE_DOCS="${VALIDATE_DOCS:-16}"
+TREEDB_COMPACT="${TREEDB_COMPACT:-}"
+TREEDB_COMPACT_SYNC_EACH_PHASE="${TREEDB_COMPACT_SYNC_EACH_PHASE:-}"
+TREEDB_VALUE_POINTER_THRESHOLD="${TREEDB_VALUE_POINTER_THRESHOLD:-}"
+TREEDB_LEAF_GENERATION_SEGMENT_TARGET="${TREEDB_LEAF_GENERATION_SEGMENT_TARGET:-}"
+TREEDB_REQUIRE_VALUE_LOG_BYTES="${TREEDB_REQUIRE_VALUE_LOG_BYTES:-}"
+TREEDB_REQUIRE_LEAF_VLOG_BYTES="${TREEDB_REQUIRE_LEAF_VLOG_BYTES:-}"
 NUMPY_PACKAGE="${NUMPY_PACKAGE:-numpy==2.0.2}"
 VECTORLITE_PACKAGE="${VECTORLITE_PACKAGE:-vectorlite-py==0.2.0}"
 
@@ -151,6 +158,28 @@ validate_backend_configuration
 if [[ -z "$TREEDB_COLUMN_GRAPH_EF_SEARCH" ]]; then
 	TREEDB_COLUMN_GRAPH_EF_SEARCH="$EF_SEARCH"
 fi
+
+# Preserve the existing TreeDB harness default for document validation, and pass
+# the remaining storage knobs only when the caller explicitly sets their env var.
+treedb_storage_args=(-validate-docs "$VALIDATE_DOCS")
+if [[ -n "$TREEDB_COMPACT" ]]; then
+	treedb_storage_args+=("-compact=$TREEDB_COMPACT")
+fi
+if [[ -n "$TREEDB_COMPACT_SYNC_EACH_PHASE" ]]; then
+	treedb_storage_args+=("-compact-sync-each-phase=$TREEDB_COMPACT_SYNC_EACH_PHASE")
+fi
+if [[ -n "$TREEDB_VALUE_POINTER_THRESHOLD" ]]; then
+	treedb_storage_args+=(-value-pointer-threshold "$TREEDB_VALUE_POINTER_THRESHOLD")
+fi
+if [[ -n "$TREEDB_LEAF_GENERATION_SEGMENT_TARGET" ]]; then
+	treedb_storage_args+=(-leaf-generation-segment-target "$TREEDB_LEAF_GENERATION_SEGMENT_TARGET")
+fi
+if [[ -n "$TREEDB_REQUIRE_VALUE_LOG_BYTES" ]]; then
+	treedb_storage_args+=("-require-value-log-bytes=$TREEDB_REQUIRE_VALUE_LOG_BYTES")
+fi
+if [[ -n "$TREEDB_REQUIRE_LEAF_VLOG_BYTES" ]]; then
+	treedb_storage_args+=("-require-leaf-vlog-bytes=$TREEDB_REQUIRE_LEAF_VLOG_BYTES")
+fi
 mkdir -p "$RUN_DIR"
 
 cat >"$RUN_DIR/README.md" <<EOF
@@ -164,6 +193,7 @@ cat >"$RUN_DIR/README.md" <<EOF
 - dims: \`$DIMS\`
 - queries: \`$QUERIES\`
 - validate queries: \`$VALIDATE_QUERIES\`
+- validate docs: \`$VALIDATE_DOCS\`
 - top_k: \`$TOP_K\`
 - concurrency: \`$SEARCH_CONCURRENCY\`
 - M / efConstruction / efSearch: \`$M / $EF_CONSTRUCTION / $EF_SEARCH\`
@@ -171,6 +201,14 @@ cat >"$RUN_DIR/README.md" <<EOF
 - minimum recall: \`$MIN_RECALL\`
 - TreeDB quantized index/rerank candidates: \`$TREEDB_QUANTIZED_INDEX_NAME / $TREEDB_QUANTIZED_RERANK_CANDIDATES\`
 - TreeDB quantized-only/rerank minimum recall: \`$TREEDB_QUANTIZED_ONLY_MIN_RECALL / $TREEDB_QUANTIZED_RERANK_MIN_RECALL\`
+- TreeDB storage/validation knobs:
+  - \`VALIDATE_DOCS=$VALIDATE_DOCS\`
+  - \`TREEDB_COMPACT=${TREEDB_COMPACT:-<unset>}\`
+  - \`TREEDB_COMPACT_SYNC_EACH_PHASE=${TREEDB_COMPACT_SYNC_EACH_PHASE:-<unset>}\`
+  - \`TREEDB_VALUE_POINTER_THRESHOLD=${TREEDB_VALUE_POINTER_THRESHOLD:-<unset>}\`
+  - \`TREEDB_LEAF_GENERATION_SEGMENT_TARGET=${TREEDB_LEAF_GENERATION_SEGMENT_TARGET:-<unset>}\`
+  - \`TREEDB_REQUIRE_VALUE_LOG_BYTES=${TREEDB_REQUIRE_VALUE_LOG_BYTES:-<unset>}\`
+  - \`TREEDB_REQUIRE_LEAF_VLOG_BYTES=${TREEDB_REQUIRE_LEAF_VLOG_BYTES:-<unset>}\`
 - Python packages: \`$NUMPY_PACKAGE\`, \`$VECTORLITE_PACKAGE\`
 
 This run compares persistent database-tier ANN search:
@@ -234,7 +272,7 @@ if contains_backend treedb; then
 		-queries "$QUERIES" \
 		-search-concurrency "$SEARCH_CONCURRENCY" \
 		-validate-queries "$VALIDATE_QUERIES" \
-		-validate-docs 16 \
+		"${treedb_storage_args[@]}" \
 		-top-k "$TOP_K" \
 		-m "$M" \
 		-ef-construction "$EF_CONSTRUCTION" \
@@ -257,7 +295,7 @@ if contains_backend treedb_column_graph; then
 		-queries "$QUERIES" \
 		-search-concurrency "$SEARCH_CONCURRENCY" \
 		-validate-queries "$VALIDATE_QUERIES" \
-		-validate-docs 16 \
+		"${treedb_storage_args[@]}" \
 		-top-k "$TOP_K" \
 		-m "$M" \
 		-ef-construction "$EF_CONSTRUCTION" \
@@ -282,7 +320,7 @@ if contains_backend treedb_column_graph_quantized_only; then
 		-queries "$QUERIES" \
 		-search-concurrency "$SEARCH_CONCURRENCY" \
 		-validate-queries "$VALIDATE_QUERIES" \
-		-validate-docs 16 \
+		"${treedb_storage_args[@]}" \
 		-top-k "$TOP_K" \
 		-m "$M" \
 		-ef-construction "$EF_CONSTRUCTION" \
@@ -308,7 +346,7 @@ if contains_backend treedb_column_graph_quantized_rerank; then
 		-queries "$QUERIES" \
 		-search-concurrency "$SEARCH_CONCURRENCY" \
 		-validate-queries "$VALIDATE_QUERIES" \
-		-validate-docs 16 \
+		"${treedb_storage_args[@]}" \
 		-top-k "$TOP_K" \
 		-m "$M" \
 		-ef-construction "$EF_CONSTRUCTION" \


### PR DESCRIPTION
## Scope

Closes #2279. Parent tracker: #2169. Source context: #2278 / stale PR #1746 triage (not rebased or merged).

- Adds TreeDB-only env passthroughs in `scripts/bench_vector_db_compare.sh` for existing `cmd/treedb_vector_search_demo` storage/validation flags:
  - `VALIDATE_DOCS`
  - `TREEDB_COMPACT`
  - `TREEDB_COMPACT_SYNC_EACH_PHASE`
  - `TREEDB_VALUE_POINTER_THRESHOLD`
  - `TREEDB_LEAF_GENERATION_SEGMENT_TARGET`
  - `TREEDB_REQUIRE_VALUE_LOG_BYTES`
  - `TREEDB_REQUIRE_LEAF_VLOG_BYTES`
- Threads the shared TreeDB storage args through all current TreeDB rows: `treedb`, `treedb_column_graph`, `treedb_column_graph_quantized_only`, and `treedb_column_graph_quantized_rerank`.
- Records selected storage/validation knobs in each generated run `README.md`.
- Documents the new TreeDB-only harness configuration knobs in `benchmarks/vector_db_compare/README.md`.

## Defaults / behavior boundary

- Existing default document validation is preserved: `VALIDATE_DOCS` defaults to the prior hard-coded `16`.
- Other TreeDB storage flags are passed only when their env var is explicitly set; otherwise the demo defaults remain in control.
- pgvector, vectorlite, and MongoDB command paths are unchanged.

## Evidence

Local syntax/static checks:

```sh
bash -n scripts/bench_vector_db_compare.sh
# PASS

git diff --check
# PASS
```

TreeDB column_graph smoke (local `python3` is 3.14, so this uses Python 3.12 to satisfy the harness's pinned `numpy==2.0.2` wheel):

```sh
RUN_DIR=/tmp/gomap_2279_smoke_column_20260604_110307 \
PYTHON=/opt/homebrew/bin/python3.12 \
BACKENDS=treedb_column_graph DOCS=100 DIMS=16 QUERIES=20 \
VALIDATE_QUERIES=4 VALIDATE_DOCS=2 \
TREEDB_COMPACT=true TREEDB_REQUIRE_VALUE_LOG_BYTES=false \
TREEDB_REQUIRE_LEAF_VLOG_BYTES=false \
scripts/bench_vector_db_compare.sh
# PASS; wrote /tmp/gomap_2279_smoke_column_20260604_110307/comparison.md
```

TreeDB quantized_only smoke:

```sh
RUN_DIR=/tmp/gomap_2279_smoke_quantized_20260604_110326 \
PYTHON=/opt/homebrew/bin/python3.12 \
BACKENDS=treedb_column_graph_quantized_only DOCS=100 DIMS=16 QUERIES=20 \
VALIDATE_QUERIES=4 VALIDATE_DOCS=2 \
TREEDB_COMPACT=true TREEDB_REQUIRE_VALUE_LOG_BYTES=false \
TREEDB_REQUIRE_LEAF_VLOG_BYTES=false \
TREEDB_QUANTIZED_INDEX_NAME=embedding.scalar_u8.fast \
scripts/bench_vector_db_compare.sh
# PASS; wrote /tmp/gomap_2279_smoke_quantized_20260604_110326/comparison.md
```

All-knobs passthrough smoke:

```sh
RUN_DIR=/tmp/gomap_2279_smoke_allknobs_20260604_110400 \
PYTHON=/opt/homebrew/bin/python3.12 \
BACKENDS=treedb DOCS=40 DIMS=8 QUERIES=8 VALIDATE_QUERIES=2 VALIDATE_DOCS=1 \
TREEDB_COMPACT=true TREEDB_COMPACT_SYNC_EACH_PHASE=true \
TREEDB_VALUE_POINTER_THRESHOLD=1 TREEDB_LEAF_GENERATION_SEGMENT_TARGET=65536 \
TREEDB_REQUIRE_VALUE_LOG_BYTES=false TREEDB_REQUIRE_LEAF_VLOG_BYTES=false \
scripts/bench_vector_db_compare.sh
# PASS; JSON confirms validate_docs=1, compact=true, compact_sync_each_phase=true,
# value_pointer_threshold=1, leaf_generation_segment_target=65536, and requirement flags=false.
```

Artifacts:

- `/tmp/gomap_2279_smoke_column_20260604_110307/README.md`
- `/tmp/gomap_2279_smoke_column_20260604_110307/comparison.md`
- `/tmp/gomap_2279_smoke_quantized_20260604_110326/README.md`
- `/tmp/gomap_2279_smoke_quantized_20260604_110326/comparison.md`
- `/tmp/gomap_2279_smoke_allknobs_20260604_110400/README.md`
- `/tmp/gomap_2279_smoke_allknobs_20260604_110400/comparison.md`

## CI / review status

- Latest-head CI: green for head `2e4cf2009b76afa402ab83e84bd26f485676a8fd`; `mergeStateStatus=CLEAN`.
- Internal self-review: complete; diff is script/docs-only and scoped to TreeDB harness args.
- Codex: requested after mature PR; reported no major issues.
- Copilot: requested after mature PR; no findings received as of latest check.
- CodeRabbit: requested after mature PR; repo status is success/review skipped, with a rate-limit/usage-credit notice and no review threads.
- Review threads: 0 open threads.

## Non-goals

- No stale PR #1746 rebase or merge.
- No new TreeDB query modes or quantized codecs.
- No pgvector quantization or pgvector/vectorlite/MongoDB behavior changes.
- No benchmark default changes except exposing `VALIDATE_DOCS` with the previous default value.
