### PR TITLE
TreeDB vector API: cache collection buffered search pack

### DIFF
--- a/TreeDB/README.md
+++ b/TreeDB/README.md
@@ -199,8 +199,9 @@ production rows include
 `BenchmarkCollectionVectorUSearchProductionCompare/TreeDB_CollectionSearchVectorIndexNoDocsOneShot`
 as the current collection-level one-shot baseline,
 `.../TreeDB_CollectionSearchVectorIndexWithBuffer` as the collection-level
-caller-owned result-buffer seam with per-call open still inside the timed
-boundary, plus `.../TreeDB_SearchWithBuffer*` versus `.../USearch_Search*`:
+caller-owned result-buffer seam on a warmed collection-owned prepared cache
+(`open_searcher_calls/op=0`, `open_setup_in_timed_loop=0` in the timed loop),
+plus `.../TreeDB_SearchWithBuffer*` versus `.../USearch_Search*`:
 TreeDB's high-QPS comparison uses persisted `column_graph` through
 `Collection.OpenVectorIndexSearcher` plus `VectorIndexSearcher.SearchWithBuffer`
 with one searcher and one reusable buffer per worker, while USearch is a pure

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -380,6 +380,16 @@ type Collection struct {
 	vectorPreparedSearchMisses uint64
 	vectorPreparedSearchWaits  uint64
 	vectorPreparedSearchBuilds uint64
+
+	vectorBufferedSearchMu            sync.Mutex
+	vectorBufferedSearch              map[string]*collectionVectorIndexPreparedSearchCacheEntry
+	vectorBufferedSearchHits          uint64
+	vectorBufferedSearchMisses        uint64
+	vectorBufferedSearchWaits         uint64
+	vectorBufferedSearchBuilds        uint64
+	vectorBufferedSearchInvalidations uint64
+	vectorBufferedSearchCloses        uint64
+	vectorBufferedSearchErrors        uint64
 }
 
 type CollectionRootOverlayCompactionStats struct {
@@ -1266,7 +1276,9 @@ func (m *CollectionManager) closeForBackend() error {
 		}
 	}()
 	m.stopUpdateCombiners()
