### PR TITLE
TreeDB: default checkpoint-kick hot-debt guard

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -2058,11 +2058,12 @@ const (
 	// 0 keeps legacy behavior (no iterator-sample gate).
 	envAdaptiveBTreeMinIteratorSamples = "TREEDB_ADAPTIVE_BTREE_MIN_ITERATOR_SAMPLES"
 	// Generational maintenance toggles (forensics / isolation).
-	envDisableVlogGenerationRewrite        = "TREEDB_DISABLE_VLOG_GENERATION_REWRITE"
-	envDisableVlogGenerationGC             = "TREEDB_DISABLE_VLOG_GENERATION_GC"
-	envDisableVlogGenerationVacuum         = "TREEDB_DISABLE_VLOG_GENERATION_VACUUM"
-	envDisableVlogGenerationLoop           = "TREEDB_DISABLE_VLOG_GENERATION_LOOP"
-	envDisableVlogGenerationCheckpointKick = "TREEDB_DISABLE_VLOG_GENERATION_CHECKPOINT_KICK"
+	envDisableVlogGenerationRewrite                   = "TREEDB_DISABLE_VLOG_GENERATION_REWRITE"
+	envDisableVlogGenerationGC                        = "TREEDB_DISABLE_VLOG_GENERATION_GC"
+	envDisableVlogGenerationVacuum                    = "TREEDB_DISABLE_VLOG_GENERATION_VACUUM"
+	envDisableVlogGenerationLoop                      = "TREEDB_DISABLE_VLOG_GENERATION_LOOP"
+	envDisableVlogGenerationCheckpointKick            = "TREEDB_DISABLE_VLOG_GENERATION_CHECKPOINT_KICK"
+	envDisableVlogGenerationCheckpointKickHotDebtOnly = "TREEDB_DISABLE_VLOG_GENERATION_CHECKPOINT_KICK_HOT_DEBT_ONLY"
 	// Experimental immutable-leaf maintenance hook. Disabled by default until
 	// the cached scheduler policy and dwell behavior are validated.
 	envEnableLeafGenerationPackMaintenance                     = "TREEDB_ENABLE_LEAF_GENERATION_PACK_MAINTENANCE"
@@ -2084,11 +2085,9 @@ const (
 	envVlogGenerationHotSegmentTargetBytes  = "TREEDB_VLOG_GENERATION_HOT_SEGMENT_TARGET_BYTES"
 	envVlogGenerationWarmSegmentTargetBytes = "TREEDB_VLOG_GENERATION_WARM_SEGMENT_TARGET_BYTES"
 	envVlogGenerationColdSegmentTargetBytes = "TREEDB_VLOG_GENERATION_COLD_SEGMENT_TARGET_BYTES"
-	// Experimental WAL-off checkpoint-kick guard: when enabled, avoid starting
-	// fresh rewrite planning during hot foreground activity. Queued rewrite debt
-	// (or deferred maintenance due) remains eligible so resumable progress is not
-	// starved.
-	envEnableVlogGenerationCheckpointKickHotDebtOnly = "TREEDB_ENABLE_VLOG_GENERATION_CHECKPOINT_KICK_HOT_DEBT_ONLY"
+	// WAL-off checkpoint-kick guard: by default, avoid starting fresh rewrite
+	// planning during hot foreground activity. Queued rewrite debt (or deferred
+	// maintenance due) remains eligible so resumable progress is not starved.
 	// Experimental WAL-off override: allow rewrite planning/execution before the
 	// first explicit checkpoint. Disabled by default because it can add restore
 	// contention during early state-sync.
@@ -20195,9 +20194,10 @@ func (db *DB) maybeKickVlogGenerationMaintenanceAfterCheckpoint() {
 		}
 		rewriteQueueLen = len(rewriteQueue)
 	}
-	if envBool(envEnableVlogGenerationCheckpointKickHotDebtOnly) && !rewriteDisabled {
+	if !envBool(envDisableVlogGenerationCheckpointKickHotDebtOnly) && !rewriteDisabled {
 		quiet := db.foregroundActivityQuietFor(now, vlogGenerationMaintenanceQuietWindow, vlogForegroundReadQuietWindow)
-		if !quiet && rewriteQueueLen == 0 && !db.vlogGenerationDeferredMaintenanceDue(now) {
+		deferredDue := db.vlogGenerationDeferredMaintenanceDue(now)
+		if !quiet && rewriteQueueLen == 0 && !deferredDue {
 			db.vlogGenerationCheckpointKickSkippedHotNoDebt.Add(1)
 			db.scheduleVlogGenerationCheckpointKickHotNoDebtWake()
 			db.debugVlogMaintf(
@@ -20206,7 +20206,7 @@ func (db *DB) maybeKickVlogGenerationMaintenanceAfterCheckpoint() {
 				rewriteQueueLen,
 				db.vlogGenerationCheckpointKickPending.Load(),
 				db.vlogGenerationDeferredMaintenancePending.Load(),
-				db.vlogGenerationDeferredMaintenanceDue(now),
+				deferredDue,
 				db.vlogGenerationCheckpointKickHotNoDebtWakeRunning.Load(),
 			)
 			return

--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -20183,6 +20183,7 @@ func (db *DB) maybeKickVlogGenerationMaintenanceAfterCheckpoint() {
 	now := time.Now()
 	rewriteDisabled := envBool(envDisableVlogGenerationRewrite)
 	rewriteQueueLen := 0
+	rewriteQueueEligibleLen := 0
 	if !rewriteDisabled {
 		rewriteQueue, qerr := db.currentVlogGenerationRewriteQueue()
 		if qerr != nil {
@@ -20193,17 +20194,30 @@ func (db *DB) maybeKickVlogGenerationMaintenanceAfterCheckpoint() {
 			return
 		}
 		rewriteQueueLen = len(rewriteQueue)
+		rewriteQueueEligibleLen = rewriteQueueLen
+		if rewriteQueueLen > 0 {
+			rewriteQueueEligible, _, qerr := db.currentVlogGenerationRewriteEligible(now)
+			if qerr != nil {
+				db.vlogGenerationSchedulerState.Store(vlogGenerationSchedulerError)
+				if db.notifyError != nil {
+					db.notifyError(fmt.Errorf("cachingdb: load eligible generational rewrite queue for checkpoint kick: %w", qerr))
+				}
+				return
+			}
+			rewriteQueueEligibleLen = len(rewriteQueueEligible)
+		}
 	}
 	if !envBool(envDisableVlogGenerationCheckpointKickHotDebtOnly) && !rewriteDisabled {
 		quiet := db.foregroundActivityQuietFor(now, vlogGenerationMaintenanceQuietWindow, vlogForegroundReadQuietWindow)
 		deferredDue := db.vlogGenerationDeferredMaintenanceDue(now)
-		if !quiet && rewriteQueueLen == 0 && !deferredDue {
+		if !quiet && rewriteQueueEligibleLen == 0 && !deferredDue {
 			db.vlogGenerationCheckpointKickSkippedHotNoDebt.Add(1)
 			db.scheduleVlogGenerationCheckpointKickHotNoDebtWake()
 			db.debugVlogMaintf(
-				"checkpoint_kick_skip reason=foreground_hot_no_debt quiet=%t queue_len=%d checkpoint_pending=%t deferred_pending=%t deferred_due=%t hot_no_debt_wake_running=%t",
+				"checkpoint_kick_skip reason=foreground_hot_no_debt quiet=%t queue_len=%d eligible_queue_len=%d checkpoint_pending=%t deferred_pending=%t deferred_due=%t hot_no_debt_wake_running=%t",
 				quiet,
 				rewriteQueueLen,
+				rewriteQueueEligibleLen,
 				db.vlogGenerationCheckpointKickPending.Load(),
 				db.vlogGenerationDeferredMaintenancePending.Load(),
 				deferredDue,

--- a/TreeDB/caching/vlog_generation_scheduler_test.go
+++ b/TreeDB/caching/vlog_generation_scheduler_test.go
@@ -7863,6 +7863,57 @@ func TestCheckpoint_KickHotDebtOnlySkipsFreshPlanDuringRecentForegroundActivity(
 	}
 }
 
+func TestCheckpoint_KickHotDebtOnlySkipsFreshPlanWhenQueuedDebtCooling(t *testing.T) {
+	disableVlogGenerationLoop(t)
+
+	dir := t.TempDir()
+
+	backend, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open backend: %v", err)
+	}
+	recorder := &rewriteBudgetRecordingBackend{
+		DB: backend,
+		planResponse: backenddb.ValueLogRewritePlan{
+			SourceFileIDs:     []uint32{22},
+			SelectedBytesLive: 128,
+		},
+		rewriteResponse: backenddb.ValueLogRewriteStats{BytesBefore: 64, BytesAfter: 32, RecordsCopied: 1},
+	}
+
+	db, cleanup := openRewriteQueueTestDB(t, dir, recorder)
+	t.Cleanup(cleanup)
+	skipRetainedPrune(db)
+	db.testSkipVlogCheckpointKick = false
+	if err := db.setVlogGenerationRewriteQueue([]uint32{11}); err != nil {
+		t.Fatalf("seed rewrite queue: %v", err)
+	}
+	if err := db.recordVlogGenerationRewritePenalty([]uint32{11}, time.Now().Add(time.Minute), 64); err != nil {
+		t.Fatalf("record rewrite penalty: %v", err)
+	}
+
+	hot := time.Now().UnixNano()
+	db.lastForegroundWriteUnixNano.Store(hot)
+	db.lastForegroundReadUnixNano.Store(hot)
+
+	db.maybeKickVlogGenerationMaintenanceAfterCheckpoint()
+
+	time.Sleep(150 * time.Millisecond)
+	if _, calls := recorder.recordedPlan(); calls != 0 {
+		t.Fatalf("plan calls=%d want 0 while queued debt is cooling", calls)
+	}
+	if _, calls := recorder.recordedRewrite(); calls != 0 {
+		t.Fatalf("rewrite calls=%d want 0 while queued debt is cooling", calls)
+	}
+	stats := db.Stats()
+	if got := stats["treedb.cache.vlog_generation.checkpoint_kick.runs"]; got != "0" {
+		t.Fatalf("checkpoint kick runs=%q want 0", got)
+	}
+	if got := stats["treedb.cache.vlog_generation.checkpoint_kick.skipped_hot_no_debt"]; got != "1" {
+		t.Fatalf("checkpoint kick skipped_hot_no_debt=%q want 1", got)
+	}
+}
+
 func TestCheckpoint_KickHotDebtOnlyWakeRunsAfterForegroundQuiets(t *testing.T) {
 	disableVlogGenerationLoop(t)
 

--- a/TreeDB/caching/vlog_generation_scheduler_test.go
+++ b/TreeDB/caching/vlog_generation_scheduler_test.go
@@ -7735,8 +7735,11 @@ func TestVlogGenerationRewrite_IneffectiveBackoffExpires(t *testing.T) {
 	}
 }
 
-func TestCheckpoint_KicksVlogGenerationRewriteDespiteRecentForegroundActivity(t *testing.T) {
+func TestCheckpoint_KickHotDebtOnlyGuardCanBeDisabled(t *testing.T) {
+	// Keep an emergency rollback knob for live experiments that need the legacy
+	// checkpoint-kick behavior.
 	disableVlogGenerationLoop(t)
+	t.Setenv(envDisableVlogGenerationCheckpointKickHotDebtOnly, "1")
 
 	dir := t.TempDir()
 
@@ -7817,7 +7820,6 @@ func TestCheckpoint_KicksVlogGenerationRewriteDespiteRecentForegroundActivity(t 
 
 func TestCheckpoint_KickHotDebtOnlySkipsFreshPlanDuringRecentForegroundActivity(t *testing.T) {
 	disableVlogGenerationLoop(t)
-	t.Setenv(envEnableVlogGenerationCheckpointKickHotDebtOnly, "1")
 
 	dir := t.TempDir()
 
@@ -7863,7 +7865,6 @@ func TestCheckpoint_KickHotDebtOnlySkipsFreshPlanDuringRecentForegroundActivity(
 
 func TestCheckpoint_KickHotDebtOnlyWakeRunsAfterForegroundQuiets(t *testing.T) {
 	disableVlogGenerationLoop(t)
-	t.Setenv(envEnableVlogGenerationCheckpointKickHotDebtOnly, "1")
 
 	dir := t.TempDir()
 
@@ -8045,7 +8046,6 @@ func TestCheckpoint_KicksQueuedRewriteDebtBelowTriggerFloor(t *testing.T) {
 
 func TestCheckpoint_KickHotDebtOnlyStillRunsQueuedRewriteDebtDuringRecentForegroundActivity(t *testing.T) {
 	disableVlogGenerationLoop(t)
-	t.Setenv(envEnableVlogGenerationCheckpointKickHotDebtOnly, "1")
 
 	dir := t.TempDir()
 

--- a/docs/TREEDB_VLOG_GENERATIONAL_RUNBOOK.md
+++ b/docs/TREEDB_VLOG_GENERATIONAL_RUNBOOK.md
@@ -209,11 +209,11 @@ Additional reporting:
   - Allows rewrite planning/execution before the first explicit checkpoint.
   - Default is disabled to avoid adding early restore contention.
   - Use for controlled `run_celestia` experiments when `maintenance.skip.before_first_checkpoint` dominates and live rewrite never starts.
-- `TREEDB_ENABLE_VLOG_GENERATION_CHECKPOINT_KICK_HOT_DEBT_ONLY=1`
+- `TREEDB_DISABLE_VLOG_GENERATION_CHECKPOINT_KICK_HOT_DEBT_ONLY=1`
   - WAL-off only.
-  - During checkpoint-kick maintenance, skips starting a fresh rewrite plan while foreground activity is hot and rewrite queue debt is empty.
-  - Still allows queued rewrite debt (and deferred-due passes) to run.
-  - Default is disabled.
+  - By default, checkpoint-kick maintenance skips starting a fresh rewrite plan while foreground activity is hot and rewrite queue debt is empty.
+  - Queued rewrite debt and deferred-due passes still run.
+  - Set this disable knob only for controlled rollback experiments that need the legacy checkpoint-kick fresh-plan behavior.
 - Optional debt-drain cap overrides (for controlled experiments):
   - `TREEDB_VLOG_GENERATION_REWRITE_RESUME_MAX_SEGMENTS`
   - `TREEDB_VLOG_GENERATION_REWRITE_DEBT_DRAIN_MAX_SEGMENTS`

--- a/docs/benchmarks/CELESTIA_CHECKPOINT_KICK_HOT_DEBT_ONLY_2026-03-28.md
+++ b/docs/benchmarks/CELESTIA_CHECKPOINT_KICK_HOT_DEBT_ONLY_2026-03-28.md
@@ -4,15 +4,15 @@
 Reduce `run_celestia` sync wall-time regression from live value-log maintenance while preserving on-disk size gains.
 
 ## Change Under Test
-Candidate enables:
+Candidate enabled the then-experimental hot-debt-only checkpoint-kick guard:
 
-- `TREEDB_ENABLE_VLOG_GENERATION_CHECKPOINT_KICK_HOT_DEBT_ONLY=1`
+- historical env: `TREEDB_ENABLE_VLOG_GENERATION_CHECKPOINT_KICK_HOT_DEBT_ONLY=1`
+- current default: the guard is enabled by default; use `TREEDB_DISABLE_VLOG_GENERATION_CHECKPOINT_KICK_HOT_DEBT_ONLY=1` only for rollback experiments.
 
 Behavior:
 
 - In WAL-off checkpoint-kick path, if foreground is hot and rewrite queue is empty, skip starting a fresh rewrite plan.
 - Queued rewrite debt and deferred-due maintenance still run.
-- Default behavior remains unchanged unless this env flag is set.
 
 ## Commands
 Both campaigns used fixed trust/target and a single interleaved pair (`MAX_PAIRS=1`) with offline rewrite enabled.
@@ -30,7 +30,7 @@ Common env (both variants):
 Variant-specific env:
 
 - `main`: `LOCAL_GOMAP_DIR=/tmp/gomap_ab_base_20260328162444`
-- `hot_debt_only`: `LOCAL_GOMAP_DIR=/home/mikers/dev/snissn/gomap-phasehook-active` + `TREEDB_ENABLE_VLOG_GENERATION_CHECKPOINT_KICK_HOT_DEBT_ONLY=1`
+- `hot_debt_only`: `LOCAL_GOMAP_DIR=/home/mikers/dev/snissn/gomap-phasehook-active` + historical `TREEDB_ENABLE_VLOG_GENERATION_CHECKPOINT_KICK_HOT_DEBT_ONLY=1`
 
 Harness:
 


### PR DESCRIPTION
## Objective

Make the WAL-off TreeDB value-log generation checkpoint-kick path default to the previously experimental hot-debt-only guard: during hot foreground activity, skip fresh rewrite planning when there is no queued rewrite debt.

## Context

A 90-minute Sepolia TreeDB run on geth commit `ff3b31e9` plateaued while a live CPU profile was dominated by checkpoint-triggered TreeDB rewrite planning:

- run: `/mnt/fast4tb/tmp/geth-treedb-exp/run_20260607T164851Z_sepolia_treedb_after_default`
- profile: `stall_profiles_20260607T181156Z/cpu_60s.pprof`
- hot path: `schedulePendingVlogGenerationCheckpointKick -> ValueLogRewritePlan -> collectValueLogLiveBytes -> tree.Iterator.Next/loadCurrent`
- focused profile: `collectValueLogLiveBytes` accounted for ~25.1s / 80.1% cumulative of the 60s sample.

This path was a fresh sparse rewrite plan with no queued rewrite debt, so it could spend a full index/value-log scan competing with geth snap sync work. The older Celestia hot-debt-only gate already encoded the intended behavior but was opt-in.

## Non-goals

- Does not change value-log on-disk formats.
- Does not disable queued rewrite debt execution.
- Does not change retained-prune safety behavior.
- Does not claim Sepolia full-sync readiness.

## Design

- Default the checkpoint-kick hot-debt-only guard on for WAL-off generation maintenance.
- Add `TREEDB_DISABLE_VLOG_GENERATION_CHECKPOINT_KICK_HOT_DEBT_ONLY=1` as a rollback/forensics knob for legacy behavior.
- The guard only skips when:
  - foreground activity is not quiet,
  - rewrite queue debt is empty,
  - no deferred generation maintenance is due.
- Queued rewrite debt and deferred-due stage/age passes remain eligible.
- The existing quiet wake remains in place so skipped fresh planning gets retried once the foreground quiet window is met.

## Scope

- Includes:
  - `TreeDB/caching/db.go`
  - `TreeDB/caching/vlog_generation_scheduler_test.go`
  - `docs/TREEDB_VLOG_GENERATIONAL_RUNBOOK.md`
  - `docs/benchmarks/CELESTIA_CHECKPOINT_KICK_HOT_DEBT_ONLY_2026-03-28.md`
- Excludes:
  - geth adapter changes
  - public API changes
  - value-log format changes

## Correctness

Tests run:

- `go test ./TreeDB/caching -run 'TestCheckpoint_Kick|TestCheckpoint_DoesNotKickVlogGenerationRewrite_WALOn|TestVlogGenerationRewrite_IneffectiveBackoffExpires' -count=1` ✅
- `go test ./TreeDB/caching -run 'TestCheckpoint_KickHotDebtOnly|TestCheckpoint_KickHotDebtOnlyGuardCanBeDisabled|TestCheckpoint_DoesNotKickVlogGenerationRewrite_WALOn' -count=1` ✅
- `go test ./TreeDB/caching -count=1` ✅
- `go test ./TreeDB/... -count=1` attempted locally, but the macOS temp volume filled (`no space left on device`) after the focused package already passed. CI latest-head broad coverage passed.
- Remote geth with PR dependency `ae7828b53ff7`: `go test ./ethdb/treedb ./core/rawdb ./node ./cmd/utils -count=1` ✅
- Remote geth with PR dependency `ae7828b53ff7`: `go test ./cmd/geth -run TestCustomBackend -count=1` ✅
- Remote geth with PR dependency `ae7828b53ff7`: `make geth` ✅

Covered behavior:

- Default hot/no-debt checkpoint kick skips fresh planning.
- Quiet wake retries and runs once foreground activity quiets.
- Queued rewrite debt still runs during recent foreground activity.
- Disable env restores legacy checkpoint-kick fresh-plan behavior.

## Performance

Profile evidence from Sepolia TreeDB run before this PR:

| Profile | Hot path | Focused cumulative cost |
|---|---|---:|
| `stall_profiles_20260607T181156Z/cpu_60s.pprof` | `checkpoint_pending -> ValueLogRewritePlan -> collectValueLogLiveBytes -> Iterator.Next/loadCurrent` | ~25.1s / 80.1% |

This PR avoids launching that fresh full-scan planning path from checkpoint kicks while geth foreground work is still hot and there is no queued rewrite debt to drain.

## Rollout / Toggle Plan

- Default setting: guard enabled.
- Disable quickly: `TREEDB_DISABLE_VLOG_GENERATION_CHECKPOINT_KICK_HOT_DEBT_ONLY=1`.
- Observability: existing stats remain:
  - `treedb.cache.vlog_generation.checkpoint_kick.skipped_hot_no_debt`
  - `treedb.cache.vlog_generation.checkpoint_kick.hot_no_debt_wake.runs`
  - `treedb.cache.vlog_generation.checkpoint_kick.runs`

## Follow-ups

- Continue #2392 with the remaining Sepolia hot paths, especially periodic `ValueLogGC` full scans and geth `HasHeader -> TreeDB.Has` throughput.
- Rerun the TreeDB Sepolia experiment after merging and bumping downstream geth.

## AI Review Loop

- Codex latest-head review: passed after fixing the initial eligible-queue finding in `ae7828b53ff7`.
- Copilot latest-head review: requested; no findings posted.
- CodeRabbit latest-head review: status passed; manual re-request reported review finished after initial rate limit.
- Review comments/threads resolved or explicitly dismissed: all resolved.
- Re-requested after final meaningful push: yes.

