### PR TITLE
TreeDB: add ARM64 RaBitQ byte-table scorer kernel

### DIFF
--- a/TreeDB/collections/column_vector_graph_quantized_scorer.go
+++ b/TreeDB/collections/column_vector_graph_quantized_scorer.go
@@ -416,7 +416,7 @@ func (s *columnVectorGraphRabitQQuantizedScorer) scoreOrdinalUnchecked(ordinal i
 		return 0, fmt.Errorf("%w: column_graph quantized index %q rabitq_1bit code_count ordinal=%d value=%d exceeds code_dimensions=%d", ErrVectorIndexSearchUnavailable, s.indexName, ordinal, codeCount, s.codeDimensions)
 	}
 	qdpInv := math.Float32frombits(binary.LittleEndian.Uint32(s.quantizedDotProductInvPayload[sideStart : sideStart+4]))
-	score, ok := rabitqQuantizedCosineScoreWithByteTables(s.query, code, qdpInv, s.queryByteMismatchWeights, s.queryWeightSum)
+	score, ok := rabitqQuantizedCosineScoreWithByteTablesPrevalidated(s.query, code, qdpInv, s.queryByteMismatchWeights, s.queryWeightSum)
 	if !ok {
 		return 0, fmt.Errorf("%w: column_graph quantized index %q rabitq_1bit score ordinal=%d unavailable", ErrVectorIndexSearchUnavailable, s.indexName, ordinal)
 	}
