### PR TITLE
TreeDB vector docs: clarify API selection

### DIFF
--- a/TreeDB/docs/guides/README.md
+++ b/TreeDB/docs/guides/README.md
@@ -23,6 +23,10 @@ directories when moving between branches.
 - [Vector typed-column guide](vector-search-typed-column.md) — place vector
   payloads in dense typed-column sections, keep metadata ownership explicit, and
   separate search/scoring from final document fetch.
+- [High-QPS collection vector-search guide](vector-search-high-qps-collection-api.md)
+  — choose between buffered no-document serving, response-owned convenience
+  calls, explicit materialization, and reusable searchers without overclaiming
+  beyond exact measured routes.
 
 ## Deeper specs
 

--- a/TreeDB/docs/guides/vector-search-high-qps-collection-api.md
+++ b/TreeDB/docs/guides/vector-search-high-qps-collection-api.md
@@ -1,22 +1,93 @@
 # TreeDB high-QPS collection vector search
 
 This guide summarizes the collection-level vector-search API boundary after the
-`#2360` high-QPS work.
+`#2360` high-QPS work. It owns the API-selection and caveat guidance from #2406;
+benchmark snapshots and full counter workflow are documented separately by
+#2410.
 
-## API boundary
+## Choosing a vector search API
 
-| API | Result ownership | Document fetch | Intended use |
-| --- | --- | --- | --- |
-| `Collection.SearchVectorIndexWithBuffer` | caller-owned `VectorIndexSearchBuffer` | rejected | primary high-QPS no-document serving path; steady state should be `0 B/op`, `0 allocs/op` |
-| `Collection.SearchVectorIndex` with `IncludeDocuments=false` | response-owned results/IDs | no documents | convenience no-document path; uses the same cached `hnsw_search_pack_v1` route when healthy, but allocates response-owned result storage |
-| `Collection.SearchVectorIndex` with `IncludeDocuments=true` | response-owned results/documents | included in timed call | explicit with-documents/materialization path; not a no-document high-QPS success row |
-| `CollectionReadView.FetchDocumentsForVectorIndexSearchResults` | response-owned documents | separate post-search call | explicit split search/fetch materialization phase for top-k IDs |
-| `OpenVectorIndexSearcher` + `SearchWithBuffer` | caller-owned buffer | rejected by buffered search | reusable-searcher path when callers control snapshot/open lifetime |
+| User goal | API | Result ownership | Document/materialization boundary | Notes |
+| --- | --- | --- | --- | --- |
+| Production high-QPS exact no-document serving through the collection API | `Collection.SearchVectorIndexWithBuffer` | caller-owned `VectorIndexSearchBuffer` | `IncludeDocuments=false`; document fetch/projection/filter/fallback controls rejected | Primary collection-level fast path. Warm the collection-owned prepared `hnsw_search_pack_v1` state before the timed/serving loop; steady state targets `0 B/op`, `0 allocs/op`. |
+| Simple no-document call when per-call result allocation is acceptable | `Collection.SearchVectorIndex` with `IncludeDocuments=false` | response-owned results/IDs | no documents materialized | Convenience route. Healthy exact calls use the cached `hnsw_search_pack_v1` route, but returned result/ID storage is response-owned and intentionally allocates. |
+| Search and materialize documents in the same call | `Collection.SearchVectorIndex` with `IncludeDocuments=true` | response-owned results/documents | with-document materialization is part of the call | explicit materialization path. Do not mix these rows into no-document high-QPS claims; report document fetch counters separately. |
+| Search first, fetch top-k documents later | `CollectionReadView.FetchDocumentsForVectorIndexSearchResults` after a no-document search | response-owned documents | separate fetch/materialization phase | Use when a service can keep ANN search no-document and fetch only selected top-k IDs later. Buffered-search results alias the caller buffer, so do not reuse/reset the buffer until this fetch returns. |
+| Reusable low-level serving when the caller owns snapshot/open lifetime | `OpenVectorIndexSearcher` + `SearchWithBuffer` | caller-owned `VectorIndexSearchBuffer` | buffered search rejects document materialization | Open/warm one searcher and one buffer per worker. Use this when explicit searcher lifetime control matters more than the collection-level convenience seam. |
+
+## Production high-QPS serving recipe
+
+For the collection-level serving path:
+
+1. Build or rebuild the declared `column_graph` vector index for the current
+   generation, and keep rebuild/setup outside the timed request loop.
+2. Use the exact/zero query mode with `IncludeDocuments=false`; leave document
+   fetch options, filters, projections, legacy fallback controls, and
+   `benchmark_debug` stats out of the high-QPS request shape.
+3. Allocate one `VectorIndexSearchBuffer` per goroutine/worker. A buffer is not
+   concurrency-safe, and returned `Results`/ID byte slices alias that buffer
+   until it is reused or reset.
+4. Warm once before serving or before `ResetTimer` so the collection-owned
+   prepared `hnsw_search_pack_v1` state is built outside the measured loop.
+5. Fetch documents only after the no-document search, as a separately measured
+   materialization phase, or choose an explicitly with-document API row instead.
+
+```go
+var buffer collections.VectorIndexSearchBuffer
+opts := collections.VectorIndexSearchOptions{
+    IndexName: "embedding_graph",
+    Query:     warmupQuery,
+    TopK:      10,
+    EfSearch:  128,
+    StatsMode: collections.VectorIndexSearchStatsModeProduction,
+}
+
+// Warm the collection-owned prepared search state outside the timed loop.
+if _, err := col.SearchVectorIndexWithBuffer(opts, &buffer); err != nil {
+    return err
+}
+
+for query := range queries {
+    opts.Query = query
+    response, err := col.SearchVectorIndexWithBuffer(opts, &buffer)
+    if err != nil {
+        return err
+    }
+    // response.Results aliases buffer; copy IDs/results before reusing buffer
+    // if another goroutine or later stage must retain them.
+    consumeTopK(response.Results)
+}
+```
+
+For lower-level serving, open `OpenVectorIndexSearcher` once per worker, warm
+`SearchWithBuffer` with that worker's own buffer, and close/reopen the searcher
+when the worker must move to a newer collection/vector-index generation.
+
+## Do not overclaim
+
+- Say TreeDB is close to USearch only for the warmed exact no-document parallel
+  buffered serving route measured in the #2360/#2379 snapshot: Apple M3
+  (`darwin/arm64`), 2026-06-05, commit
+  `2feb1f0e35459d1b3d044008203d0c8afcf5630f`, Tier S fixture (10k docs,
+  64 dims, M=16, efConstruction=128, efSearch=128, topK=10, query stream
+  length 16, `BENCHTIME=1000x`, `COUNT=3`, `CPU_LIST=1,8`). USearch in that
+  comparison is a pure in-memory external ANN baseline, not TreeDB persistent
+  storage.
+- With-document search is a different materialization path. It includes final
+  document fetch/reconstruction work and must not be mixed into no-document
+  high-QPS claims.
+- Filters, projections, debug-only stats, and quantized modes are outside the
+  exact FP32 `hnsw_search_pack_v1` no-document success claim unless a separate
+  fail-closed route row and benchmark/counter evidence are published.
+- Collection-level buffered quantized search support is unavailable/planned
+  follow-up until #2415 lands. Keep any low-level quantized search evidence
+  separate from exact FP32 `hnsw_search_pack_v1` route claims.
 
 ## Required no-document route counters
 
