### PR TITLE
Add RaBitQ profile gate runbook

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -52,6 +52,7 @@ Behavioral guarantees for downstream systems (e.g., replication layers).
 - **[TreeDB-vs-SQLite Collection Concurrency](benchmarks/collections_concurrency_main_2026-06-04.md)**: Concurrent collection read/lookup and mixed read/write rows with explicit `GOMAXPROCS` and SQLite connection-pool metadata.
 - **[TreeDB Fast Mongo/Native Client-Shape Matrix](benchmarks/mongo_gateway_fast_client_matrix_2026-06-04.md)**: Standard fast-client Mongo gateway/native/direct benchmark contract and baseline interpretation.
 - **[TreeDB Quantized Buffered Per-Row Profiling](benchmarks/treedb_quantized_buffered_profile_runbook.md)**: Isolated quantized search profile rows for downstream optimization gates.
+- **[TreeDB `rabitq_1bit` Profile Gate](benchmarks/treedb_rabitq_1bit_profile_gate.md)**: Same-host RaBitQ baseline/candidate workflow, guardrails, profile artifacts, and no-promote rules.
 - **[Unified Bench](../cmd/unified_bench/README.md)**: Usage guide for benchmark execution and artifact capture.
 - **[BenchProf](../cmd/benchprof/README.md)**: Analysis tool for CPU/alloc/block/mutex profiles and ops/sec outputs.
 - **[Redis Protocol Benchmarking](REDIS_PROTOCOL_BENCHMARKING.md)**: Preferred way to measure Redis wrapper throughput.

