### PR TITLE
TreeDB vector API: route no-doc SearchVectorIndex through cached pack path

### DIFF
--- a/TreeDB/README.md
+++ b/TreeDB/README.md
@@ -197,19 +197,20 @@ The script downloads and extracts a USearch Linux or macOS release package into
 writes results under `/tmp/gomap_vector_search_compare_*`. The canonical current
 production rows include
 `BenchmarkCollectionVectorUSearchProductionCompare/TreeDB_CollectionSearchVectorIndexNoDocsOneShot`
-as the current collection-level one-shot baseline,
+as the response-owned collection convenience API on the cached no-document
+`hnsw_search_pack_v1` route,
 `.../TreeDB_CollectionSearchVectorIndexWithBuffer` as the collection-level
-caller-owned result-buffer seam on a warmed collection-owned prepared cache
-(`open_searcher_calls/op=0`, `open_setup_in_timed_loop=0` in the timed loop),
-plus `.../TreeDB_SearchWithBuffer*` versus `.../USearch_Search*`:
+caller-owned result-buffer seam on the same warmed collection-owned prepared
+cache (`open_searcher_calls/op=0`, `open_setup_in_timed_loop=0` in the timed
+loop), plus `.../TreeDB_SearchWithBuffer*` versus `.../USearch_Search*`:
 TreeDB's high-QPS comparison uses persisted `column_graph` through
 `Collection.OpenVectorIndexSearcher` plus `VectorIndexSearcher.SearchWithBuffer`
 with one searcher and one reusable buffer per worker, while USearch is a pure
 in-memory cosine/f32 HNSW baseline.
 Use `CPU_LIST=1,8` for c=1/c=8 evidence. Older `BenchmarkCollectionVectorIndex*`
 rows are historical controls, not the current high-QPS production fast path;
-one-shot `Collection.SearchVectorIndex` benchmarks include setup/open cost and
-should not be presented as that fast path.
+with-documents `Collection.SearchVectorIndex` rows still include setup/open and
+materialization cost and should not be presented as the no-document fast path.
 Override `USEARCH_VERSION`, `USEARCH_ROOT`, `TREEDB_VECTOR_BENCH_DOCS`,
 `TREEDB_VECTOR_BENCH_DIMS`, `TREEDB_VECTOR_BENCH_M`,
 `TREEDB_VECTOR_BENCH_EF_CONSTRUCTION`, `TREEDB_VECTOR_BENCH_EF_SEARCH`,

--- a/TreeDB/collections/collection_vector_index_prepared_search_cache.go
+++ b/TreeDB/collections/collection_vector_index_prepared_search_cache.go
@@ -247,6 +247,12 @@ func (c *Collection) openCollectionVectorIndexPreparedSearch(opts VectorIndexSea
 	if err != nil {
 		return nil, response, err
 	}
+	if !columnVectorGraphDocumentIDStatePresent(view.VectorIndexState) {
+		return nil, response, fmt.Errorf("%w: vector index %q SearchVectorIndexWithBuffer requires vector-index document-id state for response IDs", ErrVectorIndexSearchUnavailable, def.Name)
+	}
+	if err := validateColumnVectorGraphDocumentIDStateAssetPayload(c.db.ColumnAssetRootDir(), readerCatalog.meta.Name, *readerCatalog.meta.Options.ColumnStore, def, graph, view.VectorIndexState); err != nil {
+		return nil, response, fmt.Errorf("%w: vector index %q SearchVectorIndexWithBuffer requires valid vector-index document-id state: %w", ErrVectorIndexSearchUnavailable, def.Name, err)
+	}
 	pack, packStatus, packOpenNanos, packErr := c.openColumnHNSWSearchPackPreparedViewForReader(readerCatalog.meta.Name, *readerCatalog.meta.Options.ColumnStore, def, graph, view.VectorIndexState)
 	if packErr != nil {
 		response.Stats = VectorIndexSearchStats{}

--- a/TreeDB/collections/column_vector_graph_inv_norm_state_test.go
+++ b/TreeDB/collections/column_vector_graph_inv_norm_state_test.go
@@ -102,7 +102,7 @@ func TestColumnGraphInvNormStateReopenSearchParityAndCounters1992(t *testing.T) 
 		t.Fatalf("state stats=%+v want healthy norm state without fallback", stateStats)
 	}
 
-	publicResponse, err := reopenedCol.SearchVectorIndex(VectorIndexSearchOptions{IndexName: def.Name, Query: query, TopK: 8, EfSearch: 24})
+	publicResponse, err := reopenedCol.SearchVectorIndex(VectorIndexSearchOptions{IndexName: def.Name, Query: query, TopK: 8, EfSearch: 24, StatsMode: VectorIndexSearchStatsModeBenchmarkDebug})
 	if err != nil {
 		t.Fatalf("SearchVectorIndex: %v", err)
 	}

--- a/TreeDB/collections/column_vector_graph_row_ref_state_test.go
+++ b/TreeDB/collections/column_vector_graph_row_ref_state_test.go
@@ -98,7 +98,7 @@ func TestColumnVectorGraphRowRefStatePublishesReopenAndSources1993(t *testing.T)
 	if err != nil {
 		t.Fatalf("OpenCollection reopen: %v", err)
 	}
-	reopenedGot, err := reopenedCol.SearchVectorIndex(VectorIndexSearchOptions{IndexName: def.Name, Query: query, TopK: 2, EfSearch: len(rows)})
+	reopenedGot, err := reopenedCol.SearchVectorIndex(VectorIndexSearchOptions{IndexName: def.Name, Query: query, TopK: 2, EfSearch: len(rows), StatsMode: VectorIndexSearchStatsModeBenchmarkDebug})
 	if err != nil {
 		t.Fatalf("SearchVectorIndex reopen: %v", err)
 	}
@@ -235,7 +235,7 @@ func TestColumnVectorGraphRowRefStatePreservesOpaqueResultIDs1993(t *testing.T) 
 		_ = d.Close()
 		t.Fatalf("RebuildVectorIndex: %v", err)
 	}
