### PR TITLE
docs: refresh collection exhaustive benchmark rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,23 +43,22 @@ Full report, commands, host context, run repeats, and artifact paths:
 
 ### Indexed Collection Insert Workload
 
-Two secondary indexes, latest-main June 3 HST / June 4 UTC rerun, `100000`
+Two secondary indexes, latest-main June 4 HST / June 4 UTC rerun, `100000`
 documents, batch size `16000`, and `command_wal_relaxed` for TreeDB. `docs/sec`
 is the timed insert measurement for the value-log outer-leaf layout. Compacted
-B/doc uses the current high-level `offline_compact` row for TreeDB template-v1
-and SQLite after `VACUUM`; TreeDB JSON awaits the exhaustive compact mode tracked
-in [#2288](https://github.com/snissn/gomap/issues/2288) before it is used as a
-README storage-floor headline.
+B/doc uses the byte-minimized `exhaustive_compact` row for TreeDB template-v1 and
+SQLite after `VACUUM`; TreeDB JSON is omitted from the README compacted-size
+headline until the canonical exhaustive fixture covers that format.
 
 | engine / format | layout | docs/sec | compacted B/doc |
 | --- | --- | ---: | ---: |
-| TreeDB template-v1 | data and index outer leaves in value log | 600,962 | 46.7 |
-| TreeDB JSON | data and index outer leaves in value log | 450,857 | — |
-| SQLite native columns | WAL normal | 344,353 | 156.7 |
-| SQLite JSON | WAL normal | 296,912 | 231.7 |
+| TreeDB template-v1 | data and index outer leaves in value log | 697,350 | 22.8 |
+| TreeDB JSON | data and index outer leaves in value log | 475,511 | — |
+| SQLite native columns | WAL normal | 332,116 | 156.7 |
+| SQLite JSON | WAL normal | 282,885 | 231.7 |
 
 Source:
-[June 3 latest-main two-index insert rerun](docs/benchmarks/collections_insert_two_index_latest_main_2026-06-03.md).
+[June 4 exhaustive-compact two-index insert rerun](docs/benchmarks/collections_insert_two_index_exhaustive_main_2026-06-04.md).
 
 ### Collection Read And Lookup Workload
 
@@ -186,7 +185,7 @@ Current YCSB status and rerun commands:
 
 Collection and engine benchmark runbooks:
 
-- `docs/benchmarks/collections_insert_two_index_latest_main_2026-06-03.md`
+- `docs/benchmarks/collections_insert_two_index_exhaustive_main_2026-06-04.md`
 - `docs/benchmarks/treedb_canonical_benchmark_runbook.md`
 - `docs/benchmarks/collections_canonical_benchmark.md`
 - `cmd/unified_bench/README.md`

--- a/docs/README.md
+++ b/docs/README.md
@@ -48,7 +48,7 @@ Behavioral guarantees for downstream systems (e.g., replication layers).
 - **[TreeDB Canonical Benchmark Runbook](benchmarks/treedb_canonical_benchmark_runbook.md)**: Standard TreeDB engine, collections, Mongo gateway, profiling, and reporting workflows.
 - **[YCSB MongoDB / TreeDB Status](benchmarks/ycsb_mongodb_treedb_current.md)**: Current report index and rerun plan for MongoDB, `treedb-native`, and TreeDB Mongo gateway.
 - **[TreeDB Collections Canonical Benchmark](benchmarks/collections_canonical_benchmark.md)**: Canonical TreeDB-vs-SQLite collection benchmark and maintenance-phase semantics.
-- **[Two-Index Collection Insert Rerun](benchmarks/collections_insert_two_index_latest_main_2026-06-03.md)**: Current TreeDB-vs-SQLite two-index insert throughput and compacted storage rows.
+- **[Two-Index Collection Insert Rerun](benchmarks/collections_insert_two_index_exhaustive_main_2026-06-04.md)**: Current TreeDB-vs-SQLite two-index insert throughput and exhaustive/VACUUM-equivalent compacted storage rows.
 - **[Unified Bench](../cmd/unified_bench/README.md)**: Usage guide for benchmark execution and artifact capture.
 - **[BenchProf](../cmd/benchprof/README.md)**: Analysis tool for CPU/alloc/block/mutex profiles and ops/sec outputs.
 - **[Redis Protocol Benchmarking](REDIS_PROTOCOL_BENCHMARKING.md)**: Preferred way to measure Redis wrapper throughput.

--- a/docs/benchmarks/collections_canonical_benchmark.md
+++ b/docs/benchmarks/collections_canonical_benchmark.md
@@ -31,7 +31,8 @@ another location such as `$TMPDIR` on macOS) and writes:
 - `benchmark_summary.md`: human-readable report.
 - `benchmark_matrix.csv`: flat table for spreadsheet/diff tooling.
 - `timed_matrix/`: existing timed TreeDB/SQLite benchmark matrix artifacts.
