### PR TITLE
Add collection buffered rabitq vector search

### DIFF
--- a/TreeDB/collections/collection_vector_index_prepared_search_cache.go
+++ b/TreeDB/collections/collection_vector_index_prepared_search_cache.go
@@ -7,7 +7,6 @@ import (
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 	"github.com/snissn/gomap/TreeDB/internal/mappedresource"
-	"github.com/snissn/gomap/TreeDB/internal/rabitq"
 )
 
 type collectionVectorIndexPreparedSearchFamily uint8
@@ -468,10 +467,6 @@ func (c *Collection) openCollectionVectorIndexPreparedQuantizedSearch(opts Vecto
 		response.Stats = collectionVectorIndexPreparedQuantizedValidationStats(reader, routeStats, opts.QuantizedIndexName, queryMode)
 		return nil, response, err
 	}
-	if qdef, ok := findQuantizedVectorIndex(def, opts.QuantizedIndexName); ok && qdef.Codec == rabitq.CodecName {
-		response.Stats = collectionVectorIndexPreparedQuantizedValidationStats(reader, routeStats, opts.QuantizedIndexName, queryMode)
-		return nil, response, fmt.Errorf("%w: vector index %q SearchVectorIndexWithBuffer collection buffered quantized route does not yet support rabitq_1bit; use VectorIndexSearcher.SearchWithBuffer for lower-level rabitq_1bit search", ErrVectorIndexSearchUnavailable, def.Name)
-	}
 	key, err := collectionVectorIndexPreparedQuantizedSearchCacheKey(readerCatalog.meta.Name, view.AssetNamespace, def, graph, view.VectorIndexState, opts.QuantizedIndexName, opts.MaxDecodedBlocks)
 	if err != nil {
 		return nil, response, err
@@ -554,7 +549,12 @@ func collectionVectorIndexPreparedQuantizedSearchCacheKey(collection string, nam
 	if !ok {
 		return "", fmt.Errorf("%w: %w: vector index %q quantized index %q has no quantized score-plane asset", ErrVectorIndexSearchUnavailable, errColumnVectorGraphQuantizedAssetMissing, def.Name, quantizedIndexName)
 	}
-	return fmt.Sprintf("collection_buffered_quantized_v1|family=quantized|q=%s|codec=%s|version=%d|max_decoded_blocks=%d|asset_id=%s|asset_schema=%d|asset_bytes=%d|asset_ref=%+v|%s", qdef.Name, qdef.Codec, qdef.Version, maxDecodedBlocks, asset.AssetID, asset.SourceSchemaHash, asset.AssetBytes, columnVectorGraphQuantizedAssetRefIdentity(asset.Ref), base), nil
+	refIdentity := columnVectorGraphQuantizedAssetRefIdentity(asset.Ref)
+	schema, err := columnVectorGraphQuantizedAssetSchema(def, graph, qdef, asset, refIdentity)
+	if err != nil {
+		return "", fmt.Errorf("%w: %w: vector index %q quantized index %q cache key schema identity: %v", ErrVectorIndexSearchUnavailable, errColumnVectorGraphQuantizedAssetInvalid, def.Name, quantizedIndexName, err)
+	}
+	return fmt.Sprintf("collection_buffered_quantized_v1|family=quantized|q=%s|codec=%s|version=%d|codec_config_hash=%d|codec_config=%x|code_dimensions=%d|code_width_bits=%d|max_decoded_blocks=%d|asset_id=%s|asset_schema=%d|asset_bytes=%d|asset_ref=%+v|%s", qdef.Name, qdef.Codec, qdef.Version, schema.Codec.ConfigHash, schema.Codec.Config, schema.CodeDimensions, schema.CodeWidthBits, maxDecodedBlocks, asset.AssetID, asset.SourceSchemaHash, asset.AssetBytes, refIdentity, base), nil
 }
 
 func (p *collectionVectorIndexPreparedSearch) readyForCurrentSearch() bool {

--- a/TreeDB/collections/column_vector_graph_quantized_bench_test.go
+++ b/TreeDB/collections/column_vector_graph_quantized_bench_test.go
@@ -63,6 +63,10 @@ func columnGraphScalarU8QuantizedCollectionWithBufferBenchCases2415() []columnGr
 	}
 }
 
