### PR TITLE
Add TreeDB collection text index metadata

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -32,7 +32,7 @@ import (
 )
 
 const (
-	collectionMetaVersion        = 3
+	collectionMetaVersion        = 4
 	maxCollectionMutationRetries = 64
 	// Bound stale buffered-read replans so a writer under constant buffered
 	// pressure eventually falls back to a publish boundary or outer retry.
@@ -904,6 +904,7 @@ type CollectionMeta struct {
 	Options       CollectionOptions       `json:"options,omitempty"`
 	Indexes       []IndexDefinition       `json:"indexes,omitempty"`
 	VectorIndexes []VectorIndexDefinition `json:"vector_indexes,omitempty"`
+	TextIndexes   []TextIndexDefinition   `json:"text_indexes,omitempty"`
 }
 
 type collectionMetaDisk struct {
@@ -912,6 +913,7 @@ type collectionMetaDisk struct {
 	Options       CollectionOptions       `json:"options,omitempty"`
 	Indexes       []IndexDefinition       `json:"indexes,omitempty"`
 	VectorIndexes []VectorIndexDefinition `json:"vector_indexes,omitempty"`
+	TextIndexes   []TextIndexDefinition   `json:"text_indexes,omitempty"`
 }
 
 type collectionCatalog struct {
@@ -3145,7 +3147,7 @@ func (c *Collection) Meta() CollectionMeta {
 
 // MetaView returns the collection metadata without deep-copying slice fields.
 // The returned value is for read-only internal fast paths; callers must not
-// mutate Indexes, VectorIndexes, or other referenced fields.
+// mutate Indexes, VectorIndexes, TextIndexes, or other referenced fields.
 func (c *Collection) MetaView() CollectionMeta {
 	if c == nil {
 		return CollectionMeta{}
@@ -3450,6 +3452,7 @@ func (c *Collection) DropVectorIndex(name string) (*CollectionMeta, error) {
 		Options:       baseMeta.Options,
 		Indexes:       baseMeta.Indexes,
 		VectorIndexes: nextIndexes,
+		TextIndexes:   baseMeta.TextIndexes,
 	})
 	if err != nil {
 		return nil, err
@@ -3566,6 +3569,7 @@ func (c *Collection) dropIndexes(names map[string]struct{}, all bool) (*Collecti
 		Options:       baseMeta.Options,
 		Indexes:       nextIndexes,
 		VectorIndexes: baseMeta.VectorIndexes,
+		TextIndexes:   baseMeta.TextIndexes,
 	})
 	if err != nil {
 		return nil, err
@@ -3608,13 +3612,16 @@ func (c *Collection) Insert(id, document []byte) ([]byte, error) {
 	if err := c.ensureWriteDomainOpen(); err != nil {
 		return nil, err
 	}
+	if err := rejectTextIndexWriteUnavailable(c.meta, "Insert"); err != nil {
+		return nil, err
+	}
 	if err := c.requireColumnStoreCommandWAL(c.meta, nil); err != nil {
 		return nil, err
 	}
 	if err := requireColumnStoreWriteOperationSupported(c.meta, ColumnPublishOperationInsert); err != nil {
 		return nil, err
 	}
-	if len(c.meta.Indexes) == 0 && len(c.meta.VectorIndexes) == 0 && !c.db.CommandWALEnabled() {
+	if len(c.meta.Indexes) == 0 && len(c.meta.VectorIndexes) == 0 && len(c.meta.TextIndexes) == 0 && !c.db.CommandWALEnabled() {
 		if c.hasBufferedNoIndexBSONPrimaryOverlayOrRootRuns() {
 			if err := c.withMutationLock(func() error {
 				return c.flushBufferedWrites()
@@ -9074,6 +9081,10 @@ func (c *Collection) insertBatchOnceWithOptimisticPlanning(ids, documents [][]by
 		return nil, err, true
 	}
 	meta := catalog.meta
+	if err := rejectTextIndexWriteUnavailable(meta, "InsertBatch"); err != nil {
+		closePlanningSnapshot()
+		return nil, err, true
+	}
 	if len(meta.Indexes) == 0 {
 		closePlanningSnapshot()
 		return nil, nil, false
@@ -9255,6 +9266,10 @@ func (c *Collection) insertBatchOnceWithLockState(
 	}
 	meta := catalog.meta
 	c.meta = meta
+	if err := rejectTextIndexWriteUnavailable(meta, "InsertBatch"); err != nil {
+		closePlanningSnapshot()
+		return nil, err
+	}
 	if err := c.requireColumnStoreCommandWAL(meta, commandWALIntent); err != nil {
 		closePlanningSnapshot()
 		return nil, err
@@ -9321,6 +9336,10 @@ func (c *Collection) insertBatchOnceWithLockState(
 		}
 		meta = catalog.meta
 		c.meta = meta
+		if err := rejectTextIndexWriteUnavailable(meta, "InsertBatch"); err != nil {
+			closePlanningSnapshot()
+			return nil, err
+		}
 		plannerOptions, err = collectionPlannerOptionsForDB(c.db, meta)
 		if err != nil {
 			closePlanningSnapshot()
@@ -9366,6 +9385,10 @@ func (c *Collection) insertBatchOnceWithLockState(
 					return nil, err
 				}
 				c.meta = meta
+				if err := rejectTextIndexWriteUnavailable(meta, "InsertBatch"); err != nil {
+					closePlanningSnapshot()
+					return nil, err
+				}
 				plannerOptions.learnTemplateIDs = templateEncoder != nil
 				plannerOptions.allowTemplateV1Stored = templateEncoder.allowsTemplateV1StoredDocuments(c)
 				commandWALNoIndexBufferedMode = c.canBufferCommandWALNoIndexInsertBatch(meta, plannerOptions.documentFormat, commandWALIntent, len(documents))
@@ -10319,6 +10342,9 @@ func (c *Collection) DeleteDocument(documentID []byte) (bool, error) {
 	if err := c.ensureWriteDomainOpen(); err != nil {
 		return false, err
 	}
+	if err := rejectTextIndexWriteUnavailable(c.meta, "DeleteDocument"); err != nil {
+		return false, err
+	}
 	if len(documentID) == 0 {
 		return false, errors.New("collections: document id cannot be empty")
 	}
@@ -10372,6 +10398,9 @@ func (c *Collection) DeleteBatch(documentIDs [][]byte) (int, error) {
 		return 0, errCollectionDBNil
 	}
 	if err := c.ensureWriteDomainOpen(); err != nil {
+		return 0, err
+	}
+	if err := rejectTextIndexWriteUnavailable(c.meta, "DeleteBatch"); err != nil {
 		return 0, err
 	}
 	for i, id := range documentIDs {
@@ -10451,6 +10480,10 @@ func (c *Collection) deleteBatchOnce(documentIDs [][]byte, commandWALIntent *bac
 		return 0, err
 	}
 	c.meta = catalog.meta
+	if err := rejectTextIndexWriteUnavailable(c.meta, "DeleteBatch"); err != nil {
+		_ = snap.Close()
+		return 0, err
+	}
 	plannerOptions, err := collectionPlannerOptionsForDB(c.db, c.meta)
 	if err != nil {
 		_ = snap.Close()
@@ -10697,6 +10730,10 @@ func (c *Collection) deleteDocumentOnce(documentID []byte, commandWALIntent *bac
 		return false, err
 	}
 	c.meta = catalog.meta
+	if err := rejectTextIndexWriteUnavailable(c.meta, "DeleteDocument"); err != nil {
+		_ = snap.Close()
+		return false, err
+	}
 	plannerOptions, err := collectionPlannerOptionsForDB(c.db, c.meta)
 	if err != nil {
 		_ = snap.Close()
@@ -10935,6 +10972,9 @@ func (c *Collection) Update(documentID []byte, update func(current []byte) (repl
 	if err := validateCollectionUpdateInput(c, documentID, update); err != nil {
 		return false, false, err
 	}
+	if err := rejectTextIndexWriteUnavailable(c.meta, "Update"); err != nil {
+		return false, false, err
+	}
 	if err := c.requireColumnStoreCommandWAL(c.meta, nil); err != nil {
 		return false, false, err
 	}
@@ -11096,6 +11136,9 @@ func (c *Collection) updateBatch(items []UpdateBatchItem, mode updateBatchMode) 
 		return nil, false, errCollectionDBNil
 	}
 	if err := c.ensureWriteDomainOpen(); err != nil {
+		return nil, false, err
+	}
+	if err := rejectTextIndexWriteUnavailable(c.meta, "UpdateBatch"); err != nil {
 		return nil, false, err
 	}
 	if len(items) == 0 {
@@ -13270,6 +13313,10 @@ func (c *Collection) updateDocumentOnceApply(documentID []byte, update func(curr
 		return false, false, err
 	}
 	c.meta = catalog.meta
+	if err := rejectTextIndexWriteUnavailable(c.meta, "Update"); err != nil {
+		_ = snap.Close()
+		return false, false, err
+	}
 	plannerOptions, err := collectionPlannerOptionsForDB(c.db, c.meta)
 	if err != nil {
 		_ = snap.Close()
@@ -15169,6 +15216,10 @@ func (c *Collection) buildUpdateBatchPlan(items []updateBatchItem, mode updateBa
 		return nil, err
 	}
 	meta := catalog.meta
+	if err := rejectTextIndexWriteUnavailable(meta, "UpdateBatch"); err != nil {
+		_ = snap.Close()
+		return nil, err
+	}
 	if err := c.requireColumnStoreCommandWAL(meta, commandWALIntent); err != nil {
 		_ = snap.Close()
 		return nil, err
@@ -20174,6 +20225,7 @@ func encodeNormalizedCollectionMeta(meta CollectionMeta) ([]byte, error) {
 		Options:       meta.Options,
 		Indexes:       meta.Indexes,
 		VectorIndexes: meta.VectorIndexes,
+		TextIndexes:   meta.TextIndexes,
 	})
 }
 
@@ -20190,6 +20242,7 @@ func decodeCollectionMeta(raw []byte) (CollectionMeta, error) {
 		Options:       disk.Options,
 		Indexes:       disk.Indexes,
 		VectorIndexes: disk.VectorIndexes,
+		TextIndexes:   disk.TextIndexes,
 	})
 }
 
@@ -20283,13 +20336,35 @@ func normalizeCollectionMeta(meta CollectionMeta) (CollectionMeta, error) {
 		seen[vectorIndexes[i].Name] = struct{}{}
 	}
 	meta.VectorIndexes = vectorIndexes
+	textIndexes := copyTextIndexDefinitions(meta.TextIndexes)
+	for i := range textIndexes {
+		normalized, err := normalizeTextIndexDefinition(textIndexes[i])
+		if err != nil {
+			name := textIndexes[i].Name
+			if name == "" {
+				name = "<unnamed>"
+			}
+			return CollectionMeta{}, fmt.Errorf("collections: invalid text index %q: %w", name, err)
+		}
+		textIndexes[i] = normalized
+	}
+	sort.SliceStable(textIndexes, func(i, j int) bool {
+		return textIndexes[i].Name < textIndexes[j].Name
+	})
+	for i := range textIndexes {
+		if _, ok := seen[textIndexes[i].Name]; ok {
+			return CollectionMeta{}, fmt.Errorf("collections: duplicate index %q", textIndexes[i].Name)
+		}
+		seen[textIndexes[i].Name] = struct{}{}
+	}
+	meta.TextIndexes = textIndexes
 	if meta.Options.DisableIndexedWriteMemtables {
 		meta.Options.BufferedIndexedWrites = false
 		meta.Options.BufferedIndexedWriteMaxDocuments = 0
 		meta.Options.BufferedIndexedWriteMaxBytes = 0
 		meta.Options.BufferedIndexedWriteMaxRootRuns = 0
 		meta.Options.BufferedIndexedOverlayRoots = false
-	} else if len(meta.Indexes) == 0 && len(meta.VectorIndexes) == 0 {
+	} else if len(meta.Indexes) == 0 && len(meta.VectorIndexes) == 0 && len(meta.TextIndexes) == 0 {
 		meta.Options.BufferedIndexedWrites = false
 	} else {
 		meta.Options.BufferedIndexedWrites = true
@@ -20484,6 +20559,7 @@ func (m CollectionMeta) copy() *CollectionMeta {
 		Options:       copyCollectionOptions(m.Options),
 		Indexes:       append([]IndexDefinition(nil), m.Indexes...),
 		VectorIndexes: copyVectorIndexDefinitions(m.VectorIndexes),
+		TextIndexes:   copyTextIndexDefinitions(m.TextIndexes),
 	}
 }
 
@@ -20521,7 +20597,8 @@ func collectionMetaValuesEqual(a, b CollectionMeta) bool {
 	if a.Name != b.Name ||
 		!collectionOptionsEqual(a.Options, b.Options) ||
 		len(a.Indexes) != len(b.Indexes) ||
-		len(a.VectorIndexes) != len(b.VectorIndexes) {
+		len(a.VectorIndexes) != len(b.VectorIndexes) ||
+		len(a.TextIndexes) != len(b.TextIndexes) {
 		return false
 	}
 	for i := range a.Indexes {
@@ -20531,6 +20608,11 @@ func collectionMetaValuesEqual(a, b CollectionMeta) bool {
 	}
 	for i := range a.VectorIndexes {
 		if !vectorIndexDefinitionValuesEqual(a.VectorIndexes[i], b.VectorIndexes[i]) {
+			return false
+		}
+	}
+	for i := range a.TextIndexes {
+		if !textIndexDefinitionValuesEqual(a.TextIndexes[i], b.TextIndexes[i]) {
 			return false
 		}
 	}
@@ -20575,11 +20657,15 @@ func addVectorIndexToCollectionMeta(meta CollectionMeta, def VectorIndexDefiniti
 	if _, ok := findVectorIndex(meta.VectorIndexes, def.Name); ok {
 		return CollectionMeta{}, VectorIndexDefinition{}, fmt.Errorf("collections: duplicate index %q", def.Name)
 	}
+	if _, ok := findTextIndex(meta.TextIndexes, def.Name); ok {
+		return CollectionMeta{}, VectorIndexDefinition{}, fmt.Errorf("collections: duplicate index %q", def.Name)
+	}
 	candidate := CollectionMeta{
 		Name:          meta.Name,
 		Options:       meta.Options,
 		Indexes:       append([]IndexDefinition(nil), meta.Indexes...),
 		VectorIndexes: append(append([]VectorIndexDefinition(nil), meta.VectorIndexes...), def),
+		TextIndexes:   copyTextIndexDefinitions(meta.TextIndexes),
 	}
 	normalized, err := normalizeCollectionMeta(candidate)
 	if err != nil {
@@ -20602,11 +20688,15 @@ func addIndexToCollectionMeta(meta CollectionMeta, def IndexDefinition) (Collect
 	if _, ok := findVectorIndex(meta.VectorIndexes, def.Name); ok {
 		return CollectionMeta{}, IndexDefinition{}, fmt.Errorf("collections: duplicate index %q", def.Name)
 	}
+	if _, ok := findTextIndex(meta.TextIndexes, def.Name); ok {
+		return CollectionMeta{}, IndexDefinition{}, fmt.Errorf("collections: duplicate index %q", def.Name)
+	}
 	candidate := CollectionMeta{
 		Name:          meta.Name,
 		Options:       meta.Options,
 		Indexes:       append(append([]IndexDefinition(nil), meta.Indexes...), def),
 		VectorIndexes: append([]VectorIndexDefinition(nil), meta.VectorIndexes...),
+		TextIndexes:   copyTextIndexDefinitions(meta.TextIndexes),
 	}
 	normalized, err := normalizeCollectionMeta(candidate)
 	if err != nil {
@@ -20729,6 +20819,9 @@ func collectionRootNames(meta CollectionMeta) []string {
 	}
 	for _, idx := range meta.VectorIndexes {
 		out = append(out, collectionVectorIndexRootName(meta.Name, idx.Name))
+	}
+	for _, idx := range meta.TextIndexes {
+		out = append(out, collectionTextRootNames(meta.Name, idx.Name)...)
 	}
 	return out
 }

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -19772,6 +19772,14 @@ func collectionRootStoragePolicyForDB(db *backenddb.DB, meta CollectionMeta, roo
 			return backendRootStoragePolicy(meta.Options.IndexStateStoragePolicy)
 		}
 	}
+	for _, idx := range meta.TextIndexes {
+		switch rootName {
+		case collectionTextIndexRootName(meta.Name, idx.Name):
+			return backendRootStoragePolicy(idx.StoragePolicy)
+		case collectionTextStateRootName(meta.Name, idx.Name), collectionTextStatsRootName(meta.Name, idx.Name):
+			return backendRootStoragePolicy(meta.Options.IndexStateStoragePolicy)
+		}
+	}
 	return backenddb.OrderedRootStorageDefault, fmt.Errorf("collections: unknown collection root %q for %q", rootName, meta.Name)
 }
 

--- a/TreeDB/collections/bson_set_update.go
+++ b/TreeDB/collections/bson_set_update.go
@@ -57,6 +57,9 @@ func (c *Collection) UpdateBSONSet(documentID []byte, fields []BSONSetField) (bo
 	if err := validateCollectionUpdateDocumentInput(c, documentID); err != nil {
 		return false, false, err
 	}
+	if err := rejectTextIndexWriteUnavailable(c.meta, "UpdateBSONSet"); err != nil {
+		return false, false, err
+	}
 	if err := c.validateBSONSetDocumentFormat(); err != nil {
 		return false, false, err
 	}
@@ -153,6 +156,9 @@ func (c *Collection) updateBSONSetBatch(items []BSONSetUpdateBatchItem, mode upd
 		return nil, false, errCollectionDBNil
 	}
 	if err := c.ensureWriteDomainOpen(); err != nil {
+		return nil, false, err
+	}
+	if err := rejectTextIndexWriteUnavailable(c.meta, "UpdateBSONSetBatch"); err != nil {
 		return nil, false, err
 	}
 	if err := c.validateBSONSetDocumentFormat(); err != nil {

--- a/TreeDB/collections/text_analyzer.go
+++ b/TreeDB/collections/text_analyzer.go
@@ -1,0 +1,76 @@
+package collections
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+)
+
+// TextToken is one analyzed token. Position is zero-based token order; offsets
+// are byte offsets in the source string.
+type TextToken struct {
+	Term        string
+	Position    int
+	StartOffset int
+	EndOffset   int
+}
+
+// AnalyzeText runs a named collection text analyzer over text. The simple
+// analyzer lowercases Unicode letters and treats Unicode letters, Unicode
+// digits, and '_' as token characters so code-ish identifiers such as
+// "HTTP_500" remain searchable without stemming.
+func AnalyzeText(analyzer TextAnalyzer, text string) ([]TextToken, error) {
+	normalized, err := normalizeTextAnalyzer(analyzer)
+	if err != nil {
+		return nil, err
+	}
+	switch normalized {
+	case TextAnalyzerSimple:
+		return analyzeSimpleText(text), nil
+	default:
+		return nil, fmt.Errorf("unsupported analyzer %q", normalized)
+	}
+}
+
+func analyzeSimpleText(text string) []TextToken {
+	var tokens []TextToken
+	var builder strings.Builder
+	start := -1
+	position := 0
+	flush := func(end int) {
+		if start < 0 {
+			return
+		}
+		term := builder.String()
+		if term != "" {
+			tokens = append(tokens, TextToken{
+				Term:        term,
+				Position:    position,
+				StartOffset: start,
+				EndOffset:   end,
+			})
+			position++
+		}
+		builder.Reset()
+		start = -1
+	}
+	for offset, r := range text {
+		if simpleTextTokenRune(r) {
+			if start < 0 {
+				start = offset
+			}
+			builder.WriteRune(unicode.ToLower(r))
+			continue
+		}
+		flush(offset)
+	}
+	flush(len(text))
+	if tokens == nil {
+		return []TextToken{}
+	}
+	return tokens
+}
+
+func simpleTextTokenRune(r rune) bool {
+	return r == '_' || unicode.IsLetter(r) || unicode.IsDigit(r)
+}

--- a/TreeDB/collections/text_index.go
+++ b/TreeDB/collections/text_index.go
@@ -1,0 +1,164 @@
+package collections
+
+import (
+	"errors"
+	"fmt"
+	"math"
+)
+
+// ErrTextIndexUnavailable reports that a declared collection text index cannot
+// yet be used for persistent maintenance or search. PR1 for #1764 intentionally
+// lands metadata/analyzer/query contracts before postings/text-state/stats
+// storage; write/search paths fail closed instead of silently scanning or
+// returning incomplete text-index results.
+var ErrTextIndexUnavailable = errors.New("collections: text index unavailable")
+
+// TextAnalyzer names a collection text analyzer. The zero value normalizes to
+// TextAnalyzerSimple.
+type TextAnalyzer string
+
+const (
+	TextAnalyzerSimple TextAnalyzer = "simple"
+)
+
+// TextIndexDefinition declares a persistent collection-native inverted index.
+// PR1 stores and validates metadata only; postings, text-state, stats, mutation
+// maintenance, and SearchText execution land in later #1764 milestones.
+type TextIndexDefinition struct {
+	Name             string            `json:"name"`
+	Fields           []TextIndexField  `json:"fields"`
+	Analyzer         TextAnalyzer      `json:"analyzer,omitempty"`
+	StorePositions   bool              `json:"store_positions,omitempty"`
+	StoreOffsets     bool              `json:"store_offsets,omitempty"`
+	StoragePolicy    RootStoragePolicy `json:"storage_policy,omitempty"`
+	SchemaGeneration uint64            `json:"schema_generation,omitempty"`
+}
+
+// TextIndexField declares one document field in a text index. Weight defaults
+// to 1.0 when omitted or set to zero.
+type TextIndexField struct {
+	Field  string  `json:"field"`
+	Weight float64 `json:"weight,omitempty"`
+}
+
+func normalizeTextAnalyzer(analyzer TextAnalyzer) (TextAnalyzer, error) {
+	switch analyzer {
+	case "", TextAnalyzerSimple:
+		return TextAnalyzerSimple, nil
+	default:
+		return "", fmt.Errorf("unsupported analyzer %q", analyzer)
+	}
+}
+
+func normalizeTextIndexDefinition(def TextIndexDefinition) (TextIndexDefinition, error) {
+	if def.Name == "" {
+		return TextIndexDefinition{}, errors.New("name is required")
+	}
+	if err := ValidateIndexName(def.Name); err != nil {
+		return TextIndexDefinition{}, err
+	}
+	analyzer, err := normalizeTextAnalyzer(def.Analyzer)
+	if err != nil {
+		return TextIndexDefinition{}, err
+	}
+	def.Analyzer = analyzer
+	if _, err := backendRootStoragePolicy(def.StoragePolicy); err != nil {
+		return TextIndexDefinition{}, err
+	}
+	if def.StoreOffsets && !def.StorePositions {
+		return TextIndexDefinition{}, errors.New("store_offsets requires store_positions")
+	}
+	if len(def.Fields) == 0 {
+		return TextIndexDefinition{}, errors.New("fields are required")
+	}
+	fields := append([]TextIndexField(nil), def.Fields...)
+	seenFields := make(map[string]struct{}, len(fields))
+	for i := range fields {
+		field := fields[i].Field
+		if err := ValidateIndexPath(field); err != nil {
+			return TextIndexDefinition{}, fmt.Errorf("field[%d]: %w", i, err)
+		}
+		if _, ok := seenFields[field]; ok {
+			return TextIndexDefinition{}, fmt.Errorf("duplicate field %q", field)
+		}
+		seenFields[field] = struct{}{}
+		weight := fields[i].Weight
+		if weight == 0 {
+			fields[i].Weight = 1
+			continue
+		}
+		if math.IsNaN(weight) || math.IsInf(weight, 0) || weight < 0 {
+			return TextIndexDefinition{}, fmt.Errorf("field[%d] weight must be finite and non-negative", i)
+		}
+	}
+	def.Fields = fields
+	return def, nil
+}
+
+func copyTextIndexDefinitions(in []TextIndexDefinition) []TextIndexDefinition {
+	if len(in) == 0 {
+		return nil
+	}
+	out := append([]TextIndexDefinition(nil), in...)
+	for i := range out {
+		out[i].Fields = append([]TextIndexField(nil), out[i].Fields...)
+	}
+	return out
+}
+
+func textIndexDefinitionValuesEqual(a, b TextIndexDefinition) bool {
+	if a.Name != b.Name ||
+		a.Analyzer != b.Analyzer ||
+		a.StorePositions != b.StorePositions ||
+		a.StoreOffsets != b.StoreOffsets ||
+		a.StoragePolicy != b.StoragePolicy ||
+		a.SchemaGeneration != b.SchemaGeneration ||
+		len(a.Fields) != len(b.Fields) {
+		return false
+	}
+	for i := range a.Fields {
+		if a.Fields[i] != b.Fields[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func findTextIndex(indexes []TextIndexDefinition, name string) (TextIndexDefinition, bool) {
+	for _, idx := range indexes {
+		if idx.Name == name {
+			return idx, true
+		}
+	}
+	return TextIndexDefinition{}, false
+}
+
+func collectionTextIndexRootName(collection, indexName string) string {
+	return collection + "/text-index/" + indexName
+}
+
+func collectionTextStateRootName(collection, indexName string) string {
+	return collection + "/text-state/" + indexName
+}
+
+func collectionTextStatsRootName(collection, indexName string) string {
+	return collection + "/text-stats/" + indexName
+}
+
+func collectionTextRootNames(collection, indexName string) []string {
+	return []string{
+		collectionTextIndexRootName(collection, indexName),
+		collectionTextStateRootName(collection, indexName),
+		collectionTextStatsRootName(collection, indexName),
+	}
+}
+
+func rejectTextIndexWriteUnavailable(meta CollectionMeta, operation string) error {
+	if len(meta.TextIndexes) == 0 {
+		return nil
+	}
+	if operation == "" {
+		operation = "write"
+	}
+	return fmt.Errorf("%w: collection %q has %d declared text index(es); %s requires postings/text-state/stats maintenance that is not implemented in this milestone", ErrTextIndexUnavailable, meta.Name, len(meta.TextIndexes), operation)
+}

--- a/TreeDB/collections/text_index_test.go
+++ b/TreeDB/collections/text_index_test.go
@@ -211,6 +211,58 @@ func TestCollectionTextRootNames(t *testing.T) {
 	}
 }
 
+func TestCollectionTextRootStoragePolicies(t *testing.T) {
+	meta, err := normalizeCollectionMeta(CollectionMeta{
+		Name: "docs",
+		Options: CollectionOptions{
+			IndexStateStoragePolicy: RootStorageFast,
+		},
+		TextIndexes: []TextIndexDefinition{{
+			Name:          "lexical",
+			Fields:        []TextIndexField{{Field: "body"}},
+			StoragePolicy: RootStorageCompressed,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("normalize metadata: %v", err)
+	}
+	cases := []struct {
+		name string
+		root string
+		want backenddb.OrderedRootStoragePolicy
+	}{
+		{
+			name: "postings honor text index storage policy",
+			root: collectionTextIndexRootName("docs", "lexical"),
+			want: backenddb.OrderedRootStorageValueLogLeaves,
+		},
+		{
+			name: "state uses index state storage policy",
+			root: collectionTextStateRootName("docs", "lexical"),
+			want: backenddb.OrderedRootStoragePagerLeaves,
+		},
+		{
+			name: "stats uses index state storage policy",
+			root: collectionTextStatsRootName("docs", "lexical"),
+			want: backenddb.OrderedRootStoragePagerLeaves,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := collectionRootStoragePolicyForDB(nil, meta, tc.root)
+			if err != nil {
+				t.Fatalf("collectionRootStoragePolicyForDB(%q): %v", tc.root, err)
+			}
+			if got != tc.want {
+				t.Fatalf("policy=%v want %v", got, tc.want)
+			}
+		})
+	}
+	if _, err := collectionRootStoragePolicyForDB(nil, meta, collectionTextIndexRootName("docs", "missing")); err == nil || !strings.Contains(err.Error(), "unknown collection root") {
+		t.Fatalf("missing text root err=%v want unknown collection root", err)
+	}
+}
+
 func TestCollectionTextIndexedOperationsFailClosedUntilStorageLands(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {

--- a/TreeDB/collections/text_index_test.go
+++ b/TreeDB/collections/text_index_test.go
@@ -1,0 +1,294 @@
+package collections
+
+import (
+	"bytes"
+	"errors"
+	"math"
+	"slices"
+	"strings"
+	"testing"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+)
+
+func TestTextAnalyzerSimpleFixtures(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		terms []string
+	}{
+		{name: "punctuation lowercase", input: "Hello, WORLD!", terms: []string{"hello", "world"}},
+		{name: "unicode and numbers", input: "Café42 東京 123", terms: []string{"café42", "東京", "123"}},
+		{name: "code-ish underscore", input: "HTTP_500 retry-count model.v1", terms: []string{"http_500", "retry", "count", "model", "v1"}},
+		{name: "repeated terms kept", input: "error.error ERROR", terms: []string{"error", "error", "error"}},
+		{name: "empty", input: " -- \t\n ", terms: []string{}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tokens, err := AnalyzeText(TextAnalyzerSimple, tc.input)
+			if err != nil {
+				t.Fatalf("AnalyzeText: %v", err)
+			}
+			terms := make([]string, len(tokens))
+			for i, token := range tokens {
+				terms[i] = token.Term
+				if token.Position != i {
+					t.Fatalf("token %d position=%d want %d", i, token.Position, i)
+				}
+				if token.StartOffset < 0 || token.EndOffset < token.StartOffset || token.EndOffset > len(tc.input) {
+					t.Fatalf("token %d invalid offsets %+v for input len %d", i, token, len(tc.input))
+				}
+			}
+			if !slices.Equal(terms, tc.terms) {
+				t.Fatalf("terms=%q want %q", terms, tc.terms)
+			}
+		})
+	}
+}
+
+func TestCollectionTextIndexMetadataValidateAndReopen(t *testing.T) {
+	dir := t.TempDir()
+	d, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	mgr := NewCollectionManager(d)
+	meta, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "docs",
+		TextIndexes: []TextIndexDefinition{{
+			Name: "lexical",
+			Fields: []TextIndexField{
+				{Field: "body"},
+				{Field: "title", Weight: 2.5},
+			},
+			StoragePolicy: RootStorageCompressed,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	assertTextIndexMetadataNormalized(t, *meta)
+	col, err := mgr.OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	assertTextIndexMetadataNormalized(t, col.Meta())
+	if err := d.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	reopened, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("reopen db: %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+	reopenedCol, err := NewCollectionManager(reopened).OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("open reopened collection: %v", err)
+	}
+	assertTextIndexMetadataNormalized(t, reopenedCol.Meta())
+}
+
+func assertTextIndexMetadataNormalized(t *testing.T, meta CollectionMeta) {
+	t.Helper()
+	if len(meta.TextIndexes) != 1 {
+		t.Fatalf("text indexes=%d want 1: %+v", len(meta.TextIndexes), meta.TextIndexes)
+	}
+	idx := meta.TextIndexes[0]
+	if idx.Name != "lexical" || idx.Analyzer != TextAnalyzerSimple || idx.StoragePolicy != RootStorageCompressed {
+		t.Fatalf("text index metadata=%+v", idx)
+	}
+	if len(idx.Fields) != 2 {
+		t.Fatalf("fields=%d want 2", len(idx.Fields))
+	}
+	if idx.Fields[0] != (TextIndexField{Field: "body", Weight: 1}) {
+		t.Fatalf("field[0]=%+v want body weight 1", idx.Fields[0])
+	}
+	if idx.Fields[1] != (TextIndexField{Field: "title", Weight: 2.5}) {
+		t.Fatalf("field[1]=%+v want title weight 2.5", idx.Fields[1])
+	}
+	if !meta.Options.BufferedIndexedWrites {
+		t.Fatal("text-indexed metadata should normalize as an indexed schema")
+	}
+}
+
+func TestCollectionTextIndexMetadataRejectsInvalidDefinitions(t *testing.T) {
+	tests := []struct {
+		name string
+		meta CollectionMeta
+		want string
+	}{
+		{
+			name: "missing name",
+			meta: CollectionMeta{Name: "docs", TextIndexes: []TextIndexDefinition{{Fields: []TextIndexField{{Field: "body"}}}}},
+			want: "name is required",
+		},
+		{
+			name: "missing fields",
+			meta: CollectionMeta{Name: "docs", TextIndexes: []TextIndexDefinition{{Name: "text"}}},
+			want: "fields are required",
+		},
+		{
+			name: "bad analyzer",
+			meta: CollectionMeta{Name: "docs", TextIndexes: []TextIndexDefinition{{Name: "text", Analyzer: TextAnalyzer("english"), Fields: []TextIndexField{{Field: "body"}}}}},
+			want: "unsupported analyzer",
+		},
+		{
+			name: "duplicate field",
+			meta: CollectionMeta{Name: "docs", TextIndexes: []TextIndexDefinition{{Name: "text", Fields: []TextIndexField{{Field: "body"}, {Field: "body"}}}}},
+			want: "duplicate field",
+		},
+		{
+			name: "offsets require positions",
+			meta: CollectionMeta{Name: "docs", TextIndexes: []TextIndexDefinition{{Name: "text", StoreOffsets: true, Fields: []TextIndexField{{Field: "body"}}}}},
+			want: "store_offsets requires store_positions",
+		},
+		{
+			name: "negative weight",
+			meta: CollectionMeta{Name: "docs", TextIndexes: []TextIndexDefinition{{Name: "text", Fields: []TextIndexField{{Field: "body", Weight: -1}}}}},
+			want: "weight must be finite",
+		},
+		{
+			name: "nan weight",
+			meta: CollectionMeta{Name: "docs", TextIndexes: []TextIndexDefinition{{Name: "text", Fields: []TextIndexField{{Field: "body", Weight: math.NaN()}}}}},
+			want: "weight must be finite",
+		},
+		{
+			name: "duplicate scalar name",
+			meta: CollectionMeta{
+				Name:    "docs",
+				Indexes: []IndexDefinition{{Name: "text", Field: "kind", ValueType: IndexValueString}},
+				TextIndexes: []TextIndexDefinition{{
+					Name:   "text",
+					Fields: []TextIndexField{{Field: "body"}},
+				}},
+			},
+			want: "duplicate index",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := normalizeCollectionMeta(tc.meta)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("normalizeCollectionMeta err=%v want containing %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestTextSearchQueryParserRejectsUnsupportedShapes(t *testing.T) {
+	for _, query := range []string{"refund AND policy OR error", "refund AND", "refund AND --", "\"refund policy\""} {
+		if _, _, err := parseTextSearchQuery(TextAnalyzerSimple, query, TextSearchOperatorOR); err == nil {
+			t.Fatalf("parseTextSearchQuery(%q) err=nil want unsupported/malformed", query)
+		}
+	}
+}
+
+func TestCollectionTextRootNames(t *testing.T) {
+	meta, err := normalizeCollectionMeta(CollectionMeta{
+		Name: "docs",
+		TextIndexes: []TextIndexDefinition{{
+			Name:   "lexical",
+			Fields: []TextIndexField{{Field: "body"}},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("normalize metadata: %v", err)
+	}
+	roots := collectionRootNames(meta)
+	for _, want := range []string{
+		collectionPrimaryRootName("docs"),
+		collectionTextIndexRootName("docs", "lexical"),
+		collectionTextStateRootName("docs", "lexical"),
+		collectionTextStatsRootName("docs", "lexical"),
+	} {
+		if !slices.Contains(roots, want) {
+			t.Fatalf("roots=%q missing %q", roots, want)
+		}
+	}
+	if slices.Contains(roots, collectionSecondaryRootName("docs", "lexical")) || slices.Contains(roots, collectionVectorIndexRootName("docs", "lexical")) {
+		t.Fatalf("text root set included scalar/vector root: %q", roots)
+	}
+}
+
+func TestCollectionTextIndexedOperationsFailClosedUntilStorageLands(t *testing.T) {
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = d.Close() }()
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{
+		Name: "docs",
+		TextIndexes: []TextIndexDefinition{{
+			Name:   "lexical",
+			Fields: []TextIndexField{{Field: "body"}},
+		}},
+	}); err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	col, err := mgr.OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("open collection: %v", err)
+	}
+	if _, err := col.InsertBatch([][]byte{[]byte("d1")}, [][]byte{[]byte(`{"body":"refund policy"}`)}); !errors.Is(err, ErrTextIndexUnavailable) {
+		t.Fatalf("InsertBatch err=%v want ErrTextIndexUnavailable", err)
+	}
+	if _, err := col.DeleteDocument([]byte("d1")); !errors.Is(err, ErrTextIndexUnavailable) {
+		t.Fatalf("DeleteDocument err=%v want ErrTextIndexUnavailable", err)
+	}
+	if _, _, err := col.Update([]byte("d1"), func(current []byte) ([]byte, bool, error) {
+		return current, false, nil
+	}); !errors.Is(err, ErrTextIndexUnavailable) {
+		t.Fatalf("Update err=%v want ErrTextIndexUnavailable", err)
+	}
+	if _, err := col.UpdateBatch([]UpdateBatchItem{{DocumentID: []byte("d1"), Update: func(current []byte) ([]byte, bool, error) {
+		return current, false, nil
+	}}}); !errors.Is(err, ErrTextIndexUnavailable) {
+		t.Fatalf("UpdateBatch err=%v want ErrTextIndexUnavailable", err)
+	}
+
+	response, err := col.SearchText(TextSearchOptions{IndexName: "lexical", Query: "refund AND policy", TopK: 10})
+	if !errors.Is(err, ErrTextIndexUnavailable) {
+		t.Fatalf("SearchText err=%v want ErrTextIndexUnavailable", err)
+	}
+	if response.Stats.QueryTerms != 2 || response.Stats.DocumentsFetched != 0 || !response.Stats.Unavailable {
+		t.Fatalf("SearchText stats=%+v want terms=2 fetched=0 unavailable", response.Stats)
+	}
+	if _, err := col.SearchText(TextSearchOptions{IndexName: "missing", Query: "refund", TopK: 10}); !errors.Is(err, ErrIndexNotFound) {
+		t.Fatalf("SearchText missing err=%v want ErrIndexNotFound", err)
+	}
+	response, err = col.SearchText(TextSearchOptions{IndexName: "lexical", Query: " -- ", TopK: 10})
+	if err != nil {
+		t.Fatalf("SearchText empty analyzed query: %v", err)
+	}
+	if len(response.Results) != 0 || response.Stats.QueryTerms != 0 || response.Stats.DocumentsFetched != 0 {
+		t.Fatalf("empty query response=%+v", response)
+	}
+}
+
+func BenchmarkSimpleTextAnalyzer(b *testing.B) {
+	cases := []struct {
+		name string
+		text []byte
+	}{
+		{name: "short", text: []byte("HTTP_500 refund policy model.v1 retry-count")},
+		{name: "long", text: bytes.Repeat([]byte("User prompt failed refund policy HTTP_500 tool_call model.v1 東京 Café42. "), 64)},
+	}
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			text := string(tc.text)
+			b.ReportAllocs()
+			b.SetBytes(int64(len(text)))
+			for i := 0; i < b.N; i++ {
+				tokens, err := AnalyzeText(TextAnalyzerSimple, text)
+				if err != nil {
+					b.Fatalf("AnalyzeText: %v", err)
+				}
+				if len(text) > 0 && len(tokens) == 0 {
+					b.Fatal("expected tokens")
+				}
+			}
+		})
+	}
+}

--- a/TreeDB/collections/text_search.go
+++ b/TreeDB/collections/text_search.go
@@ -1,0 +1,184 @@
+package collections
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+)
+
+// TextSearchOperator controls how analyzed query terms are combined. The zero
+// value currently normalizes to OR.
+type TextSearchOperator string
+
+const (
+	TextSearchOperatorOR  TextSearchOperator = "or"
+	TextSearchOperatorAND TextSearchOperator = "and"
+)
+
+const textSearchUnavailableStorage = "text_index_storage_unimplemented"
+
+// TextSearchOptions configures collection-native lexical search. PR1 validates
+// the query shape and fails closed before scanning because postings/state/stats
+// storage is not implemented yet.
+type TextSearchOptions struct {
+	IndexName            string
+	Query                string
+	Operator             TextSearchOperator
+	TopK                 int
+	IncludeDocuments     bool
+	DocumentFetchOptions DocumentFetchOptions
+}
+
+// TextSearchResult is one ranked lexical result. Later #1764 storage/search
+// milestones populate these fields from persistent postings and BM25/BM25F
+// scoring; PR1 returns no results while storage is unavailable.
+type TextSearchResult struct {
+	DocumentID    []byte
+	Rank          int
+	Score         float64
+	MatchedTerms  []string
+	MatchedFields []string
+	Document      []byte
+}
+
+// TextSearchStats reports text-only search work. Counters are intentionally
+// lexical/search-specific and avoid hybrid candidate/fusion terminology.
+type TextSearchStats struct {
+	QueryTerms        int
+	PostingsScanned   uint64
+	CandidatesScored  uint64
+	DocumentsFetched  uint64
+	Truncated         bool
+	Unavailable       bool
+	UnavailableReason string
+}
+
+// TextSearchResponse contains ranked text results and diagnostics.
+type TextSearchResponse struct {
+	Results []TextSearchResult
+	Stats   TextSearchStats
+}
+
+// SearchText validates the declared text index and query shape, then fails
+// closed until the persistent postings/text-state/stats search path lands in a
+// later #1764 milestone. It never scans/ranks all collection documents.
+func (c *Collection) SearchText(opts TextSearchOptions) (TextSearchResponse, error) {
+	var response TextSearchResponse
+	if c == nil {
+		return response, errCollectionNil
+	}
+	if c.db == nil {
+		return response, errCollectionDBNil
+	}
+	if err := ValidateIndexName(opts.IndexName); err != nil {
+		return response, err
+	}
+	if opts.TopK <= 0 {
+		return response, errors.New("collections: text search TopK must be positive")
+	}
+	if _, err := normalizeTextSearchOperator(opts.Operator); err != nil {
+		return response, err
+	}
+
+	snap := c.db.AcquireSnapshot()
+	if snap == nil {
+		return response, backenddb.ErrClosed
+	}
+	defer func() { _ = snap.Close() }()
+	catalog, err := c.catalogForSnapshot(snap)
+	if err != nil {
+		return response, err
+	}
+	if catalog == nil {
+		return response, errCollectionNotFound
+	}
+	idx, ok := findTextIndex(catalog.meta.TextIndexes, opts.IndexName)
+	if !ok {
+		return response, ErrIndexNotFound
+	}
+
+	terms, _, err := parseTextSearchQuery(idx.Analyzer, opts.Query, opts.Operator)
+	if err != nil {
+		return response, err
+	}
+	response.Stats.QueryTerms = len(terms)
+	if len(terms) == 0 {
+		response.Results = []TextSearchResult{}
+		return response, nil
+	}
+	response.Stats.Unavailable = true
+	response.Stats.UnavailableReason = textSearchUnavailableStorage
+	return response, fmt.Errorf("%w: collection %q text index %q has no persistent postings/text-state/stats storage yet", ErrTextIndexUnavailable, catalog.meta.Name, idx.Name)
+}
+
+func normalizeTextSearchOperator(op TextSearchOperator) (TextSearchOperator, error) {
+	switch op {
+	case "", TextSearchOperatorOR:
+		return TextSearchOperatorOR, nil
+	case TextSearchOperatorAND:
+		return TextSearchOperatorAND, nil
+	default:
+		return "", fmt.Errorf("collections: unsupported text search operator %q", op)
+	}
+}
+
+func parseTextSearchQuery(analyzer TextAnalyzer, query string, requested TextSearchOperator) ([]string, TextSearchOperator, error) {
+	if strings.ContainsAny(query, "\"()") {
+		return nil, "", errors.New("collections: unsupported text query syntax: phrase and grouped queries are not implemented")
+	}
+	operator := requested
+	var explicit TextSearchOperator
+	parts := strings.Fields(query)
+	terms := make([]string, 0, len(parts))
+	expectTerm := true
+	for _, part := range parts {
+		switch {
+		case strings.EqualFold(part, "AND"):
+			if expectTerm {
+				return nil, "", errors.New("collections: malformed text query: dangling AND")
+			}
+			if explicit != "" && explicit != TextSearchOperatorAND {
+				return nil, "", errors.New("collections: mixed AND/OR text queries are not supported")
+			}
+			explicit = TextSearchOperatorAND
+			expectTerm = true
+			continue
+		case strings.EqualFold(part, "OR"):
+			if expectTerm {
+				return nil, "", errors.New("collections: malformed text query: dangling OR")
+			}
+			if explicit != "" && explicit != TextSearchOperatorOR {
+				return nil, "", errors.New("collections: mixed AND/OR text queries are not supported")
+			}
+			explicit = TextSearchOperatorOR
+			expectTerm = true
+			continue
+		}
+		tokens, err := AnalyzeText(analyzer, part)
+		if err != nil {
+			return nil, "", err
+		}
+		if len(tokens) == 0 {
+			continue
+		}
+		for _, token := range tokens {
+			terms = append(terms, token.Term)
+		}
+		expectTerm = false
+	}
+	if expectTerm && len(terms) > 0 {
+		return nil, "", errors.New("collections: malformed text query: dangling operator")
+	}
+	if explicit != "" {
+		if requested != "" && requested != explicit {
+			return nil, "", fmt.Errorf("collections: text query operator %q conflicts with requested operator %q", explicit, requested)
+		}
+		operator = explicit
+	}
+	if operator == "" {
+		operator = TextSearchOperatorOR
+	}
+	return terms, operator, nil
+}

--- a/TreeDB/collections/vector_index_metadata_test.go
+++ b/TreeDB/collections/vector_index_metadata_test.go
@@ -28,8 +28,8 @@ func TestColumnGraphVectorIndexMetadataUsesCollectionMetaVersionV2A(t *testing.T
 	if err := json.Unmarshal(raw, &disk); err != nil {
 		t.Fatalf("unmarshal collectionMetaDisk: %v", err)
 	}
-	if disk.Version != 3 {
-		t.Fatalf("collection metadata version=%d want 3 after adding durable vector_indexes", disk.Version)
+	if disk.Version != collectionMetaVersion {
+		t.Fatalf("collection metadata version=%d want %d after adding durable vector_indexes", disk.Version, collectionMetaVersion)
 	}
 	if len(disk.VectorIndexes) != 1 || disk.VectorIndexes[0].Name != "embedding_graph" {
 		t.Fatalf("encoded vector indexes=%+v", disk.VectorIndexes)

--- a/TreeDB/docs/spec/README.md
+++ b/TreeDB/docs/spec/README.md
@@ -82,6 +82,9 @@ Given pre-alpha status, this is a living spec that tracks implementation.
 - `TreeDB/docs/spec/collections-write-domain.md`
   - indexed collection write-domain visibility, async flush, backpressure, and
     durability-boundary semantics.
+- `TreeDB/docs/spec/collection-text-search.md`
+  - collection-native text index metadata, analyzer, root naming, query shape,
+    and PR1 fail-closed behavior before postings/text-state/stats storage lands.
 - `TreeDB/docs/spec/write-path-and-durability.md`
   - write pipeline and durability semantics for all durability modes.
 - `TreeDB/docs/spec/recovery.md`

--- a/TreeDB/docs/spec/collection-text-search.md
+++ b/TreeDB/docs/spec/collection-text-search.md
@@ -1,0 +1,106 @@
+# Collection Text Search Contract (M0/M1)
+
+Status: PR1 substrate for issue #1764. TreeDB collections are pre-alpha; this
+contract freezes the first metadata/analyzer/root/query shape, while persistent
+postings/text-state/stats storage and ranked execution remain follow-up work.
+
+## Scope in this milestone
+
+Implemented now:
+
+- `CollectionMeta.TextIndexes []TextIndexDefinition` metadata.
+- `TextIndexDefinition` / `TextIndexField` validation and JSON persistence.
+- Root naming helpers for future durable text state:
+  - `<collection>/text-index/<indexName>` for term/document postings.
+  - `<collection>/text-state/<indexName>` for document analyzed state.
+  - `<collection>/text-stats/<indexName>` for corpus and term statistics.
+- `simple` analyzer: Unicode lowercase tokenization over letters, digits, and
+  `_` so code-ish identifiers such as `HTTP_500` remain searchable.
+- `SearchText(TextSearchOptions)` query-shape validation that fails closed before
+  scanning because storage is not implemented yet.
+
+Not implemented in this milestone:
+
+- persistent postings, text-state, or text-stats values;
+- create/backfill/drop text index commands;
+- mutation maintenance for text indexes;
+- BM25/BM25F scoring;
+- phrase/proximity/highlighting/stemming/trigram/fuzzy search;
+- gateway or hybrid text+vector executor integration.
+
+## Metadata
+
+```go
+type TextIndexDefinition struct {
+    Name             string
+    Fields           []TextIndexField
+    Analyzer          TextAnalyzer
+    StorePositions    bool
+    StoreOffsets      bool
+    StoragePolicy     RootStoragePolicy
+    SchemaGeneration  uint64
+}
+
+type TextIndexField struct {
+    Field  string
+    Weight float64
+}
+```
+
+Validation rules:
+
+- `Name` is required and uses normal collection index-name validation.
+- At least one field is required.
+- Field paths use the same dotted-path validation as scalar indexes.
+- Duplicate fields in one text index are rejected.
+- `Weight == 0` normalizes to `1.0`; non-zero weights must be finite and
+  non-negative.
+- Analyzer `""` normalizes to `"simple"`; other analyzers fail closed until
+  implemented.
+- `StoreOffsets` requires `StorePositions` in this first format.
+- Text index names share the collection-wide index namespace with scalar and
+  vector indexes.
+
+## Query shape
+
+```go
+type TextSearchOptions struct {
+    IndexName            string
+    Query                string
+    Operator             TextSearchOperator // "or" default, or "and"
+    TopK                 int
+    IncludeDocuments     bool
+    DocumentFetchOptions DocumentFetchOptions
+}
+```
+
+The PR1 parser accepts whitespace-separated terms and optional explicit `AND` or
+`OR` separators. Mixed `AND`/`OR`, phrases, and grouped syntax fail closed. Query
+terms are analyzed with the declared index analyzer.
+
+`SearchText` currently returns `ErrTextIndexUnavailable` for non-empty analyzed
+queries against an existing text index. This is intentional: normal text queries
+MUST be indexed and bounded, and PR1 must not implement a fake scan-and-rank
+fallback. Empty analyzed queries return an empty result set.
+
+## Fail-closed write behavior
+
+Collections that declare text indexes reject insert/update/delete operations with
+`ErrTextIndexUnavailable` until M2/M3 land durable postings/text-state/stats and
+mutation maintenance. This prevents silent divergence between primary documents
+and text metadata.
+
+## Follow-up storage plan
+
+Later #1764 milestones will publish the three text roots atomically with primary
+and other collection roots:
+
+- postings entries keyed by analyzed term and document ID, with term frequency
+  and field information in values;
+- text-state entries keyed by document ID for update/delete diffing;
+- stats entries for corpus document count, term document frequency, and field
+  length totals used by BM25/BM25F.
+
+The first ranked execution milestone must range-scan postings by term, bound the
+candidate set, score candidates from persisted stats, and fetch full documents
+only for final top-K results.

--- a/TreeDB/docs/spec/collection-text-search.md
+++ b/TreeDB/docs/spec/collection-text-search.md
@@ -61,6 +61,15 @@ Validation rules:
 - Text index names share the collection-wide index namespace with scalar and
   vector indexes.
 
+Root storage policies:
+
+- `TextIndexDefinition.StoragePolicy` applies to the postings root
+  `<collection>/text-index/<indexName>`.
+- `<collection>/text-state/<indexName>` and
+  `<collection>/text-stats/<indexName>` use
+  `CollectionOptions.IndexStateStoragePolicy`, matching existing index-state and
+  vector-index maintenance roots.
+
 ## Query shape
 
 ```go

--- a/TreeDB/docs/spec/verification.md
+++ b/TreeDB/docs/spec/verification.md
@@ -192,6 +192,21 @@ matrix:
 - `data_outer=false,index_outer=false` (fast/control),
 - `data_outer=false,index_outer=true` (low-priority compatibility cell).
 
+## 11.1 Collection Text Search Metadata And Analyzer
+
+Invariant:
+- Collection text index metadata persists through reopen, root names are stable,
+  the simple analyzer is deterministic, and text-indexed writes/search fail
+  closed until persistent postings/text-state/stats maintenance lands.
+
+Coverage:
+- `TreeDB/collections/text_index_test.go`:
+  - `TestTextAnalyzerSimpleFixtures`
+  - `TestCollectionTextIndexMetadataValidateAndReopen`
+  - `TestCollectionTextIndexMetadataRejectsInvalidDefinitions`
+  - `TestCollectionTextRootNames`
+  - `TestCollectionTextIndexedOperationsFailClosedUntilStorageLands`
+
 ## 11.5 Planned User-Command WAL Durability Gate
 
 This section owns the canonical planned test matrix for the user-command WAL


### PR DESCRIPTION
## Objective

Land the #1764 M0/M1 text-only substrate for TreeDB collections: text-index metadata, simple analyzer, root/query-shape contracts, docs, and fail-closed behavior before postings/text-state/stats storage exists.

Fixes part of #1764. Coordinates with #2501 and consumes the #2502 dependency-ready contract without introducing hybrid candidate/fused search APIs.

## Context

This freezes the smallest safe collection-native text-search shape so later #1764 PRs can add persistent postings/text-state/stats, mutation maintenance, and ranked SearchText execution without inventing metadata/root names midstream.

## Non-goals

- No persistent postings/text-state/stats storage values.
- No insert/update/delete text-index maintenance beyond fail-closed guards.
- No BM25/BM25F execution.
- No query-vector keyword, `VECTOR(...)`, or other hybrid/syntax gateway.
- No hybrid executor, result fusion, candidate-only seam, or vector integration.
- No stemming/trigrams/fuzzy/phrase/highlighting.

## Design

- Adds `CollectionMeta.TextIndexes []TextIndexDefinition` and metadata version 4.
- Defines roots for future durable text state:
  - `<collection>/text-index/<indexName>`
  - `<collection>/text-state/<indexName>`
  - `<collection>/text-stats/<indexName>`
- Root policies are now recognized before roots are exposed:
  - text postings root uses `TextIndexDefinition.StoragePolicy`;
  - text-state and text-stats roots use `CollectionOptions.IndexStateStoragePolicy`.
- Adds `simple` analyzer with Unicode lowercase tokenization over letters, digits, and `_`.
- Adds `SearchText(TextSearchOptions)` shape that validates queries and fails closed with `ErrTextIndexUnavailable`; it never scan/ranks all documents.
- Text-indexed write operations fail closed with `ErrTextIndexUnavailable` until M2/M3 implement durable maintenance.
- Aligns with #2502 by avoiding `HybridSearchCandidate` / `HybridSearchResult` / `HybridSearchStats` duplicate names and avoiding fused/hybrid candidate APIs.

## Scope

Includes:
- `TreeDB/collections/text_*.go`
- collection metadata normalization/copy/root-name hooks
- root storage policy mapping for text roots
- fail-closed write/search guards for declared text indexes
- docs/spec text-search contract and verification matrix

Excludes:
- storage format values for postings/state/stats
- mutation maintenance
- ranked search execution
- hybrid/fused search code

## Correctness

Latest head: `956818111`.

Tests run:

- `GOWORK=off go test ./TreeDB/collections -run 'TestText|TestCollectionText' -count=1`
- `GOWORK=off go test ./TreeDB/collections -count=1`
- `GOWORK=off go test ./TreeDB/docs -count=1`
- `git diff --check`

Covered:
- analyzer punctuation/Unicode/numbers/code-ish/repeated/empty fixtures;
- metadata validation and normalization;
- metadata reopen persistence;
- root-name inclusion/exclusion;
- text-root storage policy mapping for postings/state/stats;
- unsupported/malformed query fail-closed parsing;
- text-indexed insert/update/delete/SearchText fail closed until storage lands.

## Performance

PR1 is not intended to change no-text write behavior. I reran the insert-batch smoke benches after the text-root policy fix against `origin/main` and latest head `956818111` on Apple M. Artifacts are under `/tmp/gomap_1764_pr1/`.

Command:

- base: `(cd /tmp/gomap_1764_base && GOWORK=off go test ./TreeDB/collections -run '^$' -bench 'BenchmarkCollectionInsertBatchProvidedID$|BenchmarkCollectionInsertBatchWithSecondaryIndexes$' -benchmem -benchtime=100000x -count=5)`
- after: `GOWORK=off go test ./TreeDB/collections -run '^$' -bench 'BenchmarkCollectionInsertBatchProvidedID$|BenchmarkCollectionInsertBatchWithSecondaryIndexes$' -benchmem -benchtime=100000x -count=5`
- compare: `benchstat /tmp/gomap_1764_pr1/base_insert_100000x.txt /tmp/gomap_1764_pr1/after_insert_100000x_policyfix_head.txt`

| Benchmark | base median ns/op | latest median ns/op | ops/sec latest | allocs/op | assessment |
|---|---:|---:|---:|---:|---|
| InsertBatchProvidedID | 844.3 | 719.6 | 1,389,661 | 1 | no significant regression (p=0.056) |
| InsertBatchWithSecondaryIndexes | 2,403 | 1,773 | 564,016 | 1 | improved vs base (p=0.008) |

Fallback counters stayed at zero. No material no-text insert regression accepted or observed.

Analyzer command from the original head of this PR remains applicable; analyzer code was unchanged by the policy fix:

- `GOWORK=off go test ./TreeDB/collections -run '^$' -bench 'BenchmarkSimpleTextAnalyzer$' -benchmem -benchtime=10000x -count=5`

| Analyzer case | median ns/op | ops/sec | B/op | allocs/op |
|---|---:|---:|---:|---:|
| short | 678.8 | 1,473,188 | 664 | 11 |
| long | 55,412 | 18,047 | 96,417 | 779 |

## Rollout / Toggle Plan

No runtime toggle. Declaring a text index is explicit metadata. Until storage lands, declared text indexes fail closed for writes/search rather than silently diverging or scanning.

## Follow-ups

- #1764 M2: persistent postings/text-state/stats encodings, backfill/drop.
- #1764 M3: insert/update/delete/checkpoint/reopen maintenance.
- #1764 M4: bounded ranked `SearchText` with BM25/BM25F and final top-K document fetch only.
- #2503 can later map text results into the #2502 `HybridSearchCandidate` contract once M4 lands.

## AI Review Loop

- Internal Pi reviewer: PASS on previous head; policy-fix delta reviewed locally with focused/full tests.
- Codex/Codex connector: actionable storage-policy comment fixed in `956818111`.
- CodeRabbit/CodeҚ: unavailable/rate-limited; its generated comment says the review could not start because the review limit/usage credits were exhausted.
- Confirmation: I did not manually request additional AI reviews after this fix.
