### PR TITLE
Optimize RaBitQ scorer with query byte tables

### DIFF
--- a/TreeDB/collections/column_vector_graph_quantized_scorer.go
+++ b/TreeDB/collections/column_vector_graph_quantized_scorer.go
@@ -241,6 +241,8 @@ type columnVectorGraphRabitQQuantizedScorer struct {
 	indexName                     string
 	plan                          *rabitq.Plan
 	query                         rabitq.Query
+	queryWeightSum                float64
+	queryByteMismatchWeights      []float64
 	codeRows                      quantizedasset.CodeRowView
 	codePayload                   []byte
 	codeCountPayload              []byte
@@ -319,7 +321,11 @@ func (r *columnVectorGraphPhysicalRowReader) prepareRabitQQuantizedScorer(mode c
 	if err != nil {
 		return columnVectorGraphRabitQQuantizedScorer{}, fmt.Errorf("%w: %w: column_graph %q query_mode=%s quantized index %q rabitq_1bit query encode: %v", ErrVectorIndexSearchUnavailable, errColumnVectorGraphQuantizedAssetInvalid, r.def.Name, mode.String(), indexName, err)
 	}
-	return columnVectorGraphRabitQQuantizedScorer{indexName: indexName, plan: plan, query: encodedQuery, codeRows: codeRows, codePayload: codePayload, codeCountPayload: codeCountPayload, quantizedDotProductInvPayload: qdpInvPayload, bytesPerCode: plan.BytesPerCode(), codeDimensions: plan.CodeDimensions()}, nil
+	queryByteMismatchWeights, queryWeightSum, ok := rabitq.PrepareQueryByteMismatchWeights(encodedQuery, &scratch.quantizedRabitQWorkspace)
+	if !ok {
+		return columnVectorGraphRabitQQuantizedScorer{}, fmt.Errorf("%w: %w: column_graph %q query_mode=%s quantized index %q rabitq_1bit query byte tables unavailable", ErrVectorIndexSearchUnavailable, errColumnVectorGraphQuantizedAssetInvalid, r.def.Name, mode.String(), indexName)
+	}
+	return columnVectorGraphRabitQQuantizedScorer{indexName: indexName, plan: plan, query: encodedQuery, queryWeightSum: queryWeightSum, queryByteMismatchWeights: queryByteMismatchWeights, codeRows: codeRows, codePayload: codePayload, codeCountPayload: codeCountPayload, quantizedDotProductInvPayload: qdpInvPayload, bytesPerCode: plan.BytesPerCode(), codeDimensions: plan.CodeDimensions()}, nil
 }
 
 func (s *columnVectorGraphRabitQQuantizedScorer) scoreOrdinal(ordinal int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) (float64, error) {
@@ -370,7 +376,7 @@ func (s *columnVectorGraphRabitQQuantizedScorer) scoreOrdinals(ordinals []int, d
 }
 
 func (s *columnVectorGraphRabitQQuantizedScorer) validate() error {
-	if s == nil || s.plan == nil || !s.codeRows.Valid() || s.bytesPerCode <= 0 || s.codeDimensions <= 0 || len(s.codePayload) != s.codeRows.Rows()*s.bytesPerCode || len(s.codeCountPayload) != s.codeRows.Rows()*4 || len(s.quantizedDotProductInvPayload) != s.codeRows.Rows()*4 || !rabitqQueryShapeValidForPlan(s.query, s.plan) {
+	if s == nil || s.plan == nil || !s.codeRows.Valid() || s.bytesPerCode <= 0 || s.codeDimensions <= 0 || len(s.codePayload) != s.codeRows.Rows()*s.bytesPerCode || len(s.codeCountPayload) != s.codeRows.Rows()*4 || len(s.quantizedDotProductInvPayload) != s.codeRows.Rows()*4 || !rabitqQueryShapeValidForPlan(s.query, s.plan) || !rabitq.QueryByteMismatchWeightsValid(s.query, s.queryByteMismatchWeights, s.queryWeightSum) {
 		return fmt.Errorf("%w: column_graph quantized rabitq_1bit scorer is unavailable", ErrVectorIndexSearchUnavailable)
 	}
 	return nil
@@ -396,7 +402,7 @@ func (s *columnVectorGraphRabitQQuantizedScorer) scoreOrdinalUnchecked(ordinal i
 		return 0, fmt.Errorf("%w: column_graph quantized index %q rabitq_1bit code_count ordinal=%d value=%d exceeds code_dimensions=%d", ErrVectorIndexSearchUnavailable, s.indexName, ordinal, codeCount, s.codeDimensions)
 	}
 	qdpInv := math.Float32frombits(binary.LittleEndian.Uint32(s.quantizedDotProductInvPayload[sideStart : sideStart+4]))
-	score, ok := rabitqQuantizedCosineScore(s.query, code, qdpInv)
+	score, ok := rabitqQuantizedCosineScoreWithByteTables(s.query, code, qdpInv, s.queryByteMismatchWeights, s.queryWeightSum)
 	if !ok {
 		return 0, fmt.Errorf("%w: column_graph quantized index %q rabitq_1bit score ordinal=%d unavailable", ErrVectorIndexSearchUnavailable, s.indexName, ordinal)
 	}
@@ -416,6 +422,23 @@ func (s *columnVectorGraphRabitQQuantizedScorer) recordScoreStats(stats *columnV
 
 func rabitqQueryShapeValidForPlan(query rabitq.Query, plan *rabitq.Plan) bool {
 	return plan != nil && query.CodeDimensions == plan.CodeDimensions() && len(query.SignBits) == plan.BytesPerCode() && len(query.AbsWeights) == plan.CodeDimensions() && query.WeightSum > 0 && !math.IsNaN(float64(query.WeightSum)) && !math.IsInf(float64(query.WeightSum), 0)
+}
+
+func rabitqQuantizedCosineScoreWithByteTables(query rabitq.Query, code []byte, quantizedDotProductInv float32, byteMismatchWeights []float64, queryWeightSum float64) (float64, bool) {
+	if !rabitq.QueryByteMismatchWeightsValid(query, byteMismatchWeights, queryWeightSum) || len(code) != len(query.SignBits) || quantizedDotProductInv <= 0 || math.IsNaN(float64(quantizedDotProductInv)) || math.IsInf(float64(quantizedDotProductInv), 0) {
+		return 0, false
+	}
+	var mismatchWeight float64
+	for byteIdx, candidateByte := range code {
+		xorMask := candidateByte ^ query.SignBits[byteIdx]
+		mismatchWeight += byteMismatchWeights[byteIdx*rabitq.ByteMismatchTableEntries+int(xorMask)]
+	}
+	weightedSignDot := queryWeightSum - 2*mismatchWeight
+	score := weightedSignDot / (float64(quantizedDotProductInv) * float64(query.CodeDimensions))
+	if math.IsNaN(score) || math.IsInf(score, 0) {
+		return 0, false
+	}
+	return score, true
 }
 
 func rabitqQuantizedCosineScore(query rabitq.Query, code []byte, quantizedDotProductInv float32) (float64, bool) {

--- a/TreeDB/collections/column_vector_graph_rabitq_byte_tables_test.go
+++ b/TreeDB/collections/column_vector_graph_rabitq_byte_tables_test.go
@@ -1,0 +1,206 @@
+package collections
+
+import (
+	"math"
+	"strconv"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/internal/rabitq"
+)
+
+func TestRabitQByteMismatchWeightsLSBAndPadding2477(t *testing.T) {
+	query := rabitq.Query{
+		SignBits:       []byte{0b1010_0101, 0b0000_0010},
+		AbsWeights:     []float32{1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024},
+		WeightSum:      2047,
+		CodeDimensions: 11,
+	}
+	var tableWS rabitq.Workspace
+	tables, weightSum, ok := rabitq.PrepareQueryByteMismatchWeights(query, &tableWS)
+	if !ok {
+		t.Fatal("prepare query byte mismatch weights failed")
+	}
+	if weightSum != 2047 {
+		t.Fatalf("weightSum=%v want 2047", weightSum)
+	}
+	if got := tables[0b0000_0001]; got != 1 {
+		t.Fatalf("byte0 bit0 mismatch weight=%v want 1", got)
+	}
+	if got := tables[0b1000_0000]; got != 128 {
+		t.Fatalf("byte0 bit7 mismatch weight=%v want 128", got)
+	}
+	if got := tables[0b1000_0101]; got != 1+4+128 {
+		t.Fatalf("byte0 combined LSB-first mismatch weight=%v want %v", got, 1+4+128)
+	}
+	base := rabitq.ByteMismatchTableEntries
+	if got := tables[base+0b0000_0001]; got != 256 {
+		t.Fatalf("partial byte bit0 mismatch weight=%v want 256", got)
+	}
+	if got := tables[base+0b0000_0010]; got != 512 {
+		t.Fatalf("partial byte bit1 mismatch weight=%v want 512", got)
+	}
+	if got := tables[base+0b0000_0100]; got != 1024 {
+		t.Fatalf("partial byte bit2 mismatch weight=%v want 1024", got)
+	}
+	if got := tables[base+0b1111_1000]; got != 0 {
+		t.Fatalf("partial byte high padding mismatch weight=%v want 0", got)
+	}
+	if got := tables[base+0b1111_1111]; got != 256+512+1024 {
+		t.Fatalf("partial byte high padding combined mismatch weight=%v want %v", got, 256+512+1024)
+	}
+
+	paddedHighBitsOnly := []byte{query.SignBits[0], query.SignBits[1] | 0b1111_1000}
+	got, ok := rabitqQuantizedCosineScoreWithByteTables(query, paddedHighBitsOnly, 1, tables, weightSum)
+	if !ok {
+		t.Fatal("byte-table score rejected code with only high padding-bit differences")
+	}
+	want, ok := rabitqQuantizedCosineScore(query, paddedHighBitsOnly, 1)
+	if !ok {
+		t.Fatal("current score rejected code with only high padding-bit differences")
+	}
+	if got != want {
+		t.Fatalf("high padding score=%v want current=%v", got, want)
+	}
+
+	finalLogicalBitMismatch := []byte{query.SignBits[0], query.SignBits[1] ^ 0b0000_0100}
+	got, ok = rabitqQuantizedCosineScoreWithByteTables(query, finalLogicalBitMismatch, 1, tables, weightSum)
+	if !ok {
+		t.Fatal("byte-table score rejected final logical bit mismatch")
+	}
+	want, ok = rabitqQuantizedCosineScore(query, finalLogicalBitMismatch, 1)
+	if !ok {
+		t.Fatal("current score rejected final logical bit mismatch")
+	}
+	if got != want || got != -1.0/11.0 {
+		t.Fatalf("final logical mismatch score=%v want current=%v and -1/11", got, want)
+	}
+}
+
+func TestRabitQByteTableScorerMatchesOracleVariedDimensions2477(t *testing.T) {
+	for _, dims := range []int{1, 3, 7, 8, 9, 15, 16, 17, 31, 32, 64, 128} {
+		t.Run("dims_"+strconv.Itoa(dims), func(t *testing.T) {
+			plan, err := rabitq.NewPlan(dims, rabitq.DefaultConfig())
+			if err != nil {
+				t.Fatalf("NewPlan: %v", err)
+			}
+			var queryWS rabitq.Workspace
+			query, err := plan.EncodeQuery(rabitqTestVector2477(dims, 17), &queryWS)
+			if err != nil {
+				t.Fatalf("EncodeQuery: %v", err)
+			}
+			tables, weightSum, ok := rabitq.PrepareQueryByteMismatchWeights(query, &queryWS)
+			if !ok {
+				t.Fatal("prepare query byte mismatch weights failed")
+			}
+			var encodeWS rabitq.Workspace
+			for candidate := 0; candidate < 9; candidate++ {
+				encoded, err := plan.Encode(nil, rabitqTestVector2477(dims, uint64(candidate+31)), &encodeWS)
+				if err != nil {
+					t.Fatalf("Encode candidate %d: %v", candidate, err)
+				}
+				got, ok := rabitqQuantizedCosineScoreWithByteTables(query, encoded.Code, encoded.QuantizedDotProductInv, tables, weightSum)
+				if !ok {
+					t.Fatalf("byte-table score rejected dims=%d candidate=%d", dims, candidate)
+				}
+				want, err := plan.ScoreEncoded(query, encoded)
+				if err != nil {
+					t.Fatalf("ScoreEncoded candidate %d: %v", candidate, err)
+				}
+				current, ok := rabitqQuantizedCosineScore(query, encoded.Code, encoded.QuantizedDotProductInv)
+				if !ok {
+					t.Fatalf("current score rejected dims=%d candidate=%d", dims, candidate)
+				}
+				if math.Abs(got-want) > 1e-9 || math.Abs(got-current) > 1e-9 {
+					t.Fatalf("dims=%d candidate=%d byte-table score=%0.17g oracle=%0.17g current=%0.17g", dims, candidate, got, want, current)
+				}
+			}
+		})
+	}
+}
+
+func TestRabitQByteTableScorerFailClosed2477(t *testing.T) {
+	valid := rabitq.Query{
+		SignBits:       []byte{0b0101_1010, 0b0000_0011},
+		AbsWeights:     []float32{1, 2, 3, 4, 5, 6, 7, 8, 9},
+		WeightSum:      45,
+		CodeDimensions: 9,
+	}
+	var tableWS rabitq.Workspace
+	tables, weightSum, ok := rabitq.PrepareQueryByteMismatchWeights(valid, &tableWS)
+	if !ok {
+		t.Fatal("prepare valid query failed")
+	}
+
+	badQueries := []struct {
+		name  string
+		query rabitq.Query
+	}{
+		{name: "zero dimensions", query: rabitq.Query{SignBits: []byte{0}, AbsWeights: []float32{1}}},
+		{name: "short sign bits", query: rabitq.Query{SignBits: []byte{0}, AbsWeights: []float32{1, 2, 3, 4, 5, 6, 7, 8, 9}, CodeDimensions: 9}},
+		{name: "short weights", query: rabitq.Query{SignBits: []byte{0, 0}, AbsWeights: []float32{1}, CodeDimensions: 9}},
+		{name: "nan weight", query: rabitq.Query{SignBits: []byte{0, 0}, AbsWeights: []float32{1, 2, float32(math.NaN()), 4, 5, 6, 7, 8, 9}, CodeDimensions: 9}},
+		{name: "inf weight", query: rabitq.Query{SignBits: []byte{0, 0}, AbsWeights: []float32{1, 2, float32(math.Inf(1)), 4, 5, 6, 7, 8, 9}, CodeDimensions: 9}},
+		{name: "negative weight", query: rabitq.Query{SignBits: []byte{0, 0}, AbsWeights: []float32{1, 2, -3, 4, 5, 6, 7, 8, 9}, CodeDimensions: 9}},
+		{name: "zero weight sum", query: rabitq.Query{SignBits: []byte{0, 0}, AbsWeights: make([]float32, 9), CodeDimensions: 9}},
+	}
+	for _, tc := range badQueries {
+		if _, _, ok := rabitq.PrepareQueryByteMismatchWeights(tc.query, &tableWS); ok {
+			t.Fatalf("prepare bad query %q succeeded", tc.name)
+		}
+	}
+
+	badScores := []struct {
+		name      string
+		query     rabitq.Query
+		code      []byte
+		qdpInv    float32
+		tables    []float64
+		weightSum float64
+	}{
+		{name: "short code", query: valid, code: []byte{0}, qdpInv: 1, tables: tables, weightSum: weightSum},
+		{name: "zero qdp", query: valid, code: []byte{0, 0}, qdpInv: 0, tables: tables, weightSum: weightSum},
+		{name: "nan qdp", query: valid, code: []byte{0, 0}, qdpInv: float32(math.NaN()), tables: tables, weightSum: weightSum},
+		{name: "inf qdp", query: valid, code: []byte{0, 0}, qdpInv: float32(math.Inf(1)), tables: tables, weightSum: weightSum},
+		{name: "short tables", query: valid, code: []byte{0, 0}, qdpInv: 1, tables: tables[:len(tables)-1], weightSum: weightSum},
+		{name: "nan weight sum", query: valid, code: []byte{0, 0}, qdpInv: 1, tables: tables, weightSum: math.NaN()},
+	}
+	for _, tc := range badScores {
+		if _, ok := rabitqQuantizedCosineScoreWithByteTables(tc.query, tc.code, tc.qdpInv, tc.tables, tc.weightSum); ok {
+			t.Fatalf("bad score %q succeeded", tc.name)
+		}
+	}
+}
+
+func TestRabitQByteMismatchWeightsScratchReuseNoAlloc2477(t *testing.T) {
+	query := rabitq.Query{
+		SignBits:       []byte{0b0101_1010, 0b0000_0011},
+		AbsWeights:     []float32{1, 2, 3, 4, 5, 6, 7, 8, 9},
+		WeightSum:      45,
+		CodeDimensions: 9,
+	}
+	var tableWS rabitq.Workspace
+	if _, _, ok := rabitq.PrepareQueryByteMismatchWeights(query, &tableWS); !ok {
+		t.Fatal("prepare query byte mismatch weights failed")
+	}
+	allocs := testing.AllocsPerRun(1000, func() {
+		_, weightSum, ok := rabitq.PrepareQueryByteMismatchWeights(query, &tableWS)
+		if !ok || weightSum != 45 {
+			panic("prepare query byte mismatch weights failed")
+		}
+	})
+	if allocs != 0 {
+		t.Fatalf("prepared query byte mismatch weights allocs/run=%v want 0", allocs)
+	}
+}
+
+func rabitqTestVector2477(dims int, seed uint64) []float32 {
+	v := make([]float32, dims)
+	for i := range v {
+		x := math.Sin(float64((i+1)*int(seed+3))*0.731) + 0.5*math.Cos(float64((i+5)*int(seed+11))*0.173)
+		if x == 0 {
+			x = float64(i+1) * 0.001
+		}
+		v[i] = float32(x)
+	}
+	return v
+}

--- a/TreeDB/internal/rabitq/rabitq.go
+++ b/TreeDB/internal/rabitq/rabitq.go
@@ -78,9 +78,10 @@ type Plan struct {
 	signs            []float64
 }
 
-// Workspace holds reusable scratch for Encode and EncodeQuery. Query values
-// returned by EncodeQuery alias this workspace and remain valid until the next
-// EncodeQuery call using the same Workspace.
+// Workspace holds reusable scratch for Encode, EncodeQuery, and query byte-table
+// preparation. Query values returned by EncodeQuery alias query-specific
+// workspace buffers and remain valid until the next EncodeQuery call using the
+// same Workspace.
 type Workspace struct {
 	work         []float64
 	queryBits    []byte
@@ -102,6 +103,70 @@ type Query struct {
 	AbsWeights     []float32
 	WeightSum      float32
 	CodeDimensions int
+}
+
+// ByteMismatchTableEntries is the number of per-byte XOR masks in a query-local
+// mismatch-weight table.
+const ByteMismatchTableEntries = 256
+
+// PrepareQueryByteMismatchWeights builds query-local byte/XOR mask tables for
+// the v1 weighted sign-dot scorer. The returned slice aliases ws and remains
+// valid until the next operation that reuses the same workspace scratch.
+func PrepareQueryByteMismatchWeights(query Query, ws *Workspace) ([]float64, float64, bool) {
+	if query.CodeDimensions <= 0 || len(query.AbsWeights) < query.CodeDimensions || len(query.SignBits) == 0 {
+		return nil, 0, false
+	}
+	bytesPerCode := (query.CodeDimensions + 7) / 8
+	if len(query.SignBits) != bytesPerCode {
+		return nil, 0, false
+	}
+	if ws == nil {
+		ws = &Workspace{}
+	}
+	entries := bytesPerCode * ByteMismatchTableEntries
+	if cap(ws.work) < entries {
+		ws.work = make([]float64, entries)
+	} else {
+		ws.work = ws.work[:entries]
+	}
+	var queryWeightSum float64
+	var byteWeights [8]float64
+	for byteIdx := 0; byteIdx < bytesPerCode; byteIdx++ {
+		validBits := query.CodeDimensions - byteIdx*8
+		if validBits > 8 {
+			validBits = 8
+		}
+		if validBits <= 0 {
+			return nil, 0, false
+		}
+		for bit := 0; bit < validBits; bit++ {
+			weight := float64(query.AbsWeights[byteIdx*8+bit])
+			if math.IsNaN(weight) || math.IsInf(weight, 0) || weight < 0 {
+				return nil, 0, false
+			}
+			byteWeights[bit] = weight
+			queryWeightSum += weight
+		}
+		for bit := validBits; bit < len(byteWeights); bit++ {
+			byteWeights[bit] = 0
+		}
+		base := byteIdx * ByteMismatchTableEntries
+		ws.work[base] = 0
+		for mask := 1; mask < ByteMismatchTableEntries; mask++ {
+			leastBit := mask & -mask
+			ws.work[base+mask] = ws.work[base+(mask^leastBit)] + byteWeights[bits.TrailingZeros8(uint8(leastBit))]
+		}
+	}
+	if queryWeightSum <= 0 || math.IsNaN(queryWeightSum) || math.IsInf(queryWeightSum, 0) {
+		return nil, 0, false
+	}
+	return ws.work, queryWeightSum, true
+}
+
+// QueryByteMismatchWeightsValid reports whether weights has the shape returned
+// by PrepareQueryByteMismatchWeights for query.
+func QueryByteMismatchWeightsValid(query Query, weights []float64, queryWeightSum float64) bool {
+	return query.CodeDimensions > 0 && len(query.SignBits) == (query.CodeDimensions+7)/8 && len(weights) == len(query.SignBits)*ByteMismatchTableEntries && queryWeightSum > 0 && !math.IsNaN(queryWeightSum) && !math.IsInf(queryWeightSum, 0)
 }
 
 // NewPlan validates dimensions, derives code shape, and precomputes the v1


### PR DESCRIPTION
## Objective

Closes #2477. Implements the semantics-preserving `rabitq_1bit` v1 query byte-table scorer from #2475/#2477 while keeping storage, bit order, score formula, codec identity, asset identity, and fail-closed behavior unchanged.

## Scope / Non-goals

Changed:

- `TreeDB/internal/rabitq`: query-local byte/XOR mismatch-weight table preparation using existing `Workspace` scratch.
- `TreeDB/collections`: RaBitQ scorer uses `weighted_sign_dot = queryWeightSum - 2*sum mismatchWeight[byte][candidateByte^queryByte]`.
- Focused parity, LSB-first/padding, fail-closed, and no-allocation tests.

Not changed:

- no durable asset/storage layout changes;
- no LSB-first bit-order changes;
- no score formula/estimator change;
- no codec name/version/config or durable asset identity change;
- no scalar_u8, exact FP32, traversal/frontier/finalization, or hidden fallback changes.

## Correctness / Tests

Latest PR head: `69bcb950afb9efc5ddd321edb22f93b9b5103ea0`

- `GOWORK=off go test ./TreeDB/internal/rabitq -count=1` ✅
- `GOWORK=off go test ./TreeDB/collections -count=1` ✅
- Focused before full run:
  - `GOWORK=off go test ./TreeDB/collections -run 'TestRabitQByte|TestColumnGraphRabitQQuantizedScorerMatchesOracle2451|TestCollectionSearchVectorIndexWithBufferRabitQQuantized2452' -count=1` ✅

Added tests cover:

- byte-table parity vs current scorer and `TreeDB/internal/rabitq` oracle across varied dimensions/padding;
- LSB-first byte/mask weights and partial final-byte high-bit padding;
- bad query/code/side-array fail-closed behavior;
- warmed byte-table preparation and buffered collection RaBitQ search remain `0 allocs/op`.

## Benchmark / Profile Evidence

Baseline: `origin/main` / `435a1c06a7f5e9751f99a199ec3edae184787508`.
Candidate benchmarked: `17857e779830e7d6f2f88a33f8a11ecea2817529`; latest PR head `69bcb950...` differs only by comment/docstring text in `TreeDB/internal/rabitq/rabitq.go`.

Command shape:

```sh
ROWS=claim_rerank \
PROFILE_ROWS=rabitq_lower_quantized_only_c1,rabitq_lower_quantized_only_c8,rabitq_collection_quantized_only_c1,rabitq_collection_quantized_only_c8,rabitq_lower_quantized_rerank32_c1,rabitq_lower_quantized_rerank32_c8,rabitq_collection_quantized_rerank32_c1,rabitq_collection_quantized_rerank32_c8 \
BENCHTIME=100000x TIMING_COUNT=5 PROFILE_COUNT=1 \
GOMAXPROCS=8 GOWORK=off \
scripts/treedb_rabitq_1bit_profile_gate.sh
```

Artifacts:

- baseline: `/tmp/gomap_2477_final2_baseline_main_435a1c06_20260606_112457`
- candidate: `/tmp/gomap_2477_final2_candidate_17857e779_20260606_112935`
- scalar interleaved guardrail: `/tmp/gomap_2477_interleaved_scalar_lower_qonly_c8_20260606_114454`

RaBitQ medians from `summary.md`:

| row | baseline ns/op | baseline ops/s | candidate ns/op | candidate ops/s | delta | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| lower quantized_only c=1 | 40,721 | 24,557 | 17,790 | 56,211 | -56.3% | 0 | 0 |
| lower quantized_only c=8 | 9,977 | 100,231 | 7,991 | 125,141 | -19.9% | 0 | 0 |
| collection quantized_only c=1 | 42,805 | 23,362 | 19,348 | 51,685 | -54.8% | 0 | 0 |
| collection quantized_only c=8 | 14,258 | 70,136 | 8,455 | 118,273 | -40.7% | 0 | 0 |
| lower rerank32 c=1 | 42,156 | 23,721 | 18,772 | 53,271 | -55.5% | 0 | 0 |
| lower rerank32 c=8 | 10,652 | 93,879 | 6,852 | 145,943 | -35.7% | 0 | 0 |
| collection rerank32 c=1 | 47,355 | 21,117 | 20,298 | 49,266 | -57.1% | 0 | 0 |
| collection rerank32 c=8 | 16,056 | 62,282 | 6,593 | 151,676 | -58.9% | 0 | 0 |

Counters/quality: recall@K stayed 100%; quantized_only exact vector/norm bytes and rerank exact calls stayed 0; rerank exact calls stayed 32/search; route/fallback/asset-unavailable counters stayed at expected values; all reported rows stayed `0 B/op`, `0 allocs/op`.

CPU profile summary:

- baseline collection quantized_only c=1: old `rabitqQuantizedCosineScore` was 60.48% flat / 60.95% cum.
- candidate collection quantized_only c=1: byte-table score loop was 7.61% flat; query table prep was 17.77% flat.
- baseline collection quantized_only c=8: old `rabitqQuantizedCosineScore` was 62.17% flat / 62.34% cum.
- candidate collection quantized_only c=8: byte-table score loop was 4.32% flat; query table prep was 24.82% flat.

Scalar guardrail note: the host was noisy (see `context.txt`; Orca/fseventsd/openclaw/ANECompilerService activity), so I added interleaved scalar checks for the one noisy scalar c=8 row. Interleaved scalar lower quantized_only c=8 was not a significant regression: 2.512µs ±5% baseline vs 2.651µs ±15% candidate, `p=0.199`, n=20, with counters/allocation equal. Scalar collection c=8 rows in the count=30 guardrail were non-regressing.

## Regression Assessment / #2478 Handoff

No storage/semantic/fail-closed regressions found. RaBitQ target rows improve strongly and allocation/counter guardrails hold.

Post-#2477 profiles do **not** show packed-code accessor/reader overhead as the next clear bottleneck. The old scorer hot loop is largely removed; candidate profiles now show query byte-table preparation plus traversal/frontier/search overhead. #2478 should start from these profiles and should not assume packed-code access is material without fresh evidence.

## CI / AI Review

- CI: all latest-head checks passing on `69bcb950afb9efc5ddd321edb22f93b9b5103ea0` after rerunning the single flaky `race-check (linux)-2` failure (unrelated `TreeDB/caching` scheduled quiet-wait timeout; rerun passed).
- CodeRabbit: passed / no actionable comments.
- Codex: `@codex review` returned no major issues.
- Copilot: `@copilot review` requested; no textual findings were posted.
- Review threads: none open.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling and validation for vector quantization scoring to prevent invalid numeric results.

* **Tests**
  * Added comprehensive test coverage for quantization scoring edge cases, consistency validation, and memory efficiency.

* **Documentation**
  * Clarified workspace buffer validity contract for improved API reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
