### PR TITLE
Specify brq_1bit future codec contract

### DIFF
--- a/TreeDB/docs/brq_1bit_spec_test.go
+++ b/TreeDB/docs/brq_1bit_spec_test.go
@@ -1,0 +1,81 @@
+package docs_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDocs_BRQ1BitV1Spec2480(t *testing.T) {
+	treeRoot, _ := repoRoots(t)
+	path := filepath.Join(treeRoot, "docs", "spec", "brq-1bit-v1.md")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read brq spec: %v", err)
+	}
+	text := string(data)
+	normalized := strings.Join(strings.Fields(text), " ")
+	for _, want := range []string{
+		"`brq_1bit` version `1`",
+		"MUST NOT reinterpret or mutate `rabitq_1bit` v1",
+		"License survey and implementation boundary",
+		"Default seed | `0x6272713162697401`",
+		"Query weight width | `QueryWeightBits=4` unsigned runtime-only bit planes",
+		"Score label | `brq_1bit_estimated_cosine_q4`",
+		"codec=brq_1bit",
+		"query_weight_quantizer=max_abs_uint4_round_half_up",
+		"Asset id | `quantized/<name>/brq_1bit/packed_codes`",
+		"`packed_codes` | `packed_codes` | `packed_bit_vector` / `raw_packed_bit_vector`",
+		"logical bit `i` is byte `i/8`, bit `i%8` (LSB0 within each byte)",
+		"little-endian `uint64` word views map logical bit `i` to word `i/64`, bit `i%64`",
+		"score = signed_weight_int * query_weight_scale /",
+		"`quantized_only` returns this approximate score and must label it",
+		"Failures return `ErrVectorIndexSearchUnavailable`",
+		"canonical config bytes and `Config.Hash64` golden",
+		"Recall, storage, and performance gates",
+		"`quantized_score_codec_brq_1bit/search=1`",
+		"A complete `brq_1bit` v1 contract unblocks #2481",
+	} {
+		if !strings.Contains(normalized, strings.Join(strings.Fields(want), " ")) {
+			t.Fatalf("brq spec missing %q", want)
+		}
+	}
+}
+
+func TestDocs_BRQ1BitV1LinkedOwners2480(t *testing.T) {
+	treeRoot, _ := repoRoots(t)
+	checks := map[string][]string{
+		filepath.Join(treeRoot, "docs", "spec", "README.md"): {
+			"brq-1bit-v1.md",
+			"`brq_1bit` v1",
+			"query `uint4` bit-product score semantics",
+		},
+		filepath.Join(treeRoot, "docs", "spec", "quantized-vector-index.md"): {
+			"brq-1bit-v1.md",
+			"`brq_1bit` v1 prototype",
+			"explicit query `uint4` score label",
+		},
+		filepath.Join(treeRoot, "docs", "spec", "quantized-asset-schema.md"): {
+			"brq-1bit-v1.md",
+			"future `brq_1bit` v1 contract",
+			"runtime query `uint4` bit-product score semantics",
+		},
+		filepath.Join(treeRoot, "docs", "spec", "rabitq-1bit-v1.md"): {
+			"brq-1bit-v1.md",
+			"new codec identity/version",
+		},
+	}
+	for path, wants := range checks {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		text := string(data)
+		for _, want := range wants {
+			if !strings.Contains(text, want) {
+				t.Fatalf("%s missing brq spec text %q", path, want)
+			}
+		}
+	}
+}

--- a/TreeDB/docs/spec/README.md
+++ b/TreeDB/docs/spec/README.md
@@ -123,6 +123,11 @@ Given pre-alpha status, this is a living spec that tracks implementation.
   - issue #2482 RaBitQ performance-lane closeout for #2476/#2477 promoted
     Sublane A evidence, #2478/#2479 no-promote decisions, `rabitq_1bit` v1
     hard invariants, scalar/exact guardrail interpretation, and #2480/#2481 deferred Sublane B status.
+- `TreeDB/docs/spec/brq-1bit-v1.md`
+  - issue #2480 selected future-codec contract for `brq_1bit` v1, including the
+    new codec identity/version, durable packed-code schema, LSB0 word view,
+    query `uint4` bit-product score semantics, fail-closed validation plan,
+    oracle/golden test requirements, public counter names, and #2481 gates.
 - `TreeDB/docs/spec/typed-column-graph-search-prepared-views.md`
   - issue #2036 role-specific prepared runtime-view and admission policy for
     current-format typed-column graph search.