--- a/docs/benchmarks/treedb_rabitq_1bit_profile_gate.md
+++ b/docs/benchmarks/treedb_rabitq_1bit_profile_gate.md
@@ -1,0 +1,228 @@
+# TreeDB `rabitq_1bit` Profile Gate
+
+Use this workflow for Sublane A of the RaBitQ performance lane (#2476 and
+successors). It builds on the quantized buffered per-row profiling workflow from
+#2465 while making the `rabitq_1bit` evidence contract explicit.
+
+This gate is measurement-only. It must not be bundled with scorer/search runtime
+optimization, storage format changes, codec identity changes, asset identity
+changes, fail-closed behavior changes, or `rabitq_1bit` v1 score/LSB-first bit
+order changes.
+
+## What this gate proves
+
+The workflow captures isolated lower-level and collection buffered rows for the
+1024 row / 128 dimension / `topK=10` / `efSearch=128` fixture used by the
+current quantized search benchmarks. It records:
+
+- same-host baseline and candidate commit identity;
+- `ns/op`, `ops/sec`, `B/op`, `allocs/op`, and recall@K;
+- route, exact-read, asset-unavailable, fallback, and cache counters;
+- `quantized_code_B/search`, `quantized_code_B/vector`, and
+  `quantized_asset_B/vector`;
+- CPU and allocation profiles for selected c=1/c=8 rows.
+
+Smoke runs validate benchmark shape and counters only. They are not speedup or
+promotion evidence.
+
+## Script
+
+```sh
+scripts/treedb_rabitq_1bit_profile_gate.sh
+```
+
+Default selection:
+
+- `ROWS=claim_core`: RaBitQ `quantized_only` c=1/c=8 lower-level and collection
+  rows plus scalar_u8 `quantized_only` c=1/c=8 guardrail rows.
+- `PROFILE_ROWS=rabitq_collection_quantized_only_c1,rabitq_collection_quantized_only_c8`:
+  CPU/alloc profiles for the required RaBitQ collection buffered target rows.
+- `BENCHTIME=100000x`, `TIMING_COUNT=5`, `PROFILE_COUNT=1`.
+
+Useful selectors for `ROWS` and `PROFILE_ROWS` are comma-separated and ORed:
+
+- `claim_core`, `claim_rerank`, `all`;
+- `rabitq`, `rabitq_only`, `rabitq_rerank`;
+- `scalar_guardrail`, `scalar_only`, `scalar_rerank`;
+- `lower`, `collection`, `quantized_only`, `rerank32`, `c1`, `c8`;
+- exact row IDs from the table below.
+
+Use `DRY_RUN=true` to write context, matrix, row directories, and exact commands
+without running Go benchmarks.
+
+## Row and artifact names
+
+Each selected row gets a directory named by `row_id` under `RUN_DIR`.
+
+| row id | codec | API boundary | mode | c | benchmark regex |
+| --- | --- | --- | --- | ---: | --- |
+| `rabitq_lower_quantized_only_c1` | `rabitq_1bit` | `VectorIndexSearcher.SearchWithBuffer` | `quantized_only` | 1 | `^BenchmarkVectorIndexSearcherColumnGraphRabitQQuantizedSearchWithBuffer2451$/^route=quantized_only$/^c=1$` |
+| `rabitq_lower_quantized_only_c8` | `rabitq_1bit` | `VectorIndexSearcher.SearchWithBuffer` | `quantized_only` | 8 | `^BenchmarkVectorIndexSearcherColumnGraphRabitQQuantizedSearchWithBuffer2451$/^route=quantized_only$/^c=8$` |
+| `rabitq_collection_quantized_only_c1` | `rabitq_1bit` | `Collection.SearchVectorIndexWithBuffer` | `quantized_only` | 1 | `^BenchmarkCollectionSearchVectorIndexWithBufferColumnGraphRabitQQuantized2452$/^route=quantized_only$/^c=1$` |
+| `rabitq_collection_quantized_only_c8` | `rabitq_1bit` | `Collection.SearchVectorIndexWithBuffer` | `quantized_only` | 8 | `^BenchmarkCollectionSearchVectorIndexWithBufferColumnGraphRabitQQuantized2452$/^route=quantized_only$/^c=8$` |
+| `rabitq_lower_quantized_rerank32_c1` | `rabitq_1bit` | `VectorIndexSearcher.SearchWithBuffer` | `quantized_rerank/candidates=32` | 1 | `^BenchmarkVectorIndexSearcherColumnGraphRabitQQuantizedSearchWithBuffer2451$/^route=quantized_rerank$/^candidates=32$/^c=1$` |
+| `rabitq_lower_quantized_rerank32_c8` | `rabitq_1bit` | `VectorIndexSearcher.SearchWithBuffer` | `quantized_rerank/candidates=32` | 8 | `^BenchmarkVectorIndexSearcherColumnGraphRabitQQuantizedSearchWithBuffer2451$/^route=quantized_rerank$/^candidates=32$/^c=8$` |
+| `rabitq_collection_quantized_rerank32_c1` | `rabitq_1bit` | `Collection.SearchVectorIndexWithBuffer` | `quantized_rerank/candidates=32` | 1 | `^BenchmarkCollectionSearchVectorIndexWithBufferColumnGraphRabitQQuantized2452$/^route=quantized_rerank$/^candidates=32$/^c=1$` |
+| `rabitq_collection_quantized_rerank32_c8` | `rabitq_1bit` | `Collection.SearchVectorIndexWithBuffer` | `quantized_rerank/candidates=32` | 8 | `^BenchmarkCollectionSearchVectorIndexWithBufferColumnGraphRabitQQuantized2452$/^route=quantized_rerank$/^candidates=32$/^c=8$` |
+| `scalar_lower_quantized_only_c1` / `c8` | `scalar_u8` | lower-level guardrail | `quantized_only` | 1/8 | `BenchmarkVectorIndexSearcherColumnGraphScalarU8QuantizedSearchWithBuffer2414` subrows |
+| `scalar_collection_quantized_only_c1` / `c8` | `scalar_u8` | collection guardrail | `quantized_only` | 1/8 | `BenchmarkCollectionSearchVectorIndexWithBufferColumnGraphScalarU8Quantized2415` subrows |
+| `scalar_*_quantized_rerank32_c1` / `c8` | `scalar_u8` | rerank guardrail when rerank is in scope | `quantized_rerank/candidates=32` | 1/8 | scalar_u8 rerank subrows |
+
+Primary artifacts:
+
+- `context.txt`: branch, commit, Go version/env, `GOMAXPROCS`, `GOWORK`, uptime,
+  git status, and visible competing benchmark/test processes.
+- `matrix.tsv`: selected row IDs, codec, layer, mode, c, rerank candidates,
+  profile selection, and regex.
+- `summary.md` / `summary.tsv`: median timing, throughput, allocation, recall,
+  byte/counter summaries, and guardrail status.
+- `<row>/bench_timing.txt`: unprofiled timing/counter output. Use this for
+  tables.
+- `<row>/bench_profile.txt`: profiled benchmark output for profiled rows.
+- `<row>/cpu.pprof`, `<row>/allocs.pprof`, `<row>/cpu_top.txt`,
+  `<row>/allocs_top.txt`: required CPU/allocation artifacts for profiled rows.
+- `<row>/block.pprof`, `<row>/mutex.pprof`, top summaries, and
+  `<row>/pprof_lists/*.txt`: supporting attribution.
+
+Recommended raw directory naming:
+
+```sh
+/tmp/gomap_rabitq_1bit_<baseline|candidate>_<branch>_<shortsha>_$(date +%Y%m%d_%H%M%S)
+```
+
+## Smoke and dry-run commands
+
+Dry-run script validation:
+
+```sh
+DRY_RUN=true ROWS=rabitq_collection_quantized_only_c1 \
+  scripts/treedb_rabitq_1bit_profile_gate.sh
+```
+
+Tiny smoke for one row:
+
+```sh
+RUN_DIR=/tmp/gomap_rabitq_1bit_smoke_$(date +%Y%m%d_%H%M%S) \
+  ROWS=rabitq_collection_quantized_only_c1 \
+  BENCHTIME=1000x TIMING_COUNT=1 RUN_PROFILES=false \
+  GOMAXPROCS=8 GOWORK=off \
+  scripts/treedb_rabitq_1bit_profile_gate.sh
+```
+
+Issue-level smoke matrix (shape/counters only; no speed claim):
+
+```sh
+GOMAXPROCS=8 GOWORK=off go test ./TreeDB/collections \
+  -run '^$' \
+  -bench '^(BenchmarkVectorIndexSearcherColumnGraphRabitQQuantizedSearchWithBuffer2451|BenchmarkCollectionSearchVectorIndexWithBufferColumnGraphRabitQQuantized2452|BenchmarkVectorIndexSearcherColumnGraphScalarU8QuantizedSearchWithBuffer2414|BenchmarkCollectionSearchVectorIndexWithBufferColumnGraphScalarU8Quantized2415|BenchmarkColumnGraphScalarU8QuantizedScorePlanes1926)$' \
+  -benchmem -benchtime=100x -count=3
+```
+
+## Claim-quality same-host baseline/candidate workflow
+
+Run baseline and candidate on the same host, with the same Go toolchain,
+`GOMAXPROCS`, `GOWORK`, row selection, timing/profile counts, fixture, and as
+little wall-clock separation as practical. Record both branch and full commit
+SHA from each `context.txt`.
+
+Baseline:
+
+```sh
+BASE=/tmp/gomap_rabitq_1bit_baseline_main_$(git rev-parse --short HEAD)_$(date +%Y%m%d_%H%M%S)
+RUN_DIR="$BASE" \
+  ROWS=claim_core \
+  PROFILE_ROWS=rabitq_collection_quantized_only_c1,rabitq_collection_quantized_only_c8 \
+  BENCHTIME=100000x TIMING_COUNT=5 PROFILE_COUNT=1 \
+  GOMAXPROCS=8 GOWORK=off \
+  scripts/treedb_rabitq_1bit_profile_gate.sh
+```
+
+Candidate:
+
+```sh
+CAND=/tmp/gomap_rabitq_1bit_candidate_$(git rev-parse --short HEAD)_$(date +%Y%m%d_%H%M%S)
+RUN_DIR="$CAND" BASELINE_DIR="$BASE" \
+  ROWS=claim_core \
+  PROFILE_ROWS=rabitq_collection_quantized_only_c1,rabitq_collection_quantized_only_c8 \
+  BENCHTIME=100000x TIMING_COUNT=5 PROFILE_COUNT=1 \
+  GOMAXPROCS=8 GOWORK=off \
+  scripts/treedb_rabitq_1bit_profile_gate.sh
+```
+
+When rerank scorer/read behavior is in scope, include rerank rows and profiles:
+
+```sh
+ROWS=claim_rerank \
+PROFILE_ROWS=rabitq_collection_quantized_only_c1,rabitq_collection_quantized_only_c8,rabitq_collection_quantized_rerank32_c1,rabitq_collection_quantized_rerank32_c8 \
+  scripts/treedb_rabitq_1bit_profile_gate.sh
+```
+
+If lower-level scorer-only evidence is the claim, keep lower-level RaBitQ c=1/c=8
+rows in the timing table. Collection rows must still be present so lower-level
+wins that regress the collection seam are no-promote.
+
+## Summary table conventions
+
+Use `summary.tsv` or `summary.md` to report medians from unprofiled timing rows.
+PR or issue evidence should include at least:
+
+| field | rule |
+| --- | --- |
+| baseline/candidate identity | branch, full SHA, Go version, OS/arch, `GOMAXPROCS`, fixture |
+| timing/allocation | `ns/op`, `ops/sec`, `B/op`, `allocs/op` |
+| quality | recall@K versus exact, c=1 and c=8 shown separately |
+| bytes | `quantized_code_B/search`, `quantized_code_B/vector`, `quantized_asset_B/vector`, exact vector/norm bytes for rerank |
+| route counters | `search_route_quantized_only/search`, `search_route_quantized_rerank/search`, `search_route_column_graph_prepared/search` |
+| failure/fallback counters | document fetches, graph/typed/scratch/float64 fallbacks, quantized asset missing/invalid/stale/closed/unavailable |
+| collection seam | cache hits/misses/waits/errors, `open_setup_in_timed_loop=0`, `open_searcher_calls/op=0` |
+| profiles | `cpu_top.txt` and `allocs_top.txt` summaries for c=1/c=8 target rows |
+
+## Guardrails
+
+A row is not promotable unless its raw benchmark output and generated summary
+show:
+
+- `0 B/op` and `0 allocs/op` for steady-state buffered search;
+- `docs_fetched/search=0`, no graph-row fallback, no typed-column fallback, no
+  scratch decode, and no float64 scorer fallback;
+- selected quantized asset counters do not report missing, invalid, stale,
+  closed, or unavailable assets;
+- `quantized_only` has zero exact vector/norm bytes, zero exact rerank score
+  calls, and zero prepared exact score calls;
+- `quantized_rerank/candidates=32` exact vector/norm bytes and exact score calls
+  stay bounded by the shortlist;
+- c=1 and c=8 both preserve recall and route counters;
+- scalar_u8 guardrail rows stay allocation-free and do not materially regress
+  when shared code is touched.
+
+### Exact FP32 guardrail guidance for shared code
+
+If a PR touches shared traversal, frontier/top-k, collection prepared cache,
+row-ref/result-ID finalization, search buffer shapes, or result materialization,
+RaBitQ and scalar_u8 rows are not enough. Add exact FP32 rows from the active
+vector-search gate for that boundary (for example the #2445/#2399 HNSW-pack or
+Tier-S exact rows), and report them in the same before/after table. Exact rows
+must prove default FP32 behavior is unchanged, retain exact route/fallback
+counters, avoid new allocations, and keep vector/norm byte reads within the
+expected exact-search boundary. Do not hide exact regressions behind RaBitQ-only
+wins.
+
+## Quiet-host and no-promote policy
+
+Read `context.txt` before using a run for claims. Reject and rerun if it shows
+high load, competing benchmark/test processes, thermal throttling suspicion, or
+large unexplained per-row variance. Run baseline and candidate adjacent in time
+on the same host.
+
+Promotion is blocked by any material regression in target or guardrail rows:
+
+- c=1 improves but c=8 regresses, or vice versa;
+- lower-level improves but collection buffered search regresses;
+- RaBitQ improves but scalar_u8 or exact FP32 shared guardrails regress;
+- allocations leave `0 B/op` / `0 allocs/op`;
+- recall, route, exact-read, fallback, or asset-unavailable counters regress;
+- evidence is mixed, noisy, unrepeatable, or current-only.
+
+Mixed/noisy/regressing candidates are **no-promote**. Leave a durable issue/PR
+comment with raw artifact paths and do not request AI reviewers for performance
+promotion until same-host evidence is coherent.

--- a/docs/benchmarks/treedb_rabitq_1bit_profile_gate.md
+++ b/docs/benchmarks/treedb_rabitq_1bit_profile_gate.md
@@ -2,7 +2,7 @@
 
 Use this workflow for Sublane A of the RaBitQ performance lane (#2476 and
 successors). It builds on the quantized buffered per-row profiling workflow from
-#2465 while making the `rabitq_1bit` evidence contract explicit.
+issue #2465 while making the `rabitq_1bit` evidence contract explicit.
 
 This gate is measurement-only. It must not be bundled with scorer/search runtime
 optimization, storage format changes, codec identity changes, asset identity
