### PR TITLE
Treat JSONBench value-log threshold writes as storage-first

### DIFF
--- a/TreeDB/caching/vlog_compression_regression_test.go
+++ b/TreeDB/caching/vlog_compression_regression_test.go
@@ -407,7 +407,7 @@ func TestAppendValueLog_AutoForcePointerMediumPayloadUsesGroupedBlockFrame(t *te
 	}
 }
 
-func TestAppendValueLog_AutoForcePointerHighEntropyPayloadUsesGroupedRawFrame(t *testing.T) {
+func TestAppendValueLog_AutoBalancedForcePointerHighEntropyPayloadUsesGroupedBlockFrame(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "value.log")
 	writer, err := valuelog.NewWriter(path, page.ValueLogFileID(1))
@@ -455,8 +455,78 @@ func TestAppendValueLog_AutoForcePointerHighEntropyPayloadUsesGroupedRawFrame(t 
 	if header.K != uint8(len(records)) {
 		t.Fatalf("frame K=%d want grouped K=%d", header.K, len(records))
 	}
+	if header.Flags&valuelog.FrameFlagCompressed == 0 {
+		t.Fatalf("expected balanced forced-pointer batch to store a block-compressed frame")
+	}
+	if header.DictID != 0 {
+		t.Fatalf("expected no dict id for block-compressed high-entropy payload, got %d", header.DictID)
+	}
+	if got := valuelog.BlockCodec(header.Reserved); got != valuelog.BlockCodecSnappy {
+		t.Fatalf("block codec=%v want snappy", got)
+	}
+	writeSnap := snapshotLaneVlogWriteMode(&db.lanes[0])
+	if writeSnap.Frames[vlogWriteBlock] == 0 {
+		t.Fatalf("expected block write-mode observation")
+	}
+	if writeSnap.Frames[vlogWriteOff] != 0 {
+		t.Fatalf("expected no raw/off write-mode observation for balanced forced-pointer payload")
+	}
+	selectorSnap := db.lanes[0].vlogCompressionSelector.snapshot()
+	if selectorSnap.framesByCandidate[vlogAutoCandidateOff] != 0 {
+		t.Fatalf("expected stable block forced-pointer batch not to train selector off frames")
+	}
+}
+
+func TestAppendValueLog_AutoThroughputForcePointerHighEntropyPayloadUsesGroupedRawFrame(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "value.log")
+	writer, err := valuelog.NewWriter(path, page.ValueLogFileID(1))
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+
+	db := &DB{
+		closeCh:                  make(chan struct{}),
+		valueLogCompressionMode:  uint8(vlogCompressionAuto),
+		valueLogAutoPolicy:       uint8(vlogAutoThroughput),
+		valueLogBlockCodec:       valuelog.BlockCodecSnappy,
+		valueLogBlockTargetBytes: 4096,
+		forceValueLogPointers:    true,
+		lanes: []lane{
+			{id: 0, vlog: writer, vlogCompressionSelector: newVlogCompressionSelector(vlogAutoThroughput, 0, 0)},
+		},
+	}
+
+	records := make([]valuelog.Record, 4)
+	for i := range records {
+		value := make([]byte, forcePointerAutoBlockMinPayloadBytes)
+		for j := range value {
+			value[j] = byte(j + i*17)
+		}
+		records[i] = valuelog.Record{RID: uint64(i + 1), Value: value}
+	}
+	ptrs, err := db.appendValueLog(&db.lanes[0], 0, nil, records, journalDurabilityFlush)
+	if err != nil {
+		t.Fatalf("appendValueLog: %v", err)
+	}
+	if len(ptrs) != len(records) {
+		t.Fatalf("ptr count=%d want %d", len(ptrs), len(records))
+	}
+	for i, ptr := range ptrs {
+		if ptr == (page.ValuePtr{}) {
+			t.Fatalf("empty pointer at %d", i)
+		}
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	header := readFirstValueLogFrameHeader(t, path)
+	if header.K != uint8(len(records)) {
+		t.Fatalf("frame K=%d want grouped K=%d", header.K, len(records))
+	}
 	if header.Flags&valuelog.FrameFlagCompressed != 0 {
-		t.Fatalf("expected high-entropy forced-pointer batch to bypass block compression")
+		t.Fatalf("expected throughput high-entropy forced-pointer batch to bypass block compression")
 	}
 	if header.DictID != 0 {
 		t.Fatalf("expected no dict id for raw high-entropy payload, got %d", header.DictID)

--- a/TreeDB/caching/vlog_compression_regression_test.go
+++ b/TreeDB/caching/vlog_compression_regression_test.go
@@ -477,6 +477,79 @@ func TestAppendValueLog_AutoBalancedForcePointerHighEntropyPayloadUsesGroupedBlo
 	}
 }
 
+func TestAppendValueLog_AutoBalancedForcePointerDictSelectorOffUsesGroupedBlockFrame(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "value.log")
+	writer, err := valuelog.NewWriter(path, page.ValueLogFileID(1))
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+
+	selector := newVlogCompressionSelector(vlogAutoBalanced, 0, 0)
+	selector.dwellBytes = 0
+	selector.exploreBytes = 0
+	selector.exploreRemaining = 0
+	selector.currentCandidate = vlogAutoCandidateOff
+	selector.metrics[vlogAutoCandidateOff] = vlogCandidateMetrics{ratio: 1.0, throughput: 1.0, samples: 16}
+	selector.metrics[vlogAutoCandidateBlockSnappy] = vlogCandidateMetrics{ratio: 0.99, throughput: 0.2, samples: 16}
+	selector.metrics[vlogAutoCandidateBlockLZ4] = vlogCandidateMetrics{ratio: 0.99, throughput: 0.2, samples: 16}
+	selector.metrics[vlogAutoCandidateDict] = vlogCandidateMetrics{ratio: 0.99, throughput: 0.2, samples: 16}
+
+	db := &DB{
+		closeCh:                  make(chan struct{}),
+		valueLogCompressionMode:  uint8(vlogCompressionAuto),
+		valueLogAutoPolicy:       uint8(vlogAutoBalanced),
+		valueLogBlockCodec:       valuelog.BlockCodecSnappy,
+		valueLogBlockTargetBytes: 4096,
+		forceValueLogPointers:    true,
+		lanes: []lane{
+			{id: 0, vlog: writer, vlogCompressionSelector: selector},
+		},
+	}
+
+	base := bytes.Repeat([]byte(`{"commit":{"operation":"create","collection":"app.bsky.feed.post"},"kind":"commit","did":"did:plc:storage-parity","text":"value-log-retained-json"}`), 6)
+	value := base[:forcePointerAutoBlockMinPayloadBytes+128]
+	records := []valuelog.Record{
+		{RID: 1, Value: value},
+		{RID: 2, Value: value},
+		{RID: 3, Value: value},
+		{RID: 4, Value: value},
+	}
+	ptrs, err := db.appendValueLog(&db.lanes[0], 7, []byte("stub-dict"), records, journalDurabilityFlush)
+	if err != nil {
+		t.Fatalf("appendValueLog: %v", err)
+	}
+	if len(ptrs) != len(records) {
+		t.Fatalf("ptr count=%d want %d", len(ptrs), len(records))
+	}
+	for i, ptr := range ptrs {
+		if ptr == (page.ValuePtr{}) {
+			t.Fatalf("empty pointer at %d", i)
+		}
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	header := readFirstValueLogFrameHeader(t, path)
+	if header.K != uint8(len(records)) {
+		t.Fatalf("frame K=%d want grouped K=%d", header.K, len(records))
+	}
+	if header.Flags&valuelog.FrameFlagCompressed == 0 {
+		t.Fatalf("expected storage-first forced-pointer dict-available batch to store a block-compressed frame")
+	}
+	if header.DictID != 0 {
+		t.Fatalf("expected selector-off remap to store block frame without dict id, got %d", header.DictID)
+	}
+	writeSnap := snapshotLaneVlogWriteMode(&db.lanes[0])
+	if writeSnap.Frames[vlogWriteBlock] == 0 {
+		t.Fatalf("expected block write-mode observation")
+	}
+	if writeSnap.Frames[vlogWriteOff] != 0 {
+		t.Fatalf("expected no raw/off write-mode observation for storage-first forced-pointer dict path")
+	}
+}
+
 func TestAppendValueLog_AutoThroughputForcePointerHighEntropyPayloadUsesGroupedRawFrame(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "value.log")

--- a/TreeDB/caching/vlog_compression_regression_test.go
+++ b/TreeDB/caching/vlog_compression_regression_test.go
@@ -407,7 +407,7 @@ func TestAppendValueLog_AutoForcePointerMediumPayloadUsesGroupedBlockFrame(t *te
 	}
 }
 
