### PR TITLE
Raise geth command WAL segment cap

### DIFF
--- a/TreeDB/integration/gethethdb/README.md
+++ b/TreeDB/integration/gethethdb/README.md
@@ -20,7 +20,8 @@ Primary APIs:
 opens reject non-command-WAL TreeDB options; this adapter is intended for geth
 persistent hot-KV durability/recovery through TreeDB command WAL. When callers
 leave `WALMaxSegmentBytes` at zero, the adapter uses a 256 MiB command-WAL frame
-cap so geth's large beacon skeleton-header batches fit in one durable frame.
+cap so geth's large beacon skeleton-header batches fit in one durable frame,
+including read-only inspection of an existing command-WAL directory.
 
 ## Semantics
 

--- a/TreeDB/integration/gethethdb/README.md
+++ b/TreeDB/integration/gethethdb/README.md
@@ -18,7 +18,9 @@ Primary APIs:
 
 `Open(nil options)` defaults to `treedb.ProfileCommandWALDurable`. Writable
 opens reject non-command-WAL TreeDB options; this adapter is intended for geth
-persistent hot-KV durability/recovery through TreeDB command WAL.
+persistent hot-KV durability/recovery through TreeDB command WAL. When callers
+leave `WALMaxSegmentBytes` at zero, the adapter uses a 256 MiB command-WAL frame
+cap so geth's large beacon skeleton-header batches fit in one durable frame.
 
 ## Semantics
 

