### PR TITLE
TreeDB: parameterize RaBitQ profile gate shapes

### DIFF
--- a/TreeDB/collections/column_vector_graph_quantized_bench_test.go
+++ b/TreeDB/collections/column_vector_graph_quantized_bench_test.go
@@ -1,7 +1,11 @@
 package collections
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
+	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -20,6 +24,225 @@ type columnGraphScalarU8QuantizedBenchShape1926 struct {
 	topK         int
 	efSearch     int
 	queryOrdinal int
+}
+
+const (
+	columnGraphScalarU8QuantizedBenchShapeEnv1926        = "TREEDB_COLUMN_GRAPH_QUANTIZED_BENCH_SHAPE"
+	columnGraphScalarU8QuantizedBenchRowsEnv1926         = "TREEDB_COLUMN_GRAPH_QUANTIZED_BENCH_ROWS"
+	columnGraphScalarU8QuantizedBenchDimsEnv1926         = "TREEDB_COLUMN_GRAPH_QUANTIZED_BENCH_DIMS"
+	columnGraphScalarU8QuantizedBenchMEnv1926            = "TREEDB_COLUMN_GRAPH_QUANTIZED_BENCH_M"
+	columnGraphScalarU8QuantizedBenchTopKEnv1926         = "TREEDB_COLUMN_GRAPH_QUANTIZED_BENCH_TOP_K"
+	columnGraphScalarU8QuantizedBenchEfSearchEnv1926     = "TREEDB_COLUMN_GRAPH_QUANTIZED_BENCH_EF_SEARCH"
+	columnGraphScalarU8QuantizedBenchQueryOrdinalEnv1926 = "TREEDB_COLUMN_GRAPH_QUANTIZED_BENCH_QUERY_ORDINAL"
+)
+
+func defaultColumnGraphScalarU8QuantizedBenchShape1926() columnGraphScalarU8QuantizedBenchShape1926 {
+	return columnGraphScalarU8QuantizedBenchShape1926{rows: 1024, dims: 128, m: 16, topK: 10, efSearch: 128, queryOrdinal: 37}
+}
+
+func columnGraphScalarU8QuantizedBenchShapeFromEnv1926(tb testing.TB) columnGraphScalarU8QuantizedBenchShape1926 {
+	tb.Helper()
+	shape, err := columnGraphScalarU8QuantizedBenchShapeFromEnvValues1926(os.Getenv)
+	if err != nil {
+		tb.Fatalf("column graph quantized benchmark shape: %v", err)
+	}
+	return shape
+}
+
+func columnGraphScalarU8QuantizedBenchShapeFromEnvValues1926(getenv func(string) string) (columnGraphScalarU8QuantizedBenchShape1926, error) {
+	shape := defaultColumnGraphScalarU8QuantizedBenchShape1926()
+	if rawShape := strings.TrimSpace(getenv(columnGraphScalarU8QuantizedBenchShapeEnv1926)); rawShape != "" {
+		rows, dims, err := parseColumnGraphScalarU8QuantizedBenchShapeToken1926(rawShape)
+		if err != nil {
+			return shape, err
+		}
+		shape.rows = rows
+		shape.dims = dims
+	}
+	if err := applyPositiveColumnGraphScalarU8QuantizedBenchEnv1926(getenv, columnGraphScalarU8QuantizedBenchRowsEnv1926, "rows", &shape.rows); err != nil {
+		return shape, err
+	}
+	if err := applyPositiveColumnGraphScalarU8QuantizedBenchEnv1926(getenv, columnGraphScalarU8QuantizedBenchDimsEnv1926, "dims", &shape.dims); err != nil {
+		return shape, err
+	}
+	if err := applyPositiveColumnGraphScalarU8QuantizedBenchEnv1926(getenv, columnGraphScalarU8QuantizedBenchMEnv1926, "m", &shape.m); err != nil {
+		return shape, err
+	}
+	if err := applyPositiveColumnGraphScalarU8QuantizedBenchEnv1926(getenv, columnGraphScalarU8QuantizedBenchTopKEnv1926, "topK", &shape.topK); err != nil {
+		return shape, err
+	}
+	if err := applyPositiveColumnGraphScalarU8QuantizedBenchEnv1926(getenv, columnGraphScalarU8QuantizedBenchEfSearchEnv1926, "efSearch", &shape.efSearch); err != nil {
+		return shape, err
+	}
+	if err := applyNonNegativeColumnGraphScalarU8QuantizedBenchEnv1926(getenv, columnGraphScalarU8QuantizedBenchQueryOrdinalEnv1926, "queryOrdinal", &shape.queryOrdinal); err != nil {
+		return shape, err
+	}
+	if shape.topK > shape.rows {
+		return shape, fmt.Errorf("topK=%d exceeds rows=%d", shape.topK, shape.rows)
+	}
+	if shape.queryOrdinal >= shape.rows {
+		return shape, fmt.Errorf("queryOrdinal=%d out of range rows=%d", shape.queryOrdinal, shape.rows)
+	}
+	return shape, nil
+}
+
+func parseColumnGraphScalarU8QuantizedBenchShapeToken1926(raw string) (int, int, error) {
+	defaultShape := defaultColumnGraphScalarU8QuantizedBenchShape1926()
+	normalized := strings.ToLower(strings.TrimSpace(raw))
+	if normalized == "" || normalized == "default" || normalized == "claim_core" {
+		return defaultShape.rows, defaultShape.dims, nil
+	}
+	normalized = strings.ReplaceAll(normalized, "_x_", "x")
+	normalized = strings.ReplaceAll(normalized, "_", "")
+	parts := strings.Split(normalized, "x")
+	if len(parts) != 2 {
+		return 0, 0, fmt.Errorf("unsupported %s=%q (want default, 1024x128, 10k_x_1536, or <rows>x<dims>)", columnGraphScalarU8QuantizedBenchShapeEnv1926, raw)
+	}
+	rows, err := parseColumnGraphScalarU8QuantizedBenchPositiveToken1926(parts[0], "rows", true)
+	if err != nil {
+		return 0, 0, fmt.Errorf("unsupported %s=%q: %w", columnGraphScalarU8QuantizedBenchShapeEnv1926, raw, err)
+	}
+	dims, err := parseColumnGraphScalarU8QuantizedBenchPositiveToken1926(parts[1], "dims", true)
+	if err != nil {
+		return 0, 0, fmt.Errorf("unsupported %s=%q: %w", columnGraphScalarU8QuantizedBenchShapeEnv1926, raw, err)
+	}
+	return rows, dims, nil
+}
+
+func parseColumnGraphScalarU8QuantizedBenchPositiveToken1926(raw, name string, allowK bool) (int, error) {
+	token := strings.TrimSpace(strings.ToLower(raw))
+	multiplier := 1
+	if strings.HasSuffix(token, "k") {
+		if !allowK {
+			return 0, fmt.Errorf("%s token %q may not use k suffix", name, raw)
+		}
+		multiplier = 1000
+		token = strings.TrimSuffix(token, "k")
+	}
+	value, err := strconv.Atoi(token)
+	if err != nil || value <= 0 {
+		return 0, fmt.Errorf("%s token %q must be a positive integer", name, raw)
+	}
+	maxInt := int(^uint(0) >> 1)
+	if value > maxInt/multiplier {
+		return 0, fmt.Errorf("%s token %q overflows int", name, raw)
+	}
+	return value * multiplier, nil
+}
+
+func applyPositiveColumnGraphScalarU8QuantizedBenchEnv1926(getenv func(string) string, envName, field string, target *int) error {
+	raw := strings.TrimSpace(getenv(envName))
+	if raw == "" {
+		return nil
+	}
+	value, err := strconv.Atoi(raw)
+	if err != nil || value <= 0 {
+		return fmt.Errorf("%s=%q must be a positive integer for %s", envName, raw, field)
+	}
+	*target = value
+	return nil
+}
+
+func applyNonNegativeColumnGraphScalarU8QuantizedBenchEnv1926(getenv func(string) string, envName, field string, target *int) error {
+	raw := strings.TrimSpace(getenv(envName))
+	if raw == "" {
+		return nil
+	}
+	value, err := strconv.Atoi(raw)
+	if err != nil || value < 0 {
+		return fmt.Errorf("%s=%q must be a non-negative integer for %s", envName, raw, field)
+	}
+	*target = value
+	return nil
+}
+
+func columnGraphScalarU8QuantizedBenchInsertBatchSize1926(shape columnGraphScalarU8QuantizedBenchShape1926) int {
+	if shape.rows <= 1024 && shape.dims <= 128 {
+		return max(shape.rows, 1)
+	}
+	return 64
+}
+
+func insertColumnGraphScalarU8QuantizedBenchRows1926(tb testing.TB, col *Collection, shape columnGraphScalarU8QuantizedBenchShape1926, rows []columnGraphRebuildInputRowV2A) {
+	tb.Helper()
+	batchSize := columnGraphScalarU8QuantizedBenchInsertBatchSize1926(shape)
+	for start := 0; start < len(rows); start += batchSize {
+		end := min(start+batchSize, len(rows))
+		ids := make([][]byte, end-start)
+		docs := make([][]byte, end-start)
+		for i, row := range rows[start:end] {
+			raw, err := json.Marshal(map[string]any{
+				"time_us":   int64(start + i + 1),
+				"kind":      "vector",
+				"did":       row.id,
+				"embedding": row.vector,
+			})
+			if err != nil {
+				tb.Fatalf("json.Marshal row %q: %v", row.id, err)
+			}
+			ids[i] = []byte(row.id)
+			docs[i] = raw
+		}
+		if _, err := col.InsertBatch(ids, docs); err != nil {
+			tb.Fatalf("InsertBatch rows [%d,%d): %v", start, end, err)
+		}
+	}
+	if err := col.Flush(); err != nil {
+		tb.Fatalf("Flush: %v", err)
+	}
+}
+
+func TestColumnGraphScalarU8QuantizedBenchShapeFromEnvValues1926(t *testing.T) {
+	defaultShape := defaultColumnGraphScalarU8QuantizedBenchShape1926()
+	cases := []struct {
+		name    string
+		env     map[string]string
+		want    columnGraphScalarU8QuantizedBenchShape1926
+		wantErr string
+	}{
+		{name: "default", want: defaultShape},
+		{name: "named 10k x 1536", env: map[string]string{columnGraphScalarU8QuantizedBenchShapeEnv1926: "10k_x_1536"}, want: columnGraphScalarU8QuantizedBenchShape1926{rows: 10000, dims: 1536, m: 16, topK: 10, efSearch: 128, queryOrdinal: 37}},
+		{name: "generic shape", env: map[string]string{columnGraphScalarU8QuantizedBenchShapeEnv1926: "2048x256"}, want: columnGraphScalarU8QuantizedBenchShape1926{rows: 2048, dims: 256, m: 16, topK: 10, efSearch: 128, queryOrdinal: 37}},
+		{name: "explicit overrides", env: map[string]string{
+			columnGraphScalarU8QuantizedBenchShapeEnv1926:        "10k_x_1536",
+			columnGraphScalarU8QuantizedBenchRowsEnv1926:         "4096",
+			columnGraphScalarU8QuantizedBenchDimsEnv1926:         "384",
+			columnGraphScalarU8QuantizedBenchMEnv1926:            "12",
+			columnGraphScalarU8QuantizedBenchTopKEnv1926:         "7",
+			columnGraphScalarU8QuantizedBenchEfSearchEnv1926:     "96",
+			columnGraphScalarU8QuantizedBenchQueryOrdinalEnv1926: "5",
+		}, want: columnGraphScalarU8QuantizedBenchShape1926{rows: 4096, dims: 384, m: 12, topK: 7, efSearch: 96, queryOrdinal: 5}},
+		{name: "bad shape", env: map[string]string{columnGraphScalarU8QuantizedBenchShapeEnv1926: "wide"}, wantErr: "unsupported"},
+		{name: "topk exceeds rows", env: map[string]string{columnGraphScalarU8QuantizedBenchRowsEnv1926: "4", columnGraphScalarU8QuantizedBenchTopKEnv1926: "5"}, wantErr: "topK=5 exceeds rows=4"},
+		{name: "query ordinal out of range", env: map[string]string{columnGraphScalarU8QuantizedBenchRowsEnv1926: "4", columnGraphScalarU8QuantizedBenchTopKEnv1926: "3", columnGraphScalarU8QuantizedBenchQueryOrdinalEnv1926: "4"}, wantErr: "queryOrdinal=4 out of range rows=4"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := columnGraphScalarU8QuantizedBenchShapeFromEnvValues1926(func(key string) string { return tc.env[key] })
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("err=%v want substring %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("shape=%+v want %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestColumnGraphScalarU8QuantizedBenchInsertBatchSize1926(t *testing.T) {
+	if got := columnGraphScalarU8QuantizedBenchInsertBatchSize1926(defaultColumnGraphScalarU8QuantizedBenchShape1926()); got != 1024 {
+		t.Fatalf("default batch size=%d want 1024", got)
+	}
+	shape := columnGraphScalarU8QuantizedBenchShape1926{rows: 10000, dims: 1536, m: 16, topK: 10, efSearch: 128, queryOrdinal: 37}
+	if got := columnGraphScalarU8QuantizedBenchInsertBatchSize1926(shape); got != 64 {
+		t.Fatalf("large-shape batch size=%d want 64", got)
+	}
 }
 
 type columnGraphScalarU8QuantizedBenchFixture1926 struct {
@@ -69,7 +292,7 @@ func columnGraphRabitQQuantizedCollectionWithBufferBenchCases2452() []columnGrap
 }
 
 func BenchmarkColumnGraphScalarU8QuantizedScorePlanes1926(b *testing.B) {
-	shape := columnGraphScalarU8QuantizedBenchShape1926{rows: 1024, dims: 128, m: 16, topK: 10, efSearch: 128, queryOrdinal: 37}
+	shape := columnGraphScalarU8QuantizedBenchShapeFromEnv1926(b)
 	fixture := openColumnGraphScalarU8QuantizedBenchFixture1926(b, shape, true)
 	defer fixture.close()
 	exactIDs, exactCount := columnGraphScalarU8QuantizedBenchmarkExactIDs1926(b, fixture)
@@ -134,7 +357,7 @@ func BenchmarkColumnGraphScalarU8QuantizedScorePlanes1926(b *testing.B) {
 }
 
 func BenchmarkVectorIndexSearcherColumnGraphScalarU8QuantizedSearchWithBuffer2414(b *testing.B) {
-	shape := columnGraphScalarU8QuantizedBenchShape1926{rows: 1024, dims: 128, m: 16, topK: 10, efSearch: 128, queryOrdinal: 37}
+	shape := columnGraphScalarU8QuantizedBenchShapeFromEnv1926(b)
 	fixture := openColumnGraphScalarU8QuantizedBenchFixture1926(b, shape, true)
 	defer fixture.close()
 	exactIDs, exactCount := columnGraphScalarU8QuantizedBenchmarkExactIDs1926(b, fixture)
@@ -157,7 +380,7 @@ func BenchmarkVectorIndexSearcherColumnGraphScalarU8QuantizedSearchWithBuffer241
 }
 
 func BenchmarkVectorIndexSearcherColumnGraphRabitQQuantizedSearchWithBuffer2451(b *testing.B) {
-	shape := columnGraphScalarU8QuantizedBenchShape1926{rows: 1024, dims: 128, m: 16, topK: 10, efSearch: 128, queryOrdinal: 37}
+	shape := columnGraphScalarU8QuantizedBenchShapeFromEnv1926(b)
 	fixture := openColumnGraphRabitQQuantizedBenchFixture2451(b, shape)
 	defer fixture.close()
 	exactIDs, exactCount := columnGraphScalarU8QuantizedBenchmarkExactIDs1926(b, fixture)
@@ -180,7 +403,7 @@ func BenchmarkVectorIndexSearcherColumnGraphRabitQQuantizedSearchWithBuffer2451(
 }
 
 func BenchmarkVectorIndexSearcherColumnGraphBRQQuantizedSearchWithBuffer2481(b *testing.B) {
-	shape := columnGraphScalarU8QuantizedBenchShape1926{rows: 1024, dims: 128, m: 16, topK: 10, efSearch: 128, queryOrdinal: 37}
+	shape := columnGraphScalarU8QuantizedBenchShapeFromEnv1926(b)
 	fixture := openColumnGraphBRQQuantizedBenchFixture2481(b, shape)
 	defer fixture.close()
 	exactIDs, exactCount := columnGraphScalarU8QuantizedBenchmarkExactIDs1926(b, fixture)
@@ -203,7 +426,7 @@ func BenchmarkVectorIndexSearcherColumnGraphBRQQuantizedSearchWithBuffer2481(b *
 }
 
 func BenchmarkCollectionSearchVectorIndexWithBufferColumnGraphScalarU8Quantized2415(b *testing.B) {
-	shape := columnGraphScalarU8QuantizedBenchShape1926{rows: 1024, dims: 128, m: 16, topK: 10, efSearch: 128, queryOrdinal: 37}
+	shape := columnGraphScalarU8QuantizedBenchShapeFromEnv1926(b)
 	fixture := openColumnGraphScalarU8QuantizedBenchFixture1926(b, shape, true)
 	defer fixture.close()
 	exactIDs, exactCount := columnGraphScalarU8QuantizedBenchmarkExactIDs1926(b, fixture)
@@ -228,7 +451,7 @@ func BenchmarkCollectionSearchVectorIndexWithBufferColumnGraphScalarU8Quantized2
 }
 
 func BenchmarkCollectionSearchVectorIndexWithBufferColumnGraphRabitQQuantized2452(b *testing.B) {
-	shape := columnGraphScalarU8QuantizedBenchShape1926{rows: 1024, dims: 128, m: 16, topK: 10, efSearch: 128, queryOrdinal: 37}
+	shape := columnGraphScalarU8QuantizedBenchShapeFromEnv1926(b)
 	fixture := openColumnGraphRabitQQuantizedBenchFixture2451(b, shape)
 	defer fixture.close()
 	exactIDs, exactCount := columnGraphScalarU8QuantizedBenchmarkExactIDs1926(b, fixture)
@@ -873,7 +1096,7 @@ func assertColumnGraphBRQQuantizedSearchWithBufferGuardrails2481(tb testing.TB, 
 }
 
 func BenchmarkColumnGraphScalarU8QuantizedTraversalCounters2271(b *testing.B) {
-	shape := columnGraphScalarU8QuantizedBenchShape1926{rows: 1024, dims: 128, m: 16, topK: 10, efSearch: 128, queryOrdinal: 37}
+	shape := columnGraphScalarU8QuantizedBenchShapeFromEnv1926(b)
 	fixture := openColumnGraphScalarU8QuantizedBenchFixture1926(b, shape, true)
 	defer fixture.close()
 
@@ -1117,7 +1340,7 @@ func openColumnGraphBRQQuantizedBenchCollection2481(tb testing.TB, shape columnG
 		tb.Fatalf("OpenCollection: %v", err)
 	}
 	rows := columnGraphRebuildSyntheticRowsV2A(shape.rows, shape.dims)
-	insertColumnGraphRebuildRowsV2A(tb, col, rows)
+	insertColumnGraphScalarU8QuantizedBenchRows1926(tb, col, shape, rows)
 	return dir, d, col, def, rows
 }
 
@@ -1159,7 +1382,7 @@ func openColumnGraphScalarU8QuantizedBenchCollection1926(tb testing.TB, shape co
 		tb.Fatalf("OpenCollection: %v", err)
 	}
 	rows := columnGraphRebuildSyntheticRowsV2A(shape.rows, shape.dims)
-	insertColumnGraphRebuildRowsV2A(tb, col, rows)
+	insertColumnGraphScalarU8QuantizedBenchRows1926(tb, col, shape, rows)
 	return dir, d, col, def, rows
 }
 

--- a/TreeDB/collections/column_vector_graph_rabitq_quantized_asset_test.go
+++ b/TreeDB/collections/column_vector_graph_rabitq_quantized_asset_test.go
@@ -1259,7 +1259,7 @@ func openColumnGraphRabitQQuantizedBenchCollection2450(tb testing.TB, shape colu
 		tb.Fatalf("OpenCollection: %v", err)
 	}
 	rows := columnGraphRebuildSyntheticRowsV2A(shape.rows, shape.dims)
-	insertColumnGraphRebuildRowsV2A(tb, col, rows)
+	insertColumnGraphScalarU8QuantizedBenchRows1926(tb, col, shape, rows)
 	return dir, d, col, def, rows
 }
 

--- a/docs/benchmarks/treedb_rabitq_1bit_profile_gate.md
+++ b/docs/benchmarks/treedb_rabitq_1bit_profile_gate.md
@@ -11,9 +11,11 @@ order changes.
 
 ## What this gate proves
 
-The workflow captures isolated lower-level and collection buffered rows for the
-1024 row / 128 dimension / `topK=10` / `efSearch=128` fixture used by the
-current quantized search benchmarks. It records:
+The workflow captures isolated lower-level and collection buffered rows for a
+shape-parameterized quantized-search fixture. The default remains the historical
+1024 row / 128 dimension / `topK=10` / `efSearch=128` fixture, and
+`SHAPE=10k_x_1536` selects the high-dimensional profile contract needed by
+#2515. It records:
 
 - same-host baseline and candidate commit identity;
 - `ns/op`, `ops/sec`, `B/op`, `allocs/op`, and recall@K;
@@ -33,11 +35,16 @@ scripts/treedb_rabitq_1bit_profile_gate.sh
 
 Default selection:
 
+- `SHAPE=1024x128`: the historical fixed gate shape. Set `SHAPE=10k_x_1536`
+  for the #2515 high-dimensional contract. The underlying benchmark also
+  accepts `BENCH_ROWS`, `BENCH_DIMS`, `BENCH_M`, `BENCH_TOP_K`,
+  `BENCH_EF_SEARCH`, and `BENCH_QUERY_ORDINAL` overrides.
 - `ROWS=claim_core`: RaBitQ `quantized_only` c=1/c=8 lower-level and collection
   rows plus scalar_u8 `quantized_only` c=1/c=8 guardrail rows.
 - `PROFILE_ROWS=rabitq_collection_quantized_only_c1,rabitq_collection_quantized_only_c8`:
   CPU/alloc profiles for the required RaBitQ collection buffered target rows.
-- `BENCHTIME=100000x`, `TIMING_COUNT=5`, `PROFILE_COUNT=1`.
+- `BENCHTIME=100000x` for the default shape, `BENCHTIME=1000x` for
+  `SHAPE=10k_x_1536`, `TIMING_COUNT=5`, `PROFILE_COUNT=1`.
 - `RECALL_TOLERANCE_PCT=0`: when `BASELINE_DIR` is set, candidate median recall must be at least the matching baseline row's median recall minus this tolerance for the row guardrail to pass.
 
 Useful selectors for `ROWS` and `PROFILE_ROWS` are comma-separated and ORed:
@@ -71,10 +78,11 @@ Each selected row gets a directory named by `row_id` under `RUN_DIR`. Use a fres
 
 Primary artifacts:
 
-- `context.txt`: branch, commit, Go version/env, `GOMAXPROCS`, `GOWORK`, uptime,
-  git status, and visible competing benchmark/test processes.
+- `context.txt`: branch, commit, Go version/env, `GOMAXPROCS`, `GOWORK`, shape,
+  fixture knobs, uptime, git status, and visible competing benchmark/test
+  processes.
 - `matrix.tsv`: selected row IDs, codec, layer, mode, c, rerank candidates,
-  profile selection, and regex.
+  profile selection, shape, fixture knobs, and regex.
 - `summary.md` / `summary.tsv`: median timing, throughput, allocation, recall,
   byte/counter summaries, and guardrail status.
 - `<row>/bench_timing.txt`: unprofiled timing/counter output. Use this for
@@ -117,6 +125,18 @@ GOMAXPROCS=8 GOWORK=off go test ./TreeDB/collections \
   -run '^$' \
   -bench '^(BenchmarkVectorIndexSearcherColumnGraphRabitQQuantizedSearchWithBuffer2451|BenchmarkCollectionSearchVectorIndexWithBufferColumnGraphRabitQQuantized2452|BenchmarkVectorIndexSearcherColumnGraphScalarU8QuantizedSearchWithBuffer2414|BenchmarkCollectionSearchVectorIndexWithBufferColumnGraphScalarU8Quantized2415|BenchmarkColumnGraphScalarU8QuantizedScorePlanes1926)$' \
   -benchmem -benchtime=100x -count=3
+```
+
+#2515 `10k_x_1536` RaBitQ collection profile smoke/contract path:
+
+```sh
+RUN_DIR=/tmp/gomap_rabitq_1bit_10k_x_1536_$(date +%Y%m%d_%H%M%S) \
+  SHAPE=10k_x_1536 \
+  ROWS=rabitq_collection_quantized_only_c1,rabitq_collection_quantized_only_c8,rabitq_collection_quantized_rerank32_c1,rabitq_collection_quantized_rerank32_c8 \
+  PROFILE_ROWS=rabitq_collection_quantized_only_c1,rabitq_collection_quantized_only_c8,rabitq_collection_quantized_rerank32_c1,rabitq_collection_quantized_rerank32_c8 \
+  TIMING_COUNT=1 PROFILE_COUNT=1 BENCHTIME=1000x \
+  GOMAXPROCS=8 GOWORK=off \
+  scripts/treedb_rabitq_1bit_profile_gate.sh
 ```
 
 ## Claim-quality same-host baseline/candidate workflow
@@ -172,7 +192,7 @@ PR or issue evidence should include at least:
 | baseline/candidate identity | branch, full SHA, Go version, OS/arch, `GOMAXPROCS`, fixture |
 | timing/allocation | `ns/op`, `ops/sec`, `B/op`, `allocs/op` |
 | quality | recall@K versus exact, c=1 and c=8 shown separately |
-| bytes | `quantized_code_B/search`, `quantized_code_B/vector`, `quantized_asset_B/vector`, exact vector/norm bytes for rerank |
+| bytes | `quantized_code_B/search`, `quantized_code_B/vector` (shape-aware: scalar_u8=`dims`, RaBitQ=`ceil(dims/8)`), `quantized_asset_B/vector`, exact vector/norm bytes for rerank |
 | route counters | `search_route_quantized_only/search`, `search_route_quantized_rerank/search`, `search_route_column_graph_prepared/search` |
 | failure/fallback counters | document fetches, graph/typed/scratch/float64 fallbacks, quantized asset missing/invalid/stale/closed/unavailable |
 | collection seam | cache hits/misses/waits/errors, `open_setup_in_timed_loop=0`, `open_searcher_calls/op=0` |

--- a/docs/benchmarks/treedb_rabitq_1bit_profile_gate.md
+++ b/docs/benchmarks/treedb_rabitq_1bit_profile_gate.md
@@ -192,7 +192,7 @@ PR or issue evidence should include at least:
 | baseline/candidate identity | branch, full SHA, Go version, OS/arch, `GOMAXPROCS`, fixture |
 | timing/allocation | `ns/op`, `ops/sec`, `B/op`, `allocs/op` |
 | quality | recall@K versus exact, c=1 and c=8 shown separately |
-| bytes | `quantized_code_B/search`, `quantized_code_B/vector` (shape-aware: scalar_u8=`dims`, RaBitQ=`ceil(dims/8)`), `quantized_asset_B/vector`, exact vector/norm bytes for rerank |
+| bytes | `quantized_code_B/search`, `quantized_code_B/vector` (shape-aware: scalar_u8=`dims`, RaBitQ=`ceil(next_power_of_two(dims)/8)`), `quantized_asset_B/vector`, exact vector/norm bytes for rerank |
 | route counters | `search_route_quantized_only/search`, `search_route_quantized_rerank/search`, `search_route_column_graph_prepared/search` |
 | failure/fallback counters | document fetches, graph/typed/scratch/float64 fallbacks, quantized asset missing/invalid/stale/closed/unavailable |
 | collection seam | cache hits/misses/waits/errors, `open_setup_in_timed_loop=0`, `open_searcher_calls/op=0` |

--- a/scripts/treedb_rabitq_1bit_profile_gate.sh
+++ b/scripts/treedb_rabitq_1bit_profile_gate.sh
@@ -661,7 +661,13 @@ def guardrail_status(meta, bench_rows, baseline_rows):
     if fixture_dims <= 0:
         dims_median = median([row.get("dims") for row in bench_rows])
         fixture_dims = int(dims_median or 0)
-    expected_code_bytes = (fixture_dims + 7) // 8 if meta.get("codec") == "rabitq_1bit" else fixture_dims
+    if meta.get("codec") == "rabitq_1bit":
+        code_dims = 1
+        while code_dims < fixture_dims:
+            code_dims *= 2
+        expected_code_bytes = (code_dims + 7) // 8
+    else:
+        expected_code_bytes = fixture_dims
     checks.append(expected_code_bytes > 0 and present_all_eq(bench_rows, "quantized_code_B/vector", expected_code_bytes))
     checks.append(present_all(bench_rows, "quantized_asset_B/vector"))
 

--- a/scripts/treedb_rabitq_1bit_profile_gate.sh
+++ b/scripts/treedb_rabitq_1bit_profile_gate.sh
@@ -5,11 +5,18 @@ ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 cd "$ROOT"
 
 RUN_DIR="${RUN_DIR:-/tmp/gomap_rabitq_1bit_profile_gate_$(date +%Y%m%d_%H%M%S)}"
+SHAPE="${SHAPE:-1024x128}"
+BENCH_ROWS="${BENCH_ROWS:-}"
+BENCH_DIMS="${BENCH_DIMS:-}"
+BENCH_M="${BENCH_M:-16}"
+BENCH_TOP_K="${BENCH_TOP_K:-10}"
+BENCH_EF_SEARCH="${BENCH_EF_SEARCH:-128}"
+BENCH_QUERY_ORDINAL="${BENCH_QUERY_ORDINAL:-37}"
 ROWS="${ROWS:-claim_core}"
 PROFILE_ROWS="${PROFILE_ROWS:-rabitq_collection_quantized_only_c1,rabitq_collection_quantized_only_c8}"
-BENCHTIME="${BENCHTIME:-100000x}"
-TIMING_BENCHTIME="${TIMING_BENCHTIME:-$BENCHTIME}"
-PROFILE_BENCHTIME="${PROFILE_BENCHTIME:-$BENCHTIME}"
+BENCHTIME="${BENCHTIME:-}"
+TIMING_BENCHTIME="${TIMING_BENCHTIME:-}"
+PROFILE_BENCHTIME="${PROFILE_BENCHTIME:-}"
 TIMING_COUNT="${TIMING_COUNT:-5}"
 PROFILE_COUNT="${PROFILE_COUNT:-1}"
 RUN_TIMING="${RUN_TIMING:-true}"
@@ -44,6 +51,99 @@ quote_cmd() {
 		first=0
 	done
 	printf '\n'
+}
+
+parse_shape_token() {
+	local raw=$1
+	local normalized rows rows_suffix dims dims_suffix
+	normalized=$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]')
+	normalized=${normalized//_x_/x}
+	normalized=${normalized//_/}
+	case "$normalized" in
+		""|default|claimcore)
+			printf '1024 128\n'
+			return 0
+			;;
+	esac
+	if [[ "$normalized" =~ ^([0-9]+)(k?)x([0-9]+)(k?)$ ]]; then
+		rows=${BASH_REMATCH[1]}
+		rows_suffix=${BASH_REMATCH[2]}
+		dims=${BASH_REMATCH[3]}
+		dims_suffix=${BASH_REMATCH[4]}
+		if [[ "$rows_suffix" == "k" ]]; then
+			rows=$((rows * 1000))
+		fi
+		if [[ "$dims_suffix" == "k" ]]; then
+			dims=$((dims * 1000))
+		fi
+		printf '%s %s\n' "$rows" "$dims"
+		return 0
+	fi
+	printf 'unsupported SHAPE=%q (want default, 1024x128, 10k_x_1536, or <rows>x<dims>)\n' "$raw" >&2
+	return 2
+}
+
+require_positive_int() {
+	local name=$1 value=$2
+	if ! [[ "$value" =~ ^[0-9]+$ ]] || ((value <= 0)); then
+		printf '%s=%q must be a positive integer\n' "$name" "$value" >&2
+		return 2
+	fi
+}
+
+require_nonnegative_int() {
+	local name=$1 value=$2
+	if ! [[ "$value" =~ ^[0-9]+$ ]]; then
+		printf '%s=%q must be a non-negative integer\n' "$name" "$value" >&2
+		return 2
+	fi
+}
+
+resolve_bench_shape() {
+	local parsed shape_rows shape_dims
+	parsed=$(parse_shape_token "$SHAPE")
+	read -r shape_rows shape_dims <<<"$parsed"
+	BENCH_ROWS="${BENCH_ROWS:-$shape_rows}"
+	BENCH_DIMS="${BENCH_DIMS:-$shape_dims}"
+	require_positive_int BENCH_ROWS "$BENCH_ROWS"
+	require_positive_int BENCH_DIMS "$BENCH_DIMS"
+	require_positive_int BENCH_M "$BENCH_M"
+	require_positive_int BENCH_TOP_K "$BENCH_TOP_K"
+	require_positive_int BENCH_EF_SEARCH "$BENCH_EF_SEARCH"
+	require_nonnegative_int BENCH_QUERY_ORDINAL "$BENCH_QUERY_ORDINAL"
+	if ((BENCH_TOP_K > BENCH_ROWS)); then
+		printf 'BENCH_TOP_K=%s exceeds BENCH_ROWS=%s\n' "$BENCH_TOP_K" "$BENCH_ROWS" >&2
+		return 2
+	fi
+	if ((BENCH_QUERY_ORDINAL >= BENCH_ROWS)); then
+		printf 'BENCH_QUERY_ORDINAL=%s out of range for BENCH_ROWS=%s\n' "$BENCH_QUERY_ORDINAL" "$BENCH_ROWS" >&2
+		return 2
+	fi
+	if [[ "$BENCH_ROWS" == "10000" && "$BENCH_DIMS" == "1536" ]]; then
+		SHAPE_LABEL=10k_x_1536
+	else
+		SHAPE_LABEL="${BENCH_ROWS}x${BENCH_DIMS}"
+	fi
+	if [[ -z "$BENCHTIME" ]]; then
+		if [[ "$SHAPE_LABEL" == "10k_x_1536" ]]; then
+			BENCHTIME=1000x
+		else
+			BENCHTIME=100000x
+		fi
+	fi
+	TIMING_BENCHTIME="${TIMING_BENCHTIME:-$BENCHTIME}"
+	PROFILE_BENCHTIME="${PROFILE_BENCHTIME:-$BENCHTIME}"
+}
+
+write_go_test_env_prefix() {
+	printf 'GOMAXPROCS=%q GOWORK=%q ' "$GOMAXPROCS_VALUE" "$GOWORK_VALUE"
+	printf 'TREEDB_COLUMN_GRAPH_QUANTIZED_BENCH_SHAPE=%q ' "$SHAPE"
+	printf 'TREEDB_COLUMN_GRAPH_QUANTIZED_BENCH_ROWS=%q ' "$BENCH_ROWS"
+	printf 'TREEDB_COLUMN_GRAPH_QUANTIZED_BENCH_DIMS=%q ' "$BENCH_DIMS"
+	printf 'TREEDB_COLUMN_GRAPH_QUANTIZED_BENCH_M=%q ' "$BENCH_M"
+	printf 'TREEDB_COLUMN_GRAPH_QUANTIZED_BENCH_TOP_K=%q ' "$BENCH_TOP_K"
+	printf 'TREEDB_COLUMN_GRAPH_QUANTIZED_BENCH_EF_SEARCH=%q ' "$BENCH_EF_SEARCH"
+	printf 'TREEDB_COLUMN_GRAPH_QUANTIZED_BENCH_QUERY_ORDINAL=%q ' "$BENCH_QUERY_ORDINAL"
 }
 
 write_pprof_top() {
@@ -134,6 +234,8 @@ selected_by_list() {
 	return 1
 }
 
+resolve_bench_shape
+
 write_context() {
 	local dest=$1
 	{
@@ -151,6 +253,9 @@ write_context() {
 		printf '\n'
 		printf 'GOMAXPROCS: %s\n' "$GOMAXPROCS_VALUE"
 		printf 'GOWORK: %s\n' "$GOWORK_VALUE"
+		printf 'shape: %s\n' "$SHAPE_LABEL"
+		printf 'shape_selector: %s\n' "$SHAPE"
+		printf 'fixture: rows=%s dims=%s m=%s topK=%s efSearch=%s queryOrdinal=%s\n' "$BENCH_ROWS" "$BENCH_DIMS" "$BENCH_M" "$BENCH_TOP_K" "$BENCH_EF_SEARCH" "$BENCH_QUERY_ORDINAL"
 		printf 'rows: %s\n' "$ROWS"
 		printf 'profile_rows: %s\n' "$PROFILE_ROWS"
 		printf 'timing: enabled=%s benchtime=%s count=%s\n' "$RUN_TIMING" "$TIMING_BENCHTIME" "$TIMING_COUNT"
@@ -173,7 +278,16 @@ write_context() {
 run_go_test() {
 	local outfile=$1
 	shift
-	GOMAXPROCS="$GOMAXPROCS_VALUE" GOWORK="$GOWORK_VALUE" "$@" 2>&1 | tee "$outfile"
+	GOMAXPROCS="$GOMAXPROCS_VALUE" \
+		GOWORK="$GOWORK_VALUE" \
+		TREEDB_COLUMN_GRAPH_QUANTIZED_BENCH_SHAPE="$SHAPE" \
+		TREEDB_COLUMN_GRAPH_QUANTIZED_BENCH_ROWS="$BENCH_ROWS" \
+		TREEDB_COLUMN_GRAPH_QUANTIZED_BENCH_DIMS="$BENCH_DIMS" \
+		TREEDB_COLUMN_GRAPH_QUANTIZED_BENCH_M="$BENCH_M" \
+		TREEDB_COLUMN_GRAPH_QUANTIZED_BENCH_TOP_K="$BENCH_TOP_K" \
+		TREEDB_COLUMN_GRAPH_QUANTIZED_BENCH_EF_SEARCH="$BENCH_EF_SEARCH" \
+		TREEDB_COLUMN_GRAPH_QUANTIZED_BENCH_QUERY_ORDINAL="$BENCH_QUERY_ORDINAL" \
+		"$@" 2>&1 | tee "$outfile"
 }
 
 run_row() {
@@ -210,18 +324,25 @@ run_row() {
 		printf 'profile_selected=%s\n' "$profile_selected"
 		printf 'profile_captured=%s\n' "$profile_captured"
 		printf 'bench_regex=%s\n' "$bench_regex"
-		printf 'fixture=1024 rows / 128 dims / topK=10 / efSearch=128 / queryOrdinal=37\n'
+		printf 'shape=%s\n' "$SHAPE_LABEL"
+		printf 'fixture_rows=%s\n' "$BENCH_ROWS"
+		printf 'fixture_dims=%s\n' "$BENCH_DIMS"
+		printf 'fixture_m=%s\n' "$BENCH_M"
+		printf 'fixture_top_k=%s\n' "$BENCH_TOP_K"
+		printf 'fixture_ef_search=%s\n' "$BENCH_EF_SEARCH"
+		printf 'fixture_query_ordinal=%s\n' "$BENCH_QUERY_ORDINAL"
+		printf 'fixture=%s rows / %s dims / topK=%s / efSearch=%s / queryOrdinal=%s\n' "$BENCH_ROWS" "$BENCH_DIMS" "$BENCH_TOP_K" "$BENCH_EF_SEARCH" "$BENCH_QUERY_ORDINAL"
 	} >"$row_dir/row.env"
 
 	local timing_cmd=(go test ./TreeDB/collections -run '^$' -bench "$bench_regex" -benchmem -benchtime "$TIMING_BENCHTIME" -count "$TIMING_COUNT")
 	local profile_cmd=(go test ./TreeDB/collections -run '^$' -bench "$bench_regex" -benchmem -benchtime "$PROFILE_BENCHTIME" -count "$PROFILE_COUNT" -o "$test_binary" -cpuprofile "$cpu_profile" -memprofile "$alloc_profile" -blockprofile "$block_profile" -mutexprofile "$mutex_profile")
 
 	{
-		printf 'GOMAXPROCS=%q GOWORK=%q ' "$GOMAXPROCS_VALUE" "$GOWORK_VALUE"
+		write_go_test_env_prefix
 		quote_cmd "${timing_cmd[@]}"
 	} >"$row_dir/command_timing.txt"
 	{
-		printf 'GOMAXPROCS=%q GOWORK=%q ' "$GOMAXPROCS_VALUE" "$GOWORK_VALUE"
+		write_go_test_env_prefix
 		quote_cmd "${profile_cmd[@]}"
 	} >"$row_dir/command_profile.txt"
 
@@ -273,7 +394,7 @@ run_row() {
 - concurrency: \`$concurrency\`
 - rerank candidates: \`$rerank_candidates\`
 - benchmark regex: \`$bench_regex\`
-- fixture: 1024 rows / 128 dims / \`topK=10\` / \`efSearch=128\` / query ordinal 37
+- fixture: \`$SHAPE_LABEL\` ($BENCH_ROWS rows / $BENCH_DIMS dims / \`topK=$BENCH_TOP_K\` / \`efSearch=$BENCH_EF_SEARCH\` / query ordinal $BENCH_QUERY_ORDINAL)
 - timing command: \`$(tr '\n' ' ' <"$row_dir/command_timing.txt")\`
 - profile command: \`$(tr '\n' ' ' <"$row_dir/command_profile.txt")\`
 - profile selected: \`$profile_selected\`
@@ -358,9 +479,9 @@ fi
 write_context "$RUN_DIR/context.txt"
 
 {
-	printf 'row_id\tcodec\tlayer\tmode\tconcurrency\trerank_candidates\tprofile_selected\tbench_regex\n'
+	printf 'row_id\tcodec\tlayer\tmode\tconcurrency\trerank_candidates\tprofile_selected\tshape\tfixture_rows\tfixture_dims\tfixture_top_k\tfixture_ef_search\tbench_regex\n'
 	for i in "${!row_ids[@]}"; do
-		printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' "${row_ids[$i]}" "${row_codecs[$i]}" "${row_layers[$i]}" "${row_modes[$i]}" "${row_concurrency[$i]}" "${row_rerank_candidates[$i]}" "${row_profile_selected[$i]}" "${row_regexes[$i]}"
+		printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' "${row_ids[$i]}" "${row_codecs[$i]}" "${row_layers[$i]}" "${row_modes[$i]}" "${row_concurrency[$i]}" "${row_rerank_candidates[$i]}" "${row_profile_selected[$i]}" "$SHAPE_LABEL" "$BENCH_ROWS" "$BENCH_DIMS" "$BENCH_TOP_K" "$BENCH_EF_SEARCH" "${row_regexes[$i]}"
 	done
 } >"$RUN_DIR/matrix.tsv"
 
@@ -383,6 +504,10 @@ try:
 except ValueError:
     recall_tolerance_pct = 0.0
 metric_units = {
+    "rows",
+    "dims",
+    "top_k",
+    "ef_search",
     "ns/op",
     "ops/sec",
     "B/op",
@@ -529,8 +654,15 @@ def guardrail_status(meta, bench_rows, baseline_rows):
     checks.append(present_all_eq(bench_rows, "quantized_scorer_active/search", 1))
     checks.append(recall_guardrail_ok(bench_rows, baseline_rows))
 
-    expected_code_bytes = 16 if meta.get("codec") == "rabitq_1bit" else 128
-    checks.append(present_all_eq(bench_rows, "quantized_code_B/vector", expected_code_bytes))
+    try:
+        fixture_dims = int(meta.get("fixture_dims") or 0)
+    except ValueError:
+        fixture_dims = 0
+    if fixture_dims <= 0:
+        dims_median = median([row.get("dims") for row in bench_rows])
+        fixture_dims = int(dims_median or 0)
+    expected_code_bytes = (fixture_dims + 7) // 8 if meta.get("codec") == "rabitq_1bit" else fixture_dims
+    checks.append(expected_code_bytes > 0 and present_all_eq(bench_rows, "quantized_code_B/vector", expected_code_bytes))
     checks.append(present_all(bench_rows, "quantized_asset_B/vector"))
 
     mode = meta.get("mode", "")
@@ -613,8 +745,8 @@ for row_id in selected_row_ids:
     summary_rows.append(out)
 
 fields = [
-    "row_id", "codec", "layer", "mode", "concurrency", "rerank_candidates", "profile_selected", "profile_captured", "source", "status", "guardrail_status",
-    "ns/op", "ops/sec", "B/op", "allocs/op", "recall_at_k_pct",
+    "row_id", "codec", "layer", "mode", "concurrency", "rerank_candidates", "profile_selected", "profile_captured", "shape", "fixture_rows", "fixture_dims", "source", "status", "guardrail_status",
+    "rows", "dims", "top_k", "ef_search", "ns/op", "ops/sec", "B/op", "allocs/op", "recall_at_k_pct",
     "docs_fetched/search", "vector_B/search", "norm_B/search", "quantized_code_B/search", "quantized_code_B/vector", "quantized_asset_B/vector",
     "quantized_rerank_candidates/search", "quantized_rerank_exact_score_calls/search", "prepared_score_calls/search",
     "graph_row_fallbacks/search", "typed_column_vector_fallbacks/search", "vector_scratch_decodes/search", "score_float64_fallbacks/search",
@@ -632,12 +764,13 @@ with open(os.path.join(root, "summary.md"), "w", encoding="utf-8") as out:
     out.write("# TreeDB rabitq_1bit profile gate summary\n\n")
     out.write("This report is generated from isolated benchmark subrows. ")
     out.write("Guardrail status checks allocation, document/materialization, fallback, asset-unavailable, route, recall, code-byte, and exact-read constraints from benchmark counters.\n\n")
-    out.write("| row | codec | layer | mode | c | ns/op | ops/sec | B/op | allocs/op | recall@K % | code B/search | code B/vector | asset B/vector | vector B/search | norm B/search | rerank exact calls/search | guardrails | profile captured |\n")
-    out.write("| --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- | --- |\n")
+    out.write("| row | shape | codec | layer | mode | c | ns/op | ops/sec | B/op | allocs/op | recall@K % | code B/search | code B/vector | asset B/vector | vector B/search | norm B/search | rerank exact calls/search | guardrails | profile captured |\n")
+    out.write("| --- | --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- | --- |\n")
     for row in summary_rows:
         out.write(
-            "| {row_id} | {codec} | {layer} | {mode} | {c} | {ns} | {ops} | {bop} | {allocs} | {recall} | {code_search} | {code_vector} | {asset_vector} | {vec} | {norm} | {rerank} | {guard} | {profiled} |\n".format(
+            "| {row_id} | {shape} | {codec} | {layer} | {mode} | {c} | {ns} | {ops} | {bop} | {allocs} | {recall} | {code_search} | {code_vector} | {asset_vector} | {vec} | {norm} | {rerank} | {guard} | {profiled} |\n".format(
                 row_id=row.get("row_id", ""),
+                shape=row.get("shape", ""),
                 codec=row.get("codec", ""),
                 layer=row.get("layer", ""),
                 mode=row.get("mode", ""),
@@ -688,6 +821,7 @@ cat >"$RUN_DIR/README.md" <<EOF
 - commit: \`$(git rev-parse HEAD)\`
 - GOMAXPROCS: \`$GOMAXPROCS_VALUE\`
 - GOWORK: \`$GOWORK_VALUE\`
+- shape: \`$SHAPE_LABEL\` ($BENCH_ROWS rows / $BENCH_DIMS dims / topK=$BENCH_TOP_K / efSearch=$BENCH_EF_SEARCH / queryOrdinal=$BENCH_QUERY_ORDINAL)
 - selected rows: \`$ROWS\`
 - profile rows: \`$PROFILE_ROWS\`
 - timing: enabled=\`$RUN_TIMING\`, benchtime=\`$TIMING_BENCHTIME\`, count=\`$TIMING_COUNT\`


### PR DESCRIPTION
## Summary

- Adds shape controls for the existing TreeDB column-graph quantized benchmark/profile gate without changing search/runtime semantics.
- Keeps the historical RaBitQ/scalar_u8 default fixture at `1024x128`, while enabling `SHAPE=10k_x_1536` plus explicit fixture overrides.
- Updates the RaBitQ profile-gate script/docs so #2515/#2519 can capture c=1/c=8 `10k_x_1536` collection rows with CPU/alloc/block/mutex profiles.
- Chunks large benchmark fixture inserts so `10k_x_1536` setup does not exceed command-WAL record limits.

Closes #2515.

## Scope boundary

Harness/profile plumbing only. This PR does **not** change RaBitQ `rabitq_1bit` v1 storage, bit order, score formula, codec identity, query semantics, or production search code.

## Tests

Latest local head: `15d4b5922`.

- `GOWORK=off go test ./TreeDB/collections -run '^(TestColumnGraphScalarU8QuantizedBenchShapeFromEnvValues1926|TestColumnGraphScalarU8QuantizedBenchInsertBatchSize1926)$' -count=1`
- `GOWORK=off go test ./TreeDB/collections -run 'RabitQ|Quantized|VectorIndexSearch' -count=1`
- `GOWORK=off go test ./TreeDB/docs -run 'RabitQ|Quantized' -count=1`
- `GOWORK=off go test ./cmd/treedb_vector_search_demo -run 'SearchProfile|Parse|Config' -count=1`
- `bash -n scripts/treedb_rabitq_1bit_profile_gate.sh`
- Dry-run script checks:
  - `DRY_RUN=true SHAPE=10k_x_1536 ROWS=rabitq_collection_quantized_only_c1 PROFILE_ROWS=rabitq_collection_quantized_only_c1 scripts/treedb_rabitq_1bit_profile_gate.sh`
  - `DRY_RUN=true ROWS=rabitq_collection_quantized_only_c1 PROFILE_ROWS=rabitq_collection_quantized_only_c1 scripts/treedb_rabitq_1bit_profile_gate.sh`

## Benchmark/profile evidence

### Exact/scalar DB-tier provenance (#2494; separate evidence)

Existing exact FP32 and scalar_u8 `10k_x_1536` c=1/c=8 profiles remain separate from this PR's RaBitQ benchmark-gate evidence:

- Artifact root: `/tmp/gomap_2494_crossover_synthesis_20260606_200612/profiles/db/10k_x_1536/`
- Selected table: `/tmp/gomap_2494_crossover_synthesis_20260606_200612/derived/selected_tables.md`
- Command provenance: `/tmp/gomap_2494_crossover_synthesis_20260606_200612/logs/10k_x_1536_db_command.txt`

| fixture | mode | c | avg µs | ops/s | recall | code B/search | vector B/search | exact rerank calls | profile dir |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| `10k_x_1536` | exact | 1 | 569.797 | 1,754 | 0.9859 | 0 | 4,538,196 | 0 | `/tmp/gomap_2494_crossover_synthesis_20260606_200612/profiles/db/10k_x_1536/treedb_column_graph` |
| `10k_x_1536` | exact | 8 | 1164.455 | 6,866 | 0.9859 | 0 | 4,538,196 | 0 | same |
| `10k_x_1536` | scalar_u8 qonly | 1 | 282.007 | 3,544 | 0.8703 | 1,143,932 | 0 | 0 | `/tmp/gomap_2494_crossover_synthesis_20260606_200612/profiles/db/10k_x_1536/treedb_column_graph_quantized_only` |
| `10k_x_1536` | scalar_u8 qonly | 8 | 556.316 | 14,363 | 0.8703 | 1,143,932 | 0 | 0 | same |
| `10k_x_1536` | scalar_u8 rerank32 | 1 | 281.876 | 3,545 | 0.9828 | 1,143,932 | 196,608 | 32 | `/tmp/gomap_2494_crossover_synthesis_20260606_200612/profiles/db/10k_x_1536/treedb_column_graph_quantized_rerank` |
| `10k_x_1536` | scalar_u8 rerank32 | 8 | 519.315 | 15,326 | 0.9828 | 1,143,932 | 196,608 | 32 | same |

### RaBitQ `10k_x_1536` profile gate (this PR)

Artifact root:

- `/tmp/gomap_2515_rabitq_10k_x_1536_final_20260606_222335`
- Summary with PR-head guardrail recompute: `/tmp/gomap_2515_rabitq_10k_x_1536_final_20260606_222335/summary_head_15d4b5922.md`
- CPU/alloc/block/mutex pprof files under each row directory.

Command:

```sh
lockf /tmp/gomap_2514_benchmark.lock /tmp/gomap_2515_run_rabitq_profile_20260606_222335.sh /tmp/gomap_2515_rabitq_10k_x_1536_final_20260606_222335
```

The script ran:

```sh
SHAPE=10k_x_1536 \
ROWS=rabitq_collection_quantized_only_c1,rabitq_collection_quantized_only_c8,rabitq_collection_quantized_rerank32_c1,rabitq_collection_quantized_rerank32_c8 \
PROFILE_ROWS=rabitq_collection_quantized_only_c1,rabitq_collection_quantized_only_c8,rabitq_collection_quantized_rerank32_c1,rabitq_collection_quantized_rerank32_c8 \
TIMING_COUNT=1 PROFILE_COUNT=1 BENCHTIME=5000x \
GOMAXPROCS=8 GOWORK=off \
scripts/treedb_rabitq_1bit_profile_gate.sh
```

| row | mode | c | ns/op | ops/sec | B/op | allocs/op | recall % | code B/search | code B/vector | vector B/search | norm B/search | rerank exact calls/search | guardrails @15d4 |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| `rabitq_collection_quantized_only_c1` | quantized_only | 1 | 591,163 | 1,692 | 0 | 0 | 100 | 48,640 | 256 | 0 | 0 | 0 | pass |
| `rabitq_collection_quantized_only_c8` | quantized_only | 8 | 106,759 | 9,367 | 0 | 0 | 100 | 48,640 | 256 | 0 | 0 | 0 | pass |
| `rabitq_collection_quantized_rerank32_c1` | quantized_rerank | 1 | 192,469 | 5,196 | 0 | 0 | 100 | 48,640 | 256 | 196,608 | 128 | 32 | pass |
| `rabitq_collection_quantized_rerank32_c8` | quantized_rerank | 8 | 81,632 | 12,250 | 0 | 0 | 100 | 48,640 | 256 | 196,608 | 128 | 32 | pass |

Notes:

- The raw run used commit `7e36fdc84`; PR head `15d4b5922` fixes the script-side RaBitQ code-byte expectation to `ceil(next_power_of_two(dims)/8)`, so `1536` dims expects `256` B/code. Raw benchmark/profile files are unchanged.
- The lock context captured competing benchmark/test processes before/during the run. Treat timings as profile-contract rows, not speedup claims.
- Go benchmark `-cpuprofile` includes fixture setup as well as the measured search row; timing rows should come from unprofiled `bench_timing.txt`.

## Risks / notes

- The profile run is not a speedup claim; it establishes a reproducible 10k x 1536 profile contract for downstream RaBitQ work (#2519).
- Existing exact/scalar DB-tier evidence remains under #2494 artifacts and is not mixed with RaBitQ benchmark-gate evidence.
