### PR TITLE
TreeDB vector API: define no-document collection search contract

### DIFF
--- a/TreeDB/README.md
+++ b/TreeDB/README.md
@@ -194,15 +194,17 @@ scripts/bench_vector_search_compare.sh
 The script downloads and extracts a USearch Linux or macOS release package into
 `/tmp` when `USEARCH_ROOT` is not set, configures cgo include/library paths, and
 writes results under `/tmp/gomap_vector_search_compare_*`. The canonical current
-production rows are
-`BenchmarkCollectionVectorUSearchProductionCompare/TreeDB_SearchWithBuffer*`
-versus `.../USearch_Search*`: TreeDB uses persisted `column_graph` through
-`Collection.OpenVectorIndexSearcher` plus `VectorIndexSearcher.SearchWithBuffer`
-with one searcher and one reusable buffer per worker, while USearch is a pure
-in-memory cosine/f32 HNSW baseline. Use `CPU_LIST=1,8` for c=1/c=8 evidence.
-Older `BenchmarkCollectionVectorIndex*` rows are historical controls, not the
-current high-QPS production fast path; one-shot `Collection.SearchVectorIndex`
-benchmarks include setup/open cost and should not be presented as that fast path.
+production rows include
+`BenchmarkCollectionVectorUSearchProductionCompare/TreeDB_CollectionSearchVectorIndexNoDocsOneShot`
+as the current collection-level one-shot baseline, plus
+`.../TreeDB_SearchWithBuffer*` versus `.../USearch_Search*`: TreeDB's high-QPS
+comparison uses persisted `column_graph` through `Collection.OpenVectorIndexSearcher`
+plus `VectorIndexSearcher.SearchWithBuffer` with one searcher and one reusable
+buffer per worker, while USearch is a pure in-memory cosine/f32 HNSW baseline.
+Use `CPU_LIST=1,8` for c=1/c=8 evidence. Older `BenchmarkCollectionVectorIndex*`
+rows are historical controls, not the current high-QPS production fast path;
+one-shot `Collection.SearchVectorIndex` benchmarks include setup/open cost and
+should not be presented as that fast path.
 Override `USEARCH_VERSION`, `USEARCH_ROOT`, `TREEDB_VECTOR_BENCH_DOCS`,
 `TREEDB_VECTOR_BENCH_DIMS`, `TREEDB_VECTOR_BENCH_M`,
 `TREEDB_VECTOR_BENCH_EF_CONSTRUCTION`, `TREEDB_VECTOR_BENCH_EF_SEARCH`,

--- a/TreeDB/collections/vector_index.go
+++ b/TreeDB/collections/vector_index.go
@@ -167,14 +167,25 @@ const (
 	VectorIndexQueryModeQuantizedRerank VectorIndexQueryMode = "quantized_rerank"
 )
 
