### PR TITLE
Add TreeDB rabitq SearchWithBuffer scoring

### DIFF
--- a/TreeDB/collections/collection_vector_index_prepared_search_cache.go
+++ b/TreeDB/collections/collection_vector_index_prepared_search_cache.go
@@ -7,6 +7,7 @@ import (
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 	"github.com/snissn/gomap/TreeDB/internal/mappedresource"
+	"github.com/snissn/gomap/TreeDB/internal/rabitq"
 )
 
 type collectionVectorIndexPreparedSearchFamily uint8
@@ -466,6 +467,10 @@ func (c *Collection) openCollectionVectorIndexPreparedQuantizedSearch(opts Vecto
 	if err := reader.validateQuantizedNativeSearchOptions(queryMode, columnVectorGraphNativeSearchOptions{TopK: opts.TopK, QuantizedIndexName: opts.QuantizedIndexName, QuantizedRerankCandidates: opts.QuantizedRerankCandidates}); err != nil {
 		response.Stats = collectionVectorIndexPreparedQuantizedValidationStats(reader, routeStats, opts.QuantizedIndexName, queryMode)
 		return nil, response, err
+	}
+	if qdef, ok := findQuantizedVectorIndex(def, opts.QuantizedIndexName); ok && qdef.Codec == rabitq.CodecName {
+		response.Stats = collectionVectorIndexPreparedQuantizedValidationStats(reader, routeStats, opts.QuantizedIndexName, queryMode)
+		return nil, response, fmt.Errorf("%w: vector index %q SearchVectorIndexWithBuffer collection buffered quantized route does not yet support rabitq_1bit; use VectorIndexSearcher.SearchWithBuffer for lower-level rabitq_1bit search", ErrVectorIndexSearchUnavailable, def.Name)
 	}
 	key, err := collectionVectorIndexPreparedQuantizedSearchCacheKey(readerCatalog.meta.Name, view.AssetNamespace, def, graph, view.VectorIndexState, opts.QuantizedIndexName, opts.MaxDecodedBlocks)
 	if err != nil {

--- a/TreeDB/collections/column_vector_graph_block_view.go
+++ b/TreeDB/collections/column_vector_graph_block_view.go
@@ -42,7 +42,7 @@ type columnVectorGraphSearchPlan struct {
 	singleOrdinalRange    bool
 	scoreSource           columnVectorGraphSearchSource
 	preparedSearch        *columnVectorGraphPreparedSearchView
-	quantizedScorer       columnVectorGraphScalarU8QuantizedScorer
+	quantizedScorer       columnVectorGraphQuantizedScorer
 	quantizedScorerActive bool
 	scoreBatchMode        columnVectorGraphScoreBatchMode
 	hits                  uint64
@@ -83,7 +83,7 @@ func (s *columnVectorGraphNativeSearchScratch) prepareSearchPlanInternal(reader 
 	}
 	plan.physicalReader = physicalReader
 	plan.preparedSearch = nil
-	plan.quantizedScorer = columnVectorGraphScalarU8QuantizedScorer{}
+	plan.quantizedScorer = columnVectorGraphQuantizedScorer{}
 	plan.quantizedScorerActive = false
 	plan.hits = 0
 	plan.misses = 0

--- a/TreeDB/collections/column_vector_graph_quantized_asset.go
+++ b/TreeDB/collections/column_vector_graph_quantized_asset.go
@@ -54,6 +54,7 @@ type columnVectorGraphQuantizedAssetLoadStatus struct {
 	Definition    QuantizedVectorIndexDefinition
 	Asset         columnVectorIndexStateAssetSnapshot
 	Prepared      *quantizedasset.Prepared
+	RabitQPlan    *rabitq.Plan
 	Err           error
 	Health        columnVectorGraphQuantizedAssetHealth
 	OpenNanos     uint64
@@ -570,6 +571,17 @@ func loadColumnVectorGraphQuantizedAssetsForReader(rootDir, collection string, c
 			status.Health = columnVectorGraphQuantizedAssetHealthFromError(err)
 		} else {
 			status.Prepared = prepared
+			if q.Codec == rabitq.CodecName {
+				plan, planErr := rabitq.NewPlan(def.Dimensions, rabitq.DefaultConfig())
+				if planErr != nil {
+					status.Prepared = nil
+					status.Err = fmt.Errorf("%w: quantized asset %q rabitq_1bit plan: %v", errColumnVectorGraphQuantizedAssetInvalid, q.Name, planErr)
+					status.Health = columnVectorGraphQuantizedAssetHealthInvalid
+					out[q.Name] = status
+					continue
+				}
+				status.RabitQPlan = plan
+			}
 			status.Health = columnVectorGraphQuantizedAssetHealthHeapCopy
 			if asset.AssetBytes > 0 {
 				status.HeapCopyBytes = uint64(asset.AssetBytes)

--- a/TreeDB/collections/column_vector_graph_quantized_bench_test.go
+++ b/TreeDB/collections/column_vector_graph_quantized_bench_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/internal/rabitq"
 )
 
 const columnGraphScalarU8QuantizedBenchIndexName1926 = "embedding.scalar_u8.fast"
@@ -21,12 +22,13 @@ type columnGraphScalarU8QuantizedBenchShape1926 struct {
 }
 
 type columnGraphScalarU8QuantizedBenchFixture1926 struct {
-	close               func()
-	collection          *Collection
-	definition          VectorIndexDefinition
-	query               []float32
-	shape               columnGraphScalarU8QuantizedBenchShape1926
-	quantizedAssetBytes int64
+	close                       func()
+	collection                  *Collection
+	definition                  VectorIndexDefinition
+	query                       []float32
+	shape                       columnGraphScalarU8QuantizedBenchShape1926
+	quantizedAssetBytes         int64
+	quantizedCodeBytesPerVector int
 }
 
 type columnGraphScalarU8QuantizedSearchWithBufferBenchCase2414 struct {
@@ -145,6 +147,29 @@ func BenchmarkVectorIndexSearcherColumnGraphScalarU8QuantizedSearchWithBuffer241
 				StatsMode:                 VectorIndexSearchStatsModeProduction,
 			}
 			runColumnGraphScalarU8QuantizedSearchWithBufferBench2414(b, fixture, opts, tc.concurrency, exactIDs, exactCount)
+		})
+	}
+}
+
+func BenchmarkVectorIndexSearcherColumnGraphRabitQQuantizedSearchWithBuffer2451(b *testing.B) {
+	shape := columnGraphScalarU8QuantizedBenchShape1926{rows: 1024, dims: 128, m: 16, topK: 10, efSearch: 128, queryOrdinal: 37}
+	fixture := openColumnGraphRabitQQuantizedBenchFixture2451(b, shape)
+	defer fixture.close()
+	exactIDs, exactCount := columnGraphScalarU8QuantizedBenchmarkExactIDs1926(b, fixture)
+
+	for _, tc := range columnGraphScalarU8QuantizedSearchWithBufferBenchCases2414() {
+		tc := tc
+		b.Run(tc.name, func(b *testing.B) {
+			opts := VectorIndexSearcherSearchOptions{
+				Query:                     fixture.query,
+				QueryMode:                 tc.mode,
+				QuantizedIndexName:        columnGraphRabitQQuantizedIndexName2450,
+				QuantizedRerankCandidates: tc.rerankCandidates,
+				TopK:                      fixture.shape.topK,
+				EfSearch:                  fixture.shape.efSearch,
+				StatsMode:                 VectorIndexSearchStatsModeProduction,
+			}
+			runColumnGraphRabitQQuantizedSearchWithBufferBench2451(b, fixture, opts, tc.concurrency, exactIDs, exactCount)
 		})
 	}
 }
@@ -485,6 +510,159 @@ func assertColumnGraphScalarU8QuantizedSearchWithBufferGuardrails2414(tb testing
 	}
 }
 