-- `offline_compact/`: high-level TreeDB compaction artifacts.
+- `offline_compact/`: production high-level TreeDB compaction artifacts.
+- `exhaustive_compact/`: byte-minimized high-level TreeDB compaction artifacts.
 - `full_leafgen_pack_gc/`: full leaf-generation pack/GC fixture artifacts.
 
 Use `-out-dir <dir>` to keep a specific run directory:
@@ -100,7 +101,8 @@ byte-minimized storage-floor claims.
 `sqlite_vacuum`
 
 SQLite compacted baseline after `VACUUM`. This is the required SQLite baseline
-when comparing against TreeDB `offline_compact` or `full_leafgen_pack_gc`.
+when comparing against TreeDB `exhaustive_compact`, `offline_compact`, or
+`full_leafgen_pack_gc`.
 
 ## Fair Comparisons
 
@@ -111,13 +113,14 @@ Fair post-insert comparison:
 
 Fair compacted-state comparison:
 
-- TreeDB `offline_compact`
-- TreeDB `full_leafgen_pack_gc`
+- TreeDB `exhaustive_compact` for byte-minimized/VACUUM-equivalent public storage-floor claims
+- TreeDB `offline_compact` for production policy compaction comparisons
+- TreeDB `full_leafgen_pack_gc` as a diagnostic maintenance primitive
 - SQLite `sqlite_vacuum`
 
-Do not compare TreeDB fully compacted rows only against SQLite post-insert rows.
-The generated report includes guardrail checks for missing SQLite VACUUM rows
-and labels `online_one_pass_maintenance` as partial maintenance.
+Do not compare TreeDB compacted rows only against SQLite post-insert rows. The
+generated report includes guardrail checks for missing SQLite VACUUM rows and
+labels `online_one_pass_maintenance` as partial maintenance.
 
 ## Default Shape
 
@@ -126,8 +129,8 @@ The default run uses:
 - 100,000 documents
 - batch size 16,000
 - two secondary indexes for the primary TreeDB/SQLite comparison
-- TreeDB collection benchmark engine `production_wal_on_fast`
-- raw TreeDB compaction/profile fixtures remain on profile `fast`
+- TreeDB collection benchmark engine `command_wal_relaxed`
+- raw TreeDB compaction/profile fixtures remain on profile `command_wal_relaxed`
 - TreeDB document formats `template-v1`, `bson`, and `json`
 - SQLite JSON and SQLite native-column baselines
 - full leafgen pack/GC with:
@@ -201,13 +204,19 @@ missing, the guardrail checks report an error because B/doc would be ambiguous.
 The canonical report can represent the PR 1096-style finding without hardcoding
 it as production output:
 
-- offline rewrite:
-  - raw TreeDB template-v1: about 19.8 B/doc
-  - collection, 0 indexes: about 19.5 B/doc
-  - collection, 1 index: about 37.5 B/doc
-  - collection, 2 indexes: about 44.3 B/doc
+- production offline compact:
+  - raw TreeDB template-v1: about 25.7 B/doc
+  - collection, 0 indexes: about 22.1 B/doc
+  - collection, 1 index: about 34.4 B/doc
+  - collection, 2 indexes: about 46.7 B/doc
+- exhaustive compact:
+  - raw TreeDB template-v1: about 15.8 B/doc
+  - collection, 0 indexes: about 15.5 B/doc
+  - collection, 1 index: about 20.2 B/doc
+  - collection, 2 indexes: about 22.8 B/doc
 - full leafgen pack/GC:
-  - collection template-v1, 2 indexes: about 31.7 B/doc
+  - collection template-v1, 2 indexes: about 27.8 B/doc
+  - collection JSON, 2 indexes: about 33.7 B/doc
 - SQLite after `VACUUM`:
   - JSON: about 231.7 B/doc
   - native columns: about 156.7 B/doc

