### PR TITLE
TreeDB: add clean RaBitQ search-loop profiles

### DIFF
--- a/TreeDB/collections/column_vector_graph_quantized_bench_test.go
+++ b/TreeDB/collections/column_vector_graph_quantized_bench_test.go
@@ -109,7 +109,18 @@ func (hook *columnGraphQuantizedSearchLoopProfileHook2541) start(b *testing.B) f
 	if hook.allocsPath != "" {
 		runtime.GC()
 		if hook.allocsBasePath != "" {
-			writeColumnGraphQuantizedHotProfile2541(b, "allocs", hook.allocsBasePath)
+			// Serialize the baseline at the same sampling rate used for the raw
+			// search-loop profile. Go pprof scales sampled allocations using the
+			// current runtime.MemProfileRate at WriteTo time; using a different rate
+			// here would leave setup samples in the later raw-minus-base diff when
+			// HOT_MEM_PROFILE_RATE is greater than 1.
+			func() {
+				runtime.MemProfileRate = hook.memProfileRate
+				defer func() {
+					runtime.MemProfileRate = 0
+				}()
+				writeColumnGraphQuantizedHotProfile2541(b, "allocs", hook.allocsBasePath)
+			}()
 		}
 	}
 
@@ -132,7 +143,16 @@ func (hook *columnGraphQuantizedSearchLoopProfileHook2541) start(b *testing.B) f
 		}
 		stopped = true
 		if hook.allocsPath != "" {
-			runtime.MemProfileRate = 0
+			// Keep the collection sampling rate in effect until allocs WriteTo
+			// completes. The pprof writer scales sampled allocations using the
+			// current runtime.MemProfileRate, so disabling sampling before the raw
+			// profile is serialized underreports runs that use rates greater than 1.
+			// The harness filters pprof-writer noise from the published allocs.pprof
+			// while retaining allocs_diff_raw.pprof for auditability.
+			runtime.MemProfileRate = hook.memProfileRate
+			defer func() {
+				runtime.MemProfileRate = 0
+			}()
 		}
 		if cpuFile != nil {
 			pprof.StopCPUProfile()

--- a/TreeDB/collections/column_vector_graph_quantized_bench_test.go
+++ b/TreeDB/collections/column_vector_graph_quantized_bench_test.go
@@ -4,6 +4,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
+	"runtime"
+	"runtime/pprof"
 	"strconv"
 	"strings"
 	"sync"
@@ -34,7 +37,147 @@ const (
 	columnGraphScalarU8QuantizedBenchTopKEnv1926         = "TREEDB_COLUMN_GRAPH_QUANTIZED_BENCH_TOP_K"
 	columnGraphScalarU8QuantizedBenchEfSearchEnv1926     = "TREEDB_COLUMN_GRAPH_QUANTIZED_BENCH_EF_SEARCH"
 	columnGraphScalarU8QuantizedBenchQueryOrdinalEnv1926 = "TREEDB_COLUMN_GRAPH_QUANTIZED_BENCH_QUERY_ORDINAL"
+
+	columnGraphQuantizedHotCPUProfilePathEnv2541        = "TREEDB_COLUMN_GRAPH_QUANTIZED_HOT_CPU_PROFILE_PATH"
+	columnGraphQuantizedHotAllocsProfilePathEnv2541     = "TREEDB_COLUMN_GRAPH_QUANTIZED_HOT_ALLOCS_PROFILE_PATH"
+	columnGraphQuantizedHotAllocsBaseProfilePathEnv2541 = "TREEDB_COLUMN_GRAPH_QUANTIZED_HOT_ALLOCS_BASE_PROFILE_PATH"
+	columnGraphQuantizedHotMemProfileRateEnv2541        = "TREEDB_COLUMN_GRAPH_QUANTIZED_HOT_MEM_PROFILE_RATE"
+	defaultColumnGraphQuantizedHotMemProfileRate2541    = 1
 )
+
+func init() {
+	if strings.TrimSpace(os.Getenv(columnGraphQuantizedHotAllocsProfilePathEnv2541)) != "" {
+		runtime.MemProfileRate = 0
+	}
+}
+
+type columnGraphQuantizedSearchLoopProfileHook2541 struct {
+	cpuPath              string
+	allocsPath           string
+	allocsBasePath       string
+	oldMemProfileRate    int
+	memProfileRate       int
+	memProfileSuppressed bool
+	restored             bool
+}
+
+func newColumnGraphQuantizedSearchLoopProfileHook2541(b *testing.B) *columnGraphQuantizedSearchLoopProfileHook2541 {
+	b.Helper()
+
+	hook := &columnGraphQuantizedSearchLoopProfileHook2541{
+		cpuPath:        strings.TrimSpace(os.Getenv(columnGraphQuantizedHotCPUProfilePathEnv2541)),
+		allocsPath:     strings.TrimSpace(os.Getenv(columnGraphQuantizedHotAllocsProfilePathEnv2541)),
+		allocsBasePath: strings.TrimSpace(os.Getenv(columnGraphQuantizedHotAllocsBaseProfilePathEnv2541)),
+		memProfileRate: defaultColumnGraphQuantizedHotMemProfileRate2541,
+	}
+	if !hook.enabled() {
+		return hook
+	}
+	if hook.allocsPath != "" {
+		if raw := strings.TrimSpace(os.Getenv(columnGraphQuantizedHotMemProfileRateEnv2541)); raw != "" {
+			value, err := strconv.Atoi(raw)
+			if err != nil || value <= 0 {
+				b.Fatalf("%s=%q must be a positive integer", columnGraphQuantizedHotMemProfileRateEnv2541, raw)
+			}
+			hook.memProfileRate = value
+		}
+		hook.oldMemProfileRate = runtime.MemProfileRate
+		runtime.MemProfileRate = 0
+		hook.memProfileSuppressed = true
+		runtime.GC()
+	}
+	return hook
+}
+
+func (hook *columnGraphQuantizedSearchLoopProfileHook2541) enabled() bool {
+	return hook != nil && (hook.cpuPath != "" || hook.allocsPath != "")
+}
+
+func (hook *columnGraphQuantizedSearchLoopProfileHook2541) finish() {
+	if hook == nil || !hook.memProfileSuppressed || hook.restored {
+		return
+	}
+	runtime.MemProfileRate = hook.oldMemProfileRate
+	hook.restored = true
+}
+
+func (hook *columnGraphQuantizedSearchLoopProfileHook2541) start(b *testing.B) func() {
+	b.Helper()
+	if !hook.enabled() {
+		return func() {}
+	}
+	if hook.allocsPath != "" {
+		runtime.GC()
+		if hook.allocsBasePath != "" {
+			writeColumnGraphQuantizedHotProfile2541(b, "allocs", hook.allocsBasePath)
+		}
+	}
+
+	var cpuFile *os.File
+	if hook.cpuPath != "" {
+		cpuFile = createColumnGraphQuantizedHotProfileFile2541(b, hook.cpuPath, "cpu")
+		if err := pprof.StartCPUProfile(cpuFile); err != nil {
+			_ = cpuFile.Close()
+			b.Fatalf("start search-loop CPU profile: %v; do not also pass go test -cpuprofile", err)
+		}
+	}
+	if hook.allocsPath != "" {
+		runtime.MemProfileRate = hook.memProfileRate
+	}
+
+	stopped := false
+	return func() {
+		if stopped {
+			return
+		}
+		stopped = true
+		if hook.allocsPath != "" {
+			runtime.MemProfileRate = 0
+		}
+		if cpuFile != nil {
+			pprof.StopCPUProfile()
+			if err := cpuFile.Close(); err != nil {
+				b.Errorf("close search-loop CPU profile: %v", err)
+			}
+		}
+		if hook.allocsPath != "" {
+			runtime.GC()
+			runtime.GC()
+			writeColumnGraphQuantizedHotProfile2541(b, "allocs", hook.allocsPath)
+		}
+	}
+}
+
+func createColumnGraphQuantizedHotProfileFile2541(b *testing.B, path, kind string) *os.File {
+	b.Helper()
+	if dir := filepath.Dir(path); dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			b.Fatalf("create search-loop %s profile dir: %v", kind, err)
+		}
+	}
+	file, err := os.Create(path)
+	if err != nil {
+		b.Fatalf("create search-loop %s profile: %v", kind, err)
+	}
+	return file
+}
+
+func writeColumnGraphQuantizedHotProfile2541(b *testing.B, name, path string) {
+	b.Helper()
+	file := createColumnGraphQuantizedHotProfileFile2541(b, path, name)
+	defer func() {
+		if err := file.Close(); err != nil {
+			b.Errorf("close search-loop %s profile: %v", name, err)
+		}
+	}()
+	profile := pprof.Lookup(name)
+	if profile == nil {
+		b.Fatalf("runtime profile %q is unavailable", name)
+	}
+	if err := profile.WriteTo(file, 0); err != nil {
+		b.Fatalf("write search-loop %s profile: %v", name, err)
+	}
+}
 
 func defaultColumnGraphScalarU8QuantizedBenchShape1926() columnGraphScalarU8QuantizedBenchShape1926 {
 	return columnGraphScalarU8QuantizedBenchShape1926{rows: 1024, dims: 128, m: 16, topK: 10, efSearch: 128, queryOrdinal: 37}
@@ -380,6 +523,8 @@ func BenchmarkVectorIndexSearcherColumnGraphScalarU8QuantizedSearchWithBuffer241
 }
 
 func BenchmarkVectorIndexSearcherColumnGraphRabitQQuantizedSearchWithBuffer2451(b *testing.B) {
+	hotProfile := newColumnGraphQuantizedSearchLoopProfileHook2541(b)
+	defer hotProfile.finish()
 	shape := columnGraphScalarU8QuantizedBenchShapeFromEnv1926(b)
 	fixture := openColumnGraphRabitQQuantizedBenchFixture2451(b, shape)
 	defer fixture.close()
@@ -397,7 +542,7 @@ func BenchmarkVectorIndexSearcherColumnGraphRabitQQuantizedSearchWithBuffer2451(
 				EfSearch:                  fixture.shape.efSearch,
 				StatsMode:                 VectorIndexSearchStatsModeProduction,
 			}
-			runColumnGraphRabitQQuantizedSearchWithBufferBench2451(b, fixture, opts, tc.concurrency, exactIDs, exactCount)
+			runColumnGraphRabitQQuantizedSearchWithBufferBench2451(b, fixture, opts, tc.concurrency, exactIDs, exactCount, hotProfile)
 		})
 	}
 }
