### PR TITLE
Fix retained value-log raw frames

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -12740,10 +12740,16 @@ func (db *DB) flushVlogRequests(l *lane, requests []vlogWriteRequest) {
 	}
 	mode := normalizeVlogCompressionMode(db.valueLogCompressionMode)
 	allowDictFallback := mode == vlogCompressionAuto || (mode == vlogCompressionDict && db.vlogSelectorEnabled(mode))
-	for i := 0; i < len(requests); {
-		writeMode := requests[i].writeMode
-		blockCodec := normalizeSelectorBlockCodec(requests[i].blockCodec)
-		dictID := requests[i].dictID
+	type queuedVlogRequestPlan struct {
+		writeMode  vlogCompressionWriteMode
+		blockCodec valuelog.BlockCodec
+		dictID     uint64
+		dict       []byte
+	}
+	normalizeQueuedRequest := func(idx int) queuedVlogRequestPlan {
+		writeMode := requests[idx].writeMode
+		blockCodec := normalizeSelectorBlockCodec(requests[idx].blockCodec)
+		dictID := requests[idx].dictID
 		if writeMode != vlogWriteDict {
 			dictID = 0
 		}
@@ -12758,54 +12764,91 @@ func (db *DB) flushVlogRequests(l *lane, requests []vlogWriteRequest) {
 				}
 			}
 		}
