### PR TITLE
TreeDB vector API: add collection buffered search seam

### DIFF
--- a/TreeDB/README.md
+++ b/TreeDB/README.md
@@ -168,9 +168,10 @@ The initial API lives in `TreeDB/collections`:
 Native `column_graph` benchmark tiers are documented in
 `docs/guides/vector-search-typed-column.md#vector-search-benchmark-tiers`.
 Use that matrix to distinguish core graph search, existing public response-owned
-`Search`, reusable-buffer no-document `SearchWithBuffer`, parallel callers, and
-explicit document-fetch paths. Report `ops/sec` (`1e9 / ns/op`) with `ns/op`,
-`B/op`, `allocs/op`, and vector/adjacency direct-vs-scratch counters.
+`Search`, collection-level caller-buffered `SearchVectorIndexWithBuffer`,
+reusable-buffer no-document `SearchWithBuffer`, parallel callers, and explicit
+document-fetch paths. Report `ops/sec` (`1e9 / ns/op`) with `ns/op`, `B/op`,
+`allocs/op`, and vector/adjacency direct-vs-scratch counters.
 
 Smoke benchmark:
 
@@ -196,11 +197,14 @@ The script downloads and extracts a USearch Linux or macOS release package into
 writes results under `/tmp/gomap_vector_search_compare_*`. The canonical current
 production rows include
 `BenchmarkCollectionVectorUSearchProductionCompare/TreeDB_CollectionSearchVectorIndexNoDocsOneShot`
-as the current collection-level one-shot baseline, plus
-`.../TreeDB_SearchWithBuffer*` versus `.../USearch_Search*`: TreeDB's high-QPS
-comparison uses persisted `column_graph` through `Collection.OpenVectorIndexSearcher`
-plus `VectorIndexSearcher.SearchWithBuffer` with one searcher and one reusable
-buffer per worker, while USearch is a pure in-memory cosine/f32 HNSW baseline.
+as the current collection-level one-shot baseline,
+`.../TreeDB_CollectionSearchVectorIndexWithBuffer` as the collection-level
+caller-owned result-buffer seam with per-call open still inside the timed
+boundary, plus `.../TreeDB_SearchWithBuffer*` versus `.../USearch_Search*`:
+TreeDB's high-QPS comparison uses persisted `column_graph` through
+`Collection.OpenVectorIndexSearcher` plus `VectorIndexSearcher.SearchWithBuffer`
+with one searcher and one reusable buffer per worker, while USearch is a pure
+in-memory cosine/f32 HNSW baseline.
 Use `CPU_LIST=1,8` for c=1/c=8 evidence. Older `BenchmarkCollectionVectorIndex*`
 rows are historical controls, not the current high-QPS production fast path;
 one-shot `Collection.SearchVectorIndex` benchmarks include setup/open cost and

