### PR TITLE
TreeDB: speed scalar_u8 indexed dot on amd64 with AVX2

### DIFF
--- a/TreeDB/internal/vectorops/scalar_u8_dot_batch_amd64.go
+++ b/TreeDB/internal/vectorops/scalar_u8_dot_batch_amd64.go
@@ -2,17 +2,29 @@
 
 package vectorops
 
-const scalarU8DotBatchImplementation = "indexed_amd64_sse2"
+import simdcpu "github.com/tphakala/simd/cpu"
+
+var dotScalarU8CenteredIndexedAMD64AVX2Available = simdcpu.X86.AVX2
+
+var scalarU8DotBatchImplementation = scalarU8DotBatchImplementationAMD64()
 
 const scalarU8DotBatchOptimizedAvailable = true
+
+func scalarU8DotBatchImplementationAMD64() string {
+	if dotScalarU8CenteredIndexedAMD64AVX2Available {
+		return "indexed_amd64_avx2"
+	}
+	return "indexed_amd64_sse2"
+}
 
 const (
 	dotScalarU8CenteredIndexedAMD64MinDims = 16
 	dotScalarU8CenteredIndexedAMD64MinRows = 1
-	// The SSE2 kernel accumulates into signed 32-bit vector lanes and reduces once
-	// per row. At 32,768 dimensions, the worst-case full-row scalar_u8 dot product
-	// is 65,025*32,768 = 2,130,739,200, which still fits int32. Larger dimensions
-	// use the portable int64 scalar fallback to keep accumulation overflow-safe.
+	// The amd64 SIMD kernels accumulate into signed 32-bit vector lanes and reduce
+	// once per row. At 32,768 dimensions, the worst-case full-row scalar_u8 dot
+	// product is 65,025*32,768 = 2,130,739,200, which still fits int32. Larger
+	// dimensions use the portable int64 scalar fallback to keep accumulation
+	// overflow-safe.
 	dotScalarU8CenteredIndexedAMD64MaxSIMDDims = 32768
 )
 
