### PR TITLE
Add collection-level buffered quantized vector search

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -382,7 +382,7 @@ type Collection struct {
 	vectorPreparedSearchBuilds uint64
 
 	vectorBufferedSearchMu            sync.Mutex
-	vectorBufferedSearch              map[string]*collectionVectorIndexPreparedSearchCacheEntry
+	vectorBufferedSearch              map[collectionVectorIndexPreparedSearchCacheSlot]*collectionVectorIndexPreparedSearchCacheEntry
 	vectorBufferedSearchHits          uint64
 	vectorBufferedSearchMisses        uint64
 	vectorBufferedSearchWaits         uint64

--- a/TreeDB/collections/collection_vector_index_prepared_search_cache.go
+++ b/TreeDB/collections/collection_vector_index_prepared_search_cache.go
@@ -452,15 +452,15 @@ func (c *Collection) openCollectionVectorIndexPreparedQuantizedSearch(opts Vecto
 		}
 	}()
 
-	preparedReady := collectionVectorIndexPreparedQuantizedReaderReady(reader)
+	readerReady := collectionVectorIndexPreparedQuantizedReaderReady(reader)
 	routeStats := vectorIndexSearchRouteStatsForColumnGraphQuantized(vectorIndexSearchRouteStatsForColumnGraphReader(reader))
