### PR TITLE
Use buffered TreeDB column graph demo searches

### DIFF
--- a/benchmarks/vector_db_compare/README.md
+++ b/benchmarks/vector_db_compare/README.md
@@ -61,7 +61,11 @@ scripts/bench_vector_db_compare.sh
 
 The quantized comparison leaves TreeDB quantized recall as an observation by
 setting `TREEDB_QUANTIZED_MIN_RECALL=0`; full-vector TreeDB/pgvector rows still
-use `MIN_RECALL` (default `0.95`) as their recall gate.
+use `MIN_RECALL` (default `0.95`) as their recall gate. TreeDB `column_graph`
+search timings are no-document buffered rows: they return IDs/scores, exclude
+document fetch/materialization, and expose guardrail counters such as
+`avg_response_owned_result_allocs`, `avg_documents_fetched`, and route/fallback
+averages in the demo JSON.
 
 Backends:
 

--- a/benchmarks/vector_db_compare/summarize.py
+++ b/benchmarks/vector_db_compare/summarize.py
@@ -233,6 +233,49 @@ def render(results: list[dict[str, Any]]) -> str:
                 )
             )
         lines.append("")
+    guardrail_fields = [
+        "avg_documents_fetched",
+        "avg_response_owned_result_allocs",
+        "avg_search_route_hnsw_search_pack",
+        "avg_search_route_quantized_only",
+        "avg_search_route_quantized_rerank",
+        "avg_search_route_column_graph_prepared",
+        "avg_search_route_column_graph_fallback",
+        "avg_graph_row_fallbacks",
+        "avg_typed_column_fallbacks",
+        "avg_vector_scratch_decodes",
+    ]
+    guardrail_rows = [
+        (result, row)
+        for result in results
+        if str(result.get("backend") or "treedb").startswith("treedb")
+        for row in result.get("search_benchmarks", [])
+        if any(field in row for field in guardrail_fields)
+    ]
+    if guardrail_rows:
+        lines.append("## TreeDB Search Guardrails")
+        lines.append("")
+        lines.append("| Backend | Search mode | Concurrency | Avg docs fetched | Avg response-owned allocs | Route hnsw_pack | Route qonly | Route qrerank | Route prepared | Route fallback | Graph fallbacks | Typed-column fallbacks | Vector scratch decodes |")
+        lines.append("| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |")
+        for result, row in guardrail_rows:
+            lines.append(
+                "| {backend} | {mode} | {concurrency} | {docs:.1f} | {owned:.1f} | {hnsw:.1f} | {qonly:.1f} | {qrerank:.1f} | {prepared:.1f} | {fallback:.1f} | {graph:.1f} | {typed:.1f} | {scratch:.1f} |".format(
+                    backend=backend_name(result),
+                    mode=search_row_mode(result, row),
+                    concurrency=row["concurrency"],
+                    docs=float(row.get("avg_documents_fetched", 0)),
+                    owned=float(row.get("avg_response_owned_result_allocs", 0)),
+                    hnsw=float(row.get("avg_search_route_hnsw_search_pack", 0)),
+                    qonly=float(row.get("avg_search_route_quantized_only", 0)),
+                    qrerank=float(row.get("avg_search_route_quantized_rerank", 0)),
+                    prepared=float(row.get("avg_search_route_column_graph_prepared", 0)),
+                    fallback=float(row.get("avg_search_route_column_graph_fallback", 0)),
+                    graph=float(row.get("avg_graph_row_fallbacks", 0)),
+                    typed=float(row.get("avg_typed_column_fallbacks", 0)),
+                    scratch=float(row.get("avg_vector_scratch_decodes", 0)),
+                )
+            )
+        lines.append("")
     lines.append("## Notes")
     lines.append("")
     lines.append("- sqlite-vec is intentionally not used here because upstream sqlite-vec is brute-force today; ANN support is tracked as future work.")

--- a/benchmarks/vector_db_compare/test_summarize.py
+++ b/benchmarks/vector_db_compare/test_summarize.py
@@ -33,6 +33,16 @@ def result(backend: str, query_mode: str = "") -> dict:
         "avg_quantized_rerank_exact_score_calls": 0,
         "avg_vector_bytes": 128,
         "avg_norm_bytes": 32,
