### PR TITLE
docs: close high-QPS collection vector search

### DIFF
--- a/TreeDB/README.md
+++ b/TreeDB/README.md
@@ -211,6 +211,8 @@ Use `CPU_LIST=1,8` for c=1/c=8 evidence. Older `BenchmarkCollectionVectorIndex*`
 rows are historical controls, not the current high-QPS production fast path;
 with-documents `Collection.SearchVectorIndex` rows still include setup/open and
 materialization cost and should not be presented as the no-document fast path.
+See `TreeDB/docs/guides/vector-search-high-qps-collection-api.md` for the final
+collection API boundary, guardrail counters, and profile capture notes.
 Override `USEARCH_VERSION`, `USEARCH_ROOT`, `TREEDB_VECTOR_BENCH_DOCS`,
 `TREEDB_VECTOR_BENCH_DIMS`, `TREEDB_VECTOR_BENCH_M`,
 `TREEDB_VECTOR_BENCH_EF_CONSTRUCTION`, `TREEDB_VECTOR_BENCH_EF_SEARCH`,

--- a/TreeDB/docs/guides/vector-search-high-qps-collection-api.md
+++ b/TreeDB/docs/guides/vector-search-high-qps-collection-api.md
@@ -24,8 +24,16 @@ high-QPS path:
 - `graph_row_fallbacks/search=0`
 - `typed_column_vector_fallbacks/search=0`
 - `vector_scratch_decodes/search=0`
+
+Collection-level one-shot/buffer rows must additionally prove there is no
+per-query open/setup in the timed loop:
+
 - `open_searcher_calls/op=0`
 - `open_setup_in_timed_loop=0`
+
+Reusable-searcher `SearchWithBuffer` rows open the searcher before `ResetTimer`
+and may not emit those collection-level open/setup counters; their open/setup
+boundary is proven by the benchmark shape plus the route/fallback counters above.
 
 `Collection.SearchVectorIndexWithBuffer` must also report `0 B/op` and
 `0 allocs/op`. `Collection.SearchVectorIndex` no-document convenience rows

--- a/TreeDB/docs/guides/vector-search-high-qps-collection-api.md
+++ b/TreeDB/docs/guides/vector-search-high-qps-collection-api.md
@@ -1,7 +1,7 @@
 # TreeDB high-QPS collection vector search
 
 This guide summarizes the collection-level vector-search API boundary after the
-#2360 high-QPS work.
+`#2360` high-QPS work.
 
 ## API boundary
 
@@ -63,13 +63,28 @@ Canonical rows:
 
 ## Profile capture notes
 
-For focused CPU profiles of the response-owned no-document convenience row:
+For focused CPU profiles of the response-owned no-document convenience row,
+bootstrap USearch with `scripts/bench_vector_search_compare.sh` and reuse the
+host-specific include/library directories recorded in that run's README:
 
 ```sh
-USEARCH_ROOT=/tmp/usearch_2.25.2_macos_arm64/root
-export CGO_CFLAGS="-I$USEARCH_ROOT"
-export CGO_LDFLAGS="-L$USEARCH_ROOT -Wl,-rpath,$USEARCH_ROOT -lusearch_c"
-export DYLD_LIBRARY_PATH="$USEARCH_ROOT:${DYLD_LIBRARY_PATH:-}"
+RUN_DIR=/tmp/gomap_vector_search_compare_profile_bootstrap
+export RUN_DIR
+TREEDB_VECTOR_BENCH_DOCS=10000 TREEDB_VECTOR_BENCH_DIMS=64 \
+  TREEDB_VECTOR_BENCH_M=16 TREEDB_VECTOR_BENCH_EF_CONSTRUCTION=128 \
+  TREEDB_VECTOR_BENCH_EF_SEARCH=128 TREEDB_VECTOR_BENCH_TOPK=10 \
+  TREEDB_VECTOR_BENCH_QUERIES=16 CPU_LIST=1 BENCHTIME=1x COUNT=1 \
+  BENCH_REGEX='BenchmarkCollectionVectorUSearchProductionCompare$' \
+  scripts/bench_vector_search_compare.sh
+
+USEARCH_INCLUDE_DIR=$(awk -F'`' '/USearch include dir:/ { print $2 }' "$RUN_DIR/README.md")
+USEARCH_LIB_DIR=$(awk -F'`' '/USearch lib dir:/ { print $2 }' "$RUN_DIR/README.md")
+export CGO_CFLAGS="-I$USEARCH_INCLUDE_DIR"
+export CGO_LDFLAGS="-L$USEARCH_LIB_DIR -Wl,-rpath,$USEARCH_LIB_DIR -lusearch_c"
+case "$(uname -s)" in
+  Linux) export LD_LIBRARY_PATH="$USEARCH_LIB_DIR:${LD_LIBRARY_PATH:-}" ;;
+  Darwin) export DYLD_LIBRARY_PATH="$USEARCH_LIB_DIR:${DYLD_LIBRARY_PATH:-}" ;;
+esac
 
 TREEDB_VECTOR_BENCH_DOCS=10000 TREEDB_VECTOR_BENCH_DIMS=64 \
   TREEDB_VECTOR_BENCH_M=16 TREEDB_VECTOR_BENCH_EF_CONSTRUCTION=128 \

