### PR TITLE
Add TreeDB collection text storage backfill

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3624,8 +3624,13 @@ func (c *Collection) Insert(id, document []byte) ([]byte, error) {
 	if err := c.ensureWriteDomainOpen(); err != nil {
 		return nil, err
 	}
-	if err := rejectTextIndexWriteUnavailable(c.meta, "Insert"); err != nil {
-		return nil, err
+	if len(c.meta.TextIndexes) != 0 {
+		unlockSchema := c.lockCollectionSchemaRead()
+		err := c.refreshTextIndexWriteGuard("Insert")
+		unlockSchema()
+		if err != nil {
+			return nil, err
+		}
 	}
 	if err := c.requireColumnStoreCommandWAL(c.meta, nil); err != nil {
 		return nil, err
@@ -10370,7 +10375,7 @@ func (c *Collection) DeleteDocument(documentID []byte) (bool, error) {
 	}
 	unlockSchema := c.lockCollectionSchemaRead()
 	defer unlockSchema()
-	if err := rejectTextIndexWriteUnavailable(c.meta, "DeleteDocument"); err != nil {
+	if err := c.refreshTextIndexWriteGuard("DeleteDocument"); err != nil {
 		return false, err
 	}
 	if len(documentID) == 0 {
@@ -10430,7 +10435,7 @@ func (c *Collection) DeleteBatch(documentIDs [][]byte) (int, error) {
 	}
 	unlockSchema := c.lockCollectionSchemaRead()
 	defer unlockSchema()
-	if err := rejectTextIndexWriteUnavailable(c.meta, "DeleteBatch"); err != nil {
+	if err := c.refreshTextIndexWriteGuard("DeleteBatch"); err != nil {
 		return 0, err
 	}
 	for i, id := range documentIDs {
@@ -11004,7 +11009,7 @@ func (c *Collection) Update(documentID []byte, update func(current []byte) (repl
 	}
 	unlockSchema := c.lockCollectionSchemaRead()
 	defer unlockSchema()
-	if err := rejectTextIndexWriteUnavailable(c.meta, "Update"); err != nil {
+	if err := c.refreshTextIndexWriteGuard("Update"); err != nil {
 		return false, false, err
 	}
 	if err := c.requireColumnStoreCommandWAL(c.meta, nil); err != nil {
@@ -11172,7 +11177,7 @@ func (c *Collection) updateBatch(items []UpdateBatchItem, mode updateBatchMode) 
 	}
 	unlockSchema := c.lockCollectionSchemaRead()
 	defer unlockSchema()
-	if err := rejectTextIndexWriteUnavailable(c.meta, "UpdateBatch"); err != nil {
+	if err := c.refreshTextIndexWriteGuard("UpdateBatch"); err != nil {
 		return nil, false, err
 	}
 	if len(items) == 0 {

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -1087,6 +1087,7 @@ type collectionWriteDomain struct {
 	primaryRoot              uint64
 	storagePolicy            backenddb.OrderedRootStoragePolicy
 	commandWALCoordinator    atomic.Pointer[collectionCommandWALCoordinator]
+	schemaCoordinator        *collectionSchemaCoordinator
 	table                    memtable.Table
 	indexedPublishingUnits   []indexedFlushUnit
 	indexedFlushUnits        []indexedFlushUnit
@@ -2617,17 +2618,28 @@ func (m *CollectionManager) writeDomainForCollection(name string) *collectionWri
 	if m.domains == nil {
 		m.domains = make(map[string]*collectionWriteDomain)
 	}
+	schemaCoord := collectionSchemaCoordinatorForDBCollection(m.db, name)
 	if domain := m.domains[name]; domain != nil {
 		if domain.commandWALCoordinator.Load() == nil {
 			domain.commandWALCoordinator.Store(m.commandWALCoordinator)
+		}
+		if domain.schemaCoordinator == nil {
+			domain.schemaCoordinator = schemaCoord
+			if schemaCoord != nil {
+				schemaCoord.registerDomain(domain)
+			}
 		}
 		return domain
 	}
 	domain := &collectionWriteDomain{
 		updateCombineShards: defaultCollectionUpdateCombineShards,
+		schemaCoordinator:   schemaCoord,
 	}
 	domain.commandWALCoordinator.Store(m.commandWALCoordinator)
 	domain.updateBatchDetailedStats.Store(m.updateBatchDetailedStats.Load())
+	if schemaCoord != nil {
+		schemaCoord.registerDomain(domain)
+	}
 	m.domains[name] = domain
 	return domain
 }
@@ -3622,6 +3634,8 @@ func (c *Collection) Insert(id, document []byte) ([]byte, error) {
 		return nil, err
 	}
 	if len(c.meta.Indexes) == 0 && len(c.meta.VectorIndexes) == 0 && len(c.meta.TextIndexes) == 0 && !c.db.CommandWALEnabled() {
+		unlockSchema := c.lockCollectionSchemaRead()
+		defer unlockSchema()
 		if c.hasBufferedNoIndexBSONPrimaryOverlayOrRootRuns() {
 			if err := c.withMutationLock(func() error {
 				return c.flushBufferedWrites()
@@ -3654,6 +3668,8 @@ func (c *Collection) Flush() error {
 	if c.db == nil {
 		return errCollectionDBNil
 	}
+	unlockSchema := c.lockCollectionSchemaRead()
+	defer unlockSchema()
 	if c.writeDomain != nil {
 		unlockMutation := c.lockMutation()
 		c.writeDomain.waitIndexedAsyncFlush()
@@ -9004,6 +9020,8 @@ func (c *Collection) insertBatchWithCommandWALIntent(ids, documents [][]byte, tr
 	if err := c.ensureWriteDomainOpen(); err != nil {
 		return nil, err
 	}
+	unlockSchema := c.lockCollectionSchemaRead()
+	defer unlockSchema()
 
 	return retryInsertBatchMutation(func() ([][]byte, error) {
 		return c.insertBatchOnce(ids, documents, trustedValidBSON, templateEncoder, commandWALIntent, execOpts)
@@ -10350,6 +10368,8 @@ func (c *Collection) DeleteDocument(documentID []byte) (bool, error) {
 	if err := c.ensureWriteDomainOpen(); err != nil {
 		return false, err
 	}
+	unlockSchema := c.lockCollectionSchemaRead()
+	defer unlockSchema()
 	if err := rejectTextIndexWriteUnavailable(c.meta, "DeleteDocument"); err != nil {
 		return false, err
 	}
@@ -10408,6 +10428,8 @@ func (c *Collection) DeleteBatch(documentIDs [][]byte) (int, error) {
 	if err := c.ensureWriteDomainOpen(); err != nil {
 		return 0, err
 	}
+	unlockSchema := c.lockCollectionSchemaRead()
+	defer unlockSchema()
 	if err := rejectTextIndexWriteUnavailable(c.meta, "DeleteBatch"); err != nil {
 		return 0, err
 	}
@@ -10980,6 +11002,8 @@ func (c *Collection) Update(documentID []byte, update func(current []byte) (repl
 	if err := validateCollectionUpdateInput(c, documentID, update); err != nil {
 		return false, false, err
 	}
+	unlockSchema := c.lockCollectionSchemaRead()
+	defer unlockSchema()
 	if err := rejectTextIndexWriteUnavailable(c.meta, "Update"); err != nil {
 		return false, false, err
 	}
@@ -11146,6 +11170,8 @@ func (c *Collection) updateBatch(items []UpdateBatchItem, mode updateBatchMode) 
 	if err := c.ensureWriteDomainOpen(); err != nil {
 		return nil, false, err
 	}
+	unlockSchema := c.lockCollectionSchemaRead()
+	defer unlockSchema()
 	if err := rejectTextIndexWriteUnavailable(c.meta, "UpdateBatch"); err != nil {
 		return nil, false, err
 	}

--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3810,6 +3810,10 @@ func (c *Collection) insertOneNoIndexBuffered(id, document []byte) ([]byte, erro
 		return nil, errCollectionNotFound
 	}
 	c.meta = catalog.meta
+	if err := rejectTextIndexWriteUnavailable(catalog.meta, "Insert"); err != nil {
+		domain.mu.Unlock()
+		return nil, err
+	}
 	if err := c.requireColumnStoreCommandWAL(catalog.meta, nil); err != nil {
 		domain.mu.Unlock()
 		return nil, err
@@ -8841,6 +8845,10 @@ func (c *Collection) insertOneNoIndex(id, document []byte) ([]byte, error) {
 		return nil, err
 	}
 	c.meta = catalog.meta
+	if err := rejectTextIndexWriteUnavailable(c.meta, "Insert"); err != nil {
+		_ = snap.Close()
+		return nil, err
+	}
 	if len(c.meta.Indexes) > 0 || len(c.meta.VectorIndexes) > 0 {
 		_ = snap.Close()
 		return c.insertOneViaBatch(id, document)

--- a/TreeDB/collections/bson_set_update.go
+++ b/TreeDB/collections/bson_set_update.go
@@ -57,6 +57,8 @@ func (c *Collection) UpdateBSONSet(documentID []byte, fields []BSONSetField) (bo
 	if err := validateCollectionUpdateDocumentInput(c, documentID); err != nil {
 		return false, false, err
 	}
+	unlockSchema := c.lockCollectionSchemaRead()
+	defer unlockSchema()
 	if err := rejectTextIndexWriteUnavailable(c.meta, "UpdateBSONSet"); err != nil {
 		return false, false, err
 	}
@@ -158,6 +160,8 @@ func (c *Collection) updateBSONSetBatch(items []BSONSetUpdateBatchItem, mode upd
 	if err := c.ensureWriteDomainOpen(); err != nil {
 		return nil, false, err
 	}
+	unlockSchema := c.lockCollectionSchemaRead()
+	defer unlockSchema()
 	if err := rejectTextIndexWriteUnavailable(c.meta, "UpdateBSONSetBatch"); err != nil {
 		return nil, false, err
 	}

--- a/TreeDB/collections/bson_set_update.go
+++ b/TreeDB/collections/bson_set_update.go
@@ -59,7 +59,7 @@ func (c *Collection) UpdateBSONSet(documentID []byte, fields []BSONSetField) (bo
 	}
 	unlockSchema := c.lockCollectionSchemaRead()
 	defer unlockSchema()
-	if err := rejectTextIndexWriteUnavailable(c.meta, "UpdateBSONSet"); err != nil {
+	if err := c.refreshTextIndexWriteGuard("UpdateBSONSet"); err != nil {
 		return false, false, err
 	}
 	if err := c.validateBSONSetDocumentFormat(); err != nil {
@@ -162,7 +162,7 @@ func (c *Collection) updateBSONSetBatch(items []BSONSetUpdateBatchItem, mode upd
 	}
 	unlockSchema := c.lockCollectionSchemaRead()
 	defer unlockSchema()
-	if err := rejectTextIndexWriteUnavailable(c.meta, "UpdateBSONSetBatch"); err != nil {
+	if err := c.refreshTextIndexWriteGuard("UpdateBSONSetBatch"); err != nil {
 		return nil, false, err
 	}
 	if err := c.validateBSONSetDocumentFormat(); err != nil {

--- a/TreeDB/collections/collection_schema_coordinator.go
+++ b/TreeDB/collections/collection_schema_coordinator.go
@@ -1,0 +1,141 @@
+package collections
+
+import (
+	"sync"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+)
+
+type collectionSchemaCoordinator struct {
+	schemaMu  sync.RWMutex
+	domainsMu sync.Mutex
+	domains   map[*collectionWriteDomain]struct{}
+}
+
+type collectionDBSchemaCoordinators struct {
+	mu          sync.Mutex
+	collections map[string]*collectionSchemaCoordinator
+}
+
+var collectionSchemaCoordinators sync.Map
+
+func collectionSchemaCoordinatorForDBCollection(db *backenddb.DB, collection string) *collectionSchemaCoordinator {
+	if db == nil || collection == "" {
+		return nil
+	}
+	dbCoord := collectionDBSchemaCoordinatorForDB(db)
+	if dbCoord == nil {
+		return nil
+	}
+	dbCoord.mu.Lock()
+	defer dbCoord.mu.Unlock()
+	if dbCoord.collections == nil {
+		dbCoord.collections = make(map[string]*collectionSchemaCoordinator)
+	}
+	coord := dbCoord.collections[collection]
+	if coord == nil {
+		coord = &collectionSchemaCoordinator{}
+		dbCoord.collections[collection] = coord
+	}
+	return coord
+}
+
+func collectionDBSchemaCoordinatorForDB(db *backenddb.DB) *collectionDBSchemaCoordinators {
+	if db == nil {
+		return nil
+	}
+	coord := &collectionDBSchemaCoordinators{}
+	var actual any
+	var loaded bool
+	if _, ok := db.RegisterCloseHookIfOpenAfter(func() bool {
+		actual, loaded = collectionSchemaCoordinators.LoadOrStore(db, coord)
+		return !loaded
+	}, func() error {
+		collectionSchemaCoordinators.Delete(db)
+		return nil
+	}); !ok {
+		return nil
+	}
+	if loaded {
+		return actual.(*collectionDBSchemaCoordinators)
+	}
+	return coord
+}
+
+func (coord *collectionSchemaCoordinator) registerDomain(domain *collectionWriteDomain) {
+	if coord == nil || domain == nil {
+		return
+	}
+	coord.domainsMu.Lock()
+	defer coord.domainsMu.Unlock()
+	if coord.domains == nil {
+		coord.domains = make(map[*collectionWriteDomain]struct{})
+	}
+	coord.domains[domain] = struct{}{}
+}
+
+func (coord *collectionSchemaCoordinator) snapshotDomains() []*collectionWriteDomain {
+	if coord == nil {
+		return nil
+	}
+	coord.domainsMu.Lock()
+	defer coord.domainsMu.Unlock()
+	out := make([]*collectionWriteDomain, 0, len(coord.domains))
+	for domain := range coord.domains {
+		if domain != nil {
+			out = append(out, domain)
+		}
+	}
+	return out
+}
+
+func (c *Collection) collectionSchemaCoordinator() *collectionSchemaCoordinator {
+	if c == nil {
+		return nil
+	}
+	if c.writeDomain != nil && c.writeDomain.schemaCoordinator != nil {
+		return c.writeDomain.schemaCoordinator
+	}
+	name := c.name
+	if name == "" {
+		name = c.meta.Name
+	}
+	return collectionSchemaCoordinatorForDBCollection(c.db, name)
+}
+
+func (c *Collection) lockCollectionSchemaRead() func() {
+	coord := c.collectionSchemaCoordinator()
+	if coord == nil {
+		return func() {}
+	}
+	coord.schemaMu.RLock()
+	return coord.schemaMu.RUnlock
+}
+
+func (c *Collection) lockCollectionSchemaWrite() func() {
+	coord := c.collectionSchemaCoordinator()
+	if coord == nil {
+		return func() {}
+	}
+	coord.schemaMu.Lock()
+	return coord.schemaMu.Unlock
+}
+
+func (c *Collection) flushCollectionWriteDomainsForSchemaMutation() error {
+	if c == nil || c.db == nil {
+		return nil
+	}
+	coord := c.collectionSchemaCoordinator()
+	if coord == nil {
+		return c.flushBufferedWrites()
+	}
+	for _, domain := range coord.snapshotDomains() {
+		if domain == nil {
+			continue
+		}
+		if err := flushCollectionWriteDomain(c.db, domain); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/TreeDB/collections/text_backfill.go
+++ b/TreeDB/collections/text_backfill.go
@@ -1,0 +1,511 @@
+package collections
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/internal/memtable"
+	"github.com/snissn/gomap/TreeDB/tree"
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+// TextIndexBackfillStats reports durable root entries produced by CreateTextIndex.
+type TextIndexBackfillStats struct {
+	DocumentsScanned int
+	StateEntries     int
+	PostingEntries   int
+	StatsEntries     int
+	EncodedBytes     uint64
+}
+
+// TextIndexStorageStats reports durable text-root contents after validation.
+type TextIndexStorageStats struct {
+	Documents      uint64
+	StateEntries   uint64
+	PostingEntries uint64
+	StatsEntries   uint64
+	EncodedBytes   uint64
+}
+
+type createTextIndexBackfillPlan struct {
+	rootNames   []string
+	baseRootIDs map[string]uint64
+	tables      []memtable.Table
+	policies    []backenddb.OrderedRootStoragePolicy
+	stats       TextIndexBackfillStats
+}
+
+type textAnalyzedDocument struct {
+	Fields []textAnalyzedField
+}
+
+type textAnalyzedField struct {
+	Field  string
+	Length uint32
+	Terms  map[string]*textAnalyzedTerm
+}
+
+type textAnalyzedTerm struct {
+	Term      string
+	Frequency uint32
+	Positions []uint32
+	Offsets   []textTokenOffset
+}
+
+type textBackfillStatsAccumulator struct {
+	Corpus textStatsCorpusValue
+	Terms  map[string]*textStatsTermValue
+	Fields map[string]*textStatsFieldValue
+}
+
+func buildCreateTextIndexBackfillPlan(
+	snap *backenddb.Snapshot,
+	catalog *collectionCatalog,
+	def TextIndexDefinition,
+	opts collectionOptions,
+) (*createTextIndexBackfillPlan, error) {
+	if snap == nil {
+		return nil, backenddb.ErrClosed
+	}
+	if catalog == nil {
+		return nil, errCollectionNotFound
+	}
+	postingsRootName := collectionTextIndexRootName(catalog.meta.Name, def.Name)
+	stateRootName := collectionTextStateRootName(catalog.meta.Name, def.Name)
+	statsRootName := collectionTextStatsRootName(catalog.meta.Name, def.Name)
+	plan := &createTextIndexBackfillPlan{
+		baseRootIDs: map[string]uint64{
+			collectionPrimaryRootName(catalog.meta.Name): catalog.rootID(collectionPrimaryRootName(catalog.meta.Name)),
+			postingsRootName: catalog.rootID(postingsRootName),
+			stateRootName:    catalog.rootID(stateRootName),
+			statsRootName:    catalog.rootID(statsRootName),
+		},
+	}
+
+	postingsTable := newCollectionRunTable(0)
+	stateTable := newCollectionRunTable(0)
+	statsTable := newCollectionRunTable(0)
+	acc := textBackfillStatsAccumulator{
+		Terms:  make(map[string]*textStatsTermValue),
+		Fields: make(map[string]*textStatsFieldValue),
+	}
+
+	primaryRootID := catalog.rootID(collectionPrimaryRootName(catalog.meta.Name))
+	if primaryRootID != 0 {
+		it, err := collectionIteratorAtCatalogRoot(snap, catalog, collectionPrimaryRootName(catalog.meta.Name), nil, nil, false)
+		if err != nil {
+			resetCollectionTables([]memtable.Table{postingsTable, stateTable, statsTable})
+			return nil, err
+		}
+		if it != nil {
+			defer func() { _ = it.Close() }()
+			for it.Valid() {
+				if it.IsDeleted() {
+					it.Next()
+					continue
+				}
+				documentID := bytes.Clone(it.UnsafeKey())
+				document := it.ValueCopy(nil)
+				jsonDocument, err := materializeTextBackfillDocumentJSON(document, opts)
+				if err != nil {
+					resetCollectionTables([]memtable.Table{postingsTable, stateTable, statsTable})
+					return nil, err
+				}
+				analysis, err := analyzeTextIndexDocument(def, jsonDocument)
+				if err != nil {
+					resetCollectionTables([]memtable.Table{postingsTable, stateTable, statsTable})
+					return nil, err
+				}
+				stateRaw := encodeTextDocumentStateValue(textDocumentStateValueFromAnalysis(analysis))
+				stateKey := encodeTextStateKey(documentID)
+				stateTable.SetSteal(stateKey, stateRaw)
+				plan.stats.StateEntries++
+				plan.stats.EncodedBytes += uint64(len(stateKey) + len(stateRaw))
+				postingEntries, postingBytes := addTextPostingsForDocument(postingsTable, documentID, analysis)
+				plan.stats.PostingEntries += postingEntries
+				plan.stats.EncodedBytes += postingBytes
+				acc.addDocument(analysis)
+				plan.stats.DocumentsScanned++
+				it.Next()
+			}
+			if err := it.Error(); err != nil {
+				resetCollectionTables([]memtable.Table{postingsTable, stateTable, statsTable})
+				return nil, err
+			}
+		}
+	}
+
+	statsEntries, statsBytes := addTextStatsEntries(statsTable, acc)
+	plan.stats.StatsEntries = statsEntries
+	plan.stats.EncodedBytes += statsBytes
+
+	if postingsTable.Len() > 0 {
+		postingsTable.Freeze()
+		plan.rootNames = append(plan.rootNames, postingsRootName)
+		plan.tables = append(plan.tables, postingsTable)
+		plan.policies = append(plan.policies, mustBackendTextRootStoragePolicy(def.StoragePolicy))
+	} else {
+		resetCollectionTables([]memtable.Table{postingsTable})
+	}
+	if stateTable.Len() > 0 {
+		stateTable.Freeze()
+		plan.rootNames = append(plan.rootNames, stateRootName)
+		plan.tables = append(plan.tables, stateTable)
+		plan.policies = append(plan.policies, opts.indexStateStoragePolicy)
+	} else {
+		resetCollectionTables([]memtable.Table{stateTable})
+	}
+	if statsTable.Len() > 0 {
+		statsTable.Freeze()
+		plan.rootNames = append(plan.rootNames, statsRootName)
+		plan.tables = append(plan.tables, statsTable)
+		plan.policies = append(plan.policies, opts.indexStateStoragePolicy)
+	} else {
+		resetCollectionTables([]memtable.Table{statsTable})
+	}
+	return plan, nil
+}
+
+func materializeTextBackfillDocumentJSON(document []byte, opts collectionOptions) ([]byte, error) {
+	switch normalizedDocumentFormat(opts.documentFormat) {
+	case DocumentFormatJSON:
+		return document, nil
+	case DocumentFormatBSON:
+		raw := bson.Raw(document)
+		if err := raw.Validate(); err != nil {
+			return nil, fmt.Errorf("collections: text index backfill BSON document: %w", err)
+		}
+		return bson.MarshalExtJSON(raw, true, false)
+	case DocumentFormatTemplateV1:
+		return templateV1StoredDocumentJSON(document, opts.templateResolver)
+	default:
+		return nil, fmt.Errorf("collections: unsupported text index backfill document format %q", opts.documentFormat)
+	}
+}
+
+func analyzeTextIndexDocument(def TextIndexDefinition, jsonDocument []byte) (textAnalyzedDocument, error) {
+	var decoded any
+	decoder := json.NewDecoder(bytes.NewReader(jsonDocument))
+	decoder.UseNumber()
+	if err := decoder.Decode(&decoded); err != nil {
+		return textAnalyzedDocument{}, fmt.Errorf("collections: text index extraction requires JSON document: %w", err)
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		if err == nil {
+			err = errors.New("unexpected trailing JSON value")
+		}
+		return textAnalyzedDocument{}, fmt.Errorf("collections: text index extraction requires JSON document: %w", err)
+	}
+	obj, ok := decoded.(map[string]any)
+	if !ok {
+		return textAnalyzedDocument{}, errors.New("collections: text index extraction requires JSON object document")
+	}
+	out := textAnalyzedDocument{Fields: make([]textAnalyzedField, 0, len(def.Fields))}
+	for _, fieldDef := range def.Fields {
+		value, found := extractIndexPathValue(obj, splitIndexPath(fieldDef.Field))
+		if !found || value == nil {
+			continue
+		}
+		text, ok := textIndexFieldText(value)
+		if !ok {
+			continue
+		}
+		tokens, err := AnalyzeText(def.Analyzer, text)
+		if err != nil {
+			return textAnalyzedDocument{}, err
+		}
+		field := textAnalyzedField{Field: fieldDef.Field, Length: uint32(len(tokens)), Terms: make(map[string]*textAnalyzedTerm)}
+		for _, token := range tokens {
+			term := field.Terms[token.Term]
+			if term == nil {
+				term = &textAnalyzedTerm{Term: token.Term}
+				field.Terms[token.Term] = term
+			}
+			term.Frequency++
+			if def.StorePositions {
+				term.Positions = append(term.Positions, uint32(token.Position))
+			}
+			if def.StoreOffsets {
+				term.Offsets = append(term.Offsets, textTokenOffset{Start: uint32(token.StartOffset), End: uint32(token.EndOffset)})
+			}
+		}
+		out.Fields = append(out.Fields, field)
+	}
+	return out, nil
+}
+
+func textIndexFieldText(value any) (string, bool) {
+	switch v := value.(type) {
+	case string:
+		return v, true
+	case []any:
+		parts := make([]string, 0, len(v))
+		for _, item := range v {
+			if s, ok := item.(string); ok {
+				parts = append(parts, s)
+			}
+		}
+		if len(parts) == 0 {
+			return "", false
+		}
+		return strings.Join(parts, " "), true
+	default:
+		return "", false
+	}
+}
+
+func textDocumentStateValueFromAnalysis(analysis textAnalyzedDocument) textDocumentStateValue {
+	state := textDocumentStateValue{Fields: make([]textDocumentFieldState, 0, len(analysis.Fields))}
+	for _, analyzedField := range analysis.Fields {
+		terms := make([]textDocumentTermState, 0, len(analyzedField.Terms))
+		for _, analyzedTerm := range analyzedField.Terms {
+			terms = append(terms, textDocumentTermState{
+				Term:      analyzedTerm.Term,
+				Frequency: analyzedTerm.Frequency,
+				Positions: append([]uint32(nil), analyzedTerm.Positions...),
+				Offsets:   append([]textTokenOffset(nil), analyzedTerm.Offsets...),
+			})
+		}
+		sort.SliceStable(terms, func(i, j int) bool { return terms[i].Term < terms[j].Term })
+		state.Fields = append(state.Fields, textDocumentFieldState{
+			Field:  analyzedField.Field,
+			Length: analyzedField.Length,
+			Terms:  terms,
+		})
+	}
+	sort.SliceStable(state.Fields, func(i, j int) bool { return state.Fields[i].Field < state.Fields[j].Field })
+	return state
+}
+
+func addTextPostingsForDocument(table memtable.Table, documentID []byte, analysis textAnalyzedDocument) (int, uint64) {
+	if table == nil {
+		return 0, 0
+	}
+	byTerm := make(map[string]*textPostingValue)
+	for _, field := range analysis.Fields {
+		for _, term := range field.Terms {
+			posting := byTerm[term.Term]
+			if posting == nil {
+				posting = &textPostingValue{}
+				byTerm[term.Term] = posting
+			}
+			posting.TermFrequency += term.Frequency
+			posting.Fields = append(posting.Fields, textPostingFieldValue{
+				Field:     field.Field,
+				Frequency: term.Frequency,
+				Positions: append([]uint32(nil), term.Positions...),
+				Offsets:   append([]textTokenOffset(nil), term.Offsets...),
+			})
+		}
+	}
+	terms := make([]string, 0, len(byTerm))
+	for term := range byTerm {
+		terms = append(terms, term)
+	}
+	sort.Strings(terms)
+	var bytesWritten uint64
+	for _, term := range terms {
+		key := encodeTextPostingKey(term, documentID)
+		value := encodeTextPostingValue(*byTerm[term])
+		table.SetSteal(key, value)
+		bytesWritten += uint64(len(key) + len(value))
+	}
+	return len(terms), bytesWritten
+}
+
+func (a *textBackfillStatsAccumulator) addDocument(analysis textAnalyzedDocument) {
+	if a.Terms == nil {
+		a.Terms = make(map[string]*textStatsTermValue)
+	}
+	if a.Fields == nil {
+		a.Fields = make(map[string]*textStatsFieldValue)
+	}
+	a.Corpus.DocumentCount++
+	seenTerms := make(map[string]uint32)
+	for _, field := range analysis.Fields {
+		fieldStats := a.Fields[field.Field]
+		if fieldStats == nil {
+			fieldStats = &textStatsFieldValue{}
+			a.Fields[field.Field] = fieldStats
+		}
+		fieldStats.DocumentCount++
+		fieldStats.TotalTokenCount += uint64(field.Length)
+		for _, term := range field.Terms {
+			seenTerms[term.Term] += term.Frequency
+		}
+	}
+	for term, freq := range seenTerms {
+		stats := a.Terms[term]
+		if stats == nil {
+			stats = &textStatsTermValue{}
+			a.Terms[term] = stats
+		}
+		stats.DocumentFrequency++
+		stats.TotalTermFrequency += uint64(freq)
+	}
+}
+
+func addTextStatsEntries(table memtable.Table, acc textBackfillStatsAccumulator) (int, uint64) {
+	if table == nil {
+		return 0, 0
+	}
+	entries := 0
+	var bytesWritten uint64
+	set := func(key, value []byte) {
+		table.SetSteal(key, value)
+		entries++
+		bytesWritten += uint64(len(key) + len(value))
+	}
+	set(encodeTextStatsCorpusKey(), encodeTextStatsCorpusValue(acc.Corpus))
+	terms := make([]string, 0, len(acc.Terms))
+	for term := range acc.Terms {
+		terms = append(terms, term)
+	}
+	sort.Strings(terms)
+	for _, term := range terms {
+		set(encodeTextStatsTermKey(term), encodeTextStatsTermValue(*acc.Terms[term]))
+	}
+	fields := make([]string, 0, len(acc.Fields))
+	for field := range acc.Fields {
+		fields = append(fields, field)
+	}
+	sort.Strings(fields)
+	for _, field := range fields {
+		set(encodeTextStatsFieldKey(field), encodeTextStatsFieldValue(*acc.Fields[field]))
+	}
+	return entries, bytesWritten
+}
+
+func mustBackendTextRootStoragePolicy(policy RootStoragePolicy) backenddb.OrderedRootStoragePolicy {
+	out, err := backendRootStoragePolicy(policy)
+	if err != nil {
+		return backenddb.OrderedRootStorageDefault
+	}
+	return out
+}
+
+func inspectTextIndexStorage(snap *backenddb.Snapshot, catalog *collectionCatalog, def TextIndexDefinition) (TextIndexStorageStats, error) {
+	var stats TextIndexStorageStats
+	if snap == nil {
+		return stats, backenddb.ErrClosed
+	}
+	if catalog == nil {
+		return stats, errCollectionNotFound
+	}
+	postingsRootName := collectionTextIndexRootName(catalog.meta.Name, def.Name)
+	if err := inspectTextPostingsRoot(snap, catalog, postingsRootName, &stats); err != nil {
+		return stats, err
+	}
+	stateRootName := collectionTextStateRootName(catalog.meta.Name, def.Name)
+	if err := inspectTextStateRoot(snap, catalog, stateRootName, &stats); err != nil {
+		return stats, err
+	}
+	statsRootName := collectionTextStatsRootName(catalog.meta.Name, def.Name)
+	if err := inspectTextStatsRoot(snap, catalog, statsRootName, &stats); err != nil {
+		return stats, err
+	}
+	return stats, nil
+}
+
+func inspectTextPostingsRoot(snap *backenddb.Snapshot, catalog *collectionCatalog, rootName string, stats *TextIndexStorageStats) error {
+	it, err := collectionIteratorAtCatalogRoot(snap, catalog, rootName, nil, nil, false)
+	if errors.Is(err, tree.ErrKeyNotFound) {
+		return nil
+	}
+	if err != nil || it == nil {
+		return err
+	}
+	defer func() { _ = it.Close() }()
+	for it.Valid() {
+		if !it.IsDeleted() {
+			key := it.UnsafeKey()
+			value := it.ValueCopy(nil)
+			if _, _, err := decodeTextPostingKey(key); err != nil {
+				return err
+			}
+			if _, err := decodeTextPostingValue(value); err != nil {
+				return err
+			}
+			stats.PostingEntries++
+			stats.EncodedBytes += uint64(len(key) + len(value))
+		}
+		it.Next()
+	}
+	return it.Error()
+}
+
+func inspectTextStateRoot(snap *backenddb.Snapshot, catalog *collectionCatalog, rootName string, stats *TextIndexStorageStats) error {
+	it, err := collectionIteratorAtCatalogRoot(snap, catalog, rootName, nil, nil, false)
+	if errors.Is(err, tree.ErrKeyNotFound) {
+		return nil
+	}
+	if err != nil || it == nil {
+		return err
+	}
+	defer func() { _ = it.Close() }()
+	for it.Valid() {
+		if !it.IsDeleted() {
+			key := it.UnsafeKey()
+			value := it.ValueCopy(nil)
+			if _, err := decodeTextStateKey(key); err != nil {
+				return err
+			}
+			if _, err := decodeTextDocumentStateValue(value); err != nil {
+				return err
+			}
+			stats.StateEntries++
+			stats.EncodedBytes += uint64(len(key) + len(value))
+		}
+		it.Next()
+	}
+	return it.Error()
+}
+
+func inspectTextStatsRoot(snap *backenddb.Snapshot, catalog *collectionCatalog, rootName string, stats *TextIndexStorageStats) error {
+	it, err := collectionIteratorAtCatalogRoot(snap, catalog, rootName, nil, nil, false)
+	if errors.Is(err, tree.ErrKeyNotFound) {
+		return nil
+	}
+	if err != nil || it == nil {
+		return err
+	}
+	defer func() { _ = it.Close() }()
+	for it.Valid() {
+		if !it.IsDeleted() {
+			key := it.UnsafeKey()
+			value := it.ValueCopy(nil)
+			statsKey, err := decodeTextStatsKey(key)
+			if err != nil {
+				return err
+			}
+			switch statsKey.Kind {
+			case textStatsKeyKindCorpus:
+				corpus, err := decodeTextStatsCorpusValue(value)
+				if err != nil {
+					return err
+				}
+				stats.Documents = corpus.DocumentCount
+			case textStatsKeyKindTerm:
+				if _, err := decodeTextStatsTermValue(value); err != nil {
+					return err
+				}
+			case textStatsKeyKindField:
+				if _, err := decodeTextStatsFieldValue(value); err != nil {
+					return err
+				}
+			default:
+				return errMalformedTextStorage("unsupported text-stats key kind %d", statsKey.Kind)
+			}
+			stats.StatsEntries++
+			stats.EncodedBytes += uint64(len(key) + len(value))
+		}
+		it.Next()
+	}
+	return it.Error()
+}

--- a/TreeDB/collections/text_catalog.go
+++ b/TreeDB/collections/text_catalog.go
@@ -22,9 +22,12 @@ func (c *Collection) CreateTextIndex(def TextIndexDefinition) (*CollectionMeta, 
 	if c.db.CommandWALEnabled() {
 		return nil, emptyStats, fmt.Errorf("%w: collection catalog text index mutation is rejected under command_wal_v1 until catalog text index commands are supported", backenddb.ErrCommandWALRejected)
 	}
-	unlockMutation := c.lockMutation()
-	defer unlockMutation.Unlock()
-	if err := c.flushBufferedWrites(); err != nil {
+	if err := c.ensureWriteDomainOpen(); err != nil {
+		return nil, emptyStats, err
+	}
+	unlockSchema := c.lockCollectionSchemaWrite()
+	defer unlockSchema()
+	if err := c.flushCollectionWriteDomainsForSchemaMutation(); err != nil {
 		return nil, emptyStats, err
 	}
 
@@ -118,9 +121,12 @@ func (c *Collection) DropTextIndex(name string) (*CollectionMeta, error) {
 	if c.db.CommandWALEnabled() {
 		return nil, fmt.Errorf("%w: collection catalog text index mutation is rejected under command_wal_v1 until catalog text index commands are supported", backenddb.ErrCommandWALRejected)
 	}
-	unlockMutation := c.lockMutation()
-	defer unlockMutation.Unlock()
-	if err := c.flushBufferedWrites(); err != nil {
+	if err := c.ensureWriteDomainOpen(); err != nil {
+		return nil, err
+	}
+	unlockSchema := c.lockCollectionSchemaWrite()
+	defer unlockSchema()
+	if err := c.flushCollectionWriteDomainsForSchemaMutation(); err != nil {
 		return nil, err
 	}
 

--- a/TreeDB/collections/text_catalog.go
+++ b/TreeDB/collections/text_catalog.go
@@ -1,0 +1,268 @@
+package collections
+
+import (
+	"fmt"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/internal/iterator"
+)
+
+// CreateTextIndex adds a collection-native text index and backfills persistent
+// postings, text-state, and text-stats roots from the current documents. It
+// does not enable mutation maintenance or SearchText execution; those paths
+// remain fail-closed until later #1764 milestones.
+func (c *Collection) CreateTextIndex(def TextIndexDefinition) (*CollectionMeta, TextIndexBackfillStats, error) {
+	var emptyStats TextIndexBackfillStats
+	if c == nil {
+		return nil, emptyStats, errCollectionNil
+	}
+	if c.db == nil {
+		return nil, emptyStats, errCollectionDBNil
+	}
+	if c.db.CommandWALEnabled() {
+		return nil, emptyStats, fmt.Errorf("%w: collection catalog text index mutation is rejected under command_wal_v1 until catalog text index commands are supported", backenddb.ErrCommandWALRejected)
+	}
+	unlockMutation := c.lockMutation()
+	defer unlockMutation.Unlock()
+	if err := c.flushBufferedWrites(); err != nil {
+		return nil, emptyStats, err
+	}
+
+	snap := c.db.AcquireSnapshot()
+	if snap == nil {
+		return nil, emptyStats, backenddb.ErrClosed
+	}
+	catalog, err := loadCollectionCatalog(snap, c.meta.Name)
+	if err != nil {
+		_ = snap.Close()
+		return nil, emptyStats, err
+	}
+	if catalog == nil {
+		_ = snap.Close()
+		return nil, emptyStats, errCollectionNotFound
+	}
+	if err := rejectCatalogRootOverlaysForWrite(catalog); err != nil {
+		_ = snap.Close()
+		return nil, emptyStats, err
+	}
+	baseMeta := catalog.meta
+	c.meta = baseMeta
+	baseOptions, err := collectionPlannerOptionsForDB(c.db, baseMeta)
+	if err != nil {
+		_ = snap.Close()
+		return nil, emptyStats, err
+	}
+	baseOptions = collectionOptionsWithTemplateV1Resolver(baseOptions, snap, catalog)
+	newMeta, normalizedDef, err := addTextIndexToCollectionMeta(baseMeta, def)
+	if err != nil {
+		_ = snap.Close()
+		return nil, emptyStats, err
+	}
+	if err := rejectCreateTextIndexOnRetainedColumnField(baseMeta, normalizedDef); err != nil {
+		_ = snap.Close()
+		return nil, emptyStats, err
+	}
+	plan, err := buildCreateTextIndexBackfillPlan(snap, catalog, normalizedDef, baseOptions)
+	if err != nil {
+		_ = snap.Close()
+		return nil, emptyStats, err
+	}
+	defer func() { _ = snap.Close() }()
+
+	ordered := make([]backenddb.OrderedRootDeltaPublishInput, 0, len(plan.rootNames))
+	iterators := make([]iterator.UnsafeIterator, 0, len(plan.rootNames))
+	defer func() {
+		for _, it := range iterators {
+			_ = it.Close()
+		}
+		resetCollectionTables(plan.tables)
+	}()
+	for i, rootName := range plan.rootNames {
+		iter := plan.tables[i].NewIterator(nil, nil)
+		iterators = append(iterators, iter)
+		ordered = append(ordered, backenddb.OrderedRootDeltaPublishInput{
+			BaseRoot:      plan.baseRootIDs[rootName],
+			Iter:          iter,
+			StoragePolicy: plan.policies[i],
+		})
+	}
+
+	newSystemRoot, rootIDs, err := c.db.PublishOrderedRootDeltaGroupWithSystemBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		return c.buildSchemaAndRootDescriptorSystemIterator(baseMeta, newMeta, plan.rootNames, plan.baseRootIDs, rootIDs)
+	})
+	if err != nil {
+		return nil, emptyStats, err
+	}
+	if len(rootIDs) != len(plan.rootNames) {
+		return nil, emptyStats, unexpectedOrderedRootCountError(newMeta.Name, len(plan.rootNames), len(rootIDs))
+	}
+	c.meta = newMeta
+	nextCatalog := cloneCatalogWithRootUpdates(catalog, newMeta, plan.rootNames, rootIDs)
+	c.rememberCatalogAtSystemRoot(newSystemRoot, nextCatalog)
+	c.noteWriteDomainCatalog(newSystemRoot, nextCatalog)
+	return newMeta.copy(), plan.stats, nil
+}
+
+// DropTextIndex removes text index metadata and clears the persistent
+// postings/text-state/text-stats root descriptors for the index.
+func (c *Collection) DropTextIndex(name string) (*CollectionMeta, error) {
+	if err := ValidateIndexName(name); err != nil {
+		return nil, err
+	}
+	if c == nil {
+		return nil, errCollectionNil
+	}
+	if c.db == nil {
+		return nil, errCollectionDBNil
+	}
+	if c.db.CommandWALEnabled() {
+		return nil, fmt.Errorf("%w: collection catalog text index mutation is rejected under command_wal_v1 until catalog text index commands are supported", backenddb.ErrCommandWALRejected)
+	}
+	unlockMutation := c.lockMutation()
+	defer unlockMutation.Unlock()
+	if err := c.flushBufferedWrites(); err != nil {
+		return nil, err
+	}
+
+	snap := c.db.AcquireSnapshot()
+	if snap == nil {
+		return nil, backenddb.ErrClosed
+	}
+	catalog, err := loadCollectionCatalog(snap, c.meta.Name)
+	if err != nil {
+		_ = snap.Close()
+		return nil, err
+	}
+	if catalog == nil {
+		_ = snap.Close()
+		return nil, errCollectionNotFound
+	}
+	if err := rejectCatalogRootOverlaysForWrite(catalog); err != nil {
+		_ = snap.Close()
+		return nil, err
+	}
+	baseMeta := catalog.meta
+	c.meta = baseMeta
+	_ = snap.Close()
+
+	nextTextIndexes := make([]TextIndexDefinition, 0, len(baseMeta.TextIndexes))
+	dropped := false
+	for _, idx := range baseMeta.TextIndexes {
+		if idx.Name == name {
+			dropped = true
+			continue
+		}
+		nextTextIndexes = append(nextTextIndexes, idx)
+	}
+	if !dropped {
+		return nil, ErrIndexNotFound
+	}
+	newMeta, err := normalizeCollectionMeta(CollectionMeta{
+		Name:          baseMeta.Name,
+		Options:       baseMeta.Options,
+		Indexes:       baseMeta.Indexes,
+		VectorIndexes: baseMeta.VectorIndexes,
+		TextIndexes:   nextTextIndexes,
+	})
+	if err != nil {
+		return nil, err
+	}
+	encodedMeta, err := encodeCollectionMeta(newMeta)
+	if err != nil {
+		return nil, err
+	}
+	clearedRootNames := collectionTextRootNames(baseMeta.Name, name)
+	newSystemRoot, _, err := c.db.PublishOrderedRootDeltaGroupWithSystemDeltaBuilder(nil, func([]uint64) (iterator.UnsafeIterator, error) {
+		return c.buildSchemaOnlySystemDeltaIterator(baseMeta, encodedMeta, clearedRootNames)
+	})
+	if err != nil {
+		return nil, err
+	}
+	c.meta = newMeta
+	clearedRootIDs := make([]uint64, len(clearedRootNames))
+	nextCatalog := cloneCatalogWithRootUpdates(catalog, newMeta, clearedRootNames, clearedRootIDs)
+	c.rememberCatalogAtSystemRoot(newSystemRoot, nextCatalog)
+	c.noteWriteDomainCatalog(newSystemRoot, nextCatalog)
+	return newMeta.copy(), nil
+}
+
+// TextIndexStorageStats validates and summarizes persistent text roots for a
+// declared text index. It is a storage/accounting helper; SearchText execution
+// remains unavailable until later milestones.
+func (c *Collection) TextIndexStorageStats(indexName string) (TextIndexStorageStats, error) {
+	var stats TextIndexStorageStats
+	if err := ValidateIndexName(indexName); err != nil {
+		return stats, err
+	}
+	if c == nil {
+		return stats, errCollectionNil
+	}
+	if c.db == nil {
+		return stats, errCollectionDBNil
+	}
+	snap := c.db.AcquireSnapshot()
+	if snap == nil {
+		return stats, backenddb.ErrClosed
+	}
+	defer func() { _ = snap.Close() }()
+	catalog, err := c.catalogForSnapshot(snap)
+	if err != nil {
+		return stats, err
+	}
+	if catalog == nil {
+		return stats, errCollectionNotFound
+	}
+	def, ok := findTextIndex(catalog.meta.TextIndexes, indexName)
+	if !ok {
+		return stats, ErrIndexNotFound
+	}
+	return inspectTextIndexStorage(snap, catalog, def)
+}
+
+func addTextIndexToCollectionMeta(meta CollectionMeta, def TextIndexDefinition) (CollectionMeta, TextIndexDefinition, error) {
+	if _, ok := findIndex(meta.Indexes, def.Name); ok {
+		return CollectionMeta{}, TextIndexDefinition{}, fmt.Errorf("collections: duplicate index %q", def.Name)
+	}
+	if _, ok := findVectorIndex(meta.VectorIndexes, def.Name); ok {
+		return CollectionMeta{}, TextIndexDefinition{}, fmt.Errorf("collections: duplicate index %q", def.Name)
+	}
+	if _, ok := findTextIndex(meta.TextIndexes, def.Name); ok {
+		return CollectionMeta{}, TextIndexDefinition{}, fmt.Errorf("collections: duplicate index %q", def.Name)
+	}
+	candidate := CollectionMeta{
+		Name:          meta.Name,
+		Options:       meta.Options,
+		Indexes:       append([]IndexDefinition(nil), meta.Indexes...),
+		VectorIndexes: copyVectorIndexDefinitions(meta.VectorIndexes),
+		TextIndexes:   append(copyTextIndexDefinitions(meta.TextIndexes), def),
+	}
+	normalized, err := normalizeCollectionMeta(candidate)
+	if err != nil {
+		return CollectionMeta{}, TextIndexDefinition{}, err
+	}
+	normalizedDef, ok := findTextIndex(normalized.TextIndexes, def.Name)
+	if !ok {
+		return CollectionMeta{}, TextIndexDefinition{}, fmt.Errorf("collections: normalized text index %q not found", def.Name)
+	}
+	return normalized, normalizedDef, nil
+}
+
+func rejectCreateTextIndexOnRetainedColumnField(meta CollectionMeta, def TextIndexDefinition) error {
+	cfg := meta.Options.ColumnStore
+	if cfg == nil || !cfg.Enabled || cfg.RetainedPayload == ColumnRetainedPayloadFull {
+		return nil
+	}
+	if cfg.RetainedPayload == ColumnRetainedPayloadNone {
+		return fmt.Errorf("collections: CreateTextIndex on retained-payload-none collection is unsupported because primary rows retain no JSON payload for text index backfill")
+	}
+	for _, field := range def.Fields {
+		fieldPath := field.Field
+		for _, col := range cfg.Columns {
+			columnPath := col.Path
+			if columnRetainedPayloadPathOverlaps(fieldPath, columnPath) {
+				return fmt.Errorf("collections: CreateTextIndex on retained-payload column field %q is unsupported because primary rows omit declared column payloads", fieldPath)
+			}
+		}
+	}
+	return nil
+}

--- a/TreeDB/collections/text_index.go
+++ b/TreeDB/collections/text_index.go
@@ -7,10 +7,10 @@ import (
 )
 
 // ErrTextIndexUnavailable reports that a declared collection text index cannot
-// yet be used for persistent maintenance or search. PR1 for #1764 intentionally
-// lands metadata/analyzer/query contracts before postings/text-state/stats
-// storage; write/search paths fail closed instead of silently scanning or
-// returning incomplete text-index results.
+// yet be used for mutation maintenance or search execution. Early #1764
+// milestones land metadata/analyzer/storage contracts before write-path
+// maintenance and ranked query execution; write/search paths fail closed instead
+// of silently diverging, scanning, or returning incomplete text-index results.
 var ErrTextIndexUnavailable = errors.New("collections: text index unavailable")
 
 // TextAnalyzer names a collection text analyzer. The zero value normalizes to
@@ -22,8 +22,9 @@ const (
 )
 
 // TextIndexDefinition declares a persistent collection-native inverted index.
-// PR1 stores and validates metadata only; postings, text-state, stats, mutation
-// maintenance, and SearchText execution land in later #1764 milestones.
+// M2 stores and validates metadata plus versioned postings/text-state/stats
+// storage; mutation maintenance and SearchText execution land in later #1764
+// milestones.
 type TextIndexDefinition struct {
 	Name             string            `json:"name"`
 	Fields           []TextIndexField  `json:"fields"`

--- a/TreeDB/collections/text_index.go
+++ b/TreeDB/collections/text_index.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"fmt"
 	"math"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
 )
 
 // ErrTextIndexUnavailable reports that a declared collection text index cannot
@@ -162,4 +164,32 @@ func rejectTextIndexWriteUnavailable(meta CollectionMeta, operation string) erro
 		operation = "write"
 	}
 	return fmt.Errorf("%w: collection %q has %d declared text index(es); %s requires postings/text-state/stats maintenance that is not implemented in this milestone", ErrTextIndexUnavailable, meta.Name, len(meta.TextIndexes), operation)
+}
+
+func (c *Collection) refreshTextIndexWriteGuard(operation string) error {
+	if c == nil {
+		return errCollectionNil
+	}
+	if err := rejectTextIndexWriteUnavailable(c.meta, operation); !errors.Is(err, ErrTextIndexUnavailable) {
+		return err
+	}
+	if c.db == nil {
+		return errCollectionDBNil
+	}
+	snap := c.db.AcquireSnapshot()
+	if snap == nil {
+		return backenddb.ErrClosed
+	}
+	defer func() { _ = snap.Close() }()
+	catalog, err := c.catalogForSnapshot(snap)
+	if err != nil {
+		return err
+	}
+	if catalog == nil {
+		return errCollectionNotFound
+	}
+	c.meta = catalog.meta
+	c.rememberCatalog(snap, catalog)
+	c.noteWriteDomainCatalog(snapshotSystemRoot(snap), catalog)
+	return rejectTextIndexWriteUnavailable(catalog.meta, operation)
 }

--- a/TreeDB/collections/text_search.go
+++ b/TreeDB/collections/text_search.go
@@ -17,11 +17,11 @@ const (
 	TextSearchOperatorAND TextSearchOperator = "and"
 )
 
-const textSearchUnavailableStorage = "text_index_storage_unimplemented"
+const textSearchUnavailableExecution = "text_search_execution_unimplemented"
 
 // TextSearchOptions configures collection-native lexical search. PR1 validates
-// the query shape and fails closed before scanning because postings/state/stats
-// storage is not implemented yet.
+// the query shape and fails closed before scanning because ranked text search
+// execution is not implemented yet.
 type TextSearchOptions struct {
 	IndexName            string
 	Query                string
@@ -62,7 +62,7 @@ type TextSearchResponse struct {
 }
 
 // SearchText validates the declared text index and query shape, then fails
-// closed until the persistent postings/text-state/stats search path lands in a
+// closed until ranked postings/text-state/stats search execution lands in a
 // later #1764 milestone. It never scans/ranks all collection documents.
 func (c *Collection) SearchText(opts TextSearchOptions) (TextSearchResponse, error) {
 	var response TextSearchResponse
@@ -109,8 +109,8 @@ func (c *Collection) SearchText(opts TextSearchOptions) (TextSearchResponse, err
 		return response, nil
 	}
 	response.Stats.Unavailable = true
-	response.Stats.UnavailableReason = textSearchUnavailableStorage
-	return response, fmt.Errorf("%w: collection %q text index %q has no persistent postings/text-state/stats storage yet", ErrTextIndexUnavailable, catalog.meta.Name, idx.Name)
+	response.Stats.UnavailableReason = textSearchUnavailableExecution
+	return response, fmt.Errorf("%w: collection %q text index %q search execution is not implemented yet", ErrTextIndexUnavailable, catalog.meta.Name, idx.Name)
 }
 
 func normalizeTextSearchOperator(op TextSearchOperator) (TextSearchOperator, error) {

--- a/TreeDB/collections/text_storage.go
+++ b/TreeDB/collections/text_storage.go
@@ -1,0 +1,578 @@
+package collections
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+)
+
+var ErrTextIndexStorageCorrupt = errors.New("collections: malformed text index storage")
+
+const (
+	textPostingKeyVersion byte = 1
+	textStateKeyVersion   byte = 1
+	textStatsKeyVersion   byte = 1
+
+	textPostingValueVersion byte = 1
+	textStateValueVersion   byte = 1
+	textStatsValueVersion   byte = 1
+
+	textStatsKeyKindCorpus byte = 1
+	textStatsKeyKindTerm   byte = 2
+	textStatsKeyKindField  byte = 3
+)
+
+type textTokenOffset struct {
+	Start uint32
+	End   uint32
+}
+
+type textPostingValue struct {
+	TermFrequency uint32
+	Fields        []textPostingFieldValue
+}
+
+type textPostingFieldValue struct {
+	Field     string
+	Frequency uint32
+	Positions []uint32
+	Offsets   []textTokenOffset
+}
+
+type textDocumentStateValue struct {
+	Fields []textDocumentFieldState
+}
+
+type textDocumentFieldState struct {
+	Field  string
+	Length uint32
+	Terms  []textDocumentTermState
+}
+
+type textDocumentTermState struct {
+	Term      string
+	Frequency uint32
+	Positions []uint32
+	Offsets   []textTokenOffset
+}
+
+type textStatsCorpusValue struct {
+	DocumentCount uint64
+}
+
+type textStatsTermValue struct {
+	DocumentFrequency  uint64
+	TotalTermFrequency uint64
+}
+
+type textStatsFieldValue struct {
+	DocumentCount   uint64
+	TotalTokenCount uint64
+}
+
+func encodeTextPostingKey(term string, documentID []byte) []byte {
+	out := make([]byte, 0, 1+binary.MaxVarintLen64+len(term)+len(documentID))
+	out = append(out, textPostingKeyVersion)
+	out = appendTextUvarint(out, uint64(len(term)))
+	out = append(out, term...)
+	out = append(out, documentID...)
+	return out
+}
+
+func encodeTextPostingTermPrefix(term string) []byte {
+	out := make([]byte, 0, 1+binary.MaxVarintLen64+len(term))
+	out = append(out, textPostingKeyVersion)
+	out = appendTextUvarint(out, uint64(len(term)))
+	out = append(out, term...)
+	return out
+}
+
+func decodeTextPostingKey(raw []byte) (string, []byte, error) {
+	if len(raw) == 0 {
+		return "", nil, errMalformedTextStorage("empty postings key")
+	}
+	if raw[0] != textPostingKeyVersion {
+		return "", nil, errUnsupportedTextStorageVersion("postings key", raw[0])
+	}
+	cur := textCursor{buf: raw[1:]}
+	termBytes, err := cur.readBytes()
+	if err != nil {
+		return "", nil, errMalformedTextStorage("postings key term: %v", err)
+	}
+	if cur.remaining() == 0 {
+		return "", nil, errMalformedTextStorage("postings key missing document id")
+	}
+	return string(termBytes), bytes.Clone(cur.buf[cur.pos:]), nil
+}
+
+func encodeTextStateKey(documentID []byte) []byte {
+	out := make([]byte, 0, 1+len(documentID))
+	out = append(out, textStateKeyVersion)
+	out = append(out, documentID...)
+	return out
+}
+
+func decodeTextStateKey(raw []byte) ([]byte, error) {
+	if len(raw) == 0 {
+		return nil, errMalformedTextStorage("empty text-state key")
+	}
+	if raw[0] != textStateKeyVersion {
+		return nil, errUnsupportedTextStorageVersion("text-state key", raw[0])
+	}
+	if len(raw) == 1 {
+		return nil, errMalformedTextStorage("text-state key missing document id")
+	}
+	return bytes.Clone(raw[1:]), nil
+}
+
+func encodeTextStatsCorpusKey() []byte {
+	return []byte{textStatsKeyVersion, textStatsKeyKindCorpus}
+}
+
+func encodeTextStatsTermKey(term string) []byte {
+	out := []byte{textStatsKeyVersion, textStatsKeyKindTerm}
+	out = appendTextBytes(out, []byte(term))
+	return out
+}
+
+func encodeTextStatsFieldKey(field string) []byte {
+	out := []byte{textStatsKeyVersion, textStatsKeyKindField}
+	out = appendTextBytes(out, []byte(field))
+	return out
+}
+
+type textStatsKey struct {
+	Kind  byte
+	Value string
+}
+
+func decodeTextStatsKey(raw []byte) (textStatsKey, error) {
+	if len(raw) < 2 {
+		return textStatsKey{}, errMalformedTextStorage("short text-stats key")
+	}
+	if raw[0] != textStatsKeyVersion {
+		return textStatsKey{}, errUnsupportedTextStorageVersion("text-stats key", raw[0])
+	}
+	key := textStatsKey{Kind: raw[1]}
+	cur := textCursor{buf: raw[2:]}
+	switch key.Kind {
+	case textStatsKeyKindCorpus:
+		if cur.remaining() != 0 {
+			return textStatsKey{}, errMalformedTextStorage("corpus text-stats key has trailing bytes")
+		}
+	case textStatsKeyKindTerm, textStatsKeyKindField:
+		value, err := cur.readBytes()
+		if err != nil {
+			return textStatsKey{}, errMalformedTextStorage("text-stats key value: %v", err)
+		}
+		if cur.remaining() != 0 {
+			return textStatsKey{}, errMalformedTextStorage("text-stats key has trailing bytes")
+		}
+		key.Value = string(value)
+	default:
+		return textStatsKey{}, errMalformedTextStorage("unsupported text-stats key kind %d", key.Kind)
+	}
+	return key, nil
+}
+
+func encodeTextPostingValue(value textPostingValue) []byte {
+	fields := append([]textPostingFieldValue(nil), value.Fields...)
+	sort.SliceStable(fields, func(i, j int) bool { return fields[i].Field < fields[j].Field })
+	out := []byte{textPostingValueVersion}
+	out = appendTextUvarint(out, uint64(value.TermFrequency))
+	out = appendTextUvarint(out, uint64(len(fields)))
+	for _, field := range fields {
+		out = appendTextString(out, field.Field)
+		out = appendTextUvarint(out, uint64(field.Frequency))
+		out = appendTextUint32Slice(out, field.Positions)
+		out = appendTextOffsetSlice(out, field.Offsets)
+	}
+	return out
+}
+
+func decodeTextPostingValue(raw []byte) (textPostingValue, error) {
+	if len(raw) == 0 {
+		return textPostingValue{}, errMalformedTextStorage("empty postings value")
+	}
+	if raw[0] != textPostingValueVersion {
+		return textPostingValue{}, errUnsupportedTextStorageVersion("postings value", raw[0])
+	}
+	cur := textCursor{buf: raw[1:]}
+	freq, err := cur.readUvarint()
+	if err != nil {
+		return textPostingValue{}, errMalformedTextStorage("postings value frequency: %v", err)
+	}
+	fieldCount, err := cur.readUvarint()
+	if err != nil {
+		return textPostingValue{}, errMalformedTextStorage("postings value field count: %v", err)
+	}
+	value := textPostingValue{TermFrequency: checkedTextUint32(freq)}
+	if uint64(value.TermFrequency) != freq {
+		return textPostingValue{}, errMalformedTextStorage("postings value frequency overflows uint32")
+	}
+	if fieldCount > uint64(cur.remaining()+1) {
+		return textPostingValue{}, errMalformedTextStorage("postings value field count too large")
+	}
+	value.Fields = make([]textPostingFieldValue, 0, fieldCount)
+	for i := uint64(0); i < fieldCount; i++ {
+		field, err := cur.readString()
+		if err != nil {
+			return textPostingValue{}, errMalformedTextStorage("postings value field[%d] name: %v", i, err)
+		}
+		fieldFreq, err := cur.readUvarint()
+		if err != nil {
+			return textPostingValue{}, errMalformedTextStorage("postings value field[%d] frequency: %v", i, err)
+		}
+		positions, err := cur.readUint32Slice()
+		if err != nil {
+			return textPostingValue{}, errMalformedTextStorage("postings value field[%d] positions: %v", i, err)
+		}
+		offsets, err := cur.readOffsetSlice()
+		if err != nil {
+			return textPostingValue{}, errMalformedTextStorage("postings value field[%d] offsets: %v", i, err)
+		}
+		if uint64(checkedTextUint32(fieldFreq)) != fieldFreq {
+			return textPostingValue{}, errMalformedTextStorage("postings value field[%d] frequency overflows uint32", i)
+		}
+		if len(offsets) != 0 && len(offsets) != len(positions) {
+			return textPostingValue{}, errMalformedTextStorage("postings value field[%d] offsets/positions length mismatch", i)
+		}
+		value.Fields = append(value.Fields, textPostingFieldValue{
+			Field:     field,
+			Frequency: uint32(fieldFreq),
+			Positions: positions,
+			Offsets:   offsets,
+		})
+	}
+	if cur.remaining() != 0 {
+		return textPostingValue{}, errMalformedTextStorage("postings value trailing bytes")
+	}
+	return value, nil
+}
+
+func encodeTextDocumentStateValue(value textDocumentStateValue) []byte {
+	fields := append([]textDocumentFieldState(nil), value.Fields...)
+	sort.SliceStable(fields, func(i, j int) bool { return fields[i].Field < fields[j].Field })
+	out := []byte{textStateValueVersion}
+	out = appendTextUvarint(out, uint64(len(fields)))
+	for _, field := range fields {
+		terms := append([]textDocumentTermState(nil), field.Terms...)
+		sort.SliceStable(terms, func(i, j int) bool { return terms[i].Term < terms[j].Term })
+		out = appendTextString(out, field.Field)
+		out = appendTextUvarint(out, uint64(field.Length))
+		out = appendTextUvarint(out, uint64(len(terms)))
+		for _, term := range terms {
+			out = appendTextString(out, term.Term)
+			out = appendTextUvarint(out, uint64(term.Frequency))
+			out = appendTextUint32Slice(out, term.Positions)
+			out = appendTextOffsetSlice(out, term.Offsets)
+		}
+	}
+	return out
+}
+
+func decodeTextDocumentStateValue(raw []byte) (textDocumentStateValue, error) {
+	if len(raw) == 0 {
+		return textDocumentStateValue{}, errMalformedTextStorage("empty text-state value")
+	}
+	if raw[0] != textStateValueVersion {
+		return textDocumentStateValue{}, errUnsupportedTextStorageVersion("text-state value", raw[0])
+	}
+	cur := textCursor{buf: raw[1:]}
+	fieldCount, err := cur.readUvarint()
+	if err != nil {
+		return textDocumentStateValue{}, errMalformedTextStorage("text-state field count: %v", err)
+	}
+	if fieldCount > uint64(cur.remaining()+1) {
+		return textDocumentStateValue{}, errMalformedTextStorage("text-state field count too large")
+	}
+	value := textDocumentStateValue{Fields: make([]textDocumentFieldState, 0, fieldCount)}
+	for i := uint64(0); i < fieldCount; i++ {
+		fieldName, err := cur.readString()
+		if err != nil {
+			return textDocumentStateValue{}, errMalformedTextStorage("text-state field[%d] name: %v", i, err)
+		}
+		length, err := cur.readUvarint()
+		if err != nil {
+			return textDocumentStateValue{}, errMalformedTextStorage("text-state field[%d] length: %v", i, err)
+		}
+		if uint64(checkedTextUint32(length)) != length {
+			return textDocumentStateValue{}, errMalformedTextStorage("text-state field[%d] length overflows uint32", i)
+		}
+		termCount, err := cur.readUvarint()
+		if err != nil {
+			return textDocumentStateValue{}, errMalformedTextStorage("text-state field[%d] term count: %v", i, err)
+		}
+		if termCount > uint64(cur.remaining()+1) {
+			return textDocumentStateValue{}, errMalformedTextStorage("text-state field[%d] term count too large", i)
+		}
+		field := textDocumentFieldState{Field: fieldName, Length: uint32(length), Terms: make([]textDocumentTermState, 0, termCount)}
+		for j := uint64(0); j < termCount; j++ {
+			termName, err := cur.readString()
+			if err != nil {
+				return textDocumentStateValue{}, errMalformedTextStorage("text-state field[%d] term[%d] name: %v", i, j, err)
+			}
+			freq, err := cur.readUvarint()
+			if err != nil {
+				return textDocumentStateValue{}, errMalformedTextStorage("text-state field[%d] term[%d] frequency: %v", i, j, err)
+			}
+			if uint64(checkedTextUint32(freq)) != freq {
+				return textDocumentStateValue{}, errMalformedTextStorage("text-state field[%d] term[%d] frequency overflows uint32", i, j)
+			}
+			positions, err := cur.readUint32Slice()
+			if err != nil {
+				return textDocumentStateValue{}, errMalformedTextStorage("text-state field[%d] term[%d] positions: %v", i, j, err)
+			}
+			offsets, err := cur.readOffsetSlice()
+			if err != nil {
+				return textDocumentStateValue{}, errMalformedTextStorage("text-state field[%d] term[%d] offsets: %v", i, j, err)
+			}
+			if len(offsets) != 0 && len(offsets) != len(positions) {
+				return textDocumentStateValue{}, errMalformedTextStorage("text-state field[%d] term[%d] offsets/positions length mismatch", i, j)
+			}
+			field.Terms = append(field.Terms, textDocumentTermState{
+				Term:      termName,
+				Frequency: uint32(freq),
+				Positions: positions,
+				Offsets:   offsets,
+			})
+		}
+		value.Fields = append(value.Fields, field)
+	}
+	if cur.remaining() != 0 {
+		return textDocumentStateValue{}, errMalformedTextStorage("text-state value trailing bytes")
+	}
+	return value, nil
+}
+
+func encodeTextStatsCorpusValue(value textStatsCorpusValue) []byte {
+	out := []byte{textStatsValueVersion}
+	out = appendTextUvarint(out, value.DocumentCount)
+	return out
+}
+
+func decodeTextStatsCorpusValue(raw []byte) (textStatsCorpusValue, error) {
+	cur, err := textStatsValueCursor(raw, "corpus")
+	if err != nil {
+		return textStatsCorpusValue{}, err
+	}
+	documents, err := cur.readUvarint()
+	if err != nil {
+		return textStatsCorpusValue{}, errMalformedTextStorage("text-stats corpus document count: %v", err)
+	}
+	if cur.remaining() != 0 {
+		return textStatsCorpusValue{}, errMalformedTextStorage("text-stats corpus trailing bytes")
+	}
+	return textStatsCorpusValue{DocumentCount: documents}, nil
+}
+
+func encodeTextStatsTermValue(value textStatsTermValue) []byte {
+	out := []byte{textStatsValueVersion}
+	out = appendTextUvarint(out, value.DocumentFrequency)
+	out = appendTextUvarint(out, value.TotalTermFrequency)
+	return out
+}
+
+func decodeTextStatsTermValue(raw []byte) (textStatsTermValue, error) {
+	cur, err := textStatsValueCursor(raw, "term")
+	if err != nil {
+		return textStatsTermValue{}, err
+	}
+	df, err := cur.readUvarint()
+	if err != nil {
+		return textStatsTermValue{}, errMalformedTextStorage("text-stats term document frequency: %v", err)
+	}
+	tf, err := cur.readUvarint()
+	if err != nil {
+		return textStatsTermValue{}, errMalformedTextStorage("text-stats term total frequency: %v", err)
+	}
+	if cur.remaining() != 0 {
+		return textStatsTermValue{}, errMalformedTextStorage("text-stats term trailing bytes")
+	}
+	return textStatsTermValue{DocumentFrequency: df, TotalTermFrequency: tf}, nil
+}
+
+func encodeTextStatsFieldValue(value textStatsFieldValue) []byte {
+	out := []byte{textStatsValueVersion}
+	out = appendTextUvarint(out, value.DocumentCount)
+	out = appendTextUvarint(out, value.TotalTokenCount)
+	return out
+}
+
+func decodeTextStatsFieldValue(raw []byte) (textStatsFieldValue, error) {
+	cur, err := textStatsValueCursor(raw, "field")
+	if err != nil {
+		return textStatsFieldValue{}, err
+	}
+	documents, err := cur.readUvarint()
+	if err != nil {
+		return textStatsFieldValue{}, errMalformedTextStorage("text-stats field document count: %v", err)
+	}
+	tokens, err := cur.readUvarint()
+	if err != nil {
+		return textStatsFieldValue{}, errMalformedTextStorage("text-stats field token count: %v", err)
+	}
+	if cur.remaining() != 0 {
+		return textStatsFieldValue{}, errMalformedTextStorage("text-stats field trailing bytes")
+	}
+	return textStatsFieldValue{DocumentCount: documents, TotalTokenCount: tokens}, nil
+}
+
+func textStatsValueCursor(raw []byte, name string) (textCursor, error) {
+	if len(raw) == 0 {
+		return textCursor{}, errMalformedTextStorage("empty text-stats %s value", name)
+	}
+	if raw[0] != textStatsValueVersion {
+		return textCursor{}, errUnsupportedTextStorageVersion("text-stats "+name+" value", raw[0])
+	}
+	return textCursor{buf: raw[1:]}, nil
+}
+
+func appendTextBytes(dst []byte, value []byte) []byte {
+	dst = appendTextUvarint(dst, uint64(len(value)))
+	return append(dst, value...)
+}
+
+func appendTextString(dst []byte, value string) []byte {
+	return appendTextBytes(dst, []byte(value))
+}
+
+func appendTextUvarint(dst []byte, value uint64) []byte {
+	var buf [binary.MaxVarintLen64]byte
+	n := binary.PutUvarint(buf[:], value)
+	return append(dst, buf[:n]...)
+}
+
+func appendTextUint32Slice(dst []byte, values []uint32) []byte {
+	dst = appendTextUvarint(dst, uint64(len(values)))
+	for _, value := range values {
+		dst = appendTextUvarint(dst, uint64(value))
+	}
+	return dst
+}
+
+func appendTextOffsetSlice(dst []byte, values []textTokenOffset) []byte {
+	dst = appendTextUvarint(dst, uint64(len(values)))
+	for _, value := range values {
+		dst = appendTextUvarint(dst, uint64(value.Start))
+		dst = appendTextUvarint(dst, uint64(value.End))
+	}
+	return dst
+}
+
+type textCursor struct {
+	buf []byte
+	pos int
+}
+
+func (c *textCursor) remaining() int {
+	if c == nil || c.pos >= len(c.buf) {
+		return 0
+	}
+	return len(c.buf) - c.pos
+}
+
+func (c *textCursor) readUvarint() (uint64, error) {
+	if c == nil || c.pos >= len(c.buf) {
+		return 0, io.ErrUnexpectedEOF
+	}
+	value, n := binary.Uvarint(c.buf[c.pos:])
+	if n == 0 {
+		return 0, io.ErrUnexpectedEOF
+	}
+	if n < 0 {
+		return 0, errors.New("varint overflow")
+	}
+	c.pos += n
+	return value, nil
+}
+
+func (c *textCursor) readBytes() ([]byte, error) {
+	length, err := c.readUvarint()
+	if err != nil {
+		return nil, err
+	}
+	if length > uint64(c.remaining()) {
+		return nil, io.ErrUnexpectedEOF
+	}
+	start := c.pos
+	c.pos += int(length)
+	return c.buf[start:c.pos], nil
+}
+
+func (c *textCursor) readString() (string, error) {
+	value, err := c.readBytes()
+	if err != nil {
+		return "", err
+	}
+	return string(value), nil
+}
+
+func (c *textCursor) readUint32Slice() ([]uint32, error) {
+	count, err := c.readUvarint()
+	if err != nil {
+		return nil, err
+	}
+	if count > uint64(c.remaining()+1) {
+		return nil, errors.New("count too large")
+	}
+	out := make([]uint32, 0, count)
+	for i := uint64(0); i < count; i++ {
+		value, err := c.readUvarint()
+		if err != nil {
+			return nil, err
+		}
+		if uint64(checkedTextUint32(value)) != value {
+			return nil, errors.New("uint32 overflow")
+		}
+		out = append(out, uint32(value))
+	}
+	return out, nil
+}
+
+func (c *textCursor) readOffsetSlice() ([]textTokenOffset, error) {
+	count, err := c.readUvarint()
+	if err != nil {
+		return nil, err
+	}
+	if count > uint64(c.remaining()+1) {
+		return nil, errors.New("count too large")
+	}
+	out := make([]textTokenOffset, 0, count)
+	for i := uint64(0); i < count; i++ {
+		start, err := c.readUvarint()
+		if err != nil {
+			return nil, err
+		}
+		end, err := c.readUvarint()
+		if err != nil {
+			return nil, err
+		}
+		if uint64(checkedTextUint32(start)) != start || uint64(checkedTextUint32(end)) != end {
+			return nil, errors.New("uint32 overflow")
+		}
+		if end < start {
+			return nil, errors.New("offset end before start")
+		}
+		out = append(out, textTokenOffset{Start: uint32(start), End: uint32(end)})
+	}
+	return out, nil
+}
+
+func checkedTextUint32(value uint64) uint32 {
+	return uint32(value)
+}
+
+func errMalformedTextStorage(format string, args ...any) error {
+	if len(args) == 0 {
+		return fmt.Errorf("%w: %s", ErrTextIndexStorageCorrupt, format)
+	}
+	return fmt.Errorf("%w: %s", ErrTextIndexStorageCorrupt, fmt.Sprintf(format, args...))
+}
+
+func errUnsupportedTextStorageVersion(component string, version byte) error {
+	return fmt.Errorf("%w: unsupported %s version %d", ErrTextIndexStorageCorrupt, component, version)
+}

--- a/TreeDB/collections/text_storage_test.go
+++ b/TreeDB/collections/text_storage_test.go
@@ -1,0 +1,391 @@
+package collections
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"slices"
+	"testing"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/internal/iterator"
+	"github.com/snissn/gomap/TreeDB/internal/memtable"
+)
+
+func TestTextStorageCodecsRoundTripAndFailClosed(t *testing.T) {
+	postingKey := encodeTextPostingKey("refund", []byte{'d', 0, '1'})
+	term, docID, err := decodeTextPostingKey(postingKey)
+	if err != nil {
+		t.Fatalf("decode postings key: %v", err)
+	}
+	if term != "refund" || !bytes.Equal(docID, []byte{'d', 0, '1'}) {
+		t.Fatalf("postings key term=%q docID=%q", term, docID)
+	}
+	if !bytes.HasPrefix(postingKey, encodeTextPostingTermPrefix("refund")) {
+		t.Fatalf("postings key %v missing term prefix %v", postingKey, encodeTextPostingTermPrefix("refund"))
+	}
+
+	posting := textPostingValue{
+		TermFrequency: 3,
+		Fields: []textPostingFieldValue{{
+			Field:     "body",
+			Frequency: 3,
+			Positions: []uint32{0, 2, 5},
+			Offsets:   []textTokenOffset{{Start: 0, End: 6}, {Start: 14, End: 20}, {Start: 30, End: 36}},
+		}},
+	}
+	decodedPosting, err := decodeTextPostingValue(encodeTextPostingValue(posting))
+	if err != nil {
+		t.Fatalf("decode postings value: %v", err)
+	}
+	if decodedPosting.TermFrequency != 3 || len(decodedPosting.Fields) != 1 || decodedPosting.Fields[0].Field != "body" || !slices.Equal(decodedPosting.Fields[0].Positions, []uint32{0, 2, 5}) {
+		t.Fatalf("decoded postings=%+v", decodedPosting)
+	}
+
+	state := textDocumentStateValue{Fields: []textDocumentFieldState{{
+		Field:  "body",
+		Length: 4,
+		Terms: []textDocumentTermState{{
+			Term:      "refund",
+			Frequency: 2,
+			Positions: []uint32{0, 3},
+			Offsets:   []textTokenOffset{{Start: 0, End: 6}, {Start: 21, End: 27}},
+		}},
+	}}}
+	decodedState, err := decodeTextDocumentStateValue(encodeTextDocumentStateValue(state))
+	if err != nil {
+		t.Fatalf("decode text-state value: %v", err)
+	}
+	if len(decodedState.Fields) != 1 || decodedState.Fields[0].Terms[0].Term != "refund" || decodedState.Fields[0].Terms[0].Frequency != 2 {
+		t.Fatalf("decoded state=%+v", decodedState)
+	}
+
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{name: "postings key version", err: func() error { _, _, err := decodeTextPostingKey([]byte{99}); return err }()},
+		{name: "postings value version", err: func() error { _, err := decodeTextPostingValue([]byte{99}); return err }()},
+		{name: "postings value truncated", err: func() error { _, err := decodeTextPostingValue([]byte{textPostingValueVersion, 1, 1}); return err }()},
+		{name: "state key version", err: func() error { _, err := decodeTextStateKey([]byte{99, 'd'}); return err }()},
+		{name: "state value version", err: func() error { _, err := decodeTextDocumentStateValue([]byte{99}); return err }()},
+		{name: "stats key unknown kind", err: func() error { _, err := decodeTextStatsKey([]byte{textStatsKeyVersion, 99}); return err }()},
+		{name: "stats value version", err: func() error { _, err := decodeTextStatsCorpusValue([]byte{99}); return err }()},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if !errors.Is(tc.err, ErrTextIndexStorageCorrupt) {
+				t.Fatalf("err=%v want ErrTextIndexStorageCorrupt", tc.err)
+			}
+		})
+	}
+}
+
+func TestCollectionCreateTextIndexBackfillsReopensAndReportsStorage(t *testing.T) {
+	dir := t.TempDir()
+	d, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "docs"}); err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	col, err := mgr.OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("OpenCollection: %v", err)
+	}
+	ids := [][]byte{[]byte("d1"), []byte("d2"), []byte("d3")}
+	docs := [][]byte{
+		[]byte(`{"title":"Refund Policy","body":"refund failed refund","tags":["policy","HTTP_500"]}`),
+		[]byte(`{"title":"Other","body":"shipping policy"}`),
+		[]byte(`{"title":"Empty","body":"---"}`),
+	}
+	if _, err := col.InsertBatch(ids, docs); err != nil {
+		t.Fatalf("InsertBatch: %v", err)
+	}
+
+	meta, backfill, err := col.CreateTextIndex(TextIndexDefinition{
+		Name:           "lexical",
+		Fields:         []TextIndexField{{Field: "body"}, {Field: "title", Weight: 2}, {Field: "tags"}},
+		StorePositions: true,
+		StoreOffsets:   true,
+		StoragePolicy:  RootStorageFast,
+	})
+	if err != nil {
+		t.Fatalf("CreateTextIndex: %v", err)
+	}
+	if len(meta.TextIndexes) != 1 || meta.TextIndexes[0].Name != "lexical" {
+		t.Fatalf("text indexes after create=%+v", meta.TextIndexes)
+	}
+	if backfill.DocumentsScanned != 3 || backfill.StateEntries != 3 || backfill.PostingEntries != 8 || backfill.StatsEntries != 11 || backfill.EncodedBytes == 0 {
+		t.Fatalf("backfill stats=%+v want docs=3 state=3 postings=8 stats=11 bytes>0", backfill)
+	}
+
+	storageStats, err := col.TextIndexStorageStats("lexical")
+	if err != nil {
+		t.Fatalf("TextIndexStorageStats: %v", err)
+	}
+	if storageStats.Documents != 3 || storageStats.StateEntries != 3 || storageStats.PostingEntries != 8 || storageStats.StatsEntries != 11 || storageStats.EncodedBytes == 0 {
+		t.Fatalf("storage stats=%+v want docs=3 state=3 postings=8 stats=11 bytes>0", storageStats)
+	}
+
+	withTextCatalog(t, d, "docs", func(snap *backenddb.Snapshot, catalog *collectionCatalog) {
+		postingRaw := textRootValue(t, snap, catalog, collectionTextIndexRootName("docs", "lexical"), encodeTextPostingKey("refund", []byte("d1")))
+		posting, err := decodeTextPostingValue(postingRaw)
+		if err != nil {
+			t.Fatalf("decode refund posting: %v", err)
+		}
+		if posting.TermFrequency != 3 || len(posting.Fields) != 2 {
+			t.Fatalf("refund posting=%+v want tf=3 in body+title", posting)
+		}
+		stateRaw := textRootValue(t, snap, catalog, collectionTextStateRootName("docs", "lexical"), encodeTextStateKey([]byte("d1")))
+		state, err := decodeTextDocumentStateValue(stateRaw)
+		if err != nil {
+			t.Fatalf("decode d1 state: %v", err)
+		}
+		if len(state.Fields) != 3 {
+			t.Fatalf("d1 state fields=%+v want body/title/tags", state.Fields)
+		}
+		termStatsRaw := textRootValue(t, snap, catalog, collectionTextStatsRootName("docs", "lexical"), encodeTextStatsTermKey("policy"))
+		termStats, err := decodeTextStatsTermValue(termStatsRaw)
+		if err != nil {
+			t.Fatalf("decode policy stats: %v", err)
+		}
+		if termStats.DocumentFrequency != 2 || termStats.TotalTermFrequency != 3 {
+			t.Fatalf("policy stats=%+v want df=2 tf=3", termStats)
+		}
+	})
+
+	if err := d.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	reopened, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+	reopenedCol, err := NewCollectionManager(reopened).OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("OpenCollection reopened: %v", err)
+	}
+	reopenedStats, err := reopenedCol.TextIndexStorageStats("lexical")
+	if err != nil {
+		t.Fatalf("reopened TextIndexStorageStats: %v", err)
+	}
+	if reopenedStats != storageStats {
+		t.Fatalf("reopened stats=%+v want %+v", reopenedStats, storageStats)
+	}
+}
+
+func TestCollectionDropTextIndexClearsMetadataRootsAndWriteGuard(t *testing.T) {
+	d := openTextTestDB(t)
+	defer func() { _ = d.Close() }()
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "docs"}); err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	col, err := mgr.OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("OpenCollection: %v", err)
+	}
+	if _, err := col.InsertBatch([][]byte{[]byte("d1")}, [][]byte{[]byte(`{"body":"refund policy"}`)}); err != nil {
+		t.Fatalf("InsertBatch: %v", err)
+	}
+	if _, _, err := col.CreateTextIndex(TextIndexDefinition{Name: "lexical", Fields: []TextIndexField{{Field: "body"}}}); err != nil {
+		t.Fatalf("CreateTextIndex: %v", err)
+	}
+	if _, err := col.Insert([]byte("d2"), []byte(`{"body":"blocked"}`)); !errors.Is(err, ErrTextIndexUnavailable) {
+		t.Fatalf("Insert with text index err=%v want ErrTextIndexUnavailable", err)
+	}
+
+	meta, err := col.DropTextIndex("lexical")
+	if err != nil {
+		t.Fatalf("DropTextIndex: %v", err)
+	}
+	if len(meta.TextIndexes) != 0 {
+		t.Fatalf("text indexes after drop=%+v", meta.TextIndexes)
+	}
+	if _, err := col.TextIndexStorageStats("lexical"); !errors.Is(err, ErrIndexNotFound) {
+		t.Fatalf("TextIndexStorageStats after drop err=%v want ErrIndexNotFound", err)
+	}
+	assertTextRootCleared(t, d, collectionTextIndexRootName("docs", "lexical"))
+	assertTextRootCleared(t, d, collectionTextStateRootName("docs", "lexical"))
+	assertTextRootCleared(t, d, collectionTextStatsRootName("docs", "lexical"))
+	if _, err := col.Insert([]byte("d2"), []byte(`{"body":"allowed after drop"}`)); err != nil {
+		t.Fatalf("Insert after DropTextIndex: %v", err)
+	}
+}
+
+func TestTextIndexStorageStatsFailsClosedOnMalformedRoot(t *testing.T) {
+	d := openTextTestDB(t)
+	defer func() { _ = d.Close() }()
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "docs"}); err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	col, err := mgr.OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("OpenCollection: %v", err)
+	}
+	if _, err := col.InsertBatch([][]byte{[]byte("d1")}, [][]byte{[]byte(`{"body":"refund policy"}`)}); err != nil {
+		t.Fatalf("InsertBatch: %v", err)
+	}
+	if _, _, err := col.CreateTextIndex(TextIndexDefinition{Name: "lexical", Fields: []TextIndexField{{Field: "body"}}}); err != nil {
+		t.Fatalf("CreateTextIndex: %v", err)
+	}
+	corruptTextRootValue(t, d, "docs", collectionTextStatsRootName("docs", "lexical"), encodeTextStatsCorpusKey(), []byte{99})
+	if _, err := col.TextIndexStorageStats("lexical"); !errors.Is(err, ErrTextIndexStorageCorrupt) {
+		t.Fatalf("TextIndexStorageStats corrupted err=%v want ErrTextIndexStorageCorrupt", err)
+	}
+}
+
+func BenchmarkCreateTextIndexBackfill(b *testing.B) {
+	const docsPerBackfill = 256
+	var lastStats TextIndexBackfillStats
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		d := openTextBenchDB(b)
+		mgr := NewCollectionManager(d)
+		if _, err := mgr.CreateCollection(&CollectionMeta{Name: "docs"}); err != nil {
+			b.Fatalf("CreateCollection: %v", err)
+		}
+		col, err := mgr.OpenCollection("docs")
+		if err != nil {
+			b.Fatalf("OpenCollection: %v", err)
+		}
+		ids := make([][]byte, docsPerBackfill)
+		docs := make([][]byte, docsPerBackfill)
+		for j := 0; j < docsPerBackfill; j++ {
+			ids[j] = []byte(fmt.Sprintf("doc-%06d", j))
+			docs[j] = []byte(fmt.Sprintf(`{"title":"Ticket %d refund policy","body":"HTTP_500 retry refund policy customer %d"}`, j, j%17))
+		}
+		if _, err := col.InsertBatch(ids, docs); err != nil {
+			b.Fatalf("InsertBatch setup: %v", err)
+		}
+		b.StartTimer()
+		_, stats, err := col.CreateTextIndex(TextIndexDefinition{Name: "lexical", Fields: []TextIndexField{{Field: "title"}, {Field: "body"}}, StorePositions: true})
+		b.StopTimer()
+		if err != nil {
+			b.Fatalf("CreateTextIndex: %v", err)
+		}
+		lastStats = stats
+		_ = d.Close()
+	}
+	b.ReportMetric(float64(docsPerBackfill), "docs/backfill")
+	b.ReportMetric(float64(lastStats.PostingEntries), "postings/backfill")
+	b.ReportMetric(float64(lastStats.EncodedBytes), "encoded_bytes/backfill")
+}
+
+func openTextTestDB(t *testing.T) *backenddb.DB {
+	t.Helper()
+	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	return d
+}
+
+func openTextBenchDB(b *testing.B) *backenddb.DB {
+	b.Helper()
+	d, err := backenddb.Open(backenddb.Options{Dir: b.TempDir()})
+	if err != nil {
+		b.Fatalf("open db: %v", err)
+	}
+	return d
+}
+
+func withTextCatalog(t *testing.T, d *backenddb.DB, collection string, fn func(*backenddb.Snapshot, *collectionCatalog)) {
+	t.Helper()
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("snapshot nil")
+	}
+	defer func() { _ = snap.Close() }()
+	catalog, err := loadCollectionCatalog(snap, collection)
+	if err != nil {
+		t.Fatalf("load catalog: %v", err)
+	}
+	if catalog == nil {
+		t.Fatal("catalog nil")
+	}
+	fn(snap, catalog)
+}
+
+func textRootValue(t *testing.T, snap *backenddb.Snapshot, catalog *collectionCatalog, rootName string, key []byte) []byte {
+	t.Helper()
+	value, ok, err := collectionGetAppendAtCatalogRoot(snap, catalog, rootName, key, nil)
+	if err != nil {
+		t.Fatalf("get text root %q key %v: %v", rootName, key, err)
+	}
+	if !ok {
+		t.Fatalf("text root %q missing key %v", rootName, key)
+	}
+	return value
+}
+
+func assertTextRootCleared(t *testing.T, d *backenddb.DB, rootName string) {
+	t.Helper()
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("snapshot nil")
+	}
+	defer func() { _ = snap.Close() }()
+	raw, ok, err := getSystemValue(snap, systemCollectionRootKey(rootName))
+	if err != nil {
+		t.Fatalf("get root descriptor %q: %v", rootName, err)
+	}
+	if !ok {
+		return
+	}
+	rootID, err := decodeRootID(raw)
+	if err != nil {
+		t.Fatalf("decode root descriptor %q: %v", rootName, err)
+	}
+	if rootID != 0 {
+		t.Fatalf("root descriptor %q=%d want cleared", rootName, rootID)
+	}
+}
+
+func corruptTextRootValue(t *testing.T, d *backenddb.DB, collection, rootName string, key, value []byte) {
+	t.Helper()
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("snapshot nil")
+	}
+	catalog, err := loadCollectionCatalog(snap, collection)
+	if err != nil {
+		_ = snap.Close()
+		t.Fatalf("load catalog: %v", err)
+	}
+	baseRoot := catalog.rootID(rootName)
+	policy, err := collectionRootStoragePolicyForDB(d, catalog.meta, rootName)
+	if err != nil {
+		_ = snap.Close()
+		t.Fatalf("root policy: %v", err)
+	}
+	_ = snap.Close()
+	table := newCollectionRunTable(1)
+	table.SetSteal(bytes.Clone(key), bytes.Clone(value))
+	table.Freeze()
+	defer resetCollectionTables([]memtable.Table{table})
+	iter := table.NewIterator(nil, nil)
+	defer func() { _ = iter.Close() }()
+	ordered := []backenddb.OrderedRootDeltaPublishInput{{BaseRoot: baseRoot, Iter: iter, StoragePolicy: policy}}
+	_, rootIDs, err := d.PublishOrderedRootDeltaGroupWithSystemBuilder(ordered, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		if len(rootIDs) != 1 {
+			return nil, fmt.Errorf("unexpected root ids %d", len(rootIDs))
+		}
+		current := d.AcquireSnapshot()
+		if current == nil {
+			return nil, backenddb.ErrClosed
+		}
+		defer func() { _ = current.Close() }()
+		return buildSystemTargetIterator(current, map[string][]byte{systemCollectionRootKey(rootName): encodeRootID(rootIDs[0])})
+	})
+	if err != nil {
+		t.Fatalf("publish corrupt root: %v", err)
+	}
+	if len(rootIDs) != 1 {
+		t.Fatalf("rootIDs=%d want 1", len(rootIDs))
+	}
+}

--- a/TreeDB/collections/text_storage_test.go
+++ b/TreeDB/collections/text_storage_test.go
@@ -216,6 +216,39 @@ func TestCollectionDropTextIndexClearsMetadataRootsAndWriteGuard(t *testing.T) {
 	}
 }
 
+func TestCreateTextIndexRejectsWritesFromStaleHandles(t *testing.T) {
+	d := openTextTestDB(t)
+	defer func() { _ = d.Close() }()
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "docs"}); err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	stale, err := mgr.OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("OpenCollection stale: %v", err)
+	}
+	fresh, err := mgr.OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("OpenCollection fresh: %v", err)
+	}
+	if _, err := stale.Insert([]byte("d1"), []byte(`{"body":"before text"}`)); err != nil {
+		t.Fatalf("stale setup Insert: %v", err)
+	}
+	if _, _, err := fresh.CreateTextIndex(TextIndexDefinition{Name: "lexical", Fields: []TextIndexField{{Field: "body"}}}); err != nil {
+		t.Fatalf("CreateTextIndex: %v", err)
+	}
+	if _, err := stale.Insert([]byte("d2"), []byte(`{"body":"must not bypass"}`)); !errors.Is(err, ErrTextIndexUnavailable) {
+		t.Fatalf("stale Insert after CreateTextIndex err=%v want ErrTextIndexUnavailable", err)
+	}
+	stats, err := fresh.TextIndexStorageStats("lexical")
+	if err != nil {
+		t.Fatalf("TextIndexStorageStats: %v", err)
+	}
+	if stats.Documents != 1 || stats.StateEntries != 1 {
+		t.Fatalf("stats after stale rejected insert=%+v want one backfilled document", stats)
+	}
+}
+
 func TestTextIndexStorageStatsFailsClosedOnMalformedRoot(t *testing.T) {
 	d := openTextTestDB(t)
 	defer func() { _ = d.Close() }()

--- a/TreeDB/collections/text_storage_test.go
+++ b/TreeDB/collections/text_storage_test.go
@@ -194,6 +194,11 @@ func TestCollectionDropTextIndexClearsMetadataRootsAndWriteGuard(t *testing.T) {
 	if _, _, err := col.CreateTextIndex(TextIndexDefinition{Name: "lexical", Fields: []TextIndexField{{Field: "body"}}}); err != nil {
 		t.Fatalf("CreateTextIndex: %v", err)
 	}
+	staleMgr := NewCollectionManager(d)
+	stale, err := staleMgr.OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("OpenCollection stale: %v", err)
+	}
 	if _, err := col.Insert([]byte("d2"), []byte(`{"body":"blocked"}`)); !errors.Is(err, ErrTextIndexUnavailable) {
 		t.Fatalf("Insert with text index err=%v want ErrTextIndexUnavailable", err)
 	}
@@ -213,6 +218,9 @@ func TestCollectionDropTextIndexClearsMetadataRootsAndWriteGuard(t *testing.T) {
 	assertTextRootCleared(t, d, collectionTextStatsRootName("docs", "lexical"))
 	if _, err := col.Insert([]byte("d2"), []byte(`{"body":"allowed after drop"}`)); err != nil {
 		t.Fatalf("Insert after DropTextIndex: %v", err)
+	}
+	if _, err := stale.Insert([]byte("d3"), []byte(`{"body":"stale handle allowed after drop"}`)); err != nil {
+		t.Fatalf("stale Insert after DropTextIndex: %v", err)
 	}
 }
 

--- a/TreeDB/collections/text_storage_test.go
+++ b/TreeDB/collections/text_storage_test.go
@@ -216,6 +216,59 @@ func TestCollectionDropTextIndexClearsMetadataRootsAndWriteGuard(t *testing.T) {
 	}
 }
 
+func TestCreateTextIndexFlushesBufferedWritesFromOtherManagers(t *testing.T) {
+	d := openTextTestDB(t)
+	defer func() { _ = d.Close() }()
+	writerMgr := NewCollectionManager(d)
+	if _, err := writerMgr.CreateCollection(&CollectionMeta{Name: "docs"}); err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	writer, err := writerMgr.OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("OpenCollection writer: %v", err)
+	}
+	creatorMgr := NewCollectionManager(d)
+	creator, err := creatorMgr.OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("OpenCollection creator: %v", err)
+	}
+
+	if _, err := writer.Insert([]byte("d-buffered"), []byte(`{"body":"buffered refund policy"}`)); err != nil {
+		t.Fatalf("writer buffered Insert: %v", err)
+	}
+	if got, err := creator.Get([]byte("d-buffered")); err != nil {
+		t.Fatalf("creator Get before CreateTextIndex: %v", err)
+	} else if got != nil {
+		t.Fatalf("setup write was already published; expected buffered write from separate manager, got %q", got)
+	}
+
+	_, backfill, err := creator.CreateTextIndex(TextIndexDefinition{Name: "lexical", Fields: []TextIndexField{{Field: "body"}}})
+	if err != nil {
+		t.Fatalf("CreateTextIndex: %v", err)
+	}
+	if backfill.DocumentsScanned != 1 || backfill.StateEntries != 1 || backfill.PostingEntries != 3 {
+		t.Fatalf("backfill stats=%+v want one flushed buffered document", backfill)
+	}
+	stats, err := creator.TextIndexStorageStats("lexical")
+	if err != nil {
+		t.Fatalf("TextIndexStorageStats: %v", err)
+	}
+	if stats.Documents != 1 || stats.StateEntries != 1 || stats.PostingEntries != 3 {
+		t.Fatalf("storage stats=%+v want one flushed buffered document", stats)
+	}
+	if got, err := creator.Get([]byte("d-buffered")); err != nil {
+		t.Fatalf("creator Get after CreateTextIndex: %v", err)
+	} else if !bytes.Contains(got, []byte("buffered refund")) {
+		t.Fatalf("flushed document after CreateTextIndex=%q", got)
+	}
+	if err := writer.Flush(); err != nil {
+		t.Fatalf("writer Flush after CreateTextIndex: %v", err)
+	}
+	if _, err := writer.Insert([]byte("d-after"), []byte(`{"body":"must not bypass"}`)); !errors.Is(err, ErrTextIndexUnavailable) {
+		t.Fatalf("writer Insert after CreateTextIndex err=%v want ErrTextIndexUnavailable", err)
+	}
+}
+
 func TestCreateTextIndexRejectsWritesFromStaleHandles(t *testing.T) {
 	d := openTextTestDB(t)
 	defer func() { _ = d.Close() }()

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -458,6 +458,7 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/typed_storage_layout.go", classification: typedStorageLegacyCompatibility, matchingLines: 26, occurrences: 52},
 	{path: "TreeDB/collections/typed_storage_layout_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 41, occurrences: 41},
 	{path: "TreeDB/collections/typed_storage_naming_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 33, occurrences: 33},
+	{path: "TreeDB/collections/text_catalog.go", classification: typedStorageLegacyCompatibility, matchingLines: 1, occurrences: 1},
 	{path: "TreeDB/collections/vector_index.go", classification: typedStorageLegacyDerived, matchingLines: 1, occurrences: 1},
 	{path: "TreeDB/collections/column_vector_graph_quantized_asset.go", classification: typedStorageLegacyDerived, matchingLines: 75, occurrences: 82},
 	{path: "TreeDB/collections/column_vector_graph_rabitq_quantized_asset_test.go", classification: typedStorageLegacyDerived, matchingLines: 15, occurrences: 17},

--- a/TreeDB/docs/spec/README.md
+++ b/TreeDB/docs/spec/README.md
@@ -83,8 +83,10 @@ Given pre-alpha status, this is a living spec that tracks implementation.
   - indexed collection write-domain visibility, async flush, backpressure, and
     durability-boundary semantics.
 - `TreeDB/docs/spec/collection-text-search.md`
-  - collection-native text index metadata, analyzer, root naming, query shape,
-    and PR1 fail-closed behavior before postings/text-state/stats storage lands.
+  - collection-native text index metadata, analyzer, root naming/policies,
+    versioned postings/text-state/text-stats storage, backfill/drop, query
+    shape, and fail-closed behavior before mutation maintenance/search execution
+    lands.
 - `TreeDB/docs/spec/write-path-and-durability.md`
   - write pipeline and durability semantics for all durability modes.
 - `TreeDB/docs/spec/recovery.md`

--- a/TreeDB/docs/spec/collection-text-search.md
+++ b/TreeDB/docs/spec/collection-text-search.md
@@ -144,10 +144,12 @@ Values use `u8 value_version=1` followed by:
 
 ## Create/backfill/drop
 
-`CreateTextIndex` is a schema barrier: pending writes are flushed, the primary
-root is scanned, analyzed text is encoded into the three text roots, and root
-IDs plus metadata are published in one commit. It rejects command-WAL catalog
-mutation mode until text-index catalog commands are added.
+`CreateTextIndex` is a schema barrier: pending writes from all registered
+collection managers/write domains for the collection are drained before the
+backfill snapshot is taken, new document writes wait behind the barrier, the
+primary root is scanned, analyzed text is encoded into the three text roots,
+and root IDs plus metadata are published in one commit. It rejects command-WAL
+catalog mutation mode until text-index catalog commands are added.
 
 Backfill extracts string fields and arrays of strings from JSON-materialized
 documents. Non-string text fields are skipped. Collections with retained column

--- a/TreeDB/docs/spec/collection-text-search.md
+++ b/TreeDB/docs/spec/collection-text-search.md
@@ -1,32 +1,35 @@
-# Collection Text Search Contract (M0/M1)
+# Collection Text Search Contract (M0-M2)
 
-Status: PR1 substrate for issue #1764. TreeDB collections are pre-alpha; this
-contract freezes the first metadata/analyzer/root/query shape, while persistent
-postings/text-state/stats storage and ranked execution remain follow-up work.
+Status: PR2 storage/backfill slice for issue #1764. TreeDB collections are
+pre-alpha; these text-search storage formats are versioned and may change before
+stabilization, but malformed or unsupported versions must fail closed.
 
-## Scope in this milestone
-
-Implemented now:
+## Implemented scope
 
 - `CollectionMeta.TextIndexes []TextIndexDefinition` metadata.
 - `TextIndexDefinition` / `TextIndexField` validation and JSON persistence.
-- Root naming helpers for future durable text state:
-  - `<collection>/text-index/<indexName>` for term/document postings.
-  - `<collection>/text-state/<indexName>` for document analyzed state.
-  - `<collection>/text-stats/<indexName>` for corpus and term statistics.
+- Root naming and storage policy handling:
+  - `<collection>/text-index/<indexName>` for term/document postings; uses
+    `TextIndexDefinition.StoragePolicy`.
+  - `<collection>/text-state/<indexName>` for document analyzed state; uses
+    `CollectionOptions.IndexStateStoragePolicy`.
+  - `<collection>/text-stats/<indexName>` for corpus and term/field statistics;
+    uses `CollectionOptions.IndexStateStoragePolicy`.
 - `simple` analyzer: Unicode lowercase tokenization over letters, digits, and
   `_` so code-ish identifiers such as `HTTP_500` remain searchable.
+- `CreateTextIndex` backfills persistent postings/text-state/text-stats roots
+  over existing documents and publishes roots plus metadata atomically.
+- `DropTextIndex` removes metadata and clears the text root descriptors.
+- `TextIndexStorageStats` validates storage versions and returns root accounting.
 - `SearchText(TextSearchOptions)` query-shape validation that fails closed before
-  scanning because storage is not implemented yet.
+  scanning because ranked text search execution is not implemented yet.
 
-Not implemented in this milestone:
+Not implemented yet:
 
-- persistent postings, text-state, or text-stats values;
-- create/backfill/drop text index commands;
-- mutation maintenance for text indexes;
-- BM25/BM25F scoring;
+- insert/update/delete mutation maintenance for declared text indexes;
+- BM25/BM25F scoring and ranked SearchText execution;
 - phrase/proximity/highlighting/stemming/trigram/fuzzy search;
-- gateway or hybrid text+vector executor integration.
+- query-vector syntax, gateway integration, or hybrid text+vector executor integration.
 
 ## Metadata
 
@@ -61,14 +64,99 @@ Validation rules:
 - Text index names share the collection-wide index namespace with scalar and
   vector indexes.
 
-Root storage policies:
+## M2 storage encoding
 
-- `TextIndexDefinition.StoragePolicy` applies to the postings root
-  `<collection>/text-index/<indexName>`.
-- `<collection>/text-state/<indexName>` and
-  `<collection>/text-stats/<indexName>` use
-  `CollectionOptions.IndexStateStoragePolicy`, matching existing index-state and
-  vector-index maintenance roots.
+All text roots use versioned binary keys/values. Decoders return
+`ErrTextIndexStorageCorrupt` on malformed data or unsupported versions.
+
+### Postings root
+
+Root: `<collection>/text-index/<indexName>`.
+
+Key:
+
+```text
+u8 key_version=1 | uvarint term_len | term bytes | document_id bytes
+```
+
+Value:
+
+```text
+u8 value_version=1
+uvarint document_term_frequency
+uvarint field_count
+repeated field_count:
+  string field_name
+  uvarint field_term_frequency
+  uvarint position_count | repeated uvarint positions
+  uvarint offset_count   | repeated (uvarint start, uvarint end)
+```
+
+The postings root has one entry per `(term, documentID)` and stores per-field
+frequency plus optional positions/offsets according to the index definition.
+
+### Text-state root
+
+Root: `<collection>/text-state/<indexName>`.
+
+Key:
+
+```text
+u8 key_version=1 | document_id bytes
+```
+
+Value:
+
+```text
+u8 value_version=1
+uvarint field_count
+repeated field_count:
+  string field_name
+  uvarint field_length_tokens
+  uvarint term_count
+  repeated term_count:
+    string term
+    uvarint frequency
+    uvarint position_count | repeated uvarint positions
+    uvarint offset_count   | repeated (uvarint start, uvarint end)
+```
+
+Backfill writes a text-state entry for every scanned document so later M3
+mutation maintenance can diff or decrement document-level accounting.
+
+### Text-stats root
+
+Root: `<collection>/text-stats/<indexName>`.
+
+Keys:
+
+```text
+u8 key_version=1 | kind=1                       // corpus document count
+u8 key_version=1 | kind=2 | string term          // term statistics
+u8 key_version=1 | kind=3 | string field_name    // field length statistics
+```
+
+Values use `u8 value_version=1` followed by:
+
+- corpus: `uvarint document_count`;
+- term: `uvarint document_frequency | uvarint total_term_frequency`;
+- field: `uvarint field_document_count | uvarint total_token_count`.
+
+## Create/backfill/drop
+
+`CreateTextIndex` is a schema barrier: pending writes are flushed, the primary
+root is scanned, analyzed text is encoded into the three text roots, and root
+IDs plus metadata are published in one commit. It rejects command-WAL catalog
+mutation mode until text-index catalog commands are added.
+
+Backfill extracts string fields and arrays of strings from JSON-materialized
+documents. Non-string text fields are skipped. Collections with retained column
+payloads that omit requested text fields are rejected for now rather than
+backfilling incomplete text.
+
+`DropTextIndex` removes the text index metadata and clears all three text root
+descriptors. It does not delete historical root pages immediately; normal TreeDB
+root reachability/GC handles unreachable pages.
 
 ## Query shape
 
@@ -83,33 +171,29 @@ type TextSearchOptions struct {
 }
 ```
 
-The PR1 parser accepts whitespace-separated terms and optional explicit `AND` or
+The parser accepts whitespace-separated terms and optional explicit `AND` or
 `OR` separators. Mixed `AND`/`OR`, phrases, and grouped syntax fail closed. Query
 terms are analyzed with the declared index analyzer.
 
 `SearchText` currently returns `ErrTextIndexUnavailable` for non-empty analyzed
 queries against an existing text index. This is intentional: normal text queries
-MUST be indexed and bounded, and PR1 must not implement a fake scan-and-rank
-fallback. Empty analyzed queries return an empty result set.
+MUST be indexed, bounded, and ranked from postings; M2 does not implement the
+ranked executor and must not fall back to scan-and-rank. Empty analyzed queries
+return an empty result set.
 
 ## Fail-closed write behavior
 
 Collections that declare text indexes reject insert/update/delete operations with
-`ErrTextIndexUnavailable` until M2/M3 land durable postings/text-state/stats and
+`ErrTextIndexUnavailable` until M3 lands durable postings/text-state/stats
 mutation maintenance. This prevents silent divergence between primary documents
 and text metadata.
 
-## Follow-up storage plan
+## Follow-up execution plan
 
-Later #1764 milestones will publish the three text roots atomically with primary
-and other collection roots:
+Later #1764 milestones will:
 
-- postings entries keyed by analyzed term and document ID, with term frequency
-  and field information in values;
-- text-state entries keyed by document ID for update/delete diffing;
-- stats entries for corpus document count, term document frequency, and field
-  length totals used by BM25/BM25F.
-
-The first ranked execution milestone must range-scan postings by term, bound the
-candidate set, score candidates from persisted stats, and fetch full documents
-only for final top-K results.
+- maintain postings, text-state, and stats on insert/update/delete;
+- range-scan postings by analyzed term;
+- bound the candidate set;
+- score candidates from persisted stats with BM25/BM25F-style field weighting;
+- fetch full documents only for final top-K results.

--- a/TreeDB/docs/spec/verification.md
+++ b/TreeDB/docs/spec/verification.md
@@ -197,8 +197,9 @@ matrix:
 Invariant:
 - Collection text index metadata persists through reopen, root names/policies are
   stable, versioned postings/text-state/text-stats encodings fail closed on
-  malformed data, CreateTextIndex backfills existing documents, DropTextIndex
-  clears metadata/root descriptors, the simple analyzer is deterministic, and
+  malformed data, CreateTextIndex drains buffered writes across collection
+  managers before taking its backfill snapshot, DropTextIndex clears
+  metadata/root descriptors, the simple analyzer is deterministic, and
   text-indexed writes/search fail closed until mutation maintenance/search
   execution lands.
 
@@ -214,6 +215,8 @@ Coverage:
   - `TestTextStorageCodecsRoundTripAndFailClosed`
   - `TestCollectionCreateTextIndexBackfillsReopensAndReportsStorage`
   - `TestCollectionDropTextIndexClearsMetadataRootsAndWriteGuard`
+  - `TestCreateTextIndexFlushesBufferedWritesFromOtherManagers`
+  - `TestCreateTextIndexRejectsWritesFromStaleHandles`
   - `TestTextIndexStorageStatsFailsClosedOnMalformedRoot`
   - `BenchmarkCreateTextIndexBackfill`
 

--- a/TreeDB/docs/spec/verification.md
+++ b/TreeDB/docs/spec/verification.md
@@ -192,12 +192,15 @@ matrix:
 - `data_outer=false,index_outer=false` (fast/control),
 - `data_outer=false,index_outer=true` (low-priority compatibility cell).
 
-## 11.1 Collection Text Search Metadata And Analyzer
+## 11.1 Collection Text Search Metadata, Storage, And Analyzer
 
 Invariant:
-- Collection text index metadata persists through reopen, root names are stable,
-  the simple analyzer is deterministic, and text-indexed writes/search fail
-  closed until persistent postings/text-state/stats maintenance lands.
+- Collection text index metadata persists through reopen, root names/policies are
+  stable, versioned postings/text-state/text-stats encodings fail closed on
+  malformed data, CreateTextIndex backfills existing documents, DropTextIndex
+  clears metadata/root descriptors, the simple analyzer is deterministic, and
+  text-indexed writes/search fail closed until mutation maintenance/search
+  execution lands.
 
 Coverage:
 - `TreeDB/collections/text_index_test.go`:
@@ -205,7 +208,14 @@ Coverage:
   - `TestCollectionTextIndexMetadataValidateAndReopen`
   - `TestCollectionTextIndexMetadataRejectsInvalidDefinitions`
   - `TestCollectionTextRootNames`
+  - `TestCollectionTextRootStoragePolicies`
   - `TestCollectionTextIndexedOperationsFailClosedUntilStorageLands`
+- `TreeDB/collections/text_storage_test.go`:
+  - `TestTextStorageCodecsRoundTripAndFailClosed`
+  - `TestCollectionCreateTextIndexBackfillsReopensAndReportsStorage`
+  - `TestCollectionDropTextIndexClearsMetadataRootsAndWriteGuard`
+  - `TestTextIndexStorageStatsFailsClosedOnMalformedRoot`
+  - `BenchmarkCreateTextIndexBackfill`
 
 ## 11.5 Planned User-Command WAL Durability Gate
 


### PR DESCRIPTION
## Objective

Land the #1764 PR2 M2 storage/backfill/catalog slice for collection-native text search, building on merged PR1.

Base updated: merged latest `origin/main` / `db208164605ef7d2382d028a41e753dd4c87cc1f` into this branch. PR diff against `origin/main` is limited to the text-search M2 files plus the collection write-entry coordination hooks; it does not revert or absorb unrelated #2503/#2504/#2524/#2521 changes.

## Scope

Implemented:

- Versioned binary encodings for text postings, per-document text-state, and text-stats roots.
- `ErrTextIndexStorageCorrupt` fail-closed decode behavior for malformed/unsupported storage versions.
- `CreateTextIndex` schema barrier: drains buffered writes from all registered collection managers/write domains for the collection, scans existing documents, backfills text roots, and publishes roots + metadata atomically.
- `DropTextIndex`: removes metadata and clears `text-index`, `text-state`, and `text-stats` root descriptors under the same schema barrier.
- `TextIndexStorageStats`: storage validation/accounting helper for tests and diagnostics.
- Stale handles cannot bypass text-index write guards after another handle creates a text index.
- Docs/spec and verification matrix updates.

Still intentionally deferred:

- Insert/update/delete text-index mutation maintenance.
- Ranked `SearchText` execution, BM25/BM25F scoring, bounded candidate generation.
- Query-vector syntax, hybrid/gateway/vector integration, and #2502 candidate/fusion APIs.

## Storage Contract

Roots remain the PR1 root names/policies:

- `<collection>/text-index/<indexName>` uses `TextIndexDefinition.StoragePolicy`.
- `<collection>/text-state/<indexName>` uses `CollectionOptions.IndexStateStoragePolicy`.
- `<collection>/text-stats/<indexName>` uses `CollectionOptions.IndexStateStoragePolicy`.

All M2 keys/values are versioned. Malformed or unsupported versions decode to `ErrTextIndexStorageCorrupt` rather than silently producing partial/wrong stats.

## Correctness

Latest head: `8917390ec594ce603d332931c934bf2dc93ca780`.

Tests run:

- `GOWORK=off go test ./TreeDB/collections -run 'TestCollectionDropTextIndexClearsMetadataRootsAndWriteGuard|TestCreateTextIndexFlushesBufferedWritesFromOtherManagers|TestCreateTextIndexRejectsWritesFromStaleHandles|TestText|TestCollectionText' -count=1`
- `GOWORK=off go test ./TreeDB/collections -count=1`
- `GOWORK=off go test ./TreeDB/docs -count=1`
- `git diff --check`

New coverage includes:

- postings/state/stats codec round-trips and corrupt/version fail-closed cases;
- `CreateTextIndex` backfill over existing docs;
- two-manager regression proving acknowledged buffered writes are drained before text backfill snapshot;
- stale pre-CreateTextIndex handles cannot bypass fail-closed write guards;
- stale handles opened before DropTextIndex refresh and stop returning the removed write guard;
- text storage stats/accounting;
- reopen preserves backfilled roots;
- `DropTextIndex` clears metadata/root descriptors and removes the write guard;
- malformed durable root value is reported by storage validation.

## Benchmarks

Successful smoke benchmark command on Apple M3:

```sh
GOWORK=off go test ./TreeDB/collections -run '^$' -bench 'BenchmarkCollectionInsertProvidedID$|BenchmarkCollectionInsertBatchProvidedID$|BenchmarkCollectionInsertWithSecondaryIndexes$|BenchmarkCollectionInsertBatchWithSecondaryIndexes$|BenchmarkCreateTextIndexBackfill$' -benchmem -benchtime=1000x -count=3
```

Backfill median at 1000x:

| Benchmark | median ns/op | ops/sec | docs/backfill | docs/sec | postings/backfill | encoded bytes/backfill | B/op | allocs/op |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| CreateTextIndexBackfill | 3,690,414 | 271.0 | 256 | 69,369 | 2,031 | 101,862 | ~3.13 MiB | ~48,901 |

No-text insert smoke benchmarks also ran in that command; fallback counters stayed at zero.

## Review Status

- Codex/Cod Max: stale-handle P1 fixed in `a61c0d8ec`; cross-manager buffered-writes P1 fixed in `02686a4f2`; stale DropTextIndex P2 fixed in `9aba840b9`; review threads resolved with evidence.
- CodeRabbit/Code Rabbit: latest command completed; status context is passing.
- Copilot/Cop Max: requested on latest mature head; no findings observed yet.
- CI: running on latest head after merging `origin/main` through `db2081646`.

## Risks

- M2 storage encoding is a new pre-alpha on-disk contract; it is explicitly versioned and documented.
- `CreateTextIndex` rejects command-WAL catalog mutation mode until text-index catalog commands exist.
- Text-indexed writes and ranked search remain fail-closed until M3/M4.
