### PR TITLE
Add quantized vector search route counters

### DIFF
--- a/TreeDB/collections/column_vector_graph_quantized_asset.go
+++ b/TreeDB/collections/column_vector_graph_quantized_asset.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"time"
 
 	"github.com/snissn/gomap/TreeDB/internal/columnsemantics"
 	"github.com/snissn/gomap/TreeDB/internal/quantizedasset"
@@ -22,11 +23,35 @@ type columnVectorGraphPreparedQuantizedAsset struct {
 	SchemaHash uint64
 }
 
+type columnVectorGraphQuantizedAssetHealth uint8
+
+const (
+	columnVectorGraphQuantizedAssetHealthUnknown columnVectorGraphQuantizedAssetHealth = iota
+	columnVectorGraphQuantizedAssetHealthHeapCopy
+	columnVectorGraphQuantizedAssetHealthMmapDirect
+	columnVectorGraphQuantizedAssetHealthMissing
+	columnVectorGraphQuantizedAssetHealthInvalid
+	columnVectorGraphQuantizedAssetHealthStale
+	columnVectorGraphQuantizedAssetHealthClosed
+)
+
+var (
+	errColumnVectorGraphQuantizedAssetMissing = errors.New("collections: column_graph quantized asset missing")
+	errColumnVectorGraphQuantizedAssetInvalid = errors.New("collections: column_graph quantized asset invalid")
+	errColumnVectorGraphQuantizedAssetStale   = errors.New("collections: column_graph quantized asset stale")
+	errColumnVectorGraphQuantizedAssetClosed  = errors.New("collections: column_graph quantized asset closed")
+)
+
 type columnVectorGraphQuantizedAssetLoadStatus struct {
-	Definition QuantizedVectorIndexDefinition
-	Asset      columnVectorIndexStateAssetSnapshot
-	Prepared   *quantizedasset.Prepared
-	Err        error
+	Definition    QuantizedVectorIndexDefinition
+	Asset         columnVectorIndexStateAssetSnapshot
+	Prepared      *quantizedasset.Prepared
+	Err           error
+	Health        columnVectorGraphQuantizedAssetHealth
+	OpenNanos     uint64
+	MappedBytes   uint64
+	HeapCopyBytes uint64
+	ActiveHandles int64
 }
 
 func columnVectorGraphQuantizedCodesAssetID(q QuantizedVectorIndexDefinition) string {
@@ -336,44 +361,151 @@ func loadColumnVectorGraphQuantizedAssetsForReader(rootDir, collection string, c
 		status := columnVectorGraphQuantizedAssetLoadStatus{Definition: q}
 		asset, ok := byName[q.Name]
 		if !ok {
-			status.Err = fmt.Errorf("quantized asset %q is missing", q.Name)
+			status.Health = columnVectorGraphQuantizedAssetHealthMissing
+			status.Err = fmt.Errorf("%w: quantized asset %q is missing", errColumnVectorGraphQuantizedAssetMissing, q.Name)
 			out[q.Name] = status
 			continue
 		}
 		status.Asset = asset
+		start := time.Now()
 		prepared, err := loadColumnVectorGraphQuantizedAsset(rootDir, collection, cfg, def, graph, q, asset)
+		status.OpenNanos = uint64(time.Since(start).Nanoseconds())
 		if err != nil {
 			status.Err = err
+			status.Health = columnVectorGraphQuantizedAssetHealthFromError(err)
 		} else {
 			status.Prepared = prepared
+			status.Health = columnVectorGraphQuantizedAssetHealthHeapCopy
+			if asset.AssetBytes > 0 {
+				status.HeapCopyBytes = uint64(asset.AssetBytes)
+			} else if prepared != nil {
+				fp := prepared.Footprint()
+				if fp.AssetBytes > 0 {
+					status.HeapCopyBytes = uint64(fp.AssetBytes)
+				}
+			}
 		}
 		out[q.Name] = status
 	}
 	return out
 }
 
+func columnVectorGraphQuantizedAssetHealthFromError(err error) columnVectorGraphQuantizedAssetHealth {
+	switch {
+	case errors.Is(err, errColumnVectorGraphQuantizedAssetMissing):
+		return columnVectorGraphQuantizedAssetHealthMissing
+	case errors.Is(err, errColumnVectorGraphQuantizedAssetStale):
+		return columnVectorGraphQuantizedAssetHealthStale
+	case errors.Is(err, errColumnVectorGraphQuantizedAssetClosed):
+		return columnVectorGraphQuantizedAssetHealthClosed
+	case errors.Is(err, errColumnVectorGraphQuantizedAssetInvalid):
+		return columnVectorGraphQuantizedAssetHealthInvalid
+	default:
+		return columnVectorGraphQuantizedAssetHealthInvalid
+	}
+}
+
+func (r *columnVectorGraphPhysicalRowReader) populateQuantizedAssetSearchStats(indexName string, stats *columnVectorGraphNativeSearchStats) {
+	if stats == nil || r == nil {
+		return
+	}
+	status, ok := r.quantizedAssetStatus[indexName]
+	if !ok {
+		status = columnVectorGraphQuantizedAssetLoadStatus{
+			Definition: QuantizedVectorIndexDefinition{Name: indexName},
+			Health:     columnVectorGraphQuantizedAssetHealthMissing,
+			Err:        fmt.Errorf("%w: quantized asset %q is not loaded", errColumnVectorGraphQuantizedAssetMissing, indexName),
+		}
+	}
+	status.populateSearchStats(stats)
+}
+
+func (s columnVectorGraphQuantizedAssetLoadStatus) populateSearchStats(stats *columnVectorGraphNativeSearchStats) {
+	if stats == nil {
+		return
+	}
+	stats.QuantizedAssetOpenNanos = s.OpenNanos
+	stats.QuantizedAssetMappedBytes = s.MappedBytes
+	stats.QuantizedAssetHeapCopyBytes = s.HeapCopyBytes
+	stats.QuantizedAssetActiveHandles = s.ActiveHandles
+	if s.Prepared != nil && s.Err == nil {
+		switch s.Health {
+		case columnVectorGraphQuantizedAssetHealthMmapDirect:
+			stats.QuantizedAssetMmapDirect = 1
+		default:
+			stats.QuantizedAssetHeapCopy = 1
+		}
+		return
+	}
+	health := s.Health
+	if health == columnVectorGraphQuantizedAssetHealthUnknown {
+		if s.Err == nil {
+			health = columnVectorGraphQuantizedAssetHealthMissing
+		} else {
+			health = columnVectorGraphQuantizedAssetHealthFromError(s.Err)
+		}
+	}
+	recordColumnVectorGraphQuantizedAssetUnavailable(stats, health)
+}
+
+func recordColumnVectorGraphQuantizedAssetUnavailable(stats *columnVectorGraphNativeSearchStats, health columnVectorGraphQuantizedAssetHealth) {
+	if stats == nil {
+		return
+	}
+	stats.QuantizedAssetMmapDirect = 0
+	stats.QuantizedAssetHeapCopy = 0
+	stats.QuantizedAssetMappedBytes = 0
+	stats.QuantizedAssetHeapCopyBytes = 0
+	stats.QuantizedAssetActiveHandles = 0
+	stats.QuantizedAssetMissing = 0
+	stats.QuantizedAssetInvalid = 0
+	stats.QuantizedAssetStale = 0
+	stats.QuantizedAssetClosed = 0
+	stats.QuantizedAssetUnavailable = 1
+	switch health {
+	case columnVectorGraphQuantizedAssetHealthStale:
+		stats.QuantizedAssetStale = 1
+	case columnVectorGraphQuantizedAssetHealthClosed:
+		stats.QuantizedAssetClosed = 1
+	case columnVectorGraphQuantizedAssetHealthInvalid:
+		stats.QuantizedAssetInvalid = 1
+	default:
+		stats.QuantizedAssetMissing = 1
+	}
+}
+
+func recordColumnVectorGraphQuantizedAssetErrorStats(stats *columnVectorGraphNativeSearchStats, err error) {
+	if stats == nil || err == nil {
+		return
+	}
+	if !errors.Is(err, errColumnVectorGraphQuantizedAssetMissing) && !errors.Is(err, errColumnVectorGraphQuantizedAssetInvalid) && !errors.Is(err, errColumnVectorGraphQuantizedAssetStale) && !errors.Is(err, errColumnVectorGraphQuantizedAssetClosed) {
+		return
+	}
+	recordColumnVectorGraphQuantizedAssetUnavailable(stats, columnVectorGraphQuantizedAssetHealthFromError(err))
+}
+
 func loadColumnVectorGraphQuantizedAsset(rootDir, collection string, cfg ColumnStoreConfig, def VectorIndexDefinition, graph columnVectorGraphManifestSnapshot, q QuantizedVectorIndexDefinition, asset columnVectorIndexStateAssetSnapshot) (*quantizedasset.Prepared, error) {
 	sourceCfg, err := columnVectorGraphQuantizedCodesColumnStoreConfig(collection, cfg, def, q)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: quantized asset %q config: %v", errColumnVectorGraphQuantizedAssetInvalid, q.Name, err)
 	}
 	if asset.SourceSchemaHash != sourceCfg.SchemaHash {
-		return nil, fmt.Errorf("quantized asset %q schema_hash=%d want %d", q.Name, asset.SourceSchemaHash, sourceCfg.SchemaHash)
+		return nil, fmt.Errorf("%w: quantized asset %q schema_hash=%d want %d", errColumnVectorGraphQuantizedAssetStale, q.Name, asset.SourceSchemaHash, sourceCfg.SchemaHash)
 	}
 	if err := validateColumnVectorIndexStateAssetRefAvailable(rootDir, asset); err != nil {
-		return nil, fmt.Errorf("quantized asset %q unavailable: %w", q.Name, err)
+		return nil, fmt.Errorf("%w: quantized asset %q unavailable: %v", errColumnVectorGraphQuantizedAssetMissing, q.Name, err)
 	}
 	raw, err := readColumnPhysicalAssetFromManager(rootDir, asset.Ref)
 	if err != nil {
-		return nil, fmt.Errorf("quantized asset %q read: %w", q.Name, err)
+		return nil, fmt.Errorf("%w: quantized asset %q read: %v", errColumnVectorGraphQuantizedAssetInvalid, q.Name, err)
 	}
 	image, err := typedcolumn.ParseColumnPartImage(raw)
 	if err != nil {
-		return nil, fmt.Errorf("quantized asset %q parse typed-column image: %w", q.Name, err)
+		return nil, fmt.Errorf("%w: quantized asset %q parse typed-column image: %v", errColumnVectorGraphQuantizedAssetInvalid, q.Name, err)
 	}
 	ref := columnVectorGraphQuantizedAssetRefIdentity(asset.Ref)
 	schema := columnVectorGraphQuantizedAssetSchema(def, graph, q, asset, ref)
