### PR TITLE
Add RaBitQ vector DB comparator rows

### DIFF
--- a/benchmarks/vector_db_compare/README.md
+++ b/benchmarks/vector_db_compare/README.md
@@ -4,8 +4,8 @@ This benchmark compares persistent database-tier ANN search:
 
 - TreeDB native persisted HNSW via `cmd/treedb_vector_search_demo`
 - TreeDB `column_graph` full-vector exact/default HNSW via the same demo
-- TreeDB `column_graph` scalar_u8 `quantized_only` and `quantized_rerank`
-  query modes via explicit demo flags
+- TreeDB `column_graph` scalar_u8 and rabitq_1bit `quantized_only` and
+  `quantized_rerank` query modes via explicit demo flags
 - SQLite with the Vectorlite loadable extension, backed by hnswlib/HNSW
 - PostgreSQL with pgvector full-vector HNSW
 - MongoDB Vector Search HNSW when pointed at Atlas or a local Atlas deployment
@@ -26,8 +26,8 @@ scripts/bench_vector_db_compare.sh
 ```
 
 The default backend set is `treedb,vectorlite`. Add `treedb_column_graph`, the
-TreeDB quantized aliases, `pgvector`, or `mongodb` to `BACKENDS` when those
-paths or external services are needed.
+TreeDB scalar_u8/RaBitQ quantized aliases, `pgvector`, or `mongodb` to
+`BACKENDS` when those paths or external services are needed.
 
 Useful overrides:
 
@@ -42,19 +42,21 @@ SEARCH_CONCURRENCY=2,4,8,16,32,64,128 \
 scripts/bench_vector_db_compare.sh
 ```
 
-TreeDB exact vs quantized column-graph comparison:
+TreeDB exact vs scalar_u8/RaBitQ quantized column-graph comparison:
 
 ```sh
 RUN_DIR=/tmp/vector_db_compare_quantized \
-BACKENDS=treedb_column_graph,treedb_column_graph_quantized_only,treedb_column_graph_quantized_rerank,pgvector \
+BACKENDS=treedb_column_graph,treedb_column_graph_scalar_u8_quantized_only,treedb_column_graph_scalar_u8_quantized_rerank,treedb_column_graph_rabitq_1bit_quantized_only,treedb_column_graph_rabitq_1bit_quantized_rerank,pgvector \
 DOCS=10000 \
 DIMS=128 \
 QUERIES=10000 \
 VALIDATE_QUERIES=64 \
 TOP_K=10 \
 EF_SEARCH=128 \
-TREEDB_QUANTIZED_INDEX_NAME=embedding.scalar_u8.fast \
+TREEDB_SCALAR_U8_QUANTIZED_INDEX_NAME=embedding.scalar_u8.fast \
+TREEDB_RABITQ_QUANTIZED_INDEX_NAME=embedding.rabitq_1bit.fast \
 TREEDB_QUANTIZED_RERANK_CANDIDATES=32 \
+TREEDB_RABITQ_QUANTIZED_RERANK_CANDIDATES=32 \
 TREEDB_QUANTIZED_MIN_RECALL=0 \
 scripts/bench_vector_db_compare.sh
 ```
@@ -72,12 +74,26 @@ Backends:
 - `treedb`: runs the TreeDB native persisted vector index benchmark.
 - `treedb_column_graph`: runs TreeDB `column_graph` exact/default full-vector
   graph search.