--- a/TreeDB/docs/guides/vector-search-high-qps-collection-api.md
+++ b/TreeDB/docs/guides/vector-search-high-qps-collection-api.md
@@ -1,0 +1,91 @@
+# TreeDB high-QPS collection vector search
+
+This guide summarizes the collection-level vector-search API boundary after the
+#2360 high-QPS work.
+
+## API boundary
+
+| API | Result ownership | Document fetch | Intended use |
+| --- | --- | --- | --- |
+| `Collection.SearchVectorIndexWithBuffer` | caller-owned `VectorIndexSearchBuffer` | rejected | primary high-QPS no-document serving path; steady state should be `0 B/op`, `0 allocs/op` |
+| `Collection.SearchVectorIndex` with `IncludeDocuments=false` | response-owned results/IDs | no documents | convenience no-document path; uses the same cached `hnsw_search_pack_v1` route when healthy, but allocates response-owned result storage |
+| `Collection.SearchVectorIndex` with `IncludeDocuments=true` | response-owned results/documents | included in timed call | explicit with-documents/materialization path; not a no-document high-QPS success row |
+| `CollectionReadView.FetchDocumentsForVectorIndexSearchResults` | response-owned documents | separate post-search call | explicit split search/fetch materialization phase for top-k IDs |
+| `OpenVectorIndexSearcher` + `SearchWithBuffer` | caller-owned buffer | rejected by buffered search | reusable-searcher path when callers control snapshot/open lifetime |
+
+## Required no-document route counters
+
+Healthy no-document rows must prove all of the following before claiming the
+high-QPS path:
+
+- `search_route_hnsw_search_pack/search=1`
+- `hnsw_search_pack_active/search=1`
+- `docs_fetched/search=0`
+- `graph_row_fallbacks/search=0`
+- `typed_column_vector_fallbacks/search=0`
+- `vector_scratch_decodes/search=0`
+- `open_searcher_calls/op=0`
+- `open_setup_in_timed_loop=0`
+
+`Collection.SearchVectorIndexWithBuffer` must also report `0 B/op` and
+`0 allocs/op`. `Collection.SearchVectorIndex` no-document convenience rows
+should report `response_owned_result_alloc/op=1` and account for the small
+response-owned allocation separately. Filters, projections, debug-only stats,
+quantized modes, and document materialization are outside this exact no-document
+contract unless they have an explicitly separate fail-closed route and benchmark
+row.
+
+## Benchmark command
+
+Use the production comparison benchmark for final c=1/c=8 evidence:
+
+```sh
+TREEDB_VECTOR_BENCH_DOCS=10000 TREEDB_VECTOR_BENCH_DIMS=64 \
+  TREEDB_VECTOR_BENCH_M=16 TREEDB_VECTOR_BENCH_EF_CONSTRUCTION=128 \
+  TREEDB_VECTOR_BENCH_EF_SEARCH=128 TREEDB_VECTOR_BENCH_TOPK=10 \
+  TREEDB_VECTOR_BENCH_QUERIES=16 CPU_LIST=1,8 BENCHTIME=1000x COUNT=3 \
+  BENCH_REGEX='BenchmarkCollectionVectorUSearchProductionCompare$' \
+  scripts/bench_vector_search_compare.sh
+```
+
+Canonical rows:
+
+- `TreeDB_CollectionSearchVectorIndexWithBuffer`: collection-level
+  caller-owned-buffer no-document target.
+- `TreeDB_CollectionSearchVectorIndexNoDocsOneShot`: response-owned
+  no-document convenience route.
+- `TreeDB_SearchWithBuffer` and `TreeDB_SearchWithBufferParallel`: reusable
+  searcher/buffer route.
+- `TreeDB_CollectionSearchVectorIndexWithDocumentsOneShot`: explicit
+  with-documents/materialization row.
+- `USearch_Search` and `USearch_SearchParallel`: pure in-memory external ANN
+  baseline.
+
+## Profile capture notes
+
+For focused CPU profiles of the response-owned no-document convenience row:
+
+```sh
+USEARCH_ROOT=/tmp/usearch_2.25.2_macos_arm64/root
+export CGO_CFLAGS="-I$USEARCH_ROOT"
+export CGO_LDFLAGS="-L$USEARCH_ROOT -Wl,-rpath,$USEARCH_ROOT -lusearch_c"
+export DYLD_LIBRARY_PATH="$USEARCH_ROOT:${DYLD_LIBRARY_PATH:-}"
+
+TREEDB_VECTOR_BENCH_DOCS=10000 TREEDB_VECTOR_BENCH_DIMS=64 \
+  TREEDB_VECTOR_BENCH_M=16 TREEDB_VECTOR_BENCH_EF_CONSTRUCTION=128 \
+  TREEDB_VECTOR_BENCH_EF_SEARCH=128 TREEDB_VECTOR_BENCH_TOPK=10 \
+  TREEDB_VECTOR_BENCH_QUERIES=16 \
+  go test -tags usearch_bench ./TreeDB/collections -run '^$' \
+  -bench '^BenchmarkCollectionVectorUSearchProductionCompare/TreeDB_CollectionSearchVectorIndexNoDocsOneShot$' \
+  -benchmem -benchtime=100000x -count=1 -cpu=1 \
+  -cpuprofile /tmp/treedb_collection_searchvector_c1.pprof
+```
+
+Repeat with `-cpu=8` for the c=8 profile. Go benchmark CPU profiles include
+fixture setup/rebuild work before the timed loop; use the benchmark route
+counters above to distinguish setup from steady-state query costs. In steady
+state, expected dominant query costs are HNSW pack traversal, dot/scoring,
+frontier/top-k maintenance, and final result-ID copy for response-owned
+convenience calls. Dominant document/JSON materialization, graph-row fallback,
+typed-column vector fallback, per-query open/prepare, or allocation/GC costs are
+not acceptable in no-document fast rows.

