### PR TITLE
TreeDB: widen grouped retained value-log frames

### DIFF
--- a/TreeDB/caching/vlog_compression_selector_test.go
+++ b/TreeDB/caching/vlog_compression_selector_test.go
@@ -1038,6 +1038,19 @@ func TestChooseRetainedStorageFirstBlockCodec_ObservedBestOverridesBootstrap(t *
 	}
 }
 
+func TestChooseRetainedStorageFirstValueLogBlockWriteKUsesMaxFrameK(t *testing.T) {
+	db := &DB{}
+	l := &lane{}
+
+	records := valuelog.MaxFrameK + 64
+	rawPayloadBytes := records * 1024
+	got := db.chooseRetainedStorageFirstValueLogBlockWriteK(l, records, rawPayloadBytes, valuelog.BlockCodecZSTD)
+
+	if got != valuelog.MaxFrameK {
+		t.Fatalf("retained storage-first K=%d want max frame K=%d", got, valuelog.MaxFrameK)
+	}
+}
+
 func TestResolveVlogWriteMode_ThroughputPolicyBypassesSelectorForMediumPayload(t *testing.T) {
 	db := &DB{
 		valueLogCompressionMode: uint8(vlogCompressionAuto),

--- a/TreeDB/docs/spec/storage-format.md
+++ b/TreeDB/docs/spec/storage-format.md
@@ -183,12 +183,13 @@ Grouped pointer sub-index bits:
 - low portion: bits `29..26`
 - extra bit: bit `31` contributes one sub-index bit
 - high portion: bits `25..24`
-- total sub-index range: `0..127`
+- top portion: bit `23`
+- total encoded sub-index range: `0..255`
 
 Record-length hint:
 
-- grouped pointers keep a best-effort 24-bit record-length hint.
-- max encodable grouped record length hint: `0x00ffffff`.
+- grouped pointers keep a best-effort 23-bit record-length hint.
+- max encodable grouped record length hint: `0x007fffff`.
 - if record is larger, hint is set to zero and reader uses record header length fields.
 
 ### 4.3 Packed on-disk `ValuePtr`

--- a/TreeDB/docs/spec/storage-format.md
+++ b/TreeDB/docs/spec/storage-format.md
@@ -370,7 +370,7 @@ When grouped flag is set, payload starts with frame header:
 ```text
 u8  FrameVersion    // currently 1
 u8  FrameFlags      // bit0 = compressed
-u8  K               // 1..128
+u8  K               // 1..255
 u8  Reserved        // block codec id for compressed block frames with dictID=0
 u64 DictID
 u64 RID[K]

--- a/TreeDB/internal/valuelog/valuelog.go
+++ b/TreeDB/internal/valuelog/valuelog.go
@@ -21,7 +21,7 @@ const (
 const (
 	FrameVersion    = 1
 	FrameHeaderSize = 12
-	MaxFrameK       = 128
+	MaxFrameK       = 255
 )
 
 const (

--- a/TreeDB/internal/valuelog/valuelog_test.go
+++ b/TreeDB/internal/valuelog/valuelog_test.go
@@ -1803,7 +1803,7 @@ func TestReadAtLargeValueLengthHintOmitted(t *testing.T) {
 	}
 }
 
-func TestReadAtGroupedLengthHintBit23RoundTrip(t *testing.T) {
+func TestReadAtGroupedLengthHintBit23Omitted(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "value-000001.log")
 
@@ -1813,7 +1813,7 @@ func TestReadAtGroupedLengthHintBit23RoundTrip(t *testing.T) {
 	}
 
 	const fixedOverhead = uint32(headerWithoutCRC + FrameHeaderSize + 8 + 8)
-	const targetRecordLen = uint32(0x00800080) // grouped hint bit23 set, still <= 24-bit max
+	const targetRecordLen = uint32(0x00800080) // bit23 is now reserved for grouped sub-index expansion.
 	if targetRecordLen <= fixedOverhead {
 		_ = writer.Close()
 		t.Fatalf("invalid target record length: %d", targetRecordLen)
@@ -1829,17 +1829,9 @@ func TestReadAtGroupedLengthHintBit23RoundTrip(t *testing.T) {
 		_ = writer.Close()
 		t.Fatalf("expected grouped pointer")
 	}
-	if got, want := page.ValuePtrRecordLength(ptr), targetRecordLen; got != want {
+	if got := page.ValuePtrRecordLength(ptr); got != 0 {
 		_ = writer.Close()
-		t.Fatalf("expected grouped hint round-trip got=%d want=%d", got, want)
-	}
-
-	// Simulate a pointer whose grouped length hint has bit23 set.
-	legacyPtr := ptr
-	legacyPtr.Length = page.ValuePtrMarkGrouped(targetRecordLen, page.ValuePtrSubIndex(ptr))
-	if got, want := page.ValuePtrRecordLength(legacyPtr), targetRecordLen; got != want {
-		_ = writer.Close()
-		t.Fatalf("legacy decoded record length mismatch got=%d want=%d", got, want)
+		t.Fatalf("expected grouped length hint to be omitted, got %d", got)
 	}
 	if err := writer.Close(); err != nil {
 		t.Fatalf("close: %v", err)
@@ -1851,7 +1843,7 @@ func TestReadAtGroupedLengthHintBit23RoundTrip(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = f.Close() })
 
-	got, err := ReadAtWithDict(f, legacyPtr, true, nil, nil, nil, templ.DecodeOptions{})
+	got, err := ReadAtWithDict(f, ptr, true, nil, nil, nil, templ.DecodeOptions{})
 	if err != nil {
 		t.Fatalf("read at: %v", err)
 	}

--- a/TreeDB/page/page_test.go
+++ b/TreeDB/page/page_test.go
@@ -41,6 +41,28 @@ func TestValuePtrEncoding(t *testing.T) {
 	}
 }
 
+func TestValuePtrGroupedSubIndexUsesHighBit(t *testing.T) {
+	for _, subIndex := range []uint8{0, 15, 16, 31, 32, 64, 127, 128, 254, 255} {
+		ptr := ValuePtr{
+			Offset: 1024,
+			Length: ValuePtrMarkGrouped(ValuePtrGroupedMaxRecordLen, subIndex),
+			FileID: ValueLogFileID(1),
+		}
+		if !ValuePtrIsGrouped(ptr) {
+			t.Fatalf("subIndex=%d: pointer is not grouped", subIndex)
+		}
+		if ValuePtrIsCompressed(ptr) {
+			t.Fatalf("subIndex=%d: grouped pointer must not report compressed", subIndex)
+		}
+		if got := ValuePtrSubIndex(ptr); got != subIndex {
+			t.Fatalf("subIndex=%d: decoded sub-index=%d", subIndex, got)
+		}
+		if got := ValuePtrRecordLength(ptr); got != ValuePtrGroupedMaxRecordLen {
+			t.Fatalf("subIndex=%d: record length=%d want %d", subIndex, got, ValuePtrGroupedMaxRecordLen)
+		}
+	}
+}
+
 func TestLeafLogPtrFromValuePtrPreservesGroupedFlag(t *testing.T) {
 	original := ValuePtr{
 		Offset: 128,

--- a/TreeDB/page/value_ptr_flags.go
+++ b/TreeDB/page/value_ptr_flags.go
@@ -11,21 +11,26 @@ const (
 	// when the grouped flag is set.
 	valuePtrSubIndexHiMask  uint32 = 0x03000000
 	valuePtrSubIndexHiShift        = 24
+
+	// Top grouped sub-index bit. Grouped pointers use this bit from the length
+	// hint space, so grouped record-length hints keep 23 bits.
+	valuePtrSubIndexTopMask  uint32 = 0x00800000
+	valuePtrSubIndexTopShift        = 23
 )
 
 // ValuePtrGroupedMaxRecordLen is the maximum record length (excluding CRC) that
 // can be encoded in a grouped ValuePtr length hint for new writes.
 //
-// Grouped pointers embed a sub-index in the Length field, leaving 24 bits for a
+// Grouped pointers embed a sub-index in the Length field, leaving 23 bits for a
 // best-effort record length hint. Larger records must set the hint to 0 and
 // rely on the value-log record header's ValueLen instead.
-const ValuePtrGroupedMaxRecordLen uint32 = 0x00ffffff
+const ValuePtrGroupedMaxRecordLen uint32 = 0x007fffff
 
 // ValuePtrRecordLength returns the record length with internal flags stripped.
 func ValuePtrRecordLength(ptr ValuePtr) uint32 {
 	mask := valuePtrCompressedMask | valuePtrGroupedMask | valuePtrSubIndexMask
 	if ValuePtrIsGrouped(ptr) {
-		mask |= valuePtrSubIndexHiMask
+		mask |= valuePtrSubIndexHiMask | valuePtrSubIndexTopMask
 	}
 	return ptr.Length &^ mask
 }
@@ -67,6 +72,9 @@ func ValuePtrSubIndex(ptr ValuePtr) uint8 {
 	if ptr.Length&valuePtrCompressedMask != 0 {
 		idx |= 0x10
 	}
+	if ptr.Length&valuePtrSubIndexTopMask != 0 {
+		idx |= 0x80
+	}
 	return idx
 }
 
@@ -75,14 +83,17 @@ func ValuePtrMarkCompressed(length uint32) uint32 {
 	return length | valuePtrCompressedMask
 }
 
-// ValuePtrMarkGrouped sets the grouped flag and sub-index (0-127) on a record length.
+// ValuePtrMarkGrouped sets the grouped flag and sub-index on a record length.
 func ValuePtrMarkGrouped(length uint32, subIndex uint8) uint32 {
 	idx := uint32(subIndex & 0x0f)
 	hi := uint32((subIndex >> 5) & 0x03)
-	length &^= (valuePtrSubIndexMask | valuePtrSubIndexHiMask | valuePtrCompressedMask)
+	length &^= (valuePtrSubIndexMask | valuePtrSubIndexHiMask | valuePtrSubIndexTopMask | valuePtrCompressedMask)
 	out := length | valuePtrGroupedMask | (idx << valuePtrSubIndexShift) | (hi << valuePtrSubIndexHiShift)
 	if subIndex&0x10 != 0 {
 		out |= valuePtrCompressedMask
+	}
+	if subIndex&0x80 != 0 {
+		out |= valuePtrSubIndexTopMask
 	}
 	return out
 }

--- a/docs/TREEDB_STORAGE_FORMAT.md
+++ b/docs/TREEDB_STORAGE_FORMAT.md
@@ -127,12 +127,13 @@ Grouped records (frames with `k>1`) embed a sub-record index inside `Length`
 When the grouped flag is set, the `Length` field packs:
 
 - **Grouped flag**: bit 30 (`0x4000_0000`)
-- **Sub-index** (0–127) within the grouped value-log record:
+- **Sub-index** (encoded range 0–255) within the grouped value-log record:
   - bits 29..26: sub-index bits 3..0
   - bit 31: sub-index bit 4
   - bits 25..24: sub-index bits 6..5
-- **Optional record-length hint**: low 24 bits (bits 23..0), storing the record length
-  excluding CRC (`HeaderSize-4 + ValueLen`) when it fits in 24 bits.
+  - bit 23: sub-index bit 7
+- **Optional record-length hint**: low 23 bits (bits 22..0), storing the record length
+  excluding CRC (`HeaderSize-4 + ValueLen`) when it fits in 23 bits.
 
 Notes:
 - The record-length hint is **best-effort**: if the record is larger than the


### PR DESCRIPTION
Closes part of #2395.

## Design note

This is the smallest production-default retained storage improvement I could make safely in one pass after the value-log ZSTD bootstrap. The retained Template-v1 path is already the default for non-column retained payloads, and retained values are already stored as grouped persistent value-log frames. The remaining obvious artificial cap was grouped frame cardinality: `MaxFrameK` was 128 because grouped `ValuePtr.Length` only encoded a 7-bit sub-index.

This PR widens grouped pointer sub-index encoding by taking bit 23 from the best-effort grouped record-length hint. That changes grouped hints from 24 bits to 23 bits and raises `valuelog.MaxFrameK` to 255, the largest safe value for the current uint8 frame header. Persistent value-log pointers, value-log GC reachability, rewrite behavior, and collection reconstruction stay on the same pointer model. No slabs are introduced, and leaf/value-log bytes remain fully counted.

The PR head is `6b856e8a97433667b14371d260c119e06cb5b79d`. The content commit is `27fba70d46e3bc8e758bb4f08675209749822807`; the merge commit exists because repository rules reject force-pushes to PR branches.

## Storage evidence

Same remote host/dataset/JSONBench command, 100k smoke because this is a bounded format hygiene pass rather than the full retained asset rewrite.

Baseline `origin/main` (`8ba30c9d1f2b66271ba01899c5e0fad99cc969fe`):

- result: `/tmp/treedb_2395_retained_pack_baseline_20260605_181100/run_100k/result.json`
- audit: `/tmp/treedb_2395_retained_pack_baseline_20260605_181100/run_100k/audit/compression_audit.json`
- durable excluding command WAL: `21,302,637` bytes
- leaf_vlog: `915,411` bytes
- value_vlog: `12,090,825` bytes
- value_vlog grouped_block_zstd frames: `774`
- value_vlog grouped_block_zstd records/frame: `127.876`
- value_vlog grouped_block_zstd stored/raw: `0.417251`
- retained audit: passed, `100,000` rows
- raw retained frame bytes: `0`

Final candidate `6b856e8a97433667b14371d260c119e06cb5b79d`:

- result: `/tmp/treedb_2395_retained_pack_final_20260605_181624/run_100k/result.json`
- audit: `/tmp/treedb_2395_retained_pack_final_20260605_181624/run_100k/audit/compression_audit.json`
- durable excluding command WAL: `21,172,461` bytes (`-130,176`, `-0.61%`)
- leaf_vlog: `914,587` bytes (`-824`)
- value_vlog: `11,961,473` bytes (`-129,352`)
- value_vlog grouped_block_zstd frames: `482`
- value_vlog grouped_block_zstd records/frame: `205.344`
- value_vlog grouped_block_zstd stored/raw: `0.413555`
- retained audit: passed, `100,000` rows
- raw retained frame bytes: `0`
- gzip oracle: value_vlog gzip/raw `0.943`, maindb gzip/raw `0.668`

Query timings, one loaded 100k DB:

| query | baseline | final candidate |
|---|---:|---:|
| q1 | 0.006318542 | 0.011508979 |
| q2 | 0.042868892 | 0.055726595 |
| q3 | 0.020290968 | 0.020440239 |
| q4 | 0.019332014 | 0.032879437 |
| q5 | 0.020106061 | 0.028406071 |

The final candidate timing run is a one-try 100k smoke and should not be treated as throughput proof. Storage and correctness are the useful signals here.

Reconstruction hash stayed valid on both runs: `0fafcd8220976d86686d3dee177ce520c7701293148609f47d4c58a5bd357cc8`.

## Tests

Pre-push focused and affected-package validation on the final diff:

- `go test ./TreeDB/page ./TreeDB/internal/valuelog -run 'TestValuePtr|TestReadAtGrouped|TestReadAtLargeValueLengthHintOmitted|TestReadAtGroupedLengthHintBit23Omitted|TestEncodeFrame|TestAppendFrame' -count=1`
- `go test ./TreeDB/caching -run 'TestChooseRetainedStorageFirst|TestChooseValueLogBlockWriteK|TestAppendValueLog_AutoBalanced|TestAppendValueLogForRecords' -count=1`
- `go test ./TreeDB/page ./TreeDB/internal/valuelog ./TreeDB/caching -count=1`
- `go test ./TreeDB/db ./TreeDB/internal/bulk ./TreeDB/zipper ./TreeDB/internal/dictdb -count=1`
- `go test ./TreeDB/collections -run 'Test.*Retained|Test.*Reconstruct|Test.*Column' -count=1`

After rebasing onto latest `origin/main` (`46b23b8f8af6e8cfdd22739ec7c5461fa9ba0e31`), I reran:

- `go test ./TreeDB/page ./TreeDB/internal/valuelog ./TreeDB/caching -count=1`
- `go test ./TreeDB/db ./TreeDB/internal/bulk ./TreeDB/zipper ./TreeDB/internal/dictdb -count=1`
- `go test ./TreeDB/collections -run 'Test.*Retained|Test.*Reconstruct|Test.*Column' -count=1`

## Remaining work

This does not implement the full Template-v1 retained-remainder batch asset or super-pack representation requested in #2395. It removes the current 128-row frame cap and proves a production-default storage reduction, but the main remaining value-log bytes still require a higher-level retained asset/locator design to materially close the ClickHouse/colgranule gap.
