### PR TITLE
Fix retained payload audit value-log decoding

### DIFF
--- a/TreeDB/collections/column_retained_payload_audit.go
+++ b/TreeDB/collections/column_retained_payload_audit.go
@@ -137,8 +137,12 @@ func auditColumnRetainedPayloadPathsAbsentWithResolver(cfg ColumnStoreConfig, re
 // bodies and verifies that declared typed-column paths were removed. It is
 // read-only: it does not flush buffered writes, publish roots, compact, or
 // mutate storage.
-func (c *Collection) AuditRetainedPayloadDeclaredPathsAbsent(opts ColumnRetainedPayloadCollectionAuditOptions) (ColumnRetainedPayloadCollectionAuditResult, error) {
-	var result ColumnRetainedPayloadCollectionAuditResult
+func (c *Collection) AuditRetainedPayloadDeclaredPathsAbsent(opts ColumnRetainedPayloadCollectionAuditOptions) (result ColumnRetainedPayloadCollectionAuditResult, err error) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			result, err = retainedPayloadCollectionAuditError(result, fmt.Errorf("collections: retained payload audit panic: %v", recovered))
+		}
+	}()
 	if c == nil {
 		return retainedPayloadCollectionAuditError(result, errCollectionNil)
 	}
@@ -203,6 +207,12 @@ func (c *Collection) AuditRetainedPayloadDeclaredPathsAbsent(opts ColumnRetained
 		}
 		documentID := string(it.UnsafeKey())
 		retained := it.ValueCopy(nil)
+		if err := it.Error(); err != nil {
+			return retainedPayloadCollectionAuditError(result, fmt.Errorf("collections: retained payload audit read %q: %w", documentID, err))
+		}
+		if !it.Valid() {
+			return retainedPayloadCollectionAuditError(result, fmt.Errorf("collections: retained payload audit iterator invalid after reading %q", documentID))
+		}
 		result.CheckedRows++
 		result.RetainedPayloadBytes += int64(len(retained))
 		payloadAudit, auditErr := auditColumnRetainedPayloadPathsAbsentWithResolver(cfg, retained, result.DeclaredPaths, resolver)

