### PR TITLE
TreeDB: reuse RaBitQ query byte tables

### DIFF
--- a/TreeDB/internal/rabitq/rabitq.go
+++ b/TreeDB/internal/rabitq/rabitq.go
@@ -1,6 +1,7 @@
 package rabitq
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"hash/fnv"
@@ -86,6 +87,13 @@ type Workspace struct {
 	work         []float64
 	queryBits    []byte
 	queryWeights []float32
+
+	queryByteMismatchWeights    []float64
+	queryByteMismatchSignBits   []byte
+	queryByteMismatchAbsWeights []float32
+	queryByteMismatchCodeDims   int
+	queryByteMismatchWeightSum  float64
+	queryByteMismatchCacheValid bool
 }
 
 // EncodedVector contains the data-code row and side-array values produced by
@@ -120,14 +128,21 @@ func PrepareQueryByteMismatchWeights(query Query, ws *Workspace) ([]float64, flo
 	if len(query.SignBits) != bytesPerCode {
 		return nil, 0, false
 	}
+	cacheable := ws != nil
 	if ws == nil {
 		ws = &Workspace{}
 	}
 	entries := bytesPerCode * ByteMismatchTableEntries
-	if cap(ws.work) < entries {
-		ws.work = make([]float64, entries)
+	if cacheable && ws.queryByteMismatchCacheMatches(query, bytesPerCode, entries) {
+		return ws.queryByteMismatchWeights, ws.queryByteMismatchWeightSum, true
+	}
+	if cacheable {
+		ws.queryByteMismatchCacheValid = false
+	}
+	if cap(ws.queryByteMismatchWeights) < entries {
+		ws.queryByteMismatchWeights = make([]float64, entries)
 	} else {
-		ws.work = ws.work[:entries]
+		ws.queryByteMismatchWeights = ws.queryByteMismatchWeights[:entries]
 	}
 	var queryWeightSum float64
 	var byteWeights [8]float64
@@ -151,16 +166,63 @@ func PrepareQueryByteMismatchWeights(query Query, ws *Workspace) ([]float64, flo
 			byteWeights[bit] = 0
 		}
 		base := byteIdx * ByteMismatchTableEntries
-		ws.work[base] = 0
+		ws.queryByteMismatchWeights[base] = 0
 		for mask := 1; mask < ByteMismatchTableEntries; mask++ {
 			leastBit := mask & -mask
-			ws.work[base+mask] = ws.work[base+(mask^leastBit)] + byteWeights[bits.TrailingZeros8(uint8(leastBit))]
+			ws.queryByteMismatchWeights[base+mask] = ws.queryByteMismatchWeights[base+(mask^leastBit)] + byteWeights[bits.TrailingZeros8(uint8(leastBit))]
 		}
 	}
 	if queryWeightSum <= 0 || math.IsNaN(queryWeightSum) || math.IsInf(queryWeightSum, 0) {
 		return nil, 0, false
 	}
-	return ws.work, queryWeightSum, true
+	if cacheable {
+		ws.rememberQueryByteMismatchCache(query, queryWeightSum)
+	}
+	return ws.queryByteMismatchWeights, queryWeightSum, true
+}
+
+func (ws *Workspace) queryByteMismatchCacheMatches(query Query, bytesPerCode, entries int) bool {
+	return ws != nil &&
+		ws.queryByteMismatchCacheValid &&
+		ws.queryByteMismatchCodeDims == query.CodeDimensions &&
+		len(ws.queryByteMismatchWeights) == entries &&
+		len(ws.queryByteMismatchSignBits) == bytesPerCode &&
+		len(ws.queryByteMismatchAbsWeights) == query.CodeDimensions &&
+		bytes.Equal(ws.queryByteMismatchSignBits, query.SignBits) &&
+		equalFloat32Slice(ws.queryByteMismatchAbsWeights, query.AbsWeights[:query.CodeDimensions]) &&
+		ws.queryByteMismatchWeightSum > 0 &&
+		!math.IsNaN(ws.queryByteMismatchWeightSum) &&
+		!math.IsInf(ws.queryByteMismatchWeightSum, 0)
+}
+
+func (ws *Workspace) rememberQueryByteMismatchCache(query Query, queryWeightSum float64) {
+	if cap(ws.queryByteMismatchSignBits) < len(query.SignBits) {
+		ws.queryByteMismatchSignBits = make([]byte, len(query.SignBits))
+	} else {
+		ws.queryByteMismatchSignBits = ws.queryByteMismatchSignBits[:len(query.SignBits)]
+	}
+	copy(ws.queryByteMismatchSignBits, query.SignBits)
+	if cap(ws.queryByteMismatchAbsWeights) < query.CodeDimensions {
+		ws.queryByteMismatchAbsWeights = make([]float32, query.CodeDimensions)
+	} else {
+		ws.queryByteMismatchAbsWeights = ws.queryByteMismatchAbsWeights[:query.CodeDimensions]
+	}
+	copy(ws.queryByteMismatchAbsWeights, query.AbsWeights[:query.CodeDimensions])
+	ws.queryByteMismatchCodeDims = query.CodeDimensions
+	ws.queryByteMismatchWeightSum = queryWeightSum
+	ws.queryByteMismatchCacheValid = true
+}
+
+func equalFloat32Slice(a, b []float32) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }
 
 // QueryByteMismatchWeightsValid reports whether weights has the shape returned

