### PR TITLE
Publish TreeDB vector search closeout guidance

### DIFF
--- a/TreeDB/docs/brq_1bit_spec_test.go
+++ b/TreeDB/docs/brq_1bit_spec_test.go
@@ -18,6 +18,7 @@ func TestDocs_BRQ1BitV1Spec2480(t *testing.T) {
 	normalized := strings.Join(strings.Fields(text), " ")
 	for _, want := range []string{
 		"`brq_1bit` version `1`",
+		"lower-level runtime prototype for #2481",
 		"MUST NOT reinterpret or mutate `rabitq_1bit` v1",
 		"License survey and implementation boundary",
 		"Default seed | `0x6272713162697401`",
@@ -35,7 +36,7 @@ func TestDocs_BRQ1BitV1Spec2480(t *testing.T) {
 		"canonical config bytes and `Config.Hash64` golden",
 		"Recall, storage, and performance gates",
 		"`quantized_score_codec_brq_1bit/search=1`",
-		"A complete `brq_1bit` v1 contract unblocks #2481",
+		"#2507 added lower-level BRQ quantized asset/search runtime",
 	} {
 		if !strings.Contains(normalized, strings.Join(strings.Fields(want), " ")) {
 			t.Fatalf("brq spec missing %q", want)
@@ -58,7 +59,7 @@ func TestDocs_BRQ1BitV1LinkedOwners2480(t *testing.T) {
 		},
 		filepath.Join(treeRoot, "docs", "spec", "quantized-asset-schema.md"): {
 			"brq-1bit-v1.md",
-			"future `brq_1bit` v1 contract",
+			"`brq_1bit` v1 contract/prototype",
 			"runtime query `uint4` bit-product score semantics",
 		},
 		filepath.Join(treeRoot, "docs", "spec", "rabitq-1bit-v1.md"): {

--- a/TreeDB/docs/guides/README.md
+++ b/TreeDB/docs/guides/README.md
@@ -24,13 +24,14 @@ directories when moving between branches.
   payloads in dense typed-column sections, keep metadata ownership explicit, and
   separate search/scoring from final document fetch.
 - [High-QPS collection vector-search guide](vector-search-high-qps-collection-api.md)
-  — choose between buffered no-document serving, response-owned convenience
-  calls, explicit materialization, and reusable searchers without overclaiming
-  beyond exact measured routes.
+  — choose between exact buffered no-document serving, quantized route states,
+  response-owned convenience calls, explicit materialization, and reusable searchers
+  without overclaiming beyond measured routes.
 - [TreeDB vs USearch vector benchmark workflow](vector-search-benchmark-workflow.md)
   — reproduce the dated Tier S/Tier F comparison workflow, required fast-path
-  counters, USearch bootstrap, artifact directories, and profile capture without
-  blurring exact no-document rows with materialization or quantized evidence.
+  counters, USearch bootstrap, artifact directories, profile capture, and the
+  #2483 closeout link without blurring exact no-document rows with
+  materialization or quantized evidence.
 
 ## Deeper specs
 

--- a/TreeDB/docs/guides/vector-search-benchmark-workflow.md
+++ b/TreeDB/docs/guides/vector-search-benchmark-workflow.md
@@ -6,6 +6,14 @@ post-#2360 TreeDB collection vector-search docs stack. It is a dated exact-FP32
 or matches USearch outside the stated fixture, hardware, commit, route, and
 counters.
 
+For the #2483 final vector docs closeout, use
+[`vector-search-closeout-2483.md`](../spec/vector-search-closeout-2483.md) as the
+current route/evidence index. It incorporates the #2487 unified current-main
+snapshot for exact FP32, `scalar_u8`, and `rabitq_1bit`, plus the #2507
+prototype `brq_1bit` lower-level evidence. The scale-sensitive crossover
+campaign (#2490-#2494) is still pending, so final exact-vs-quantized-vs-USearch
+positioning must either consume #2494 or say that crossover evidence is pending.
+
 ## Current performance snapshot: Tier S exact no-document comparison
 
 Current public numbers should cite this exact snapshot until a newer #2399 or

--- a/TreeDB/docs/guides/vector-search-high-qps-collection-api.md
+++ b/TreeDB/docs/guides/vector-search-high-qps-collection-api.md
@@ -1,15 +1,18 @@
 # TreeDB high-QPS collection vector search
 
 This guide summarizes the collection-level vector-search API boundary after the
-`#2360` high-QPS work. It owns the API-selection and caveat guidance from #2406;
-benchmark snapshots and full counter workflow are documented separately by
-#2410.
+#2483 closeout. It owns the API-selection and caveat guidance from #2406 and now
+keeps exact FP32, `scalar_u8`, `rabitq_1bit`, and prototype `brq_1bit` evidence
+separate. Benchmark snapshots and full counter workflow are documented by the
+[benchmark workflow](vector-search-benchmark-workflow.md) and the
+[#2483 closeout index](../spec/vector-search-closeout-2483.md).
 
 ## Choosing a vector search API
 
 | User goal | API | Result ownership | Document/materialization boundary | Notes |
 | --- | --- | --- | --- | --- |
-| Production high-QPS exact no-document serving through the collection API | `Collection.SearchVectorIndexWithBuffer` | caller-owned `VectorIndexSearchBuffer` | `IncludeDocuments=false`; document fetch/projection/filter/fallback controls rejected | Primary collection-level fast path. Warm the collection-owned prepared `hnsw_search_pack_v1` state before the timed/serving loop; steady state targets `0 B/op`, `0 allocs/op`. |
+| Production high-QPS exact no-document serving through the collection API | `Collection.SearchVectorIndexWithBuffer` | caller-owned `VectorIndexSearchBuffer` | `IncludeDocuments=false`; document fetch/projection/filter/fallback controls rejected | Primary exact collection-level fast path. Warm the collection-owned prepared `hnsw_search_pack_v1` state before the timed/serving loop; steady state targets `0 B/op`, `0 allocs/op`. |
+| Collection-level buffered quantized serving for supported score planes | `Collection.SearchVectorIndexWithBuffer` with `QueryMode=quantized_only` or `quantized_rerank` and `QuantizedIndexName` | caller-owned `VectorIndexSearchBuffer` | `IncludeDocuments=false`; document materialization remains separate | Separate route state from exact FP32. Current collection evidence covers `scalar_u8` and `rabitq_1bit`; `quantized_only` reads no exact vectors/norms, while `quantized_rerank` exact-reads only the shortlist. |
 | Simple no-document call when per-call result allocation is acceptable | `Collection.SearchVectorIndex` with `IncludeDocuments=false` | response-owned results/IDs | no documents materialized | Convenience route. Healthy exact calls use the cached `hnsw_search_pack_v1` route, but returned result/ID storage is response-owned and intentionally allocates. |
 | Search and materialize documents in the same call | `Collection.SearchVectorIndex` with `IncludeDocuments=true` | response-owned results/documents | with-document materialization is part of the call | explicit materialization path. Do not mix these rows into no-document high-QPS claims; report document fetch counters separately. |
 | Search first, fetch top-k documents later | `CollectionReadView.FetchDocumentsForVectorIndexSearchResults` after a no-document search | response-owned documents | separate fetch/materialization phase | Use when a service can keep ANN search no-document and fetch only selected top-k IDs later. Buffered-search results alias the caller buffer, so do not reuse/reset the buffer until this fetch returns. |
@@ -59,6 +62,11 @@ for query := range queries {
 }
 ```
 
+For quantized collection serving, use the same buffered API with an explicit
+`QueryMode` and `QuantizedIndexName`. Keep `scalar_u8`, `rabitq_1bit`, and
+`brq_1bit` evidence separate: #2487 covers collection-level `scalar_u8` and
+`rabitq_1bit`; #2507 adds lower-level prototype `brq_1bit` rows only.
+
 For lower-level serving, open `OpenVectorIndexSearcher` once per worker, warm
 `SearchWithBuffer` with that worker's own buffer, and close/reopen the searcher
 when the worker must move to a newer collection/vector-index generation.
@@ -85,29 +93,30 @@ evidence.
 
 ## Do not overclaim
 
-- Say TreeDB is close to USearch only for the warmed exact no-document parallel
-  buffered serving route measured in the #2360/#2379 snapshot: Apple M3
-  (`darwin/arm64`), 2026-06-05, commit
-  `2feb1f0e35459d1b3d044008203d0c8afcf5630f`, Tier S fixture (10k docs,
-  64 dims, M=16, efConstruction=128, efSearch=128, topK=10, query stream
-  length 16, `BENCHTIME=1000x`, `COUNT=3`, `CPU_LIST=1,8`). USearch in that
-  comparison is a pure in-memory external ANN baseline, not TreeDB persistent
-  storage.
+- Do not turn dated fixture rows into general parity claims. The #2487 exact
+  snapshot reports TreeDB and USearch rows on an Apple M3 (`darwin/arm64`) at
+  commit `32e143240dbffb24172e0ec91c5565ea7c84328a` under moderate host load;
+  use it as current-main route evidence, not a universal ranking.
 - With-document search is a different materialization path. It includes final
   document fetch/reconstruction work and must not be mixed into no-document
   high-QPS claims.
 - Filters, projections, debug-only stats, and quantized modes are outside the
-  exact FP32 `hnsw_search_pack_v1` no-document success claim unless a separate
-  fail-closed route row and benchmark/counter evidence are published.
-- Collection-level buffered quantized search support is unavailable/planned
-  follow-up until #2415 lands. Keep any low-level quantized search evidence
-  separate from exact FP32 `hnsw_search_pack_v1` route claims.
+  exact FP32 `hnsw_search_pack_v1` no-document success claim. Quantized modes
+  must use their own route rows, fail-closed counters, exact-read bounds, recall,
+  code/asset bytes, and allocation evidence.
+- Quantized collection buffered search is supported as a separate route state for
+  accepted `scalar_u8` and `rabitq_1bit` rows. The `brq_1bit` #2507 work is a
+  lower-level prototype with its own benchmark evidence and no promotion claim.
+  Future scale-sensitive positioning should consume #2494 crossover synthesis or
+  say explicitly that crossover evidence is pending.
 
 ## Required no-document route counters
 
-#2410 owns the full benchmark snapshot and counter workflow. As a contract
-summary, healthy exact no-document rows must prove all of the following before
-claiming the high-QPS path:
+#2410 owns the historical benchmark workflow, while
+[`vector-search-closeout-2483.md`](../spec/vector-search-closeout-2483.md)
+indexes the current accepted evidence. As a contract summary, healthy exact
+no-document rows must prove all of the following before claiming the exact
+high-QPS path:
 
 - `search_route_hnsw_search_pack/search=1`
 - `hnsw_search_pack_active/search=1`
@@ -130,6 +139,21 @@ boundary is proven by the benchmark shape plus the route/fallback counters above
 `0 allocs/op`. `Collection.SearchVectorIndex` no-document convenience rows
 should report `response_owned_result_alloc/op=1` and account for the small
 response-owned allocation separately.
+
+Quantized no-document rows must additionally prove their own route state:
+
+- `search_route_quantized_only/search=1` or
+  `search_route_quantized_rerank/search=1`
+- `quantized_scorer_active/search=1`
+- `quantized_asset_unavailable/search=0`
+- `docs_fetched/search=0`
+- qonly rows: `vector_B/search=0`, `norm_B/search=0`, and
+  `quantized_rerank_exact_score_calls/search=0`
+- rerank rows: `quantized_rerank_candidates/search` and
+  `quantized_rerank_exact_score_calls/search` bounded to the configured
+  shortlist
+- codec/storage evidence such as `quantized_code_B/vector`,
+  `quantized_asset_B/vector`, recall@K, `B/op`, and `allocs/op`
 
 ## Benchmark command
 

--- a/TreeDB/docs/guides/vector-search-high-qps-collection-api.md
+++ b/TreeDB/docs/guides/vector-search-high-qps-collection-api.md
@@ -112,7 +112,7 @@ evidence.
 
 ## Required no-document route counters
 
-#2410 owns the historical benchmark workflow, while
+Issue #2410 owns the historical benchmark workflow, while
 [`vector-search-closeout-2483.md`](../spec/vector-search-closeout-2483.md)
 indexes the current accepted evidence. As a contract summary, healthy exact
 no-document rows must prove all of the following before claiming the exact

--- a/TreeDB/docs/guides/vector-search-typed-column.md
+++ b/TreeDB/docs/guides/vector-search-typed-column.md
@@ -20,7 +20,7 @@ changes.
 | Adjacency list | typed-column `uint32_list` assets owned by vector-index state | `raw_uint32_offsets_list` is the physical encoding for HNSW adjacency state. Legacy `column_graph` adjacency direct sources and the `adjacency_layout: "uint32_offsets_list"` selector are quarantined compatibility only; new graph builds should not publish those graph-specific source assets or legacy graph row adjacency payloads. |
 | Ordinal-to-base-row references | vector-index state `row_refs` assets (`int64` / `raw_int64`) | Search uses row-ref state to map HNSW ordinals to base rows and to materialize documents without an ID-to-row-ref locator lookup. |
 | Returned opaque document IDs | vector-index state `document_ids` asset (`bytes` / `raw_bytes_offsets`) | Exact arbitrary binary IDs are opaque bytes state. Legacy graph row ID bytes are compatibility or quarantine fallback only. |
-| Optional quantized score planes | vector-index state `quantized_codes` assets (`byte_vector` / `raw_fixed_bytes` for `scalar_u8`, `packed_bit_vector` / `raw_packed_bit_vector` plus side arrays for `rabitq_1bit`) | Declared score planes are derived assets for explicit `quantized_only` and `quantized_rerank` modes. They are not authoritative vector storage and fail closed when missing, stale, mismatched, unsupported, or unprepared. |
+| Optional quantized score planes | vector-index state `quantized_codes` assets (`byte_vector` / `raw_fixed_bytes` for `scalar_u8`, `packed_bit_vector` / `raw_packed_bit_vector` plus side arrays for `rabitq_1bit` and prototype `brq_1bit`) | Declared score planes are derived assets for explicit `quantized_only` and `quantized_rerank` modes. They are not authoritative vector storage and fail closed when missing, stale, mismatched, unsupported, or unprepared. |
 
 Best practice: keep vector payloads out of retained JSON for search-heavy
 workloads when the typed-column vector section is the intended search data plane.
@@ -78,7 +78,8 @@ Ownership rules:
 ## Optional quantized query modes
 
 The default/zero query mode is exact and preserves current prepared float32
-scoring. To use a declared scalar_u8 or RaBitQ score plane, select it explicitly:
+scoring. To use a declared `scalar_u8`, `rabitq_1bit`, or prototype `brq_1bit`
+score plane, select it explicitly:
 
 ```go
 estimated, err := searcher.Search(collections.VectorIndexSearcherSearchOptions{
@@ -105,9 +106,11 @@ vector/norm reads in stats. `quantized_rerank` reports
 `search_route_quantized_rerank=1`, keeps quantized traversal over the normalized
 `ef_search` pool, trims to `QuantizedRerankCandidates`, exact-reranks that
 shortlist, and returns exact cosine scores. See
-[`quantized-vector-index.md`](../spec/quantized-vector-index.md) and
-[`rabitq-closeout-2454.md`](../spec/rabitq-closeout-2454.md) for benchmark
-commands, RaBitQ storage/recall evidence, and current no-speedup caveats.
+[`quantized-vector-index.md`](../spec/quantized-vector-index.md),
+[`rabitq-closeout-2454.md`](../spec/rabitq-closeout-2454.md), and
+[`vector-search-closeout-2483.md`](../spec/vector-search-closeout-2483.md) for
+benchmark commands, RaBitQ/BRQ storage/recall evidence, and current no-speedup /
+crossover-pending caveats.
 
 ## Retained-payload final-fetch policy
 
@@ -472,7 +475,7 @@ counters.
 | Row+column COW maintenance uses shared reachability and active mappedresource pin protection for typed assets; vector graph bytes remain derived, not authoritative. | [#1788](https://github.com/snissn/gomap/issues/1788), parent [#1736](https://github.com/snissn/gomap/issues/1736), [maintenance spec](../spec/typed-asset-maintenance-1788.md) |
 | Nullable/missing vector and adjacency typed-column support remains staged/fail-closed. | See typed-column adapter/spec caveats and follow-up roadmap. |
 | Graph-search prepared-view admission is tiered by generic typed-column optimized-consumer capability. | See [typed-column optimized-consumer capabilities](../spec/typed-column-optimized-consumer-capabilities.md), [prepared graph-search runtime views](../spec/typed-column-graph-search-prepared-views.md), and the [#2044 admission table](../spec/typed-column-graph-search-admission.md); #2046 owns reusable direct-view certifiers. |
-| `scalar_u8` and pure-Go `rabitq_1bit` score planes are behavior/storage/recall evidence, not a speedup claim or universal replacement. | See the [#1926/#2454 quantized score-plane spec](../spec/quantized-vector-index.md) and [RaBitQ closeout](../spec/rabitq-closeout-2454.md). BRQ/PQ/OPQ/residual codecs, accelerated RaBitQ backends, batch/control-flow, and windowing optimizations are future work. |
+| `scalar_u8`, pure-Go `rabitq_1bit`, and prototype `brq_1bit` score planes are behavior/storage/recall evidence, not a speedup claim or universal replacement. | See the [#1926/#2454/#2481 quantized score-plane spec](../spec/quantized-vector-index.md), [RaBitQ closeout](../spec/rabitq-closeout-2454.md), and [#2483 vector closeout](../spec/vector-search-closeout-2483.md). PQ/OPQ/residual codecs, accelerated RaBitQ backends, batch/control-flow, and windowing optimizations are future work. |
 
 ## Best practices
 

--- a/TreeDB/docs/quantized_vector_index_test.go
+++ b/TreeDB/docs/quantized_vector_index_test.go
@@ -25,17 +25,22 @@ func TestDocs_QuantizedVectorIndex1926Closeout(t *testing.T) {
 		"BenchmarkColumnGraphScalarU8QuantizedScorePlanes1926",
 		"BenchmarkVectorIndexSearcherColumnGraphScalarU8QuantizedSearchWithBuffer2414",
 		"BenchmarkVectorIndexSearcherColumnGraphRabitQQuantizedSearchWithBuffer2451",
+		"BenchmarkVectorIndexSearcherColumnGraphBRQQuantizedSearchWithBuffer2481",
 		"BenchmarkCollectionSearchVectorIndexWithBufferColumnGraphScalarU8Quantized2415",
 		"BenchmarkCollectionSearchVectorIndexWithBufferColumnGraphRabitQQuantized2452",
 		"Collection.SearchVectorIndexWithBuffer",
 		"BenchmarkColumnGraphScalarU8QuantizedRebuildStorage1926",
 		"BenchmarkColumnGraphRabitQQuantizedRebuildStorage2450",
+		"BenchmarkColumnGraphBRQQuantizedRebuildStorage2481",
+		"brq_1bit_estimated_cosine_q4",
+		"quantized_score_codec_brq_1bit/search=1",
 		"recall_at_k_pct",
 		"quantized_code_B/search",
 		"vector_B/search",
 		"norm_B/search",
 		"quantized_asset_B/vector",
 		"rabitq-closeout-2454.md",
+		"vector-search-closeout-2483.md",
 		"RaBitQ go-highway acceleration did not land",
 		"does **not** claim a current speedup",
 		"Batch scorer kernels, SIMD/popcount integration, graph control-flow changes, block-planner/windowing changes",
@@ -52,6 +57,7 @@ func TestDocs_QuantizedVectorIndex1926LinkedOwners(t *testing.T) {
 		filepath.Join(treeRoot, "docs", "spec", "README.md"): {
 			"quantized-vector-index.md",
 			"rabitq-closeout-2454.md",
+			"vector-search-closeout-2483.md",
 		},
 		filepath.Join(treeRoot, "docs", "spec", "column-graph-native-vector-search.md"): {
 			"quantized-vector-index.md",
@@ -60,6 +66,7 @@ func TestDocs_QuantizedVectorIndex1926LinkedOwners(t *testing.T) {
 		},
 		filepath.Join(treeRoot, "docs", "spec", "quantized-asset-schema.md"): {
 			"quantized-vector-index.md",
+			"prototype `brq_1bit` v1",
 		},
 		filepath.Join(treeRoot, "docs", "spec", "typed-column-graph-search-admission.md"): {
 			"BenchmarkColumnGraphScalarU8QuantizedScorePlanes1926",
@@ -82,8 +89,8 @@ func TestDocs_QuantizedVectorIndex1926LinkedOwners(t *testing.T) {
 		filepath.Join(treeRoot, "docs", "guides", "vector-search-typed-column.md"): {
 			"Optional quantized query modes",
 			"quantized-vector-index.md",
-			"pure-Go `rabitq_1bit` score planes are behavior/storage/recall evidence",
-			"BRQ/PQ/OPQ/residual codecs, accelerated RaBitQ backends",
+			"prototype `brq_1bit` score planes are behavior/storage/recall evidence",
+			"PQ/OPQ/residual codecs, accelerated RaBitQ backends",
 		},
 	}
 	for path, wants := range checks {
@@ -95,6 +102,62 @@ func TestDocs_QuantizedVectorIndex1926LinkedOwners(t *testing.T) {
 		for _, want := range wants {
 			if !strings.Contains(text, want) {
 				t.Fatalf("%s missing quantized vector index closeout text %q", path, want)
+			}
+		}
+	}
+}
+
+func TestDocs_VectorSearchCloseout2483(t *testing.T) {
+	treeRoot, repoRoot := repoRoots(t)
+	path := filepath.Join(treeRoot, "docs", "spec", "vector-search-closeout-2483.md")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read vector search closeout: %v", err)
+	}
+	text := string(data)
+	normalized := strings.Join(strings.Fields(text), " ")
+	for _, want := range []string{
+		"# TreeDB vector search closeout guidance (#2483)",
+		"#2487 unified current-main snapshot",
+		"#2507 added lower-level BRQ asset/search runtime",
+		"#2494 crossover evidence is pending",
+		"TreeDB_SearchWithBufferParallel",
+		"collection `quantized_only`, c=8",
+		"rabitq_1bit",
+		"brq_1bit_estimated_cosine_q4",
+		"/tmp/2481_runtime_bench_20260606_165236",
+		"quantized_score_codec_brq_1bit/search=1",
+	} {
+		if !strings.Contains(normalized, strings.Join(strings.Fields(want), " ")) {
+			t.Fatalf("vector search closeout missing %q", want)
+		}
+	}
+	for path, wants := range map[string][]string{
+		filepath.Join(treeRoot, "docs", "guides", "vector-search-high-qps-collection-api.md"): {
+			"vector-search-closeout-2483.md",
+			"Quantized collection buffered search is supported as a separate route state",
+		},
+		filepath.Join(treeRoot, "docs", "guides", "vector-search-benchmark-workflow.md"): {
+			"vector-search-closeout-2483.md",
+			"#2494",
+		},
+		filepath.Join(treeRoot, "docs", "spec", "README.md"): {
+			"vector-search-closeout-2483.md",
+			"#2494 crossover-pending status",
+		},
+		filepath.Join(repoRoot, "docs", "README.md"): {
+			"TreeDB Vector Search Closeout",
+			"vector-search-closeout-2483.md",
+		},
+	} {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		text := string(data)
+		for _, want := range wants {
+			if !strings.Contains(text, want) {
+				t.Fatalf("%s missing #2483 closeout link text %q", path, want)
 			}
 		}
 	}
@@ -150,7 +213,7 @@ func TestDocs_RaBitQPerformanceLaneCloseout2482(t *testing.T) {
 	for _, want := range []string{
 		"# TreeDB RaBitQ performance lane closeout (#2482)",
 		"closes **Sublane A**, the `rabitq_1bit` v1 performance sweep",
-		"**Sublane B** remains deferred to open follow-ups #2480 and #2481",
+		"**Sublane B** was deferred; it has since completed through #2480",
 		"`rabitq_1bit` v1 durable storage layout",
 		"LSB-first bit order",
 		"weighted sign-dot score formula",
@@ -172,7 +235,8 @@ func TestDocs_RaBitQPerformanceLaneCloseout2482(t *testing.T) {
 		"Scalar guardrail row",
 		"Exact FP32 `hnsw_search_pack_v1` rows were not required for #2477",
 		"no code PR or AI review was opened",
-		"No future codec has been selected yet",
+		"Sublane B is complete for design/prototype purposes",
+		"#2507 merge `8e7377cc995ffc928ac99a42ed8aec769f8f72fb`",
 	} {
 		if !strings.Contains(normalized, strings.Join(strings.Fields(want), " ")) {
 			t.Fatalf("rabitq performance lane closeout missing %q", want)
@@ -182,7 +246,7 @@ func TestDocs_RaBitQPerformanceLaneCloseout2482(t *testing.T) {
 	checks := map[string][]string{
 		filepath.Join(treeRoot, "docs", "spec", "README.md"): {
 			"rabitq-performance-lane-closeout-2482.md",
-			"#2480/#2481 deferred Sublane B status",
+			"completed Sublane B status",
 		},
 		filepath.Join(treeRoot, "docs", "spec", "rabitq-1bit-v1.md"): {
 			"rabitq-performance-lane-closeout-2482.md",
@@ -195,6 +259,7 @@ func TestDocs_RaBitQPerformanceLaneCloseout2482(t *testing.T) {
 		filepath.Join(repoRoot, "docs", "README.md"): {
 			"TreeDB RaBitQ Performance Lane Closeout",
 			"rabitq-performance-lane-closeout-2482.md",
+			"TreeDB Vector Search Closeout",
 		},
 	}
 	for path, wants := range checks {

--- a/TreeDB/docs/spec/README.md
+++ b/TreeDB/docs/spec/README.md
@@ -107,9 +107,13 @@ Given pre-alpha status, this is a living spec that tracks implementation.
     `column_graph` vector indexes that search through the native physical column
     row reader.
 - `TreeDB/docs/spec/quantized-vector-index.md`
-  - issue #1926 scalar_u8 quantized score-plane semantics, fail-closed query
-    modes, exact rerank behavior, benchmark/storage evidence, and future-work
-    boundaries.
+  - issue #1926/#2454/#2481 scalar_u8, `rabitq_1bit`, and prototype
+    `brq_1bit` quantized score-plane semantics, fail-closed query modes, exact
+    rerank behavior, benchmark/storage evidence, and future-work boundaries.
+- `TreeDB/docs/spec/vector-search-closeout-2483.md`
+  - issue #2483 final vector-search docs closeout index for accepted exact FP32,
+    scalar_u8, RaBitQ, and BRQ evidence, #2487 snapshot rows, no-promote
+    caveats, and #2494 crossover-pending status.
 - `TreeDB/docs/spec/rabitq-1bit-v1.md`
   - issue #2449/#2451/#2452 `rabitq_1bit` v1 codec identity, packed-bit
     storage shape, deterministic reference rotation, pure-Go query/scoring APIs,
@@ -122,12 +126,14 @@ Given pre-alpha status, this is a living spec that tracks implementation.
 - `TreeDB/docs/spec/rabitq-performance-lane-closeout-2482.md`
   - issue #2482 RaBitQ performance-lane closeout for #2476/#2477 promoted
     Sublane A evidence, #2478/#2479 no-promote decisions, `rabitq_1bit` v1
-    hard invariants, scalar/exact guardrail interpretation, and #2480/#2481 deferred Sublane B status.
+    hard invariants, scalar/exact guardrail interpretation, and later #2480/#2481
+    completed Sublane B status.
 - `TreeDB/docs/spec/brq-1bit-v1.md`
-  - issue #2480 selected future-codec contract for `brq_1bit` v1, including the
-    new codec identity/version, durable packed-code schema, LSB0 word view,
-    query `uint4` bit-product score semantics, fail-closed validation plan,
-    oracle/golden test requirements, public counter names, and #2481 gates.
+  - issue #2480/#2481 selected codec contract and lower-level prototype for
+    `brq_1bit` v1, including the new codec identity/version, durable packed-code
+    schema, LSB0 word view, query `uint4` bit-product score semantics,
+    fail-closed validation plan, oracle/golden/runtime test requirements, public
+    counter names, and promotion gates.
 - `TreeDB/docs/spec/typed-column-graph-search-prepared-views.md`
   - issue #2036 role-specific prepared runtime-view and admission policy for
     current-format typed-column graph search.
@@ -313,8 +319,8 @@ typed-column maintenance behavior is recorded in
 policy is owned by `typed-column-schema-evolution.md`, optimized-consumer tier
 classification is owned by `typed-column-optimized-consumer-capabilities.md`,
 quantized asset role descriptors and ordinal-reader contracts are owned by
-`quantized-asset-schema.md`; `brq-1bit-v1.md` owns the selected #2480 future
-`brq_1bit` codec contract until any #2481 prototype updates it; graph-search
+`quantized-asset-schema.md`; `brq-1bit-v1.md` owns the selected #2480/#2481
+`brq_1bit` codec contract and lower-level prototype boundary; graph-search
 prepared runtime-view shapes and hot-loop boundaries are owned by
 `typed-column-graph-search-prepared-views.md`, graph-search optimized-state
 readiness/admission status is owned by

--- a/TreeDB/docs/spec/brq-1bit-v1.md
+++ b/TreeDB/docs/spec/brq-1bit-v1.md
@@ -1,13 +1,15 @@
-# TreeDB `brq_1bit` v1 Future Codec Contract (#2480)
+# TreeDB `brq_1bit` v1 Codec Contract (#2480/#2481)
 
-Status: pre-alpha **selected future-codec contract** for #2480. This is a
-specification gate for #2481 prototype work; it is not current runtime behavior,
-does not publish assets/search by itself, and does not claim a throughput win.
+Status: pre-alpha **selected codec contract** for #2480 and lower-level runtime
+prototype for #2481. The spec gate landed first; #2481 subsequently added oracle
+goldens plus lower-level durable asset/search support. This document still does
+not claim a throughput win or production promotion for BRQ.
 
 ## Decision
 
-Issue #2480 selects `brq_1bit` version `1` as the single future codec candidate
-to prototype next. `brq_1bit` is a TreeDB-owned bit-product binary quantizer: it
+Issue #2480 selected `brq_1bit` version `1` as the single codec candidate for
+#2481, and #2481 landed the first lower-level prototype. `brq_1bit` is a
+TreeDB-owned bit-product binary quantizer: it
 keeps one durable sign bit per rotated data dimension, makes query-weight
 quantization explicit, and labels returned quantized scores as approximate
 `brq_1bit` estimates. It exists because the #2453 go-highway probe showed that a
@@ -25,10 +27,11 @@ Any `brq_1bit` implementation must use the new identity below.
   are clean-room TreeDB design/spec text.
 - `github.com/ajroetker/go-highway` v0.0.12 was evaluated for #2453. Its module
   and RaBitQ package are Apache-2.0 and may be used only as an optional kernel
-  dependency with normal notices if #2481 proves compatibility and value.
+  dependency with normal notices if future BRQ acceleration proves compatibility
+  and value.
 - The upstream go-highway `QuantizeVectors` MSB-first word output is not TreeDB
-  durable storage. A future implementation must either write the TreeDB layout
-  directly or transcode before persisting assets.
+  durable storage. Any future accelerated implementation must either write the
+  TreeDB layout directly or transcode before persisting assets.
 - Do not copy code from CockroachDB Software License, ELv2, AGPL, Antfly, or
   incompatible C++ RaBitQ/BRQ libraries. Papers may be cited for algorithmic
   background, but production code must be clean-room or from compatible
@@ -215,9 +218,11 @@ codec-generic quantized asset unavailable/invalid/stale/closed counters. There i
 no silent exact fallback. Exact/default mode continues to reject quantized-only
 fields.
 
-## Required oracle and golden tests before #2481 assets/search
+## Required oracle and golden/runtime tests
 
-Issue #2481 must land oracle/spec coverage before durable assets or production search:
+Issue #2481 landed oracle/spec coverage before durable asset/search support, and
+#2507 added lower-level runtime tests for the same contract. Required coverage
+includes:
 
 - canonical config bytes and `Config.Hash64` golden;
 - rotation metadata, code dimensions, row bytes, and seed golden;
@@ -240,18 +245,21 @@ Issue #2481 must land oracle/spec coverage before durable assets or production s
 `brq_1bit` is selected only as a prototype candidate. It may be closed
 no-promote if the gates below are not met.
 
-Required matrix versus exact FP32, `scalar_u8`, and `rabitq_1bit`:
+Required matrix versus exact FP32, `scalar_u8`, and `rabitq_1bit` for the
+current lower-level prototype:
 
 ```sh
 GOMAXPROCS=8 GOWORK=off go test ./TreeDB/collections \
   -run '^$' \
-  -bench '^(BenchmarkVectorIndexSearcherColumnGraphBRQQuantizedSearchWithBuffer2481|BenchmarkCollectionSearchVectorIndexWithBufferColumnGraphBRQQuantized2481|BenchmarkColumnGraphBRQQuantizedRebuildStorage2481|BenchmarkVectorIndexSearcherColumnGraphScalarU8QuantizedSearchWithBuffer2414|BenchmarkCollectionSearchVectorIndexWithBufferColumnGraphScalarU8Quantized2415|BenchmarkVectorIndexSearcherColumnGraphRabitQQuantizedSearchWithBuffer2451|BenchmarkCollectionSearchVectorIndexWithBufferColumnGraphRabitQQuantized2452|BenchmarkColumnGraphScalarU8QuantizedRebuildStorage1926|BenchmarkColumnGraphRabitQQuantizedRebuildStorage2450)$' \
+  -bench '^(BenchmarkVectorIndexSearcherColumnGraphBRQQuantizedSearchWithBuffer2481|BenchmarkColumnGraphBRQQuantizedRebuildStorage2481|BenchmarkVectorIndexSearcherColumnGraphScalarU8QuantizedSearchWithBuffer2414|BenchmarkVectorIndexSearcherColumnGraphRabitQQuantizedSearchWithBuffer2451|BenchmarkColumnGraphScalarU8QuantizedRebuildStorage1926|BenchmarkColumnGraphRabitQQuantizedRebuildStorage2450)$' \
   -benchmem -benchtime=100000x -count=5
 ```
 
-Rows must include lower-level and collection `quantized_only` plus
-`quantized_rerank/candidates=32` at c=1/c=8, with the same fixture and same-host
-baseline/candidate discipline used by the RaBitQ profile gate. Report `ns/op`,
+The #2507 artifact root is `/tmp/2481_runtime_bench_20260606_165236`; a full
+collection-level BRQ promotion matrix remains future work. Rows must include
+lower-level `quantized_only` plus `quantized_rerank/candidates=32` at c=1/c=8,
+with the same fixture and same-host baseline/candidate discipline used by the
+RaBitQ profile gate. Report `ns/op`,
 `ops/sec`, `B/op`, `allocs/op`, recall@K versus exact, exact vector/norm bytes,
 exact rerank calls, route/fallback/unavailable counters, `quantized_code_B/search`,
 logical code bytes/vector, actual asset bytes/vector, graph total storage, and
@@ -272,15 +280,16 @@ Promotion gates:
   asset bytes/vector should stay within the same order as `rabitq_1bit` unless a
   measured trade-off is accepted.
 - A speedup claim requires same-host BRQ rows to beat optimized `rabitq_1bit` for
-  both c=1 and c=8 lower-level and collection `quantized_only` rows, with no
-  scalar_u8/exact guardrail regressions where shared code is touched.
+  both c=1 and c=8 rows in the relevant lower-level and collection serving
+  shapes, with no scalar_u8/exact guardrail regressions where shared code is
+  touched.
 - Compactness-only or mixed/noisy/regressing evidence must be documented as
   no-promote and must not be presented as acceleration.
 
 ## Public counter and label requirements
 
-Future search stats/benchmarks must keep the existing generic quantized counters
-and add BRQ-specific visibility when this codec is selected:
+Search stats/benchmarks keep the existing generic quantized counters and add
+BRQ-specific visibility when this codec is selected:
 
 - `quantized_score_codec_brq_1bit/search=1`;
 - `brq_1bit_query_weight_bits/search=4`;
@@ -306,7 +315,9 @@ than attempting complex migration scaffolding.
 
 ## #2481 dependency status
 
-A complete `brq_1bit` v1 contract unblocks #2481 only for a lower-level-first
-prototype after this spec is merged or explicitly accepted as the recorded #2480
-contract. #2481 must not implement production assets/search for any other codec
-name/version and must not change `rabitq_1bit` v1 semantics.
+The `brq_1bit` v1 contract unblocked #2481. #2481 completed in two steps: PR
+#2489 added internal oracle/golden coverage, and PR #2507 added lower-level BRQ
+quantized asset/search runtime with fail-closed validation, exact-read guardrails,
+zero-allocation warmed buffered rows, and benchmark evidence. The implementation
+must not change `rabitq_1bit` v1 semantics, and broader promotion/crossover
+claims remain future work.

--- a/TreeDB/docs/spec/column-graph-native-vector-search.md
+++ b/TreeDB/docs/spec/column-graph-native-vector-search.md
@@ -42,13 +42,15 @@ Explicit #1926/#2454 quantized modes are documented in
 [`quantized-vector-index.md`](quantized-vector-index.md) and the RaBitQ closeout
 workflow is in [`rabitq-closeout-2454.md`](rabitq-closeout-2454.md). The
 zero/default query mode remains exact. `quantized_only` uses a selected prepared
-`scalar_u8` or pure-Go `rabitq_1bit` score plane and returns estimated scores
-without exact vector/norm reads. `quantized_rerank` traverses with the selected
-quantized scorer over the normalized `ef_search` candidate pool, trims to
-`QuantizedRerankCandidates`, exact-reranks that shortlist by graph ordinal
-through the authoritative float32 vector/norm path, and returns exact cosine
-scores. Missing, stale, mismatched, unsupported, closed, or unprepared quantized
-assets fail closed; quantized modes must not hide an exact fallback.
+`scalar_u8`, pure-Go `rabitq_1bit`, or prototype `brq_1bit` score plane and
+returns estimated scores without exact vector/norm reads. `quantized_rerank`
+traverses with the selected quantized scorer over the normalized `ef_search`
+candidate pool, trims to `QuantizedRerankCandidates`, exact-reranks that
+shortlist by graph ordinal through the authoritative float32 vector/norm path,
+and returns exact cosine scores. Missing, stale, mismatched, unsupported,
+closed, or unprepared quantized assets fail closed; quantized modes must not hide
+an exact fallback. #2483 summarizes current exact/scalar/RaBitQ/BRQ evidence in
+[`vector-search-closeout-2483.md`](vector-search-closeout-2483.md).
 
 ## Quickstart
 

--- a/TreeDB/docs/spec/quantized-asset-schema.md
+++ b/TreeDB/docs/spec/quantized-asset-schema.md
@@ -28,19 +28,21 @@ The `rabitq_1bit` v1 contract in `rabitq-1bit-v1.md` chooses
 `CodeDimensions=next_power_of_two(VectorDimensions)`, `CodeWidthBits=1`,
 TreeDB LSB-first bit order, and zero high-bit padding. Its required side arrays
 are `code_count` (`uint32`) and `quantized_dot_product_inv` (`float32`). The
-future `brq_1bit` v1 contract in `brq-1bit-v1.md` deliberately uses a new codec
-identity and asset id while reusing the same one-bit data-code roles plus
+`brq_1bit` v1 contract/prototype in `brq-1bit-v1.md` deliberately uses a new
+codec identity and asset id while reusing the same one-bit data-code roles plus
 explicit runtime query `uint4` bit-product score semantics.
 
 ## Query-mode guardrail
 
-Collection vector-index metadata can declare named `scalar_u8` v1 and
-`rabitq_1bit` v1 quantized score planes under
+Collection vector-index metadata can declare named `scalar_u8` v1,
+`rabitq_1bit` v1, and prototype `brq_1bit` v1 quantized score planes under
 `VectorIndexDefinition.QuantizedIndexes`. Public search options expose explicit
 `exact`, `quantized_only`, and `quantized_rerank` query modes. The zero/default
 mode remains exact. As of #2451/#2452, `rabitq_1bit` assets are built,
 persisted, prepared/validated, and consumed by the pure-Go RaBitQ scorer in
-lower-level and collection-level buffered no-document search.
+lower-level and collection-level buffered no-document search. As of #2507,
+`brq_1bit` assets and lower-level `SearchWithBuffer` scoring are available as a
+prototype route with separate counters.
 
 The #1926 scalar lifecycle builds and loads `scalar_u8` v1 `codes` assets for
 declared `column_graph` quantized indexes. For the current cosine
@@ -58,9 +60,11 @@ asset role remains `quantized_codes`, but the asset id is
 `quantized/<name>/packed_codes`, the state logical type/encoding are
 `packed_bit_vector` / `raw_packed_bit_vector`, and the part contains three
 required role columns: `packed_codes`, `code_count`, and
-`quantized_dot_product_inv`. The RaBitQ codec descriptor records canonical config
-bytes plus FNV-1a config hash; the generated typed-column schema hash includes
-that config hash so stale/config-mismatched assets fail closed before prepare.
+`quantized_dot_product_inv`. #2507 uses the same role columns for `brq_1bit` but
+with asset id `quantized/<name>/brq_1bit/packed_codes` and BRQ config identity.
+The codec descriptor records canonical config bytes plus FNV-1a config hash; the
+generated typed-column schema hash includes that config hash so
+stale/config-mismatched assets fail closed before prepare.
 
 Quantized modes validate the selected name/options and asset load status before
 graph traversal/scoring. The `scalar_u8` v1 `quantized_only` scorer consumes the

--- a/TreeDB/docs/spec/quantized-vector-index.md
+++ b/TreeDB/docs/spec/quantized-vector-index.md
@@ -1,15 +1,16 @@
 # Quantized Vector Index Score Planes (#1926, #2454)
 
 Status: pre-alpha `column_graph` score-plane contract for explicit exact,
-`quantized_only`, and `quantized_rerank` query modes. `scalar_u8` v1 and
-`rabitq_1bit` v1 are durable named score planes with fail-closed search. Exact /
-default behavior remains the production baseline. The `rabitq_1bit` v1 codec and
-bit/storage contract are specified separately in
-[`rabitq-1bit-v1.md`](rabitq-1bit-v1.md); the RaBitQ closeout benchmark workflow
-and representative matrix are in
-[`rabitq-closeout-2454.md`](rabitq-closeout-2454.md). The later #2482
+`quantized_only`, and `quantized_rerank` query modes. `scalar_u8` v1,
+`rabitq_1bit` v1, and prototype `brq_1bit` v1 are durable named score planes
+with fail-closed search. Exact / default behavior remains the production
+baseline. The `rabitq_1bit` v1 codec and bit/storage contract are specified
+separately in [`rabitq-1bit-v1.md`](rabitq-1bit-v1.md); the BRQ v1 contract is
+specified in [`brq-1bit-v1.md`](brq-1bit-v1.md). Current route guidance and
+accepted benchmark boundaries are summarized in
+[`vector-search-closeout-2483.md`](vector-search-closeout-2483.md). The #2482
 RaBitQ performance-lane closeout for the #2477 semantics-preserving query
-byte-table scorer, no-promote decisions, and deferred future-codec work is in
+byte-table scorer, no-promote decisions, and later Sublane B outcome is in
 [`rabitq-performance-lane-closeout-2482.md`](rabitq-performance-lane-closeout-2482.md).
 
 ## User-visible query modes
@@ -17,15 +18,16 @@ byte-table scorer, no-promote decisions, and deferred future-codec work is in
 `VectorIndexDefinition.QuantizedIndexes` declares one or more named derived score
 planes for a `column_graph` vector index. Current normalized declarations default
 to `codec="scalar_u8"` and `version=1`; they also accept explicit
-`codec="rabitq_1bit", version=1` declarations.
+`codec="rabitq_1bit", version=1` and `codec="brq_1bit", version=1`
+declarations.
 
 Search uses an explicit mode:
 
 | Mode | Score plane | Returned scores | Exact vector/norm reads | Notes |
 | --- | --- | --- | --- | --- |
 | `exact` / zero value | Authoritative `float32_vector` / prepared exact pack | Exact cosine | Yes, for scored candidates or prepared pack scoring | Existing/default behavior. Quantized-only options are rejected in exact mode. |
-| `quantized_only` | Selected prepared `scalar_u8` or `rabitq_1bit` codes | Selected-codec estimated cosine | No | Traversal and final ranking use the quantized scorer. No hidden exact fallback, vector reads, norm reads, or document materialization. |
-| `quantized_rerank` | Selected prepared `scalar_u8` or `rabitq_1bit` codes for traversal, authoritative vectors for rerank | Exact cosine over the quantized shortlist | Yes, only for the trimmed quantized shortlist | Traversal still collects the normalized `ef_search` candidate pool, then trims to `QuantizedRerankCandidates` before exact rerank. |
+| `quantized_only` | Selected prepared `scalar_u8`, `rabitq_1bit`, or `brq_1bit` codes | Selected-codec estimated cosine | No | Traversal and final ranking use the quantized scorer. No hidden exact fallback, vector reads, norm reads, or document materialization. |
+| `quantized_rerank` | Selected prepared `scalar_u8`, `rabitq_1bit`, or `brq_1bit` codes for traversal, authoritative vectors for rerank | Exact cosine over the quantized shortlist | Yes, only for the trimmed quantized shortlist | Traversal still collects the normalized `ef_search` candidate pool, then trims to `QuantizedRerankCandidates` before exact rerank. |
 
 `QuantizedRerankCandidates=0` means the normalized `ef_search` candidate set.
 Non-zero values must be at least `TopK`. Returned `quantized_rerank` results are
@@ -54,7 +56,10 @@ the same row.
 Each declared `rabitq_1bit` v1 score plane also rebuilds one TVIS
 vector-index-state asset, with role `quantized_codes`, asset id
 `quantized/<name>/packed_codes`, logical type `packed_bit_vector`, and physical
-encoding `raw_packed_bit_vector`. Its typed-column part stores:
+encoding `raw_packed_bit_vector`. Each declared prototype `brq_1bit` v1 score
+plane uses the same role/logical type/physical encoding with asset id
+`quantized/<name>/brq_1bit/packed_codes` so it cannot be confused with
+`rabitq_1bit` storage. These typed-column parts store:
 
 - `packed_codes`: `quantizedasset.RolePackedCodes` backed by
   `packed_bit_vector` / `raw_packed_bit_vector`, LSB-first with zero high-bit
@@ -62,11 +67,11 @@ encoding `raw_packed_bit_vector`. Its typed-column part stores:
 - `code_count`: `uint32` / `raw_uint32` side array;
 - `quantized_dot_product_inv`: `float32` / `raw_float32` side array.
 
-For RaBitQ, `CodeDimensions=next_power_of_two(VectorDimensions)` and logical code
-bytes per vector are `ceil(CodeDimensions/8)`. The typed-column schema identity
-includes the canonical RaBitQ config hash, and prepare validates the config
-bytes/hash, base graph identity, row count, typed-column schema/ref/checksum,
-packed shape/padding, `code_count`, and positive finite
+For RaBitQ and BRQ, `CodeDimensions=next_power_of_two(VectorDimensions)` and
+logical code bytes per vector are `ceil(CodeDimensions/8)`. The typed-column
+schema identity includes the canonical codec config hash and bytes. Prepare
+validates config identity, base graph identity, row count, typed-column
+schema/ref/checksum, packed shape/padding, `code_count`, and positive finite
 `quantized_dot_product_inv` before returning prepared readers.
 
 Typed-column assets also contain part headers, primary-id/sort-key metadata,
@@ -88,24 +93,30 @@ quantized-mode fields so callers do not accidentally depend on no-op options.
 `scalar_u8` v1 `quantized_only` consumes the prepared `codes` reader and scores
 normalized query/candidate code rows. `rabitq_1bit` v1 `quantized_only` consumes
 `packed_codes`, `code_count`, and `quantized_dot_product_inv` and uses the
-weighted sign-dot estimator specified in `rabitq-1bit-v1.md`. For both codecs,
-`quantized_rerank` uses the selected quantized scorer for traversal/candidate
-collection, then exact-scores only the configured shortlist through the
-authoritative float32 vector/norm path and returns final topK in exact cosine
-score order. Search stats report `quantized_score_calls`,
+weighted sign-dot estimator specified in `rabitq-1bit-v1.md`. Prototype
+`brq_1bit` v1 consumes the same side arrays but uses the `uint4` runtime query
+bit-product estimator. This `brq_1bit` v1 prototype uses the score label
+`brq_1bit_estimated_cosine_q4` specified
+in `brq-1bit-v1.md`; its stats include
+`quantized_score_codec_brq_1bit/search=1`, `brq_1bit_query_weight_bits/search`,
+`brq_1bit_bitproduct_passes/search`, and `brq_1bit_query_weight_scale/search`.
+For all codecs, `quantized_rerank` uses the selected quantized scorer for
+traversal/candidate collection, then exact-scores only the configured shortlist
+through the authoritative float32 vector/norm path and returns final topK in
+exact cosine score order. Search stats report `quantized_score_calls`,
 `quantized_code_B/search`, route counters, and
 `quantized_rerank_exact_score_calls/search` for rerank.
 
 ## Benchmark and storage evidence
 
-The permanent #1926/#2454 evidence harness compares exact, `scalar_u8`, and
-pure-Go `rabitq_1bit` rows on deterministic fixtures and separately reports
-rebuild/storage overhead:
+The permanent #1926/#2454/#2481 evidence harness compares exact, `scalar_u8`,
+pure-Go `rabitq_1bit`, and prototype lower-level `brq_1bit` rows on
+deterministic fixtures and separately reports rebuild/storage overhead:
 
 ```sh
 GOMAXPROCS=8 GOWORK=off go test ./TreeDB/collections \
   -run '^$' \
-  -bench '^(BenchmarkColumnGraphScalarU8QuantizedScorePlanes1926|BenchmarkVectorIndexSearcherColumnGraphScalarU8QuantizedSearchWithBuffer2414|BenchmarkVectorIndexSearcherColumnGraphRabitQQuantizedSearchWithBuffer2451|BenchmarkCollectionSearchVectorIndexWithBufferColumnGraphScalarU8Quantized2415|BenchmarkCollectionSearchVectorIndexWithBufferColumnGraphRabitQQuantized2452|BenchmarkColumnGraphScalarU8QuantizedRebuildStorage1926|BenchmarkColumnGraphRabitQQuantizedRebuildStorage2450)$' \
+  -bench '^(BenchmarkColumnGraphScalarU8QuantizedScorePlanes1926|BenchmarkVectorIndexSearcherColumnGraphScalarU8QuantizedSearchWithBuffer2414|BenchmarkVectorIndexSearcherColumnGraphRabitQQuantizedSearchWithBuffer2451|BenchmarkVectorIndexSearcherColumnGraphBRQQuantizedSearchWithBuffer2481|BenchmarkCollectionSearchVectorIndexWithBufferColumnGraphScalarU8Quantized2415|BenchmarkCollectionSearchVectorIndexWithBufferColumnGraphRabitQQuantized2452|BenchmarkColumnGraphScalarU8QuantizedRebuildStorage1926|BenchmarkColumnGraphRabitQQuantizedRebuildStorage2450|BenchmarkColumnGraphBRQQuantizedRebuildStorage2481)$' \
   -benchmem -benchtime=100x -count=3
 ```
 
@@ -114,12 +125,15 @@ per-query rows; `BenchmarkVectorIndexSearcherColumnGraphScalarU8QuantizedSearchW
 emits explicit lower-level buffered scalar_u8 rows;
 `BenchmarkVectorIndexSearcherColumnGraphRabitQQuantizedSearchWithBuffer2451`
 emits explicit lower-level buffered RaBitQ rows;
+`BenchmarkVectorIndexSearcherColumnGraphBRQQuantizedSearchWithBuffer2481`
+emits prototype lower-level buffered BRQ rows;
 `BenchmarkCollectionSearchVectorIndexWithBufferColumnGraphScalarU8Quantized2415`
 emits collection-level buffered scalar_u8 rows;
 `BenchmarkCollectionSearchVectorIndexWithBufferColumnGraphRabitQQuantized2452`
 emits collection-level buffered RaBitQ rows; and rebuild/storage rows are emitted
-by `BenchmarkColumnGraphScalarU8QuantizedRebuildStorage1926` plus
-`BenchmarkColumnGraphRabitQQuantizedRebuildStorage2450`.
+by `BenchmarkColumnGraphScalarU8QuantizedRebuildStorage1926`,
+`BenchmarkColumnGraphRabitQQuantizedRebuildStorage2450`, and
+`BenchmarkColumnGraphBRQQuantizedRebuildStorage2481`.
 
 The buffered benchmark families include `route=quantized_only/c=1`,
 `route=quantized_only/c=8`, `route=quantized_rerank/candidates=32/c=1`, and
@@ -135,14 +149,23 @@ fixture, `search_route_quantized_only/search`,
 cost, total graph/vector-index-state storage, quantized asset bytes, and
 quantized asset bytes/vector.
 
-Representative #2454 evidence on Apple M3 / darwin arm64 / Go `go1.26.0` is
-recorded in `rabitq-closeout-2454.md`. That run shows `0 B/op`, `0 allocs/op`,
-100% fixture recall, fail-closed/route counters, no exact vector/norm reads for
+Representative #2454/#2482/#2487 evidence on Apple M3 / darwin arm64 / Go
+`go1.26.0` is recorded in `rabitq-closeout-2454.md`,
+`rabitq-performance-lane-closeout-2482.md`, and
+`vector-search-closeout-2483.md`. Those runs show `0 B/op`, `0 allocs/op`, 100%
+fixture recall, fail-closed/route counters, no exact vector/norm reads for
 `quantized_only`, exact shortlist reads for `quantized_rerank`, and much smaller
 RaBitQ code bytes (`16` logical B/vector on 128 dims) than scalar_u8 (`128`
-logical B/vector). It also shows that the current pure-Go RaBitQ weighted scorer
-is slower than exact FP32 and scalar_u8 on that fixture; this evidence does
+logical B/vector). They also show that the current pure-Go RaBitQ weighted
+scorer is slower than scalar_u8 on the checked fixture; this evidence does
 **not** claim a current speedup or universal replacement.
+
+Representative #2507 BRQ prototype evidence is in
+`/tmp/2481_runtime_bench_20260606_165236` and summarized in
+`vector-search-closeout-2483.md`. It shows lower-level BRQ `quantized_only` and
+`quantized_rerank` rows with `0 B/op`, `0 allocs/op`, expected BRQ counters,
+16 logical code B/vector, and about 74.47 quantized asset B/vector in its rebuild
+shape. This is prototype evidence, not a promotion or crossover claim.
 
 ## Acceleration and future work boundaries
 
@@ -156,14 +179,17 @@ scorer. The #2477 query-byte-table scorer is the promoted semantics-preserving
 it does not change storage, bit order, score formula, codec/asset identity, or fail-closed behavior. Do not report an accelerated RaBitQ row unless a future
 issue lands one with parity tests, same-fixture benchmarks, and profiles.
 
-Future quantization work should be separate from this scalar/RaBitQ closeout:
+Future quantization work should be separate from this scalar/RaBitQ/BRQ closeout.
+BRQ keeps an explicit query `uint4` score label and must not be folded into
+RaBitQ evidence.
 
-- [`brq-1bit-v1.md`](brq-1bit-v1.md) is the selected #2480 future-codec
-  contract for a bit-product `brq_1bit` v1 prototype. It uses a new codec
-  identity/version, explicit query `uint4` score label, validation plan, and
-  promotion gates; it is not current behavior until #2481 lands support.
-- PQ/OPQ/residual-PQ codecs and other packed popcount scorers still need their
-  own codec specs, tests, recall sweeps, and benchmark gates.
+- [`brq-1bit-v1.md`](brq-1bit-v1.md) is the selected #2480 codec contract and
+  #2507 lower-level prototype for bit-product `brq_1bit` v1. Promotion beyond
+  prototype status still needs future scale-sensitive same-host/crossover
+  evidence, especially #2494.
+- PQ/OPQ/residual-PQ codecs, multi-bit BRQ variants, and other packed popcount
+  scorers still need their own codec specs, tests, recall sweeps, and benchmark
+  gates.
 - Batch scorer kernels, SIMD/popcount integration, graph control-flow changes,
   block-planner/windowing changes, and traversal scheduling changes are not part
   of #1926/#2454 acceptance. They must not be smuggled into quantized docs or

--- a/TreeDB/docs/spec/rabitq-1bit-v1.md
+++ b/TreeDB/docs/spec/rabitq-1bit-v1.md
@@ -206,9 +206,9 @@ recorded in
 - No changes to exact/default FP32 search or `scalar_u8` score-plane behavior.
 - No go-highway accelerated RaBitQ backend landed in this stack; #2453 is
   no-land/not-planned for the current weighted scorer and durable asset shape.
-- No multi-bit RaBitQ, BRQ bit-product, PQ/OPQ, IVF, or graph topology changes;
-  the future `brq_1bit` v1 candidate is specified separately in
-  [`brq-1bit-v1.md`](brq-1bit-v1.md) under a new codec identity/version.
+- No multi-bit RaBitQ, BRQ bit-product, PQ/OPQ, IVF, or graph topology changes
+  are part of `rabitq_1bit` v1; the separate `brq_1bit` v1 contract/prototype is
+  specified in [`brq-1bit-v1.md`](brq-1bit-v1.md) under a new codec identity/version.
 - No dependency on CockroachDB, Antfly, AGPL, cgo, or production go-highway code.
 - No claim that RaBitQ universally replaces exact FP32 or scalar_u8.
 

--- a/TreeDB/docs/spec/rabitq-performance-lane-closeout-2482.md
+++ b/TreeDB/docs/spec/rabitq-performance-lane-closeout-2482.md
@@ -2,10 +2,11 @@
 
 Status: pre-alpha closeout for the #2475 RaBitQ performance lane. This note
 closes **Sublane A**, the `rabitq_1bit` v1 performance sweep, including the
-semantics-preserving #2477 query-byte-table scorer evidence, and records that
-**Sublane B** remains deferred to open follow-ups #2480 and #2481. It is a
-benchmark/evidence boundary, not a runtime feature change and not a claim that
-RaBitQ universally replaces exact FP32 or `scalar_u8`.
+semantics-preserving #2477 query-byte-table scorer evidence. At the original
+#2482 closeout, **Sublane B** was deferred; it has since completed through #2480
+and #2481 with a separate `brq_1bit` v1 contract/prototype. This file remains a
+benchmark/evidence boundary, not a claim that RaBitQ universally replaces exact
+FP32 or `scalar_u8`.
 
 ## Scope and hard invariants
 
@@ -36,12 +37,12 @@ fallback behavior.
 | #2477 | Merged in PR #2485 | merge `77d9f371832f2dbb51c02084f8c1876118eeca06`; final baseline `/tmp/gomap_2477_final2_baseline_main_435a1c06_20260606_112457`; final candidate `/tmp/gomap_2477_final2_candidate_17857e779_20260606_112935`; scalar interleaved guardrail `/tmp/gomap_2477_interleaved_scalar_lower_qonly_c8_20260606_114454` | Promoted the query byte-table scorer with strong same-host RaBitQ wins and unchanged allocation/recall/exact-read/route/fallback counters. |
 | #2478 | Closed no-entry / no-promote | <https://github.com/snissn/gomap/issues/2478#issuecomment-4640631624> | Post-#2477 profiles did not show packed-code reader/stride/bounds/accessor overhead as a material bottleneck, so no code PR or AI review was opened. |
 | #2479 | Closed skipped / no-promote | <https://github.com/snissn/gomap/issues/2479#issuecomment-4640644622> | Post-#2477/#2478 evidence did not show a credible batching/windowing opportunity, so no experiment branch, code PR, or AI review was opened. |
-| #2480 | Open / deferred | <https://github.com/snissn/gomap/issues/2480> | Future codec design/spec gate. No future codec has been selected yet. |
-| #2481 | Open / hard-blocked | <https://github.com/snissn/gomap/issues/2481> | Future codec prototype. It must not start until #2480 selects an explicit codec contract. |
+| #2480 | Merged in PR #2488 | merge `206a8fb3e5243de1b094e52746907771fee640ed`; spec [`brq-1bit-v1.md`](brq-1bit-v1.md) | Selected the separate `brq_1bit` v1 future-codec contract. It does not reinterpret `rabitq_1bit` v1. |
+| #2481 | Completed via PR #2489 and PR #2507 | #2489 merge `f2016198b8d00824021b8e05420f1e939f751df7`; #2507 merge `8e7377cc995ffc928ac99a42ed8aec769f8f72fb`; BRQ artifacts `/tmp/2481_runtime_bench_20260606_165236` | Added BRQ oracle goldens, then lower-level BRQ asset/search runtime. This is prototype evidence, not a RaBitQ Sublane A promotion claim. |
 
-#2482 can close when this closeout is merged because it records Sublane A's
-promoted and no-promote outcomes and reports Sublane B accurately as deferred.
-The parent tracker #2475 may remain open for #2480/#2481.
+#2482 closed when this closeout was merged because it recorded Sublane A's
+promoted and no-promote outcomes. #2483 later reconciled Sublane B completion in
+[`vector-search-closeout-2483.md`](vector-search-closeout-2483.md).
 
 ## Evidence boundary
 
@@ -166,12 +167,14 @@ The runbook labels this as smoke/shape evidence only. Representative medians:
 
 ## Future work status
 
-Sublane B is not complete in this closeout. #2480 is open as the future
-RaBitQ/BRQ codec design/spec gate. #2481 is open and hard-blocked on #2480; it
-must not implement assets or search until #2480 selects an explicit codec name,
-version, storage shape, score semantics, oracle tests, recall gates, benchmark
-matrix, and fail-closed validation plan.
+Sublane B is complete for design/prototype purposes: #2480 selected the
+`brq_1bit` v1 contract and #2481 landed oracle plus lower-level runtime support.
+BRQ remains a separate prototype route with its own evidence and counters; it is
+not part of the #2477 RaBitQ promotion and not a universal speedup claim. Future
+scale-sensitive positioning should consume #2494 crossover synthesis when it is
+available.
 
-Any future estimator, popcount/BRQ shape, or multi-bit RaBitQ variant that
-differs from `rabitq_1bit` v1 must use a new codec identity/version. It must not
-reinterpret `rabitq_1bit` v1 storage, bit order, or score semantics for speed.
+Any future estimator, popcount/BRQ shape beyond v1, or multi-bit RaBitQ variant
+that differs from `rabitq_1bit` v1 must use a new codec identity/version. It
+must not reinterpret `rabitq_1bit` v1 storage, bit order, or score semantics for
+speed.

--- a/TreeDB/docs/spec/storage-format.md
+++ b/TreeDB/docs/spec/storage-format.md
@@ -734,9 +734,10 @@ over `raw_bytes_offsets`), and quantized code assets (`quantized_codes` role).
 Declared scalar_u8 score planes use `byte_vector` over `raw_fixed_bytes` with
 asset IDs `quantized/<name>/codes`. Declared `rabitq_1bit` v1 score planes use
 `packed_bit_vector` over `raw_packed_bit_vector` with asset IDs
-`quantized/<name>/packed_codes`; their typed-column part contains the
-`packed_codes`, `code_count`, and `quantized_dot_product_inv` roles described in
-`quantized-vector-index.md` and `rabitq-1bit-v1.md`. The active manifest
+`quantized/<name>/packed_codes`; prototype `brq_1bit` v1 score planes use asset
+IDs `quantized/<name>/brq_1bit/packed_codes`. Their typed-column parts contain
+the `packed_codes`, `code_count`, and `quantized_dot_product_inv` roles described
+in `quantized-vector-index.md`, `rabitq-1bit-v1.md`, and `brq-1bit-v1.md`. The active manifest
 checksum includes the control record, but the record's base checksum excludes
 vector-index derived records so stale-state checks compare against authoritative
 collection data. See `vector-index-state-manifest.md` and
@@ -1162,9 +1163,11 @@ returned document IDs, and declared quantized code score planes as vector-index
 state assets, and records vector-index control identity in the `TVIS` state
 record. Quantized assets use role `quantized_codes`; scalar_u8 assets use asset
 ids `quantized/<name>/codes` with `byte_vector` / `raw_fixed_bytes`, while
-`rabitq_1bit` v1 assets use asset ids `quantized/<name>/packed_codes` with
-`packed_bit_vector` / `raw_packed_bit_vector`. Query modes that select
-quantized assets fail closed when matching state is absent or stale. Old
+`rabitq_1bit` v1 assets use asset ids `quantized/<name>/packed_codes` and
+prototype `brq_1bit` v1 assets use asset ids
+`quantized/<name>/brq_1bit/packed_codes` with `packed_bit_vector` /
+`raw_packed_bit_vector`. Query modes that select quantized assets fail closed
+when matching state is absent or stale. Old
 adjacency-source refs are `#1989-quarantined` compatibility. Current graph
 manifests may still contain row graph refs and legacy layer-source trailer refs
 for compatibility; new derived-state refs belong in vector-index state. Replay

--- a/TreeDB/docs/spec/vector-search-closeout-2483.md
+++ b/TreeDB/docs/spec/vector-search-closeout-2483.md
@@ -1,0 +1,122 @@
+# TreeDB vector search closeout guidance (#2483)
+
+Status: pre-alpha documentation closeout for the accepted exact FP32,
+`scalar_u8`, `rabitq_1bit`, and `brq_1bit` work through #2507. This page is an
+evidence index and route-boundary guide. It is not a claim that one route is a
+universal replacement for another, and it is not a USearch parity claim. #2494
+crossover evidence is pending.
+
+## Dependency status
+
+| Lane | Status for docs | Evidence boundary |
+| --- | --- | --- |
+| Exact FP32 #2445 | Closed no-promote; PR #2457 was closed unmerged. | Do not publish #2457 speedups. Keep the prior exact interpretation: remaining c=8 gaps are traversal/scoring/frontier work, not setup/materialization/allocation. |
+| Quantized `scalar_u8` #2446/#2460-#2465 | Closed. #2456 and #2466 merged; #2460-#2464 are no-promote. | Use #2456/#2466 plus the #2487 current-main snapshot. Do not use no-promote candidate numbers as wins. |
+| RaBitQ Sublane A #2475/#2476-#2479/#2482 | Closed. #2484, #2485, and #2486 merged; #2478/#2479 are no-promote. | `rabitq_1bit` v1 is current behavior. Use #2477/#2482 and #2487 evidence, with route/counter caveats. |
+| Sublane B #2480/#2481 | Completed as design plus prototype. #2488 selected `brq_1bit` v1, #2489 added oracle goldens, and #2507 added lower-level BRQ asset/search runtime. | Treat BRQ as prototype evidence. It is not part of the #2487 current-main snapshot and has no promotion/crossover claim. |
+| Unified current-main snapshot #2487 | Complete. | Artifact root `/tmp/gomap_2487_unified_snapshot_20260606_135941`; commit `32e143240dbffb24172e0ec91c5565ea7c84328a`; noisy/moderate Apple M3 host. |
+| Crossover campaign #2490-#2494 | Pending. | Final scale-sensitive positioning versus exact FP32, quantized routes, USearch, and pgvector should consume #2494 when it lands or explicitly state that crossover evidence is pending. |
+
+## Route boundary summary
+
+- Exact/default mode uses authoritative `float32_vector` scoring and, for the
+  current high-QPS no-document fast path, the prepared `hnsw_search_pack_v1`
+  route. Keep exact route claims separate from quantized route claims.
+- `scalar_u8` and `rabitq_1bit` are supported quantized score planes for
+  `quantized_only` and `quantized_rerank`, including collection-level buffered
+  rows. `quantized_only` must report zero exact vector/norm reads;
+  `quantized_rerank` exact-reads only the configured shortlist.
+- `brq_1bit` v1 is the selected #2480 bit-product codec contract and #2507
+  lower-level prototype. It uses a new codec identity, `uint4` runtime query
+  bit-products, and score label `brq_1bit_estimated_cosine_q4`. Do not
+  reinterpret `rabitq_1bit` rows as BRQ rows, and do not promote BRQ as faster
+  without a future same-host/crossover gate.
+- Buffered no-document APIs target caller-owned result storage. Response-owned
+  `SearchVectorIndex` convenience rows can be healthy while still allocating
+  response result/ID storage.
+- With-document materialization, projections, filters, and split fetch are
+  separate measurement boundaries.
+
+## #2487 unified current-main snapshot
+
+The #2487 unified current-main snapshot is suitable for docs as absolute current-main rows with host
+load caveats. It intentionally excludes no-promote/draft candidates (#2457,
+#2460-#2464, #2478, #2479) and does not include BRQ Sublane B.
+
+### Exact FP32 no-document rows
+
+Fixture: 10,000 docs, 64 dims, M=16, efConstruction=128, efSearch=128, topK=10,
+16-query stream, `BENCHTIME=1000x`, `COUNT=3`, `CPU_LIST=1,8`.
+
+| Row | c | ns/op | ops/sec | B/op | allocs/op | Boundary |
+| --- | ---: | ---: | ---: | ---: | ---: | --- |
+| `TreeDB_SearchWithBuffer` | 1 | 45,333 | 22,059 | 0 | 0 | reusable exact searcher, caller-owned buffer |
+| `TreeDB_SearchWithBufferParallel` | 8 | 14,525 | 68,845 | 3 | 0 | reusable exact parallel row; nonzero B/op caveated in #2487 |
+| `TreeDB_CollectionSearchVectorIndexWithBuffer` | 1 | 44,058 | 22,697 | 0 | 0 | collection buffered exact no-doc |
+| `TreeDB_CollectionSearchVectorIndexWithBuffer` | 8 | 74,075 | 13,500 | 0 | 0 | collection buffered exact no-doc, serial row at GOMAXPROCS=8 |
+| `TreeDB_CollectionSearchVectorIndexNoDocsOneShot` | 1 | 43,889 | 22,785 | 816 | 2 | response-owned no-doc convenience |
+| `TreeDB_CollectionSearchVectorIndexNoDocsOneShot` | 8 | 49,471 | 20,214 | 816 | 2 | response-owned no-doc convenience |
+| `USearch_Search` | 1 | 33,716 | 29,659 | 136 | 3 | pure in-memory external control |
+| `USearch_SearchParallel` | 8 | 12,106 | 82,601 | 138 | 3 | pure in-memory external control |
+
+Healthy exact rows reported `search_route_hnsw_search_pack/search=1`,
+`docs_fetched/search=0`, no graph/vector/scratch fallbacks, and no document
+bytes. The USearch rows are controls, not persistent TreeDB storage.
+
+### `scalar_u8` quantized rows
+
+Fixture: 1,024 rows, 128 dims, topK=10, efSearch=128, query ordinal 37,
+`BENCHTIME=100000x`, `TIMING_COUNT=5`, `GOMAXPROCS=8`.
+
+| Row | ns/op | ops/sec | B/op | allocs/op | recall@K | code B/vector | asset B/vector | exact reads/calls |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| lower `quantized_only`, c=1 | 9,800 | 102,038 | 0 | 0 | 100% | 128 | 169.7 | vector/norm `0/0`, exact calls `0` |
+| lower `quantized_only`, c=8 | 2,762 | 362,100 | 0 | 0 | 100% | 128 | 169.7 | vector/norm `0/0`, exact calls `0` |
+| lower `quantized_rerank`, c=1 | 11,417 | 87,588 | 0 | 0 | 100% | 128 | 169.7 | vector/norm `16,384/128`, exact calls `32` |
+| lower `quantized_rerank`, c=8 | 3,116 | 320,907 | 0 | 0 | 100% | 128 | 169.7 | vector/norm `16,384/128`, exact calls `32` |
+| collection `quantized_only`, c=1 | 11,291 | 88,569 | 0 | 0 | 100% | 128 | 169.7 | vector/norm `0/0`, exact calls `0` |
+| collection `quantized_only`, c=8 | 3,288 | 304,117 | 0 | 0 | 100% | 128 | 169.7 | vector/norm `0/0`, exact calls `0` |
+| collection `quantized_rerank`, c=1 | 11,621 | 86,054 | 0 | 0 | 100% | 128 | 169.7 | vector/norm `16,384/128`, exact calls `32` |
+| collection `quantized_rerank`, c=8 | 4,025 | 248,455 | 0 | 0 | 100% | 128 | 169.7 | vector/norm `16,384/128`, exact calls `32` |
+
+### `rabitq_1bit` quantized rows
+
+Same quantized fixture as above.
+
+| Row | ns/op | ops/sec | B/op | allocs/op | recall@K | code B/vector | asset B/vector | exact reads/calls |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| lower `quantized_only`, c=1 | 17,463 | 57,264 | 0 | 0 | 100% | 16 | 66.62 | vector/norm `0/0`, exact calls `0` |
+| lower `quantized_only`, c=8 | 4,752 | 210,433 | 0 | 0 | 100% | 16 | 66.62 | vector/norm `0/0`, exact calls `0` |
+| lower `quantized_rerank`, c=1 | 19,013 | 52,595 | 0 | 0 | 100% | 16 | 66.62 | vector/norm `16,384/128`, exact calls `32` |
+| lower `quantized_rerank`, c=8 | 4,931 | 202,779 | 0 | 0 | 100% | 16 | 66.62 | vector/norm `16,384/128`, exact calls `32` |
+| collection `quantized_only`, c=1 | 18,862 | 53,016 | 0 | 0 | 100% | 16 | 66.62 | vector/norm `0/0`, exact calls `0` |
+| collection `quantized_only`, c=8 | 5,038 | 198,494 | 0 | 0 | 100% | 16 | 66.62 | vector/norm `0/0`, exact calls `0` |
+| collection `quantized_rerank`, c=1 | 20,731 | 48,236 | 0 | 0 | 100% | 16 | 66.62 | vector/norm `16,384/128`, exact calls `32` |
+| collection `quantized_rerank`, c=8 | 6,251 | 159,982 | 0 | 0 | 100% | 16 | 66.62 | vector/norm `16,384/128`, exact calls `32` |
+
+## BRQ prototype evidence (#2507)
+
+#2507 adds `brq_1bit` v1 lower-level quantized asset/search runtime. Its local
+artifact root is `/tmp/2481_runtime_bench_20260606_165236`. The benchmark matrix
+used a 1,024-row / 128-dim synthetic shape with `BENCHTIME=100000x`, `count=5`
+for search and `BENCHTIME=100x`, `count=5` for rebuild/storage.
+
+| BRQ row | median ns/op | ops/sec | B/op | allocs/op | recall@K | exact reads/calls | BRQ counters |
+| --- | ---: | ---: | ---: | ---: | ---: | --- | --- |
+| lower `quantized_only`, c=1 | 20,671 | 48,377 | 0 | 0 | 100% | vector/norm `0/0`, exact calls `0` | `quantized_score_codec_brq_1bit/search=1`, `brq_1bit_bitproduct_passes/search=338` |
+| lower `quantized_only`, c=8 | 4,841 | 206,585 | 0 | 0 | 100% | vector/norm `0/0`, exact calls `0` | same |
+| lower `quantized_rerank`, c=1 | 21,236 | 47,089 | 0 | 0 | 100% | vector/norm `16,384/128`, exact calls `32` | same |
+| lower `quantized_rerank`, c=8 | 5,581 | 179,172 | 0 | 0 | 100% | vector/norm `16,384/128`, exact calls `32` | same |
+
+BRQ reports 16 logical code bytes/vector and about 74.47 quantized asset
+bytes/vector in the 256-row rebuild/storage shape. Existing scalar_u8/RaBitQ
+rows showed no same-host regression in the #2507 spot check, but the BRQ row is
+prototype evidence only.
+
+## Required evidence for future claims
+
+Any future PR or doc update that changes route guidance must report the command,
+commit, fixture, hardware/context, `ns/op`, `ops/sec`, `B/op`, `allocs/op`,
+route/fallback counters, recall, code/asset bytes, and exact-read/rerank bounds.
+Material speedup or crossover claims require same-host before/after evidence and
+must consume #2494 once that synthesis is available.

--- a/TreeDB/docs/spec/verification.md
+++ b/TreeDB/docs/spec/verification.md
@@ -929,9 +929,9 @@ Coverage:
 Invariant:
 - Exact/default `column_graph` search remains authoritative float32-vector
   scoring unless callers explicitly select a named quantized score plane.
-- `quantized_only` returns estimated scalar_u8 or pure-Go `rabitq_1bit` scores
-  from the selected named score plane and must not read exact vectors or norms
-  during scoring.
+- `quantized_only` returns estimated scalar_u8, pure-Go `rabitq_1bit`, or
+  prototype `brq_1bit` scores from the selected named score plane and must not
+  read exact vectors or norms during scoring.
 - `quantized_rerank` uses the selected quantized traversal over the normalized
   `ef_search` candidate pool, trims to `QuantizedRerankCandidates`, exact-reranks
   only that shortlist by graph ordinal, and returns exact cosine scores.
@@ -951,6 +951,10 @@ Coverage:
     lower-level and collection buffered quantized search, exact-read guardrails,
     cache/lifecycle behavior, allocation guardrails, and fail-closed asset
     validation.
+  - `TreeDB/collections/column_vector_graph_brq_quantized_asset_test.go` covers
+    `brq_1bit` definition normalization, asset build/prepare/reopen, oracle
+    parity, lower-level buffered quantized search, exact-read guardrails,
+    allocation guardrails, BRQ counters, and fail-closed asset validation.
   - `TreeDB/collections/vector_index_search_test.go` covers public exact,
     quantized_only, quantized_rerank, searcher buffer, and missing-name behavior.
   - `TreeDB/internal/quantizedasset/quantized_asset_test.go` covers prepared
@@ -969,6 +973,11 @@ Coverage:
     RaBitQ lower-level/collection buffered search, c=1/c=8 concurrency rows,
     logical code bytes/vector, actual asset bytes/vector, exact-read counters,
     recall@K, and storage overhead for #2454 closeout.
+  - `BenchmarkVectorIndexSearcherColumnGraphBRQQuantizedSearchWithBuffer2481`
+    and `BenchmarkColumnGraphBRQQuantizedRebuildStorage2481` report prototype
+    BRQ lower-level buffered search, BRQ-specific counters, exact-read
+    guardrails, logical code bytes/vector, asset bytes/vector, recall@K, and
+    rebuild/storage overhead.
 
 ## 13. Native Wire Protocol
 

--- a/TreeDB/docs/vector_high_qps_collection_api_test.go
+++ b/TreeDB/docs/vector_high_qps_collection_api_test.go
@@ -37,11 +37,13 @@ func TestDocs_VectorHighQPSCollectionAPIGuide2406(t *testing.T) {
 		"## Do not overclaim",
 		"Apple M3",
 		"`darwin/arm64`",
-		"`2feb1f0e35459d1b3d044008203d0c8afcf5630f`",
+		"`32e143240dbffb24172e0ec91c5565ea7c84328a`",
 		"With-document search is a different materialization path",
 		"Filters, projections, debug-only stats, and quantized modes are outside",
-		"Collection-level buffered quantized search support is unavailable/planned",
-		"#2410 owns the full benchmark snapshot and counter workflow",
+		"Collection-level buffered quantized serving for supported score planes",
+		"Quantized collection buffered search is supported as a separate route state",
+		"vector-search-closeout-2483.md",
+		"#2494 crossover synthesis",
 	} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("%s missing #2406 high-QPS API guidance %q", guidePath, want)
@@ -52,7 +54,7 @@ func TestDocs_VectorHighQPSCollectionAPIGuide2406(t *testing.T) {
 		"TreeDB beats USearch",
 		"TreeDB is faster than USearch",
 		"Collection.SearchVectorIndex` is the zero-allocation target",
-		"Collection-level buffered quantized search is supported",
+		"Collection-level buffered quantized search support is unavailable/planned",
 	} {
 		if strings.Contains(text, forbidden) {
 			t.Fatalf("%s contains overclaim %q", guidePath, forbidden)

--- a/docs/README.md
+++ b/docs/README.md
@@ -54,7 +54,8 @@ Behavioral guarantees for downstream systems (e.g., replication layers).
 - **[TreeDB Quantized Buffered Per-Row Profiling](benchmarks/treedb_quantized_buffered_profile_runbook.md)**: Isolated quantized search profile rows for downstream optimization gates.
 - **[TreeDB `rabitq_1bit` Profile Gate](benchmarks/treedb_rabitq_1bit_profile_gate.md)**: Same-host RaBitQ baseline/candidate workflow, guardrails, profile artifacts, and no-promote rules.
 - **[TreeDB Vector Crossover Benchmark Runbook](benchmarks/treedb_vector_crossover_runbook.md)**: Scale-matrix command contract for exact FP32, scalar_u8, RaBitQ, USearch, and pgvector crossover evidence.
-- **[TreeDB RaBitQ Performance Lane Closeout](../TreeDB/docs/spec/rabitq-performance-lane-closeout-2482.md)**: Final Sublane A promoted/no-promote evidence and deferred Sublane B status for the RaBitQ performance lane.
+- **[TreeDB RaBitQ Performance Lane Closeout](../TreeDB/docs/spec/rabitq-performance-lane-closeout-2482.md)**: Final Sublane A promoted/no-promote evidence and later Sublane B outcome for the RaBitQ performance lane.
+- **[TreeDB Vector Search Closeout](../TreeDB/docs/spec/vector-search-closeout-2483.md)**: Exact FP32, scalar_u8, RaBitQ, and BRQ route-boundary/evidence index with #2487 snapshot caveats and #2494 crossover-pending status.
 - **[Unified Bench](../cmd/unified_bench/README.md)**: Usage guide for benchmark execution and artifact capture.
 - **[BenchProf](../cmd/benchprof/README.md)**: Analysis tool for CPU/alloc/block/mutex profiles and ops/sec outputs.
 - **[Redis Protocol Benchmarking](REDIS_PROTOCOL_BENCHMARKING.md)**: Preferred way to measure Redis wrapper throughput.


### PR DESCRIPTION
## Summary
- Publishes the #2483 vector-search closeout index for exact FP32, scalar_u8, RaBitQ, and BRQ route boundaries/evidence.
- Updates high-QPS, benchmark workflow, typed-column, quantized, RaBitQ, BRQ, storage-format, and verification docs to reflect #2487 plus merged #2480/#2481 status.
- Keeps no-promote/draft rows out of promotion claims and records that #2494 crossover synthesis is still pending.

## Dependency gates
| Gate | Status |
| --- | --- |
| #2445 exact sweep | Closed no-promote; no #2457 speedup claim. |
| #2446/#2460-#2465 quantized cleanup | Closed; no-promote candidates excluded. |
| #2475 Sublane A | Closed; #2476/#2477/#2482 merged, #2478/#2479 no-promote. |
| #2487 snapshot | Complete; artifact `/tmp/gomap_2487_unified_snapshot_20260606_135941`. |
| #2480/#2481 Sublane B | Complete: #2488, #2489, #2507 merged. |
| #2490-#2494 crossover | Pending; docs explicitly caveat final crossover positioning. |

## Evidence sources
- #2487 unified snapshot: `/tmp/gomap_2487_unified_snapshot_20260606_135941/summary.md`
- #2481/#2507 BRQ prototype artifacts: `/tmp/2481_runtime_bench_20260606_165236`
- RaBitQ lane closeout docs/artifacts already indexed in `rabitq-performance-lane-closeout-2482.md`.

## Tests
- `GOWORK=off go test ./TreeDB/docs -count=1` ✅
- `git diff --check` ✅

## Caveats
- No USearch parity/general ranking claim.
- Exact FP32, scalar_u8, `rabitq_1bit`, and prototype `brq_1bit` remain separate route states.
- BRQ is documented as lower-level prototype evidence, not a promoted speedup.

Closes #2483.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added vector-search closeout guidance documenting supported exact FP32, scalar_u8, rabitq_1bit, and brq_1bit quantized search variants.
  * Updated vector-search guides with clearer quantized scoring mode specifications and benchmark evidence.
  * Enhanced spec documentation covering quantized asset schemas, typed-column storage, and quantized vector index support.
  * Added comprehensive test coverage for new closeout and quantized search documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->