--- a/TreeDB/docs/guides/vector-search-typed-column.md
+++ b/TreeDB/docs/guides/vector-search-typed-column.md
@@ -348,8 +348,10 @@ inverse norms including storage/rebuild cost.
 
 ## USearch comparison boundary
 
-Use `scripts/bench_vector_search_compare.sh` for the optional external ANN
-baseline. Its current production comparison benchmark is
+See `vector-search-high-qps-collection-api.md` for the final collection API
+boundary, route guardrails, and profile capture notes. Use
+`scripts/bench_vector_search_compare.sh` for the optional external ANN baseline.
+Its current production comparison benchmark is
 `BenchmarkCollectionVectorUSearchProductionCompare`:
 
 - `TreeDB_CollectionSearchVectorIndexNoDocsOneShot` times the public


### PR DESCRIPTION
## Objective

Close out the high-QPS collection vector-search workstream with final API-boundary docs, guardrail counters, and benchmark/profile evidence for #2366.

Closes #2366.

## Context

#2361-#2365 landed the contract, buffered collection seam, collection-owned prepared-search cache, document-fetch split, and cached no-document `Collection.SearchVectorIndex` route. This PR records the final production boundary so the zero-allocation buffered path is not confused with the response-owned convenience path or the with-document materialization path.

## Non-goals

- No new vector-search feature route.
- No on-disk format change.
- No attempt to make `Collection.SearchVectorIndex` response-owned convenience calls zero-allocation.
- No changes to filters/projections/quantized modes; they remain outside the exact no-document high-QPS contract unless handled by a separate fail-closed route.

## Design

- Adds `TreeDB/docs/guides/vector-search-high-qps-collection-api.md` covering:
  - API boundary for `SearchVectorIndexWithBuffer`, `SearchVectorIndex`, split document fetch, and reusable searchers.
  - Required no-document guardrail counters.
  - Canonical production benchmark command and rows.
  - c=1/c=8 profile capture notes and bottleneck classification.
- Links the new guide from `TreeDB/README.md` and the typed-column vector guide.

## Scope

- Includes:
  - `TreeDB/docs/guides/vector-search-high-qps-collection-api.md`
  - `TreeDB/README.md`
  - `TreeDB/docs/guides/vector-search-typed-column.md`
- Excludes:
  - Runtime code changes.
  - Benchmark harness changes.
  - API or on-disk format changes.

## Correctness

Tests run:

```sh
GOWORK=off go test ./TreeDB/docs -count=1
GOWORK=off go test ./TreeDB/collections -run 'TestSearchVectorIndexNoDocumentHighQPSContractBoundary2361|TestVectorIndexSearchNoDocumentSplitFetchDocuments2364|TestSearchVectorIndexWithBufferPreparedCache|TestSearchVectorIndexColumnGraphResultIDsAreCapacityIsolatedV4' -count=1
GOWORK=off go test ./TreeDB/collections -count=1
```