-- `treedb_column_graph_quantized_only`: runs TreeDB `column_graph` with a named
-  scalar_u8 score plane and `query_mode=quantized_only`.
-- `treedb_column_graph_quantized_rerank`: runs TreeDB `column_graph` with a
-  named scalar_u8 score plane and `query_mode=quantized_rerank`, exact-reranking
-  `TREEDB_QUANTIZED_RERANK_CANDIDATES` candidates (or the demo's normalized
-  `ef_search` set when set to `0`).
+- `treedb_column_graph_quantized_only`: compatibility alias for a TreeDB
+  `column_graph` quantized-only row using `TREEDB_QUANTIZED_CODEC` and
+  `TREEDB_QUANTIZED_INDEX_NAME` (defaults to scalar_u8).
+- `treedb_column_graph_quantized_rerank`: compatibility alias for a TreeDB
+  `column_graph` quantized-rerank row using `TREEDB_QUANTIZED_CODEC` and
+  `TREEDB_QUANTIZED_INDEX_NAME` (defaults to scalar_u8).
+- `treedb_column_graph_scalar_u8_quantized_only`: runs TreeDB `column_graph`
+  with a named scalar_u8 score plane and `query_mode=quantized_only`.
+- `treedb_column_graph_scalar_u8_quantized_rerank`: runs TreeDB `column_graph`
+  with a named scalar_u8 score plane and `query_mode=quantized_rerank`,
+  exact-reranking `TREEDB_QUANTIZED_RERANK_CANDIDATES` candidates (or the
+  demo's normalized `ef_search` set when set to `0`).
+- `treedb_column_graph_rabitq_1bit_quantized_only`: runs TreeDB `column_graph`
+  with a named RaBitQ `rabitq_1bit` score plane and
+  `query_mode=quantized_only`.
+- `treedb_column_graph_rabitq_1bit_quantized_rerank`: runs TreeDB
+  `column_graph` with a named RaBitQ `rabitq_1bit` score plane and
+  `query_mode=quantized_rerank`, exact-reranking
+  `TREEDB_RABITQ_QUANTIZED_RERANK_CANDIDATES` candidates (or the demo's
+  normalized `ef_search` set when set to `0`).
 - `vectorlite`: runs SQLite+Vectorlite with its persisted HNSW sidecar file.
 - `pgvector`: runs PostgreSQL+pgvector full-vector HNSW. If `PGVECTOR_DSN` is not set, the
   runner starts a temporary `pgvector/pgvector:pg16` Docker container. The
@@ -131,17 +147,30 @@ Configuration:
   the Go runtime's current/default sampling rate. Block profiles are emitted
   from the runtime's current block profiler and may be empty unless block
   profiling was already enabled.
-- `TREEDB_QUANTIZED_INDEX_NAME`: scalar_u8 TreeDB quantized score-plane name.
-  Defaults to `embedding.scalar_u8.fast`.
-- `TREEDB_QUANTIZED_RERANK_CANDIDATES`: TreeDB quantized-rerank exact rerank
-  candidate limit. Defaults to `max(32, TOP_K)`; set `0` to use the normalized
-  efSearch set.
+- `TREEDB_QUANTIZED_CODEC`: codec for the compatibility quantized aliases.
+  Defaults to `scalar_u8`; set to `rabitq_1bit` only when deliberately using the
+  generic aliases for RaBitQ.
+- `TREEDB_QUANTIZED_INDEX_NAME`: score-plane name for the compatibility
+  quantized aliases. Defaults to `embedding.scalar_u8.fast`.
+- `TREEDB_SCALAR_U8_QUANTIZED_INDEX_NAME`: scalar_u8 score-plane name for the
+  explicit scalar_u8 aliases. Defaults to `TREEDB_QUANTIZED_INDEX_NAME`.
+- `TREEDB_RABITQ_QUANTIZED_INDEX_NAME`: RaBitQ score-plane name for the
+  explicit RaBitQ aliases. Defaults to `embedding.rabitq_1bit.fast`.
+- `TREEDB_QUANTIZED_RERANK_CANDIDATES`: TreeDB scalar_u8/compat quantized-rerank
+  exact rerank candidate limit. Defaults to `max(32, TOP_K)`; set `0` to use the
+  normalized efSearch set.
+- `TREEDB_RABITQ_QUANTIZED_RERANK_CANDIDATES`: TreeDB RaBitQ quantized-rerank
+  exact rerank candidate limit. Defaults to `TREEDB_QUANTIZED_RERANK_CANDIDATES`.
 - `TREEDB_QUANTIZED_MIN_RECALL`: recall gate for both TreeDB quantized rows.
   Defaults to `0`, so comparisons report quantized recall instead of failing
   before rendering; set a positive value to enforce a quantized recall floor.
 - `TREEDB_QUANTIZED_ONLY_MIN_RECALL` and
-  `TREEDB_QUANTIZED_RERANK_MIN_RECALL`: optional per-mode overrides for
-  `TREEDB_QUANTIZED_MIN_RECALL`.
+  `TREEDB_QUANTIZED_RERANK_MIN_RECALL`: optional scalar_u8/compat per-mode
+  overrides for `TREEDB_QUANTIZED_MIN_RECALL`.
+- `TREEDB_RABITQ_QUANTIZED_MIN_RECALL`,
+  `TREEDB_RABITQ_QUANTIZED_ONLY_MIN_RECALL`, and
+  `TREEDB_RABITQ_QUANTIZED_RERANK_MIN_RECALL`: optional RaBitQ recall gates;
+  default to the corresponding generic quantized gates.
 - `PGVECTOR_DSN`: external PostgreSQL DSN. If empty and `pgvector` is enabled,
   the runner starts Docker unless `PGVECTOR_DOCKER=false`.
 - `PGVECTOR_DOCKER`, `PGVECTOR_IMAGE`, `PGVECTOR_MAX_CONNECTIONS`: automatic
@@ -162,8 +191,12 @@ The runner writes:
 - `dataset/`: TreeDB-owned synthetic vectors and manifest
 - `treedb.json`: TreeDB native benchmark result
 - `treedb_column_graph.json`: TreeDB column_graph exact/default result when enabled
-- `treedb_column_graph_quantized_only.json`: TreeDB scalar_u8 quantized-only result when enabled
-- `treedb_column_graph_quantized_rerank.json`: TreeDB scalar_u8 quantized-rerank result when enabled
+- `treedb_column_graph_quantized_only.json`: compatibility quantized-only result when enabled
+- `treedb_column_graph_quantized_rerank.json`: compatibility quantized-rerank result when enabled
+- `treedb_column_graph_scalar_u8_quantized_only.json`: TreeDB scalar_u8 quantized-only result when enabled
+- `treedb_column_graph_scalar_u8_quantized_rerank.json`: TreeDB scalar_u8 quantized-rerank result when enabled
+- `treedb_column_graph_rabitq_1bit_quantized_only.json`: TreeDB RaBitQ quantized-only result when enabled
+- `treedb_column_graph_rabitq_1bit_quantized_rerank.json`: TreeDB RaBitQ quantized-rerank result when enabled
 - `vectorlite.json`: SQLite+Vectorlite benchmark result
 - `pgvector.json`: PostgreSQL+pgvector full-vector HNSW benchmark result when enabled
 - `mongodb.json`: MongoDB Vector Search benchmark result when enabled

--- a/benchmarks/vector_db_compare/summarize.py
+++ b/benchmarks/vector_db_compare/summarize.py
@@ -88,7 +88,15 @@ def backend_name(result: dict[str, Any]) -> str:
     backend = result.get("backend")
     if backend in (None, "", "treedb"):
         return "TreeDB native HNSW"
-    if backend in ("treedb_column_graph", "treedb_column_graph_quantized_only", "treedb_column_graph_quantized_rerank"):
+    if backend in (
+        "treedb_column_graph",
+        "treedb_column_graph_quantized_only",
+        "treedb_column_graph_quantized_rerank",
+        "treedb_column_graph_scalar_u8_quantized_only",
+        "treedb_column_graph_scalar_u8_quantized_rerank",
+        "treedb_column_graph_rabitq_1bit_quantized_only",
+        "treedb_column_graph_rabitq_1bit_quantized_rerank",
+    ):
         return "TreeDB column-store graph HNSW"
     if backend == "sqlite_vectorlite":
         return "SQLite+Vectorlite HNSW"
@@ -99,6 +107,35 @@ def backend_name(result: dict[str, Any]) -> str:
     raise ValueError(f"unknown backend {backend!r}")
 
 
+def quantized_codec(result: dict[str, Any], row: dict[str, Any] | None = None) -> str:
+    if row:
+        codec = str(row.get("quantized_codec") or "").strip()
+        if codec:
+            return codec
+    codec = str(result.get("quantized_codec") or "").strip()
+    if codec:
+        return codec
+    backend = str(result.get("backend") or "")
+    if "rabitq_1bit" in backend:
+        return "rabitq_1bit"
+    if "scalar_u8" in backend:
+        return "scalar_u8"
+    index_name = str(result.get("quantized_index_name") or "")
+    if "rabitq_1bit" in index_name:
+        return "rabitq_1bit"
+    if "scalar_u8" in index_name:
+        return "scalar_u8"
+    if backend in ("treedb_column_graph_quantized_only", "treedb_column_graph_quantized_rerank"):
+        return "scalar_u8"
+    return ""
+
+
+def label_quantized_mode(mode: str, codec: str) -> str:
+    if mode in ("quantized_only", "quantized_rerank") and codec:
+        return f"{codec} {mode}"
+    return mode
+
+
 def search_mode(result: dict[str, Any]) -> str:
     backend = result.get("backend")
     mode = str(result.get("query_mode") or "").strip()
@@ -106,10 +143,10 @@ def search_mode(result: dict[str, Any]) -> str:
         return "exact/default" if mode in ("", "exact") else mode
     if backend == "treedb_column_graph":
         return "exact/default" if mode in ("", "exact") else mode
-    if backend == "treedb_column_graph_quantized_only":
-        return mode or "quantized_only"
-    if backend == "treedb_column_graph_quantized_rerank":
-        return mode or "quantized_rerank"
+    if backend in ("treedb_column_graph_quantized_only", "treedb_column_graph_scalar_u8_quantized_only", "treedb_column_graph_rabitq_1bit_quantized_only"):
+        return label_quantized_mode(mode or "quantized_only", quantized_codec(result))
+    if backend in ("treedb_column_graph_quantized_rerank", "treedb_column_graph_scalar_u8_quantized_rerank", "treedb_column_graph_rabitq_1bit_quantized_rerank"):
+        return label_quantized_mode(mode or "quantized_rerank", quantized_codec(result))
     if backend == "pgvector":
         return "full-vector HNSW"
     if backend in ("sqlite_vectorlite", "mongodb_vector_search"):
@@ -124,7 +161,7 @@ def search_row_mode(result: dict[str, Any], row: dict[str, Any]) -> str:
     mode = str(row.get("query_mode") or result.get("query_mode") or "").strip()
     if backend in (None, "", "treedb", "treedb_column_graph") and mode in ("", "exact"):
         return "exact/default"
-    return mode or search_mode(result)
+    return label_quantized_mode(mode, quantized_codec(result, row)) or search_mode(result)
 
 
 def result_label(result: dict[str, Any]) -> str:
@@ -155,7 +192,7 @@ def render(results: list[dict[str, Any]]) -> str:
     lines: list[str] = []
     lines.append("# Vector Database Benchmark")
     lines.append("")
-    lines.append("All reported systems use persistent database files or server-side durable storage, close/reopen or reconnect before validation/search, cosine distance, HNSW ANN search, and the same TreeDB-exported vectors and query set. TreeDB quantized rows are explicit TreeDB column_graph scalar_u8 query modes; PostgreSQL+pgvector remains a full-vector HNSW anchor.")
+    lines.append("All reported systems use persistent database files or server-side durable storage, close/reopen or reconnect before validation/search, cosine distance, HNSW ANN search, and the same TreeDB-exported vectors and query set. TreeDB quantized rows are explicit TreeDB column_graph query modes with named scalar_u8 or rabitq_1bit score planes; PostgreSQL+pgvector remains a full-vector HNSW anchor.")
     lines.append("")
     lines.append("## Build, Recall, Storage")
     lines.append("")
@@ -285,7 +322,7 @@ def render(results: list[dict[str, Any]]) -> str:
     lines.append("- MongoDB is included only when run against a MongoDB Vector Search deployment, such as Atlas or local Atlas with `mongot`; plain `mongod` is not a vector-search comparator.")
     lines.append("- MongoDB storage marked with `*` uses `collStats` collection storage and ordinary index bytes; MongoDB Vector Search index bytes are not exposed by this harness.")
     lines.append("- TreeDB storage uses the post-close, post-index-vacuum retained datastore when reported by `treedb_vector_search_demo`; raw pre-close and pre-vacuum storage fields remain in the JSON.")
-    lines.append("- TreeDB quantized rows declare a named scalar_u8 score plane and select it through explicit `query_mode`; exact/default TreeDB rows do not declare or use quantized assets.")
+    lines.append("- TreeDB quantized rows declare a named quantized score plane (`scalar_u8` or `rabitq_1bit`) and select it through explicit `query_mode`; exact/default TreeDB rows do not declare or use quantized assets.")
     lines.append("- Memory columns are intentionally separated: TreeDB reports native vector-index memory when available, while Python-backed comparator harnesses report whole benchmark process max RSS.")
     lines.append("")
     return "\n".join(lines)

--- a/benchmarks/vector_db_compare/test_summarize.py
+++ b/benchmarks/vector_db_compare/test_summarize.py
@@ -14,11 +14,12 @@ summarize = importlib.util.module_from_spec(_SPEC)
 _SPEC.loader.exec_module(summarize)
 
 
-def result(backend: str, query_mode: str = "") -> dict:
+def result(backend: str, query_mode: str = "", quantized_codec: str = "") -> dict:
     row = {
         "concurrency": 1,
         "queries": 4,
         "query_mode": query_mode,
+        "quantized_codec": quantized_codec,
         "total_duration_nanos": 1000,
         "avg_nanos": 250,
         "avg_micros": 0.25,
@@ -70,6 +71,7 @@ def result(backend: str, query_mode: str = "") -> dict:
         "backend": backend,
         "engine": backend,
         "query_mode": query_mode,
+        "quantized_codec": quantized_codec,
         "docs": 64,
         "dimensions": 8,
         "queries": 4,
@@ -89,8 +91,9 @@ class SummaryRenderTests(unittest.TestCase):
         rendered = summarize.render(
             [
                 result("treedb_column_graph", "exact"),
-                result("treedb_column_graph_quantized_only", "quantized_only"),
-                result("treedb_column_graph_quantized_rerank", "quantized_rerank"),
+                result("treedb_column_graph_scalar_u8_quantized_only", "quantized_only", "scalar_u8"),
+                result("treedb_column_graph_rabitq_1bit_quantized_only", "quantized_only", "rabitq_1bit"),
+                result("treedb_column_graph_rabitq_1bit_quantized_rerank", "quantized_rerank", "rabitq_1bit"),
                 {
                     **result("pgvector"),
                     "build": {"seconds": 0.25},
@@ -100,16 +103,18 @@ class SummaryRenderTests(unittest.TestCase):
         )
         self.assertIn("| Backend | Search mode | Insert |", rendered)
         self.assertIn("| TreeDB column-store graph HNSW | exact/default |", rendered)
-        self.assertIn("| TreeDB column-store graph HNSW | quantized_only |", rendered)
-        self.assertIn("| TreeDB column-store graph HNSW | quantized_rerank |", rendered)
+        self.assertIn("| TreeDB column-store graph HNSW | scalar_u8 quantized_only |", rendered)
+        self.assertIn("| TreeDB column-store graph HNSW | rabitq_1bit quantized_only |", rendered)
+        self.assertIn("| TreeDB column-store graph HNSW | rabitq_1bit quantized_rerank |", rendered)
         self.assertIn("| PostgreSQL+pgvector HNSW | full-vector HNSW |", rendered)
         self.assertIn("## TreeDB Search Counters", rendered)
-        self.assertIn("| TreeDB column-store graph HNSW | quantized_only | 1 | 32.0 | 40.0 | 5120.0 | 0.0 | 0.0 | 0.0 | 0.0 |", rendered)
-        self.assertIn("| TreeDB column-store graph HNSW | quantized_rerank | 1 | 32.0 | 40.0 | 5120.0 | 16.0 | 16.0 | 128.0 | 32.0 |", rendered)
+        self.assertIn("| TreeDB column-store graph HNSW | scalar_u8 quantized_only | 1 | 32.0 | 40.0 | 5120.0 | 0.0 | 0.0 | 0.0 | 0.0 |", rendered)
+        self.assertIn("| TreeDB column-store graph HNSW | rabitq_1bit quantized_rerank | 1 | 32.0 | 40.0 | 5120.0 | 16.0 | 16.0 | 128.0 | 32.0 |", rendered)
         self.assertIn("## TreeDB Search Guardrails", rendered)
         self.assertIn("| TreeDB column-store graph HNSW | exact/default | 1 | 0.0 | 0.0 | 1.0 | 0.0 | 0.0 |", rendered)
-        self.assertIn("| TreeDB column-store graph HNSW | quantized_only | 1 | 0.0 | 0.0 | 0.0 | 1.0 | 0.0 |", rendered)
-        self.assertIn("| TreeDB column-store graph HNSW | quantized_rerank | 1 | 0.0 | 0.0 | 0.0 | 0.0 | 1.0 |", rendered)
+        self.assertIn("| TreeDB column-store graph HNSW | scalar_u8 quantized_only | 1 | 0.0 | 0.0 | 0.0 | 1.0 | 0.0 |", rendered)
+        self.assertIn("| TreeDB column-store graph HNSW | rabitq_1bit quantized_only | 1 | 0.0 | 0.0 | 0.0 | 1.0 | 0.0 |", rendered)
+        self.assertIn("| TreeDB column-store graph HNSW | rabitq_1bit quantized_rerank | 1 | 0.0 | 0.0 | 0.0 | 0.0 | 1.0 |", rendered)
         self.assertIn("PostgreSQL+pgvector is not quantized", rendered)
 
 

--- a/cmd/treedb_vector_search_demo/README.md
+++ b/cmd/treedb_vector_search_demo/README.md
@@ -32,12 +32,13 @@ timing projected documents without embeddings.
 
 For `-vector-index-strategy column_graph`, the demo can also select explicit
 TreeDB query modes with `-vector-query-mode exact|quantized_only|quantized_rerank`.
-Quantized modes declare a named `scalar_u8` score plane on the TreeDB vector
-index, build it during `RebuildVectorIndex`, validate recall against exact
-full-vector ground truth, and report per-search quantized counters. They do not
-change exact/default behavior and do not affect PostgreSQL+pgvector comparator
-semantics in the external harness. The `column_graph` JSON/text search rows
-also report no-document guardrail counters such as `avg_documents_fetched`,
+Quantized modes declare a named `scalar_u8` or `rabitq_1bit` score plane on the
+TreeDB vector index, build it during `RebuildVectorIndex`, validate recall
+against exact full-vector ground truth, and report per-search quantized
+counters. They do not change exact/default behavior and do not affect
+PostgreSQL+pgvector comparator semantics in the external harness. The
+`column_graph` JSON/text search rows also report no-document guardrail counters
+such as `avg_documents_fetched`,
 `avg_response_owned_result_allocs`, and route/fallback averages so profile runs
 can distinguish buffered search-loop cost from response-owned convenience or
 document-materialization paths.
@@ -68,13 +69,14 @@ GOWORK=off go run ./cmd/treedb_vector_search_demo \
   -json
 ```
 
-TreeDB column_graph quantized-rerank example:
+TreeDB column_graph scalar_u8 quantized-rerank example:
 
 ```sh
 GOWORK=off go run ./cmd/treedb_vector_search_demo \
   -matrix=false \
   -vector-index-strategy column_graph \
   -vector-query-mode quantized_rerank \
+  -quantized-codec scalar_u8 \
   -quantized-index-name embedding.scalar_u8.fast \
   -quantized-rerank-candidates 32 \
   -docs 10000 \
@@ -97,6 +99,27 @@ Use `-matrix=false` to run only the single 1560-style case; add
 The matrix search stage defaults to 10,000 ANN queries per lane and parallel
 concurrency levels `2,4,8,16,32,64,128`; override those with `-queries` and
 `-search-concurrency`.
+
+TreeDB column_graph RaBitQ quantized-only example:
+
+```sh
+GOWORK=off go run ./cmd/treedb_vector_search_demo \
+  -matrix=false \
+  -vector-index-strategy column_graph \
+  -vector-query-mode quantized_only \
+  -quantized-codec rabitq_1bit \
+  -quantized-index-name embedding.rabitq_1bit.fast \
+  -docs 10000 \
+  -dims 1536 \
+  -queries 10000 \
+  -validate-queries 64 \
+  -top-k 10 \
+  -m 16 \
+  -ef-construction 128 \
+  -ef-search 128 \
+  -min-recall 0 \
+  -json
+```
 
 Use `-search-profile-dir DIR` with `-vector-index-strategy column_graph` to
 write per-concurrency profiles for the column_graph search stage. Native
@@ -173,9 +196,14 @@ Useful flags:
 - `-vector-query-mode exact|quantized_only|quantized_rerank`: select the
   column_graph score plane. The default is `exact`; quantized modes require
   `column_graph` and a quantized index name.
-- `-quantized-index-name NAME`: named scalar_u8 score plane for quantized modes
-  (for example `embedding.scalar_u8.fast`). Exact mode rejects this flag so it
-  cannot accidentally declare quantized assets.
+- `-quantized-codec scalar_u8|rabitq_1bit`: quantized score-plane codec for
+  quantized modes. Empty defaults to `scalar_u8` when a quantized query mode is
+  selected. Exact mode rejects this flag so it cannot accidentally declare
+  quantized assets.
+- `-quantized-index-name NAME`: named quantized score plane for quantized modes
+  (for example `embedding.scalar_u8.fast` or `embedding.rabitq_1bit.fast`).
+  Exact mode rejects this flag so it cannot accidentally declare quantized
+  assets.
 - `-quantized-rerank-candidates N`: exact-rerank candidate limit for
   `quantized_rerank`; `0` uses the normalized `ef_search` candidate set.
 - `-json`: emit the full result object for scripts.

--- a/cmd/treedb_vector_search_demo/main.go
+++ b/cmd/treedb_vector_search_demo/main.go
@@ -29,19 +29,22 @@ import (
 )
 
 const (
-	defaultDocs                  = 10000
-	defaultDimensions            = 64
-	defaultQueries               = 10000
-	defaultSearchConcurrency     = "2,4,8,16,32,64,128"
-	defaultTopK                  = 10
-	defaultBatchSize             = 512
-	defaultM                     = 16
-	defaultEfConstruct           = 128
-	defaultEfSearch              = 128
-	defaultValuePointerThreshold = 1024
-	defaultLeafGenerationTarget  = 4 << 20
-	defaultQuantizedIndexName    = "embedding.scalar_u8.fast"
-	nativeRuntimeSnapshotPath    = collections.VectorIndexSearchPath("native_runtime_snapshot")
+	defaultDocs                     = 10000
+	defaultDimensions               = 64
+	defaultQueries                  = 10000
+	defaultSearchConcurrency        = "2,4,8,16,32,64,128"
+	defaultTopK                     = 10
+	defaultBatchSize                = 512
+	defaultM                        = 16
+	defaultEfConstruct              = 128
+	defaultEfSearch                 = 128
+	defaultValuePointerThreshold    = 1024
+	defaultLeafGenerationTarget     = 4 << 20
+	defaultQuantizedCodec           = collections.QuantizedVectorCodecScalarU8
+	defaultQuantizedIndexName       = "embedding.scalar_u8.fast"
+	defaultRabitQQuantizedIndexName = "embedding.rabitq_1bit.fast"
+	quantizedVectorCodecRabitQ1Bit  = "rabitq_1bit"
+	nativeRuntimeSnapshotPath       = collections.VectorIndexSearchPath("native_runtime_snapshot")
 )
 
 type validationExactSource string
@@ -84,6 +87,7 @@ type config struct {
 	indexOuterLeavesInValueLog *bool
 	vectorIndexStrategy        collections.VectorIndexStrategy
 	vectorQueryMode            collections.VectorIndexQueryMode
+	quantizedCodec             string
 	quantizedIndexName         string
 	quantizedRerankCandidates  int
 }
@@ -94,6 +98,7 @@ type result struct {
 	VectorIndexStrategy       collections.VectorIndexStrategy   `json:"vector_index_strategy"`
 	VectorIndexSearchPath     collections.VectorIndexSearchPath `json:"vector_index_search_path,omitempty"`
 	QueryMode                 collections.VectorIndexQueryMode  `json:"query_mode"`
+	QuantizedCodec            string                            `json:"quantized_codec"`
 	QuantizedIndexName        string                            `json:"quantized_index_name"`
 	QuantizedRerankCandidates int                               `json:"quantized_rerank_candidates"`
 	Dir                       string                            `json:"dir"`
@@ -181,6 +186,7 @@ type searchBenchmarkResult struct {
 	Concurrency                       int                              `json:"concurrency"`
 	Queries                           int                              `json:"queries"`
 	QueryMode                         collections.VectorIndexQueryMode `json:"query_mode"`
+	QuantizedCodec                    string                           `json:"quantized_codec"`
 	QuantizedIndexName                string                           `json:"quantized_index_name"`
 	QuantizedRerankCandidates         int                              `json:"quantized_rerank_candidates"`
 	TotalDurationNanos                int64                            `json:"total_duration_nanos"`
@@ -366,7 +372,8 @@ func parseConfig(args []string) (config, error) {
 	fs.StringVar(&vectorIndexStrategyRaw, "vector-index-strategy", vectorIndexStrategyRaw, "TreeDB vector index strategy: native_runtime or column_graph")
 	fs.StringVar(&vectorQueryModeRaw, "vector-query-mode", vectorQueryModeRaw, "TreeDB vector query mode: exact, quantized_only, or quantized_rerank")
 	fs.StringVar(&validationExactSourceRaw, "validation-exact-source", validationExactSourceRaw, "Exact baseline source for recall validation: treedb or dataset")
-	fs.StringVar(&cfg.quantizedIndexName, "quantized-index-name", cfg.quantizedIndexName, "Named scalar_u8 quantized index to use for column_graph quantized query modes, for example "+defaultQuantizedIndexName)
+	fs.StringVar(&cfg.quantizedCodec, "quantized-codec", cfg.quantizedCodec, "Quantized codec for column_graph quantized query modes: scalar_u8 or rabitq_1bit; empty defaults to scalar_u8 for quantized modes")
+	fs.StringVar(&cfg.quantizedIndexName, "quantized-index-name", cfg.quantizedIndexName, "Named quantized index to use for column_graph quantized query modes, for example "+defaultQuantizedIndexName+" or "+defaultRabitQQuantizedIndexName)
 	fs.IntVar(&cfg.quantizedRerankCandidates, "quantized-rerank-candidates", cfg.quantizedRerankCandidates, "Candidate limit exact-reranked by column_graph quantized_rerank mode; 0 uses the normalized ef_search set")
 	fs.IntVar(&cfg.docs, "docs", cfg.docs, "Number of synthetic documents to load")
 	fs.IntVar(&cfg.dimensions, "dims", cfg.dimensions, "Vector dimensions per document")
@@ -413,6 +420,9 @@ func parseConfig(args []string) (config, error) {
 		return config{}, err
 	}
 	cfg.vectorQueryMode = queryMode
+	if err := applyQuantizedConfigDefaults(&cfg); err != nil {
+		return config{}, err
+	}
 	validationExactSource, err := parseValidationExactSource(validationExactSourceRaw)
 	if err != nil {
 		return config{}, err
@@ -529,12 +539,40 @@ func validateValidationExactSourceConfig(cfg config) error {
 	return nil
 }
 
+func applyQuantizedConfigDefaults(cfg *config) error {
+	codec, err := parseQuantizedCodec(cfg.quantizedCodec)
+	if err != nil {
+		return err
+	}
+	cfg.quantizedCodec = codec
+	if vectorQueryModeIsQuantized(normalizedVectorQueryMode(cfg.vectorQueryMode)) && cfg.quantizedCodec == "" {
+		cfg.quantizedCodec = defaultQuantizedCodec
+	}
+	return nil
+}
+
+func parseQuantizedCodec(raw string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "":
+		return "", nil
+	case collections.QuantizedVectorCodecScalarU8:
+		return collections.QuantizedVectorCodecScalarU8, nil
+	case quantizedVectorCodecRabitQ1Bit:
+		return quantizedVectorCodecRabitQ1Bit, nil
+	default:
+		return "", fmt.Errorf("unsupported -quantized-codec %q; allowed: %s,%s", raw, collections.QuantizedVectorCodecScalarU8, quantizedVectorCodecRabitQ1Bit)
+	}
+}
+
 func validateVectorQueryConfig(cfg config) error {
 	mode := normalizedVectorQueryMode(cfg.vectorQueryMode)
 	if cfg.quantizedRerankCandidates < 0 {
 		return errors.New("-quantized-rerank-candidates cannot be negative")
 	}
 	if !vectorQueryModeIsQuantized(mode) {
+		if cfg.quantizedCodec != "" {
+			return errors.New("-quantized-codec requires -vector-query-mode quantized_only or quantized_rerank")
+		}
 		if cfg.quantizedIndexName != "" {
 			return errors.New("-quantized-index-name requires -vector-query-mode quantized_only or quantized_rerank")
 		}
@@ -545,6 +583,12 @@ func validateVectorQueryConfig(cfg config) error {
 	}
 	if cfg.vectorIndexStrategy != collections.VectorIndexStrategyColumnGraph {
 		return errors.New("quantized vector query modes require -vector-index-strategy column_graph")
+	}
+	if cfg.quantizedCodec == "" {
+		return errors.New("-quantized-codec is required for quantized vector query modes")
+	}
+	if _, err := parseQuantizedCodec(cfg.quantizedCodec); err != nil {
+		return err
 	}
 	if cfg.quantizedIndexName == "" {
 		return errors.New("-quantized-index-name is required for quantized vector query modes")
@@ -733,18 +777,36 @@ func resultBackendForStrategy(strategy collections.VectorIndexStrategy) string {
 	return "treedb"
 }
 
-func resultBackendForQuery(strategy collections.VectorIndexStrategy, mode collections.VectorIndexQueryMode) string {
+func resultBackendForQuery(strategy collections.VectorIndexStrategy, mode collections.VectorIndexQueryMode, quantizedCodec string) string {
 	if strategy != collections.VectorIndexStrategyColumnGraph {
 		return resultBackendForStrategy(strategy)
 	}
 	switch normalizedVectorQueryMode(mode) {
 	case collections.VectorIndexQueryModeQuantizedOnly:
-		return "treedb_column_graph_quantized_only"
+		return "treedb_column_graph_" + quantizedBackendCodecLabel(quantizedCodec) + "_quantized_only"
 	case collections.VectorIndexQueryModeQuantizedRerank:
-		return "treedb_column_graph_quantized_rerank"
+		return "treedb_column_graph_" + quantizedBackendCodecLabel(quantizedCodec) + "_quantized_rerank"
 	default:
 		return "treedb_column_graph"
 	}
+}
+
+func quantizedBackendCodecLabel(codec string) string {
+	switch codec {
+	case collections.QuantizedVectorCodecScalarU8:
+		return collections.QuantizedVectorCodecScalarU8
+	case quantizedVectorCodecRabitQ1Bit:
+		return quantizedVectorCodecRabitQ1Bit
+	default:
+		return "quantized"
+	}
+}
+
+func effectiveQuantizedCodec(cfg config) string {
+	if vectorQueryModeIsQuantized(normalizedVectorQueryMode(cfg.vectorQueryMode)) {
+		return cfg.quantizedCodec
+	}
+	return ""
 }
 
 func effectiveQuantizedIndexName(cfg config) string {
@@ -803,6 +865,9 @@ func execute(ctx context.Context, cfg config) (result, error) {
 	}
 	cfg.validationExactSource = validationExactSource
 	if err := validateValidationExactSourceConfig(cfg); err != nil {
+		return result{}, err
+	}
+	if err := applyQuantizedConfigDefaults(&cfg); err != nil {
 		return result{}, err
 	}
 	if err := validateVectorQueryConfig(cfg); err != nil {
@@ -873,15 +938,16 @@ func execute(ctx context.Context, cfg config) (result, error) {
 	if vectorQueryModeIsQuantized(cfg.vectorQueryMode) {
 		def.QuantizedIndexes = []collections.QuantizedVectorIndexDefinition{{
 			Name:    cfg.quantizedIndexName,
-			Codec:   collections.QuantizedVectorCodecScalarU8,
+			Codec:   cfg.quantizedCodec,
 			Version: 1,
 		}}
 	}
 	res := result{
-		Backend:                   resultBackendForQuery(def.Strategy, cfg.vectorQueryMode),
+		Backend:                   resultBackendForQuery(def.Strategy, cfg.vectorQueryMode, cfg.quantizedCodec),
 		Engine:                    "treedb",
 		VectorIndexStrategy:       def.Strategy,
 		QueryMode:                 normalizedVectorQueryMode(cfg.vectorQueryMode),
+		QuantizedCodec:            effectiveQuantizedCodec(cfg),
 		QuantizedIndexName:        effectiveQuantizedIndexName(cfg),
 		QuantizedRerankCandidates: effectiveQuantizedRerankCandidates(cfg),
 		Dir:                       dir,
@@ -2278,6 +2344,7 @@ func benchmarkColumnGraphSearchLoadedConcurrent(col *collections.Collection, ind
 		Concurrency:                       concurrency,
 		Queries:                           len(queries),
 		QueryMode:                         normalizedVectorQueryMode(cfg.vectorQueryMode),
+		QuantizedCodec:                    effectiveQuantizedCodec(cfg),
 		QuantizedIndexName:                effectiveQuantizedIndexName(cfg),
 		QuantizedRerankCandidates:         effectiveQuantizedRerankCandidates(cfg),
 		TotalDurationNanos:                total.Nanoseconds(),
@@ -2636,8 +2703,8 @@ func percentile(sorted []int64, p float64) int64 {
 
 func printText(w io.Writer, res result) {
 	fmt.Fprintf(w, "TreeDB vector search demo\n")
-	fmt.Fprintf(w, "dir=%s kept=%t profile=%s backend=%s vector_index_strategy=%s vector_index_search_path=%s query_mode=%s quantized_index_name=%s quantized_rerank_candidates=%d docs=%d dims=%d queries=%d top_k=%d m=%d ef_construction=%d ef_search=%d value_pointer_threshold=%d leaf_generation_segment_target=%d\n",
-		res.Dir, res.KeptDir, res.Profile, resultBackend(res), resultStrategy(res), resultSearchPath(res), resultQueryMode(res), res.QuantizedIndexName, res.QuantizedRerankCandidates, res.Docs, res.Dimensions, res.Queries, res.TopK, res.M, res.EfConstruction, res.EfSearch, res.ValuePointerThreshold, res.LeafGenerationTarget)
+	fmt.Fprintf(w, "dir=%s kept=%t profile=%s backend=%s vector_index_strategy=%s vector_index_search_path=%s query_mode=%s quantized_codec=%s quantized_index_name=%s quantized_rerank_candidates=%d docs=%d dims=%d queries=%d top_k=%d m=%d ef_construction=%d ef_search=%d value_pointer_threshold=%d leaf_generation_segment_target=%d\n",
+		res.Dir, res.KeptDir, res.Profile, resultBackend(res), resultStrategy(res), resultSearchPath(res), resultQueryMode(res), res.QuantizedCodec, res.QuantizedIndexName, res.QuantizedRerankCandidates, res.Docs, res.Dimensions, res.Queries, res.TopK, res.M, res.EfConstruction, res.EfSearch, res.ValuePointerThreshold, res.LeafGenerationTarget)
 	if res.SearchProfileDir != "" {
 		fmt.Fprintf(w, "search_profile_dir=%s\n", res.SearchProfileDir)
 	}
@@ -2729,11 +2796,12 @@ func printMatrixText(w io.Writer, res matrixResult) {
 	for _, testCase := range res.Cases {
 		fmt.Fprintf(w, "\nCase %s\n", testCase.Name)
 		fmt.Fprintf(w, "%s\n", testCase.Description)
-		fmt.Fprintf(w, "backend=%s vector_index_strategy=%s vector_index_search_path=%s query_mode=%s\n",
+		fmt.Fprintf(w, "backend=%s vector_index_strategy=%s vector_index_search_path=%s query_mode=%s quantized_codec=%s\n",
 			resultBackend(testCase.Result),
 			resultStrategy(testCase.Result),
 			resultSearchPath(testCase.Result),
-			resultQueryMode(testCase.Result))
+			resultQueryMode(testCase.Result),
+			testCase.Result.QuantizedCodec)
 		if testCase.Result.SearchProfileDir != "" {
 			fmt.Fprintf(w, "search_profile_dir=%s\n", testCase.Result.SearchProfileDir)
 		}
@@ -2768,7 +2836,7 @@ func resultBackend(res result) string {
 	if res.Backend != "" {
 		return res.Backend
 	}
-	return resultBackendForStrategy(resultStrategy(res))
+	return resultBackendForQuery(resultStrategy(res), resultQueryMode(res), res.QuantizedCodec)
 }
 
 func resultStrategy(res result) collections.VectorIndexStrategy {
@@ -2794,10 +2862,11 @@ func resultQueryMode(res result) collections.VectorIndexQueryMode {
 
 func printSearchBenchmarks(w io.Writer, benchmarks []searchBenchmarkResult) {
 	for _, bench := range benchmarks {
-		fmt.Fprintf(w, "search concurrency=%d queries=%d query_mode=%s avg=%.2fus p50=%.2fus p95=%.2fus p99=%.2fus ops/sec=%.1f exact_fallbacks=%d avg_candidates=%.1f avg_quantized_score_calls=%.1f avg_quantized_code_bytes=%.1f avg_quantized_rerank_candidates=%.1f avg_quantized_rerank_exact_score_calls=%.1f avg_vector_bytes=%.1f avg_norm_bytes=%.1f",
+		fmt.Fprintf(w, "search concurrency=%d queries=%d query_mode=%s quantized_codec=%s avg=%.2fus p50=%.2fus p95=%.2fus p99=%.2fus ops/sec=%.1f exact_fallbacks=%d avg_candidates=%.1f avg_quantized_score_calls=%.1f avg_quantized_code_bytes=%.1f avg_quantized_rerank_candidates=%.1f avg_quantized_rerank_exact_score_calls=%.1f avg_vector_bytes=%.1f avg_norm_bytes=%.1f",
 			bench.Concurrency,
 			bench.Queries,
 			bench.QueryMode,
+			bench.QuantizedCodec,
 			bench.AvgMicros,
 			float64(bench.P50Nanos)/1000,
 			float64(bench.P95Nanos)/1000,

--- a/cmd/treedb_vector_search_demo/main_test.go
+++ b/cmd/treedb_vector_search_demo/main_test.go
@@ -407,7 +407,25 @@ func TestExecuteColumnGraphSearchPath(t *testing.T) {
 }
 
 func TestExecuteColumnGraphQuantizedModes(t *testing.T) {
-	for _, tc := range []struct {
+	codecCases := []struct {
+		name             string
+		codec            string
+		indexName        string
+		wantBackendCodec string
+	}{
+		{
+			name:             "scalar_u8_default",
+			indexName:        defaultQuantizedIndexName,
+			wantBackendCodec: collections.QuantizedVectorCodecScalarU8,
+		},
+		{
+			name:             "rabitq_1bit",
+			codec:            quantizedVectorCodecRabitQ1Bit,
+			indexName:        defaultRabitQQuantizedIndexName,
+			wantBackendCodec: quantizedVectorCodecRabitQ1Bit,
+		},
+	}
+	modeCases := []struct {
 		name        string
 		mode        collections.VectorIndexQueryMode
 		rerank      int
@@ -460,54 +478,69 @@ func TestExecuteColumnGraphQuantizedModes(t *testing.T) {
 				}
 			},
 		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			res, err := execute(context.Background(), config{
-				dir:                       t.TempDir(),
-				keepDir:                   true,
-				docs:                      96,
-				dimensions:                8,
-				queries:                   4,
-				searchConcurrency:         []int{2},
-				validateQueries:           2,
-				validateDocs:              2,
-				topK:                      3,
-				batchSize:                 32,
-				m:                         4,
-				efConstruction:            32,
-				efSearch:                  32,
-				valuePointerThreshold:     defaultValuePointerThreshold,
-				leafGenerationTarget:      defaultLeafGenerationTarget,
-				minRecall:                 0,
-				disableExactFallback:      true,
-				vectorIndexStrategy:       collections.VectorIndexStrategyColumnGraph,
-				vectorQueryMode:           tc.mode,
-				quantizedIndexName:        defaultQuantizedIndexName,
-				quantizedRerankCandidates: tc.rerank,
+	}
+	for _, codecCase := range codecCases {
+		for _, tc := range modeCases {
+			t.Run(codecCase.name+"/"+tc.name, func(t *testing.T) {
+				res, err := execute(context.Background(), config{
+					dir:                       t.TempDir(),
+					keepDir:                   true,
+					docs:                      96,
+					dimensions:                8,
+					queries:                   4,
+					searchConcurrency:         []int{2},
+					validateQueries:           2,
+					validateDocs:              2,
+					topK:                      3,
+					batchSize:                 32,
+					m:                         4,
+					efConstruction:            32,
+					efSearch:                  32,
+					valuePointerThreshold:     defaultValuePointerThreshold,
+					leafGenerationTarget:      defaultLeafGenerationTarget,
+					minRecall:                 0,
+					disableExactFallback:      true,
+					vectorIndexStrategy:       collections.VectorIndexStrategyColumnGraph,
+					vectorQueryMode:           tc.mode,
+					quantizedCodec:            codecCase.codec,
+					quantizedIndexName:        codecCase.indexName,
+					quantizedRerankCandidates: tc.rerank,
+				})
+				if err != nil {
+					t.Fatalf("execute %s/%s: %v", codecCase.name, tc.name, err)
+				}
+				wantBackend := "treedb_column_graph_" + codecCase.wantBackendCodec + "_" + tc.name
+				if res.Backend != wantBackend {
+					t.Fatalf("backend=%q want %s", res.Backend, wantBackend)
+				}
+				if res.QueryMode != tc.mode || res.QuantizedCodec != codecCase.wantBackendCodec {
+					t.Fatalf("query config mode=%q codec=%q", res.QueryMode, res.QuantizedCodec)
+				}
+				if res.QuantizedIndexName != codecCase.indexName || res.QuantizedRerankCandidates != tc.rerank {
+					t.Fatalf("quantized config name=%q rerank=%d", res.QuantizedIndexName, res.QuantizedRerankCandidates)
+				}
+				if res.Search.ExactFallbacks != 0 || !res.Search.DisableExactFallback {
+					t.Fatalf("quantized row did not stay fail-closed: %+v", res.Search)
+				}
+				if len(res.SearchBenchmarks) != 2 || res.SearchBenchmarks[0].QueryMode != tc.mode || res.SearchBenchmarks[1].QueryMode != tc.mode || res.SearchBenchmarks[0].QuantizedCodec != codecCase.wantBackendCodec || res.SearchBenchmarks[1].QuantizedCodec != codecCase.wantBackendCodec {
+					t.Fatalf("search benchmark modes/codecs not threaded: %+v", res.SearchBenchmarks)
+				}
+				if requireFloat64Metric(t, res.Search.AvgResponseOwnedResultAllocs, "avg_response_owned_result_allocs") != 0 || requireFloat64Metric(t, res.Search.AvgDocumentsFetched, "avg_documents_fetched") != 0 {
+					t.Fatalf("quantized benchmark should use no-doc buffered results: %+v", res.Search)
+				}
+				if requireFloat64Metric(t, res.Search.AvgGraphRowFallbacks, "avg_graph_row_fallbacks") != 0 || requireFloat64Metric(t, res.Search.AvgTypedColumnFallbacks, "avg_typed_column_fallbacks") != 0 || requireFloat64Metric(t, res.Search.AvgVectorScratchDecodes, "avg_vector_scratch_decodes") != 0 {
+					t.Fatalf("unexpected quantized fallback counters: %+v", res.Search)
+				}
+				var out bytes.Buffer
+				printText(&out, res)
+				for _, want := range []string{"backend=" + wantBackend, "quantized_codec=" + codecCase.wantBackendCodec, "quantized_index_name=" + codecCase.indexName} {
+					if !strings.Contains(out.String(), want) {
+						t.Fatalf("text output missing %q:\n%s", want, out.String())
+					}
+				}
+				tc.assertStats(t, res)
 			})
-			if err != nil {
-				t.Fatalf("execute %s: %v", tc.name, err)
-			}
-			if res.Backend != "treedb_column_graph_"+tc.name {
-				t.Fatalf("backend=%q want treedb_column_graph_%s", res.Backend, tc.name)
-			}
-			if res.QueryMode != tc.mode {
-				t.Fatalf("query_mode=%q want %q", res.QueryMode, tc.mode)
-			}
-			if res.QuantizedIndexName != defaultQuantizedIndexName || res.QuantizedRerankCandidates != tc.rerank {
-				t.Fatalf("quantized config name=%q rerank=%d", res.QuantizedIndexName, res.QuantizedRerankCandidates)
-			}
-			if len(res.SearchBenchmarks) != 2 || res.SearchBenchmarks[0].QueryMode != tc.mode || res.SearchBenchmarks[1].QueryMode != tc.mode {
-				t.Fatalf("search benchmark modes not threaded: %+v", res.SearchBenchmarks)
-			}
-			if requireFloat64Metric(t, res.Search.AvgResponseOwnedResultAllocs, "avg_response_owned_result_allocs") != 0 || requireFloat64Metric(t, res.Search.AvgDocumentsFetched, "avg_documents_fetched") != 0 {
-				t.Fatalf("quantized benchmark should use no-doc buffered results: %+v", res.Search)
-			}
-			if requireFloat64Metric(t, res.Search.AvgGraphRowFallbacks, "avg_graph_row_fallbacks") != 0 || requireFloat64Metric(t, res.Search.AvgTypedColumnFallbacks, "avg_typed_column_fallbacks") != 0 || requireFloat64Metric(t, res.Search.AvgVectorScratchDecodes, "avg_vector_scratch_decodes") != 0 {
-				t.Fatalf("unexpected quantized fallback counters: %+v", res.Search)
-			}
-			tc.assertStats(t, res)
-		})
+		}
 	}
 }
 
@@ -738,14 +771,28 @@ func TestParseConfigVectorQueryMode(t *testing.T) {
 		"-matrix=false",
 		"-vector-index-strategy", "column_graph",
 		"-vector-query-mode", "quantized_rerank",
-		"-quantized-index-name", defaultQuantizedIndexName,
+		"-quantized-codec", " RaBiTQ_1BiT ",
+		"-quantized-index-name", defaultRabitQQuantizedIndexName,
 		"-quantized-rerank-candidates", "32",
 	})
 	if err != nil {
 		t.Fatalf("parseConfig quantized_rerank: %v", err)
 	}
-	if cfg.vectorQueryMode != collections.VectorIndexQueryModeQuantizedRerank || cfg.quantizedIndexName != defaultQuantizedIndexName || cfg.quantizedRerankCandidates != 32 {
+	if cfg.vectorQueryMode != collections.VectorIndexQueryModeQuantizedRerank || cfg.quantizedCodec != quantizedVectorCodecRabitQ1Bit || cfg.quantizedIndexName != defaultRabitQQuantizedIndexName || cfg.quantizedRerankCandidates != 32 {
 		t.Fatalf("parsed quantized config=%+v", cfg)
+	}
+	defaultCodecCfg, err := parseConfig([]string{
+		"-matrix=false",
+		"-vector-index-strategy", "column_graph",
+		"-vector-query-mode", "quantized_only",
+		"-quantized-index-name", defaultQuantizedIndexName,
+		"-min-recall", "0",
+	})
+	if err != nil {
+		t.Fatalf("parseConfig default quantized codec: %v", err)
+	}
+	if defaultCodecCfg.quantizedCodec != defaultQuantizedCodec {
+		t.Fatalf("default quantized codec=%q want %q", defaultCodecCfg.quantizedCodec, defaultQuantizedCodec)
 	}
 
 	datasetCfg, err := parseConfig([]string{
@@ -812,9 +859,19 @@ func TestParseConfigVectorQueryMode(t *testing.T) {
 			want: "-quantized-index-name is required",
 		},
 		{
+			name: "exact rejects quantized codec",
+			args: []string{"-vector-query-mode", "exact", "-quantized-codec", quantizedVectorCodecRabitQ1Bit},
+			want: "-quantized-codec requires",
+		},
+		{
 			name: "exact rejects quantized name",
 			args: []string{"-vector-query-mode", "exact", "-quantized-index-name", defaultQuantizedIndexName},
 			want: "-quantized-index-name requires",
+		},
+		{
+			name: "rejects unsupported quantized codec",
+			args: []string{"-vector-index-strategy", "column_graph", "-vector-query-mode", "quantized_only", "-quantized-codec", "binary_quantize", "-quantized-index-name", defaultQuantizedIndexName},
+			want: "unsupported -quantized-codec",
 		},
 		{
 			name: "quantized only rejects rerank candidates",

--- a/docs/benchmarks/treedb_vector_crossover_runbook.md
+++ b/docs/benchmarks/treedb_vector_crossover_runbook.md
@@ -127,11 +127,11 @@ RUN_ROOT=${RUN_ROOT:-/tmp/gomap_2490_vector_crossover_$(date +%Y%m%d_%H%M%S)}
 run_scalar_db_fixture() {
   local id=$1 docs=$2 dims=$3
   RUN_DIR="$RUN_ROOT/db_compare/$id" \
-  BACKENDS=treedb_column_graph,treedb_column_graph_quantized_only,treedb_column_graph_quantized_rerank \
+  BACKENDS=treedb_column_graph,treedb_column_graph_scalar_u8_quantized_only,treedb_column_graph_scalar_u8_quantized_rerank \
   DOCS="$docs" DIMS="$dims" QUERIES=10000 VALIDATE_QUERIES=64 \
   TOP_K=10 M=16 EF_CONSTRUCTION=128 EF_SEARCH=128 \
   SEARCH_CONCURRENCY=8 \
-  TREEDB_QUANTIZED_INDEX_NAME=embedding.scalar_u8.fast \
+  TREEDB_SCALAR_U8_QUANTIZED_INDEX_NAME=embedding.scalar_u8.fast \
   TREEDB_QUANTIZED_RERANK_CANDIDATES=32 \
   TREEDB_QUANTIZED_MIN_RECALL=0 \
   scripts/bench_vector_db_compare.sh
@@ -157,15 +157,28 @@ RUN_DIR="$RUN_ROOT/scalar_u8_fixed_profile" ROWS=all \
 
 ## RaBitQ `rabitq_1bit` command contract
 
-Current checked-in RaBitQ Go benchmark/profile rows are fixed at 1024x128. Do
-not silently present them as the larger fixture matrix. Until a separate harness
-change adds scale parameters for `rabitq_1bit`, the contract is:
+For database-tier scale fixtures, use the persistent DB comparison harness with
+explicit RaBitQ aliases so these rows stay separate from scalar_u8 evidence:
 
-1. Run the fixed RaBitQ gate to prove route/counter/profile health on current
-   main.
-2. Mark larger RaBitQ fixture cells as `unavailable: no checked-in scale-matrix
-   RaBitQ harness` unless a separate approved harness PR exists.
-3. Never substitute future-codec or no-promote rows for current `rabitq_1bit` v1.
+```sh
+RUN_ROOT=${RUN_ROOT:-/tmp/gomap_2490_vector_crossover_$(date +%Y%m%d_%H%M%S)}
+
+run_rabitq_db_fixture() {
+  local id=$1 docs=$2 dims=$3
+  RUN_DIR="$RUN_ROOT/db_compare_rabitq/$id" \
+  BACKENDS=treedb_column_graph,treedb_column_graph_rabitq_1bit_quantized_only,treedb_column_graph_rabitq_1bit_quantized_rerank \
+  DOCS="$docs" DIMS="$dims" QUERIES=10000 VALIDATE_QUERIES=64 \
+  TOP_K=10 M=16 EF_CONSTRUCTION=128 EF_SEARCH=128 \
+  SEARCH_CONCURRENCY=8 \
+  TREEDB_RABITQ_QUANTIZED_INDEX_NAME=embedding.rabitq_1bit.fast \
+  TREEDB_RABITQ_QUANTIZED_RERANK_CANDIDATES=32 \
+  TREEDB_RABITQ_QUANTIZED_MIN_RECALL=0 \
+  scripts/bench_vector_db_compare.sh
+}
+```
+
+For RaBitQ scorer/profile attribution only, use the fixed profile gate. Never
+substitute future-codec or no-promote rows for current `rabitq_1bit` v1:
 
 ```sh
 RUN_ROOT=${RUN_ROOT:-/tmp/gomap_2490_vector_crossover_$(date +%Y%m%d_%H%M%S)}
@@ -189,11 +202,11 @@ RUN_ROOT=${RUN_ROOT:-/tmp/gomap_2490_vector_crossover_$(date +%Y%m%d_%H%M%S)}
 run_pgvector_fixture() {
   local id=$1 docs=$2 dims=$3
   RUN_DIR="$RUN_ROOT/db_compare_pgvector/$id" \
-  BACKENDS=treedb_column_graph,treedb_column_graph_quantized_only,treedb_column_graph_quantized_rerank,pgvector \
+  BACKENDS=treedb_column_graph,treedb_column_graph_scalar_u8_quantized_only,treedb_column_graph_scalar_u8_quantized_rerank,pgvector \
   DOCS="$docs" DIMS="$dims" QUERIES=10000 VALIDATE_QUERIES=64 \
   TOP_K=10 M=16 EF_CONSTRUCTION=128 EF_SEARCH=128 \
   SEARCH_CONCURRENCY=8 \
-  TREEDB_QUANTIZED_INDEX_NAME=embedding.scalar_u8.fast \
+  TREEDB_SCALAR_U8_QUANTIZED_INDEX_NAME=embedding.scalar_u8.fast \
   TREEDB_QUANTIZED_RERANK_CANDIDATES=32 \
   TREEDB_QUANTIZED_MIN_RECALL=0 \
   scripts/bench_vector_db_compare.sh

--- a/scripts/bench_vector_db_compare.sh
+++ b/scripts/bench_vector_db_compare.sh
@@ -18,16 +18,23 @@ M="${M:-16}"
 EF_CONSTRUCTION="${EF_CONSTRUCTION:-128}"
 EF_SEARCH="${EF_SEARCH:-128}"
 TREEDB_COLUMN_GRAPH_EF_SEARCH="${TREEDB_COLUMN_GRAPH_EF_SEARCH:-}"
+TREEDB_QUANTIZED_CODEC="${TREEDB_QUANTIZED_CODEC:-scalar_u8}"
 TREEDB_QUANTIZED_INDEX_NAME="${TREEDB_QUANTIZED_INDEX_NAME:-embedding.scalar_u8.fast}"
+TREEDB_SCALAR_U8_QUANTIZED_INDEX_NAME="${TREEDB_SCALAR_U8_QUANTIZED_INDEX_NAME:-$TREEDB_QUANTIZED_INDEX_NAME}"
+TREEDB_RABITQ_QUANTIZED_INDEX_NAME="${TREEDB_RABITQ_QUANTIZED_INDEX_NAME:-embedding.rabitq_1bit.fast}"
 DEFAULT_TREEDB_QUANTIZED_RERANK_CANDIDATES=32
 if [[ "$TOP_K" =~ ^[0-9]+$ ]] && ((TOP_K > DEFAULT_TREEDB_QUANTIZED_RERANK_CANDIDATES)); then
 	DEFAULT_TREEDB_QUANTIZED_RERANK_CANDIDATES="$TOP_K"
 fi
 TREEDB_QUANTIZED_RERANK_CANDIDATES="${TREEDB_QUANTIZED_RERANK_CANDIDATES:-$DEFAULT_TREEDB_QUANTIZED_RERANK_CANDIDATES}"
+TREEDB_RABITQ_QUANTIZED_RERANK_CANDIDATES="${TREEDB_RABITQ_QUANTIZED_RERANK_CANDIDATES:-$TREEDB_QUANTIZED_RERANK_CANDIDATES}"
 MIN_RECALL="${MIN_RECALL:-0.95}"
 TREEDB_QUANTIZED_MIN_RECALL="${TREEDB_QUANTIZED_MIN_RECALL:-0}"
 TREEDB_QUANTIZED_ONLY_MIN_RECALL="${TREEDB_QUANTIZED_ONLY_MIN_RECALL:-$TREEDB_QUANTIZED_MIN_RECALL}"
 TREEDB_QUANTIZED_RERANK_MIN_RECALL="${TREEDB_QUANTIZED_RERANK_MIN_RECALL:-$TREEDB_QUANTIZED_MIN_RECALL}"
+TREEDB_RABITQ_QUANTIZED_MIN_RECALL="${TREEDB_RABITQ_QUANTIZED_MIN_RECALL:-$TREEDB_QUANTIZED_MIN_RECALL}"
+TREEDB_RABITQ_QUANTIZED_ONLY_MIN_RECALL="${TREEDB_RABITQ_QUANTIZED_ONLY_MIN_RECALL:-$TREEDB_RABITQ_QUANTIZED_MIN_RECALL}"
+TREEDB_RABITQ_QUANTIZED_RERANK_MIN_RECALL="${TREEDB_RABITQ_QUANTIZED_RERANK_MIN_RECALL:-$TREEDB_RABITQ_QUANTIZED_MIN_RECALL}"
 VALIDATE_DOCS="${VALIDATE_DOCS:-16}"
 TREEDB_COMPACT="${TREEDB_COMPACT:-}"
 TREEDB_COMPACT_SYNC_EACH_PHASE="${TREEDB_COMPACT_SYNC_EACH_PHASE:-}"
@@ -86,18 +93,31 @@ validate_backends() {
 	for backend in "${raw[@]}"; do
 		backend="${backend//[[:space:]]/}"
 		case "$backend" in
-			treedb|treedb_column_graph|treedb_column_graph_quantized_only|treedb_column_graph_quantized_rerank|vectorlite|pgvector|mongodb)
+			treedb|treedb_column_graph|treedb_column_graph_quantized_only|treedb_column_graph_quantized_rerank|treedb_column_graph_scalar_u8_quantized_only|treedb_column_graph_scalar_u8_quantized_rerank|treedb_column_graph_rabitq_1bit_quantized_only|treedb_column_graph_rabitq_1bit_quantized_rerank|vectorlite|pgvector|mongodb)
 				;;
 			"")
 				echo "empty backend in BACKENDS=$BACKENDS" >&2
 				exit 1
 				;;
 			*)
-				echo "unknown backend: $backend (known: treedb,treedb_column_graph,treedb_column_graph_quantized_only,treedb_column_graph_quantized_rerank,vectorlite,pgvector,mongodb)" >&2
+				echo "unknown backend: $backend (known: treedb,treedb_column_graph,treedb_column_graph_quantized_only,treedb_column_graph_quantized_rerank,treedb_column_graph_scalar_u8_quantized_only,treedb_column_graph_scalar_u8_quantized_rerank,treedb_column_graph_rabitq_1bit_quantized_only,treedb_column_graph_rabitq_1bit_quantized_rerank,vectorlite,pgvector,mongodb)" >&2
 				exit 1
 				;;
 		esac
 	done
+}
+
+validate_treedb_quantized_codec() {
+	local codec="$1"
+	local source="$2"
+	case "$codec" in
+		scalar_u8|rabitq_1bit)
+			;;
+		*)
+			echo "$source must be scalar_u8 or rabitq_1bit, got: $codec" >&2
+			exit 1
+			;;
+	esac
 }
 
 validate_backend_configuration() {
@@ -105,6 +125,9 @@ validate_backend_configuration() {
 		echo "mongodb backend requested, but MONGODB_VECTOR_URI is empty" >&2
 		echo "Set MONGODB_VECTOR_URI to an Atlas or local Atlas Vector Search deployment, or remove mongodb from BACKENDS." >&2
 		exit 1
+	fi
+	if contains_backend treedb_column_graph_quantized_only || contains_backend treedb_column_graph_quantized_rerank; then
+		validate_treedb_quantized_codec "$TREEDB_QUANTIZED_CODEC" TREEDB_QUANTIZED_CODEC
 	fi
 }
 
@@ -188,7 +211,7 @@ fi
 treedb_profile_args=()
 treedb_search_profile_backend_supported() {
 	case "$1" in
-		treedb_column_graph|treedb_column_graph_quantized_only|treedb_column_graph_quantized_rerank)
+		treedb_column_graph|treedb_column_graph_quantized_only|treedb_column_graph_quantized_rerank|treedb_column_graph_scalar_u8_quantized_only|treedb_column_graph_scalar_u8_quantized_rerank|treedb_column_graph_rabitq_1bit_quantized_only|treedb_column_graph_rabitq_1bit_quantized_rerank)
 			return 0
 			;;
 		*)
@@ -223,8 +246,11 @@ cat >"$RUN_DIR/README.md" <<EOF
 - M / efConstruction / efSearch: \`$M / $EF_CONSTRUCTION / $EF_SEARCH\`
 - TreeDB column_graph efSearch: \`$TREEDB_COLUMN_GRAPH_EF_SEARCH\`
 - minimum recall: \`$MIN_RECALL\`
-- TreeDB quantized index/rerank candidates: \`$TREEDB_QUANTIZED_INDEX_NAME / $TREEDB_QUANTIZED_RERANK_CANDIDATES\`
+- TreeDB legacy quantized codec/index/rerank candidates: \`$TREEDB_QUANTIZED_CODEC / $TREEDB_QUANTIZED_INDEX_NAME / $TREEDB_QUANTIZED_RERANK_CANDIDATES\`
+- TreeDB scalar_u8 quantized index: \`$TREEDB_SCALAR_U8_QUANTIZED_INDEX_NAME\`
+- TreeDB RaBitQ quantized index/rerank candidates: \`$TREEDB_RABITQ_QUANTIZED_INDEX_NAME / $TREEDB_RABITQ_QUANTIZED_RERANK_CANDIDATES\`
 - TreeDB quantized-only/rerank minimum recall: \`$TREEDB_QUANTIZED_ONLY_MIN_RECALL / $TREEDB_QUANTIZED_RERANK_MIN_RECALL\`
+- TreeDB RaBitQ quantized-only/rerank minimum recall: \`$TREEDB_RABITQ_QUANTIZED_ONLY_MIN_RECALL / $TREEDB_RABITQ_QUANTIZED_RERANK_MIN_RECALL\`
 - TreeDB storage/validation knobs:
   - \`VALIDATE_DOCS=$VALIDATE_DOCS\`
   - \`TREEDB_COMPACT=${TREEDB_COMPACT:-<unset>}\`
@@ -242,8 +268,9 @@ This run compares persistent database-tier ANN search:
 - TreeDB native persisted HNSW through \`cmd/treedb_vector_search_demo\`
 - TreeDB column-store graph exact/default search through
   \`cmd/treedb_vector_search_demo -vector-index-strategy column_graph\`
-- TreeDB column-store graph scalar_u8 quantized modes through explicit
-  \`-vector-query-mode quantized_only|quantized_rerank\` demo flags
+- TreeDB column-store graph scalar_u8 and rabitq_1bit quantized modes through
+  explicit \`-vector-query-mode quantized_only|quantized_rerank\`,
+  \`-quantized-codec\`, and \`-quantized-index-name\` demo flags
 - SQLite+Vectorlite HNSW through Python's \`sqlite3\` and the \`vectorlite-py\`
   loadable extension
 - PostgreSQL+pgvector HNSW through a PostgreSQL server
@@ -339,16 +366,26 @@ if contains_backend treedb_column_graph; then
 	result_args+=(--result "$RUN_DIR/treedb_column_graph.json")
 fi
 
-if contains_backend treedb_column_graph_quantized_only; then
-	echo "running TreeDB column-store graph scalar_u8 quantized_only benchmark"
-	treedb_profile_args_for_backend treedb_column_graph_quantized_only
+run_treedb_column_graph_quantized() {
+	local backend="$1"
+	local mode="$2"
+	local codec="$3"
+	local index_name="$4"
+	local rerank_candidates="$5"
+	local min_recall="$6"
+	local output_name="$7"
+	local quantized_args=(-vector-query-mode "$mode" -quantized-codec "$codec" -quantized-index-name "$index_name")
+	if [[ "$mode" == "quantized_rerank" ]]; then
+		quantized_args+=(-quantized-rerank-candidates "$rerank_candidates")
+	fi
+	echo "running TreeDB column-store graph $codec $mode benchmark"
+	treedb_profile_args_for_backend "$backend"
 	GOWORK=off go run ./cmd/treedb_vector_search_demo \
 		-matrix=false \
 		-vector-index-strategy column_graph \
-		-vector-query-mode quantized_only \
-		-quantized-index-name "$TREEDB_QUANTIZED_INDEX_NAME" \
+		"${quantized_args[@]}" \
 		-dataset-dir "$RUN_DIR/dataset" \
-		-dir "$RUN_DIR/treedb_column_graph_quantized_only" \
+		-dir "$RUN_DIR/$output_name" \
 		-keep-dir \
 		-docs "$DOCS" \
 		-dims "$DIMS" \
@@ -361,37 +398,75 @@ if contains_backend treedb_column_graph_quantized_only; then
 		-m "$M" \
 		-ef-construction "$EF_CONSTRUCTION" \
 		-ef-search "$TREEDB_COLUMN_GRAPH_EF_SEARCH" \
-		-min-recall "$TREEDB_QUANTIZED_ONLY_MIN_RECALL" \
-		-json >"$RUN_DIR/treedb_column_graph_quantized_only.json"
-	result_args+=(--result "$RUN_DIR/treedb_column_graph_quantized_only.json")
+		-min-recall "$min_recall" \
+		-json >"$RUN_DIR/$output_name.json"
+	result_args+=(--result "$RUN_DIR/$output_name.json")
+}
+
+if contains_backend treedb_column_graph_quantized_only; then
+	run_treedb_column_graph_quantized \
+		treedb_column_graph_quantized_only \
+		quantized_only \
+		"$TREEDB_QUANTIZED_CODEC" \
+		"$TREEDB_QUANTIZED_INDEX_NAME" \
+		"$TREEDB_QUANTIZED_RERANK_CANDIDATES" \
+		"$TREEDB_QUANTIZED_ONLY_MIN_RECALL" \
+		treedb_column_graph_quantized_only
 fi
 
 if contains_backend treedb_column_graph_quantized_rerank; then
-	echo "running TreeDB column-store graph scalar_u8 quantized_rerank benchmark"
-	treedb_profile_args_for_backend treedb_column_graph_quantized_rerank
-	GOWORK=off go run ./cmd/treedb_vector_search_demo \
-		-matrix=false \
-		-vector-index-strategy column_graph \
-		-vector-query-mode quantized_rerank \
-		-quantized-index-name "$TREEDB_QUANTIZED_INDEX_NAME" \
-		-quantized-rerank-candidates "$TREEDB_QUANTIZED_RERANK_CANDIDATES" \
-		-dataset-dir "$RUN_DIR/dataset" \
-		-dir "$RUN_DIR/treedb_column_graph_quantized_rerank" \
-		-keep-dir \
-		-docs "$DOCS" \
-		-dims "$DIMS" \
-		-queries "$QUERIES" \
-		-search-concurrency "$SEARCH_CONCURRENCY" \
-		-validate-queries "$VALIDATE_QUERIES" \
-		${treedb_storage_args[@]+"${treedb_storage_args[@]}"} \
-		${treedb_profile_args[@]+"${treedb_profile_args[@]}"} \
-		-top-k "$TOP_K" \
-		-m "$M" \
-		-ef-construction "$EF_CONSTRUCTION" \
-		-ef-search "$TREEDB_COLUMN_GRAPH_EF_SEARCH" \
-		-min-recall "$TREEDB_QUANTIZED_RERANK_MIN_RECALL" \
-		-json >"$RUN_DIR/treedb_column_graph_quantized_rerank.json"
-	result_args+=(--result "$RUN_DIR/treedb_column_graph_quantized_rerank.json")
+	run_treedb_column_graph_quantized \
+		treedb_column_graph_quantized_rerank \
+		quantized_rerank \
+		"$TREEDB_QUANTIZED_CODEC" \
+		"$TREEDB_QUANTIZED_INDEX_NAME" \
+		"$TREEDB_QUANTIZED_RERANK_CANDIDATES" \
+		"$TREEDB_QUANTIZED_RERANK_MIN_RECALL" \
+		treedb_column_graph_quantized_rerank
+fi
+
+if contains_backend treedb_column_graph_scalar_u8_quantized_only; then
+	run_treedb_column_graph_quantized \
+		treedb_column_graph_scalar_u8_quantized_only \
+		quantized_only \
+		scalar_u8 \
+		"$TREEDB_SCALAR_U8_QUANTIZED_INDEX_NAME" \
+		"$TREEDB_QUANTIZED_RERANK_CANDIDATES" \
+		"$TREEDB_QUANTIZED_ONLY_MIN_RECALL" \
+		treedb_column_graph_scalar_u8_quantized_only
+fi
+
+if contains_backend treedb_column_graph_scalar_u8_quantized_rerank; then
+	run_treedb_column_graph_quantized \
+		treedb_column_graph_scalar_u8_quantized_rerank \
+		quantized_rerank \
+		scalar_u8 \
+		"$TREEDB_SCALAR_U8_QUANTIZED_INDEX_NAME" \
+		"$TREEDB_QUANTIZED_RERANK_CANDIDATES" \
+		"$TREEDB_QUANTIZED_RERANK_MIN_RECALL" \
+		treedb_column_graph_scalar_u8_quantized_rerank
+fi
+
+if contains_backend treedb_column_graph_rabitq_1bit_quantized_only; then
+	run_treedb_column_graph_quantized \
+		treedb_column_graph_rabitq_1bit_quantized_only \
+		quantized_only \
+		rabitq_1bit \
+		"$TREEDB_RABITQ_QUANTIZED_INDEX_NAME" \
+		"$TREEDB_RABITQ_QUANTIZED_RERANK_CANDIDATES" \
+		"$TREEDB_RABITQ_QUANTIZED_ONLY_MIN_RECALL" \
+		treedb_column_graph_rabitq_1bit_quantized_only
+fi
+
+if contains_backend treedb_column_graph_rabitq_1bit_quantized_rerank; then
+	run_treedb_column_graph_quantized \
+		treedb_column_graph_rabitq_1bit_quantized_rerank \
+		quantized_rerank \
+		rabitq_1bit \
+		"$TREEDB_RABITQ_QUANTIZED_INDEX_NAME" \
+		"$TREEDB_RABITQ_QUANTIZED_RERANK_CANDIDATES" \
+		"$TREEDB_RABITQ_QUANTIZED_RERANK_MIN_RECALL" \
+		treedb_column_graph_rabitq_1bit_quantized_rerank
 fi
 
 if contains_backend vectorlite; then


### PR DESCRIPTION
## Summary

Closes #2539. Part of #2538.

Adds first-class TreeDB DB/demo comparator support for RaBitQ `rabitq_1bit` rows at the buffered no-document `column_graph` boundary:

- `cmd/treedb_vector_search_demo` now accepts `-quantized-codec scalar_u8|rabitq_1bit` and emits `quantized_codec` in JSON/text/search rows.
- DB/demo backend labels are codec-separated: `treedb_column_graph_scalar_u8_quantized_*` vs `treedb_column_graph_rabitq_1bit_quantized_*`.
- `scripts/bench_vector_db_compare.sh` adds explicit scalar_u8 and RaBitQ backend aliases while keeping the old generic quantized aliases as scalar-compatible aliases.
- `benchmarks/vector_db_compare/summarize.py` renders separate `scalar_u8 quantized_*` and `rabitq_1bit quantized_*` modes.
- Docs/runbooks now show explicit scalar/RaBitQ row selection.

Guardrails: this PR does **not** change the RaBitQ codec identity, storage schema, bit order, scoring formula, or fail-closed search behavior.

## Tests

```sh
GOWORK=off go test -count=1 ./cmd/treedb_vector_search_demo
GOWORK=off go test -count=1 ./TreeDB/collections -run 'TestColumnGraphRabitQ|TestVectorIndexSearchQuantized'
python3 -m unittest discover benchmarks/vector_db_compare
bash -n scripts/bench_vector_db_compare.sh
```

Internal Pi review: PASS, saved at `/tmp/gomap_2539_review.txt`.

## Smoke evidence

Artifact dir: `/tmp/gomap_2539_smoke_20260607_095309`

Lock/context: `/tmp/gomap_2539_smoke_20260607_095309/lock_context.txt` (used `/tmp/gomap_2538_benchmark.lock` via `shlock`).

Command:

```sh
RUN_DIR=/tmp/gomap_2539_smoke_20260607_095309 \
BACKENDS=treedb_column_graph,treedb_column_graph_scalar_u8_quantized_only,treedb_column_graph_scalar_u8_quantized_rerank,treedb_column_graph_rabitq_1bit_quantized_only,treedb_column_graph_rabitq_1bit_quantized_rerank \
DOCS=128 DIMS=16 QUERIES=8 VALIDATE_QUERIES=2 VALIDATE_DOCS=1 TOP_K=3 SEARCH_CONCURRENCY=8 \
MIN_RECALL=0 TREEDB_QUANTIZED_MIN_RECALL=0 TREEDB_QUANTIZED_RERANK_CANDIDATES=32 \
TREEDB_RABITQ_QUANTIZED_RERANK_CANDIDATES=32 NUMPY_PACKAGE=numpy==2.3.5 \
scripts/bench_vector_db_compare.sh
```

Rows selected:

- exact: `treedb_column_graph.json`
- scalar_u8 qonly/rerank32: `treedb_column_graph_scalar_u8_quantized_only.json`, `treedb_column_graph_scalar_u8_quantized_rerank.json`
- RaBitQ qonly/rerank32: `treedb_column_graph_rabitq_1bit_quantized_only.json`, `treedb_column_graph_rabitq_1bit_quantized_rerank.json`
- summary: `comparison.md`
- counters: `guardrail_summary.txt`

RaBitQ guardrail counters from the smoke (`c=1` and `c=8`):

| row | c | avg exact rerank calls | avg vector bytes | avg norm bytes | docs fetched | exact fallbacks |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| rabitq_1bit qonly | 1 | 0 | 0 | 0 | 0 | 0 |
| rabitq_1bit qonly | 8 | 0 | 0 | 0 | 0 | 0 |
| rabitq_1bit rerank32 | 1 | 32 | 2048 | 128 | 0 | 0 |
| rabitq_1bit rerank32 | 8 | 32 | 2048 | 128 | 0 | 0 |

For `dims=16`, rerank32 bounds are `32 * 16 * 4 = 2048` vector bytes and `32 * 4 = 128` norm bytes.

## Dependency readiness

The row contract is stable for #2540/#2543 once this PR is accepted: exact, scalar_u8 qonly/rerank32, and RaBitQ qonly/rerank32 can be selected from the same DB/demo comparator harness with separate labels and guardrail counters.
