### PR TITLE
collections: reduce indexed insert accumulator growth copies

### DIFF
--- a/TreeDB/collections/freeze_sort_run_table.go
+++ b/TreeDB/collections/freeze_sort_run_table.go
@@ -3,7 +3,6 @@ package collections
 import (
 	"bytes"
 	"errors"
-	"slices"
 	"sort"
 	"sync"
 	"unsafe"
@@ -280,7 +279,7 @@ func (t *freezeSortRunTable) applyStealEntryFuncOwned(ownerGeneration uint64, co
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	t.mustOwnedLocked(ownerGeneration)
-	t.entries = slices.Grow(t.entries, count)
+	t.entries = growFreezeSortRunEntries(t.entries, count)
 	for i := 0; i < count; i++ {
 		key, value, ptr, flags, err := emit(i)
 		if err != nil {
@@ -615,6 +614,28 @@ func (t *freezeSortRunTable) sortedLatestCopyLocked() []freezeSortRunEntry {
 func (t *freezeSortRunTable) sortAndCoalesceLocked() {
 	t.entries = sortAndCoalesceFreezeSortEntries(t.entries)
 	t.sizeBytes = freezeSortEntriesSize(t.entries)
+}
+
+func growFreezeSortRunEntries(entries []freezeSortRunEntry, count int) []freezeSortRunEntry {
+	// Indexed insert accumulators append many similarly-sized batches into the
+	// same mutable root table before publishing. Doubling here keeps append-copy
+	// work bounded for that steady-state path; slices.Grow follows the runtime's
+	// post-threshold growth curve and was visible in batch-insert allocation
+	// profiles as repeated root-run entry copies.
+	if count <= 0 || len(entries)+count <= cap(entries) {
+		return entries
+	}
+	needed := len(entries) + count
+	newCap := cap(entries) * 2
+	if newCap < needed {
+		newCap = needed
+	}
+	if newCap == 0 {
+		newCap = count
+	}
+	grown := make([]freezeSortRunEntry, len(entries), newCap)
+	copy(grown, entries)
+	return grown
 }
 
 func sortAndCoalesceFreezeSortEntries(entries []freezeSortRunEntry) []freezeSortRunEntry {


### PR DESCRIPTION
## Summary

Closes #2339 as the smallest measured indexed-insert planning/staging optimization from the current profile.

- Replaces `slices.Grow` for mutable freeze-sort root-run accumulators with a doubling growth policy.
- Targets the indexed InsertBatch accumulator path, where many similarly-sized batches append into the same root table before publish/flush.
- Keeps append semantics and freeze/coalesce behavior unchanged.

## Validation

```sh
GOWORK=off go test ./TreeDB/collections -run 'TestFreezeSortRunTable|TestCollectionInsertBatchValidatedBSON' -count=1
GOWORK=off go test ./TreeDB/collections -run 'TestFreezeSortRunTable' -count=1
GOWORK=off go test ./TreeDB/collections -count=1
```

## Benchmark / Profile Evidence

Before artifact:

- `/tmp/treedb_insert_planning_2339_before_20260604_170726`

After artifact:

- `/tmp/treedb_insert_planning_2339_after_20260604_170938`

Shared workload: 50k docs, 2 secondary indexes, 1k batch size, 16 insert producers, TreeDB `raw-wire-tcp`, `command_wal_relaxed`, settled read state, pprof enabled.

| metric | before | after |
| --- | ---: | ---: |
| `load_insert_many` foreground duration | 76.589 ms | 69.767 ms |
| `load_insert_many` settled drain duration | 76.444 ms | 92.545 ms |
| `load_insert_many` sampled ns/op | 21,825.4 | 19,924.9 |
| root-run entry growth alloc-space | 23.06 MiB (`slices.Grow`) | 10.63 MiB (`growFreezeSortRunEntries`) |

The end-to-end settled ops/sec row is noisy because this workload includes async settled drain after foreground insert; the targeted profile reduction is the relevant regression guard for this PR.
