### PR TITLE
Add TreeDB vector search profiling hook

### DIFF
--- a/benchmarks/vector_db_compare/README.md
+++ b/benchmarks/vector_db_compare/README.md
@@ -114,6 +114,12 @@ Configuration:
   `-validation-exact-source=treedb|dataset` for every TreeDB row. Unset keeps
   the demo default (`treedb`). Set `dataset` to compute validation exact top-K
   IDs from the exported dataset vectors instead of TreeDB exact search.
+- `TREEDB_SEARCH_PROFILE_DIR`: optional top-level directory for TreeDB search
+  profiles. When set, each TreeDB row passes a backend-specific subdirectory to
+  `-search-profile-dir`; column_graph rows emit per-concurrency
+  `search_<mode>_c<N>_{cpu,heap,allocs,block,mutex}.pprof` files there. CPU
+  profiles are scoped to the search loop; the other files are runtime snapshots
+  for supporting diagnosis.
 - `TREEDB_QUANTIZED_INDEX_NAME`: scalar_u8 TreeDB quantized score-plane name.
   Defaults to `embedding.scalar_u8.fast`.
 - `TREEDB_QUANTIZED_RERANK_CANDIDATES`: TreeDB quantized-rerank exact rerank
@@ -151,6 +157,8 @@ The runner writes:
 - `pgvector.json`: PostgreSQL+pgvector full-vector HNSW benchmark result when enabled
 - `mongodb.json`: MongoDB Vector Search benchmark result when enabled
 - `comparison.md`: normalized comparison table
+- TreeDB search profiles under backend-specific subdirectories of
+  `TREEDB_SEARCH_PROFILE_DIR`, when set
 
 The TreeDB dataset exporter writes row-major little-endian `float32` vector
 files plus JSONL convenience files. TreeDB loads documents from the exported

--- a/cmd/treedb_vector_search_demo/README.md
+++ b/cmd/treedb_vector_search_demo/README.md
@@ -90,6 +90,14 @@ The matrix search stage defaults to 10,000 ANN queries per lane and parallel
 concurrency levels `2,4,8,16,32,64,128`; override those with `-queries` and
 `-search-concurrency`.
 
+Use `-search-profile-dir DIR` to write per-concurrency search profiles for the
+column_graph search stage. Each measured concurrency emits
+`search_<mode>_c<N>_cpu.pprof`, plus `heap`, `allocs`, `block`, and `mutex`
+runtime snapshots with the same prefix. CPU profiles are scoped to the measured
+search loop; the runtime snapshots are supporting diagnostics and can include
+process state outside the search loop. Profiling changes timings and should be
+used for bottleneck analysis, not as the comparison number to publish.
+
 When `-dataset-dir` is used, `-queries` may truncate the exported query vector
 file but cannot exceed the manifest query count. `-validate-queries` is a recall
 sample size and is clamped to the exported query count. Recall validation uses
@@ -135,6 +143,8 @@ Useful flags:
   run.
 - `-disable-exact-fallback=false`: allow exact fallback during benchmark
   searches.
+- `-search-profile-dir DIR`: write per-concurrency column_graph search profiles
+  under `DIR`.
 - `-validate-queries N` and `-min-recall R`: run recall validation for `N`
   queries; set `-min-recall=0` when disabling validation with
   `-validate-queries=0`.

--- a/cmd/treedb_vector_search_demo/main.go
+++ b/cmd/treedb_vector_search_demo/main.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"runtime/pprof"
 	"sort"
 	"strconv"
 	"strings"