-func TestAppendValueLog_AutoBalancedForcePointerHighEntropyPayloadUsesGroupedBlockFrame(t *testing.T) {
+func TestAppendValueLog_AutoBalancedForcePointerHighEntropyPayloadUsesGroupedRawFrame(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "value.log")
 	writer, err := valuelog.NewWriter(path, page.ValueLogFileID(1))
@@ -455,25 +455,22 @@ func TestAppendValueLog_AutoBalancedForcePointerHighEntropyPayloadUsesGroupedBlo
 	if header.K != uint8(len(records)) {
 		t.Fatalf("frame K=%d want grouped K=%d", header.K, len(records))
 	}
-	if header.Flags&valuelog.FrameFlagCompressed == 0 {
-		t.Fatalf("expected balanced forced-pointer batch to store a block-compressed frame")
+	if header.Flags&valuelog.FrameFlagCompressed != 0 {
+		t.Fatalf("expected balanced forced-pointer high-entropy batch to use grouped raw frame")
 	}
 	if header.DictID != 0 {
-		t.Fatalf("expected no dict id for block-compressed high-entropy payload, got %d", header.DictID)
-	}
-	if got := valuelog.BlockCodec(header.Reserved); got != valuelog.BlockCodecSnappy {
-		t.Fatalf("block codec=%v want snappy", got)
+		t.Fatalf("expected no dict id for high-entropy raw payload, got %d", header.DictID)
 	}
 	writeSnap := snapshotLaneVlogWriteMode(&db.lanes[0])
-	if writeSnap.Frames[vlogWriteBlock] == 0 {
-		t.Fatalf("expected block write-mode observation")
+	if writeSnap.Frames[vlogWriteOff] == 0 {
+		t.Fatalf("expected raw/off write-mode observation")
 	}
-	if writeSnap.Frames[vlogWriteOff] != 0 {
-		t.Fatalf("expected no raw/off write-mode observation for balanced forced-pointer payload")
+	if writeSnap.Frames[vlogWriteBlock] != 0 {
+		t.Fatalf("expected no block write-mode observation for high-entropy raw bypass")
 	}
 	selectorSnap := db.lanes[0].vlogCompressionSelector.snapshot()
 	if selectorSnap.framesByCandidate[vlogAutoCandidateOff] != 0 {
-		t.Fatalf("expected stable block forced-pointer batch not to train selector off frames")
+		t.Fatalf("expected high-entropy forced-pointer bypass not to train selector off frames")
 	}
 }
 

--- a/TreeDB/caching/vlog_compression_regression_test.go
+++ b/TreeDB/caching/vlog_compression_regression_test.go
@@ -477,7 +477,7 @@ func TestAppendValueLog_AutoBalancedForcePointerHighEntropyPayloadUsesGroupedBlo
 	}
 }
 
-func TestAppendValueLog_AutoBalancedForcePointerDictSelectorOffUsesGroupedBlockFrame(t *testing.T) {
+func TestAppendValueLog_AutoBalancedValueLogDictSelectorOffUsesGroupedBlockFrame(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "value.log")
 	writer, err := valuelog.NewWriter(path, page.ValueLogFileID(1))
@@ -501,7 +501,7 @@ func TestAppendValueLog_AutoBalancedForcePointerDictSelectorOffUsesGroupedBlockF
 		valueLogAutoPolicy:       uint8(vlogAutoBalanced),
 		valueLogBlockCodec:       valuelog.BlockCodecSnappy,
 		valueLogBlockTargetBytes: 4096,
-		forceValueLogPointers:    true,
+		valueLogThreshold:        page.DefaultInlineThreshold,
 		lanes: []lane{
 			{id: 0, vlog: writer, vlogCompressionSelector: selector},
 		},
@@ -536,7 +536,7 @@ func TestAppendValueLog_AutoBalancedForcePointerDictSelectorOffUsesGroupedBlockF
 		t.Fatalf("frame K=%d want grouped K=%d", header.K, len(records))
 	}
 	if header.Flags&valuelog.FrameFlagCompressed == 0 {
-		t.Fatalf("expected storage-first forced-pointer dict-available batch to store a block-compressed frame")
+		t.Fatalf("expected storage-first value-log dict-available batch to store a block-compressed frame")
 	}
 	if header.DictID != 0 {
 		t.Fatalf("expected selector-off remap to store block frame without dict id, got %d", header.DictID)
@@ -546,7 +546,7 @@ func TestAppendValueLog_AutoBalancedForcePointerDictSelectorOffUsesGroupedBlockF
 		t.Fatalf("expected block write-mode observation")
 	}
 	if writeSnap.Frames[vlogWriteOff] != 0 {
-		t.Fatalf("expected no raw/off write-mode observation for storage-first forced-pointer dict path")
+		t.Fatalf("expected no raw/off write-mode observation for storage-first value-log dict path")
 	}
 }
 
