### PR TITLE
Optimize quantized graph edge accounting

### DIFF
--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -1577,11 +1577,11 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 					// Keep the steady-state visited check/mark loop free of
 					// benchmark-debug counter branches; the debug path below
 					// preserves the #2271 counter contract.
+					if countLoopEdges {
+						loopEdgeVisits += uint64(len(adjacency))
+					}
 					if !hasCandidateRows {
 						for i, neighbor := range adjacency {
-							if countLoopEdges {
-								loopEdgeVisits++
-							}
 							if uint64(neighbor) >= rowCount64 {
 								return nil, stats, fmt.Errorf("collections: column_graph %q ordinal=%d adjacency[%d]=%d outside row_count=%d: %w", r.def.Name, candidate.ordinal, i, neighbor, rowCount, errColumnVectorGraphAdjacencyOrdinalOutOfBounds)
 							}
@@ -1594,9 +1594,6 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 						}
 					} else {
 						for i, neighbor := range adjacency {
-							if countLoopEdges {
-								loopEdgeVisits++
-							}
 							if uint64(neighbor) >= rowCount64 {
 								return nil, stats, fmt.Errorf("collections: column_graph %q ordinal=%d adjacency[%d]=%d outside row_count=%d: %w", r.def.Name, candidate.ordinal, i, neighbor, rowCount, errColumnVectorGraphAdjacencyOrdinalOutOfBounds)
 							}
@@ -1660,8 +1657,11 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 				}
 				continue
 			}
+			if debugStats == nil && debugCounters == nil && countLoopEdges {
+				loopEdgeVisits += uint64(len(adjacency))
+			}
 			for i, neighbor := range adjacency {
-				if countLoopEdges {
+				if countLoopEdges && (debugStats != nil || debugCounters != nil) {
 					loopEdgeVisits++
 				}
 				if debugStats != nil {


### PR DESCRIPTION
Closes #2446.

## Summary
- Move production/full-diagnostics layer-0 edge counting out of the per-neighbor inner loop and aggregate once per adjacency slice.
- Keep benchmark-debug traversal accounting per-edge so detailed #2271-style debug counters remain unchanged.
- Preserve quantized no-document buffered guardrails and existing public edge/candidate counters.

## Evidence
Clean M0 baseline:
- `/tmp/gomap_2446_m0_baseline_20260605_220621/lower_bench.txt`
- `/tmp/gomap_2446_m0_baseline_20260605_220621/collection_bench.txt`
- CPU/alloc/block/mutex profiles under `/tmp/gomap_2446_m0_baseline_20260605_220621/{lower_profile,collection_profile}`

M1 after edge aggregation (matches this PR patch):
- `/tmp/gomap_2446_m1_edge_aggregate_20260605_221520/lower_bench.txt`
- `/tmp/gomap_2446_m1_edge_aggregate_20260605_221520/collection_bench.txt`
- `benchstat` summaries under the same directory
- CPU profiles under `/tmp/gomap_2446_m1_edge_aggregate_20260605_221520/{lower_profile,collection_profile}`

Profile result:
- M0 lower profile showed the steady-state adjacency loop spending samples on `loopEdgeVisits++` inside every neighbor iteration.
- M1 profile shows edge accounting aggregated before the loop; the per-neighbor increment is gone from the production hot path while `edges/search` and `visited_edges/search` remain unchanged.

Benchmark summary (M0 count=3 vs M1 count=3, noisy host):
- Lower-level geomean: `7.290µs` -> `6.994µs` (`-4.06%` sec/op)
- Collection buffered medians improved on the clean M1 run and all quantized rows stayed `0 B/op`, `0 allocs/op`.
- Later 6-count runs were discarded as contaminated by host load (`load averages ~62/50/30`) and are not used as evidence.

## Validation
- `GOWORK=off go test ./TreeDB/collections -run 'TestSearchVectorIndexWithBufferQuantizedOnlyAndRerank2415|TestSearchVectorIndexWithBufferQuantizedEmptyCollection2415|TestSearchVectorIndexWithBufferQuantizedAssetUnavailableFailClosed2415|TestSearchVectorIndexWithBufferQuantizedQueryErrorsKeepPreparedState2415|TestSearchVectorIndexWithBufferQuantizedMaxDecodedBlocksCacheSlot2415|TestSearchVectorIndexWithBufferQuantizedUnsupportedShapesAndLifecycle2415|TestCollectionSearchVectorIndexWithBufferQuantizedBenchmarkRows2415|TestVectorIndexSearchQuantizedRoutes1926|TestColumnVectorGraphNativeSearchFrontierHeap' -count=1`
- `GOWORK=off go test ./TreeDB/collections -count=1`
- `GOWORK=off go test ./TreeDB/docs -count=1`
- `git diff --check`
