### PR TITLE
TreeDB vector docs: publish benchmark workflow

### DIFF
--- a/TreeDB/README.md
+++ b/TreeDB/README.md
@@ -212,8 +212,12 @@ rows are historical controls, not the current high-QPS production fast path;
 with-documents `Collection.SearchVectorIndex` rows still include setup/open and
 materialization cost and should not be presented as the no-document fast path.
 See `TreeDB/docs/guides/vector-search-high-qps-collection-api.md` for the final
-collection API boundary, guardrail counters, and profile capture notes.
-Override `USEARCH_VERSION`, `USEARCH_ROOT`, `TREEDB_VECTOR_BENCH_DOCS`,
+collection API boundary, and
+`TreeDB/docs/guides/vector-search-benchmark-workflow.md` for the dated Tier S
+snapshot from #2366/#2379, required fast-path counters, canonical Tier S/Tier F
+commands, USearch platform path setup, artifact/profile capture notes, and the
+zero-allocation vs response-owned vs materialization row boundary. Override
+`USEARCH_VERSION`, `USEARCH_ROOT`, `TREEDB_VECTOR_BENCH_DOCS`,
 `TREEDB_VECTOR_BENCH_DIMS`, `TREEDB_VECTOR_BENCH_M`,
 `TREEDB_VECTOR_BENCH_EF_CONSTRUCTION`, `TREEDB_VECTOR_BENCH_EF_SEARCH`,
 `TREEDB_VECTOR_BENCH_TOPK`, `TREEDB_VECTOR_BENCH_QUERIES`, `BENCHTIME`, `COUNT`,

