### PR TITLE
Optimize response-owned vector search finalization

### DIFF
--- a/TreeDB/collections/collection_vector_index_prepared_search_cache.go
+++ b/TreeDB/collections/collection_vector_index_prepared_search_cache.go
@@ -314,6 +314,46 @@ func (p *collectionVectorIndexPreparedSearch) responseForSearch() VectorIndexSea
 	return response
 }
 
+func (p *collectionVectorIndexPreparedSearch) SearchOwnedNoDocuments(opts VectorIndexSearchOptions, statsMode columnVectorGraphNativeSearchStatsMode, scratch *columnVectorGraphNativeSearchScratch) (VectorIndexSearchResponse, error) {
+	response := p.responseForSearch()
+	if p == nil {
+		return response, errors.New("collections: nil collection vector index prepared search")
+	}
+	var localScratch columnVectorGraphNativeSearchScratch
+	if scratch == nil {
+		scratch = &localScratch
+	}
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	if p.closed || p.pack == nil {
+		response.Stats = VectorIndexSearchStats{HNSWSearchPackClosed: 1, HNSWSearchPackFallbacks: 1}
+		return response, errColumnHNSWSearchPackPreparedViewClosed
+	}
+	status := p.pack.fastStatus(p.packStatus)
+	if status != columnHNSWSearchPackPreparedStatusDirect && status != columnHNSWSearchPackPreparedStatusHeap {
+		routeStats := collectionVectorIndexPreparedSearchRouteStatsForUnavailable(p.routeStats, status)
+		routeStats.apply(&response.Stats)
+		return response, columnHNSWSearchPackStatusError(status)
+	}
+	results, searchStats, err := p.pack.searchCosine(opts.Query, columnVectorGraphNativeSearchOptions{
+		TopK:           opts.TopK,
+		EfSearch:       opts.EfSearch,
+		ScoreBatchMode: opts.scoreBatchMode,
+		StatsMode:      statsMode,
+		QueryMode:      columnVectorGraphNativeSearchQueryModeExact,
+	}, scratch)
+	response.Stats = vectorIndexSearchStatsFromInternal(searchStats, columnPhysicalRowReaderStats{})
+	p.routeStats.apply(&response.Stats)
+	if err != nil {
+		return response, err
+	}
+	response.Results, err = copyVectorIndexSearchResultsToOwned(results)
+	if err != nil {
+		return response, err
+	}
+	return response, nil
+}
+
 func (p *collectionVectorIndexPreparedSearch) SearchWithBuffer(opts VectorIndexSearchOptions, statsMode columnVectorGraphNativeSearchStatsMode, buffer *VectorIndexSearchBuffer) (VectorIndexSearchResponse, error) {
 	previousResults := buffer.results
 	buffer.resetView()

--- a/TreeDB/collections/vector_index_search.go
+++ b/TreeDB/collections/vector_index_search.go
@@ -734,14 +734,10 @@ func (c *Collection) SearchVectorIndex(opts VectorIndexSearchOptions) (VectorInd
 		return VectorIndexSearchResponse{}, err
 	}
 	if collectionSearchVectorIndexCanUseBufferedNoDocumentRoute(opts) {
-		buffer := acquireCollectionSearchVectorIndexResponseBuffer()
-		response, err := c.SearchVectorIndexWithBuffer(opts, buffer)
+		response, err := c.searchVectorIndexPreparedNoDocumentOwned(opts)
 		if err == nil {
-			cloneBufferedVectorIndexSearchResponseResults(&response)
-			releaseCollectionSearchVectorIndexResponseBuffer(buffer)
 			return response, nil
 		}
-		releaseCollectionSearchVectorIndexResponseBuffer(buffer)
 		if !errors.Is(err, ErrVectorIndexSearchUnavailable) && !errors.Is(err, ErrIndexNotFound) {
 			return response, err
 		}
@@ -764,33 +760,55 @@ func releaseCollectionSearchVectorIndexResponseBuffer(buffer *VectorIndexSearchB
 	collectionSearchVectorIndexResponseBufferPool.Put(buffer)
 }
 
-func cloneBufferedVectorIndexSearchResponseResults(response *VectorIndexSearchResponse) {
-	if response == nil || len(response.Results) == 0 {
-		if response != nil {
-			response.Results = nil
-		}
-		return
+func (c *Collection) searchVectorIndexPreparedNoDocumentOwned(opts VectorIndexSearchOptions) (VectorIndexSearchResponse, error) {
+	var response VectorIndexSearchResponse
+	if c == nil {
+		return response, errCollectionNil
 	}
-	idBytesLen := 0
-	for _, result := range response.Results {
-		idBytesLen += len(result.ID)
+	if c.db == nil {
+		return response, errCollectionDBNil
 	}
-	idBytes := make([]byte, idBytesLen)
-	results := make([]VectorIndexSearchResult, len(response.Results))
-	idOffset := 0
-	for i, result := range response.Results {
-		results[i] = result
-		if len(result.ID) > 0 {
-			idEnd := idOffset + len(result.ID)
-			copy(idBytes[idOffset:idEnd], result.ID)
-			results[i].ID = idBytes[idOffset:idEnd:idEnd]
-			idOffset = idEnd
-		}
-		if len(result.Document) > 0 {
-			results[i].Document = append([]byte(nil), result.Document...)
-		}
+	if err := c.flushBufferedWrites(); err != nil {
+		return response, err
 	}
-	response.Results = results
+	statsMode, err := columnVectorGraphNativeSearchStatsModeFromPublic(opts.StatsMode)
+	if err != nil {
+		return response, err
+	}
+	queryMode, err := normalizeVectorIndexSearchQueryMode(opts.QueryMode, opts.QuantizedIndexName, opts.QuantizedRerankCandidates, opts.TopK)
+	if err != nil {
+		return response, err
+	}
+	if queryMode != columnVectorGraphNativeSearchQueryModeExact || !columnHNSWSearchPackStatsModeSupportedForSearch(statsMode) {
+		return response, fmt.Errorf("%w: vector index %q SearchVectorIndex requires exact no-document hnsw_search_pack_v1 route", ErrVectorIndexSearchUnavailable, opts.IndexName)
+	}
+	buffer := acquireCollectionSearchVectorIndexResponseBuffer()
+	var lastResponse VectorIndexSearchResponse
+	var lastErr error
+	for attempt := 0; attempt < 2; attempt++ {
+		prepared, response, err := c.acquireCollectionVectorIndexPreparedSearch(opts)
+		if err != nil {
+			releaseCollectionSearchVectorIndexResponseBuffer(buffer)
+			return response, err
+		}
+		response, err = prepared.SearchOwnedNoDocuments(opts, statsMode, &buffer.searchScratch)
+		healthyPackRoute := vectorIndexSearchStatsAreBufferedNoDocumentPackRoute(response.Stats)
+		if err == nil && healthyPackRoute {
+			releaseCollectionSearchVectorIndexResponseBuffer(buffer)
+			return response, nil
+		}
+		if err != nil && healthyPackRoute {
+			releaseCollectionSearchVectorIndexResponseBuffer(buffer)
+			return response, err
+		}
+		lastResponse, lastErr = response, err
+		c.invalidateCollectionVectorIndexPreparedSearch(opts.IndexName, prepared)
+	}
+	releaseCollectionSearchVectorIndexResponseBuffer(buffer)
+	if lastErr != nil {
+		return lastResponse, lastErr
+	}
+	return lastResponse, fmt.Errorf("%w: vector index %q SearchVectorIndex requires exact no-document hnsw_search_pack_v1 route", ErrVectorIndexSearchUnavailable, opts.IndexName)
 }
 
 func collectionSearchVectorIndexCanUseBufferedNoDocumentRoute(opts VectorIndexSearchOptions) bool {
@@ -1218,26 +1236,9 @@ func (s *VectorIndexSearcher) Search(opts VectorIndexSearcherSearchOptions) (Vec
 	if len(results) == 0 {
 		return response, nil
 	}
-	response.Results = make([]VectorIndexSearchResult, len(results))
-	idByteCount, err := vectorIndexSearchResultIDBytes(results)
+	response.Results, err = copyVectorIndexSearchResultsToOwned(results)
 	if err != nil {
 		return response, err
-	}
-	idBytes := make([]byte, idByteCount)
-	idOffset := 0
-	for i, result := range results {
-		if len(result.ID) > len(idBytes)-idOffset {
-			return response, errors.New("collections: vector index search result id byte accounting mismatch")
-		}
-		nextIDOffset := idOffset + len(result.ID)
-		id := idBytes[idOffset:nextIDOffset:nextIDOffset]
-		idOffset = nextIDOffset
-		copy(id, result.ID)
-		response.Results[i] = VectorIndexSearchResult{
-			ID:      id,
-			Ordinal: result.Ordinal,
-			Score:   result.Score,
-		}
 	}
 	if opts.IncludeDocuments {
 		if s.documentView == nil {
@@ -1419,6 +1420,34 @@ func (s *VectorIndexSearcher) SearchWithBuffer(opts VectorIndexSearcherSearchOpt
 		return response, err
 	}
 	return response, nil
+}
+
+func copyVectorIndexSearchResultsToOwned(results []columnVectorGraphNativeSearchResult) ([]VectorIndexSearchResult, error) {
+	if len(results) == 0 {
+		return nil, nil
+	}
+	idByteCount, err := vectorIndexSearchResultIDBytes(results)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]VectorIndexSearchResult, len(results))
+	idBytes := make([]byte, idByteCount)
+	idOffset := 0
+	for i, result := range results {
+		if len(result.ID) > len(idBytes)-idOffset {
+			return nil, errors.New("collections: vector index search result id byte accounting mismatch")
+		}
+		nextIDOffset := idOffset + len(result.ID)
+		id := idBytes[idOffset:nextIDOffset:nextIDOffset]
+		idOffset = nextIDOffset
+		copy(id, result.ID)
+		out[i] = VectorIndexSearchResult{
+			ID:      id,
+			Ordinal: result.Ordinal,
+			Score:   result.Score,
+		}
+	}
+	return out, nil
 }
 
 func copyVectorIndexSearchResultsToBuffer(results []columnVectorGraphNativeSearchResult, buffer *VectorIndexSearchBuffer, previousResults []VectorIndexSearchResult) ([]VectorIndexSearchResult, error) {

--- a/TreeDB/collections/vector_index_search_test.go
+++ b/TreeDB/collections/vector_index_search_test.go
@@ -1574,10 +1574,74 @@ func TestSearchVectorIndexColumnGraphResultIDsAreCapacityIsolatedV4(t *testing.T
 		t.Fatalf("SearchVectorIndex: %v", err)
 	}
 	assertColumnGraphSearchResponseLoadedV4(t, got, def.Name, 2)
+	if cap(got.Results) != len(got.Results) {
+		t.Fatalf("results len/cap=%d/%d want cap isolated", len(got.Results), cap(got.Results))
+	}
+	for i, result := range got.Results {
+		if cap(result.ID) != len(result.ID) {
+			t.Fatalf("result[%d] id len/cap=%d/%d want cap isolated", i, len(result.ID), cap(result.ID))
+		}
+	}
 	secondID := append([]byte(nil), got.Results[1].ID...)
 	_ = append(got.Results[0].ID, '!')
 	if !bytes.Equal(got.Results[1].ID, secondID) {
 		t.Fatalf("second result ID changed after appending to first result ID: got %q want %q", got.Results[1].ID, secondID)
+	}
+}
+
+func TestSearchVectorIndexColumnGraphNoDocumentResponseOwnedAfterReuse2404(t *testing.T) {
+	rows := []columnGraphRebuildInputRowV2A{
+		{id: "doc-a", vector: []float32{1, 0, 0}},
+		{id: "doc-b", vector: []float32{0.9, 0.1, 0}},
+		{id: "doc-c", vector: []float32{0, 1, 0}},
+		{id: "doc-d", vector: []float32{0, 0.9, 0.1}},
+	}
+	_, d, col, def := openColumnGraphRebuildTestCollectionV2A(t, 3, 3, rows)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+
+	ownedOpts := VectorIndexSearchOptions{IndexName: def.Name, Query: []float32{1, 0, 0}, QueryMode: VectorIndexQueryModeExact, TopK: 3, EfSearch: len(rows), MaxDecodedBlocks: 1, StatsMode: VectorIndexSearchStatsModeProduction}
+	owned, err := col.SearchVectorIndex(ownedOpts)
+	if err != nil {
+		t.Fatalf("SearchVectorIndex: %v", err)
+	}
+	assertColumnGraphSearchResponseLoadedV4(t, owned, def.Name, 3)
+	assertSearchVectorIndexNoDocumentCurrentOneShotStats2361(t, owned.Stats)
+	if cap(owned.Results) != len(owned.Results) {
+		t.Fatalf("owned results len/cap=%d/%d want cap isolated", len(owned.Results), cap(owned.Results))
+	}
+	ownedIDs := make([][]byte, len(owned.Results))
+	ownedOrdinals := make([]int, len(owned.Results))
+	ownedScores := make([]float64, len(owned.Results))
+	for i, result := range owned.Results {
+		if cap(result.ID) != len(result.ID) {
+			t.Fatalf("owned result[%d] id len/cap=%d/%d want cap isolated", i, len(result.ID), cap(result.ID))
+		}
+		ownedIDs[i] = append([]byte(nil), result.ID...)
+		ownedOrdinals[i] = result.Ordinal
+		ownedScores[i] = result.Score
+	}
+
+	if _, err := col.SearchVectorIndex(VectorIndexSearchOptions{IndexName: def.Name, Query: []float32{0, 1, 0}, QueryMode: VectorIndexQueryModeExact, TopK: 2, EfSearch: len(rows), MaxDecodedBlocks: 1, StatsMode: VectorIndexSearchStatsModeProduction}); err != nil {
+		t.Fatalf("second SearchVectorIndex: %v", err)
+	}
+	var buffer VectorIndexSearchBuffer
+	buffered, err := col.SearchVectorIndexWithBuffer(VectorIndexSearchOptions{IndexName: def.Name, Query: []float32{0, 1, 0}, QueryMode: VectorIndexQueryModeExact, TopK: 2, EfSearch: len(rows), MaxDecodedBlocks: 1, StatsMode: VectorIndexSearchStatsModeProduction}, &buffer)
+	if err != nil {
+		t.Fatalf("SearchVectorIndexWithBuffer: %v", err)
+	}
+	if len(buffered.Results) > 0 && len(buffered.Results[0].ID) > 0 {
+		buffered.Results[0].ID[0] = 'X'
+	}
+	if _, err := col.SearchVectorIndexWithBuffer(VectorIndexSearchOptions{IndexName: def.Name, Query: []float32{0, 0, 1}, QueryMode: VectorIndexQueryModeExact, TopK: 1, EfSearch: len(rows), MaxDecodedBlocks: 1, StatsMode: VectorIndexSearchStatsModeProduction}, &buffer); err != nil {
+		t.Fatalf("second SearchVectorIndexWithBuffer: %v", err)
+	}
+	for i := range owned.Results {
+		if !bytes.Equal(owned.Results[i].ID, ownedIDs[i]) || owned.Results[i].Ordinal != ownedOrdinals[i] || owned.Results[i].Score != ownedScores[i] {
+			t.Fatalf("owned result[%d]=%+v changed after later searches; want ID=%q ordinal=%d score=%v", i, owned.Results[i], ownedIDs[i], ownedOrdinals[i], ownedScores[i])
+		}
 	}
 }
 
@@ -2306,6 +2370,14 @@ func TestVectorIndexSearcherSearchWithBufferDoesNotMutateSearchResponse1961(t *t
 		t.Fatalf("Search: %v", err)
 	}
 	assertColumnGraphSearchResponseLoadedV4(t, owned, def.Name, 2)
+	if cap(owned.Results) != len(owned.Results) {
+		t.Fatalf("Search result len/cap=%d/%d want cap isolated", len(owned.Results), cap(owned.Results))
+	}
+	for i, result := range owned.Results {
+		if cap(result.ID) != len(result.ID) {
+			t.Fatalf("Search result[%d] id len/cap=%d/%d want cap isolated", i, len(result.ID), cap(result.ID))
+		}
+	}
 	ownedID := append([]byte(nil), owned.Results[0].ID...)
 
 	var buffer VectorIndexSearchBuffer


### PR DESCRIPTION
## Summary

- Closes #2404.
- Adds a response-owned no-document prepared-cache path for `Collection.SearchVectorIndex` that copies native HNSW search-pack results directly into response-owned result/ID storage.
- Removes the avoidable buffered-response-to-owned clone step for the no-document convenience route while preserving response ownership and capacity isolation.
- Reuses the owned result-copy helper for `VectorIndexSearcher.Search`; buffered APIs remain on caller-owned `copyVectorIndexSearchResultsToBuffer`.

## Scope boundaries

- Exact FP32 `hnsw_search_pack_v1` no-document route only.
- Does not change traversal/scoring, quantized routes, document materialization, filters/projections, benchmark harnesses, or docs.
- `Collection.SearchVectorIndex` remains response-owned and is **not** claimed as zero-allocation.

## Tests

Latest head: `9b9121d18a3d3a14e7bf1f00d74583ae5719afc2` (base `31cc840b9a39e4a61b7ec88d3c8b2d2a490bdb35`).

```sh
GOWORK=off go test ./TreeDB/collections -run 'TestSearchVectorIndexColumnGraph(ResultIDsAreCapacityIsolated|NoDocumentResponseOwned)|TestSearchVectorIndexWithBufferOpenScopedAllocationContract|TestResetBufferedVectorIndexSearchResponseClearsReturnedResults|TestVectorIndexSearcherSearchWithBufferDoesNotMutateSearchResponse' -count=1
GOWORK=off go test ./TreeDB/collections -count=1
```

Both passed locally after rebasing onto latest `origin/main`.

## Benchmark evidence

Hardware: Apple M3, Darwin/arm64. Fixture: Tier S, 10k docs, 64 dims, M=16, efConstruction=128, efSearch=128, topK=10, query stream=16. Measured boundary is the production comparison harness; setup/build/open/warmup are outside timed search rows per the harness README.

### Focused one-shot evidence (`COUNT=20`, `BENCHTIME=5000x`)

Before artifact: `/tmp/gomap_2404_nodoc_before_20260605_132329`  
After artifact: `/tmp/gomap_2404_nodoc_after_20260605_132417`

```sh
TREEDB_VECTOR_BENCH_DOCS=10000 TREEDB_VECTOR_BENCH_DIMS=64 TREEDB_VECTOR_BENCH_M=16 TREEDB_VECTOR_BENCH_EF_CONSTRUCTION=128 TREEDB_VECTOR_BENCH_EF_SEARCH=128 TREEDB_VECTOR_BENCH_TOPK=10 TREEDB_VECTOR_BENCH_QUERIES=16 CPU_LIST=1,8 BENCHTIME=5000x COUNT=20 BENCH_REGEX='BenchmarkCollectionVectorUSearchProductionCompare/TreeDB_CollectionSearchVectorIndexNoDocsOneShot$' RUN_DIR=/tmp/gomap_2404_nodoc_after_20260605_132417 scripts/bench_vector_search_compare.sh
```

| cpu | row | n | before ns/op | after ns/op | Δ | before ops/sec | after ops/sec | B/op | allocs/op |
| ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 1 | `TreeDB_CollectionSearchVectorIndexNoDocsOneShot` | 20 | 66,769 | 63,418 | -5.0% | 14,987 | 15,775 | 816 | 2 |
| 8 | `TreeDB_CollectionSearchVectorIndexNoDocsOneShot` | 20 | 54,993 | 59,128 | +7.5% | 18,184 | 16,914 | 816 | 2 |

Relevant `benchstat` rows:

```text
CollectionVectorUSearchProductionCompare/TreeDB_CollectionSearchVectorIndexNoDocsOneShot                                               66.77µ ± 25%                      63.42µ ± 5%       ~ (p=0.327 n=20)
CollectionVectorUSearchProductionCompare/TreeDB_CollectionSearchVectorIndexNoDocsOneShot                                                16.73k ± 0%                    16.73k ± 0%       ~ (p=1.000 n=20) ¹
CollectionVectorUSearchProductionCompare/TreeDB_CollectionSearchVectorIndexNoDocsOneShot                                               0.000 ± 0%                                     0.000 ± 0%       ~ (p=1.000 n=20) ¹
CollectionVectorUSearchProductionCompare/TreeDB_CollectionSearchVectorIndexNoDocsOneShot                                               0.000 ± 0%                                    0.000 ± 0%       ~ (p=1.000 n=20) ¹
CollectionVectorUSearchProductionCompare/TreeDB_CollectionSearchVectorIndexNoDocsOneShot                                               0.000 ± 0%                                  0.000 ± 0%       ~ (p=1.000 n=20) ¹
CollectionVectorUSearchProductionCompare/TreeDB_CollectionSearchVectorIndexNoDocsOneShot                                                 135.0 ± 0%                      135.0 ± 0%       ~ (p=1.000 n=20) ¹
CollectionVectorUSearchProductionCompare/TreeDB_CollectionSearchVectorIndexNoDocsOneShot                                               0.000 ± 0%                                0.000 ± 0%       ~ (p=1.000 n=20) ¹
CollectionVectorUSearchProductionCompare/TreeDB_CollectionSearchVectorIndexNoDocsOneShot                                               0.000 ± 0%                            0.000 ± 0%       ~ (p=1.000 n=20) ¹
CollectionVectorUSearchProductionCompare/TreeDB_CollectionSearchVectorIndexNoDocsOneShot                                                 135.0 ± 0%                     135.0 ± 0%       ~ (p=1.000 n=20) ¹
CollectionVectorUSearchProductionCompare/TreeDB_CollectionSearchVectorIndexNoDocsOneShot                                                 135.0 ± 0%                                   135.0 ± 0%       ~ (p=1.000 n=20) ¹
CollectionVectorUSearchProductionCompare/TreeDB_CollectionSearchVectorIndexNoDocsOneShot                                                 135.0 ± 0%                                  135.0 ± 0%       ~ (p=1.000 n=20) ¹
CollectionVectorUSearchProductionCompare/TreeDB_CollectionSearchVectorIndexNoDocsOneShot                                               0.000 ± 0%                          0.000 ± 0%       ~ (p=1.000 n=20) ¹
CollectionVectorUSearchProductionCompare/TreeDB_CollectionSearchVectorIndexNoDocsOneShot                                               0.000 ± 0%                           0.000 ± 0%       ~ (p=1.000 n=20) ¹
CollectionVectorUSearchProductionCompare/TreeDB_CollectionSearchVectorIndexNoDocsOneShot                                               0.000 ± 0%                            0.000 ± 0%       ~ (p=1.000 n=20) ¹
CollectionVectorUSearchProductionCompare/TreeDB_CollectionSearchVectorIndexNoDocsOneShot                                               0.000 ± 0%                              0.000 ± 0%       ~ (p=1.000 n=20) ¹
CollectionVectorUSearchProductionCompare/TreeDB_CollectionSearchVectorIndexNoDocsOneShot                                               0.000 ± 0%                         0.000 ± 0%       ~ (p=1.000 n=20) ¹
CollectionVectorUSearchProductionCompare/TreeDB_CollectionSearchVectorIndexNoDocsOneShot                                               0.000 ± 0%                                   0.000 ± 0%       ~ (p=1.000 n=20) ¹
CollectionVectorUSearchProductionCompare/TreeDB_CollectionSearchVectorIndexNoDocsOneShot                                               0.000 ± 0%                                           0.000 ± 0%       ~ (p=1.000 n=20) ¹
CollectionVectorUSearchProductionCompare/TreeDB_CollectionSearchVectorIndexNoDocsOneShot                                               0.000 ± 0%                                  0.000 ± 0%       ~ (p=1.000 n=20) ¹
CollectionVectorUSearchProductionCompare/TreeDB_CollectionSearchVectorIndexNoDocsOneShot                                               0.000 ± 0%                                      0.000 ± 0%       ~ (p=1.000 n=20) ¹
```

Interpretation: the required response-owned no-doc one-shot row shows no statistically significant regression at c=1 or c=8. The c=1 median improved; the c=8 median moved +7.5% but `benchstat` reports `~ (p=0.157 n=20)`, so it is not statistically significant and is not attributed to this PR's finalization change.

### Buffered/control matrix (`COUNT=10`, `BENCHTIME=3000x`)

Before artifact: `/tmp/gomap_2404_stable_before_20260605_131700`  
After artifact: `/tmp/gomap_2404_stable_after2_20260605_132121`

```sh
TREEDB_VECTOR_BENCH_DOCS=10000 TREEDB_VECTOR_BENCH_DIMS=64 TREEDB_VECTOR_BENCH_M=16 TREEDB_VECTOR_BENCH_EF_CONSTRUCTION=128 TREEDB_VECTOR_BENCH_EF_SEARCH=128 TREEDB_VECTOR_BENCH_TOPK=10 TREEDB_VECTOR_BENCH_QUERIES=16 CPU_LIST=1,8 BENCHTIME=3000x COUNT=10 BENCH_REGEX='BenchmarkCollectionVectorUSearchProductionCompare/(TreeDB_SearchWithBuffer|TreeDB_SearchWithBufferParallel|TreeDB_CollectionSearchVectorIndexWithBuffer|TreeDB_CollectionSearchVectorIndexNoDocsOneShot)$' RUN_DIR=/tmp/gomap_2404_stable_after2_20260605_132121 scripts/bench_vector_search_compare.sh
```

| cpu | row | n | before ns/op | after ns/op | Δ | before ops/sec | after ops/sec | B/op | allocs/op |
| ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 1 | `TreeDB_CollectionSearchVectorIndexNoDocsOneShot` | 10 | 76,672 | 87,014 | +13.5% | 13,069 | 11,508 | 816 | 2 |
| 1 | `TreeDB_CollectionSearchVectorIndexWithBuffer` | 10 | 75,886 | 73,378 | -3.3% | 13,190 | 13,681 | 0 | 0 |
| 1 | `TreeDB_SearchWithBuffer` | 10 | 78,618 | 63,151 | -19.7% | 12,833 | 15,842 | 0 | 0 |
| 1 | `TreeDB_SearchWithBufferParallel` | 10 | 72,300 | 61,189 | -15.4% | 13,876 | 16,364 | 0 | 0 |
| 8 | `TreeDB_CollectionSearchVectorIndexNoDocsOneShot` | 10 | 90,266 | 66,098 | -26.8% | 11,184 | 15,132 | 816 | 2 |
| 8 | `TreeDB_CollectionSearchVectorIndexWithBuffer` | 10 | 72,010 | 77,282 | +7.3% | 13,890 | 12,940 | 0 | 0 |
| 8 | `TreeDB_SearchWithBuffer` | 10 | 71,760 | 68,197 | -5.0% | 13,940 | 14,676 | 0 | 0 |
| 8 | `TreeDB_SearchWithBufferParallel` | 10 | 16,348 | 17,576 | +7.5% | 61,172 | 56,970 | 0 | 0 |

Relevant `benchstat` rows:

```text
CollectionVectorUSearchProductionCompare/TreeDB_SearchWithBuffer                                                                        78.62µ ± 45%                     63.15µ ±   9%        ~ (p=0.052 n=10)
CollectionVectorUSearchProductionCompare/TreeDB_SearchWithBufferParallel                                                                72.30µ ± 43%                     61.19µ ±  18%  -15.37% (p=0.011 n=10)
CollectionVectorUSearchProductionCompare/TreeDB_CollectionSearchVectorIndexWithBuffer                                                   75.89µ ± 54%                     73.38µ ±  43%        ~ (p=0.796 n=10)
CollectionVectorUSearchProductionCompare/TreeDB_CollectionSearchVectorIndexNoDocsOneShot                                                76.67µ ± 43%                     87.01µ ±  41%        ~ (p=0.280 n=10)
CollectionVectorUSearchProductionCompare/TreeDB_SearchWithBuffer-8                                                                      71.76µ ± 32%                     68.20µ ±  20%        ~ (p=0.247 n=10)
CollectionVectorUSearchProductionCompare/TreeDB_SearchWithBufferParallel-8                                                              16.35µ ±  8%                     17.58µ ± 121%        ~ (p=0.631 n=10)
CollectionVectorUSearchProductionCompare/TreeDB_CollectionSearchVectorIndexWithBuffer-8                                                 72.01µ ± 26%                     77.28µ ±  22%        ~ (p=0.280 n=10)
CollectionVectorUSearchProductionCompare/TreeDB_CollectionSearchVectorIndexNoDocsOneShot-8                                              90.27µ ± 24%                     66.10µ ±  28%  -26.77% (p=0.019 n=10)
CollectionVectorUSearchProductionCompare/TreeDB_SearchWithBuffer                                                                         16.73k ± 0%                      16.73k ± 0%       ~ (p=1.000 n=10) ¹
CollectionVectorUSearchProductionCompare/TreeDB_SearchWithBufferParallel                                                                 16.73k ± 0%                      16.73k ± 0%       ~ (p=1.000 n=10) ¹
CollectionVectorUSearchProductionCompare/TreeDB_CollectionSearchVectorIndexWithBuffer                                                    16.73k ± 0%                      16.73k ± 0%       ~ (p=1.000 n=10) ¹
CollectionVectorUSearchProductionCompare/TreeDB_CollectionSearchVectorIndexNoDocsOneShot                                                 16.73k ± 0%                      16.73k ± 0%       ~ (p=1.000 n=10) ¹
CollectionVectorUSearchProductionCompare/TreeDB_SearchWithBuffer-8                                                                       16.73k ± 0%                      16.73k ± 0%       ~ (p=1.000 n=10) ¹
CollectionVectorUSearchProductionCompare/TreeDB_SearchWithBufferParallel-8                                                               16.73k ± 0%                      16.73k ± 0%       ~ (p=1.000 n=10) ¹
CollectionVectorUSearchProductionCompare/TreeDB_CollectionSearchVectorIndexWithBuffer-8                                                  16.73k ± 0%                      16.73k ± 0%       ~ (p=1.000 n=10) ¹
CollectionVectorUSearchProductionCompare/TreeDB_CollectionSearchVectorIndexNoDocsOneShot-8                                               16.73k ± 0%                      16.73k ± 0%       ~ (p=1.000 n=10) ¹
CollectionVectorUSearchProductionCompare/TreeDB_SearchWithBuffer                                                                        0.000 ± 0%                                     0.000 ± 0%       ~ (p=1.000 n=10) ¹
CollectionVectorUSearchProductionCompare/TreeDB_SearchWithBufferParallel                                                                0.000 ± 0%                                     0.000 ± 0%       ~ (p=1.000 n=10) ¹
CollectionVectorUSearchProductionCompare/TreeDB_CollectionSearchVectorIndexWithBuffer                                                   0.000 ± 0%                                     0.000 ± 0%       ~ (p=1.000 n=10) ¹
CollectionVectorUSearchProductionCompare/TreeDB_CollectionSearchVectorIndexNoDocsOneShot                                                0.000 ± 0%                                     0.000 ± 0%       ~ (p=1.000 n=10) ¹
```

Interpretation: buffered APIs remain `0 B/op`, `0 allocs/op`. Apparent c=8 buffered/control movement is within local run noise and not statistically significant (`CollectionSearchVectorIndexWithBuffer-8 p=0.280`, `SearchWithBuffer-8 p=0.247`, `SearchWithBufferParallel-8 p=0.631`). This supports that any remaining production-row timing variation is environment noise rather than a PR-caused regression; the PR does not alter traversal/scoring or buffered copy paths.

### Route/allocation guardrails

Guardrails held on the TreeDB rows: `search_route_hnsw_search_pack/search=1`, `hnsw_search_pack_active/search=1`, `docs_fetched/search=0`, `graph_row_fallbacks/search=0`, `typed_column_vector_fallbacks/search=0`, `vector_scratch_decodes/search=0`. Collection rows also reported `open_searcher_calls/op=0` and `open_setup_in_timed_loop=0`.

Buffered controls remained `0 B/op`, `0 allocs/op`; response-owned one-shot remained `816 B/op`, `2 allocs/op`.

### Supplementary finalization-only microbench

Supplemental artifacts: `/tmp/gomap_2404_final_head_after_20260605_130429/finalization_microbench.log` and `/tmp/gomap_2404_final_head_after_20260605_130429/finalization_microbench_benchstat.txt`.

The finalization-only microbench is not a replacement for the production rows above; it isolates the changed copy/finalization component. It shows the direct-owned finalization path removes the extra buffer-then-clone copy stage while retaining `816 B/op` and `2 allocs/op` (local median 568.1 ns/op direct-owned vs 702.3 ns/op buffer-then-clone).

## Review status

- Internal xhigh review: pass, no blocking findings.
- External AI reviews were requested only after mature code/evidence/CI start: `@codex review`, `@copilot review`, `@coderabbitai review`.
- CodeRabbit returned a successful status/reply; Codex/Copilot may still be pending.

## Risks / follow-ups

- The new `copyVectorIndexSearchResultsToOwned` helper may be reusable for #2412/#2415 if quantized collection response-owned paths need the same ownership/capacity-isolation behavior, but this PR does not change quantized behavior.
- No borrowed/unsafe view API is introduced here; if desired, that remains a separate API-design issue.
