### PR TITLE
Map geth adapter Compact to TreeDB CompactStorage

### DIFF
--- a/TreeDB/integration/gethethdb/README.md
+++ b/TreeDB/integration/gethethdb/README.md
@@ -30,9 +30,13 @@ persistent hot-KV durability/recovery through TreeDB command WAL.
 - `NewIterator(prefix, start)` iterates `prefix` keys starting at
   `prefix || start`.
 - `SyncKeyValue` maps to `TreeDB.DB.Checkpoint()`.
-- `Compact` maps to TreeDB's current whole-index `CompactIndex()` primitive;
-  geth's range arguments are accepted for interface compatibility but do not
-  narrow the TreeDB compaction.
+- `Compact(nil, nil)` maps to TreeDB's high-level `CompactStorage` full-storage
+  compaction sequence.
+- Bounded `Compact(start, limit)` calls with non-nil `limit` are accepted as
+  advisory no-ops because TreeDB does not currently expose geth-style
+  range-scoped compaction. A nil `limit` also handles the final tail range in
+  geth's 16/256-range compaction sweeps and runs one full TreeDB storage
+  compaction.
 
 ## Validation
 

--- a/TreeDB/integration/gethethdb/adapter.go
+++ b/TreeDB/integration/gethethdb/adapter.go
@@ -8,6 +8,7 @@
 package gethethdb
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -130,16 +131,24 @@ func resolveTreeDBOptions(path string, options *OpenOptions) (treedb.Options, er
 	return opts, nil
 }
 
+type compactStorageFunc func(context.Context, *treedb.DB) error
+
+func runCompactStorageFull(ctx context.Context, tdb *treedb.DB) error {
+	_, err := tdb.CompactStorage(ctx, treedb.CompactStorageOptions{Mode: treedb.CompactStorageFull})
+	return err
+}
+
 // Wrap adapts an already-open TreeDB handle. The caller owns the handle through
 // the returned Database; Close closes the wrapped TreeDB handle.
 func Wrap(db *treedb.DB) *Database {
-	return &Database{db: db}
+	return &Database{db: db, compactStorage: runCompactStorageFull}
 }
 
 // Database implements ethdb.KeyValueStore on top of TreeDB.
 type Database struct {
-	db     *treedb.DB
-	closed atomic.Bool
+	db             *treedb.DB
+	compactStorage compactStorageFunc
+	closed         atomic.Bool
 }
 
 var _ ethdb.KeyValueStore = (*Database)(nil)
@@ -301,15 +310,27 @@ func (d *Database) NewIterator(prefix []byte, start []byte) ethdb.Iterator {
 	return &Iterator{inner: inner}
 }
 
