### PR TITLE
mongo-gateway: cache collection handles for indexed reads

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3112,6 +3112,16 @@ func (c *Collection) Meta() CollectionMeta {
 	return *c.meta.copy()
 }
 
+// MetaView returns the collection metadata without deep-copying slice fields.
+// The returned value is for read-only internal fast paths; callers must not
+// mutate Indexes, VectorIndexes, or other referenced fields.
+func (c *Collection) MetaView() CollectionMeta {
+	if c == nil {
+		return CollectionMeta{}
+	}
+	return c.meta
+}
+
 // SameCachedCatalog reports whether both handles are cached against the same
 // collection catalog state. For commit-agnostic catalog shapes, the system root
 // is the catalog identity; data-only commits can advance CommitSeq without

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -66,7 +66,7 @@ func (s *Server) insertResponse(command wire.Document, sequences []wire.Document
 
 	var col *collections.Collection
 	format := s.DefaultCollectionOptions.DocumentFormat
-	if existing, err := s.openCollectionCached(name); err == nil {
+	if existing, err := s.Collections.OpenCollection(name); err == nil {
 		col = existing
 		format = existing.MetaView().Options.DocumentFormat
 	} else if !errors.Is(err, collections.ErrCollectionNotFound) {
@@ -866,7 +866,7 @@ func (s *Server) updateResponse(command wire.Document, sequences []wire.Document
 		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
 	}
 
-	col, err := s.openCollectionCached(name)
+	col, err := s.Collections.OpenCollection(name)
 	if err != nil {
 		if errors.Is(err, collections.ErrCollectionNotFound) {
 			return marshalUpdateResponse(0, 0)
@@ -1714,7 +1714,7 @@ func (s *Server) deleteResponse(command wire.Document, sequences []wire.Document
 		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
 	}
 
-	col, err := s.openCollectionCached(name)
+	col, err := s.Collections.OpenCollection(name)
 	if err != nil {
 		if errors.Is(err, collections.ErrCollectionNotFound) {
 			return marshalDeleteResponse(0)
@@ -1867,7 +1867,7 @@ func (s *Server) createCollectionResponse(command wire.Document) (wire.Document,
 	if err := validateCreateCollectionCommand(command); err != nil {
 		return commandError(commandCodeBadValue, "BadValue", err.Error())
 	}
-	if _, err := s.openCollectionCached(name); err == nil {
+	if _, err := s.Collections.OpenCollection(name); err == nil {
 		return marshalDocument(bson.D{
 			{Key: "ok", Value: 1.0},
 			{Key: "note", Value: "TreeDB Mongo gateway treats duplicate create as idempotent success"},
@@ -2015,7 +2015,8 @@ func (s *Server) createIndexesResponse(command wire.Document) (wire.Document, er
 	}
 
 	createdAutomatically := false
-	col, err := s.openCollectionCached(name)
+	s.invalidateCollectionCache(name)
+	col, err := s.Collections.OpenCollection(name)
 	if err != nil {
 		if !errors.Is(err, collections.ErrCollectionNotFound) {
 			return commandError(commandCodeBadValue, "BadValue", err.Error())
@@ -2029,7 +2030,7 @@ func (s *Server) createIndexesResponse(command wire.Document) (wire.Document, er
 			// If another request created the collection after our miss, fall
 			// through to the idempotent add-index path below.
 			createErr := err
-			col, err = s.openCollectionCached(name)
+			col, err = s.Collections.OpenCollection(name)
 			if err != nil {
 				return commandError(commandCodeBadValue, "BadValue", createErr.Error())
 			}
@@ -2128,7 +2129,8 @@ func (s *Server) dropIndexesResponse(command wire.Document) (wire.Document, erro
 	if err != nil {
 		return commandError(commandCodeBadValue, "BadValue", err.Error())
 	}
-	col, err := s.openCollectionCached(name)
+	s.invalidateCollectionCache(name)
+	col, err := s.Collections.OpenCollection(name)
 	if err != nil {
 		if errors.Is(err, collections.ErrCollectionNotFound) {
 			return commandError(commandCodeNamespaceNotFound, "NamespaceNotFound", "collection not found: "+db+"."+collection)
@@ -2931,7 +2933,7 @@ func rawDocumentsBatchLimit(docs []wire.Document, maxDocs int, maxBytes int) (in
 }
 
 func (s *Server) openOrCreateCollection(name string) (*collections.Collection, error) {
-	col, err := s.openCollectionCached(name)
+	col, err := s.Collections.OpenCollection(name)
 	if err == nil {
 		return col, nil
 	}
@@ -2939,7 +2941,7 @@ func (s *Server) openOrCreateCollection(name string) (*collections.Collection, e
 		return nil, createErr
 	}
 	s.invalidateCollectionCache(name)
-	return s.openCollectionCached(name)
+	return s.Collections.OpenCollection(name)
 }
 
 func (s *Server) defaultCollectionMeta(name string) *collections.CollectionMeta {

--- a/TreeDB/mongo_gateway/commands.go
+++ b/TreeDB/mongo_gateway/commands.go
@@ -66,9 +66,9 @@ func (s *Server) insertResponse(command wire.Document, sequences []wire.Document
 
 	var col *collections.Collection
 	format := s.DefaultCollectionOptions.DocumentFormat
-	if existing, err := s.Collections.OpenCollection(name); err == nil {
+	if existing, err := s.openCollectionCached(name); err == nil {
 		col = existing
-		format = existing.Meta().Options.DocumentFormat
+		format = existing.MetaView().Options.DocumentFormat
 	} else if !errors.Is(err, collections.ErrCollectionNotFound) {
 		return commandError(commandCodeBadValue, "BadValue", err.Error())
 	}
@@ -81,7 +81,7 @@ func (s *Server) insertResponse(command wire.Document, sequences []wire.Document
 		if err != nil {
 			return commandError(commandCodeBadValue, "BadValue", err.Error())
 		}
-		if actualFormat := col.Meta().Options.DocumentFormat; actualFormat != format {
+		if actualFormat := col.MetaView().Options.DocumentFormat; actualFormat != format {
 			ids, stored, err = prepareInsertDocuments(documents, actualFormat)
 			if err != nil {
 				return commandError(commandCodeBadValue, "BadValue", err.Error())
@@ -667,7 +667,7 @@ func (s *Server) findResponsePayload(command wire.Document, cursorOwner int64) (
 		doc, err := commandError(commandCodeBadValue, "BadValue", err.Error())
 		return findResponsePayload{document: doc}, err
 	}
-	col, err := s.Collections.OpenCollection(name)
+	col, err := s.openCollectionCached(name)
 	if errors.Is(err, collections.ErrCollectionNotFound) {
 		doc, err := marshalCursorResponse(db, collection, bson.A{})
 		return findResponsePayload{document: doc}, err
@@ -695,7 +695,7 @@ func (s *Server) findResponsePayload(command wire.Document, cursorOwner int64) (
 		return payload, nil
 	}
 	if !plan.projection.present {
-		idx, opts, limit, ok, empty, err := pureIndexedRangeLimitPlan(col.Meta(), plan, s.maxFindScanDocuments())
+		idx, opts, limit, ok, empty, err := pureIndexedRangeLimitPlan(col.MetaView(), plan, s.maxFindScanDocuments())
 		if err != nil {
 			doc, err := commandError(commandCodeBadValue, "BadValue", err.Error())
 			return findResponsePayload{document: doc}, err
@@ -866,7 +866,7 @@ func (s *Server) updateResponse(command wire.Document, sequences []wire.Document
 		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
 	}
 
-	col, err := s.Collections.OpenCollection(name)
+	col, err := s.openCollectionCached(name)
 	if err != nil {
 		if errors.Is(err, collections.ErrCollectionNotFound) {
 			return marshalUpdateResponse(0, 0)
@@ -1114,7 +1114,7 @@ func applyMongoUpdateToStoredDocument(col *collections.Collection, materializer 
 	if err != nil {
 		return nil, false, fmt.Errorf("updates[%d]: %w", update.index, err)
 	}
-	updatedKey, encoded, err := prepareInsertDocument(updated, col.Meta().Options.DocumentFormat)
+	updatedKey, encoded, err := prepareInsertDocument(updated, col.MetaView().Options.DocumentFormat)
 	if err != nil {
 		return nil, false, fmt.Errorf("updates[%d]: %w", update.index, err)
 	}
@@ -1539,7 +1539,7 @@ func mongoUpdateCoalescerBatchCanUseBatch(batch []mongoUpdateCoalescerRequest) b
 	if len(batch) == 0 || batch[0].col == nil {
 		return false
 	}
-	meta := batch[0].col.Meta()
+	meta := batch[0].col.MetaView()
 	for _, req := range batch {
 		if !mongoUpdateCanUseBatchMeta(meta, req.item) {
 			return false
@@ -1559,7 +1559,7 @@ func mongoUpdateItemsCanUseBatch(col *collections.Collection, updates []mongoUpd
 	if col == nil {
 		return false
 	}
-	meta := col.Meta()
+	meta := col.MetaView()
 	for _, update := range updates {
 		if !mongoUpdateCanUseBatchMeta(meta, update) {
 			return false
@@ -1572,7 +1572,7 @@ func mongoUpdateCanUseBatch(col *collections.Collection, update mongoUpdateItem)
 	if col == nil {
 		return false
 	}
-	return mongoUpdateCanUseBatchMeta(col.Meta(), update)
+	return mongoUpdateCanUseBatchMeta(col.MetaView(), update)
 }
 
 func mongoUpdateItemsCanUseBSONSet(col *collections.Collection, updates []mongoUpdateItem) bool {
@@ -1595,7 +1595,7 @@ func normalizedMongoUpdateDocumentFormat(col *collections.Collection) collection
 	if col == nil {
 		return collections.DocumentFormatDefault
 	}
-	format := col.Meta().Options.DocumentFormat
+	format := col.MetaView().Options.DocumentFormat
 	if format == collections.DocumentFormatDefault {
 		return collections.DocumentFormatJSON
 	}
@@ -1714,7 +1714,7 @@ func (s *Server) deleteResponse(command wire.Document, sequences []wire.Document
 		return commandError(commandCodeFailedToParse, "FailedToParse", err.Error())
 	}
 
-	col, err := s.Collections.OpenCollection(name)
+	col, err := s.openCollectionCached(name)
 	if err != nil {
 		if errors.Is(err, collections.ErrCollectionNotFound) {
 			return marshalDeleteResponse(0)
@@ -1867,7 +1867,7 @@ func (s *Server) createCollectionResponse(command wire.Document) (wire.Document,
 	if err := validateCreateCollectionCommand(command); err != nil {
 		return commandError(commandCodeBadValue, "BadValue", err.Error())
 	}
-	if _, err := s.Collections.OpenCollection(name); err == nil {
+	if _, err := s.openCollectionCached(name); err == nil {
 		return marshalDocument(bson.D{
 			{Key: "ok", Value: 1.0},
 			{Key: "note", Value: "TreeDB Mongo gateway treats duplicate create as idempotent success"},
@@ -1878,6 +1878,7 @@ func (s *Server) createCollectionResponse(command wire.Document) (wire.Document,
 	if _, err := s.Collections.CreateCollection(s.defaultCollectionMeta(name)); err != nil {
 		return commandError(commandCodeBadValue, "BadValue", err.Error())
 	}
+	s.invalidateCollectionCache(name)
 	return marshalDocument(bson.D{{Key: "ok", Value: 1.0}})
 }
 
@@ -2014,7 +2015,7 @@ func (s *Server) createIndexesResponse(command wire.Document) (wire.Document, er
 	}
 
 	createdAutomatically := false
-	col, err := s.Collections.OpenCollection(name)
+	col, err := s.openCollectionCached(name)
 	if err != nil {
 		if !errors.Is(err, collections.ErrCollectionNotFound) {
 			return commandError(commandCodeBadValue, "BadValue", err.Error())
@@ -2023,11 +2024,12 @@ func (s *Server) createIndexesResponse(command wire.Document) (wire.Document, er
 		meta.Indexes = scalarDefs
 		meta.VectorIndexes = vectorDefs
 		created, err := s.Collections.CreateCollection(meta)
+		s.invalidateCollectionCache(name)
 		if err != nil {
 			// If another request created the collection after our miss, fall
 			// through to the idempotent add-index path below.
 			createErr := err
-			col, err = s.Collections.OpenCollection(name)
+			col, err = s.openCollectionCached(name)
 			if err != nil {
 				return commandError(commandCodeBadValue, "BadValue", createErr.Error())
 			}
@@ -2040,8 +2042,8 @@ func (s *Server) createIndexesResponse(command wire.Document) (wire.Document, er
 			})
 		}
 	}
-	numBefore := int32(1 + len(col.Meta().Indexes) + len(col.Meta().VectorIndexes))
-	meta := col.Meta()
+	numBefore := int32(1 + len(col.MetaView().Indexes) + len(col.MetaView().VectorIndexes))
+	meta := col.MetaView()
 	if err := validateCreateIndexesCrossKindNames(meta, scalarDefs, vectorDefs); err != nil {
 		return commandError(commandCodeDuplicateKey, "DuplicateKey", err.Error())
 	}
@@ -2072,6 +2074,7 @@ func (s *Server) createIndexesResponse(command wire.Document) (wire.Document, er
 		}
 		meta = *next
 	}
+	s.invalidateCollectionCache(name)
 	return marshalDocument(bson.D{
 		{Key: "ok", Value: 1.0},
 		{Key: "createdCollectionAutomatically", Value: createdAutomatically},
@@ -2096,14 +2099,14 @@ func (s *Server) listIndexesResponse(command wire.Document) (wire.Document, erro
 	if err != nil {
 		return commandError(commandCodeBadValue, "BadValue", err.Error())
 	}
-	col, err := s.Collections.OpenCollection(name)
+	col, err := s.openCollectionCached(name)
 	if err != nil {
 		if errors.Is(err, collections.ErrCollectionNotFound) {
 			return commandError(commandCodeNamespaceNotFound, "NamespaceNotFound", "collection not found: "+db+"."+collection)
 		}
 		return commandError(commandCodeBadValue, "BadValue", err.Error())
 	}
-	return marshalCursorResponse(db, collection, mongoIndexDocuments(col.Meta()))
+	return marshalCursorResponse(db, collection, mongoIndexDocuments(col.MetaView()))
 }
 
 func (s *Server) dropIndexesResponse(command wire.Document) (wire.Document, error) {
@@ -2125,14 +2128,14 @@ func (s *Server) dropIndexesResponse(command wire.Document) (wire.Document, erro
 	if err != nil {
 		return commandError(commandCodeBadValue, "BadValue", err.Error())
 	}
-	col, err := s.Collections.OpenCollection(name)
+	col, err := s.openCollectionCached(name)
 	if err != nil {
 		if errors.Is(err, collections.ErrCollectionNotFound) {
 			return commandError(commandCodeNamespaceNotFound, "NamespaceNotFound", "collection not found: "+db+"."+collection)
 		}
 		return commandError(commandCodeBadValue, "BadValue", err.Error())
 	}
-	metaBefore := col.Meta()
+	metaBefore := col.MetaView()
 	before := int32(1 + len(metaBefore.Indexes) + len(metaBefore.VectorIndexes))
 	names, all, err := dropIndexNames(command)
 	if err != nil {
@@ -2172,6 +2175,7 @@ func (s *Server) dropIndexesResponse(command wire.Document) (wire.Document, erro
 			}
 		}
 	}
+	s.invalidateCollectionCache(name)
 	return marshalDocument(bson.D{
 		{Key: "ok", Value: 1.0},
 		{Key: "nIndexesWas", Value: before},
@@ -2927,14 +2931,15 @@ func rawDocumentsBatchLimit(docs []wire.Document, maxDocs int, maxBytes int) (in
 }
 
 func (s *Server) openOrCreateCollection(name string) (*collections.Collection, error) {
-	col, err := s.Collections.OpenCollection(name)
+	col, err := s.openCollectionCached(name)
 	if err == nil {
 		return col, nil
 	}
 	if _, createErr := s.Collections.CreateCollection(s.defaultCollectionMeta(name)); createErr != nil {
 		return nil, createErr
 	}
-	return s.Collections.OpenCollection(name)
+	s.invalidateCollectionCache(name)
+	return s.openCollectionCached(name)
 }
 
 func (s *Server) defaultCollectionMeta(name string) *collections.CollectionMeta {
@@ -3269,7 +3274,7 @@ func storedDocumentMaterializerForCollection(col *collections.Collection) (*coll
 	if col == nil {
 		return nil, nil
 	}
-	switch col.Meta().Options.DocumentFormat {
+	switch col.MetaView().Options.DocumentFormat {
 	case collections.DocumentFormatDefault, collections.DocumentFormatJSON:
 		return nil, nil
 	default:

--- a/TreeDB/mongo_gateway/find_planner.go
+++ b/TreeDB/mongo_gateway/find_planner.go
@@ -202,7 +202,7 @@ func (s *Server) maxFindBatchBytes() int {
 }
 
 func (s *Server) findPureIndexedRangeLimitDocuments(col *collections.Collection, materializer *collections.StoredDocumentJSONMaterializer, plan findPlan) ([]wire.Document, bool, error) {
-	idx, opts, limit, ok, empty, err := pureIndexedRangeLimitPlan(col.Meta(), plan, s.maxFindScanDocuments())
+	idx, opts, limit, ok, empty, err := pureIndexedRangeLimitPlan(col.MetaView(), plan, s.maxFindScanDocuments())
 	if err != nil || !ok {
 		return nil, ok, err
 	}
@@ -246,7 +246,7 @@ func pureIndexedRangeLimitPlan(meta collections.CollectionMeta, plan findPlan, m
 }
 
 func (s *Server) findCandidateDocuments(col *collections.Collection, materializer *collections.StoredDocumentJSONMaterializer, plan findPlan) ([]wire.Document, error) {
-	meta := col.Meta()
+	meta := col.MetaView()
 	maxDocuments := s.maxFindScanDocuments()
 	var primaryDocs []wire.Document
 	primarySet := false
@@ -292,7 +292,7 @@ func (s *Server) findCandidateDocuments(col *collections.Collection, materialize
 }
 
 func (s *Server) findUnsortedScanDocuments(col *collections.Collection, materializer *collections.StoredDocumentJSONMaterializer, plan findPlan) ([]wire.Document, bool, error) {
-	if plan.sort.field != "" || findPlanHasDirectCandidate(col.Meta(), plan.predicates) {
+	if plan.sort.field != "" || findPlanHasDirectCandidate(col.MetaView(), plan.predicates) {
 		return nil, false, nil
 	}
 	maxDocuments := s.maxFindScanDocuments()
@@ -388,7 +388,7 @@ func storedDocumentMatchesPredicatesForCollection(col *collections.Collection, s
 	if col == nil {
 		return storedDocumentMatchesPredicates(stored, predicates)
 	}
-	switch col.Meta().Options.DocumentFormat {
+	switch col.MetaView().Options.DocumentFormat {
 	case collections.DocumentFormatDefault, collections.DocumentFormatJSON:
 		return storedDocumentMatchesPredicates(stored, predicates)
 	case collections.DocumentFormatBSON:

--- a/TreeDB/mongo_gateway/server_core.go
+++ b/TreeDB/mongo_gateway/server_core.go
@@ -82,22 +82,24 @@ type Server struct {
 	DefaultCollectionOptions  collections.CollectionOptions
 	DefaultIndexStoragePolicy collections.RootStoragePolicy
 
-	nextResponseID   atomic.Int32
-	nextConnectionID atomic.Int64
-	nextCursorID     atomic.Int64
-	cursorCount      atomic.Int64
-	connMu           sync.Mutex
-	conns            map[net.Conn]struct{}
-	listenerMu       sync.Mutex
-	listeners        map[net.Listener]struct{}
-	cursorMu         sync.Mutex
-	cursors          map[int64]*serverCursor
-	lastCursorReap   time.Time
-	updateMu         sync.Mutex
-	updateCoalescers map[string]*mongoUpdateCoalescer
-	insertMu         sync.Mutex
-	insertCoalescers map[string]*mongoInsertCoalescer
-	closed           atomic.Bool
+	nextResponseID    atomic.Int32
+	nextConnectionID  atomic.Int64
+	nextCursorID      atomic.Int64
+	cursorCount       atomic.Int64
+	connMu            sync.Mutex
+	conns             map[net.Conn]struct{}
+	listenerMu        sync.Mutex
+	listeners         map[net.Listener]struct{}
+	cursorMu          sync.Mutex
+	cursors           map[int64]*serverCursor
+	lastCursorReap    time.Time
+	collectionCacheMu sync.RWMutex
+	collectionCache   map[string]*collections.Collection
+	updateMu          sync.Mutex
+	updateCoalescers  map[string]*mongoUpdateCoalescer
+	insertMu          sync.Mutex
+	insertCoalescers  map[string]*mongoInsertCoalescer
+	closed            atomic.Bool
 }
 
 type serverCursor struct {
@@ -123,11 +125,51 @@ func NewServer() *Server {
 	return s
 }
 
+func (s *Server) openCollectionCached(name string) (*collections.Collection, error) {
+	if s == nil || s.Collections == nil {
+		return nil, collections.ErrCollectionNotFound
+	}
+	s.collectionCacheMu.RLock()
+	if col := s.collectionCache[name]; col != nil {
+		s.collectionCacheMu.RUnlock()
+		return col, nil
+	}
+	s.collectionCacheMu.RUnlock()
+
+	col, err := s.Collections.OpenCollection(name)
+	if err != nil {
+		return nil, err
+	}
+	s.collectionCacheMu.Lock()
+	if s.collectionCache == nil {
+		s.collectionCache = make(map[string]*collections.Collection)
+	}
+	if cached := s.collectionCache[name]; cached != nil {
+		col = cached
+	} else {
+		s.collectionCache[name] = col
+	}
+	s.collectionCacheMu.Unlock()
+	return col, nil
+}
+
+func (s *Server) invalidateCollectionCache(name string) {
+	if s == nil || name == "" {
+		return
+	}
+	s.collectionCacheMu.Lock()
+	delete(s.collectionCache, name)
+	s.collectionCacheMu.Unlock()
+}
+
 func (s *Server) Close() error {
 	if s == nil {
 		return nil
 	}
 	s.closed.Store(true)
+	s.collectionCacheMu.Lock()
+	clear(s.collectionCache)
+	s.collectionCacheMu.Unlock()
 	s.closeActiveListeners()
 	s.closeActiveConns()
 	s.closeUpdateCoalescers()


### PR DESCRIPTION
## Summary

Closes #2337 and completes the indexed-read optimization node for #2335.

- Adds a small Mongo gateway collection-handle cache so repeated reads do not reopen/copy collection metadata on every command.
- Invalidates the cache around collection creation and index schema mutations.
- Adds `Collection.MetaView()` for read-only internal fast paths that need metadata without deep-copying index slices.
- Switches gateway read/planning paths to the read-only metadata view while retaining defensive `Meta()` for public callers.

## Validation

```sh
GOWORK=off go test ./TreeDB/mongo_gateway -run 'TestServerFindChoosesNarrowestIndexedPredicate|TestServerFindChoosesNarrowestSameFieldIndexedPredicate|TestServerFindIndexed|TestServerCreateIndexes|TestServerDropIndexes' -count=1
GOWORK=off go test ./cmd/mongo_gateway_bench -run '^TestTreeDBRawWireIndexedFindClientModeSmoke$' -count=1
GOWORK=off go test -race ./TreeDB/mongo_gateway -run '^TestStandaloneServerCommandWALBSONInsertReadUpdateVisibility$' -count=1
GOWORK=off go test ./TreeDB/mongo_gateway ./cmd/mongo_gateway_bench -count=1
GOWORK=off go test ./TreeDB/collections -count=1
```

## Benchmark / Profile Evidence

Before artifact:

- `/tmp/treedb_indexed_read_2337_baseline_20260604_172836`

After artifact:

- `/tmp/treedb_indexed_read_2337_after3_20260604_175658`

Shared workload: 50k docs, 2 secondary indexes, 50k serial reads, TreeDB `raw-wire-tcp`, `command_wal_relaxed`, BSON documents, settled read state, pprof enabled.

| phase | before ops/sec | after ops/sec | before sampled ns/op | after sampled ns/op | p95 before/after |
| --- | ---: | ---: | ---: | ---: | ---: |
| `_id` find | 48,357.6 | 51,238.7 | 19,595.4 | 18,478.3 | 25us / 25us |
| `email` indexed find | 38,437.7 | 40,590.2 | 24,807.9 | 23,435.0 | 31us / 31us |

Allocation profile, raw-wire `email_find_one`:

- Before: `openCollectionFromWriteDomainCache` 129.75 MiB and `CollectionMeta.copy` 96.52 MiB were top per-read overheads.
- After: `openCollectionFromWriteDomainCache` is gone from the top allocation profile and `CollectionMeta.copy` is removed from the raw-wire indexed-read hot list.
- Total sampled alloc-space for the phase dropped from about 899.79 MiB to 603.30 MiB in this smoke profile.

The remaining dominant cost is syscall/wire round-trip plus response construction, so this PR intentionally stops at the measured metadata/open overhead boundary.