@@ -308,8 +313,9 @@ typed-column maintenance behavior is recorded in
 policy is owned by `typed-column-schema-evolution.md`, optimized-consumer tier
 classification is owned by `typed-column-optimized-consumer-capabilities.md`,
 quantized asset role descriptors and ordinal-reader contracts are owned by
-`quantized-asset-schema.md`, graph-search prepared runtime-view shapes and
-hot-loop boundaries are owned by
+`quantized-asset-schema.md`; `brq-1bit-v1.md` owns the selected #2480 future
+`brq_1bit` codec contract until any #2481 prototype updates it; graph-search
+prepared runtime-view shapes and hot-loop boundaries are owned by
 `typed-column-graph-search-prepared-views.md`, graph-search optimized-state
 readiness/admission status is owned by
 `typed-column-graph-search-admission.md`, #1886 direct-view closeout evidence is owned by

--- a/TreeDB/docs/spec/brq-1bit-v1.md
+++ b/TreeDB/docs/spec/brq-1bit-v1.md
@@ -6,8 +6,8 @@ does not publish assets/search by itself, and does not claim a throughput win.
 
 ## Decision
 
-#2480 selects `brq_1bit` version `1` as the single future codec candidate to
-prototype next. `brq_1bit` is a TreeDB-owned bit-product binary quantizer: it
+Issue #2480 selects `brq_1bit` version `1` as the single future codec candidate
+to prototype next. `brq_1bit` is a TreeDB-owned bit-product binary quantizer: it
 keeps one durable sign bit per rotated data dimension, makes query-weight
 quantization explicit, and labels returned quantized scores as approximate
 `brq_1bit` estimates. It exists because the #2453 go-highway probe showed that a
@@ -217,7 +217,7 @@ fields.
 
 ## Required oracle and golden tests before #2481 assets/search
 
-#2481 must land oracle/spec coverage before durable assets or production search:
+Issue #2481 must land oracle/spec coverage before durable assets or production search:
 
 - canonical config bytes and `Config.Hash64` golden;
 - rotation metadata, code dimensions, row bytes, and seed golden;

