### PR TITLE
Reduce production typed-column storage kernels

### DIFF
--- a/TreeDB/collections/typed_column_adapter.go
+++ b/TreeDB/collections/typed_column_adapter.go
@@ -366,6 +366,21 @@ func applyTypedColumnAdapterDefinitionOptions(field TypedStorageField, def *type
 	return validateTypedColumnProductionDefinition(field, *def)
 }
 
+func typedColumnAdapterPrimaryIDDefinition(opts typedColumnAdapterOptions) typedcolumn.ColumnDefinition {
+	compression := typedcolumn.CompressionNone
+	if opts.DefaultCompressionSet {
+		compression = opts.DefaultCompression
+	}
+	return typedcolumn.ColumnDefinition{
+		Name:           typedColumnAdapterPrimaryIDColumn,
+		Type:           typedcolumn.ColumnTypeInt64,
+		Encoding:       typedcolumn.EncodingDeltaVarint,
+		Compression:    compression,
+		CompressionSet: true,
+		StatsDisabled:  true,
+	}
+}
+
 func typedColumnAdapterColumnsForFields(fields []TypedStorageField) ([]typedColumnAdapterColumn, error) {
 	return typedColumnAdapterColumnsForFieldsMapped(fields, nil)
 }
@@ -559,14 +574,7 @@ func buildTypedColumnAdapterPart(opts typedColumnAdapterOptions, rows []typedCol
 	}
 
 	defs := make([]typedcolumn.ColumnDefinition, 0, len(columns)+1)
-	defs = append(defs, typedcolumn.ColumnDefinition{
-		Name:           typedColumnAdapterPrimaryIDColumn,
-		Type:           typedcolumn.ColumnTypeInt64,
-		Encoding:       typedcolumn.EncodingRawInt64,
-		Compression:    typedcolumn.CompressionNone,
-		CompressionSet: true,
-		StatsDisabled:  true,
-	})
+	defs = append(defs, typedColumnAdapterPrimaryIDDefinition(opts))
 	for _, column := range columns {
 		defs = append(defs, column.Definition)
 	}
