### PR TITLE
Fix compression audit silent-none detection

### DIFF
--- a/scripts/treedb_jsonbench_storage_audit.py
+++ b/scripts/treedb_jsonbench_storage_audit.py
@@ -321,18 +321,54 @@ def load_result_json(result_json: Path | None) -> Any | None:
     return json.loads(result_json.read_text())
 
 
+def compression_value_tokens(value: Any) -> set[str]:
+    tokens: set[str] = set()
+    if isinstance(value, str):
+        text = value.lower()
+        if "none" in text:
+            tokens.add("none")
+        for codec in ("lz4", "snappy", "zstd", "dict", "value_log_grouped_frame"):
+            if codec in text:
+                tokens.add(codec)
+        if "active_" in text:
+            tokens.add("active")
+    elif isinstance(value, dict):
+        for key, child in value.items():
+            key_text = str(key).lower()
+            if key_text == "none":
+                tokens.add("none")
+            for codec in ("lz4", "snappy", "zstd", "dict"):
+                if key_text == codec:
+                    tokens.add(codec)
+            tokens.update(compression_value_tokens(child))
+    elif isinstance(value, list):
+        for child in value:
+            tokens.update(compression_value_tokens(child))
+    return tokens
+
+
 def load_result_compression_summary(result_json: Path | None, data: Any | None = None) -> dict[str, Any] | None:
     if result_json is None:
         return None
     if data is None:
         data = load_result_json(result_json)
     fields = compression_fields(data)
-    raw = json.dumps(fields, sort_keys=True).lower()
-    silent_none = "requested=none" in raw or "actual=none" in raw or '"none"' in raw
+    active_tokens = {"active", "lz4", "snappy", "zstd", "dict", "value_log_grouped_frame"}
+    none_fields: list[dict[str, Any]] = []
+    active_fields: list[dict[str, Any]] = []
+    for field in fields:
+        tokens = compression_value_tokens(field.get("value"))
+        if "none" in tokens:
+            none_fields.append(field)
+        if tokens & active_tokens:
+            active_fields.append(field)
+    silent_none = bool(none_fields) and not active_fields
     return {
         "path": str(result_json),
         "compression_fields": fields,
         "silent_none_suspected": silent_none,
+        "compression_none_fields": none_fields,
+        "compression_active_fields": active_fields,
     }
 
 

--- a/scripts/treedb_jsonbench_storage_audit.py
+++ b/scripts/treedb_jsonbench_storage_audit.py
@@ -353,6 +353,21 @@ def compression_metadata_only_field(field: dict[str, Any]) -> bool:
     return "requested" in leaf or "policy" in leaf
 
 
+def compression_active_evidence_field(field: dict[str, Any]) -> bool:
+    leaf = str(field.get("path", "")).lower().rsplit(".", 1)[-1]
+    if compression_metadata_only_field(field):
+        return False
+    if "attribution" in leaf or leaf.endswith("_detail") or leaf.endswith("_details"):
+        return False
+    return (
+        "actual" in leaf
+        or "status" in leaf
+        or leaf == "compression"
+        or leaf == "compression_mode"
+        or leaf.endswith("_compression")
+    )
+
+
 def observed_compression_value_tokens(value: Any) -> set[str]:
     if isinstance(value, str):
         text = value.lower()