--- a/TreeDB/docs/spec/brq-1bit-v1.md
+++ b/TreeDB/docs/spec/brq-1bit-v1.md
@@ -1,0 +1,312 @@
+# TreeDB `brq_1bit` v1 Future Codec Contract (#2480)
+
+Status: pre-alpha **selected future-codec contract** for #2480. This is a
+specification gate for #2481 prototype work; it is not current runtime behavior,
+does not publish assets/search by itself, and does not claim a throughput win.
+
+## Decision
+
+#2480 selects `brq_1bit` version `1` as the single future codec candidate to
+prototype next. `brq_1bit` is a TreeDB-owned bit-product binary quantizer: it
+keeps one durable sign bit per rotated data dimension, makes query-weight
+quantization explicit, and labels returned quantized scores as approximate
+`brq_1bit` estimates. It exists because the #2453 go-highway probe showed that a
+fast bit-product scorer is a different storage/scoring contract from
+[`rabitq_1bit` v1](rabitq-1bit-v1.md).
+
+This contract MUST NOT reinterpret or mutate `rabitq_1bit` v1. Existing
+`rabitq_1bit` assets keep their codec name/version/config bytes, LSB-first
+layout, weighted sign-dot score formula, side arrays, and fail-closed behavior.
+Any `brq_1bit` implementation must use the new identity below.
+
+## License survey and implementation boundary
+
+- TreeDB's `brq_1bit` oracle, config bytes, storage schema, and scoring formula
+  are clean-room TreeDB design/spec text.
+- `github.com/ajroetker/go-highway` v0.0.12 was evaluated for #2453. Its module
+  and RaBitQ package are Apache-2.0 and may be used only as an optional kernel
+  dependency with normal notices if #2481 proves compatibility and value.
+- The upstream go-highway `QuantizeVectors` MSB-first word output is not TreeDB
+  durable storage. A future implementation must either write the TreeDB layout
+  directly or transcode before persisting assets.
+- Do not copy code from CockroachDB Software License, ELv2, AGPL, Antfly, or
+  incompatible C++ RaBitQ/BRQ libraries. Papers may be cited for algorithmic
+  background, but production code must be clean-room or from compatible
+  Apache-2.0/BSD-3 sources with notices.
+
+## Identity
+
+| Field | v1 value |
+| --- | --- |
+| Codec name | `brq_1bit` |
+| Codec version | `1` |
+| First metric/scope | `cosine` over `column_graph` float32 vectors |
+| Normalization | unit-L2 normalized data/query vectors |
+| Rotation | `signed_permutation_fwht_padded_v1` |
+| Default seed | `0x6272713162697401` |
+| Data code width | `CodeWidthBits=1` |
+| Query weight width | `QueryWeightBits=4` unsigned runtime-only bit planes |
+| Code dimensions | `CodeDimensions=next_power_of_two(VectorDimensions)` |
+| Durable data-code layout | `packed_bit_vector` / `raw_packed_bit_vector`, LSB0 |
+| Score label | `brq_1bit_estimated_cosine_q4` |
+
+The default seed differs from `rabitq_1bit` so assets cannot accidentally share
+config identity. Reusing the same rotation algorithm is allowed; sharing the
+`rabitq_1bit` codec name/version is not.
+
+## Canonical config bytes and hash
+
+`brq_1bit` v1 must define a small oracle package before assets/search land. Its
+`Config.CanonicalBytes` format is line-oriented ASCII and must be exactly:
+
+```text
+codec=brq_1bit
+version=1
+metric=cosine
+normalization=unit_l2
+rotation=signed_permutation_fwht_padded_v1
+seed=0x6272713162697401
+storage_role=packed_codes
+storage_logical_type=packed_bit_vector
+storage_encoding=raw_packed_bit_vector
+bit_order=lsb0
+word_order=little_endian_uint64
+padding=zero
+code_width_bits=1
+query_weight_bits=4
+query_weight_quantizer=max_abs_uint4_round_half_up
+score=brq_1bit_estimated_cosine_q4
+data_scale_side_array=quantized_dot_product_inv
+```
+
+`Config.Hash64` is FNV-1a over these bytes and is recorded in
+`quantizedasset.CodecDescriptor.ConfigHash`; the full canonical bytes are
+recorded in `CodecDescriptor.Config`. Vector dimensions and row counts remain
+schema/base-graph identity fields, not config bytes.
+
+## Durable asset schema
+
+Each declared `QuantizedVectorIndexDefinition{Codec:"brq_1bit", Version:1}`
+for a cosine `column_graph` vector index writes one vector-index-state asset in
+graph ordinal order.
+
+| State field | v1 value |
+| --- | --- |
+| Vector-index-state role | `quantized_codes` |
+| Asset id | `quantized/<name>/brq_1bit/packed_codes` |
+| State logical type / encoding | `packed_bit_vector` / `raw_packed_bit_vector` |
+| Ordinal order | `vector_ordinal` (`row i == graph ordinal i`) |
+
+The typed-column part contains:
+
+| Role | Column | Type / encoding | Shape | Required validation |
+| --- | --- | --- | --- | --- |
+| `packed_codes` | `packed_codes` | `packed_bit_vector` / `raw_packed_bit_vector` | `Rows=graph.RowCount`, `ElementsPerRow=CodeDimensions`, `BitsPerElement=1` | row bytes `ceil(CodeDimensions/8)`, zero padding |
+| `code_count` | `code_count` | `uint32` / `raw_uint32` | one scalar per graph ordinal | equals popcount over logical code bits |
+| `quantized_dot_product_inv` | `quantized_dot_product_inv` | `float32` / `raw_float32` | one scalar per graph ordinal | finite and in `[1/sqrt(CodeDimensions), 1]` with oracle tolerance |
+
+`brq_1bit` has no durable query arrays. Query sign bits, positive/negative
+query-weight bit planes, and query-weight scale are built per query and may be
+cached only within caller-owned search buffers.
+
+## Bit and word order
+
+Durable `packed_codes` rows use the existing TreeDB packed-code layout:
+
+- logical bit `i` is byte `i/8`, bit `i%8` (LSB0 within each byte);
+- unused high bits in the final byte are zero and fail validation if set;
+- little-endian `uint64` word views map logical bit `i` to word `i/64`, bit
+  `i%64`; partial final words are zero-filled in scratch only;
+- implementations may use SIMD/popcount kernels over word views, but must not
+  persist MSB-first words or rely on host-endian reinterpretation without the
+  typed-column direct-view/scratch safety checks.
+
+## Reference data encoding
+
+For a finite non-zero vector `x` with `VectorDimensions=d`:
+
+1. Normalize `x` to unit L2.
+2. Pad to `m = CodeDimensions` with zeros.
+3. Apply the deterministic signed permutation and normalized FWHT rotation named
+   in the config, using the `brq_1bit` seed.
+4. Store one bit per rotated component: `1` for `value >= 0`, `0` for
+   `value < 0`.
+5. Emit `code_count = popcount(packed_codes)`.
+6. Emit `quantized_dot_product_inv = 1 / sum(abs(rotated_data[i]))`.
+
+Zero vectors, non-finite values, dimension mismatches, invalid padding,
+`code_count` mismatches, and invalid side-array values fail closed in the oracle
+and in asset prepare/search validation.
+
+## Query encoding and score semantics
+
+A query uses the same unit-L2 normalization and rotation. Let:
+
+- `s_i = 1` when rotated query component `i` is non-negative, else `0`;
+- `a_i = abs(rotated_query[i])`;
+- `max_abs = max_i(a_i)`.
+
+`max_abs` must be finite and positive. Runtime query-weight quantization is:
+
+```text
+raw_i = a_i * 15 / max_abs
+w_i = clamp_uint4(floor(raw_i + 0.5))
+query_weight_scale = max_abs / 15
+query_weight_sum_int = sum_i w_i
+```
+
+Build eight runtime bit-plane masks over little-endian word views:
+
+- `pos_q1`, `pos_q2`, `pos_q4`, `pos_q8`: bit `i` set when `s_i == 1` and the
+  corresponding bit of `w_i` is set;
+- `neg_q1`, `neg_q2`, `neg_q4`, `neg_q8`: bit `i` set when `s_i == 0` and the
+  corresponding bit of `w_i` is set.
+
+For one candidate data-code word row, the oracle bit-product is:
+
+```text
+bitproduct(code, q1, q2, q4, q8) =
+    1*popcount(code & q1) + 2*popcount(code & q2) +
+    4*popcount(code & q4) + 8*popcount(code & q8)
+
+pos_set = bitproduct(code, pos_q1, pos_q2, pos_q4, pos_q8)
+neg_set = bitproduct(code, neg_q1, neg_q2, neg_q4, neg_q8)
+neg_weight_sum_int = sum_i (s_i == 0 ? w_i : 0)
+match_weight_int = pos_set + (neg_weight_sum_int - neg_set)
+signed_weight_int = 2*match_weight_int - query_weight_sum_int
+score = signed_weight_int * query_weight_scale /
+        (quantized_dot_product_inv * CodeDimensions)
+```
+
+`quantized_only` returns this approximate score and must label it
+`brq_1bit_estimated_cosine_q4` in docs, debug output, and benchmark rows. It is
+not exact cosine and is not the `rabitq_1bit` weighted sign-dot score.
+`quantized_rerank` uses `brq_1bit` only for traversal/candidate collection and
+returns exact cosine over the configured exact-rerank shortlist.
+
+A future optimized kernel may fuse the two bit-products or use XNOR-style masks,
+but oracle/golden tests must prove bit-for-bit agreement with the formula above
+before search can use it.
+
+## Fail-closed prepare/search validation plan
+
+Follow-on PRs must fail closed before any scorer-shaped loop when any of these
+checks fail:
+
+- selected declaration has codec/version other than `brq_1bit`/`1`;
+- metric is not cosine, dimensions are not positive, or `CodeDimensions` is not
+  `next_power_of_two(VectorDimensions)`;
+- codec canonical bytes or FNV-1a `ConfigHash` mismatch;
+- base graph identity, generation/checksum/schema hash, row count, or ordinal
+  order mismatch;
+- asset id, role, typed-column logical type, physical encoding, section length,
+  compression, direct-view certification, source schema hash, ref length, or
+  checksum mismatch;
+- packed-code padding is non-zero or `code_count` does not equal logical
+  popcount;
+- `quantized_dot_product_inv` is non-finite or outside the valid range;
+- query vectors are zero, non-finite, dimension-mismatched, or cannot build valid
+  query masks and `query_weight_scale`;
+- prepared handles are stale/closed, missing, unsupported, or not allocation-safe
+  for the selected hot path.
+
+Failures return `ErrVectorIndexSearchUnavailable` through the existing
+codec-generic quantized asset unavailable/invalid/stale/closed counters. There is
+no silent exact fallback. Exact/default mode continues to reject quantized-only
+fields.
+
+## Required oracle and golden tests before #2481 assets/search
+
+#2481 must land oracle/spec coverage before durable assets or production search:
+
+- canonical config bytes and `Config.Hash64` golden;
+- rotation metadata, code dimensions, row bytes, and seed golden;
+- encode golden for finite deterministic vectors, including LSB0 bytes,
+  `code_count`, and `quantized_dot_product_inv`;
+- query golden for sign bits, `uint4` weights, positive/negative q1/q2/q4/q8
+  planes, `query_weight_scale`, and score label;
+- score oracle golden comparing the slow formula to any bit-product or fused
+  implementation;
+- padding and word-order tests, including non-multiple-of-64 dimensions;
+- zero vector, non-finite, dimension mismatch, config mismatch, stale/corrupt
+  asset, missing side-array, bad code-count, invalid side-array, and closed-handle
+  fail-closed tests;
+- asset build/prepare/reopen tests and `quantized_only` exact-read-zero plus
+  `quantized_rerank` exact-read-bound guardrails;
+- zero steady-state allocation tests for warmed buffered rows.
+
+## Recall, storage, and performance gates
+
+`brq_1bit` is selected only as a prototype candidate. It may be closed
+no-promote if the gates below are not met.
+
+Required matrix versus exact FP32, `scalar_u8`, and `rabitq_1bit`:
+
+```sh
+GOMAXPROCS=8 GOWORK=off go test ./TreeDB/collections \
+  -run '^$' \
+  -bench '^(BenchmarkVectorIndexSearcherColumnGraphBRQQuantizedSearchWithBuffer2481|BenchmarkCollectionSearchVectorIndexWithBufferColumnGraphBRQQuantized2481|BenchmarkColumnGraphBRQQuantizedRebuildStorage2481|BenchmarkVectorIndexSearcherColumnGraphScalarU8QuantizedSearchWithBuffer2414|BenchmarkCollectionSearchVectorIndexWithBufferColumnGraphScalarU8Quantized2415|BenchmarkVectorIndexSearcherColumnGraphRabitQQuantizedSearchWithBuffer2451|BenchmarkCollectionSearchVectorIndexWithBufferColumnGraphRabitQQuantized2452|BenchmarkColumnGraphScalarU8QuantizedRebuildStorage1926|BenchmarkColumnGraphRabitQQuantizedRebuildStorage2450)$' \
+  -benchmem -benchtime=100000x -count=5
+```
+
+Rows must include lower-level and collection `quantized_only` plus
+`quantized_rerank/candidates=32` at c=1/c=8, with the same fixture and same-host
+baseline/candidate discipline used by the RaBitQ profile gate. Report `ns/op`,
+`ops/sec`, `B/op`, `allocs/op`, recall@K versus exact, exact vector/norm bytes,
+exact rerank calls, route/fallback/unavailable counters, `quantized_code_B/search`,
+logical code bytes/vector, actual asset bytes/vector, graph total storage, and
+CPU/alloc profiles for claimed c=1/c=8 wins.
+
+Promotion gates:
+
+- `quantized_only` must preserve `0 B/op`, `0 allocs/op`, zero exact vector/norm
+  reads, zero document fetches, and zero fallback/unavailable counters on healthy
+  prepared assets.
+- `quantized_rerank` exact reads must be bounded by the configured shortlist and
+  report exact cosine final scores.
+- Recall must be reported against exact on every row; public support is blocked
+  if recall is materially worse than same-fixture `scalar_u8` or `rabitq_1bit`
+  without an explicit no-promote/experimental decision.
+- Storage must remain in the one-bit class: logical code bytes/vector are
+  `ceil(CodeDimensions/8)`, no durable query arrays are written, and actual
+  asset bytes/vector should stay within the same order as `rabitq_1bit` unless a
+  measured trade-off is accepted.
+- A speedup claim requires same-host BRQ rows to beat optimized `rabitq_1bit` for
+  both c=1 and c=8 lower-level and collection `quantized_only` rows, with no
+  scalar_u8/exact guardrail regressions where shared code is touched.
+- Compactness-only or mixed/noisy/regressing evidence must be documented as
+  no-promote and must not be presented as acceleration.
+
+## Public counter and label requirements
+
+Future search stats/benchmarks must keep the existing generic quantized counters
+and add BRQ-specific visibility when this codec is selected:
+
+- `quantized_score_codec_brq_1bit/search=1`;
+- `brq_1bit_query_weight_bits/search=4`;
+- `brq_1bit_bitproduct_passes/search` for the logical bit-product passes used
+  per search;
+- `brq_1bit_query_weight_scale/search` or equivalent debug/stat field for the
+  query-local scale;
+- existing `quantized_score_calls/search`, `quantized_code_B/search`,
+  `quantized_asset_unavailable/search`, route counters, exact vector/norm bytes,
+  exact rerank calls, and document-fetch counters.
+
+Benchmark rows, issue comments, and docs must label `quantized_only` returned
+scores as `brq_1bit_estimated_cosine_q4`. `quantized_rerank` rows must state that
+final scores are exact cosine over the BRQ shortlist.
+
+## Migration and compatibility
+
+TreeDB is pre-alpha. `brq_1bit` introduces a new codec identity, config hash,
+asset id, and schema hash, so no migration from `rabitq_1bit` or `scalar_u8` is
+required. Old DB directories without matching assets should fail closed or be
+rebuilt for experiments. New binaries may reject stale/mismatched assets rather
+than attempting complex migration scaffolding.
+
+## #2481 dependency status
+
+A complete `brq_1bit` v1 contract unblocks #2481 only for a lower-level-first
+prototype after this spec is merged or explicitly accepted as the recorded #2480
+contract. #2481 must not implement production assets/search for any other codec
+name/version and must not change `rabitq_1bit` v1 semantics.

