### PR TITLE
Refresh TreeDB vector search profiling hook

### DIFF
--- a/benchmarks/vector_db_compare/README.md
+++ b/benchmarks/vector_db_compare/README.md
@@ -121,7 +121,8 @@ Configuration:
   demo matrix mode is used, profiles are further nested under the matrix case
   name (`<profile-dir>/<backend>/<matrix_case>/...`) so case artifacts are not
   overwritten. CPU profiles are scoped to the search loop; the other files are
-  runtime snapshots for supporting diagnosis.
+  runtime snapshots for supporting diagnosis. Heap and allocation profiles use
+  the Go runtime's current/default sampling rate.
 - `TREEDB_QUANTIZED_INDEX_NAME`: scalar_u8 TreeDB quantized score-plane name.
   Defaults to `embedding.scalar_u8.fast`.
 - `TREEDB_QUANTIZED_RERANK_CANDIDATES`: TreeDB quantized-rerank exact rerank

--- a/benchmarks/vector_db_compare/README.md
+++ b/benchmarks/vector_db_compare/README.md
@@ -122,7 +122,9 @@ Configuration:
   name (`<profile-dir>/<backend>/<matrix_case>/...`) so case artifacts are not
   overwritten. CPU profiles are scoped to the search loop; the other files are
   runtime snapshots for supporting diagnosis. Heap and allocation profiles use
-  the Go runtime's current/default sampling rate.
+  the Go runtime's current/default sampling rate. Block profiles are emitted
+  from the runtime's current block profiler and may be empty unless block
+  profiling was already enabled.
 - `TREEDB_QUANTIZED_INDEX_NAME`: scalar_u8 TreeDB quantized score-plane name.
   Defaults to `embedding.scalar_u8.fast`.
 - `TREEDB_QUANTIZED_RERANK_CANDIDATES`: TreeDB quantized-rerank exact rerank

--- a/benchmarks/vector_db_compare/README.md
+++ b/benchmarks/vector_db_compare/README.md
@@ -114,9 +114,11 @@ Configuration:
   `-validation-exact-source=treedb|dataset` for every TreeDB row. Unset keeps
   the demo default (`treedb`). Set `dataset` to compute validation exact top-K
   IDs from the exported dataset vectors instead of TreeDB exact search.
-- `TREEDB_SEARCH_PROFILE_DIR`: optional top-level directory for TreeDB search
-  profiles. When set, each TreeDB row passes a backend-specific subdirectory to
-  `-search-profile-dir`; column_graph rows emit per-concurrency
+- `TREEDB_SEARCH_PROFILE_DIR`: optional top-level directory for TreeDB
+  column_graph search profiles. When set, only TreeDB column_graph rows pass a
+  backend-specific subdirectory to `-search-profile-dir`; the native `treedb`
+  row does not receive the flag because native search profiling is not
+  implemented. Column_graph rows emit per-concurrency
   `search_<mode>_c<N>_{cpu,heap,allocs,block,mutex}.pprof` files there. If the
   demo matrix mode is used, profiles are further nested under the matrix case
   name (`<profile-dir>/<backend>/<matrix_case>/...`) so case artifacts are not
@@ -162,7 +164,7 @@ The runner writes:
 - `pgvector.json`: PostgreSQL+pgvector full-vector HNSW benchmark result when enabled
 - `mongodb.json`: MongoDB Vector Search benchmark result when enabled
 - `comparison.md`: normalized comparison table
-- TreeDB search profiles under backend-specific subdirectories of
+- TreeDB column_graph search profiles under backend-specific subdirectories of
   `TREEDB_SEARCH_PROFILE_DIR`, when set
 
 The TreeDB dataset exporter writes row-major little-endian `float32` vector

--- a/benchmarks/vector_db_compare/README.md
+++ b/benchmarks/vector_db_compare/README.md
@@ -117,9 +117,11 @@ Configuration:
 - `TREEDB_SEARCH_PROFILE_DIR`: optional top-level directory for TreeDB search
   profiles. When set, each TreeDB row passes a backend-specific subdirectory to
   `-search-profile-dir`; column_graph rows emit per-concurrency
-  `search_<mode>_c<N>_{cpu,heap,allocs,block,mutex}.pprof` files there. CPU
-  profiles are scoped to the search loop; the other files are runtime snapshots
-  for supporting diagnosis.
+  `search_<mode>_c<N>_{cpu,heap,allocs,block,mutex}.pprof` files there. If the
+  demo matrix mode is used, profiles are further nested under the matrix case
+  name (`<profile-dir>/<backend>/<matrix_case>/...`) so case artifacts are not
+  overwritten. CPU profiles are scoped to the search loop; the other files are
+  runtime snapshots for supporting diagnosis.
 - `TREEDB_QUANTIZED_INDEX_NAME`: scalar_u8 TreeDB quantized score-plane name.
   Defaults to `embedding.scalar_u8.fast`.
 - `TREEDB_QUANTIZED_RERANK_CANDIDATES`: TreeDB quantized-rerank exact rerank

--- a/benchmarks/vector_db_compare/README.md
+++ b/benchmarks/vector_db_compare/README.md
@@ -114,6 +114,12 @@ Configuration:
   `-validation-exact-source=treedb|dataset` for every TreeDB row. Unset keeps
   the demo default (`treedb`). Set `dataset` to compute validation exact top-K
   IDs from the exported dataset vectors instead of TreeDB exact search.
+- `TREEDB_SEARCH_PROFILE_DIR`: optional top-level directory for TreeDB search
+  profiles. When set, each TreeDB row passes a backend-specific subdirectory to
+  `-search-profile-dir`; column_graph rows emit per-concurrency
+  `search_<mode>_c<N>_{cpu,heap,allocs,block,mutex}.pprof` files there. CPU
+  profiles are scoped to the search loop; the other files are runtime snapshots
+  for supporting diagnosis.
 - `TREEDB_QUANTIZED_INDEX_NAME`: scalar_u8 TreeDB quantized score-plane name.
   Defaults to `embedding.scalar_u8.fast`.
 - `TREEDB_QUANTIZED_RERANK_CANDIDATES`: TreeDB quantized-rerank exact rerank
@@ -151,6 +157,8 @@ The runner writes:
 - `pgvector.json`: PostgreSQL+pgvector full-vector HNSW benchmark result when enabled
 - `mongodb.json`: MongoDB Vector Search benchmark result when enabled
 - `comparison.md`: normalized comparison table
+- TreeDB search profiles under backend-specific subdirectories of
+  `TREEDB_SEARCH_PROFILE_DIR`, when set
 
 The TreeDB dataset exporter writes row-major little-endian `float32` vector
 files plus JSONL convenience files. TreeDB loads documents from the exported

--- a/cmd/treedb_vector_search_demo/README.md
+++ b/cmd/treedb_vector_search_demo/README.md
@@ -90,6 +90,14 @@ The matrix search stage defaults to 10,000 ANN queries per lane and parallel
 concurrency levels `2,4,8,16,32,64,128`; override those with `-queries` and
 `-search-concurrency`.
 
+Use `-search-profile-dir DIR` to write per-concurrency search profiles for the
+column_graph search stage. Each measured concurrency emits
+`search_<mode>_c<N>_cpu.pprof`, plus `heap`, `allocs`, `block`, and `mutex`
+runtime snapshots with the same prefix. CPU profiles are scoped to the measured
+search loop; the runtime snapshots are supporting diagnostics and can include
+process state outside the search loop. Profiling changes timings and should be
+used for bottleneck analysis, not as the comparison number to publish.
+
 When `-dataset-dir` is used, `-queries` may truncate the exported query vector
 file but cannot exceed the manifest query count. `-validate-queries` is a recall
 sample size and is clamped to the exported query count. Recall validation uses