@@ -38,6 +38,7 @@ Default selection:
 - `PROFILE_ROWS=rabitq_collection_quantized_only_c1,rabitq_collection_quantized_only_c8`:
   CPU/alloc profiles for the required RaBitQ collection buffered target rows.
 - `BENCHTIME=100000x`, `TIMING_COUNT=5`, `PROFILE_COUNT=1`.
+- `RECALL_TOLERANCE_PCT=0`: when `BASELINE_DIR` is set, candidate median recall must be at least the matching baseline row's median recall minus this tolerance for the row guardrail to pass.
 
 Useful selectors for `ROWS` and `PROFILE_ROWS` are comma-separated and ORed:
 

--- a/docs/benchmarks/treedb_rabitq_1bit_profile_gate.md
+++ b/docs/benchmarks/treedb_rabitq_1bit_profile_gate.md
@@ -52,7 +52,7 @@ without running Go benchmarks.
 
 ## Row and artifact names
 
-Each selected row gets a directory named by `row_id` under `RUN_DIR`.
+Each selected row gets a directory named by `row_id` under `RUN_DIR`. Use a fresh `RUN_DIR` for claim-quality runs; the generated summary is limited to the current `matrix.tsv` rows, but stale directories from reused run roots should still be treated as archival clutter, not current evidence.
 
 | row id | codec | API boundary | mode | c | benchmark regex |
 | --- | --- | --- | --- | ---: | --- |

--- a/scripts/treedb_rabitq_1bit_profile_gate.sh
+++ b/scripts/treedb_rabitq_1bit_profile_gate.sh
@@ -19,6 +19,7 @@ GOMAXPROCS_VALUE="${GOMAXPROCS:-8}"
 GOWORK_VALUE="${GOWORK:-off}"
 PPROF_FRAMES="${PPROF_FRAMES:-columnVectorGraphRabitQQuantizedScorer.scoreOrdinalUnchecked,columnVectorGraphRabitQQuantizedScorer.scoreOrdinals,ScoreCosine,scoreAndPushFrontierVisitedTile,frontierSiftDown,insertTop,fetchTopPreparedSearchResults,acquireCollectionVectorIndexPreparedSearch}"
 BASELINE_DIR="${BASELINE_DIR:-}"
+RECALL_TOLERANCE_PCT="${RECALL_TOLERANCE_PCT:-0}"
 
 mkdir -p "$RUN_DIR"
 