--- a/TreeDB/docs/docs_lint_test.go
+++ b/TreeDB/docs/docs_lint_test.go
@@ -269,6 +269,8 @@ func TestDocs_VectorHighQPSBenchmarkWorkflow2410(t *testing.T) {
 		"/tmp/gomap_2366_final_20260605_030355/tier_s_bench.log",
 		"/tmp/gomap_2366_final_20260605_030355/with_buffer_alloc_proof.log",
 		"The exact FP32 `hnsw_search_pack_v1` counters above are distinct from future quantized route counters",
+		"`TreeDB_SearchWithBufferParallel` for the actual c=8 concurrent profile",
+		"only raises `GOMAXPROCS`; it does not create concurrent benchmark workers",
 	} {
 		normalizedWant := strings.Join(strings.Fields(want), " ")
 		if !strings.Contains(doc, want) && !strings.Contains(normalizedDoc, normalizedWant) {

--- a/TreeDB/docs/docs_lint_test.go
+++ b/TreeDB/docs/docs_lint_test.go
@@ -223,6 +223,69 @@ func TestDocs_VectorProjectionFetchGuidance(t *testing.T) {
 	}
 }
 
+func TestDocs_VectorHighQPSBenchmarkWorkflow2410(t *testing.T) {
+	treeRoot, _ := repoRoots(t)
+	path := filepath.Join(treeRoot, "docs", "guides", "vector-search-benchmark-workflow.md")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	doc := string(data)
+	normalizedDoc := strings.Join(strings.Fields(doc), " ")
+
+	for _, want := range []string{
+		"# TreeDB vs USearch vector benchmark workflow",
+		"## Current performance snapshot: Tier S exact no-document comparison",
+		"2feb1f0e35459d1b3d044008203d0c8afcf5630f",
+		"Apple M3 (`darwin/arm64`)",
+		"Fixture: 10k documents, 64 dimensions, `M=16`, `efConstruction=128`",
+		"USearch is a pure in-memory external ANN baseline, not TreeDB persistent storage",
+		"| `TreeDB_CollectionSearchVectorIndexWithBuffer` | 1 | 43,049 | 0 | 0 | collection buffered, caller-owned results |",
+		"| `TreeDB_CollectionSearchVectorIndexNoDocsOneShot` | 8 | 44,679 | 816 | 2 | public one-shot convenience, response-owned results |",
+		"| `TreeDB_SearchWithBufferParallel` | 8 | 8,610 | 0 | 0 | reusable searcher, one buffer/searcher per worker |",
+		"| `USearch_SearchParallel` | 8 | 6,906 | 139 | 3 | pure in-memory USearch baseline |",
+		"search_route_hnsw_search_pack/search=1",
+		"hnsw_search_pack_active/search=1",
+		"docs_fetched/search=0",
+		"open_searcher_calls/op=0",
+		"open_setup_in_timed_loop=0",
+		"graph_row_fallbacks/search=0",
+		"typed_column_vector_fallbacks/search=0",
+		"vector_scratch_decodes/search=0",
+		"`816 B/op`, `2 allocs/op`, and `response_owned_result_alloc/op=1`",
+		"`TreeDB_CollectionSearchVectorIndexWithDocumentsOneShot` | 0 | 1.000 | 10.00",
+		"libusearch_c.dylib",
+		"libusearch_c.so",
+		"DYLD_LIBRARY_PATH",
+		"LD_LIBRARY_PATH",
+		"$RUN_DIR/README.md",
+		"$RUN_DIR/bench.txt",
+		"RUN_DIR=/tmp/gomap_vector_search_compare_tier_s_$(date +%Y%m%d_%H%M%S)",
+		"TREEDB_VECTOR_BENCH_DOCS=10000 TREEDB_VECTOR_BENCH_DIMS=64",
+		"TREEDB_VECTOR_BENCH_DOCS=100000 TREEDB_VECTOR_BENCH_DIMS=128",
+		"CPU_LIST=1,8 BENCHTIME=1000x COUNT=3",
+		"BENCH_REGEX='BenchmarkCollectionVectorUSearchProductionCompare$'",
+		"/tmp/gomap_2366_final_20260605_030355/closeout_summary.md",
+		"/tmp/gomap_2366_final_20260605_030355/tier_s_bench.log",
+		"/tmp/gomap_2366_final_20260605_030355/with_buffer_alloc_proof.log",
+		"The exact FP32 `hnsw_search_pack_v1` counters above are distinct from future quantized route counters",
+	} {
+		normalizedWant := strings.Join(strings.Fields(want), " ")
+		if !strings.Contains(doc, want) && !strings.Contains(normalizedDoc, normalizedWant) {
+			t.Fatalf("%s missing #2410 vector benchmark contract text %q", path, want)
+		}
+	}
+
+	readmePath := filepath.Join(treeRoot, "README.md")
+	readme, err := os.ReadFile(readmePath)
+	if err != nil {
+		t.Fatalf("read %s: %v", readmePath, err)
+	}
+	if !strings.Contains(string(readme), "TreeDB/docs/guides/vector-search-benchmark-workflow.md") {
+		t.Fatalf("%s missing link to #2410 vector benchmark workflow guide", readmePath)
+	}
+}
+
 func TestTypedStorageStorageFormatDocsMentionCompatibilityDirectory(t *testing.T) {
 	treeRoot, _ := repoRoots(t)
 	path := filepath.Join(treeRoot, "docs", "spec", "storage-format.md")

--- a/TreeDB/docs/docs_lint_test.go
+++ b/TreeDB/docs/docs_lint_test.go
@@ -223,6 +223,87 @@ func TestDocs_VectorProjectionFetchGuidance(t *testing.T) {
 	}
 }
 
+func TestDocs_VectorHighQPSBenchmarkWorkflow2410(t *testing.T) {
+	treeRoot, _ := repoRoots(t)
+	path := filepath.Join(treeRoot, "docs", "guides", "vector-search-benchmark-workflow.md")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	doc := string(data)
+	normalizedDoc := strings.Join(strings.Fields(doc), " ")
+
+	for _, want := range []string{
+		"# TreeDB vs USearch vector benchmark workflow",
+		"## Current performance snapshot: Tier S exact no-document comparison",
+		"2feb1f0e35459d1b3d044008203d0c8afcf5630f",
+		"Apple M3 (`darwin/arm64`)",
+		"Fixture: 10k documents, 64 dimensions, `M=16`, `efConstruction=128`",
+		"USearch is a pure in-memory external ANN baseline, not TreeDB persistent storage",
+		"| `TreeDB_CollectionSearchVectorIndexWithBuffer` | 1 | 43,049 | 0 | 0 | collection buffered, caller-owned results |",
+		"| `TreeDB_CollectionSearchVectorIndexNoDocsOneShot` | 8 | 44,679 | 816 | 2 | public one-shot convenience, response-owned results |",
+		"| `TreeDB_SearchWithBufferParallel` | 8 | 8,610 | 0 | 0 | reusable searcher, one buffer/searcher per worker |",
+		"| `USearch_SearchParallel` | 8 | 6,906 | 139 | 3 | pure in-memory USearch baseline |",
+		"search_route_hnsw_search_pack/search=1",
+		"hnsw_search_pack_active/search=1",
+		"docs_fetched/search=0",
+		"open_searcher_calls/op=0",
+		"open_setup_in_timed_loop=0",
+		"graph_row_fallbacks/search=0",
+		"typed_column_vector_fallbacks/search=0",
+		"vector_scratch_decodes/search=0",
+		"`816 B/op`, `2 allocs/op`, and `response_owned_result_alloc/op=1`",
+		"`TreeDB_CollectionSearchVectorIndexWithDocumentsOneShot` | 0 | 1.000 | 10.00",
+		"libusearch_c.dylib",
+		"libusearch_c.so",
+		"DYLD_LIBRARY_PATH",
+		"LD_LIBRARY_PATH",
+		"$RUN_DIR/README.md",
+		"$RUN_DIR/bench.txt",
+		"RUN_DIR=/tmp/gomap_vector_search_compare_tier_s_$(date +%Y%m%d_%H%M%S)",
+		"TREEDB_VECTOR_BENCH_DOCS=10000 TREEDB_VECTOR_BENCH_DIMS=64",
+		"TREEDB_VECTOR_BENCH_DOCS=100000 TREEDB_VECTOR_BENCH_DIMS=128",
+		"CPU_LIST=1,8 BENCHTIME=1000x COUNT=3",
+		"BENCH_REGEX='BenchmarkCollectionVectorUSearchProductionCompare$'",
+		"/tmp/gomap_2366_final_20260605_030355/closeout_summary.md",
+		"/tmp/gomap_2366_final_20260605_030355/tier_s_bench.log",
+		"/tmp/gomap_2366_final_20260605_030355/with_buffer_alloc_proof.log",
+		"The exact FP32 `hnsw_search_pack_v1` counters above are distinct from future quantized route counters",
+	} {
+		normalizedWant := strings.Join(strings.Fields(want), " ")
+		if !strings.Contains(doc, want) && !strings.Contains(normalizedDoc, normalizedWant) {
+			t.Fatalf("%s missing #2410 vector benchmark contract text %q", path, want)
+		}
+	}
+
+	readmePath := filepath.Join(treeRoot, "README.md")
+	readme, err := os.ReadFile(readmePath)
+	if err != nil {
+		t.Fatalf("read %s: %v", readmePath, err)
+	}
+	if !strings.Contains(string(readme), "TreeDB/docs/guides/vector-search-benchmark-workflow.md") {
+		t.Fatalf("%s missing link to #2410 vector benchmark workflow guide", readmePath)
+	}
+
+	guidesReadmePath := filepath.Join(treeRoot, "docs", "guides", "README.md")
+	guidesReadme, err := os.ReadFile(guidesReadmePath)
+	if err != nil {
+		t.Fatalf("read %s: %v", guidesReadmePath, err)
+	}
+	guidesReadmeText := string(guidesReadme)
+	for _, want := range []string{
+		"TreeDB vs USearch vector benchmark workflow",
+		"vector-search-benchmark-workflow.md",
+		"required fast-path",
+		"artifact directories",
+		"profile capture",
+	} {
+		if !strings.Contains(guidesReadmeText, want) {
+			t.Fatalf("%s missing #2410 guide index wording %q", guidesReadmePath, want)
+		}
+	}
+}
+
 func TestTypedStorageStorageFormatDocsMentionCompatibilityDirectory(t *testing.T) {
 	treeRoot, _ := repoRoots(t)
 	path := filepath.Join(treeRoot, "docs", "spec", "storage-format.md")

--- a/TreeDB/docs/docs_lint_test.go
+++ b/TreeDB/docs/docs_lint_test.go
@@ -265,6 +265,8 @@ func TestDocs_VectorHighQPSBenchmarkWorkflow2410(t *testing.T) {
 		"TREEDB_VECTOR_BENCH_DOCS=100000 TREEDB_VECTOR_BENCH_DIMS=128",
 		"CPU_LIST=1,8 BENCHTIME=1000x COUNT=3",
 		"BENCH_REGEX='BenchmarkCollectionVectorUSearchProductionCompare$'",
+		"focused regex that excludes the with-documents/materialization row",
+		"BENCH_REGEX='BenchmarkCollectionVectorUSearchProductionCompare/(TreeDB_SearchWithBuffer|TreeDB_SearchWithBufferParallel|TreeDB_CollectionSearchVectorIndexWithBuffer|TreeDB_CollectionSearchVectorIndexNoDocsOneShot|USearch_Search|USearch_SearchParallel)$'",
 		"/tmp/gomap_2366_final_20260605_030355/closeout_summary.md",
 		"/tmp/gomap_2366_final_20260605_030355/tier_s_bench.log",
 		"/tmp/gomap_2366_final_20260605_030355/with_buffer_alloc_proof.log",

--- a/TreeDB/docs/guides/README.md
+++ b/TreeDB/docs/guides/README.md
@@ -27,6 +27,10 @@ directories when moving between branches.
   — choose between buffered no-document serving, response-owned convenience
   calls, explicit materialization, and reusable searchers without overclaiming
   beyond exact measured routes.
+- [TreeDB vs USearch vector benchmark workflow](vector-search-benchmark-workflow.md)
+  — reproduce the dated Tier S/Tier F comparison workflow, required fast-path
+  counters, USearch bootstrap, artifact directories, and profile capture without
+  blurring exact no-document rows with materialization or quantized evidence.
 
 ## Deeper specs
 

--- a/TreeDB/docs/guides/vector-search-benchmark-workflow.md
+++ b/TreeDB/docs/guides/vector-search-benchmark-workflow.md
@@ -205,11 +205,17 @@ go tool pprof -top -alloc_space -nodecount=40 "$PROFILE_DIR/no_doc_c1_mem.pprof"
   > "$PROFILE_DIR/no_doc_c1_alloc_top.txt"
 ```
 
-Repeat with `-cpu=8` for the c=8 profile and change the benchmark suffix to
-`TreeDB_CollectionSearchVectorIndexWithBuffer` when proving the caller-owned
-buffer allocation ceiling. Go benchmark CPU profiles include fixture setup,
-rebuild, and package initialization work before the timed loop; use the route
-counters above to separate setup from steady-state query costs.
+Repeat with `-cpu=8` on `TreeDB_SearchWithBufferParallel` for the actual c=8
+concurrent profile; that subbenchmark uses `b.RunParallel` with one searcher and
+one caller-owned buffer per worker. Running `-cpu=8` against non-parallel
+subbenchmarks such as `TreeDB_CollectionSearchVectorIndexNoDocsOneShot` or
+`TreeDB_CollectionSearchVectorIndexWithBuffer` only raises `GOMAXPROCS`; it does
+not create concurrent benchmark workers. Use those non-parallel rows for
+single-goroutine response-owned or caller-owned allocation profiles, and use the
+parallel row for c=8 bottleneck/scaling evidence. Go benchmark CPU profiles
+include fixture setup, rebuild, and package initialization work before the timed
+loop; use the route counters above to separate setup from steady-state query
+costs.
 
 In healthy no-document rows, expected steady-state costs are HNSW pack traversal,
 dot/scoring, frontier/top-k maintenance, and final result-ID copy for

--- a/TreeDB/docs/guides/vector-search-benchmark-workflow.md
+++ b/TreeDB/docs/guides/vector-search-benchmark-workflow.md
@@ -1,0 +1,218 @@
+# TreeDB vs USearch vector benchmark workflow
+
+This guide owns the #2410 benchmark snapshot and counter workflow for the
+post-#2360 TreeDB collection vector-search docs stack. It is a dated exact-FP32
+`hnsw_search_pack_v1` benchmark contract, not a general claim that TreeDB beats
+or matches USearch outside the stated fixture, hardware, commit, route, and
+counters.
+
+## Current performance snapshot: Tier S exact no-document comparison
+
+Current public numbers should cite this exact snapshot until a newer #2399 or
+#2412-derived evidence bundle is merged and routed back into the docs. The
+snapshot was captured at the close of #2366/#2379 on 2026-06-05 at commit
+`2feb1f0e35459d1b3d044008203d0c8afcf5630f`, Apple M3 (`darwin/arm64`).
+
+Fixture: 10k documents, 64 dimensions, `M=16`, `efConstruction=128`,
+`efSearch=128`, `topK=10`, query stream length 16, `BENCHTIME=1000x`,
+`COUNT=3`, `CPU_LIST=1,8`. USearch is a pure in-memory external ANN baseline,
+not TreeDB persistent storage. TreeDB vectors cross the collection JSON insert,
+persisted `column_graph`, derived `hnsw_search_pack_v1`, and warmed search
+boundary described in the row labels.
+
+| Row | cpu | median ns/op | B/op | allocs/op | Boundary |
+| --- | ---: | ---: | ---: | ---: | --- |
+| `TreeDB_CollectionSearchVectorIndexWithBuffer` | 1 | 43,049 | 0 | 0 | collection buffered, caller-owned results |
+| `TreeDB_CollectionSearchVectorIndexWithBuffer` | 8 | 43,307 | 0 | 0 | collection buffered, caller-owned results |
+| `TreeDB_CollectionSearchVectorIndexNoDocsOneShot` | 1 | 43,016 | 816 | 2 | public one-shot convenience, response-owned results |
+| `TreeDB_CollectionSearchVectorIndexNoDocsOneShot` | 8 | 44,679 | 816 | 2 | public one-shot convenience, response-owned results |
+| `TreeDB_SearchWithBuffer` | 1 | 43,612 | 0 | 0 | reusable searcher, caller-owned buffer |
+| `TreeDB_SearchWithBufferParallel` | 8 | 8,610 | 0 | 0 | reusable searcher, one buffer/searcher per worker |
+| `USearch_Search` | 1 | 30,065 | 136 | 3 | pure in-memory USearch baseline |
+| `USearch_SearchParallel` | 8 | 6,906 | 139 | 3 | pure in-memory USearch baseline |
+
+Source artifacts from the closeout bundle:
+
+- `/tmp/gomap_2366_final_20260605_030355/closeout_summary.md`
+- `/tmp/gomap_2366_final_20260605_030355/tier_s_bench.log`
+- `/tmp/gomap_2366_final_20260605_030355/no_doc_c1_100k_cpu_top.txt`
+- `/tmp/gomap_2366_final_20260605_030355/no_doc_c8_100k_cpu_top.txt`
+- `/tmp/gomap_2366_final_20260605_030355/with_buffer_alloc_proof.log`
+
+## Required no-document route counters and row contracts
+
+Healthy exact no-document rows must prove all of the following before claiming
+the high-QPS path:
+
+- `search_route_hnsw_search_pack/search=1`
+- `hnsw_search_pack_active/search=1`
+- `docs_fetched/search=0`
+- `graph_row_fallbacks/search=0`
+- `typed_column_vector_fallbacks/search=0`
+- `vector_scratch_decodes/search=0`
+
+Collection-level one-shot/buffer rows must additionally prove there is no
+per-query open/setup in the timed loop:
+
+- `open_searcher_calls/op=0`
+- `open_setup_in_timed_loop=0`
+
+Reusable-searcher `SearchWithBuffer` rows open the searcher before `ResetTimer`
+and may not emit those collection-level open/setup counters; their open/setup
+boundary is proven by the benchmark shape plus the route/fallback counters above.
+
+Allocation accounting is part of the contract:
+
+- `Collection.SearchVectorIndexWithBuffer` and
+  `VectorIndexSearcher.SearchWithBuffer` target `0 B/op`, `0 allocs/op` after
+  setup/warmup with caller-owned buffers.
+- `Collection.SearchVectorIndex` with `IncludeDocuments=false` is a
+  response-owned convenience row. The current Tier S snapshot expects
+  `816 B/op`, `2 allocs/op`, and `response_owned_result_alloc/op=1`; that row
+  can be fast and healthy without being the zero-allocation target.
+- `Collection.SearchVectorIndex` with `IncludeDocuments=true` is an explicit
+  with-documents/materialization row. It must report document counters such as
+  `docs_fetched/search` and must not be included in no-document high-QPS success
+  claims.
+
+The closeout guardrail sample for the first c=1 Tier S run was:
+
+| Row | `search_route_hnsw_search_pack/search` | `hnsw_search_pack_active/search` | `docs_fetched/search` | `open_searcher_calls/op` | `open_setup_in_timed_loop` | `graph_row_fallbacks/search` | `typed_column_vector_fallbacks/search` | `vector_scratch_decodes/search` | `response_owned_result_alloc/op` |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| `TreeDB_CollectionSearchVectorIndexWithBuffer` | 1.000 | 1.000 | 0 | 0 | 0 | 0 | 0 | 0 | 0 |
+| `TreeDB_CollectionSearchVectorIndexNoDocsOneShot` | 1.000 | 1.000 | 0 | 0 | 0 | 0 | 0 | 0 | 1.000 |
+| `TreeDB_SearchWithBuffer` | 1.000 | 1.000 | 0 | n/a | n/a | 0 | 0 | 0 | n/a |
+| `TreeDB_CollectionSearchVectorIndexWithDocumentsOneShot` | 0 | 1.000 | 10.00 | 1.000 | 1.000 | 0 | 0 | 0 | 1.000 |
+
+The exact FP32 `hnsw_search_pack_v1` counters above are distinct from future
+quantized route counters. Do not put quantized-only or quantized-rerank rows in
+this exact no-document success claim unless they have separate fail-closed route
+rows, fixtures, counters, and evidence.
+
+## Canonical TreeDB vs USearch workflow
+
+Use `scripts/bench_vector_search_compare.sh` for the optional external ANN
+comparison. The script records a reproducibility README and full benchmark output
+under `RUN_DIR`.
+
+### USearch bootstrap and platform library paths
+
+- Set `USEARCH_ROOT` when you already have a USearch C install. It must contain
+  `usearch.h` under either `$USEARCH_ROOT/include` or `$USEARCH_ROOT`, and the
+  platform library under either `$USEARCH_ROOT/lib` or `$USEARCH_ROOT`.
+- If `USEARCH_ROOT` is unset, the script downloads USearch `USEARCH_VERSION`
+  (default `2.25.2`) into `/tmp` and extracts it to the platform default:
+  - macOS: `/tmp/usearch_${USEARCH_VERSION}_macos_<arch>/root`
+  - Linux: `/tmp/usearch_${USEARCH_VERSION}_linux_<arch>/root/usr/local`
+- The script searches for `libusearch_c.dylib` on Darwin and
+  `libusearch_c.so` on Linux, then exports the correct `CGO_CFLAGS`,
+  `CGO_LDFLAGS`, and `DYLD_LIBRARY_PATH` or `LD_LIBRARY_PATH` for the `go test`
+  subprocess.
+- Override `USEARCH_ARCH` only when the host architecture auto-detection is not
+  the package architecture you want (`arm64`, `aarch64`, `x86_64`, `amd64`).
+
+### Artifact directory, CPU list, benchtime, and count
+
+- Set `RUN_DIR=/tmp/<stable-name>` when collecting publishable evidence. The
+  default is `/tmp/gomap_vector_search_compare_<timestamp>`.
+- The script writes `$RUN_DIR/README.md` with the branch, commit, USearch paths,
+  fixture, regexes, and row-boundary notes, and `$RUN_DIR/bench.txt` with the
+  raw benchmark stream.
+- `CPU_LIST=1,8` means the script runs one `go test -cpu=1` block and one
+  `go test -cpu=8` block; it does not rely on a combined Go benchmark CPU list.
+- `BENCHTIME` and `COUNT` map directly to `go test -benchtime` and `-count`.
+  Use `BENCHTIME=1000x COUNT=3` for the current Tier S snapshot shape, and a
+  smaller `BENCHTIME=1x COUNT=1` only for smoke validation.
+
+### Tier S publishable command
+
+```sh
+RUN_DIR=/tmp/gomap_vector_search_compare_tier_s_$(date +%Y%m%d_%H%M%S) \
+TREEDB_VECTOR_BENCH_DOCS=10000 TREEDB_VECTOR_BENCH_DIMS=64 \
+  TREEDB_VECTOR_BENCH_M=16 TREEDB_VECTOR_BENCH_EF_CONSTRUCTION=128 \
+  TREEDB_VECTOR_BENCH_EF_SEARCH=128 TREEDB_VECTOR_BENCH_TOPK=10 \
+  TREEDB_VECTOR_BENCH_QUERIES=16 CPU_LIST=1,8 BENCHTIME=1000x COUNT=3 \
+  BENCH_REGEX='BenchmarkCollectionVectorUSearchProductionCompare$' \
+  scripts/bench_vector_search_compare.sh
+```
+
+### Tier F scaling command template
+
+Tier F is the 100k-document, 128-dimension scaling fixture. Use it when measuring
+scaling-sensitive work; do not replace the Tier S snapshot table with Tier F
+numbers unless the PR or tracker cites the exact command, hardware, commit,
+route counters, `ns/op`, derived `ops/sec`, `B/op`, and `allocs/op`.
+
+```sh
+RUN_DIR=/tmp/gomap_vector_search_compare_tier_f_$(date +%Y%m%d_%H%M%S) \
+TREEDB_VECTOR_BENCH_DOCS=100000 TREEDB_VECTOR_BENCH_DIMS=128 \
+  TREEDB_VECTOR_BENCH_M=16 TREEDB_VECTOR_BENCH_EF_CONSTRUCTION=128 \
+  TREEDB_VECTOR_BENCH_EF_SEARCH=128 TREEDB_VECTOR_BENCH_TOPK=10 \
+  TREEDB_VECTOR_BENCH_QUERIES=16 CPU_LIST=1,8 BENCHTIME=1000x COUNT=3 \
+  BENCH_REGEX='BenchmarkCollectionVectorUSearchProductionCompare$' \
+  scripts/bench_vector_search_compare.sh
+```
+
+For smoke checks of either tier, keep the same fixture variables and use
+`BENCHTIME=1x COUNT=1` with a throwaway `RUN_DIR`.
+
+### Focused profile capture
+
+The wrapper does not create pprof files by default. To capture focused CPU or
+allocation profiles, first run the wrapper once and reuse the host-specific
+USearch include/library paths recorded in `$RUN_DIR/README.md`:
+
+```sh
+RUN_DIR=/tmp/gomap_vector_search_compare_profile_bootstrap
+export RUN_DIR
+TREEDB_VECTOR_BENCH_DOCS=10000 TREEDB_VECTOR_BENCH_DIMS=64 \
+  TREEDB_VECTOR_BENCH_M=16 TREEDB_VECTOR_BENCH_EF_CONSTRUCTION=128 \
+  TREEDB_VECTOR_BENCH_EF_SEARCH=128 TREEDB_VECTOR_BENCH_TOPK=10 \
+  TREEDB_VECTOR_BENCH_QUERIES=16 CPU_LIST=1 BENCHTIME=1x COUNT=1 \
+  BENCH_REGEX='BenchmarkCollectionVectorUSearchProductionCompare$' \
+  scripts/bench_vector_search_compare.sh
+
+USEARCH_INCLUDE_DIR=$(awk -F'`' '/USearch include dir:/ { print $2 }' "$RUN_DIR/README.md")
+USEARCH_LIB_DIR=$(awk -F'`' '/USearch lib dir:/ { print $2 }' "$RUN_DIR/README.md")
+export CGO_CFLAGS="-I$USEARCH_INCLUDE_DIR"
+case "$(uname -s)" in
+  Linux)
+    export CGO_LDFLAGS="-L$USEARCH_LIB_DIR -lusearch_c"
+    export LD_LIBRARY_PATH="$USEARCH_LIB_DIR:${LD_LIBRARY_PATH:-}"
+    ;;
+  Darwin)
+    export CGO_LDFLAGS="-L$USEARCH_LIB_DIR -Wl,-rpath,$USEARCH_LIB_DIR -lusearch_c"
+    export DYLD_LIBRARY_PATH="$USEARCH_LIB_DIR:${DYLD_LIBRARY_PATH:-}"
+    ;;
+esac
+
+PROFILE_DIR=/tmp/gomap_vector_search_profiles_$(date +%Y%m%d_%H%M%S)
+mkdir -p "$PROFILE_DIR"
+TREEDB_VECTOR_BENCH_DOCS=10000 TREEDB_VECTOR_BENCH_DIMS=64 \
+  TREEDB_VECTOR_BENCH_M=16 TREEDB_VECTOR_BENCH_EF_CONSTRUCTION=128 \
+  TREEDB_VECTOR_BENCH_EF_SEARCH=128 TREEDB_VECTOR_BENCH_TOPK=10 \
+  TREEDB_VECTOR_BENCH_QUERIES=16 \
+  go test -tags usearch_bench ./TreeDB/collections -run '^$' \
+  -bench '^BenchmarkCollectionVectorUSearchProductionCompare/TreeDB_CollectionSearchVectorIndexNoDocsOneShot$' \
+  -benchmem -benchtime=100000x -count=1 -cpu=1 \
+  -cpuprofile "$PROFILE_DIR/no_doc_c1_cpu.pprof" \
+  -memprofile "$PROFILE_DIR/no_doc_c1_mem.pprof" \
+  > "$PROFILE_DIR/no_doc_c1.log" 2>&1
+
+go tool pprof -top -nodecount=40 "$PROFILE_DIR/no_doc_c1_cpu.pprof" \
+  > "$PROFILE_DIR/no_doc_c1_cpu_top.txt"
+go tool pprof -top -alloc_space -nodecount=40 "$PROFILE_DIR/no_doc_c1_mem.pprof" \
+  > "$PROFILE_DIR/no_doc_c1_alloc_top.txt"
+```
+
+Repeat with `-cpu=8` for the c=8 profile and change the benchmark suffix to
+`TreeDB_CollectionSearchVectorIndexWithBuffer` when proving the caller-owned
+buffer allocation ceiling. Go benchmark CPU profiles include fixture setup,
+rebuild, and package initialization work before the timed loop; use the route
+counters above to separate setup from steady-state query costs.
+
+In healthy no-document rows, expected steady-state costs are HNSW pack traversal,
+dot/scoring, frontier/top-k maintenance, and final result-ID copy for
+response-owned convenience calls. Dominant document/JSON materialization,
+graph-row fallback, typed-column vector fallback, per-query open/prepare, or
+allocation/GC costs are blocking evidence for a no-document fast-row claim.

--- a/TreeDB/docs/guides/vector-search-benchmark-workflow.md
+++ b/TreeDB/docs/guides/vector-search-benchmark-workflow.md
@@ -139,9 +139,11 @@ TREEDB_VECTOR_BENCH_DOCS=10000 TREEDB_VECTOR_BENCH_DIMS=64 \
 ### Tier F scaling command template
 
 Tier F is the 100k-document, 128-dimension scaling fixture. Use it when measuring
-scaling-sensitive work; do not replace the Tier S snapshot table with Tier F
-numbers unless the PR or tracker cites the exact command, hardware, commit,
-route counters, `ns/op`, derived `ops/sec`, `B/op`, and `allocs/op`.
+scaling-sensitive exact no-document work; do not replace the Tier S snapshot
+table with Tier F numbers unless the PR or tracker cites the exact command,
+hardware, commit, route counters, `ns/op`, derived `ops/sec`, `B/op`, and
+`allocs/op`. The publishable no-document Tier F command intentionally uses a
+focused regex that excludes the with-documents/materialization row.
 
 ```sh
 RUN_DIR=/tmp/gomap_vector_search_compare_tier_f_$(date +%Y%m%d_%H%M%S) \
@@ -149,7 +151,7 @@ TREEDB_VECTOR_BENCH_DOCS=100000 TREEDB_VECTOR_BENCH_DIMS=128 \
   TREEDB_VECTOR_BENCH_M=16 TREEDB_VECTOR_BENCH_EF_CONSTRUCTION=128 \
   TREEDB_VECTOR_BENCH_EF_SEARCH=128 TREEDB_VECTOR_BENCH_TOPK=10 \
   TREEDB_VECTOR_BENCH_QUERIES=16 CPU_LIST=1,8 BENCHTIME=1000x COUNT=3 \
-  BENCH_REGEX='BenchmarkCollectionVectorUSearchProductionCompare$' \
+  BENCH_REGEX='BenchmarkCollectionVectorUSearchProductionCompare/(TreeDB_SearchWithBuffer|TreeDB_SearchWithBufferParallel|TreeDB_CollectionSearchVectorIndexWithBuffer|TreeDB_CollectionSearchVectorIndexNoDocsOneShot|USearch_Search|USearch_SearchParallel)$' \
   scripts/bench_vector_search_compare.sh
 ```
 


### PR DESCRIPTION
## Summary

Closes #2410.
Part of #2411 and #2400.

- Adds `TreeDB/docs/guides/vector-search-benchmark-workflow.md` as the canonical TreeDB vs USearch benchmark workflow for the high-QPS vector docs stack.
- Publishes the dated #2366/#2379 Tier S snapshot, required fast-path counters, and row-boundary contract for zero-allocation buffered rows vs response-owned one-shot rows vs with-document/materialization rows.
- Documents Tier S and focused no-document Tier F command templates, `USEARCH_ROOT`/platform library path behavior, `CPU_LIST`, `BENCHTIME`, `COUNT`, `RUN_DIR` artifacts, and focused profile capture.
- Links the benchmark workflow from `TreeDB/README.md` and `TreeDB/docs/guides/README.md`, and adds docs lint coverage for the #2410 contract.

## Scope / non-goals

- Docs/tests only; no runtime, API, benchmark harness, row-name, artifact-name, or script behavior changes.
- Does not claim TreeDB generally beats or matches USearch. The Tier S snapshot is limited to the exact fixture/hardware/date/commit/route/counters below.
- Keeps exact FP32 `hnsw_search_pack_v1` route claims distinct from future quantized route claims.
- Keeps no-document buffered rows distinct from response-owned convenience rows and with-document/materialization rows.
- #2406 API chooser/caveat docs are merged in base `dd3106637d416c51de395c3875c4747bd483d8b5`; this PR preserves those sections and does not edit `TreeDB/docs/guides/vector-search-high-qps-collection-api.md`.

## Published Tier S snapshot / docs contract

Source evidence: #2366/#2379 closeout artifacts at `/tmp/gomap_2366_final_20260605_030355`.

- Commit: `2feb1f0e35459d1b3d044008203d0c8afcf5630f`
- Hardware/context: Apple M3, `darwin/arm64`, 2026-06-05
- Tier S fixture: 10k docs, 64 dims, `M=16`, `efConstruction=128`, `efSearch=128`, `topK=10`, query stream length 16, `BENCHTIME=1000x`, `COUNT=3`, `CPU_LIST=1,8`
- USearch boundary: pure in-memory external ANN baseline, not TreeDB persistent storage

| Row | cpu | median ns/op | B/op | allocs/op | Boundary |
| --- | ---: | ---: | ---: | ---: | --- |
| `TreeDB_CollectionSearchVectorIndexWithBuffer` | 1 | 43,049 | 0 | 0 | collection buffered, caller-owned results |
| `TreeDB_CollectionSearchVectorIndexWithBuffer` | 8 | 43,307 | 0 | 0 | collection buffered, caller-owned results |
| `TreeDB_CollectionSearchVectorIndexNoDocsOneShot` | 1 | 43,016 | 816 | 2 | public one-shot convenience, response-owned results |
| `TreeDB_CollectionSearchVectorIndexNoDocsOneShot` | 8 | 44,679 | 816 | 2 | public one-shot convenience, response-owned results |
| `TreeDB_SearchWithBuffer` | 1 | 43,612 | 0 | 0 | reusable searcher, caller-owned buffer |
| `TreeDB_SearchWithBufferParallel` | 8 | 8,610 | 0 | 0 | reusable searcher, one buffer/searcher per worker |
| `USearch_Search` | 1 | 30,065 | 136 | 3 | pure in-memory USearch baseline |
| `USearch_SearchParallel` | 8 | 6,906 | 139 | 3 | pure in-memory USearch baseline |

Required no-doc guardrails documented:

- `search_route_hnsw_search_pack/search=1`
- `hnsw_search_pack_active/search=1`
- `docs_fetched/search=0`
- `graph_row_fallbacks/search=0`
- `typed_column_vector_fallbacks/search=0`
- `vector_scratch_decodes/search=0`
- collection one-shot/buffer rows: `open_searcher_calls/op=0`, `open_setup_in_timed_loop=0`
- buffered rows: `0 B/op`, `0 allocs/op`; response-owned no-doc row: `816 B/op`, `2 allocs/op`, `response_owned_result_alloc/op=1`

## Tier F / #2423 handling

#2405 / PR #2423 posted Tier F 100k/128 exact-FP32 no-document evidence to #2410. This PR documents the focused Tier F command shape from that evidence and explicitly excludes the with-documents/materialization row:

```sh
BENCH_REGEX='BenchmarkCollectionVectorUSearchProductionCompare/(TreeDB_SearchWithBuffer|TreeDB_SearchWithBufferParallel|TreeDB_CollectionSearchVectorIndexWithBuffer|TreeDB_CollectionSearchVectorIndexNoDocsOneShot|USearch_Search|USearch_SearchParallel)$'
```

The guide still does not replace the Tier S snapshot table with Tier F numbers; it says Tier F numbers need exact command, hardware, commit, route counters, `ns/op`, derived `ops/sec`, `B/op`, and `allocs/op`.

## Dependency sync / newer evidence check

Re-read #2400, #2411, #2410, #2406, #2399, #2412, #2415, and #2416 before implementation, before first push, after #2406 merged, and after the #2423 Tier F evidence comment.

- Synced on top of merged #2406 / PR #2420: base `origin/main` is `dd3106637d416c51de395c3875c4747bd483d8b5`.
- Sync conflicts: one duplicate-test conflict in `TreeDB/docs/docs_lint_test.go`, resolved by keeping the #2410 benchmark workflow guide-index assertions. No conflict in #2406's `vector-search-high-qps-collection-api.md` because this PR does not edit that file.
- No merged #2399 replacement performance evidence was found.
- #2412 has open PR #2419 for an opt-in profiling hook, but it does not publish replacement performance rows for this snapshot.

## Tests

- `GOWORK=off go test ./TreeDB/docs -count=1` ✅ before initial PR
- `GOWORK=off go test ./TreeDB/docs -count=1` ✅ after #2406 sync/rebase/merge
- `GOWORK=off go test ./TreeDB/docs -count=1` ✅ after profile-concurrency review fix
- `GOWORK=off go test ./TreeDB/docs -count=1` ✅ after Tier F focused-regex fix
- `git diff --check origin/main...HEAD` ✅ after latest fix

## CI status

Latest-head CI is green on `c1a2581f86d52d91c4a2544055ed5d8de2ab71f8` (26/26 checks passing). The prior red `race-check (linux)-2` on superseded head `47341a52ee876d407aa074a5582192c0dbb93f57` failed in unrelated `TreeDB/mongo_gateway` (`TestStandaloneServerCommandWALBSONInsertReadUpdateVisibility/command_wal_relaxed`) and did not repeat on the latest head.

## Benchmarks

Not run. This is docs/test coverage only and cites existing #2366/#2379 and #2423 evidence; no benchmark commands, harness behavior, search hot paths, counters, or artifact names were changed.

## AI review status

- Codex: one finding on c=8 profile wording was fixed in `47341a52ee876d407aa074a5582192c0dbb93f57`; thread resolved. Re-requested on final head `c1a2581f86d52d91c4a2544055ed5d8de2ab71f8`; no additional Codex findings posted during the wait window.
- CodeRabbit: review command completed on final head; no actionable findings.
- Copilot: requested on final head; no visible Copilot response/findings.