+func columnGraphRabitQQuantizedCollectionWithBufferBenchCases2452() []columnGraphScalarU8QuantizedCollectionWithBufferBenchCase2415 {
+	return columnGraphScalarU8QuantizedCollectionWithBufferBenchCases2415()
+}
+
 func BenchmarkColumnGraphScalarU8QuantizedScorePlanes1926(b *testing.B) {
 	shape := columnGraphScalarU8QuantizedBenchShape1926{rows: 1024, dims: 128, m: 16, topK: 10, efSearch: 128, queryOrdinal: 37}
 	fixture := openColumnGraphScalarU8QuantizedBenchFixture1926(b, shape, true)
@@ -188,6 +192,31 @@ func BenchmarkCollectionSearchVectorIndexWithBufferColumnGraphScalarU8Quantized2
 				Query:                     fixture.query,
 				QueryMode:                 tc.mode,
 				QuantizedIndexName:        columnGraphScalarU8QuantizedBenchIndexName1926,
+				QuantizedRerankCandidates: tc.rerankCandidates,
+				TopK:                      fixture.shape.topK,
+				EfSearch:                  fixture.shape.efSearch,
+				MaxDecodedBlocks:          1,
+				StatsMode:                 VectorIndexSearchStatsModeProduction,
+			}
+			runColumnGraphScalarU8QuantizedCollectionWithBufferBench2415(b, fixture, opts, tc.concurrency, exactIDs, exactCount)
+		})
+	}
+}
+
+func BenchmarkCollectionSearchVectorIndexWithBufferColumnGraphRabitQQuantized2452(b *testing.B) {
+	shape := columnGraphScalarU8QuantizedBenchShape1926{rows: 1024, dims: 128, m: 16, topK: 10, efSearch: 128, queryOrdinal: 37}
+	fixture := openColumnGraphRabitQQuantizedBenchFixture2451(b, shape)
+	defer fixture.close()
+	exactIDs, exactCount := columnGraphScalarU8QuantizedBenchmarkExactIDs1926(b, fixture)
+
+	for _, tc := range columnGraphRabitQQuantizedCollectionWithBufferBenchCases2452() {
+		tc := tc
+		b.Run(tc.name, func(b *testing.B) {
+			opts := VectorIndexSearchOptions{
+				IndexName:                 fixture.definition.Name,
+				Query:                     fixture.query,
+				QueryMode:                 tc.mode,
+				QuantizedIndexName:        columnGraphRabitQQuantizedIndexName2450,
 				QuantizedRerankCandidates: tc.rerankCandidates,
 				TopK:                      fixture.shape.topK,
 				EfSearch:                  fixture.shape.efSearch,

--- a/TreeDB/collections/column_vector_graph_quantized_bench_test.go
+++ b/TreeDB/collections/column_vector_graph_quantized_bench_test.go
@@ -330,16 +330,16 @@ func runColumnGraphScalarU8QuantizedCollectionWithBufferBench2415(b *testing.B, 
 	}
 	cacheBeforeTimed := fixture.collection.collectionVectorIndexPreparedSearchCacheSnapshot()
 	b.ReportAllocs()
+	b.ResetTimer()
+	close(start)
+	wg.Wait()
+	b.StopTimer()
 	b.ReportMetric(float64(concurrency), "concurrency")
 	b.ReportMetric(1, "collection_searchvectorindex_with_buffer_seam")
 	b.ReportMetric(1, "collection_buffered_quantized_row")
 	b.ReportMetric(0, "open_searcher_calls/op")
 	b.ReportMetric(0, "open_setup_in_timed_loop")
 	b.ReportMetric(1, "reported_stats_mode_production")
-	b.ResetTimer()
-	close(start)
-	wg.Wait()
-	b.StopTimer()
 	if errValue := firstErr.Load(); errValue != nil {
 		b.Fatalf("%s", errValue.(string))
 	}

--- a/TreeDB/collections/column_vector_graph_rabitq_quantized_asset_test.go
+++ b/TreeDB/collections/column_vector_graph_rabitq_quantized_asset_test.go
@@ -3,6 +3,7 @@ package collections
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"math"
 	"strings"
 	"testing"
@@ -188,9 +189,11 @@ func TestVectorIndexSearcherRabitQQuantizedSearchWithBuffer2451(t *testing.T) {
 
 	var collectionBuffer VectorIndexSearchBuffer
 	collectionGot, err := col.SearchVectorIndexWithBuffer(VectorIndexSearchOptions{IndexName: def.Name, Query: query, QueryMode: VectorIndexQueryModeQuantizedOnly, QuantizedIndexName: q.Name, TopK: 3, EfSearch: len(rows), MaxDecodedBlocks: 1}, &collectionBuffer)
-	if !errors.Is(err, ErrVectorIndexSearchUnavailable) || !strings.Contains(err.Error(), "does not yet support rabitq_1bit") || len(collectionGot.Results) != 0 {
-		t.Fatalf("collection SearchVectorIndexWithBuffer rabitq response=%+v err=%v want scoped unsupported fail-closed", collectionGot, err)
+	if err != nil {
+		t.Fatalf("collection rabitq quantized_only SearchVectorIndexWithBuffer: %v", err)
 	}
+	assertVectorIndexSearchResultsV4(t, collectionGot.Results, rabitqQuantizedTopKForTest2451(t, rows, query, 3), false)
+	assertRabitQQuantizedOnlyStats2451(t, collectionGot.Stats, plan.BytesPerCode())
 
 	rerankedAll, err := searcher.SearchWithBuffer(VectorIndexSearcherSearchOptions{Query: query, QueryMode: VectorIndexQueryModeQuantizedRerank, QuantizedIndexName: q.Name, QuantizedRerankCandidates: len(rows), TopK: 2, EfSearch: len(rows)}, &buffer)
 	if err != nil {
@@ -208,6 +211,307 @@ func TestVectorIndexSearcherRabitQQuantizedSearchWithBuffer2451(t *testing.T) {
 		t.Fatalf("rabitq quantized_rerank short results=%d want 2", len(rerankedShort.Results))
 	}
 	assertRabitQQuantizedRerankStats2451(t, rerankedShort.Stats, shortlist, def.Dimensions, plan.BytesPerCode())
+}
+
+func TestCollectionSearchVectorIndexWithBufferRabitQQuantized2452(t *testing.T) {
+	rows := []columnGraphRebuildInputRowV2A{
+		{id: "doc-a", vector: []float32{1, 0, 0}},
+		{id: "doc-b", vector: []float32{0.5, 0.5, 0}},
+		{id: "doc-c", vector: []float32{0, 1, 0}},
+		{id: "doc-d", vector: []float32{0, 0, 1}},
+		{id: "doc-e", vector: []float32{-0.25, 0.75, 0.125}},
+	}
+	query := []float32{0.2, 0.9, 0.1}
+	_, d, col, def := openColumnGraphRabitQQuantizedTestCollection2450(t, rows)
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		_ = d.Close()
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	q := def.QuantizedIndexes[0]
+	plan, err := rabitq.NewPlan(def.Dimensions, rabitq.DefaultConfig())
+	if err != nil {
+		_ = d.Close()
+		t.Fatalf("rabitq.NewPlan: %v", err)
+	}
+
+	quantizedOnlyOpts := VectorIndexSearchOptions{IndexName: def.Name, Query: query, QueryMode: VectorIndexQueryModeQuantizedOnly, QuantizedIndexName: q.Name, TopK: 3, EfSearch: len(rows), MaxDecodedBlocks: 1, StatsMode: VectorIndexSearchStatsModeProduction}
+	var buffer VectorIndexSearchBuffer
+	quantizedOnly, err := col.SearchVectorIndexWithBuffer(quantizedOnlyOpts, &buffer)
+	if err != nil {
+		_ = d.Close()
+		t.Fatalf("SearchVectorIndexWithBuffer rabitq quantized_only: %v", err)
+	}
+	assertColumnGraphSearchResponseLoadedV4(t, quantizedOnly, def.Name, quantizedOnlyOpts.TopK)
+	assertVectorIndexSearchResultsV4(t, quantizedOnly.Results, rabitqQuantizedTopKForTest2451(t, rows, query, quantizedOnlyOpts.TopK), false)
+	assertCollectionBufferedRabitQQuantizedRouteStats2452(t, quantizedOnly.Stats, columnVectorGraphNativeSearchQueryModeQuantizedOnly, quantizedOnlyOpts, def.Dimensions, plan.BytesPerCode())
+	if len(buffer.results) != quantizedOnlyOpts.TopK || len(buffer.idBytes) == 0 || &quantizedOnly.Results[0] != &buffer.results[0] || &quantizedOnly.Results[0].ID[0] != &buffer.idBytes[0] {
+		_ = d.Close()
+		t.Fatalf("rabitq quantized_only response does not alias caller-owned buffer: results=%d idBytes=%d", len(buffer.results), len(buffer.idBytes))
+	}
+	warmSnap := col.collectionVectorIndexPreparedSearchCacheSnapshot()
+	if warmSnap.Entries != 1 || warmSnap.CacheBuilds != 1 || warmSnap.CacheMisses != 1 {
+		_ = d.Close()
+		t.Fatalf("cache after rabitq quantized warm=%+v want one prepared entry", warmSnap)
+	}
+
+	for i := 0; i < 3; i++ {
+		got, err := col.SearchVectorIndexWithBuffer(quantizedOnlyOpts, &buffer)
+		if err != nil {
+			_ = d.Close()
+			t.Fatalf("cached rabitq quantized_only iteration %d: %v", i, err)
+		}
+		assertCollectionBufferedRabitQQuantizedRouteStats2452(t, got.Stats, columnVectorGraphNativeSearchQueryModeQuantizedOnly, quantizedOnlyOpts, def.Dimensions, plan.BytesPerCode())
+	}
+	afterOnly := col.collectionVectorIndexPreparedSearchCacheSnapshot()
+	if afterOnly.Entries != 1 || afterOnly.CacheBuilds != warmSnap.CacheBuilds || afterOnly.CacheHits < warmSnap.CacheHits+3 {
+		_ = d.Close()
+		t.Fatalf("cache after rabitq quantized_only reuse=%+v warm=%+v want hits without rebuild", afterOnly, warmSnap)
+	}
+
+	rerankOpts := quantizedOnlyOpts
+	rerankOpts.QueryMode = VectorIndexQueryModeQuantizedRerank
+	rerankOpts.QuantizedRerankCandidates = len(rows)
+	rerankOpts.TopK = 2
+	reranked, err := col.SearchVectorIndexWithBuffer(rerankOpts, &buffer)
+	if err != nil {
+		_ = d.Close()
+		t.Fatalf("SearchVectorIndexWithBuffer rabitq quantized_rerank: %v", err)
+	}
+	assertColumnGraphSearchResponseLoadedV4(t, reranked, def.Name, rerankOpts.TopK)
+	assertVectorIndexSearchResultsV4(t, reranked.Results, exactColumnGraphTopKForTest(t, rows, query, rerankOpts.TopK), false)
+	assertCollectionBufferedRabitQQuantizedRouteStats2452(t, reranked.Stats, columnVectorGraphNativeSearchQueryModeQuantizedRerank, rerankOpts, def.Dimensions, plan.BytesPerCode())
+	afterRerank := col.collectionVectorIndexPreparedSearchCacheSnapshot()
+	if afterRerank.Entries != 1 || afterRerank.CacheBuilds != afterOnly.CacheBuilds || afterRerank.CacheHits <= afterOnly.CacheHits {
+		_ = d.Close()
+		t.Fatalf("cache after rabitq quantized_rerank=%+v afterOnly=%+v want shared prepared entry", afterRerank, afterOnly)
+	}
+
+	quantizedOnlyAllocs := testing.AllocsPerRun(100, func() {
+		got, err := col.SearchVectorIndexWithBuffer(quantizedOnlyOpts, &buffer)
+		if err != nil || len(got.Results) != quantizedOnlyOpts.TopK {
+			panic("unexpected rabitq quantized_only SearchVectorIndexWithBuffer allocation probe result")
+		}
+	})
+	if quantizedOnlyAllocs != 0 {
+		_ = d.Close()
+		t.Fatalf("rabitq quantized_only SearchVectorIndexWithBuffer steady-state allocs/run=%v want 0", quantizedOnlyAllocs)
+	}
+	rerankAllocs := testing.AllocsPerRun(100, func() {
+		got, err := col.SearchVectorIndexWithBuffer(rerankOpts, &buffer)
+		if err != nil || len(got.Results) != rerankOpts.TopK {
+			panic("unexpected rabitq quantized_rerank SearchVectorIndexWithBuffer allocation probe result")
+		}
+	})
+	if rerankAllocs != 0 {
+		_ = d.Close()
+		t.Fatalf("rabitq quantized_rerank SearchVectorIndexWithBuffer steady-state allocs/run=%v want 0", rerankAllocs)
+	}
+
+	beforeClose := col.collectionVectorIndexPreparedSearchCacheSnapshot()
+	if beforeClose.Entries != 1 || beforeClose.ActiveHandles == 0 {
+		_ = d.Close()
+		t.Fatalf("cache before close=%+v want active rabitq quantized entry", beforeClose)
+	}
+	if err := col.closeCollectionVectorIndexPreparedSearchCache(); err != nil {
+		_ = d.Close()
+		t.Fatalf("close collection cache: %v", err)
+	}
+	if snap := col.collectionVectorIndexPreparedSearchCacheSnapshot(); snap.Entries != 0 || snap.ActiveHandles != 0 {
+		_ = d.Close()
+		t.Fatalf("cache after collection close=%+v want released", snap)
+	}
+	if _, err := col.SearchVectorIndexWithBuffer(quantizedOnlyOpts, &buffer); err != nil {
+		_ = d.Close()
+		t.Fatalf("SearchVectorIndexWithBuffer after rabitq cache close: %v", err)
+	}
+	if snap := col.collectionVectorIndexPreparedSearchCacheSnapshot(); snap.Entries != 1 || snap.ActiveHandles == 0 {
+		_ = d.Close()
+		t.Fatalf("cache after rabitq rebuild=%+v want active entry", snap)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("DB Close: %v", err)
+	}
+	if snap := col.collectionVectorIndexPreparedSearchCacheSnapshot(); snap.Entries != 0 || snap.ActiveHandles != 0 {
+		t.Fatalf("cache after DB close=%+v want released by manager close hook", snap)
+	}
+}
+
+func TestCollectionSearchVectorIndexWithBufferRabitQFailClosedAndQueryErrors2452(t *testing.T) {
+	rows := []columnGraphRebuildInputRowV2A{
+		{id: "doc-a", vector: []float32{1, 0, 0}},
+		{id: "doc-b", vector: []float32{0, 1, 0}},
+		{id: "doc-c", vector: []float32{0, 0, 1}},
+	}
+	_, d, col, def := openColumnGraphRabitQQuantizedTestCollection2450(t, rows)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	q := def.QuantizedIndexes[0]
+	plan, err := rabitq.NewPlan(def.Dimensions, rabitq.DefaultConfig())
+	if err != nil {
+		t.Fatalf("rabitq.NewPlan: %v", err)
+	}
+	base := VectorIndexSearchOptions{IndexName: def.Name, Query: []float32{1, 0, 0}, QueryMode: VectorIndexQueryModeQuantizedOnly, QuantizedIndexName: q.Name, TopK: 1, EfSearch: len(rows), MaxDecodedBlocks: 1, StatsMode: VectorIndexSearchStatsModeProduction}
+	var buffer VectorIndexSearchBuffer
+	if _, err := col.SearchVectorIndexWithBuffer(base, &buffer); err != nil {
+		t.Fatalf("warm SearchVectorIndexWithBuffer: %v", err)
+	}
+	beforeBadQuery := col.collectionVectorIndexPreparedSearchCacheSnapshot()
+	if beforeBadQuery.Entries != 1 || beforeBadQuery.CacheBuilds != 1 || beforeBadQuery.ActiveHandles == 0 {
+		t.Fatalf("cache before bad rabitq query=%+v want warmed entry", beforeBadQuery)
+	}
+	badQuery := base
+	badQuery.Query = []float32{1, 0}
+	bad, err := col.SearchVectorIndexWithBuffer(badQuery, &buffer)
+	if !errors.Is(err, errColumnVectorGraphNativeSearchQueryDimensionMismatch) {
+		t.Fatalf("bad rabitq query response=%+v err=%v want dimension mismatch", bad, err)
+	}
+	if len(bad.Results) != 0 || len(buffer.results) != 0 || len(buffer.idBytes) != 0 {
+		t.Fatalf("bad rabitq query left results response=%d bufferResults=%d idBytes=%d", len(bad.Results), len(buffer.results), len(buffer.idBytes))
+	}
+	afterBadQuery := col.collectionVectorIndexPreparedSearchCacheSnapshot()
+	if afterBadQuery.Entries != 1 || afterBadQuery.CacheBuilds != beforeBadQuery.CacheBuilds || afterBadQuery.Invalidations != beforeBadQuery.Invalidations || afterBadQuery.ActiveHandles == 0 {
+		t.Fatalf("cache after bad rabitq query=%+v before=%+v want healthy prepared state retained", afterBadQuery, beforeBadQuery)
+	}
+	valid, err := col.SearchVectorIndexWithBuffer(base, &buffer)
+	if err != nil {
+		t.Fatalf("valid rabitq SearchVectorIndexWithBuffer after bad query: %v", err)
+	}
+	assertCollectionBufferedRabitQQuantizedRouteStats2452(t, valid.Stats, columnVectorGraphNativeSearchQueryModeQuantizedOnly, base, def.Dimensions, plan.BytesPerCode())
+
+	for _, tc := range []struct {
+		name   string
+		mode   VectorIndexQueryMode
+		health columnVectorGraphQuantizedAssetHealth
+		mutate func(map[string]columnVectorGraphQuantizedAssetLoadStatus, string, columnVectorGraphQuantizedAssetLoadStatus)
+	}{
+		{
+			name:   "missing",
+			mode:   VectorIndexQueryModeQuantizedOnly,
+			health: columnVectorGraphQuantizedAssetHealthMissing,
+			mutate: func(status map[string]columnVectorGraphQuantizedAssetLoadStatus, qName string, original columnVectorGraphQuantizedAssetLoadStatus) {
+				delete(status, qName)
+			},
+		},
+		{
+			name:   "invalid",
+			mode:   VectorIndexQueryModeQuantizedOnly,
+			health: columnVectorGraphQuantizedAssetHealthInvalid,
+			mutate: func(status map[string]columnVectorGraphQuantizedAssetLoadStatus, qName string, original columnVectorGraphQuantizedAssetLoadStatus) {
+				original.Prepared = nil
+				original.RabitQPlan = nil
+				original.Health = columnVectorGraphQuantizedAssetHealthInvalid
+				original.Err = fmt.Errorf("%w: checksum mismatch", errColumnVectorGraphQuantizedAssetInvalid)
+				status[qName] = original
+			},
+		},
+		{
+			name:   "stale",
+			mode:   VectorIndexQueryModeQuantizedRerank,
+			health: columnVectorGraphQuantizedAssetHealthStale,
+			mutate: func(status map[string]columnVectorGraphQuantizedAssetLoadStatus, qName string, original columnVectorGraphQuantizedAssetLoadStatus) {
+				original.Prepared = nil
+				original.RabitQPlan = nil
+				original.Health = columnVectorGraphQuantizedAssetHealthStale
+				original.Err = fmt.Errorf("%w: base graph identity mismatch", errColumnVectorGraphQuantizedAssetStale)
+				status[qName] = original
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := base
+			opts.QueryMode = tc.mode
+			if tc.mode == VectorIndexQueryModeQuantizedRerank {
+				opts.QuantizedRerankCandidates = 1
+			}
+			if _, err := col.SearchVectorIndexWithBuffer(opts, &buffer); err != nil {
+				t.Fatalf("warm %s SearchVectorIndexWithBuffer: %v", tc.name, err)
+			}
+			mutateCachedCollectionQuantizedAssetStatus2415(t, col, opts, tc.mutate)
+			got, err := col.SearchVectorIndexWithBuffer(opts, &buffer)
+			if !errors.Is(err, ErrVectorIndexSearchUnavailable) {
+				t.Fatalf("SearchVectorIndexWithBuffer err=%v want ErrVectorIndexSearchUnavailable", err)
+			}
+			if len(got.Results) != 0 || len(buffer.results) != 0 || len(buffer.idBytes) != 0 {
+				t.Fatalf("unavailable rabitq response results=%d buffer.results=%d idBytes=%d want fail-closed empty", len(got.Results), len(buffer.results), len(buffer.idBytes))
+			}
+			assertQuantizedUnavailableGuardrailStats2416(t, got.Stats, columnVectorGraphNativeSearchQueryModeFromPublic2415(tc.mode), tc.health)
+			if got.Stats.SearchRouteHNSWSearchPack != 0 || got.Stats.HNSWSearchPackFallbacks != 0 || got.Stats.PreparedScoreCalls != 0 || got.Stats.QuantizedScoreCalls != 0 || got.Stats.VectorBytesRead != 0 || got.Stats.NormBytesRead != 0 || got.Stats.OpenSearcherCalls != 0 || got.Stats.OpenSetupInTimedLoop != 0 {
+				t.Fatalf("unavailable rabitq stats=%+v want fail-closed without exact fallback/open", got.Stats)
+			}
+			afterFailure := col.collectionVectorIndexPreparedSearchCacheSnapshot()
+			if afterFailure.Entries != 0 || afterFailure.ActiveHandles != 0 {
+				t.Fatalf("cache after rabitq fail-closed asset=%+v want invalidated closed entry", afterFailure)
+			}
+			recovered, err := col.SearchVectorIndexWithBuffer(opts, &buffer)
+			if err != nil {
+				t.Fatalf("SearchVectorIndexWithBuffer after rabitq fail-closed rebuild: %v", err)
+			}
+			assertCollectionBufferedRabitQQuantizedRouteStats2452(t, recovered.Stats, columnVectorGraphNativeSearchQueryModeFromPublic2415(tc.mode), opts, def.Dimensions, plan.BytesPerCode())
+		})
+	}
+}
+
+func TestCollectionVectorIndexPreparedQuantizedSearchCacheKeyRabitQIdentity2452(t *testing.T) {
+	makeKey := func(t *testing.T, q QuantizedVectorIndexDefinition) string {
+		t.Helper()
+		def := columnGraphRebuildVectorIndexDefinitionV2A(3, 3)
+		def.QuantizedIndexes = []QuantizedVectorIndexDefinition{q}
+		def, err := normalizeVectorIndexDefinition(def)
+		if err != nil {
+			t.Fatalf("normalizeVectorIndexDefinition: %v", err)
+		}
+		q = def.QuantizedIndexes[0]
+		graphRef := ColumnAssetRef{Kind: ColumnAssetKindTCS1PartImage, Namespace: "ns", Generation: 7, PartID: 11, FileID: 13, Offset: 17, Length: 19, Checksum: 23}
+		graph := columnVectorGraphManifestSnapshot{IndexName: def.Name, Field: def.Field, Metric: def.Metric, Encoding: def.Encoding, Dimensions: def.Dimensions, M: def.M, EfConstruction: def.EfConstruction, EfSearch: def.EfSearch, BaseManifestGeneration: 29, BaseManifestChecksum: 31, BaseSchemaHash: 37, GraphSchemaHash: 41, RowCount: 5, AssetRef: graphRef, AssetBytes: graphRef.Length}
+		logicalType, physicalEncoding := columnVectorGraphQuantizedAssetStateType(q)
+		asset := columnVectorIndexStateAssetSnapshot{Role: columnVectorIndexStateAssetRoleQuantizedCodes, AssetID: columnVectorGraphQuantizedAssetID(q), LogicalType: logicalType, PhysicalEncoding: physicalEncoding, RowCount: graph.RowCount, SourceSchemaHash: 43, AssetBytes: 47, Ref: ColumnAssetRef{Kind: ColumnAssetKindTCS1TypedColumnPart, Namespace: "ns", Generation: graph.BaseManifestGeneration, PartID: 53, FileID: 59, Offset: 61, Length: 67, Checksum: 71}}
+		state := columnVectorIndexStateSnapshot{IndexName: def.Name, Field: def.Field, Metric: def.Metric, Encoding: def.Encoding, Dimensions: def.Dimensions, M: def.M, EfConstruction: def.EfConstruction, EfSearch: def.EfSearch, RowCount: graph.RowCount, BaseManifestGeneration: graph.BaseManifestGeneration, BaseManifestChecksum: graph.BaseManifestChecksum, BaseSchemaHash: graph.BaseSchemaHash, AdjacencyLayerCount: graph.AdjacencyLayerCount, Assets: []columnVectorIndexStateAssetSnapshot{asset}}
+		key, err := collectionVectorIndexPreparedQuantizedSearchCacheKey("docs", "ns", def, graph, state, q.Name, 1)
+		if err != nil {
+			t.Fatalf("collectionVectorIndexPreparedQuantizedSearchCacheKey %s: %v", q.Codec, err)
+		}
+		return key
+	}
+
+	scalarKey := makeKey(t, QuantizedVectorIndexDefinition{Name: columnGraphScalarU8QuantizedBenchIndexName1926, Codec: QuantizedVectorCodecScalarU8})
+	rabitqKey := makeKey(t, QuantizedVectorIndexDefinition{Name: columnGraphRabitQQuantizedIndexName2450, Codec: rabitq.CodecName})
+	if scalarKey == rabitqKey {
+		t.Fatalf("scalar_u8 and rabitq cache keys are equal: %q", scalarKey)
+	}
+	if !strings.Contains(scalarKey, "codec=scalar_u8|version=1|codec_config_hash=0|codec_config=|code_dimensions=3|code_width_bits=8|") || !strings.Contains(scalarKey, "asset_id=quantized/embedding.scalar_u8.fast/codes") {
+		t.Fatalf("scalar cache key missing codec/version/config/asset identity: %s", scalarKey)
+	}
+	wantRabitQIdentity := fmt.Sprintf("codec=%s|version=%d|codec_config_hash=%d|codec_config=%x|code_dimensions=4|code_width_bits=%d|", rabitq.CodecName, rabitq.CodecVersion, rabitq.DefaultConfig().Hash64(), rabitq.DefaultConfig().CanonicalBytes(), rabitq.CodeWidthBits)
+	if !strings.Contains(rabitqKey, wantRabitQIdentity) || !strings.Contains(rabitqKey, "asset_id=quantized/embedding.rabitq_1bit.fast/packed_codes") {
+		t.Fatalf("rabitq cache key missing codec/version/config/asset identity: %s want identity %s", rabitqKey, wantRabitQIdentity)
+	}
+}
+
+func assertCollectionBufferedRabitQQuantizedRouteStats2452(tb testing.TB, stats VectorIndexSearchStats, mode columnVectorGraphNativeSearchQueryMode, opts VectorIndexSearchOptions, dims int, bytesPerCode int) {
+	tb.Helper()
+	if bytesPerCode <= 0 {
+		tb.Fatalf("rabitq bytes_per_code=%d", bytesPerCode)
+	}
+	if !vectorIndexSearchStatsAreBufferedNoDocumentQuantizedRoute(stats, mode, opts, dims) {
+		tb.Fatalf("collection buffered rabitq stats=%+v want healthy no-document quantized route", stats)
+	}
+	if stats.OpenSearcherCalls != 0 || stats.OpenSetupInTimedLoop != 0 || stats.ResponseOwnedResultAllocs != 0 {
+		tb.Fatalf("collection buffered rabitq boundary stats=%+v want no one-shot open/setup or response-owned allocation signal", stats)
+	}
+	switch mode {
+	case columnVectorGraphNativeSearchQueryModeQuantizedOnly:
+		assertRabitQQuantizedOnlyStats2451(tb, stats, bytesPerCode)
+	case columnVectorGraphNativeSearchQueryModeQuantizedRerank:
+		shortlist := opts.QuantizedRerankCandidates
+		if shortlist == 0 {
+			shortlist = opts.EfSearch
+		}
+		assertRabitQQuantizedRerankStats2451(tb, stats, shortlist, dims, bytesPerCode)
+	default:
+		tb.Fatalf("unexpected rabitq query mode %s", mode.String())
+	}
 }
 
 func TestColumnGraphRabitQQuantizedScorerMatchesOracle2451(t *testing.T) {

--- a/TreeDB/collections/vector_index_search_test.go
+++ b/TreeDB/collections/vector_index_search_test.go
@@ -1198,6 +1198,42 @@ func TestCollectionSearchVectorIndexWithBufferQuantizedBenchmarkRows2415(t *test
 	}
 }
 
+func TestCollectionSearchVectorIndexWithBufferRabitQBenchmarkRows2452(t *testing.T) {
+	cases := columnGraphRabitQQuantizedCollectionWithBufferBenchCases2452()
+	if len(cases) != 4 {
+		t.Fatalf("benchmark cases=%d want four collection c=1/c=8 rabitq SearchVectorIndexWithBuffer rows", len(cases))
+	}
+	seen := make(map[string]columnGraphScalarU8QuantizedCollectionWithBufferBenchCase2415, len(cases))
+	for _, tc := range cases {
+		if tc.mode != VectorIndexQueryModeQuantizedOnly && tc.mode != VectorIndexQueryModeQuantizedRerank {
+			t.Fatalf("case %+v is not an explicit collection buffered rabitq quantized row", tc)
+		}
+		if tc.concurrency != 1 && tc.concurrency != 8 {
+			t.Fatalf("case %+v has unsupported concurrency; want c=1 or c=8", tc)
+		}
+		if _, ok := seen[tc.name]; ok {
+			t.Fatalf("duplicate benchmark case name %q", tc.name)
+		}
+		seen[tc.name] = tc
+	}
+	for _, name := range []string{
+		"route=quantized_only/c=1",
+		"route=quantized_only/c=8",
+		"route=quantized_rerank/candidates=32/c=1",
+		"route=quantized_rerank/candidates=32/c=8",
+	} {
+		if _, ok := seen[name]; !ok {
+			t.Fatalf("missing collection rabitq benchmark case %q in %+v", name, cases)
+		}
+	}
+	if seen["route=quantized_only/c=1"].rerankCandidates != 0 || seen["route=quantized_only/c=8"].rerankCandidates != 0 {
+		t.Fatalf("quantized_only collection rabitq benchmark rows must not configure rerank candidates: %+v", cases)
+	}
+	if seen["route=quantized_rerank/candidates=32/c=1"].rerankCandidates != 32 || seen["route=quantized_rerank/candidates=32/c=8"].rerankCandidates != 32 {
+		t.Fatalf("quantized_rerank collection rabitq benchmark rows must configure candidates=32: %+v", cases)
+	}
+}
+
 func TestNativeRuntimeVectorIndexRejectsQuantizedQueryMode1926(t *testing.T) {
 	idx, err := newVectorIndex(nil, VectorIndexOptions{Name: "embedding_idx", Field: "embedding", Metric: VectorMetricCosine, Dimensions: 2})
 	if err != nil {


### PR DESCRIPTION
## Summary

- Enables `rabitq_1bit` on the existing `Collection.SearchVectorIndexWithBuffer` quantized no-document route now that #2451 / #2469 is merged.
- Keeps the collection-owned prepared quantized cache lifecycle and fail-closed behavior, and extends cache identity with codec config/hash plus code shape and asset identity.
- Adds collection-level RaBitQ success/fail-closed/cache/lifecycle coverage and c=1/c=8 benchmark rows.

Closes #2452. Parent tracker: #2447.

## Scope notes

- No new public API; RaBitQ is selected with existing `QueryMode`, `QuantizedIndexName`, and `QuantizedRerankCandidates` options.
- No document materialization/filter/projection support is added to the buffered route; unsupported shapes still fail closed.
- Exact FP32 and scalar_u8 collection buffered behavior is preserved.

## Tests

- `go test ./TreeDB/collections -run 'Test(VectorIndexSearcherRabitQQuantizedSearchWithBuffer2451|CollectionSearchVectorIndexWithBufferRabitQQuantized2452|CollectionSearchVectorIndexWithBufferRabitQFailClosedAndQueryErrors2452|CollectionVectorIndexPreparedQuantizedSearchCacheKeyRabitQIdentity2452|CollectionSearchVectorIndexWithBufferRabitQBenchmarkRows2452|SearchVectorIndexWithBufferQuantizedOnlyAndRerank2415|SearchVectorIndexWithBufferQuantizedAssetUnavailableFailClosed2415|SearchVectorIndexWithBufferQuantizedQueryErrorsKeepPreparedState2415|SearchVectorIndexWithBufferQuantizedUnsupportedShapesAndLifecycle2415|CollectionSearchVectorIndexWithBufferQuantizedBenchmarkRows2415|SearchVectorIndexWithBufferUnsupportedShapesFailClosed2362|VectorIndexSearchDiagnosticsExactPackRoute2407)$'`
- `go test ./TreeDB/collections`
- `go test ./TreeDB/...`

Note: one earlier `go test ./TreeDB/...` run hit `TreeDB/mongo_gateway` `TestStandaloneServerCommandWALBSONInsertReadUpdateVisibility/command_wal_durable` with a buffered-root base mismatch; the exact test passed on immediate retry, and the later full `go test ./TreeDB/...` passed.

## Benchmarks

Command:

```sh
go test ./TreeDB/collections -run '^$' -bench '^BenchmarkCollectionSearchVectorIndexWithBufferColumnGraphRabitQQuantized2452$' -benchtime=100x -count=1
```

Hardware: Apple M3 / darwin arm64.

| Row | ns/op | ops/sec | B/op | allocs/op | open_searcher_calls/op | open_setup_in_timed_loop | recall_at_k_pct | quantized_code_B/vector |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| quantized_only c=1 | 40,813 | 24,502 | 0 | 0 | 0 | 0 | 100 | 16 |
| quantized_only c=8 | 11,787 | 84,842 | 0 | 0 | 0 | 0 | 100 | 16 |
| quantized_rerank candidates=32 c=1 | 39,779 | 25,139 | 0 | 0 | 0 | 0 | 100 | 16 |
| quantized_rerank candidates=32 c=8 | 11,698 | 85,485 | 0 | 0 | 0 | 0 | 100 | 16 |

Guardrails reported separately in benchmark output include quantized/exact bytes, route counters, prepared-cache counters, no HNSW-pack fallback, no graph-row fallback, no typed-column fallback, no vector scratch decodes, and no documents fetched.

## AI review / CI

- Codex requested.
- Copilot requested.
- CodeRabbit auto-review attempted but is currently rate-limited/usage-limited; retry when available.
- CI is running for latest head `e3a042e3520391f38407786b49db0d92a9ad492e`.
