### PR TITLE
TreeDB: add Haystack document service contract

### DIFF
--- a/TreeDB/documentservice/doc.go
+++ b/TreeDB/documentservice/doc.go
@@ -1,0 +1,15 @@
+// Package documentservice exposes TreeDB's pre-alpha Haystack-style document
+// service contract.
+//
+// The package is the Go implementation seam for the HTTP/JSON API documented in
+// docs/TREEDB_DOCUMENT_SERVICE_API.md. It maps Haystack-style documents
+// (id/content/embedding/meta/score) onto TreeDB collections, supports exact
+// dense-vector scoring with metadata filters, and intentionally fails closed for
+// keyword and hybrid retrieval until TreeDB's ranked text/hybrid executors are
+// implemented.
+//
+// The contract is pre-alpha: request/response schemas may change before TreeDB
+// stabilizes. Exact dense scoring here is the correctness/MVP service path for
+// Python and Haystack clients; it is not TreeDB's high-QPS column_graph ANN
+// serving path.
+package documentservice

--- a/TreeDB/documentservice/errors.go
+++ b/TreeDB/documentservice/errors.go
@@ -1,0 +1,103 @@
+package documentservice
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+)
+
+// ErrorCode is the stable, pre-alpha service error vocabulary returned by the
+// HTTP API and exposed by Go service methods.
+type ErrorCode string
+
+const (
+	CodeInvalidRequest   ErrorCode = "invalid_request"
+	CodeMalformedJSON    ErrorCode = "malformed_json"
+	CodeIndexNotFound    ErrorCode = "index_not_found"
+	CodeIndexUnavailable ErrorCode = "index_unavailable"
+	CodeIndexStale       ErrorCode = "index_stale"
+	CodeConflict         ErrorCode = "conflict"
+	CodeUnsupported      ErrorCode = "unsupported"
+	CodeInternal         ErrorCode = "internal"
+)
+
+// Error is a structured service error. Callers should branch on Code rather
+// than matching message text.
+type Error struct {
+	Code    ErrorCode `json:"code"`
+	Message string    `json:"message"`
+	Err     error     `json:"-"`
+}
+
+func (e *Error) Error() string {
+	if e == nil {
+		return "<nil>"
+	}
+	if e.Message != "" {
+		return string(e.Code) + ": " + e.Message
+	}
+	return string(e.Code)
+}
+
+func (e *Error) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+func serviceError(code ErrorCode, message string) error {
+	return &Error{Code: code, Message: message}
+}
+
+func serviceErrorf(code ErrorCode, format string, args ...any) error {
+	return &Error{Code: code, Message: fmt.Sprintf(format, args...)}
+}
+
+func wrapServiceError(code ErrorCode, message string, err error) error {
+	if err == nil {
+		return serviceError(code, message)
+	}
+	return &Error{Code: code, Message: message, Err: err}
+}
+
+// ErrorCodeOf returns the service code for err. Non-service errors are internal.
+func ErrorCodeOf(err error) ErrorCode {
+	if err == nil {
+		return ""
+	}
+	var serviceErr *Error
+	if errors.As(err, &serviceErr) && serviceErr != nil {
+		return serviceErr.Code
+	}
+	return CodeInternal
+}
+
+func httpStatusForError(err error) int {
+	switch ErrorCodeOf(err) {
+	case CodeInvalidRequest, CodeMalformedJSON:
+		return http.StatusBadRequest
+	case CodeIndexNotFound:
+		return http.StatusNotFound
+	case CodeConflict, CodeIndexStale:
+		return http.StatusConflict
+	case CodeIndexUnavailable:
+		return http.StatusServiceUnavailable
+	case CodeUnsupported:
+		return http.StatusNotImplemented
+	default:
+		return http.StatusInternalServerError
+	}
+}
+
+func serviceErrorFromCollectionOpen(err error, index string) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, backenddb.ErrClosed) {
+		return wrapServiceError(CodeIndexUnavailable, "TreeDB backend is closed", err)
+	}
+	return wrapServiceError(CodeIndexNotFound, fmt.Sprintf("index %q was not found", index), err)
+}

--- a/TreeDB/documentservice/filter.go
+++ b/TreeDB/documentservice/filter.go
@@ -1,0 +1,344 @@
+package documentservice
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"reflect"
+	"strings"
+)
+
+const (
+	filterOpAND   = "and"
+	filterOpOR    = "or"
+	filterOpNOT   = "not"
+	filterOpEQ    = "=="
+	filterOpNE    = "!="
+	filterOpGT    = ">"
+	filterOpGTE   = ">="
+	filterOpLT    = "<"
+	filterOpLTE   = "<="
+	filterOpIn    = "in"
+	filterOpNotIn = "not in"
+)
+
+// Filter is the supported Haystack-style metadata filter AST.
+//
+// Boolean nodes use operator AND/OR/NOT and conditions. Leaf nodes use field,
+// operator, and value. Field names may be id, content, meta.<path>, or a
+// metadata path without the meta. prefix.
+type Filter struct {
+	Operator   string   `json:"operator"`
+	Field      string   `json:"field,omitempty"`
+	Value      any      `json:"value,omitempty"`
+	Conditions []Filter `json:"conditions,omitempty"`
+}
+
+// Validate rejects unsupported operators and malformed filter shapes before any
+// document scan runs.
+func (f *Filter) Validate() error {
+	if f == nil {
+		return nil
+	}
+	return f.validateAt("filter")
+}
+
+func (f *Filter) validateAt(path string) error {
+	op, err := normalizeFilterOperator(f.Operator)
+	if err != nil {
+		return err
+	}
+	switch op {
+	case filterOpAND, filterOpOR:
+		if f.Field != "" {
+			return serviceErrorf(CodeInvalidRequest, "%s: boolean operator %q cannot set field", path, f.Operator)
+		}
+		if len(f.Conditions) == 0 {
+			return serviceErrorf(CodeInvalidRequest, "%s: operator %q requires at least one condition", path, f.Operator)
+		}
+		for i := range f.Conditions {
+			if err := f.Conditions[i].validateAt(fmt.Sprintf("%s.conditions[%d]", path, i)); err != nil {
+				return err
+			}
+		}
+		return nil
+	case filterOpNOT:
+		if f.Field != "" {
+			return serviceErrorf(CodeInvalidRequest, "%s: NOT cannot set field", path)
+		}
+		if len(f.Conditions) != 1 {
+			return serviceErrorf(CodeInvalidRequest, "%s: NOT requires exactly one condition", path)
+		}
+		return f.Conditions[0].validateAt(path + ".conditions[0]")
+	case filterOpEQ, filterOpNE, filterOpGT, filterOpGTE, filterOpLT, filterOpLTE, filterOpIn, filterOpNotIn:
+		field := strings.TrimSpace(f.Field)
+		if field == "" {
+			return serviceErrorf(CodeInvalidRequest, "%s: field is required for operator %q", path, f.Operator)
+		}
+		if strings.HasPrefix(field, "embedding") || strings.HasPrefix(field, "meta.embedding.") {
+			return serviceErrorf(CodeInvalidRequest, "%s: embedding filters are unsupported; filter metadata fields instead", path)
+		}
+		if len(f.Conditions) != 0 {
+			return serviceErrorf(CodeInvalidRequest, "%s: leaf operator %q cannot set conditions", path, f.Operator)
+		}
+		if op == filterOpIn || op == filterOpNotIn {
+			if _, ok := filterListValues(f.Value); !ok {
+				return serviceErrorf(CodeInvalidRequest, "%s: operator %q requires an array value", path, f.Operator)
+			}
+		}
+		return nil
+	default:
+		return serviceErrorf(CodeInvalidRequest, "%s: unsupported filter operator %q", path, f.Operator)
+	}
+}
+
+func normalizeFilterOperator(raw string) (string, error) {
+	op := strings.TrimSpace(strings.ToLower(raw))
+	switch op {
+	case filterOpAND:
+		return filterOpAND, nil
+	case filterOpOR:
+		return filterOpOR, nil
+	case filterOpNOT:
+		return filterOpNOT, nil
+	case filterOpEQ:
+		return filterOpEQ, nil
+	case filterOpNE:
+		return filterOpNE, nil
+	case filterOpGT:
+		return filterOpGT, nil
+	case filterOpGTE:
+		return filterOpGTE, nil
+	case filterOpLT:
+		return filterOpLT, nil
+	case filterOpLTE:
+		return filterOpLTE, nil
+	case filterOpIn:
+		return filterOpIn, nil
+	case filterOpNotIn:
+		return filterOpNotIn, nil
+	default:
+		return "", serviceErrorf(CodeInvalidRequest, "unsupported filter operator %q", raw)
+	}
+}
+
+func matchFilter(filter *Filter, doc Document) (bool, error) {
+	if filter == nil {
+		return true, nil
+	}
+	return filter.match(doc)
+}
+
+func (f *Filter) match(doc Document) (bool, error) {
+	op, err := normalizeFilterOperator(f.Operator)
+	if err != nil {
+		return false, err
+	}
+	switch op {
+	case filterOpAND:
+		for i := range f.Conditions {
+			ok, err := f.Conditions[i].match(doc)
+			if err != nil || !ok {
+				return ok, err
+			}
+		}
+		return true, nil
+	case filterOpOR:
+		for i := range f.Conditions {
+			ok, err := f.Conditions[i].match(doc)
+			if err != nil {
+				return false, err
+			}
+			if ok {
+				return true, nil
+			}
+		}
+		return false, nil
+	case filterOpNOT:
+		ok, err := f.Conditions[0].match(doc)
+		return !ok, err
+	}
+	left, found := lookupFilterField(doc, f.Field)
+	if !found {
+		return false, nil
+	}
+	switch op {
+	case filterOpEQ:
+		return valuesEqual(left, f.Value), nil
+	case filterOpNE:
+		return !valuesEqual(left, f.Value), nil
+	case filterOpGT, filterOpGTE, filterOpLT, filterOpLTE:
+		cmp, err := compareFilterValues(left, f.Value)
+		if err != nil {
+			return false, err
+		}
+		switch op {
+		case filterOpGT:
+			return cmp > 0, nil
+		case filterOpGTE:
+			return cmp >= 0, nil
+		case filterOpLT:
+			return cmp < 0, nil
+		case filterOpLTE:
+			return cmp <= 0, nil
+		}
+	case filterOpIn, filterOpNotIn:
+		values, ok := filterListValues(f.Value)
+		if !ok {
+			return false, serviceErrorf(CodeInvalidRequest, "operator %q requires an array value", f.Operator)
+		}
+		contained := valueInList(left, values)
+		if op == filterOpNotIn {
+			return !contained, nil
+		}
+		return contained, nil
+	}
+	return false, serviceErrorf(CodeInvalidRequest, "unsupported filter operator %q", f.Operator)
+}
+
+func lookupFilterField(doc Document, field string) (any, bool) {
+	field = strings.TrimSpace(field)
+	switch field {
+	case "id":
+		return doc.ID, true
+	case "content":
+		return doc.Content, true
+	}
+	if strings.HasPrefix(field, "meta.") {
+		return lookupPath(doc.Meta, strings.TrimPrefix(field, "meta."))
+	}
+	return lookupPath(doc.Meta, field)
+}
+
+func lookupPath(root map[string]any, path string) (any, bool) {
+	if root == nil || path == "" {
+		return nil, false
+	}
+	parts := strings.Split(path, ".")
+	var current any = root
+	for _, part := range parts {
+		if part == "" {
+			return nil, false
+		}
+		m, ok := current.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		current, ok = m[part]
+		if !ok {
+			return nil, false
+		}
+	}
+	return current, true
+}
+
+func compareFilterValues(left, right any) (int, error) {
+	if lf, ok := numberAsFloat64(left); ok {
+		rf, ok := numberAsFloat64(right)
+		if !ok {
+			return 0, serviceErrorf(CodeInvalidRequest, "cannot compare numeric field to non-numeric filter value")
+		}
+		switch {
+		case lf < rf:
+			return -1, nil
+		case lf > rf:
+			return 1, nil
+		default:
+			return 0, nil
+		}
+	}
+	ls, lok := left.(string)
+	rs, rok := right.(string)
+	if lok && rok {
+		return strings.Compare(ls, rs), nil
+	}
+	return 0, serviceErrorf(CodeInvalidRequest, "filter comparisons require numeric or string operands")
+}
+
+func valuesEqual(left, right any) bool {
+	if lf, ok := numberAsFloat64(left); ok {
+		if rf, ok := numberAsFloat64(right); ok {
+			return lf == rf
+		}
+	}
+	return reflect.DeepEqual(left, right)
+}
+
+func valueInList(value any, list []any) bool {
+	if values, ok := filterListValues(value); ok && !isBytes(value) {
+		for _, item := range values {
+			if valueInList(item, list) {
+				return true
+			}
+		}
+		return false
+	}
+	for _, item := range list {
+		if valuesEqual(value, item) {
+			return true
+		}
+	}
+	return false
+}
+
+func filterListValues(value any) ([]any, bool) {
+	if value == nil {
+		return nil, false
+	}
+	if list, ok := value.([]any); ok {
+		return list, true
+	}
+	rv := reflect.ValueOf(value)
+	if rv.Kind() != reflect.Slice && rv.Kind() != reflect.Array {
+		return nil, false
+	}
+	out := make([]any, rv.Len())
+	for i := 0; i < rv.Len(); i++ {
+		out[i] = rv.Index(i).Interface()
+	}
+	return out, true
+}
+
+func isBytes(value any) bool {
+	_, ok := value.([]byte)
+	return ok
+}
+
+func finiteFloat(value float64) bool {
+	return !math.IsNaN(value) && !math.IsInf(value, 0)
+}
+
+func numberAsFloat64(value any) (float64, bool) {
+	switch v := value.(type) {
+	case json.Number:
+		f, err := v.Float64()
+		return f, err == nil && finiteFloat(f)
+	case float64:
+		return v, finiteFloat(v)
+	case float32:
+		f := float64(v)
+		return f, finiteFloat(f)
+	case int:
+		return float64(v), true
+	case int8:
+		return float64(v), true
+	case int16:
+		return float64(v), true
+	case int32:
+		return float64(v), true
+	case int64:
+		return float64(v), true
+	case uint:
+		return float64(v), true
+	case uint8:
+		return float64(v), true
+	case uint16:
+		return float64(v), true
+	case uint32:
+		return float64(v), true
+	case uint64:
+		return float64(v), true
+	default:
+		return 0, false
+	}
+}

