### PR TITLE
docs: classify vector search parallel scaling profiles

### DIFF
--- a/TreeDB/docs/guides/vector-search-benchmark-workflow.md
+++ b/TreeDB/docs/guides/vector-search-benchmark-workflow.md
@@ -224,3 +224,22 @@ dot/scoring, frontier/top-k maintenance, and final result-ID copy for
 response-owned convenience calls. Dominant document/JSON materialization,
 graph-row fallback, typed-column vector fallback, per-query open/prepare, or
 allocation/GC costs are blocking evidence for a no-document fast-row claim.
+
+### Parallel scaling profile interpretation
+
+Use the `TreeDB_SearchWithBufferParallel` row, not a serial row with only
+`-cpu=8`, when classifying c=8+ reusable-buffer scaling. The parallel row must
+show one opened searcher and one `VectorIndexSearchBuffer` per worker,
+`parallel_workers=<GOMAXPROCS>`, `0 B/op`, `0 allocs/op`, and the no-document
+route counters above. Treat the profile as evidence of avoidable contention only
+when the steady-state timed branch shows material time in shared locks, atomics,
+resource-manager lookups, collection prepared-cache synchronization, per-query
+open/setup, or response-owned allocation/GC.
+
+When the c=8 profile is instead dominated by
+`columnHNSWSearchPackPreparedView.searchCosine`, `vectorops.DotFloat32Indexed` /
+platform SIMD kernels, `insertTop`, `pushFrontier`, `popFrontier`, or
+frontier/top-k heap maintenance, classify the remaining gap as traversal,
+scoring, or ranking-kernel work. Keep that follow-up in the exact FP32
+optimization lane, and hand SIMD/scoring-kernel work to #2403 instead of mixing
+it into a parallel-contention PR.


### PR DESCRIPTION
## Summary

- Closes #2402. Parent: #2399.
- Adds benchmark-workflow guidance for interpreting c=8+ reusable-buffer vector-search profiles.
- Measurement/validation result: no runtime/search code changed; the current c=8 `TreeDB_SearchWithBufferParallel` gap is not explained by material shared locks, atomics, per-query resource lookups, open/setup, document fetch, fallback, or allocation/GC. The remaining visible hot path is HNSW traversal, FP32 indexed dot/scoring, and frontier/top-k maintenance, so broad SIMD/scoring-kernel work stays deferred to #2403.

## Scope / non-goals

- Exact FP32 `hnsw_search_pack_v1` no-document route only.
- Docs/workflow interpretation only; no benchmark row special casing and no runtime behavior change.
- No quantized/docs/materialization/filter/projection claims.
- No generic sidecar cache or cross-route shared-state change.

## Contract / dependency-ready facts for #2403

- Changed c=8/c=1 runtime contract: **unchanged** (docs-only PR).
- Reusable parallel row still uses one opened searcher and one caller-owned buffer per worker.
- Guardrails remained healthy: `search_route_hnsw_search_pack/search=1`, `hnsw_search_pack_active/search=1`, `docs_fetched/search=0`, `graph_row_fallbacks/search=0`, `typed_column_vector_fallbacks/search=0`, `vector_scratch_decodes/search=0`; collection rows also reported `open_searcher_calls/op=0` and `open_setup_in_timed_loop=0`.
- Downstream #2403 can start from the stable fact that the current c=8 gap is traversal/scoring/frontier work rather than avoidable synchronization/bookkeeping overhead in #2402 scope.

## Benchmarks / profiles

Hardware/context: Apple M3, `darwin/arm64`, Go `go1.25.5`, branch `snissn/2402-manager` at `358fac256`. Fixture: Tier S exact FP32 no-doc, 10k docs, 64 dims, M=16, efConstruction=128, efSearch=128, topK=10, query stream=16.

Canonical Tier S command (latest head):

```sh
RUN_DIR=/tmp/gomap_2402_final_tiers_20260605_152012 \
TREEDB_VECTOR_BENCH_DOCS=10000 TREEDB_VECTOR_BENCH_DIMS=64 \
  TREEDB_VECTOR_BENCH_M=16 TREEDB_VECTOR_BENCH_EF_CONSTRUCTION=128 \
  TREEDB_VECTOR_BENCH_EF_SEARCH=128 TREEDB_VECTOR_BENCH_TOPK=10 \
  TREEDB_VECTOR_BENCH_QUERIES=16 CPU_LIST=1,8 BENCHTIME=1000x COUNT=3 \
  BENCH_REGEX='BenchmarkCollectionVectorUSearchProductionCompare$' \
  scripts/bench_vector_search_compare.sh
```

