### PR TITLE
Fix CompactStorage leaf-vlog lifetime during index vacuum

### DIFF
--- a/TreeDB/db/compact_storage.go
+++ b/TreeDB/db/compact_storage.go
@@ -394,9 +394,6 @@ func (db *DB) compactStorage(ctx context.Context, opts CompactStorageOptions) (C
 	}); err != nil {
 		return stats, err
 	}
-	// If index vacuum was unsupported, keep the guard through settle/final audit;
-	// otherwise settle leaf GC could delete retiring sources before any vacuum
-	// cloned away the old leaf-log references.
 	if !indexVacuumSkipped {
 		if err := releaseIndexVacuumLeafGuard(); err != nil {
 			return stats, err
@@ -405,6 +402,14 @@ func (db *DB) compactStorage(ctx context.Context, opts CompactStorageOptions) (C
 
 	if err := db.settleCompactStorageGC(ctx, opts, &stats, !maintenanceLocked); err != nil {
 		return stats, err
+	}
+	// If index vacuum was unsupported, release after settle leaf GC has observed
+	// the pinned generations, but before value-log cleanup/final audit so the
+	// guard's snapshot does not keep unrelated zero-byte segments pinned.
+	if indexVacuumSkipped {
+		if err := releaseIndexVacuumLeafGuard(); err != nil {
+			return stats, err
+		}
 	}
 
 	if opts.DisableZeroByteValueLogCleanup {

--- a/TreeDB/db/compact_storage.go
+++ b/TreeDB/db/compact_storage.go
@@ -250,6 +250,31 @@ func (db *DB) compactStorage(ctx context.Context, opts CompactStorageOptions) (C
 	if opts.Mode == CompactStorageExhaustive && db.indexOuterLeavesInValueLog && compactLeafLog == nil && db.leafPageLog != nil {
 		return stats, fmt.Errorf("treedb: exhaustive compact requires an internally-owned leaf page log; close or clear the installed leaf page log before compacting")
 	}
+
+	// Leaf-pack/GC can make pre-compact leaf generations unreachable before
+	// index-vacuum has cloned the current index. Keep a public snapshot pinned
+	// through vacuum so those source leaf-log files remain readable.
+	var indexVacuumLeafGuard *Snapshot
+	if db.indexOuterLeavesInValueLog {
+		indexVacuumLeafGuard = db.AcquireSnapshot()
+		if indexVacuumLeafGuard == nil {
+			return stats, ErrClosed
+		}
+		defer func() {
+			if indexVacuumLeafGuard != nil {
+				_ = indexVacuumLeafGuard.Close()
+			}
+		}()
+	}
+	releaseIndexVacuumLeafGuard := func() error {
+		if indexVacuumLeafGuard == nil {
+			return nil
+		}
+		err := indexVacuumLeafGuard.Close()
+		indexVacuumLeafGuard = nil
+		return err
+	}
+
 	if err := db.runCompactStoragePhase(&stats, "value-log-rewrite", func() error {
 		protectedPaths := compactStorageOnlineRewriteProtectedPaths(opts)
 		protectedRootIDs, protectedSystemRootIDs := db.compactStorageLeafGenerationProtectedRootIDPair(opts)
@@ -367,6 +392,9 @@ func (db *DB) compactStorage(ctx context.Context, opts CompactStorageOptions) (C
 	} else if err := db.runCompactStoragePhase(&stats, "checkpoint-after-index-vacuum", func() error {
 		return db.Checkpoint()
 	}); err != nil {
+		return stats, err
+	}
+	if err := releaseIndexVacuumLeafGuard(); err != nil {
 		return stats, err
 	}
 

--- a/TreeDB/db/compact_storage.go
+++ b/TreeDB/db/compact_storage.go
@@ -394,8 +394,13 @@ func (db *DB) compactStorage(ctx context.Context, opts CompactStorageOptions) (C
 	}); err != nil {
 		return stats, err
 	}
-	if err := releaseIndexVacuumLeafGuard(); err != nil {
-		return stats, err
+	// If index vacuum was unsupported, keep the guard through settle/final audit;
+	// otherwise settle leaf GC could delete retiring sources before any vacuum
+	// cloned away the old leaf-log references.
+	if !indexVacuumSkipped {
+		if err := releaseIndexVacuumLeafGuard(); err != nil {
+			return stats, err
+		}
 	}
 
 	if err := db.settleCompactStorageGC(ctx, opts, &stats, !maintenanceLocked); err != nil {

--- a/TreeDB/db/compact_storage.go
+++ b/TreeDB/db/compact_storage.go
@@ -274,6 +274,21 @@ func (db *DB) compactStorage(ctx context.Context, opts CompactStorageOptions) (C
 		indexVacuumLeafGuard = nil
 		return err
 	}
+	releaseIndexVacuumLeafGuardValueLogPin := func() error {
+		if indexVacuumLeafGuard == nil || !indexVacuumLeafGuard.vlogPinned {
+			return nil
+		}
+		if indexVacuumLeafGuard.state == nil || indexVacuumLeafGuard.vlogManager == nil {
+			return nil
+		}
+		set := indexVacuumLeafGuard.state.ValueLogSet
+		if set == nil {
+			return nil
+		}
+		err := indexVacuumLeafGuard.vlogManager.Release(set)
+		indexVacuumLeafGuard.vlogPinned = false
+		return err
+	}
 
 	if err := db.runCompactStoragePhase(&stats, "value-log-rewrite", func() error {
 		protectedPaths := compactStorageOnlineRewriteProtectedPaths(opts)
@@ -403,11 +418,11 @@ func (db *DB) compactStorage(ctx context.Context, opts CompactStorageOptions) (C
 	if err := db.settleCompactStorageGC(ctx, opts, &stats, !maintenanceLocked); err != nil {
 		return stats, err
 	}
-	// If index vacuum was unsupported, release after settle leaf GC has observed
-	// the pinned generations, but before value-log cleanup/final audit so the
-	// guard's snapshot does not keep unrelated zero-byte segments pinned.
+	// If index vacuum was unsupported, keep leaf-generation pins through final
+	// audit, but drop the unrelated value-log set pin before value-log cleanup so
+	// zero-byte value_vlog segments are not kept alive by this guard.
 	if indexVacuumSkipped {
-		if err := releaseIndexVacuumLeafGuard(); err != nil {
+		if err := releaseIndexVacuumLeafGuardValueLogPin(); err != nil {
 			return stats, err
 		}
 	}

--- a/TreeDB/db/compact_storage_test.go
+++ b/TreeDB/db/compact_storage_test.go
@@ -999,6 +999,48 @@ func TestCompactStorageSettlesLeafGenerationGCAfterPinnedRetiring(t *testing.T) 
 	}
 }
 
+func TestCompactStorageKeepsPackedLeafSourcesUntilIndexVacuum(t *testing.T) {
+	d, leafLog, dir := openLeafGenerationPackTestDB(t)
+
+	writeLeafGenerationKeys(t, d, "k", 2048, 'a')
+	path1, fileID1 := currentLeafSegmentOrFatal(t, leafLog)
+	rawFileID1 := page.ValueLogSegmentID(fileID1)
+	if err := leafLog.rotateLeaf(); err != nil {
+		t.Fatalf("rotateLeaf: %v", err)
+	}
+	writeLeafGenerationKeyRange(t, d, "k", 0, 1024, 'b')
+	writeLeafGenerationKeys(t, d, "z", 32, 'z')
+	d.SetLeafPageLog(nil)
+
+	sawLeafGC := false
+	d.compactStorageAfterPhase = func(name string) {
+		if name != "leaf-generation-gc" {
+			return
+		}
+		sawLeafGC = true
+		if _, err := os.Stat(path1); err != nil {
+			t.Fatalf("pre-vacuum leaf segment removed: %v", err)
+		}
+		manifest := loadLeafGenerationManifestOrFatal(t, dir)
+		gen := findLeafGenerationByFileID(t, manifest, rawFileID1)
+		if got, want := gen.State, leafGenerationStateRetiring; got != want {
+			t.Fatalf("generation state after leaf gc=%q want %q manifest=%+v", got, want, manifest.Generations)
+		}
+	}
+	t.Cleanup(func() { d.compactStorageAfterPhase = nil })
+
+	stats, err := d.CompactStorage(context.Background(), CompactStorageOptions{LeafPackMaxPasses: 4})
+	if err != nil {
+		t.Fatalf("CompactStorage: %v", err)
+	}
+	if !sawLeafGC {
+		t.Fatal("leaf-generation-gc phase hook did not run")
+	}
+	if !stats.FullyCompacted {
+		t.Fatalf("FullyCompacted=false debt=%+v", stats.RemainingDebt)
+	}
+}
+
 func TestCompactStoragePlan_ProtectedRootIDsKeepDetachedLeafGenerationLive(t *testing.T) {
 	d, leafLog, _ := openLeafGenerationPackTestDB(t)
 

--- a/TreeDB/db/compact_storage_test.go
+++ b/TreeDB/db/compact_storage_test.go
@@ -937,6 +937,9 @@ func TestCompactStorageHoldsMaintenanceLockAcrossPhases(t *testing.T) {
 }
 
 func TestCompactStorageSettlesLeafGenerationGCAfterPinnedRetiring(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("index vacuum is unsupported on Windows; skipped-vacuum guard intentionally keeps leaf sources pinned")
+	}
 	d, leafLog, dir := openLeafGenerationPackTestDB(t)
 
 	writeLeafGenerationKeys(t, d, "k", 64, 'a')

--- a/TreeDB/db/compact_storage_test.go
+++ b/TreeDB/db/compact_storage_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -1038,6 +1039,40 @@ func TestCompactStorageKeepsPackedLeafSourcesUntilIndexVacuum(t *testing.T) {
 	}
 	if !stats.FullyCompacted {
 		t.Fatalf("FullyCompacted=false debt=%+v", stats.RemainingDebt)
+	}
+}
+
+func TestCompactStorageWindowsKeepsPackedLeafSourcesWhenIndexVacuumUnsupported(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("index vacuum is supported on this platform")
+	}
+	d, leafLog, _ := openLeafGenerationPackTestDB(t)
+
+	writeLeafGenerationKeys(t, d, "k", 2048, 'a')
+	path1, _ := currentLeafSegmentOrFatal(t, leafLog)
+	if err := leafLog.rotateLeaf(); err != nil {
+		t.Fatalf("rotateLeaf: %v", err)
+	}
+	writeLeafGenerationKeyRange(t, d, "k", 0, 1024, 'b')
+	writeLeafGenerationKeys(t, d, "z", 32, 'z')
+	d.SetLeafPageLog(nil)
+
+	stats, err := d.CompactStorage(context.Background(), CompactStorageOptions{LeafPackMaxPasses: 4})
+	if err != nil {
+		t.Fatalf("CompactStorage: %v", err)
+	}
+	indexVacuumSkipped := false
+	for _, phase := range stats.Phases {
+		if phase.Name == "index-vacuum" && phase.Skipped {
+			indexVacuumSkipped = true
+			break
+		}
+	}
+	if !indexVacuumSkipped {
+		t.Fatalf("index-vacuum was not skipped on windows: %+v", stats.Phases)
+	}
+	if _, err := os.Stat(path1); err != nil {
+		t.Fatalf("leaf source removed after skipped index-vacuum: %v", err)
 	}
 }
 

--- a/TreeDB/db/leaf_generation_gc.go
+++ b/TreeDB/db/leaf_generation_gc.go
@@ -113,6 +113,23 @@ func (db *DB) leafGenerationGC(ctx context.Context, opts LeafGenerationGCOptions
 		}
 		stats.GenerationsTotal++
 		if gen.State == leafGenerationStateDeleted {
+			// Zombie state is in-memory only. After a reopen, deleted manifest records
+			// whose files are still present must be marked zombie again so deletion is
+			// retried, unless another active generation has legitimately reused the ID.
+			seenFiles := make(map[uint32]struct{}, len(gen.FileIDs))
+			for _, fileID := range gen.FileIDs {
+				if fileID == 0 {
+					continue
+				}
+				if _, seen := seenFiles[fileID]; seen {
+					continue
+				}
+				seenFiles[fileID] = struct{}{}
+				if activeFileRefs[fileID] > 0 {
+					continue
+				}
+				zombieFileIDs[page.ValueLogFileID(fileID)] = struct{}{}
+			}
 			continue
 		}
 		if gen.State == leafGenerationStateWritable {
@@ -196,6 +213,8 @@ func (db *DB) leafGenerationGC(ctx context.Context, opts LeafGenerationGCOptions
 			return stats, err
 		}
 		db.leafGenerationManifest = manifest
+	}
+	if intermediateChanged || len(zombieFileIDs) > 0 {
 		if err := db.publishLeafGenerationState(len(zombieFileIDs) > 0); err != nil {
 			return stats, err
 		}

--- a/TreeDB/db/leaf_generation_gc.go
+++ b/TreeDB/db/leaf_generation_gc.go
@@ -99,6 +99,7 @@ func (db *DB) leafGenerationGC(ctx context.Context, opts LeafGenerationGCOptions
 	snap = nil
 	intermediateChanged := false
 	zombieFileIDs := make(map[uint32]struct{})
+	activeFileRefs := leafGenerationActiveFileRefCounts(manifest)
 	for i := range manifest.Generations {
 		gen := &manifest.Generations[i]
 		genBytes := int64(0)
@@ -152,8 +153,24 @@ func (db *DB) leafGenerationGC(ctx context.Context, opts LeafGenerationGCOptions
 			if bytes := loadGenBytes(); bytes > 0 {
 				stats.BytesDeleted += bytes
 			}
+			seenFiles := make(map[uint32]struct{}, len(gen.FileIDs))
 			for _, fileID := range gen.FileIDs {
 				if fileID == 0 {
+					continue
+				}
+				if _, seen := seenFiles[fileID]; seen {
+					continue
+				}
+				seenFiles[fileID] = struct{}{}
+				// Malformed legacy manifests may mention a physical leaf segment in
+				// more than one active generation. Deleting this generation must not
+				// unlink a segment another active generation still references, but it
+				// should still reclaim the file when this pass deletes the final active
+				// reference.
+				if activeFileRefs[fileID] > 0 {
+					activeFileRefs[fileID]--
+				}
+				if activeFileRefs[fileID] > 0 {
 					continue
 				}
 				zombieFileIDs[page.ValueLogFileID(fileID)] = struct{}{}
@@ -199,6 +216,30 @@ func (db *DB) leafGenerationGC(ctx context.Context, opts LeafGenerationGCOptions
 	}
 	db.leafGenerationManifest = manifest
 	return stats, nil
+}
+
+func leafGenerationActiveFileRefCounts(manifest *leafGenerationManifest) map[uint32]int {
+	counts := make(map[uint32]int)
+	if manifest == nil {
+		return counts
+	}
+	for _, gen := range manifest.Generations {
+		if gen.State == leafGenerationStateDeleted {
+			continue
+		}
+		seen := make(map[uint32]struct{}, len(gen.FileIDs))
+		for _, fileID := range gen.FileIDs {
+			if fileID == 0 {
+				continue
+			}
+			if _, ok := seen[fileID]; ok {
+				continue
+			}
+			seen[fileID] = struct{}{}
+			counts[fileID]++
+		}
+	}
+	return counts
 }
 
 func collectLiveLeafGenerationIDs(ctx context.Context, snap *Snapshot, protectedRootIDs, protectedSystemRootIDs []uint64) (map[uint64]struct{}, error) {

--- a/TreeDB/db/leaf_generation_gc_test.go
+++ b/TreeDB/db/leaf_generation_gc_test.go
@@ -210,6 +210,49 @@ func TestLeafGenerationGC_DeletesFullyDeadGeneration(t *testing.T) {
 	}
 }
 
+func TestLeafGenerationGC_DoesNotZombieSharedActiveFileID(t *testing.T) {
+	db, _ := openLeafGenerationGCTestDB(t)
+	path, fileID := createLeafGenerationTestSegment(t, LeafLogDirPath(db.dir), rewriteLeafLogLaneID, 1)
+	rawFileID := page.ValueLogSegmentID(fileID)
+	if err := db.valueLogManager.Refresh(); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	manifest := &leafGenerationManifest{
+		Version:             leafGenerationManifestVersion,
+		CurrentGenerationID: 2,
+		NextGenerationID:    3,
+		Generations: []leafGenerationRecord{
+			{GenerationID: 1, State: leafGenerationStateSealed, FileIDs: []uint32{rawFileID}, CreatedCommitSeq: 1, SealedCommitSeq: 1, PublishedCommitSeq: 1},
+			{GenerationID: 2, State: leafGenerationStateWritable, FileIDs: []uint32{rawFileID}, CreatedCommitSeq: 2, PublishedCommitSeq: 2},
+		},
+	}
+	if err := saveLeafGenerationManifest(LeafLogDirPath(db.dir), manifest); err != nil {
+		t.Fatalf("save manifest: %v", err)
+	}
+	db.mu.Lock()
+	db.leafGenerationManifest = manifest
+	db.mu.Unlock()
+	if err := db.publishLeafGenerationState(true); err != nil {
+		t.Fatalf("publish leaf state: %v", err)
+	}
+
+	stats, err := db.LeafGenerationGC(context.Background(), LeafGenerationGCOptions{})
+	if err != nil {
+		t.Fatalf("LeafGenerationGC: %v", err)
+	}
+	if got, want := stats.GenerationsEligible, 1; got != want {
+		t.Fatalf("GenerationsEligible=%d want %d stats=%+v", got, want, stats)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("shared active segment was removed: %v", err)
+	}
+	manifestAfter := loadLeafGenerationManifestOrFatal(t, db.dir)
+	gen := findLeafGenerationByFileID(t, manifestAfter, rawFileID)
+	if gen.GenerationID != 1 || gen.State != leafGenerationStateDeleted {
+		t.Fatalf("first shared generation not marked deleted: %+v manifest=%+v", gen, manifestAfter.Generations)
+	}
+}
+
 func TestLeafGenerationGC_ProtectedRootIDsKeepDetachedRootLive(t *testing.T) {
 	db, leafLog := openLeafGenerationGCTestDB(t)
 

--- a/TreeDB/db/leaf_generation_gc_test.go
+++ b/TreeDB/db/leaf_generation_gc_test.go
@@ -253,6 +253,69 @@ func TestLeafGenerationGC_DoesNotZombieSharedActiveFileID(t *testing.T) {
 	}
 }
 
+func TestLeafGenerationGC_RetriesDeletedGenerationFileAfterReopen(t *testing.T) {
+	dir := t.TempDir()
+	opts := Options{
+		Dir:                        dir,
+		Durability:                 DurabilityWALOffRelaxed,
+		DisableBackgroundPrune:     true,
+		IndexOuterLeavesInValueLog: true,
+	}
+	db, err := Open(opts)
+	if err != nil {
+		t.Fatalf("Open initial: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close initial: %v", err)
+	}
+
+	path, fileID := createLeafGenerationTestSegment(t, LeafLogDirPath(dir), rewriteLeafLogLaneID, 1)
+	rawFileID := page.ValueLogSegmentID(fileID)
+	manifest := &leafGenerationManifest{
+		Version:             leafGenerationManifestVersion,
+		CurrentGenerationID: 2,
+		NextGenerationID:    3,
+		Generations: []leafGenerationRecord{
+			{GenerationID: 1, State: leafGenerationStateDeleted, FileIDs: []uint32{rawFileID}, CreatedCommitSeq: 1, DeletedCommitSeq: 2, PublishedCommitSeq: 2},
+			{GenerationID: 2, State: leafGenerationStateWritable, CreatedCommitSeq: 3, PublishedCommitSeq: 3},
+		},
+	}
+	if err := saveLeafGenerationManifest(LeafLogDirPath(dir), manifest); err != nil {
+		t.Fatalf("save manifest: %v", err)
+	}
+
+	db, err = Open(opts)
+	if err != nil {
+		t.Fatalf("Open with pending deleted leaf file: %v", err)
+	}
+	defer closeNoErr(t, db)
+	current := db.leafGenerationManifest.Generations[db.leafGenerationManifest.currentGenerationIndex()]
+	if len(current.FileIDs) != 0 {
+		t.Fatalf("current FileIDs=%v, want empty; pending-deleted file should not be resurrected", current.FileIDs)
+	}
+
+	stats, err := db.LeafGenerationGC(context.Background(), LeafGenerationGCOptions{})
+	if err != nil {
+		t.Fatalf("LeafGenerationGC: %v", err)
+	}
+	if got, want := stats.GenerationsDeleted, 1; got != want {
+		t.Fatalf("GenerationsDeleted=%d, want %d (stats=%+v)", got, want, stats)
+	}
+	if got, want := stats.FilesDeleted, 1; got != want {
+		t.Fatalf("FilesDeleted=%d, want %d (stats=%+v)", got, want, stats)
+	}
+	if err := waitForPathRemoval(path, 5*time.Second); err != nil {
+		t.Fatalf("waitForPathRemoval(%s): %v", path, err)
+	}
+	manifestAfter := loadLeafGenerationManifestOrFatal(t, dir)
+	if len(manifestAfter.Generations) != 1 {
+		t.Fatalf("len(Gens)=%d, want only writable generation after pruning: %+v", len(manifestAfter.Generations), manifestAfter.Generations)
+	}
+	if gen := manifestAfter.Generations[0]; gen.State != leafGenerationStateWritable || gen.GenerationID != 2 {
+		t.Fatalf("remaining generation=%+v, want writable generation 2", gen)
+	}
+}
+
 func TestLeafGenerationGC_ProtectedRootIDsKeepDetachedRootLive(t *testing.T) {
 	db, leafLog := openLeafGenerationGCTestDB(t)
 

--- a/TreeDB/db/leaf_generation_manifest.go
+++ b/TreeDB/db/leaf_generation_manifest.go
@@ -90,9 +90,11 @@ func (m *leafGenerationManifest) registerCurrentGenerationFileID(fileID uint32, 
 	if gen.State != leafGenerationStateWritable {
 		return false, fmt.Errorf("treedb: current generation %d is not writable (state=%q)", gen.GenerationID, gen.State)
 	}
-	for _, existing := range gen.FileIDs {
-		if existing == fileID {
-			return false, nil
+	for _, existingGen := range m.Generations {
+		for _, existing := range existingGen.FileIDs {
+			if existing == fileID {
+				return false, nil
+			}
 		}
 	}
 	if len(gen.FileIDs) == 0 {

--- a/TreeDB/db/leaf_generation_manifest.go
+++ b/TreeDB/db/leaf_generation_manifest.go
@@ -762,6 +762,9 @@ func reconcileLeafGenerationManifestWithDir(leafDir string, manifest *leafGenera
 	}
 	seen := make(map[uint32]struct{}, len(manifest.Generations))
 	for _, gen := range manifest.Generations {
+		if gen.State == leafGenerationStateDeleted {
+			continue
+		}
 		for _, rawFileID := range gen.FileIDs {
 			if rawFileID == 0 {
 				continue

--- a/TreeDB/db/leaf_generation_manifest.go
+++ b/TreeDB/db/leaf_generation_manifest.go
@@ -188,6 +188,9 @@ func (m *leafGenerationManifest) appendRecoveredSealedGenerationFileID(fileID ui
 		return false, errors.New("treedb: leaf generation file_id must be non-zero")
 	}
 	for _, gen := range m.Generations {
+		if gen.State == leafGenerationStateDeleted {
+			continue
+		}
 		for _, existing := range gen.FileIDs {
 			if existing == fileID {
 				return false, nil
@@ -760,9 +763,27 @@ func reconcileLeafGenerationManifestWithDir(leafDir string, manifest *leafGenera
 	if len(files) == 0 {
 		return manifest, false, nil
 	}
+	diskFiles := make(map[uint32]struct{}, len(files))
+	for _, file := range files {
+		if file.rawFileID != 0 {
+			diskFiles[file.rawFileID] = struct{}{}
+		}
+	}
 	seen := make(map[uint32]struct{}, len(manifest.Generations))
 	for _, gen := range manifest.Generations {
 		if gen.State == leafGenerationStateDeleted {
+			// A deleted record for a file that is still on disk is retry state for a
+			// pending zombie delete. Keep it seen so reconciliation does not resurrect
+			// the orphan into an active generation. Missing deleted files are ignored so
+			// the raw file ID can be reused and registered by subsequent writes.
+			for _, rawFileID := range gen.FileIDs {
+				if rawFileID == 0 {
+					continue
+				}
+				if _, ok := diskFiles[rawFileID]; ok {
+					seen[rawFileID] = struct{}{}
+				}
+			}
 			continue
 		}
 		for _, rawFileID := range gen.FileIDs {

--- a/TreeDB/db/leaf_generation_manifest.go
+++ b/TreeDB/db/leaf_generation_manifest.go
@@ -91,6 +91,9 @@ func (m *leafGenerationManifest) registerCurrentGenerationFileID(fileID uint32, 
 		return false, fmt.Errorf("treedb: current generation %d is not writable (state=%q)", gen.GenerationID, gen.State)
 	}
 	for _, existingGen := range m.Generations {
+		if existingGen.State == leafGenerationStateDeleted {
+			continue
+		}
 		for _, existing := range existingGen.FileIDs {
 			if existing == fileID {
 				return false, nil

--- a/TreeDB/db/leaf_generation_manifest_test.go
+++ b/TreeDB/db/leaf_generation_manifest_test.go
@@ -355,7 +355,7 @@ func TestLoadOrCreateLeafGenerationManifest_BootstrapsExistingLeafFiles(t *testi
 	}
 }
 
-func TestReconcileLeafGenerationManifestWithDir_IgnoresDeletedGenerationDuplicates(t *testing.T) {
+func TestReconcileLeafGenerationManifestWithDir_PreservesDeletedGenerationFilePresentOnDisk(t *testing.T) {
 	leafDir := t.TempDir()
 	_, fileID := createLeafGenerationTestSegment(t, leafDir, rewriteLeafLogLaneID, 1)
 	rawFileID := page.ValueLogSegmentID(fileID)
@@ -373,12 +373,45 @@ func TestReconcileLeafGenerationManifestWithDir_IgnoresDeletedGenerationDuplicat
 	if err != nil {
 		t.Fatalf("reconcileLeafGenerationManifestWithDir: %v", err)
 	}
-	if !changed {
-		t.Fatal("expected reconcile to register file only present in deleted generation")
+	if changed {
+		t.Fatal("expected reconcile to preserve pending-deleted on-disk file without re-registering it")
 	}
-	current := reconciled.Generations[reconciled.currentGenerationIndex()]
-	if got, want := current.FileIDs, []uint32{rawFileID}; !reflect.DeepEqual(got, want) {
-		t.Fatalf("current FileIDs=%v, want %v", got, want)
+	if reconciled != manifest {
+		t.Fatal("expected unchanged reconcile to return original manifest")
+	}
+	current := manifest.Generations[manifest.currentGenerationIndex()]
+	if len(current.FileIDs) != 0 {
+		t.Fatalf("current FileIDs=%v, want empty while deleted file is pending cleanup", current.FileIDs)
+	}
+}
+
+func TestLeafGenerationManifest_AppendRecoveredSealedGenerationFileID_IgnoresDeletedGenerationDuplicates(t *testing.T) {
+	manifest := &leafGenerationManifest{
+		Version:             leafGenerationManifestVersion,
+		CurrentGenerationID: 2,
+		NextGenerationID:    3,
+		Generations: []leafGenerationRecord{
+			{GenerationID: 1, State: leafGenerationStateDeleted, FileIDs: []uint32{77}, CreatedCommitSeq: 10, DeletedCommitSeq: 20, PublishedCommitSeq: 20},
+			{GenerationID: 2, State: leafGenerationStateWritable, CreatedCommitSeq: 30, PublishedCommitSeq: 30},
+		},
+	}
+
+	changed, err := manifest.appendRecoveredSealedGenerationFileID(77, 99)
+	if err != nil {
+		t.Fatalf("appendRecoveredSealedGenerationFileID: %v", err)
+	}
+	if !changed {
+		t.Fatal("expected deleted duplicate file recovery to append a sealed generation")
+	}
+	if got, want := len(manifest.Generations), 3; got != want {
+		t.Fatalf("len(Generations)=%d, want %d", got, want)
+	}
+	recovered := manifest.Generations[2]
+	if got, want := recovered.State, leafGenerationStateSealed; got != want {
+		t.Fatalf("recovered.State=%q, want %q", got, want)
+	}
+	if got, want := recovered.FileIDs, []uint32{77}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("recovered.FileIDs=%v, want %v", got, want)
 	}
 }
 

--- a/TreeDB/db/leaf_generation_manifest_test.go
+++ b/TreeDB/db/leaf_generation_manifest_test.go
@@ -176,6 +176,29 @@ func TestLeafGenerationManifest_RegisterCurrentGenerationFileID_DedupesAcrossGen
 	}
 }
 
+func TestLeafGenerationManifest_RegisterCurrentGenerationFileID_IgnoresDeletedGenerationDuplicates(t *testing.T) {
+	manifest := &leafGenerationManifest{
+		Version:             leafGenerationManifestVersion,
+		CurrentGenerationID: 2,
+		NextGenerationID:    3,
+		Generations: []leafGenerationRecord{
+			{GenerationID: 1, State: leafGenerationStateDeleted, FileIDs: []uint32{77}, CreatedCommitSeq: 10, DeletedCommitSeq: 20, PublishedCommitSeq: 20},
+			{GenerationID: 2, State: leafGenerationStateWritable, CreatedCommitSeq: 30, PublishedCommitSeq: 30},
+		},
+	}
+
+	changed, err := manifest.registerCurrentGenerationFileID(77, 99)
+	if err != nil {
+		t.Fatalf("registerCurrentGenerationFileID deleted duplicate: %v", err)
+	}
+	if !changed {
+		t.Fatalf("expected deleted duplicate file registration to update current generation")
+	}
+	if got, want := manifest.Generations[1].FileIDs, []uint32{77}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("current FileIDs=%v, want %v", got, want)
+	}
+}
+
 func TestLeafGenerationManifest_RegisterCurrentGenerationFileID_RollsGenerationOnNewFile(t *testing.T) {
 	manifest := newLeafGenerationManifest(10)
 	if _, err := manifest.registerCurrentGenerationFileID(77, 44); err != nil {

--- a/TreeDB/db/leaf_generation_manifest_test.go
+++ b/TreeDB/db/leaf_generation_manifest_test.go
@@ -147,6 +147,35 @@ func TestLeafGenerationManifest_RegisterCurrentGenerationFileID(t *testing.T) {
 	}
 }
 
+func TestLeafGenerationManifest_RegisterCurrentGenerationFileID_DedupesAcrossGenerations(t *testing.T) {
+	manifest := &leafGenerationManifest{
+		Version:             leafGenerationManifestVersion,
+		CurrentGenerationID: 2,
+		NextGenerationID:    3,
+		Generations: []leafGenerationRecord{
+			{GenerationID: 1, State: leafGenerationStateSealed, FileIDs: []uint32{77}, CreatedCommitSeq: 10, SealedCommitSeq: 20, PublishedCommitSeq: 20},
+			{GenerationID: 2, State: leafGenerationStateWritable, CreatedCommitSeq: 30, PublishedCommitSeq: 30},
+		},
+	}
+
+	changed, err := manifest.registerCurrentGenerationFileID(77, 99)
+	if err != nil {
+		t.Fatalf("registerCurrentGenerationFileID duplicate across generations: %v", err)
+	}
+	if changed {
+		t.Fatalf("expected duplicate file registration across generations to be a no-op")
+	}
+	if got, want := manifest.CurrentGenerationID, uint64(2); got != want {
+		t.Fatalf("CurrentGenerationID=%d, want %d", got, want)
+	}
+	if got, want := manifest.NextGenerationID, uint64(3); got != want {
+		t.Fatalf("NextGenerationID=%d, want %d", got, want)
+	}
+	if got := manifest.Generations[1].FileIDs; len(got) != 0 {
+		t.Fatalf("current FileIDs=%v, want empty after duplicate", got)
+	}
+}
+
 func TestLeafGenerationManifest_RegisterCurrentGenerationFileID_RollsGenerationOnNewFile(t *testing.T) {
 	manifest := newLeafGenerationManifest(10)
 	if _, err := manifest.registerCurrentGenerationFileID(77, 44); err != nil {

--- a/TreeDB/db/leaf_generation_manifest_test.go
+++ b/TreeDB/db/leaf_generation_manifest_test.go
@@ -355,6 +355,33 @@ func TestLoadOrCreateLeafGenerationManifest_BootstrapsExistingLeafFiles(t *testi
 	}
 }
 
+func TestReconcileLeafGenerationManifestWithDir_IgnoresDeletedGenerationDuplicates(t *testing.T) {
+	leafDir := t.TempDir()
+	_, fileID := createLeafGenerationTestSegment(t, leafDir, rewriteLeafLogLaneID, 1)
+	rawFileID := page.ValueLogSegmentID(fileID)
+	manifest := &leafGenerationManifest{
+		Version:             leafGenerationManifestVersion,
+		CurrentGenerationID: 2,
+		NextGenerationID:    3,
+		Generations: []leafGenerationRecord{
+			{GenerationID: 1, State: leafGenerationStateDeleted, FileIDs: []uint32{rawFileID}, CreatedCommitSeq: 10, DeletedCommitSeq: 20, PublishedCommitSeq: 20},
+			{GenerationID: 2, State: leafGenerationStateWritable, CreatedCommitSeq: 30, PublishedCommitSeq: 30},
+		},
+	}
+
+	reconciled, changed, err := reconcileLeafGenerationManifestWithDir(leafDir, manifest, 99)
+	if err != nil {
+		t.Fatalf("reconcileLeafGenerationManifestWithDir: %v", err)
+	}
+	if !changed {
+		t.Fatal("expected reconcile to register file only present in deleted generation")
+	}
+	current := reconciled.Generations[reconciled.currentGenerationIndex()]
+	if got, want := current.FileIDs, []uint32{rawFileID}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("current FileIDs=%v, want %v", got, want)
+	}
+}
+
 func TestLoadOrCreateLeafGenerationManifest_RecoversUnknownLeafFilesPreservesWritableTail(t *testing.T) {
 	leafDir := t.TempDir()
 	_, fileID1 := createLeafGenerationTestSegment(t, leafDir, rewriteLeafLogLaneID, 1)


### PR DESCRIPTION
## Summary

- keep a CompactStorage snapshot pinned through the index-vacuum phase when outer leaves live in `leaf_vlog`
- prevent leaf-generation manifests from registering the same raw leaf-log file ID into multiple active generations
- make leaf-generation GC fail closed for malformed/legacy manifests that already share an active file ID
- preserve on-disk `deleted` leaf-generation files as pending cleanup on reopen, then retry zombie deletion without resurrecting them into the writable generation
- allow file IDs to be reused after stale `deleted` manifest records once the old file is gone, including sealed recovery helper paths
- when index vacuum is unsupported/skipped, keep leaf-generation pins through settle/final audit but drop the guard's value-log set pin before zero-byte cleanup

Fixes #2468.

## Root cause

`CompactStorage` can rewrite/pack leaf generations before `index-vacuum` clones the active index. The leaf-generation GC phase could then make source leaf-log segments unreachable and delete them while vacuum still needed to read them. A second edge case allowed the same raw leaf-log file ID to appear in multiple active manifest generations; GC could zombie the shared physical segment when deleting only one generation. Reopen recovery also needs to distinguish stale deleted records whose files are gone from deleted records whose files are still on disk and need another zombie-delete attempt.

## Tests

- `go test ./TreeDB/db -run 'TestReconcileLeafGenerationManifestWithDir_PreservesDeletedGenerationFilePresentOnDisk|TestLeafGenerationManifest_AppendRecoveredSealedGenerationFileID_IgnoresDeletedGenerationDuplicates|TestLeafGenerationGC_RetriesDeletedGenerationFileAfterReopen|TestLeafGenerationGC_DoesNotZombieSharedActiveFileID|TestLeafGenerationManifest_RegisterCurrentGenerationFileID_IgnoresDeletedGenerationDuplicates' -count=1 -v` — PASS
- `go test ./TreeDB/db -run 'TestCompactStorageSettlesLeafGenerationGCAfterPinnedRetiring|TestCompactStorageWindowsKeepsPackedLeafSourcesWhenIndexVacuumUnsupported' -count=1 -v` — PASS on darwin (`TestCompactStorageWindowsKeepsPackedLeafSourcesWhenIndexVacuumUnsupported` skipped as expected)
- `go test ./TreeDB/db -run 'TestCompactStorage|TestLeafGenerationGC|TestLeafGenerationPack|TestLeafGenerationManifest|TestReconcileLeafGenerationManifestWithDir_PreservesDeletedGenerationFilePresentOnDisk|TestLeafGenerationManifest_AppendRecoveredSealedGenerationFileID_IgnoresDeletedGenerationDuplicates' -count=1` — PASS
- `go test ./TreeDB/db ./TreeDB -count=1` — PASS

## Latest-head CI / review status

- Latest head: `65192c27c651574df6752df6e3411ddb4e625edf`
- CI: all latest-head checks pass (`gh pr checks 2470 --repo snissn/gomap`), including `TreeDB: vet+test` on ubuntu/macos/windows, race checks, format, guardrails, and benchmark/profile gates.
- AI review: Codex latest review reported no major issues; CodeRabbit status is pass/review skipped after processing latest head; Copilot was re-requested and has no actionable comments posted. All review threads are resolved.

## Notes

The fix avoids format migration; TreeDB is pre-alpha and the manifest change prevents new duplicate active file-ID registrations while GC preserves already-shared active file IDs safely. On Windows, the generic settle-GC pinned-retiring test is skipped because online index vacuum is unsupported there and the skipped-vacuum guard intentionally keeps leaf sources pinned; Windows-specific skipped-vacuum coverage remains in `TestCompactStorageWindowsKeepsPackedLeafSourcesWhenIndexVacuumUnsupported`.
