### PR TITLE
Repair missing leaf generation manifest files

### DIFF
--- a/TreeDB/db/compact_storage.go
+++ b/TreeDB/db/compact_storage.go
@@ -220,6 +220,16 @@ func (db *DB) compactStorage(ctx context.Context, opts CompactStorageOptions) (C
 	}
 	stats.Before = before
 
+	if !opts.DryRun && db.indexOuterLeavesInValueLog {
+		commitSeq := uint64(1)
+		if state := db.State(); state != nil && state.CommitSeq != 0 {
+			commitSeq = state.CommitSeq
+		}
+		if _, err := db.reconcileLeafGenerationManifestWithDirInPlace(commitSeq); err != nil {
+			return stats, err
+		}
+	}
+
 	initialDebt, err := db.populateCompactStorageAudit(ctx, opts, &stats, !maintenanceLocked, nil)
 	if err != nil {
 		return stats, err

--- a/TreeDB/db/compact_storage_test.go
+++ b/TreeDB/db/compact_storage_test.go
@@ -15,6 +15,63 @@ import (
 	"github.com/snissn/gomap/TreeDB/page"
 )
 
+func TestCompactStorageRepairsMissingCurrentLeafGenerationFile(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(Options{Dir: dir, IndexOuterLeavesInValueLog: true})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	leafDir := LeafLogDirPath(dir)
+	_, fileID18 := createLeafGenerationTestSegment(t, leafDir, rewriteLeafLogLaneID, 18)
+	_, fileID19 := createLeafGenerationTestSegment(t, leafDir, rewriteLeafLogLaneID, 19)
+	_, fileID20 := createLeafGenerationTestSegment(t, leafDir, rewriteLeafLogLaneID, 20)
+	fileID17, err := valuelog.EncodeFileID(rewriteLeafLogLaneID, 17)
+	if err != nil {
+		t.Fatalf("EncodeFileID: %v", err)
+	}
+	raw17 := page.ValueLogSegmentID(fileID17)
+	raw18 := page.ValueLogSegmentID(fileID18)
+	raw19 := page.ValueLogSegmentID(fileID19)
+	raw20 := page.ValueLogSegmentID(fileID20)
+	manifest := &leafGenerationManifest{
+		Version:             leafGenerationManifestVersion,
+		CurrentGenerationID: 3,
+		NextGenerationID:    4,
+		Generations: []leafGenerationRecord{
+			{GenerationID: 1, State: leafGenerationStateSealed, FileIDs: []uint32{raw18}, CreatedCommitSeq: 10, SealedCommitSeq: 20, PublishedCommitSeq: 20},
+			{GenerationID: 2, State: leafGenerationStateSealed, FileIDs: []uint32{raw19}, CreatedCommitSeq: 21, SealedCommitSeq: 30, PublishedCommitSeq: 30},
+			{GenerationID: 3, State: leafGenerationStateWritable, FileIDs: []uint32{raw17}, CreatedCommitSeq: 31, PublishedCommitSeq: 31},
+		},
+	}
+	db.writeMu.Lock()
+	db.leafGenerationManifest = manifest
+	db.writeMu.Unlock()
+	if err := db.publishLeafGenerationState(false); err != nil {
+		t.Fatalf("publishLeafGenerationState: %v", err)
+	}
+	if _, err := db.CompactStoragePlan(context.Background(), CompactStorageOptions{Mode: CompactStorageFull}); err != nil {
+		t.Fatalf("CompactStoragePlan with stale missing leaf generation: %v", err)
+	}
+	if _, err := db.CompactStorage(context.Background(), CompactStorageOptions{Mode: CompactStorageFull}); err != nil {
+		t.Fatalf("CompactStorage with stale missing leaf generation: %v", err)
+	}
+
+	view := db.currentLeafGenerationView()
+	if _, ok := view.FileToGeneration[raw17]; ok {
+		t.Fatalf("missing raw file %d still visible after CompactStorage", raw17)
+	}
+	if _, ok := view.FileToGeneration[raw20]; !ok {
+		t.Fatalf("existing writable raw file %d missing after CompactStorage", raw20)
+	}
+	for rawFileID := range view.FileToGeneration {
+		if exists, err := leafGenerationRawFileExists(dir, rawFileID); err != nil || !exists {
+			t.Fatalf("view references missing raw file %d: exists=%v err=%v", rawFileID, exists, err)
+		}
+	}
+}
+
 func TestCompactStorageDeletesZeroByteValueLogFiles(t *testing.T) {
 	dir := t.TempDir()
 	d, err := Open(Options{

--- a/TreeDB/db/leaf_generation_gc.go
+++ b/TreeDB/db/leaf_generation_gc.go
@@ -67,6 +67,13 @@ func (db *DB) leafGenerationGC(ctx context.Context, opts LeafGenerationGCOptions
 	if err := db.valueLogManager.Refresh(); err != nil {
 		return stats, err
 	}
+	commitSeq := uint64(1)
+	if state := db.State(); state != nil && state.CommitSeq != 0 {
+		commitSeq = state.CommitSeq
+	}
+	if _, err := db.reconcileLeafGenerationManifestWithDirLocked(commitSeq); err != nil {
+		return stats, err
+	}
 
 	manifest := db.leafGenerationManifest.clone()
 	if manifest == nil {

--- a/TreeDB/db/leaf_generation_manifest.go
+++ b/TreeDB/db/leaf_generation_manifest.go
@@ -227,8 +227,46 @@ func (m *leafGenerationManifest) currentGenerationMaxRecoveredSeq() uint32 {
 	if idx < 0 {
 		return 0
 	}
+	return maxLeafGenerationFileSeq(m.Generations[idx].FileIDs)
+}
+
+func (m *leafGenerationManifest) maxNonDeletedRecoveredSeq() uint32 {
+	if m == nil {
+		return 0
+	}
 	maxSeq := uint32(0)
-	for _, rawFileID := range m.Generations[idx].FileIDs {
+	for i := range m.Generations {
+		gen := m.Generations[i]
+		if gen.State == leafGenerationStateDeleted {
+			continue
+		}
+		if seq := maxLeafGenerationFileSeq(gen.FileIDs); seq > maxSeq {
+			maxSeq = seq
+		}
+	}
+	return maxSeq
+}
+
+func (m *leafGenerationManifest) hasNonDeletedFileID(fileID uint32) bool {
+	if m == nil || fileID == 0 {
+		return false
+	}
+	for _, gen := range m.Generations {
+		if gen.State == leafGenerationStateDeleted {
+			continue
+		}
+		for _, existing := range gen.FileIDs {
+			if existing == fileID {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func maxLeafGenerationFileSeq(fileIDs []uint32) uint32 {
+	maxSeq := uint32(0)
+	for _, rawFileID := range fileIDs {
 		if rawFileID == 0 {
 			continue
 		}
@@ -531,7 +569,16 @@ func (db *DB) stagedLeafGenerationManifestWithPending(base *leafGenerationManife
 		if len(batch) == 0 {
 			return nil
 		}
-		_, changed, err := noteLeafGenerationWritableFileIDsInManifest(working, batch, batchCommitSeq)
+		registrable, err := db.filterLeafGenerationRegistrableRawFileIDs(working, batch)
+		if err != nil {
+			return err
+		}
+		if len(registrable) == 0 {
+			batch = batch[:0]
+			batchCommitSeq = 0
+			return nil
+		}
+		_, changed, err := noteLeafGenerationWritableFileIDsInManifest(working, registrable, batchCommitSeq)
 		if err != nil {
 			return err
 		}
@@ -563,7 +610,10 @@ func (db *DB) stagedLeafGenerationManifestWithPending(base *leafGenerationManife
 	if err := flushBatch(); err != nil {
 		return base, false, err
 	}
-	return working, changedAny, nil
+	if !changedAny {
+		return base, false, nil
+	}
+	return working, true, nil
 }
 
 func (db *DB) noteLeafGenerationWritableFileIDs(fileIDs []uint32, commitSeq uint64) error {
@@ -577,7 +627,14 @@ func (db *DB) noteLeafGenerationWritableFileIDs(fileIDs []uint32, commitSeq uint
 	}
 	nextManifest := db.leafGenerationManifest.clone()
 	db.mu.Unlock()
-	sealedFileIDs, changedAny, err := noteLeafGenerationWritableFileIDsInManifest(nextManifest, fileIDs, commitSeq)
+	registrable, err := db.filterLeafGenerationRegistrableRawFileIDs(nextManifest, fileIDs)
+	if err != nil {
+		return err
+	}
+	if len(registrable) == 0 {
+		return nil
+	}
+	sealedFileIDs, changedAny, err := noteLeafGenerationWritableFileIDsInManifest(nextManifest, registrable, commitSeq)
 	if err != nil {
 		return err
 	}
@@ -752,6 +809,108 @@ func bootstrapLeafGenerationManifestFromDir(leafDir string, commitSeq uint64) (*
 	return manifest, nil
 }
 
+func pruneMissingLeafGenerationManifestFileIDs(manifest *leafGenerationManifest, diskFiles map[uint32]struct{}, commitSeq uint64) bool {
+	if manifest == nil {
+		return false
+	}
+	changed := false
+	for i := range manifest.Generations {
+		gen := &manifest.Generations[i]
+		if gen.State == leafGenerationStateDeleted {
+			continue
+		}
+		if len(gen.FileIDs) == 0 {
+			continue
+		}
+		kept := gen.FileIDs[:0]
+		for _, rawFileID := range gen.FileIDs {
+			if rawFileID == 0 {
+				changed = true
+				continue
+			}
+			if _, ok := diskFiles[rawFileID]; !ok {
+				changed = true
+				continue
+			}
+			kept = append(kept, rawFileID)
+		}
+		if len(kept) != len(gen.FileIDs) {
+			changed = true
+		}
+		gen.FileIDs = append([]uint32(nil), kept...)
+		if gen.State != leafGenerationStateWritable && len(gen.FileIDs) == 0 {
+			gen.State = leafGenerationStateDeleted
+			if commitSeq > gen.DeletedCommitSeq {
+				gen.DeletedCommitSeq = commitSeq
+			}
+			if commitSeq > gen.PublishedCommitSeq {
+				gen.PublishedCommitSeq = commitSeq
+			}
+			changed = true
+		}
+	}
+	return changed
+}
+
+func leafGenerationRawFileExists(rootDir string, rawFileID uint32) (bool, error) {
+	if rootDir == "" || rawFileID == 0 {
+		return false, nil
+	}
+	path := leafGenerationFallbackPath(rootDir, rawFileID)
+	if path == "" {
+		return false, nil
+	}
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+func (db *DB) filterLeafGenerationRegistrableRawFileIDs(manifest *leafGenerationManifest, fileIDs []uint32) ([]uint32, error) {
+	if db == nil || manifest == nil || len(fileIDs) == 0 {
+		return nil, nil
+	}
+	maxSeq := manifest.maxNonDeletedRecoveredSeq()
+	out := make([]uint32, 0, len(fileIDs))
+	seen := make(map[uint32]struct{}, len(fileIDs))
+	for _, rawFileID := range fileIDs {
+		if rawFileID == 0 {
+			continue
+		}
+		if _, ok := seen[rawFileID]; ok {
+			continue
+		}
+		seen[rawFileID] = struct{}{}
+		if manifest.hasNonDeletedFileID(rawFileID) {
+			continue
+		}
+		exists, err := leafGenerationRawFileExists(db.dir, rawFileID)
+		if err != nil {
+			return nil, err
+		}
+		if !exists {
+			continue
+		}
+		_, seq := valuelog.DecodeSegmentID(rawFileID)
+		if maxSeq != 0 && seq <= maxSeq {
+			continue
+		}
+		out = append(out, rawFileID)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		_, seqI := valuelog.DecodeSegmentID(out[i])
+		_, seqJ := valuelog.DecodeSegmentID(out[j])
+		if seqI != seqJ {
+			return seqI < seqJ
+		}
+		return out[i] < out[j]
+	})
+	return out, nil
+}
+
 func reconcileLeafGenerationManifestWithDir(leafDir string, manifest *leafGenerationManifest, commitSeq uint64) (*leafGenerationManifest, bool, error) {
 	if manifest == nil {
 		return nil, false, nil
@@ -760,17 +919,16 @@ func reconcileLeafGenerationManifestWithDir(leafDir string, manifest *leafGenera
 	if err != nil {
 		return nil, false, err
 	}
-	if len(files) == 0 {
-		return manifest, false, nil
-	}
 	diskFiles := make(map[uint32]struct{}, len(files))
 	for _, file := range files {
 		if file.rawFileID != 0 {
 			diskFiles[file.rawFileID] = struct{}{}
 		}
 	}
-	seen := make(map[uint32]struct{}, len(manifest.Generations))
-	for _, gen := range manifest.Generations {
+	reconciled := manifest.clone()
+	changedAny := pruneMissingLeafGenerationManifestFileIDs(reconciled, diskFiles, commitSeq)
+	seen := make(map[uint32]struct{}, len(reconciled.Generations))
+	for _, gen := range reconciled.Generations {
 		if gen.State == leafGenerationStateDeleted {
 			// A deleted record for a file that is still on disk is retry state for a
 			// pending zombie delete. Keep it seen so reconciliation does not resurrect
@@ -793,9 +951,7 @@ func reconcileLeafGenerationManifestWithDir(leafDir string, manifest *leafGenera
 			seen[rawFileID] = struct{}{}
 		}
 	}
-	reconciled := manifest.clone()
-	changedAny := false
-	currentSeq := reconciled.currentGenerationMaxRecoveredSeq()
+	currentSeq := reconciled.maxNonDeletedRecoveredSeq()
 	for _, file := range files {
 		if _, ok := seen[file.rawFileID]; ok {
 			continue
@@ -820,6 +976,9 @@ func reconcileLeafGenerationManifestWithDir(leafDir string, manifest *leafGenera
 	}
 	if !changedAny {
 		return manifest, false, nil
+	}
+	if err := validateLeafGenerationManifest(reconciled); err != nil {
+		return nil, false, err
 	}
 	return reconciled, true, nil
 }
@@ -855,4 +1014,34 @@ func loadOrCreateLeafGenerationManifest(leafDir string, commitSeq uint64, readOn
 		return nil, err
 	}
 	return manifest.clone(), nil
+}
+
+func (db *DB) reconcileLeafGenerationManifestWithDirInPlace(commitSeq uint64) (bool, error) {
+	if db == nil || db.readOnly || !db.indexOuterLeavesInValueLog {
+		return false, nil
+	}
+	db.writeMu.Lock()
+	defer db.writeMu.Unlock()
+	return db.reconcileLeafGenerationManifestWithDirLocked(commitSeq)
+}
+
+func (db *DB) reconcileLeafGenerationManifestWithDirLocked(commitSeq uint64) (bool, error) {
+	if db == nil || db.readOnly || db.leafGenerationManifest == nil {
+		return false, nil
+	}
+	leafDir := LeafLogDirPath(db.dir)
+	reconciled, changed, err := reconcileLeafGenerationManifestWithDir(leafDir, db.leafGenerationManifest, commitSeq)
+	if err != nil || !changed {
+		return false, err
+	}
+	if err := saveLeafGenerationManifest(leafDir, reconciled); err != nil {
+		return false, err
+	}
+	db.mu.Lock()
+	db.leafGenerationManifest = reconciled
+	db.mu.Unlock()
+	if err := db.publishLeafGenerationState(false); err != nil {
+		return false, err
+	}
+	return true, nil
 }

--- a/TreeDB/db/leaf_generation_manifest_test.go
+++ b/TreeDB/db/leaf_generation_manifest_test.go
@@ -385,6 +385,56 @@ func TestReconcileLeafGenerationManifestWithDir_PreservesDeletedGenerationFilePr
 	}
 }
 
+func TestReconcileLeafGenerationManifestWithDir_DropsMissingCurrentWritableFile(t *testing.T) {
+	leafDir := t.TempDir()
+	_, fileID18 := createLeafGenerationTestSegment(t, leafDir, rewriteLeafLogLaneID, 18)
+	_, fileID19 := createLeafGenerationTestSegment(t, leafDir, rewriteLeafLogLaneID, 19)
+	_, fileID20 := createLeafGenerationTestSegment(t, leafDir, rewriteLeafLogLaneID, 20)
+	fileID17, err := valuelog.EncodeFileID(rewriteLeafLogLaneID, 17)
+	if err != nil {
+		t.Fatalf("EncodeFileID: %v", err)
+	}
+	raw17 := page.ValueLogSegmentID(fileID17)
+	raw18 := page.ValueLogSegmentID(fileID18)
+	raw19 := page.ValueLogSegmentID(fileID19)
+	raw20 := page.ValueLogSegmentID(fileID20)
+	manifest := &leafGenerationManifest{
+		Version:             leafGenerationManifestVersion,
+		CurrentGenerationID: 3,
+		NextGenerationID:    4,
+		Generations: []leafGenerationRecord{
+			{GenerationID: 1, State: leafGenerationStateSealed, FileIDs: []uint32{raw18}, CreatedCommitSeq: 10, SealedCommitSeq: 20, PublishedCommitSeq: 20},
+			{GenerationID: 2, State: leafGenerationStateSealed, FileIDs: []uint32{raw19}, CreatedCommitSeq: 21, SealedCommitSeq: 30, PublishedCommitSeq: 30},
+			{GenerationID: 3, State: leafGenerationStateWritable, FileIDs: []uint32{raw17}, CreatedCommitSeq: 31, PublishedCommitSeq: 31},
+		},
+	}
+
+	reconciled, changed, err := reconcileLeafGenerationManifestWithDir(leafDir, manifest, 99)
+	if err != nil {
+		t.Fatalf("reconcileLeafGenerationManifestWithDir: %v", err)
+	}
+	if !changed {
+		t.Fatal("expected reconcile to drop missing current file and recover writable tail")
+	}
+	view := newLeafGenerationView(reconciled)
+	if _, ok := view.FileToGeneration[raw17]; ok {
+		t.Fatalf("missing raw file %d still present in generation view", raw17)
+	}
+	if got, want := view.FileToGeneration[raw18], uint64(1); got != want {
+		t.Fatalf("raw18 generation=%d, want %d", got, want)
+	}
+	if got, want := view.FileToGeneration[raw19], uint64(2); got != want {
+		t.Fatalf("raw19 generation=%d, want %d", got, want)
+	}
+	if got, want := view.FileToGeneration[raw20], uint64(3); got != want {
+		t.Fatalf("raw20 generation=%d, want %d", got, want)
+	}
+	current := reconciled.Generations[reconciled.currentGenerationIndex()]
+	if got, want := current.FileIDs, []uint32{raw20}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("current FileIDs=%v, want %v", got, want)
+	}
+}
+
 func TestLeafGenerationManifest_AppendRecoveredSealedGenerationFileID_IgnoresDeletedGenerationDuplicates(t *testing.T) {
 	manifest := &leafGenerationManifest{
 		Version:             leafGenerationManifestVersion,
@@ -763,6 +813,56 @@ func TestStagedLeafGenerationManifestWithPending_ReflectsQueuedWritableFiles(t *
 	liveCurrent := db.leafGenerationManifest.Generations[db.leafGenerationManifest.currentGenerationIndex()]
 	if got, want := liveCurrent.FileIDs, []uint32{page.ValueLogSegmentID(fileID1)}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("live current FileIDs=%v, want %v", got, want)
+	}
+}
+
+func TestStagedLeafGenerationManifestWithPending_IgnoresStaleMissingOlderFile(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(Options{Dir: dir, IndexOuterLeavesInValueLog: true})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	_, fileID18 := createLeafGenerationTestSegment(t, LeafLogDirPath(dir), rewriteLeafLogLaneID, 18)
+	_, fileID19 := createLeafGenerationTestSegment(t, LeafLogDirPath(dir), rewriteLeafLogLaneID, 19)
+	if err := db.noteLeafGenerationWritableFileID(fileID18, 55); err != nil {
+		t.Fatalf("noteLeafGenerationWritableFileID first: %v", err)
+	}
+	if err := db.noteLeafGenerationWritableFileID(fileID19, 89); err != nil {
+		t.Fatalf("noteLeafGenerationWritableFileID second: %v", err)
+	}
+
+	fileID17, err := valuelog.EncodeFileID(rewriteLeafLogLaneID, 17)
+	if err != nil {
+		t.Fatalf("EncodeFileID: %v", err)
+	}
+	raw17 := page.ValueLogSegmentID(fileID17)
+	raw19 := page.ValueLogSegmentID(fileID19)
+	db.queueLeafGenerationWritableFileID(fileID17)
+
+	staged, changed, err := db.stagedLeafGenerationManifestWithPending(db.leafGenerationManifest, 0, 144)
+	if err != nil {
+		t.Fatalf("stagedLeafGenerationManifestWithPending: %v", err)
+	}
+	if changed {
+		t.Fatalf("expected stale missing file %d to be ignored", raw17)
+	}
+	if staged != db.leafGenerationManifest {
+		t.Fatal("expected unchanged staging to return the live manifest")
+	}
+	if err := db.noteLeafGenerationPendingFileIDs(0, 144); err != nil {
+		t.Fatalf("noteLeafGenerationPendingFileIDs: %v", err)
+	}
+	if len(db.leafGenerationPendingFileIDs) != 0 {
+		t.Fatalf("pending file IDs after stale drain=%v, want empty", db.leafGenerationPendingFileIDs)
+	}
+	current := db.leafGenerationManifest.Generations[db.leafGenerationManifest.currentGenerationIndex()]
+	if got, want := current.FileIDs, []uint32{raw19}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("current FileIDs=%v, want %v", got, want)
+	}
+	if view := db.currentLeafGenerationView(); view.FileToGeneration[raw17] != 0 {
+		t.Fatalf("stale raw file %d became visible in current view", raw17)
 	}
 }
 

--- a/TreeDB/db/leaf_generation_plan.go
+++ b/TreeDB/db/leaf_generation_plan.go
@@ -3,8 +3,10 @@ package db
 import (
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"math/bits"
+	"os"
 	"sort"
 	"sync"
 
@@ -880,6 +882,9 @@ func (db *DB) scanLeafGenerationLiveStatsWithOptions(ctx context.Context, snap *
 		persist := gen.State == leafGenerationStateSealed
 		idx, err := db.loadOrBuildLeafGenerationRecordLengthIndex(fileID, snap.state.ValueLogSet, persist)
 		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
 			return leafGenerationLiveScanStats{}, err
 		}
 		fileStates = append(fileStates, leafGenerationScanFileState{

--- a/TreeDB/db/leaf_generation_plan_test.go
+++ b/TreeDB/db/leaf_generation_plan_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/snissn/gomap/TreeDB/page"
 )
 
-func TestLeafGenerationPlan_SkipsUnreferencedMissingManifestFile(t *testing.T) {
+func TestLeafGenerationPlan_ReportsZeroBytesForMissingManifestFile(t *testing.T) {
 	db, err := Open(Options{Dir: t.TempDir(), IndexOuterLeavesInValueLog: true})
 	if err != nil {
 		t.Fatalf("Open: %v", err)

--- a/TreeDB/db/leaf_generation_plan_test.go
+++ b/TreeDB/db/leaf_generation_plan_test.go
@@ -8,8 +8,40 @@ import (
 	"testing"
 
 	"github.com/snissn/gomap/TreeDB/internal/leafrefscan"
+	"github.com/snissn/gomap/TreeDB/internal/valuelog"
 	"github.com/snissn/gomap/TreeDB/page"
 )
+
+func TestLeafGenerationPlan_SkipsUnreferencedMissingManifestFile(t *testing.T) {
+	db, err := Open(Options{Dir: t.TempDir(), IndexOuterLeavesInValueLog: true})
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	fileID, err := valuelog.EncodeFileID(rewriteLeafLogLaneID, 17)
+	if err != nil {
+		t.Fatalf("EncodeFileID: %v", err)
+	}
+	rawFileID := page.ValueLogSegmentID(fileID)
+	manifest := db.leafGenerationManifest.clone()
+	manifest.Generations[manifest.currentGenerationIndex()].FileIDs = []uint32{rawFileID}
+	db.writeMu.Lock()
+	db.leafGenerationManifest = manifest
+	db.writeMu.Unlock()
+	if err := db.publishLeafGenerationState(false); err != nil {
+		t.Fatalf("publishLeafGenerationState: %v", err)
+	}
+
+	plan, err := db.LeafGenerationPlan(context.Background(), LeafGenerationPlanOptions{Force: true})
+	if err != nil {
+		t.Fatalf("LeafGenerationPlan with stale missing manifest file: %v", err)
+	}
+	entry := findLeafGenerationPlanEntry(t, plan, manifest.CurrentGenerationID)
+	if got, want := entry.BytesTotal, int64(0); got != want {
+		t.Fatalf("BytesTotal=%d, want %d", got, want)
+	}
+}
 
 func findLeafGenerationPlanEntry(t *testing.T, plan LeafGenerationPlan, generationID uint64) LeafGenerationPlanGeneration {
 	t.Helper()


### PR DESCRIPTION
## Summary
- Repair leaf-generation manifests that retain non-deleted entries for missing `leaf_vlog` files.
- Filter stale/missing pending writable leaf-log registrations so an older compact leaf writer cannot reintroduce a reclaimed segment as current.
- Let leaf-generation planning ignore unreferenced missing manifest files, while still failing if a live leaf pointer references an untracked/missing generation.
- Add CompactStorage/manifest/plan regression coverage for the reopened #2468 missing `value-l255-000017.log` shape.

Fixes #2468.

## Tests
- `go test ./TreeDB/db -count=1`
- `go test ./TreeDB -count=1`
- `go test ./TreeDB/integration/gethethdb -count=1`
- `go test ./... -count=1` (initial `TreeDB/mongo_gateway` timeout in `TestStandaloneServerCommandWALBSONInsertReadUpdateVisibility`; rerun passed)
- `go test ./TreeDB/mongo_gateway -run TestStandaloneServerCommandWALBSONInsertReadUpdateVisibility -count=1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved database robustness by automatically reconciling and repairing missing or stale leaf-generation file references during storage compaction and garbage collection operations.
  * Added automatic cleanup of orphaned manifest entries that reference non-existent files.
  * Enhanced error handling to gracefully skip unreferenced missing files during planning and scanning operations.

* **Tests**
  * Added test coverage for manifest repair and reconciliation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->