### PR TITLE
TreeDB HNSW search-pack baseline counters

### DIFF
--- a/TreeDB/collections/vector_index_search.go
+++ b/TreeDB/collections/vector_index_search.go
@@ -396,6 +396,25 @@ type VectorIndexSearchStats struct {
 	// GraphRowFallbacks aggregates compatibility graph-row reads/fallbacks observed during vector/norm/adjacency/result materialization.
 	GraphRowFallbacks uint64 `json:"graph_row_fallbacks,omitempty"`
 
+	// SearchRouteColumnGraphPrepared reports that this search used the current prepared column_graph route.
+	SearchRouteColumnGraphPrepared uint64 `json:"search_route_column_graph_prepared,omitempty"`
+	// SearchRouteColumnGraphFallback reports that this search used the column_graph compatibility/fallback route instead of the prepared route.
+	SearchRouteColumnGraphFallback uint64 `json:"search_route_column_graph_fallback,omitempty"`
+	// SearchRouteHNSWSearchPack reports that this search used the future hnsw_search_pack_v1 route.
+	SearchRouteHNSWSearchPack uint64 `json:"search_route_hnsw_search_pack,omitempty"`
+	// HNSWSearchPackActive reports that a validated hnsw_search_pack_v1 served this search.
+	HNSWSearchPackActive uint64 `json:"hnsw_search_pack_active,omitempty"`
+	// HNSWSearchPackMissing reports that no hnsw_search_pack_v1 was available for this searcher.
+	HNSWSearchPackMissing uint64 `json:"hnsw_search_pack_missing,omitempty"`
+	// HNSWSearchPackInvalid reports that a hnsw_search_pack_v1 candidate was present but failed validation.
+	HNSWSearchPackInvalid uint64 `json:"hnsw_search_pack_invalid,omitempty"`
+	// HNSWSearchPackFallbacks reports searches that fell back from hnsw_search_pack_v1 to an existing route.
+	HNSWSearchPackFallbacks uint64 `json:"hnsw_search_pack_fallbacks,omitempty"`
+	// HNSWSearchPackMmapDirect reports searches served from a direct mmap hnsw_search_pack_v1 view.
+	HNSWSearchPackMmapDirect uint64 `json:"hnsw_search_pack_mmap_direct,omitempty"`
+	// HNSWSearchPackHeapCopy reports searches served from a heap-copy hnsw_search_pack_v1 view.
+	HNSWSearchPackHeapCopy uint64 `json:"hnsw_search_pack_heap_copy,omitempty"`
+
 	// BenchmarkDebugSearches reports searches collected with benchmark_debug graph-control-flow instrumentation.
 	BenchmarkDebugSearches uint64 `json:"benchmark_debug_searches,omitempty"`
 	// NeighborTiles counts expanded adjacency neighbor tiles.
@@ -549,7 +568,45 @@ type VectorIndexSearcher struct {
 	documentView *CollectionReadView
 	scratch      columnVectorGraphNativeSearchScratch
 	readerLast   columnPhysicalRowReaderStats
+	routeStats   vectorIndexSearchRouteStats
 	closed       bool
+}
+
+type vectorIndexSearchRouteStats struct {
+	SearchRouteColumnGraphPrepared uint64
+	SearchRouteColumnGraphFallback uint64
+	SearchRouteHNSWSearchPack      uint64
+	HNSWSearchPackActive           uint64
+	HNSWSearchPackMissing          uint64
+	HNSWSearchPackInvalid          uint64
+	HNSWSearchPackFallbacks        uint64
+	HNSWSearchPackMmapDirect       uint64
+	HNSWSearchPackHeapCopy         uint64
+}
+
+func vectorIndexSearchRouteStatsForColumnGraphReader(reader *columnVectorGraphPhysicalRowReader) vectorIndexSearchRouteStats {
+	stats := vectorIndexSearchRouteStats{HNSWSearchPackMissing: 1}
+	if reader != nil && reader.preparedSearch != nil && reader.preparedSearch.ready() {
+		stats.SearchRouteColumnGraphPrepared = 1
+		return stats
+	}
+	stats.SearchRouteColumnGraphFallback = 1
+	return stats
+}
+
+func (r vectorIndexSearchRouteStats) apply(stats *VectorIndexSearchStats) {
+	if stats == nil {
+		return
+	}
+	stats.SearchRouteColumnGraphPrepared = r.SearchRouteColumnGraphPrepared
+	stats.SearchRouteColumnGraphFallback = r.SearchRouteColumnGraphFallback
+	stats.SearchRouteHNSWSearchPack = r.SearchRouteHNSWSearchPack
+	stats.HNSWSearchPackActive = r.HNSWSearchPackActive
+	stats.HNSWSearchPackMissing = r.HNSWSearchPackMissing
+	stats.HNSWSearchPackInvalid = r.HNSWSearchPackInvalid
+	stats.HNSWSearchPackFallbacks = r.HNSWSearchPackFallbacks
+	stats.HNSWSearchPackMmapDirect = r.HNSWSearchPackMmapDirect
+	stats.HNSWSearchPackHeapCopy = r.HNSWSearchPackHeapCopy
 }
 
 // SearchVectorIndex searches a collection vector index through the public
@@ -705,6 +762,7 @@ func (c *Collection) openVectorIndexSearcher(opts VectorIndexSearcherOptions) (*
 		catalog:    readerCatalog,
 		reader:     reader,
 		readerLast: reader.Stats(),
+		routeStats: vectorIndexSearchRouteStatsForColumnGraphReader(reader),
 	}
 	closeOnErr = false
 	return searcher, response, nil
@@ -768,6 +826,7 @@ func (s *VectorIndexSearcher) Search(opts VectorIndexSearcherSearchOptions) (Vec
 	s.readerLast = readerStatsAfter
 	readerStats := columnPhysicalRowReaderStatsDelta(readerStatsBefore, readerStatsAfter)
 	response.Stats = vectorIndexSearchStatsFromInternal(searchStats, readerStats)
+	s.routeStats.apply(&response.Stats)
 	if err != nil {
 		return response, err
 	}
@@ -933,6 +992,7 @@ func (s *VectorIndexSearcher) SearchWithBuffer(opts VectorIndexSearcherSearchOpt
 	s.readerLast = readerStatsAfter
 	readerStats := columnPhysicalRowReaderStatsDelta(readerStatsBefore, readerStatsAfter)
 	response.Stats = vectorIndexSearchStatsFromInternal(searchStats, readerStats)
+	s.routeStats.apply(&response.Stats)
 	if err != nil {
 		clear(previousResults)
 		return response, err

--- a/TreeDB/collections/vector_index_search_test.go
+++ b/TreeDB/collections/vector_index_search_test.go
@@ -1028,14 +1028,17 @@ func TestVectorIndexSearcherSearchWithBufferRouteStatsAndNoDocumentBoundary2311(
 		t.Fatalf("path=%q want current column_graph native-reader route", got.Path)
 	}
 	stats := got.Stats
-	if stats.SearchRouteColumnGraphPrepared != 1 || stats.SearchRouteColumnGraphFallback != 0 || stats.SearchRouteHNSWSearchPack != 0 {
-		t.Fatalf("route stats=%+v want current prepared column_graph route only", stats)
+	if stats.SearchRouteHNSWSearchPack != 0 || stats.SearchRouteColumnGraphPrepared+stats.SearchRouteColumnGraphFallback != 1 {
+		t.Fatalf("route stats=%+v want exactly one current column_graph route and no search-pack route", stats)
 	}
 	if stats.HNSWSearchPackActive != 0 || stats.HNSWSearchPackMissing != 1 || stats.HNSWSearchPackInvalid != 0 || stats.HNSWSearchPackFallbacks != 0 || stats.HNSWSearchPackMmapDirect != 0 || stats.HNSWSearchPackHeapCopy != 0 {
 		t.Fatalf("pack stats=%+v want hnsw_search_pack_v1 absent and inactive in #2311 baseline", stats)
 	}
-	if stats.PreparedGraphSearchViews != 1 || stats.GraphRows != 0 || stats.GraphRowFallbacks != 0 {
-		t.Fatalf("graph route stats=%+v want prepared current-format route without graph-row fallback", stats)
+	if stats.SearchRouteColumnGraphPrepared == 1 && stats.PreparedGraphSearchViews == 0 {
+		t.Fatalf("graph route stats=%+v want prepared-route views when prepared route is active", stats)
+	}
+	if stats.GraphRows != 0 || stats.GraphRowFallbacks != 0 {
+		t.Fatalf("graph route stats=%+v want current-format route without graph-row fallback", stats)
 	}
 	if stats.DocumentsFetched != 0 || stats.DocumentsMissing != 0 || stats.DocumentBytes != 0 || stats.DocumentOutputBytes != 0 || stats.DocumentFieldsReconstructed != 0 {
 		t.Fatalf("document boundary stats=%+v want no document materialization for SearchWithBuffer", stats)
@@ -1051,11 +1054,13 @@ func TestVectorIndexSearcherSearchWithBufferRouteStatsAndNoDocumentBoundary2311(
 	if stats.ScoreBatchCalls == 0 || stats.ScoreBatchCandidates == 0 || stats.ScoreBatchOptimizedCalls+stats.ScoreBatchScalarFallbackCalls == 0 {
 		t.Fatalf("score-batch counters=%+v want score batch mode/fallback evidence", stats)
 	}
-	if stats.VectorMmapDirectViews == 0 || stats.VectorHeapCopyTypedViews != 0 || stats.VectorScratchDecodes != 0 {
-		t.Fatalf("vector source stats=%+v want mmap-direct typed-column source without heap/scratch fallback", stats)
+	vectorTypedSourceViews := stats.VectorDirectViews + stats.VectorMmapDirectViews + stats.VectorPreparedDirectViews + stats.VectorHeapCopyTypedViews
+	if vectorTypedSourceViews == 0 || stats.VectorScratchDecodes != 0 {
+		t.Fatalf("vector source stats=%+v want typed-column vector source without scratch fallback", stats)
 	}
-	if stats.AdjacencyPreparedCSRMmapDirectViews == 0 || stats.AdjacencyHeapCopyTypedViews != 0 || stats.AdjacencyScratchDecodes != 0 {
-		t.Fatalf("adjacency source stats=%+v want prepared CSR mmap source without heap/scratch fallback", stats)
+	adjacencyTypedSourceViews := stats.AdjacencyPreparedCSRDirectViews + stats.AdjacencyPreparedCSRMmapDirectViews + stats.AdjacencyTypedListDirectViews + stats.AdjacencyTypedListMmapDirectViews + stats.AdjacencyTypedListHeapCopyTypedViews
+	if adjacencyTypedSourceViews == 0 || stats.AdjacencyScratchDecodes != 0 || stats.AdjacencyLegacyFallbacks != 0 || stats.AdjacencySourceFallbacks != 0 {
+		t.Fatalf("adjacency source stats=%+v want typed-column adjacency source without legacy/scratch fallback", stats)
 	}
 	if stats.ResultIDTypedBytesState == 0 || stats.RowRefStateResultRefs == 0 || stats.ResultIDGraphFallbacks != 0 {
 		t.Fatalf("identity stats=%+v want vector-index row-ref/document-id state without graph-row fallback", stats)
@@ -1930,8 +1935,8 @@ func assertVectorIndexSearchResultIDStatsContract2124(tb testing.TB, got, want V
 	if got.GraphRows != 0 || got.ResultIDGraphFallbacks != 0 || got.GraphRowFallbacks != 0 || got.VectorScratchDecodes != 0 || got.NormScratchDecodes != 0 || got.AdjacencyScratchDecodes != 0 || got.TypedColumnFallbacks != 0 {
 		tb.Fatalf("stats=%+v want healthy typed-column result-ID path without graph-row/scratch fallbacks", got)
 	}
-	if got.SearchRouteColumnGraphPrepared != 1 || got.SearchRouteColumnGraphFallback != 0 || got.SearchRouteHNSWSearchPack != 0 {
-		tb.Fatalf("stats=%+v want current prepared column_graph route identity", got)
+	if got.SearchRouteHNSWSearchPack != 0 || got.SearchRouteColumnGraphPrepared+got.SearchRouteColumnGraphFallback != 1 {
+		tb.Fatalf("stats=%+v want exactly one current column_graph route and no search-pack route", got)
 	}
 	if got.HNSWSearchPackActive != 0 || got.HNSWSearchPackMissing != 1 || got.HNSWSearchPackInvalid != 0 || got.HNSWSearchPackFallbacks != 0 || got.HNSWSearchPackMmapDirect != 0 || got.HNSWSearchPackHeapCopy != 0 {
 		tb.Fatalf("stats=%+v want hnsw_search_pack_v1 absent/inactive baseline", got)

--- a/TreeDB/collections/vector_index_search_test.go
+++ b/TreeDB/collections/vector_index_search_test.go
@@ -994,6 +994,74 @@ func TestVectorIndexSearcherSearchWithBufferResultEquivalenceAndZeroAllocs2124(t
 	}
 }
 
+func TestVectorIndexSearcherSearchWithBufferRouteStatsAndNoDocumentBoundary2311(t *testing.T) {
+	rows := []columnGraphRebuildInputRowV2A{
+		{id: "doc-a", vector: []float32{1, 0, 0}},
+		{id: "doc-b", vector: []float32{0, 1, 0}},
+		{id: "doc-c", vector: []float32{0, 0, 1}},
+		{id: "doc-d", vector: []float32{0.7, 0.3, 0}},
+		{id: "doc-e", vector: []float32{0.4, 0.6, 0}},
+	}
+	_, d, col, def := openColumnGraphRebuildTestCollectionV2A(t, 3, 3, rows)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	searcher, err := col.OpenVectorIndexSearcher(VectorIndexSearcherOptions{IndexName: def.Name, MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("OpenVectorIndexSearcher: %v", err)
+	}
+	defer func() { _ = searcher.Close() }()
+
+	var buffer VectorIndexSearchBuffer
+	got, err := searcher.SearchWithBuffer(VectorIndexSearcherSearchOptions{
+		Query:     []float32{0.6, 0.4, 0},
+		TopK:      3,
+		EfSearch:  len(rows),
+		StatsMode: VectorIndexSearchStatsModeFullDiagnostics,
+	}, &buffer)
+	if err != nil {
+		t.Fatalf("SearchWithBuffer: %v", err)
+	}
+	assertColumnGraphSearchResponseLoadedV4(t, got, def.Name, 3)
+	if got.Path != VectorIndexSearchPathColumnGraphNativeReader {
+		t.Fatalf("path=%q want current column_graph native-reader route", got.Path)
+	}
+	stats := got.Stats
+	if stats.SearchRouteColumnGraphPrepared != 1 || stats.SearchRouteColumnGraphFallback != 0 || stats.SearchRouteHNSWSearchPack != 0 {
+		t.Fatalf("route stats=%+v want current prepared column_graph route only", stats)
+	}
+	if stats.HNSWSearchPackActive != 0 || stats.HNSWSearchPackMissing != 1 || stats.HNSWSearchPackInvalid != 0 || stats.HNSWSearchPackFallbacks != 0 || stats.HNSWSearchPackMmapDirect != 0 || stats.HNSWSearchPackHeapCopy != 0 {
+		t.Fatalf("pack stats=%+v want hnsw_search_pack_v1 absent and inactive in #2311 baseline", stats)
+	}
+	if stats.PreparedGraphSearchViews != 1 || stats.GraphRows != 0 || stats.GraphRowFallbacks != 0 {
+		t.Fatalf("graph route stats=%+v want prepared current-format route without graph-row fallback", stats)
+	}
+	if stats.DocumentsFetched != 0 || stats.DocumentsMissing != 0 || stats.DocumentBytes != 0 || stats.DocumentOutputBytes != 0 || stats.DocumentFieldsReconstructed != 0 {
+		t.Fatalf("document boundary stats=%+v want no document materialization for SearchWithBuffer", stats)
+	}
+	for i, result := range got.Results {
+		if len(result.Document) != 0 {
+			t.Fatalf("result[%d] materialized document len=%d want no-document boundary", i, len(result.Document))
+		}
+	}
+	if stats.Candidates == 0 || stats.VisitedNodes == 0 || stats.VisitedEdges == 0 || stats.VectorBytesRead == 0 || stats.AdjacencyBytesRead == 0 {
+		t.Fatalf("hot-loop counters=%+v want candidates, visited nodes/edges, vector bytes, adjacency bytes", stats)
+	}
+	if stats.ScoreBatchCalls == 0 || stats.ScoreBatchCandidates == 0 || stats.ScoreBatchOptimizedCalls+stats.ScoreBatchScalarFallbackCalls == 0 {
+		t.Fatalf("score-batch counters=%+v want score batch mode/fallback evidence", stats)
+	}
+	if stats.VectorMmapDirectViews == 0 || stats.VectorHeapCopyTypedViews != 0 || stats.VectorScratchDecodes != 0 {
+		t.Fatalf("vector source stats=%+v want mmap-direct typed-column source without heap/scratch fallback", stats)
+	}
+	if stats.AdjacencyPreparedCSRMmapDirectViews == 0 || stats.AdjacencyHeapCopyTypedViews != 0 || stats.AdjacencyScratchDecodes != 0 {
+		t.Fatalf("adjacency source stats=%+v want prepared CSR mmap source without heap/scratch fallback", stats)
+	}
+	if stats.ResultIDTypedBytesState == 0 || stats.RowRefStateResultRefs == 0 || stats.ResultIDGraphFallbacks != 0 {
+		t.Fatalf("identity stats=%+v want vector-index row-ref/document-id state without graph-row fallback", stats)
+	}
+}
+
 func TestVectorIndexSearcherSearchWithBufferReuseGrowShrinkNoStaleIDs1961(t *testing.T) {
 	rows := []columnGraphRebuildInputRowV2A{
 		{id: "doc-long-a", vector: []float32{1, 0, 0}},
@@ -1836,6 +1904,15 @@ func assertVectorIndexSearchResultIDStatsContract2124(tb testing.TB, got, want V
 		{name: "expansion_fetches", got: got.ExpansionFetches, want: want.ExpansionFetches},
 		{name: "result_fetches", got: got.ResultFetches, want: want.ResultFetches},
 		{name: "prepared_graph_search_views", got: got.PreparedGraphSearchViews, want: want.PreparedGraphSearchViews},
+		{name: "search_route_column_graph_prepared", got: got.SearchRouteColumnGraphPrepared, want: want.SearchRouteColumnGraphPrepared},
+		{name: "search_route_column_graph_fallback", got: got.SearchRouteColumnGraphFallback, want: want.SearchRouteColumnGraphFallback},
+		{name: "search_route_hnsw_search_pack", got: got.SearchRouteHNSWSearchPack, want: want.SearchRouteHNSWSearchPack},
+		{name: "hnsw_search_pack_active", got: got.HNSWSearchPackActive, want: want.HNSWSearchPackActive},
+		{name: "hnsw_search_pack_missing", got: got.HNSWSearchPackMissing, want: want.HNSWSearchPackMissing},
+		{name: "hnsw_search_pack_invalid", got: got.HNSWSearchPackInvalid, want: want.HNSWSearchPackInvalid},
+		{name: "hnsw_search_pack_fallbacks", got: got.HNSWSearchPackFallbacks, want: want.HNSWSearchPackFallbacks},
+		{name: "hnsw_search_pack_mmap_direct", got: got.HNSWSearchPackMmapDirect, want: want.HNSWSearchPackMmapDirect},
+		{name: "hnsw_search_pack_heap_copy", got: got.HNSWSearchPackHeapCopy, want: want.HNSWSearchPackHeapCopy},
 		{name: "result_id_typed_bytes_state", got: got.ResultIDTypedBytesState, want: want.ResultIDTypedBytesState},
 		{name: "result_id_graph_fallbacks", got: got.ResultIDGraphFallbacks, want: want.ResultIDGraphFallbacks},
 		{name: "row_ref_state_result_refs", got: got.RowRefStateResultRefs, want: want.RowRefStateResultRefs},
@@ -1852,6 +1929,12 @@ func assertVectorIndexSearchResultIDStatsContract2124(tb testing.TB, got, want V
 	}
 	if got.GraphRows != 0 || got.ResultIDGraphFallbacks != 0 || got.GraphRowFallbacks != 0 || got.VectorScratchDecodes != 0 || got.NormScratchDecodes != 0 || got.AdjacencyScratchDecodes != 0 || got.TypedColumnFallbacks != 0 {
 		tb.Fatalf("stats=%+v want healthy typed-column result-ID path without graph-row/scratch fallbacks", got)
+	}
+	if got.SearchRouteColumnGraphPrepared != 1 || got.SearchRouteColumnGraphFallback != 0 || got.SearchRouteHNSWSearchPack != 0 {
+		tb.Fatalf("stats=%+v want current prepared column_graph route identity", got)
+	}
+	if got.HNSWSearchPackActive != 0 || got.HNSWSearchPackMissing != 1 || got.HNSWSearchPackInvalid != 0 || got.HNSWSearchPackFallbacks != 0 || got.HNSWSearchPackMmapDirect != 0 || got.HNSWSearchPackHeapCopy != 0 {
+		tb.Fatalf("stats=%+v want hnsw_search_pack_v1 absent/inactive baseline", got)
 	}
 	if got.ResultIDTypedBytesState == 0 || got.ResultIDPreparedBytesViews == 0 || got.RowRefVectorSourceState == 0 {
 		tb.Fatalf("stats=%+v want typed-column result-ID and row-ref state", got)
@@ -2956,6 +3039,25 @@ func reportVectorIndexSearchBenchMetricsV4(b *testing.B, n int, stats VectorInde
 	b.ReportMetric(float64(stats.ResultIDStateValidationFailures), "result_id_state_validation_failures/search")
 	b.ReportMetric(float64(stats.PreparedGraphSearchViews), "prepared_graph_search_views/search")
 	b.ReportMetric(float64(stats.GraphRowFallbacks), "graph_row_fallbacks/search")
+	b.ReportMetric(float64(stats.SearchRouteColumnGraphPrepared), "search_route_column_graph_prepared/search")
+	b.ReportMetric(float64(stats.SearchRouteColumnGraphFallback), "search_route_column_graph_fallback/search")
+	b.ReportMetric(float64(stats.SearchRouteHNSWSearchPack), "search_route_hnsw_search_pack/search")
+	b.ReportMetric(float64(stats.HNSWSearchPackActive), "hnsw_search_pack_active/search")
+	b.ReportMetric(float64(stats.HNSWSearchPackMissing), "hnsw_search_pack_missing/search")
+	b.ReportMetric(float64(stats.HNSWSearchPackInvalid), "hnsw_search_pack_invalid/search")
+	b.ReportMetric(float64(stats.HNSWSearchPackFallbacks), "hnsw_search_pack_fallbacks/search")
+	b.ReportMetric(float64(stats.HNSWSearchPackMmapDirect), "hnsw_search_pack_mmap_direct/search")
+	b.ReportMetric(float64(stats.HNSWSearchPackHeapCopy), "hnsw_search_pack_heap_copy/search")
+	scoreBatchFallbackReasonScalar := 0.0
+	if stats.ScoreBatchScalarFallbackCalls > 0 {
+		scoreBatchFallbackReasonScalar = 1
+	}
+	b.ReportMetric(scoreBatchFallbackReasonScalar, "score_batch_fallback_reason_scalar")
+	scoreBatchFallbackReasonNone := 0.0
+	if stats.ScoreBatchCalls > 0 && stats.ScoreBatchScalarFallbackCalls == 0 {
+		scoreBatchFallbackReasonNone = 1
+	}
+	b.ReportMetric(scoreBatchFallbackReasonNone, "score_batch_fallback_reason_none")
 	b.ReportMetric(float64(stats.RowFetches), "row_fetches/search")
 	b.ReportMetric(float64(stats.BatchFetches), "batch_fetches/search")
 	b.ReportMetric(float64(stats.RowsFetched), "rows_fetched/search")

--- a/scripts/bench_vector_search_compare.sh
+++ b/scripts/bench_vector_search_compare.sh
@@ -174,7 +174,14 @@ Canonical current production comparison:
   The script emits a separate \`## search benchmarks cpu=<n>\` block for each
   requested concurrency so worker counts stay unambiguous.
   The timed loop uses production stats mode; a full-diagnostics sample is taken
-  outside the timed loop to report candidates/search and edge counters.
+  outside the timed loop to report candidates/search and edge counters. TreeDB
+  rows also report route/search-pack guardrails such as
+  \`search_route_column_graph_prepared/search\`,
+  \`hnsw_search_pack_active/search\`,
+  \`hnsw_search_pack_missing/search\`, \`docs_fetched/search\`,
+  \`graph_row_fallbacks/search\`, score-batch fallback reason flags,
+  vector/adjacency source-state counters, and candidate/visited-edge byte
+  counters used by the HNSW search-pack stack.
 - \`.../USearch_Search\` and \`.../USearch_SearchParallel\` time the pure
   in-memory USearch Go binding baseline with cosine/f32 HNSW and the same
   synthetic vector/query generator, M, efConstruction, efSearch, topK, docs,


### PR DESCRIPTION
## Objective

Establish #2311 baseline route/counter guardrails for the TreeDB HNSW search-pack stack without implementing or routing through `hnsw_search_pack_v1`.

Fixes #2311. Parent tracker: #2309.

## Context

Later PRs need a stable benchmark/stat contract before adding the pack format, writer, reader, and production route. This PR makes the current production no-document `VectorIndexSearcher.SearchWithBuffer` route explicit in public stats and benchmark output.

## Non-goals

- No `hnsw_search_pack_v1` format, writer, reader, mmap view, or search route.
- No HNSW graph semantics/tuning changes (`M`, `M0`, pruning, insertion order, `efSearch`, recall behavior unchanged).
- No public vector search semantic changes.

## Design / Counter Contract

- Adds additive `VectorIndexSearchStats` route/pack counters:
  - `search_route_column_graph_prepared`, `search_route_column_graph_fallback`, `search_route_hnsw_search_pack`
  - `hnsw_search_pack_active`, `hnsw_search_pack_missing`, `hnsw_search_pack_invalid`, `hnsw_search_pack_fallbacks`, `hnsw_search_pack_mmap_direct`, `hnsw_search_pack_heap_copy`
- Current baseline reports exactly one current `column_graph` route per search:
  - `search_route_column_graph_prepared=1` on mmap/prepared-view capable hosts;
  - `search_route_column_graph_fallback=1` on hosts where prepared mmap views are unavailable, e.g. Windows test runners.
- Current baseline reports no search-pack route and pack absent/inactive:
  - `search_route_hnsw_search_pack=0`
  - `hnsw_search_pack_active=0`, `hnsw_search_pack_missing=1`, invalid/fallback/direct/heap-copy pack counters `0`
- Adds benchmark metrics for the same route/pack counters plus stable score-batch fallback reason flags.
- Updates the vector comparison script README template to document the route/search-pack guardrail metrics.

## Scope

- Includes:
  - `TreeDB/collections/vector_index_search.go`
  - `TreeDB/collections/vector_index_search_test.go`
  - `scripts/bench_vector_search_compare.sh`
- Excludes:
  - pack format/manifests/rebuild/open/search implementation
  - graph construction/traversal semantic changes

## Correctness

Tests run on latest head `30a4724b17e3705f86091fc4a35dd0498877cbb3`:

```sh
go test ./TreeDB/collections -run 'Test(VectorIndexSearcherSearchWithBuffer(RouteStatsAndNoDocumentBoundary2311|ResultEquivalenceAndZeroAllocs2124|ParallelIndependentBuffers1961)|ColumnVectorGraphPreparedSearchParallelScratchSafety2045|ColumnVectorGraphSharedPreparedSearchParallelIndependentSearchers1735)$'
go test ./TreeDB/collections
bash -n scripts/bench_vector_search_compare.sh
```

Post-fix artifacts:
- `/tmp/gomap_2311_route_assertion_fix_20260604_125353/focused_collections_tests.txt`
- `/tmp/gomap_2311_route_assertion_fix_20260604_125353/collections_tests.txt`
- `/tmp/gomap_2311_route_assertion_fix_20260604_125353/bench_vector_search_compare_bash_n.txt`

Coverage added/confirmed:
- route/no-document stats guardrail test added (`TestVectorIndexSearcherSearchWithBufferRouteStatsAndNoDocumentBoundary2311`)
- SearchWithBuffer result-equivalence and zero-allocation test still passes
- parallel independent-buffer/searcher tests still pass
- Windows/non-mmap assertion fix in `30a4724b1`: route assertions now accept exactly one current `column_graph` route (prepared OR fallback) while still requiring no `hnsw_search_pack` route and pack absent/inactive

## CI

Latest-head CI verified clean on `30a4724b17e3705f86091fc4a35dd0498877cbb3` via `gh pr checks 2319 --repo snissn/gomap`:
- all reported checks passing, including `windows-core-2`, TreeDB Linux/macOS/Windows jobs, race checks, perf-smoke, unified bench suites/profiles, gofmt, and CodeRabbit.

## Performance

Hardware/context:
- latest PR head: `snissn/2311-manager` / `30a4724b17e3705f86091fc4a35dd0498877cbb3`
- benchmarked production-code candidate: `070e560f69cb84bce42267fa35823aa488b2e72e` (superseded only by the test-only Windows assertion fix `30a4724b1`)
- base: `origin/main` / `71172830d580c131beffcb5693707471d22f9f89`
- machine: Apple M3, `goos=darwin`, `goarch=arm64`
- hardware file: `/tmp/gomap_2311_candidate_20260604_123138/hardware.txt`

Start-phase baseline artifacts (base commit before implementation):
- `/tmp/gomap_2311_start_baseline_20260604_121522/tier_s_smoke/bench.txt`
- `/tmp/gomap_2311_start_baseline_20260604_121522/tier_f_full/bench.txt`

Candidate artifacts (route/pack counter implementation):
- `/tmp/gomap_2311_candidate_20260604_123138/tier_s_smoke/bench.txt`
- `/tmp/gomap_2311_candidate_20260604_123138/tier_f_full/bench.txt`
- summaries: `/tmp/gomap_2311_candidate_20260604_123138/analysis/candidate_summary.md`
- benchstat: `/tmp/gomap_2311_candidate_20260604_123138/analysis/benchstat_tier_s_start_vs_candidate.txt`, `/tmp/gomap_2311_candidate_20260604_123138/analysis/benchstat_tier_f_start_vs_candidate.txt`

Tier S command:

```sh
RUN_DIR=/tmp/gomap_2311_candidate_20260604_123138/tier_s_smoke \
USEARCH_ROOT=/tmp/usearch_2.25.2_macos_arm64/root \
BENCH_REGEX='^BenchmarkCollectionVectorUSearchProductionCompare$' \
TREEDB_VECTOR_BENCH_DOCS=10000 \
TREEDB_VECTOR_BENCH_DIMS=64 \
TREEDB_VECTOR_BENCH_M=16 \
TREEDB_VECTOR_BENCH_EF_CONSTRUCTION=128 \
TREEDB_VECTOR_BENCH_EF_SEARCH=128 \
TREEDB_VECTOR_BENCH_TOPK=10 \
TREEDB_VECTOR_BENCH_QUERIES=16 \
CPU_LIST=1,8 \
BENCHTIME=1000x \
COUNT=3 \
scripts/bench_vector_search_compare.sh
```

Tier F command:

```sh
RUN_DIR=/tmp/gomap_2311_candidate_20260604_123138/tier_f_full \
USEARCH_ROOT=/tmp/usearch_2.25.2_macos_arm64/root \
BENCH_REGEX='^BenchmarkCollectionVectorUSearchProductionCompare$' \
TREEDB_VECTOR_BENCH_DOCS=100000 \
TREEDB_VECTOR_BENCH_DIMS=128 \
TREEDB_VECTOR_BENCH_M=16 \
TREEDB_VECTOR_BENCH_EF_CONSTRUCTION=128 \
TREEDB_VECTOR_BENCH_EF_SEARCH=128 \
TREEDB_VECTOR_BENCH_TOPK=10 \
TREEDB_VECTOR_BENCH_QUERIES=16 \
CPU_LIST=1,8 \
BENCHTIME=1s \
COUNT=3 \
scripts/bench_vector_search_compare.sh
```

Candidate median summary:

| Tier | Row | ns/op | ops/sec | B/op | allocs/op | candidates/search | visited nodes/search | visited edges/search | vector B/search | adjacency B/search | docs fetched/search | route | pack active/missing | graph-row fallback | vector scratch decode |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- | --- | ---: | ---: |
| S 10k/64 | TreeDB SearchWithBuffer c=1 | 71,505 | 13,985 | 0 | 0 | 1,436 | 1,525 | 4,182 | 390,400 | 16,740 | 0 | column_graph_prepared=1 | 0 / 1 | 0 | 0 |
| S 10k/64 | TreeDB SearchWithBufferParallel c=8 | 14,103 | 70,909 | 4* | 0 | 1,436 | 1,525 | 4,182 | 390,400 | 16,740 | 0 | column_graph_prepared=1 | 0 / 1 | 0 | 0 |
| F 100k/128 | TreeDB SearchWithBuffer c=1 | 393,796 | 2,539 | 0 | 0 | 2,496 | 2,595 | 4,192 | 1,328,640 | 16,832 | 0 | column_graph_prepared=1 | 0 / 1 | 0 | 0 |
| F 100k/128 | TreeDB SearchWithBufferParallel c=8 | 134,635 | 7,428 | 0 | 0 | 2,496 | 2,595 | 4,192 | 1,328,640 | 16,832 | 0 | column_graph_prepared=1 | 0 / 1 | 0 | 0 |

`*` Tier S parallel showed 4 B/op / 0 allocs/op with identical pre-existing noise in start-phase evidence; the deterministic SearchWithBuffer zero-allocation test passed and Tier F parallel was 0 B/op, 0 allocs/op.

Regression assessment:
- Domain counters are unchanged vs start baseline: candidates/search, visited nodes/edges, vector/adjacency bytes, docs fetched, graph-row fallback, scratch decode.
- Allocations remain 0 allocs/op for TreeDB rows; c=1 rows are 0 B/op.
- Runtime differences were statistically inconclusive/noisy (USearch comparator moved similarly); no material regression attributable to this additive counter PR.

## Rollout / Toggle Plan

No runtime toggle. The new counters are additive observability only; current production route remains unchanged.

## Follow-ups

- #2312 can use these public stats/benchmark names as the initial contract snapshot for pack format/manifest work.
- #2312+ should update the cached route stats at searcher open once a pack candidate can be validated or rejected.

## AI Review Loop

- Codex review on `070e560f69`: one P2 thread about Windows/non-mmap route assertions. Fixed in `30a4724b1`, replied, and resolved.
- CodeRabbit latest-head status: pass.
- Copilot latest-head review: not requested/no blocking Copilot review present.
- Internal high-thinking review: PASS, no blocking findings.

## Optimization PR Checklist (TreeDB)

### Scope
- [x] Single, clear objective for this PR
- [x] Explicit include/exclude list above
- [x] No unwanted feature reintroduction

### Safety / Correctness
- [x] No storage/mmap/persistence format changes
- [x] No graph/search semantic changes

### Tests
- [x] Added deterministic route/no-document stats test
- [x] Ran targeted and package tests above

### Benchmarks / Measurements
- [x] Tier S and Tier F artifacts captured with start baseline and candidate
- [x] Reported route, candidates, visited nodes/edges, bytes, docs, B/op, allocs/op

### Docs
- [x] Updated vector comparison script benchmark-boundary text for the new guardrail metrics
