### PR TITLE
Implement bounded TreeDB hybrid search executor

### DIFF
--- a/TreeDB/collections/hybrid_executor.go
+++ b/TreeDB/collections/hybrid_executor.go
@@ -240,9 +240,16 @@ func (c *Collection) hybridScalarAllowSet(plan hybridSearchExecutionPlan) (hybri
 		limit = plan.topK
 	}
 	filter := plan.scalarFilter
+	exists, err := c.hybridScalarIndexExists(filter.IndexName)
+	if err != nil {
+		return nil, HybridSearchStats{}, fmt.Errorf("%w: hybrid scalar filter index %q lookup failed: %w", ErrHybridSearchIndexUnavailable, filter.IndexName, err)
+	}
+	if !exists {
+		return nil, HybridSearchStats{}, fmt.Errorf("%w: hybrid scalar filter index %q is unavailable", ErrHybridSearchIndexUnavailable, filter.IndexName)
+	}
+
 	var ids [][]byte
 	var truncated bool
-	var err error
 	if filter.Range != nil {
 		rangeOpts := *filter.Range
 		rangeOpts.Limit = limit
@@ -254,7 +261,7 @@ func (c *Collection) hybridScalarAllowSet(plan hybridSearchExecutionPlan) (hybri
 		return nil, HybridSearchStats{}, fmt.Errorf("%w: hybrid scalar filter index %q lookup failed: %w", ErrHybridSearchIndexUnavailable, filter.IndexName, err)
 	}
 	if ids == nil {
-		return nil, HybridSearchStats{}, fmt.Errorf("%w: hybrid scalar filter index %q is unavailable", ErrHybridSearchIndexUnavailable, filter.IndexName)
+		ids = [][]byte{}
 	}
 	if truncated {
 		stats := HybridSearchStats{Truncated: 1}
@@ -271,6 +278,32 @@ func (c *Collection) hybridScalarAllowSet(plan hybridSearchExecutionPlan) (hybri
 	return set, stats, nil
 }
 
+func (c *Collection) hybridScalarIndexExists(indexName string) (bool, error) {
+	if err := ValidateIndexName(indexName); err != nil {
+		return false, err
+	}
+	if c == nil {
+		return false, errCollectionNil
+	}
+	if c.db == nil {
+		return false, errCollectionDBNil
+	}
+	snap := c.db.AcquireSnapshot()
+	if snap == nil {
+		return false, backenddb.ErrClosed
+	}
+	defer func() { _ = snap.Close() }()
+	catalog, err := c.catalogForSnapshot(snap)
+	if err != nil {
+		return false, err
+	}
+	if catalog == nil {
+		return false, errCollectionNotFound
+	}
+	_, ok := findIndex(catalog.meta.Indexes, indexName)
+	return ok, nil
+}
+
 func (c *Collection) hybridSearchCandidates(plan hybridSearchExecutionPlan) ([]HybridSearchCandidate, HybridSearchStats, error) {
 	var out []HybridSearchCandidate
 	var stats HybridSearchStats
@@ -281,7 +314,7 @@ func (c *Collection) hybridSearchCandidates(plan hybridSearchExecutionPlan) ([]H
 		response, err := c.SearchHybridTextCandidates(*plan.text)
 		hybridMergeStats(&stats, response.Stats)
 		if err != nil {
-			return err
+			return hybridCandidateSourceError{source: HybridCandidateSourceText, err: err}
 		}
 		out = append(out, response.Candidates...)
 		return nil
@@ -293,7 +326,7 @@ func (c *Collection) hybridSearchCandidates(plan hybridSearchExecutionPlan) ([]H
 		response, err := c.SearchHybridVectorCandidates(*plan.vector)
 		hybridMergeStats(&stats, response.Stats)
 		if err != nil {
-			return err
+			return hybridCandidateSourceError{source: HybridCandidateSourceVector, err: err}
 		}
 		out = append(out, response.Candidates...)
 		return nil
@@ -515,17 +548,40 @@ func hybridStatsFailClosedReason(stats HybridSearchStats, fallback HybridFailClo
 	return fallback
 }
 
+type hybridCandidateSourceError struct {
+	source HybridCandidateSource
+	err    error
+}
+
+func (e hybridCandidateSourceError) Error() string {
+	if e.err == nil {
+		return ""
+	}
+	return e.err.Error()
+}
+
+func (e hybridCandidateSourceError) Unwrap() error { return e.err }
+
 func hybridCandidateErrorFailClosedReason(err error) HybridFailClosedReason {
 	switch {
 	case err == nil:
 		return HybridFailClosedReasonNone
+	case errors.Is(err, ErrHybridSearchStaleIndex):
+		return HybridFailClosedReasonSnapshotMismatch
 	case errors.Is(err, ErrHybridSearchIndexUnavailable):
+		var sourceErr hybridCandidateSourceError
+		if errors.As(err, &sourceErr) {
+			switch sourceErr.source {
+			case HybridCandidateSourceText:
+				return HybridFailClosedReasonTextIndexUnavailable
+			case HybridCandidateSourceVector:
+				return HybridFailClosedReasonVectorIndexUnavailable
+			}
+		}
 		if errors.Is(err, ErrIndexNotFound) {
 			return HybridFailClosedReasonTextIndexUnavailable
 		}
 		return HybridFailClosedReasonVectorIndexUnavailable
-	case errors.Is(err, ErrHybridSearchStaleIndex):
-		return HybridFailClosedReasonSnapshotMismatch
 	default:
 		return HybridFailClosedReasonUnsupported
 	}

--- a/TreeDB/collections/hybrid_executor.go
+++ b/TreeDB/collections/hybrid_executor.go
@@ -1,0 +1,545 @@
+package collections
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+)
+
+const hybridDefaultCandidateLimitMultiplier = 4
+
+type hybridSearchExecutionPlan struct {
+	public HybridSearchPlan
+
+	text                 *HybridTextQuery
+	vector               *HybridVectorQuery
+	scalarFilter         *HybridScalarFilter
+	scalarFilterStrategy HybridScalarFilterStrategy
+	fusion               HybridFusionOptions
+	topK                 int
+	scalarLookupLimit    int
+}
+
+func (c *Collection) searchHybrid(opts HybridSearchOptions) (HybridSearchResponse, error) {
+	plan, err := planHybridSearch(opts)
+	response := HybridSearchResponse{Plan: plan.public}
+	if err != nil {
+		return hybridSearchFailClosed(response, hybridPlanFailClosedReason(err), err)
+	}
+
+	if err := c.flushBufferedWrites(); err != nil {
+		return hybridSearchFailClosed(response, HybridFailClosedReasonSnapshotMismatch, fmt.Errorf("%w: hybrid search cannot flush current snapshot: %w", ErrHybridSearchIndexUnavailable, err))
+	}
+	baseState := c.db.State()
+	response.Snapshot = hybridSearchSnapshotFromState(baseState)
+	if baseState == nil {
+		return hybridSearchFailClosed(response, HybridFailClosedReasonSnapshotMismatch, fmt.Errorf("%w: hybrid search current snapshot unavailable", ErrHybridSearchIndexUnavailable))
+	}
+
+	allowSet, scalarStats, err := c.hybridScalarAllowSet(plan)
+	hybridMergeStats(&response.Stats, scalarStats)
+	if err != nil {
+		return hybridSearchFailClosed(response, HybridFailClosedReasonScalarFilterUnbounded, err)
+	}
+	if err := hybridSearchCheckCurrentSnapshot(c.db.State(), baseState); err != nil {
+		return hybridSearchFailClosed(response, HybridFailClosedReasonSnapshotMismatch, err)
+	}
+
+	candidates, candidateStats, err := c.hybridSearchCandidates(plan)
+	hybridMergeStats(&response.Stats, candidateStats)
+	if err != nil {
+		return hybridSearchFailClosed(response, hybridStatsFailClosedReason(candidateStats, hybridCandidateErrorFailClosedReason(err)), err)
+	}
+	if err := hybridSearchCheckCurrentSnapshot(c.db.State(), baseState); err != nil {
+		return hybridSearchFailClosed(response, HybridFailClosedReasonSnapshotMismatch, err)
+	}
+
+	fusionCandidates := candidates
+	if allowSet != nil && plan.scalarFilterStrategy != HybridScalarFilterStrategyPostfilter {
+		fusionCandidates = hybridFilterCandidatesByScalarAllowSet(candidates, allowSet, &response.Stats)
+		response.Stats.CandidatesAfterFilter = uint64(len(fusionCandidates))
+	}
+	if opts.Debug.IncludeCandidates {
+		response.Candidates = cloneHybridSearchCandidates(fusionCandidates)
+	}
+
+	results, fusionStats, err := hybridFusePlannedCandidates(fusionCandidates, plan)
+	hybridMergeStats(&response.Stats, fusionStats)
+	if err != nil {
+		return hybridSearchFailClosed(response, HybridFailClosedReasonUnsupported, err)
+	}
+	if allowSet != nil && plan.scalarFilterStrategy == HybridScalarFilterStrategyPostfilter {
+		results = hybridFilterResultsByScalarAllowSet(results, allowSet, plan.topK, &response.Stats)
+	} else if response.Stats.CandidatesAfterFilter == 0 {
+		response.Stats.CandidatesAfterFilter = uint64(len(results))
+	}
+	response.Results = results
+
+	if err := hybridSearchCheckCurrentSnapshot(c.db.State(), baseState); err != nil {
+		return hybridSearchFailClosed(response, HybridFailClosedReasonSnapshotMismatch, err)
+	}
+	if opts.IncludeDocuments {
+		if err := c.hybridFetchResultDocuments(&response, opts.DocumentFetchOptions, baseState); err != nil {
+			reason := HybridFailClosedReasonDocumentFetchUnavailable
+			if errors.Is(err, ErrHybridSearchStaleIndex) {
+				reason = HybridFailClosedReasonSnapshotMismatch
+			}
+			return hybridSearchFailClosed(response, reason, err)
+		}
+	}
+	return response, nil
+}
+
+func planHybridSearch(opts HybridSearchOptions) (hybridSearchExecutionPlan, error) {
+	var plan hybridSearchExecutionPlan
+	if opts.TopK <= 0 {
+		return plan, fmt.Errorf("%w: hybrid search top_k must be positive", ErrHybridSearchUnsupported)
+	}
+	mode := opts.Consistency.Mode
+	if mode == "" {
+		mode = HybridConsistencyCurrentSnapshot
+	}
+	if mode != HybridConsistencyCurrentSnapshot {
+		return plan, fmt.Errorf("%w: hybrid search consistency mode %q requires an explicit bound snapshot API", ErrHybridSearchUnsupported, mode)
+	}
+	if opts.Text == nil && opts.Vector == nil {
+		return plan, fmt.Errorf("%w: hybrid search requires at least one text or vector source", ErrHybridSearchUnsupported)
+	}
+
+	plan.topK = opts.TopK
+	plan.fusion = opts.Fusion
+	plan.public.FinalTopK = opts.TopK
+	plan.public.FusionMethod = opts.Fusion.Method
+	if plan.public.FusionMethod == "" {
+		plan.public.FusionMethod = HybridFusionMethodRRF
+	}
+	plan.public.FusionTiePolicy = opts.Fusion.TiePolicy
+	if plan.public.FusionTiePolicy == "" {
+		plan.public.FusionTiePolicy = HybridFusionTiePolicyScoreBestRankSourceID
+	}
+
+	if opts.Text != nil {
+		text := *opts.Text
+		if text.CandidateLimit < 0 {
+			return plan, fmt.Errorf("%w: text candidate limit cannot be negative", ErrHybridSearchUnsupported)
+		}
+		if text.CandidateLimit == 0 {
+			text.CandidateLimit = hybridDefaultCandidateLimit(opts.TopK)
+		}
+		plan.text = &text
+		plan.public.TextCandidateLimit = text.CandidateLimit
+	}
+	if opts.Vector != nil {
+		vector := *opts.Vector
+		if vector.CandidateLimit < 0 {
+			return plan, fmt.Errorf("%w: vector candidate limit cannot be negative", ErrHybridSearchUnsupported)
+		}
+		if vector.CandidateLimit == 0 {
+			vector.CandidateLimit = hybridDefaultCandidateLimit(opts.TopK)
+		}
+		plan.vector = &vector
+		plan.public.VectorCandidateLimit = vector.CandidateLimit
+	}
+
+	strategy, err := normalizeHybridScalarFilterStrategy(opts.ScalarFilterStrategy, plan.text != nil, plan.vector != nil, opts.ScalarFilter != nil)
+	if err != nil {
+		return plan, err
+	}
+	plan.scalarFilterStrategy = strategy
+	plan.public.ScalarFilterStrategy = strategy
+
+	if opts.ScalarFilter != nil {
+		filter := *opts.ScalarFilter
+		if err := validateHybridScalarFilter(filter); err != nil {
+			return plan, err
+		}
+		plan.scalarFilter = &filter
+		plan.scalarLookupLimit = hybridScalarLookupLimit(plan)
+	}
+	return plan, nil
+}
+
+func hybridDefaultCandidateLimit(topK int) int {
+	if topK <= 0 {
+		return 0
+	}
+	if topK > maxCollectionInt/hybridDefaultCandidateLimitMultiplier {
+		return maxCollectionInt
+	}
+	return topK * hybridDefaultCandidateLimitMultiplier
+}
+
+func normalizeHybridScalarFilterStrategy(strategy HybridScalarFilterStrategy, hasText, hasVector, hasScalar bool) (HybridScalarFilterStrategy, error) {
+	if strategy != "" {
+		switch strategy {
+		case HybridScalarFilterStrategyPrefilter,
+			HybridScalarFilterStrategyPostfilter,
+			HybridScalarFilterStrategyTextFirst,
+			HybridScalarFilterStrategyVectorFirst,
+			HybridScalarFilterStrategyUnionFusion:
+			return strategy, nil
+		default:
+			return "", fmt.Errorf("%w: hybrid scalar filter strategy %q", ErrHybridSearchUnsupported, strategy)
+		}
+	}
+	if hasScalar {
+		return HybridScalarFilterStrategyPrefilter, nil
+	}
+	if hasText && hasVector {
+		return HybridScalarFilterStrategyUnionFusion, nil
+	}
+	if hasText {
+		return HybridScalarFilterStrategyTextFirst, nil
+	}
+	return HybridScalarFilterStrategyVectorFirst, nil
+}
+
+func validateHybridScalarFilter(filter HybridScalarFilter) error {
+	if filter.IndexName == "" {
+		return fmt.Errorf("%w: hybrid scalar filter requires an index name", ErrHybridSearchUnsupported)
+	}
+	if filter.Range != nil && filter.Value != nil {
+		return fmt.Errorf("%w: hybrid scalar filter cannot set both value and range", ErrHybridSearchUnsupported)
+	}
+	if filter.Range != nil && filter.Range.Limit < 0 {
+		return fmt.Errorf("%w: hybrid scalar filter range limit cannot be negative", ErrHybridSearchUnsupported)
+	}
+	return nil
+}
+
+func hybridScalarLookupLimit(plan hybridSearchExecutionPlan) int {
+	limit := plan.topK
+	if plan.text != nil {
+		if limit > maxCollectionInt-plan.text.CandidateLimit {
+			return maxCollectionInt
+		}
+		limit += plan.text.CandidateLimit
+	}
+	if plan.vector != nil {
+		if limit > maxCollectionInt-plan.vector.CandidateLimit {
+			return maxCollectionInt
+		}
+		limit += plan.vector.CandidateLimit
+	}
+	if limit <= 0 {
+		return plan.topK
+	}
+	return limit
+}
+
+type hybridScalarAllowSet map[string]struct{}
+
+func (c *Collection) hybridScalarAllowSet(plan hybridSearchExecutionPlan) (hybridScalarAllowSet, HybridSearchStats, error) {
+	if plan.scalarFilter == nil {
+		return nil, HybridSearchStats{}, nil
+	}
+	limit := plan.scalarLookupLimit
+	if limit <= 0 {
+		limit = plan.topK
+	}
+	filter := plan.scalarFilter
+	var ids [][]byte
+	var truncated bool
+	var err error
+	if filter.Range != nil {
+		rangeOpts := *filter.Range
+		rangeOpts.Limit = limit
+		ids, truncated, err = c.FindByIndexRange(filter.IndexName, rangeOpts)
+	} else {
+		ids, truncated, err = c.FindByIndexValueLimit(filter.IndexName, filter.Value, limit)
+	}
+	if err != nil {
+		return nil, HybridSearchStats{}, fmt.Errorf("%w: hybrid scalar filter index %q lookup failed: %w", ErrHybridSearchIndexUnavailable, filter.IndexName, err)
+	}
+	if ids == nil {
+		return nil, HybridSearchStats{}, fmt.Errorf("%w: hybrid scalar filter index %q is unavailable", ErrHybridSearchIndexUnavailable, filter.IndexName)
+	}
+	if truncated {
+		stats := HybridSearchStats{Truncated: 1}
+		return nil, stats, fmt.Errorf("%w: hybrid scalar filter index %q exceeded bounded lookup limit %d", ErrHybridSearchIndexUnavailable, filter.IndexName, limit)
+	}
+	set := make(hybridScalarAllowSet, len(ids))
+	for _, id := range ids {
+		set[string(id)] = struct{}{}
+	}
+	stats := HybridSearchStats{}
+	if plan.scalarFilterStrategy == HybridScalarFilterStrategyPrefilter {
+		stats.ScalarPrefilterIDs = uint64(len(set))
+	}
+	return set, stats, nil
+}
+
+func (c *Collection) hybridSearchCandidates(plan hybridSearchExecutionPlan) ([]HybridSearchCandidate, HybridSearchStats, error) {
+	var out []HybridSearchCandidate
+	var stats HybridSearchStats
+	runText := func() error {
+		if plan.text == nil {
+			return nil
+		}
+		response, err := c.SearchHybridTextCandidates(*plan.text)
+		hybridMergeStats(&stats, response.Stats)
+		if err != nil {
+			return err
+		}
+		out = append(out, response.Candidates...)
+		return nil
+	}
+	runVector := func() error {
+		if plan.vector == nil {
+			return nil
+		}
+		response, err := c.SearchHybridVectorCandidates(*plan.vector)
+		hybridMergeStats(&stats, response.Stats)
+		if err != nil {
+			return err
+		}
+		out = append(out, response.Candidates...)
+		return nil
+	}
+
+	switch plan.scalarFilterStrategy {
+	case HybridScalarFilterStrategyVectorFirst:
+		if err := runVector(); err != nil {
+			return nil, stats, err
+		}
+		if err := runText(); err != nil {
+			return nil, stats, err
+		}
+	default:
+		if err := runText(); err != nil {
+			return nil, stats, err
+		}
+		if err := runVector(); err != nil {
+			return nil, stats, err
+		}
+	}
+	return out, stats, nil
+}
+
+func hybridFilterCandidatesByScalarAllowSet(candidates []HybridSearchCandidate, allowSet hybridScalarAllowSet, stats *HybridSearchStats) []HybridSearchCandidate {
+	if allowSet == nil {
+		return candidates
+	}
+	out := make([]HybridSearchCandidate, 0, len(candidates))
+	for _, candidate := range candidates {
+		if stats != nil {
+			stats.ScalarPostfilterChecks++
+		}
+		if _, ok := allowSet[string(candidate.ID)]; ok {
+			if stats != nil {
+				stats.ScalarFilterMatched++
+			}
+			out = append(out, candidate)
+		} else if stats != nil {
+			stats.ScalarFilterRejected++
+		}
+	}
+	return out
+}
+
+func hybridFusePlannedCandidates(candidates []HybridSearchCandidate, plan hybridSearchExecutionPlan) ([]HybridSearchResult, HybridSearchStats, error) {
+	topK := plan.topK
+	if plan.scalarFilter != nil && plan.scalarFilterStrategy == HybridScalarFilterStrategyPostfilter {
+		topK = len(candidates)
+	}
+	return FuseHybridSearchCandidates(candidates, plan.fusion, topK)
+}
+
+func hybridFilterResultsByScalarAllowSet(results []HybridSearchResult, allowSet hybridScalarAllowSet, topK int, stats *HybridSearchStats) []HybridSearchResult {
+	if allowSet == nil {
+		return results
+	}
+	filtered := make([]HybridSearchResult, 0, len(results))
+	for _, result := range results {
+		if stats != nil {
+			stats.ScalarPostfilterChecks++
+		}
+		if _, ok := allowSet[string(result.ID)]; ok {
+			if stats != nil {
+				stats.ScalarFilterMatched++
+			}
+			filtered = append(filtered, result)
+		} else if stats != nil {
+			stats.ScalarFilterRejected++
+		}
+	}
+	limit := topK
+	if limit < 0 {
+		limit = 0
+	}
+	if limit > len(filtered) {
+		limit = len(filtered)
+	}
+	if stats != nil {
+		stats.CandidatesAfterFilter = uint64(limit)
+		if limit < len(filtered) {
+			stats.Truncated += uint64(len(filtered) - limit)
+		}
+	}
+	out := filtered[:limit]
+	for i := range out {
+		out[i].Rank = i + 1
+	}
+	return out
+}
+
+func (c *Collection) hybridFetchResultDocuments(response *HybridSearchResponse, opts DocumentFetchOptions, baseState *backenddb.DBState) error {
+	if response == nil || len(response.Results) == 0 {
+		return nil
+	}
+	ids := make([][]byte, len(response.Results))
+	for i := range response.Results {
+		ids[i] = response.Results[i].ID
+	}
+	view, err := c.OpenCollectionReadView()
+	if err != nil {
+		return fmt.Errorf("%w: hybrid final document read view unavailable: %w", ErrHybridSearchIndexUnavailable, err)
+	}
+	defer func() { _ = view.Close() }()
+	if err := hybridSearchCheckCurrentSnapshot(view.snapshot.State(), baseState); err != nil {
+		return err
+	}
+	fetch, err := view.FetchDocumentsByID(ids, opts)
+	hybridMergeDocumentFetchStats(&response.Stats, fetch.Stats)
+	if err != nil {
+		return fmt.Errorf("%w: hybrid final document fetch failed: %w", ErrHybridSearchIndexUnavailable, err)
+	}
+	if len(fetch.Results) != len(response.Results) {
+		return fmt.Errorf("%w: hybrid final document fetch returned %d results for %d ids", ErrHybridSearchIndexUnavailable, len(fetch.Results), len(response.Results))
+	}
+	for i := range fetch.Results {
+		if !fetch.Results[i].Found {
+			return fmt.Errorf("%w: hybrid final document %q not found", ErrHybridSearchIndexUnavailable, string(fetch.Results[i].ID))
+		}
+		response.Results[i].Document = bytes.Clone(fetch.Results[i].Document)
+		response.Results[i].DocumentFound = true
+	}
+	return nil
+}
+
+func hybridSearchSnapshotFromState(state *backenddb.DBState) HybridSearchSnapshot {
+	snapshot := HybridSearchSnapshot{Consistency: HybridConsistencyCurrentSnapshot}
+	if state == nil {
+		return snapshot
+	}
+	snapshot.CommitSeq = state.CommitSeq
+	snapshot.SystemRootPageID = state.SystemRootPageID
+	snapshot.CollectionGeneration = state.CommitSeq
+	return snapshot
+}
+
+func hybridSearchCheckCurrentSnapshot(current, base *backenddb.DBState) error {
+	if current == nil || base == nil {
+		return fmt.Errorf("%w: hybrid search current snapshot disappeared", ErrHybridSearchStaleIndex)
+	}
+	if current.CommitSeq != base.CommitSeq || current.SystemRootPageID != base.SystemRootPageID || current.RootPageID != base.RootPageID {
+		return fmt.Errorf("%w: hybrid search snapshot changed from commit=%d system_root=%d root=%d to commit=%d system_root=%d root=%d", ErrHybridSearchStaleIndex, base.CommitSeq, base.SystemRootPageID, base.RootPageID, current.CommitSeq, current.SystemRootPageID, current.RootPageID)
+	}
+	return nil
+}
+
+func hybridMergeStats(dst *HybridSearchStats, src HybridSearchStats) {
+	if dst == nil {
+		return
+	}
+	dst.TextCandidatesRequested += src.TextCandidatesRequested
+	dst.TextCandidatesReturned += src.TextCandidatesReturned
+	dst.TextPostingsScanned += src.TextPostingsScanned
+	dst.TextCandidatesScored += src.TextCandidatesScored
+	dst.VectorCandidatesRequested += src.VectorCandidatesRequested
+	dst.VectorCandidatesReturned += src.VectorCandidatesReturned
+	dst.VectorCandidatesExamined += src.VectorCandidatesExamined
+	dst.VectorEdgesVisited += src.VectorEdgesVisited
+	dst.ScalarPrefilterIDs += src.ScalarPrefilterIDs
+	dst.ScalarPostfilterChecks += src.ScalarPostfilterChecks
+	dst.ScalarFilterMatched += src.ScalarFilterMatched
+	dst.ScalarFilterRejected += src.ScalarFilterRejected
+	dst.CandidatesFused += src.CandidatesFused
+	dst.CandidatesAfterFusion += src.CandidatesAfterFusion
+	dst.FusionTextOnly += src.FusionTextOnly
+	dst.FusionVectorOnly += src.FusionVectorOnly
+	dst.FusionBoth += src.FusionBoth
+	dst.FusionDuplicateCandidates += src.FusionDuplicateCandidates
+	dst.CandidatesAfterFilter += src.CandidatesAfterFilter
+	dst.DocumentsFetched += src.DocumentsFetched
+	dst.DocumentsMissing += src.DocumentsMissing
+	dst.FullDocumentScanFallbacks += src.FullDocumentScanFallbacks
+	dst.Truncated += src.Truncated
+	dst.FailClosed += src.FailClosed
+	if dst.FailClosedReason == "" || dst.FailClosedReason == HybridFailClosedReasonNone {
+		dst.FailClosedReason = src.FailClosedReason
+	}
+}
+
+func hybridMergeDocumentFetchStats(dst *HybridSearchStats, src DocumentMaterializationStats) {
+	if dst == nil {
+		return
+	}
+	dst.DocumentsFetched += src.DocumentsFetched
+	dst.DocumentsMissing += src.DocumentsMissing
+}
+
+func hybridSearchFailClosed(response HybridSearchResponse, reason HybridFailClosedReason, err error) (HybridSearchResponse, error) {
+	if reason == "" {
+		reason = HybridFailClosedReasonUnsupported
+	}
+	if response.Stats.FailClosed == 0 {
+		response.Stats.FailClosed = 1
+	}
+	response.Stats.FailClosedReason = reason
+	response.Results = nil
+	response.Candidates = nil
+	return response, err
+}
+
+func hybridPlanFailClosedReason(err error) HybridFailClosedReason {
+	if err == nil {
+		return HybridFailClosedReasonNone
+	}
+	if stringsContainsSnapshotMode(err.Error()) {
+		return HybridFailClosedReasonSnapshotMismatch
+	}
+	return HybridFailClosedReasonUnsupported
+}
+
+func stringsContainsSnapshotMode(s string) bool {
+	return bytes.Contains([]byte(s), []byte("consistency mode")) || bytes.Contains([]byte(s), []byte("snapshot"))
+}
+
+func hybridStatsFailClosedReason(stats HybridSearchStats, fallback HybridFailClosedReason) HybridFailClosedReason {
+	if stats.FailClosedReason != "" && stats.FailClosedReason != HybridFailClosedReasonNone {
+		return stats.FailClosedReason
+	}
+	return fallback
+}
+
+func hybridCandidateErrorFailClosedReason(err error) HybridFailClosedReason {
+	switch {
+	case err == nil:
+		return HybridFailClosedReasonNone
+	case errors.Is(err, ErrHybridSearchIndexUnavailable):
+		if errors.Is(err, ErrIndexNotFound) {
+			return HybridFailClosedReasonTextIndexUnavailable
+		}
+		return HybridFailClosedReasonVectorIndexUnavailable
+	case errors.Is(err, ErrHybridSearchStaleIndex):
+		return HybridFailClosedReasonSnapshotMismatch
+	default:
+		return HybridFailClosedReasonUnsupported
+	}
+}
+
+func cloneHybridSearchCandidates(in []HybridSearchCandidate) []HybridSearchCandidate {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]HybridSearchCandidate, len(in))
+	for i := range in {
+		out[i] = in[i]
+		out[i].ID = bytes.Clone(in[i].ID)
+		out[i].TextMatches = cloneHybridTextMatches(in[i].TextMatches)
+	}
+	return out
+}

--- a/TreeDB/collections/hybrid_search.go
+++ b/TreeDB/collections/hybrid_search.go
@@ -1,9 +1,6 @@
 package collections
 
-import (
-	"errors"
-	"fmt"
-)
+import "errors"
 
 // Hybrid-search errors are fail-closed sentinels. Implementations may wrap them
 // with source/index-specific detail, but must not silently scan all documents or
@@ -269,17 +266,17 @@ type HybridSearchResponse struct {
 	Results    []HybridSearchResult    `json:"results,omitempty"`
 }
 
-// SearchHybrid is the reserved collection-level hybrid search entry point. The
-// #2505 executor will implement it; until then it fails closed so callers cannot
-// accidentally depend on a scan-all-documents fallback.
+// SearchHybrid executes a bounded hybrid search over optional text and vector
+// candidate sources, an optional scalar-index filter, deterministic rank fusion,
+// and optional final top-k document materialization. It fails closed instead of
+// scanning primary documents when a requested source/filter/fetch path is
+// unavailable or unsupported.
 func (c *Collection) SearchHybrid(opts HybridSearchOptions) (HybridSearchResponse, error) {
-	_ = opts
 	if c == nil {
 		return HybridSearchResponse{}, errCollectionNil
 	}
 	if c.db == nil {
 		return HybridSearchResponse{}, errCollectionDBNil
 	}
-	response := HybridSearchResponse{Stats: HybridSearchStats{FailClosed: 1, FailClosedReason: HybridFailClosedReasonUnsupported}}
-	return response, fmt.Errorf("%w: SearchHybrid executor is deferred to issue #2505", ErrHybridSearchUnsupported)
+	return c.searchHybrid(opts)
 }

--- a/TreeDB/collections/hybrid_search_contract_test.go
+++ b/TreeDB/collections/hybrid_search_contract_test.go
@@ -147,13 +147,13 @@ func TestHybridSearchCandidateAndResultShape2502(t *testing.T) {
 	}
 }
 
-func TestSearchHybridStubFailsClosed2502(t *testing.T) {
+func TestSearchHybridValidationFailsClosed2502(t *testing.T) {
 	response, err := (&Collection{db: &backenddb.DB{}}).SearchHybrid(HybridSearchOptions{TopK: 10})
 	if !errors.Is(err, ErrHybridSearchUnsupported) {
 		t.Fatalf("SearchHybrid err=%v want ErrHybridSearchUnsupported", err)
 	}
 	if len(response.Results) != 0 || response.Stats.FailClosed != 1 || response.Stats.FailClosedReason != HybridFailClosedReasonUnsupported || response.Stats.FullDocumentScanFallbacks != 0 {
-		t.Fatalf("SearchHybrid response=%+v want fail-closed stub with no scan fallback", response)
+		t.Fatalf("SearchHybrid response=%+v want fail-closed unsupported shape with no scan fallback", response)
 	}
 
 	nilResponse, err := (*Collection)(nil).SearchHybrid(HybridSearchOptions{})

--- a/TreeDB/collections/hybrid_search_executor_test.go
+++ b/TreeDB/collections/hybrid_search_executor_test.go
@@ -1,0 +1,485 @@
+package collections
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+
+	backenddb "github.com/snissn/gomap/TreeDB/db"
+)
+
+type hybridSearchExecutorFixtureRow2505 struct {
+	id     string
+	title  string
+	body   string
+	city   string
+	score  int64
+	vector []float32
+}
+
+func TestSearchHybridExecutorTextVectorOverlapAndBoundedFetch2505(t *testing.T) {
+	_, d, col, def := openHybridSearchExecutorFixture2505(t, []hybridSearchExecutorFixtureRow2505{
+		{id: "doc-shared", title: "refund", body: "refund refund", city: "sea", score: 10, vector: []float32{1, 0, 0}},
+		{id: "doc-text", title: "refund", body: "refund customer policy", city: "sea", score: 20, vector: []float32{0.2, 0.8, 0}},
+		{id: "doc-vector", title: "shipping", body: "shipping update", city: "sea", score: 30, vector: []float32{0.99, 0.01, 0}},
+		{id: "doc-filtered", title: "refund", body: "refund", city: "sfo", score: 40, vector: []float32{0.4, 0.6, 0}},
+		{id: "doc-background", title: "other", body: "other", city: "sea", score: 50, vector: []float32{0, 0, 1}},
+	})
+	defer func() { _ = d.Close() }()
+
+	opts := HybridSearchOptions{
+		TopK:             3,
+		Text:             &HybridTextQuery{IndexName: "lexical", Query: "refund", CandidateLimit: 4},
+		Vector:           &HybridVectorQuery{IndexName: def.Name, Query: []float32{1, 0, 0}, CandidateLimit: 4, EfSearch: 5, QueryMode: VectorIndexQueryModeExact},
+		IncludeDocuments: true,
+		DocumentFetchOptions: DocumentFetchOptions{
+			ExcludePaths: []string{"embedding"},
+		},
+		Debug: HybridSearchDebugOptions{IncludeCandidates: true},
+	}
+	got, err := col.SearchHybrid(opts)
+	if err != nil {
+		t.Fatalf("SearchHybrid: %v", err)
+	}
+	if got.Plan.FinalTopK != opts.TopK || got.Plan.TextCandidateLimit != 4 || got.Plan.VectorCandidateLimit != 4 || got.Plan.ScalarFilterStrategy != HybridScalarFilterStrategyUnionFusion || got.Plan.FusionMethod != HybridFusionMethodRRF {
+		t.Fatalf("plan=%+v want bounded union-fusion RRF plan", got.Plan)
+	}
+	if got.Snapshot.Consistency != HybridConsistencyCurrentSnapshot || got.Snapshot.CommitSeq == 0 || got.Snapshot.SystemRootPageID == 0 {
+		t.Fatalf("snapshot=%+v want current snapshot identity", got.Snapshot)
+	}
+	if len(got.Results) != 3 {
+		t.Fatalf("results=%d want 3: %+v", len(got.Results), got.Results)
+	}
+	if gotID := string(got.Results[0].ID); gotID != "doc-shared" {
+		t.Fatalf("top result=%q want overlapping doc-shared; results=%+v", gotID, got.Results)
+	}
+	if !hybridResultHasSource2505(got.Results[0], HybridCandidateSourceText) || !hybridResultHasSource2505(got.Results[0], HybridCandidateSourceVector) {
+		t.Fatalf("top sources=%+v want text+vector overlap attribution", got.Results[0].Sources)
+	}
+	for _, result := range got.Results {
+		if !result.DocumentFound || len(result.Document) == 0 || bytes.Contains(result.Document, []byte("embedding")) {
+			t.Fatalf("result=%+v want bounded fetched document respecting projection", result)
+		}
+	}
+	if len(got.Candidates) == 0 {
+		t.Fatalf("debug candidates missing")
+	}
+	if got.Stats.TextCandidatesReturned == 0 || got.Stats.VectorCandidatesReturned == 0 || got.Stats.CandidatesFused != uint64(len(got.Candidates)) || got.Stats.FusionBoth == 0 {
+		t.Fatalf("stats=%+v want text/vector/fusion counters", got.Stats)
+	}
+	if got.Stats.ScalarPrefilterIDs != 0 || got.Stats.ScalarFilterRejected != 0 || got.Stats.DocumentsFetched != uint64(len(got.Results)) || got.Stats.DocumentsFetched > uint64(opts.TopK) || got.Stats.FullDocumentScanFallbacks != 0 || got.Stats.FailClosed != 0 {
+		t.Fatalf("stats=%+v want bounded final fetch only", got.Stats)
+	}
+
+	noDocsOpts := opts
+	noDocsOpts.IncludeDocuments = false
+	noDocsOpts.Debug.IncludeCandidates = false
+	noDocs, err := col.SearchHybrid(noDocsOpts)
+	if err != nil {
+		t.Fatalf("SearchHybrid IncludeDocuments=false: %v", err)
+	}
+	if len(noDocs.Candidates) != 0 || noDocs.Stats.DocumentsFetched != 0 || noDocs.Stats.DocumentsMissing != 0 {
+		t.Fatalf("no-doc response candidates=%d stats=%+v want no debug echo and zero document fetch", len(noDocs.Candidates), noDocs.Stats)
+	}
+	if gotIDs, noDocIDs := hybridResultIDs2505(got.Results), hybridResultIDs2505(noDocs.Results); !slicesEqualStrings(gotIDs, noDocIDs) {
+		t.Fatalf("deterministic topK changed with IncludeDocuments=false: docs=%v no_docs=%v", gotIDs, noDocIDs)
+	}
+	for _, result := range noDocs.Results {
+		if result.DocumentFound || len(result.Document) != 0 {
+			t.Fatalf("IncludeDocuments=false result=%+v carried document", result)
+		}
+	}
+}
+
+func TestSearchHybridExecutorTextOnlyAndVectorOnly2505(t *testing.T) {
+	_, d, col, def := openHybridSearchExecutorFixture2505(t, []hybridSearchExecutorFixtureRow2505{
+		{id: "doc-a", title: "refund", body: "refund refund", city: "sea", score: 10, vector: []float32{1, 0, 0}},
+		{id: "doc-b", title: "refund", body: "refund", city: "sea", score: 20, vector: []float32{0, 1, 0}},
+		{id: "doc-c", title: "other", body: "other", city: "sea", score: 30, vector: []float32{0, 0, 1}},
+	})
+	defer func() { _ = d.Close() }()
+
+	textOnly, err := col.SearchHybrid(HybridSearchOptions{TopK: 2, Text: &HybridTextQuery{IndexName: "lexical", Query: "refund", CandidateLimit: 2}})
+	if err != nil {
+		t.Fatalf("SearchHybrid text-only: %v", err)
+	}
+	if len(textOnly.Results) != 2 || textOnly.Plan.ScalarFilterStrategy != HybridScalarFilterStrategyTextFirst || textOnly.Stats.VectorCandidatesReturned != 0 || textOnly.Stats.FusionVectorOnly != 0 {
+		t.Fatalf("text-only response=%+v stats=%+v", textOnly, textOnly.Stats)
+	}
+	for _, result := range textOnly.Results {
+		if len(result.Sources) != 1 || result.Sources[0].Source != HybridCandidateSourceText {
+			t.Fatalf("text-only result=%+v want text source only", result)
+		}
+	}
+
+	vectorOnly, err := col.SearchHybrid(HybridSearchOptions{TopK: 2, Vector: &HybridVectorQuery{IndexName: def.Name, Query: []float32{0, 1, 0}, CandidateLimit: 2, EfSearch: 3}})
+	if err != nil {
+		t.Fatalf("SearchHybrid vector-only: %v", err)
+	}
+	if len(vectorOnly.Results) != 2 || vectorOnly.Plan.ScalarFilterStrategy != HybridScalarFilterStrategyVectorFirst || vectorOnly.Stats.TextCandidatesReturned != 0 || vectorOnly.Stats.FusionTextOnly != 0 {
+		t.Fatalf("vector-only response=%+v stats=%+v", vectorOnly, vectorOnly.Stats)
+	}
+	for _, result := range vectorOnly.Results {
+		if len(result.Sources) != 1 || result.Sources[0].Source != HybridCandidateSourceVector {
+			t.Fatalf("vector-only result=%+v want vector source only", result)
+		}
+	}
+}
+
+func TestSearchHybridScalarFilterRangeAndFailClosed2505(t *testing.T) {
+	_, d, col := openHybridScalarSearchExecutorFixture2505(t, []hybridSearchExecutorFixtureRow2505{
+		{id: "doc-10", title: "refund", body: "refund", city: "sea", score: 10, vector: []float32{1, 0, 0}},
+		{id: "doc-20", title: "refund", body: "refund", city: "sea", score: 20, vector: []float32{0.9, 0.1, 0}},
+		{id: "doc-30", title: "refund", body: "refund", city: "sea", score: 30, vector: []float32{0.8, 0.2, 0}},
+		{id: "doc-40", title: "refund", body: "refund", city: "sea", score: 40, vector: []float32{0.7, 0.3, 0}},
+	})
+	defer func() { _ = d.Close() }()
+
+	ranged, err := col.SearchHybrid(HybridSearchOptions{
+		TopK: 2,
+		Text: &HybridTextQuery{IndexName: "lexical", Query: "refund", CandidateLimit: 4},
+		ScalarFilter: &HybridScalarFilter{IndexName: "score", Range: &IndexRangeOptions{
+			Lower: IndexRangeBound{Value: int64(10), Inclusive: true},
+			Upper: IndexRangeBound{Value: int64(20), Inclusive: true},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("SearchHybrid range scalar: %v", err)
+	}
+	if gotIDs := hybridResultIDs2505(ranged.Results); !slicesEqualStrings(gotIDs, []string{"doc-10", "doc-20"}) {
+		t.Fatalf("range result ids=%v want doc-10/doc-20 response=%+v", gotIDs, ranged)
+	}
+	if ranged.Stats.ScalarPrefilterIDs != 2 || ranged.Stats.ScalarFilterRejected != 2 || ranged.Stats.FailClosed != 0 {
+		t.Fatalf("range stats=%+v want bounded scalar include/exclude", ranged.Stats)
+	}
+
+	postfiltered, err := col.SearchHybrid(HybridSearchOptions{
+		TopK:                 2,
+		Text:                 &HybridTextQuery{IndexName: "lexical", Query: "refund", CandidateLimit: 4},
+		ScalarFilterStrategy: HybridScalarFilterStrategyPostfilter,
+		ScalarFilter: &HybridScalarFilter{IndexName: "score", Range: &IndexRangeOptions{
+			Lower: IndexRangeBound{Value: int64(10), Inclusive: true},
+			Upper: IndexRangeBound{Value: int64(20), Inclusive: true},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("SearchHybrid postfilter scalar: %v", err)
+	}
+	if gotIDs := hybridResultIDs2505(postfiltered.Results); !slicesEqualStrings(gotIDs, []string{"doc-10", "doc-20"}) || postfiltered.Plan.ScalarFilterStrategy != HybridScalarFilterStrategyPostfilter {
+		t.Fatalf("postfilter ids=%v plan=%+v want doc-10/doc-20 postfilter", gotIDs, postfiltered.Plan)
+	}
+	if postfiltered.Stats.ScalarPrefilterIDs != 0 || postfiltered.Stats.ScalarPostfilterChecks != 4 || postfiltered.Stats.ScalarFilterMatched != 2 || postfiltered.Stats.ScalarFilterRejected != 2 {
+		t.Fatalf("postfilter stats=%+v want bounded fused-result checks", postfiltered.Stats)
+	}
+
+	broad, err := col.SearchHybrid(HybridSearchOptions{
+		TopK:         1,
+		Text:         &HybridTextQuery{IndexName: "lexical", Query: "refund", CandidateLimit: 1},
+		ScalarFilter: &HybridScalarFilter{IndexName: "city", Value: "sea"},
+	})
+	if !errors.Is(err, ErrHybridSearchIndexUnavailable) {
+		t.Fatalf("broad scalar err=%v want ErrHybridSearchIndexUnavailable", err)
+	}
+	if broad.Stats.FailClosed != 1 || broad.Stats.FailClosedReason != HybridFailClosedReasonScalarFilterUnbounded || broad.Stats.Truncated == 0 || broad.Stats.TextCandidatesReturned != 0 {
+		t.Fatalf("broad response=%+v want scalar unbounded before candidate generation", broad)
+	}
+
+	missing, err := col.SearchHybrid(HybridSearchOptions{
+		TopK:         2,
+		Text:         &HybridTextQuery{IndexName: "lexical", Query: "refund", CandidateLimit: 2},
+		ScalarFilter: &HybridScalarFilter{IndexName: "missing_city", Value: "sea"},
+	})
+	if !errors.Is(err, ErrHybridSearchIndexUnavailable) {
+		t.Fatalf("missing scalar err=%v want ErrHybridSearchIndexUnavailable", err)
+	}
+	if missing.Stats.FailClosed != 1 || missing.Stats.FailClosedReason != HybridFailClosedReasonScalarFilterUnbounded || missing.Stats.FullDocumentScanFallbacks != 0 {
+		t.Fatalf("missing scalar response=%+v want fail-closed scalar reason and no fallback", missing)
+	}
+}
+
+func TestSearchHybridMissingSourcesAndSnapshotModeFailClosed2505(t *testing.T) {
+	_, d, col, def := openHybridSearchExecutorFixture2505(t, []hybridSearchExecutorFixtureRow2505{
+		{id: "doc-a", title: "refund", body: "refund", city: "sea", score: 10, vector: []float32{1, 0, 0}},
+	})
+	defer func() { _ = d.Close() }()
+
+	missingText, err := col.SearchHybrid(HybridSearchOptions{TopK: 1, Text: &HybridTextQuery{IndexName: "missing", Query: "refund", CandidateLimit: 1}})
+	if !errors.Is(err, ErrHybridSearchIndexUnavailable) || missingText.Stats.FailClosedReason != HybridFailClosedReasonTextIndexUnavailable {
+		t.Fatalf("missing text response=%+v err=%v", missingText, err)
+	}
+
+	missingVector, err := col.SearchHybrid(HybridSearchOptions{TopK: 1, Vector: &HybridVectorQuery{IndexName: "missing", Query: []float32{1, 0, 0}, CandidateLimit: 1, EfSearch: 1}})
+	if !errors.Is(err, ErrHybridSearchIndexUnavailable) || missingVector.Stats.FailClosedReason != HybridFailClosedReasonVectorIndexUnavailable {
+		t.Fatalf("missing vector response=%+v err=%v (valid def was %q)", missingVector, err, def.Name)
+	}
+
+	badFetch, err := col.SearchHybrid(HybridSearchOptions{
+		TopK:             1,
+		Text:             &HybridTextQuery{IndexName: "lexical", Query: "refund", CandidateLimit: 1},
+		IncludeDocuments: true,
+		DocumentFetchOptions: DocumentFetchOptions{
+			IncludePaths: []string{"body.nested"},
+		},
+	})
+	if !errors.Is(err, ErrHybridSearchIndexUnavailable) || badFetch.Stats.FailClosedReason != HybridFailClosedReasonDocumentFetchUnavailable || badFetch.Stats.DocumentsFetched != 0 {
+		t.Fatalf("bad fetch response=%+v err=%v want document-fetch unavailable without fetched docs", badFetch, err)
+	}
+
+	boundSnapshot, err := col.SearchHybrid(HybridSearchOptions{TopK: 1, Text: &HybridTextQuery{IndexName: "lexical", Query: "refund", CandidateLimit: 1}, Consistency: HybridConsistencyOptions{Mode: HybridConsistencyBoundSnapshot}})
+	if !errors.Is(err, ErrHybridSearchUnsupported) || boundSnapshot.Stats.FailClosedReason != HybridFailClosedReasonSnapshotMismatch {
+		t.Fatalf("bound snapshot response=%+v err=%v want unsupported snapshot mismatch", boundSnapshot, err)
+	}
+}
+
+func TestSearchHybridInsertUpdateDeleteReopenConsistency2505(t *testing.T) {
+	dir, d, col := openHybridScalarSearchExecutorFixture2505(t, []hybridSearchExecutorFixtureRow2505{
+		{id: "mutable", title: "refund", body: "refund", city: "sea", score: 10, vector: []float32{1, 0, 0}},
+		{id: "deleted", title: "refund", body: "refund", city: "sea", score: 20, vector: []float32{0.9, 0.1, 0}},
+		{id: "stable", title: "shipping", body: "shipping", city: "sea", score: 30, vector: []float32{0, 1, 0}},
+	})
+	closed := false
+	defer func() {
+		if !closed {
+			_ = d.Close()
+		}
+	}()
+
+	before, err := col.SearchHybrid(HybridSearchOptions{TopK: 10, Text: &HybridTextQuery{IndexName: "lexical", Query: "refund", CandidateLimit: 10}, ScalarFilter: &HybridScalarFilter{IndexName: "city", Value: "sea"}})
+	if err != nil {
+		t.Fatalf("SearchHybrid before mutations: %v", err)
+	}
+	if gotIDs := hybridResultIDs2505(before.Results); !slicesEqualStrings(gotIDs, []string{"deleted", "mutable"}) {
+		t.Fatalf("before ids=%v want deleted/mutable", gotIDs)
+	}
+
+	updatedDoc := mustHybridFixtureDocument2505(t, hybridSearchExecutorFixtureRow2505{id: "mutable", title: "shipping", body: "shipping", city: "sfo", score: 11, vector: []float32{1, 0, 0}}, 10)
+	if _, changed, err := col.Update([]byte("mutable"), func(current []byte) ([]byte, bool, error) {
+		if len(current) == 0 {
+			return nil, false, fmt.Errorf("missing mutable")
+		}
+		return updatedDoc, true, nil
+	}); err != nil || !changed {
+		t.Fatalf("Update mutable changed=%v err=%v", changed, err)
+	}
+	if _, err := col.Insert([]byte("new"), mustHybridFixtureDocument2505(t, hybridSearchExecutorFixtureRow2505{id: "new", title: "refund", body: "refund", city: "sea", score: 12, vector: []float32{0.8, 0.2, 0}}, 11)); err != nil {
+		t.Fatalf("Insert new: %v", err)
+	}
+	if err := col.Delete([]byte("deleted")); err != nil {
+		t.Fatalf("Delete deleted: %v", err)
+	}
+	if err := col.Flush(); err != nil {
+		t.Fatalf("Flush mutations: %v", err)
+	}
+
+	wantAfter := []string{"new"}
+	if gotIDs := searchHybridTextScalarIDs2505(t, col); !slicesEqualStrings(gotIDs, wantAfter) {
+		t.Fatalf("after mutation ids=%v want %v", gotIDs, wantAfter)
+	}
+	if err := d.Checkpoint(); err != nil {
+		t.Fatalf("Checkpoint: %v", err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	closed = true
+
+	reopened, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+	reopenedCol, err := NewCollectionManager(reopened).OpenCollection("docs")
+	if err != nil {
+		t.Fatalf("OpenCollection reopened: %v", err)
+	}
+	if gotIDs := searchHybridTextScalarIDs2505(t, reopenedCol); !slicesEqualStrings(gotIDs, wantAfter) {
+		t.Fatalf("after reopen ids=%v want %v", gotIDs, wantAfter)
+	}
+}
+
+var hybridSearchExecutorBenchmarkSink2505 HybridSearchResponse
+
+func BenchmarkSearchHybridExecutor2505(b *testing.B) {
+	rows := make([]hybridSearchExecutorFixtureRow2505, 128)
+	for i := range rows {
+		city := "city-rare"
+		if i%4 != 0 {
+			city = "city-common"
+		}
+		rows[i] = hybridSearchExecutorFixtureRow2505{
+			id:     fmt.Sprintf("doc-%03d", i),
+			title:  "refund policy",
+			body:   fmt.Sprintf("refund policy shard %d customer %d", i%8, i%17),
+			city:   city,
+			score:  int64(i),
+			vector: []float32{1 + float32(i%11)*0.01, float32((i*7)%17) * 0.01, float32((i*13)%19) * 0.01},
+		}
+	}
+	_, d, col, def := openHybridSearchExecutorFixture2505(b, rows)
+	defer func() { _ = d.Close() }()
+	opts := HybridSearchOptions{
+		TopK:             10,
+		Text:             &HybridTextQuery{IndexName: "lexical", Query: "refund policy", CandidateLimit: 32},
+		Vector:           &HybridVectorQuery{IndexName: def.Name, Query: []float32{1, 0.1, 0.05}, CandidateLimit: 32, EfSearch: 64},
+		IncludeDocuments: true,
+		DocumentFetchOptions: DocumentFetchOptions{
+			ExcludePaths: []string{"embedding"},
+		},
+	}
+	warm, err := col.SearchHybrid(opts)
+	if err != nil {
+		b.Fatalf("warm SearchHybrid: %v", err)
+	}
+	if len(warm.Results) == 0 || warm.Stats.DocumentsFetched == 0 || warm.Stats.DocumentsFetched > uint64(opts.TopK) {
+		b.Fatalf("warm response=%+v want bounded fetched hybrid results", warm)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	var sink HybridSearchResponse
+	for i := 0; i < b.N; i++ {
+		got, err := col.SearchHybrid(opts)
+		if err != nil {
+			b.Fatalf("SearchHybrid: %v", err)
+		}
+		if len(got.Results) == 0 {
+			b.Fatal("SearchHybrid returned no results")
+		}
+		sink = got
+	}
+	b.StopTimer()
+	hybridSearchExecutorBenchmarkSink2505 = sink
+	b.ReportMetric(float64(sink.Stats.TextCandidatesReturned), "text_candidates/search")
+	b.ReportMetric(float64(sink.Stats.VectorCandidatesReturned), "vector_candidates/search")
+	b.ReportMetric(float64(sink.Stats.CandidatesFused), "candidates_fused/search")
+	b.ReportMetric(float64(sink.Stats.DocumentsFetched), "docs_fetched/search")
+	b.ReportMetric(float64(sink.Stats.FusionBoth), "fusion_both/search")
+}
+
+func openHybridSearchExecutorFixture2505(tb testing.TB, rows []hybridSearchExecutorFixtureRow2505) (string, *backenddb.DB, *Collection, VectorIndexDefinition) {
+	tb.Helper()
+	dir := tb.TempDir()
+	if err := backenddb.SaveFormatConfig(dir, backenddb.FormatConfig{RequiredFeatures: []string{backenddb.RequiredFeatureCommandWALV1}}); err != nil {
+		tb.Fatalf("SaveFormatConfig: %v", err)
+	}
+	d := openCollectionCommandWALDB(tb, dir)
+	def := columnGraphRebuildVectorIndexDefinitionV2A(3, 4)
+	meta := CollectionMeta{
+		Name: "docs",
+		Options: CollectionOptions{
+			DocumentFormat: DocumentFormatJSON,
+			ColumnStore:    columnGraphRebuildColumnStoreConfigV2A(3),
+		},
+		VectorIndexes: []VectorIndexDefinition{def},
+		TextIndexes:   []TextIndexDefinition{{Name: "lexical", Fields: []TextIndexField{{Field: "title", Weight: 3}, {Field: "body"}}, StorePositions: true}},
+	}
+	col := createHybridFixtureCollection2505(tb, d, meta, rows)
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		_ = d.Close()
+		tb.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	return dir, d, col, def
+}
+
+func openHybridScalarSearchExecutorFixture2505(tb testing.TB, rows []hybridSearchExecutorFixtureRow2505) (string, *backenddb.DB, *Collection) {
+	tb.Helper()
+	dir := tb.TempDir()
+	d, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		tb.Fatalf("open db: %v", err)
+	}
+	meta := CollectionMeta{
+		Name:    "docs",
+		Options: CollectionOptions{DocumentFormat: DocumentFormatJSON},
+	}
+	col := createHybridFixtureCollection2505(tb, d, meta, rows)
+	if _, err := col.CreateIndex(IndexDefinition{Name: "city", Field: "city", ValueType: IndexValueString}); err != nil {
+		_ = d.Close()
+		tb.Fatalf("CreateIndex city: %v", err)
+	}
+	if _, err := col.CreateIndex(IndexDefinition{Name: "score", Field: "score", ValueType: IndexValueInt64}); err != nil {
+		_ = d.Close()
+		tb.Fatalf("CreateIndex score: %v", err)
+	}
+	if _, _, err := col.CreateTextIndex(TextIndexDefinition{Name: "lexical", Fields: []TextIndexField{{Field: "title", Weight: 3}, {Field: "body"}}, StorePositions: true}); err != nil {
+		_ = d.Close()
+		tb.Fatalf("CreateTextIndex: %v", err)
+	}
+	return dir, d, col
+}
+
+func createHybridFixtureCollection2505(tb testing.TB, d *backenddb.DB, meta CollectionMeta, rows []hybridSearchExecutorFixtureRow2505) *Collection {
+	tb.Helper()
+	if _, err := NewCollectionManager(d).CreateCollection(&meta); err != nil {
+		_ = d.Close()
+		tb.Fatalf("CreateCollection: %v", err)
+	}
+	col, err := NewCollectionManager(d).OpenCollection("docs")
+	if err != nil {
+		_ = d.Close()
+		tb.Fatalf("OpenCollection: %v", err)
+	}
+	ids := make([][]byte, len(rows))
+	docs := make([][]byte, len(rows))
+	for i, row := range rows {
+		ids[i] = []byte(row.id)
+		docs[i] = mustHybridFixtureDocument2505(tb, row, i+1)
+	}
+	if len(rows) > 0 {
+		if _, err := col.InsertBatch(ids, docs); err != nil {
+			_ = d.Close()
+			tb.Fatalf("InsertBatch: %v", err)
+		}
+	}
+	if err := col.Flush(); err != nil {
+		_ = d.Close()
+		tb.Fatalf("Flush: %v", err)
+	}
+	return col
+}
+
+func mustHybridFixtureDocument2505(tb testing.TB, row hybridSearchExecutorFixtureRow2505, timeUS int) []byte {
+	tb.Helper()
+	raw, err := json.Marshal(map[string]any{
+		"time_us":   int64(timeUS),
+		"kind":      "hybrid",
+		"did":       row.id,
+		"embedding": row.vector,
+		"title":     row.title,
+		"body":      row.body,
+		"city":      row.city,
+		"score":     row.score,
+	})
+	if err != nil {
+		tb.Fatalf("json.Marshal row %q: %v", row.id, err)
+	}
+	return raw
+}
+
+func hybridResultHasSource2505(result HybridSearchResult, source HybridCandidateSource) bool {
+	for _, contribution := range result.Sources {
+		if contribution.Source == source {
+			return true
+		}
+	}
+	return false
+}
+
+func hybridResultIDs2505(results []HybridSearchResult) []string {
+	ids := make([]string, len(results))
+	for i := range results {
+		ids[i] = string(results[i].ID)
+	}
+	return ids
+}
+
+func searchHybridTextScalarIDs2505(tb testing.TB, col *Collection) []string {
+	tb.Helper()
+	got, err := col.SearchHybrid(HybridSearchOptions{TopK: 10, Text: &HybridTextQuery{IndexName: "lexical", Query: "refund", CandidateLimit: 10}, ScalarFilter: &HybridScalarFilter{IndexName: "city", Value: "sea"}})
+	if err != nil {
+		tb.Fatalf("SearchHybrid text+scalar: %v", err)
+	}
+	return hybridResultIDs2505(got.Results)
+}

--- a/TreeDB/collections/hybrid_search_executor_test.go
+++ b/TreeDB/collections/hybrid_search_executor_test.go
@@ -183,6 +183,18 @@ func TestSearchHybridScalarFilterRangeAndFailClosed2505(t *testing.T) {
 		t.Fatalf("postfilter stats=%+v want bounded fused-result checks", postfiltered.Stats)
 	}
 
+	empty, err := col.SearchHybrid(HybridSearchOptions{
+		TopK:         2,
+		Text:         &HybridTextQuery{IndexName: "lexical", Query: "refund", CandidateLimit: 4},
+		ScalarFilter: &HybridScalarFilter{IndexName: "city", Value: "does-not-exist"},
+	})
+	if err != nil {
+		t.Fatalf("SearchHybrid empty scalar match: %v", err)
+	}
+	if len(empty.Results) != 0 || empty.Stats.FailClosed != 0 || empty.Stats.FailClosedReason != "" || empty.Stats.ScalarPrefilterIDs != 0 || empty.Stats.ScalarFilterMatched != 0 || empty.Stats.ScalarFilterRejected != 4 {
+		t.Fatalf("empty scalar response=%+v want no results without fail-closed", empty)
+	}
+
 	broad, err := col.SearchHybrid(HybridSearchOptions{
 		TopK:         1,
 		Text:         &HybridTextQuery{IndexName: "lexical", Query: "refund", CandidateLimit: 1},
@@ -205,6 +217,17 @@ func TestSearchHybridScalarFilterRangeAndFailClosed2505(t *testing.T) {
 	}
 	if missing.Stats.FailClosed != 1 || missing.Stats.FailClosedReason != HybridFailClosedReasonScalarFilterUnbounded || missing.Stats.FullDocumentScanFallbacks != 0 {
 		t.Fatalf("missing scalar response=%+v want fail-closed scalar reason and no fallback", missing)
+	}
+}
+
+func TestHybridCandidateErrorFailClosedReasonSourceAware2505(t *testing.T) {
+	textErr := hybridCandidateSourceError{source: HybridCandidateSourceText, err: fmt.Errorf("%w: text unavailable without stats", ErrHybridSearchIndexUnavailable)}
+	if got := hybridCandidateErrorFailClosedReason(textErr); got != HybridFailClosedReasonTextIndexUnavailable {
+		t.Fatalf("text source fallback reason=%q want %q", got, HybridFailClosedReasonTextIndexUnavailable)
+	}
+	vectorErr := hybridCandidateSourceError{source: HybridCandidateSourceVector, err: fmt.Errorf("%w: vector unavailable without stats", ErrHybridSearchIndexUnavailable)}
+	if got := hybridCandidateErrorFailClosedReason(vectorErr); got != HybridFailClosedReasonVectorIndexUnavailable {
+		t.Fatalf("vector source fallback reason=%q want %q", got, HybridFailClosedReasonVectorIndexUnavailable)
 	}
 }
 

--- a/TreeDB/collections/hybrid_search_executor_test.go
+++ b/TreeDB/collections/hybrid_search_executor_test.go
@@ -33,6 +33,7 @@ func TestSearchHybridExecutorTextVectorOverlapAndBoundedFetch2505(t *testing.T) 
 		TopK:             3,
 		Text:             &HybridTextQuery{IndexName: "lexical", Query: "refund", CandidateLimit: 4},
 		Vector:           &HybridVectorQuery{IndexName: def.Name, Query: []float32{1, 0, 0}, CandidateLimit: 4, EfSearch: 5, QueryMode: VectorIndexQueryModeExact},
+		ScalarFilter:     &HybridScalarFilter{IndexName: "city", Value: "sea"},
 		IncludeDocuments: true,
 		DocumentFetchOptions: DocumentFetchOptions{
 			ExcludePaths: []string{"embedding"},
@@ -43,8 +44,8 @@ func TestSearchHybridExecutorTextVectorOverlapAndBoundedFetch2505(t *testing.T) 
 	if err != nil {
 		t.Fatalf("SearchHybrid: %v", err)
 	}
-	if got.Plan.FinalTopK != opts.TopK || got.Plan.TextCandidateLimit != 4 || got.Plan.VectorCandidateLimit != 4 || got.Plan.ScalarFilterStrategy != HybridScalarFilterStrategyUnionFusion || got.Plan.FusionMethod != HybridFusionMethodRRF {
-		t.Fatalf("plan=%+v want bounded union-fusion RRF plan", got.Plan)
+	if got.Plan.FinalTopK != opts.TopK || got.Plan.TextCandidateLimit != 4 || got.Plan.VectorCandidateLimit != 4 || got.Plan.ScalarFilterStrategy != HybridScalarFilterStrategyPrefilter || got.Plan.FusionMethod != HybridFusionMethodRRF {
+		t.Fatalf("plan=%+v want bounded prefilter RRF plan", got.Plan)
 	}
 	if got.Snapshot.Consistency != HybridConsistencyCurrentSnapshot || got.Snapshot.CommitSeq == 0 || got.Snapshot.SystemRootPageID == 0 {
 		t.Fatalf("snapshot=%+v want current snapshot identity", got.Snapshot)
@@ -59,18 +60,26 @@ func TestSearchHybridExecutorTextVectorOverlapAndBoundedFetch2505(t *testing.T) 
 		t.Fatalf("top sources=%+v want text+vector overlap attribution", got.Results[0].Sources)
 	}
 	for _, result := range got.Results {
-		if !result.DocumentFound || len(result.Document) == 0 || bytes.Contains(result.Document, []byte("embedding")) {
-			t.Fatalf("result=%+v want bounded fetched document respecting projection", result)
+		if string(result.ID) == "doc-filtered" {
+			t.Fatalf("scalar-filtered document reached results: %+v", got.Results)
+		}
+		if !result.DocumentFound || len(result.Document) == 0 || bytes.Contains(result.Document, []byte("embedding")) || !bytes.Contains(result.Document, []byte(`"city":"sea"`)) {
+			t.Fatalf("result=%+v want bounded fetched sea document respecting projection", result)
 		}
 	}
 	if len(got.Candidates) == 0 {
 		t.Fatalf("debug candidates missing")
 	}
+	for _, candidate := range got.Candidates {
+		if string(candidate.ID) == "doc-filtered" {
+			t.Fatalf("prefiltered debug candidate escaped scalar allow-set: %+v", got.Candidates)
+		}
+	}
 	if got.Stats.TextCandidatesReturned == 0 || got.Stats.VectorCandidatesReturned == 0 || got.Stats.CandidatesFused != uint64(len(got.Candidates)) || got.Stats.FusionBoth == 0 {
 		t.Fatalf("stats=%+v want text/vector/fusion counters", got.Stats)
 	}
-	if got.Stats.ScalarPrefilterIDs != 0 || got.Stats.ScalarFilterRejected != 0 || got.Stats.DocumentsFetched != uint64(len(got.Results)) || got.Stats.DocumentsFetched > uint64(opts.TopK) || got.Stats.FullDocumentScanFallbacks != 0 || got.Stats.FailClosed != 0 {
-		t.Fatalf("stats=%+v want bounded final fetch only", got.Stats)
+	if got.Stats.ScalarPrefilterIDs != 4 || got.Stats.ScalarFilterRejected == 0 || got.Stats.DocumentsFetched != uint64(len(got.Results)) || got.Stats.DocumentsFetched > uint64(opts.TopK) || got.Stats.FullDocumentScanFallbacks != 0 || got.Stats.FailClosed != 0 {
+		t.Fatalf("stats=%+v want scalar filtering and bounded final fetch only", got.Stats)
 	}
 
 	noDocsOpts := opts
@@ -323,6 +332,7 @@ func BenchmarkSearchHybridExecutor2505(b *testing.B) {
 		TopK:             10,
 		Text:             &HybridTextQuery{IndexName: "lexical", Query: "refund policy", CandidateLimit: 32},
 		Vector:           &HybridVectorQuery{IndexName: def.Name, Query: []float32{1, 0.1, 0.05}, CandidateLimit: 32, EfSearch: 64},
+		ScalarFilter:     &HybridScalarFilter{IndexName: "city", Value: "city-rare"},
 		IncludeDocuments: true,
 		DocumentFetchOptions: DocumentFetchOptions{
 			ExcludePaths: []string{"embedding"},
@@ -356,6 +366,7 @@ func BenchmarkSearchHybridExecutor2505(b *testing.B) {
 	b.ReportMetric(float64(sink.Stats.CandidatesFused), "candidates_fused/search")
 	b.ReportMetric(float64(sink.Stats.DocumentsFetched), "docs_fetched/search")
 	b.ReportMetric(float64(sink.Stats.FusionBoth), "fusion_both/search")
+	b.ReportMetric(float64(sink.Stats.ScalarFilterRejected), "scalar_rejected/search")
 }
 
 func openHybridSearchExecutorFixture2505(tb testing.TB, rows []hybridSearchExecutorFixtureRow2505) (string, *backenddb.DB, *Collection, VectorIndexDefinition) {
@@ -366,11 +377,18 @@ func openHybridSearchExecutorFixture2505(tb testing.TB, rows []hybridSearchExecu
 	}
 	d := openCollectionCommandWALDB(tb, dir)
 	def := columnGraphRebuildVectorIndexDefinitionV2A(3, 4)
+	cfg := columnGraphRebuildColumnStoreConfigV2A(3)
+	cfg.RetainedPayload = ColumnRetainedPayloadFull
+	cfg.RetainedPayloadEncoding = ColumnRetainedPayloadEncodingJSON
 	meta := CollectionMeta{
 		Name: "docs",
 		Options: CollectionOptions{
 			DocumentFormat: DocumentFormatJSON,
-			ColumnStore:    columnGraphRebuildColumnStoreConfigV2A(3),
+			ColumnStore:    cfg,
+		},
+		Indexes: []IndexDefinition{
+			{Name: "city", Field: "city", ValueType: IndexValueString},
+			{Name: "score", Field: "score", ValueType: IndexValueInt64},
 		},
 		VectorIndexes: []VectorIndexDefinition{def},
 		TextIndexes:   []TextIndexDefinition{{Name: "lexical", Fields: []TextIndexField{{Field: "title", Weight: 3}, {Field: "body"}}, StorePositions: true}},

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -390,7 +390,7 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/document_materializer.go", classification: typedStorageLegacyCompatibility, matchingLines: 13, occurrences: 13},
 	{path: "TreeDB/collections/document_materializer_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 32, occurrences: 32},
 	{path: "TreeDB/collections/document_projection.go", classification: typedStorageLegacyCompatibility, matchingLines: 3, occurrences: 3},
-	{path: "TreeDB/collections/hybrid_search_executor_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 1, occurrences: 2},
+	{path: "TreeDB/collections/hybrid_search_executor_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 2, occurrences: 2},
 	{path: "TreeDB/collections/quantized_asset_reopen_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 6, occurrences: 6},
 	{path: "TreeDB/collections/column_vector_graph_quantized_asset_test.go", classification: typedStorageLegacyDerived, matchingLines: 3, occurrences: 4},
 	{path: "TreeDB/collections/column_vector_graph_brq_quantized_asset_test.go", classification: typedStorageLegacyDerived, matchingLines: 1, occurrences: 1},

--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -390,6 +390,7 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/document_materializer.go", classification: typedStorageLegacyCompatibility, matchingLines: 13, occurrences: 13},
 	{path: "TreeDB/collections/document_materializer_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 32, occurrences: 32},
 	{path: "TreeDB/collections/document_projection.go", classification: typedStorageLegacyCompatibility, matchingLines: 3, occurrences: 3},
+	{path: "TreeDB/collections/hybrid_search_executor_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 1, occurrences: 2},
 	{path: "TreeDB/collections/quantized_asset_reopen_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 6, occurrences: 6},
 	{path: "TreeDB/collections/column_vector_graph_quantized_asset_test.go", classification: typedStorageLegacyDerived, matchingLines: 3, occurrences: 4},
 	{path: "TreeDB/collections/column_vector_graph_brq_quantized_asset_test.go", classification: typedStorageLegacyDerived, matchingLines: 1, occurrences: 1},

--- a/TreeDB/docs/spec/hybrid-search-contract.md
+++ b/TreeDB/docs/spec/hybrid-search-contract.md
@@ -1,8 +1,9 @@
 # TreeDB Hybrid Search Contract (#2502)
 
-Status: design gate for the #2501 hybrid lexical + vector search stack. TreeDB
-is pre-alpha, so this API/contract may change, but downstream work should treat
-this note as the current source of truth until a later PR updates it.
+Status: design contract plus initial #2505 collection executor for the #2501
+hybrid lexical + vector search stack. TreeDB is pre-alpha, so this API/contract
+may change, but downstream work should treat this note as the current source of
+truth until a later PR updates it.
 
 Parent tracker: <https://github.com/snissn/gomap/issues/2501>.
 
@@ -20,8 +21,9 @@ scalar/metadata filters
 ```
 
 It does **not** implement the text index (#1764), vector optimizations
-(#2490/#2475 lanes), gateway syntax, or the hybrid executor (#2505). Normal
-hybrid search MUST NOT scan or fetch every document as a fallback.
+(#2490/#2475 lanes), gateway syntax, or reranking beyond deterministic rank
+fusion. The initial hybrid executor is implemented by #2505. Normal hybrid
+search MUST NOT scan or fetch every document as a fallback.
 
 Text-only and vector-only APIs/benchmarks remain separate evidence lanes:
 Issue `#1764` owns indexed lexical `SearchText`/BM25/BM25F behavior, and the existing
@@ -41,9 +43,9 @@ The collection package now reserves these names for downstream implementation:
 - fail-closed errors: `ErrHybridSearchUnsupported`,
   `ErrHybridSearchIndexUnavailable`, and `ErrHybridSearchStaleIndex`.
 
-`SearchHybrid` is only a fail-closed stub until #2505 implements the executor.
-It exists so #1764/#2503/#2504/#2505 have stable names to target without
-inventing incompatible seams.
+`SearchHybrid` now routes through the #2505 bounded executor. Unsupported query
+shapes and unavailable sources still fail closed so callers cannot accidentally
+depend on a scan-all-documents fallback.
 
 ## Query contract
 
@@ -62,7 +64,9 @@ inventing incompatible seams.
   - No document materialization knobs are present on the vector clause; hybrid
     materialization is a final bounded phase.
 - `ScalarFilter *HybridScalarFilter`: bounded scalar-index filter. Equality uses
-  `Value`; ranges use `Range *IndexRangeOptions`.
+  `Value`; ranges use `Range *IndexRangeOptions`. The #2505 executor serves
+  these filters only from existing secondary indexes and fails closed when the
+  bounded lookup truncates or the index is absent.
 - `ScalarFilterStrategy`: one of `prefilter`, `postfilter`, `text_first`,
   `vector_first`, or `union_fusion`.
 - `Fusion`: deterministic fusion options. The first supported method is
@@ -272,4 +276,18 @@ policy above over slices of `HybridSearchCandidate`. The helper surface is
 fetching documents, or consulting text/vector indexes.
 
 Issue `#2505` owns the executor that binds scalar filtering, source candidate APIs,
-fusion, and bounded final document fetch under the snapshot/epoch contract.
+fusion, and bounded final document fetch under the snapshot/epoch contract. The
+initial executor uses the #2503 text/vector candidate adapters, #2504 RRF fusion,
+secondary-index-only scalar filtering, and final document materialization only
+after fusion/filter/top-k selection. Scalar equality uses
+`FindByIndexValueLimit`; scalar ranges use `FindByIndexRange` with an explicit
+executor limit derived from the final top-k and source candidate budgets. If the
+scalar lookup truncates before the executor can build a complete allow-set, the
+query fails closed with `scalar_filter_unbounded`. In this initial executor,
+`prefilter`, `text_first`, `vector_first`, and `union_fusion` are bounded
+planning/reporting labels unless a source API can accept an ID restriction; the
+executor still builds the scalar allow-set before source generation and applies
+it before fusion for non-`postfilter` strategies. `bound_snapshot` remains
+reserved for a future explicit read-view/searcher API; the current executor
+supports `current_snapshot` and fails closed on root/commit changes observed
+between bounded phases.


### PR DESCRIPTION
## Summary

Implements the #2505 bounded `Collection.SearchHybrid` executor on top of the approved #2501 dependency stack:

- adds a small planner for text-only, vector-only, combined text+vector, and scalar-filtered execution;
- uses the #2503 `SearchHybridTextCandidates` / `SearchHybridVectorCandidates` adapters and #2504 `FuseHybridSearchCandidates` RRF helper;
- applies scalar filters only through existing secondary-index lookups (`FindByIndexValueLimit` / bounded `FindByIndexRange`) and fails closed on missing/truncated/unbounded scalar filters;
- materializes documents only after fusion/filter/final top-k and only when `IncludeDocuments=true`, honoring `DocumentFetchOptions`;
- populates plan/stats/snapshot/debug candidates and updates the hybrid-search spec for #2505 behavior.

Closes #2505. Part of #2501.

## Guardrails / non-goals

- No vector algorithm changes.
- No candidate-generation document fetches.
- No scan-all-documents fallback.
- `bound_snapshot` remains reserved and fails closed; current-snapshot execution validates commit/root identity between bounded phases.
- No gateway syntax, LLM/cross-encoder reranking, or #2506 benchmark/docs closeout.

## Base / review fix update

Latest head `933211ffddc6baa982071adfe9c1a6cadd9cb3b0` contains current `origin/main` `da9c11807e0d6d7d8bd2a610c05c83caec2711ca`, preserving the Haystack examples/listing-plan changes. The PR diff is limited to intended #2505 files.

This branch also fixes the latest CodeRabbit/coordinator findings:

- scalar filters check scalar-index existence explicitly before lookup, so a valid indexed filter with zero matches returns empty results without fail-closed while a missing scalar index still fails closed;
- candidate-source unavailable fallback carries text/vector source identity, avoiding vector-labeled fail-closed reasons for text-source errors when adapter stats are absent.

## Tests

Latest local evidence on head `933211ffddc6baa982071adfe9c1a6cadd9cb3b0`:

- `git merge-base HEAD origin/main == origin/main` — PASS
- `git diff --name-only origin/main..HEAD` — PASS, limited to:
  - `TreeDB/collections/hybrid_executor.go`
  - `TreeDB/collections/hybrid_search.go`
  - `TreeDB/collections/hybrid_search_contract_test.go`
  - `TreeDB/collections/hybrid_search_executor_test.go`
  - `TreeDB/collections/typed_storage_naming_test.go`
  - `TreeDB/docs/spec/hybrid-search-contract.md`
- `git diff --check origin/main..HEAD` — PASS
- `GOWORK=off go test ./TreeDB/collections -run 'SearchHybrid.*2505|HybridCandidateErrorFailClosedReasonSourceAware2505|HybridSearchContract|TestTypedStorageLegacyNameAllowlistIsComplete' -count=1` — PASS
- `GOWORK=off go test ./TreeDB/docs -count=1` — PASS

No conflicts occurred during the latest base update, so full `./TreeDB/collections` was not rerun for this main-only merge.

## Benchmark

Last #2505 benchmark command (from an earlier pre-base-update head; not rerun for the latest main-only merge):

```sh
GOWORK=off go test ./TreeDB/collections -run '^$' -bench BenchmarkSearchHybridExecutor2505 -benchtime=1x -count=1
```

Previous Apple M3 result:

| benchmark | ns/op | B/op | allocs/op | text candidates/search | vector candidates/search | candidates fused/search | docs fetched/search | scalar rejected/search | fusion both/search |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| BenchmarkSearchHybridExecutor2505-8 | 494,250 | 462,400 | 7,580 | 32 | 32 | 16 | 10 | 48 | 1 |

## Review status

Internal high-thinking review passed with no blocking findings. Latest CodeRabbit/coordinator findings have been fixed.

Fresh Codex and CodeRabbit reviews have been requested after the latest base-update push. Unresolved findings will be handled before mergeability is claimed.