--- a/TreeDB/docs/spec/quantized-asset-schema.md
+++ b/TreeDB/docs/spec/quantized-asset-schema.md
@@ -27,7 +27,10 @@ The `rabitq_1bit` v1 contract in `rabitq-1bit-v1.md` chooses
 `RolePackedCodes` / `packed_bit_vector` for one-bit code rows, with
 `CodeDimensions=next_power_of_two(VectorDimensions)`, `CodeWidthBits=1`,
 TreeDB LSB-first bit order, and zero high-bit padding. Its required side arrays
-are `code_count` (`uint32`) and `quantized_dot_product_inv` (`float32`).
+are `code_count` (`uint32`) and `quantized_dot_product_inv` (`float32`). The
+future `brq_1bit` v1 contract in `brq-1bit-v1.md` deliberately uses a new codec
+identity and asset id while reusing the same one-bit data-code roles plus
+explicit runtime query `uint4` bit-product score semantics.
 
 ## Query-mode guardrail
 

--- a/TreeDB/docs/spec/quantized-vector-index.md
+++ b/TreeDB/docs/spec/quantized-vector-index.md
@@ -158,8 +158,12 @@ issue lands one with parity tests, same-fixture benchmarks, and profiles.
 
 Future quantization work should be separate from this scalar/RaBitQ closeout:
 