@@ -155,6 +156,8 @@ write_context() {
 		printf 'timing: enabled=%s benchtime=%s count=%s\n' "$RUN_TIMING" "$TIMING_BENCHTIME" "$TIMING_COUNT"
 		printf 'profiles: enabled=%s benchtime=%s count=%s\n' "$RUN_PROFILES" "$PROFILE_BENCHTIME" "$PROFILE_COUNT"
 		printf 'dry_run: %s\n' "$DRY_RUN"
+		printf 'baseline_dir: %s\n' "$BASELINE_DIR"
+		printf 'recall_tolerance_pct: %s\n' "$RECALL_TOLERANCE_PCT"
 		printf 'pprof_frames: %s\n' "$PPROF_FRAMES"
 		printf '\n# git status --short\n'
 		git status --short || true
@@ -365,7 +368,7 @@ for i in "${!row_ids[@]}"; do
 	run_row "${row_ids[$i]}" "${row_codecs[$i]}" "${row_layers[$i]}" "${row_modes[$i]}" "${row_concurrency[$i]}" "${row_rerank_candidates[$i]}" "${row_regexes[$i]}" "${row_profile_selected[$i]}"
 done
 
-python3 - "$RUN_DIR" <<'PY'
+python3 - "$RUN_DIR" "$BASELINE_DIR" "$RECALL_TOLERANCE_PCT" <<'PY'
 import glob
 import math
 import os
@@ -374,6 +377,11 @@ import statistics
 import sys
 
 root = sys.argv[1]
+baseline_root = sys.argv[2] if len(sys.argv) > 2 else ""
+try:
+    recall_tolerance_pct = float(sys.argv[3]) if len(sys.argv) > 3 and sys.argv[3] else 0.0
+except ValueError:
+    recall_tolerance_pct = 0.0
 metric_units = {
     "ns/op",
     "ops/sec",
@@ -484,7 +492,21 @@ def present_all_le(rows, name, limit):
     return present_all(rows, name) and all(row.get(name) <= limit for row in rows)
 
 
-def guardrail_status(meta, bench_rows):
+def present_all_ge(rows, name, minimum):
+    return present_all(rows, name) and all(row.get(name) >= minimum for row in rows)
+
+
+def recall_guardrail_ok(bench_rows, baseline_rows):
+    if not present_all(bench_rows, "recall_at_k_pct"):
+        return False
+    if baseline_rows and present_all(baseline_rows, "recall_at_k_pct"):
+        candidate = median([row.get("recall_at_k_pct") for row in bench_rows])
+        baseline = median([row.get("recall_at_k_pct") for row in baseline_rows])
+        return candidate is not None and baseline is not None and candidate + recall_tolerance_pct >= baseline
+    return present_all_ge(bench_rows, "recall_at_k_pct", 99.999)
+
+
+def guardrail_status(meta, bench_rows, baseline_rows):
     if not bench_rows:
         return "n/a"
     checks = []
@@ -505,7 +527,7 @@ def guardrail_status(meta, bench_rows):
         checks.append(present_all_zero(bench_rows, name))
     checks.append(present_all_eq(bench_rows, "search_route_column_graph_prepared/search", 1))
     checks.append(present_all_eq(bench_rows, "quantized_scorer_active/search", 1))
-    checks.append(present_all_eq(bench_rows, "recall_at_k_pct", 100))
+    checks.append(recall_guardrail_ok(bench_rows, baseline_rows))
 
     expected_code_bytes = 16 if meta.get("codec") == "rabitq_1bit" else 128
     checks.append(present_all_eq(bench_rows, "quantized_code_B/vector", expected_code_bytes))
@@ -582,7 +604,12 @@ for row_id in selected_row_ids:
         values = [row.get(unit) for row in bench_rows]
         out[unit] = median(values)
         out[unit + "__max"] = max([v for v in values if v is not None], default=None)
-    out["guardrail_status"] = guardrail_status(meta, bench_rows)
+    baseline_rows = []
+    if baseline_root:
+        baseline_rows = parse_file(os.path.join(baseline_root, row_id, "bench_timing.txt"))
+        if not baseline_rows:
+            baseline_rows = parse_file(os.path.join(baseline_root, row_id, "bench_profile.txt"))
+    out["guardrail_status"] = guardrail_status(meta, bench_rows, baseline_rows)
     summary_rows.append(out)
 
 fields = [
@@ -666,6 +693,8 @@ cat >"$RUN_DIR/README.md" <<EOF
 - timing: enabled=\`$RUN_TIMING\`, benchtime=\`$TIMING_BENCHTIME\`, count=\`$TIMING_COUNT\`
 - profiles: enabled=\`$RUN_PROFILES\`, benchtime=\`$PROFILE_BENCHTIME\`, count=\`$PROFILE_COUNT\`
 - dry run: \`$DRY_RUN\`
+- baseline dir: \`$BASELINE_DIR\`
+- recall tolerance pct: \`$RECALL_TOLERANCE_PCT\`
 
 Primary files:
 

--- a/scripts/treedb_rabitq_1bit_profile_gate.sh
+++ b/scripts/treedb_rabitq_1bit_profile_gate.sh
@@ -1,0 +1,680 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+cd "$ROOT"
+
+RUN_DIR="${RUN_DIR:-/tmp/gomap_rabitq_1bit_profile_gate_$(date +%Y%m%d_%H%M%S)}"
+ROWS="${ROWS:-claim_core}"
+PROFILE_ROWS="${PROFILE_ROWS:-rabitq_collection_quantized_only_c1,rabitq_collection_quantized_only_c8}"
+BENCHTIME="${BENCHTIME:-100000x}"
+TIMING_BENCHTIME="${TIMING_BENCHTIME:-$BENCHTIME}"
+PROFILE_BENCHTIME="${PROFILE_BENCHTIME:-$BENCHTIME}"
+TIMING_COUNT="${TIMING_COUNT:-5}"
+PROFILE_COUNT="${PROFILE_COUNT:-1}"
+RUN_TIMING="${RUN_TIMING:-true}"
+RUN_PROFILES="${RUN_PROFILES:-true}"
+DRY_RUN="${DRY_RUN:-false}"
+GOMAXPROCS_VALUE="${GOMAXPROCS:-8}"
+GOWORK_VALUE="${GOWORK:-off}"
+PPROF_FRAMES="${PPROF_FRAMES:-columnVectorGraphRabitQQuantizedScorer.scoreOrdinalUnchecked,columnVectorGraphRabitQQuantizedScorer.scoreOrdinals,ScoreCosine,scoreAndPushFrontierVisitedTile,frontierSiftDown,insertTop,fetchTopPreparedSearchResults,acquireCollectionVectorIndexPreparedSearch}"
+BASELINE_DIR="${BASELINE_DIR:-}"
+
+mkdir -p "$RUN_DIR"
+
+is_true() {
+	case "$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')" in
+		1|true|yes|y|on) return 0 ;;
+		*) return 1 ;;
+	esac
+}
+
+sanitize() {
+	printf '%s' "$1" | tr -c 'A-Za-z0-9_.=-' '_'
+}
+
+quote_cmd() {
+	local first=1 arg
+	for arg in "$@"; do
+		if [[ $first -eq 0 ]]; then
+			printf ' '
+		fi
+		printf '%q' "$arg"
+		first=0
+	done
+	printf '\n'
+}
+
+write_pprof_top() {
+	local profile=$1
+	local dest=$2
+	shift 2
+	if [[ ! -s "$profile" ]]; then
+		printf 'profile %s is missing or empty\n' "$profile" >"$dest"
+		return 0
+	fi
+	if ! go tool pprof "$@" "$profile" >"$dest.tmp" 2>"$dest.err"; then
+		{
+			printf 'go tool pprof failed for %s\n' "$profile"
+			cat "$dest.err"
+		} >"$dest"
+	else
+		mv "$dest.tmp" "$dest"
+	fi
+	rm -f "$dest.tmp" "$dest.err"
+}
+
+write_pprof_list() {
+	local profile=$1
+	local frame=$2
+	local dest=$3
+	if [[ ! -s "$profile" ]]; then
+		printf 'profile %s is missing or empty\n' "$profile" >"$dest"
+		return 0
+	fi
+	if ! go tool pprof -list="$frame" "$profile" >"$dest.tmp" 2>"$dest.err"; then
+		{
+			printf 'go tool pprof -list=%s failed for %s\n' "$frame" "$profile"
+			cat "$dest.err"
+		} >"$dest"
+	else
+		mv "$dest.tmp" "$dest"
+	fi
+	rm -f "$dest.tmp" "$dest.err"
+}
+
+matches_selector() {
+	local selector=$1
+	local id=$2
+	local codec=$3
+	local layer=$4
+	local mode=$5
+	local concurrency=$6
+	case "$selector" in
+		all) return 0 ;;
+		claim_core) [[ "$mode" == "quantized_only" && ( "$codec" == "rabitq_1bit" || "$codec" == "scalar_u8" ) ]] ;;
+		claim_rerank|claim_with_rerank) [[ ( "$codec" == "rabitq_1bit" || "$codec" == "scalar_u8" ) && ( "$mode" == "quantized_only" || "$mode" == "quantized_rerank" ) ]] ;;
+		target|rabitq|rabitq_1bit) [[ "$codec" == "rabitq_1bit" ]] ;;
+		rabitq_only|rabitq_quantized_only) [[ "$codec" == "rabitq_1bit" && "$mode" == "quantized_only" ]] ;;
+		rabitq_rerank|rabitq_quantized_rerank|rabitq_quantized_rerank32) [[ "$codec" == "rabitq_1bit" && "$mode" == "quantized_rerank" ]] ;;
+		scalar|scalar_u8|scalar_guardrail|scalar_guardrails) [[ "$codec" == "scalar_u8" ]] ;;
+		scalar_only|scalar_quantized_only) [[ "$codec" == "scalar_u8" && "$mode" == "quantized_only" ]] ;;
+		scalar_rerank|scalar_quantized_rerank|scalar_quantized_rerank32) [[ "$codec" == "scalar_u8" && "$mode" == "quantized_rerank" ]] ;;
+		lower) [[ "$layer" == "lower" ]] ;;
+		collection) [[ "$layer" == "collection" ]] ;;
+		quantized_only) [[ "$mode" == "quantized_only" ]] ;;
+		quantized_rerank|rerank|rerank32) [[ "$mode" == "quantized_rerank" ]] ;;
+		c1|c=1) [[ "$concurrency" == "1" ]] ;;
+		c8|c=8) [[ "$concurrency" == "8" ]] ;;
+		*) [[ "$selector" == "$id" ]] ;;
+	esac
+}
+
+selected_by_list() {
+	local selector_list=$1
+	local id=$2
+	local codec=$3
+	local layer=$4
+	local mode=$5
+	local concurrency=$6
+	local old_ifs=$IFS part
+	IFS=','
+	for part in $selector_list; do
+		part=${part//[[:space:]]/}
+		if [[ -z "$part" ]]; then
+			continue
+		fi
+		if matches_selector "$part" "$id" "$codec" "$layer" "$mode" "$concurrency"; then
+			IFS=$old_ifs
+			return 0
+		fi
+	done
+	IFS=$old_ifs
+	return 1
+}
+
+write_context() {
+	local dest=$1
+	{
+		printf 'TreeDB rabitq_1bit profile gate context\n'
+		printf '=======================================\n\n'
+		printf 'run_dir: %s\n' "$RUN_DIR"
+		printf 'worktree: %s\n' "$ROOT"
+		printf 'branch: %s\n' "$(git rev-parse --abbrev-ref HEAD)"
+		printf 'commit: %s\n' "$(git rev-parse HEAD)"
+		printf 'short_commit: %s\n' "$(git rev-parse --short HEAD)"
+		printf 'origin_main: %s\n' "$(git rev-parse origin/main 2>/dev/null || true)"
+		printf 'go_version: %s\n' "$(go version)"
+		printf 'go_env: '
+		GOWORK="$GOWORK_VALUE" go env GOOS GOARCH GOVERSION GOMOD GOWORK CGO_ENABLED | tr '\n' ' '
+		printf '\n'
+		printf 'GOMAXPROCS: %s\n' "$GOMAXPROCS_VALUE"
+		printf 'GOWORK: %s\n' "$GOWORK_VALUE"
+		printf 'rows: %s\n' "$ROWS"
+		printf 'profile_rows: %s\n' "$PROFILE_ROWS"
+		printf 'timing: enabled=%s benchtime=%s count=%s\n' "$RUN_TIMING" "$TIMING_BENCHTIME" "$TIMING_COUNT"
+		printf 'profiles: enabled=%s benchtime=%s count=%s\n' "$RUN_PROFILES" "$PROFILE_BENCHTIME" "$PROFILE_COUNT"
+		printf 'dry_run: %s\n' "$DRY_RUN"
+		printf 'pprof_frames: %s\n' "$PPROF_FRAMES"
+		printf '\n# git status --short\n'
+		git status --short || true
+		printf '\n# uptime\n'
+		uptime || true
+		printf '\n# top competing processes by %%cpu\n'
+		ps -axo pid,pcpu,pmem,comm,args 2>/dev/null | sort -nrk2 | head -n 40 || true
+		printf '\n# visible benchmark/test/go processes\n'
+		ps -axo pid,pcpu,pmem,comm,args 2>/dev/null | grep -E '(^|/)(go|compile|link|gomap|bench|test)( |$)|go test|pprof|benchstat|TreeDB' | grep -v grep || true
+	} >"$dest"
+}
+
+run_go_test() {
+	local outfile=$1
+	shift
+	GOMAXPROCS="$GOMAXPROCS_VALUE" GOWORK="$GOWORK_VALUE" "$@" 2>&1 | tee "$outfile"
+}
+
+run_row() {
+	local id=$1
+	local codec=$2
+	local layer=$3
+	local mode=$4
+	local concurrency=$5
+	local rerank_candidates=$6
+	local bench_regex=$7
+	local profile_selected=$8
+	local profile_captured=false
+	if ! is_true "$DRY_RUN" && is_true "$RUN_PROFILES" && is_true "$profile_selected"; then
+		profile_captured=true
+	fi
+	local row_dir="$RUN_DIR/$id"
+	local timing_txt="$row_dir/bench_timing.txt"
+	local profile_txt="$row_dir/bench_profile.txt"
+	local cpu_profile="$row_dir/cpu.pprof"
+	local alloc_profile="$row_dir/allocs.pprof"
+	local block_profile="$row_dir/block.pprof"
+	local mutex_profile="$row_dir/mutex.pprof"
+	local lists_dir="$row_dir/pprof_lists"
+	local test_binary="$row_dir/collections.test"
+
+	mkdir -p "$row_dir" "$lists_dir"
+	{
+		printf 'row_id=%s\n' "$id"
+		printf 'codec=%s\n' "$codec"
+		printf 'layer=%s\n' "$layer"
+		printf 'mode=%s\n' "$mode"
+		printf 'concurrency=%s\n' "$concurrency"
+		printf 'rerank_candidates=%s\n' "$rerank_candidates"
+		printf 'profile_selected=%s\n' "$profile_selected"
+		printf 'profile_captured=%s\n' "$profile_captured"
+		printf 'bench_regex=%s\n' "$bench_regex"
+		printf 'fixture=1024 rows / 128 dims / topK=10 / efSearch=128 / queryOrdinal=37\n'
+	} >"$row_dir/row.env"
+
+	local timing_cmd=(go test ./TreeDB/collections -run '^$' -bench "$bench_regex" -benchmem -benchtime "$TIMING_BENCHTIME" -count "$TIMING_COUNT")
+	local profile_cmd=(go test ./TreeDB/collections -run '^$' -bench "$bench_regex" -benchmem -benchtime "$PROFILE_BENCHTIME" -count "$PROFILE_COUNT" -o "$test_binary" -cpuprofile "$cpu_profile" -memprofile "$alloc_profile" -blockprofile "$block_profile" -mutexprofile "$mutex_profile")
+
+	{
+		printf 'GOMAXPROCS=%q GOWORK=%q ' "$GOMAXPROCS_VALUE" "$GOWORK_VALUE"
+		quote_cmd "${timing_cmd[@]}"
+	} >"$row_dir/command_timing.txt"
+	{
+		printf 'GOMAXPROCS=%q GOWORK=%q ' "$GOMAXPROCS_VALUE" "$GOWORK_VALUE"
+		quote_cmd "${profile_cmd[@]}"
+	} >"$row_dir/command_profile.txt"
+
+	if is_true "$DRY_RUN"; then
+		printf 'dry run: timing command not executed\n' >"$timing_txt"
+		printf 'dry run: profile command not executed\n' >"$profile_txt"
+		for dest in "$row_dir/cpu_top.txt" "$row_dir/allocs_top.txt" "$row_dir/block_top.txt" "$row_dir/mutex_top.txt"; do
+			printf 'dry run: no profile captured\n' >"$dest"
+		done
+	else
+		if is_true "$RUN_TIMING"; then
+			printf '==> timing %s\n' "$id"
+			run_go_test "$timing_txt" "${timing_cmd[@]}"
+		else
+			printf 'timing skipped for %s\n' "$id" >"$timing_txt"
+		fi
+
+		if is_true "$RUN_PROFILES" && is_true "$profile_selected"; then
+			printf '==> profiles %s\n' "$id"
+			run_go_test "$profile_txt" "${profile_cmd[@]}"
+			write_pprof_top "$cpu_profile" "$row_dir/cpu_top.txt" -top
+			write_pprof_top "$alloc_profile" "$row_dir/allocs_top.txt" -top -sample_index=alloc_space
+			write_pprof_top "$block_profile" "$row_dir/block_top.txt" -top
+			write_pprof_top "$mutex_profile" "$row_dir/mutex_top.txt" -top
+
+			local old_ifs=$IFS frame safe
+			IFS=','
+			for frame in $PPROF_FRAMES; do
+				frame=${frame//[[:space:]]/}
+				[[ -z "$frame" ]] && continue
+				safe=$(sanitize "$frame")
+				write_pprof_list "$cpu_profile" "$frame" "$lists_dir/${safe}.txt"
+			done
+			IFS=$old_ifs
+		else
+			printf 'profiles skipped for %s (RUN_PROFILES=%s profile_selected=%s)\n' "$id" "$RUN_PROFILES" "$profile_selected" >"$profile_txt"
+			for dest in "$row_dir/cpu_top.txt" "$row_dir/allocs_top.txt" "$row_dir/block_top.txt" "$row_dir/mutex_top.txt"; do
+				printf 'profile not selected for %s\n' "$id" >"$dest"
+			done
+		fi
+	fi
+
+	cat >"$row_dir/README.md" <<EOF
+# RaBitQ profile gate row: $id
+
+- codec: \`$codec\`
+- layer: \`$layer\`
+- mode: \`$mode\`
+- concurrency: \`$concurrency\`
+- rerank candidates: \`$rerank_candidates\`
+- benchmark regex: \`$bench_regex\`
+- fixture: 1024 rows / 128 dims / \`topK=10\` / \`efSearch=128\` / query ordinal 37
+- timing command: \`$(tr '\n' ' ' <"$row_dir/command_timing.txt")\`
+- profile command: \`$(tr '\n' ' ' <"$row_dir/command_profile.txt")\`
+- profile selected: \`$profile_selected\`
+- profile captured: \`$profile_captured\`
+
+Artifacts:
+
+- \`bench_timing.txt\`: unprofiled per-row timing/guardrail output.
+- \`bench_profile.txt\`: profiled benchmark output when this row is in \`PROFILE_ROWS\` and \`RUN_PROFILES=true\`.
+- \`cpu.pprof\`, \`allocs.pprof\`, \`block.pprof\`, \`mutex.pprof\` when \`profile_captured=true\`.
+- \`collections.test\`: test binary emitted by Go profiling flags when \`profile_captured=true\`.
+- \`cpu_top.txt\`, \`allocs_top.txt\`, \`block_top.txt\`, \`mutex_top.txt\`.
+- \`pprof_lists/*.txt\`: line-level CPU excerpts for configured target frames.
+
+Use unprofiled \`bench_timing.txt\` rows for \`ns/op\`, \`B/op\`, and
+\`allocs/op\`. The pprof files intentionally cover one selected benchmark
+subrow plus that row's Go test fixture setup/teardown.
+EOF
+}
+
+add_row() {
+	local id=$1
+	local codec=$2
+	local layer=$3
+	local mode=$4
+	local concurrency=$5
+	local rerank_candidates=$6
+	local bench_regex=$7
+	if selected_by_list "$ROWS" "$id" "$codec" "$layer" "$mode" "$concurrency"; then
+		local profile_selected=false
+		if selected_by_list "$PROFILE_ROWS" "$id" "$codec" "$layer" "$mode" "$concurrency"; then
+			profile_selected=true
+		fi
+		row_ids+=("$id")
+		row_codecs+=("$codec")
+		row_layers+=("$layer")
+		row_modes+=("$mode")
+		row_concurrency+=("$concurrency")
+		row_rerank_candidates+=("$rerank_candidates")
+		row_regexes+=("$bench_regex")
+		row_profile_selected+=("$profile_selected")
+	fi
+}
+
+row_ids=()
+row_codecs=()
+row_layers=()
+row_modes=()
+row_concurrency=()
+row_rerank_candidates=()
+row_regexes=()
+row_profile_selected=()
+
+rabitq_lower_bench='^BenchmarkVectorIndexSearcherColumnGraphRabitQQuantizedSearchWithBuffer2451$'
+rabitq_collection_bench='^BenchmarkCollectionSearchVectorIndexWithBufferColumnGraphRabitQQuantized2452$'
+scalar_lower_bench='^BenchmarkVectorIndexSearcherColumnGraphScalarU8QuantizedSearchWithBuffer2414$'
+scalar_collection_bench='^BenchmarkCollectionSearchVectorIndexWithBufferColumnGraphScalarU8Quantized2415$'
+
+add_quantized_rows() {
+	local prefix=$1
+	local codec=$2
+	local lower_bench=$3
+	local collection_bench=$4
+	add_row "${prefix}_lower_quantized_only_c1" "$codec" lower quantized_only 1 0 "$lower_bench/^route=quantized_only$/^c=1$"
+	add_row "${prefix}_lower_quantized_only_c8" "$codec" lower quantized_only 8 0 "$lower_bench/^route=quantized_only$/^c=8$"
+	add_row "${prefix}_lower_quantized_rerank32_c1" "$codec" lower quantized_rerank 1 32 "$lower_bench/^route=quantized_rerank$/^candidates=32$/^c=1$"
+	add_row "${prefix}_lower_quantized_rerank32_c8" "$codec" lower quantized_rerank 8 32 "$lower_bench/^route=quantized_rerank$/^candidates=32$/^c=8$"
+	add_row "${prefix}_collection_quantized_only_c1" "$codec" collection quantized_only 1 0 "$collection_bench/^route=quantized_only$/^c=1$"
+	add_row "${prefix}_collection_quantized_only_c8" "$codec" collection quantized_only 8 0 "$collection_bench/^route=quantized_only$/^c=8$"
+	add_row "${prefix}_collection_quantized_rerank32_c1" "$codec" collection quantized_rerank 1 32 "$collection_bench/^route=quantized_rerank$/^candidates=32$/^c=1$"
+	add_row "${prefix}_collection_quantized_rerank32_c8" "$codec" collection quantized_rerank 8 32 "$collection_bench/^route=quantized_rerank$/^candidates=32$/^c=8$"
+}
+
+add_quantized_rows rabitq rabitq_1bit "$rabitq_lower_bench" "$rabitq_collection_bench"
+add_quantized_rows scalar scalar_u8 "$scalar_lower_bench" "$scalar_collection_bench"
+
+if [[ ${#row_ids[@]} -eq 0 ]]; then
+	printf 'no rows selected by ROWS=%s\n' "$ROWS" >&2
+	exit 2
+fi
+
+write_context "$RUN_DIR/context.txt"
+
+{
+	printf 'row_id\tcodec\tlayer\tmode\tconcurrency\trerank_candidates\tprofile_selected\tbench_regex\n'
+	for i in "${!row_ids[@]}"; do
+		printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' "${row_ids[$i]}" "${row_codecs[$i]}" "${row_layers[$i]}" "${row_modes[$i]}" "${row_concurrency[$i]}" "${row_rerank_candidates[$i]}" "${row_profile_selected[$i]}" "${row_regexes[$i]}"
+	done
+} >"$RUN_DIR/matrix.tsv"
+
+for i in "${!row_ids[@]}"; do
+	run_row "${row_ids[$i]}" "${row_codecs[$i]}" "${row_layers[$i]}" "${row_modes[$i]}" "${row_concurrency[$i]}" "${row_rerank_candidates[$i]}" "${row_regexes[$i]}" "${row_profile_selected[$i]}"
+done
+
+python3 - "$RUN_DIR" <<'PY'
+import glob
+import math
+import os
+import re
+import statistics
+import sys
+
+root = sys.argv[1]
+metric_units = {
+    "ns/op",
+    "ops/sec",
+    "B/op",
+    "allocs/op",
+    "recall_at_k_pct",
+    "docs_fetched/search",
+    "vector_B/search",
+    "norm_B/search",
+    "exact_vector_B/vector",
+    "exact_norm_B/vector",
+    "exact_vector_norm_B/vector",
+    "quantized_code_B/search",
+    "quantized_code_B/vector",
+    "quantized_asset_B/vector",
+    "quantized_asset_B_total",
+    "quantized_rerank_candidates/search",
+    "quantized_rerank_exact_score_calls/search",
+    "prepared_score_calls/search",
+    "quantized_score_calls/search",
+    "quantized_scorer_active/search",
+    "quantized_asset_missing/search",
+    "quantized_asset_invalid/search",
+    "quantized_asset_stale/search",
+    "quantized_asset_closed/search",
+    "quantized_asset_unavailable/search",
+    "prepared_graph_search_views/search",
+    "score_float64_fallbacks/search",
+    "graph_row_fallbacks/search",
+    "typed_column_vector_fallbacks/search",
+    "vector_scratch_decodes/search",
+    "search_route_quantized_only/search",
+    "search_route_quantized_rerank/search",
+    "search_route_column_graph_prepared/search",
+    "search_route_column_graph_fallback/search",
+    "open_setup_in_timed_loop",
+    "open_searcher_calls/op",
+    "collection_prepared_cache_builds/op",
+    "collection_prepared_cache_hits/op",
+    "collection_prepared_cache_misses/op",
+    "collection_prepared_cache_waits/op",
+    "collection_prepared_cache_errors/op",
+}
+
+number_re = re.compile(r"^[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?$")
+bench_re = re.compile(r"^Benchmark\S+")
+
+
+def parse_file(path):
+    rows = []
+    if not os.path.exists(path):
+        return rows
+    with open(path, "r", encoding="utf-8", errors="replace") as handle:
+        for line in handle:
+            if not bench_re.match(line):
+                continue
+            fields = line.split()
+            if len(fields) < 4 or not fields[1].isdigit():
+                continue
+            metrics = {"benchmark": fields[0], "iterations": float(fields[1])}
+            i = 2
+            while i + 1 < len(fields):
+                value, unit = fields[i], fields[i + 1]
+                if number_re.match(value):
+                    try:
+                        metrics[unit] = float(value)
+                    except ValueError:
+                        pass
+                    i += 2
+                else:
+                    i += 1
+            rows.append(metrics)
+    return rows
+
+
+def median(values):
+    values = [v for v in values if v is not None and not math.isnan(v)]
+    if not values:
+        return None
+    return statistics.median(values)
+
+
+def fmt(value):
+    if value is None:
+        return ""
+    if not isinstance(value, (int, float)):
+        return str(value)
+    if abs(value - round(value)) < 1e-9:
+        return str(int(round(value)))
+    if abs(value) >= 1000:
+        return f"{value:.0f}"
+    return f"{value:.3f}".rstrip("0").rstrip(".")
+
+
+def present_all(rows, name):
+    return all(name in row for row in rows)
+
+
+def present_all_zero(rows, name):
+    return present_all(rows, name) and all(row.get(name) == 0 for row in rows)
+
+
+def present_all_eq(rows, name, want):
+    return present_all(rows, name) and all(row.get(name) == want for row in rows)
+
+
+def present_all_le(rows, name, limit):
+    return present_all(rows, name) and all(row.get(name) <= limit for row in rows)
+
+
+def guardrail_status(meta, bench_rows):
+    if not bench_rows:
+        return "n/a"
+    checks = []
+    checks.append(present_all_zero(bench_rows, "B/op"))
+    checks.append(present_all_zero(bench_rows, "allocs/op"))
+    checks.append(present_all_zero(bench_rows, "docs_fetched/search"))
+    for name in (
+        "graph_row_fallbacks/search",
+        "typed_column_vector_fallbacks/search",
+        "vector_scratch_decodes/search",
+        "score_float64_fallbacks/search",
+        "quantized_asset_missing/search",
+        "quantized_asset_invalid/search",
+        "quantized_asset_stale/search",
+        "quantized_asset_closed/search",
+        "quantized_asset_unavailable/search",
+    ):
+        checks.append(present_all_zero(bench_rows, name))
+    checks.append(present_all_eq(bench_rows, "search_route_column_graph_prepared/search", 1))
+    checks.append(present_all_eq(bench_rows, "quantized_scorer_active/search", 1))
+    checks.append(present_all_eq(bench_rows, "recall_at_k_pct", 100))
+
+    expected_code_bytes = 16 if meta.get("codec") == "rabitq_1bit" else 128
+    checks.append(present_all_eq(bench_rows, "quantized_code_B/vector", expected_code_bytes))
+    checks.append(present_all(bench_rows, "quantized_asset_B/vector"))
+
+    mode = meta.get("mode", "")
+    if mode == "quantized_only":
+        checks.append(present_all_eq(bench_rows, "search_route_quantized_only/search", 1))
+        checks.append(present_all_zero(bench_rows, "search_route_quantized_rerank/search"))
+        checks.append(present_all_zero(bench_rows, "vector_B/search"))
+        checks.append(present_all_zero(bench_rows, "norm_B/search"))
+        checks.append(present_all_zero(bench_rows, "quantized_rerank_candidates/search"))
+        checks.append(present_all_zero(bench_rows, "quantized_rerank_exact_score_calls/search"))
+        checks.append(present_all_zero(bench_rows, "prepared_score_calls/search"))
+    elif mode == "quantized_rerank":
+        candidates = int(meta.get("rerank_candidates") or 0)
+        checks.append(present_all_zero(bench_rows, "search_route_quantized_only/search"))
+        checks.append(present_all_eq(bench_rows, "search_route_quantized_rerank/search", 1))
+        checks.append(present_all_eq(bench_rows, "quantized_rerank_candidates/search", candidates))
+        checks.append(present_all_le(bench_rows, "quantized_rerank_exact_score_calls/search", candidates))
+        checks.append(present_all_le(bench_rows, "prepared_score_calls/search", candidates))
+        exact_read_ok = True
+        for row in bench_rows:
+            required = ("vector_B/search", "norm_B/search", "exact_vector_B/vector", "exact_norm_B/vector")
+            if any(name not in row for name in required):
+                exact_read_ok = False
+                break
+            if row["vector_B/search"] > candidates * row["exact_vector_B/vector"]:
+                exact_read_ok = False
+                break
+            if row["norm_B/search"] > candidates * row["exact_norm_B/vector"]:
+                exact_read_ok = False
+                break
+        checks.append(exact_read_ok)
+    return "pass" if all(checks) else "check"
+
+summary_rows = []
+for row_dir in sorted(glob.glob(os.path.join(root, "*"))):
+    if not os.path.isdir(row_dir):
+        continue
+    row_id = os.path.basename(row_dir)
+    env_path = os.path.join(row_dir, "row.env")
+    if not os.path.exists(env_path):
+        continue
+    meta = {}
+    with open(env_path, "r", encoding="utf-8", errors="replace") as handle:
+        for line in handle:
+            if "=" in line:
+                key, value = line.rstrip("\n").split("=", 1)
+                meta[key] = value
+    source = "bench_timing.txt"
+    bench_rows = parse_file(os.path.join(row_dir, source))
+    if not bench_rows:
+        source = "bench_profile.txt"
+        bench_rows = parse_file(os.path.join(row_dir, source))
+    if not bench_rows:
+        summary_rows.append({"row_id": row_id, "source": source, "status": "no benchmark rows", "guardrail_status": "n/a", **meta})
+        continue
+    out = {"row_id": row_id, "source": source, "status": "ok", **meta}
+    all_metrics = sorted({key for row in bench_rows for key in row.keys()} | metric_units)
+    for unit in all_metrics:
+        if unit == "benchmark" or unit in meta:
+            continue
+        values = [row.get(unit) for row in bench_rows]
+        out[unit] = median(values)
+        out[unit + "__max"] = max([v for v in values if v is not None], default=None)
+    out["guardrail_status"] = guardrail_status(meta, bench_rows)
+    summary_rows.append(out)
+
+fields = [
+    "row_id", "codec", "layer", "mode", "concurrency", "rerank_candidates", "profile_selected", "profile_captured", "source", "status", "guardrail_status",
+    "ns/op", "ops/sec", "B/op", "allocs/op", "recall_at_k_pct",
+    "docs_fetched/search", "vector_B/search", "norm_B/search", "quantized_code_B/search", "quantized_code_B/vector", "quantized_asset_B/vector",
+    "quantized_rerank_candidates/search", "quantized_rerank_exact_score_calls/search", "prepared_score_calls/search",
+    "graph_row_fallbacks/search", "typed_column_vector_fallbacks/search", "vector_scratch_decodes/search", "score_float64_fallbacks/search",
+    "quantized_asset_missing/search", "quantized_asset_invalid/search", "quantized_asset_stale/search", "quantized_asset_closed/search", "quantized_asset_unavailable/search",
+    "search_route_quantized_only/search", "search_route_quantized_rerank/search", "search_route_column_graph_prepared/search",
+    "open_setup_in_timed_loop", "open_searcher_calls/op", "collection_prepared_cache_hits/op", "collection_prepared_cache_misses/op", "collection_prepared_cache_waits/op",
+]
+
+with open(os.path.join(root, "summary.tsv"), "w", encoding="utf-8") as out:
+    out.write("\t".join(fields) + "\n")
+    for row in summary_rows:
+        out.write("\t".join(fmt(row.get(field)) for field in fields) + "\n")
+
+with open(os.path.join(root, "summary.md"), "w", encoding="utf-8") as out:
+    out.write("# TreeDB rabitq_1bit profile gate summary\n\n")
+    out.write("This report is generated from isolated benchmark subrows. ")
+    out.write("Guardrail status checks allocation, document/materialization, fallback, asset-unavailable, route, recall, code-byte, and exact-read constraints from benchmark counters.\n\n")
+    out.write("| row | codec | layer | mode | c | ns/op | ops/sec | B/op | allocs/op | recall@K % | code B/search | code B/vector | asset B/vector | vector B/search | norm B/search | rerank exact calls/search | guardrails | profile captured |\n")
+    out.write("| --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- | --- |\n")
+    for row in summary_rows:
+        out.write(
+            "| {row_id} | {codec} | {layer} | {mode} | {c} | {ns} | {ops} | {bop} | {allocs} | {recall} | {code_search} | {code_vector} | {asset_vector} | {vec} | {norm} | {rerank} | {guard} | {profiled} |\n".format(
+                row_id=row.get("row_id", ""),
+                codec=row.get("codec", ""),
+                layer=row.get("layer", ""),
+                mode=row.get("mode", ""),
+                c=row.get("concurrency", ""),
+                ns=fmt(row.get("ns/op")),
+                ops=fmt(row.get("ops/sec")),
+                bop=fmt(row.get("B/op")),
+                allocs=fmt(row.get("allocs/op")),
+                recall=fmt(row.get("recall_at_k_pct")),
+                code_search=fmt(row.get("quantized_code_B/search")),
+                code_vector=fmt(row.get("quantized_code_B/vector")),
+                asset_vector=fmt(row.get("quantized_asset_B/vector")),
+                vec=fmt(row.get("vector_B/search")),
+                norm=fmt(row.get("norm_B/search")),
+                rerank=fmt(row.get("quantized_rerank_exact_score_calls/search")),
+                guard=row.get("guardrail_status", ""),
+                profiled=row.get("profile_captured", ""),
+            )
+        )
+    out.write("\n## Artifact layout\n\n")
+    out.write("Each selected row directory contains `bench_timing.txt`, `bench_profile.txt`, command files, a row README, top summaries, and pprof files when `profile_captured=true`.\n")
+PY
+
+if [[ -n "$BASELINE_DIR" ]]; then
+	if command -v benchstat >/dev/null 2>&1; then
+		: >"$RUN_DIR/benchstat_vs_baseline.txt"
+		for id in "${row_ids[@]}"; do
+			base_file="$BASELINE_DIR/$id/bench_timing.txt"
+			cand_file="$RUN_DIR/$id/bench_timing.txt"
+			if [[ -s "$base_file" && -s "$cand_file" ]]; then
+				{
+					printf '## %s\n' "$id"
+					benchstat "$base_file" "$cand_file"
+					printf '\n'
+				} >>"$RUN_DIR/benchstat_vs_baseline.txt"
+			fi
+		done
+	else
+		printf 'benchstat not found; skipping BASELINE_DIR comparison\n' >"$RUN_DIR/benchstat_vs_baseline.txt"
+	fi
+fi
+
+cat >"$RUN_DIR/README.md" <<EOF
+# TreeDB rabitq_1bit Profile Gate Bundle
+
+- worktree: \`$ROOT\`
+- branch: \`$(git rev-parse --abbrev-ref HEAD)\`
+- commit: \`$(git rev-parse HEAD)\`
+- GOMAXPROCS: \`$GOMAXPROCS_VALUE\`
+- GOWORK: \`$GOWORK_VALUE\`
+- selected rows: \`$ROWS\`
+- profile rows: \`$PROFILE_ROWS\`
+- timing: enabled=\`$RUN_TIMING\`, benchtime=\`$TIMING_BENCHTIME\`, count=\`$TIMING_COUNT\`
+- profiles: enabled=\`$RUN_PROFILES\`, benchtime=\`$PROFILE_BENCHTIME\`, count=\`$PROFILE_COUNT\`
+- dry run: \`$DRY_RUN\`
+
+Primary files:
+
+- \`context.txt\`: commit, Go version, OS/arch, uptime, and process inventory.
+- \`matrix.tsv\`: exact row IDs, benchmark regexes, and profile selection.
+- \`summary.md\`, \`summary.tsv\`: per-row timing medians and guardrail counter summary.
+- \`<row>/bench_timing.txt\`: unprofiled benchmark output for the selected row.
+- \`<row>/bench_profile.txt\`: profiled benchmark output for rows selected by \`PROFILE_ROWS\`.
+- \`<row>/cpu.pprof\`, \`<row>/allocs.pprof\`, \`<row>/block.pprof\`, \`<row>/mutex.pprof\` when \`profile_captured=true\`.
+- \`<row>/collections.test\`: test binary emitted by Go profiling flags when \`profile_captured=true\`.
+- \`<row>/cpu_top.txt\`, \`<row>/allocs_top.txt\`, \`<row>/block_top.txt\`, \`<row>/mutex_top.txt\`.
+- \`<row>/pprof_lists/*.txt\`: line-level CPU excerpts for target frames.
+
+Host-load caveat: if \`context.txt\` shows competing benchmark/test processes or
+high load, treat the run as contaminated and rerun before claiming a candidate
+win. Smoke runs and dry runs validate shape only; they are not speedup evidence.
+EOF
+
+printf 'rabitq_1bit profile gate bundle: %s\n' "$RUN_DIR"
+printf 'summary: %s\n' "$RUN_DIR/summary.md"
+printf 'matrix: %s\n' "$RUN_DIR/matrix.tsv"
+printf 'context: %s\n' "$RUN_DIR/context.txt"

--- a/scripts/treedb_rabitq_1bit_profile_gate.sh
+++ b/scripts/treedb_rabitq_1bit_profile_gate.sh
@@ -542,13 +542,23 @@ def guardrail_status(meta, bench_rows):
         checks.append(exact_read_ok)
     return "pass" if all(checks) else "check"
 
+selected_row_ids = []
+matrix_path = os.path.join(root, "matrix.tsv")
+if os.path.exists(matrix_path):
+    with open(matrix_path, "r", encoding="utf-8", errors="replace") as handle:
+        for line_number, line in enumerate(handle):
+            if line_number == 0:
+                continue
+            fields = line.rstrip("\n").split("\t")
+            if fields and fields[0]:
+                selected_row_ids.append(fields[0])
+
 summary_rows = []
-for row_dir in sorted(glob.glob(os.path.join(root, "*"))):
-    if not os.path.isdir(row_dir):
-        continue
-    row_id = os.path.basename(row_dir)
+for row_id in selected_row_ids:
+    row_dir = os.path.join(root, row_id)
     env_path = os.path.join(row_dir, "row.env")
     if not os.path.exists(env_path):
+        summary_rows.append({"row_id": row_id, "source": "row.env", "status": "missing row.env", "guardrail_status": "n/a"})
         continue
     meta = {}
     with open(env_path, "r", encoding="utf-8", errors="replace") as handle:


### PR DESCRIPTION
## Objective

Closes #2476. Adds a checked-in TreeDB `rabitq_1bit` benchmark/profile gate for Sublane A of #2475 so later RaBitQ optimization PRs have a durable same-host baseline/candidate workflow before making performance claims.

## Context

#2476 is the mandatory foundation before #2477 performance claims. The new workflow builds on #2465/#2466 but makes RaBitQ row naming, profiles, scalar_u8 guardrails, exact FP32 guidance, quiet-host rejection, and no-promote policy explicit.

## Non-goals

- No runtime scorer/search optimization.
- No `rabitq_1bit` v1 storage, LSB-first bit order, score formula, codec/asset identity, durable asset identity, or fail-closed behavior changes.
- No speedup claim from smoke-only data.

## Design / Scope

Includes:

- `docs/benchmarks/treedb_rabitq_1bit_profile_gate.md`
  - smoke commands and claim-quality same-host baseline/candidate commands;
  - c=1/c=8 artifact names for `quantized_only` and `quantized_rerank/candidates=32`;
  - scalar_u8 guardrail summaries and exact FP32 guardrail guidance for shared search/traversal/cache/finalization changes;
  - quiet-host/load notes, summary-table conventions, profile artifact conventions, and explicit mixed/noisy/regressing no-promote rule.
- `scripts/treedb_rabitq_1bit_profile_gate.sh`
  - `claim_core`, `claim_rerank`, `rabitq`, `scalar_guardrail`, lower/collection/mode/c selectors;
  - `DRY_RUN=true` path;
  - `summary.md`/`summary.tsv`, row command files, context, CPU/alloc/block/mutex profiles and top summaries.
- `docs/README.md` benchmark index link.

Excludes runtime TreeDB collection/search/scorer code.

## Correctness / Tests

Latest local head: `c5d9f4d64d4ca654ca59594d26dd0f2a9f7d86d0`

- `GOWORK=off go test ./TreeDB/docs -count=1` ✅
- `GOWORK=off go test ./TreeDB/collections -count=1` ✅
- `bash -n scripts/treedb_rabitq_1bit_profile_gate.sh` ✅
- Stale-summary guard smoke: reused one `RUN_DIR` with `ROWS=claim_core` then `ROWS=rabitq_collection_quantized_only_c1`; regenerated `summary.md` included only the current `matrix.tsv` row ✅ (`/tmp/gomap_2476_stale_summary_smoke_20260606_103839`)
- Baseline recall comparison smoke: ran one-row baseline and candidate with `BASELINE_DIR` set; summary guardrails passed when candidate median recall matched baseline ✅ (`/tmp/gomap_2476_baseline_recall_smoke_*`, `/tmp/gomap_2476_candidate_recall_smoke_*`)
- Dry run: `RUN_DIR=/tmp/gomap_2476_postcommit_dryrun_20260606_103200 DRY_RUN=true ROWS=claim_core scripts/treedb_rabitq_1bit_profile_gate.sh` ✅
  - matrix rows: 8 selected rows (RaBitQ + scalar_u8 `quantized_only` c=1/c=8 lower/collection), profile selection for RaBitQ collection c=1/c=8.
- Profile smoke: `RUN_DIR=/tmp/gomap_2476_postcommit_profile_smoke_20260606_103201 ROWS=rabitq_collection_quantized_only_c1 PROFILE_ROWS=rabitq_collection_quantized_only_c1 BENCHTIME=1x TIMING_COUNT=1 PROFILE_COUNT=1 GOMAXPROCS=8 GOWORK=off scripts/treedb_rabitq_1bit_profile_gate.sh` ✅
  - produced `summary.md`, `cpu.pprof`, `allocs.pprof`, `cpu_top.txt`, `allocs_top.txt`; guardrails passed for the smoke row.

## Starting-commit smoke baseline (no speed claim)

Baseline commit/branch: `origin/main` / `7c38b993ad20875f7307ab151229814d2bb62844`.
Raw local artifact: `/tmp/gomap_2476_starting_smoke_20260606_102027/starting_smoke_matrix.txt`; summary: `/tmp/gomap_2476_starting_smoke_20260606_102027/starting_smoke_summary.md`.
Command: issue-required smoke matrix with `GOMAXPROCS=8 GOWORK=off`, `-benchtime=100x`, `-count=3`, `-benchmem`.

Interpretation: shape/counter smoke only. Claim-quality evidence must use the checked-in same-host baseline/candidate workflow with longer counts/profiles.

| Row | ns/op median | ops/sec median | B/op median (max) | allocs/op median (max) | recall@K % | code B/search | code B/vector | asset B/vector | guardrail note |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| RaBitQ lower `quantized_only` c=1 | 37,942 | 26,356 | 0 (0) | 0 (0) | 100 | 2,704 | 16 | 66.62 | docs=0, exact=0, alloc pass |
| RaBitQ lower `quantized_only` c=8 | 8,823 | 113,341 | 0 (0) | 0 (0) | 100 | 2,704 | 16 | 66.62 | docs=0, exact=0, alloc pass |
| RaBitQ collection `quantized_only` c=1 | 48,398 | 20,662 | 0 (0) | 0 (0) | 100 | 2,704 | 16 | 66.62 | docs=0, exact=0, alloc pass |
| RaBitQ collection `quantized_only` c=8 | 10,480 | 95,420 | 0 (0) | 0 (0) | 100 | 2,704 | 16 | 66.62 | docs=0, exact=0, alloc pass |
| scalar_u8 lower `quantized_only` c=1 | 9,705 | 103,035 | 0 (0) | 0 (0) | 100 | 21,632 | 128 | 169.7 | docs=0, exact=0, alloc pass |
| scalar_u8 lower `quantized_only` c=8 | 2,958 | 338,075 | 0 (1) | 0 (0) | 100 | 21,632 | 128 | 169.7 | docs=0, exact=0, allocation smoke check |
| scalar_u8 collection `quantized_only` c=1 | 10,772 | 92,832 | 0 (0) | 0 (0) | 100 | 21,632 | 128 | 169.7 | docs=0, exact=0, alloc pass |
| scalar_u8 collection `quantized_only` c=8 | 3,000 | 333,333 | 0 (0) | 0 (0) | 100 | 21,632 | 128 | 169.7 | docs=0, exact=0, alloc pass |

## Performance / Regression Assessment

This PR changes docs and a benchmark/profile script only. It makes no runtime performance claim and does not change measured search/scorer behavior. The runbook requires no-promote for mixed, noisy, unrepeatable, current-only, or regressing candidate evidence.

## CI / AI Review

- CI: latest head `c5d9f4d6461ceb74bcadbc7c4fbeff1ab2e2d269` green.
- AI review: Codex latest comment says no major issues; CodeRabbit actionable findings fixed and all review threads resolved (latest CodeRabbit status green; explicit re-request was rate-limited); Copilot requested, no standalone findings posted.
