### PR TITLE
Optimize arm64 scalar_u8 dot accumulation

### DIFF
--- a/TreeDB/internal/vectorops/scalar_u8_dot_batch_arm64.go
+++ b/TreeDB/internal/vectorops/scalar_u8_dot_batch_arm64.go
@@ -9,6 +9,11 @@ const scalarU8DotBatchOptimizedAvailable = true
 const (
 	dotScalarU8CenteredIndexedARM64MinDims = 16
 	dotScalarU8CenteredIndexedARM64MinRows = 1
+	// The bounded int32-accumulation kernel sums at most ceil(dims/32) products
+	// per vector lane. Each q*row product is bounded by 255*255, so this conservative
+	// limit keeps per-lane raw sums below int32 max while covering TreeDB's common
+	// 128/256/768-dimensional vector-search shapes.
+	dotScalarU8CenteredIndexedARM64Int32MaxDims = 32768
 )
 
 func dotScalarU8CenteredIndexedOptimizedEligible(rows, dims int) bool {
@@ -33,7 +38,12 @@ func DotScalarU8CenteredIndexed(dst []int64, codes []byte, query ScalarU8Centere
 		return scalarU8DotBatchStatus(rows, false)
 	}
 	queryValues := query.values[:dims]
-	dotScalarU8CenteredIndexedARM64(dst, codes, queryValues, rowIDs, dims, rows, query.CenteredSum())
+	querySum := query.CenteredSum()
+	if dims <= dotScalarU8CenteredIndexedARM64Int32MaxDims {
+		dotScalarU8CenteredIndexedARM64Int32(dst, codes, queryValues, rowIDs, dims, rows, querySum)
+	} else {
+		dotScalarU8CenteredIndexedARM64(dst, codes, queryValues, rowIDs, dims, rows, querySum)
+	}
 	return scalarU8DotBatchStatus(rows, true)
 }
 