Key latest-head c=8 medians:

| Row | c | median ns/op | ops/sec | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: | ---: |
| `TreeDB_CollectionSearchVectorIndexWithBuffer` | 8 | 45,208 | 22,120 | 0 | 0 |
| `TreeDB_CollectionSearchVectorIndexNoDocsOneShot` | 8 | 44,240 | 22,604 | 816 | 2 |
| `TreeDB_SearchWithBuffer` | 8 | 44,757 | 22,343 | 0 | 0 |
| `TreeDB_SearchWithBufferParallel` | 8 | 9,450 | 105,816 | 3* | 0 |
| `USearch_Search` | 8 | 36,230 | 27,602 | 136 | 3 |
| `USearch_SearchParallel` | 8 | 7,419 | 134,790 | 137 | 3 |

`*` The 1000x reusable parallel row shows tiny setup/profiling noise in B/op as seen in prior Tier F evidence. Dedicated long allocation proof below reports steady-state `0 B/op`, `0 allocs/op`.

Focused c=1 verification after a noisy canonical c=1 block:

```sh
RUN_DIR=/tmp/gomap_2402_final_c1_verify_20260605_152209 \
CPU_LIST=1 BENCHTIME=5000x COUNT=3 \
BENCH_REGEX='BenchmarkCollectionVectorUSearchProductionCompare/(TreeDB_SearchWithBuffer|TreeDB_SearchWithBufferParallel|TreeDB_CollectionSearchVectorIndexWithBuffer|TreeDB_CollectionSearchVectorIndexNoDocsOneShot)$' \
scripts/bench_vector_search_compare.sh
```

| Row | c | median ns/op | ops/sec | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: | ---: |
| `TreeDB_CollectionSearchVectorIndexWithBuffer` | 1 | 43,746 | 22,859 | 0 | 0 |
| `TreeDB_CollectionSearchVectorIndexNoDocsOneShot` | 1 | 52,390 | 19,088 | 816 | 2 |
| `TreeDB_SearchWithBuffer` | 1 | 42,040 | 23,787 | 0 | 0 |
| `TreeDB_SearchWithBufferParallel` | 1 | 43,164 | 23,167 | 0 | 0 |

c=8 parallel CPU/allocation profile:

- Artifact dir: `/tmp/gomap_2402_c8_parallel_profile_long_20260605_151640`
- Command: `go test -tags usearch_bench ./TreeDB/collections -run '^$' -bench 'BenchmarkCollectionVectorUSearchProductionCompare/TreeDB_SearchWithBufferParallel$' -benchmem -benchtime=1000000x -count=1 -cpu=8 -cpuprofile ...`
- Row result: `11,744 ns/op`, `85,148 ops/sec`, `0 B/op`, `0 allocs/op`.
- Top steady-state samples: `searchCosine` 92.3% cum, `dotFloat32IndexedARM64` 26.4% flat, `scoreAndPushFrontierVisitedTile` 55.9% cum, `insertTop` 15.0% flat, `frontierSiftDown` 6.9% flat. `VectorIndexSearcher.SearchWithBuffer` wrapper was 0.44% flat; locks/atomics/resource-manager/open/setup were not material.

Optional c=16 was attempted at `/tmp/gomap_2402_c16_optional_20260605_151817`, but the USearch cgo row crashed the Go runtime on this Darwin host, so no c=16 comparison is claimed.

## Tests

```sh
GOWORK=off go test ./TreeDB/docs -count=1
GOWORK=off go test ./TreeDB/collections -run 'TestVectorIndexSearcherSearchWithBufferParallelIndependentBuffers1961|TestVectorIndexSearcherSharedPreparedResourceCounters1735|TestVectorIndexSearcherSearchWithBufferResultEquivalenceAndZeroAllocs2124' -count=1
git diff --check
```

## CI / review status

- Latest-head CI: pending after PR open.
- Internal xhigh review: pass; docs wording keeps exact FP32/no-doc route separate and does not overclaim vs USearch.
- AI reviews: not requested until CI is running and PR is mature.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the vector-search benchmark workflow guide with a new section on parallel scaling profile interpretation, providing guidance on analyzing performance results and distinguishing between avoidable contention sources and algorithm-level bottlenecks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->