### PR TITLE
bench: add collection concurrency benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,17 @@ Two secondary indexes, April 27 collection/SQLite matrix.
 Source:
 [April 27 collection/SQLite matrix](docs/benchmarks/collections_rewrite_vacuum_matrix_pr1075_2026-04-27.md).
 
+### Collection Concurrency Workload
+
+The collection insert/read/lookup rows above are single benchmark-driver rows.
+For concurrent collection-layer reads and mixed read/write evidence, use the
+separate concurrency report. In the June 4 run, TreeDB template-v1 primary reads
+into a caller buffer measured 332.3 ns/op at `GOMAXPROCS=12`; mixed primary
+reads with one writer measured 2.96M reader ops/sec and 44.3k writer docs/sec.
+
+Source:
+[June 4 collection concurrency report](docs/benchmarks/collections_concurrency_main_2026-06-04.md).
+
 ### `application.db` Offline Density Workload
 
 Offline compacted-size comparison from the June 2 Celestia `application.db`

--- a/TreeDB/collections/concurrency_bench_test.go
+++ b/TreeDB/collections/concurrency_bench_test.go
@@ -1,0 +1,129 @@
+package collections_test
+
+import (
+	"fmt"
+	"runtime"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/collections"
+)
+
+func benchmarkReportCollectionConcurrency(b *testing.B, kind string) {
+	b.Helper()
+	b.ReportMetric(float64(runtime.GOMAXPROCS(0)), "gomaxprocs")
+	b.ReportMetric(2, "indexes/doc")
+	if kind != "" {
+		// Keep the benchmark name as the primary machine-readable label. The string
+		// parameter exists so callers are explicit about the concurrency shape they
+		// are reporting when this helper grows more counters.
+		_ = kind
+	}
+}
+
+func BenchmarkCollectionConcurrencyReadPrimaryParallel(b *testing.B) {
+	backend, collection := openBenchmarkCollection(b, "bench_concurrency_read_primary", collectionShapeIndexes(2)...)
+	ids := seedBenchmarkCollection(b, collection, 0, collectionBenchSeedDocs, true)
+	benchmarkSyncBoundary(b, backend)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	benchmarkReportCollectionConcurrency(b, "primary_read_parallel")
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		stride := runtime.GOMAXPROCS(0)
+		if stride <= 0 {
+			stride = 1
+		}
+		for pb.Next() {
+			if _, err := collection.Get(ids[i%len(ids)]); err != nil {
+				b.Errorf("concurrent primary read: %v", err)
+			}
+			i += stride
+		}
+	})
+}
+
+func BenchmarkCollectionConcurrencyReadPrimaryIntoParallel(b *testing.B) {
+	backend, collection := openBenchmarkCollection(b, "bench_concurrency_read_primary_into", collectionShapeIndexes(2)...)
+	ids := seedBenchmarkCollection(b, collection, 0, collectionBenchSeedDocs, true)
+	benchmarkSyncBoundary(b, backend)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	benchmarkReportCollectionConcurrency(b, "primary_read_into_parallel")
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		stride := runtime.GOMAXPROCS(0)
+		if stride <= 0 {
+			stride = 1
+		}
+		buf := make([]byte, 0, 8<<10)
+		for pb.Next() {
+			got, found, err := collection.GetInto(ids[i%len(ids)], buf)
+			if err != nil {
+				b.Errorf("concurrent primary read into: %v", err)
+			}
+			if !found {
+				b.Errorf("concurrent primary read into: document not found")
+			}
+			buf = got
+			i += stride
+		}
+	})
+}
+
+func BenchmarkCollectionConcurrencySecondaryLookupUniqueParallel(b *testing.B) {
+	backend, collection := openBenchmarkCollection(
+		b,
+		"bench_concurrency_secondary_unique",
+		collections.IndexDefinition{Name: "email_idx", Field: "email", ValueType: collections.IndexValueString, Unique: true},
+	)
+	seedBenchmarkCollection(b, collection, 0, collectionBenchSeedDocs, true)
+	benchmarkSyncBoundary(b, backend)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	benchmarkReportCollectionConcurrency(b, "secondary_unique_parallel")
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		stride := runtime.GOMAXPROCS(0)
+		if stride <= 0 {
+			stride = 1
+		}
+		for pb.Next() {
+			email := fmt.Sprintf("user-%09d@example.com", i%collectionBenchSeedDocs)
+			if _, err := collection.FindByIndex("email_idx", email); err != nil {
+				b.Errorf("concurrent unique secondary lookup: %v", err)
+			}
+			i += stride
+		}
+	})
+}
+
+func BenchmarkCollectionConcurrencySecondaryLookupNonUniqueParallel(b *testing.B) {
+	backend, collection := openBenchmarkCollection(
+		b,
+		"bench_concurrency_secondary_nonunique",
+		collections.IndexDefinition{Name: "city_idx", Field: "city", ValueType: collections.IndexValueString},
+	)
+	seedBenchmarkCollection(b, collection, 0, collectionBenchSeedDocs, true)
+	benchmarkSyncBoundary(b, backend)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	benchmarkReportCollectionConcurrency(b, "secondary_nonunique_parallel")
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		stride := runtime.GOMAXPROCS(0)
+		if stride <= 0 {
+			stride = 1
+		}
+		for pb.Next() {
+			city := fmt.Sprintf("city-%02d", i%collectionBenchCities)
+			if _, err := collection.FindByIndex("city_idx", city); err != nil {
+				b.Errorf("concurrent nonunique secondary lookup: %v", err)
+			}
+			i += stride
+		}
+	})
+}