--- a/docs/benchmarks/collections_insert_two_index_exhaustive_main_2026-06-04.md
+++ b/docs/benchmarks/collections_insert_two_index_exhaustive_main_2026-06-04.md
@@ -1,0 +1,120 @@
+# Two-Index Collection Insert Exhaustive-Compact Rerun
+
+Date: 2026-06-04 HST / 2026-06-04 UTC
+
+This rerun refreshes the README two-index collection insert rows after the
+canonical benchmark learned an explicit `exhaustive_compact` phase. It uses the
+same primary shape as the June 3 latest-main report, but the public TreeDB
+compacted-size headline now comes from the byte-minimized/VACUUM-equivalent
+`treemap compact <dir> -rw -mode exhaustive` row rather than the production
+`offline_compact` row or lower-level leaf-generation diagnostics.
+
+These are developer-machine results. Treat them as current local engineering
+evidence, not a formal product benchmark.
+
+## Command
+
+```sh
+OUT=/tmp/collections_exhaustive_main_$(date +%Y%m%d_%H%M%S)
+mkdir -p "$OUT"
+GOWORK=off USE_BUILT_BIN=1 ./scripts/bench_collections_canonical.sh \
+  -out-dir "$OUT" \
+  -formats template-v1,json \
+  -indexes 2 \
+  -docs 100000 \
+  -batch-size 16000 \
+  -count 1 \
+  2>&1 | tee "$OUT.stdout.log"
+```
+
+Measured run:
+
+```text
+/tmp/collections_exhaustive_main_20260604_113639
+```
+
+Measured code:
+
+```text
+branch: main
+commit: d64a06b8e710
+```
+
+Host context:
+
+```text
+OS: Linux mikers-B560-DS3H-AC-Y1 6.8.0-111-generic x86_64
+CPU: 11th Gen Intel(R) Core(TM) i5-11400F @ 2.60GHz, 6 cores / 12 threads
+Go: go1.25.7 linux/amd64
+```
+
+Generated artifacts:
+
+- `/tmp/collections_exhaustive_main_20260604_113639/benchmark_summary.md`
+- `/tmp/collections_exhaustive_main_20260604_113639/benchmark_results.json`
+- `/tmp/collections_exhaustive_main_20260604_113639/benchmark_matrix.csv`
+- `/tmp/collections_exhaustive_main_20260604_113639/timed_matrix/collections_matrix_summary.md`
+- `/tmp/collections_exhaustive_main_20260604_113639/offline_compact/compression_matrix.tsv`
+- `/tmp/collections_exhaustive_main_20260604_113639/exhaustive_compact/compression_matrix.tsv`
+
+## Timed Insert Rows
+
+These rows are benchmark-timed post-insert measurements for two secondary
+indexes, `100000` documents, batch size `16000`, and `command_wal_relaxed` for
+TreeDB. The B/doc column in this section is the post-insert footprint after the
+benchmark flush or checkpoint. It is not a compacted-state number.
+
+The canonical runner uses `storage-cells=index-vlog`, which is the TreeDB layout
+that writes data and index outer leaves to the value log.
+
+| engine / format | layout | ns/doc | docs/sec | post-insert B/doc |
+| --- | --- | ---: | ---: | ---: |
+| TreeDB template-v1 | data and index outer leaves in value log | 1,434 | 697,350 | 211.6 |
+| TreeDB JSON | data and index outer leaves in value log | 2,103 | 475,511 | 224.5 |
+| SQLite native columns | WAL normal | 3,011 | 332,116 | 176.1 |
+| SQLite JSON | WAL normal | 3,535 | 282,885 | 262.6 |
+
+## Compacted Storage Rows
+
+These rows separate production compaction, byte-minimized compaction, and
+lower-level diagnostics. README compacted-size claims should use
+`exhaustive_compact` for TreeDB template-v1 and SQLite `VACUUM` for SQLite.
+TreeDB JSON is still omitted from the README compacted-size headline because the
+canonical exhaustive offline fixture currently covers template-v1 rows; the JSON
+`full_leafgen_pack_gc` row below remains diagnostic only.
+
+| engine / format | phase | B/doc | comparison basis | README headline? |
+| --- | --- | ---: | --- | --- |
+| TreeDB template-v1 | `exhaustive_compact` | 22.8 | byte-minimized `treemap compact <dir> -rw -mode exhaustive` | yes |
+| TreeDB template-v1 | `offline_compact` | 46.7 | production `treemap compact <dir> -rw -mode full` | no |
+| TreeDB template-v1 | `full_leafgen_pack_gc` | 27.8 | diagnostic full leaf generation pack/GC plus offline index vacuum | no |
+| TreeDB JSON | `full_leafgen_pack_gc` | 33.7 | diagnostic full leaf generation pack/GC plus offline index vacuum | no |
+| SQLite native columns | `sqlite_vacuum` | 156.7 | SQLite `VACUUM` | yes |
+| SQLite JSON | `sqlite_vacuum` | 231.7 | SQLite `VACUUM` | yes |
+
+Derived comparison ratios from `benchmark_results.json`:
+
+| TreeDB row | vs SQLite native columns after `VACUUM` | vs SQLite JSON after `VACUUM` | README headline? |
+| --- | ---: | ---: | --- |
+| template-v1 `exhaustive_compact` | 6.9x smaller | 10.2x smaller | yes |
+| template-v1 `offline_compact` | 3.4x smaller | 5.0x smaller | no, production compaction row |
+| template-v1 `full_leafgen_pack_gc` | 5.6x smaller | 8.3x smaller | no, diagnostic only |
+| JSON `full_leafgen_pack_gc` | 4.7x smaller | 6.9x smaller | no, diagnostic only |
+
+## Comparison With June 3 Latest-Main Report
+
+Previous checked-in report:
+`docs/benchmarks/collections_insert_two_index_latest_main_2026-06-03.md`.
+
+| engine / format | previous docs/sec | current docs/sec | docs/sec delta | previous README compacted B/doc | current README compacted B/doc | B/doc delta |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| TreeDB template-v1 | 600,962 | 697,350 | +16.0% | 46.7 (`offline_compact`) | 22.8 (`exhaustive_compact`) | -51.2% |
+| TreeDB JSON | 450,857 | 475,511 | +5.5% | — | — | — |
+| SQLite native columns | 344,353 | 332,116 | -3.6% | 156.7 | 156.7 | +0.0% |
+| SQLite JSON | 296,912 | 282,885 | -4.7% | 231.7 | 231.7 | +0.0% |
+
+The main storage change is the comparison contract: the TreeDB template-v1
+README compacted row now uses an explicit byte-minimized high-level compaction
+mode. The older `offline_compact` number remains useful as the production
+compaction point, and `full_leafgen_pack_gc` remains useful for diagnosing leaf
+log packing behavior, but neither is the public storage-floor headline.