-	if preparedReady && reader.RowCount() == 0 {
+	if readerReady && reader.RowCount() == 0 {
 		routeStats.SearchRouteColumnGraphPrepared = 1
 		routeStats.SearchRouteColumnGraphFallback = 0
 	}
-	if !preparedReady || routeStats.SearchRouteColumnGraphPrepared != 1 || routeStats.SearchRouteColumnGraphFallback != 0 {
+	if !readerReady || !collectionVectorIndexPreparedQuantizedRouteStatsReady(routeStats) {
 		response.Stats = collectionVectorIndexPreparedQuantizedValidationStats(reader, routeStats, opts.QuantizedIndexName, queryMode)
-		return nil, response, fmt.Errorf("%w: vector index %q SearchVectorIndexWithBuffer quantized mode requires healthy prepared column_graph state; rebuild the vector index before using the collection buffered quantized route", ErrVectorIndexSearchUnavailable, def.Name)
+		return nil, response, fmt.Errorf("%w: vector index %q SearchVectorIndexWithBuffer quantized mode requires healthy column_graph quantized reader state; rebuild the vector index before using the collection buffered quantized route", ErrVectorIndexSearchUnavailable, def.Name)
 	}
 	if err := reader.validateQuantizedNativeSearchOptions(queryMode, columnVectorGraphNativeSearchOptions{TopK: opts.TopK, QuantizedIndexName: opts.QuantizedIndexName, QuantizedRerankCandidates: opts.QuantizedRerankCandidates}); err != nil {
 		response.Stats = collectionVectorIndexPreparedQuantizedValidationStats(reader, routeStats, opts.QuantizedIndexName, queryMode)
@@ -503,13 +503,17 @@ func collectionVectorIndexPreparedQuantizedReaderReady(reader *columnVectorGraph
 	if reader == nil || reader.def.Dimensions <= 0 {
 		return false
 	}
-	if reader.RowCount() == 0 {
+	if reader.RowCount() == 0 || reader.preparedSearch == nil {
 		return true
 	}
-	if reader.preparedSearch == nil {
+	return reader.preparedSearch.ready()
+}
+
+func collectionVectorIndexPreparedQuantizedRouteStatsReady(stats vectorIndexSearchRouteStats) bool {
+	if stats.SearchRouteHNSWSearchPack != 0 {
 		return false
 	}
-	return reader.preparedSearch.ready()
+	return stats.SearchRouteColumnGraphPrepared+stats.SearchRouteColumnGraphFallback == 1
 }
 
 func collectionVectorIndexPreparedSearchSnapshotCacheKey(base string, commitSeq, systemRoot uint64) string {
@@ -788,7 +792,7 @@ func (p *collectionVectorIndexPreparedSearch) openCollectionVectorIndexPreparedQ
 	if !collectionVectorIndexPreparedQuantizedReaderReady(reader) {
 		stats := collectionVectorIndexPreparedQuantizedValidationStats(reader, p.routeStats, opts.QuantizedIndexName, queryMode)
 		_ = reader.Close()
-		return nil, stats, fmt.Errorf("%w: vector index %q SearchVectorIndexWithBuffer quantized mode requires healthy prepared column_graph state; rebuild the vector index before using the collection buffered quantized route", ErrVectorIndexSearchUnavailable, p.indexName)
+		return nil, stats, fmt.Errorf("%w: vector index %q SearchVectorIndexWithBuffer quantized mode requires healthy column_graph quantized reader state; rebuild the vector index before using the collection buffered quantized route", ErrVectorIndexSearchUnavailable, p.indexName)
 	}
 	if err := reader.validateQuantizedNativeSearchOptions(queryMode, columnVectorGraphNativeSearchOptions{TopK: opts.TopK, QuantizedIndexName: opts.QuantizedIndexName, QuantizedRerankCandidates: opts.QuantizedRerankCandidates}); err != nil {
 		stats := collectionVectorIndexPreparedQuantizedValidationStats(reader, p.routeStats, opts.QuantizedIndexName, queryMode)

--- a/TreeDB/collections/collection_vector_index_prepared_search_cache.go
+++ b/TreeDB/collections/collection_vector_index_prepared_search_cache.go
@@ -20,6 +20,7 @@ type collectionVectorIndexPreparedSearchCacheSlot struct {
 	family             collectionVectorIndexPreparedSearchFamily
 	indexName          string
 	quantizedIndexName string
+	maxDecodedBlocks   int
 }
 
 type collectionVectorIndexPreparedSearchCacheEntry struct {
@@ -105,7 +106,7 @@ func callCollectionVectorIndexPreparedSearchBuildHookForTest(indexName string) {
 
 func collectionVectorIndexPreparedSearchCacheSlotForOptions(opts VectorIndexSearchOptions, queryMode columnVectorGraphNativeSearchQueryMode) collectionVectorIndexPreparedSearchCacheSlot {
 	if queryMode.quantized() {
-		return collectionVectorIndexPreparedSearchCacheSlot{family: collectionVectorIndexPreparedSearchFamilyQuantized, indexName: opts.IndexName, quantizedIndexName: opts.QuantizedIndexName}
+		return collectionVectorIndexPreparedSearchCacheSlot{family: collectionVectorIndexPreparedSearchFamilyQuantized, indexName: opts.IndexName, quantizedIndexName: opts.QuantizedIndexName, maxDecodedBlocks: opts.MaxDecodedBlocks}
 	}
 	return collectionVectorIndexPreparedSearchCacheSlot{family: collectionVectorIndexPreparedSearchFamilyExactHNSWPack, indexName: opts.IndexName}
 }
@@ -466,7 +467,7 @@ func (c *Collection) openCollectionVectorIndexPreparedQuantizedSearch(opts Vecto
 		response.Stats = collectionVectorIndexPreparedQuantizedValidationStats(reader, routeStats, opts.QuantizedIndexName, queryMode)
 		return nil, response, err
 	}
-	key, err := collectionVectorIndexPreparedQuantizedSearchCacheKey(readerCatalog.meta.Name, view.AssetNamespace, def, graph, view.VectorIndexState, opts.QuantizedIndexName)
+	key, err := collectionVectorIndexPreparedQuantizedSearchCacheKey(readerCatalog.meta.Name, view.AssetNamespace, def, graph, view.VectorIndexState, opts.QuantizedIndexName, opts.MaxDecodedBlocks)
 	if err != nil {
 		return nil, response, err
 	}
@@ -535,7 +536,7 @@ func collectionVectorIndexPreparedQuantizedValidationStats(reader *columnVectorG
 	return stats
 }
 
-func collectionVectorIndexPreparedQuantizedSearchCacheKey(collection string, namespace string, def VectorIndexDefinition, graph columnVectorGraphManifestSnapshot, state columnVectorIndexStateSnapshot, quantizedIndexName string) (string, error) {
+func collectionVectorIndexPreparedQuantizedSearchCacheKey(collection string, namespace string, def VectorIndexDefinition, graph columnVectorGraphManifestSnapshot, state columnVectorIndexStateSnapshot, quantizedIndexName string, maxDecodedBlocks int) (string, error) {
 	base, err := columnVectorGraphSharedPreparedSearchCacheKey(collection, namespace, def, graph, state)
 	if err != nil {
 		return "", err
@@ -548,7 +549,7 @@ func collectionVectorIndexPreparedQuantizedSearchCacheKey(collection string, nam
 	if !ok {
 		return "", fmt.Errorf("%w: %w: vector index %q quantized index %q has no quantized score-plane asset", ErrVectorIndexSearchUnavailable, errColumnVectorGraphQuantizedAssetMissing, def.Name, quantizedIndexName)
 	}
-	return fmt.Sprintf("collection_buffered_quantized_v1|family=quantized|q=%s|codec=%s|version=%d|asset_id=%s|asset_schema=%d|asset_bytes=%d|asset_ref=%+v|%s", qdef.Name, qdef.Codec, qdef.Version, asset.AssetID, asset.SourceSchemaHash, asset.AssetBytes, columnVectorGraphQuantizedAssetRefIdentity(asset.Ref), base), nil
+	return fmt.Sprintf("collection_buffered_quantized_v1|family=quantized|q=%s|codec=%s|version=%d|max_decoded_blocks=%d|asset_id=%s|asset_schema=%d|asset_bytes=%d|asset_ref=%+v|%s", qdef.Name, qdef.Codec, qdef.Version, maxDecodedBlocks, asset.AssetID, asset.SourceSchemaHash, asset.AssetBytes, columnVectorGraphQuantizedAssetRefIdentity(asset.Ref), base), nil
 }
 
 func (p *collectionVectorIndexPreparedSearch) readyForCurrentSearch() bool {

--- a/TreeDB/collections/collection_vector_index_prepared_search_cache.go
+++ b/TreeDB/collections/collection_vector_index_prepared_search_cache.go
@@ -9,6 +9,19 @@ import (
 	"github.com/snissn/gomap/TreeDB/internal/mappedresource"
 )
 
+type collectionVectorIndexPreparedSearchFamily uint8
+
+const (
+	collectionVectorIndexPreparedSearchFamilyExactHNSWPack collectionVectorIndexPreparedSearchFamily = iota + 1
+	collectionVectorIndexPreparedSearchFamilyQuantized
+)
+
+type collectionVectorIndexPreparedSearchCacheSlot struct {
+	family             collectionVectorIndexPreparedSearchFamily
+	indexName          string
+	quantizedIndexName string
+}
+
 type collectionVectorIndexPreparedSearchCacheEntry struct {
 	ready      chan struct{}
 	building   bool
@@ -22,14 +35,18 @@ type collectionVectorIndexPreparedSearchCacheEntry struct {
 type collectionVectorIndexPreparedSearch struct {
 	mu sync.RWMutex
 
-	key        string
-	indexName  string
-	commitSeq  uint64
-	systemRoot uint64
-	response   VectorIndexSearchResponse
+	key                string
+	family             collectionVectorIndexPreparedSearchFamily
+	indexName          string
+	quantizedIndexName string
+	dimensions         int
+	commitSeq          uint64
+	systemRoot         uint64
+	response           VectorIndexSearchResponse
 
 	pack       *columnHNSWSearchPackPreparedView
 	packStatus columnHNSWSearchPackPreparedStatus
+	searcher   *VectorIndexSearcher
 	routeStats vectorIndexSearchRouteStats
 	closed     bool
 }
@@ -64,6 +81,13 @@ func callCollectionVectorIndexPreparedSearchBuildHookForTest(indexName string) {
 	}
 }
 
+func collectionVectorIndexPreparedSearchCacheSlotForOptions(opts VectorIndexSearchOptions, queryMode columnVectorGraphNativeSearchQueryMode) collectionVectorIndexPreparedSearchCacheSlot {
+	if queryMode.quantized() {
+		return collectionVectorIndexPreparedSearchCacheSlot{family: collectionVectorIndexPreparedSearchFamilyQuantized, indexName: opts.IndexName, quantizedIndexName: opts.QuantizedIndexName}
+	}
+	return collectionVectorIndexPreparedSearchCacheSlot{family: collectionVectorIndexPreparedSearchFamilyExactHNSWPack, indexName: opts.IndexName}
+}
+
 func (c *Collection) acquireCollectionVectorIndexPreparedSearch(opts VectorIndexSearchOptions) (*collectionVectorIndexPreparedSearch, VectorIndexSearchResponse, error) {
 	var response VectorIndexSearchResponse
 	if err := ValidateIndexName(opts.IndexName); err != nil {
@@ -72,6 +96,11 @@ func (c *Collection) acquireCollectionVectorIndexPreparedSearch(opts VectorIndex
 	if opts.MaxDecodedBlocks < 0 {
 		return nil, response, errors.New("collections: vector index search max_decoded_blocks cannot be negative")
 	}
+	queryMode, err := normalizeVectorIndexSearchQueryMode(opts.QueryMode, opts.QuantizedIndexName, opts.QuantizedRerankCandidates, opts.TopK)
+	if err != nil {
+		return nil, response, err
+	}
+	slot := collectionVectorIndexPreparedSearchCacheSlotForOptions(opts, queryMode)
 	if c == nil {
 		return nil, response, errCollectionNil
 	}
@@ -90,9 +119,9 @@ func (c *Collection) acquireCollectionVectorIndexPreparedSearch(opts VectorIndex
 		var oldPrepared *collectionVectorIndexPreparedSearch
 		c.vectorBufferedSearchMu.Lock()
 		if c.vectorBufferedSearch == nil {
-			c.vectorBufferedSearch = make(map[string]*collectionVectorIndexPreparedSearchCacheEntry)
+			c.vectorBufferedSearch = make(map[collectionVectorIndexPreparedSearchCacheSlot]*collectionVectorIndexPreparedSearchCacheEntry)
 		}
-		entry := c.vectorBufferedSearch[opts.IndexName]
+		entry := c.vectorBufferedSearch[slot]
 		if entry != nil && entry.building {
 			ready := entry.ready
 			c.vectorBufferedSearchWaits++
@@ -106,7 +135,7 @@ func (c *Collection) acquireCollectionVectorIndexPreparedSearch(opts VectorIndex
 		}
 		if entry != nil && entry.commitSeq == commitSeq && entry.systemRoot == systemRoot {
 			if entry.err != nil {
-				delete(c.vectorBufferedSearch, opts.IndexName)
+				delete(c.vectorBufferedSearch, slot)
 				c.vectorBufferedSearchErrors++
 				response = entry.response
 				err := entry.err
@@ -119,11 +148,11 @@ func (c *Collection) acquireCollectionVectorIndexPreparedSearch(opts VectorIndex
 			if prepared != nil && prepared.readyForCurrentSearch() {
 				return prepared, prepared.responseForSearch(), nil
 			}
-			c.invalidateCollectionVectorIndexPreparedSearch(opts.IndexName, prepared)
+			c.invalidateCollectionVectorIndexPreparedSearch(slot, prepared)
 			continue
 		}
 		if entry != nil {
-			delete(c.vectorBufferedSearch, opts.IndexName)
+			delete(c.vectorBufferedSearch, slot)
 			oldPrepared = entry.prepared
 			c.vectorBufferedSearchInvalidations++
 		}
@@ -133,7 +162,7 @@ func (c *Collection) acquireCollectionVectorIndexPreparedSearch(opts VectorIndex
 			commitSeq:  commitSeq,
 			systemRoot: systemRoot,
 		}
-		c.vectorBufferedSearch[opts.IndexName] = entry
+		c.vectorBufferedSearch[slot] = entry
 		c.vectorBufferedSearchMisses++
 		c.vectorBufferedSearchBuilds++
 		c.vectorBufferedSearchMu.Unlock()
@@ -162,9 +191,9 @@ func (c *Collection) acquireCollectionVectorIndexPreparedSearch(opts VectorIndex
 		}
 		entry.prepared = prepared
 		entry.building = false
-		if c.vectorBufferedSearch[opts.IndexName] == entry {
+		if c.vectorBufferedSearch[slot] == entry {
 			if buildErr != nil {
-				delete(c.vectorBufferedSearch, opts.IndexName)
+				delete(c.vectorBufferedSearch, slot)
 				c.vectorBufferedSearchErrors++
 			} else {
 				stored = true
@@ -184,6 +213,17 @@ func (c *Collection) acquireCollectionVectorIndexPreparedSearch(opts VectorIndex
 }
 
 func (c *Collection) openCollectionVectorIndexPreparedSearch(opts VectorIndexSearchOptions) (*collectionVectorIndexPreparedSearch, VectorIndexSearchResponse, error) {
+	queryMode, err := normalizeVectorIndexSearchQueryMode(opts.QueryMode, opts.QuantizedIndexName, opts.QuantizedRerankCandidates, opts.TopK)
+	if err != nil {
+		return nil, VectorIndexSearchResponse{}, err
+	}
+	if queryMode.quantized() {
+		return c.openCollectionVectorIndexPreparedQuantizedSearch(opts, queryMode)
+	}
+	return c.openCollectionVectorIndexPreparedExactSearch(opts)
+}
+
+func (c *Collection) openCollectionVectorIndexPreparedExactSearch(opts VectorIndexSearchOptions) (*collectionVectorIndexPreparedSearch, VectorIndexSearchResponse, error) {
 	var response VectorIndexSearchResponse
 	if c == nil {
 		return nil, response, errCollectionNil
@@ -250,6 +290,7 @@ func (c *Collection) openCollectionVectorIndexPreparedSearch(opts VectorIndexSea
 	if err != nil {
 		return nil, response, err
 	}
+	key = collectionVectorIndexPreparedSearchSnapshotCacheKey(key, snapshotCommitSeq(snap), snapshotSystemRoot(snap))
 	if !columnVectorGraphDocumentIDStatePresent(view.VectorIndexState) {
 		return nil, response, fmt.Errorf("%w: vector index %q SearchVectorIndexWithBuffer requires vector-index document-id state for no-document result IDs; rebuild the vector index", ErrVectorIndexSearchUnavailable, def.Name)
 	}
@@ -273,7 +314,9 @@ func (c *Collection) openCollectionVectorIndexPreparedSearch(opts VectorIndexSea
 	routeStats := vectorIndexSearchRouteStatsForHNSWSearchPackRoute(pack.routeStats(packStatus, packOpenNanos))
 	return &collectionVectorIndexPreparedSearch{
 		key:        key,
+		family:     collectionVectorIndexPreparedSearchFamilyExactHNSWPack,
 		indexName:  def.Name,
+		dimensions: def.Dimensions,
 		commitSeq:  snapshotCommitSeq(snap),
 		systemRoot: snapshotSystemRoot(snap),
 		response:   response,
@@ -291,17 +334,193 @@ func collectionVectorIndexPreparedSearchCacheKey(collection string, namespace st
 	return "collection_buffered_hnsw_search_pack_v1|" + key, nil
 }
 
+func (c *Collection) openCollectionVectorIndexPreparedQuantizedSearch(opts VectorIndexSearchOptions, queryMode columnVectorGraphNativeSearchQueryMode) (*collectionVectorIndexPreparedSearch, VectorIndexSearchResponse, error) {
+	var response VectorIndexSearchResponse
+	if c == nil {
+		return nil, response, errCollectionNil
+	}
+	if c.db == nil {
+		return nil, response, errCollectionDBNil
+	}
+	snap := c.db.AcquireSnapshot()
+	if snap == nil {
+		return nil, response, backenddb.ErrClosed
+	}
+	closeSnapOnErr := true
+	defer func() {
+		if closeSnapOnErr {
+			_ = snap.Close()
+		}
+	}()
+
+	catalog, err := c.catalogForSnapshot(snap)
+	if err != nil {
+		return nil, response, err
+	}
+	if catalog == nil {
+		return nil, response, errCollectionNotFound
+	}
+	def, ok := findVectorIndex(catalog.meta.VectorIndexes, opts.IndexName)
+	if !ok {
+		return nil, response, fmt.Errorf("%w: vector index %q SearchVectorIndexWithBuffer requires a declared vector index", ErrIndexNotFound, opts.IndexName)
+	}
+	response.IndexName = def.Name
+	response.Strategy = def.Strategy
+	switch def.Strategy {
+	case VectorIndexStrategyNativeRuntime:
+		response.Status = VectorIndexStatus{Name: def.Name, Strategy: def.Strategy, State: VectorIndexStateNativeRuntime, Reason: VectorIndexReasonNativeRuntime}
+		return nil, response, fmt.Errorf("%w: vector index %q SearchVectorIndexWithBuffer quantized mode requires an explicit column_graph index; native_runtime cannot serve the no-document quantized route", ErrVectorIndexSearchUnavailable, def.Name)
+	case VectorIndexStrategyColumnGraph:
+	default:
+		response.Status = VectorIndexStatus{Name: def.Name, Strategy: def.Strategy, State: VectorIndexStateColumnGraphUnavailable, Reason: VectorIndexReasonUnsupportedStrategy}
+		return nil, response, fmt.Errorf("%w: vector index %q SearchVectorIndexWithBuffer quantized mode requires column_graph strategy; got unsupported strategy %q", ErrVectorIndexSearchUnavailable, def.Name, def.Strategy)
+	}
+	if def.Metric != VectorMetricCosine {
+		response.Status = VectorIndexStatus{Name: def.Name, Strategy: def.Strategy, State: VectorIndexStateColumnGraphUnavailable, Reason: VectorIndexReasonColumnGraphUnsupportedMetric}
+		return nil, response, fmt.Errorf("%w: vector index %q SearchVectorIndexWithBuffer quantized mode requires cosine column_graph state; got metric %q", ErrVectorIndexSearchUnavailable, def.Name, def.Metric)
+	}
+
+	def, graph, view, err := c.columnVectorGraphPhysicalRowReaderSnapshotViewAtSnapshot(def.Name, snap)
+	if err != nil {
+		status, statusErr := c.columnGraphVectorIndexStatusAtSnapshot(def.Name, snap)
+		if statusErr != nil {
+			if errors.Is(statusErr, ErrIndexNotFound) {
+				return nil, response, fmt.Errorf("%w: vector index %q SearchVectorIndexWithBuffer requires a declared vector index", ErrIndexNotFound, def.Name)
+			}
+			return nil, response, statusErr
+		}
+		status = failClosedColumnGraphReaderOpenStatus(def, status)
+		response.Status = status
+		return nil, response, fmt.Errorf("%w: vector index %q SearchVectorIndexWithBuffer quantized mode requires loaded column_graph state: state=%s reason=%s", ErrVectorIndexSearchUnavailable, def.Name, status.State, status.Reason)
+	}
+	readerCatalog := view.Catalog
+	if readerCatalog == nil || readerCatalog.meta.Options.ColumnStore == nil {
+		return nil, response, errors.New("collections: column_graph prepared quantized collection search missing snapshot catalog")
+	}
+	response.IndexName = def.Name
+	response.Strategy = def.Strategy
+	response.Path = VectorIndexSearchPathColumnGraphNativeReader
+	response.Status = VectorIndexStatus{Name: def.Name, Strategy: def.Strategy, State: VectorIndexStateColumnGraphLoaded, Loaded: true}
+	if !columnVectorGraphDocumentIDStatePresent(view.VectorIndexState) {
+		return nil, response, fmt.Errorf("%w: vector index %q SearchVectorIndexWithBuffer quantized mode requires vector-index document-id state for no-document result IDs; rebuild the vector index", ErrVectorIndexSearchUnavailable, def.Name)
+	}
+	if err := validateColumnVectorGraphDocumentIDStateAssetPayload(c.db.ColumnAssetRootDir(), readerCatalog.meta.Name, *readerCatalog.meta.Options.ColumnStore, def, graph, view.VectorIndexState); err != nil {
+		return nil, response, fmt.Errorf("%w: vector index %q SearchVectorIndexWithBuffer quantized mode requires valid vector-index document-id state for no-document result IDs; rebuild the vector index", ErrVectorIndexSearchUnavailable, def.Name)
+	}
+
+	reader, err := c.openColumnVectorGraphPhysicalRowReaderAtSnapshot(def.Name, snap, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: opts.MaxDecodedBlocks})
+	if err != nil {
+		status, statusErr := c.columnGraphVectorIndexStatusAtSnapshot(def.Name, snap)
+		if statusErr != nil {
+			return nil, response, statusErr
+		}
+		status = failClosedColumnGraphReaderOpenStatus(def, status)
+		response.Status = status
+		return nil, response, fmt.Errorf("%w: vector index %q SearchVectorIndexWithBuffer quantized mode requires loaded column_graph reader state: state=%s reason=%s: %w", ErrVectorIndexSearchUnavailable, def.Name, status.State, status.Reason, err)
+	}
+	closeReaderOnErr := true
+	defer func() {
+		if closeReaderOnErr {
+			_ = reader.Close()
+		}
+	}()
+
+	routeStats := vectorIndexSearchRouteStatsForColumnGraphQuantized(vectorIndexSearchRouteStatsForColumnGraphReader(reader))
+	if reader.preparedSearch == nil || !reader.preparedSearch.ready() || routeStats.SearchRouteColumnGraphPrepared != 1 || routeStats.SearchRouteColumnGraphFallback != 0 {
+		response.Stats = collectionVectorIndexPreparedQuantizedValidationStats(reader, routeStats, opts.QuantizedIndexName, queryMode)
+		return nil, response, fmt.Errorf("%w: vector index %q SearchVectorIndexWithBuffer quantized mode requires healthy prepared column_graph state; rebuild the vector index before using the collection buffered quantized route", ErrVectorIndexSearchUnavailable, def.Name)
+	}
+	if err := reader.validateQuantizedNativeSearchOptions(queryMode, columnVectorGraphNativeSearchOptions{TopK: opts.TopK, QuantizedIndexName: opts.QuantizedIndexName, QuantizedRerankCandidates: opts.QuantizedRerankCandidates}); err != nil {
+		response.Stats = collectionVectorIndexPreparedQuantizedValidationStats(reader, routeStats, opts.QuantizedIndexName, queryMode)
+		return nil, response, err
+	}
+	key, err := collectionVectorIndexPreparedQuantizedSearchCacheKey(readerCatalog.meta.Name, view.AssetNamespace, def, graph, view.VectorIndexState, opts.QuantizedIndexName)
+	if err != nil {
+		return nil, response, err
+	}
+	key = collectionVectorIndexPreparedSearchSnapshotCacheKey(key, snapshotCommitSeq(snap), snapshotSystemRoot(snap))
+	searcher := &VectorIndexSearcher{
+		collection: c,
+		indexName:  response.IndexName,
+		strategy:   response.Strategy,
+		path:       response.Path,
+		status:     response.Status,
+		snapshot:   snap,
+		catalog:    reader.catalog,
+		reader:     reader,
+		readerLast: reader.Stats(),
+		routeStats: routeStats,
+	}
+	closeSnapOnErr = false
+	closeReaderOnErr = false
+	return &collectionVectorIndexPreparedSearch{
+		key:                key,
+		family:             collectionVectorIndexPreparedSearchFamilyQuantized,
+		indexName:          def.Name,
+		quantizedIndexName: opts.QuantizedIndexName,
+		dimensions:         def.Dimensions,
+		commitSeq:          snapshotCommitSeq(snap),
+		systemRoot:         snapshotSystemRoot(snap),
+		response:           response,
+		searcher:           searcher,
+		routeStats:         routeStats,
+	}, response, nil
+}
+
+func collectionVectorIndexPreparedSearchSnapshotCacheKey(base string, commitSeq, systemRoot uint64) string {
+	return fmt.Sprintf("%s|commit_seq=%d|system_root=%d", base, commitSeq, systemRoot)
+}
+
+func collectionVectorIndexPreparedQuantizedValidationStats(reader *columnVectorGraphPhysicalRowReader, routeStats vectorIndexSearchRouteStats, quantizedIndexName string, queryMode columnVectorGraphNativeSearchQueryMode) VectorIndexSearchStats {
+	var internal columnVectorGraphNativeSearchStats
+	if queryMode == columnVectorGraphNativeSearchQueryModeQuantizedOnly {
+		internal.SearchRouteQuantizedOnly = 1
+	} else if queryMode == columnVectorGraphNativeSearchQueryModeQuantizedRerank {
+		internal.SearchRouteQuantizedRerank = 1
+	}
+	if reader != nil {
+		reader.populateQuantizedAssetSearchStats(quantizedIndexName, &internal)
+	}
+	stats := vectorIndexSearchStatsFromInternal(internal, columnPhysicalRowReaderStats{})
+	routeStats.apply(&stats)
+	return stats
+}
+
+func collectionVectorIndexPreparedQuantizedSearchCacheKey(collection string, namespace string, def VectorIndexDefinition, graph columnVectorGraphManifestSnapshot, state columnVectorIndexStateSnapshot, quantizedIndexName string) (string, error) {
+	base, err := columnVectorGraphSharedPreparedSearchCacheKey(collection, namespace, def, graph, state)
+	if err != nil {
+		return "", err
+	}
+	qdef, ok := findQuantizedVectorIndex(def, quantizedIndexName)
+	if !ok {
+		return "", fmt.Errorf("%w: vector index %q quantized index %q is not declared", ErrVectorIndexSearchUnavailable, def.Name, quantizedIndexName)
+	}
+	asset, ok := columnVectorGraphQuantizedAssetByName(state, def)[quantizedIndexName]
+	if !ok {
+		return "", fmt.Errorf("%w: %w: vector index %q quantized index %q has no quantized score-plane asset", ErrVectorIndexSearchUnavailable, errColumnVectorGraphQuantizedAssetMissing, def.Name, quantizedIndexName)
+	}
+	return fmt.Sprintf("collection_buffered_quantized_v1|family=quantized|q=%s|codec=%s|version=%d|asset_id=%s|asset_schema=%d|asset_bytes=%d|asset_ref=%+v|%s", qdef.Name, qdef.Codec, qdef.Version, asset.AssetID, asset.SourceSchemaHash, asset.AssetBytes, columnVectorGraphQuantizedAssetRefIdentity(asset.Ref), base), nil
+}
+
 func (p *collectionVectorIndexPreparedSearch) readyForCurrentSearch() bool {
 	if p == nil {
 		return false
 	}
 	p.mu.RLock()
 	defer p.mu.RUnlock()
-	if p.closed || p.pack == nil {
+	if p.closed {
 		return false
 	}
-	status := p.pack.fastStatus(p.packStatus)
-	return status == columnHNSWSearchPackPreparedStatusDirect || status == columnHNSWSearchPackPreparedStatusHeap
+	switch p.family {
+	case collectionVectorIndexPreparedSearchFamilyQuantized:
+		return p.searcher != nil && !p.searcher.closed && p.searcher.reader != nil
+	default:
+		if p.pack == nil {
+			return false
+		}
+		status := p.pack.fastStatus(p.packStatus)
+		return status == columnHNSWSearchPackPreparedStatusDirect || status == columnHNSWSearchPackPreparedStatusHeap
+	}
 }
 
 func (p *collectionVectorIndexPreparedSearch) responseForSearch() VectorIndexSearchResponse {
@@ -396,6 +615,54 @@ func (p *collectionVectorIndexPreparedSearch) SearchWithBuffer(opts VectorIndexS
 	return response, nil
 }
 
+func (p *collectionVectorIndexPreparedSearch) SearchQuantizedWithBuffer(opts VectorIndexSearchOptions, buffer *VectorIndexSearchBuffer) (VectorIndexSearchResponse, error) {
+	if buffer == nil {
+		return VectorIndexSearchResponse{}, errors.New("collections: nil vector index search buffer")
+	}
+	previousResults := buffer.results
+	buffer.resetView()
+	if p == nil {
+		clear(previousResults)
+		return VectorIndexSearchResponse{}, errors.New("collections: nil collection vector index prepared quantized search")
+	}
+	response := p.responseForSearch()
+	queryMode, _ := normalizeVectorIndexSearchQueryMode(opts.QueryMode, opts.QuantizedIndexName, opts.QuantizedRerankCandidates, opts.TopK)
+	statsMode, statsModeErr := columnVectorGraphNativeSearchStatsModeFromPublic(opts.StatsMode)
+	if statsModeErr != nil {
+		clear(previousResults)
+		return response, statsModeErr
+	}
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	if p.closed || p.searcher == nil || p.searcher.closed || p.searcher.reader == nil {
+		clear(previousResults)
+		response.Stats = collectionVectorIndexPreparedQuantizedValidationStats(nil, p.routeStats, opts.QuantizedIndexName, queryMode)
+		response.Stats.QuantizedAssetUnavailable = 1
+		response.Stats.QuantizedAssetClosed = 1
+		return response, fmt.Errorf("%w: vector index %q collection buffered quantized prepared state is closed", ErrVectorIndexSearchUnavailable, p.indexName)
+	}
+	results, searchStats, err := p.searcher.reader.SearchCosine(opts.Query, columnVectorGraphNativeSearchOptions{
+		TopK:                      opts.TopK,
+		EfSearch:                  opts.EfSearch,
+		ScoreBatchMode:            opts.scoreBatchMode,
+		StatsMode:                 statsMode,
+		QueryMode:                 queryMode,
+		QuantizedIndexName:        opts.QuantizedIndexName,
+		QuantizedRerankCandidates: opts.QuantizedRerankCandidates,
+	}, &buffer.searchScratch)
+	response.Stats = vectorIndexSearchStatsFromInternal(searchStats, columnPhysicalRowReaderStats{})
+	p.routeStats.apply(&response.Stats)
+	if err != nil {
+		clear(previousResults)
+		return response, err
+	}
+	response.Results, err = copyVectorIndexSearchResultsToBuffer(results, buffer, previousResults)
+	if err != nil {
+		return response, err
+	}
+	return response, nil
+}
+
 func collectionVectorIndexPreparedSearchRouteStatsForUnavailable(cached vectorIndexSearchRouteStats, status columnHNSWSearchPackPreparedStatus) vectorIndexSearchRouteStats {
 	stats := cached
 	stats.SearchRouteHNSWSearchPack = 0
@@ -416,8 +683,12 @@ func (p *collectionVectorIndexPreparedSearch) Close() error {
 	p.closed = true
 	var err error
 	if p.pack != nil {
-		err = p.pack.Close()
+		err = errors.Join(err, p.pack.Close())
 		p.pack = nil
+	}
+	if p.searcher != nil {
+		err = errors.Join(err, p.searcher.Close())
+		p.searcher = nil
 	}
 	return err
 }
@@ -428,20 +699,35 @@ func (p *collectionVectorIndexPreparedSearch) stats() mappedresource.Stats {
 	}
 	p.mu.RLock()
 	defer p.mu.RUnlock()
-	if p.pack == nil || p.pack.manager == nil {
-		return mappedresource.Stats{}
+	var out mappedresource.Stats
+	add := func(stats mappedresource.Stats) {
+		out.ActiveHandles += stats.ActiveHandles
+		out.ActiveMappedBytes += stats.ActiveMappedBytes
+		out.ActiveHeapCopyBytes += stats.ActiveHeapCopyBytes
+		out.ActiveDerivedMetadataBytes += stats.ActiveDerivedMetadataBytes
 	}
-	return p.pack.manager.Stats()
+	if p.pack != nil && p.pack.manager != nil {
+		add(p.pack.manager.Stats())
+	}
+	if p.searcher != nil && p.searcher.reader != nil {
+		reader := p.searcher.reader
+		if reader.sharedPreparedSearch != nil && reader.sharedPreparedSearch.holder != nil {
+			add(reader.sharedPreparedSearch.holder.stats())
+		} else if reader.hnswSearchPack != nil && reader.hnswSearchPack.manager != nil {
+			add(reader.hnswSearchPack.manager.Stats())
+		}
+	}
+	return out
 }
 
-func (c *Collection) invalidateCollectionVectorIndexPreparedSearch(indexName string, prepared *collectionVectorIndexPreparedSearch) {
-	if c == nil || indexName == "" {
+func (c *Collection) invalidateCollectionVectorIndexPreparedSearch(slot collectionVectorIndexPreparedSearchCacheSlot, prepared *collectionVectorIndexPreparedSearch) {
+	if c == nil || slot.indexName == "" {
 		return
 	}
 	for {
 		var closePrepared *collectionVectorIndexPreparedSearch
 		c.vectorBufferedSearchMu.Lock()
-		entry := c.vectorBufferedSearch[indexName]
+		entry := c.vectorBufferedSearch[slot]
 		if entry != nil && entry.building {
 			ready := entry.ready
 			c.vectorBufferedSearchWaits++
@@ -450,7 +736,7 @@ func (c *Collection) invalidateCollectionVectorIndexPreparedSearch(indexName str
 			continue
 		}
 		if entry != nil && (prepared == nil || entry.prepared == prepared) {
-			delete(c.vectorBufferedSearch, indexName)
+			delete(c.vectorBufferedSearch, slot)
 			closePrepared = entry.prepared
 			c.vectorBufferedSearchInvalidations++
 		}

--- a/TreeDB/collections/collection_vector_index_prepared_search_cache.go
+++ b/TreeDB/collections/collection_vector_index_prepared_search_cache.go
@@ -47,6 +47,11 @@ type collectionVectorIndexPreparedSearch struct {
 	pack       *columnHNSWSearchPackPreparedView
 	packStatus columnHNSWSearchPackPreparedStatus
 	searcher   *VectorIndexSearcher
+
+	quantizedReadersMu        sync.Mutex
+	quantizedReaders          []*columnVectorGraphPhysicalRowReader
+	quantizedAvailableReaders []int
+
 	routeStats vectorIndexSearchRouteStats
 	closed     bool
 }
@@ -474,23 +479,23 @@ func (c *Collection) openCollectionVectorIndexPreparedQuantizedSearch(opts Vecto
 		status:     response.Status,
 		snapshot:   snap,
 		catalog:    reader.catalog,
-		reader:     reader,
-		readerLast: reader.Stats(),
 		routeStats: routeStats,
 	}
 	closeSnapOnErr = false
 	closeReaderOnErr = false
 	return &collectionVectorIndexPreparedSearch{
-		key:                key,
-		family:             collectionVectorIndexPreparedSearchFamilyQuantized,
-		indexName:          def.Name,
-		quantizedIndexName: opts.QuantizedIndexName,
-		dimensions:         def.Dimensions,
-		commitSeq:          snapshotCommitSeq(snap),
-		systemRoot:         snapshotSystemRoot(snap),
-		response:           response,
-		searcher:           searcher,
-		routeStats:         routeStats,
+		key:                       key,
+		family:                    collectionVectorIndexPreparedSearchFamilyQuantized,
+		indexName:                 def.Name,
+		quantizedIndexName:        opts.QuantizedIndexName,
+		dimensions:                def.Dimensions,
+		commitSeq:                 snapshotCommitSeq(snap),
+		systemRoot:                snapshotSystemRoot(snap),
+		response:                  response,
+		searcher:                  searcher,
+		quantizedReaders:          []*columnVectorGraphPhysicalRowReader{reader},
+		quantizedAvailableReaders: []int{0},
+		routeStats:                routeStats,
 	}, response, nil
 }
 
@@ -553,7 +558,13 @@ func (p *collectionVectorIndexPreparedSearch) readyForCurrentSearch() bool {
 	}
 	switch p.family {
 	case collectionVectorIndexPreparedSearchFamilyQuantized:
-		return p.searcher != nil && !p.searcher.closed && p.searcher.reader != nil
+		if p.searcher == nil || p.searcher.closed || p.searcher.snapshot == nil {
+			return false
+		}
+		p.quantizedReadersMu.Lock()
+		ready := len(p.quantizedReaders) > 0
+		p.quantizedReadersMu.Unlock()
+		return ready
 	default:
 		if p.pack == nil {
 			return false
@@ -673,29 +684,43 @@ func (p *collectionVectorIndexPreparedSearch) SearchQuantizedWithBuffer(opts Vec
 		clear(previousResults)
 		return response, statsModeErr
 	}
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	if p.closed || p.searcher == nil || p.searcher.closed || p.searcher.reader == nil {
+	p.mu.RLock()
+	if p.closed || p.searcher == nil || p.searcher.closed || p.searcher.snapshot == nil {
+		p.mu.RUnlock()
 		clear(previousResults)
 		response.Stats = collectionVectorIndexPreparedQuantizedValidationStats(nil, p.routeStats, opts.QuantizedIndexName, queryMode)
 		response.Stats.QuantizedAssetUnavailable = 1
 		response.Stats.QuantizedAssetClosed = 1
 		return response, fmt.Errorf("%w: vector index %q collection buffered quantized prepared state is closed", ErrVectorIndexSearchUnavailable, p.indexName)
 	}
-	if opts.TopK == 0 || p.searcher.reader.RowCount() == 0 {
-		response.Stats = collectionVectorIndexPreparedQuantizedValidationStats(p.searcher.reader, p.routeStats, opts.QuantizedIndexName, queryMode)
+	reader, readerIndex, checkoutStats, checkoutErr := p.checkoutCollectionVectorIndexPreparedQuantizedReader(opts, queryMode)
+	if checkoutErr != nil {
+		p.mu.RUnlock()
+		clear(previousResults)
+		response.Stats = checkoutStats
+		if response.Stats.SearchRouteQuantizedOnly == 0 && response.Stats.SearchRouteQuantizedRerank == 0 {
+			response.Stats = collectionVectorIndexPreparedQuantizedValidationStats(nil, p.routeStats, opts.QuantizedIndexName, queryMode)
+		}
+		return response, checkoutErr
+	}
+	defer func() {
+		p.returnCollectionVectorIndexPreparedQuantizedReader(readerIndex)
+		p.mu.RUnlock()
+	}()
+	if opts.TopK == 0 || reader.RowCount() == 0 {
+		response.Stats = collectionVectorIndexPreparedQuantizedValidationStats(reader, p.routeStats, opts.QuantizedIndexName, queryMode)
 		if len(opts.Query) != p.dimensions {
 			clear(previousResults)
 			return response, fmt.Errorf("collections: column_graph %q query dims=%d want %d: %w", p.indexName, len(opts.Query), p.dimensions, errColumnVectorGraphNativeSearchQueryDimensionMismatch)
 		}
-		if err := p.searcher.reader.validateQuantizedNativeSearchOptions(queryMode, columnVectorGraphNativeSearchOptions{TopK: opts.TopK, QuantizedIndexName: opts.QuantizedIndexName, QuantizedRerankCandidates: opts.QuantizedRerankCandidates}); err != nil {
+		if err := reader.validateQuantizedNativeSearchOptions(queryMode, columnVectorGraphNativeSearchOptions{TopK: opts.TopK, QuantizedIndexName: opts.QuantizedIndexName, QuantizedRerankCandidates: opts.QuantizedRerankCandidates}); err != nil {
 			clear(previousResults)
 			return response, err
 		}
 		clear(previousResults)
 		return response, nil
 	}
-	results, searchStats, err := p.searcher.reader.SearchCosine(opts.Query, columnVectorGraphNativeSearchOptions{
+	results, searchStats, err := reader.SearchCosine(opts.Query, columnVectorGraphNativeSearchOptions{
 		TopK:                      opts.TopK,
 		EfSearch:                  opts.EfSearch,
 		ScoreBatchMode:            opts.scoreBatchMode,
@@ -715,6 +740,62 @@ func (p *collectionVectorIndexPreparedSearch) SearchQuantizedWithBuffer(opts Vec
 		return response, err
 	}
 	return response, nil
+}
+
+func (p *collectionVectorIndexPreparedSearch) checkoutCollectionVectorIndexPreparedQuantizedReader(opts VectorIndexSearchOptions, queryMode columnVectorGraphNativeSearchQueryMode) (*columnVectorGraphPhysicalRowReader, int, VectorIndexSearchStats, error) {
+	p.quantizedReadersMu.Lock()
+	if n := len(p.quantizedAvailableReaders); n > 0 {
+		idx := p.quantizedAvailableReaders[n-1]
+		p.quantizedAvailableReaders = p.quantizedAvailableReaders[:n-1]
+		if idx >= 0 && idx < len(p.quantizedReaders) && p.quantizedReaders[idx] != nil {
+			reader := p.quantizedReaders[idx]
+			p.quantizedReadersMu.Unlock()
+			return reader, idx, VectorIndexSearchStats{}, nil
+		}
+	}
+	p.quantizedReadersMu.Unlock()
+
+	reader, stats, err := p.openCollectionVectorIndexPreparedQuantizedReader(opts, queryMode)
+	if err != nil {
+		return nil, -1, stats, err
+	}
+	p.quantizedReadersMu.Lock()
+	idx := len(p.quantizedReaders)
+	p.quantizedReaders = append(p.quantizedReaders, reader)
+	p.quantizedReadersMu.Unlock()
+	return reader, idx, VectorIndexSearchStats{}, nil
+}
+
+func (p *collectionVectorIndexPreparedSearch) returnCollectionVectorIndexPreparedQuantizedReader(idx int) {
+	if idx < 0 {
+		return
+	}
+	p.quantizedReadersMu.Lock()
+	if idx < len(p.quantizedReaders) && p.quantizedReaders[idx] != nil {
+		p.quantizedAvailableReaders = append(p.quantizedAvailableReaders, idx)
+	}
+	p.quantizedReadersMu.Unlock()
+}
+
+func (p *collectionVectorIndexPreparedSearch) openCollectionVectorIndexPreparedQuantizedReader(opts VectorIndexSearchOptions, queryMode columnVectorGraphNativeSearchQueryMode) (*columnVectorGraphPhysicalRowReader, VectorIndexSearchStats, error) {
+	if p == nil || p.searcher == nil || p.searcher.collection == nil || p.searcher.snapshot == nil {
+		return nil, collectionVectorIndexPreparedQuantizedValidationStats(nil, vectorIndexSearchRouteStats{}, opts.QuantizedIndexName, queryMode), backenddb.ErrClosed
+	}
+	reader, err := p.searcher.collection.openColumnVectorGraphPhysicalRowReaderAtSnapshot(p.indexName, p.searcher.snapshot, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: opts.MaxDecodedBlocks})
+	if err != nil {
+		return nil, collectionVectorIndexPreparedQuantizedValidationStats(nil, p.routeStats, opts.QuantizedIndexName, queryMode), err
+	}
+	if !collectionVectorIndexPreparedQuantizedReaderReady(reader) {
+		stats := collectionVectorIndexPreparedQuantizedValidationStats(reader, p.routeStats, opts.QuantizedIndexName, queryMode)
+		_ = reader.Close()
+		return nil, stats, fmt.Errorf("%w: vector index %q SearchVectorIndexWithBuffer quantized mode requires healthy prepared column_graph state; rebuild the vector index before using the collection buffered quantized route", ErrVectorIndexSearchUnavailable, p.indexName)
+	}
+	if err := reader.validateQuantizedNativeSearchOptions(queryMode, columnVectorGraphNativeSearchOptions{TopK: opts.TopK, QuantizedIndexName: opts.QuantizedIndexName, QuantizedRerankCandidates: opts.QuantizedRerankCandidates}); err != nil {
+		stats := collectionVectorIndexPreparedQuantizedValidationStats(reader, p.routeStats, opts.QuantizedIndexName, queryMode)
+		_ = reader.Close()
+		return nil, stats, err
+	}
+	return reader, VectorIndexSearchStats{}, nil
 }
 
 func collectionVectorIndexPreparedSearchRouteStatsForUnavailable(cached vectorIndexSearchRouteStats, status columnHNSWSearchPackPreparedStatus) vectorIndexSearchRouteStats {
@@ -740,6 +821,16 @@ func (p *collectionVectorIndexPreparedSearch) Close() error {
 		err = errors.Join(err, p.pack.Close())
 		p.pack = nil
 	}
+	p.quantizedReadersMu.Lock()
+	for i, reader := range p.quantizedReaders {
+		if reader != nil {
+			err = errors.Join(err, reader.Close())
+			p.quantizedReaders[i] = nil
+		}
+	}
+	p.quantizedReaders = nil
+	p.quantizedAvailableReaders = nil
+	p.quantizedReadersMu.Unlock()
 	if p.searcher != nil {
 		err = errors.Join(err, p.searcher.Close())
 		p.searcher = nil
@@ -771,7 +862,38 @@ func (p *collectionVectorIndexPreparedSearch) stats() mappedresource.Stats {
 			add(reader.hnswSearchPack.manager.Stats())
 		}
 	}
+	p.quantizedReadersMu.Lock()
+	seenSharedPrepared := make(map[*columnVectorGraphSharedPreparedSearch]struct{})
+	for _, reader := range p.quantizedReaders {
+		addCollectionVectorIndexPreparedQuantizedAssetStats(&out, reader, p.quantizedIndexName)
+		if reader == nil {
+			continue
+		}
+		if reader.sharedPreparedSearch != nil && reader.sharedPreparedSearch.holder != nil {
+			holder := reader.sharedPreparedSearch.holder
+			if _, ok := seenSharedPrepared[holder]; !ok {
+				seenSharedPrepared[holder] = struct{}{}
+				add(holder.stats())
+			}
+		} else if reader.hnswSearchPack != nil && reader.hnswSearchPack.manager != nil {
+			add(reader.hnswSearchPack.manager.Stats())
+		}
+	}
+	p.quantizedReadersMu.Unlock()
 	return out
+}
+
+func addCollectionVectorIndexPreparedQuantizedAssetStats(out *mappedresource.Stats, reader *columnVectorGraphPhysicalRowReader, quantizedIndexName string) {
+	if out == nil || reader == nil || quantizedIndexName == "" {
+		return
+	}
+	status, ok := reader.quantizedAssetStatus[quantizedIndexName]
+	if !ok {
+		return
+	}
+	out.ActiveHandles += status.ActiveHandles
+	out.ActiveMappedBytes += int64(status.MappedBytes)
+	out.ActiveHeapCopyBytes += int64(status.HeapCopyBytes)
 }
 
 func (c *Collection) invalidateCollectionVectorIndexPreparedSearch(slot collectionVectorIndexPreparedSearchCacheSlot, prepared *collectionVectorIndexPreparedSearch) {

--- a/TreeDB/collections/collection_vector_index_prepared_search_cache.go
+++ b/TreeDB/collections/collection_vector_index_prepared_search_cache.go
@@ -632,14 +632,27 @@ func (p *collectionVectorIndexPreparedSearch) SearchQuantizedWithBuffer(opts Vec
 		clear(previousResults)
 		return response, statsModeErr
 	}
-	p.mu.RLock()
-	defer p.mu.RUnlock()
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	if p.closed || p.searcher == nil || p.searcher.closed || p.searcher.reader == nil {
 		clear(previousResults)
 		response.Stats = collectionVectorIndexPreparedQuantizedValidationStats(nil, p.routeStats, opts.QuantizedIndexName, queryMode)
 		response.Stats.QuantizedAssetUnavailable = 1
 		response.Stats.QuantizedAssetClosed = 1
 		return response, fmt.Errorf("%w: vector index %q collection buffered quantized prepared state is closed", ErrVectorIndexSearchUnavailable, p.indexName)
+	}
+	if opts.TopK == 0 || p.searcher.reader.RowCount() == 0 {
+		response.Stats = collectionVectorIndexPreparedQuantizedValidationStats(p.searcher.reader, p.routeStats, opts.QuantizedIndexName, queryMode)
+		if len(opts.Query) != p.dimensions {
+			clear(previousResults)
+			return response, fmt.Errorf("collections: column_graph %q query dims=%d want %d: %w", p.indexName, len(opts.Query), p.dimensions, errColumnVectorGraphNativeSearchQueryDimensionMismatch)
+		}
+		if err := p.searcher.reader.validateQuantizedNativeSearchOptions(queryMode, columnVectorGraphNativeSearchOptions{TopK: opts.TopK, QuantizedIndexName: opts.QuantizedIndexName, QuantizedRerankCandidates: opts.QuantizedRerankCandidates}); err != nil {
+			clear(previousResults)
+			return response, err
+		}
+		clear(previousResults)
+		return response, nil
 	}
 	results, searchStats, err := p.searcher.reader.SearchCosine(opts.Query, columnVectorGraphNativeSearchOptions{
 		TopK:                      opts.TopK,

--- a/TreeDB/collections/collection_vector_index_prepared_search_cache.go
+++ b/TreeDB/collections/collection_vector_index_prepared_search_cache.go
@@ -447,8 +447,13 @@ func (c *Collection) openCollectionVectorIndexPreparedQuantizedSearch(opts Vecto
 		}
 	}()
 
+	preparedReady := collectionVectorIndexPreparedQuantizedReaderReady(reader)
 	routeStats := vectorIndexSearchRouteStatsForColumnGraphQuantized(vectorIndexSearchRouteStatsForColumnGraphReader(reader))
-	if reader.preparedSearch == nil || !reader.preparedSearch.ready() || routeStats.SearchRouteColumnGraphPrepared != 1 || routeStats.SearchRouteColumnGraphFallback != 0 {
+	if preparedReady && reader.RowCount() == 0 {
+		routeStats.SearchRouteColumnGraphPrepared = 1
+		routeStats.SearchRouteColumnGraphFallback = 0
+	}
+	if !preparedReady || routeStats.SearchRouteColumnGraphPrepared != 1 || routeStats.SearchRouteColumnGraphFallback != 0 {
 		response.Stats = collectionVectorIndexPreparedQuantizedValidationStats(reader, routeStats, opts.QuantizedIndexName, queryMode)
 		return nil, response, fmt.Errorf("%w: vector index %q SearchVectorIndexWithBuffer quantized mode requires healthy prepared column_graph state; rebuild the vector index before using the collection buffered quantized route", ErrVectorIndexSearchUnavailable, def.Name)
 	}
@@ -487,6 +492,19 @@ func (c *Collection) openCollectionVectorIndexPreparedQuantizedSearch(opts Vecto
 		searcher:           searcher,
 		routeStats:         routeStats,
 	}, response, nil
+}
+
+func collectionVectorIndexPreparedQuantizedReaderReady(reader *columnVectorGraphPhysicalRowReader) bool {
+	if reader == nil || reader.def.Dimensions <= 0 {
+		return false
+	}
+	if reader.RowCount() == 0 {
+		return true
+	}
+	if reader.preparedSearch == nil {
+		return false
+	}
+	return reader.preparedSearch.ready()
 }
 
 func collectionVectorIndexPreparedSearchSnapshotCacheKey(base string, commitSeq, systemRoot uint64) string {

--- a/TreeDB/collections/column_vector_graph_quantized_bench_test.go
+++ b/TreeDB/collections/column_vector_graph_quantized_bench_test.go
@@ -45,6 +45,22 @@ func columnGraphScalarU8QuantizedSearchWithBufferBenchCases2414() []columnGraphS
 	}
 }
 
+type columnGraphScalarU8QuantizedCollectionWithBufferBenchCase2415 struct {
+	name             string
+	mode             VectorIndexQueryMode
+	rerankCandidates int
+	concurrency      int
+}
+
+func columnGraphScalarU8QuantizedCollectionWithBufferBenchCases2415() []columnGraphScalarU8QuantizedCollectionWithBufferBenchCase2415 {
+	return []columnGraphScalarU8QuantizedCollectionWithBufferBenchCase2415{
+		{name: "route=quantized_only/c=1", mode: VectorIndexQueryModeQuantizedOnly, concurrency: 1},
+		{name: "route=quantized_only/c=8", mode: VectorIndexQueryModeQuantizedOnly, concurrency: 8},
+		{name: "route=quantized_rerank/candidates=32/c=1", mode: VectorIndexQueryModeQuantizedRerank, rerankCandidates: 32, concurrency: 1},
+		{name: "route=quantized_rerank/candidates=32/c=8", mode: VectorIndexQueryModeQuantizedRerank, rerankCandidates: 32, concurrency: 8},
+	}
+}
+
 func BenchmarkColumnGraphScalarU8QuantizedScorePlanes1926(b *testing.B) {
 	shape := columnGraphScalarU8QuantizedBenchShape1926{rows: 1024, dims: 128, m: 16, topK: 10, efSearch: 128, queryOrdinal: 37}
 	fixture := openColumnGraphScalarU8QuantizedBenchFixture1926(b, shape, true)
@@ -130,6 +146,198 @@ func BenchmarkVectorIndexSearcherColumnGraphScalarU8QuantizedSearchWithBuffer241
 			}
 			runColumnGraphScalarU8QuantizedSearchWithBufferBench2414(b, fixture, opts, tc.concurrency, exactIDs, exactCount)
 		})
+	}
+}
+
+func BenchmarkCollectionSearchVectorIndexWithBufferColumnGraphScalarU8Quantized2415(b *testing.B) {
+	shape := columnGraphScalarU8QuantizedBenchShape1926{rows: 1024, dims: 128, m: 16, topK: 10, efSearch: 128, queryOrdinal: 37}
+	fixture := openColumnGraphScalarU8QuantizedBenchFixture1926(b, shape, true)
+	defer fixture.close()
+	exactIDs, exactCount := columnGraphScalarU8QuantizedBenchmarkExactIDs1926(b, fixture)
+
+	for _, tc := range columnGraphScalarU8QuantizedCollectionWithBufferBenchCases2415() {
+		tc := tc
+		b.Run(tc.name, func(b *testing.B) {
+			opts := VectorIndexSearchOptions{
+				IndexName:                 fixture.definition.Name,
+				Query:                     fixture.query,
+				QueryMode:                 tc.mode,
+				QuantizedIndexName:        columnGraphScalarU8QuantizedBenchIndexName1926,
+				QuantizedRerankCandidates: tc.rerankCandidates,
+				TopK:                      fixture.shape.topK,
+				EfSearch:                  fixture.shape.efSearch,
+				MaxDecodedBlocks:          1,
+				StatsMode:                 VectorIndexSearchStatsModeProduction,
+			}
+			runColumnGraphScalarU8QuantizedCollectionWithBufferBench2415(b, fixture, opts, tc.concurrency, exactIDs, exactCount)
+		})
+	}
+}
+
+func runColumnGraphScalarU8QuantizedCollectionWithBufferBench2415(b *testing.B, fixture columnGraphScalarU8QuantizedBenchFixture1926, opts VectorIndexSearchOptions, concurrency int, exactIDs map[string]struct{}, exactCount int) {
+	b.Helper()
+	if concurrency <= 0 {
+		b.Fatalf("concurrency=%d must be positive", concurrency)
+	}
+	type benchWorker struct {
+		buffer VectorIndexSearchBuffer
+		stats  VectorIndexSearchStats
+		sink   int64
+	}
+	if err := fixture.collection.closeCollectionVectorIndexPreparedSearchCache(); err != nil {
+		b.Fatalf("close collection prepared cache before benchmark row: %v", err)
+	}
+	workers := make([]benchWorker, concurrency)
+	for i := range workers {
+		warmOpts := opts
+		warmOpts.Query = fixture.query
+		warm, err := fixture.collection.SearchVectorIndexWithBuffer(warmOpts, &workers[i].buffer)
+		if err != nil {
+			b.Fatalf("warm SearchVectorIndexWithBuffer worker %d: %v", i, err)
+		}
+		if len(warm.Results) == 0 {
+			b.Fatalf("warm SearchVectorIndexWithBuffer worker %d returned no results", i)
+		}
+		assertColumnGraphScalarU8QuantizedCollectionWithBufferGuardrails2415(b, warm.Stats, opts, fixture.definition.Dimensions)
+	}
+	statsOpts := opts
+	statsOpts.StatsMode = VectorIndexSearchStatsModeFullDiagnostics
+	measured, err := fixture.collection.SearchVectorIndexWithBuffer(statsOpts, &workers[0].buffer)
+	if err != nil {
+		b.Fatalf("measure SearchVectorIndexWithBuffer stats: %v", err)
+	}
+	assertColumnGraphScalarU8QuantizedCollectionWithBufferGuardrails2415(b, measured.Stats, statsOpts, fixture.definition.Dimensions)
+	warmRecall := columnGraphScalarU8QuantizedBenchmarkRecallAtK1926(measured.Results, exactIDs, exactCount)
+
+	var next atomic.Uint64
+	var sink atomic.Int64
+	var failed atomic.Bool
+	var firstErr atomic.Value
+	recordErr := func(format string, args ...any) {
+		if failed.CompareAndSwap(false, true) {
+			firstErr.Store(fmt.Sprintf(format, args...))
+		}
+	}
+	var wg sync.WaitGroup
+	ready := make(chan struct{}, len(workers))
+	start := make(chan struct{})
+	wg.Add(len(workers))
+	for i := range workers {
+		worker := &workers[i]
+		go func() {
+			defer wg.Done()
+			localOpts := opts
+			localOpts.Query = fixture.query
+			for warmIter := 0; warmIter < 16; warmIter++ {
+				if warm, err := fixture.collection.SearchVectorIndexWithBuffer(localOpts, &worker.buffer); err != nil {
+					recordErr("goroutine warm SearchVectorIndexWithBuffer: %v", err)
+					break
+				} else if len(warm.Results) == 0 {
+					recordErr("goroutine warm SearchVectorIndexWithBuffer returned no results")
+					break
+				}
+			}
+			ready <- struct{}{}
+			<-start
+			var localStats VectorIndexSearchStats
+			var localSink int64
+			for {
+				iteration := int(next.Add(1)) - 1
+				if iteration >= b.N {
+					break
+				}
+				if failed.Load() {
+					continue
+				}
+				response, err := fixture.collection.SearchVectorIndexWithBuffer(localOpts, &worker.buffer)
+				if err != nil {
+					recordErr("SearchVectorIndexWithBuffer: %v", err)
+					continue
+				}
+				if len(response.Results) == 0 {
+					recordErr("SearchVectorIndexWithBuffer returned no results")
+					continue
+				}
+				localSink += int64(response.Results[0].Ordinal)
+				addColumnGraphScalarU8QuantizedBenchmarkStats1926(&localStats, response.Stats)
+			}
+			worker.stats = localStats
+			worker.sink = localSink
+		}()
+	}
+	for range workers {
+		<-ready
+	}
+	if errValue := firstErr.Load(); errValue != nil {
+		close(start)
+		wg.Wait()
+		b.Fatalf("%s", errValue.(string))
+	}
+	cacheBeforeTimed := fixture.collection.collectionVectorIndexPreparedSearchCacheSnapshot()
+	b.ReportAllocs()
+	b.ReportMetric(float64(concurrency), "concurrency")
+	b.ReportMetric(1, "collection_searchvectorindex_with_buffer_seam")
+	b.ReportMetric(1, "collection_buffered_quantized_row")
+	b.ReportMetric(0, "open_searcher_calls/op")
+	b.ReportMetric(0, "open_setup_in_timed_loop")
+	b.ReportMetric(1, "reported_stats_mode_production")
+	b.ResetTimer()
+	close(start)
+	wg.Wait()
+	b.StopTimer()
+	if errValue := firstErr.Load(); errValue != nil {
+		b.Fatalf("%s", errValue.(string))
+	}
+	var stats VectorIndexSearchStats
+	for i := range workers {
+		addColumnGraphScalarU8QuantizedBenchmarkStats1926(&stats, workers[i].stats)
+		sink.Add(workers[i].sink)
+	}
+	columnPhysicalScanBenchSum += sink.Load()
+	recallSum := warmRecall * float64(b.N)
+	reportCollectionVectorIndexPreparedSearchBenchMetrics2415(b, cacheBeforeTimed, fixture.collection.collectionVectorIndexPreparedSearchCacheSnapshot())
+	reportColumnGraphScalarU8QuantizedScorePlaneMetrics1926(b, fixture, stats, recallSum)
+}
+
+func reportCollectionVectorIndexPreparedSearchBenchMetrics2415(b *testing.B, before, after collectionVectorIndexPreparedSearchCacheSnapshot) {
+	b.Helper()
+	iterations := float64(b.N)
+	if iterations <= 0 {
+		iterations = 1
+	}
+	cacheBuilds := after.CacheBuilds - before.CacheBuilds
+	cacheMisses := after.CacheMisses - before.CacheMisses
+	cacheHits := after.CacheHits - before.CacheHits
+	cacheWaits := after.CacheWaits - before.CacheWaits
+	invalidations := after.Invalidations - before.Invalidations
+	closes := after.Closes - before.Closes
+	errors := after.Errors - before.Errors
+	b.ReportMetric(float64(after.Entries), "collection_prepared_cache_entries")
+	b.ReportMetric(float64(after.BuildingEntries), "collection_prepared_cache_building_entries")
+	b.ReportMetric(float64(cacheBuilds)/iterations, "collection_prepared_cache_builds/op")
+	b.ReportMetric(float64(cacheMisses)/iterations, "collection_prepared_cache_misses/op")
+	b.ReportMetric(float64(cacheHits)/iterations, "collection_prepared_cache_hits/op")
+	b.ReportMetric(float64(cacheWaits)/iterations, "collection_prepared_cache_waits/op")
+	b.ReportMetric(float64(invalidations)/iterations, "collection_prepared_cache_invalidations/op")
+	b.ReportMetric(float64(closes)/iterations, "collection_prepared_cache_closes/op")
+	b.ReportMetric(float64(errors)/iterations, "collection_prepared_cache_errors/op")
+	if lookups := cacheHits + cacheMisses; lookups > 0 {
+		b.ReportMetric(float64(cacheHits)/float64(lookups), "collection_prepared_cache_hit_ratio")
+	}
+	b.ReportMetric(float64(after.ActiveHandles), "collection_prepared_active_handles")
+	b.ReportMetric(float64(after.ActiveMappedBytes), "collection_prepared_mapped_B")
+	b.ReportMetric(float64(after.ActiveHeapCopyBytes), "collection_prepared_heap_copy_B")
+	b.ReportMetric(float64(after.ActiveDerivedMetadataBytes), "collection_prepared_derived_metadata_B")
+}
+
+func assertColumnGraphScalarU8QuantizedCollectionWithBufferGuardrails2415(tb testing.TB, stats VectorIndexSearchStats, opts VectorIndexSearchOptions, dims int) {
+	tb.Helper()
+	queryMode, err := normalizeVectorIndexSearchQueryMode(opts.QueryMode, opts.QuantizedIndexName, opts.QuantizedRerankCandidates, opts.TopK)
+	if err != nil {
+		tb.Fatalf("normalize query mode: %v", err)
+	}
+	if !vectorIndexSearchStatsAreBufferedNoDocumentQuantizedRoute(stats, queryMode, opts, dims) {
+		tb.Fatalf("Collection.SearchVectorIndexWithBuffer quantized stats=%+v want no-document quantized route", stats)
 	}
 }
 

--- a/TreeDB/collections/column_vector_graph_quantized_bench_test.go
+++ b/TreeDB/collections/column_vector_graph_quantized_bench_test.go
@@ -207,6 +207,7 @@ func runColumnGraphScalarU8QuantizedCollectionWithBufferBench2415(b *testing.B, 
 		b.Fatalf("measure SearchVectorIndexWithBuffer stats: %v", err)
 	}
 	assertColumnGraphScalarU8QuantizedCollectionWithBufferGuardrails2415(b, measured.Stats, statsOpts, fixture.definition.Dimensions)
+	ensureColumnGraphScalarU8QuantizedCollectionReaderPool2415(b, fixture.collection, opts, concurrency)
 	warmRecall := columnGraphScalarU8QuantizedBenchmarkRecallAtK1926(measured.Results, exactIDs, exactCount)
 
 	var next atomic.Uint64
@@ -297,6 +298,40 @@ func runColumnGraphScalarU8QuantizedCollectionWithBufferBench2415(b *testing.B, 
 	recallSum := warmRecall * float64(b.N)
 	reportCollectionVectorIndexPreparedSearchBenchMetrics2415(b, cacheBeforeTimed, fixture.collection.collectionVectorIndexPreparedSearchCacheSnapshot())
 	reportColumnGraphScalarU8QuantizedScorePlaneMetrics1926(b, fixture, stats, recallSum)
+}
+
+func ensureColumnGraphScalarU8QuantizedCollectionReaderPool2415(b *testing.B, col *Collection, opts VectorIndexSearchOptions, concurrency int) {
+	b.Helper()
+	queryMode, err := normalizeVectorIndexSearchQueryMode(opts.QueryMode, opts.QuantizedIndexName, opts.QuantizedRerankCandidates, opts.TopK)
+	if err != nil {
+		b.Fatalf("normalize collection quantized benchmark query mode: %v", err)
+	}
+	prepared, _, _, err := col.acquireCollectionVectorIndexPreparedSearch(opts)
+	if err != nil {
+		b.Fatalf("acquire collection quantized prepared search for reader-pool warmup: %v", err)
+	}
+	prepared.mu.RLock()
+	defer prepared.mu.RUnlock()
+	if prepared.closed || prepared.searcher == nil || prepared.searcher.closed || prepared.searcher.snapshot == nil {
+		b.Fatalf("collection quantized prepared search is not ready for reader-pool warmup")
+	}
+	for {
+		prepared.quantizedReadersMu.Lock()
+		have := len(prepared.quantizedReaders)
+		prepared.quantizedReadersMu.Unlock()
+		if have >= concurrency {
+			return
+		}
+		reader, _, err := prepared.openCollectionVectorIndexPreparedQuantizedReader(opts, queryMode)
+		if err != nil {
+			b.Fatalf("open collection quantized prepared reader %d/%d: %v", have+1, concurrency, err)
+		}
+		prepared.quantizedReadersMu.Lock()
+		idx := len(prepared.quantizedReaders)
+		prepared.quantizedReaders = append(prepared.quantizedReaders, reader)
+		prepared.quantizedAvailableReaders = append(prepared.quantizedAvailableReaders, idx)
+		prepared.quantizedReadersMu.Unlock()
+	}
 }
 
 func reportCollectionVectorIndexPreparedSearchBenchMetrics2415(b *testing.B, before, after collectionVectorIndexPreparedSearchCacheSnapshot) {

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -350,7 +350,7 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/column_hnsw_search_pack_reader.go", classification: typedStorageLegacyDerived, matchingLines: 2, occurrences: 2},
 	{path: "TreeDB/collections/column_hnsw_search_pack_test.go", classification: typedStorageLegacyDerived, matchingLines: 1, occurrences: 2},
 	{path: "TreeDB/collections/column_hnsw_search_pack_writer.go", classification: typedStorageLegacyDerived, matchingLines: 3, occurrences: 3},
-	{path: "TreeDB/collections/collection_vector_index_prepared_search_cache.go", classification: typedStorageLegacyDerived, matchingLines: 3, occurrences: 3},
+	{path: "TreeDB/collections/collection_vector_index_prepared_search_cache.go", classification: typedStorageLegacyDerived, matchingLines: 5, occurrences: 5},
 	{path: "TreeDB/collections/column_int64_query.go", classification: typedStorageLegacyDerived, matchingLines: 2, occurrences: 2},
 	{path: "TreeDB/collections/column_int64_values_asset.go", classification: typedStorageLegacyDerived, matchingLines: 8, occurrences: 8},
 	{path: "TreeDB/collections/column_manifest_format.go", classification: typedStorageLegacyCompatibility, matchingLines: 2, occurrences: 2},

--- a/TreeDB/collections/vector_index_search.go
+++ b/TreeDB/collections/vector_index_search.go
@@ -1069,6 +1069,7 @@ func (c *Collection) searchVectorIndexPreparedNoDocumentOwned(opts VectorIndexSe
 			return response, err
 		}
 		lastResponse, lastErr = response, err
+		lastResponse.Results = nil
 		c.invalidateCollectionVectorIndexPreparedSearch(slot, prepared)
 	}
 	releaseCollectionSearchVectorIndexResponseBuffer(buffer)
@@ -1239,6 +1240,7 @@ func (c *Collection) SearchVectorIndexWithBuffer(opts VectorIndexSearchOptions, 
 			return response, err
 		}
 		lastResponse, lastErr = response, err
+		lastResponse.Results = nil
 		resetBufferedVectorIndexSearchResponse(&response, buffer)
 		c.invalidateCollectionVectorIndexPreparedSearch(slot, prepared)
 	}

--- a/TreeDB/collections/vector_index_search.go
+++ b/TreeDB/collections/vector_index_search.go
@@ -1144,7 +1144,11 @@ func vectorIndexSearchStatsAreBufferedNoDocumentQuantizedRoute(stats VectorIndex
 	if stats.SearchRouteColumnGraphPrepared != 1 || stats.SearchRouteColumnGraphFallback != 0 {
 		return false
 	}
-	if stats.QuantizedScorerActive != 1 || stats.QuantizedAssetUnavailable != 0 || stats.QuantizedAssetMissing != 0 || stats.QuantizedAssetInvalid != 0 || stats.QuantizedAssetStale != 0 || stats.QuantizedAssetClosed != 0 {
+	emptySearch := opts.TopK == 0 || stats.CandidateRows == 0
+	if !emptySearch && stats.QuantizedScorerActive != 1 {
+		return false
+	}
+	if stats.QuantizedAssetUnavailable != 0 || stats.QuantizedAssetMissing != 0 || stats.QuantizedAssetInvalid != 0 || stats.QuantizedAssetStale != 0 || stats.QuantizedAssetClosed != 0 {
 		return false
 	}
 	if stats.QuantizedAssetHeapCopy+stats.QuantizedAssetMmapDirect != 1 || stats.QuantizedAssetHeapCopyBytes+stats.QuantizedAssetMappedBytes == 0 {
@@ -1153,7 +1157,6 @@ func vectorIndexSearchStatsAreBufferedNoDocumentQuantizedRoute(stats VectorIndex
 	if stats.DocumentsFetched != 0 || stats.DocumentBytes != 0 || stats.DocumentOutputBytes != 0 || stats.GraphRowFallbacks != 0 || stats.TypedColumnFallbacks != 0 || stats.VectorScratchDecodes != 0 {
 		return false
 	}
-	emptySearch := opts.TopK == 0 || stats.CandidateRows == 0
 	if !emptySearch && (stats.QuantizedScoreCalls == 0 || stats.QuantizedCodeBytesRead == 0) {
 		return false
 	}

--- a/TreeDB/collections/vector_index_search.go
+++ b/TreeDB/collections/vector_index_search.go
@@ -838,6 +838,7 @@ func (c *Collection) searchVectorIndexPreparedNoDocumentOwned(opts VectorIndexSe
 	if queryMode != columnVectorGraphNativeSearchQueryModeExact || !columnHNSWSearchPackStatsModeSupportedForSearch(statsMode) {
 		return response, fmt.Errorf("%w: vector index %q SearchVectorIndex requires exact no-document hnsw_search_pack_v1 route", ErrVectorIndexSearchUnavailable, opts.IndexName)
 	}
+	slot := collectionVectorIndexPreparedSearchCacheSlotForOptions(opts, queryMode)
 	buffer := acquireCollectionSearchVectorIndexResponseBuffer()
 	var lastResponse VectorIndexSearchResponse
 	var lastErr error
@@ -858,7 +859,7 @@ func (c *Collection) searchVectorIndexPreparedNoDocumentOwned(opts VectorIndexSe
 			return response, err
 		}
 		lastResponse, lastErr = response, err
-		c.invalidateCollectionVectorIndexPreparedSearch(opts.IndexName, prepared)
+		c.invalidateCollectionVectorIndexPreparedSearch(slot, prepared)
 	}
 	releaseCollectionSearchVectorIndexResponseBuffer(buffer)
 	if lastErr != nil {
@@ -923,19 +924,22 @@ func (c *Collection) searchVectorIndexOneShot(opts VectorIndexSearchOptions) (Ve
 	return response, err
 }
 
-// SearchVectorIndexWithBuffer searches a collection vector index through the
-// exact no-document high-QPS seam using caller-owned result storage. Returned
-// Results and result IDs alias buffer and remain valid only until buffer is
-// reused or Reset is called. The same buffer must not be reused concurrently;
-// parallel callers should use independent buffers.
+// SearchVectorIndexWithBuffer searches a collection vector index through a
+// no-document high-QPS seam using caller-owned result storage. Returned Results
+// and result IDs alias buffer and remain valid only until buffer is reused or
+// Reset is called. The same buffer must not be reused concurrently; parallel
+// callers should use independent buffers.
 //
-// This method intentionally fails closed for document materialization,
-// projections, filters, quantized modes, benchmark-debug stats mode, missing or
-// invalid hnsw_search_pack_v1 state, and legacy/fallback routes. Healthy current
-// hnsw_search_pack_v1 state is opened once into a collection-owned prepared
-// cache keyed by the current collection/vector-index manifest identity; steady
-// state searches reuse the prepared pack and caller-owned buffer/scratch instead
-// of opening a VectorIndexSearcher per call.
+// This method supports exact/zero QueryMode through the exact
+// hnsw_search_pack_v1 route, and explicit quantized_only / quantized_rerank
+// modes through a collection-owned prepared quantized route selected by
+// QuantizedIndexName. It intentionally fails closed for document materialization,
+// projections, filters, benchmark-debug stats mode, missing or invalid prepared
+// assets, stale route identities, and legacy/fallback routes. Healthy prepared
+// state is opened once into the collection cache keyed by the current
+// collection/vector-index/score-plane manifest identity; steady-state searches
+// reuse that prepared state and caller-owned result buffer instead of opening a
+// VectorIndexSearcher per call.
 func (c *Collection) SearchVectorIndexWithBuffer(opts VectorIndexSearchOptions, buffer *VectorIndexSearchBuffer) (VectorIndexSearchResponse, error) {
 	if err := validateCollectionVectorIndexSearchWithBufferOptions(opts, buffer); err != nil {
 		return VectorIndexSearchResponse{}, err
@@ -962,9 +966,31 @@ func (c *Collection) SearchVectorIndexWithBuffer(opts VectorIndexSearchOptions, 
 		buffer.Reset()
 		return VectorIndexSearchResponse{}, err
 	}
-	if queryMode != columnVectorGraphNativeSearchQueryModeExact || !columnHNSWSearchPackStatsModeSupportedForSearch(statsMode) {
+	if queryMode == columnVectorGraphNativeSearchQueryModeExact && !columnHNSWSearchPackStatsModeSupportedForSearch(statsMode) {
 		buffer.Reset()
-		return VectorIndexSearchResponse{}, fmt.Errorf("%w: vector index %q SearchVectorIndexWithBuffer requires the exact no-document hnsw_search_pack_v1 route; unsupported query or stats options must use SearchVectorIndex or OpenVectorIndexSearcher", ErrVectorIndexSearchUnavailable, opts.IndexName)
+		return VectorIndexSearchResponse{}, fmt.Errorf("%w: vector index %q SearchVectorIndexWithBuffer requires the exact no-document hnsw_search_pack_v1 route for the selected stats mode; unsupported stats options must use SearchVectorIndex or OpenVectorIndexSearcher", ErrVectorIndexSearchUnavailable, opts.IndexName)
+	}
+	slot := collectionVectorIndexPreparedSearchCacheSlotForOptions(opts, queryMode)
+	if queryMode.quantized() {
+		prepared, response, err := c.acquireCollectionVectorIndexPreparedSearch(opts)
+		if err != nil {
+			buffer.Reset()
+			return response, err
+		}
+		response, err = prepared.SearchQuantizedWithBuffer(opts, buffer)
+		healthyQuantizedRoute := vectorIndexSearchStatsAreBufferedNoDocumentQuantizedRoute(response.Stats, queryMode, opts, prepared.dimensions)
+		if err == nil && healthyQuantizedRoute {
+			return response, nil
+		}
+		if err != nil {
+			if errors.Is(err, ErrVectorIndexSearchUnavailable) && !healthyQuantizedRoute {
+				c.invalidateCollectionVectorIndexPreparedSearch(slot, prepared)
+			}
+			return response, err
+		}
+		resetBufferedVectorIndexSearchResponse(&response, buffer)
+		c.invalidateCollectionVectorIndexPreparedSearch(slot, prepared)
+		return response, fmt.Errorf("%w: vector index %q SearchVectorIndexWithBuffer quantized route did not satisfy no-document quantized guardrails; rebuild the vector index", ErrVectorIndexSearchUnavailable, opts.IndexName)
 	}
 	var lastResponse VectorIndexSearchResponse
 	var lastErr error
@@ -984,7 +1010,7 @@ func (c *Collection) SearchVectorIndexWithBuffer(opts VectorIndexSearchOptions, 
 		}
 		lastResponse, lastErr = response, err
 		resetBufferedVectorIndexSearchResponse(&response, buffer)
-		c.invalidateCollectionVectorIndexPreparedSearch(opts.IndexName, prepared)
+		c.invalidateCollectionVectorIndexPreparedSearch(slot, prepared)
 	}
 	if lastErr != nil {
 		return lastResponse, lastErr
@@ -1032,20 +1058,17 @@ func validateCollectionVectorIndexSearchWithBufferOptions(opts VectorIndexSearch
 		buffer.Reset()
 		return collectionVectorIndexWithBufferUnsupportedOptionError("DisableExactFallback", "the collection buffered route already fails closed instead of falling back")
 	}
-	if opts.QueryMode != "" && opts.QueryMode != VectorIndexQueryModeExact {
+	if opts.QueryMode != "" && opts.QueryMode != VectorIndexQueryModeExact && opts.QueryMode != VectorIndexQueryModeQuantizedOnly && opts.QueryMode != VectorIndexQueryModeQuantizedRerank {
 		buffer.Reset()
-		if opts.QueryMode == VectorIndexQueryModeQuantizedOnly || opts.QueryMode == VectorIndexQueryModeQuantizedRerank {
-			return collectionVectorIndexWithBufferUnsupportedOptionError(fmt.Sprintf("QueryMode=%q", opts.QueryMode), "collection buffered quantized search is not supported by this exact hnsw_search_pack_v1 route; use SearchVectorIndex or OpenVectorIndexSearcher plus SearchWithBuffer for supported quantized searches until a separate quantized buffered route is available")
-		}
-		return collectionVectorIndexWithBufferUnsupportedOptionError(fmt.Sprintf("QueryMode=%q", opts.QueryMode), "this API currently supports only exact/zero QueryMode on the no-document hnsw_search_pack_v1 route")
+		return collectionVectorIndexWithBufferUnsupportedOptionError(fmt.Sprintf("QueryMode=%q", opts.QueryMode), "this API supports exact/zero, quantized_only, or quantized_rerank QueryMode on no-document buffered routes")
 	}
-	if opts.QuantizedIndexName != "" {
+	if (opts.QueryMode == "" || opts.QueryMode == VectorIndexQueryModeExact) && opts.QuantizedIndexName != "" {
 		buffer.Reset()
-		return collectionVectorIndexWithBufferUnsupportedOptionError("QuantizedIndexName", "quantized collection buffered search is not supported by this exact route; use SearchVectorIndex or OpenVectorIndexSearcher plus SearchWithBuffer for supported quantized searches")
+		return collectionVectorIndexWithBufferUnsupportedOptionError("QuantizedIndexName", "exact collection buffered search cannot select a quantized index; set QueryMode=quantized_only or QueryMode=quantized_rerank for the quantized no-document route")
 	}
-	if opts.QuantizedRerankCandidates != 0 {
+	if (opts.QueryMode == "" || opts.QueryMode == VectorIndexQueryModeExact) && opts.QuantizedRerankCandidates != 0 {
 		buffer.Reset()
-		return collectionVectorIndexWithBufferUnsupportedOptionError("QuantizedRerankCandidates", "quantized collection buffered rerank is not supported by this exact route; use SearchVectorIndex or OpenVectorIndexSearcher plus SearchWithBuffer for supported quantized searches")
+		return collectionVectorIndexWithBufferUnsupportedOptionError("QuantizedRerankCandidates", "exact collection buffered search cannot set quantized rerank candidates; set QueryMode=quantized_rerank with QuantizedIndexName for the quantized no-document route")
 	}
 	if opts.StatsMode == VectorIndexSearchStatsModeBenchmarkDebug {
 		buffer.Reset()
@@ -1054,6 +1077,10 @@ func validateCollectionVectorIndexSearchWithBufferOptions(opts VectorIndexSearch
 	if _, err := columnVectorGraphNativeSearchStatsModeFromPublic(opts.StatsMode); err != nil {
 		buffer.Reset()
 		return collectionVectorIndexWithBufferUnsupportedOptionError(fmt.Sprintf("StatsMode=%q", opts.StatsMode), err.Error())
+	}
+	if _, err := normalizeVectorIndexSearchQueryMode(opts.QueryMode, opts.QuantizedIndexName, opts.QuantizedRerankCandidates, opts.TopK); err != nil {
+		buffer.Reset()
+		return collectionVectorIndexWithBufferUnsupportedOptionError("QueryMode/QuantizedIndexName", err.Error())
 	}
 	return nil
 }
@@ -1105,6 +1132,66 @@ func vectorIndexSearchStatsAreBufferedNoDocumentPackRoute(stats VectorIndexSearc
 		stats.GraphRowFallbacks == 0 &&
 		stats.TypedColumnFallbacks == 0 &&
 		stats.VectorScratchDecodes == 0
+}
+
+func vectorIndexSearchStatsAreBufferedNoDocumentQuantizedRoute(stats VectorIndexSearchStats, queryMode columnVectorGraphNativeSearchQueryMode, opts VectorIndexSearchOptions, dimensions int) bool {
+	if !queryMode.quantized() {
+		return false
+	}
+	if stats.SearchRouteHNSWSearchPack != 0 || stats.HNSWSearchPackActive != 0 || stats.HNSWSearchPackMissing != 0 || stats.HNSWSearchPackInvalid != 0 || stats.HNSWSearchPackStale != 0 || stats.HNSWSearchPackClosed != 0 || stats.HNSWSearchPackFallbacks != 0 {
+		return false
+	}
+	if stats.SearchRouteColumnGraphPrepared != 1 || stats.SearchRouteColumnGraphFallback != 0 {
+		return false
+	}
+	if stats.QuantizedScorerActive != 1 || stats.QuantizedAssetUnavailable != 0 || stats.QuantizedAssetMissing != 0 || stats.QuantizedAssetInvalid != 0 || stats.QuantizedAssetStale != 0 || stats.QuantizedAssetClosed != 0 {
+		return false
+	}
+	if stats.QuantizedAssetHeapCopy+stats.QuantizedAssetMmapDirect != 1 || stats.QuantizedAssetHeapCopyBytes+stats.QuantizedAssetMappedBytes == 0 {
+		return false
+	}
+	if stats.DocumentsFetched != 0 || stats.DocumentBytes != 0 || stats.DocumentOutputBytes != 0 || stats.GraphRowFallbacks != 0 || stats.TypedColumnFallbacks != 0 || stats.VectorScratchDecodes != 0 {
+		return false
+	}
+	emptySearch := opts.TopK == 0 || stats.CandidateRows == 0
+	if !emptySearch && (stats.QuantizedScoreCalls == 0 || stats.QuantizedCodeBytesRead == 0) {
+		return false
+	}
+	if queryMode == columnVectorGraphNativeSearchQueryModeQuantizedOnly {
+		return stats.SearchRouteQuantizedOnly == 1 &&
+			stats.SearchRouteQuantizedRerank == 0 &&
+			stats.PreparedScoreCalls == 0 &&
+			stats.QuantizedRerankCandidates == 0 &&
+			stats.QuantizedRerankExactScoreCalls == 0 &&
+			stats.VectorBytesRead == 0 &&
+			stats.NormBytesRead == 0
+	}
+	if queryMode == columnVectorGraphNativeSearchQueryModeQuantizedRerank {
+		if stats.SearchRouteQuantizedOnly != 0 || stats.SearchRouteQuantizedRerank != 1 {
+			return false
+		}
+		if emptySearch {
+			return stats.PreparedScoreCalls == 0 && stats.QuantizedRerankCandidates == 0 && stats.QuantizedRerankExactScoreCalls == 0 && stats.VectorBytesRead == 0 && stats.NormBytesRead == 0
+		}
+		if stats.QuantizedRerankCandidates == 0 || stats.QuantizedRerankExactScoreCalls != stats.QuantizedRerankCandidates {
+			return false
+		}
+		if opts.QuantizedRerankCandidates > 0 && stats.QuantizedRerankCandidates > uint64(opts.QuantizedRerankCandidates) {
+			return false
+		}
+		if stats.VectorBytesRead == 0 || stats.NormBytesRead == 0 {
+			return false
+		}
+		if dimensions > 0 {
+			maxVectorBytes := stats.QuantizedRerankCandidates * uint64(dimensions) * 4
+			maxNormBytes := stats.QuantizedRerankCandidates * 4
+			if stats.VectorBytesRead > maxVectorBytes || stats.NormBytesRead > maxNormBytes {
+				return false
+			}
+		}
+		return true
+	}
+	return false
 }
 
 // OpenVectorIndexSearcher opens a reusable search handle for steady-state

--- a/TreeDB/collections/vector_index_search.go
+++ b/TreeDB/collections/vector_index_search.go
@@ -1373,7 +1373,7 @@ func vectorIndexSearchStatsAreBufferedNoDocumentQuantizedRoute(stats VectorIndex
 	if stats.SearchRouteHNSWSearchPack != 0 || stats.HNSWSearchPackActive != 0 || stats.HNSWSearchPackMissing != 0 || stats.HNSWSearchPackInvalid != 0 || stats.HNSWSearchPackStale != 0 || stats.HNSWSearchPackClosed != 0 || stats.HNSWSearchPackFallbacks != 0 {
 		return false
 	}
-	if stats.SearchRouteColumnGraphPrepared != 1 || stats.SearchRouteColumnGraphFallback != 0 {
+	if stats.SearchRouteColumnGraphPrepared+stats.SearchRouteColumnGraphFallback != 1 {
 		return false
 	}
 	emptySearch := opts.TopK == 0 || stats.CandidateRows == 0

--- a/TreeDB/collections/vector_index_search_test.go
+++ b/TreeDB/collections/vector_index_search_test.go
@@ -1048,13 +1048,25 @@ func mutateCachedCollectionQuantizedAssetStatus2415(tb testing.TB, col *Collecti
 	col.vectorBufferedSearchMu.Lock()
 	entry := col.vectorBufferedSearch[slot]
 	col.vectorBufferedSearchMu.Unlock()
-	if entry == nil || entry.prepared == nil || entry.prepared.searcher == nil || entry.prepared.searcher.reader == nil {
+	if entry == nil || entry.prepared == nil || entry.prepared.searcher == nil {
 		tb.Fatalf("missing cached prepared quantized entry for slot %+v", slot)
 	}
 	prepared := entry.prepared
 	prepared.mu.Lock()
 	defer prepared.mu.Unlock()
-	status := prepared.searcher.reader.quantizedAssetStatus
+	prepared.quantizedReadersMu.Lock()
+	defer prepared.quantizedReadersMu.Unlock()
+	var reader *columnVectorGraphPhysicalRowReader
+	for _, candidate := range prepared.quantizedReaders {
+		if candidate != nil {
+			reader = candidate
+			break
+		}
+	}
+	if reader == nil {
+		tb.Fatalf("cached prepared quantized entry has no pooled reader for slot %+v", slot)
+	}
+	status := reader.quantizedAssetStatus
 	if status == nil {
 		tb.Fatalf("cached prepared quantized entry has nil asset status")
 	}

--- a/TreeDB/collections/vector_index_search_test.go
+++ b/TreeDB/collections/vector_index_search_test.go
@@ -926,6 +926,43 @@ func TestSearchVectorIndexWithBufferQuantizedQueryErrorsKeepPreparedState2415(t 
 	}
 }
 
+func TestSearchVectorIndexWithBufferQuantizedMaxDecodedBlocksCacheSlot2415(t *testing.T) {
+	rows := []columnGraphRebuildInputRowV2A{
+		{id: "doc-a", vector: []float32{1, 0, 0}},
+		{id: "doc-b", vector: []float32{0, 1, 0}},
+	}
+	_, d, col, def := openColumnGraphQuantizedGuardrailTestCollection1926(t, rows)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	base := VectorIndexSearchOptions{IndexName: def.Name, Query: []float32{1, 0, 0}, QueryMode: VectorIndexQueryModeQuantizedOnly, QuantizedIndexName: def.QuantizedIndexes[0].Name, TopK: 1, EfSearch: len(rows), MaxDecodedBlocks: 1, StatsMode: VectorIndexSearchStatsModeProduction}
+	var buffer VectorIndexSearchBuffer
+	if _, err := col.SearchVectorIndexWithBuffer(base, &buffer); err != nil {
+		t.Fatalf("SearchVectorIndexWithBuffer MaxDecodedBlocks=1: %v", err)
+	}
+	afterFirst := col.collectionVectorIndexPreparedSearchCacheSnapshot()
+	if afterFirst.Entries != 1 || afterFirst.CacheBuilds != 1 {
+		t.Fatalf("cache after MaxDecodedBlocks=1=%+v want one built entry", afterFirst)
+	}
+	second := base
+	second.MaxDecodedBlocks = 2
+	if _, err := col.SearchVectorIndexWithBuffer(second, &buffer); err != nil {
+		t.Fatalf("SearchVectorIndexWithBuffer MaxDecodedBlocks=2: %v", err)
+	}
+	afterSecond := col.collectionVectorIndexPreparedSearchCacheSnapshot()
+	if afterSecond.Entries != 2 || afterSecond.CacheBuilds != 2 {
+		t.Fatalf("cache after MaxDecodedBlocks=2=%+v want distinct quantized cache entry", afterSecond)
+	}
+	mode, err := normalizeVectorIndexSearchQueryMode(base.QueryMode, base.QuantizedIndexName, base.QuantizedRerankCandidates, base.TopK)
+	if err != nil {
+		t.Fatalf("normalize query mode: %v", err)
+	}
+	if slotA, slotB := collectionVectorIndexPreparedSearchCacheSlotForOptions(base, mode), collectionVectorIndexPreparedSearchCacheSlotForOptions(second, mode); slotA == slotB {
+		t.Fatalf("quantized cache slots are equal for MaxDecodedBlocks=1 and 2: %+v", slotA)
+	}
+}
+
 func TestSearchVectorIndexWithBufferQuantizedUnsupportedShapesAndLifecycle2415(t *testing.T) {
 	rows := []columnGraphRebuildInputRowV2A{
 		{id: "doc-a", vector: []float32{1, 0, 0}},

--- a/TreeDB/collections/vector_index_search_test.go
+++ b/TreeDB/collections/vector_index_search_test.go
@@ -598,6 +598,388 @@ func TestVectorIndexSearcherQuantizedSearchAndSearchWithBufferParity2414(t *test
 	}
 }
 
+func TestSearchVectorIndexWithBufferQuantizedOnlyAndRerank2415(t *testing.T) {
+	rows := []columnGraphRebuildInputRowV2A{
+		{id: "doc-a", vector: []float32{1, 0, 0}},
+		{id: "doc-b", vector: []float32{0.9, 0.1, 0}},
+		{id: "doc-c", vector: []float32{0, 1, 0}},
+		{id: "doc-d", vector: []float32{0, 0, 1}},
+		{id: "doc-e", vector: []float32{0.4, 0.6, 0}},
+	}
+	_, d, col, def := openColumnGraphQuantizedGuardrailTestCollection1926(t, rows)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+
+	query := []float32{0.8, 0.2, 0}
+	qName := def.QuantizedIndexes[0].Name
+	quantizedOnlyOpts := VectorIndexSearchOptions{IndexName: def.Name, Query: query, QueryMode: VectorIndexQueryModeQuantizedOnly, QuantizedIndexName: qName, TopK: 3, EfSearch: len(rows), MaxDecodedBlocks: 1, StatsMode: VectorIndexSearchStatsModeProduction}
+	var buffer VectorIndexSearchBuffer
+	quantizedOnly, err := col.SearchVectorIndexWithBuffer(quantizedOnlyOpts, &buffer)
+	if err != nil {
+		t.Fatalf("SearchVectorIndexWithBuffer quantized_only: %v", err)
+	}
+	assertColumnGraphSearchResponseLoadedV4(t, quantizedOnly, def.Name, quantizedOnlyOpts.TopK)
+	assertVectorIndexSearchResultsV4(t, quantizedOnly.Results, scalarU8QuantizedTopKForTest1926(t, rows, query, quantizedOnlyOpts.TopK), false)
+	assertQuantizedOnlyGuardrailStats2416(t, quantizedOnly.Stats, def.Dimensions)
+	assertCollectionBufferedQuantizedRouteStats2415(t, quantizedOnly.Stats, columnVectorGraphNativeSearchQueryModeQuantizedOnly, quantizedOnlyOpts, def.Dimensions)
+	if len(buffer.results) != quantizedOnlyOpts.TopK || len(buffer.idBytes) == 0 || &quantizedOnly.Results[0] != &buffer.results[0] || &quantizedOnly.Results[0].ID[0] != &buffer.idBytes[0] {
+		t.Fatalf("quantized_only response does not alias caller-owned buffer: results=%d idBytes=%d", len(buffer.results), len(buffer.idBytes))
+	}
+	warmSnap := col.collectionVectorIndexPreparedSearchCacheSnapshot()
+	if warmSnap.Entries != 1 || warmSnap.CacheBuilds != 1 || warmSnap.CacheMisses != 1 {
+		t.Fatalf("cache after quantized warm=%+v want one prepared quantized entry", warmSnap)
+	}
+
+	for i := 0; i < 3; i++ {
+		got, err := col.SearchVectorIndexWithBuffer(quantizedOnlyOpts, &buffer)
+		if err != nil {
+			t.Fatalf("cached quantized_only iteration %d: %v", i, err)
+		}
+		assertQuantizedOnlyGuardrailStats2416(t, got.Stats, def.Dimensions)
+	}
+	afterOnly := col.collectionVectorIndexPreparedSearchCacheSnapshot()
+	if afterOnly.Entries != 1 || afterOnly.CacheBuilds != warmSnap.CacheBuilds || afterOnly.CacheHits < warmSnap.CacheHits+3 {
+		t.Fatalf("cache after quantized_only reuse=%+v warm=%+v want hits without rebuild", afterOnly, warmSnap)
+	}
+
+	rerankOpts := quantizedOnlyOpts
+	rerankOpts.QueryMode = VectorIndexQueryModeQuantizedRerank
+	rerankOpts.QuantizedRerankCandidates = 4
+	reranked, err := col.SearchVectorIndexWithBuffer(rerankOpts, &buffer)
+	if err != nil {
+		t.Fatalf("SearchVectorIndexWithBuffer quantized_rerank: %v", err)
+	}
+	assertColumnGraphSearchResponseLoadedV4(t, reranked, def.Name, rerankOpts.TopK)
+	assertVectorIndexSearchResultsV4(t, reranked.Results, exactColumnGraphTopKForTest(t, rows, query, rerankOpts.TopK), false)
+	assertQuantizedRerankNoDocumentGuardrailStats2416(t, reranked.Stats, rerankOpts.QuantizedRerankCandidates)
+	assertCollectionBufferedQuantizedRouteStats2415(t, reranked.Stats, columnVectorGraphNativeSearchQueryModeQuantizedRerank, rerankOpts, def.Dimensions)
+	afterRerank := col.collectionVectorIndexPreparedSearchCacheSnapshot()
+	if afterRerank.Entries != 1 || afterRerank.CacheBuilds != afterOnly.CacheBuilds || afterRerank.CacheHits <= afterOnly.CacheHits {
+		t.Fatalf("cache after quantized_rerank=%+v afterOnly=%+v want shared quantized prepared entry and no rerank-candidate-key rebuild", afterRerank, afterOnly)
+	}
+
+	rerankOpts.QuantizedRerankCandidates = 5
+	if _, err := col.SearchVectorIndexWithBuffer(rerankOpts, &buffer); err != nil {
+		t.Fatalf("SearchVectorIndexWithBuffer quantized_rerank candidates=5: %v", err)
+	}
+	afterPolicyChange := col.collectionVectorIndexPreparedSearchCacheSnapshot()
+	if afterPolicyChange.Entries != 1 || afterPolicyChange.CacheBuilds != afterOnly.CacheBuilds || afterPolicyChange.CacheHits <= afterRerank.CacheHits {
+		t.Fatalf("cache after rerank policy change=%+v afterRerank=%+v want query-policy hit without rebuild", afterPolicyChange, afterRerank)
+	}
+	quantizedOnlyAllocs := testing.AllocsPerRun(100, func() {
+		got, err := col.SearchVectorIndexWithBuffer(quantizedOnlyOpts, &buffer)
+		if err != nil || len(got.Results) != quantizedOnlyOpts.TopK {
+			panic("unexpected quantized_only SearchVectorIndexWithBuffer allocation probe result")
+		}
+	})
+	if quantizedOnlyAllocs != 0 {
+		t.Fatalf("quantized_only SearchVectorIndexWithBuffer steady-state allocs/run=%v want 0", quantizedOnlyAllocs)
+	}
+	rerankAllocs := testing.AllocsPerRun(100, func() {
+		got, err := col.SearchVectorIndexWithBuffer(rerankOpts, &buffer)
+		if err != nil || len(got.Results) != rerankOpts.TopK {
+			panic("unexpected quantized_rerank SearchVectorIndexWithBuffer allocation probe result")
+		}
+	})
+	if rerankAllocs != 0 {
+		t.Fatalf("quantized_rerank SearchVectorIndexWithBuffer steady-state allocs/run=%v want 0", rerankAllocs)
+	}
+
+	exactOpts := VectorIndexSearchOptions{IndexName: def.Name, Query: query, QueryMode: VectorIndexQueryModeExact, TopK: 3, EfSearch: len(rows), MaxDecodedBlocks: 1, StatsMode: VectorIndexSearchStatsModeProduction}
+	exact, err := col.SearchVectorIndexWithBuffer(exactOpts, &buffer)
+	if err != nil {
+		t.Fatalf("SearchVectorIndexWithBuffer exact after quantized: %v", err)
+	}
+	assertSearchVectorIndexWithBufferNoDocumentPackStats2362(t, exact.Stats)
+	afterExact := col.collectionVectorIndexPreparedSearchCacheSnapshot()
+	if afterExact.Entries != 2 || afterExact.CacheBuilds != afterPolicyChange.CacheBuilds+1 {
+		t.Fatalf("cache after exact=%+v afterQuantized=%+v want distinct exact and quantized prepared entries", afterExact, afterPolicyChange)
+	}
+}
+
+func TestSearchVectorIndexWithBufferQuantizedAssetUnavailableFailClosed2415(t *testing.T) {
+	rows := []columnGraphRebuildInputRowV2A{
+		{id: "doc-a", vector: []float32{1, 0, 0}},
+		{id: "doc-b", vector: []float32{0, 1, 0}},
+		{id: "doc-c", vector: []float32{0, 0, 1}},
+	}
+	_, d, col, def := openColumnGraphQuantizedGuardrailTestCollection1926(t, rows)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	qName := def.QuantizedIndexes[0].Name
+	base := VectorIndexSearchOptions{IndexName: def.Name, Query: []float32{1, 0, 0}, QueryMode: VectorIndexQueryModeQuantizedOnly, QuantizedIndexName: qName, TopK: 1, EfSearch: len(rows), MaxDecodedBlocks: 1, StatsMode: VectorIndexSearchStatsModeProduction}
+
+	for _, tc := range []struct {
+		name   string
+		mode   VectorIndexQueryMode
+		health columnVectorGraphQuantizedAssetHealth
+		mutate func(map[string]columnVectorGraphQuantizedAssetLoadStatus, string, columnVectorGraphQuantizedAssetLoadStatus)
+	}{
+		{
+			name:   "missing",
+			mode:   VectorIndexQueryModeQuantizedOnly,
+			health: columnVectorGraphQuantizedAssetHealthMissing,
+			mutate: func(status map[string]columnVectorGraphQuantizedAssetLoadStatus, qName string, original columnVectorGraphQuantizedAssetLoadStatus) {
+				delete(status, qName)
+			},
+		},
+		{
+			name:   "invalid",
+			mode:   VectorIndexQueryModeQuantizedOnly,
+			health: columnVectorGraphQuantizedAssetHealthInvalid,
+			mutate: func(status map[string]columnVectorGraphQuantizedAssetLoadStatus, qName string, original columnVectorGraphQuantizedAssetLoadStatus) {
+				original.Prepared = nil
+				original.Health = columnVectorGraphQuantizedAssetHealthInvalid
+				original.Err = fmt.Errorf("%w: checksum mismatch", errColumnVectorGraphQuantizedAssetInvalid)
+				status[qName] = original
+			},
+		},
+		{
+			name:   "stale_identity_mismatch",
+			mode:   VectorIndexQueryModeQuantizedRerank,
+			health: columnVectorGraphQuantizedAssetHealthStale,
+			mutate: func(status map[string]columnVectorGraphQuantizedAssetLoadStatus, qName string, original columnVectorGraphQuantizedAssetLoadStatus) {
+				original.Prepared = nil
+				original.Health = columnVectorGraphQuantizedAssetHealthStale
+				original.Err = fmt.Errorf("%w: base graph identity mismatch", errColumnVectorGraphQuantizedAssetStale)
+				status[qName] = original
+			},
+		},
+		{
+			name:   "closed",
+			mode:   VectorIndexQueryModeQuantizedRerank,
+			health: columnVectorGraphQuantizedAssetHealthClosed,
+			mutate: func(status map[string]columnVectorGraphQuantizedAssetLoadStatus, qName string, original columnVectorGraphQuantizedAssetLoadStatus) {
+				original.Prepared = nil
+				original.Health = columnVectorGraphQuantizedAssetHealthClosed
+				original.Err = fmt.Errorf("%w: closed handle", errColumnVectorGraphQuantizedAssetClosed)
+				status[qName] = original
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := base
+			opts.QueryMode = tc.mode
+			if tc.mode == VectorIndexQueryModeQuantizedRerank {
+				opts.QuantizedRerankCandidates = 1
+			}
+			var buffer VectorIndexSearchBuffer
+			warm, err := col.SearchVectorIndexWithBuffer(opts, &buffer)
+			if err != nil {
+				t.Fatalf("warm SearchVectorIndexWithBuffer: %v", err)
+			}
+			assertCollectionBufferedQuantizedRouteStats2415(t, warm.Stats, columnVectorGraphNativeSearchQueryModeFromPublic2415(tc.mode), opts, def.Dimensions)
+			mutateCachedCollectionQuantizedAssetStatus2415(t, col, opts, tc.mutate)
+			got, err := col.SearchVectorIndexWithBuffer(opts, &buffer)
+			if !errors.Is(err, ErrVectorIndexSearchUnavailable) {
+				t.Fatalf("SearchVectorIndexWithBuffer err=%v want ErrVectorIndexSearchUnavailable", err)
+			}
+			if len(got.Results) != 0 || len(buffer.results) != 0 || len(buffer.idBytes) != 0 {
+				t.Fatalf("unavailable response results=%d buffer.results=%d idBytes=%d want fail-closed empty", len(got.Results), len(buffer.results), len(buffer.idBytes))
+			}
+			assertQuantizedUnavailableGuardrailStats2416(t, got.Stats, columnVectorGraphNativeSearchQueryModeFromPublic2415(tc.mode), tc.health)
+			if got.Stats.SearchRouteHNSWSearchPack != 0 || got.Stats.HNSWSearchPackActive != 0 || got.Stats.SearchRouteColumnGraphFallback != 0 {
+				t.Fatalf("unavailable stats=%+v want no exact hnsw route/fallback", got.Stats)
+			}
+			afterFailure := col.collectionVectorIndexPreparedSearchCacheSnapshot()
+			if afterFailure.Entries != 0 || afterFailure.ActiveHandles != 0 {
+				t.Fatalf("cache after fail-closed unavailable asset=%+v want invalidated closed entry", afterFailure)
+			}
+			recovered, err := col.SearchVectorIndexWithBuffer(opts, &buffer)
+			if err != nil {
+				t.Fatalf("SearchVectorIndexWithBuffer after fail-closed rebuild: %v", err)
+			}
+			assertCollectionBufferedQuantizedRouteStats2415(t, recovered.Stats, columnVectorGraphNativeSearchQueryModeFromPublic2415(tc.mode), opts, def.Dimensions)
+		})
+	}
+}
+
+func TestSearchVectorIndexWithBufferQuantizedQueryErrorsKeepPreparedState2415(t *testing.T) {
+	rows := []columnGraphRebuildInputRowV2A{
+		{id: "doc-a", vector: []float32{1, 0, 0}},
+		{id: "doc-b", vector: []float32{0, 1, 0}},
+	}
+	_, d, col, def := openColumnGraphQuantizedGuardrailTestCollection1926(t, rows)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	opts := VectorIndexSearchOptions{IndexName: def.Name, Query: []float32{1, 0, 0}, QueryMode: VectorIndexQueryModeQuantizedOnly, QuantizedIndexName: def.QuantizedIndexes[0].Name, TopK: 1, EfSearch: len(rows), MaxDecodedBlocks: 1, StatsMode: VectorIndexSearchStatsModeProduction}
+	var buffer VectorIndexSearchBuffer
+	if _, err := col.SearchVectorIndexWithBuffer(opts, &buffer); err != nil {
+		t.Fatalf("warm SearchVectorIndexWithBuffer: %v", err)
+	}
+	before := col.collectionVectorIndexPreparedSearchCacheSnapshot()
+	if before.Entries != 1 || before.CacheBuilds != 1 {
+		t.Fatalf("cache before bad query=%+v want warmed quantized entry", before)
+	}
+	badOpts := opts
+	badOpts.Query = []float32{1, 0}
+	bad, err := col.SearchVectorIndexWithBuffer(badOpts, &buffer)
+	if !errors.Is(err, errColumnVectorGraphNativeSearchQueryDimensionMismatch) {
+		t.Fatalf("bad quantized query response=%+v err=%v want dimension mismatch", bad, err)
+	}
+	if len(bad.Results) != 0 || len(buffer.results) != 0 || len(buffer.idBytes) != 0 {
+		t.Fatalf("bad query left results response=%d bufferResults=%d idBytes=%d", len(bad.Results), len(buffer.results), len(buffer.idBytes))
+	}
+	afterBad := col.collectionVectorIndexPreparedSearchCacheSnapshot()
+	if afterBad.Entries != 1 || afterBad.CacheBuilds != before.CacheBuilds || afterBad.Invalidations != before.Invalidations || afterBad.ActiveHandles == 0 {
+		t.Fatalf("cache after bad query=%+v before=%+v want healthy prepared state retained", afterBad, before)
+	}
+	valid, err := col.SearchVectorIndexWithBuffer(opts, &buffer)
+	if err != nil {
+		t.Fatalf("valid SearchVectorIndexWithBuffer after bad query: %v", err)
+	}
+	assertQuantizedOnlyGuardrailStats2416(t, valid.Stats, def.Dimensions)
+	afterValid := col.collectionVectorIndexPreparedSearchCacheSnapshot()
+	if afterValid.CacheBuilds != before.CacheBuilds || afterValid.CacheHits <= afterBad.CacheHits {
+		t.Fatalf("cache after valid retry=%+v afterBad=%+v want hit without rebuild", afterValid, afterBad)
+	}
+}
+
+func TestSearchVectorIndexWithBufferQuantizedUnsupportedShapesAndLifecycle2415(t *testing.T) {
+	rows := []columnGraphRebuildInputRowV2A{
+		{id: "doc-a", vector: []float32{1, 0, 0}},
+		{id: "doc-b", vector: []float32{0, 1, 0}},
+	}
+	_, d, col, def := openColumnGraphQuantizedGuardrailTestCollection1926(t, rows)
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		_ = d.Close()
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	qName := def.QuantizedIndexes[0].Name
+	base := VectorIndexSearchOptions{IndexName: def.Name, Query: []float32{1, 0, 0}, QueryMode: VectorIndexQueryModeQuantizedOnly, QuantizedIndexName: qName, TopK: 1, EfSearch: len(rows), MaxDecodedBlocks: 1, StatsMode: VectorIndexSearchStatsModeProduction}
+	var buffer VectorIndexSearchBuffer
+	valid, err := col.SearchVectorIndexWithBuffer(base, &buffer)
+	if err != nil {
+		_ = d.Close()
+		t.Fatalf("valid SearchVectorIndexWithBuffer: %v", err)
+	}
+	assertQuantizedOnlyGuardrailStats2416(t, valid.Stats, def.Dimensions)
+
+	for _, tc := range []struct {
+		name     string
+		mutate   func(*VectorIndexSearchOptions)
+		wantErrs []string
+	}{
+		{name: "include_documents", mutate: func(opts *VectorIndexSearchOptions) { opts.IncludeDocuments = true }, wantErrs: []string{"IncludeDocuments=true", "no-document"}},
+		{name: "projection", mutate: func(opts *VectorIndexSearchOptions) { opts.DocumentFetchOptions.IncludePaths = []string{"did"} }, wantErrs: []string{"DocumentFetchOptions.IncludePaths", "projection"}},
+		{name: "document_integrity", mutate: func(opts *VectorIndexSearchOptions) {
+			opts.DocumentFetchOptions.ColumnAssetReadIntegrity = ColumnAssetReadIntegritySkipChecksums
+		}, wantErrs: []string{"DocumentFetchOptions.ColumnAssetReadIntegrity", "materialization"}},
+		{name: "filter", mutate: func(opts *VectorIndexSearchOptions) {
+			opts.Filter = func(DocumentRecord) (bool, error) { return true, nil }
+		}, wantErrs: []string{"Filter", "no-document"}},
+		{name: "range_filter", mutate: func(opts *VectorIndexSearchOptions) {
+			opts.IndexRangeFilter = &VectorIndexRangeFilter{IndexName: "kind"}
+		}, wantErrs: []string{"IndexRangeFilter", "no-document"}},
+		{name: "benchmark_debug", mutate: func(opts *VectorIndexSearchOptions) { opts.StatsMode = VectorIndexSearchStatsModeBenchmarkDebug }, wantErrs: []string{"StatsMode=benchmark_debug", "debug-only"}},
+		{name: "missing_quantized_name", mutate: func(opts *VectorIndexSearchOptions) { opts.QuantizedIndexName = "" }, wantErrs: []string{"QueryMode/QuantizedIndexName", "quantized vector index name is required"}},
+		{name: "quantized_only_rerank_candidates", mutate: func(opts *VectorIndexSearchOptions) { opts.QuantizedRerankCandidates = 2 }, wantErrs: []string{"QueryMode/QuantizedIndexName", "quantized_only", "cannot set"}},
+		{name: "rerank_candidates_below_topk", mutate: func(opts *VectorIndexSearchOptions) {
+			opts.QueryMode = VectorIndexQueryModeQuantizedRerank
+			opts.TopK = 2
+			opts.QuantizedRerankCandidates = 1
+		}, wantErrs: []string{"QueryMode/QuantizedIndexName", "cannot be less than top_k"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := base
+			tc.mutate(&opts)
+			got, err := col.SearchVectorIndexWithBuffer(opts, &buffer)
+			if err == nil {
+				t.Fatalf("SearchVectorIndexWithBuffer err=nil want %v", tc.wantErrs)
+			}
+			if !errors.Is(err, ErrVectorIndexSearchUnavailable) {
+				t.Fatalf("SearchVectorIndexWithBuffer err=%v want ErrVectorIndexSearchUnavailable", err)
+			}
+			for _, want := range tc.wantErrs {
+				if !strings.Contains(err.Error(), want) {
+					t.Fatalf("SearchVectorIndexWithBuffer err=%v want substring %q", err, want)
+				}
+			}
+			if len(got.Results) != 0 || len(buffer.results) != 0 || len(buffer.idBytes) != 0 {
+				t.Fatalf("unsupported shape left results response=%d bufferResults=%d idBytes=%d", len(got.Results), len(buffer.results), len(buffer.idBytes))
+			}
+			if _, err := col.SearchVectorIndexWithBuffer(base, &buffer); err != nil {
+				t.Fatalf("valid SearchVectorIndexWithBuffer after %s: %v", tc.name, err)
+			}
+		})
+	}
+
+	beforeClose := col.collectionVectorIndexPreparedSearchCacheSnapshot()
+	if beforeClose.Entries != 1 || beforeClose.ActiveHandles == 0 {
+		_ = d.Close()
+		t.Fatalf("cache before close=%+v want active quantized entry", beforeClose)
+	}
+	if err := col.closeCollectionVectorIndexPreparedSearchCache(); err != nil {
+		_ = d.Close()
+		t.Fatalf("close collection cache: %v", err)
+	}
+	if snap := col.collectionVectorIndexPreparedSearchCacheSnapshot(); snap.Entries != 0 || snap.ActiveHandles != 0 {
+		_ = d.Close()
+		t.Fatalf("cache after collection close=%+v want released", snap)
+	}
+	if _, err := col.SearchVectorIndexWithBuffer(base, &buffer); err != nil {
+		_ = d.Close()
+		t.Fatalf("SearchVectorIndexWithBuffer after cache close: %v", err)
+	}
+	if snap := col.collectionVectorIndexPreparedSearchCacheSnapshot(); snap.Entries != 1 || snap.ActiveHandles == 0 {
+		_ = d.Close()
+		t.Fatalf("cache after rebuild=%+v want active quantized entry", snap)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("DB Close: %v", err)
+	}
+	if snap := col.collectionVectorIndexPreparedSearchCacheSnapshot(); snap.Entries != 0 || snap.ActiveHandles != 0 {
+		t.Fatalf("cache after DB close=%+v want released by manager close hook", snap)
+	}
+}
+
+func columnVectorGraphNativeSearchQueryModeFromPublic2415(mode VectorIndexQueryMode) columnVectorGraphNativeSearchQueryMode {
+	if mode == VectorIndexQueryModeQuantizedRerank {
+		return columnVectorGraphNativeSearchQueryModeQuantizedRerank
+	}
+	return columnVectorGraphNativeSearchQueryModeQuantizedOnly
+}
+
+func assertCollectionBufferedQuantizedRouteStats2415(tb testing.TB, stats VectorIndexSearchStats, mode columnVectorGraphNativeSearchQueryMode, opts VectorIndexSearchOptions, dims int) {
+	tb.Helper()
+	if !vectorIndexSearchStatsAreBufferedNoDocumentQuantizedRoute(stats, mode, opts, dims) {
+		tb.Fatalf("collection buffered quantized stats=%+v want healthy no-document quantized route", stats)
+	}
+}
+
+func mutateCachedCollectionQuantizedAssetStatus2415(tb testing.TB, col *Collection, opts VectorIndexSearchOptions, mutate func(map[string]columnVectorGraphQuantizedAssetLoadStatus, string, columnVectorGraphQuantizedAssetLoadStatus)) {
+	tb.Helper()
+	queryMode, err := normalizeVectorIndexSearchQueryMode(opts.QueryMode, opts.QuantizedIndexName, opts.QuantizedRerankCandidates, opts.TopK)
+	if err != nil {
+		tb.Fatalf("normalize query mode: %v", err)
+	}
+	slot := collectionVectorIndexPreparedSearchCacheSlotForOptions(opts, queryMode)
+	col.vectorBufferedSearchMu.Lock()
+	entry := col.vectorBufferedSearch[slot]
+	col.vectorBufferedSearchMu.Unlock()
+	if entry == nil || entry.prepared == nil || entry.prepared.searcher == nil || entry.prepared.searcher.reader == nil {
+		tb.Fatalf("missing cached prepared quantized entry for slot %+v", slot)
+	}
+	prepared := entry.prepared
+	prepared.mu.Lock()
+	defer prepared.mu.Unlock()
+	status := prepared.searcher.reader.quantizedAssetStatus
+	if status == nil {
+		tb.Fatalf("cached prepared quantized entry has nil asset status")
+	}
+	original, ok := status[opts.QuantizedIndexName]
+	if !ok {
+		tb.Fatalf("cached prepared quantized entry missing status for %q", opts.QuantizedIndexName)
+	}
+	mutate(status, opts.QuantizedIndexName, original)
+}
+
 func TestVectorIndexSearcherQuantizedSearchWithBufferBenchmarkRows2414(t *testing.T) {
 	cases := columnGraphScalarU8QuantizedSearchWithBufferBenchCases2414()
 	if len(cases) != 4 {
@@ -631,6 +1013,42 @@ func TestVectorIndexSearcherQuantizedSearchWithBufferBenchmarkRows2414(t *testin
 	}
 	if seen["route=quantized_rerank/candidates=32/c=1"].rerankCandidates != 32 || seen["route=quantized_rerank/candidates=32/c=8"].rerankCandidates != 32 {
 		t.Fatalf("quantized_rerank benchmark rows must configure candidates=32: %+v", cases)
+	}
+}
+
+func TestCollectionSearchVectorIndexWithBufferQuantizedBenchmarkRows2415(t *testing.T) {
+	cases := columnGraphScalarU8QuantizedCollectionWithBufferBenchCases2415()
+	if len(cases) != 4 {
+		t.Fatalf("benchmark cases=%d want four collection c=1/c=8 quantized SearchVectorIndexWithBuffer rows", len(cases))
+	}
+	seen := make(map[string]columnGraphScalarU8QuantizedCollectionWithBufferBenchCase2415, len(cases))
+	for _, tc := range cases {
+		if tc.mode != VectorIndexQueryModeQuantizedOnly && tc.mode != VectorIndexQueryModeQuantizedRerank {
+			t.Fatalf("case %+v is not an explicit collection buffered quantized row", tc)
+		}
+		if tc.concurrency != 1 && tc.concurrency != 8 {
+			t.Fatalf("case %+v has unsupported concurrency; want c=1 or c=8", tc)
+		}
+		if _, ok := seen[tc.name]; ok {
+			t.Fatalf("duplicate benchmark case name %q", tc.name)
+		}
+		seen[tc.name] = tc
+	}
+	for _, name := range []string{
+		"route=quantized_only/c=1",
+		"route=quantized_only/c=8",
+		"route=quantized_rerank/candidates=32/c=1",
+		"route=quantized_rerank/candidates=32/c=8",
+	} {
+		if _, ok := seen[name]; !ok {
+			t.Fatalf("missing collection benchmark case %q in %+v", name, cases)
+		}
+	}
+	if seen["route=quantized_only/c=1"].rerankCandidates != 0 || seen["route=quantized_only/c=8"].rerankCandidates != 0 {
+		t.Fatalf("quantized_only collection benchmark rows must not configure rerank candidates: %+v", cases)
+	}
+	if seen["route=quantized_rerank/candidates=32/c=1"].rerankCandidates != 32 || seen["route=quantized_rerank/candidates=32/c=8"].rerankCandidates != 32 {
+		t.Fatalf("quantized_rerank collection benchmark rows must configure candidates=32: %+v", cases)
 	}
 }
 
@@ -1755,15 +2173,6 @@ func TestSearchVectorIndexWithBufferUnsupportedShapesFailClosed2362(t *testing.T
 		{name: "fetch_multiplier", mutate: func(opts *VectorIndexSearchOptions) { opts.FetchMultiplier = 2 }, wantErrs: []string{"SearchVectorIndexWithBuffer", "FetchMultiplier", "pack-only"}, wantUnavailable: true},
 		{name: "exact_filter_max_docs", mutate: func(opts *VectorIndexSearchOptions) { opts.ExactFilterMaxDocs = 32 }, wantErrs: []string{"SearchVectorIndexWithBuffer", "ExactFilterMaxDocs", "pack-only"}, wantUnavailable: true},
 		{name: "disable_exact_fallback", mutate: func(opts *VectorIndexSearchOptions) { opts.DisableExactFallback = true }, wantErrs: []string{"SearchVectorIndexWithBuffer", "DisableExactFallback", "fails closed"}, wantUnavailable: true},
-		{name: "quantized_only_mode", mutate: func(opts *VectorIndexSearchOptions) {
-			opts.QueryMode = VectorIndexQueryModeQuantizedOnly
-			opts.QuantizedIndexName = "embedding.scalar_u8.fast"
-		}, wantErrs: []string{"SearchVectorIndexWithBuffer", "QueryMode=\"quantized_only\"", "quantized", "OpenVectorIndexSearcher"}, wantUnavailable: true},
-		{name: "quantized_rerank_mode", mutate: func(opts *VectorIndexSearchOptions) {
-			opts.QueryMode = VectorIndexQueryModeQuantizedRerank
-			opts.QuantizedIndexName = "embedding.scalar_u8.fast"
-			opts.QuantizedRerankCandidates = 2
-		}, wantErrs: []string{"SearchVectorIndexWithBuffer", "QueryMode=\"quantized_rerank\"", "quantized", "OpenVectorIndexSearcher"}, wantUnavailable: true},
 		{name: "unknown_query_mode", mutate: func(opts *VectorIndexSearchOptions) { opts.QueryMode = VectorIndexQueryMode("future_mode") }, wantErrs: []string{"SearchVectorIndexWithBuffer", "QueryMode=\"future_mode\"", "exact/zero"}, wantUnavailable: true},
 		{name: "quantized_index_name_option", mutate: func(opts *VectorIndexSearchOptions) { opts.QuantizedIndexName = "embedding.scalar_u8.fast" }, wantErrs: []string{"SearchVectorIndexWithBuffer", "QuantizedIndexName", "quantized"}, wantUnavailable: true},
 		{name: "quantized_rerank_candidates_option", mutate: func(opts *VectorIndexSearchOptions) { opts.QuantizedRerankCandidates = 8 }, wantErrs: []string{"SearchVectorIndexWithBuffer", "QuantizedRerankCandidates", "quantized"}, wantUnavailable: true},

--- a/TreeDB/collections/vector_index_search_test.go
+++ b/TreeDB/collections/vector_index_search_test.go
@@ -746,6 +746,44 @@ func TestSearchVectorIndexWithBufferQuantizedOnlyAndRerank2415(t *testing.T) {
 	}
 }
 
+func TestSearchVectorIndexWithBufferQuantizedEmptyCollection2415(t *testing.T) {
+	_, d, col, def := openColumnGraphQuantizedGuardrailTestCollection1926(t, nil)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	qName := def.QuantizedIndexes[0].Name
+	query := []float32{1, 0, 0}
+	var buffer VectorIndexSearchBuffer
+	for _, tc := range []struct {
+		name             string
+		mode             VectorIndexQueryMode
+		route            columnVectorGraphNativeSearchQueryMode
+		rerankCandidates int
+	}{
+		{name: "quantized_only", mode: VectorIndexQueryModeQuantizedOnly, route: columnVectorGraphNativeSearchQueryModeQuantizedOnly},
+		{name: "quantized_rerank", mode: VectorIndexQueryModeQuantizedRerank, route: columnVectorGraphNativeSearchQueryModeQuantizedRerank, rerankCandidates: 3},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := VectorIndexSearchOptions{IndexName: def.Name, Query: query, QueryMode: tc.mode, QuantizedIndexName: qName, QuantizedRerankCandidates: tc.rerankCandidates, TopK: 3, EfSearch: 8, MaxDecodedBlocks: 1, StatsMode: VectorIndexSearchStatsModeProduction}
+			got, err := col.SearchVectorIndexWithBuffer(opts, &buffer)
+			if err != nil {
+				t.Fatalf("SearchVectorIndexWithBuffer empty %s: %v", tc.name, err)
+			}
+			if len(got.Results) != 0 || len(buffer.results) != 0 || len(buffer.idBytes) != 0 {
+				t.Fatalf("empty %s results=%d bufferResults=%d idBytes=%d want empty buffered response", tc.name, len(got.Results), len(buffer.results), len(buffer.idBytes))
+			}
+			assertCollectionBufferedQuantizedRouteStats2415(t, got.Stats, tc.route, opts, def.Dimensions)
+			badOpts := opts
+			badOpts.Query = []float32{1, 0}
+			bad, err := col.SearchVectorIndexWithBuffer(badOpts, &buffer)
+			if !errors.Is(err, errColumnVectorGraphNativeSearchQueryDimensionMismatch) {
+				t.Fatalf("SearchVectorIndexWithBuffer empty bad dims response=%+v err=%v want dimension mismatch", bad, err)
+			}
+		})
+	}
+}
+
 func TestSearchVectorIndexWithBufferQuantizedAssetUnavailableFailClosed2415(t *testing.T) {
 	rows := []columnGraphRebuildInputRowV2A{
 		{id: "doc-a", vector: []float32{1, 0, 0}},

--- a/TreeDB/collections/vector_index_search_test.go
+++ b/TreeDB/collections/vector_index_search_test.go
@@ -867,7 +867,7 @@ func TestSearchVectorIndexWithBufferQuantizedAssetUnavailableFailClosed2415(t *t
 				t.Fatalf("unavailable response results=%d buffer.results=%d idBytes=%d want fail-closed empty", len(got.Results), len(buffer.results), len(buffer.idBytes))
 			}
 			assertQuantizedUnavailableGuardrailStats2416(t, got.Stats, columnVectorGraphNativeSearchQueryModeFromPublic2415(tc.mode), tc.health)
-			if got.Stats.SearchRouteHNSWSearchPack != 0 || got.Stats.HNSWSearchPackActive != 0 || got.Stats.SearchRouteColumnGraphFallback != 0 {
+			if got.Stats.SearchRouteHNSWSearchPack != 0 || got.Stats.HNSWSearchPackActive != 0 {
 				t.Fatalf("unavailable stats=%+v want no exact hnsw route/fallback", got.Stats)
 			}
 			afterFailure := col.collectionVectorIndexPreparedSearchCacheSnapshot()

--- a/TreeDB/collections/vector_index_search_test.go
+++ b/TreeDB/collections/vector_index_search_test.go
@@ -668,6 +668,35 @@ func TestSearchVectorIndexWithBufferQuantizedOnlyAndRerank2415(t *testing.T) {
 	if afterPolicyChange.Entries != 1 || afterPolicyChange.CacheBuilds != afterOnly.CacheBuilds || afterPolicyChange.CacheHits <= afterRerank.CacheHits {
 		t.Fatalf("cache after rerank policy change=%+v afterRerank=%+v want query-policy hit without rebuild", afterPolicyChange, afterRerank)
 	}
+
+	emptyOnlyOpts := quantizedOnlyOpts
+	emptyOnlyOpts.TopK = 0
+	emptyOnly, err := col.SearchVectorIndexWithBuffer(emptyOnlyOpts, &buffer)
+	if err != nil {
+		t.Fatalf("SearchVectorIndexWithBuffer quantized_only topK=0: %v", err)
+	}
+	if len(emptyOnly.Results) != 0 || len(buffer.results) != 0 || len(buffer.idBytes) != 0 {
+		t.Fatalf("quantized_only topK=0 results=%d bufferResults=%d idBytes=%d want empty buffered response", len(emptyOnly.Results), len(buffer.results), len(buffer.idBytes))
+	}
+	assertCollectionBufferedQuantizedRouteStats2415(t, emptyOnly.Stats, columnVectorGraphNativeSearchQueryModeQuantizedOnly, emptyOnlyOpts, def.Dimensions)
+	badEmptyOnlyOpts := emptyOnlyOpts
+	badEmptyOnlyOpts.Query = []float32{1, 0}
+	badEmptyOnly, err := col.SearchVectorIndexWithBuffer(badEmptyOnlyOpts, &buffer)
+	if !errors.Is(err, errColumnVectorGraphNativeSearchQueryDimensionMismatch) {
+		t.Fatalf("SearchVectorIndexWithBuffer quantized_only topK=0 bad dims response=%+v err=%v want dimension mismatch", badEmptyOnly, err)
+	}
+	emptyRerankOpts := rerankOpts
+	emptyRerankOpts.TopK = 0
+	emptyRerankOpts.QuantizedRerankCandidates = 0
+	emptyRerank, err := col.SearchVectorIndexWithBuffer(emptyRerankOpts, &buffer)
+	if err != nil {
+		t.Fatalf("SearchVectorIndexWithBuffer quantized_rerank topK=0: %v", err)
+	}
+	if len(emptyRerank.Results) != 0 || len(buffer.results) != 0 || len(buffer.idBytes) != 0 {
+		t.Fatalf("quantized_rerank topK=0 results=%d bufferResults=%d idBytes=%d want empty buffered response", len(emptyRerank.Results), len(buffer.results), len(buffer.idBytes))
+	}
+	assertCollectionBufferedQuantizedRouteStats2415(t, emptyRerank.Stats, columnVectorGraphNativeSearchQueryModeQuantizedRerank, emptyRerankOpts, def.Dimensions)
+
 	quantizedOnlyAllocs := testing.AllocsPerRun(100, func() {
 		got, err := col.SearchVectorIndexWithBuffer(quantizedOnlyOpts, &buffer)
 		if err != nil || len(got.Results) != quantizedOnlyOpts.TopK {

--- a/TreeDB/collections/vector_index_search_test.go
+++ b/TreeDB/collections/vector_index_search_test.go
@@ -867,8 +867,20 @@ func TestSearchVectorIndexWithBufferQuantizedAssetUnavailableFailClosed2415(t *t
 				t.Fatalf("unavailable response results=%d buffer.results=%d idBytes=%d want fail-closed empty", len(got.Results), len(buffer.results), len(buffer.idBytes))
 			}
 			assertQuantizedUnavailableGuardrailStats2416(t, got.Stats, columnVectorGraphNativeSearchQueryModeFromPublic2415(tc.mode), tc.health)
-			if got.Stats.SearchRouteHNSWSearchPack != 0 || got.Stats.HNSWSearchPackActive != 0 {
-				t.Fatalf("unavailable stats=%+v want no exact hnsw route/fallback", got.Stats)
+			if got.Stats.SearchRouteHNSWSearchPack != 0 ||
+				got.Stats.HNSWSearchPackActive != 0 ||
+				got.Stats.HNSWSearchPackMissing != 0 ||
+				got.Stats.HNSWSearchPackInvalid != 0 ||
+				got.Stats.HNSWSearchPackStale != 0 ||
+				got.Stats.HNSWSearchPackClosed != 0 ||
+				got.Stats.HNSWSearchPackFallbacks != 0 ||
+				got.Stats.HNSWSearchPackMmapDirect != 0 ||
+				got.Stats.HNSWSearchPackHeapCopy != 0 ||
+				got.Stats.HNSWSearchPackOpenNanos != 0 ||
+				got.Stats.HNSWSearchPackMappedBytes != 0 ||
+				got.Stats.HNSWSearchPackHeapCopyBytes != 0 ||
+				got.Stats.HNSWSearchPackActiveHandles != 0 {
+				t.Fatalf("unavailable stats=%+v want no exact hnsw route/fallback telemetry", got.Stats)
 			}
 			afterFailure := col.collectionVectorIndexPreparedSearchCacheSnapshot()
 			if afterFailure.Entries != 0 || afterFailure.ActiveHandles != 0 {

--- a/TreeDB/docs/quantized_vector_index_test.go
+++ b/TreeDB/docs/quantized_vector_index_test.go
@@ -24,6 +24,8 @@ func TestDocs_QuantizedVectorIndex1926Closeout(t *testing.T) {
 		"Missing, stale, corrupt, mismatched, unsupported, or unprepared assets return `ErrVectorIndexSearchUnavailable`",
 		"BenchmarkColumnGraphScalarU8QuantizedScorePlanes1926",
 		"BenchmarkVectorIndexSearcherColumnGraphScalarU8QuantizedSearchWithBuffer2414",
+		"BenchmarkCollectionSearchVectorIndexWithBufferColumnGraphScalarU8Quantized2415",
+		"Collection.SearchVectorIndexWithBuffer",
 		"BenchmarkColumnGraphScalarU8QuantizedRebuildStorage1926",
 		"recall_at_k_pct",
 		"quantized_code_B/search",

--- a/TreeDB/docs/spec/quantized-vector-index.md
+++ b/TreeDB/docs/spec/quantized-vector-index.md
@@ -25,7 +25,12 @@ ranked by exact cosine over the trimmed quantized candidate set; they are not a
 silent full-exact search. Quantized route counters identify the selected query
 mode and may be reported alongside the `column_graph` prepared physical route;
 `hnsw_search_pack_v1` route/active/fallback counters remain zero for quantized
-search.
+search. No-document buffered serving is available through both lower-level
+`VectorIndexSearcher.SearchWithBuffer` and collection-level
+`Collection.SearchVectorIndexWithBuffer` when `QueryMode` and
+`QuantizedIndexName` select an explicit quantized mode; document materialization,
+projections, filters, and benchmark-debug stats remain outside this buffered
+collection route.
 
 ## Durable asset model
 
@@ -64,15 +69,17 @@ rebuild/storage overhead:
 ```sh
 GOMAXPROCS=8 GOWORK=off go test ./TreeDB/collections \
   -run '^$' \
-  -bench '^Benchmark(ColumnGraphScalarU8Quantized(ScorePlanes|RebuildStorage)1926|VectorIndexSearcherColumnGraphScalarU8QuantizedSearchWithBuffer2414)$' \
+  -bench '^Benchmark(ColumnGraphScalarU8Quantized(ScorePlanes|RebuildStorage)1926|VectorIndexSearcherColumnGraphScalarU8QuantizedSearchWithBuffer2414|CollectionSearchVectorIndexWithBufferColumnGraphScalarU8Quantized2415)$' \
   -benchmem -benchtime=500ms -count=3
 ```
 
 `BenchmarkColumnGraphScalarU8QuantizedScorePlanes1926` emits the per-query rows;
 `BenchmarkVectorIndexSearcherColumnGraphScalarU8QuantizedSearchWithBuffer2414`
-emits explicit lower-level buffered `VectorIndexSearcher.SearchWithBuffer` rows
-for `route=quantized_only/c=1`, `route=quantized_only/c=8`,
-`route=quantized_rerank/candidates=32/c=1`, and
+emits explicit lower-level buffered `VectorIndexSearcher.SearchWithBuffer` rows;
+`BenchmarkCollectionSearchVectorIndexWithBufferColumnGraphScalarU8Quantized2415`
+emits collection-level buffered `Collection.SearchVectorIndexWithBuffer` rows;
+both buffered benchmark families include `route=quantized_only/c=1`,
+`route=quantized_only/c=8`, `route=quantized_rerank/candidates=32/c=1`, and
 `route=quantized_rerank/candidates=32/c=8`; and
 `BenchmarkColumnGraphScalarU8QuantizedRebuildStorage1926` emits rebuild/storage
 rows. The score-plane and buffered rows report `ns/op`, `ops/sec`, `B/op`,


### PR DESCRIPTION
Closes #2415.
Part of #2412.

## Summary
- Adds collection-level `SearchVectorIndexWithBuffer` support for native column_graph quantized vector search (`quantized_only` and `quantized_rerank`).
- Keeps exact collection buffered search on its existing `hnsw_search_pack_v1` path and stores quantized prepared entries in a separate cache family keyed by quantized index name.
- Uses fail-closed quantized validation: missing/invalid/stale/closed/mismatched scalar_u8 assets do not silently fall back to exact search.
- Adds a pooled prepared quantized reader path so concurrent buffered collection searches do not serialize on one non-concurrency-safe row reader.
- Allows Windows/non-mmap platforms to use the graph-reader compatibility route only when all no-document/no-exact quantized guardrails still hold.
- Extends docs/tests/benchmark rows for collection buffered quantized search and route counters.

## Guardrails / no-goals
- `hnsw_search_pack_v1` remains exact FP32 serving state; quantized routes use graph reader + scalar_u8 scoring only.
- `quantized_only`: no exact vector/norm reads, no document fetch/materialization, no exact fallback.
- `quantized_rerank`: exact reads/score calls are limited to the rerank shortlist; no document fetch/materialization.
- Public counters remain codec-generic `quantized_*`; scalar_u8 is internal/benchmark-label-only.
- Unsupported collection buffered shapes (docs/materialization/filter/debug combinations) remain rejected for the quantized route.

## Validation
- `GOWORK=off go test ./TreeDB/collections -run 'Test(SearchVectorIndexWithBufferQuantizedOnlyAndRerank2415|SearchVectorIndexWithBufferQuantizedEmptyCollection2415|SearchVectorIndexWithBufferQuantizedAssetUnavailableFailClosed2415|SearchVectorIndexWithBufferQuantizedQueryErrorsKeepPreparedState2415|SearchVectorIndexWithBufferQuantizedUnsupportedShapesAndLifecycle2415|CollectionSearchVectorIndexWithBufferQuantizedBenchmarkRows2415|SearchVectorIndexWithBufferPreparedCacheCloseReleasesHandles2363|SearchVectorIndexWithBufferPreparedCacheConcurrentSharedState2363|SearchVectorIndexWithBufferParallelIndependentBuffers2362)$' -count=1`
- `GOWORK=off go test -race ./TreeDB/collections -run 'Test(SearchVectorIndexWithBufferQuantizedOnlyAndRerank2415|SearchVectorIndexWithBufferQuantizedEmptyCollection2415|SearchVectorIndexWithBufferQuantizedAssetUnavailableFailClosed2415|SearchVectorIndexWithBufferQuantizedQueryErrorsKeepPreparedState2415|SearchVectorIndexWithBufferPreparedCacheConcurrentSharedState2363|SearchVectorIndexWithBufferParallelIndependentBuffers2362)$' -count=1`
- `GOWORK=off go test ./TreeDB/collections -count=1`
- `GOWORK=off go test ./TreeDB/docs -count=1`
- `git diff --check`
- Static review: `/tmp/gomap_2415_internal_review8.txt` => PASS
- Static review for Windows graph-route fix: `/tmp/gomap_2415_internal_review9_windowsfix.txt` => PASS
- Static review for MaxDecodedBlocks cache-key fix: `/tmp/gomap_2415_internal_review10_cachekey.txt` => PASS

## Benchmark evidence
Latest artifact: `/tmp/gomap_2415_collection_quantized_bench_final14_hnswassert_20260605_195916/collection_quantized_buffered_100000x.txt`

Command:
```sh
GOMAXPROCS=8 GOWORK=off go test ./TreeDB/collections \
  -run '^$' \
  -bench '^BenchmarkCollectionSearchVectorIndexWithBufferColumnGraphScalarU8Quantized2415$' \
  -benchmem -benchtime=100000x -count=1
```

Highlights (Apple M3):
- `quantized_only/c=1`: 14750 ns/op, `0 B/op`, `0 allocs/op`
- `quantized_only/c=8`: 3840 ns/op, `0 B/op`, `0 allocs/op`
- `quantized_rerank/candidates=32/c=1`: 22930 ns/op, `0 B/op`, `0 allocs/op`
- `quantized_rerank/candidates=32/c=8`: 7077 ns/op, `0 B/op`, `0 allocs/op`

## #2417 handoff
The collection-level buffered quantized route is now available and benchmarked. #2417 can profile the remaining scalar_u8 score-plane work without changing the exact FP32 `hnsw_search_pack_v1` path or broadening exact fallback semantics.