-- BRQ/PQ/OPQ/residual-PQ codecs and other packed popcount scorers need their own
-  codec specs, tests, recall sweeps, and benchmark gates.
+- [`brq-1bit-v1.md`](brq-1bit-v1.md) is the selected #2480 future-codec
+  contract for a bit-product `brq_1bit` v1 prototype. It uses a new codec
+  identity/version, explicit query `uint4` score label, validation plan, and
+  promotion gates; it is not current behavior until #2481 lands support.
+- PQ/OPQ/residual-PQ codecs and other packed popcount scorers still need their
+  own codec specs, tests, recall sweeps, and benchmark gates.
 - Batch scorer kernels, SIMD/popcount integration, graph control-flow changes,
   block-planner/windowing changes, and traversal scheduling changes are not part
   of #1926/#2454 acceptance. They must not be smuggled into quantized docs or

--- a/TreeDB/docs/spec/rabitq-1bit-v1.md
+++ b/TreeDB/docs/spec/rabitq-1bit-v1.md
@@ -206,7 +206,9 @@ recorded in
 - No changes to exact/default FP32 search or `scalar_u8` score-plane behavior.
 - No go-highway accelerated RaBitQ backend landed in this stack; #2453 is
   no-land/not-planned for the current weighted scorer and durable asset shape.
