### PR TITLE
[codex] Reuse compact outer-leaf payload buffers

### DIFF
--- a/TreeDB/db/vlog_rewrite.go
+++ b/TreeDB/db/vlog_rewrite.go
@@ -3423,6 +3423,11 @@ type rewriteWriter struct {
 	pendingDictRecords []valuelog.Record
 	pendingDictPtrs    []page.ValuePtr
 	pendingDictDst     []page.ValuePtr
+
+	leafCompactScratch []byte
+	leafCompactArena   []byte
+	leafBatchRecords   []valuelog.Record
+	leafBatchValuePtrs []page.ValuePtr
 }
 
 type rewriteTemplateClass uint8
@@ -3713,9 +3718,14 @@ func (w *rewriteWriter) appendLeafPageWithRID(rid uint64, leafPage []byte) (page
 	encodedLeafPage := leafPage
 	if w.leafPagesUseCompactPayload() {
 		var err error
-		encodedLeafPage, _, err = valuelog.MaybeCompactLeafLogPayload(leafPage)
+		encodedLeafPage, _, err = valuelog.MaybeCompactLeafLogPayloadTo(w.leafCompactScratch[:0], leafPage)
 		if err != nil {
 			return page.LeafLogPtr{}, err
+		}
+		if cap(encodedLeafPage) > page.PageSize*2 {
+			w.leafCompactScratch = nil
+		} else {
+			w.leafCompactScratch = encodedLeafPage[:0]
 		}
 	}
 	if w.leafDir != "" {
@@ -3790,7 +3800,12 @@ func (w *rewriteWriter) appendLeafPagesWithRIDStart(startRID uint64, leafPages [
 	if err := w.ensureLeafWriter(); err != nil {
 		return nil, err
 	}
-	records := make([]valuelog.Record, len(leafPages))
+	if cap(w.leafBatchRecords) < len(leafPages) {
+		w.leafBatchRecords = make([]valuelog.Record, len(leafPages))
+	}
+	records := w.leafBatchRecords[:len(leafPages)]
+	clear(records)
+	w.leafCompactArena = w.leafCompactArena[:0]
 	rawPayloadBytes := 0
 	dictID := uint64(0)
 	var dict []byte
@@ -3806,7 +3821,7 @@ func (w *rewriteWriter) appendLeafPagesWithRIDStart(startRID uint64, leafPages [
 		encodedLeafPage := leafPage
 		if w.leafPagesUseCompactPayload() {
 			var err error
-			encodedLeafPage, _, err = valuelog.MaybeCompactLeafLogPayload(leafPage)
+			w.leafCompactArena, encodedLeafPage, _, err = valuelog.MaybeAppendCompactLeafLogPayloadTo(w.leafCompactArena, leafPage)
 			if err != nil {
 				return nil, err
 			}
@@ -3844,7 +3859,10 @@ func (w *rewriteWriter) appendLeafPagesWithRIDStart(startRID uint64, leafPages [
 	if err := w.maybeRotateLeafForEstimate(rewriteDictFrameRecordLen(rawPayloadBytes, len(records))); err != nil {
 		return nil, err
 	}
-	valuePtrs := make([]page.ValuePtr, len(records))
+	if cap(w.leafBatchValuePtrs) < len(records) {
+		w.leafBatchValuePtrs = make([]page.ValuePtr, len(records))
+	}
+	valuePtrs := w.leafBatchValuePtrs[:len(records)]
 	valuePtrs, _, err := w.leafW.AppendFrameWithStatsInto(dictID, dict, records, valuePtrs)
 	if err != nil {
 		return nil, err

--- a/TreeDB/internal/valuelog/leaf_page_payload.go
+++ b/TreeDB/internal/valuelog/leaf_page_payload.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"path/filepath"
+	"slices"
 
 	"github.com/snissn/gomap/TreeDB/node"
 	"github.com/snissn/gomap/TreeDB/page"
@@ -53,6 +54,36 @@ func MaybeCompactLeafLogPayloadTo(dst, leafPage []byte) ([]byte, bool, error) {
 	sum := page.CalculateChecksumWithZeroGap(prefix, page.PageSize-prefixLen-suffixLen, suffix)
 	binary.LittleEndian.PutUint32(prefix[8:12], sum)
 	return payload, true, nil
+}
+
+func MaybeAppendCompactLeafLogPayloadTo(dst, leafPage []byte) ([]byte, []byte, bool, error) {
+	if len(leafPage) != page.PageSize {
+		return dst, leafPage, false, nil
+	}
+	prefixLen, suffixLen, err := node.LeafPageLiveBounds(leafPage)
+	if err != nil {
+		return dst, leafPage, false, nil
+	}
+	compactLen := compactLeafPagePayloadHeaderSize + prefixLen + suffixLen
+	if compactLen >= len(leafPage) {
+		return dst, leafPage, false, nil
+	}
+
+	start := len(dst)
+	dst = slices.Grow(dst, compactLen)
+	dst = dst[:start+compactLen]
+	payload := dst[start:]
+	suffixStart := len(leafPage) - suffixLen
+	copy(payload[:len(compactLeafPagePayloadMagic)], compactLeafPagePayloadMagic[:])
+	binary.LittleEndian.PutUint16(payload[len(compactLeafPagePayloadMagic):len(compactLeafPagePayloadMagic)+2], uint16(prefixLen))
+	binary.LittleEndian.PutUint16(payload[len(compactLeafPagePayloadMagic)+2:compactLeafPagePayloadHeaderSize], uint16(suffixLen))
+	prefix := payload[compactLeafPagePayloadHeaderSize : compactLeafPagePayloadHeaderSize+prefixLen]
+	suffix := payload[compactLeafPagePayloadHeaderSize+prefixLen:]
+	copy(prefix, leafPage[:prefixLen])
+	copy(suffix, leafPage[suffixStart:])
+	sum := page.CalculateChecksumWithZeroGap(prefix, page.PageSize-prefixLen-suffixLen, suffix)
+	binary.LittleEndian.PutUint32(prefix[8:12], sum)
+	return dst, payload, true, nil
 }
 
 func compactLeafLogPayloadBounds(payload []byte) (prefixLen, suffixLen int, decoded bool, err error) {

--- a/TreeDB/internal/valuelog/leaf_page_payload_test.go
+++ b/TreeDB/internal/valuelog/leaf_page_payload_test.go
@@ -147,6 +147,51 @@ func TestMaybeCompactLeafLogPayload_SparseLeafRoundTrips(t *testing.T) {
 	requireLeafPagesLogicallyEqual(t, leaf, decoded)
 }
 
+func TestMaybeAppendCompactLeafLogPayloadTo_AppendsStablePayloads(t *testing.T) {
+	leafA := buildSparseLeafPageForPayloadTest(t)
+	leafB := buildSparseLeafPageForPayloadTest(t)
+	copy(leafB[page.PageSize-16:], []byte("different-leaf-b"))
+
+	var arena []byte
+	arena, payloadA, compacted, err := MaybeAppendCompactLeafLogPayloadTo(arena, leafA)
+	if err != nil {
+		t.Fatalf("MaybeAppendCompactLeafLogPayloadTo(A): %v", err)
+	}
+	if !compacted {
+		t.Fatal("expected leaf A to compact")
+	}
+	payloadAStable := append([]byte(nil), payloadA...)
+
+	arena, payloadB, compacted, err := MaybeAppendCompactLeafLogPayloadTo(arena, leafB)
+	if err != nil {
+		t.Fatalf("MaybeAppendCompactLeafLogPayloadTo(B): %v", err)
+	}
+	if !compacted {
+		t.Fatal("expected leaf B to compact")
+	}
+	if !bytes.Equal(payloadA, payloadAStable) {
+		t.Fatal("payload A changed after appending payload B")
+	}
+
+	decodedA, _, decoded, err := decodeCompactLeafLogPayloadTo(payloadA, nil)
+	if err != nil {
+		t.Fatalf("decode A: %v", err)
+	}
+	if !decoded {
+		t.Fatal("expected payload A to decode")
+	}
+	requireLeafPagesLogicallyEqual(t, leafA, decodedA)
+
+	decodedB, _, decoded, err := decodeCompactLeafLogPayloadTo(payloadB, nil)
+	if err != nil {
+		t.Fatalf("decode B: %v", err)
+	}
+	if !decoded {
+		t.Fatal("expected payload B to decode")
+	}
+	requireLeafPagesLogicallyEqual(t, leafB, decodedB)
+}
+
 func TestDecodeCompactLeafLogPayloadTo_AliasedDstRoundTrips(t *testing.T) {
 	leaf := buildSparseLeafPageForPayloadTest(t)
 


### PR DESCRIPTION
## Objective
Reduce TreeDB outer-leaf materialization allocation churn in the compact leaf-log payload path.

Closes https://github.com/snissn/gomap/issues/2435
Part of https://github.com/snissn/gomap/issues/2433
Depends on https://github.com/snissn/gomap/issues/2434

## Context
The benchmark harness from PR #2425 showed compressed outer-leaf random-overwrite work spending most allocation space in compact payload construction. Before this patch, the focused benchmark was around 9.4 MB/op and ~2.4k allocs/op, with the allocation profile dominated by `MaybeCompactLeafLogPayloadTo`.

## Design
- Add `MaybeAppendCompactLeafLogPayloadTo` so batched compact payloads are appended into a reusable arena.
- Reuse rewrite-writer scratch for single-leaf compact payloads.
- Reuse batch `valuelog.Record` and `ValuePtr` slices in the batched leaf write path.
- Keep returned `LeafLogPtr` slices freshly allocated because callers may retain them.

## Correctness
- Added coverage that appending a second compact payload does not invalidate the first payload slice and both decode back to logically equivalent leaf pages.
- Existing compact payload decode/round-trip behavior is preserved.

## Validation
- `GOWORK=off go test ./TreeDB/internal/valuelog -run 'TestMaybeAppendCompactLeafLogPayloadTo|TestMaybeCompactLeafLogPayload|TestDecodeCompactLeafLogPayloadTo' -count=1`
- `GOWORK=off go test ./TreeDB/db -run 'TestRewriteWriter_AppendLeafPage|TestRewriteWriterAppendLeafPages' -count=1`
- `GOWORK=off go test ./TreeDB/db -run '^$' -bench '^BenchmarkZipperApplyOuterLeafCompressedRandomOverwrite$' -benchmem -count=5 -benchtime=3s`

## Performance Evidence
Focused compressed outer-leaf microbench on this branch:

- `10.31-11.70 ms/op`
- `95.18-108.02 MB/s`
- `122-137 KB/op`
- `99 allocs/op`

Prior baseline evidence from the benchmark PR/current issue:

- ~`8.96-9.73 ms/op`
- ~`9.4 MB/op`
- ~`2388-2395 allocs/op`
- allocation profile had `MaybeCompactLeafLogPayloadTo` at ~95.8% alloc-space

This patch removes the targeted allocation bottleneck: roughly 98% lower B/op and 95% fewer allocs/op in the focused benchmark. Throughput is neutral/noisy, not a standalone throughput win.

End-to-end 10M unified-bench block/snappy comparison on this machine:

- Clean `origin/main`: sequential `4,256,900 ops/s`, random `480,897 ops/s`
- This branch no-profile: sequential `4,107,525 ops/s`, random `453,684 ops/s`
- This branch with profile-dir: sequential `4,005,272 ops/s`, random `488,541 ops/s`

Interpretation: unified-bench random-write is neutral within local noise; no demonstrated material win, but no stable regression signal. This should not merge unless CI is green and reviewers accept this as a prerequisite allocation cleanup for #2436/#2437.

## Non-goals
- Does not change value-log codec selection or block/frame batching.
- Does not change on-disk compact leaf payload format.
- Does not attempt to reuse returned `LeafLogPtr` slices.

## Merge Gate
- Latest-head CI must pass.
- No benchmark regression should be visible in a repeated focused run.
- If a maintainer requires end-to-end throughput increase for this specific PR, hold this PR and merge it only as part of a measured stack with #2436/#2437.