--- a/TreeDB/internal/rabitq/rabitq_test.go
+++ b/TreeDB/internal/rabitq/rabitq_test.go
@@ -370,6 +370,85 @@ func TestReferenceKernelsNoAllocAfterWarm2449(t *testing.T) {
 	}
 }
 
+func TestPrepareQueryByteMismatchWeightsCacheRefreshes2519(t *testing.T) {
+	plan, err := NewPlan(1536, DefaultConfig())
+	if err != nil {
+		t.Fatalf("NewPlan: %v", err)
+	}
+	queryVec := rabitqVectorForTest2519(plan.VectorDimensions(), 17)
+	changedQueryVec := rabitqVectorForTest2519(plan.VectorDimensions(), 31)
+
+	var ws Workspace
+	query, err := plan.EncodeQuery(queryVec, &ws)
+	if err != nil {
+		t.Fatalf("EncodeQuery: %v", err)
+	}
+	tables, weightSum, ok := PrepareQueryByteMismatchWeights(query, &ws)
+	if !ok {
+		t.Fatal("PrepareQueryByteMismatchWeights initial failed")
+	}
+	if !ws.queryByteMismatchCacheValid || ws.queryByteMismatchCodeDims != plan.CodeDimensions() || len(ws.queryByteMismatchWeights) != len(tables) || weightSum <= 0 {
+		t.Fatalf("cache not populated: valid=%v codeDims=%d table=%d weightSum=%v", ws.queryByteMismatchCacheValid, ws.queryByteMismatchCodeDims, len(ws.queryByteMismatchWeights), weightSum)
+	}
+	firstTable := tables
+	firstTableCopy := append([]float64(nil), tables...)
+	firstWeightSum := weightSum
+
+	queryAgain, err := plan.EncodeQuery(queryVec, &ws)
+	if err != nil {
+		t.Fatalf("EncodeQuery again: %v", err)
+	}
+	tablesAgain, weightSumAgain, ok := PrepareQueryByteMismatchWeights(queryAgain, &ws)
+	if !ok {
+		t.Fatal("PrepareQueryByteMismatchWeights cached failed")
+	}
+	if len(firstTable) == 0 || len(tablesAgain) == 0 || &firstTable[0] != &tablesAgain[0] || weightSumAgain != firstWeightSum {
+		t.Fatalf("cache miss for repeated query: first_ptr=%p again_ptr=%p first_sum=%v again_sum=%v", &firstTable[0], &tablesAgain[0], firstWeightSum, weightSumAgain)
+	}
+
+	badQuery := queryAgain
+	badQuery.AbsWeights = append([]float32(nil), queryAgain.AbsWeights...)
+	badQuery.AbsWeights[9] = -1
+	if _, _, ok := PrepareQueryByteMismatchWeights(badQuery, &ws); ok {
+		t.Fatal("PrepareQueryByteMismatchWeights bad query unexpectedly succeeded")
+	}
+	if ws.queryByteMismatchCacheValid {
+		t.Fatal("failed prepare left byte-table cache marked valid")
+	}
+	queryAfterFailure, err := plan.EncodeQuery(queryVec, &ws)
+	if err != nil {
+		t.Fatalf("EncodeQuery after failure: %v", err)
+	}
+	tablesAfterFailure, weightSumAfterFailure, ok := PrepareQueryByteMismatchWeights(queryAfterFailure, &ws)
+	if !ok {
+		t.Fatal("PrepareQueryByteMismatchWeights after failed prepare failed")
+	}
+	if weightSumAfterFailure != firstWeightSum || !equalFloat64Slice(tablesAfterFailure, firstTableCopy) {
+		t.Fatalf("cache rebuild after failed prepare mismatch: got_sum=%v want_sum=%v", weightSumAfterFailure, firstWeightSum)
+	}
+
+	changedQuery, err := plan.EncodeQuery(changedQueryVec, &ws)
+	if err != nil {
+		t.Fatalf("EncodeQuery changed: %v", err)
+	}
+	changedTables, changedWeightSum, ok := PrepareQueryByteMismatchWeights(changedQuery, &ws)
+	if !ok {
+		t.Fatal("PrepareQueryByteMismatchWeights changed failed")
+	}
+	var independentWS Workspace
+	independentQuery, err := plan.EncodeQuery(changedQueryVec, &independentWS)
+	if err != nil {
+		t.Fatalf("EncodeQuery independent changed: %v", err)
+	}
+	wantTables, wantWeightSum, ok := PrepareQueryByteMismatchWeights(independentQuery, &independentWS)
+	if !ok {
+		t.Fatal("PrepareQueryByteMismatchWeights independent changed failed")
+	}
+	if changedWeightSum != wantWeightSum || !equalFloat64Slice(changedTables, wantTables) {
+		t.Fatalf("changed query cache refresh mismatch: got_sum=%v want_sum=%v", changedWeightSum, wantWeightSum)
+	}
+}
+
 func BenchmarkReferenceScoreCosine2449(b *testing.B) {
 	plan, err := NewPlan(128, DefaultConfig())
 	if err != nil {
@@ -402,6 +481,30 @@ func BenchmarkReferenceScoreCosine2449(b *testing.B) {
 		score += s
 	}
 	rabitqScoreSink += score
+}
+
+func rabitqVectorForTest2519(dims int, seed uint64) []float32 {
+	v := make([]float32, dims)
+	for i := range v {
+		x := math.Sin(float64((i+1)*int(seed+3))*0.731) + 0.5*math.Cos(float64((i+5)*int(seed+11))*0.173)
+		if x == 0 {
+			x = float64(i+1) * 0.001
+		}
+		v[i] = float32(x)
+	}
+	return v
+}
+
+func equalFloat64Slice(a, b []float64) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func exactCosineForTest2449(a, b []float32) float64 {


### PR DESCRIPTION
## Summary

Closes #2519.

- Reuses RaBitQ `rabitq_1bit` query byte-mismatch tables across repeated searches that use the same caller-owned workspace/query.
- Keeps the v1 codec identity, storage schema, bit ordering, score formula, and fail-closed behavior unchanged.
- Adds cache-hit/cache-refresh tests, including failed-prepare invalidation so a bad query cannot leave a partially rebuilt table marked valid.

## Scope boundary

RaBitQ query-table preparation only. This PR does **not** change persisted bytes, codec config/version/name, packed-code bit order, scoring formula, rerank limits, exact fallback behavior, benchmark harness shape handling, or demo behavior.

Base: `main` after #2521 and #2523 (`e9830fdc70471f083ff483740287d6743f96b08b`). Latest local head: `f6ab3eb752a0bce63e6c705bd6f9d70fba1b16f4`.

## Tests

- `GOWORK=off go test ./TreeDB/internal/rabitq -count=1`
- `GOWORK=off go test ./TreeDB/collections -run 'RabitQ|Quantized|VectorIndexSearch' -count=1`
- `GOWORK=off go test ./cmd/treedb_vector_search_demo -run 'SearchProfile|Parse|Config|Vector' -count=1`

Internal review: high-thinking Orca reviewer PASS; no blocking findings, no non-blocking nits.

## Benchmark/profile evidence

All timed/profile runs below were serialized with `/tmp/gomap_2514_benchmark.lock`; lock context files are in each artifact root. Treat timings as same-host profile-contract rows, not universal speed claims.

Baseline artifact root: `/tmp/gomap_2519_main_e983_baseline_full_20260606_231537` (`origin/main`/`e9830fdc7`, profiles captured).  
Candidate latest-head timing artifact root: `/tmp/gomap_2519_candidate_f6ab_latest_timing_20260606_233118` (`f6ab3eb75`, no profiles).  
Candidate latest-head CPU profile artifact root: `/tmp/gomap_2519_candidate_f6ab_profiles_20260606_233401` (`f6ab3eb75`, profile-only; use timing artifact for B/op guardrails).  
CPU frame compare: `/tmp/gomap_2519_rabitq_cpu_frame_compare_f6ab_20260606_233651.txt`.

Command shape:

```sh
SHAPE=10k_x_1536 \
ROWS=rabitq_collection_quantized_only_c1,rabitq_collection_quantized_only_c8,rabitq_collection_quantized_rerank32_c1,rabitq_collection_quantized_rerank32_c8 \
PROFILE_ROWS=rabitq_collection_quantized_only_c1,rabitq_collection_quantized_only_c8,rabitq_collection_quantized_rerank32_c1,rabitq_collection_quantized_rerank32_c8 \
TIMING_COUNT=1 PROFILE_COUNT=1 BENCHTIME=5000x \
GOMAXPROCS=8 GOWORK=off \
scripts/treedb_rabitq_1bit_profile_gate.sh
```

| row | baseline ns/op | candidate ns/op | Δ ns/op | baseline ops/s | candidate ops/s | B/op | allocs/op | recall % | code B/search | code B/vector | vector B/search | norm B/search | rerank exact calls | guardrails |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| `rabitq_collection_quantized_only_c1` | 153,007 | 64,631 | -57.8% | 6,536 | 15,473 | 0 | 0 | 100 | 48,640 | 256 | 0 | 0 | 0 | pass |
| `rabitq_collection_quantized_only_c8` | 68,393 | 17,287 | -74.7% | 14,621 | 57,848 | 0 | 0 | 100 | 48,640 | 256 | 0 | 0 | 0 | pass |
| `rabitq_collection_quantized_rerank32_c1` | 174,625 | 75,459 | -56.8% | 5,727 | 13,252 | 0 | 0 | 100 | 48,640 | 256 | 196,608 | 128 | 32 | pass |
| `rabitq_collection_quantized_rerank32_c8` | 48,808 | 19,316 | -60.4% | 20,488 | 51,770 | 0 | 0 | 100 | 48,640 | 256 | 196,608 | 128 | 32 | pass |

CPU focus evidence for `PrepareQueryByteMismatchWeights`:

| row | baseline focused CPU | candidate focused CPU |
| --- | ---: | ---: |
| qonly c1 | 0.44s / 1.61% | no samples / 0% |
| qonly c8 | 0.54s / 1.98% | no samples / 0% |
| rerank32 c1 | 0.47s / 1.73% | no samples / 0% |
| rerank32 c8 | 0.58s / 2.19% | no samples / 0% |

Guardrail notes:

- qonly exact vector/norm reads remain `0`.
- rerank exact score calls remain `32`; rerank vector/norm bytes remain shortlist-bounded (`196,608` / `128`).
- Buffered rows remain `0 B/op`, `0 allocs/op` in latest-head unprofiled timing.
- Code bytes remain `48,640` per search and `256` per vector.
- Recall remains `100%` in these deterministic benchmark rows.

## Risks / notes

- The workspace is still caller-owned and not concurrency-safe, matching the existing `rabitq.Workspace` contract.
- The returned table slice remains workspace scratch; callers must not mutate it. The cache now invalidates before rebuild on a miss so failed rebuilds cannot poison subsequent valid prepares.