-	return m.FlushAll()
+	cacheErr := m.closeCollectionVectorIndexPreparedSearchCaches()
+	flushErr := m.FlushAll()
+	return errors.Join(cacheErr, flushErr)
 }
 
 func (m *CollectionManager) isClosing() bool {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3011,6 +3011,23 @@ func (m *CollectionManager) registerCollectionHandle(collection *Collection) {
 	}
 	m.collectionsMu.Lock()
 	defer m.collectionsMu.Unlock()
+	m.registerCollectionHandleLocked(collection)
+}
+
+func (m *CollectionManager) registerCollectionHandleIfOpen(collection *Collection) bool {
+	if m == nil || collection == nil {
+		return false
+	}
+	m.collectionsMu.Lock()
+	defer m.collectionsMu.Unlock()
+	if m.isClosing() {
+		return false
+	}
+	m.registerCollectionHandleLocked(collection)
+	return true
+}
+
+func (m *CollectionManager) registerCollectionHandleLocked(collection *Collection) {
 	if m.collections == nil {
 		m.collections = make(map[*Collection]struct{})
 	}

--- a/TreeDB/collections/collection_vector_index_prepared_search_cache.go
+++ b/TreeDB/collections/collection_vector_index_prepared_search_cache.go
@@ -151,6 +151,9 @@ func (c *Collection) acquireCollectionVectorIndexPreparedSearch(opts VectorIndex
 		entry.response = buildResponse
 		entry.err = buildErr
 
+		if buildErr == nil && c.manager != nil && !c.manager.registerCollectionHandleIfOpen(c) {
+			buildErr = backenddb.ErrClosed
+		}
 		stored := false
 		c.vectorBufferedSearchMu.Lock()
 		closing := buildErr == nil && ((c.manager != nil && c.manager.isClosing()) || c.db == nil || c.db.IsClosing())
@@ -175,9 +178,6 @@ func (c *Collection) acquireCollectionVectorIndexPreparedSearch(opts VectorIndex
 		}
 		if buildErr != nil {
 			return nil, buildResponse, buildErr
-		}
-		if stored && c.manager != nil {
-			c.manager.registerCollectionHandle(c)
 		}
 		return prepared, buildResponse, nil
 	}

--- a/TreeDB/collections/collection_vector_index_prepared_search_cache.go
+++ b/TreeDB/collections/collection_vector_index_prepared_search_cache.go
@@ -153,6 +153,10 @@ func (c *Collection) acquireCollectionVectorIndexPreparedSearch(opts VectorIndex
 
 		stored := false
 		c.vectorBufferedSearchMu.Lock()
+		closing := buildErr == nil && ((c.manager != nil && c.manager.isClosing()) || c.db == nil || c.db.IsClosing())
+		if closing {
+			buildErr = backenddb.ErrClosed
+		}
 		entry.prepared = prepared
 		entry.building = false
 		if c.vectorBufferedSearch[opts.IndexName] == entry {

--- a/TreeDB/collections/collection_vector_index_prepared_search_cache.go
+++ b/TreeDB/collections/collection_vector_index_prepared_search_cache.go
@@ -1,0 +1,511 @@
+package collections
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/internal/mappedresource"
+)
+
+type collectionVectorIndexPreparedSearchCacheEntry struct {
+	ready      chan struct{}
+	building   bool
+	commitSeq  uint64
+	systemRoot uint64
+	prepared   *collectionVectorIndexPreparedSearch
+	response   VectorIndexSearchResponse
+	err        error
+}
+
+type collectionVectorIndexPreparedSearch struct {
+	mu sync.RWMutex
+
+	key        string
+	indexName  string
+	commitSeq  uint64
+	systemRoot uint64
+	response   VectorIndexSearchResponse
+
+	pack       *columnHNSWSearchPackPreparedView
+	packStatus columnHNSWSearchPackPreparedStatus
+	routeStats vectorIndexSearchRouteStats
+	closed     bool
+}
+
+type collectionVectorIndexPreparedSearchCacheSnapshot struct {
+	Entries                    int
+	BuildingEntries            int
+	ActiveHandles              int64
+	ActiveMappedBytes          int64
+	ActiveHeapCopyBytes        int64
+	ActiveDerivedMetadataBytes int64
+	CacheHits                  uint64
+	CacheMisses                uint64
+	CacheWaits                 uint64
+	CacheBuilds                uint64
+	Invalidations              uint64
+	Closes                     uint64
+	Errors                     uint64
+}
+
+var collectionVectorIndexPreparedSearchBuildHookForTest struct {
+	mu sync.Mutex
+	fn func(indexName string)
+}
+
+func callCollectionVectorIndexPreparedSearchBuildHookForTest(indexName string) {
+	collectionVectorIndexPreparedSearchBuildHookForTest.mu.Lock()
+	hook := collectionVectorIndexPreparedSearchBuildHookForTest.fn
+	collectionVectorIndexPreparedSearchBuildHookForTest.mu.Unlock()
+	if hook != nil {
+		hook(indexName)
+	}
+}
+
+func (c *Collection) acquireCollectionVectorIndexPreparedSearch(opts VectorIndexSearchOptions) (*collectionVectorIndexPreparedSearch, VectorIndexSearchResponse, error) {
+	var response VectorIndexSearchResponse
+	if err := ValidateIndexName(opts.IndexName); err != nil {
+		return nil, response, err
+	}
+	if opts.MaxDecodedBlocks < 0 {
+		return nil, response, errors.New("collections: vector index search max_decoded_blocks cannot be negative")
+	}
+	if c == nil {
+		return nil, response, errCollectionNil
+	}
+	if c.db == nil {
+		return nil, response, errCollectionDBNil
+	}
+	if c.manager != nil && c.manager.isClosing() {
+		return nil, response, backenddb.ErrClosed
+	}
+	commitSeq, systemRoot := dbCommitSeqAndSystemRoot(c.db)
+	if commitSeq == 0 || systemRoot == 0 || c.db.IsClosing() {
+		return nil, response, backenddb.ErrClosed
+	}
+
+	for {
+		var oldPrepared *collectionVectorIndexPreparedSearch
+		c.vectorBufferedSearchMu.Lock()
+		if c.vectorBufferedSearch == nil {
+			c.vectorBufferedSearch = make(map[string]*collectionVectorIndexPreparedSearchCacheEntry)
+		}
+		entry := c.vectorBufferedSearch[opts.IndexName]
+		if entry != nil && entry.building {
+			ready := entry.ready
+			c.vectorBufferedSearchWaits++
+			c.vectorBufferedSearchMu.Unlock()
+			<-ready
+			commitSeq, systemRoot = dbCommitSeqAndSystemRoot(c.db)
+			if commitSeq == 0 || systemRoot == 0 || c.db.IsClosing() {
+				return nil, response, backenddb.ErrClosed
+			}
+			continue
+		}
+		if entry != nil && entry.commitSeq == commitSeq && entry.systemRoot == systemRoot {
+			if entry.err != nil {
+				delete(c.vectorBufferedSearch, opts.IndexName)
+				c.vectorBufferedSearchErrors++
+				response = entry.response
+				err := entry.err
+				c.vectorBufferedSearchMu.Unlock()
+				return nil, response, err
+			}
+			prepared := entry.prepared
+			c.vectorBufferedSearchHits++
+			c.vectorBufferedSearchMu.Unlock()
+			if prepared != nil && prepared.readyForCurrentSearch() {
+				return prepared, prepared.responseForSearch(), nil
+			}
+			c.invalidateCollectionVectorIndexPreparedSearch(opts.IndexName, prepared)
+			continue
+		}
+		if entry != nil {
+			delete(c.vectorBufferedSearch, opts.IndexName)
+			oldPrepared = entry.prepared
+			c.vectorBufferedSearchInvalidations++
+		}
+		entry = &collectionVectorIndexPreparedSearchCacheEntry{
+			ready:      make(chan struct{}),
+			building:   true,
+			commitSeq:  commitSeq,
+			systemRoot: systemRoot,
+		}
+		c.vectorBufferedSearch[opts.IndexName] = entry
+		c.vectorBufferedSearchMisses++
+		c.vectorBufferedSearchBuilds++
+		c.vectorBufferedSearchMu.Unlock()
+
+		if oldPrepared != nil {
+			_ = oldPrepared.Close()
+		}
+
+		callCollectionVectorIndexPreparedSearchBuildHookForTest(opts.IndexName)
+		prepared, buildResponse, buildErr := c.openCollectionVectorIndexPreparedSearch(opts)
+		if prepared != nil {
+			entry.commitSeq = prepared.commitSeq
+			entry.systemRoot = prepared.systemRoot
+		}
+		entry.response = buildResponse
+		entry.err = buildErr
+
+		stored := false
+		c.vectorBufferedSearchMu.Lock()
+		entry.prepared = prepared
+		entry.building = false
+		if c.vectorBufferedSearch[opts.IndexName] == entry {
+			if buildErr != nil {
+				delete(c.vectorBufferedSearch, opts.IndexName)
+				c.vectorBufferedSearchErrors++
+			} else {
+				stored = true
+			}
+		}
+		close(entry.ready)
+		c.vectorBufferedSearchMu.Unlock()
+
+		if !stored && prepared != nil {
+			_ = prepared.Close()
+		}
+		if buildErr != nil {
+			return nil, buildResponse, buildErr
+		}
+		if stored && c.manager != nil {
+			c.manager.registerCollectionHandle(c)
+		}
+		return prepared, buildResponse, nil
+	}
+}
+
+func (c *Collection) openCollectionVectorIndexPreparedSearch(opts VectorIndexSearchOptions) (*collectionVectorIndexPreparedSearch, VectorIndexSearchResponse, error) {
+	var response VectorIndexSearchResponse
+	if c == nil {
+		return nil, response, errCollectionNil
+	}
+	if c.db == nil {
+		return nil, response, errCollectionDBNil
+	}
+	snap := c.db.AcquireSnapshot()
+	if snap == nil {
+		return nil, response, backenddb.ErrClosed
+	}
+	defer func() { _ = snap.Close() }()
+
+	catalog, err := c.catalogForSnapshot(snap)
+	if err != nil {
+		return nil, response, err
+	}
+	if catalog == nil {
+		return nil, response, errCollectionNotFound
+	}
+	def, ok := findVectorIndex(catalog.meta.VectorIndexes, opts.IndexName)
+	if !ok {
+		return nil, response, ErrIndexNotFound
+	}
+	response.IndexName = def.Name
+	response.Strategy = def.Strategy
+	switch def.Strategy {
+	case VectorIndexStrategyNativeRuntime:
+		response.Status = VectorIndexStatus{Name: def.Name, Strategy: def.Strategy, State: VectorIndexStateNativeRuntime, Reason: VectorIndexReasonNativeRuntime}
+		return nil, response, fmt.Errorf("%w: vector index %q uses native_runtime; collection buffered search currently requires an explicit column_graph index", ErrVectorIndexSearchUnavailable, def.Name)
+	case VectorIndexStrategyColumnGraph:
+	default:
+		response.Status = VectorIndexStatus{Name: def.Name, Strategy: def.Strategy, State: VectorIndexStateColumnGraphUnavailable, Reason: VectorIndexReasonUnsupportedStrategy}
+		return nil, response, fmt.Errorf("%w: vector index %q uses unsupported strategy %q", ErrVectorIndexSearchUnavailable, def.Name, def.Strategy)
+	}
+	if def.Metric != VectorMetricCosine {
+		response.Status = VectorIndexStatus{Name: def.Name, Strategy: def.Strategy, State: VectorIndexStateColumnGraphUnavailable, Reason: VectorIndexReasonColumnGraphUnsupportedMetric}
+		return nil, response, fmt.Errorf("%w: column_graph vector index %q uses metric %q; native reader currently supports only %q", ErrVectorIndexSearchUnavailable, def.Name, def.Metric, VectorMetricCosine)
+	}
+
+	def, graph, view, err := c.columnVectorGraphPhysicalRowReaderSnapshotViewAtSnapshot(def.Name, snap)
+	if err != nil {
+		status, statusErr := c.columnGraphVectorIndexStatusAtSnapshot(def.Name, snap)
+		if statusErr != nil {
+			return nil, response, statusErr
+		}
+		status = failClosedColumnGraphReaderOpenStatus(def, status)
+		response.Status = status
+		return nil, response, fmt.Errorf("%w: column_graph %q is not loaded: state=%s reason=%s: %w", ErrVectorIndexSearchUnavailable, def.Name, status.State, status.Reason, err)
+	}
+	readerCatalog := view.Catalog
+	if readerCatalog == nil || readerCatalog.meta.Options.ColumnStore == nil {
+		return nil, response, errors.New("collections: column_graph prepared collection search missing snapshot catalog")
+	}
+	response.IndexName = def.Name
+	response.Strategy = def.Strategy
+	response.Path = VectorIndexSearchPathColumnGraphNativeReader
+	response.Status = VectorIndexStatus{Name: def.Name, Strategy: def.Strategy, State: VectorIndexStateColumnGraphLoaded, Loaded: true}
+
+	key, err := collectionVectorIndexPreparedSearchCacheKey(readerCatalog.meta.Name, view.AssetNamespace, def, graph, view.VectorIndexState)
+	if err != nil {
+		return nil, response, err
+	}
+	pack, packStatus, packOpenNanos, packErr := c.openColumnHNSWSearchPackPreparedViewForReader(readerCatalog.meta.Name, *readerCatalog.meta.Options.ColumnStore, def, graph, view.VectorIndexState)
+	if packErr != nil {
+		response.Stats = VectorIndexSearchStats{}
+		vectorIndexSearchRouteStatsForHNSWSearchPackFastStatus(vectorIndexSearchRouteStats{}, columnHNSWSearchPackPreparedStatusInvalid).apply(&response.Stats)
+		return nil, response, fmt.Errorf("%w: vector index %q SearchVectorIndexWithBuffer requires valid hnsw_search_pack_v1 state: %w", ErrVectorIndexSearchUnavailable, def.Name, packErr)
+	}
+	if packStatus != columnHNSWSearchPackPreparedStatusDirect && packStatus != columnHNSWSearchPackPreparedStatusHeap {
+		if pack != nil {
+			_ = pack.Close()
+		}
+		response.Stats = VectorIndexSearchStats{}
+		vectorIndexSearchRouteStatsForHNSWSearchPackFastStatus(vectorIndexSearchRouteStats{}, packStatus).apply(&response.Stats)
+		return nil, response, fmt.Errorf("%w: vector index %q SearchVectorIndexWithBuffer requires healthy hnsw_search_pack_v1 state", ErrVectorIndexSearchUnavailable, def.Name)
+	}
+	routeStats := vectorIndexSearchRouteStatsForHNSWSearchPackRoute(pack.routeStats(packStatus, packOpenNanos))
+	return &collectionVectorIndexPreparedSearch{
+		key:        key,
+		indexName:  def.Name,
+		commitSeq:  snapshotCommitSeq(snap),
+		systemRoot: snapshotSystemRoot(snap),
+		response:   response,
+		pack:       pack,
+		packStatus: packStatus,
+		routeStats: routeStats,
+	}, response, nil
+}
+
+func collectionVectorIndexPreparedSearchCacheKey(collection string, namespace string, def VectorIndexDefinition, graph columnVectorGraphManifestSnapshot, state columnVectorIndexStateSnapshot) (string, error) {
+	key, err := columnVectorGraphSharedPreparedSearchCacheKey(collection, namespace, def, graph, state)
+	if err != nil {
+		return "", err
+	}
+	return "collection_buffered_hnsw_search_pack_v1|" + key, nil
+}
+
+func (p *collectionVectorIndexPreparedSearch) readyForCurrentSearch() bool {
+	if p == nil {
+		return false
+	}
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	if p.closed || p.pack == nil {
+		return false
+	}
+	status := p.pack.fastStatus(p.packStatus)
+	return status == columnHNSWSearchPackPreparedStatusDirect || status == columnHNSWSearchPackPreparedStatusHeap
+}
+
+func (p *collectionVectorIndexPreparedSearch) responseForSearch() VectorIndexSearchResponse {
+	if p == nil {
+		return VectorIndexSearchResponse{}
+	}
+	response := p.response
+	response.Stats = VectorIndexSearchStats{}
+	response.Results = nil
+	return response
+}
+
+func (p *collectionVectorIndexPreparedSearch) SearchWithBuffer(opts VectorIndexSearchOptions, statsMode columnVectorGraphNativeSearchStatsMode, buffer *VectorIndexSearchBuffer) (VectorIndexSearchResponse, error) {
+	previousResults := buffer.results
+	buffer.resetView()
+	response := p.responseForSearch()
+	if p == nil {
+		clear(previousResults)
+		return response, errors.New("collections: nil collection vector index prepared search")
+	}
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	if p.closed || p.pack == nil {
+		clear(previousResults)
+		response.Stats = VectorIndexSearchStats{HNSWSearchPackClosed: 1, HNSWSearchPackFallbacks: 1}
+		return response, errColumnHNSWSearchPackPreparedViewClosed
+	}
+	status := p.pack.fastStatus(p.packStatus)
+	if status != columnHNSWSearchPackPreparedStatusDirect && status != columnHNSWSearchPackPreparedStatusHeap {
+		clear(previousResults)
+		routeStats := collectionVectorIndexPreparedSearchRouteStatsForUnavailable(p.routeStats, status)
+		routeStats.apply(&response.Stats)
+		return response, columnHNSWSearchPackStatusError(status)
+	}
+	results, searchStats, err := p.pack.searchCosine(opts.Query, columnVectorGraphNativeSearchOptions{
+		TopK:           opts.TopK,
+		EfSearch:       opts.EfSearch,
+		ScoreBatchMode: opts.scoreBatchMode,
+		StatsMode:      statsMode,
+		QueryMode:      columnVectorGraphNativeSearchQueryModeExact,
+	}, &buffer.searchScratch)
+	response.Stats = vectorIndexSearchStatsFromInternal(searchStats, columnPhysicalRowReaderStats{})
+	p.routeStats.apply(&response.Stats)
+	if err != nil {
+		clear(previousResults)
+		return response, err
+	}
+	response.Results, err = copyVectorIndexSearchResultsToBuffer(results, buffer, previousResults)
+	if err != nil {
+		return response, err
+	}
+	return response, nil
+}
+
+func collectionVectorIndexPreparedSearchRouteStatsForUnavailable(cached vectorIndexSearchRouteStats, status columnHNSWSearchPackPreparedStatus) vectorIndexSearchRouteStats {
+	stats := cached
+	stats.SearchRouteHNSWSearchPack = 0
+	stats.clearHNSWSearchPackAvailability()
+	stats.applyHNSWSearchPackStatus(status)
+	return stats
+}
+
+func (p *collectionVectorIndexPreparedSearch) Close() error {
+	if p == nil {
+		return nil
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.closed {
+		return nil
+	}
+	p.closed = true
+	var err error
+	if p.pack != nil {
+		err = p.pack.Close()
+		p.pack = nil
+	}
+	return err
+}
+
+func (p *collectionVectorIndexPreparedSearch) stats() mappedresource.Stats {
+	if p == nil {
+		return mappedresource.Stats{}
+	}
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	if p.pack == nil || p.pack.manager == nil {
+		return mappedresource.Stats{}
+	}
+	return p.pack.manager.Stats()
+}
+
+func (c *Collection) invalidateCollectionVectorIndexPreparedSearch(indexName string, prepared *collectionVectorIndexPreparedSearch) {
+	if c == nil || indexName == "" {
+		return
+	}
+	for {
+		var closePrepared *collectionVectorIndexPreparedSearch
+		c.vectorBufferedSearchMu.Lock()
+		entry := c.vectorBufferedSearch[indexName]
+		if entry != nil && entry.building {
+			ready := entry.ready
+			c.vectorBufferedSearchWaits++
+			c.vectorBufferedSearchMu.Unlock()
+			<-ready
+			continue
+		}
+		if entry != nil && (prepared == nil || entry.prepared == prepared) {
+			delete(c.vectorBufferedSearch, indexName)
+			closePrepared = entry.prepared
+			c.vectorBufferedSearchInvalidations++
+		}
+		c.vectorBufferedSearchMu.Unlock()
+		if closePrepared != nil {
+			_ = closePrepared.Close()
+		}
+		return
+	}
+}
+
+func (c *Collection) closeCollectionVectorIndexPreparedSearchCache() error {
+	if c == nil {
+		return nil
+	}
+	var entries []*collectionVectorIndexPreparedSearchCacheEntry
+	for {
+		var waits []chan struct{}
+		c.vectorBufferedSearchMu.Lock()
+		for _, entry := range c.vectorBufferedSearch {
+			if entry == nil {
+				continue
+			}
+			if entry.building {
+				waits = append(waits, entry.ready)
+			}
+		}
+		if len(waits) == 0 {
+			for _, entry := range c.vectorBufferedSearch {
+				entries = append(entries, entry)
+			}
+			c.vectorBufferedSearch = nil
+			if len(entries) > 0 {
+				c.vectorBufferedSearchCloses += uint64(len(entries))
+			}
+			c.vectorBufferedSearchMu.Unlock()
+			break
+		}
+		c.vectorBufferedSearchMu.Unlock()
+		for _, ready := range waits {
+			<-ready
+		}
+	}
+	var closeErr error
+	for _, entry := range entries {
+		if entry != nil && entry.prepared != nil {
+			closeErr = errors.Join(closeErr, entry.prepared.Close())
+		}
+	}
+	return closeErr
+}
+
+func (m *CollectionManager) closeCollectionVectorIndexPreparedSearchCaches() error {
+	if m == nil {
+		return nil
+	}
+	m.collectionsMu.RLock()
+	collections := make([]*Collection, 0, len(m.collections))
+	for collection := range m.collections {
+		if collection != nil {
+			collections = append(collections, collection)
+		}
+	}
+	m.collectionsMu.RUnlock()
+	var closeErr error
+	for _, collection := range collections {
+		closeErr = errors.Join(closeErr, collection.closeCollectionVectorIndexPreparedSearchCache())
+	}
+	return closeErr
+}
+
+func (c *Collection) collectionVectorIndexPreparedSearchCacheSnapshot() collectionVectorIndexPreparedSearchCacheSnapshot {
+	if c == nil {
+		return collectionVectorIndexPreparedSearchCacheSnapshot{}
+	}
+	c.vectorBufferedSearchMu.Lock()
+	defer c.vectorBufferedSearchMu.Unlock()
+	snap := collectionVectorIndexPreparedSearchCacheSnapshot{
+		CacheHits:     c.vectorBufferedSearchHits,
+		CacheMisses:   c.vectorBufferedSearchMisses,
+		CacheWaits:    c.vectorBufferedSearchWaits,
+		CacheBuilds:   c.vectorBufferedSearchBuilds,
+		Invalidations: c.vectorBufferedSearchInvalidations,
+		Closes:        c.vectorBufferedSearchCloses,
+		Errors:        c.vectorBufferedSearchErrors,
+	}
+	for _, entry := range c.vectorBufferedSearch {
+		if entry == nil {
+			continue
+		}
+		snap.Entries++
+		if entry.building {
+			snap.BuildingEntries++
+			continue
+		}
+		if entry.prepared != nil {
+			snap.add(entry.prepared.stats())
+		}
+	}
+	return snap
+}
+
+func (s *collectionVectorIndexPreparedSearchCacheSnapshot) add(stats mappedresource.Stats) {
+	if s == nil {
+		return
+	}
+	s.ActiveHandles += stats.ActiveHandles
+	s.ActiveMappedBytes += stats.ActiveMappedBytes
+	s.ActiveHeapCopyBytes += stats.ActiveHeapCopyBytes
+	s.ActiveDerivedMetadataBytes += stats.ActiveDerivedMetadataBytes
+}

--- a/TreeDB/collections/collection_vector_index_prepared_search_cache.go
+++ b/TreeDB/collections/collection_vector_index_prepared_search_cache.go
@@ -409,6 +409,15 @@ func (c *Collection) invalidateCollectionVectorIndexPreparedSearch(indexName str
 	}
 }
 
+func (c *Collection) hasCollectionVectorIndexPreparedSearchCacheEntries() bool {
+	if c == nil {
+		return false
+	}
+	c.vectorBufferedSearchMu.Lock()
+	defer c.vectorBufferedSearchMu.Unlock()
+	return len(c.vectorBufferedSearch) > 0
+}
+
 func (c *Collection) closeCollectionVectorIndexPreparedSearchCache() error {
 	if c == nil {
 		return nil
@@ -446,6 +455,9 @@ func (c *Collection) closeCollectionVectorIndexPreparedSearchCache() error {
 		if entry != nil && entry.prepared != nil {
 			closeErr = errors.Join(closeErr, entry.prepared.Close())
 		}
+	}
+	if c.manager != nil && !c.hasDirtyNativeVectorIndex() {
+		c.manager.unregisterCollectionHandle(c)
 	}
 	return closeErr
 }

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -331,7 +331,7 @@ type typedStorageLegacyNameAllowlistEntry struct {
 }
 
 var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
-	{path: "TreeDB/collections/api.go", classification: typedStorageLegacyCompatibility, matchingLines: 46, occurrences: 52},
+	{path: "TreeDB/collections/api.go", classification: typedStorageLegacyCompatibility, matchingLines: 47, occurrences: 53},
 	{path: "TreeDB/collections/column_aggregate_metadata_asset.go", classification: typedStorageLegacyDerived, matchingLines: 16, occurrences: 19},
 	{path: "TreeDB/collections/column_aggregate_metadata_predicate.go", classification: typedStorageLegacyDerived, matchingLines: 6, occurrences: 6},
 	{path: "TreeDB/collections/column_aggregate_metadata_predicate_1951_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 15, occurrences: 16},
@@ -350,6 +350,7 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/column_hnsw_search_pack_reader.go", classification: typedStorageLegacyDerived, matchingLines: 2, occurrences: 2},
 	{path: "TreeDB/collections/column_hnsw_search_pack_test.go", classification: typedStorageLegacyDerived, matchingLines: 1, occurrences: 2},
 	{path: "TreeDB/collections/column_hnsw_search_pack_writer.go", classification: typedStorageLegacyDerived, matchingLines: 3, occurrences: 3},
+	{path: "TreeDB/collections/collection_vector_index_prepared_search_cache.go", classification: typedStorageLegacyDerived, matchingLines: 2, occurrences: 2},
 	{path: "TreeDB/collections/column_int64_query.go", classification: typedStorageLegacyDerived, matchingLines: 2, occurrences: 2},
 	{path: "TreeDB/collections/column_int64_values_asset.go", classification: typedStorageLegacyDerived, matchingLines: 8, occurrences: 8},
 	{path: "TreeDB/collections/column_manifest_format.go", classification: typedStorageLegacyCompatibility, matchingLines: 2, occurrences: 2},

--- a/TreeDB/collections/vector_index.go
+++ b/TreeDB/collections/vector_index.go
@@ -175,9 +175,9 @@ const (
 // Collection.SearchVectorIndex method is a response-owned one-shot convenience
 // boundary that opens a searcher per call. Collection.SearchVectorIndexWithBuffer
 // exposes caller-owned result storage for the exact no-document hnsw_search_pack_v1
-// seam but still opens per call until collection-owned prepared caching lands;
-// callers that need zero-allocation steady-state behavior should use a reusable
-// VectorIndexSearcher with VectorIndexSearcher.SearchWithBuffer.
+// seam and reuses collection-owned prepared pack state on warmed healthy current
+// state; callers that need explicit snapshot lifetime control can still use a
+// reusable VectorIndexSearcher with VectorIndexSearcher.SearchWithBuffer.
 type VectorIndexSearchOptions struct {
 	// IndexName is used by collection-level physical column_graph search.
 	IndexName string

--- a/TreeDB/collections/vector_index.go
+++ b/TreeDB/collections/vector_index.go
@@ -559,7 +559,7 @@ func (c *Collection) UnregisterVectorIndex(name string) {
 	c.vectorIndexesMu.Lock()
 	defer c.vectorIndexesMu.Unlock()
 	delete(c.vectorIndexes, name)
-	if !c.hasNativePersistentVectorIndexLocked() && c.manager != nil {
+	if !c.hasNativePersistentVectorIndexLocked() && c.manager != nil && !c.hasCollectionVectorIndexPreparedSearchCacheEntries() {
 		c.manager.unregisterCollectionHandle(c)
 	}
 }
@@ -895,7 +895,7 @@ func (c *Collection) persistDirtyNativeVectorIndexes() error {
 			return err
 		}
 	}
-	if c.manager != nil && !c.hasDirtyNativeVectorIndex() {
+	if c.manager != nil && !c.hasDirtyNativeVectorIndex() && !c.hasCollectionVectorIndexPreparedSearchCacheEntries() {
 		c.manager.unregisterCollectionHandle(c)
 	}
 	return nil

--- a/TreeDB/collections/vector_index_search.go
+++ b/TreeDB/collections/vector_index_search.go
@@ -803,8 +803,12 @@ func (c *Collection) SearchVectorIndexWithBuffer(opts VectorIndexSearchOptions, 
 			return response, err
 		}
 		response, err = prepared.SearchWithBuffer(opts, statsMode, buffer)
-		if err == nil && vectorIndexSearchStatsAreBufferedNoDocumentPackRoute(response.Stats) {
+		healthyPackRoute := vectorIndexSearchStatsAreBufferedNoDocumentPackRoute(response.Stats)
+		if err == nil && healthyPackRoute {
 			return response, nil
+		}
+		if err != nil && healthyPackRoute {
+			return response, err
 		}
 		lastResponse, lastErr = response, err
 		resetBufferedVectorIndexSearchResponse(&response, buffer)

--- a/TreeDB/collections/vector_index_search.go
+++ b/TreeDB/collections/vector_index_search.go
@@ -776,6 +776,14 @@ func (c *Collection) SearchVectorIndexWithBuffer(opts VectorIndexSearchOptions, 
 	if err := validateCollectionVectorIndexSearchWithBufferOptions(opts, buffer); err != nil {
 		return VectorIndexSearchResponse{}, err
 	}
+	if c == nil {
+		buffer.Reset()
+		return VectorIndexSearchResponse{}, errCollectionNil
+	}
+	if c.db == nil {
+		buffer.Reset()
+		return VectorIndexSearchResponse{}, errCollectionDBNil
+	}
 	if err := c.flushBufferedWrites(); err != nil {
 		buffer.Reset()
 		return VectorIndexSearchResponse{}, err

--- a/TreeDB/collections/vector_index_search.go
+++ b/TreeDB/collections/vector_index_search.go
@@ -543,8 +543,9 @@ type VectorIndexSearchResponse struct {
 // buffer is reused or Reset is called. Parallel callers should use independent
 // searcher/buffer pairs per worker.
 type VectorIndexSearchBuffer struct {
-	results []VectorIndexSearchResult
-	idBytes []byte
+	results       []VectorIndexSearchResult
+	idBytes       []byte
+	searchScratch columnVectorGraphNativeSearchScratch
 }
 
 // Reset clears the buffer's current response view while retaining reusable
@@ -766,64 +767,53 @@ func (c *Collection) SearchVectorIndex(opts VectorIndexSearchOptions) (VectorInd
 //
 // This method intentionally fails closed for document materialization,
 // projections, filters, quantized modes, benchmark-debug stats mode, missing or
-// invalid hnsw_search_pack_v1 state, and legacy/fallback routes. It currently
-// opens and closes a VectorIndexSearcher per call; that open/prepare allocation
-// and validation cost is still inside this collection-level seam until a
-// collection-owned prepared cache is introduced. Callers that already manage
-// reusable open state should prefer OpenVectorIndexSearcher plus
-// VectorIndexSearcher.SearchWithBuffer for the zero-allocation steady-state hot
-// path.
+// invalid hnsw_search_pack_v1 state, and legacy/fallback routes. Healthy current
+// hnsw_search_pack_v1 state is opened once into a collection-owned prepared
+// cache keyed by the current collection/vector-index manifest identity; steady
+// state searches reuse the prepared pack and caller-owned buffer/scratch instead
+// of opening a VectorIndexSearcher per call.
 func (c *Collection) SearchVectorIndexWithBuffer(opts VectorIndexSearchOptions, buffer *VectorIndexSearchBuffer) (VectorIndexSearchResponse, error) {
 	if err := validateCollectionVectorIndexSearchWithBufferOptions(opts, buffer); err != nil {
 		return VectorIndexSearchResponse{}, err
 	}
-	searcher, response, err := c.openVectorIndexSearcher(VectorIndexSearcherOptions{
-		IndexName:        opts.IndexName,
-		MaxDecodedBlocks: opts.MaxDecodedBlocks,
-	})
-	if err != nil {
+	if err := c.flushBufferedWrites(); err != nil {
 		buffer.Reset()
-		return response, err
+		return VectorIndexSearchResponse{}, err
 	}
 	statsMode, err := columnVectorGraphNativeSearchStatsModeFromPublic(opts.StatsMode)
 	if err != nil {
 		buffer.Reset()
-		_ = searcher.Close()
-		return response, err
+		return VectorIndexSearchResponse{}, err
 	}
 	queryMode, err := normalizeVectorIndexSearchQueryMode(opts.QueryMode, opts.QuantizedIndexName, opts.QuantizedRerankCandidates, opts.TopK)
 	if err != nil {
 		buffer.Reset()
-		_ = searcher.Close()
-		return response, err
+		return VectorIndexSearchResponse{}, err
 	}
-	if _, routeStats, usePackRoute := searcher.hnswSearchPackSearchWithBufferRoute(queryMode, statsMode); !usePackRoute {
+	if queryMode != columnVectorGraphNativeSearchQueryModeExact || !columnHNSWSearchPackStatsModeSupportedForSearch(statsMode) {
 		buffer.Reset()
-		response.Stats = VectorIndexSearchStats{}
-		routeStats.apply(&response.Stats)
-		_ = searcher.Close()
-		return response, fmt.Errorf("%w: vector index %q SearchVectorIndexWithBuffer requires exact no-document hnsw_search_pack_v1 route", ErrVectorIndexSearchUnavailable, opts.IndexName)
+		return VectorIndexSearchResponse{}, fmt.Errorf("%w: vector index %q SearchVectorIndexWithBuffer requires exact no-document hnsw_search_pack_v1 route", ErrVectorIndexSearchUnavailable, opts.IndexName)
 	}
-	response, err = searcher.SearchWithBuffer(VectorIndexSearcherSearchOptions{
-		Query:          opts.Query,
-		QueryMode:      opts.QueryMode,
-		TopK:           opts.TopK,
-		EfSearch:       opts.EfSearch,
-		StatsMode:      opts.StatsMode,
-		scoreBatchMode: opts.scoreBatchMode,
-	}, buffer)
-	if closeErr := searcher.Close(); err == nil && closeErr != nil {
+	var lastResponse VectorIndexSearchResponse
+	var lastErr error
+	for attempt := 0; attempt < 2; attempt++ {
+		prepared, response, err := c.acquireCollectionVectorIndexPreparedSearch(opts)
+		if err != nil {
+			buffer.Reset()
+			return response, err
+		}
+		response, err = prepared.SearchWithBuffer(opts, statsMode, buffer)
+		if err == nil && vectorIndexSearchStatsAreBufferedNoDocumentPackRoute(response.Stats) {
+			return response, nil
+		}
+		lastResponse, lastErr = response, err
 		resetBufferedVectorIndexSearchResponse(&response, buffer)
-		return response, closeErr
+		c.invalidateCollectionVectorIndexPreparedSearch(opts.IndexName, prepared)
 	}
-	if err != nil {
-		return response, err
+	if lastErr != nil {
+		return lastResponse, lastErr
 	}
-	if !vectorIndexSearchStatsAreBufferedNoDocumentPackRoute(response.Stats) {
-		resetBufferedVectorIndexSearchResponse(&response, buffer)
-		return response, fmt.Errorf("%w: vector index %q SearchVectorIndexWithBuffer requires exact no-document hnsw_search_pack_v1 route", ErrVectorIndexSearchUnavailable, opts.IndexName)
-	}
-	return response, nil
+	return lastResponse, fmt.Errorf("%w: vector index %q SearchVectorIndexWithBuffer requires exact no-document hnsw_search_pack_v1 route", ErrVectorIndexSearchUnavailable, opts.IndexName)
 }
 
 func validateCollectionVectorIndexSearchWithBufferOptions(opts VectorIndexSearchOptions, buffer *VectorIndexSearchBuffer) error {

--- a/TreeDB/collections/vector_index_search_test.go
+++ b/TreeDB/collections/vector_index_search_test.go
@@ -998,7 +998,19 @@ func TestSearchVectorIndexWithBufferPreparedCacheCloseReleasesHandles2363(t *tes
 	}
 	if snap := col.collectionVectorIndexPreparedSearchCacheSnapshot(); snap.Entries != 1 || snap.ActiveHandles != 1 {
 		_ = d.Close()
-		t.Fatalf("cache before DB close=%+v want rebuilt active handle", snap)
+		t.Fatalf("cache before manager flush=%+v want rebuilt active handle", snap)
+	}
+	if col.manager == nil {
+		_ = d.Close()
+		t.Fatal("test setup missing collection manager")
+	}
+	if err := col.manager.FlushAll(); err != nil {
+		_ = d.Close()
+		t.Fatalf("manager FlushAll with active prepared cache: %v", err)
+	}
+	if snap := col.collectionVectorIndexPreparedSearchCacheSnapshot(); snap.Entries != 1 || snap.ActiveHandles != 1 {
+		_ = d.Close()
+		t.Fatalf("cache after manager flush=%+v want still registered active handle", snap)
 	}
 	if err := d.Close(); err != nil {
 		t.Fatalf("DB Close: %v", err)

--- a/TreeDB/collections/vector_index_search_test.go
+++ b/TreeDB/collections/vector_index_search_test.go
@@ -1005,6 +1005,79 @@ func waitForCollectionVectorIndexPreparedSearchWaits2363(tb testing.TB, col *Col
 	tb.Fatalf("timed out waiting for collection prepared-search cache waits >= %d", waits)
 }
 
+func TestSearchVectorIndexWithBufferPreparedCacheDoesNotPublishDuringClose2363(t *testing.T) {
+	rows := []columnGraphRebuildInputRowV2A{{id: "doc-a", vector: []float32{1, 0, 0}}, {id: "doc-b", vector: []float32{0, 1, 0}}}
+	_, d, col, def := openColumnGraphRebuildTestCollectionV2A(t, 3, 1, rows)
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		_ = d.Close()
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	opts := VectorIndexSearchOptions{IndexName: def.Name, Query: []float32{1, 0, 0}, TopK: 1, EfSearch: len(rows), MaxDecodedBlocks: 1}
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var hookOnce sync.Once
+	collectionVectorIndexPreparedSearchBuildHookForTest.mu.Lock()
+	collectionVectorIndexPreparedSearchBuildHookForTest.fn = func(indexName string) {
+		if indexName != def.Name {
+			return
+		}
+		hookOnce.Do(func() {
+			close(started)
+			<-release
+		})
+	}
+	collectionVectorIndexPreparedSearchBuildHookForTest.mu.Unlock()
+	defer func() {
+		collectionVectorIndexPreparedSearchBuildHookForTest.mu.Lock()
+		collectionVectorIndexPreparedSearchBuildHookForTest.fn = nil
+		collectionVectorIndexPreparedSearchBuildHookForTest.mu.Unlock()
+	}()
+
+	searchDone := make(chan error, 1)
+	go func() {
+		var buffer VectorIndexSearchBuffer
+		_, err := col.SearchVectorIndexWithBuffer(opts, &buffer)
+		searchDone <- err
+	}()
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		_ = d.Close()
+		t.Fatal("timed out waiting for cache build to start")
+	}
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- d.Close() }()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) && (col.manager == nil || !col.manager.isClosing()) {
+		time.Sleep(time.Millisecond)
+	}
+	if col.manager == nil || !col.manager.isClosing() {
+		close(release)
+		t.Fatal("timed out waiting for manager close to start")
+	}
+	close(release)
+	select {
+	case err := <-searchDone:
+		if !errors.Is(err, backenddb.ErrClosed) {
+			t.Fatalf("SearchVectorIndexWithBuffer during close err=%v want ErrClosed", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for search during close")
+	}
+	select {
+	case err := <-closeDone:
+		if err != nil {
+			t.Fatalf("DB Close: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for DB close")
+	}
+	if snap := col.collectionVectorIndexPreparedSearchCacheSnapshot(); snap.Entries != 0 || snap.ActiveHandles != 0 {
+		t.Fatalf("cache after close race=%+v want no published prepared state", snap)
+	}
+}
+
 func TestSearchVectorIndexWithBufferPreparedCacheCloseReleasesHandles2363(t *testing.T) {
 	rows := []columnGraphRebuildInputRowV2A{{id: "doc-a", vector: []float32{1, 0, 0}}, {id: "doc-b", vector: []float32{0, 1, 0}}}
 	_, d, col, def := openColumnGraphRebuildTestCollectionV2A(t, 3, 1, rows)

--- a/TreeDB/collections/vector_index_search_test.go
+++ b/TreeDB/collections/vector_index_search_test.go
@@ -823,6 +823,48 @@ func TestSearchVectorIndexWithBufferPreparedCacheReusesState2363(t *testing.T) {
 	}
 }
 
+func TestSearchVectorIndexWithBufferPreparedCacheKeepsWarmStateOnQueryError2363(t *testing.T) {
+	rows := []columnGraphRebuildInputRowV2A{
+		{id: "doc-a", vector: []float32{1, 0, 0}},
+		{id: "doc-b", vector: []float32{0, 1, 0}},
+	}
+	_, d, col, def := openColumnGraphRebuildTestCollectionV2A(t, 3, 1, rows)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	opts := VectorIndexSearchOptions{IndexName: def.Name, Query: []float32{1, 0, 0}, TopK: 1, EfSearch: len(rows), MaxDecodedBlocks: 1}
+	var buffer VectorIndexSearchBuffer
+	if _, err := col.SearchVectorIndexWithBuffer(opts, &buffer); err != nil {
+		t.Fatalf("warm SearchVectorIndexWithBuffer: %v", err)
+	}
+	before := col.collectionVectorIndexPreparedSearchCacheSnapshot()
+	if before.Entries != 1 || before.CacheBuilds != 1 || before.ActiveHandles != 1 {
+		t.Fatalf("cache before bad query=%+v want one warmed entry", before)
+	}
+
+	badOpts := opts
+	badOpts.Query = []float32{1, 0}
+	bad, err := col.SearchVectorIndexWithBuffer(badOpts, &buffer)
+	if !errors.Is(err, errColumnVectorGraphNativeSearchQueryDimensionMismatch) {
+		t.Fatalf("bad query response=%+v err=%v want query dimension mismatch", bad, err)
+	}
+	if len(bad.Results) != 0 || len(buffer.results) != 0 || len(buffer.idBytes) != 0 {
+		t.Fatalf("bad query left results response=%d bufferResults=%d idBytes=%d", len(bad.Results), len(buffer.results), len(buffer.idBytes))
+	}
+	afterBad := col.collectionVectorIndexPreparedSearchCacheSnapshot()
+	if afterBad.Entries != 1 || afterBad.CacheBuilds != before.CacheBuilds || afterBad.Invalidations != before.Invalidations || afterBad.ActiveHandles != 1 {
+		t.Fatalf("cache after bad query=%+v before=%+v want warm cache retained", afterBad, before)
+	}
+	if _, err := col.SearchVectorIndexWithBuffer(opts, &buffer); err != nil {
+		t.Fatalf("valid SearchVectorIndexWithBuffer after bad query: %v", err)
+	}
+	afterValid := col.collectionVectorIndexPreparedSearchCacheSnapshot()
+	if afterValid.CacheBuilds != before.CacheBuilds || afterValid.CacheHits <= afterBad.CacheHits {
+		t.Fatalf("cache after valid retry=%+v afterBad=%+v want hit without rebuild", afterValid, afterBad)
+	}
+}
+
 func TestSearchVectorIndexWithBufferPreparedCacheInvalidatesOnMutationAndRefreshesAfterRebuild2363(t *testing.T) {
 	rows := []columnGraphRebuildInputRowV2A{
 		{id: "doc-a", vector: []float32{1, 0, 0}},

--- a/TreeDB/collections/vector_index_search_test.go
+++ b/TreeDB/collections/vector_index_search_test.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 	"github.com/snissn/gomap/TreeDB/internal/mappedresource"
@@ -722,8 +723,8 @@ func TestSearchVectorIndexWithBufferOpenScopedAllocationContract2362(t *testing.
 	if sink == 0 {
 		t.Fatal("allocation check did not consume results")
 	}
-	if bufferedAllocs >= ownedAllocs {
-		t.Fatalf("SearchVectorIndexWithBuffer allocs=%v want below response-owned SearchVectorIndex allocs=%v; remaining allocations are per-call open/prepare work for #2363", bufferedAllocs, ownedAllocs)
+	if bufferedAllocs != 0 {
+		t.Fatalf("SearchVectorIndexWithBuffer warmed-cache allocs=%v want 0; response-owned SearchVectorIndex allocs=%v", bufferedAllocs, ownedAllocs)
 	}
 }
 
@@ -779,6 +780,297 @@ func TestSearchVectorIndexWithBufferParallelIndependentBuffers2362(t *testing.T)
 	close(errs)
 	for err := range errs {
 		t.Error(err)
+	}
+}
+
+func TestSearchVectorIndexWithBufferPreparedCacheReusesState2363(t *testing.T) {
+	rows := []columnGraphRebuildInputRowV2A{
+		{id: "doc-a", vector: []float32{1, 0, 0}},
+		{id: "doc-b", vector: []float32{0, 1, 0}},
+		{id: "doc-c", vector: []float32{0, 0, 1}},
+		{id: "doc-d", vector: []float32{0.7, 0.3, 0}},
+	}
+	_, d, col, def := openColumnGraphRebuildTestCollectionV2A(t, 3, 3, rows)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	opts := VectorIndexSearchOptions{IndexName: def.Name, Query: []float32{1, 0, 0}, TopK: 2, EfSearch: len(rows), MaxDecodedBlocks: 1, StatsMode: VectorIndexSearchStatsModeProduction}
+	var buffer VectorIndexSearchBuffer
+	warm, err := col.SearchVectorIndexWithBuffer(opts, &buffer)
+	if err != nil {
+		t.Fatalf("warm SearchVectorIndexWithBuffer: %v", err)
+	}
+	assertColumnGraphSearchResponseLoadedV4(t, warm, def.Name, opts.TopK)
+	assertSearchVectorIndexWithBufferNoDocumentPackStats2362(t, warm.Stats)
+	snap := col.collectionVectorIndexPreparedSearchCacheSnapshot()
+	if snap.Entries != 1 || snap.BuildingEntries != 0 || snap.CacheBuilds != 1 || snap.CacheMisses != 1 || snap.ActiveHandles != 1 {
+		t.Fatalf("cache snapshot after warm=%+v want one built active prepared state", snap)
+	}
+	for i := 0; i < 5; i++ {
+		got, err := col.SearchVectorIndexWithBuffer(opts, &buffer)
+		if err != nil {
+			t.Fatalf("cached SearchVectorIndexWithBuffer iteration %d: %v", i, err)
+		}
+		assertSearchVectorIndexWithBufferNoDocumentPackStats2362(t, got.Stats)
+		if got.Stats.HNSWSearchPackOpenNanos == 0 {
+			t.Fatalf("cached stats=%+v want cached open-time route stats retained", got.Stats)
+		}
+	}
+	after := col.collectionVectorIndexPreparedSearchCacheSnapshot()
+	if after.Entries != 1 || after.CacheBuilds != 1 || after.CacheMisses != 1 || after.CacheHits < 5 || after.ActiveHandles != 1 {
+		t.Fatalf("cache snapshot after reuse=%+v want hits without rebuild", after)
+	}
+}
+
+func TestSearchVectorIndexWithBufferPreparedCacheInvalidatesOnMutationAndRefreshesAfterRebuild2363(t *testing.T) {
+	rows := []columnGraphRebuildInputRowV2A{
+		{id: "doc-a", vector: []float32{1, 0, 0}},
+		{id: "doc-b", vector: []float32{0, 1, 0}},
+	}
+	_, d, col, def := openColumnGraphRebuildTestCollectionV2A(t, 3, 2, rows)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		t.Fatalf("RebuildVectorIndex initial: %v", err)
+	}
+	var buffer VectorIndexSearchBuffer
+	warmOpts := VectorIndexSearchOptions{IndexName: def.Name, Query: []float32{1, 0, 0}, TopK: 1, EfSearch: len(rows), MaxDecodedBlocks: 1}
+	warm, err := col.SearchVectorIndexWithBuffer(warmOpts, &buffer)
+	if err != nil {
+		t.Fatalf("warm SearchVectorIndexWithBuffer: %v", err)
+	}
+	assertSearchVectorIndexWithBufferNoDocumentPackStats2362(t, warm.Stats)
+	before := col.collectionVectorIndexPreparedSearchCacheSnapshot()
+	if before.Entries != 1 || before.ActiveHandles != 1 || before.CacheBuilds != 1 {
+		t.Fatalf("cache before mutation=%+v want one active entry", before)
+	}
+
+	insertColumnGraphRebuildRowsV2A(t, col, []columnGraphRebuildInputRowV2A{{id: "doc-c", vector: []float32{0, 0, 1}}})
+	staleOpts := VectorIndexSearchOptions{IndexName: def.Name, Query: []float32{0, 0, 1}, TopK: 1, EfSearch: len(rows) + 1, MaxDecodedBlocks: 1}
+	stale, err := col.SearchVectorIndexWithBuffer(staleOpts, &buffer)
+	if err == nil {
+		t.Fatalf("stale SearchVectorIndexWithBuffer response=%+v err=nil want fail-closed error", stale)
+	}
+	if len(stale.Results) != 0 || len(buffer.results) != 0 || len(buffer.idBytes) != 0 {
+		t.Fatalf("stale search left results response=%d bufferResults=%d idBytes=%d", len(stale.Results), len(buffer.results), len(buffer.idBytes))
+	}
+	afterStale := col.collectionVectorIndexPreparedSearchCacheSnapshot()
+	if afterStale.ActiveHandles != 0 || afterStale.CacheBuilds < 2 || afterStale.Invalidations == 0 || afterStale.Errors == 0 {
+		t.Fatalf("cache after stale mutation=%+v want old entry invalidated and failed refresh recorded", afterStale)
+	}
+
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		t.Fatalf("RebuildVectorIndex refresh: %v", err)
+	}
+	refreshed, err := col.SearchVectorIndexWithBuffer(staleOpts, &buffer)
+	if err != nil {
+		t.Fatalf("refreshed SearchVectorIndexWithBuffer: %v", err)
+	}
+	assertSearchVectorIndexWithBufferNoDocumentPackStats2362(t, refreshed.Stats)
+	if len(refreshed.Results) == 0 || string(refreshed.Results[0].ID) != "doc-c" {
+		t.Fatalf("refreshed top result=%+v want doc-c", refreshed.Results)
+	}
+	afterRefresh := col.collectionVectorIndexPreparedSearchCacheSnapshot()
+	if afterRefresh.Entries != 1 || afterRefresh.ActiveHandles != 1 || afterRefresh.CacheBuilds < 3 {
+		t.Fatalf("cache after rebuild refresh=%+v want one refreshed active entry", afterRefresh)
+	}
+}
+
+func TestSearchVectorIndexWithBufferPreparedCacheWaitsForBuildingEntryAcrossCommitChange2363(t *testing.T) {
+	rows := []columnGraphRebuildInputRowV2A{{id: "doc-a", vector: []float32{1, 0, 0}}, {id: "doc-b", vector: []float32{0, 1, 0}}}
+	_, d, col, def := openColumnGraphRebuildTestCollectionV2A(t, 3, 1, rows)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	opts := VectorIndexSearchOptions{IndexName: def.Name, Query: []float32{1, 0, 0}, TopK: 1, EfSearch: len(rows), MaxDecodedBlocks: 1}
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var hookOnce sync.Once
+	collectionVectorIndexPreparedSearchBuildHookForTest.mu.Lock()
+	collectionVectorIndexPreparedSearchBuildHookForTest.fn = func(indexName string) {
+		if indexName != def.Name {
+			return
+		}
+		hookOnce.Do(func() {
+			close(started)
+			<-release
+		})
+	}
+	collectionVectorIndexPreparedSearchBuildHookForTest.mu.Unlock()
+	defer func() {
+		collectionVectorIndexPreparedSearchBuildHookForTest.mu.Lock()
+		collectionVectorIndexPreparedSearchBuildHookForTest.fn = nil
+		collectionVectorIndexPreparedSearchBuildHookForTest.mu.Unlock()
+	}()
+
+	runSearch := func(done chan<- error) {
+		var buffer VectorIndexSearchBuffer
+		got, err := col.SearchVectorIndexWithBuffer(opts, &buffer)
+		if err != nil {
+			done <- err
+			return
+		}
+		if len(got.Results) != 1 || string(got.Results[0].ID) != "doc-a" {
+			done <- fmt.Errorf("results=%+v want doc-a", got.Results)
+			return
+		}
+		done <- nil
+	}
+
+	done := make(chan error, 3)
+	go runSearch(done)
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for first cache build to start")
+	}
+	go runSearch(done)
+	waitForCollectionVectorIndexPreparedSearchWaits2363(t, col, 1)
+
+	if _, err := NewCollectionManager(d).CreateCollection(&CollectionMeta{Name: "other"}); err != nil {
+		t.Fatalf("CreateCollection other: %v", err)
+	}
+	go runSearch(done)
+	waitForCollectionVectorIndexPreparedSearchWaits2363(t, col, 2)
+	close(release)
+
+	for i := 0; i < 3; i++ {
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Fatalf("concurrent search %d: %v", i, err)
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatalf("timed out waiting for concurrent search %d; building cache entry may not have signaled waiters", i)
+		}
+	}
+	if snap := col.collectionVectorIndexPreparedSearchCacheSnapshot(); snap.Entries != 1 || snap.BuildingEntries != 0 || snap.CacheWaits < 2 || snap.ActiveHandles != 1 {
+		t.Fatalf("cache snapshot=%+v want one ready entry and two recorded waits", snap)
+	}
+}
+
+func waitForCollectionVectorIndexPreparedSearchWaits2363(tb testing.TB, col *Collection, waits uint64) {
+	tb.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if snap := col.collectionVectorIndexPreparedSearchCacheSnapshot(); snap.CacheWaits >= waits {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	tb.Fatalf("timed out waiting for collection prepared-search cache waits >= %d", waits)
+}
+
+func TestSearchVectorIndexWithBufferPreparedCacheCloseReleasesHandles2363(t *testing.T) {
+	rows := []columnGraphRebuildInputRowV2A{{id: "doc-a", vector: []float32{1, 0, 0}}, {id: "doc-b", vector: []float32{0, 1, 0}}}
+	_, d, col, def := openColumnGraphRebuildTestCollectionV2A(t, 3, 1, rows)
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		_ = d.Close()
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	opts := VectorIndexSearchOptions{IndexName: def.Name, Query: []float32{1, 0, 0}, TopK: 1, EfSearch: len(rows), MaxDecodedBlocks: 1}
+	var buffer VectorIndexSearchBuffer
+	if _, err := col.SearchVectorIndexWithBuffer(opts, &buffer); err != nil {
+		_ = d.Close()
+		t.Fatalf("warm SearchVectorIndexWithBuffer: %v", err)
+	}
+	if snap := col.collectionVectorIndexPreparedSearchCacheSnapshot(); snap.Entries != 1 || snap.ActiveHandles != 1 {
+		_ = d.Close()
+		t.Fatalf("cache before close=%+v want active handle", snap)
+	}
+	if err := col.closeCollectionVectorIndexPreparedSearchCache(); err != nil {
+		_ = d.Close()
+		t.Fatalf("close collection cache: %v", err)
+	}
+	if err := col.closeCollectionVectorIndexPreparedSearchCache(); err != nil {
+		_ = d.Close()
+		t.Fatalf("second close collection cache: %v", err)
+	}
+	if snap := col.collectionVectorIndexPreparedSearchCacheSnapshot(); snap.Entries != 0 || snap.ActiveHandles != 0 {
+		_ = d.Close()
+		t.Fatalf("cache after collection close=%+v want released", snap)
+	}
+	if _, err := col.SearchVectorIndexWithBuffer(opts, &buffer); err != nil {
+		_ = d.Close()
+		t.Fatalf("SearchVectorIndexWithBuffer after collection cache close: %v", err)
+	}
+	if snap := col.collectionVectorIndexPreparedSearchCacheSnapshot(); snap.Entries != 1 || snap.ActiveHandles != 1 {
+		_ = d.Close()
+		t.Fatalf("cache before DB close=%+v want rebuilt active handle", snap)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("DB Close: %v", err)
+	}
+	if snap := col.collectionVectorIndexPreparedSearchCacheSnapshot(); snap.Entries != 0 || snap.ActiveHandles != 0 {
+		t.Fatalf("cache after DB close=%+v want released by manager close hook", snap)
+	}
+	if err := col.closeCollectionVectorIndexPreparedSearchCache(); err != nil {
+		t.Fatalf("cache close after DB close: %v", err)
+	}
+}
+
+func TestSearchVectorIndexWithBufferPreparedCacheConcurrentSharedState2363(t *testing.T) {
+	rows := []columnGraphRebuildInputRowV2A{
+		{id: "doc-a", vector: []float32{1, 0, 0}},
+		{id: "doc-b", vector: []float32{0, 1, 0}},
+		{id: "doc-c", vector: []float32{0, 0, 1}},
+		{id: "doc-d", vector: []float32{0.7, 0.3, 0}},
+	}
+	_, d, col, def := openColumnGraphRebuildTestCollectionV2A(t, 3, 3, rows)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	query := []float32{1, 0, 0}
+	topK := 2
+	want := exactColumnGraphTopKForTest(t, rows, query, topK)
+	opts := VectorIndexSearchOptions{IndexName: def.Name, Query: query, TopK: topK, EfSearch: len(rows), MaxDecodedBlocks: 1, StatsMode: VectorIndexSearchStatsModeProduction}
+	var warmBuffer VectorIndexSearchBuffer
+	if _, err := col.SearchVectorIndexWithBuffer(opts, &warmBuffer); err != nil {
+		t.Fatalf("warm SearchVectorIndexWithBuffer: %v", err)
+	}
+	const workers = 4
+	const iterations = 20
+	var wg sync.WaitGroup
+	errs := make(chan string, workers)
+	for worker := 0; worker < workers; worker++ {
+		wg.Add(1)
+		go func(worker int) {
+			defer wg.Done()
+			var buffer VectorIndexSearchBuffer
+			for i := 0; i < iterations; i++ {
+				got, err := col.SearchVectorIndexWithBuffer(opts, &buffer)
+				if err != nil {
+					errs <- fmt.Sprintf("worker %d iteration %d SearchVectorIndexWithBuffer: %v", worker, i, err)
+					return
+				}
+				if !vectorIndexSearchStatsAreBufferedNoDocumentPackRoute(got.Stats) {
+					errs <- fmt.Sprintf("worker %d iteration %d stats=%+v want pack route", worker, i, got.Stats)
+					return
+				}
+				if len(got.Results) != len(want) || len(buffer.results) != len(want) || len(buffer.idBytes) == 0 {
+					errs <- fmt.Sprintf("worker %d iteration %d result/buffer lens got=%d/%d/%d want %d", worker, i, len(got.Results), len(buffer.results), len(buffer.idBytes), len(want))
+					return
+				}
+				for j := range want {
+					if !bytes.Equal(got.Results[j].ID, want[j].ID) || math.Abs(got.Results[j].Score-want[j].Score) > 1e-6 {
+						errs <- fmt.Sprintf("worker %d iteration %d result[%d]=%+v want id=%q score=%v", worker, i, j, got.Results[j], want[j].ID, want[j].Score)
+						return
+					}
+				}
+			}
+		}(worker)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Error(err)
+	}
+	snap := col.collectionVectorIndexPreparedSearchCacheSnapshot()
+	if snap.Entries != 1 || snap.CacheBuilds != 1 || snap.CacheHits < workers*iterations || snap.ActiveHandles != 1 {
+		t.Fatalf("cache snapshot after concurrent search=%+v want one shared prepared state", snap)
 	}
 }
 

--- a/TreeDB/collections/vector_index_search_test.go
+++ b/TreeDB/collections/vector_index_search_test.go
@@ -1225,6 +1225,17 @@ func TestSearchVectorIndexWithBufferUnsupportedShapesFailClosed2362(t *testing.T
 	if _, err := col.SearchVectorIndexWithBuffer(base, nil); err == nil || !strings.Contains(err.Error(), "nil vector index search buffer") {
 		t.Fatalf("nil buffer err=%v want fail closed", err)
 	}
+	var nilCollection *Collection
+	gotNilCollection, err := nilCollection.SearchVectorIndexWithBuffer(base, &buffer)
+	if !errors.Is(err, errCollectionNil) {
+		t.Fatalf("nil collection err=%v want errCollectionNil", err)
+	}
+	if len(gotNilCollection.Results) != 0 || len(buffer.results) != 0 || len(buffer.idBytes) != 0 {
+		t.Fatalf("nil collection left results: returned=%d bufferResults=%d idBytes=%d", len(gotNilCollection.Results), len(buffer.results), len(buffer.idBytes))
+	}
+	if _, err := col.SearchVectorIndexWithBuffer(base, &buffer); err != nil {
+		t.Fatalf("valid SearchVectorIndexWithBuffer after nil collection: %v", err)
+	}
 
 	tests := []struct {
 		name    string

--- a/TreeDB/collections/vector_usearch_bench_test.go
+++ b/TreeDB/collections/vector_usearch_bench_test.go
@@ -759,15 +759,22 @@ func openVectorUSearchBenchmarkIndex(tb testing.TB, docs, dims, m, efConstructio
 
 func reportCollectionVectorIndexPreparedSearchBenchMetrics2363(b *testing.B, snap collectionVectorIndexPreparedSearchCacheSnapshot) {
 	b.Helper()
+	iterations := float64(b.N)
+	if iterations <= 0 {
+		iterations = 1
+	}
 	b.ReportMetric(float64(snap.Entries), "collection_prepared_cache_entries")
 	b.ReportMetric(float64(snap.BuildingEntries), "collection_prepared_cache_building_entries")
-	b.ReportMetric(float64(snap.CacheBuilds), "collection_prepared_cache_builds")
-	b.ReportMetric(float64(snap.CacheMisses), "collection_prepared_cache_misses")
-	b.ReportMetric(float64(snap.CacheHits), "collection_prepared_cache_hits")
-	b.ReportMetric(float64(snap.CacheWaits), "collection_prepared_cache_waits")
-	b.ReportMetric(float64(snap.Invalidations), "collection_prepared_cache_invalidations")
-	b.ReportMetric(float64(snap.Closes), "collection_prepared_cache_closes")
-	b.ReportMetric(float64(snap.Errors), "collection_prepared_cache_errors")
+	b.ReportMetric(float64(snap.CacheBuilds)/iterations, "collection_prepared_cache_builds/op")
+	b.ReportMetric(float64(snap.CacheMisses)/iterations, "collection_prepared_cache_misses/op")
+	b.ReportMetric(float64(snap.CacheHits)/iterations, "collection_prepared_cache_hits/op")
+	b.ReportMetric(float64(snap.CacheWaits)/iterations, "collection_prepared_cache_waits/op")
+	b.ReportMetric(float64(snap.Invalidations)/iterations, "collection_prepared_cache_invalidations/op")
+	b.ReportMetric(float64(snap.Closes)/iterations, "collection_prepared_cache_closes/op")
+	b.ReportMetric(float64(snap.Errors)/iterations, "collection_prepared_cache_errors/op")
+	if lookups := snap.CacheHits + snap.CacheMisses; lookups > 0 {
+		b.ReportMetric(float64(snap.CacheHits)/float64(lookups), "collection_prepared_cache_hit_ratio")
+	}
 	b.ReportMetric(float64(snap.ActiveHandles), "collection_prepared_active_handles")
 	b.ReportMetric(float64(snap.ActiveMappedBytes), "collection_prepared_mapped_B")
 	b.ReportMetric(float64(snap.ActiveHeapCopyBytes), "collection_prepared_heap_copy_B")

--- a/TreeDB/collections/vector_usearch_bench_test.go
+++ b/TreeDB/collections/vector_usearch_bench_test.go
@@ -288,9 +288,10 @@ func BenchmarkCollectionVectorUSearchProductionCompare(b *testing.B) {
 		reportVectorIndexSearchStatsModeBenchMetric2126(b, params.statsMode())
 		b.ReportMetric(1, "reported_stats_mode_full_diagnostics")
 		b.ReportMetric(1, "collection_searchvectorindex_with_buffer_seam")
-		b.ReportMetric(1, "open_searcher_calls/op")
-		b.ReportMetric(1, "open_setup_in_timed_loop")
+		b.ReportMetric(0, "open_searcher_calls/op")
+		b.ReportMetric(0, "open_setup_in_timed_loop")
 		b.ReportMetric(0, "response_owned_result_alloc/op")
+		reportCollectionVectorIndexPreparedSearchBenchMetrics2363(b, col.collectionVectorIndexPreparedSearchCacheSnapshot())
 		reportVectorIndexSearchBenchMetricsV4(b, b.N, stats, true)
 	})
 
@@ -754,6 +755,23 @@ func openVectorUSearchBenchmarkIndex(tb testing.TB, docs, dims, m, efConstructio
 		}
 	}
 	return index
+}
+
+func reportCollectionVectorIndexPreparedSearchBenchMetrics2363(b *testing.B, snap collectionVectorIndexPreparedSearchCacheSnapshot) {
+	b.Helper()
+	b.ReportMetric(float64(snap.Entries), "collection_prepared_cache_entries")
+	b.ReportMetric(float64(snap.BuildingEntries), "collection_prepared_cache_building_entries")
+	b.ReportMetric(float64(snap.CacheBuilds), "collection_prepared_cache_builds")
+	b.ReportMetric(float64(snap.CacheMisses), "collection_prepared_cache_misses")
+	b.ReportMetric(float64(snap.CacheHits), "collection_prepared_cache_hits")
+	b.ReportMetric(float64(snap.CacheWaits), "collection_prepared_cache_waits")
+	b.ReportMetric(float64(snap.Invalidations), "collection_prepared_cache_invalidations")
+	b.ReportMetric(float64(snap.Closes), "collection_prepared_cache_closes")
+	b.ReportMetric(float64(snap.Errors), "collection_prepared_cache_errors")
+	b.ReportMetric(float64(snap.ActiveHandles), "collection_prepared_active_handles")
+	b.ReportMetric(float64(snap.ActiveMappedBytes), "collection_prepared_mapped_B")
+	b.ReportMetric(float64(snap.ActiveHeapCopyBytes), "collection_prepared_heap_copy_B")
+	b.ReportMetric(float64(snap.ActiveDerivedMetadataBytes), "collection_prepared_derived_metadata_B")
 }
 
 func openVectorUSearchFixtureIndex(tb testing.TB, fixture []vectorBenchmarkFixtureRecord, m, efConstruction, efSearch int) *usearch.Index {

--- a/TreeDB/docs/guides/vector-search-typed-column.md
+++ b/TreeDB/docs/guides/vector-search-typed-column.md
@@ -361,12 +361,12 @@ baseline. Its current production comparison benchmark is
   warmup are outside the timed loop. Parallel rows use one searcher and one
   `VectorIndexSearchBuffer` per worker.
 - `TreeDB_CollectionSearchVectorIndexWithBuffer` times the collection-level
-  caller-owned result-buffer seam. It mirrors the `SearchWithBuffer`
-  no-document route contract: exact mode, caller-owned buffer, no
-  documents/projection, and the healthy `hnsw_search_pack_v1` route. Until the
-  collection-owned prepared cache lands, this seam still opens/closes per
-  operation; report `open_searcher_calls/op=1`, `open_setup_in_timed_loop=1`,
-  and attribute those remaining allocations to the cache follow-up.
+  caller-owned result-buffer seam on a warmed collection-owned prepared cache.
+  It mirrors the `SearchWithBuffer` no-document route contract: exact mode,
+  caller-owned buffer, no documents/projection, and the healthy
+  `hnsw_search_pack_v1` route. Cache warmup/build happens outside the timed
+  loop; report `open_searcher_calls/op=0`, `open_setup_in_timed_loop=0`,
+  `response_owned_result_alloc/op=0`, and collection prepared-cache counters.
 - `USearch_Search` / `USearch_SearchParallel` time the pure in-memory USearch Go
   binding with cosine/f32 HNSW.
 - Both sides use the same deterministic synthetic vector/query generator and the

--- a/TreeDB/docs/spec/column-graph-native-vector-search.md
+++ b/TreeDB/docs/spec/column-graph-native-vector-search.md
@@ -105,10 +105,10 @@ fmt.Println(status.State, response.Path, response.Stats.RowFetches)
 Use `SearchVectorIndex` for response-owned one-shot calls. It opens and closes
 the native reader per call, so it measures setup/open cost in addition to graph
 search. Use `SearchVectorIndexWithBuffer` when collection-level code needs the
-exact no-document caller-owned result-buffer seam; until collection-owned
-prepared caching lands, it still opens/closes a searcher per call. Use
-`OpenVectorIndexSearcher` plus `SearchWithBuffer` when benchmarking or serving
-steady-state query load with open/prepared state outside the hot loop.
+exact no-document caller-owned result-buffer seam; healthy current
+`hnsw_search_pack_v1` state is prepared once in a collection-owned warmed cache.
+Use `OpenVectorIndexSearcher` plus `SearchWithBuffer` when callers need explicit
+snapshot/open lifetime control outside the hot loop.
 
 ## Collection-level no-document high-QPS contract (#2361)
 
@@ -131,8 +131,9 @@ claiming high-QPS vector search:
 - Current buffered collection seam: `Collection.SearchVectorIndexWithBuffer`
   exposes caller-owned reusable result/ID storage for exact no-document searches
   and fails closed when a healthy `hnsw_search_pack_v1` route is not selected.
-  It still opens/closes per call until the collection-owned prepared cache lands,
-  so benchmark rows must report that setup boundary separately.
+  On warmed healthy current pack state, it reuses collection-owned prepared pack
+  state and benchmark rows must report no per-search open/setup inside the timed
+  boundary.
 - Current response-owned baseline boundary: `Collection.SearchVectorIndex` is
   still a one-shot convenience API. It opens/closes per call and owns response
   result buffers, so its no-document benchmark row is a baseline/regression

--- a/scripts/bench_vector_search_compare.sh
+++ b/scripts/bench_vector_search_compare.sh
@@ -201,14 +201,16 @@ Canonical current production comparison:
   vector/adjacency source-state counters, and candidate/visited-edge byte
   counters used by the HNSW search-pack stack.
 - \`BenchmarkCollectionVectorUSearchProductionCompare/TreeDB_CollectionSearchVectorIndexWithBuffer\`
-  times the new collection-level caller-owned result-buffer seam. It uses the
-  same exact no-document route contract as \`SearchWithBuffer\`: caller-owned
-  buffer, no documents/projection, no graph-row fallback, no vector scratch
-  decode, and \`search_route_hnsw_search_pack/search=1\` on healthy packs. Until
-  the collection-owned prepared cache lands, this row still opens/closes a
-  searcher per operation and should report \`open_searcher_calls/op=1\` and
-  \`open_setup_in_timed_loop=1\`; attribute those remaining allocations to the
-  cache follow-up rather than to response-owned result storage.
+  times the collection-level caller-owned result-buffer seam on a warmed
+  collection-owned prepared search-pack cache. It uses the same exact
+  no-document route contract as \`SearchWithBuffer\`: caller-owned buffer, no
+  documents/projection, no graph-row fallback, no vector scratch decode, and
+  \`search_route_hnsw_search_pack/search=1\` on healthy packs. Cache warmup/build
+  happens before the timed loop; the timed row should report
+  \`open_searcher_calls/op=0\`, \`open_setup_in_timed_loop=0\`,
+  \`response_owned_result_alloc/op=0\`, and collection prepared-cache metrics
+  such as \`collection_prepared_cache_builds\` and
+  \`collection_prepared_cache_hits\`.
 - \`.../USearch_Search\` and \`.../USearch_SearchParallel\` time the pure
   in-memory USearch Go binding baseline with cosine/f32 HNSW and the same
   synthetic vector/query generator, M, efConstruction, efSearch, topK, docs,


### PR DESCRIPTION
## Summary

Closes #2363. Parent tracker: #2360. Depends on merged #2362 / PR #2369.

This PR removes per-call open/prepare from the collection-level no-document buffered route by adding a collection-owned prepared `hnsw_search_pack_v1` cache for `Collection.SearchVectorIndexWithBuffer`.

Changes:

- adds a collection-owned prepared search-pack cache keyed by current DB commit/system root and vector-index/manifest identity;
- reuses cached pack state for warmed exact no-document `SearchVectorIndexWithBuffer` calls;
- moves collection-level search scratch into `VectorIndexSearchBuffer`, keeping independent caller buffers safe for concurrent search;
- invalidates/refetches on commit/root changes, stale/closed pack status, mutation/rebuild transitions, and manager close;
- keeps `OpenVectorIndexSearcher` / `VectorIndexSearcher.SearchWithBuffer` behavior intact;
- updates tests, docs, and benchmark metrics so the collection buffered row reports `open_searcher_calls/op=0`, `open_setup_in_timed_loop=0`, `response_owned_result_alloc/op=0`, and collection prepared-cache counters.

## Cache contract

The cache is intentionally scoped to vector-index-owned HNSW serving state. It does not create generic column granules/sidecars and does not materialize documents. Healthy searches still require exact/zero query mode, no documents/projection/filters, and active current-format `hnsw_search_pack_v1` state. Stale or invalid cache entries are closed and rebuilt/fail closed.

## Validation

Latest local head: `671aa89e`.

- Focused tests:
  - `GOWORK=off go test ./TreeDB/collections -run 'Test(SearchVectorIndexWithBuffer|ResetBufferedVectorIndexSearchResponseClearsReturnedResults2362|SearchVectorIndexNoDocumentHighQPSContractBoundary2361|VectorIndexSearcherSearchWithBufferHighQPSContractRejectsDocuments2361)' -count=1`
  - PASS: `/tmp/gomap_2363_self_verify_20260605_001951/focused_tests.log`

- Review-fix focused tests for Codex cache-registration finding:
  - `GOWORK=off go test ./TreeDB/collections -run 'TestSearchVectorIndexWithBufferPreparedCacheCloseReleasesHandles2363|TestSearchVectorIndexWithBufferPreparedCacheWaitsForBuildingEntryAcrossCommitChange2363' -count=1`
  - PASS: `/tmp/gomap_2363_self_verify_20260605_001951/review_fix_tests_post_commit.log`

- Full collections package:
  - `GOWORK=off go test ./TreeDB/collections -count=1`
  - PASS: `/tmp/gomap_2363_self_verify_20260605_001951/collections_tests_after_allowlist.log`
- Start baseline artifact:
  - `/tmp/gomap_2363_baseline_20260604_234745/focused_script/bench.txt`
- Candidate artifacts:
  - Focused row smoke: `/tmp/gomap_2363_candidate_20260605_000348/focused_script/bench.txt`
  - Tier S: `/tmp/gomap_2363_candidate_20260605_000348/tier_s/bench.txt`
  - Tier F: `/tmp/gomap_2363_candidate_20260605_000348/tier_f/bench.txt`
  - CPU profiles: `/tmp/gomap_2363_candidate_20260605_000348/profile_collection_buffered*/cpu_top.txt`


- Review-fix focused tests for Codex query-error cache-retention finding:
  - `GOWORK=off go test ./TreeDB/collections -run 'TestSearchVectorIndexWithBufferPreparedCacheKeepsWarmStateOnQueryError2363|TestSearchVectorIndexWithBufferPreparedCacheCloseReleasesHandles2363' -count=1`
  - PASS: `/tmp/gomap_2363_self_verify_20260605_001951/review_fix2_tests.log`
- Full collections package after second review fix:
  - `GOWORK=off go test ./TreeDB/collections -count=1`
  - PASS: `/tmp/gomap_2363_self_verify_20260605_001951/collections_tests_review_fix2.log`


- Review-fix focused tests for Codex shutdown publication finding:
  - `GOWORK=off go test ./TreeDB/collections -run 'TestSearchVectorIndexWithBufferPreparedCacheDoesNotPublishDuringClose2363|TestSearchVectorIndexWithBufferPreparedCacheKeepsWarmStateOnQueryError2363' -count=1`
  - PASS: `/tmp/gomap_2363_self_verify_20260605_001951/review_fix3_tests.log`
- Full collections package after third review fix:
  - `GOWORK=off go test ./TreeDB/collections -count=1`
  - PASS: `/tmp/gomap_2363_self_verify_20260605_001951/collections_tests_review_fix3.log`


- Review-fix focused tests after atomic registration change:
  - `GOWORK=off go test ./TreeDB/collections -run 'TestSearchVectorIndexWithBufferPreparedCacheDoesNotPublishDuringClose2363|TestSearchVectorIndexWithBufferPreparedCacheCloseReleasesHandles2363|TestSearchVectorIndexWithBufferPreparedCacheKeepsWarmStateOnQueryError2363' -count=1`
  - PASS: `/tmp/gomap_2363_self_verify_20260605_001951/review_fix4_tests.log`
- Full collections package after fourth review fix:
  - `GOWORK=off go test ./TreeDB/collections -count=1`
  - PASS: `/tmp/gomap_2363_self_verify_20260605_001951/collections_tests_review_fix4.log`


- Review-fix focused tests after benchmark counter normalization:
  - `GOWORK=off go test ./TreeDB/collections -run 'TestSearchVectorIndexWithBufferPreparedCache' -count=1`
  - PASS: `/tmp/gomap_2363_self_verify_20260605_001951/review_fix5_tests.log`


- Review-fix focused tests after nil-handle guard:
  - `GOWORK=off go test ./TreeDB/collections -run 'TestSearchVectorIndexWithBufferUnsupportedShapesFailClosed2362|TestSearchVectorIndexWithBufferPreparedCache' -count=1`
  - PASS: `/tmp/gomap_2363_self_verify_20260605_001951/review_fix6_tests.log`
- Full collections package after sixth review fix:
  - `GOWORK=off go test ./TreeDB/collections -count=1`
  - PASS: `/tmp/gomap_2363_self_verify_20260605_001951/collections_tests_review_fix6.log`

## Performance status

Focused 10k/64 row smoke (c=1, 100x) before vs after:

| Row | Before ns/op | Before B/op | Before allocs/op | Before open/setup | After ns/op | After B/op | After allocs/op | After open/setup |
| --- | ---: | ---: | ---: | --- | ---: | ---: | ---: | --- |
| `TreeDB_CollectionSearchVectorIndexWithBuffer` | 8,592,725 | 14,607,798 | 5,367 | 1 / 1 | 59,040 | 0 | 0 | 0 / 0 |
| `TreeDB_SearchWithBuffer` | 64,480 | 0 | 0 | reusable | 48,232 | 0 | 0 | reusable |

Candidate Tier S/F rows keep `0 B/op`, `0 allocs/op` for the collection buffered route with `search_route_hnsw_search_pack/search=1`, docs/fallback/scratch counters at 0, `open_searcher_calls/op=0`, and `open_setup_in_timed_loop=0`.

CPU profile (`/tmp/gomap_2363_candidate_20260605_000348/profile_collection_buffered_100k/cpu_top.txt`) is dominated by `columnHNSWSearchPackPreparedView.searchCosine`, indexed dot/scoring, frontier/top maintenance, and CSR traversal. Cache acquire is ~0.64% flat / ~0.96% cum; no open/decode/document/JSON path dominates the healthy route.

## Review notes

- Scope is #2363 only: no document fetch optimization and no response-owned `SearchVectorIndex` final routing.
- Collection buffered cache stores one active prepared pack per index/current identity and closes entries on invalidation/manager close.
- A test hook covers the building-entry/commit-change wait path to avoid lost waiter signals.


## Review fix

Follow-up commit `edcba4704` keeps collections registered while the buffered search-pack cache owns active entries, preventing `FlushAll` from dropping the manager close hook before DB close. `TestSearchVectorIndexWithBufferPreparedCacheCloseReleasesHandles2363` now covers FlushAll + DB close releasing the cache.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Vector search with buffer now leverages a collection-owned prepared search cache for improved performance on repeated searches.

* **Documentation**
  * Updated benchmark documentation to clarify warmed prepared cache behavior and expected metrics for vector search operations.

* **Tests**
  * Added comprehensive tests covering prepared search cache functionality, including state reuse, invalidation on mutations, concurrent access, and cache lifecycle management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Review fix 4

- `d1009108` makes collection handle registration conditional on manager-open state and performs registration before cache publication, so either shutdown sees the collection in its close-cache pass or publication fails closed with `ErrClosed`.


## Review fix 5

- `ebd6f875` normalizes lifetime prepared-cache benchmark counters to `/op` units and reports a hit ratio, leaving gauge-like active handle/byte fields unchanged.


## Review fix 6

- `671aa89e` checks nil collection/DB handles before flushing buffered writes in `SearchVectorIndexWithBuffer`, preserving error-return semantics and resetting caller-owned buffers.