+		return queuedVlogRequestPlan{
+			writeMode:  writeMode,
+			blockCodec: blockCodec,
+			dictID:     dictID,
+			dict:       dict,
+		}
+	}
+	for i := 0; i < len(requests); {
+		current := normalizeQueuedRequest(i)
+		writeMode := current.writeMode
+		blockCodec := current.blockCodec
+		dictID := current.dictID
+		dict := current.dict
 		probe := requests[i].probeCompression
 		maxValLen := len(requests[i].value)
 		rawBytes := len(requests[i].value)
 		end := i + 1
-		for end < len(requests) {
-			nextMode := requests[end].writeMode
-			nextCodec := normalizeSelectorBlockCodec(requests[end].blockCodec)
-			nextDictID := requests[end].dictID
-			nextDict := lookupVlogDictBytes(nextDictID, singleDictID, singleDict, dictByID)
-			if nextMode != vlogWriteDict {
-				nextDictID = 0
+		retainedStorageFirst := false
+		if mode != vlogCompressionOff && writeMode != vlogWriteDict {
+			retainedRawBytes := 0
+			retainedMaxValLen := 0
+			retainedProbe := false
+			retainedEnd := i
+			for retainedEnd < len(requests) {
+				next := normalizeQueuedRequest(retainedEnd)
+				if next.writeMode == vlogWriteDict && next.dictID != 0 {
+					break
+				}
+				if !valueLogPayloadLooksRetainedJSONLike(requests[retainedEnd].value) {
+					break
+				}
+				retainedProbe = retainedProbe || requests[retainedEnd].probeCompression
+				if n := len(requests[retainedEnd].value); n > retainedMaxValLen {
+					retainedMaxValLen = n
+				}
+				retainedRawBytes += len(requests[retainedEnd].value)
+				retainedEnd++
 			}
-			if nextDictID == 0 || len(nextDict) == 0 || nextMode != vlogWriteDict {
-				nextDictID = 0
-			}
-			if nextMode == vlogWriteDict && nextDictID == 0 {
-				nextMode = fallbackAutoVlogWriteMode(mode, nextMode, allowDictFallback)
-				if nextMode == vlogWriteDict {
-					nextMode = vlogWriteOff
+			if retainedEnd > i {
+				retainedRecords := retainedEnd - i
+				retainedUnitBytes := retainedRawBytes / retainedRecords
+				if db.retainedStorageFirstValueLogAuto(retainedRawBytes, retainedUnitBytes, records[i:retainedEnd]) {
+					writeMode = vlogWriteBlock
+					blockCodec = chooseRetainedStorageFirstBlockCodec(l, db.valueLogBlockCodec)
+					dictID = 0
+					dict = nil
+					probe = retainedProbe
+					maxValLen = retainedMaxValLen
+					rawBytes = retainedRawBytes
+					end = retainedEnd
+					retainedStorageFirst = true
 				}
 			}
-			if nextMode != writeMode {
-				break
-			}
-			if nextMode == vlogWriteBlock && nextCodec != blockCodec {
-				break
-			}
-			if nextDictID != dictID {
-				break
-			}
-			probe = probe || requests[end].probeCompression
-			if n := len(requests[end].value); n > maxValLen {
-				maxValLen = n
-			}
-			rawBytes += len(requests[end].value)
-			end++
 		}
+		if !retainedStorageFirst {
+			for end < len(requests) {
+				next := normalizeQueuedRequest(end)
+				if next.writeMode != writeMode {
+					break
+				}
+				if next.writeMode == vlogWriteBlock && next.blockCodec != blockCodec {
+					break
+				}
+				if next.dictID != dictID {
+					break
+				}
+				probe = probe || requests[end].probeCompression
+				if n := len(requests[end].value); n > maxValLen {
+					maxValLen = n
+				}
+				rawBytes += len(requests[end].value)
+				end++
+			}
 
-		unitPayloadBytes := rawBytes
-		if recordsInPlan := end - i; recordsInPlan > 0 {
-			unitPayloadBytes = rawBytes / recordsInPlan
-		}
-		retainedStorageFirst := db.retainedStorageFirstValueLogAuto(rawBytes, unitPayloadBytes, records[i:end])
-		if retainedStorageFirst && mode != vlogCompressionOff && writeMode != vlogWriteDict {
-			writeMode = vlogWriteBlock
-			blockCodec = chooseRetainedStorageFirstBlockCodec(l, db.valueLogBlockCodec)
-			dictID = 0
-			dict = nil
+			unitPayloadBytes := rawBytes
+			if recordsInPlan := end - i; recordsInPlan > 0 {
+				unitPayloadBytes = rawBytes / recordsInPlan
+			}
+			retainedStorageFirst = db.retainedStorageFirstValueLogAuto(rawBytes, unitPayloadBytes, records[i:end])
+			if retainedStorageFirst && mode != vlogCompressionOff && writeMode != vlogWriteDict {
+				writeMode = vlogWriteBlock
+				blockCodec = chooseRetainedStorageFirstBlockCodec(l, db.valueLogBlockCodec)
+				dictID = 0
+				dict = nil
+			}
 		}
 
 		k := 1

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -12718,18 +12718,19 @@ func (db *DB) flushVlogRequests(l *lane, requests []vlogWriteRequest) {
 	}
 
 	type vlogBatchPlan struct {
-		start       int
-		end         int
-		writeMode   vlogCompressionWriteMode
-		blockCodec  valuelog.BlockCodec
-		dictID      uint64
-		dict        []byte
-		k           int
-		probe       bool
-		rawBytes    int
-		frames      []preparedDictFrame
-		storedBytes int
-		wallNs      int64
+		start                int
+		end                  int
+		writeMode            vlogCompressionWriteMode
+		blockCodec           valuelog.BlockCodec
+		dictID               uint64
+		dict                 []byte
+		k                    int
+		probe                bool
+		rawBytes             int
+		retainedStorageFirst bool
+		frames               []preparedDictFrame
+		storedBytes          int
+		wallNs               int64
 	}
 	rawPaused := db.valueLogDictPauseRemaining.Load() > 0
 	var planScratch [16]vlogBatchPlan
@@ -12795,6 +12796,18 @@ func (db *DB) flushVlogRequests(l *lane, requests []vlogWriteRequest) {
 			end++
 		}
 
+		unitPayloadBytes := rawBytes
+		if recordsInPlan := end - i; recordsInPlan > 0 {
+			unitPayloadBytes = rawBytes / recordsInPlan
+		}
+		retainedStorageFirst := db.retainedStorageFirstValueLogAuto(rawBytes, unitPayloadBytes, records[i:end])
+		if retainedStorageFirst && mode != vlogCompressionOff && writeMode != vlogWriteDict {
+			writeMode = vlogWriteBlock
+			blockCodec = chooseRetainedStorageFirstBlockCodec(l, db.valueLogBlockCodec)
+			dictID = 0
+			dict = nil
+		}
+
 		k := 1
 		if end-i > 1 {
 			if writeMode == vlogWriteDict && dictID != 0 {
@@ -12804,7 +12817,11 @@ func (db *DB) flushVlogRequests(l *lane, requests []vlogWriteRequest) {
 					k = valuelog.MaxFrameK
 				}
 			} else if writeMode == vlogWriteBlock {
-				k = db.chooseValueLogBlockWriteK(l, end-i, rawBytes, blockCodec)
+				if retainedStorageFirst {
+					k = db.chooseRetainedStorageFirstValueLogBlockWriteK(l, end-i, rawBytes, blockCodec)
+				} else {
+					k = db.chooseValueLogBlockWriteK(l, end-i, rawBytes, blockCodec)
+				}
 			} else {
 				k = db.chooseValueLogRawWriteK(l, end-i, false, rawPaused)
 			}
@@ -12818,18 +12835,28 @@ func (db *DB) flushVlogRequests(l *lane, requests []vlogWriteRequest) {
 				k = maxKBySize
 			}
 		}
-		k = db.clampValueLogDictK(k)
+		if writeMode == vlogWriteDict && dictID != 0 {
+			k = db.clampValueLogDictK(k)
+		} else {
+			if k < 1 {
+				k = 1
+			}
+			if k > valuelog.MaxFrameK {
+				k = valuelog.MaxFrameK
+			}
+		}
 
 		plans = append(plans, vlogBatchPlan{
-			start:      i,
-			end:        end,
-			writeMode:  writeMode,
-			blockCodec: blockCodec,
-			dictID:     dictID,
-			dict:       dict,
-			k:          k,
-			probe:      probe,
-			rawBytes:   rawBytes,
+			start:                i,
+			end:                  end,
+			writeMode:            writeMode,
+			blockCodec:           blockCodec,
+			dictID:               dictID,
+			dict:                 dict,
+			k:                    k,
+			probe:                probe,
+			rawBytes:             rawBytes,
+			retainedStorageFirst: retainedStorageFirst,
 		})
 		i = end
 	}
@@ -13069,12 +13096,7 @@ func (db *DB) flushVlogRequests(l *lane, requests []vlogWriteRequest) {
 		if plan.start < 0 || plan.end > len(records) || plan.start >= plan.end {
 			return false
 		}
-		unitPayloadBytes := plan.rawBytes
-		if recordsInPlan := plan.end - plan.start; recordsInPlan > 0 {
-			unitPayloadBytes = plan.rawBytes / recordsInPlan
-		}
-		return db.storageFirstValueLogAuto(unitPayloadBytes) &&
-			valueLogRecordsLookRetainedJSONLike(records[plan.start:plan.end])
+		return plan.retainedStorageFirst
 	}
 
 	ptrs = getValueLogPtrsCap(len(records))
@@ -13920,6 +13942,7 @@ func (db *DB) appendValueLog(l *lane, dictID uint64, dict []byte, records []valu
 	if n := len(records); n > 0 {
 		selectorUnitPayloadBytes = rawPayloadBytes / n
 	}
+	retainedStorageFirstBatch := db.retainedStorageFirstValueLogAuto(rawPayloadBytes, selectorUnitPayloadBytes, records)
 	autoRawBypass := db.shouldBypassAutoRawValueCompression(dictID, records, selectorUnitPayloadBytes, payloadKindForFallback)
 	writeMode, blockCodec, selectorProbe := vlogWriteOff, db.valueLogBlockCodec, false
 	if !autoRawBypass {
@@ -13945,14 +13968,22 @@ func (db *DB) appendValueLog(l *lane, dictID uint64, dict []byte, records []valu
 		}
 		blockCodec = chooseLargePayloadNoDictBlockCodec(l, db.valueLogBlockCodec)
 	}
-	blockMode := writeMode == vlogWriteBlock
+	forceRetainedStorageFirstBlock := func() {
+		if !retainedStorageFirstBatch || mode == vlogCompressionOff || dictID != 0 {
+			return
+		}
+		writeMode = vlogWriteBlock
+		blockCodec = chooseRetainedStorageFirstBlockCodec(l, db.valueLogBlockCodec)
+	}
 	probeCompression := selectorProbe
 	paused := false
 	if writeMode != vlogWriteDict {
 		dictID = 0
 		dict = nil
 		normalizeNoDictBlockCodec()
+		forceRetainedStorageFirstBlock()
 	}
+	blockMode := writeMode == vlogWriteBlock
 
 	if dictID != 0 {
 		attemptCompression, dictProbe, dictPaused := db.valueLogDictShouldAttemptCompression(rawPayloadBytes)
@@ -13962,16 +13993,18 @@ func (db *DB) appendValueLog(l *lane, dictID uint64, dict []byte, records []valu
 			dictID = 0
 			dict = nil
 			writeMode = dictFallbackWriteMode(writeMode)
-			blockMode = writeMode == vlogWriteBlock
 			normalizeNoDictBlockCodec()
+			forceRetainedStorageFirstBlock()
+			blockMode = writeMode == vlogWriteBlock
 		}
 	}
 	if dictID != 0 && db.shouldBypassValueLogDictForRecords(records, probeCompression) {
 		dictID = 0
 		dict = nil
 		writeMode = dictFallbackWriteMode(writeMode)
-		blockMode = writeMode == vlogWriteBlock
 		normalizeNoDictBlockCodec()
+		forceRetainedStorageFirstBlock()
+		blockMode = writeMode == vlogWriteBlock
 	}
 	if dictID != 0 && db.valueLogAutotuneOptions.DisableBelowValueBytes > 0 {
 		avg := rawPayloadBytes / len(records)
@@ -13979,8 +14012,9 @@ func (db *DB) appendValueLog(l *lane, dictID uint64, dict []byte, records []valu
 			dictID = 0
 			dict = nil
 			writeMode = dictFallbackWriteMode(writeMode)
-			blockMode = writeMode == vlogWriteBlock
 			normalizeNoDictBlockCodec()
+			forceRetainedStorageFirstBlock()
+			blockMode = writeMode == vlogWriteBlock
 		}
 	}
 	if dictID != 0 && len(dict) == 0 {
@@ -13990,8 +14024,9 @@ func (db *DB) appendValueLog(l *lane, dictID uint64, dict []byte, records []valu
 			dictID = 0
 			dict = nil
 			writeMode = dictFallbackWriteMode(writeMode)
-			blockMode = writeMode == vlogWriteBlock
 			normalizeNoDictBlockCodec()
+			forceRetainedStorageFirstBlock()
+			blockMode = writeMode == vlogWriteBlock
 		}
 	}
 	switch mode {
@@ -14011,7 +14046,11 @@ func (db *DB) appendValueLog(l *lane, dictID uint64, dict []byte, records []valu
 			k = 16
 		}
 	} else if blockMode && len(records) > 1 {
-		k = db.chooseValueLogBlockWriteK(l, len(records), rawPayloadBytes, blockCodec)
+		if retainedStorageFirstBatch {
+			k = db.chooseRetainedStorageFirstValueLogBlockWriteK(l, len(records), rawPayloadBytes, blockCodec)
+		} else {
+			k = db.chooseValueLogBlockWriteK(l, len(records), rawPayloadBytes, blockCodec)
+		}
 	} else if len(records) > 1 {
 		// Even when dictionary compression is disabled/paused, grouping records into
 		// frames reduces per-record overhead (CRC/header writes) on append-heavy
@@ -14086,8 +14125,7 @@ func (db *DB) appendValueLog(l *lane, dictID uint64, dict []byte, records []valu
 	encodeNsPerRawForWriter := encodeNsPerRaw
 	blockEvalBypass := mode == vlogCompressionAuto || (mode == vlogCompressionDict && db.vlogSelectorEnabled(mode))
 	retainedStorageFirstBlockAttempt := finalWriteMode == vlogWriteBlock &&
-		db.storageFirstValueLogAuto(selectorUnitPayloadBytes) &&
-		valueLogRecordsLookRetainedJSONLike(records)
+		retainedStorageFirstBatch
 	forceBlockCompressionAttempt := finalWriteMode == vlogWriteBlock &&
 		(probeCompression || blockEvalBypass || retainedStorageFirstBlockAttempt)
 	if forceBlockCompressionAttempt {
@@ -14613,6 +14651,7 @@ func (db *DB) appendValueLogOneInternal(l *lane, dictID uint64, dict []byte, rid
 	mode := normalizeVlogCompressionMode(db.valueLogCompressionMode)
 	allowDictFallback := mode == vlogCompressionAuto || (mode == vlogCompressionDict && db.vlogSelectorEnabled(mode))
 	outerLeafPayload := db.isOuterLeafValueLogPayload(value)
+	retainedStorageFirstValue := db.retainedStorageFirstValueLogAutoValue(value)
 	dictFallbackWriteMode := func(current vlogCompressionWriteMode) vlogCompressionWriteMode {
 		next := fallbackAutoVlogWriteMode(mode, current, allowDictFallback)
 		if mode == vlogCompressionDict && next == vlogWriteDict && outerLeafPayload {
@@ -14643,11 +14682,19 @@ func (db *DB) appendValueLogOneInternal(l *lane, dictID uint64, dict []byte, rid
 		}
 		blockCodec = chooseLargePayloadNoDictBlockCodec(l, db.valueLogBlockCodec)
 	}
+	forceRetainedStorageFirstBlock := func() {
+		if !retainedStorageFirstValue || mode == vlogCompressionOff || dictID != 0 {
+			return
+		}
+		writeMode = vlogWriteBlock
+		blockCodec = chooseRetainedStorageFirstBlockCodec(l, db.valueLogBlockCodec)
+	}
 	probeCompression := selectorProbe
 	if writeMode != vlogWriteDict {
 		dictID = 0
 		dict = nil
 		normalizeNoDictBlockCodec()
+		forceRetainedStorageFirstBlock()
 	}
 	if dictID != 0 {
 		attemptCompression, dictProbe, _ := db.valueLogDictShouldAttemptCompression(len(value))
@@ -14657,6 +14704,7 @@ func (db *DB) appendValueLogOneInternal(l *lane, dictID uint64, dict []byte, rid
 			dict = nil
 			writeMode = dictFallbackWriteMode(writeMode)
 			normalizeNoDictBlockCodec()
+			forceRetainedStorageFirstBlock()
 		}
 	}
 	if dictID != 0 && db.shouldBypassValueLogDictForValue(value, probeCompression) {
@@ -14664,12 +14712,14 @@ func (db *DB) appendValueLogOneInternal(l *lane, dictID uint64, dict []byte, rid
 		dict = nil
 		writeMode = dictFallbackWriteMode(writeMode)
 		normalizeNoDictBlockCodec()
+		forceRetainedStorageFirstBlock()
 	}
 	if dictID != 0 && db.valueLogAutotuneOptions.DisableBelowValueBytes > 0 && len(value) < db.valueLogAutotuneOptions.DisableBelowValueBytes {
 		dictID = 0
 		dict = nil
 		writeMode = dictFallbackWriteMode(writeMode)
 		normalizeNoDictBlockCodec()
+		forceRetainedStorageFirstBlock()
 	}
 	if dictID != 0 && len(dict) == 0 {
 		if b, dictErr := db.dictBytes(context.Background(), dictID); dictErr == nil {
@@ -14679,6 +14729,7 @@ func (db *DB) appendValueLogOneInternal(l *lane, dictID uint64, dict []byte, rid
 			dict = nil
 			writeMode = dictFallbackWriteMode(writeMode)
 			normalizeNoDictBlockCodec()
+			forceRetainedStorageFirstBlock()
 		}
 	}
 	finalWriteMode := vlogWriteOff
@@ -14695,8 +14746,7 @@ func (db *DB) appendValueLogOneInternal(l *lane, dictID uint64, dict []byte, rid
 		finalBlockCodec = db.valueLogBlockCodec
 	}
 	retainedStorageFirstBlockAttempt := finalWriteMode == vlogWriteBlock &&
-		db.storageFirstValueLogAuto(len(value)) &&
-		valueLogPayloadLooksRetainedJSONLike(value)
+		retainedStorageFirstValue
 	forceBlockCompressionAttempt := finalWriteMode == vlogWriteBlock &&
 		(probeCompression || mode == vlogCompressionAuto || (mode == vlogCompressionDict && db.vlogSelectorEnabled(mode)) || retainedStorageFirstBlockAttempt)
 	resetBlockCompressionHints := finalWriteMode == vlogWriteBlock &&

--- a/TreeDB/caching/vlog_compression_regression_test.go
+++ b/TreeDB/caching/vlog_compression_regression_test.go
@@ -93,6 +93,13 @@ func compactRetainedTemplatePayload(suffix byte) []byte {
 	return value
 }
 
+func largeRetainedTemplatePayload(suffix byte) []byte {
+	base := []byte(`TD1D{"commit":{"operation":"create","collection":"app.bsky.feed.post"},"kind":"commit","did":"did:plc:storage-parity","text":"large-retained-template-body-for-block-resolution"}`)
+	value := bytes.Repeat(base, 5)
+	value[len(value)-1] = suffix
+	return value
+}
+
 func TestResolveVlogWriteMode_DefaultUsesAutoBehavior(t *testing.T) {
 	db := &DB{
 		valueLogCompressionMode: uint8(vlogCompressionDefault),
@@ -327,6 +334,88 @@ func TestFlushVlogRequests_AutoBalancedCompactRetainedTemplateQueueUsesBlockFram
 	}
 	if writeSnap.Frames[vlogWriteOff] != 0 {
 		t.Fatalf("expected no queued raw/off write-mode observations for compact retained template batch")
+	}
+}
+
+func TestFlushVlogRequests_AutoBalancedMixedRetainedResolvedModesCoalesceBeforeRaw(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "value.log")
+	writer, err := valuelog.NewWriter(path, page.ValueLogFileID(1))
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+
+	db := &DB{
+		closeCh:                  make(chan struct{}),
+		valueLogCompressionMode:  uint8(vlogCompressionAuto),
+		valueLogAutoPolicy:       uint8(vlogAutoBalanced),
+		valueLogBlockCodec:       valuelog.BlockCodecSnappy,
+		valueLogBlockTargetBytes: 4096,
+		lanes: []lane{
+			{id: 0, vlog: writer, vlogCompressionSelector: newVlogCompressionSelector(vlogAutoBalanced, 0, 0)},
+		},
+	}
+	db.valueLogDictCurrentK.Store(32)
+
+	requests := make([]vlogWriteRequest, 14)
+	for i := 0; i < 13; i++ {
+		ack := &vlogAck{}
+		ack.wg.Add(1)
+		requests[i] = vlogWriteRequest{
+			rid:        uint64(i + 1),
+			value:      compactRetainedTemplatePayload(byte(i)),
+			writeMode:  vlogWriteOff,
+			blockCodec: valuelog.BlockCodecSnappy,
+			durability: journalDurabilityFlush,
+			ack:        ack,
+		}
+	}
+	ack := &vlogAck{}
+	ack.wg.Add(1)
+	requests[len(requests)-1] = vlogWriteRequest{
+		rid:        uint64(len(requests)),
+		value:      largeRetainedTemplatePayload(byte(len(requests))),
+		writeMode:  vlogWriteBlock,
+		blockCodec: valuelog.BlockCodecSnappy,
+		durability: journalDurabilityFlush,
+		ack:        ack,
+	}
+
+	db.flushVlogRequests(&db.lanes[0], requests)
+	for i := range requests {
+		ack := requests[i].ack
+		ack.wg.Wait()
+		if ack.err != nil {
+			t.Fatalf("ack[%d] err: %v", i, ack.err)
+		}
+		if ack.ptr == (page.ValuePtr{}) {
+			t.Fatalf("ack[%d] missing pointer", i)
+		}
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	headers := readValueLogFrameHeaders(t, path)
+	recordsSeen := 0
+	for i, header := range headers {
+		recordsSeen += int(header.K)
+		if header.Flags&valuelog.FrameFlagCompressed == 0 {
+			t.Fatalf("frame %d is raw; retained mode coalescing must happen before old write-mode boundaries", i)
+		}
+		if header.DictID != 0 {
+			t.Fatalf("frame %d dict id=%d, want block-compressed no-dict frame", i, header.DictID)
+		}
+	}
+	if recordsSeen != len(requests) {
+		t.Fatalf("records in frames=%d want %d", recordsSeen, len(requests))
+	}
+	writeSnap := snapshotLaneVlogWriteMode(&db.lanes[0])
+	if writeSnap.Frames[vlogWriteBlock] == 0 {
+		t.Fatalf("expected mixed resolved-mode queue to record block write-mode observation")
+	}
+	if writeSnap.Frames[vlogWriteOff] != 0 {
+		t.Fatalf("expected no raw/off observations for mixed retained resolved-mode queue")
 	}
 }
 

--- a/TreeDB/caching/vlog_compression_regression_test.go
+++ b/TreeDB/caching/vlog_compression_regression_test.go
@@ -53,6 +53,46 @@ func readValueLogFrameHeaderAt(t *testing.T, path string, index int) valuelog.Fr
 	return valuelog.FrameHeader{}
 }
 
+func readValueLogFrameHeaders(t *testing.T, path string) []valuelog.FrameHeader {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	headers := make([]valuelog.FrameHeader, 0, 8)
+	for pos := 0; pos < len(data); {
+		if len(data)-pos < valuelog.HeaderSize {
+			t.Fatalf("truncated value-log frame header at offset %d in file length %d", pos, len(data))
+		}
+		bodyLen := int(binary.LittleEndian.Uint32(data[pos+16 : pos+20]))
+		end := pos + valuelog.HeaderSize + bodyLen
+		if bodyLen < valuelog.FrameHeaderSize || end > len(data) {
+			t.Fatalf("invalid value-log body length %d at offset %d in file length %d", bodyLen, pos, len(data))
+		}
+		header, rids, offsets, _, err := valuelog.DecodeFrame(data[pos+valuelog.HeaderSize : end])
+		if err != nil {
+			t.Fatalf("DecodeFrame: %v", err)
+		}
+		if len(rids) != int(header.K) || len(offsets) != int(header.K)+1 {
+			t.Fatalf("decoded frame cardinality mismatch: k=%d rids=%d offsets=%d", header.K, len(rids), len(offsets))
+		}
+		headers = append(headers, header)
+		pos = end
+	}
+	return headers
+}
+
+func compactRetainedTemplatePayload(suffix byte) []byte {
+	base := []byte(`TD1D{"commit":{"operation":"create","collection":"app.bsky.feed.post"},"kind":"commit","did":"did:plc:storage-parity","text":"compact-retained-template-body"}`)
+	value := bytes.Repeat(base, 2)
+	if len(value) > 300 {
+		value = value[:300]
+	}
+	value[len(value)-1] = suffix
+	return value
+}
+
 func TestResolveVlogWriteMode_DefaultUsesAutoBehavior(t *testing.T) {
 	db := &DB{
 		valueLogCompressionMode: uint8(vlogCompressionDefault),
@@ -142,6 +182,151 @@ func TestResolveVlogWriteMode_DictAggressiveSelectorBlockUsesConfiguredCodec(t *
 	mode, codec, probe := db.resolveVlogWriteMode(l, 7, 4096, 4096, false)
 	if mode != vlogWriteBlock || codec != valuelog.BlockCodecLZ4 || probe {
 		t.Fatalf("dict/aggressive selector block fallback should use configured block codec, got mode=%v codec=%v probe=%v", mode, codec, probe)
+	}
+}
+
+func TestAppendValueLog_AutoBalancedCompactRetainedTemplateBatchUsesBlockFrames(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "value.log")
+	writer, err := valuelog.NewWriter(path, page.ValueLogFileID(1))
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+
+	selector := newVlogCompressionSelector(vlogAutoBalanced, 0, 0)
+	selector.dwellBytes = 0
+	selector.exploreBytes = 0
+	selector.exploreRemaining = 0
+	selector.currentCandidate = vlogAutoCandidateOff
+	selector.metrics[vlogAutoCandidateOff] = vlogCandidateMetrics{ratio: 1.0, throughput: 1.0, samples: 16}
+	selector.metrics[vlogAutoCandidateBlockSnappy] = vlogCandidateMetrics{ratio: 0.99, throughput: 0.20, samples: 16}
+	selector.metrics[vlogAutoCandidateBlockLZ4] = vlogCandidateMetrics{ratio: 0.99, throughput: 0.20, samples: 16}
+	selector.metrics[vlogAutoCandidateBlockZSTD] = vlogCandidateMetrics{ratio: 0.99, throughput: 0.20, samples: 16}
+
+	db := &DB{
+		closeCh:                  make(chan struct{}),
+		valueLogCompressionMode:  uint8(vlogCompressionAuto),
+		valueLogAutoPolicy:       uint8(vlogAutoBalanced),
+		valueLogBlockCodec:       valuelog.BlockCodecSnappy,
+		valueLogBlockTargetBytes: 4096,
+		lanes: []lane{
+			{id: 0, vlog: writer, vlogCompressionSelector: selector},
+		},
+	}
+	db.valueLogDictCurrentK.Store(32)
+
+	records := make([]valuelog.Record, 64)
+	for i := range records {
+		records[i] = valuelog.Record{RID: uint64(i + 1), Value: compactRetainedTemplatePayload(byte(i))}
+	}
+	ptrs, err := db.appendValueLog(&db.lanes[0], 0, nil, records, journalDurabilityFlush)
+	if err != nil {
+		t.Fatalf("appendValueLog: %v", err)
+	}
+	if len(ptrs) != len(records) {
+		t.Fatalf("ptr count=%d want %d", len(ptrs), len(records))
+	}
+	for i, ptr := range ptrs {
+		if ptr == (page.ValuePtr{}) {
+			t.Fatalf("empty pointer at %d", i)
+		}
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	headers := readValueLogFrameHeaders(t, path)
+	recordsSeen := 0
+	for i, header := range headers {
+		recordsSeen += int(header.K)
+		if header.Flags&valuelog.FrameFlagCompressed == 0 {
+			t.Fatalf("frame %d is raw; compact retained template batches must not follow grouped_raw path", i)
+		}
+		if header.DictID != 0 {
+			t.Fatalf("frame %d dict id=%d, want block-compressed no-dict frame", i, header.DictID)
+		}
+	}
+	if recordsSeen != len(records) {
+		t.Fatalf("records in frames=%d want %d", recordsSeen, len(records))
+	}
+	writeSnap := snapshotLaneVlogWriteMode(&db.lanes[0])
+	if writeSnap.Frames[vlogWriteBlock] == 0 {
+		t.Fatalf("expected block write-mode observation")
+	}
+	if writeSnap.Frames[vlogWriteOff] != 0 {
+		t.Fatalf("expected no raw/off write-mode observations for compact retained template batch")
+	}
+}
+
+func TestFlushVlogRequests_AutoBalancedCompactRetainedTemplateQueueUsesBlockFrames(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "value.log")
+	writer, err := valuelog.NewWriter(path, page.ValueLogFileID(1))
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+
+	db := &DB{
+		closeCh:                  make(chan struct{}),
+		valueLogCompressionMode:  uint8(vlogCompressionAuto),
+		valueLogAutoPolicy:       uint8(vlogAutoBalanced),
+		valueLogBlockCodec:       valuelog.BlockCodecSnappy,
+		valueLogBlockTargetBytes: 4096,
+		lanes: []lane{
+			{id: 0, vlog: writer, vlogCompressionSelector: newVlogCompressionSelector(vlogAutoBalanced, 0, 0)},
+		},
+	}
+	db.valueLogDictCurrentK.Store(32)
+
+	requests := make([]vlogWriteRequest, 64)
+	for i := range requests {
+		ack := &vlogAck{}
+		ack.wg.Add(1)
+		requests[i] = vlogWriteRequest{
+			rid:        uint64(i + 1),
+			value:      compactRetainedTemplatePayload(byte(i)),
+			writeMode:  vlogWriteOff,
+			blockCodec: valuelog.BlockCodecSnappy,
+			durability: journalDurabilityFlush,
+			ack:        ack,
+		}
+	}
+
+	db.flushVlogRequests(&db.lanes[0], requests)
+	for i := range requests {
+		ack := requests[i].ack
+		ack.wg.Wait()
+		if ack.err != nil {
+			t.Fatalf("ack[%d] err: %v", i, ack.err)
+		}
+		if ack.ptr == (page.ValuePtr{}) {
+			t.Fatalf("ack[%d] missing pointer", i)
+		}
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	headers := readValueLogFrameHeaders(t, path)
+	recordsSeen := 0
+	for i, header := range headers {
+		recordsSeen += int(header.K)
+		if header.Flags&valuelog.FrameFlagCompressed == 0 {
+			t.Fatalf("frame %d is raw; queued compact retained template batches must not follow grouped_raw path", i)
+		}
+		if header.DictID != 0 {
+			t.Fatalf("frame %d dict id=%d, want block-compressed no-dict frame", i, header.DictID)
+		}
+	}
+	if recordsSeen != len(requests) {
+		t.Fatalf("records in frames=%d want %d", recordsSeen, len(requests))
+	}
+	writeSnap := snapshotLaneVlogWriteMode(&db.lanes[0])
+	if writeSnap.Frames[vlogWriteBlock] == 0 {
+		t.Fatalf("expected queued block write-mode observation")
+	}
+	if writeSnap.Frames[vlogWriteOff] != 0 {
+		t.Fatalf("expected no queued raw/off write-mode observations for compact retained template batch")
 	}
 }
 

--- a/TreeDB/caching/vlog_compression_selector.go
+++ b/TreeDB/caching/vlog_compression_selector.go
@@ -90,6 +90,13 @@ const (
 	// on a stable block codec path and let the frame preparer fall back to raw
 	// only when compressed bytes are not worth keeping.
 	forcePointerAutoBlockMinPayloadBytes = 512
+	// Template-v1 retained bodies in collection typed-storage runs are often
+	// smaller than the generic forced-pointer threshold after column elision, but
+	// they arrive as highly repetitive value-log batches. Treat those batches as
+	// storage-first once the frame has enough total bytes to amortize block
+	// compression.
+	retainedStorageFirstMinUnitPayloadBytes  = 128
+	retainedStorageFirstMinBatchPayloadBytes = 4 << 10
 	// High-entropy forced-pointer streams may bypass compression in explicit
 	// throughput policy. Balanced/size policy treats forced pointers as durable
 	// storage-first payloads and keeps them on block compression so retained JSON
@@ -1483,6 +1490,10 @@ func chooseLargePayloadNoDictBlockCodec(l *lane, configured valuelog.BlockCodec)
 	return configured
 }
 
+func chooseRetainedStorageFirstBlockCodec(l *lane, configured valuelog.BlockCodec) valuelog.BlockCodec {
+	return chooseLargePayloadNoDictBlockCodec(l, configured)
+}
+
 func (db *DB) storageFirstValueLogAuto(unitPayloadBytes int) bool {
 	if db == nil {
 		return false
@@ -1497,6 +1508,44 @@ func (db *DB) storageFirstValueLogAuto(unitPayloadBytes int) bool {
 		return true
 	}
 	return unitPayloadBytes > db.minValueLogInlineThreshold()
+}
+
+func (db *DB) retainedStorageFirstValueLogAuto(rawPayloadBytes, unitPayloadBytes int, records []valuelog.Record) bool {
+	if db == nil || len(records) == 0 {
+		return false
+	}
+	if normalizeVlogAutoPolicy(db.valueLogAutoPolicy) == vlogAutoThroughput {
+		return false
+	}
+	if rawPayloadBytes <= 0 {
+		for i := range records {
+			rawPayloadBytes += len(records[i].Value)
+		}
+	}
+	if unitPayloadBytes <= 0 {
+		unitPayloadBytes = rawPayloadBytes / len(records)
+	}
+	if !valueLogRecordsLookRetainedJSONLike(records) {
+		return false
+	}
+	if db.storageFirstValueLogAuto(unitPayloadBytes) {
+		return true
+	}
+	if unitPayloadBytes >= forcePointerAutoBlockMinPayloadBytes {
+		return true
+	}
+	return unitPayloadBytes >= retainedStorageFirstMinUnitPayloadBytes &&
+		rawPayloadBytes >= retainedStorageFirstMinBatchPayloadBytes
+}
+
+func (db *DB) retainedStorageFirstValueLogAutoValue(value []byte) bool {
+	if db == nil || !valueLogPayloadLooksRetainedJSONLike(value) {
+		return false
+	}
+	if normalizeVlogAutoPolicy(db.valueLogAutoPolicy) == vlogAutoThroughput {
+		return false
+	}
+	return db.storageFirstValueLogAuto(len(value)) || len(value) >= forcePointerAutoBlockMinPayloadBytes
 }
 
 func (db *DB) valueLogPayloadExceedsInlineThreshold(unitPayloadBytes int) bool {
@@ -1923,6 +1972,31 @@ func (db *DB) chooseValueLogBlockWriteK(l *lane, records, rawPayloadBytes int, c
 		if targetCompressedBytes < largePayloadTargetBytes {
 			targetCompressedBytes = largePayloadTargetBytes
 		}
+	}
+	k := valuelog.ChooseBlockGroupK(records, rawPayloadBytes, targetCompressedBytes, ratio)
+	if k < 1 {
+		k = 1
+	}
+	if k > valuelog.MaxFrameK {
+		k = valuelog.MaxFrameK
+	}
+	k = db.clampLiveLeafLogFrameK(l, k)
+	recordLaneVlogBlockK(l, codec, k)
+	return k
+}
+
+func (db *DB) chooseRetainedStorageFirstValueLogBlockWriteK(l *lane, records, rawPayloadBytes int, codec valuelog.BlockCodec) int {
+	if records <= 1 {
+		recordLaneVlogBlockK(l, codec, 1)
+		return 1
+	}
+	ratio, ratioSamples := laneVlogBlockObservedRatioWithSamples(l, codec)
+	if ratio <= 0 || ratioSamples == 0 || ratio >= 0.98 {
+		ratio = forcePointerBlockBootstrapRatio
+	}
+	targetCompressedBytes := db.valueLogBlockTargetBytes
+	if targetCompressedBytes < storageFirstRetainedValueLogBlockTargetCompressedBytes {
+		targetCompressedBytes = storageFirstRetainedValueLogBlockTargetCompressedBytes
 	}
 	k := valuelog.ChooseBlockGroupK(records, rawPayloadBytes, targetCompressedBytes, ratio)
 	if k < 1 {


### PR DESCRIPTION
Fixes #2375.

## Summary
- classify JSON/template-v1 retained value-log batches as storage-first even when each retained body is below the generic 512-byte forced-pointer threshold
- force retained no-dict batches onto grouped block frames in both direct append and queued value-log flush paths
- let queued block writes use the retained storage-first block target instead of inheriting the dict/raw K clamp
- add compact TD1D retained regressions for direct and queued paths, preserving high-entropy raw-bypass behavior

## Test Evidence
- `go test ./TreeDB/caching -run 'Test(AppendValueLog_AutoBalancedCompactRetainedTemplateBatchUsesBlockFrames|FlushVlogRequests_AutoBalancedCompactRetainedTemplateQueueUsesBlockFrames|AppendValueLog_AutoForcePointerMediumPayloadUsesGroupedBlockFrame|AppendValueLog_AutoBalancedForcePointerHighEntropyPayloadUsesGroupedRawFrame|AppendValueLog_AutoThroughputForcePointerHighEntropyPayloadUsesGroupedRawFrame|AppendValueLogOne_AutoForcePointerRetainedPayloadResetsBlockBackoff)' -count=1`\n- `go test ./TreeDB/caching -count=1`\n- `go test ./TreeDB/collections -count=1`\n\n## Notes\nThis does not claim final JSONBench parity. Issue #2359 still needs the current-head 1M rerun and compression audit after this lands.