### PR TITLE
TreeDB: rank collection text search from postings

### DIFF
--- a/TreeDB/collections/text_catalog.go
+++ b/TreeDB/collections/text_catalog.go
@@ -9,8 +9,7 @@ import (
 
 // CreateTextIndex adds a collection-native text index and backfills persistent
 // postings, text-state, and text-stats roots from the current documents. Write
-// paths maintain those roots after creation; SearchText execution remains
-// fail-closed until a later #1764 milestone.
+// paths maintain those roots after creation, and SearchText ranks from them.
 func (c *Collection) CreateTextIndex(def TextIndexDefinition) (*CollectionMeta, TextIndexBackfillStats, error) {
 	var emptyStats TextIndexBackfillStats
 	if c == nil {
@@ -193,8 +192,8 @@ func (c *Collection) DropTextIndex(name string) (*CollectionMeta, error) {
 }
 
 // TextIndexStorageStats validates and summarizes persistent text roots for a
-// declared text index. It is a storage/accounting helper; SearchText execution
-// remains unavailable until later milestones.
+// declared text index. It is a storage/accounting helper for the roots that
+// SearchText also validates while scanning and scoring.
 func (c *Collection) TextIndexStorageStats(indexName string) (TextIndexStorageStats, error) {
 	var stats TextIndexStorageStats
 	if err := ValidateIndexName(indexName); err != nil {

--- a/TreeDB/collections/text_index.go
+++ b/TreeDB/collections/text_index.go
@@ -7,9 +7,10 @@ import (
 )
 
 // ErrTextIndexUnavailable reports that a declared collection text index cannot
-// yet be used for search execution. #1764 M3 maintains postings/text-state/stats
-// on writes, but ranked query execution remains fail-closed instead of silently
-// scanning or returning incomplete text-index results.
+// safely serve a requested text-search operation. Ranked SearchText executes from
+// postings in #1764 M4, but bounded candidate-generation guardrails still fail
+// closed instead of silently scanning all documents or returning incomplete text
+// rankings.
 var ErrTextIndexUnavailable = errors.New("collections: text index unavailable")
 
 // TextAnalyzer names a collection text analyzer. The zero value normalizes to
@@ -22,8 +23,8 @@ const (
 
 // TextIndexDefinition declares a persistent collection-native inverted index.
 // M2 stores and validates metadata plus versioned postings/text-state/stats
-// storage. #1764 M3 maintains these roots on writes; SearchText execution lands
-// in a later milestone.
+// storage, M3 maintains these roots on writes, and M4 ranks SearchText results
+// from bounded postings scans.
 type TextIndexDefinition struct {
 	Name             string            `json:"name"`
 	Fields           []TextIndexField  `json:"fields"`

--- a/TreeDB/collections/text_index_test.go
+++ b/TreeDB/collections/text_index_test.go
@@ -263,7 +263,7 @@ func TestCollectionTextRootStoragePolicies(t *testing.T) {
 	}
 }
 
-func TestCollectionTextIndexedWritesMaintainStorageAndSearchFailsClosed(t *testing.T) {
+func TestCollectionTextIndexedWritesMaintainStorageAndSearchRanks(t *testing.T) {
 	d, err := backenddb.Open(backenddb.Options{Dir: t.TempDir()})
 	if err != nil {
 		t.Fatalf("open db: %v", err)
@@ -295,11 +295,14 @@ func TestCollectionTextIndexedWritesMaintainStorageAndSearchFailsClosed(t *testi
 	}
 
 	response, err := col.SearchText(TextSearchOptions{IndexName: "lexical", Query: "refund AND policy", TopK: 10})
-	if !errors.Is(err, ErrTextIndexUnavailable) {
-		t.Fatalf("SearchText err=%v want ErrTextIndexUnavailable", err)
+	if err != nil {
+		t.Fatalf("SearchText: %v", err)
 	}
-	if response.Stats.QueryTerms != 2 || response.Stats.DocumentsFetched != 0 || !response.Stats.Unavailable {
-		t.Fatalf("SearchText stats=%+v want terms=2 fetched=0 unavailable", response.Stats)
+	if len(response.Results) != 1 || string(response.Results[0].DocumentID) != "d1" || response.Results[0].Rank != 1 || response.Results[0].Score <= 0 {
+		t.Fatalf("SearchText results=%+v want ranked d1", response.Results)
+	}
+	if response.Stats.QueryTerms != 2 || response.Stats.TextPostingsScanned != 2 || response.Stats.TextCandidatesScored != 1 || response.Stats.DocumentsFetched != 0 || response.Stats.FailClosed != 0 {
+		t.Fatalf("SearchText stats=%+v want indexed search counters", response.Stats)
 	}
 	if _, err := col.SearchText(TextSearchOptions{IndexName: "missing", Query: "refund", TopK: 10}); !errors.Is(err, ErrIndexNotFound) {
 		t.Fatalf("SearchText missing err=%v want ErrIndexNotFound", err)

--- a/TreeDB/collections/text_search.go
+++ b/TreeDB/collections/text_search.go
@@ -327,7 +327,7 @@ func scanTextSearchPostingsTerm(
 	stats *TextSearchStats,
 ) (bool, error) {
 	prefix := encodeTextPostingTermPrefix(term)
-	it, err := collectionIteratorAtCatalogRoot(snap, catalog, postingsRootName, prefix, textSearchPrefixEnd(prefix), false)
+	it, err := collectionIteratorAtCatalogRoot(snap, catalog, postingsRootName, prefix, textSearchPrefixEnd(prefix), true)
 	if err != nil {
 		return false, err
 	}
@@ -338,7 +338,7 @@ func scanTextSearchPostingsTerm(
 		return false, nil
 	}
 	defer func() { _ = it.Close() }()
-	var postingsForTerm uint64
+	var livePostingsForTerm uint64
 	for it.Valid() {
 		key := it.UnsafeKey()
 		if !bytes.HasPrefix(key, prefix) {
@@ -349,6 +349,7 @@ func scanTextSearchPostingsTerm(
 			stats.FailClosedReason = textSearchFailClosedPostingsLimit
 			return true, nil
 		}
+		stats.TextPostingsScanned++
 		if it.IsDeleted() {
 			it.Next()
 			continue
@@ -367,8 +368,7 @@ func scanTextSearchPostingsTerm(
 		if termStats.DocumentFrequency == 0 {
 			return false, errMalformedTextStorage("postings exist for term %q with zero document frequency", term)
 		}
-		stats.TextPostingsScanned++
-		postingsForTerm++
+		livePostingsForTerm++
 		keyString := string(documentID)
 		candidate := candidates[keyString]
 		if candidate == nil {
@@ -402,8 +402,8 @@ func scanTextSearchPostingsTerm(
 	if err := it.Error(); err != nil {
 		return false, err
 	}
-	if postingsForTerm != termStats.DocumentFrequency {
-		return false, errMalformedTextStorage("text-stats term %q document frequency %d does not match postings %d", term, termStats.DocumentFrequency, postingsForTerm)
+	if livePostingsForTerm != termStats.DocumentFrequency {
+		return false, errMalformedTextStorage("text-stats term %q document frequency %d does not match live postings %d", term, termStats.DocumentFrequency, livePostingsForTerm)
 	}
 	return false, nil
 }
@@ -532,7 +532,13 @@ func textSearchFailClosed(response TextSearchResponse, reason string, err error)
 	if response.Stats.CandidatesScored == 0 {
 		response.Stats.CandidatesScored = response.Stats.TextCandidatesScored
 	}
-	return response, err
+	if err == nil {
+		return response, fmt.Errorf("%w: %s", ErrTextIndexUnavailable, reason)
+	}
+	if errors.Is(err, ErrTextIndexUnavailable) {
+		return response, err
+	}
+	return response, fmt.Errorf("%w: %w", ErrTextIndexUnavailable, err)
 }
 
 func normalizeTextSearchCandidateLimit(topK, requested int) int {

--- a/TreeDB/collections/text_search.go
+++ b/TreeDB/collections/text_search.go
@@ -1,15 +1,19 @@
 package collections
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
+	"math"
+	"sort"
 	"strings"
+	"time"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
 )
 
 // TextSearchOperator controls how analyzed query terms are combined. The zero
-// value currently normalizes to OR.
+// value normalizes to OR.
 type TextSearchOperator string
 
 const (
@@ -17,53 +21,100 @@ const (
 	TextSearchOperatorAND TextSearchOperator = "and"
 )
 
-const textSearchUnavailableExecution = "text_search_execution_unimplemented"
+const (
+	textSearchDefaultMinCandidateLimit = 1024
+	textSearchDefaultMaxPostingsScan   = 1 << 20
 
-// TextSearchOptions configures collection-native lexical search. PR1 validates
-// the query shape and fails closed before scanning because ranked text search
-// execution is not implemented yet.
+	textSearchFailClosedCandidateLimit = "candidate_limit_exceeded"
+	textSearchFailClosedPostingsLimit  = "postings_scan_limit_exceeded"
+	textSearchFailClosedStorageCorrupt = "text_index_storage_corrupt"
+	textSearchFailClosedDocumentFetch  = "document_fetch_unavailable"
+)
+
+const (
+	textSearchBM25K1 = 1.2
+	textSearchBM25B  = 0.75
+)
+
+// TextSearchOptions configures collection-native lexical search.
 type TextSearchOptions struct {
-	IndexName            string
-	Query                string
-	Operator             TextSearchOperator
-	TopK                 int
+	IndexName string
+	Query     string
+	Operator  TextSearchOperator
+	TopK      int
+	// CandidateLimit bounds the number of unique document candidates generated
+	// from postings before scoring. The zero value uses an implementation default
+	// derived from TopK. When the limit is exceeded, SearchText fails closed rather
+	// than returning silently incomplete rankings.
+	CandidateLimit int
+	// MaxPostingsScanned bounds postings range-scan work. The zero value uses an
+	// implementation default. When the limit is exceeded, SearchText fails closed.
+	MaxPostingsScanned   int
 	IncludeDocuments     bool
 	DocumentFetchOptions DocumentFetchOptions
 }
 
-// TextSearchResult is one ranked lexical result. Later #1764 storage/search
-// milestones populate these fields from persistent postings and BM25/BM25F
-// scoring; PR1 returns no results while storage is unavailable.
+// TextSearchMatch carries matched field/term attribution for a lexical result.
+type TextSearchMatch struct {
+	Field string
+	Terms []string
+}
+
+// TextSearchResult is one ranked lexical result. Rank is one-based in descending
+// BM25F score order and DocumentID is response-owned.
 type TextSearchResult struct {
 	DocumentID    []byte
+	IndexName     string
 	Rank          int
 	Score         float64
+	ScoreKind     HybridScoreKind
 	MatchedTerms  []string
 	MatchedFields []string
+	TextMatches   []TextSearchMatch
 	Document      []byte
 }
 
-// TextSearchStats reports text-only search work. Counters are intentionally
-// lexical/search-specific and avoid hybrid candidate/fusion terminology.
+// TextSearchStats reports text-only search work. The Text* candidate counters
+// intentionally mirror the hybrid-search counter vocabulary so #2503 can adapt
+// text-only results without inventing new counter names. The shorter aliases are
+// retained for text-only callers.
 type TextSearchStats struct {
-	QueryTerms        int
-	PostingsScanned   uint64
-	CandidatesScored  uint64
-	DocumentsFetched  uint64
-	Truncated         bool
-	Unavailable       bool
-	UnavailableReason string
+	QueryTerms                int
+	TextCandidatesRequested   uint64
+	TextCandidatesReturned    uint64
+	TextPostingsScanned       uint64
+	TextCandidatesScored      uint64
+	PostingsScanned           uint64
+	CandidatesScored          uint64
+	DocumentsFetched          uint64
+	DocumentsMissing          uint64
+	FullDocumentScanFallbacks uint64
+	PostingsScanNanos         uint64
+	CandidateScoreNanos       uint64
+	DocumentFetchNanos        uint64
+	Truncated                 bool
+	FailClosed                uint64
+	FailClosedReason          string
+	Unavailable               bool
+	UnavailableReason         string
 }
 
 // TextSearchResponse contains ranked text results and diagnostics.
 type TextSearchResponse struct {
-	Results []TextSearchResult
-	Stats   TextSearchStats
+	IndexName string
+	Results   []TextSearchResult
+	Stats     TextSearchStats
 }
 
-// SearchText validates the declared text index and query shape, then fails
-// closed until ranked postings/text-state/stats search execution lands in a
-// later #1764 milestone. It never scans/ranks all collection documents.
+type textSearchCandidate struct {
+	documentID []byte
+	postings   map[string]textPostingValue
+	matches    map[string]map[string]struct{}
+	score      float64
+}
+
+// SearchText executes a bounded postings-backed lexical search for a declared
+// collection text index. It never scans/ranks all collection documents.
 func (c *Collection) SearchText(opts TextSearchOptions) (TextSearchResponse, error) {
 	var response TextSearchResponse
 	if c == nil {
@@ -77,6 +128,12 @@ func (c *Collection) SearchText(opts TextSearchOptions) (TextSearchResponse, err
 	}
 	if opts.TopK <= 0 {
 		return response, errors.New("collections: text search TopK must be positive")
+	}
+	if opts.CandidateLimit < 0 {
+		return response, errors.New("collections: text search CandidateLimit must be non-negative")
+	}
+	if opts.MaxPostingsScanned < 0 {
+		return response, errors.New("collections: text search MaxPostingsScanned must be non-negative")
 	}
 	if _, err := normalizeTextSearchOperator(opts.Operator); err != nil {
 		return response, err
@@ -98,19 +155,461 @@ func (c *Collection) SearchText(opts TextSearchOptions) (TextSearchResponse, err
 	if !ok {
 		return response, ErrIndexNotFound
 	}
+	response.IndexName = idx.Name
 
-	terms, _, err := parseTextSearchQuery(idx.Analyzer, opts.Query, opts.Operator)
+	terms, operator, err := parseTextSearchQuery(idx.Analyzer, opts.Query, opts.Operator)
 	if err != nil {
 		return response, err
 	}
+	terms = uniqueTextSearchTerms(terms)
 	response.Stats.QueryTerms = len(terms)
 	if len(terms) == 0 {
 		response.Results = []TextSearchResult{}
 		return response, nil
 	}
+	candidateLimit := normalizeTextSearchCandidateLimit(opts.TopK, opts.CandidateLimit)
+	maxPostingsScanned := normalizeTextSearchMaxPostingsScanned(candidateLimit, len(terms), opts.MaxPostingsScanned)
+	response.Stats.TextCandidatesRequested = uint64(candidateLimit)
+
+	return executeTextSearchAtSnapshot(c, snap, catalog, idx, opts, terms, operator, candidateLimit, maxPostingsScanned, response)
+}
+
+func executeTextSearchAtSnapshot(
+	c *Collection,
+	snap *backenddb.Snapshot,
+	catalog *collectionCatalog,
+	idx TextIndexDefinition,
+	opts TextSearchOptions,
+	terms []string,
+	operator TextSearchOperator,
+	candidateLimit, maxPostingsScanned int,
+	response TextSearchResponse,
+) (TextSearchResponse, error) {
+	statsRootName := collectionTextStatsRootName(catalog.meta.Name, idx.Name)
+	corpus, err := readTextStatsCorpusAtRoot(snap, catalog, statsRootName)
+	if err != nil {
+		return textSearchFailClosed(response, textSearchFailClosedStorageCorrupt, err)
+	}
+	termStats := make(map[string]textStatsTermValue, len(terms))
+	for _, term := range terms {
+		termValue, err := readTextStatsTermAtRoot(snap, catalog, statsRootName, term)
+		if err != nil {
+			return textSearchFailClosed(response, textSearchFailClosedStorageCorrupt, err)
+		}
+		termStats[term] = termValue
+	}
+	fieldStats := make(map[string]textStatsFieldValue, len(idx.Fields))
+	fieldWeights := make(map[string]float64, len(idx.Fields))
+	for _, field := range idx.Fields {
+		statsValue, err := readTextStatsFieldAtRoot(snap, catalog, statsRootName, field.Field)
+		if err != nil {
+			return textSearchFailClosed(response, textSearchFailClosedStorageCorrupt, err)
+		}
+		fieldStats[field.Field] = statsValue
+		weight := field.Weight
+		if weight == 0 {
+			weight = 1
+		}
+		fieldWeights[field.Field] = weight
+	}
+
+	candidates := make(map[string]*textSearchCandidate)
+	scanTerms := orderTextSearchScanTerms(terms, operator, termStats)
+	scanStart := time.Now()
+	postingsRootName := collectionTextIndexRootName(catalog.meta.Name, idx.Name)
+	for i, term := range scanTerms {
+		allowNewCandidates := operator != TextSearchOperatorAND || i == 0
+		truncated, err := scanTextSearchPostingsTerm(snap, catalog, postingsRootName, term, termStats[term], candidates, allowNewCandidates, candidateLimit, maxPostingsScanned, &response.Stats)
+		if err != nil {
+			return textSearchFailClosed(response, textSearchFailClosedStorageCorrupt, err)
+		}
+		if truncated {
+			response.Stats.PostingsScanNanos += uint64(time.Since(scanStart).Nanoseconds())
+			return textSearchFailClosed(response, response.Stats.FailClosedReason, fmt.Errorf("%w: collection %q text index %q exceeded bounded candidate generation", ErrTextIndexUnavailable, catalog.meta.Name, idx.Name))
+		}
+		if operator == TextSearchOperatorAND {
+			pruneTextSearchANDCandidates(candidates, term)
+			if len(candidates) == 0 {
+				break
+			}
+		}
+	}
+	response.Stats.PostingsScanNanos += uint64(time.Since(scanStart).Nanoseconds())
+	response.Stats.PostingsScanned = response.Stats.TextPostingsScanned
+
+	if operator == TextSearchOperatorAND {
+		for key, candidate := range candidates {
+			if len(candidate.postings) != len(terms) {
+				delete(candidates, key)
+			}
+		}
+	}
+	if len(candidates) == 0 {
+		response.Results = []TextSearchResult{}
+		return response, nil
+	}
+
+	scoreStart := time.Now()
+	scored := make([]*textSearchCandidate, 0, len(candidates))
+	stateRootName := collectionTextStateRootName(catalog.meta.Name, idx.Name)
+	for _, candidate := range candidates {
+		stateRaw, found, err := collectionGetAppendAtCatalogRoot(snap, catalog, stateRootName, encodeTextStateKey(candidate.documentID), nil)
+		if err != nil {
+			return textSearchFailClosed(response, textSearchFailClosedStorageCorrupt, err)
+		}
+		if !found {
+			return textSearchFailClosed(response, textSearchFailClosedStorageCorrupt, errMalformedTextStorage("missing text-state for collection %q index %q document %q", catalog.meta.Name, idx.Name, string(candidate.documentID)))
+		}
+		state, err := decodeTextDocumentStateValue(stateRaw)
+		if err != nil {
+			return textSearchFailClosed(response, textSearchFailClosedStorageCorrupt, err)
+		}
+		score, err := scoreTextSearchCandidate(candidate, terms, corpus, termStats, fieldStats, fieldWeights, state)
+		if err != nil {
+			return textSearchFailClosed(response, textSearchFailClosedStorageCorrupt, err)
+		}
+		candidate.score = score
+		scored = append(scored, candidate)
+	}
+	response.Stats.CandidateScoreNanos += uint64(time.Since(scoreStart).Nanoseconds())
+	response.Stats.TextCandidatesScored = uint64(len(scored))
+	response.Stats.CandidatesScored = response.Stats.TextCandidatesScored
+
+	sort.Slice(scored, func(i, j int) bool {
+		if scored[i].score != scored[j].score {
+			return scored[i].score > scored[j].score
+		}
+		return bytes.Compare(scored[i].documentID, scored[j].documentID) < 0
+	})
+	if len(scored) > opts.TopK {
+		scored = scored[:opts.TopK]
+	}
+	response.Stats.TextCandidatesReturned = uint64(len(scored))
+	response.Results = make([]TextSearchResult, len(scored))
+	for i, candidate := range scored {
+		matchedTerms, matchedFields, matches := textSearchCandidateMatches(candidate)
+		response.Results[i] = TextSearchResult{
+			DocumentID:    bytes.Clone(candidate.documentID),
+			IndexName:     idx.Name,
+			Rank:          i + 1,
+			Score:         candidate.score,
+			ScoreKind:     HybridScoreKindBM25F,
+			MatchedTerms:  matchedTerms,
+			MatchedFields: matchedFields,
+			TextMatches:   matches,
+		}
+	}
+
+	if opts.IncludeDocuments && len(response.Results) > 0 {
+		if err := fetchTextSearchResultDocuments(c, snap, catalog, opts, &response); err != nil {
+			return textSearchFailClosed(response, textSearchFailClosedDocumentFetch, err)
+		}
+	}
+	return response, nil
+}
+
+func pruneTextSearchANDCandidates(candidates map[string]*textSearchCandidate, term string) {
+	for key, candidate := range candidates {
+		if _, ok := candidate.postings[term]; !ok {
+			delete(candidates, key)
+		}
+	}
+}
+
+func scanTextSearchPostingsTerm(
+	snap *backenddb.Snapshot,
+	catalog *collectionCatalog,
+	postingsRootName, term string,
+	termStats textStatsTermValue,
+	candidates map[string]*textSearchCandidate,
+	allowNewCandidates bool,
+	candidateLimit, maxPostingsScanned int,
+	stats *TextSearchStats,
+) (bool, error) {
+	prefix := encodeTextPostingTermPrefix(term)
+	it, err := collectionIteratorAtCatalogRoot(snap, catalog, postingsRootName, prefix, textSearchPrefixEnd(prefix), false)
+	if err != nil {
+		return false, err
+	}
+	if it == nil {
+		if termStats.DocumentFrequency != 0 {
+			return false, errMalformedTextStorage("text-stats term %q document frequency %d has no postings root", term, termStats.DocumentFrequency)
+		}
+		return false, nil
+	}
+	defer func() { _ = it.Close() }()
+	var postingsForTerm uint64
+	for it.Valid() {
+		key := it.UnsafeKey()
+		if !bytes.HasPrefix(key, prefix) {
+			break
+		}
+		if maxPostingsScanned > 0 && stats.TextPostingsScanned >= uint64(maxPostingsScanned) {
+			stats.Truncated = true
+			stats.FailClosedReason = textSearchFailClosedPostingsLimit
+			return true, nil
+		}
+		if it.IsDeleted() {
+			it.Next()
+			continue
+		}
+		decodedTerm, documentID, err := decodeTextPostingKey(key)
+		if err != nil {
+			return false, err
+		}
+		if decodedTerm != term {
+			return false, errMalformedTextStorage("postings key term %q outside scan term %q", decodedTerm, term)
+		}
+		posting, err := decodeTextPostingValue(it.ValueCopy(nil))
+		if err != nil {
+			return false, err
+		}
+		if termStats.DocumentFrequency == 0 {
+			return false, errMalformedTextStorage("postings exist for term %q with zero document frequency", term)
+		}
+		stats.TextPostingsScanned++
+		postingsForTerm++
+		keyString := string(documentID)
+		candidate := candidates[keyString]
+		if candidate == nil {
+			if !allowNewCandidates {
+				it.Next()
+				continue
+			}
+			if candidateLimit > 0 && len(candidates) >= candidateLimit {
+				stats.Truncated = true
+				stats.FailClosedReason = textSearchFailClosedCandidateLimit
+				return true, nil
+			}
+			candidate = &textSearchCandidate{
+				documentID: bytes.Clone(documentID),
+				postings:   make(map[string]textPostingValue),
+				matches:    make(map[string]map[string]struct{}),
+			}
+			candidates[keyString] = candidate
+		}
+		candidate.postings[term] = posting
+		for _, field := range posting.Fields {
+			terms := candidate.matches[field.Field]
+			if terms == nil {
+				terms = make(map[string]struct{})
+				candidate.matches[field.Field] = terms
+			}
+			terms[term] = struct{}{}
+		}
+		it.Next()
+	}
+	if err := it.Error(); err != nil {
+		return false, err
+	}
+	if postingsForTerm != termStats.DocumentFrequency {
+		return false, errMalformedTextStorage("text-stats term %q document frequency %d does not match postings %d", term, termStats.DocumentFrequency, postingsForTerm)
+	}
+	return false, nil
+}
+
+func scoreTextSearchCandidate(candidate *textSearchCandidate, terms []string, corpus textStatsCorpusValue, termStats map[string]textStatsTermValue, fieldStats map[string]textStatsFieldValue, fieldWeights map[string]float64, state textDocumentStateValue) (float64, error) {
+	if corpus.DocumentCount == 0 {
+		return 0, errMalformedTextStorage("text-stats corpus document count is zero with search candidates")
+	}
+	fieldLengths := make(map[string]uint32, len(state.Fields))
+	for _, field := range state.Fields {
+		fieldLengths[field.Field] = field.Length
+	}
+	corpusDocuments := float64(corpus.DocumentCount)
+	var score float64
+	for _, term := range terms {
+		posting, ok := candidate.postings[term]
+		if !ok {
+			continue
+		}
+		stats := termStats[term]
+		if stats.DocumentFrequency == 0 || stats.DocumentFrequency > corpus.DocumentCount {
+			return 0, errMalformedTextStorage("text-stats term %q document frequency %d outside corpus %d", term, stats.DocumentFrequency, corpus.DocumentCount)
+		}
+		df := float64(stats.DocumentFrequency)
+		idf := math.Log(1 + (corpusDocuments-df+0.5)/(df+0.5))
+		var combinedTF float64
+		for _, fieldPosting := range posting.Fields {
+			weight, ok := fieldWeights[fieldPosting.Field]
+			if !ok {
+				return 0, errMalformedTextStorage("posting references undeclared text field %q", fieldPosting.Field)
+			}
+			statsValue := fieldStats[fieldPosting.Field]
+			if statsValue.DocumentCount == 0 || statsValue.TotalTokenCount == 0 {
+				return 0, errMalformedTextStorage("missing text-stats field accounting for %q", fieldPosting.Field)
+			}
+			fieldLength, ok := fieldLengths[fieldPosting.Field]
+			if !ok {
+				return 0, errMalformedTextStorage("missing text-state field length for %q", fieldPosting.Field)
+			}
+			avgLength := float64(statsValue.TotalTokenCount) / float64(statsValue.DocumentCount)
+			if avgLength <= 0 {
+				return 0, errMalformedTextStorage("invalid average text field length for %q", fieldPosting.Field)
+			}
+			fieldTF := float64(fieldPosting.Frequency)
+			if fieldTF <= 0 {
+				continue
+			}
+			normalizedTF := fieldTF / (1 - textSearchBM25B + textSearchBM25B*(float64(fieldLength)/avgLength))
+			combinedTF += weight * normalizedTF
+		}
+		if combinedTF > 0 {
+			score += idf * ((combinedTF * (textSearchBM25K1 + 1)) / (combinedTF + textSearchBM25K1))
+		}
+	}
+	return score, nil
+}
+
+func fetchTextSearchResultDocuments(c *Collection, snap *backenddb.Snapshot, catalog *collectionCatalog, opts TextSearchOptions, response *TextSearchResponse) error {
+	ids := make([][]byte, len(response.Results))
+	for i := range response.Results {
+		ids[i] = response.Results[i].DocumentID
+	}
+	view := newCollectionReadViewAtSnapshot(c, snap, catalog, false, "")
+	fetchStart := time.Now()
+	fetch, err := view.FetchDocumentsByID(ids, opts.DocumentFetchOptions)
+	response.Stats.DocumentFetchNanos += uint64(time.Since(fetchStart).Nanoseconds())
+	closeErr := view.Close()
+	if err != nil {
+		return err
+	}
+	if closeErr != nil {
+		return closeErr
+	}
+	for i := range fetch.Results {
+		if i >= len(response.Results) {
+			break
+		}
+		if fetch.Results[i].Found {
+			response.Results[i].Document = bytes.Clone(fetch.Results[i].Document)
+			response.Stats.DocumentsFetched++
+		} else {
+			response.Stats.DocumentsMissing++
+		}
+	}
+	return nil
+}
+
+func textSearchCandidateMatches(candidate *textSearchCandidate) ([]string, []string, []TextSearchMatch) {
+	fields := make([]string, 0, len(candidate.matches))
+	termSet := make(map[string]struct{})
+	for field, terms := range candidate.matches {
+		fields = append(fields, field)
+		for term := range terms {
+			termSet[term] = struct{}{}
+		}
+	}
+	sort.Strings(fields)
+	matchedTerms := make([]string, 0, len(termSet))
+	for term := range termSet {
+		matchedTerms = append(matchedTerms, term)
+	}
+	sort.Strings(matchedTerms)
+	matches := make([]TextSearchMatch, 0, len(fields))
+	for _, field := range fields {
+		terms := make([]string, 0, len(candidate.matches[field]))
+		for term := range candidate.matches[field] {
+			terms = append(terms, term)
+		}
+		sort.Strings(terms)
+		matches = append(matches, TextSearchMatch{Field: field, Terms: terms})
+	}
+	return matchedTerms, fields, matches
+}
+
+func textSearchFailClosed(response TextSearchResponse, reason string, err error) (TextSearchResponse, error) {
+	if reason == "" {
+		reason = textSearchFailClosedStorageCorrupt
+	}
+	response.Stats.FailClosed = 1
+	response.Stats.FailClosedReason = reason
 	response.Stats.Unavailable = true
-	response.Stats.UnavailableReason = textSearchUnavailableExecution
-	return response, fmt.Errorf("%w: collection %q text index %q search execution is not implemented yet", ErrTextIndexUnavailable, catalog.meta.Name, idx.Name)
+	response.Stats.UnavailableReason = reason
+	if response.Stats.PostingsScanned == 0 {
+		response.Stats.PostingsScanned = response.Stats.TextPostingsScanned
+	}
+	if response.Stats.CandidatesScored == 0 {
+		response.Stats.CandidatesScored = response.Stats.TextCandidatesScored
+	}
+	return response, err
+}
+
+func normalizeTextSearchCandidateLimit(topK, requested int) int {
+	if requested > 0 {
+		return requested
+	}
+	limit := topK * 64
+	if limit < textSearchDefaultMinCandidateLimit {
+		limit = textSearchDefaultMinCandidateLimit
+	}
+	return limit
+}
+
+func normalizeTextSearchMaxPostingsScanned(candidateLimit, termCount, requested int) int {
+	if requested > 0 {
+		return requested
+	}
+	limit := candidateLimit * maxIntForTextSearch(termCount, 1) * 4
+	if limit < textSearchDefaultMinCandidateLimit {
+		limit = textSearchDefaultMinCandidateLimit
+	}
+	if limit > textSearchDefaultMaxPostingsScan {
+		limit = textSearchDefaultMaxPostingsScan
+	}
+	return limit
+}
+
+func maxIntForTextSearch(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func uniqueTextSearchTerms(terms []string) []string {
+	if len(terms) <= 1 {
+		return terms
+	}
+	seen := make(map[string]struct{}, len(terms))
+	out := make([]string, 0, len(terms))
+	for _, term := range terms {
+		if _, ok := seen[term]; ok {
+			continue
+		}
+		seen[term] = struct{}{}
+		out = append(out, term)
+	}
+	return out
+}
+
+func orderTextSearchScanTerms(terms []string, operator TextSearchOperator, stats map[string]textStatsTermValue) []string {
+	out := append([]string(nil), terms...)
+	if operator == TextSearchOperatorAND {
+		sort.SliceStable(out, func(i, j int) bool {
+			left := stats[out[i]].DocumentFrequency
+			right := stats[out[j]].DocumentFrequency
+			if left != right {
+				return left < right
+			}
+			return out[i] < out[j]
+		})
+	}
+	return out
+}
+
+func textSearchPrefixEnd(prefix []byte) []byte {
+	if len(prefix) == 0 {
+		return nil
+	}
+	out := bytes.Clone(prefix)
+	for i := len(out) - 1; i >= 0; i-- {
+		if out[i] != 0xff {
+			out[i]++
+			return out[:i+1]
+		}
+	}
+	return nil
 }
 
 func normalizeTextSearchOperator(op TextSearchOperator) (TextSearchOperator, error) {

--- a/TreeDB/collections/text_search.go
+++ b/TreeDB/collections/text_search.go
@@ -138,6 +138,9 @@ func (c *Collection) SearchText(opts TextSearchOptions) (TextSearchResponse, err
 	if _, err := normalizeTextSearchOperator(opts.Operator); err != nil {
 		return response, err
 	}
+	if err := c.flushBufferedWrites(); err != nil {
+		return response, err
+	}
 
 	snap := c.db.AcquireSnapshot()
 	if snap == nil {

--- a/TreeDB/collections/text_search_m4_test.go
+++ b/TreeDB/collections/text_search_m4_test.go
@@ -1,0 +1,289 @@
+package collections
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"math"
+	"testing"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+)
+
+func TestSearchTextSingleTermRankedSearchM4(t *testing.T) {
+	d := openTextTestDB(t)
+	defer func() { _ = d.Close() }()
+	col := createTextSearchM4Collection(t, d, []TextIndexField{{Field: "body"}})
+	if _, err := col.InsertBatch([][]byte{[]byte("d1"), []byte("d2"), []byte("d3")}, [][]byte{
+		[]byte(`{"body":"refund refund refund"}`),
+		[]byte(`{"body":"refund"}`),
+		[]byte(`{"body":"shipping policy"}`),
+	}); err != nil {
+		t.Fatalf("InsertBatch: %v", err)
+	}
+
+	got, err := col.SearchText(TextSearchOptions{IndexName: "lexical", Query: "refund", TopK: 2, IncludeDocuments: true})
+	if err != nil {
+		t.Fatalf("SearchText: %v", err)
+	}
+	if got.IndexName != "lexical" || len(got.Results) != 2 {
+		t.Fatalf("SearchText response=%+v want two lexical results", got)
+	}
+	if string(got.Results[0].DocumentID) != "d1" || got.Results[0].Rank != 1 || got.Results[0].ScoreKind != HybridScoreKindBM25F {
+		t.Fatalf("result[0]=%+v want d1 rank=1 bm25f", got.Results[0])
+	}
+	if string(got.Results[1].DocumentID) != "d2" || got.Results[1].Rank != 2 || got.Results[0].Score <= got.Results[1].Score {
+		t.Fatalf("results=%+v want d1 above d2", got.Results)
+	}
+	if !bytes.Contains(got.Results[0].Document, []byte("refund refund")) || !slicesEqualStrings(got.Results[0].MatchedTerms, []string{"refund"}) || !slicesEqualStrings(got.Results[0].MatchedFields, []string{"body"}) {
+		t.Fatalf("result[0] document/matches=%+v", got.Results[0])
+	}
+	if got.Stats.QueryTerms != 1 || got.Stats.TextPostingsScanned != 2 || got.Stats.PostingsScanned != 2 || got.Stats.TextCandidatesScored != 2 || got.Stats.CandidatesScored != 2 || got.Stats.DocumentsFetched != 2 || got.Stats.FullDocumentScanFallbacks != 0 || got.Stats.FailClosed != 0 {
+		t.Fatalf("stats=%+v want postings=2 scored=2 fetched=2 no fallback", got.Stats)
+	}
+}
+
+func TestSearchTextANDOROperatorsM4(t *testing.T) {
+	d := openTextTestDB(t)
+	defer func() { _ = d.Close() }()
+	col := createTextSearchM4Collection(t, d, []TextIndexField{{Field: "body"}})
+	if _, err := col.InsertBatch([][]byte{[]byte("both"), []byte("refund"), []byte("policy")}, [][]byte{
+		[]byte(`{"body":"refund policy"}`),
+		[]byte(`{"body":"refund"}`),
+		[]byte(`{"body":"policy"}`),
+	}); err != nil {
+		t.Fatalf("InsertBatch: %v", err)
+	}
+
+	andResult, err := col.SearchText(TextSearchOptions{IndexName: "lexical", Query: "refund AND policy", TopK: 10})
+	if err != nil {
+		t.Fatalf("SearchText AND: %v", err)
+	}
+	if len(andResult.Results) != 1 || string(andResult.Results[0].DocumentID) != "both" {
+		t.Fatalf("AND results=%+v want only both", andResult.Results)
+	}
+	orResult, err := col.SearchText(TextSearchOptions{IndexName: "lexical", Query: "refund OR policy", TopK: 10})
+	if err != nil {
+		t.Fatalf("SearchText OR: %v", err)
+	}
+	if len(orResult.Results) != 3 || orResult.Stats.TextPostingsScanned != 4 || orResult.Stats.TextCandidatesScored != 3 {
+		t.Fatalf("OR response=%+v want three docs postings=4 scored=3", orResult)
+	}
+	missingAnd, err := col.SearchText(TextSearchOptions{IndexName: "lexical", Query: "missing AND refund", TopK: 10})
+	if err != nil {
+		t.Fatalf("SearchText missing AND refund: %v", err)
+	}
+	if len(missingAnd.Results) != 0 || missingAnd.Stats.TextPostingsScanned != 0 || missingAnd.Stats.TextCandidatesScored != 0 || missingAnd.Stats.TextCandidatesReturned != 0 || missingAnd.Stats.Truncated || missingAnd.Stats.FailClosed != 0 {
+		t.Fatalf("missing AND response=%+v want empty without scanning common term or fail-closed", missingAnd)
+	}
+}
+
+func TestSearchTextFieldWeightAffectsRankingM4(t *testing.T) {
+	d := openTextTestDB(t)
+	defer func() { _ = d.Close() }()
+	col := createTextSearchM4Collection(t, d, []TextIndexField{{Field: "title", Weight: 8}, {Field: "body"}})
+	if _, err := col.InsertBatch([][]byte{[]byte("body-heavy"), []byte("title-hit")}, [][]byte{
+		[]byte(`{"title":"plain","body":"refund refund refund refund refund refund"}`),
+		[]byte(`{"title":"refund","body":"other"}`),
+	}); err != nil {
+		t.Fatalf("InsertBatch: %v", err)
+	}
+
+	got, err := col.SearchText(TextSearchOptions{IndexName: "lexical", Query: "refund", TopK: 2})
+	if err != nil {
+		t.Fatalf("SearchText: %v", err)
+	}
+	if len(got.Results) != 2 || string(got.Results[0].DocumentID) != "title-hit" || got.Results[0].Score <= got.Results[1].Score {
+		t.Fatalf("weighted results=%+v want title-hit first", got.Results)
+	}
+	if len(got.Results[0].TextMatches) != 1 || got.Results[0].TextMatches[0].Field != "title" || !slicesEqualStrings(got.Results[0].TextMatches[0].Terms, []string{"refund"}) {
+		t.Fatalf("title-hit matches=%+v want title/refund", got.Results[0].TextMatches)
+	}
+}
+
+func TestSearchTextMissingIndexUnsupportedSyntaxAndTruncationM4(t *testing.T) {
+	d := openTextTestDB(t)
+	defer func() { _ = d.Close() }()
+	col := createTextSearchM4Collection(t, d, []TextIndexField{{Field: "body"}})
+	if _, err := col.InsertBatch([][]byte{[]byte("d1"), []byte("d2")}, [][]byte{
+		[]byte(`{"body":"refund"}`),
+		[]byte(`{"body":"refund"}`),
+	}); err != nil {
+		t.Fatalf("InsertBatch: %v", err)
+	}
+
+	if _, err := col.SearchText(TextSearchOptions{IndexName: "missing", Query: "refund", TopK: 1}); !errors.Is(err, ErrIndexNotFound) {
+		t.Fatalf("missing index err=%v want ErrIndexNotFound", err)
+	}
+	if _, err := col.SearchText(TextSearchOptions{IndexName: "lexical", Query: `"refund policy"`, TopK: 1}); err == nil {
+		t.Fatal("phrase query err=nil want unsupported syntax")
+	}
+	truncated, err := col.SearchText(TextSearchOptions{IndexName: "lexical", Query: "refund", TopK: 1, CandidateLimit: 1})
+	if !errors.Is(err, ErrTextIndexUnavailable) {
+		t.Fatalf("truncated SearchText err=%v want ErrTextIndexUnavailable", err)
+	}
+	if truncated.Stats.Truncated != true || truncated.Stats.FailClosed != 1 || truncated.Stats.FailClosedReason != textSearchFailClosedCandidateLimit || truncated.Stats.FullDocumentScanFallbacks != 0 {
+		t.Fatalf("truncated stats=%+v want candidate-limit fail closed", truncated.Stats)
+	}
+}
+
+func TestSearchTextTopKBoundsDocumentFetchM4(t *testing.T) {
+	d := openTextTestDB(t)
+	defer func() { _ = d.Close() }()
+	col := createTextSearchM4Collection(t, d, []TextIndexField{{Field: "body"}})
+	ids := make([][]byte, 5)
+	docs := make([][]byte, 5)
+	for i := 0; i < 5; i++ {
+		ids[i] = []byte{byte('a' + i)}
+		docs[i] = []byte(`{"body":"refund policy"}`)
+	}
+	if _, err := col.InsertBatch(ids, docs); err != nil {
+		t.Fatalf("InsertBatch: %v", err)
+	}
+	got, err := col.SearchText(TextSearchOptions{IndexName: "lexical", Query: "refund", TopK: 2, IncludeDocuments: true})
+	if err != nil {
+		t.Fatalf("SearchText: %v", err)
+	}
+	if len(got.Results) != 2 || got.Stats.TextCandidatesScored != 5 || got.Stats.TextCandidatesReturned != 2 || got.Stats.DocumentsFetched != 2 || got.Stats.DocumentsMissing != 0 {
+		t.Fatalf("response=%+v want scored=5 returned/fetched=2", got)
+	}
+	for _, result := range got.Results {
+		if len(result.Document) == 0 {
+			t.Fatalf("result %+v missing fetched document", result)
+		}
+	}
+}
+
+func TestSearchTextReopenParityM4(t *testing.T) {
+	dir := t.TempDir()
+	d, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	col := createTextSearchM4Collection(t, d, []TextIndexField{{Field: "title", Weight: 3}, {Field: "body"}})
+	if _, err := col.InsertBatch([][]byte{[]byte("d1"), []byte("d2")}, [][]byte{
+		[]byte(`{"title":"refund","body":"policy refund"}`),
+		[]byte(`{"title":"policy","body":"refund"}`),
+	}); err != nil {
+		t.Fatalf("InsertBatch: %v", err)
+	}
+	before, err := col.SearchText(TextSearchOptions{IndexName: "lexical", Query: "refund", TopK: 2})
+	if err != nil {
+		t.Fatalf("SearchText before reopen: %v", err)
+	}
+	if err := d.Checkpoint(); err != nil {
+		t.Fatalf("Checkpoint: %v", err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	reopened, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+	reopenedCol, err := NewCollectionManager(reopened).OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("OpenCollection reopened: %v", err)
+	}
+	after, err := reopenedCol.SearchText(TextSearchOptions{IndexName: "lexical", Query: "refund", TopK: 2})
+	if err != nil {
+		t.Fatalf("SearchText after reopen: %v", err)
+	}
+	if len(before.Results) != len(after.Results) {
+		t.Fatalf("reopen result length before=%d after=%d", len(before.Results), len(after.Results))
+	}
+	for i := range before.Results {
+		if !bytes.Equal(before.Results[i].DocumentID, after.Results[i].DocumentID) || before.Results[i].Rank != after.Results[i].Rank || math.Abs(before.Results[i].Score-after.Results[i].Score) > 1e-12 {
+			t.Fatalf("result[%d] before=%+v after=%+v", i, before.Results[i], after.Results[i])
+		}
+	}
+	if before.Stats.TextPostingsScanned != after.Stats.TextPostingsScanned || before.Stats.TextCandidatesScored != after.Stats.TextCandidatesScored {
+		t.Fatalf("stats before=%+v after=%+v", before.Stats, after.Stats)
+	}
+}
+
+func BenchmarkSearchTextM4(b *testing.B) {
+	const docCount = 1024
+	d := openTextBenchDB(b)
+	defer func() { _ = d.Close() }()
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "docs"}); err != nil {
+		b.Fatalf("CreateCollection: %v", err)
+	}
+	col, err := mgr.OpenCollection("docs")
+	if err != nil {
+		b.Fatalf("OpenCollection: %v", err)
+	}
+	if _, _, err := col.CreateTextIndex(TextIndexDefinition{Name: "lexical", Fields: []TextIndexField{{Field: "title", Weight: 3}, {Field: "body"}}, StorePositions: true}); err != nil {
+		b.Fatalf("CreateTextIndex: %v", err)
+	}
+	ids := make([][]byte, docCount)
+	docs := make([][]byte, docCount)
+	for i := 0; i < docCount; i++ {
+		ids[i] = []byte(fmt.Sprintf("doc-%06d", i))
+		docs[i] = []byte(fmt.Sprintf(`{"title":"Ticket %d refund policy","body":"HTTP_500 retry refund policy customer %d shard %d"}`, i, i%17, i%8))
+	}
+	if _, err := col.InsertBatch(ids, docs); err != nil {
+		b.Fatalf("InsertBatch setup: %v", err)
+	}
+	cases := []struct {
+		name string
+		opts TextSearchOptions
+	}{
+		{name: "candidate_generation_scoring", opts: TextSearchOptions{IndexName: "lexical", Query: "refund policy", Operator: TextSearchOperatorAND, TopK: 20, CandidateLimit: docCount}},
+		{name: "end_to_end_with_documents", opts: TextSearchOptions{IndexName: "lexical", Query: "refund policy", Operator: TextSearchOperatorAND, TopK: 20, CandidateLimit: docCount, IncludeDocuments: true}},
+		{name: "or_query_bounded_topk", opts: TextSearchOptions{IndexName: "lexical", Query: "HTTP_500 OR customer", TopK: 10, CandidateLimit: docCount}},
+	}
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			var last TextSearchResponse
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				got, err := col.SearchText(tc.opts)
+				if err != nil {
+					b.Fatalf("SearchText: %v", err)
+				}
+				if len(got.Results) == 0 {
+					b.Fatal("SearchText returned no results")
+				}
+				last = got
+			}
+			b.ReportMetric(float64(last.Stats.TextPostingsScanned), "postings_scanned/search")
+			b.ReportMetric(float64(last.Stats.TextCandidatesScored), "candidates_scored/search")
+			b.ReportMetric(float64(last.Stats.DocumentsFetched), "docs_fetched/search")
+			b.ReportMetric(float64(last.Stats.PostingsScanNanos), "postings_scan_ns/search")
+			b.ReportMetric(float64(last.Stats.CandidateScoreNanos), "candidate_score_ns/search")
+			b.ReportMetric(float64(last.Stats.DocumentFetchNanos), "document_fetch_ns/search")
+		})
+	}
+}
+
+func createTextSearchM4Collection(t *testing.T, d *backenddb.DB, fields []TextIndexField) *Collection {
+	t.Helper()
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "docs"}); err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	col, err := mgr.OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("OpenCollection: %v", err)
+	}
+	if _, _, err := col.CreateTextIndex(TextIndexDefinition{Name: "lexical", Fields: fields, StorePositions: true}); err != nil {
+		t.Fatalf("CreateTextIndex: %v", err)
+	}
+	return col
+}
+
+func slicesEqualStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/TreeDB/collections/text_search_m4_test.go
+++ b/TreeDB/collections/text_search_m4_test.go
@@ -128,6 +128,23 @@ func TestSearchTextMissingIndexUnsupportedSyntaxAndTruncationM4(t *testing.T) {
 	}
 }
 
+func TestSearchTextSeesUnflushedTextIndexedInsertM4(t *testing.T) {
+	d := openTextTestDB(t)
+	defer func() { _ = d.Close() }()
+	col := createTextSearchM4Collection(t, d, []TextIndexField{{Field: "body"}})
+	if _, err := col.Insert([]byte("d1"), []byte(`{"body":"visible without caller flush"}`)); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+
+	got, err := col.SearchText(TextSearchOptions{IndexName: "lexical", Query: "visible", TopK: 10})
+	if err != nil {
+		t.Fatalf("SearchText: %v", err)
+	}
+	if len(got.Results) != 1 || string(got.Results[0].DocumentID) != "d1" || got.Stats.FullDocumentScanFallbacks != 0 {
+		t.Fatalf("SearchText response=%+v want just-written text-indexed document without explicit Flush", got)
+	}
+}
+
 func TestSearchTextTombstonedPostingsConsumeScanBudgetM4(t *testing.T) {
 	d := openTextTestDB(t)
 	defer func() { _ = d.Close() }()

--- a/TreeDB/collections/text_search_m4_test.go
+++ b/TreeDB/collections/text_search_m4_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
+	"github.com/snissn/gomap/TreeDB/internal/iterator"
 )
 
 func TestSearchTextSingleTermRankedSearchM4(t *testing.T) {
@@ -127,6 +128,45 @@ func TestSearchTextMissingIndexUnsupportedSyntaxAndTruncationM4(t *testing.T) {
 	}
 }
 
+func TestSearchTextTombstonedPostingsConsumeScanBudgetM4(t *testing.T) {
+	d := openTextTestDB(t)
+	defer func() { _ = d.Close() }()
+	col := createTextSearchM4Collection(t, d, []TextIndexField{{Field: "body"}})
+	if _, err := col.InsertBatch([][]byte{[]byte("a"), []byte("b")}, [][]byte{
+		[]byte(`{"body":"refund"}`),
+		[]byte(`{"body":"refund"}`),
+	}); err != nil {
+		t.Fatalf("InsertBatch: %v", err)
+	}
+	publishTextPostingOverlayTombstone(t, d, "docs", "lexical", "refund", []byte("a"))
+
+	got, err := col.SearchText(TextSearchOptions{IndexName: "lexical", Query: "refund", TopK: 1, MaxPostingsScanned: 1})
+	if !errors.Is(err, ErrTextIndexUnavailable) {
+		t.Fatalf("SearchText err=%v want ErrTextIndexUnavailable", err)
+	}
+	if got.Stats.TextPostingsScanned != 1 || !got.Stats.Truncated || got.Stats.FailClosedReason != textSearchFailClosedPostingsLimit {
+		t.Fatalf("stats=%+v want tombstoned posting charged to scan budget", got.Stats)
+	}
+}
+
+func TestSearchTextFailClosedWrapsStorageCorruptionM4(t *testing.T) {
+	d := openTextTestDB(t)
+	defer func() { _ = d.Close() }()
+	col := createTextSearchM4Collection(t, d, []TextIndexField{{Field: "body"}})
+	if _, err := col.Insert([]byte("d1"), []byte(`{"body":"refund policy"}`)); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+	corruptTextRootValue(t, d, "docs", collectionTextStatsRootName("docs", "lexical"), encodeTextStatsCorpusKey(), []byte{99})
+
+	got, err := col.SearchText(TextSearchOptions{IndexName: "lexical", Query: "refund", TopK: 1})
+	if !errors.Is(err, ErrTextIndexUnavailable) || !errors.Is(err, ErrTextIndexStorageCorrupt) {
+		t.Fatalf("SearchText err=%v want ErrTextIndexUnavailable and ErrTextIndexStorageCorrupt", err)
+	}
+	if got.Stats.FailClosed != 1 || got.Stats.FailClosedReason != textSearchFailClosedStorageCorrupt || !got.Stats.Unavailable {
+		t.Fatalf("stats=%+v want storage-corrupt fail-closed", got.Stats)
+	}
+}
+
 func TestSearchTextTopKBoundsDocumentFetchM4(t *testing.T) {
 	d := openTextTestDB(t)
 	defer func() { _ = d.Close() }()
@@ -160,6 +200,12 @@ func TestSearchTextReopenParityM4(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open db: %v", err)
 	}
+	firstClosed := false
+	defer func() {
+		if !firstClosed {
+			_ = d.Close()
+		}
+	}()
 	col := createTextSearchM4Collection(t, d, []TextIndexField{{Field: "title", Weight: 3}, {Field: "body"}})
 	if _, err := col.InsertBatch([][]byte{[]byte("d1"), []byte("d2")}, [][]byte{
 		[]byte(`{"title":"refund","body":"policy refund"}`),
@@ -177,6 +223,7 @@ func TestSearchTextReopenParityM4(t *testing.T) {
 	if err := d.Close(); err != nil {
 		t.Fatalf("close: %v", err)
 	}
+	firstClosed = true
 	reopened, err := backenddb.Open(backenddb.Options{Dir: dir})
 	if err != nil {
 		t.Fatalf("reopen: %v", err)
@@ -257,6 +304,34 @@ func BenchmarkSearchTextM4(b *testing.B) {
 			b.ReportMetric(float64(last.Stats.CandidateScoreNanos), "candidate_score_ns/search")
 			b.ReportMetric(float64(last.Stats.DocumentFetchNanos), "document_fetch_ns/search")
 		})
+	}
+}
+
+func publishTextPostingOverlayTombstone(t *testing.T, d *backenddb.DB, collection, indexName, term string, documentID []byte) {
+	t.Helper()
+	rootName := collectionTextIndexRootName(collection, indexName)
+	table := newCollectionRunTable(1)
+	table.DeleteSteal(encodeTextPostingKey(term, documentID))
+	table.Freeze()
+	defer resetCollectionRunTable(table)
+	iter := table.NewIterator(nil, nil)
+	defer func() { _ = iter.Close() }()
+	_, rootIDs, err := d.PublishOrderedRootGroupWithSystemBuilder([]backenddb.OrderedRootPublishInput{{BaseRoot: 0, Iter: iter}}, func(rootIDs []uint64) (iterator.UnsafeIterator, error) {
+		if len(rootIDs) != 1 {
+			return nil, fmt.Errorf("unexpected overlay root ids %d", len(rootIDs))
+		}
+		snap := d.AcquireSnapshot()
+		if snap == nil {
+			return nil, backenddb.ErrClosed
+		}
+		defer func() { _ = snap.Close() }()
+		return buildSystemTargetIterator(snap, map[string][]byte{systemCollectionRootOverlayKey(rootName): encodeRootIDList([]uint64{rootIDs[0]})})
+	})
+	if err != nil {
+		t.Fatalf("publish text posting overlay tombstone: %v", err)
+	}
+	if len(rootIDs) != 1 {
+		t.Fatalf("overlay root ids=%d want 1", len(rootIDs))
 	}
 }
 

--- a/TreeDB/docs/spec/README.md
+++ b/TreeDB/docs/spec/README.md
@@ -85,8 +85,8 @@ Given pre-alpha status, this is a living spec that tracks implementation.
 - `TreeDB/docs/spec/collection-text-search.md`
   - collection-native text index metadata, analyzer, root naming/policies,
     versioned postings/text-state/text-stats storage, backfill/drop, write-path
-    maintenance, and fail-closed query-shape behavior before ranked search
-    execution lands.
+    maintenance, bounded SearchText postings scans, BM25F-style ranking,
+    top-K document fetch, and fail-closed search guardrails.
 - `TreeDB/docs/spec/write-path-and-durability.md`
   - write pipeline and durability semantics for all durability modes.
 - `TreeDB/docs/spec/recovery.md`

--- a/TreeDB/docs/spec/collection-text-search.md
+++ b/TreeDB/docs/spec/collection-text-search.md
@@ -1,6 +1,6 @@
-# Collection Text Search Contract (M0-M3)
+# Collection Text Search Contract (M0-M4)
 
-Status: PR3 mutation-maintenance slice for issue #1764. TreeDB collections are
+Status: PR4 ranked SearchText slice for issue #1764. TreeDB collections are
 pre-alpha; these text-search storage formats are versioned and may change before
 stabilization, but malformed or unsupported versions must fail closed.
 
@@ -23,12 +23,13 @@ stabilization, but malformed or unsupported versions must fail closed.
 - `TextIndexStorageStats` validates storage versions and returns root accounting.
 - Insert, delete, update, and batch write paths maintain postings, text-state,
   and corpus/term/field stats for declared text indexes.
-- `SearchText(TextSearchOptions)` query-shape validation that fails closed before
-  scanning because ranked text search execution is not implemented yet.
+- `SearchText(TextSearchOptions)` executes bounded postings range scans, applies
+  simple term `AND`/`OR` semantics, scores candidates with BM25F-style field
+  weighting from persisted stats/text-state, and fetches documents only for final
+  top-K results when requested.
 
 Not implemented yet:
 
-- BM25/BM25F scoring and ranked SearchText execution;
 - phrase/proximity/highlighting/stemming/trigram/fuzzy search;
 - query-vector syntax, gateway integration, or hybrid text+vector executor integration.
 
@@ -170,6 +171,8 @@ type TextSearchOptions struct {
     Query                string
     Operator             TextSearchOperator // "or" default, or "and"
     TopK                 int
+    CandidateLimit       int // optional candidate budget before scoring
+    MaxPostingsScanned   int // optional postings scan budget
     IncludeDocuments     bool
     DocumentFetchOptions DocumentFetchOptions
 }
@@ -179,11 +182,27 @@ The parser accepts whitespace-separated terms and optional explicit `AND` or
 `OR` separators. Mixed `AND`/`OR`, phrases, and grouped syntax fail closed. Query
 terms are analyzed with the declared index analyzer.
 
-`SearchText` currently returns `ErrTextIndexUnavailable` for non-empty analyzed
-queries against an existing text index. This is intentional: normal text queries
-MUST be indexed, bounded, and ranked from postings; M3 does not implement the
-ranked executor and must not fall back to scan-and-rank. Empty analyzed queries
-return an empty result set.
+`SearchText` normalizes duplicate analyzed terms, range-scans the postings root
+by encoded term prefix, builds a bounded unique-document candidate set, and
+scores candidates from postings + text-state + text-stats. It does not scan or
+rank all collection documents. If candidate or postings budgets are exceeded, it
+returns `ErrTextIndexUnavailable` with truncation/fail-closed counters rather
+than returning silently incomplete rankings. Empty analyzed queries return an
+empty result set.
+
+Results expose response-owned document IDs, source index name, one-based lexical
+rank, higher-is-better BM25F score, score kind `bm25f`, matched terms/fields, and
+optional final documents. Documents are fetched only after top-K ranking, so
+`DocumentsFetched <= TopK` for successful searches.
+
+`TextSearchStats` includes text/hybrid-compatible counters:
+`text_candidates_requested`, `text_candidates_returned`,
+`text_postings_scanned`, `text_candidates_scored`, `documents_fetched`,
+`documents_missing`, `full_document_scan_fallbacks`, `truncated`, `fail_closed`,
+and `fail_closed_reason`, plus text-only aliases and scan/score/fetch timing
+fields. `TextCandidatesScored` counts the full bounded scored candidate set;
+`TextCandidatesReturned` counts ranked results/candidates actually returned after
+TopK truncation.
 
 ## Mutation maintenance
 
@@ -204,7 +223,8 @@ maintained text roots.
 
 Later #1764 milestones will:
 
-- range-scan postings by analyzed term;
-- bound the candidate set;
-- score candidates from persisted stats with BM25/BM25F-style field weighting;
-- fetch full documents only for final top-K results.
+- expose a candidate-only lexical adapter for the #2503 hybrid seam without full
+  document fetch;
+- add gateway/query-language integration;
+- add phrase/proximity/highlighting/stemming/trigram/fuzzy search only after
+  explicit storage/query contracts land.

--- a/TreeDB/docs/spec/verification.md
+++ b/TreeDB/docs/spec/verification.md
@@ -232,6 +232,7 @@ Coverage:
   - `TestSearchTextANDOROperatorsM4`
   - `TestSearchTextFieldWeightAffectsRankingM4`
   - `TestSearchTextMissingIndexUnsupportedSyntaxAndTruncationM4`
+  - `TestSearchTextSeesUnflushedTextIndexedInsertM4`
   - `TestSearchTextTombstonedPostingsConsumeScanBudgetM4`
   - `TestSearchTextFailClosedWrapsStorageCorruptionM4`
   - `TestSearchTextTopKBoundsDocumentFetchM4`

--- a/TreeDB/docs/spec/verification.md
+++ b/TreeDB/docs/spec/verification.md
@@ -232,6 +232,8 @@ Coverage:
   - `TestSearchTextANDOROperatorsM4`
   - `TestSearchTextFieldWeightAffectsRankingM4`
   - `TestSearchTextMissingIndexUnsupportedSyntaxAndTruncationM4`
+  - `TestSearchTextTombstonedPostingsConsumeScanBudgetM4`
+  - `TestSearchTextFailClosedWrapsStorageCorruptionM4`
   - `TestSearchTextTopKBoundsDocumentFetchM4`
   - `TestSearchTextReopenParityM4`
   - `BenchmarkSearchTextM4`

--- a/TreeDB/docs/spec/verification.md
+++ b/TreeDB/docs/spec/verification.md
@@ -201,8 +201,9 @@ Invariant:
   managers before taking its backfill snapshot, insert/delete/update/batch paths
   maintain postings/text-state/text-stats across flush/checkpoint/reopen,
   DropTextIndex clears metadata/root descriptors, the simple analyzer is
-  deterministic, and text search execution fails closed until ranked query
-  execution lands.
+  deterministic, and SearchText uses bounded postings scans plus BM25F-style
+  ranking with top-K-bounded document fetch and fail-closed truncation/storage
+  counters.
 
 Coverage:
 - `TreeDB/collections/text_index_test.go`:
@@ -211,7 +212,7 @@ Coverage:
   - `TestCollectionTextIndexMetadataRejectsInvalidDefinitions`
   - `TestCollectionTextRootNames`
   - `TestCollectionTextRootStoragePolicies`
-  - `TestCollectionTextIndexedWritesMaintainStorageAndSearchFailsClosed`
+  - `TestCollectionTextIndexedWritesMaintainStorageAndSearchRanks`
 - `TreeDB/collections/text_storage_test.go`:
   - `TestTextStorageCodecsRoundTripAndFailClosed`
   - `TestCollectionCreateTextIndexBackfillsReopensAndReportsStorage`
@@ -226,6 +227,14 @@ Coverage:
   - `TestTextIndexMaintenanceUpdateRemovesOldAndAddsNewTerms`
   - `TestTextIndexMaintenanceBatchInsertUpdateDelete`
   - `TestTextIndexMaintenanceBufferedCreateFlushCheckpointReopen`
+- `TreeDB/collections/text_search_m4_test.go`:
+  - `TestSearchTextSingleTermRankedSearchM4`
+  - `TestSearchTextANDOROperatorsM4`
+  - `TestSearchTextFieldWeightAffectsRankingM4`
+  - `TestSearchTextMissingIndexUnsupportedSyntaxAndTruncationM4`
+  - `TestSearchTextTopKBoundsDocumentFetchM4`
+  - `TestSearchTextReopenParityM4`
+  - `BenchmarkSearchTextM4`
 
 ## 11.5 Planned User-Command WAL Durability Gate
 


### PR DESCRIPTION
## Scope

Part of #1764, M4 only: ranked collection-native `SearchText` execution.

This PR:

- Implements bounded postings-backed `Collection.SearchText(TextSearchOptions)` for declared text indexes.
- Supports simple analyzed term queries with explicit/default `AND` / `OR` semantics.
- Range-scans postings by encoded term prefix; it never scans/ranks all primary documents.
- Builds a bounded unique-document candidate set with `CandidateLimit` / `MaxPostingsScanned` guardrails.
- Scores candidates with BM25F-style field weighting using persisted postings, text-state field lengths, corpus/term stats, field-length stats, and text index field weights.
- Returns response-owned stable document IDs, index name, one-based lexical rank, higher-is-better BM25F score, score kind, matched terms/fields, and optional final documents.
- Fetches documents only after final TopK ranking; `DocumentsFetched <= TopK`.
- Adds text/hybrid-compatible counters for requested/returned/scored candidates, postings scanned, docs fetched/missing, full-scan fallback, truncation, and fail-closed reason.
- Keeps truncation/storage guardrails fail-closed instead of returning silently incomplete rankings.
- Fixes local review blockers before PR open: `TextCandidatesReturned` now reflects post-TopK returned results, and `missing AND common` exits empty without scanning the common postings list.

## Non-goals / deferred

- No hybrid executor/fusion/vector/scalar integration.
- No #2503 text candidate adapter yet; this PR only exposes the SearchText results/counters needed by that downstream seam.
- No gateway query syntax integration.
- No phrase/proximity/highlighting/stemming/fuzzy/trigram support.

## Base / head

- Base: `origin/main` `c8264acfb40f1f121362b54379ae9b2a429f731d`
- Head: `7f64654480d4d5cee6640412f54ecaa89599291d`

## Tests

```sh
GOWORK=off go test ./TreeDB/collections -run 'TestText|TestCollectionText|TestSearchText|TestCreateText' -count=1
GOWORK=off go test ./TreeDB/collections -count=1
GOWORK=off go test ./TreeDB/docs -count=1
git diff --check
```

All passed locally on head `7f6465448`.

## Benchmark evidence

Apple M3, artifact: `/tmp/gomap_1764_pr4/bench_text_m4_after_flush_rerun.txt (SearchText) and /tmp/gomap_1764_pr4/bench_text_m4_backfill_after_flush.txt (backfill)`

```sh
GOWORK=off go test ./TreeDB/collections \
  -run '^$' \
  -bench 'Benchmark(SearchTextM4|CreateTextIndexBackfill)' \
  -benchtime=50x -count=3 -benchmem
```

Median of 3 runs:

| Benchmark | ns/op | ops/sec | B/op | allocs/op | Counters / notes |
|---|---:|---:|---:|---:|---|
| `SearchTextM4/candidate_generation_scoring` | 3,517,589 | 284 | 3,290,788 | 58,889 | 2,048 postings/search, 1,024 candidates scored/search, 0 docs fetched |
| `SearchTextM4/end_to_end_with_documents` | 3,182,080 | 314 | 3,304,934 | 58,931 | 2,048 postings/search, 1,024 candidates scored/search, 20 docs fetched/search |
| `SearchTextM4/or_query_bounded_topk` | 2,792,570 | 358 | 2,859,865 | 52,673 | 2,048 postings/search, 1,024 candidates scored/search, 0 docs fetched |
| `BenchmarkCreateTextIndexBackfill` | 3,356,782 | 298 | 3,319,450 | 48,912 | 256 docs/backfill, 2,031 postings/backfill |

Representative timing boundary medians from benchmark counters:

| Benchmark | postings scan ns/search | candidate score ns/search | document fetch ns/search |
|---|---:|---:|---:|
| `candidate_generation_scoring` | 1,310,000 | 1,793,209 | 0 |
| `end_to_end_with_documents` | 1,238,250 | 2,006,500 | 10,834 |
| `or_query_bounded_topk` | 844,084 | 1,813,916 | 0 |

## Review / CI status

- Latest-head CI: passing on head `7f6465448` (`gh pr checks 2529`).
- Codex: latest re-review after the flush fix reported no major issues.
- CodeRabbit: latest command completed/review skipped or finished with no new actionable findings; prior threads were replied to and resolved.
- Review threads: no unresolved threads in GraphQL inventory.
- Agent did not merge this PR.

## Review notes

- PR diff is limited to text-search M4 execution/docs/tests plus text comments; no hybrid executor/fusion/vector/scalar files are changed.
- Latest CodeRabbit blocker fixes are included: first-DB cleanup in reopen parity test, tombstoned posting entries charge scan budget, and fail-closed SearchText execution errors wrap `ErrTextIndexUnavailable` while preserving underlying causes.
- Latest Codex blocker fix is included: `SearchText` flushes this collection's buffered writes before acquiring the search snapshot, with regression coverage for a just-written text-indexed document visible without caller `Flush()`.
- Full-document scan fallback counter remains zero in successful SearchText tests/benchmarks.
- Agent did not merge this PR.
