### PR TITLE
Bootstrap retained value-log compression with zstd

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -12807,7 +12807,7 @@ func (db *DB) flushVlogRequests(l *lane, requests []vlogWriteRequest) {
 				retainedUnitBytes := retainedRawBytes / retainedRecords
 				if db.retainedStorageFirstValueLogAuto(retainedRawBytes, retainedUnitBytes, records[i:retainedEnd]) {
 					writeMode = vlogWriteBlock
-					blockCodec = chooseRetainedStorageFirstBlockCodec(l, db.valueLogBlockCodec)
+					blockCodec = chooseRetainedStorageFirstBlockCodec(l, db.valueLogBlockCodec, mode)
 					dictID = 0
 					dict = nil
 					probe = retainedProbe
@@ -12845,7 +12845,7 @@ func (db *DB) flushVlogRequests(l *lane, requests []vlogWriteRequest) {
 			retainedStorageFirst = db.retainedStorageFirstValueLogAuto(rawBytes, unitPayloadBytes, records[i:end])
 			if retainedStorageFirst && mode != vlogCompressionOff && writeMode != vlogWriteDict {
 				writeMode = vlogWriteBlock
-				blockCodec = chooseRetainedStorageFirstBlockCodec(l, db.valueLogBlockCodec)
+				blockCodec = chooseRetainedStorageFirstBlockCodec(l, db.valueLogBlockCodec, mode)
 				dictID = 0
 				dict = nil
 			}
@@ -14016,7 +14016,7 @@ func (db *DB) appendValueLog(l *lane, dictID uint64, dict []byte, records []valu
 			return
 		}
 		writeMode = vlogWriteBlock
-		blockCodec = chooseRetainedStorageFirstBlockCodec(l, db.valueLogBlockCodec)
+		blockCodec = chooseRetainedStorageFirstBlockCodec(l, db.valueLogBlockCodec, mode)
 	}
 	probeCompression := selectorProbe
 	paused := false
@@ -14730,7 +14730,7 @@ func (db *DB) appendValueLogOneInternal(l *lane, dictID uint64, dict []byte, rid
 			return
 		}
 		writeMode = vlogWriteBlock
-		blockCodec = chooseRetainedStorageFirstBlockCodec(l, db.valueLogBlockCodec)
+		blockCodec = chooseRetainedStorageFirstBlockCodec(l, db.valueLogBlockCodec, mode)
 	}
 	probeCompression := selectorProbe
 	if writeMode != vlogWriteDict {

--- a/TreeDB/caching/vlog_compression_regression_test.go
+++ b/TreeDB/caching/vlog_compression_regression_test.go
@@ -252,6 +252,9 @@ func TestAppendValueLog_AutoBalancedCompactRetainedTemplateBatchUsesBlockFrames(
 		if header.DictID != 0 {
 			t.Fatalf("frame %d dict id=%d, want block-compressed no-dict frame", i, header.DictID)
 		}
+		if got := valuelog.BlockCodec(header.Reserved); got != valuelog.BlockCodecZSTD {
+			t.Fatalf("frame %d block codec=%v, want zstd for retained storage-first bootstrap", i, got)
+		}
 	}
 	if recordsSeen != len(records) {
 		t.Fatalf("records in frames=%d want %d", recordsSeen, len(records))
@@ -323,6 +326,9 @@ func TestFlushVlogRequests_AutoBalancedCompactRetainedTemplateQueueUsesBlockFram
 		}
 		if header.DictID != 0 {
 			t.Fatalf("frame %d dict id=%d, want block-compressed no-dict frame", i, header.DictID)
+		}
+		if got := valuelog.BlockCodec(header.Reserved); got != valuelog.BlockCodecZSTD {
+			t.Fatalf("frame %d block codec=%v, want zstd for queued retained storage-first bootstrap", i, got)
 		}
 	}
 	if recordsSeen != len(requests) {
@@ -694,8 +700,8 @@ func TestAppendValueLog_AutoForcePointerMediumPayloadUsesGroupedBlockFrame(t *te
 	if header.DictID != 0 {
 		t.Fatalf("expected no dict id for block-compressed retained payload, got %d", header.DictID)
 	}
-	if got := valuelog.BlockCodec(header.Reserved); got != valuelog.BlockCodecSnappy {
-		t.Fatalf("block codec=%v want snappy", got)
+	if got := valuelog.BlockCodec(header.Reserved); got != valuelog.BlockCodecZSTD {
+		t.Fatalf("block codec=%v want zstd", got)
 	}
 }
 
@@ -759,8 +765,8 @@ func TestAppendValueLogOne_AutoForcePointerRetainedPayloadResetsBlockBackoff(t *
 	if header.DictID != 0 {
 		t.Fatalf("expected no dict id for retained single write, got %d", header.DictID)
 	}
-	if got := valuelog.BlockCodec(header.Reserved); got != valuelog.BlockCodecSnappy {
-		t.Fatalf("block codec=%v want snappy", got)
+	if got := valuelog.BlockCodec(header.Reserved); got != valuelog.BlockCodecZSTD {
+		t.Fatalf("block codec=%v want zstd", got)
 	}
 }
 

--- a/TreeDB/caching/vlog_compression_selector.go
+++ b/TreeDB/caching/vlog_compression_selector.go
@@ -1464,7 +1464,7 @@ func laneVlogBlockObservedRatioWithSamples(l *lane, codec valuelog.BlockCodec) (
 	return normalizeMetricRatio(math.Float64frombits(bits)), samples
 }
 
-func chooseLargePayloadNoDictBlockCodec(l *lane, configured valuelog.BlockCodec) valuelog.BlockCodec {
+func chooseLargePayloadNoDictBlockCodecObserved(l *lane, configured valuelog.BlockCodec) (valuelog.BlockCodec, bool) {
 	configured = normalizeSelectorBlockCodec(configured)
 	bestCodec := configured
 	bestRatio := 1.0
@@ -1485,13 +1485,25 @@ func chooseLargePayloadNoDictBlockCodec(l *lane, configured valuelog.BlockCodec)
 		}
 	}
 	if found {
-		return bestCodec
+		return bestCodec, true
 	}
-	return configured
+	return configured, false
 }
 
-func chooseRetainedStorageFirstBlockCodec(l *lane, configured valuelog.BlockCodec) valuelog.BlockCodec {
-	return chooseLargePayloadNoDictBlockCodec(l, configured)
+func chooseLargePayloadNoDictBlockCodec(l *lane, configured valuelog.BlockCodec) valuelog.BlockCodec {
+	codec, _ := chooseLargePayloadNoDictBlockCodecObserved(l, configured)
+	return codec
+}
+
+func chooseRetainedStorageFirstBlockCodec(l *lane, configured valuelog.BlockCodec, mode vlogCompressionMode) valuelog.BlockCodec {
+	configured = normalizeSelectorBlockCodec(configured)
+	if mode != vlogCompressionDefault && mode != vlogCompressionAuto {
+		return configured
+	}
+	if codec, ok := chooseLargePayloadNoDictBlockCodecObserved(l, configured); ok {
+		return codec
+	}
+	return valuelog.BlockCodecZSTD
 }
 
 func (db *DB) storageFirstValueLogAuto(unitPayloadBytes int) bool {

--- a/TreeDB/caching/vlog_compression_selector.go
+++ b/TreeDB/caching/vlog_compression_selector.go
@@ -1495,12 +1495,27 @@ func chooseLargePayloadNoDictBlockCodec(l *lane, configured valuelog.BlockCodec)
 	return codec
 }
 
+func retainedStorageFirstObservedBlockCodecReady(l *lane) bool {
+	sampledCodecs := 0
+	for _, codec := range vlogSelectorBlockCodecs {
+		_, samples := laneVlogBlockObservedRatioWithSamples(l, codec)
+		if samples < largePayloadBlockCodecMinSamples {
+			continue
+		}
+		if codec == valuelog.BlockCodecZSTD {
+			return true
+		}
+		sampledCodecs++
+	}
+	return sampledCodecs >= 2
+}
+
 func chooseRetainedStorageFirstBlockCodec(l *lane, configured valuelog.BlockCodec, mode vlogCompressionMode) valuelog.BlockCodec {
 	configured = normalizeSelectorBlockCodec(configured)
 	if mode != vlogCompressionDefault && mode != vlogCompressionAuto {
 		return configured
 	}
-	if codec, ok := chooseLargePayloadNoDictBlockCodecObserved(l, configured); ok {
+	if codec, ok := chooseLargePayloadNoDictBlockCodecObserved(l, configured); ok && retainedStorageFirstObservedBlockCodecReady(l) {
 		return codec
 	}
 	return valuelog.BlockCodecZSTD

--- a/TreeDB/caching/vlog_compression_selector_test.go
+++ b/TreeDB/caching/vlog_compression_selector_test.go
@@ -990,6 +990,41 @@ func TestResolveVlogWriteMode_LargePayloadBalancedUsesObservedBetterBlockCodec(t
 	}
 }
 
+func TestChooseRetainedStorageFirstBlockCodec_DefaultBootstrapsZSTD(t *testing.T) {
+	l := &lane{}
+
+	got := chooseRetainedStorageFirstBlockCodec(l, valuelog.BlockCodecSnappy, vlogCompressionDefault)
+
+	if got != valuelog.BlockCodecZSTD {
+		t.Fatalf("retained storage-first bootstrap codec=%v want zstd", got)
+	}
+}
+
+func TestChooseRetainedStorageFirstBlockCodec_ExplicitBlockKeepsConfiguredCodec(t *testing.T) {
+	l := &lane{}
+
+	got := chooseRetainedStorageFirstBlockCodec(l, valuelog.BlockCodecLZ4, vlogCompressionBlock)
+
+	if got != valuelog.BlockCodecLZ4 {
+		t.Fatalf("explicit block retained codec=%v want configured lz4", got)
+	}
+}
+
+func TestChooseRetainedStorageFirstBlockCodec_ObservedBestOverridesBootstrap(t *testing.T) {
+	l := &lane{}
+	for i := 0; i < largePayloadBlockCodecMinSamples; i++ {
+		observeLaneVlogBlockRatio(l, valuelog.BlockCodecSnappy, 4096, 3000)
+		observeLaneVlogBlockRatio(l, valuelog.BlockCodecLZ4, 4096, 1800)
+		observeLaneVlogBlockRatio(l, valuelog.BlockCodecZSTD, 4096, 2200)
+	}
+
+	got := chooseRetainedStorageFirstBlockCodec(l, valuelog.BlockCodecSnappy, vlogCompressionAuto)
+
+	if got != valuelog.BlockCodecLZ4 {
+		t.Fatalf("retained observed codec=%v want observed-best lz4", got)
+	}
+}
+
 func TestResolveVlogWriteMode_ThroughputPolicyBypassesSelectorForMediumPayload(t *testing.T) {
 	db := &DB{
 		valueLogCompressionMode: uint8(vlogCompressionAuto),

--- a/TreeDB/caching/vlog_compression_selector_test.go
+++ b/TreeDB/caching/vlog_compression_selector_test.go
@@ -1000,6 +1000,19 @@ func TestChooseRetainedStorageFirstBlockCodec_DefaultBootstrapsZSTD(t *testing.T
 	}
 }
 
+func TestChooseRetainedStorageFirstBlockCodec_SingleConfiguredCodecHistoryKeepsZSTDBootstrap(t *testing.T) {
+	l := &lane{}
+	for i := 0; i < largePayloadBlockCodecMinSamples; i++ {
+		observeLaneVlogBlockRatio(l, valuelog.BlockCodecSnappy, 4096, 1800)
+	}
+
+	got := chooseRetainedStorageFirstBlockCodec(l, valuelog.BlockCodecSnappy, vlogCompressionAuto)
+
+	if got != valuelog.BlockCodecZSTD {
+		t.Fatalf("single-codec retained bootstrap codec=%v want zstd", got)
+	}
+}
+
 func TestChooseRetainedStorageFirstBlockCodec_ExplicitBlockKeepsConfiguredCodec(t *testing.T) {
 	l := &lane{}
 


### PR DESCRIPTION
Fixes #2386.

## Summary
- bootstrap retained storage-first value-log block compression with ZSTD for default/auto modes
- preserve explicit block/dict fallback configured codecs instead of overriding user-selected block mode
- keep observed best-codec selection once the lane has enough block ratio samples
- tighten retained value-log regression tests to assert ZSTD frames for default/auto retained JSON payloads

## Validation
- `go test ./TreeDB/caching -run 'TestChooseRetainedStorageFirstBlockCodec|TestAppendValueLog_AutoBalancedCompactRetainedTemplateBatchUsesBlockFrames|TestFlushVlogRequests_AutoBalancedCompactRetainedTemplateQueueUsesBlockFrames|TestAppendValueLogOne_AutoForcePointerRetainedPayloadResetsBlockBackoff' -count=1`
- `go test ./TreeDB/internal/valuelog -run TestValueLogBlockCodecRoundTrip -count=1`
- `go test ./TreeDB/caching -run 'Retained|VlogWriteMode|BlockCodec|CompressionSelector' -count=1`
- `go test ./TreeDB -run 'TestReopenVerify_WALOn_Checkpoint|TestReopenVerify_WALOn_WriteSync|TestReopenVerify_WALOn_Checkpoint_CompressionModes' -count=1`
- `go test ./TreeDB/db -run TestValueLogGC_RemovesUnreferencedSegment -count=1`