--- a/TreeDB/integration/gethethdb/adapter.go
+++ b/TreeDB/integration/gethethdb/adapter.go
@@ -173,8 +173,10 @@ func wrapWithOptions(db *treedb.DB, opts treedb.Options) *Database {
 
 // Database implements ethdb.KeyValueStore on top of TreeDB.
 type Database struct {
-	db                 *treedb.DB
-	compactStorage     compactStorageFunc
+	db             *treedb.DB
+	compactStorage compactStorageFunc
+	// walMaxSegmentBytes records the effective adapter WAL cap for tests and
+	// future diagnostics. Wrap cannot infer this for already-open handles.
 	walMaxSegmentBytes int64
 	closed             atomic.Bool
 }

--- a/TreeDB/integration/gethethdb/adapter.go
+++ b/TreeDB/integration/gethethdb/adapter.go
@@ -49,6 +49,8 @@ type OpenOptions struct {
 	MemtableMode string
 }
 
+const defaultGethCommandWALMaxSegmentBytes int64 = 256 << 20
+
 // DefaultOpenOptions returns the production-oriented adapter defaults.
 func DefaultOpenOptions() OpenOptions {
 	return OpenOptions{Profile: treedb.ProfileCommandWALDurable}
@@ -78,8 +80,11 @@ func Open(path string, options *OpenOptions) (*Database, error) {
 }
 
 // OpenWithOptions opens TreeDB with caller-supplied options and wraps it as an
-// ethdb.KeyValueStore. Writable options must enable TreeDB command WAL.
+// ethdb.KeyValueStore. Writable options must enable TreeDB command WAL. When
+// WALMaxSegmentBytes is left at zero, the adapter applies a geth-sized command
+// WAL frame cap so large skeleton-header batches fit in one durable frame.
 func OpenWithOptions(opts treedb.Options) (*Database, error) {
+	applyGethCommandWALDefaults(&opts)
 	if strings.TrimSpace(opts.Dir) == "" {
 		return nil, errors.New("gethethdb: TreeDB options Dir must be non-empty")
 	}
@@ -128,7 +133,19 @@ func resolveTreeDBOptions(path string, options *OpenOptions) (treedb.Options, er
 	if !opts.ReadOnly && !opts.CommandWAL {
 		return treedb.Options{}, errors.New("gethethdb: writable TreeDB ethdb adapter requires command WAL")
 	}
+	applyGethCommandWALDefaults(&opts)
 	return opts, nil
+}
+
+func applyGethCommandWALDefaults(opts *treedb.Options) {
+	if opts == nil || !opts.CommandWAL || opts.WALMaxSegmentBytes != 0 {
+		return
+	}
+	// Geth beacon skeleton sync can commit the whole 131,072-header scratch
+	// window in one ethdb batch. Its encoded raw-KV command WAL payload is larger
+	// than TreeDB's generic 64MiB commitlog default, so use a geth adapter default
+	// with enough headroom while preserving explicit caller overrides.
+	opts.WALMaxSegmentBytes = defaultGethCommandWALMaxSegmentBytes
 }
 
 type compactStorageFunc func(context.Context, *treedb.DB) error

--- a/TreeDB/integration/gethethdb/adapter.go
+++ b/TreeDB/integration/gethethdb/adapter.go
@@ -36,8 +36,8 @@ type OpenOptions struct {
 
 	// Options, when non-nil, supplies TreeDB options to use. Open copies the
 	// struct, forces Dir to the Open path when path is non-empty, applies
-	// ReadOnly/KeepRecent/MemtableMode overrides below, applies geth-safe command
-	// WAL defaults for zero-valued knobs, and still requires CommandWAL for
+	// ReadOnly/KeepRecent/MemtableMode overrides below, applies geth-safe WAL
+	// sizing defaults for zero-valued knobs, and still requires CommandWAL for
 	// writable opens.
 	Options *treedb.Options
 
@@ -82,8 +82,9 @@ func Open(path string, options *OpenOptions) (*Database, error) {
 
 // OpenWithOptions opens TreeDB with caller-supplied options and wraps it as an
 // ethdb.KeyValueStore. Writable options must enable TreeDB command WAL. When
-// WALMaxSegmentBytes is left at zero, the adapter applies a geth-sized command
-// WAL frame cap so large skeleton-header batches fit in one durable frame.
+// WALMaxSegmentBytes is left at zero, the adapter applies a geth-sized WAL frame
+// cap before open so command-WAL activation from persisted format config also
+// uses the larger cap.
 func OpenWithOptions(opts treedb.Options) (*Database, error) {
 	applyGethCommandWALDefaults(&opts)
 	if strings.TrimSpace(opts.Dir) == "" {
@@ -139,13 +140,15 @@ func resolveTreeDBOptions(path string, options *OpenOptions) (treedb.Options, er
 }
 
 func applyGethCommandWALDefaults(opts *treedb.Options) {
-	if opts == nil || !opts.CommandWAL || opts.WALMaxSegmentBytes != 0 {
+	if opts == nil || opts.WALMaxSegmentBytes != 0 {
 		return
 	}
 	// Geth beacon skeleton sync can commit the whole 131,072-header scratch
 	// window in one ethdb batch. Its encoded raw-KV command WAL payload is larger
 	// than TreeDB's generic 64MiB commitlog default, so use a geth adapter default
-	// with enough headroom while preserving explicit caller overrides.
+	// with enough headroom while preserving explicit caller overrides. Apply this
+	// before open even when CommandWAL is false because an existing DB can activate
+	// command WAL from its persisted format config during read-only inspection.
 	opts.WALMaxSegmentBytes = defaultGethCommandWALMaxSegmentBytes
 }
 

--- a/TreeDB/integration/gethethdb/adapter.go
+++ b/TreeDB/integration/gethethdb/adapter.go
@@ -96,7 +96,7 @@ func OpenWithOptions(opts treedb.Options) (*Database, error) {
 	if err != nil {
 		return nil, err
 	}
-	return Wrap(tdb), nil
+	return wrapWithOptions(tdb, opts), nil
 }
 
 func resolveTreeDBOptions(path string, options *OpenOptions) (treedb.Options, error) {
@@ -162,11 +162,18 @@ func Wrap(db *treedb.DB) *Database {
 	return &Database{db: db, compactStorage: runCompactStorageFull}
 }
 
+func wrapWithOptions(db *treedb.DB, opts treedb.Options) *Database {
+	wrapped := Wrap(db)
+	wrapped.walMaxSegmentBytes = opts.WALMaxSegmentBytes
+	return wrapped
+}
+
 // Database implements ethdb.KeyValueStore on top of TreeDB.
 type Database struct {
-	db             *treedb.DB
-	compactStorage compactStorageFunc
-	closed         atomic.Bool
+	db                 *treedb.DB
+	compactStorage     compactStorageFunc
+	walMaxSegmentBytes int64
+	closed             atomic.Bool
 }
 
 var _ ethdb.KeyValueStore = (*Database)(nil)

--- a/TreeDB/integration/gethethdb/adapter.go
+++ b/TreeDB/integration/gethethdb/adapter.go
@@ -34,10 +34,11 @@ type OpenOptions struct {
 	// durability through TreeDB command WAL.
 	Profile treedb.Profile
 
-	// Options, when non-nil, supplies the exact TreeDB options to use. Open copies
-	// the struct, forces Dir to the Open path when path is non-empty, applies
-	// ReadOnly/KeepRecent/MemtableMode overrides below, and still requires
-	// CommandWAL for writable opens.
+	// Options, when non-nil, supplies TreeDB options to use. Open copies the
+	// struct, forces Dir to the Open path when path is non-empty, applies
+	// ReadOnly/KeepRecent/MemtableMode overrides below, applies geth-safe command
+	// WAL defaults for zero-valued knobs, and still requires CommandWAL for
+	// writable opens.
 	Options *treedb.Options
 
 	// ReadOnly opens the TreeDB directory read-only.

--- a/TreeDB/integration/gethethdb/adapter_test.go
+++ b/TreeDB/integration/gethethdb/adapter_test.go
@@ -67,6 +67,19 @@ func TestOpenDefaultsUseGethSizedCommandWALSegments(t *testing.T) {
 	}
 }
 
+func TestOpenWithOptionsAppliesGethSizedCommandWALSegments(t *testing.T) {
+	opts := treedb.OptionsFor(treedb.ProfileCommandWALDurable, filepath.Join(t.TempDir(), "treedb"))
+	opts.WALMaxSegmentBytes = 0
+	db, err := OpenWithOptions(opts)
+	if err != nil {
+		t.Fatalf("OpenWithOptions: %v", err)
+	}
+	defer db.Close()
+	if got := db.walMaxSegmentBytes; got != defaultGethCommandWALMaxSegmentBytes {
+		t.Fatalf("OpenWithOptions WALMaxSegmentBytes=%d want %d", got, defaultGethCommandWALMaxSegmentBytes)
+	}
+}
+
 func TestOpenRejectsWritableNonCommandWALOptions(t *testing.T) {
 	opts := treedb.OptionsFor(treedb.ProfileBench, filepath.Join(t.TempDir(), "treedb"))
 	if _, err := OpenWithOptions(opts); err == nil {

--- a/TreeDB/integration/gethethdb/adapter_test.go
+++ b/TreeDB/integration/gethethdb/adapter_test.go
@@ -80,6 +80,26 @@ func TestOpenWithOptionsAppliesGethSizedCommandWALSegments(t *testing.T) {
 	}
 }
 
+func TestOpenWithOptionsAppliesGethSizedWALSegmentsBeforeReadOnlyFormatActivation(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "treedb")
+	writable, err := Open(dir, nil)
+	if err != nil {
+		t.Fatalf("Open writable: %v", err)
+	}
+	if err := writable.Close(); err != nil {
+		t.Fatalf("close writable: %v", err)
+	}
+
+	readOnly, err := OpenWithOptions(treedb.Options{Dir: dir, ReadOnly: true})
+	if err != nil {
+		t.Fatalf("OpenWithOptions read-only: %v", err)
+	}
+	defer readOnly.Close()
+	if got := readOnly.walMaxSegmentBytes; got != defaultGethCommandWALMaxSegmentBytes {
+		t.Fatalf("read-only WALMaxSegmentBytes=%d want %d", got, defaultGethCommandWALMaxSegmentBytes)
+	}
+}
+
 func TestOpenRejectsWritableNonCommandWALOptions(t *testing.T) {
 	opts := treedb.OptionsFor(treedb.ProfileBench, filepath.Join(t.TempDir(), "treedb"))
 	if _, err := OpenWithOptions(opts); err == nil {

--- a/TreeDB/integration/gethethdb/adapter_test.go
+++ b/TreeDB/integration/gethethdb/adapter_test.go
@@ -46,6 +46,27 @@ func TestOpenDefaultsToCommandWALDurable(t *testing.T) {
 	}
 }
 
+func TestOpenDefaultsUseGethSizedCommandWALSegments(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "treedb")
+	opts, err := resolveTreeDBOptions(dir, nil)
+	if err != nil {
+		t.Fatalf("resolve default options: %v", err)
+	}
+	if got := opts.WALMaxSegmentBytes; got != defaultGethCommandWALMaxSegmentBytes {
+		t.Fatalf("default WALMaxSegmentBytes=%d want %d", got, defaultGethCommandWALMaxSegmentBytes)
+	}
+
+	custom := treedb.OptionsFor(treedb.ProfileCommandWALDurable, dir)
+	custom.WALMaxSegmentBytes = 1024
+	opts, err = resolveTreeDBOptions(dir, &OpenOptions{Options: &custom})
+	if err != nil {
+		t.Fatalf("resolve custom options: %v", err)
+	}
+	if got := opts.WALMaxSegmentBytes; got != 1024 {
+		t.Fatalf("explicit WALMaxSegmentBytes=%d want preserved 1024", got)
+	}
+}
+
 func TestOpenRejectsWritableNonCommandWALOptions(t *testing.T) {
 	opts := treedb.OptionsFor(treedb.ProfileBench, filepath.Join(t.TempDir(), "treedb"))
 	if _, err := OpenWithOptions(opts); err == nil {


### PR DESCRIPTION
## Summary
- raise the geth ethdb adapter's default command-WAL segment cap to 256 MiB when callers leave `WALMaxSegmentBytes` at zero
- preserve explicit caller segment-size overrides
- document the geth skeleton-header batch rationale and cover the default in adapter tests

## Why
A post-#2471 Sepolia TreeDB sync reached geth beacon skeleton header sync, then geth aborted with:

```
CRIT Failed to write skeleton headers and progress err="commitlog: record too large"
```

Geth can commit its full 131,072-header skeleton scratch window in one `ethdb.Batch`; the encoded raw-KV command-WAL payload can exceed TreeDB's generic 64 MiB commitlog default. The adapter needs a geth-sized default so the batch remains one durable command-WAL frame.

## Validation
- `go test ./TreeDB -count=1`
- `go test ./... -count=1`
- `(cd TreeDB/integration/gethethdb && go test ./... -count=1)`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified command-WAL durability and recovery support, explaining the default 256 MiB segment size for optimal batch handling.

* **Improvements**
  * Enhanced default configuration for command-WAL segment sizing to better accommodate large batch operations.

* **Tests**
  * Added test coverage for default command-WAL segment sizing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->