### PR TITLE
Implement TreeDB hybrid RRF fusion primitives

### DIFF
--- a/TreeDB/collections/hybrid_fusion.go
+++ b/TreeDB/collections/hybrid_fusion.go
@@ -1,0 +1,339 @@
+package collections
+
+import (
+	"fmt"
+	"math"
+	"sort"
+)
+
+// HybridFusionDefaultRRFK is the contract default RRF denominator offset used
+// when HybridFusionOptions.RRFK is zero.
+const HybridFusionDefaultRRFK = 60
+
+// FuseHybridSearchCandidates deterministically fuses already-generated hybrid
+// text/vector candidates into a bounded final result slice. The helper does not
+// run text or vector searches, open storage, apply scalar filters, or fetch
+// documents; callers must pass the already-bounded candidate lists they want to
+// fuse.
+//
+// The zero-value fusion method and tie policy use the #2502 contract defaults:
+// reciprocal-rank fusion and fused_score_best_rank_source_order_id. For RRF,
+// RRFK=0 means HybridFusionDefaultRRFK. topK bounds only the returned result
+// slice; counters still describe the full supplied candidate set.
+func FuseHybridSearchCandidates(candidates []HybridSearchCandidate, fusion HybridFusionOptions, topK int) ([]HybridSearchResult, HybridSearchStats, error) {
+	method := fusion.Method
+	if method == "" {
+		method = HybridFusionMethodRRF
+	}
+	if method != HybridFusionMethodRRF {
+		return nil, HybridSearchStats{}, fmt.Errorf("%w: hybrid fusion method %q", ErrHybridSearchUnsupported, method)
+	}
+
+	tiePolicy := fusion.TiePolicy
+	if tiePolicy == "" {
+		tiePolicy = HybridFusionTiePolicyScoreBestRankSourceID
+	}
+	if tiePolicy != HybridFusionTiePolicyScoreBestRankSourceID {
+		return nil, HybridSearchStats{}, fmt.Errorf("%w: hybrid fusion tie policy %q", ErrHybridSearchUnsupported, tiePolicy)
+	}
+
+	rrfK := fusion.RRFK
+	if rrfK == 0 {
+		rrfK = HybridFusionDefaultRRFK
+	}
+	if rrfK < 0 {
+		return nil, HybridSearchStats{}, fmt.Errorf("%w: hybrid fusion rrf_k must be non-negative", ErrHybridSearchUnsupported)
+	}
+
+	stats := HybridSearchStats{CandidatesFused: uint64(len(candidates))}
+	if len(candidates) == 0 {
+		return nil, stats, nil
+	}
+
+	sourceOrder, err := normalizeHybridFusionSourceOrder(fusion.SourceOrder)
+	if err != nil {
+		return nil, HybridSearchStats{}, err
+	}
+	accByID := make(map[string]int, len(candidates))
+	accumulators := make([]hybridFusionAccumulator, 0, len(candidates))
+
+	for _, candidate := range candidates {
+		if candidate.SourceRank <= 0 {
+			return nil, HybridSearchStats{}, fmt.Errorf("%w: hybrid candidate source_rank must be one-based", ErrHybridSearchUnsupported)
+		}
+		denominator := rrfK + candidate.SourceRank
+		if denominator <= 0 {
+			return nil, HybridSearchStats{}, fmt.Errorf("%w: hybrid fusion rrf denominator overflow", ErrHybridSearchUnsupported)
+		}
+
+		if _, err := hybridFusionSourceRank(candidate.Source, sourceOrder); err != nil {
+			return nil, HybridSearchStats{}, err
+		}
+
+		idx, ok := accByID[string(candidate.ID)]
+		if !ok {
+			idKey := string(candidate.ID)
+			idx = len(accumulators)
+			accByID[idKey] = idx
+			accumulators = append(accumulators, hybridFusionAccumulator{idKey: idKey})
+		}
+
+		if accumulators[idx].add(candidate, denominator) {
+			stats.FusionDuplicateCandidates++
+		}
+	}
+
+	stats.CandidatesAfterFusion = uint64(len(accumulators))
+	for i := range accumulators {
+		accumulators[i].finalize(sourceOrder)
+		switch {
+		case accumulators[i].hasText && accumulators[i].hasVector:
+			stats.FusionBoth++
+		case accumulators[i].hasText:
+			stats.FusionTextOnly++
+		case accumulators[i].hasVector:
+			stats.FusionVectorOnly++
+		}
+	}
+
+	sort.Slice(accumulators, func(i, j int) bool {
+		return hybridFusionAccumulatorLess(accumulators[i], accumulators[j])
+	})
+
+	limit := topK
+	if limit < 0 {
+		limit = 0
+	}
+	if limit > len(accumulators) {
+		limit = len(accumulators)
+	}
+	if limit < len(accumulators) {
+		stats.Truncated = uint64(len(accumulators) - limit)
+	}
+	if limit == 0 {
+		return nil, stats, nil
+	}
+
+	results := make([]HybridSearchResult, limit)
+	for i := 0; i < limit; i++ {
+		acc := accumulators[i]
+		sources := acc.sources(sourceOrder)
+		results[i] = HybridSearchResult{
+			ID:         []byte(acc.idKey),
+			Rank:       i + 1,
+			FusedScore: acc.fusedScore,
+			Sources:    sources,
+		}
+	}
+	return results, stats, nil
+}
+
+type hybridFusionAccumulator struct {
+	idKey string
+
+	text      HybridSourceContribution
+	hasText   bool
+	vector    HybridSourceContribution
+	hasVector bool
+
+	fusedScore        float64
+	bestRank          int
+	contributionCount int
+	bestSourceOrder   int
+}
+
+// add returns true when the candidate was a duplicate for the same exact
+// document ID and source. Same-source duplicates keep the best source-rank
+// contribution and never double-count RRF score.
+func (acc *hybridFusionAccumulator) add(candidate HybridSearchCandidate, denominator int) bool {
+	contribution := hybridSourceContributionFromCandidate(candidate, denominator)
+	switch candidate.Source {
+	case HybridCandidateSourceText:
+		if acc.hasText {
+			if hybridSourceContributionPreferred(contribution, acc.text) {
+				acc.text = contribution
+			}
+			return true
+		}
+		acc.text = contribution
+		acc.hasText = true
+		return false
+	case HybridCandidateSourceVector:
+		if acc.hasVector {
+			if hybridSourceContributionPreferred(contribution, acc.vector) {
+				acc.vector = contribution
+			}
+			return true
+		}
+		acc.vector = contribution
+		acc.hasVector = true
+		return false
+	default:
+		// Source validation happens before add. Keep the default branch as a guard
+		// for future call-site changes.
+		return false
+	}
+}
+
+func (acc *hybridFusionAccumulator) finalize(sourceOrder hybridFusionSourceOrder) {
+	acc.fusedScore = 0
+	acc.bestRank = 0
+	acc.contributionCount = 0
+	acc.bestSourceOrder = hybridFusionSourceOrderMissing
+	if acc.hasText {
+		acc.includeContribution(acc.text, sourceOrder)
+	}
+	if acc.hasVector {
+		acc.includeContribution(acc.vector, sourceOrder)
+	}
+}
+
+func (acc *hybridFusionAccumulator) includeContribution(contribution HybridSourceContribution, sourceOrder hybridFusionSourceOrder) {
+	acc.fusedScore += contribution.FusionScore
+	if acc.bestRank == 0 || contribution.SourceRank < acc.bestRank {
+		acc.bestRank = contribution.SourceRank
+	}
+	acc.contributionCount++
+	if rank, err := hybridFusionSourceRank(contribution.Source, sourceOrder); err == nil && rank < acc.bestSourceOrder {
+		acc.bestSourceOrder = rank
+	}
+}
+
+func (acc hybridFusionAccumulator) sources(sourceOrder hybridFusionSourceOrder) []HybridSourceContribution {
+	if acc.contributionCount == 0 {
+		return nil
+	}
+	if acc.hasText && acc.hasVector {
+		text := cloneHybridSourceContribution(acc.text)
+		vector := cloneHybridSourceContribution(acc.vector)
+		if sourceOrder.vectorRank < sourceOrder.textRank {
+			return []HybridSourceContribution{vector, text}
+		}
+		return []HybridSourceContribution{text, vector}
+	}
+	if acc.hasText {
+		return []HybridSourceContribution{cloneHybridSourceContribution(acc.text)}
+	}
+	return []HybridSourceContribution{cloneHybridSourceContribution(acc.vector)}
+}
+
+func hybridSourceContributionFromCandidate(candidate HybridSearchCandidate, denominator int) HybridSourceContribution {
+	return HybridSourceContribution{
+		Source:      candidate.Source,
+		IndexName:   candidate.IndexName,
+		SourceRank:  candidate.SourceRank,
+		Score:       candidate.Score,
+		ScoreKind:   candidate.ScoreKind,
+		FusionScore: 1.0 / float64(denominator),
+		TextMatches: candidate.TextMatches,
+	}
+}
+
+func hybridSourceContributionPreferred(candidate, existing HybridSourceContribution) bool {
+	if candidate.SourceRank != existing.SourceRank {
+		return candidate.SourceRank < existing.SourceRank
+	}
+	candidateScoreNaN := math.IsNaN(candidate.Score)
+	existingScoreNaN := math.IsNaN(existing.Score)
+	if candidateScoreNaN != existingScoreNaN {
+		return !candidateScoreNaN
+	}
+	if !candidateScoreNaN && candidate.Score != existing.Score {
+		return candidate.Score > existing.Score
+	}
+	if candidate.IndexName != existing.IndexName {
+		return candidate.IndexName < existing.IndexName
+	}
+	return string(candidate.ScoreKind) < string(existing.ScoreKind)
+}
+
+func hybridFusionAccumulatorLess(a, b hybridFusionAccumulator) bool {
+	if a.fusedScore != b.fusedScore {
+		return a.fusedScore > b.fusedScore
+	}
+	if a.bestRank != b.bestRank {
+		return a.bestRank < b.bestRank
+	}
+	if a.contributionCount != b.contributionCount {
+		return a.contributionCount > b.contributionCount
+	}
+	if a.bestSourceOrder != b.bestSourceOrder {
+		return a.bestSourceOrder < b.bestSourceOrder
+	}
+	return a.idKey < b.idKey
+}
+
+type hybridFusionSourceOrder struct {
+	textRank   int
+	vectorRank int
+}
+
+const hybridFusionSourceOrderMissing = 1 << 30
+
+func normalizeHybridFusionSourceOrder(sourceOrder []HybridCandidateSource) (hybridFusionSourceOrder, error) {
+	order := hybridFusionSourceOrder{textRank: hybridFusionSourceOrderMissing, vectorRank: hybridFusionSourceOrderMissing}
+	nextRank := 0
+	assign := func(source HybridCandidateSource) error {
+		switch source {
+		case "":
+			return nil
+		case HybridCandidateSourceText:
+			if order.textRank == hybridFusionSourceOrderMissing {
+				order.textRank = nextRank
+				nextRank++
+			}
+			return nil
+		case HybridCandidateSourceVector:
+			if order.vectorRank == hybridFusionSourceOrderMissing {
+				order.vectorRank = nextRank
+				nextRank++
+			}
+			return nil
+		default:
+			return fmt.Errorf("%w: hybrid fusion source order contains source %q", ErrHybridSearchUnsupported, source)
+		}
+	}
+	for _, source := range sourceOrder {
+		if err := assign(source); err != nil {
+			return hybridFusionSourceOrder{}, err
+		}
+	}
+	if err := assign(HybridCandidateSourceText); err != nil {
+		return hybridFusionSourceOrder{}, err
+	}
+	if err := assign(HybridCandidateSourceVector); err != nil {
+		return hybridFusionSourceOrder{}, err
+	}
+	return order, nil
+}
+
+func hybridFusionSourceRank(source HybridCandidateSource, sourceOrder hybridFusionSourceOrder) (int, error) {
+	switch source {
+	case HybridCandidateSourceText:
+		return sourceOrder.textRank, nil
+	case HybridCandidateSourceVector:
+		return sourceOrder.vectorRank, nil
+	default:
+		return 0, fmt.Errorf("%w: hybrid candidate source %q", ErrHybridSearchUnsupported, source)
+	}
+}
+
+func cloneHybridSourceContribution(in HybridSourceContribution) HybridSourceContribution {
+	out := in
+	out.TextMatches = cloneHybridTextMatches(in.TextMatches)
+	return out
+}
+
+func cloneHybridTextMatches(in []HybridTextMatch) []HybridTextMatch {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]HybridTextMatch, len(in))
+	for i := range in {
+		out[i].Field = in[i].Field
+		if len(in[i].Terms) > 0 {
+			out[i].Terms = append([]string(nil), in[i].Terms...)
+		}
+	}
+	return out
+}