-- No multi-bit RaBitQ, PQ/OPQ, IVF, or graph topology changes.
+- No multi-bit RaBitQ, BRQ bit-product, PQ/OPQ, IVF, or graph topology changes;
+  the future `brq_1bit` v1 candidate is specified separately in
+  [`brq-1bit-v1.md`](brq-1bit-v1.md) under a new codec identity/version.
 - No dependency on CockroachDB, Antfly, AGPL, cgo, or production go-highway code.
 - No claim that RaBitQ universally replaces exact FP32 or scalar_u8.
 


### PR DESCRIPTION
## Objective

Specify the selected future TreeDB RaBitQ/BRQ-style codec contract for #2480: `brq_1bit` v1. This is a design/spec PR only and does not implement production assets, search, or benchmark rows.

Closes #2480; updates #2475 Sublane B status.

## Context

#2475 Sublane A is complete for `rabitq_1bit` v1. #2481 is blocked until #2480 records a complete future-codec contract or defer/no-go decision. The #2453 go-highway probe showed the fast bit-product shape needs a new codec identity instead of reinterpreting `rabitq_1bit` v1.

## Non-goals

- No runtime asset/search implementation.
- No changes to `rabitq_1bit` v1 storage, bit order, score formula, identity, or fail-closed behavior.
- No performance table/current-main benchmark snapshot; #2487 owns those numbers.
- No production acceleration claim.