@@ -445,12 +590,14 @@ func BenchmarkCollectionSearchVectorIndexWithBufferColumnGraphScalarU8Quantized2
 				MaxDecodedBlocks:          1,
 				StatsMode:                 VectorIndexSearchStatsModeProduction,
 			}
-			runColumnGraphScalarU8QuantizedCollectionWithBufferBench2415(b, fixture, opts, tc.concurrency, exactIDs, exactCount)
+			runColumnGraphScalarU8QuantizedCollectionWithBufferBench2415(b, fixture, opts, tc.concurrency, exactIDs, exactCount, nil)
 		})
 	}
 }
 
 func BenchmarkCollectionSearchVectorIndexWithBufferColumnGraphRabitQQuantized2452(b *testing.B) {
+	hotProfile := newColumnGraphQuantizedSearchLoopProfileHook2541(b)
+	defer hotProfile.finish()
 	shape := columnGraphScalarU8QuantizedBenchShapeFromEnv1926(b)
 	fixture := openColumnGraphRabitQQuantizedBenchFixture2451(b, shape)
 	defer fixture.close()
@@ -470,12 +617,12 @@ func BenchmarkCollectionSearchVectorIndexWithBufferColumnGraphRabitQQuantized245
 				MaxDecodedBlocks:          1,
 				StatsMode:                 VectorIndexSearchStatsModeProduction,
 			}
-			runColumnGraphScalarU8QuantizedCollectionWithBufferBench2415(b, fixture, opts, tc.concurrency, exactIDs, exactCount)
+			runColumnGraphScalarU8QuantizedCollectionWithBufferBench2415(b, fixture, opts, tc.concurrency, exactIDs, exactCount, hotProfile)
 		})
 	}
 }
 
