### PR TITLE
Use hnsw_search_pack_v1 for buffered vector search

### DIFF
--- a/TreeDB/collections/column_hnsw_search_pack_reader.go
+++ b/TreeDB/collections/column_hnsw_search_pack_reader.go
@@ -505,6 +505,27 @@ func columnHNSWSearchPackSectionBytes(raw []byte, section columnHNSWSearchPackSe
 	return raw[int(section.Offset):int(section.Offset+section.Length)]
 }
 
+func (v *columnHNSWSearchPackPreparedView) fastStatus(defaultStatus columnHNSWSearchPackPreparedStatus) columnHNSWSearchPackPreparedStatus {
+	if v == nil {
+		if defaultStatus == "" {
+			return columnHNSWSearchPackPreparedStatusMissing
+		}
+		return defaultStatus
+	}
+	if v.closed.Load() {
+		return columnHNSWSearchPackPreparedStatusClosed
+	}
+	if v.handle == nil || v.handle.Released() {
+		return columnHNSWSearchPackPreparedStatusStale
+	}
+	switch v.status {
+	case columnHNSWSearchPackPreparedStatusDirect, columnHNSWSearchPackPreparedStatusHeap, columnHNSWSearchPackPreparedStatusInvalid, columnHNSWSearchPackPreparedStatusStale, columnHNSWSearchPackPreparedStatusClosed, columnHNSWSearchPackPreparedStatusMissing:
+		return v.status
+	default:
+		return columnHNSWSearchPackPreparedStatusInvalid
+	}
+}
+
 func (v *columnHNSWSearchPackPreparedView) validateLive() error {
 	if v == nil {
 		return columnHNSWSearchPackStatusError(columnHNSWSearchPackPreparedStatusMissing)

--- a/TreeDB/collections/column_hnsw_search_pack_search.go
+++ b/TreeDB/collections/column_hnsw_search_pack_search.go
@@ -1,0 +1,515 @@
+package collections
+
+import (
+	"errors"
+	"fmt"
+	"math"
+
+	"github.com/snissn/gomap/TreeDB/internal/vectorops"
+)
+
+var (
+	errColumnHNSWSearchPackSearchUnavailable     = errors.New("collections: hnsw_search_pack_v1 search unavailable")
+	errColumnHNSWSearchPackSearchUnsupportedMode = errors.New("collections: hnsw_search_pack_v1 search supports only exact no-document mode")
+	errColumnHNSWSearchPackSearchCandidateRows   = errors.New("collections: hnsw_search_pack_v1 search does not support candidate row filters")
+)
+
+func columnHNSWSearchPackStatsModeSupportedForSearch(mode columnVectorGraphNativeSearchStatsMode) bool {
+	return mode.normalized() != columnVectorGraphNativeSearchStatsModeBenchmarkDebug
+}
+
+func (v *columnHNSWSearchPackPreparedView) searchCosine(query []float32, opts columnVectorGraphNativeSearchOptions, scratch *columnVectorGraphNativeSearchScratch) ([]columnVectorGraphNativeSearchResult, columnVectorGraphNativeSearchStats, error) {
+	var stats columnVectorGraphNativeSearchStats
+	if v == nil {
+		return nil, stats, errColumnHNSWSearchPackSearchUnavailable
+	}
+	switch status := v.fastStatus(""); status {
+	case columnHNSWSearchPackPreparedStatusDirect, columnHNSWSearchPackPreparedStatusHeap:
+	default:
+		return nil, stats, columnHNSWSearchPackStatusError(status)
+	}
+	if scratch == nil {
+		return nil, stats, errColumnVectorGraphNativeSearchScratchRequired
+	}
+	if len(query) != v.Header.Dimensions {
+		return nil, stats, fmt.Errorf("collections: hnsw_search_pack_v1 query dims=%d want %d: %w", len(query), v.Header.Dimensions, errColumnVectorGraphNativeSearchQueryDimensionMismatch)
+	}
+	queryMode, err := opts.QueryMode.normalized()
+	if err != nil {
+		return nil, stats, fmt.Errorf("collections: hnsw_search_pack_v1 query mode: %w", err)
+	}
+	if queryMode != columnVectorGraphNativeSearchQueryModeExact || opts.QuantizedIndexName != "" || opts.QuantizedRerankCandidates != 0 {
+		return nil, stats, errColumnHNSWSearchPackSearchUnsupportedMode
+	}
+	if opts.HasCandidateRows {
+		return nil, stats, errColumnHNSWSearchPackSearchCandidateRows
+	}
+	statsMode := opts.StatsMode.normalized()
+	if !columnHNSWSearchPackStatsModeSupportedForSearch(statsMode) {
+		return nil, stats, errColumnHNSWSearchPackSearchUnsupportedMode
+	}
+	rowCount := v.Header.Rows
+	topK := opts.TopK
+	if topK < 0 {
+		return nil, stats, errColumnVectorGraphNativeSearchTopKNegative
+	}
+	efSearch := opts.EfSearch
+	if efSearch < 0 {
+		return nil, stats, errColumnVectorGraphNativeSearchEfSearchNegative
+	}
+	if topK == 0 || rowCount == 0 {
+		return nil, stats, nil
+	}
+	stats.CandidateRows = uint64(rowCount)
+	if topK > rowCount {
+		topK = rowCount
+	}
+	if efSearch == 0 {
+		efSearch = v.Header.EfSearch
+	}
+	if efSearch < topK {
+		efSearch = topK
+	}
+	if efSearch > rowCount {
+		efSearch = rowCount
+	}
+	degree := v.Header.M
+	if degree < 1 {
+		degree = 1
+	}
+	if degree <= math.MaxInt/2 {
+		degree *= 2
+	}
+	if err := scratch.prepare(rowCount, v.Header.VectorStride, degree, topK, efSearch, degree, 0); err != nil {
+		return nil, stats, fmt.Errorf("collections: hnsw_search_pack_v1 search scratch prepare: %w", err)
+	}
+	queryInvNorm, err := columnVectorGraphInvNorm(query)
+	if err != nil {
+		return nil, stats, fmt.Errorf("collections: hnsw_search_pack_v1 query norm: %w: %w", errColumnVectorGraphNativeSearchQueryNormInvalid, err)
+	}
+	normalizedQuery := scratch.scoreScratch.Float32Values[:v.Header.VectorStride]
+	for i := 0; i < v.Header.Dimensions; i++ {
+		normalizedQuery[i] = query[i] * queryInvNorm
+	}
+	if v.Header.VectorStride > v.Header.Dimensions {
+		clear(normalizedQuery[v.Header.Dimensions:])
+	}
+	countLoopEdges := !statsMode.minimal()
+	var loopEdgeVisits uint64
+	var visitedCandidates uint64
+	entryOrdinal := v.Header.EntryOrdinal
+	if entryOrdinal < 0 || entryOrdinal >= rowCount {
+		return nil, stats, fmt.Errorf("collections: hnsw_search_pack_v1 entry ordinal=%d outside rows=%d", entryOrdinal, rowCount)
+	}
+	maxLayer, err := v.maxLayerForOrdinal(entryOrdinal)
+	if err != nil {
+		return nil, stats, err
+	}
+	for layer := maxLayer; layer > 0; layer-- {
+		entryOrdinal, err = v.greedyNearestAtLayer(normalizedQuery, entryOrdinal, layer, opts.ScoreBatchMode, scratch, &stats, countLoopEdges, &loopEdgeVisits)
+		if err != nil {
+			return nil, stats, err
+		}
+	}
+	visitMarks := scratch.visitMarks
+	visitEpoch := scratch.visitEpoch
+	visitMarks[entryOrdinal] = visitEpoch
+	if err := v.scoreAndPushFrontierVisited(normalizedQuery, entryOrdinal, efSearch, opts.ScoreBatchMode, scratch, &stats, &visitedCandidates); err != nil {
+		return nil, stats, err
+	}
+	nextSeed := 0
+	rowCount64 := uint64(rowCount)
+	for {
+		candidate, ok := scratch.popFrontier()
+		if !ok {
+			if len(scratch.top) >= efSearch {
+				break
+			}
+			seed, seedOK := columnHNSWSearchPackNextCandidateSeed(nextSeed, rowCount, visitMarks, visitEpoch)
+			if !seedOK {
+				break
+			}
+			nextSeed = seed + 1
+			visitMarks[seed] = visitEpoch
+			if err := v.scoreAndPushFrontierVisited(normalizedQuery, seed, efSearch, opts.ScoreBatchMode, scratch, &stats, &visitedCandidates); err != nil {
+				return nil, stats, err
+			}
+			continue
+		}
+		if columnVectorGraphLayer0SearchShouldStop(candidate, scratch.top, efSearch) {
+			break
+		}
+		adjacency, err := v.adjacencyLayerForOrdinal(candidate.ordinal, 0, &stats)
+		if err != nil {
+			return nil, stats, err
+		}
+		if len(adjacency) == 0 {
+			continue
+		}
+		scratch.scoreTileOrdinals = ensureColumnVectorGraphNativeIntScratch(scratch.scoreTileOrdinals, len(adjacency))
+		tile := scratch.scoreTileOrdinals[:0]
+		for i, neighbor := range adjacency {
+			if countLoopEdges {
+				loopEdgeVisits++
+			}
+			if uint64(neighbor) >= rowCount64 {
+				return nil, stats, fmt.Errorf("collections: hnsw_search_pack_v1 ordinal=%d adjacency[%d]=%d outside row_count=%d: %w", candidate.ordinal, i, neighbor, rowCount, errColumnVectorGraphAdjacencyOrdinalOutOfBounds)
+			}
+			neighborOrdinal := int(neighbor)
+			if visitMarks[neighborOrdinal] == visitEpoch {
+				continue
+			}
+			visitMarks[neighborOrdinal] = visitEpoch
+			tile = append(tile, neighborOrdinal)
+		}
+		if len(tile) != 0 {
+			if err := v.scoreAndPushFrontierVisitedTile(normalizedQuery, tile, efSearch, opts.ScoreBatchMode, scratch, &stats, &visitedCandidates); err != nil {
+				return nil, stats, err
+			}
+		}
+	}
+	if countLoopEdges {
+		stats.Edges = loopEdgeVisits
+		stats.VisitedEdges = loopEdgeVisits
+		stats.Candidates = visitedCandidates
+	}
+	if len(scratch.top) == 0 {
+		return scratch.results, stats, nil
+	}
+	if len(scratch.top) > topK {
+		scratch.top = scratch.top[:topK]
+	}
+	if opts.OmitResultMaterialization {
+		for _, candidate := range scratch.top {
+			scratch.results = append(scratch.results, columnVectorGraphNativeSearchResult{Ordinal: candidate.ordinal, Score: candidate.score})
+		}
+		return scratch.results, stats, nil
+	}
+	if err := v.fetchTopSearchResults(scratch, &stats); err != nil {
+		return nil, stats, err
+	}
+	return scratch.results, stats, nil
+}
+
+func columnHNSWSearchPackNextCandidateSeed(start int, rowCount int, visitMarks []uint64, visitEpoch uint64) (int, bool) {
+	if start < 0 {
+		start = 0
+	}
+	for ordinal := start; ordinal < rowCount; ordinal++ {
+		if len(visitMarks) > ordinal && visitMarks[ordinal] == visitEpoch {
+			continue
+		}
+		return ordinal, true
+	}
+	return 0, false
+}
+
+func (v *columnHNSWSearchPackPreparedView) maxLayerForOrdinal(ordinal int) (int, error) {
+	if v == nil || ordinal < 0 || ordinal >= len(v.Levels) {
+		return 0, fmt.Errorf("collections: hnsw_search_pack_v1 max-layer ordinal=%d unavailable", ordinal)
+	}
+	return int(v.Levels[ordinal]), nil
+}
+
+func (v *columnHNSWSearchPackPreparedView) greedyNearestAtLayer(normalizedQuery []float32, entryOrdinal int, layer int, scoreBatchMode columnVectorGraphScoreBatchMode, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats, countLoopEdges bool, loopEdgeVisits *uint64) (int, error) {
+	best := entryOrdinal
+	bestScore, err := v.scoreOrdinal(normalizedQuery, best, scratch, stats)
+	if err != nil {
+		return 0, err
+	}
+	changed := true
+	for changed {
+		changed = false
+		adjacency, err := v.adjacencyLayerForOrdinal(best, layer, stats)
+		if err != nil {
+			return 0, err
+		}
+		if len(adjacency) == 0 {
+			continue
+		}
+		scratch.scoreTileOrdinals = ensureColumnVectorGraphNativeIntScratch(scratch.scoreTileOrdinals, len(adjacency))
+		tile := scratch.scoreTileOrdinals[:0]
+		for i, neighbor := range adjacency {
+			if countLoopEdges && loopEdgeVisits != nil {
+				(*loopEdgeVisits)++
+			}
+			if uint64(neighbor) >= uint64(v.Header.Rows) {
+				return 0, fmt.Errorf("collections: hnsw_search_pack_v1 ordinal=%d layer=%d adjacency[%d]=%d outside row_count=%d: %w", best, layer, i, neighbor, v.Header.Rows, errColumnVectorGraphAdjacencyOrdinalOutOfBounds)
+			}
+			tile = append(tile, int(neighbor))
+		}
+		if len(tile) == 0 {
+			continue
+		}
+		scratch.scoreTileScores = ensureColumnVectorGraphNativeFloat64Scratch(scratch.scoreTileScores, len(tile))
+		scores, err := v.scoreOrdinals(normalizedQuery, tile, scratch.scoreTileScores, scoreBatchMode, scratch, stats)
+		if err != nil {
+			return 0, err
+		}
+		for i, neighborOrdinal := range tile {
+			score := scores[i]
+			if score > bestScore || (score == bestScore && neighborOrdinal < best) {
+				best = neighborOrdinal
+				bestScore = score
+				changed = true
+			}
+		}
+	}
+	return best, nil
+}
+
+func (v *columnHNSWSearchPackPreparedView) scoreAndPushFrontierVisited(normalizedQuery []float32, ordinal, topK int, scoreBatchMode columnVectorGraphScoreBatchMode, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats, visitedCandidates *uint64) error {
+	score, err := v.scoreOrdinal(normalizedQuery, ordinal, scratch, stats)
+	if err != nil {
+		return err
+	}
+	if visitedCandidates != nil {
+		(*visitedCandidates)++
+	}
+	candidate := columnVectorGraphSearchCandidate{ordinal: ordinal, score: score}
+	if scratch.insertTop(topK, candidate) {
+		scratch.pushFrontier(candidate)
+	}
+	return nil
+}
+
+func (v *columnHNSWSearchPackPreparedView) scoreAndPushFrontierVisitedTile(normalizedQuery []float32, ordinals []int, topK int, scoreBatchMode columnVectorGraphScoreBatchMode, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats, visitedCandidates *uint64) error {
+	if len(ordinals) == 0 {
+		return nil
+	}
+	scratch.scoreTileScores = ensureColumnVectorGraphNativeFloat64Scratch(scratch.scoreTileScores, len(ordinals))
+	scores, err := v.scoreOrdinals(normalizedQuery, ordinals, scratch.scoreTileScores, scoreBatchMode, scratch, stats)
+	if err != nil {
+		return err
+	}
+	for i, ordinal := range ordinals {
+		if visitedCandidates != nil {
+			(*visitedCandidates)++
+		}
+		candidate := columnVectorGraphSearchCandidate{ordinal: ordinal, score: scores[i]}
+		if scratch.insertTop(topK, candidate) {
+			scratch.pushFrontier(candidate)
+		}
+	}
+	return nil
+}
+
+func (v *columnHNSWSearchPackPreparedView) scoreOrdinal(normalizedQuery []float32, ordinal int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) (float64, error) {
+	if v == nil || ordinal < 0 || ordinal >= v.Header.Rows {
+		return 0, fmt.Errorf("collections: hnsw_search_pack_v1 vector ordinal=%d unavailable", ordinal)
+	}
+	start := ordinal * v.Header.VectorStride
+	end := start + v.Header.Dimensions
+	if start < 0 || end < start || end > len(v.NormalizedVectors) || len(normalizedQuery) < v.Header.Dimensions {
+		return 0, fmt.Errorf("collections: hnsw_search_pack_v1 vector ordinal=%d shape mismatch", ordinal)
+	}
+	vector := v.NormalizedVectors[start:end]
+	score := float64(vectorDotProductFloat32(normalizedQuery[:v.Header.Dimensions], vector))
+	if math.IsNaN(score) || math.IsInf(score, 0) {
+		return 0, fmt.Errorf("collections: hnsw_search_pack_v1 candidate ordinal=%d normalized-dot score is not finite", ordinal)
+	}
+	recordColumnHNSWSearchPackScoreBatchStats(stats, 1, false, true)
+	v.recordScoreStats(stats, 1)
+	_ = scratch
+	return score, nil
+}
+
+func (v *columnHNSWSearchPackPreparedView) scoreOrdinals(normalizedQuery []float32, ordinals []int, dst []float64, scoreBatchMode columnVectorGraphScoreBatchMode, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) ([]float64, error) {
+	if cap(dst) < len(ordinals) {
+		dst = make([]float64, len(ordinals))
+	} else {
+		dst = dst[:len(ordinals)]
+	}
+	if len(ordinals) == 0 {
+		return dst, nil
+	}
+	if scoreBatchMode != columnVectorGraphScoreBatchModeScalar && len(ordinals) > 1 && scratch != nil && len(normalizedQuery) >= v.Header.VectorStride {
+		scratch.scoreTileRowIDs = ensureColumnVectorGraphNativeUint32Scratch(scratch.scoreTileRowIDs, len(ordinals))
+		rowIDs := scratch.scoreTileRowIDs[:len(ordinals)]
+		ok := true
+		for i, ordinal := range ordinals {
+			if ordinal < 0 || ordinal >= v.Header.Rows || uint64(ordinal) > uint64(^uint32(0)) {
+				ok = false
+				break
+			}
+			rowIDs[i] = uint32(ordinal)
+		}
+		if ok {
+			scratch.scoreTileDots = ensureColumnVectorGraphNativeFloat32Scratch(scratch.scoreTileDots, len(ordinals))
+			dots := scratch.scoreTileDots[:len(ordinals)]
+			status := vectorops.DotFloat32Indexed(dots, v.NormalizedVectors, normalizedQuery[:v.Header.VectorStride], rowIDs, v.Header.VectorStride)
+			if !status.Invalid && status.Rows == len(ordinals) {
+				for i, ordinal := range ordinals {
+					score := float64(dots[i])
+					if math.IsNaN(score) || math.IsInf(score, 0) {
+						return dst[:i], fmt.Errorf("collections: hnsw_search_pack_v1 candidate ordinal=%d normalized-dot score is not finite", ordinal)
+					}
+					dst[i] = score
+				}
+				recordColumnHNSWSearchPackScoreBatchStats(stats, len(ordinals), status.Optimized, status.Fallback)
+				v.recordScoreStats(stats, len(ordinals))
+				return dst, nil
+			}
+		}
+	}
+	for i, ordinal := range ordinals {
+		score, err := v.scoreOrdinal(normalizedQuery, ordinal, scratch, nil)
+		if err != nil {
+			return dst[:i], err
+		}
+		dst[i] = score
+	}
+	recordColumnHNSWSearchPackScoreBatchStats(stats, len(ordinals), false, true)
+	v.recordScoreStats(stats, len(ordinals))
+	return dst, nil
+}
+
+func recordColumnHNSWSearchPackScoreBatchStats(stats *columnVectorGraphNativeSearchStats, tileSize int, optimized bool, scalarFallback bool) {
+	recordColumnVectorGraphScoreBatchStats(stats, tileSize, optimized, scalarFallback)
+}
+
+func (v *columnHNSWSearchPackPreparedView) recordScoreStats(stats *columnVectorGraphNativeSearchStats, count int) {
+	if stats == nil || v == nil || count <= 0 {
+		return
+	}
+	count64 := uint64(count)
+	stats.PreparedScoreCalls += count64
+	stats.VisitedNodes += count64
+	stats.CandidateFetches += count64
+	stats.VectorBytesRead += count64 * uint64(v.Header.Dimensions) * 4
+	switch v.status {
+	case columnHNSWSearchPackPreparedStatusDirect:
+		stats.VectorDirectViews += count64
+		stats.VectorMmapDirectViews += count64
+		stats.VectorPreparedDirectViews += count64
+	case columnHNSWSearchPackPreparedStatusHeap:
+		stats.VectorHeapCopyTypedViews += count64
+		stats.VectorPreparedDirectViews += count64
+	}
+}
+
+func (v *columnHNSWSearchPackPreparedView) adjacencyLayerForOrdinal(ordinal int, layer int, stats *columnVectorGraphNativeSearchStats) ([]uint32, error) {
+	if v == nil || layer < 0 || layer >= len(v.AdjacencyLayers) || ordinal < 0 || ordinal >= v.Header.Rows {
+		return nil, fmt.Errorf("collections: hnsw_search_pack_v1 adjacency ordinal=%d layer=%d unavailable", ordinal, layer)
+	}
+	adjacency := v.AdjacencyLayers[layer]
+	if ordinal+1 >= len(adjacency.Offsets) {
+		return nil, fmt.Errorf("collections: hnsw_search_pack_v1 adjacency ordinal=%d layer=%d offsets unavailable", ordinal, layer)
+	}
+	start64 := adjacency.Offsets[ordinal]
+	end64 := adjacency.Offsets[ordinal+1]
+	if end64 < start64 || end64 > uint64(len(adjacency.Neighbors)) || end64 > uint64(math.MaxInt) {
+		return nil, fmt.Errorf("collections: hnsw_search_pack_v1 adjacency ordinal=%d layer=%d bounds invalid", ordinal, layer)
+	}
+	neighbors := adjacency.Neighbors[int(start64):int(end64)]
+	v.recordAdjacencyStats(stats, len(neighbors))
+	return neighbors, nil
+}
+
+func (v *columnHNSWSearchPackPreparedView) recordAdjacencyStats(stats *columnVectorGraphNativeSearchStats, adjacencyLen int) {
+	if stats == nil || adjacencyLen < 0 {
+		return
+	}
+	stats.ExpansionFetches++
+	stats.AdjacencyExpansions++
+	stats.AdjacencyBytesRead += uint64(adjacencyLen) * 4
+	switch v.status {
+	case columnHNSWSearchPackPreparedStatusDirect:
+		stats.AdjacencyDirectViews++
+		stats.AdjacencyMmapDirectViews++
+		stats.AdjacencyPreparedCSRDirectViews++
+		stats.AdjacencyPreparedCSRMmapDirectViews++
+	case columnHNSWSearchPackPreparedStatusHeap:
+		stats.AdjacencyHeapCopyTypedViews++
+	}
+}
+
+func (v *columnHNSWSearchPackPreparedView) fetchTopSearchResults(scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) error {
+	if v == nil {
+		return errColumnHNSWSearchPackSearchUnavailable
+	}
+	n := len(scratch.top)
+	scratch.resultOrder = scratch.resultOrder[:n]
+	scratch.resultOrdinals = scratch.resultOrdinals[:n]
+	for i := 0; i < n; i++ {
+		scratch.resultOrder[i] = i
+	}
+	sortColumnVectorGraphResultOrderByOrdinal(scratch.resultOrder, scratch.top)
+	for fetchPos, topIndex := range scratch.resultOrder {
+		scratch.resultOrdinals[fetchPos] = scratch.top[topIndex].ordinal
+	}
+	scratch.resultRowRefs = scratch.resultRowRefs[:n]
+	scratch.resultHasRefs = scratch.resultHasRefs[:n]
+	clear(scratch.resultRowRefs)
+	clear(scratch.resultHasRefs)
+	for resultPos, topIndex := range scratch.resultOrder {
+		ordinal := scratch.resultOrdinals[resultPos]
+		id, ok := v.documentIDForOrdinal(ordinal)
+		if !ok {
+			return fmt.Errorf("collections: hnsw_search_pack_v1 result-id unavailable for ordinal=%d", ordinal)
+		}
+		scratch.resultIDViews[topIndex] = id
+		if stats != nil {
+			stats.ResultIDTypedBytesState++
+		}
+		rowRef, ok := v.rowRefForOrdinal(ordinal)
+		if !ok {
+			return fmt.Errorf("collections: hnsw_search_pack_v1 row-ref unavailable for ordinal=%d", ordinal)
+		}
+		rowRef.DocumentID = id
+		scratch.resultRowRefs[topIndex] = rowRef
+		scratch.resultHasRefs[topIndex] = true
+		if stats != nil {
+			stats.RowRefStateResultRefs++
+		}
+	}
+	if stats != nil {
+		stats.ResultFetches += uint64(n)
+		stats.ResultIDPreparedBytesViews = 1
+		stats.RowRefStatePreparedViews = 1
+		if v.status == columnHNSWSearchPackPreparedStatusDirect {
+			stats.RowRefStateMmapDirectFields = uint64(len(columnVectorGraphRowRefStateFields))
+		}
+	}
+	for i, candidate := range scratch.top {
+		scratch.results = append(scratch.results, columnVectorGraphNativeSearchResult{
+			Ordinal:   candidate.ordinal,
+			ID:        scratch.resultIDViews[i],
+			RowRef:    scratch.resultRowRefs[i],
+			HasRowRef: scratch.resultHasRefs[i],
+			Score:     candidate.score,
+		})
+	}
+	return nil
+}
+
+func (v *columnHNSWSearchPackPreparedView) documentIDForOrdinal(ordinal int) ([]byte, bool) {
+	if v == nil || ordinal < 0 || ordinal >= v.Header.Rows || ordinal+1 >= len(v.DocumentIDOffsets) {
+		return nil, false
+	}
+	start64 := v.DocumentIDOffsets[ordinal]
+	end64 := v.DocumentIDOffsets[ordinal+1]
+	if end64 < start64 || end64 > uint64(len(v.DocumentIDBytes)) || end64 > uint64(math.MaxInt) {
+		return nil, false
+	}
+	return v.DocumentIDBytes[int(start64):int(end64)], true
+}
+
+func (v *columnHNSWSearchPackPreparedView) rowRefForOrdinal(ordinal int) (DocumentRowRef, bool) {
+	if v == nil || ordinal < 0 || ordinal >= v.Header.Rows || ordinal >= len(v.RowRefGenerations) || ordinal >= len(v.RowRefPartIDs) || ordinal >= len(v.RowRefRowIndexes) || ordinal >= len(v.RowRefAppliedLSNs) {
+		return DocumentRowRef{}, false
+	}
+	generation := v.RowRefGenerations[ordinal]
+	partID := v.RowRefPartIDs[ordinal]
+	rowIndex := v.RowRefRowIndexes[ordinal]
+	appliedLSN := v.RowRefAppliedLSNs[ordinal]
+	if generation <= 0 || partID <= 0 || rowIndex < 0 || appliedLSN <= 0 {
+		return DocumentRowRef{}, false
+	}
+	return DocumentRowRef{
+		Generation:        uint64(generation),
+		PartID:            uint64(partID),
+		RowIndex:          int(rowIndex),
+		AppliedCommandLSN: uint64(appliedLSN),
+	}, true
+}

--- a/TreeDB/collections/column_hnsw_search_pack_test.go
+++ b/TreeDB/collections/column_hnsw_search_pack_test.go
@@ -329,9 +329,15 @@ func TestColumnHNSWSearchPackReopenPreservesManifestIdentity2313(t *testing.T) {
 		t.Fatalf("SearchWithBuffer reopen: %v", err)
 	}
 	stats := response.Stats
-	if stats.SearchRouteHNSWSearchPack != 0 || stats.SearchRouteColumnGraphPrepared+stats.SearchRouteColumnGraphFallback != 1 || stats.HNSWSearchPackActive != 1 || stats.HNSWSearchPackMmapDirect+stats.HNSWSearchPackHeapCopy != 1 || stats.HNSWSearchPackOpenNanos == 0 || stats.HNSWSearchPackMappedBytes+stats.HNSWSearchPackHeapCopyBytes == 0 {
-		t.Fatalf("reopen search stats=%+v want pack availability without route change", stats)
+	if stats.SearchRouteHNSWSearchPack != 1 || stats.SearchRouteColumnGraphPrepared+stats.SearchRouteColumnGraphFallback != 0 || stats.HNSWSearchPackActive != 1 || stats.HNSWSearchPackFallbacks != 0 || stats.HNSWSearchPackMmapDirect+stats.HNSWSearchPackHeapCopy != 1 || stats.HNSWSearchPackOpenNanos == 0 || stats.HNSWSearchPackMappedBytes+stats.HNSWSearchPackHeapCopyBytes == 0 {
+		t.Fatalf("reopen search stats=%+v want hnsw_search_pack_v1 route", stats)
 	}
+	fullOpts := VectorIndexSearcherSearchOptions{Query: []float32{1, 0, 0}, TopK: 2, EfSearch: 8, StatsMode: VectorIndexSearchStatsModeFullDiagnostics}
+	fullResponse, err := searcher.SearchWithBuffer(fullOpts, &buf)
+	if err != nil {
+		t.Fatalf("SearchWithBuffer reopen full stats: %v", err)
+	}
+	assertColumnHNSWSearchPackMatchesColumnGraphRoute2315(t, searcher, fullOpts, fullResponse)
 }
 
 func TestColumnHNSWSearchPackEmptyAndSingleRowFixtures2313(t *testing.T) {
@@ -394,7 +400,7 @@ func TestColumnHNSWSearchPackValidationRejectsMismatchedRefs2313(t *testing.T) {
 	}
 }
 
-func TestColumnHNSWSearchPackFallbackSearchPathStillUsable2313(t *testing.T) {
+func TestColumnHNSWSearchPackSearchPathServesSearchWithBuffer2313(t *testing.T) {
 	rows := []columnGraphRebuildInputRowV2A{
 		{id: "doc-a", vector: []float32{1, 0, 0}},
 		{id: "doc-b", vector: []float32{0.9, 0.1, 0}},
@@ -419,11 +425,11 @@ func TestColumnHNSWSearchPackFallbackSearchPathStillUsable2313(t *testing.T) {
 		t.Fatalf("results=%d want 2", len(response.Results))
 	}
 	stats := response.Stats
-	if stats.SearchRouteHNSWSearchPack != 0 || stats.SearchRouteColumnGraphPrepared+stats.SearchRouteColumnGraphFallback != 1 {
-		t.Fatalf("route stats=%+v want existing column_graph route, no pack route", stats)
+	if stats.SearchRouteHNSWSearchPack != 1 || stats.SearchRouteColumnGraphPrepared+stats.SearchRouteColumnGraphFallback != 0 {
+		t.Fatalf("route stats=%+v want hnsw_search_pack_v1 route", stats)
 	}
-	if stats.HNSWSearchPackActive != 1 || stats.HNSWSearchPackMissing != 0 || stats.HNSWSearchPackInvalid != 0 || stats.HNSWSearchPackMmapDirect+stats.HNSWSearchPackHeapCopy != 1 || stats.HNSWSearchPackOpenNanos == 0 || stats.HNSWSearchPackMappedBytes+stats.HNSWSearchPackHeapCopyBytes == 0 {
-		t.Fatalf("pack stats=%+v want opened hnsw_search_pack_v1 view without search routing", stats)
+	if stats.HNSWSearchPackActive != 1 || stats.HNSWSearchPackMissing != 0 || stats.HNSWSearchPackInvalid != 0 || stats.HNSWSearchPackFallbacks != 0 || stats.HNSWSearchPackMmapDirect+stats.HNSWSearchPackHeapCopy != 1 || stats.HNSWSearchPackOpenNanos == 0 || stats.HNSWSearchPackMappedBytes+stats.HNSWSearchPackHeapCopyBytes == 0 || stats.GraphRowFallbacks != 0 || stats.VectorScratchDecodes != 0 || stats.DocumentsFetched != 0 {
+		t.Fatalf("pack stats=%+v want healthy hnsw_search_pack_v1 search routing", stats)
 	}
 }
 
@@ -556,6 +562,117 @@ func TestColumnHNSWSearchPackPreparedViewSharedReadersRelease2314(t *testing.T) 
 	}
 	if stats := view.mappedResourceStats(); stats.ActiveHandles != 0 || !view.closed.Load() {
 		t.Fatalf("shared pack stats after final close=%+v closed=%v", stats, view.closed.Load())
+	}
+}
+
+func TestColumnHNSWSearchPackRouteMatchesColumnGraph2315(t *testing.T) {
+	rows := []columnGraphRebuildInputRowV2A{
+		{id: "doc-a", vector: []float32{1, 0, 0}},
+		{id: "doc-b", vector: []float32{0.9, 0.1, 0}},
+		{id: "doc-c", vector: []float32{0, 1, 0}},
+		{id: "doc-d", vector: []float32{0, 0, 1}},
+		{id: "doc-e", vector: []float32{0.5, 0.5, 0}},
+		{id: "doc-f", vector: []float32{0.2, 0.8, 0}},
+	}
+	_, d, col, def := openColumnGraphRebuildTestCollectionV2A(t, 3, 3, rows)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	searcher, err := col.OpenVectorIndexSearcher(VectorIndexSearcherOptions{IndexName: def.Name, MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("OpenVectorIndexSearcher: %v", err)
+	}
+	defer func() { _ = searcher.Close() }()
+	opts := VectorIndexSearcherSearchOptions{Query: []float32{1, 0.05, 0}, TopK: 4, EfSearch: len(rows), StatsMode: VectorIndexSearchStatsModeFullDiagnostics}
+	var buffer VectorIndexSearchBuffer
+	packResponse, err := searcher.SearchWithBuffer(opts, &buffer)
+	if err != nil {
+		t.Fatalf("SearchWithBuffer pack route: %v", err)
+	}
+	if packResponse.Stats.SearchRouteHNSWSearchPack != 1 || packResponse.Stats.HNSWSearchPackActive != 1 || packResponse.Stats.HNSWSearchPackFallbacks != 0 || packResponse.Stats.GraphRowFallbacks != 0 || packResponse.Stats.VectorScratchDecodes != 0 || packResponse.Stats.DocumentsFetched != 0 {
+		t.Fatalf("pack route stats=%+v", packResponse.Stats)
+	}
+	assertColumnHNSWSearchPackMatchesColumnGraphRoute2315(t, searcher, opts, packResponse)
+}
+
+func TestColumnHNSWSearchPackMissingAndStaleFallbackSearchWithBuffer2315(t *testing.T) {
+	rows := []columnGraphRebuildInputRowV2A{
+		{id: "doc-a", vector: []float32{1, 0, 0}},
+		{id: "doc-b", vector: []float32{0, 1, 0}},
+		{id: "doc-c", vector: []float32{0, 0, 1}},
+	}
+	_, d, col, def := openColumnGraphRebuildTestCollectionV2A(t, 3, 2, rows)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	opts := VectorIndexSearcherSearchOptions{Query: []float32{1, 0, 0}, TopK: 2, EfSearch: len(rows), StatsMode: VectorIndexSearchStatsModeProduction}
+
+	missingSearcher, err := col.OpenVectorIndexSearcher(VectorIndexSearcherOptions{IndexName: def.Name, MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("OpenVectorIndexSearcher missing: %v", err)
+	}
+	missingSearcher.reader.hnswSearchPack = nil
+	missingSearcher.reader.hnswSearchPackStatus = columnHNSWSearchPackPreparedStatusMissing
+	missingSearcher.reader.hnswSearchPackOpenNanos = 0
+	var missingBuffer VectorIndexSearchBuffer
+	missingResponse, err := missingSearcher.SearchWithBuffer(opts, &missingBuffer)
+	if closeErr := missingSearcher.Close(); err == nil && closeErr != nil {
+		err = closeErr
+	}
+	if err != nil {
+		t.Fatalf("SearchWithBuffer missing pack fallback: %v", err)
+	}
+	if len(missingResponse.Results) != opts.TopK || missingResponse.Stats.SearchRouteHNSWSearchPack != 0 || missingResponse.Stats.SearchRouteColumnGraphPrepared+missingResponse.Stats.SearchRouteColumnGraphFallback != 1 || missingResponse.Stats.HNSWSearchPackMissing != 1 || missingResponse.Stats.HNSWSearchPackFallbacks != 1 {
+		t.Fatalf("missing fallback response=%+v stats=%+v", missingResponse.Results, missingResponse.Stats)
+	}
+
+	staleSearcher, err := col.OpenVectorIndexSearcher(VectorIndexSearcherOptions{IndexName: def.Name, MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("OpenVectorIndexSearcher stale: %v", err)
+	}
+	if staleSearcher.reader == nil || staleSearcher.reader.hnswSearchPack == nil || staleSearcher.reader.hnswSearchPack.handle == nil {
+		_ = staleSearcher.Close()
+		t.Fatal("stale test opened searcher without hnsw search pack handle")
+	}
+	if err := staleSearcher.reader.hnswSearchPack.handle.Release(); err != nil {
+		_ = staleSearcher.Close()
+		t.Fatalf("release pack handle for stale simulation: %v", err)
+	}
+	var staleBuffer VectorIndexSearchBuffer
+	staleResponse, err := staleSearcher.SearchWithBuffer(opts, &staleBuffer)
+	if closeErr := staleSearcher.Close(); err == nil && closeErr != nil {
+		err = closeErr
+	}
+	if err != nil {
+		t.Fatalf("SearchWithBuffer stale pack fallback: %v", err)
+	}
+	if len(staleResponse.Results) != opts.TopK || staleResponse.Stats.SearchRouteHNSWSearchPack != 0 || staleResponse.Stats.SearchRouteColumnGraphPrepared+staleResponse.Stats.SearchRouteColumnGraphFallback != 1 || staleResponse.Stats.HNSWSearchPackStale != 1 || staleResponse.Stats.HNSWSearchPackFallbacks != 1 {
+		t.Fatalf("stale fallback response=%+v stats=%+v", staleResponse.Results, staleResponse.Stats)
+	}
+}
+
+func assertColumnHNSWSearchPackMatchesColumnGraphRoute2315(tb testing.TB, searcher *VectorIndexSearcher, opts VectorIndexSearcherSearchOptions, packResponse VectorIndexSearchResponse) {
+	tb.Helper()
+	if searcher == nil || searcher.reader == nil {
+		tb.Fatal("nil searcher/reader for column_graph parity")
+	}
+	var scratch columnVectorGraphNativeSearchScratch
+	reference, referenceStats, err := searcher.reader.SearchCosine(opts.Query, columnVectorGraphNativeSearchOptions{TopK: opts.TopK, EfSearch: opts.EfSearch, StatsMode: columnVectorGraphNativeSearchStatsModeFullDiagnostics}, &scratch)
+	if err != nil {
+		tb.Fatalf("reference SearchCosine: %v", err)
+	}
+	if len(packResponse.Results) != len(reference) {
+		tb.Fatalf("pack results=%d reference=%d", len(packResponse.Results), len(reference))
+	}
+	for i := range reference {
+		if packResponse.Results[i].Ordinal != reference[i].Ordinal || string(packResponse.Results[i].ID) != string(reference[i].ID) || math.Abs(packResponse.Results[i].Score-reference[i].Score) > 1e-5 {
+			tb.Fatalf("result[%d]=%+v reference ordinal=%d id=%q score=%v", i, packResponse.Results[i], reference[i].Ordinal, reference[i].ID, reference[i].Score)
+		}
+	}
+	if packResponse.Stats.Candidates != referenceStats.Candidates || packResponse.Stats.VisitedEdges != referenceStats.VisitedEdges {
+		tb.Fatalf("pack stats candidates/edges=(%d,%d) reference=(%d,%d) pack=%+v reference=%+v", packResponse.Stats.Candidates, packResponse.Stats.VisitedEdges, referenceStats.Candidates, referenceStats.VisitedEdges, packResponse.Stats, referenceStats)
 	}
 }
 

--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -968,6 +968,7 @@ type columnVectorGraphNativeSearchScratch struct {
 	top                    []columnVectorGraphSearchCandidate
 	results                []columnVectorGraphNativeSearchResult
 	idBuffers              [][]byte
+	resultIDViews          [][]byte
 	resultOrder            []int
 	resultOrdinals         []int
 	resultRowRefs          []DocumentRowRef
@@ -1014,6 +1015,7 @@ func (s *columnVectorGraphNativeSearchScratch) prepare(rowCount, dimensions, deg
 	s.top = resizeColumnVectorGraphNativeCandidateScratch(s.top, topCandidateCap)
 	s.results = resizeColumnVectorGraphNativeResultScratch(s.results, topK)
 	s.idBuffers = resizeColumnVectorGraphNativeIDBuffersScratch(s.idBuffers, topK)
+	s.resultIDViews = resizeColumnVectorGraphNativeIDBuffersScratch(s.resultIDViews, topK)
 	s.resultOrder = resizeColumnVectorGraphNativeIntScratch(s.resultOrder, topK)
 	s.resultOrdinals = resizeColumnVectorGraphNativeIntScratch(s.resultOrdinals, topK)
 	s.resultRowRefs = resizeColumnVectorGraphNativeRowRefScratch(s.resultRowRefs, topK)

--- a/TreeDB/collections/column_vector_graph_shared_prepared_test.go
+++ b/TreeDB/collections/column_vector_graph_shared_prepared_test.go
@@ -61,8 +61,8 @@ func TestVectorIndexSearcherSharedPreparedResourceCounters1735(t *testing.T) {
 					errs <- fmt.Sprintf("worker %d iteration %d top result=%v baseline=%v", worker, i, got.Results, baseline.Results)
 					return
 				}
-				if got.Stats.PreparedGraphSearchViews != 1 || got.Stats.TypedColumnFallbacks != 0 || got.Stats.GraphRowFallbacks != 0 || got.Stats.ResultIDGraphFallbacks != 0 {
-					errs <- fmt.Sprintf("worker %d stats=%+v want prepared current-format path", worker, got.Stats)
+				if got.Stats.SearchRouteHNSWSearchPack != 1 || got.Stats.HNSWSearchPackActive != 1 || got.Stats.HNSWSearchPackFallbacks != 0 || got.Stats.TypedColumnFallbacks != 0 || got.Stats.GraphRowFallbacks != 0 || got.Stats.ResultIDGraphFallbacks != 0 || got.Stats.VectorScratchDecodes != 0 {
+					errs <- fmt.Sprintf("worker %d stats=%+v want shared hnsw_search_pack_v1 path", worker, got.Stats)
 					return
 				}
 			}
@@ -252,8 +252,8 @@ func openWarmCloseVectorSearchersSharedPrepared1735(col *Collection, indexName s
 		if len(got.Results) == 0 {
 			return sample, fmt.Errorf("warm SearchWithBuffer worker %d returned no results", i)
 		}
-		if got.Stats.PreparedGraphSearchViews != 1 || got.Stats.TypedColumnFallbacks != 0 || got.Stats.GraphRowFallbacks != 0 || got.Stats.ResultIDGraphFallbacks != 0 {
-			return sample, fmt.Errorf("warm SearchWithBuffer worker %d stats=%+v want shared prepared current-format path", i, got.Stats)
+		if got.Stats.SearchRouteHNSWSearchPack != 1 || got.Stats.HNSWSearchPackActive != 1 || got.Stats.HNSWSearchPackFallbacks != 0 || got.Stats.TypedColumnFallbacks != 0 || got.Stats.GraphRowFallbacks != 0 || got.Stats.ResultIDGraphFallbacks != 0 || got.Stats.VectorScratchDecodes != 0 {
+			return sample, fmt.Errorf("warm SearchWithBuffer worker %d stats=%+v want shared hnsw_search_pack_v1 path", i, got.Stats)
 		}
 	}
 	sample.warmupNanos = time.Since(warmStart).Nanoseconds()

--- a/TreeDB/collections/vector_index_search.go
+++ b/TreeDB/collections/vector_index_search.go
@@ -617,6 +617,72 @@ func vectorIndexSearchRouteStatsForColumnGraphReader(reader *columnVectorGraphPh
 	return stats
 }
 
+func vectorIndexSearchRouteStatsForColumnGraphSearchWithBufferFallback(cached vectorIndexSearchRouteStats) vectorIndexSearchRouteStats {
+	stats := cached
+	stats.SearchRouteHNSWSearchPack = 0
+	stats.HNSWSearchPackFallbacks = 1
+	return stats
+}
+
+func vectorIndexSearchRouteStatsForHNSWSearchPackRoute(cached vectorIndexSearchRouteStats) vectorIndexSearchRouteStats {
+	stats := cached
+	stats.SearchRouteColumnGraphPrepared = 0
+	stats.SearchRouteColumnGraphFallback = 0
+	stats.SearchRouteHNSWSearchPack = 1
+	return stats
+}
+
+func vectorIndexSearchRouteStatsForHNSWSearchPackFastStatus(cached vectorIndexSearchRouteStats, status columnHNSWSearchPackPreparedStatus) vectorIndexSearchRouteStats {
+	stats := cached
+	switch status {
+	case columnHNSWSearchPackPreparedStatusDirect, columnHNSWSearchPackPreparedStatusHeap:
+		return stats
+	}
+	stats.clearHNSWSearchPackAvailability()
+	stats.applyHNSWSearchPackStatus(status)
+	if status == columnHNSWSearchPackPreparedStatusMissing || status == "" {
+		stats.HNSWSearchPackFallbacks = 1
+	}
+	return stats
+}
+
+func (r *vectorIndexSearchRouteStats) clearHNSWSearchPackAvailability() {
+	if r == nil {
+		return
+	}
+	openNanos := r.HNSWSearchPackOpenNanos
+	r.HNSWSearchPackActive = 0
+	r.HNSWSearchPackMissing = 0
+	r.HNSWSearchPackInvalid = 0
+	r.HNSWSearchPackStale = 0
+	r.HNSWSearchPackClosed = 0
+	r.HNSWSearchPackFallbacks = 0
+	r.HNSWSearchPackMmapDirect = 0
+	r.HNSWSearchPackHeapCopy = 0
+	r.HNSWSearchPackOpenNanos = openNanos
+	r.HNSWSearchPackMappedBytes = 0
+	r.HNSWSearchPackHeapCopyBytes = 0
+	r.HNSWSearchPackActiveHandles = 0
+}
+
+func (s *VectorIndexSearcher) hnswSearchPackSearchWithBufferRoute(queryMode columnVectorGraphNativeSearchQueryMode, statsMode columnVectorGraphNativeSearchStatsMode) (*columnHNSWSearchPackPreparedView, vectorIndexSearchRouteStats, bool) {
+	cached := s.routeStats
+	reader := s.reader
+	pack := (*columnHNSWSearchPackPreparedView)(nil)
+	status := columnHNSWSearchPackPreparedStatusMissing
+	if reader != nil {
+		pack = reader.hnswSearchPack
+		status = pack.fastStatus(reader.hnswSearchPackStatus)
+	}
+	if status != columnHNSWSearchPackPreparedStatusDirect && status != columnHNSWSearchPackPreparedStatusHeap {
+		return nil, vectorIndexSearchRouteStatsForHNSWSearchPackFastStatus(cached, status), false
+	}
+	if queryMode != columnVectorGraphNativeSearchQueryModeExact || !columnHNSWSearchPackStatsModeSupportedForSearch(statsMode) || pack == nil {
+		return nil, vectorIndexSearchRouteStatsForColumnGraphSearchWithBufferFallback(cached), false
+	}
+	return pack, vectorIndexSearchRouteStatsForHNSWSearchPackRoute(cached), true
+}
+
 func (r vectorIndexSearchRouteStats) apply(stats *VectorIndexSearchStats) {
 	if stats == nil {
 		return
@@ -1009,6 +1075,31 @@ func (s *VectorIndexSearcher) SearchWithBuffer(opts VectorIndexSearcherSearchOpt
 		clear(previousResults)
 		return response, err
 	}
+	pack, routeStats, usePackRoute := s.hnswSearchPackSearchWithBufferRoute(queryMode, statsMode)
+	if usePackRoute {
+		results, searchStats, err := pack.searchCosine(opts.Query, columnVectorGraphNativeSearchOptions{
+			TopK:                      opts.TopK,
+			EfSearch:                  opts.EfSearch,
+			ScoreBatchMode:            opts.scoreBatchMode,
+			StatsMode:                 statsMode,
+			QueryMode:                 queryMode,
+			QuantizedIndexName:        opts.QuantizedIndexName,
+			QuantizedRerankCandidates: opts.QuantizedRerankCandidates,
+		}, &s.scratch)
+		response.Stats = vectorIndexSearchStatsFromInternal(searchStats, columnPhysicalRowReaderStats{})
+		routeStats.apply(&response.Stats)
+		if err != nil {
+			clear(previousResults)
+			return response, err
+		}
+		response.Results, err = copyVectorIndexSearchResultsToBuffer(results, buffer, previousResults)
+		if err != nil {
+			return response, err
+		}
+		return response, nil
+	}
+
+	fallbackRouteStats := routeStats
 	readerStatsBefore := s.readerLast
 	results, searchStats, err := s.reader.SearchCosine(opts.Query, columnVectorGraphNativeSearchOptions{
 		TopK:                      opts.TopK,
@@ -1023,19 +1114,27 @@ func (s *VectorIndexSearcher) SearchWithBuffer(opts VectorIndexSearcherSearchOpt
 	s.readerLast = readerStatsAfter
 	readerStats := columnPhysicalRowReaderStatsDelta(readerStatsBefore, readerStatsAfter)
 	response.Stats = vectorIndexSearchStatsFromInternal(searchStats, readerStats)
-	s.routeStats.apply(&response.Stats)
+	fallbackRouteStats.apply(&response.Stats)
 	if err != nil {
 		clear(previousResults)
 		return response, err
 	}
+	response.Results, err = copyVectorIndexSearchResultsToBuffer(results, buffer, previousResults)
+	if err != nil {
+		return response, err
+	}
+	return response, nil
+}
+
+func copyVectorIndexSearchResultsToBuffer(results []columnVectorGraphNativeSearchResult, buffer *VectorIndexSearchBuffer, previousResults []VectorIndexSearchResult) ([]VectorIndexSearchResult, error) {
 	if len(results) == 0 {
 		clear(previousResults)
-		return response, nil
+		return nil, nil
 	}
 	idByteCount, err := vectorIndexSearchResultIDBytes(results)
 	if err != nil {
 		clear(previousResults)
-		return response, err
+		return nil, err
 	}
 	buffer.results = resizeVectorIndexSearchResultBuffer(buffer.results, len(results))
 	buffer.idBytes = resizeVectorIndexSearchByteBuffer(buffer.idBytes, idByteCount)
@@ -1047,7 +1146,7 @@ func (s *VectorIndexSearcher) SearchWithBuffer(opts VectorIndexSearcherSearchOpt
 		if len(result.ID) > len(buffer.idBytes)-idOffset {
 			clear(previousResults)
 			buffer.Reset()
-			return response, errors.New("collections: vector index search result id byte accounting mismatch")
+			return nil, errors.New("collections: vector index search result id byte accounting mismatch")
 		}
 		nextIDOffset := idOffset + len(result.ID)
 		id := buffer.idBytes[idOffset:nextIDOffset:nextIDOffset]
@@ -1059,8 +1158,7 @@ func (s *VectorIndexSearcher) SearchWithBuffer(opts VectorIndexSearcherSearchOpt
 			Score:   result.Score,
 		}
 	}
-	response.Results = buffer.results
-	return response, nil
+	return buffer.results, nil
 }
 
 func resizeVectorIndexSearchResultBuffer(dst []VectorIndexSearchResult, target int) []VectorIndexSearchResult {

--- a/TreeDB/collections/vector_index_search_test.go
+++ b/TreeDB/collections/vector_index_search_test.go
@@ -969,6 +969,9 @@ func TestVectorIndexSearcherSearchWithBufferResultEquivalenceAndZeroAllocs2124(t
 		t.Fatalf("SearchWithBuffer: %v", err)
 	}
 	assertColumnGraphSearchResponseLoadedV4(t, buffered, def.Name, opts.TopK)
+	if buffered.Stats.SearchRouteHNSWSearchPack != 1 || buffered.Stats.HNSWSearchPackActive != 1 || buffered.Stats.HNSWSearchPackFallbacks != 0 {
+		t.Fatalf("SearchWithBuffer stats=%+v want hnsw_search_pack_v1 route", buffered.Stats)
+	}
 	assertVectorIndexSearchResponsesEquivalentNoDocs2124(t, buffered, owned)
 	assertVectorIndexSearchResultIDStatsContract2124(t, buffered.Stats, owned.Stats)
 
@@ -1028,17 +1031,14 @@ func TestVectorIndexSearcherSearchWithBufferRouteStatsAndNoDocumentBoundary2311(
 		t.Fatalf("path=%q want current column_graph native-reader route", got.Path)
 	}
 	stats := got.Stats
-	if stats.SearchRouteHNSWSearchPack != 0 || stats.SearchRouteColumnGraphPrepared+stats.SearchRouteColumnGraphFallback != 1 {
-		t.Fatalf("route stats=%+v want exactly one current column_graph route and no search-pack route", stats)
+	if stats.SearchRouteHNSWSearchPack != 1 || stats.SearchRouteColumnGraphPrepared+stats.SearchRouteColumnGraphFallback != 0 {
+		t.Fatalf("route stats=%+v want hnsw_search_pack_v1 route", stats)
 	}
 	if stats.HNSWSearchPackActive != 1 || stats.HNSWSearchPackMissing != 0 || stats.HNSWSearchPackInvalid != 0 || stats.HNSWSearchPackStale != 0 || stats.HNSWSearchPackClosed != 0 || stats.HNSWSearchPackFallbacks != 0 || stats.HNSWSearchPackMmapDirect+stats.HNSWSearchPackHeapCopy != 1 || stats.HNSWSearchPackOpenNanos == 0 || stats.HNSWSearchPackActiveHandles != 1 || stats.HNSWSearchPackMappedBytes+stats.HNSWSearchPackHeapCopyBytes == 0 {
-		t.Fatalf("pack stats=%+v want hnsw_search_pack_v1 opened and counted without route selection", stats)
+		t.Fatalf("pack stats=%+v want active hnsw_search_pack_v1 route", stats)
 	}
-	if stats.SearchRouteColumnGraphPrepared == 1 && stats.PreparedGraphSearchViews == 0 {
-		t.Fatalf("graph route stats=%+v want prepared-route views when prepared route is active", stats)
-	}
-	if stats.GraphRows != 0 || stats.GraphRowFallbacks != 0 {
-		t.Fatalf("graph route stats=%+v want current-format route without graph-row fallback", stats)
+	if stats.PreparedGraphSearchViews != 0 || stats.GraphRows != 0 || stats.GraphRowFallbacks != 0 {
+		t.Fatalf("pack route stats=%+v want no column_graph prepared/row fallback", stats)
 	}
 	if stats.DocumentsFetched != 0 || stats.DocumentsMissing != 0 || stats.DocumentBytes != 0 || stats.DocumentOutputBytes != 0 || stats.DocumentFieldsReconstructed != 0 {
 		t.Fatalf("document boundary stats=%+v want no document materialization for SearchWithBuffer", stats)
@@ -1054,9 +1054,9 @@ func TestVectorIndexSearcherSearchWithBufferRouteStatsAndNoDocumentBoundary2311(
 	if stats.ScoreBatchCalls == 0 || stats.ScoreBatchCandidates == 0 || stats.ScoreBatchOptimizedCalls+stats.ScoreBatchScalarFallbackCalls == 0 {
 		t.Fatalf("score-batch counters=%+v want score batch mode/fallback evidence", stats)
 	}
-	vectorTypedSourceViews := stats.VectorDirectViews + stats.VectorMmapDirectViews + stats.VectorPreparedDirectViews + stats.VectorHeapCopyTypedViews
-	if vectorTypedSourceViews == 0 || stats.VectorScratchDecodes != 0 {
-		t.Fatalf("vector source stats=%+v want typed-column vector source without scratch fallback", stats)
+	packVectorViews := stats.VectorDirectViews + stats.VectorMmapDirectViews + stats.VectorPreparedDirectViews + stats.VectorHeapCopyTypedViews
+	if packVectorViews == 0 || stats.VectorScratchDecodes != 0 || stats.TypedColumnFallbacks != 0 || stats.NormBytesRead != 0 || stats.NormScratchDecodes != 0 {
+		t.Fatalf("vector source stats=%+v want pack normalized-vector dot path without norm/scratch fallback", stats)
 	}
 	adjacencyTypedSourceViews := stats.AdjacencyPreparedCSRDirectViews + stats.AdjacencyPreparedCSRMmapDirectViews + stats.AdjacencyTypedListDirectViews + stats.AdjacencyTypedListMmapDirectViews + stats.AdjacencyTypedListHeapCopyTypedViews
 	if adjacencyTypedSourceViews == 0 || stats.AdjacencyScratchDecodes != 0 || stats.AdjacencyLegacyFallbacks != 0 || stats.AdjacencySourceFallbacks != 0 {
@@ -1260,6 +1260,10 @@ func TestVectorIndexSearcherSearchWithBufferParallelIndependentBuffers1961(t *te
 				}
 				if len(got.Results) != len(want) {
 					errs <- fmt.Sprintf("worker %d iteration %d results=%d want %d", worker, i, len(got.Results), len(want))
+					return
+				}
+				if got.Stats.SearchRouteHNSWSearchPack != 1 || got.Stats.HNSWSearchPackActive != 1 || got.Stats.HNSWSearchPackFallbacks != 0 {
+					errs <- fmt.Sprintf("worker %d iteration %d stats=%+v want hnsw_search_pack_v1 route", worker, i, got.Stats)
 					return
 				}
 				for j := range want {
@@ -1903,25 +1907,9 @@ func assertVectorIndexSearchResultIDStatsContract2124(tb testing.TB, got, want V
 		{name: "visited_nodes", got: got.VisitedNodes, want: want.VisitedNodes},
 		{name: "visited_edges", got: got.VisitedEdges, want: want.VisitedEdges},
 		{name: "vector_bytes_read", got: got.VectorBytesRead, want: want.VectorBytesRead},
-		{name: "norm_bytes_read", got: got.NormBytesRead, want: want.NormBytesRead},
-		{name: "adjacency_bytes_read", got: got.AdjacencyBytesRead, want: want.AdjacencyBytesRead},
 		{name: "candidate_fetches", got: got.CandidateFetches, want: want.CandidateFetches},
 		{name: "expansion_fetches", got: got.ExpansionFetches, want: want.ExpansionFetches},
 		{name: "result_fetches", got: got.ResultFetches, want: want.ResultFetches},
-		{name: "prepared_graph_search_views", got: got.PreparedGraphSearchViews, want: want.PreparedGraphSearchViews},
-		{name: "search_route_column_graph_prepared", got: got.SearchRouteColumnGraphPrepared, want: want.SearchRouteColumnGraphPrepared},
-		{name: "search_route_column_graph_fallback", got: got.SearchRouteColumnGraphFallback, want: want.SearchRouteColumnGraphFallback},
-		{name: "search_route_hnsw_search_pack", got: got.SearchRouteHNSWSearchPack, want: want.SearchRouteHNSWSearchPack},
-		{name: "hnsw_search_pack_active", got: got.HNSWSearchPackActive, want: want.HNSWSearchPackActive},
-		{name: "hnsw_search_pack_missing", got: got.HNSWSearchPackMissing, want: want.HNSWSearchPackMissing},
-		{name: "hnsw_search_pack_invalid", got: got.HNSWSearchPackInvalid, want: want.HNSWSearchPackInvalid},
-		{name: "hnsw_search_pack_stale", got: got.HNSWSearchPackStale, want: want.HNSWSearchPackStale},
-		{name: "hnsw_search_pack_closed", got: got.HNSWSearchPackClosed, want: want.HNSWSearchPackClosed},
-		{name: "hnsw_search_pack_fallbacks", got: got.HNSWSearchPackFallbacks, want: want.HNSWSearchPackFallbacks},
-		{name: "hnsw_search_pack_mmap_direct", got: got.HNSWSearchPackMmapDirect, want: want.HNSWSearchPackMmapDirect},
-		{name: "hnsw_search_pack_heap_copy", got: got.HNSWSearchPackHeapCopy, want: want.HNSWSearchPackHeapCopy},
-		{name: "hnsw_search_pack_mapped_bytes", got: got.HNSWSearchPackMappedBytes, want: want.HNSWSearchPackMappedBytes},
-		{name: "hnsw_search_pack_heap_copy_bytes", got: got.HNSWSearchPackHeapCopyBytes, want: want.HNSWSearchPackHeapCopyBytes},
 		{name: "result_id_typed_bytes_state", got: got.ResultIDTypedBytesState, want: want.ResultIDTypedBytesState},
 		{name: "result_id_graph_fallbacks", got: got.ResultIDGraphFallbacks, want: want.ResultIDGraphFallbacks},
 		{name: "row_ref_state_result_refs", got: got.RowRefStateResultRefs, want: want.RowRefStateResultRefs},
@@ -1937,10 +1925,10 @@ func assertVectorIndexSearchResultIDStatsContract2124(tb testing.TB, got, want V
 		}
 	}
 	if got.GraphRows != 0 || got.ResultIDGraphFallbacks != 0 || got.GraphRowFallbacks != 0 || got.VectorScratchDecodes != 0 || got.NormScratchDecodes != 0 || got.AdjacencyScratchDecodes != 0 || got.TypedColumnFallbacks != 0 {
-		tb.Fatalf("stats=%+v want healthy typed-column result-ID path without graph-row/scratch fallbacks", got)
+		tb.Fatalf("stats=%+v want healthy vector-index result-ID path without graph-row/scratch fallbacks", got)
 	}
-	if got.SearchRouteHNSWSearchPack != 0 || got.SearchRouteColumnGraphPrepared+got.SearchRouteColumnGraphFallback != 1 {
-		tb.Fatalf("stats=%+v want exactly one current column_graph route and no search-pack route", got)
+	if got.SearchRouteHNSWSearchPack+got.SearchRouteColumnGraphPrepared+got.SearchRouteColumnGraphFallback != 1 {
+		tb.Fatalf("stats=%+v want exactly one search route", got)
 	}
 	if got.HNSWSearchPackActive+got.HNSWSearchPackMissing+got.HNSWSearchPackInvalid+got.HNSWSearchPackStale+got.HNSWSearchPackClosed != 1 {
 		tb.Fatalf("stats=%+v want exactly one hnsw_search_pack_v1 availability status", got)
@@ -1948,8 +1936,8 @@ func assertVectorIndexSearchResultIDStatsContract2124(tb testing.TB, got, want V
 	if got.HNSWSearchPackActive == 1 && (got.HNSWSearchPackMmapDirect+got.HNSWSearchPackHeapCopy != 1 || got.HNSWSearchPackOpenNanos == 0 || got.HNSWSearchPackActiveHandles != 1 || got.HNSWSearchPackMappedBytes+got.HNSWSearchPackHeapCopyBytes == 0) {
 		tb.Fatalf("stats=%+v want active hnsw_search_pack_v1 direct/heap resource evidence", got)
 	}
-	if got.ResultIDTypedBytesState == 0 || got.ResultIDPreparedBytesViews == 0 || got.RowRefVectorSourceState == 0 {
-		tb.Fatalf("stats=%+v want typed-column result-ID and row-ref state", got)
+	if got.ResultIDTypedBytesState == 0 || got.ResultIDPreparedBytesViews == 0 || got.RowRefStateResultRefs == 0 {
+		tb.Fatalf("stats=%+v want vector-index result-ID and row-ref identity state", got)
 	}
 }
 
@@ -3020,10 +3008,10 @@ func reportVectorIndexSearchBenchMetricsV4(b *testing.B, n int, stats VectorInde
 	b.ReportMetric(float64(stats.NormDecodedBytes), "norm_decoded_B")
 	b.ReportMetric(float64(stats.NormActiveHandles), "norm_active_handles")
 	b.ReportMetric(float64(stats.NormDeniedResources), "norm_denied_resources")
-	if stats.VectorMmapDirectViews > 0 {
+	if stats.VectorMmapDirectViews > 0 && stats.TypedColumnMappedBytes > 0 {
 		b.ReportMetric(1, "typed_column_vector_source_mmap")
 	}
-	if stats.VectorHeapCopyTypedViews > 0 {
+	if stats.VectorHeapCopyTypedViews > 0 && stats.TypedColumnHeapCopyBytes > 0 {
 		b.ReportMetric(1, "typed_column_vector_source_heap_copy")
 	}
 	if stats.VectorScratchDecodes > 0 && stats.TypedColumnDecodedBytes > 0 {

--- a/TreeDB/collections/vector_index_search_test.go
+++ b/TreeDB/collections/vector_index_search_test.go
@@ -1058,9 +1058,9 @@ func TestVectorIndexSearcherSearchWithBufferRouteStatsAndNoDocumentBoundary2311(
 	if packVectorViews == 0 || stats.VectorScratchDecodes != 0 || stats.TypedColumnFallbacks != 0 || stats.NormBytesRead != 0 || stats.NormScratchDecodes != 0 {
 		t.Fatalf("vector source stats=%+v want pack normalized-vector dot path without norm/scratch fallback", stats)
 	}
-	adjacencyTypedSourceViews := stats.AdjacencyPreparedCSRDirectViews + stats.AdjacencyPreparedCSRMmapDirectViews + stats.AdjacencyTypedListDirectViews + stats.AdjacencyTypedListMmapDirectViews + stats.AdjacencyTypedListHeapCopyTypedViews
-	if adjacencyTypedSourceViews == 0 || stats.AdjacencyScratchDecodes != 0 || stats.AdjacencyLegacyFallbacks != 0 || stats.AdjacencySourceFallbacks != 0 {
-		t.Fatalf("adjacency source stats=%+v want typed-column adjacency source without legacy/scratch fallback", stats)
+	packAdjacencyViews := stats.AdjacencyDirectViews + stats.AdjacencyMmapDirectViews + stats.AdjacencyHeapCopyTypedViews + stats.AdjacencyPreparedCSRDirectViews + stats.AdjacencyPreparedCSRMmapDirectViews
+	if packAdjacencyViews == 0 || stats.AdjacencyScratchDecodes != 0 || stats.AdjacencyLegacyFallbacks != 0 || stats.AdjacencySourceFallbacks != 0 {
+		t.Fatalf("adjacency source stats=%+v want pack CSR adjacency source without legacy/scratch fallback", stats)
 	}
 	if stats.ResultIDTypedBytesState == 0 || stats.RowRefStateResultRefs == 0 || stats.ResultIDGraphFallbacks != 0 {
 		t.Fatalf("identity stats=%+v want vector-index row-ref/document-id state without graph-row fallback", stats)

--- a/TreeDB/collections/vector_usearch_bench_test.go
+++ b/TreeDB/collections/vector_usearch_bench_test.go
@@ -110,8 +110,8 @@ func BenchmarkCollectionVectorUSearchProductionCompare(b *testing.B) {
 			b.Fatalf("measure SearchWithBuffer stats: %v", err)
 		}
 		stats := measured.Stats
-		if stats.TypedColumnFallbacks != 0 || stats.VectorMmapDirectViews+stats.VectorHeapCopyTypedViews+stats.VectorScratchDecodes == 0 {
-			b.Fatalf("TreeDB production comparison stats=%+v want active typed-column vector source counters", stats)
+		if stats.SearchRouteHNSWSearchPack != 1 || stats.HNSWSearchPackActive != 1 || stats.HNSWSearchPackFallbacks != 0 || stats.SearchRouteColumnGraphPrepared+stats.SearchRouteColumnGraphFallback != 0 || stats.TypedColumnFallbacks != 0 || stats.VectorScratchDecodes != 0 || stats.GraphRowFallbacks != 0 || stats.DocumentsFetched != 0 {
+			b.Fatalf("TreeDB production comparison stats=%+v want active hnsw_search_pack_v1 route", stats)
 		}
 		b.ReportAllocs()
 		b.ResetTimer()
@@ -170,8 +170,8 @@ func BenchmarkCollectionVectorUSearchProductionCompare(b *testing.B) {
 			b.Fatalf("measure SearchWithBuffer stats: %v", err)
 		}
 		stats := measured.Stats
-		if stats.TypedColumnFallbacks != 0 || stats.VectorMmapDirectViews+stats.VectorHeapCopyTypedViews+stats.VectorScratchDecodes == 0 {
-			b.Fatalf("TreeDB production parallel comparison stats=%+v want active typed-column vector source counters", stats)
+		if stats.SearchRouteHNSWSearchPack != 1 || stats.HNSWSearchPackActive != 1 || stats.HNSWSearchPackFallbacks != 0 || stats.SearchRouteColumnGraphPrepared+stats.SearchRouteColumnGraphFallback != 0 || stats.TypedColumnFallbacks != 0 || stats.VectorScratchDecodes != 0 || stats.GraphRowFallbacks != 0 || stats.DocumentsFetched != 0 {
+			b.Fatalf("TreeDB production parallel comparison stats=%+v want active hnsw_search_pack_v1 route", stats)
 		}
 		top1Got, top1Want := string(measured.Results[0].ID), vectorUSearchProductionDocID(queryDocIndexes[0])
 		var nextWorker atomic.Uint64

--- a/scripts/bench_vector_search_compare.sh
+++ b/scripts/bench_vector_search_compare.sh
@@ -167,16 +167,20 @@ Canonical current production comparison:
 
 - \`BenchmarkCollectionVectorUSearchProductionCompare/TreeDB_SearchWithBuffer\`
   and \`.../TreeDB_SearchWithBufferParallel\` time the persisted TreeDB
-  \`column_graph\` path through \`Collection.OpenVectorIndexSearcher\` plus
-  \`VectorIndexSearcher.SearchWithBuffer\`. Setup, inserts, rebuild, open, and
-  warmup are outside the timed loop. Parallel runs use one searcher and one
+  no-document \`hnsw_search_pack_v1\` route through
+  \`Collection.OpenVectorIndexSearcher\` plus \`VectorIndexSearcher.SearchWithBuffer\`
+  when a live validated pack is available. The existing prepared \`column_graph\`
+  route remains the fallback for missing/invalid/stale packs or unsupported
+  query modes. Setup, inserts, rebuild, open, and warmup are outside the timed
+  loop. Parallel runs use one searcher and one
   caller-owned buffer per Go worker; use \`CPU_LIST=1,8\` for c=1/c=8 evidence.
   The script emits a separate \`## search benchmarks cpu=<n>\` block for each
   requested concurrency so worker counts stay unambiguous.
   The timed loop uses production stats mode; a full-diagnostics sample is taken
-  outside the timed loop to report candidates/search and edge counters. TreeDB
-  rows also report route/search-pack guardrails such as
-  \`search_route_column_graph_prepared/search\`,
+  outside the timed loop to report candidates/search and edge counters. Healthy
+  pack rows should report \`search_route_hnsw_search_pack/search=1\`, no document
+  fetches, no graph-row fallback, no vector scratch decode, and route/search-pack
+  guardrails such as \`search_route_column_graph_prepared/search\`,
   \`hnsw_search_pack_active/search\`,
   \`hnsw_search_pack_missing/search\`, \`hnsw_search_pack_invalid/search\`,
   \`hnsw_search_pack_stale/search\`, \`hnsw_search_pack_closed/search\`,
@@ -201,8 +205,10 @@ Legacy/control rows:
   production fast path.
 
 Data boundary: TreeDB stores generated float32 vectors through JSON collection
-inserts and rebuilds the persisted \`column_graph\`; USearch is built directly
-from the generated float32 vectors as a pure in-memory external ANN baseline.
+inserts and rebuilds the persisted \`column_graph\` plus derived
+\`hnsw_search_pack_v1\`; raw collection vectors remain authoritative while the
+pack is vector-index serving state. USearch is built directly from the generated
+float32 vectors as a pure in-memory external ANN baseline.
 
 With \`RUN_WRITE_BENCH=true\`, the script also compares TreeDB incremental
 \`InsertBatch\` with a registered in-memory vector index against USearch


### PR DESCRIPTION
## Objective

Closes #2315. Make production no-document `VectorIndexSearcher.SearchWithBuffer` prefer the opened, validated `hnsw_search_pack_v1` serving pack when it is live and compatible.

## Context

Before this PR, searchers opened the pack and reported its availability, but `SearchWithBuffer` still searched through the prepared `column_graph` path. This kept extra generic typed-column/vector/norm/row plumbing in the hot loop even when the pack already contained normalized vectors, CSR adjacency, levels, document IDs, and row refs.

## Non-goals

- No raw collection-vector authority change: raw collection vectors remain authoritative; the pack is derived vector-index serving state.
- No `Search`/document-materialization route change; this is scoped to no-document `SearchWithBuffer`.
- No quantized-mode pack search in this PR; quantized and benchmark-debug modes keep the existing `column_graph` route.
- No on-disk format change.

## Design

- `SearchWithBuffer` routes to `hnsw_search_pack_v1` only when the opened searcher has a direct/heap pack, exact query mode, no docs, and supported stats mode.
- The hot route searches over pack arrays:
  - one query normalization into scratch;
  - dot-only scoring against pack normalized vectors;
  - traversal through pack levels and CSR adjacency;
  - final IDs/rowrefs from pack identity sections.
- The existing prepared `column_graph` route remains fallback for missing/stale/invalid/closed packs and unsupported modes.
- The healthy path uses cached open-time `VectorIndexSearcher.routeStats` plus cheap `closed` / `handle.Released()` guards; it does not call per-search `routeStats()` or `validateLive()`.
- Pack result ID slices are scratch-owned views until the final copy into the caller-owned `VectorIndexSearchBuffer`, preserving `SearchWithBuffer` result ownership and allocation behavior.

## Scope

Includes:

- `TreeDB/collections/column_hnsw_search_pack_search.go`
- `TreeDB/collections/column_hnsw_search_pack_reader.go`
- `TreeDB/collections/vector_index_search.go`
- HNSW/searcher tests and benchmark guardrails
- `scripts/bench_vector_search_compare.sh` wording/guardrail docs

Excludes:

- `Search` document materialization
- quantized pack serving
- pack encoding/writer format changes

## Correctness

Tests run:

- `go test ./TreeDB/collections -run '^TestVectorIndexSearcherSearchWithBufferRouteStatsAndNoDocumentBoundary2311$' -count=1`
- `go test ./TreeDB/collections -count=1`
- `go test ./...`

Coverage added/updated:

- pack route selected for `SearchWithBuffer` and matches the existing `column_graph` reference route;
- reopen route continues using the pack and preserves parity;
- zero-allocation/result-buffer behavior remains covered;
- parallel callers with independent searcher/buffer pairs use the pack route;
- missing/stale/invalid/corrupt packs fall back to the existing route;
- no-document boundary remains enforced.

## Performance

Benchmark commands:

```sh
RUN_DIR=/tmp/gomap_2315_baseline_tier_s_20260604_181352 CPU_LIST=1,8 BENCHTIME=1000x COUNT=3 TREEDB_VECTOR_BENCH_DOCS=10000 TREEDB_VECTOR_BENCH_DIMS=64 BENCH_REGEX='BenchmarkCollectionVectorUSearchProductionCompare$' scripts/bench_vector_search_compare.sh
RUN_DIR=/tmp/gomap_2315_baseline_tier_f_20260604_181439 CPU_LIST=1,8 BENCHTIME=1s COUNT=3 TREEDB_VECTOR_BENCH_DOCS=100000 TREEDB_VECTOR_BENCH_DIMS=128 BENCH_REGEX='BenchmarkCollectionVectorUSearchProductionCompare$' scripts/bench_vector_search_compare.sh
RUN_DIR=/tmp/gomap_2315_candidate_tier_s_20260604_184935 CPU_LIST=1,8 BENCHTIME=1000x COUNT=3 TREEDB_VECTOR_BENCH_DOCS=10000 TREEDB_VECTOR_BENCH_DIMS=64 BENCH_REGEX='BenchmarkCollectionVectorUSearchProductionCompare$' scripts/bench_vector_search_compare.sh
RUN_DIR=/tmp/gomap_2315_candidate_tier_f_20260604_185023 CPU_LIST=1,8 BENCHTIME=1s COUNT=3 TREEDB_VECTOR_BENCH_DOCS=100000 TREEDB_VECTOR_BENCH_DIMS=128 BENCH_REGEX='BenchmarkCollectionVectorUSearchProductionCompare$' scripts/bench_vector_search_compare.sh
```

Artifacts:

- Baseline Tier S: `/tmp/gomap_2315_baseline_tier_s_20260604_181352/bench.txt`
- Baseline Tier F: `/tmp/gomap_2315_baseline_tier_f_20260604_181439/bench.txt`
- Candidate Tier S: `/tmp/gomap_2315_candidate_tier_s_20260604_184935/bench.txt`
- Candidate Tier F: `/tmp/gomap_2315_candidate_tier_f_20260604_185023/bench.txt`
- Benchstat: `/tmp/gomap_2315_candidate_tier_s_benchstat.txt`, `/tmp/gomap_2315_candidate_tier_f_benchstat.txt`

TreeDB `SearchWithBuffer` medians:

| tier | row | baseline | candidate | ops/sec candidate |
| --- | --- | ---: | ---: | ---: |
| S 10k/64 c=1 | serial | 79.7 us/op | 51.3 us/op | ~19.5k |
| S 10k/64 c=8 | parallel | 16.8 us/op | 10.0 us/op | ~100.1k |
| F 100k/128 c=1 | serial | 332.8 us/op | 209.1 us/op | ~4.8k |
| F 100k/128 c=8 | parallel | 173.8 us/op | 50.2 us/op | ~19.9k |

Candidate guardrails in both Tier S and Tier F samples:

- `search_route_hnsw_search_pack/search=1`
- `search_route_column_graph_prepared/search=0`
- `search_route_column_graph_fallback/search=0`
- `hnsw_search_pack_fallbacks/search=0`
- `doc_B/search=0`, `docs_fetched/search=0`
- `graph_row_fallbacks/search=0`
- `vector_scratch_decodes/search=0`
- `typed_column_vector_fallbacks/search=0`
- serial TreeDB rows stayed `0 B/op`, `0 allocs/op`

Hot profile for the candidate steady-state pack route:

- `/tmp/gomap_2315_candidate_hot_profile_20260604_185833/cpu_hot.pprof`
- `/tmp/gomap_2315_candidate_hot_profile_20260604_185833/cpu_hot_top.txt`

The hot profile is dominated by vector dot/scoring (`dotFloat32IndexedARM64`, `searchCosine`, `scoreOrdinals`). No `validateLive`, per-search `routeStats`, checksum, read-at, or lock path appears in the top profile.

## CI / latest-head status

Latest pushed head: `a4d7176e7`. The prior Windows `windows-core-2` failure was PR-caused test guardrail drift: Windows opens the pack through heap-copy, so the assertion needed to count `AdjacencyHeapCopyTypedViews` as healthy pack CSR adjacency evidence. Fixed in `a4d7176e7`; local targeted and package tests pass. Latest-head CI is green, including `windows-core-2`.

## Rollout / Toggle Plan

Default behavior is automatic for healthy exact no-document `SearchWithBuffer` searches. Immediate fallback remains available by making the pack unavailable/stale/invalid or by using an unsupported mode; the existing `column_graph` route is unchanged.

## Follow-ups

- Quantized pack serving remains intentionally deferred.
- #2316 is not started here.

## AI Review Loop

- Codex latest-head review: requested after PR creation; re-requested after `a4d7176e7`; no major issues reported.
- Copilot latest-head review: requested after PR creation; re-requested after `a4d7176e7`; no Copilot response observed.
- CodeRabbit latest-head review: requested after PR creation; re-requested after `a4d7176e7`; review completed.
- Review comments/threads: no unresolved review threads found.