--- a/TreeDB/collections/column_retained_payload_audit_test.go
+++ b/TreeDB/collections/column_retained_payload_audit_test.go
@@ -2,6 +2,8 @@ package collections
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -205,6 +207,72 @@ func TestAuditCollectionRetainedPayloadDeclaredPathsAbsentSampled2382(t *testing
 	}
 	if audit.Status != "passed_sampled" || !audit.Truncated || audit.CheckedRows != 1 {
 		t.Fatalf("sample audit=%+v want passed_sampled truncated one row", audit)
+	}
+}
+
+func TestAuditCollectionRetainedPayloadDeclaredPathsAbsentValueReadErrorFailsClosed2384(t *testing.T) {
+	dir := t.TempDir()
+	if err := backenddb.SaveFormatConfig(dir, backenddb.FormatConfig{RequiredFeatures: []string{backenddb.RequiredFeatureCommandWALV1}}); err != nil {
+		t.Fatalf("SaveFormatConfig: %v", err)
+	}
+	d, err := backenddb.Open(backenddb.Options{
+		Dir:                        dir,
+		DisableBackgroundPrune:     true,
+		ValueLog:                   backenddb.ValueLogOptions{PointerThreshold: 1},
+		IndexOuterLeavesInValueLog: true,
+	})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "events",
+		Options: CollectionOptions{
+			DocumentFormat:          DocumentFormatJSON,
+			ColumnStore:             jsonbenchRetainedPayloadAuditConfig2382(true),
+			DataRootStoragePolicy:   RootStorageCompressed,
+			IndexStateStoragePolicy: RootStorageCompressed,
+		},
+	}); err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	col, err := mgr.OpenCollection("events")
+	if err != nil {
+		t.Fatalf("OpenCollection: %v", err)
+	}
+	if _, err := col.InsertBatch([][]byte{[]byte("doc-000000")}, [][]byte{
+		[]byte(`{"time_us":1,"kind":"commit","did":"did:plc:one","commit":{"operation":"create","collection":"app.bsky.feed.post"},"payload":"` + strings.Repeat("kept", 512) + `"}`),
+	}); err != nil {
+		t.Fatalf("InsertBatch: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+	if err := d.Checkpoint(); err != nil {
+		t.Fatalf("Checkpoint: %v", err)
+	}
+	paths, err := filepath.Glob(filepath.Join(backenddb.ValueLogDirPath(dir), "value-l*.log"))
+	if err != nil {
+		t.Fatalf("glob value log: %v", err)
+	}
+	if len(paths) == 0 {
+		t.Fatal("expected value-log segment for forced pointer retained payload")
+	}
+	for _, path := range paths {
+		if err := os.Truncate(path, 0); err != nil {
+			t.Fatalf("truncate value log %s: %v", path, err)
+		}
+	}
+	audit, err := col.AuditRetainedPayloadDeclaredPathsAbsent(ColumnRetainedPayloadCollectionAuditOptions{})
+	if err == nil {
+		t.Fatalf("AuditRetainedPayloadDeclaredPathsAbsent err=nil want value read failure audit=%+v", audit)
+	}
+	if audit.Status != "failed" || len(audit.Errors) == 0 {
+		t.Fatalf("audit=%+v want failed status with error", audit)
+	}
+	if strings.Contains(strings.ToLower(audit.Errors[0]), "panic") {
+		t.Fatalf("audit error still reports panic: %+v", audit)
 	}
 }
 

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -382,7 +382,7 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/column_reconstruction.go", classification: typedStorageLegacyCompatibility, matchingLines: 56, occurrences: 71},
 	{path: "TreeDB/collections/column_reconstruction_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 27, occurrences: 31},
 	{path: "TreeDB/collections/column_retained_payload_audit.go", classification: typedStorageLegacyCompatibility, matchingLines: 8, occurrences: 8},
-	{path: "TreeDB/collections/column_retained_payload_audit_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 24, occurrences: 25},
+	{path: "TreeDB/collections/column_retained_payload_audit_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 25, occurrences: 26},
 	{path: "TreeDB/collections/column_retained_vlog_placement_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 11, occurrences: 11},
 	{path: "TreeDB/collections/column_semantics.go", classification: typedStorageLegacyCompatibility, matchingLines: 34, occurrences: 34},
 	{path: "TreeDB/collections/dense_numeric_vector.go", classification: typedStorageLegacyCompatibility, matchingLines: 32, occurrences: 41},

--- a/cmd/treedb_retained_payload_audit/main.go
+++ b/cmd/treedb_retained_payload_audit/main.go
@@ -8,19 +8,24 @@ import (
 	"os"
 	"strings"
 
+	treedb "github.com/snissn/gomap/TreeDB"
 	"github.com/snissn/gomap/TreeDB/collections"
-	backenddb "github.com/snissn/gomap/TreeDB/db"
 )
 
 func main() {
 	os.Exit(run())
 }
 
-func run() int {
+func run() (code int) {
 	var dbDir string
 	var collectionName string
 	var pathsCSV string
 	var maxDocuments int
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			code = writeFailure(collectionName, fmt.Errorf("retained payload audit panic: %v", recovered))
+		}
+	}()
 	flag.StringVar(&dbDir, "db-dir", "", "TreeDB DB directory")
 	flag.StringVar(&collectionName, "collection", "", "Collection name; defaults to the only collection")
 	flag.StringVar(&pathsCSV, "paths", "", "Comma-separated JSON paths to require absent; defaults to collection column paths")
@@ -30,11 +35,11 @@ func run() int {
 	if strings.TrimSpace(dbDir) == "" {
 		return writeFailure("", errors.New("-db-dir is required"))
 	}
-	db, err := backenddb.Open(backenddb.Options{Dir: dbDir, ReadOnly: true, DisableBackgroundPrune: true})
+	db, cleanup, err := treedb.OpenBackend(treedb.Options{Dir: dbDir, ReadOnly: true, DisableBackgroundPrune: true})
 	if err != nil {
 		return writeFailure(collectionName, fmt.Errorf("open read-only DB: %w", err))
 	}
-	defer func() { _ = db.Close() }()
+	defer func() { _ = cleanup() }()
 
 	manager := collections.NewCollectionManager(db)
 	if strings.TrimSpace(collectionName) == "" {


### PR DESCRIPTION
Fixes #2384.

## Summary
- open `treedb_retained_payload_audit` through `treedb.OpenBackend` so read-only audits wire persisted format config and dictdb/templatedb side-store lookups
- make retained-payload collection audits fail closed after value-log read errors instead of calling `Next()` on an invalid iterator
- add a forced-pointer corrupt value-log regression that verifies the audit returns failed status instead of panic
- update the typed-storage legacy-name allowlist for the new retained audit test reference

## Validation
- `go test ./cmd/treedb_retained_payload_audit -count=1`
- `go test ./TreeDB/collections -run 'TestAuditCollectionRetainedPayloadDeclaredPathsAbsent|TestColumnRetainedPayload|TestAuditColumnRetainedPayload' -count=1`\n- `go test ./TreeDB/collections -count=1`\n- `git diff --check`\n\n## Evidence\nRemote patched audit against final 1M DB:\n- DB: `/tmp/treedb_jsonbench_final_1m_after_2382_20260605_152755/run_1m/db`\n- patched report: `/tmp/treedb_jsonbench_final_1m_after_2382_20260605_152755/run_1m/audit_after_2384/compression_audit.md`\n- retained audit status: `passed`\n- checked rows: `1000000`\n- retained payload bytes: `257024123`\n- declared paths absent: `commit.collection`, `commit.operation`, `did`, `kind`, `time_us`\n- leaf/value raw-mode payload bytes: `0` / `0`\n- TreeDB durable WAL-excluded storage for the run remains `263591680` bytes (2.68x ClickHouse 1M total `98534792` bytes), so this fixes the audit/evidence blocker rather than claiming storage parity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and recovery in audit operations to prevent panics and ensure graceful failures.
  * Enhanced iterator validation during payload audits to prevent proceeding with invalid data states.

* **Tests**
  * Added test coverage for audit failure scenarios when reading retained payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->