--- a/TreeDB/documentservice/filter.go
+++ b/TreeDB/documentservice/filter.go
@@ -75,7 +75,7 @@ func (f *Filter) validateAt(path string) error {
 		if field == "" {
 			return serviceErrorf(CodeInvalidRequest, "%s: field is required for operator %q", path, f.Operator)
 		}
-		if strings.HasPrefix(field, "embedding") || strings.HasPrefix(field, "meta.embedding.") {
+		if field == "embedding" {
 			return serviceErrorf(CodeInvalidRequest, "%s: embedding filters are unsupported; filter metadata fields instead", path)
 		}
 		if len(f.Conditions) != 0 {

--- a/TreeDB/documentservice/filter.go
+++ b/TreeDB/documentservice/filter.go
@@ -81,7 +81,12 @@ func (f *Filter) validateAt(path string) error {
 		if len(f.Conditions) != 0 {
 			return serviceErrorf(CodeInvalidRequest, "%s: leaf operator %q cannot set conditions", path, f.Operator)
 		}
-		if op == filterOpIn || op == filterOpNotIn {
+		switch op {
+		case filterOpGT, filterOpGTE, filterOpLT, filterOpLTE:
+			if !isComparableFilterValue(f.Value) {
+				return serviceErrorf(CodeInvalidRequest, "%s: operator %q requires a numeric or string value", path, f.Operator)
+			}
+		case filterOpIn, filterOpNotIn:
 			if _, ok := filterListValues(f.Value); !ok {
 				return serviceErrorf(CodeInvalidRequest, "%s: operator %q requires an array value", path, f.Operator)
 			}
@@ -230,6 +235,14 @@ func lookupPath(root map[string]any, path string) (any, bool) {
 		}
 	}
 	return current, true
+}
+
+func isComparableFilterValue(value any) bool {
+	if _, ok := numberAsFloat64(value); ok {
+		return true
+	}
+	_, ok := value.(string)
+	return ok
 }
 
 func compareFilterValues(left, right any) (int, error) {

--- a/TreeDB/documentservice/filter_test.go
+++ b/TreeDB/documentservice/filter_test.go
@@ -26,6 +26,35 @@ func TestFilterBooleanOperatorsAndMetadataPaths(t *testing.T) {
 	}
 }
 
+func TestFilterAllowsEmbeddingNamedMetadataPaths(t *testing.T) {
+	doc := Document{ID: "doc-1", Content: "hello", Meta: map[string]any{
+		"embedding_model":    "text-embedding-3-small",
+		"embedding_provider": "openai",
+		"embedding": map[string]any{
+			"model":    "text-embedding-3-small",
+			"provider": "openai",
+		},
+	}}
+	tests := []Filter{
+		{Field: "embedding_model", Operator: "==", Value: "text-embedding-3-small"},
+		{Field: "embedding_provider", Operator: "==", Value: "openai"},
+		{Field: "meta.embedding_model", Operator: "==", Value: "text-embedding-3-small"},
+		{Field: "meta.embedding.provider", Operator: "==", Value: "openai"},
+		{Field: "embedding.model", Operator: "==", Value: "text-embedding-3-small"},
+	}
+	for _, filter := range tests {
+		t.Run(filter.Field, func(t *testing.T) {
+			if err := filter.Validate(); err != nil {
+				t.Fatalf("Validate: %v", err)
+			}
+			ok, err := matchFilter(&filter, doc)
+			if err != nil || !ok {
+				t.Fatalf("match=%v err=%v", ok, err)
+			}
+		})
+	}
+}
+
 func TestFilterMissingFieldDoesNotMatch(t *testing.T) {
 	filter := &Filter{Field: "meta.missing", Operator: "!=", Value: "x"}
 	if err := filter.Validate(); err != nil {

--- a/TreeDB/documentservice/filter_test.go
+++ b/TreeDB/documentservice/filter_test.go
@@ -49,6 +49,8 @@ func TestFilterRejectsMalformedShapes(t *testing.T) {
 		{name: "and no conditions", filter: Filter{Operator: "AND"}},
 		{name: "not two conditions", filter: Filter{Operator: "NOT", Conditions: []Filter{{Field: "meta.repo", Operator: "==", Value: "gomap"}, {Field: "meta.repo", Operator: "==", Value: "other"}}}},
 		{name: "leaf conditions", filter: Filter{Field: "meta.repo", Operator: "==", Value: "gomap", Conditions: []Filter{{Field: "meta.language", Operator: "==", Value: "go"}}}},
+		{name: "comparison array", filter: Filter{Field: "meta.version", Operator: ">", Value: []any{1.0}}},
+		{name: "comparison bool", filter: Filter{Field: "meta.version", Operator: "<=", Value: true}},
 		{name: "embedding", filter: Filter{Field: "embedding", Operator: "==", Value: []any{1.0, 0.0}}},
 	}
 	for _, tt := range tests {

--- a/TreeDB/documentservice/filter_test.go
+++ b/TreeDB/documentservice/filter_test.go
@@ -1,0 +1,61 @@
+package documentservice
+
+import "testing"
+
+func TestFilterBooleanOperatorsAndMetadataPaths(t *testing.T) {
+	doc := Document{ID: "doc-1", Content: "hello", Meta: map[string]any{
+		"repo":       "gomap",
+		"language":   "go",
+		"start_line": 42.0,
+		"nested":     map[string]any{"symbol": "SearchDenseVector"},
+	}}
+	filter := &Filter{Operator: "AND", Conditions: []Filter{
+		{Field: "meta.repo", Operator: "==", Value: "gomap"},
+		{Operator: "OR", Conditions: []Filter{
+			{Field: "language", Operator: "==", Value: "python"},
+			{Field: "nested.symbol", Operator: "==", Value: "SearchDenseVector"},
+		}},
+		{Operator: "NOT", Conditions: []Filter{{Field: "meta.start_line", Operator: "<", Value: 10.0}}},
+	}}
+	if err := filter.Validate(); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	ok, err := matchFilter(filter, doc)
+	if err != nil || !ok {
+		t.Fatalf("match=%v err=%v", ok, err)
+	}
+}
+
+func TestFilterMissingFieldDoesNotMatch(t *testing.T) {
+	filter := &Filter{Field: "meta.missing", Operator: "!=", Value: "x"}
+	if err := filter.Validate(); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	ok, err := matchFilter(filter, Document{ID: "doc", Meta: map[string]any{"repo": "gomap"}})
+	if err != nil {
+		t.Fatalf("match err=%v", err)
+	}
+	if ok {
+		t.Fatal("missing field matched != filter; missing fields should fail closed")
+	}
+}
+
+func TestFilterRejectsMalformedShapes(t *testing.T) {
+	tests := []struct {
+		name   string
+		filter Filter
+	}{
+		{name: "empty operator", filter: Filter{Field: "meta.repo", Value: "gomap"}},
+		{name: "and no conditions", filter: Filter{Operator: "AND"}},
+		{name: "not two conditions", filter: Filter{Operator: "NOT", Conditions: []Filter{{Field: "meta.repo", Operator: "==", Value: "gomap"}, {Field: "meta.repo", Operator: "==", Value: "other"}}}},
+		{name: "leaf conditions", filter: Filter{Field: "meta.repo", Operator: "==", Value: "gomap", Conditions: []Filter{{Field: "meta.language", Operator: "==", Value: "go"}}}},
+		{name: "embedding", filter: Filter{Field: "embedding", Operator: "==", Value: []any{1.0, 0.0}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.filter.Validate(); ErrorCodeOf(err) != CodeInvalidRequest {
+				t.Fatalf("Validate err=%v code=%s", err, ErrorCodeOf(err))
+			}
+		})
+	}
+}

--- a/TreeDB/documentservice/http.go
+++ b/TreeDB/documentservice/http.go
@@ -195,9 +195,16 @@ func splitPath(path string) []string {
 }
 
 func writeJSON(w http.ResponseWriter, status int, value any) {
+	payload, err := json.Marshal(value)
+	if err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":{"code":"internal","message":"failed to encode response"}}` + "\n"))
+		return
+	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
-	_ = json.NewEncoder(w).Encode(value)
+	_, _ = w.Write(append(payload, '\n'))
 }
 
 func writeError(w http.ResponseWriter, err error) {

--- a/TreeDB/documentservice/http.go
+++ b/TreeDB/documentservice/http.go
@@ -1,0 +1,218 @@
+package documentservice
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+const defaultMaxRequestBytes = 16 << 20
+
+// Handler serves the pre-alpha HTTP/JSON document service contract.
+type Handler struct {
+	Service      *Service
+	MaxBodyBytes int64
+}
+
+// NewHandler returns an HTTP handler for service.
+func NewHandler(service *Service) *Handler {
+	return &Handler{Service: service, MaxBodyBytes: defaultMaxRequestBytes}
+}
+
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if h == nil || h.Service == nil {
+		writeError(w, serviceError(CodeIndexUnavailable, "document service is unavailable"))
+		return
+	}
+	if h.MaxBodyBytes <= 0 {
+		h.MaxBodyBytes = defaultMaxRequestBytes
+	}
+	parts := splitPath(r.URL.Path)
+	if len(parts) == 2 && parts[0] == "v1" && parts[1] == "health" {
+		if r.Method != http.MethodGet {
+			writeError(w, serviceErrorf(CodeInvalidRequest, "method %s is not allowed for %s", r.Method, r.URL.Path))
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"ok": true, "contract_version": ContractVersion})
+		return
+	}
+	if len(parts) == 2 && parts[0] == "v1" && parts[1] == "indexes" {
+		if r.Method != http.MethodPost {
+			writeError(w, serviceErrorf(CodeInvalidRequest, "method %s is not allowed for %s", r.Method, r.URL.Path))
+			return
+		}
+		var req CreateIndexRequest
+		if !h.decodeJSON(w, r, &req) {
+			return
+		}
+		info, err := h.Service.CreateIndex(r.Context(), req)
+		if err != nil {
+			writeError(w, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"index": info})
+		return
+	}
+	if len(parts) >= 3 && parts[0] == "v1" && parts[1] == "indexes" {
+		index, err := url.PathUnescape(parts[2])
+		if err != nil {
+			writeError(w, wrapServiceError(CodeInvalidRequest, "invalid index path", err))
+			return
+		}
+		if len(parts) == 3 {
+			if r.Method != http.MethodGet {
+				writeError(w, serviceErrorf(CodeInvalidRequest, "method %s is not allowed for %s", r.Method, r.URL.Path))
+				return
+			}
+			info, err := h.Service.OpenIndex(r.Context(), index)
+			if err != nil {
+				writeError(w, err)
+				return
+			}
+			writeJSON(w, http.StatusOK, map[string]any{"index": info})
+			return
+		}
+		if r.Method != http.MethodPost {
+			writeError(w, serviceErrorf(CodeInvalidRequest, "method %s is not allowed for %s", r.Method, r.URL.Path))
+			return
+		}
+		if len(parts) == 5 && parts[3] == "documents" {
+			h.serveDocumentOperation(w, r, index, parts[4])
+			return
+		}
+		if len(parts) == 5 && parts[3] == "search" {
+			h.serveSearchOperation(w, r, index, parts[4])
+			return
+		}
+	}
+	writeError(w, serviceErrorf(CodeInvalidRequest, "unknown document service route %q", r.URL.Path))
+}
+
+func (h *Handler) serveDocumentOperation(w http.ResponseWriter, r *http.Request, index, op string) {
+	switch op {
+	case "upsert":
+		var req UpsertDocumentsRequest
+		if !h.decodeJSON(w, r, &req) {
+			return
+		}
+		res, err := h.Service.UpsertDocuments(r.Context(), index, req)
+		if err != nil {
+			writeError(w, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, res)
+	case "delete":
+		var req DeleteDocumentsRequest
+		if !h.decodeJSON(w, r, &req) {
+			return
+		}
+		res, err := h.Service.DeleteDocuments(r.Context(), index, req)
+		if err != nil {
+			writeError(w, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, res)
+	case "count":
+		var req CountDocumentsRequest
+		if !h.decodeJSON(w, r, &req) {
+			return
+		}
+		res, err := h.Service.CountDocuments(r.Context(), index, req)
+		if err != nil {
+			writeError(w, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, res)
+	case "filter":
+		var req FilterDocumentsRequest
+		if !h.decodeJSON(w, r, &req) {
+			return
+		}
+		res, err := h.Service.FilterDocuments(r.Context(), index, req)
+		if err != nil {
+			writeError(w, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, res)
+	default:
+		writeError(w, serviceErrorf(CodeInvalidRequest, "unknown document operation %q", op))
+	}
+}
+
+func (h *Handler) serveSearchOperation(w http.ResponseWriter, r *http.Request, index, op string) {
+	switch op {
+	case "vector":
+		var req DenseVectorSearchRequest
+		if !h.decodeJSON(w, r, &req) {
+			return
+		}
+		res, err := h.Service.SearchDenseVector(r.Context(), index, req)
+		if err != nil {
+			writeError(w, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, res)
+	case "keyword":
+		writeError(w, h.Service.SearchKeyword(r.Context(), index, nil))
+	case "hybrid":
+		writeError(w, h.Service.SearchHybrid(r.Context(), index, nil))
+	default:
+		writeError(w, serviceErrorf(CodeInvalidRequest, "unknown search operation %q", op))
+	}
+}
+
+func (h *Handler) decodeJSON(w http.ResponseWriter, r *http.Request, dst any) bool {
+	body := http.MaxBytesReader(w, r.Body, h.MaxBodyBytes)
+	defer func() { _ = body.Close() }()
+	dec := json.NewDecoder(body)
+	dec.UseNumber()
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(dst); err != nil {
+		writeError(w, wrapServiceError(CodeMalformedJSON, "malformed JSON request body", err))
+		return false
+	}
+	if err := dec.Decode(&struct{}{}); err != io.EOF {
+		if err == nil {
+			err = fmt.Errorf("multiple JSON values in request body")
+		}
+		writeError(w, wrapServiceError(CodeMalformedJSON, "malformed JSON request body", err))
+		return false
+	}
+	return true
+}
+
+func splitPath(path string) []string {
+	trimmed := strings.Trim(path, "/")
+	if trimmed == "" {
+		return nil
+	}
+	return strings.Split(trimmed, "/")
+}
+
+func writeJSON(w http.ResponseWriter, status int, value any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(value)
+}
+
+func writeError(w http.ResponseWriter, err error) {
+	if err == nil {
+		writeJSON(w, http.StatusOK, map[string]any{"ok": true})
+		return
+	}
+	var out *Error
+	if serviceCode := ErrorCodeOf(err); serviceCode != CodeInternal {
+		var serviceErr *Error
+		if errors.As(err, &serviceErr) {
+			out = serviceErr
+		}
+	}
+	if out == nil {
+		out = &Error{Code: ErrorCodeOf(err), Message: err.Error()}
+	}
+	writeJSON(w, httpStatusForError(err), map[string]any{"error": out})
+}

--- a/TreeDB/documentservice/http.go
+++ b/TreeDB/documentservice/http.go
@@ -28,8 +28,9 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		writeError(w, serviceError(CodeIndexUnavailable, "document service is unavailable"))
 		return
 	}
-	if h.MaxBodyBytes <= 0 {
-		h.MaxBodyBytes = defaultMaxRequestBytes
+	maxBodyBytes := h.MaxBodyBytes
+	if maxBodyBytes <= 0 {
+		maxBodyBytes = defaultMaxRequestBytes
 	}
 	parts := splitPath(r.URL.Path)
 	if len(parts) == 2 && parts[0] == "v1" && parts[1] == "health" {
@@ -46,7 +47,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		var req CreateIndexRequest
-		if !h.decodeJSON(w, r, &req) {
+		if !h.decodeJSON(w, r, maxBodyBytes, &req) {
 			return
 		}
 		info, err := h.Service.CreateIndex(r.Context(), req)
@@ -81,22 +82,22 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if len(parts) == 5 && parts[3] == "documents" {
-			h.serveDocumentOperation(w, r, index, parts[4])
+			h.serveDocumentOperation(w, r, index, parts[4], maxBodyBytes)
 			return
 		}
 		if len(parts) == 5 && parts[3] == "search" {
-			h.serveSearchOperation(w, r, index, parts[4])
+			h.serveSearchOperation(w, r, index, parts[4], maxBodyBytes)
 			return
 		}
 	}
 	writeError(w, serviceErrorf(CodeInvalidRequest, "unknown document service route %q", r.URL.Path))
 }
 
-func (h *Handler) serveDocumentOperation(w http.ResponseWriter, r *http.Request, index, op string) {
+func (h *Handler) serveDocumentOperation(w http.ResponseWriter, r *http.Request, index, op string, maxBodyBytes int64) {
 	switch op {
 	case "upsert":
 		var req UpsertDocumentsRequest
-		if !h.decodeJSON(w, r, &req) {
+		if !h.decodeJSON(w, r, maxBodyBytes, &req) {
 			return
 		}
 		res, err := h.Service.UpsertDocuments(r.Context(), index, req)
@@ -107,7 +108,7 @@ func (h *Handler) serveDocumentOperation(w http.ResponseWriter, r *http.Request,
 		writeJSON(w, http.StatusOK, res)
 	case "delete":
 		var req DeleteDocumentsRequest
-		if !h.decodeJSON(w, r, &req) {
+		if !h.decodeJSON(w, r, maxBodyBytes, &req) {
 			return
 		}
 		res, err := h.Service.DeleteDocuments(r.Context(), index, req)
@@ -118,7 +119,7 @@ func (h *Handler) serveDocumentOperation(w http.ResponseWriter, r *http.Request,
 		writeJSON(w, http.StatusOK, res)
 	case "count":
 		var req CountDocumentsRequest
-		if !h.decodeJSON(w, r, &req) {
+		if !h.decodeJSON(w, r, maxBodyBytes, &req) {
 			return
 		}
 		res, err := h.Service.CountDocuments(r.Context(), index, req)
@@ -129,7 +130,7 @@ func (h *Handler) serveDocumentOperation(w http.ResponseWriter, r *http.Request,
 		writeJSON(w, http.StatusOK, res)
 	case "filter":
 		var req FilterDocumentsRequest
-		if !h.decodeJSON(w, r, &req) {
+		if !h.decodeJSON(w, r, maxBodyBytes, &req) {
 			return
 		}
 		res, err := h.Service.FilterDocuments(r.Context(), index, req)
@@ -143,11 +144,11 @@ func (h *Handler) serveDocumentOperation(w http.ResponseWriter, r *http.Request,
 	}
 }
 
-func (h *Handler) serveSearchOperation(w http.ResponseWriter, r *http.Request, index, op string) {
+func (h *Handler) serveSearchOperation(w http.ResponseWriter, r *http.Request, index, op string, maxBodyBytes int64) {
 	switch op {
 	case "vector":
 		var req DenseVectorSearchRequest
-		if !h.decodeJSON(w, r, &req) {
+		if !h.decodeJSON(w, r, maxBodyBytes, &req) {
 			return
 		}
 		res, err := h.Service.SearchDenseVector(r.Context(), index, req)
@@ -165,8 +166,8 @@ func (h *Handler) serveSearchOperation(w http.ResponseWriter, r *http.Request, i
 	}
 }
 
-func (h *Handler) decodeJSON(w http.ResponseWriter, r *http.Request, dst any) bool {
-	body := http.MaxBytesReader(w, r.Body, h.MaxBodyBytes)
+func (h *Handler) decodeJSON(w http.ResponseWriter, r *http.Request, maxBodyBytes int64, dst any) bool {
+	body := http.MaxBytesReader(w, r.Body, maxBodyBytes)
 	defer func() { _ = body.Close() }()
 	dec := json.NewDecoder(body)
 	dec.UseNumber()

--- a/TreeDB/documentservice/http_test.go
+++ b/TreeDB/documentservice/http_test.go
@@ -35,6 +35,17 @@ func TestHTTPMalformedJSONAndUnsupportedSearchFailClosed(t *testing.T) {
 	}
 }
 
+func TestHTTPDefaultMaxBodyBytesDoesNotMutateHandler(t *testing.T) {
+	svc, db := newTestService(t)
+	defer db.Close()
+	handler := &Handler{Service: svc}
+
+	postJSON(t, handler, "/v1/indexes", CreateIndexRequest{Name: "docs", Dimension: 2}, http.StatusOK, nil)
+	if handler.MaxBodyBytes != 0 {
+		t.Fatalf("MaxBodyBytes mutated to %d, want zero", handler.MaxBodyBytes)
+	}
+}
+
 func TestHTTPDocumentVectorRoundTrip(t *testing.T) {
 	svc, db := newTestService(t)
 	defer db.Close()

--- a/TreeDB/documentservice/http_test.go
+++ b/TreeDB/documentservice/http_test.go
@@ -1,0 +1,90 @@
+package documentservice
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHTTPMalformedJSONAndUnsupportedSearchFailClosed(t *testing.T) {
+	svc, db := newTestService(t)
+	defer db.Close()
+	handler := NewHandler(svc)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/indexes", bytes.NewBufferString(`{"name":"docs","dimension":2`))
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("malformed status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	assertHTTPErrorCode(t, rr.Body.Bytes(), CodeMalformedJSON)
+
+	if _, err := svc.CreateIndex(req.Context(), CreateIndexRequest{Name: "docs", Dimension: 2}); err != nil {
+		t.Fatalf("CreateIndex: %v", err)
+	}
+	for _, path := range []string{"/v1/indexes/docs/search/keyword", "/v1/indexes/docs/search/hybrid"} {
+		req := httptest.NewRequest(http.MethodPost, path, bytes.NewBufferString(`{"query":"refund"}`))
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+		if rr.Code != http.StatusNotImplemented {
+			t.Fatalf("%s status=%d body=%s", path, rr.Code, rr.Body.String())
+		}
+		assertHTTPErrorCode(t, rr.Body.Bytes(), CodeUnsupported)
+	}
+}
+
+func TestHTTPDocumentVectorRoundTrip(t *testing.T) {
+	svc, db := newTestService(t)
+	defer db.Close()
+	handler := NewHandler(svc)
+
+	postJSON(t, handler, "/v1/indexes", CreateIndexRequest{Name: "docs", Dimension: 2}, http.StatusOK, nil)
+	postJSON(t, handler, "/v1/indexes/docs/documents/upsert", UpsertDocumentsRequest{Documents: []Document{
+		{ID: "a", Content: "alpha", Embedding: []float32{1, 0}, Meta: map[string]any{"repo": "gomap"}},
+		{ID: "b", Content: "beta", Embedding: []float32{0, 1}, Meta: map[string]any{"repo": "other"}},
+	}}, http.StatusOK, nil)
+	var count CountDocumentsResponse
+	postJSON(t, handler, "/v1/indexes/docs/documents/count", CountDocumentsRequest{Filter: &Filter{Field: "meta.repo", Operator: "==", Value: "gomap"}}, http.StatusOK, &count)
+	if count.Count != 1 {
+		t.Fatalf("count=%+v", count)
+	}
+	var search DenseVectorSearchResponse
+	postJSON(t, handler, "/v1/indexes/docs/search/vector", DenseVectorSearchRequest{QueryEmbedding: []float32{1, 0}, TopK: 1, ReturnEmbedding: true}, http.StatusOK, &search)
+	if len(search.Documents) != 1 || search.Documents[0].ID != "a" || len(search.Documents[0].Embedding) != 2 || search.Documents[0].Score == nil {
+		t.Fatalf("search=%+v", search)
+	}
+}
+
+func postJSON(t *testing.T, handler http.Handler, path string, body any, wantStatus int, out any) {
+	t.Helper()
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal body: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, path, bytes.NewReader(raw))
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	if rr.Code != wantStatus {
+		t.Fatalf("POST %s status=%d want %d body=%s", path, rr.Code, wantStatus, rr.Body.String())
+	}
+	if out != nil {
+		if err := json.Unmarshal(rr.Body.Bytes(), out); err != nil {
+			t.Fatalf("decode response: %v body=%s", err, rr.Body.String())
+		}
+	}
+}
+
+func assertHTTPErrorCode(t *testing.T, raw []byte, want ErrorCode) {
+	t.Helper()
+	var decoded struct {
+		Error Error `json:"error"`
+	}
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("decode error response: %v body=%s", err, raw)
+	}
+	if decoded.Error.Code != want {
+		t.Fatalf("error code=%s want %s body=%s", decoded.Error.Code, want, raw)
+	}
+}

--- a/TreeDB/documentservice/http_test.go
+++ b/TreeDB/documentservice/http_test.go
@@ -3,6 +3,7 @@ package documentservice
 import (
 	"bytes"
 	"encoding/json"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -54,6 +55,28 @@ func TestHTTPWriteJSONEncodeErrorKeepsErrorShape(t *testing.T) {
 		t.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
 	}
 	assertHTTPErrorCode(t, rr.Body.Bytes(), CodeInternal)
+}
+
+func TestHTTPL2LargeFiniteEmbeddingsReturnFiniteScore(t *testing.T) {
+	svc, db := newTestService(t)
+	defer db.Close()
+	handler := NewHandler(svc)
+
+	postJSON(t, handler, "/v1/indexes", CreateIndexRequest{Name: "l2docs", Dimension: 1, Metric: "l2"}, http.StatusOK, nil)
+	postJSON(t, handler, "/v1/indexes/l2docs/documents/upsert", UpsertDocumentsRequest{Documents: []Document{{
+		ID:        "large",
+		Embedding: []float32{-3e38},
+	}}}, http.StatusOK, nil)
+
+	var search DenseVectorSearchResponse
+	postJSON(t, handler, "/v1/indexes/l2docs/search/vector", DenseVectorSearchRequest{QueryEmbedding: []float32{3e38}, TopK: 1}, http.StatusOK, &search)
+	if len(search.Documents) != 1 || search.Documents[0].Score == nil {
+		t.Fatalf("search=%+v", search)
+	}
+	score := *search.Documents[0].Score
+	if math.IsInf(score, 0) || math.IsNaN(score) {
+		t.Fatalf("score=%v, want finite", score)
+	}
 }
 
 func TestHTTPDocumentVectorRoundTrip(t *testing.T) {

--- a/TreeDB/documentservice/http_test.go
+++ b/TreeDB/documentservice/http_test.go
@@ -46,6 +46,16 @@ func TestHTTPDefaultMaxBodyBytesDoesNotMutateHandler(t *testing.T) {
 	}
 }
 
+func TestHTTPWriteJSONEncodeErrorKeepsErrorShape(t *testing.T) {
+	rr := httptest.NewRecorder()
+	writeJSON(rr, http.StatusOK, map[string]any{"bad": make(chan int)})
+
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	assertHTTPErrorCode(t, rr.Body.Bytes(), CodeInternal)
+}
+
 func TestHTTPDocumentVectorRoundTrip(t *testing.T) {
 	svc, db := newTestService(t)
 	defer db.Close()

--- a/TreeDB/documentservice/service.go
+++ b/TreeDB/documentservice/service.go
@@ -96,6 +96,7 @@ func (s *Service) UpsertDocuments(ctx context.Context, index string, req UpsertD
 	ids := make([]string, 0, len(prepared))
 	insertIDs := make([][]byte, 0, len(prepared))
 	insertDocs := make([][]byte, 0, len(prepared))
+	inserts := make([]preparedDocument, 0, len(prepared))
 	updates := make([]preparedDocument, 0)
 	for _, doc := range prepared {
 		if err := ctxErr(ctx); err != nil {
@@ -109,34 +110,48 @@ func (s *Service) UpsertDocuments(ctx context.Context, index string, req UpsertD
 		if current == nil {
 			insertIDs = append(insertIDs, []byte(doc.id))
 			insertDocs = append(insertDocs, doc.raw)
+			inserts = append(inserts, doc)
 			continue
 		}
 		updates = append(updates, doc)
 	}
 	inserted := 0
+	updated := 0
 	if len(insertIDs) > 0 {
-		if _, err := col.InsertBatch(insertIDs, insertDocs); err != nil {
+		if _, err := col.InsertBatch(insertIDs, insertDocs); err == nil {
+			inserted = len(insertIDs)
+		} else if collections.IsDuplicateKeyError(err) {
+			// Upsert is a service contract, while Collection.InsertBatch is an
+			// insert-only primitive. If another request inserts one of these IDs
+			// between the read preflight and InsertBatch, fall back per item to
+			// replace-or-insert semantics instead of leaking ErrDocumentExists.
+			for _, doc := range inserts {
+				wasInserted, wasUpdated, err := upsertPreparedDocument(ctx, col, doc, true)
+				if err != nil {
+					return UpsertDocumentsResponse{}, err
+				}
+				if wasInserted {
+					inserted++
+				}
+				if wasUpdated {
+					updated++
+				}
+			}
+		} else {
 			return UpsertDocumentsResponse{}, wrapServiceError(CodeInternal, "insert documents failed", err)
 		}
-		inserted = len(insertIDs)
 	}
-	updated := 0
 	for _, doc := range updates {
-		if err := ctxErr(ctx); err != nil {
+		wasInserted, wasUpdated, err := upsertPreparedDocument(ctx, col, doc, false)
+		if err != nil {
 			return UpsertDocumentsResponse{}, err
 		}
-		matched, err := col.Replace([]byte(doc.id), doc.raw)
-		if err != nil {
-			return UpsertDocumentsResponse{}, wrapServiceError(CodeInternal, "replace document failed", err)
-		}
-		if !matched {
-			if _, err := col.InsertBatch([][]byte{[]byte(doc.id)}, [][]byte{doc.raw}); err != nil {
-				return UpsertDocumentsResponse{}, wrapServiceError(CodeInternal, "insert raced replacement failed", err)
-			}
+		if wasInserted {
 			inserted++
-			continue
 		}
-		updated++
+		if wasUpdated {
+			updated++
+		}
 	}
 	return UpsertDocumentsResponse{Index: info, Upserted: len(prepared), Inserted: inserted, Updated: updated, IDs: ids}, nil
 }
@@ -389,6 +404,33 @@ func indexInfoFromMeta(meta collections.CollectionMeta) (IndexInfo, error) {
 type preparedDocument struct {
 	id  string
 	raw []byte
+}
+
+func upsertPreparedDocument(ctx context.Context, col *collections.Collection, doc preparedDocument, preferInsert bool) (inserted bool, updated bool, err error) {
+	const maxAttempts = 4
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		if err := ctxErr(ctx); err != nil {
+			return false, false, err
+		}
+		if preferInsert {
+			if _, err := col.InsertBatch([][]byte{[]byte(doc.id)}, [][]byte{doc.raw}); err == nil {
+				return true, false, nil
+			} else if !collections.IsDuplicateKeyError(err) {
+				return false, false, wrapServiceError(CodeInternal, "insert document failed", err)
+			}
+			preferInsert = false
+			continue
+		}
+		matched, err := col.Replace([]byte(doc.id), doc.raw)
+		if err != nil {
+			return false, false, wrapServiceError(CodeInternal, "replace document failed", err)
+		}
+		if matched {
+			return false, true, nil
+		}
+		preferInsert = true
+	}
+	return false, false, serviceErrorf(CodeConflict, "document %q changed concurrently during upsert", doc.id)
 }
 
 func prepareDocumentsForWrite(documents []Document, info IndexInfo) ([]preparedDocument, error) {

--- a/TreeDB/documentservice/service.go
+++ b/TreeDB/documentservice/service.go
@@ -1,0 +1,608 @@
+package documentservice
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"sort"
+	"strings"
+
+	"github.com/snissn/gomap/TreeDB/collections"
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+)
+
+const maxServiceScanDocuments = int(^uint(0) >> 1)
+
+// Service maps the document/search contract onto TreeDB collections.
+type Service struct {
+	manager *collections.CollectionManager
+}
+
+// New returns a document/search service backed by manager.
+func New(manager *collections.CollectionManager) *Service {
+	return &Service{manager: manager}
+}
+
+// CreateIndex creates or opens a compatible document service index.
+func (s *Service) CreateIndex(ctx context.Context, req CreateIndexRequest) (IndexInfo, error) {
+	if err := ctxErr(ctx); err != nil {
+		return IndexInfo{}, err
+	}
+	if s == nil || s.manager == nil {
+		return IndexInfo{}, serviceError(CodeIndexUnavailable, "document service has no collection manager")
+	}
+	if err := collections.ValidateCollectionName(req.Name); err != nil {
+		return IndexInfo{}, wrapServiceError(CodeInvalidRequest, "invalid index name", err)
+	}
+	if req.Dimension <= 0 {
+		return IndexInfo{}, serviceError(CodeInvalidRequest, "dimension must be positive")
+	}
+	metric, err := normalizeMetric(req.Metric)
+	if err != nil {
+		return IndexInfo{}, err
+	}
+	collectionMetric, err := metricToCollection(metric)
+	if err != nil {
+		return IndexInfo{}, err
+	}
+	meta := &collections.CollectionMeta{
+		Name: req.Name,
+		Options: collections.CollectionOptions{
+			DocumentFormat: collections.DocumentFormatJSON,
+		},
+		VectorIndexes: []collections.VectorIndexDefinition{{
+			Name:             defaultVectorIndexName,
+			Field:            defaultEmbeddingField,
+			Metric:           collectionMetric,
+			Dimensions:       req.Dimension,
+			Encoding:         collections.VectorIndexEncodingFloat32,
+			Strategy:         collections.VectorIndexStrategyNativeRuntime,
+			SchemaGeneration: 1,
+		}},
+	}
+	created, err := s.manager.CreateCollection(meta)
+	if err != nil {
+		if strings.Contains(err.Error(), "incompatible") {
+			return IndexInfo{}, wrapServiceError(CodeConflict, fmt.Sprintf("index %q already exists with an incompatible schema", req.Name), err)
+		}
+		return IndexInfo{}, wrapServiceError(CodeInternal, "create index failed", err)
+	}
+	return indexInfoFromMeta(*created)
+}
+
+// OpenIndex returns metadata for an existing document service index.
+func (s *Service) OpenIndex(ctx context.Context, name string) (IndexInfo, error) {
+	col, info, err := s.openIndex(ctx, name, 0)
+	_ = col
+	return info, err
+}
+
+// UpsertDocuments writes or replaces documents in index.
+func (s *Service) UpsertDocuments(ctx context.Context, index string, req UpsertDocumentsRequest) (UpsertDocumentsResponse, error) {
+	col, info, err := s.openIndex(ctx, index, req.ExpectedGeneration)
+	if err != nil {
+		return UpsertDocumentsResponse{}, err
+	}
+	if len(req.Documents) == 0 {
+		return UpsertDocumentsResponse{}, serviceError(CodeInvalidRequest, "documents must not be empty")
+	}
+	prepared, err := prepareDocumentsForWrite(req.Documents, info)
+	if err != nil {
+		return UpsertDocumentsResponse{}, err
+	}
+	ids := make([]string, 0, len(prepared))
+	insertIDs := make([][]byte, 0, len(prepared))
+	insertDocs := make([][]byte, 0, len(prepared))
+	updates := make([]preparedDocument, 0)
+	for _, doc := range prepared {
+		if err := ctxErr(ctx); err != nil {
+			return UpsertDocumentsResponse{}, err
+		}
+		ids = append(ids, doc.id)
+		current, err := col.Get([]byte(doc.id))
+		if err != nil {
+			return UpsertDocumentsResponse{}, wrapServiceError(CodeInternal, "read before upsert failed", err)
+		}
+		if current == nil {
+			insertIDs = append(insertIDs, []byte(doc.id))
+			insertDocs = append(insertDocs, doc.raw)
+			continue
+		}
+		updates = append(updates, doc)
+	}
+	inserted := 0
+	if len(insertIDs) > 0 {
+		if _, err := col.InsertBatch(insertIDs, insertDocs); err != nil {
+			return UpsertDocumentsResponse{}, wrapServiceError(CodeInternal, "insert documents failed", err)
+		}
+		inserted = len(insertIDs)
+	}
+	updated := 0
+	for _, doc := range updates {
+		if err := ctxErr(ctx); err != nil {
+			return UpsertDocumentsResponse{}, err
+		}
+		matched, err := col.Replace([]byte(doc.id), doc.raw)
+		if err != nil {
+			return UpsertDocumentsResponse{}, wrapServiceError(CodeInternal, "replace document failed", err)
+		}
+		if !matched {
+			if _, err := col.InsertBatch([][]byte{[]byte(doc.id)}, [][]byte{doc.raw}); err != nil {
+				return UpsertDocumentsResponse{}, wrapServiceError(CodeInternal, "insert raced replacement failed", err)
+			}
+			inserted++
+			continue
+		}
+		updated++
+	}
+	return UpsertDocumentsResponse{Index: info, Upserted: len(prepared), Inserted: inserted, Updated: updated, IDs: ids}, nil
+}
+
+// DeleteDocuments deletes explicit IDs or documents matching a filter.
+func (s *Service) DeleteDocuments(ctx context.Context, index string, req DeleteDocumentsRequest) (DeleteDocumentsResponse, error) {
+	col, info, err := s.openIndex(ctx, index, req.ExpectedGeneration)
+	if err != nil {
+		return DeleteDocumentsResponse{}, err
+	}
+	if len(req.IDs) > 0 && req.Filter != nil {
+		return DeleteDocumentsResponse{}, serviceError(CodeInvalidRequest, "delete accepts either ids or filter, not both")
+	}
+	var ids []string
+	if len(req.IDs) > 0 {
+		ids, err = validateDocumentIDs(req.IDs)
+		if err != nil {
+			return DeleteDocumentsResponse{}, err
+		}
+	} else if req.Filter != nil {
+		if err := req.Filter.Validate(); err != nil {
+			return DeleteDocumentsResponse{}, err
+		}
+		ids, err = s.collectMatchingIDs(ctx, col, req.Filter)
+		if err != nil {
+			return DeleteDocumentsResponse{}, err
+		}
+	} else {
+		return DeleteDocumentsResponse{}, serviceError(CodeInvalidRequest, "delete requires ids or filter")
+	}
+	if len(ids) == 0 {
+		return DeleteDocumentsResponse{Index: info, IDs: []string{}}, nil
+	}
+	deleteIDs := make([][]byte, len(ids))
+	for i, id := range ids {
+		deleteIDs[i] = []byte(id)
+	}
+	deleted, err := col.DeleteBatch(deleteIDs)
+	if err != nil {
+		return DeleteDocumentsResponse{}, wrapServiceError(CodeInternal, "delete documents failed", err)
+	}
+	return DeleteDocumentsResponse{Index: info, Deleted: deleted, IDs: ids}, nil
+}
+
+// CountDocuments counts documents matching a filter.
+func (s *Service) CountDocuments(ctx context.Context, index string, req CountDocumentsRequest) (CountDocumentsResponse, error) {
+	col, info, err := s.openIndex(ctx, index, req.ExpectedGeneration)
+	if err != nil {
+		return CountDocumentsResponse{}, err
+	}
+	if err := req.Filter.Validate(); err != nil {
+		return CountDocumentsResponse{}, err
+	}
+	count := 0
+	err = s.scanDocuments(ctx, col, func(doc Document) error {
+		ok, err := matchFilter(req.Filter, doc)
+		if err != nil || !ok {
+			return err
+		}
+		count++
+		return nil
+	})
+	if err != nil {
+		return CountDocumentsResponse{}, err
+	}
+	return CountDocumentsResponse{Index: info, Count: count}, nil
+}
+
+// FilterDocuments returns documents matching a filter in stable document-ID order.
+func (s *Service) FilterDocuments(ctx context.Context, index string, req FilterDocumentsRequest) (FilterDocumentsResponse, error) {
+	col, info, err := s.openIndex(ctx, index, req.ExpectedGeneration)
+	if err != nil {
+		return FilterDocumentsResponse{}, err
+	}
+	if req.Limit < 0 || req.Offset < 0 {
+		return FilterDocumentsResponse{}, serviceError(CodeInvalidRequest, "limit and offset must be non-negative")
+	}
+	if err := req.Filter.Validate(); err != nil {
+		return FilterDocumentsResponse{}, err
+	}
+	var docs []Document
+	matched := 0
+	err = s.scanDocuments(ctx, col, func(doc Document) error {
+		ok, err := matchFilter(req.Filter, doc)
+		if err != nil || !ok {
+			return err
+		}
+		matched++
+		if matched <= req.Offset {
+			return nil
+		}
+		if req.Limit > 0 && len(docs) >= req.Limit {
+			return nil
+		}
+		if !req.ReturnEmbedding {
+			doc.Embedding = nil
+		}
+		docs = append(docs, doc)
+		return nil
+	})
+	if err != nil {
+		return FilterDocumentsResponse{}, err
+	}
+	truncated := req.Limit > 0 && matched > req.Offset+len(docs)
+	if docs == nil {
+		docs = []Document{}
+	}
+	return FilterDocumentsResponse{Index: info, Documents: docs, MatchedCount: matched, Truncated: truncated}, nil
+}
+
+// SearchDenseVector runs exact dense scoring with optional metadata filters.
+func (s *Service) SearchDenseVector(ctx context.Context, index string, req DenseVectorSearchRequest) (DenseVectorSearchResponse, error) {
+	col, info, err := s.openIndex(ctx, index, req.ExpectedGeneration)
+	if err != nil {
+		return DenseVectorSearchResponse{}, err
+	}
+	if req.TopK <= 0 {
+		return DenseVectorSearchResponse{}, serviceError(CodeInvalidRequest, "top_k must be positive")
+	}
+	if err := validateEmbedding("query_embedding", req.QueryEmbedding, info.Dimension, info.Metric); err != nil {
+		return DenseVectorSearchResponse{}, err
+	}
+	if err := req.Filter.Validate(); err != nil {
+		return DenseVectorSearchResponse{}, err
+	}
+	var candidates []scoredDocument
+	candidateCount := 0
+	err = s.scanDocuments(ctx, col, func(doc Document) error {
+		ok, err := matchFilter(req.Filter, doc)
+		if err != nil || !ok {
+			return err
+		}
+		candidateCount++
+		if err := validateEmbedding("document "+doc.ID+" embedding", doc.Embedding, info.Dimension, info.Metric); err != nil {
+			return err
+		}
+		score, err := scoreEmbedding(req.QueryEmbedding, doc.Embedding, info.Metric)
+		if err != nil {
+			return err
+		}
+		if !req.ReturnEmbedding {
+			doc.Embedding = nil
+		}
+		doc.Score = scorePtr(score)
+		candidates = append(candidates, scoredDocument{document: doc, score: score})
+		return nil
+	})
+	if err != nil {
+		return DenseVectorSearchResponse{}, err
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		if candidates[i].score == candidates[j].score {
+			return candidates[i].document.ID < candidates[j].document.ID
+		}
+		return candidates[i].score > candidates[j].score
+	})
+	if len(candidates) > req.TopK {
+		candidates = candidates[:req.TopK]
+	}
+	docs := make([]Document, len(candidates))
+	for i := range candidates {
+		docs[i] = candidates[i].document
+	}
+	if docs == nil {
+		docs = []Document{}
+	}
+	return DenseVectorSearchResponse{Index: info, Documents: docs, Metric: info.Metric, Exact: true, Candidates: candidateCount}, nil
+}
+
+// SearchKeyword intentionally fails closed until TreeDB ranked text execution is implemented.
+func (s *Service) SearchKeyword(context.Context, string, json.RawMessage) error {
+	return serviceError(CodeUnsupported, "keyword search is not implemented; TreeDB text search currently fails closed and the service does not scan documents as a fallback")
+}
+
+// SearchHybrid intentionally fails closed until TreeDB hybrid execution is implemented.
+func (s *Service) SearchHybrid(context.Context, string, json.RawMessage) error {
+	return serviceError(CodeUnsupported, "hybrid search is not implemented; the service does not run text/hybrid document-scan fallbacks")
+}
+
+func (s *Service) openIndex(ctx context.Context, name string, expectedGeneration uint64) (*collections.Collection, IndexInfo, error) {
+	if err := ctxErr(ctx); err != nil {
+		return nil, IndexInfo{}, err
+	}
+	if s == nil || s.manager == nil {
+		return nil, IndexInfo{}, serviceError(CodeIndexUnavailable, "document service has no collection manager")
+	}
+	if err := collections.ValidateCollectionName(name); err != nil {
+		return nil, IndexInfo{}, wrapServiceError(CodeInvalidRequest, "invalid index name", err)
+	}
+	col, err := s.manager.OpenCollection(name)
+	if err != nil {
+		return nil, IndexInfo{}, serviceErrorFromCollectionOpen(err, name)
+	}
+	info, err := indexInfoFromMeta(col.Meta())
+	if err != nil {
+		return nil, IndexInfo{}, err
+	}
+	if expectedGeneration != 0 && expectedGeneration != info.Generation {
+		return nil, IndexInfo{}, serviceErrorf(CodeIndexStale, "index %q generation %d does not match expected_generation %d", name, info.Generation, expectedGeneration)
+	}
+	return col, info, nil
+}
+
+func indexInfoFromMeta(meta collections.CollectionMeta) (IndexInfo, error) {
+	format := meta.Options.DocumentFormat
+	if format == "" {
+		format = collections.DocumentFormatJSON
+	}
+	if format != collections.DocumentFormatJSON {
+		return IndexInfo{}, serviceErrorf(CodeIndexUnavailable, "collection %q is not a document service JSON index", meta.Name)
+	}
+	var def collections.VectorIndexDefinition
+	found := false
+	for _, candidate := range meta.VectorIndexes {
+		if candidate.Name == defaultVectorIndexName || candidate.Field == defaultEmbeddingField {
+			def = candidate
+			found = true
+			break
+		}
+	}
+	if !found {
+		return IndexInfo{}, serviceErrorf(CodeIndexUnavailable, "collection %q does not expose the service embedding index", meta.Name)
+	}
+	if def.Field != defaultEmbeddingField {
+		return IndexInfo{}, serviceErrorf(CodeIndexUnavailable, "collection %q uses unsupported embedding field %q", meta.Name, def.Field)
+	}
+	if def.Dimensions <= 0 {
+		return IndexInfo{}, serviceErrorf(CodeIndexUnavailable, "collection %q has invalid embedding dimensions", meta.Name)
+	}
+	metric, err := metricFromCollection(def.Metric)
+	if err != nil {
+		return IndexInfo{}, err
+	}
+	generation := def.SchemaGeneration
+	if generation == 0 {
+		generation = 1
+	}
+	return IndexInfo{
+		Name:            meta.Name,
+		Dimension:       def.Dimensions,
+		Metric:          metric,
+		Generation:      generation,
+		ContractVersion: ContractVersion,
+		EmbeddingField:  defaultEmbeddingField,
+		DocumentType:    defaultCollectionDocType,
+		Capabilities:    indexCapabilities(),
+	}, nil
+}
+
+type preparedDocument struct {
+	id  string
+	raw []byte
+}
+
+func prepareDocumentsForWrite(documents []Document, info IndexInfo) ([]preparedDocument, error) {
+	seen := make(map[string]struct{}, len(documents))
+	prepared := make([]preparedDocument, len(documents))
+	for i, doc := range documents {
+		id := strings.TrimSpace(doc.ID)
+		if id == "" {
+			return nil, serviceErrorf(CodeInvalidRequest, "documents[%d].id must not be empty", i)
+		}
+		if id != doc.ID {
+			return nil, serviceErrorf(CodeInvalidRequest, "documents[%d].id must not have leading or trailing whitespace", i)
+		}
+		if _, ok := seen[id]; ok {
+			return nil, serviceErrorf(CodeInvalidRequest, "duplicate document id %q", id)
+		}
+		seen[id] = struct{}{}
+		if err := validateEmbedding(fmt.Sprintf("documents[%d].embedding", i), doc.Embedding, info.Dimension, info.Metric); err != nil {
+			return nil, err
+		}
+		stored := Document{ID: id, Content: doc.Content, Embedding: append([]float32(nil), doc.Embedding...), Meta: cloneMeta(doc.Meta)}
+		raw, err := json.Marshal(stored)
+		if err != nil {
+			return nil, wrapServiceError(CodeInvalidRequest, fmt.Sprintf("documents[%d] is not JSON-serializable", i), err)
+		}
+		prepared[i] = preparedDocument{id: id, raw: raw}
+	}
+	return prepared, nil
+}
+
+func validateDocumentIDs(ids []string) ([]string, error) {
+	seen := make(map[string]struct{}, len(ids))
+	out := make([]string, len(ids))
+	for i, id := range ids {
+		trimmed := strings.TrimSpace(id)
+		if trimmed == "" {
+			return nil, serviceErrorf(CodeInvalidRequest, "ids[%d] must not be empty", i)
+		}
+		if trimmed != id {
+			return nil, serviceErrorf(CodeInvalidRequest, "ids[%d] must not have leading or trailing whitespace", i)
+		}
+		if _, ok := seen[id]; ok {
+			return nil, serviceErrorf(CodeInvalidRequest, "duplicate document id %q", id)
+		}
+		seen[id] = struct{}{}
+		out[i] = id
+	}
+	return out, nil
+}
+
+func (s *Service) collectMatchingIDs(ctx context.Context, col *collections.Collection, filter *Filter) ([]string, error) {
+	var ids []string
+	err := s.scanDocuments(ctx, col, func(doc Document) error {
+		ok, err := matchFilter(filter, doc)
+		if err != nil || !ok {
+			return err
+		}
+		ids = append(ids, doc.ID)
+		return nil
+	})
+	return ids, err
+}
+
+func (s *Service) scanDocuments(ctx context.Context, col *collections.Collection, fn func(Document) error) error {
+	if err := ctxErr(ctx); err != nil {
+		return err
+	}
+	if col == nil {
+		return serviceError(CodeIndexUnavailable, "index collection is unavailable")
+	}
+	materializer, err := col.NewStoredDocumentJSONMaterializer()
+	if err != nil {
+		return wrapServiceError(CodeIndexUnavailable, "document materializer unavailable", err)
+	}
+	defer func() { _ = materializer.Close() }()
+	_, err = col.ScanDocumentsFunc(maxServiceScanDocuments, func(record collections.DocumentRecord) (bool, error) {
+		if err := ctxErr(ctx); err != nil {
+			return false, err
+		}
+		jsonDoc, err := materializer.StoredDocumentJSON(record.Document)
+		if err != nil {
+			return false, wrapServiceError(CodeInternal, "stored document materialization failed", err)
+		}
+		doc, err := decodeStoredDocument(record.ID, jsonDoc)
+		if err != nil {
+			return false, err
+		}
+		if err := fn(doc); err != nil {
+			return false, err
+		}
+		return true, nil
+	})
+	if err != nil {
+		var serviceErr *Error
+		if errors.As(err, &serviceErr) {
+			return err
+		}
+		if errors.Is(err, backenddb.ErrClosed) {
+			return wrapServiceError(CodeIndexUnavailable, "TreeDB backend is closed", err)
+		}
+		return wrapServiceError(CodeInternal, "document scan failed", err)
+	}
+	return nil
+}
+
+func decodeStoredDocument(id []byte, raw []byte) (Document, error) {
+	var doc Document
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.UseNumber()
+	if err := dec.Decode(&doc); err != nil {
+		return Document{}, wrapServiceError(CodeInternal, "stored document JSON is invalid", err)
+	}
+	doc.ID = string(id)
+	doc.Score = nil
+	if doc.Meta == nil {
+		doc.Meta = map[string]any{}
+	}
+	return doc, nil
+}
+
+func validateEmbedding(label string, embedding []float32, dimension int, metric Metric) error {
+	if len(embedding) == 0 {
+		return serviceErrorf(CodeInvalidRequest, "%s is required", label)
+	}
+	if len(embedding) != dimension {
+		return serviceErrorf(CodeInvalidRequest, "%s dimension %d does not match index dimension %d", label, len(embedding), dimension)
+	}
+	var norm float64
+	for i, value := range embedding {
+		f := float64(value)
+		if math.IsNaN(f) || math.IsInf(f, 0) {
+			return serviceErrorf(CodeInvalidRequest, "%s[%d] is not finite", label, i)
+		}
+		norm += f * f
+	}
+	if metric == MetricCosine && norm == 0 {
+		return serviceErrorf(CodeInvalidRequest, "%s must have non-zero magnitude for cosine metric", label)
+	}
+	return nil
+}
+
+func scoreEmbedding(query, document []float32, metric Metric) (float64, error) {
+	if len(query) != len(document) {
+		return 0, serviceErrorf(CodeInvalidRequest, "embedding dimension %d does not match query dimension %d", len(document), len(query))
+	}
+	switch metric {
+	case MetricCosine:
+		var dot, leftNorm, rightNorm float64
+		for i := range query {
+			q := float64(query[i])
+			d := float64(document[i])
+			dot += q * d
+			leftNorm += q * q
+			rightNorm += d * d
+		}
+		if leftNorm == 0 || rightNorm == 0 {
+			return 0, serviceError(CodeInvalidRequest, "cosine embeddings must have non-zero magnitude")
+		}
+		return dot / (math.Sqrt(leftNorm) * math.Sqrt(rightNorm)), nil
+	case MetricL2:
+		var sum float64
+		for i := range query {
+			delta := float64(query[i] - document[i])
+			sum += delta * delta
+		}
+		return -sum, nil
+	case MetricInnerProduct:
+		var dot float64
+		for i := range query {
+			dot += float64(query[i]) * float64(document[i])
+		}
+		return dot, nil
+	default:
+		return 0, serviceErrorf(CodeInvalidRequest, "unsupported metric %q", metric)
+	}
+}
+
+type scoredDocument struct {
+	document Document
+	score    float64
+}
+
+func cloneMeta(in map[string]any) map[string]any {
+	if len(in) == 0 {
+		return map[string]any{}
+	}
+	out := make(map[string]any, len(in))
+	for key, value := range in {
+		out[key] = cloneJSONValue(value)
+	}
+	return out
+}
+
+func cloneJSONValue(value any) any {
+	switch v := value.(type) {
+	case map[string]any:
+		return cloneMeta(v)
+	case []any:
+		out := make([]any, len(v))
+		for i := range v {
+			out[i] = cloneJSONValue(v[i])
+		}
+		return out
+	default:
+		return v
+	}
+}
+
+func ctxErr(ctx context.Context) error {
+	if ctx == nil {
+		return nil
+	}
+	if err := ctx.Err(); err != nil {
+		return wrapServiceError(CodeIndexUnavailable, "request context is no longer available", err)
+	}
+	return nil
+}

--- a/TreeDB/documentservice/service.go
+++ b/TreeDB/documentservice/service.go
@@ -9,6 +9,7 @@ import (
 	"math"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/snissn/gomap/TreeDB/collections"
 	backenddb "github.com/snissn/gomap/TreeDB/db"
@@ -19,6 +20,7 @@ const maxServiceScanDocuments = int(^uint(0) >> 1)
 // Service maps the document/search contract onto TreeDB collections.
 type Service struct {
 	manager *collections.CollectionManager
+	writeMu sync.Mutex
 }
 
 // New returns a document/search service backed by manager.
@@ -93,6 +95,9 @@ func (s *Service) UpsertDocuments(ctx context.Context, index string, req UpsertD
 	if err != nil {
 		return UpsertDocumentsResponse{}, err
 	}
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+
 	ids := make([]string, 0, len(prepared))
 	insertIDs := make([][]byte, 0, len(prepared))
 	insertDocs := make([][]byte, 0, len(prepared))
@@ -165,6 +170,9 @@ func (s *Service) DeleteDocuments(ctx context.Context, index string, req DeleteD
 	if len(req.IDs) > 0 && req.Filter != nil {
 		return DeleteDocumentsResponse{}, serviceError(CodeInvalidRequest, "delete accepts either ids or filter, not both")
 	}
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+
 	var ids []string
 	if len(req.IDs) > 0 {
 		ids, err = validateDocumentIDs(req.IDs)
@@ -593,7 +601,7 @@ func scoreEmbedding(query, document []float32, metric Metric) (float64, error) {
 	case MetricL2:
 		var sum float64
 		for i := range query {
-			delta := float64(query[i] - document[i])
+			delta := float64(query[i]) - float64(document[i])
 			sum += delta * delta
 		}
 		return -sum, nil

--- a/TreeDB/documentservice/service_test.go
+++ b/TreeDB/documentservice/service_test.go
@@ -2,9 +2,11 @@ package documentservice
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/snissn/gomap/TreeDB/collections"
@@ -105,6 +107,95 @@ func TestServiceUpsertDeleteCountFilterRoundTrip(t *testing.T) {
 	count, err = svc.CountDocuments(ctx, "docs", CountDocumentsRequest{})
 	if err != nil || count.Count != 1 {
 		t.Fatalf("final count=%+v err=%v", count, err)
+	}
+}
+
+func TestServiceUpsertInsertRaceFallsBackToReplace(t *testing.T) {
+	svc, db := newTestService(t)
+	defer db.Close()
+	ctx := context.Background()
+	info, err := svc.CreateIndex(ctx, CreateIndexRequest{Name: "docs", Dimension: 2})
+	if err != nil {
+		t.Fatalf("CreateIndex: %v", err)
+	}
+	col, _, err := svc.openIndex(ctx, "docs", 0)
+	if err != nil {
+		t.Fatalf("openIndex: %v", err)
+	}
+	first, err := prepareDocumentsForWrite([]Document{{ID: "race", Content: "first", Embedding: []float32{1, 0}}}, info)
+	if err != nil {
+		t.Fatalf("prepare first: %v", err)
+	}
+	if _, err := col.InsertBatch([][]byte{[]byte(first[0].id)}, [][]byte{first[0].raw}); err != nil {
+		t.Fatalf("InsertBatch first: %v", err)
+	}
+	raced, err := prepareDocumentsForWrite([]Document{{ID: "race", Content: "winner", Embedding: []float32{0, 1}, Meta: map[string]any{"repo": "gomap"}}}, info)
+	if err != nil {
+		t.Fatalf("prepare raced: %v", err)
+	}
+	inserted, updated, err := upsertPreparedDocument(ctx, col, raced[0], true)
+	if err != nil {
+		t.Fatalf("upsertPreparedDocument raced insert: %v", err)
+	}
+	if inserted || !updated {
+		t.Fatalf("inserted=%v updated=%v, want replace fallback", inserted, updated)
+	}
+	listed, err := svc.FilterDocuments(ctx, "docs", FilterDocumentsRequest{ReturnEmbedding: true})
+	if err != nil {
+		t.Fatalf("FilterDocuments: %v", err)
+	}
+	if len(listed.Documents) != 1 || listed.Documents[0].Content != "winner" || !reflect.DeepEqual(listed.Documents[0].Embedding, []float32{0, 1}) {
+		t.Fatalf("listed after raced upsert=%+v", listed)
+	}
+}
+
+func TestServiceConcurrentSameIDUpsertsSucceed(t *testing.T) {
+	svc, db := newTestService(t)
+	defer db.Close()
+	ctx := context.Background()
+	if _, err := svc.CreateIndex(ctx, CreateIndexRequest{Name: "docs", Dimension: 2}); err != nil {
+		t.Fatalf("CreateIndex: %v", err)
+	}
+	const workers = 32
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	errs := make(chan error, workers)
+	for i := 0; i < workers; i++ {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			_, err := svc.UpsertDocuments(ctx, "docs", UpsertDocumentsRequest{Documents: []Document{{
+				ID:        "same-id",
+				Content:   fmt.Sprintf("writer-%02d", i),
+				Embedding: []float32{1, float32(i + 1)},
+				Meta:      map[string]any{"writer": float64(i)},
+			}}})
+			if err != nil {
+				errs <- err
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Fatalf("concurrent upsert returned error: %v", err)
+	}
+	count, err := svc.CountDocuments(ctx, "docs", CountDocumentsRequest{})
+	if err != nil {
+		t.Fatalf("CountDocuments: %v", err)
+	}
+	if count.Count != 1 {
+		t.Fatalf("count=%d want 1", count.Count)
+	}
+	search, err := svc.SearchDenseVector(ctx, "docs", DenseVectorSearchRequest{QueryEmbedding: []float32{1, 1}, TopK: 1, ReturnEmbedding: true})
+	if err != nil {
+		t.Fatalf("SearchDenseVector: %v", err)
+	}
+	if len(search.Documents) != 1 || search.Documents[0].ID != "same-id" || len(search.Documents[0].Embedding) != 2 {
+		t.Fatalf("search after concurrent upsert=%+v", search)
 	}
 }
 

--- a/TreeDB/documentservice/service_test.go
+++ b/TreeDB/documentservice/service_test.go
@@ -1,0 +1,238 @@
+package documentservice
+
+import (
+	"context"
+	"math"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/snissn/gomap/TreeDB/collections"
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+)
+
+func TestServiceSchemaValidationAndUnsupportedFilterErrors(t *testing.T) {
+	svc, db := newTestService(t)
+	defer db.Close()
+	ctx := context.Background()
+
+	if _, err := svc.CreateIndex(ctx, CreateIndexRequest{Name: "docs", Dimension: 0}); ErrorCodeOf(err) != CodeInvalidRequest {
+		t.Fatalf("CreateIndex dimension err=%v code=%s", err, ErrorCodeOf(err))
+	}
+	if _, err := svc.CreateIndex(ctx, CreateIndexRequest{Name: "docs", Dimension: 2, Metric: "manhattan"}); ErrorCodeOf(err) != CodeInvalidRequest {
+		t.Fatalf("CreateIndex metric err=%v code=%s", err, ErrorCodeOf(err))
+	}
+	if _, err := svc.CreateIndex(ctx, CreateIndexRequest{Name: "docs", Dimension: 2}); err != nil {
+		t.Fatalf("CreateIndex: %v", err)
+	}
+	if _, err := svc.UpsertDocuments(ctx, "docs", UpsertDocumentsRequest{Documents: []Document{{ID: "missing", Content: "missing embedding"}}}); ErrorCodeOf(err) != CodeInvalidRequest || !strings.Contains(err.Error(), "embedding") {
+		t.Fatalf("missing embedding err=%v code=%s", err, ErrorCodeOf(err))
+	}
+	if _, err := svc.UpsertDocuments(ctx, "docs", UpsertDocumentsRequest{Documents: []Document{{ID: "bad", Embedding: []float32{1}}}}); ErrorCodeOf(err) != CodeInvalidRequest || !strings.Contains(err.Error(), "dimension") {
+		t.Fatalf("dimension mismatch err=%v code=%s", err, ErrorCodeOf(err))
+	}
+	_, err := svc.CountDocuments(ctx, "docs", CountDocumentsRequest{Filter: &Filter{Field: "meta.repo", Operator: "LIKE", Value: "gomap"}})
+	if ErrorCodeOf(err) != CodeInvalidRequest || !strings.Contains(err.Error(), "unsupported filter operator") {
+		t.Fatalf("unsupported filter err=%v code=%s", err, ErrorCodeOf(err))
+	}
+	_, err = svc.CountDocuments(ctx, "docs", CountDocumentsRequest{Filter: &Filter{Field: "meta.repo", Operator: "in", Value: "gomap"}})
+	if ErrorCodeOf(err) != CodeInvalidRequest || !strings.Contains(err.Error(), "array") {
+		t.Fatalf("unsupported in operand err=%v code=%s", err, ErrorCodeOf(err))
+	}
+}
+
+func TestServiceUpsertDeleteCountFilterRoundTrip(t *testing.T) {
+	svc, db := newTestService(t)
+	defer db.Close()
+	ctx := context.Background()
+	info, err := svc.CreateIndex(ctx, CreateIndexRequest{Name: "docs", Dimension: 2})
+	if err != nil {
+		t.Fatalf("CreateIndex: %v", err)
+	}
+	upsert, err := svc.UpsertDocuments(ctx, "docs", UpsertDocumentsRequest{Documents: []Document{
+		{ID: "a", Content: "alpha", Embedding: []float32{1, 0}, Meta: map[string]any{"repo": "gomap", "language": "go", "start_line": 10.0, "tags": []any{"core", "api"}}},
+		{ID: "b", Content: "beta", Embedding: []float32{0, 1}, Meta: map[string]any{"repo": "gomap", "language": "python", "start_line": 30.0}},
+		{ID: "c", Content: "gamma", Embedding: []float32{0.7, 0.7}, Meta: map[string]any{"repo": "other", "language": "go", "start_line": 50.0}},
+	}})
+	if err != nil {
+		t.Fatalf("UpsertDocuments: %v", err)
+	}
+	if upsert.Upserted != 3 || upsert.Inserted != 3 || upsert.Updated != 0 || !reflect.DeepEqual(upsert.IDs, []string{"a", "b", "c"}) {
+		t.Fatalf("upsert=%+v", upsert)
+	}
+	if upsert.Index.Generation != info.Generation {
+		t.Fatalf("generation changed: upsert=%d create=%d", upsert.Index.Generation, info.Generation)
+	}
+	count, err := svc.CountDocuments(ctx, "docs", CountDocumentsRequest{})
+	if err != nil || count.Count != 3 {
+		t.Fatalf("count all=%+v err=%v", count, err)
+	}
+	filteredCount, err := svc.CountDocuments(ctx, "docs", CountDocumentsRequest{Filter: &Filter{Operator: "AND", Conditions: []Filter{
+		{Field: "meta.repo", Operator: "==", Value: "gomap"},
+		{Field: "meta.start_line", Operator: ">=", Value: 20.0},
+	}}})
+	if err != nil || filteredCount.Count != 1 {
+		t.Fatalf("filtered count=%+v err=%v", filteredCount, err)
+	}
+	listed, err := svc.FilterDocuments(ctx, "docs", FilterDocumentsRequest{Filter: &Filter{Field: "meta.language", Operator: "in", Value: []any{"go"}}, ReturnEmbedding: false})
+	if err != nil {
+		t.Fatalf("FilterDocuments: %v", err)
+	}
+	if listed.MatchedCount != 2 || len(listed.Documents) != 2 || listed.Documents[0].ID != "a" || listed.Documents[1].ID != "c" {
+		t.Fatalf("listed=%+v", listed)
+	}
+	if listed.Documents[0].Embedding != nil {
+		t.Fatalf("embedding returned despite return_embedding=false: %+v", listed.Documents[0].Embedding)
+	}
+	if _, ok := listed.Documents[0].Meta["repo"]; !ok {
+		t.Fatalf("metadata missing from listed document: %+v", listed.Documents[0].Meta)
+	}
+	updated, err := svc.UpsertDocuments(ctx, "docs", UpsertDocumentsRequest{Documents: []Document{{ID: "a", Content: "alpha updated", Embedding: []float32{1, 0}, Meta: map[string]any{"repo": "gomap", "language": "go", "start_line": 11.0}}}})
+	if err != nil {
+		t.Fatalf("Upsert update: %v", err)
+	}
+	if updated.Inserted != 0 || updated.Updated != 1 {
+		t.Fatalf("updated=%+v", updated)
+	}
+	deleted, err := svc.DeleteDocuments(ctx, "docs", DeleteDocumentsRequest{IDs: []string{"b"}})
+	if err != nil || deleted.Deleted != 1 || !reflect.DeepEqual(deleted.IDs, []string{"b"}) {
+		t.Fatalf("delete id=%+v err=%v", deleted, err)
+	}
+	deleted, err = svc.DeleteDocuments(ctx, "docs", DeleteDocumentsRequest{Filter: &Filter{Field: "meta.repo", Operator: "!=", Value: "gomap"}})
+	if err != nil || deleted.Deleted != 1 || !reflect.DeepEqual(deleted.IDs, []string{"c"}) {
+		t.Fatalf("delete filter=%+v err=%v", deleted, err)
+	}
+	count, err = svc.CountDocuments(ctx, "docs", CountDocumentsRequest{})
+	if err != nil || count.Count != 1 {
+		t.Fatalf("final count=%+v err=%v", count, err)
+	}
+}
+
+func TestServiceDenseVectorSearchStableIDsScoresMetadataAndEmbeddingEcho(t *testing.T) {
+	svc, db := newTestService(t)
+	defer db.Close()
+	ctx := context.Background()
+	if _, err := svc.CreateIndex(ctx, CreateIndexRequest{Name: "docs", Dimension: 2}); err != nil {
+		t.Fatalf("CreateIndex: %v", err)
+	}
+	_, err := svc.UpsertDocuments(ctx, "docs", UpsertDocumentsRequest{Documents: []Document{
+		{ID: "doc-a", Content: "a", Embedding: []float32{1, 0}, Meta: map[string]any{"repo": "gomap", "path": "a.go"}},
+		{ID: "doc-aa", Content: "aa", Embedding: []float32{1, 0}, Meta: map[string]any{"repo": "gomap", "path": "aa.go"}},
+		{ID: "doc-b", Content: "b", Embedding: []float32{0.8, 0.2}, Meta: map[string]any{"repo": "gomap", "path": "b.go"}},
+		{ID: "doc-c", Content: "c", Embedding: []float32{0, 1}, Meta: map[string]any{"repo": "other", "path": "c.go"}},
+	}})
+	if err != nil {
+		t.Fatalf("UpsertDocuments: %v", err)
+	}
+	res, err := svc.SearchDenseVector(ctx, "docs", DenseVectorSearchRequest{QueryEmbedding: []float32{1, 0}, TopK: 3, Filter: &Filter{Field: "meta.repo", Operator: "==", Value: "gomap"}, ReturnEmbedding: false})
+	if err != nil {
+		t.Fatalf("SearchDenseVector: %v", err)
+	}
+	if !res.Exact || res.Candidates != 3 || len(res.Documents) != 3 {
+		t.Fatalf("search response=%+v", res)
+	}
+	gotIDs := []string{res.Documents[0].ID, res.Documents[1].ID, res.Documents[2].ID}
+	wantIDs := []string{"doc-a", "doc-aa", "doc-b"}
+	if !reflect.DeepEqual(gotIDs, wantIDs) {
+		t.Fatalf("ids=%v want %v", gotIDs, wantIDs)
+	}
+	if res.Documents[0].Score == nil || math.Abs(*res.Documents[0].Score-1) > 1e-6 || res.Documents[1].Score == nil || math.Abs(*res.Documents[1].Score-1) > 1e-6 {
+		t.Fatalf("top scores=%v %v", res.Documents[0].Score, res.Documents[1].Score)
+	}
+	if res.Documents[2].Score == nil || *res.Documents[2].Score >= 1 || *res.Documents[2].Score <= 0.9 {
+		t.Fatalf("third score=%v", res.Documents[2].Score)
+	}
+	if res.Documents[0].Embedding != nil {
+		t.Fatalf("embedding returned despite return_embedding=false")
+	}
+	if res.Documents[0].Meta["path"] != "a.go" {
+		t.Fatalf("metadata=%+v", res.Documents[0].Meta)
+	}
+	withEmbedding, err := svc.SearchDenseVector(ctx, "docs", DenseVectorSearchRequest{QueryEmbedding: []float32{1, 0}, TopK: 1, ReturnEmbedding: true})
+	if err != nil {
+		t.Fatalf("SearchDenseVector echo: %v", err)
+	}
+	if !reflect.DeepEqual(withEmbedding.Documents[0].Embedding, []float32{1, 0}) {
+		t.Fatalf("embedding echo=%v", withEmbedding.Documents[0].Embedding)
+	}
+}
+
+func TestServicePersistenceReopenDocumentsAndEmbeddings(t *testing.T) {
+	dir := t.TempDir()
+	ctx := context.Background()
+	db, err := backenddb.Open(backenddb.Options{Dir: dir, DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	svc := New(collections.NewCollectionManager(db))
+	if _, err := svc.CreateIndex(ctx, CreateIndexRequest{Name: "docs", Dimension: 2}); err != nil {
+		_ = db.Close()
+		t.Fatalf("CreateIndex: %v", err)
+	}
+	if _, err := svc.UpsertDocuments(ctx, "docs", UpsertDocumentsRequest{Documents: []Document{{ID: "persist", Content: "persistent", Embedding: []float32{1, 0}, Meta: map[string]any{"repo": "gomap"}}}}); err != nil {
+		_ = db.Close()
+		t.Fatalf("UpsertDocuments: %v", err)
+	}
+	if err := db.Checkpoint(); err != nil {
+		_ = db.Close()
+		t.Fatalf("Checkpoint: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+	reopened, err := backenddb.Open(backenddb.Options{Dir: dir, DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatalf("reopen db: %v", err)
+	}
+	defer reopened.Close()
+	reopenedSvc := New(collections.NewCollectionManager(reopened))
+	count, err := reopenedSvc.CountDocuments(ctx, "docs", CountDocumentsRequest{})
+	if err != nil || count.Count != 1 {
+		t.Fatalf("reopened count=%+v err=%v", count, err)
+	}
+	search, err := reopenedSvc.SearchDenseVector(ctx, "docs", DenseVectorSearchRequest{QueryEmbedding: []float32{1, 0}, TopK: 1, ReturnEmbedding: true})
+	if err != nil {
+		t.Fatalf("reopened search: %v", err)
+	}
+	if len(search.Documents) != 1 || search.Documents[0].ID != "persist" || !reflect.DeepEqual(search.Documents[0].Embedding, []float32{1, 0}) {
+		t.Fatalf("reopened search=%+v", search)
+	}
+}
+
+func TestServiceErrorCasesDimensionStaleUnavailable(t *testing.T) {
+	svc, db := newTestService(t)
+	defer db.Close()
+	ctx := context.Background()
+	info, err := svc.CreateIndex(ctx, CreateIndexRequest{Name: "docs", Dimension: 2})
+	if err != nil {
+		t.Fatalf("CreateIndex: %v", err)
+	}
+	if _, err := svc.UpsertDocuments(ctx, "docs", UpsertDocumentsRequest{Documents: []Document{{ID: "a", Embedding: []float32{1, 0}}}}); err != nil {
+		t.Fatalf("UpsertDocuments: %v", err)
+	}
+	if _, err := svc.SearchDenseVector(ctx, "docs", DenseVectorSearchRequest{QueryEmbedding: []float32{1}, TopK: 1}); ErrorCodeOf(err) != CodeInvalidRequest || !strings.Contains(err.Error(), "dimension") {
+		t.Fatalf("query dimension err=%v code=%s", err, ErrorCodeOf(err))
+	}
+	if _, err := svc.CountDocuments(ctx, "docs", CountDocumentsRequest{ExpectedGeneration: info.Generation + 1}); ErrorCodeOf(err) != CodeIndexStale {
+		t.Fatalf("stale err=%v code=%s", err, ErrorCodeOf(err))
+	}
+	if _, err := svc.CountDocuments(ctx, "missing", CountDocumentsRequest{}); ErrorCodeOf(err) != CodeIndexNotFound {
+		t.Fatalf("missing err=%v code=%s", err, ErrorCodeOf(err))
+	}
+	mgr := collections.NewCollectionManager(db)
+	if _, err := mgr.CreateCollection(&collections.CollectionMeta{Name: "raw", Options: collections.CollectionOptions{DocumentFormat: collections.DocumentFormatJSON}}); err != nil {
+		t.Fatalf("CreateCollection raw: %v", err)
+	}
+	if _, err := svc.CountDocuments(ctx, "raw", CountDocumentsRequest{}); ErrorCodeOf(err) != CodeIndexUnavailable {
+		t.Fatalf("unavailable err=%v code=%s", err, ErrorCodeOf(err))
+	}
+}
+
+func newTestService(t *testing.T) (*Service, *backenddb.DB) {
+	t.Helper()
+	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir(), DisableBackgroundPrune: true})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	return New(collections.NewCollectionManager(db)), db
+}

--- a/TreeDB/documentservice/service_test.go
+++ b/TreeDB/documentservice/service_test.go
@@ -41,6 +41,10 @@ func TestServiceSchemaValidationAndUnsupportedFilterErrors(t *testing.T) {
 	if ErrorCodeOf(err) != CodeInvalidRequest || !strings.Contains(err.Error(), "array") {
 		t.Fatalf("unsupported in operand err=%v code=%s", err, ErrorCodeOf(err))
 	}
+	_, err = svc.CountDocuments(ctx, "docs", CountDocumentsRequest{Filter: &Filter{Field: "meta.version", Operator: ">", Value: []any{1.0}}})
+	if ErrorCodeOf(err) != CodeInvalidRequest || !strings.Contains(err.Error(), "numeric or string") {
+		t.Fatalf("unsupported comparison operand on empty index err=%v code=%s", err, ErrorCodeOf(err))
+	}
 }
 
 func TestServiceUpsertDeleteCountFilterRoundTrip(t *testing.T) {

--- a/TreeDB/documentservice/service_test.go
+++ b/TreeDB/documentservice/service_test.go
@@ -203,6 +203,65 @@ func TestServiceConcurrentSameIDUpsertsSucceed(t *testing.T) {
 	}
 }
 
+func TestServiceConcurrentFilterDeleteAndUpsertPreservesReplacement(t *testing.T) {
+	svc, db := newTestService(t)
+	defer db.Close()
+	ctx := context.Background()
+	if _, err := svc.CreateIndex(ctx, CreateIndexRequest{Name: "docs", Dimension: 2}); err != nil {
+		t.Fatalf("CreateIndex: %v", err)
+	}
+
+	for i := 0; i < 25; i++ {
+		id := fmt.Sprintf("race-%02d", i)
+		if _, err := svc.UpsertDocuments(ctx, "docs", UpsertDocumentsRequest{Documents: []Document{{
+			ID:        id,
+			Content:   "matching before delete",
+			Embedding: []float32{1, 0},
+			Meta:      map[string]any{"repo": "gomap"},
+		}}}); err != nil {
+			t.Fatalf("initial UpsertDocuments: %v", err)
+		}
+
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		errs := make(chan error, 2)
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			<-start
+			_, err := svc.DeleteDocuments(ctx, "docs", DeleteDocumentsRequest{Filter: &Filter{Field: "meta.repo", Operator: "==", Value: "gomap"}})
+			errs <- err
+		}()
+		go func() {
+			defer wg.Done()
+			<-start
+			_, err := svc.UpsertDocuments(ctx, "docs", UpsertDocumentsRequest{Documents: []Document{{
+				ID:        id,
+				Content:   "replacement should survive",
+				Embedding: []float32{0, 1},
+				Meta:      map[string]any{"repo": "other"},
+			}}})
+			errs <- err
+		}()
+		close(start)
+		wg.Wait()
+		close(errs)
+		for err := range errs {
+			if err != nil {
+				t.Fatalf("concurrent delete/upsert error: %v", err)
+			}
+		}
+
+		listed, err := svc.FilterDocuments(ctx, "docs", FilterDocumentsRequest{Filter: &Filter{Field: "id", Operator: "==", Value: id}})
+		if err != nil {
+			t.Fatalf("FilterDocuments final: %v", err)
+		}
+		if len(listed.Documents) != 1 || listed.Documents[0].Meta["repo"] != "other" {
+			t.Fatalf("final document for %s=%+v, want surviving replacement", id, listed.Documents)
+		}
+	}
+}
+
 func TestServiceDenseVectorSearchStableIDsScoresMetadataAndEmbeddingEcho(t *testing.T) {
 	svc, db := newTestService(t)
 	defer db.Close()

--- a/TreeDB/documentservice/types.go
+++ b/TreeDB/documentservice/types.go
@@ -1,0 +1,198 @@
+package documentservice
+
+import (
+	"strings"
+
+	"github.com/snissn/gomap/TreeDB/collections"
+)
+
+const (
+	// ContractVersion is returned by health and index metadata responses so
+	// clients can pin the pre-alpha schema they implement.
+	ContractVersion = "treedb-document-service/v1alpha1"
+
+	defaultEmbeddingField    = "embedding"
+	defaultVectorIndexName   = "embedding"
+	defaultCollectionDocType = "treedb_document_service_v1"
+)
+
+// Metric selects the dense-vector score function. Scores returned by the
+// service are always higher-is-better.
+type Metric string
+
+const (
+	MetricCosine       Metric = "cosine"
+	MetricL2           Metric = "l2"
+	MetricInnerProduct Metric = "inner_product"
+)
+
+// Document is the service's Haystack-compatible document shape.
+type Document struct {
+	ID        string         `json:"id"`
+	Content   string         `json:"content,omitempty"`
+	Embedding []float32      `json:"embedding,omitempty"`
+	Score     *float64       `json:"score,omitempty"`
+	Meta      map[string]any `json:"meta,omitempty"`
+}
+
+// IndexCapabilities describes the supported operations for one service index.
+type IndexCapabilities struct {
+	DenseVectorSearch bool `json:"dense_vector_search"`
+	ExactDenseScoring bool `json:"exact_dense_scoring"`
+	MetadataFilters   bool `json:"metadata_filters"`
+	KeywordSearch     bool `json:"keyword_search"`
+	HybridSearch      bool `json:"hybrid_search"`
+}
+
+// IndexInfo is returned by create/open and echoed by operation responses.
+type IndexInfo struct {
+	Name            string            `json:"name"`
+	Dimension       int               `json:"dimension"`
+	Metric          Metric            `json:"metric"`
+	Generation      uint64            `json:"generation"`
+	ContractVersion string            `json:"contract_version"`
+	EmbeddingField  string            `json:"embedding_field"`
+	DocumentType    string            `json:"document_type"`
+	Capabilities    IndexCapabilities `json:"capabilities"`
+}
+
+// CreateIndexRequest creates or opens a service index. Existing compatible
+// indexes are returned idempotently; incompatible existing collections fail.
+type CreateIndexRequest struct {
+	Name      string `json:"name"`
+	Dimension int    `json:"dimension"`
+	Metric    Metric `json:"metric,omitempty"`
+}
+
+// UpsertDocumentsRequest writes or replaces service documents.
+type UpsertDocumentsRequest struct {
+	ExpectedGeneration uint64     `json:"expected_generation,omitempty"`
+	Documents          []Document `json:"documents"`
+}
+
+type UpsertDocumentsResponse struct {
+	Index    IndexInfo `json:"index"`
+	Upserted int       `json:"upserted"`
+	Inserted int       `json:"inserted"`
+	Updated  int       `json:"updated"`
+	IDs      []string  `json:"ids"`
+}
+
+// DeleteDocumentsRequest deletes either explicit IDs or documents matching a
+// metadata filter. Supplying both IDs and Filter is rejected as ambiguous.
+type DeleteDocumentsRequest struct {
+	ExpectedGeneration uint64   `json:"expected_generation,omitempty"`
+	IDs                []string `json:"ids,omitempty"`
+	Filter             *Filter  `json:"filter,omitempty"`
+}
+
+type DeleteDocumentsResponse struct {
+	Index   IndexInfo `json:"index"`
+	Deleted int       `json:"deleted"`
+	IDs     []string  `json:"ids"`
+}
+
+// CountDocumentsRequest counts documents matching Filter. A nil filter counts
+// every service document in the index.
+type CountDocumentsRequest struct {
+	ExpectedGeneration uint64  `json:"expected_generation,omitempty"`
+	Filter             *Filter `json:"filter,omitempty"`
+}
+
+type CountDocumentsResponse struct {
+	Index IndexInfo `json:"index"`
+	Count int       `json:"count"`
+}
+
+// FilterDocumentsRequest lists documents matching Filter in stable document-ID
+// order. Limit=0 returns all matches; Offset must be non-negative.
+type FilterDocumentsRequest struct {
+	ExpectedGeneration uint64  `json:"expected_generation,omitempty"`
+	Filter             *Filter `json:"filter,omitempty"`
+	Limit              int     `json:"limit,omitempty"`
+	Offset             int     `json:"offset,omitempty"`
+	ReturnEmbedding    bool    `json:"return_embedding,omitempty"`
+}
+
+type FilterDocumentsResponse struct {
+	Index        IndexInfo  `json:"index"`
+	Documents    []Document `json:"documents"`
+	MatchedCount int        `json:"matched_count"`
+	Truncated    bool       `json:"truncated,omitempty"`
+}
+
+// DenseVectorSearchRequest runs exact dense scoring over documents that match
+// Filter. QueryEmbedding must match the index dimension.
+type DenseVectorSearchRequest struct {
+	ExpectedGeneration uint64    `json:"expected_generation,omitempty"`
+	QueryEmbedding     []float32 `json:"query_embedding"`
+	TopK               int       `json:"top_k"`
+	Filter             *Filter   `json:"filter,omitempty"`
+	ReturnEmbedding    bool      `json:"return_embedding,omitempty"`
+}
+
+type DenseVectorSearchResponse struct {
+	Index      IndexInfo  `json:"index"`
+	Documents  []Document `json:"documents"`
+	Metric     Metric     `json:"metric"`
+	Exact      bool       `json:"exact"`
+	Candidates int        `json:"candidates"`
+}
+
+func normalizeMetric(metric Metric) (Metric, error) {
+	switch strings.TrimSpace(strings.ToLower(string(metric))) {
+	case "", string(MetricCosine):
+		return MetricCosine, nil
+	case string(MetricL2):
+		return MetricL2, nil
+	case "inner_product", "inner-product", "innerproduct":
+		return MetricInnerProduct, nil
+	default:
+		return "", serviceErrorf(CodeInvalidRequest, "unsupported metric %q", metric)
+	}
+}
+
+func metricToCollection(metric Metric) (collections.VectorMetric, error) {
+	normalized, err := normalizeMetric(metric)
+	if err != nil {
+		return 0, err
+	}
+	switch normalized {
+	case MetricCosine:
+		return collections.VectorMetricCosine, nil
+	case MetricL2:
+		return collections.VectorMetricL2, nil
+	case MetricInnerProduct:
+		return collections.VectorMetricInnerProduct, nil
+	default:
+		return 0, serviceErrorf(CodeInvalidRequest, "unsupported metric %q", metric)
+	}
+}
+
+func metricFromCollection(metric collections.VectorMetric) (Metric, error) {
+	switch metric {
+	case collections.VectorMetricCosine:
+		return MetricCosine, nil
+	case collections.VectorMetricL2:
+		return MetricL2, nil
+	case collections.VectorMetricInnerProduct:
+		return MetricInnerProduct, nil
+	default:
+		return "", serviceErrorf(CodeIndexUnavailable, "unsupported stored vector metric %d", metric)
+	}
+}
+
+func indexCapabilities() IndexCapabilities {
+	return IndexCapabilities{
+		DenseVectorSearch: true,
+		ExactDenseScoring: true,
+		MetadataFilters:   true,
+		KeywordSearch:     false,
+		HybridSearch:      false,
+	}
+}
+
+func scorePtr(score float64) *float64 {
+	out := score
+	return &out
+}

--- a/cmd/treedb-document-service/main.go
+++ b/cmd/treedb-document-service/main.go
@@ -54,7 +54,8 @@ func main() {
 	fmt.Printf("TreeDB data directory: %s\n", *dataDir)
 	fmt.Printf("TreeDB profile: %s\n", normalizedProfile)
 	if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-		log.Fatalf("Server error: %v", err)
+		log.Printf("Server error: %v", err)
+		return
 	}
 }
 

--- a/cmd/treedb-document-service/main.go
+++ b/cmd/treedb-document-service/main.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/snissn/gomap/TreeDB"
+	"github.com/snissn/gomap/TreeDB/collections"
+	"github.com/snissn/gomap/TreeDB/documentservice"
+)
+
+func main() {
+	addr := flag.String("addr", "127.0.0.1:7120", "HTTP address to listen on")
+	dataDir := flag.String("dir", "/tmp/treedb-document-service", "TreeDB data directory")
+	profile := flag.String("profile", string(treedb.ProfileCommandWALDurable), "TreeDB profile: "+treedb.ProfileFlagHelp)
+	flag.Parse()
+
+	if *dataDir == "" {
+		log.Fatal("Data directory (-dir) is required")
+	}
+	normalizedProfile, err := parsePublicProfileFlag(*profile)
+	if err != nil {
+		log.Fatal(err)
+	}
+	opts := treedb.OptionsFor(normalizedProfile, *dataDir)
+	database, cleanup, err := treedb.OpenBackendWithCachedLeafLog(opts)
+	if err != nil {
+		log.Fatalf("Failed to open TreeDB: %v", err)
+	}
+	defer func() { _ = cleanup() }()
+
+	manager := collections.NewCollectionManager(database)
+	handler := documentservice.NewHandler(documentservice.New(manager))
+	server := &http.Server{Addr: *addr, Handler: handler, ReadHeaderTimeout: 5 * time.Second}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	go func() {
+		<-ctx.Done()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		_ = server.Shutdown(shutdownCtx)
+	}()
+
+	fmt.Printf("TreeDB Document Service listening on http://%s\n", *addr)
+	fmt.Printf("TreeDB data directory: %s\n", *dataDir)
+	fmt.Printf("TreeDB profile: %s\n", normalizedProfile)
+	if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		log.Fatalf("Server error: %v", err)
+	}
+}
+
+func parsePublicProfileFlag(raw string) (treedb.Profile, error) {
+	profile, ok := treedb.ParsePublicProfile(raw, treedb.ProfileCommandWALDurable)
+	if !ok {
+		return "", fmt.Errorf("unsupported TreeDB profile %q; allowed: %s", raw, treedb.ProfileFlagHelp)
+	}
+	return profile, nil
+}

--- a/cmd/treedb-document-service/main.go
+++ b/cmd/treedb-document-service/main.go
@@ -18,6 +18,13 @@ import (
 )
 
 func main() {
+	exitCode := 0
+	defer func() {
+		if exitCode != 0 {
+			os.Exit(exitCode)
+		}
+	}()
+
 	addr := flag.String("addr", "127.0.0.1:7120", "HTTP address to listen on")
 	dataDir := flag.String("dir", "/tmp/treedb-document-service", "TreeDB data directory")
 	profile := flag.String("profile", string(treedb.ProfileCommandWALDurable), "TreeDB profile: "+treedb.ProfileFlagHelp)
@@ -55,6 +62,7 @@ func main() {
 	fmt.Printf("TreeDB profile: %s\n", normalizedProfile)
 	if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		log.Printf("Server error: %v", err)
+		exitCode = 1
 		return
 	}
 }

--- a/cmd/treedb-document-service/main_test.go
+++ b/cmd/treedb-document-service/main_test.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	treedb "github.com/snissn/gomap/TreeDB"
+)
+
+func TestParsePublicProfileFlagDocumentService(t *testing.T) {
+	profile, err := parsePublicProfileFlag("command_wal_relaxed")
+	if err != nil {
+		t.Fatalf("parsePublicProfileFlag: %v", err)
+	}
+	if profile != treedb.ProfileCommandWALRelaxed {
+		t.Fatalf("profile=%q", profile)
+	}
+	if _, err := parsePublicProfileFlag("fast"); err == nil || !strings.Contains(err.Error(), treedb.ProfileFlagHelp) {
+		t.Fatalf("deprecated profile err=%v", err)
+	}
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,7 @@ TreeDB is a persistent B+Tree with a high-throughput cached write-back layer.
 - **[Profiles](TREEDB_PROFILES.md)**: High-level command-WAL, legacy-WAL, no-WAL, and benchmark option presets.
 - **[Tuning](TREEDB_TUNING.md)**: Configuration knobs for performance.
 - **[Typed-Storage Guides](../TreeDB/docs/guides/README.md)**: Collection layout quickstarts, typed-storage benchmark/profile guide, and vector typed-column guidance.
+- **[Document Service API](TREEDB_DOCUMENT_SERVICE_API.md)**: Pre-alpha Haystack-style HTTP/JSON contract for documents, metadata filters, and exact dense-vector search.
 
 ## ⚡ HashDB
 

--- a/docs/TREEDB_COLLECTION_QUICKSTART.md
+++ b/docs/TREEDB_COLLECTION_QUICKSTART.md
@@ -70,7 +70,11 @@ make that visible instead of implying the optimized path was used.
 
 ## Vector/RAG quickstart
 
-See also `cmd/treedb_vector_demo/README.md`.
+See also `cmd/treedb_vector_demo/README.md` and the pre-alpha
+[TreeDB Document Service API](TREEDB_DOCUMENT_SERVICE_API.md) for the
+Haystack-style HTTP/JSON contract. The document service's filtered dense search
+uses exact scoring as a correctness/MVP path; it is not the high-QPS
+`column_graph` ANN route described below.
 
 `cmd/treedb_vector_demo` creates a fresh TreeDB directory, declares a collection,
 loads deterministic JSON fixtures, publishes embeddings as typed-column dense

--- a/docs/TREEDB_DOCUMENT_SERVICE_API.md
+++ b/docs/TREEDB_DOCUMENT_SERVICE_API.md
@@ -1,0 +1,306 @@
+# TreeDB Document Service API (pre-alpha)
+
+Issue: [#2531](https://github.com/snissn/gomap/issues/2531). Parent tracker:
+[#2530](https://github.com/snissn/gomap/issues/2530).
+
+This is the smallest TreeDB document/search service contract intended for the
+Python client and the first Haystack integration. TreeDB is **pre-alpha**:
+request/response fields and on-disk collection layouts may change before a
+stable release.
+
+## Running the service
+
+```sh
+go run ./cmd/treedb-document-service \
+  -dir /tmp/treedb-document-service \
+  -addr 127.0.0.1:7120 \
+  -profile command_wal_durable
+```
+
+The command opens TreeDB with the selected public profile and serves the routes
+below. `GET /v1/health` returns the current `contract_version`.
+
+## Scope and honesty
+
+Supported now:
+
+- create/open a document index;
+- upsert Haystack-style documents;
+- delete by ID or metadata filter;
+- count/filter/list documents;
+- exact dense-vector search with metadata filters;
+- optional embedding echo in returned documents.
+
+Not supported now:
+
+- keyword search;
+- hybrid search;
+- text ranking/BM25/BM25F;
+- client-side or service-side full-document scan fallbacks for keyword/hybrid.
+
+Keyword and hybrid routes return `unsupported`/HTTP 501. This matches current
+TreeDB core behavior: `SearchText` and `SearchHybrid` fail closed until ranked
+text and hybrid executors land.
+
+Dense-vector search in this service is an **exact scoring correctness/MVP path**.
+It scans service documents that match the metadata filter and scores their stored
+embeddings. It is not the high-QPS `column_graph` ANN route documented in the
+TreeDB vector-search guides, and this contract makes no ANN throughput claim.
+
+## Haystack document mapping
+
+Service documents use Haystack-compatible fields:
+
+```json
+{
+  "id": "doc-1",
+  "content": "body text",
+  "embedding": [0.1, 0.2, 0.3],
+  "meta": {
+    "repo": "snissn/gomap",
+    "path": "TreeDB/documentservice/service.go",
+    "language": "go",
+    "symbol": "SearchDenseVector",
+    "start_line": 120,
+    "end_line": 180,
+    "chunk_kind": "function"
+  },
+  "score": 0.99
+}
+```
+
+`score` is response-only. `embedding` is required on upsert for this dense-search
+MVP. Responses omit embeddings unless `return_embedding=true`.
+
+TreeDB stores each service index as a JSON collection. The document ID is the
+TreeDB collection key and the JSON `id` field is kept for client compatibility.
+
+## Indexes
+
+Create an index:
+
+```http
+POST /v1/indexes
+```
+
+Request:
+
+```json
+{
+  "name": "docs",
+  "dimension": 768,
+  "metric": "cosine"
+}
+```
+
+`metric` defaults to `cosine`. Supported metrics are `cosine`, `l2`, and
+`inner_product`. Scores are always higher-is-better:
+
+- cosine: cosine similarity;
+- l2: negative squared L2 distance;
+- inner_product: dot product.
+
+Open/read index metadata:
+
+```http
+GET /v1/indexes/{index}
+```
+
+Responses include:
+
+```json
+{
+  "index": {
+    "name": "docs",
+    "dimension": 768,
+    "metric": "cosine",
+    "generation": 1,
+    "contract_version": "treedb-document-service/v1alpha1",
+    "embedding_field": "embedding",
+    "document_type": "treedb_document_service_v1",
+    "capabilities": {
+      "dense_vector_search": true,
+      "exact_dense_scoring": true,
+      "metadata_filters": true,
+      "keyword_search": false,
+      "hybrid_search": false
+    }
+  }
+}
+```
+
+Operations may include `expected_generation`. If it does not match the current
+index generation, the service returns `index_stale` rather than running against a
+caller-stale contract.
+
+## Write documents
+
+```http
+POST /v1/indexes/{index}/documents/upsert
+```
+
+```json
+{
+  "expected_generation": 1,
+  "documents": [
+    {
+      "id": "doc-1",
+      "content": "body text",
+      "embedding": [0.1, 0.2, 0.3],
+      "meta": {"repo": "snissn/gomap", "language": "go"}
+    }
+  ]
+}
+```
+
+Duplicate IDs in one request, missing embeddings, non-finite vector values, and
+dimension mismatches fail with `invalid_request`.
+
+## Delete documents
+
+Delete by ID:
+
+```http
+POST /v1/indexes/{index}/documents/delete
+```
+
+```json
+{"ids": ["doc-1", "doc-2"]}
+```
+
+Delete by metadata filter:
+
+```json
+{"filter": {"field": "meta.repo", "operator": "==", "value": "snissn/gomap"}}
+```
+
+Supplying both `ids` and `filter` is rejected as ambiguous.
+
+## Count and filter/list documents
+
+Count:
+
+```http
+POST /v1/indexes/{index}/documents/count
+```
+
+```json
+{"filter": {"field": "meta.language", "operator": "==", "value": "go"}}
+```
+
+Filter/list:
+
+```http
+POST /v1/indexes/{index}/documents/filter
+```
+
+```json
+{
+  "filter": {"field": "meta.repo", "operator": "==", "value": "snissn/gomap"},
+  "limit": 100,
+  "offset": 0,
+  "return_embedding": false
+}
+```
+
+`limit=0` means no service-side result cap. Results are returned in stable
+TreeDB document-ID order.
+
+## Metadata filters
+
+Filter nodes use this shape:
+
+```json
+{"field": "meta.language", "operator": "==", "value": "go"}
+```
+
+Boolean nodes use `conditions`:
+
+```json
+{
+  "operator": "AND",
+  "conditions": [
+    {"field": "meta.repo", "operator": "==", "value": "snissn/gomap"},
+    {"field": "meta.start_line", "operator": ">=", "value": 100}
+  ]
+}
+```
+
+Supported operators:
+
+- boolean: `AND`, `OR`, `NOT`;
+- comparison: `==`, `!=`, `>`, `>=`, `<`, `<=`;
+- membership: `in`, `not in`.
+
+Fields may be `id`, `content`, `meta.<path>`, or a metadata path without the
+`meta.` prefix. Missing fields do not match any operator, including `!=` and
+`not in`, so filters fail closed rather than broadening result sets. Comparison
+operators require numeric or string operands. Membership values must be arrays.
+Unsupported operators fail with `invalid_request`; the service does not rewrite
+unsupported filters into broader scans.
+
+## Dense-vector search
+
+```http
+POST /v1/indexes/{index}/search/vector
+```
+
+```json
+{
+  "query_embedding": [0.1, 0.2, 0.3],
+  "top_k": 10,
+  "filter": {"field": "meta.repo", "operator": "==", "value": "snissn/gomap"},
+  "return_embedding": false
+}
+```
+
+Response:
+
+```json
+{
+  "metric": "cosine",
+  "exact": true,
+  "candidates": 42,
+  "documents": [
+    {
+      "id": "doc-1",
+      "content": "body text",
+      "meta": {"repo": "snissn/gomap"},
+      "score": 0.991
+    }
+  ]
+}
+```
+
+Tie order is deterministic: higher score first, then document ID ascending.
+
+## Keyword and hybrid fail-closed routes
+
+These endpoints are reserved for downstream clients but are not implemented:
+
+```http
+POST /v1/indexes/{index}/search/keyword
+POST /v1/indexes/{index}/search/hybrid
+```
+
+They return HTTP 501 with `unsupported`. They do **not** scan all documents or
+silently downgrade to vector-only/text-only behavior.
+
+## Error envelope
+
+Errors use a stable code/message envelope:
+
+```json
+{"error": {"code": "invalid_request", "message": "top_k must be positive"}}
+```
+
+Codes used by this contract:
+
+- `invalid_request`
+- `malformed_json`
+- `index_not_found`
+- `index_unavailable`
+- `index_stale`
+- `conflict`
+- `unsupported`
+- `internal`


### PR DESCRIPTION
## Objective

Closes #2531. Part of #2530.

Define and expose the smallest pre-alpha TreeDB document/search service contract needed by the Python client and Haystack workstream.

## Context

TreeDB already has collection/document and vector-search APIs, but Python/Haystack clients needed a documented service seam that does not depend on private Go internals. Haystack expects documents with `id`, `content`, `embedding`, `score`, and `meta`, plus metadata filters and embedding search.

## Non-goals

- No keyword search implementation.
- No hybrid search implementation.
- No text/hybrid full-document scan fallback.
- No native Python binding.
- No high-QPS `column_graph` ANN claim for this service path.

## Design

- Adds `TreeDB/documentservice` with typed Go request/response structs and an HTTP/JSON handler.
- Adds `cmd/treedb-document-service` to serve the contract over HTTP.
- Maps Haystack-style documents to JSON TreeDB collections keyed by document ID.
- Persists index dimension/metric in collection vector-index metadata.
- Supports metadata filters: `AND`, `OR`, `NOT`, `==`, `!=`, `>`, `>=`, `<`, `<=`, `in`, `not in`.
- Dense vector search uses exact scoring over documents matching the metadata filter. Scores are higher-is-better.
- Keyword and hybrid HTTP routes are reserved but return `unsupported`/501 without scanning.
- Adds optional `expected_generation` guards so stale client index metadata can fail closed.

## Scope

Changed files are limited to:

- new `TreeDB/documentservice` package and tests;
- new `cmd/treedb-document-service` command and tests;
- `docs/TREEDB_DOCUMENT_SERVICE_API.md` plus doc index/quickstart links.

## Correctness

Covered by Go tests for:

- schema validation and unsupported filter/operator errors;
- upsert/delete/count/filter round trips;
- dense-vector search stable IDs, scores, metadata, and optional embeddings;
- persistence/reopen of documents and embeddings;
- dimension mismatch, missing embedding, stale generation, unavailable index, malformed JSON, and unsupported keyword/hybrid calls.

## Performance

No existing TreeDB storage/search hot path was changed. The new service search path is explicitly documented as exact dense scoring for correctness/MVP use, not the high-QPS `column_graph` ANN route. No benchmark was required.

## Rollout/Toggle Plan

Pre-alpha additive surface only. Users opt in by running `cmd/treedb-document-service` and creating a service index. Existing TreeDB collection/native-wire/vector APIs are unchanged.

## Follow-ups

- #2532 can implement the Python client against this HTTP/JSON contract.
- #2533 can use that Python client for the Haystack DocumentStore + embedding retriever MVP.
- #2534 remains blocked on real TreeDB ranked text/hybrid execution and must not claim keyword/hybrid support yet.
- #2535 should wait for stable package/client facts before listing docs.

## Tests

- `go test ./TreeDB/documentservice ./cmd/treedb-document-service`
- `go test ./TreeDB/collections ./TreeDB/documentservice ./cmd/treedb-document-service`
- `go test ./TreeDB/docs`
- `go test ./...`

## AI review status

Requested after PR creation once latest-head CI was running:

- Codex: requested via PR comment.
- Copilot: requested via PR comment.
- CodeRabbit: pending/auto-started and re-requested via PR comment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced TreeDB Document Service: a new HTTP/JSON API for document management and vector search operations compatible with Haystack format.
  * Added document operations: upsert, delete, count, and filter with metadata-based filtering support.
  * Implemented dense vector search with exact scoring and optional metadata filtering.
  * Added standalone command-line service to run the document service.

* **Documentation**
  * Added comprehensive API documentation including endpoints, request/response schemas, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->