--- a/TreeDB/collections/hybrid_fusion.go
+++ b/TreeDB/collections/hybrid_fusion.go
@@ -45,14 +45,14 @@ func FuseHybridSearchCandidates(candidates []HybridSearchCandidate, fusion Hybri
 		return nil, HybridSearchStats{}, fmt.Errorf("%w: hybrid fusion rrf_k must be non-negative", ErrHybridSearchUnsupported)
 	}
 
-	stats := HybridSearchStats{CandidatesFused: uint64(len(candidates))}
-	if len(candidates) == 0 {
-		return nil, stats, nil
-	}
-
 	sourceOrder, err := normalizeHybridFusionSourceOrder(fusion.SourceOrder)
 	if err != nil {
 		return nil, HybridSearchStats{}, err
+	}
+
+	stats := HybridSearchStats{CandidatesFused: uint64(len(candidates))}
+	if len(candidates) == 0 {
+		return nil, stats, nil
 	}
 	accByID := make(map[string]int, len(candidates))
 	accumulators := make([]hybridFusionAccumulator, 0, len(candidates))

--- a/TreeDB/collections/hybrid_fusion.go
+++ b/TreeDB/collections/hybrid_fusion.go
@@ -190,12 +190,19 @@ func (acc *hybridFusionAccumulator) finalize(sourceOrder hybridFusionSourceOrder
 
 func (acc *hybridFusionAccumulator) includeContribution(contribution HybridSourceContribution, sourceOrder hybridFusionSourceOrder) {
 	acc.fusedScore += contribution.FusionScore
+	acc.contributionCount++
+
+	contributionSourceOrder := hybridFusionSourceOrderMissing
+	if rank, err := hybridFusionSourceRank(contribution.Source, sourceOrder); err == nil {
+		contributionSourceOrder = rank
+	}
 	if acc.bestRank == 0 || contribution.SourceRank < acc.bestRank {
 		acc.bestRank = contribution.SourceRank
+		acc.bestSourceOrder = contributionSourceOrder
+		return
 	}
-	acc.contributionCount++
-	if rank, err := hybridFusionSourceRank(contribution.Source, sourceOrder); err == nil && rank < acc.bestSourceOrder {
-		acc.bestSourceOrder = rank
+	if contribution.SourceRank == acc.bestRank && contributionSourceOrder < acc.bestSourceOrder {
+		acc.bestSourceOrder = contributionSourceOrder
 	}
 }
 

--- a/TreeDB/collections/hybrid_fusion_bench_test.go
+++ b/TreeDB/collections/hybrid_fusion_bench_test.go
@@ -3,7 +3,6 @@ package collections
 import (
 	"fmt"
 	"testing"
-	"time"
 )
 
 var (
@@ -22,7 +21,6 @@ func BenchmarkHybridRRFFusion(b *testing.B) {
 			}
 			b.ReportAllocs()
 			b.ResetTimer()
-			start := time.Now()
 			for i := 0; i < b.N; i++ {
 				results, stats, err := FuseHybridSearchCandidates(candidates, HybridFusionOptions{}, topK)
 				if err != nil {
@@ -30,9 +28,6 @@ func BenchmarkHybridRRFFusion(b *testing.B) {
 				}
 				hybridFusionBenchmarkResults = results
 				hybridFusionBenchmarkStats = stats
-			}
-			if elapsed := time.Since(start); elapsed > 0 {
-				b.ReportMetric(float64(b.N)/elapsed.Seconds(), "ops/sec")
 			}
 		})
 	}

--- a/TreeDB/collections/hybrid_fusion_bench_test.go
+++ b/TreeDB/collections/hybrid_fusion_bench_test.go
@@ -1,0 +1,69 @@
+package collections
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+var (
+	hybridFusionBenchmarkResults []HybridSearchResult
+	hybridFusionBenchmarkStats   HybridSearchStats
+)
+
+func BenchmarkHybridRRFFusion(b *testing.B) {
+	for _, candidateCount := range []int{10, 100, 1000, 10000} {
+		candidateCount := candidateCount
+		b.Run(fmt.Sprintf("candidates_%d", candidateCount), func(b *testing.B) {
+			candidates := makeHybridFusionBenchmarkCandidates(candidateCount)
+			topK := 25
+			if candidateCount < topK {
+				topK = candidateCount
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			start := time.Now()
+			for i := 0; i < b.N; i++ {
+				results, stats, err := FuseHybridSearchCandidates(candidates, HybridFusionOptions{}, topK)
+				if err != nil {
+					b.Fatalf("FuseHybridSearchCandidates: %v", err)
+				}
+				hybridFusionBenchmarkResults = results
+				hybridFusionBenchmarkStats = stats
+			}
+			if elapsed := time.Since(start); elapsed > 0 {
+				b.ReportMetric(float64(b.N)/elapsed.Seconds(), "ops/sec")
+			}
+		})
+	}
+}
+
+func makeHybridFusionBenchmarkCandidates(n int) []HybridSearchCandidate {
+	candidates := make([]HybridSearchCandidate, 0, n)
+	for i := 0; i < n; i++ {
+		source := HybridCandidateSourceText
+		scoreKind := HybridScoreKindBM25
+		indexName := "body"
+		sourceRank := i/2 + 1
+		// Every fourth text/vector pair overlaps on the same document ID so the
+		// benchmark covers both union and duplicate-contribution paths.
+		docOrdinal := i
+		if i%2 == 1 {
+			source = HybridCandidateSourceVector
+			scoreKind = HybridScoreKindVectorSimilarity
+			indexName = "embedding"
+			if (i/2)%4 == 0 {
+				docOrdinal = i - 1
+			}
+		}
+		candidates = append(candidates, HybridSearchCandidate{
+			ID:         []byte(fmt.Sprintf("doc-%08d", docOrdinal)),
+			Source:     source,
+			IndexName:  indexName,
+			SourceRank: sourceRank,
+			Score:      float64(n-i) / float64(n+1),
+			ScoreKind:  scoreKind,
+		})
+	}
+	return candidates
+}

--- a/TreeDB/collections/hybrid_fusion_test.go
+++ b/TreeDB/collections/hybrid_fusion_test.go
@@ -181,6 +181,35 @@ func TestHybridRRFFusionStableTiesSourceOrderAndIDBytes(t *testing.T) {
 	}
 }
 
+func TestHybridRRFFusionTieUsesBestRankedContributionSourceOrder(t *testing.T) {
+	candidates := []HybridSearchCandidate{
+		// The two documents have equal fused score, equal best rank, and equal
+		// contributing-source count. The source-order tie breaker must use the
+		// source that supplied the best-ranked contribution, not just the earliest
+		// source among all contributions.
+		hybridFusionCandidate("a-vector-best", HybridCandidateSourceVector, 1, 1, HybridScoreKindVectorSimilarity),
+		hybridFusionCandidate("a-vector-best", HybridCandidateSourceText, 2, 1, HybridScoreKindBM25),
+		hybridFusionCandidate("z-text-best", HybridCandidateSourceText, 1, 1, HybridScoreKindBM25),
+		hybridFusionCandidate("z-text-best", HybridCandidateSourceVector, 2, 1, HybridScoreKindVectorSimilarity),
+	}
+
+	results, _, err := FuseHybridSearchCandidates(candidates, HybridFusionOptions{}, 2)
+	if err != nil {
+		t.Fatalf("FuseHybridSearchCandidates default source order: %v", err)
+	}
+	if got := []string{string(results[0].ID), string(results[1].ID)}; got[0] != "z-text-best" || got[1] != "a-vector-best" {
+		t.Fatalf("default best-ranked source tie order=%v want text-best before vector-best", got)
+	}
+
+	results, _, err = FuseHybridSearchCandidates(candidates, HybridFusionOptions{SourceOrder: []HybridCandidateSource{HybridCandidateSourceVector, HybridCandidateSourceText}}, 2)
+	if err != nil {
+		t.Fatalf("FuseHybridSearchCandidates custom source order: %v", err)
+	}
+	if got := []string{string(results[0].ID), string(results[1].ID)}; got[0] != "a-vector-best" || got[1] != "z-text-best" {
+		t.Fatalf("custom best-ranked source tie order=%v want vector-best before text-best", got)
+	}
+}
+
 func TestHybridRRFFusionTopKAndCandidateBounds(t *testing.T) {
 	candidates := []HybridSearchCandidate{
 		hybridFusionCandidate("d1", HybridCandidateSourceText, 1, 1, HybridScoreKindBM25),

--- a/TreeDB/collections/hybrid_fusion_test.go
+++ b/TreeDB/collections/hybrid_fusion_test.go
@@ -227,6 +227,11 @@ func TestHybridRRFFusionRejectsUnsupportedOptions(t *testing.T) {
 		t.Fatalf("unsupported tie err=%v want ErrHybridSearchUnsupported", err)
 	}
 
+	_, _, err = FuseHybridSearchCandidates(nil, HybridFusionOptions{SourceOrder: []HybridCandidateSource{HybridCandidateSource("image")}}, 1)
+	if !errors.Is(err, ErrHybridSearchUnsupported) {
+		t.Fatalf("bad source order on empty candidates err=%v want ErrHybridSearchUnsupported", err)
+	}
+
 	_, _, err = FuseHybridSearchCandidates([]HybridSearchCandidate{hybridFusionCandidate("d1", HybridCandidateSourceText, 1, 1, HybridScoreKindBM25)}, HybridFusionOptions{SourceOrder: []HybridCandidateSource{HybridCandidateSource("image")}}, 1)
 	if !errors.Is(err, ErrHybridSearchUnsupported) {
 		t.Fatalf("bad source order err=%v want ErrHybridSearchUnsupported", err)

--- a/TreeDB/collections/hybrid_fusion_test.go
+++ b/TreeDB/collections/hybrid_fusion_test.go
@@ -1,0 +1,263 @@
+package collections
+
+import (
+	"errors"
+	"math"
+	"testing"
+)
+
+func TestHybridRRFFusionTextOnlyVectorOnlyAndOverlap(t *testing.T) {
+	candidates := []HybridSearchCandidate{
+		hybridFusionCandidate("doc-text-1", HybridCandidateSourceText, 1, 12, HybridScoreKindBM25),
+		hybridFusionCandidate("doc-shared", HybridCandidateSourceText, 2, 9, HybridScoreKindBM25),
+		hybridFusionCandidate("doc-vector-1", HybridCandidateSourceVector, 1, 0.95, HybridScoreKindVectorSimilarity),
+		hybridFusionCandidate("doc-shared", HybridCandidateSourceVector, 2, 0.90, HybridScoreKindVectorSimilarity),
+	}
+
+	results, stats, err := FuseHybridSearchCandidates(candidates, HybridFusionOptions{}, 10)
+	if err != nil {
+		t.Fatalf("FuseHybridSearchCandidates: %v", err)
+	}
+	if len(results) != 3 {
+		t.Fatalf("len(results)=%d want 3", len(results))
+	}
+	if got, want := string(results[0].ID), "doc-shared"; got != want {
+		t.Fatalf("top result id=%q want %q; results=%+v", got, want, results)
+	}
+	wantSharedScore := 1.0/62.0 + 1.0/62.0
+	if !hybridFloatClose(results[0].FusedScore, wantSharedScore) {
+		t.Fatalf("shared fused score=%g want %g", results[0].FusedScore, wantSharedScore)
+	}
+	if len(results[0].Sources) != 2 || results[0].Sources[0].Source != HybridCandidateSourceText || results[0].Sources[1].Source != HybridCandidateSourceVector {
+		t.Fatalf("shared sources=%+v want text then vector contributions", results[0].Sources)
+	}
+	if got, want := results[1].FusedScore, 1.0/61.0; !hybridFloatClose(got, want) {
+		t.Fatalf("single-source fused score=%g want %g", got, want)
+	}
+	if got := []string{string(results[1].ID), string(results[2].ID)}; got[0] != "doc-text-1" || got[1] != "doc-vector-1" {
+		t.Fatalf("single-source tie order=%v want text-only before vector-only", got)
+	}
+	if stats.CandidatesFused != 4 || stats.CandidatesAfterFusion != 3 || stats.FusionTextOnly != 1 || stats.FusionVectorOnly != 1 || stats.FusionBoth != 1 || stats.Truncated != 0 {
+		t.Fatalf("stats=%+v want fused=4 unique=3 text-only=1 vector-only=1 both=1 truncated=0", stats)
+	}
+	for i, result := range results {
+		if result.Rank != i+1 {
+			t.Fatalf("result[%d].Rank=%d want %d", i, result.Rank, i+1)
+		}
+	}
+}
+
+func TestHybridRRFFusionVectorOnlyUsesRanks(t *testing.T) {
+	candidates := []HybridSearchCandidate{
+		hybridFusionCandidate("v3", HybridCandidateSourceVector, 3, 0.99, HybridScoreKindVectorSimilarity),
+		hybridFusionCandidate("v1", HybridCandidateSourceVector, 1, 0.80, HybridScoreKindVectorSimilarity),
+		hybridFusionCandidate("v2", HybridCandidateSourceVector, 2, 0.70, HybridScoreKindVectorSimilarity),
+	}
+
+	results, stats, err := FuseHybridSearchCandidates(candidates, HybridFusionOptions{RRFK: 10}, 3)
+	if err != nil {
+		t.Fatalf("FuseHybridSearchCandidates: %v", err)
+	}
+	gotIDs := []string{string(results[0].ID), string(results[1].ID), string(results[2].ID)}
+	wantIDs := []string{"v1", "v2", "v3"}
+	for i := range wantIDs {
+		if gotIDs[i] != wantIDs[i] {
+			t.Fatalf("ids=%v want %v", gotIDs, wantIDs)
+		}
+	}
+	if got, want := results[0].FusedScore, 1.0/11.0; !hybridFloatClose(got, want) {
+		t.Fatalf("rank-1 score=%g want %g", got, want)
+	}
+	if stats.FusionVectorOnly != 3 || stats.FusionTextOnly != 0 || stats.FusionBoth != 0 {
+		t.Fatalf("stats=%+v want three vector-only returned results", stats)
+	}
+}
+
+func TestHybridRRFFusionDeduplicatesExactIDsAndPreservesAttribution(t *testing.T) {
+	candidates := []HybridSearchCandidate{
+		{
+			ID:         []byte("same"),
+			Source:     HybridCandidateSourceText,
+			IndexName:  "body",
+			SourceRank: 2,
+			Score:      4.2,
+			ScoreKind:  HybridScoreKindBM25F,
+			TextMatches: []HybridTextMatch{{
+				Field: "body",
+				Terms: []string{"tree", "db"},
+			}},
+		},
+		// Same exact document ID and same source should not double-count; the better
+		// source rank remains the text contribution.
+		{
+			ID:         []byte("same"),
+			Source:     HybridCandidateSourceText,
+			IndexName:  "body",
+			SourceRank: 5,
+			Score:      99,
+			ScoreKind:  HybridScoreKindBM25F,
+		},
+		hybridFusionCandidate("same", HybridCandidateSourceVector, 3, 0.75, HybridScoreKindVectorSimilarity),
+		hybridFusionCandidate("missing-text-side", HybridCandidateSourceVector, 1, 0.9, HybridScoreKindVectorSimilarity),
+	}
+
+	results, stats, err := FuseHybridSearchCandidates(candidates, HybridFusionOptions{}, 10)
+	if err != nil {
+		t.Fatalf("FuseHybridSearchCandidates: %v", err)
+	}
+	var shared *HybridSearchResult
+	for i := range results {
+		if string(results[i].ID) == "same" {
+			shared = &results[i]
+		}
+	}
+	if shared == nil {
+		t.Fatalf("shared result missing: %+v", results)
+	}
+	if len(shared.Sources) != 2 {
+		t.Fatalf("shared sources=%+v want exactly text and vector", shared.Sources)
+	}
+	if shared.Sources[0].Source != HybridCandidateSourceText || shared.Sources[0].SourceRank != 2 || shared.Sources[0].Score != 4.2 || shared.Sources[0].ScoreKind != HybridScoreKindBM25F {
+		t.Fatalf("text contribution=%+v want best text duplicate with attribution", shared.Sources[0])
+	}
+	if shared.Sources[1].Source != HybridCandidateSourceVector || shared.Sources[1].SourceRank != 3 {
+		t.Fatalf("vector contribution=%+v want vector rank 3", shared.Sources[1])
+	}
+	wantScore := 1.0/62.0 + 1.0/63.0
+	if !hybridFloatClose(shared.FusedScore, wantScore) {
+		t.Fatalf("shared fused score=%g want %g", shared.FusedScore, wantScore)
+	}
+	if len(shared.Sources[0].TextMatches) != 1 || shared.Sources[0].TextMatches[0].Terms[0] != "tree" {
+		t.Fatalf("text matches=%+v want preserved terms", shared.Sources[0].TextMatches)
+	}
+
+	candidates[0].ID[0] = 'X'
+	candidates[0].TextMatches[0].Terms[0] = "mutated"
+	if got := string(shared.ID); got != "same" {
+		t.Fatalf("result ID mutated to %q; want response-owned copy", got)
+	}
+	if got := shared.Sources[0].TextMatches[0].Terms[0]; got != "tree" {
+		t.Fatalf("text match term mutated to %q; want response-owned copy", got)
+	}
+	if stats.CandidatesFused != 4 || stats.CandidatesAfterFusion != 2 || stats.FusionDuplicateCandidates != 1 || stats.FusionBoth != 1 || stats.FusionVectorOnly != 1 {
+		t.Fatalf("stats=%+v want input, dedup, both, and vector-only counters", stats)
+	}
+}
+
+func TestHybridRRFFusionStableTiesSourceOrderAndIDBytes(t *testing.T) {
+	candidates := []HybridSearchCandidate{
+		hybridFusionCandidate("vector-doc", HybridCandidateSourceVector, 1, 1, HybridScoreKindVectorSimilarity),
+		hybridFusionCandidate("text-doc", HybridCandidateSourceText, 1, 1, HybridScoreKindBM25),
+		hybridFusionCandidate("b", HybridCandidateSourceText, 5, 1, HybridScoreKindBM25),
+		hybridFusionCandidate("a", HybridCandidateSourceText, 5, 1, HybridScoreKindBM25),
+	}
+
+	results, _, err := FuseHybridSearchCandidates(candidates, HybridFusionOptions{}, 10)
+	if err != nil {
+		t.Fatalf("FuseHybridSearchCandidates default order: %v", err)
+	}
+	if got := []string{string(results[0].ID), string(results[1].ID), string(results[2].ID), string(results[3].ID)}; got[0] != "text-doc" || got[1] != "vector-doc" || got[2] != "a" || got[3] != "b" {
+		t.Fatalf("default tie order=%v want text-doc, vector-doc, a, b", got)
+	}
+
+	results, _, err = FuseHybridSearchCandidates(candidates, HybridFusionOptions{SourceOrder: []HybridCandidateSource{HybridCandidateSourceVector, HybridCandidateSourceText}}, 10)
+	if err != nil {
+		t.Fatalf("FuseHybridSearchCandidates custom order: %v", err)
+	}
+	if got := []string{string(results[0].ID), string(results[1].ID)}; got[0] != "vector-doc" || got[1] != "text-doc" {
+		t.Fatalf("custom source order tie=%v want vector-doc before text-doc", got)
+	}
+
+	byteTieCandidates := []HybridSearchCandidate{
+		{ID: []byte{0x01}, Source: HybridCandidateSourceText, SourceRank: 7, Score: 1, ScoreKind: HybridScoreKindBM25},
+		{ID: []byte{0x00, 0xff}, Source: HybridCandidateSourceText, SourceRank: 7, Score: 1, ScoreKind: HybridScoreKindBM25},
+	}
+	results, _, err = FuseHybridSearchCandidates(byteTieCandidates, HybridFusionOptions{}, 10)
+	if err != nil {
+		t.Fatalf("FuseHybridSearchCandidates byte ties: %v", err)
+	}
+	if got := results[0].ID; len(got) != 2 || got[0] != 0x00 || got[1] != 0xff {
+		t.Fatalf("byte tie winner=%v want lexicographically smallest opaque bytes", got)
+	}
+}
+
+func TestHybridRRFFusionTopKAndCandidateBounds(t *testing.T) {
+	candidates := []HybridSearchCandidate{
+		hybridFusionCandidate("d1", HybridCandidateSourceText, 1, 1, HybridScoreKindBM25),
+		hybridFusionCandidate("d2", HybridCandidateSourceText, 2, 1, HybridScoreKindBM25),
+		hybridFusionCandidate("d3", HybridCandidateSourceVector, 3, 1, HybridScoreKindVectorSimilarity),
+	}
+
+	results, stats, err := FuseHybridSearchCandidates(candidates, HybridFusionOptions{}, 2)
+	if err != nil {
+		t.Fatalf("FuseHybridSearchCandidates topK=2: %v", err)
+	}
+	if len(results) != 2 || results[0].Rank != 1 || results[1].Rank != 2 {
+		t.Fatalf("results=%+v want exactly top 2 with one-based ranks", results)
+	}
+	if stats.CandidatesFused != 3 || stats.CandidatesAfterFusion != 3 || stats.Truncated != 1 || stats.FusionTextOnly != 2 || stats.FusionVectorOnly != 1 {
+		t.Fatalf("stats=%+v want fused=3 after=3 truncated=1 and full fused-set source counters", stats)
+	}
+
+	results, stats, err = FuseHybridSearchCandidates(candidates, HybridFusionOptions{}, 10)
+	if err != nil {
+		t.Fatalf("FuseHybridSearchCandidates topK=10: %v", err)
+	}
+	if len(results) != 3 || stats.Truncated != 0 || stats.FusionVectorOnly != 1 {
+		t.Fatalf("len=%d stats=%+v want all candidates and no truncation", len(results), stats)
+	}
+
+	results, stats, err = FuseHybridSearchCandidates(candidates, HybridFusionOptions{}, 0)
+	if err != nil {
+		t.Fatalf("FuseHybridSearchCandidates topK=0: %v", err)
+	}
+	if len(results) != 0 || stats.CandidatesAfterFusion != 3 || stats.Truncated != 3 || stats.FusionTextOnly != 2 || stats.FusionVectorOnly != 1 {
+		t.Fatalf("topK=0 results=%+v stats=%+v want no results, full fused counters, truncated count", results, stats)
+	}
+}
+
+func TestHybridRRFFusionRejectsUnsupportedOptions(t *testing.T) {
+	_, _, err := FuseHybridSearchCandidates([]HybridSearchCandidate{hybridFusionCandidate("d1", HybridCandidateSourceText, 1, 1, HybridScoreKindBM25)}, HybridFusionOptions{Method: HybridFusionMethod("linear")}, 1)
+	if !errors.Is(err, ErrHybridSearchUnsupported) {
+		t.Fatalf("unsupported method err=%v want ErrHybridSearchUnsupported", err)
+	}
+
+	_, _, err = FuseHybridSearchCandidates([]HybridSearchCandidate{hybridFusionCandidate("d1", HybridCandidateSourceText, 1, 1, HybridScoreKindBM25)}, HybridFusionOptions{TiePolicy: HybridFusionTiePolicy("score_only")}, 1)
+	if !errors.Is(err, ErrHybridSearchUnsupported) {
+		t.Fatalf("unsupported tie err=%v want ErrHybridSearchUnsupported", err)
+	}
+
+	_, _, err = FuseHybridSearchCandidates([]HybridSearchCandidate{hybridFusionCandidate("d1", HybridCandidateSourceText, 1, 1, HybridScoreKindBM25)}, HybridFusionOptions{SourceOrder: []HybridCandidateSource{HybridCandidateSource("image")}}, 1)
+	if !errors.Is(err, ErrHybridSearchUnsupported) {
+		t.Fatalf("bad source order err=%v want ErrHybridSearchUnsupported", err)
+	}
+
+	_, _, err = FuseHybridSearchCandidates([]HybridSearchCandidate{hybridFusionCandidate("d1", HybridCandidateSourceText, 0, 1, HybridScoreKindBM25)}, HybridFusionOptions{}, 1)
+	if !errors.Is(err, ErrHybridSearchUnsupported) {
+		t.Fatalf("bad rank err=%v want ErrHybridSearchUnsupported", err)
+	}
+
+	_, _, err = FuseHybridSearchCandidates([]HybridSearchCandidate{{ID: []byte("d1"), Source: HybridCandidateSource("image"), SourceRank: 1}}, HybridFusionOptions{}, 1)
+	if !errors.Is(err, ErrHybridSearchUnsupported) {
+		t.Fatalf("bad source err=%v want ErrHybridSearchUnsupported", err)
+	}
+}
+
+func hybridFusionCandidate(id string, source HybridCandidateSource, rank int, score float64, kind HybridScoreKind) HybridSearchCandidate {
+	indexName := "body"
+	if source == HybridCandidateSourceVector {
+		indexName = "embedding"
+	}
+	return HybridSearchCandidate{
+		ID:         []byte(id),
+		Source:     source,
+		IndexName:  indexName,
+		SourceRank: rank,
+		Score:      score,
+		ScoreKind:  kind,
+	}
+}
+
+func hybridFloatClose(got, want float64) bool {
+	return math.Abs(got-want) <= 1e-12
+}

--- a/TreeDB/collections/hybrid_search.go
+++ b/TreeDB/collections/hybrid_search.go
@@ -246,6 +246,10 @@ type HybridSearchStats struct {
 	ScalarFilterRejected      uint64                 `json:"scalar_filter_rejected,omitempty"`
 	CandidatesFused           uint64                 `json:"candidates_fused,omitempty"`
 	CandidatesAfterFusion     uint64                 `json:"candidates_after_fusion,omitempty"`
+	FusionTextOnly            uint64                 `json:"fusion_text_only,omitempty"`
+	FusionVectorOnly          uint64                 `json:"fusion_vector_only,omitempty"`
+	FusionBoth                uint64                 `json:"fusion_both,omitempty"`
+	FusionDuplicateCandidates uint64                 `json:"fusion_duplicate_candidates,omitempty"`
 	CandidatesAfterFilter     uint64                 `json:"candidates_after_filter,omitempty"`
 	DocumentsFetched          uint64                 `json:"documents_fetched,omitempty"`
 	DocumentsMissing          uint64                 `json:"documents_missing,omitempty"`

--- a/TreeDB/docs/spec/hybrid-search-contract.md
+++ b/TreeDB/docs/spec/hybrid-search-contract.md
@@ -204,7 +204,8 @@ counter families:
 - scalar: `scalar_prefilter_ids`, `scalar_postfilter_checks`,
   `scalar_filter_matched`, `scalar_filter_rejected`;
 - fusion/finalization: `candidates_fused`, `candidates_after_fusion`,
-  `candidates_after_filter`, `truncated`;
+  `fusion_text_only`, `fusion_vector_only`, `fusion_both`,
+  `fusion_duplicate_candidates`, `candidates_after_filter`, `truncated`;
 - final fetch: `documents_fetched`, `documents_missing`;
 - guardrails: `full_document_scan_fallbacks`, `fail_closed`, and
   `fail_closed_reason`.
@@ -249,9 +250,10 @@ Issue `#2503` candidate-only paths should consume this contract as follows:
   source/index name, and source counters.
 
 Issue `#2504` fusion primitives should implement the RRF formula and deterministic tie
-policy above over slices of `HybridSearchCandidate`, returning fused result or
-source-contribution values without opening storage, fetching documents, or
-consulting text/vector indexes.
+policy above over slices of `HybridSearchCandidate`. The helper surface is
+`FuseHybridSearchCandidates(candidates, fusion, topK)`, which returns bounded
+`HybridSearchResult` values and fusion counters without opening storage,
+fetching documents, or consulting text/vector indexes.
 
 Issue `#2505` owns the executor that binds scalar filtering, source candidate APIs,
 fusion, and bounded final document fetch under the snapshot/epoch contract.

--- a/benchmarks/vector_db_compare/README.md
+++ b/benchmarks/vector_db_compare/README.md
@@ -61,7 +61,11 @@ scripts/bench_vector_db_compare.sh
 
 The quantized comparison leaves TreeDB quantized recall as an observation by
 setting `TREEDB_QUANTIZED_MIN_RECALL=0`; full-vector TreeDB/pgvector rows still
-use `MIN_RECALL` (default `0.95`) as their recall gate.
+use `MIN_RECALL` (default `0.95`) as their recall gate. TreeDB `column_graph`
+search timings are no-document buffered rows: they return IDs/scores, exclude
+document fetch/materialization, and expose guardrail counters such as
+`avg_response_owned_result_allocs`, `avg_documents_fetched`, and route/fallback
+averages in the demo JSON.
 
 Backends:
 

--- a/benchmarks/vector_db_compare/summarize.py
+++ b/benchmarks/vector_db_compare/summarize.py
@@ -233,6 +233,49 @@ def render(results: list[dict[str, Any]]) -> str:
                 )
             )
         lines.append("")
+    guardrail_fields = [
+        "avg_documents_fetched",
+        "avg_response_owned_result_allocs",
+        "avg_search_route_hnsw_search_pack",
+        "avg_search_route_quantized_only",
+        "avg_search_route_quantized_rerank",
+        "avg_search_route_column_graph_prepared",
+        "avg_search_route_column_graph_fallback",
+        "avg_graph_row_fallbacks",
+        "avg_typed_column_fallbacks",
+        "avg_vector_scratch_decodes",
+    ]
+    guardrail_rows = [
+        (result, row)
+        for result in results
+        if str(result.get("backend") or "treedb").startswith("treedb")
+        for row in result.get("search_benchmarks", [])
+        if any(field in row for field in guardrail_fields)
+    ]
+    if guardrail_rows:
+        lines.append("## TreeDB Search Guardrails")
+        lines.append("")
+        lines.append("| Backend | Search mode | Concurrency | Avg docs fetched | Avg response-owned allocs | Route hnsw_pack | Route qonly | Route qrerank | Route prepared | Route fallback | Graph fallbacks | Typed-column fallbacks | Vector scratch decodes |")
+        lines.append("| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |")
+        for result, row in guardrail_rows:
+            lines.append(
+                "| {backend} | {mode} | {concurrency} | {docs:.1f} | {owned:.1f} | {hnsw:.1f} | {qonly:.1f} | {qrerank:.1f} | {prepared:.1f} | {fallback:.1f} | {graph:.1f} | {typed:.1f} | {scratch:.1f} |".format(
+                    backend=backend_name(result),
+                    mode=search_row_mode(result, row),
+                    concurrency=row["concurrency"],
+                    docs=float(row.get("avg_documents_fetched", 0)),
+                    owned=float(row.get("avg_response_owned_result_allocs", 0)),
+                    hnsw=float(row.get("avg_search_route_hnsw_search_pack", 0)),
+                    qonly=float(row.get("avg_search_route_quantized_only", 0)),
+                    qrerank=float(row.get("avg_search_route_quantized_rerank", 0)),
+                    prepared=float(row.get("avg_search_route_column_graph_prepared", 0)),
+                    fallback=float(row.get("avg_search_route_column_graph_fallback", 0)),
+                    graph=float(row.get("avg_graph_row_fallbacks", 0)),
+                    typed=float(row.get("avg_typed_column_fallbacks", 0)),
+                    scratch=float(row.get("avg_vector_scratch_decodes", 0)),
+                )
+            )
+        lines.append("")
     lines.append("## Notes")
     lines.append("")
     lines.append("- sqlite-vec is intentionally not used here because upstream sqlite-vec is brute-force today; ANN support is tracked as future work.")

--- a/benchmarks/vector_db_compare/test_summarize.py
+++ b/benchmarks/vector_db_compare/test_summarize.py
@@ -33,6 +33,16 @@ def result(backend: str, query_mode: str = "") -> dict:
         "avg_quantized_rerank_exact_score_calls": 0,
         "avg_vector_bytes": 128,
         "avg_norm_bytes": 32,
+        "avg_documents_fetched": 0,
+        "avg_response_owned_result_allocs": 0,
+        "avg_search_route_hnsw_search_pack": 1,
+        "avg_search_route_quantized_only": 0,
+        "avg_search_route_quantized_rerank": 0,
+        "avg_search_route_column_graph_prepared": 0,
+        "avg_search_route_column_graph_fallback": 0,
+        "avg_graph_row_fallbacks": 0,
+        "avg_typed_column_fallbacks": 0,
+        "avg_vector_scratch_decodes": 0,
     }
     if query_mode == "quantized_only":
         row.update(
@@ -41,6 +51,8 @@ def result(backend: str, query_mode: str = "") -> dict:
                 "avg_quantized_code_bytes": 5120,
                 "avg_vector_bytes": 0,
                 "avg_norm_bytes": 0,
+                "avg_search_route_hnsw_search_pack": 0,
+                "avg_search_route_quantized_only": 1,
             }
         )
     if query_mode == "quantized_rerank":
@@ -50,6 +62,8 @@ def result(backend: str, query_mode: str = "") -> dict:
                 "avg_quantized_code_bytes": 5120,
                 "avg_quantized_rerank_candidates": 16,
                 "avg_quantized_rerank_exact_score_calls": 16,
+                "avg_search_route_hnsw_search_pack": 0,
+                "avg_search_route_quantized_rerank": 1,
             }
         )
     return {
@@ -92,6 +106,10 @@ class SummaryRenderTests(unittest.TestCase):
         self.assertIn("## TreeDB Search Counters", rendered)
         self.assertIn("| TreeDB column-store graph HNSW | quantized_only | 1 | 32.0 | 40.0 | 5120.0 | 0.0 | 0.0 | 0.0 | 0.0 |", rendered)
         self.assertIn("| TreeDB column-store graph HNSW | quantized_rerank | 1 | 32.0 | 40.0 | 5120.0 | 16.0 | 16.0 | 128.0 | 32.0 |", rendered)
+        self.assertIn("## TreeDB Search Guardrails", rendered)
+        self.assertIn("| TreeDB column-store graph HNSW | exact/default | 1 | 0.0 | 0.0 | 1.0 | 0.0 | 0.0 |", rendered)
+        self.assertIn("| TreeDB column-store graph HNSW | quantized_only | 1 | 0.0 | 0.0 | 0.0 | 1.0 | 0.0 |", rendered)
+        self.assertIn("| TreeDB column-store graph HNSW | quantized_rerank | 1 | 0.0 | 0.0 | 0.0 | 0.0 | 1.0 |", rendered)
         self.assertIn("PostgreSQL+pgvector is not quantized", rendered)
 
 

--- a/cmd/treedb_vector_search_demo/README.md
+++ b/cmd/treedb_vector_search_demo/README.md
@@ -21,10 +21,14 @@ Each case:
 
 The benchmark search phase is a no-document ANN/search-throughput boundary:
 serial and parallel search metrics return IDs/scores and do not time final
-document fetch, reconstruction, projection, or serialization. Document reads in
-validation are correctness checks, not the preferred vector response-shape
-evidence; use `ProjectionOrientedVectorDocumentFetchPreset` in collection/vector
-APIs when timing projected documents without embeddings.
+document fetch, reconstruction, projection, or serialization. For
+`column_graph` rows, the timed search loop uses caller-owned reusable result
+buffers and excludes response-owned convenience allocation. Native-runtime rows
+remain on the native-runtime benchmark path and should not be read as buffered
+zero-allocation evidence. Document reads in validation are correctness checks,
+not the preferred vector response-shape evidence; use
+`ProjectionOrientedVectorDocumentFetchPreset` in collection/vector APIs when
+timing projected documents without embeddings.
 
 For `-vector-index-strategy column_graph`, the demo can also select explicit
 TreeDB query modes with `-vector-query-mode exact|quantized_only|quantized_rerank`.
@@ -32,7 +36,11 @@ Quantized modes declare a named `scalar_u8` score plane on the TreeDB vector
 index, build it during `RebuildVectorIndex`, validate recall against exact
 full-vector ground truth, and report per-search quantized counters. They do not
 change exact/default behavior and do not affect PostgreSQL+pgvector comparator
-semantics in the external harness.
+semantics in the external harness. The `column_graph` JSON/text search rows
+also report no-document guardrail counters such as `avg_documents_fetched`,
+`avg_response_owned_result_allocs`, and route/fallback averages so profile runs
+can distinguish buffered search-loop cost from response-owned convenience or
+document-materialization paths.
 
 `CompactStorageFull` is intentionally used instead of manually chaining
 maintenance calls. It is TreeDB's canonical full storage compaction path:

--- a/cmd/treedb_vector_search_demo/main.go
+++ b/cmd/treedb_vector_search_demo/main.go
@@ -200,8 +200,42 @@ type searchBenchmarkResult struct {
 	AvgNormBytes                      float64                          `json:"avg_norm_bytes"`
 	AvgPreparedScoreCalls             float64                          `json:"avg_prepared_score_calls"`
 	AvgScoreBatchCandidates           float64                          `json:"avg_score_batch_candidates"`
+	AvgDocumentsFetched               *float64                         `json:"avg_documents_fetched,omitempty"`
+	AvgResponseOwnedResultAllocs      *float64                         `json:"avg_response_owned_result_allocs,omitempty"`
+	AvgSearchRouteHNSWSearchPack      *float64                         `json:"avg_search_route_hnsw_search_pack,omitempty"`
+	AvgSearchRouteQuantizedOnly       *float64                         `json:"avg_search_route_quantized_only,omitempty"`
+	AvgSearchRouteQuantizedRerank     *float64                         `json:"avg_search_route_quantized_rerank,omitempty"`
+	AvgSearchRouteColumnGraphPrepared *float64                         `json:"avg_search_route_column_graph_prepared,omitempty"`
+	AvgSearchRouteColumnGraphFallback *float64                         `json:"avg_search_route_column_graph_fallback,omitempty"`
+	AvgGraphRowFallbacks              *float64                         `json:"avg_graph_row_fallbacks,omitempty"`
+	AvgTypedColumnFallbacks           *float64                         `json:"avg_typed_column_fallbacks,omitempty"`
+	AvgVectorScratchDecodes           *float64                         `json:"avg_vector_scratch_decodes,omitempty"`
 	ExactFallbacks                    int                              `json:"exact_fallbacks"`
 	DisableExactFallback              bool                             `json:"disable_exact_fallback"`
+}
+
+func float64Ptr(value float64) *float64 {
+	return &value
+}
+
+func float64Value(value *float64) float64 {
+	if value == nil {
+		return 0
+	}
+	return *value
+}
+
+func searchBenchmarkHasGuardrailMetrics(bench searchBenchmarkResult) bool {
+	return bench.AvgDocumentsFetched != nil ||
+		bench.AvgResponseOwnedResultAllocs != nil ||
+		bench.AvgSearchRouteHNSWSearchPack != nil ||
+		bench.AvgSearchRouteQuantizedOnly != nil ||
+		bench.AvgSearchRouteQuantizedRerank != nil ||
+		bench.AvgSearchRouteColumnGraphPrepared != nil ||
+		bench.AvgSearchRouteColumnGraphFallback != nil ||
+		bench.AvgGraphRowFallbacks != nil ||
+		bench.AvgTypedColumnFallbacks != nil ||
+		bench.AvgVectorScratchDecodes != nil
 }
 
 type storageReport struct {
@@ -2093,6 +2127,7 @@ func benchmarkColumnGraphSearchLoadedConcurrent(col *collections.Collection, ind
 			_ = searcher.Close()
 		}
 	}()
+	buffers := make([]collections.VectorIndexSearchBuffer, concurrency)
 
 	latencies := make([]int64, len(queries))
 	var next atomic.Int64
@@ -2105,6 +2140,19 @@ func benchmarkColumnGraphSearchLoadedConcurrent(col *collections.Collection, ind
 	var normBytesTotal uint64
 	var preparedScoreCallsTotal uint64
 	var scoreBatchCandidatesTotal uint64
+	type columnGraphGuardrailTotals struct {
+		documentsFetched               uint64
+		responseOwnedResultAllocs      uint64
+		searchRouteHNSWSearchPack      uint64
+		searchRouteQuantizedOnly       uint64
+		searchRouteQuantizedRerank     uint64
+		searchRouteColumnGraphPrepared uint64
+		searchRouteColumnGraphFallback uint64
+		graphRowFallbacks              uint64
+		typedColumnFallbacks           uint64
+		vectorScratchDecodes           uint64
+	}
+	guardrailTotals := make([]columnGraphGuardrailTotals, concurrency)
 	var errMu sync.Mutex
 	var firstErr error
 	setErr := func(err error) {
@@ -2114,14 +2162,20 @@ func benchmarkColumnGraphSearchLoadedConcurrent(col *collections.Collection, ind
 			firstErr = err
 		}
 	}
-	worker := func(searcher *collections.VectorIndexSearcher) {
+	worker := func(searcher *collections.VectorIndexSearcher, buffer *collections.VectorIndexSearchBuffer, totals *columnGraphGuardrailTotals) {
+		var local columnGraphGuardrailTotals
+		defer func() {
+			if totals != nil {
+				*totals = local
+			}
+		}()
 		for {
 			i := int(next.Add(1) - 1)
 			if i >= len(queries) {
 				return
 			}
 			start := time.Now()
-			response, err := searcher.Search(columnGraphSearchOptions(queries[i], cfg))
+			response, err := searcher.SearchWithBuffer(columnGraphSearchOptions(queries[i], cfg), buffer)
 			if err != nil {
 				setErr(err)
 				return
@@ -2144,6 +2198,16 @@ func benchmarkColumnGraphSearchLoadedConcurrent(col *collections.Collection, ind
 			atomic.AddUint64(&normBytesTotal, response.Stats.NormBytesRead)
 			atomic.AddUint64(&preparedScoreCallsTotal, response.Stats.PreparedScoreCalls)
 			atomic.AddUint64(&scoreBatchCandidatesTotal, response.Stats.ScoreBatchCandidates)
+			local.documentsFetched += response.Stats.DocumentsFetched
+			local.responseOwnedResultAllocs += response.Stats.ResponseOwnedResultAllocs
+			local.searchRouteHNSWSearchPack += response.Stats.SearchRouteHNSWSearchPack
+			local.searchRouteQuantizedOnly += response.Stats.SearchRouteQuantizedOnly
+			local.searchRouteQuantizedRerank += response.Stats.SearchRouteQuantizedRerank
+			local.searchRouteColumnGraphPrepared += response.Stats.SearchRouteColumnGraphPrepared
+			local.searchRouteColumnGraphFallback += response.Stats.SearchRouteColumnGraphFallback
+			local.graphRowFallbacks += response.Stats.GraphRowFallbacks
+			local.typedColumnFallbacks += response.Stats.TypedColumnFallbacks
+			local.vectorScratchDecodes += response.Stats.VectorScratchDecodes
 		}
 	}
 	stopProfile, err := startColumnGraphSearchProfile(cfg, concurrency)
@@ -2152,15 +2216,17 @@ func benchmarkColumnGraphSearchLoadedConcurrent(col *collections.Collection, ind
 	}
 	startAll := time.Now()
 	if concurrency == 1 {
-		worker(searchers[0])
+		worker(searchers[0], &buffers[0], &guardrailTotals[0])
 	} else {
 		var wg sync.WaitGroup
 		wg.Add(concurrency)
 		for i := 0; i < concurrency; i++ {
 			searcher := searchers[i]
+			buffer := &buffers[i]
+			totals := &guardrailTotals[i]
 			go func() {
 				defer wg.Done()
-				worker(searcher)
+				worker(searcher, buffer, totals)
 			}()
 		}
 		wg.Wait()
@@ -2183,6 +2249,28 @@ func benchmarkColumnGraphSearchLoadedConcurrent(col *collections.Collection, ind
 	opsPerSecond := 0.0
 	if total > 0 {
 		opsPerSecond = float64(len(queries)) / total.Seconds()
+	}
+	var documentsFetchedTotal uint64
+	var responseOwnedResultAllocsTotal uint64
+	var searchRouteHNSWSearchPackTotal uint64
+	var searchRouteQuantizedOnlyTotal uint64
+	var searchRouteQuantizedRerankTotal uint64
+	var searchRouteColumnGraphPreparedTotal uint64
+	var searchRouteColumnGraphFallbackTotal uint64
+	var graphRowFallbacksTotal uint64
+	var typedColumnFallbacksTotal uint64
+	var vectorScratchDecodesTotal uint64
+	for _, totals := range guardrailTotals {
+		documentsFetchedTotal += totals.documentsFetched
+		responseOwnedResultAllocsTotal += totals.responseOwnedResultAllocs
+		searchRouteHNSWSearchPackTotal += totals.searchRouteHNSWSearchPack
+		searchRouteQuantizedOnlyTotal += totals.searchRouteQuantizedOnly
+		searchRouteQuantizedRerankTotal += totals.searchRouteQuantizedRerank
+		searchRouteColumnGraphPreparedTotal += totals.searchRouteColumnGraphPrepared
+		searchRouteColumnGraphFallbackTotal += totals.searchRouteColumnGraphFallback
+		graphRowFallbacksTotal += totals.graphRowFallbacks
+		typedColumnFallbacksTotal += totals.typedColumnFallbacks
+		vectorScratchDecodesTotal += totals.vectorScratchDecodes
 	}
 	queryCount := float64(len(queries))
 	avgQuantizedRerankCandidates := float64(quantizedRerankCandidatesTotal) / queryCount
@@ -2209,6 +2297,16 @@ func benchmarkColumnGraphSearchLoadedConcurrent(col *collections.Collection, ind
 		AvgNormBytes:                      float64(normBytesTotal) / queryCount,
 		AvgPreparedScoreCalls:             float64(preparedScoreCallsTotal) / queryCount,
 		AvgScoreBatchCandidates:           float64(scoreBatchCandidatesTotal) / queryCount,
+		AvgDocumentsFetched:               float64Ptr(float64(documentsFetchedTotal) / queryCount),
+		AvgResponseOwnedResultAllocs:      float64Ptr(float64(responseOwnedResultAllocsTotal) / queryCount),
+		AvgSearchRouteHNSWSearchPack:      float64Ptr(float64(searchRouteHNSWSearchPackTotal) / queryCount),
+		AvgSearchRouteQuantizedOnly:       float64Ptr(float64(searchRouteQuantizedOnlyTotal) / queryCount),
+		AvgSearchRouteQuantizedRerank:     float64Ptr(float64(searchRouteQuantizedRerankTotal) / queryCount),
+		AvgSearchRouteColumnGraphPrepared: float64Ptr(float64(searchRouteColumnGraphPreparedTotal) / queryCount),
+		AvgSearchRouteColumnGraphFallback: float64Ptr(float64(searchRouteColumnGraphFallbackTotal) / queryCount),
+		AvgGraphRowFallbacks:              float64Ptr(float64(graphRowFallbacksTotal) / queryCount),
+		AvgTypedColumnFallbacks:           float64Ptr(float64(typedColumnFallbacksTotal) / queryCount),
+		AvgVectorScratchDecodes:           float64Ptr(float64(vectorScratchDecodesTotal) / queryCount),
 		ExactFallbacks:                    0,
 		DisableExactFallback:              cfg.disableExactFallback,
 	}, nil
@@ -2581,6 +2679,19 @@ func printText(w io.Writer, res result) {
 		res.Search.AvgQuantizedRerankExactScoreCalls,
 		res.Search.AvgVectorBytes,
 		res.Search.AvgNormBytes)
+	if searchBenchmarkHasGuardrailMetrics(res.Search) {
+		fmt.Fprintf(w, "avg_documents_fetched=%.1f avg_response_owned_result_allocs=%.1f avg_route_hnsw_search_pack=%.1f avg_route_quantized_only=%.1f avg_route_quantized_rerank=%.1f avg_route_column_graph_prepared=%.1f avg_route_column_graph_fallback=%.1f avg_graph_row_fallbacks=%.1f avg_typed_column_fallbacks=%.1f avg_vector_scratch_decodes=%.1f\n",
+			float64Value(res.Search.AvgDocumentsFetched),
+			float64Value(res.Search.AvgResponseOwnedResultAllocs),
+			float64Value(res.Search.AvgSearchRouteHNSWSearchPack),
+			float64Value(res.Search.AvgSearchRouteQuantizedOnly),
+			float64Value(res.Search.AvgSearchRouteQuantizedRerank),
+			float64Value(res.Search.AvgSearchRouteColumnGraphPrepared),
+			float64Value(res.Search.AvgSearchRouteColumnGraphFallback),
+			float64Value(res.Search.AvgGraphRowFallbacks),
+			float64Value(res.Search.AvgTypedColumnFallbacks),
+			float64Value(res.Search.AvgVectorScratchDecodes))
+	}
 	fmt.Fprintf(w, "\nParallel Search Benchmark\n")
 	printSearchBenchmarks(w, res.SearchBenchmarks)
 	fmt.Fprintf(w, "\nStorage\n")
@@ -2683,7 +2794,7 @@ func resultQueryMode(res result) collections.VectorIndexQueryMode {
 
 func printSearchBenchmarks(w io.Writer, benchmarks []searchBenchmarkResult) {
 	for _, bench := range benchmarks {
-		fmt.Fprintf(w, "search concurrency=%d queries=%d query_mode=%s avg=%.2fus p50=%.2fus p95=%.2fus p99=%.2fus ops/sec=%.1f exact_fallbacks=%d avg_candidates=%.1f avg_quantized_score_calls=%.1f avg_quantized_code_bytes=%.1f avg_quantized_rerank_candidates=%.1f avg_quantized_rerank_exact_score_calls=%.1f avg_vector_bytes=%.1f avg_norm_bytes=%.1f\n",
+		fmt.Fprintf(w, "search concurrency=%d queries=%d query_mode=%s avg=%.2fus p50=%.2fus p95=%.2fus p99=%.2fus ops/sec=%.1f exact_fallbacks=%d avg_candidates=%.1f avg_quantized_score_calls=%.1f avg_quantized_code_bytes=%.1f avg_quantized_rerank_candidates=%.1f avg_quantized_rerank_exact_score_calls=%.1f avg_vector_bytes=%.1f avg_norm_bytes=%.1f",
 			bench.Concurrency,
 			bench.Queries,
 			bench.QueryMode,
@@ -2700,6 +2811,20 @@ func printSearchBenchmarks(w io.Writer, benchmarks []searchBenchmarkResult) {
 			bench.AvgQuantizedRerankExactScoreCalls,
 			bench.AvgVectorBytes,
 			bench.AvgNormBytes)
+		if searchBenchmarkHasGuardrailMetrics(bench) {
+			fmt.Fprintf(w, " avg_documents_fetched=%.1f avg_response_owned_result_allocs=%.1f avg_route_hnsw_search_pack=%.1f avg_route_quantized_only=%.1f avg_route_quantized_rerank=%.1f avg_route_column_graph_prepared=%.1f avg_route_column_graph_fallback=%.1f avg_graph_row_fallbacks=%.1f avg_typed_column_fallbacks=%.1f avg_vector_scratch_decodes=%.1f",
+				float64Value(bench.AvgDocumentsFetched),
+				float64Value(bench.AvgResponseOwnedResultAllocs),
+				float64Value(bench.AvgSearchRouteHNSWSearchPack),
+				float64Value(bench.AvgSearchRouteQuantizedOnly),
+				float64Value(bench.AvgSearchRouteQuantizedRerank),
+				float64Value(bench.AvgSearchRouteColumnGraphPrepared),
+				float64Value(bench.AvgSearchRouteColumnGraphFallback),
+				float64Value(bench.AvgGraphRowFallbacks),
+				float64Value(bench.AvgTypedColumnFallbacks),
+				float64Value(bench.AvgVectorScratchDecodes))
+		}
+		fmt.Fprintln(w)
 	}
 }
 

--- a/cmd/treedb_vector_search_demo/main_test.go
+++ b/cmd/treedb_vector_search_demo/main_test.go
@@ -18,6 +18,14 @@ import (
 	"github.com/snissn/gomap/TreeDB/collections"
 )
 
+func requireFloat64Metric(t *testing.T, value *float64, name string) float64 {
+	t.Helper()
+	if value == nil {
+		t.Fatalf("missing %s metric", name)
+	}
+	return *value
+}
+
 func TestExecuteSmokeCompactsReopensValidatesAndBenchmarks(t *testing.T) {
 	res, err := execute(context.Background(), config{
 		dir:                   t.TempDir(),
@@ -382,6 +390,20 @@ func TestExecuteColumnGraphSearchPath(t *testing.T) {
 	if res.Search.Queries != 4 || res.Search.ExactFallbacks != 0 {
 		t.Fatalf("unexpected column_graph search result: %+v", res.Search)
 	}
+	if requireFloat64Metric(t, res.Search.AvgResponseOwnedResultAllocs, "avg_response_owned_result_allocs") != 0 || requireFloat64Metric(t, res.Search.AvgDocumentsFetched, "avg_documents_fetched") != 0 {
+		t.Fatalf("column_graph benchmark should use no-doc buffered results: %+v", res.Search)
+	}
+	if requireFloat64Metric(t, res.Search.AvgSearchRouteHNSWSearchPack, "avg_search_route_hnsw_search_pack") != 1 || requireFloat64Metric(t, res.Search.AvgSearchRouteQuantizedOnly, "avg_search_route_quantized_only") != 0 || requireFloat64Metric(t, res.Search.AvgSearchRouteQuantizedRerank, "avg_search_route_quantized_rerank") != 0 {
+		t.Fatalf("unexpected exact column_graph route counters: %+v", res.Search)
+	}
+	if requireFloat64Metric(t, res.Search.AvgGraphRowFallbacks, "avg_graph_row_fallbacks") != 0 || requireFloat64Metric(t, res.Search.AvgTypedColumnFallbacks, "avg_typed_column_fallbacks") != 0 || requireFloat64Metric(t, res.Search.AvgVectorScratchDecodes, "avg_vector_scratch_decodes") != 0 {
+		t.Fatalf("unexpected exact column_graph fallback counters: %+v", res.Search)
+	}
+	var out bytes.Buffer
+	printText(&out, res)
+	if !strings.Contains(out.String(), "avg_response_owned_result_allocs=0.0") {
+		t.Fatalf("column_graph text output missing buffered guardrails:\n%s", out.String())
+	}
 }
 
 func TestExecuteColumnGraphQuantizedModes(t *testing.T) {
@@ -402,6 +424,12 @@ func TestExecuteColumnGraphQuantizedModes(t *testing.T) {
 				if res.Search.AvgQuantizedRerankCandidates != 0 || res.Search.AvgQuantizedRerankExactScoreCalls != 0 {
 					t.Fatalf("quantized_only unexpectedly reranked: %+v", res.Search)
 				}
+				if res.Search.AvgVectorBytes != 0 || res.Search.AvgNormBytes != 0 {
+					t.Fatalf("quantized_only unexpectedly read exact vectors/norms: %+v", res.Search)
+				}
+				if requireFloat64Metric(t, res.Search.AvgSearchRouteQuantizedOnly, "avg_search_route_quantized_only") != 1 || requireFloat64Metric(t, res.Search.AvgSearchRouteQuantizedRerank, "avg_search_route_quantized_rerank") != 0 || requireFloat64Metric(t, res.Search.AvgSearchRouteHNSWSearchPack, "avg_search_route_hnsw_search_pack") != 0 {
+					t.Fatalf("quantized_only route counters not isolated: %+v", res.Search)
+				}
 			},
 		},
 		{
@@ -416,8 +444,19 @@ func TestExecuteColumnGraphQuantizedModes(t *testing.T) {
 				if res.Search.AvgQuantizedRerankCandidates <= 0 || res.Search.AvgQuantizedRerankExactScoreCalls <= 0 {
 					t.Fatalf("quantized_rerank stats missing exact rerank: %+v", res.Search)
 				}
+				if res.Search.AvgQuantizedRerankExactScoreCalls > float64(res.QuantizedRerankCandidates) {
+					t.Fatalf("quantized_rerank exact score calls exceeded limit: %+v", res.Search)
+				}
 				if res.Search.AvgVectorBytes <= 0 || res.Search.AvgNormBytes <= 0 {
 					t.Fatalf("quantized_rerank stats missing exact vector/norm reads: %+v", res.Search)
+				}
+				maxVectorBytes := float64(res.QuantizedRerankCandidates * res.Dimensions * 4)
+				maxNormBytes := float64(res.QuantizedRerankCandidates * 4)
+				if res.Search.AvgVectorBytes > maxVectorBytes || res.Search.AvgNormBytes > maxNormBytes {
+					t.Fatalf("quantized_rerank exact reads exceeded rerank bound: %+v", res.Search)
+				}
+				if requireFloat64Metric(t, res.Search.AvgSearchRouteQuantizedOnly, "avg_search_route_quantized_only") != 0 || requireFloat64Metric(t, res.Search.AvgSearchRouteQuantizedRerank, "avg_search_route_quantized_rerank") != 1 || requireFloat64Metric(t, res.Search.AvgSearchRouteHNSWSearchPack, "avg_search_route_hnsw_search_pack") != 0 {
+					t.Fatalf("quantized_rerank route counters not isolated: %+v", res.Search)
 				}
 			},
 		},
@@ -460,6 +499,12 @@ func TestExecuteColumnGraphQuantizedModes(t *testing.T) {
 			}
 			if len(res.SearchBenchmarks) != 2 || res.SearchBenchmarks[0].QueryMode != tc.mode || res.SearchBenchmarks[1].QueryMode != tc.mode {
 				t.Fatalf("search benchmark modes not threaded: %+v", res.SearchBenchmarks)
+			}
+			if requireFloat64Metric(t, res.Search.AvgResponseOwnedResultAllocs, "avg_response_owned_result_allocs") != 0 || requireFloat64Metric(t, res.Search.AvgDocumentsFetched, "avg_documents_fetched") != 0 {
+				t.Fatalf("quantized benchmark should use no-doc buffered results: %+v", res.Search)
+			}
+			if requireFloat64Metric(t, res.Search.AvgGraphRowFallbacks, "avg_graph_row_fallbacks") != 0 || requireFloat64Metric(t, res.Search.AvgTypedColumnFallbacks, "avg_typed_column_fallbacks") != 0 || requireFloat64Metric(t, res.Search.AvgVectorScratchDecodes, "avg_vector_scratch_decodes") != 0 {
+				t.Fatalf("unexpected quantized fallback counters: %+v", res.Search)
 			}
 			tc.assertStats(t, res)
 		})


### PR DESCRIPTION
## Linked tracker

Closes #2504 under the #2501 hybrid lexical + vector search umbrella. Builds on the #2502 contract merged in #2512. Branch is updated with latest `origin/main` (`e9830fdc70471f083ff483740287d6743f96b08b`) and preserves the #1764 PR1 merge (`19cfa7ba398c318c3b107390ee6674b3f7538560`) plus later main vector benchmark/demo changes.

## Scope

Implements deterministic TreeDB hybrid rank-fusion primitives over already-generated candidates:

- adds `FuseHybridSearchCandidates(candidates []HybridSearchCandidate, fusion HybridFusionOptions, topK int)`;
- supports reciprocal-rank fusion (`rrf`) with `HybridFusionDefaultRRFK = 60` when `RRFK == 0`;
- validates unsupported fusion methods, tie policies, source-order entries, source labels, and non-one-based ranks fail closed;
- applies the #2502 deterministic tie policy: fused score, best source rank, contributing-source count, source order of the best-ranked contribution, opaque ID bytes;
- deduplicates exact document ID bytes and same-source duplicate candidates while preserving best source contribution attribution;
- returns bounded `HybridSearchResult` values and fusion counters (`candidates_fused`, `candidates_after_fusion`, `fusion_text_only`, `fusion_vector_only`, `fusion_both`, `fusion_duplicate_candidates`, `truncated`).

Final PR diff is limited to #2504 fusion files/types/docs and preserves merged main changes. Current `git diff --name-only origin/main..HEAD` contains only:

- `TreeDB/collections/hybrid_fusion.go`
- `TreeDB/collections/hybrid_fusion_bench_test.go`
- `TreeDB/collections/hybrid_fusion_test.go`
- `TreeDB/collections/hybrid_search.go`
- `TreeDB/docs/spec/hybrid-search-contract.md`

## Explicit non-goals

- Does not run text or vector searches.
- Does not open storage, apply scalar filters, fetch documents, or implement `SearchHybrid` executor (#2505).
- Does not build text index or vector adapters (#1764/#2503).
- Does not claim end-to-end hybrid relevance or benchmark product quality.

## Local test evidence

Latest local/PR head: `d28ec31562c81db35ee20f522aaa8134d37ac409`.

- `git diff --check origin/main..HEAD` — PASS
- `GOWORK=off go test ./TreeDB/collections -run 'Test.*Hybrid.*Fusion|Test.*RRF' -count=1` — PASS (`ok ... 0.558s`)
- `GOWORK=off go test ./TreeDB/docs -count=1` — PASS (`ok ... 1.710s`)
- `GOWORK=off go test ./TreeDB/collections -count=1` — PASS (`ok ... 61.662s`)

Internal Orca review: PASS after one fix. Reviewer found source attribution counters should describe the full fused candidate set rather than only returned top-K; fixed and re-reviewed clean.

AI review fixes already addressed:

- Codex: moved `SourceOrder` validation before the empty-candidate fast path and added an empty-input fail-closed test.
- CodeRabbit: removed manual benchmark timing/custom `ops/sec`; benchmark now relies on Go's built-in `ns/op` timing.
- Codex follow-up: source-order tie breaking now tracks the source of the best-ranked contribution (using `SourceOrder` when multiple contributions share the best rank); added a regression test for text-best vs vector-best tied hybrid docs.

## Benchmark evidence

Command:

```sh
GOWORK=off go test ./TreeDB/collections -run '^$' -bench '^BenchmarkHybridRRFFusion$' -benchmem -count=1
```

Hardware/context: local darwin/arm64, Apple M3. The benchmark times fusion only over prebuilt in-memory candidate slices; it does not include candidate generation, storage IO, scalar filtering, or document fetch. `ops/sec` below is computed as `1e9 / ns/op` from the Go benchmark output.

| Candidates | ns/op | ops/sec (computed) | B/op | allocs/op |
| ---: | ---: | ---: | ---: | ---: |
| 10 | 2,292 | 436,300 | 5,584 | 32 |
| 100 | 31,084 | 32,171 | 39,216 | 145 |
| 1,000 | 272,377 | 3,671 | 338,296 | 935 |
| 10,000 | 3,248,257 | 307.9 | 3,148,505 | 8,838 |

Performance regression assessment: new helper/benchmark only; no existing hot path or shared result buffer was modified. No before/after regression claim is applicable.

## AI review status

Initial AI reviews were requested only after the PR was mature (coherent code pushed, local tests/benchmark evidence complete, PR body current, no known local blockers, latest-head CI running). Prior Codex and CodeRabbit findings have been addressed. Latest-head AI/CI status is tracked in PR comments/checks after restoring current-main vector benchmark/demo files.

## Known risks / possible churn

TreeDB is pre-alpha. #2505 may request minor helper signature/counter refinements when integrating scalar filtering and candidate adapters, but this PR keeps the scope candidate-list-only and storage-free.