@@ -77,6 +78,7 @@ type config struct {
 	disableExactFallback  bool
 	requireValueLogBytes  bool
 	requireLeafVLogBytes  bool
+	searchProfileDir      string
 	jsonOut               bool
 
 	indexOuterLeavesInValueLog *bool
@@ -105,6 +107,7 @@ type result struct {
 	ValidateQueries           int                               `json:"validate_queries"`
 	ValidateDocs              int                               `json:"validate_docs"`
 	ValidationExactSource     validationExactSource             `json:"validation_exact_source"`
+	SearchProfileDir          string                            `json:"search_profile_dir,omitempty"`
 	TopK                      int                               `json:"top_k"`
 	M                         int                               `json:"m"`
 	EfConstruction            int                               `json:"ef_construction"`
@@ -350,6 +353,7 @@ func parseConfig(args []string) (config, error) {
 	fs.BoolVar(&cfg.disableExactFallback, "disable-exact-fallback", cfg.disableExactFallback, "Disable exact fallback during ANN benchmark queries")
 	fs.BoolVar(&cfg.requireValueLogBytes, "require-value-log-bytes", false, "Fail if compacted storage has no value-log bytes")
 	fs.BoolVar(&cfg.requireLeafVLogBytes, "require-leaf-vlog-bytes", false, "Fail if compacted storage has no leaf value-log bytes")
+	fs.StringVar(&cfg.searchProfileDir, "search-profile-dir", "", "Write per-concurrency search CPU/heap/alloc/block/mutex profiles under this directory")
 	fs.BoolVar(&cfg.jsonOut, "json", false, "Emit JSON instead of text")
 	if err := fs.Parse(args); err != nil {
 		return config{}, err
@@ -426,6 +430,9 @@ func parseConfig(args []string) (config, error) {
 	}
 	if cfg.datasetDir != "" {
 		cfg.datasetDir = filepath.Clean(cfg.datasetDir)
+	}
+	if cfg.searchProfileDir != "" {
+		cfg.searchProfileDir = filepath.Clean(cfg.searchProfileDir)
 	}
 	if err := validateValidationExactSourceConfig(cfg); err != nil {
 		return config{}, err
@@ -848,6 +855,7 @@ func execute(ctx context.Context, cfg config) (result, error) {
 		ValidateQueries:           cfg.validateQueries,
 		ValidateDocs:              cfg.validateDocs,
 		ValidationExactSource:     cfg.validationExactSource,
+		SearchProfileDir:          cfg.searchProfileDir,
 		TopK:                      cfg.topK,
 		M:                         cfg.m,
 		EfConstruction:            cfg.efConstruction,
@@ -2125,6 +2133,10 @@ func benchmarkColumnGraphSearchLoadedConcurrent(col *collections.Collection, ind
 			atomic.AddUint64(&scoreBatchCandidatesTotal, response.Stats.ScoreBatchCandidates)
 		}
 	}
+	stopProfile, err := startColumnGraphSearchProfile(cfg, concurrency)
+	if err != nil {
+		return searchBenchmarkResult{}, err
+	}
 	startAll := time.Now()
 	if concurrency == 1 {
 		worker(searchers[0])
@@ -2141,6 +2153,11 @@ func benchmarkColumnGraphSearchLoadedConcurrent(col *collections.Collection, ind
 		wg.Wait()
 	}
 	total := time.Since(startAll)
+	if stopProfile != nil {
+		if err := stopProfile(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
 	if firstErr != nil {
 		return searchBenchmarkResult{}, firstErr
 	}
@@ -2182,6 +2199,71 @@ func benchmarkColumnGraphSearchLoadedConcurrent(col *collections.Collection, ind
 		ExactFallbacks:                    0,
 		DisableExactFallback:              cfg.disableExactFallback,
 	}, nil
+}
+
+func startColumnGraphSearchProfile(cfg config, concurrency int) (func() error, error) {
+	if cfg.searchProfileDir == "" {
+		return nil, nil
+	}
+	if err := os.MkdirAll(cfg.searchProfileDir, 0o755); err != nil {
+		return nil, fmt.Errorf("create search profile dir: %w", err)
+	}
+	mode := string(normalizedVectorQueryMode(cfg.vectorQueryMode))
+	if mode == "" {
+		mode = "exact"
+	}
+	prefix := fmt.Sprintf("search_%s_c%d", mode, concurrency)
+	cpuFile, err := os.Create(filepath.Join(cfg.searchProfileDir, prefix+"_cpu.pprof"))
+	if err != nil {
+		return nil, fmt.Errorf("create search CPU profile: %w", err)
+	}
+	oldMemProfileRate := runtime.MemProfileRate
+	oldMutexProfileFraction := runtime.SetMutexProfileFraction(1)
+	runtime.MemProfileRate = 1
+	runtime.SetBlockProfileRate(1)
+	if err := pprof.StartCPUProfile(cpuFile); err != nil {
+		_ = cpuFile.Close()
+		restoreRuntimeSearchProfileSettings(oldMemProfileRate, oldMutexProfileFraction)
+		return nil, fmt.Errorf("start search CPU profile: %w", err)
+	}
+	return func() error {
+		pprof.StopCPUProfile()
+		var errs []error
+		if err := cpuFile.Close(); err != nil {
+			errs = append(errs, fmt.Errorf("close search CPU profile: %w", err))
+		}
+		runtime.GC()
+		for _, name := range []string{"heap", "allocs", "block", "mutex"} {
+			path := filepath.Join(cfg.searchProfileDir, prefix+"_"+name+".pprof")
+			if err := writeRuntimeProfile(path, name); err != nil {
+				errs = append(errs, err)
+			}
+		}
+		restoreRuntimeSearchProfileSettings(oldMemProfileRate, oldMutexProfileFraction)
+		return errors.Join(errs...)
+	}, nil
+}
+
+func restoreRuntimeSearchProfileSettings(memProfileRate, mutexProfileFraction int) {
+	runtime.MemProfileRate = memProfileRate
+	runtime.SetBlockProfileRate(0)
+	runtime.SetMutexProfileFraction(mutexProfileFraction)
+}
+
+func writeRuntimeProfile(path, name string) error {
+	profile := pprof.Lookup(name)
+	if profile == nil {
+		return fmt.Errorf("runtime profile %q is unavailable", name)
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("create %s profile: %w", name, err)
+	}
+	defer func() { _ = f.Close() }()
+	if err := profile.WriteTo(f, 0); err != nil {
+		return fmt.Errorf("write %s profile: %w", name, err)
+	}
+	return nil
 }
 
 func vectorIndexOptions(def collections.VectorIndexDefinition) collections.VectorIndexOptions {

--- a/cmd/treedb_vector_search_demo/main_test.go
+++ b/cmd/treedb_vector_search_demo/main_test.go
@@ -91,6 +91,55 @@ func TestExecuteSmokeCompactsReopensValidatesAndBenchmarks(t *testing.T) {
 	}
 }
 
+func TestExecuteColumnGraphSearchProfileDirWritesProfiles(t *testing.T) {
+	profileDir := t.TempDir()
+	res, err := execute(context.Background(), config{
+		dir:                       t.TempDir(),
+		keepDir:                   true,
+		docs:                      64,
+		dimensions:                8,
+		queries:                   4,
+		searchConcurrency:         []int{2},
+		validateQueries:           0,
+		validateDocs:              0,
+		topK:                      3,
+		batchSize:                 16,
+		m:                         4,
+		efConstruction:            32,
+		efSearch:                  32,
+		valuePointerThreshold:     defaultValuePointerThreshold,
+		leafGenerationTarget:      defaultLeafGenerationTarget,
+		minRecall:                 0,
+		disableExactFallback:      true,
+		vectorIndexStrategy:       collections.VectorIndexStrategyColumnGraph,
+		vectorQueryMode:           collections.VectorIndexQueryModeQuantizedRerank,
+		quantizedIndexName:        defaultQuantizedIndexName,
+		quantizedRerankCandidates: 4,
+		searchProfileDir:          profileDir,
+	})
+	if err != nil {
+		t.Fatalf("execute with search profile dir: %v", err)
+	}
+	if res.SearchProfileDir != profileDir {
+		t.Fatalf("search profile dir=%q want %q", res.SearchProfileDir, profileDir)
+	}
+	if len(res.SearchBenchmarks) != 2 || res.SearchBenchmarks[0].Concurrency != 1 || res.SearchBenchmarks[1].Concurrency != 2 {
+		t.Fatalf("unexpected search benchmarks: %+v", res.SearchBenchmarks)
+	}
+	for _, concurrency := range []int{1, 2} {
+		for _, kind := range []string{"cpu", "heap", "allocs", "block", "mutex"} {
+			path := filepath.Join(profileDir, fmt.Sprintf("search_quantized_rerank_c%d_%s.pprof", concurrency, kind))
+			info, err := os.Stat(path)
+			if err != nil {
+				t.Fatalf("stat profile %s: %v", path, err)
+			}
+			if info.Size() == 0 {
+				t.Fatalf("profile %s is empty", path)
+			}
+		}
+	}
+}
+
 func TestDemoCommandWALFormatConfigPreservesProfileKnobs(t *testing.T) {
 	cfg := demoCommandWALFormatConfig(demoBackendOptions(config{}, t.TempDir()))
 	if len(cfg.RequiredFeatures) != 1 || cfg.RequiredFeatures[0] != "command_wal_v1" {
@@ -603,6 +652,13 @@ func TestParseConfigVectorQueryMode(t *testing.T) {
 	}
 	if defaultCfg.validationExactSource != validationExactSourceTreeDB {
 		t.Fatalf("default validation exact source=%q want treedb", defaultCfg.validationExactSource)
+	}
+	profileCfg, err := parseConfig([]string{"-search-profile-dir", filepath.Join("tmp", ".", "profiles")})
+	if err != nil {
+		t.Fatalf("parseConfig search profile dir: %v", err)
+	}
+	if profileCfg.searchProfileDir != filepath.Join("tmp", "profiles") {
+		t.Fatalf("search profile dir=%q want tmp/profiles", profileCfg.searchProfileDir)
 	}
 
 	for _, tc := range []struct {

--- a/scripts/bench_vector_db_compare.sh
+++ b/scripts/bench_vector_db_compare.sh
@@ -36,6 +36,7 @@ TREEDB_LEAF_GENERATION_SEGMENT_TARGET="${TREEDB_LEAF_GENERATION_SEGMENT_TARGET:-
 TREEDB_REQUIRE_VALUE_LOG_BYTES="${TREEDB_REQUIRE_VALUE_LOG_BYTES:-}"
 TREEDB_REQUIRE_LEAF_VLOG_BYTES="${TREEDB_REQUIRE_LEAF_VLOG_BYTES:-}"
 TREEDB_VALIDATION_EXACT_SOURCE="${TREEDB_VALIDATION_EXACT_SOURCE:-}"
+TREEDB_SEARCH_PROFILE_DIR="${TREEDB_SEARCH_PROFILE_DIR:-}"
 NUMPY_PACKAGE="${NUMPY_PACKAGE:-numpy==2.0.2}"
 VECTORLITE_PACKAGE="${VECTORLITE_PACKAGE:-vectorlite-py==0.2.0}"
 
@@ -184,6 +185,14 @@ fi
 if [[ -n "$TREEDB_VALIDATION_EXACT_SOURCE" ]]; then
 	treedb_storage_args+=(-validation-exact-source "$TREEDB_VALIDATION_EXACT_SOURCE")
 fi
+treedb_profile_args=()
+treedb_profile_args_for_backend() {
+	local backend="$1"
+	treedb_profile_args=()
+	if [[ -n "$TREEDB_SEARCH_PROFILE_DIR" ]]; then
+		treedb_profile_args=(-search-profile-dir "$TREEDB_SEARCH_PROFILE_DIR/$backend")
+	fi
+}
 mkdir -p "$RUN_DIR"
 
 cat >"$RUN_DIR/README.md" <<EOF
@@ -214,6 +223,7 @@ cat >"$RUN_DIR/README.md" <<EOF
   - \`TREEDB_REQUIRE_VALUE_LOG_BYTES=${TREEDB_REQUIRE_VALUE_LOG_BYTES:-<unset>}\`
   - \`TREEDB_REQUIRE_LEAF_VLOG_BYTES=${TREEDB_REQUIRE_LEAF_VLOG_BYTES:-<unset>}\`
   - \`TREEDB_VALIDATION_EXACT_SOURCE=${TREEDB_VALIDATION_EXACT_SOURCE:-<unset; demo default treedb>}\`
+  - \`TREEDB_SEARCH_PROFILE_DIR=${TREEDB_SEARCH_PROFILE_DIR:-<unset>}\`
 - Python packages: \`$NUMPY_PACKAGE\`, \`$VECTORLITE_PACKAGE\`
 
 This run compares persistent database-tier ANN search:
@@ -267,6 +277,7 @@ result_args=()
 
 if contains_backend treedb; then
 	echo "running TreeDB benchmark"
+	treedb_profile_args_for_backend treedb
 	GOWORK=off go run ./cmd/treedb_vector_search_demo \
 		-matrix=false \
 		-dataset-dir "$RUN_DIR/dataset" \
@@ -278,6 +289,7 @@ if contains_backend treedb; then
 		-search-concurrency "$SEARCH_CONCURRENCY" \
 		-validate-queries "$VALIDATE_QUERIES" \
 		"${treedb_storage_args[@]}" \
+		"${treedb_profile_args[@]}" \
 		-top-k "$TOP_K" \
 		-m "$M" \
 		-ef-construction "$EF_CONSTRUCTION" \
@@ -289,6 +301,7 @@ fi
 
 if contains_backend treedb_column_graph; then
 	echo "running TreeDB column-store graph benchmark"
+	treedb_profile_args_for_backend treedb_column_graph
 	GOWORK=off go run ./cmd/treedb_vector_search_demo \
 		-matrix=false \
 		-vector-index-strategy column_graph \
@@ -301,6 +314,7 @@ if contains_backend treedb_column_graph; then
 		-search-concurrency "$SEARCH_CONCURRENCY" \
 		-validate-queries "$VALIDATE_QUERIES" \
 		"${treedb_storage_args[@]}" \
+		"${treedb_profile_args[@]}" \
 		-top-k "$TOP_K" \
 		-m "$M" \
 		-ef-construction "$EF_CONSTRUCTION" \
@@ -312,6 +326,7 @@ fi
 
 if contains_backend treedb_column_graph_quantized_only; then
 	echo "running TreeDB column-store graph scalar_u8 quantized_only benchmark"
+	treedb_profile_args_for_backend treedb_column_graph_quantized_only
 	GOWORK=off go run ./cmd/treedb_vector_search_demo \
 		-matrix=false \
 		-vector-index-strategy column_graph \
@@ -326,6 +341,7 @@ if contains_backend treedb_column_graph_quantized_only; then
 		-search-concurrency "$SEARCH_CONCURRENCY" \
 		-validate-queries "$VALIDATE_QUERIES" \
 		"${treedb_storage_args[@]}" \
+		"${treedb_profile_args[@]}" \
 		-top-k "$TOP_K" \
 		-m "$M" \
 		-ef-construction "$EF_CONSTRUCTION" \
@@ -337,6 +353,7 @@ fi
 
 if contains_backend treedb_column_graph_quantized_rerank; then
 	echo "running TreeDB column-store graph scalar_u8 quantized_rerank benchmark"
+	treedb_profile_args_for_backend treedb_column_graph_quantized_rerank
 	GOWORK=off go run ./cmd/treedb_vector_search_demo \
 		-matrix=false \
 		-vector-index-strategy column_graph \
@@ -352,6 +369,7 @@ if contains_backend treedb_column_graph_quantized_rerank; then
 		-search-concurrency "$SEARCH_CONCURRENCY" \
 		-validate-queries "$VALIDATE_QUERIES" \
 		"${treedb_storage_args[@]}" \
+		"${treedb_profile_args[@]}" \
 		-top-k "$TOP_K" \
 		-m "$M" \
 		-ef-construction "$EF_CONSTRUCTION" \


### PR DESCRIPTION
## Summary

- add an opt-in `-search-profile-dir` flag to `treedb_vector_search_demo` for column_graph search runs
- emit per-concurrency `cpu`, `heap`, `allocs`, `block`, and `mutex` profiles with the `search_<mode>_c<N>_*.pprof` prefix
- record the effective profile directory in JSON output and document the profiling caveats
- add `TREEDB_SEARCH_PROFILE_DIR` passthrough to `scripts/bench_vector_db_compare.sh`, using backend-specific subdirectories to avoid overwrites

## Validation

- `GOWORK=off go test -count=1 ./cmd/treedb_vector_search_demo`
- `bash -n scripts/bench_vector_db_compare.sh`
- `git diff --check`
- tiny harness smoke with `TREEDB_SEARCH_PROFILE_DIR` set:
  - `BACKENDS=treedb_column_graph_quantized_rerank DOCS=64 DIMS=8 QUERIES=4 VALIDATE_QUERIES=0 VALIDATE_DOCS=0 TOP_K=3 SEARCH_CONCURRENCY=1,2 M=4 EF_CONSTRUCTION=32 EF_SEARCH=32 MIN_RECALL=0 TREEDB_QUANTIZED_RERANK_MIN_RECALL=0 TREEDB_SEARCH_PROFILE_DIR=/tmp/vector_db_profile_script_smoke_20260604_143430/profiles RUN_DIR=/tmp/vector_db_profile_script_smoke_20260604_143430 GOWORK=off scripts/bench_vector_db_compare.sh`
  - verified 10 profile files under `/tmp/vector_db_profile_script_smoke_20260604_143430/profiles/treedb_column_graph_quantized_rerank`
  - verified JSON `search_profile_dir` points at that backend-specific profile directory

## Profiling Notes

This PR adds the hook needed for repeatable profiling; it does not claim profiled timings as comparison numbers. CPU profiles are scoped to the measured search loop. Heap, allocation, block, and mutex profiles are supporting runtime snapshots and may include process state beyond the search loop. Enabling profiles changes latency and throughput, so unprofiled runs should remain the source for published benchmark numbers.

In the c=1/c=8 quantized_rerank investigation that motivated this, the c=8 CPU profile on the post-traversal artifact run pointed primarily at scalar_u8 indexed dot scoring, `SearchCosine`, scratch clearing, top-candidate insertion, and quantized scorer traversal work, with exact rerank scoring a smaller contributor.