-	got, err := col.SearchVectorIndex(VectorIndexSearchOptions{IndexName: def.Name, Query: []float32{1, 0, 0}, TopK: 1, EfSearch: 2})
+	got, err := col.SearchVectorIndex(VectorIndexSearchOptions{IndexName: def.Name, Query: []float32{1, 0, 0}, TopK: 1, EfSearch: 2, StatsMode: VectorIndexSearchStatsModeBenchmarkDebug})
 	if err != nil {
 		_ = d.Close()
 		t.Fatalf("SearchVectorIndex: %v", err)

--- a/TreeDB/collections/column_vector_graph_typed_column_test.go
+++ b/TreeDB/collections/column_vector_graph_typed_column_test.go
@@ -195,7 +195,7 @@ func TestSearchVectorIndexTypedColumnVectorReopenGeneration1782(t *testing.T) {
 		t.Fatalf("OpenCollection reopen: %v", err)
 	}
 	query := []float32{0, 0, 1}
-	got, err := reopenedCol.SearchVectorIndex(VectorIndexSearchOptions{IndexName: def.Name, Query: query, TopK: 2, EfSearch: len(rows), MaxDecodedBlocks: 1})
+	got, err := reopenedCol.SearchVectorIndex(VectorIndexSearchOptions{IndexName: def.Name, Query: query, TopK: 2, EfSearch: len(rows), MaxDecodedBlocks: 1, StatsMode: VectorIndexSearchStatsModeBenchmarkDebug})
 	if err != nil {
 		t.Fatalf("SearchVectorIndex reopen: %v", err)
 	}

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -350,7 +350,7 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/column_hnsw_search_pack_reader.go", classification: typedStorageLegacyDerived, matchingLines: 2, occurrences: 2},
 	{path: "TreeDB/collections/column_hnsw_search_pack_test.go", classification: typedStorageLegacyDerived, matchingLines: 1, occurrences: 2},
 	{path: "TreeDB/collections/column_hnsw_search_pack_writer.go", classification: typedStorageLegacyDerived, matchingLines: 3, occurrences: 3},
-	{path: "TreeDB/collections/collection_vector_index_prepared_search_cache.go", classification: typedStorageLegacyDerived, matchingLines: 2, occurrences: 2},
+	{path: "TreeDB/collections/collection_vector_index_prepared_search_cache.go", classification: typedStorageLegacyDerived, matchingLines: 3, occurrences: 3},
 	{path: "TreeDB/collections/column_int64_query.go", classification: typedStorageLegacyDerived, matchingLines: 2, occurrences: 2},
 	{path: "TreeDB/collections/column_int64_values_asset.go", classification: typedStorageLegacyDerived, matchingLines: 8, occurrences: 8},
 	{path: "TreeDB/collections/column_manifest_format.go", classification: typedStorageLegacyCompatibility, matchingLines: 2, occurrences: 2},

--- a/TreeDB/collections/vector_index.go
+++ b/TreeDB/collections/vector_index.go
@@ -172,10 +172,12 @@ const (
 // Collection-level high-QPS no-document searches are intentionally narrow: use
 // an explicit column_graph index, exact/zero QueryMode, IncludeDocuments=false,
 // no document projection, and no legacy filter fields. The current
-// Collection.SearchVectorIndex method is a response-owned one-shot convenience
-// boundary that opens a searcher per call. Collection.SearchVectorIndexWithBuffer
-// exposes caller-owned result storage for the exact no-document hnsw_search_pack_v1
-// seam and reuses collection-owned prepared pack state on warmed healthy current
+// Collection.SearchVectorIndex method is a response-owned convenience boundary
+// that uses the cached hnsw_search_pack_v1 route for healthy exact no-document
+// calls and falls back to a one-shot searcher for unsupported shapes.
+// Collection.SearchVectorIndexWithBuffer exposes caller-owned result storage for
+// the exact no-document hnsw_search_pack_v1 seam and reuses collection-owned
+// prepared pack state on warmed healthy current
 // state; callers that need explicit snapshot lifetime control can still use a
 // reusable VectorIndexSearcher with VectorIndexSearcher.SearchWithBuffer. To
 // materialize documents after a no-document search, open a CollectionReadView

--- a/TreeDB/collections/vector_index_search.go
+++ b/TreeDB/collections/vector_index_search.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"sync"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 	"github.com/snissn/gomap/TreeDB/internal/mappedresource"
@@ -12,6 +13,8 @@ import (
 // ErrVectorIndexSearchUnavailable reports that the requested vector index is
 // not currently searchable through the selected product path.
 var ErrVectorIndexSearchUnavailable = errors.New("collections: vector index search unavailable")
+
+var collectionSearchVectorIndexResponseBufferPool sync.Pool
 
 // VectorIndexSearchPath identifies the physical implementation used for a
 // public vector-index search.
@@ -717,20 +720,104 @@ func (r vectorIndexSearchRouteStats) apply(stats *VectorIndexSearchStats) {
 // With IncludeDocuments=false, SearchVectorIndex returns response-owned result
 // IDs and scores only and must not materialize documents. With
 // IncludeDocuments=true, document fetch happens after top-k selection and is
-// reported through document counters. This method currently opens and closes a
-// searcher per call, so its no-document benchmarks are one-shot/convenience
-// baselines rather than the high-QPS target; compare route/open counters before
-// treating it as a serving hot path. Use SearchVectorIndexWithBuffer for the
-// collection-level caller-owned result-buffer seam, and OpenVectorIndexSearcher
-// plus SearchWithBuffer when callers can keep open/prepared state outside the
-// timed query boundary. Callers that want a split search/fetch shape can run a
-// no-document search first, then use
+// reported through document counters. Exact no-document calls use the
+// collection-owned prepared hnsw_search_pack_v1 cache when healthy; unsupported
+// shapes and unavailable packs fall back to the one-shot searcher path. Use
+// SearchVectorIndexWithBuffer for the zero-allocation caller-owned result-buffer
+// seam, and OpenVectorIndexSearcher plus SearchWithBuffer when callers can keep
+// open/prepared state outside the timed query boundary. Callers that want a
+// split search/fetch shape can run a no-document search first, then use
 // CollectionReadView.FetchDocumentsForVectorIndexSearchResults as a separate
 // materialization phase with separate counters.
 func (c *Collection) SearchVectorIndex(opts VectorIndexSearchOptions) (VectorIndexSearchResponse, error) {
 	if err := validateVectorIndexSearchRequest(opts.TopK, opts.EfSearch); err != nil {
 		return VectorIndexSearchResponse{}, err
 	}
+	if collectionSearchVectorIndexCanUseBufferedNoDocumentRoute(opts) {
+		buffer := acquireCollectionSearchVectorIndexResponseBuffer()
+		response, err := c.SearchVectorIndexWithBuffer(opts, buffer)
+		if err == nil {
+			cloneBufferedVectorIndexSearchResponseResults(&response)
+			releaseCollectionSearchVectorIndexResponseBuffer(buffer)
+			return response, nil
+		}
+		releaseCollectionSearchVectorIndexResponseBuffer(buffer)
+		if !errors.Is(err, ErrVectorIndexSearchUnavailable) && !errors.Is(err, ErrIndexNotFound) {
+			return response, err
+		}
+	}
+	return c.searchVectorIndexOneShot(opts)
+}
+
+func acquireCollectionSearchVectorIndexResponseBuffer() *VectorIndexSearchBuffer {
+	if buffer, ok := collectionSearchVectorIndexResponseBufferPool.Get().(*VectorIndexSearchBuffer); ok && buffer != nil {
+		return buffer
+	}
+	return &VectorIndexSearchBuffer{}
+}
+
+func releaseCollectionSearchVectorIndexResponseBuffer(buffer *VectorIndexSearchBuffer) {
+	if buffer == nil {
+		return
+	}
+	buffer.Reset()
+	collectionSearchVectorIndexResponseBufferPool.Put(buffer)
+}
+
+func cloneBufferedVectorIndexSearchResponseResults(response *VectorIndexSearchResponse) {
+	if response == nil || len(response.Results) == 0 {
+		if response != nil {
+			response.Results = nil
+		}
+		return
+	}
+	idBytesLen := 0
+	for _, result := range response.Results {
+		idBytesLen += len(result.ID)
+	}
+	idBytes := make([]byte, idBytesLen)
+	results := make([]VectorIndexSearchResult, len(response.Results))
+	idOffset := 0
+	for i, result := range response.Results {
+		results[i] = result
+		if len(result.ID) > 0 {
+			idEnd := idOffset + len(result.ID)
+			copy(idBytes[idOffset:idEnd], result.ID)
+			results[i].ID = idBytes[idOffset:idEnd:idEnd]
+			idOffset = idEnd
+		}
+		if len(result.Document) > 0 {
+			results[i].Document = append([]byte(nil), result.Document...)
+		}
+	}
+	response.Results = results
+}
+
+func collectionSearchVectorIndexCanUseBufferedNoDocumentRoute(opts VectorIndexSearchOptions) bool {
+	if opts.IncludeDocuments || vectorIndexDocumentFetchOptionsNonZero(opts.DocumentFetchOptions) {
+		return false
+	}
+	if opts.Filter != nil || opts.IndexRangeFilter != nil {
+		return false
+	}
+	if opts.FetchMultiplier != 0 || opts.ExactFilterMaxDocs != 0 || opts.DisableExactFallback {
+		return false
+	}
+	if opts.QueryMode != "" && opts.QueryMode != VectorIndexQueryModeExact {
+		return false
+	}
+	if opts.QuantizedIndexName != "" || opts.QuantizedRerankCandidates != 0 {
+		return false
+	}
+	statsMode, err := columnVectorGraphNativeSearchStatsModeFromPublic(opts.StatsMode)
+	if err != nil || !columnHNSWSearchPackStatsModeSupportedForSearch(statsMode) {
+		return false
+	}
+	queryMode, err := normalizeVectorIndexSearchQueryMode(opts.QueryMode, opts.QuantizedIndexName, opts.QuantizedRerankCandidates, opts.TopK)
+	return err == nil && queryMode == columnVectorGraphNativeSearchQueryModeExact
+}
+
+func (c *Collection) searchVectorIndexOneShot(opts VectorIndexSearchOptions) (VectorIndexSearchResponse, error) {
 	searcher, response, err := c.openVectorIndexSearcher(VectorIndexSearcherOptions{
 		IndexName:        opts.IndexName,
 		MaxDecodedBlocks: opts.MaxDecodedBlocks,

--- a/TreeDB/collections/vector_index_search_test.go
+++ b/TreeDB/collections/vector_index_search_test.go
@@ -394,6 +394,7 @@ func TestSearchVectorIndexColumnGraphNativeReaderReopenV4(t *testing.T) {
 		TopK:             2,
 		EfSearch:         len(rows),
 		MaxDecodedBlocks: 1,
+		StatsMode:        VectorIndexSearchStatsModeBenchmarkDebug,
 	})
 	if err != nil {
 		t.Fatalf("SearchVectorIndex: %v", err)
@@ -475,10 +476,42 @@ func TestSearchVectorIndexNoDocumentHighQPSContractBoundary2361(t *testing.T) {
 	assertColumnGraphSearchResponseLoadedV4(t, noDocs, def.Name, 2)
 	assertVectorIndexSearchResultsV4(t, noDocs.Results, exactColumnGraphTopKForTest(t, rows, query, 2), false)
 	assertSearchVectorIndexNoDocumentCurrentOneShotStats2361(t, noDocs.Stats)
+	firstNoDocTopID := string(noDocs.Results[0].ID)
 	for i, result := range noDocs.Results {
 		if len(result.ID) == 0 || len(result.Document) != 0 {
 			t.Fatalf("no-doc result[%d]=%+v want ID/score only without document", i, result)
 		}
+	}
+	var searcherBuffer VectorIndexSearchBuffer
+	searcher, err := col.OpenVectorIndexSearcher(VectorIndexSearcherOptions{IndexName: def.Name, MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("OpenVectorIndexSearcher: %v", err)
+	}
+	searcherNoDocs, err := searcher.SearchWithBuffer(VectorIndexSearcherSearchOptions{Query: query, QueryMode: VectorIndexQueryModeExact, TopK: 2, EfSearch: len(rows)}, &searcherBuffer)
+	if closeErr := searcher.Close(); err == nil && closeErr != nil {
+		err = closeErr
+	}
+	if err != nil {
+		t.Fatalf("SearchWithBuffer no-doc: %v", err)
+	}
+	if len(noDocs.Results) != len(searcherNoDocs.Results) {
+		t.Fatalf("SearchVectorIndex results=%d SearchWithBuffer results=%d", len(noDocs.Results), len(searcherNoDocs.Results))
+	}
+	for i := range noDocs.Results {
+		if !bytes.Equal(noDocs.Results[i].ID, searcherNoDocs.Results[i].ID) || noDocs.Results[i].Ordinal != searcherNoDocs.Results[i].Ordinal || math.Abs(float64(noDocs.Results[i].Score-searcherNoDocs.Results[i].Score)) > 1e-6 {
+			t.Fatalf("result[%d] SearchVectorIndex=%+v SearchWithBuffer=%+v want same ID/order/score", i, noDocs.Results[i], searcherNoDocs.Results[i])
+		}
+	}
+	noDocsAgain, err := col.SearchVectorIndex(base)
+	if err != nil {
+		t.Fatalf("second SearchVectorIndex no-doc: %v", err)
+	}
+	assertSearchVectorIndexNoDocumentCurrentOneShotStats2361(t, noDocsAgain.Stats)
+	if string(noDocs.Results[0].ID) != firstNoDocTopID {
+		t.Fatalf("first no-doc response ID changed after second call: got %q want %q", noDocs.Results[0].ID, firstNoDocTopID)
+	}
+	if snap := col.collectionVectorIndexPreparedSearchCacheSnapshot(); snap.Entries != 1 || snap.CacheBuilds != 1 || snap.CacheHits == 0 {
+		t.Fatalf("cache snapshot after SearchVectorIndex no-doc route=%+v want reused collection prepared pack", snap)
 	}
 
 	withDocsOpts := base
@@ -1395,9 +1428,8 @@ func assertSearchVectorIndexNoDocumentCurrentOneShotStats2361(tb testing.TB, sta
 		stats.DocumentJSONReconstructionRows != 0 {
 		tb.Fatalf("no-doc stats=%+v want zero document materialization counters", stats)
 	}
-	assertSearchVectorIndexCurrentOneShotRoute2361(tb, "no-doc", stats)
-	if stats.HNSWSearchPackActive != 1 || stats.HNSWSearchPackOpenNanos == 0 {
-		tb.Fatalf("no-doc stats=%+v want hnsw_search_pack_v1 active/open evidence available for future high-QPS route", stats)
+	if !vectorIndexSearchStatsAreBufferedNoDocumentPackRoute(stats) {
+		tb.Fatalf("no-doc stats=%+v want Collection.SearchVectorIndex exact no-document cached hnsw_search_pack_v1 route", stats)
 	}
 	assertVectorIndexSearchNoFallbackStats2361(tb, stats)
 }

--- a/TreeDB/collections/vector_usearch_bench_test.go
+++ b/TreeDB/collections/vector_usearch_bench_test.go
@@ -320,14 +320,12 @@ func BenchmarkCollectionVectorUSearchProductionCompare(b *testing.B) {
 			b.Fatalf("measure SearchVectorIndex stats: %v", err)
 		}
 		stats := measured.Stats
-		if stats.SearchRouteColumnGraphPrepared+stats.SearchRouteColumnGraphFallback != 1 ||
-			stats.SearchRouteHNSWSearchPack != 0 ||
-			stats.HNSWSearchPackActive != 1 ||
+		if !vectorIndexSearchStatsAreBufferedNoDocumentPackRoute(stats) ||
 			stats.TypedColumnFallbacks != 0 ||
 			stats.VectorScratchDecodes != 0 ||
 			stats.GraphRowFallbacks != 0 ||
 			stats.DocumentsFetched != 0 {
-			b.Fatalf("TreeDB collection one-shot stats=%+v want current no-document SearchVectorIndex baseline with docs/fallback/decode counters clear and pack available but not selected", stats)
+			b.Fatalf("TreeDB collection no-doc stats=%+v want cached hnsw_search_pack_v1 SearchVectorIndex route with docs/fallback/decode counters clear", stats)
 		}
 		b.ReportAllocs()
 		b.ResetTimer()
@@ -349,8 +347,10 @@ func BenchmarkCollectionVectorUSearchProductionCompare(b *testing.B) {
 		reportVectorIndexSearchStatsModeBenchMetric2126(b, params.statsMode())
 		b.ReportMetric(1, "reported_stats_mode_full_diagnostics")
 		b.ReportMetric(1, "collection_searchvectorindex_one_shot")
-		b.ReportMetric(1, "open_searcher_calls/op")
-		b.ReportMetric(1, "open_setup_in_timed_loop")
+		b.ReportMetric(0, "open_searcher_calls/op")
+		b.ReportMetric(0, "open_setup_in_timed_loop")
+		b.ReportMetric(1, "response_owned_result_alloc/op")
+		reportCollectionVectorIndexPreparedSearchBenchMetrics2363(b, col.collectionVectorIndexPreparedSearchCacheSnapshot())
 		reportVectorIndexSearchBenchMetricsV4(b, b.N, stats, true)
 	})
 

--- a/TreeDB/docs/guides/vector-search-typed-column.md
+++ b/TreeDB/docs/guides/vector-search-typed-column.md
@@ -352,11 +352,12 @@ Use `scripts/bench_vector_search_compare.sh` for the optional external ANN
 baseline. Its current production comparison benchmark is
 `BenchmarkCollectionVectorUSearchProductionCompare`:
 
-- `TreeDB_CollectionSearchVectorIndexNoDocsOneShot` times today's public
-  collection-level no-document convenience API. It calls
-  `Collection.SearchVectorIndex` once per operation, so setup/open/validation,
-  response-owned result allocation, and close are inside the timed boundary. Use
-  this row as a baseline/guardrail only; it is not the high-QPS target.
+- `TreeDB_CollectionSearchVectorIndexNoDocsOneShot` times the public
+  collection-level no-document convenience API. Exact healthy calls use the
+  cached `hnsw_search_pack_v1` route with `open_searcher_calls/op=0` and
+  `open_setup_in_timed_loop=0`, but still allocate response-owned result/ID
+  storage. Use this row as the response-owned convenience route, not the
+  zero-allocation target.
 - `TreeDB_SearchWithBuffer` / `TreeDB_SearchWithBufferParallel` time persisted
   `column_graph` search through `Collection.OpenVectorIndexSearcher` and
   `VectorIndexSearcher.SearchWithBuffer`; setup, inserts, rebuild, open, and
@@ -392,9 +393,11 @@ TREEDB_VECTOR_BENCH_DOCS=10000 TREEDB_VECTOR_BENCH_DIMS=64 \
 
 Older `BenchmarkCollectionVectorIndex*` and graph-only rows remain useful
 historical controls, but they are not the current persisted production
-no-document fast path. One-shot `Collection.SearchVectorIndex` rows, including
-`TreeDB_CollectionSearchVectorIndexNoDocsOneShot`, include setup/open cost per
-operation; do not use them as the high-QPS production comparator.
+no-document fast path. The response-owned
+`TreeDB_CollectionSearchVectorIndexNoDocsOneShot` row should use the cached pack
+route but still reports convenience-wrapper allocations; use the buffered rows
+for zero-allocation high-QPS production claims. With-document one-shot rows still
+include setup/open and document materialization cost per operation.
 
 The broader legacy/canonical matrix remains useful when comparing with older
 artifacts or when you also need one-shot open/setup names:
@@ -415,7 +418,7 @@ Read the benchmark names and row labels before comparing numbers:
 | `OpenVectorIndexSearcher...Setup...` | Native-reader setup/open only; no search. |
 | `ColumnVectorGraphNativeSearchCosine...` | Lower-level graph traversal/scoring/top-k over the physical reader. |
 | `OpenVectorIndexSearcher...V4` | Reusable searcher steady-state query; setup/open outside timed loop. |
-| `SearchVectorIndex...V4` | Public one-shot search; setup/open inside each operation. |
+| `SearchVectorIndex...V4` | Public response-owned search; exact no-doc collection convenience rows use the cached pack route when healthy, while with-doc/unsupported one-shot rows include setup/open inside each operation. |
 | `...ReusableBuffer...` | Opened public no-document search with caller-owned reusable response buffers. |
 | `...WithDocumentsExcludeEmbedding1875` | Preferred projection-oriented final-fetch row: search plus post-top-k documents with the vector field excluded. |
 | `...WithDocumentsV4` | Explicit full-document comparison row: search plus post-top-k documents including the vector field. |

--- a/TreeDB/docs/spec/column-graph-native-vector-search.md
+++ b/TreeDB/docs/spec/column-graph-native-vector-search.md
@@ -102,13 +102,16 @@ response, _ := searcher.Search(collections.VectorIndexSearcherSearchOptions{
 fmt.Println(status.State, response.Path, response.Stats.RowFetches)
 ```
 
-Use `SearchVectorIndex` for response-owned one-shot calls. It opens and closes
-the native reader per call, so it measures setup/open cost in addition to graph
-search. Use `SearchVectorIndexWithBuffer` when collection-level code needs the
-exact no-document caller-owned result-buffer seam; healthy current
-`hnsw_search_pack_v1` state is prepared once in a collection-owned warmed cache.
-Use `OpenVectorIndexSearcher` plus `SearchWithBuffer` when callers need explicit
-snapshot/open lifetime control outside the hot loop.
+Use `SearchVectorIndex` for response-owned convenience calls. Exact
+no-document calls use the collection-owned prepared `hnsw_search_pack_v1` cache
+when healthy and own/copy the returned result storage for the response.
+With-document or unsupported shapes still use the one-shot reader path and report
+that setup/materialization cost. Use `SearchVectorIndexWithBuffer` when
+collection-level code needs the exact no-document caller-owned result-buffer
+seam; healthy current `hnsw_search_pack_v1` state is prepared once in a
+collection-owned warmed cache. Use `OpenVectorIndexSearcher` plus
+`SearchWithBuffer` when callers need explicit snapshot/open lifetime control
+outside the hot loop.
 
 ## Collection-level no-document high-QPS contract (#2361)
 
@@ -134,10 +137,11 @@ claiming high-QPS vector search:
   On warmed healthy current pack state, it reuses collection-owned prepared pack
   state and benchmark rows must report no per-search open/setup inside the timed
   boundary.
-- Current response-owned baseline boundary: `Collection.SearchVectorIndex` is
-  still a one-shot convenience API. It opens/closes per call and owns response
-  result buffers, so its no-document benchmark row is a baseline/regression
-  guardrail, not proof of high-QPS success.
+- Current response-owned convenience boundary: `Collection.SearchVectorIndex`
+  exact no-document calls use the same collection-owned prepared pack route when
+  healthy, but still allocate response-owned results/IDs. It is a convenience
+  fast route, not the zero-allocation target; use `SearchVectorIndexWithBuffer`
+  for the caller-owned-buffer target.
 - Document boundary: `IncludeDocuments=true` is an explicit post-top-k fetch
   path. It must report document counters (`docs_fetched/search`, output bytes,
   row-ref/point-fetch counters as applicable) and remains outside the
@@ -162,13 +166,13 @@ Healthy no-document fast-path evidence must include `ns/op`, `ops/sec`, `B/op`,
 - `vector_scratch_decodes/search=0`;
 - no per-search open/setup/validation/decode bottleneck in the timed boundary.
 
-The current one-shot baseline row should instead show the boundary explicitly,
-for example `open_searcher_calls/op=1`, `open_setup_in_timed_loop=1`,
-`search_route_hnsw_search_pack/search=0`, and the selected one-shot
-`column_graph` route (`search_route_column_graph_prepared/search=1` on direct
-prepared platforms, or `search_route_column_graph_fallback/search=1` when the
-platform/source state requires the existing non-pack route), while still proving
-no documents or graph-row/typed-vector fallback/scratch decodes.
+The response-owned no-document convenience row should show the cached pack route
+explicitly (`open_searcher_calls/op=0`, `open_setup_in_timed_loop=0`,
+`search_route_hnsw_search_pack/search=1`, documents/fallback/scratch counters at
+0) while separately reporting its response-owned result allocation. With-document
+one-shot rows should show `open_searcher_calls/op=1`,
+`open_setup_in_timed_loop=1`, document counters, and the selected non-pack
+`column_graph` route.
 
 ## Demo
 

--- a/scripts/bench_vector_search_compare.sh
+++ b/scripts/bench_vector_search_compare.sh
@@ -166,16 +166,13 @@ cat >"$RUN_DIR/README.md" <<EOF
 Canonical current production comparison:
 
 - \`BenchmarkCollectionVectorUSearchProductionCompare/TreeDB_CollectionSearchVectorIndexNoDocsOneShot\`
-  times today's public collection-level no-document convenience API. It calls
-  \`Collection.SearchVectorIndex\` once per operation, so setup/open/validation,
-  response-owned result allocation, and close are inside the timed boundary.
-  This row is a baseline and guardrail for future collection-level high-QPS work,
-  not a success criterion. It should report \`docs_fetched/search=0\`, no
-  graph-row fallback, no typed-column vector fallback, no vector scratch decode,
-  \`search_route_hnsw_search_pack/search=0\`, pack availability/open evidence,
-  the selected one-shot \`column_graph\` route (prepared on direct-view
-  platforms, fallback on heap-copy/source-limited platforms),
-  \`open_searcher_calls/op=1\`, and \`open_setup_in_timed_loop=1\`.
+  times the public response-owned collection-level no-document convenience API.
+  Exact healthy calls use the collection-owned prepared \`hnsw_search_pack_v1\`
+  cache, so this row should report \`docs_fetched/search=0\`, no graph-row
+  fallback, no typed-column vector fallback, no vector scratch decode,
+  \`search_route_hnsw_search_pack/search=1\`, \`open_searcher_calls/op=0\`,
+  and \`open_setup_in_timed_loop=0\`. It still reports
+  \`response_owned_result_alloc/op=1\` and is not the zero-allocation target.
 - \`BenchmarkCollectionVectorUSearchProductionCompare/TreeDB_SearchWithBuffer\`
   and \`.../TreeDB_SearchWithBufferParallel\` time the persisted TreeDB
   no-document \`hnsw_search_pack_v1\` route through
@@ -228,8 +225,9 @@ Legacy/control rows:
   vector-index controls. They are useful historical comparators but are not the
   current production no-document fast path.
 - \`BenchmarkCollectionVectorSearchExact\` is an exact scan control.
-- Other one-shot \`Collection.SearchVectorIndex\` benchmarks pay setup/open costs
-  per operation and should not be presented as the high-QPS production fast path.
+- With-document or unsupported one-shot \`Collection.SearchVectorIndex\`
+  benchmarks pay setup/open and/or materialization costs per operation and should
+  not be presented as the no-document high-QPS production fast path.
 
 Data boundary: TreeDB stores generated float32 vectors through JSON collection
 inserts and rebuilds the persisted \`column_graph\` plus derived


### PR DESCRIPTION
## Summary

Closes #2365. Parent tracker: #2360. Depends on merged #2364.

Changes:

- Routes exact no-document `Collection.SearchVectorIndex` through the collection-owned prepared `hnsw_search_pack_v1` cache when the request shape is supported and the pack/document-ID serving state is healthy.
- Keeps response-owned convenience semantics by cloning buffered results/ID bytes before returning; uses a small pooled temporary `VectorIndexSearchBuffer` for scratch reuse.
- Falls back to the existing one-shot searcher path for documents, filters, quantized/unsupported modes, missing/stale/unavailable packs, and legacy fallback controls.
- Preserves fail-closed document-ID state validation before using the pack route so corrupted/missing authoritative ID state does not get bypassed.
- Updates benchmarks/docs to mark the no-doc `SearchVectorIndex` row as cached pack route with response-owned allocation, while with-doc rows remain explicit one-shot/materialization rows.

## Scope / non-goals

- Does not change `SearchVectorIndexWithBuffer` zero-allocation contract.
- Does not route `IncludeDocuments=true`, filters, quantized modes, benchmark-debug stats, or stale/missing packs through the no-doc pack route.
- Does not tune graph quality or HNSW construction/search parameters.

## Validation

Focused route/fallback tests:

```sh
GOWORK=off go test ./TreeDB/collections \
  -run 'TestSearchVectorIndexNoDocumentHighQPSContractBoundary2361|TestColumnVectorGraphDocumentIDStateMissingAssetFailsClosed2013|TestColumnVectorGraphDocumentIDStateCorruptFailsClosed2013|TestSearchVectorIndexFlushesBufferedWritesBeforeSnapshotV4|TestSearchVectorIndexColumnGraphUnavailableStatusV4|TestSearchVectorIndexColumnGraphStaleAfterMutationV4|TestSearchVectorIndexColumnGraphMutationStaleStatusSurvivesReopenV5' \
  -count=1
```

PASS: `/tmp/gomap_2365_candidate_20260605_023209/focused_tests3.log`

Capacity-isolation/final focused check:

```sh
GOWORK=off go test ./TreeDB/collections \
  -run 'TestSearchVectorIndexColumnGraphResultIDsAreCapacityIsolatedV4|TestSearchVectorIndexNoDocumentHighQPSContractBoundary2361' \
  -count=1
```

PASS: `/tmp/gomap_2365_candidate_20260605_023209/focused_tests4.log`

Full collections package:

```sh
GOWORK=off go test ./TreeDB/collections -count=1
```

PASS: `/tmp/gomap_2365_candidate_20260605_023209/collections_tests5.log`

Docs tests:

```sh
GOWORK=off go test ./TreeDB/docs -count=1
```

PASS: `/tmp/gomap_2365_candidate_20260605_023209/docs_tests2.log`

## Performance evidence

Baseline from `origin/main@42fed163c53589d17b78b7c193f8b81edcba7a06`:

- `/tmp/gomap_2365_baseline_20260605_023903/bench_script.log`

Candidate head `18dcfc7ae`:

- `/tmp/gomap_2365_candidate_20260605_023209/bench_script2.log`

Benchmark command:

```sh
TREEDB_VECTOR_BENCH_DOCS=10000 TREEDB_VECTOR_BENCH_DIMS=64 \
TREEDB_VECTOR_BENCH_QUERIES=16 BENCHTIME=20x COUNT=1 \
BENCH_REGEX='BenchmarkCollectionVectorUSearchProductionCompare$' \
scripts/bench_vector_search_compare.sh
```

| Row | Baseline ns/op | Baseline B/op | Baseline allocs/op | Candidate ns/op | Candidate B/op | Candidate allocs/op | Route/counters |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| `TreeDB_CollectionSearchVectorIndexNoDocsOneShot` cpu=1 | 9,242,967 | 14,575,917 | 5,382 | 60,442 | 816 | 2 | pack=1, docs=0, open/setup=0/0 |
| `TreeDB_CollectionSearchVectorIndexNoDocsOneShot` cpu=8 | 8,507,567 | 14,584,246 | 5,382 | 81,279 | 816 | 2 | pack=1, docs=0, open/setup=0/0 |
| `TreeDB_CollectionSearchVectorIndexWithBuffer` cpu=1 | 86,123 | 0 | 0 | 55,221 | 0 | 0 | unchanged zero-allocation buffered route |
| `TreeDB_CollectionSearchVectorIndexWithDocumentsOneShot` cpu=1 | 9,622,177 | 17,939,550 | 9,578 | 9,645,806 | 17,939,623 | 9,579 | explicit with-doc one-shot/materialization |

Candidate no-doc row also reports `graph_row_fallbacks/search=0`, `typed_column_vector_fallbacks/search=0`, `vector_scratch_decodes/search=0`, `docs_fetched/search=0`, `search_route_hnsw_search_pack/search=1`, `open_searcher_calls/op=0`, `open_setup_in_timed_loop=0`, and `response_owned_result_alloc/op=1`.

## Review / merge status

- Local focused/full tests and benchmark smoke passed.
- Latest-head CI and AI reviews requested after PR creation.