Validation artifacts: `/tmp/gomap_2366_final_20260605_030355/`.

## Performance

Benchmark command:

```sh
TREEDB_VECTOR_BENCH_DOCS=10000 TREEDB_VECTOR_BENCH_DIMS=64 \
  TREEDB_VECTOR_BENCH_M=16 TREEDB_VECTOR_BENCH_EF_CONSTRUCTION=128 \
  TREEDB_VECTOR_BENCH_EF_SEARCH=128 TREEDB_VECTOR_BENCH_TOPK=10 \
  TREEDB_VECTOR_BENCH_QUERIES=16 CPU_LIST=1,8 BENCHTIME=1000x COUNT=3 \
  BENCH_REGEX='BenchmarkCollectionVectorUSearchProductionCompare$' \
  scripts/bench_vector_search_compare.sh
```

Median summary from `tier_s_bench.log`:

| Row | cpu | median ns/op | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: |
| `TreeDB_CollectionSearchVectorIndexWithBuffer` | 1 | 43,049 | 0 | 0 |
| `TreeDB_CollectionSearchVectorIndexWithBuffer` | 8 | 43,307 | 0 | 0 |
| `TreeDB_CollectionSearchVectorIndexNoDocsOneShot` | 1 | 43,016 | 816 | 2 |
| `TreeDB_CollectionSearchVectorIndexNoDocsOneShot` | 8 | 44,679 | 816 | 2 |
| `TreeDB_SearchWithBuffer` | 1 | 43,612 | 0 | 0 |
| `TreeDB_SearchWithBuffer` | 8 | 44,269 | 0 | 0 |
| `TreeDB_SearchWithBufferParallel` | 8 | 8,610 | 0 | 0 |
| `USearch_Search` | 1 | 30,065 | 136 | 3 |
| `USearch_Search` | 8 | 32,309 | 136 | 3 |
| `USearch_SearchParallel` | 8 | 6,906 | 139 | 3 |
| `TreeDB_CollectionSearchVectorIndexWithDocumentsOneShot` | 1 | 9,905,729 | 17,948,280 | 9,598 |

Guardrail proof from first c=1 samples:

| Row | pack route | docs fetched | open calls/op | open setup in timed loop | graph/vector/scratch fallbacks | response-owned alloc/op |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| `TreeDB_CollectionSearchVectorIndexWithBuffer` | 1.000 | 0 | 0 | 0 | 0 | 0 |
| `TreeDB_CollectionSearchVectorIndexNoDocsOneShot` | 1.000 | 0 | 0 | 0 | 0 | 1.000 |
| `TreeDB_SearchWithBuffer` | 1.000 | 0 | n/a | n/a | 0 | n/a |
| `TreeDB_CollectionSearchVectorIndexWithDocumentsOneShot` | 0 | 10.00 | 1.000 | 1.000 | 0 | 1.000 |

Additional focused artifacts:

- `profile_c1_100k.log`, `no_doc_c1_100k_cpu.pprof`, `no_doc_c1_100k_cpu_top.txt`
- `profile_c8_100k.log`, `no_doc_c8_100k_cpu.pprof`, `no_doc_c8_100k_cpu_top.txt`
- `with_buffer_alloc_proof.log`, `with_buffer_c1_100k_mem.pprof` (`0 B/op`, `0 allocs/op`)
- `closeout_summary.md`

## Rollout / Toggle Plan

Docs-only closeout. Runtime behavior is already controlled by the fail-closed route checks landed in #2361-#2365.

## Follow-ups

- Close parent tracker #2360 after this PR is merged.
- Keep with-document/materialization and any filter/projection/quantized paths as separate rows and claims.

## AI Review Loop

- Codex latest-head review: passed on `0669006e2` ("Didn't find any major issues"). Earlier Codex findings were fixed.
- Copilot latest-head review: requested after final push; no formal review returned in `gh pr view` at closeout.
- CodeRabbit latest-head review: completed after final push; earlier actionable Markdown finding fixed.
- Review comments/threads resolved or explicitly dismissed: all review threads resolved.
- Re-requested after final meaningful push: yes (`@codex review`, `@copilot review`, `@coderabbitai review`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* **Added**: New guide covering high-QPS vector-search collection API boundaries, performance guardrails, official benchmarking methodology, and profiling best practices.
* **Updated**: Related vector-search documentation now references the new comprehensive API guide and benchmark scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
