### PR TITLE
TreeDB: support public command-WAL DeleteRange

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -21203,13 +21203,51 @@ func (db *DB) Delete(key []byte) error {
 // When WAL is disabled and the backend is empty, a full-range delete can be
 // satisfied by clearing the in-memory layers without enumerating keys.
 func (db *DB) DeleteRange(start, end []byte) error {
+	return db.deleteRange(start, end, nil)
+}
+
+// DeleteRangeAfterCommandWALAppend applies a range delete after appendCommand
+// succeeds. appendCommand runs after ordinary cached-mode preflight and before
+// the range delete becomes visible in memory or durable backend roots. This is
+// for public command-WAL mode, where command WAL durability replaces the cached
+// redo log.
+func (db *DB) DeleteRangeAfterCommandWALAppend(start, end []byte, appendCommand func() error) error {
+	if appendCommand == nil {
+		return fmt.Errorf("cachingdb: missing command wal append callback")
+	}
+	if db != nil && !db.disableJournal {
+		return fmt.Errorf("cachingdb: command wal range deletes require disabled cached redo log")
+	}
+	return db.deleteRange(start, end, appendCommand)
+}
+
+func (db *DB) deleteRange(start, end []byte, appendCommand func() error) (err error) {
 	if db == nil {
 		return nil
 	}
-	if start != nil && end != nil && bytes.Compare(start, end) >= 0 {
+	if batch.IsDeleteRangeNoop(start, end) {
 		return nil
 	}
+	if appendCommand != nil && !db.disableJournal {
+		return fmt.Errorf("cachingdb: command wal range deletes require disabled cached redo log")
+	}
 	db.waitForCheckpoint()
+	commandWALAppended := false
+	appendCommandBeforeVisibility := func() error {
+		if appendCommand == nil || commandWALAppended {
+			return nil
+		}
+		if err := appendCommand(); err != nil {
+			return err
+		}
+		commandWALAppended = true
+		return nil
+	}
+	defer func() {
+		if err != nil && commandWALAppended {
+			db.reportError(fmt.Errorf("cachingdb: post-command-wal delete range failed: %w", err))
+		}
+	}()
 
 	// Journal-enabled mode: do a snapshot scan and apply per-key deletes directly.
 	// Append journal records one-by-one to preserve batch atomicity and to avoid
@@ -21357,7 +21395,7 @@ func (db *DB) DeleteRange(start, end []byte) error {
 	//
 	// This is safe only when we have no queued memtables and the mutable memtable
 	// is empty; otherwise we'd violate "newest wins" semantics.
-	if db.disableJournal {
+	if db.disableJournal && appendCommand == nil {
 		db.mu.Lock()
 		backendOnly := len(db.queue) == 0 && db.mutableBytes.Load() == 0
 		db.mu.Unlock()
@@ -21443,7 +21481,7 @@ func (db *DB) DeleteRange(start, end []byte) error {
 		// Fast path: if the backend is empty and the delete range covers all keys we
 		// currently have buffered in memory, just drop the in-memory state. This
 		// avoids iterator creation, merges, and per-key tombstones.
-		if coversAll && db.disableJournal && backendEmpty {
+		if coversAll && db.disableJournal && backendEmpty && appendCommand == nil {
 			curMode := db.currentMemtableMode()
 			nextMode := curMode
 			if db.memtableAdaptive {
@@ -21492,6 +21530,10 @@ func (db *DB) DeleteRange(start, end []byte) error {
 		defer db.writeMu.Unlock()
 
 		db.mu.Lock()
+		if err := appendCommandBeforeVisibility(); err != nil {
+			db.mu.Unlock()
+			return err
+		}
 		mutableRange := db.snapshotMutableRange()
 		coversInMemory := queryCoversRange(start, end, mutableRange)
 		for _, r := range db.queueRanges {
@@ -21505,7 +21547,7 @@ func (db *DB) DeleteRange(start, end []byte) error {
 		// in-memory keys, clear the in-memory layers and delete directly from the
 		// backend. This avoids building large tombstone sets and avoids per-key
 		// copies into an intermediate slice.
-		if coversInMemory {
+		if coversInMemory && appendCommand == nil {
 			curMode := db.currentMemtableMode()
 			nextMode := curMode
 			if db.memtableAdaptive {

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -21211,6 +21211,11 @@ func (db *DB) DeleteRange(start, end []byte) error {
 // the range delete becomes visible in memory or durable backend roots. This is
 // for public command-WAL mode, where command WAL durability replaces the cached
 // redo log.
+//
+// appendCommand runs while delete serialization is active. It must not re-enter
+// the same caching DB or call methods that need the cache writer lock. It should
+// return quickly and handle any synchronization with other components itself;
+// long-blocking callbacks stall cached writers.
 func (db *DB) DeleteRangeAfterCommandWALAppend(start, end []byte, appendCommand func() error) error {
 	if appendCommand == nil {
 		return fmt.Errorf("cachingdb: missing command wal append callback")
@@ -21530,6 +21535,9 @@ func (db *DB) deleteRange(start, end []byte, appendCommand func() error) (err er
 		defer db.writeMu.Unlock()
 
 		db.mu.Lock()
+		// appendCommand runs while the cache writer is serialized. It must not
+		// re-enter this DB; see DeleteRangeAfterCommandWALAppend for the callback
+		// contract.
 		if err := appendCommandBeforeVisibility(); err != nil {
 			db.mu.Unlock()
 			return err

--- a/TreeDB/caching/delete_range_test.go
+++ b/TreeDB/caching/delete_range_test.go
@@ -119,6 +119,80 @@ func TestCachingDB_DeleteRange_WALApplyFailurePoisonsWrites(t *testing.T) {
 	}
 }
 
+func TestCachingDB_DeleteRangeAfterCommandWALAppendFailureDoesNotMutate(t *testing.T) {
+	dir := t.TempDir()
+	backend := NewMockBackend()
+
+	db, err := Open(dir, backend, Options{
+		DisableWAL:     true,
+		AllowUnsafe:    true,
+		FlushThreshold: 1 << 20,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	if err := db.Set([]byte("a"), []byte("va")); err != nil {
+		t.Fatalf("Set(a): %v", err)
+	}
+	if err := db.Set([]byte("z"), []byte("vz")); err != nil {
+		t.Fatalf("Set(z): %v", err)
+	}
+
+	appendErr := errors.New("append failed")
+	appendCalls := 0
+	if err := db.DeleteRangeAfterCommandWALAppend([]byte("a"), []byte("z"), func() error {
+		appendCalls++
+		return appendErr
+	}); !errors.Is(err, appendErr) {
+		t.Fatalf("DeleteRangeAfterCommandWALAppend error=%v, want appendErr", err)
+	}
+	if appendCalls != 1 {
+		t.Fatalf("append calls=%d, want 1", appendCalls)
+	}
+	got, err := db.Get([]byte("a"))
+	if err != nil || string(got) != "va" {
+		t.Fatalf("Get(a)=(%q,%v), want va,nil after append failure", got, err)
+	}
+	got, err = db.Get([]byte("z"))
+	if err != nil || string(got) != "vz" {
+		t.Fatalf("Get(z)=(%q,%v), want vz,nil after append failure", got, err)
+	}
+}
+
+func TestCachingDB_DeleteRangeAfterCommandWALAppendNoopDoesNotAppend(t *testing.T) {
+	dir := t.TempDir()
+	backend := NewMockBackend()
+
+	db, err := Open(dir, backend, Options{
+		DisableWAL:     true,
+		AllowUnsafe:    true,
+		FlushThreshold: 1 << 20,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	appendCalls := 0
+	if err := db.DeleteRangeAfterCommandWALAppend([]byte("z"), []byte("a"), func() error {
+		appendCalls++
+		return nil
+	}); err != nil {
+		t.Fatalf("reversed no-op DeleteRangeAfterCommandWALAppend: %v", err)
+	}
+	if err := db.DeleteRangeAfterCommandWALAppend(nil, []byte{}, func() error {
+		appendCalls++
+		return nil
+	}); err != nil {
+		t.Fatalf("unbounded-to-empty no-op DeleteRangeAfterCommandWALAppend: %v", err)
+	}
+	if appendCalls != 0 {
+		t.Fatalf("append calls=%d, want 0 for no-op ranges", appendCalls)
+	}
+}
+
 func TestCachingDB_DeleteRange_WALFlushesAfterDeletes(t *testing.T) {
 	dir := t.TempDir()
 	backend := NewMockBackend()

--- a/TreeDB/command_wal_public_cached.go
+++ b/TreeDB/command_wal_public_cached.go
@@ -41,6 +41,18 @@ func (tdb *DB) appendPublicRawKVCommandPayload(payload []byte, sync bool) error 
 	return err
 }
 
+func (tdb *DB) appendPublicRawKVDeleteRangeCommand(start, end []byte, sync bool) error {
+	if tdb == nil || !tdb.commandWALCached || batch.IsDeleteRangeNoop(start, end) {
+		return nil
+	}
+	var payload commitlog.RawKVBatchPayloadBuilder
+	_ = payload.ResetWithHint(1, len(start)+len(end))
+	if _, err := payload.AppendDeleteRange(start, end); err != nil {
+		return err
+	}
+	return tdb.appendPublicRawKVCommandPayload(payload.Payload(), sync)
+}
+
 func (tdb *DB) recordPublicCommandWALPendingLSN(lsn uint64) {
 	if tdb == nil || lsn == 0 {
 		return

--- a/TreeDB/command_wal_public_test.go
+++ b/TreeDB/command_wal_public_test.go
@@ -301,10 +301,6 @@ func TestPublicCommandWALRejectsUnsupportedCachedRawMutations(t *testing.T) {
 	if updateSyncCalled {
 		t.Fatal("UpdateSync callback ran after command-WAL rejection")
 	}
-	if err := db.DeleteRange([]byte("a"), []byte("z")); !errors.Is(err, ErrCommandWALRejected) {
-		t.Fatalf("DeleteRange err=%v, want ErrCommandWALRejected", err)
-	}
-
 	got, err := db.Get([]byte("keep"))
 	if err != nil {
 		t.Fatalf("Get(keep): %v", err)
@@ -323,10 +319,7 @@ func assertPublicCommandWALFrames(t *testing.T, db *DB, minFrames uint64) {
 	if stats["treedb.command_wal.stats_scan"] != "true" {
 		t.Fatalf("stats_scan=%q, want true", stats["treedb.command_wal.stats_scan"])
 	}
-	frames, err := strconv.ParseUint(stats["treedb.command_wal.frames"], 10, 64)
-	if err != nil {
-		t.Fatalf("parse command_wal.frames=%q: %v", stats["treedb.command_wal.frames"], err)
-	}
+	frames := publicCommandWALFrameCount(t, db)
 	if frames < minFrames {
 		t.Fatalf("command_wal.frames=%d, want at least %d", frames, minFrames)
 	}
@@ -337,6 +330,16 @@ func assertPublicCommandWALFrames(t *testing.T, db *DB, minFrames uint64) {
 	if maxLSN < minFrames {
 		t.Fatalf("command_wal.max_lsn=%d, want at least %d", maxLSN, minFrames)
 	}
+}
+
+func publicCommandWALFrameCount(t *testing.T, db *DB) uint64 {
+	t.Helper()
+	stats := db.Stats()
+	frames, err := strconv.ParseUint(stats["treedb.command_wal.frames"], 10, 64)
+	if err != nil {
+		t.Fatalf("parse command_wal.frames=%q: %v", stats["treedb.command_wal.frames"], err)
+	}
+	return frames
 }
 
 func TestPublicCommandWALLiveCountersDoNotRequireStatsScan(t *testing.T) {
@@ -1094,6 +1097,322 @@ func assertPublicCommandWALFramesB(b *testing.B, db *DB, minFrames uint64) {
 	}
 	if frames < minFrames {
 		b.Fatalf("command_wal.frames=%d, want at least %d", frames, minFrames)
+	}
+}
+
+func TestPublicCommandWALDeleteRangeCachedReopen(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(Options{
+		Dir:                          dir,
+		Durability:                   DurabilityWALOnRelaxed,
+		CommandWAL:                   true,
+		CommandWALStatsScan:          true,
+		DisableSideStores:            true,
+		BackgroundCheckpointInterval: -1,
+	})
+	if err != nil {
+		t.Fatalf("Open command WAL: %v", err)
+	}
+	for _, kv := range []struct{ k, v string }{{"a", "va"}, {"b", "vb"}, {"c", "vc"}, {"d", "vd"}} {
+		if err := db.Set([]byte(kv.k), []byte(kv.v)); err != nil {
+			t.Fatalf("Set %s: %v", kv.k, err)
+		}
+	}
+	before := publicCommandWALFrameCount(t, db)
+	if err := db.DeleteRange([]byte("b"), []byte("d")); err != nil {
+		t.Fatalf("DeleteRange: %v", err)
+	}
+	if got := publicCommandWALFrameCount(t, db); got != before+1 {
+		t.Fatalf("command_wal.frames=%d, want %d after one DB-level DeleteRange", got, before+1)
+	}
+	for _, key := range []string{"b", "c"} {
+		has, err := db.Has([]byte(key))
+		if err != nil || has {
+			t.Fatalf("Has(%s)=(%t,%v), want false,nil before reopen", key, has, err)
+		}
+	}
+	requireRawKVValue(t, db, []byte("a"), []byte("va"))
+	requireRawKVValue(t, db, []byte("d"), []byte("vd"))
+
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	reopen, err := Open(Options{Dir: dir, CommandWALStatsScan: true, DisableSideStores: true, BackgroundCheckpointInterval: -1})
+	if err != nil {
+		t.Fatalf("Reopen: %v", err)
+	}
+	defer reopen.Close()
+	for _, key := range []string{"b", "c"} {
+		has, err := reopen.Has([]byte(key))
+		if err != nil || has {
+			t.Fatalf("Has(%s)=(%t,%v), want false,nil after replay", key, has, err)
+		}
+	}
+	requireRawKVValue(t, reopen, []byte("a"), []byte("va"))
+	requireRawKVValue(t, reopen, []byte("d"), []byte("vd"))
+	if got := reopen.backend.State().AppliedCommandLSN; got < before+1 {
+		t.Fatalf("AppliedCommandLSN=%d, want at least %d after reopen", got, before+1)
+	}
+}
+
+func TestPublicCommandWALDeleteRangeReplaysUnappliedFrame(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(Options{
+		Dir:                          dir,
+		Durability:                   DurabilityWALOnRelaxed,
+		CommandWAL:                   true,
+		CommandWALStatsScan:          true,
+		DisableSideStores:            true,
+		BackgroundCheckpointInterval: -1,
+	})
+	if err != nil {
+		t.Fatalf("Open command WAL: %v", err)
+	}
+	for _, kv := range []struct{ k, v string }{{"a", "va"}, {"b", "vb"}, {"c", "vc"}, {"d", "vd"}} {
+		if err := db.Set([]byte(kv.k), []byte(kv.v)); err != nil {
+			_ = db.Close()
+			t.Fatalf("Set %s: %v", kv.k, err)
+		}
+	}
+	if err := db.Checkpoint(); err != nil {
+		_ = db.Close()
+		t.Fatalf("Checkpoint: %v", err)
+	}
+	baseApplied := db.backend.State().AppliedCommandLSN
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	backend, err := backenddb.Open(backenddb.Options{Dir: dir, CommandWAL: true, DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatalf("backend Open for manual command append: %v", err)
+	}
+	lsn, err := backend.AppendRawKVSingleCommandWAL(commitlog.RawKVOperation{Op: commitlog.RawKVOpDeleteRange, Key: []byte("b"), Value: []byte("d")}, true)
+	if err != nil {
+		_ = backend.Close()
+		t.Fatalf("AppendRawKVSingleCommandWAL DeleteRange: %v", err)
+	}
+	if lsn <= baseApplied {
+		_ = backend.Close()
+		t.Fatalf("DeleteRange frame lsn=%d, want > base applied %d", lsn, baseApplied)
+	}
+	if err := backend.Close(); err != nil {
+		t.Fatalf("backend Close after manual command append: %v", err)
+	}
+
+	reopen, err := Open(Options{Dir: dir, CommandWALStatsScan: true, DisableSideStores: true, BackgroundCheckpointInterval: -1})
+	if err != nil {
+		t.Fatalf("Reopen: %v", err)
+	}
+	defer reopen.Close()
+	for _, key := range []string{"b", "c"} {
+		has, err := reopen.Has([]byte(key))
+		if err != nil || has {
+			t.Fatalf("Has(%s)=(%t,%v), want false,nil after replay", key, has, err)
+		}
+	}
+	requireRawKVValue(t, reopen, []byte("a"), []byte("va"))
+	requireRawKVValue(t, reopen, []byte("d"), []byte("vd"))
+	if got := reopen.backend.State().AppliedCommandLSN; got < lsn {
+		t.Fatalf("AppliedCommandLSN=%d, want at least replayed lsn %d", got, lsn)
+	}
+}
+
+func TestPublicCommandWALDeleteRangeBoundsNoopFramesAndCheckpointLSN(t *testing.T) {
+	db, err := Open(Options{
+		Dir:                          t.TempDir(),
+		Durability:                   DurabilityWALOnRelaxed,
+		CommandWAL:                   true,
+		CommandWALStatsScan:          true,
+		DisableSideStores:            true,
+		BackgroundCheckpointInterval: -1,
+	})
+	if err != nil {
+		t.Fatalf("Open command WAL: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	for _, kv := range []struct{ k, v string }{{"a", "va"}, {"b", "vb"}, {"c", "vc"}, {"z", "vz"}} {
+		if err := db.Set([]byte(kv.k), []byte(kv.v)); err != nil {
+			t.Fatalf("Set %s: %v", kv.k, err)
+		}
+	}
+	baseFrames := publicCommandWALFrameCount(t, db)
+	for _, bounds := range []struct{ start, end []byte }{
+		{start: []byte("c"), end: []byte("c")},
+		{start: []byte("z"), end: []byte("a")},
+		{start: nil, end: []byte{}},
+	} {
+		if err := db.DeleteRange(bounds.start, bounds.end); err != nil {
+			t.Fatalf("noop DeleteRange(%q,%q): %v", bounds.start, bounds.end, err)
+		}
+		if got := publicCommandWALFrameCount(t, db); got != baseFrames {
+			t.Fatalf("noop DeleteRange(%q,%q) frames=%d, want unchanged %d", bounds.start, bounds.end, got, baseFrames)
+		}
+	}
+
+	if err := db.DeleteRange(nil, []byte("b")); err != nil {
+		t.Fatalf("DeleteRange nil,b: %v", err)
+	}
+	if got := publicCommandWALFrameCount(t, db); got != baseFrames+1 {
+		t.Fatalf("frames after lower-unbounded DeleteRange=%d, want %d", got, baseFrames+1)
+	}
+	for _, key := range []string{"a"} {
+		has, err := db.Has([]byte(key))
+		if err != nil || has {
+			t.Fatalf("Has(%s)=(%t,%v), want false,nil", key, has, err)
+		}
+	}
+	requireRawKVValue(t, db, []byte("b"), []byte("vb"))
+	requireRawKVValue(t, db, []byte("c"), []byte("vc"))
+	requireRawKVValue(t, db, []byte("z"), []byte("vz"))
+
+	if err := db.DeleteRange([]byte("z"), nil); err != nil {
+		t.Fatalf("DeleteRange z,nil: %v", err)
+	}
+	if got := publicCommandWALFrameCount(t, db); got != baseFrames+2 {
+		t.Fatalf("frames after upper-unbounded DeleteRange=%d, want %d", got, baseFrames+2)
+	}
+	has, err := db.Has([]byte("z"))
+	if err != nil || has {
+		t.Fatalf("Has(z)=(%t,%v), want false,nil", has, err)
+	}
+
+	first, last := db.publicCommandWALPendingRange()
+	if first == 0 || last != baseFrames+2 {
+		t.Fatalf("pending command WAL range=(%d,%d), want non-empty ending at %d", first, last, baseFrames+2)
+	}
+	if err := db.Checkpoint(); err != nil {
+		t.Fatalf("Checkpoint: %v", err)
+	}
+	if got := db.backend.State().AppliedCommandLSN; got != baseFrames+2 {
+		t.Fatalf("AppliedCommandLSN=%d, want %d", got, baseFrames+2)
+	}
+}
+
+func TestPublicCommandWALDeleteRangeFullRangeInMemoryCheckpoint(t *testing.T) {
+	db, err := Open(Options{
+		Dir:                          t.TempDir(),
+		Durability:                   DurabilityWALOnRelaxed,
+		CommandWAL:                   true,
+		CommandWALStatsScan:          true,
+		DisableSideStores:            true,
+		BackgroundCheckpointInterval: -1,
+	})
+	if err != nil {
+		t.Fatalf("Open command WAL: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	for _, kv := range []struct{ k, v string }{{"a", "va"}, {"b", "vb"}} {
+		if err := db.Set([]byte(kv.k), []byte(kv.v)); err != nil {
+			t.Fatalf("Set %s: %v", kv.k, err)
+		}
+	}
+	before := publicCommandWALFrameCount(t, db)
+	if err := db.DeleteRange(nil, nil); err != nil {
+		t.Fatalf("DeleteRange nil,nil: %v", err)
+	}
+	if got := publicCommandWALFrameCount(t, db); got != before+1 {
+		t.Fatalf("frames after full-range DeleteRange=%d, want %d", got, before+1)
+	}
+	for _, key := range []string{"a", "b"} {
+		has, err := db.Has([]byte(key))
+		if err != nil || has {
+			t.Fatalf("Has(%s)=(%t,%v), want false,nil after full range", key, has, err)
+		}
+	}
+	if err := db.Checkpoint(); err != nil {
+		t.Fatalf("Checkpoint: %v", err)
+	}
+	if got := db.backend.State().AppliedCommandLSN; got != before+1 {
+		t.Fatalf("AppliedCommandLSN=%d, want %d", got, before+1)
+	}
+}
+
+func TestPublicCommandWALDeleteRangeSnapshotIsolation(t *testing.T) {
+	db, err := Open(Options{
+		Dir:                          t.TempDir(),
+		Durability:                   DurabilityWALOnRelaxed,
+		CommandWAL:                   true,
+		CommandWALStatsScan:          true,
+		DisableSideStores:            true,
+		BackgroundCheckpointInterval: -1,
+	})
+	if err != nil {
+		t.Fatalf("Open command WAL: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	for _, kv := range []struct{ k, v string }{{"a", "va"}, {"b", "vb"}, {"c", "vc"}, {"d", "vd"}} {
+		if err := db.Set([]byte(kv.k), []byte(kv.v)); err != nil {
+			t.Fatalf("Set %s: %v", kv.k, err)
+		}
+	}
+	snap := db.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("AcquireSnapshot returned nil")
+	}
+	defer func() { _ = snap.Close() }()
+	if err := db.DeleteRange([]byte("b"), []byte("d")); err != nil {
+		t.Fatalf("DeleteRange: %v", err)
+	}
+	for _, key := range []string{"b", "c"} {
+		has, err := snap.Has([]byte(key))
+		if err != nil || !has {
+			t.Fatalf("snapshot Has(%s)=(%t,%v), want true,nil", key, has, err)
+		}
+		has, err = db.Has([]byte(key))
+		if err != nil || has {
+			t.Fatalf("db Has(%s)=(%t,%v), want false,nil after DeleteRange", key, has, err)
+		}
+	}
+	requireRawKVValue(t, db, []byte("a"), []byte("va"))
+	requireRawKVValue(t, db, []byte("d"), []byte("vd"))
+}
+
+func TestPublicCommandWALDeleteRangeValueLogPointersReopen(t *testing.T) {
+	dir := t.TempDir()
+	opts := Options{
+		Dir:                          dir,
+		Durability:                   DurabilityWALOnRelaxed,
+		CommandWAL:                   true,
+		CommandWALStatsScan:          true,
+		DisableSideStores:            true,
+		BackgroundCheckpointInterval: -1,
+	}
+	opts.ValueLog.PointerThreshold = 1
+	opts.ValueLog.ForcePointers = true
+	db, err := Open(opts)
+	if err != nil {
+		t.Fatalf("Open command WAL: %v", err)
+	}
+	for _, kv := range []struct{ k, v string }{{"a", "left-pointer-value"}, {"b", "deleted-pointer-value"}, {"c", "right-pointer-value"}} {
+		if err := db.Set([]byte(kv.k), []byte(kv.v)); err != nil {
+			_ = db.Close()
+			t.Fatalf("Set %s: %v", kv.k, err)
+		}
+	}
+	if err := db.DeleteRange([]byte("b"), []byte("c")); err != nil {
+		_ = db.Close()
+		t.Fatalf("DeleteRange: %v", err)
+	}
+	if err := db.Checkpoint(); err != nil {
+		_ = db.Close()
+		t.Fatalf("Checkpoint: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	reopen, err := Open(Options{Dir: dir, CommandWALStatsScan: true, DisableSideStores: true, BackgroundCheckpointInterval: -1})
+	if err != nil {
+		t.Fatalf("Reopen: %v", err)
+	}
+	defer reopen.Close()
+	requireRawKVValue(t, reopen, []byte("a"), []byte("left-pointer-value"))
+	requireRawKVValue(t, reopen, []byte("c"), []byte("right-pointer-value"))
+	has, err := reopen.Has([]byte("b"))
+	if err != nil || has {
+		t.Fatalf("Has(b)=(%t,%v), want false,nil", has, err)
 	}
 }
 

--- a/TreeDB/command_wal_public_test.go
+++ b/TreeDB/command_wal_public_test.go
@@ -1188,10 +1188,16 @@ func TestPublicCommandWALDeleteRangeReplaysUnappliedFrame(t *testing.T) {
 	if err != nil {
 		t.Fatalf("backend Open for manual command append: %v", err)
 	}
-	lsn, err := backend.AppendRawKVSingleCommandWAL(commitlog.RawKVOperation{Op: commitlog.RawKVOpDeleteRange, Key: []byte("b"), Value: []byte("d")}, true)
+	var payload commitlog.RawKVBatchPayloadBuilder
+	_ = payload.ResetWithHint(1, len("b")+len("d"))
+	if _, err := payload.AppendDeleteRange([]byte("b"), []byte("d")); err != nil {
+		_ = backend.Close()
+		t.Fatalf("AppendDeleteRange payload: %v", err)
+	}
+	lsn, err := backend.AppendRawKVBatchPayloadCommandWALTrusted(payload.Payload(), true)
 	if err != nil {
 		_ = backend.Close()
-		t.Fatalf("AppendRawKVSingleCommandWAL DeleteRange: %v", err)
+		t.Fatalf("AppendRawKVBatchPayloadCommandWALTrusted DeleteRange: %v", err)
 	}
 	if lsn <= baseApplied {
 		_ = backend.Close()

--- a/TreeDB/db/command_wal_raw.go
+++ b/TreeDB/db/command_wal_raw.go
@@ -761,6 +761,18 @@ func (db *DB) MarkCommandWALIntentRecoveryRequired(intent *CommandWALIntent) {
 	db.poisonCommandWALAfterPublicPostAppendFailure(intent)
 }
 
+// MarkCommandWALRecoveryRequired marks this open handle as requiring recovery
+// after a public command-WAL frame was appended but the caller could not prove
+// that the matching physical mutation became visible/publishable on this
+// handle. Reopen recovery may apply the frame, so further command appends and
+// AppliedCommandLSN publishes must fail closed.
+func (db *DB) MarkCommandWALRecoveryRequired() {
+	if db == nil || !db.commandWAL {
+		return
+	}
+	db.commandWALFlushPoisoned.Store(true)
+}
+
 func applyRawKVCommandWALFrame(db *DB, env commitlog.CommandEnvelope, ridMap map[uint64]page.ValuePtr, inlineAppender *replayInlineAppender, ensureReplayRIDMap commandWALReplayRIDMapFunc, ensureReplayLogSupport commandWALReplayLogSupportFunc) error {
 	if db == nil {
 		return fmt.Errorf("treedb: command wal recovery missing db")

--- a/TreeDB/public.go
+++ b/TreeDB/public.go
@@ -1619,7 +1619,21 @@ func (db *DB) DeleteRange(start, end []byte) error {
 		return err
 	}
 	if db.commandWALCached {
-		return ErrCommandWALRejected
+		if batch.IsDeleteRangeNoop(start, end) {
+			return nil
+		}
+		appended := false
+		err := db.cached.DeleteRangeAfterCommandWALAppend(start, end, func() error {
+			if err := db.appendPublicRawKVDeleteRangeCommand(start, end, false); err != nil {
+				return err
+			}
+			appended = true
+			return nil
+		})
+		if err != nil && appended && db.backend != nil {
+			db.backend.MarkCommandWALRecoveryRequired()
+		}
+		return err
 	}
 	if db.cached != nil {
 		return db.cached.DeleteRange(start, end)


### PR DESCRIPTION
## Summary

Closes #2328. Part of #2284.

- Enables public cached command-WAL `TreeDB.DB.DeleteRange(start, end)` instead of rejecting it with `ErrCommandWALRejected`.
- Appends one logical raw-KV `RawKVOpDeleteRange` command frame before the cached range delete becomes visible.
- Adds `caching.DB.DeleteRangeAfterCommandWALAppend`, analogous to point Set/Delete hooks, and routes command-WAL range deletes through the writer-serialized cached path.
- Preserves no-op range behavior: empty/reversed bounded ranges and `[nil, empty)` return without appending a command frame.
- Keeps nil range bounds as unbounded and does not change #2331 point-key/nil-value behavior.
- Avoids backend-direct physical DeleteRange fast paths while a command-WAL append hook is active so AppliedCommandLSN coverage is only published after the matching cached physical state is checkpointed.

## Scope / non-goals

- Raw TreeDB public DB-level DeleteRange only.
- No geth/Nitro adapter plumbing.
- No raw point-key/nil-value parity changes beyond preserving existing #2331 behavior.
- No value-log format changes; persistent value-log pointer semantics are preserved.

## Tests

Latest local head: `8040f9f0e9321bcd1d6132337c380d6a83c6d822`.

- `go test ./TreeDB -run 'PublicCommandWAL.*DeleteRange|DeleteRange.*CommandWAL' -count=1`
- `go test ./TreeDB/caching -run 'DeleteRangeAfterCommandWALAppend|DeleteRange' -count=1`
- `go test ./TreeDB ./TreeDB/db ./TreeDB/caching -run 'CommandWAL|DeleteRange|Reopen' -count=1`
- `go test ./TreeDB ./TreeDB/db ./TreeDB/caching -count=1`
- `git diff --check`

Coverage added includes public append success, append failure/no mutation at caching hook, no-op no-frame ranges, nil lower/upper bounds, checkpoint AppliedCommandLSN publication, reopen/replay, full-range DeleteRange, snapshot isolation, and pointer-backed value-log values retained/deleted across reopen.

## Performance evidence

Point/batch command-WAL regression guard:

```sh
go test ./TreeDB -run '^$' \
  -bench '^BenchmarkPublicCommandWALRawKV(Set|BatchWrite)$' \
  -benchmem -benchtime=100x -count=3
benchstat /tmp/2328_base_public_command_wal_point_batch_bench.txt /tmp/2328_public_command_wal_point_batch_bench.txt
```

Result summary: no statistically significant point/batch regression signal in the local noisy n=3 run; geomean `allocs/op` +0.09%, `B/op` -5.07%, `sec/op` noisy/improved. Artifacts: `/tmp/2328_base_public_command_wal_point_batch_bench.txt`, `/tmp/2328_public_command_wal_point_batch_bench.txt`, `/tmp/2328_point_batch_benchstat.txt`.

DeleteRange smoke comparison (100 ranges x width 100, load/checkpoint excluded from timed delete phase):

| Scenario | range ops/sec | affected keys/sec |
|---|---:|---:|
| public DB DeleteRange, command WAL | 52,675 | 5.27M |
| public batch DeleteRange workaround, command WAL | 10,188 | 1.02M |
| public DB DeleteRange, non-command WAL-off | 17,009 | 1.70M |

Command: `go run /tmp/treedb_2328_delete_range_perf.go`; artifact: `/tmp/2328_delete_range_perf_after_serialized_fix.txt`.

## Review / CI status

- Internal high-thinking review completed: no blockers after removing the command-WAL full-range/backend-direct fast path; no remaining nits or missing material evidence beyond standard CI.
- Codex review passed on the first pushed head. CodeRabbit comments were addressed where valid (callback contract docs, replay test payload format) and the backend-empty fast-path suggestion was rejected with correctness rationale.
- Latest-head CI is green at `8040f9f0edebf55235a28c4c1d74e722c3c1475b` (25 successful checks; mergeState CLEAN).
- Copilot was requested but did not produce a visible review/comment in this repo session.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of delete range operations with enhanced error handling and recovery mechanisms.
  * Better isolation and correctness guarantees for delete operations in cached database mode.

* **Tests**
  * Added comprehensive test coverage for delete range operations across various scenarios including error conditions, edge cases, and recovery procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