@@ -390,7 +405,11 @@ def load_result_compression_summary(result_json: Path | None, data: Any | None =
         tokens = compression_value_tokens(field.get("value"))
         if "none" in tokens:
             none_fields.append(field)
-        observed_tokens = set() if compression_metadata_only_field(field) else observed_compression_value_tokens(field.get("value"))
+        observed_tokens = (
+            observed_compression_value_tokens(field.get("value"))
+            if compression_active_evidence_field(field)
+            else set()
+        )
         if observed_tokens & active_tokens:
             active_fields.append(field)
     silent_none = bool(none_fields) and not active_fields

--- a/scripts/treedb_jsonbench_storage_audit.py
+++ b/scripts/treedb_jsonbench_storage_audit.py
@@ -15,6 +15,7 @@ import argparse
 import gzip
 import json
 import os
+import re
 import shlex
 import struct
 import subprocess
@@ -347,6 +348,35 @@ def compression_value_tokens(value: Any) -> set[str]:
     return tokens
 
 
+def compression_metadata_only_field(field: dict[str, Any]) -> bool:
+    leaf = str(field.get("path", "")).lower().rsplit(".", 1)[-1]
+    return "requested" in leaf or "policy" in leaf
+
+
+def observed_compression_value_tokens(value: Any) -> set[str]:
+    if isinstance(value, str):
+        text = value.lower()
+        if "requested" in text:
+            pieces = [piece for piece in re.split(r"[;,]", text) if "requested" not in piece]
+            text = " ".join(pieces)
+        return compression_value_tokens(text)
+    if isinstance(value, dict):
+        tokens: set[str] = set()
+        for key, child in value.items():
+            key_text = str(key).lower()
+            if "requested" in key_text or "policy" in key_text:
+                continue
+            tokens.update(compression_value_tokens(key_text))
+            tokens.update(observed_compression_value_tokens(child))
+        return tokens
+    if isinstance(value, list):
+        tokens: set[str] = set()
+        for child in value:
+            tokens.update(observed_compression_value_tokens(child))
+        return tokens
+    return compression_value_tokens(value)
+
+
 def load_result_compression_summary(result_json: Path | None, data: Any | None = None) -> dict[str, Any] | None:
     if result_json is None:
         return None
@@ -360,7 +390,8 @@ def load_result_compression_summary(result_json: Path | None, data: Any | None =
         tokens = compression_value_tokens(field.get("value"))
         if "none" in tokens:
             none_fields.append(field)
-        if tokens & active_tokens:
+        observed_tokens = set() if compression_metadata_only_field(field) else observed_compression_value_tokens(field.get("value"))
+        if observed_tokens & active_tokens:
             active_fields.append(field)
     silent_none = bool(none_fields) and not active_fields
     return {

--- a/scripts/treedb_jsonbench_storage_audit_test.py
+++ b/scripts/treedb_jsonbench_storage_audit_test.py
@@ -284,6 +284,41 @@ class StorageAuditTest(unittest.TestCase):
         self.assertGreater(len(summary["compression_none_fields"]), 0)
         self.assertEqual(summary["compression_active_fields"], [])
 
+    def test_result_compression_summary_ignores_attribution_labels_as_active_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            result = Path(tmp) / "result.json"
+            result.write_text(
+                json.dumps(
+                    {
+                        "storage": {
+                            "column_store_physical": {
+                                "typed_column_parts": [
+                                    {
+                                        "image": {
+                                            "sections": [
+                                                {
+                                                    "compression_attribution": {
+                                                        "actual_compression": "none",
+                                                        "codec_layout_label": "typed_column_part/section/dictionaries/zstd",
+                                                        "support_reason": "dictionary compression is unsupported",
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                )
+            )
+
+            summary = audit.load_result_compression_summary(result)
+
+        self.assertTrue(summary["silent_none_suspected"])
+        self.assertGreater(len(summary["compression_none_fields"]), 0)
+        self.assertEqual(summary["compression_active_fields"], [])
+
     def test_retained_payload_audit_command_wrapper(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             script = Path(tmp) / "fake_retained_audit.py"

--- a/scripts/treedb_jsonbench_storage_audit_test.py
+++ b/scripts/treedb_jsonbench_storage_audit_test.py
@@ -169,6 +169,87 @@ class StorageAuditTest(unittest.TestCase):
         self.assertFalse(enriched["retained_payload_compression_inactive"])
         self.assertEqual(enriched["retained_payload_status_source"], "retained_payload_audit")
 
+    def test_result_compression_summary_accepts_mixed_active_and_intentional_none(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            result = Path(tmp) / "result.json"
+            result.write_text(
+                json.dumps(
+                    {
+                        "storage": {
+                            "column_store_physical": {
+                                "typed_column_parts": [
+                                    {
+                                        "image": {
+                                            "columns_detail": [
+                                                {
+                                                    "column": "__treedb_primary_id",
+                                                    "requested_compression": "none",
+                                                    "actual_compression_mix": {"none": 2},
+                                                },
+                                                {
+                                                    "column": "did",
+                                                    "requested_compression": "lz4",
+                                                    "actual_compression_mix": {"lz4": 2},
+                                                },
+                                                {
+                                                    "column": "time_us",
+                                                    "requested_compression": "lz4",
+                                                    "actual_compression_mix": {"none": 2},
+                                                    "fallback_reasons": {"not_smaller": 2},
+                                                },
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "retained_payload_audit": {
+                            "retained_payload_compression": "value_log_grouped_frame",
+                            "retained_payload_compression_status": "active_value_log_auto_grouped_frame_non_column_retained_payload",
+                        },
+                    }
+                )
+            )
+
+            summary = audit.load_result_compression_summary(result)
+
+        self.assertFalse(summary["silent_none_suspected"])
+        self.assertGreater(len(summary["compression_none_fields"]), 0)
+        self.assertGreater(len(summary["compression_active_fields"]), 0)
+
+    def test_result_compression_summary_flags_all_none(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            result = Path(tmp) / "result.json"
+            result.write_text(
+                json.dumps(
+                    {
+                        "storage": {
+                            "column_store_physical": {
+                                "typed_column_parts": [
+                                    {
+                                        "image": {
+                                            "columns_detail": [
+                                                {
+                                                    "column": "did",
+                                                    "requested_compression": "none",
+                                                    "actual_compression_mix": {"none": 2},
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                )
+            )
+
+            summary = audit.load_result_compression_summary(result)
+
+        self.assertTrue(summary["silent_none_suspected"])
+        self.assertGreater(len(summary["compression_none_fields"]), 0)
+        self.assertEqual(summary["compression_active_fields"], [])
+
     def test_retained_payload_audit_command_wrapper(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             script = Path(tmp) / "fake_retained_audit.py"

--- a/scripts/treedb_jsonbench_storage_audit_test.py
+++ b/scripts/treedb_jsonbench_storage_audit_test.py
@@ -250,6 +250,40 @@ class StorageAuditTest(unittest.TestCase):
         self.assertGreater(len(summary["compression_none_fields"]), 0)
         self.assertEqual(summary["compression_active_fields"], [])
 
+    def test_result_compression_summary_ignores_requested_codec_as_active_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            result = Path(tmp) / "result.json"
+            result.write_text(
+                json.dumps(
+                    {
+                        "storage": {
+                            "column_store_physical": {
+                                "typed_column_parts": [
+                                    {
+                                        "image": {
+                                            "columns_detail": [
+                                                {
+                                                    "column": "did",
+                                                    "requested_compression": "lz4",
+                                                    "actual_compression_mix": {"none": 2},
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "compression_mode": "requested=lz4:1; actual=none:1",
+                    }
+                )
+            )
+
+            summary = audit.load_result_compression_summary(result)
+
+        self.assertTrue(summary["silent_none_suspected"])
+        self.assertGreater(len(summary["compression_none_fields"]), 0)
+        self.assertEqual(summary["compression_active_fields"], [])
+
     def test_retained_payload_audit_command_wrapper(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             script = Path(tmp) / "fake_retained_audit.py"


### PR DESCRIPTION
Fixes #2388.

## Summary

- tighten `silent_none_suspected` so mixed active compression plus intentional raw/rejected sections is not flagged as an all-none compression run
- keep true all-none compression detection
- report active/none compression evidence fields in the audit summary
- add regression coverage for mixed active/raw and all-none cases

## Evidence

- `python3 scripts/treedb_jsonbench_storage_audit_test.py`
- `git diff --check`
- patched summary against final 1M result `/tmp/treedb_jsonbench_final_reports_after_2385_20260605_160041/result.json`:
  - `silent_none_suspected=False`
  - `compression_none_fields=3213`
  - `compression_active_fields=4725`

This leaves the final storage claim non-final for the real remaining reason, `column audit filesystem-only`, tracked by #2387.