### PR TITLE
Add brq_1bit oracle goldens

### DIFF
--- a/TreeDB/internal/brq/brq.go
+++ b/TreeDB/internal/brq/brq.go
@@ -1,0 +1,699 @@
+package brq
+
+import (
+	"errors"
+	"fmt"
+	"hash/fnv"
+	"math"
+	"math/bits"
+)
+
+const (
+	// CodecName is the durable quantized codec name for TreeDB BRQ v1.
+	CodecName = "brq_1bit"
+	// CodecVersion is the first TreeDB BRQ codec contract version.
+	CodecVersion uint32 = 1
+	// CodeWidthBits is the number of stored bits per code dimension.
+	CodeWidthBits = 1
+	// QueryWeightBits is the runtime query-weight bit width.
+	QueryWeightBits = 4
+
+	// StorageRole is the quantizedasset role selected by the v1 contract.
+	StorageRole = "packed_codes"
+	// StorageLogicalType is the typed-column logical/physical code shape.
+	StorageLogicalType = "packed_bit_vector"
+	// StorageEncoding is the raw typed-column encoding for StorageLogicalType.
+	StorageEncoding = "raw_packed_bit_vector"
+	// BitOrder documents the TreeDB packed-code bit order used on disk.
+	BitOrder = "lsb0"
+	// WordOrder documents little-endian uint64 scratch views for scorer kernels.
+	WordOrder = "little_endian_uint64"
+	// Padding is the only valid padding policy for partial final bytes.
+	Padding = "zero"
+	// QueryWeightQuantizer is the runtime query-weight quantizer identity.
+	QueryWeightQuantizer = "max_abs_uint4_round_half_up"
+	// ScoreLabel is the public label for quantized-only approximate scores.
+	ScoreLabel = "brq_1bit_estimated_cosine_q4"
+	// DataScaleSideArray is the required data side-array name.
+	DataScaleSideArray = "quantized_dot_product_inv"
+
+	// RotationName is part of the canonical codec config identity.
+	RotationName = "signed_permutation_fwht_padded_v1"
+	// DefaultSeed is the deterministic v1 seed used when callers do not supply a
+	// workload-specific seed. It intentionally differs from rabitq_1bit.
+	DefaultSeed uint64 = 0x6272713162697401
+)
+
+var (
+	// ErrInvalidConfig reports an impossible or unsupported codec shape.
+	ErrInvalidConfig = errors.New("brq: invalid config")
+	// ErrDimensionMismatch reports vector/query/code shape mismatch.
+	ErrDimensionMismatch = errors.New("brq: dimension mismatch")
+	// ErrDegenerateVector reports zero, non-finite, or otherwise unencodable input.
+	ErrDegenerateVector = errors.New("brq: degenerate vector")
+)
+
+// Config is the v1 codec configuration identity. Vector dimensions are schema
+// shape rather than serialized config; NewPlan binds Config to dimensions.
+type Config struct {
+	Seed uint64
+}
+
+// DefaultConfig returns the stable TreeDB brq_1bit v1 config.
+func DefaultConfig() Config { return Config{Seed: DefaultSeed} }
+
+// CanonicalBytes returns the stable byte identity used for manifest config
+// comparison and hashing. The format is line-oriented ASCII by design so docs,
+// tests, and future non-Go implementations can reproduce it exactly.
+func (c Config) CanonicalBytes() []byte {
+	return []byte(fmt.Sprintf("codec=%s\nversion=%d\nmetric=cosine\nnormalization=unit_l2\nrotation=%s\nseed=0x%016x\nstorage_role=%s\nstorage_logical_type=%s\nstorage_encoding=%s\nbit_order=%s\nword_order=%s\npadding=%s\ncode_width_bits=%d\nquery_weight_bits=%d\nquery_weight_quantizer=%s\nscore=%s\ndata_scale_side_array=%s\n", CodecName, CodecVersion, RotationName, c.Seed, StorageRole, StorageLogicalType, StorageEncoding, BitOrder, WordOrder, Padding, CodeWidthBits, QueryWeightBits, QueryWeightQuantizer, ScoreLabel, DataScaleSideArray))
+}
+
+// Hash64 returns the FNV-1a hash of CanonicalBytes. Quantized manifests may use
+// this as CodecDescriptor.ConfigHash while storing CanonicalBytes as Config.
+func (c Config) Hash64() uint64 {
+	h := fnv.New64a()
+	_, _ = h.Write(c.CanonicalBytes())
+	return h.Sum64()
+}
+
+// Plan binds a Config to a vector dimension and owns deterministic rotation
+// metadata. Plan is immutable and safe for concurrent use; caller-provided
+// Workspace values are not safe for concurrent sharing.
+type Plan struct {
+	cfg              Config
+	vectorDimensions int
+	codeDimensions   int
+	bytesPerCode     int
+	invSqrtCodeDims  float64
+	perm             []int
+	signs            []float64
+}
+
+// Workspace holds reusable scratch for Encode and EncodeQuery. Query values
+// returned by EncodeQuery alias query-specific workspace buffers and remain
+// valid until the next EncodeQuery call using the same Workspace.
+type Workspace struct {
+	work         []float64
+	queryBits    []byte
+	queryWeights []uint8
+	posQ1        []byte
+	posQ2        []byte
+	posQ4        []byte
+	posQ8        []byte
+	negQ1        []byte
+	negQ2        []byte
+	negQ4        []byte
+	negQ8        []byte
+}
+
+// EncodedVector contains the data-code row and side-array values produced by
+// Encode. Code is a packed_bit_vector row using TreeDB LSB-first layout.
+type EncodedVector struct {
+	Code                   []byte
+	CodeCount              uint32
+	QuantizedDotProductInv float32
+}
+
+// Query contains the runtime brq_1bit query representation. SignBits and all
+// q-planes use TreeDB LSB0 packed rows. Weights stores one uint4 value per
+// logical code dimension for validation and slow oracle scoring.
+type Query struct {
+	SignBits             []byte
+	Weights              []uint8
+	PosQ1                []byte
+	PosQ2                []byte
+	PosQ4                []byte
+	PosQ8                []byte
+	NegQ1                []byte
+	NegQ2                []byte
+	NegQ4                []byte
+	NegQ8                []byte
+	QueryWeightScale     float32
+	QueryWeightSumInt    uint32
+	NegativeWeightSumInt uint32
+	CodeDimensions       int
+}
+
+// NewPlan validates dimensions, derives code shape, and precomputes the v1
+// deterministic signed permutation. CodeDimensions is next_power_of_two(dims),
+// matching the padded Walsh-Hadamard rotation length.
+func NewPlan(vectorDimensions int, cfg Config) (*Plan, error) {
+	if vectorDimensions <= 0 {
+		return nil, fmt.Errorf("%w: vector_dimensions=%d must be positive", ErrInvalidConfig, vectorDimensions)
+	}
+	codeDimensions, err := nextPowerOfTwoInt(vectorDimensions)
+	if err != nil {
+		return nil, err
+	}
+	bytesPerCode := (codeDimensions + 7) / 8
+	perm := make([]int, codeDimensions)
+	for i := range perm {
+		perm[i] = i
+	}
+	rng := splitmix64{state: rotationSeed(cfg.Seed, vectorDimensions, codeDimensions)}
+	for i := codeDimensions - 1; i > 0; i-- {
+		j := int(rng.next() % uint64(i+1))
+		perm[i], perm[j] = perm[j], perm[i]
+	}
+	signs := make([]float64, codeDimensions)
+	for i := range signs {
+		if rng.next()&1 == 0 {
+			signs[i] = 1
+		} else {
+			signs[i] = -1
+		}
+	}
+	return &Plan{cfg: cfg, vectorDimensions: vectorDimensions, codeDimensions: codeDimensions, bytesPerCode: bytesPerCode, invSqrtCodeDims: 1 / math.Sqrt(float64(codeDimensions)), perm: perm, signs: signs}, nil
+}
+
+// Config returns the plan's codec config.
+func (p *Plan) Config() Config {
+	if p == nil {
+		return Config{}
+	}
+	return p.cfg
+}
+
+// VectorDimensions returns the source float32 vector dimensions.
+func (p *Plan) VectorDimensions() int {
+	if p == nil {
+		return 0
+	}
+	return p.vectorDimensions
+}
+
+// CodeDimensions returns the number of one-bit dimensions stored per row.
+func (p *Plan) CodeDimensions() int {
+	if p == nil {
+		return 0
+	}
+	return p.codeDimensions
+}
+
+// BytesPerCode returns ceil(CodeDimensions/8), the packed row width.
+func (p *Plan) BytesPerCode() int {
+	if p == nil {
+		return 0
+	}
+	return p.bytesPerCode
+}
+
+// Encode normalizes vector, rotates it, packs sign bits into dst, and returns
+// code_count plus quantized_dot_product_inv side-array values. It allocates only
+// when dst or workspace scratch lacks capacity.
+func (p *Plan) Encode(dst []byte, vector []float32, ws *Workspace) (EncodedVector, error) {
+	if p == nil || p.vectorDimensions <= 0 || p.codeDimensions <= 0 {
+		return EncodedVector{}, fmt.Errorf("%w: nil or invalid plan", ErrInvalidConfig)
+	}
+	rotated, err := p.rotateUnit(vector, ws)
+	if err != nil {
+		return EncodedVector{}, err
+	}
+	code := ensureByteLen(dst, p.bytesPerCode)
+	clear(code)
+	var count uint32
+	var l1 float64
+	for i, value := range rotated[:p.codeDimensions] {
+		if value >= 0 {
+			code[i>>3] |= byte(1 << uint(i&7))
+			count++
+		}
+		l1 += math.Abs(value)
+	}
+	if l1 <= 0 || math.IsNaN(l1) || math.IsInf(l1, 0) {
+		return EncodedVector{}, fmt.Errorf("%w: rotated L1 norm is not positive", ErrDegenerateVector)
+	}
+	return EncodedVector{Code: code, CodeCount: count, QuantizedDotProductInv: float32(1 / l1)}, nil
+}
+
+// EncodeQuery normalizes and rotates query, quantizes absolute rotated values to
+// uint4 weights, then prepares sign bits and positive/negative q1/q2/q4/q8
+// bit-planes consumed by ScoreCosine. Returned slices alias ws.
+func (p *Plan) EncodeQuery(query []float32, ws *Workspace) (Query, error) {
+	if p == nil || p.vectorDimensions <= 0 || p.codeDimensions <= 0 {
+		return Query{}, fmt.Errorf("%w: nil or invalid plan", ErrInvalidConfig)
+	}
+	rotated, err := p.rotateUnit(query, ws)
+	if err != nil {
+		return Query{}, err
+	}
+	if ws == nil {
+		ws = &Workspace{}
+	}
+	ws.queryBits = ensureByteLen(ws.queryBits, p.bytesPerCode)
+	ws.queryWeights = ensureUint8Len(ws.queryWeights, p.codeDimensions)
+	ws.posQ1 = ensureByteLen(ws.posQ1, p.bytesPerCode)
+	ws.posQ2 = ensureByteLen(ws.posQ2, p.bytesPerCode)
+	ws.posQ4 = ensureByteLen(ws.posQ4, p.bytesPerCode)
+	ws.posQ8 = ensureByteLen(ws.posQ8, p.bytesPerCode)
+	ws.negQ1 = ensureByteLen(ws.negQ1, p.bytesPerCode)
+	ws.negQ2 = ensureByteLen(ws.negQ2, p.bytesPerCode)
+	ws.negQ4 = ensureByteLen(ws.negQ4, p.bytesPerCode)
+	ws.negQ8 = ensureByteLen(ws.negQ8, p.bytesPerCode)
+	clear(ws.queryBits)
+	clear(ws.queryWeights)
+	clear(ws.posQ1)
+	clear(ws.posQ2)
+	clear(ws.posQ4)
+	clear(ws.posQ8)
+	clear(ws.negQ1)
+	clear(ws.negQ2)
+	clear(ws.negQ4)
+	clear(ws.negQ8)
+
+	var maxAbs float64
+	for _, value := range rotated[:p.codeDimensions] {
+		abs := math.Abs(value)
+		if abs > maxAbs {
+			maxAbs = abs
+		}
+	}
+	if maxAbs <= 0 || math.IsNaN(maxAbs) || math.IsInf(maxAbs, 0) {
+		return Query{}, fmt.Errorf("%w: query max_abs is not positive", ErrDegenerateVector)
+	}
+
+	var weightSum uint32
+	var negativeWeightSum uint32
+	for i, value := range rotated[:p.codeDimensions] {
+		positive := value >= 0
+		if positive {
+			ws.queryBits[i>>3] |= byte(1 << uint(i&7))
+		}
+		weight := quantizeUint4(math.Abs(value), maxAbs)
+		ws.queryWeights[i] = weight
+		weightSum += uint32(weight)
+		if !positive {
+			negativeWeightSum += uint32(weight)
+		}
+		setQueryPlaneBit(i, positive, weight, ws)
+	}
+	if weightSum == 0 {
+		return Query{}, fmt.Errorf("%w: query uint4 weights are not positive", ErrDegenerateVector)
+	}
+	return Query{
+		SignBits:             ws.queryBits,
+		Weights:              ws.queryWeights,
+		PosQ1:                ws.posQ1,
+		PosQ2:                ws.posQ2,
+		PosQ4:                ws.posQ4,
+		PosQ8:                ws.posQ8,
+		NegQ1:                ws.negQ1,
+		NegQ2:                ws.negQ2,
+		NegQ4:                ws.negQ4,
+		NegQ8:                ws.negQ8,
+		QueryWeightScale:     float32(maxAbs / 15),
+		QueryWeightSumInt:    weightSum,
+		NegativeWeightSumInt: negativeWeightSum,
+		CodeDimensions:       p.codeDimensions,
+	}, nil
+}
+
+// ScoreCosine validates side-array inputs and returns the v1 estimated cosine
+// score for one encoded data vector. This is the reference bit-product oracle;
+// accelerated implementations may skip repeated validation only after matching
+// this result bit-for-bit under golden tests.
+func (p *Plan) ScoreCosine(query Query, code []byte, codeCount uint32, quantizedDotProductInv float32) (float64, error) {
+	if err := p.ValidateCode(code, codeCount); err != nil {
+		return 0, err
+	}
+	if err := p.ValidateQuery(query); err != nil {
+		return 0, err
+	}
+	if err := p.ValidateQuantizedDotProductInv(quantizedDotProductInv); err != nil {
+		return 0, err
+	}
+	return p.scoreCosineValidated(query, code, quantizedDotProductInv), nil
+}
+
+// ScoreEncoded is a convenience wrapper around ScoreCosine.
+func (p *Plan) ScoreEncoded(query Query, encoded EncodedVector) (float64, error) {
+	return p.ScoreCosine(query, encoded.Code, encoded.CodeCount, encoded.QuantizedDotProductInv)
+}
+
+// ScoreCosineSlow validates inputs and evaluates the same score by walking one
+// logical dimension at a time. It is useful for parity tests of fused kernels.
+func (p *Plan) ScoreCosineSlow(query Query, code []byte, codeCount uint32, quantizedDotProductInv float32) (float64, error) {
+	if err := p.ValidateCode(code, codeCount); err != nil {
+		return 0, err
+	}
+	if err := p.ValidateQuery(query); err != nil {
+		return 0, err
+	}
+	if err := p.ValidateQuantizedDotProductInv(quantizedDotProductInv); err != nil {
+		return 0, err
+	}
+	var matchWeight uint32
+	for i, weight8 := range query.Weights[:p.codeDimensions] {
+		weight := uint32(weight8)
+		if bitAt(query.SignBits, i) == bitAt(code, i) {
+			matchWeight += weight
+		}
+	}
+	signedWeight := int64(2*matchWeight) - int64(query.QueryWeightSumInt)
+	return float64(signedWeight) * float64(query.QueryWeightScale) / (float64(quantizedDotProductInv) * float64(p.codeDimensions)), nil
+}
+
+// BitProduct evaluates the weighted bit-product formula over q1/q2/q4/q8 masks.
+func (p *Plan) BitProduct(code, q1, q2, q4, q8 []byte) (uint32, error) {
+	if p == nil || p.codeDimensions <= 0 || p.bytesPerCode <= 0 {
+		return 0, fmt.Errorf("%w: nil or invalid plan", ErrInvalidConfig)
+	}
+	for name, row := range map[string][]byte{"code": code, "q1": q1, "q2": q2, "q4": q4, "q8": q8} {
+		if len(row) != p.bytesPerCode {
+			return 0, fmt.Errorf("%w: %s bytes=%d want %d", ErrDimensionMismatch, name, len(row), p.bytesPerCode)
+		}
+		if err := validatePadding(row, p.codeDimensions); err != nil {
+			return 0, fmt.Errorf("%w: %s padding: %v", ErrDimensionMismatch, name, err)
+		}
+	}
+	return bitProductNoValidate(code, q1, q2, q4, q8), nil
+}
+
+// ValidateCode verifies row width, zero high padding bits, and code_count.
+func (p *Plan) ValidateCode(code []byte, codeCount uint32) error {
+	if p == nil || p.codeDimensions <= 0 || p.bytesPerCode <= 0 {
+		return fmt.Errorf("%w: nil or invalid plan", ErrInvalidConfig)
+	}
+	if len(code) != p.bytesPerCode {
+		return fmt.Errorf("%w: code bytes=%d want %d", ErrDimensionMismatch, len(code), p.bytesPerCode)
+	}
+	if err := validatePadding(code, p.codeDimensions); err != nil {
+		return err
+	}
+	got := p.CountCodeBits(code)
+	if got != codeCount {
+		return fmt.Errorf("%w: code_count=%d want %d", ErrDimensionMismatch, codeCount, got)
+	}
+	return nil
+}
+
+// CountCodeBits returns the popcount over logical code dimensions, excluding
+// any zero padding bits in the final byte.
+func (p *Plan) CountCodeBits(code []byte) uint32 {
+	if p == nil || len(code) != p.bytesPerCode || p.codeDimensions <= 0 {
+		return 0
+	}
+	full := p.codeDimensions / 8
+	var count int
+	for i := 0; i < full; i++ {
+		count += bits.OnesCount8(code[i])
+	}
+	if rem := p.codeDimensions & 7; rem != 0 {
+		mask := byte((1 << uint(rem)) - 1)
+		count += bits.OnesCount8(code[full] & mask)
+	}
+	return uint32(count)
+}
+
+// ValidateQuantizedDotProductInv verifies the finite side-array range implied by
+// unit-L2 vectors and an orthonormal rotation: L1(rotated) is in
+// [1, sqrt(CodeDimensions)], so its inverse is in [1/sqrt(CodeDimensions), 1]
+// modulo float32 rounding tolerance.
+func (p *Plan) ValidateQuantizedDotProductInv(value float32) error {
+	if p == nil || p.codeDimensions <= 0 {
+		return fmt.Errorf("%w: nil or invalid plan", ErrInvalidConfig)
+	}
+	fv := float64(value)
+	if value <= 0 || math.IsNaN(fv) || math.IsInf(fv, 0) {
+		return fmt.Errorf("%w: invalid quantized_dot_product_inv=%v", ErrDegenerateVector, value)
+	}
+	minValue := p.invSqrtCodeDims
+	const tolerance = 1e-5
+	if fv < minValue-tolerance || fv > 1+tolerance {
+		return fmt.Errorf("%w: quantized_dot_product_inv=%v outside valid range [%v,%v]", ErrDegenerateVector, value, minValue, 1.0)
+	}
+	return nil
+}
+
+// ValidateQuery verifies query shape, sign-bit padding, uint4 weights, finite
+// positive scale, integer sums, and exact q1/q2/q4/q8 plane consistency.
+func (p *Plan) ValidateQuery(q Query) error {
+	if p == nil || p.codeDimensions <= 0 || p.bytesPerCode <= 0 {
+		return fmt.Errorf("%w: nil or invalid plan", ErrInvalidConfig)
+	}
+	if q.CodeDimensions != p.codeDimensions {
+		return fmt.Errorf("%w: query code_dimensions=%d want %d", ErrDimensionMismatch, q.CodeDimensions, p.codeDimensions)
+	}
+	if err := p.validatePlane("sign_bits", q.SignBits); err != nil {
+		return err
+	}
+	planes := []struct {
+		name string
+		row  []byte
+	}{
+		{"pos_q1", q.PosQ1}, {"pos_q2", q.PosQ2}, {"pos_q4", q.PosQ4}, {"pos_q8", q.PosQ8},
+		{"neg_q1", q.NegQ1}, {"neg_q2", q.NegQ2}, {"neg_q4", q.NegQ4}, {"neg_q8", q.NegQ8},
+	}
+	for _, plane := range planes {
+		if err := p.validatePlane(plane.name, plane.row); err != nil {
+			return err
+		}
+	}
+	if len(q.Weights) != p.codeDimensions {
+		return fmt.Errorf("%w: query weights=%d want %d", ErrDimensionMismatch, len(q.Weights), p.codeDimensions)
+	}
+	if q.QueryWeightScale <= 0 || math.IsNaN(float64(q.QueryWeightScale)) || math.IsInf(float64(q.QueryWeightScale), 0) {
+		return fmt.Errorf("%w: invalid query_weight_scale=%v", ErrDegenerateVector, q.QueryWeightScale)
+	}
+	var sum uint32
+	var negSum uint32
+	for i, weight := range q.Weights {
+		if weight > 15 {
+			return fmt.Errorf("%w: query weight[%d]=%d exceeds uint4", ErrDimensionMismatch, i, weight)
+		}
+		sum += uint32(weight)
+		positive := bitAt(q.SignBits, i)
+		if !positive {
+			negSum += uint32(weight)
+		}
+		if err := validateQueryPlaneBitsAt(q, i, positive, weight); err != nil {
+			return err
+		}
+	}
+	if sum == 0 {
+		return fmt.Errorf("%w: query weights are not positive", ErrDegenerateVector)
+	}
+	if q.QueryWeightSumInt != sum {
+		return fmt.Errorf("%w: query_weight_sum_int=%d want %d", ErrDimensionMismatch, q.QueryWeightSumInt, sum)
+	}
+	if q.NegativeWeightSumInt != negSum {
+		return fmt.Errorf("%w: negative_weight_sum_int=%d want %d", ErrDimensionMismatch, q.NegativeWeightSumInt, negSum)
+	}
+	return nil
+}
+
+// ValidFor reports whether q can be used with p without allocation or shape
+// adaptation.
+func (q Query) ValidFor(p *Plan) bool {
+	return p != nil && p.ValidateQuery(q) == nil
+}
+
+func (p *Plan) scoreCosineValidated(query Query, code []byte, quantizedDotProductInv float32) float64 {
+	posSet := bitProductNoValidate(code, query.PosQ1, query.PosQ2, query.PosQ4, query.PosQ8)
+	negSet := bitProductNoValidate(code, query.NegQ1, query.NegQ2, query.NegQ4, query.NegQ8)
+	matchWeight := posSet + (query.NegativeWeightSumInt - negSet)
+	signedWeight := int64(2*matchWeight) - int64(query.QueryWeightSumInt)
+	return float64(signedWeight) * float64(query.QueryWeightScale) / (float64(quantizedDotProductInv) * float64(p.codeDimensions))
+}
+
+func (p *Plan) rotateUnit(vector []float32, ws *Workspace) ([]float64, error) {
+	if len(vector) != p.vectorDimensions {
+		return nil, fmt.Errorf("%w: vector dimensions=%d want %d", ErrDimensionMismatch, len(vector), p.vectorDimensions)
+	}
+	var norm2 float64
+	for i, v := range vector {
+		fv := float64(v)
+		if math.IsNaN(fv) || math.IsInf(fv, 0) {
+			return nil, fmt.Errorf("%w: vector[%d]=%v is not finite", ErrDegenerateVector, i, v)
+		}
+		norm2 += fv * fv
+	}
+	if norm2 <= 0 || math.IsNaN(norm2) || math.IsInf(norm2, 0) {
+		return nil, fmt.Errorf("%w: vector norm is not positive", ErrDegenerateVector)
+	}
+	if ws == nil {
+		ws = &Workspace{}
+	}
+	need := p.codeDimensions * 2
+	if cap(ws.work) < need {
+		ws.work = make([]float64, need)
+	} else {
+		ws.work = ws.work[:need]
+		clear(ws.work)
+	}
+	src := ws.work[:p.codeDimensions]
+	permuted := ws.work[p.codeDimensions:need]
+	invNorm := 1 / math.Sqrt(norm2)
+	for i := 0; i < p.vectorDimensions; i++ {
+		src[i] = float64(vector[i]) * invNorm
+	}
+	for i := p.vectorDimensions; i < p.codeDimensions; i++ {
+		src[i] = 0
+	}
+	for i, source := range p.perm {
+		permuted[i] = src[source] * p.signs[i]
+	}
+	fwhtInPlace(permuted)
+	for i := range permuted {
+		permuted[i] *= p.invSqrtCodeDims
+	}
+	return permuted, nil
+}
+
+func fwhtInPlace(values []float64) {
+	for width := 1; width < len(values); width <<= 1 {
+		for start := 0; start < len(values); start += width << 1 {
+			for i := 0; i < width; i++ {
+				a := values[start+i]
+				b := values[start+i+width]
+				values[start+i] = a + b
+				values[start+i+width] = a - b
+			}
+		}
+	}
+}
+
+func quantizeUint4(abs, maxAbs float64) uint8 {
+	raw := abs * 15 / maxAbs
+	w := math.Floor(raw + 0.5)
+	if w < 0 {
+		return 0
+	}
+	if w > 15 {
+		return 15
+	}
+	return uint8(w)
+}
+
+func setQueryPlaneBit(i int, positive bool, weight uint8, ws *Workspace) {
+	bit := byte(1 << uint(i&7))
+	idx := i >> 3
+	if positive {
+		if weight&1 != 0 {
+			ws.posQ1[idx] |= bit
+		}
+		if weight&2 != 0 {
+			ws.posQ2[idx] |= bit
+		}
+		if weight&4 != 0 {
+			ws.posQ4[idx] |= bit
+		}
+		if weight&8 != 0 {
+			ws.posQ8[idx] |= bit
+		}
+		return
+	}
+	if weight&1 != 0 {
+		ws.negQ1[idx] |= bit
+	}
+	if weight&2 != 0 {
+		ws.negQ2[idx] |= bit
+	}
+	if weight&4 != 0 {
+		ws.negQ4[idx] |= bit
+	}
+	if weight&8 != 0 {
+		ws.negQ8[idx] |= bit
+	}
+}
+
+func validateQueryPlaneBitsAt(q Query, i int, positive bool, weight uint8) error {
+	planes := []struct {
+		name string
+		row  []byte
+		mask uint8
+		pos  bool
+	}{
+		{"pos_q1", q.PosQ1, 1, true}, {"pos_q2", q.PosQ2, 2, true}, {"pos_q4", q.PosQ4, 4, true}, {"pos_q8", q.PosQ8, 8, true},
+		{"neg_q1", q.NegQ1, 1, false}, {"neg_q2", q.NegQ2, 2, false}, {"neg_q4", q.NegQ4, 4, false}, {"neg_q8", q.NegQ8, 8, false},
+	}
+	for _, plane := range planes {
+		want := positive == plane.pos && weight&plane.mask != 0
+		if got := bitAt(plane.row, i); got != want {
+			return fmt.Errorf("%w: %s bit[%d]=%t want %t", ErrDimensionMismatch, plane.name, i, got, want)
+		}
+	}
+	return nil
+}
+
+func bitProductNoValidate(code, q1, q2, q4, q8 []byte) uint32 {
+	var total uint32
+	for i, b := range code {
+		total += uint32(bits.OnesCount8(b & q1[i]))
+		total += 2 * uint32(bits.OnesCount8(b&q2[i]))
+		total += 4 * uint32(bits.OnesCount8(b&q4[i]))
+		total += 8 * uint32(bits.OnesCount8(b&q8[i]))
+	}
+	return total
+}
+
+func (p *Plan) validatePlane(name string, row []byte) error {
+	if len(row) != p.bytesPerCode {
+		return fmt.Errorf("%w: %s bytes=%d want %d", ErrDimensionMismatch, name, len(row), p.bytesPerCode)
+	}
+	if err := validatePadding(row, p.codeDimensions); err != nil {
+		return fmt.Errorf("%w: %s: %v", ErrDimensionMismatch, name, err)
+	}
+	return nil
+}
+
+func validatePadding(code []byte, codeDimensions int) error {
+	rem := codeDimensions & 7
+	if rem == 0 {
+		return nil
+	}
+	mask := byte((1 << uint(rem)) - 1)
+	if code[len(code)-1]&^mask != 0 {
+		return fmt.Errorf("%w: non-zero padding bits final_byte=0x%02x valid_mask=0x%02x", ErrDimensionMismatch, code[len(code)-1], mask)
+	}
+	return nil
+}
+
+func bitAt(row []byte, i int) bool {
+	return row[i>>3]&(1<<uint(i&7)) != 0
+}
+
+func ensureByteLen(dst []byte, n int) []byte {
+	if cap(dst) < n {
+		return make([]byte, n)
+	}
+	return dst[:n]
+}
+
+func ensureUint8Len(dst []uint8, n int) []uint8 {
+	if cap(dst) < n {
+		return make([]uint8, n)
+	}
+	return dst[:n]
+}
+
+func nextPowerOfTwoInt(n int) (int, error) {
+	if n <= 0 {
+		return 0, fmt.Errorf("%w: dimensions=%d must be positive", ErrInvalidConfig, n)
+	}
+	if n > (math.MaxInt>>1)+1 {
+		return 0, fmt.Errorf("%w: dimensions=%d overflow", ErrInvalidConfig, n)
+	}
+	if n&(n-1) == 0 {
+		return n, nil
+	}
+	return 1 << bits.Len(uint(n)), nil
+}
+
+type splitmix64 struct{ state uint64 }
+
+func (s *splitmix64) next() uint64 {
+	s.state += 0x9e3779b97f4a7c15
+	z := s.state
+	z = (z ^ (z >> 30)) * 0xbf58476d1ce4e5b9
+	z = (z ^ (z >> 27)) * 0x94d049bb133111eb
+	return z ^ (z >> 31)
+}
+
+func rotationSeed(seed uint64, vectorDimensions, codeDimensions int) uint64 {
+	z := seed ^ 0x8f3f73b5d8f24429
+	z ^= uint64(vectorDimensions) * 0x9e3779b97f4a7c15
+	z ^= bits.RotateLeft64(uint64(codeDimensions)*0xbf58476d1ce4e5b9, 17)
+	return z
+}

