### PR TITLE
TreeDB: maintain collection text indexes on writes

### DIFF
--- a/TreeDB/collections/api.go
+++ b/TreeDB/collections/api.go
@@ -3624,14 +3624,6 @@ func (c *Collection) Insert(id, document []byte) ([]byte, error) {
 	if err := c.ensureWriteDomainOpen(); err != nil {
 		return nil, err
 	}
-	if len(c.meta.TextIndexes) != 0 {
-		unlockSchema := c.lockCollectionSchemaRead()
-		err := c.refreshTextIndexWriteGuard("Insert")
-		unlockSchema()
-		if err != nil {
-			return nil, err
-		}
-	}
 	if err := c.requireColumnStoreCommandWAL(c.meta, nil); err != nil {
 		return nil, err
 	}
@@ -3831,10 +3823,6 @@ func (c *Collection) insertOneNoIndexBuffered(id, document []byte) ([]byte, erro
 		return nil, errCollectionNotFound
 	}
 	c.meta = catalog.meta
-	if err := rejectTextIndexWriteUnavailable(catalog.meta, "Insert"); err != nil {
-		domain.mu.Unlock()
-		return nil, err
-	}
 	if err := c.requireColumnStoreCommandWAL(catalog.meta, nil); err != nil {
 		domain.mu.Unlock()
 		return nil, err
@@ -3843,7 +3831,7 @@ func (c *Collection) insertOneNoIndexBuffered(id, document []byte) ([]byte, erro
 		domain.mu.Unlock()
 		return nil, err
 	}
-	if indexed || len(catalog.meta.VectorIndexes) > 0 || plannerOptions.documentFormat != DocumentFormatJSON {
+	if indexed || len(catalog.meta.VectorIndexes) > 0 || len(catalog.meta.TextIndexes) > 0 || plannerOptions.documentFormat != DocumentFormatJSON {
 		domain.mu.Unlock()
 		return c.insertOneViaBatch(id, document)
 	}
@@ -3889,7 +3877,7 @@ func (c *Collection) canBufferCommandWALNoIndexInsertBatch(meta CollectionMeta, 
 	if !c.db.CommandWALEnabled() || c.db.DurabilityMode() == backenddb.DurabilityWALOffRelaxed {
 		return false
 	}
-	if len(meta.Indexes) != 0 || len(meta.VectorIndexes) != 0 || columnStoreWriteEnabled(meta) {
+	if len(meta.Indexes) != 0 || len(meta.VectorIndexes) != 0 || len(meta.TextIndexes) != 0 || columnStoreWriteEnabled(meta) {
 		return false
 	}
 	switch normalizedDocumentFormat(format) {
@@ -3907,7 +3895,7 @@ func (c *Collection) canUseCommandWALIndexedInsertBuffer(meta CollectionMeta, fo
 	if !c.db.CommandWALEnabled() || c.db.DurabilityMode() == backenddb.DurabilityWALOffRelaxed {
 		return false
 	}
-	if len(meta.VectorIndexes) != 0 || columnStoreWriteEnabled(meta) {
+	if len(meta.VectorIndexes) != 0 || len(meta.TextIndexes) != 0 || columnStoreWriteEnabled(meta) {
 		return false
 	}
 	if !c.shouldBufferIndexedInserts(meta) {
@@ -4399,7 +4387,7 @@ func (c *Collection) flushBufferedNoIndexLocked(domain *collectionWriteDomain) e
 }
 
 func (c *Collection) shouldBufferIndexedInserts(meta CollectionMeta) bool {
-	return c != nil && c.writeDomain != nil && meta.Options.BufferedIndexedWrites && len(meta.Indexes) > 0
+	return c != nil && c.writeDomain != nil && meta.Options.BufferedIndexedWrites && len(meta.Indexes) > 0 && len(meta.TextIndexes) == 0
 }
 
 func (c *Collection) shouldBufferIndexedDeletes(meta CollectionMeta) bool {
@@ -4407,6 +4395,7 @@ func (c *Collection) shouldBufferIndexedDeletes(meta CollectionMeta) bool {
 		c.writeDomain != nil &&
 		meta.Options.BufferedIndexedWrites &&
 		len(meta.Indexes) > 0 &&
+		len(meta.TextIndexes) == 0 &&
 		!collectionMetaHasSecondaryUniqueIndex(meta)
 }
 
@@ -8866,11 +8855,7 @@ func (c *Collection) insertOneNoIndex(id, document []byte) ([]byte, error) {
 		return nil, err
 	}
 	c.meta = catalog.meta
-	if err := rejectTextIndexWriteUnavailable(c.meta, "Insert"); err != nil {
-		_ = snap.Close()
-		return nil, err
-	}
-	if len(c.meta.Indexes) > 0 || len(c.meta.VectorIndexes) > 0 {
+	if len(c.meta.Indexes) > 0 || len(c.meta.VectorIndexes) > 0 || len(c.meta.TextIndexes) > 0 {
 		_ = snap.Close()
 		return c.insertOneViaBatch(id, document)
 	}
@@ -9112,10 +9097,6 @@ func (c *Collection) insertBatchOnceWithOptimisticPlanning(ids, documents [][]by
 		return nil, err, true
 	}
 	meta := catalog.meta
-	if err := rejectTextIndexWriteUnavailable(meta, "InsertBatch"); err != nil {
-		closePlanningSnapshot()
-		return nil, err, true
-	}
 	if len(meta.Indexes) == 0 {
 		closePlanningSnapshot()
 		return nil, nil, false
@@ -9251,6 +9232,7 @@ func (c *Collection) insertBatchOnceWithLockState(
 	if !commandWALActive &&
 		c.canBufferNoIndexInsertBatchAck() &&
 		len(c.meta.Indexes) == 0 &&
+		len(c.meta.TextIndexes) == 0 &&
 		canBufferNoIndexInsertBatchFormat(c.meta.Options.DocumentFormat, trustedValidBSON) {
 		skipInitialNoIndexFlush = true
 	}
@@ -9297,10 +9279,6 @@ func (c *Collection) insertBatchOnceWithLockState(
 	}
 	meta := catalog.meta
 	c.meta = meta
-	if err := rejectTextIndexWriteUnavailable(meta, "InsertBatch"); err != nil {
-		closePlanningSnapshot()
-		return nil, err
-	}
 	if err := c.requireColumnStoreCommandWAL(meta, commandWALIntent); err != nil {
 		closePlanningSnapshot()
 		return nil, err
@@ -9331,7 +9309,7 @@ func (c *Collection) insertBatchOnceWithLockState(
 	plannerOptions.allowTemplateV1Stored = templateEncoder.allowsTemplateV1StoredDocuments(c)
 	plannerOptions = collectionOptionsWithTemplateV1Resolver(plannerOptions, snap, catalog)
 	if skipInitialNoIndexFlush &&
-		(len(meta.Indexes) != 0 || !canBufferNoIndexInsertBatchFormat(plannerOptions.documentFormat, trustedValidBSON)) {
+		(len(meta.Indexes) != 0 || len(meta.TextIndexes) != 0 || !canBufferNoIndexInsertBatchFormat(plannerOptions.documentFormat, trustedValidBSON)) {
 		catalog, meta, plannerOptions, err = c.reloadInsertBatchPlanningSnapshot(&snap, trustedValidBSON, c.flushBufferedNoIndex)
 		if err != nil {
 			return nil, err
@@ -9367,10 +9345,6 @@ func (c *Collection) insertBatchOnceWithLockState(
 		}
 		meta = catalog.meta
 		c.meta = meta
-		if err := rejectTextIndexWriteUnavailable(meta, "InsertBatch"); err != nil {
-			closePlanningSnapshot()
-			return nil, err
-		}
 		plannerOptions, err = collectionPlannerOptionsForDB(c.db, meta)
 		if err != nil {
 			closePlanningSnapshot()
@@ -9416,10 +9390,6 @@ func (c *Collection) insertBatchOnceWithLockState(
 					return nil, err
 				}
 				c.meta = meta
-				if err := rejectTextIndexWriteUnavailable(meta, "InsertBatch"); err != nil {
-					closePlanningSnapshot()
-					return nil, err
-				}
 				plannerOptions.learnTemplateIDs = templateEncoder != nil
 				plannerOptions.allowTemplateV1Stored = templateEncoder.allowsTemplateV1StoredDocuments(c)
 				commandWALNoIndexBufferedMode = c.canBufferCommandWALNoIndexInsertBatch(meta, plannerOptions.documentFormat, commandWALIntent, len(documents))
@@ -9433,6 +9403,7 @@ func (c *Collection) insertBatchOnceWithLockState(
 	}
 	if !commandWALActive &&
 		len(meta.Indexes) == 0 &&
+		len(meta.TextIndexes) == 0 &&
 		c.canBufferNoIndexInsertBatchAck() &&
 		canBufferNoIndexInsertBatchFormat(plannerOptions.documentFormat, trustedValidBSON) {
 		if resultIDs, buffered, err := c.bufferNoIndexInsertBatch(c.writeDomain, catalog, snap, plannerOptions, ids, documents, execOpts); buffered {
@@ -9460,6 +9431,9 @@ func (c *Collection) insertBatchOnceWithLockState(
 	}
 	keepDirectBufferedInsertPlanningLocked := directBufferedInsertAccumulators && shouldKeepDirectBufferedInsertPlanningLocked(plannerOptions, len(documents), mutationLockWait)
 	unlockForPlanning := shouldUnlockInsertPlanning(plannerOptions, indexedMemtablesEnabled, bufferIndexedInserts, keepDirectBufferedInsertPlanningLocked)
+	if len(meta.TextIndexes) > 0 {
+		unlockForPlanning = false
+	}
 	preflightPersistedConflicts := false
 	preflight := insertBatchPreflight{}
 	if unlockForPlanning {
@@ -9502,6 +9476,13 @@ func (c *Collection) insertBatchOnceWithLockState(
 		plan.stats.BufferedIndexedBatches = 1
 	} else if indexedMemtablesEnabled {
 		plan.stats.BufferedIndexedBypassBatches = 1
+	}
+	if len(meta.TextIndexes) > 0 {
+		if err := appendTextIndexInsertPlanDeltas(snap, catalog, plannerOptions, plan); err != nil {
+			closePlanningSnapshot()
+			resetCollectionRunTables(plan.runs)
+			return nil, err
+		}
 	}
 	if !insertBatchPlanHasRootWork(plan) {
 		closePlanningSnapshot()
@@ -10286,6 +10267,33 @@ func (c *Collection) insertBatchNoIndex(
 			})
 		}
 	}
+	var textTables []memtable.Table
+	var textIters []iterator.UnsafeIterator
+	defer func() {
+		for _, it := range textIters {
+			_ = it.Close()
+		}
+		resetCollectionTables(textTables)
+	}()
+	if len(c.meta.TextIndexes) > 0 {
+		textRootNames := make([]string, 0, len(c.meta.TextIndexes)*3)
+		textBaseRootIDs := make(map[string]uint64, len(c.meta.TextIndexes)*3)
+		textPolicies := make([]backenddb.OrderedRootStoragePolicy, 0, len(c.meta.TextIndexes)*3)
+		if err := appendTextIndexNoIndexInsertDeltas(snap, catalog, plannerOptions, entries, &textRootNames, textBaseRootIDs, &textPolicies, &textTables); err != nil {
+			return nil, err
+		}
+		for i, textRootName := range textRootNames {
+			textIter := textTables[i].NewIterator(nil, nil)
+			textIters = append(textIters, textIter)
+			rootNames = append(rootNames, textRootName)
+			baseRootIDs[textRootName] = textBaseRootIDs[textRootName]
+			ordered = append(ordered, backenddb.OrderedRootDeltaPublishInput{
+				BaseRoot:      textBaseRootIDs[textRootName],
+				Iter:          textIter,
+				StoragePolicy: textPolicies[i],
+			})
+		}
+	}
 	var newSystemRoot uint64
 	var rootIDs []uint64
 	if columnStoreWriteEnabled(c.meta) {
@@ -10375,9 +10383,6 @@ func (c *Collection) DeleteDocument(documentID []byte) (bool, error) {
 	}
 	unlockSchema := c.lockCollectionSchemaRead()
 	defer unlockSchema()
-	if err := c.refreshTextIndexWriteGuard("DeleteDocument"); err != nil {
-		return false, err
-	}
 	if len(documentID) == 0 {
 		return false, errors.New("collections: document id cannot be empty")
 	}
@@ -10435,9 +10440,6 @@ func (c *Collection) DeleteBatch(documentIDs [][]byte) (int, error) {
 	}
 	unlockSchema := c.lockCollectionSchemaRead()
 	defer unlockSchema()
-	if err := c.refreshTextIndexWriteGuard("DeleteBatch"); err != nil {
-		return 0, err
-	}
 	for i, id := range documentIDs {
 		if len(id) == 0 {
 			return 0, fmt.Errorf("collections: document id cannot be empty at index %d", i)
@@ -10515,10 +10517,6 @@ func (c *Collection) deleteBatchOnce(documentIDs [][]byte, commandWALIntent *bac
 		return 0, err
 	}
 	c.meta = catalog.meta
-	if err := rejectTextIndexWriteUnavailable(c.meta, "DeleteBatch"); err != nil {
-		_ = snap.Close()
-		return 0, err
-	}
 	plannerOptions, err := collectionPlannerOptionsForDB(c.db, c.meta)
 	if err != nil {
 		_ = snap.Close()
@@ -10563,8 +10561,9 @@ func (c *Collection) deleteBatchOnce(documentIDs [][]byte, commandWALIntent *bac
 	}
 
 	type existingDelete struct {
-		id    []byte
-		state documentIndexState
+		id       []byte
+		state    documentIndexState
+		document []byte
 	}
 	existing := make([]existingDelete, 0, len(documentIDs))
 	for _, documentID := range documentIDs {
@@ -10588,6 +10587,9 @@ func (c *Collection) deleteBatchOnce(documentIDs [][]byte, commandWALIntent *bac
 			continue
 		}
 		item := existingDelete{id: documentID}
+		if len(c.meta.TextIndexes) > 0 {
+			item.document = bytes.Clone(entry.Value)
+		}
 		if len(runtimes) > 0 {
 			item.state, err = loadDeleteIndexState(snap, catalog, documentID, entry.Value, runtimes, plannerOptions)
 			if err != nil {
@@ -10661,7 +10663,19 @@ func (c *Collection) deleteBatchOnce(documentIDs [][]byte, commandWALIntent *bac
 		}
 	}
 
-	if !commandWALActive {
+	fallbackDocuments := make([][]byte, 0, len(existing))
+	if len(c.meta.TextIndexes) > 0 {
+		for _, item := range existing {
+			fallbackDocuments = append(fallbackDocuments, item.document)
+		}
+		if err := appendTextIndexDeleteDeltas(snap, catalog, plannerOptions, deleteIDs, fallbackDocuments, &rootNames, baseRootIDs, &policies, &deltaTables); err != nil {
+			_ = snap.Close()
+			resetCollectionTables(deltaTables)
+			return 0, err
+		}
+	}
+
+	if !commandWALActive && len(c.meta.TextIndexes) == 0 {
 		if buffered, err := c.bufferIndexedDeleteTablesLocked(catalog, baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, policies, deltaTables, len(existing)); buffered || err != nil {
 			_ = snap.Close()
 			if err != nil {
@@ -10765,10 +10779,6 @@ func (c *Collection) deleteDocumentOnce(documentID []byte, commandWALIntent *bac
 		return false, err
 	}
 	c.meta = catalog.meta
-	if err := rejectTextIndexWriteUnavailable(c.meta, "DeleteDocument"); err != nil {
-		_ = snap.Close()
-		return false, err
-	}
 	plannerOptions, err := collectionPlannerOptionsForDB(c.db, c.meta)
 	if err != nil {
 		_ = snap.Close()
@@ -10891,7 +10901,14 @@ func (c *Collection) deleteDocumentOnce(documentID []byte, commandWALIntent *bac
 	}
 	// Keep the base snapshot pinned through publish so page reuse cannot invalidate
 	// base roots before stale-root validation rejects concurrent modifications.
-	if !commandWALActive {
+	if len(c.meta.TextIndexes) > 0 {
+		if err := appendTextIndexDeleteDeltas(snap, catalog, plannerOptions, [][]byte{documentID}, [][]byte{entry.Value}, &rootNames, baseRootIDs, &policies, &deltaTables); err != nil {
+			_ = snap.Close()
+			resetCollectionTables(deltaTables)
+			return false, err
+		}
+	}
+	if !commandWALActive && len(c.meta.TextIndexes) == 0 {
 		if buffered, err := c.bufferIndexedDeleteTablesLocked(catalog, baseCommitSeq, baseSystemRoot, rootNames, baseRootIDs, policies, deltaTables, 1); buffered || err != nil {
 			_ = snap.Close()
 			if err != nil {
@@ -11009,9 +11026,6 @@ func (c *Collection) Update(documentID []byte, update func(current []byte) (repl
 	}
 	unlockSchema := c.lockCollectionSchemaRead()
 	defer unlockSchema()
-	if err := c.refreshTextIndexWriteGuard("Update"); err != nil {
-		return false, false, err
-	}
 	if err := c.requireColumnStoreCommandWAL(c.meta, nil); err != nil {
 		return false, false, err
 	}
@@ -11177,9 +11191,6 @@ func (c *Collection) updateBatch(items []UpdateBatchItem, mode updateBatchMode) 
 	}
 	unlockSchema := c.lockCollectionSchemaRead()
 	defer unlockSchema()
-	if err := c.refreshTextIndexWriteGuard("UpdateBatch"); err != nil {
-		return nil, false, err
-	}
 	if len(items) == 0 {
 		c.setLastUpdateStats(CollectionUpdateStats{})
 		return nil, true, nil
@@ -13352,10 +13363,6 @@ func (c *Collection) updateDocumentOnceApply(documentID []byte, update func(curr
 		return false, false, err
 	}
 	c.meta = catalog.meta
-	if err := rejectTextIndexWriteUnavailable(c.meta, "Update"); err != nil {
-		_ = snap.Close()
-		return false, false, err
-	}
 	plannerOptions, err := collectionPlannerOptionsForDB(c.db, c.meta)
 	if err != nil {
 		_ = snap.Close()
@@ -13374,7 +13381,7 @@ func (c *Collection) updateDocumentOnceApply(documentID []byte, update func(curr
 		Indexes: len(c.meta.Indexes),
 	}
 	plannerOptions = collectionOptionsWithTemplateV1Resolver(plannerOptions, snap, catalog)
-	primaryOnlyUpdate := len(c.meta.Indexes) == 0
+	primaryOnlyUpdate := len(c.meta.Indexes) == 0 && len(c.meta.TextIndexes) == 0
 	baseUserRoot := snapshotUserRoot(snap)
 	baseSystemRoot := snapshotSystemRoot(snap)
 	baseCommitSeq := snapshotCommitSeq(snap)
@@ -13540,10 +13547,10 @@ func (c *Collection) updateDocumentOnceApply(documentID []byte, update func(curr
 		}
 	}
 
-	rootNames := make([]string, 0, 2+len(runtimes))
-	baseRootIDs := make(map[string]uint64, 2+len(runtimes))
-	policies := make([]backenddb.OrderedRootStoragePolicy, 0, 2+len(runtimes))
-	deltaTables := make([]memtable.Table, 0, 2+len(runtimes))
+	rootNames := make([]string, 0, 2+len(runtimes)+len(c.meta.TextIndexes)*3)
+	baseRootIDs := make(map[string]uint64, 2+len(runtimes)+len(c.meta.TextIndexes)*3)
+	policies := make([]backenddb.OrderedRootStoragePolicy, 0, 2+len(runtimes)+len(c.meta.TextIndexes)*3)
+	deltaTables := make([]memtable.Table, 0, 2+len(runtimes)+len(c.meta.TextIndexes)*3)
 
 	if len(templateRecords) > 0 {
 		phaseStart = updateBatchStatsNow(detailedStats)
@@ -13675,6 +13682,14 @@ func (c *Collection) updateDocumentOnceApply(documentID []byte, update func(curr
 			}
 		}
 		stats.SecondaryRunBuild += updateBatchStatsSince(detailedStats, phaseStart)
+	}
+	if len(c.meta.TextIndexes) > 0 {
+		textChanged := []preparedBatchUpdate{{documentID: documentID, document: document}}
+		if err := appendTextIndexUpdateDeltas(snap, catalog, plannerOptions, textChanged, &rootNames, baseRootIDs, &policies, &deltaTables); err != nil {
+			_ = snap.Close()
+			resetCollectionTables(deltaTables)
+			return false, false, err
+		}
 	}
 	// Keep the base snapshot pinned through publish so page reuse cannot invalidate
 	// base roots before stale-root validation rejects concurrent modifications.
@@ -14408,6 +14423,9 @@ func (c *Collection) shouldUseDirectBufferedUpdatePlan(meta CollectionMeta, opts
 		return false
 	}
 	if columnStoreNeedsRetainedPayloadTransform(meta) {
+		return false
+	}
+	if len(meta.TextIndexes) != 0 {
 		return false
 	}
 	if len(meta.Indexes) == 0 {
@@ -15255,10 +15273,6 @@ func (c *Collection) buildUpdateBatchPlan(items []updateBatchItem, mode updateBa
 		return nil, err
 	}
 	meta := catalog.meta
-	if err := rejectTextIndexWriteUnavailable(meta, "UpdateBatch"); err != nil {
-		_ = snap.Close()
-		return nil, err
-	}
 	if err := c.requireColumnStoreCommandWAL(meta, commandWALIntent); err != nil {
 		_ = snap.Close()
 		return nil, err
@@ -15279,6 +15293,7 @@ func (c *Collection) buildUpdateBatchPlan(items []updateBatchItem, mode updateBa
 	retainedPayloadTransform := columnStoreNeedsRetainedPayloadTransform(meta)
 	canBufferIndexedUpdateBatch := !retainedPayloadTransform &&
 		len(meta.Indexes) > 0 &&
+		len(meta.TextIndexes) == 0 &&
 		(!collectionMetaHasSecondaryUniqueIndex(meta) ||
 			mode == updateBatchModeNoSecondaryUniqueIndexes ||
 			mode == updateBatchModeNoSecondaryUniqueIndexChanges)
@@ -15935,6 +15950,15 @@ func (c *Collection) buildUpdateBatchPlan(items []updateBatchItem, mode updateBa
 			delete(secondaryTables, rootName)
 		}
 		stats.SecondaryRunBuild += updateBatchStatsSince(detailedStats, phaseStart)
+	}
+	if len(meta.TextIndexes) > 0 {
+		if err := appendTextIndexUpdateDeltas(snap, catalog, plannerOptions, changed, &rootNames, baseRootIDs, &policies, &deltaTables); err != nil {
+			_ = snap.Close()
+			return nil, err
+		}
+		for len(uniqueSecondary) < len(rootNames) {
+			uniqueSecondary = append(uniqueSecondary, -1)
+		}
 	}
 
 	// Tables moved into deltaTables are nil/deleted above; only unused scratch

--- a/TreeDB/collections/bson_set_update.go
+++ b/TreeDB/collections/bson_set_update.go
@@ -59,9 +59,6 @@ func (c *Collection) UpdateBSONSet(documentID []byte, fields []BSONSetField) (bo
 	}
 	unlockSchema := c.lockCollectionSchemaRead()
 	defer unlockSchema()
-	if err := c.refreshTextIndexWriteGuard("UpdateBSONSet"); err != nil {
-		return false, false, err
-	}
 	if err := c.validateBSONSetDocumentFormat(); err != nil {
 		return false, false, err
 	}
@@ -162,9 +159,6 @@ func (c *Collection) updateBSONSetBatch(items []BSONSetUpdateBatchItem, mode upd
 	}
 	unlockSchema := c.lockCollectionSchemaRead()
 	defer unlockSchema()
-	if err := c.refreshTextIndexWriteGuard("UpdateBSONSetBatch"); err != nil {
-		return nil, false, err
-	}
 	if err := c.validateBSONSetDocumentFormat(); err != nil {
 		return nil, false, err
 	}

--- a/TreeDB/collections/planner.go
+++ b/TreeDB/collections/planner.go
@@ -99,6 +99,7 @@ type insertBatchPlan struct {
 	allUniqueProbeRunsBuilt    bool
 	templateRecords            []templateV1Record
 	templateLearned            []templateV1LearnedTemplate
+	templateResolver           templateV1Resolver
 	stats                      insertBatchPlanStats
 }
 
@@ -296,6 +297,7 @@ func (p insertBatchPlanner) planInsertBatchWithPreflight(ids, documents [][]byte
 		allUniqueProbeRunsBuilt:    allUniqueProbeRunsBuilt,
 		templateRecords:            templateRecords,
 		templateLearned:            templateLearned,
+		templateResolver:           templateResolver,
 		stats:                      insertBatchPlanStats{CollectionInsertStats: stats},
 	}
 	if p.directBufferedRuns {

--- a/TreeDB/collections/text_catalog.go
+++ b/TreeDB/collections/text_catalog.go
@@ -8,9 +8,9 @@ import (
 )
 
 // CreateTextIndex adds a collection-native text index and backfills persistent
-// postings, text-state, and text-stats roots from the current documents. It
-// does not enable mutation maintenance or SearchText execution; those paths
-// remain fail-closed until later #1764 milestones.
+// postings, text-state, and text-stats roots from the current documents. Write
+// paths maintain those roots after creation; SearchText execution remains
+// fail-closed until a later #1764 milestone.
 func (c *Collection) CreateTextIndex(def TextIndexDefinition) (*CollectionMeta, TextIndexBackfillStats, error) {
 	var emptyStats TextIndexBackfillStats
 	if c == nil {

--- a/TreeDB/collections/text_index.go
+++ b/TreeDB/collections/text_index.go
@@ -4,15 +4,12 @@ import (
 	"errors"
 	"fmt"
 	"math"
-
-	backenddb "github.com/snissn/gomap/TreeDB/db"
 )
 
 // ErrTextIndexUnavailable reports that a declared collection text index cannot
-// yet be used for mutation maintenance or search execution. Early #1764
-// milestones land metadata/analyzer/storage contracts before write-path
-// maintenance and ranked query execution; write/search paths fail closed instead
-// of silently diverging, scanning, or returning incomplete text-index results.
+// yet be used for search execution. #1764 M3 maintains postings/text-state/stats
+// on writes, but ranked query execution remains fail-closed instead of silently
+// scanning or returning incomplete text-index results.
 var ErrTextIndexUnavailable = errors.New("collections: text index unavailable")
 
 // TextAnalyzer names a collection text analyzer. The zero value normalizes to
@@ -25,8 +22,8 @@ const (
 
 // TextIndexDefinition declares a persistent collection-native inverted index.
 // M2 stores and validates metadata plus versioned postings/text-state/stats
-// storage; mutation maintenance and SearchText execution land in later #1764
-// milestones.
+// storage. #1764 M3 maintains these roots on writes; SearchText execution lands
+// in a later milestone.
 type TextIndexDefinition struct {
 	Name             string            `json:"name"`
 	Fields           []TextIndexField  `json:"fields"`
@@ -154,42 +151,4 @@ func collectionTextRootNames(collection, indexName string) []string {
 		collectionTextStateRootName(collection, indexName),
 		collectionTextStatsRootName(collection, indexName),
 	}
-}
-
-func rejectTextIndexWriteUnavailable(meta CollectionMeta, operation string) error {
-	if len(meta.TextIndexes) == 0 {
-		return nil
-	}
-	if operation == "" {
-		operation = "write"
-	}
-	return fmt.Errorf("%w: collection %q has %d declared text index(es); %s requires postings/text-state/stats maintenance that is not implemented in this milestone", ErrTextIndexUnavailable, meta.Name, len(meta.TextIndexes), operation)
-}
-
-func (c *Collection) refreshTextIndexWriteGuard(operation string) error {
-	if c == nil {
-		return errCollectionNil
-	}
-	if err := rejectTextIndexWriteUnavailable(c.meta, operation); !errors.Is(err, ErrTextIndexUnavailable) {
-		return err
-	}
-	if c.db == nil {
-		return errCollectionDBNil
-	}
-	snap := c.db.AcquireSnapshot()
-	if snap == nil {
-		return backenddb.ErrClosed
-	}
-	defer func() { _ = snap.Close() }()
-	catalog, err := c.catalogForSnapshot(snap)
-	if err != nil {
-		return err
-	}
-	if catalog == nil {
-		return errCollectionNotFound
-	}
-	c.meta = catalog.meta
-	c.rememberCatalog(snap, catalog)
-	c.noteWriteDomainCatalog(snapshotSystemRoot(snap), catalog)
-	return rejectTextIndexWriteUnavailable(catalog.meta, operation)
 }

--- a/TreeDB/collections/text_index_test.go
+++ b/TreeDB/collections/text_index_test.go
@@ -263,7 +263,7 @@ func TestCollectionTextRootStoragePolicies(t *testing.T) {
 	}
 }
 
-func TestCollectionTextIndexedOperationsFailClosedUntilStorageLands(t *testing.T) {
+func TestCollectionTextIndexedWritesMaintainStorageAndSearchFailsClosed(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {
 		t.Fatalf("open db: %v", err)
@@ -283,21 +283,15 @@ func TestCollectionTextIndexedOperationsFailClosedUntilStorageLands(t *testing.T
 	if err != nil {
 		t.Fatalf("open collection: %v", err)
 	}
-	if _, err := col.InsertBatch([][]byte{[]byte("d1")}, [][]byte{[]byte(`{"body":"refund policy"}`)}); !errors.Is(err, ErrTextIndexUnavailable) {
-		t.Fatalf("InsertBatch err=%v want ErrTextIndexUnavailable", err)
+	if _, err := col.InsertBatch([][]byte{[]byte("d1")}, [][]byte{[]byte(`{"body":"refund policy"}`)}); err != nil {
+		t.Fatalf("InsertBatch: %v", err)
 	}
-	if _, err := col.DeleteDocument([]byte("d1")); !errors.Is(err, ErrTextIndexUnavailable) {
-		t.Fatalf("DeleteDocument err=%v want ErrTextIndexUnavailable", err)
+	storage, err := col.TextIndexStorageStats("lexical")
+	if err != nil {
+		t.Fatalf("TextIndexStorageStats: %v", err)
 	}
-	if _, _, err := col.Update([]byte("d1"), func(current []byte) ([]byte, bool, error) {
-		return current, false, nil
-	}); !errors.Is(err, ErrTextIndexUnavailable) {
-		t.Fatalf("Update err=%v want ErrTextIndexUnavailable", err)
-	}
-	if _, err := col.UpdateBatch([]UpdateBatchItem{{DocumentID: []byte("d1"), Update: func(current []byte) ([]byte, bool, error) {
-		return current, false, nil
-	}}}); !errors.Is(err, ErrTextIndexUnavailable) {
-		t.Fatalf("UpdateBatch err=%v want ErrTextIndexUnavailable", err)
+	if storage.Documents != 1 || storage.StateEntries != 1 || storage.PostingEntries != 2 {
+		t.Fatalf("storage stats after maintained insert=%+v want docs=1 state=1 postings=2", storage)
 	}
 
 	response, err := col.SearchText(TextSearchOptions{IndexName: "lexical", Query: "refund AND policy", TopK: 10})

--- a/TreeDB/collections/text_maintenance.go
+++ b/TreeDB/collections/text_maintenance.go
@@ -1,0 +1,486 @@
+package collections
+
+import (
+	"bytes"
+	"errors"
+	"sort"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/internal/memtable"
+)
+
+type textDocumentMutation struct {
+	documentID  []byte
+	oldDocument []byte
+	deleteOld   bool
+	newDocument []byte
+	setNew      bool
+}
+
+type textStatsDelta struct {
+	Documents int64
+	Terms     map[string]textStatsTermDelta
+	Fields    map[string]textStatsFieldDelta
+}
+
+type textStatsTermDelta struct {
+	DocumentFrequency  int64
+	TotalTermFrequency int64
+}
+
+type textStatsFieldDelta struct {
+	DocumentCount   int64
+	TotalTokenCount int64
+}
+
+func appendTextIndexMutationDeltas(
+	snap *backenddb.Snapshot,
+	catalog *collectionCatalog,
+	opts collectionOptions,
+	mutations []textDocumentMutation,
+	rootNames *[]string,
+	baseRootIDs map[string]uint64,
+	policies *[]backenddb.OrderedRootStoragePolicy,
+	deltaTables *[]memtable.Table,
+) error {
+	if snap == nil {
+		return backenddb.ErrClosed
+	}
+	if catalog == nil {
+		return errCollectionNotFound
+	}
+	if len(catalog.meta.TextIndexes) == 0 || len(mutations) == 0 {
+		return nil
+	}
+	if rootNames == nil || policies == nil || deltaTables == nil {
+		return errors.New("collections: text index maintenance missing root accumulator")
+	}
+	if baseRootIDs == nil {
+		return errors.New("collections: text index maintenance missing base root map")
+	}
+	for _, def := range catalog.meta.TextIndexes {
+		if err := appendSingleTextIndexMutationDeltas(snap, catalog, opts, def, mutations, rootNames, baseRootIDs, policies, deltaTables); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func appendSingleTextIndexMutationDeltas(
+	snap *backenddb.Snapshot,
+	catalog *collectionCatalog,
+	opts collectionOptions,
+	def TextIndexDefinition,
+	mutations []textDocumentMutation,
+	rootNames *[]string,
+	baseRootIDs map[string]uint64,
+	policies *[]backenddb.OrderedRootStoragePolicy,
+	deltaTables *[]memtable.Table,
+) error {
+	postingsRootName := collectionTextIndexRootName(catalog.meta.Name, def.Name)
+	stateRootName := collectionTextStateRootName(catalog.meta.Name, def.Name)
+	statsRootName := collectionTextStatsRootName(catalog.meta.Name, def.Name)
+	postingsTable := newCollectionRunTable(0)
+	stateTable := newCollectionRunTable(len(mutations))
+	statsDelta := textStatsDelta{}
+	success := false
+	defer func() {
+		if success {
+			return
+		}
+		resetCollectionRunTable(postingsTable)
+		resetCollectionRunTable(stateTable)
+	}()
+
+	for _, mutation := range mutations {
+		if len(mutation.documentID) == 0 {
+			return errors.New("collections: text index maintenance document id cannot be empty")
+		}
+		if mutation.deleteOld {
+			oldState, err := loadTextDocumentStateForMutation(snap, catalog, def, mutation.documentID, mutation.oldDocument, opts)
+			if err != nil {
+				return err
+			}
+			deleteTextPostingsForDocument(postingsTable, mutation.documentID, oldState)
+			stateTable.DeleteSteal(encodeTextStateKey(mutation.documentID))
+			statsDelta.addState(oldState, -1)
+		}
+		if mutation.setNew {
+			newState, err := analyzeTextIndexStoredDocument(def, mutation.newDocument, opts)
+			if err != nil {
+				return err
+			}
+			addTextPostingsForDocument(postingsTable, mutation.documentID, textAnalysisFromDocumentState(newState))
+			stateTable.SetSteal(encodeTextStateKey(mutation.documentID), encodeTextDocumentStateValue(newState))
+			statsDelta.addState(newState, 1)
+		}
+	}
+
+	statsTable := newCollectionRunTable(0)
+	if err := buildTextStatsDeltaTable(snap, catalog, statsRootName, statsDelta, statsTable); err != nil {
+		resetCollectionRunTable(statsTable)
+		return err
+	}
+	if postingsTable.Len() > 0 {
+		postingsTable.Freeze()
+		appendTextRootDelta(rootNames, baseRootIDs, policies, deltaTables, postingsRootName, catalog.rootID(postingsRootName), mustBackendTextRootStoragePolicy(def.StoragePolicy), postingsTable)
+		postingsTable = nil
+	}
+	if stateTable.Len() > 0 {
+		stateTable.Freeze()
+		appendTextRootDelta(rootNames, baseRootIDs, policies, deltaTables, stateRootName, catalog.rootID(stateRootName), opts.indexStateStoragePolicy, stateTable)
+		stateTable = nil
+	}
+	if statsTable.Len() > 0 {
+		statsTable.Freeze()
+		appendTextRootDelta(rootNames, baseRootIDs, policies, deltaTables, statsRootName, catalog.rootID(statsRootName), opts.indexStateStoragePolicy, statsTable)
+	} else {
+		resetCollectionRunTable(statsTable)
+	}
+	success = true
+	return nil
+}
+
+func appendTextRootDelta(rootNames *[]string, baseRootIDs map[string]uint64, policies *[]backenddb.OrderedRootStoragePolicy, deltaTables *[]memtable.Table, rootName string, baseRootID uint64, policy backenddb.OrderedRootStoragePolicy, table memtable.Table) {
+	*rootNames = append(*rootNames, rootName)
+	baseRootIDs[rootName] = baseRootID
+	*policies = append(*policies, policy)
+	*deltaTables = append(*deltaTables, table)
+}
+
+func analyzeTextIndexStoredDocument(def TextIndexDefinition, document []byte, opts collectionOptions) (textDocumentStateValue, error) {
+	jsonDocument, err := materializeTextBackfillDocumentJSON(document, opts)
+	if err != nil {
+		return textDocumentStateValue{}, err
+	}
+	analysis, err := analyzeTextIndexDocument(def, jsonDocument)
+	if err != nil {
+		return textDocumentStateValue{}, err
+	}
+	return textDocumentStateValueFromAnalysis(analysis), nil
+}
+
+func loadTextDocumentStateForMutation(snap *backenddb.Snapshot, catalog *collectionCatalog, def TextIndexDefinition, documentID, fallbackDocument []byte, opts collectionOptions) (textDocumentStateValue, error) {
+	stateRootName := collectionTextStateRootName(catalog.meta.Name, def.Name)
+	stateKey := encodeTextStateKey(documentID)
+	raw, ok, err := collectionGetAppendAtCatalogRoot(snap, catalog, stateRootName, stateKey, nil)
+	if err != nil {
+		return textDocumentStateValue{}, err
+	}
+	if ok {
+		return decodeTextDocumentStateValue(raw)
+	}
+	if fallbackDocument != nil {
+		return analyzeTextIndexStoredDocument(def, fallbackDocument, opts)
+	}
+	return textDocumentStateValue{}, errMalformedTextStorage("missing text-state for collection %q index %q document %q", catalog.meta.Name, def.Name, string(documentID))
+}
+
+func deleteTextPostingsForDocument(table memtable.Table, documentID []byte, state textDocumentStateValue) int {
+	if table == nil {
+		return 0
+	}
+	terms := textDocumentStateTerms(state)
+	for _, term := range terms {
+		table.DeleteSteal(encodeTextPostingKey(term, documentID))
+	}
+	return len(terms)
+}
+
+func textDocumentStateTerms(state textDocumentStateValue) []string {
+	seen := make(map[string]struct{})
+	for _, field := range state.Fields {
+		for _, term := range field.Terms {
+			seen[term.Term] = struct{}{}
+		}
+	}
+	terms := make([]string, 0, len(seen))
+	for term := range seen {
+		terms = append(terms, term)
+	}
+	sort.Strings(terms)
+	return terms
+}
+
+func textAnalysisFromDocumentState(state textDocumentStateValue) textAnalyzedDocument {
+	analysis := textAnalyzedDocument{Fields: make([]textAnalyzedField, 0, len(state.Fields))}
+	for _, fieldState := range state.Fields {
+		field := textAnalyzedField{Field: fieldState.Field, Length: fieldState.Length, Terms: make(map[string]*textAnalyzedTerm, len(fieldState.Terms))}
+		for _, termState := range fieldState.Terms {
+			field.Terms[termState.Term] = &textAnalyzedTerm{
+				Term:      termState.Term,
+				Frequency: termState.Frequency,
+				Positions: append([]uint32(nil), termState.Positions...),
+				Offsets:   append([]textTokenOffset(nil), termState.Offsets...),
+			}
+		}
+		analysis.Fields = append(analysis.Fields, field)
+	}
+	return analysis
+}
+
+func (d *textStatsDelta) addState(state textDocumentStateValue, sign int64) {
+	if sign == 0 {
+		return
+	}
+	d.Documents += sign
+	if d.Terms == nil {
+		d.Terms = make(map[string]textStatsTermDelta)
+	}
+	if d.Fields == nil {
+		d.Fields = make(map[string]textStatsFieldDelta)
+	}
+	seenTerms := make(map[string]uint64)
+	for _, field := range state.Fields {
+		fieldDelta := d.Fields[field.Field]
+		fieldDelta.DocumentCount += sign
+		fieldDelta.TotalTokenCount += signedTextDelta(field.Length, sign)
+		d.Fields[field.Field] = fieldDelta
+		for _, term := range field.Terms {
+			seenTerms[term.Term] += uint64(term.Frequency)
+		}
+	}
+	for term, freq := range seenTerms {
+		termDelta := d.Terms[term]
+		termDelta.DocumentFrequency += sign
+		termDelta.TotalTermFrequency += signedTextDeltaUint64(freq, sign)
+		d.Terms[term] = termDelta
+	}
+}
+
+func signedTextDelta(value uint32, sign int64) int64 {
+	return signedTextDeltaUint64(uint64(value), sign)
+}
+
+func signedTextDeltaUint64(value uint64, sign int64) int64 {
+	if sign < 0 {
+		if value > uint64(^uint64(0)>>1) {
+			return -int64(^uint64(0) >> 1)
+		}
+		return -int64(value)
+	}
+	if value > uint64(^uint64(0)>>1) {
+		return int64(^uint64(0) >> 1)
+	}
+	return int64(value)
+}
+
+func buildTextStatsDeltaTable(snap *backenddb.Snapshot, catalog *collectionCatalog, rootName string, delta textStatsDelta, table memtable.Table) error {
+	if table == nil {
+		return nil
+	}
+	if delta.Documents != 0 {
+		current, err := readTextStatsCorpusAtRoot(snap, catalog, rootName)
+		if err != nil {
+			return err
+		}
+		next, err := applySignedTextDelta(current.DocumentCount, delta.Documents, "text-stats corpus document count")
+		if err != nil {
+			return err
+		}
+		table.SetSteal(encodeTextStatsCorpusKey(), encodeTextStatsCorpusValue(textStatsCorpusValue{DocumentCount: next}))
+	}
+	terms := make([]string, 0, len(delta.Terms))
+	for term, termDelta := range delta.Terms {
+		if termDelta.DocumentFrequency == 0 && termDelta.TotalTermFrequency == 0 {
+			continue
+		}
+		terms = append(terms, term)
+	}
+	sort.Strings(terms)
+	for _, term := range terms {
+		termDelta := delta.Terms[term]
+		current, err := readTextStatsTermAtRoot(snap, catalog, rootName, term)
+		if err != nil {
+			return err
+		}
+		df, err := applySignedTextDelta(current.DocumentFrequency, termDelta.DocumentFrequency, "text-stats term document frequency")
+		if err != nil {
+			return err
+		}
+		tf, err := applySignedTextDelta(current.TotalTermFrequency, termDelta.TotalTermFrequency, "text-stats term total frequency")
+		if err != nil {
+			return err
+		}
+		key := encodeTextStatsTermKey(term)
+		if df == 0 && tf == 0 {
+			table.DeleteSteal(key)
+		} else {
+			table.SetSteal(key, encodeTextStatsTermValue(textStatsTermValue{DocumentFrequency: df, TotalTermFrequency: tf}))
+		}
+	}
+	fields := make([]string, 0, len(delta.Fields))
+	for field, fieldDelta := range delta.Fields {
+		if fieldDelta.DocumentCount == 0 && fieldDelta.TotalTokenCount == 0 {
+			continue
+		}
+		fields = append(fields, field)
+	}
+	sort.Strings(fields)
+	for _, field := range fields {
+		fieldDelta := delta.Fields[field]
+		current, err := readTextStatsFieldAtRoot(snap, catalog, rootName, field)
+		if err != nil {
+			return err
+		}
+		docs, err := applySignedTextDelta(current.DocumentCount, fieldDelta.DocumentCount, "text-stats field document count")
+		if err != nil {
+			return err
+		}
+		tokens, err := applySignedTextDelta(current.TotalTokenCount, fieldDelta.TotalTokenCount, "text-stats field token count")
+		if err != nil {
+			return err
+		}
+		key := encodeTextStatsFieldKey(field)
+		if docs == 0 && tokens == 0 {
+			table.DeleteSteal(key)
+		} else {
+			table.SetSteal(key, encodeTextStatsFieldValue(textStatsFieldValue{DocumentCount: docs, TotalTokenCount: tokens}))
+		}
+	}
+	return nil
+}
+
+func readTextStatsCorpusAtRoot(snap *backenddb.Snapshot, catalog *collectionCatalog, rootName string) (textStatsCorpusValue, error) {
+	raw, ok, err := collectionGetAppendAtCatalogRoot(snap, catalog, rootName, encodeTextStatsCorpusKey(), nil)
+	if err != nil {
+		return textStatsCorpusValue{}, err
+	}
+	if !ok {
+		return textStatsCorpusValue{}, nil
+	}
+	return decodeTextStatsCorpusValue(raw)
+}
+
+func readTextStatsTermAtRoot(snap *backenddb.Snapshot, catalog *collectionCatalog, rootName, term string) (textStatsTermValue, error) {
+	raw, ok, err := collectionGetAppendAtCatalogRoot(snap, catalog, rootName, encodeTextStatsTermKey(term), nil)
+	if err != nil {
+		return textStatsTermValue{}, err
+	}
+	if !ok {
+		return textStatsTermValue{}, nil
+	}
+	return decodeTextStatsTermValue(raw)
+}
+
+func readTextStatsFieldAtRoot(snap *backenddb.Snapshot, catalog *collectionCatalog, rootName, field string) (textStatsFieldValue, error) {
+	raw, ok, err := collectionGetAppendAtCatalogRoot(snap, catalog, rootName, encodeTextStatsFieldKey(field), nil)
+	if err != nil {
+		return textStatsFieldValue{}, err
+	}
+	if !ok {
+		return textStatsFieldValue{}, nil
+	}
+	return decodeTextStatsFieldValue(raw)
+}
+
+func applySignedTextDelta(current uint64, delta int64, label string) (uint64, error) {
+	if delta < 0 {
+		amount := uint64(-delta)
+		if amount > current {
+			return 0, errMalformedTextStorage("%s underflow applying delta %d to %d", label, delta, current)
+		}
+		return current - amount, nil
+	}
+	amount := uint64(delta)
+	if amount > ^uint64(0)-current {
+		return 0, errMalformedTextStorage("%s overflow applying delta %d to %d", label, delta, current)
+	}
+	return current + amount, nil
+}
+
+func appendTextIndexInsertPlanDeltas(snap *backenddb.Snapshot, catalog *collectionCatalog, opts collectionOptions, plan *insertBatchPlan) error {
+	if plan == nil || len(catalog.meta.TextIndexes) == 0 {
+		return nil
+	}
+	if plan.templateResolver != nil {
+		opts.templateResolver = plan.templateResolver
+	}
+	primaryRootName := collectionPrimaryRootName(catalog.meta.Name)
+	if catalog.primaryRootName != "" {
+		primaryRootName = catalog.primaryRootName
+	}
+	var primaryRun *collectionRootRun
+	for i := range plan.runs {
+		if plan.runs[i].name == primaryRootName || plan.runs[i].kind == collectionRootPrimary {
+			primaryRun = &plan.runs[i]
+			break
+		}
+	}
+	if primaryRun == nil || primaryRun.table == nil {
+		return nil
+	}
+	it := primaryRun.table.NewIterator(nil, nil)
+	defer func() { _ = it.Close() }()
+	mutations := make([]textDocumentMutation, 0, primaryRun.table.Len())
+	for it.Valid() {
+		if !it.IsDeleted() {
+			mutations = append(mutations, textDocumentMutation{
+				documentID:  bytes.Clone(it.UnsafeKey()),
+				newDocument: it.ValueCopy(nil),
+				setNew:      true,
+			})
+		}
+		it.Next()
+	}
+	if err := it.Error(); err != nil {
+		return err
+	}
+	if len(mutations) == 0 {
+		return nil
+	}
+	rootNames := make([]string, 0, len(catalog.meta.TextIndexes)*3)
+	baseRootIDs := make(map[string]uint64, len(catalog.meta.TextIndexes)*3)
+	policies := make([]backenddb.OrderedRootStoragePolicy, 0, len(catalog.meta.TextIndexes)*3)
+	deltaTables := make([]memtable.Table, 0, len(catalog.meta.TextIndexes)*3)
+	if err := appendTextIndexMutationDeltas(snap, catalog, opts, mutations, &rootNames, baseRootIDs, &policies, &deltaTables); err != nil {
+		resetCollectionTables(deltaTables)
+		return err
+	}
+	for i, rootName := range rootNames {
+		plan.runs = append(plan.runs, collectionRootRun{
+			name:          rootName,
+			table:         deltaTables[i],
+			storagePolicy: policies[i],
+		})
+	}
+	plan.stats.Runs = len(plan.runs)
+	return nil
+}
+
+func appendTextIndexNoIndexInsertDeltas(snap *backenddb.Snapshot, catalog *collectionCatalog, opts collectionOptions, entries []noIndexBatchEntry, rootNames *[]string, baseRootIDs map[string]uint64, policies *[]backenddb.OrderedRootStoragePolicy, deltaTables *[]memtable.Table) error {
+	if len(catalog.meta.TextIndexes) == 0 || len(entries) == 0 {
+		return nil
+	}
+	mutations := make([]textDocumentMutation, 0, len(entries))
+	for _, entry := range entries {
+		mutations = append(mutations, textDocumentMutation{documentID: entry.id, newDocument: entry.document, setNew: true})
+	}
+	return appendTextIndexMutationDeltas(snap, catalog, opts, mutations, rootNames, baseRootIDs, policies, deltaTables)
+}
+
+func appendTextIndexDeleteDeltas(snap *backenddb.Snapshot, catalog *collectionCatalog, opts collectionOptions, documentIDs [][]byte, fallbackDocuments [][]byte, rootNames *[]string, baseRootIDs map[string]uint64, policies *[]backenddb.OrderedRootStoragePolicy, deltaTables *[]memtable.Table) error {
+	if len(catalog.meta.TextIndexes) == 0 || len(documentIDs) == 0 {
+		return nil
+	}
+	mutations := make([]textDocumentMutation, 0, len(documentIDs))
+	for i, id := range documentIDs {
+		var fallback []byte
+		if i < len(fallbackDocuments) {
+			fallback = fallbackDocuments[i]
+		}
+		mutations = append(mutations, textDocumentMutation{documentID: id, oldDocument: fallback, deleteOld: true})
+	}
+	return appendTextIndexMutationDeltas(snap, catalog, opts, mutations, rootNames, baseRootIDs, policies, deltaTables)
+}
+
+func appendTextIndexUpdateDeltas(snap *backenddb.Snapshot, catalog *collectionCatalog, opts collectionOptions, changed []preparedBatchUpdate, rootNames *[]string, baseRootIDs map[string]uint64, policies *[]backenddb.OrderedRootStoragePolicy, deltaTables *[]memtable.Table) error {
+	if len(catalog.meta.TextIndexes) == 0 || len(changed) == 0 {
+		return nil
+	}
+	mutations := make([]textDocumentMutation, 0, len(changed))
+	for _, item := range changed {
+		mutations = append(mutations, textDocumentMutation{documentID: item.documentID, deleteOld: true, newDocument: item.document, setNew: true})
+	}
+	return appendTextIndexMutationDeltas(snap, catalog, opts, mutations, rootNames, baseRootIDs, policies, deltaTables)
+}

--- a/TreeDB/collections/text_maintenance_test.go
+++ b/TreeDB/collections/text_maintenance_test.go
@@ -1,0 +1,447 @@
+package collections
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+)
+
+func TestTextIndexMaintenanceInsertMaintainsPostingsStateStats(t *testing.T) {
+	d := openTextTestDB(t)
+	defer func() { _ = d.Close() }()
+	col := createTextMaintenanceCollection(t, d)
+
+	if _, err := col.Insert([]byte("d1"), []byte(`{"body":"refund refund policy"}`)); err != nil {
+		t.Fatalf("Insert d1: %v", err)
+	}
+	if _, err := col.Insert([]byte("d2"), []byte(`{"body":"shipping policy"}`)); err != nil {
+		t.Fatalf("Insert d2: %v", err)
+	}
+	stats, err := col.TextIndexStorageStats("lexical")
+	if err != nil {
+		t.Fatalf("TextIndexStorageStats: %v", err)
+	}
+	if stats.Documents != 2 || stats.StateEntries != 2 || stats.PostingEntries != 4 || stats.StatsEntries != 5 {
+		t.Fatalf("stats=%+v want docs=2 state=2 postings=4 stats=5", stats)
+	}
+	posting := requireTextPosting(t, d, "docs", "lexical", "refund", []byte("d1"))
+	if posting.TermFrequency != 2 || len(posting.Fields) != 1 || posting.Fields[0].Frequency != 2 || len(posting.Fields[0].Positions) != 2 {
+		t.Fatalf("refund posting=%+v want tf=2 with positions", posting)
+	}
+	policyStats := requireTextTermStats(t, d, "docs", "lexical", "policy")
+	if policyStats.DocumentFrequency != 2 || policyStats.TotalTermFrequency != 2 {
+		t.Fatalf("policy stats=%+v want df=2 tf=2", policyStats)
+	}
+}
+
+func TestTextIndexMaintenanceDeleteRemovesPostingsAfterFlushReopen(t *testing.T) {
+	dir := t.TempDir()
+	d, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	col := createTextMaintenanceCollection(t, d)
+	if _, err := col.InsertBatch([][]byte{[]byte("d1"), []byte("d2")}, [][]byte{[]byte(`{"body":"refund policy"}`), []byte(`{"body":"shipping policy"}`)}); err != nil {
+		t.Fatalf("InsertBatch: %v", err)
+	}
+	if deleted, err := col.DeleteDocument([]byte("d1")); err != nil || !deleted {
+		t.Fatalf("DeleteDocument deleted=%v err=%v", deleted, err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+	if err := d.Checkpoint(); err != nil {
+		t.Fatalf("Checkpoint: %v", err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	reopened, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+	reopenedCol, err := NewCollectionManager(reopened).OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("OpenCollection reopened: %v", err)
+	}
+	stats, err := reopenedCol.TextIndexStorageStats("lexical")
+	if err != nil {
+		t.Fatalf("TextIndexStorageStats reopened: %v", err)
+	}
+	if stats.Documents != 1 || stats.StateEntries != 1 || stats.PostingEntries != 2 {
+		t.Fatalf("reopened stats=%+v want one remaining document", stats)
+	}
+	assertTextPostingMissing(t, reopened, "docs", "lexical", "refund", []byte("d1"))
+	assertTextStateMissing(t, reopened, "docs", "lexical", []byte("d1"))
+	shipping := requireTextPosting(t, reopened, "docs", "lexical", "shipping", []byte("d2"))
+	if shipping.TermFrequency != 1 {
+		t.Fatalf("shipping posting=%+v want tf=1", shipping)
+	}
+	assertTextTermStatsMissing(t, reopened, "docs", "lexical", "refund")
+}
+
+func TestTextIndexMaintenanceUpdateRemovesOldAndAddsNewTerms(t *testing.T) {
+	d := openTextTestDB(t)
+	defer func() { _ = d.Close() }()
+	col := createTextMaintenanceCollection(t, d)
+	if _, err := col.Insert([]byte("d1"), []byte(`{"body":"refund policy"}`)); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+	matched, modified, err := col.Update([]byte("d1"), func(current []byte) ([]byte, bool, error) {
+		return []byte(`{"body":"shipping shipping policy"}`), true, nil
+	})
+	if err != nil || !matched || !modified {
+		t.Fatalf("Update matched=%v modified=%v err=%v", matched, modified, err)
+	}
+	stats, err := col.TextIndexStorageStats("lexical")
+	if err != nil {
+		t.Fatalf("TextIndexStorageStats: %v", err)
+	}
+	if stats.Documents != 1 || stats.StateEntries != 1 || stats.PostingEntries != 2 || stats.StatsEntries != 4 {
+		t.Fatalf("stats after update=%+v want docs=1 state=1 postings=2 stats=4", stats)
+	}
+	assertTextPostingMissing(t, d, "docs", "lexical", "refund", []byte("d1"))
+	assertTextTermStatsMissing(t, d, "docs", "lexical", "refund")
+	shipping := requireTextPosting(t, d, "docs", "lexical", "shipping", []byte("d1"))
+	if shipping.TermFrequency != 2 {
+		t.Fatalf("shipping posting=%+v want tf=2", shipping)
+	}
+	shippingStats := requireTextTermStats(t, d, "docs", "lexical", "shipping")
+	if shippingStats.DocumentFrequency != 1 || shippingStats.TotalTermFrequency != 2 {
+		t.Fatalf("shipping stats=%+v want df=1 tf=2", shippingStats)
+	}
+}
+
+func TestTextIndexMaintenanceBatchInsertUpdateDelete(t *testing.T) {
+	d := openTextTestDB(t)
+	defer func() { _ = d.Close() }()
+	col := createTextMaintenanceCollection(t, d)
+	ids := [][]byte{[]byte("d1"), []byte("d2"), []byte("d3")}
+	docs := [][]byte{[]byte(`{"body":"alpha keep"}`), []byte(`{"body":"beta keep"}`), []byte(`{"body":"gamma keep"}`)}
+	if _, err := col.InsertBatch(ids, docs); err != nil {
+		t.Fatalf("InsertBatch: %v", err)
+	}
+	updates := []UpdateBatchItem{
+		{DocumentID: []byte("d1"), Update: func(current []byte) ([]byte, bool, error) { return []byte(`{"body":"alpha updated"}`), true, nil }},
+		{DocumentID: []byte("d2"), Update: func(current []byte) ([]byte, bool, error) { return []byte(`{"body":"beta updated"}`), true, nil }},
+	}
+	results, err := col.UpdateBatch(updates)
+	if err != nil {
+		t.Fatalf("UpdateBatch: %v", err)
+	}
+	if len(results) != 2 || !results[0].Modified || !results[1].Modified {
+		t.Fatalf("UpdateBatch results=%+v want two modified", results)
+	}
+	deleted, err := col.DeleteBatch([][]byte{[]byte("d3")})
+	if err != nil || deleted != 1 {
+		t.Fatalf("DeleteBatch deleted=%d err=%v", deleted, err)
+	}
+	stats, err := col.TextIndexStorageStats("lexical")
+	if err != nil {
+		t.Fatalf("TextIndexStorageStats: %v", err)
+	}
+	if stats.Documents != 2 || stats.StateEntries != 2 || stats.PostingEntries != 4 {
+		t.Fatalf("batch stats=%+v want two updated documents", stats)
+	}
+	assertTextPostingMissing(t, d, "docs", "lexical", "gamma", []byte("d3"))
+	requireTextPosting(t, d, "docs", "lexical", "updated", []byte("d1"))
+	requireTextPosting(t, d, "docs", "lexical", "updated", []byte("d2"))
+}
+
+func TestTextIndexMaintenanceBufferedCreateFlushCheckpointReopen(t *testing.T) {
+	dir := t.TempDir()
+	d, err := backenddb.Open(backenddb.Options{Dir: dir, Durability: backenddb.DurabilityWALOffRelaxed})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "docs"}); err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	writer, err := mgr.OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("OpenCollection writer: %v", err)
+	}
+	if _, err := writer.Insert([]byte("buffered"), []byte(`{"body":"buffered before create"}`)); err != nil {
+		t.Fatalf("buffered Insert before CreateTextIndex: %v", err)
+	}
+	creator, err := NewCollectionManager(d).OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("OpenCollection creator: %v", err)
+	}
+	if got, err := creator.Get([]byte("buffered")); err != nil {
+		t.Fatalf("creator Get before CreateTextIndex: %v", err)
+	} else if got != nil {
+		t.Fatalf("expected setup insert to remain buffered before CreateTextIndex, got %q", got)
+	}
+	if _, _, err := creator.CreateTextIndex(TextIndexDefinition{Name: "lexical", Fields: []TextIndexField{{Field: "body"}}, StorePositions: true}); err != nil {
+		t.Fatalf("CreateTextIndex: %v", err)
+	}
+	if _, err := writer.Insert([]byte("after"), []byte(`{"body":"after create durable"}`)); err != nil {
+		t.Fatalf("Insert after CreateTextIndex: %v", err)
+	}
+	if err := writer.Flush(); err != nil {
+		t.Fatalf("writer Flush: %v", err)
+	}
+	if err := d.Checkpoint(); err != nil {
+		t.Fatalf("Checkpoint: %v", err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	reopened, err := backenddb.Open(backenddb.Options{Dir: dir, Durability: backenddb.DurabilityWALOffRelaxed})
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+	col, err := NewCollectionManager(reopened).OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("OpenCollection reopened: %v", err)
+	}
+	stats, err := col.TextIndexStorageStats("lexical")
+	if err != nil {
+		t.Fatalf("TextIndexStorageStats reopened: %v", err)
+	}
+	if stats.Documents != 2 || stats.StateEntries != 2 || stats.PostingEntries != 6 {
+		t.Fatalf("reopened stats=%+v want two maintained documents", stats)
+	}
+	requireTextPosting(t, reopened, "docs", "lexical", "buffered", []byte("buffered"))
+	requireTextPosting(t, reopened, "docs", "lexical", "after", []byte("after"))
+}
+
+func BenchmarkTextIndexMaintenanceBatchWritePaths(b *testing.B) {
+	const docsPerBatch = 256
+	b.Run("insert_batch_no_text", func(b *testing.B) {
+		ids, docs := textMaintenanceBenchDocuments(docsPerBatch, "insert")
+		b.ReportAllocs()
+		b.ReportMetric(docsPerBatch, "docs/batch")
+		for i := 0; i < b.N; i++ {
+			b.StopTimer()
+			d := openTextBenchDB(b)
+			mgr := NewCollectionManager(d)
+			if _, err := mgr.CreateCollection(&CollectionMeta{Name: "docs"}); err != nil {
+				b.Fatalf("CreateCollection: %v", err)
+			}
+			col, err := mgr.OpenCollection("docs")
+			if err != nil {
+				b.Fatalf("OpenCollection: %v", err)
+			}
+			batchIDs := cloneBenchIDsWithIteration(ids, i)
+			b.StartTimer()
+			_, err = col.InsertBatch(batchIDs, docs)
+			b.StopTimer()
+			if err != nil {
+				b.Fatalf("InsertBatch: %v", err)
+			}
+			_ = d.Close()
+		}
+	})
+	b.Run("insert_batch_text_indexed", func(b *testing.B) {
+		ids, docs := textMaintenanceBenchDocuments(docsPerBatch, "insert")
+		var lastStats TextIndexStorageStats
+		b.ReportAllocs()
+		b.ReportMetric(docsPerBatch, "docs/batch")
+		for i := 0; i < b.N; i++ {
+			b.StopTimer()
+			d := openTextBenchDB(b)
+			col := createTextMaintenanceBenchCollection(b, d)
+			batchIDs := cloneBenchIDsWithIteration(ids, i)
+			b.StartTimer()
+			_, err := col.InsertBatch(batchIDs, docs)
+			b.StopTimer()
+			if err != nil {
+				b.Fatalf("InsertBatch text-indexed: %v", err)
+			}
+			lastStats, err = col.TextIndexStorageStats("lexical")
+			if err != nil {
+				b.Fatalf("TextIndexStorageStats: %v", err)
+			}
+			_ = d.Close()
+		}
+		b.ReportMetric(float64(lastStats.PostingEntries), "postings/batch")
+		b.ReportMetric(float64(lastStats.EncodedBytes), "encoded_bytes/batch")
+	})
+	b.Run("update_batch_text_indexed", func(b *testing.B) {
+		ids, docs := textMaintenanceBenchDocuments(docsPerBatch, "update-old")
+		_, updatedDocs := textMaintenanceBenchDocuments(docsPerBatch, "update-new")
+		updates := make([]UpdateBatchItem, docsPerBatch)
+		for i := 0; i < docsPerBatch; i++ {
+			docID := bytes.Clone(ids[i])
+			replacement := bytes.Clone(updatedDocs[i])
+			updates[i] = UpdateBatchItem{DocumentID: docID, Update: func(current []byte) ([]byte, bool, error) {
+				return replacement, true, nil
+			}}
+		}
+		b.ReportAllocs()
+		b.ReportMetric(docsPerBatch, "docs/batch")
+		for i := 0; i < b.N; i++ {
+			b.StopTimer()
+			d := openTextBenchDB(b)
+			col := createTextMaintenanceBenchCollection(b, d)
+			batchIDs := cloneBenchIDsWithIteration(ids, i)
+			batchUpdates := make([]UpdateBatchItem, docsPerBatch)
+			for j := 0; j < docsPerBatch; j++ {
+				batchUpdates[j] = updates[j]
+				batchUpdates[j].DocumentID = batchIDs[j]
+			}
+			if _, err := col.InsertBatch(batchIDs, docs); err != nil {
+				b.Fatalf("InsertBatch setup: %v", err)
+			}
+			b.StartTimer()
+			results, err := col.UpdateBatch(batchUpdates)
+			b.StopTimer()
+			if err != nil {
+				b.Fatalf("UpdateBatch text-indexed: %v", err)
+			}
+			if len(results) != docsPerBatch {
+				b.Fatalf("UpdateBatch results=%d want %d", len(results), docsPerBatch)
+			}
+			_ = d.Close()
+		}
+	})
+	b.Run("delete_batch_text_indexed", func(b *testing.B) {
+		ids, docs := textMaintenanceBenchDocuments(docsPerBatch, "delete")
+		b.ReportAllocs()
+		b.ReportMetric(docsPerBatch, "docs/batch")
+		for i := 0; i < b.N; i++ {
+			b.StopTimer()
+			d := openTextBenchDB(b)
+			col := createTextMaintenanceBenchCollection(b, d)
+			batchIDs := cloneBenchIDsWithIteration(ids, i)
+			if _, err := col.InsertBatch(batchIDs, docs); err != nil {
+				b.Fatalf("InsertBatch setup: %v", err)
+			}
+			b.StartTimer()
+			deleted, err := col.DeleteBatch(batchIDs)
+			b.StopTimer()
+			if err != nil {
+				b.Fatalf("DeleteBatch text-indexed: %v", err)
+			}
+			if deleted != docsPerBatch {
+				b.Fatalf("DeleteBatch deleted=%d want %d", deleted, docsPerBatch)
+			}
+			_ = d.Close()
+		}
+	})
+}
+
+func textMaintenanceBenchDocuments(count int, label string) ([][]byte, [][]byte) {
+	ids := make([][]byte, count)
+	docs := make([][]byte, count)
+	for i := 0; i < count; i++ {
+		ids[i] = []byte(fmt.Sprintf("doc-%s-%06d", label, i))
+		docs[i] = []byte(fmt.Sprintf(`{"title":"Ticket %s %d refund policy","body":"HTTP_500 retry refund policy customer %d batch %s"}`, label, i, i%17, label))
+	}
+	return ids, docs
+}
+
+func cloneBenchIDsWithIteration(ids [][]byte, iteration int) [][]byte {
+	out := make([][]byte, len(ids))
+	for i := range ids {
+		out[i] = []byte(fmt.Sprintf("%s-%06d", ids[i], iteration))
+	}
+	return out
+}
+
+func createTextMaintenanceBenchCollection(b *testing.B, d *backenddb.DB) *Collection {
+	b.Helper()
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "docs"}); err != nil {
+		b.Fatalf("CreateCollection: %v", err)
+	}
+	col, err := mgr.OpenCollection("docs")
+	if err != nil {
+		b.Fatalf("OpenCollection: %v", err)
+	}
+	if _, _, err := col.CreateTextIndex(TextIndexDefinition{Name: "lexical", Fields: []TextIndexField{{Field: "title"}, {Field: "body"}}, StorePositions: true}); err != nil {
+		b.Fatalf("CreateTextIndex: %v", err)
+	}
+	return col
+}
+
+func createTextMaintenanceCollection(t *testing.T, d *backenddb.DB) *Collection {
+	t.Helper()
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "docs"}); err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	col, err := mgr.OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("OpenCollection: %v", err)
+	}
+	if _, _, err := col.CreateTextIndex(TextIndexDefinition{Name: "lexical", Fields: []TextIndexField{{Field: "body"}}, StorePositions: true}); err != nil {
+		t.Fatalf("CreateTextIndex: %v", err)
+	}
+	return col
+}
+
+func requireTextPosting(t *testing.T, d *backenddb.DB, collection, indexName, term string, documentID []byte) textPostingValue {
+	t.Helper()
+	raw, ok := lookupTextRootValue(t, d, collection, collectionTextIndexRootName(collection, indexName), encodeTextPostingKey(term, documentID))
+	if !ok {
+		t.Fatalf("missing text posting term=%q document=%q", term, documentID)
+	}
+	posting, err := decodeTextPostingValue(raw)
+	if err != nil {
+		t.Fatalf("decode text posting term=%q document=%q: %v", term, documentID, err)
+	}
+	return posting
+}
+
+func assertTextPostingMissing(t *testing.T, d *backenddb.DB, collection, indexName, term string, documentID []byte) {
+	t.Helper()
+	if raw, ok := lookupTextRootValue(t, d, collection, collectionTextIndexRootName(collection, indexName), encodeTextPostingKey(term, documentID)); ok {
+		t.Fatalf("unexpected text posting term=%q document=%q raw=%v", term, documentID, raw)
+	}
+}
+
+func assertTextStateMissing(t *testing.T, d *backenddb.DB, collection, indexName string, documentID []byte) {
+	t.Helper()
+	if raw, ok := lookupTextRootValue(t, d, collection, collectionTextStateRootName(collection, indexName), encodeTextStateKey(documentID)); ok {
+		t.Fatalf("unexpected text state document=%q raw=%v", documentID, raw)
+	}
+}
+
+func requireTextTermStats(t *testing.T, d *backenddb.DB, collection, indexName, term string) textStatsTermValue {
+	t.Helper()
+	raw, ok := lookupTextRootValue(t, d, collection, collectionTextStatsRootName(collection, indexName), encodeTextStatsTermKey(term))
+	if !ok {
+		t.Fatalf("missing text term stats term=%q", term)
+	}
+	stats, err := decodeTextStatsTermValue(raw)
+	if err != nil {
+		t.Fatalf("decode text term stats term=%q: %v", term, err)
+	}
+	return stats
+}
+
+func assertTextTermStatsMissing(t *testing.T, d *backenddb.DB, collection, indexName, term string) {
+	t.Helper()
+	if raw, ok := lookupTextRootValue(t, d, collection, collectionTextStatsRootName(collection, indexName), encodeTextStatsTermKey(term)); ok {
+		t.Fatalf("unexpected text term stats term=%q raw=%v", term, raw)
+	}
+}
+
+func lookupTextRootValue(t *testing.T, d *backenddb.DB, collection, rootName string, key []byte) ([]byte, bool) {
+	t.Helper()
+	snap := d.AcquireSnapshot()
+	if snap == nil {
+		t.Fatal("snapshot nil")
+	}
+	defer func() { _ = snap.Close() }()
+	catalog, err := loadCollectionCatalog(snap, collection)
+	if err != nil {
+		t.Fatalf("load catalog: %v", err)
+	}
+	if catalog == nil {
+		t.Fatal("catalog nil")
+	}
+	value, ok, err := collectionGetAppendAtCatalogRoot(snap, catalog, rootName, key, nil)
+	if err != nil {
+		t.Fatalf("lookup text root %q key=%v: %v", rootName, key, err)
+	}
+	return bytes.Clone(value), ok
+}

--- a/TreeDB/collections/text_storage_test.go
+++ b/TreeDB/collections/text_storage_test.go
@@ -199,8 +199,8 @@ func TestCollectionDropTextIndexClearsMetadataRootsAndWriteGuard(t *testing.T) {
 	if err != nil {
 		t.Fatalf("OpenCollection stale: %v", err)
 	}
-	if _, err := col.Insert([]byte("d2"), []byte(`{"body":"blocked"}`)); !errors.Is(err, ErrTextIndexUnavailable) {
-		t.Fatalf("Insert with text index err=%v want ErrTextIndexUnavailable", err)
+	if _, err := col.Insert([]byte("d2"), []byte(`{"body":"maintained before drop"}`)); err != nil {
+		t.Fatalf("Insert with text index before drop: %v", err)
 	}
 
 	meta, err := col.DropTextIndex("lexical")
@@ -216,10 +216,10 @@ func TestCollectionDropTextIndexClearsMetadataRootsAndWriteGuard(t *testing.T) {
 	assertTextRootCleared(t, d, collectionTextIndexRootName("docs", "lexical"))
 	assertTextRootCleared(t, d, collectionTextStateRootName("docs", "lexical"))
 	assertTextRootCleared(t, d, collectionTextStatsRootName("docs", "lexical"))
-	if _, err := col.Insert([]byte("d2"), []byte(`{"body":"allowed after drop"}`)); err != nil {
+	if _, err := col.Insert([]byte("d3"), []byte(`{"body":"allowed after drop"}`)); err != nil {
 		t.Fatalf("Insert after DropTextIndex: %v", err)
 	}
-	if _, err := stale.Insert([]byte("d3"), []byte(`{"body":"stale handle allowed after drop"}`)); err != nil {
+	if _, err := stale.Insert([]byte("d4"), []byte(`{"body":"stale handle allowed after drop"}`)); err != nil {
 		t.Fatalf("stale Insert after DropTextIndex: %v", err)
 	}
 }
@@ -272,12 +272,19 @@ func TestCreateTextIndexFlushesBufferedWritesFromOtherManagers(t *testing.T) {
 	if err := writer.Flush(); err != nil {
 		t.Fatalf("writer Flush after CreateTextIndex: %v", err)
 	}
-	if _, err := writer.Insert([]byte("d-after"), []byte(`{"body":"must not bypass"}`)); !errors.Is(err, ErrTextIndexUnavailable) {
-		t.Fatalf("writer Insert after CreateTextIndex err=%v want ErrTextIndexUnavailable", err)
+	if _, err := writer.Insert([]byte("d-after"), []byte(`{"body":"maintained after create"}`)); err != nil {
+		t.Fatalf("writer Insert after CreateTextIndex: %v", err)
+	}
+	stats, err = creator.TextIndexStorageStats("lexical")
+	if err != nil {
+		t.Fatalf("TextIndexStorageStats after writer insert: %v", err)
+	}
+	if stats.Documents != 2 || stats.StateEntries != 2 || stats.PostingEntries != 6 {
+		t.Fatalf("storage stats after writer insert=%+v want docs=2 state=2 postings=6", stats)
 	}
 }
 
-func TestCreateTextIndexRejectsWritesFromStaleHandles(t *testing.T) {
+func TestCreateTextIndexMaintainsWritesFromStaleHandles(t *testing.T) {
 	d := openTextTestDB(t)
 	defer func() { _ = d.Close() }()
 	mgr := NewCollectionManager(d)
@@ -298,15 +305,15 @@ func TestCreateTextIndexRejectsWritesFromStaleHandles(t *testing.T) {
 	if _, _, err := fresh.CreateTextIndex(TextIndexDefinition{Name: "lexical", Fields: []TextIndexField{{Field: "body"}}}); err != nil {
 		t.Fatalf("CreateTextIndex: %v", err)
 	}
-	if _, err := stale.Insert([]byte("d2"), []byte(`{"body":"must not bypass"}`)); !errors.Is(err, ErrTextIndexUnavailable) {
-		t.Fatalf("stale Insert after CreateTextIndex err=%v want ErrTextIndexUnavailable", err)
+	if _, err := stale.Insert([]byte("d2"), []byte(`{"body":"maintained stale handle"}`)); err != nil {
+		t.Fatalf("stale Insert after CreateTextIndex: %v", err)
 	}
 	stats, err := fresh.TextIndexStorageStats("lexical")
 	if err != nil {
 		t.Fatalf("TextIndexStorageStats: %v", err)
 	}
-	if stats.Documents != 1 || stats.StateEntries != 1 {
-		t.Fatalf("stats after stale rejected insert=%+v want one backfilled document", stats)
+	if stats.Documents != 2 || stats.StateEntries != 2 || stats.PostingEntries != 5 {
+		t.Fatalf("stats after stale maintained insert=%+v want two maintained documents", stats)
 	}
 }
 

--- a/TreeDB/docs/spec/README.md
+++ b/TreeDB/docs/spec/README.md
@@ -84,9 +84,9 @@ Given pre-alpha status, this is a living spec that tracks implementation.
     durability-boundary semantics.
 - `TreeDB/docs/spec/collection-text-search.md`
   - collection-native text index metadata, analyzer, root naming/policies,
-    versioned postings/text-state/text-stats storage, backfill/drop, query
-    shape, and fail-closed behavior before mutation maintenance/search execution
-    lands.
+    versioned postings/text-state/text-stats storage, backfill/drop, write-path
+    maintenance, and fail-closed query-shape behavior before ranked search
+    execution lands.
 - `TreeDB/docs/spec/write-path-and-durability.md`
   - write pipeline and durability semantics for all durability modes.
 - `TreeDB/docs/spec/recovery.md`

--- a/TreeDB/docs/spec/collection-text-search.md
+++ b/TreeDB/docs/spec/collection-text-search.md
@@ -1,6 +1,6 @@
-# Collection Text Search Contract (M0-M2)
+# Collection Text Search Contract (M0-M3)
 
-Status: PR2 storage/backfill slice for issue #1764. TreeDB collections are
+Status: PR3 mutation-maintenance slice for issue #1764. TreeDB collections are
 pre-alpha; these text-search storage formats are versioned and may change before
 stabilization, but malformed or unsupported versions must fail closed.
 
@@ -21,12 +21,13 @@ stabilization, but malformed or unsupported versions must fail closed.
   over existing documents and publishes roots plus metadata atomically.
 - `DropTextIndex` removes metadata and clears the text root descriptors.
 - `TextIndexStorageStats` validates storage versions and returns root accounting.
+- Insert, delete, update, and batch write paths maintain postings, text-state,
+  and corpus/term/field stats for declared text indexes.
 - `SearchText(TextSearchOptions)` query-shape validation that fails closed before
   scanning because ranked text search execution is not implemented yet.
 
 Not implemented yet:
 
-- insert/update/delete mutation maintenance for declared text indexes;
 - BM25/BM25F scoring and ranked SearchText execution;
 - phrase/proximity/highlighting/stemming/trigram/fuzzy search;
 - query-vector syntax, gateway integration, or hybrid text+vector executor integration.
@@ -121,8 +122,9 @@ repeated field_count:
     uvarint offset_count   | repeated (uvarint start, uvarint end)
 ```
 
-Backfill writes a text-state entry for every scanned document so later M3
-mutation maintenance can diff or decrement document-level accounting.
+Backfill and insert maintenance write a text-state entry for every indexed
+document so update/delete maintenance can diff or decrement document-level
+accounting without re-reading old document payloads.
 
 ### Text-stats root
 
@@ -179,22 +181,29 @@ terms are analyzed with the declared index analyzer.
 
 `SearchText` currently returns `ErrTextIndexUnavailable` for non-empty analyzed
 queries against an existing text index. This is intentional: normal text queries
-MUST be indexed, bounded, and ranked from postings; M2 does not implement the
+MUST be indexed, bounded, and ranked from postings; M3 does not implement the
 ranked executor and must not fall back to scan-and-rank. Empty analyzed queries
 return an empty result set.
 
-## Fail-closed write behavior
+## Mutation maintenance
 
-Collections that declare text indexes reject insert/update/delete operations with
-`ErrTextIndexUnavailable` until M3 lands durable postings/text-state/stats
-mutation maintenance. This prevents silent divergence between primary documents
-and text metadata.
+Text-indexed insert paths analyze the stored document, set one text-state entry,
+set one posting per `(term, documentID)`, and increment corpus/term/field stats.
+Delete paths load the text-state entry, delete the document's postings and
+state, and decrement stats. Update paths load old text-state, analyze the new
+stored document, replace postings/state, and apply a stats delta. Stats entries
+whose counts drop to zero are deleted; the corpus stats entry remains with the
+current document count.
+
+M3 keeps text-indexed writes on immediate root-publish paths rather than staging
+new text deltas in buffered write domains. Existing buffered writes are drained
+by `CreateTextIndex` before backfill, and `Flush`/`Checkpoint`/reopen preserve
+maintained text roots.
 
 ## Follow-up execution plan
 
 Later #1764 milestones will:
 
-- maintain postings, text-state, and stats on insert/update/delete;
 - range-scan postings by analyzed term;
 - bound the candidate set;
 - score candidates from persisted stats with BM25/BM25F-style field weighting;

--- a/TreeDB/docs/spec/verification.md
+++ b/TreeDB/docs/spec/verification.md
@@ -198,9 +198,10 @@ Invariant:
 - Collection text index metadata persists through reopen, root names/policies are
   stable, versioned postings/text-state/text-stats encodings fail closed on
   malformed data, CreateTextIndex drains buffered writes across collection
-  managers before taking its backfill snapshot, DropTextIndex clears
-  metadata/root descriptors, the simple analyzer is deterministic, and
-  text-indexed writes/search fail closed until mutation maintenance/search
+  managers before taking its backfill snapshot, insert/delete/update/batch paths
+  maintain postings/text-state/text-stats across flush/checkpoint/reopen,
+  DropTextIndex clears metadata/root descriptors, the simple analyzer is
+  deterministic, and text search execution fails closed until ranked query
   execution lands.
 
 Coverage:
@@ -210,15 +211,21 @@ Coverage:
   - `TestCollectionTextIndexMetadataRejectsInvalidDefinitions`
   - `TestCollectionTextRootNames`
   - `TestCollectionTextRootStoragePolicies`
-  - `TestCollectionTextIndexedOperationsFailClosedUntilStorageLands`
+  - `TestCollectionTextIndexedWritesMaintainStorageAndSearchFailsClosed`
 - `TreeDB/collections/text_storage_test.go`:
   - `TestTextStorageCodecsRoundTripAndFailClosed`
   - `TestCollectionCreateTextIndexBackfillsReopensAndReportsStorage`
   - `TestCollectionDropTextIndexClearsMetadataRootsAndWriteGuard`
   - `TestCreateTextIndexFlushesBufferedWritesFromOtherManagers`
-  - `TestCreateTextIndexRejectsWritesFromStaleHandles`
+  - `TestCreateTextIndexMaintainsWritesFromStaleHandles`
   - `TestTextIndexStorageStatsFailsClosedOnMalformedRoot`
   - `BenchmarkCreateTextIndexBackfill`
+- `TreeDB/collections/text_maintenance_test.go`:
+  - `TestTextIndexMaintenanceInsertMaintainsPostingsStateStats`
+  - `TestTextIndexMaintenanceDeleteRemovesPostingsAfterFlushReopen`
+  - `TestTextIndexMaintenanceUpdateRemovesOldAndAddsNewTerms`
+  - `TestTextIndexMaintenanceBatchInsertUpdateDelete`
+  - `TestTextIndexMaintenanceBufferedCreateFlushCheckpointReopen`
 
 ## 11.5 Planned User-Command WAL Durability Gate
 


### PR DESCRIPTION
## Scope

Part of #1764, M3 only: collection-native text-index mutation maintenance.

This PR:

- Adds durable text-index maintenance for insert/delete/update paths, including batch paths.
- Maintains the persistent text postings, text-state, and text-stats roots published in the M2 storage/backfill slice.
- Applies stats deltas for corpus, term, and field accounting, deleting zeroed term/field stats entries.
- Keeps text-indexed writes off unsafe buffered fast paths and routes them through immediate root publish semantics.
- Preserves CreateTextIndex backfill/drop/catalog behavior and updates stale-handle tests now that writes are maintained instead of rejected.
- Adds M3 coverage for insert maintenance, delete after flush/checkpoint/reopen, update old/new term replacement, batch insert/update/delete, and buffered-write drain before CreateTextIndex.
- Updates the text-search spec/verification docs from M2 fail-closed writes to M3 maintained writes.

## Non-goals / deferred

- No ranked `SearchText` execution, BM25/BM25F, candidate bounding, or postings scanner API yet; non-empty `SearchText` still fails closed with `ErrTextIndexUnavailable`.
- No phrase/proximity/highlighting/stemming/fuzzy/trigram support.
- No hybrid/vector/fusion/gateway work and no #2502 candidate/fusion APIs.

## Base / head

- Base: `origin/main` `fffaf6845d92deb807085a8a407a60e13d006fa5`
- Head: `c691907d7515a9834e27e297b17e0b2f2a8c219f`

## Tests

```sh
GOWORK=off go test ./TreeDB/collections -run 'TestTextIndexMaintenance|TestCollectionTextIndexedWrites|TestCollectionDropTextIndex|TestCreateTextIndex' -count=1
GOWORK=off go test ./TreeDB/collections -count=1
GOWORK=off go test ./TreeDB/docs -count=1
git diff --check
```

All passed locally on head `c691907d`.

## Benchmark evidence

Apple M3, artifact: `/tmp/gomap_1764_pr3/bench_text_m3_after_main_fffaf68.txt`

```sh
GOWORK=off go test ./TreeDB/collections \
  -run '^$' \
  -bench 'Benchmark(CreateTextIndexBackfill|TextIndexMaintenanceBatchWritePaths)' \
  -benchtime=20x -count=3 -benchmem
```

Median of 3 runs:

| Benchmark | ns/op | ops/sec | B/op | allocs/op | Notes |
|---|---:|---:|---:|---:|---|
| `insert_batch_no_text` | 106,108 | 9,424 | 100,562 | 175 | 256 docs/batch baseline |
| `insert_batch_text_indexed` | 5,057,385 | 198 | 5,297,165 | 67,552 | 256 docs/batch, 2,543 postings/batch |
| `update_batch_text_indexed` | 7,406,581 | 135 | 6,804,300 | 89,077 | 256 docs/batch |
| `delete_batch_text_indexed` | 2,308,335 | 433 | 1,729,733 | 15,382 | 256 docs/batch |
| `BenchmarkCreateTextIndexBackfill` | 3,944,477 | 254 | 3,343,733 | 48,917 | 256 docs/backfill, 2,031 postings/backfill |

## Review / CI status

- Latest-head CI: passing on head `c691907d` (`gh pr checks 2528`).
- Codex: `@codex review` completed with no major issues.
- CodeRabbit: `@coderabbitai review` command returned `Review finished`; no unresolved CodeRabbit threads observed. The initial automatic run posted a rate-limit warning before the manual command completed.
- Copilot: `@copilot review` requested; no Copilot findings observed yet.
- Review threads: none unresolved in GraphQL inventory.

## Review notes

- Internal scope check: PR diff is limited to text-search M3 maintenance plus necessary collection write-path hooks/docs/tests; no hybrid/vector/fusion files are included in this PR diff.
- Search remains fail-closed until a later #1764 ranked execution slice.
- Agent did not merge this PR.
