### PR TITLE
docs: add Tier F vector search evidence command

### DIFF
--- a/TreeDB/docs/guides/vector-search-high-qps-collection-api.md
+++ b/TreeDB/docs/guides/vector-search-high-qps-collection-api.md
@@ -137,6 +137,28 @@ Canonical rows:
 - `USearch_Search` and `USearch_SearchParallel`: pure in-memory external ANN
   baseline.
 
+### Tier F no-document scaling command
+
+For 100k/128-class Tier F evidence, keep the same exact FP32 fixture and route
+contract but focus the benchmark regex on the no-document TreeDB rows and the
+USearch baseline. The with-documents/materialization row is intentionally
+excluded here because it is not part of the high-QPS no-document contract and can
+be measured separately as a document-fetch row.
+
+```sh
+TREEDB_VECTOR_BENCH_DOCS=100000 TREEDB_VECTOR_BENCH_DIMS=128 \
+  TREEDB_VECTOR_BENCH_M=16 TREEDB_VECTOR_BENCH_EF_CONSTRUCTION=128 \
+  TREEDB_VECTOR_BENCH_EF_SEARCH=128 TREEDB_VECTOR_BENCH_TOPK=10 \
+  TREEDB_VECTOR_BENCH_QUERIES=16 CPU_LIST=1,8 BENCHTIME=1000x COUNT=3 \
+  BENCH_REGEX='BenchmarkCollectionVectorUSearchProductionCompare/(TreeDB_SearchWithBuffer|TreeDB_SearchWithBufferParallel|TreeDB_CollectionSearchVectorIndexWithBuffer|TreeDB_CollectionSearchVectorIndexNoDocsOneShot|USearch_Search|USearch_SearchParallel)$' \
+  scripts/bench_vector_search_compare.sh
+```
+
+Report the same guardrail counters as the Tier S run, especially
+`search_route_hnsw_search_pack/search=1`, `hnsw_search_pack_active/search=1`,
+zero document/fallback/scratch counters, collection `open_*` counters at 0, and
+allocation accounting for the caller-owned-buffer rows.
+
 ## Profile capture notes
 
 For focused CPU profiles of the response-owned no-document convenience row,


### PR DESCRIPTION
## Summary

- Adds the documented Tier F 100k/128 no-document vector-search benchmark command.
- Keeps Tier F evidence scoped to exact FP32 `hnsw_search_pack_v1` no-document rows plus USearch baseline.
- Excludes the with-documents/materialization row from the Tier F command because it is not part of #2405's high-QPS no-document evidence scope.

Closes #2405. Parent: #2399.

## Scope / non-goals

No runtime optimization code changed. No shared traversal/scratch/result-buffer/stat files were edited, avoiding #2404/#2412 overlap. This PR does not claim quantized, with-document/materialization, filter, projection, or debug-only-route performance.

## Tier F evidence

Branch/head used for measurement: `snissn/2405-tierf-evidence` at `e8665627282628c828dfcdb2e6222db69935f92e` (same runtime code as this docs-only PR; latest PR head only rebases over docs changes). Hardware: Apple M3, 8 logical CPUs, 16 GiB RAM, `darwin/arm64`, Go `go1.25.5`.

Fixture/boundary: exact FP32 synthetic fixture, 100,000 docs, 128 dims, M=16, efConstruction=128, efSearch=128, topK=10, query stream length=16. TreeDB inserts/rebuild/open/warmup are outside timed search loops; timed rows use production stats mode with diagnostics sample outside the timer. USearch is pure in-memory F32/cosine HNSW baseline.

Command:

```sh
RUN_DIR=/tmp/gomap_2405_tierf_focused_20260605_112826 \
TREEDB_VECTOR_BENCH_DOCS=100000 \
TREEDB_VECTOR_BENCH_DIMS=128 \
TREEDB_VECTOR_BENCH_M=16 \
TREEDB_VECTOR_BENCH_EF_CONSTRUCTION=128 \
TREEDB_VECTOR_BENCH_EF_SEARCH=128 \
TREEDB_VECTOR_BENCH_TOPK=10 \
TREEDB_VECTOR_BENCH_QUERIES=16 \
CPU_LIST=1,8 \
BENCHTIME=1000x \
COUNT=3 \
BENCH_REGEX='BenchmarkCollectionVectorUSearchProductionCompare/(TreeDB_SearchWithBuffer|TreeDB_SearchWithBufferParallel|TreeDB_CollectionSearchVectorIndexWithBuffer|TreeDB_CollectionSearchVectorIndexNoDocsOneShot|USearch_Search|USearch_SearchParallel)$' \
scripts/bench_vector_search_compare.sh
```

Medians across `COUNT=3`:

