### PR TITLE
Define TreeDB hybrid search contract

### DIFF
--- a/TreeDB/collections/hybrid_search.go
+++ b/TreeDB/collections/hybrid_search.go
@@ -270,12 +270,12 @@ type HybridSearchResponse struct {
 // accidentally depend on a scan-all-documents fallback.
 func (c *Collection) SearchHybrid(opts HybridSearchOptions) (HybridSearchResponse, error) {
 	_ = opts
-	response := HybridSearchResponse{Stats: HybridSearchStats{FailClosed: 1, FailClosedReason: HybridFailClosedReasonUnsupported}}
 	if c == nil {
-		return response, errCollectionNil
+		return HybridSearchResponse{}, errCollectionNil
 	}
 	if c.db == nil {
-		return response, errCollectionDBNil
+		return HybridSearchResponse{}, errCollectionDBNil
 	}
+	response := HybridSearchResponse{Stats: HybridSearchStats{FailClosed: 1, FailClosedReason: HybridFailClosedReasonUnsupported}}
 	return response, fmt.Errorf("%w: SearchHybrid executor is deferred to issue #2505", ErrHybridSearchUnsupported)
 }

--- a/TreeDB/collections/hybrid_search.go
+++ b/TreeDB/collections/hybrid_search.go
@@ -1,0 +1,281 @@
+package collections
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Hybrid-search errors are fail-closed sentinels. Implementations may wrap them
+// with source/index-specific detail, but must not silently scan all documents or
+// downgrade to stale/unavailable indexes for normal hybrid queries.
+var (
+	// ErrHybridSearchUnsupported reports an unsupported hybrid query shape or a
+	// not-yet-implemented hybrid executor.
+	ErrHybridSearchUnsupported = errors.New("collections: hybrid search unsupported")
+	// ErrHybridSearchIndexUnavailable reports a missing, closed, corrupt, or
+	// otherwise unavailable text/vector/scalar source required by a hybrid query.
+	ErrHybridSearchIndexUnavailable = errors.New("collections: hybrid search index unavailable")
+	// ErrHybridSearchStaleIndex reports a source index whose epoch does not match
+	// the collection snapshot selected for a hybrid query.
+	ErrHybridSearchStaleIndex = errors.New("collections: hybrid search index stale")
+)
+
+// HybridCandidateSource identifies the candidate-producing subsystem.
+type HybridCandidateSource string
+
+const (
+	HybridCandidateSourceText   HybridCandidateSource = "text"
+	HybridCandidateSourceVector HybridCandidateSource = "vector"
+)
+
+// HybridScoreKind identifies the native score scale carried on a candidate.
+// Higher scores are better after conversion into this shared candidate shape.
+type HybridScoreKind string
+
+const (
+	HybridScoreKindBM25             HybridScoreKind = "bm25"
+	HybridScoreKindBM25F            HybridScoreKind = "bm25f"
+	HybridScoreKindVectorSimilarity HybridScoreKind = "vector_similarity"
+)
+
+// HybridFusionMethod selects the rank-fusion algorithm. The zero value defaults
+// to reciprocal-rank fusion for the first implementation.
+type HybridFusionMethod string
+
+const (
+	HybridFusionMethodRRF HybridFusionMethod = "rrf"
+)
+
+// HybridFusionTiePolicy names the deterministic total-order policy applied
+// after fused scores are computed.
+type HybridFusionTiePolicy string
+
+const (
+	HybridFusionTiePolicyScoreBestRankSourceID HybridFusionTiePolicy = "fused_score_best_rank_source_order_id"
+)
+
+// HybridScalarFilterStrategy describes where scalar/metadata filters are
+// applied relative to candidate generation and fusion.
+type HybridScalarFilterStrategy string
+
+const (
+	HybridScalarFilterStrategyPrefilter   HybridScalarFilterStrategy = "prefilter"
+	HybridScalarFilterStrategyPostfilter  HybridScalarFilterStrategy = "postfilter"
+	HybridScalarFilterStrategyTextFirst   HybridScalarFilterStrategy = "text_first"
+	HybridScalarFilterStrategyVectorFirst HybridScalarFilterStrategy = "vector_first"
+	HybridScalarFilterStrategyUnionFusion HybridScalarFilterStrategy = "union_fusion"
+)
+
+// HybridConsistencyMode identifies how text, vector, scalar, and final document
+// fetch phases bind to a collection snapshot.
+type HybridConsistencyMode string
+
+const (
+	HybridConsistencyCurrentSnapshot HybridConsistencyMode = "current_snapshot"
+	HybridConsistencyBoundSnapshot   HybridConsistencyMode = "bound_snapshot"
+)
+
+// HybridFailClosedReason is a low-cardinality reason suitable for counters and
+// debug traces when a hybrid query refuses to run.
+type HybridFailClosedReason string
+
+const (
+	HybridFailClosedReasonNone                      HybridFailClosedReason = "none"
+	HybridFailClosedReasonUnsupported               HybridFailClosedReason = "unsupported"
+	HybridFailClosedReasonTextIndexUnavailable      HybridFailClosedReason = "text_index_unavailable"
+	HybridFailClosedReasonVectorIndexUnavailable    HybridFailClosedReason = "vector_index_unavailable"
+	HybridFailClosedReasonTextIndexStale            HybridFailClosedReason = "text_index_stale"
+	HybridFailClosedReasonVectorIndexStale          HybridFailClosedReason = "vector_index_stale"
+	HybridFailClosedReasonScalarFilterUnbounded     HybridFailClosedReason = "scalar_filter_unbounded"
+	HybridFailClosedReasonSnapshotMismatch          HybridFailClosedReason = "snapshot_mismatch"
+	HybridFailClosedReasonDocumentFetchUnavailable  HybridFailClosedReason = "document_fetch_unavailable"
+	HybridFailClosedReasonFullDocumentScanForbidden HybridFailClosedReason = "full_document_scan_forbidden"
+)
+
+// HybridTextQuery configures the lexical candidate source. Query syntax,
+// analyzers, and BM25/BM25F scoring are owned by the text-search tracker; this
+// contract fixes only the candidate budget and source naming consumed by hybrid
+// planning and fusion.
+type HybridTextQuery struct {
+	IndexName      string `json:"index_name"`
+	Query          string `json:"query"`
+	CandidateLimit int    `json:"candidate_limit,omitempty"`
+}
+
+// HybridVectorQuery configures the vector candidate source. It intentionally
+// carries no document materialization knobs; hybrid document fetch is a bounded
+// final phase after fusion.
+type HybridVectorQuery struct {
+	IndexName                 string               `json:"index_name"`
+	Query                     []float32            `json:"query"`
+	CandidateLimit            int                  `json:"candidate_limit,omitempty"`
+	EfSearch                  int                  `json:"ef_search,omitempty"`
+	QueryMode                 VectorIndexQueryMode `json:"query_mode,omitempty"`
+	QuantizedIndexName        string               `json:"quantized_index_name,omitempty"`
+	QuantizedRerankCandidates int                  `json:"quantized_rerank_candidates,omitempty"`
+}
+
+// HybridScalarFilter describes a bounded scalar-index filter. Equality uses
+// Value; ranges use Range. Strategies that need an indexed allow-set must fail
+// closed when the filter cannot be served by a scalar index.
+type HybridScalarFilter struct {
+	IndexName string             `json:"index_name"`
+	Value     any                `json:"value,omitempty"`
+	Range     *IndexRangeOptions `json:"range,omitempty"`
+}
+
+// HybridFusionOptions configures deterministic rank fusion. For RRF, RRFK=0
+// means the implementation default (documented as 60 by the contract spec).
+type HybridFusionOptions struct {
+	Method      HybridFusionMethod      `json:"method,omitempty"`
+	RRFK        int                     `json:"rrf_k,omitempty"`
+	TiePolicy   HybridFusionTiePolicy   `json:"tie_policy,omitempty"`
+	SourceOrder []HybridCandidateSource `json:"source_order,omitempty"`
+}
+
+// HybridConsistencyOptions describes the snapshot binding requested by the
+// caller. The zero value uses the current collection snapshot after flushing
+// buffered writes, matching existing collection read visibility.
+type HybridConsistencyOptions struct {
+	Mode HybridConsistencyMode `json:"mode,omitempty"`
+}
+
+// HybridSearchDebugOptions controls optional trace payloads. Implementations
+// must keep normal production stats available without requiring candidate echo.
+type HybridSearchDebugOptions struct {
+	IncludeCandidates bool `json:"include_candidates,omitempty"`
+}
+
+// HybridSearchOptions is the collection-level combined retrieval contract for
+// scalar filters, lexical candidates, vector candidates, deterministic fusion,
+// and bounded final document fetch.
+type HybridSearchOptions struct {
+	TopK                 int                        `json:"top_k"`
+	Text                 *HybridTextQuery           `json:"text,omitempty"`
+	Vector               *HybridVectorQuery         `json:"vector,omitempty"`
+	ScalarFilter         *HybridScalarFilter        `json:"scalar_filter,omitempty"`
+	ScalarFilterStrategy HybridScalarFilterStrategy `json:"scalar_filter_strategy,omitempty"`
+	Fusion               HybridFusionOptions        `json:"fusion,omitempty"`
+	IncludeDocuments     bool                       `json:"include_documents,omitempty"`
+	DocumentFetchOptions DocumentFetchOptions       `json:"document_fetch_options,omitempty"`
+	Consistency          HybridConsistencyOptions   `json:"consistency,omitempty"`
+	Debug                HybridSearchDebugOptions   `json:"debug,omitempty"`
+}
+
+// HybridTextMatch carries text attribution when the lexical source can provide
+// it. Terms are analyzer-normalized query/index terms where available.
+type HybridTextMatch struct {
+	Field string   `json:"field"`
+	Terms []string `json:"terms,omitempty"`
+}
+
+// HybridSearchCandidate is the shared candidate shape produced by text and
+// vector candidate-only paths before fusion.
+type HybridSearchCandidate struct {
+	ID          []byte                `json:"id"`
+	Source      HybridCandidateSource `json:"source"`
+	IndexName   string                `json:"index_name"`
+	SourceRank  int                   `json:"source_rank"`
+	Score       float64               `json:"score"`
+	ScoreKind   HybridScoreKind       `json:"score_kind"`
+	TextMatches []HybridTextMatch     `json:"text_matches,omitempty"`
+}
+
+// HybridSourceContribution records one source's contribution to a final fused
+// result. FusionScore is the normalized contribution (for example one source's
+// RRF term), not the native BM25/BM25F/vector score.
+type HybridSourceContribution struct {
+	Source      HybridCandidateSource `json:"source"`
+	IndexName   string                `json:"index_name"`
+	SourceRank  int                   `json:"source_rank"`
+	Score       float64               `json:"score"`
+	ScoreKind   HybridScoreKind       `json:"score_kind"`
+	FusionScore float64               `json:"fusion_score"`
+	TextMatches []HybridTextMatch     `json:"text_matches,omitempty"`
+}
+
+// HybridSearchResult is one fused final result. Rank is one-based in the final
+// fused order. FusedScore is higher-is-better. Document is populated only when
+// IncludeDocuments is true and only after bounded top-k selection.
+type HybridSearchResult struct {
+	ID            []byte                     `json:"id"`
+	Rank          int                        `json:"rank"`
+	FusedScore    float64                    `json:"fused_score"`
+	Sources       []HybridSourceContribution `json:"sources,omitempty"`
+	Document      []byte                     `json:"document,omitempty"`
+	DocumentFound bool                       `json:"document_found,omitempty"`
+}
+
+// HybridSearchPlan reports the planner choices that affected source ordering,
+// scalar filtering, fusion, and final fetch bounds.
+type HybridSearchPlan struct {
+	ScalarFilterStrategy HybridScalarFilterStrategy `json:"scalar_filter_strategy,omitempty"`
+	FusionMethod         HybridFusionMethod         `json:"fusion_method,omitempty"`
+	FusionTiePolicy      HybridFusionTiePolicy      `json:"fusion_tie_policy,omitempty"`
+	TextCandidateLimit   int                        `json:"text_candidate_limit,omitempty"`
+	VectorCandidateLimit int                        `json:"vector_candidate_limit,omitempty"`
+	FinalTopK            int                        `json:"final_top_k,omitempty"`
+}
+
+// HybridSearchSnapshot reports the snapshot/epoch identity used by the query.
+// Generation fields are filled when the corresponding source can expose an
+// index/catalog epoch; zero means unavailable or not applicable.
+type HybridSearchSnapshot struct {
+	Consistency          HybridConsistencyMode `json:"consistency,omitempty"`
+	CommitSeq            uint64                `json:"commit_seq,omitempty"`
+	SystemRootPageID     uint64                `json:"system_root_page_id,omitempty"`
+	CollectionGeneration uint64                `json:"collection_generation,omitempty"`
+	TextIndexEpoch       uint64                `json:"text_index_epoch,omitempty"`
+	VectorIndexEpoch     uint64                `json:"vector_index_epoch,omitempty"`
+}
+
+// HybridSearchStats is the common debug/counter vocabulary for hybrid planning,
+// candidate generation, fusion, scalar filtering, and bounded final fetch.
+type HybridSearchStats struct {
+	TextCandidatesRequested   uint64                 `json:"text_candidates_requested,omitempty"`
+	TextCandidatesReturned    uint64                 `json:"text_candidates_returned,omitempty"`
+	TextPostingsScanned       uint64                 `json:"text_postings_scanned,omitempty"`
+	TextCandidatesScored      uint64                 `json:"text_candidates_scored,omitempty"`
+	VectorCandidatesRequested uint64                 `json:"vector_candidates_requested,omitempty"`
+	VectorCandidatesReturned  uint64                 `json:"vector_candidates_returned,omitempty"`
+	VectorCandidatesExamined  uint64                 `json:"vector_candidates_examined,omitempty"`
+	VectorEdgesVisited        uint64                 `json:"vector_edges_visited,omitempty"`
+	ScalarPrefilterIDs        uint64                 `json:"scalar_prefilter_ids,omitempty"`
+	ScalarPostfilterChecks    uint64                 `json:"scalar_postfilter_checks,omitempty"`
+	ScalarFilterMatched       uint64                 `json:"scalar_filter_matched,omitempty"`
+	ScalarFilterRejected      uint64                 `json:"scalar_filter_rejected,omitempty"`
+	CandidatesFused           uint64                 `json:"candidates_fused,omitempty"`
+	CandidatesAfterFusion     uint64                 `json:"candidates_after_fusion,omitempty"`
+	CandidatesAfterFilter     uint64                 `json:"candidates_after_filter,omitempty"`
+	DocumentsFetched          uint64                 `json:"documents_fetched,omitempty"`
+	DocumentsMissing          uint64                 `json:"documents_missing,omitempty"`
+	FullDocumentScanFallbacks uint64                 `json:"full_document_scan_fallbacks,omitempty"`
+	Truncated                 uint64                 `json:"truncated,omitempty"`
+	FailClosed                uint64                 `json:"fail_closed,omitempty"`
+	FailClosedReason          HybridFailClosedReason `json:"fail_closed_reason,omitempty"`
+}
+
+// HybridSearchResponse is returned by SearchHybrid once the executor lands. The
+// current contract stub fails closed and returns no results.
+type HybridSearchResponse struct {
+	Snapshot   HybridSearchSnapshot    `json:"snapshot,omitempty"`
+	Plan       HybridSearchPlan        `json:"plan,omitempty"`
+	Stats      HybridSearchStats       `json:"stats,omitempty"`
+	Candidates []HybridSearchCandidate `json:"candidates,omitempty"`
+	Results    []HybridSearchResult    `json:"results,omitempty"`
+}
+
+// SearchHybrid is the reserved collection-level hybrid search entry point. The
+// #2505 executor will implement it; until then it fails closed so callers cannot
+// accidentally depend on a scan-all-documents fallback.
+func (c *Collection) SearchHybrid(opts HybridSearchOptions) (HybridSearchResponse, error) {
+	_ = opts
+	response := HybridSearchResponse{Stats: HybridSearchStats{FailClosed: 1, FailClosedReason: HybridFailClosedReasonUnsupported}}
+	if c == nil {
+		return response, errCollectionNil
+	}
+	if c.db == nil {
+		return response, errCollectionDBNil
+	}
+	return response, fmt.Errorf("%w: SearchHybrid executor is deferred to issue #2505", ErrHybridSearchUnsupported)
+}

--- a/TreeDB/collections/hybrid_search_contract_test.go
+++ b/TreeDB/collections/hybrid_search_contract_test.go
@@ -156,8 +156,19 @@ func TestSearchHybridStubFailsClosed2502(t *testing.T) {
 		t.Fatalf("SearchHybrid response=%+v want fail-closed stub with no scan fallback", response)
 	}
 
-	_, err = (*Collection)(nil).SearchHybrid(HybridSearchOptions{})
+	nilResponse, err := (*Collection)(nil).SearchHybrid(HybridSearchOptions{})
 	if !errors.Is(err, errCollectionNil) {
 		t.Fatalf("nil SearchHybrid err=%v want errCollectionNil", err)
+	}
+	if nilResponse.Stats.FailClosed != 0 || nilResponse.Stats.FailClosedReason != "" {
+		t.Fatalf("nil SearchHybrid response=%+v want zero stats for receiver validation failure", nilResponse)
+	}
+
+	nilDBResponse, err := (&Collection{}).SearchHybrid(HybridSearchOptions{})
+	if !errors.Is(err, errCollectionDBNil) {
+		t.Fatalf("nil db SearchHybrid err=%v want errCollectionDBNil", err)
+	}
+	if nilDBResponse.Stats.FailClosed != 0 || nilDBResponse.Stats.FailClosedReason != "" {
+		t.Fatalf("nil db SearchHybrid response=%+v want zero stats for db validation failure", nilDBResponse)
 	}
 }