-Healthy no-document rows must prove all of the following before claiming the
-high-QPS path:
+#2410 owns the full benchmark snapshot and counter workflow. As a contract
+summary, healthy exact no-document rows must prove all of the following before
+claiming the high-QPS path:
 
 - `search_route_hnsw_search_pack/search=1`
 - `hnsw_search_pack_active/search=1`
@@ -38,10 +109,7 @@ boundary is proven by the benchmark shape plus the route/fallback counters above
 `Collection.SearchVectorIndexWithBuffer` must also report `0 B/op` and
 `0 allocs/op`. `Collection.SearchVectorIndex` no-document convenience rows
 should report `response_owned_result_alloc/op=1` and account for the small
-response-owned allocation separately. Filters, projections, debug-only stats,
-quantized modes, and document materialization are outside this exact no-document
-contract unless they have an explicitly separate fail-closed route and benchmark
-row.
+response-owned allocation separately.
 
 ## Benchmark command
 

--- a/TreeDB/docs/vector_high_qps_collection_api_test.go
+++ b/TreeDB/docs/vector_high_qps_collection_api_test.go
@@ -1,0 +1,77 @@
+package docs_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDocs_VectorHighQPSCollectionAPIGuide2406(t *testing.T) {
+	treeRoot, _ := repoRoots(t)
+	guidePath := filepath.Join(treeRoot, "docs", "guides", "vector-search-high-qps-collection-api.md")
+	data, err := os.ReadFile(guidePath)
+	if err != nil {
+		t.Fatalf("read high-qps vector guide: %v", err)
+	}
+	text := string(data)
+	for _, want := range []string{
+		"## Choosing a vector search API",
+		"`Collection.SearchVectorIndexWithBuffer`",
+		"caller-owned `VectorIndexSearchBuffer`",
+		"steady state targets `0 B/op`, `0 allocs/op`",
+		"`Collection.SearchVectorIndex` with `IncludeDocuments=false`",
+		"response-owned results/IDs",
+		"`Collection.SearchVectorIndex` with `IncludeDocuments=true`",
+		"explicit materialization path",
+		"`OpenVectorIndexSearcher` + `SearchWithBuffer`",
+		"Open/warm one searcher and one buffer per worker",
+		"## Production high-QPS serving recipe",
+		"Warm the collection-owned prepared search state outside the timed loop",
+		"response.Results aliases buffer",
+		"## Do not overclaim",
+		"Apple M3",
+		"`darwin/arm64`",
+		"`2feb1f0e35459d1b3d044008203d0c8afcf5630f`",
+		"With-document search is a different materialization path",
+		"Filters, projections, debug-only stats, and quantized modes are outside",
+		"Collection-level buffered quantized search support is unavailable/planned",
+		"#2410 owns the full benchmark snapshot and counter workflow",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("%s missing #2406 high-QPS API guidance %q", guidePath, want)
+		}
+	}
+
+	for _, forbidden := range []string{
+		"TreeDB beats USearch",
+		"TreeDB is faster than USearch",
+		"Collection.SearchVectorIndex` is the zero-allocation target",
+		"Collection-level buffered quantized search is supported",
+	} {
+		if strings.Contains(text, forbidden) {
+			t.Fatalf("%s contains overclaim %q", guidePath, forbidden)
+		}
+	}
+}
+
+func TestDocs_GuidesReadmeLinksHighQPSCollectionAPI2406(t *testing.T) {
+	treeRoot, _ := repoRoots(t)
+	readmePath := filepath.Join(treeRoot, "docs", "guides", "README.md")
+	data, err := os.ReadFile(readmePath)
+	if err != nil {
+		t.Fatalf("read guides README: %v", err)
+	}
+	text := string(data)
+	for _, want := range []string{
+		"High-QPS collection vector-search guide",
+		"vector-search-high-qps-collection-api.md",
+		"buffered no-document serving",
+		"explicit materialization",
+		"reusable searchers",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("%s missing high-QPS guide link wording %q", readmePath, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Closes #2406.
Part of #2411 and #2400.

- Adds a user-facing “Choosing a vector search API” table for TreeDB collection vector search.
- Adds a concise high-QPS serving recipe using caller-owned `VectorIndexSearchBuffer` and warmed/prepared search state.
- Adds explicit no-document vs with-document/materialization boundaries and a do-not-overclaim caveat.
- Links the high-QPS collection guide from the TreeDB guides README.
- Adds docs coverage for the #2406 public docs contract.

## Scope boundaries

- Docs-only; no runtime/API changes.
- #2410 owns performance snapshot tables and the full benchmark/counter workflow. This PR only keeps a counter-contract summary and defers snapshot ownership to #2410.
- #2408 owns exact fail-closed error wording; this PR uses generic wording such as rejected/fail-closed and does not pin error strings.
- #2415 is still open, so collection-level buffered quantized support is documented as unavailable/planned follow-up. Quantized evidence remains separate from exact FP32 `hnsw_search_pack_v1` claims.

## Tests

- `GOWORK=off go test ./TreeDB/docs -count=1`

## Benchmarks

Not run. This is docs/test coverage only and does not change benchmark commands, performance values, search hot paths, materialization code, or benchmark harnesses.

## Risks / coordination

- Potential docs-file overlap with #2410 in `TreeDB/docs/guides/vector-search-high-qps-collection-api.md`; wording here is deliberately limited to #2406 API selection/recipe/caveats.
- #2409 can use this docs snapshot for exact-only demo guidance, but should avoid quantized collection buffered examples until #2415 lands.