@@ -22,10 +34,10 @@ func dotScalarU8CenteredIndexedOptimizedEligible(rows, dims int) bool {
 
 // DotScalarU8CenteredIndexed writes integer dot products for row-major scalar_u8
 // code rows selected by rowIDs against a pre-centered scalar_u8 query. Supported
-// amd64 builds use an SSE2-backed indexed-row kernel for sufficiently large
-// overflow-safe tiles. Tiny/short or very high-dimensional shapes use the
-// portable scalar fallback. Invalid shapes leave dst unchanged and return
-// Invalid=true.
+// amd64 builds use an AVX2 indexed-row kernel when available, otherwise an SSE2
+// kernel, for sufficiently large overflow-safe tiles. Tiny/short or very
+// high-dimensional shapes use the portable scalar fallback. Invalid shapes leave
+// dst unchanged and return Invalid=true.
 func DotScalarU8CenteredIndexed(dst []int64, codes []byte, query ScalarU8CenteredQuery, rowIDs []uint32, dims int) ScalarU8DotBatchStatus {
 	rows := dotScalarU8CenteredIndexedRows(dst, rowIDs)
 	if rows == 0 {
@@ -39,12 +51,23 @@ func DotScalarU8CenteredIndexed(dst []int64, codes []byte, query ScalarU8Centere
 		return scalarU8DotBatchStatus(rows, false)
 	}
 	queryValues := query.values[:dims]
-	dotScalarU8CenteredIndexedAMD64(dst, codes, queryValues, rowIDs, dims, rows, query.CenteredSum())
+	querySum := query.CenteredSum()
+	if dotScalarU8CenteredIndexedAMD64AVX2Available {
+		dotScalarU8CenteredIndexedAMD64AVX2(dst, codes, queryValues, rowIDs, dims, rows, querySum)
+	} else {
+		dotScalarU8CenteredIndexedAMD64SSE2(dst, codes, queryValues, rowIDs, dims, rows, querySum)
+	}
 	return scalarU8DotBatchStatus(rows, true)
 }
 
-// dotScalarU8CenteredIndexedAMD64 computes rows indexed scalar_u8 centered dot
-// products. The Go wrapper must validate all slice lengths, row IDs, dims, and
-// rows before calling. querySum is sum(query[:dims]); the kernel computes
+// dotScalarU8CenteredIndexedAMD64SSE2 computes rows indexed scalar_u8 centered
+// dot products. The Go wrapper must validate all slice lengths, row IDs, dims,
+// and rows before calling. querySum is sum(query[:dims]); the kernel computes
 // sum(q*(2*row-255)) as 2*sum(q*row)-255*querySum.
-func dotScalarU8CenteredIndexedAMD64(dst []int64, codes []byte, query []ScalarU8CenteredCode, rowIDs []uint32, dims int, rows int, querySum int64)
+func dotScalarU8CenteredIndexedAMD64SSE2(dst []int64, codes []byte, query []ScalarU8CenteredCode, rowIDs []uint32, dims int, rows int, querySum int64)
+
+// dotScalarU8CenteredIndexedAMD64AVX2 computes rows indexed scalar_u8 centered
+// dot products with an AVX2 kernel. The Go wrapper must validate all slice
+// lengths, row IDs, dims, rows, CPU feature availability, and the int32 SIMD
+// accumulation bound before calling.
+func dotScalarU8CenteredIndexedAMD64AVX2(dst []int64, codes []byte, query []ScalarU8CenteredCode, rowIDs []uint32, dims int, rows int, querySum int64)

--- a/TreeDB/internal/vectorops/scalar_u8_dot_batch_amd64.s
+++ b/TreeDB/internal/vectorops/scalar_u8_dot_batch_amd64.s
@@ -2,7 +2,7 @@
 
 #include "textflag.h"
 
-// func dotScalarU8CenteredIndexedAMD64(dst []int64, codes []byte, query []ScalarU8CenteredCode, rowIDs []uint32, dims int, rows int, querySum int64)
+// func dotScalarU8CenteredIndexedAMD64SSE2(dst []int64, codes []byte, query []ScalarU8CenteredCode, rowIDs []uint32, dims int, rows int, querySum int64)
 //
 // Preconditions are checked by the Go wrapper: rows <= len(dst,rowIDs), dims > 0,
 // len(query) >= dims, and every row ID addresses a full row in codes. querySum
@@ -10,7 +10,7 @@
 // signed 32-bit vector accumulation cannot overflow. It computes centered scores
 // as:
 //   sum(q * (2*row - 255)) == 2*sum(q*row) - 255*querySum.
-TEXT ·dotScalarU8CenteredIndexedAMD64(SB), NOSPLIT, $0-120
+TEXT ·dotScalarU8CenteredIndexedAMD64SSE2(SB), NOSPLIT, $0-120
 	MOVQ dst_base+0(FP), DI
 	MOVQ codes_base+24(FP), SI
 	MOVQ query_base+48(FP), R8
@@ -92,4 +92,106 @@ scalaru8_amd64_store:
 	JMP scalaru8_amd64_row_loop
 
 scalaru8_amd64_done:
+	RET
+
+// func dotScalarU8CenteredIndexedAMD64AVX2(dst []int64, codes []byte, query []ScalarU8CenteredCode, rowIDs []uint32, dims int, rows int, querySum int64)
+//
+// Preconditions are checked by the Go wrapper: rows <= len(dst,rowIDs), dims > 0,
+// len(query) >= dims, every row ID addresses a full row in codes, the CPU has
+// AVX2, and dims <= 32768 so signed int32 vector accumulation cannot overflow.
+// It computes centered scores as:
+//   sum(q * (2*row - 255)) == 2*sum(q*row) - 255*querySum.
+TEXT ·dotScalarU8CenteredIndexedAMD64AVX2(SB), NOSPLIT, $0-120
+	MOVQ dst_base+0(FP), DI
+	MOVQ codes_base+24(FP), SI
+	MOVQ query_base+48(FP), R8
+	MOVQ rowIDs_base+72(FP), R9
+	MOVQ dims+96(FP), R10
+	MOVQ rows+104(FP), R11
+	MOVQ querySum+112(FP), R12
+
+scalaru8_amd64_avx2_row_loop:
+	TESTQ R11, R11
+	JZ scalaru8_amd64_avx2_done
+
+	MOVL (R9), AX                // row ID; MOVL zero-extends on amd64
+	ADDQ $4, R9
+	IMULQ R10, AX                // byte offset = rowID*dims
+	LEAQ (SI)(AX*1), BX          // row pointer
+	MOVQ R8, CX                  // query pointer
+	MOVQ R10, DX                 // remaining dims for scalar tail mask
+	XORQ R13, R13                // raw scalar accumulator after vector reduction
+	VPXOR Y0, Y0, Y0             // packed int32 accumulator
+
+	MOVQ DX, AX
+	SHRQ $5, AX                  // 32 dimensions per AVX2 iteration
+	JZ scalaru8_amd64_avx2_tail16
+
+scalaru8_amd64_avx2_loop32:
+	// Widen 32 row bytes to two uint16 YMM vectors and multiply by the matching
+	// 32 int16 centered query values. VPMADDWD reduces adjacent products to int32.
+	VPMOVZXBW (BX), Y1
+	VPMOVZXBW 16(BX), Y2
+	VMOVDQU (CX), Y3
+	VMOVDQU 32(CX), Y4
+	VPMADDWD Y3, Y1, Y1
+	VPMADDWD Y4, Y2, Y2
+	VPADDD Y1, Y0, Y0
+	VPADDD Y2, Y0, Y0
+	ADDQ $32, BX
+	ADDQ $64, CX
+	DECQ AX
+	JNZ scalaru8_amd64_avx2_loop32
+
+scalaru8_amd64_avx2_tail16:
+	ANDQ $31, DX
+	CMPQ DX, $16
+	JL scalaru8_amd64_avx2_reduce
+	VPMOVZXBW (BX), Y1
+	VMOVDQU (CX), Y3
+	VPMADDWD Y3, Y1, Y1
+	VPADDD Y1, Y0, Y0
+	ADDQ $16, BX
+	ADDQ $32, CX
+	SUBQ $16, DX
+
+scalaru8_amd64_avx2_reduce:
+	// Horizontal signed int32 reduction of Y0 into R13.
+	VEXTRACTI128 $1, Y0, X1
+	VPADDD X1, X0, X0
+	VPSRLDQ $8, X0, X1
+	VPADDD X1, X0, X0
+	VPSRLDQ $4, X0, X1
+	VPADDD X1, X0, X0
+	VMOVQ X0, AX
+	MOVLQSX AX, AX
+	ADDQ AX, R13
+
+	TESTQ DX, DX
+	JZ scalaru8_amd64_avx2_store
+
+scalaru8_amd64_avx2_scalar_tail:
+	MOVBQZX (BX), AX
+	MOVWQSX (CX), R14
+	IMULQ R14, AX
+	ADDQ AX, R13
+	INCQ BX
+	ADDQ $2, CX
+	DECQ DX
+	JNZ scalaru8_amd64_avx2_scalar_tail
+
+scalaru8_amd64_avx2_store:
+	// centeredScore = 2*rawSum - 255*querySum.
+	LEAQ (R13)(R13*1), AX
+	MOVQ R12, R14
+	SHLQ $8, R14
+	SUBQ R12, R14
+	SUBQ R14, AX
+	MOVQ AX, (DI)
+	ADDQ $8, DI
+	DECQ R11
+	JMP scalaru8_amd64_avx2_row_loop
+
+scalaru8_amd64_avx2_done:
+	VZEROUPPER
 	RET

--- a/TreeDB/internal/vectorops/scalar_u8_dot_batch_test.go
+++ b/TreeDB/internal/vectorops/scalar_u8_dot_batch_test.go
@@ -258,7 +258,7 @@ func BenchmarkDotScalarU8CenteredIndexedScalar(b *testing.B) {
 
 func benchmarkDotScalarU8CenteredIndexedMatrix(b *testing.B, impl string, call func(dst []int64, codes []byte, query ScalarU8CenteredQuery, rowIDs []uint32, dims, rows int) ScalarU8DotBatchStatus) {
 	b.Helper()
-	dimsCases := []int{32, 64, 128, 256, 768}
+	dimsCases := []int{32, 64, 128, 256, 768, 1536}
 	rowCases := []int{1, 2, 8, 16, 64}
 	for _, dims := range dimsCases {
 		for _, rows := range rowCases {


### PR DESCRIPTION
## Summary

- Add an amd64 AVX2 implementation for `DotScalarU8CenteredIndexed`, runtime-dispatched when AVX2 is available.
- Preserve the existing SSE2 kernel as the amd64 fallback and leave purego/non-amd64 paths unchanged.
- Extend the scalar_u8 dot benchmark matrix with 1536-dim rows to cover the integrated collection shape from #2544.

Closes #2544.

## Latest-head revalidation after main `86cd213f0058c78d1696d57012e10e3c72fba38b`

PR head was updated by merging `origin/main` into `snissn/2544-manager` because force-push is disallowed for this branch. Current PR head: `c967a07339f53cee98f75facf329b4c7f6859586`.

Remote amd64 latest-head artifacts, captured under `/tmp/gomap_2538_benchmark.lock`:

- `/home/mikers/tmp/gomap_2544_latest_head_20260607_110022/`
- baseline: `86cd213f0058c78d1696d57012e10e3c72fba38b`
- candidate: `c967a07339f53cee98f75facf329b4c7f6859586`

### Latest-head microbench: scalar_u8 centered indexed dot

`benchstat_micro_with_1536_count6_ns_allocs_vs_main.txt` (main uses the benchmark-only 1536-dim case so code paths are comparable):

| shape | baseline | candidate | change |
| --- | ---: | ---: | ---: |
| 1536 dims, rows=1 | 116.30 ns/op | 70.61 ns/op | -39.29% |
| 1536 dims, rows=2 | 206.5 ns/op | 125.4 ns/op | -39.26% |
| 1536 dims, rows=8 | 739.5 ns/op | 509.7 ns/op | -31.08% |
| 1536 dims, rows=16 | 1400.5 ns/op | 951.8 ns/op | -32.04% |
| 1536 dims, rows=64 | 6.021 us/op | 4.345 us/op | -27.84% |
| all benchmarked shapes geomean | 151.4 ns/op | 116.5 ns/op | -23.07% |

All rows remained `0 B/op`, `0 allocs/op`.

### Latest-head integrated collection search: scalar_u8 10k x 1536

`benchstat_integrated_10k_x_1536_correct_ns_allocs_vs_main.txt` (n=6):

| route | baseline | candidate | change |
| --- | ---: | ---: | ---: |
| quantized_only c=1 | 50.90 us/op | 45.63 us/op | ~ |
| quantized_only c=8 | 11.16 us/op | 10.43 us/op | ~ |
| quantized_rerank32 c=1 | 56.37 us/op | 55.85 us/op | ~ |
| quantized_rerank32 c=8 | 13.89 us/op | 11.94 us/op | -14.02% |
| geomean | 25.82 us/op | 23.74 us/op | -8.09% |

Guardrails in latest integrated output:

- buffered search rows remain `0 B/op`, `0 allocs/op`
- quantized-only route keeps `vector_B/search=0`, `norm_B/search=0`, `quantized_rerank_exact_score_calls/search=0`
- rerank32 route keeps `quantized_rerank_candidates/search=32`, `quantized_rerank_exact_score_calls/search=32`, `vector_B/search=196608`, `norm_B/search=128`

## Prior amd64 benchmark evidence

Initial remote amd64 AVX2 run used `/tmp/gomap_2538_benchmark.lock` and captured artifacts under:

- Baseline: `/home/mikers/tmp/gomap_2544_baseline_20260607_093856/`
- Candidate: `/home/mikers/tmp/gomap_2544_candidate_avx2_final_20260607_100722/`
- Latest-code smoke: `/home/mikers/tmp/gomap_2544_candidate_avx2_current_smoke_20260607_102622/`

### Prior microbench: scalar_u8 centered indexed dot, 1536 dims

`benchstat` from `scalar_u8_dot_bench_1536.txt` vs candidate:

| rows | baseline | candidate | change |
| ---: | ---: | ---: | ---: |
| 1 | 85.73 ns/op | 59.13 ns/op | -31.03% |
| 2 | 161.4 ns/op | 105.5 ns/op | -34.63% |
| 8 | 606.9 ns/op | 388.1 ns/op | -36.05% |
| 16 | 1161.0 ns/op | 719.9 ns/op | -37.99% |
| 64 | 4.824 us/op | 3.165 us/op | -34.39% |

All rows remained `0 B/op`, `0 allocs/op`.

### Prior integrated collection search: scalar_u8 10k x 1536

`benchstat` n=6 (`benchstat_integrated_ns_allocs_vs_baseline_n6.txt`):

| route | baseline | candidate | change |
| --- | ---: | ---: | ---: |
| quantized_only c=1 | 41.28 us/op | 36.67 us/op | -11.16% |
| quantized_only c=8 | 7.580 us/op | 6.568 us/op | -13.35% |
| quantized_rerank32 c=1 | 47.32 us/op | 42.58 us/op | ~ |
| quantized_rerank32 c=8 | 8.584 us/op | 7.407 us/op | -13.71% |

## Tests

Latest head:

- `go test ./TreeDB/internal/vectorops -count=1`
- `go test ./TreeDB/collections -run 'TestColumnGraphScalarU8Quantized' -count=1`
- cross-compile checks:
  - `GOOS=linux GOARCH=amd64 go test -c ./TreeDB/internal/vectorops`
  - `GOOS=linux GOARCH=amd64 go test -tags purego -c ./TreeDB/internal/vectorops`
  - `GOOS=linux GOARCH=arm64 go test -c ./TreeDB/internal/vectorops`
  - `GOOS=linux GOARCH=amd64 go test -c ./TreeDB/collections`
  - `GOOS=linux GOARCH=arm64 go test -c ./TreeDB/collections`
- remote amd64 latest head:
  - `go test ./TreeDB/internal/vectorops -run 'TestDotScalarU8CenteredIndexed|TestScalarU8Centered' -count=1`
  - `go test ./TreeDB/collections -run 'TestColumnGraphScalarU8Quantized' -count=1`

Prior head also passed the same focused remote tests and scalar_u8 collections tests.
