### PR TITLE
Encode retained payloads with template-v1

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -10077,17 +10077,28 @@ func (c *Collection) insertBatchNoIndex(
 	// base roots before stale-root validation rejects concurrent modifications.
 	defer func() { _ = snap.Close() }()
 
+	var retainedDocuments [][]byte
+	var retainedTemplateRecords []templateV1Record
+	if columnStoreNeedsRetainedPayloadTransform(c.meta) {
+		fullDocuments := make([][]byte, len(entries))
+		for i := range entries {
+			fullDocuments[i] = entries[i].document
+		}
+		prepared, err := prepareColumnRetainedPayloadStorageDocuments(*c.meta.Options.ColumnStore, fullDocuments, columnRetainedPayloadTemplateResolver(snap, catalog))
+		if err != nil {
+			return nil, err
+		}
+		retainedDocuments = prepared.documents
+		retainedTemplateRecords = prepared.templateRecords
+	}
+
 	phaseStart = time.Now()
 	table := newCollectionRunTable(len(entries))
 	var rowRemainderBytes int64
 	for i := range entries {
 		storedDocument := entries[i].document
-		if columnStoreNeedsRetainedPayloadTransform(c.meta) {
-			storedDocument, err = columnRetainedPayloadFromJSONDocument(*c.meta.Options.ColumnStore, entries[i].document)
-			if err != nil {
-				resetCollectionRunTable(table)
-				return nil, err
-			}
+		if retainedDocuments != nil {
+			storedDocument = retainedDocuments[i]
 		}
 		rowRemainderBytes = saturatingAddNonNegativeInt64(rowRemainderBytes, int64(len(entries[i].id)+len(storedDocument)))
 		setCollectionRunValue(table, entries[i].id, storedDocument)
@@ -10108,25 +10119,57 @@ func (c *Collection) insertBatchNoIndex(
 	}()
 
 	publishStart := time.Now()
+	rootNames := []string{rootName}
+	baseRootIDs := map[string]uint64{rootName: baseRoot}
 	ordered := []backenddb.OrderedRootDeltaPublishInput{{
 		BaseRoot:      baseRoot,
 		Iter:          iter,
 		StoragePolicy: plannerOptions.dataStoragePolicy,
 	}}
+	var templateTables []memtable.Table
+	var templateIters []iterator.UnsafeIterator
+	defer func() {
+		for _, it := range templateIters {
+			_ = it.Close()
+		}
+		resetCollectionTables(templateTables)
+	}()
+	if len(retainedTemplateRecords) > 0 {
+		templatePlan := &insertBatchPlan{}
+		if err := (insertBatchPlanner{
+			collection:             c.meta.Name,
+			templateRoot:           collectionTemplateRootName(c.meta.Name),
+			options:                plannerOptions,
+			cloneTemplateRunValues: true,
+		}).emitTemplateRun(templatePlan, retainedTemplateRecords); err != nil {
+			return nil, err
+		}
+		for _, run := range templatePlan.runs {
+			templateTables = append(templateTables, run.table)
+			templateIter := run.table.NewIterator(nil, nil)
+			templateIters = append(templateIters, templateIter)
+			rootNames = append(rootNames, run.name)
+			baseRootIDs[run.name] = catalog.rootID(run.name)
+			ordered = append(ordered, backenddb.OrderedRootDeltaPublishInput{
+				BaseRoot:      catalog.rootID(run.name),
+				Iter:          templateIter,
+				StoragePolicy: run.storagePolicy,
+			})
+		}
+	}
 	var newSystemRoot uint64
 	var rootIDs []uint64
 	if columnStoreWriteEnabled(c.meta) {
 		var publishMeta CollectionMeta
 		var publishRootNames []string
-		columnBaseRootIDs := map[string]uint64{rootName: baseRoot}
 		err = c.withCommandWALPublishCoordinator(func() error {
 			newSystemRoot, rootIDs, publishMeta, publishRootNames, err = c.publishRootDeltaGroupMaybeColumn(ordered, columnWritePublishInput{
 				meta:              c.meta,
 				catalog:           catalog,
 				baseCommitSeq:     baseCommitSeq,
 				baseSystemRoot:    baseSystemRoot,
-				rootNames:         []string{rootName},
-				baseRootIDs:       columnBaseRootIDs,
+				rootNames:         cloneColumnPublishRootNames(rootNames),
+				baseRootIDs:       cloneColumnPublishBaseRootIDs(baseRootIDs),
 				commandWALIntent:  commandWALIntent,
 				operation:         ColumnPublishOperationInsert,
 				documents:         columnWriteDocumentsFromNoIndexEntries(entries),
@@ -10142,7 +10185,7 @@ func (c *Collection) insertBatchNoIndex(
 		if len(rootIDs) != len(publishRootNames) {
 			return nil, unexpectedOrderedRootCountError(c.meta.Name, len(publishRootNames), len(rootIDs))
 		}
-		stats.Runs = 1
+		stats.Runs = len(rootNames)
 		nextCatalog := cloneCatalogWithRootUpdates(catalog, publishMeta, publishRootNames, rootIDs)
 		c.meta = publishMeta
 		c.rememberCatalogAtSystemRoot(newSystemRoot, nextCatalog)
@@ -10151,28 +10194,27 @@ func (c *Collection) insertBatchNoIndex(
 		return maybeInsertBatchResultIDs(resultIDs, execOpts), nil
 	}
 
-	baseRootIDs := map[string]uint64{rootName: baseRoot}
 	if commandWALIntent != nil {
 		err = c.withCommandWALPublishCoordinator(func() error {
 			newSystemRoot, rootIDs, err = c.db.PublishOrderedRootDeltaGroupWithCommandWALAndSystemDeltaBuilder(ordered, commandWALIntent, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
-				return c.buildRootDescriptorSystemDeltaIterator(baseCommitSeq, baseSystemRoot, []string{rootName}, baseRootIDs, rootIDs)
+				return c.buildRootDescriptorSystemDeltaIterator(baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, rootIDs)
 			})
 			return err
 		})
 	} else {
 		newSystemRoot, rootIDs, err = c.db.PublishOrderedRootDeltaGroupWithSystemDeltaBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
-			return c.buildRootDescriptorSystemDeltaIterator(baseCommitSeq, baseSystemRoot, []string{rootName}, baseRootIDs, rootIDs)
+			return c.buildRootDescriptorSystemDeltaIterator(baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, rootIDs)
 		})
 	}
 	stats.Publish = time.Since(publishStart)
 	if err != nil {
 		return nil, err
 	}
-	if len(rootIDs) != 1 {
-		return nil, unexpectedOrderedRootCountError(c.meta.Name, 1, len(rootIDs))
+	if len(rootIDs) != len(rootNames) {
+		return nil, unexpectedOrderedRootCountError(c.meta.Name, len(rootNames), len(rootIDs))
 	}
-	stats.Runs = 1
-	nextCatalog := cloneCatalogWithRootUpdates(catalog, c.meta, []string{rootName}, rootIDs)
+	stats.Runs = len(rootNames)
+	nextCatalog := cloneCatalogWithRootUpdates(catalog, c.meta, rootNames, rootIDs)
 	c.rememberCatalogAtSystemRoot(newSystemRoot, nextCatalog)
 	c.noteWriteDomainCatalog(newSystemRoot, nextCatalog)
 	c.setLastInsertStats(stats)
@@ -13275,6 +13317,20 @@ func (c *Collection) updateDocumentOnceApply(documentID []byte, update func(curr
 	if templateResolver != nil {
 		plannerOptions.templateResolver = templateResolver
 	}
+	var retainedPrimaryDocument []byte
+	if columnStoreNeedsRetainedPayloadTransform(c.meta) {
+		prepared, err := prepareColumnRetainedPayloadStorageDocuments(*c.meta.Options.ColumnStore, [][]byte{document}, columnRetainedPayloadTemplateResolver(snap, catalog))
+		if err != nil {
+			_ = snap.Close()
+			return false, false, err
+		}
+		if len(prepared.documents) != 1 {
+			_ = snap.Close()
+			return false, false, errors.New("collections: update retained payload prepared unexpected document count")
+		}
+		retainedPrimaryDocument = prepared.documents[0]
+		templateRecords = append(templateRecords, prepared.templateRecords...)
+	}
 
 	if len(runtimes) > 0 {
 		phaseStart = updateBatchStatsNow(detailedStats)
@@ -13355,13 +13411,8 @@ func (c *Collection) updateDocumentOnceApply(documentID []byte, update func(curr
 	phaseStart = updateBatchStatsNow(detailedStats)
 	primaryDocument := document
 	var rowRemainderBytes int64
-	if columnStoreNeedsRetainedPayloadTransform(c.meta) {
-		primaryDocument, err = columnRetainedPayloadFromJSONDocument(*c.meta.Options.ColumnStore, document)
-		if err != nil {
-			_ = snap.Close()
-			resetCollectionTables(deltaTables)
-			return false, false, err
-		}
+	if retainedPrimaryDocument != nil {
+		primaryDocument = retainedPrimaryDocument
 	}
 	rowRemainderBytes = int64(len(documentID) + len(primaryDocument))
 	primaryTable := newCollectionRunTable(1)
@@ -15351,15 +15402,24 @@ func (c *Collection) buildUpdateBatchPlan(items []updateBatchItem, mode updateBa
 	if normalizedDocumentFormat(plannerOptions.documentFormat) == DocumentFormatTemplateV1 {
 		templateV1CommandWALDocuments = collectionDocumentsFromBatchUpdateDocuments(changed, changedDocuments)
 	}
+	var retainedPrimaryDocuments [][]byte
+	if columnStoreNeedsRetainedPayloadTransform(meta) {
+		prepared, err := prepareColumnRetainedPayloadStorageDocuments(*meta.Options.ColumnStore, changedDocuments, columnRetainedPayloadTemplateResolver(snap, catalog))
+		if err != nil {
+			_ = snap.Close()
+			return nil, err
+		}
+		if len(prepared.documents) != len(changed) {
+			_ = snap.Close()
+			return nil, errors.New("collections: update batch retained payload prepared unexpected document count")
+		}
+		retainedPrimaryDocuments = prepared.documents
+		templateRecords = append(templateRecords, prepared.templateRecords...)
+	}
 	for i := range changed {
 		changed[i].document = preparedDocuments[i]
-		if columnStoreNeedsRetainedPayloadTransform(meta) {
-			retained, err := columnRetainedPayloadFromJSONDocument(*meta.Options.ColumnStore, changed[i].document)
-			if err != nil {
-				_ = snap.Close()
-				return nil, updateBatchItemError(changed[i].itemIndex, err)
-			}
-			changed[i].primaryDocument = appendUpdateBatchPlanScratchDocument(scratch, retained)
+		if retainedPrimaryDocuments != nil {
+			changed[i].primaryDocument = appendUpdateBatchPlanScratchDocument(scratch, retainedPrimaryDocuments[i])
 			changed[i].hasPrimaryDocument = true
 		}
 		if len(runtimes) > 0 {
@@ -19386,6 +19446,7 @@ func (c *Collection) scanDocumentsFuncWithColumnReconstruction(
 	manifestRootID := catalog.rootID(collectionColumnManifestRootName(catalog.meta.Name))
 	typedScratch := make([]columnDeclaredValue, 0, len(columnStoreTypedColumnPartFields(columnStoreConfig)))
 	mergeScratch := make([]columnDeclaredValue, 0, len(columnStoreConfig.Columns))
+	retainedTemplateResolver := columnRetainedPayloadTemplateResolver(snap, catalog)
 	for _, record := range records {
 		for visiblePos < len(visibleRows) && bytes.Compare(visibleRows[visiblePos].ID, record.ID) < 0 {
 			visiblePos++
@@ -19401,7 +19462,7 @@ func (c *Collection) scanDocumentsFuncWithColumnReconstruction(
 		if err != nil {
 			return false, err
 		}
-		reconstructed, err := reconstructColumnDocumentFromVisibleRowValues(columnStoreConfig, record.Document, visibleRows[visiblePos], fullValues)
+		_, reconstructed, err := reconstructColumnDocumentFromVisibleRowValuesProjectedIntoWithResolver(nil, columnStoreConfig, record.Document, visibleRows[visiblePos], fullValues, nil, nil, retainedTemplateResolver)
 		if err != nil {
 			return false, err
 		}
@@ -20566,7 +20627,7 @@ func findVectorIndex(indexes []VectorIndexDefinition, name string) (VectorIndexD
 
 func collectionRootNames(meta CollectionMeta) []string {
 	out := []string{collectionPrimaryRootName(meta.Name)}
-	if normalizedDocumentFormat(meta.Options.DocumentFormat) == DocumentFormatTemplateV1 {
+	if normalizedDocumentFormat(meta.Options.DocumentFormat) == DocumentFormatTemplateV1 || columnStoreRetainedPayloadUsesTemplateV1(meta.Options.ColumnStore) {
 		out = append(out, collectionTemplateRootName(meta.Name))
 	}
 	if len(meta.Indexes) > 0 && persistIndexStateForDocumentFormat(meta.Options.DocumentFormat) {

--- a/TreeDB/collections/column_physical_query_test.go
+++ b/TreeDB/collections/column_physical_query_test.go
@@ -753,11 +753,12 @@ func TestColumnStoreGetReconstructsRetainedPayloadM13C(t *testing.T) {
 	assertJSONEqualM13C(t, got, []byte(`{"time_us":1,"kind":"like","did":"d1","payload":"alpha","nested":{"keep":true}}`))
 
 	raw := readRawPrimaryDocumentForTestM13C(t, reopen, "events", []byte("e1"))
-	if strings.Contains(string(raw), "time_us") || strings.Contains(string(raw), "kind") || strings.Contains(string(raw), "did") {
-		t.Fatalf("raw retained payload still duplicates declared fields: %s", raw)
+	retainedJSON := readRawRetainedPayloadJSONForTestM13C(t, reopen, "events", raw)
+	if strings.Contains(string(retainedJSON), "time_us") || strings.Contains(string(retainedJSON), "kind") || strings.Contains(string(retainedJSON), "did") {
+		t.Fatalf("raw retained payload still duplicates declared fields: %s", retainedJSON)
 	}
-	if !strings.Contains(string(raw), "payload") {
-		t.Fatalf("raw retained payload lost non-column field: %s", raw)
+	if !strings.Contains(string(retainedJSON), "payload") {
+		t.Fatalf("raw retained payload lost non-column field: %s", retainedJSON)
 	}
 }
 
@@ -1025,11 +1026,44 @@ func TestColumnStoreReconstructionPreservesMissingNullableColumnsM13C(t *testing
 	}
 }
 
-func TestColumnStoreReconstructionFailsClosedOnScalarAncestorM13C(t *testing.T) {
+func TestColumnStoreReconstructionPreservesRetainedJSONNumberLiteralM13C(t *testing.T) {
 	cfg := ColumnStoreConfig{
 		Enabled:         true,
 		RetainedPayload: ColumnRetainedPayloadNonColumn,
 		Reconstruction:  ColumnReconstructionRetainedPayloadAndColumns,
+		Columns: []ColumnStoreColumn{
+			{Name: "time_us", Path: "time_us", ValueType: ColumnStoreValueInt64},
+			{Name: "kind", Path: "kind", ValueType: ColumnStoreValueString},
+			{Name: "did", Path: "did", ValueType: ColumnStoreValueString},
+		},
+	}
+	doc := []byte(`{"time_us":9223372036854775807,"kind":"like","did":"d1","payload_id":9223372036854775806}`)
+	retained, err := columnRetainedPayloadFromJSONDocument(cfg, doc)
+	if err != nil {
+		t.Fatalf("columnRetainedPayloadFromJSONDocument: %v", err)
+	}
+	rows, err := extractColumnDeclaredRowsFromJSONDocuments(cfg, []columnWriteDocument{{
+		ID:       []byte("e1"),
+		Document: doc,
+	}})
+	if err != nil {
+		t.Fatalf("extractColumnDeclaredRowsFromJSONDocuments: %v", err)
+	}
+	got, err := reconstructColumnJSONDocument(cfg, retained, rows[0].Values)
+	if err != nil {
+		t.Fatalf("reconstructColumnJSONDocument: %v", err)
+	}
+	if strings.Contains(string(got), "9.223") || !strings.Contains(string(got), `"payload_id":9223372036854775806`) {
+		t.Fatalf("reconstructed JSON number fidelity lost: %s", got)
+	}
+}
+
+func TestColumnStoreReconstructionFailsClosedOnScalarAncestorM13C(t *testing.T) {
+	cfg := ColumnStoreConfig{
+		Enabled:                 true,
+		RetainedPayload:         ColumnRetainedPayloadNonColumn,
+		RetainedPayloadEncoding: ColumnRetainedPayloadEncodingJSON,
+		Reconstruction:          ColumnReconstructionRetainedPayloadAndColumns,
 		Columns: []ColumnStoreColumn{
 			{Name: "nested", Path: "a.b", ValueType: ColumnStoreValueString, Nullable: true},
 		},
@@ -1095,8 +1129,9 @@ func TestColumnStoreScanDocumentsReconstructsRetainedPayloadM13C(t *testing.T) {
 	assertJSONEqualM13C(t, records[0].Document, []byte(`{"time_us":3,"kind":"share","did":"d1","payload":"alpha2"}`))
 
 	raw := readRawPrimaryDocumentForTestM13C(t, reopen, "events", []byte("e1"))
-	if strings.Contains(string(raw), "time_us") || strings.Contains(string(raw), "kind") || strings.Contains(string(raw), "did") {
-		t.Fatalf("raw retained payload still duplicates declared fields: %s", raw)
+	retainedJSON := readRawRetainedPayloadJSONForTestM13C(t, reopen, "events", raw)
+	if strings.Contains(string(retainedJSON), "time_us") || strings.Contains(string(retainedJSON), "kind") || strings.Contains(string(retainedJSON), "did") {
+		t.Fatalf("raw retained payload still duplicates declared fields: %s", retainedJSON)
 	}
 }
 
@@ -1469,11 +1504,12 @@ func TestColumnStoreRandomizedMutationOracleM13C(t *testing.T) {
 		}
 		assertJSONEqualM13C(t, got, doc.JSON())
 		raw := readRawPrimaryDocumentForTestM13C(t, reopen, "events", []byte(id))
-		if strings.Contains(string(raw), "time_us") || strings.Contains(string(raw), "kind") || strings.Contains(string(raw), "did") {
-			t.Fatalf("raw retained payload for %s duplicates declared fields: %s", id, raw)
+		retainedJSON := readRawRetainedPayloadJSONForTestM13C(t, reopen, "events", raw)
+		if strings.Contains(string(retainedJSON), "time_us") || strings.Contains(string(retainedJSON), "kind") || strings.Contains(string(retainedJSON), "did") {
+			t.Fatalf("raw retained payload for %s duplicates declared fields: %s", id, retainedJSON)
 		}
-		if !strings.Contains(string(raw), "payload") {
-			t.Fatalf("raw retained payload for %s lost retained field: %s", id, raw)
+		if !strings.Contains(string(retainedJSON), "payload") {
+			t.Fatalf("raw retained payload for %s lost retained field: %s", id, retainedJSON)
 		}
 	}
 	result, err := reopened.RunColumnPhysicalQuery(ColumnPhysicalQueryRequest{
@@ -1524,8 +1560,9 @@ func TestColumnStoreReplayReconstructsRetainedPayloadM13C(t *testing.T) {
 	}
 	assertJSONEqualM13C(t, got, []byte(`{"time_us":2,"kind":"share","did":"d1","payload":"beta"}`))
 	raw := readRawPrimaryDocumentForTestM13C(t, reopen, "events", []byte("e1"))
-	if strings.Contains(string(raw), "time_us") || strings.Contains(string(raw), "kind") || strings.Contains(string(raw), "did") || !strings.Contains(string(raw), "payload") {
-		t.Fatalf("replayed raw retained payload=%s, want retained-only payload", raw)
+	retainedJSON := readRawRetainedPayloadJSONForTestM13C(t, reopen, "events", raw)
+	if strings.Contains(string(retainedJSON), "time_us") || strings.Contains(string(retainedJSON), "kind") || strings.Contains(string(retainedJSON), "did") || !strings.Contains(string(retainedJSON), "payload") {
+		t.Fatalf("replayed raw retained payload=%s, want retained-only payload", retainedJSON)
 	}
 	result, err := reopened.RunColumnPhysicalQuery(ColumnPhysicalQueryRequest{Kind: ColumnPhysicalQueryGroupCount, GroupColumn: "kind"})
 	if err != nil {
@@ -1887,6 +1924,32 @@ func readRawPrimaryDocumentForTestM13C(t *testing.T, d *backenddb.DB, collection
 		t.Fatalf("raw primary document %q not found", string(id))
 	}
 	return raw
+}
+
+func readRawRetainedPayloadJSONForTestM13C(t *testing.T, d *backenddb.DB, collection string, raw []byte) []byte {
+	t.Helper()
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatalf("AcquireSnapshot returned nil")
+	}
+	defer func() { _ = snap.Close() }()
+	catalog, err := loadCollectionCatalog(snap, collection)
+	if err != nil {
+		t.Fatalf("loadCollectionCatalog: %v", err)
+	}
+	if catalog == nil {
+		t.Fatalf("collection %q not found", collection)
+	}
+	cfg := catalog.meta.Options.ColumnStore.copy()
+	obj, err := decodeColumnRetainedPayloadObject(cfg, raw, columnRetainedPayloadTemplateResolver(snap, catalog))
+	if err != nil {
+		t.Fatalf("decode raw retained payload: %v raw=%q", err, raw)
+	}
+	out, err := json.Marshal(obj)
+	if err != nil {
+		t.Fatalf("marshal raw retained payload: %v", err)
+	}
+	return out
 }
 
 type columnStoreOracleDocM13C struct {

--- a/TreeDB/collections/column_reconstruction.go
+++ b/TreeDB/collections/column_reconstruction.go
@@ -39,7 +39,7 @@ type columnDocumentReconstructionDiagnostics struct {
 	ReconstructionNanos  int64
 }
 
-func columnRetainedPayloadFromJSONDocument(cfg ColumnStoreConfig, document []byte) ([]byte, error) {
+func columnRetainedPayloadJSONFromJSONDocument(cfg ColumnStoreConfig, document []byte) ([]byte, error) {
 	switch cfg.RetainedPayload {
 	case ColumnRetainedPayloadFull:
 		return bytes.Clone(document), nil
@@ -60,6 +60,72 @@ func columnRetainedPayloadFromJSONDocument(cfg ColumnStoreConfig, document []byt
 		return out, nil
 	default:
 		return nil, fmt.Errorf("collections: unsupported retained payload policy %q", cfg.RetainedPayload)
+	}
+}
+
+func columnRetainedPayloadFromJSONDocument(cfg ColumnStoreConfig, document []byte) ([]byte, error) {
+	retained, err := columnRetainedPayloadJSONFromJSONDocument(cfg, document)
+	if err != nil {
+		return nil, err
+	}
+	if cfg.RetainedPayload == ColumnRetainedPayloadNonColumn && columnRetainedPayloadEffectiveEncoding(&cfg) == ColumnRetainedPayloadEncodingTemplateV1 {
+		encoded, err := EncodeTemplateV1DocumentJSON(retained)
+		if err != nil {
+			return nil, fmt.Errorf("collections: encode template-v1 retained payload: %w", err)
+		}
+		return encoded, nil
+	}
+	return retained, nil
+}
+
+type columnRetainedPayloadStorageDocuments struct {
+	documents       [][]byte
+	templateRecords []templateV1Record
+}
+
+func prepareColumnRetainedPayloadStorageDocuments(cfg ColumnStoreConfig, documents [][]byte, fallback templateV1Resolver) (columnRetainedPayloadStorageDocuments, error) {
+	out := columnRetainedPayloadStorageDocuments{documents: make([][]byte, len(documents))}
+	if len(documents) == 0 {
+		return out, nil
+	}
+	retainedJSON := make([][]byte, len(documents))
+	for i, document := range documents {
+		retained, err := columnRetainedPayloadJSONFromJSONDocument(cfg, document)
+		if err != nil {
+			return columnRetainedPayloadStorageDocuments{}, err
+		}
+		retainedJSON[i] = retained
+	}
+	if cfg.RetainedPayload == ColumnRetainedPayloadNonColumn && columnRetainedPayloadEffectiveEncoding(&cfg) == ColumnRetainedPayloadEncodingTemplateV1 {
+		encoded := make([][]byte, len(retainedJSON))
+		for i, retained := range retainedJSON {
+			next, err := EncodeTemplateV1DocumentJSON(retained)
+			if err != nil {
+				return columnRetainedPayloadStorageDocuments{}, fmt.Errorf("collections: encode template-v1 retained payload: %w", err)
+			}
+			encoded[i] = next
+		}
+		prepared, records, _, _, err := prepareTemplateV1InsertDocuments(encoded, fallback, false, false)
+		if err != nil {
+			return columnRetainedPayloadStorageDocuments{}, fmt.Errorf("collections: prepare template-v1 retained payload: %w", err)
+		}
+		out.documents = prepared
+		out.templateRecords = records
+		return out, nil
+	}
+	out.documents = retainedJSON
+	return out, nil
+}
+
+func columnRetainedPayloadTemplateResolver(snap *backenddb.Snapshot, catalog *collectionCatalog) templateV1Resolver {
+	if snap == nil || catalog == nil || !columnStoreRetainedPayloadUsesTemplateV1(catalog.meta.Options.ColumnStore) {
+		return nil
+	}
+	return &templateV1SnapshotResolver{
+		snap:   snap,
+		rootID: catalog.rootID(collectionTemplateRootName(catalog.meta.Name)),
+		byID:   make(map[uint64]*templateV1Template),
+		byHash: make(map[[32]byte]*templateV1Template),
 	}
 }
 
@@ -118,7 +184,7 @@ func (c *Collection) reconstructColumnDocumentAtSnapshotWithDiagnostics(snap *ba
 	if err != nil {
 		return nil, diag, err
 	}
-	out, err := reconstructColumnDocumentFromVisibleRowValues(cfg, retained, row, fullValues)
+	_, out, err := reconstructColumnDocumentFromVisibleRowValuesProjectedIntoWithResolver(nil, cfg, retained, row, fullValues, nil, nil, columnRetainedPayloadTemplateResolver(snap, catalog))
 	if err != nil {
 		return nil, diag, err
 	}
@@ -148,11 +214,15 @@ func reconstructColumnDocumentFromVisibleRowValuesProjected(cfg ColumnStoreConfi
 }
 
 func reconstructColumnDocumentFromVisibleRowValuesProjectedInto(arena []byte, cfg ColumnStoreConfig, retained []byte, row columnPhysicalVisibleRow, values []columnDeclaredValue, projection *documentProjection, stats *DocumentMaterializationStats) ([]byte, []byte, error) {
+	return reconstructColumnDocumentFromVisibleRowValuesProjectedIntoWithResolver(arena, cfg, retained, row, values, projection, stats, nil)
+}
+
+func reconstructColumnDocumentFromVisibleRowValuesProjectedIntoWithResolver(arena []byte, cfg ColumnStoreConfig, retained []byte, row columnPhysicalVisibleRow, values []columnDeclaredValue, projection *documentProjection, stats *DocumentMaterializationStats, resolver templateV1Resolver) ([]byte, []byte, error) {
 	start := len(arena)
 	if row.Deleted {
 		return arena[:start], nil, errors.New("collections: column reconstruction latest physical row is deleted")
 	}
-	arena, doc, err := reconstructColumnJSONDocumentProjectedInto(arena, cfg, retained, values, projection, stats)
+	arena, doc, err := reconstructColumnJSONDocumentProjectedIntoWithResolver(arena, cfg, retained, values, projection, stats, resolver)
 	if err != nil {
 		return arena[:start], nil, err
 	}
@@ -212,6 +282,42 @@ func mergeColumnReconstructionValuesProjectedInto(cfg ColumnStoreConfig, rowValu
 	return values, nil
 }
 
+func decodeColumnRetainedPayloadObject(cfg ColumnStoreConfig, retained []byte, resolver templateV1Resolver) (map[string]any, error) {
+	trimmed := bytes.TrimSpace(retained)
+	if len(trimmed) == 0 {
+		return make(map[string]any), nil
+	}
+	if cfg.RetainedPayload == ColumnRetainedPayloadNonColumn && columnRetainedPayloadEffectiveEncoding(&cfg) == ColumnRetainedPayloadEncodingTemplateV1 {
+		obj, err := decodeTemplateV1RetainedPayloadObject(trimmed, resolver)
+		if err != nil {
+			return nil, fmt.Errorf("collections: decode template-v1 retained payload: %w", err)
+		}
+		return obj, nil
+	}
+	return decodeColumnJSONObject(trimmed)
+}
+
+func decodeTemplateV1RetainedPayloadObject(retained []byte, resolver templateV1Resolver) (map[string]any, error) {
+	switch {
+	case hasTemplateV1Magic(retained, templateV1StoredMagic):
+		if resolver == nil {
+			return nil, errTemplateV1MissingResolver
+		}
+		return templateV1StoredDocumentObject(retained, resolver)
+	case hasTemplateV1Magic(retained, templateV1InputMagic), hasTemplateV1Magic(retained, templateV1InsertDocumentMagic):
+		prepared, _, _, preparedResolver, err := prepareTemplateV1InsertDocuments([][]byte{retained}, resolver, false, false)
+		if err != nil {
+			return nil, err
+		}
+		if len(prepared) != 1 {
+			return nil, errors.New("collections: template-v1 retained payload prepared unexpected document count")
+		}
+		return templateV1StoredDocumentObject(prepared[0], preparedResolver)
+	default:
+		return nil, errors.New("collections: retained payload is not template-v1 encoded")
+	}
+}
+
 func reconstructColumnJSONDocument(cfg ColumnStoreConfig, retained []byte, values []columnDeclaredValue) ([]byte, error) {
 	return reconstructColumnJSONDocumentProjected(cfg, retained, values, nil, nil)
 }
@@ -222,17 +328,15 @@ func reconstructColumnJSONDocumentProjected(cfg ColumnStoreConfig, retained []by
 }
 
 func reconstructColumnJSONDocumentProjectedInto(arena []byte, cfg ColumnStoreConfig, retained []byte, values []columnDeclaredValue, projection *documentProjection, stats *DocumentMaterializationStats) ([]byte, []byte, error) {
+	return reconstructColumnJSONDocumentProjectedIntoWithResolver(arena, cfg, retained, values, projection, stats, nil)
+}
+
+func reconstructColumnJSONDocumentProjectedIntoWithResolver(arena []byte, cfg ColumnStoreConfig, retained []byte, values []columnDeclaredValue, projection *documentProjection, stats *DocumentMaterializationStats, resolver templateV1Resolver) ([]byte, []byte, error) {
 	start := len(arena)
 	projectionActive := projection.active()
-	var obj map[string]any
-	var err error
-	if len(bytes.TrimSpace(retained)) == 0 {
-		obj = make(map[string]any)
-	} else {
-		obj, err = decodeColumnJSONObject(retained)
-		if err != nil {
-			return arena[:start], nil, err
-		}
+	obj, err := decodeColumnRetainedPayloadObject(cfg, retained, resolver)
+	if err != nil {
+		return arena[:start], nil, err
 	}
 	if len(values) != len(cfg.Columns) {
 		return arena[:start], nil, fmt.Errorf("collections: column reconstruction values=%d columns=%d", len(values), len(cfg.Columns))

--- a/TreeDB/collections/column_retained_payload_audit.go
+++ b/TreeDB/collections/column_retained_payload_audit.go
@@ -50,13 +50,10 @@ type ColumnRetainedPayloadPath struct {
 // are absent from a retained payload body. It fails closed on malformed retained
 // payloads and on any declared path that remains present.
 func AuditColumnRetainedPayloadPathsAbsent(cfg ColumnStoreConfig, retained []byte, paths []string) (ColumnRetainedPayloadPathAudit, error) {
-	return AuditColumnRetainedPayloadPathsAbsentWithResolver(cfg, retained, paths, nil)
+	return auditColumnRetainedPayloadPathsAbsentWithResolver(cfg, retained, paths, nil)
 }
 
-// AuditColumnRetainedPayloadPathsAbsentWithResolver is AuditColumnRetainedPayloadPathsAbsent
-// with an optional Template-v1 resolver for retained payloads stored in the
-// collection template root.
-func AuditColumnRetainedPayloadPathsAbsentWithResolver(cfg ColumnStoreConfig, retained []byte, paths []string, resolver templateV1Resolver) (ColumnRetainedPayloadPathAudit, error) {
+func auditColumnRetainedPayloadPathsAbsentWithResolver(cfg ColumnStoreConfig, retained []byte, paths []string, resolver templateV1Resolver) (ColumnRetainedPayloadPathAudit, error) {
 	policy := columnRetainedPayloadAuditPolicy(&cfg)
 	encoding, status := ColumnRetainedPayloadEncodingStatus(&cfg)
 	audit := ColumnRetainedPayloadPathAudit{

--- a/TreeDB/collections/column_retained_payload_audit.go
+++ b/TreeDB/collections/column_retained_payload_audit.go
@@ -1,38 +1,34 @@
 package collections
 
 import (
-	"bytes"
 	"fmt"
 	"sort"
 	"strings"
 )
 
-const (
-	// ColumnRetainedPayloadEncodingJSON records the current production retained
-	// payload body encoding: retained payloads are stored as JSON objects after
-	// applying the retained-payload policy.
-	ColumnRetainedPayloadEncodingJSON = "json"
-	// ColumnRetainedPayloadEncodingNone records that no retained body is active.
-	ColumnRetainedPayloadEncodingNone = "none"
-)
-
 // ColumnRetainedPayloadEncodingStatus reports the retained payload body encoding
-// currently implied by column-store metadata. It is status/reporting metadata;
-// Template-v1 retained bodies are intentionally deferred to the Template-v1
-// storage implementation issue.
+// currently implied by column-store metadata.
 func ColumnRetainedPayloadEncodingStatus(cfg *ColumnStoreConfig) (encoding, status string) {
 	if cfg == nil || !cfg.Enabled {
-		return ColumnRetainedPayloadEncodingNone, "not_configured"
+		return string(ColumnRetainedPayloadEncodingNone), "not_configured"
 	}
-	switch columnRetainedPayloadAuditPolicy(cfg) {
+	policy := columnRetainedPayloadAuditPolicy(cfg)
+	switch policy {
 	case ColumnRetainedPayloadNone:
-		return ColumnRetainedPayloadEncodingNone, "inactive_no_retained_payload"
-	case ColumnRetainedPayloadNonColumn:
-		return ColumnRetainedPayloadEncodingJSON, "active_json_non_column_retained_payload"
+		return string(ColumnRetainedPayloadEncodingNone), "inactive_no_retained_payload"
 	case ColumnRetainedPayloadFull, "":
-		return ColumnRetainedPayloadEncodingJSON, "active_json_full_retained_payload"
+		return string(ColumnRetainedPayloadEncodingJSON), "active_json_full_retained_payload"
+	case ColumnRetainedPayloadNonColumn:
+		switch cfg.RetainedPayloadEncoding {
+		case ColumnRetainedPayloadEncodingTemplateV1, "":
+			return string(ColumnRetainedPayloadEncodingTemplateV1), "active_template_v1_non_column_retained_payload"
+		case ColumnRetainedPayloadEncodingJSON:
+			return string(ColumnRetainedPayloadEncodingJSON), "active_legacy_json_non_column_retained_payload"
+		default:
+			return string(ColumnRetainedPayloadEncodingUnavailable), fmt.Sprintf("unavailable_unsupported_retained_payload_encoding_%s", cfg.RetainedPayloadEncoding)
+		}
 	default:
-		return ColumnRetainedPayloadEncodingJSON, fmt.Sprintf("unknown_retained_payload_policy_%s", cfg.RetainedPayload)
+		return string(ColumnRetainedPayloadEncodingUnavailable), fmt.Sprintf("unknown_retained_payload_policy_%s", cfg.RetainedPayload)
 	}
 }
 
@@ -52,8 +48,15 @@ type ColumnRetainedPayloadPath struct {
 
 // AuditColumnRetainedPayloadPathsAbsent verifies that declared typed JSON paths
 // are absent from a retained payload body. It fails closed on malformed retained
-// JSON and on any declared path that remains present.
+// payloads and on any declared path that remains present.
 func AuditColumnRetainedPayloadPathsAbsent(cfg ColumnStoreConfig, retained []byte, paths []string) (ColumnRetainedPayloadPathAudit, error) {
+	return AuditColumnRetainedPayloadPathsAbsentWithResolver(cfg, retained, paths, nil)
+}
+
+// AuditColumnRetainedPayloadPathsAbsentWithResolver is AuditColumnRetainedPayloadPathsAbsent
+// with an optional Template-v1 resolver for retained payloads stored in the
+// collection template root.
+func AuditColumnRetainedPayloadPathsAbsentWithResolver(cfg ColumnStoreConfig, retained []byte, paths []string, resolver templateV1Resolver) (ColumnRetainedPayloadPathAudit, error) {
 	policy := columnRetainedPayloadAuditPolicy(&cfg)
 	encoding, status := ColumnRetainedPayloadEncodingStatus(&cfg)
 	audit := ColumnRetainedPayloadPathAudit{
@@ -62,15 +65,8 @@ func AuditColumnRetainedPayloadPathsAbsent(cfg ColumnStoreConfig, retained []byt
 		RetainedPayloadEncodingStatus: status,
 		RetainedPayloadBytes:          len(retained),
 	}
-	if encoding != ColumnRetainedPayloadEncodingJSON && encoding != ColumnRetainedPayloadEncodingNone {
-		return audit, fmt.Errorf("collections: retained payload path audit unsupported encoding %q", encoding)
-	}
 
-	trimmed := bytes.TrimSpace(retained)
-	if len(trimmed) == 0 {
-		trimmed = []byte("{}")
-	}
-	obj, err := decodeColumnJSONObject(trimmed)
+	obj, err := decodeColumnRetainedPayloadObject(cfg, retained, resolver)
 	if err != nil {
 		return audit, fmt.Errorf("collections: retained payload path audit: %w", err)
 	}

--- a/TreeDB/collections/column_retained_payload_audit_test.go
+++ b/TreeDB/collections/column_retained_payload_audit_test.go
@@ -31,7 +31,7 @@ func TestAuditColumnRetainedPayloadPathsAbsentJSONBenchPaths2354(t *testing.T) {
 	if err != nil {
 		t.Fatalf("AuditColumnRetainedPayloadPathsAbsent: %v audit=%+v retained=%s", err, audit, retained)
 	}
-	if audit.RetainedPayloadEncoding != ColumnRetainedPayloadEncodingJSON || audit.RetainedPayloadEncodingStatus == "" {
+	if audit.RetainedPayloadEncoding != string(ColumnRetainedPayloadEncodingTemplateV1) || audit.RetainedPayloadEncodingStatus == "" {
 		t.Fatalf("unexpected encoding status: %+v", audit)
 	}
 	if len(audit.Paths) != 5 {
@@ -45,7 +45,7 @@ func TestAuditColumnRetainedPayloadPathsAbsentJSONBenchPaths2354(t *testing.T) {
 }
 
 func TestAuditColumnRetainedPayloadPathsAbsentFailsClosed2354(t *testing.T) {
-	cfg := ColumnStoreConfig{Enabled: true, RetainedPayload: ColumnRetainedPayloadNonColumn}
+	cfg := ColumnStoreConfig{Enabled: true, RetainedPayload: ColumnRetainedPayloadNonColumn, RetainedPayloadEncoding: ColumnRetainedPayloadEncodingJSON}
 	audit, err := AuditColumnRetainedPayloadPathsAbsent(cfg, []byte(`{"commit":{"operation":"create"},"payload":"kept"}`), []string{"commit.operation"})
 	if err == nil || !strings.Contains(err.Error(), "commit.operation") {
 		t.Fatalf("audit err=%v want commit.operation violation audit=%+v", err, audit)

--- a/TreeDB/collections/column_store.go
+++ b/TreeDB/collections/column_store.go
@@ -123,10 +123,24 @@ const (
 
 type ColumnRetainedPayloadPolicy string
 
+type ColumnRetainedPayloadEncoding string
+
 const (
 	ColumnRetainedPayloadNonColumn ColumnRetainedPayloadPolicy = "non-column"
 	ColumnRetainedPayloadFull      ColumnRetainedPayloadPolicy = "full"
 	ColumnRetainedPayloadNone      ColumnRetainedPayloadPolicy = "none"
+
+	// ColumnRetainedPayloadEncodingJSON records retained payload bodies stored as
+	// JSON objects after applying the retained-payload policy.
+	ColumnRetainedPayloadEncodingJSON = "json"
+	// ColumnRetainedPayloadEncodingTemplateV1 records retained payload bodies
+	// stored as Template-v1 documents with templates in the collection template root.
+	ColumnRetainedPayloadEncodingTemplateV1 = "template-v1"
+	// ColumnRetainedPayloadEncodingNone records that no retained body is active.
+	ColumnRetainedPayloadEncodingNone = "none"
+	// ColumnRetainedPayloadEncodingUnavailable is a reporting sentinel for
+	// unsupported or unrecognized retained-payload encoding metadata.
+	ColumnRetainedPayloadEncodingUnavailable = "unavailable"
 )
 
 type ColumnReconstructionPolicy string
@@ -209,6 +223,7 @@ type ColumnStoreConfig struct {
 	SortKey                                []ColumnSortKey                   `json:"sort_key,omitempty"`
 	AggregateMetadata                      []ColumnAggregateMetadata         `json:"aggregate_metadata,omitempty"`
 	RetainedPayload                        ColumnRetainedPayloadPolicy       `json:"retained_payload,omitempty"`
+	RetainedPayloadEncoding                ColumnRetainedPayloadEncoding     `json:"retained_payload_encoding,omitempty"`
 	Reconstruction                         ColumnReconstructionPolicy        `json:"reconstruction,omitempty"`
 	AssetManager                           *ColumnAssetManagerConfig         `json:"asset_manager,omitempty"`
 	ManifestRoot                           *ColumnManifestRootDescriptor     `json:"manifest_root,omitempty"`
@@ -448,6 +463,9 @@ func normalizeColumnStoreConfig(collection string, in *ColumnStoreConfig) (*Colu
 	if out.RetainedPayload == "" {
 		out.RetainedPayload = ColumnRetainedPayloadNonColumn
 	}
+	if out.RetainedPayloadEncoding == "" {
+		out.RetainedPayloadEncoding = defaultColumnRetainedPayloadEncoding(out.RetainedPayload)
+	}
 	if out.Reconstruction == "" {
 		out.Reconstruction = ColumnReconstructionRetainedPayloadAndColumns
 	}
@@ -518,6 +536,57 @@ func normalizeColumnStoreConfig(collection string, in *ColumnStoreConfig) (*Colu
 	}
 	out.SchemaHash = hashColumnStoreSchema(&out)
 	return &out, nil
+}
+
+func defaultColumnRetainedPayloadEncoding(policy ColumnRetainedPayloadPolicy) ColumnRetainedPayloadEncoding {
+	switch policy {
+	case ColumnRetainedPayloadNone:
+		return ColumnRetainedPayloadEncodingNone
+	case ColumnRetainedPayloadFull:
+		return ColumnRetainedPayloadEncodingJSON
+	case ColumnRetainedPayloadNonColumn:
+		return ColumnRetainedPayloadEncodingTemplateV1
+	default:
+		return ColumnRetainedPayloadEncodingUnavailable
+	}
+}
+
+func validateColumnRetainedPayloadEncoding(policy ColumnRetainedPayloadPolicy, encoding ColumnRetainedPayloadEncoding) error {
+	switch policy {
+	case ColumnRetainedPayloadNone:
+		if encoding == ColumnRetainedPayloadEncodingNone {
+			return nil
+		}
+		return fmt.Errorf("collections: retained payload policy %q requires encoding %q, got %q", policy, ColumnRetainedPayloadEncodingNone, encoding)
+	case ColumnRetainedPayloadFull:
+		if encoding == ColumnRetainedPayloadEncodingJSON {
+			return nil
+		}
+		return fmt.Errorf("collections: retained payload policy %q requires encoding %q, got %q", policy, ColumnRetainedPayloadEncodingJSON, encoding)
+	case ColumnRetainedPayloadNonColumn:
+		switch encoding {
+		case ColumnRetainedPayloadEncodingJSON, ColumnRetainedPayloadEncodingTemplateV1:
+			return nil
+		default:
+			return fmt.Errorf("collections: retained payload policy %q does not support encoding %q", policy, encoding)
+		}
+	default:
+		return fmt.Errorf("collections: unsupported retained payload policy %q", policy)
+	}
+}
+
+func columnRetainedPayloadEffectiveEncoding(cfg *ColumnStoreConfig) ColumnRetainedPayloadEncoding {
+	if cfg == nil {
+		return ColumnRetainedPayloadEncodingNone
+	}
+	if cfg.RetainedPayloadEncoding != "" {
+		return cfg.RetainedPayloadEncoding
+	}
+	return defaultColumnRetainedPayloadEncoding(cfg.RetainedPayload)
+}
+
+func columnStoreRetainedPayloadUsesTemplateV1(cfg *ColumnStoreConfig) bool {
+	return cfg != nil && cfg.Enabled && cfg.RetainedPayload == ColumnRetainedPayloadNonColumn && columnRetainedPayloadEffectiveEncoding(cfg) == ColumnRetainedPayloadEncodingTemplateV1
 }
 
 func validateColumnStoreConfig(collection string, cfg ColumnStoreConfig) error {
@@ -786,6 +855,9 @@ func validateColumnStoreConfig(collection string, cfg ColumnStoreConfig) error {
 	case ColumnRetainedPayloadNonColumn, ColumnRetainedPayloadFull, ColumnRetainedPayloadNone:
 	default:
 		return fmt.Errorf("collections: unsupported retained payload policy %q", cfg.RetainedPayload)
+	}
+	if err := validateColumnRetainedPayloadEncoding(cfg.RetainedPayload, cfg.RetainedPayloadEncoding); err != nil {
+		return err
 	}
 	switch cfg.Reconstruction {
 	case ColumnReconstructionRetainedPayloadAndColumns:
@@ -1155,6 +1227,7 @@ func columnStoreConfigEmpty(cfg ColumnStoreConfig) bool {
 		len(cfg.SortKey) == 0 &&
 		len(cfg.AggregateMetadata) == 0 &&
 		cfg.RetainedPayload == "" &&
+		cfg.RetainedPayloadEncoding == "" &&
 		cfg.Reconstruction == "" &&
 		cfg.AssetManager == nil &&
 		cfg.ManifestRoot == nil &&
@@ -1238,6 +1311,7 @@ func columnStoreConfigEqual(a, b *ColumnStoreConfig) bool {
 	}
 	if a.Enabled != b.Enabled ||
 		a.RetainedPayload != b.RetainedPayload ||
+		a.RetainedPayloadEncoding != b.RetainedPayloadEncoding ||
 		a.Reconstruction != b.Reconstruction ||
 		a.ControlRootStoragePolicy != b.ControlRootStoragePolicy ||
 		a.RecoveryAuthoritativeAppliedCommandLSN != b.RecoveryAuthoritativeAppliedCommandLSN ||
@@ -1308,6 +1382,7 @@ func hashColumnStoreSchema(cfg *ColumnStoreConfig) uint64 {
 	}
 	var d xxhash.Digest
 	writeHashString(&d, string(cfg.RetainedPayload))
+	writeHashString(&d, string(cfg.RetainedPayloadEncoding))
 	writeHashString(&d, string(cfg.Reconstruction))
 	writeHashString(&d, string(cfg.ControlRootStoragePolicy))
 	writeHashString(&d, string(cfg.TypedColumnCompression))

--- a/TreeDB/collections/document_materializer.go
+++ b/TreeDB/collections/document_materializer.go
@@ -924,6 +924,7 @@ func (v *CollectionReadView) fetchColumnStoreDocumentsByRowRef(response Document
 	manifestRootID := v.catalog.rootID(collectionColumnManifestRootName(v.catalog.meta.Name))
 	typedScratch := make([]columnDeclaredValue, 0, len(columnStoreTypedColumnPartFields(cfg)))
 	mergeScratch := make([]columnDeclaredValue, 0, len(cfg.Columns))
+	retainedTemplateResolver := columnRetainedPayloadTemplateResolver(v.snapshot, v.catalog)
 	var rowScratch columnPhysicalRowReaderScratch
 	var documentArena []byte
 	for i := range out.Results {
@@ -968,7 +969,7 @@ func (v *CollectionReadView) fetchColumnStoreDocumentsByRowRef(response Document
 			return out, err
 		}
 		var document []byte
-		documentArena, document, err = reconstructColumnDocumentFromVisibleRowValuesProjectedInto(documentArena, cfg, retained[i], row, fullValues, projection, &out.Stats)
+		documentArena, document, err = reconstructColumnDocumentFromVisibleRowValuesProjectedIntoWithResolver(documentArena, cfg, retained[i], row, fullValues, projection, &out.Stats, retainedTemplateResolver)
 		if err != nil {
 			return out, err
 		}
@@ -1028,6 +1029,7 @@ func (v *CollectionReadView) fetchColumnStoreDocumentsByID(response DocumentFetc
 	manifestRootID := v.catalog.rootID(collectionColumnManifestRootName(v.catalog.meta.Name))
 	typedScratch := make([]columnDeclaredValue, 0, len(columnStoreTypedColumnPartFields(cfg)))
 	mergeScratch := make([]columnDeclaredValue, 0, len(cfg.Columns))
+	retainedTemplateResolver := columnRetainedPayloadTemplateResolver(v.snapshot, v.catalog)
 	var documentArena []byte
 	for i := range out.Results {
 		if !out.Results[i].Found {
@@ -1072,7 +1074,7 @@ func (v *CollectionReadView) fetchColumnStoreDocumentsByID(response DocumentFetc
 			return out, err
 		}
 		var document []byte
-		documentArena, document, err = reconstructColumnDocumentFromVisibleRowValuesProjectedInto(documentArena, cfg, retained[i], row, fullValues, projection, &out.Stats)
+		documentArena, document, err = reconstructColumnDocumentFromVisibleRowValuesProjectedIntoWithResolver(documentArena, cfg, retained[i], row, fullValues, projection, &out.Stats, retainedTemplateResolver)
 		if err != nil {
 			return out, err
 		}

--- a/TreeDB/collections/template_v1.go
+++ b/TreeDB/collections/template_v1.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"math"
 	"slices"
 	"sort"
@@ -32,6 +33,7 @@ const (
 	templateV1KindString
 	templateV1KindObject
 	templateV1KindArray
+	templateV1KindJSONNumber
 
 	templateV1MaxArrayElements uint64 = 1 << 20
 	templateV1ArrayPreallocCap        = 4096
@@ -960,8 +962,17 @@ func (e *TemplateV1Encoder) encodeStoredDocumentWithLearnedTemplates(root []byte
 }
 
 func EncodeTemplateV1DocumentJSON(raw []byte) ([]byte, error) {
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
 	var decoded any
-	if err := json.Unmarshal(raw, &decoded); err != nil {
+	if err := decoder.Decode(&decoded); err != nil {
+		return nil, fmt.Errorf("collections: template-v1 JSON input: %w", err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		if err == nil {
+			err = errors.New("trailing JSON value")
+		}
 		return nil, fmt.Errorf("collections: template-v1 JSON input: %w", err)
 	}
 	obj, ok := decoded.(map[string]any)
@@ -972,6 +983,18 @@ func EncodeTemplateV1DocumentJSON(raw []byte) ([]byte, error) {
 }
 
 func templateV1StoredDocumentJSON(raw []byte, resolver templateV1Resolver) ([]byte, error) {
+	obj, err := templateV1StoredDocumentObject(raw, resolver)
+	if err != nil {
+		return nil, err
+	}
+	out, err := json.Marshal(obj)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func templateV1StoredDocumentObject(raw []byte, resolver templateV1Resolver) (map[string]any, error) {
 	root, err := parseTemplateV1StoredDocument(raw)
 	if err != nil {
 		return nil, err
@@ -984,11 +1007,7 @@ func templateV1StoredDocumentJSON(raw []byte, resolver templateV1Resolver) ([]by
 	if pos != len(root.values) {
 		return nil, errors.New("collections: trailing template-v1 object values")
 	}
-	out, err := json.Marshal(obj)
-	if err != nil {
-		return nil, err
-	}
-	return out, nil
+	return obj, nil
 }
 
 func decodeTemplateV1ObjectFields(id uint64, raw []byte, pos *int, resolver templateV1Resolver) (map[string]any, error) {
@@ -1030,6 +1049,8 @@ func decodeTemplateV1Value(raw []byte, pos *int, resolver templateV1Resolver) (a
 		v := math.Float64frombits(binary.BigEndian.Uint64(raw[*pos:]))
 		*pos += 8
 		return v, nil
+	case templateV1KindJSONNumber:
+		return readTemplateV1JSONNumber(raw, pos)
 	case templateV1KindString:
 		n, err := readTemplateV1Uvarint(raw, pos)
 		if err != nil {
@@ -1217,6 +1238,11 @@ func (s *templateV1BuildState) appendKnownIDValue(dst []byte, raw []byte, pos *i
 		}
 		*pos += 8
 		return append(dst, raw[start:*pos]...), nil
+	case templateV1KindJSONNumber:
+		if _, err := readTemplateV1JSONNumber(raw, pos); err != nil {
+			return nil, err
+		}
+		return append(dst, raw[start:*pos]...), nil
 	case templateV1KindString:
 		n, err := readTemplateV1Uvarint(raw, pos)
 		if err != nil {
@@ -1375,6 +1401,58 @@ func (s *templateV1BuildState) appendObjectValue(dst []byte, obj map[string]any)
 	return dst, nil
 }
 
+func appendTemplateV1JSONNumber(dst []byte, n json.Number) ([]byte, error) {
+	if err := validateTemplateV1JSONNumber(n); err != nil {
+		return nil, err
+	}
+	literal := n.String()
+	dst = append(dst, templateV1KindJSONNumber)
+	dst = appendTemplateV1Uvarint(dst, uint64(len(literal)))
+	return append(dst, literal...), nil
+}
+
+func validateTemplateV1JSONNumber(n json.Number) error {
+	if n.String() == "" {
+		return errors.New("collections: empty template-v1 JSON number")
+	}
+	if _, err := json.Marshal(n); err != nil {
+		return fmt.Errorf("collections: invalid template-v1 JSON number %q: %w", n.String(), err)
+	}
+	return nil
+}
+
+func readTemplateV1JSONNumber(raw []byte, pos *int) (json.Number, error) {
+	n, err := readTemplateV1Uvarint(raw, pos)
+	if err != nil {
+		return "", err
+	}
+	if n > uint64(len(raw)-*pos) {
+		return "", errors.New("collections: malformed template-v1 JSON number")
+	}
+	valueEnd := *pos + int(n)
+	value := json.Number(string(raw[*pos:valueEnd]))
+	*pos = valueEnd
+	if err := validateTemplateV1JSONNumber(value); err != nil {
+		return "", err
+	}
+	return value, nil
+}
+
+func templateV1JSONNumberString(raw []byte) (string, bool, error) {
+	if len(raw) == 0 || raw[0] != templateV1KindJSONNumber {
+		return "", false, nil
+	}
+	pos := 1
+	n, err := readTemplateV1JSONNumber(raw, &pos)
+	if err != nil {
+		return "", true, err
+	}
+	if pos != len(raw) {
+		return "", true, errors.New("collections: trailing template-v1 JSON number bytes")
+	}
+	return n.String(), true, nil
+}
+
 func (s *templateV1BuildState) appendValue(dst []byte, value any) ([]byte, error) {
 	switch v := value.(type) {
 	case nil:
@@ -1394,17 +1472,13 @@ func (s *templateV1BuildState) appendValue(dst []byte, value any) ([]byte, error
 		binary.BigEndian.PutUint64(scratch[:], math.Float64bits(v))
 		return append(dst, scratch[:]...), nil
 	case int:
-		return s.appendValue(dst, float64(v))
+		return appendTemplateV1JSONNumber(dst, json.Number(strconv.FormatInt(int64(v), 10)))
 	case int64:
-		return s.appendValue(dst, float64(v))
+		return appendTemplateV1JSONNumber(dst, json.Number(strconv.FormatInt(v, 10)))
 	case uint64:
-		return s.appendValue(dst, float64(v))
+		return appendTemplateV1JSONNumber(dst, json.Number(strconv.FormatUint(v, 10)))
 	case json.Number:
-		f, err := strconv.ParseFloat(string(v), 64)
-		if err != nil {
-			return nil, err
-		}
-		return s.appendValue(dst, f)
+		return appendTemplateV1JSONNumber(dst, v)
 	case []any:
 		dst = append(dst, templateV1KindArray)
 		dst = appendTemplateV1Uvarint(dst, uint64(len(v)))
@@ -1620,6 +1694,11 @@ func templateV1ValueNeedsHashConversion(raw []byte, pos *int) (bool, error) {
 		}
 		*pos += 8
 		return false, nil
+	case templateV1KindJSONNumber:
+		if _, err := readTemplateV1JSONNumber(raw, pos); err != nil {
+			return false, err
+		}
+		return false, nil
 	case templateV1KindString:
 		n, err := readTemplateV1Uvarint(raw, pos)
 		if err != nil {
@@ -1667,6 +1746,11 @@ func appendTemplateV1ConvertedValue(dst []byte, raw []byte, pos *int, resolver t
 			return nil, learned, errors.New("collections: malformed template-v1 number")
 		}
 		*pos += 8
+		return append(dst, raw[start:*pos]...), learned, nil
+	case templateV1KindJSONNumber:
+		if _, err := readTemplateV1JSONNumber(raw, pos); err != nil {
+			return nil, learned, err
+		}
 		return append(dst, raw[start:*pos]...), learned, nil
 	case templateV1KindString:
 		n, err := readTemplateV1Uvarint(raw, pos)
@@ -1819,6 +1903,11 @@ func appendTemplateV1RootFieldIndexValues(state orderedDocumentIndexState, field
 			return errors.New("collections: malformed template-v1 number")
 		}
 		*pos += 8
+		return appendTemplateV1RawIndexValueToRootStates(state, field, firstRuntimeIdx, runtimes, raw[valueStart:*pos], opts, encoder)
+	case templateV1KindJSONNumber:
+		if _, err := readTemplateV1JSONNumber(raw, pos); err != nil {
+			return err
+		}
 		return appendTemplateV1RawIndexValueToRootStates(state, field, firstRuntimeIdx, runtimes, raw[valueStart:*pos], opts, encoder)
 	case templateV1KindString:
 		n, err := readTemplateV1Uvarint(raw, pos)
@@ -2097,25 +2186,49 @@ func appendTemplateV1IndexScalar(dst []byte, valueType IndexValueType, raw []byt
 			return dst, nil, fmt.Errorf("collections: indexed template-v1 value for type %q must be bool, got kind %d", valueType, raw[0])
 		}
 	case IndexValueInt64:
-		if raw[0] != templateV1KindFloat64 {
+		switch raw[0] {
+		case templateV1KindFloat64:
+			if len(raw) != 1+8 {
+				return dst, nil, errors.New("collections: malformed template-v1 number")
+			}
+			i, err := exactFloat64AsInt64(math.Float64frombits(binary.BigEndian.Uint64(raw[1:])))
+			if err != nil {
+				return dst, nil, err
+			}
+			dst = appendIndexInt64Component(dst, i)
+		case templateV1KindJSONNumber:
+			literal, ok, err := templateV1JSONNumberString(raw)
+			if err != nil || !ok {
+				return dst, nil, err
+			}
+			i, err := parseJSONInt64IndexValue(literal)
+			if err != nil {
+				return dst, nil, err
+			}
+			dst = appendIndexInt64Component(dst, i)
+		default:
 			return dst, nil, fmt.Errorf("collections: indexed template-v1 value for type %q must be number, got kind %d", valueType, raw[0])
 		}
-		if len(raw) != 1+8 {
-			return dst, nil, errors.New("collections: malformed template-v1 number")
-		}
-		i, err := exactFloat64AsInt64(math.Float64frombits(binary.BigEndian.Uint64(raw[1:])))
-		if err != nil {
-			return dst, nil, err
-		}
-		dst = appendIndexInt64Component(dst, i)
 	case IndexValueDouble:
-		if raw[0] != templateV1KindFloat64 {
+		switch raw[0] {
+		case templateV1KindFloat64:
+			if len(raw) != 1+8 {
+				return dst, nil, errors.New("collections: malformed template-v1 number")
+			}
+			dst = appendIndexDoubleComponent(dst, math.Float64frombits(binary.BigEndian.Uint64(raw[1:])))
+		case templateV1KindJSONNumber:
+			literal, ok, err := templateV1JSONNumberString(raw)
+			if err != nil || !ok {
+				return dst, nil, err
+			}
+			d, err := parseJSONDoubleIndexValue(literal)
+			if err != nil {
+				return dst, nil, err
+			}
+			dst = appendIndexDoubleComponent(dst, d)
+		default:
 			return dst, nil, fmt.Errorf("collections: indexed template-v1 value for type %q must be number, got kind %d", valueType, raw[0])
 		}
-		if len(raw) != 1+8 {
-			return dst, nil, errors.New("collections: malformed template-v1 number")
-		}
-		dst = appendIndexDoubleComponent(dst, math.Float64frombits(binary.BigEndian.Uint64(raw[1:])))
 	default:
 		return dst, nil, fmt.Errorf("collections: unsupported index value type %q", valueType)
 	}
@@ -2137,6 +2250,9 @@ func skipTemplateV1Value(raw []byte, pos *int, resolver templateV1Resolver) erro
 		}
 		*pos += 8
 		return nil
+	case templateV1KindJSONNumber:
+		_, err := readTemplateV1JSONNumber(raw, pos)
+		return err
 	case templateV1KindString:
 		n, err := readTemplateV1Uvarint(raw, pos)
 		if err != nil {

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -331,7 +331,7 @@ type typedStorageLegacyNameAllowlistEntry struct {
 }
 
 var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
-	{path: "TreeDB/collections/api.go", classification: typedStorageLegacyCompatibility, matchingLines: 45, occurrences: 51},
+	{path: "TreeDB/collections/api.go", classification: typedStorageLegacyCompatibility, matchingLines: 46, occurrences: 52},
 	{path: "TreeDB/collections/column_aggregate_metadata_asset.go", classification: typedStorageLegacyDerived, matchingLines: 16, occurrences: 19},
 	{path: "TreeDB/collections/column_aggregate_metadata_predicate.go", classification: typedStorageLegacyDerived, matchingLines: 6, occurrences: 6},
 	{path: "TreeDB/collections/column_aggregate_metadata_predicate_1951_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 15, occurrences: 16},
@@ -364,7 +364,7 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/column_physical_typed_column_1947_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 15, occurrences: 16},
 	{path: "TreeDB/collections/column_physical_typed_column_query.go", classification: typedStorageLegacyCompatibility, matchingLines: 21, occurrences: 21},
 	{path: "TreeDB/collections/column_physical_typed_column_sortkey_1948_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 51, occurrences: 59},
-	{path: "TreeDB/collections/column_physical_query_test.go", classification: typedStorageLegacyDeferred, matchingLines: 168, occurrences: 191},
+	{path: "TreeDB/collections/column_physical_query_test.go", classification: typedStorageLegacyDeferred, matchingLines: 175, occurrences: 198},
 	{path: "TreeDB/collections/column_physical_row_reader.go", classification: typedStorageLegacyDeferred, matchingLines: 39, occurrences: 64},
 	{path: "TreeDB/collections/column_physical_row_reader_test.go", classification: typedStorageLegacyDeferred, matchingLines: 24, occurrences: 27},
 	{path: "TreeDB/collections/column_physical_scan.go", classification: typedStorageLegacyDeferred, matchingLines: 50, occurrences: 61},
@@ -378,9 +378,9 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/column_publish_write_path_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 163, occurrences: 183},
 	{path: "TreeDB/collections/column_query_plan.go", classification: typedStorageLegacyCompatibility, matchingLines: 43, occurrences: 43},
 	{path: "TreeDB/collections/column_query_plan_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 56, occurrences: 68},
-	{path: "TreeDB/collections/column_reconstruction.go", classification: typedStorageLegacyCompatibility, matchingLines: 50, occurrences: 65},
+	{path: "TreeDB/collections/column_reconstruction.go", classification: typedStorageLegacyCompatibility, matchingLines: 56, occurrences: 71},
 	{path: "TreeDB/collections/column_reconstruction_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 27, occurrences: 31},
-	{path: "TreeDB/collections/column_retained_payload_audit.go", classification: typedStorageLegacyCompatibility, matchingLines: 4, occurrences: 4},
+	{path: "TreeDB/collections/column_retained_payload_audit.go", classification: typedStorageLegacyCompatibility, matchingLines: 5, occurrences: 5},
 	{path: "TreeDB/collections/column_retained_payload_audit_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 9, occurrences: 9},
 	{path: "TreeDB/collections/column_semantics.go", classification: typedStorageLegacyCompatibility, matchingLines: 34, occurrences: 34},
 	{path: "TreeDB/collections/dense_numeric_vector.go", classification: typedStorageLegacyCompatibility, matchingLines: 32, occurrences: 41},
@@ -391,7 +391,7 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/quantized_asset_reopen_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 6, occurrences: 6},
 	{path: "TreeDB/collections/column_vector_graph_quantized_asset_test.go", classification: typedStorageLegacyDerived, matchingLines: 3, occurrences: 4},
 	{path: "TreeDB/collections/column_vector_graph_quantized_bench_test.go", classification: typedStorageLegacyDerived, matchingLines: 1, occurrences: 2},
-	{path: "TreeDB/collections/column_store.go", classification: typedStorageLegacyCompatibility, matchingLines: 129, occurrences: 233},
+	{path: "TreeDB/collections/column_store.go", classification: typedStorageLegacyCompatibility, matchingLines: 131, occurrences: 235},
 	{path: "TreeDB/collections/column_store_compaction.go", classification: typedStorageLegacyCompatibility, matchingLines: 34, occurrences: 41},
 	{path: "TreeDB/collections/column_store_compaction_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 71, occurrences: 82},
 	{path: "TreeDB/collections/column_store_compatibility_api_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 7, occurrences: 9},

--- a/cmd/unified_bench/suite_column_store_test.go
+++ b/cmd/unified_bench/suite_column_store_test.go
@@ -33,8 +33,12 @@ func TestColumnStoreSuiteRetainedPayloadPreservesJSONNumbersM13C(t *testing.T) {
 	if bytes.Contains(retained, []byte("9.223")) {
 		t.Fatalf("retained payload used floating/scientific notation: %s", retained)
 	}
-	if !bytes.Contains(retained, []byte(`"payload_id":9223372036854775806`)) {
+	if !bytes.Contains(retained, []byte(`9223372036854775806`)) {
 		t.Fatalf("retained payload lost integer fidelity: %s", retained)
+	}
+	audit, err := collections.AuditColumnRetainedPayloadPathsAbsent(*cfg, retained, []string{"time_us", "kind", "did"})
+	if err != nil {
+		t.Fatalf("retained payload path audit: %v audit=%+v retained=%s", err, audit, retained)
 	}
 	if bytes.Contains(retained, []byte("time_us")) || bytes.Contains(retained, []byte("kind")) || bytes.Contains(retained, []byte("did")) {
 		t.Fatalf("retained payload still contains declared columns: %s", retained)


### PR DESCRIPTION
Closes #2355.
Parent tracker: #2353.
Depends on #2354, merged as `71202fef3747e6648fe849ff25e1528ee25f3368`.

## Summary

- Adds an explicit retained payload encoding contract for collection column-store configs: `json`, `template-v1`, `none`, and `unavailable`.
- Defaults `retained_payload_policy=non-column` to Template-v1 retained encoding while preserving JSON retained payloads for full-retained and no retained payload for `none`.
- Encodes non-column retained JSON through Template-v1, stores/publishes the template records durably, and reconstructs canonical documents through the Template-v1 snapshot resolver plus typed columns.
- Updates retained payload path audits so Template-v1 retained payloads are decoded through the production decoder before path absence is asserted.
- Preserves JSON numeric literals in Template-v1 retained payloads with a `json.Number` record kind, avoiding float64 coercion during reconstruction.

## Scope Boundary

This PR changes the column-store retained payload format for the production candidate layout. TreeDB is pre-alpha, so no old-DB migration scaffolding is included. Storage measurement is intentionally deferred to the dependent placement/compression work (#2357, #2356) and the final evidence refresh (#2359), because this PR establishes the retained encoding contract but does not yet remove retained bodies from `leaf_vlog` or add the final retained compression policy.

## Tests

- `go test ./TreeDB/collections -run 'TestAuditColumnRetainedPayloadPathsAbsentJSONBenchPaths2354|TestColumnStoreGetReconstructsRetainedPayloadM13C|TestColumnStoreScanDocumentsReconstructsRetainedPayloadM13C|TestColumnStoreReplayReconstructsRetainedPayloadM13C|TestTemplateV1RejectsOversizedArrayCount|TestColumnStoreReconstructionPreservesMissingNullableColumnsM13C|TestColumnStoreRandomizedMutationOracleM13C' -count=1`
- `go test ./cmd/unified_bench -run TestColumnStoreSuiteRetainedPayloadPreservesJSONNumbersM13C -count=1`
- `go test ./TreeDB/collections -run 'TestColumnStoreReconstructionPreservesRetainedJSONNumberLiteralM13C|TestColumnStoreReconstructionPreservesMissingNullableColumnsM13C|TestAuditColumnRetainedPayloadPathsAbsentJSONBenchPaths2354' -count=1`
- `python3 scripts/treedb_jsonbench_storage_audit_test.py`
- `go test ./cmd/unified_bench -count=1`
- `go test ./TreeDB/collections -run TestTypedStorageLegacyNameAllowlistIsComplete -count=1`
- `go test ./TreeDB/collections -count=1`

## Known Caveats

- Does not claim final JSONBench storage parity by itself.
- Does not yet force retained payload bodies out of `leaf_vlog`; that is #2357.
- Does not yet land the storage-first retained value-log compression policy; that is #2356.