@@ -42,3 +52,9 @@ func DotScalarU8CenteredIndexed(dst []int64, codes []byte, query ScalarU8Centere
 // rows before calling. querySum is sum(query[:dims]); the kernel computes
 // sum(q*(2*row-255)) as 2*sum(q*row)-255*querySum.
 func dotScalarU8CenteredIndexedARM64(dst []int64, codes []byte, query []ScalarU8CenteredCode, rowIDs []uint32, dims int, rows int, querySum int64)
+
+// dotScalarU8CenteredIndexedARM64Int32 computes rows indexed scalar_u8 centered
+// dot products for bounded dimensions whose per-lane int32 partial sums cannot
+// overflow. The Go wrapper must validate all slice lengths, row IDs, dims, and
+// rows before calling.
+func dotScalarU8CenteredIndexedARM64Int32(dst []int64, codes []byte, query []ScalarU8CenteredCode, rowIDs []uint32, dims int, rows int, querySum int64)

--- a/TreeDB/internal/vectorops/scalar_u8_dot_batch_arm64.s
+++ b/TreeDB/internal/vectorops/scalar_u8_dot_batch_arm64.s
@@ -148,3 +148,135 @@ scalaru8_arm64_store:
 
 scalaru8_arm64_done:
 	RET
+
+// func dotScalarU8CenteredIndexedARM64Int32(dst []int64, codes []byte, query []ScalarU8CenteredCode, rowIDs []uint32, dims int, rows int, querySum int64)
+//
+// Preconditions are checked by the Go wrapper: rows <= len(dst,rowIDs), dims is
+// within dotScalarU8CenteredIndexedARM64Int32MaxDims, len(query) >= dims, and
+// every row ID addresses a full row in codes. This bounded-dimension variant
+// keeps q*row partial sums in int32 vector lanes and widens once per row at the
+// final reduction, avoiding the per-32-dimension SADDLP/int64 accumulation cost
+// in the fully overflow-safe kernel above.
+TEXT ·dotScalarU8CenteredIndexedARM64Int32(SB), NOSPLIT, $0-120
+	MOVD dst_base+0(FP), R0
+	MOVD codes_base+24(FP), R1
+	MOVD query_base+48(FP), R2
+	MOVD rowIDs_base+72(FP), R3
+	MOVD dims+96(FP), R4
+	MOVD rows+104(FP), R5
+	MOVD querySum+112(FP), R6
+
+scalaru8_arm64_i32_row_loop:
+	CBZ R5, scalaru8_arm64_i32_done
+	MOVWU (R3), R7               // row ID
+	ADD $4, R3
+	MUL R4, R7, R8               // row offset in bytes (dims is byte width)
+	ADD R1, R8, R9               // row pointer
+	MOVD R2, R10                 // query pointer
+	MOVD R4, R11                 // remaining dims
+
+	// Initialize eight int32 vector accumulators. The Go wrapper only dispatches
+	// here for dimensions whose worst-case lane sums fit in signed int32.
+	VEOR V0.B16, V0.B16, V0.B16
+	VEOR V1.B16, V1.B16, V1.B16
+	VEOR V2.B16, V2.B16, V2.B16
+	VEOR V3.B16, V3.B16, V3.B16
+	VEOR V4.B16, V4.B16, V4.B16
+	VEOR V5.B16, V5.B16, V5.B16
+	VEOR V6.B16, V6.B16, V6.B16
+	VEOR V7.B16, V7.B16, V7.B16
+
+	CMP $32, R11
+	BLT scalaru8_arm64_i32_tail16
+
+scalaru8_arm64_i32_loop32:
+	// Load 32 row bytes and 32 int16 centered query values.
+	VLD1.P 16(R9), [V16.B16]
+	VLD1.P 16(R9), [V17.B16]
+	VLD1.P 32(R10), [V20.H8, V21.H8]
+	VLD1.P 32(R10), [V22.H8, V23.H8]
+
+	// Zero-extend row bytes to int16 lanes: V16 -> V24,V25; V17 -> V26,V27.
+	VUXTL V16.B8, V24.H8
+	VUXTL2 V16.B16, V25.H8
+	VUXTL V17.B8, V26.H8
+	VUXTL2 V17.B16, V27.H8
+
+	// q(int16) * row(uint8 widened to positive int16) accumulates into int32.
+	WORD $0x0E788280              // SMLAL V0.4S, V20.4H, V24.4H
+	WORD $0x4E788281              // SMLAL2 V1.4S, V20.8H, V24.8H
+	WORD $0x0E7982A2              // SMLAL V2.4S, V21.4H, V25.4H
+	WORD $0x4E7982A3              // SMLAL2 V3.4S, V21.8H, V25.8H
+	WORD $0x0E7A82C4              // SMLAL V4.4S, V22.4H, V26.4H
+	WORD $0x4E7A82C5              // SMLAL2 V5.4S, V22.8H, V26.8H
+	WORD $0x0E7B82E6              // SMLAL V6.4S, V23.4H, V27.4H
+	WORD $0x4E7B82E7              // SMLAL2 V7.4S, V23.8H, V27.8H
+
+	SUB $32, R11
+	CMP $32, R11
+	BGE scalaru8_arm64_i32_loop32
+
+scalaru8_arm64_i32_tail16:
+	CMP $16, R11
+	BLT scalaru8_arm64_i32_reduce
+
+	VLD1.P 16(R9), [V16.B16]
+	VLD1.P 32(R10), [V20.H8, V21.H8]
+	VUXTL V16.B8, V24.H8
+	VUXTL2 V16.B16, V25.H8
+
+	WORD $0x0E788280              // SMLAL V0.4S, V20.4H, V24.4H
+	WORD $0x4E788281              // SMLAL2 V1.4S, V20.8H, V24.8H
+	WORD $0x0E7982A2              // SMLAL V2.4S, V21.4H, V25.4H
+	WORD $0x4E7982A3              // SMLAL2 V3.4S, V21.8H, V25.8H
+	SUB $16, R11
+
+scalaru8_arm64_i32_reduce:
+	// Widen each int32 accumulator to int64 once per row, then reuse the same
+	// int64 tree reduction shape as the overflow-safe kernel.
+	WORD $0x4EA02800              // SADDLP V0.2D, V0.4S
+	WORD $0x4EA02821              // SADDLP V1.2D, V1.4S
+	WORD $0x4EA02842              // SADDLP V2.2D, V2.4S
+	WORD $0x4EA02863              // SADDLP V3.2D, V3.4S
+	WORD $0x4EA02884              // SADDLP V4.2D, V4.4S
+	WORD $0x4EA028A5              // SADDLP V5.2D, V5.4S
+	WORD $0x4EA028C6              // SADDLP V6.2D, V6.4S
+	WORD $0x4EA028E7              // SADDLP V7.2D, V7.4S
+	WORD $0x4EE48400              // ADD V0.2D, V0.2D, V4.2D
+	WORD $0x4EE58421              // ADD V1.2D, V1.2D, V5.2D
+	WORD $0x4EE68442              // ADD V2.2D, V2.2D, V6.2D
+	WORD $0x4EE78463              // ADD V3.2D, V3.2D, V7.2D
+	WORD $0x4EE28400              // ADD V0.2D, V0.2D, V2.2D
+	WORD $0x4EE38421              // ADD V1.2D, V1.2D, V3.2D
+	WORD $0x4EE18400              // ADD V0.2D, V0.2D, V1.2D
+	VMOV V0.D[0], R12
+	VMOV V0.D[1], R13
+	ADD R13, R12, R12
+
+scalaru8_arm64_i32_scalar_tail:
+	CBZ R11, scalaru8_arm64_i32_store
+	MOVBU (R9), R13
+	MOVH (R10), R14
+	SXTH R14, R14
+	MUL R13, R14, R13
+	ADD R13, R12, R12
+	ADD $1, R9
+	ADD $2, R10
+	SUB $1, R11
+	B scalaru8_arm64_i32_scalar_tail
+
+scalaru8_arm64_i32_store:
+	// centeredScore = 2*rawSum - 255*querySum.
+	MOVD R12, R13
+	LSL $1, R13
+	MOVD R6, R14
+	LSL $8, R14
+	SUB R6, R14, R14
+	SUB R14, R13, R13
+	MOVD R13, (R0)
+	ADD $8, R0
+	SUB $1, R5
+	B scalaru8_arm64_i32_row_loop
+
+scalaru8_arm64_i32_done:
+	RET

--- a/TreeDB/internal/vectorops/scalar_u8_dot_batch_arm64_test.go
+++ b/TreeDB/internal/vectorops/scalar_u8_dot_batch_arm64_test.go
@@ -1,0 +1,39 @@
+//go:build arm64 && !purego
+
+package vectorops
+
+import "testing"
+
+func TestDotScalarU8CenteredIndexedARM64Int32Boundary2418(t *testing.T) {
+	t.Parallel()
+
+	const dims = dotScalarU8CenteredIndexedARM64Int32MaxDims
+	queryCodes := make([]byte, dims)
+	for i := range queryCodes {
+		queryCodes[i] = 255
+	}
+	scratch := make([]ScalarU8CenteredCode, 0, dims)
+	query, _, ok := PrepareScalarU8CenteredQuery(scratch, queryCodes, dims)
+	if !ok {
+		t.Fatalf("PrepareScalarU8CenteredQuery dims=%d failed", dims)
+	}
+
+	codes := make([]byte, 2*dims)
+	for i := 0; i < dims; i++ {
+		codes[i] = 255
+		codes[dims+i] = 0
+	}
+	rowIDs := []uint32{0, 1}
+
+	got := make([]int64, len(rowIDs))
+	dotScalarU8CenteredIndexedARM64Int32(got, codes, query.values[:dims], rowIDs, dims, len(rowIDs), query.CenteredSum())
+	want := []int64{int64(65025 * dims), -int64(65025 * dims)}
+	assertInt64SliceExact(t, got, want)
+
+	publicGot := make([]int64, len(rowIDs))
+	status := DotScalarU8CenteredIndexed(publicGot, codes, query, rowIDs, dims)
+	if status.Invalid || status.Rows != len(rowIDs) || !status.Optimized || status.Fallback {
+		t.Fatalf("status=%+v want optimized public boundary rows", status)
+	}
+	assertInt64SliceExact(t, publicGot, want)
+}


### PR DESCRIPTION
## Summary

Closes #2418.

- Adds a bounded-dimension arm64 NEON scalar_u8 indexed dot kernel that accumulates `q*row` partial sums in int32 lanes and widens once per row.
- Keeps the existing overflow-safe int64 accumulation kernel for dimensions above the conservative bound.
- Adds an arm64 boundary test at `dotScalarU8CenteredIndexedARM64Int32MaxDims` to verify worst-case all-255/all-0 scores and public dispatch.

## Guardrails

- Quantized route semantics unchanged: no exact fallback, no document materialization, codec-generic public counters preserved.
- `quantized_only` continues to report zero vector/norm bytes; `quantized_rerank` reads exact vectors/norms only for the 32-candidate shortlist.
- Buffered collection/searcher rows remain `0 B/op`, `0 allocs/op`.

## Tests

- `GOWORK=off go test ./TreeDB/internal/vectorops -count=1`
- `GOWORK=off go test ./TreeDB/internal/vectorops ./TreeDB/collections -count=1`
- `git diff --check`

## Benchmarks / profiles

### scalar_u8 vectorops microbenchmark

Before: `/tmp/gomap_2418_vectorops_baseline_20260605_203038/scalar_u8_vectorops_bench.txt`
After: `/tmp/gomap_2418_vectorops_i32accum_20260605_203345/scalar_u8_vectorops_bench.txt`
Benchstat: `/tmp/gomap_2418_vectorops_i32accum_20260605_203345/benchstat_vs_baseline.txt`

Highlights (`ops/sec`, after vs before):

- `dims=128/rows=1`: +29.8%
- `dims=128/rows=8`: +66.9%
- `dims=128/rows=16`: +75.3%
- `dims=128/rows=64`: +52.7%
- `dims=256/rows=64`: +76.8%
- `dims=768/rows=64`: +89.4%
- geomean scores/sec: +55.4%
- all rows: `0 B/op`, `0 allocs/op`

### Collection buffered quantized benchmark

Same-host main baseline: `/tmp/gomap_2418_collection_baseline_samehost_20260605_203717/bench.txt`
After: `/tmp/gomap_2418_collection_i32accum_unprofiled_20260605_203518/bench.txt`
Benchstat: `/tmp/gomap_2418_collection_i32accum_unprofiled_benchstat_vs_samehost_baseline.txt`

`sec/op` summary:

- `quantized_only/c=1`: 16.68µ → 16.46µ (~)
- `quantized_only/c=8`: 4.800µ → 4.594µ (~)
- `quantized_rerank/candidates=32/c=1`: 17.16µ → 16.97µ (~)
- `quantized_rerank/candidates=32/c=8`: 5.815µ → 4.739µ (-18.5%)
- geomean: -6.6%
- all rows: `0 B/op`, `0 allocs/op`

Profiled after artifact: `/tmp/gomap_2418_collection_i32accum_20260605_203434`

CPU top changed from #2417's current-main collection profile `dotScalarU8CenteredIndexedARM64` 7.2% flat to `dotScalarU8CenteredIndexedARM64Int32` 5.3% flat in the mixed collection profile. The remaining leading costs are search/frontier/top maintenance and benchmark/runtime scheduling noise.

### Lower-level buffered quantized benchmark

Same-host main baseline: `/tmp/gomap_2418_lower_baseline_samehost_20260605_203831/bench.txt`
After: `/tmp/gomap_2418_lower_i32accum_20260605_203803/bench.txt`
Benchstat: `/tmp/gomap_2418_lower_i32accum_benchstat_vs_samehost_baseline.txt`

Geomean `sec/op`: -3.4%; all rows stay `0 B/op`, `0 allocs/op`.

### Production-style profile rerun

After artifact: `/tmp/gomap_2418_profiles_i32accum_20260605_203554`

Same command shape as #2417 with `NUMPY_PACKAGE=numpy==2.4.6`. Recall/counters stayed within contract (`quantized_only` no exact vector/norm bytes; `quantized_rerank` 32 exact rerank score calls/search). This run had higher wall-clock noise than the same-host Go benches, so the PR relies on the same-host Go before/after and CPU attribution for merge evidence.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized ARM64 vector operations with adaptive kernel selection for improved performance on scalar dot product calculations with varying data dimensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->