### PR TITLE
docs: polish TreeDB vector README entry points

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,29 @@ reads with one writer measured 2.96M reader ops/sec and 44.3k writer docs/sec.
 Source:
 [June 4 collection concurrency report](docs/benchmarks/collections_concurrency_main_2026-06-04.md).
 
+### Vector Search Serving Workload
+
+Dated Tier S exact-FP32 no-document snapshot: Apple M3 (`darwin/arm64`),
+2026-06-05, commit `2feb1f0e35459d1b3d044008203d0c8afcf5630f`, `10000`
+documents, `64` dimensions, `M=16`, `efConstruction=128`, `efSearch=128`,
+`topK=10`, query stream length `16`, `BENCHTIME=1000x`, and `COUNT=3`. TreeDB
+rows use warmed persisted `column_graph` / `hnsw_search_pack_v1` no-document
+routes. USearch rows are pure in-memory external ANN baselines, not
+persistence-equivalent storage rows.
+
+| row | cpu | median ns/op | derived ops/sec | B/op | allocs/op |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| TreeDB `Collection.SearchVectorIndexWithBuffer` | 1 | 43,049 | 23,229 | 0 | 0 |
+| TreeDB `OpenVectorIndexSearcher` + `SearchWithBuffer` parallel row | 8 | 8,610 | 116,144 | 0 | 0 |
+| USearch `Search` | 1 | 30,065 | 33,261 | 136 | 3 |
+| USearch `SearchParallel` | 8 | 6,906 | 144,802 | 139 | 3 |
+
+Source and reproduction workflow:
+[TreeDB vs USearch vector benchmark workflow](TreeDB/docs/guides/vector-search-benchmark-workflow.md).
+API chooser, route guardrails, and runnable exact-only demo:
+[high-QPS collection vector-search guide](TreeDB/docs/guides/vector-search-high-qps-collection-api.md)
+and [`cmd/treedb_vector_highqps_demo`](cmd/treedb_vector_highqps_demo/README.md).
+
 ### TreeDB Mongo Gateway Client-Shape Workload
 
 Gateway-shaped BSON documents, `200000` documents, batch size `1000`,
@@ -221,10 +244,13 @@ Current YCSB status and rerun commands:
 - `docs/benchmarks/ycsb_latest_main_2026-06-03.md`
 - `scripts/ycsb_compare_mongodb_treedb.sh`
 
-Collection and engine benchmark runbooks:
+Collection, vector-search, and engine benchmark runbooks:
 
 - `docs/benchmarks/collections_insert_two_index_exhaustive_main_2026-06-04.md`
 - `docs/benchmarks/mongo_gateway_fast_client_matrix_2026-06-04.md`
+- `TreeDB/docs/guides/vector-search-high-qps-collection-api.md`
+- `TreeDB/docs/guides/vector-search-benchmark-workflow.md`
+- `cmd/treedb_vector_highqps_demo/README.md`
 - `docs/benchmarks/treedb_canonical_benchmark_runbook.md`
 - `docs/benchmarks/collections_canonical_benchmark.md`
 - `cmd/unified_bench/README.md`

--- a/TreeDB/README.md
+++ b/TreeDB/README.md
@@ -138,7 +138,43 @@ fields and search them without making ANN storage the source of truth. Canonical
 documents and embeddings remain in TreeDB primary storage; vector indexes keep
 stable collection document IDs and exact-rerank candidates from canonical rows.
 