-// VectorIndexSearchOptions configures one in-memory vector index search.
+// VectorIndexSearchOptions configures one vector index search.
+//
+// Collection-level high-QPS no-document searches are intentionally narrow: use
+// an explicit column_graph index, exact/zero QueryMode, IncludeDocuments=false,
+// no document projection, and no legacy filter fields. The current
+// Collection.SearchVectorIndex method is a response-owned one-shot convenience
+// boundary that opens a searcher per call; callers that need steady-state
+// high-QPS behavior should use a reusable VectorIndexSearcher and, for the
+// zero-allocation no-document path, VectorIndexSearcher.SearchWithBuffer until
+// a collection-level buffered route is added.
 type VectorIndexSearchOptions struct {
 	// IndexName is used by collection-level physical column_graph search.
 	IndexName string
 	// Query is used by collection-level physical column_graph search.
 	Query []float32
 	// QueryMode selects exact, quantized-only, or quantized-rerank search for
-	// collection column_graph APIs. The zero value is exact.
+	// collection column_graph APIs. The zero value is exact. Only exact/zero mode
+	// is in the collection-level no-document high-QPS contract; quantized modes are
+	// explicit score-plane paths with their own fail-closed semantics.
 	QueryMode VectorIndexQueryMode
 	// QuantizedIndexName selects the named derived score plane for quantized modes.
 	QuantizedIndexName string

--- a/TreeDB/collections/vector_index_search.go
+++ b/TreeDB/collections/vector_index_search.go
@@ -710,6 +710,14 @@ func (r vectorIndexSearchRouteStats) apply(stats *VectorIndexSearchStats) {
 // rather than silently falling back or pretending to use column storage. When
 // availability or staleness checks fail, the returned response may still carry
 // the index status so callers can distinguish rebuild-needed/unavailable cases.
+//
+// With IncludeDocuments=false, SearchVectorIndex returns response-owned result
+// IDs and scores only and must not materialize documents. With
+// IncludeDocuments=true, document fetch happens after top-k selection and is
+// reported through document counters. This method currently opens and closes a
+// searcher per call, so its no-document benchmarks are one-shot/convenience
+// baselines rather than the high-QPS target; compare route/open counters before
+// treating it as a serving hot path.
 func (c *Collection) SearchVectorIndex(opts VectorIndexSearchOptions) (VectorIndexSearchResponse, error) {
 	if err := validateVectorIndexSearchRequest(opts.TopK, opts.EfSearch); err != nil {
 		return VectorIndexSearchResponse{}, err
@@ -748,7 +756,8 @@ func (c *Collection) SearchVectorIndex(opts VectorIndexSearchOptions) (VectorInd
 // OpenVectorIndexSearcher opens a reusable search handle for steady-state
 // vector queries. Setup/open/decode cost is paid at open; Search then measures
 // graph traversal, vector scoring, top-k production, and optional post-top-k
-// document fetch.
+// document fetch. For the current exact no-document high-QPS contract, pair a
+// reusable searcher with SearchWithBuffer and a warmed caller-owned buffer.
 func (c *Collection) OpenVectorIndexSearcher(opts VectorIndexSearcherOptions) (*VectorIndexSearcher, error) {
 	searcher, _, err := c.openVectorIndexSearcher(opts)
 	return searcher, err
@@ -1028,6 +1037,12 @@ func (s *VectorIndexSearcher) Search(opts VectorIndexSearcherSearchOptions) (Vec
 // concurrently; parallel callers should use independent searcher/buffer pairs
 // per worker. IncludeDocuments is not supported by this reusable no-document
 // path.
+//
+// The high-QPS public contract for this path is exact/zero QueryMode with no
+// document projection and no document materialization. Healthy current-format
+// evidence should show hnsw_search_pack_v1 active and selected, zero document
+// fetches, zero graph-row fallback, zero typed-column vector fallback, and zero
+// vector scratch decodes.
 //
 // On any error after a non-nil buffer is supplied, the buffer's reusable
 // result/id views are reset to length zero and the returned response has no

--- a/TreeDB/collections/vector_index_search_test.go
+++ b/TreeDB/collections/vector_index_search_test.go
@@ -561,9 +561,7 @@ func assertSearchVectorIndexNoDocumentCurrentOneShotStats2361(tb testing.TB, sta
 		stats.DocumentJSONReconstructionRows != 0 {
 		tb.Fatalf("no-doc stats=%+v want zero document materialization counters", stats)
 	}
-	if stats.SearchRouteColumnGraphPrepared != 1 || stats.SearchRouteHNSWSearchPack != 0 || stats.SearchRouteColumnGraphFallback != 0 {
-		tb.Fatalf("no-doc stats=%+v want current Collection.SearchVectorIndex one-shot column_graph route, not high-QPS pack route", stats)
-	}
+	assertSearchVectorIndexCurrentOneShotRoute2361(tb, "no-doc", stats)
 	if stats.HNSWSearchPackActive != 1 || stats.HNSWSearchPackOpenNanos == 0 {
 		tb.Fatalf("no-doc stats=%+v want hnsw_search_pack_v1 active/open evidence available for future high-QPS route", stats)
 	}
@@ -581,10 +579,18 @@ func assertSearchVectorIndexIncludeDocumentsStats2361(tb testing.TB, stats Vecto
 		stats.DocumentPointRowDecodes != uint64(results) {
 		tb.Fatalf("with-docs stats=%+v want vector-index row-ref state point fetches", stats)
 	}
-	if stats.SearchRouteColumnGraphPrepared != 1 || stats.SearchRouteHNSWSearchPack != 0 || stats.SearchRouteColumnGraphFallback != 0 {
-		tb.Fatalf("with-docs stats=%+v want document materialization outside high-QPS pack route", stats)
-	}
+	assertSearchVectorIndexCurrentOneShotRoute2361(tb, "with-docs", stats)
 	assertVectorIndexSearchNoFallbackStats2361(tb, stats)
+}
+
+func assertSearchVectorIndexCurrentOneShotRoute2361(tb testing.TB, label string, stats VectorIndexSearchStats) {
+	tb.Helper()
+	if stats.SearchRouteHNSWSearchPack != 0 {
+		tb.Fatalf("%s stats=%+v want current Collection.SearchVectorIndex one-shot route, not high-QPS pack route", label, stats)
+	}
+	if stats.SearchRouteColumnGraphPrepared+stats.SearchRouteColumnGraphFallback != 1 {
+		tb.Fatalf("%s stats=%+v want exactly one current Collection.SearchVectorIndex one-shot column_graph route", label, stats)
+	}
 }
 
 func assertVectorIndexSearchNoFallbackStats2361(tb testing.TB, stats VectorIndexSearchStats) {

--- a/TreeDB/collections/vector_index_search_test.go
+++ b/TreeDB/collections/vector_index_search_test.go
@@ -445,6 +445,163 @@ func TestSearchVectorIndexColumnGraphNativeReaderReopenV4(t *testing.T) {
 	}
 }
 
+func TestSearchVectorIndexNoDocumentHighQPSContractBoundary2361(t *testing.T) {
+	rows := []columnGraphRebuildInputRowV2A{
+		{id: "doc-a", vector: []float32{1, 0, 0}},
+		{id: "doc-b", vector: []float32{0.9, 0.1, 0}},
+		{id: "doc-c", vector: []float32{0, 1, 0}},
+		{id: "doc-d", vector: []float32{0, 0, 1}},
+	}
+	_, d, col, def := openColumnGraphRebuildTestCollectionV2A(t, 3, 3, rows)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+
+	query := []float32{1, 0, 0}
+	base := VectorIndexSearchOptions{
+		IndexName:        def.Name,
+		Query:            query,
+		QueryMode:        VectorIndexQueryModeExact,
+		TopK:             2,
+		EfSearch:         len(rows),
+		MaxDecodedBlocks: 1,
+	}
+	noDocs, err := col.SearchVectorIndex(base)
+	if err != nil {
+		t.Fatalf("SearchVectorIndex no-doc: %v", err)
+	}
+	assertColumnGraphSearchResponseLoadedV4(t, noDocs, def.Name, 2)
+	assertVectorIndexSearchResultsV4(t, noDocs.Results, exactColumnGraphTopKForTest(t, rows, query, 2), false)
+	assertSearchVectorIndexNoDocumentCurrentOneShotStats2361(t, noDocs.Stats)
+	for i, result := range noDocs.Results {
+		if len(result.ID) == 0 || len(result.Document) != 0 {
+			t.Fatalf("no-doc result[%d]=%+v want ID/score only without document", i, result)
+		}
+	}
+
+	withDocsOpts := base
+	withDocsOpts.IncludeDocuments = true
+	withDocs, err := col.SearchVectorIndex(withDocsOpts)
+	if err != nil {
+		t.Fatalf("SearchVectorIndex IncludeDocuments: %v", err)
+	}
+	assertColumnGraphSearchResponseLoadedV4(t, withDocs, def.Name, 2)
+	assertVectorIndexSearchResultsV4(t, withDocs.Results, exactColumnGraphTopKForTest(t, rows, query, 2), true)
+	assertSearchVectorIndexIncludeDocumentsStats2361(t, withDocs.Stats, len(withDocs.Results))
+	for i, result := range withDocs.Results {
+		if len(result.ID) == 0 || len(result.Document) == 0 {
+			t.Fatalf("with-docs result[%d]=%+v want ID/score plus materialized document", i, result)
+		}
+		assertVectorIndexSearchDocumentDIDV4(t, result.Document, string(result.ID))
+	}
+}
+
+func TestVectorIndexSearcherSearchWithBufferHighQPSContractRejectsDocuments2361(t *testing.T) {
+	rows := []columnGraphRebuildInputRowV2A{
+		{id: "doc-a", vector: []float32{1, 0, 0}},
+		{id: "doc-b", vector: []float32{0, 1, 0}},
+	}
+	_, d, col, def := openColumnGraphRebuildTestCollectionV2A(t, 3, 1, rows)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	searcher, err := col.OpenVectorIndexSearcher(VectorIndexSearcherOptions{IndexName: def.Name, MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("OpenVectorIndexSearcher: %v", err)
+	}
+	defer func() { _ = searcher.Close() }()
+
+	var buffer VectorIndexSearchBuffer
+	valid, err := searcher.SearchWithBuffer(VectorIndexSearcherSearchOptions{
+		Query:     []float32{1, 0, 0},
+		QueryMode: VectorIndexQueryModeExact,
+		TopK:      1,
+		EfSearch:  len(rows),
+	}, &buffer)
+	if err != nil {
+		t.Fatalf("SearchWithBuffer no-doc: %v", err)
+	}
+	assertColumnGraphSearchResponseLoadedV4(t, valid, def.Name, 1)
+	if valid.Stats.SearchRouteHNSWSearchPack != 1 ||
+		valid.Stats.HNSWSearchPackActive != 1 ||
+		valid.Stats.DocumentsFetched != 0 ||
+		valid.Stats.GraphRowFallbacks != 0 ||
+		valid.Stats.TypedColumnFallbacks != 0 ||
+		valid.Stats.VectorScratchDecodes != 0 {
+		t.Fatalf("SearchWithBuffer stats=%+v want exact no-document hnsw_search_pack_v1 route without docs/fallback/decode", valid.Stats)
+	}
+	if len(valid.Results[0].Document) != 0 || len(buffer.results) != 1 || len(buffer.idBytes) == 0 {
+		t.Fatalf("SearchWithBuffer result=%+v bufferResults=%d idBytes=%d want no-doc buffered result", valid.Results[0], len(buffer.results), len(buffer.idBytes))
+	}
+
+	got, err := searcher.SearchWithBuffer(VectorIndexSearcherSearchOptions{
+		Query:            []float32{1, 0, 0},
+		TopK:             1,
+		EfSearch:         len(rows),
+		IncludeDocuments: true,
+	}, &buffer)
+	if err == nil || !strings.Contains(err.Error(), "IncludeDocuments") {
+		t.Fatalf("SearchWithBuffer IncludeDocuments err=%v want documented fail-closed no-document boundary", err)
+	}
+	if len(got.Results) != 0 || got.Stats.DocumentsFetched != 0 || len(buffer.results) != 0 || len(buffer.idBytes) != 0 {
+		t.Fatalf("IncludeDocuments error response=%+v bufferResults=%d idBytes=%d want no results/doc counters", got, len(buffer.results), len(buffer.idBytes))
+	}
+}
+
+func assertSearchVectorIndexNoDocumentCurrentOneShotStats2361(tb testing.TB, stats VectorIndexSearchStats) {
+	tb.Helper()
+	if stats.DocumentsFetched != 0 ||
+		stats.DocumentBytes != 0 ||
+		stats.DocumentOutputBytes != 0 ||
+		stats.DocumentRowRefStateFetches != 0 ||
+		stats.DocumentRowRefLookupFallbacks != 0 ||
+		stats.DocumentPointRowFetches != 0 ||
+		stats.DocumentJSONReconstructionRows != 0 {
+		tb.Fatalf("no-doc stats=%+v want zero document materialization counters", stats)
+	}
+	if stats.SearchRouteColumnGraphPrepared != 1 || stats.SearchRouteHNSWSearchPack != 0 || stats.SearchRouteColumnGraphFallback != 0 {
+		tb.Fatalf("no-doc stats=%+v want current Collection.SearchVectorIndex one-shot column_graph route, not high-QPS pack route", stats)
+	}
+	if stats.HNSWSearchPackActive != 1 || stats.HNSWSearchPackOpenNanos == 0 {
+		tb.Fatalf("no-doc stats=%+v want hnsw_search_pack_v1 active/open evidence available for future high-QPS route", stats)
+	}
+	assertVectorIndexSearchNoFallbackStats2361(tb, stats)
+}
+
+func assertSearchVectorIndexIncludeDocumentsStats2361(tb testing.TB, stats VectorIndexSearchStats, results int) {
+	tb.Helper()
+	if stats.DocumentsFetched != uint64(results) || stats.DocumentBytes == 0 || stats.DocumentOutputBytes == 0 {
+		tb.Fatalf("with-docs stats=%+v want document materialization counters for %d results", stats, results)
+	}
+	if stats.DocumentRowRefStateFetches != uint64(results) ||
+		stats.DocumentRowRefLookupFallbacks != 0 ||
+		stats.DocumentPointRowFetches != uint64(results) ||
+		stats.DocumentPointRowDecodes != uint64(results) {
+		tb.Fatalf("with-docs stats=%+v want vector-index row-ref state point fetches", stats)
+	}
+	if stats.SearchRouteColumnGraphPrepared != 1 || stats.SearchRouteHNSWSearchPack != 0 || stats.SearchRouteColumnGraphFallback != 0 {
+		tb.Fatalf("with-docs stats=%+v want document materialization outside high-QPS pack route", stats)
+	}
+	assertVectorIndexSearchNoFallbackStats2361(tb, stats)
+}
+
+func assertVectorIndexSearchNoFallbackStats2361(tb testing.TB, stats VectorIndexSearchStats) {
+	tb.Helper()
+	if stats.GraphRows != 0 ||
+		stats.GraphRowFallbacks != 0 ||
+		stats.TypedColumnFallbacks != 0 ||
+		stats.VectorScratchDecodes != 0 ||
+		stats.RowFetches != 0 ||
+		stats.BatchFetches != 0 ||
+		stats.RowsFetched != 0 ||
+		stats.ResultIDGraphFallbacks != 0 ||
+		stats.RowRefVectorSourceLegacyGraphIDs != 0 {
+		tb.Fatalf("stats=%+v want no graph-row fallback, no typed-column fallback, no vector scratch decode, and no legacy row/ID path", stats)
+	}
+}
+
 func TestSearchVectorIndexColumnGraphResultIDsAreCapacityIsolatedV4(t *testing.T) {
 	rows := []columnGraphRebuildInputRowV2A{
 		{id: "doc-a", vector: []float32{1, 0, 0}},

--- a/TreeDB/collections/vector_usearch_bench_test.go
+++ b/TreeDB/collections/vector_usearch_bench_test.go
@@ -232,6 +232,66 @@ func BenchmarkCollectionVectorUSearchProductionCompare(b *testing.B) {
 		reportVectorIndexSearchBenchMetricsV4(b, b.N, stats, false)
 	})
 
+	b.Run("TreeDB_CollectionSearchVectorIndexNoDocsOneShot", func(b *testing.B) {
+		timedOpts := VectorIndexSearchOptions{
+			IndexName:        def.Name,
+			Query:            queries[0],
+			QueryMode:        VectorIndexQueryModeExact,
+			TopK:             params.topK,
+			EfSearch:         params.efSearch,
+			MaxDecodedBlocks: 1,
+			StatsMode:        VectorIndexSearchStatsModeProduction,
+		}
+		warm, err := col.SearchVectorIndex(timedOpts)
+		if err != nil {
+			b.Fatalf("warm SearchVectorIndex: %v", err)
+		}
+		if len(warm.Results) == 0 {
+			b.Fatal("warm SearchVectorIndex returned no results")
+		}
+		top1Got, top1Want := string(warm.Results[0].ID), vectorUSearchProductionDocID(queryDocIndexes[0])
+		statsOpts := timedOpts
+		statsOpts.StatsMode = VectorIndexSearchStatsModeFullDiagnostics
+		measured, err := col.SearchVectorIndex(statsOpts)
+		if err != nil {
+			b.Fatalf("measure SearchVectorIndex stats: %v", err)
+		}
+		stats := measured.Stats
+		if stats.SearchRouteColumnGraphPrepared != 1 ||
+			stats.SearchRouteHNSWSearchPack != 0 ||
+			stats.HNSWSearchPackActive != 1 ||
+			stats.SearchRouteColumnGraphFallback != 0 ||
+			stats.TypedColumnFallbacks != 0 ||
+			stats.VectorScratchDecodes != 0 ||
+			stats.GraphRowFallbacks != 0 ||
+			stats.DocumentsFetched != 0 {
+			b.Fatalf("TreeDB collection one-shot stats=%+v want current no-document SearchVectorIndex baseline with docs/fallback/decode counters clear and pack available but not selected", stats)
+		}
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			timedOpts.Query = queries[i%len(queries)]
+			got, err := col.SearchVectorIndex(timedOpts)
+			if err != nil {
+				b.Fatalf("SearchVectorIndex: %v", err)
+			}
+			if len(got.Results) == 0 {
+				b.Fatal("SearchVectorIndex returned no results")
+			}
+			vectorSearchBenchSinkOrdinalV4 += got.Results[0].Ordinal
+		}
+		b.StopTimer()
+		reportVectorUSearchProductionTop1Metric(b, top1Got, top1Want)
+		reportVectorUSearchProductionCommonMetrics(b, docs, dims, params, len(queries))
+		reportVectorUSearchProductionTreeDBFootprintMetrics(b, status)
+		reportVectorIndexSearchStatsModeBenchMetric2126(b, params.statsMode())
+		b.ReportMetric(1, "reported_stats_mode_full_diagnostics")
+		b.ReportMetric(1, "collection_searchvectorindex_one_shot")
+		b.ReportMetric(1, "open_searcher_calls/op")
+		b.ReportMetric(1, "open_setup_in_timed_loop")
+		reportVectorIndexSearchBenchMetricsV4(b, b.N, stats, true)
+	})
+
 	b.Run("USearch_Search", func(b *testing.B) {
 		keys, _, err := index.Search(queries[0], uint(params.topK))
 		if err != nil {

--- a/TreeDB/collections/vector_usearch_bench_test.go
+++ b/TreeDB/collections/vector_usearch_bench_test.go
@@ -257,10 +257,9 @@ func BenchmarkCollectionVectorUSearchProductionCompare(b *testing.B) {
 			b.Fatalf("measure SearchVectorIndex stats: %v", err)
 		}
 		stats := measured.Stats
-		if stats.SearchRouteColumnGraphPrepared != 1 ||
+		if stats.SearchRouteColumnGraphPrepared+stats.SearchRouteColumnGraphFallback != 1 ||
 			stats.SearchRouteHNSWSearchPack != 0 ||
 			stats.HNSWSearchPackActive != 1 ||
-			stats.SearchRouteColumnGraphFallback != 0 ||
 			stats.TypedColumnFallbacks != 0 ||
 			stats.VectorScratchDecodes != 0 ||
 			stats.GraphRowFallbacks != 0 ||

--- a/TreeDB/docs/guides/vector-search-typed-column.md
+++ b/TreeDB/docs/guides/vector-search-typed-column.md
@@ -349,11 +349,19 @@ Use `scripts/bench_vector_search_compare.sh` for the optional external ANN
 baseline. Its current production comparison benchmark is
 `BenchmarkCollectionVectorUSearchProductionCompare`:
 
+- `TreeDB_CollectionSearchVectorIndexNoDocsOneShot` times today's public
+  collection-level no-document convenience API. It calls
+  `Collection.SearchVectorIndex` once per operation, so setup/open/validation,
+  response-owned result allocation, and close are inside the timed boundary. Use
+  this row as a baseline/guardrail only; it is not the high-QPS target.
 - `TreeDB_SearchWithBuffer` / `TreeDB_SearchWithBufferParallel` time persisted
   `column_graph` search through `Collection.OpenVectorIndexSearcher` and
   `VectorIndexSearcher.SearchWithBuffer`; setup, inserts, rebuild, open, and
   warmup are outside the timed loop. Parallel rows use one searcher and one
   `VectorIndexSearchBuffer` per worker.
+- A future collection-level buffered row should mirror the `SearchWithBuffer`
+  no-document contract: exact mode, caller-owned buffer, no documents/projection,
+  no per-search open/setup, and the healthy `hnsw_search_pack_v1` route.
 - `USearch_Search` / `USearch_SearchParallel` time the pure in-memory USearch Go
   binding with cosine/f32 HNSW.
 - Both sides use the same deterministic synthetic vector/query generator and the
@@ -373,9 +381,9 @@ TREEDB_VECTOR_BENCH_DOCS=10000 TREEDB_VECTOR_BENCH_DIMS=64 \
 
 Older `BenchmarkCollectionVectorIndex*` and graph-only rows remain useful
 historical controls, but they are not the current persisted production
-no-document fast path. One-shot `Collection.SearchVectorIndex` rows include
-setup/open cost per operation; do not use them as the high-QPS production
-comparator.
+no-document fast path. One-shot `Collection.SearchVectorIndex` rows, including
+`TreeDB_CollectionSearchVectorIndexNoDocsOneShot`, include setup/open cost per
+operation; do not use them as the high-QPS production comparator.
 
 The broader legacy/canonical matrix remains useful when comparing with older
 artifacts or when you also need one-shot open/setup names:

--- a/TreeDB/docs/spec/column-graph-native-vector-search.md
+++ b/TreeDB/docs/spec/column-graph-native-vector-search.md
@@ -106,6 +106,54 @@ Use `SearchVectorIndex` for one-shot calls. It opens and closes the native reade
 per call, so it measures setup/open cost in addition to graph search. Use
 `OpenVectorIndexSearcher` when benchmarking or serving steady-state query load.
 
+## Collection-level no-document high-QPS contract (#2361)
+
+This is the public contract downstream collection API work must preserve before
+claiming high-QPS vector search:
+
+- Query shape: explicit `column_graph` vector index, cosine metric, exact/zero
+  `QueryMode`, `IncludeDocuments=false`, no `DocumentFetchOptions`, and no
+  legacy filter/range-filter semantics in the high-QPS timed boundary.
+- Result shape: return IDs/ordinals/scores only. Result/document ID bytes may be
+  response-owned for convenience APIs or caller-buffer-owned for buffered APIs;
+  document JSON must not be materialized unless `IncludeDocuments=true` is set
+  on an API that supports document fetch.
+- Serving state: raw collection vectors remain authoritative. The
+  `hnsw_search_pack_v1` is derived vector-index serving state; it is healthy
+  evidence only when validated against the current vector-index identity.
+- Preferred high-QPS route: exact no-document search through a validated
+  vector-index-owned `hnsw_search_pack_v1`, with reusable open/prepared state and
+  caller-owned buffers where the API exposes them.
+- Current baseline boundary: `Collection.SearchVectorIndex` is still a one-shot
+  convenience API. It opens/closes per call and owns response result buffers, so
+  its no-document benchmark row is a baseline/regression guardrail, not proof of
+  high-QPS success.
+- Document boundary: `IncludeDocuments=true` is an explicit post-top-k fetch
+  path. It must report document counters (`docs_fetched/search`, output bytes,
+  row-ref/point-fetch counters as applicable) and remains outside the
+  zero-allocation no-document contract.
+- Unsupported high-QPS shapes: document fetch, projection, non-exact quantized
+  modes, stale/missing packs, unsupported metrics/strategies, and future filter
+  shapes must fail closed or run through clearly labeled non-high-QPS
+  convenience/fallback rows with counters.
+
+Healthy no-document fast-path evidence must include `ns/op`, `ops/sec`, `B/op`,
+`allocs/op`, and route/fallback counters proving:
+
+- `search_route_hnsw_search_pack/search=1` and
+  `hnsw_search_pack_active/search=1`;
+- `docs_fetched/search=0`;
+- `graph_row_fallbacks/search=0`;
+- `typed_column_vector_fallbacks/search=0`;
+- `vector_scratch_decodes/search=0`;
+- no per-search open/setup/validation/decode bottleneck in the timed boundary.
+
+The current one-shot baseline row should instead show the boundary explicitly,
+for example `open_searcher_calls/op=1`, `open_setup_in_timed_loop=1`,
+`search_route_column_graph_prepared/search=1`, and
+`search_route_hnsw_search_pack/search=0`, while still proving no documents or
+fallback/scratch decodes.
+
 ## Demo
 
 Run a synthetic close/reopen demo:

--- a/TreeDB/docs/spec/column-graph-native-vector-search.md
+++ b/TreeDB/docs/spec/column-graph-native-vector-search.md
@@ -150,9 +150,11 @@ Healthy no-document fast-path evidence must include `ns/op`, `ops/sec`, `B/op`,
 
 The current one-shot baseline row should instead show the boundary explicitly,
 for example `open_searcher_calls/op=1`, `open_setup_in_timed_loop=1`,
-`search_route_column_graph_prepared/search=1`, and
-`search_route_hnsw_search_pack/search=0`, while still proving no documents or
-fallback/scratch decodes.
+`search_route_hnsw_search_pack/search=0`, and the selected one-shot
+`column_graph` route (`search_route_column_graph_prepared/search=1` on direct
+prepared platforms, or `search_route_column_graph_fallback/search=1` when the
+platform/source state requires the existing non-pack route), while still proving
+no documents or graph-row/typed-vector fallback/scratch decodes.
 
 ## Demo
 

--- a/scripts/bench_vector_search_compare.sh
+++ b/scripts/bench_vector_search_compare.sh
@@ -165,6 +165,16 @@ cat >"$RUN_DIR/README.md" <<EOF
 
 Canonical current production comparison:
 
+- \`BenchmarkCollectionVectorUSearchProductionCompare/TreeDB_CollectionSearchVectorIndexNoDocsOneShot\`
+  times today's public collection-level no-document convenience API. It calls
+  \`Collection.SearchVectorIndex\` once per operation, so setup/open/validation,
+  response-owned result allocation, and close are inside the timed boundary.
+  This row is a baseline and guardrail for future collection-level high-QPS work,
+  not a success criterion. It should report \`docs_fetched/search=0\`, no
+  graph-row fallback, no typed-column vector fallback, no vector scratch decode,
+  \`search_route_column_graph_prepared/search=1\`,
+  \`search_route_hnsw_search_pack/search=0\`, pack availability/open evidence,
+  \`open_searcher_calls/op=1\`, and \`open_setup_in_timed_loop=1\`.
 - \`BenchmarkCollectionVectorUSearchProductionCompare/TreeDB_SearchWithBuffer\`
   and \`.../TreeDB_SearchWithBufferParallel\` time the persisted TreeDB
   no-document \`hnsw_search_pack_v1\` route through
@@ -189,6 +199,10 @@ Canonical current production comparison:
   \`graph_row_fallbacks/search\`, score-batch fallback reason flags,
   vector/adjacency source-state counters, and candidate/visited-edge byte
   counters used by the HNSW search-pack stack.
+- Future collection-level buffered rows should use the same exact no-document
+  contract as \`SearchWithBuffer\`: caller-owned buffer, no documents/projection,
+  no graph-row fallback, no vector scratch decode, no per-search open/setup, and
+  \`search_route_hnsw_search_pack/search=1\` on healthy packs.
 - \`.../USearch_Search\` and \`.../USearch_SearchParallel\` time the pure
   in-memory USearch Go binding baseline with cosine/f32 HNSW and the same
   synthetic vector/query generator, M, efConstruction, efSearch, topK, docs,
@@ -200,9 +214,8 @@ Legacy/control rows:
   vector-index controls. They are useful historical comparators but are not the
   current production no-document fast path.
 - \`BenchmarkCollectionVectorSearchExact\` is an exact scan control.
-- One-shot \`Collection.SearchVectorIndex\` benchmarks, when run separately, pay
-  setup/open costs per operation and should not be presented as the high-QPS
-  production fast path.
+- Other one-shot \`Collection.SearchVectorIndex\` benchmarks pay setup/open costs
+  per operation and should not be presented as the high-QPS production fast path.
 
 Data boundary: TreeDB stores generated float32 vectors through JSON collection
 inserts and rebuilds the persisted \`column_graph\` plus derived

--- a/scripts/bench_vector_search_compare.sh
+++ b/scripts/bench_vector_search_compare.sh
@@ -172,8 +172,9 @@ Canonical current production comparison:
   This row is a baseline and guardrail for future collection-level high-QPS work,
   not a success criterion. It should report \`docs_fetched/search=0\`, no
   graph-row fallback, no typed-column vector fallback, no vector scratch decode,
-  \`search_route_column_graph_prepared/search=1\`,
   \`search_route_hnsw_search_pack/search=0\`, pack availability/open evidence,
+  the selected one-shot \`column_graph\` route (prepared on direct-view
+  platforms, fallback on heap-copy/source-limited platforms),
   \`open_searcher_calls/op=1\`, and \`open_setup_in_timed_loop=1\`.
 - \`BenchmarkCollectionVectorUSearchProductionCompare/TreeDB_SearchWithBuffer\`
   and \`.../TreeDB_SearchWithBufferParallel\` time the persisted TreeDB


### PR DESCRIPTION
## Summary

Closes #2361. Parent tracker: #2360.

This PR defines and guards the public collection-level no-document vector-search contract before the follow-up high-QPS implementation PRs:

- documents the exact no-document contract for collection-level search: explicit `column_graph`, exact/zero `QueryMode`, `IncludeDocuments=false`, no projection/filter work in the timed high-QPS boundary, raw vectors authoritative, `hnsw_search_pack_v1` derived serving state;
- clarifies that current `Collection.SearchVectorIndex` is a one-shot convenience baseline that opens/closes per search and must not be used as high-QPS success evidence;
- adds guardrail tests for no-document `SearchVectorIndex`, explicit `IncludeDocuments=true` materialization, and `SearchWithBuffer` rejecting document materialization;
- adds `BenchmarkCollectionVectorUSearchProductionCompare/TreeDB_CollectionSearchVectorIndexNoDocsOneShot` with route/open counters so current collection one-shot, future collection buffered route, existing `SearchWithBuffer`, and USearch can be compared in one harness.

Non-goals honored: no prepared cache, no final collection-level buffered route, no graph tuning, no M/efSearch/insertion-order changes, no document materialization behavior change beyond tests/docs/benchmark reporting.

## Contract / row names

Contract snapshot for #2362+:

- Preferred high-QPS shape: exact no-document search (`QueryMode` zero/exact, `IncludeDocuments=false`) through a validated vector-index-owned `hnsw_search_pack_v1`.
- Healthy high-QPS evidence must show: `search_route_hnsw_search_pack/search=1`, `hnsw_search_pack_active/search=1`, `docs_fetched/search=0`, `graph_row_fallbacks/search=0`, `typed_column_vector_fallbacks/search=0`, `vector_scratch_decodes/search=0`, and no per-search open/setup in the timed boundary.
- `IncludeDocuments=true` remains an explicit post-top-k document-fetch path with document counters and is outside the zero-allocation no-document contract.
- Current baseline row added: `TreeDB_CollectionSearchVectorIndexNoDocsOneShot`.
- Existing rows preserved: `TreeDB_SearchWithBuffer`, `TreeDB_SearchWithBufferParallel`, `USearch_Search`, `USearch_SearchParallel`.
- Future buffered row should mirror `SearchWithBuffer` semantics with caller-owned `VectorIndexSearchBuffer` and no documents/projection.

## Tests

Hardware/context for local evidence: Apple M3, darwin/arm64, 16 GB RAM, Go `go1.25.5`.

- `GOWORK=off go test ./TreeDB/collections -run 'TestSearchVectorIndexNoDocumentHighQPSContractBoundary2361|TestVectorIndexSearcherSearchWithBufferHighQPSContractRejectsDocuments2361|TestSearchVectorIndexColumnGraphNativeReaderReopenV4|TestSearchVectorIndexColumnGraphMaterializesDocumentsAfterTopKV4|TestVectorIndexSearcherSearchWithBufferErrorResetsBuffer1961' -count=1`
  - PASS, artifact: `/tmp/gomap_2361_close_20260604_215449/focused_tests.txt`
- `GOWORK=off go test ./TreeDB/collections -count=1`
  - PASS, artifact: `/tmp/gomap_2361_close_20260604_215449/collections_tests.txt`
- Build-tag smoke for new production compare row:
  - `RUN_DIR=/tmp/gomap_2361_row_smoke2_20260604_215834 USEARCH_ROOT=/tmp/usearch_2.25.2_macos_arm64/root BENCH_REGEX='^BenchmarkCollectionVectorUSearchProductionCompare$' TREEDB_VECTOR_BENCH_DOCS=1000 TREEDB_VECTOR_BENCH_DIMS=32 TREEDB_VECTOR_BENCH_M=16 TREEDB_VECTOR_BENCH_EF_CONSTRUCTION=128 TREEDB_VECTOR_BENCH_EF_SEARCH=64 TREEDB_VECTOR_BENCH_TOPK=10 TREEDB_VECTOR_BENCH_QUERIES=4 CPU_LIST=1 BENCHTIME=1x COUNT=1 scripts/bench_vector_search_compare.sh`
  - PASS, artifact: `/tmp/gomap_2361_row_smoke2_20260604_215834/bench.txt`
- Recovery current-head validation after the Windows one-shot route assertion fix (`3292e0ebab2c8abde5d2341d71259fe3eb3f01e1`):
  - `GOWORK=off go test ./TreeDB/collections -run 'TestSearchVectorIndexNoDocumentHighQPSContractBoundary2361|TestVectorIndexSearcherSearchWithBufferHighQPSContractRejectsDocuments2361|TestSearchVectorIndexColumnGraphNativeReaderReopenV4|TestSearchVectorIndexColumnGraphMaterializesDocumentsAfterTopKV4|TestVectorIndexSearcherSearchWithBufferErrorResetsBuffer1961' -count=1`
    - PASS, artifact: `/tmp/gomap_2368_final_local_20260604_222354/focused_tests.txt`
  - `GOWORK=off go test ./TreeDB/collections -count=1`
    - PASS, artifact: `/tmp/gomap_2368_final_local_20260604_222354/collections_tests.txt`
  - Build-tag row smoke with `COUNT=1 BENCHTIME=1x` and `TREEDB_VECTOR_BENCH_DOCS=1000 TREEDB_VECTOR_BENCH_DIMS=32`
    - PASS, artifact: `/tmp/gomap_2368_final_local_20260604_222354/row_smoke/bench.txt`

## Benchmark evidence

Start-phase baseline commit: `414abebb92363a7319fb740bdc192fdcf92fd044` on branch `snissn/2361-manager` before changes.  
Close-phase full benchmark matrix commit: `8e23031a4935b809ca9932f1ed388a4f9938869f`.
Recovery/current head after the Windows route-assertion follow-up: `3292e0ebab2c8abde5d2341d71259fe3eb3f01e1` (test/docs/benchmark guard only; no production hot-path code changed after the full matrix).

Primary artifact dirs:

- Start: `/tmp/gomap_2361_start_20260604_214525/`
- Close: `/tmp/gomap_2361_close_20260604_215449/`
- Parsed summary: `/tmp/gomap_2361_close_20260604_215449/summary_tables.md`
- Current API benchstat: `/tmp/gomap_2361_close_20260604_215449/current_api_benchstat.txt`
- Tier S benchstat: `/tmp/gomap_2361_close_20260604_215449/tier_s_production_compare/benchstat_start_vs_close.txt`
- Profiles: `/tmp/gomap_2361_{start,close}_*/current_api_{cpu,mem}.pprof` plus `*_top.txt`

### Current one-shot vs reusable allocation baseline

Command used identically before/after:

```sh
GOMAXPROCS=8 GOWORK=off go test ./TreeDB/collections -run '^$' \
  -bench '^(BenchmarkSearchVectorIndexColumnGraphNativeReaderV4|BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderReusableBufferV4)$' \
  -benchmem -benchtime=1000x -count=3 \
  -cpuprofile "$OUT/current_api_cpu.pprof" -memprofile "$OUT/current_api_mem.pprof"
```

Median summary:

| Row | Start | Close | Route/counters |
| --- | ---: | ---: | --- |
| `BenchmarkSearchVectorIndexColumnGraphNativeReaderV4-8` | 1.435 ms, 697 ops/sec, 1,819,441 B/op, 2,273 allocs/op | 1.484 ms, 674 ops/sec, 1,803,530 B/op, 2,273 allocs/op | docs=0, pack active=1, pack route=0, column_graph prepared=1, graph/typed/scratch fallbacks=0 |
| `BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderReusableBufferV4-8` | 11.545 µs, 86,616 ops/sec, 0 B/op, 0 allocs/op | 11.225 µs, 89,089 ops/sec, 0 B/op, 0 allocs/op | docs=0, pack route=1, pack active=1, graph/typed/scratch fallbacks=0 |

### Tier S production compare

Command used identically before/after; close adds the new row:

```sh
RUN_DIR=$OUT/tier_s_production_compare USEARCH_ROOT=/tmp/usearch_2.25.2_macos_arm64/root \
  BENCH_REGEX='^BenchmarkCollectionVectorUSearchProductionCompare$' \
  TREEDB_VECTOR_BENCH_DOCS=10000 TREEDB_VECTOR_BENCH_DIMS=64 \
  TREEDB_VECTOR_BENCH_M=16 TREEDB_VECTOR_BENCH_EF_CONSTRUCTION=128 \
  TREEDB_VECTOR_BENCH_EF_SEARCH=128 TREEDB_VECTOR_BENCH_TOPK=10 \
  TREEDB_VECTOR_BENCH_QUERIES=16 CPU_LIST=1,8 BENCHTIME=1000x COUNT=3 \
  scripts/bench_vector_search_compare.sh
```

Close median highlights (`docs=0`, `graph_row_fallbacks=0`, `typed_column_vector_fallbacks=0`, `vector_scratch_decodes=0` for all TreeDB rows):

| Row | c | ns/op | ops/sec | B/op | allocs/op | Route/open |
| --- | ---: | ---: | ---: | ---: | ---: | --- |
| `TreeDB_CollectionSearchVectorIndexNoDocsOneShot` | 1 | 8.618 ms | 116 | 14,575,325 | 5,381 | pack active=1, pack route=0, column_graph prepared=1, `open_searcher_calls/op=1` |
| `TreeDB_SearchWithBuffer` | 1 | 45.125 µs | 22,161 | 0 | 0 | pack route=1, pack active=1 |
| `USearch_Search` | 1 | 33.585 µs | 29,775 | 136 | 3 | external in-memory baseline |
| `TreeDB_CollectionSearchVectorIndexNoDocsOneShot` | 8 | 11.594 ms | 86 | 14,671,595 | 5,384 | pack active=1, pack route=0, column_graph prepared=1, `open_searcher_calls/op=1` |
| `TreeDB_SearchWithBufferParallel` | 8 | 10.335 µs | 96,763 | 4 | 0 | pack route=1, pack active=1 |
| `USearch_SearchParallel` | 8 | 9.300 µs | 107,521 | 138 | 3 | external in-memory baseline |

Performance status: no production hot-path code was changed. Existing benchmark rows are statistically noisy with `count=3` but show no accepted material regression; route/fallback/doc counters are unchanged and clear. The new one-shot row intentionally exposes current collection API setup/open and allocation cost and must not be cited as high-QPS success.

## Review notes

- No on-disk format changes.
- No graph construction/tuning changes.
- AI reviews should be requested only after CI is running/green on this mature head.

