### PR TITLE
TreeDB: optimize portable RaBitQ byte-table scorer

### DIFF
--- a/TreeDB/collections/column_vector_graph_rabitq_byte_table.go
+++ b/TreeDB/collections/column_vector_graph_rabitq_byte_table.go
@@ -3,10 +3,41 @@ package collections
 import "github.com/snissn/gomap/TreeDB/internal/rabitq"
 
 func rabitqByteTableMismatchWeightPortable(querySignBits []byte, code []byte, byteMismatchWeights []float64) float64 {
-	var mismatchWeight float64
-	for byteIdx, candidateByte := range code {
-		xorMask := candidateByte ^ querySignBits[byteIdx]
-		mismatchWeight += byteMismatchWeights[byteIdx*rabitq.ByteMismatchTableEntries+int(xorMask)]
+	const tableEntries = rabitq.ByteMismatchTableEntries
+	n := len(code)
+	if n == 0 {
+		return 0
 	}
-	return mismatchWeight
+	// The checked scorer validates these lengths before reaching the hot loop.
+	// Keep the preloads here so portable Go builds have the same fail-fast
+	// behavior while giving the compiler enough shape information to remove
+	// per-iteration bounds checks in the unrolled loop below.
+	_ = querySignBits[n-1]
+	_ = byteMismatchWeights[n*tableEntries-1]
+
+	var sum0, sum1, sum2, sum3 float64
+	byteIdx := 0
+	tableBase := 0
+	for ; byteIdx+4 <= n; byteIdx += 4 {
+		candidate0 := code[byteIdx]
+		candidate1 := code[byteIdx+1]
+		candidate2 := code[byteIdx+2]
+		candidate3 := code[byteIdx+3]
+		query0 := querySignBits[byteIdx]
+		query1 := querySignBits[byteIdx+1]
+		query2 := querySignBits[byteIdx+2]
+		query3 := querySignBits[byteIdx+3]
+
+		sum0 += byteMismatchWeights[tableBase+int(candidate0^query0)]
+		sum1 += byteMismatchWeights[tableBase+tableEntries+int(candidate1^query1)]
+		sum2 += byteMismatchWeights[tableBase+2*tableEntries+int(candidate2^query2)]
+		sum3 += byteMismatchWeights[tableBase+3*tableEntries+int(candidate3^query3)]
+		tableBase += 4 * tableEntries
+	}
+	for ; byteIdx < n; byteIdx++ {
+		xorMask := code[byteIdx] ^ querySignBits[byteIdx]
+		sum0 += byteMismatchWeights[tableBase+int(xorMask)]
+		tableBase += tableEntries
+	}
+	return (sum0 + sum1) + (sum2 + sum3)
 }


### PR DESCRIPTION
## Objective

Evaluate and land a focused amd64-safe RaBitQ `rabitq_1bit` scorer optimization for #2542, without changing codec identity, storage schema, bit order, score formula, or fail-closed behavior.

Closes #2542. Parent tracker: #2538.

## What changed

- Optimizes the portable RaBitQ byte-table mismatch scorer by validating slice shapes once, unrolling four code bytes per loop, and using four independent accumulators.
- Keeps the ARM64 `!purego` assembly kernel unchanged.
- Keeps `purego` and non-native fallback behavior correct; no AVX/AVX512/assembly was needed because the Go-only path produced material amd64 wins with lower risk.

## amd64 context

Remote timed/profile jobs were run under `/tmp/gomap_2538_benchmark.lock`.

- CPU: 11th Gen Intel(R) Core(TM) i5-11400F @ 2.60GHz, 6 cores / 12 threads
- OS: Linux 6.8.0-124-generic x86_64 GNU/Linux
- Go: `go version go1.26.0 linux/amd64`
- Env: `GOMAXPROCS=8`, `GOWORK=off`
- Base: `origin/main` / `bff079294ea0fcc27dd9da16e385ca7426ab695b`
- Candidate head measured: local patch equivalent to this PR on top of `bff079294ea0fcc27dd9da16e385ca7426ab695b`

## Focused scorer evidence

Artifacts:

- Baseline: `/tmp/gomap_2542_baseline_micro_main_bff079_20260607_094232`
- Candidate: `/tmp/gomap_2542_candidate_final_micro_unroll4_20260607_095812`
- Benchstat: `/tmp/gomap_2542_candidate_final_micro_unroll4_20260607_095812/benchstat_vs_baseline_micro.txt`
- Profiles: `searchloop_cpu.pprof`, `searchloop_cpu_top.txt`, `searchloop_allocs.pprof`, `searchloop_allocs_top.txt` in each artifact dir

Commands:

```sh
# baseline/candidate timing
GOMAXPROCS=8 GOWORK=off go test ./TreeDB/collections \
  -run '^$' \
  -bench '^BenchmarkRabitQByteTableRuntimeScore' \
  -benchmem -benchtime=200000x -count=7

# baseline/candidate search-loop profile
GOMAXPROCS=8 GOWORK=off go test ./TreeDB/collections \
  -run '^$' \
  -bench '^BenchmarkRabitQByteTableRuntimeScoreSearchLoop2525$' \
  -benchmem -benchtime=200000x -count=1 \
  -cpuprofile <run>/searchloop_cpu.pprof \
  -memprofile <run>/searchloop_allocs.pprof
```

| benchmark | baseline ns/op | candidate ns/op | delta | baseline throughput | candidate throughput | B/op | allocs/op |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| runtime score dims=128 | 17.80 | 17.37 | flat/noisy | 56.2M scores/s | 57.6M scores/s | 0 | 0 |
| runtime score dims=1536 | 269.0 | 236.4 | -12.12% | 3.72M scores/s | 4.23M scores/s | 0 | 0 |
| runtime score search-loop (190 scores) | 50.15 µs | 43.91 µs | -12.43% | 19.9k searches/s | 22.8k searches/s | 0 | 0 |

CPU attribution remains in `rabitqByteTableMismatchWeightPortable`, but with lower walltime:

- Baseline search-loop profile: `Benchmark...SearchLoop2525` 49.752 µs/op; top frame `rabitqByteTableMismatchWeightPortable` 9.58s flat / 94.01%.
- Candidate search-loop profile: 45.388 µs/op; top frame `rabitqByteTableMismatchWeightPortable` 8.58s flat / 92.16%.

I also evaluated an 8-byte Go unroll (`/tmp/gomap_2542_candidate_unroll8_micro_20260607_095313`); it was not better overall and was discarded.

## Integrated `10k_x_1536` RaBitQ collection evidence

Artifacts:

- Baseline: `/tmp/gomap_2542_baseline_integrated_main_bff079_20260607_094421`
- Candidate: `/tmp/gomap_2542_candidate_integrated_unroll4_20260607_100020`
- Candidate summary: `/tmp/gomap_2542_candidate_integrated_unroll4_20260607_100020/summary.md`
- Benchstat vs baseline: `/tmp/gomap_2542_candidate_integrated_unroll4_20260607_100020/benchstat_vs_baseline.txt`

Command:

```sh
RUN_DIR=<run> BASELINE_DIR=<baseline-for-candidate> \
  SHAPE=10k_x_1536 \
  ROWS=rabitq_collection_quantized_only_c1,rabitq_collection_quantized_only_c8,rabitq_collection_quantized_rerank32_c1,rabitq_collection_quantized_rerank32_c8 \
  PROFILE_ROWS=rabitq_collection_quantized_only_c1,rabitq_collection_quantized_only_c8,rabitq_collection_quantized_rerank32_c1,rabitq_collection_quantized_rerank32_c8 \
  TIMING_COUNT=3 PROFILE_COUNT=1 BENCHTIME=1000x \
  GOMAXPROCS=8 GOWORK=off \
  scripts/treedb_rabitq_1bit_profile_gate.sh
```

| row | baseline ns/op | candidate ns/op | delta | baseline ops/sec | candidate ops/sec | guardrails |
| --- | ---: | ---: | ---: | ---: | ---: | --- |
| qonly c=1 | 89,373 | 80,979 | -9.39% | 11,189 | 12,349 | pass; 0 B/op, 0 allocs/op, exact reads 0 |
| qonly c=8 | 15,168 | 14,083 | -7.15% | 65,927 | 71,006 | pass; 0 B/op, 0 allocs/op, exact reads 0 |
| rerank32 c=1 | 97,372 | 87,826 | -9.80% | 10,270 | 11,386 | pass; exact score calls 32, vector/norm reads shortlist-bounded |
| rerank32 c=8 | 18,337 | 14,962 | -18.41% | 54,536 | 66,835 | pass; exact score calls 32, vector/norm reads shortlist-bounded |

All integrated rows report `0 B/op`, `0 allocs/op`, recall@K 100%, no docs fetched, no graph/typed/scratch/float64 fallback, no quantized asset unavailable counters, and unchanged route counters.

## Tests

Local validation artifacts: `/tmp/gomap_2542_validation_local`.
Remote amd64 focused validation artifact: `/tmp/gomap_2542_validation_remote_20260607_101401`.

```sh
GOWORK=off go test ./TreeDB/collections \
  -run 'TestRabitQByte|TestColumnGraphRabitQQuantizedScorerMatchesOracle2451|TestVectorIndexSearcherRabitQQuantizedSearchWithBuffer2451|TestCollectionSearchVectorIndexWithBufferRabitQQuantized2452' \
  -count=1

GOWORK=off go test -tags=purego ./TreeDB/collections \
  -run 'TestRabitQByteTableMismatchWeightKernelMatchesPortable2525|TestRabitQByteTableScorerMatchesOracleVariedDimensions2477|TestRabitQByteTableScorerFailClosed2477' \
  -count=1

GOWORK=off go test ./TreeDB/internal/rabitq -count=1
GOWORK=off go test ./TreeDB/collections -count=1
GOOS=linux GOARCH=amd64 GOWORK=off go test -c -o /tmp/gomap_2542_validation_local/collections_linux_amd64.test ./TreeDB/collections
GOOS=linux GOARCH=arm64 GOWORK=off go test -c -o /tmp/gomap_2542_validation_local/collections_linux_arm64.test ./TreeDB/collections
```

## Risk / rollout

Risk is limited to portable RaBitQ byte-table score summation. The public checked scorer and per-row qdp/code validation still fail closed. ARM64 native assembly dispatch is unchanged; `purego` uses the optimized portable path and is covered by focused tests.

## CI / Reviews

Latest head: `9f30b9fc3fe642c56eb0251b17c1b037993bac4d`.

- GitHub CI: green on latest head (`gh pr checks 2548`).
- Internal manager review: PASS; one-file scorer-only diff, no codec/storage/bit-order/score/fail-closed changes, tests and benchmark evidence match issue guardrails.
- Codex: requested with `@codex review`; result: no major issues.
- Copilot: requested with `@copilot review`; no surfaced findings/review as of latest-head CI green.
- CodeRabbit: status check green; PR comment indicates organization/rate-limit prevented a full generated review, with no actionable findings surfaced.
- Review threads: none open.
