### PR TITLE
Keep retained payload bodies in the value log

### DIFF
--- a/TreeDB/caching/value_log_appender.go
+++ b/TreeDB/caching/value_log_appender.go
@@ -51,6 +51,13 @@ func (a *cachingValueLogAppender) AppendValues(values [][]byte) ([]page.ValuePtr
 	return out, nil
 }
 
+func (a *cachingValueLogAppender) ReserveRIDs(count int) (uint64, error) {
+	if a == nil || a.db == nil {
+		return 0, errWALUnavailable
+	}
+	return a.db.ReserveValueLogRIDs(count)
+}
+
 func (a *cachingValueLogAppender) Flush() error {
 	if a == nil || a.db == nil || a.lane == nil {
 		return errWALUnavailable

--- a/TreeDB/caching/value_log_appender.go
+++ b/TreeDB/caching/value_log_appender.go
@@ -52,7 +52,7 @@ func (a *cachingValueLogAppender) AppendValues(values [][]byte) ([]page.ValuePtr
 }
 
 func (a *cachingValueLogAppender) ReserveRIDs(count int) (uint64, error) {
-	if a == nil || a.db == nil {
+	if a == nil || a.db == nil || a.lane == nil {
 		return 0, errWALUnavailable
 	}
 	return a.db.ReserveValueLogRIDs(count)

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -4292,7 +4292,7 @@ func (c *Collection) flushBufferedNoIndexLocked(domain *collectionWriteDomain) e
 	baseCommitSeq := snapshotCommitSeq(pin)
 	baseRootIDs := map[string]uint64{rootName: baseRoot}
 	table := domain.table
-	publishTable, pointerized, err := pointerizeCollectionRunTableValues(c.db, table)
+	publishTable, pointerized, err := pointerizeCollectionRunTableValuesForRoot(c.db, meta, rootName, table)
 	if err != nil {
 		return err
 	}
@@ -5004,8 +5004,52 @@ func collectionRunTableHasStableUnsafeSlices(table memtable.Table) bool {
 }
 
 func pointerizeCollectionRunTableValues(db *backenddb.DB, table memtable.Table) (memtable.Table, bool, error) {
+	return pointerizeCollectionRunTableValuesWithResolver(db, table, nil)
+}
+
+func pointerizeCollectionRunTableValuesForRoot(db *backenddb.DB, meta CollectionMeta, rootName string, table memtable.Table) (memtable.Table, bool, error) {
+	return pointerizeCollectionRunTableValuesWithResolver(db, table, collectionValueLogInlineThresholdResolverForRoot(db, meta, rootName))
+}
+
+func collectionValueLogInlineThresholdResolverForRoot(db *backenddb.DB, meta CollectionMeta, rootName string) func([]byte) int {
+	if db == nil || !collectionRootStoresRetainedPayloadBodies(meta, rootName) {
+		return nil
+	}
+	return func([]byte) int {
+		// Retained payload bodies are the residual/original document bytes for this
+		// primary root. Keep them out of leaf pages regardless of document-body
+		// representation; empty retained bodies still remain inline.
+		return 0
+	}
+}
+
+func collectionRootStoresRetainedPayloadBodies(meta CollectionMeta, rootName string) bool {
+	if rootName == "" || rootName != collectionPrimaryRootName(meta.Name) {
+		return false
+	}
+	cfg := meta.Options.ColumnStore
+	if cfg == nil || !cfg.Enabled {
+		return false
+	}
+	switch columnRetainedPayloadAuditPolicy(cfg) {
+	case ColumnRetainedPayloadNone:
+		return false
+	case ColumnRetainedPayloadNonColumn, ColumnRetainedPayloadFull:
+		return true
+	default:
+		// Invalid retained-payload policies are rejected during collection metadata
+		// normalization. If one reaches placement, fail closed by keeping the body
+		// out of leaf pages rather than silently inlining it.
+		return true
+	}
+}
+
+func pointerizeCollectionRunTableValuesWithResolver(db *backenddb.DB, table memtable.Table, inlineThresholdForKey func([]byte) int) (memtable.Table, bool, error) {
 	if db == nil || table == nil || !db.HasValueLogAppender() {
 		return table, false, nil
+	}
+	if inlineThresholdForKey == nil {
+		inlineThresholdForKey = db.InlineThresholdForKey
 	}
 	needsPointer := false
 	probe := table.NewIterator(nil, nil)
@@ -5013,7 +5057,7 @@ func pointerizeCollectionRunTableValues(db *backenddb.DB, table memtable.Table) 
 		value, _, flags := probe.UnsafeEntry()
 		if flags&node.FlagTombstone == 0 &&
 			flags&node.FlagPointer == 0 &&
-			len(value) > db.InlineThresholdForKey(probe.UnsafeKey()) {
+			len(value) > inlineThresholdForKey(probe.UnsafeKey()) {
 			needsPointer = true
 			break
 		}
@@ -5075,7 +5119,7 @@ func pointerizeCollectionRunTableValues(db *backenddb.DB, table memtable.Table) 
 		}
 		if flags&node.FlagTombstone == 0 &&
 			flags&node.FlagPointer == 0 &&
-			len(value) > db.InlineThresholdForKey(entry.key) {
+			len(value) > inlineThresholdForKey(entry.key) {
 			entries = append(entries, entry)
 			appendValue := value
 			if !borrowPointerValues {
@@ -5115,7 +5159,7 @@ func pointerizeCollectionRunTableValues(db *backenddb.DB, table memtable.Table) 
 	return out, true, nil
 }
 
-func pointerizeInsertBatchPlanDataRuns(db *backenddb.DB, plan *insertBatchPlan) ([]memtable.Table, error) {
+func pointerizeInsertBatchPlanDataRuns(db *backenddb.DB, meta CollectionMeta, plan *insertBatchPlan) ([]memtable.Table, error) {
 	if plan == nil || db == nil || !db.HasValueLogAppender() {
 		return nil, nil
 	}
@@ -5126,7 +5170,7 @@ func pointerizeInsertBatchPlanDataRuns(db *backenddb.DB, plan *insertBatchPlan) 
 		default:
 			continue
 		}
-		pointerizedTable, pointerized, err := pointerizeCollectionRunTableValues(db, plan.runs[i].table)
+		pointerizedTable, pointerized, err := pointerizeCollectionRunTableValuesForRoot(db, meta, plan.runs[i].name, plan.runs[i].table)
 		if err != nil {
 			resetCollectionTables(obsolete)
 			return nil, err
@@ -5164,7 +5208,7 @@ func pointerizeCollectionDataRootDeltaTables(db *backenddb.DB, meta CollectionMe
 		if _, ok := dataRoots[rootName]; !ok {
 			continue
 		}
-		pointerizedTable, pointerized, err := pointerizeCollectionRunTableValues(db, tables[i])
+		pointerizedTable, pointerized, err := pointerizeCollectionRunTableValuesForRoot(db, meta, rootName, tables[i])
 		if err != nil {
 			cleanup()
 			return nil, nil, err
@@ -5210,7 +5254,7 @@ func pointerizeCollectionDataRootRunMapValues(db *backenddb.DB, meta CollectionM
 			continue
 		}
 		for i, run := range runs {
-			pointerizedTable, pointerized, err := pointerizeCollectionRunTableValues(db, run)
+			pointerizedTable, pointerized, err := pointerizeCollectionRunTableValuesForRoot(db, meta, rootName, run)
 			if err != nil {
 				cleanup()
 				return nil, nil, err
@@ -8795,7 +8839,7 @@ func (c *Collection) insertOneNoIndex(id, document []byte) ([]byte, error) {
 	table := newCollectionRunTable(1)
 	setCollectionRunValue(table, resultID, bytes.Clone(document))
 	table.Freeze()
-	publishTable, pointerized, err := pointerizeCollectionRunTableValues(c.db, table)
+	publishTable, pointerized, err := pointerizeCollectionRunTableValuesForRoot(c.db, c.meta, rootName, table)
 	if err != nil {
 		resetCollectionRunTable(table)
 		return nil, err
@@ -9491,7 +9535,7 @@ func (c *Collection) insertBatchOnceWithLockState(
 	// Keep the base snapshot pinned through publish so page reuse cannot invalidate
 	// base roots before stale-root validation rejects concurrent modifications.
 	defer func() { _ = pin.Close() }()
-	obsoletePointerizedTables, err := pointerizeInsertBatchPlanDataRuns(c.db, plan)
+	obsoletePointerizedTables, err := pointerizeInsertBatchPlanDataRuns(c.db, meta, plan)
 	if err != nil {
 		return nil, err
 	}
@@ -10094,7 +10138,7 @@ func (c *Collection) insertBatchNoIndex(
 	}
 	table.Freeze()
 	stats.PrimaryRunBuild = time.Since(phaseStart)
-	publishTable, pointerized, err := pointerizeCollectionRunTableValues(c.db, table)
+	publishTable, pointerized, err := pointerizeCollectionRunTableValuesForRoot(c.db, c.meta, rootName, table)
 	if err != nil {
 		return nil, err
 	}
@@ -13367,7 +13411,7 @@ func (c *Collection) updateDocumentOnceApply(documentID []byte, update func(curr
 	primaryTable := newCollectionRunTable(1)
 	setCollectionRunValue(primaryTable, bytes.Clone(documentID), primaryDocument)
 	primaryTable.Freeze()
-	if pointerizedPrimaryTable, pointerized, err := pointerizeCollectionRunTableValues(c.db, primaryTable); err != nil {
+	if pointerizedPrimaryTable, pointerized, err := pointerizeCollectionRunTableValuesForRoot(c.db, c.meta, primaryRootName, primaryTable); err != nil {
 		_ = snap.Close()
 		resetCollectionTables(append(deltaTables, primaryTable))
 		return false, false, err

--- a/TreeDB/collections/column_retained_vlog_placement_test.go
+++ b/TreeDB/collections/column_retained_vlog_placement_test.go
@@ -1,0 +1,374 @@
+package collections
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/internal/valuelog"
+	"github.com/snissn/gomap/TreeDB/node"
+	"github.com/snissn/gomap/TreeDB/page"
+)
+
+func TestColumnRetainedPayloadValueLogPlacementReopen(t *testing.T) {
+	dir := t.TempDir()
+	enableColumnRetainedPlacementCommandWAL(t, dir)
+
+	d := openColumnRetainedPlacementDB(t, dir, backenddb.Options{})
+	col := createColumnRetainedPlacementCollection(t, d, "events")
+	doc := retainedPlacementDocument("durable-reopen", 1)
+	if _, err := col.InsertBatch([][]byte{[]byte("doc-1")}, [][]byte{doc}); err != nil {
+		t.Fatalf("InsertBatch: %v", err)
+	}
+	ptr := requireColumnRetainedPlacementPointer(t, d, "events", []byte("doc-1"))
+	if ptr.FileID == 0 || !page.IsValueLogFileID(ptr.FileID) {
+		t.Fatalf("retained payload pointer file id=%d want value-log pointer", ptr.FileID)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	reopen := openColumnRetainedPlacementDB(t, dir, backenddb.Options{})
+	defer func() { _ = reopen.Close() }()
+	reopenedCol := openColumnRetainedPlacementCollection(t, reopen, "events")
+	got, err := reopenedCol.Get([]byte("doc-1"))
+	if err != nil {
+		t.Fatalf("Get after reopen: %v", err)
+	}
+	assertJSONMapEqual1875(t, got, map[string]any{"row_id": float64(1), "kind": "kind-1", "payload": strings.Repeat("durable-reopen", 10)})
+	reopenedPtr := requireColumnRetainedPlacementPointer(t, reopen, "events", []byte("doc-1"))
+	if reopenedPtr != ptr {
+		t.Fatalf("retained payload pointer changed after reopen: got=%+v want=%+v", reopenedPtr, ptr)
+	}
+}
+
+func TestColumnRetainedPayloadValueLogPlacementGCRewrite(t *testing.T) {
+	dir := t.TempDir()
+	enableColumnRetainedPlacementCommandWAL(t, dir)
+
+	d := openColumnRetainedPlacementDB(t, dir, backenddb.Options{})
+	col := createColumnRetainedPlacementCollection(t, d, "events")
+	if _, err := col.InsertBatch([][]byte{[]byte("doc-a")}, [][]byte{retainedPlacementDocument("gc-stale", 1)}); err != nil {
+		t.Fatalf("InsertBatch doc-a: %v", err)
+	}
+	ptrA := requireColumnRetainedPlacementPointer(t, d, "events", []byte("doc-a"))
+	pathA := valueLogPathForFileID(t, dir, ptrA.FileID)
+	if err := d.Close(); err != nil {
+		t.Fatalf("Close after doc-a: %v", err)
+	}
+
+	d = openColumnRetainedPlacementDB(t, dir, backenddb.Options{})
+	col = openColumnRetainedPlacementCollection(t, d, "events")
+	if _, err := col.InsertBatch([][]byte{[]byte("doc-b")}, [][]byte{retainedPlacementDocument("rewrite-live", 2)}); err != nil {
+		_ = d.Close()
+		t.Fatalf("InsertBatch doc-b: %v", err)
+	}
+	ptrB := requireColumnRetainedPlacementPointer(t, d, "events", []byte("doc-b"))
+	pathB := valueLogPathForFileID(t, dir, ptrB.FileID)
+	if ptrA.FileID == ptrB.FileID {
+		_ = d.Close()
+		t.Fatalf("test expected separate retained payload segments, both pointers use file %d", ptrA.FileID)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("Close after doc-b: %v", err)
+	}
+
+	// Reopen and append another retained payload so doc-b's segment is no longer
+	// the command-WAL appender's active segment when the rewrite cleanup runs.
+	d = openColumnRetainedPlacementDB(t, dir, backenddb.Options{})
+	col = openColumnRetainedPlacementCollection(t, d, "events")
+	if _, err := col.InsertBatch([][]byte{[]byte("doc-c")}, [][]byte{retainedPlacementDocument("active-tail", 3)}); err != nil {
+		_ = d.Close()
+		t.Fatalf("InsertBatch doc-c: %v", err)
+	}
+	_ = requireColumnRetainedPlacementPointer(t, d, "events", []byte("doc-c"))
+	if err := col.Delete([]byte("doc-a")); err != nil {
+		_ = d.Close()
+		t.Fatalf("Delete doc-a: %v", err)
+	}
+
+	gcStats, err := d.ValueLogGC(context.Background(), backenddb.ValueLogGCOptions{})
+	if err != nil {
+		_ = d.Close()
+		t.Fatalf("ValueLogGC: %v", err)
+	}
+	if gcStats.SegmentsDeleted == 0 {
+		_ = d.Close()
+		t.Fatalf("ValueLogGC deleted no segments after deleting retained payload: %+v", gcStats)
+	}
+	if _, err := os.Stat(pathA); err == nil || !os.IsNotExist(err) {
+		_ = d.Close()
+		t.Fatalf("stale retained payload segment %s stat err=%v, want removed", pathA, err)
+	}
+	if got, err := col.Get([]byte("doc-b")); err != nil {
+		_ = d.Close()
+		t.Fatalf("Get doc-b after GC: %v", err)
+	} else {
+		assertJSONMapEqual1875(t, got, map[string]any{"row_id": float64(2), "kind": "kind-2", "payload": strings.Repeat("rewrite-live", 10)})
+	}
+
+	rewriteStats, err := d.ValueLogRewriteOnline(context.Background(), backenddb.ValueLogRewriteOnlineOptions{
+		SourceFileIDs: []uint32{ptrB.FileID},
+		BatchSize:     1,
+	})
+	if err != nil {
+		_ = d.Close()
+		t.Fatalf("ValueLogRewriteOnline: %v", err)
+	}
+	if rewriteStats.RecordsCopied == 0 {
+		_ = d.Close()
+		t.Fatalf("ValueLogRewriteOnline copied no retained payload records: %+v", rewriteStats)
+	}
+	rewrittenPtr := requireColumnRetainedPlacementPointer(t, d, "events", []byte("doc-b"))
+	if rewrittenPtr.FileID == ptrB.FileID {
+		_ = d.Close()
+		t.Fatalf("retained payload pointer still references rewrite source segment %d", ptrB.FileID)
+	}
+	if got, err := col.Get([]byte("doc-b")); err != nil {
+		_ = d.Close()
+		t.Fatalf("Get doc-b after rewrite: %v", err)
+	} else {
+		assertJSONMapEqual1875(t, got, map[string]any{"row_id": float64(2), "kind": "kind-2", "payload": strings.Repeat("rewrite-live", 10)})
+	}
+	if rewriteStats.SourceSegmentsUnreferenced == 0 {
+		postRewriteGC, err := d.ValueLogGC(context.Background(), backenddb.ValueLogGCOptions{})
+		if err != nil {
+			_ = d.Close()
+			t.Fatalf("ValueLogGC after rewrite: %v", err)
+		}
+		if postRewriteGC.SegmentsDeleted == 0 {
+			_ = d.Close()
+			t.Fatalf("rewrite source segment was not reclaimed: rewrite=%+v gc=%+v", rewriteStats, postRewriteGC)
+		}
+	}
+	if _, err := os.Stat(pathB); err == nil || !os.IsNotExist(err) {
+		_ = d.Close()
+		t.Fatalf("rewritten source segment %s stat err=%v, want removed", pathB, err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("Close after rewrite: %v", err)
+	}
+
+	reopen := openColumnRetainedPlacementDB(t, dir, backenddb.Options{})
+	defer func() { _ = reopen.Close() }()
+	reopenedCol := openColumnRetainedPlacementCollection(t, reopen, "events")
+	if got, err := reopenedCol.Get([]byte("doc-b")); err != nil {
+		t.Fatalf("Get doc-b after rewrite reopen: %v", err)
+	} else {
+		assertJSONMapEqual1875(t, got, map[string]any{"row_id": float64(2), "kind": "kind-2", "payload": strings.Repeat("rewrite-live", 10)})
+	}
+	reopenedPtr := requireColumnRetainedPlacementPointer(t, reopen, "events", []byte("doc-b"))
+	if reopenedPtr != rewrittenPtr {
+		t.Fatalf("rewritten retained payload pointer changed after reopen: got=%+v want=%+v", reopenedPtr, rewrittenPtr)
+	}
+}
+
+func TestColumnRetainedPayloadLeafLogSyntheticShrink(t *testing.T) {
+	const docs = 512
+	const marker = "retained-leaf-vlog-marker-2357"
+
+	rowDir := t.TempDir()
+	rowLeafBytes := writeRetainedPlacementSynthetic(t, rowDir, "row_docs", nil, docs, marker)
+	if !filesUnderDirContain(t, backenddb.LeafLogDirPath(rowDir), []byte(marker)) {
+		t.Fatalf("row-store baseline leaf_vlog did not contain marker %q", marker)
+	}
+
+	retainedDir := t.TempDir()
+	retainedCfg := &ColumnStoreConfig{
+		Enabled: true,
+		Columns: []ColumnStoreColumn{
+			{Name: "row_id", Path: "row_id", ValueType: ColumnStoreValueInt64, Owner: TypedStorageOwnerRowAsset},
+			{Name: "kind", Path: "kind", ValueType: ColumnStoreValueString, Owner: TypedStorageOwnerColumnPart, Dictionary: true},
+		},
+		RetainedPayload: ColumnRetainedPayloadNonColumn,
+		Reconstruction:  ColumnReconstructionRetainedPayloadAndColumns,
+	}
+	retainedLeafBytes := writeRetainedPlacementSynthetic(t, retainedDir, "retained_docs", retainedCfg, docs, marker)
+	if filesUnderDirContain(t, backenddb.LeafLogDirPath(retainedDir), []byte(marker)) {
+		t.Fatalf("retained payload marker %q remained inline in leaf_vlog", marker)
+	}
+	if !filesUnderDirContain(t, backenddb.ValueLogDirPath(retainedDir), []byte(marker)) {
+		t.Fatalf("retained payload marker %q was not found in value_vlog", marker)
+	}
+
+	if retainedLeafBytes >= rowLeafBytes/2 {
+		t.Fatalf("retained leaf_vlog did not shrink enough: retained=%d row_baseline=%d", retainedLeafBytes, rowLeafBytes)
+	}
+	t.Logf("synthetic leaf_vlog bytes: retained=%d row_baseline=%d shrink=%.1f%%", retainedLeafBytes, rowLeafBytes, 100*(1-float64(retainedLeafBytes)/float64(rowLeafBytes)))
+}
+
+func enableColumnRetainedPlacementCommandWAL(t testing.TB, dir string) {
+	t.Helper()
+	if err := backenddb.SaveFormatConfig(dir, backenddb.FormatConfig{RequiredFeatures: []string{backenddb.RequiredFeatureCommandWALV1}}); err != nil {
+		t.Fatalf("SaveFormatConfig: %v", err)
+	}
+}
+
+func openColumnRetainedPlacementDB(t testing.TB, dir string, opts backenddb.Options) *backenddb.DB {
+	t.Helper()
+	opts.Dir = dir
+	opts.DisableBackgroundPrune = true
+	d, err := backenddb.Open(opts)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	return d
+}
+
+func createColumnRetainedPlacementCollection(t testing.TB, d *backenddb.DB, name string) *Collection {
+	t.Helper()
+	cfg := &ColumnStoreConfig{
+		Enabled: true,
+		Columns: []ColumnStoreColumn{
+			{Name: "row_id", Path: "row_id", ValueType: ColumnStoreValueInt64, Owner: TypedStorageOwnerRowAsset},
+			{Name: "kind", Path: "kind", ValueType: ColumnStoreValueString, Owner: TypedStorageOwnerColumnPart, Dictionary: true},
+		},
+		RetainedPayload: ColumnRetainedPayloadNonColumn,
+		Reconstruction:  ColumnReconstructionRetainedPayloadAndColumns,
+	}
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: name, Options: CollectionOptions{DocumentFormat: DocumentFormatJSON, ColumnStore: cfg}}); err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	return openColumnRetainedPlacementCollection(t, d, name)
+}
+
+func openColumnRetainedPlacementCollection(t testing.TB, d *backenddb.DB, name string) *Collection {
+	t.Helper()
+	col, err := NewCollectionManager(d).OpenCollection(name)
+	if err != nil {
+		t.Fatalf("OpenCollection: %v", err)
+	}
+	return col
+}
+
+func retainedPlacementDocument(payload string, rowID int) []byte {
+	return []byte(fmt.Sprintf(`{"row_id":%d,"kind":"kind-%d","payload":"%s"}`, rowID, rowID, strings.Repeat(payload, 10)))
+}
+
+func requireColumnRetainedPlacementPointer(t testing.TB, d *backenddb.DB, collection string, documentID []byte) page.ValuePtr {
+	t.Helper()
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("AcquireSnapshot returned nil")
+	}
+	defer func() { _ = snap.Close() }()
+	catalog, err := loadCollectionCatalog(snap, collection)
+	if err != nil {
+		t.Fatalf("loadCollectionCatalog: %v", err)
+	}
+	if catalog == nil {
+		t.Fatalf("collection catalog %q missing", collection)
+	}
+	entry, _, err := collectionGetEntryAtCatalogRoot(snap, catalog, collectionPrimaryRootName(collection), documentID)
+	if err != nil {
+		t.Fatalf("collection primary entry %q: %v", string(documentID), err)
+	}
+	if entry.Flags&node.FlagPointer == 0 {
+		t.Fatalf("collection primary entry %q flags=%#x value_len=%d want retained payload ValuePtr", string(documentID), entry.Flags, len(entry.Value))
+	}
+	if len(entry.Value) != 0 {
+		t.Fatalf("collection primary pointer entry %q carried inline value bytes len=%d", string(documentID), len(entry.Value))
+	}
+	if !page.IsValueLogFileID(entry.ValuePtr.FileID) {
+		t.Fatalf("collection primary entry %q pointer file id=%d is not a value-log file", string(documentID), entry.ValuePtr.FileID)
+	}
+	return entry.ValuePtr
+}
+
+func valueLogPathForFileID(t testing.TB, dir string, fileID uint32) string {
+	t.Helper()
+	lane, seq := valuelog.DecodeFileID(fileID)
+	return filepath.Join(backenddb.ValueLogDirPath(dir), fmt.Sprintf("value-l%d-%06d.log", lane, seq))
+}
+
+func writeRetainedPlacementSynthetic(t testing.TB, dir, collection string, cfg *ColumnStoreConfig, count int, marker string) int64 {
+	t.Helper()
+	enableColumnRetainedPlacementCommandWAL(t, dir)
+	d := openColumnRetainedPlacementDB(t, dir, backenddb.Options{ValueLog: backenddb.ValueLogOptions{Compression: backenddb.ValueLogCompressionOff}})
+	mgr := NewCollectionManager(d)
+	options := CollectionOptions{DocumentFormat: DocumentFormatJSON}
+	if cfg != nil {
+		options.ColumnStore = cfg
+	}
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: collection, Options: options}); err != nil {
+		_ = d.Close()
+		t.Fatalf("CreateCollection %s: %v", collection, err)
+	}
+	col, err := mgr.OpenCollection(collection)
+	if err != nil {
+		_ = d.Close()
+		t.Fatalf("OpenCollection %s: %v", collection, err)
+	}
+	ids := make([][]byte, count)
+	docs := make([][]byte, count)
+	for i := 0; i < count; i++ {
+		ids[i] = []byte(fmt.Sprintf("doc-%06d", i))
+		docs[i] = []byte(fmt.Sprintf(`{"row_id":%d,"kind":"kind-%03d","payload":"%s-%06d-%s"}`, i, i%17, marker, i, strings.Repeat("x", 260)))
+	}
+	if _, err := col.InsertBatch(ids, docs); err != nil {
+		_ = d.Close()
+		t.Fatalf("InsertBatch %s: %v", collection, err)
+	}
+	if cfg != nil {
+		_ = requireColumnRetainedPlacementPointer(t, d, collection, ids[0])
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("Close %s: %v", collection, err)
+	}
+	return retainedPlacementDirSize(t, backenddb.LeafLogDirPath(dir))
+}
+
+func retainedPlacementDirSize(t testing.TB, dir string) int64 {
+	t.Helper()
+	var total int64
+	err := filepath.WalkDir(dir, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		total += info.Size()
+		return nil
+	})
+	if err != nil && !os.IsNotExist(err) {
+		t.Fatalf("walk %s: %v", dir, err)
+	}
+	return total
+}
+
+func filesUnderDirContain(t testing.TB, dir string, needle []byte) bool {
+	t.Helper()
+	found := false
+	err := filepath.WalkDir(dir, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if found || entry.IsDir() {
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		if bytes.Contains(data, needle) {
+			found = true
+		}
+		return nil
+	})
+	if err != nil && !os.IsNotExist(err) {
+		t.Fatalf("walk %s: %v", dir, err)
+	}
+	return found
+}

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -331,7 +331,7 @@ type typedStorageLegacyNameAllowlistEntry struct {
 }
 
 var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
-	{path: "TreeDB/collections/api.go", classification: typedStorageLegacyCompatibility, matchingLines: 45, occurrences: 51},
+	{path: "TreeDB/collections/api.go", classification: typedStorageLegacyCompatibility, matchingLines: 46, occurrences: 52},
 	{path: "TreeDB/collections/column_aggregate_metadata_asset.go", classification: typedStorageLegacyDerived, matchingLines: 16, occurrences: 19},
 	{path: "TreeDB/collections/column_aggregate_metadata_predicate.go", classification: typedStorageLegacyDerived, matchingLines: 6, occurrences: 6},
 	{path: "TreeDB/collections/column_aggregate_metadata_predicate_1951_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 15, occurrences: 16},
@@ -382,6 +382,7 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/column_reconstruction_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 27, occurrences: 31},
 	{path: "TreeDB/collections/column_retained_payload_audit.go", classification: typedStorageLegacyCompatibility, matchingLines: 4, occurrences: 4},
 	{path: "TreeDB/collections/column_retained_payload_audit_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 9, occurrences: 9},
+	{path: "TreeDB/collections/column_retained_vlog_placement_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 11, occurrences: 11},
 	{path: "TreeDB/collections/column_semantics.go", classification: typedStorageLegacyCompatibility, matchingLines: 34, occurrences: 34},
 	{path: "TreeDB/collections/dense_numeric_vector.go", classification: typedStorageLegacyCompatibility, matchingLines: 32, occurrences: 41},
 	{path: "TreeDB/collections/dense_numeric_vector_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 35, occurrences: 38},

--- a/TreeDB/db/value_log_appender.go
+++ b/TreeDB/db/value_log_appender.go
@@ -24,6 +24,10 @@ type valueLogAppenderHolder struct {
 	appender ValueLogAppender
 }
 
+type valueLogRIDReserver interface {
+	ReserveRIDs(count int) (start uint64, err error)
+}
+
 // SetValueLogAppender installs the appender used by native-root APIs that need
 // to create persistent value-log pointers. Cached mode wires this to its normal
 // value-log writer.
@@ -47,6 +51,18 @@ func (db *DB) currentValueLogAppender() ValueLogAppender {
 		return nil
 	}
 	return holder.appender
+}
+
+func (db *DB) currentValueLogRIDReserver() valueLogRIDReserver {
+	appender := db.currentValueLogAppender()
+	if appender == nil {
+		return nil
+	}
+	reserver, ok := appender.(valueLogRIDReserver)
+	if !ok {
+		return nil
+	}
+	return reserver
 }
 
 // HasValueLogAppender reports whether native-root callers can append user

--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -1563,6 +1563,14 @@ func (db *DB) valueLogRewriteOnline(ctx context.Context, opts ValueLogRewriteOnl
 	if ctx == nil {
 		ctx = context.Background()
 	}
+	if opts.ReserveRIDs == nil {
+		// A live appender may have advanced the RID namespace beyond what a disk
+		// scan can observe (for example, command-WAL native-root writes). Share its
+		// allocator so online rewrite cannot create duplicate value-log RIDs.
+		if reserver := db.currentValueLogRIDReserver(); reserver != nil {
+			opts.ReserveRIDs = reserver.ReserveRIDs
+		}
+	}
 	if err := db.publishValueLogSetNoRefresh(); err != nil {
 		return stats, err
 	}

--- a/TreeDB/db/wal_recovery.go
+++ b/TreeDB/db/wal_recovery.go
@@ -812,6 +812,29 @@ func (a *replayInlineAppender) AppendValues(values [][]byte) ([]page.ValuePtr, e
 	return ptrs, nil
 }
 
+func (a *replayInlineAppender) ReserveRIDs(count int) (uint64, error) {
+	if a == nil {
+		return 0, fmt.Errorf("commitlog: replay value-log appender unavailable")
+	}
+	if err := validateRewriteRIDCount(count); err != nil {
+		return 0, err
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.writer == nil {
+		return 0, fmt.Errorf("commitlog: replay value-log appender unavailable")
+	}
+	start := a.nextRID
+	if start == 0 {
+		return 0, fmt.Errorf("value-log rid space exhausted")
+	}
+	if err := validateRewriteRIDRange(start, count); err != nil {
+		return 0, err
+	}
+	a.nextRID = start + uint64(count)
+	return start, nil
+}
+
 func (a *replayInlineAppender) AppendLeafPage(leafPage []byte) (page.LeafLogPtr, error) {
 	if a == nil {
 		return page.LeafLogPtr{}, fmt.Errorf("commitlog: replay value-log appender unavailable")

--- a/TreeDB/db/wal_recovery.go
+++ b/TreeDB/db/wal_recovery.go
@@ -800,16 +800,27 @@ func (a *replayInlineAppender) AppendValues(values [][]byte) ([]page.ValuePtr, e
 	if a == nil {
 		return nil, fmt.Errorf("commitlog: replay value-log appender unavailable")
 	}
+	ptrs := make([]page.ValuePtr, len(values))
+	if len(values) == 0 {
+		return ptrs, nil
+	}
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	ptrs := make([]page.ValuePtr, len(values))
+	if a.writer == nil {
+		return nil, fmt.Errorf("commitlog: replay value-log appender unavailable")
+	}
+	startRID, err := a.reserveAppendRIDsLocked(len(values))
+	if err != nil {
+		return nil, err
+	}
 	for i := range values {
-		ptr, err := a.appendLocked(values[i])
+		ptr, err := a.writer.appendValue(startRID+uint64(i), values[i])
 		if err != nil {
 			return nil, err
 		}
 		ptrs[i] = ptr
 	}
+	a.dirty = true
 	return ptrs, nil
 }
 

--- a/TreeDB/db/wal_recovery.go
+++ b/TreeDB/db/wal_recovery.go
@@ -721,6 +721,7 @@ func commitFenceSatisfied(records []commitlog.Record, ridMap map[uint64]page.Val
 
 type replayInlineAppender struct {
 	mu      sync.Mutex
+	db      *DB
 	writer  *rewriteWriter
 	nextRID uint64
 	dirty   bool
@@ -764,6 +765,7 @@ func newReplayInlineAppender(db *DB, segments []logSegment, ridMap map[uint64]pa
 	writer.blockCodec = valuelogBlockCodecFromDB(db.valueLogBlockCodec)
 	writer.leafBlockCodec = leafPageBlockCodecFromOptions(db.valueLogCompression, db.valueLogAutoPolicy, db.valueLogBlockCodec, db.indexOuterLeavesInValueLog)
 	return &replayInlineAppender{
+		db:      db,
 		writer:  writer,
 		nextRID: maxRID + 1,
 	}, nil
@@ -782,11 +784,10 @@ func (a *replayInlineAppender) appendLocked(value []byte) (page.ValuePtr, error)
 	if a == nil || a.writer == nil {
 		return page.ValuePtr{}, fmt.Errorf("commitlog: replay value-log appender unavailable")
 	}
-	if a.nextRID == 0 {
-		return page.ValuePtr{}, fmt.Errorf("value-log rid space exhausted")
+	rid, err := a.reserveAppendRIDsLocked(1)
+	if err != nil {
+		return page.ValuePtr{}, err
 	}
-	rid := a.nextRID
-	a.nextRID++
 	ptr, err := a.writer.appendValue(rid, value)
 	if err != nil {
 		return page.ValuePtr{}, err
@@ -824,6 +825,10 @@ func (a *replayInlineAppender) ReserveRIDs(count int) (uint64, error) {
 	if a.writer == nil {
 		return 0, fmt.Errorf("commitlog: replay value-log appender unavailable")
 	}
+	return a.reserveLocalRIDsLocked(count)
+}
+
+func (a *replayInlineAppender) reserveLocalRIDsLocked(count int) (uint64, error) {
 	start := a.nextRID
 	if start == 0 {
 		return 0, fmt.Errorf("value-log rid space exhausted")
@@ -835,6 +840,20 @@ func (a *replayInlineAppender) ReserveRIDs(count int) (uint64, error) {
 	return start, nil
 }
 
+// reserveAppendRIDsLocked keeps command-WAL inline leaf/value appends in the
+// same RID namespace as any appender installed after replay, such as cached
+// mode's persistent value-log appender.
+func (a *replayInlineAppender) reserveAppendRIDsLocked(count int) (uint64, error) {
+	if a != nil && a.db != nil {
+		if reserver := a.db.currentValueLogRIDReserver(); reserver != nil {
+			if current, ok := reserver.(*replayInlineAppender); !ok || current != a {
+				return reserver.ReserveRIDs(count)
+			}
+		}
+	}
+	return a.reserveLocalRIDsLocked(count)
+}
+
 func (a *replayInlineAppender) AppendLeafPage(leafPage []byte) (page.LeafLogPtr, error) {
 	if a == nil {
 		return page.LeafLogPtr{}, fmt.Errorf("commitlog: replay value-log appender unavailable")
@@ -844,11 +863,10 @@ func (a *replayInlineAppender) AppendLeafPage(leafPage []byte) (page.LeafLogPtr,
 	if a == nil || a.writer == nil {
 		return page.LeafLogPtr{}, fmt.Errorf("commitlog: replay value-log appender unavailable")
 	}
-	if a.nextRID == 0 {
-		return page.LeafLogPtr{}, fmt.Errorf("value-log rid space exhausted")
+	rid, err := a.reserveAppendRIDsLocked(1)
+	if err != nil {
+		return page.LeafLogPtr{}, err
 	}
-	rid := a.nextRID
-	a.nextRID++
 	leafPtr, err := a.writer.appendLeafPageWithRID(rid, leafPage)
 	if err != nil {
 		return page.LeafLogPtr{}, err

--- a/TreeDB/db/wal_recovery_test.go
+++ b/TreeDB/db/wal_recovery_test.go
@@ -228,6 +228,92 @@ func TestReplayInlineAppender_LeafPagesUseConfiguredLeafLogDir(t *testing.T) {
 	}
 }
 
+type replayInlineRIDReserveTestAppender struct {
+	next  uint64
+	calls []int
+}
+
+func (a *replayInlineRIDReserveTestAppender) AppendValues(values [][]byte) ([]page.ValuePtr, error) {
+	return nil, fmt.Errorf("AppendValues should not be called by stale replay appender")
+}
+
+func (a *replayInlineRIDReserveTestAppender) ReserveRIDs(count int) (uint64, error) {
+	if err := validateRewriteRIDCount(count); err != nil {
+		return 0, err
+	}
+	start := a.next
+	if err := validateRewriteRIDRange(start, count); err != nil {
+		return 0, err
+	}
+	a.next += uint64(count)
+	a.calls = append(a.calls, count)
+	return start, nil
+}
+
+func (a *replayInlineRIDReserveTestAppender) Flush() error { return nil }
+
+func (a *replayInlineRIDReserveTestAppender) Sync() error { return nil }
+
+func (a *replayInlineRIDReserveTestAppender) CurrentValueLogSegment() (string, uint32, bool) {
+	return "", 0, false
+}
+
+func TestReplayInlineAppenderUsesCurrentRIDReserverWhenStaleM12A(t *testing.T) {
+	dir := t.TempDir()
+	if err := ensureStorageLayoutDirs(dir); err != nil {
+		t.Fatalf("ensureStorageLayoutDirs: %v", err)
+	}
+	db := &DB{
+		dir:                 dir,
+		valueLogCompression: ValueLogCompressionOff,
+	}
+	stale, err := newReplayInlineAppender(db, nil, nil)
+	if err != nil {
+		t.Fatalf("newReplayInlineAppender: %v", err)
+	}
+
+	active := &replayInlineRIDReserveTestAppender{next: 100}
+	db.SetValueLogAppender(active)
+
+	if _, err := stale.AppendValues([][]byte{[]byte("retained-value-1"), []byte("retained-value-2")}); err != nil {
+		_ = stale.close()
+		t.Fatalf("AppendValues: %v", err)
+	}
+	if _, err := stale.AppendLeafPage(bytes.Repeat([]byte("l"), page.PageSize)); err != nil {
+		_ = stale.close()
+		t.Fatalf("AppendLeafPage: %v", err)
+	}
+	if err := stale.close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	if got, want := fmt.Sprint(active.calls), "[2 1]"; got != want {
+		t.Fatalf("ReserveRIDs calls=%s want %s", got, want)
+	}
+	valueSegments, err := listSegmentsInDir(ValueLogDirPath(dir))
+	if err != nil {
+		t.Fatalf("list value segments: %v", err)
+	}
+	leafSegments, err := listSegmentsInDir(LeafLogDirPath(dir))
+	if err != nil {
+		t.Fatalf("list leaf segments: %v", err)
+	}
+	ridMap, err := scanValueLogSegments(append(valueSegments, leafSegments...), nil)
+	if err != nil {
+		t.Fatalf("scanValueLogSegments: %v", err)
+	}
+	for _, rid := range []uint64{100, 101, 102} {
+		if _, ok := ridMap[rid]; !ok {
+			t.Fatalf("rid %d missing from stale replay append rid map: %v", rid, ridMap)
+		}
+	}
+	for _, rid := range []uint64{1, 2, 3} {
+		if _, ok := ridMap[rid]; ok {
+			t.Fatalf("stale replay appender used local rid %d instead of active allocator", rid)
+		}
+	}
+}
+
 func TestReplayWALIntoBackend_IgnoresEmptyCommitSegments(t *testing.T) {
 	segments := []logSegment{
 		{path: "/tmp/empty-commit.log", size: 0, valueLog: false},


### PR DESCRIPTION
## Summary

Closes #2357. Parent tracker: #2353.

Dependency status: predecessor #2354 / PR #2367 has merged into `origin/main` as `71202fef3747e6648fe849ff25e1528ee25f3368`; this branch is based on that commit.

- make collection run-table pointerization root-aware so retained payload bodies in the primary root use persistent value-log pointers regardless of the generic inline threshold
- keep the placement policy representation-agnostic (legacy JSON retained bodies now; Template-v1 retained encoding remains owned by #2355)
- let online value-log rewrite share a live value-log appender RID allocator, preventing duplicate RID reuse when command-WAL native-root appends and rewrite run in the same open DB
- keep command-WAL replay leaf/value appends in the current value-log appender RID namespace so cached-mode retained payload pointers do not collide with leaf-log RIDs on reopen
- batch stale replay `AppendValues` RID reservations and cover the stale replay/current allocator path directly
- add retained payload placement tests for reopen durability, GC/rewrite/reopen, and synthetic leaf-log shrinkage

## Tests

Latest local head: `67584df32`.

- `go test ./TreeDB/db -run 'TestReplayInlineAppender|TestCommandWAL' -count=1`
- `go test ./cmd/treedb_collection_demo -run TestReopenReadSmoke -count=1 -v`
- `go test ./TreeDB/collections -run 'TestColumnRetainedPayloadValueLogPlacement' -count=1 -v`
- `go test ./TreeDB/collections ./TreeDB/db ./TreeDB/caching ./cmd/treedb_collection_demo -count=1`

Earlier focused runs:

- `go test ./TreeDB/db -run 'TestValueLogRewrite|TestValueLogGC|TestCommandWAL' -count=1`
- `go test ./TreeDB/caching -run 'Test.*RID|TestValueLog.*RID|TestCached.*RID' -count=1`
- synthetic leaf_vlog shrink retained `18,300` bytes vs row baseline `188,806` bytes (`90.3%` shrink)

## Status

- CI: all checks green on latest head.
- AI review: Codex follow-up review passed on latest head; Copilot follow-up requested; CodeRabbit check completed/skipped due review limits and did not report findings.
- Merge: do not merge from this PR branch yet; handoff only after checks/reviews are clean and explicit approval to merge is given.

## Notes

- No slab path or ephemeral value-store behavior is introduced; retained payload pointers are persistent value-log pointers and remain subject to existing value-log GC/rewrite lifecycle.
- No on-disk format migration is added.