@@ -135,6 +143,8 @@ Useful flags:
   run.
 - `-disable-exact-fallback=false`: allow exact fallback during benchmark
   searches.
+- `-search-profile-dir DIR`: write per-concurrency column_graph search profiles
+  under `DIR`.
 - `-validate-queries N` and `-min-recall R`: run recall validation for `N`
   queries; set `-min-recall=0` when disabling validation with
   `-validate-queries=0`.

--- a/cmd/treedb_vector_search_demo/README.md
+++ b/cmd/treedb_vector_search_demo/README.md
@@ -98,8 +98,10 @@ under `DIR/<matrix_case>/` (for example
 `DIR/leaf_vlog_after_compact/search_exact_c8_cpu.pprof`) so case artifacts are
 not overwritten. CPU profiles are scoped to the measured search loop; the
 runtime snapshots are supporting diagnostics and can include process state
-outside the search loop. Profiling changes timings and should be used for
-bottleneck analysis, not as the comparison number to publish.
+outside the search loop. Heap and allocation profiles use the Go runtime's
+current sampling rate; the demo does not change `runtime.MemProfileRate` for a
+profile run. Profiling changes timings and should be used for bottleneck
+analysis, not as the comparison number to publish.
 
 When `-dataset-dir` is used, `-queries` may truncate the exported query vector
 file but cannot exceed the manifest query count. `-validate-queries` is a recall

--- a/cmd/treedb_vector_search_demo/README.md
+++ b/cmd/treedb_vector_search_demo/README.md
@@ -93,10 +93,13 @@ concurrency levels `2,4,8,16,32,64,128`; override those with `-queries` and
 Use `-search-profile-dir DIR` to write per-concurrency search profiles for the
 column_graph search stage. Each measured concurrency emits
 `search_<mode>_c<N>_cpu.pprof`, plus `heap`, `allocs`, `block`, and `mutex`
-runtime snapshots with the same prefix. CPU profiles are scoped to the measured
-search loop; the runtime snapshots are supporting diagnostics and can include
-process state outside the search loop. Profiling changes timings and should be
-used for bottleneck analysis, not as the comparison number to publish.
+runtime snapshots with the same prefix. In matrix mode, each storage case writes
+under `DIR/<matrix_case>/` (for example
+`DIR/leaf_vlog_after_compact/search_exact_c8_cpu.pprof`) so case artifacts are
+not overwritten. CPU profiles are scoped to the measured search loop; the
+runtime snapshots are supporting diagnostics and can include process state
+outside the search loop. Profiling changes timings and should be used for
+bottleneck analysis, not as the comparison number to publish.
 
 When `-dataset-dir` is used, `-queries` may truncate the exported query vector
 file but cannot exceed the manifest query count. `-validate-queries` is a recall

--- a/cmd/treedb_vector_search_demo/README.md
+++ b/cmd/treedb_vector_search_demo/README.md
@@ -100,8 +100,10 @@ not overwritten. CPU profiles are scoped to the measured search loop; the
 runtime snapshots are supporting diagnostics and can include process state
 outside the search loop. Heap and allocation profiles use the Go runtime's
 current sampling rate; the demo does not change `runtime.MemProfileRate` for a
-profile run. Profiling changes timings and should be used for bottleneck
-analysis, not as the comparison number to publish.
+profile run. Block profiles are emitted from the runtime's current block
+profiler and may be empty unless the caller/process already enabled block
+profiling. Profiling changes timings and should be used for bottleneck analysis,
+not as the comparison number to publish.
 
 When `-dataset-dir` is used, `-queries` may truncate the exported query vector
 file but cannot exceed the manifest query count. `-validate-queries` is a recall

--- a/cmd/treedb_vector_search_demo/README.md
+++ b/cmd/treedb_vector_search_demo/README.md
@@ -90,8 +90,10 @@ The matrix search stage defaults to 10,000 ANN queries per lane and parallel
 concurrency levels `2,4,8,16,32,64,128`; override those with `-queries` and
 `-search-concurrency`.
 