| Row | c | ns/op | ops/sec | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: | ---: |
| `TreeDB_CollectionSearchVectorIndexWithBuffer` | 1 | 753,211 | 1,328 | 0 | 0 |
| `TreeDB_CollectionSearchVectorIndexWithBuffer` | 8 | 623,996 | 1,603 | 0 | 0 |
| `TreeDB_CollectionSearchVectorIndexNoDocsOneShot` | 1 | 850,574 | 1,176 | 816 | 2 |
| `TreeDB_CollectionSearchVectorIndexNoDocsOneShot` | 8 | 647,339 | 1,545 | 816 | 2 |
| `TreeDB_SearchWithBuffer` | 1 | 743,832 | 1,344 | 0 | 0 |
| `TreeDB_SearchWithBuffer` | 8 | 581,742 | 1,719 | 0 | 0 |
| `TreeDB_SearchWithBufferParallel` | 1 | 710,614 | 1,407 | 0 | 0 |
| `TreeDB_SearchWithBufferParallel` | 8 | 110,050 | 9,087 | 2 | 0 |
| `USearch_Search` | 1 | 526,142 | 1,901 | 136 | 3 |
| `USearch_Search` | 8 | 596,559 | 1,676 | 136 | 3 |
| `USearch_SearchParallel` | 1 | 551,315 | 1,814 | 136 | 3 |
| `USearch_SearchParallel` | 8 | 260,705 | 3,836 | 140 | 3 |

Guardrails for TreeDB no-doc rows: `search_route_hnsw_search_pack/search=1`, `hnsw_search_pack_active/search=1`, `docs_fetched/search=0`, `graph_row_fallbacks/search=0`, `typed_column_vector_fallbacks/search=0`, `vector_scratch_decodes/search=0`. Collection buffered and no-doc one-shot rows also report `open_searcher_calls/op=0`, `open_setup_in_timed_loop=0`. `Collection.SearchVectorIndexWithBuffer` remains `0 B/op`, `0 allocs/op`; no-doc one-shot remains response-owned at 816 B/op, 2 allocs/op. The c=8 reusable parallel 1000x row showed tiny `B/op` setup noise; dedicated allocation proof at `BENCHTIME=100000x` reports `0 B/op`, `0 allocs/op`.

## Profiles and artifacts

Main artifact directory: `/tmp/gomap_2405_tierf_focused_20260605_112826`

- Raw benchmark log: `/tmp/gomap_2405_tierf_focused_20260605_112826/bench.txt`
- Parsed summary: `/tmp/gomap_2405_tierf_focused_20260605_112826/parsed_summary.md`
- Handoff: `/tmp/gomap_2405_tierf_focused_20260605_112826/handoff.md`
- CPU/alloc profiles:
  - `profiles/collection_buffered_c1_cpu.pprof`, `profiles/collection_buffered_c1_cpu_top.txt`, `profiles/collection_buffered_c1_allocs.pprof`
  - `profiles/collection_nodocs_oneshot_c1_cpu.pprof`, `profiles/collection_nodocs_oneshot_c1_cpu_top.txt`, `profiles/collection_nodocs_oneshot_c1_allocs.pprof`
  - `profiles/collection_buffered_c8_cpu.pprof`, `profiles/collection_buffered_c8_cpu_top.txt`, `profiles/collection_buffered_c8_allocs.pprof`
  - `profiles/collection_nodocs_oneshot_c8_cpu.pprof`, `profiles/collection_nodocs_oneshot_c8_cpu_top.txt`, `profiles/collection_nodocs_oneshot_c8_allocs.pprof`
- Additional allocation proof: `/tmp/gomap_2405_tierf_focused_20260605_112826/alloc_proof/search_with_buffer_parallel_c8_100000x.log`

Profile caveat: Go benchmark CPU/mem profiles include parent setup/rebuild/build work before timed loops. The steady-state claims above are based on benchmark `ns/op`, `B/op`, `allocs/op`, and route counters. Search-related samples still show the expected HNSW traversal/scoring/dot/frontier work, not document fetch/open/setup/fallback/GC bottlenecks.

## Tier S vs Tier F bottleneck classification

- Tier F slows both TreeDB and USearch versus the Tier S 10k/64 closeout, but no guardrail shifted into documents, graph-row fallback, typed-column fallback, scratch decode, or per-query open/setup.
- The c=1 TreeDB-vs-USearch gap persists at roughly 1.4x for reusable/buffered rows and ~1.6x for response-owned no-doc one-shot, keeping #2401/#2403 as the likely single-query/scoring workstreams.
- c=8 reusable TreeDB parallel evidence is useful for #2402, but laptop c=8/USearch rows are noisy and should not be overclaimed.

## Tests

```sh
GOWORK=off go test ./TreeDB/docs -count=1
git diff --check
```

Latest-head CI for `1662713d61b9861c7215a0068d49bf4ebf692330` is green.

Internal xhigh review: PASS; no blocking findings. `@codex review` and `@copilot review` were requested after PR maturity. Codex reported no major issues. Copilot has not responded/appears unavailable for this PR. CodeRabbit auto-started on PR open but returned a rate-limit/credits notice and the check is marked skipped/success, so no manual CodeRabbit re-request has been made.
