### PR TITLE
TreeDB vector buffered search fail-closed errors

### DIFF
--- a/TreeDB/collections/collection_vector_index_prepared_search_cache.go
+++ b/TreeDB/collections/collection_vector_index_prepared_search_cache.go
@@ -206,33 +206,36 @@ func (c *Collection) openCollectionVectorIndexPreparedSearch(opts VectorIndexSea
 	}
 	def, ok := findVectorIndex(catalog.meta.VectorIndexes, opts.IndexName)
 	if !ok {
-		return nil, response, ErrIndexNotFound
+		return nil, response, fmt.Errorf("%w: vector index %q SearchVectorIndexWithBuffer requires a declared vector index", ErrIndexNotFound, opts.IndexName)
 	}
 	response.IndexName = def.Name
 	response.Strategy = def.Strategy
 	switch def.Strategy {
 	case VectorIndexStrategyNativeRuntime:
 		response.Status = VectorIndexStatus{Name: def.Name, Strategy: def.Strategy, State: VectorIndexStateNativeRuntime, Reason: VectorIndexReasonNativeRuntime}
-		return nil, response, fmt.Errorf("%w: vector index %q uses native_runtime; collection buffered search currently requires an explicit column_graph index", ErrVectorIndexSearchUnavailable, def.Name)
+		return nil, response, fmt.Errorf("%w: vector index %q SearchVectorIndexWithBuffer requires an explicit column_graph index; native_runtime cannot serve the no-document hnsw_search_pack_v1 route", ErrVectorIndexSearchUnavailable, def.Name)
 	case VectorIndexStrategyColumnGraph:
 	default:
 		response.Status = VectorIndexStatus{Name: def.Name, Strategy: def.Strategy, State: VectorIndexStateColumnGraphUnavailable, Reason: VectorIndexReasonUnsupportedStrategy}
-		return nil, response, fmt.Errorf("%w: vector index %q uses unsupported strategy %q", ErrVectorIndexSearchUnavailable, def.Name, def.Strategy)
+		return nil, response, fmt.Errorf("%w: vector index %q SearchVectorIndexWithBuffer requires column_graph strategy; got unsupported strategy %q", ErrVectorIndexSearchUnavailable, def.Name, def.Strategy)
 	}
 	if def.Metric != VectorMetricCosine {
 		response.Status = VectorIndexStatus{Name: def.Name, Strategy: def.Strategy, State: VectorIndexStateColumnGraphUnavailable, Reason: VectorIndexReasonColumnGraphUnsupportedMetric}
-		return nil, response, fmt.Errorf("%w: column_graph vector index %q uses metric %q; native reader currently supports only %q", ErrVectorIndexSearchUnavailable, def.Name, def.Metric, VectorMetricCosine)
+		return nil, response, fmt.Errorf("%w: vector index %q SearchVectorIndexWithBuffer requires cosine column_graph state; got metric %q", ErrVectorIndexSearchUnavailable, def.Name, def.Metric)
 	}
 
 	def, graph, view, err := c.columnVectorGraphPhysicalRowReaderSnapshotViewAtSnapshot(def.Name, snap)
 	if err != nil {
 		status, statusErr := c.columnGraphVectorIndexStatusAtSnapshot(def.Name, snap)
 		if statusErr != nil {
+			if errors.Is(statusErr, ErrIndexNotFound) {
+				return nil, response, fmt.Errorf("%w: vector index %q SearchVectorIndexWithBuffer requires a declared vector index", ErrIndexNotFound, def.Name)
+			}
 			return nil, response, statusErr
 		}
 		status = failClosedColumnGraphReaderOpenStatus(def, status)
 		response.Status = status
-		return nil, response, fmt.Errorf("%w: column_graph %q is not loaded: state=%s reason=%s: %w", ErrVectorIndexSearchUnavailable, def.Name, status.State, status.Reason, err)
+		return nil, response, fmt.Errorf("%w: vector index %q SearchVectorIndexWithBuffer requires loaded column_graph state: state=%s reason=%s", ErrVectorIndexSearchUnavailable, def.Name, status.State, status.Reason)
 	}
 	readerCatalog := view.Catalog
 	if readerCatalog == nil || readerCatalog.meta.Options.ColumnStore == nil {
@@ -248,16 +251,16 @@ func (c *Collection) openCollectionVectorIndexPreparedSearch(opts VectorIndexSea
 		return nil, response, err
 	}
 	if !columnVectorGraphDocumentIDStatePresent(view.VectorIndexState) {
-		return nil, response, fmt.Errorf("%w: vector index %q SearchVectorIndexWithBuffer requires vector-index document-id state for response IDs", ErrVectorIndexSearchUnavailable, def.Name)
+		return nil, response, fmt.Errorf("%w: vector index %q SearchVectorIndexWithBuffer requires vector-index document-id state for no-document result IDs; rebuild the vector index", ErrVectorIndexSearchUnavailable, def.Name)
 	}
 	if err := validateColumnVectorGraphDocumentIDStateAssetPayload(c.db.ColumnAssetRootDir(), readerCatalog.meta.Name, *readerCatalog.meta.Options.ColumnStore, def, graph, view.VectorIndexState); err != nil {
-		return nil, response, fmt.Errorf("%w: vector index %q SearchVectorIndexWithBuffer requires valid vector-index document-id state: %w", ErrVectorIndexSearchUnavailable, def.Name, err)
+		return nil, response, fmt.Errorf("%w: vector index %q SearchVectorIndexWithBuffer requires valid vector-index document-id state for no-document result IDs; rebuild the vector index", ErrVectorIndexSearchUnavailable, def.Name)
 	}
 	pack, packStatus, packOpenNanos, packErr := c.openColumnHNSWSearchPackPreparedViewForReader(readerCatalog.meta.Name, *readerCatalog.meta.Options.ColumnStore, def, graph, view.VectorIndexState)
 	if packErr != nil {
 		response.Stats = VectorIndexSearchStats{}
 		vectorIndexSearchRouteStatsForHNSWSearchPackFastStatus(vectorIndexSearchRouteStats{}, columnHNSWSearchPackPreparedStatusInvalid).apply(&response.Stats)
-		return nil, response, fmt.Errorf("%w: vector index %q SearchVectorIndexWithBuffer requires valid hnsw_search_pack_v1 state: %w", ErrVectorIndexSearchUnavailable, def.Name, packErr)
+		return nil, response, fmt.Errorf("%w: vector index %q SearchVectorIndexWithBuffer requires valid hnsw_search_pack_v1 state; rebuild the vector index before using the buffered no-document route", ErrVectorIndexSearchUnavailable, def.Name)
 	}
 	if packStatus != columnHNSWSearchPackPreparedStatusDirect && packStatus != columnHNSWSearchPackPreparedStatusHeap {
 		if pack != nil {
@@ -265,7 +268,7 @@ func (c *Collection) openCollectionVectorIndexPreparedSearch(opts VectorIndexSea
 		}
 		response.Stats = VectorIndexSearchStats{}
 		vectorIndexSearchRouteStatsForHNSWSearchPackFastStatus(vectorIndexSearchRouteStats{}, packStatus).apply(&response.Stats)
-		return nil, response, fmt.Errorf("%w: vector index %q SearchVectorIndexWithBuffer requires healthy hnsw_search_pack_v1 state", ErrVectorIndexSearchUnavailable, def.Name)
+		return nil, response, fmt.Errorf("%w: vector index %q SearchVectorIndexWithBuffer requires healthy hnsw_search_pack_v1 state; rebuild the vector index before using the buffered no-document route", ErrVectorIndexSearchUnavailable, def.Name)
 	}
 	routeStats := vectorIndexSearchRouteStatsForHNSWSearchPackRoute(pack.routeStats(packStatus, packOpenNanos))
 	return &collectionVectorIndexPreparedSearch{

--- a/TreeDB/collections/vector_index_search.go
+++ b/TreeDB/collections/vector_index_search.go
@@ -890,7 +890,7 @@ func (c *Collection) SearchVectorIndexWithBuffer(opts VectorIndexSearchOptions, 
 	}
 	if queryMode != columnVectorGraphNativeSearchQueryModeExact || !columnHNSWSearchPackStatsModeSupportedForSearch(statsMode) {
 		buffer.Reset()
-		return VectorIndexSearchResponse{}, fmt.Errorf("%w: vector index %q SearchVectorIndexWithBuffer requires exact no-document hnsw_search_pack_v1 route", ErrVectorIndexSearchUnavailable, opts.IndexName)
+		return VectorIndexSearchResponse{}, fmt.Errorf("%w: vector index %q SearchVectorIndexWithBuffer requires the exact no-document hnsw_search_pack_v1 route; unsupported query or stats options must use SearchVectorIndex or OpenVectorIndexSearcher", ErrVectorIndexSearchUnavailable, opts.IndexName)
 	}
 	var lastResponse VectorIndexSearchResponse
 	var lastErr error
@@ -915,7 +915,7 @@ func (c *Collection) SearchVectorIndexWithBuffer(opts VectorIndexSearchOptions, 
 	if lastErr != nil {
 		return lastResponse, lastErr
 	}
-	return lastResponse, fmt.Errorf("%w: vector index %q SearchVectorIndexWithBuffer requires exact no-document hnsw_search_pack_v1 route", ErrVectorIndexSearchUnavailable, opts.IndexName)
+	return lastResponse, fmt.Errorf("%w: vector index %q SearchVectorIndexWithBuffer requires a healthy exact no-document hnsw_search_pack_v1 route; rebuild the vector index or use SearchVectorIndex for the response-owned convenience path", ErrVectorIndexSearchUnavailable, opts.IndexName)
 }
 
 func validateCollectionVectorIndexSearchWithBufferOptions(opts VectorIndexSearchOptions, buffer *VectorIndexSearchBuffer) error {
@@ -926,37 +926,80 @@ func validateCollectionVectorIndexSearchWithBufferOptions(opts VectorIndexSearch
 		buffer.Reset()
 		return err
 	}
+	if opts.MaxDecodedBlocks < 0 {
+		buffer.Reset()
+		return errors.New("collections: vector index search max_decoded_blocks cannot be negative")
+	}
 	if opts.IncludeDocuments {
 		buffer.Reset()
-		return errors.New("collections: vector index SearchVectorIndexWithBuffer does not support IncludeDocuments")
+		return collectionVectorIndexWithBufferUnsupportedOptionError("IncludeDocuments=true", "this API returns no-document result IDs and scores only; use SearchVectorIndex with IncludeDocuments=true for materialization or run a separate document fetch after buffered search")
 	}
-	if vectorIndexDocumentFetchOptionsNonZero(opts.DocumentFetchOptions) {
+	if err := collectionVectorIndexWithBufferDocumentFetchOptionsError(opts.DocumentFetchOptions); err != nil {
 		buffer.Reset()
-		return errors.New("collections: vector index SearchVectorIndexWithBuffer does not support DocumentFetchOptions")
+		return err
 	}
-	if opts.Filter != nil || opts.IndexRangeFilter != nil {
+	if opts.Filter != nil {
 		buffer.Reset()
-		return errors.New("collections: vector index SearchVectorIndexWithBuffer does not support filters")
+		return collectionVectorIndexWithBufferUnsupportedOptionError("Filter", "filters are outside the exact no-document hnsw_search_pack_v1 route; use SearchVectorIndex for response-owned search or build a separate measured filtered path")
 	}
-	if opts.FetchMultiplier != 0 || opts.ExactFilterMaxDocs != 0 || opts.DisableExactFallback {
+	if opts.IndexRangeFilter != nil {
 		buffer.Reset()
-		return errors.New("collections: vector index SearchVectorIndexWithBuffer does not support legacy fallback/filter controls")
+		return collectionVectorIndexWithBufferUnsupportedOptionError("IndexRangeFilter", "filters are outside the exact no-document hnsw_search_pack_v1 route; use SearchVectorIndex for response-owned search or build a separate measured filtered path")
+	}
+	if opts.FetchMultiplier != 0 {
+		buffer.Reset()
+		return collectionVectorIndexWithBufferUnsupportedOptionError("FetchMultiplier", "the collection buffered route is pack-only and does not run legacy fallback or rerank controls")
+	}
+	if opts.ExactFilterMaxDocs != 0 {
+		buffer.Reset()
+		return collectionVectorIndexWithBufferUnsupportedOptionError("ExactFilterMaxDocs", "the collection buffered route is pack-only and does not run legacy fallback or filter controls")
+	}
+	if opts.DisableExactFallback {
+		buffer.Reset()
+		return collectionVectorIndexWithBufferUnsupportedOptionError("DisableExactFallback", "the collection buffered route already fails closed instead of falling back")
 	}
 	if opts.QueryMode != "" && opts.QueryMode != VectorIndexQueryModeExact {
 		buffer.Reset()
-		return fmt.Errorf("collections: vector index SearchVectorIndexWithBuffer supports only exact query mode, got %q", opts.QueryMode)
+		if opts.QueryMode == VectorIndexQueryModeQuantizedOnly || opts.QueryMode == VectorIndexQueryModeQuantizedRerank {
+			return collectionVectorIndexWithBufferUnsupportedOptionError(fmt.Sprintf("QueryMode=%q", opts.QueryMode), "collection buffered quantized search is not supported by this exact hnsw_search_pack_v1 route; use SearchVectorIndex or OpenVectorIndexSearcher plus SearchWithBuffer for supported quantized searches until a separate quantized buffered route is available")
+		}
+		return collectionVectorIndexWithBufferUnsupportedOptionError(fmt.Sprintf("QueryMode=%q", opts.QueryMode), "this API currently supports only exact/zero QueryMode on the no-document hnsw_search_pack_v1 route")
 	}
-	if opts.QuantizedIndexName != "" || opts.QuantizedRerankCandidates != 0 {
+	if opts.QuantizedIndexName != "" {
 		buffer.Reset()
-		return errors.New("collections: vector index SearchVectorIndexWithBuffer does not support quantized search options")
+		return collectionVectorIndexWithBufferUnsupportedOptionError("QuantizedIndexName", "quantized collection buffered search is not supported by this exact route; use SearchVectorIndex or OpenVectorIndexSearcher plus SearchWithBuffer for supported quantized searches")
+	}
+	if opts.QuantizedRerankCandidates != 0 {
+		buffer.Reset()
+		return collectionVectorIndexWithBufferUnsupportedOptionError("QuantizedRerankCandidates", "quantized collection buffered rerank is not supported by this exact route; use SearchVectorIndex or OpenVectorIndexSearcher plus SearchWithBuffer for supported quantized searches")
 	}
 	if opts.StatsMode == VectorIndexSearchStatsModeBenchmarkDebug {
 		buffer.Reset()
-		return errors.New("collections: vector index SearchVectorIndexWithBuffer does not support benchmark_debug stats mode")
+		return collectionVectorIndexWithBufferUnsupportedOptionError("StatsMode=benchmark_debug", "debug-only per-candidate/per-edge counters are outside the high-QPS buffered route; use SearchVectorIndex or OpenVectorIndexSearcher for diagnostic searches")
 	}
 	if _, err := columnVectorGraphNativeSearchStatsModeFromPublic(opts.StatsMode); err != nil {
 		buffer.Reset()
-		return err
+		return collectionVectorIndexWithBufferUnsupportedOptionError(fmt.Sprintf("StatsMode=%q", opts.StatsMode), err.Error())
+	}
+	return nil
+}
+
+func collectionVectorIndexWithBufferUnsupportedOptionError(option, guidance string) error {
+	return fmt.Errorf("%w: vector index SearchVectorIndexWithBuffer unsupported option %s: %s", ErrVectorIndexSearchUnavailable, option, guidance)
+}
+
+func collectionVectorIndexWithBufferDocumentFetchOptionsError(opts DocumentFetchOptions) error {
+	if len(opts.IncludePaths) > 0 {
+		return collectionVectorIndexWithBufferUnsupportedOptionError("DocumentFetchOptions.IncludePaths", "document projection requires materialization; use SearchVectorIndex with IncludeDocuments=true or fetch documents in a separate phase")
+	}
+	if len(opts.ExcludePaths) > 0 {
+		return collectionVectorIndexWithBufferUnsupportedOptionError("DocumentFetchOptions.ExcludePaths", "document projection requires materialization; use SearchVectorIndex with IncludeDocuments=true or fetch documents in a separate phase")
+	}
+	if opts.Format != "" {
+		return collectionVectorIndexWithBufferUnsupportedOptionError("DocumentFetchOptions.Format", "document format selection applies only to materialization; use SearchVectorIndex with IncludeDocuments=true or fetch documents in a separate phase")
+	}
+	if opts.ColumnAssetReadIntegrity != "" {
+		return collectionVectorIndexWithBufferUnsupportedOptionError("DocumentFetchOptions.ColumnAssetReadIntegrity", "document read-integrity controls apply only to materialization; use SearchVectorIndex with IncludeDocuments=true or fetch documents in a separate phase")
 	}
 	return nil
 }

--- a/TreeDB/collections/vector_index_search_test.go
+++ b/TreeDB/collections/vector_index_search_test.go
@@ -958,8 +958,8 @@ func TestSearchVectorIndexWithBufferPreparedCacheKeepsWarmStateOnQueryError2363(
 	badOpts := opts
 	badOpts.Query = []float32{1, 0}
 	bad, err := col.SearchVectorIndexWithBuffer(badOpts, &buffer)
-	if !errors.Is(err, errColumnVectorGraphNativeSearchQueryDimensionMismatch) {
-		t.Fatalf("bad query response=%+v err=%v want query dimension mismatch", bad, err)
+	if !errors.Is(err, errColumnVectorGraphNativeSearchQueryDimensionMismatch) || !strings.Contains(err.Error(), "hnsw_search_pack_v1 query dims=2 want 3") {
+		t.Fatalf("bad query response=%+v err=%v want hnsw_search_pack_v1 query dimension mismatch", bad, err)
 	}
 	if len(bad.Results) != 0 || len(buffer.results) != 0 || len(buffer.idBytes) != 0 {
 		t.Fatalf("bad query left results response=%d bufferResults=%d idBytes=%d", len(bad.Results), len(buffer.results), len(buffer.idBytes))
@@ -1002,8 +1002,8 @@ func TestSearchVectorIndexWithBufferPreparedCacheInvalidatesOnMutationAndRefresh
 	insertColumnGraphRebuildRowsV2A(t, col, []columnGraphRebuildInputRowV2A{{id: "doc-c", vector: []float32{0, 0, 1}}})
 	staleOpts := VectorIndexSearchOptions{IndexName: def.Name, Query: []float32{0, 0, 1}, TopK: 1, EfSearch: len(rows) + 1, MaxDecodedBlocks: 1}
 	stale, err := col.SearchVectorIndexWithBuffer(staleOpts, &buffer)
-	if err == nil {
-		t.Fatalf("stale SearchVectorIndexWithBuffer response=%+v err=nil want fail-closed error", stale)
+	if !errors.Is(err, ErrIndexNotFound) || !strings.Contains(err.Error(), "SearchVectorIndexWithBuffer requires a declared vector index") {
+		t.Fatalf("stale SearchVectorIndexWithBuffer response=%+v err=%v want fail-closed declared-index error", stale, err)
 	}
 	if len(stale.Results) != 0 || len(buffer.results) != 0 || len(buffer.idBytes) != 0 {
 		t.Fatalf("stale search left results response=%d bufferResults=%d idBytes=%d", len(stale.Results), len(buffer.results), len(buffer.idBytes))
@@ -1313,6 +1313,61 @@ func TestSearchVectorIndexWithBufferPreparedCacheConcurrentSharedState2363(t *te
 	}
 }
 
+func TestSearchVectorIndexWithBufferMissingIndexStateFailsClosed2408(t *testing.T) {
+	rows := []columnGraphRebuildInputRowV2A{
+		{id: "doc-a", vector: []float32{1, 0, 0}},
+		{id: "doc-b", vector: []float32{0, 1, 0}},
+	}
+	_, d, col, def := openColumnGraphRebuildTestCollectionV2A(t, 3, 1, rows)
+	defer func() { _ = d.Close() }()
+	base := VectorIndexSearchOptions{IndexName: def.Name, Query: []float32{1, 0, 0}, TopK: 1, EfSearch: len(rows), MaxDecodedBlocks: 1}
+	buffer := VectorIndexSearchBuffer{
+		results: []VectorIndexSearchResult{{ID: []byte("stale"), Score: 1}},
+		idBytes: []byte("stale"),
+	}
+
+	got, err := col.SearchVectorIndexWithBuffer(base, &buffer)
+	if !errors.Is(err, ErrIndexNotFound) || !strings.Contains(err.Error(), "SearchVectorIndexWithBuffer requires a declared vector index") || strings.Contains(err.Error(), "manifest") {
+		t.Fatalf("SearchVectorIndexWithBuffer missing state response=%+v err=%v want stable fail-closed declared-index error", got, err)
+	}
+	if len(got.Results) != 0 || len(buffer.results) != 0 || len(buffer.idBytes) != 0 {
+		t.Fatalf("missing state left results: returned=%d bufferResults=%d idBytes=%d", len(got.Results), len(buffer.results), len(buffer.idBytes))
+	}
+}
+
+func TestSearchVectorIndexWithBufferClosedDBFailsClosed2408(t *testing.T) {
+	rows := []columnGraphRebuildInputRowV2A{
+		{id: "doc-a", vector: []float32{1, 0, 0}},
+		{id: "doc-b", vector: []float32{0, 1, 0}},
+	}
+	_, d, col, def := openColumnGraphRebuildTestCollectionV2A(t, 3, 1, rows)
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		_ = d.Close()
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	base := VectorIndexSearchOptions{IndexName: def.Name, Query: []float32{1, 0, 0}, TopK: 1, EfSearch: len(rows), MaxDecodedBlocks: 1}
+	var buffer VectorIndexSearchBuffer
+	if _, err := col.SearchVectorIndexWithBuffer(base, &buffer); err != nil {
+		_ = d.Close()
+		t.Fatalf("warm SearchVectorIndexWithBuffer: %v", err)
+	}
+	if len(buffer.results) == 0 || len(buffer.idBytes) == 0 {
+		_ = d.Close()
+		t.Fatalf("warm buffer results=%d idBytes=%d want populated before closed DB case", len(buffer.results), len(buffer.idBytes))
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	got, err := col.SearchVectorIndexWithBuffer(base, &buffer)
+	if !errors.Is(err, backenddb.ErrClosed) {
+		t.Fatalf("SearchVectorIndexWithBuffer closed DB response=%+v err=%v want ErrClosed", got, err)
+	}
+	if len(got.Results) != 0 || len(buffer.results) != 0 || len(buffer.idBytes) != 0 {
+		t.Fatalf("closed DB left results: returned=%d bufferResults=%d idBytes=%d", len(got.Results), len(buffer.results), len(buffer.idBytes))
+	}
+}
+
 func TestSearchVectorIndexWithBufferUnsupportedShapesFailClosed2362(t *testing.T) {
 	rows := []columnGraphRebuildInputRowV2A{
 		{id: "doc-a", vector: []float32{1, 0, 0}},
@@ -1350,36 +1405,58 @@ func TestSearchVectorIndexWithBufferUnsupportedShapesFailClosed2362(t *testing.T
 	}
 
 	tests := []struct {
-		name    string
-		mutate  func(*VectorIndexSearchOptions)
-		wantErr string
+		name            string
+		mutate          func(*VectorIndexSearchOptions)
+		wantErrs        []string
+		wantUnavailable bool
 	}{
-		{name: "include_documents", mutate: func(opts *VectorIndexSearchOptions) { opts.IncludeDocuments = true }, wantErr: "IncludeDocuments"},
-		{name: "document_projection", mutate: func(opts *VectorIndexSearchOptions) { opts.DocumentFetchOptions.IncludePaths = []string{"did"} }, wantErr: "DocumentFetchOptions"},
+		{name: "include_documents", mutate: func(opts *VectorIndexSearchOptions) { opts.IncludeDocuments = true }, wantErrs: []string{"SearchVectorIndexWithBuffer", "IncludeDocuments=true", "no-document", "SearchVectorIndex with IncludeDocuments=true"}, wantUnavailable: true},
+		{name: "document_include_projection", mutate: func(opts *VectorIndexSearchOptions) { opts.DocumentFetchOptions.IncludePaths = []string{"did"} }, wantErrs: []string{"SearchVectorIndexWithBuffer", "DocumentFetchOptions.IncludePaths", "projection", "IncludeDocuments=true"}, wantUnavailable: true},
+		{name: "document_exclude_projection", mutate: func(opts *VectorIndexSearchOptions) { opts.DocumentFetchOptions.ExcludePaths = []string{"embedding"} }, wantErrs: []string{"SearchVectorIndexWithBuffer", "DocumentFetchOptions.ExcludePaths", "projection", "IncludeDocuments=true"}, wantUnavailable: true},
+		{name: "document_format", mutate: func(opts *VectorIndexSearchOptions) { opts.DocumentFetchOptions.Format = DocumentFormatJSON }, wantErrs: []string{"SearchVectorIndexWithBuffer", "DocumentFetchOptions.Format", "materialization"}, wantUnavailable: true},
 		{name: "document_integrity_option", mutate: func(opts *VectorIndexSearchOptions) {
 			opts.DocumentFetchOptions.ColumnAssetReadIntegrity = ColumnAssetReadIntegritySkipChecksums
-		}, wantErr: "DocumentFetchOptions"},
+		}, wantErrs: []string{"SearchVectorIndexWithBuffer", "DocumentFetchOptions.ColumnAssetReadIntegrity", "materialization"}, wantUnavailable: true},
 		{name: "filter", mutate: func(opts *VectorIndexSearchOptions) {
 			opts.Filter = func(DocumentRecord) (bool, error) { return true, nil }
-		}, wantErr: "filters"},
+		}, wantErrs: []string{"SearchVectorIndexWithBuffer", "Filter", "hnsw_search_pack_v1"}, wantUnavailable: true},
 		{name: "range_filter", mutate: func(opts *VectorIndexSearchOptions) {
 			opts.IndexRangeFilter = &VectorIndexRangeFilter{IndexName: "kind"}
-		}, wantErr: "filters"},
-		{name: "quantized_mode", mutate: func(opts *VectorIndexSearchOptions) {
+		}, wantErrs: []string{"SearchVectorIndexWithBuffer", "IndexRangeFilter", "hnsw_search_pack_v1"}, wantUnavailable: true},
+		{name: "fetch_multiplier", mutate: func(opts *VectorIndexSearchOptions) { opts.FetchMultiplier = 2 }, wantErrs: []string{"SearchVectorIndexWithBuffer", "FetchMultiplier", "pack-only"}, wantUnavailable: true},
+		{name: "exact_filter_max_docs", mutate: func(opts *VectorIndexSearchOptions) { opts.ExactFilterMaxDocs = 32 }, wantErrs: []string{"SearchVectorIndexWithBuffer", "ExactFilterMaxDocs", "pack-only"}, wantUnavailable: true},
+		{name: "disable_exact_fallback", mutate: func(opts *VectorIndexSearchOptions) { opts.DisableExactFallback = true }, wantErrs: []string{"SearchVectorIndexWithBuffer", "DisableExactFallback", "fails closed"}, wantUnavailable: true},
+		{name: "quantized_only_mode", mutate: func(opts *VectorIndexSearchOptions) {
 			opts.QueryMode = VectorIndexQueryModeQuantizedOnly
 			opts.QuantizedIndexName = "embedding.scalar_u8.fast"
-		}, wantErr: "only exact"},
-		{name: "quantized_option", mutate: func(opts *VectorIndexSearchOptions) { opts.QuantizedIndexName = "embedding.scalar_u8.fast" }, wantErr: "quantized"},
-		{name: "legacy_controls", mutate: func(opts *VectorIndexSearchOptions) { opts.FetchMultiplier = 2 }, wantErr: "legacy"},
-		{name: "benchmark_debug", mutate: func(opts *VectorIndexSearchOptions) { opts.StatsMode = VectorIndexSearchStatsModeBenchmarkDebug }, wantErr: "benchmark_debug"},
+		}, wantErrs: []string{"SearchVectorIndexWithBuffer", "QueryMode=\"quantized_only\"", "quantized", "OpenVectorIndexSearcher"}, wantUnavailable: true},
+		{name: "quantized_rerank_mode", mutate: func(opts *VectorIndexSearchOptions) {
+			opts.QueryMode = VectorIndexQueryModeQuantizedRerank
+			opts.QuantizedIndexName = "embedding.scalar_u8.fast"
+			opts.QuantizedRerankCandidates = 2
+		}, wantErrs: []string{"SearchVectorIndexWithBuffer", "QueryMode=\"quantized_rerank\"", "quantized", "OpenVectorIndexSearcher"}, wantUnavailable: true},
+		{name: "unknown_query_mode", mutate: func(opts *VectorIndexSearchOptions) { opts.QueryMode = VectorIndexQueryMode("future_mode") }, wantErrs: []string{"SearchVectorIndexWithBuffer", "QueryMode=\"future_mode\"", "exact/zero"}, wantUnavailable: true},
+		{name: "quantized_index_name_option", mutate: func(opts *VectorIndexSearchOptions) { opts.QuantizedIndexName = "embedding.scalar_u8.fast" }, wantErrs: []string{"SearchVectorIndexWithBuffer", "QuantizedIndexName", "quantized"}, wantUnavailable: true},
+		{name: "quantized_rerank_candidates_option", mutate: func(opts *VectorIndexSearchOptions) { opts.QuantizedRerankCandidates = 8 }, wantErrs: []string{"SearchVectorIndexWithBuffer", "QuantizedRerankCandidates", "quantized"}, wantUnavailable: true},
+		{name: "benchmark_debug", mutate: func(opts *VectorIndexSearchOptions) { opts.StatsMode = VectorIndexSearchStatsModeBenchmarkDebug }, wantErrs: []string{"SearchVectorIndexWithBuffer", "StatsMode=benchmark_debug", "debug-only"}, wantUnavailable: true},
+		{name: "unknown_stats_mode", mutate: func(opts *VectorIndexSearchOptions) { opts.StatsMode = VectorIndexSearchStatsMode("debug_everything") }, wantErrs: []string{"SearchVectorIndexWithBuffer", "StatsMode=\"debug_everything\"", "unsupported"}, wantUnavailable: true},
+		{name: "negative_max_decoded_blocks", mutate: func(opts *VectorIndexSearchOptions) { opts.MaxDecodedBlocks = -1 }, wantErrs: []string{"max_decoded_blocks", "cannot be negative"}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			opts := base
 			tt.mutate(&opts)
 			got, err := col.SearchVectorIndexWithBuffer(opts, &buffer)
-			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
-				t.Fatalf("SearchVectorIndexWithBuffer err=%v want substring %q", err, tt.wantErr)
+			if err == nil {
+				t.Fatalf("SearchVectorIndexWithBuffer err=nil want fail-closed error containing %v", tt.wantErrs)
+			}
+			for _, want := range tt.wantErrs {
+				if !strings.Contains(err.Error(), want) {
+					t.Fatalf("SearchVectorIndexWithBuffer err=%v want substring %q", err, want)
+				}
+			}
+			if tt.wantUnavailable && !errors.Is(err, ErrVectorIndexSearchUnavailable) {
+				t.Fatalf("SearchVectorIndexWithBuffer err=%v want ErrVectorIndexSearchUnavailable", err)
 			}
 			if len(got.Results) != 0 || len(buffer.results) != 0 || len(buffer.idBytes) != 0 {
 				t.Fatalf("unsupported shape left results: returned=%d bufferResults=%d idBytes=%d", len(got.Results), len(buffer.results), len(buffer.idBytes))


### PR DESCRIPTION
## Objective

Polish `Collection.SearchVectorIndexWithBuffer` fail-closed errors so unsupported high-QPS buffered shapes identify the exact option that disabled the exact no-document route and point users at the appropriate API boundary.

Closes #2408. Part of #2400.

## Context

#2360/#2379 established the warmed exact no-document `hnsw_search_pack_v1` collection buffered route. This PR keeps that route narrow and fail-closed while making rejection messages stable enough for tests/docs and less dependent on internal state details.

Base sync: branch was updated by merging latest `origin/main` (`dd3106637d416c51de395c3875c4747bd483d8b5`, #2420/#2406 docs) into `snissn/2408-manager` without force-push. Latest PR head: `220708fc4c40028c094efa713a2f75a136b8b073`.

## Non-goals

- No fallback from `SearchVectorIndexWithBuffer` into document materialization or legacy routes.
- No quantized collection-buffered support; `QueryMode`, `QuantizedIndexName`, and `QuantizedRerankCandidates` remain explicitly rejected for this exact route pending #2415.
- No docs/demo broadening in this PR.

## Design / Scope

- `TreeDB/collections/vector_index_search.go`
  - Adds option-specific `SearchVectorIndexWithBuffer` unsupported-option errors for documents/projection, filters, legacy filter/fallback controls, quantized options, and debug-only stats.
  - Keeps healthy exact no-document route behavior unchanged.
- `TreeDB/collections/collection_vector_index_prepared_search_cache.go`
  - Standardizes missing/unhealthy prepared state errors without exposing internal manifest/file details.
- `TreeDB/collections/vector_index_search_test.go`
  - Expands fail-closed option coverage, missing/closed state coverage, and dimension-mismatch assertions.

## Correctness

Tests run:

- `GOWORK=off go test ./TreeDB/collections -run 'TestSearchVectorIndexWithBuffer(MissingIndexStateFailsClosed2408|ClosedDBFailsClosed2408|UnsupportedShapesFailClosed2362|PreparedCacheKeepsWarmStateOnQueryError2363|PreparedCacheInvalidatesOnMutationAndRefreshesAfterRebuild2363)$' -count=1`
- `GOWORK=off go test ./TreeDB/collections -count=1`
- `GOWORK=off go test ./TreeDB/collections -run '^TestSearchVectorIndexWithBufferOpenScopedAllocationContract2362$' -count=1 -v`
- After merging latest `origin/main`: `GOWORK=off go test ./TreeDB/collections -count=1`

Covered edge cases:

- `IncludeDocuments=true`, `DocumentFetchOptions` projection/format/integrity, filters, legacy controls, quantized modes/options, benchmark-debug/unknown stats mode.
- Missing declared/current vector index state, closed DB, query dimension mismatch.
- Healthy route still succeeds after each rejection and resets caller-owned buffers on errors.

Latest-head CI: all checks green for `220708fc4c40028c094efa713a2f75a136b8b073` after base merge (Format; TreeDB vet/test including race/perf-smoke; root/unified/hashdb/read-snapshot/redis checks).

## Performance

- The added work on the healthy entry path is branch-only validation before the existing search; no search/scoring/cache behavior changed.
- Allocation contract preserved by `TestSearchVectorIndexWithBufferOpenScopedAllocationContract2362` (passes, asserts warmed route stays allocation-free).
- Optional usearch benchmark attempt was not runnable in this worktree because local CGo headers are unavailable:
  - `GOWORK=off go test -tags usearch_bench ./TreeDB/collections -run '^$' -bench '^BenchmarkCollectionVectorUSearchProductionCompare/TreeDB_CollectionSearchVectorIndexWithBuffer$' -benchtime=200x -count=3 -benchmem`
  - Result: build failed in `github.com/unum-cloud/usearch/golang` with `fatal error: 'usearch.h' file not found`.

## Coordination / Follow-ups

- #2406/#2420 is now merged into this branch. No code conflicts.
- #2409 should mirror the wording that collection buffered search is exact/no-document only and that documents/projections/filters/debug stats/quantized collection-buffered support require other APIs or follow-ups.
- #2415 should remain free to add a separate quantized buffered route later; this PR only clarifies the current fail-closed rejection.

## AI Review Loop

- Codex latest-head review: requested after base merge; completed with “Didn't find any major issues.”
- Copilot latest-head review: requested after base merge; no findings/comments observed beyond an eyes reaction on the request.
- CodeRabbit latest-head review: auto-attempted after base merge but skipped due organization review rate limit/usage credits; no actionable findings/threads were produced.
- Review threads: none open.