@@ -4992,8 +5000,13 @@ func scanTypedColumnStringPreparedPartWithVisibility(preparedPart *typedColumnPr
 	if !ok {
 		return false, fmt.Errorf("missing primary id section %q", typedColumnAdapterPrimaryIDColumn)
 	}
-	if idCol.Definition.Type != typedcolumn.ColumnTypeInt64 || idCol.Definition.Encoding != typedcolumn.EncodingRawInt64 {
-		return false, fmt.Errorf("primary id column %q type=%s encoding=%s", typedColumnAdapterPrimaryIDColumn, idCol.Definition.Type, idCol.Definition.Encoding)
+	if idCol.Definition.Type != typedcolumn.ColumnTypeInt64 {
+		return false, fmt.Errorf("primary id column %q type=%s", typedColumnAdapterPrimaryIDColumn, idCol.Definition.Type)
+	}
+	switch idCol.Definition.Encoding {
+	case typedcolumn.EncodingRawInt64, typedcolumn.EncodingDeltaVarint, typedcolumn.EncodingDoubleDeltaVarint:
+	default:
+		return false, fmt.Errorf("primary id column %q unsupported encoding=%s", typedColumnAdapterPrimaryIDColumn, idCol.Definition.Encoding)
 	}
 	cardinality := preparedColumn.Column.Definition.Cardinality
 	if cardinality == 0 {

--- a/TreeDB/collections/typed_column_adapter_test.go
+++ b/TreeDB/collections/typed_column_adapter_test.go
@@ -2251,7 +2251,7 @@ func TestTypedColumnAdapterPrepareInt64AggregateValidationFailsClosed(t *testing
 		{Name: "count", Type: typedcolumn.ColumnTypeInt64, Encoding: typedcolumn.EncodingDeltaVarint, Compression: typedcolumn.CompressionNone, CompressionSet: true},
 	}, "id", 2)
 	primaryEncodingMismatch := typedColumnAdapterBuildCustomInt64AggregateImage(t, []typedcolumn.ColumnDefinition{
-		{Name: typedColumnAdapterPrimaryIDColumn, Type: typedcolumn.ColumnTypeInt64, Encoding: typedcolumn.EncodingDeltaVarint, Compression: typedcolumn.CompressionNone, CompressionSet: true},
+		{Name: typedColumnAdapterPrimaryIDColumn, Type: typedcolumn.ColumnTypeInt64, Encoding: typedcolumn.EncodingNullableInt64, Compression: typedcolumn.CompressionNone, CompressionSet: true},
 		{Name: "count", Type: typedcolumn.ColumnTypeInt64, Encoding: typedcolumn.EncodingDeltaVarint, Compression: typedcolumn.CompressionNone, CompressionSet: true},
 	}, typedColumnAdapterPrimaryIDColumn, 2)
 	selectedEncodingMismatch := typedColumnAdapterBuildCustomInt64AggregateImage(t, []typedcolumn.ColumnDefinition{

--- a/TreeDB/collections/typed_column_capability.go
+++ b/TreeDB/collections/typed_column_capability.go
@@ -611,10 +611,15 @@ func validateTypedColumnProductionPartColumnLayout(field TypedStorageField, colu
 }
 
 func validateTypedColumnProductionPrimaryColumnLayout(column typedcolumn.ColumnPartColumn) error {
-	if column.Definition.Name != typedColumnAdapterPrimaryIDColumn || column.Definition.Type != typedcolumn.ColumnTypeInt64 || column.Definition.Encoding != typedcolumn.EncodingRawInt64 || column.Definition.Compression != typedcolumn.CompressionNone {
-		return fmt.Errorf("%w: primary-id column %q type=%s encoding=%s compression=%s want type=%s encoding=%s compression=%s", errTypedColumnProductionLayoutUnsupported, column.Definition.Name, column.Definition.Type, column.Definition.Encoding, column.Definition.Compression, typedcolumn.ColumnTypeInt64, typedcolumn.EncodingRawInt64, typedcolumn.CompressionNone)
+	if column.Definition.Name != typedColumnAdapterPrimaryIDColumn || column.Definition.Type != typedcolumn.ColumnTypeInt64 {
+		return fmt.Errorf("%w: primary-id column %q type=%s want type=%s", errTypedColumnProductionLayoutUnsupported, column.Definition.Name, column.Definition.Type, typedcolumn.ColumnTypeInt64)
 	}
-	return validateTypedColumnProductionBlocks(typedColumnAdapterPrimaryIDColumn, typedcolumn.EncodingRawInt64, typedcolumn.CompressionNone, column.Blocks)
+	switch column.Definition.Encoding {
+	case typedcolumn.EncodingRawInt64, typedcolumn.EncodingDeltaVarint, typedcolumn.EncodingDoubleDeltaVarint:
+	default:
+		return fmt.Errorf("%w: primary-id column %q encoding=%s is unsupported", errTypedColumnProductionLayoutUnsupported, column.Definition.Name, column.Definition.Encoding)
+	}
+	return validateTypedColumnProductionBlocks(typedColumnAdapterPrimaryIDColumn, column.Definition.Encoding, column.Definition.Compression, column.Blocks)
 }
 
 func validateTypedColumnProductionBlocks(label string, wantEncoding typedcolumn.Encoding, requestedCompression typedcolumn.Compression, blocks []typedcolumn.ColumnBlock) error {

--- a/TreeDB/collections/typed_column_capability_test.go
+++ b/TreeDB/collections/typed_column_capability_test.go
@@ -218,8 +218,8 @@ func TestTypedColumnProductionCapabilityValidatesCompressedReadLayouts(t *testin
 		primary.Definition.Compression = typedcolumn.CompressionSnappy
 		part.Part.Columns[typedColumnAdapterPrimaryIDColumn] = primary
 		err := validateTypedColumnAdapterImageSchema(part.Part, part.Columns, uint32(part.Part.Descriptor.SchemaVersion))
-		if !errors.Is(err, errTypedColumnProductionLayoutUnsupported) || !strings.Contains(err.Error(), "primary-id validation failed") || !strings.Contains(err.Error(), "compression=snappy") {
-			t.Fatalf("err=%v want compressed primary rejection", err)
+		if err != nil {
+			t.Fatalf("validate compressed primary layout: %v", err)
 		}
 	})
 }

--- a/TreeDB/collections/typed_column_codec_policy_test.go
+++ b/TreeDB/collections/typed_column_codec_policy_test.go
@@ -33,10 +33,15 @@ func TestTypedColumnAdapterOptInCompressionRoundTrip1952(t *testing.T) {
 				t.Fatalf("build compressed part: %v", err)
 			}
 			primary := part.Part.Columns[typedColumnAdapterPrimaryIDColumn]
-			if primary.Definition.Compression != typedcolumn.CompressionNone {
-				t.Fatalf("primary compression=%s want none", primary.Definition.Compression)
+			if primary.Definition.Encoding != typedcolumn.EncodingDeltaVarint || primary.Definition.Compression != compression {
+				t.Fatalf("primary definition=%+v want delta_varint/%s", primary.Definition, compression)
 			}
 			kept := 0
+			for _, block := range primary.Blocks {
+				if block.Descriptor.Encoding != typedcolumn.EncodingDeltaVarint || block.Granule.Encoding != typedcolumn.EncodingDeltaVarint {
+					t.Fatalf("primary block encoding=%s/%s want delta_varint", block.Descriptor.Encoding, block.Granule.Encoding)
+				}
+			}
 			for _, column := range part.Columns {
 				got := part.Part.Columns[column.Definition.Name]
 				if got.Definition.Compression != compression {
@@ -211,7 +216,18 @@ func TestTypedColumnProductionCompressionPolicyDefaultsDurable2297(t *testing.T)
 	}
 	foundColumnPolicy := false
 	foundLocatorSection := false
+	foundPruningSection := false
+	foundPrimaryID := false
 	for _, part := range accounting.TypedColumnParts {
+		for _, column := range part.Image.ColumnsDetail {
+			if column.Column != typedColumnAdapterPrimaryIDColumn {
+				continue
+			}
+			foundPrimaryID = true
+			if column.Encoding != typedcolumn.EncodingDeltaVarint.String() || column.RequestedCompression != string(ColumnStoreTypedColumnCompressionLZ4) || column.StoredBytes >= column.LogicalValueBytes {
+				t.Fatalf("primary-id column accounting=%+v want compact delta_varint/lz4 storage", column)
+			}
+		}
 		for _, detail := range part.Image.CompressionDetail {
 			if detail.Column != "time_us" || detail.RequestedCompression != string(ColumnStoreTypedColumnCompressionLZ4) {
 				continue
@@ -223,6 +239,12 @@ func TestTypedColumnProductionCompressionPolicyDefaultsDurable2297(t *testing.T)
 		}
 		for _, section := range part.Image.SerializedSections {
 			if section.Kind != string(typedcolumn.ColumnPartImageSectionRowLocators) {
+				if section.Kind == string(typedcolumn.ColumnPartImageSectionPruningMetadata) {
+					foundPruningSection = true
+					if section.Compression != string(ColumnStoreTypedColumnCompressionLZ4) || section.RawBytes <= section.StoredBytes || section.StoredBytes != section.Bytes {
+						t.Fatalf("pruning metadata section=%+v want kept LZ4 section compression", section)
+					}
+				}
 				continue
 			}
 			foundLocatorSection = true
@@ -236,6 +258,12 @@ func TestTypedColumnProductionCompressionPolicyDefaultsDurable2297(t *testing.T)
 	}
 	if !foundLocatorSection {
 		t.Fatalf("missing compressed row locator section in %+v", accounting.TypedColumnParts)
+	}
+	if !foundPruningSection {
+		t.Fatalf("missing compressed pruning metadata section in %+v", accounting.TypedColumnParts)
+	}
+	if !foundPrimaryID {
+		t.Fatalf("missing primary-id column accounting in %+v", accounting.TypedColumnParts)
 	}
 }
 

--- a/TreeDB/collections/typed_column_prepared_int64.go
+++ b/TreeDB/collections/typed_column_prepared_int64.go
@@ -163,8 +163,16 @@ func validateTypedColumnPreparedInt64AggregatePart(part *typedColumnPreparedPart
 	if !primaryFound {
 		return fmt.Errorf("collections: typed-column int64 aggregate prepared image missing primary-id column %q", primaryName)
 	}
-	if primary.Definition.Type != typedcolumn.ColumnTypeInt64 || primary.Definition.Encoding != typedcolumn.EncodingRawInt64 || primary.Definition.Compression != typedcolumn.CompressionNone {
-		return fmt.Errorf("collections: typed-column int64 aggregate prepared image primary-id column %q type=%s encoding=%s compression=%s want type=%s encoding=%s compression=%s", primaryName, primary.Definition.Type, primary.Definition.Encoding, primary.Definition.Compression, typedcolumn.ColumnTypeInt64, typedcolumn.EncodingRawInt64, typedcolumn.CompressionNone)
+	if primary.Definition.Type != typedcolumn.ColumnTypeInt64 {
+		return fmt.Errorf("collections: typed-column int64 aggregate prepared image primary-id column %q type=%s want %s", primaryName, primary.Definition.Type, typedcolumn.ColumnTypeInt64)
+	}
+	switch primary.Definition.Encoding {
+	case typedcolumn.EncodingRawInt64, typedcolumn.EncodingDeltaVarint, typedcolumn.EncodingDoubleDeltaVarint:
+	default:
+		return fmt.Errorf("collections: typed-column int64 aggregate prepared image primary-id column %q encoding=%s is unsupported", primaryName, primary.Definition.Encoding)
+	}
+	if err := validateTypedColumnProductionCompression(primary.Definition.Compression); err != nil {
+		return fmt.Errorf("collections: typed-column int64 aggregate prepared image primary-id column %q compression=%s: %w", primaryName, primary.Definition.Compression, err)
 	}
 	preparedColumn, ok := part.Columns[adapterColumn.Definition.Name]
 	if !ok || preparedColumn == nil {

--- a/TreeDB/collections/typed_column_prepared_state.go
+++ b/TreeDB/collections/typed_column_prepared_state.go
@@ -797,7 +797,7 @@ func typedColumnAttachPreparedPruning(part *typedColumnPreparedPartState, image 
 		return diag, err
 	}
 	diag.DecodedMetadataBytes += uint64(len(raw))
-	pruning, err := typedcolumn.DecodeColumnPartPruningSection(raw)
+	pruning, err := typedcolumn.DecodeColumnPartPruningImageSection(section, raw)
 	if err != nil {
 		return diag, err
 	}

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -431,7 +431,7 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/typed_column_benchmark_policy.go", classification: typedStorageLegacyCompatibility, matchingLines: 17, occurrences: 20},
 	{path: "TreeDB/collections/typed_column_capability.go", classification: typedStorageLegacyCompatibility, matchingLines: 60, occurrences: 135},
 	{path: "TreeDB/collections/typed_column_capability_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 20, occurrences: 20},
-	{path: "TreeDB/collections/typed_column_codec_policy_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 54, occurrences: 62},
+	{path: "TreeDB/collections/typed_column_codec_policy_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 56, occurrences: 64},
 	{path: "TreeDB/collections/typed_column_bool_scan.go", classification: typedStorageLegacyCompatibility, matchingLines: 14, occurrences: 19},
 	{path: "TreeDB/collections/typed_column_bool_scan_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 3, occurrences: 4},
 	{path: "TreeDB/collections/typed_column_conformance_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 28, occurrences: 37},

--- a/TreeDB/docs/spec/storage-format.md
+++ b/TreeDB/docs/spec/storage-format.md
@@ -573,10 +573,10 @@ the final byte of each row, and uncompressed row-major payload sections
 (`rows * ceil(elements_per_row * bits_per_element / 8)` bytes). Readers must
 fail closed on unknown type codes rather than guessing a payload shape.
 Current typed-column image version 4 directory entries carry per-section
-`raw_bytes` metadata for compressed sections. Row-locator and dictionary
-sections may use Snappy or LZ4 when the raw length is within the decoder cap;
-readers validate the raw byte count before decompression and fail closed on
-unsupported section compression.
+`raw_bytes` metadata for compressed sections. Row-locator, dictionary, and
+pruning-metadata sections may use Snappy or LZ4 when the raw length is within
+the decoder cap; readers validate the raw byte count before decompression and
+fail closed on unsupported section compression.
 
 Version 1 row payloads omitted the `Deleted` flag and represented only live
 insert/update rows:

--- a/TreeDB/internal/typedcolumn/part_image.go
+++ b/TreeDB/internal/typedcolumn/part_image.go
@@ -812,15 +812,14 @@ func (b *columnPartImageBuilder) addPruningMetadataSection() error {
 	if len(data) == 0 {
 		return nil
 	}
-	b.appendSection(ColumnPartImageSection{
+	return b.appendSectionWithOptionalCompression(ColumnPartImageSection{
 		Kind:     ColumnPartImageSectionPruningMetadata,
 		Category: ColumnPartImageCategoryPruningMetadata,
 		Name:     "column_pruning",
 		Rows:     b.part.Descriptor.RowCount,
 		Granules: len(b.part.Descriptor.Granules),
 		Blocks:   countColumnBlocks(b.part.Descriptor),
-	}, data)
-	return nil
+	}, data, b.opts.SectionCompression)
 }
 
 func (b *columnPartImageBuilder) addDictionarySection() error {
@@ -1109,7 +1108,7 @@ func canCompressImageSection(section ColumnPartImageSection, rawBytes int, compr
 			return false
 		}
 		switch section.Kind {
-		case ColumnPartImageSectionRowLocators, ColumnPartImageSectionDictionaries:
+		case ColumnPartImageSectionRowLocators, ColumnPartImageSectionDictionaries, ColumnPartImageSectionPruningMetadata:
 			return true
 		default:
 			return false

--- a/TreeDB/internal/typedcolumn/part_image_decode.go
+++ b/TreeDB/internal/typedcolumn/part_image_decode.go
@@ -18,6 +18,8 @@ const maxCompressedRowLocatorSectionRawBytes = maxCompressedImageSectionRawBytes
 
 const maxCompressedDictionarySectionRawBytes = maxCompressedImageSectionRawBytes
 
+const maxCompressedPruningMetadataSectionRawBytes = maxCompressedImageSectionRawBytes
+
 const ColumnPartImageManifestHeaderBytes = 32
 
 func ParseColumnPartImage(data []byte) (ColumnPartImage, error) {
@@ -2464,8 +2466,23 @@ func (i ColumnPartImage) dictionarySectionBytes(section ColumnPartImageSection) 
 	return i.sectionBytesWithKnownRawLength(section, rawBytes, maxCompressedDictionarySectionRawBytes, "dictionaries")
 }
 
+func (i ColumnPartImage) pruningMetadataSectionBytes(section ColumnPartImageSection) ([]byte, error) {
+	rawBytes := section.RawBytes
+	if rawBytes == 0 && section.Compression == CompressionNone {
+		rawBytes = section.Length
+	}
+	return i.sectionBytesWithKnownRawLength(section, rawBytes, maxCompressedPruningMetadataSectionRawBytes, "pruning metadata")
+}
+
 func (i ColumnPartImage) sectionBytesWithKnownRawLength(section ColumnPartImageSection, rawBytes int, maxRawBytes int, label string) ([]byte, error) {
 	payload := i.sectionBytes(section)
+	return sectionPayloadBytesWithKnownRawLength(section, payload, rawBytes, maxRawBytes, label)
+}
+
+func sectionPayloadBytesWithKnownRawLength(section ColumnPartImageSection, payload []byte, rawBytes int, maxRawBytes int, label string) ([]byte, error) {
+	if len(payload) != section.Length {
+		return nil, fmt.Errorf("typedcolumn: %s section payload bytes=%d want section length=%d", label, len(payload), section.Length)
+	}
 	switch section.Compression {
 	case CompressionNone:
 		if len(payload) != rawBytes {
@@ -2582,7 +2599,11 @@ func validateImageSectionCompression(section ColumnPartImageSection) error {
 		default:
 			return fmt.Errorf("typedcolumn: section %s compression=%s is unsupported", section.Kind, section.Compression)
 		}
-	case ColumnPartImageSectionDictionaries:
+	case ColumnPartImageSectionDictionaries, ColumnPartImageSectionPruningMetadata:
+		maxRawBytes := maxCompressedDictionarySectionRawBytes
+		if section.Kind == ColumnPartImageSectionPruningMetadata {
+			maxRawBytes = maxCompressedPruningMetadataSectionRawBytes
+		}
 		switch section.Compression {
 		case CompressionNone:
 			if section.RawBytes != 0 && section.RawBytes != section.Length {
@@ -2593,8 +2614,8 @@ func validateImageSectionCompression(section ColumnPartImageSection) error {
 			if section.RawBytes <= 0 {
 				return fmt.Errorf("typedcolumn: section %s compressed raw bytes=%d is invalid", section.Kind, section.RawBytes)
 			}
-			if section.RawBytes > maxCompressedDictionarySectionRawBytes {
-				return fmt.Errorf("typedcolumn: section %s raw bytes=%d exceeds max=%d", section.Kind, section.RawBytes, maxCompressedDictionarySectionRawBytes)
+			if section.RawBytes > maxRawBytes {
+				return fmt.Errorf("typedcolumn: section %s raw bytes=%d exceeds max=%d", section.Kind, section.RawBytes, maxRawBytes)
 			}
 			return nil
 		default:

--- a/TreeDB/internal/typedcolumn/pruning.go
+++ b/TreeDB/internal/typedcolumn/pruning.go
@@ -477,7 +477,11 @@ func decodeColumnPruningSectionFromImage(image ColumnPartImage, desc ColumnPartD
 	if err != nil || !ok {
 		return ColumnPartPruning{}, err
 	}
-	pruning, err := DecodeColumnPartPruningSection(image.sectionBytes(section))
+	data, err := image.pruningMetadataSectionBytes(section)
+	if err != nil {
+		return ColumnPartPruning{}, err
+	}
+	pruning, err := DecodeColumnPartPruningSection(data)
 	if err != nil {
 		return ColumnPartPruning{}, err
 	}
@@ -485,6 +489,18 @@ func decodeColumnPruningSectionFromImage(image ColumnPartImage, desc ColumnPartD
 		return ColumnPartPruning{}, err
 	}
 	return pruning, nil
+}
+
+func DecodeColumnPartPruningImageSection(section ColumnPartImageSection, payload []byte) (ColumnPartPruning, error) {
+	rawBytes := section.RawBytes
+	if rawBytes == 0 && section.Compression == CompressionNone {
+		rawBytes = section.Length
+	}
+	data, err := sectionPayloadBytesWithKnownRawLength(section, payload, rawBytes, maxCompressedPruningMetadataSectionRawBytes, "pruning metadata")
+	if err != nil {
+		return ColumnPartPruning{}, err
+	}
+	return DecodeColumnPartPruningSection(data)
 }
 
 func DecodeColumnPartPruningSection(data []byte) (ColumnPartPruning, error) {

--- a/TreeDB/internal/typedcolumn/pruning_test.go
+++ b/TreeDB/internal/typedcolumn/pruning_test.go
@@ -55,6 +55,59 @@ func TestColumnPruningInt64ValueRowsRoundTrip(t *testing.T) {
 	}
 }
 
+func TestColumnPruningCompressedImageSectionRoundTrip(t *testing.T) {
+	values := make([]int64, 8192)
+	for i := range values {
+		values[i] = int64(i % 8)
+	}
+	part := mustStatsTestPartWithBlockRows(t, values, EncodingDeltaVarint, 512)
+	image, err := BuildColumnPartImage(part, ColumnPartImageOptions{
+		LayoutLogicalTypes: map[string]string{"id": "int64", "value": "int64"},
+		SectionCompression: CompressionLZ4,
+	})
+	if err != nil {
+		t.Fatalf("BuildColumnPartImage: %v", err)
+	}
+	section, ok, err := image.PruningMetadataSection()
+	if err != nil || !ok {
+		t.Fatalf("PruningMetadataSection ok=%v err=%v", ok, err)
+	}
+	if section.Compression != CompressionLZ4 || section.RawBytes <= section.Length {
+		t.Fatalf("pruning metadata section=%+v want kept lz4 compression", section)
+	}
+	parsed, err := ParseColumnPartImage(image.Bytes)
+	if err != nil {
+		t.Fatalf("ParseColumnPartImage: %v", err)
+	}
+	reopened, err := ColumnPartFromImage(parsed)
+	if err != nil {
+		t.Fatalf("ColumnPartFromImage: %v", err)
+	}
+	index, ok := reopened.PruningMetadata.Int64Column("value")
+	if !ok {
+		t.Fatalf("reopened pruning metadata missing value column")
+	}
+	plan, err := index.PlanInt64Predicate(Int64PruningPredicate{Kind: Int64PruningPredicateEqual, Value: 3})
+	if err != nil {
+		t.Fatalf("PlanInt64Predicate: %v", err)
+	}
+	if got, want := plan.CandidateRows, len(values)/8; got != want {
+		t.Fatalf("candidate rows=%d want %d", got, want)
+	}
+
+	corrupt := parsed
+	corrupt.Sections = append([]ColumnPartImageSection(nil), parsed.Sections...)
+	for i := range corrupt.Sections {
+		if corrupt.Sections[i].Kind == ColumnPartImageSectionPruningMetadata {
+			corrupt.Sections[i].RawBytes--
+			break
+		}
+	}
+	if _, err := ColumnPartFromImage(corrupt); err == nil || !strings.Contains(err.Error(), "pruning metadata") {
+		t.Fatalf("ColumnPartFromImage corrupt pruning metadata err=%v want pruning metadata raw-length failure", err)
+	}
+}
+
 func TestColumnPruningAllPredicateDoesNotScanValueRows(t *testing.T) {
 	part := mustStatsTestPartWithBlockRows(t, []int64{3, 4, 5, 6}, EncodingRawInt64, 2)
 	index, ok := part.PruningMetadata.Int64Column("value")


### PR DESCRIPTION
## Summary
- compact the internal `__treedb_primary_id` column with delta-varint plus the active production compression policy
- add section-aware compression/decompression for typed-column pruning metadata
- keep prepared pruning and physical accounting section-aware so audit output reports actual section modes

Refs #2396

## Validation
- `go test ./TreeDB/internal/typedcolumn -count=1`
- `go test ./TreeDB/collections -count=1`
- `go test ./cmd/treedb_column_section_audit -count=1`
- `python3 scripts/treedb_jsonbench_storage_audit_test.py`
- `git diff --check`

## 1M JSONBench evidence
Remote exact-head run: `/tmp/treedb_jsonbench_2396_1m_rebased_20260605_182111/run_1m/result.json`
Audit: `/tmp/treedb_jsonbench_2396_1m_rebased_20260605_182111/run_1m/audit/compression_audit.json`

Run heads:
- gomap: `d70e9d371bb6b0bc99428e5d9b0baffffdfb4d9c`
- JSONBench: `07844fa758101ad6d38b703478cefc0f0bd61c9e`

Compared with the post-#2390/#2391 baseline supplied in #2396:

| metric | baseline | this PR | delta |
|---|---:|---:|---:|
| durable excluding command WAL | 208,648,502 | 193,654,538 | -14,993,964 |
| column_asset_segments | 79,153,284 | 64,184,052 | -14,969,232 |
| active typed_column_part | 62,146,228 | 47,176,996 | -14,969,232 |
| row/compat asset | 17,007,056 | 17,007,056 | 0 |
| declared column data | 15,569,913 | 7,576,726 | -7,993,187 |
| pruning metadata | 16,018,795 | 9,042,677 | -6,976,118 |
| dictionaries | 17,692,852 | 17,692,852 | 0 |
| locators | 12,522,557 | 12,522,557 | 0 |

Section audit summary for this PR:

| section/compression | stored | raw |
|---|---:|---:|
| lz4 sections | 44,826,984 | 109,655,845 |
| none sections | 2,350,012 | 2,350,012 |
| `__treedb_primary_id` column_data | 6,813 | 1,000,124 |
| pruning_metadata | 9,042,677 | 16,018,795 |

Queries q1-q5 ran from one full-data DB with reconstruction validation enabled. Exact-head timings: q1 `0.062904296`, q2 `0.506592421`, q3 `0.197589935`, q4 `0.191784133`, q5 `0.207743934`.

## Remaining work
- dictionary bytes are unchanged in this pass; grouping/dictionary-specific kernels remain open
- row locators are unchanged in this pass
- time_us stored bytes are unchanged because its encoded raw payload is already small and LZ4 admission keeps it uncompressed
- value_vlog/leaf_vlog work is outside this typed-column PR