--- a/TreeDB/collections/hybrid_search_contract_test.go
+++ b/TreeDB/collections/hybrid_search_contract_test.go
@@ -1,0 +1,163 @@
+package collections
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+)
+
+func TestHybridSearchContractVocabulary2502(t *testing.T) {
+	checks := map[string]string{
+		"text source":           string(HybridCandidateSourceText),
+		"vector source":         string(HybridCandidateSourceVector),
+		"bm25 score":            string(HybridScoreKindBM25),
+		"bm25f score":           string(HybridScoreKindBM25F),
+		"vector score":          string(HybridScoreKindVectorSimilarity),
+		"rrf method":            string(HybridFusionMethodRRF),
+		"tie policy":            string(HybridFusionTiePolicyScoreBestRankSourceID),
+		"prefilter strategy":    string(HybridScalarFilterStrategyPrefilter),
+		"postfilter strategy":   string(HybridScalarFilterStrategyPostfilter),
+		"text-first strategy":   string(HybridScalarFilterStrategyTextFirst),
+		"vector-first strategy": string(HybridScalarFilterStrategyVectorFirst),
+		"union-fusion strategy": string(HybridScalarFilterStrategyUnionFusion),
+		"current snapshot mode": string(HybridConsistencyCurrentSnapshot),
+		"bound snapshot mode":   string(HybridConsistencyBoundSnapshot),
+		"unsupported reason":    string(HybridFailClosedReasonUnsupported),
+		"scan-forbidden reason": string(HybridFailClosedReasonFullDocumentScanForbidden),
+	}
+	wants := map[string]string{
+		"text source":           "text",
+		"vector source":         "vector",
+		"bm25 score":            "bm25",
+		"bm25f score":           "bm25f",
+		"vector score":          "vector_similarity",
+		"rrf method":            "rrf",
+		"tie policy":            "fused_score_best_rank_source_order_id",
+		"prefilter strategy":    "prefilter",
+		"postfilter strategy":   "postfilter",
+		"text-first strategy":   "text_first",
+		"vector-first strategy": "vector_first",
+		"union-fusion strategy": "union_fusion",
+		"current snapshot mode": "current_snapshot",
+		"bound snapshot mode":   "bound_snapshot",
+		"unsupported reason":    "unsupported",
+		"scan-forbidden reason": "full_document_scan_forbidden",
+	}
+	for name, got := range checks {
+		if want := wants[name]; got != want {
+			t.Fatalf("%s=%q want %q", name, got, want)
+		}
+	}
+}
+
+func TestHybridSearchContractJSONNames2502(t *testing.T) {
+	opts := HybridSearchOptions{
+		TopK: 5,
+		Text: &HybridTextQuery{IndexName: "body_text", Query: "tree db", CandidateLimit: 32},
+		Vector: &HybridVectorQuery{
+			IndexName:                 "embedding_graph",
+			Query:                     []float32{1, 0},
+			CandidateLimit:            64,
+			EfSearch:                  128,
+			QueryMode:                 VectorIndexQueryModeQuantizedRerank,
+			QuantizedIndexName:        "embedding.rabitq_1bit.fast",
+			QuantizedRerankCandidates: 24,
+		},
+		ScalarFilter:         &HybridScalarFilter{IndexName: "tenant", Value: "acme"},
+		ScalarFilterStrategy: HybridScalarFilterStrategyUnionFusion,
+		Fusion: HybridFusionOptions{
+			Method:      HybridFusionMethodRRF,
+			RRFK:        60,
+			TiePolicy:   HybridFusionTiePolicyScoreBestRankSourceID,
+			SourceOrder: []HybridCandidateSource{HybridCandidateSourceText, HybridCandidateSourceVector},
+		},
+		IncludeDocuments: true,
+		DocumentFetchOptions: DocumentFetchOptions{
+			ExcludePaths: []string{"embedding"},
+		},
+		Consistency: HybridConsistencyOptions{Mode: HybridConsistencyCurrentSnapshot},
+		Debug:       HybridSearchDebugOptions{IncludeCandidates: true},
+	}
+	raw, err := json.Marshal(opts)
+	if err != nil {
+		t.Fatalf("Marshal HybridSearchOptions: %v", err)
+	}
+	jsonText := string(raw)
+	for _, want := range []string{
+		`"top_k":5`,
+		`"candidate_limit":32`,
+		`"candidate_limit":64`,
+		`"ef_search":128`,
+		`"query_mode":"quantized_rerank"`,
+		`"quantized_index_name":"embedding.rabitq_1bit.fast"`,
+		`"quantized_rerank_candidates":24`,
+		`"scalar_filter_strategy":"union_fusion"`,
+		`"rrf_k":60`,
+		`"tie_policy":"fused_score_best_rank_source_order_id"`,
+		`"source_order":["text","vector"]`,
+		`"include_documents":true`,
+		`"ExcludePaths":["embedding"]`,
+		`"mode":"current_snapshot"`,
+		`"include_candidates":true`,
+	} {
+		if !strings.Contains(jsonText, want) {
+			t.Fatalf("HybridSearchOptions JSON %s missing %s", jsonText, want)
+		}
+	}
+}
+
+func TestHybridSearchCandidateAndResultShape2502(t *testing.T) {
+	candidate := HybridSearchCandidate{
+		ID:         []byte("doc-1"),
+		Source:     HybridCandidateSourceText,
+		IndexName:  "body_text",
+		SourceRank: 1,
+		Score:      12.5,
+		ScoreKind:  HybridScoreKindBM25F,
+		TextMatches: []HybridTextMatch{{
+			Field: "body",
+			Terms: []string{"tree", "db"},
+		}},
+	}
+	result := HybridSearchResult{
+		ID:         candidate.ID,
+		Rank:       1,
+		FusedScore: 1.0 / 61.0,
+		Sources: []HybridSourceContribution{{
+			Source:      candidate.Source,
+			IndexName:   candidate.IndexName,
+			SourceRank:  candidate.SourceRank,
+			Score:       candidate.Score,
+			ScoreKind:   candidate.ScoreKind,
+			FusionScore: 1.0 / 61.0,
+			TextMatches: candidate.TextMatches,
+		}},
+	}
+	if string(result.ID) != "doc-1" || result.Rank != 1 || result.FusedScore <= 0 {
+		t.Fatalf("result=%+v want stable id, one-based rank, positive fused score", result)
+	}
+	if len(result.Sources) != 1 || result.Sources[0].SourceRank != 1 || result.Sources[0].ScoreKind != HybridScoreKindBM25F {
+		t.Fatalf("sources=%+v want text contribution with source rank and score kind", result.Sources)
+	}
+	if len(result.Sources[0].TextMatches) != 1 || result.Sources[0].TextMatches[0].Field != "body" {
+		t.Fatalf("text matches=%+v want matched field attribution", result.Sources[0].TextMatches)
+	}
+}
+
+func TestSearchHybridStubFailsClosed2502(t *testing.T) {
+	response, err := (&Collection{db: &backenddb.DB{}}).SearchHybrid(HybridSearchOptions{TopK: 10})
+	if !errors.Is(err, ErrHybridSearchUnsupported) {
+		t.Fatalf("SearchHybrid err=%v want ErrHybridSearchUnsupported", err)
+	}
+	if len(response.Results) != 0 || response.Stats.FailClosed != 1 || response.Stats.FailClosedReason != HybridFailClosedReasonUnsupported || response.Stats.FullDocumentScanFallbacks != 0 {
+		t.Fatalf("SearchHybrid response=%+v want fail-closed stub with no scan fallback", response)
+	}
+
+	_, err = (*Collection)(nil).SearchHybrid(HybridSearchOptions{})
+	if !errors.Is(err, errCollectionNil) {
+		t.Fatalf("nil SearchHybrid err=%v want errCollectionNil", err)
+	}
+}