-// Compact compacts TreeDB's index. TreeDB's public compaction primitive is
-// currently whole-index, so start/limit are accepted for ethdb compatibility but
-// not used to narrow the compaction.
+// Compact accepts geth ethdb compaction requests.
+//
+// TreeDB currently has no range-scoped compaction equivalent to geth's
+// LevelDB/Pebble range compaction. Bounded ranges are therefore treated as
+// advisory no-ops so geth range sweeps do not multiply full-storage compaction
+// cost. A nil limit represents either geth's whole-DB request (nil, nil) or the
+// final tail range in geth range sweeps, and runs TreeDB's high-level storage
+// compaction entrypoint.
 func (d *Database) Compact(start []byte, limit []byte) error {
 	tdb, err := d.tree()
 	if err != nil {
 		return err
 	}
-	return tdb.CompactIndex()
+	if limit != nil {
+		return nil
+	}
+	compactStorage := d.compactStorage
+	if compactStorage == nil {
+		compactStorage = runCompactStorageFull
+	}
+	return compactStorage(context.Background(), tdb)
 }
 
 func iteratorLowerBound(prefix, start []byte) []byte {

--- a/TreeDB/integration/gethethdb/compact_test.go
+++ b/TreeDB/integration/gethethdb/compact_test.go
@@ -1,0 +1,175 @@
+package gethethdb
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	treedb "github.com/snissn/gomap/TreeDB"
+)
+
+func openCompactTestDBAt(t testing.TB, dir string) *Database {
+	t.Helper()
+	opts := treedb.OptionsFor(treedb.ProfileCommandWALRelaxed, dir)
+	opts.BackgroundCheckpointInterval = -1
+	opts.BackgroundCheckpointIdleDuration = -1
+	opts.BackgroundIndexVacuumInterval = -1
+	// Force non-empty values through TreeDB's persistent value log so adapter
+	// compaction coverage includes value-log pointer preservation.
+	opts.ValueLog.PointerThreshold = 1
+	db, err := OpenWithOptions(opts)
+	if err != nil {
+		t.Fatalf("OpenWithOptions(%s): %v", dir, err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func compactTestValue(i int) []byte {
+	return []byte(fmt.Sprintf("value-%03d-abcdefghijklmnopqrstuvwxyz", i))
+}
+
+func compactCommitSeq(t testing.TB, db *Database) uint64 {
+	t.Helper()
+	stats := db.TreeDB().Stats()
+	raw, ok := stats["treedb.commit_seq"]
+	if !ok {
+		t.Fatalf("treedb.commit_seq missing from stats")
+	}
+	seq, err := strconv.ParseUint(raw, 10, 64)
+	if err != nil {
+		t.Fatalf("parse treedb.commit_seq=%q: %v", raw, err)
+	}
+	return seq
+}
+
+func TestCompactWholeDBCommandWALPreservesDataAfterReopen(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "treedb")
+	db := openCompactTestDBAt(t, dir)
+
+	for i := 0; i < 64; i++ {
+		key := []byte(fmt.Sprintf("compact/live/%03d", i))
+		if err := db.Put(key, compactTestValue(i)); err != nil {
+			t.Fatalf("Put %q: %v", key, err)
+		}
+	}
+	for i := 0; i < 16; i++ {
+		key := []byte(fmt.Sprintf("compact/live/%03d", i))
+		if err := db.Delete(key); err != nil {
+			t.Fatalf("Delete %q: %v", key, err)
+		}
+	}
+
+	if err := db.Compact(nil, nil); err != nil {
+		t.Fatalf("Compact(nil, nil): %v", err)
+	}
+	for i := 0; i < 64; i++ {
+		key := []byte(fmt.Sprintf("compact/live/%03d", i))
+		if i < 16 {
+			assertMissing(t, db, key)
+			continue
+		}
+		assertValue(t, db, key, compactTestValue(i))
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close after compact: %v", err)
+	}
+
+	reopened := openCompactTestDBAt(t, dir)
+	for i := 0; i < 64; i++ {
+		key := []byte(fmt.Sprintf("compact/live/%03d", i))
+		if i < 16 {
+			assertMissing(t, reopened, key)
+			continue
+		}
+		assertValue(t, reopened, key, compactTestValue(i))
+	}
+}
+
+func TestCompactBoundedRangeIsAdvisoryNoOp(t *testing.T) {
+	db := openCompactTestDBAt(t, filepath.Join(t.TempDir(), "treedb"))
+	before := compactCommitSeq(t, db)
+	if err := db.Put([]byte("pending/bounded"), compactTestValue(1)); err != nil {
+		t.Fatalf("Put pending: %v", err)
+	}
+	afterPut := compactCommitSeq(t, db)
+	if afterPut != before {
+		t.Fatalf("Put advanced commit seq from %d to %d; test requires pending cached write", before, afterPut)
+	}
+
+	if err := db.Compact([]byte{0x00}, []byte{0x10}); err != nil {
+		t.Fatalf("bounded Compact: %v", err)
+	}
+	afterBounded := compactCommitSeq(t, db)
+	if afterBounded != afterPut {
+		t.Fatalf("bounded Compact advanced commit seq from %d to %d; want advisory no-op", afterPut, afterBounded)
+	}
+	assertValue(t, db, []byte("pending/bounded"), compactTestValue(1))
+}
+
+func TestCompactGethRangeSweepsOnlyCompactAtNilLimitTail(t *testing.T) {
+	db := openCompactTestDBAt(t, filepath.Join(t.TempDir(), "treedb"))
+	compactions := 0
+	db.compactStorage = func(ctx context.Context, tdb *treedb.DB) error {
+		compactions++
+		return tdb.Checkpoint()
+	}
+
+	if err := db.Put([]byte("pending/range16"), compactTestValue(16)); err != nil {
+		t.Fatalf("Put range16 pending: %v", err)
+	}
+	before16 := compactCommitSeq(t, db)
+	for b := 0x00; b <= 0xe0; b += 0x10 {
+		start := []byte{byte(b)}
+		limit := []byte{byte(b + 0x10)}
+		if err := db.Compact(start, limit); err != nil {
+			t.Fatalf("16-range bounded Compact %#x-%#x: %v", start, limit, err)
+		}
+		if got := compactCommitSeq(t, db); got != before16 {
+			t.Fatalf("16-range bounded Compact %#x-%#x advanced commit seq from %d to %d", start, limit, before16, got)
+		}
+	}
+	if compactions != 0 {
+		t.Fatalf("16-range bounded compactions=%d want 0", compactions)
+	}
+	if err := db.Compact([]byte{0xf0}, nil); err != nil {
+		t.Fatalf("16-range tail Compact: %v", err)
+	}
+	if compactions != 1 {
+		t.Fatalf("16-range tail compactions=%d want 1", compactions)
+	}
+	if got := compactCommitSeq(t, db); got <= before16 {
+		t.Fatalf("16-range tail Compact did not run full storage compaction/checkpoint: before=%d after=%d", before16, got)
+	}
+	assertValue(t, db, []byte("pending/range16"), compactTestValue(16))
+
+	if err := db.Put([]byte("pending/range256"), compactTestValue(255)); err != nil {
+		t.Fatalf("Put range256 pending: %v", err)
+	}
+	before256 := compactCommitSeq(t, db)
+	for b := 0; b < 255; b++ {
+		start := []byte{byte(b)}
+		limit := []byte{byte(b + 1)}
+		if err := db.Compact(start, limit); err != nil {
+			t.Fatalf("256-range bounded Compact %#x-%#x: %v", start, limit, err)
+		}
+		if got := compactCommitSeq(t, db); got != before256 {
+			t.Fatalf("256-range bounded Compact %#x-%#x advanced commit seq from %d to %d", start, limit, before256, got)
+		}
+	}
+	if compactions != 1 {
+		t.Fatalf("256-range bounded compactions=%d want 1", compactions)
+	}
+	if err := db.Compact([]byte{0xff}, nil); err != nil {
+		t.Fatalf("256-range tail Compact: %v", err)
+	}
+	if compactions != 2 {
+		t.Fatalf("256-range tail compactions=%d want 2", compactions)
+	}
+	if got := compactCommitSeq(t, db); got <= before256 {
+		t.Fatalf("256-range tail Compact did not run full storage compaction/checkpoint: before=%d after=%d", before256, got)
+	}
+	assertValue(t, db, []byte("pending/range256"), compactTestValue(255))
+}


### PR DESCRIPTION
## Objective

Map the reusable geth `ethdb` TreeDB adapter's `Compact` method to TreeDB's high-level `CompactStorage` entrypoint for whole/tail compaction, and make bounded geth range-compaction calls advisory no-ops.

Fixes #2441.

## Context

TreeDB's old adapter mapping used `CompactIndex`, which is index-only and can fail under command-WAL root-publish protection. Geth also calls `Compact` in 16/256 bounded range sweeps, so mapping every bounded range call to full TreeDB compaction would multiply maintenance cost.

## Non-goals

- No true TreeDB range-scoped compaction is added.
- No `SyncKeyValue` optimization is attempted.
- No adapter-side key codec changes.
- TreeDB remains explicit/experimental for geth/Nitro consumers.

## Design

- `Compact(start, limit)` with non-nil `limit`: return nil as an advisory no-op.
- `Compact(_, nil)`: run `TreeDB.DB.CompactStorage(context.Background(), CompactStorageFull)`.
- Add a small unexported compaction function seam on the adapter for focused dispatch tests without running expensive full storage compaction hundreds of times.
- Update adapter README semantics.

## Correctness

Tests run:

```sh
cd TreeDB/integration/gethethdb
go test ./... -run 'TestCompact' -count=1 -v
go test ./... -count=1
```

Results:

- `ok github.com/snissn/gomap/TreeDB/integration/gethethdb 16.599s`
- `ok github.com/snissn/gomap/TreeDB/integration/gethethdb 18.023s`

Additional TreeDB compact-storage smoke:

```sh
go test ./TreeDB -run 'TestCompactStorage' -count=1
```

Result:

- `ok github.com/snissn/gomap/TreeDB 32.321s`

Covered cases:

- `Compact(nil, nil)` succeeds under command-WAL TreeDB and preserves pointer-backed values after close/reopen.
- Bounded `Compact(start, limit)` is advisory/no-op and does not checkpoint pending cached writes.
- Geth-style 16-range and 256-range bounded sweeps do not invoke full compaction until the nil-limit tail call.

## Performance

This is primarily a compatibility/correctness change. The dispatch test asserts bounded range sweeps do not multiply full TreeDB compaction calls. No throughput improvement is claimed.

## Rollout / Toggle Plan

Default adapter behavior changes only for explicit TreeDB geth adapter consumers. Pebble/default geth behavior is unaffected.

## AI Review Loop

- Codex: implemented locally before PR creation.
- Copilot/CodeRabbit: request after PR is open and latest-head CI starts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined database compaction to properly perform full storage operations when required and gracefully handle bounded range compaction requests as advisory no-operations.

* **Documentation**
  * Updated documentation to clarify the adapter's compaction semantics, including distinctions between full-database and range-scoped compaction behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->