--- a/TreeDB/internal/brq/brq.go
+++ b/TreeDB/internal/brq/brq.go
@@ -461,6 +461,12 @@ func (p *Plan) ValidateQuery(q Query) error {
 	if q.QueryWeightScale <= 0 || math.IsNaN(q.QueryWeightScale) || math.IsInf(q.QueryWeightScale, 0) {
 		return fmt.Errorf("%w: invalid query_weight_scale=%v", ErrDegenerateVector, q.QueryWeightScale)
 	}
+	minScale := p.invSqrtCodeDims / 15
+	maxScale := 1.0 / 15.0
+	const scaleTolerance = 1e-12
+	if q.QueryWeightScale < minScale-scaleTolerance || q.QueryWeightScale > maxScale+scaleTolerance {
+		return fmt.Errorf("%w: query_weight_scale=%v outside valid range [%v,%v]", ErrDegenerateVector, q.QueryWeightScale, minScale, maxScale)
+	}
 	var sum uint32
 	var negSum uint32
 	for i, weight := range q.Weights {

--- a/TreeDB/internal/brq/brq.go
+++ b/TreeDB/internal/brq/brq.go
@@ -129,7 +129,7 @@ type Query struct {
 	NegQ2                []byte
 	NegQ4                []byte
 	NegQ8                []byte
-	QueryWeightScale     float32
+	QueryWeightScale     float64
 	QueryWeightSumInt    uint32
 	NegativeWeightSumInt uint32
 	CodeDimensions       int
@@ -302,7 +302,7 @@ func (p *Plan) EncodeQuery(query []float32, ws *Workspace) (Query, error) {
 		NegQ2:                ws.negQ2,
 		NegQ4:                ws.negQ4,
 		NegQ8:                ws.negQ8,
-		QueryWeightScale:     float32(maxAbs / 15),
+		QueryWeightScale:     maxAbs / 15,
 		QueryWeightSumInt:    weightSum,
 		NegativeWeightSumInt: negativeWeightSum,
 		CodeDimensions:       p.codeDimensions,
@@ -359,12 +359,17 @@ func (p *Plan) BitProduct(code, q1, q2, q4, q8 []byte) (uint32, error) {
 	if p == nil || p.codeDimensions <= 0 || p.bytesPerCode <= 0 {
 		return 0, fmt.Errorf("%w: nil or invalid plan", ErrInvalidConfig)
 	}
-	for name, row := range map[string][]byte{"code": code, "q1": q1, "q2": q2, "q4": q4, "q8": q8} {
-		if len(row) != p.bytesPerCode {
-			return 0, fmt.Errorf("%w: %s bytes=%d want %d", ErrDimensionMismatch, name, len(row), p.bytesPerCode)
+	for _, input := range []struct {
+		name string
+		row  []byte
+	}{
+		{"code", code}, {"q1", q1}, {"q2", q2}, {"q4", q4}, {"q8", q8},
+	} {
+		if len(input.row) != p.bytesPerCode {
+			return 0, fmt.Errorf("%w: %s bytes=%d want %d", ErrDimensionMismatch, input.name, len(input.row), p.bytesPerCode)
 		}
-		if err := validatePadding(row, p.codeDimensions); err != nil {
-			return 0, fmt.Errorf("%w: %s padding: %v", ErrDimensionMismatch, name, err)
+		if err := validatePadding(input.row, p.codeDimensions); err != nil {
+			return 0, fmt.Errorf("%w: %s padding: %v", ErrDimensionMismatch, input.name, err)
 		}
 	}
 	return bitProductNoValidate(code, q1, q2, q4, q8), nil
@@ -453,7 +458,7 @@ func (p *Plan) ValidateQuery(q Query) error {
 	if len(q.Weights) != p.codeDimensions {
 		return fmt.Errorf("%w: query weights=%d want %d", ErrDimensionMismatch, len(q.Weights), p.codeDimensions)
 	}
-	if q.QueryWeightScale <= 0 || math.IsNaN(float64(q.QueryWeightScale)) || math.IsInf(float64(q.QueryWeightScale), 0) {
+	if q.QueryWeightScale <= 0 || math.IsNaN(q.QueryWeightScale) || math.IsInf(q.QueryWeightScale, 0) {
 		return fmt.Errorf("%w: invalid query_weight_scale=%v", ErrDegenerateVector, q.QueryWeightScale)
 	}
 	var sum uint32

--- a/TreeDB/internal/brq/brq_test.go
+++ b/TreeDB/internal/brq/brq_test.go
@@ -1,0 +1,458 @@
+package brq
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/internal/quantizedasset"
+	"github.com/snissn/gomap/TreeDB/internal/typedcolumn"
+)
+
+var (
+	brqEncodedSink EncodedVector
+	brqQuerySink   Query
+	brqScoreSink   float64
+)
+
+func TestConfigCanonicalBytesAndHash2481(t *testing.T) {
+	cfg := DefaultConfig()
+	want := "codec=brq_1bit\n" +
+		"version=1\n" +
+		"metric=cosine\n" +
+		"normalization=unit_l2\n" +
+		"rotation=signed_permutation_fwht_padded_v1\n" +
+		"seed=0x6272713162697401\n" +
+		"storage_role=packed_codes\n" +
+		"storage_logical_type=packed_bit_vector\n" +
+		"storage_encoding=raw_packed_bit_vector\n" +
+		"bit_order=lsb0\n" +
+		"word_order=little_endian_uint64\n" +
+		"padding=zero\n" +
+		"code_width_bits=1\n" +
+		"query_weight_bits=4\n" +
+		"query_weight_quantizer=max_abs_uint4_round_half_up\n" +
+		"score=brq_1bit_estimated_cosine_q4\n" +
+		"data_scale_side_array=quantized_dot_product_inv\n"
+	if got := string(cfg.CanonicalBytes()); got != want {
+		t.Fatalf("CanonicalBytes mismatch:\ngot:\n%swant:\n%s", got, want)
+	}
+	if got, want := cfg.Hash64(), uint64(0xf705b6becc1769f9); got != want {
+		t.Fatalf("Config.Hash64=%#x want %#x", got, want)
+	}
+	if got, want := (Config{Seed: 0x0123456789abcdef}).Hash64(), uint64(0xcee1cfbd6c328075); got != want {
+		t.Fatalf("custom Config.Hash64=%#x want %#x", got, want)
+	}
+}
+
+func TestIdentityRotationAndShape2481(t *testing.T) {
+	if CodecName != "brq_1bit" || CodecVersion != 1 || DefaultSeed != 0x6272713162697401 {
+		t.Fatalf("unexpected identity: codec=%q version=%d seed=%#x", CodecName, CodecVersion, DefaultSeed)
+	}
+	if RotationName != "signed_permutation_fwht_padded_v1" {
+		t.Fatalf("RotationName=%q", RotationName)
+	}
+	if CodeWidthBits != 1 || QueryWeightBits != 4 {
+		t.Fatalf("widths code=%d query=%d", CodeWidthBits, QueryWeightBits)
+	}
+	if BitOrder != "lsb0" || WordOrder != "little_endian_uint64" || ScoreLabel != "brq_1bit_estimated_cosine_q4" {
+		t.Fatalf("unexpected bit/word/score labels: %q %q %q", BitOrder, WordOrder, ScoreLabel)
+	}
+	if StorageRole != string(quantizedasset.RolePackedCodes) {
+		t.Fatalf("StorageRole=%q want quantizedasset.RolePackedCodes", StorageRole)
+	}
+	if StorageLogicalType != string(typedcolumn.ColumnTypePackedBitVector) {
+		t.Fatalf("StorageLogicalType=%q want packed_bit_vector", StorageLogicalType)
+	}
+	if StorageEncoding != typedcolumn.EncodingRawPackedBitVector.String() {
+		t.Fatalf("StorageEncoding=%q want raw_packed_bit_vector", StorageEncoding)
+	}
+
+	for _, tc := range []struct {
+		dims      int
+		codeDims  int
+		codeBytes int
+	}{
+		{dims: 1, codeDims: 1, codeBytes: 1},
+		{dims: 3, codeDims: 4, codeBytes: 1},
+		{dims: 5, codeDims: 8, codeBytes: 1},
+		{dims: 8, codeDims: 8, codeBytes: 1},
+		{dims: 9, codeDims: 16, codeBytes: 2},
+		{dims: 63, codeDims: 64, codeBytes: 8},
+		{dims: 65, codeDims: 128, codeBytes: 16},
+		{dims: 129, codeDims: 256, codeBytes: 32},
+	} {
+		t.Run(fmt.Sprintf("dims_%d", tc.dims), func(t *testing.T) {
+			plan, err := NewPlan(tc.dims, DefaultConfig())
+			if err != nil {
+				t.Fatalf("NewPlan(%d): %v", tc.dims, err)
+			}
+			if got := plan.Config().Seed; got != DefaultSeed {
+				t.Fatalf("plan seed=%#x want %#x", got, DefaultSeed)
+			}
+			if got := plan.VectorDimensions(); got != tc.dims {
+				t.Fatalf("VectorDimensions=%d want %d", got, tc.dims)
+			}
+			if got := plan.CodeDimensions(); got != tc.codeDims {
+				t.Fatalf("CodeDimensions=%d want %d", got, tc.codeDims)
+			}
+			if got := plan.BytesPerCode(); got != tc.codeBytes {
+				t.Fatalf("BytesPerCode=%d want %d", got, tc.codeBytes)
+			}
+		})
+	}
+}
+
+func TestEncodeQueryAndScoreGolden2481(t *testing.T) {
+	plan, err := NewPlan(5, Config{Seed: 0x0123456789abcdef})
+	if err != nil {
+		t.Fatalf("NewPlan: %v", err)
+	}
+	var ws Workspace
+	encoded, err := plan.Encode(nil, []float32{0.75, -0.5, 0.25, 1.25, -0.75}, &ws)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	query, err := plan.EncodeQuery([]float32{-0.25, 0.5, 1.5, -1, 0.75}, &ws)
+	if err != nil {
+		t.Fatalf("EncodeQuery: %v", err)
+	}
+	score, err := plan.ScoreEncoded(query, encoded)
+	if err != nil {
+		t.Fatalf("ScoreEncoded: %v", err)
+	}
+	slow, err := plan.ScoreCosineSlow(query, encoded.Code, encoded.CodeCount, encoded.QuantizedDotProductInv)
+	if err != nil {
+		t.Fatalf("ScoreCosineSlow: %v", err)
+	}
+
+	if got, want := encoded.Code, []byte{0xd8}; string(got) != string(want) {
+		t.Fatalf("encoded.Code=% x want % x", got, want)
+	}
+	if got, want := encoded.CodeCount, uint32(4); got != want {
+		t.Fatalf("CodeCount=%d want %d", got, want)
+	}
+	if got, want := math.Float32bits(encoded.QuantizedDotProductInv), uint32(0x3ec0f1c6); got != want {
+		t.Fatalf("QuantizedDotProductInv bits=%#x want %#x", got, want)
+	}
+	if got, want := query.SignBits, []byte{0x75}; string(got) != string(want) {
+		t.Fatalf("query.SignBits=% x want % x", got, want)
+	}
+	wantWeights := []uint8{13, 4, 11, 15, 2, 2, 0, 9}
+	if got := query.Weights; string(got) != string(wantWeights) {
+		t.Fatalf("query.Weights=%v want %v", got, wantWeights)
+	}
+	if got, want := math.Float32bits(query.QueryWeightScale), uint32(0x3d265f2f); got != want {
+		t.Fatalf("QueryWeightScale bits=%#x want %#x", got, want)
+	}
+	if got, want := query.QueryWeightSumInt, uint32(56); got != want {
+		t.Fatalf("QueryWeightSumInt=%d want %d", got, want)
+	}
+	if got, want := query.NegativeWeightSumInt, uint32(28); got != want {
+		t.Fatalf("NegativeWeightSumInt=%d want %d", got, want)
+	}
+	assertBytes2481(t, "PosQ1", query.PosQ1, []byte{0x05})
+	assertBytes2481(t, "PosQ2", query.PosQ2, []byte{0x34})
+	assertBytes2481(t, "PosQ4", query.PosQ4, []byte{0x01})
+	assertBytes2481(t, "PosQ8", query.PosQ8, []byte{0x05})
+	assertBytes2481(t, "NegQ1", query.NegQ1, []byte{0x88})
+	assertBytes2481(t, "NegQ2", query.NegQ2, []byte{0x08})
+	assertBytes2481(t, "NegQ4", query.NegQ4, []byte{0x0a})
+	assertBytes2481(t, "NegQ8", query.NegQ8, []byte{0x88})
+	if ScoreLabel != "brq_1bit_estimated_cosine_q4" {
+		t.Fatalf("ScoreLabel=%q", ScoreLabel)
+	}
+	if math.Abs(score-(-0.592816395324689)) > 1e-12 {
+		t.Fatalf("score=%.15f want %.15f", score, -0.592816395324689)
+	}
+	if score != slow {
+		t.Fatalf("bit-product score %.17g differs from slow %.17g", score, slow)
+	}
+}
+
+func TestBitProductFormulaParity2481(t *testing.T) {
+	plan, err := NewPlan(10, Config{Seed: 0x2481})
+	if err != nil {
+		t.Fatalf("NewPlan: %v", err)
+	}
+	var ws Workspace
+	encoded, err := plan.Encode(nil, []float32{1, -2, 3, -4, 5, -6, 7, -8, 9, -10}, &ws)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	query, err := plan.EncodeQuery([]float32{-0.5, 1.5, -2.5, 3.5, -4.5, 5.5, -6.5, 7.5, -8.5, 9.5}, &ws)
+	if err != nil {
+		t.Fatalf("EncodeQuery: %v", err)
+	}
+	assertBytes2481(t, "code", encoded.Code, []byte{0x41, 0x7b})
+	if got, want := encoded.CodeCount, uint32(8); got != want {
+		t.Fatalf("CodeCount=%d want %d", got, want)
+	}
+	if got, want := math.Float32bits(encoded.QuantizedDotProductInv), uint32(0x3e9cf8a9); got != want {
+		t.Fatalf("QuantizedDotProductInv bits=%#x want %#x", got, want)
+	}
+	assertBytes2481(t, "sign", query.SignBits, []byte{0xbf, 0x84})
+	wantWeights := []uint8{0, 15, 5, 5, 5, 11, 3, 13, 2, 2, 6, 5, 1, 4, 5, 7}
+	if got := query.Weights; string(got) != string(wantWeights) {
+		t.Fatalf("query.Weights=%v want %v", got, wantWeights)
+	}
+	assertBytes2481(t, "PosQ1", query.PosQ1, []byte{0xbe, 0x80})
+	assertBytes2481(t, "PosQ2", query.PosQ2, []byte{0x22, 0x84})
+	assertBytes2481(t, "PosQ4", query.PosQ4, []byte{0x9e, 0x84})
+	assertBytes2481(t, "PosQ8", query.PosQ8, []byte{0xa2, 0x00})
+	assertBytes2481(t, "NegQ1", query.NegQ1, []byte{0x40, 0x58})
+	assertBytes2481(t, "NegQ2", query.NegQ2, []byte{0x40, 0x03})
+	assertBytes2481(t, "NegQ4", query.NegQ4, []byte{0x00, 0x68})
+	assertBytes2481(t, "NegQ8", query.NegQ8, []byte{0x00, 0x00})
+	posSet, err := plan.BitProduct(encoded.Code, query.PosQ1, query.PosQ2, query.PosQ4, query.PosQ8)
+	if err != nil {
+		t.Fatalf("BitProduct pos: %v", err)
+	}
+	negSet, err := plan.BitProduct(encoded.Code, query.NegQ1, query.NegQ2, query.NegQ4, query.NegQ8)
+	if err != nil {
+		t.Fatalf("BitProduct neg: %v", err)
+	}
+	matchWeight := posSet + (query.NegativeWeightSumInt - negSet)
+	signedWeight := int64(2*matchWeight) - int64(query.QueryWeightSumInt)
+	manual := float64(signedWeight) * float64(query.QueryWeightScale) / (float64(encoded.QuantizedDotProductInv) * float64(plan.CodeDimensions()))
+	score, err := plan.ScoreEncoded(query, encoded)
+	if err != nil {
+		t.Fatalf("ScoreEncoded: %v", err)
+	}
+	slow, err := plan.ScoreCosineSlow(query, encoded.Code, encoded.CodeCount, encoded.QuantizedDotProductInv)
+	if err != nil {
+		t.Fatalf("ScoreCosineSlow: %v", err)
+	}
+	if posSet != 0 || negSet != 22 || query.QueryWeightSumInt != 89 || query.NegativeWeightSumInt != 22 {
+		t.Fatalf("formula terms pos=%d neg=%d sum=%d negsum=%d", posSet, negSet, query.QueryWeightSumInt, query.NegativeWeightSumInt)
+	}
+	if score != manual || score != slow {
+		t.Fatalf("score parity failed score=%.17g manual=%.17g slow=%.17g", score, manual, slow)
+	}
+	if math.Abs(score-(-0.663334448546277)) > 1e-12 {
+		t.Fatalf("score=%.15f want %.15f", score, -0.663334448546277)
+	}
+}
+
+func TestPackedCodeBitOrderAndPadding2481(t *testing.T) {
+	plan, err := NewPlan(3, Config{Seed: 0x2481}) // CodeDimensions=4, one physical byte with four high padding bits.
+	if err != nil {
+		t.Fatalf("NewPlan: %v", err)
+	}
+	var ws Workspace
+	encoded, err := plan.Encode(nil, []float32{1, -2, 3}, &ws)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	if len(encoded.Code) != 1 {
+		t.Fatalf("code bytes=%d want 1", len(encoded.Code))
+	}
+	if encoded.Code[0]&0xf0 != 0 {
+		t.Fatalf("encoded padding bits are non-zero: code=%08b", encoded.Code[0])
+	}
+	if got := plan.CountCodeBits(encoded.Code); got != encoded.CodeCount {
+		t.Fatalf("CountCodeBits=%d want CodeCount=%d", got, encoded.CodeCount)
+	}
+	corrupt := append([]byte(nil), encoded.Code...)
+	corrupt[0] |= 0x80
+	if err := plan.ValidateCode(corrupt, encoded.CodeCount); err == nil || !strings.Contains(err.Error(), "padding") {
+		t.Fatalf("ValidateCode corrupt padding err=%v want padding failure", err)
+	}
+
+	// Explicit LSB0 check for a ten-element logical row: element i maps to bit
+	// i%8 of byte i/8, matching typed-column packed_bit_vector rows.
+	bits := []bool{true, false, true, true, false, false, true, false, true, true}
+	row := make([]byte, 2)
+	var count uint32
+	for i, bit := range bits {
+		if bit {
+			row[i>>3] |= byte(1 << uint(i&7))
+			count++
+		}
+	}
+	if got, want := row, []byte{0x4d, 0x03}; string(got) != string(want) {
+		t.Fatalf("manual packed LSB0 row=% x want % x", got, want)
+	}
+	if got, want := count, uint32(6); got != want {
+		t.Fatalf("manual code_count=%d want %d", got, want)
+	}
+	packedRows, err := typedcolumn.NewPackedUintRows(1, len(bits), CodeWidthBits, row)
+	if err != nil {
+		t.Fatalf("typedcolumn.NewPackedUintRows for brq row: %v", err)
+	}
+	if got, err := packedRows.Element(0, 8); err != nil || got != 1 {
+		t.Fatalf("typedcolumn Element(8)=%d err=%v want LSB-first bit 1", got, err)
+	}
+	badRow := append([]byte(nil), row...)
+	badRow[len(badRow)-1] |= 0x80
+	if _, err := typedcolumn.NewPackedUintRows(1, len(bits), CodeWidthBits, badRow); err == nil || !strings.Contains(err.Error(), "padding") {
+		t.Fatalf("typedcolumn.NewPackedUintRows corrupt padding err=%v want padding failure", err)
+	}
+}
+
+func TestScoreFailsClosedOnMalformedSideInputs2481(t *testing.T) {
+	plan, err := NewPlan(3, Config{Seed: 0x2481}) // CodeDimensions=4, so query/code padding is visible.
+	if err != nil {
+		t.Fatalf("NewPlan: %v", err)
+	}
+	var ws Workspace
+	encoded, err := plan.Encode(nil, []float32{1, -2, 3}, &ws)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	query, err := plan.EncodeQuery([]float32{0.5, 1.5, -0.25}, &ws)
+	if err != nil {
+		t.Fatalf("EncodeQuery: %v", err)
+	}
+	if _, err := plan.ScoreEncoded(query, encoded); err != nil {
+		t.Fatalf("valid ScoreEncoded: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name string
+		mut  func(*Query, *EncodedVector)
+		want error
+	}{
+		{name: "query_code_dimensions", mut: func(q *Query, _ *EncodedVector) { q.CodeDimensions++ }, want: ErrDimensionMismatch},
+		{name: "weight_len", mut: func(q *Query, _ *EncodedVector) { q.Weights = q.Weights[:len(q.Weights)-1] }, want: ErrDimensionMismatch},
+		{name: "uint4_weight", mut: func(q *Query, _ *EncodedVector) {
+			q.Weights = append([]uint8(nil), q.Weights...)
+			q.Weights[0] = 16
+		}, want: ErrDimensionMismatch},
+		{name: "weight_sum", mut: func(q *Query, _ *EncodedVector) { q.QueryWeightSumInt++ }, want: ErrDimensionMismatch},
+		{name: "negative_weight_sum", mut: func(q *Query, _ *EncodedVector) { q.NegativeWeightSumInt++ }, want: ErrDimensionMismatch},
+		{name: "zero_scale", mut: func(q *Query, _ *EncodedVector) { q.QueryWeightScale = 0 }, want: ErrDegenerateVector},
+		{name: "nan_scale", mut: func(q *Query, _ *EncodedVector) { q.QueryWeightScale = float32(math.NaN()) }, want: ErrDegenerateVector},
+		{name: "sign_padding", mut: func(q *Query, _ *EncodedVector) {
+			q.SignBits = append([]byte(nil), q.SignBits...)
+			q.SignBits[0] |= 0x80
+		}, want: ErrDimensionMismatch},
+		{name: "plane_padding", mut: func(q *Query, _ *EncodedVector) {
+			q.PosQ1 = append([]byte(nil), q.PosQ1...)
+			q.PosQ1[0] |= 0x80
+		}, want: ErrDimensionMismatch},
+		{name: "plane_mismatch", mut: func(q *Query, _ *EncodedVector) {
+			q.NegQ8 = append([]byte(nil), q.NegQ8...)
+			q.NegQ8[0] ^= 0x01
+		}, want: ErrDimensionMismatch},
+		{name: "code_count", mut: func(_ *Query, e *EncodedVector) { e.CodeCount++ }, want: ErrDimensionMismatch},
+		{name: "code_padding", mut: func(_ *Query, e *EncodedVector) {
+			e.Code = append([]byte(nil), e.Code...)
+			e.Code[0] |= 0x80
+		}, want: ErrDimensionMismatch},
+		{name: "zero_qdp_inv", mut: func(_ *Query, e *EncodedVector) { e.QuantizedDotProductInv = 0 }, want: ErrDegenerateVector},
+		{name: "nan_qdp_inv", mut: func(_ *Query, e *EncodedVector) { e.QuantizedDotProductInv = float32(math.NaN()) }, want: ErrDegenerateVector},
+		{name: "tiny_qdp_inv", mut: func(_ *Query, e *EncodedVector) { e.QuantizedDotProductInv = math.SmallestNonzeroFloat32 }, want: ErrDegenerateVector},
+		{name: "large_qdp_inv", mut: func(_ *Query, e *EncodedVector) { e.QuantizedDotProductInv = 1.25 }, want: ErrDegenerateVector},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			badQuery := cloneQuery2481(query)
+			badEncoded := EncodedVector{Code: append([]byte(nil), encoded.Code...), CodeCount: encoded.CodeCount, QuantizedDotProductInv: encoded.QuantizedDotProductInv}
+			tc.mut(&badQuery, &badEncoded)
+			if _, err := plan.ScoreEncoded(badQuery, badEncoded); !errors.Is(err, tc.want) {
+				t.Fatalf("ScoreEncoded err=%v want %v", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestDegenerateInputsFailClosed2481(t *testing.T) {
+	if _, err := NewPlan(0, DefaultConfig()); !errors.Is(err, ErrInvalidConfig) {
+		t.Fatalf("NewPlan(0) err=%v want ErrInvalidConfig", err)
+	}
+	plan, err := NewPlan(4, DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewPlan: %v", err)
+	}
+	for _, tc := range []struct {
+		name string
+		vec  []float32
+		want error
+	}{
+		{name: "short", vec: []float32{1, 2, 3}, want: ErrDimensionMismatch},
+		{name: "long", vec: []float32{1, 2, 3, 4, 5}, want: ErrDimensionMismatch},
+		{name: "zero", vec: []float32{0, 0, 0, 0}, want: ErrDegenerateVector},
+		{name: "nan", vec: []float32{1, float32(math.NaN()), 0, 0}, want: ErrDegenerateVector},
+		{name: "inf", vec: []float32{1, 0, float32(math.Inf(1)), 0}, want: ErrDegenerateVector},
+	} {
+		t.Run(tc.name+"_encode", func(t *testing.T) {
+			if _, err := plan.Encode(nil, tc.vec, &Workspace{}); !errors.Is(err, tc.want) {
+				t.Fatalf("Encode err=%v want %v", err, tc.want)
+			}
+		})
+		t.Run(tc.name+"_query", func(t *testing.T) {
+			if _, err := plan.EncodeQuery(tc.vec, &Workspace{}); !errors.Is(err, tc.want) {
+				t.Fatalf("EncodeQuery err=%v want %v", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestReferenceKernelsNoAllocAfterWarm2481(t *testing.T) {
+	plan, err := NewPlan(16, Config{Seed: 0x2481})
+	if err != nil {
+		t.Fatalf("NewPlan: %v", err)
+	}
+	vector := []float32{0.30, -0.20, 0.70, 0.10, -0.55, 0.40, 0.05, -0.15, 0.33, -0.44, 0.12, 0.88, -0.25, 0.31, -0.05, 0.18}
+	queryVec := []float32{-0.10, 0.35, 0.62, -0.41, 0.22, -0.09, 0.54, 0.13, -0.49, 0.27, 0.16, -0.31, 0.71, -0.06, 0.24, -0.19}
+	var ws Workspace
+	code := make([]byte, 0, plan.BytesPerCode())
+	encoded, err := plan.Encode(code, vector, &ws)
+	if err != nil {
+		t.Fatalf("warm Encode: %v", err)
+	}
+	query, err := plan.EncodeQuery(queryVec, &ws)
+	if err != nil {
+		t.Fatalf("warm EncodeQuery: %v", err)
+	}
+	if _, err := plan.ScoreEncoded(query, encoded); err != nil {
+		t.Fatalf("warm ScoreEncoded: %v", err)
+	}
+
+	allocs := testing.AllocsPerRun(1000, func() {
+		encoded, err := plan.Encode(code, vector, &ws)
+		if err != nil {
+			panic(err)
+		}
+		query, err := plan.EncodeQuery(queryVec, &ws)
+		if err != nil {
+			panic(err)
+		}
+		score, err := plan.ScoreEncoded(query, encoded)
+		if err != nil {
+			panic(err)
+		}
+		brqEncodedSink = encoded
+		brqQuerySink = query
+		brqScoreSink += score
+	})
+	if allocs != 0 {
+		t.Fatalf("reference encode/query/score allocs/run=%v want 0", allocs)
+	}
+	if !brqQuerySink.ValidFor(plan) || brqEncodedSink.CodeCount == 0 || brqScoreSink == 0 {
+		t.Fatalf("unexpected zero sinks: query=%+v encoded=%+v score=%f", brqQuerySink, brqEncodedSink, brqScoreSink)
+	}
+}
+
+func assertBytes2481(t *testing.T, name string, got, want []byte) {
+	t.Helper()
+	if string(got) != string(want) {
+		t.Fatalf("%s=% x want % x", name, got, want)
+	}
+}
+
+func cloneQuery2481(q Query) Query {
+	q.SignBits = append([]byte(nil), q.SignBits...)
+	q.Weights = append([]uint8(nil), q.Weights...)
+	q.PosQ1 = append([]byte(nil), q.PosQ1...)
+	q.PosQ2 = append([]byte(nil), q.PosQ2...)
+	q.PosQ4 = append([]byte(nil), q.PosQ4...)
+	q.PosQ8 = append([]byte(nil), q.PosQ8...)
+	q.NegQ1 = append([]byte(nil), q.NegQ1...)
+	q.NegQ2 = append([]byte(nil), q.NegQ2...)
+	q.NegQ4 = append([]byte(nil), q.NegQ4...)
+	q.NegQ8 = append([]byte(nil), q.NegQ8...)
+	return q
+}

--- a/TreeDB/internal/brq/brq_test.go
+++ b/TreeDB/internal/brq/brq_test.go
@@ -57,6 +57,22 @@ func TestIdentityRotationAndShape2481(t *testing.T) {
 	if CodeWidthBits != 1 || QueryWeightBits != 4 {
 		t.Fatalf("widths code=%d query=%d", CodeWidthBits, QueryWeightBits)
 	}
+	metaPlan, err := NewPlan(5, Config{Seed: 0x0123456789abcdef})
+	if err != nil {
+		t.Fatalf("NewPlan metadata: %v", err)
+	}
+	wantPerm := []int{6, 2, 4, 1, 0, 3, 7, 5}
+	for i, want := range wantPerm {
+		if got := metaPlan.perm[i]; got != want {
+			t.Fatalf("rotation perm[%d]=%d want %d", i, got, want)
+		}
+	}
+	wantSigns := []float64{-1, 1, 1, -1, -1, -1, 1, 1}
+	for i, want := range wantSigns {
+		if got := metaPlan.signs[i]; got != want {
+			t.Fatalf("rotation signs[%d]=%v want %v", i, got, want)
+		}
+	}
 	if BitOrder != "lsb0" || WordOrder != "little_endian_uint64" || ScoreLabel != "brq_1bit_estimated_cosine_q4" {
 		t.Fatalf("unexpected bit/word/score labels: %q %q %q", BitOrder, WordOrder, ScoreLabel)
 	}
@@ -144,7 +160,7 @@ func TestEncodeQueryAndScoreGolden2481(t *testing.T) {
 	if got := query.Weights; string(got) != string(wantWeights) {
 		t.Fatalf("query.Weights=%v want %v", got, wantWeights)
 	}
-	if got, want := math.Float32bits(query.QueryWeightScale), uint32(0x3d265f2f); got != want {
+	if got, want := math.Float64bits(query.QueryWeightScale), uint64(0x3fa4cbe5efaba9f6); got != want {
 		t.Fatalf("QueryWeightScale bits=%#x want %#x", got, want)
 	}
 	if got, want := query.QueryWeightSumInt, uint32(56); got != want {
@@ -164,8 +180,8 @@ func TestEncodeQueryAndScoreGolden2481(t *testing.T) {
 	if ScoreLabel != "brq_1bit_estimated_cosine_q4" {
 		t.Fatalf("ScoreLabel=%q", ScoreLabel)
 	}
-	if math.Abs(score-(-0.592816395324689)) > 1e-12 {
-		t.Fatalf("score=%.15f want %.15f", score, -0.592816395324689)
+	if math.Abs(score-(-0.592816421950027)) > 1e-12 {
+		t.Fatalf("score=%.15f want %.15f", score, -0.592816421950027)
 	}
 	if score != slow {
 		t.Fatalf("bit-product score %.17g differs from slow %.17g", score, slow)
@@ -231,8 +247,8 @@ func TestBitProductFormulaParity2481(t *testing.T) {
 	if score != manual || score != slow {
 		t.Fatalf("score parity failed score=%.17g manual=%.17g slow=%.17g", score, manual, slow)
 	}
-	if math.Abs(score-(-0.663334448546277)) > 1e-12 {
-		t.Fatalf("score=%.15f want %.15f", score, -0.663334448546277)
+	if math.Abs(score-(-0.663334471054573)) > 1e-12 {
+		t.Fatalf("score=%.15f want %.15f", score, -0.663334471054573)
 	}
 }
 
@@ -324,7 +340,7 @@ func TestScoreFailsClosedOnMalformedSideInputs2481(t *testing.T) {
 		{name: "weight_sum", mut: func(q *Query, _ *EncodedVector) { q.QueryWeightSumInt++ }, want: ErrDimensionMismatch},
 		{name: "negative_weight_sum", mut: func(q *Query, _ *EncodedVector) { q.NegativeWeightSumInt++ }, want: ErrDimensionMismatch},
 		{name: "zero_scale", mut: func(q *Query, _ *EncodedVector) { q.QueryWeightScale = 0 }, want: ErrDegenerateVector},
-		{name: "nan_scale", mut: func(q *Query, _ *EncodedVector) { q.QueryWeightScale = float32(math.NaN()) }, want: ErrDegenerateVector},
+		{name: "nan_scale", mut: func(q *Query, _ *EncodedVector) { q.QueryWeightScale = math.NaN() }, want: ErrDegenerateVector},
 		{name: "sign_padding", mut: func(q *Query, _ *EncodedVector) {
 			q.SignBits = append([]byte(nil), q.SignBits...)
 			q.SignBits[0] |= 0x80

--- a/TreeDB/internal/brq/brq_test.go
+++ b/TreeDB/internal/brq/brq_test.go
@@ -341,6 +341,8 @@ func TestScoreFailsClosedOnMalformedSideInputs2481(t *testing.T) {
 		{name: "negative_weight_sum", mut: func(q *Query, _ *EncodedVector) { q.NegativeWeightSumInt++ }, want: ErrDimensionMismatch},
 		{name: "zero_scale", mut: func(q *Query, _ *EncodedVector) { q.QueryWeightScale = 0 }, want: ErrDegenerateVector},
 		{name: "nan_scale", mut: func(q *Query, _ *EncodedVector) { q.QueryWeightScale = math.NaN() }, want: ErrDegenerateVector},
+		{name: "tiny_scale", mut: func(q *Query, _ *EncodedVector) { q.QueryWeightScale = math.SmallestNonzeroFloat64 }, want: ErrDegenerateVector},
+		{name: "large_scale", mut: func(q *Query, _ *EncodedVector) { q.QueryWeightScale = 1 }, want: ErrDegenerateVector},
 		{name: "sign_padding", mut: func(q *Query, _ *EncodedVector) {
 			q.SignBits = append([]byte(nil), q.SignBits...)
 			q.SignBits[0] |= 0x80

--- a/TreeDB/internal/brq/doc.go
+++ b/TreeDB/internal/brq/doc.go
@@ -1,0 +1,8 @@
+// Package brq implements the TreeDB brq_1bit v1 oracle.
+//
+// The package is intentionally internal and reference-oriented: it defines the
+// codec identity, canonical config bytes, deterministic rotation, golden data
+// encoding, query uint4 bit-plane encoding, and score formula used to validate
+// future optimized asset/search implementations. It does not publish collection
+// runtime behavior or mutate rabitq_1bit semantics.
+package brq


### PR DESCRIPTION
## Objective

Add the first narrow #2481 prototype slice: an internal clean-room `brq_1bit` v1 oracle and golden tests for the contract selected by #2480 / PR #2488. This is partial #2481 only; graph status remains unresolved until durable asset/search support lands or is explicitly no-promote/deferred.

Refs #2481. Parent tracker: #2475. Consumes selected contract from #2480 / #2488.

## Context

`TreeDB/docs/spec/brq-1bit-v1.md` requires oracle/spec coverage before durable assets or runtime search are implemented. This PR establishes the codec identity, config hash, LSB0 encode/query goldens, and score formula parity used by follow-on asset/search PRs.

## Non-goals

- No collection runtime, durable asset writer/prepare path, or `VectorIndexSearcher.SearchWithBuffer` support.
- No collection-level buffered support.
- No benchmark/throughput/acceleration claim.
- No changes to `rabitq_1bit` v1 semantics, identity, bit order, score formula, assets, or fail-closed behavior.

## Design

- Adds internal package `TreeDB/internal/brq` for the `brq_1bit` v1 reference oracle.
- Implements:
  - canonical line-oriented config bytes and FNV-1a `Hash64`;
  - `CodeDimensions=next_power_of_two(VectorDimensions)` and LSB0 packed data rows;
  - deterministic `signed_permutation_fwht_padded_v1` rotation using the BRQ default seed;
  - data encode with `code_count` and `quantized_dot_product_inv` side-array value;
  - query encode with uint4 weights, positive/negative q1/q2/q4/q8 masks, query-weight scale, and score label;
  - bit-product score formula plus slow formula parity checks;
  - fail-closed validation for malformed dimensions, vectors, query masks/weights, padding, code counts, and side arrays.

## Scope

Includes:
- `TreeDB/internal/brq/doc.go`
- `TreeDB/internal/brq/brq.go`
- `TreeDB/internal/brq/brq_test.go`

Excludes:
- `TreeDB/collections/*`
- `TreeDB/internal/rabitq/*`
- durable typed-column asset/search support
- benchmark harness changes

## Correctness

Tests run locally on latest head `367ab8ab4`:

```sh
git diff --check origin/main...HEAD
GOWORK=off go test ./TreeDB/internal/brq -count=1
GOWORK=off go test ./TreeDB/internal/... -count=1
```

Coverage added:
- canonical config bytes/hash goldens;
- rotation metadata, code dimensions, row bytes, seed identity;
- LSB0 encode bytes, `code_count`, and `quantized_dot_product_inv` goldens;
- query uint4 weights, q1/q2/q4/q8 positive/negative masks, scale, and score label;
- bit-product formula parity with slow oracle scoring;
- fail-closed malformed vector/query/code/padding/side-array validation;
- warmed reference encode/query/score allocation guardrail.

`GOWORK=off go test ./TreeDB/collections -count=1` was not run because this PR does not change collection code or tests.

Internal review:
- High-thinking executor implemented chunk A in child worktree `2481-brq-oracle`.
- Xhigh reviewer inspected final diff and reran focused tests; no blocking findings.

## Performance

Benchmarks: not applicable. This PR adds oracle/reference tests only and does not enable runtime assets/search.

No recall/storage/route/exact-read runtime evidence is claimed here; those are required for follow-on chunks B/C before #2481 can be marked completed.

## Rollout / Toggle Plan

Default behavior is unchanged. No public API or runtime path selects `brq_1bit` yet. Reverting this PR removes only the internal oracle package.

## Follow-ups

- Chunk B: durable `brq_1bit` asset build/prepare/reopen and fail-closed validation.
- Chunk C: lower-level `VectorIndexSearcher.SearchWithBuffer` support with recall/storage/perf/counter evidence.
- Chunk D: collection buffered support only if lower-level evidence is positive.

### AI Review Loop

- Codex latest-head review: requested after mature PR evidence; initial P2 query-scale finding fixed in `367ab8ab4`; latest-head re-review reported no major issues.
- Copilot latest-head review: requested twice; no visible completed Copilot response as of final check.
- CodeRabbit latest-head review: automatic review/check is passing with latest-head "Review skipped" status; earlier trivial padding-test nit was acknowledged as intentionally out-of-scope and its thread resolved.
- Review comments/threads resolved or explicitly dismissed: all review threads resolved (Codex query-scale fixed; CodeRabbit padding sentinel nit intentionally not broadened).

### Latest-head CI

- Latest head: `367ab8ab4`.
- CI status: all latest-head checks passing for `367ab8ab4`; `gh pr checks 2489 --repo snissn/gomap` clean at final check.