@@ -886,6 +886,7 @@ func TestAppendValueLogOne_AutoHoldOffSkipsDictSampling(t *testing.T) {
 		closeCh:                 make(chan struct{}),
 		valueLogCompressionMode: uint8(vlogCompressionAuto),
 		valueLogBlockCodec:      valuelog.BlockCodecSnappy,
+		valueLogThreshold:       1 << 20,
 		valueLogAutotuneOptions: valuelog.AutotuneOptions{Mode: valuelog.AutotuneOff},
 		valueLogDictTrainer:     tr,
 		lanes: []lane{

--- a/TreeDB/caching/vlog_compression_selector.go
+++ b/TreeDB/caching/vlog_compression_selector.go
@@ -1442,11 +1442,7 @@ func (db *DB) storageFirstValueLogAuto(unitPayloadBytes int) bool {
 	if db.forceValueLogPointers {
 		return true
 	}
-	threshold := db.valueLogThreshold
-	if threshold <= 0 {
-		threshold = page.DefaultInlineThreshold
-	}
-	return unitPayloadBytes > threshold
+	return unitPayloadBytes > db.minValueLogInlineThreshold()
 }
 
 func (db *DB) valueLogPayloadExceedsInlineThreshold(unitPayloadBytes int) bool {
@@ -1456,11 +1452,21 @@ func (db *DB) valueLogPayloadExceedsInlineThreshold(unitPayloadBytes int) bool {
 	if db.forceValueLogPointers {
 		return true
 	}
+	return unitPayloadBytes > db.minValueLogInlineThreshold()
+}
+
+func (db *DB) minValueLogInlineThreshold() int {
 	threshold := db.valueLogThreshold
 	if threshold <= 0 {
 		threshold = page.DefaultInlineThreshold
 	}
-	return unitPayloadBytes > threshold
+	for i := range db.valueLogDomainThresholds {
+		domainThreshold := db.valueLogDomainThresholds[i].InlineThreshold
+		if domainThreshold >= 0 && domainThreshold < threshold {
+			threshold = domainThreshold
+		}
+	}
+	return threshold
 }
 
 func (db *DB) storageFirstMediumValueLogAuto(unitPayloadBytes int) bool {

--- a/TreeDB/caching/vlog_compression_selector.go
+++ b/TreeDB/caching/vlog_compression_selector.go
@@ -1428,6 +1428,16 @@ func chooseLargePayloadNoDictBlockCodec(l *lane, configured valuelog.BlockCodec)
 	return configured
 }
 
+func (db *DB) storageFirstForcePointerAuto(unitPayloadBytes int) bool {
+	if db == nil || !db.forceValueLogPointers {
+		return false
+	}
+	if unitPayloadBytes < forcePointerAutoBlockMinPayloadBytes {
+		return false
+	}
+	return normalizeVlogAutoPolicy(db.valueLogAutoPolicy) != vlogAutoThroughput
+}
+
 func (db *DB) preferLeafPageBlockCodec(l *lane, unitPayloadBytes int, configured valuelog.BlockCodec) (valuelog.BlockCodec, bool) {
 	if db == nil || l == nil || !db.indexOuterLeavesInValueLog {
 		return configured, false
@@ -1566,7 +1576,7 @@ func (db *DB) resolveVlogWriteMode(l *lane, dictID uint64, rawPayloadBytes, unit
 		if unitPayloadBytes <= 0 {
 			unitPayloadBytes = rawPayloadBytes
 		}
-		if dictID == 0 && db.forceValueLogPointers && unitPayloadBytes >= forcePointerAutoBlockMinPayloadBytes {
+		if dictID == 0 && db.storageFirstForcePointerAuto(unitPayloadBytes) {
 			return vlogWriteBlock, db.valueLogBlockCodec, false
 		}
 		if dictID == 0 && normalizeVlogAutoPolicy(db.valueLogAutoPolicy) == vlogAutoThroughput && unitPayloadBytes >= throughputAutoBlockMinPayloadBytes {
@@ -1584,7 +1594,11 @@ func (db *DB) resolveVlogWriteMode(l *lane, dictID uint64, rawPayloadBytes, unit
 			}
 			return vlogWriteBlock, db.valueLogBlockCodec, false
 		}
-		return l.vlogCompressionSelector.choose(dictID != 0, rawPayloadBytes, unitPayloadBytes)
+		chosenMode, chosenCodec, probe := l.vlogCompressionSelector.choose(dictID != 0, rawPayloadBytes, unitPayloadBytes)
+		if chosenMode == vlogWriteOff && db.storageFirstForcePointerAuto(unitPayloadBytes) {
+			return vlogWriteBlock, chooseLargePayloadNoDictBlockCodec(l, db.valueLogBlockCodec), probe
+		}
+		return chosenMode, chosenCodec, probe
 	}
 }
 

--- a/TreeDB/caching/vlog_compression_selector.go
+++ b/TreeDB/caching/vlog_compression_selector.go
@@ -87,10 +87,10 @@ const (
 	// on a stable block codec path and let the frame preparer fall back to raw
 	// only when compressed bytes are not worth keeping.
 	forcePointerAutoBlockMinPayloadBytes = 512
-	// High-entropy forced-pointer streams should bypass compression even at the
-	// block fast-path threshold. This keeps auto mode close to off-mode on
-	// incompressible workloads without disabling block grouping for JSON-like
-	// retained payloads.
+	// High-entropy forced-pointer streams may bypass compression in explicit
+	// throughput policy. Balanced/size policy treats forced pointers as durable
+	// storage-first payloads and keeps them on block compression so retained JSON
+	// does not silently land as raw value-log frames.
 	forcePointerAutoRawBypassMinPayloadBytes = 512
 	forcePointerAutoRawBypassMaxPayloadBytes = 1024
 	// Larger grouped-frame targets reduce per-record compression overhead for
@@ -1593,6 +1593,9 @@ func (db *DB) shouldBypassAutoRawValueCompression(dictID uint64, records []value
 		return false
 	}
 	if dictID != 0 || !db.forceValueLogPointers || payloadKind != vlogPayloadKindSingleValue {
+		return false
+	}
+	if normalizeVlogAutoPolicy(db.valueLogAutoPolicy) != vlogAutoThroughput {
 		return false
 	}
 	if unitPayloadBytes < forcePointerAutoRawBypassMinPayloadBytes ||

--- a/TreeDB/caching/vlog_compression_selector.go
+++ b/TreeDB/caching/vlog_compression_selector.go
@@ -1449,6 +1449,20 @@ func (db *DB) storageFirstValueLogAuto(unitPayloadBytes int) bool {
 	return unitPayloadBytes > threshold
 }
 
+func (db *DB) valueLogPayloadExceedsInlineThreshold(unitPayloadBytes int) bool {
+	if db == nil {
+		return false
+	}
+	if db.forceValueLogPointers {
+		return true
+	}
+	threshold := db.valueLogThreshold
+	if threshold <= 0 {
+		threshold = page.DefaultInlineThreshold
+	}
+	return unitPayloadBytes > threshold
+}
+
 func (db *DB) storageFirstMediumValueLogAuto(unitPayloadBytes int) bool {
 	return db.storageFirstValueLogAuto(unitPayloadBytes) &&
 		unitPayloadBytes < largePayloadBlockTargetMinPayloadBytes
@@ -1622,10 +1636,10 @@ func (db *DB) shouldBypassAutoRawValueCompression(dictID uint64, records []value
 	if db == nil || normalizeVlogCompressionMode(db.valueLogCompressionMode) != vlogCompressionAuto {
 		return false
 	}
-	if dictID != 0 || !db.forceValueLogPointers || payloadKind != vlogPayloadKindSingleValue {
+	if dictID != 0 || payloadKind != vlogPayloadKindSingleValue {
 		return false
 	}
-	if normalizeVlogAutoPolicy(db.valueLogAutoPolicy) != vlogAutoThroughput {
+	if !db.valueLogPayloadExceedsInlineThreshold(unitPayloadBytes) {
 		return false
 	}
 	if unitPayloadBytes < forcePointerAutoRawBypassMinPayloadBytes ||
@@ -1714,7 +1728,7 @@ func (db *DB) chooseValueLogRawWriteK(l *lane, records int, autoRawBypass, pause
 	}
 	k := 1
 	switch {
-	case db != nil && autoRawBypass && db.forceValueLogPointers:
+	case db != nil && autoRawBypass:
 		k = valuelog.MaxFrameK
 	case db != nil && paused && db.disableJournal:
 		k = valuelog.MaxFrameK

--- a/TreeDB/caching/vlog_compression_selector.go
+++ b/TreeDB/caching/vlog_compression_selector.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"github.com/snissn/gomap/TreeDB/internal/valuelog"
+	"github.com/snissn/gomap/TreeDB/page"
 )
 
 type vlogCompressionMode uint8
@@ -1428,14 +1429,29 @@ func chooseLargePayloadNoDictBlockCodec(l *lane, configured valuelog.BlockCodec)
 	return configured
 }
 
-func (db *DB) storageFirstForcePointerAuto(unitPayloadBytes int) bool {
-	if db == nil || !db.forceValueLogPointers {
+func (db *DB) storageFirstValueLogAuto(unitPayloadBytes int) bool {
+	if db == nil {
 		return false
 	}
 	if unitPayloadBytes < forcePointerAutoBlockMinPayloadBytes {
 		return false
 	}
-	return normalizeVlogAutoPolicy(db.valueLogAutoPolicy) != vlogAutoThroughput
+	if normalizeVlogAutoPolicy(db.valueLogAutoPolicy) == vlogAutoThroughput {
+		return false
+	}
+	if db.forceValueLogPointers {
+		return true
+	}
+	threshold := db.valueLogThreshold
+	if threshold <= 0 {
+		threshold = page.DefaultInlineThreshold
+	}
+	return unitPayloadBytes > threshold
+}
+
+func (db *DB) storageFirstMediumValueLogAuto(unitPayloadBytes int) bool {
+	return db.storageFirstValueLogAuto(unitPayloadBytes) &&
+		unitPayloadBytes < largePayloadBlockTargetMinPayloadBytes
 }
 
 func (db *DB) preferLeafPageBlockCodec(l *lane, unitPayloadBytes int, configured valuelog.BlockCodec) (valuelog.BlockCodec, bool) {
@@ -1576,8 +1592,8 @@ func (db *DB) resolveVlogWriteMode(l *lane, dictID uint64, rawPayloadBytes, unit
 		if unitPayloadBytes <= 0 {
 			unitPayloadBytes = rawPayloadBytes
 		}
-		if dictID == 0 && db.storageFirstForcePointerAuto(unitPayloadBytes) {
-			return vlogWriteBlock, db.valueLogBlockCodec, false
+		if dictID == 0 && db.storageFirstValueLogAuto(unitPayloadBytes) {
+			return vlogWriteBlock, chooseLargePayloadNoDictBlockCodec(l, db.valueLogBlockCodec), false
 		}
 		if dictID == 0 && normalizeVlogAutoPolicy(db.valueLogAutoPolicy) == vlogAutoThroughput && unitPayloadBytes >= throughputAutoBlockMinPayloadBytes {
 			return vlogWriteBlock, db.valueLogBlockCodec, false
@@ -1595,7 +1611,7 @@ func (db *DB) resolveVlogWriteMode(l *lane, dictID uint64, rawPayloadBytes, unit
 			return vlogWriteBlock, db.valueLogBlockCodec, false
 		}
 		chosenMode, chosenCodec, probe := l.vlogCompressionSelector.choose(dictID != 0, rawPayloadBytes, unitPayloadBytes)
-		if chosenMode == vlogWriteOff && db.storageFirstForcePointerAuto(unitPayloadBytes) {
+		if chosenMode == vlogWriteOff && db.storageFirstValueLogAuto(unitPayloadBytes) {
 			return vlogWriteBlock, chooseLargePayloadNoDictBlockCodec(l, db.valueLogBlockCodec), probe
 		}
 		return chosenMode, chosenCodec, probe
@@ -1752,7 +1768,7 @@ func (db *DB) chooseValueLogBlockWriteK(l *lane, records, rawPayloadBytes int, c
 	// collapse K on fallback paths.
 	useSelectorRatio := compressionMode == vlogCompressionAuto && l != nil && l.vlogCompressionSelector != nil
 	stableFastPath := compressionMode == vlogCompressionAuto &&
-		((db.forceValueLogPointers && avgPayloadBytes >= forcePointerAutoBlockMinPayloadBytes) ||
+		(db.storageFirstMediumValueLogAuto(avgPayloadBytes) ||
 			(normalizeVlogAutoPolicy(db.valueLogAutoPolicy) == vlogAutoThroughput && avgPayloadBytes >= throughputAutoBlockMinPayloadBytes))
 	if useSelectorRatio && !stableFastPath {
 		ratio, ratioSamples = l.vlogCompressionSelector.blockObservedRatioWithSamples(codec)
@@ -1769,8 +1785,7 @@ func (db *DB) chooseValueLogBlockWriteK(l *lane, records, rawPayloadBytes int, c
 			targetCompressedBytes = leafLogBlockTargetCompressedBytes
 		}
 	}
-	if db.forceValueLogPointers &&
-		avgPayloadBytes >= forcePointerAutoBlockMinPayloadBytes &&
+	if db.storageFirstMediumValueLogAuto(avgPayloadBytes) &&
 		ratioSamples == 0 &&
 		ratio >= 0.98 {
 		// Retained-payload value-log streams are expected to be JSON-like in the
@@ -1785,10 +1800,8 @@ func (db *DB) chooseValueLogBlockWriteK(l *lane, records, rawPayloadBytes int, c
 		// forms grouped frames; normal observed ratios take over after writes.
 		ratio = 0.50
 	}
-	if db.forceValueLogPointers && targetCompressedBytes < forcePointerBlockTargetCompressedBytes {
-		if avgPayloadBytes >= forcePointerAutoBlockMinPayloadBytes {
-			targetCompressedBytes = forcePointerBlockTargetCompressedBytes
-		}
+	if db.storageFirstMediumValueLogAuto(avgPayloadBytes) && targetCompressedBytes < forcePointerBlockTargetCompressedBytes {
+		targetCompressedBytes = forcePointerBlockTargetCompressedBytes
 	}
 	if avgPayloadBytes >= largePayloadBlockTargetMinPayloadBytes {
 		largePayloadTargetBytes := valuelog.NormalizeBlockTargetCompressedBytes(avgPayloadBytes * largePayloadBlockTargetMultiplier)

--- a/TreeDB/caching/vlog_compression_selector_test.go
+++ b/TreeDB/caching/vlog_compression_selector_test.go
@@ -1063,12 +1063,12 @@ func TestResolveVlogWriteMode_ForcePointersLargeBypassesSelectorToConfiguredBloc
 	}
 }
 
-func TestResolveVlogWriteMode_StorageFirstForcePointersWithDictCannotSelectOff(t *testing.T) {
+func TestResolveVlogWriteMode_StorageFirstValueLogWithDictCannotSelectOff(t *testing.T) {
 	db := &DB{
 		valueLogCompressionMode: uint8(vlogCompressionAuto),
 		valueLogAutoPolicy:      uint8(vlogAutoBalanced),
 		valueLogBlockCodec:      valuelog.BlockCodecSnappy,
-		forceValueLogPointers:   true,
+		valueLogThreshold:       page.DefaultInlineThreshold,
 	}
 	s := newVlogCompressionSelector(vlogAutoBalanced, 0, 0)
 	s.dwellBytes = 0
@@ -1081,18 +1081,19 @@ func TestResolveVlogWriteMode_StorageFirstForcePointersWithDictCannotSelectOff(t
 	s.metrics[vlogAutoCandidateDict] = vlogCandidateMetrics{ratio: 0.99, throughput: 0.2, samples: 16}
 	l := &lane{vlogCompressionSelector: s}
 
-	mode, codec, probe := db.resolveVlogWriteMode(l, 7, forcePointerAutoBlockMinPayloadBytes*4, forcePointerAutoBlockMinPayloadBytes, false)
+	unitPayloadBytes := forcePointerAutoBlockMinPayloadBytes + 128
+	mode, codec, probe := db.resolveVlogWriteMode(l, 7, unitPayloadBytes*4, unitPayloadBytes, false)
 	if mode != vlogWriteBlock || codec != valuelog.BlockCodecSnappy || probe {
-		t.Fatalf("expected storage-first forced pointers to remap selector off to block, got mode=%v codec=%v probe=%t", mode, codec, probe)
+		t.Fatalf("expected storage-first value-log payload to remap selector off to block, got mode=%v codec=%v probe=%t", mode, codec, probe)
 	}
 }
 
-func TestResolveVlogWriteMode_ThroughputForcePointersWithDictCanSelectOff(t *testing.T) {
+func TestResolveVlogWriteMode_ThroughputValueLogWithDictCanSelectOff(t *testing.T) {
 	db := &DB{
 		valueLogCompressionMode: uint8(vlogCompressionAuto),
 		valueLogAutoPolicy:      uint8(vlogAutoThroughput),
 		valueLogBlockCodec:      valuelog.BlockCodecSnappy,
-		forceValueLogPointers:   true,
+		valueLogThreshold:       page.DefaultInlineThreshold,
 	}
 	s := newVlogCompressionSelector(vlogAutoThroughput, 0, 0)
 	s.dwellBytes = 0
@@ -1105,9 +1106,10 @@ func TestResolveVlogWriteMode_ThroughputForcePointersWithDictCanSelectOff(t *tes
 	s.metrics[vlogAutoCandidateDict] = vlogCandidateMetrics{ratio: 0.99, throughput: 0.2, samples: 16}
 	l := &lane{vlogCompressionSelector: s}
 
-	mode, _, probe := db.resolveVlogWriteMode(l, 7, forcePointerAutoBlockMinPayloadBytes*4, forcePointerAutoBlockMinPayloadBytes, false)
+	unitPayloadBytes := forcePointerAutoBlockMinPayloadBytes + 128
+	mode, _, probe := db.resolveVlogWriteMode(l, 7, unitPayloadBytes*4, unitPayloadBytes, false)
 	if mode != vlogWriteOff || probe {
-		t.Fatalf("expected throughput forced pointers to keep selector off, got mode=%v probe=%t", mode, probe)
+		t.Fatalf("expected throughput value-log payload to keep selector off, got mode=%v probe=%t", mode, probe)
 	}
 }
 

--- a/TreeDB/caching/vlog_compression_selector_test.go
+++ b/TreeDB/caching/vlog_compression_selector_test.go
@@ -1063,6 +1063,54 @@ func TestResolveVlogWriteMode_ForcePointersLargeBypassesSelectorToConfiguredBloc
 	}
 }
 
+func TestResolveVlogWriteMode_StorageFirstForcePointersWithDictCannotSelectOff(t *testing.T) {
+	db := &DB{
+		valueLogCompressionMode: uint8(vlogCompressionAuto),
+		valueLogAutoPolicy:      uint8(vlogAutoBalanced),
+		valueLogBlockCodec:      valuelog.BlockCodecSnappy,
+		forceValueLogPointers:   true,
+	}
+	s := newVlogCompressionSelector(vlogAutoBalanced, 0, 0)
+	s.dwellBytes = 0
+	s.exploreBytes = 0
+	s.exploreRemaining = 0
+	s.currentCandidate = vlogAutoCandidateOff
+	s.metrics[vlogAutoCandidateOff] = vlogCandidateMetrics{ratio: 1.0, throughput: 1.0, samples: 16}
+	s.metrics[vlogAutoCandidateBlockSnappy] = vlogCandidateMetrics{ratio: 0.99, throughput: 0.2, samples: 16}
+	s.metrics[vlogAutoCandidateBlockLZ4] = vlogCandidateMetrics{ratio: 0.99, throughput: 0.2, samples: 16}
+	s.metrics[vlogAutoCandidateDict] = vlogCandidateMetrics{ratio: 0.99, throughput: 0.2, samples: 16}
+	l := &lane{vlogCompressionSelector: s}
+
+	mode, codec, probe := db.resolveVlogWriteMode(l, 7, forcePointerAutoBlockMinPayloadBytes*4, forcePointerAutoBlockMinPayloadBytes, false)
+	if mode != vlogWriteBlock || codec != valuelog.BlockCodecSnappy || probe {
+		t.Fatalf("expected storage-first forced pointers to remap selector off to block, got mode=%v codec=%v probe=%t", mode, codec, probe)
+	}
+}
+
+func TestResolveVlogWriteMode_ThroughputForcePointersWithDictCanSelectOff(t *testing.T) {
+	db := &DB{
+		valueLogCompressionMode: uint8(vlogCompressionAuto),
+		valueLogAutoPolicy:      uint8(vlogAutoThroughput),
+		valueLogBlockCodec:      valuelog.BlockCodecSnappy,
+		forceValueLogPointers:   true,
+	}
+	s := newVlogCompressionSelector(vlogAutoThroughput, 0, 0)
+	s.dwellBytes = 0
+	s.exploreBytes = 0
+	s.exploreRemaining = 0
+	s.currentCandidate = vlogAutoCandidateOff
+	s.metrics[vlogAutoCandidateOff] = vlogCandidateMetrics{ratio: 1.0, throughput: 1.0, samples: 16}
+	s.metrics[vlogAutoCandidateBlockSnappy] = vlogCandidateMetrics{ratio: 0.99, throughput: 0.2, samples: 16}
+	s.metrics[vlogAutoCandidateBlockLZ4] = vlogCandidateMetrics{ratio: 0.99, throughput: 0.2, samples: 16}
+	s.metrics[vlogAutoCandidateDict] = vlogCandidateMetrics{ratio: 0.99, throughput: 0.2, samples: 16}
+	l := &lane{vlogCompressionSelector: s}
+
+	mode, _, probe := db.resolveVlogWriteMode(l, 7, forcePointerAutoBlockMinPayloadBytes*4, forcePointerAutoBlockMinPayloadBytes, false)
+	if mode != vlogWriteOff || probe {
+		t.Fatalf("expected throughput forced pointers to keep selector off, got mode=%v probe=%t", mode, probe)
+	}
+}
+
 func TestShouldBypassAutoRawValueCompression_ForcePointerHighEntropy(t *testing.T) {
 	db := &DB{
 		valueLogCompressionMode: uint8(vlogCompressionAuto),

--- a/TreeDB/caching/vlog_compression_selector_test.go
+++ b/TreeDB/caching/vlog_compression_selector_test.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"testing"
 
+	backenddb "github.com/snissn/gomap/TreeDB/db"
 	"github.com/snissn/gomap/TreeDB/internal/valuelog"
 	"github.com/snissn/gomap/TreeDB/page"
 )
@@ -1086,6 +1087,34 @@ func TestResolveVlogWriteMode_StorageFirstValueLogWithDictCannotSelectOff(t *tes
 	}
 }
 
+func TestResolveVlogWriteMode_StorageFirstValueLogUsesDomainThreshold(t *testing.T) {
+	db := &DB{
+		valueLogCompressionMode: uint8(vlogCompressionAuto),
+		valueLogAutoPolicy:      uint8(vlogAutoBalanced),
+		valueLogBlockCodec:      valuelog.BlockCodecSnappy,
+		valueLogThreshold:       1 << 20,
+		valueLogDomainThresholds: []backenddb.ValueLogDomainThreshold{
+			{Prefix: []byte("hot/"), InlineThreshold: page.DefaultInlineThreshold},
+		},
+	}
+	s := newVlogCompressionSelector(vlogAutoBalanced, 0, 0)
+	s.dwellBytes = 0
+	s.exploreBytes = 0
+	s.exploreRemaining = 0
+	s.currentCandidate = vlogAutoCandidateOff
+	s.metrics[vlogAutoCandidateOff] = vlogCandidateMetrics{ratio: 1.0, throughput: 1.0, samples: 16}
+	s.metrics[vlogAutoCandidateBlockSnappy] = vlogCandidateMetrics{ratio: 0.99, throughput: 0.2, samples: 16}
+	s.metrics[vlogAutoCandidateBlockLZ4] = vlogCandidateMetrics{ratio: 0.99, throughput: 0.2, samples: 16}
+	s.metrics[vlogAutoCandidateDict] = vlogCandidateMetrics{ratio: 0.99, throughput: 0.2, samples: 16}
+	l := &lane{vlogCompressionSelector: s}
+
+	unitPayloadBytes := forcePointerAutoBlockMinPayloadBytes + 128
+	mode, codec, probe := db.resolveVlogWriteMode(l, 7, unitPayloadBytes*4, unitPayloadBytes, false)
+	if mode != vlogWriteBlock || codec != valuelog.BlockCodecSnappy || probe {
+		t.Fatalf("expected domain-threshold value-log payload to remap selector off to block, got mode=%v codec=%v probe=%t", mode, codec, probe)
+	}
+}
+
 func TestResolveVlogWriteMode_ThroughputValueLogWithDictCanSelectOff(t *testing.T) {
 	db := &DB{
 		valueLogCompressionMode: uint8(vlogCompressionAuto),
@@ -1153,6 +1182,18 @@ func TestShouldBypassAutoRawValueCompression_StorageOwnedHighEntropy(t *testing.
 	}
 	if !thresholdDB.shouldBypassAutoRawValueCompression(0, records, len(value), vlogPayloadKindSingleValue) {
 		t.Fatal("expected high-entropy threshold-owned value batch to bypass auto compression")
+	}
+
+	domainThresholdDB := &DB{
+		valueLogCompressionMode: uint8(vlogCompressionAuto),
+		valueLogAutoPolicy:      uint8(vlogAutoBalanced),
+		valueLogThreshold:       1 << 20,
+		valueLogDomainThresholds: []backenddb.ValueLogDomainThreshold{
+			{Prefix: []byte("hot/"), InlineThreshold: 1},
+		},
+	}
+	if !domainThresholdDB.shouldBypassAutoRawValueCompression(0, records, len(value), vlogPayloadKindSingleValue) {
+		t.Fatal("expected high-entropy domain-threshold-owned value batch to bypass auto compression")
 	}
 }
 

--- a/TreeDB/caching/vlog_compression_selector_test.go
+++ b/TreeDB/caching/vlog_compression_selector_test.go
@@ -1,6 +1,7 @@
 package caching
 
 import (
+	"bytes"
 	"sync"
 	"testing"
 
@@ -546,7 +547,7 @@ func TestChooseValueLogRawWriteK_LiveLeafLogCapsGroupedFramesForColdReads(t *tes
 			},
 		},
 		{
-			name: "force-pointer auto raw bypass",
+			name: "auto raw bypass",
 			configure: func(db *DB) {
 				db.forceValueLogPointers = true
 			},
@@ -600,10 +601,7 @@ func TestChooseValueLogRawWriteK_NonLeafRawPolicyUnchanged(t *testing.T) {
 			want: 16,
 		},
 		{
-			name: "force-pointer auto raw bypass",
-			configure: func(db *DB) {
-				db.forceValueLogPointers = true
-			},
+			name:          "auto raw bypass",
 			autoRawBypass: true,
 			want:          valuelog.MaxFrameK,
 		},
@@ -1113,10 +1111,10 @@ func TestResolveVlogWriteMode_ThroughputValueLogWithDictCanSelectOff(t *testing.
 	}
 }
 
-func TestShouldBypassAutoRawValueCompression_ForcePointerHighEntropy(t *testing.T) {
+func TestShouldBypassAutoRawValueCompression_StorageOwnedHighEntropy(t *testing.T) {
 	db := &DB{
 		valueLogCompressionMode: uint8(vlogCompressionAuto),
-		valueLogAutoPolicy:      uint8(vlogAutoThroughput),
+		valueLogAutoPolicy:      uint8(vlogAutoBalanced),
 		forceValueLogPointers:   true,
 	}
 	value := make([]byte, forcePointerAutoRawBypassMinPayloadBytes)
@@ -1147,39 +1145,28 @@ func TestShouldBypassAutoRawValueCompression_ForcePointerHighEntropy(t *testing.
 	if db.shouldBypassAutoRawValueCompression(0, records, len(value), vlogPayloadKindOuterLeaf) {
 		t.Fatal("expected outer-leaf payloads to keep leaf-log compression selection")
 	}
+
+	thresholdDB := &DB{
+		valueLogCompressionMode: uint8(vlogCompressionAuto),
+		valueLogAutoPolicy:      uint8(vlogAutoBalanced),
+		valueLogThreshold:       1,
+	}
+	if !thresholdDB.shouldBypassAutoRawValueCompression(0, records, len(value), vlogPayloadKindSingleValue) {
+		t.Fatal("expected high-entropy threshold-owned value batch to bypass auto compression")
+	}
 }
 
-func TestShouldBypassAutoRawValueCompression_BalancedForcePointerHighEntropyStaysEligible(t *testing.T) {
+func TestShouldBypassAutoRawValueCompression_CompressibleStorageOwnedStaysEligible(t *testing.T) {
 	db := &DB{
 		valueLogCompressionMode: uint8(vlogCompressionAuto),
 		valueLogAutoPolicy:      uint8(vlogAutoBalanced),
-		forceValueLogPointers:   true,
+		valueLogThreshold:       1,
 	}
-	value := make([]byte, forcePointerAutoRawBypassMinPayloadBytes)
-	for i := range value {
-		value[i] = byte(i)
-	}
-	records := []valuelog.Record{
-		{RID: 1, Value: value},
-		{RID: 2, Value: value},
-		{RID: 3, Value: value},
-	}
-
-	if db.shouldBypassAutoRawValueCompression(0, records, len(value), vlogPayloadKindSingleValue) {
-		t.Fatal("expected balanced force-pointer value batch to stay eligible for block compression")
-	}
-}
-
-func TestShouldBypassAutoRawValueCompression_CompressibleStaysEligible(t *testing.T) {
-	db := &DB{
-		valueLogCompressionMode: uint8(vlogCompressionAuto),
-		forceValueLogPointers:   true,
-	}
-	value := make([]byte, forcePointerAutoRawBypassMinPayloadBytes)
+	value := bytes.Repeat([]byte(`{"text":"retained-json","did":"did:plc:abc"}`), 16)
 	records := []valuelog.Record{{RID: 1, Value: value}}
 
 	if db.shouldBypassAutoRawValueCompression(0, records, len(value), vlogPayloadKindSingleValue) {
-		t.Fatal("expected low-entropy value batch to stay eligible for selector sampling")
+		t.Fatal("expected JSON-like retained value batch to stay eligible for compression")
 	}
 }
 

--- a/TreeDB/caching/vlog_compression_selector_test.go
+++ b/TreeDB/caching/vlog_compression_selector_test.go
@@ -1066,6 +1066,7 @@ func TestResolveVlogWriteMode_ForcePointersLargeBypassesSelectorToConfiguredBloc
 func TestShouldBypassAutoRawValueCompression_ForcePointerHighEntropy(t *testing.T) {
 	db := &DB{
 		valueLogCompressionMode: uint8(vlogCompressionAuto),
+		valueLogAutoPolicy:      uint8(vlogAutoThroughput),
 		forceValueLogPointers:   true,
 	}
 	value := make([]byte, forcePointerAutoRawBypassMinPayloadBytes)
@@ -1095,6 +1096,27 @@ func TestShouldBypassAutoRawValueCompression_ForcePointerHighEntropy(t *testing.
 	}
 	if db.shouldBypassAutoRawValueCompression(0, records, len(value), vlogPayloadKindOuterLeaf) {
 		t.Fatal("expected outer-leaf payloads to keep leaf-log compression selection")
+	}
+}
+
+func TestShouldBypassAutoRawValueCompression_BalancedForcePointerHighEntropyStaysEligible(t *testing.T) {
+	db := &DB{
+		valueLogCompressionMode: uint8(vlogCompressionAuto),
+		valueLogAutoPolicy:      uint8(vlogAutoBalanced),
+		forceValueLogPointers:   true,
+	}
+	value := make([]byte, forcePointerAutoRawBypassMinPayloadBytes)
+	for i := range value {
+		value[i] = byte(i)
+	}
+	records := []valuelog.Record{
+		{RID: 1, Value: value},
+		{RID: 2, Value: value},
+		{RID: 3, Value: value},
+	}
+
+	if db.shouldBypassAutoRawValueCompression(0, records, len(value), vlogPayloadKindSingleValue) {
+		t.Fatal("expected balanced force-pointer value batch to stay eligible for block compression")
 	}
 }
 


### PR DESCRIPTION
Closes #2301.

This final evidence-refresh pass fixes the remaining production JSONBench value-log raw-frame gap for pointer-threshold retained payloads. The earlier storage-first logic covered forced-pointer streams, but the 1M production JSONBench run writes retained payloads through the default value-log threshold path. This changes auto compression to treat threshold-owned value-log payloads as storage-first as well, while preserving grouped raw/off frames for clearly high-entropy 512-1024 byte payload batches.

What changed:
- Treat balanced/size auto value-log payloads above the effective inline threshold as storage-first, not only `forceValueLogPointers` payloads.
- Include lowered `ValueLogDomainInlineThresholds` in that effective-threshold decision by using the minimum active threshold when append-time selector state no longer has key-prefix context.
- Remap selector raw/off choices to block compression for storage-first value-log payloads.
- Bootstrap grouped frames for medium retained payloads on the threshold path so batching is enabled before lane ratios exist.
- Keep clearly high-entropy 512-1024 byte value-log batches on grouped raw/off frames to preserve the incompressible auto-vs-off perf gate.
- Keep throughput policy behavior able to select raw/off.
- Update regression coverage for threshold-path grouped block frames, domain-threshold storage-first decisions, high-entropy grouped raw frames, and selector-off behavior.

Local validation:
- `GOCACHE=/tmp/go-cache-treedb-2301-targeted GOROOT= /opt/homebrew/bin/go test ./TreeDB/caching -run 'TestStorageFirstValueLogAuto_UsesMinimumDomainThreshold|TestResolveVlogWriteMode_StorageFirstValueLogUsesDomainThreshold|TestShouldBypassAutoRawValueCompression|TestAppendValueLog_AutoBalancedForcePointerHighEntropyPayloadUsesGroupedRawFrame|TestAppendValueLog_AutoForcePointerMediumPayloadUsesGroupedBlockFrame|TestAppendValueLog_AutoBalancedValueLogDictSelectorOffUsesGroupedBlockFrame|TestResolveVlogWriteMode_StorageFirstValueLogWithDictCannotSelectOff|TestResolveVlogWriteMode_ThroughputValueLogWithDictCanSelectOff' -count=1`
- `GOCACHE=/tmp/go-cache-treedb-2301-broad GOROOT= /opt/homebrew/bin/go test ./TreeDB/caching ./TreeDB/internal/valuelog ./TreeDB/db ./TreeDB/cmd/treemap -run 'ValueLog|Vlog|vlog|Compression|CompactStorage|LeafGeneration' -count=1`
- Exact local perf-smoke gate: `PASS incompressible auto-vs-off gate`; throughput fraction `1.2059`; size fraction `0.9901`.

Remote 1M JSONBench evidence, no reconstruction because the reconstruction path is separately slow on latest main:
- gomap commit: `4b0cc34451df2085631d48e9149db27759ac55fa`
- JSONBench commit: `07844fa758101ad6d38b703478cefc0f0bd61c9e`
- Result: `/tmp/treedb_value_log_storage_first_1m_20260605_013336/run_1m/result.json`
- Audit: `/tmp/treedb_value_log_storage_first_1m_20260605_013336/run_1m/compression_audit/compression_audit.json`
- Shape: `storage_layout=column-store-full-prepared`, `data_shape=full-retained-json`, `retained_payload_policy=non-column`, `typed_column_owner=typed_column_part`, `column_reconstruction_policy=retained-payload-and-columns`
- Durable excluding command WAL: `263,133,612` bytes
- `leaf_vlog`: `155,515,064` bytes, raw-frame payload fraction `0.0`, stored/raw `0.498`
- `value_vlog`: `25,776,576` bytes, raw-frame payload fraction `0.0`, stored/raw `0.476`
- `column_asset_segments`: `79,153,284` bytes
- Query best seconds: q1 `0.067795516`, q2 `0.52575385`, q3 `0.194568349`, q4 `0.199130024`, q5 `0.205856022`

Previous latest-main no-reconstruction comparison before this branch head was `286,954,506` durable bytes with `value_vlog` raw-mode fraction `0.856`; this run removes that raw-frame gap and saves about `23.8 MB` on the 1M production shape.