+        "avg_documents_fetched": 0,
+        "avg_response_owned_result_allocs": 0,
+        "avg_search_route_hnsw_search_pack": 1,
+        "avg_search_route_quantized_only": 0,
+        "avg_search_route_quantized_rerank": 0,
+        "avg_search_route_column_graph_prepared": 0,
+        "avg_search_route_column_graph_fallback": 0,
+        "avg_graph_row_fallbacks": 0,
+        "avg_typed_column_fallbacks": 0,
+        "avg_vector_scratch_decodes": 0,
     }
     if query_mode == "quantized_only":
         row.update(
@@ -41,6 +51,8 @@ def result(backend: str, query_mode: str = "") -> dict:
                 "avg_quantized_code_bytes": 5120,
                 "avg_vector_bytes": 0,
                 "avg_norm_bytes": 0,
+                "avg_search_route_hnsw_search_pack": 0,
+                "avg_search_route_quantized_only": 1,
             }
         )
     if query_mode == "quantized_rerank":
@@ -50,6 +62,8 @@ def result(backend: str, query_mode: str = "") -> dict:
                 "avg_quantized_code_bytes": 5120,
                 "avg_quantized_rerank_candidates": 16,
                 "avg_quantized_rerank_exact_score_calls": 16,
+                "avg_search_route_hnsw_search_pack": 0,
+                "avg_search_route_quantized_rerank": 1,
             }
         )
     return {
@@ -92,6 +106,10 @@ class SummaryRenderTests(unittest.TestCase):
         self.assertIn("## TreeDB Search Counters", rendered)
         self.assertIn("| TreeDB column-store graph HNSW | quantized_only | 1 | 32.0 | 40.0 | 5120.0 | 0.0 | 0.0 | 0.0 | 0.0 |", rendered)
         self.assertIn("| TreeDB column-store graph HNSW | quantized_rerank | 1 | 32.0 | 40.0 | 5120.0 | 16.0 | 16.0 | 128.0 | 32.0 |", rendered)
+        self.assertIn("## TreeDB Search Guardrails", rendered)
+        self.assertIn("| TreeDB column-store graph HNSW | exact/default | 1 | 0.0 | 0.0 | 1.0 | 0.0 | 0.0 |", rendered)
+        self.assertIn("| TreeDB column-store graph HNSW | quantized_only | 1 | 0.0 | 0.0 | 0.0 | 1.0 | 0.0 |", rendered)
+        self.assertIn("| TreeDB column-store graph HNSW | quantized_rerank | 1 | 0.0 | 0.0 | 0.0 | 0.0 | 1.0 |", rendered)
         self.assertIn("PostgreSQL+pgvector is not quantized", rendered)
 
 

--- a/cmd/treedb_vector_search_demo/README.md
+++ b/cmd/treedb_vector_search_demo/README.md
@@ -21,10 +21,14 @@ Each case:
 
 The benchmark search phase is a no-document ANN/search-throughput boundary:
 serial and parallel search metrics return IDs/scores and do not time final
-document fetch, reconstruction, projection, or serialization. Document reads in
-validation are correctness checks, not the preferred vector response-shape
-evidence; use `ProjectionOrientedVectorDocumentFetchPreset` in collection/vector
-APIs when timing projected documents without embeddings.
+document fetch, reconstruction, projection, or serialization. For
+`column_graph` rows, the timed search loop uses caller-owned reusable result
+buffers and excludes response-owned convenience allocation. Native-runtime rows
+remain on the native-runtime benchmark path and should not be read as buffered
+zero-allocation evidence. Document reads in validation are correctness checks,
+not the preferred vector response-shape evidence; use
+`ProjectionOrientedVectorDocumentFetchPreset` in collection/vector APIs when
+timing projected documents without embeddings.
 
 For `-vector-index-strategy column_graph`, the demo can also select explicit
 TreeDB query modes with `-vector-query-mode exact|quantized_only|quantized_rerank`.
@@ -32,7 +36,11 @@ Quantized modes declare a named `scalar_u8` score plane on the TreeDB vector
 index, build it during `RebuildVectorIndex`, validate recall against exact
 full-vector ground truth, and report per-search quantized counters. They do not
 change exact/default behavior and do not affect PostgreSQL+pgvector comparator
-semantics in the external harness.
+semantics in the external harness. The `column_graph` JSON/text search rows
+also report no-document guardrail counters such as `avg_documents_fetched`,
+`avg_response_owned_result_allocs`, and route/fallback averages so profile runs
+can distinguish buffered search-loop cost from response-owned convenience or
+document-materialization paths.
 
 `CompactStorageFull` is intentionally used instead of manually chaining
 maintenance calls. It is TreeDB's canonical full storage compaction path:

--- a/cmd/treedb_vector_search_demo/main.go
+++ b/cmd/treedb_vector_search_demo/main.go
@@ -200,8 +200,42 @@ type searchBenchmarkResult struct {
 	AvgNormBytes                      float64                          `json:"avg_norm_bytes"`
 	AvgPreparedScoreCalls             float64                          `json:"avg_prepared_score_calls"`
 	AvgScoreBatchCandidates           float64                          `json:"avg_score_batch_candidates"`
+	AvgDocumentsFetched               *float64                         `json:"avg_documents_fetched,omitempty"`
+	AvgResponseOwnedResultAllocs      *float64                         `json:"avg_response_owned_result_allocs,omitempty"`
+	AvgSearchRouteHNSWSearchPack      *float64                         `json:"avg_search_route_hnsw_search_pack,omitempty"`
+	AvgSearchRouteQuantizedOnly       *float64                         `json:"avg_search_route_quantized_only,omitempty"`
+	AvgSearchRouteQuantizedRerank     *float64                         `json:"avg_search_route_quantized_rerank,omitempty"`
+	AvgSearchRouteColumnGraphPrepared *float64                         `json:"avg_search_route_column_graph_prepared,omitempty"`
+	AvgSearchRouteColumnGraphFallback *float64                         `json:"avg_search_route_column_graph_fallback,omitempty"`
+	AvgGraphRowFallbacks              *float64                         `json:"avg_graph_row_fallbacks,omitempty"`
+	AvgTypedColumnFallbacks           *float64                         `json:"avg_typed_column_fallbacks,omitempty"`
+	AvgVectorScratchDecodes           *float64                         `json:"avg_vector_scratch_decodes,omitempty"`
 	ExactFallbacks                    int                              `json:"exact_fallbacks"`
 	DisableExactFallback              bool                             `json:"disable_exact_fallback"`
+}
+
+func float64Ptr(value float64) *float64 {
+	return &value
+}
+
+func float64Value(value *float64) float64 {
+	if value == nil {
+		return 0
+	}
+	return *value
+}
+
+func searchBenchmarkHasGuardrailMetrics(bench searchBenchmarkResult) bool {
+	return bench.AvgDocumentsFetched != nil ||
+		bench.AvgResponseOwnedResultAllocs != nil ||
+		bench.AvgSearchRouteHNSWSearchPack != nil ||
+		bench.AvgSearchRouteQuantizedOnly != nil ||
+		bench.AvgSearchRouteQuantizedRerank != nil ||
+		bench.AvgSearchRouteColumnGraphPrepared != nil ||
+		bench.AvgSearchRouteColumnGraphFallback != nil ||
+		bench.AvgGraphRowFallbacks != nil ||
+		bench.AvgTypedColumnFallbacks != nil ||
+		bench.AvgVectorScratchDecodes != nil
 }
 
 type storageReport struct {
@@ -2093,6 +2127,7 @@ func benchmarkColumnGraphSearchLoadedConcurrent(col *collections.Collection, ind
 			_ = searcher.Close()
 		}
 	}()
+	buffers := make([]collections.VectorIndexSearchBuffer, concurrency)
 
 	latencies := make([]int64, len(queries))
 	var next atomic.Int64
@@ -2105,6 +2140,16 @@ func benchmarkColumnGraphSearchLoadedConcurrent(col *collections.Collection, ind
 	var normBytesTotal uint64
 	var preparedScoreCallsTotal uint64
 	var scoreBatchCandidatesTotal uint64
+	var documentsFetchedTotal uint64
+	var responseOwnedResultAllocsTotal uint64
+	var searchRouteHNSWSearchPackTotal uint64
+	var searchRouteQuantizedOnlyTotal uint64
+	var searchRouteQuantizedRerankTotal uint64
+	var searchRouteColumnGraphPreparedTotal uint64
+	var searchRouteColumnGraphFallbackTotal uint64
+	var graphRowFallbacksTotal uint64
+	var typedColumnFallbacksTotal uint64
+	var vectorScratchDecodesTotal uint64
 	var errMu sync.Mutex
 	var firstErr error
 	setErr := func(err error) {
@@ -2114,14 +2159,14 @@ func benchmarkColumnGraphSearchLoadedConcurrent(col *collections.Collection, ind
 			firstErr = err
 		}
 	}
-	worker := func(searcher *collections.VectorIndexSearcher) {
+	worker := func(searcher *collections.VectorIndexSearcher, buffer *collections.VectorIndexSearchBuffer) {
 		for {
 			i := int(next.Add(1) - 1)
 			if i >= len(queries) {
 				return
 			}
 			start := time.Now()
-			response, err := searcher.Search(columnGraphSearchOptions(queries[i], cfg))
+			response, err := searcher.SearchWithBuffer(columnGraphSearchOptions(queries[i], cfg), buffer)
 			if err != nil {
 				setErr(err)
 				return
@@ -2144,6 +2189,16 @@ func benchmarkColumnGraphSearchLoadedConcurrent(col *collections.Collection, ind
 			atomic.AddUint64(&normBytesTotal, response.Stats.NormBytesRead)
 			atomic.AddUint64(&preparedScoreCallsTotal, response.Stats.PreparedScoreCalls)
 			atomic.AddUint64(&scoreBatchCandidatesTotal, response.Stats.ScoreBatchCandidates)
+			atomic.AddUint64(&documentsFetchedTotal, response.Stats.DocumentsFetched)
+			atomic.AddUint64(&responseOwnedResultAllocsTotal, response.Stats.ResponseOwnedResultAllocs)
+			atomic.AddUint64(&searchRouteHNSWSearchPackTotal, response.Stats.SearchRouteHNSWSearchPack)
+			atomic.AddUint64(&searchRouteQuantizedOnlyTotal, response.Stats.SearchRouteQuantizedOnly)
+			atomic.AddUint64(&searchRouteQuantizedRerankTotal, response.Stats.SearchRouteQuantizedRerank)
+			atomic.AddUint64(&searchRouteColumnGraphPreparedTotal, response.Stats.SearchRouteColumnGraphPrepared)
+			atomic.AddUint64(&searchRouteColumnGraphFallbackTotal, response.Stats.SearchRouteColumnGraphFallback)
+			atomic.AddUint64(&graphRowFallbacksTotal, response.Stats.GraphRowFallbacks)
+			atomic.AddUint64(&typedColumnFallbacksTotal, response.Stats.TypedColumnFallbacks)
+			atomic.AddUint64(&vectorScratchDecodesTotal, response.Stats.VectorScratchDecodes)
 		}
 	}
 	stopProfile, err := startColumnGraphSearchProfile(cfg, concurrency)
@@ -2152,15 +2207,16 @@ func benchmarkColumnGraphSearchLoadedConcurrent(col *collections.Collection, ind
 	}
 	startAll := time.Now()
 	if concurrency == 1 {
-		worker(searchers[0])
+		worker(searchers[0], &buffers[0])
 	} else {
 		var wg sync.WaitGroup
 		wg.Add(concurrency)
 		for i := 0; i < concurrency; i++ {
 			searcher := searchers[i]
+			buffer := &buffers[i]
 			go func() {
 				defer wg.Done()
-				worker(searcher)
+				worker(searcher, buffer)
 			}()
 		}
 		wg.Wait()
@@ -2209,6 +2265,16 @@ func benchmarkColumnGraphSearchLoadedConcurrent(col *collections.Collection, ind
 		AvgNormBytes:                      float64(normBytesTotal) / queryCount,
 		AvgPreparedScoreCalls:             float64(preparedScoreCallsTotal) / queryCount,
 		AvgScoreBatchCandidates:           float64(scoreBatchCandidatesTotal) / queryCount,
+		AvgDocumentsFetched:               float64Ptr(float64(documentsFetchedTotal) / queryCount),
+		AvgResponseOwnedResultAllocs:      float64Ptr(float64(responseOwnedResultAllocsTotal) / queryCount),
+		AvgSearchRouteHNSWSearchPack:      float64Ptr(float64(searchRouteHNSWSearchPackTotal) / queryCount),
+		AvgSearchRouteQuantizedOnly:       float64Ptr(float64(searchRouteQuantizedOnlyTotal) / queryCount),
+		AvgSearchRouteQuantizedRerank:     float64Ptr(float64(searchRouteQuantizedRerankTotal) / queryCount),
+		AvgSearchRouteColumnGraphPrepared: float64Ptr(float64(searchRouteColumnGraphPreparedTotal) / queryCount),
+		AvgSearchRouteColumnGraphFallback: float64Ptr(float64(searchRouteColumnGraphFallbackTotal) / queryCount),
+		AvgGraphRowFallbacks:              float64Ptr(float64(graphRowFallbacksTotal) / queryCount),
+		AvgTypedColumnFallbacks:           float64Ptr(float64(typedColumnFallbacksTotal) / queryCount),
+		AvgVectorScratchDecodes:           float64Ptr(float64(vectorScratchDecodesTotal) / queryCount),
 		ExactFallbacks:                    0,
 		DisableExactFallback:              cfg.disableExactFallback,
 	}, nil
@@ -2581,6 +2647,19 @@ func printText(w io.Writer, res result) {
 		res.Search.AvgQuantizedRerankExactScoreCalls,
 		res.Search.AvgVectorBytes,
 		res.Search.AvgNormBytes)
+	if searchBenchmarkHasGuardrailMetrics(res.Search) {
+		fmt.Fprintf(w, "avg_documents_fetched=%.1f avg_response_owned_result_allocs=%.1f avg_route_hnsw_search_pack=%.1f avg_route_quantized_only=%.1f avg_route_quantized_rerank=%.1f avg_route_column_graph_prepared=%.1f avg_route_column_graph_fallback=%.1f avg_graph_row_fallbacks=%.1f avg_typed_column_fallbacks=%.1f avg_vector_scratch_decodes=%.1f\n",
+			float64Value(res.Search.AvgDocumentsFetched),
+			float64Value(res.Search.AvgResponseOwnedResultAllocs),
+			float64Value(res.Search.AvgSearchRouteHNSWSearchPack),
+			float64Value(res.Search.AvgSearchRouteQuantizedOnly),
+			float64Value(res.Search.AvgSearchRouteQuantizedRerank),
+			float64Value(res.Search.AvgSearchRouteColumnGraphPrepared),
+			float64Value(res.Search.AvgSearchRouteColumnGraphFallback),
+			float64Value(res.Search.AvgGraphRowFallbacks),
+			float64Value(res.Search.AvgTypedColumnFallbacks),
+			float64Value(res.Search.AvgVectorScratchDecodes))
+	}
 	fmt.Fprintf(w, "\nParallel Search Benchmark\n")
 	printSearchBenchmarks(w, res.SearchBenchmarks)
 	fmt.Fprintf(w, "\nStorage\n")
@@ -2683,7 +2762,7 @@ func resultQueryMode(res result) collections.VectorIndexQueryMode {
 
 func printSearchBenchmarks(w io.Writer, benchmarks []searchBenchmarkResult) {
 	for _, bench := range benchmarks {
-		fmt.Fprintf(w, "search concurrency=%d queries=%d query_mode=%s avg=%.2fus p50=%.2fus p95=%.2fus p99=%.2fus ops/sec=%.1f exact_fallbacks=%d avg_candidates=%.1f avg_quantized_score_calls=%.1f avg_quantized_code_bytes=%.1f avg_quantized_rerank_candidates=%.1f avg_quantized_rerank_exact_score_calls=%.1f avg_vector_bytes=%.1f avg_norm_bytes=%.1f\n",
+		fmt.Fprintf(w, "search concurrency=%d queries=%d query_mode=%s avg=%.2fus p50=%.2fus p95=%.2fus p99=%.2fus ops/sec=%.1f exact_fallbacks=%d avg_candidates=%.1f avg_quantized_score_calls=%.1f avg_quantized_code_bytes=%.1f avg_quantized_rerank_candidates=%.1f avg_quantized_rerank_exact_score_calls=%.1f avg_vector_bytes=%.1f avg_norm_bytes=%.1f",
 			bench.Concurrency,
 			bench.Queries,
 			bench.QueryMode,
@@ -2700,6 +2779,20 @@ func printSearchBenchmarks(w io.Writer, benchmarks []searchBenchmarkResult) {
 			bench.AvgQuantizedRerankExactScoreCalls,
 			bench.AvgVectorBytes,
 			bench.AvgNormBytes)
+		if searchBenchmarkHasGuardrailMetrics(bench) {
+			fmt.Fprintf(w, " avg_documents_fetched=%.1f avg_response_owned_result_allocs=%.1f avg_route_hnsw_search_pack=%.1f avg_route_quantized_only=%.1f avg_route_quantized_rerank=%.1f avg_route_column_graph_prepared=%.1f avg_route_column_graph_fallback=%.1f avg_graph_row_fallbacks=%.1f avg_typed_column_fallbacks=%.1f avg_vector_scratch_decodes=%.1f",
+				float64Value(bench.AvgDocumentsFetched),
+				float64Value(bench.AvgResponseOwnedResultAllocs),
+				float64Value(bench.AvgSearchRouteHNSWSearchPack),
+				float64Value(bench.AvgSearchRouteQuantizedOnly),
+				float64Value(bench.AvgSearchRouteQuantizedRerank),
+				float64Value(bench.AvgSearchRouteColumnGraphPrepared),
+				float64Value(bench.AvgSearchRouteColumnGraphFallback),
+				float64Value(bench.AvgGraphRowFallbacks),
+				float64Value(bench.AvgTypedColumnFallbacks),
+				float64Value(bench.AvgVectorScratchDecodes))
+		}
+		fmt.Fprintln(w)
 	}
 }
 

--- a/cmd/treedb_vector_search_demo/main_test.go
+++ b/cmd/treedb_vector_search_demo/main_test.go
@@ -18,6 +18,14 @@ import (
 	"github.com/snissn/gomap/TreeDB/collections"
 )
 
+func requireFloat64Metric(t *testing.T, value *float64, name string) float64 {
+	t.Helper()
+	if value == nil {
+		t.Fatalf("missing %s metric", name)
+	}
+	return *value
+}
+
 func TestExecuteSmokeCompactsReopensValidatesAndBenchmarks(t *testing.T) {
 	res, err := execute(context.Background(), config{
 		dir:                   t.TempDir(),
@@ -382,6 +390,20 @@ func TestExecuteColumnGraphSearchPath(t *testing.T) {
 	if res.Search.Queries != 4 || res.Search.ExactFallbacks != 0 {
 		t.Fatalf("unexpected column_graph search result: %+v", res.Search)
 	}
+	if requireFloat64Metric(t, res.Search.AvgResponseOwnedResultAllocs, "avg_response_owned_result_allocs") != 0 || requireFloat64Metric(t, res.Search.AvgDocumentsFetched, "avg_documents_fetched") != 0 {
+		t.Fatalf("column_graph benchmark should use no-doc buffered results: %+v", res.Search)
+	}
+	if requireFloat64Metric(t, res.Search.AvgSearchRouteHNSWSearchPack, "avg_search_route_hnsw_search_pack") != 1 || requireFloat64Metric(t, res.Search.AvgSearchRouteQuantizedOnly, "avg_search_route_quantized_only") != 0 || requireFloat64Metric(t, res.Search.AvgSearchRouteQuantizedRerank, "avg_search_route_quantized_rerank") != 0 {
+		t.Fatalf("unexpected exact column_graph route counters: %+v", res.Search)
+	}
+	if requireFloat64Metric(t, res.Search.AvgGraphRowFallbacks, "avg_graph_row_fallbacks") != 0 || requireFloat64Metric(t, res.Search.AvgTypedColumnFallbacks, "avg_typed_column_fallbacks") != 0 || requireFloat64Metric(t, res.Search.AvgVectorScratchDecodes, "avg_vector_scratch_decodes") != 0 {
+		t.Fatalf("unexpected exact column_graph fallback counters: %+v", res.Search)
+	}
+	var out bytes.Buffer
+	printText(&out, res)
+	if !strings.Contains(out.String(), "avg_response_owned_result_allocs=0.0") {
+		t.Fatalf("column_graph text output missing buffered guardrails:\n%s", out.String())
+	}
 }
 
 func TestExecuteColumnGraphQuantizedModes(t *testing.T) {
@@ -402,6 +424,12 @@ func TestExecuteColumnGraphQuantizedModes(t *testing.T) {
 				if res.Search.AvgQuantizedRerankCandidates != 0 || res.Search.AvgQuantizedRerankExactScoreCalls != 0 {
 					t.Fatalf("quantized_only unexpectedly reranked: %+v", res.Search)
 				}
+				if res.Search.AvgVectorBytes != 0 || res.Search.AvgNormBytes != 0 {
+					t.Fatalf("quantized_only unexpectedly read exact vectors/norms: %+v", res.Search)
+				}
+				if requireFloat64Metric(t, res.Search.AvgSearchRouteQuantizedOnly, "avg_search_route_quantized_only") != 1 || requireFloat64Metric(t, res.Search.AvgSearchRouteQuantizedRerank, "avg_search_route_quantized_rerank") != 0 || requireFloat64Metric(t, res.Search.AvgSearchRouteHNSWSearchPack, "avg_search_route_hnsw_search_pack") != 0 {
+					t.Fatalf("quantized_only route counters not isolated: %+v", res.Search)
+				}
 			},
 		},
 		{
@@ -416,8 +444,19 @@ func TestExecuteColumnGraphQuantizedModes(t *testing.T) {
 				if res.Search.AvgQuantizedRerankCandidates <= 0 || res.Search.AvgQuantizedRerankExactScoreCalls <= 0 {
 					t.Fatalf("quantized_rerank stats missing exact rerank: %+v", res.Search)
 				}
+				if res.Search.AvgQuantizedRerankExactScoreCalls > float64(res.QuantizedRerankCandidates) {
+					t.Fatalf("quantized_rerank exact score calls exceeded limit: %+v", res.Search)
+				}
 				if res.Search.AvgVectorBytes <= 0 || res.Search.AvgNormBytes <= 0 {
 					t.Fatalf("quantized_rerank stats missing exact vector/norm reads: %+v", res.Search)
+				}
+				maxVectorBytes := float64(res.QuantizedRerankCandidates * res.Dimensions * 4)
+				maxNormBytes := float64(res.QuantizedRerankCandidates * 4)
+				if res.Search.AvgVectorBytes > maxVectorBytes || res.Search.AvgNormBytes > maxNormBytes {
+					t.Fatalf("quantized_rerank exact reads exceeded rerank bound: %+v", res.Search)
+				}
+				if requireFloat64Metric(t, res.Search.AvgSearchRouteQuantizedOnly, "avg_search_route_quantized_only") != 0 || requireFloat64Metric(t, res.Search.AvgSearchRouteQuantizedRerank, "avg_search_route_quantized_rerank") != 1 || requireFloat64Metric(t, res.Search.AvgSearchRouteHNSWSearchPack, "avg_search_route_hnsw_search_pack") != 0 {
+					t.Fatalf("quantized_rerank route counters not isolated: %+v", res.Search)
 				}
 			},
 		},
@@ -460,6 +499,12 @@ func TestExecuteColumnGraphQuantizedModes(t *testing.T) {
 			}
 			if len(res.SearchBenchmarks) != 2 || res.SearchBenchmarks[0].QueryMode != tc.mode || res.SearchBenchmarks[1].QueryMode != tc.mode {
 				t.Fatalf("search benchmark modes not threaded: %+v", res.SearchBenchmarks)
+			}
+			if requireFloat64Metric(t, res.Search.AvgResponseOwnedResultAllocs, "avg_response_owned_result_allocs") != 0 || requireFloat64Metric(t, res.Search.AvgDocumentsFetched, "avg_documents_fetched") != 0 {
+				t.Fatalf("quantized benchmark should use no-doc buffered results: %+v", res.Search)
+			}
+			if requireFloat64Metric(t, res.Search.AvgGraphRowFallbacks, "avg_graph_row_fallbacks") != 0 || requireFloat64Metric(t, res.Search.AvgTypedColumnFallbacks, "avg_typed_column_fallbacks") != 0 || requireFloat64Metric(t, res.Search.AvgVectorScratchDecodes, "avg_vector_scratch_decodes") != 0 {
+				t.Fatalf("unexpected quantized fallback counters: %+v", res.Search)
 			}
 			tc.assertStats(t, res)
 		})


### PR DESCRIPTION
## Summary

Closes #2518.

- Switches the `cmd/treedb_vector_search_demo` TreeDB `column_graph` timed search loop to `VectorIndexSearcher.SearchWithBuffer` with one reusable `VectorIndexSearchBuffer` per worker.
- Adds column-graph-only guardrail metrics for no-doc benchmark rows: documents fetched, response-owned result allocs, route counters, fallback counters, and scratch vector decodes.
- Keeps metrics omitted for non-column-graph/native rows so comparator output does not imply zero-allocation evidence where it was not measured.
- Updates vector DB comparison summarization and READMEs to label TreeDB column-graph rows as buffered no-doc rows; with-document/materialization costs are not hidden.

## Scope / non-goals

- Demo/benchmark tooling only; no public vector search API semantics changed.
- No with-document rows are relabeled as buffered/no-doc.
- Response-owned convenience search remains available and documented separately from buffered no-doc benchmark rows.

## Tests

Latest local head: `9d42cc4f4be1a21706f0f23a503f0e17a7ca1239`.

- `go test ./cmd/treedb_vector_search_demo`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest benchmarks/vector_db_compare/test_summarize.py`
- `go test ./TreeDB/collections -run 'Vector|ColumnGraph|HNSW|Quantized' -count=1`

## Benchmark / profile evidence

All vector benchmark/profile runs were serialized with `/tmp/gomap_2514_benchmark.lock`.

Primary before/after profile run:

- Artifact root: `/tmp/gomap_2518_buffer_bench_20260606_214831`
- Shape: `10,000 docs x 1,536 dims`, `4,000` timed queries, `c=1,c=8`, `top_k=10`, `ef=128`, exact / qonly / rerank.
- Baseline: `3c4857302`; candidate: `8b9974c15`.

| mode | c | baseline avg µs | candidate avg µs | avg change | baseline QPS | candidate QPS | QPS change | recall | candidate guardrails |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| exact | 1 | 786.3 | 536.1 | -31.8% | 1271.1 | 1864.2 | +46.7% | 0.9906 | docs=0; owned=0; hnsw=1; fallbacks=0 |
| exact | 8 | 2816.8 | 1314.9 | -53.3% | 2830.4 | 6076.3 | +114.7% | 0.9906 | docs=0; owned=0; hnsw=1; fallbacks=0 |
| qonly | 1 | 550.2 | 339.7 | -38.3% | 1816.1 | 2940.8 | +61.9% | 0.8812 | docs=0; owned=0; qonly=1; fallbacks=0 |
| qonly | 8 | 922.5 | 711.3 | -22.9% | 8570.4 | 11158.0 | +30.2% | 0.8812 | docs=0; owned=0; qonly=1; fallbacks=0 |
| rerank | 1 | 333.9 | 299.2 | -10.4% | 2992.8 | 3340.0 | +11.6% | 0.9875 | docs=0; owned=0; qrerank=1; fallbacks=0 |
| rerank | 8 | 877.9 | 704.8 | -19.7% | 8922.0 | 11327.0 | +27.0% | 0.9875 | docs=0; owned=0; qrerank=1; fallbacks=0 |

Focused copy/memclr profile evidence from the same artifact root:

| mode | c | baseline focused copy/memclr | candidate focused copy/memclr |
| --- | ---: | --- | --- |
| exact | 1 | 0.13s, 5.18% of 2.51s total | 0, 0% of 1.87s total |
| exact | 8 | 0.13s, 5.20% of 2.50s total | 0, 0% of 1.81s total |
| qonly | 1 | 0.08s, 5.63% of 1.42s total | 0.01s, 0.84% of 1.19s total |
| qonly | 8 | 0.02s, 1.59% of 1.26s total | 0.01s, 0.82% of 1.22s total |
| rerank | 1 | 0.06s, 5.26% of 1.14s total | 0, 0% of 1.01s total |
| rerank | 8 | 0.01s, 0.93% of 1.07s total | 0.01s, 0.90% of 1.11s total |

Latest-head candidate guardrail spot check after merging current `main`:

- Artifact root: `/tmp/gomap_2518_candidate_latest_9d42_20260606_225109`
- Candidate head: `9d42cc4f4be1a21706f0f23a503f0e17a7ca1239`
- Same shape as above, no profiles.

| mode | c | avg µs | QPS | recall | docs | owned | route | qexact | vector bytes | norm bytes |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | --- | ---: | ---: | ---: |
| exact | 1 | 506.5 | 1973.2 | 0.9906 | 0 | 0 | hnsw=1 | 0 | 4535442.4 | 0.0 |
| exact | 8 | 1331.0 | 6002.4 | 0.9906 | 0 | 0 | hnsw=1 | 0 | 4535442.4 | 0.0 |
| qonly | 1 | 203.6 | 4905.3 | 0.8812 | 0 | 0 | qonly=1 | 0 | 0.0 | 0.0 |
| qonly | 8 | 527.3 | 15028.5 | 0.8812 | 0 | 0 | qonly=1 | 0 | 0.0 | 0.0 |
| rerank | 1 | 198.6 | 5031.2 | 0.9875 | 0 | 0 | qrerank=1 | 32 | 196608.0 | 128.0 |
| rerank | 8 | 646.1 | 12363.5 | 0.9875 | 0 | 0 | qrerank=1 | 32 | 196608.0 | 128.0 |

Guardrail notes: qonly exact reads stay zero; rerank exact score calls stay bounded at configured rerank candidates (`32`); graph/typed fallbacks and scratch decodes were zero in the candidate rows.
