### PR TITLE
TreeDB hybrid: add text candidate adapter

### DIFF
--- a/TreeDB/collections/hybrid_candidates.go
+++ b/TreeDB/collections/hybrid_candidates.go
@@ -1,0 +1,20 @@
+package collections
+
+// HybridCandidateResponse is returned by candidate-only source adapters. The
+// adapters are pre-fusion and pre-final-fetch: Candidates contains source hits
+// only, and Stats reports candidate-generation counters in the shared hybrid
+// vocabulary.
+type HybridCandidateResponse struct {
+	Stats      HybridSearchStats       `json:"stats,omitempty"`
+	Candidates []HybridSearchCandidate `json:"candidates,omitempty"`
+}
+
+func hybridMaxUint64(values ...uint64) uint64 {
+	var max uint64
+	for _, value := range values {
+		if value > max {
+			max = value
+		}
+	}
+	return max
+}

--- a/TreeDB/collections/hybrid_text_candidates.go
+++ b/TreeDB/collections/hybrid_text_candidates.go
@@ -1,0 +1,157 @@
+package collections
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+)
+
+// SearchHybridTextCandidates adapts collection-native ranked text search into
+// the shared hybrid candidate shape. It is candidate-only: it requests no
+// documents from SearchText, copies stable result IDs into response-owned
+// HybridSearchCandidate values, assigns one-based source ranks, preserves text
+// match attribution, and fails closed if the backing text path reports any full
+// document materialization or scan fallback.
+func (c *Collection) SearchHybridTextCandidates(query HybridTextQuery) (HybridCandidateResponse, error) {
+	if c == nil {
+		return HybridCandidateResponse{}, errCollectionNil
+	}
+	if c.db == nil {
+		return HybridCandidateResponse{}, errCollectionDBNil
+	}
+	requested := query.CandidateLimit
+	if err := validateHybridTextCandidateQuery(query); err != nil {
+		response := HybridCandidateResponse{Stats: hybridTextCandidateStatsFromSearch(requested, TextSearchStats{}, 0)}
+		response.Stats.FailClosed = 1
+		response.Stats.FailClosedReason = HybridFailClosedReasonUnsupported
+		return response, err
+	}
+
+	textResponse, err := c.SearchText(TextSearchOptions{
+		IndexName:        query.IndexName,
+		Query:            query.Query,
+		TopK:             requested,
+		IncludeDocuments: false,
+	})
+	if err != nil {
+		response := HybridCandidateResponse{Stats: hybridTextCandidateStatsFromSearch(requested, textResponse.Stats, 0)}
+		response.Stats.FailClosed = 1
+		response.Stats.FailClosedReason = hybridTextCandidateFailClosedReason(err)
+		return response, hybridTextCandidateError(err, query.IndexName)
+	}
+
+	return hybridTextCandidatesFromSearchResponse(requested, query.IndexName, textResponse)
+}
+
+func validateHybridTextCandidateQuery(query HybridTextQuery) error {
+	if query.CandidateLimit <= 0 {
+		return fmt.Errorf("%w: text candidate limit must be positive", ErrHybridSearchUnsupported)
+	}
+	return nil
+}
+
+func hybridTextCandidatesFromSearchResponse(requested int, textIndexName string, textResponse TextSearchResponse) (HybridCandidateResponse, error) {
+	stats := hybridTextCandidateStatsFromSearch(requested, textResponse.Stats, 0)
+	if !hybridTextCandidateNoDocumentGuardrailsOK(textResponse) {
+		stats.FailClosed = 1
+		stats.FailClosedReason = HybridFailClosedReasonFullDocumentScanForbidden
+		return HybridCandidateResponse{Stats: stats}, fmt.Errorf("%w: text candidate generation fetched documents or used a full-document fallback", ErrHybridSearchUnsupported)
+	}
+
+	indexName := textResponse.IndexName
+	if indexName == "" {
+		indexName = textIndexName
+	}
+	candidates := make([]HybridSearchCandidate, len(textResponse.Results))
+	for i, result := range textResponse.Results {
+		id := bytes.Clone(result.DocumentID)
+		id = id[:len(id):len(id)]
+		rank := result.Rank
+		if rank <= 0 {
+			rank = i + 1
+		}
+		scoreKind := result.ScoreKind
+		if scoreKind == "" {
+			scoreKind = HybridScoreKindBM25F
+		}
+		candidates[i] = HybridSearchCandidate{
+			ID:          id,
+			Source:      HybridCandidateSourceText,
+			IndexName:   indexName,
+			SourceRank:  rank,
+			Score:       result.Score,
+			ScoreKind:   scoreKind,
+			TextMatches: hybridTextMatchesFromSearchResult(result),
+		}
+	}
+	stats = hybridTextCandidateStatsFromSearch(requested, textResponse.Stats, len(candidates))
+	return HybridCandidateResponse{Stats: stats, Candidates: candidates}, nil
+}
+
+func hybridTextCandidateStatsFromSearch(requested int, textStats TextSearchStats, returned int) HybridSearchStats {
+	var requested64 uint64
+	if requested > 0 {
+		requested64 = uint64(requested)
+	}
+	returned64 := uint64(returned)
+	textCandidatesScored := hybridMaxUint64(textStats.TextCandidatesScored, textStats.CandidatesScored)
+	stats := HybridSearchStats{
+		TextCandidatesRequested:   requested64,
+		TextCandidatesReturned:    returned64,
+		TextPostingsScanned:       hybridMaxUint64(textStats.TextPostingsScanned, textStats.PostingsScanned),
+		TextCandidatesScored:      textCandidatesScored,
+		DocumentsFetched:          textStats.DocumentsFetched,
+		DocumentsMissing:          textStats.DocumentsMissing,
+		FullDocumentScanFallbacks: textStats.FullDocumentScanFallbacks,
+	}
+	if textCandidatesScored > returned64 {
+		stats.Truncated = textCandidatesScored - returned64
+	}
+	if textStats.Truncated && stats.Truncated == 0 {
+		stats.Truncated = 1
+	}
+	if textStats.FailClosed != 0 {
+		stats.FailClosed = textStats.FailClosed
+		stats.FailClosedReason = HybridFailClosedReasonTextIndexUnavailable
+	}
+	return stats
+}
+
+func hybridTextCandidateNoDocumentGuardrailsOK(response TextSearchResponse) bool {
+	stats := response.Stats
+	if stats.DocumentsFetched != 0 || stats.DocumentsMissing != 0 || stats.DocumentFetchNanos != 0 || stats.FullDocumentScanFallbacks != 0 {
+		return false
+	}
+	for _, result := range response.Results {
+		if len(result.Document) != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func hybridTextMatchesFromSearchResult(result TextSearchResult) []HybridTextMatch {
+	if len(result.TextMatches) == 0 {
+		return nil
+	}
+	matches := make([]HybridTextMatch, len(result.TextMatches))
+	for i, match := range result.TextMatches {
+		terms := append([]string(nil), match.Terms...)
+		matches[i] = HybridTextMatch{Field: match.Field, Terms: terms}
+	}
+	return matches
+}
+
+func hybridTextCandidateFailClosedReason(err error) HybridFailClosedReason {
+	if errors.Is(err, ErrTextIndexUnavailable) || errors.Is(err, ErrIndexNotFound) {
+		return HybridFailClosedReasonTextIndexUnavailable
+	}
+	return HybridFailClosedReasonUnsupported
+}
+
+func hybridTextCandidateError(err error, indexName string) error {
+	if errors.Is(err, ErrTextIndexUnavailable) || errors.Is(err, ErrIndexNotFound) {
+		return fmt.Errorf("%w: text index %q candidate generation unavailable: %w", ErrHybridSearchIndexUnavailable, indexName, err)
+	}
+	return fmt.Errorf("%w: text index %q candidate generation unsupported: %w", ErrHybridSearchUnsupported, indexName, err)
+}

--- a/TreeDB/collections/hybrid_text_candidates_test.go
+++ b/TreeDB/collections/hybrid_text_candidates_test.go
@@ -1,0 +1,299 @@
+package collections
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"math"
+	"testing"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+)
+
+func TestSearchHybridTextCandidatesNoDocumentsStableIDs2503(t *testing.T) {
+	d := openTextTestDB(t)
+	defer func() { _ = d.Close() }()
+	col := createTextSearchM4Collection(t, d, []TextIndexField{{Field: "title", Weight: 4}, {Field: "body"}})
+	if _, err := col.InsertBatch([][]byte{[]byte("d1"), []byte("d2"), []byte("d3")}, [][]byte{
+		[]byte(`{"title":"refund","body":"refund refund policy"}`),
+		[]byte(`{"title":"plain","body":"refund policy"}`),
+		[]byte(`{"title":"shipping","body":"policy"}`),
+	}); err != nil {
+		t.Fatalf("InsertBatch: %v", err)
+	}
+
+	opts := HybridTextQuery{IndexName: "lexical", Query: "refund", CandidateLimit: 2}
+	got, err := col.SearchHybridTextCandidates(opts)
+	if err != nil {
+		t.Fatalf("SearchHybridTextCandidates: %v", err)
+	}
+
+	assertHybridTextCandidateBasics2503(t, got.Candidates, "lexical")
+	if len(got.Candidates) != 2 {
+		t.Fatalf("candidates=%d want 2", len(got.Candidates))
+	}
+	if string(got.Candidates[0].ID) != "d1" || string(got.Candidates[1].ID) != "d2" || got.Candidates[0].Score <= got.Candidates[1].Score {
+		t.Fatalf("candidates=%+v want d1 above d2 by BM25F", got.Candidates)
+	}
+	if got.Candidates[0].TextMatches[0].Field != "body" || !slicesEqualStrings(got.Candidates[0].TextMatches[0].Terms, []string{"refund"}) {
+		t.Fatalf("candidate[0] matches=%+v want body/refund attribution", got.Candidates[0].TextMatches)
+	}
+	if got.Stats.TextCandidatesRequested != uint64(opts.CandidateLimit) || got.Stats.TextCandidatesReturned != 2 || got.Stats.TextPostingsScanned != 2 || got.Stats.TextCandidatesScored != 2 {
+		t.Fatalf("stats=%+v want requested=2 returned=2 postings=2 scored=2", got.Stats)
+	}
+	if got.Stats.DocumentsFetched != 0 || got.Stats.DocumentsMissing != 0 || got.Stats.FullDocumentScanFallbacks != 0 || got.Stats.FailClosed != 0 || got.Stats.Truncated != 0 {
+		t.Fatalf("stats=%+v want no document fetch/fallback/fail-closed/truncation", got.Stats)
+	}
+	firstID := append([]byte(nil), got.Candidates[0].ID...)
+	got.Candidates[0].ID[0] = 'X'
+
+	again, err := col.SearchHybridTextCandidates(HybridTextQuery{IndexName: "lexical", Query: "refund", CandidateLimit: 1})
+	if err != nil {
+		t.Fatalf("second SearchHybridTextCandidates: %v", err)
+	}
+	if len(again.Candidates) != 1 || !bytes.Equal(again.Candidates[0].ID, firstID) || again.Candidates[0].SourceRank != 1 {
+		t.Fatalf("second candidates=%+v want stable response-owned top candidate %q", again.Candidates, firstID)
+	}
+	if again.Stats.TextCandidatesReturned != 1 || again.Stats.Truncated != 1 || again.Stats.DocumentsFetched != 0 || again.Stats.FullDocumentScanFallbacks != 0 {
+		t.Fatalf("second stats=%+v want top-N bound with zero document work", again.Stats)
+	}
+}
+
+func TestSearchHybridTextCandidatesUnsupportedAndUnavailableFailClosed2503(t *testing.T) {
+	d := openTextTestDB(t)
+	defer func() { _ = d.Close() }()
+	col := createTextSearchM4Collection(t, d, []TextIndexField{{Field: "body"}})
+	if _, err := col.Insert([]byte("d1"), []byte(`{"body":"refund policy"}`)); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+
+	tests := []struct {
+		name       string
+		query      HybridTextQuery
+		wantErr    error
+		wantReason HybridFailClosedReason
+	}{
+		{name: "missing_index", query: HybridTextQuery{IndexName: "missing", Query: "refund", CandidateLimit: 1}, wantErr: ErrHybridSearchIndexUnavailable, wantReason: HybridFailClosedReasonTextIndexUnavailable},
+		{name: "unsupported_phrase", query: HybridTextQuery{IndexName: "lexical", Query: `"refund policy"`, CandidateLimit: 1}, wantErr: ErrHybridSearchUnsupported, wantReason: HybridFailClosedReasonUnsupported},
+		{name: "zero_candidate_limit", query: HybridTextQuery{IndexName: "lexical", Query: "refund", CandidateLimit: 0}, wantErr: ErrHybridSearchUnsupported, wantReason: HybridFailClosedReasonUnsupported},
+		{name: "negative_candidate_limit", query: HybridTextQuery{IndexName: "lexical", Query: "refund", CandidateLimit: -1}, wantErr: ErrHybridSearchUnsupported, wantReason: HybridFailClosedReasonUnsupported},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := col.SearchHybridTextCandidates(tc.query)
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("SearchHybridTextCandidates err=%v want %v", err, tc.wantErr)
+			}
+			if tc.wantErr == ErrHybridSearchUnsupported && errors.Is(err, ErrHybridSearchIndexUnavailable) {
+				t.Fatalf("SearchHybridTextCandidates err=%v must not wrap ErrHybridSearchIndexUnavailable for unsupported text shape", err)
+			}
+			if tc.wantErr == ErrHybridSearchIndexUnavailable && errors.Is(err, ErrHybridSearchUnsupported) {
+				t.Fatalf("SearchHybridTextCandidates err=%v must not wrap ErrHybridSearchUnsupported for unavailable text index", err)
+			}
+			if len(got.Candidates) != 0 || got.Stats.FailClosed != 1 || got.Stats.FailClosedReason != tc.wantReason {
+				t.Fatalf("response=%+v want fail-closed reason %q and no candidates", got, tc.wantReason)
+			}
+			if got.Stats.DocumentsFetched != 0 || got.Stats.DocumentsMissing != 0 || got.Stats.FullDocumentScanFallbacks != 0 {
+				t.Fatalf("stats=%+v want no document fetch or fallback on fail-closed text candidate path", got.Stats)
+			}
+		})
+	}
+}
+
+func TestSearchHybridTextCandidatesBudgetAndStorageFailClosed2503(t *testing.T) {
+	t.Run("budget_truncation", func(t *testing.T) {
+		d := openTextTestDB(t)
+		defer func() { _ = d.Close() }()
+		col := createTextSearchM4Collection(t, d, []TextIndexField{{Field: "body"}})
+		ids := make([][]byte, textSearchDefaultMinCandidateLimit+1)
+		docs := make([][]byte, len(ids))
+		for i := range ids {
+			ids[i] = []byte(fmt.Sprintf("doc-%04d", i))
+			docs[i] = []byte(`{"body":"refund"}`)
+		}
+		if _, err := col.InsertBatch(ids, docs); err != nil {
+			t.Fatalf("InsertBatch: %v", err)
+		}
+
+		got, err := col.SearchHybridTextCandidates(HybridTextQuery{IndexName: "lexical", Query: "refund", CandidateLimit: 1})
+		if !errors.Is(err, ErrHybridSearchIndexUnavailable) || !errors.Is(err, ErrTextIndexUnavailable) {
+			t.Fatalf("SearchHybridTextCandidates err=%v want hybrid/text unavailable", err)
+		}
+		if len(got.Candidates) != 0 || got.Stats.FailClosed != 1 || got.Stats.FailClosedReason != HybridFailClosedReasonTextIndexUnavailable || got.Stats.Truncated == 0 {
+			t.Fatalf("response=%+v want budget fail-closed truncation", got)
+		}
+		if got.Stats.TextPostingsScanned == 0 || got.Stats.TextCandidatesScored != 0 || got.Stats.DocumentsFetched != 0 || got.Stats.FullDocumentScanFallbacks != 0 {
+			t.Fatalf("stats=%+v want postings work, no scored/doc/fallback work", got.Stats)
+		}
+	})
+
+	t.Run("storage_corrupt", func(t *testing.T) {
+		d := openTextTestDB(t)
+		defer func() { _ = d.Close() }()
+		col := createTextSearchM4Collection(t, d, []TextIndexField{{Field: "body"}})
+		if _, err := col.Insert([]byte("d1"), []byte(`{"body":"refund policy"}`)); err != nil {
+			t.Fatalf("Insert: %v", err)
+		}
+		corruptTextRootValue(t, d, "docs", collectionTextStatsRootName("docs", "lexical"), encodeTextStatsCorpusKey(), []byte{99})
+
+		got, err := col.SearchHybridTextCandidates(HybridTextQuery{IndexName: "lexical", Query: "refund", CandidateLimit: 1})
+		if !errors.Is(err, ErrHybridSearchIndexUnavailable) || !errors.Is(err, ErrTextIndexUnavailable) || !errors.Is(err, ErrTextIndexStorageCorrupt) {
+			t.Fatalf("SearchHybridTextCandidates err=%v want hybrid unavailable and text storage corrupt", err)
+		}
+		if len(got.Candidates) != 0 || got.Stats.FailClosed != 1 || got.Stats.FailClosedReason != HybridFailClosedReasonTextIndexUnavailable || got.Stats.DocumentsFetched != 0 || got.Stats.FullDocumentScanFallbacks != 0 {
+			t.Fatalf("response=%+v want storage-corrupt fail-closed stats and no document work", got)
+		}
+	})
+}
+
+func TestSearchHybridTextCandidatesReopenNoDocuments2503(t *testing.T) {
+	dir := t.TempDir()
+	d, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	firstClosed := false
+	defer func() {
+		if !firstClosed {
+			_ = d.Close()
+		}
+	}()
+	col := createTextSearchM4Collection(t, d, []TextIndexField{{Field: "title", Weight: 3}, {Field: "body"}})
+	if _, err := col.InsertBatch([][]byte{[]byte("d1"), []byte("d2")}, [][]byte{
+		[]byte(`{"title":"refund","body":"policy refund"}`),
+		[]byte(`{"title":"policy","body":"refund"}`),
+	}); err != nil {
+		t.Fatalf("InsertBatch: %v", err)
+	}
+	before, err := col.SearchHybridTextCandidates(HybridTextQuery{IndexName: "lexical", Query: "refund", CandidateLimit: 2})
+	if err != nil {
+		t.Fatalf("SearchHybridTextCandidates before reopen: %v", err)
+	}
+	if err := d.Checkpoint(); err != nil {
+		t.Fatalf("Checkpoint: %v", err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	firstClosed = true
+
+	reopened, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+	reopenedCol, err := NewCollectionManager(reopened).OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("OpenCollection reopened: %v", err)
+	}
+	after, err := reopenedCol.SearchHybridTextCandidates(HybridTextQuery{IndexName: "lexical", Query: "refund", CandidateLimit: 2})
+	if err != nil {
+		t.Fatalf("SearchHybridTextCandidates after reopen: %v", err)
+	}
+	if len(before.Candidates) != len(after.Candidates) {
+		t.Fatalf("reopen candidate length before=%d after=%d", len(before.Candidates), len(after.Candidates))
+	}
+	for i := range before.Candidates {
+		if !bytes.Equal(before.Candidates[i].ID, after.Candidates[i].ID) || before.Candidates[i].SourceRank != after.Candidates[i].SourceRank || math.Abs(before.Candidates[i].Score-after.Candidates[i].Score) > 1e-12 {
+			t.Fatalf("candidate[%d] before=%+v after=%+v", i, before.Candidates[i], after.Candidates[i])
+		}
+	}
+	if before.Stats.DocumentsFetched != 0 || after.Stats.DocumentsFetched != 0 || before.Stats.FullDocumentScanFallbacks != 0 || after.Stats.FullDocumentScanFallbacks != 0 {
+		t.Fatalf("stats before=%+v after=%+v want no document work", before.Stats, after.Stats)
+	}
+}
+
+func TestHybridTextCandidatesRejectDocumentMaterialization2503(t *testing.T) {
+	got, err := hybridTextCandidatesFromSearchResponse(1, "lexical", TextSearchResponse{
+		IndexName: "lexical",
+		Stats: TextSearchStats{
+			TextCandidatesReturned: 1,
+			DocumentsFetched:       1,
+			DocumentFetchNanos:     7,
+		},
+		Results: []TextSearchResult{{DocumentID: []byte("doc-a"), Rank: 1, Score: 1, ScoreKind: HybridScoreKindBM25F, Document: []byte(`{"body":"refund"}`)}},
+	})
+	if !errors.Is(err, ErrHybridSearchUnsupported) {
+		t.Fatalf("hybridTextCandidatesFromSearchResponse err=%v want ErrHybridSearchUnsupported", err)
+	}
+	if len(got.Candidates) != 0 || got.Stats.FailClosed != 1 || got.Stats.FailClosedReason != HybridFailClosedReasonFullDocumentScanForbidden {
+		t.Fatalf("response=%+v want fail-closed document materialization guard", got)
+	}
+	if got.Stats.DocumentsFetched != 1 || got.Stats.TextCandidatesReturned != 0 {
+		t.Fatalf("stats=%+v want document-fetch counter preserved and no returned candidates", got.Stats)
+	}
+}
+
+func assertHybridTextCandidateBasics2503(tb testing.TB, got []HybridSearchCandidate, indexName string) {
+	tb.Helper()
+	for i, candidate := range got {
+		if candidate.Source != HybridCandidateSourceText || candidate.IndexName != indexName || candidate.SourceRank != i+1 || candidate.ScoreKind != HybridScoreKindBM25F {
+			tb.Fatalf("candidate[%d]=%+v want text source/index/rank/bm25f score kind", i, candidate)
+		}
+		if candidate.Score <= 0 {
+			tb.Fatalf("candidate[%d]=%+v want positive BM25F score", i, candidate)
+		}
+		if len(candidate.ID) == 0 || cap(candidate.ID) != len(candidate.ID) {
+			tb.Fatalf("candidate[%d] id len/cap=%d/%d want response-owned cap-isolated stable ID", i, len(candidate.ID), cap(candidate.ID))
+		}
+		if len(candidate.TextMatches) == 0 {
+			tb.Fatalf("candidate[%d]=%+v want text match attribution", i, candidate)
+		}
+	}
+}
+
+var hybridTextCandidateBenchmarkSink2503 HybridCandidateResponse
+
+func BenchmarkSearchHybridTextCandidates2503(b *testing.B) {
+	const docCount = 512
+	d := openTextBenchDB(b)
+	defer func() { _ = d.Close() }()
+	mgr := NewCollectionManager(d)
+	if _, err := mgr.CreateCollection(&CollectionMeta{Name: "docs"}); err != nil {
+		b.Fatalf("CreateCollection: %v", err)
+	}
+	col, err := mgr.OpenCollection("docs")
+	if err != nil {
+		b.Fatalf("OpenCollection: %v", err)
+	}
+	if _, _, err := col.CreateTextIndex(TextIndexDefinition{Name: "lexical", Fields: []TextIndexField{{Field: "title", Weight: 3}, {Field: "body"}}, StorePositions: true}); err != nil {
+		b.Fatalf("CreateTextIndex: %v", err)
+	}
+	ids := make([][]byte, docCount)
+	docs := make([][]byte, docCount)
+	for i := 0; i < docCount; i++ {
+		ids[i] = []byte(fmt.Sprintf("doc-%06d", i))
+		docs[i] = []byte(fmt.Sprintf(`{"title":"Ticket %d refund policy","body":"HTTP_500 retry refund policy customer %d shard %d"}`, i, i%17, i%8))
+	}
+	if _, err := col.InsertBatch(ids, docs); err != nil {
+		b.Fatalf("InsertBatch setup: %v", err)
+	}
+	opts := HybridTextQuery{IndexName: "lexical", Query: "refund policy", CandidateLimit: 20}
+	warm, err := col.SearchHybridTextCandidates(opts)
+	if err != nil {
+		b.Fatalf("warm SearchHybridTextCandidates: %v", err)
+	}
+	if len(warm.Candidates) != opts.CandidateLimit || warm.Stats.DocumentsFetched != 0 || warm.Stats.FullDocumentScanFallbacks != 0 {
+		b.Fatalf("warm response=%+v want %d no-document candidates", warm, opts.CandidateLimit)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	var sink HybridCandidateResponse
+	for i := 0; i < b.N; i++ {
+		got, err := col.SearchHybridTextCandidates(opts)
+		if err != nil {
+			b.Fatalf("SearchHybridTextCandidates: %v", err)
+		}
+		if len(got.Candidates) != opts.CandidateLimit {
+			b.Fatalf("candidates=%d want %d", len(got.Candidates), opts.CandidateLimit)
+		}
+		sink = got
+	}
+	b.StopTimer()
+	hybridTextCandidateBenchmarkSink2503 = sink
+	b.ReportMetric(float64(sink.Stats.TextCandidatesReturned), "candidates/search")
+	b.ReportMetric(float64(sink.Stats.TextPostingsScanned), "postings_scanned/search")
+	b.ReportMetric(float64(sink.Stats.TextCandidatesScored), "candidates_scored/search")
+	b.ReportMetric(float64(sink.Stats.DocumentsFetched), "docs_fetched/search")
+}

--- a/TreeDB/collections/hybrid_vector_candidates.go
+++ b/TreeDB/collections/hybrid_vector_candidates.go
@@ -5,19 +5,8 @@ import (
 	"fmt"
 )
 
-// HybridCandidateResponse is returned by candidate-only source adapters. The
-// adapters are pre-fusion and pre-final-fetch: Candidates contains source hits
-// only, and Stats reports candidate-generation counters in the shared hybrid
-// vocabulary.
-type HybridCandidateResponse struct {
-	Stats      HybridSearchStats       `json:"stats,omitempty"`
-	Candidates []HybridSearchCandidate `json:"candidates,omitempty"`
-}
-
 // SearchHybridVectorCandidates adapts an existing collection vector-index
-// search into the shared hybrid candidate shape. This is the vector-only #2503
-// split; lexical/text candidates remain blocked on the #1764 ranked SearchText
-// API/counters.
+// search into the shared hybrid candidate shape.
 //
 // Candidate generation is no-document by construction: it uses
 // SearchVectorIndexWithBuffer with IncludeDocuments=false, copies stable result
@@ -70,7 +59,7 @@ func validateHybridVectorCandidateQuery(query HybridVectorQuery) error {
 		return fmt.Errorf("%w: vector candidate ef_search cannot be negative", ErrHybridSearchUnsupported)
 	}
 	if query.QueryMode != "" && query.QueryMode != VectorIndexQueryModeExact {
-		return fmt.Errorf("%w: vector candidate query mode %q is unsupported by the vector-only #2503 split", ErrHybridSearchUnsupported, query.QueryMode)
+		return fmt.Errorf("%w: vector candidate query mode %q is unsupported by the vector candidate adapter", ErrHybridSearchUnsupported, query.QueryMode)
 	}
 	if query.QuantizedIndexName != "" {
 		return fmt.Errorf("%w: vector candidate quantized index %q is unsupported by the vector-only #2503 split", ErrHybridSearchUnsupported, query.QuantizedIndexName)
@@ -179,14 +168,4 @@ func hybridVectorCandidateError(err error, indexName string) error {
 		return fmt.Errorf("%w: vector index %q candidate generation unavailable: %w", ErrHybridSearchIndexUnavailable, indexName, err)
 	}
 	return fmt.Errorf("%w: vector index %q candidate generation unsupported: %w", ErrHybridSearchUnsupported, indexName, err)
-}
-
-func hybridMaxUint64(values ...uint64) uint64 {
-	var max uint64
-	for _, value := range values {
-		if value > max {
-			max = value
-		}
-	}
-	return max
 }

--- a/TreeDB/docs/spec/collection-text-search.md
+++ b/TreeDB/docs/spec/collection-text-search.md
@@ -221,10 +221,13 @@ maintained text roots.
 
 ## Follow-up execution plan
 
-Later #1764 milestones will:
+The #2503 hybrid seam now exposes
+`Collection.SearchHybridTextCandidates(HybridTextQuery)` as a candidate-only
+adapter over `SearchText`; it requests no full documents and reuses the shared
+hybrid candidate/stat vocabulary.
 
-- expose a candidate-only lexical adapter for the #2503 hybrid seam without full
-  document fetch;
+Later text-search milestones will:
+
 - add gateway/query-language integration;
 - add phrase/proximity/highlighting/stemming/trigram/fuzzy search only after
   explicit storage/query contracts land.

--- a/TreeDB/docs/spec/hybrid-search-contract.md
+++ b/TreeDB/docs/spec/hybrid-search-contract.md
@@ -249,13 +249,21 @@ Issue `#2503` candidate-only paths should consume this contract as follows:
 - both adapters preserve stable document ID bytes, one-based source rank,
   source/index name, and source counters.
 
-The first partial #2503 vector-only split exposes
-`Collection.SearchHybridVectorCandidates(HybridVectorQuery)`. It returns a
-`HybridCandidateResponse` containing vector-source `HybridSearchCandidate`
-values and shared `HybridSearchStats`, and it fails closed if the backing vector
-path is unavailable or reports document materialization. This split does not
-implement lexical candidates; text remains blocked on #1764 ranked `SearchText`
-results/counters.
+The #2503 candidate-only source splits expose:
+
+- `Collection.SearchHybridTextCandidates(HybridTextQuery)`, which adapts ranked
+  `SearchText` results into text-source `HybridSearchCandidate` values without
+  requesting documents and fails closed if text search is unsupported,
+  unavailable, corrupt, truncated by bounded generation, or reports document
+  materialization/fallback work.
+- `Collection.SearchHybridVectorCandidates(HybridVectorQuery)`, which adapts
+  vector-index search into vector-source `HybridSearchCandidate` values and
+  fails closed if the backing vector path is unavailable or reports document
+  materialization.
+
+Both return `HybridCandidateResponse` with shared `HybridSearchStats`. These
+splits provide source candidates only; final fusion/planning/document fetch
+remain deferred to #2504/#2505.
 
 Issue `#2504` fusion primitives should implement the RRF formula and deterministic tie
 policy above over slices of `HybridSearchCandidate`. The helper surface is


### PR DESCRIPTION
## Objective

Add the next narrow #2503 slice: a candidate-only lexical/text adapter over the ranked `SearchText` API. Refs #2503 and parent #2501.

## Context

`main` now includes the #1764 ranked `SearchText` result/counter surface, so the hybrid candidate seam can adapt text results without pulling in the full hybrid executor.

## Non-goals

- No fusion/reranking implementation (#2504).
- No hybrid executor/planner/scalar filtering/final fetch integration (#2505).
- No text storage/search algorithm changes beyond using the existing `SearchText` API.
- No vector behavior changes beyond moving shared candidate plumbing out of the vector file and updating stale wording.

## Design

- Adds `Collection.SearchHybridTextCandidates(HybridTextQuery)` returning `HybridCandidateResponse` with text-source `HybridSearchCandidate` values.
- Calls `SearchText` with `IncludeDocuments=false`, converts response-owned IDs, one-based source ranks, BM25/BM25F score kind, source index name, and text match attribution.
- Maps text counters into `HybridSearchStats`: requested/returned/scored candidates, postings scanned, truncation, document fetch/fallback counters, and fail-closed reason.
- Fails closed for unsupported shapes/syntax, missing or unavailable text indexes, bounded generation truncation, storage corruption, and any reported document materialization/full-document fallback.

## Scope

- Includes:
  - `TreeDB/collections/hybrid_candidates.go`
  - `TreeDB/collections/hybrid_text_candidates.go`
  - `TreeDB/collections/hybrid_text_candidates_test.go`
  - `TreeDB/collections/hybrid_vector_candidates.go` shared-plumbing cleanup/stale wording only
  - `TreeDB/docs/spec/collection-text-search.md`
  - `TreeDB/docs/spec/hybrid-search-contract.md`
- Excludes: fusion, planner/executor, final document fetch, gateway syntax, text-index storage changes.

## Correctness

Tests run:

- `GOWORK=off go test ./TreeDB/collections -run 'TestSearchHybridTextCandidates|TestHybridTextCandidatesReject|TestSearchHybridVectorCandidates|TestHybridVectorCandidatesReject' -count=1`
- `GOWORK=off go test ./TreeDB/collections -run 'TestSearchHybridVectorCandidatesUnsupportedShapesFailClosed2503|TestSearchHybridTextCandidatesUnsupportedAndUnavailableFailClosed2503' -count=1`
- `GOWORK=off go test ./TreeDB/collections -count=1`
- `GOWORK=off go test ./TreeDB/docs -count=1`
- `git diff --check`

Covered edge cases:

- zero-document text candidate generation (`documents_fetched=0`, `full_document_scan_fallbacks=0`)
- stable response-owned candidate IDs and one-based ranks
- top-N returned candidate bounds/truncation counter
- missing index, unsupported phrase syntax, zero/negative candidate limit
- fail-closed candidate-budget truncation
- text stats storage corruption wrapping
- reopen parity with zero document fetches
- guard rejection when a backing text response reports document materialization

## Performance

Benchmark run:

- `GOWORK=off go test ./TreeDB/collections -run '^$' -bench 'BenchmarkSearchHybridTextCandidates2503$' -benchmem -count=1`

| Benchmark | ns/op | ops/sec | B/op | allocs/op | candidates/search | candidates_scored/search | postings_scanned/search | docs_fetched/search |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| `BenchmarkSearchHybridTextCandidates2503-8` | 2,543,052 | 393.2 | 1,654,768 | 29,600 | 20.00 | 512.0 | 1024 | 0 |

No before/after comparison is included because this PR adds a new candidate-only adapter surface rather than modifying an existing hot path. The key boundary counter is `docs_fetched/search = 0`.

## Rollout / Toggle Plan

No runtime toggle. This adds a new API; existing text-only/vector-only paths remain unchanged.

## Follow-ups

- #2504 remains responsible for fusion.
- #2505 remains responsible for the full hybrid executor/planner and bounded final document fetch.

## CI / AI Review Loop

- Latest-head CI: started for `0c46034562e37bbe62f792231b298225dd5ade24`; pending at PR creation.
- Codex latest-head review: not requested yet.
- Copilot latest-head review: not requested yet.
- CodeRabbit latest-head review: automatic review pending at PR creation.
- Merge intent: opened for review only; do not merge from this PR without coordinator approval.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added hybrid text candidate search functionality, enabling candidate-only ranking without full document materialization.

* **Tests**
  * Comprehensive test coverage for hybrid text search across failure scenarios, edge cases, and performance benchmarking.

* **Documentation**
  * Updated specifications to document the new hybrid text candidate search API and its error-handling contracts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->