--- a/TreeDB/docs/docs_lint_test.go
+++ b/TreeDB/docs/docs_lint_test.go
@@ -468,6 +468,46 @@ func TestDocs_SpecManifestFilesExist(t *testing.T) {
 	}
 }
 
+func TestDocs_HybridSearchContract2502(t *testing.T) {
+	treeRoot, _ := repoRoots(t)
+	path := filepath.Join(treeRoot, "docs", "spec", "hybrid-search-contract.md")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	doc := string(data)
+	normalizedDoc := strings.Join(strings.Fields(doc), " ")
+	for _, want := range []string{
+		"Collection.SearchHybrid(HybridSearchOptions)",
+		"HybridSearchCandidate",
+		"HybridSearchStats",
+		"ErrHybridSearchUnsupported",
+		"ErrHybridSearchIndexUnavailable",
+		"ErrHybridSearchStaleIndex",
+		"higher-is-better",
+		"reciprocal-rank fusion",
+		"fused_score_best_rank_source_order_id",
+		"prefilter",
+		"postfilter",
+		"text_first",
+		"vector_first",
+		"union_fusion",
+		"current_snapshot",
+		"bound_snapshot",
+		"full_document_scan_fallbacks",
+		"documents_fetched",
+		"#1764",
+		"#2503",
+		"#2504",
+		"#2505",
+	} {
+		normalizedWant := strings.Join(strings.Fields(want), " ")
+		if !strings.Contains(doc, want) && !strings.Contains(normalizedDoc, normalizedWant) {
+			t.Fatalf("%s missing hybrid contract wording %q", path, want)
+		}
+	}
+}
+
 func TestDocs_NativeWireRaftLocalWALSeparation(t *testing.T) {
 	treeRoot, _ := repoRoots(t)
 	paths := []string{

--- a/TreeDB/docs/spec/README.md
+++ b/TreeDB/docs/spec/README.md
@@ -106,6 +106,10 @@ Given pre-alpha status, this is a living spec that tracks implementation.
   - user-facing quickstart, benchmark matrix, demo, and caveats for explicit
     `column_graph` vector indexes that search through the native physical column
     row reader.
+- `TreeDB/docs/spec/hybrid-search-contract.md`
+  - issue #2502 hybrid lexical + vector search contract for query/options,
+    shared candidates/results, rank fusion, scalar filter strategy vocabulary,
+    snapshot/epoch consistency, counters, and fail-closed behavior.
 - `TreeDB/docs/spec/quantized-vector-index.md`
   - issue #1926/#2454/#2481 scalar_u8, `rabitq_1bit`, and prototype
     `brq_1bit` quantized score-plane semantics, fail-closed query modes, exact

--- a/TreeDB/docs/spec/hybrid-search-contract.md
+++ b/TreeDB/docs/spec/hybrid-search-contract.md
@@ -24,7 +24,7 @@ It does **not** implement the text index (#1764), vector optimizations
 hybrid search MUST NOT scan or fetch every document as a fallback.
 
 Text-only and vector-only APIs/benchmarks remain separate evidence lanes:
-#1764 owns indexed lexical `SearchText`/BM25/BM25F behavior, and the existing
+Issue `#1764` owns indexed lexical `SearchText`/BM25/BM25F behavior, and the existing
 vector API/evidence owns vector-only search. Hybrid benchmarks must measure the
 combined executor separately from those single-source paths.
 
@@ -135,7 +135,7 @@ means use `60`.
 
 `HybridFusionTiePolicyScoreBestRankSourceID`
 (`fused_score_best_rank_source_order_id`) is the deterministic total order for
-#2504 to implement:
+Issue `#2504` to implement:
 
 1. higher `FusedScore` first;
 2. lower best contributing `SourceRank` first;
@@ -218,7 +218,7 @@ source paths report fail-closed reasons such as `text_index_unavailable`,
 
 ## Dependencies on #1764 text-search milestones
 
-#1764 remains the owner of text-only indexed lexical search. Hybrid work depends
+Issue `#1764` remains the owner of text-only indexed lexical search. Hybrid work depends
 on #1764 exposing, by or after its M4/M6 seams:
 
 - persistent text index metadata/analyzers/postings/state/stats;
@@ -233,13 +233,13 @@ on #1764 exposing, by or after its M4/M6 seams:
 - document fetch only for final text-only results, with a candidate-only seam for
   hybrid adapters.
 
-#1764 should not invent alternative hybrid candidate/result/counter names. It
+Issue `#1764` should not invent alternative hybrid candidate/result/counter names. It
 may keep text-specific public types, but the candidate-only handoff to #2503
 should convert or directly emit `HybridSearchCandidate`-compatible data.
 
 ## Handoff to #2503 and #2504
 
-#2503 candidate-only paths should consume this contract as follows:
+Issue `#2503` candidate-only paths should consume this contract as follows:
 
 - text candidate adapters return `HybridSearchCandidate` with `Source=text`,
   `ScoreKind=bm25` or `bm25f`, and zero full-document fetches;
@@ -248,10 +248,10 @@ should convert or directly emit `HybridSearchCandidate`-compatible data.
 - both adapters preserve stable document ID bytes, one-based source rank,
   source/index name, and source counters.
 
-#2504 fusion primitives should implement the RRF formula and deterministic tie
+Issue `#2504` fusion primitives should implement the RRF formula and deterministic tie
 policy above over slices of `HybridSearchCandidate`, returning fused result or
 source-contribution values without opening storage, fetching documents, or
 consulting text/vector indexes.
 
-#2505 owns the executor that binds scalar filtering, source candidate APIs,
+Issue `#2505` owns the executor that binds scalar filtering, source candidate APIs,
 fusion, and bounded final document fetch under the snapshot/epoch contract.

--- a/TreeDB/docs/spec/hybrid-search-contract.md
+++ b/TreeDB/docs/spec/hybrid-search-contract.md
@@ -1,0 +1,257 @@
+# TreeDB Hybrid Search Contract (#2502)
+
+Status: design gate for the #2501 hybrid lexical + vector search stack. TreeDB
+is pre-alpha, so this API/contract may change, but downstream work should treat
+this note as the current source of truth until a later PR updates it.
+
+Parent tracker: <https://github.com/snissn/gomap/issues/2501>.
+
+## Scope and non-goals
+
+This contract defines the first shared TreeDB collection vocabulary for a
+bounded hybrid retrieval pipeline:
+
+```text
+scalar/metadata filters
++ ranked lexical candidates
++ vector candidates
++ deterministic rank fusion
++ bounded final document fetch
+```
+
+It does **not** implement the text index (#1764), vector optimizations
+(#2490/#2475 lanes), gateway syntax, or the hybrid executor (#2505). Normal
+hybrid search MUST NOT scan or fetch every document as a fallback.
+
+Text-only and vector-only APIs/benchmarks remain separate evidence lanes:
+#1764 owns indexed lexical `SearchText`/BM25/BM25F behavior, and the existing
+vector API/evidence owns vector-only search. Hybrid benchmarks must measure the
+combined executor separately from those single-source paths.
+
+## Public naming direction
+
+The collection package now reserves these names for downstream implementation:
+
+- entry point: `Collection.SearchHybrid(HybridSearchOptions)`;
+- response/result types: `HybridSearchResponse`, `HybridSearchResult`;
+- shared candidate type: `HybridSearchCandidate`;
+- source contribution type: `HybridSourceContribution`;
+- stats/counter type: `HybridSearchStats`;
+- planner/debug metadata: `HybridSearchPlan`, `HybridSearchSnapshot`;
+- fail-closed errors: `ErrHybridSearchUnsupported`,
+  `ErrHybridSearchIndexUnavailable`, and `ErrHybridSearchStaleIndex`.
+
+`SearchHybrid` is only a fail-closed stub until #2505 implements the executor.
+It exists so #1764/#2503/#2504/#2505 have stable names to target without
+inventing incompatible seams.
+
+## Query contract
+
+`HybridSearchOptions` is the public contract surface:
+
+- `TopK`: final fused result count. Final document fetches are bounded by this
+  value.
+- `Text *HybridTextQuery`: lexical candidate source.
+  - `IndexName`: text index name.
+  - `Query`: text-query string. Grammar/analyzer semantics are owned by #1764.
+  - `CandidateLimit`: lexical candidate budget before fusion.
+- `Vector *HybridVectorQuery`: vector candidate source.
+  - `IndexName`, `Query`, `EfSearch`, `QueryMode`, `QuantizedIndexName`, and
+    `QuantizedRerankCandidates` mirror the existing vector-index vocabulary.
+  - `CandidateLimit` is the vector candidate budget before fusion.
+  - No document materialization knobs are present on the vector clause; hybrid
+    materialization is a final bounded phase.
+- `ScalarFilter *HybridScalarFilter`: bounded scalar-index filter. Equality uses
+  `Value`; ranges use `Range *IndexRangeOptions`.
+- `ScalarFilterStrategy`: one of `prefilter`, `postfilter`, `text_first`,
+  `vector_first`, or `union_fusion`.
+- `Fusion`: deterministic fusion options. The first supported method is
+  reciprocal-rank fusion (`rrf`). `RRFK=0` means the implementation default of
+  `60`.
+- `IncludeDocuments` and `DocumentFetchOptions`: apply only after final top-k
+  fusion.
+- `Consistency`: snapshot binding mode. The zero value means
+  `current_snapshot`.
+- `Debug.IncludeCandidates`: optional candidate echo. Counters must remain
+  available without enabling candidate echo.
+
+Normal product hybrid queries are expected to include both `Text` and `Vector`.
+Single-source text-only and vector-only user flows should continue to use their
+own APIs and benchmark rows. Candidate adapters from #2503 may still use
+`HybridSearchCandidate` as a shared internal shape.
+
+## Candidate and result shape
+
+Every `HybridSearchCandidate` MUST carry:
+
+- `ID []byte`: the stable opaque collection document ID shared by text, vector,
+  scalar, and primary storage;
+- `Source`: `text` or `vector`;
+- `IndexName`: source index name;
+- `SourceRank`: one-based rank within that source result list;
+- `Score`: source-native score after conversion to the shared orientation;
+- `ScoreKind`: `bm25`, `bm25f`, or `vector_similarity`;
+- `TextMatches`: matched text fields/terms where the lexical source can provide
+  them.
+
+Final `HybridSearchResult` values carry:
+
+- `ID`, final one-based `Rank`, and higher-is-better `FusedScore`;
+- one `HybridSourceContribution` per source that contributed to the document;
+- optional `Document`/`DocumentFound`, populated only when `IncludeDocuments` is
+  true and only after top-k fusion.
+
+Candidate-generation paths MUST produce response-owned/caller-safe document IDs
+at the API boundary. They MUST NOT require fetching full documents to discover
+IDs during normal candidate generation.
+
+## Score orientation and rank semantics
+
+All shared candidate scores use **higher-is-better** orientation:
+
+- BM25/BM25F scores are already higher-is-better.
+- Vector adapters MUST convert lower-is-better distances into a
+  higher-is-better similarity before creating a `HybridSearchCandidate`.
+- Existing vector-index cosine scores are treated as `vector_similarity` when
+  they are already returned in descending score order.
+
+`SourceRank` is one-based, assigned after each source applies its own stable
+source ordering and tie policy. Rank fusion uses ranks, not raw BM25/vector
+score normalization, for the default method. Raw scores are retained only for
+attribution, debugging, reranking seams, and future fusion methods.
+
+## Fusion contract
+
+The first default fusion method is reciprocal-rank fusion:
+
+```text
+rrf_contribution = source_weight / (RRFK + SourceRank)
+fused_score = sum(rrf_contribution for every contributing source)
+```
+
+Initial source weights are `1.0` for text and `1.0` for vector unless a later
+PR extends `HybridFusionOptions` with explicit weighting. `RRFK=0` in options
+means use `60`.
+
+`HybridFusionTiePolicyScoreBestRankSourceID`
+(`fused_score_best_rank_source_order_id`) is the deterministic total order for
+#2504 to implement:
+
+1. higher `FusedScore` first;
+2. lower best contributing `SourceRank` first;
+3. higher contributing-source count first;
+4. source-order tie breaker using `Fusion.SourceOrder`, defaulting to
+   `[text, vector]`;
+5. lexicographic opaque document ID bytes ascending.
+
+Fusion MUST deduplicate candidates by exact document ID bytes. A document that
+appears in both sources has one final result with two source contributions.
+
+## Scalar filter strategy vocabulary
+
+`HybridScalarFilterStrategy` values are planner vocabulary and counter labels:
+
+- `prefilter`: use a scalar index to build a bounded allow-set before text/vector
+  candidate generation. If the filter cannot be served by a scalar index, fail
+  closed; do not scan primary documents.
+- `postfilter`: generate/fuse candidates under explicit budgets, then apply the
+  scalar predicate to candidate IDs or snapshot-bound scalar state. It may return
+  fewer than `TopK` and report truncation/exhaustion; it MUST NOT expand into a
+  full-document scan.
+- `text_first`: run lexical candidates first, then use their bounded IDs to
+  restrict scalar/vector work where the available source APIs support it.
+- `vector_first`: run vector candidates first, then use their bounded IDs to
+  restrict scalar/text work where the available source APIs support it.
+- `union_fusion`: run text and vector candidate generation independently under
+  budgets, fuse the union, then apply scalar filtering/final fetch bounds.
+
+The planner records the actual chosen strategy in `HybridSearchPlan` and uses
+`HybridSearchStats` counters such as `scalar_prefilter_ids`,
+`scalar_postfilter_checks`, `scalar_filter_matched`, and
+`scalar_filter_rejected`.
+
+## Snapshot and epoch consistency
+
+A normal hybrid query binds text, vector, scalar, fusion, and final fetch to one
+collection snapshot:
+
+- `current_snapshot` flushes buffered collection writes first, acquires the
+  current backend snapshot, and opens all candidate/fetch state against that
+  snapshot.
+- `bound_snapshot` is reserved for future explicit read-view/searcher APIs where
+  the caller controls snapshot lifetime.
+
+Text index state, vector index state, scalar roots, and primary document fetch
+MUST all match the same catalog/root snapshot or expose source epochs that are
+validated against it. If an index is missing, unavailable, stale, corrupt, or
+from a different epoch, the query MUST fail closed with the appropriate error and
+`HybridSearchStats.FailClosedReason`; it MUST NOT silently use another source,
+legacy fallback, or primary-document scan as a substitute.
+
+`HybridSearchSnapshot` reports the snapshot identity (`commit_seq`,
+`system_root_page_id`) and source epochs when the implementation can expose them.
+Zero epoch fields mean unavailable/not applicable, not proof of freshness.
+
+## Counters and fail-closed behavior
+
+`HybridSearchStats` is the common debug vocabulary for follow-on PRs. Required
+counter families:
+
+- text: `text_candidates_requested`, `text_candidates_returned`,
+  `text_postings_scanned`, `text_candidates_scored`;
+- vector: `vector_candidates_requested`, `vector_candidates_returned`,
+  `vector_candidates_examined`, `vector_edges_visited`;
+- scalar: `scalar_prefilter_ids`, `scalar_postfilter_checks`,
+  `scalar_filter_matched`, `scalar_filter_rejected`;
+- fusion/finalization: `candidates_fused`, `candidates_after_fusion`,
+  `candidates_after_filter`, `truncated`;
+- final fetch: `documents_fetched`, `documents_missing`;
+- guardrails: `full_document_scan_fallbacks`, `fail_closed`, and
+  `fail_closed_reason`.
+
+For normal hybrid queries, `full_document_scan_fallbacks` MUST remain zero and
+`documents_fetched` MUST be bounded by final `TopK`. Missing or unsupported
+source paths report fail-closed reasons such as `text_index_unavailable`,
+`vector_index_unavailable`, `text_index_stale`, `vector_index_stale`,
+`scalar_filter_unbounded`, `snapshot_mismatch`,
+`document_fetch_unavailable`, or `full_document_scan_forbidden`.
+
+## Dependencies on #1764 text-search milestones
+
+#1764 remains the owner of text-only indexed lexical search. Hybrid work depends
+on #1764 exposing, by or after its M4/M6 seams:
+
+- persistent text index metadata/analyzers/postings/state/stats;
+- bounded ranked text candidate generation without scanning all documents;
+- BM25 or BM25F score output with higher-is-better orientation;
+- stable opaque collection document IDs;
+- one-based lexical rank;
+- source index name;
+- matched fields/terms where available;
+- counters for postings scanned, candidates scored, documents fetched,
+  truncation, unavailable/fallback/fail-closed status;
+- document fetch only for final text-only results, with a candidate-only seam for
+  hybrid adapters.
+
+#1764 should not invent alternative hybrid candidate/result/counter names. It
+may keep text-specific public types, but the candidate-only handoff to #2503
+should convert or directly emit `HybridSearchCandidate`-compatible data.
+
+## Handoff to #2503 and #2504
+
+#2503 candidate-only paths should consume this contract as follows:
+
+- text candidate adapters return `HybridSearchCandidate` with `Source=text`,
+  `ScoreKind=bm25` or `bm25f`, and zero full-document fetches;
+- vector candidate adapters return `HybridSearchCandidate` with
+  `Source=vector`, `ScoreKind=vector_similarity`, and zero full-document fetches;
+- both adapters preserve stable document ID bytes, one-based source rank,
+  source/index name, and source counters.
+
+#2504 fusion primitives should implement the RRF formula and deterministic tie
+policy above over slices of `HybridSearchCandidate`, returning fused result or
+source-contribution values without opening storage, fetching documents, or
+consulting text/vector indexes.
+
+#2505 owns the executor that binds scalar filtering, source candidate APIs,
+fusion, and bounded final document fetch under the snapshot/epoch contract.


### PR DESCRIPTION
## Linked tracker and child milestone

Closes #2502 under the #2501 hybrid lexical + vector search umbrella.

## Scope

Defines the TreeDB hybrid search design contract for downstream implementation PRs:

- reserves `Collection.SearchHybrid(HybridSearchOptions)` as a fail-closed stub;
- adds shared hybrid query/result/candidate/source-contribution/stats names;
- documents higher-is-better score orientation, one-based source ranks, RRF vocabulary, deterministic tie policy, scalar filter strategy vocabulary, snapshot/epoch consistency, and fail-closed behavior;
- documents #1764 text-search dependencies and handoffs to #2503 candidate-only paths and #2504 fusion primitives.

## Explicit non-goals

- Does not implement the text index (#1764).
- Does not optimize vector search (#2490/#2475 lanes).
- Does not implement gateway syntax.
- Does not implement the hybrid executor (#2505).
- Does not add any scan-all-documents fallback.

## Start-phase test plan

- Add docs lint coverage so the contract note remains discoverable and keeps required vocabulary.
- Add collections tests for exported names/constants, candidate/result shape, JSON field names for new hybrid types, and fail-closed `SearchHybrid` stub behavior.

## Start-phase performance plan / rationale

This PR is not performance-sensitive: it adds docs, public type definitions, tests, and a new `SearchHybrid` stub that only runs when explicitly called and immediately fails closed. It does not touch existing search, write, read, vector, scalar, or document materialization hot paths. No benchmarks are required for mergeability.

## Close-phase test evidence

Latest local/PR head: `43c016761ef9feeb54275cfa6ac4ae7196a6a965`.

- `git diff origin/main...HEAD --check` — PASS
- `GOWORK=off go test ./TreeDB/docs -count=1` — PASS (`ok ... 1.798s` on latest head)
- `GOWORK=off go test ./TreeDB/collections -count=1` — PASS (`ok ... 51.046s` on latest head)

Internal review: PASS, no blocking findings. CodeRabbit's two initial actionable comments were addressed in commit `43c016761` and the corresponding review threads are resolved.

## Close-phase benchmark evidence

Not run; no existing hot path is changed. Performance regression assessment: no material regression expected because existing hot paths are not touched.

## Measurement boundary

Contract-only. Candidate generation, fusion, and final document fetch are documented for downstream PRs but not implemented here.

## AI review status

AI reviews were requested only after the PR was mature (coherent pushed diff, local focused tests and benchmark/no-benchmark rationale complete, current PR evidence, no known blockers, latest-head CI running):

- CodeRabbit: auto-started by repo; initial actionable comments fixed/resolved. Follow-up automatic review after `43c016761` hit CodeRabbit rate limit, but the CodeRabbit status context is passing.
- Codex: initial review found no major issues; re-requested after the latest meaningful push.
- Copilot: requested; re-requested after the latest meaningful push.

## Known risks / possible churn

TreeDB is pre-alpha. Downstream #2503/#2504/#2505 may refine the API shape, but they should preserve the contract vocabulary here unless they update the spec/tests in the same PR.