-	return quantizedasset.Prepare(quantizedasset.PrepareRequest{
+	prepared, err := quantizedasset.Prepare(quantizedasset.PrepareRequest{
 		Schema: schema,
 		Expected: quantizedasset.ExpectedSchema{
 			Metric:           schema.Metric,
@@ -388,6 +520,10 @@ func loadColumnVectorGraphQuantizedAsset(rootDir, collection string, cfg ColumnS
 		},
 		Parts: []quantizedasset.PartImageSource{{Image: image, Ref: ref, AssetBytes: asset.AssetBytes, SourceSchemaHash: asset.SourceSchemaHash}},
 	})
+	if err != nil {
+		return nil, fmt.Errorf("%w: quantized asset %q prepare: %v", errColumnVectorGraphQuantizedAssetInvalid, q.Name, err)
+	}
+	return prepared, nil
 }
 
 func columnVectorGraphQuantizedAssetSchema(def VectorIndexDefinition, graph columnVectorGraphManifestSnapshot, q QuantizedVectorIndexDefinition, asset columnVectorIndexStateAssetSnapshot, ref quantizedasset.AssetRefIdentity) quantizedasset.SchemaDescriptor {

--- a/TreeDB/collections/column_vector_graph_quantized_bench_test.go
+++ b/TreeDB/collections/column_vector_graph_quantized_bench_test.go
@@ -317,9 +317,23 @@ func addColumnGraphScalarU8QuantizedBenchmarkStats1926(dst *VectorIndexSearchSta
 	dst.QuantizedCodeBytesRead += src.QuantizedCodeBytesRead
 	dst.QuantizedRerankCandidates += src.QuantizedRerankCandidates
 	dst.QuantizedRerankExactScoreCalls += src.QuantizedRerankExactScoreCalls
+	dst.QuantizedScorerActive += src.QuantizedScorerActive
+	dst.QuantizedAssetMissing += src.QuantizedAssetMissing
+	dst.QuantizedAssetInvalid += src.QuantizedAssetInvalid
+	dst.QuantizedAssetStale += src.QuantizedAssetStale
+	dst.QuantizedAssetClosed += src.QuantizedAssetClosed
+	dst.QuantizedAssetUnavailable += src.QuantizedAssetUnavailable
+	dst.QuantizedAssetMmapDirect += src.QuantizedAssetMmapDirect
+	dst.QuantizedAssetHeapCopy += src.QuantizedAssetHeapCopy
+	dst.QuantizedAssetOpenNanos += src.QuantizedAssetOpenNanos
+	dst.QuantizedAssetMappedBytes += src.QuantizedAssetMappedBytes
+	dst.QuantizedAssetHeapCopyBytes += src.QuantizedAssetHeapCopyBytes
+	dst.QuantizedAssetActiveHandles += src.QuantizedAssetActiveHandles
 	dst.ScoreFloat64Fallbacks += src.ScoreFloat64Fallbacks
 	dst.PreparedGraphSearchViews += src.PreparedGraphSearchViews
 	dst.GraphRowFallbacks += src.GraphRowFallbacks
+	dst.SearchRouteQuantizedOnly += src.SearchRouteQuantizedOnly
+	dst.SearchRouteQuantizedRerank += src.SearchRouteQuantizedRerank
 	dst.TypedColumnFallbacks += src.TypedColumnFallbacks
 	dst.AdjacencyLegacyFallbacks += src.AdjacencyLegacyFallbacks
 	dst.AdjacencySourceFallbacks += src.AdjacencySourceFallbacks
@@ -424,9 +438,23 @@ func reportColumnGraphScalarU8QuantizedScorePlaneMetrics1926(b *testing.B, fixtu
 	b.ReportMetric(float64(stats.QuantizedCodeBytesRead)/denom, "quantized_code_B/search")
 	b.ReportMetric(float64(stats.QuantizedRerankCandidates)/denom, "quantized_rerank_candidates/search")
 	b.ReportMetric(float64(stats.QuantizedRerankExactScoreCalls)/denom, "quantized_rerank_exact_score_calls/search")
+	b.ReportMetric(float64(stats.QuantizedScorerActive)/denom, "quantized_scorer_active/search")
+	b.ReportMetric(float64(stats.QuantizedAssetMissing)/denom, "quantized_asset_missing/search")
+	b.ReportMetric(float64(stats.QuantizedAssetInvalid)/denom, "quantized_asset_invalid/search")
+	b.ReportMetric(float64(stats.QuantizedAssetStale)/denom, "quantized_asset_stale/search")
+	b.ReportMetric(float64(stats.QuantizedAssetClosed)/denom, "quantized_asset_closed/search")
+	b.ReportMetric(float64(stats.QuantizedAssetUnavailable)/denom, "quantized_asset_unavailable/search")
+	b.ReportMetric(float64(stats.QuantizedAssetMmapDirect)/denom, "quantized_asset_mmap_direct/search")
+	b.ReportMetric(float64(stats.QuantizedAssetHeapCopy)/denom, "quantized_asset_heap_copy/search")
+	b.ReportMetric(float64(stats.QuantizedAssetOpenNanos)/denom, "quantized_asset_open_ns")
+	b.ReportMetric(float64(stats.QuantizedAssetMappedBytes)/denom, "quantized_asset_mapped_B")
+	b.ReportMetric(float64(stats.QuantizedAssetHeapCopyBytes)/denom, "quantized_asset_heap_copy_B")
+	b.ReportMetric(float64(stats.QuantizedAssetActiveHandles)/denom, "quantized_asset_active_handles")
 	b.ReportMetric(float64(stats.ScoreFloat64Fallbacks)/denom, "score_float64_fallbacks/search")
 	b.ReportMetric(float64(stats.PreparedGraphSearchViews)/denom, "prepared_graph_search_views/search")
 	b.ReportMetric(float64(stats.GraphRowFallbacks)/denom, "graph_row_fallbacks/search")
+	b.ReportMetric(float64(stats.SearchRouteQuantizedOnly)/denom, "search_route_quantized_only/search")
+	b.ReportMetric(float64(stats.SearchRouteQuantizedRerank)/denom, "search_route_quantized_rerank/search")
 	b.ReportMetric(float64(stats.TypedColumnFallbacks)/denom, "typed_column_vector_fallbacks/search")
 	b.ReportMetric(float64(stats.AdjacencyLegacyFallbacks)/denom, "adjacency_legacy_fallbacks/search")
 	b.ReportMetric(float64(stats.AdjacencySourceFallbacks)/denom, "adjacency_source_fallbacks/search")

--- a/TreeDB/collections/column_vector_graph_quantized_scorer.go
+++ b/TreeDB/collections/column_vector_graph_quantized_scorer.go
@@ -25,26 +25,26 @@ func (r *columnVectorGraphPhysicalRowReader) prepareScalarU8QuantizedScorer(mode
 	}
 	status, ok := r.quantizedAssetStatus[indexName]
 	if !ok {
-		return columnVectorGraphScalarU8QuantizedScorer{}, fmt.Errorf("%w: column_graph %q query_mode=%s quantized index %q has no prepared quantized score-plane asset", ErrVectorIndexSearchUnavailable, r.def.Name, mode.String(), indexName)
+		return columnVectorGraphScalarU8QuantizedScorer{}, fmt.Errorf("%w: %w: column_graph %q query_mode=%s quantized index %q has no prepared quantized score-plane asset", ErrVectorIndexSearchUnavailable, errColumnVectorGraphQuantizedAssetMissing, r.def.Name, mode.String(), indexName)
 	}
 	if status.Err != nil {
 		return columnVectorGraphScalarU8QuantizedScorer{}, fmt.Errorf("%w: column_graph %q query_mode=%s quantized index %q score-plane asset unavailable: %w", ErrVectorIndexSearchUnavailable, r.def.Name, mode.String(), indexName, status.Err)
 	}
 	if status.Prepared == nil {
-		return columnVectorGraphScalarU8QuantizedScorer{}, fmt.Errorf("%w: column_graph %q query_mode=%s quantized index %q has no prepared quantized score-plane asset", ErrVectorIndexSearchUnavailable, r.def.Name, mode.String(), indexName)
+		return columnVectorGraphScalarU8QuantizedScorer{}, fmt.Errorf("%w: %w: column_graph %q query_mode=%s quantized index %q has no prepared quantized score-plane asset", ErrVectorIndexSearchUnavailable, errColumnVectorGraphQuantizedAssetMissing, r.def.Name, mode.String(), indexName)
 	}
 	qdef, ok := findQuantizedVectorIndex(r.def, indexName)
 	if !ok {
 		return columnVectorGraphScalarU8QuantizedScorer{}, fmt.Errorf("%w: column_graph %q quantized index %q is not declared", ErrVectorIndexSearchUnavailable, r.def.Name, indexName)
 	}
 	if status.Definition != qdef {
-		return columnVectorGraphScalarU8QuantizedScorer{}, fmt.Errorf("%w: column_graph %q query_mode=%s quantized index %q prepared definition mismatch", ErrVectorIndexSearchUnavailable, r.def.Name, mode.String(), indexName)
+		return columnVectorGraphScalarU8QuantizedScorer{}, fmt.Errorf("%w: %w: column_graph %q query_mode=%s quantized index %q prepared definition mismatch", ErrVectorIndexSearchUnavailable, errColumnVectorGraphQuantizedAssetStale, r.def.Name, mode.String(), indexName)
 	}
 	if qdef.Codec != QuantizedVectorCodecScalarU8 || qdef.Version != 1 {
-		return columnVectorGraphScalarU8QuantizedScorer{}, fmt.Errorf("%w: column_graph %q quantized index %q codec/version=(%q,%d) is not scalar_u8 v1", ErrVectorIndexSearchUnavailable, r.def.Name, indexName, qdef.Codec, qdef.Version)
+		return columnVectorGraphScalarU8QuantizedScorer{}, fmt.Errorf("%w: %w: column_graph %q quantized index %q codec/version=(%q,%d) is not scalar_u8 v1", ErrVectorIndexSearchUnavailable, errColumnVectorGraphQuantizedAssetInvalid, r.def.Name, indexName, qdef.Codec, qdef.Version)
 	}
 	if r.def.Metric != VectorMetricCosine {
-		return columnVectorGraphScalarU8QuantizedScorer{}, fmt.Errorf("%w: column_graph %q quantized index %q metric %q is unsupported for scalar_u8 scorer", ErrVectorIndexSearchUnavailable, r.def.Name, indexName, r.def.Metric)
+		return columnVectorGraphScalarU8QuantizedScorer{}, fmt.Errorf("%w: %w: column_graph %q quantized index %q metric %q is unsupported for scalar_u8 scorer", ErrVectorIndexSearchUnavailable, errColumnVectorGraphQuantizedAssetInvalid, r.def.Name, indexName, r.def.Metric)
 	}
 	if len(query) != r.def.Dimensions {
 		return columnVectorGraphScalarU8QuantizedScorer{}, fmt.Errorf("collections: column_graph %q query dims=%d want %d: %w", r.def.Name, len(query), r.def.Dimensions, errColumnVectorGraphNativeSearchQueryDimensionMismatch)
@@ -54,24 +54,24 @@ func (r *columnVectorGraphPhysicalRowReader) prepareScalarU8QuantizedScorer(mode
 	}
 	prepared := status.Prepared
 	if prepared.Rows() != r.RowCount() {
-		return columnVectorGraphScalarU8QuantizedScorer{}, fmt.Errorf("%w: column_graph %q query_mode=%s quantized index %q prepared rows=%d want graph rows=%d", ErrVectorIndexSearchUnavailable, r.def.Name, mode.String(), indexName, prepared.Rows(), r.RowCount())
+		return columnVectorGraphScalarU8QuantizedScorer{}, fmt.Errorf("%w: %w: column_graph %q query_mode=%s quantized index %q prepared rows=%d want graph rows=%d", ErrVectorIndexSearchUnavailable, errColumnVectorGraphQuantizedAssetStale, r.def.Name, mode.String(), indexName, prepared.Rows(), r.RowCount())
 	}
 	codeRows, ok := prepared.CodeRowView(quantizedasset.RoleCodes)
 	if !ok {
-		return columnVectorGraphScalarU8QuantizedScorer{}, fmt.Errorf("%w: column_graph %q query_mode=%s quantized index %q code row view unavailable", ErrVectorIndexSearchUnavailable, r.def.Name, mode.String(), indexName)
+		return columnVectorGraphScalarU8QuantizedScorer{}, fmt.Errorf("%w: %w: column_graph %q query_mode=%s quantized index %q code row view unavailable", ErrVectorIndexSearchUnavailable, errColumnVectorGraphQuantizedAssetInvalid, r.def.Name, mode.String(), indexName)
 	}
 	if codeRows.Rows() != r.RowCount() {
-		return columnVectorGraphScalarU8QuantizedScorer{}, fmt.Errorf("%w: column_graph %q query_mode=%s quantized index %q code row view rows=%d want graph rows=%d", ErrVectorIndexSearchUnavailable, r.def.Name, mode.String(), indexName, codeRows.Rows(), r.RowCount())
+		return columnVectorGraphScalarU8QuantizedScorer{}, fmt.Errorf("%w: %w: column_graph %q query_mode=%s quantized index %q code row view rows=%d want graph rows=%d", ErrVectorIndexSearchUnavailable, errColumnVectorGraphQuantizedAssetStale, r.def.Name, mode.String(), indexName, codeRows.Rows(), r.RowCount())
 	}
 	if bytesPerRow := codeRows.BytesPerRow(); bytesPerRow != r.def.Dimensions {
-		return columnVectorGraphScalarU8QuantizedScorer{}, fmt.Errorf("%w: column_graph %q query_mode=%s quantized index %q code bytes_per_row=%d want dimensions=%d", ErrVectorIndexSearchUnavailable, r.def.Name, mode.String(), indexName, bytesPerRow, r.def.Dimensions)
+		return columnVectorGraphScalarU8QuantizedScorer{}, fmt.Errorf("%w: %w: column_graph %q query_mode=%s quantized index %q code bytes_per_row=%d want dimensions=%d", ErrVectorIndexSearchUnavailable, errColumnVectorGraphQuantizedAssetInvalid, r.def.Name, mode.String(), indexName, bytesPerRow, r.def.Dimensions)
 	}
 	if elements := codeRows.ElementsPerRow(); elements != r.def.Dimensions {
-		return columnVectorGraphScalarU8QuantizedScorer{}, fmt.Errorf("%w: column_graph %q query_mode=%s quantized index %q code elements_per_row=%d want dimensions=%d", ErrVectorIndexSearchUnavailable, r.def.Name, mode.String(), indexName, elements, r.def.Dimensions)
+		return columnVectorGraphScalarU8QuantizedScorer{}, fmt.Errorf("%w: %w: column_graph %q query_mode=%s quantized index %q code elements_per_row=%d want dimensions=%d", ErrVectorIndexSearchUnavailable, errColumnVectorGraphQuantizedAssetInvalid, r.def.Name, mode.String(), indexName, elements, r.def.Dimensions)
 	}
 	codePayload, ok := codeRows.PayloadBytes()
 	if !ok || len(codePayload) != r.RowCount()*r.def.Dimensions {
-		return columnVectorGraphScalarU8QuantizedScorer{}, fmt.Errorf("%w: column_graph %q query_mode=%s quantized index %q code row payload bytes=%d ok=%v want %d", ErrVectorIndexSearchUnavailable, r.def.Name, mode.String(), indexName, len(codePayload), ok, r.RowCount()*r.def.Dimensions)
+		return columnVectorGraphScalarU8QuantizedScorer{}, fmt.Errorf("%w: %w: column_graph %q query_mode=%s quantized index %q code row payload bytes=%d ok=%v want %d", ErrVectorIndexSearchUnavailable, errColumnVectorGraphQuantizedAssetInvalid, r.def.Name, mode.String(), indexName, len(codePayload), ok, r.RowCount()*r.def.Dimensions)
 	}
 	queryCode := resizeColumnVectorGraphNativeByteScratch(scratch.quantizedQueryCodes, r.def.Dimensions)
 	for _, value := range query {
@@ -81,7 +81,7 @@ func (r *columnVectorGraphPhysicalRowReader) prepareScalarU8QuantizedScorer(mode
 	centeredScratch := resizeColumnVectorGraphNativeScalarU8CenteredScratch(scratch.quantizedQueryCentered, r.def.Dimensions)
 	centeredQuery, centeredScratch, ok := vectorops.PrepareScalarU8CenteredQuery(centeredScratch, queryCode, r.def.Dimensions)
 	if !ok {
-		return columnVectorGraphScalarU8QuantizedScorer{}, fmt.Errorf("%w: column_graph %q query_mode=%s quantized index %q centered scalar_u8 query unavailable", ErrVectorIndexSearchUnavailable, r.def.Name, mode.String(), indexName)
+		return columnVectorGraphScalarU8QuantizedScorer{}, fmt.Errorf("%w: %w: column_graph %q query_mode=%s quantized index %q centered scalar_u8 query unavailable", ErrVectorIndexSearchUnavailable, errColumnVectorGraphQuantizedAssetInvalid, r.def.Name, mode.String(), indexName)
 	}
 	scratch.quantizedQueryCentered = centeredScratch
 	return columnVectorGraphScalarU8QuantizedScorer{indexName: indexName, dims: r.def.Dimensions, codeRows: codeRows, codePayload: codePayload, queryCode: queryCode, centeredQuery: centeredQuery}, nil

--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -365,6 +365,18 @@ type columnVectorGraphNativeSearchStats struct {
 	QuantizedCodeBytesRead               uint64
 	QuantizedRerankCandidates            uint64
 	QuantizedRerankExactScoreCalls       uint64
+	QuantizedScorerActive                uint64
+	QuantizedAssetMissing                uint64
+	QuantizedAssetInvalid                uint64
+	QuantizedAssetStale                  uint64
+	QuantizedAssetClosed                 uint64
+	QuantizedAssetUnavailable            uint64
+	QuantizedAssetMmapDirect             uint64
+	QuantizedAssetHeapCopy               uint64
+	QuantizedAssetOpenNanos              uint64
+	QuantizedAssetMappedBytes            uint64
+	QuantizedAssetHeapCopyBytes          uint64
+	QuantizedAssetActiveHandles          int64
 	ScoreFloat64Fallbacks                uint64
 	BlockViewHits                        uint64
 	BlockViewMisses                      uint64
@@ -434,6 +446,8 @@ type columnVectorGraphNativeSearchStats struct {
 	ResultIDStateValidationFailures      uint64
 	PreparedGraphSearchViews             uint64
 	GraphRowFallbacks                    uint64
+	SearchRouteQuantizedOnly             uint64
+	SearchRouteQuantizedRerank           uint64
 
 	WavefrontSearches        uint64
 	WavefrontWidth           uint64
@@ -1258,8 +1272,16 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 	if err != nil {
 		return nil, columnVectorGraphNativeSearchStats{}, fmt.Errorf("collections: column_graph %q native search query mode: %w", r.def.Name, err)
 	}
+	if queryMode == columnVectorGraphNativeSearchQueryModeQuantizedOnly {
+		stats.SearchRouteQuantizedOnly = 1
+	} else if queryMode == columnVectorGraphNativeSearchQueryModeQuantizedRerank {
+		stats.SearchRouteQuantizedRerank = 1
+	}
+	if queryMode.quantized() {
+		r.populateQuantizedAssetSearchStats(opts.QuantizedIndexName, &stats)
+	}
 	if err := r.validateQuantizedNativeSearchOptions(queryMode, opts); err != nil {
-		return nil, columnVectorGraphNativeSearchStats{}, err
+		return nil, stats, err
 	}
 	rowCount := r.RowCount()
 	topK := opts.TopK
@@ -1390,9 +1412,11 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 	if queryMode.quantized() {
 		plan.quantizedScorer, err = r.prepareScalarU8QuantizedScorer(queryMode, opts.QuantizedIndexName, query, queryInvNorm, scratch)
 		if err != nil {
+			recordColumnVectorGraphQuantizedAssetErrorStats(&stats, err)
 			return nil, stats, err
 		}
 		plan.quantizedScorerActive = true
+		stats.QuantizedScorerActive = 1
 	}
 	plan.scoreBatchMode = columnVectorGraphScoreBatchModeForSearchPlan(opts.ScoreBatchMode, plan)
 	if traversalMode == columnVectorGraphNativeSearchTraversalModeWavefront {

--- a/TreeDB/collections/vector_index_search.go
+++ b/TreeDB/collections/vector_index_search.go
@@ -163,6 +163,30 @@ type VectorIndexSearchStats struct {
 	QuantizedRerankCandidates uint64 `json:"quantized_rerank_candidates,omitempty"`
 	// QuantizedRerankExactScoreCalls counts exact float32/norm score calls used by quantized_rerank.
 	QuantizedRerankExactScoreCalls uint64 `json:"quantized_rerank_exact_score_calls,omitempty"`
+	// QuantizedScorerActive reports that a validated quantized scorer served this search.
+	QuantizedScorerActive uint64 `json:"quantized_scorer_active,omitempty"`
+	// QuantizedAssetMissing reports that the selected quantized score-plane asset was absent.
+	QuantizedAssetMissing uint64 `json:"quantized_asset_missing,omitempty"`
+	// QuantizedAssetInvalid reports that the selected quantized score-plane asset failed validation or decode.
+	QuantizedAssetInvalid uint64 `json:"quantized_asset_invalid,omitempty"`
+	// QuantizedAssetStale reports that the selected quantized score-plane asset did not match the current graph/index identity.
+	QuantizedAssetStale uint64 `json:"quantized_asset_stale,omitempty"`
+	// QuantizedAssetClosed reports that the selected quantized score-plane asset was closed before use.
+	QuantizedAssetClosed uint64 `json:"quantized_asset_closed,omitempty"`
+	// QuantizedAssetUnavailable aggregates missing, invalid, stale, or closed quantized score-plane asset failures.
+	QuantizedAssetUnavailable uint64 `json:"quantized_asset_unavailable,omitempty"`
+	// QuantizedAssetMmapDirect reports searches with a validated direct mmap quantized score-plane asset bound to the searcher.
+	QuantizedAssetMmapDirect uint64 `json:"quantized_asset_mmap_direct,omitempty"`
+	// QuantizedAssetHeapCopy reports searches with a validated heap-copy quantized score-plane asset bound to the searcher.
+	QuantizedAssetHeapCopy uint64 `json:"quantized_asset_heap_copy,omitempty"`
+	// QuantizedAssetOpenNanos reports open/prepare time for the selected quantized score-plane asset.
+	QuantizedAssetOpenNanos uint64 `json:"quantized_asset_open_nanos,omitempty"`
+	// QuantizedAssetMappedBytes is the mapped byte total backing the selected quantized score-plane asset.
+	QuantizedAssetMappedBytes uint64 `json:"quantized_asset_mapped_bytes,omitempty"`
+	// QuantizedAssetHeapCopyBytes is the heap-copy byte total backing the selected quantized score-plane asset.
+	QuantizedAssetHeapCopyBytes uint64 `json:"quantized_asset_heap_copy_bytes,omitempty"`
+	// QuantizedAssetActiveHandles is the current active mappedresource handle count for the selected quantized score-plane asset.
+	QuantizedAssetActiveHandles int64 `json:"quantized_asset_active_handles,omitempty"`
 	// ScoreFloat64Fallbacks counts rare dot-product retries using float64 after a non-finite float32 dot.
 	ScoreFloat64Fallbacks uint64 `json:"score_float64_fallbacks,omitempty"`
 	// ExpansionFetches is the per-search count of adjacency row fetches for expanded nodes.
@@ -405,6 +429,10 @@ type VectorIndexSearchStats struct {
 	SearchRouteColumnGraphFallback uint64 `json:"search_route_column_graph_fallback,omitempty"`
 	// SearchRouteHNSWSearchPack reports that this search used the future hnsw_search_pack_v1 route.
 	SearchRouteHNSWSearchPack uint64 `json:"search_route_hnsw_search_pack,omitempty"`
+	// SearchRouteQuantizedOnly reports that this search used the codec-generic quantized-only route.
+	SearchRouteQuantizedOnly uint64 `json:"search_route_quantized_only,omitempty"`
+	// SearchRouteQuantizedRerank reports that this search used the codec-generic quantized-rerank route.
+	SearchRouteQuantizedRerank uint64 `json:"search_route_quantized_rerank,omitempty"`
 	// HNSWSearchPackActive reports that a validated hnsw_search_pack_v1 served this search.
 	HNSWSearchPackActive uint64 `json:"hnsw_search_pack_active,omitempty"`
 	// HNSWSearchPackMissing reports that no hnsw_search_pack_v1 was available for this searcher.
@@ -652,11 +680,36 @@ func vectorIndexSearchRouteStatsForHNSWSearchPackFastStatus(cached vectorIndexSe
 	return stats
 }
 
+func vectorIndexSearchRouteStatsForColumnGraphQuantized(cached vectorIndexSearchRouteStats) vectorIndexSearchRouteStats {
+	stats := cached
+	stats.SearchRouteHNSWSearchPack = 0
+	stats.clearHNSWSearchPackCounters()
+	if stats.SearchRouteColumnGraphPrepared == 0 && stats.SearchRouteColumnGraphFallback == 0 {
+		stats.SearchRouteColumnGraphFallback = 1
+	}
+	return stats
+}
+
+func vectorIndexSearchRouteStatsForQueryMode(cached vectorIndexSearchRouteStats, queryMode columnVectorGraphNativeSearchQueryMode) vectorIndexSearchRouteStats {
+	if queryMode.quantized() {
+		return vectorIndexSearchRouteStatsForColumnGraphQuantized(cached)
+	}
+	return cached
+}
+
 func (r *vectorIndexSearchRouteStats) clearHNSWSearchPackAvailability() {
 	if r == nil {
 		return
 	}
 	openNanos := r.HNSWSearchPackOpenNanos
+	r.clearHNSWSearchPackCounters()
+	r.HNSWSearchPackOpenNanos = openNanos
+}
+
+func (r *vectorIndexSearchRouteStats) clearHNSWSearchPackCounters() {
+	if r == nil {
+		return
+	}
 	r.HNSWSearchPackActive = 0
 	r.HNSWSearchPackMissing = 0
 	r.HNSWSearchPackInvalid = 0
@@ -665,7 +718,7 @@ func (r *vectorIndexSearchRouteStats) clearHNSWSearchPackAvailability() {
 	r.HNSWSearchPackFallbacks = 0
 	r.HNSWSearchPackMmapDirect = 0
 	r.HNSWSearchPackHeapCopy = 0
-	r.HNSWSearchPackOpenNanos = openNanos
+	r.HNSWSearchPackOpenNanos = 0
 	r.HNSWSearchPackMappedBytes = 0
 	r.HNSWSearchPackHeapCopyBytes = 0
 	r.HNSWSearchPackActiveHandles = 0
@@ -673,6 +726,9 @@ func (r *vectorIndexSearchRouteStats) clearHNSWSearchPackAvailability() {
 
 func (s *VectorIndexSearcher) hnswSearchPackSearchWithBufferRoute(queryMode columnVectorGraphNativeSearchQueryMode, statsMode columnVectorGraphNativeSearchStatsMode) (*columnHNSWSearchPackPreparedView, vectorIndexSearchRouteStats, bool) {
 	cached := s.routeStats
+	if queryMode.quantized() {
+		return nil, vectorIndexSearchRouteStatsForColumnGraphQuantized(cached), false
+	}
 	reader := s.reader
 	pack := (*columnHNSWSearchPackPreparedView)(nil)
 	status := columnHNSWSearchPackPreparedStatusMissing
@@ -1168,7 +1224,7 @@ func (s *VectorIndexSearcher) Search(opts VectorIndexSearcherSearchOptions) (Vec
 	s.readerLast = readerStatsAfter
 	readerStats := columnPhysicalRowReaderStatsDelta(readerStatsBefore, readerStatsAfter)
 	response.Stats = vectorIndexSearchStatsFromInternal(searchStats, readerStats)
-	s.routeStats.apply(&response.Stats)
+	vectorIndexSearchRouteStatsForQueryMode(s.routeStats, queryMode).apply(&response.Stats)
 	if err != nil {
 		return response, err
 	}
@@ -1275,11 +1331,14 @@ func (s *VectorIndexSearcher) Search(opts VectorIndexSearcherSearchOptions) (Vec
 // per worker. IncludeDocuments is not supported by this reusable no-document
 // path.
 //
-// The high-QPS public contract for this path is exact/zero QueryMode with no
-// document projection and no document materialization. Healthy current-format
-// evidence should show hnsw_search_pack_v1 active and selected, zero document
-// fetches, zero graph-row fallback, zero typed-column vector fallback, and zero
-// vector scratch decodes.
+// The high-QPS exact public contract for this path is exact/zero QueryMode with
+// no document projection and no document materialization. Healthy exact
+// current-format evidence should show hnsw_search_pack_v1 active and selected,
+// zero document fetches, zero graph-row fallback, zero typed-column vector
+// fallback, and zero vector scratch decodes. Explicit quantized modes use the
+// column_graph quantized scorer route instead of hnsw_search_pack_v1 and must
+// fail closed with quantized_* asset counters when the selected score plane is
+// unavailable.
 //
 // On any error after a non-nil buffer is supplied, the buffer's reusable
 // result/id views are reset to length zero and the returned response has no
@@ -1605,6 +1664,18 @@ func vectorIndexSearchStatsFromInternal(searchStats columnVectorGraphNativeSearc
 		QuantizedCodeBytesRead:                searchStats.QuantizedCodeBytesRead,
 		QuantizedRerankCandidates:             searchStats.QuantizedRerankCandidates,
 		QuantizedRerankExactScoreCalls:        searchStats.QuantizedRerankExactScoreCalls,
+		QuantizedScorerActive:                 searchStats.QuantizedScorerActive,
+		QuantizedAssetMissing:                 searchStats.QuantizedAssetMissing,
+		QuantizedAssetInvalid:                 searchStats.QuantizedAssetInvalid,
+		QuantizedAssetStale:                   searchStats.QuantizedAssetStale,
+		QuantizedAssetClosed:                  searchStats.QuantizedAssetClosed,
+		QuantizedAssetUnavailable:             searchStats.QuantizedAssetUnavailable,
+		QuantizedAssetMmapDirect:              searchStats.QuantizedAssetMmapDirect,
+		QuantizedAssetHeapCopy:                searchStats.QuantizedAssetHeapCopy,
+		QuantizedAssetOpenNanos:               searchStats.QuantizedAssetOpenNanos,
+		QuantizedAssetMappedBytes:             searchStats.QuantizedAssetMappedBytes,
+		QuantizedAssetHeapCopyBytes:           searchStats.QuantizedAssetHeapCopyBytes,
+		QuantizedAssetActiveHandles:           searchStats.QuantizedAssetActiveHandles,
 		ScoreFloat64Fallbacks:                 searchStats.ScoreFloat64Fallbacks,
 		ExpansionFetches:                      searchStats.ExpansionFetches,
 		ResultFetches:                         searchStats.ResultFetches,
@@ -1683,6 +1754,8 @@ func vectorIndexSearchStatsFromInternal(searchStats columnVectorGraphNativeSearc
 		ResultIDStateValidationFailures:       searchStats.ResultIDStateValidationFailures,
 		PreparedGraphSearchViews:              searchStats.PreparedGraphSearchViews,
 		GraphRowFallbacks:                     searchStats.GraphRowFallbacks,
+		SearchRouteQuantizedOnly:              searchStats.SearchRouteQuantizedOnly,
+		SearchRouteQuantizedRerank:            searchStats.SearchRouteQuantizedRerank,
 		BenchmarkDebugSearches:                searchStats.BenchmarkDebugSearches,
 		NeighborTiles:                         searchStats.NeighborTiles,
 		NeighborTileNeighbors:                 searchStats.NeighborTileNeighbors,

--- a/TreeDB/collections/vector_index_search_test.go
+++ b/TreeDB/collections/vector_index_search_test.go
@@ -147,11 +147,13 @@ func TestSearchVectorIndexQuantizedOnlyAndRerankSupported1926(t *testing.T) {
 	}
 	assertColumnGraphSearchResponseLoadedV4(t, exact, def.Name, 2)
 	assertVectorIndexSearchResultsV4(t, exact.Results, exactColumnGraphTopKForTest(t, rows, query, 2), false)
+	assertExactVectorIndexSearchHasNoQuantizedRouteStats2416(t, exact.Stats)
 	explicitExact, err := col.SearchVectorIndex(VectorIndexSearchOptions{IndexName: def.Name, Query: query, QueryMode: VectorIndexQueryModeExact, TopK: 2, EfSearch: len(rows), MaxDecodedBlocks: 1})
 	if err != nil {
 		t.Fatalf("explicit exact SearchVectorIndex: %v", err)
 	}
 	assertVectorIndexSearchResultsV4(t, explicitExact.Results, exactColumnGraphTopKForTest(t, rows, query, 2), false)
+	assertExactVectorIndexSearchHasNoQuantizedRouteStats2416(t, explicitExact.Stats)
 
 	quantizedOnly, err := col.SearchVectorIndex(VectorIndexSearchOptions{
 		IndexName:          def.Name,
@@ -173,6 +175,7 @@ func TestSearchVectorIndexQuantizedOnlyAndRerankSupported1926(t *testing.T) {
 	if quantizedOnly.Stats.PreparedScoreCalls != 0 || quantizedOnly.Stats.VectorBytesRead != 0 || quantizedOnly.Stats.NormBytesRead != 0 || quantizedOnly.Stats.DocumentsFetched != 0 {
 		t.Fatalf("quantized stats=%+v want no exact vector/norm scoring or document materialization", quantizedOnly.Stats)
 	}
+	assertQuantizedOnlyGuardrailStats2416(t, quantizedOnly.Stats, def.Dimensions)
 	minimal, err := col.SearchVectorIndex(VectorIndexSearchOptions{IndexName: def.Name, Query: query, QueryMode: VectorIndexQueryModeQuantizedOnly, QuantizedIndexName: def.QuantizedIndexes[0].Name, TopK: 2, EfSearch: len(rows), MaxDecodedBlocks: 1, StatsMode: VectorIndexSearchStatsModeProduction})
 	if err != nil {
 		t.Fatalf("production-stats quantized_only SearchVectorIndex: %v", err)
@@ -180,6 +183,24 @@ func TestSearchVectorIndexQuantizedOnlyAndRerankSupported1926(t *testing.T) {
 	if minimal.Stats.Candidates == 0 || minimal.Stats.VisitedEdges == 0 || minimal.Stats.QuantizedScoreCalls == 0 {
 		t.Fatalf("production-stats quantized stats=%+v want candidate/edge/code counters", minimal.Stats)
 	}
+	assertQuantizedOnlyGuardrailStats2416(t, minimal.Stats, def.Dimensions)
+
+	rerankedNoDocs, err := col.SearchVectorIndex(VectorIndexSearchOptions{
+		IndexName:                 def.Name,
+		Query:                     query,
+		QueryMode:                 VectorIndexQueryModeQuantizedRerank,
+		QuantizedIndexName:        def.QuantizedIndexes[0].Name,
+		QuantizedRerankCandidates: 3,
+		TopK:                      2,
+		EfSearch:                  len(rows),
+		MaxDecodedBlocks:          1,
+	})
+	if err != nil {
+		t.Fatalf("quantized_rerank no-doc SearchVectorIndex: %v", err)
+	}
+	assertColumnGraphSearchResponseLoadedV4(t, rerankedNoDocs, def.Name, 2)
+	assertVectorIndexSearchResultsV4(t, rerankedNoDocs.Results, exactColumnGraphTopKForTest(t, rows, query, 2), false)
+	assertQuantizedRerankNoDocumentGuardrailStats2416(t, rerankedNoDocs.Stats, 3)
 
 	reranked, err := col.SearchVectorIndex(VectorIndexSearchOptions{
 		IndexName:                 def.Name,
@@ -204,13 +225,16 @@ func TestSearchVectorIndexQuantizedOnlyAndRerankSupported1926(t *testing.T) {
 		t.Fatalf("quantized_rerank stats=%+v want documents fetched after exact rerank", reranked.Stats)
 	}
 
-	if _, err := col.SearchVectorIndex(VectorIndexSearchOptions{IndexName: def.Name, Query: query, QueryMode: VectorIndexQueryModeQuantizedOnly, QuantizedIndexName: "missing.scalar_u8", TopK: 1, EfSearch: len(rows), MaxDecodedBlocks: 1}); !errors.Is(err, ErrVectorIndexSearchUnavailable) || !strings.Contains(err.Error(), "is not declared") {
+	missingOnly, err := col.SearchVectorIndex(VectorIndexSearchOptions{IndexName: def.Name, Query: query, QueryMode: VectorIndexQueryModeQuantizedOnly, QuantizedIndexName: "missing.scalar_u8", TopK: 1, EfSearch: len(rows), MaxDecodedBlocks: 1})
+	if !errors.Is(err, ErrVectorIndexSearchUnavailable) || !strings.Contains(err.Error(), "is not declared") {
 		t.Fatalf("undeclared quantized index err=%v want unavailable declared-name failure", err)
 	}
+	assertQuantizedUnavailableGuardrailStats2416(t, missingOnly.Stats, columnVectorGraphNativeSearchQueryModeQuantizedOnly, columnVectorGraphQuantizedAssetHealthMissing)
 	got, err := col.SearchVectorIndex(VectorIndexSearchOptions{IndexName: def.Name, Query: query, QueryMode: VectorIndexQueryModeQuantizedRerank, QuantizedIndexName: "missing.scalar_u8", TopK: 1, EfSearch: len(rows), MaxDecodedBlocks: 1})
 	if !errors.Is(err, ErrVectorIndexSearchUnavailable) || !strings.Contains(err.Error(), "is not declared") || len(got.Results) != 0 || got.Stats.CandidateFetches != 0 || got.Stats.QuantizedScoreCalls != 0 || got.Stats.PreparedScoreCalls != 0 {
 		t.Fatalf("undeclared quantized_rerank response=%+v err=%v want fail-closed no fallback", got, err)
 	}
+	assertQuantizedUnavailableGuardrailStats2416(t, got.Stats, columnVectorGraphNativeSearchQueryModeQuantizedRerank, columnVectorGraphQuantizedAssetHealthMissing)
 	if _, err := col.SearchVectorIndex(VectorIndexSearchOptions{IndexName: def.Name, Query: query, QueryMode: VectorIndexQueryModeExact, QuantizedIndexName: def.QuantizedIndexes[0].Name, TopK: 1, EfSearch: len(rows), MaxDecodedBlocks: 1}); err == nil || !strings.Contains(err.Error(), "exact") {
 		t.Fatalf("exact with quantized index err=%v want validation failure", err)
 	}
@@ -230,6 +254,97 @@ func TestSearchVectorIndexQuantizedOnlyAndRerankSupported1926(t *testing.T) {
 	reopenedMeta := reopenedCol.Meta()
 	if got := reopenedMeta.VectorIndexes[0].QuantizedIndexes; len(got) != 1 || got[0] != def.QuantizedIndexes[0] {
 		t.Fatalf("reopened QuantizedIndexes=%+v want %+v", got, def.QuantizedIndexes)
+	}
+}
+
+func assertExactVectorIndexSearchHasNoQuantizedRouteStats2416(tb testing.TB, stats VectorIndexSearchStats) {
+	tb.Helper()
+	if stats.SearchRouteQuantizedOnly != 0 || stats.SearchRouteQuantizedRerank != 0 || stats.QuantizedScorerActive != 0 || stats.QuantizedAssetUnavailable != 0 || stats.QuantizedAssetHeapCopy != 0 || stats.QuantizedAssetMmapDirect != 0 {
+		tb.Fatalf("exact stats=%+v want no quantized route/scorer/asset counters", stats)
+	}
+}
+
+func assertQuantizedOnlyGuardrailStats2416(tb testing.TB, stats VectorIndexSearchStats, dims int) {
+	tb.Helper()
+	if stats.SearchRouteQuantizedOnly != 1 || stats.SearchRouteQuantizedRerank != 0 || stats.QuantizedScorerActive != 1 {
+		tb.Fatalf("quantized_only route stats=%+v want quantized-only scorer route", stats)
+	}
+	if stats.SearchRouteHNSWSearchPack != 0 || stats.HNSWSearchPackActive != 0 || stats.HNSWSearchPackFallbacks != 0 {
+		tb.Fatalf("quantized_only stats=%+v want no hnsw_search_pack_v1 route/active/fallback claim", stats)
+	}
+	if stats.QuantizedAssetUnavailable != 0 || stats.QuantizedAssetMissing != 0 || stats.QuantizedAssetInvalid != 0 || stats.QuantizedAssetStale != 0 || stats.QuantizedAssetClosed != 0 {
+		tb.Fatalf("quantized_only asset stats=%+v want available quantized asset", stats)
+	}
+	if stats.QuantizedAssetHeapCopy+stats.QuantizedAssetMmapDirect != 1 || stats.QuantizedAssetHeapCopyBytes+stats.QuantizedAssetMappedBytes == 0 {
+		tb.Fatalf("quantized_only asset stats=%+v want exactly one quantized asset residency counter", stats)
+	}
+	if stats.QuantizedScoreCalls == 0 || stats.QuantizedCodeBytesRead != stats.QuantizedScoreCalls*uint64(dims) {
+		tb.Fatalf("quantized_only score stats=%+v dims=%d want quantized code scoring bytes", stats, dims)
+	}
+	if stats.PreparedScoreCalls != 0 || stats.QuantizedRerankExactScoreCalls != 0 || stats.VectorBytesRead != 0 || stats.NormBytesRead != 0 {
+		tb.Fatalf("quantized_only stats=%+v want no exact vector/norm reads or exact rerank", stats)
+	}
+	if stats.DocumentsFetched != 0 || stats.GraphRowFallbacks != 0 || stats.TypedColumnFallbacks != 0 || stats.VectorScratchDecodes != 0 {
+		tb.Fatalf("quantized_only guardrails stats=%+v want no docs/fallback/scratch decode", stats)
+	}
+}
+
+func assertQuantizedRerankNoDocumentGuardrailStats2416(tb testing.TB, stats VectorIndexSearchStats, shortlist int) {
+	tb.Helper()
+	if stats.SearchRouteQuantizedOnly != 0 || stats.SearchRouteQuantizedRerank != 1 || stats.QuantizedScorerActive != 1 {
+		tb.Fatalf("quantized_rerank route stats=%+v want quantized-rerank scorer route", stats)
+	}
+	if stats.SearchRouteHNSWSearchPack != 0 || stats.HNSWSearchPackActive != 0 || stats.HNSWSearchPackFallbacks != 0 {
+		tb.Fatalf("quantized_rerank stats=%+v want no hnsw_search_pack_v1 route/active/fallback claim", stats)
+	}
+	if stats.QuantizedAssetUnavailable != 0 || stats.QuantizedAssetHeapCopy+stats.QuantizedAssetMmapDirect != 1 {
+		tb.Fatalf("quantized_rerank asset stats=%+v want available quantized asset", stats)
+	}
+	if stats.QuantizedScoreCalls == 0 || stats.QuantizedRerankCandidates != uint64(shortlist) || stats.QuantizedRerankExactScoreCalls != uint64(shortlist) {
+		tb.Fatalf("quantized_rerank stats=%+v want exact score calls equal shortlist=%d", stats, shortlist)
+	}
+	if stats.VectorBytesRead == 0 || stats.NormBytesRead == 0 {
+		tb.Fatalf("quantized_rerank stats=%+v want exact vector/norm reads only for rerank shortlist", stats)
+	}
+	if stats.DocumentsFetched != 0 || stats.GraphRowFallbacks != 0 || stats.TypedColumnFallbacks != 0 || stats.VectorScratchDecodes != 0 {
+		tb.Fatalf("quantized_rerank guardrails stats=%+v want no docs/fallback/scratch decode", stats)
+	}
+}
+
+func assertQuantizedUnavailableGuardrailStats2416(tb testing.TB, stats VectorIndexSearchStats, mode columnVectorGraphNativeSearchQueryMode, health columnVectorGraphQuantizedAssetHealth) {
+	tb.Helper()
+	if mode == columnVectorGraphNativeSearchQueryModeQuantizedOnly {
+		if stats.SearchRouteQuantizedOnly != 1 || stats.SearchRouteQuantizedRerank != 0 {
+			tb.Fatalf("unavailable quantized_only stats=%+v want quantized-only route", stats)
+		}
+	} else if mode == columnVectorGraphNativeSearchQueryModeQuantizedRerank {
+		if stats.SearchRouteQuantizedOnly != 0 || stats.SearchRouteQuantizedRerank != 1 {
+			tb.Fatalf("unavailable quantized_rerank stats=%+v want quantized-rerank route", stats)
+		}
+	}
+	if stats.QuantizedAssetUnavailable != 1 || stats.QuantizedScorerActive != 0 || stats.QuantizedAssetHeapCopy != 0 || stats.QuantizedAssetMmapDirect != 0 {
+		tb.Fatalf("unavailable quantized stats=%+v want fail-closed unavailable asset and no active scorer", stats)
+	}
+	switch health {
+	case columnVectorGraphQuantizedAssetHealthInvalid:
+		if stats.QuantizedAssetInvalid != 1 || stats.QuantizedAssetMissing != 0 || stats.QuantizedAssetStale != 0 || stats.QuantizedAssetClosed != 0 {
+			tb.Fatalf("unavailable quantized stats=%+v want invalid asset", stats)
+		}
+	case columnVectorGraphQuantizedAssetHealthStale:
+		if stats.QuantizedAssetStale != 1 || stats.QuantizedAssetMissing != 0 || stats.QuantizedAssetInvalid != 0 || stats.QuantizedAssetClosed != 0 {
+			tb.Fatalf("unavailable quantized stats=%+v want stale asset", stats)
+		}
+	case columnVectorGraphQuantizedAssetHealthClosed:
+		if stats.QuantizedAssetClosed != 1 || stats.QuantizedAssetMissing != 0 || stats.QuantizedAssetInvalid != 0 || stats.QuantizedAssetStale != 0 {
+			tb.Fatalf("unavailable quantized stats=%+v want closed asset", stats)
+		}
+	default:
+		if stats.QuantizedAssetMissing != 1 || stats.QuantizedAssetInvalid != 0 || stats.QuantizedAssetStale != 0 || stats.QuantizedAssetClosed != 0 {
+			tb.Fatalf("unavailable quantized stats=%+v want missing asset", stats)
+		}
+	}
+	if stats.SearchRouteHNSWSearchPack != 0 || stats.HNSWSearchPackActive != 0 || stats.HNSWSearchPackFallbacks != 0 || stats.PreparedScoreCalls != 0 || stats.QuantizedScoreCalls != 0 || stats.QuantizedRerankExactScoreCalls != 0 || stats.VectorBytesRead != 0 || stats.NormBytesRead != 0 || stats.DocumentsFetched != 0 || stats.GraphRowFallbacks != 0 || stats.TypedColumnFallbacks != 0 || stats.VectorScratchDecodes != 0 {
+		tb.Fatalf("unavailable quantized stats=%+v want fail-closed with no exact/quantized scoring, docs, or fallback", stats)
 	}
 }
 
@@ -257,13 +372,14 @@ func TestVectorIndexSearcherQuantizedSearchWithBufferSuccessAndErrorReset1926(t 
 	if err != nil || len(valid.Results) != 2 || len(buffer.results) != 2 {
 		t.Fatalf("initial SearchWithBuffer results=%d buffer=%d err=%v want 2,2,nil", len(valid.Results), len(buffer.results), err)
 	}
-	quantized, err := searcher.SearchWithBuffer(VectorIndexSearcherSearchOptions{
+	quantizedOpts := VectorIndexSearcherSearchOptions{
 		Query:              query,
 		QueryMode:          VectorIndexQueryModeQuantizedOnly,
 		QuantizedIndexName: def.QuantizedIndexes[0].Name,
 		TopK:               2,
 		EfSearch:           len(rows),
-	}, &buffer)
+	}
+	quantized, err := searcher.SearchWithBuffer(quantizedOpts, &buffer)
 	if err != nil {
 		t.Fatalf("quantized SearchWithBuffer: %v", err)
 	}
@@ -271,20 +387,41 @@ func TestVectorIndexSearcherQuantizedSearchWithBufferSuccessAndErrorReset1926(t 
 	if len(buffer.results) != 2 || len(buffer.idBytes) == 0 || quantized.Stats.QuantizedScoreCalls == 0 {
 		t.Fatalf("quantized buffer/results stats=%+v buffer.results=%d idBytes=%d", quantized.Stats, len(buffer.results), len(buffer.idBytes))
 	}
-	reranked, err := searcher.SearchWithBuffer(VectorIndexSearcherSearchOptions{
+	assertQuantizedOnlyGuardrailStats2416(t, quantized.Stats, def.Dimensions)
+	rerankOpts := VectorIndexSearcherSearchOptions{
 		Query:                     query,
 		QueryMode:                 VectorIndexQueryModeQuantizedRerank,
 		QuantizedIndexName:        def.QuantizedIndexes[0].Name,
 		QuantizedRerankCandidates: len(rows),
 		TopK:                      2,
 		EfSearch:                  len(rows),
-	}, &buffer)
+	}
+	reranked, err := searcher.SearchWithBuffer(rerankOpts, &buffer)
 	if err != nil {
 		t.Fatalf("quantized_rerank SearchWithBuffer: %v", err)
 	}
 	assertVectorIndexSearchResultsV4(t, reranked.Results, exactColumnGraphTopKForTest(t, rows, query, 2), false)
 	if len(buffer.results) != 2 || len(buffer.idBytes) == 0 || reranked.Stats.QuantizedScoreCalls == 0 || reranked.Stats.QuantizedRerankExactScoreCalls == 0 {
 		t.Fatalf("rerank buffer/results stats=%+v buffer.results=%d idBytes=%d", reranked.Stats, len(buffer.results), len(buffer.idBytes))
+	}
+	assertQuantizedRerankNoDocumentGuardrailStats2416(t, reranked.Stats, len(rows))
+	quantizedAllocs := testing.AllocsPerRun(100, func() {
+		got, err := searcher.SearchWithBuffer(quantizedOpts, &buffer)
+		if err != nil || len(got.Results) != 2 {
+			panic("unexpected quantized SearchWithBuffer allocation probe result")
+		}
+	})
+	if quantizedAllocs != 0 {
+		t.Fatalf("quantized SearchWithBuffer steady-state allocs/run=%v want 0", quantizedAllocs)
+	}
+	rerankAllocs := testing.AllocsPerRun(100, func() {
+		got, err := searcher.SearchWithBuffer(rerankOpts, &buffer)
+		if err != nil || len(got.Results) != 2 {
+			panic("unexpected quantized_rerank SearchWithBuffer allocation probe result")
+		}
+	})
+	if rerankAllocs != 0 {
+		t.Fatalf("quantized_rerank SearchWithBuffer steady-state allocs/run=%v want 0", rerankAllocs)
 	}
 	got, err := searcher.SearchWithBuffer(VectorIndexSearcherSearchOptions{
 		Query:              query,
@@ -299,9 +436,91 @@ func TestVectorIndexSearcherQuantizedSearchWithBufferSuccessAndErrorReset1926(t 
 	if len(got.Results) != 0 || len(buffer.results) != 0 || len(buffer.idBytes) != 0 {
 		t.Fatalf("quantized error results=%d buffer.results=%d idBytes=%d want reset empty views", len(got.Results), len(buffer.results), len(buffer.idBytes))
 	}
+	assertQuantizedUnavailableGuardrailStats2416(t, got.Stats, columnVectorGraphNativeSearchQueryModeQuantizedRerank, columnVectorGraphQuantizedAssetHealthMissing)
 	validAgain, err := searcher.SearchWithBuffer(validOpts, &buffer)
 	if err != nil || len(validAgain.Results) != 2 {
 		t.Fatalf("valid SearchWithBuffer after quantized error results=%d err=%v", len(validAgain.Results), err)
+	}
+}
+
+func TestVectorIndexSearcherQuantizedAssetUnavailableCounters2416(t *testing.T) {
+	rows := []columnGraphRebuildInputRowV2A{
+		{id: "doc-a", vector: []float32{1, 0, 0}},
+		{id: "doc-b", vector: []float32{0, 1, 0}},
+		{id: "doc-c", vector: []float32{0, 0, 1}},
+	}
+	_, d, col, def := openColumnGraphQuantizedGuardrailTestCollection1926(t, rows)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	searcher, err := col.OpenVectorIndexSearcher(VectorIndexSearcherOptions{IndexName: def.Name, MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("OpenVectorIndexSearcher: %v", err)
+	}
+	defer func() { _ = searcher.Close() }()
+	qName := def.QuantizedIndexes[0].Name
+	original := searcher.reader.quantizedAssetStatus[qName]
+	query := []float32{1, 0, 0}
+	for _, tc := range []struct {
+		name   string
+		mode   VectorIndexQueryMode
+		health columnVectorGraphQuantizedAssetHealth
+		mutate func()
+	}{
+		{
+			name:   "missing",
+			mode:   VectorIndexQueryModeQuantizedOnly,
+			health: columnVectorGraphQuantizedAssetHealthMissing,
+			mutate: func() { delete(searcher.reader.quantizedAssetStatus, qName) },
+		},
+		{
+			name:   "invalid",
+			mode:   VectorIndexQueryModeQuantizedOnly,
+			health: columnVectorGraphQuantizedAssetHealthInvalid,
+			mutate: func() {
+				status := original
+				status.Prepared = nil
+				status.Health = columnVectorGraphQuantizedAssetHealthInvalid
+				status.Err = fmt.Errorf("%w: checksum mismatch", errColumnVectorGraphQuantizedAssetInvalid)
+				searcher.reader.quantizedAssetStatus[qName] = status
+			},
+		},
+		{
+			name:   "stale",
+			mode:   VectorIndexQueryModeQuantizedRerank,
+			health: columnVectorGraphQuantizedAssetHealthStale,
+			mutate: func() {
+				status := original
+				status.Prepared = nil
+				status.Health = columnVectorGraphQuantizedAssetHealthStale
+				status.Err = fmt.Errorf("%w: base manifest mismatch", errColumnVectorGraphQuantizedAssetStale)
+				searcher.reader.quantizedAssetStatus[qName] = status
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			searcher.reader.quantizedAssetStatus[qName] = original
+			tc.mutate()
+			var buffer VectorIndexSearchBuffer
+			opts := VectorIndexSearcherSearchOptions{Query: query, QueryMode: tc.mode, QuantizedIndexName: qName, TopK: 1, EfSearch: len(rows)}
+			if tc.mode == VectorIndexQueryModeQuantizedRerank {
+				opts.QuantizedRerankCandidates = 1
+			}
+			got, err := searcher.SearchWithBuffer(opts, &buffer)
+			if !errors.Is(err, ErrVectorIndexSearchUnavailable) {
+				t.Fatalf("SearchWithBuffer err=%v want ErrVectorIndexSearchUnavailable", err)
+			}
+			if len(got.Results) != 0 || len(buffer.results) != 0 || len(buffer.idBytes) != 0 {
+				t.Fatalf("unavailable results=%d buffer.results=%d idBytes=%d want fail-closed empty", len(got.Results), len(buffer.results), len(buffer.idBytes))
+			}
+			internalMode := columnVectorGraphNativeSearchQueryModeQuantizedOnly
+			if tc.mode == VectorIndexQueryModeQuantizedRerank {
+				internalMode = columnVectorGraphNativeSearchQueryModeQuantizedRerank
+			}
+			assertQuantizedUnavailableGuardrailStats2416(t, got.Stats, internalMode, tc.health)
+			searcher.reader.quantizedAssetStatus[qName] = original
+		})
 	}
 }
 
@@ -3980,6 +4199,18 @@ func reportVectorIndexSearchBenchMetricsV4(b *testing.B, n int, stats VectorInde
 	b.ReportMetric(float64(stats.QuantizedCodeBytesRead), "quantized_code_B/search")
 	b.ReportMetric(float64(stats.QuantizedRerankCandidates), "quantized_rerank_candidates/search")
 	b.ReportMetric(float64(stats.QuantizedRerankExactScoreCalls), "quantized_rerank_exact_score_calls/search")
+	b.ReportMetric(float64(stats.QuantizedScorerActive), "quantized_scorer_active/search")
+	b.ReportMetric(float64(stats.QuantizedAssetMissing), "quantized_asset_missing/search")
+	b.ReportMetric(float64(stats.QuantizedAssetInvalid), "quantized_asset_invalid/search")
+	b.ReportMetric(float64(stats.QuantizedAssetStale), "quantized_asset_stale/search")
+	b.ReportMetric(float64(stats.QuantizedAssetClosed), "quantized_asset_closed/search")
+	b.ReportMetric(float64(stats.QuantizedAssetUnavailable), "quantized_asset_unavailable/search")
+	b.ReportMetric(float64(stats.QuantizedAssetMmapDirect), "quantized_asset_mmap_direct/search")
+	b.ReportMetric(float64(stats.QuantizedAssetHeapCopy), "quantized_asset_heap_copy/search")
+	b.ReportMetric(float64(stats.QuantizedAssetOpenNanos), "quantized_asset_open_ns")
+	b.ReportMetric(float64(stats.QuantizedAssetMappedBytes), "quantized_asset_mapped_B")
+	b.ReportMetric(float64(stats.QuantizedAssetHeapCopyBytes), "quantized_asset_heap_copy_B")
+	b.ReportMetric(float64(stats.QuantizedAssetActiveHandles), "quantized_asset_active_handles")
 	b.ReportMetric(float64(stats.ScoreFloat64Fallbacks), "score_float64_fallbacks/search")
 	if stats.ScoreBatchCalls > 0 {
 		b.ReportMetric(float64(stats.ScoreBatchCandidates)/float64(stats.ScoreBatchCalls), "score_batch_avg_tile_size")
@@ -4071,6 +4302,8 @@ func reportVectorIndexSearchBenchMetricsV4(b *testing.B, n int, stats VectorInde
 	b.ReportMetric(float64(stats.SearchRouteColumnGraphPrepared), "search_route_column_graph_prepared/search")
 	b.ReportMetric(float64(stats.SearchRouteColumnGraphFallback), "search_route_column_graph_fallback/search")
 	b.ReportMetric(float64(stats.SearchRouteHNSWSearchPack), "search_route_hnsw_search_pack/search")
+	b.ReportMetric(float64(stats.SearchRouteQuantizedOnly), "search_route_quantized_only/search")
+	b.ReportMetric(float64(stats.SearchRouteQuantizedRerank), "search_route_quantized_rerank/search")
 	b.ReportMetric(float64(stats.HNSWSearchPackActive), "hnsw_search_pack_active/search")
 	b.ReportMetric(float64(stats.HNSWSearchPackMissing), "hnsw_search_pack_missing/search")
 	b.ReportMetric(float64(stats.HNSWSearchPackInvalid), "hnsw_search_pack_invalid/search")

--- a/TreeDB/docs/guides/vector-search-typed-column.md
+++ b/TreeDB/docs/guides/vector-search-typed-column.md
@@ -95,10 +95,12 @@ reranked, err := searcher.Search(collections.VectorIndexSearcherSearchOptions{
 })
 ```
 
-`quantized_only` returns estimated scalar_u8 scores and should show zero exact
-vector/norm reads in stats. `quantized_rerank` keeps quantized traversal over the
-normalized `ef_search` pool, trims to `QuantizedRerankCandidates`, exact-reranks
-that shortlist, and returns exact cosine scores. See
+`quantized_only` returns estimated scalar_u8 scores and should report
+`search_route_quantized_only=1`, `quantized_scorer_active=1`, and zero exact
+vector/norm reads in stats. `quantized_rerank` reports
+`search_route_quantized_rerank=1`, keeps quantized traversal over the normalized
+`ef_search` pool, trims to `QuantizedRerankCandidates`, exact-reranks that
+shortlist, and returns exact cosine scores. See
 [`quantized-vector-index.md`](../spec/quantized-vector-index.md) for benchmark
 commands and current no-speedup caveats.
 

--- a/TreeDB/docs/spec/quantized-vector-index.md
+++ b/TreeDB/docs/spec/quantized-vector-index.md
@@ -22,7 +22,10 @@ Search uses an explicit mode:
 `QuantizedRerankCandidates=0` means the normalized `ef_search` candidate set.
 Non-zero values must be at least `TopK`. Returned `quantized_rerank` results are
 ranked by exact cosine over the trimmed quantized candidate set; they are not a
-silent full-exact search.
+silent full-exact search. Quantized route counters identify the selected query
+mode and may be reported alongside the `column_graph` prepared physical route;
+`hnsw_search_pack_v1` route/active/fallback counters remain zero for quantized
+search.
 
 ## Durable asset model
 
@@ -47,8 +50,10 @@ asset, row count, dimensions, metric, source schema, base graph identity, asset
 ref identity, and typed-column layout before traversal/scoring. Missing, stale,
 corrupt, mismatched, unsupported, or unprepared assets return
 `ErrVectorIndexSearchUnavailable`; they must not fall back to exact traversal or
-document reconstruction. Exact mode rejects quantized-mode fields so callers do
-not accidentally depend on no-op options.
+document reconstruction. Fail-closed stats use codec-generic counters such as
+`quantized_asset_missing`, `quantized_asset_invalid`, `quantized_asset_stale`,
+and `quantized_asset_unavailable`. Exact mode rejects quantized-mode fields so
+callers do not accidentally depend on no-op options.
 
 ## Benchmark and storage evidence
 
@@ -67,6 +72,8 @@ GOMAXPROCS=8 GOWORK=off go test ./TreeDB/collections \
 `BenchmarkColumnGraphScalarU8QuantizedRebuildStorage1926` emits rebuild/storage
 rows. The score-plane rows report `ns/op`, `ops/sec`, `B/op`, `allocs/op`,
 `recall_at_k_pct` versus exact-mode topK on the same fixture,
+`search_route_quantized_only/search`, `search_route_quantized_rerank/search`,
+`quantized_scorer_active/search`, `quantized_asset_unavailable/search`,
 `candidates/search`, `quantized_rerank_candidates/search`,
 `quantized_rerank_exact_score_calls/search`, `quantized_code_B/search`,
 `vector_B/search`, `norm_B/search`, logical code bytes/vector, and actual

--- a/scripts/bench_vector_search_compare.sh
+++ b/scripts/bench_vector_search_compare.sh
@@ -196,7 +196,14 @@ Canonical current production comparison:
   \`hnsw_search_pack_heap_copy_B\`, \`docs_fetched/search\`,
   \`graph_row_fallbacks/search\`, score-batch fallback reason flags,
   vector/adjacency source-state counters, and candidate/visited-edge byte
-  counters used by the HNSW search-pack stack.
+  counters used by the HNSW search-pack stack. Quantized benchmark rows should
+  use codec-generic route/asset counters such as
+  \`search_route_quantized_only/search\`,
+  \`search_route_quantized_rerank/search\`, \`quantized_scorer_active/search\`,
+  \`quantized_asset_unavailable/search\`, \`quantized_asset_invalid/search\`,
+  \`quantized_asset_stale/search\`, \`quantized_asset_open_ns\`,
+  \`quantized_asset_mapped_B\`, and \`quantized_asset_heap_copy_B\`; scalar_u8
+  names are reserved for scalar_u8-specific benchmark labels and internals.
 - \`BenchmarkCollectionVectorUSearchProductionCompare/TreeDB_CollectionSearchVectorIndexWithBuffer\`
   times the collection-level caller-owned result-buffer seam on a warmed
   collection-owned prepared search-pack cache. It uses the same exact


### PR DESCRIPTION
## Linked issues

- Closes #2416
- Part of #2412
- Coordinated with #2407 public observability naming: quantized public counters are codec-generic `quantized_*`; scalar_u8 names remain internal or scalar_u8-specific benchmark labels.

## What changed

- Adds public `VectorIndexSearchStats` fields for codec-generic quantized query routes:
  - `search_route_quantized_only`
  - `search_route_quantized_rerank`
- Adds public quantized scorer/asset-health stats:
  - `quantized_scorer_active`
  - `quantized_asset_missing`, `quantized_asset_invalid`, `quantized_asset_stale`, `quantized_asset_closed`, `quantized_asset_unavailable`
  - `quantized_asset_mmap_direct`, `quantized_asset_heap_copy`, `quantized_asset_open_nanos`, `quantized_asset_mapped_bytes`, `quantized_asset_heap_copy_bytes`, `quantized_asset_active_handles`
- Keeps `hnsw_search_pack_v1` exact FP32 route counters reserved for exact pack search; quantized searches route through column_graph/scalar_u8 scoring and clear hnsw pack route/active/fallback claims.
- Adds focused guardrail assertions for:
  - quantized-only: no exact vector/norm reads, no exact rerank, no docs/materialization, no fallback/scratch decode, route/asset counters present.
  - quantized-rerank: exact score calls equal configured shortlist, docs/materialization zero on no-doc route, route/asset counters present.
  - missing/invalid/stale quantized assets: explicit unavailable counters and fail-closed empty buffered response.
  - exact/default path: no quantized route/scorer/asset counters.
- Updates benchmark output to include the new route/asset counters and updates targeted vector docs/script wording.

## Scope boundaries / non-goals

- Does not change ranking semantics.
- Does not make `hnsw_search_pack_v1` quantized-active or scorer-generic.
- Does not add collection-level quantized buffered API support (#2415).
- Does not add lower-level quantized benchmark rows beyond counter output plumbing (#2414).
- Does not optimize scalar_u8 kernels.

## Start-phase test plan

- Focused quantized route/asset guardrail tests.
- Exact hnsw_search_pack_v1 route preservation tests.
- Full affected package test.
- Docs tests because vector docs were touched.

## Start-phase performance plan

- Before/after benchmark on the reusable `SearchWithBuffer` quantized modes benchmark, comparing exact, quantized_only, and quantized_rerank rows.
- Treat material ns/op, B/op, or allocs/op regressions as blockers.
- Confirm buffered rows remain `0 B/op`, `0 allocs/op`.

## Close-phase test evidence

```sh
GOWORK=off go test ./TreeDB/collections \
  -run 'Test(SearchVectorIndexQuantizedOnlyAndRerankSupported1926|VectorIndexSearcherQuantizedSearchWithBufferSuccessAndErrorReset1926|VectorIndexSearcherQuantizedAssetUnavailableCounters2416|ColumnGraphQuantizedAssetValidationFailClosedWhenUnavailable1926|VectorIndexSearcherSearchWithBufferHighQPSContractRejectsDocuments2361|VectorIndexSearcherSearchWithBufferRouteStatsAndNoDocumentBoundary2311|VectorIndexSearcherSearchWithBufferResultEquivalenceAndZeroAllocs2124)$' \
  -count=1
# ok github.com/snissn/gomap/TreeDB/collections 1.203s

GOWORK=off go test ./TreeDB/collections -count=1
# ok github.com/snissn/gomap/TreeDB/collections 47.831s

GOWORK=off go test ./TreeDB/docs -count=1
# ok github.com/snissn/gomap/TreeDB/docs 1.279s
```

Internal read-only Pi review: PASS, no blocking findings. Review artifact: `/tmp/gomap_2416_internal_review.txt`.

## Close-phase benchmark evidence

Host: Apple M3 / darwin arm64. Measured boundary: reusable `VectorIndexSearcher.SearchWithBuffer` over an opened/warmed searcher and caller-owned result buffer; setup, insert, rebuild, open, and warmup are outside the timed loop.

Command:

```sh
GOMAXPROCS=1 GOWORK=off go test ./TreeDB/collections \
  -run '^$' \
  -bench '^BenchmarkOpenVectorIndexSearcherColumnGraphScalarU8QuantizedModes1926$' \
  -benchmem -benchtime=2000x -count=7 -cpu=1
```

Artifacts:

- `/tmp/gomap_2416_bench_c1_20260605_120551/base_quantized_modes.log`
- `/tmp/gomap_2416_bench_c1_20260605_120551/head_quantized_modes.log`
- `/tmp/gomap_2416_bench_c1_20260605_120551/benchstat_quantized_modes.txt`
- `/tmp/gomap_2416_bench_c1_20260605_120551/summary.md`

Before/after median table:

| row | base median ns/op | head median ns/op | delta | head B/op | head allocs/op |
| --- | ---: | ---: | ---: | ---: | ---: |
| mode=exact | 11,509 | 11,457 | -0.5% | 0 | 0 |
| mode=quantized_only | 13,966 | 13,845 | -0.9% | 0 | 0 |
| mode=quantized_rerank | 16,325 | 16,587 | +1.6% | 0 | 0 |

Benchstat: geomean +0.09%; all row p-values non-significant. No material counter overhead observed.

Representative head guardrail counters:

| row | docs_fetched/search | graph_row_fallbacks/search | typed_column_vector_fallbacks/search | vector_scratch_decodes/search | search_route_hnsw_search_pack/search | search_route_quantized_only/search | search_route_quantized_rerank/search | quantized_scorer_active/search | quantized_asset_unavailable/search | quantized_score_calls/search | quantized_code_B/search | quantized_rerank_exact_score_calls/search | vector_B/search | norm_B/search |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| mode=exact | 0 | 0 | 0 | 0 | 1 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 86,528 | 0 |
| mode=quantized_only | 0 | 0 | 0 | 0 | 0 | 1 | 0 | 1 | 0 | 169 | 21,632 | 0 | 0 | 0 |
| mode=quantized_rerank | 0 | 0 | 0 | 0 | 0 | 0 | 1 | 1 | 0 | 169 | 21,632 | 128 | 65,536 | 512 |

Additional c=8 rerun artifact: `/tmp/gomap_2416_bench_rerun_20260605_115758/summary.md` (geomean -1.17%, no material regression, but higher variance than c=1).

## Performance regression assessment

No material regression from the counter changes. Buffered rows remain `0 B/op`, `0 allocs/op`. An initial short c=8 comparison looked noisy/regressed, so it was rerun with higher iteration count and a c=1 matrix; final c=1 evidence is stable and non-regressing.

## Dependency-ready schema handoff

Downstream #2414/#2415 can safely implement against these proposed public counter names:

- Routes: `search_route_quantized_only`, `search_route_quantized_rerank`
- Scorer/asset health: `quantized_scorer_active`, `quantized_asset_missing`, `quantized_asset_invalid`, `quantized_asset_stale`, `quantized_asset_closed`, `quantized_asset_unavailable`, `quantized_asset_mmap_direct`, `quantized_asset_heap_copy`, `quantized_asset_open_nanos`, `quantized_asset_mapped_bytes`, `quantized_asset_heap_copy_bytes`, `quantized_asset_active_handles`
- Benchmark labels use `_open_ns`, `_mapped_B`, and `_heap_copy_B` to match existing HNSW benchmark-label convention.

Known caveats: `quantized_asset_closed` is schema-wired/reserved; current heap-copy quantized asset path has no production close-state transition to exercise it.


## Latest-head sync update

Synced with `origin/main` `31cc840b9a39e4a61b7ec88d3c8b2d2a490bdb35` via merge-forward/no force-push. Latest PR head: `59175c4262634662bc447af039cb86a2023ca25d`.

Conflict status: merge was conflict-free; gofmt and `git diff --check` passed after sync. #2408 fail-closed buffered unsupported-shape errors and #2410/#2423 docs/benchmark command updates are preserved.

Latest sync validation:

```sh
gofmt -w TreeDB/collections/vector_index_search.go TreeDB/collections/vector_index_search_test.go TreeDB/collections/column_vector_graph_quantized_asset.go TreeDB/collections/column_vector_graph_quantized_scorer.go TreeDB/collections/column_vector_graph_search.go TreeDB/collections/column_vector_graph_quantized_bench_test.go TreeDB/collections/collection_vector_index_prepared_search_cache.go TreeDB/docs/docs_lint_test.go TreeDB/docs/vector_high_qps_collection_api_test.go
git diff --check
# pass

GOWORK=off go test ./TreeDB/collections -run 'Test(SearchVectorIndexQuantizedOnlyAndRerankSupported1926|VectorIndexSearcherQuantizedSearchWithBufferSuccessAndErrorReset1926|VectorIndexSearcherQuantizedAssetUnavailableCounters2416|ColumnGraphQuantizedAssetValidationFailClosedWhenUnavailable1926|VectorIndexSearcherSearchWithBufferHighQPSContractRejectsDocuments2361|SearchVectorIndexWithBufferMatchesSearcherSearchWithBuffer2362|SearchVectorIndexWithBufferOpenScopedAllocationContract2362|SearchVectorIndexWithBufferMissingIndexStateFailsClosed2408|SearchVectorIndexWithBufferClosedDBFailsClosed2408|SearchVectorIndexWithBufferUnsupportedShapesFailClosed2362)$' -count=1
# ok github.com/snissn/gomap/TreeDB/collections 1.431s

GOWORK=off go test ./TreeDB/collections -count=1
# ok github.com/snissn/gomap/TreeDB/collections 57.074s

GOWORK=off go test ./TreeDB/docs -count=1
# ok github.com/snissn/gomap/TreeDB/docs 1.682s
```

Latest sync logs:

- `/tmp/gomap_2416_sync_focused_tests.log`
- `/tmp/gomap_2416_sync_collections_tests.log`
- `/tmp/gomap_2416_sync_docs_tests.log`

## Latest-head sync update (origin/main 8c6357979)

Synced with `origin/main` `8c635797924645b45729249d86c531a1e9556db7` via merge-forward/no force-push. Latest PR head: `b1e6ce36e649895724e8091513aef591a705961d`.

Conflict status: merge was conflict-free; gofmt and `git diff --check` passed after sync. #2416 codec-generic `quantized_*` counter names and exact FP32 `hnsw_search_pack_v1` separation are preserved, along with newly merged #2404/#2413 vector-search/profile changes.

Latest sync validation:

```sh
gofmt -w TreeDB/collections/vector_index_search.go TreeDB/collections/vector_index_search_test.go TreeDB/collections/column_vector_graph_quantized_asset.go TreeDB/collections/column_vector_graph_quantized_scorer.go TreeDB/collections/column_vector_graph_search.go TreeDB/collections/column_vector_graph_quantized_bench_test.go TreeDB/collections/collection_vector_index_prepared_search_cache.go cmd/treedb_vector_search_demo/main.go cmd/treedb_vector_search_demo/main_test.go
git diff --check
# pass

GOWORK=off go test ./TreeDB/collections -run 'Test(SearchVectorIndexQuantizedOnlyAndRerankSupported1926|VectorIndexSearcherQuantizedSearchWithBufferSuccessAndErrorReset1926|VectorIndexSearcherQuantizedAssetUnavailableCounters2416|ColumnGraphQuantizedAssetValidationFailClosedWhenUnavailable1926|VectorIndexSearcherSearchWithBufferHighQPSContractRejectsDocuments2361|SearchVectorIndexWithBufferMatchesSearcherSearchWithBuffer2362|SearchVectorIndexWithBufferOpenScopedAllocationContract2362|SearchVectorIndexWithBufferMissingIndexStateFailsClosed2408|SearchVectorIndexWithBufferClosedDBFailsClosed2408|SearchVectorIndexWithBufferUnsupportedShapesFailClosed2362)$' -count=1
# ok github.com/snissn/gomap/TreeDB/collections 2.057s

GOWORK=off go test ./TreeDB/collections -count=1
# ok github.com/snissn/gomap/TreeDB/collections 48.197s

GOWORK=off go test ./TreeDB/docs -count=1
# ok github.com/snissn/gomap/TreeDB/docs 1.156s
```

Latest sync logs:

- `/tmp/gomap_2416_sync2_focused_tests.log`
- `/tmp/gomap_2416_sync2_collections_tests.log`
- `/tmp/gomap_2416_sync2_docs_tests.log`

## CI / AI review status

Final latest-head status:

- Head: `b1e6ce36e649895724e8091513aef591a705961d`
- Base: `origin/main` `8c635797924645b45729249d86c531a1e9556db7`
- Merge state: `CLEAN`
- CI: latest-head checks are green, including gofmt, Linux suites/profiles/bench/perf/race, macOS, Ubuntu, Windows core/caching, append-only snapshot guardrail, and windows-latest.
- Codex: latest synced-head comment reports no major issues.
- CodeRabbit: status context is pass / review skipped after the earlier stale thread was answered and resolved/retracted; no detailed blocking findings remain.
- Copilot: requested on the synced head; no actionable PR-thread findings are present.
- Review threads: GraphQL inventory shows `0` unresolved review threads.
- Merge: not performed by this PR manager.