--- a/TreeDB/collections/sqlite_concurrency_bench_test.go
+++ b/TreeDB/collections/sqlite_concurrency_bench_test.go
@@ -1,0 +1,524 @@
+//go:build sqlite_bench && cgo
+
+package collections_test
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type sqliteConcurrencyConnCase struct {
+	name  string
+	conns int
+}
+
+func sqliteConcurrencyConnCases() []sqliteConcurrencyConnCase {
+	gomax := runtime.GOMAXPROCS(0)
+	if gomax <= 0 {
+		gomax = 1
+	}
+	cases := []sqliteConcurrencyConnCase{{name: "conns_1", conns: 1}}
+	if gomax != 1 {
+		cases = append(cases, sqliteConcurrencyConnCase{name: "conns_gomaxprocs", conns: gomax})
+	}
+	return cases
+}
+
+func configureBenchmarkSQLiteConcurrency(db *sql.DB, conns int) {
+	if conns <= 0 {
+		conns = 1
+	}
+	db.SetMaxOpenConns(conns)
+	db.SetMaxIdleConns(conns)
+}
+
+func reportSQLiteConcurrency(b *testing.B, conns int) {
+	b.Helper()
+	b.ReportMetric(float64(runtime.GOMAXPROCS(0)), "gomaxprocs")
+	b.ReportMetric(float64(conns), "sqlite_max_open_conns")
+	b.ReportMetric(2, "indexes/doc")
+}
+
+func BenchmarkSQLiteConcurrencyReadPrimaryJSONParallel(b *testing.B) {
+	for _, cc := range sqliteConcurrencyConnCases() {
+		b.Run(cc.name, func(b *testing.B) {
+			db := openBenchmarkSQLiteJSONShapeDB(b, fmt.Sprintf("bench_sqlite_concurrency_read_json_%s", cc.name), 2)
+			configureBenchmarkSQLiteConcurrency(db, cc.conns)
+			ids := seedBenchmarkSQLiteJSON(b, db, collectionBenchSeedDocs)
+			checkpointSQLiteWAL(b, db)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			reportSQLiteConcurrency(b, cc.conns)
+			b.RunParallel(func(pb *testing.PB) {
+				stmt, err := db.Prepare(`SELECT document FROM documents WHERE id = ?`)
+				if err != nil {
+					b.Errorf("sqlite prepare concurrent JSON primary read: %v", err)
+					return
+				}
+				defer stmt.Close()
+				i := 0
+				stride := runtime.GOMAXPROCS(0)
+				if stride <= 0 {
+					stride = 1
+				}
+				var doc string
+				for pb.Next() {
+					if err := stmt.QueryRow(ids[i%len(ids)]).Scan(&doc); err != nil {
+						b.Errorf("sqlite concurrent JSON primary read: %v", err)
+					}
+					i += stride
+				}
+			})
+		})
+	}
+}
+
+func BenchmarkSQLiteConcurrencyReadPrimaryNativeColumnsParallel(b *testing.B) {
+	for _, cc := range sqliteConcurrencyConnCases() {
+		b.Run(cc.name, func(b *testing.B) {
+			db := openBenchmarkSQLiteNativeColumnsShapeDB(b, fmt.Sprintf("bench_sqlite_concurrency_read_native_%s", cc.name), 2)
+			configureBenchmarkSQLiteConcurrency(db, cc.conns)
+			docs := seedBenchmarkSQLiteNativeColumns(b, db, collectionBenchSeedDocs)
+			checkpointSQLiteWAL(b, db)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			reportSQLiteConcurrency(b, cc.conns)
+			b.RunParallel(func(pb *testing.PB) {
+				stmt, err := db.Prepare(`SELECT name, email, city, pad FROM documents WHERE id = ?`)
+				if err != nil {
+					b.Errorf("sqlite prepare concurrent native primary read: %v", err)
+					return
+				}
+				defer stmt.Close()
+				i := 0
+				stride := runtime.GOMAXPROCS(0)
+				if stride <= 0 {
+					stride = 1
+				}
+				var name, email, city, pad string
+				for pb.Next() {
+					if err := stmt.QueryRow(docs[i%len(docs)].id).Scan(&name, &email, &city, &pad); err != nil {
+						b.Errorf("sqlite concurrent native primary read: %v", err)
+					}
+					i += stride
+				}
+			})
+		})
+	}
+}
+
+func BenchmarkSQLiteConcurrencySecondaryLookupJSONParallel(b *testing.B) {
+	for _, cc := range sqliteConcurrencyConnCases() {
+		b.Run(cc.name, func(b *testing.B) {
+			b.Run("unique", func(b *testing.B) {
+				benchmarkSQLiteConcurrencySecondaryLookupJSON(b, cc.conns, true)
+			})
+			b.Run("non_unique", func(b *testing.B) {
+				benchmarkSQLiteConcurrencySecondaryLookupJSON(b, cc.conns, false)
+			})
+		})
+	}
+}
+
+func benchmarkSQLiteConcurrencySecondaryLookupJSON(b *testing.B, conns int, unique bool) {
+	db := openBenchmarkSQLiteJSONShapeDB(b, fmt.Sprintf("bench_sqlite_concurrency_secondary_json_c%d", conns), 2)
+	configureBenchmarkSQLiteConcurrency(db, conns)
+	seedBenchmarkSQLiteJSON(b, db, collectionBenchSeedDocs)
+	checkpointSQLiteWAL(b, db)
+	query := `SELECT id FROM documents WHERE email = ?`
+	if !unique {
+		query = `SELECT id FROM documents WHERE city = ?`
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	reportSQLiteConcurrency(b, conns)
+	b.RunParallel(func(pb *testing.PB) {
+		stmt, err := db.Prepare(query)
+		if err != nil {
+			b.Errorf("sqlite prepare concurrent JSON secondary lookup: %v", err)
+			return
+		}
+		defer stmt.Close()
+		i := 0
+		stride := runtime.GOMAXPROCS(0)
+		if stride <= 0 {
+			stride = 1
+		}
+		for pb.Next() {
+			if unique {
+				email := benchmarkSQLiteUserEmail(i % collectionBenchSeedDocs)
+				var id string
+				if err := stmt.QueryRow(email).Scan(&id); err != nil {
+					b.Errorf("sqlite concurrent unique JSON lookup: %v", err)
+				}
+			} else {
+				city := benchmarkSQLiteCity(i)
+				rows, err := stmt.Query(city)
+				if err != nil {
+					b.Errorf("sqlite concurrent nonunique JSON lookup: %v", err)
+					return
+				}
+				for rows.Next() {
+					var id string
+					if err := rows.Scan(&id); err != nil {
+						_ = rows.Close()
+						b.Errorf("sqlite concurrent nonunique JSON scan: %v", err)
+						return
+					}
+				}
+				if err := rows.Err(); err != nil {
+					_ = rows.Close()
+					b.Errorf("sqlite concurrent nonunique JSON rows: %v", err)
+					return
+				}
+				if err := rows.Close(); err != nil {
+					b.Errorf("sqlite concurrent nonunique JSON close: %v", err)
+					return
+				}
+			}
+			i += stride
+		}
+	})
+}
+
+func BenchmarkSQLiteConcurrencySecondaryLookupNativeColumnsParallel(b *testing.B) {
+	for _, cc := range sqliteConcurrencyConnCases() {
+		b.Run(cc.name, func(b *testing.B) {
+			b.Run("unique", func(b *testing.B) {
+				benchmarkSQLiteConcurrencySecondaryLookupNativeColumns(b, cc.conns, true)
+			})
+			b.Run("non_unique", func(b *testing.B) {
+				benchmarkSQLiteConcurrencySecondaryLookupNativeColumns(b, cc.conns, false)
+			})
+		})
+	}
+}
+
+func benchmarkSQLiteConcurrencySecondaryLookupNativeColumns(b *testing.B, conns int, unique bool) {
+	db := openBenchmarkSQLiteNativeColumnsShapeDB(b, fmt.Sprintf("bench_sqlite_concurrency_secondary_native_c%d", conns), 2)
+	configureBenchmarkSQLiteConcurrency(db, conns)
+	seedBenchmarkSQLiteNativeColumns(b, db, collectionBenchSeedDocs)
+	checkpointSQLiteWAL(b, db)
+	query := `SELECT id FROM documents WHERE email = ?`
+	if !unique {
+		query = `SELECT id FROM documents WHERE city = ?`
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	reportSQLiteConcurrency(b, conns)
+	b.RunParallel(func(pb *testing.PB) {
+		stmt, err := db.Prepare(query)
+		if err != nil {
+			b.Errorf("sqlite prepare concurrent native secondary lookup: %v", err)
+			return
+		}
+		defer stmt.Close()
+		i := 0
+		stride := runtime.GOMAXPROCS(0)
+		if stride <= 0 {
+			stride = 1
+		}
+		for pb.Next() {
+			if unique {
+				email := benchmarkSQLiteUserEmail(i % collectionBenchSeedDocs)
+				var id string
+				if err := stmt.QueryRow(email).Scan(&id); err != nil {
+					b.Errorf("sqlite concurrent unique native lookup: %v", err)
+				}
+			} else {
+				city := benchmarkSQLiteCity(i)
+				rows, err := stmt.Query(city)
+				if err != nil {
+					b.Errorf("sqlite concurrent nonunique native lookup: %v", err)
+					return
+				}
+				for rows.Next() {
+					var id string
+					if err := rows.Scan(&id); err != nil {
+						_ = rows.Close()
+						b.Errorf("sqlite concurrent nonunique native scan: %v", err)
+						return
+					}
+				}
+				if err := rows.Err(); err != nil {
+					_ = rows.Close()
+					b.Errorf("sqlite concurrent nonunique native rows: %v", err)
+					return
+				}
+				if err := rows.Close(); err != nil {
+					b.Errorf("sqlite concurrent nonunique native close: %v", err)
+					return
+				}
+			}
+			i += stride
+		}
+	})
+}
+
+func sqliteConcurrencyJSONDocumentBatch(start, count int) ([]string, []string) {
+	ids := make([]string, count)
+	docs := make([]string, count)
+	for i := 0; i < count; i++ {
+		docNum := start + i
+		ids[i] = string(benchmarkDocumentID(docNum))
+		docs[i] = string(benchmarkIndexedDocument(docNum))
+	}
+	return ids, docs
+}
+
+func sqliteConcurrencyNativeColumnsDocumentBatch(start, count int) []benchmarkSQLiteNativeColumnsDocument {
+	docs := make([]benchmarkSQLiteNativeColumnsDocument, count)
+	for i := range docs {
+		docNum := start + i
+		docs[i] = benchmarkSQLiteNativeColumnsDocument{
+			id:    string(benchmarkDocumentID(docNum)),
+			name:  benchmarkSQLiteUserName(docNum),
+			email: benchmarkSQLiteUserEmail(docNum),
+			city:  benchmarkSQLiteCity(docNum),
+			pad:   collectionBenchIndexedPad,
+		}
+	}
+	return docs
+}
+
+func insertSQLiteDocumentBatchErr(ctx context.Context, db *sql.DB, ids, docs []string) error {
+	if len(ids) != len(docs) {
+		return fmt.Errorf("sqlite batch length mismatch ids=%d docs=%d", len(ids), len(docs))
+	}
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("sqlite begin: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	stmt, err := tx.PrepareContext(ctx, sqliteInsertIndexedDocumentSQL)
+	if err != nil {
+		return fmt.Errorf("sqlite prepare insert: %w", err)
+	}
+	defer stmt.Close()
+
+	for i := range ids {
+		if _, err := stmt.ExecContext(ctx, ids[i], docs[i]); err != nil {
+			return fmt.Errorf("sqlite insert %d: %w", i, err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("sqlite commit: %w", err)
+	}
+	committed = true
+	return nil
+}
+
+func insertSQLiteNativeColumnsDocumentBatchErr(ctx context.Context, db *sql.DB, docs []benchmarkSQLiteNativeColumnsDocument) error {
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("sqlite native-columns begin: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	stmt, err := tx.PrepareContext(ctx, sqliteInsertNativeColumnsIndexedDocumentSQL)
+	if err != nil {
+		return fmt.Errorf("sqlite native-columns prepare insert: %w", err)
+	}
+	defer stmt.Close()
+
+	for i := range docs {
+		doc := docs[i]
+		if _, err := stmt.ExecContext(ctx, doc.id, doc.name, doc.email, doc.city, doc.pad); err != nil {
+			return fmt.Errorf("sqlite native-columns insert %d: %w", i, err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("sqlite native-columns commit: %w", err)
+	}
+	committed = true
+	return nil
+}
+
+type sqliteMixedConcurrencyCase struct {
+	readers int
+	writers int
+}
+
+func BenchmarkSQLiteConcurrencyMixedReadWriteJSON(b *testing.B) {
+	for _, tc := range []sqliteMixedConcurrencyCase{{readers: 1, writers: 1}, {readers: 4, writers: 1}, {readers: 8, writers: 2}} {
+		b.Run(fmt.Sprintf("readers_%d/writers_%d", tc.readers, tc.writers), func(b *testing.B) {
+			benchmarkSQLiteConcurrencyMixedReadWriteJSON(b, tc.readers, tc.writers)
+		})
+	}
+}
+
+func benchmarkSQLiteConcurrencyMixedReadWriteJSON(b *testing.B, readers, writers int) {
+	if readers <= 0 {
+		readers = 1
+	}
+	if writers <= 0 {
+		writers = 1
+	}
+	db := openBenchmarkSQLiteJSONShapeDB(b, fmt.Sprintf("bench_sqlite_mixed_json_r%d_w%d", readers, writers), 2)
+	conns := readers + writers + 1
+	configureBenchmarkSQLiteConcurrency(db, conns)
+	ids := seedBenchmarkSQLiteJSON(b, db, collectionBenchSeedDocs)
+	checkpointSQLiteWAL(b, db)
+	benchmarkSQLiteConcurrencyMixedReadWrite(b, db, readers, writers, conns, ids, nil)
+}
+
+func BenchmarkSQLiteConcurrencyMixedReadWriteNativeColumns(b *testing.B) {
+	for _, tc := range []sqliteMixedConcurrencyCase{{readers: 1, writers: 1}, {readers: 4, writers: 1}, {readers: 8, writers: 2}} {
+		b.Run(fmt.Sprintf("readers_%d/writers_%d", tc.readers, tc.writers), func(b *testing.B) {
+			benchmarkSQLiteConcurrencyMixedReadWriteNativeColumns(b, tc.readers, tc.writers)
+		})
+	}
+}
+
+func benchmarkSQLiteConcurrencyMixedReadWriteNativeColumns(b *testing.B, readers, writers int) {
+	if readers <= 0 {
+		readers = 1
+	}
+	if writers <= 0 {
+		writers = 1
+	}
+	db := openBenchmarkSQLiteNativeColumnsShapeDB(b, fmt.Sprintf("bench_sqlite_mixed_native_r%d_w%d", readers, writers), 2)
+	conns := readers + writers + 1
+	configureBenchmarkSQLiteConcurrency(db, conns)
+	docs := seedBenchmarkSQLiteNativeColumns(b, db, collectionBenchSeedDocs)
+	checkpointSQLiteWAL(b, db)
+	ids := make([]string, len(docs))
+	for i := range docs {
+		ids[i] = docs[i].id
+	}
+	benchmarkSQLiteConcurrencyMixedReadWrite(b, db, readers, writers, conns, ids, docs)
+}
+
+func benchmarkSQLiteConcurrencyMixedReadWrite(b *testing.B, db *sql.DB, readers, writers, conns int, ids []string, nativeDocs []benchmarkSQLiteNativeColumnsDocument) {
+	ctx := context.Background()
+	writeBatchSize := benchmarkIntEnv(b, "TREEDB_COLLECTION_MIXED_WRITE_BATCH_SIZE", defaultCollectionMixedWriteBatchSize)
+	if writeBatchSize <= 0 {
+		writeBatchSize = defaultCollectionMixedWriteBatchSize
+	}
+	if maxBatch := benchmarkBatchSize(b); writeBatchSize > maxBatch {
+		writeBatchSize = maxBatch
+	}
+
+	var stop atomic.Bool
+	var writerDocs atomic.Uint64
+	errCh := make(chan error, readers+writers)
+	startCh := make(chan struct{})
+	var readerWG sync.WaitGroup
+	var writerWG sync.WaitGroup
+
+	for writerID := 0; writerID < writers; writerID++ {
+		writerID := writerID
+		writerWG.Add(1)
+		go func() {
+			defer writerWG.Done()
+			<-startCh
+			for next := 1_000_000 + writerID*100_000_000; !stop.Load(); next += writeBatchSize {
+				var err error
+				if nativeDocs == nil {
+					batchIDs, docs := sqliteConcurrencyJSONDocumentBatch(next, writeBatchSize)
+					err = insertSQLiteDocumentBatchErr(ctx, db, batchIDs, docs)
+				} else {
+					docs := sqliteConcurrencyNativeColumnsDocumentBatch(next, writeBatchSize)
+					err = insertSQLiteNativeColumnsDocumentBatchErr(ctx, db, docs)
+				}
+				if err != nil {
+					select {
+					case errCh <- err:
+					default:
+					}
+					return
+				}
+				writerDocs.Add(uint64(writeBatchSize))
+			}
+		}()
+	}
+
+	readBase := b.N / readers
+	readRemainder := b.N % readers
+	for readerID := 0; readerID < readers; readerID++ {
+		readerID := readerID
+		readOps := readBase
+		if readerID < readRemainder {
+			readOps++
+		}
+		readerWG.Add(1)
+		go func() {
+			defer readerWG.Done()
+			stmt, err := db.PrepareContext(ctx, `SELECT id FROM documents WHERE id = ?`)
+			if err != nil {
+				select {
+				case errCh <- err:
+				default:
+				}
+				return
+			}
+			defer stmt.Close()
+			<-startCh
+			stride := runtime.GOMAXPROCS(0)
+			if stride <= 0 {
+				stride = 1
+			}
+			i := (readerID * max(1, len(ids)/readers)) % len(ids)
+			for op := 0; op < readOps; op++ {
+				var id string
+				if err := stmt.QueryRowContext(ctx, ids[i%len(ids)]).Scan(&id); err != nil {
+					select {
+					case errCh <- err:
+					default:
+					}
+					return
+				}
+				i += stride
+			}
+		}()
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.ReportMetric(float64(readers), "readers")
+	b.ReportMetric(float64(writers), "writers")
+	b.ReportMetric(float64(conns), "sqlite_max_open_conns")
+	b.ReportMetric(float64(runtime.GOMAXPROCS(0)), "gomaxprocs")
+	b.ReportMetric(float64(writeBatchSize), "writer_docs/batch")
+	start := time.Now()
+	close(startCh)
+
+	readerWG.Wait()
+	readerElapsed := time.Since(start)
+	b.StopTimer()
+	stop.Store(true)
+	writerWG.Wait()
+	select {
+	case err := <-errCh:
+		b.Fatalf("sqlite mixed concurrency benchmark: %v", err)
+	default:
+	}
+	if readerElapsed > 0 {
+		b.ReportMetric(float64(b.N)/readerElapsed.Seconds(), "reader_ops/sec")
+	}
+	writerElapsed := time.Since(start)
+	if writerElapsed > 0 {
+		b.ReportMetric(float64(writerDocs.Load())/writerElapsed.Seconds(), "writer_docs/sec")
+	}
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -49,6 +49,7 @@ Behavioral guarantees for downstream systems (e.g., replication layers).
 - **[YCSB MongoDB / TreeDB Status](benchmarks/ycsb_mongodb_treedb_current.md)**: Current report index and rerun plan for MongoDB, `treedb-native`, and TreeDB Mongo gateway.
 - **[TreeDB Collections Canonical Benchmark](benchmarks/collections_canonical_benchmark.md)**: Canonical TreeDB-vs-SQLite collection benchmark and maintenance-phase semantics.
 - **[Two-Index Collection Insert Rerun](benchmarks/collections_insert_two_index_exhaustive_main_2026-06-04.md)**: Current TreeDB-vs-SQLite two-index insert throughput and exhaustive/VACUUM-equivalent compacted storage rows.
+- **[TreeDB-vs-SQLite Collection Concurrency](benchmarks/collections_concurrency_main_2026-06-04.md)**: Concurrent collection read/lookup and mixed read/write rows with explicit `GOMAXPROCS` and SQLite connection-pool metadata.
 - **[Unified Bench](../cmd/unified_bench/README.md)**: Usage guide for benchmark execution and artifact capture.
 - **[BenchProf](../cmd/benchprof/README.md)**: Analysis tool for CPU/alloc/block/mutex profiles and ops/sec outputs.
 - **[Redis Protocol Benchmarking](REDIS_PROTOCOL_BENCHMARKING.md)**: Preferred way to measure Redis wrapper throughput.

--- a/docs/benchmarks/collections_canonical_benchmark.md
+++ b/docs/benchmarks/collections_canonical_benchmark.md
@@ -5,6 +5,10 @@ SQLite. It exists to prevent the earlier reporting mistake where TreeDB's
 partial online maintenance size was presented as if it were a fully compacted
 state.
 
+The canonical insert/read rows are single benchmark-driver rows. Use
+`scripts/bench_collections_concurrency.sh` and the concurrency report when making
+claims about concurrent collection-layer reads or mixed read/write workloads.
+
 ## Run
 
 The canonical end-to-end run target is:

--- a/docs/benchmarks/collections_concurrency_main_2026-06-04.md
+++ b/docs/benchmarks/collections_concurrency_main_2026-06-04.md
@@ -1,0 +1,73 @@
+# TreeDB-vs-SQLite Collection Concurrency Benchmark — June 4, 2026
+
+This report adds collection-layer concurrency evidence alongside the canonical
+single-client insert/read rows. It should not be mixed with the single-client
+storage-density claims in the README tables.
+
+## Run Context
+
+- Commit: `4ee6a8891f976de22216fcfa56e061b3bb54ea73` plus issue #2327 benchmark harness changes.
+- Host: Linux `mikers-B560-DS3H-AC-Y1`, Intel i5-11400F, Go `go1.25.7 linux/amd64`.
+- Artifact: `/tmp/collections_concurrency_2327_current_20260604_151045`.
+- Command:
+
+```sh
+OUT_DIR=/tmp/collections_concurrency_2327_current_20260604_151045 \
+  COUNT=1 BENCHTIME=1s CPU_LIST=1,2,4,8,12 \
+  scripts/bench_collections_concurrency.sh
+```
+
+TreeDB settings were the collection benchmark defaults used by the script:
+`command_wal_relaxed`, template-v1 documents, batch size `16000`, and data/index
+outer leaves in the value log. SQLite used WAL, `synchronous=NORMAL`,
+`wal_autocheckpoint=0`, and rows report `sqlite_max_open_conns` when relevant.
+
+## Interpretation
+
+- Existing README collection insert/read/lookup rows remain single benchmark-driver
+  rows unless they explicitly reference this concurrency report.
+- Go's `-cpu` suffix records `GOMAXPROCS`; benchmark rows also emit a
+  `gomaxprocs` metric.
+- TreeDB mixed rows below use one writer and concurrent readers. SQLite mixed
+  rows include the configured reader/writer counts and connection-pool size.
+- These rows are benchmark harness evidence, not a complete concurrency contract.
+
+## Selected Read/Lookup Rows
+
+| workload | engine / format | GOMAXPROCS=1 ns/op | GOMAXPROCS=12 ns/op | allocs/op |
+| --- | --- | ---: | ---: | ---: |
+| Primary read into caller buffer | TreeDB template-v1 | 725.0 | 332.3 | 1 |
+| Primary read | SQLite native columns, pooled conns | 4,968 | 1,438 | 33 |
+| Unique secondary lookup | TreeDB template-v1 | 2,482 | 2,207 | 20 |
+| Unique secondary lookup | SQLite native columns, pooled conns | 3,627 | 1,278 | 20 |
+| Nonunique secondary lookup | TreeDB template-v1 | 6,675 | 4,799 | 81 |
+| Nonunique secondary lookup | SQLite native columns, pooled conns | 28,004 | 5,150 | 208 |
+
+## Selected Mixed Read/Write Rows
+
+| workload | engine / format | GOMAXPROCS=1 reader ops/sec | GOMAXPROCS=12 reader ops/sec | GOMAXPROCS=1 writer docs/sec | GOMAXPROCS=12 writer docs/sec |
+| --- | --- | ---: | ---: | ---: | ---: |
+| primary reads + 1 writer | TreeDB template-v1 | 509,944 | 2,964,434 | 26,299 | 44,298 |
+| unique-index reads + 1 writer | TreeDB template-v1 | 145,286 | 88,160 | 21,039 | 49,211 |
+| 4 readers + 1 writer | SQLite native columns | 271,237 | 731,421 | 32,320 | 30,835 |
+| 8 readers + 2 writers | SQLite native columns | 290,805 | 778,468 | 21,096 | 107,872 |
+
+## Full Artifact Pointers
+
+- TreeDB JSON output: `/tmp/collections_concurrency_2327_current_20260604_151045/treedb/go_test.json`
+- TreeDB bench text: `/tmp/collections_concurrency_2327_current_20260604_151045/treedb/bench.txt`
+- SQLite JSON output: `/tmp/collections_concurrency_2327_current_20260604_151045/sqlite/go_test.json`
+- SQLite bench text: `/tmp/collections_concurrency_2327_current_20260604_151045/sqlite/bench.txt`
+
+## Reproduction Notes
+
+Use the checked-in runner:
+
+```sh
+OUT_DIR=/tmp/collections_concurrency_$(date +%Y%m%d_%H%M%S) \
+  COUNT=1 BENCHTIME=3s CPU_LIST=1,2,4,8,12 \
+  scripts/bench_collections_concurrency.sh
+```
+
+The runner writes normalized `go test -json` artifacts and extracted benchmark
+text for TreeDB and SQLite under the output directory.

--- a/scripts/bench_collections_concurrency.sh
+++ b/scripts/bench_collections_concurrency.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+cd "$ROOT"
+
+OUT_DIR="${OUT_DIR:-$(mktemp -d /tmp/gomap_collections_concurrency_XXXXXX)}"
+COUNT="${COUNT:-1}"
+BENCHTIME="${BENCHTIME:-3s}"
+CPU_LIST="${CPU_LIST:-1,2,4,8,12}"
+TREE_ENGINE="${TREEDB_COLLECTION_BENCH_ENGINE:-command_wal_relaxed}"
+TREE_FORMAT="${TREEDB_COLLECTION_DOCUMENT_FORMAT:-template-v1}"
+TREE_BATCH="${TREEDB_COLLECTION_BENCH_BATCH_SIZE:-16000}"
+DATA_OUTER="${TREEDB_COLLECTION_DATA_OUTER_LEAVES_IN_VLOG:-true}"
+INDEX_OUTER="${TREEDB_COLLECTION_INDEX_OUTER_LEAVES_IN_VLOG:-true}"
+
+TREE_REGEX="${TREE_REGEX:-^BenchmarkCollectionConcurrency(ReadPrimaryParallel|ReadPrimaryIntoParallel|SecondaryLookupUniqueParallel|SecondaryLookupNonUniqueParallel)$|^BenchmarkCollectionMixedReadWrite(Primary|SecondaryUnique)$}"
+SQLITE_REGEX="${SQLITE_REGEX:-^BenchmarkSQLiteConcurrency(ReadPrimaryJSONParallel|ReadPrimaryNativeColumnsParallel|SecondaryLookupJSONParallel|SecondaryLookupNativeColumnsParallel|MixedReadWriteJSON|MixedReadWriteNativeColumns)$}"
+
+mkdir -p "$OUT_DIR"
+
+run_go_bench() {
+  local name=$1
+  local tags=$2
+  local regex=$3
+  local out="$OUT_DIR/$name"
+  mkdir -p "$out"
+  local cmd=(go test)
+  if [[ -n "$tags" ]]; then
+    cmd+=(-tags "$tags")
+  fi
+  cmd+=(./TreeDB/collections -run '^$' -bench "$regex" -benchmem -count "$COUNT" -benchtime "$BENCHTIME" -cpu "$CPU_LIST" -json)
+  echo "running $name -> $out/go_test.json"
+  if [[ "$name" == treedb* ]]; then
+    TREEDB_COLLECTION_BENCH_ENGINE="$TREE_ENGINE" \
+    TREEDB_COLLECTION_DOCUMENT_FORMAT="$TREE_FORMAT" \
+    TREEDB_COLLECTION_BENCH_BATCH_SIZE="$TREE_BATCH" \
+    TREEDB_COLLECTION_DATA_OUTER_LEAVES_IN_VLOG="$DATA_OUTER" \
+    TREEDB_COLLECTION_INDEX_OUTER_LEAVES_IN_VLOG="$INDEX_OUTER" \
+    GOWORK=off "${cmd[@]}" | tee "$out/go_test.json"
+  else
+    GOWORK=off "${cmd[@]}" | tee "$out/go_test.json"
+  fi
+  python3 - "$out/go_test.json" "$out/bench.txt" <<'PY'
+import json, sys
+src, dst = sys.argv[1:3]
+with open(src, encoding='utf-8') as inp, open(dst, 'w', encoding='utf-8') as out:
+    for line in inp:
+        try:
+            item = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if item.get('Action') == 'output':
+            out.write(item.get('Output', ''))
+PY
+}
+
+run_go_bench treedb "" "$TREE_REGEX"
+run_go_bench sqlite sqlite_bench "$SQLITE_REGEX"
+
+cat >"$OUT_DIR/README.md" <<EOF
+# TreeDB-vs-SQLite Collection Concurrency Benchmark
+
+- worktree: \`$ROOT\`
+- branch: \`$(git rev-parse --abbrev-ref HEAD)\`
+- commit: \`$(git rev-parse --short HEAD)\`
+- count: \`$COUNT\`
+- benchtime: \`$BENCHTIME\`
+- cpu list: \`$CPU_LIST\`
+- TreeDB profile: \`$TREE_ENGINE\`
+- TreeDB format: \`$TREE_FORMAT\`
+- TreeDB batch size: \`$TREE_BATCH\`
+- TreeDB storage policy: \`data_outer=$DATA_OUTER,index_outer=$INDEX_OUTER\`
+- SQLite setup: WAL, synchronous=NORMAL, wal_autocheckpoint=0; concurrency rows report \`sqlite_max_open_conns\`.
+
+Artifacts:
+
+- \`treedb/go_test.json\`, \`treedb/bench.txt\`
+- \`sqlite/go_test.json\`, \`sqlite/bench.txt\`
+
+The benchmark suffix from Go's \`-cpu\` sweep records \`GOMAXPROCS\`. Rows also report \`gomaxprocs\`; SQLite rows report \`sqlite_max_open_conns\`.
+EOF
+
+echo "concurrency benchmark bundle: $OUT_DIR"
+echo "bundle index: $OUT_DIR/README.md"


### PR DESCRIPTION
## Summary

Closes #2327 by adding a reproducible TreeDB-vs-SQLite collection concurrency benchmark path and documenting current results.

- Adds TreeDB concurrent primary read, primary read-into, unique secondary lookup, and nonunique secondary lookup benchmarks.
- Adds SQLite concurrent read/lookup benchmarks with explicit `sqlite_max_open_conns` reporting and JSON/native-column variants.
- Adds mixed read/write SQLite benchmarks and reuses existing TreeDB single-writer mixed read/write benchmarks in the runner.
- Adds `scripts/bench_collections_concurrency.sh` to run the TreeDB/SQLite concurrency matrix with `-cpu` sweeps and artifact capture.
- Adds the June 4 concurrency report and updates README/docs caveats so single-client collection rows are not misread as concurrency evidence.

## Evidence

Artifacts:

- `/tmp/collections_concurrency_2327_current_20260604_151045`
- prior failed exploratory multi-writer scaling artifact, not used for headline rows: `/tmp/collections_concurrency_2327_20260604_145349`

Validation:

```sh
GOWORK=off go test ./TreeDB/collections
GOWORK=off go test -tags sqlite_bench ./TreeDB/collections \
  -run '^$' \
  -bench '^BenchmarkSQLiteConcurrency(ReadPrimaryJSONParallel|MixedReadWriteJSON)/' \
  -benchtime=20x -cpu=1,2 -count=1
OUT_DIR=/tmp/collections_concurrency_2327_current_20260604_151045 \
  COUNT=1 BENCHTIME=1s CPU_LIST=1,2,4,8,12 \
  scripts/bench_collections_concurrency.sh
```

Selected current rows are recorded in `docs/benchmarks/collections_concurrency_main_2026-06-04.md`.