-func runColumnGraphScalarU8QuantizedCollectionWithBufferBench2415(b *testing.B, fixture columnGraphScalarU8QuantizedBenchFixture1926, opts VectorIndexSearchOptions, concurrency int, exactIDs map[string]struct{}, exactCount int) {
+func runColumnGraphScalarU8QuantizedCollectionWithBufferBench2415(b *testing.B, fixture columnGraphScalarU8QuantizedBenchFixture1926, opts VectorIndexSearchOptions, concurrency int, exactIDs map[string]struct{}, exactCount int, hotProfile *columnGraphQuantizedSearchLoopProfileHook2541) {
 	b.Helper()
 	if concurrency <= 0 {
 		b.Fatalf("concurrency=%d must be positive", concurrency)
@@ -577,10 +724,19 @@ func runColumnGraphScalarU8QuantizedCollectionWithBufferBench2415(b *testing.B, 
 	}
 	cacheBeforeTimed := fixture.collection.collectionVectorIndexPreparedSearchCacheSnapshot()
 	b.ReportAllocs()
+	stopHotProfile := hotProfile.start(b)
+	hotProfileActive := hotProfile.enabled()
+	defer func() {
+		if hotProfileActive {
+			stopHotProfile()
+		}
+	}()
 	b.ResetTimer()
 	close(start)
 	wg.Wait()
 	b.StopTimer()
+	stopHotProfile()
+	hotProfileActive = false
 	b.ReportMetric(float64(concurrency), "concurrency")
 	b.ReportMetric(1, "collection_searchvectorindex_with_buffer_seam")
 	b.ReportMetric(1, "collection_buffered_quantized_row")
@@ -786,7 +942,7 @@ func assertColumnGraphScalarU8QuantizedSearchWithBufferGuardrails2414(tb testing
 	}
 }
 
-func runColumnGraphRabitQQuantizedSearchWithBufferBench2451(b *testing.B, fixture columnGraphScalarU8QuantizedBenchFixture1926, opts VectorIndexSearcherSearchOptions, concurrency int, exactIDs map[string]struct{}, exactCount int) {
+func runColumnGraphRabitQQuantizedSearchWithBufferBench2451(b *testing.B, fixture columnGraphScalarU8QuantizedBenchFixture1926, opts VectorIndexSearcherSearchOptions, concurrency int, exactIDs map[string]struct{}, exactCount int, hotProfile *columnGraphQuantizedSearchLoopProfileHook2541) {
 	b.Helper()
 	if concurrency <= 0 {
 		b.Fatalf("concurrency=%d must be positive", concurrency)
@@ -888,10 +1044,19 @@ func runColumnGraphRabitQQuantizedSearchWithBufferBench2451(b *testing.B, fixtur
 	b.ReportMetric(1, "searchwithbuffer_buffered_row")
 	b.ReportMetric(1, "rabitq_1bit_row")
 	b.ReportMetric(1, "reported_stats_mode_production")
+	stopHotProfile := hotProfile.start(b)
+	hotProfileActive := hotProfile.enabled()
+	defer func() {
+		if hotProfileActive {
+			stopHotProfile()
+		}
+	}()
 	b.ResetTimer()
 	close(start)
 	wg.Wait()
 	b.StopTimer()
+	stopHotProfile()
+	hotProfileActive = false
 	if errValue := firstErr.Load(); errValue != nil {
 		b.Fatalf("%s", errValue.(string))
 	}

--- a/docs/benchmarks/treedb_rabitq_1bit_profile_gate.md
+++ b/docs/benchmarks/treedb_rabitq_1bit_profile_gate.md
@@ -55,6 +55,8 @@ Default selection:
   `-memprofile` flags. `PROFILE_SCOPE=search_loop` rejects non-RaBitQ profile
   rows up front; use `PROFILE_SCOPE=go_test` only for the legacy compatibility
   mode that includes setup/rebuild attribution or for scalar guardrail profiles.
+- `ALLOC_PROFILE_IGNORE`: optional pprof regexp used only by `PROFILE_SCOPE=search_loop`
+  to filter allocation-profile writer frames from the diffed `allocs.pprof`.
 - `RECALL_TOLERANCE_PCT=0`: when `BASELINE_DIR` is set, candidate median recall must be at least the matching baseline row's median recall minus this tolerance for the row guardrail to pass.
 
 Useful selectors for `ROWS` and `PROFILE_ROWS` are comma-separated and ORed:
@@ -101,12 +103,14 @@ Primary artifacts:
 - `<row>/cpu.pprof`, `<row>/allocs.pprof`, `<row>/cpu_top.txt`,
   `<row>/allocs_top.txt`: required CPU/allocation artifacts for profiled rows.
   In the default `PROFILE_SCOPE=search_loop`, these exclude setup/rebuild and
-  cover only the timed search loop. `allocs.pprof` is generated as a diff of
-  `<row>/allocs_raw.pprof` minus `<row>/allocs_base.pprof`, so fixture setup and
-  rebuild allocations are removed; it is expected to be empty or
+  cover only the timed search loop. `allocs.pprof` is generated from
+  `<row>/allocs_raw.pprof` minus `<row>/allocs_base.pprof`, then filtered with
+  `ALLOC_PROFILE_IGNORE` to remove allocation-profile writer noise such as
+  `runtime/pprof` and `compress/gzip`; it is expected to be empty or
   runtime-noise-only when the row remains `0 B/op`, `0 allocs/op`.
-- `<row>/allocs_base.pprof`, `<row>/allocs_raw.pprof`: supporting profiles for
-  `PROFILE_SCOPE=search_loop` allocation diffing.
+- `<row>/allocs_base.pprof`, `<row>/allocs_raw.pprof`,
+  `<row>/allocs_diff_raw.pprof`: supporting profiles for `PROFILE_SCOPE=search_loop`
+  allocation diffing and filter audits.
 - `<row>/block.pprof`, `<row>/mutex.pprof`, top summaries: emitted only by
   `PROFILE_SCOPE=go_test` legacy mode.
 - `<row>/pprof_lists/*.txt`: supporting line-level CPU attribution.

--- a/docs/benchmarks/treedb_rabitq_1bit_profile_gate.md
+++ b/docs/benchmarks/treedb_rabitq_1bit_profile_gate.md
@@ -51,9 +51,10 @@ Default selection:
   `TREEDB_COLUMN_GRAPH_QUANTIZED_HOT_CPU_PROFILE_PATH`,
   `TREEDB_COLUMN_GRAPH_QUANTIZED_HOT_ALLOCS_PROFILE_PATH`, and
   `TREEDB_COLUMN_GRAPH_QUANTIZED_HOT_ALLOCS_BASE_PROFILE_PATH` for one isolated
-  benchmark subrow and does **not** pass Go's test-level `-cpuprofile` /
-  `-memprofile` flags. Use `PROFILE_SCOPE=go_test` only for the legacy
-  compatibility mode that includes setup/rebuild attribution.
+  RaBitQ benchmark subrow and does **not** pass Go's test-level `-cpuprofile` /
+  `-memprofile` flags. `PROFILE_SCOPE=search_loop` rejects non-RaBitQ profile
+  rows up front; use `PROFILE_SCOPE=go_test` only for the legacy compatibility
+  mode that includes setup/rebuild attribution or for scalar guardrail profiles.
 - `RECALL_TOLERANCE_PCT=0`: when `BASELINE_DIR` is set, candidate median recall must be at least the matching baseline row's median recall minus this tolerance for the row guardrail to pass.
 
 Useful selectors for `ROWS` and `PROFILE_ROWS` are comma-separated and ORed:

--- a/docs/benchmarks/treedb_rabitq_1bit_profile_gate.md
+++ b/docs/benchmarks/treedb_rabitq_1bit_profile_gate.md
@@ -22,7 +22,9 @@ shape-parameterized quantized-search fixture. The default remains the historical
 - route, exact-read, asset-unavailable, fallback, and cache counters;
 - `quantized_code_B/search`, `quantized_code_B/vector`, and
   `quantized_asset_B/vector`;
-- CPU and allocation profiles for selected c=1/c=8 rows.
+- CPU and allocation profiles for selected c=1/c=8 rows. By default these
+  use benchmark-controlled search-loop hooks that start after fixture setup,
+  vector-index rebuild, collection prepared-cache warmup, and worker warmup.
 
 Smoke runs validate benchmark shape and counters only. They are not speedup or
 promotion evidence.
@@ -45,6 +47,13 @@ Default selection:
   CPU/alloc profiles for the required RaBitQ collection buffered target rows.
 - `BENCHTIME=100000x` for the default shape, `BENCHTIME=1000x` for
   `SHAPE=10k_x_1536`, `TIMING_COUNT=5`, `PROFILE_COUNT=1`.
+- `PROFILE_SCOPE=search_loop`: default clean pprof mode. The script sets
+  `TREEDB_COLUMN_GRAPH_QUANTIZED_HOT_CPU_PROFILE_PATH`,
+  `TREEDB_COLUMN_GRAPH_QUANTIZED_HOT_ALLOCS_PROFILE_PATH`, and
+  `TREEDB_COLUMN_GRAPH_QUANTIZED_HOT_ALLOCS_BASE_PROFILE_PATH` for one isolated
+  benchmark subrow and does **not** pass Go's test-level `-cpuprofile` /
+  `-memprofile` flags. Use `PROFILE_SCOPE=go_test` only for the legacy
+  compatibility mode that includes setup/rebuild attribution.
 - `RECALL_TOLERANCE_PCT=0`: when `BASELINE_DIR` is set, candidate median recall must be at least the matching baseline row's median recall minus this tolerance for the row guardrail to pass.
 
 Useful selectors for `ROWS` and `PROFILE_ROWS` are comma-separated and ORed:
@@ -90,8 +99,16 @@ Primary artifacts:
 - `<row>/bench_profile.txt`: profiled benchmark output for profiled rows.
 - `<row>/cpu.pprof`, `<row>/allocs.pprof`, `<row>/cpu_top.txt`,
   `<row>/allocs_top.txt`: required CPU/allocation artifacts for profiled rows.
-- `<row>/block.pprof`, `<row>/mutex.pprof`, top summaries, and
-  `<row>/pprof_lists/*.txt`: supporting attribution.
+  In the default `PROFILE_SCOPE=search_loop`, these exclude setup/rebuild and
+  cover only the timed search loop. `allocs.pprof` is generated as a diff of
+  `<row>/allocs_raw.pprof` minus `<row>/allocs_base.pprof`, so fixture setup and
+  rebuild allocations are removed; it is expected to be empty or
+  runtime-noise-only when the row remains `0 B/op`, `0 allocs/op`.
+- `<row>/allocs_base.pprof`, `<row>/allocs_raw.pprof`: supporting profiles for
+  `PROFILE_SCOPE=search_loop` allocation diffing.
+- `<row>/block.pprof`, `<row>/mutex.pprof`, top summaries: emitted only by
+  `PROFILE_SCOPE=go_test` legacy mode.
+- `<row>/pprof_lists/*.txt`: supporting line-level CPU attribution.
 
 Recommended raw directory naming:
 
@@ -131,13 +148,18 @@ GOMAXPROCS=8 GOWORK=off go test ./TreeDB/collections \
 
 ```sh
 RUN_DIR=/tmp/gomap_rabitq_1bit_10k_x_1536_$(date +%Y%m%d_%H%M%S) \
+  BENCHMARK_LOCK=/tmp/gomap_2538_benchmark.lock \
+  PROFILE_SCOPE=search_loop \
   SHAPE=10k_x_1536 \
   ROWS=rabitq_collection_quantized_only_c1,rabitq_collection_quantized_only_c8,rabitq_collection_quantized_rerank32_c1,rabitq_collection_quantized_rerank32_c8 \
   PROFILE_ROWS=rabitq_collection_quantized_only_c1,rabitq_collection_quantized_only_c8,rabitq_collection_quantized_rerank32_c1,rabitq_collection_quantized_rerank32_c8 \
   TIMING_COUNT=1 PROFILE_COUNT=1 BENCHTIME=1000x \
   GOMAXPROCS=8 GOWORK=off \
-  scripts/treedb_rabitq_1bit_profile_gate.sh
+  lockf /tmp/gomap_2538_benchmark.lock scripts/treedb_rabitq_1bit_profile_gate.sh
 ```
+
+On Linux hosts, use `flock /tmp/gomap_2538_benchmark.lock -c '<same env-prefixed command>'`
+if `lockf` is unavailable.
 
 ## Claim-quality same-host baseline/candidate workflow
 

--- a/docs/benchmarks/treedb_rabitq_1bit_profile_gate.md
+++ b/docs/benchmarks/treedb_rabitq_1bit_profile_gate.md
@@ -55,6 +55,11 @@ Default selection:
   `-memprofile` flags. `PROFILE_SCOPE=search_loop` rejects non-RaBitQ profile
   rows up front; use `PROFILE_SCOPE=go_test` only for the legacy compatibility
   mode that includes setup/rebuild attribution or for scalar guardrail profiles.
+- `HOT_MEM_PROFILE_RATE=1`: allocation sampling rate used during the timed
+  search loop and preserved while `allocs_raw.pprof` is serialized so Go pprof
+  scales sampled allocations correctly. Raise it only to reduce allocation
+  profiling overhead; the guardrail timing row remains the source of truth for
+  `B/op` and `allocs/op`.
 - `ALLOC_PROFILE_IGNORE`: optional pprof regexp used only by `PROFILE_SCOPE=search_loop`
   to filter allocation-profile writer frames from the diffed `allocs.pprof`.
 - `RECALL_TOLERANCE_PCT=0`: when `BASELINE_DIR` is set, candidate median recall must be at least the matching baseline row's median recall minus this tolerance for the row guardrail to pass.

--- a/scripts/treedb_rabitq_1bit_profile_gate.sh
+++ b/scripts/treedb_rabitq_1bit_profile_gate.sh
@@ -34,6 +34,7 @@ HOT_ALLOCS_PROFILE_ENV=TREEDB_COLUMN_GRAPH_QUANTIZED_HOT_ALLOCS_PROFILE_PATH
 HOT_ALLOCS_BASE_PROFILE_ENV=TREEDB_COLUMN_GRAPH_QUANTIZED_HOT_ALLOCS_BASE_PROFILE_PATH
 HOT_MEM_PROFILE_RATE_ENV=TREEDB_COLUMN_GRAPH_QUANTIZED_HOT_MEM_PROFILE_RATE
 HOT_MEM_PROFILE_RATE="${HOT_MEM_PROFILE_RATE:-${TREEDB_COLUMN_GRAPH_QUANTIZED_HOT_MEM_PROFILE_RATE:-1}}"
+ALLOC_PROFILE_IGNORE="${ALLOC_PROFILE_IGNORE:-runtime/pprof|compress/gzip|github.com/snissn/gomap/TreeDB/collections\\.\\(\\*columnGraphQuantizedSearchLoopProfileHook2541\\)|github.com/snissn/gomap/TreeDB/collections\\.writeColumnGraphQuantizedHotProfile2541|github.com/snissn/gomap/TreeDB/collections\\.createColumnGraphQuantizedHotProfileFile2541|time\\.Sleep|sync\\.\\(\\*WaitGroup\\)\\.Wait}"
 
 mkdir -p "$RUN_DIR"
 
@@ -219,6 +220,27 @@ write_pprof_diff() {
 	rm -f "$dest.err"
 }
 
+write_pprof_filtered() {
+	local src=$1
+	local dest=$2
+	local ignore=$3
+	if [[ ! -s "$src" ]]; then
+		printf 'profile %s is missing or empty\n' "$src" >&2
+		return 1
+	fi
+	if [[ -z "$ignore" ]]; then
+		cp "$src" "$dest"
+		return 0
+	fi
+	if ! go tool pprof -proto -ignore="$ignore" "$src" >"$dest.tmp" 2>"$dest.err"; then
+		cat "$dest.err" >&2
+		rm -f "$dest.tmp" "$dest.err"
+		return 1
+	fi
+	mv "$dest.tmp" "$dest"
+	rm -f "$dest.err"
+}
+
 matches_selector() {
 	local selector=$1
 	local id=$2
@@ -298,6 +320,7 @@ write_context() {
 		printf 'profiles: enabled=%s benchtime=%s count=%s\n' "$RUN_PROFILES" "$PROFILE_BENCHTIME" "$PROFILE_COUNT"
 		printf 'profile_scope: %s\n' "$PROFILE_SCOPE"
 		printf 'hot_profile_env: %s %s %s %s=%s\n' "$HOT_CPU_PROFILE_ENV" "$HOT_ALLOCS_PROFILE_ENV" "$HOT_ALLOCS_BASE_PROFILE_ENV" "$HOT_MEM_PROFILE_RATE_ENV" "$HOT_MEM_PROFILE_RATE"
+		printf 'alloc_profile_ignore: %s\n' "$ALLOC_PROFILE_IGNORE"
 		printf 'dry_run: %s\n' "$DRY_RUN"
 		printf 'benchmark_lock: %s\n' "$BENCHMARK_LOCK"
 		printf 'baseline_dir: %s\n' "$BASELINE_DIR"
@@ -372,6 +395,7 @@ run_row() {
 	local alloc_profile="$row_dir/allocs.pprof"
 	local alloc_base_profile="$row_dir/allocs_base.pprof"
 	local alloc_raw_profile="$row_dir/allocs_raw.pprof"
+	local alloc_diff_raw_profile="$row_dir/allocs_diff_raw.pprof"
 	local block_profile="$row_dir/block.pprof"
 	local mutex_profile="$row_dir/mutex.pprof"
 	local lists_dir="$row_dir/pprof_lists"
@@ -447,7 +471,8 @@ run_row() {
 					printf 'missing search-loop allocs baseline profile %s\n' "$alloc_base_profile" >&2
 					exit 1
 				fi
-				write_pprof_diff "$alloc_base_profile" "$alloc_raw_profile" "$alloc_profile"
+				write_pprof_diff "$alloc_base_profile" "$alloc_raw_profile" "$alloc_diff_raw_profile"
+				write_pprof_filtered "$alloc_diff_raw_profile" "$alloc_profile" "$ALLOC_PROFILE_IGNORE"
 			else
 				run_go_test "$profile_txt" "${profile_cmd[@]}"
 			fi
@@ -498,8 +523,8 @@ Artifacts:
 
 - \`bench_timing.txt\`: unprofiled per-row timing/guardrail output.
 - \`bench_profile.txt\`: profiled benchmark output when this row is in \`PROFILE_ROWS\` and \`RUN_PROFILES=true\`.
-- \`cpu.pprof\`, \`allocs.pprof\`: CPU/allocation profiles when \`profile_captured=true\`; for \`PROFILE_SCOPE=search_loop\`, \`allocs.pprof\` is a diff of \`allocs_raw.pprof\` minus \`allocs_base.pprof\` so setup allocations are removed.
-- \`allocs_base.pprof\`, \`allocs_raw.pprof\`: supporting allocation profiles emitted only for \`PROFILE_SCOPE=search_loop\`.
+- \`cpu.pprof\`, \`allocs.pprof\`: CPU/allocation profiles when \`profile_captured=true\`; for \`PROFILE_SCOPE=search_loop\`, \`allocs.pprof\` is \`allocs_diff_raw.pprof\` filtered by \`ALLOC_PROFILE_IGNORE\` so setup allocations and pprof-writer noise are removed.
+- \`allocs_base.pprof\`, \`allocs_raw.pprof\`, \`allocs_diff_raw.pprof\`: supporting allocation profiles emitted only for \`PROFILE_SCOPE=search_loop\`.
 - \`block.pprof\`, \`mutex.pprof\`: emitted only for \`PROFILE_SCOPE=go_test\`.
 - \`collections.test\`: test binary emitted by \`go test -o\` when \`profile_captured=true\`.
 - \`cpu_top.txt\`, \`allocs_top.txt\`, \`block_top.txt\`, \`mutex_top.txt\`.
@@ -900,7 +925,7 @@ with open(os.path.join(root, "summary.md"), "w", encoding="utf-8") as out:
             )
         )
     out.write("\n## Artifact layout\n\n")
-    out.write("Each selected row directory contains `bench_timing.txt`, `bench_profile.txt`, command files, a row README, top summaries, and CPU/alloc pprof files when `profile_captured=true` (`allocs_base.pprof`/`allocs_raw.pprof` support `PROFILE_SCOPE=search_loop`; `block.pprof`/`mutex.pprof` only for `PROFILE_SCOPE=go_test`).\n")
+    out.write("Each selected row directory contains `bench_timing.txt`, `bench_profile.txt`, command files, a row README, top summaries, and CPU/alloc pprof files when `profile_captured=true` (`allocs_base.pprof`/`allocs_raw.pprof`/`allocs_diff_raw.pprof` support `PROFILE_SCOPE=search_loop`; `block.pprof`/`mutex.pprof` only for `PROFILE_SCOPE=go_test`).\n")
 PY
 
 if [[ -n "$BASELINE_DIR" ]]; then
@@ -948,8 +973,8 @@ Primary files:
 - \`summary.md\`, \`summary.tsv\`: per-row timing medians and guardrail counter summary.
 - \`<row>/bench_timing.txt\`: unprofiled benchmark output for the selected row.
 - \`<row>/bench_profile.txt\`: profiled benchmark output for rows selected by \`PROFILE_ROWS\`.
-- \`<row>/cpu.pprof\`, \`<row>/allocs.pprof\`: CPU/allocation profiles when \`profile_captured=true\`; for \`PROFILE_SCOPE=search_loop\`, \`allocs.pprof\` is a diff of \`allocs_raw.pprof\` minus \`allocs_base.pprof\` so setup allocations are removed.
-- \`<row>/allocs_base.pprof\`, \`<row>/allocs_raw.pprof\`: supporting allocation profiles emitted only for \`PROFILE_SCOPE=search_loop\`.
+- \`<row>/cpu.pprof\`, \`<row>/allocs.pprof\`: CPU/allocation profiles when \`profile_captured=true\`; for \`PROFILE_SCOPE=search_loop\`, \`allocs.pprof\` is \`allocs_diff_raw.pprof\` filtered by \`ALLOC_PROFILE_IGNORE\` so setup allocations and pprof-writer noise are removed.
+- \`<row>/allocs_base.pprof\`, \`<row>/allocs_raw.pprof\`, \`<row>/allocs_diff_raw.pprof\`: supporting allocation profiles emitted only for \`PROFILE_SCOPE=search_loop\`.
 - \`<row>/block.pprof\`, \`<row>/mutex.pprof\`: emitted only for \`PROFILE_SCOPE=go_test\`.
 - \`<row>/collections.test\`: test binary emitted by \`go test -o\` when \`profile_captured=true\`.
 - \`<row>/cpu_top.txt\`, \`<row>/allocs_top.txt\`, \`<row>/block_top.txt\`, \`<row>/mutex_top.txt\`.

--- a/scripts/treedb_rabitq_1bit_profile_gate.sh
+++ b/scripts/treedb_rabitq_1bit_profile_gate.sh
@@ -534,8 +534,11 @@ Use unprofiled \`bench_timing.txt\` rows for \`ns/op\`, \`B/op\`, and
 \`allocs/op\`. With \`PROFILE_SCOPE=search_loop\`, \`cpu.pprof\` and
 \`allocs.pprof\` come from benchmark-controlled hooks that start after fixture
 setup, vector-index rebuild, collection prepared-cache warmup, and worker
-warmup. With \`PROFILE_SCOPE=go_test\`, Go's test-level profiling flags include
-that setup/rebuild work and are kept only as a compatibility fallback.
+warmup. \`HOT_MEM_PROFILE_RATE\` is preserved while \`allocs_raw.pprof\` is written
+so Go pprof scales sampled allocations correctly before the harness filters the
+published \`allocs.pprof\`. With \`PROFILE_SCOPE=go_test\`, Go's test-level
+profiling flags include that setup/rebuild work and are kept only as a
+compatibility fallback.
 EOF
 }
 
@@ -975,6 +978,7 @@ Primary files:
 - \`<row>/bench_profile.txt\`: profiled benchmark output for rows selected by \`PROFILE_ROWS\`.
 - \`<row>/cpu.pprof\`, \`<row>/allocs.pprof\`: CPU/allocation profiles when \`profile_captured=true\`; for \`PROFILE_SCOPE=search_loop\`, \`allocs.pprof\` is \`allocs_diff_raw.pprof\` filtered by \`ALLOC_PROFILE_IGNORE\` so setup allocations and pprof-writer noise are removed.
 - \`<row>/allocs_base.pprof\`, \`<row>/allocs_raw.pprof\`, \`<row>/allocs_diff_raw.pprof\`: supporting allocation profiles emitted only for \`PROFILE_SCOPE=search_loop\`.
+  \`HOT_MEM_PROFILE_RATE\` is preserved while \`allocs_raw.pprof\` is written so Go pprof scales sampled allocations correctly before the published \`allocs.pprof\` filter runs.
 - \`<row>/block.pprof\`, \`<row>/mutex.pprof\`: emitted only for \`PROFILE_SCOPE=go_test\`.
 - \`<row>/collections.test\`: test binary emitted by \`go test -o\` when \`profile_captured=true\`.
 - \`<row>/cpu_top.txt\`, \`<row>/allocs_top.txt\`, \`<row>/block_top.txt\`, \`<row>/mutex_top.txt\`.

--- a/scripts/treedb_rabitq_1bit_profile_gate.sh
+++ b/scripts/treedb_rabitq_1bit_profile_gate.sh
@@ -22,11 +22,18 @@ PROFILE_COUNT="${PROFILE_COUNT:-1}"
 RUN_TIMING="${RUN_TIMING:-true}"
 RUN_PROFILES="${RUN_PROFILES:-true}"
 DRY_RUN="${DRY_RUN:-false}"
+PROFILE_SCOPE="${PROFILE_SCOPE:-search_loop}"
 GOMAXPROCS_VALUE="${GOMAXPROCS:-8}"
 GOWORK_VALUE="${GOWORK:-off}"
 PPROF_FRAMES="${PPROF_FRAMES:-columnVectorGraphRabitQQuantizedScorer.scoreOrdinalUnchecked,columnVectorGraphRabitQQuantizedScorer.scoreOrdinals,ScoreCosine,scoreAndPushFrontierVisitedTile,frontierSiftDown,insertTop,fetchTopPreparedSearchResults,acquireCollectionVectorIndexPreparedSearch}"
 BASELINE_DIR="${BASELINE_DIR:-}"
 RECALL_TOLERANCE_PCT="${RECALL_TOLERANCE_PCT:-0}"
+BENCHMARK_LOCK="${BENCHMARK_LOCK:-}"
+HOT_CPU_PROFILE_ENV=TREEDB_COLUMN_GRAPH_QUANTIZED_HOT_CPU_PROFILE_PATH
+HOT_ALLOCS_PROFILE_ENV=TREEDB_COLUMN_GRAPH_QUANTIZED_HOT_ALLOCS_PROFILE_PATH
+HOT_ALLOCS_BASE_PROFILE_ENV=TREEDB_COLUMN_GRAPH_QUANTIZED_HOT_ALLOCS_BASE_PROFILE_PATH
+HOT_MEM_PROFILE_RATE_ENV=TREEDB_COLUMN_GRAPH_QUANTIZED_HOT_MEM_PROFILE_RATE
+HOT_MEM_PROFILE_RATE="${HOT_MEM_PROFILE_RATE:-${TREEDB_COLUMN_GRAPH_QUANTIZED_HOT_MEM_PROFILE_RATE:-1}}"
 
 mkdir -p "$RUN_DIR"
 
@@ -97,6 +104,17 @@ require_nonnegative_int() {
 		printf '%s=%q must be a non-negative integer\n' "$name" "$value" >&2
 		return 2
 	fi
+}
+
+validate_profile_scope() {
+	case "$PROFILE_SCOPE" in
+		search_loop|go_test) ;;
+		*)
+			printf 'unsupported PROFILE_SCOPE=%q (want search_loop or go_test)\n' "$PROFILE_SCOPE" >&2
+			return 2
+			;;
+	esac
+	require_positive_int HOT_MEM_PROFILE_RATE "$HOT_MEM_PROFILE_RATE"
 }
 
 resolve_bench_shape() {
@@ -184,6 +202,23 @@ write_pprof_list() {
 	rm -f "$dest.tmp" "$dest.err"
 }
 
+write_pprof_diff() {
+	local base=$1
+	local after=$2
+	local dest=$3
+	if [[ ! -s "$base" || ! -s "$after" ]]; then
+		printf 'diff base %s or profile %s is missing or empty\n' "$base" "$after" >&2
+		return 1
+	fi
+	if ! go tool pprof -proto -diff_base "$base" "$after" >"$dest.tmp" 2>"$dest.err"; then
+		cat "$dest.err" >&2
+		rm -f "$dest.tmp" "$dest.err"
+		return 1
+	fi
+	mv "$dest.tmp" "$dest"
+	rm -f "$dest.err"
+}
+
 matches_selector() {
 	local selector=$1
 	local id=$2
@@ -234,6 +269,7 @@ selected_by_list() {
 	return 1
 }
 
+validate_profile_scope
 resolve_bench_shape
 
 write_context() {
@@ -260,7 +296,10 @@ write_context() {
 		printf 'profile_rows: %s\n' "$PROFILE_ROWS"
 		printf 'timing: enabled=%s benchtime=%s count=%s\n' "$RUN_TIMING" "$TIMING_BENCHTIME" "$TIMING_COUNT"
 		printf 'profiles: enabled=%s benchtime=%s count=%s\n' "$RUN_PROFILES" "$PROFILE_BENCHTIME" "$PROFILE_COUNT"
+		printf 'profile_scope: %s\n' "$PROFILE_SCOPE"
+		printf 'hot_profile_env: %s %s %s %s=%s\n' "$HOT_CPU_PROFILE_ENV" "$HOT_ALLOCS_PROFILE_ENV" "$HOT_ALLOCS_BASE_PROFILE_ENV" "$HOT_MEM_PROFILE_RATE_ENV" "$HOT_MEM_PROFILE_RATE"
 		printf 'dry_run: %s\n' "$DRY_RUN"
+		printf 'benchmark_lock: %s\n' "$BENCHMARK_LOCK"
 		printf 'baseline_dir: %s\n' "$BASELINE_DIR"
 		printf 'recall_tolerance_pct: %s\n' "$RECALL_TOLERANCE_PCT"
 		printf 'pprof_frames: %s\n' "$PPROF_FRAMES"
@@ -290,6 +329,29 @@ run_go_test() {
 		"$@" 2>&1 | tee "$outfile"
 }
 
+run_search_loop_profile_go_test() {
+	local outfile=$1
+	local cpu_profile=$2
+	local alloc_profile=$3
+	local alloc_base_profile=$4
+	shift 4
+	env \
+		GOMAXPROCS="$GOMAXPROCS_VALUE" \
+		GOWORK="$GOWORK_VALUE" \
+		TREEDB_COLUMN_GRAPH_QUANTIZED_BENCH_SHAPE="$SHAPE" \
+		TREEDB_COLUMN_GRAPH_QUANTIZED_BENCH_ROWS="$BENCH_ROWS" \
+		TREEDB_COLUMN_GRAPH_QUANTIZED_BENCH_DIMS="$BENCH_DIMS" \
+		TREEDB_COLUMN_GRAPH_QUANTIZED_BENCH_M="$BENCH_M" \
+		TREEDB_COLUMN_GRAPH_QUANTIZED_BENCH_TOP_K="$BENCH_TOP_K" \
+		TREEDB_COLUMN_GRAPH_QUANTIZED_BENCH_EF_SEARCH="$BENCH_EF_SEARCH" \
+		TREEDB_COLUMN_GRAPH_QUANTIZED_BENCH_QUERY_ORDINAL="$BENCH_QUERY_ORDINAL" \
+		"$HOT_CPU_PROFILE_ENV=$cpu_profile" \
+		"$HOT_ALLOCS_PROFILE_ENV=$alloc_profile" \
+		"$HOT_ALLOCS_BASE_PROFILE_ENV=$alloc_base_profile" \
+		"$HOT_MEM_PROFILE_RATE_ENV=$HOT_MEM_PROFILE_RATE" \
+		"$@" 2>&1 | tee "$outfile"
+}
+
 run_row() {
 	local id=$1
 	local codec=$2
@@ -308,6 +370,8 @@ run_row() {
 	local profile_txt="$row_dir/bench_profile.txt"
 	local cpu_profile="$row_dir/cpu.pprof"
 	local alloc_profile="$row_dir/allocs.pprof"
+	local alloc_base_profile="$row_dir/allocs_base.pprof"
+	local alloc_raw_profile="$row_dir/allocs_raw.pprof"
 	local block_profile="$row_dir/block.pprof"
 	local mutex_profile="$row_dir/mutex.pprof"
 	local lists_dir="$row_dir/pprof_lists"
@@ -323,6 +387,7 @@ run_row() {
 		printf 'rerank_candidates=%s\n' "$rerank_candidates"
 		printf 'profile_selected=%s\n' "$profile_selected"
 		printf 'profile_captured=%s\n' "$profile_captured"
+		printf 'profile_scope=%s\n' "$PROFILE_SCOPE"
 		printf 'bench_regex=%s\n' "$bench_regex"
 		printf 'shape=%s\n' "$SHAPE_LABEL"
 		printf 'fixture_rows=%s\n' "$BENCH_ROWS"
@@ -335,7 +400,10 @@ run_row() {
 	} >"$row_dir/row.env"
 
 	local timing_cmd=(go test ./TreeDB/collections -run '^$' -bench "$bench_regex" -benchmem -benchtime "$TIMING_BENCHTIME" -count "$TIMING_COUNT")
-	local profile_cmd=(go test ./TreeDB/collections -run '^$' -bench "$bench_regex" -benchmem -benchtime "$PROFILE_BENCHTIME" -count "$PROFILE_COUNT" -o "$test_binary" -cpuprofile "$cpu_profile" -memprofile "$alloc_profile" -blockprofile "$block_profile" -mutexprofile "$mutex_profile")
+	local profile_cmd=(go test ./TreeDB/collections -run '^$' -bench "$bench_regex" -benchmem -benchtime "$PROFILE_BENCHTIME" -count "$PROFILE_COUNT" -o "$test_binary")
+	if [[ "$PROFILE_SCOPE" == "go_test" ]]; then
+		profile_cmd+=(-cpuprofile "$cpu_profile" -memprofile "$alloc_profile" -blockprofile "$block_profile" -mutexprofile "$mutex_profile")
+	fi
 
 	{
 		write_go_test_env_prefix
@@ -343,6 +411,9 @@ run_row() {
 	} >"$row_dir/command_timing.txt"
 	{
 		write_go_test_env_prefix
+		if [[ "$PROFILE_SCOPE" == "search_loop" ]]; then
+			printf '%s=%q %s=%q %s=%q %s=%q ' "$HOT_CPU_PROFILE_ENV" "$cpu_profile" "$HOT_ALLOCS_PROFILE_ENV" "$alloc_raw_profile" "$HOT_ALLOCS_BASE_PROFILE_ENV" "$alloc_base_profile" "$HOT_MEM_PROFILE_RATE_ENV" "$HOT_MEM_PROFILE_RATE"
+		fi
 		quote_cmd "${profile_cmd[@]}"
 	} >"$row_dir/command_profile.txt"
 
@@ -362,11 +433,33 @@ run_row() {
 
 		if is_true "$RUN_PROFILES" && is_true "$profile_selected"; then
 			printf '==> profiles %s\n' "$id"
-			run_go_test "$profile_txt" "${profile_cmd[@]}"
+			if [[ "$PROFILE_SCOPE" == "search_loop" ]]; then
+				run_search_loop_profile_go_test "$profile_txt" "$cpu_profile" "$alloc_raw_profile" "$alloc_base_profile" "${profile_cmd[@]}"
+				if [[ ! -s "$cpu_profile" ]]; then
+					printf 'missing search-loop CPU profile %s\n' "$cpu_profile" >&2
+					exit 1
+				fi
+				if [[ ! -s "$alloc_raw_profile" ]]; then
+					printf 'missing search-loop raw allocs profile %s\n' "$alloc_raw_profile" >&2
+					exit 1
+				fi
+				if [[ ! -s "$alloc_base_profile" ]]; then
+					printf 'missing search-loop allocs baseline profile %s\n' "$alloc_base_profile" >&2
+					exit 1
+				fi
+				write_pprof_diff "$alloc_base_profile" "$alloc_raw_profile" "$alloc_profile"
+			else
+				run_go_test "$profile_txt" "${profile_cmd[@]}"
+			fi
 			write_pprof_top "$cpu_profile" "$row_dir/cpu_top.txt" -top
 			write_pprof_top "$alloc_profile" "$row_dir/allocs_top.txt" -top -sample_index=alloc_space
-			write_pprof_top "$block_profile" "$row_dir/block_top.txt" -top
-			write_pprof_top "$mutex_profile" "$row_dir/mutex_top.txt" -top
+			if [[ "$PROFILE_SCOPE" == "go_test" ]]; then
+				write_pprof_top "$block_profile" "$row_dir/block_top.txt" -top
+				write_pprof_top "$mutex_profile" "$row_dir/mutex_top.txt" -top
+			else
+				printf 'block profile not captured for PROFILE_SCOPE=search_loop\n' >"$row_dir/block_top.txt"
+				printf 'mutex profile not captured for PROFILE_SCOPE=search_loop\n' >"$row_dir/mutex_top.txt"
+			fi
 
 			local old_ifs=$IFS frame safe
 			IFS=','
@@ -399,19 +492,25 @@ run_row() {
 - profile command: \`$(tr '\n' ' ' <"$row_dir/command_profile.txt")\`
 - profile selected: \`$profile_selected\`
 - profile captured: \`$profile_captured\`
+- profile scope: \`$PROFILE_SCOPE\`
 
 Artifacts:
 
 - \`bench_timing.txt\`: unprofiled per-row timing/guardrail output.
 - \`bench_profile.txt\`: profiled benchmark output when this row is in \`PROFILE_ROWS\` and \`RUN_PROFILES=true\`.
-- \`cpu.pprof\`, \`allocs.pprof\`, \`block.pprof\`, \`mutex.pprof\` when \`profile_captured=true\`.
-- \`collections.test\`: test binary emitted by Go profiling flags when \`profile_captured=true\`.
+- \`cpu.pprof\`, \`allocs.pprof\`: CPU/allocation profiles when \`profile_captured=true\`; for \`PROFILE_SCOPE=search_loop\`, \`allocs.pprof\` is a diff of \`allocs_raw.pprof\` minus \`allocs_base.pprof\` so setup allocations are removed.
+- \`allocs_base.pprof\`, \`allocs_raw.pprof\`: supporting allocation profiles emitted only for \`PROFILE_SCOPE=search_loop\`.
+- \`block.pprof\`, \`mutex.pprof\`: emitted only for \`PROFILE_SCOPE=go_test\`.
+- \`collections.test\`: test binary emitted by \`go test -o\` when \`profile_captured=true\`.
 - \`cpu_top.txt\`, \`allocs_top.txt\`, \`block_top.txt\`, \`mutex_top.txt\`.
 - \`pprof_lists/*.txt\`: line-level CPU excerpts for configured target frames.
 
 Use unprofiled \`bench_timing.txt\` rows for \`ns/op\`, \`B/op\`, and
-\`allocs/op\`. The pprof files intentionally cover one selected benchmark
-subrow plus that row's Go test fixture setup/teardown.
+\`allocs/op\`. With \`PROFILE_SCOPE=search_loop\`, \`cpu.pprof\` and
+\`allocs.pprof\` come from benchmark-controlled hooks that start after fixture
+setup, vector-index rebuild, collection prepared-cache warmup, and worker
+warmup. With \`PROFILE_SCOPE=go_test\`, Go's test-level profiling flags include
+that setup/rebuild work and are kept only as a compatibility fallback.
 EOF
 }
 
@@ -751,7 +850,7 @@ for row_id in selected_row_ids:
     summary_rows.append(out)
 
 fields = [
-    "row_id", "codec", "layer", "mode", "concurrency", "rerank_candidates", "profile_selected", "profile_captured", "shape", "fixture_rows", "fixture_dims", "source", "status", "guardrail_status",
+    "row_id", "codec", "layer", "mode", "concurrency", "rerank_candidates", "profile_selected", "profile_captured", "profile_scope", "shape", "fixture_rows", "fixture_dims", "source", "status", "guardrail_status",
     "rows", "dims", "top_k", "ef_search", "ns/op", "ops/sec", "B/op", "allocs/op", "recall_at_k_pct",
     "docs_fetched/search", "vector_B/search", "norm_B/search", "quantized_code_B/search", "quantized_code_B/vector", "quantized_asset_B/vector",
     "quantized_rerank_candidates/search", "quantized_rerank_exact_score_calls/search", "prepared_score_calls/search",
@@ -797,7 +896,7 @@ with open(os.path.join(root, "summary.md"), "w", encoding="utf-8") as out:
             )
         )
     out.write("\n## Artifact layout\n\n")
-    out.write("Each selected row directory contains `bench_timing.txt`, `bench_profile.txt`, command files, a row README, top summaries, and pprof files when `profile_captured=true`.\n")
+    out.write("Each selected row directory contains `bench_timing.txt`, `bench_profile.txt`, command files, a row README, top summaries, and CPU/alloc pprof files when `profile_captured=true` (`allocs_base.pprof`/`allocs_raw.pprof` support `PROFILE_SCOPE=search_loop`; `block.pprof`/`mutex.pprof` only for `PROFILE_SCOPE=go_test`).\n")
 PY
 
 if [[ -n "$BASELINE_DIR" ]]; then
@@ -832,7 +931,9 @@ cat >"$RUN_DIR/README.md" <<EOF
 - profile rows: \`$PROFILE_ROWS\`
 - timing: enabled=\`$RUN_TIMING\`, benchtime=\`$TIMING_BENCHTIME\`, count=\`$TIMING_COUNT\`
 - profiles: enabled=\`$RUN_PROFILES\`, benchtime=\`$PROFILE_BENCHTIME\`, count=\`$PROFILE_COUNT\`
+- profile scope: \`$PROFILE_SCOPE\`
 - dry run: \`$DRY_RUN\`
+- benchmark lock: \`$BENCHMARK_LOCK\`
 - baseline dir: \`$BASELINE_DIR\`
 - recall tolerance pct: \`$RECALL_TOLERANCE_PCT\`
 
@@ -843,8 +944,10 @@ Primary files:
 - \`summary.md\`, \`summary.tsv\`: per-row timing medians and guardrail counter summary.
 - \`<row>/bench_timing.txt\`: unprofiled benchmark output for the selected row.
 - \`<row>/bench_profile.txt\`: profiled benchmark output for rows selected by \`PROFILE_ROWS\`.
-- \`<row>/cpu.pprof\`, \`<row>/allocs.pprof\`, \`<row>/block.pprof\`, \`<row>/mutex.pprof\` when \`profile_captured=true\`.
-- \`<row>/collections.test\`: test binary emitted by Go profiling flags when \`profile_captured=true\`.
+- \`<row>/cpu.pprof\`, \`<row>/allocs.pprof\`: CPU/allocation profiles when \`profile_captured=true\`; for \`PROFILE_SCOPE=search_loop\`, \`allocs.pprof\` is a diff of \`allocs_raw.pprof\` minus \`allocs_base.pprof\` so setup allocations are removed.
+- \`<row>/allocs_base.pprof\`, \`<row>/allocs_raw.pprof\`: supporting allocation profiles emitted only for \`PROFILE_SCOPE=search_loop\`.
+- \`<row>/block.pprof\`, \`<row>/mutex.pprof\`: emitted only for \`PROFILE_SCOPE=go_test\`.
+- \`<row>/collections.test\`: test binary emitted by \`go test -o\` when \`profile_captured=true\`.
 - \`<row>/cpu_top.txt\`, \`<row>/allocs_top.txt\`, \`<row>/block_top.txt\`, \`<row>/mutex_top.txt\`.
 - \`<row>/pprof_lists/*.txt\`: line-level CPU excerpts for target frames.
 

--- a/scripts/treedb_rabitq_1bit_profile_gate.sh
+++ b/scripts/treedb_rabitq_1bit_profile_gate.sh
@@ -527,6 +527,10 @@ add_row() {
 		if selected_by_list "$PROFILE_ROWS" "$id" "$codec" "$layer" "$mode" "$concurrency"; then
 			profile_selected=true
 		fi
+		if [[ "$PROFILE_SCOPE" == "search_loop" && "$profile_selected" == "true" && "$codec" != "rabitq_1bit" ]]; then
+			printf 'PROFILE_SCOPE=search_loop only supports rabitq_1bit profile rows; row %s uses codec=%s. Set PROFILE_SCOPE=go_test or remove this row from PROFILE_ROWS.\n' "$id" "$codec" >&2
+			exit 2
+		fi
 		row_ids+=("$id")
 		row_codecs+=("$codec")
 		row_layers+=("$layer")

--- a/scripts/treedb_rabitq_1bit_profile_gate_test.py
+++ b/scripts/treedb_rabitq_1bit_profile_gate_test.py
@@ -94,6 +94,31 @@ class RabitQProfileGateScriptTest(unittest.TestCase):
         row_env = (row_dir / "row.env").read_text(encoding="utf-8")
         self.assertIn("profile_scope=go_test", row_env)
 
+    def test_search_loop_rejects_scalar_profile_rows_before_work(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gomap_rabitq_profile_gate_test_") as tmp:
+            env = os.environ.copy()
+            env.update(
+                {
+                    "RUN_DIR": tmp,
+                    "DRY_RUN": "true",
+                    "PROFILE_SCOPE": "search_loop",
+                    "ROWS": "scalar_collection_quantized_only_c1",
+                    "PROFILE_ROWS": "scalar_collection_quantized_only_c1",
+                    "GOWORK": "off",
+                }
+            )
+            result = subprocess.run(
+                [str(SCRIPT)],
+                cwd=ROOT,
+                env=env,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+        self.assertEqual(result.returncode, 2, result.stdout + result.stderr)
+        self.assertIn("PROFILE_SCOPE=search_loop only supports rabitq_1bit", result.stderr)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/treedb_rabitq_1bit_profile_gate_test.py
+++ b/scripts/treedb_rabitq_1bit_profile_gate_test.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Dry-run contract tests for treedb_rabitq_1bit_profile_gate.sh."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("treedb_rabitq_1bit_profile_gate.sh")
+ROOT = SCRIPT.parents[1]
+TARGET_ROW = "rabitq_collection_quantized_only_c1"
+
+
+class RabitQProfileGateScriptTest(unittest.TestCase):
+    def run_dry_run(self, *, profile_scope: str) -> Path:
+        tmpdir = tempfile.TemporaryDirectory(prefix="gomap_rabitq_profile_gate_test_")
+        self.addCleanup(tmpdir.cleanup)
+        run_dir = Path(tmpdir.name)
+        env = os.environ.copy()
+        env.update(
+            {
+                "RUN_DIR": str(run_dir),
+                "DRY_RUN": "true",
+                "PROFILE_SCOPE": profile_scope,
+                "SHAPE": "10k_x_1536",
+                "ROWS": TARGET_ROW,
+                "PROFILE_ROWS": TARGET_ROW,
+                "TIMING_COUNT": "1",
+                "PROFILE_COUNT": "1",
+                "BENCHTIME": "7x",
+                "GOMAXPROCS": "2",
+                "GOWORK": "off",
+                "BENCHMARK_LOCK": "/tmp/gomap_2538_benchmark.lock",
+            }
+        )
+        result = subprocess.run(
+            [str(SCRIPT)],
+            cwd=ROOT,
+            env=env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        if result.returncode != 0:
+            self.fail(f"dry run failed with {result.returncode}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}")
+        return run_dir
+
+    def test_search_loop_dry_run_uses_hot_profile_env_and_no_go_test_profile_flags(self) -> None:
+        run_dir = self.run_dry_run(profile_scope="search_loop")
+        row_dir = run_dir / TARGET_ROW
+
+        command = (row_dir / "command_profile.txt").read_text(encoding="utf-8")
+        self.assertIn("TREEDB_COLUMN_GRAPH_QUANTIZED_HOT_CPU_PROFILE_PATH=", command)
+        self.assertIn("TREEDB_COLUMN_GRAPH_QUANTIZED_HOT_ALLOCS_PROFILE_PATH=", command)
+        self.assertIn("TREEDB_COLUMN_GRAPH_QUANTIZED_HOT_ALLOCS_BASE_PROFILE_PATH=", command)
+        self.assertIn("TREEDB_COLUMN_GRAPH_QUANTIZED_HOT_MEM_PROFILE_RATE=", command)
+        self.assertNotIn("-cpuprofile", command)
+        self.assertNotIn("-memprofile", command)
+        self.assertIn("-o", command)
+
+        row_env = (row_dir / "row.env").read_text(encoding="utf-8")
+        self.assertIn("profile_scope=search_loop", row_env)
+        self.assertIn("shape=10k_x_1536", row_env)
+        self.assertIn("fixture_rows=10000", row_env)
+        self.assertIn("fixture_dims=1536", row_env)
+
+        row_readme = (row_dir / "README.md").read_text(encoding="utf-8")
+        self.assertIn("PROFILE_SCOPE=search_loop", row_readme)
+        self.assertIn("start after fixture", row_readme)
+
+        context = (run_dir / "context.txt").read_text(encoding="utf-8")
+        self.assertIn("profile_scope: search_loop", context)
+        self.assertIn("benchmark_lock: /tmp/gomap_2538_benchmark.lock", context)
+
+        summary_header = (run_dir / "summary.tsv").read_text(encoding="utf-8").splitlines()[0]
+        self.assertIn("profile_scope", summary_header.split("\t"))
+
+    def test_go_test_scope_dry_run_keeps_legacy_profile_flags(self) -> None:
+        run_dir = self.run_dry_run(profile_scope="go_test")
+        row_dir = run_dir / TARGET_ROW
+
+        command = (row_dir / "command_profile.txt").read_text(encoding="utf-8")
+        self.assertIn("-cpuprofile", command)
+        self.assertIn("-memprofile", command)
+        self.assertIn("-blockprofile", command)
+        self.assertIn("-mutexprofile", command)
+        self.assertNotIn("TREEDB_COLUMN_GRAPH_QUANTIZED_HOT_CPU_PROFILE_PATH=", command)
+
+        row_env = (row_dir / "row.env").read_text(encoding="utf-8")
+        self.assertIn("profile_scope=go_test", row_env)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/treedb_rabitq_1bit_profile_gate_test.py
+++ b/scripts/treedb_rabitq_1bit_profile_gate_test.py
@@ -72,9 +72,12 @@ class RabitQProfileGateScriptTest(unittest.TestCase):
         row_readme = (row_dir / "README.md").read_text(encoding="utf-8")
         self.assertIn("PROFILE_SCOPE=search_loop", row_readme)
         self.assertIn("start after fixture", row_readme)
+        self.assertIn("allocs_diff_raw.pprof", row_readme)
+        self.assertIn("pprof-writer noise", row_readme)
 
         context = (run_dir / "context.txt").read_text(encoding="utf-8")
         self.assertIn("profile_scope: search_loop", context)
+        self.assertIn("alloc_profile_ignore:", context)
         self.assertIn("benchmark_lock: /tmp/gomap_2538_benchmark.lock", context)
 
         summary_header = (run_dir / "summary.tsv").read_text(encoding="utf-8").splitlines()[0]

--- a/scripts/treedb_rabitq_1bit_profile_gate_test.py
+++ b/scripts/treedb_rabitq_1bit_profile_gate_test.py
@@ -74,6 +74,8 @@ class RabitQProfileGateScriptTest(unittest.TestCase):
         self.assertIn("start after fixture", row_readme)
         self.assertIn("allocs_diff_raw.pprof", row_readme)
         self.assertIn("pprof-writer noise", row_readme)
+        self.assertIn("HOT_MEM_PROFILE_RATE", row_readme)
+        self.assertIn("scales sampled allocations", row_readme)
 
         context = (run_dir / "context.txt").read_text(encoding="utf-8")
         self.assertIn("profile_scope: search_loop", context)


### PR DESCRIPTION
## Summary

Closes #2541. Part of #2538.

Adds a clean RaBitQ search-loop profile scope for `treedb_rabitq_1bit_profile_gate.sh`:

- benchmark-controlled CPU/alloc hooks start after fixture setup, `RebuildVectorIndex`, prepared-cache warmup, and worker warmup;
- `PROFILE_SCOPE=search_loop` is the default; `PROFILE_SCOPE=go_test` remains as the legacy setup-inclusive fallback;
- search-loop alloc profiles are captured as `allocs_raw.pprof - allocs_base.pprof`, then filtered with `ALLOC_PROFILE_IGNORE` so setup/rebuild allocations and pprof-writer allocations are removed from published `allocs.pprof`;
- `allocs_diff_raw.pprof` is retained for auditability;
- `runtime.MemProfileRate` is preserved while both baseline and raw alloc profiles are serialized, so `HOT_MEM_PROFILE_RATE>1` profiles are scaled correctly before filtering;
- scalar profile rows are rejected up front for `PROFILE_SCOPE=search_loop` with a `PROFILE_SCOPE=go_test` fallback;
- dry-run/parser artifact tests and runbook docs cover command/env/artifact naming.

Scope is harness/profile plumbing only. No RaBitQ codec identity/storage/bit-order/scoring/fail-closed runtime semantics changed.

## Latest-head revalidation

PR head: `52f03f76d7ce2d52ceff3e29aae6643918030348`.
Base included in branch/evidence: `origin/main` `5a3a9f584e5f39185a9d6729adb8405569b66c4c`.

Representative `10k_x_1536` rows from the latest locked run used `HOT_MEM_PROFILE_RATE=65536` to exercise the reviewed sampled-allocation path. Unprofiled timing rows still pass guardrails at `0 B/op`, `0 allocs/op`:

| row | ns/op | ops/sec | B/op | allocs/op | exact vector/norm bytes | rerank exact calls | guardrails |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| qonly c=1 | 88,522 | 11,297 | 0 | 0 | 0 / 0 | 0 | pass |
| rerank32 c=8 | 27,345 | 36,569 | 0 | 0 | 196,608 / 128 | 32 | pass |

Host load was non-idle, so timings are attribution/guardrail evidence rather than speed claims.

## Profile evidence

Latest-head artifact root (`GOMAXPROCS=8`, `GOWORK=off`, `SHAPE=10k_x_1536`, lock `/tmp/gomap_2538_benchmark.lock`, `HOT_MEM_PROFILE_RATE=65536`):

- `/tmp/gomap_2541_memrate_prhead_search_loop_10k_20260607_120757`
  - `rabitq_collection_quantized_only_c1/cpu.pprof`
  - `rabitq_collection_quantized_only_c1/allocs.pprof`
  - `rabitq_collection_quantized_only_c1/allocs_diff_raw.pprof`
  - `rabitq_collection_quantized_rerank32_c8/cpu.pprof`
  - `rabitq_collection_quantized_rerank32_c8/allocs.pprof`
  - `rabitq_collection_quantized_rerank32_c8/allocs_diff_raw.pprof`

CPU top is dominated by search/scoring frames, not `RebuildVectorIndex`/JSON ingest:

- qonly c=1: `Collection.SearchVectorIndexWithBuffer` 96.67% cumulative; `SearchCosine` 93.33% cumulative; `rabitqByteTableMismatchWeightARM64`, RaBitQ query prep, `scoreOrdinalUnchecked`, and `scoreOrdinals` are the visible CPU frames.
- rerank32 c=8: `Collection.SearchVectorIndexWithBuffer` and `SearchQuantizedWithBuffer` 95.24% cumulative; `SearchCosine` 95.24% cumulative; `rabitqByteTableMismatchWeightARM64` leads flat CPU; exact rerank appears as bounded shortlist dot-product work.

Allocation evidence after the latest review fix:

- `allocs.pprof` is the filtered search-loop diff. qonly c=1 top output is empty; rerank32 c=8 shows only ~64 KiB runtime scavenger/timer noise.
- `allocs_diff_raw.pprof` still shows the removed `runtime/pprof`, `compress/gzip`, and hook/file-creation samples, proving the filter is auditable while the published profile no longer attributes them to the search loop.
- No setup/rebuild/JSON ingest frames dominate the published `allocs.pprof` despite `HOT_MEM_PROFILE_RATE=65536`.

## Exact command

```sh
BENCHMARK_LOCK=/tmp/gomap_2538_benchmark.lock \
RUN_DIR=/tmp/gomap_2541_memrate_prhead_search_loop_10k_20260607_120757 \
PROFILE_SCOPE=search_loop HOT_MEM_PROFILE_RATE=65536 \
SHAPE=10k_x_1536 \
ROWS=rabitq_collection_quantized_only_c1,rabitq_collection_quantized_rerank32_c8 \
PROFILE_ROWS=rabitq_collection_quantized_only_c1,rabitq_collection_quantized_rerank32_c8 \
TIMING_COUNT=1 PROFILE_COUNT=1 \
TIMING_BENCHTIME=100x PROFILE_BENCHTIME=3000x \
GOMAXPROCS=8 GOWORK=off \
lockf /tmp/gomap_2538_benchmark.lock scripts/treedb_rabitq_1bit_profile_gate.sh
```

## Tests

```sh
bash -n scripts/treedb_rabitq_1bit_profile_gate.sh
python3 -m unittest scripts/treedb_rabitq_1bit_profile_gate_test.py
GOWORK=off go test ./TreeDB/collections -run 'TestColumnGraphScalarU8QuantizedBench(ShapeFromEnvValues1926|InsertBatchSize1926)$'
GOWORK=off go test ./TreeDB/collections -run '^$' -bench '^BenchmarkCollectionSearchVectorIndexWithBufferColumnGraphRabitQQuantized2452$/^route=quantized_only$/^c=1$' -benchmem -benchtime=1x -count=1
```