-Use `-search-profile-dir DIR` to write per-concurrency search profiles for the
-column_graph search stage. Each measured concurrency emits
+Use `-search-profile-dir DIR` with `-vector-index-strategy column_graph` to
+write per-concurrency profiles for the column_graph search stage. Native
+`native_runtime` search profiling is not implemented, so the flag is rejected
+unless the column_graph strategy is selected. Each measured concurrency emits
 `search_<mode>_c<N>_cpu.pprof`, plus `heap`, `allocs`, `block`, and `mutex`
 runtime snapshots with the same prefix. In matrix mode, each storage case writes
 under `DIR/<matrix_case>/` (for example
@@ -151,7 +153,7 @@ Useful flags:
 - `-disable-exact-fallback=false`: allow exact fallback during benchmark
   searches.
 - `-search-profile-dir DIR`: write per-concurrency column_graph search profiles
-  under `DIR`.
+  under `DIR`; requires `-vector-index-strategy column_graph`.
 - `-validate-queries N` and `-min-recall R`: run recall validation for `N`
   queries; set `-min-recall=0` when disabling validation with
   `-validate-queries=0`.

--- a/cmd/treedb_vector_search_demo/main.go
+++ b/cmd/treedb_vector_search_demo/main.go
@@ -144,6 +144,7 @@ type matrixResult struct {
 	Dir               string             `json:"dir"`
 	KeptDir           bool               `json:"kept_dir"`
 	Profile           string             `json:"profile"`
+	SearchProfileDir  string             `json:"search_profile_dir,omitempty"`
 	Docs              int                `json:"docs"`
 	Dimensions        int                `json:"dimensions"`
 	Queries           int                `json:"queries"`
@@ -1157,6 +1158,9 @@ func executeMatrix(ctx context.Context, cfg config) (matrixResult, error) {
 	if err := applySearchBenchmarkDefaults(&cfg); err != nil {
 		return matrixResult{}, err
 	}
+	if cfg.searchProfileDir != "" {
+		cfg.searchProfileDir = filepath.Clean(cfg.searchProfileDir)
+	}
 	root, err := normalizeDemoDir(cfg.dir)
 	if err != nil {
 		return matrixResult{}, err
@@ -1228,6 +1232,7 @@ func executeMatrix(ctx context.Context, cfg config) (matrixResult, error) {
 		Dir:               root,
 		KeptDir:           cfg.keepDir || explicitRoot,
 		Profile:           string(cfg.profile),
+		SearchProfileDir:  cfg.searchProfileDir,
 		Docs:              cfg.docs,
 		Dimensions:        cfg.dimensions,
 		Queries:           cfg.queries,
@@ -1241,6 +1246,9 @@ func executeMatrix(ctx context.Context, cfg config) (matrixResult, error) {
 		caseCfg.keepDir = true
 		caseCfg.compact = testCase.compact
 		caseCfg.dir = filepath.Join(root, testCase.name)
+		if cfg.searchProfileDir != "" {
+			caseCfg.searchProfileDir = filepath.Join(cfg.searchProfileDir, testCase.name)
+		}
 		caseCfg.indexOuterLeavesInValueLog = testCase.outerLeaves
 		if testCase.name == "index_db_outer_leaves" {
 			caseCfg.requireLeafVLogBytes = false
@@ -2546,6 +2554,9 @@ func printText(w io.Writer, res result) {
 	fmt.Fprintf(w, "TreeDB vector search demo\n")
 	fmt.Fprintf(w, "dir=%s kept=%t profile=%s backend=%s vector_index_strategy=%s vector_index_search_path=%s query_mode=%s quantized_index_name=%s quantized_rerank_candidates=%d docs=%d dims=%d queries=%d top_k=%d m=%d ef_construction=%d ef_search=%d value_pointer_threshold=%d leaf_generation_segment_target=%d\n",
 		res.Dir, res.KeptDir, res.Profile, resultBackend(res), resultStrategy(res), resultSearchPath(res), resultQueryMode(res), res.QuantizedIndexName, res.QuantizedRerankCandidates, res.Docs, res.Dimensions, res.Queries, res.TopK, res.M, res.EfConstruction, res.EfSearch, res.ValuePointerThreshold, res.LeafGenerationTarget)
+	if res.SearchProfileDir != "" {
+		fmt.Fprintf(w, "search_profile_dir=%s\n", res.SearchProfileDir)
+	}
 	fmt.Fprintf(w, "\nPhases\n")
 	fmt.Fprintf(w, "insert: %.3fs\n", res.Insert.Seconds)
 	fmt.Fprintf(w, "rebuild_vector_index strategy=%s: %.3fs native_root_bytes=%d\n", resultStrategy(res), res.Rebuild.Seconds, res.NativeRootBytes)
@@ -2615,6 +2626,9 @@ func printMatrixText(w io.Writer, res matrixResult) {
 	fmt.Fprintf(w, "TreeDB vector search matrix\n")
 	fmt.Fprintf(w, "dir=%s kept=%t profile=%s docs=%d dims=%d queries=%d top_k=%d search_concurrency=%s\n",
 		res.Dir, res.KeptDir, res.Profile, res.Docs, res.Dimensions, res.Queries, res.TopK, joinInts(res.SearchConcurrency))
+	if res.SearchProfileDir != "" {
+		fmt.Fprintf(w, "search_profile_dir=%s\n", res.SearchProfileDir)
+	}
 	for _, testCase := range res.Cases {
 		fmt.Fprintf(w, "\nCase %s\n", testCase.Name)
 		fmt.Fprintf(w, "%s\n", testCase.Description)
@@ -2623,6 +2637,9 @@ func printMatrixText(w io.Writer, res matrixResult) {
 			resultStrategy(testCase.Result),
 			resultSearchPath(testCase.Result),
 			resultQueryMode(testCase.Result))
+		if testCase.Result.SearchProfileDir != "" {
+			fmt.Fprintf(w, "search_profile_dir=%s\n", testCase.Result.SearchProfileDir)
+		}
 		fmt.Fprintf(w, "storage_after_compact_total=%d bytes (%.1f/doc)\n",
 			testCase.Result.StorageAfterCompact.TotalBytes,
 			testCase.Result.StorageAfterCompact.BytesPerDoc)

--- a/cmd/treedb_vector_search_demo/main.go
+++ b/cmd/treedb_vector_search_demo/main.go
@@ -2228,7 +2228,6 @@ func startColumnGraphSearchProfile(cfg config, concurrency int) (func() error, e
 		return nil, fmt.Errorf("create search CPU profile: %w", err)
 	}
 	oldMutexProfileFraction := runtime.SetMutexProfileFraction(1)
-	runtime.SetBlockProfileRate(1)
 	if err := pprof.StartCPUProfile(cpuFile); err != nil {
 		_ = cpuFile.Close()
 		restoreRuntimeSearchProfileSettings(oldMutexProfileFraction)
@@ -2253,7 +2252,6 @@ func startColumnGraphSearchProfile(cfg config, concurrency int) (func() error, e
 }
 
 func restoreRuntimeSearchProfileSettings(mutexProfileFraction int) {
-	runtime.SetBlockProfileRate(0)
 	runtime.SetMutexProfileFraction(mutexProfileFraction)
 }
 

--- a/cmd/treedb_vector_search_demo/main.go
+++ b/cmd/treedb_vector_search_demo/main.go
@@ -354,7 +354,7 @@ func parseConfig(args []string) (config, error) {
 	fs.BoolVar(&cfg.disableExactFallback, "disable-exact-fallback", cfg.disableExactFallback, "Disable exact fallback during ANN benchmark queries")
 	fs.BoolVar(&cfg.requireValueLogBytes, "require-value-log-bytes", false, "Fail if compacted storage has no value-log bytes")
 	fs.BoolVar(&cfg.requireLeafVLogBytes, "require-leaf-vlog-bytes", false, "Fail if compacted storage has no leaf value-log bytes")
-	fs.StringVar(&cfg.searchProfileDir, "search-profile-dir", "", "Write per-concurrency search CPU/heap/alloc/block/mutex profiles under this directory")
+	fs.StringVar(&cfg.searchProfileDir, "search-profile-dir", "", "Write per-concurrency column_graph search CPU/heap/alloc/block/mutex profiles under this directory")
 	fs.BoolVar(&cfg.jsonOut, "json", false, "Emit JSON instead of text")
 	if err := fs.Parse(args); err != nil {
 		return config{}, err
@@ -434,6 +434,9 @@ func parseConfig(args []string) (config, error) {
 	}
 	if cfg.searchProfileDir != "" {
 		cfg.searchProfileDir = filepath.Clean(cfg.searchProfileDir)
+		if cfg.vectorIndexStrategy != collections.VectorIndexStrategyColumnGraph {
+			return config{}, errors.New("-search-profile-dir requires -vector-index-strategy column_graph")
+		}
 	}
 	if err := validateValidationExactSourceConfig(cfg); err != nil {
 		return config{}, err

--- a/cmd/treedb_vector_search_demo/main.go
+++ b/cmd/treedb_vector_search_demo/main.go
@@ -773,6 +773,10 @@ func execute(ctx context.Context, cfg config) (result, error) {
 	if err := applySearchBenchmarkDefaults(&cfg); err != nil {
 		return result{}, err
 	}
+	restoreMemProfileRate := configureSearchMemoryProfileRate(cfg)
+	if restoreMemProfileRate != nil {
+		defer restoreMemProfileRate()
+	}
 	work, err := loadWorkload(&cfg)
 	if err != nil {
 		return result{}, err
@@ -2219,13 +2223,11 @@ func startColumnGraphSearchProfile(cfg config, concurrency int) (func() error, e
 	if err != nil {
 		return nil, fmt.Errorf("create search CPU profile: %w", err)
 	}
-	oldMemProfileRate := runtime.MemProfileRate
 	oldMutexProfileFraction := runtime.SetMutexProfileFraction(1)
-	runtime.MemProfileRate = 1
 	runtime.SetBlockProfileRate(1)
 	if err := pprof.StartCPUProfile(cpuFile); err != nil {
 		_ = cpuFile.Close()
-		restoreRuntimeSearchProfileSettings(oldMemProfileRate, oldMutexProfileFraction)
+		restoreRuntimeSearchProfileSettings(oldMutexProfileFraction)
 		return nil, fmt.Errorf("start search CPU profile: %w", err)
 	}
 	return func() error {
@@ -2241,13 +2243,23 @@ func startColumnGraphSearchProfile(cfg config, concurrency int) (func() error, e
 				errs = append(errs, err)
 			}
 		}
-		restoreRuntimeSearchProfileSettings(oldMemProfileRate, oldMutexProfileFraction)
+		restoreRuntimeSearchProfileSettings(oldMutexProfileFraction)
 		return errors.Join(errs...)
 	}, nil
 }
 
-func restoreRuntimeSearchProfileSettings(memProfileRate, mutexProfileFraction int) {
-	runtime.MemProfileRate = memProfileRate
+func configureSearchMemoryProfileRate(cfg config) func() {
+	if cfg.searchProfileDir == "" || cfg.vectorIndexStrategy != collections.VectorIndexStrategyColumnGraph {
+		return nil
+	}
+	oldMemProfileRate := runtime.MemProfileRate
+	runtime.MemProfileRate = 1
+	return func() {
+		runtime.MemProfileRate = oldMemProfileRate
+	}
+}
+
+func restoreRuntimeSearchProfileSettings(mutexProfileFraction int) {
 	runtime.SetBlockProfileRate(0)
 	runtime.SetMutexProfileFraction(mutexProfileFraction)
 }
@@ -2261,9 +2273,16 @@ func writeRuntimeProfile(path, name string) error {
 	if err != nil {
 		return fmt.Errorf("create %s profile: %w", name, err)
 	}
-	defer func() { _ = f.Close() }()
-	if err := profile.WriteTo(f, 0); err != nil {
-		return fmt.Errorf("write %s profile: %w", name, err)
+	writeErr := profile.WriteTo(f, 0)
+	closeErr := f.Close()
+	if writeErr != nil && closeErr != nil {
+		return errors.Join(fmt.Errorf("write %s profile: %w", name, writeErr), fmt.Errorf("close %s profile: %w", name, closeErr))
+	}
+	if writeErr != nil {
+		return fmt.Errorf("write %s profile: %w", name, writeErr)
+	}
+	if closeErr != nil {
+		return fmt.Errorf("close %s profile: %w", name, closeErr)
 	}
 	return nil
 }

--- a/cmd/treedb_vector_search_demo/main.go
+++ b/cmd/treedb_vector_search_demo/main.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"runtime/pprof"
 	"sort"
 	"strconv"
 	"strings"
@@ -77,6 +78,7 @@ type config struct {
 	disableExactFallback  bool
 	requireValueLogBytes  bool
 	requireLeafVLogBytes  bool
+	searchProfileDir      string
 	jsonOut               bool
 
 	indexOuterLeavesInValueLog *bool
@@ -105,6 +107,7 @@ type result struct {
 	ValidateQueries           int                               `json:"validate_queries"`
 	ValidateDocs              int                               `json:"validate_docs"`
 	ValidationExactSource     validationExactSource             `json:"validation_exact_source"`
+	SearchProfileDir          string                            `json:"search_profile_dir,omitempty"`
 	TopK                      int                               `json:"top_k"`
 	M                         int                               `json:"m"`
 	EfConstruction            int                               `json:"ef_construction"`
@@ -350,6 +353,7 @@ func parseConfig(args []string) (config, error) {
 	fs.BoolVar(&cfg.disableExactFallback, "disable-exact-fallback", cfg.disableExactFallback, "Disable exact fallback during ANN benchmark queries")
 	fs.BoolVar(&cfg.requireValueLogBytes, "require-value-log-bytes", false, "Fail if compacted storage has no value-log bytes")
 	fs.BoolVar(&cfg.requireLeafVLogBytes, "require-leaf-vlog-bytes", false, "Fail if compacted storage has no leaf value-log bytes")
+	fs.StringVar(&cfg.searchProfileDir, "search-profile-dir", "", "Write per-concurrency search CPU/heap/alloc/block/mutex profiles under this directory")
 	fs.BoolVar(&cfg.jsonOut, "json", false, "Emit JSON instead of text")
 	if err := fs.Parse(args); err != nil {
 		return config{}, err
@@ -426,6 +430,9 @@ func parseConfig(args []string) (config, error) {
 	}
 	if cfg.datasetDir != "" {
 		cfg.datasetDir = filepath.Clean(cfg.datasetDir)
+	}
+	if cfg.searchProfileDir != "" {
+		cfg.searchProfileDir = filepath.Clean(cfg.searchProfileDir)
 	}
 	if err := validateValidationExactSourceConfig(cfg); err != nil {
 		return config{}, err
@@ -850,6 +857,7 @@ func execute(ctx context.Context, cfg config) (result, error) {
 		ValidateQueries:           cfg.validateQueries,
 		ValidateDocs:              cfg.validateDocs,
 		ValidationExactSource:     cfg.validationExactSource,
+		SearchProfileDir:          cfg.searchProfileDir,
 		TopK:                      cfg.topK,
 		M:                         cfg.m,
 		EfConstruction:            cfg.efConstruction,
@@ -2127,6 +2135,10 @@ func benchmarkColumnGraphSearchLoadedConcurrent(col *collections.Collection, ind
 			atomic.AddUint64(&scoreBatchCandidatesTotal, response.Stats.ScoreBatchCandidates)
 		}
 	}
+	stopProfile, err := startColumnGraphSearchProfile(cfg, concurrency)
+	if err != nil {
+		return searchBenchmarkResult{}, err
+	}
 	startAll := time.Now()
 	if concurrency == 1 {
 		worker(searchers[0])
@@ -2143,6 +2155,11 @@ func benchmarkColumnGraphSearchLoadedConcurrent(col *collections.Collection, ind
 		wg.Wait()
 	}
 	total := time.Since(startAll)
+	if stopProfile != nil {
+		if err := stopProfile(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
 	if firstErr != nil {
 		return searchBenchmarkResult{}, firstErr
 	}
@@ -2184,6 +2201,71 @@ func benchmarkColumnGraphSearchLoadedConcurrent(col *collections.Collection, ind
 		ExactFallbacks:                    0,
 		DisableExactFallback:              cfg.disableExactFallback,
 	}, nil
+}
+
+func startColumnGraphSearchProfile(cfg config, concurrency int) (func() error, error) {
+	if cfg.searchProfileDir == "" {
+		return nil, nil
+	}
+	if err := os.MkdirAll(cfg.searchProfileDir, 0o755); err != nil {
+		return nil, fmt.Errorf("create search profile dir: %w", err)
+	}
+	mode := string(normalizedVectorQueryMode(cfg.vectorQueryMode))
+	if mode == "" {
+		mode = "exact"
+	}
+	prefix := fmt.Sprintf("search_%s_c%d", mode, concurrency)
+	cpuFile, err := os.Create(filepath.Join(cfg.searchProfileDir, prefix+"_cpu.pprof"))
+	if err != nil {
+		return nil, fmt.Errorf("create search CPU profile: %w", err)
+	}
+	oldMemProfileRate := runtime.MemProfileRate
+	oldMutexProfileFraction := runtime.SetMutexProfileFraction(1)
+	runtime.MemProfileRate = 1
+	runtime.SetBlockProfileRate(1)
+	if err := pprof.StartCPUProfile(cpuFile); err != nil {
+		_ = cpuFile.Close()
+		restoreRuntimeSearchProfileSettings(oldMemProfileRate, oldMutexProfileFraction)
+		return nil, fmt.Errorf("start search CPU profile: %w", err)
+	}
+	return func() error {
+		pprof.StopCPUProfile()
+		var errs []error
+		if err := cpuFile.Close(); err != nil {
+			errs = append(errs, fmt.Errorf("close search CPU profile: %w", err))
+		}
+		runtime.GC()
+		for _, name := range []string{"heap", "allocs", "block", "mutex"} {
+			path := filepath.Join(cfg.searchProfileDir, prefix+"_"+name+".pprof")
+			if err := writeRuntimeProfile(path, name); err != nil {
+				errs = append(errs, err)
+			}
+		}
+		restoreRuntimeSearchProfileSettings(oldMemProfileRate, oldMutexProfileFraction)
+		return errors.Join(errs...)
+	}, nil
+}
+
+func restoreRuntimeSearchProfileSettings(memProfileRate, mutexProfileFraction int) {
+	runtime.MemProfileRate = memProfileRate
+	runtime.SetBlockProfileRate(0)
+	runtime.SetMutexProfileFraction(mutexProfileFraction)
+}
+
+func writeRuntimeProfile(path, name string) error {
+	profile := pprof.Lookup(name)
+	if profile == nil {
+		return fmt.Errorf("runtime profile %q is unavailable", name)
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("create %s profile: %w", name, err)
+	}
+	defer func() { _ = f.Close() }()
+	if err := profile.WriteTo(f, 0); err != nil {
+		return fmt.Errorf("write %s profile: %w", name, err)
+	}
+	return nil
 }
 
 func vectorIndexOptions(def collections.VectorIndexDefinition) collections.VectorIndexOptions {

--- a/cmd/treedb_vector_search_demo/main.go
+++ b/cmd/treedb_vector_search_demo/main.go
@@ -774,10 +774,6 @@ func execute(ctx context.Context, cfg config) (result, error) {
 	if err := applySearchBenchmarkDefaults(&cfg); err != nil {
 		return result{}, err
 	}
-	restoreMemProfileRate := configureSearchMemoryProfileRate(cfg)
-	if restoreMemProfileRate != nil {
-		defer restoreMemProfileRate()
-	}
 	work, err := loadWorkload(&cfg)
 	if err != nil {
 		return result{}, err
@@ -2254,17 +2250,6 @@ func startColumnGraphSearchProfile(cfg config, concurrency int) (func() error, e
 		restoreRuntimeSearchProfileSettings(oldMutexProfileFraction)
 		return errors.Join(errs...)
 	}, nil
-}
-
-func configureSearchMemoryProfileRate(cfg config) func() {
-	if cfg.searchProfileDir == "" || cfg.vectorIndexStrategy != collections.VectorIndexStrategyColumnGraph {
-		return nil
-	}
-	oldMemProfileRate := runtime.MemProfileRate
-	runtime.MemProfileRate = 1
-	return func() {
-		runtime.MemProfileRate = oldMemProfileRate
-	}
 }
 
 func restoreRuntimeSearchProfileSettings(mutexProfileFraction int) {

--- a/cmd/treedb_vector_search_demo/main_test.go
+++ b/cmd/treedb_vector_search_demo/main_test.go
@@ -91,6 +91,55 @@ func TestExecuteSmokeCompactsReopensValidatesAndBenchmarks(t *testing.T) {
 	}
 }
 
+func TestExecuteColumnGraphSearchProfileDirWritesProfiles(t *testing.T) {
+	profileDir := t.TempDir()
+	res, err := execute(context.Background(), config{
+		dir:                       t.TempDir(),
+		keepDir:                   true,
+		docs:                      64,
+		dimensions:                8,
+		queries:                   4,
+		searchConcurrency:         []int{2},
+		validateQueries:           0,
+		validateDocs:              0,
+		topK:                      3,
+		batchSize:                 16,
+		m:                         4,
+		efConstruction:            32,
+		efSearch:                  32,
+		valuePointerThreshold:     defaultValuePointerThreshold,
+		leafGenerationTarget:      defaultLeafGenerationTarget,
+		minRecall:                 0,
+		disableExactFallback:      true,
+		vectorIndexStrategy:       collections.VectorIndexStrategyColumnGraph,
+		vectorQueryMode:           collections.VectorIndexQueryModeQuantizedRerank,
+		quantizedIndexName:        defaultQuantizedIndexName,
+		quantizedRerankCandidates: 4,
+		searchProfileDir:          profileDir,
+	})
+	if err != nil {
+		t.Fatalf("execute with search profile dir: %v", err)
+	}
+	if res.SearchProfileDir != profileDir {
+		t.Fatalf("search profile dir=%q want %q", res.SearchProfileDir, profileDir)
+	}
+	if len(res.SearchBenchmarks) != 2 || res.SearchBenchmarks[0].Concurrency != 1 || res.SearchBenchmarks[1].Concurrency != 2 {
+		t.Fatalf("unexpected search benchmarks: %+v", res.SearchBenchmarks)
+	}
+	for _, concurrency := range []int{1, 2} {
+		for _, kind := range []string{"cpu", "heap", "allocs", "block", "mutex"} {
+			path := filepath.Join(profileDir, fmt.Sprintf("search_quantized_rerank_c%d_%s.pprof", concurrency, kind))
+			info, err := os.Stat(path)
+			if err != nil {
+				t.Fatalf("stat profile %s: %v", path, err)
+			}
+			if info.Size() == 0 {
+				t.Fatalf("profile %s is empty", path)
+			}
+		}
+	}
+}
+
 func TestDemoCommandWALFormatConfigPreservesProfileKnobs(t *testing.T) {
 	cfg := demoCommandWALFormatConfig(demoBackendOptions(config{}, t.TempDir()))
 	if len(cfg.RequiredFeatures) != 1 || cfg.RequiredFeatures[0] != "command_wal_v1" {
@@ -603,6 +652,13 @@ func TestParseConfigVectorQueryMode(t *testing.T) {
 	}
 	if defaultCfg.validationExactSource != validationExactSourceTreeDB {
 		t.Fatalf("default validation exact source=%q want treedb", defaultCfg.validationExactSource)
+	}
+	profileCfg, err := parseConfig([]string{"-search-profile-dir", filepath.Join("tmp", ".", "profiles")})
+	if err != nil {
+		t.Fatalf("parseConfig search profile dir: %v", err)
+	}
+	if profileCfg.searchProfileDir != filepath.Join("tmp", "profiles") {
+		t.Fatalf("search profile dir=%q want tmp/profiles", profileCfg.searchProfileDir)
 	}
 
 	for _, tc := range []struct {

--- a/cmd/treedb_vector_search_demo/main_test.go
+++ b/cmd/treedb_vector_search_demo/main_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -93,6 +94,7 @@ func TestExecuteSmokeCompactsReopensValidatesAndBenchmarks(t *testing.T) {
 
 func TestExecuteColumnGraphSearchProfileDirWritesProfiles(t *testing.T) {
 	profileDir := t.TempDir()
+	oldMemProfileRate := runtime.MemProfileRate
 	res, err := execute(context.Background(), config{
 		dir:                       t.TempDir(),
 		keepDir:                   true,
@@ -119,6 +121,9 @@ func TestExecuteColumnGraphSearchProfileDirWritesProfiles(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("execute with search profile dir: %v", err)
+	}
+	if runtime.MemProfileRate != oldMemProfileRate {
+		t.Fatalf("MemProfileRate=%d want restored %d", runtime.MemProfileRate, oldMemProfileRate)
 	}
 	if res.SearchProfileDir != profileDir {
 		t.Fatalf("search profile dir=%q want %q", res.SearchProfileDir, profileDir)

--- a/cmd/treedb_vector_search_demo/main_test.go
+++ b/cmd/treedb_vector_search_demo/main_test.go
@@ -720,7 +720,10 @@ func TestParseConfigVectorQueryMode(t *testing.T) {
 	if defaultCfg.validationExactSource != validationExactSourceTreeDB {
 		t.Fatalf("default validation exact source=%q want treedb", defaultCfg.validationExactSource)
 	}
-	profileCfg, err := parseConfig([]string{"-search-profile-dir", filepath.Join("tmp", ".", "profiles")})
+	profileCfg, err := parseConfig([]string{
+		"-vector-index-strategy", "column_graph",
+		"-search-profile-dir", filepath.Join("tmp", ".", "profiles"),
+	})
 	if err != nil {
 		t.Fatalf("parseConfig search profile dir: %v", err)
 	}
@@ -742,6 +745,11 @@ func TestParseConfigVectorQueryMode(t *testing.T) {
 			name: "invalid validation source",
 			args: []string{"-validation-exact-source", "pgvector"},
 			want: "unsupported -validation-exact-source",
+		},
+		{
+			name: "search profile dir requires column graph",
+			args: []string{"-search-profile-dir", filepath.Join("tmp", "profiles")},
+			want: "requires -vector-index-strategy column_graph",
 		},
 		{
 			name: "dataset validation source requires dataset dir",

--- a/cmd/treedb_vector_search_demo/main_test.go
+++ b/cmd/treedb_vector_search_demo/main_test.go
@@ -145,6 +145,68 @@ func TestExecuteColumnGraphSearchProfileDirWritesProfiles(t *testing.T) {
 	}
 }
 
+func TestExecuteMatrixSearchProfileDirUsesCaseSubdirectories(t *testing.T) {
+	profileDir := t.TempDir()
+	res, err := executeMatrix(context.Background(), config{
+		docs:                  48,
+		dimensions:            8,
+		queries:               2,
+		searchConcurrency:     []int{2},
+		validateQueries:       0,
+		validateDocs:          0,
+		topK:                  3,
+		batchSize:             16,
+		m:                     4,
+		efConstruction:        32,
+		efSearch:              32,
+		valuePointerThreshold: defaultValuePointerThreshold,
+		leafGenerationTarget:  defaultLeafGenerationTarget,
+		minRecall:             0,
+		disableExactFallback:  true,
+		vectorIndexStrategy:   collections.VectorIndexStrategyColumnGraph,
+		searchProfileDir:      filepath.Join(profileDir, "."),
+	})
+	if err != nil {
+		t.Fatalf("executeMatrix with search profile dir: %v", err)
+	}
+	if res.SearchProfileDir != profileDir {
+		t.Fatalf("matrix search profile dir=%q want %q", res.SearchProfileDir, profileDir)
+	}
+	if len(res.Cases) != 3 {
+		t.Fatalf("matrix cases=%d want 3", len(res.Cases))
+	}
+	for _, testCase := range res.Cases {
+		caseProfileDir := filepath.Join(profileDir, testCase.Name)
+		if testCase.Result.SearchProfileDir != caseProfileDir {
+			t.Fatalf("case %s profile dir=%q want %q", testCase.Name, testCase.Result.SearchProfileDir, caseProfileDir)
+		}
+		for _, concurrency := range []int{1, 2} {
+			for _, kind := range []string{"cpu", "heap", "allocs", "block", "mutex"} {
+				path := filepath.Join(caseProfileDir, fmt.Sprintf("search_exact_c%d_%s.pprof", concurrency, kind))
+				info, err := os.Stat(path)
+				if err != nil {
+					t.Fatalf("stat profile %s: %v", path, err)
+				}
+				if info.Size() == 0 {
+					t.Fatalf("profile %s is empty", path)
+				}
+			}
+		}
+	}
+	entries, err := os.ReadDir(profileDir)
+	if err != nil {
+		t.Fatalf("read profile dir: %v", err)
+	}
+	if len(entries) != len(res.Cases) {
+		t.Fatalf("profile dir entries=%d want %d case directories", len(entries), len(res.Cases))
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			t.Fatalf("profile root entry %s is not a directory", entry.Name())
+		}
+	}
+}
+
 func TestDemoCommandWALFormatConfigPreservesProfileKnobs(t *testing.T) {
 	cfg := demoCommandWALFormatConfig(demoBackendOptions(config{}, t.TempDir()))
 	if len(cfg.RequiredFeatures) != 1 || cfg.RequiredFeatures[0] != "command_wal_v1" {

--- a/scripts/bench_vector_db_compare.sh
+++ b/scripts/bench_vector_db_compare.sh
@@ -186,10 +186,21 @@ if [[ -n "$TREEDB_VALIDATION_EXACT_SOURCE" ]]; then
 	treedb_storage_args+=(-validation-exact-source "$TREEDB_VALIDATION_EXACT_SOURCE")
 fi
 treedb_profile_args=()
+treedb_search_profile_backend_supported() {
+	case "$1" in
+		treedb_column_graph|treedb_column_graph_quantized_only|treedb_column_graph_quantized_rerank)
+			return 0
+			;;
+		*)
+			return 1
+			;;
+	esac
+}
+
 treedb_profile_args_for_backend() {
 	local backend="$1"
 	treedb_profile_args=()
-	if [[ -n "$TREEDB_SEARCH_PROFILE_DIR" ]]; then
+	if [[ -n "$TREEDB_SEARCH_PROFILE_DIR" ]] && treedb_search_profile_backend_supported "$backend"; then
 		treedb_profile_args=(-search-profile-dir "$TREEDB_SEARCH_PROFILE_DIR/$backend")
 	fi
 }
@@ -241,6 +252,10 @@ This run compares persistent database-tier ANN search:
 
 \`sqlite-vec\` is not included because upstream sqlite-vec's \`vec0\` table is
 brute-force today; ANN support is still future work.
+
+When \`TREEDB_SEARCH_PROFILE_DIR\` is set, the runner forwards it only to TreeDB
+\`column_graph\` rows; the native \`treedb\` row does not emit search profile
+artifacts.
 EOF
 
 echo "run dir: $RUN_DIR"
@@ -288,8 +303,8 @@ if contains_backend treedb; then
 		-queries "$QUERIES" \
 		-search-concurrency "$SEARCH_CONCURRENCY" \
 		-validate-queries "$VALIDATE_QUERIES" \
-		"${treedb_storage_args[@]}" \
-		"${treedb_profile_args[@]}" \
+		${treedb_storage_args[@]+"${treedb_storage_args[@]}"} \
+		${treedb_profile_args[@]+"${treedb_profile_args[@]}"} \
 		-top-k "$TOP_K" \
 		-m "$M" \
 		-ef-construction "$EF_CONSTRUCTION" \
@@ -313,8 +328,8 @@ if contains_backend treedb_column_graph; then
 		-queries "$QUERIES" \
 		-search-concurrency "$SEARCH_CONCURRENCY" \
 		-validate-queries "$VALIDATE_QUERIES" \
-		"${treedb_storage_args[@]}" \
-		"${treedb_profile_args[@]}" \
+		${treedb_storage_args[@]+"${treedb_storage_args[@]}"} \
+		${treedb_profile_args[@]+"${treedb_profile_args[@]}"} \
 		-top-k "$TOP_K" \
 		-m "$M" \
 		-ef-construction "$EF_CONSTRUCTION" \
@@ -340,8 +355,8 @@ if contains_backend treedb_column_graph_quantized_only; then
 		-queries "$QUERIES" \
 		-search-concurrency "$SEARCH_CONCURRENCY" \
 		-validate-queries "$VALIDATE_QUERIES" \
-		"${treedb_storage_args[@]}" \
-		"${treedb_profile_args[@]}" \
+		${treedb_storage_args[@]+"${treedb_storage_args[@]}"} \
+		${treedb_profile_args[@]+"${treedb_profile_args[@]}"} \
 		-top-k "$TOP_K" \
 		-m "$M" \
 		-ef-construction "$EF_CONSTRUCTION" \
@@ -368,8 +383,8 @@ if contains_backend treedb_column_graph_quantized_rerank; then
 		-queries "$QUERIES" \
 		-search-concurrency "$SEARCH_CONCURRENCY" \
 		-validate-queries "$VALIDATE_QUERIES" \
-		"${treedb_storage_args[@]}" \
-		"${treedb_profile_args[@]}" \
+		${treedb_storage_args[@]+"${treedb_storage_args[@]}"} \
+		${treedb_profile_args[@]+"${treedb_profile_args[@]}"} \
 		-top-k "$TOP_K" \
 		-m "$M" \
 		-ef-construction "$EF_CONSTRUCTION" \

--- a/scripts/bench_vector_db_compare.sh
+++ b/scripts/bench_vector_db_compare.sh
@@ -36,6 +36,7 @@ TREEDB_LEAF_GENERATION_SEGMENT_TARGET="${TREEDB_LEAF_GENERATION_SEGMENT_TARGET:-
 TREEDB_REQUIRE_VALUE_LOG_BYTES="${TREEDB_REQUIRE_VALUE_LOG_BYTES:-}"
 TREEDB_REQUIRE_LEAF_VLOG_BYTES="${TREEDB_REQUIRE_LEAF_VLOG_BYTES:-}"
 TREEDB_VALIDATION_EXACT_SOURCE="${TREEDB_VALIDATION_EXACT_SOURCE:-}"
+TREEDB_SEARCH_PROFILE_DIR="${TREEDB_SEARCH_PROFILE_DIR:-}"
 NUMPY_PACKAGE="${NUMPY_PACKAGE:-numpy==2.0.2}"
 VECTORLITE_PACKAGE="${VECTORLITE_PACKAGE:-vectorlite-py==0.2.0}"
 
@@ -184,6 +185,14 @@ fi
 if [[ -n "$TREEDB_VALIDATION_EXACT_SOURCE" ]]; then
 	treedb_storage_args+=(-validation-exact-source "$TREEDB_VALIDATION_EXACT_SOURCE")
 fi
+treedb_profile_args=()
+treedb_profile_args_for_backend() {
+	local backend="$1"
+	treedb_profile_args=()
+	if [[ -n "$TREEDB_SEARCH_PROFILE_DIR" ]]; then
+		treedb_profile_args=(-search-profile-dir "$TREEDB_SEARCH_PROFILE_DIR/$backend")
+	fi
+}
 mkdir -p "$RUN_DIR"
 
 cat >"$RUN_DIR/README.md" <<EOF
@@ -214,6 +223,7 @@ cat >"$RUN_DIR/README.md" <<EOF
   - \`TREEDB_REQUIRE_VALUE_LOG_BYTES=${TREEDB_REQUIRE_VALUE_LOG_BYTES:-<unset>}\`
   - \`TREEDB_REQUIRE_LEAF_VLOG_BYTES=${TREEDB_REQUIRE_LEAF_VLOG_BYTES:-<unset>}\`
   - \`TREEDB_VALIDATION_EXACT_SOURCE=${TREEDB_VALIDATION_EXACT_SOURCE:-<unset; demo default treedb>}\`
+  - \`TREEDB_SEARCH_PROFILE_DIR=${TREEDB_SEARCH_PROFILE_DIR:-<unset>}\`
 - Python packages: \`$NUMPY_PACKAGE\`, \`$VECTORLITE_PACKAGE\`
 
 This run compares persistent database-tier ANN search:
@@ -267,6 +277,7 @@ result_args=()
 
 if contains_backend treedb; then
 	echo "running TreeDB benchmark"
+	treedb_profile_args_for_backend treedb
 	GOWORK=off go run ./cmd/treedb_vector_search_demo \
 		-matrix=false \
 		-dataset-dir "$RUN_DIR/dataset" \
@@ -278,6 +289,7 @@ if contains_backend treedb; then
 		-search-concurrency "$SEARCH_CONCURRENCY" \
 		-validate-queries "$VALIDATE_QUERIES" \
 		"${treedb_storage_args[@]}" \
+		"${treedb_profile_args[@]}" \
 		-top-k "$TOP_K" \
 		-m "$M" \
 		-ef-construction "$EF_CONSTRUCTION" \
@@ -289,6 +301,7 @@ fi
 
 if contains_backend treedb_column_graph; then
 	echo "running TreeDB column-store graph benchmark"
+	treedb_profile_args_for_backend treedb_column_graph
 	GOWORK=off go run ./cmd/treedb_vector_search_demo \
 		-matrix=false \
 		-vector-index-strategy column_graph \
@@ -301,6 +314,7 @@ if contains_backend treedb_column_graph; then
 		-search-concurrency "$SEARCH_CONCURRENCY" \
 		-validate-queries "$VALIDATE_QUERIES" \
 		"${treedb_storage_args[@]}" \
+		"${treedb_profile_args[@]}" \
 		-top-k "$TOP_K" \
 		-m "$M" \
 		-ef-construction "$EF_CONSTRUCTION" \
@@ -312,6 +326,7 @@ fi
 
 if contains_backend treedb_column_graph_quantized_only; then
 	echo "running TreeDB column-store graph scalar_u8 quantized_only benchmark"
+	treedb_profile_args_for_backend treedb_column_graph_quantized_only
 	GOWORK=off go run ./cmd/treedb_vector_search_demo \
 		-matrix=false \
 		-vector-index-strategy column_graph \
@@ -326,6 +341,7 @@ if contains_backend treedb_column_graph_quantized_only; then
 		-search-concurrency "$SEARCH_CONCURRENCY" \
 		-validate-queries "$VALIDATE_QUERIES" \
 		"${treedb_storage_args[@]}" \
+		"${treedb_profile_args[@]}" \
 		-top-k "$TOP_K" \
 		-m "$M" \
 		-ef-construction "$EF_CONSTRUCTION" \
@@ -337,6 +353,7 @@ fi
 
 if contains_backend treedb_column_graph_quantized_rerank; then
 	echo "running TreeDB column-store graph scalar_u8 quantized_rerank benchmark"
+	treedb_profile_args_for_backend treedb_column_graph_quantized_rerank
 	GOWORK=off go run ./cmd/treedb_vector_search_demo \
 		-matrix=false \
 		-vector-index-strategy column_graph \
@@ -352,6 +369,7 @@ if contains_backend treedb_column_graph_quantized_rerank; then
 		-search-concurrency "$SEARCH_CONCURRENCY" \
 		-validate-queries "$VALIDATE_QUERIES" \
 		"${treedb_storage_args[@]}" \
+		"${treedb_profile_args[@]}" \
 		-top-k "$TOP_K" \
 		-m "$M" \
 		-ef-construction "$EF_CONSTRUCTION" \


### PR DESCRIPTION
## Summary

- Fold PR #2330's TreeDB vector search profiling hook onto current `origin/main` for #2413.
- Add `-search-profile-dir` to `cmd/treedb_vector_search_demo` for TreeDB `column_graph` search profiling.
- Add `TREEDB_SEARCH_PROFILE_DIR` passthrough in `scripts/bench_vector_db_compare.sh`, restricted to TreeDB `column_graph` backends with backend-specific profile directories.
- In demo matrix mode, nest profile output by storage case (`<profile-dir>/<matrix_case>/...`) so matrix cases do not overwrite each other.
- Document the opt-in profile artifacts, backend/case directory shape, runtime-profile sampling caveats, and profiling overhead.
- Harden review findings by propagating profile file close errors, avoiding `runtime.MemProfileRate` mutation, preserving existing block profiler state, and not advertising profiles for unsupported native TreeDB runs.

Links: closes #2413; part of #2412; refreshes/supersedes #2330.

## Scope / Non-goals

- No quantized collection API changes.
- No scalar_u8 optimization.
- No search semantics, route, or counter changes.
- `hnsw_search_pack_v1` remains exact FP32 serving state; quantized search remains on the current column_graph/scalar_u8 route.

## Public contract surface

- New demo flag: `-search-profile-dir DIR`, requiring `-vector-index-strategy column_graph`.
- New script env passthrough: `TREEDB_SEARCH_PROFILE_DIR`, forwarded only to TreeDB `column_graph` backends (`treedb_column_graph`, `treedb_column_graph_quantized_only`, `treedb_column_graph_quantized_rerank`).
- Native `treedb` does not receive `-search-profile-dir` and does not advertise `search_profile_dir` because native search profiling is not implemented.
- Column_graph search writes per-concurrency files under the effective profile dir:
  `search_<mode>_c<N>_{cpu,heap,allocs,block,mutex}.pprof`.
- The comparison script passes backend-specific subdirectories, e.g.
  `$TREEDB_SEARCH_PROFILE_DIR/treedb_column_graph_quantized_rerank`.
- Demo matrix mode further nests by matrix case, e.g.
  `$DIR/leaf_vlog_after_compact/search_exact_c8_cpu.pprof`.
- JSON/text output includes `search_profile_dir` when profiling is enabled and supported; matrix JSON includes the top-level profile dir and each case's effective case-specific profile dir.
- Heap/allocs profiles use the Go runtime's current/default sampling rate; this hook does not mutate `runtime.MemProfileRate`.
- Block profiles are emitted from the runtime's current block profiler and may be empty unless block profiling was already enabled; this hook does not enable or disable block profiling, so it does not clobber an embedding process or `go test -blockprofile`.

## Test evidence

Latest local evidence for `a383e4ee9`:

- `GOWORK=off go test -count=1 ./cmd/treedb_vector_search_demo` ✅
- `bash -n scripts/bench_vector_db_compare.sh` ✅
- `git diff --check` ✅

Focused coverage added/updated:

- `TestExecuteMatrixSearchProfileDirUsesCaseSubdirectories` verifies matrix profile output is separated by `index_db_outer_leaves`, `leaf_vlog_before_compact`, and `leaf_vlog_after_compact`, with non-empty c1/c2 `{cpu,heap,allocs,block,mutex}.pprof` files in each case directory.
- `TestParseConfigVectorQueryMode` now verifies `-search-profile-dir` requires `-vector-index-strategy column_graph`, preventing native runs from advertising unsupported profile output when invoked directly.

## Smoke evidence

Backend-specific quantized-rerank script smoke from `bec4bdeb0` remains valid:

- `/tmp/vector_db_profile_script_smoke_2413_fix_20260605_113509/profiles/treedb_column_graph_quantized_rerank/`

Matrix/profile smoke from `14a1c756a` remains valid:

- `/tmp/treedb_matrix_profile_smoke_2413_blockrate_20260605_123743/profiles/index_db_outer_leaves/search_exact_c{1,2}_{cpu,heap,allocs,block,mutex}.pprof`
- `/tmp/treedb_matrix_profile_smoke_2413_blockrate_20260605_123743/profiles/leaf_vlog_before_compact/search_exact_c{1,2}_{cpu,heap,allocs,block,mutex}.pprof`
- `/tmp/treedb_matrix_profile_smoke_2413_blockrate_20260605_123743/profiles/leaf_vlog_after_compact/search_exact_c{1,2}_{cpu,heap,allocs,block,mutex}.pprof`

Latest native-gating script smoke for `a383e4ee9`:

```sh
SMOKE_DIR=/tmp/vector_db_profile_native_gate_2413_20260605_130537
BACKENDS=treedb,treedb_column_graph \
DOCS=48 DIMS=8 QUERIES=2 VALIDATE_QUERIES=0 VALIDATE_DOCS=0 \
TOP_K=3 SEARCH_CONCURRENCY=2 M=4 EF_CONSTRUCTION=32 EF_SEARCH=32 \
TREEDB_COLUMN_GRAPH_EF_SEARCH=32 MIN_RECALL=0 \
TREEDB_SEARCH_PROFILE_DIR="$SMOKE_DIR/profiles" \
RUN_DIR="$SMOKE_DIR" GOWORK=off NUMPY_PACKAGE='numpy==2.4.6' \
scripts/bench_vector_db_compare.sh
```

Verified:

- `treedb.json` has no `search_profile_dir`.
- `$SMOKE_DIR/profiles/treedb` does not exist.
- `treedb_column_graph.json` reports `$SMOKE_DIR/profiles/treedb_column_graph`.
- `$SMOKE_DIR/profiles/treedb_column_graph/search_exact_c{1,2}_{cpu,heap,allocs,block,mutex}.pprof` exists and is non-empty.

## Benchmark / performance evidence

No performance benchmark claim is made. This PR adds opt-in profile capture only. The smoke runs above verify artifact placement; profiled timings are intentionally not comparison evidence.

No material performance regression is expected for default/unprofiled runs: the new work is gated behind an empty-by-default profile directory and runs only when callers opt in for supported column_graph profile capture. Profile-enabled runs have expected profiling overhead and are diagnostic.

## Blocking finding disposition

- Native TreeDB profile-dir advertising finding: accepted and fixed in `a383e4ee9` by forwarding `TREEDB_SEARCH_PROFILE_DIR` only to column_graph backends, rejecting direct demo `-search-profile-dir` use unless `-vector-index-strategy column_graph` is selected, updating docs, and adding native/column_graph smoke verification.
- Matrix overwrite finding: accepted and fixed in `6913fb797` by nesting matrix profile output by case and adding test/smoke coverage.
- `runtime.MemProfileRate` changing per run/case findings: accepted and fixed in `dd762d5fd` by removing `runtime.MemProfileRate` mutation entirely and documenting default runtime sampling for heap/allocs profiles.
- Block profiler clobber finding: accepted and fixed in `14a1c756a` by removing `runtime.SetBlockProfileRate(1)` and the reset-to-0 path; block artifacts now reflect the current runtime block profiler without changing process-wide state.
- Profile file `Close()` finding: accepted and fixed in `bec4bdeb0` by propagating close errors.

## Review / AI review / CI status

- Internal manager review: diff remains limited to #2413 profiling hook/docs/tests; no search semantics/counters/API behavior changed beyond the new opt-in column_graph profiling flag/env/profile-dir behavior.
- Latest-head CI for `a383e4ee9` is green.
- Latest Codex review/comment reports no major issues.
- CodeRabbit status is pass / review completed.
- No unresolved review threads remain.
