### PR TITLE
Refine HNSW pack score-batch fallback accounting

### DIFF
--- a/TreeDB/collections/column_hnsw_search_pack_search.go
+++ b/TreeDB/collections/column_hnsw_search_pack_search.go
@@ -213,7 +213,7 @@ func (v *columnHNSWSearchPackPreparedView) maxLayerForOrdinal(ordinal int) (int,
 
 func (v *columnHNSWSearchPackPreparedView) greedyNearestAtLayer(normalizedQuery []float32, entryOrdinal int, layer int, scoreBatchMode columnVectorGraphScoreBatchMode, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats, countLoopEdges bool, loopEdgeVisits *uint64) (int, error) {
 	best := entryOrdinal
-	bestScore, err := v.scoreOrdinal(normalizedQuery, best, scratch, stats)
+	bestScore, err := v.scoreOrdinal(normalizedQuery, best, scoreBatchMode, scratch, stats)
 	if err != nil {
 		return 0, err
 	}
@@ -254,7 +254,7 @@ func (v *columnHNSWSearchPackPreparedView) greedyNearestAtLayer(normalizedQuery 
 }
 
 func (v *columnHNSWSearchPackPreparedView) scoreAndPushFrontierVisited(normalizedQuery []float32, ordinal, topK int, scoreBatchMode columnVectorGraphScoreBatchMode, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats, visitedCandidates *uint64) error {
-	score, err := v.scoreOrdinal(normalizedQuery, ordinal, scratch, stats)
+	score, err := v.scoreOrdinal(normalizedQuery, ordinal, scoreBatchMode, scratch, stats)
 	if err != nil {
 		return err
 	}
@@ -275,7 +275,7 @@ func (v *columnHNSWSearchPackPreparedView) scoreAndPushFrontierVisitedTile(norma
 	if scoreBatchMode != columnVectorGraphScoreBatchModeScalar && len(rowIDs) > 1 && scratch != nil && len(normalizedQuery) >= v.Header.VectorStride {
 		scratch.scoreTileDots = ensureColumnVectorGraphNativeFloat32Scratch(scratch.scoreTileDots, len(rowIDs))
 		dots := scratch.scoreTileDots[:len(rowIDs)]
-		status := vectorops.DotFloat32Indexed(dots, v.NormalizedVectors, normalizedQuery[:v.Header.VectorStride], rowIDs, v.Header.VectorStride)
+		status := vectorops.DotFloat32IndexedPrevalidated(dots, v.NormalizedVectors, normalizedQuery[:v.Header.VectorStride], rowIDs, v.Header.VectorStride)
 		if !status.Invalid && status.Rows == len(rowIDs) {
 			recordColumnHNSWSearchPackScoreBatchStats(stats, len(rowIDs), status.Optimized, status.Fallback)
 			v.recordScoreStats(stats, len(rowIDs))
@@ -308,7 +308,7 @@ func (v *columnHNSWSearchPackPreparedView) scoreAndPushFrontierVisitedTile(norma
 	return nil
 }
 
-func (v *columnHNSWSearchPackPreparedView) scoreOrdinal(normalizedQuery []float32, ordinal int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) (float64, error) {
+func (v *columnHNSWSearchPackPreparedView) scoreOrdinal(normalizedQuery []float32, ordinal int, scoreBatchMode columnVectorGraphScoreBatchMode, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) (float64, error) {
 	if v == nil || ordinal < 0 || ordinal >= v.Header.Rows {
 		return 0, fmt.Errorf("collections: hnsw_search_pack_v1 vector ordinal=%d unavailable", ordinal)
 	}
@@ -319,7 +319,8 @@ func (v *columnHNSWSearchPackPreparedView) scoreOrdinal(normalizedQuery []float3
 	}
 	vector := v.NormalizedVectors[start:end]
 	score := float64(vectorDotProductFloat32(normalizedQuery[:v.Header.Dimensions], vector))
-	recordColumnHNSWSearchPackScoreBatchStats(stats, 1, false, true)
+	optimized := scoreBatchMode != columnVectorGraphScoreBatchModeScalar && vectorops.DotFloat32OptimizedAvailable()
+	recordColumnHNSWSearchPackScoreBatchStats(stats, 1, optimized, !optimized)
 	v.recordScoreStats(stats, 1)
 	_ = scratch
 	return score, nil
@@ -337,7 +338,7 @@ func (v *columnHNSWSearchPackPreparedView) scoreRowIDs(normalizedQuery []float32
 	if scoreBatchMode != columnVectorGraphScoreBatchModeScalar && len(rowIDs) > 1 && scratch != nil && len(normalizedQuery) >= v.Header.VectorStride {
 		scratch.scoreTileDots = ensureColumnVectorGraphNativeFloat32Scratch(scratch.scoreTileDots, len(rowIDs))
 		dots := scratch.scoreTileDots[:len(rowIDs)]
-		status := vectorops.DotFloat32Indexed(dots, v.NormalizedVectors, normalizedQuery[:v.Header.VectorStride], rowIDs, v.Header.VectorStride)
+		status := vectorops.DotFloat32IndexedPrevalidated(dots, v.NormalizedVectors, normalizedQuery[:v.Header.VectorStride], rowIDs, v.Header.VectorStride)
 		if !status.Invalid && status.Rows == len(rowIDs) {
 			for i := range rowIDs {
 				dst[i] = float64(dots[i])
@@ -348,13 +349,14 @@ func (v *columnHNSWSearchPackPreparedView) scoreRowIDs(normalizedQuery []float32
 		}
 	}
 	for i, rowID := range rowIDs {
-		score, err := v.scoreOrdinal(normalizedQuery, int(rowID), scratch, nil)
+		score, err := v.scoreOrdinal(normalizedQuery, int(rowID), scoreBatchMode, scratch, nil)
 		if err != nil {
 			return dst[:i], err
 		}
 		dst[i] = score
 	}
-	recordColumnHNSWSearchPackScoreBatchStats(stats, len(rowIDs), false, true)
+	optimized := len(rowIDs) == 1 && scoreBatchMode != columnVectorGraphScoreBatchModeScalar && vectorops.DotFloat32OptimizedAvailable()
+	recordColumnHNSWSearchPackScoreBatchStats(stats, len(rowIDs), optimized, !optimized)
 	v.recordScoreStats(stats, len(rowIDs))
 	return dst, nil
 }

--- a/TreeDB/collections/column_hnsw_search_pack_search.go
+++ b/TreeDB/collections/column_hnsw_search_pack_search.go
@@ -319,7 +319,7 @@ func (v *columnHNSWSearchPackPreparedView) scoreOrdinal(normalizedQuery []float3
 	}
 	vector := v.NormalizedVectors[start:end]
 	score := float64(vectorDotProductFloat32(normalizedQuery[:v.Header.Dimensions], vector))
-	optimized := scoreBatchMode != columnVectorGraphScoreBatchModeScalar && vectorops.DotFloat32OptimizedAvailable()
+	optimized := scoreBatchMode != columnVectorGraphScoreBatchModeScalar && vectorops.DotFloat32OptimizedEligible(v.Header.Dimensions)
 	recordColumnHNSWSearchPackScoreBatchStats(stats, 1, optimized, !optimized)
 	v.recordScoreStats(stats, 1)
 	_ = scratch
@@ -355,7 +355,7 @@ func (v *columnHNSWSearchPackPreparedView) scoreRowIDs(normalizedQuery []float32
 		}
 		dst[i] = score
 	}
-	optimized := len(rowIDs) == 1 && scoreBatchMode != columnVectorGraphScoreBatchModeScalar && vectorops.DotFloat32OptimizedAvailable()
+	optimized := len(rowIDs) == 1 && scoreBatchMode != columnVectorGraphScoreBatchModeScalar && vectorops.DotFloat32OptimizedEligible(v.Header.Dimensions)
 	recordColumnHNSWSearchPackScoreBatchStats(stats, len(rowIDs), optimized, !optimized)
 	v.recordScoreStats(stats, len(rowIDs))
 	return dst, nil

--- a/TreeDB/internal/vectorops/doc.go
+++ b/TreeDB/internal/vectorops/doc.go
@@ -6,7 +6,8 @@
 // Row-major batch dot wrappers accept flat []float32 payloads and ordinal/row-id
 // tiles directly. They validate full-row shapes, leave dst unchanged for invalid
 // shapes, and report whether a platform batch SIMD kernel or a non-batch
-// fallback handled the call. Scalar_u8 helpers expose centered int16 query
-// layouts and indexed row-major byte-code dot kernels while keeping callers
-// allocation-free.
+// fallback handled the call. Prevalidated row-id wrappers are reserved for hot
+// paths that have already checked row bounds while composing an adjacency tile.
+// Scalar_u8 helpers expose centered int16 query layouts and indexed row-major
+// byte-code dot kernels while keeping callers allocation-free.
 package vectorops

--- a/TreeDB/internal/vectorops/dot_amd64.go
+++ b/TreeDB/internal/vectorops/dot_amd64.go
@@ -8,6 +8,10 @@ const dotFloat32Implementation = "simd_tphakala_f32"
 
 const dotFloat32OptimizedAvailable = true
 
+// Conservative minimum that guarantees the selected amd64 SIMD backend executes
+// at least one packed-vector dot chunk (AVX-512: 16 lanes, AVX: 8, SSE: 4).
+const dotFloat32OptimizedMinLength = 16
+
 // DotFloat32 returns the float32 dot product over the shared prefix of left and
 // right using the amd64 SIMD implementation. Callers must pass validated
 // []float32 slices; this kernel does not reinterpret raw bytes.
@@ -25,6 +29,11 @@ func DotFloat32(left, right []float32) float32 {
 // DotFloat32Implementation identifies the active DotFloat32 implementation.
 func DotFloat32Implementation() string { return dotFloat32Implementation }
 
-// DotFloat32OptimizedAvailable reports whether this build's single-vector dot
-// product uses a platform-optimized backend rather than the portable scalar loop.
+// DotFloat32OptimizedAvailable reports whether this build includes a
+// platform-optimized single-vector dot backend. It does not guarantee that every
+// call uses SIMD; use DotFloat32OptimizedEligible for per-length accounting.
 func DotFloat32OptimizedAvailable() bool { return dotFloat32OptimizedAvailable }
+
+// DotFloat32OptimizedEligible reports whether DotFloat32 is expected to use the
+// platform-optimized backend for a dot product of n float32 values.
+func DotFloat32OptimizedEligible(n int) bool { return n >= dotFloat32OptimizedMinLength }

--- a/TreeDB/internal/vectorops/dot_amd64.go
+++ b/TreeDB/internal/vectorops/dot_amd64.go
@@ -6,6 +6,8 @@ import simdf32 "github.com/tphakala/simd/f32"
 
 const dotFloat32Implementation = "simd_tphakala_f32"
 
+const dotFloat32OptimizedAvailable = true
+
 // DotFloat32 returns the float32 dot product over the shared prefix of left and
 // right using the amd64 SIMD implementation. Callers must pass validated
 // []float32 slices; this kernel does not reinterpret raw bytes.
@@ -22,3 +24,7 @@ func DotFloat32(left, right []float32) float32 {
 
 // DotFloat32Implementation identifies the active DotFloat32 implementation.
 func DotFloat32Implementation() string { return dotFloat32Implementation }
+
+// DotFloat32OptimizedAvailable reports whether this build's single-vector dot
+// product uses a platform-optimized backend rather than the portable scalar loop.
+func DotFloat32OptimizedAvailable() bool { return dotFloat32OptimizedAvailable }

--- a/TreeDB/internal/vectorops/dot_amd64.go
+++ b/TreeDB/internal/vectorops/dot_amd64.go
@@ -2,15 +2,30 @@
 
 package vectorops
 
-import simdf32 "github.com/tphakala/simd/f32"
+import (
+	simdcpu "github.com/tphakala/simd/cpu"
+	simdf32 "github.com/tphakala/simd/f32"
+)
 
 const dotFloat32Implementation = "simd_tphakala_f32"
 
-const dotFloat32OptimizedAvailable = true
+// Minimum that guarantees the runtime-selected amd64 SIMD backend executes at
+// least one packed-vector dot chunk (AVX-512: 16 lanes, AVX: 8, SSE: 4).
+// Keep this aligned with github.com/tphakala/simd/f32 init dispatch.
+var dotFloat32OptimizedMinLength = amd64DotFloat32OptimizedMinLength()
 
-// Conservative minimum that guarantees the selected amd64 SIMD backend executes
-// at least one packed-vector dot chunk (AVX-512: 16 lanes, AVX: 8, SSE: 4).
-const dotFloat32OptimizedMinLength = 16
+func amd64DotFloat32OptimizedMinLength() int {
+	switch {
+	case simdcpu.X86.AVX512F && simdcpu.X86.AVX512VL:
+		return 16
+	case simdcpu.X86.AVX && simdcpu.X86.FMA:
+		return 8
+	case simdcpu.X86.SSE2:
+		return 4
+	default:
+		return 0
+	}
+}
 
 // DotFloat32 returns the float32 dot product over the shared prefix of left and
 // right using the amd64 SIMD implementation. Callers must pass validated
@@ -32,8 +47,10 @@ func DotFloat32Implementation() string { return dotFloat32Implementation }
 // DotFloat32OptimizedAvailable reports whether this build includes a
 // platform-optimized single-vector dot backend. It does not guarantee that every
 // call uses SIMD; use DotFloat32OptimizedEligible for per-length accounting.
-func DotFloat32OptimizedAvailable() bool { return dotFloat32OptimizedAvailable }
+func DotFloat32OptimizedAvailable() bool { return dotFloat32OptimizedMinLength > 0 }
 
 // DotFloat32OptimizedEligible reports whether DotFloat32 is expected to use the
 // platform-optimized backend for a dot product of n float32 values.
-func DotFloat32OptimizedEligible(n int) bool { return n >= dotFloat32OptimizedMinLength }
+func DotFloat32OptimizedEligible(n int) bool {
+	return dotFloat32OptimizedMinLength > 0 && n >= dotFloat32OptimizedMinLength
+}

--- a/TreeDB/internal/vectorops/dot_arm64.go
+++ b/TreeDB/internal/vectorops/dot_arm64.go
@@ -8,6 +8,11 @@ const dotFloat32Implementation = "simd_axiomhq_simdgo"
 
 const dotFloat32OptimizedAvailable = true
 
+// Keep this threshold aligned with axiomhq/simd-go's Apple/NEON
+// DotProductFloat32 dispatch threshold. Below it DotProductFloat32 may execute
+// the scalar fallback even though this build includes a SIMD backend.
+const dotFloat32OptimizedMinLength = 32
+
 // DotFloat32 returns the float32 dot product over the shared prefix of left and
 // right using the arm64 SIMD implementation. Callers must pass validated
 // []float32 slices; this kernel does not reinterpret raw bytes.
@@ -25,6 +30,12 @@ func DotFloat32(left, right []float32) float32 {
 // DotFloat32Implementation identifies the active DotFloat32 implementation.
 func DotFloat32Implementation() string { return dotFloat32Implementation }
 
-// DotFloat32OptimizedAvailable reports whether this build's single-vector dot
-// product uses a platform-optimized backend rather than the portable scalar loop.
+// DotFloat32OptimizedAvailable reports whether this build includes a
+// platform-optimized single-vector dot backend. It does not guarantee that every
+// call uses SIMD; use DotFloat32OptimizedEligible for per-length accounting.
 func DotFloat32OptimizedAvailable() bool { return dotFloat32OptimizedAvailable }
+
+// DotFloat32OptimizedEligible reports whether DotFloat32 is expected to use the
+// platform-optimized backend for a dot product of n float32 values. arm64
+// axiomhq/simd-go dispatches small dots to scalar below its threshold.
+func DotFloat32OptimizedEligible(n int) bool { return n >= dotFloat32OptimizedMinLength }

--- a/TreeDB/internal/vectorops/dot_arm64.go
+++ b/TreeDB/internal/vectorops/dot_arm64.go
@@ -6,6 +6,8 @@ import axiomsimd "github.com/axiomhq/simd-go"
 
 const dotFloat32Implementation = "simd_axiomhq_simdgo"
 
+const dotFloat32OptimizedAvailable = true
+
 // DotFloat32 returns the float32 dot product over the shared prefix of left and
 // right using the arm64 SIMD implementation. Callers must pass validated
 // []float32 slices; this kernel does not reinterpret raw bytes.
@@ -22,3 +24,7 @@ func DotFloat32(left, right []float32) float32 {
 
 // DotFloat32Implementation identifies the active DotFloat32 implementation.
 func DotFloat32Implementation() string { return dotFloat32Implementation }
+
+// DotFloat32OptimizedAvailable reports whether this build's single-vector dot
+// product uses a platform-optimized backend rather than the portable scalar loop.
+func DotFloat32OptimizedAvailable() bool { return dotFloat32OptimizedAvailable }

--- a/TreeDB/internal/vectorops/dot_batch.go
+++ b/TreeDB/internal/vectorops/dot_batch.go
@@ -68,11 +68,11 @@ func dotFloat32StridedRows(dst []float32, rowCount int) int {
 }
 
 func dotFloat32IndexedShapeOK(base []float32, query []float32, rowIDs []uint32, dims, rows int) bool {
+	if !dotFloat32IndexedPrevalidatedShapeOK(base, query, dims, rows) {
+		return false
+	}
 	if rows == 0 {
 		return true
-	}
-	if dims <= 0 || len(query) < dims || len(base) < dims {
-		return false
 	}
 	maxRow := uint64((len(base) - dims) / dims)
 	for i := 0; i < rows; i++ {
@@ -81,6 +81,13 @@ func dotFloat32IndexedShapeOK(base []float32, query []float32, rowIDs []uint32, 
 		}
 	}
 	return true
+}
+
+func dotFloat32IndexedPrevalidatedShapeOK(base []float32, query []float32, dims, rows int) bool {
+	if rows == 0 {
+		return true
+	}
+	return dims > 0 && len(query) >= dims && len(base) >= dims
 }
 
 func dotFloat32StridedShapeOK(base []float32, query []float32, rows, dims, stride int) bool {

--- a/TreeDB/internal/vectorops/dot_batch_arm64.go
+++ b/TreeDB/internal/vectorops/dot_batch_arm64.go
@@ -28,6 +28,27 @@ func DotFloat32Indexed(dst []float32, base []float32, query []float32, rowIDs []
 	if !dotFloat32IndexedShapeOK(base, query, rowIDs, dims, rows) {
 		return dotFloat32BatchInvalidStatus()
 	}
+	return dotFloat32IndexedPrevalidated(dst, base, query, rowIDs, dims, rows)
+}
+
+// DotFloat32IndexedPrevalidated writes dot products for row-major base rows
+// selected by rowIDs whose bounds were already checked by the caller. It still
+// validates the non-indexed shape (dst/row count, dims, base/query minimum
+// length) but intentionally skips scanning rowIDs so hot graph-search paths that
+// already validated adjacency ordinals do not pay that check twice. Passing an
+// out-of-range row ID violates this function's contract.
+func DotFloat32IndexedPrevalidated(dst []float32, base []float32, query []float32, rowIDs []uint32, dims int) DotFloat32BatchStatus {
+	rows := dotFloat32IndexedRows(dst, rowIDs)
+	if rows == 0 {
+		return DotFloat32BatchStatus{}
+	}
+	if !dotFloat32IndexedPrevalidatedShapeOK(base, query, dims, rows) {
+		return dotFloat32BatchInvalidStatus()
+	}
+	return dotFloat32IndexedPrevalidated(dst, base, query, rowIDs, dims, rows)
+}
+
+func dotFloat32IndexedPrevalidated(dst []float32, base []float32, query []float32, rowIDs []uint32, dims, rows int) DotFloat32BatchStatus {
 	if !dotFloat32IndexedOptimizedEligible(rows, dims) {
 		dotFloat32IndexedScalar(dst, base, query, rowIDs, dims, rows)
 		return dotFloat32BatchStatus(rows, false)

--- a/TreeDB/internal/vectorops/dot_batch_fallback.go
+++ b/TreeDB/internal/vectorops/dot_batch_fallback.go
@@ -20,6 +20,27 @@ func DotFloat32Indexed(dst []float32, base []float32, query []float32, rowIDs []
 	if !dotFloat32IndexedShapeOK(base, query, rowIDs, dims, rows) {
 		return dotFloat32BatchInvalidStatus()
 	}
+	return dotFloat32IndexedPrevalidated(dst, base, query, rowIDs, dims, rows)
+}
+
+// DotFloat32IndexedPrevalidated writes dot products for row-major base rows
+// selected by rowIDs whose bounds were already checked by the caller. It still
+// validates the non-indexed shape (dst/row count, dims, base/query minimum
+// length) but intentionally skips scanning rowIDs so hot graph-search paths that
+// already validated adjacency ordinals do not pay that check twice. Passing an
+// out-of-range row ID violates this function's contract.
+func DotFloat32IndexedPrevalidated(dst []float32, base []float32, query []float32, rowIDs []uint32, dims int) DotFloat32BatchStatus {
+	rows := dotFloat32IndexedRows(dst, rowIDs)
+	if rows == 0 {
+		return DotFloat32BatchStatus{}
+	}
+	if !dotFloat32IndexedPrevalidatedShapeOK(base, query, dims, rows) {
+		return dotFloat32BatchInvalidStatus()
+	}
+	return dotFloat32IndexedPrevalidated(dst, base, query, rowIDs, dims, rows)
+}
+
+func dotFloat32IndexedPrevalidated(dst []float32, base []float32, query []float32, rowIDs []uint32, dims, rows int) DotFloat32BatchStatus {
 	dotFloat32IndexedScalar(dst, base, query, rowIDs, dims, rows)
 	return dotFloat32BatchStatus(rows, false)
 }

--- a/TreeDB/internal/vectorops/dot_batch_test.go
+++ b/TreeDB/internal/vectorops/dot_batch_test.go
@@ -55,6 +55,72 @@ func TestDotFloat32IndexedParity(t *testing.T) {
 	}
 }
 
+func TestDotFloat32IndexedPrevalidatedParity(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		dims   int
+		rowIDs []uint32
+	}{
+		{name: "short_dims_tail", dims: 7, rowIDs: []uint32{0, 1, 2, 3, 4}},
+		{name: "contiguous_batch", dims: 64, rowIDs: []uint32{0, 1, 2, 3}},
+		{name: "scattered_batch", dims: 128, rowIDs: []uint32{12, 2, 9, 0, 7, 3, 15, 1, 6, 10, 4, 14, 5}},
+		{name: "duplicates", dims: 63, rowIDs: []uint32{3, 3, 1, 7, 1}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			baseRows := maxRowID(tc.rowIDs) + 1
+			base := dotBatchTestBase(baseRows, tc.dims, tc.dims)
+			query := dotBatchTestVector(tc.dims, 47)
+			got := make([]float32, len(tc.rowIDs))
+
+			status := DotFloat32IndexedPrevalidated(got, base, query, tc.rowIDs, tc.dims)
+			if status.Invalid {
+				t.Fatalf("DotFloat32IndexedPrevalidated rejected valid prevalidated shape: %+v", status)
+			}
+			if status.Rows != len(tc.rowIDs) {
+				t.Fatalf("status.Rows=%d want %d", status.Rows, len(tc.rowIDs))
+			}
+			if status.Rows > 0 && status.Optimized == status.Fallback {
+				t.Fatalf("optimized/fallback status mismatch: %+v", status)
+			}
+
+			want := make([]float32, len(tc.rowIDs))
+			dotFloat32IndexedScalar(want, base, query, tc.rowIDs, tc.dims, len(tc.rowIDs))
+			assertFloat32SliceNear(t, got, want, tc.dims)
+		})
+	}
+}
+
+func TestDotFloat32IndexedPrevalidatedInvalidShapesLeaveDestinationUnchanged(t *testing.T) {
+	t.Parallel()
+
+	base := dotBatchTestBase(2, 4, 4)
+	query := dotBatchTestVector(4, 53)
+	cases := []struct {
+		name  string
+		base  []float32
+		query []float32
+		dims  int
+	}{
+		{name: "zero_dims", base: base, query: query, dims: 0},
+		{name: "short_query", base: base, query: query[:3], dims: 4},
+		{name: "short_base", base: base[:3], query: query, dims: 4},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dst := []float32{-31, -32, -33}
+			before := append([]float32(nil), dst...)
+			status := DotFloat32IndexedPrevalidated(dst, tc.base, tc.query, []uint32{0, 1}, tc.dims)
+			if !status.Invalid || status.Rows != 0 || status.Optimized || status.Fallback {
+				t.Fatalf("status=%+v want invalid without writes", status)
+			}
+			assertFloat32SliceExact(t, dst, before)
+		})
+	}
+}
+
 func TestDotFloat32StridedParity(t *testing.T) {
 	t.Parallel()
 
@@ -273,6 +339,36 @@ func BenchmarkDotFloat32IndexedWrapper(b *testing.B) {
 			dst := make([]float32, tc.rows)
 			benchmarkDotFloat32BatchCall(b, tc.dims, tc.rows, func() DotFloat32BatchStatus {
 				return DotFloat32Indexed(dst, base, query, rowIDs, tc.dims)
+			}, dst)
+		})
+	}
+}
+
+func BenchmarkDotFloat32IndexedPrevalidatedWrapper(b *testing.B) {
+	cases := []struct {
+		name      string
+		dims      int
+		rows      int
+		scattered bool
+	}{
+		{name: "dims16_rows4_contiguous_fallback", dims: 16, rows: 4},
+		{name: "dims64_rows4_contiguous", dims: 64, rows: 4},
+		{name: "dims64_rows13_scattered", dims: 64, rows: 13, scattered: true},
+		{name: "dims128_rows32_scattered", dims: 128, rows: 32, scattered: true},
+		{name: "dims768_rows13_scattered", dims: 768, rows: 13, scattered: true},
+	}
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			baseRows := tc.rows
+			if tc.scattered {
+				baseRows = tc.rows*4 + 17
+			}
+			base := dotBatchTestBase(baseRows, tc.dims, tc.dims)
+			query := dotBatchTestVector(tc.dims, 39)
+			rowIDs := dotBatchTestRowIDs(tc.rows, baseRows, tc.scattered)
+			dst := make([]float32, tc.rows)
+			benchmarkDotFloat32BatchCall(b, tc.dims, tc.rows, func() DotFloat32BatchStatus {
+				return DotFloat32IndexedPrevalidated(dst, base, query, rowIDs, tc.dims)
 			}, dst)
 		})
 	}

--- a/TreeDB/internal/vectorops/dot_fallback.go
+++ b/TreeDB/internal/vectorops/dot_fallback.go
@@ -4,6 +4,8 @@ package vectorops
 
 const dotFloat32Implementation = "scalar"
 
+const dotFloat32OptimizedAvailable = false
+
 // DotFloat32 returns the float32 dot product over the shared prefix of left and
 // right using the portable scalar implementation. Callers must pass validated
 // []float32 slices; this kernel does not reinterpret raw bytes.
@@ -13,3 +15,7 @@ func DotFloat32(left, right []float32) float32 {
 
 // DotFloat32Implementation identifies the active DotFloat32 implementation.
 func DotFloat32Implementation() string { return dotFloat32Implementation }
+
+// DotFloat32OptimizedAvailable reports whether this build's single-vector dot
+// product uses a platform-optimized backend rather than the portable scalar loop.
+func DotFloat32OptimizedAvailable() bool { return dotFloat32OptimizedAvailable }

--- a/TreeDB/internal/vectorops/dot_fallback.go
+++ b/TreeDB/internal/vectorops/dot_fallback.go
@@ -16,6 +16,11 @@ func DotFloat32(left, right []float32) float32 {
 // DotFloat32Implementation identifies the active DotFloat32 implementation.
 func DotFloat32Implementation() string { return dotFloat32Implementation }
 
-// DotFloat32OptimizedAvailable reports whether this build's single-vector dot
-// product uses a platform-optimized backend rather than the portable scalar loop.
+// DotFloat32OptimizedAvailable reports whether this build includes a
+// platform-optimized single-vector dot backend. It does not guarantee that every
+// call uses SIMD; use DotFloat32OptimizedEligible for per-length accounting.
 func DotFloat32OptimizedAvailable() bool { return dotFloat32OptimizedAvailable }
+
+// DotFloat32OptimizedEligible reports whether DotFloat32 is expected to use the
+// platform-optimized backend for a dot product of n float32 values.
+func DotFloat32OptimizedEligible(n int) bool { return false }

--- a/TreeDB/internal/vectorops/dot_test.go
+++ b/TreeDB/internal/vectorops/dot_test.go
@@ -81,9 +81,18 @@ func TestDotFloat32OptimizedAvailabilityMatchesImplementation(t *testing.T) {
 		if optimized {
 			t.Fatalf("DotFloat32OptimizedAvailable=true for scalar implementation")
 		}
+		if DotFloat32OptimizedEligible(1024) {
+			t.Fatalf("DotFloat32OptimizedEligible=true for scalar implementation")
+		}
 	default:
 		if !optimized {
 			t.Fatalf("DotFloat32OptimizedAvailable=false for optimized implementation %q", DotFloat32Implementation())
+		}
+		if DotFloat32OptimizedEligible(0) || DotFloat32OptimizedEligible(1) {
+			t.Fatalf("DotFloat32OptimizedEligible accepted tiny dot for implementation %q", DotFloat32Implementation())
+		}
+		if !DotFloat32OptimizedEligible(1024) {
+			t.Fatalf("DotFloat32OptimizedEligible rejected large dot for implementation %q", DotFloat32Implementation())
 		}
 	}
 }

--- a/TreeDB/internal/vectorops/dot_test.go
+++ b/TreeDB/internal/vectorops/dot_test.go
@@ -74,6 +74,20 @@ func TestDotFloat32SpecialValues1790(t *testing.T) {
 	}
 }
 
+func TestDotFloat32OptimizedAvailabilityMatchesImplementation(t *testing.T) {
+	optimized := DotFloat32OptimizedAvailable()
+	switch DotFloat32Implementation() {
+	case "scalar":
+		if optimized {
+			t.Fatalf("DotFloat32OptimizedAvailable=true for scalar implementation")
+		}
+	default:
+		if !optimized {
+			t.Fatalf("DotFloat32OptimizedAvailable=false for optimized implementation %q", DotFloat32Implementation())
+		}
+	}
+}
+
 func TestDotFloat32ZeroAllocs1790(t *testing.T) {
 	left := dotTestVector1790(257, 3)
 	right := dotTestVector1790(257, 5)


### PR DESCRIPTION
## Summary

Refs #2403.

This PR installs a focused HNSW search-pack scoring/accounting cleanup for exact FP32 no-document search:

- adds `vectorops.DotFloat32IndexedPrevalidated` for hot callers that have already bounds-checked row IDs;
- keeps arm64 SIMD and portable/purego fallback implementations allocation-free;
- uses the prevalidated indexed-dot wrapper in `hnsw_search_pack_v1` tile scoring only after existing adjacency ordinal bounds checks;
- adds `DotFloat32OptimizedEligible` so singleton scores are counted as optimized only when the active single-vector dot backend is expected to use SIMD for that length.

No graph topology, recall tuning, ef/M tuning, quantized path, docs/materialization behavior, or public API behavior is changed.

## Safety / semantics

- Scope is the exact FP32 `hnsw_search_pack_v1` no-document route.
- Row-ID safety is preserved by existing search-pack checks before prevalidated scoring:
  - layer-0 tiles validate every neighbor `< rowCount` before append;
  - upper-layer adjacency validates all neighbors before calling `scoreRowIDs`;
  - prepared-view validation keeps normalized-vector storage at `rows * vectorStride`.
- `DotFloat32IndexedPrevalidated` still validates non-index shape (`dims`, `base`, `query`, `dst`/row count), but intentionally skips the row-ID scan under that caller contract.
- FP32 scoring remains raw-vector cosine authoritative. Existing indexed tile scoring already uses zero-padded `vectorStride`; singleton scoring still calls `vectorDotProductFloat32` over real dimensions.
- Portable/purego builds use scalar fallback.
- Follow-up fixes for Codex P2s: singleton counter classification is now length/runtime-backend-aware; tiny dots remain fallback-classified below the active SIMD dispatch threshold, including arm64 and amd64 AVX-512/AVX+FMA/SSE2 selections.

## Tests

Latest local validation after final head `a191f3f47`:

- `GOWORK=off go test ./TreeDB/internal/vectorops -count=1`
- `GOWORK=off go test -tags purego ./TreeDB/internal/vectorops -count=1`
- `GOWORK=off go test ./TreeDB/collections -run 'TestColumnHNSWSearchPackSearchPathServesSearchWithBuffer|TestVectorIndexSearcherSearchWithBuffer|TestVectorIndexSearcherSearchWithBufferResultEquivalenceAndZeroAllocs2124' -count=1`
- `GOWORK=off go test ./TreeDB/collections -count=1`
- `git diff --check origin/main..HEAD`

Earlier post-`origin/main` local validation logs:

- `/tmp/gomap_2403_vectorops_test_after_2440_merge.log`
- `/tmp/gomap_2403_vectorops_purego_test_after_2440_merge.log`
- `/tmp/gomap_2403_collections_test_after_2440_merge.log`

## Benchmark / counter evidence

No wall-clock speedup is claimed. Timing remains noisy/mixed, including USearch controls. The useful claim is counter/behavioral: singleton SIMD-capable scores at the measured Tier S/Tier F lengths are no longer classified as scalar fallback, prevalidated indexed scoring is installed behind existing row-ID checks, route guardrails remain healthy, and buffered allocation contracts are preserved.

Primary quiet artifact root:

- `/tmp/gomap_2403_final_evidence_20260605_170916`
- quietness: `process_quietness_preflight.txt`, `process_monitor_during_benchmarks.txt`, `QUIETNESS_VALIDATED.md`
- Tier S: `tier_s_base/bench.txt`, `tier_s_head/bench.txt`, `tier_s_benchstat.txt`, `summary.tsv`
- Tier F repeat: `tier_f_count3_base/bench.txt`, `tier_f_count3_head/bench.txt`, `tier_f_count3_benchstat.txt`, `tier_f_count3_summary.tsv`, `process_monitor_tier_f_count3.txt`
- alloc proof: `head_alloc_proof/bench.txt`, `head_alloc_proof_summary.txt`

Note: the Tier S/Tier F benchmarks ran at base `5e130ee24` and head `719c5c5a1`. Afterward `origin/main` advanced by docs-only #2440 (`README.md`, `TreeDB/README.md`) and this branch merged it as `7805148b4`; final head `a191f3f47` then made counter classification length-aware for small dimensions. The measured Tier S/Tier F dimensions (64/128) remain eligible under the final length/runtime-backend-aware classification, so the counter deltas below are still representative for those fixtures; no runtime speedup is claimed.

Commands used the same benchmark regex on base and head:

```sh
BENCH_REGEX='BenchmarkCollectionVectorUSearchProductionCompare/(TreeDB_SearchWithBuffer|TreeDB_SearchWithBufferParallel|TreeDB_CollectionSearchVectorIndexWithBuffer|TreeDB_CollectionSearchVectorIndexNoDocsOneShot|USearch_Search|USearch_SearchParallel)$'
```

Tier S command shape: `GOWORK=off COUNT=3 BENCHTIME=1000x CPU_LIST=1,8 TREEDB_VECTOR_BENCH_DOCS=10000 TREEDB_VECTOR_BENCH_DIMS=64 ... scripts/bench_vector_search_compare.sh`

Tier F repeat command shape: `GOWORK=off COUNT=3 BENCHTIME=100x CPU_LIST=1,8 TREEDB_VECTOR_BENCH_DOCS=100000 TREEDB_VECTOR_BENCH_DIMS=128 ... scripts/bench_vector_search_compare.sh`

### Counter deltas

| Fixture | Rows | base | head |
| --- | --- | ---: | ---: |
| Tier S 10k/64 | `score_batch_fallback/search` | 6 | 0 |
| Tier S 10k/64 | `score_batch_fallback_reason_scalar` | 1 | 0 |
| Tier S 10k/64 | `score_batch_optimized/search` | 132 | 138 |
| Tier S 10k/64 | `score_batch_calls/search` | 138 | 138 |
| Tier S 10k/64 | `score_batch_candidates/search` | 1525 | 1525 |
| Tier F 100k/128 | `score_batch_fallback/search` | 4 | 0 |
| Tier F 100k/128 | `score_batch_fallback_reason_scalar` | 1 | 0 |
| Tier F 100k/128 | `score_batch_optimized/search` | 134 | 138 |
| Tier F 100k/128 | `score_batch_calls/search` | 138 | 138 |
| Tier F 100k/128 | `score_batch_candidates/search` | 2595 | 2595 |

### Route / fallback guardrails

Smoke/final benchmark rows kept the exact no-document search-pack route healthy:

- `search_route_hnsw_search_pack/search=1`
- `hnsw_search_pack_active/search=1`
- `docs_fetched/search=0`
- `graph_row_fallbacks/search=0`
- `typed_column_vector_fallbacks/search=0`
- `vector_scratch_decodes/search=0`
- exact rows kept quantized route/scorer counters at zero
- collection buffered rows kept `open_searcher_calls/op=0` and `open_setup_in_timed_loop=0`

### Allocation proof

Focused head-only allocation proof (`BENCHTIME=100000x`, c=1/c=8, Tier S fixture) showed buffered rows at 0 B/op and 0 allocs/op, including parallel:

| Row | c=1 | c=8 |
| --- | --- | --- |
| `TreeDB_SearchWithBuffer` | `0 B/op`, `0 allocs/op` | `0 B/op`, `0 allocs/op` |
| `TreeDB_SearchWithBufferParallel` | `0 B/op`, `0 allocs/op` | `0 B/op`, `0 allocs/op` |
| `TreeDB_CollectionSearchVectorIndexWithBuffer` | `0 B/op`, `0 allocs/op` | `0 B/op`, `0 allocs/op` |

## Timing caveat

Tier S medians improved across TreeDB rows but benchstat reported no significant per-row change at `n=3`. Tier F repeat (`n=3`) was mixed/noisy with no significant per-row change. This PR therefore does **not** claim runtime speedup or parity movement versus USearch.