--- a/TreeDB/collections/vector_index.go
+++ b/TreeDB/collections/vector_index.go
@@ -173,10 +173,11 @@ const (
 // an explicit column_graph index, exact/zero QueryMode, IncludeDocuments=false,
 // no document projection, and no legacy filter fields. The current
 // Collection.SearchVectorIndex method is a response-owned one-shot convenience
-// boundary that opens a searcher per call; callers that need steady-state
-// high-QPS behavior should use a reusable VectorIndexSearcher and, for the
-// zero-allocation no-document path, VectorIndexSearcher.SearchWithBuffer until
-// a collection-level buffered route is added.
+// boundary that opens a searcher per call. Collection.SearchVectorIndexWithBuffer
+// exposes caller-owned result storage for the exact no-document hnsw_search_pack_v1
+// seam but still opens per call until collection-owned prepared caching lands;
+// callers that need zero-allocation steady-state behavior should use a reusable
+// VectorIndexSearcher with VectorIndexSearcher.SearchWithBuffer.
 type VectorIndexSearchOptions struct {
 	// IndexName is used by collection-level physical column_graph search.
 	IndexName string

--- a/TreeDB/collections/vector_index_search.go
+++ b/TreeDB/collections/vector_index_search.go
@@ -524,20 +524,22 @@ type VectorIndexSearchResponse struct {
 	// Stats contains search and reader telemetry.
 	Stats VectorIndexSearchStats `json:"stats,omitempty"`
 	// Results contains top-k hits in descending score order. Search and
-	// SearchVectorIndex return response-owned slices; SearchWithBuffer returns a
-	// slice owned by the caller's VectorIndexSearchBuffer.
+	// SearchVectorIndex return response-owned slices; SearchWithBuffer and
+	// SearchVectorIndexWithBuffer return slices owned by the caller's
+	// VectorIndexSearchBuffer.
 	Results []VectorIndexSearchResult `json:"results,omitempty"`
 }
 
 // VectorIndexSearchBuffer is caller-owned reusable response storage for
-// VectorIndexSearcher.SearchWithBuffer. It is intended for steady-state
-// no-document searches that need to avoid per-call response allocation. Reuse a
-// warmed buffer to keep result-ID searches allocation-free.
+// VectorIndexSearcher.SearchWithBuffer and Collection.SearchVectorIndexWithBuffer.
+// It is intended for steady-state no-document searches that need to avoid
+// per-call response allocation. Reuse a warmed buffer to keep result-ID searches
+// allocation-free once open/prepared state is outside the measured boundary.
 //
 // A VectorIndexSearchBuffer is not safe for concurrent use. Do not reuse or
 // reset the same buffer while any caller still needs a response previously
 // returned from it. The response Results slice and each result ID returned by
-// SearchWithBuffer alias this buffer and remain valid only until the same
+// buffered search APIs alias this buffer and remain valid only until the same
 // buffer is reused or Reset is called. Parallel callers should use independent
 // searcher/buffer pairs per worker.
 type VectorIndexSearchBuffer struct {
@@ -546,7 +548,7 @@ type VectorIndexSearchBuffer struct {
 }
 
 // Reset clears the buffer's current response view while retaining reusable
-// capacity. Any response previously returned by SearchWithBuffer with this
+// capacity. Any response previously returned by a buffered search API with this
 // buffer must be considered invalid after Reset returns.
 func (b *VectorIndexSearchBuffer) Reset() {
 	if b == nil {
@@ -717,7 +719,10 @@ func (r vectorIndexSearchRouteStats) apply(stats *VectorIndexSearchStats) {
 // reported through document counters. This method currently opens and closes a
 // searcher per call, so its no-document benchmarks are one-shot/convenience
 // baselines rather than the high-QPS target; compare route/open counters before
-// treating it as a serving hot path.
+// treating it as a serving hot path. Use SearchVectorIndexWithBuffer for the
+// collection-level caller-owned result-buffer seam, and OpenVectorIndexSearcher
+// plus SearchWithBuffer when callers can keep open/prepared state outside the
+// timed query boundary.
 func (c *Collection) SearchVectorIndex(opts VectorIndexSearchOptions) (VectorIndexSearchResponse, error) {
 	if err := validateVectorIndexSearchRequest(opts.TopK, opts.EfSearch); err != nil {
 		return VectorIndexSearchResponse{}, err
@@ -751,6 +756,138 @@ func (c *Collection) SearchVectorIndex(opts VectorIndexSearchOptions) (VectorInd
 		response.Stats.DocumentAssetActiveHandles = counters.activeHandles
 	}
 	return response, err
+}
+
+// SearchVectorIndexWithBuffer searches a collection vector index through the
+// exact no-document high-QPS seam using caller-owned result storage. Returned
+// Results and result IDs alias buffer and remain valid only until buffer is
+// reused or Reset is called. The same buffer must not be reused concurrently;
+// parallel callers should use independent buffers.
+//
+// This method intentionally fails closed for document materialization,
+// projections, filters, quantized modes, benchmark-debug stats mode, missing or
+// invalid hnsw_search_pack_v1 state, and legacy/fallback routes. It currently
+// opens and closes a VectorIndexSearcher per call; that open/prepare allocation
+// and validation cost is still inside this collection-level seam until a
+// collection-owned prepared cache is introduced. Callers that already manage
+// reusable open state should prefer OpenVectorIndexSearcher plus
+// VectorIndexSearcher.SearchWithBuffer for the zero-allocation steady-state hot
+// path.
+func (c *Collection) SearchVectorIndexWithBuffer(opts VectorIndexSearchOptions, buffer *VectorIndexSearchBuffer) (VectorIndexSearchResponse, error) {
+	if err := validateCollectionVectorIndexSearchWithBufferOptions(opts, buffer); err != nil {
+		return VectorIndexSearchResponse{}, err
+	}
+	searcher, response, err := c.openVectorIndexSearcher(VectorIndexSearcherOptions{
+		IndexName:        opts.IndexName,
+		MaxDecodedBlocks: opts.MaxDecodedBlocks,
+	})
+	if err != nil {
+		buffer.Reset()
+		return response, err
+	}
+	statsMode, err := columnVectorGraphNativeSearchStatsModeFromPublic(opts.StatsMode)
+	if err != nil {
+		buffer.Reset()
+		_ = searcher.Close()
+		return response, err
+	}
+	queryMode, err := normalizeVectorIndexSearchQueryMode(opts.QueryMode, opts.QuantizedIndexName, opts.QuantizedRerankCandidates, opts.TopK)
+	if err != nil {
+		buffer.Reset()
+		_ = searcher.Close()
+		return response, err
+	}
+	if _, routeStats, usePackRoute := searcher.hnswSearchPackSearchWithBufferRoute(queryMode, statsMode); !usePackRoute {
+		buffer.Reset()
+		response.Stats = VectorIndexSearchStats{}
+		routeStats.apply(&response.Stats)
+		_ = searcher.Close()
+		return response, fmt.Errorf("%w: vector index %q SearchVectorIndexWithBuffer requires exact no-document hnsw_search_pack_v1 route", ErrVectorIndexSearchUnavailable, opts.IndexName)
+	}
+	response, err = searcher.SearchWithBuffer(VectorIndexSearcherSearchOptions{
+		Query:          opts.Query,
+		QueryMode:      opts.QueryMode,
+		TopK:           opts.TopK,
+		EfSearch:       opts.EfSearch,
+		StatsMode:      opts.StatsMode,
+		scoreBatchMode: opts.scoreBatchMode,
+	}, buffer)
+	if closeErr := searcher.Close(); err == nil && closeErr != nil {
+		buffer.Reset()
+		return response, closeErr
+	}
+	if err != nil {
+		return response, err
+	}
+	if !vectorIndexSearchStatsAreBufferedNoDocumentPackRoute(response.Stats) {
+		buffer.Reset()
+		response.Results = nil
+		return response, fmt.Errorf("%w: vector index %q SearchVectorIndexWithBuffer requires exact no-document hnsw_search_pack_v1 route", ErrVectorIndexSearchUnavailable, opts.IndexName)
+	}
+	return response, nil
+}
+
+func validateCollectionVectorIndexSearchWithBufferOptions(opts VectorIndexSearchOptions, buffer *VectorIndexSearchBuffer) error {
+	if buffer == nil {
+		return errors.New("collections: nil vector index search buffer")
+	}
+	if err := validateVectorIndexSearchRequest(opts.TopK, opts.EfSearch); err != nil {
+		buffer.Reset()
+		return err
+	}
+	if opts.IncludeDocuments {
+		buffer.Reset()
+		return errors.New("collections: vector index SearchVectorIndexWithBuffer does not support IncludeDocuments")
+	}
+	if vectorIndexDocumentFetchOptionsNonZero(opts.DocumentFetchOptions) {
+		buffer.Reset()
+		return errors.New("collections: vector index SearchVectorIndexWithBuffer does not support DocumentFetchOptions")
+	}
+	if opts.Filter != nil || opts.IndexRangeFilter != nil {
+		buffer.Reset()
+		return errors.New("collections: vector index SearchVectorIndexWithBuffer does not support filters")
+	}
+	if opts.FetchMultiplier != 0 || opts.ExactFilterMaxDocs != 0 || opts.DisableExactFallback {
+		buffer.Reset()
+		return errors.New("collections: vector index SearchVectorIndexWithBuffer does not support legacy fallback/filter controls")
+	}
+	if opts.QueryMode != "" && opts.QueryMode != VectorIndexQueryModeExact {
+		buffer.Reset()
+		return fmt.Errorf("collections: vector index SearchVectorIndexWithBuffer supports only exact query mode, got %q", opts.QueryMode)
+	}
+	if opts.QuantizedIndexName != "" || opts.QuantizedRerankCandidates != 0 {
+		buffer.Reset()
+		return errors.New("collections: vector index SearchVectorIndexWithBuffer does not support quantized search options")
+	}
+	if opts.StatsMode == VectorIndexSearchStatsModeBenchmarkDebug {
+		buffer.Reset()
+		return errors.New("collections: vector index SearchVectorIndexWithBuffer does not support benchmark_debug stats mode")
+	}
+	if _, err := columnVectorGraphNativeSearchStatsModeFromPublic(opts.StatsMode); err != nil {
+		buffer.Reset()
+		return err
+	}
+	return nil
+}
+
+func vectorIndexDocumentFetchOptionsNonZero(opts DocumentFetchOptions) bool {
+	return documentFetchOptionsHasProjection(opts) || opts.Format != "" || opts.ColumnAssetReadIntegrity != ""
+}
+
+func vectorIndexSearchStatsAreBufferedNoDocumentPackRoute(stats VectorIndexSearchStats) bool {
+	return stats.SearchRouteHNSWSearchPack == 1 &&
+		stats.HNSWSearchPackActive == 1 &&
+		stats.HNSWSearchPackMissing == 0 &&
+		stats.HNSWSearchPackInvalid == 0 &&
+		stats.HNSWSearchPackStale == 0 &&
+		stats.HNSWSearchPackClosed == 0 &&
+		stats.HNSWSearchPackFallbacks == 0 &&
+		stats.SearchRouteColumnGraphPrepared == 0 &&
+		stats.SearchRouteColumnGraphFallback == 0 &&
+		stats.DocumentsFetched == 0 &&
+		stats.GraphRowFallbacks == 0 &&
+		stats.TypedColumnFallbacks == 0 &&
+		stats.VectorScratchDecodes == 0
 }
 
 // OpenVectorIndexSearcher opens a reusable search handle for steady-state

--- a/TreeDB/collections/vector_index_search.go
+++ b/TreeDB/collections/vector_index_search.go
@@ -813,15 +813,14 @@ func (c *Collection) SearchVectorIndexWithBuffer(opts VectorIndexSearchOptions, 
 		scoreBatchMode: opts.scoreBatchMode,
 	}, buffer)
 	if closeErr := searcher.Close(); err == nil && closeErr != nil {
-		buffer.Reset()
+		resetBufferedVectorIndexSearchResponse(&response, buffer)
 		return response, closeErr
 	}
 	if err != nil {
 		return response, err
 	}
 	if !vectorIndexSearchStatsAreBufferedNoDocumentPackRoute(response.Stats) {
-		buffer.Reset()
-		response.Results = nil
+		resetBufferedVectorIndexSearchResponse(&response, buffer)
 		return response, fmt.Errorf("%w: vector index %q SearchVectorIndexWithBuffer requires exact no-document hnsw_search_pack_v1 route", ErrVectorIndexSearchUnavailable, opts.IndexName)
 	}
 	return response, nil
@@ -868,6 +867,15 @@ func validateCollectionVectorIndexSearchWithBufferOptions(opts VectorIndexSearch
 		return err
 	}
 	return nil
+}
+
+func resetBufferedVectorIndexSearchResponse(response *VectorIndexSearchResponse, buffer *VectorIndexSearchBuffer) {
+	if buffer != nil {
+		buffer.Reset()
+	}
+	if response != nil {
+		response.Results = nil
+	}
 }
 
 func vectorIndexDocumentFetchOptionsNonZero(opts DocumentFetchOptions) bool {

--- a/TreeDB/collections/vector_index_search_test.go
+++ b/TreeDB/collections/vector_index_search_test.go
@@ -849,6 +849,22 @@ func TestSearchVectorIndexWithBufferUnsupportedShapesFailClosed2362(t *testing.T
 	}
 }
 
+func TestResetBufferedVectorIndexSearchResponseClearsReturnedResults2362(t *testing.T) {
+	var buffer VectorIndexSearchBuffer
+	buffer.results = append(buffer.results, VectorIndexSearchResult{ID: []byte("stale"), Score: 1})
+	buffer.idBytes = append(buffer.idBytes, "stale"...)
+	response := VectorIndexSearchResponse{Results: buffer.results}
+
+	resetBufferedVectorIndexSearchResponse(&response, &buffer)
+
+	if response.Results != nil {
+		t.Fatalf("response results=%v want nil after buffered error invalidation", response.Results)
+	}
+	if len(buffer.results) != 0 || len(buffer.idBytes) != 0 {
+		t.Fatalf("buffer results=%d idBytes=%d want reset view", len(buffer.results), len(buffer.idBytes))
+	}
+}
+
 func assertSearchVectorIndexWithBufferNoDocumentPackStats2362(tb testing.TB, stats VectorIndexSearchStats) {
 	tb.Helper()
 	if !vectorIndexSearchStatsAreBufferedNoDocumentPackRoute(stats) {

--- a/TreeDB/collections/vector_index_search_test.go
+++ b/TreeDB/collections/vector_index_search_test.go
@@ -550,6 +550,315 @@ func TestVectorIndexSearcherSearchWithBufferHighQPSContractRejectsDocuments2361(
 	}
 }
 
+func TestSearchVectorIndexWithBufferMatchesSearcherSearchWithBuffer2362(t *testing.T) {
+	rows := []columnGraphRebuildInputRowV2A{
+		{id: "doc-a", vector: []float32{1, 0, 0}},
+		{id: "doc-b", vector: []float32{0.9, 0.1, 0}},
+		{id: "doc-c", vector: []float32{0, 1, 0}},
+		{id: "doc-d", vector: []float32{0, 0, 1}},
+		{id: "doc-e", vector: []float32{0.4, 0.6, 0}},
+	}
+	_, d, col, def := openColumnGraphRebuildTestCollectionV2A(t, 3, 3, rows)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	searcher, err := col.OpenVectorIndexSearcher(VectorIndexSearcherOptions{IndexName: def.Name, MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("OpenVectorIndexSearcher: %v", err)
+	}
+	defer func() { _ = searcher.Close() }()
+
+	query := []float32{0.6, 0.4, 0}
+	searcherOpts := VectorIndexSearcherSearchOptions{Query: query, TopK: 3, EfSearch: len(rows), StatsMode: VectorIndexSearchStatsModeFullDiagnostics}
+	var searcherBuffer VectorIndexSearchBuffer
+	want, err := searcher.SearchWithBuffer(searcherOpts, &searcherBuffer)
+	if err != nil {
+		t.Fatalf("SearchWithBuffer: %v", err)
+	}
+	assertColumnGraphSearchResponseLoadedV4(t, want, def.Name, searcherOpts.TopK)
+
+	collectionOpts := VectorIndexSearchOptions{IndexName: def.Name, Query: query, QueryMode: VectorIndexQueryModeExact, TopK: searcherOpts.TopK, EfSearch: searcherOpts.EfSearch, MaxDecodedBlocks: 1, StatsMode: searcherOpts.StatsMode}
+	var collectionBuffer VectorIndexSearchBuffer
+	got, err := col.SearchVectorIndexWithBuffer(collectionOpts, &collectionBuffer)
+	if err != nil {
+		t.Fatalf("SearchVectorIndexWithBuffer: %v", err)
+	}
+	assertColumnGraphSearchResponseLoadedV4(t, got, def.Name, collectionOpts.TopK)
+	assertVectorIndexSearchResponsesEquivalentNoDocs2124(t, got, want)
+	assertSearchVectorIndexWithBufferNoDocumentPackStats2362(t, got.Stats)
+	if len(collectionBuffer.results) != len(got.Results) || len(collectionBuffer.idBytes) == 0 {
+		t.Fatalf("buffer results=%d idBytes=%d want populated caller-owned result storage", len(collectionBuffer.results), len(collectionBuffer.idBytes))
+	}
+	if len(got.Results) == 0 || &got.Results[0] != &collectionBuffer.results[0] {
+		t.Fatalf("response results do not alias caller-owned result buffer")
+	}
+	if len(got.Results[0].ID) == 0 || &got.Results[0].ID[0] != &collectionBuffer.idBytes[0] {
+		t.Fatalf("response IDs do not alias caller-owned ID byte buffer")
+	}
+	for i, result := range got.Results {
+		if len(result.Document) != 0 || cap(result.ID) != len(result.ID) {
+			t.Fatalf("result[%d]=%+v id len/cap=%d/%d want no documents and cap-isolated ID bytes", i, result, len(result.ID), cap(result.ID))
+		}
+	}
+}
+
+func TestSearchVectorIndexWithBufferReuseGrowShrinkNoStaleIDs2362(t *testing.T) {
+	rows := []columnGraphRebuildInputRowV2A{
+		{id: "doc-long-a", vector: []float32{1, 0, 0}},
+		{id: "b", vector: []float32{0, 1, 0}},
+		{id: "cc", vector: []float32{0, 0, 1}},
+		{id: "dddd", vector: []float32{0.7, 0.3, 0}},
+	}
+	_, d, col, def := openColumnGraphRebuildTestCollectionV2A(t, 3, 3, rows)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+
+	var buffer VectorIndexSearchBuffer
+	growOpts := VectorIndexSearchOptions{IndexName: def.Name, Query: []float32{1, 0, 0}, TopK: 3, EfSearch: len(rows), MaxDecodedBlocks: 1}
+	for i := 0; i < 3; i++ {
+		got, err := col.SearchVectorIndexWithBuffer(growOpts, &buffer)
+		if err != nil {
+			t.Fatalf("SearchVectorIndexWithBuffer grow iteration %d: %v", i, err)
+		}
+		assertColumnGraphSearchResponseLoadedV4(t, got, def.Name, 3)
+		assertVectorIndexSearchResultsV4(t, got.Results, exactColumnGraphTopKForTest(t, rows, growOpts.Query, growOpts.TopK), false)
+		assertSearchVectorIndexWithBufferNoDocumentPackStats2362(t, got.Stats)
+		for j, result := range got.Results {
+			if cap(result.ID) != len(result.ID) {
+				t.Fatalf("grow iteration %d result[%d] id len/cap=%d/%d want cap isolated", i, j, len(result.ID), cap(result.ID))
+			}
+		}
+	}
+
+	if len(buffer.results) != 3 {
+		t.Fatalf("test setup buffer results=%d want 3 before shrink", len(buffer.results))
+	}
+	buffer.results[1].Document = []byte("stale-document")
+	buffer.results[2].Score = 99
+
+	shrinkOpts := VectorIndexSearchOptions{IndexName: def.Name, Query: []float32{0, 1, 0}, TopK: 1, EfSearch: len(rows), MaxDecodedBlocks: 1}
+	shrunk, err := col.SearchVectorIndexWithBuffer(shrinkOpts, &buffer)
+	if err != nil {
+		t.Fatalf("SearchVectorIndexWithBuffer shrink: %v", err)
+	}
+	assertColumnGraphSearchResponseLoadedV4(t, shrunk, def.Name, 1)
+	assertVectorIndexSearchResultsV4(t, shrunk.Results, exactColumnGraphTopKForTest(t, rows, shrinkOpts.Query, shrinkOpts.TopK), false)
+	assertSearchVectorIndexWithBufferNoDocumentPackStats2362(t, shrunk.Stats)
+	if gotID := string(shrunk.Results[0].ID); gotID != "b" {
+		t.Fatalf("shrunk top id=%q want b without stale bytes from longer prior IDs", gotID)
+	}
+	if cap(shrunk.Results[0].ID) != len(shrunk.Results[0].ID) {
+		t.Fatalf("shrunk id len/cap=%d/%d want cap isolated", len(shrunk.Results[0].ID), cap(shrunk.Results[0].ID))
+	}
+	allResults := buffer.results[:cap(buffer.results)]
+	for i := len(buffer.results); i < 3 && i < len(allResults); i++ {
+		if allResults[i].ID != nil || allResults[i].Ordinal != 0 || allResults[i].Score != 0 || allResults[i].Document != nil {
+			t.Fatalf("shrunk stale tail result[%d]=%+v want cleared", i, allResults[i])
+		}
+	}
+
+	regrown, err := col.SearchVectorIndexWithBuffer(growOpts, &buffer)
+	if err != nil {
+		t.Fatalf("SearchVectorIndexWithBuffer regrow: %v", err)
+	}
+	assertColumnGraphSearchResponseLoadedV4(t, regrown, def.Name, 3)
+	assertVectorIndexSearchResultsV4(t, regrown.Results, exactColumnGraphTopKForTest(t, rows, growOpts.Query, growOpts.TopK), false)
+}
+
+func TestSearchVectorIndexWithBufferOpenScopedAllocationContract2362(t *testing.T) {
+	rows := []columnGraphRebuildInputRowV2A{
+		{id: "doc-a", vector: []float32{1, 0, 0}},
+		{id: "doc-b", vector: []float32{0, 1, 0}},
+		{id: "doc-c", vector: []float32{0, 0, 1}},
+		{id: "doc-d", vector: []float32{0.7, 0.3, 0}},
+		{id: "doc-e", vector: []float32{0.4, 0.6, 0}},
+	}
+	_, d, col, def := openColumnGraphRebuildTestCollectionV2A(t, 3, 3, rows)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	opts := VectorIndexSearchOptions{IndexName: def.Name, Query: []float32{0.6, 0.4, 0}, QueryMode: VectorIndexQueryModeExact, TopK: 3, EfSearch: len(rows), MaxDecodedBlocks: 1, StatsMode: VectorIndexSearchStatsModeProduction}
+
+	var buffer VectorIndexSearchBuffer
+	warm, err := col.SearchVectorIndexWithBuffer(opts, &buffer)
+	if err != nil {
+		t.Fatalf("warm SearchVectorIndexWithBuffer: %v", err)
+	}
+	assertColumnGraphSearchResponseLoadedV4(t, warm, def.Name, opts.TopK)
+	assertSearchVectorIndexWithBufferNoDocumentPackStats2362(t, warm.Stats)
+	resultCap, idCap := cap(buffer.results), cap(buffer.idBytes)
+	if resultCap < opts.TopK || idCap == 0 {
+		t.Fatalf("warm buffer caps results=%d idBytes=%d want reusable capacity", resultCap, idCap)
+	}
+
+	var sink int
+	bufferedAllocs := testing.AllocsPerRun(100, func() {
+		got, err := col.SearchVectorIndexWithBuffer(opts, &buffer)
+		if err != nil {
+			panic(err)
+		}
+		if len(got.Results) != opts.TopK {
+			panic("unexpected SearchVectorIndexWithBuffer result count")
+		}
+		if cap(buffer.results) != resultCap || cap(buffer.idBytes) != idCap {
+			panic("SearchVectorIndexWithBuffer grew caller buffer after warmup")
+		}
+		sink += len(got.Results) + got.Results[0].Ordinal
+	})
+	ownedAllocs := testing.AllocsPerRun(100, func() {
+		got, err := col.SearchVectorIndex(opts)
+		if err != nil {
+			panic(err)
+		}
+		if len(got.Results) != opts.TopK {
+			panic("unexpected SearchVectorIndex result count")
+		}
+		sink += len(got.Results) + got.Results[0].Ordinal
+	})
+	if sink == 0 {
+		t.Fatal("allocation check did not consume results")
+	}
+	if bufferedAllocs >= ownedAllocs {
+		t.Fatalf("SearchVectorIndexWithBuffer allocs=%v want below response-owned SearchVectorIndex allocs=%v; remaining allocations are per-call open/prepare work for #2363", bufferedAllocs, ownedAllocs)
+	}
+}
+
+func TestSearchVectorIndexWithBufferParallelIndependentBuffers2362(t *testing.T) {
+	rows := []columnGraphRebuildInputRowV2A{
+		{id: "doc-a", vector: []float32{1, 0, 0}},
+		{id: "doc-b", vector: []float32{0, 1, 0}},
+		{id: "doc-c", vector: []float32{0, 0, 1}},
+		{id: "doc-d", vector: []float32{0.7, 0.3, 0}},
+	}
+	_, d, col, def := openColumnGraphRebuildTestCollectionV2A(t, 3, 3, rows)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	query := []float32{1, 0, 0}
+	topK := 2
+	want := exactColumnGraphTopKForTest(t, rows, query, topK)
+	const workers = 4
+	const iterations = 10
+	var wg sync.WaitGroup
+	errs := make(chan string, workers)
+	for worker := 0; worker < workers; worker++ {
+		wg.Add(1)
+		go func(worker int) {
+			defer wg.Done()
+			var buffer VectorIndexSearchBuffer
+			opts := VectorIndexSearchOptions{IndexName: def.Name, Query: query, TopK: topK, EfSearch: len(rows), MaxDecodedBlocks: 1}
+			for i := 0; i < iterations; i++ {
+				got, err := col.SearchVectorIndexWithBuffer(opts, &buffer)
+				if err != nil {
+					errs <- fmt.Sprintf("worker %d iteration %d SearchVectorIndexWithBuffer: %v", worker, i, err)
+					return
+				}
+				if len(got.Results) != len(want) {
+					errs <- fmt.Sprintf("worker %d iteration %d results=%d want %d", worker, i, len(got.Results), len(want))
+					return
+				}
+				if !vectorIndexSearchStatsAreBufferedNoDocumentPackRoute(got.Stats) {
+					errs <- fmt.Sprintf("worker %d iteration %d stats=%+v want hnsw_search_pack_v1 no-document route", worker, i, got.Stats)
+					return
+				}
+				for j := range want {
+					if !bytes.Equal(got.Results[j].ID, want[j].ID) || math.Abs(got.Results[j].Score-want[j].Score) > 1e-6 {
+						errs <- fmt.Sprintf("worker %d iteration %d result[%d]=%+v want id=%q score=%v", worker, i, j, got.Results[j], want[j].ID, want[j].Score)
+						return
+					}
+				}
+			}
+		}(worker)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Error(err)
+	}
+}
+
+func TestSearchVectorIndexWithBufferUnsupportedShapesFailClosed2362(t *testing.T) {
+	rows := []columnGraphRebuildInputRowV2A{
+		{id: "doc-a", vector: []float32{1, 0, 0}},
+		{id: "doc-b", vector: []float32{0, 1, 0}},
+	}
+	_, d, col, def := openColumnGraphRebuildTestCollectionV2A(t, 3, 1, rows)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	base := VectorIndexSearchOptions{IndexName: def.Name, Query: []float32{1, 0, 0}, TopK: 1, EfSearch: len(rows), MaxDecodedBlocks: 1}
+	var buffer VectorIndexSearchBuffer
+	valid, err := col.SearchVectorIndexWithBuffer(base, &buffer)
+	if err != nil {
+		t.Fatalf("valid SearchVectorIndexWithBuffer: %v", err)
+	}
+	assertColumnGraphSearchResponseLoadedV4(t, valid, def.Name, 1)
+	if len(buffer.results) == 0 || len(buffer.idBytes) == 0 {
+		t.Fatalf("test setup buffer results=%d idBytes=%d want populated before unsupported cases", len(buffer.results), len(buffer.idBytes))
+	}
+
+	if _, err := col.SearchVectorIndexWithBuffer(base, nil); err == nil || !strings.Contains(err.Error(), "nil vector index search buffer") {
+		t.Fatalf("nil buffer err=%v want fail closed", err)
+	}
+
+	tests := []struct {
+		name    string
+		mutate  func(*VectorIndexSearchOptions)
+		wantErr string
+	}{
+		{name: "include_documents", mutate: func(opts *VectorIndexSearchOptions) { opts.IncludeDocuments = true }, wantErr: "IncludeDocuments"},
+		{name: "document_projection", mutate: func(opts *VectorIndexSearchOptions) { opts.DocumentFetchOptions.IncludePaths = []string{"did"} }, wantErr: "DocumentFetchOptions"},
+		{name: "document_integrity_option", mutate: func(opts *VectorIndexSearchOptions) {
+			opts.DocumentFetchOptions.ColumnAssetReadIntegrity = ColumnAssetReadIntegritySkipChecksums
+		}, wantErr: "DocumentFetchOptions"},
+		{name: "filter", mutate: func(opts *VectorIndexSearchOptions) {
+			opts.Filter = func(DocumentRecord) (bool, error) { return true, nil }
+		}, wantErr: "filters"},
+		{name: "range_filter", mutate: func(opts *VectorIndexSearchOptions) {
+			opts.IndexRangeFilter = &VectorIndexRangeFilter{IndexName: "kind"}
+		}, wantErr: "filters"},
+		{name: "quantized_mode", mutate: func(opts *VectorIndexSearchOptions) {
+			opts.QueryMode = VectorIndexQueryModeQuantizedOnly
+			opts.QuantizedIndexName = "embedding.scalar_u8.fast"
+		}, wantErr: "only exact"},
+		{name: "quantized_option", mutate: func(opts *VectorIndexSearchOptions) { opts.QuantizedIndexName = "embedding.scalar_u8.fast" }, wantErr: "quantized"},
+		{name: "legacy_controls", mutate: func(opts *VectorIndexSearchOptions) { opts.FetchMultiplier = 2 }, wantErr: "legacy"},
+		{name: "benchmark_debug", mutate: func(opts *VectorIndexSearchOptions) { opts.StatsMode = VectorIndexSearchStatsModeBenchmarkDebug }, wantErr: "benchmark_debug"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := base
+			tt.mutate(&opts)
+			got, err := col.SearchVectorIndexWithBuffer(opts, &buffer)
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("SearchVectorIndexWithBuffer err=%v want substring %q", err, tt.wantErr)
+			}
+			if len(got.Results) != 0 || len(buffer.results) != 0 || len(buffer.idBytes) != 0 {
+				t.Fatalf("unsupported shape left results: returned=%d bufferResults=%d idBytes=%d", len(got.Results), len(buffer.results), len(buffer.idBytes))
+			}
+			if _, err := col.SearchVectorIndexWithBuffer(base, &buffer); err != nil {
+				t.Fatalf("valid SearchVectorIndexWithBuffer after %s: %v", tt.name, err)
+			}
+		})
+	}
+}
+
+func assertSearchVectorIndexWithBufferNoDocumentPackStats2362(tb testing.TB, stats VectorIndexSearchStats) {
+	tb.Helper()
+	if !vectorIndexSearchStatsAreBufferedNoDocumentPackRoute(stats) {
+		tb.Fatalf("SearchVectorIndexWithBuffer stats=%+v want exact no-document hnsw_search_pack_v1 route", stats)
+	}
+	if stats.DocumentBytes != 0 || stats.DocumentOutputBytes != 0 || stats.DocumentRowRefStateFetches != 0 || stats.DocumentRowRefLookupFallbacks != 0 || stats.DocumentPointRowFetches != 0 || stats.DocumentJSONReconstructionRows != 0 {
+		tb.Fatalf("SearchVectorIndexWithBuffer document stats=%+v want no materialization", stats)
+	}
+}
+
 func assertSearchVectorIndexNoDocumentCurrentOneShotStats2361(tb testing.TB, stats VectorIndexSearchStats) {
 	tb.Helper()
 	if stats.DocumentsFetched != 0 ||

--- a/TreeDB/collections/vector_usearch_bench_test.go
+++ b/TreeDB/collections/vector_usearch_bench_test.go
@@ -232,6 +232,68 @@ func BenchmarkCollectionVectorUSearchProductionCompare(b *testing.B) {
 		reportVectorIndexSearchBenchMetricsV4(b, b.N, stats, false)
 	})
 
+	b.Run("TreeDB_CollectionSearchVectorIndexWithBuffer", func(b *testing.B) {
+		timedOpts := VectorIndexSearchOptions{
+			IndexName:        def.Name,
+			Query:            queries[0],
+			QueryMode:        VectorIndexQueryModeExact,
+			TopK:             params.topK,
+			EfSearch:         params.efSearch,
+			MaxDecodedBlocks: 1,
+			StatsMode:        VectorIndexSearchStatsModeProduction,
+		}
+		var buffer VectorIndexSearchBuffer
+		warm, err := col.SearchVectorIndexWithBuffer(timedOpts, &buffer)
+		if err != nil {
+			b.Fatalf("warm SearchVectorIndexWithBuffer: %v", err)
+		}
+		if len(warm.Results) == 0 {
+			b.Fatal("warm SearchVectorIndexWithBuffer returned no results")
+		}
+		top1Got, top1Want := string(warm.Results[0].ID), vectorUSearchProductionDocID(queryDocIndexes[0])
+		statsOpts := timedOpts
+		statsOpts.StatsMode = VectorIndexSearchStatsModeFullDiagnostics
+		measured, err := col.SearchVectorIndexWithBuffer(statsOpts, &buffer)
+		if err != nil {
+			b.Fatalf("measure SearchVectorIndexWithBuffer stats: %v", err)
+		}
+		stats := measured.Stats
+		if stats.SearchRouteHNSWSearchPack != 1 ||
+			stats.HNSWSearchPackActive != 1 ||
+			stats.HNSWSearchPackFallbacks != 0 ||
+			stats.SearchRouteColumnGraphPrepared+stats.SearchRouteColumnGraphFallback != 0 ||
+			stats.TypedColumnFallbacks != 0 ||
+			stats.VectorScratchDecodes != 0 ||
+			stats.GraphRowFallbacks != 0 ||
+			stats.DocumentsFetched != 0 {
+			b.Fatalf("TreeDB collection buffered stats=%+v want exact no-document hnsw_search_pack_v1 route", stats)
+		}
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			timedOpts.Query = queries[i%len(queries)]
+			got, err := col.SearchVectorIndexWithBuffer(timedOpts, &buffer)
+			if err != nil {
+				b.Fatalf("SearchVectorIndexWithBuffer: %v", err)
+			}
+			if len(got.Results) == 0 {
+				b.Fatal("SearchVectorIndexWithBuffer returned no results")
+			}
+			vectorSearchBenchSinkOrdinalV4 += got.Results[0].Ordinal
+		}
+		b.StopTimer()
+		reportVectorUSearchProductionTop1Metric(b, top1Got, top1Want)
+		reportVectorUSearchProductionCommonMetrics(b, docs, dims, params, len(queries))
+		reportVectorUSearchProductionTreeDBFootprintMetrics(b, status)
+		reportVectorIndexSearchStatsModeBenchMetric2126(b, params.statsMode())
+		b.ReportMetric(1, "reported_stats_mode_full_diagnostics")
+		b.ReportMetric(1, "collection_searchvectorindex_with_buffer_seam")
+		b.ReportMetric(1, "open_searcher_calls/op")
+		b.ReportMetric(1, "open_setup_in_timed_loop")
+		b.ReportMetric(0, "response_owned_result_alloc/op")
+		reportVectorIndexSearchBenchMetricsV4(b, b.N, stats, true)
+	})
+
 	b.Run("TreeDB_CollectionSearchVectorIndexNoDocsOneShot", func(b *testing.B) {
 		timedOpts := VectorIndexSearchOptions{
 			IndexName:        def.Name,

--- a/TreeDB/docs/guides/vector-search-typed-column.md
+++ b/TreeDB/docs/guides/vector-search-typed-column.md
@@ -299,11 +299,12 @@ once prepared CSR adjacency is active.
 | `BenchmarkVectorSearchReusableBufferParallelTypedColumn1961` | `BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderReusableBufferParallelV4` | Reusable-buffer path with one independent searcher and buffer per worker. |
 
 Use the reusable-buffer tier only for no-document callers that can honor the
-buffer lifetime contract. `VectorIndexSearcher.SearchWithBuffer` rejects
-`IncludeDocuments`; callers that fetch documents should continue using
-`Search`/`SearchVectorIndex` and report the document-fetch counters separately.
-A `VectorIndexSearchBuffer` is not concurrency-safe, and returned `Results`/`ID`
-slices are valid only until the same buffer is reused or reset.
+buffer lifetime contract. `VectorIndexSearcher.SearchWithBuffer` and
+`Collection.SearchVectorIndexWithBuffer` reject `IncludeDocuments`; callers that
+fetch documents should continue using `Search`/`SearchVectorIndex` and report the
+document-fetch counters separately. A `VectorIndexSearchBuffer` is not
+concurrency-safe, and returned `Results`/`ID` slices are valid only until the same
+buffer is reused or reset.
 
 Use the #2037 truth matrix when comparing legacy/direct graph-row controls,
 current TVIS/base typed-column routing, and combined prepared typed-column rows
@@ -359,9 +360,13 @@ baseline. Its current production comparison benchmark is
   `VectorIndexSearcher.SearchWithBuffer`; setup, inserts, rebuild, open, and
   warmup are outside the timed loop. Parallel rows use one searcher and one
   `VectorIndexSearchBuffer` per worker.
-- A future collection-level buffered row should mirror the `SearchWithBuffer`
-  no-document contract: exact mode, caller-owned buffer, no documents/projection,
-  no per-search open/setup, and the healthy `hnsw_search_pack_v1` route.
+- `TreeDB_CollectionSearchVectorIndexWithBuffer` times the collection-level
+  caller-owned result-buffer seam. It mirrors the `SearchWithBuffer`
+  no-document route contract: exact mode, caller-owned buffer, no
+  documents/projection, and the healthy `hnsw_search_pack_v1` route. Until the
+  collection-owned prepared cache lands, this seam still opens/closes per
+  operation; report `open_searcher_calls/op=1`, `open_setup_in_timed_loop=1`,
+  and attribute those remaining allocations to the cache follow-up.
 - `USearch_Search` / `USearch_SearchParallel` time the pure in-memory USearch Go
   binding with cosine/f32 HNSW.
 - Both sides use the same deterministic synthetic vector/query generator and the

--- a/TreeDB/docs/spec/column-graph-native-vector-search.md
+++ b/TreeDB/docs/spec/column-graph-native-vector-search.md
@@ -102,9 +102,13 @@ response, _ := searcher.Search(collections.VectorIndexSearcherSearchOptions{
 fmt.Println(status.State, response.Path, response.Stats.RowFetches)
 ```
 
-Use `SearchVectorIndex` for one-shot calls. It opens and closes the native reader
-per call, so it measures setup/open cost in addition to graph search. Use
-`OpenVectorIndexSearcher` when benchmarking or serving steady-state query load.
+Use `SearchVectorIndex` for response-owned one-shot calls. It opens and closes
+the native reader per call, so it measures setup/open cost in addition to graph
+search. Use `SearchVectorIndexWithBuffer` when collection-level code needs the
+exact no-document caller-owned result-buffer seam; until collection-owned
+prepared caching lands, it still opens/closes a searcher per call. Use
+`OpenVectorIndexSearcher` plus `SearchWithBuffer` when benchmarking or serving
+steady-state query load with open/prepared state outside the hot loop.
 
 ## Collection-level no-document high-QPS contract (#2361)
 
@@ -124,10 +128,15 @@ claiming high-QPS vector search:
 - Preferred high-QPS route: exact no-document search through a validated
   vector-index-owned `hnsw_search_pack_v1`, with reusable open/prepared state and
   caller-owned buffers where the API exposes them.
-- Current baseline boundary: `Collection.SearchVectorIndex` is still a one-shot
-  convenience API. It opens/closes per call and owns response result buffers, so
-  its no-document benchmark row is a baseline/regression guardrail, not proof of
-  high-QPS success.
+- Current buffered collection seam: `Collection.SearchVectorIndexWithBuffer`
+  exposes caller-owned reusable result/ID storage for exact no-document searches
+  and fails closed when a healthy `hnsw_search_pack_v1` route is not selected.
+  It still opens/closes per call until the collection-owned prepared cache lands,
+  so benchmark rows must report that setup boundary separately.
+- Current response-owned baseline boundary: `Collection.SearchVectorIndex` is
+  still a one-shot convenience API. It opens/closes per call and owns response
+  result buffers, so its no-document benchmark row is a baseline/regression
+  guardrail, not proof of high-QPS success.
 - Document boundary: `IncludeDocuments=true` is an explicit post-top-k fetch
   path. It must report document counters (`docs_fetched/search`, output bytes,
   row-ref/point-fetch counters as applicable) and remains outside the

--- a/scripts/bench_vector_search_compare.sh
+++ b/scripts/bench_vector_search_compare.sh
@@ -200,10 +200,15 @@ Canonical current production comparison:
   \`graph_row_fallbacks/search\`, score-batch fallback reason flags,
   vector/adjacency source-state counters, and candidate/visited-edge byte
   counters used by the HNSW search-pack stack.
-- Future collection-level buffered rows should use the same exact no-document
-  contract as \`SearchWithBuffer\`: caller-owned buffer, no documents/projection,
-  no graph-row fallback, no vector scratch decode, no per-search open/setup, and
-  \`search_route_hnsw_search_pack/search=1\` on healthy packs.
+- \`BenchmarkCollectionVectorUSearchProductionCompare/TreeDB_CollectionSearchVectorIndexWithBuffer\`
+  times the new collection-level caller-owned result-buffer seam. It uses the
+  same exact no-document route contract as \`SearchWithBuffer\`: caller-owned
+  buffer, no documents/projection, no graph-row fallback, no vector scratch
+  decode, and \`search_route_hnsw_search_pack/search=1\` on healthy packs. Until
+  the collection-owned prepared cache lands, this row still opens/closes a
+  searcher per operation and should report \`open_searcher_calls/op=1\` and
+  \`open_setup_in_timed_loop=1\`; attribute those remaining allocations to the
+  cache follow-up rather than to response-owned result storage.
 - \`.../USearch_Search\` and \`.../USearch_SearchParallel\` time the pure
   in-memory USearch Go binding baseline with cosine/f32 HNSW and the same
   synthetic vector/query generator, M, efConstruction, efSearch, topK, docs,


### PR DESCRIPTION
## Summary

Closes #2362. Parent tracker: #2360. Predecessor #2361 / PR #2368 is merged in `main` at `c62706c2e3905367a8fe4635400ae99c8c2ef729`; this PR now targets `main`.

Changes:

- adds `Collection.SearchVectorIndexWithBuffer(opts VectorIndexSearchOptions, buffer *VectorIndexSearchBuffer)`;
- preserves existing `Collection.SearchVectorIndex` response-owned one-shot behavior;
- documents `VectorIndexSearchBuffer` aliasing for both reusable searcher and collection-level buffered APIs;
- routes the buffered collection seam through `VectorIndexSearcher.SearchWithBuffer` only for exact no-document `hnsw_search_pack_v1` searches;
- fails closed for `IncludeDocuments=true`, `DocumentFetchOptions`, filters/range filters, quantized modes/options, benchmark-debug stats mode, legacy fallback/filter controls, and missing/unsupported non-pack routes;
- clears returned buffered `Results` on late buffered-error invalidation, including `Close` errors;
- adds the `TreeDB_CollectionSearchVectorIndexWithBuffer` benchmark row and docs/harness wording.

## Contract / caveats

`SearchVectorIndexWithBuffer` returns result slices and ID bytes owned by the caller's `VectorIndexSearchBuffer`; they are invalidated on buffer reuse or `Reset`. A buffer is not concurrency-safe; parallel callers need independent buffers.

This PR intentionally does **not** add a collection-owned prepared cache (#2363). The new collection-level seam still opens/closes a searcher per call, so per-call open/prepare allocations remain in this row and are explicitly attributed to #2363. The API buffer itself is reused and the benchmark reports `response_owned_result_alloc/op=0`.

## Validation

Latest head: `2681570a60daafef965c4255b52c6088ee93b5a7`.

- `GOWORK=off go test ./TreeDB/collections -run 'Test(SearchVectorIndexWithBuffer|ResetBufferedVectorIndexSearchResponseClearsReturnedResults2362|SearchVectorIndexNoDocumentHighQPSContractBoundary2361|VectorIndexSearcherSearchWithBufferHighQPSContractRejectsDocuments2361)' -count=1`
  - PASS, artifact: `/tmp/gomap_2362_final_20260604_230856/focused_tests_post_commit.txt`
- `GOWORK=off go test ./TreeDB/collections -count=1`
  - PASS, artifact: `/tmp/gomap_2362_final_20260604_230856/collections_tests_post_commit.txt`
- Current API allocation sanity:
  - `GOMAXPROCS=8 GOWORK=off go test ./TreeDB/collections -run '^$' -bench '^(BenchmarkSearchVectorIndexColumnGraphNativeReaderV4|BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderReusableBufferV4)$' -benchmem -benchtime=1000x -count=3`
  - PASS, artifact: `/tmp/gomap_2362_final_20260604_230856/current_api_bench_post_commit.txt`
  - `BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderReusableBufferV4`: median `11,298 ns/op`, `88,514 ops/sec`, `0 B/op`, `0 allocs/op`, `search_route_hnsw_search_pack/search=1`.
- Tier S smoke matrix:
  - `RUN_DIR=/tmp/gomap_2362_final_20260604_230856/tier_s USEARCH_ROOT=/tmp/usearch_2.25.2_macos_arm64/root BENCH_REGEX='^BenchmarkCollectionVectorUSearchProductionCompare$' TREEDB_VECTOR_BENCH_DOCS=10000 TREEDB_VECTOR_BENCH_DIMS=64 TREEDB_VECTOR_BENCH_M=16 TREEDB_VECTOR_BENCH_EF_CONSTRUCTION=128 TREEDB_VECTOR_BENCH_EF_SEARCH=128 TREEDB_VECTOR_BENCH_TOPK=10 TREEDB_VECTOR_BENCH_QUERIES=16 CPU_LIST=1,8 BENCHTIME=1000x COUNT=3 scripts/bench_vector_search_compare.sh`
  - PASS, artifact: `/tmp/gomap_2362_final_20260604_230856/tier_s/bench.txt`
- Tier F full matrix:
  - `RUN_DIR=/tmp/gomap_2362_final_20260604_230856/tier_f USEARCH_ROOT=/tmp/usearch_2.25.2_macos_arm64/root BENCH_REGEX='^BenchmarkCollectionVectorUSearchProductionCompare$' TREEDB_VECTOR_BENCH_DOCS=100000 TREEDB_VECTOR_BENCH_DIMS=128 TREEDB_VECTOR_BENCH_M=16 TREEDB_VECTOR_BENCH_EF_CONSTRUCTION=128 TREEDB_VECTOR_BENCH_EF_SEARCH=128 TREEDB_VECTOR_BENCH_TOPK=10 TREEDB_VECTOR_BENCH_QUERIES=16 CPU_LIST=1,8 BENCHTIME=1s COUNT=3 scripts/bench_vector_search_compare.sh`
  - PASS, artifact: `/tmp/gomap_2362_final_20260604_230856/tier_f/bench.txt`

## Performance status

Median Apple M3 (`darwin/arm64`) results from the Tier S/F artifacts:

| Tier | CPU | Row | ns/op | ops/sec | B/op | allocs/op | Route/docs/fallback counters |
| --- | ---: | --- | ---: | ---: | ---: | ---: | --- |
| S 10k/64 | 1 | `TreeDB_CollectionSearchVectorIndexWithBuffer` | 8,892,468 | 112 | 14,607,305 | 5,367 | pack=1, docs=0, graph_fb=0, typed_fb=0, scratch=0, open/op=1, response_alloc/op=0 |
| S 10k/64 | 8 | `TreeDB_CollectionSearchVectorIndexWithBuffer` | 8,631,846 | 116 | 14,680,843 | 5,369 | pack=1, docs=0, graph_fb=0, typed_fb=0, scratch=0, open/op=1, response_alloc/op=0 |
| F 100k/128 | 1 | `TreeDB_CollectionSearchVectorIndexWithBuffer` | 93,416,269 | 10.7 | 140,721,169 | 32,068 | pack=1, docs=0, graph_fb=0, typed_fb=0, scratch=0, open/op=1, response_alloc/op=0 |
| F 100k/128 | 8 | `TreeDB_CollectionSearchVectorIndexWithBuffer` | 90,589,846 | 11.0 | 140,836,329 | 32,073 | pack=1, docs=0, graph_fb=0, typed_fb=0, scratch=0, open/op=1, response_alloc/op=0 |
| S 10k/64 | 1 | `TreeDB_SearchWithBuffer` | 47,270 | 21,155 | 0 | 0 | pack=1, docs=0, graph_fb=0, typed_fb=0, scratch=0 |
| F 100k/128 | 1 | `TreeDB_SearchWithBuffer` | 210,440 | 4,752 | 0 | 0 | pack=1, docs=0, graph_fb=0, typed_fb=0, scratch=0 |

The new collection-level buffered seam proves the no-document pack route and avoids response-owned result allocation. Its `B/op` and `allocs/op` are still dominated by per-call open/prepare (`open_searcher_calls/op=1`, `open_setup_in_timed_loop=1`), which is scoped to #2363's prepared cache work. The reusable `VectorIndexSearcher.SearchWithBuffer` comparator remains `0 B/op`, `0 allocs/op`.

## Scope, CI, and review status

- Scope is limited to the #2362 API seam, tests, docs, and benchmark row. It does not add the #2363 collection-owned cache or final `SearchVectorIndex` routing.
- Local diff against `main` contains no retained-payload/#2367 changes beyond what is already in base `main`.
- Latest-head CI for `2681570a60daafef965c4255b52c6088ee93b5a7`: all GitHub checks pass; GraphQL reports `mergeable=MERGEABLE`, `mergeStateStatus=CLEAN`.
- AI reviews requested after the PR was marked ready-for-review:
  - Codex: completed, "Didn't find any major issues."
  - CodeRabbit: requested; status context is success and no review threads are open, but the visible summary/comment also reports the review limit/credits were reached. Treat as requested with rate-limit caveat.
  - Copilot: requested; no review output surfaced by the time CI was green. Treat as requested/no returned findings.
- Review threads: none (`reviewThreads.nodes=[]`). Coordinator/human still performs final merge; this PR should not be self-merged by the issue manager.
