### PR TITLE
Bound retained-vlog live-ID scans

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -5019,8 +5019,9 @@ type backendPointerProjectionIterator interface {
 }
 
 var (
-	errForegroundWritesResumed    = errors.New("cachingdb: foreground writes resumed")
-	errRetainedPruneCloseCanceled = errors.New("cachingdb: retained prune canceled by close")
+	errForegroundWritesResumed         = errors.New("cachingdb: foreground writes resumed")
+	errRetainedPruneCloseCanceled      = errors.New("cachingdb: retained prune canceled by close")
+	errRetainedPruneScanBudgetExceeded = errors.New("cachingdb: retained prune live-ID scan budget exceeded")
 )
 
 func retainedPruneContextErr(ctx context.Context) error {
@@ -5052,17 +5053,18 @@ func (db *DB) retainedPruneLiveIDScanContext(parent context.Context, lastWrite i
 	if parent == nil {
 		parent = context.Background()
 	}
-	var timeoutCancel context.CancelFunc
-	base := parent
+	ctx, cancelCause := context.WithCancelCause(parent)
+	var timeoutTimer *time.Timer
 	if timeout > 0 {
-		base, timeoutCancel = context.WithTimeout(parent, timeout)
+		timeoutTimer = time.AfterFunc(timeout, func() {
+			cancelCause(errRetainedPruneScanBudgetExceeded)
+		})
 	}
-	ctx, cancelCause := context.WithCancelCause(base)
 	cancel := func() {
-		cancelCause(context.Canceled)
-		if timeoutCancel != nil {
-			timeoutCancel()
+		if timeoutTimer != nil {
+			timeoutTimer.Stop()
 		}
+		cancelCause(context.Canceled)
 	}
 	if db == nil {
 		return ctx, cancel
@@ -5125,6 +5127,10 @@ func (db *DB) observeRetainedPruneAbortError(out *retainedValueLogPruneStats, er
 		out.AbortedForegroundWrites = true
 		return true
 	}
+	if errors.Is(err, errRetainedPruneScanBudgetExceeded) {
+		out.AbortedScanBudget = true
+		return true
+	}
 	return false
 }
 
@@ -5161,6 +5167,7 @@ const (
 	retainedPruneStatusNoCandidates
 	retainedPruneStatusForegroundAbort
 	retainedPruneStatusCloseAbort
+	retainedPruneStatusBudgetAbort
 	retainedPruneStatusError
 )
 
@@ -5176,6 +5183,8 @@ func retainedPruneStatusString(status uint32) string {
 		return "foreground_abort"
 	case retainedPruneStatusCloseAbort:
 		return "close_abort"
+	case retainedPruneStatusBudgetAbort:
+		return "budget_abort"
 	case retainedPruneStatusError:
 		return "error"
 	default:
@@ -5226,6 +5235,10 @@ func (db *DB) collectValueLogLiveIDsUntilWithStats(lastWrite int64, scanStats *v
 }
 
 func (db *DB) collectValueLogLiveIDsUntilWithContext(ctx context.Context, lastWrite int64, scanStats *valueLogLiveIDScanStats) (map[uint32]struct{}, error) {
+	return db.collectValueLogLiveIDsUntilWithContextAndTimeout(ctx, lastWrite, scanStats, 0)
+}
+
+func (db *DB) collectValueLogLiveIDsUntilWithContextAndTimeout(ctx context.Context, lastWrite int64, scanStats *valueLogLiveIDScanStats, timeout time.Duration) (map[uint32]struct{}, error) {
 	if db == nil || !db.valueLogEnabled() {
 		return make(map[uint32]struct{}), nil
 	}
@@ -5237,7 +5250,7 @@ func (db *DB) collectValueLogLiveIDsUntilWithContext(ctx context.Context, lastWr
 			return nil, err
 		}
 	}
-	ctx, cancel := db.retainedPruneLiveIDScanContext(ctx, lastWrite, 0)
+	ctx, cancel := db.retainedPruneLiveIDScanContext(ctx, lastWrite, timeout)
 	defer cancel()
 	live := make(map[uint32]struct{})
 	if snapper, ok := db.backend.(interface{ AcquireSnapshot() *backenddb.Snapshot }); ok {
@@ -5626,9 +5639,14 @@ type retainedValueLogPruneStats struct {
 	ElapsedNanos                       int64
 	AbortedClose                       bool
 	AbortedForegroundWrites            bool
+	AbortedScanBudget                  bool
 	ScanError                          bool
 	RetriedWithoutWriteGate            bool
 	RetrySucceeded                     bool
+}
+
+type retainedValueLogPruneRunOptions struct {
+	fullLiveIDScanBudget time.Duration
 }
 
 func retainedPruneStatusForStats(pruneStats retainedValueLogPruneStats) retainedPruneStatus {
@@ -5637,6 +5655,9 @@ func retainedPruneStatusForStats(pruneStats retainedValueLogPruneStats) retained
 	}
 	if pruneStats.AbortedForegroundWrites {
 		return retainedPruneStatusForegroundAbort
+	}
+	if pruneStats.AbortedScanBudget {
+		return retainedPruneStatusBudgetAbort
 	}
 	if pruneStats.ScanError {
 		return retainedPruneStatusError
@@ -5704,7 +5725,10 @@ func (db *DB) observeRetainedValueLogPruneStats(pruneStats retainedValueLogPrune
 	db.retainedValueLogPruneLastScanOuterLeafRecords.Store(pruneStats.ScanStats.OuterLeafRecords)
 	db.retainedValueLogPruneLastScanOuterLeafBytes.Store(pruneStats.ScanStats.OuterLeafBytes)
 	db.retainedValueLogPruneLastScanNestedValuePointers.Store(pruneStats.ScanStats.NestedValuePointers)
-	if status != retainedPruneStatusForegroundAbort && status != retainedPruneStatusCloseAbort && status != retainedPruneStatusError {
+	if status != retainedPruneStatusForegroundAbort &&
+		status != retainedPruneStatusCloseAbort &&
+		status != retainedPruneStatusBudgetAbort &&
+		status != retainedPruneStatusError {
 		db.retainedValueLogPruneCompletedRuns.Add(1)
 	}
 	if status == retainedPruneStatusError {
@@ -5712,6 +5736,9 @@ func (db *DB) observeRetainedValueLogPruneStats(pruneStats retainedValueLogPrune
 	}
 	if status == retainedPruneStatusCloseAbort {
 		db.retainedValueLogPruneCloseAbortRuns.Add(1)
+	}
+	if status == retainedPruneStatusBudgetAbort {
+		db.retainedValueLogPruneBudgetAbortRuns.Add(1)
 	}
 	if pruneStats.Mode == retainedPruneModeNoCandidates {
 		db.retainedValueLogPruneNoCandidateRuns.Add(1)
@@ -5746,6 +5773,9 @@ func (db *DB) observeRetainedValueLogPruneStats(pruneStats retainedValueLogPrune
 	case retainedPruneStatusCloseAbort:
 		debugEvent = "abort"
 		debugReason = "close"
+	case retainedPruneStatusBudgetAbort:
+		debugEvent = "abort"
+		debugReason = retainedPruneStatusString(uint32(status))
 	case retainedPruneStatusError:
 		debugEvent = "abort"
 		debugReason = retainedPruneStatusString(uint32(status))
@@ -5910,6 +5940,10 @@ func (db *DB) pruneRetainedValueLogsWithObserved(force bool, observedSourceIDs m
 }
 
 func (db *DB) pruneRetainedValueLogsWithObservedContext(ctx context.Context, force bool, observedSourceIDs map[uint32]struct{}) retainedValueLogPruneStats {
+	return db.pruneRetainedValueLogsWithObservedContextOptions(ctx, force, observedSourceIDs, retainedValueLogPruneRunOptions{})
+}
+
+func (db *DB) pruneRetainedValueLogsWithObservedContextOptions(ctx context.Context, force bool, observedSourceIDs map[uint32]struct{}, runOpts retainedValueLogPruneRunOptions) retainedValueLogPruneStats {
 	var out retainedValueLogPruneStats
 	if ctx == nil {
 		ctx = context.Background()
@@ -6124,7 +6158,13 @@ func (db *DB) pruneRetainedValueLogsWithObservedContext(ctx context.Context, for
 	}
 
 	out.Mode = retainedPruneModeFullLiveIDScan
-	liveIDs, err := db.collectValueLogLiveIDsUntilWithContext(ctx, db.lastForegroundWriteUnixNano.Load(), &out.ScanStats)
+	lastWrite := db.lastForegroundWriteUnixNano.Load()
+	liveIDs, err := db.collectValueLogLiveIDsUntilWithContextAndTimeout(
+		ctx,
+		lastWrite,
+		&out.ScanStats,
+		runOpts.fullLiveIDScanBudget,
+	)
 	if err != nil {
 		if db.observeRetainedPruneAbortError(&out, err) {
 			return out
@@ -6304,6 +6344,20 @@ func (db *DB) retainedPrunePressureBytes() int64 {
 		pressure = retainedPrunePressureFloorBytes
 	}
 	return pressure
+}
+
+func (db *DB) retainedPruneBackgroundFullLiveIDScanBudget() time.Duration {
+	if db == nil {
+		return 0
+	}
+	budget := db.retainedPruneFullLiveIDScanBudget
+	if budget < 0 {
+		return 0
+	}
+	if budget == 0 {
+		return retainedPruneDefaultFullLiveIDScanBudget
+	}
+	return budget
 }
 
 func (db *DB) shouldScheduleRetainedValueLogPrune() bool {
@@ -6712,7 +6766,9 @@ func (db *DB) scheduleRetainedValueLogPruneWithForce(force bool) {
 		db.retainedValueLogPruneLastUnixNano.Store(now.UnixNano())
 		observedSourceIDs := db.takeRetainedPruneObservedSourceIDs()
 		db.observeRetainedValueLogPruneStart(effectiveForce, len(observedSourceIDs), false, now)
-		pruneStats := db.pruneRetainedValueLogsWithObservedContext(pruneCtx, effectiveForce, observedSourceIDs)
+		pruneStats := db.pruneRetainedValueLogsWithObservedContextOptions(pruneCtx, effectiveForce, observedSourceIDs, retainedValueLogPruneRunOptions{
+			fullLiveIDScanBudget: db.retainedPruneBackgroundFullLiveIDScanBudget(),
+		})
 		pruneStats.ElapsedNanos = time.Since(now).Nanoseconds()
 		db.observeRetainedValueLogPruneStats(pruneStats)
 		if len(observedSourceIDs) > 0 && (pruneStats.ObservedSourceZombieMarkedSegments > 0 || pruneStats.ObservedSourceRemovedSegments > 0) {
@@ -7793,6 +7849,7 @@ type DB struct {
 	retainedValueLogPruneErrorRuns                               atomic.Uint64
 	retainedValueLogPruneCloseAbortRuns                          atomic.Uint64
 	retainedValueLogPruneForegroundAbortRuns                     atomic.Uint64
+	retainedValueLogPruneBudgetAbortRuns                         atomic.Uint64
 	retainedValueLogPruneLastScanRecords                         atomic.Int64
 	retainedValueLogPruneLastScanValuePointerRecords             atomic.Int64
 	retainedValueLogPruneLastScanOuterLeafRecords                atomic.Int64
@@ -7853,6 +7910,7 @@ type DB struct {
 	retainedValueLogPruneWriteGateRetries                        atomic.Uint64
 	retainedValueLogPruneWriteGateRetrySuccesses                 atomic.Uint64
 	retainedPruneForceRequested                                  atomic.Bool
+	retainedPruneFullLiveIDScanBudget                            time.Duration
 	retainedPruneObservedMu                                      sync.Mutex
 	retainedPruneObservedSourceIDs                               map[uint32]struct{}
 	vlogGenerationObservedGCMu                                   sync.Mutex
@@ -8299,6 +8357,10 @@ const (
 	// reclaim. Require a meaningfully idle window before starting it so hot
 	// write workloads do not pay for a large scan between active phases.
 	retainedPruneQuietWindow = 15 * time.Second
+	// Opportunistic retained-prune full live-ID scans run during geth/Sepolia
+	// lulls. Keep the default short so a stale foreground-quiet signal cannot
+	// consume unbounded CPU/I/O; explicit maintenance uses an unbudgeted path.
+	retainedPruneDefaultFullLiveIDScanBudget = 2 * time.Second
 	// Retained-path prune is opportunistic reclaim. Do not restart a full live-ID
 	// scan on every periodic checkpoint during a hot workload.
 	retainedPruneMinInterval = 30 * time.Second
@@ -27284,6 +27346,7 @@ func (db *DB) Stats() map[string]string {
 	stats["treedb.cache.vlog_retained_prune.error_runs"] = fmt.Sprintf("%d", db.retainedValueLogPruneErrorRuns.Load())
 	stats["treedb.cache.vlog_retained_prune.close_abort_runs"] = fmt.Sprintf("%d", db.retainedValueLogPruneCloseAbortRuns.Load())
 	stats["treedb.cache.vlog_retained_prune.foreground_abort_runs"] = fmt.Sprintf("%d", db.retainedValueLogPruneForegroundAbortRuns.Load())
+	stats["treedb.cache.vlog_retained_prune.budget_abort_runs"] = fmt.Sprintf("%d", db.retainedValueLogPruneBudgetAbortRuns.Load())
 	stats["treedb.cache.vlog_retained_prune.last_scan.records"] = fmt.Sprintf("%d", db.retainedValueLogPruneLastScanRecords.Load())
 	stats["treedb.cache.vlog_retained_prune.last_scan.value_pointer_records"] = fmt.Sprintf("%d", db.retainedValueLogPruneLastScanValuePointerRecords.Load())
 	stats["treedb.cache.vlog_retained_prune.last_scan.outer_leaf_records"] = fmt.Sprintf("%d", db.retainedValueLogPruneLastScanOuterLeafRecords.Load())

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -5167,8 +5167,8 @@ const (
 	retainedPruneStatusNoCandidates
 	retainedPruneStatusForegroundAbort
 	retainedPruneStatusCloseAbort
-	retainedPruneStatusBudgetAbort
 	retainedPruneStatusError
+	retainedPruneStatusBudgetAbort
 )
 
 func retainedPruneStatusString(status uint32) string {

--- a/TreeDB/caching/db_test.go
+++ b/TreeDB/caching/db_test.go
@@ -2433,6 +2433,91 @@ func TestRetainedValueLogPruneDiagnostics_ForegroundAbort(t *testing.T) {
 	}
 }
 
+func TestRetainedValueLogPruneBudgetAbortSkipsUnprovenReclaim(t *testing.T) {
+	dir := t.TempDir()
+	backend := NewMockBackend()
+	backend.Set([]byte("ptr"), []byte("value"))
+
+	cache, err := Open(dir, backend, Options{
+		DisableWAL:               true,
+		RelaxedSync:              true,
+		AllowUnsafe:              true,
+		FlushThreshold:           1 << 20,
+		ValueLogPointerThreshold: 1,
+	})
+	if err != nil {
+		t.Fatalf("cache open: %v", err)
+	}
+	defer cache.Close()
+
+	retainedPath, fileID := seedRetainedPruneSegment(t, cache, 406, 2<<30)
+	backend.mu.Lock()
+	backend.pointerEntries = map[string]page.ValuePtr{
+		"ptr": {FileID: fileID, Length: 1},
+	}
+	backend.mu.Unlock()
+
+	cache.retainedPruneFullLiveIDScanBudget = 50 * time.Millisecond
+	cache.lastForegroundWriteUnixNano.Store(time.Now().Add(-2 * retainedPruneQuietWindow).UnixNano())
+
+	started := make(chan struct{})
+	var startedOnce sync.Once
+	cache.testRetainedPruneScanHook = func(ctx context.Context, phase string) error {
+		if phase != "iterator_record" {
+			return nil
+		}
+		startedOnce.Do(func() { close(started) })
+		<-ctx.Done()
+		return retainedPruneContextErr(ctx)
+	}
+
+	cache.scheduleRetainedValueLogPruneForce()
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("retained prune did not enter budgeted full live-ID scan")
+	}
+
+	waitDone := make(chan struct{})
+	go func() {
+		cache.waitForRetainedValueLogPrune()
+		close(waitDone)
+	}()
+	select {
+	case <-waitDone:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("budgeted retained prune did not finish")
+	}
+
+	if _, err := os.Stat(retainedPath); err != nil {
+		t.Fatalf("retained path removed after budget-aborted prune: %v", err)
+	}
+	if !cache.valueLogRetained(retainedPath) {
+		t.Fatalf("retained path unmarked after budget-aborted prune")
+	}
+
+	stats := cache.Stats()
+	if got := stats["treedb.cache.vlog_retained_prune.last_status"]; got != "budget_abort" {
+		t.Fatalf("last_status=%q want budget_abort", got)
+	}
+	if got := stats["treedb.cache.vlog_retained_prune.last_mode"]; got != "full_live_id_scan" {
+		t.Fatalf("last_mode=%q want full_live_id_scan", got)
+	}
+	if got := stats["treedb.cache.vlog_retained_prune.budget_abort_runs"]; got != "1" {
+		t.Fatalf("budget_abort_runs=%q want 1", got)
+	}
+	if got := stats["treedb.cache.vlog_retained_prune.completed_runs"]; got != "0" {
+		t.Fatalf("completed_runs=%q want 0", got)
+	}
+	if got := stats["treedb.cache.vlog_retained_prune.removed_segments"]; got != "0" {
+		t.Fatalf("removed_segments=%q want 0", got)
+	}
+	if got := stats["treedb.cache.vlog_retained_prune.zombie_marked_segments"]; got != "0" {
+		t.Fatalf("zombie_marked_segments=%q want 0", got)
+	}
+}
+
 func TestRetainedValueLogPruneDiagnostics_CloseAbort(t *testing.T) {
 	dir := t.TempDir()
 	backend := NewMockBackend()


### PR DESCRIPTION
## Summary

Stacked PR for #2498 on top of #2510 / `snissn/2497-manager`.

- Added a retained-prune scan budget abort cause (`errRetainedPruneScanBudgetExceeded`) with `budget_abort` status and `treedb.cache.vlog_retained_prune.budget_abort_runs` stats.
- Changed `retainedPruneLiveIDScanContext` timeout handling to use a timer that cancels with the budget-specific cause instead of generic deadline errors.
- Budgeted scheduled/background retained-prune full live-ID scans with a 2s default window; explicit inline maintenance remains unbudgeted, and the observed-source fast path remains scan-free.
- Kept retained-prune budget exhaustion fail-closed: no removal/zombie marking happens unless the full live-ID proof completes.
- Preserved existing retained-prune status ordinal order and appended the new budget status after the existing statuses.

## Scope / non-goals

- No gethethdb adapter changes and no public TreeDB option added; the default is internal to opportunistic retained-prune scheduling.
- No changes to TreeDB value-log persistence semantics, geth default engine selection, compaction mapping, or key codecs.

## Tests

Latest head: `3f096d191a23e882b8f53a251c89647704af8ff3`.

- `source ~/.gvm/scripts/gvm && gvm use go1.26.0 && go test ./TreeDB/caching -run 'RetainedValueLogPrune.*(Budget|Close|Cancellation|Foreground|Diagnostics)' -count=1` — PASS
- `source ~/.gvm/scripts/gvm && gvm use go1.26.0 && go test ./TreeDB/caching -count=1` — PASS
- `source ~/.gvm/scripts/gvm && gvm use go1.26.0 && go test ./TreeDB -count=1` — PASS
- `source ~/.gvm/scripts/gvm && gvm use go1.26.0 && go test ./TreeDB/mongo_gateway -run TestStandaloneServerCommandWALBSONInsertReadUpdateVisibility -count=5` — PASS
- Earlier broad attempt: `source ~/.gvm/scripts/gvm && gvm use go1.26.0 && go test ./... -count=1` — FAIL twice under the broad run in `TreeDB/mongo_gateway` `TestStandaloneServerCommandWALBSONInsertReadUpdateVisibility` (timeouts / transient invalid page type under broad package load); targeted reruns above passed. Not rerun after the final ordinal-only follow-up commit.

## Risks / notes

- The 2s budget bounds the full live-ID scan context; blocking backend calls without context parameters can only observe the budget after they return, but the prune path still fails closed before reclaim.
- Candidate enumeration remains unbudgeted; the budget is deliberately scoped to the expensive full live-ID scan requested by #2498.
