### PR TITLE
Add TreeDB hybrid vector candidate adapter

### DIFF
--- a/TreeDB/collections/hybrid_vector_candidates.go
+++ b/TreeDB/collections/hybrid_vector_candidates.go
@@ -31,12 +31,14 @@ func (c *Collection) SearchHybridVectorCandidates(query HybridVectorQuery) (Hybr
 	if c.db == nil {
 		return HybridCandidateResponse{}, errCollectionDBNil
 	}
-	if query.CandidateLimit < 0 {
-		response := HybridCandidateResponse{Stats: HybridSearchStats{FailClosed: 1, FailClosedReason: HybridFailClosedReasonUnsupported}}
-		return response, fmt.Errorf("%w: vector candidate limit cannot be negative", ErrHybridSearchUnsupported)
+	requested := query.CandidateLimit
+	if err := validateHybridVectorCandidateQuery(query); err != nil {
+		response := HybridCandidateResponse{Stats: hybridVectorCandidateStatsFromSearch(requested, VectorIndexSearchStats{}, 0)}
+		response.Stats.FailClosed = 1
+		response.Stats.FailClosedReason = HybridFailClosedReasonUnsupported
+		return response, err
 	}
 
-	requested := query.CandidateLimit
 	opts := VectorIndexSearchOptions{
 		IndexName:                 query.IndexName,
 		Query:                     query.Query,
@@ -58,6 +60,25 @@ func (c *Collection) SearchHybridVectorCandidates(query HybridVectorQuery) (Hybr
 	}
 
 	return hybridVectorCandidatesFromSearchResponse(requested, query.IndexName, vectorResponse)
+}
+
+func validateHybridVectorCandidateQuery(query HybridVectorQuery) error {
+	if query.CandidateLimit < 0 {
+		return fmt.Errorf("%w: vector candidate limit cannot be negative", ErrHybridSearchUnsupported)
+	}
+	if query.EfSearch < 0 {
+		return fmt.Errorf("%w: vector candidate ef_search cannot be negative", ErrHybridSearchUnsupported)
+	}
+	if query.QueryMode != "" && query.QueryMode != VectorIndexQueryModeExact {
+		return fmt.Errorf("%w: vector candidate query mode %q is unsupported by the vector-only #2503 split", ErrHybridSearchUnsupported, query.QueryMode)
+	}
+	if query.QuantizedIndexName != "" {
+		return fmt.Errorf("%w: vector candidate quantized index %q is unsupported by the vector-only #2503 split", ErrHybridSearchUnsupported, query.QuantizedIndexName)
+	}
+	if query.QuantizedRerankCandidates != 0 {
+		return fmt.Errorf("%w: vector candidate quantized rerank candidates are unsupported by the vector-only #2503 split", ErrHybridSearchUnsupported)
+	}
+	return nil
 }
 
 func hybridVectorCandidatesFromSearchResponse(requested int, vectorIndexName string, vectorResponse VectorIndexSearchResponse) (HybridCandidateResponse, error) {

--- a/TreeDB/collections/hybrid_vector_candidates.go
+++ b/TreeDB/collections/hybrid_vector_candidates.go
@@ -1,0 +1,171 @@
+package collections
+
+import (
+	"errors"
+	"fmt"
+)
+
+// HybridCandidateResponse is returned by candidate-only source adapters. The
+// adapters are pre-fusion and pre-final-fetch: Candidates contains source hits
+// only, and Stats reports candidate-generation counters in the shared hybrid
+// vocabulary.
+type HybridCandidateResponse struct {
+	Stats      HybridSearchStats       `json:"stats,omitempty"`
+	Candidates []HybridSearchCandidate `json:"candidates,omitempty"`
+}
+
+// SearchHybridVectorCandidates adapts an existing collection vector-index
+// search into the shared hybrid candidate shape. This is the vector-only #2503
+// split; lexical/text candidates remain blocked on the #1764 ranked SearchText
+// API/counters.
+//
+// Candidate generation is no-document by construction: it uses
+// SearchVectorIndexWithBuffer with IncludeDocuments=false, copies stable result
+// IDs into response-owned HybridSearchCandidate values, assigns one-based source
+// ranks, and fails closed if the backing vector path reports any document
+// materialization or unavailable vector-index state.
+func (c *Collection) SearchHybridVectorCandidates(query HybridVectorQuery) (HybridCandidateResponse, error) {
+	if c == nil {
+		return HybridCandidateResponse{}, errCollectionNil
+	}
+	if c.db == nil {
+		return HybridCandidateResponse{}, errCollectionDBNil
+	}
+	if query.CandidateLimit < 0 {
+		response := HybridCandidateResponse{Stats: HybridSearchStats{FailClosed: 1, FailClosedReason: HybridFailClosedReasonUnsupported}}
+		return response, fmt.Errorf("%w: vector candidate limit cannot be negative", ErrHybridSearchUnsupported)
+	}
+
+	requested := query.CandidateLimit
+	opts := VectorIndexSearchOptions{
+		IndexName:                 query.IndexName,
+		Query:                     query.Query,
+		QueryMode:                 query.QueryMode,
+		QuantizedIndexName:        query.QuantizedIndexName,
+		QuantizedRerankCandidates: query.QuantizedRerankCandidates,
+		TopK:                      requested,
+		EfSearch:                  query.EfSearch,
+		StatsMode:                 VectorIndexSearchStatsModeFullDiagnostics,
+	}
+
+	var buffer VectorIndexSearchBuffer
+	vectorResponse, err := c.SearchVectorIndexWithBuffer(opts, &buffer)
+	if err != nil {
+		response := HybridCandidateResponse{Stats: hybridVectorCandidateStatsFromSearch(requested, vectorResponse.Stats, 0)}
+		response.Stats.FailClosed = 1
+		response.Stats.FailClosedReason = hybridVectorCandidateFailClosedReason(err)
+		return response, hybridVectorCandidateError(err, query.IndexName)
+	}
+
+	return hybridVectorCandidatesFromSearchResponse(requested, query.IndexName, vectorResponse)
+}
+
+func hybridVectorCandidatesFromSearchResponse(requested int, vectorIndexName string, vectorResponse VectorIndexSearchResponse) (HybridCandidateResponse, error) {
+	stats := hybridVectorCandidateStatsFromSearch(requested, vectorResponse.Stats, 0)
+	if !hybridVectorCandidateNoDocumentGuardrailsOK(vectorResponse) {
+		stats.FailClosed = 1
+		stats.FailClosedReason = HybridFailClosedReasonFullDocumentScanForbidden
+		return HybridCandidateResponse{Stats: stats}, fmt.Errorf("%w: vector candidate generation fetched documents", ErrHybridSearchUnsupported)
+	}
+
+	indexName := vectorResponse.IndexName
+	if indexName == "" {
+		indexName = vectorIndexName
+	}
+	candidates := make([]HybridSearchCandidate, len(vectorResponse.Results))
+	for i, result := range vectorResponse.Results {
+		id := append([]byte(nil), result.ID...)
+		id = id[:len(id):len(id)]
+		candidates[i] = HybridSearchCandidate{
+			ID:         id,
+			Source:     HybridCandidateSourceVector,
+			IndexName:  indexName,
+			SourceRank: i + 1,
+			Score:      result.Score,
+			ScoreKind:  HybridScoreKindVectorSimilarity,
+		}
+	}
+	stats = hybridVectorCandidateStatsFromSearch(requested, vectorResponse.Stats, len(candidates))
+	return HybridCandidateResponse{Stats: stats, Candidates: candidates}, nil
+}
+
+func hybridVectorCandidateStatsFromSearch(requested int, vectorStats VectorIndexSearchStats, returned int) HybridSearchStats {
+	var requested64 uint64
+	if requested > 0 {
+		requested64 = uint64(requested)
+	}
+	returned64 := uint64(returned)
+	stats := HybridSearchStats{
+		VectorCandidatesRequested: requested64,
+		VectorCandidatesReturned:  returned64,
+		VectorCandidatesExamined: hybridMaxUint64(
+			vectorStats.Candidates,
+			vectorStats.VisitedNodes,
+			vectorStats.CandidateFetches,
+			vectorStats.ScoreBatchCandidates,
+			vectorStats.PreparedScoreCalls,
+			vectorStats.QuantizedScoreCalls,
+			vectorStats.QuantizedRerankExactScoreCalls,
+		),
+		VectorEdgesVisited: hybridMaxUint64(
+			vectorStats.VisitedEdges,
+			vectorStats.Edges,
+			vectorStats.UpperLayerEdgeVisits+vectorStats.Layer0EdgeVisits,
+		),
+		DocumentsFetched: vectorStats.DocumentsFetched,
+		DocumentsMissing: vectorStats.DocumentsMissing,
+	}
+	if vectorStats.CandidateRows > returned64 {
+		stats.Truncated = vectorStats.CandidateRows - returned64
+	}
+	return stats
+}
+
+func hybridVectorCandidateNoDocumentGuardrailsOK(response VectorIndexSearchResponse) bool {
+	stats := response.Stats
+	if stats.DocumentsFetched != 0 || stats.DocumentsMissing != 0 || stats.DocumentBytes != 0 || stats.DocumentOutputBytes != 0 || stats.DocumentFetchNanos != 0 {
+		return false
+	}
+	if stats.DocumentFieldsReconstructed != 0 || stats.DocumentFieldsSkipped != 0 || stats.DocumentRetainedFetches != 0 || stats.DocumentRetainedBytes != 0 {
+		return false
+	}
+	if stats.DocumentVisibilityScans != 0 || stats.DocumentVisibilityRowsScanned != 0 || stats.DocumentVisibilityRows != 0 || stats.DocumentVisibilityPhysicalBytes != 0 || stats.DocumentVisibilityNanos != 0 {
+		return false
+	}
+	if stats.DocumentTypedColumnRows != 0 || stats.DocumentTypedColumnPartLoads != 0 || stats.DocumentTypedColumnPartDecodes != 0 || stats.DocumentJSONReconstructionRows != 0 {
+		return false
+	}
+	if stats.DocumentPointRowFetches != 0 || stats.DocumentPointRowDecodes != 0 || stats.DocumentRowRefFallbackScans != 0 || stats.DocumentRowRefUnsupported != 0 {
+		return false
+	}
+	for _, result := range response.Results {
+		if len(result.Document) != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func hybridVectorCandidateFailClosedReason(err error) HybridFailClosedReason {
+	if errors.Is(err, ErrVectorIndexSearchUnavailable) || errors.Is(err, ErrIndexNotFound) {
+		return HybridFailClosedReasonVectorIndexUnavailable
+	}
+	return HybridFailClosedReasonUnsupported
+}
+
+func hybridVectorCandidateError(err error, indexName string) error {
+	if errors.Is(err, ErrVectorIndexSearchUnavailable) || errors.Is(err, ErrIndexNotFound) {
+		return fmt.Errorf("%w: vector index %q candidate generation unavailable: %w", ErrHybridSearchIndexUnavailable, indexName, err)
+	}
+	return fmt.Errorf("%w: vector index %q candidate generation unsupported: %w", ErrHybridSearchUnsupported, indexName, err)
+}
+
+func hybridMaxUint64(values ...uint64) uint64 {
+	var max uint64
+	for _, value := range values {
+		if value > max {
+			max = value
+		}
+	}
+	return max
+}

--- a/TreeDB/collections/hybrid_vector_candidates_test.go
+++ b/TreeDB/collections/hybrid_vector_candidates_test.go
@@ -1,0 +1,173 @@
+package collections
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"math"
+	"testing"
+)
+
+func TestSearchHybridVectorCandidatesNoDocumentsStableIDs2503(t *testing.T) {
+	rows := []columnGraphRebuildInputRowV2A{
+		{id: "doc-a", vector: []float32{1, 0, 0}},
+		{id: "doc-b", vector: []float32{0.9, 0.1, 0}},
+		{id: "doc-c", vector: []float32{0.3, 0.7, 0}},
+		{id: "doc-d", vector: []float32{0, 0, 1}},
+	}
+	_, d, col, def := openColumnGraphRebuildTestCollectionV2A(t, 3, 3, rows)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+
+	query := []float32{1, 0, 0}
+	opts := HybridVectorQuery{IndexName: def.Name, Query: query, CandidateLimit: 3, EfSearch: len(rows), QueryMode: VectorIndexQueryModeExact}
+	got, err := col.SearchHybridVectorCandidates(opts)
+	if err != nil {
+		t.Fatalf("SearchHybridVectorCandidates: %v", err)
+	}
+
+	want := exactColumnGraphTopKForTest(t, rows, query, opts.CandidateLimit)
+	assertHybridVectorCandidates2503(t, got.Candidates, want, def.Name)
+	if got.Stats.VectorCandidatesRequested != uint64(opts.CandidateLimit) || got.Stats.VectorCandidatesReturned != uint64(len(want)) {
+		t.Fatalf("stats=%+v want requested=%d returned=%d", got.Stats, opts.CandidateLimit, len(want))
+	}
+	if got.Stats.VectorCandidatesExamined == 0 || got.Stats.VectorEdgesVisited == 0 {
+		t.Fatalf("stats=%+v want non-zero vector graph candidate/edge counters", got.Stats)
+	}
+	if got.Stats.DocumentsFetched != 0 || got.Stats.DocumentsMissing != 0 || got.Stats.FullDocumentScanFallbacks != 0 || got.Stats.FailClosed != 0 {
+		t.Fatalf("stats=%+v want no document fetch/fallback/fail-closed counters", got.Stats)
+	}
+	if got.Stats.Truncated == 0 {
+		t.Fatalf("stats=%+v want truncation because candidate limit is below row count", got.Stats)
+	}
+	firstID := append([]byte(nil), got.Candidates[0].ID...)
+
+	again, err := col.SearchHybridVectorCandidates(HybridVectorQuery{IndexName: def.Name, Query: []float32{0, 1, 0}, CandidateLimit: 2, EfSearch: len(rows)})
+	if err != nil {
+		t.Fatalf("second SearchHybridVectorCandidates: %v", err)
+	}
+	if !bytes.Equal(got.Candidates[0].ID, firstID) {
+		t.Fatalf("first response ID changed after later search: got %q want stable %q", got.Candidates[0].ID, firstID)
+	}
+	if len(again.Candidates) != 2 || again.Candidates[0].SourceRank != 1 || again.Candidates[1].SourceRank != 2 {
+		t.Fatalf("second candidates=%+v want bounded one-based ranks", again.Candidates)
+	}
+}
+
+func TestSearchHybridVectorCandidatesMissingIndexFailsClosed2503(t *testing.T) {
+	rows := []columnGraphRebuildInputRowV2A{{id: "doc-a", vector: []float32{1, 0, 0}}}
+	_, d, col, def := openColumnGraphRebuildTestCollectionV2A(t, 3, 1, rows)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+
+	got, err := col.SearchHybridVectorCandidates(HybridVectorQuery{IndexName: "missing_embedding_graph", Query: []float32{1, 0, 0}, CandidateLimit: 1, EfSearch: 1})
+	if !errors.Is(err, ErrHybridSearchIndexUnavailable) {
+		t.Fatalf("SearchHybridVectorCandidates err=%v want ErrHybridSearchIndexUnavailable", err)
+	}
+	if len(got.Candidates) != 0 || got.Stats.FailClosed != 1 || got.Stats.FailClosedReason != HybridFailClosedReasonVectorIndexUnavailable {
+		t.Fatalf("response=%+v want fail-closed vector-index-unavailable stats and no candidates", got)
+	}
+	if got.Stats.DocumentsFetched != 0 || got.Stats.FullDocumentScanFallbacks != 0 {
+		t.Fatalf("stats=%+v want no document fetch or full scan fallback on unavailable vector index", got.Stats)
+	}
+}
+
+func TestHybridVectorCandidatesRejectDocumentMaterialization2503(t *testing.T) {
+	got, err := hybridVectorCandidatesFromSearchResponse(1, "embedding_graph", VectorIndexSearchResponse{
+		IndexName: "embedding_graph",
+		Stats: VectorIndexSearchStats{
+			CandidateRows:      1,
+			DocumentsFetched:   1,
+			DocumentBytes:      14,
+			DocumentFetchNanos: 7,
+		},
+		Results: []VectorIndexSearchResult{{ID: []byte("doc-a"), Score: 1, Document: []byte(`{"did":"doc-a"}`)}},
+	})
+	if !errors.Is(err, ErrHybridSearchUnsupported) {
+		t.Fatalf("hybridVectorCandidatesFromSearchResponse err=%v want ErrHybridSearchUnsupported", err)
+	}
+	if len(got.Candidates) != 0 || got.Stats.FailClosed != 1 || got.Stats.FailClosedReason != HybridFailClosedReasonFullDocumentScanForbidden {
+		t.Fatalf("response=%+v want fail-closed document materialization guard", got)
+	}
+	if got.Stats.DocumentsFetched != 1 || got.Stats.VectorCandidatesReturned != 0 {
+		t.Fatalf("stats=%+v want document-fetch counter preserved and no returned candidates", got.Stats)
+	}
+}
+
+func assertHybridVectorCandidates2503(tb testing.TB, got []HybridSearchCandidate, want []columnVectorGraphNativeSearchResult, indexName string) {
+	tb.Helper()
+	if len(got) != len(want) {
+		tb.Fatalf("candidates=%d want %d", len(got), len(want))
+	}
+	for i := range want {
+		candidate := got[i]
+		if !bytes.Equal(candidate.ID, want[i].ID) || math.Abs(candidate.Score-want[i].Score) > 1e-6 {
+			tb.Fatalf("candidate[%d]=%+v want id=%q score=%v", i, candidate, want[i].ID, want[i].Score)
+		}
+		if candidate.Source != HybridCandidateSourceVector || candidate.IndexName != indexName || candidate.SourceRank != i+1 || candidate.ScoreKind != HybridScoreKindVectorSimilarity {
+			tb.Fatalf("candidate[%d]=%+v want vector source/index/rank/score kind", i, candidate)
+		}
+		if len(candidate.TextMatches) != 0 {
+			tb.Fatalf("candidate[%d] text matches=%+v want none for vector source", i, candidate.TextMatches)
+		}
+		if len(candidate.ID) == 0 || cap(candidate.ID) != len(candidate.ID) {
+			tb.Fatalf("candidate[%d] id len/cap=%d/%d want response-owned cap-isolated stable ID", i, len(candidate.ID), cap(candidate.ID))
+		}
+	}
+}
+
+var hybridVectorCandidateBenchmarkSink2503 HybridCandidateResponse
+
+func BenchmarkSearchHybridVectorCandidates2503(b *testing.B) {
+	rows := make([]columnGraphRebuildInputRowV2A, 128)
+	for i := range rows {
+		rows[i] = columnGraphRebuildInputRowV2A{
+			id: fmt.Sprintf("doc-%03d", i),
+			vector: []float32{
+				1 + float32(i%11)*0.01,
+				float32((i*7)%17) * 0.01,
+				float32((i*13)%19) * 0.01,
+			},
+		}
+	}
+	_, d, col, def := openColumnGraphRebuildTestCollectionV2A(b, 3, 8, rows)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		b.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	opts := HybridVectorQuery{IndexName: def.Name, Query: []float32{1, 0.1, 0.05}, CandidateLimit: 10, EfSearch: 64, QueryMode: VectorIndexQueryModeExact}
+	warm, err := col.SearchHybridVectorCandidates(opts)
+	if err != nil {
+		b.Fatalf("warm SearchHybridVectorCandidates: %v", err)
+	}
+	if len(warm.Candidates) != opts.CandidateLimit || warm.Stats.DocumentsFetched != 0 {
+		b.Fatalf("warm response=%+v want %d no-document candidates", warm, opts.CandidateLimit)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	var sink HybridCandidateResponse
+	for i := 0; i < b.N; i++ {
+		got, err := col.SearchHybridVectorCandidates(opts)
+		if err != nil {
+			b.Fatalf("SearchHybridVectorCandidates: %v", err)
+		}
+		if len(got.Candidates) != opts.CandidateLimit {
+			b.Fatalf("candidates=%d want %d", len(got.Candidates), opts.CandidateLimit)
+		}
+		sink = got
+	}
+	b.StopTimer()
+	hybridVectorCandidateBenchmarkSink2503 = sink
+	if elapsed := b.Elapsed(); elapsed > 0 {
+		b.ReportMetric(float64(b.N)/elapsed.Seconds(), "ops/sec")
+	}
+	b.ReportMetric(float64(sink.Stats.VectorCandidatesReturned), "candidates/search")
+	b.ReportMetric(float64(sink.Stats.VectorCandidatesExamined), "examined/search")
+	b.ReportMetric(float64(sink.Stats.VectorEdgesVisited), "edges/search")
+	b.ReportMetric(float64(sink.Stats.DocumentsFetched), "docs_fetched/search")
+}

--- a/TreeDB/collections/hybrid_vector_candidates_test.go
+++ b/TreeDB/collections/hybrid_vector_candidates_test.go
@@ -56,6 +56,78 @@ func TestSearchHybridVectorCandidatesNoDocumentsStableIDs2503(t *testing.T) {
 	}
 }
 
+func TestSearchHybridVectorCandidatesUnsupportedShapesFailClosed2503(t *testing.T) {
+	rows := []columnGraphRebuildInputRowV2A{{id: "doc-a", vector: []float32{1, 0, 0}}}
+	_, d, col, def := openColumnGraphRebuildTestCollectionV2A(t, 3, 1, rows)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+
+	base := HybridVectorQuery{IndexName: def.Name, Query: []float32{1, 0, 0}, CandidateLimit: 2, EfSearch: 2}
+	tests := []struct {
+		name   string
+		mutate func(*HybridVectorQuery)
+	}{
+		{name: "invalid_query_mode", mutate: func(q *HybridVectorQuery) { q.QueryMode = VectorIndexQueryMode("future_mode") }},
+		{name: "zero_exact_with_quantized_index", mutate: func(q *HybridVectorQuery) { q.QuantizedIndexName = "embedding.scalar_u8.fast" }},
+		{name: "explicit_exact_with_quantized_index", mutate: func(q *HybridVectorQuery) {
+			q.QueryMode = VectorIndexQueryModeExact
+			q.QuantizedIndexName = "embedding.scalar_u8.fast"
+		}},
+		{name: "exact_with_quantized_rerank_candidates", mutate: func(q *HybridVectorQuery) {
+			q.QueryMode = VectorIndexQueryModeExact
+			q.QuantizedRerankCandidates = 8
+		}},
+		{name: "quantized_only_missing_index_name", mutate: func(q *HybridVectorQuery) { q.QueryMode = VectorIndexQueryModeQuantizedOnly }},
+		{name: "valid_looking_quantized_only", mutate: func(q *HybridVectorQuery) {
+			q.QueryMode = VectorIndexQueryModeQuantizedOnly
+			q.QuantizedIndexName = "embedding.scalar_u8.fast"
+		}},
+		{name: "quantized_only_with_rerank_candidates", mutate: func(q *HybridVectorQuery) {
+			q.QueryMode = VectorIndexQueryModeQuantizedOnly
+			q.QuantizedIndexName = "embedding.scalar_u8.fast"
+			q.QuantizedRerankCandidates = 8
+		}},
+		{name: "quantized_rerank_missing_index_name", mutate: func(q *HybridVectorQuery) { q.QueryMode = VectorIndexQueryModeQuantizedRerank }},
+		{name: "quantized_rerank_negative_candidates", mutate: func(q *HybridVectorQuery) {
+			q.QueryMode = VectorIndexQueryModeQuantizedRerank
+			q.QuantizedIndexName = "embedding.scalar_u8.fast"
+			q.QuantizedRerankCandidates = -1
+		}},
+		{name: "quantized_rerank_candidates_below_limit", mutate: func(q *HybridVectorQuery) {
+			q.QueryMode = VectorIndexQueryModeQuantizedRerank
+			q.QuantizedIndexName = "embedding.scalar_u8.fast"
+			q.QuantizedRerankCandidates = 1
+		}},
+		{name: "valid_looking_quantized_rerank", mutate: func(q *HybridVectorQuery) {
+			q.QueryMode = VectorIndexQueryModeQuantizedRerank
+			q.QuantizedIndexName = "embedding.scalar_u8.fast"
+			q.QuantizedRerankCandidates = q.CandidateLimit
+		}},
+		{name: "negative_ef_search", mutate: func(q *HybridVectorQuery) { q.EfSearch = -1 }},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := base
+			tc.mutate(&opts)
+			got, err := col.SearchHybridVectorCandidates(opts)
+			if !errors.Is(err, ErrHybridSearchUnsupported) {
+				t.Fatalf("SearchHybridVectorCandidates err=%v want ErrHybridSearchUnsupported", err)
+			}
+			if errors.Is(err, ErrHybridSearchIndexUnavailable) {
+				t.Fatalf("SearchHybridVectorCandidates err=%v must not wrap ErrHybridSearchIndexUnavailable for unsupported shape", err)
+			}
+			if len(got.Candidates) != 0 || got.Stats.FailClosed != 1 || got.Stats.FailClosedReason != HybridFailClosedReasonUnsupported {
+				t.Fatalf("response=%+v want unsupported fail-closed stats and no candidates", got)
+			}
+			if got.Stats.DocumentsFetched != 0 || got.Stats.DocumentsMissing != 0 || got.Stats.FullDocumentScanFallbacks != 0 {
+				t.Fatalf("stats=%+v want no document fetch or fallback on unsupported vector candidate shape", got.Stats)
+			}
+		})
+	}
+}
+
 func TestSearchHybridVectorCandidatesMissingIndexFailsClosed2503(t *testing.T) {
 	rows := []columnGraphRebuildInputRowV2A{{id: "doc-a", vector: []float32{1, 0, 0}}}
 	_, d, col, def := openColumnGraphRebuildTestCollectionV2A(t, 3, 1, rows)
@@ -163,9 +235,6 @@ func BenchmarkSearchHybridVectorCandidates2503(b *testing.B) {
 	}
 	b.StopTimer()
 	hybridVectorCandidateBenchmarkSink2503 = sink
-	if elapsed := b.Elapsed(); elapsed > 0 {
-		b.ReportMetric(float64(b.N)/elapsed.Seconds(), "ops/sec")
-	}
 	b.ReportMetric(float64(sink.Stats.VectorCandidatesReturned), "candidates/search")
 	b.ReportMetric(float64(sink.Stats.VectorCandidatesExamined), "examined/search")
 	b.ReportMetric(float64(sink.Stats.VectorEdgesVisited), "edges/search")

--- a/TreeDB/docs/spec/hybrid-search-contract.md
+++ b/TreeDB/docs/spec/hybrid-search-contract.md
@@ -249,6 +249,14 @@ Issue `#2503` candidate-only paths should consume this contract as follows:
 - both adapters preserve stable document ID bytes, one-based source rank,
   source/index name, and source counters.
 
+The first partial #2503 vector-only split exposes
+`Collection.SearchHybridVectorCandidates(HybridVectorQuery)`. It returns a
+`HybridCandidateResponse` containing vector-source `HybridSearchCandidate`
+values and shared `HybridSearchStats`, and it fails closed if the backing vector
+path is unavailable or reports document materialization. This split does not
+implement lexical candidates; text remains blocked on #1764 ranked `SearchText`
+results/counters.
+
 Issue `#2504` fusion primitives should implement the RRF formula and deterministic tie
 policy above over slices of `HybridSearchCandidate`. The helper surface is
 `FuseHybridSearchCandidates(candidates, fusion, topK)`, which returns bounded


### PR DESCRIPTION
## Linked tracker and child milestone

- Partial split for #2503 under umbrella #2501.
- Scope: vector candidate-only adapter over already-merged #2502/#2504 contracts.
- Current base consumed: `origin/main` @ `18dab369a96d9a1ac713cdf788b7612d61ce330e` (includes #2524).

## Scope and non-goals

This PR adds only the vector-source candidate adapter:

- `Collection.SearchHybridVectorCandidates(HybridVectorQuery)`
- `HybridCandidateResponse`
- vector-source `HybridSearchCandidate` conversion with stable response-owned IDs, one-based source ranks, `vector_similarity` scores, source/index name, and shared vector stats counters.

Explicit non-goals / still blocked:

- no lexical/text candidate implementation;
- no #1764 PR2 code consumed;
- no fusion changes (#2504 already merged);
- no hybrid executor/planner (#2505 owns it);
- no vector algorithm or hot-path optimization.

Final #2503 dependency-ready status and issue completion remain blocked on #1764 exposing stable ranked `SearchText` results/counters.

## Start-phase test / performance plan

- Reuse existing `SearchVectorIndexWithBuffer` no-document vector path and fail closed on unavailable state.
- Add tests for stable candidate shape/rank/score/ID, top-N bounds, zero document fetch, missing index fail-closed, and guardrail rejection if backing stats/results indicate document materialization.
- Benchmark the new adapter boundary; no before/after vector hot-path benchmark is required because this PR does not modify existing vector search algorithms/routes.

## Close-phase test evidence

- `GOWORK=off go test ./TreeDB/collections -run 'TestSearchHybridVectorCandidates|TestHybridVectorCandidates' -count=1` — PASS
- `GOWORK=off go test ./TreeDB/collections -run 'TestSearchHybridVectorCandidates|TestHybridVectorCandidates|TestSearchVectorIndexWithBuffer|TestSearchVectorIndexNoDocument' -count=1` — PASS
- `GOWORK=off go test ./TreeDB/docs -count=1` — PASS
- `GOWORK=off go test ./TreeDB/collections -count=1` — PASS
- `git diff --check origin/main...HEAD` — PASS

## Benchmark evidence

Command:

```sh
GOWORK=off go test ./TreeDB/collections -run '^$' -bench '^BenchmarkSearchHybridVectorCandidates2503$' -benchtime=100x -count=1
```

Environment: darwin/arm64, Apple M3.

| Benchmark | ns/op | B/op | allocs/op | candidates/search | examined/search | edges/search | docs_fetched/search |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| `BenchmarkSearchHybridVectorCandidates2503-8` | 17,220 | 8,528 | 26 | 10 | 116 | 1,040 | 0 |

Measurement boundary: candidate generation only, backed by the existing no-document vector search route plus response-owned hybrid candidate ID copies. No final document fetch is included.

## Performance regression assessment

No existing vector algorithm/search hot path was changed. The new adapter calls the existing fail-closed buffered no-document vector API and copies bounded top-N IDs/scores into hybrid candidate structs. Material regression risk to existing vector-only paths is therefore limited; affected vector tests still pass.

## Latest-head CI status

Latest PR head `96719b783a55cca74d268a9a3241752c6a174a54`: all GitHub checks passing.

## AI review status

- Codex: latest re-review found no major issues; previous P2 thread replied/resolved.
- Copilot: requested via PR comment; no unresolved findings observed.
- CodeRabbit: latest review completed; previous blocker replied/resolved.

## Merge/status caveat

This PR is intentionally partial and must not close #2503. Lexical candidates and final #2503 completion remain blocked on #1764 ranked `SearchText` results/counters.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added vector-only candidate search functionality, enabling hybrid queries to retrieve ranked candidates with scores and metadata while maintaining data safety guardrails.

* **Tests**
  * Added comprehensive test coverage for vector candidate search, including stability validation and failure mode scenarios.

* **Documentation**
  * Updated hybrid search specification documenting the new vector candidate search API and its fail-safe behavior on unavailability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