-The initial API lives in `TreeDB/collections`:
+Current entry points:
+
+| Goal | Entry point | Boundary |
+| --- | --- | --- |
+| High-QPS no-document collection serving | `Collection.SearchVectorIndexWithBuffer` | Caller-owned `VectorIndexSearchBuffer`; exact `IncludeDocuments=false`; warm the `hnsw_search_pack_v1` prepared route before serving. |
+| Convenience no-document calls | `Collection.SearchVectorIndex` with `IncludeDocuments=false` | Response-owned results/IDs; healthy exact calls use the cached no-document route but intentionally allocate result storage. |
+| Reusable low-level workers | `Collection.OpenVectorIndexSearcher` + `VectorIndexSearcher.SearchWithBuffer` | One opened searcher and one reusable buffer per worker; caller owns searcher/snapshot lifetime. |
+| Search plus materialization | `Collection.SearchVectorIndex` with `IncludeDocuments=true` | Explicit with-document path; report document-fetch/materialization counters separately from no-document rows. |
+| Quantized score planes | Explicit `quantized_only` / `quantized_rerank` modes | Separate codec-generic follow-up path; not the exact high-QPS demo route or no-document `hnsw_search_pack_v1` claim. |
+
+Exact-only runnable demo from the repository root:
+
+```sh
+GOWORK=off go run ./cmd/treedb_vector_highqps_demo \
+  -docs 1000 \
+  -dims 64 \
+  -queries 1000 \
+  -warmup-queries 16 \
+  -top-k 10 \
+  -m 16 \
+  -ef-construction 128 \
+  -ef-search 128
+```
+
+Use
+[`TreeDB/docs/guides/vector-search-high-qps-collection-api.md`](docs/guides/vector-search-high-qps-collection-api.md)
+for the API chooser and buffer lifetime caveats,
+[`TreeDB/docs/guides/vector-search-benchmark-workflow.md`](docs/guides/vector-search-benchmark-workflow.md)
+for the canonical Tier S/Tier F workflow and guardrail counters, and
+[`cmd/treedb_vector_highqps_demo/README.md`](../cmd/treedb_vector_highqps_demo/README.md)
+for demo output interpretation. The exact demo intentionally excludes document
+materialization and quantized modes. Healthy exact no-document rows prove
+`search_route_hnsw_search_pack/search=1`,
+`hnsw_search_pack_active/search=1`, `docs_fetched/search=0`, zero fallback and
+scratch counters, and no per-query collection open/setup in timed loops.
+
+Additional collection vector APIs and diagnostics live in `TreeDB/collections`:
 
 - `Collection.SearchVectorsExact` scans live rows and returns exact top-k
   results for cosine, squared L2, or inner-product distance.
@@ -150,9 +186,12 @@ The initial API lives in `TreeDB/collections`:
 - `BenchmarkCollectionVectorIndexBuild` and
   `BenchmarkCollectionVectorUSearchBuild` isolate index build cost from query
   latency for TreeDB and the optional USearch comparator.
-- `VectorIndexOptions.Encoding` can be set to `VectorIndexEncodingInt8` to keep
-  an ANN-side scalar-quantized vector copy. This reduces index vector memory and
-  snapshot size while preserving full-precision canonical rows for exact rerank.
+- Declared quantized score planes use explicit `quantized_only` or
+  `quantized_rerank` query modes with codec-generic `quantized_*` route,
+  validation, and fail-closed counters. Scalar `scalar_u8` evidence is a
+  behavior/storage baseline, not a current speedup claim; keep it separate from
+  the exact no-document high-QPS path and demo. See
+  [`TreeDB/docs/spec/quantized-vector-index.md`](docs/spec/quantized-vector-index.md).
 - `VectorIndex.SaveSnapshot` and `Collection.LoadVectorIndexSnapshot` persist
   immutable index epochs under `vector_indexes/<collection>/<index>/` with a
   manifest plus checksum-verified node, edge, tombstone, and docmap files.


### PR DESCRIPTION
## Objective

Polish the root and TreeDB README vector-search entry points so readers can quickly find the current exact no-document serving APIs, runnable demo, benchmark workflow, and caveats.

Closes #2439.

## Scope

- Updated `README.md` with a scoped Tier S vector-search serving highlight and links to the API chooser, benchmark workflow, and demo.
- Updated `TreeDB/README.md` with a compact current API chooser covering:
  - `Collection.SearchVectorIndexWithBuffer` high-QPS no-document serving;
  - `Collection.SearchVectorIndex` no-document convenience calls;
  - `Collection.OpenVectorIndexSearcher` + `VectorIndexSearcher.SearchWithBuffer` reusable low-level workers;
  - `IncludeDocuments=true` materialization;
  - quantized score planes as a separate codec-generic follow-up path.
- Added the exact-only `cmd/treedb_vector_highqps_demo` run command and linked canonical guardrail/counter docs.

## Non-goals

- No runtime/search API changes.
- No new benchmark claims beyond the existing dated Tier S snapshot.
- No benchmark rerun for this docs-only change; the README links to the canonical workflow/report for reproduction.
- No quantized demo or claim that quantized modes are the exact high-QPS demo path.

## Correctness

Tests run:

- `GOWORK=off go test ./TreeDB/docs -count=1`
- `GOWORK=off go test ./cmd/treedb_vector_highqps_demo -count=1`
- `git diff --check origin/main...HEAD`

## Performance

Benchmarks run: none. This is README/docs-only and cites the existing scoped Tier S snapshot without changing benchmark code or runtime behavior.

## AI Review Loop

- Codex latest-head review: completed with no major issues.
- Copilot latest-head review: requested; no actionable thread present.
- CodeRabbit latest-head review: completed/pass.

## CI

Latest-head CI is green for `74a40e442f5d71d1b049242f4242525d1d6f175a`.