@@ -656,11 +656,17 @@ func rabitqQuantizedCosineScoreWithByteTables(query rabitq.Query, code []byte, q
 	if !rabitq.QueryByteMismatchWeightsValid(query, byteMismatchWeights, queryWeightSum) || len(code) != len(query.SignBits) || quantizedDotProductInv <= 0 || math.IsNaN(float64(quantizedDotProductInv)) || math.IsInf(float64(quantizedDotProductInv), 0) {
 		return 0, false
 	}
-	var mismatchWeight float64
-	for byteIdx, candidateByte := range code {
-		xorMask := candidateByte ^ query.SignBits[byteIdx]
-		mismatchWeight += byteMismatchWeights[byteIdx*rabitq.ByteMismatchTableEntries+int(xorMask)]
+	return rabitqQuantizedCosineScoreWithByteTablesPrevalidated(query, code, quantizedDotProductInv, byteMismatchWeights, queryWeightSum)
+}
+
+// rabitqQuantizedCosineScoreWithByteTablesPrevalidated is the hot-loop form for
+// callers that already validated the query shape and byte mismatch table. It
+// still checks per-row code/qdp side inputs so corrupted row data fails closed.
+func rabitqQuantizedCosineScoreWithByteTablesPrevalidated(query rabitq.Query, code []byte, quantizedDotProductInv float32, byteMismatchWeights []float64, queryWeightSum float64) (float64, bool) {
+	if len(code) != len(query.SignBits) || quantizedDotProductInv <= 0 || math.IsNaN(float64(quantizedDotProductInv)) || math.IsInf(float64(quantizedDotProductInv), 0) {
+		return 0, false
 	}
+	mismatchWeight := rabitqByteTableMismatchWeight(query.SignBits, code, byteMismatchWeights)
 	weightedSignDot := queryWeightSum - 2*mismatchWeight
 	score := weightedSignDot / (float64(quantizedDotProductInv) * float64(query.CodeDimensions))
 	if math.IsNaN(score) || math.IsInf(score, 0) {

--- a/TreeDB/collections/column_vector_graph_rabitq_byte_table.go
+++ b/TreeDB/collections/column_vector_graph_rabitq_byte_table.go
@@ -1,0 +1,12 @@
+package collections
+
+import "github.com/snissn/gomap/TreeDB/internal/rabitq"
+
+func rabitqByteTableMismatchWeightPortable(querySignBits []byte, code []byte, byteMismatchWeights []float64) float64 {
+	var mismatchWeight float64
+	for byteIdx, candidateByte := range code {
+		xorMask := candidateByte ^ querySignBits[byteIdx]
+		mismatchWeight += byteMismatchWeights[byteIdx*rabitq.ByteMismatchTableEntries+int(xorMask)]
+	}
+	return mismatchWeight
+}

--- a/TreeDB/collections/column_vector_graph_rabitq_byte_table_arm64.go
+++ b/TreeDB/collections/column_vector_graph_rabitq_byte_table_arm64.go
@@ -1,0 +1,17 @@
+//go:build arm64 && !purego
+
+package collections
+
+func rabitqByteTableMismatchWeight(querySignBits []byte, code []byte, byteMismatchWeights []float64) float64 {
+	if len(code) == 0 {
+		return 0
+	}
+	return rabitqByteTableMismatchWeightARM64(querySignBits, code, byteMismatchWeights, len(code))
+}
+
+// rabitqByteTableMismatchWeightARM64 sums byteMismatchWeights[i*256 + (code[i]^querySignBits[i])].
+// The Go caller must validate that querySignBits and code have equal length and
+// that byteMismatchWeights has at least len(code)*256 entries.
+//
+//go:noescape
+func rabitqByteTableMismatchWeightARM64(querySignBits []byte, code []byte, byteMismatchWeights []float64, n int) float64

--- a/TreeDB/collections/column_vector_graph_rabitq_byte_table_arm64.s
+++ b/TreeDB/collections/column_vector_graph_rabitq_byte_table_arm64.s
@@ -1,0 +1,77 @@
+//go:build arm64 && !purego
+
+#include "textflag.h"
+
+// func rabitqByteTableMismatchWeightARM64(querySignBits []byte, code []byte, byteMismatchWeights []float64, n int) float64
+//
+// Preconditions are checked by the Go caller: n == len(code) == len(querySignBits)
+// and byteMismatchWeights contains n contiguous 256-entry float64 tables.
+TEXT ·rabitqByteTableMismatchWeightARM64(SB), NOSPLIT, $0-88
+	MOVD querySignBits_base+0(FP), R0
+	MOVD code_base+24(FP), R1
+	MOVD byteMismatchWeights_base+48(FP), R2
+	MOVD n+72(FP), R3
+
+	FMOVD ZR, F0
+	FMOVD ZR, F1
+	FMOVD ZR, F2
+	FMOVD ZR, F3
+	CBZ R3, rabitq_byte_table_arm64_reduce
+
+	CMP $4, R3
+	BLT rabitq_byte_table_arm64_tail
+
+rabitq_byte_table_arm64_loop4:
+	MOVBU 0(R1), R4
+	MOVBU 0(R0), R5
+	EOR R5, R4, R4
+	FMOVD (R2)(R4<<3), F4
+	FADDD F4, F0, F0
+
+	MOVBU 1(R1), R4
+	MOVBU 1(R0), R5
+	EOR R5, R4, R4
+	ADD $2048, R2, R6
+	FMOVD (R6)(R4<<3), F4
+	FADDD F4, F1, F1
+
+	MOVBU 2(R1), R4
+	MOVBU 2(R0), R5
+	EOR R5, R4, R4
+	ADD $4096, R2, R6
+	FMOVD (R6)(R4<<3), F4
+	FADDD F4, F2, F2
+
+	MOVBU 3(R1), R4
+	MOVBU 3(R0), R5
+	EOR R5, R4, R4
+	ADD $6144, R2, R6
+	FMOVD (R6)(R4<<3), F4
+	FADDD F4, F3, F3
+
+	ADD $4, R0
+	ADD $4, R1
+	ADD $8192, R2
+	SUB $4, R3
+	CMP $4, R3
+	BGE rabitq_byte_table_arm64_loop4
+
+rabitq_byte_table_arm64_tail:
+	CBZ R3, rabitq_byte_table_arm64_reduce
+	MOVBU (R1), R4
+	MOVBU (R0), R5
+	EOR R5, R4, R4
+	FMOVD (R2)(R4<<3), F4
+	FADDD F4, F0, F0
+	ADD $1, R0
+	ADD $1, R1
+	ADD $2048, R2
+	SUB $1, R3
+	B rabitq_byte_table_arm64_tail
+
+rabitq_byte_table_arm64_reduce:
+	FADDD F1, F0, F0
+	FADDD F2, F0, F0
+	FADDD F3, F0, F0
+	FMOVD F0, ret+80(FP)
+	RET

--- a/TreeDB/collections/column_vector_graph_rabitq_byte_table_fallback.go
+++ b/TreeDB/collections/column_vector_graph_rabitq_byte_table_fallback.go
@@ -1,0 +1,7 @@
+//go:build purego || !arm64
+
+package collections
+
+func rabitqByteTableMismatchWeight(querySignBits []byte, code []byte, byteMismatchWeights []float64) float64 {
+	return rabitqByteTableMismatchWeightPortable(querySignBits, code, byteMismatchWeights)
+}

--- a/TreeDB/collections/column_vector_graph_rabitq_byte_tables_test.go
+++ b/TreeDB/collections/column_vector_graph_rabitq_byte_tables_test.go
@@ -77,7 +77,7 @@ func TestRabitQByteMismatchWeightsLSBAndPadding2477(t *testing.T) {
 }
 
 func TestRabitQByteTableScorerMatchesOracleVariedDimensions2477(t *testing.T) {
-	for _, dims := range []int{1, 3, 7, 8, 9, 15, 16, 17, 31, 32, 64, 128} {
+	for _, dims := range []int{1, 3, 7, 8, 9, 15, 16, 17, 31, 32, 64, 128, 1536} {
 		t.Run("dims_"+strconv.Itoa(dims), func(t *testing.T) {
 			plan, err := rabitq.NewPlan(dims, rabitq.DefaultConfig())
 			if err != nil {
@@ -171,6 +171,38 @@ func TestRabitQByteTableScorerFailClosed2477(t *testing.T) {
 	}
 }
 
+func TestRabitQByteTableMismatchWeightKernelMatchesPortable2525(t *testing.T) {
+	for _, dims := range []int{1, 3, 8, 9, 31, 128, 1536} {
+		t.Run("dims_"+strconv.Itoa(dims), func(t *testing.T) {
+			plan, err := rabitq.NewPlan(dims, rabitq.DefaultConfig())
+			if err != nil {
+				t.Fatalf("NewPlan: %v", err)
+			}
+			var queryWS rabitq.Workspace
+			query, err := plan.EncodeQuery(rabitqTestVector2477(dims, 17), &queryWS)
+			if err != nil {
+				t.Fatalf("EncodeQuery: %v", err)
+			}
+			tables, _, ok := rabitq.PrepareQueryByteMismatchWeights(query, &queryWS)
+			if !ok {
+				t.Fatal("prepare query byte mismatch weights failed")
+			}
+			var encodeWS rabitq.Workspace
+			for candidate := 0; candidate < 64; candidate++ {
+				encoded, err := plan.Encode(nil, rabitqTestVector2477(dims, uint64(candidate+31)), &encodeWS)
+				if err != nil {
+					t.Fatalf("Encode candidate %d: %v", candidate, err)
+				}
+				got := rabitqByteTableMismatchWeight(query.SignBits, encoded.Code, tables)
+				want := rabitqByteTableMismatchWeightPortable(query.SignBits, encoded.Code, tables)
+				if got != want {
+					t.Fatalf("dims=%d candidate=%d mismatchWeight=%0.17g want portable=%0.17g", dims, candidate, got, want)
+				}
+			}
+		})
+	}
+}
+
 func TestRabitQByteMismatchWeightsScratchReuseNoAlloc2477(t *testing.T) {
 	query := rabitq.Query{
 		SignBits:       []byte{0b0101_1010, 0b0000_0011},
@@ -191,6 +223,131 @@ func TestRabitQByteMismatchWeightsScratchReuseNoAlloc2477(t *testing.T) {
 	if allocs != 0 {
 		t.Fatalf("prepared query byte mismatch weights allocs/run=%v want 0", allocs)
 	}
+}
+
+type rabitqByteTableScoreBenchFixture2525 struct {
+	query        rabitq.Query
+	tables       []float64
+	weightSum    float64
+	codes        []byte
+	qdpInv       []float32
+	bytesPerCode int
+	rows         int
+}
+
+func BenchmarkRabitQByteTableScore2525(b *testing.B) {
+	for _, dims := range []int{128, 1536} {
+		b.Run("dims_"+strconv.Itoa(dims)+"/checked", func(b *testing.B) {
+			benchmarkRabitQByteTableScore2525(b, dims, rabitqQuantizedCosineScoreWithByteTables)
+		})
+		b.Run("dims_"+strconv.Itoa(dims)+"/prevalidated", func(b *testing.B) {
+			benchmarkRabitQByteTableScore2525(b, dims, rabitqQuantizedCosineScoreWithByteTablesPrevalidated)
+		})
+	}
+}
+
+func BenchmarkRabitQByteTableScoreSearchLoop2525(b *testing.B) {
+	b.Run("checked", func(b *testing.B) {
+		benchmarkRabitQByteTableScoreSearchLoop2525(b, rabitqQuantizedCosineScoreWithByteTables)
+	})
+	b.Run("prevalidated", func(b *testing.B) {
+		benchmarkRabitQByteTableScoreSearchLoop2525(b, rabitqQuantizedCosineScoreWithByteTablesPrevalidated)
+	})
+}
+
+func BenchmarkRabitQByteTableRuntimeScore2525(b *testing.B) {
+	for _, dims := range []int{128, 1536} {
+		b.Run("dims_"+strconv.Itoa(dims), func(b *testing.B) {
+			benchmarkRabitQByteTableScore2525(b, dims, rabitqQuantizedCosineScoreWithByteTablesPrevalidated)
+		})
+	}
+}
+
+func BenchmarkRabitQByteTableRuntimeScoreSearchLoop2525(b *testing.B) {
+	benchmarkRabitQByteTableScoreSearchLoop2525(b, rabitqQuantizedCosineScoreWithByteTablesPrevalidated)
+}
+
+func benchmarkRabitQByteTableScore2525(b *testing.B, dims int, scoreFn func(rabitq.Query, []byte, float32, []float64, float64) (float64, bool)) {
+	fixture := newRabitQByteTableScoreBenchFixture2525(b, dims, 2048)
+	b.ReportAllocs()
+	b.SetBytes(int64(fixture.bytesPerCode))
+	b.ReportMetric(float64(fixture.bytesPerCode), "code_bytes/score")
+	mask := fixture.rows - 1
+	var scoreSum float64
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		row := i & mask
+		start := row * fixture.bytesPerCode
+		score, ok := scoreFn(fixture.query, fixture.codes[start:start+fixture.bytesPerCode], fixture.qdpInv[row], fixture.tables, fixture.weightSum)
+		if !ok {
+			b.Fatalf("score rejected row=%d", row)
+		}
+		scoreSum += score
+	}
+	b.StopTimer()
+	columnPhysicalScanBenchSum += int64(scoreSum * 1e9)
+}
+
+func benchmarkRabitQByteTableScoreSearchLoop2525(b *testing.B, scoreFn func(rabitq.Query, []byte, float32, []float64, float64) (float64, bool)) {
+	const scoresPerSearch = 190
+	fixture := newRabitQByteTableScoreBenchFixture2525(b, 1536, 2048)
+	b.ReportAllocs()
+	b.SetBytes(int64(scoresPerSearch * fixture.bytesPerCode))
+	b.ReportMetric(float64(scoresPerSearch), "scores/search")
+	b.ReportMetric(float64(fixture.bytesPerCode), "code_bytes/score")
+	mask := fixture.rows - 1
+	var scoreSum float64
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		base := (i * scoresPerSearch) & mask
+		for j := 0; j < scoresPerSearch; j++ {
+			row := (base + j) & mask
+			start := row * fixture.bytesPerCode
+			score, ok := scoreFn(fixture.query, fixture.codes[start:start+fixture.bytesPerCode], fixture.qdpInv[row], fixture.tables, fixture.weightSum)
+			if !ok {
+				b.Fatalf("score rejected row=%d", row)
+			}
+			scoreSum += score
+		}
+	}
+	b.StopTimer()
+	columnPhysicalScanBenchSum += int64(scoreSum * 1e9)
+}
+
+func newRabitQByteTableScoreBenchFixture2525(tb testing.TB, dims int, rows int) rabitqByteTableScoreBenchFixture2525 {
+	tb.Helper()
+	if rows <= 0 || rows&(rows-1) != 0 {
+		tb.Fatalf("rows=%d must be a positive power of two", rows)
+	}
+	plan, err := rabitq.NewPlan(dims, rabitq.DefaultConfig())
+	if err != nil {
+		tb.Fatalf("NewPlan: %v", err)
+	}
+	var queryWS rabitq.Workspace
+	query, err := plan.EncodeQuery(rabitqTestVector2477(dims, 17), &queryWS)
+	if err != nil {
+		tb.Fatalf("EncodeQuery: %v", err)
+	}
+	tables, weightSum, ok := rabitq.PrepareQueryByteMismatchWeights(query, &queryWS)
+	if !ok {
+		tb.Fatal("PrepareQueryByteMismatchWeights failed")
+	}
+	bytesPerCode := plan.BytesPerCode()
+	codes := make([]byte, rows*bytesPerCode)
+	qdpInv := make([]float32, rows)
+	var encodeWS rabitq.Workspace
+	for row := 0; row < rows; row++ {
+		start := row * bytesPerCode
+		encoded, err := plan.Encode(codes[start:start+bytesPerCode], rabitqTestVector2477(dims, uint64(row+31)), &encodeWS)
+		if err != nil {
+			tb.Fatalf("Encode row=%d: %v", row, err)
+		}
+		if len(encoded.Code) != bytesPerCode {
+			tb.Fatalf("encoded row=%d code bytes=%d want %d", row, len(encoded.Code), bytesPerCode)
+		}
+		qdpInv[row] = encoded.QuantizedDotProductInv
+	}
+	return rabitqByteTableScoreBenchFixture2525{query: query, tables: tables, weightSum: weightSum, codes: codes, qdpInv: qdpInv, bytesPerCode: bytesPerCode, rows: rows}
 }
 
 func rabitqTestVector2477(dims int, seed uint64) []float32 {


### PR DESCRIPTION
## Objective

Add a focused ARM64 kernel for TreeDB RaBitQ `rabitq_1bit` byte-table mismatch scoring, preserving the v1 codec/storage/bit-order/score contract and the existing fail-closed public scorer path.

Closes #2525. Parent tracker: #2514.

## Context

#2524 removed repeated query byte-table preparation from the hot loop. The remaining focused scorer/search-loop cost is the per-code byte-table mismatch sum for 10k x 1536 RaBitQ collection search.

## Scope / Non-goals

Includes:

- `TreeDB/collections/column_vector_graph_quantized_scorer.go`
- `TreeDB/collections/column_vector_graph_rabitq_byte_table*.go`
- `TreeDB/collections/column_vector_graph_rabitq_byte_table_arm64.s`
- `TreeDB/collections/column_vector_graph_rabitq_byte_tables_test.go`

Excludes:

- No codec identity/version, storage schema, packed-bit order, score formula, or asset/fail-closed semantic changes.
- No scalar_u8, exact FP32, BRQ, graph traversal, benchmark setup/rebuild, or collection materialization optimization.

## Design

- Splits the checked byte-table scorer from a prevalidated hot-loop scorer used only after `columnVectorGraphRabitQQuantizedScorer.validate()`.
- Adds `rabitqByteTableMismatchWeightARM64` for `arm64 && !purego`, unrolled four bytes at a time over the existing query-local 256-entry per-byte tables.
- Keeps a portable Go fallback for `purego` and non-arm64 builds.
- Per-row code length and qdp side inputs are still checked in the hot scorer; public `rabitqQuantizedCosineScoreWithByteTables` still validates query/table shape and fails closed.

## Correctness

Tests run at `cf9acca12201ef9407d5ed27a6350f8ad1a4a2f7`:

```sh
GOWORK=off go test ./TreeDB/collections -run 'TestRabitQByte|TestColumnGraphRabitQQuantizedScorerMatchesOracle2451|TestVectorIndexSearcherRabitQQuantizedSearchWithBuffer2451|TestCollectionSearchVectorIndexWithBufferRabitQQuantized2452'
GOWORK=off go test -tags=purego ./TreeDB/collections -run 'TestRabitQByteTableMismatchWeightKernelMatchesPortable2525|TestRabitQByteTableScorerMatchesOracleVariedDimensions2477|TestColumnGraphRabitQQuantizedScorerMatchesOracle2451'
GOWORK=off go test ./TreeDB/internal/rabitq
GOWORK=off go test ./TreeDB/collections
GOOS=linux GOARCH=amd64 GOWORK=off go test -c -o /tmp/gomap_2525_validation_postcommit_20260607_061656/collections_linux_amd64.test ./TreeDB/collections
GOOS=linux GOARCH=arm64 GOWORK=off go test -c -o /tmp/gomap_2525_validation_postcommit_20260607_061656/collections_linux_arm64.test ./TreeDB/collections
```

Validation artifact: `/tmp/gomap_2525_validation_postcommit_20260607_061656`.

## Performance

All timed/profile jobs were run under `/tmp/gomap_2514_benchmark.lock`.

Focused scorer microbenchmark (`goos=darwin`, `goarch=arm64`, Apple M3, `GOMAXPROCS=8`, `GOWORK=off`):

- Baseline artifact: `/tmp/gomap_2525_origin_main_runtime_scorer_20260607_053407`
- Candidate artifact: `/tmp/gomap_2525_candidate_runtime_scorer_postcommit_20260607_060630`

| benchmark | origin/main | candidate | throughput origin | throughput candidate | delta | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| runtime score dims=128 | 13.09 ns/op | 11.46 ns/op | 76.4M scores/s | 87.3M scores/s | -12.4% | 0 | 0 |
| runtime score dims=1536 | 237.8 ns/op | 146.5 ns/op | 4.20M scores/s | 6.83M scores/s | -38.4% | 0 | 0 |
| runtime score search-loop (190 scores) | 41.06 µs/op | 31.08 µs/op | 24.4k searches/s | 32.2k searches/s | -24.3% | 0 | 0 |

CPU attribution:

- Baseline profile: `/tmp/gomap_2525_origin_main_runtime_scorer_profile_20260607_054750`
  - `BenchmarkRabitQByteTableRuntimeScoreSearchLoop2525`: 37,268 ns/op, 0 B/op, 0 allocs/op.
  - Top frame: `rabitqQuantizedCosineScoreWithByteTables` 1.93s flat / 76.6%.
- Candidate profile: `/tmp/gomap_2525_candidate_runtime_scorer_profile_latest_20260607_060540`
  - `BenchmarkRabitQByteTableRuntimeScoreSearchLoop2525`: 29,768 ns/op, 0 B/op, 0 allocs/op.
  - Top frame moves to `rabitqByteTableMismatchWeightARM64` 1.96s flat / 78.1%.

Integrated `SHAPE=10k_x_1536` RaBitQ collection timing:

- Origin/main full timing: `/tmp/gomap_2525_origin_main_integrated_timing_20260607_053934`
- Candidate postcommit full timing: `/tmp/gomap_2525_candidate_integrated_timing_postcommit_20260607_060728`
- Candidate c8 repeat: `/tmp/gomap_2525_candidate_c8_repeat_long_postcommit_20260607_061158`
- Origin/candidate rerank c8 50kx repeats: `/tmp/gomap_2525_origin_main_rerank_c8_50kx_20260607_061552`, `/tmp/gomap_2525_candidate_rerank_c8_50kx_postcommit_20260607_061452`
- Candidate rerank c1 repeat: `/tmp/gomap_2525_candidate_rerank_c1_repeat_20260607_055325`

| row | origin/main basis | candidate basis | throughput origin | throughput candidate | guardrails |
| --- | ---: | ---: | ---: | ---: | --- |
| qonly c=1 | 91.14 µs/op | 58.51 µs/op | 11.0k q/s | 17.1k q/s | pass; 0 B/op, 0 allocs/op, exact reads 0 |
| qonly c=8 | 16.91 µs/op | 16.19 µs/op (long repeat median) | 59.1k q/s | 61.8k q/s | pass; 0 B/op, 0 allocs/op, exact reads 0 |
| rerank32 c=1 | 75.37 µs/op | 66.95 µs/op (repeat median) | 13.3k q/s | 14.9k q/s | pass; exact calls 32, vector/norm bytes shortlist-bounded |
| rerank32 c=8 | 20.23 µs/op (50kx median) | 20.12 µs/op (50kx median) | 49.4k q/s | 49.7k q/s | pass; exact calls 32, vector/norm bytes shortlist-bounded |

The integrated c=8 rows are noisy at this scale; focused scorer evidence is the primary attribution. No allocation, exact-read, rerank-bound, recall, route, fallback, code-byte, or document/materialization guardrail regressed in the captured runs.

## CI / Reviews

Latest head: `cf9acca12201ef9407d5ed27a6350f8ad1a4a2f7`.

- GitHub CI: green. One unrelated `TreeDB/caching` race job flake (`TestVlogGenerationMaintenance_PeriodicLeafPackDoesNotBlockOnScheduledRetainedPruneQuietWait`) was retried in-place and passed.
- Internal high-thinking review: PASS, no blocking findings (`term_528fdd71-9c5c-41ba-a177-3dafdab849d5`).
- CodeRabbit: no actionable comments; status success.
- Codex: no major issues.
- Copilot: requested via `@copilot review` and reviewer request; GitHub acknowledged with 👀 but no surfaced findings/review as of the latest update.
- Review threads: none open.

## Rollout / Toggle Plan

Default on for native `arm64 && !purego`; build with `-tags=purego` or use a non-arm64 target for the portable fallback.

## Follow-ups

None required for this PR. Broader future-codec work remains outside `rabitq_1bit` v1.