## Design

- Adds `TreeDB/docs/spec/brq-1bit-v1.md` selecting `brq_1bit` version `1` as the #2480 future-codec contract.
- Defines codec identity/config bytes/hash, metric/scope, storage schema, LSB0 bit and little-endian word view, code width, side arrays, query `uint4` score semantics/label, oracle tests, fail-closed validation, recall/storage/perf gates, public counters, license boundary, and #2481 dependency status.
- Updates linked quantized/RaBitQ docs to keep the `rabitq_1bit` v1 boundary explicit.

## Scope

- Includes:
  - `TreeDB/docs/spec/brq-1bit-v1.md`
  - `TreeDB/docs/brq_1bit_spec_test.go`
  - spec index and quantized/RaBitQ boundary docs
- Excludes:
  - `TreeDB/internal/*` codec/runtime implementation
  - `TreeDB/collections/*` asset/search support
  - benchmark harness changes

## Correctness

- Tests run:
  - `git diff --check`
  - `GOWORK=off go test ./TreeDB/docs -count=1`
- Corruption/edge cases covered: documented for #2481 follow-on (config mismatch, padding, stale/corrupt assets, missing side arrays, invalid query/side values, closed handles).
- Concurrency/race coverage: not applicable; docs/spec only.

## Performance

- Benchmarks run: not applicable; docs/spec only.
- Results table: not included by design. #2487 owns current-main benchmark snapshot evidence.
- Regressions: none expected; no runtime code changed.

## Rollout / Toggle Plan

- Default setting: no runtime behavior changes.
- How to disable quickly: revert docs/spec commit; no user-facing feature is enabled.

## Follow-ups

- #2481 may start a lower-level-first prototype only after this spec is merged or explicitly accepted as the recorded #2480 contract.
- If #2481 evidence is compactness-only, noisy, regressing, or recall-poor, it should close no-promote rather than claim acceleration.

### AI Review Loop

- Codex latest-head review: requested after mature PR evidence; latest review found no major issues.
- Copilot latest-head review: requested after mature PR evidence; no visible completed Copilot review response as of final check.
- CodeRabbit latest-head review: reviewed; one markdown issue-reference/heading nit was fixed in `809ddb3c`, CodeRabbit status is passing. An earlier CodeRabbit request also reported repo usage/rate-limit text, so only the visible completed review is claimed.
- Review comments/threads resolved or explicitly dismissed: CodeRabbit thread resolved after fix; no unresolved review threads at final check.
- Re-requested after final meaningful push: Codex/Copilot were re-requested after `809ddb3c`; CodeRabbit completed automatically/passed after the fix.

### Latest-head CI

- Latest head: `809ddb3c66ab9802b0b510d90452f81f80b2a3f9`.
- `gh pr checks 2488 --repo snissn/gomap`: all checks passing, including gofmt, docs/suites/bench/profiles/perf smoke, append-only snapshot guardrail, Linux/macOS/Windows shards, and race checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added complete BRQ 1-bit v1 codec specification detailing durable asset schemas, encoding procedures, validation rules, and query semantics.
  * Updated related codec specifications to reference the new BRQ 1-bit v1 contract and clarify terminology ownership.

* **Tests**
  * Added validation tests for BRQ 1-bit v1 specification documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