### PR DESCRIPTION
## Summary

- Refresh README/docs indexed-collection insert rows from the June 4 canonical rerun on latest `main`.
- Add a dated benchmark report with the new `exhaustive_compact` storage-floor row and artifact paths.
- Update the canonical collection benchmark docs so `exhaustive_compact` is the byte-minimized/VACUUM-equivalent public comparison basis while `offline_compact` and `full_leafgen_pack_gc` remain production/diagnostic rows.

Closes #2292.
Parent tracker: #2288.
Depends on: #2291 (merged via #2305 / d64a06b8e710).

## Benchmark evidence

Command:

```sh
OUT=/tmp/collections_exhaustive_main_$(date +%Y%m%d_%H%M%S)
mkdir -p "$OUT"
GOWORK=off USE_BUILT_BIN=1 ./scripts/bench_collections_canonical.sh \
  -out-dir "$OUT" \
  -formats template-v1,json \
  -indexes 2 \
  -docs 100000 \
  -batch-size 16000 \
  -count 1 \
  2>&1 | tee "$OUT.stdout.log"
```

Artifacts:

- `/tmp/collections_exhaustive_main_20260604_113639/benchmark_summary.md`
- `/tmp/collections_exhaustive_main_20260604_113639/benchmark_results.json`
- `/tmp/collections_exhaustive_main_20260604_113639/benchmark_matrix.csv`
- `/tmp/collections_exhaustive_main_20260604_113639/exhaustive_compact/compression_matrix.tsv`

Headline rows:

- TreeDB template-v1 two-index insert: `697,350 docs/sec`, `22.8 B/doc` after `exhaustive_compact`.
- TreeDB JSON two-index insert: `475,511 docs/sec`, compacted README headline remains `—` because canonical exhaustive coverage currently covers template-v1.
- SQLite native columns: `332,116 docs/sec`, `156.7 B/doc` after `VACUUM`.
- SQLite JSON: `282,885 docs/sec`, `231.7 B/doc` after `VACUUM`.

## Validation

- `git diff --check`
- Full benchmark command above completed successfully.