+func runColumnGraphRabitQQuantizedSearchWithBufferBench2451(b *testing.B, fixture columnGraphScalarU8QuantizedBenchFixture1926, opts VectorIndexSearcherSearchOptions, concurrency int, exactIDs map[string]struct{}, exactCount int) {
+	b.Helper()
+	if concurrency <= 0 {
+		b.Fatalf("concurrency=%d must be positive", concurrency)
+	}
+	type benchWorker struct {
+		searcher *VectorIndexSearcher
+		buffer   VectorIndexSearchBuffer
+		stats    VectorIndexSearchStats
+		sink     int64
+	}
+	workers := make([]benchWorker, concurrency)
+	for i := range workers {
+		searcher, err := fixture.collection.OpenVectorIndexSearcher(VectorIndexSearcherOptions{IndexName: fixture.definition.Name, MaxDecodedBlocks: 1})
+		if err != nil {
+			b.Fatalf("OpenVectorIndexSearcher worker %d: %v", i, err)
+		}
+		defer func(searcher *VectorIndexSearcher) { _ = searcher.Close() }(searcher)
+		workers[i].searcher = searcher
+		warm, err := searcher.SearchWithBuffer(opts, &workers[i].buffer)
+		if err != nil {
+			b.Fatalf("warm rabitq SearchWithBuffer worker %d: %v", i, err)
+		}
+		if len(warm.Results) == 0 {
+			b.Fatalf("warm rabitq SearchWithBuffer worker %d returned no results", i)
+		}
+		assertColumnGraphRabitQQuantizedSearchWithBufferGuardrails2451(b, warm.Stats, opts, fixture.definition.Dimensions, fixture.quantizedCodeBytesPerVector)
+	}
+	warmRecall := columnGraphScalarU8QuantizedBenchmarkRecallAtK1926(workers[0].buffer.results, exactIDs, exactCount)
+
+	var next atomic.Uint64
+	var sink atomic.Int64
+	var failed atomic.Bool
+	var firstErr atomic.Value
+	recordErr := func(format string, args ...any) {
+		if failed.CompareAndSwap(false, true) {
+			firstErr.Store(fmt.Sprintf(format, args...))
+		}
+	}
+	var wg sync.WaitGroup
+	ready := make(chan struct{}, len(workers))
+	start := make(chan struct{})
+	wg.Add(len(workers))
+	for i := range workers {
+		worker := &workers[i]
+		go func() {
+			defer wg.Done()
+			for warmIter := 0; warmIter < 8; warmIter++ {
+				response, err := worker.searcher.SearchWithBuffer(opts, &worker.buffer)
+				if err != nil {
+					recordErr("rabitq goroutine warm SearchWithBuffer: %v", err)
+					break
+				}
+				if len(response.Results) == 0 {
+					recordErr("rabitq goroutine warm SearchWithBuffer returned no results")
+					break
+				}
+			}
+			ready <- struct{}{}
+			<-start
+			if failed.Load() {
+				return
+			}
+			var localStats VectorIndexSearchStats
+			var localSink int64
+			for {
+				iteration := int(next.Add(1)) - 1
+				if iteration >= b.N {
+					break
+				}
+				if failed.Load() {
+					continue
+				}
+				response, err := worker.searcher.SearchWithBuffer(opts, &worker.buffer)
+				if err != nil {
+					recordErr("rabitq SearchWithBuffer: %v", err)
+					continue
+				}
+				if len(response.Results) == 0 {
+					recordErr("rabitq SearchWithBuffer returned no results")
+					continue
+				}
+				localSink += int64(response.Results[0].Ordinal)
+				addColumnGraphScalarU8QuantizedBenchmarkStats1926(&localStats, response.Stats)
+			}
+			worker.stats = localStats
+			worker.sink = localSink
+		}()
+	}
+	for range workers {
+		<-ready
+	}
+	if errValue := firstErr.Load(); errValue != nil {
+		close(start)
+		wg.Wait()
+		b.Fatalf("%s", errValue.(string))
+	}
+	b.ReportAllocs()
+	b.ReportMetric(float64(concurrency), "concurrency")
+	b.ReportMetric(1, "searchwithbuffer_buffered_row")
+	b.ReportMetric(1, "rabitq_1bit_row")
+	b.ReportMetric(1, "reported_stats_mode_production")
+	b.ResetTimer()
+	close(start)
+	wg.Wait()
+	b.StopTimer()
+	if errValue := firstErr.Load(); errValue != nil {
+		b.Fatalf("%s", errValue.(string))
+	}
+	var stats VectorIndexSearchStats
+	for i := range workers {
+		addColumnGraphScalarU8QuantizedBenchmarkStats1926(&stats, workers[i].stats)
+		sink.Add(workers[i].sink)
+	}
+	columnPhysicalScanBenchSum += sink.Load()
+	recallSum := warmRecall * float64(b.N)
+	reportColumnGraphScalarU8QuantizedScorePlaneMetrics1926(b, fixture, stats, recallSum)
+}
+
+func assertColumnGraphRabitQQuantizedSearchWithBufferGuardrails2451(tb testing.TB, stats VectorIndexSearchStats, opts VectorIndexSearcherSearchOptions, dims int, bytesPerCode int) {
+	tb.Helper()
+	if bytesPerCode <= 0 {
+		tb.Fatalf("rabitq bytes_per_code=%d", bytesPerCode)
+	}
+	switch opts.QueryMode {
+	case VectorIndexQueryModeQuantizedOnly:
+		if stats.SearchRouteQuantizedOnly != 1 || stats.SearchRouteQuantizedRerank != 0 || stats.QuantizedScorerActive != 1 {
+			tb.Fatalf("rabitq quantized_only route stats=%+v", stats)
+		}
+		if stats.PreparedScoreCalls != 0 || stats.QuantizedRerankExactScoreCalls != 0 || stats.VectorBytesRead != 0 || stats.NormBytesRead != 0 {
+			tb.Fatalf("rabitq quantized_only exact stats=%+v want none", stats)
+		}
+	case VectorIndexQueryModeQuantizedRerank:
+		if stats.SearchRouteQuantizedOnly != 0 || stats.SearchRouteQuantizedRerank != 1 || stats.QuantizedScorerActive != 1 {
+			tb.Fatalf("rabitq quantized_rerank route stats=%+v", stats)
+		}
+		if stats.QuantizedRerankCandidates != uint64(opts.QuantizedRerankCandidates) || stats.QuantizedRerankExactScoreCalls != uint64(opts.QuantizedRerankCandidates) {
+			tb.Fatalf("rabitq quantized_rerank stats=%+v want shortlist=%d", stats, opts.QuantizedRerankCandidates)
+		}
+		if stats.VectorBytesRead != uint64(opts.QuantizedRerankCandidates*dims*4) || stats.NormBytesRead != uint64(opts.QuantizedRerankCandidates*4) {
+			tb.Fatalf("rabitq quantized_rerank exact bytes stats=%+v want vector=%d norm=%d", stats, opts.QuantizedRerankCandidates*dims*4, opts.QuantizedRerankCandidates*4)
+		}
+	default:
+		tb.Fatalf("unexpected rabitq SearchWithBuffer benchmark query mode %q", opts.QueryMode)
+	}
+	if stats.QuantizedScoreCalls == 0 || stats.QuantizedCodeBytesRead != stats.QuantizedScoreCalls*uint64(bytesPerCode) {
+		tb.Fatalf("rabitq quantized code stats=%+v bytes_per_code=%d", stats, bytesPerCode)
+	}
+	if stats.DocumentsFetched != 0 || stats.GraphRowFallbacks != 0 || stats.TypedColumnFallbacks != 0 || stats.VectorScratchDecodes != 0 {
+		tb.Fatalf("rabitq SearchWithBuffer buffered guardrails stats=%+v want no docs/materialization/fallback/scratch", stats)
+	}
+}
+
 func BenchmarkColumnGraphScalarU8QuantizedTraversalCounters2271(b *testing.B) {
 	shape := columnGraphScalarU8QuantizedBenchShape1926{rows: 1024, dims: 128, m: 16, topK: 10, efSearch: 128, queryOrdinal: 37}
 	fixture := openColumnGraphScalarU8QuantizedBenchFixture1926(b, shape, true)
@@ -606,8 +784,38 @@ func openColumnGraphScalarU8QuantizedBenchFixture1926(tb testing.TB, shape colum
 	}
 	if quantized {
 		fixture.quantizedAssetBytes = columnGraphScalarU8QuantizedAssetBytes1926(tb, d, def)
+		fixture.quantizedCodeBytesPerVector = shape.dims
 	}
 	return fixture
+}
+
+func openColumnGraphRabitQQuantizedBenchFixture2451(tb testing.TB, shape columnGraphScalarU8QuantizedBenchShape1926) columnGraphScalarU8QuantizedBenchFixture1926 {
+	tb.Helper()
+	_, d, col, def, rows := openColumnGraphRabitQQuantizedBenchCollection2450(tb, shape)
+	status, err := col.RebuildVectorIndex(def.Name)
+	if err != nil {
+		_ = d.Close()
+		tb.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	assertColumnGraphRebuildLoadedStatusV2A(tb, status, def.Name)
+	if shape.queryOrdinal < 0 || shape.queryOrdinal >= len(rows) {
+		_ = d.Close()
+		tb.Fatalf("query ordinal=%d out of range rows=%d", shape.queryOrdinal, len(rows))
+	}
+	plan, err := rabitq.NewPlan(shape.dims, rabitq.DefaultConfig())
+	if err != nil {
+		_ = d.Close()
+		tb.Fatalf("rabitq.NewPlan: %v", err)
+	}
+	return columnGraphScalarU8QuantizedBenchFixture1926{
+		close:                       func() { _ = d.Close() },
+		collection:                  col,
+		definition:                  def,
+		query:                       append([]float32(nil), rows[shape.queryOrdinal].vector...),
+		shape:                       shape,
+		quantizedAssetBytes:         columnGraphQuantizedAssetBytesForName2451(tb, d, def, columnGraphRabitQQuantizedIndexName2450),
+		quantizedCodeBytesPerVector: plan.BytesPerCode(),
+	}
 }
 
 func openColumnGraphScalarU8QuantizedBenchCollection1926(tb testing.TB, shape columnGraphScalarU8QuantizedBenchShape1926, quantized bool) (string, *backenddb.DB, *Collection, VectorIndexDefinition, []columnGraphRebuildInputRowV2A) {
@@ -890,7 +1098,11 @@ func reportColumnGraphScalarU8QuantizedScorePlaneMetrics1926(b *testing.B, fixtu
 	b.ReportMetric(float64(stats.ResultIDTypedBytesState)/denom, "result_id_typed_bytes_state/search")
 	b.ReportMetric(float64(stats.RowRefVectorSourceState)/denom, "row_ref_vector_source_state/search")
 	b.ReportMetric(float64(stats.RowRefVectorSourceLegacyGraphIDs)/denom, "row_ref_vector_source_legacy_graph_ids/search")
-	b.ReportMetric(float64(fixture.shape.dims), "quantized_code_B/vector")
+	quantizedCodeBytes := fixture.quantizedCodeBytesPerVector
+	if quantizedCodeBytes == 0 {
+		quantizedCodeBytes = fixture.shape.dims
+	}
+	b.ReportMetric(float64(quantizedCodeBytes), "quantized_code_B/vector")
 	b.ReportMetric(float64(fixture.shape.dims*4), "exact_vector_B/vector")
 	b.ReportMetric(4, "exact_norm_B/vector")
 	b.ReportMetric(float64(fixture.shape.dims*4+4), "exact_vector_norm_B/vector")
@@ -988,15 +1200,20 @@ func reportColumnGraphScalarU8QuantizedStorageMetrics1926(b *testing.B, d *backe
 
 func columnGraphScalarU8QuantizedAssetBytes1926(tb testing.TB, d *backenddb.DB, def VectorIndexDefinition) int64 {
 	tb.Helper()
+	return columnGraphQuantizedAssetBytesForName2451(tb, d, def, columnGraphScalarU8QuantizedBenchIndexName1926)
+}
+
+func columnGraphQuantizedAssetBytesForName2451(tb testing.TB, d *backenddb.DB, def VectorIndexDefinition, quantizedIndexName string) int64 {
+	tb.Helper()
 	records, _ := loadColumnGraphRebuildManifestRecordsAndConfigV2A(tb, d, "docs")
 	state := columnVectorIndexStateFromRecords1987(tb, records, def)
 	assets := columnVectorGraphQuantizedAssetByName(state, def)
-	asset, ok := assets[columnGraphScalarU8QuantizedBenchIndexName1926]
+	asset, ok := assets[quantizedIndexName]
 	if !ok {
-		tb.Fatalf("quantized asset %q missing from state assets: %+v", columnGraphScalarU8QuantizedBenchIndexName1926, state.Assets)
+		tb.Fatalf("quantized asset %q missing from state assets: %+v", quantizedIndexName, state.Assets)
 	}
 	if asset.AssetBytes <= 0 {
-		tb.Fatalf("quantized asset bytes=%d want positive", asset.AssetBytes)
+		tb.Fatalf("quantized asset %q bytes=%d want positive", quantizedIndexName, asset.AssetBytes)
 	}
 	return asset.AssetBytes
 }

--- a/TreeDB/collections/column_vector_graph_quantized_scorer.go
+++ b/TreeDB/collections/column_vector_graph_quantized_scorer.go
@@ -1,13 +1,84 @@
 package collections
 
 import (
+	"encoding/binary"
 	"fmt"
+	"math"
 
 	"github.com/snissn/gomap/TreeDB/internal/quantizedasset"
+	"github.com/snissn/gomap/TreeDB/internal/rabitq"
 	"github.com/snissn/gomap/TreeDB/internal/vectorops"
 )
 
 const columnVectorGraphScalarU8CodeScale = 255.0 * 255.0
+
+type columnVectorGraphQuantizedScorerKind uint8
+
+const (
+	columnVectorGraphQuantizedScorerKindNone columnVectorGraphQuantizedScorerKind = iota
+	columnVectorGraphQuantizedScorerKindScalarU8
+	columnVectorGraphQuantizedScorerKindRabitQ1Bit
+)
+
+type columnVectorGraphQuantizedScorer struct {
+	kind     columnVectorGraphQuantizedScorerKind
+	scalarU8 columnVectorGraphScalarU8QuantizedScorer
+	rabitq   columnVectorGraphRabitQQuantizedScorer
+}
+
+func (r *columnVectorGraphPhysicalRowReader) prepareQuantizedScorer(mode columnVectorGraphNativeSearchQueryMode, indexName string, query []float32, queryInvNorm float32, scratch *columnVectorGraphNativeSearchScratch) (columnVectorGraphQuantizedScorer, error) {
+	if r == nil {
+		return columnVectorGraphQuantizedScorer{}, errNilColumnVectorGraphPhysicalRowReader
+	}
+	qdef, ok := findQuantizedVectorIndex(r.def, indexName)
+	if !ok {
+		return columnVectorGraphQuantizedScorer{}, fmt.Errorf("%w: column_graph %q quantized index %q is not declared", ErrVectorIndexSearchUnavailable, r.def.Name, indexName)
+	}
+	switch qdef.Codec {
+	case QuantizedVectorCodecScalarU8:
+		scorer, err := r.prepareScalarU8QuantizedScorer(mode, indexName, query, queryInvNorm, scratch)
+		if err != nil {
+			return columnVectorGraphQuantizedScorer{}, err
+		}
+		return columnVectorGraphQuantizedScorer{kind: columnVectorGraphQuantizedScorerKindScalarU8, scalarU8: scorer}, nil
+	case rabitq.CodecName:
+		scorer, err := r.prepareRabitQQuantizedScorer(mode, indexName, query, scratch)
+		if err != nil {
+			return columnVectorGraphQuantizedScorer{}, err
+		}
+		return columnVectorGraphQuantizedScorer{kind: columnVectorGraphQuantizedScorerKindRabitQ1Bit, rabitq: scorer}, nil
+	default:
+		return columnVectorGraphQuantizedScorer{}, fmt.Errorf("%w: %w: column_graph %q quantized index %q codec/version=(%q,%d) is unsupported", ErrVectorIndexSearchUnavailable, errColumnVectorGraphQuantizedAssetInvalid, r.def.Name, indexName, qdef.Codec, qdef.Version)
+	}
+}
+
+func (s *columnVectorGraphQuantizedScorer) scoreOrdinal(ordinal int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) (float64, error) {
+	if s == nil {
+		return 0, fmt.Errorf("%w: column_graph quantized scorer is unavailable", ErrVectorIndexSearchUnavailable)
+	}
+	switch s.kind {
+	case columnVectorGraphQuantizedScorerKindScalarU8:
+		return s.scalarU8.scoreOrdinal(ordinal, scratch, stats)
+	case columnVectorGraphQuantizedScorerKindRabitQ1Bit:
+		return s.rabitq.scoreOrdinal(ordinal, scratch, stats)
+	default:
+		return 0, fmt.Errorf("%w: column_graph quantized scorer is unavailable", ErrVectorIndexSearchUnavailable)
+	}
+}
+
+func (s *columnVectorGraphQuantizedScorer) scoreOrdinals(ordinals []int, dst []float64, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) ([]float64, error) {
+	if s == nil {
+		return dst[:0], fmt.Errorf("%w: column_graph quantized scorer is unavailable", ErrVectorIndexSearchUnavailable)
+	}
+	switch s.kind {
+	case columnVectorGraphQuantizedScorerKindScalarU8:
+		return s.scalarU8.scoreOrdinals(ordinals, dst, scratch, stats)
+	case columnVectorGraphQuantizedScorerKindRabitQ1Bit:
+		return s.rabitq.scoreOrdinals(ordinals, dst, scratch, stats)
+	default:
+		return dst[:0], fmt.Errorf("%w: column_graph quantized scorer is unavailable", ErrVectorIndexSearchUnavailable)
+	}
+}
 
 type columnVectorGraphScalarU8QuantizedScorer struct {
 	indexName   string
@@ -164,6 +235,211 @@ func (s *columnVectorGraphScalarU8QuantizedScorer) recordScoreStats(stats *colum
 	stats.CandidateFetches += count64
 	stats.QuantizedScoreCalls += count64
 	stats.QuantizedCodeBytesRead += count64 * uint64(s.dims)
+}
+
+type columnVectorGraphRabitQQuantizedScorer struct {
+	indexName                     string
+	plan                          *rabitq.Plan
+	query                         rabitq.Query
+	codeRows                      quantizedasset.CodeRowView
+	codePayload                   []byte
+	codeCountPayload              []byte
+	quantizedDotProductInvPayload []byte
+	bytesPerCode                  int
+	codeDimensions                int
+}
+
+func (r *columnVectorGraphPhysicalRowReader) prepareRabitQQuantizedScorer(mode columnVectorGraphNativeSearchQueryMode, indexName string, query []float32, scratch *columnVectorGraphNativeSearchScratch) (columnVectorGraphRabitQQuantizedScorer, error) {
+	if r == nil {
+		return columnVectorGraphRabitQQuantizedScorer{}, errNilColumnVectorGraphPhysicalRowReader
+	}
+	status, ok := r.quantizedAssetStatus[indexName]
+	if !ok {
+		return columnVectorGraphRabitQQuantizedScorer{}, fmt.Errorf("%w: %w: column_graph %q query_mode=%s quantized index %q has no prepared quantized score-plane asset", ErrVectorIndexSearchUnavailable, errColumnVectorGraphQuantizedAssetMissing, r.def.Name, mode.String(), indexName)
+	}
+	if status.Err != nil {
+		return columnVectorGraphRabitQQuantizedScorer{}, fmt.Errorf("%w: column_graph %q query_mode=%s quantized index %q score-plane asset unavailable: %w", ErrVectorIndexSearchUnavailable, r.def.Name, mode.String(), indexName, status.Err)
+	}
+	if status.Prepared == nil {
+		return columnVectorGraphRabitQQuantizedScorer{}, fmt.Errorf("%w: %w: column_graph %q query_mode=%s quantized index %q has no prepared quantized score-plane asset", ErrVectorIndexSearchUnavailable, errColumnVectorGraphQuantizedAssetMissing, r.def.Name, mode.String(), indexName)
+	}
+	qdef, ok := findQuantizedVectorIndex(r.def, indexName)
+	if !ok {
+		return columnVectorGraphRabitQQuantizedScorer{}, fmt.Errorf("%w: column_graph %q quantized index %q is not declared", ErrVectorIndexSearchUnavailable, r.def.Name, indexName)
+	}
+	if status.Definition != qdef {
+		return columnVectorGraphRabitQQuantizedScorer{}, fmt.Errorf("%w: %w: column_graph %q query_mode=%s quantized index %q prepared definition mismatch", ErrVectorIndexSearchUnavailable, errColumnVectorGraphQuantizedAssetStale, r.def.Name, mode.String(), indexName)
+	}
+	if qdef.Codec != rabitq.CodecName || qdef.Version != rabitq.CodecVersion {
+		return columnVectorGraphRabitQQuantizedScorer{}, fmt.Errorf("%w: %w: column_graph %q quantized index %q codec/version=(%q,%d) is not rabitq_1bit v%d", ErrVectorIndexSearchUnavailable, errColumnVectorGraphQuantizedAssetInvalid, r.def.Name, indexName, qdef.Codec, qdef.Version, rabitq.CodecVersion)
+	}
+	if r.def.Metric != VectorMetricCosine {
+		return columnVectorGraphRabitQQuantizedScorer{}, fmt.Errorf("%w: %w: column_graph %q quantized index %q metric %q is unsupported for rabitq_1bit scorer", ErrVectorIndexSearchUnavailable, errColumnVectorGraphQuantizedAssetInvalid, r.def.Name, indexName, r.def.Metric)
+	}
+	if len(query) != r.def.Dimensions {
+		return columnVectorGraphRabitQQuantizedScorer{}, fmt.Errorf("collections: column_graph %q query dims=%d want %d: %w", r.def.Name, len(query), r.def.Dimensions, errColumnVectorGraphNativeSearchQueryDimensionMismatch)
+	}
+	if scratch == nil {
+		return columnVectorGraphRabitQQuantizedScorer{}, fmt.Errorf("collections: column_graph %q: %w", r.def.Name, errColumnVectorGraphNativeSearchScratchRequired)
+	}
+	prepared := status.Prepared
+	if prepared.Rows() != r.RowCount() {
+		return columnVectorGraphRabitQQuantizedScorer{}, fmt.Errorf("%w: %w: column_graph %q query_mode=%s quantized index %q prepared rows=%d want graph rows=%d", ErrVectorIndexSearchUnavailable, errColumnVectorGraphQuantizedAssetStale, r.def.Name, mode.String(), indexName, prepared.Rows(), r.RowCount())
+	}
+	plan := status.RabitQPlan
+	if plan == nil || plan.VectorDimensions() != r.def.Dimensions {
+		return columnVectorGraphRabitQQuantizedScorer{}, fmt.Errorf("%w: %w: column_graph %q query_mode=%s quantized index %q rabitq_1bit plan unavailable", ErrVectorIndexSearchUnavailable, errColumnVectorGraphQuantizedAssetInvalid, r.def.Name, mode.String(), indexName)
+	}
+	codeRows, ok := prepared.CodeRowView(quantizedasset.RolePackedCodes)
+	if !ok {
+		return columnVectorGraphRabitQQuantizedScorer{}, fmt.Errorf("%w: %w: column_graph %q query_mode=%s quantized index %q packed code row view unavailable", ErrVectorIndexSearchUnavailable, errColumnVectorGraphQuantizedAssetInvalid, r.def.Name, mode.String(), indexName)
+	}
+	if codeRows.Rows() != r.RowCount() {
+		return columnVectorGraphRabitQQuantizedScorer{}, fmt.Errorf("%w: %w: column_graph %q query_mode=%s quantized index %q packed code row view rows=%d want graph rows=%d", ErrVectorIndexSearchUnavailable, errColumnVectorGraphQuantizedAssetStale, r.def.Name, mode.String(), indexName, codeRows.Rows(), r.RowCount())
+	}
+	if bytesPerRow := codeRows.BytesPerRow(); bytesPerRow != plan.BytesPerCode() {
+		return columnVectorGraphRabitQQuantizedScorer{}, fmt.Errorf("%w: %w: column_graph %q query_mode=%s quantized index %q packed code bytes_per_row=%d want %d", ErrVectorIndexSearchUnavailable, errColumnVectorGraphQuantizedAssetInvalid, r.def.Name, mode.String(), indexName, bytesPerRow, plan.BytesPerCode())
+	}
+	if elements := codeRows.ElementsPerRow(); elements != plan.CodeDimensions() {
+		return columnVectorGraphRabitQQuantizedScorer{}, fmt.Errorf("%w: %w: column_graph %q query_mode=%s quantized index %q packed code elements_per_row=%d want %d", ErrVectorIndexSearchUnavailable, errColumnVectorGraphQuantizedAssetInvalid, r.def.Name, mode.String(), indexName, elements, plan.CodeDimensions())
+	}
+	codePayload, ok := codeRows.PayloadBytes()
+	if !ok || len(codePayload) != r.RowCount()*plan.BytesPerCode() {
+		return columnVectorGraphRabitQQuantizedScorer{}, fmt.Errorf("%w: %w: column_graph %q query_mode=%s quantized index %q packed code payload bytes=%d ok=%v want %d", ErrVectorIndexSearchUnavailable, errColumnVectorGraphQuantizedAssetInvalid, r.def.Name, mode.String(), indexName, len(codePayload), ok, r.RowCount()*plan.BytesPerCode())
+	}
+	codeCountPayload, ok := prepared.Uint32Payload(quantizedasset.RoleCodeCount)
+	if !ok || len(codeCountPayload) != r.RowCount()*4 {
+		return columnVectorGraphRabitQQuantizedScorer{}, fmt.Errorf("%w: %w: column_graph %q query_mode=%s quantized index %q code_count payload bytes=%d ok=%v want %d", ErrVectorIndexSearchUnavailable, errColumnVectorGraphQuantizedAssetInvalid, r.def.Name, mode.String(), indexName, len(codeCountPayload), ok, r.RowCount()*4)
+	}
+	qdpInvPayload, ok := prepared.Float32Payload(quantizedasset.RoleQuantizedDotProductInv)
+	if !ok || len(qdpInvPayload) != r.RowCount()*4 {
+		return columnVectorGraphRabitQQuantizedScorer{}, fmt.Errorf("%w: %w: column_graph %q query_mode=%s quantized index %q quantized_dot_product_inv payload bytes=%d ok=%v want %d", ErrVectorIndexSearchUnavailable, errColumnVectorGraphQuantizedAssetInvalid, r.def.Name, mode.String(), indexName, len(qdpInvPayload), ok, r.RowCount()*4)
+	}
+	encodedQuery, err := plan.EncodeQuery(query, &scratch.quantizedRabitQWorkspace)
+	if err != nil {
+		return columnVectorGraphRabitQQuantizedScorer{}, fmt.Errorf("%w: %w: column_graph %q query_mode=%s quantized index %q rabitq_1bit query encode: %v", ErrVectorIndexSearchUnavailable, errColumnVectorGraphQuantizedAssetInvalid, r.def.Name, mode.String(), indexName, err)
+	}
+	return columnVectorGraphRabitQQuantizedScorer{indexName: indexName, plan: plan, query: encodedQuery, codeRows: codeRows, codePayload: codePayload, codeCountPayload: codeCountPayload, quantizedDotProductInvPayload: qdpInvPayload, bytesPerCode: plan.BytesPerCode(), codeDimensions: plan.CodeDimensions()}, nil
+}
+
+func (s *columnVectorGraphRabitQQuantizedScorer) scoreOrdinal(ordinal int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) (float64, error) {
+	if err := s.validate(); err != nil {
+		return 0, err
+	}
+	if scratch == nil {
+		return 0, fmt.Errorf("collections: column_graph quantized rabitq_1bit scorer: %w", errColumnVectorGraphNativeSearchScratchRequired)
+	}
+	score, err := s.scoreOrdinalUnchecked(ordinal)
+	if err != nil {
+		return 0, err
+	}
+	if stats != nil {
+		recordColumnVectorGraphScoreBatchStats(stats, 1, false, true)
+		s.recordScoreStats(stats, 1)
+	}
+	return score, nil
+}
+
+func (s *columnVectorGraphRabitQQuantizedScorer) scoreOrdinals(ordinals []int, dst []float64, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) ([]float64, error) {
+	if cap(dst) < len(ordinals) {
+		dst = make([]float64, len(ordinals))
+	} else {
+		dst = dst[:len(ordinals)]
+	}
+	if len(ordinals) == 0 {
+		return dst, nil
+	}
+	if err := s.validate(); err != nil {
+		return dst[:0], err
+	}
+	if scratch == nil {
+		return dst[:0], fmt.Errorf("collections: column_graph quantized rabitq_1bit scorer: %w", errColumnVectorGraphNativeSearchScratchRequired)
+	}
+	for i, ordinal := range ordinals {
+		score, err := s.scoreOrdinalUnchecked(ordinal)
+		if err != nil {
+			return dst[:i], err
+		}
+		dst[i] = score
+	}
+	if stats != nil {
+		recordColumnVectorGraphScoreBatchStats(stats, len(ordinals), false, true)
+		s.recordScoreStats(stats, len(ordinals))
+	}
+	return dst, nil
+}
+
+func (s *columnVectorGraphRabitQQuantizedScorer) validate() error {
+	if s == nil || s.plan == nil || !s.codeRows.Valid() || s.bytesPerCode <= 0 || s.codeDimensions <= 0 || len(s.codePayload) != s.codeRows.Rows()*s.bytesPerCode || len(s.codeCountPayload) != s.codeRows.Rows()*4 || len(s.quantizedDotProductInvPayload) != s.codeRows.Rows()*4 || !rabitqQueryShapeValidForPlan(s.query, s.plan) {
+		return fmt.Errorf("%w: column_graph quantized rabitq_1bit scorer is unavailable", ErrVectorIndexSearchUnavailable)
+	}
+	return nil
+}
+
+func (s *columnVectorGraphRabitQQuantizedScorer) scoreOrdinalUnchecked(ordinal int) (float64, error) {
+	rows := s.codeRows.Rows()
+	if ordinal < 0 || ordinal >= rows {
+		return 0, fmt.Errorf("%w: column_graph quantized index %q rabitq_1bit code row ordinal=%d unavailable want rows=%d", ErrVectorIndexSearchUnavailable, s.indexName, ordinal, rows)
+	}
+	start := ordinal * s.bytesPerCode
+	end := start + s.bytesPerCode
+	if start < 0 || end < start || end > len(s.codePayload) {
+		return 0, fmt.Errorf("%w: column_graph quantized index %q rabitq_1bit code row ordinal=%d range [%d,%d) outside payload=%d", ErrVectorIndexSearchUnavailable, s.indexName, ordinal, start, end, len(s.codePayload))
+	}
+	sideStart := ordinal * 4
+	if sideStart < 0 || sideStart > len(s.codeCountPayload)-4 || sideStart > len(s.quantizedDotProductInvPayload)-4 {
+		return 0, fmt.Errorf("%w: column_graph quantized index %q rabitq_1bit side row ordinal=%d unavailable", ErrVectorIndexSearchUnavailable, s.indexName, ordinal)
+	}
+	code := s.codePayload[start:end]
+	codeCount := binary.LittleEndian.Uint32(s.codeCountPayload[sideStart : sideStart+4])
+	if codeCount > uint32(s.codeDimensions) {
+		return 0, fmt.Errorf("%w: column_graph quantized index %q rabitq_1bit code_count ordinal=%d value=%d exceeds code_dimensions=%d", ErrVectorIndexSearchUnavailable, s.indexName, ordinal, codeCount, s.codeDimensions)
+	}
+	qdpInv := math.Float32frombits(binary.LittleEndian.Uint32(s.quantizedDotProductInvPayload[sideStart : sideStart+4]))
+	score, ok := rabitqQuantizedCosineScore(s.query, code, qdpInv)
+	if !ok {
+		return 0, fmt.Errorf("%w: column_graph quantized index %q rabitq_1bit score ordinal=%d unavailable", ErrVectorIndexSearchUnavailable, s.indexName, ordinal)
+	}
+	return score, nil
+}
+
+func (s *columnVectorGraphRabitQQuantizedScorer) recordScoreStats(stats *columnVectorGraphNativeSearchStats, count int) {
+	if stats == nil || count <= 0 {
+		return
+	}
+	count64 := uint64(count)
+	stats.VisitedNodes += count64
+	stats.CandidateFetches += count64
+	stats.QuantizedScoreCalls += count64
+	stats.QuantizedCodeBytesRead += count64 * uint64(s.bytesPerCode)
+}
+
+func rabitqQueryShapeValidForPlan(query rabitq.Query, plan *rabitq.Plan) bool {
+	return plan != nil && query.CodeDimensions == plan.CodeDimensions() && len(query.SignBits) == plan.BytesPerCode() && len(query.AbsWeights) == plan.CodeDimensions() && query.WeightSum > 0 && !math.IsNaN(float64(query.WeightSum)) && !math.IsInf(float64(query.WeightSum), 0)
+}
+
+func rabitqQuantizedCosineScore(query rabitq.Query, code []byte, quantizedDotProductInv float32) (float64, bool) {
+	if query.CodeDimensions <= 0 || len(query.AbsWeights) < query.CodeDimensions || len(query.SignBits) == 0 || len(code) != len(query.SignBits) || quantizedDotProductInv <= 0 || math.IsNaN(float64(quantizedDotProductInv)) || math.IsInf(float64(quantizedDotProductInv), 0) {
+		return 0, false
+	}
+	var weightedSignDot float64
+	for i, weight32 := range query.AbsWeights[:query.CodeDimensions] {
+		weight := float64(weight32)
+		if math.IsNaN(weight) || math.IsInf(weight, 0) || weight < 0 {
+			return 0, false
+		}
+		mask := byte(1 << uint(i&7))
+		if (code[i>>3]&mask != 0) == (query.SignBits[i>>3]&mask != 0) {
+			weightedSignDot += weight
+		} else {
+			weightedSignDot -= weight
+		}
+	}
+	score := weightedSignDot / (float64(quantizedDotProductInv) * float64(query.CodeDimensions))
+	if math.IsNaN(score) || math.IsInf(score, 0) {
+		return 0, false
+	}
+	return score, true
 }
 
 func scalarU8CenteredQuantizedCosineScore(query vectorops.ScalarU8CenteredQuery, row []byte) (float64, bool) {

--- a/TreeDB/collections/column_vector_graph_rabitq_quantized_asset_test.go
+++ b/TreeDB/collections/column_vector_graph_rabitq_quantized_asset_test.go
@@ -86,8 +86,13 @@ func TestColumnGraphRabitQQuantizedAssetRebuildPrepareReopen2450(t *testing.T) {
 		t.Fatalf("reader Close: %v", err)
 	}
 
-	if _, err := col.SearchVectorIndex(VectorIndexSearchOptions{IndexName: def.Name, Query: []float32{1, 0, 0}, QueryMode: VectorIndexQueryModeQuantizedOnly, QuantizedIndexName: q.Name, TopK: 1, EfSearch: len(rows), MaxDecodedBlocks: 1}); !errors.Is(err, ErrVectorIndexSearchUnavailable) || !strings.Contains(err.Error(), "not scalar_u8") {
-		t.Fatalf("rabitq quantized_only err=%v want fail-closed unavailable without exact fallback", err)
+	quantized, err := col.SearchVectorIndex(VectorIndexSearchOptions{IndexName: def.Name, Query: []float32{1, 0, 0}, QueryMode: VectorIndexQueryModeQuantizedOnly, QuantizedIndexName: q.Name, TopK: 1, EfSearch: len(rows), MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("rabitq quantized_only SearchVectorIndex: %v", err)
+	}
+	assertVectorIndexSearchResultsV4(t, quantized.Results, rabitqQuantizedTopKForTest2451(t, rows, []float32{1, 0, 0}, 1), false)
+	if quantized.Stats.QuantizedScoreCalls == 0 || quantized.Stats.PreparedScoreCalls != 0 || quantized.Stats.VectorBytesRead != 0 || quantized.Stats.NormBytesRead != 0 {
+		t.Fatalf("rabitq quantized stats=%+v want code scoring without exact vector/norm scoring", quantized.Stats)
 	}
 	if exact, err := col.SearchVectorIndex(VectorIndexSearchOptions{IndexName: def.Name, Query: []float32{1, 0, 0}, QueryMode: VectorIndexQueryModeExact, TopK: 1, EfSearch: len(rows), MaxDecodedBlocks: 1}); err != nil || len(exact.Results) != 1 {
 		t.Fatalf("exact SearchVectorIndex results=%d err=%v", len(exact.Results), err)
@@ -115,6 +120,275 @@ func TestColumnGraphRabitQQuantizedAssetRebuildPrepareReopen2450(t *testing.T) {
 		t.Fatalf("reopened reader rabitq status=%+v", reopenedStatus)
 	}
 	assertPreparedRabitQRows2450(t, reopenedStatus.Prepared, def, scannedRows)
+}
+
+func TestVectorIndexSearcherRabitQQuantizedSearchWithBuffer2451(t *testing.T) {
+	rows := []columnGraphRebuildInputRowV2A{
+		{id: "doc-a", vector: []float32{1, 0, 0}},
+		{id: "doc-b", vector: []float32{0.5, 0.5, 0}},
+		{id: "doc-c", vector: []float32{0, 1, 0}},
+		{id: "doc-d", vector: []float32{0, 0, 1}},
+		{id: "doc-e", vector: []float32{-0.25, 0.75, 0.125}},
+	}
+	query := []float32{0.2, 0.9, 0.1}
+	_, d, col, def := openColumnGraphRabitQQuantizedTestCollection2450(t, rows)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	searcher, err := col.OpenVectorIndexSearcher(VectorIndexSearcherOptions{IndexName: def.Name, MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("OpenVectorIndexSearcher: %v", err)
+	}
+	defer func() { _ = searcher.Close() }()
+	q := def.QuantizedIndexes[0]
+	plan, err := rabitq.NewPlan(def.Dimensions, rabitq.DefaultConfig())
+	if err != nil {
+		t.Fatalf("rabitq.NewPlan: %v", err)
+	}
+	var buffer VectorIndexSearchBuffer
+
+	if _, err := searcher.SearchWithBuffer(VectorIndexSearcherSearchOptions{Query: query, QueryMode: VectorIndexQueryModeExact, QuantizedIndexName: q.Name, TopK: 1, EfSearch: len(rows)}, &buffer); err == nil || !strings.Contains(err.Error(), "exact") {
+		t.Fatalf("exact SearchWithBuffer with rabitq index err=%v want exact quantized-option rejection", err)
+	}
+	if _, err := searcher.SearchWithBuffer(VectorIndexSearcherSearchOptions{Query: query, QuantizedRerankCandidates: 2, TopK: 1, EfSearch: len(rows)}, &buffer); err == nil || !strings.Contains(err.Error(), "exact") || !strings.Contains(err.Error(), "rerank") {
+		t.Fatalf("default exact SearchWithBuffer with rerank candidates err=%v want exact quantized-option rejection", err)
+	}
+
+	quantizedOnly, err := searcher.SearchWithBuffer(VectorIndexSearcherSearchOptions{Query: query, QueryMode: VectorIndexQueryModeQuantizedOnly, QuantizedIndexName: q.Name, TopK: 3, EfSearch: len(rows)}, &buffer)
+	if err != nil {
+		t.Fatalf("rabitq quantized_only SearchWithBuffer: %v", err)
+	}
+	assertVectorIndexSearchResultsV4(t, quantizedOnly.Results, rabitqQuantizedTopKForTest2451(t, rows, query, 3), false)
+	assertRabitQQuantizedOnlyStats2451(t, quantizedOnly.Stats, plan.BytesPerCode())
+
+	var collectionBuffer VectorIndexSearchBuffer
+	collectionGot, err := col.SearchVectorIndexWithBuffer(VectorIndexSearchOptions{IndexName: def.Name, Query: query, QueryMode: VectorIndexQueryModeQuantizedOnly, QuantizedIndexName: q.Name, TopK: 3, EfSearch: len(rows), MaxDecodedBlocks: 1}, &collectionBuffer)
+	if !errors.Is(err, ErrVectorIndexSearchUnavailable) || !strings.Contains(err.Error(), "does not yet support rabitq_1bit") || len(collectionGot.Results) != 0 {
+		t.Fatalf("collection SearchVectorIndexWithBuffer rabitq response=%+v err=%v want scoped unsupported fail-closed", collectionGot, err)
+	}
+
+	rerankedAll, err := searcher.SearchWithBuffer(VectorIndexSearcherSearchOptions{Query: query, QueryMode: VectorIndexQueryModeQuantizedRerank, QuantizedIndexName: q.Name, QuantizedRerankCandidates: len(rows), TopK: 2, EfSearch: len(rows)}, &buffer)
+	if err != nil {
+		t.Fatalf("rabitq quantized_rerank all SearchWithBuffer: %v", err)
+	}
+	assertVectorIndexSearchResultsV4(t, rerankedAll.Results, exactColumnGraphTopKForTest(t, rows, query, 2), false)
+	assertRabitQQuantizedRerankStats2451(t, rerankedAll.Stats, len(rows), def.Dimensions, plan.BytesPerCode())
+
+	const shortlist = 3
+	rerankedShort, err := searcher.SearchWithBuffer(VectorIndexSearcherSearchOptions{Query: query, QueryMode: VectorIndexQueryModeQuantizedRerank, QuantizedIndexName: q.Name, QuantizedRerankCandidates: shortlist, TopK: 2, EfSearch: len(rows)}, &buffer)
+	if err != nil {
+		t.Fatalf("rabitq quantized_rerank short SearchWithBuffer: %v", err)
+	}
+	if len(rerankedShort.Results) != 2 {
+		t.Fatalf("rabitq quantized_rerank short results=%d want 2", len(rerankedShort.Results))
+	}
+	assertRabitQQuantizedRerankStats2451(t, rerankedShort.Stats, shortlist, def.Dimensions, plan.BytesPerCode())
+}
+
+func TestColumnGraphRabitQQuantizedScorerMatchesOracle2451(t *testing.T) {
+	rows := []columnGraphRebuildInputRowV2A{
+		{id: "doc-a", vector: []float32{1, 0, -1}},
+		{id: "doc-b", vector: []float32{0.5, -0.5, 0.25}},
+		{id: "doc-c", vector: []float32{-0.25, 0.75, 0.125}},
+		{id: "doc-d", vector: []float32{0.1, 0.2, 0.95}},
+	}
+	query := []float32{0.15, -0.35, 0.75}
+	_, d, col, def := openColumnGraphRabitQQuantizedTestCollection2450(t, rows)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	reader, err := col.openColumnVectorGraphPhysicalRowReader(def.Name, columnVectorGraphPhysicalRowReaderOptions{MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("open reader: %v", err)
+	}
+	defer func() { _ = reader.Close() }()
+	q := def.QuantizedIndexes[0]
+	status := reader.quantizedAssetStatus[q.Name]
+	if status.Prepared == nil || status.RabitQPlan == nil || status.Err != nil {
+		t.Fatalf("rabitq prepared status=%+v", status)
+	}
+	var scratch columnVectorGraphNativeSearchScratch
+	scorer, err := reader.prepareRabitQQuantizedScorer(columnVectorGraphNativeSearchQueryModeQuantizedOnly, q.Name, query, &scratch)
+	if err != nil {
+		t.Fatalf("prepareRabitQQuantizedScorer: %v", err)
+	}
+	ordinals := []int{0, 1, 2, 3}
+	var stats columnVectorGraphNativeSearchStats
+	scores, err := scorer.scoreOrdinals(ordinals, nil, &scratch, &stats)
+	if err != nil {
+		t.Fatalf("scoreOrdinals: %v", err)
+	}
+	oracleQuery, err := status.RabitQPlan.EncodeQuery(query, &rabitq.Workspace{})
+	if err != nil {
+		t.Fatalf("oracle EncodeQuery: %v", err)
+	}
+	view, ok := status.Prepared.CodeRowView(quantizedasset.RolePackedCodes)
+	if !ok {
+		t.Fatal("prepared packed code view unavailable")
+	}
+	for i, ordinal := range ordinals {
+		code, ok := view.RowBytes(ordinal)
+		if !ok {
+			t.Fatalf("row %d code unavailable", ordinal)
+		}
+		codeCount, ok := status.Prepared.Uint32(quantizedasset.RoleCodeCount, ordinal)
+		if !ok {
+			t.Fatalf("row %d code_count unavailable", ordinal)
+		}
+		qdpInv, ok := status.Prepared.Float32(quantizedasset.RoleQuantizedDotProductInv, ordinal)
+		if !ok {
+			t.Fatalf("row %d qdp unavailable", ordinal)
+		}
+		want, err := status.RabitQPlan.ScoreCosine(oracleQuery, code, codeCount, qdpInv)
+		if err != nil {
+			t.Fatalf("oracle ScoreCosine ordinal=%d: %v", ordinal, err)
+		}
+		if math.Abs(scores[i]-want) > 1e-9 {
+			t.Fatalf("ordinal=%d score=%v want oracle=%v", ordinal, scores[i], want)
+		}
+	}
+	if stats.QuantizedScoreCalls != uint64(len(ordinals)) || stats.QuantizedCodeBytesRead != uint64(len(ordinals)*status.RabitQPlan.BytesPerCode()) || stats.VectorBytesRead != 0 || stats.NormBytesRead != 0 {
+		t.Fatalf("rabitq scorer stats=%+v want packed code reads only", stats)
+	}
+	_, err = scorer.scoreOrdinals([]int{0, len(rows)}, scores[:0], &scratch, &columnVectorGraphNativeSearchStats{})
+	if !errors.Is(err, ErrVectorIndexSearchUnavailable) || !strings.Contains(err.Error(), "ordinal=4") {
+		t.Fatalf("invalid ordinal err=%v want fail-closed unavailable", err)
+	}
+	if _, err = scorer.scoreOrdinals(ordinals, scores[:0], nil, &columnVectorGraphNativeSearchStats{}); !errors.Is(err, errColumnVectorGraphNativeSearchScratchRequired) {
+		t.Fatalf("nil scratch err=%v want scratch required", err)
+	}
+
+	_, err = scorer.scoreOrdinals(ordinals, scores[:0], &scratch, &columnVectorGraphNativeSearchStats{})
+	if err != nil {
+		t.Fatalf("warm scoreOrdinals: %v", err)
+	}
+	allocs := testing.AllocsPerRun(1000, func() {
+		got, err := scorer.scoreOrdinals(ordinals, scores[:0], &scratch, &columnVectorGraphNativeSearchStats{})
+		if err != nil {
+			panic(err)
+		}
+		columnPhysicalScanBenchSum += int64(got[0] * 1_000_000)
+	})
+	if allocs != 0 {
+		t.Fatalf("steady-state rabitq scoreOrdinals allocs/run=%v want 0", allocs)
+	}
+}
+
+func TestVectorIndexSearcherRabitQQuantizedFailClosedStats2451(t *testing.T) {
+	rows := []columnGraphRebuildInputRowV2A{
+		{id: "doc-a", vector: []float32{1, 0, 0}},
+		{id: "doc-b", vector: []float32{0, 1, 0}},
+		{id: "doc-c", vector: []float32{0, 0, 1}},
+	}
+	query := []float32{1, 0, 0}
+	_, d, col, def := openColumnGraphRabitQQuantizedTestCollection2450(t, rows)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	q := def.QuantizedIndexes[0]
+	cases := []struct {
+		name   string
+		status *columnVectorGraphQuantizedAssetLoadStatus
+		health columnVectorGraphQuantizedAssetHealth
+	}{
+		{name: "missing_status", health: columnVectorGraphQuantizedAssetHealthMissing},
+		{name: "missing_asset", status: &columnVectorGraphQuantizedAssetLoadStatus{Definition: q, Err: errColumnVectorGraphQuantizedAssetMissing}, health: columnVectorGraphQuantizedAssetHealthMissing},
+		{name: "invalid_asset", status: &columnVectorGraphQuantizedAssetLoadStatus{Definition: q, Err: errColumnVectorGraphQuantizedAssetInvalid}, health: columnVectorGraphQuantizedAssetHealthInvalid},
+		{name: "stale_asset", status: &columnVectorGraphQuantizedAssetLoadStatus{Definition: q, Err: errColumnVectorGraphQuantizedAssetStale}, health: columnVectorGraphQuantizedAssetHealthStale},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			searcher, err := col.OpenVectorIndexSearcher(VectorIndexSearcherOptions{IndexName: def.Name, MaxDecodedBlocks: 1})
+			if err != nil {
+				t.Fatalf("OpenVectorIndexSearcher: %v", err)
+			}
+			defer func() { _ = searcher.Close() }()
+			if tc.status == nil {
+				delete(searcher.reader.quantizedAssetStatus, q.Name)
+			} else {
+				searcher.reader.quantizedAssetStatus[q.Name] = *tc.status
+			}
+			var buffer VectorIndexSearchBuffer
+			got, err := searcher.SearchWithBuffer(VectorIndexSearcherSearchOptions{Query: query, QueryMode: VectorIndexQueryModeQuantizedOnly, QuantizedIndexName: q.Name, TopK: 1, EfSearch: len(rows)}, &buffer)
+			if !errors.Is(err, ErrVectorIndexSearchUnavailable) || len(got.Results) != 0 {
+				t.Fatalf("SearchWithBuffer response=%+v err=%v want fail-closed unavailable", got, err)
+			}
+			assertQuantizedUnavailableGuardrailStats2416(t, got.Stats, columnVectorGraphNativeSearchQueryModeQuantizedOnly, tc.health)
+			if got.Stats.QuantizedScoreCalls != 0 || got.Stats.PreparedScoreCalls != 0 || got.Stats.VectorBytesRead != 0 || got.Stats.NormBytesRead != 0 {
+				t.Fatalf("fail-closed stats=%+v want no scoring or exact fallback", got.Stats)
+			}
+		})
+	}
+}
+
+func assertRabitQQuantizedOnlyStats2451(tb testing.TB, stats VectorIndexSearchStats, bytesPerCode int) {
+	tb.Helper()
+	if stats.SearchRouteQuantizedOnly != 1 || stats.SearchRouteQuantizedRerank != 0 || stats.QuantizedScorerActive != 1 {
+		tb.Fatalf("rabitq quantized_only route stats=%+v", stats)
+	}
+	if stats.QuantizedScoreCalls == 0 || stats.QuantizedCodeBytesRead != stats.QuantizedScoreCalls*uint64(bytesPerCode) {
+		tb.Fatalf("rabitq quantized_only code stats=%+v bytes_per_code=%d", stats, bytesPerCode)
+	}
+	if stats.PreparedScoreCalls != 0 || stats.QuantizedRerankCandidates != 0 || stats.QuantizedRerankExactScoreCalls != 0 || stats.VectorBytesRead != 0 || stats.NormBytesRead != 0 || stats.DocumentsFetched != 0 {
+		tb.Fatalf("rabitq quantized_only exact/doc stats=%+v want none", stats)
+	}
+}
+
+func assertRabitQQuantizedRerankStats2451(tb testing.TB, stats VectorIndexSearchStats, shortlist int, dims int, bytesPerCode int) {
+	tb.Helper()
+	if stats.SearchRouteQuantizedOnly != 0 || stats.SearchRouteQuantizedRerank != 1 || stats.QuantizedScorerActive != 1 {
+		tb.Fatalf("rabitq quantized_rerank route stats=%+v", stats)
+	}
+	if stats.QuantizedScoreCalls == 0 || stats.QuantizedCodeBytesRead != stats.QuantizedScoreCalls*uint64(bytesPerCode) {
+		tb.Fatalf("rabitq quantized_rerank code stats=%+v bytes_per_code=%d", stats, bytesPerCode)
+	}
+	if stats.QuantizedRerankCandidates != uint64(shortlist) || stats.QuantizedRerankExactScoreCalls != uint64(shortlist) {
+		tb.Fatalf("rabitq quantized_rerank exact calls stats=%+v shortlist=%d", stats, shortlist)
+	}
+	if stats.VectorBytesRead != uint64(shortlist*dims*4) || stats.NormBytesRead != uint64(shortlist*4) {
+		tb.Fatalf("rabitq quantized_rerank exact bytes stats=%+v want vector=%d norm=%d", stats, shortlist*dims*4, shortlist*4)
+	}
+	if stats.DocumentsFetched != 0 {
+		tb.Fatalf("rabitq quantized_rerank stats=%+v want no documents", stats)
+	}
+}
+
+func rabitqQuantizedTopKForTest2451(tb testing.TB, rows []columnGraphRebuildInputRowV2A, query []float32, topK int) []columnVectorGraphNativeSearchResult {
+	tb.Helper()
+	if len(rows) == 0 || topK <= 0 {
+		return nil
+	}
+	plan, err := rabitq.NewPlan(len(query), rabitq.DefaultConfig())
+	if err != nil {
+		tb.Fatalf("rabitq.NewPlan: %v", err)
+	}
+	var ws rabitq.Workspace
+	encodedQuery, err := plan.EncodeQuery(query, &ws)
+	if err != nil {
+		tb.Fatalf("rabitq EncodeQuery: %v", err)
+	}
+	var top []columnVectorGraphSearchCandidate
+	var codeScratch []byte
+	for ordinal, row := range rows {
+		encoded, err := plan.Encode(codeScratch, row.vector, &ws)
+		if err != nil {
+			tb.Fatalf("rabitq Encode row %d: %v", ordinal, err)
+		}
+		codeScratch = encoded.Code
+		score, err := plan.ScoreEncoded(encodedQuery, encoded)
+		if err != nil {
+			tb.Fatalf("rabitq ScoreEncoded row %d: %v", ordinal, err)
+		}
+		top = insertColumnGraphTopForTest(top, topK, columnVectorGraphSearchCandidate{ordinal: ordinal, score: score})
+	}
+	out := make([]columnVectorGraphNativeSearchResult, len(top))
+	for i, candidate := range top {
+		out[i] = columnVectorGraphNativeSearchResult{Ordinal: candidate.ordinal, ID: []byte(rows[candidate.ordinal].id), Score: candidate.score}
+	}
+	return out
 }
 
 func TestColumnGraphRabitQQuantizedAssetFailClosed2450(t *testing.T) {

--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"sort"
 
+	"github.com/snissn/gomap/TreeDB/internal/rabitq"
 	"github.com/snissn/gomap/TreeDB/internal/typedcolumn"
 	"github.com/snissn/gomap/TreeDB/internal/typeddecode"
 	"github.com/snissn/gomap/TreeDB/internal/vectorops"
@@ -973,29 +974,30 @@ type columnVectorGraphSearchCandidate struct {
 // It is not concurrency-safe. Parallel searches over immutable graph assets are
 // valid with one reader and one scratch per worker.
 type columnVectorGraphNativeSearchScratch struct {
-	scoreScratch           columnPhysicalRowReaderScratch
-	expandScratch          columnPhysicalRowReaderScratch
-	resultScratch          columnPhysicalRowReaderScratch
-	visitMarks             []uint64
-	visitEpoch             uint64
-	frontier               []columnVectorGraphSearchCandidate
-	top                    []columnVectorGraphSearchCandidate
-	results                []columnVectorGraphNativeSearchResult
-	idBuffers              [][]byte
-	resultIDViews          [][]byte
-	resultOrder            []int
-	resultOrdinals         []int
-	resultRowRefs          []DocumentRowRef
-	resultHasRefs          []bool
-	scoreTileOrdinals      []int
-	scoreTileScores        []float64
-	scoreTileRowIDs        []uint32
-	scoreTileDots          []float32
-	scoreTileQuantizedDots []int64
-	quantizedQueryCodes    []byte
-	quantizedQueryCentered []vectorops.ScalarU8CenteredCode
-	wavefrontCandidates    []columnVectorGraphSearchCandidate
-	searchPlan             columnVectorGraphSearchPlan
+	scoreScratch             columnPhysicalRowReaderScratch
+	expandScratch            columnPhysicalRowReaderScratch
+	resultScratch            columnPhysicalRowReaderScratch
+	visitMarks               []uint64
+	visitEpoch               uint64
+	frontier                 []columnVectorGraphSearchCandidate
+	top                      []columnVectorGraphSearchCandidate
+	results                  []columnVectorGraphNativeSearchResult
+	idBuffers                [][]byte
+	resultIDViews            [][]byte
+	resultOrder              []int
+	resultOrdinals           []int
+	resultRowRefs            []DocumentRowRef
+	resultHasRefs            []bool
+	scoreTileOrdinals        []int
+	scoreTileScores          []float64
+	scoreTileRowIDs          []uint32
+	scoreTileDots            []float32
+	scoreTileQuantizedDots   []int64
+	quantizedQueryCodes      []byte
+	quantizedQueryCentered   []vectorops.ScalarU8CenteredCode
+	quantizedRabitQWorkspace rabitq.Workspace
+	wavefrontCandidates      []columnVectorGraphSearchCandidate
+	searchPlan               columnVectorGraphSearchPlan
 }
 
 func (s *columnVectorGraphNativeSearchScratch) prepare(rowCount, dimensions, degree, topK, efSearch, scoreTileCapacity, wavefrontWidth int) error {
@@ -1463,7 +1465,7 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosine(query []float32, opts 
 		return nil, stats, err
 	}
 	if queryMode.quantized() {
-		plan.quantizedScorer, err = r.prepareScalarU8QuantizedScorer(queryMode, opts.QuantizedIndexName, query, queryInvNorm, scratch)
+		plan.quantizedScorer, err = r.prepareQuantizedScorer(queryMode, opts.QuantizedIndexName, query, queryInvNorm, scratch)
 		if err != nil {
 			recordColumnVectorGraphQuantizedAssetErrorStats(&stats, err)
 			return nil, stats, err

--- a/TreeDB/internal/quantizedasset/quantized_asset.go
+++ b/TreeDB/internal/quantizedasset/quantized_asset.go
@@ -856,28 +856,50 @@ func (p *Prepared) CodeRowBytes(role Role, ordinal int) ([]byte, bool) {
 
 // Float32 returns a scalar side-array value for role/ordinal.
 func (p *Prepared) Float32(role Role, ordinal int) (float32, bool) {
-	col, ok := p.preparedColumn(role)
-	if !ok || col.kind != preparedColumnScalarFloat32 || !col.validOrdinal(ordinal) {
+	payload, ok := p.Float32Payload(role)
+	if !ok || ordinal < 0 || ordinal >= len(payload)/4 {
 		return 0, false
 	}
 	start := ordinal * 4
-	if start < 0 || start > len(col.payload)-4 {
-		return 0, false
+	return math.Float32frombits(binary.LittleEndian.Uint32(payload[start : start+4])), true
+}
+
+// Float32Payload returns the immutable little-endian scalar float32 payload for
+// role. The slice aliases prepared image bytes and must be treated as read-only.
+func (p *Prepared) Float32Payload(role Role) ([]byte, bool) {
+	col, ok := p.preparedColumn(role)
+	if !ok || col.kind != preparedColumnScalarFloat32 || col.rows < 0 {
+		return nil, false
 	}
-	return math.Float32frombits(binary.LittleEndian.Uint32(col.payload[start : start+4])), true
+	want, err := checkedMul(col.rows, 4)
+	if err != nil || len(col.payload) != want {
+		return nil, false
+	}
+	return col.payload, true
 }
 
 // Uint32 returns a uint32 scalar side-array value for role/ordinal.
 func (p *Prepared) Uint32(role Role, ordinal int) (uint32, bool) {
-	col, ok := p.preparedColumn(role)
-	if !ok || col.kind != preparedColumnScalarUint32 || !col.validOrdinal(ordinal) {
+	payload, ok := p.Uint32Payload(role)
+	if !ok || ordinal < 0 || ordinal >= len(payload)/4 {
 		return 0, false
 	}
 	start := ordinal * 4
-	if start < 0 || start > len(col.payload)-4 {
-		return 0, false
+	return binary.LittleEndian.Uint32(payload[start : start+4]), true
+}
+
+// Uint32Payload returns the immutable little-endian scalar uint32 payload for
+// role. The slice aliases prepared image bytes and must be treated as read-only.
+func (p *Prepared) Uint32Payload(role Role) ([]byte, bool) {
+	col, ok := p.preparedColumn(role)
+	if !ok || col.kind != preparedColumnScalarUint32 || col.rows < 0 {
+		return nil, false
 	}
-	return binary.LittleEndian.Uint32(col.payload[start : start+4]), true
+	want, err := checkedMul(col.rows, 4)
+	if err != nil || len(col.payload) != want {
+		return nil, false
+	}
+	return col.payload, true
 }
 
 // Uint64 returns a uint64 scalar side-array value for role/ordinal.


### PR DESCRIPTION
## Objective

Add lower-level `VectorIndexSearcher.SearchWithBuffer` support for TreeDB `rabitq_1bit` v1 `quantized_only` and `quantized_rerank` scoring.

Closes #2451. Parent tracker: #2447.

## Final-base status

- Base branch: `main`
- Current `main` base SHA: `127e052d3a0d74ae711aa166c889f38604f989ed`
- #2450 / PR #2467 merged into `main` at: `127e052d3a0d74ae711aa166c889f38604f989ed`
- Final #2467 head included in `main`: `42790f8e35cd949bbcfc2a9e2c4a0a7fd1de807e`
- Current PR head: `2c319469756d38e6ad6a261b6dea0bef9ae9c29c`
- Branch sync note: the PR branch was fast-forwarded with a main-first merge commit because repository rules block force-push rewrites on this branch. The PR diff against `main` is scoped to the eight #2451-owned files.

## Scope

- Dispatch column_graph quantized scoring by codec while preserving existing `scalar_u8` behavior.
- Add a RaBitQ scorer over the prepared `packed_codes`, `code_count`, and `quantized_dot_product_inv` assets from #2450.
- Encode RaBitQ query scratch via caller-owned search scratch and keep warmed `SearchWithBuffer` no-document rows allocation-free.
- Use RaBitQ traversal/final scoring for `quantized_only`.
- Use RaBitQ traversal plus exact shortlist rerank for `quantized_rerank`.
- Keep counters codec-generic: quantized routes/scorer active, asset health/unavailable, quantized score/code bytes, and exact rerank/vector/norm reads.
- Keep `Collection.SearchVectorIndexWithBuffer` RaBitQ support out of scope; it fails closed and points callers at lower-level `VectorIndexSearcher.SearchWithBuffer` until #2452.

## Non-goals

- No collection-level buffered RaBitQ route.
- No SIMD/go-highway backend.
- No durable asset format changes.
- No scalar_u8 behavior changes.
- No hidden exact fallback for explicit quantized modes.

## Correctness / guardrails

- `quantized_only` asserts zero exact vector/norm reads and zero exact rerank score calls.
- `quantized_rerank` asserts exact score calls and vector/norm bytes equal the configured shortlist.
- Missing/invalid/stale RaBitQ asset states fail closed with unavailable counters and no exact fallback.
- Exact/default paths reject RaBitQ-specific quantized options via existing exact quantized-option rules.
- Deterministic scorer/search tests compare RaBitQ SearchWithBuffer scores/results with the pure-Go `TreeDB/internal/rabitq` oracle.

## Tests run on final `main` base

Artifacts are under `/tmp/gomap_2451_final_main_evidence/`.

```sh
go test ./TreeDB/collections -run 'Test(ColumnGraphRabitQQuantizedAssetRebuildPrepareReopen2450|VectorIndexSearcherRabitQQuantizedSearchWithBuffer2451|ColumnGraphRabitQQuantizedScorerMatchesOracle2451|VectorIndexSearcherRabitQQuantizedFailClosedStats2451)' -count=1 -v
```

Result: pass (`ok github.com/snissn/gomap/TreeDB/collections 0.952s`).

```sh
go test ./TreeDB/collections -run 'Test(VectorIndexSearcherRabitQQuantizedSearchWithBuffer2451|ColumnGraphRabitQQuantizedScorerMatchesOracle2451|VectorIndexSearcherRabitQQuantizedFailClosedStats2451|SearchVectorIndexQuantizedOnlyAndRerankSupported1926)' -count=1
```

Result: pass (`ok github.com/snissn/gomap/TreeDB/collections 0.835s`).

```sh
go test ./TreeDB/internal/rabitq ./TreeDB/internal/quantizedasset ./TreeDB/collections
```

Result: pass (`TreeDB/collections 47.802s`, other packages cached/pass).

```sh
go test ./TreeDB/...
```

Result: pass.

```sh
git diff --check origin/main...HEAD
```

Result: pass/no output.

## Benchmark evidence on final `main` base

Apple M3 / darwin arm64, `rows=1024 dims=128 top_k=10 ef_search=128`.

### RaBitQ lower-level SearchWithBuffer

Command:

```sh
go test ./TreeDB/collections -run '^$' -bench '^BenchmarkVectorIndexSearcherColumnGraphRabitQQuantizedSearchWithBuffer2451$' -benchmem -benchtime=100x -count=1
```

Artifact: `/tmp/gomap_2451_final_main_evidence/rabitq_searchwithbuffer_bench_100x.txt`.

| row | ns/op | ops/sec | B/op | allocs/op | recall@K | quantized_code_B/search | exact vector_B/search | exact rerank calls/search |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| `route=quantized_only/c=1` | 43,924 | 22,767 | 0 | 0 | 100% | 2,704 | 0 | 0 |
| `route=quantized_only/c=8` | 27,823 | 35,942 | 0 | 0 | 100% | 2,704 | 0 | 0 |
| `route=quantized_rerank/candidates=32/c=1` | 39,773 | 25,142 | 0 | 0 | 100% | 2,704 | 16,384 | 32 |
| `route=quantized_rerank/candidates=32/c=8` | 13,235 | 75,555 | 0 | 0 | 100% | 2,704 | 16,384 | 32 |

Interpretation: `quantized_only` stays on RaBitQ codes with no exact vector/norm reads or rerank calls. `quantized_rerank` uses RaBitQ traversal and exact-reads only the configured 32-candidate shortlist.

### RaBitQ score primitive

Command:

```sh
go test ./TreeDB/internal/rabitq -run '^$' -bench '^BenchmarkReferenceScoreCosine2449$' -benchmem -benchtime=100000x -count=1
```

Result: `261.9 ns/op`, `61.08 MB/s`, `0 B/op`, `0 allocs/op`.

### scalar_u8 dispatch guardrail

Command:

```sh
go test ./TreeDB/collections -run '^$' -bench '^BenchmarkVectorIndexSearcherColumnGraphScalarU8QuantizedSearchWithBuffer2414$' -benchmem -benchtime=100x -count=1
```

Artifact: `/tmp/gomap_2451_final_main_evidence/scalar_searchwithbuffer_bench_100x.txt`. Existing scalar_u8 rows remain at `0 allocs/op`; B/op is 0-1 bytes/op measurement noise with zero heap allocations.

## Review / CI status

- Latest-head CI: running for final-main head `2c319469756d38e6ad6a261b6dea0bef9ae9c29c`.
- Internal review: completed locally against `origin/main`; final diff is scoped to the eight #2451-owned files, and no known correctness/performance blockers are open.
- AI reviews: CodeRabbit auto-started after the final-main push. Codex/Copilot/CodeRabbit will be requested/re-requested after latest-head CI is running/green and the PR is mature. Do not treat previous stacked-head reviews as final-main evidence.
- Review threads: to be rechecked after latest-head reviews finish.

## Merge policy

Do not merge directly from this agent handoff until latest-head CI is green and review threads are resolved. This PR is now in final-main revalidation mode rather than speculative stack mode.
