### PR TITLE
Fix column visibility upsert indexing

### DIFF
--- a/TreeDB/collections/column_physical_visibility.go
+++ b/TreeDB/collections/column_physical_visibility.go
@@ -221,7 +221,7 @@ func (c *Collection) latestColumnPhysicalVisibleRowAtSnapshot(
 
 type columnPhysicalVisibilityIndex struct {
 	rows        []columnPhysicalVisibleRow
-	byHash      map[uint64]int
+	byHash      map[uint64][]int
 	bytesArena  []byte
 	valuesArena []columnDeclaredValue
 }
@@ -234,8 +234,7 @@ const (
 func (idx *columnPhysicalVisibilityIndex) upsert(row columnPhysicalScanRowView) {
 	hash := columnPhysicalQueryHashBytes(row.ID)
 	if idx.byHash != nil {
-		if posPlusOne := idx.byHash[hash]; posPlusOne != 0 {
-			pos := posPlusOne - 1
+		for _, pos := range idx.byHash[hash] {
 			if bytes.Equal(idx.rows[pos].ID, row.ID) {
 				if columnPhysicalScanRowViewNewer(row, idx.rows[pos]) {
 					idx.assignColumnPhysicalVisibleRow(&idx.rows[pos], row)
@@ -244,23 +243,13 @@ func (idx *columnPhysicalVisibilityIndex) upsert(row columnPhysicalScanRowView) 
 			}
 		}
 	}
-	for pos := range idx.rows {
-		if bytes.Equal(idx.rows[pos].ID, row.ID) {
-			if columnPhysicalScanRowViewNewer(row, idx.rows[pos]) {
-				idx.assignColumnPhysicalVisibleRow(&idx.rows[pos], row)
-			}
-			return
-		}
-	}
 	if idx.byHash == nil {
-		idx.byHash = make(map[uint64]int, 1024)
+		idx.byHash = make(map[uint64][]int, 1024)
 	}
 	idx.rows = append(idx.rows, columnPhysicalVisibleRow{ID: idx.cloneBytes(row.ID)})
 	pos := len(idx.rows) - 1
 	idx.assignColumnPhysicalVisibleRow(&idx.rows[pos], row)
-	if idx.byHash[hash] == 0 {
-		idx.byHash[hash] = pos + 1
-	}
+	idx.byHash[hash] = append(idx.byHash[hash], pos)
 }
 
 func (idx *columnPhysicalVisibilityIndex) assignColumnPhysicalVisibleRow(dst *columnPhysicalVisibleRow, row columnPhysicalScanRowView) {

--- a/TreeDB/collections/column_physical_visibility_test.go
+++ b/TreeDB/collections/column_physical_visibility_test.go
@@ -1,6 +1,184 @@
 package collections
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+)
+
+func TestColumnPhysicalVisibilityIndexUpsertKeepsLatestAndClonesID2378(t *testing.T) {
+	var idx columnPhysicalVisibilityIndex
+	id := []byte("row-1")
+	value := []byte("old")
+	idx.upsert(columnPhysicalScanRowView{
+		AppliedCommandLSN: 2,
+		ID:                id,
+		Values: []columnDeclaredValue{
+			{Present: true, StringBytes: value},
+		},
+	})
+
+	id[0] = 'X'
+	value[0] = 'X'
+	if len(idx.rows) != 1 {
+		t.Fatalf("rows=%d want 1", len(idx.rows))
+	}
+	if got := string(idx.rows[0].ID); got != "row-1" {
+		t.Fatalf("ID aliased scanner scratch: got %q", got)
+	}
+	if got := string(idx.rows[0].Values[0].StringBytes); got != "old" {
+		t.Fatalf("value aliased scanner scratch: got %q", got)
+	}
+
+	idx.upsert(columnPhysicalScanRowView{
+		AppliedCommandLSN: 1,
+		ID:                []byte("row-1"),
+		Values: []columnDeclaredValue{
+			{Present: true, StringBytes: []byte("older")},
+		},
+	})
+	if got := string(idx.rows[0].Values[0].StringBytes); got != "old" {
+		t.Fatalf("older row replaced visible row: got %q", got)
+	}
+
+	idx.upsert(columnPhysicalScanRowView{
+		AppliedCommandLSN: 3,
+		ID:                []byte("row-1"),
+		Deleted:           true,
+	})
+	if len(idx.rows) != 1 {
+		t.Fatalf("delete duplicated row: rows=%d", len(idx.rows))
+	}
+	if !idx.rows[0].Deleted || idx.rows[0].Values != nil {
+		t.Fatalf("delete not visible: deleted=%t values=%v", idx.rows[0].Deleted, idx.rows[0].Values)
+	}
+
+	idx.upsert(columnPhysicalScanRowView{
+		AppliedCommandLSN: 4,
+		ID:                []byte("row-1"),
+		Values: []columnDeclaredValue{
+			{Present: true, StringBytes: []byte("new")},
+		},
+	})
+	if idx.rows[0].Deleted {
+		t.Fatalf("newer insert did not replace delete")
+	}
+	if got := string(idx.rows[0].Values[0].StringBytes); got != "new" {
+		t.Fatalf("newer row value=%q want new", got)
+	}
+}
+
+func TestColumnPhysicalVisibilityIndexUpsertHandlesHashBucketCollision2378(t *testing.T) {
+	var idx columnPhysicalVisibilityIndex
+	targetID := []byte("target")
+	targetHash := columnPhysicalQueryHashBytes(targetID)
+	idx.rows = append(idx.rows, columnPhysicalVisibleRow{ID: []byte("different")})
+	idx.byHash = map[uint64][]int{
+		targetHash: {0},
+	}
+
+	idx.upsert(columnPhysicalScanRowView{
+		AppliedCommandLSN: 1,
+		ID:                targetID,
+		Values: []columnDeclaredValue{
+			{Present: true, StringBytes: []byte("first")},
+		},
+	})
+	if len(idx.rows) != 2 {
+		t.Fatalf("rows=%d want 2 after collision insert", len(idx.rows))
+	}
+	if got := len(idx.byHash[targetHash]); got != 2 {
+		t.Fatalf("collision bucket len=%d want 2", got)
+	}
+
+	idx.upsert(columnPhysicalScanRowView{
+		AppliedCommandLSN: 2,
+		ID:                []byte("target"),
+		Values: []columnDeclaredValue{
+			{Present: true, StringBytes: []byte("second")},
+		},
+	})
+	if len(idx.rows) != 2 {
+		t.Fatalf("matching collision bucket row duplicated: rows=%d", len(idx.rows))
+	}
+	if got := len(idx.byHash[targetHash]); got != 2 {
+		t.Fatalf("collision bucket grew on update: len=%d", got)
+	}
+	if got := string(idx.rows[1].Values[0].StringBytes); got != "second" {
+		t.Fatalf("collision bucket update value=%q want second", got)
+	}
+}
+
+func TestColumnPhysicalVisibilityIndexUpsertLatestTieBreakers2378(t *testing.T) {
+	var idx columnPhysicalVisibilityIndex
+	upsert := func(lsn, generation, partID uint64, rowIndex int, value string) {
+		idx.upsert(columnPhysicalScanRowView{
+			AppliedCommandLSN: lsn,
+			Generation:        generation,
+			PartID:            partID,
+			RowIndex:          rowIndex,
+			ID:                []byte("row"),
+			Values: []columnDeclaredValue{
+				{Present: true, StringBytes: []byte(value)},
+			},
+		})
+		if len(idx.rows) != 1 {
+			t.Fatalf("rows=%d want 1 after %q", len(idx.rows), value)
+		}
+	}
+	want := func(value string) {
+		if got := string(idx.rows[0].Values[0].StringBytes); got != value {
+			t.Fatalf("visible value=%q want %q", got, value)
+		}
+	}
+
+	upsert(10, 1, 1, 1, "base")
+	upsert(9, 100, 100, 100, "older-lsn")
+	want("base")
+	upsert(10, 2, 1, 1, "newer-generation")
+	want("newer-generation")
+	upsert(10, 2, 0, 100, "older-part")
+	want("newer-generation")
+	upsert(10, 2, 3, 1, "newer-part")
+	want("newer-part")
+	upsert(10, 2, 3, 0, "older-row")
+	want("newer-part")
+	upsert(10, 2, 3, 2, "newer-row")
+	want("newer-row")
+	upsert(11, 0, 0, 0, "newer-lsn")
+	want("newer-lsn")
+}
+
+func TestColumnPhysicalVisibilityIndexUpsertIndexesUniqueIDs2378(t *testing.T) {
+	var idx columnPhysicalVisibilityIndex
+	const rows = 4096
+	for i := 0; i < rows; i++ {
+		idx.upsert(columnPhysicalScanRowView{
+			AppliedCommandLSN: uint64(i + 1),
+			ID:                []byte(fmt.Sprintf("row-%06d", i)),
+		})
+	}
+	if len(idx.rows) != rows {
+		t.Fatalf("rows=%d want %d", len(idx.rows), rows)
+	}
+	positions := 0
+	for hash, bucket := range idx.byHash {
+		if len(bucket) == 0 {
+			t.Fatalf("empty bucket for hash %d", hash)
+		}
+		for _, pos := range bucket {
+			if pos < 0 || pos >= len(idx.rows) {
+				t.Fatalf("bucket hash %d has out-of-range pos %d", hash, pos)
+			}
+			if got := columnPhysicalQueryHashBytes(idx.rows[pos].ID); got != hash {
+				t.Fatalf("bucket hash mismatch for pos %d: got %d want %d", pos, got, hash)
+			}
+			positions++
+		}
+	}
+	if positions != rows {
+		t.Fatalf("indexed positions=%d want %d", positions, rows)
+	}
+}
 
 func TestColumnPhysicalVisibilityIndexClonesSliceBackedValues1930(t *testing.T) {
 	var idx columnPhysicalVisibilityIndex


### PR DESCRIPTION
## Summary

- replace `columnPhysicalVisibilityIndex.byHash` with per-hash position buckets
- remove the fallback whole-index scan from `upsert`, so new unique IDs do not make visibility indexing quadratic
- add focused coverage for ID/value cloning, delete/latest semantics, hash-bucket collisions, latest tie-breakers, and unique-ID indexing

## Why

The #2359 1M JSONBench evidence run after #2376 was stopped after about 25 minutes without `result.json`. A non-mutating perf sample showed the process was CPU-bound in reconstruction validation:

```text
validateStoredReconstruction -> scanCollectionJSON -> scanColumnPhysicalVisibleRowsAtSnapshotForTargetsWithReadCache -> scanColumnPhysicalAssetRowsWithManifestOperation -> columnPhysicalVisibilityIndex.upsert
```

The generated DB storage audit showed the retained value-log raw-frame blocker was already fixed (`leaf_vlog` raw bytes 0, `value_vlog` raw bytes 0), so the remaining blocker was the visibility index doing an O(n) absence scan for each new unique ID.

Artifacts from the aborted run:

- run root: `/tmp/treedb_jsonbench_final_1m_20260605_123952/run_1m`
- aborted audit: `/tmp/treedb_jsonbench_final_1m_20260605_123952/run_1m/aborted_audit/audit.json`
- gomap head used in aborted run: `47a5c873b7925932adedfd54e4a2d2a23d32cf20`
- `leaf_vlog` raw payload bytes: `0`
- `value_vlog` raw payload bytes: `0`
- `value_vlog` raw payload fraction: `0.0`

## Validation

- `go test ./TreeDB/collections -run 'TestColumnPhysicalVisibilityIndex' -count=1`
- `go test ./TreeDB/collections -count=1`
- `git diff --check`

Closes #2378. Blocks/unblocks #2359 evidence rerun.
