### PR TITLE
TreeDB: add Python document service client

### DIFF
--- a/clients/python/treedb_client/.gitignore
+++ b/clients/python/treedb_client/.gitignore
@@ -1,0 +1,7 @@
+.venv/
+build/
+dist/
+__pycache__/
+*.py[cod]
+*.egg-info/
+.pytest_cache/

--- a/clients/python/treedb_client/README.md
+++ b/clients/python/treedb_client/README.md
@@ -1,0 +1,178 @@
+# TreeDB Python client (pre-alpha)
+
+This package is a small synchronous Python client for TreeDB's pre-alpha
+HTTP/JSON document service. It is intended to be the shared base used by a later
+`treedb-haystack` package, but **does not import or require Haystack**.
+
+Service contract: [`docs/TREEDB_DOCUMENT_SERVICE_API.md`](../../../docs/TREEDB_DOCUMENT_SERVICE_API.md)
+
+## Scope
+
+Supported by the base client:
+
+- `TreeDBClient(base_url, timeout=...)`
+- create/open/ensure index metadata
+- upsert Haystack-shaped documents (`id`, `content`, `embedding`, `meta`)
+- delete by explicit IDs
+- delete by server-side metadata filter
+- count/filter/list documents
+- exact dense-vector search with optional metadata filters and embedding echo
+- typed dataclasses for documents, index metadata, responses, and errors
+- Haystack-style filter conversion/validation without a Haystack dependency
+
+Not supported:
+
+- keyword search
+- hybrid search
+- async client APIs
+- client-side scans to emulate unsupported TreeDB behavior
+
+TreeDB and this client are pre-alpha; APIs may change with the service contract.
+
+## Install for local development
+
+From the repository root, use a virtual environment for editable installs
+(system Python installations may reject direct writes under PEP 668):
+
+```sh
+cd clients/python/treedb_client
+python3 -m venv .venv
+. .venv/bin/activate
+python -m pip install -e .
+```
+
+The client has no runtime dependencies outside the Python standard library.
+
+## Run tests
+
+Unit tests use `unittest` and the standard library:
+
+```sh
+cd clients/python/treedb_client
+PYTHONPATH=src python3 -m unittest discover -s tests
+```
+
+Optional integration tests start `go run ./cmd/treedb-document-service`, write to
+a temporary TreeDB directory, and restart the service for a persistence/reopen
+smoke:
+
+```sh
+cd clients/python/treedb_client
+TREEDB_CLIENT_RUN_INTEGRATION=1 PYTHONPATH=src python3 -m unittest discover -s tests
+```
+
+You can also sanity-check the Go service contract from the repository root:
+
+```sh
+go test ./TreeDB/documentservice ./cmd/treedb-document-service
+```
+
+## Start the TreeDB document service
+
+From the repository root:
+
+```sh
+go run ./cmd/treedb-document-service \
+  -dir /tmp/treedb-document-service \
+  -addr 127.0.0.1:7120 \
+  -profile command_wal_durable
+```
+
+## Example
+
+```python
+from treedb_client import Document, Filter, TreeDBClient
+
+client = TreeDBClient("http://127.0.0.1:7120", timeout=5)
+
+client.ensure_index("docs", dimension=3, metric="cosine")
+client.upsert_documents(
+    "docs",
+    [
+        Document(
+            id="TreeDB/documentservice/service.go:SearchDenseVector",
+            content="SearchDenseVector runs exact dense scoring with filters.",
+            embedding=[0.1, 0.2, 0.3],
+            meta={
+                "repo": "snissn/gomap",
+                "path": "TreeDB/documentservice/service.go",
+                "language": "go",
+                "symbol": "SearchDenseVector",
+                "start_line": 250,
+                "end_line": 310,
+                "chunk_kind": "function",
+            },
+        )
+    ],
+)
+
+count = client.count_documents(
+    "docs",
+    {"field": "meta.language", "operator": "==", "value": "go"},
+)
+print(count.count)
+
+results = client.query_by_embedding(
+    "docs",
+    query_embedding=[0.1, 0.2, 0.3],
+    top_k=5,
+    filter=Filter(
+        operator="AND",
+        conditions=[
+            Filter(field="meta.repo", operator="==", value="snissn/gomap"),
+            Filter(field="meta.start_line", operator=">=", value=1),
+        ],
+    ),
+    return_embedding=False,
+)
+
+for doc in results.documents:
+    print(doc.id, doc.score, doc.meta.get("path"))
+```
+
+## Filters
+
+The client accepts the service/Haystack-style filter AST:
+
+```python
+{"field": "meta.language", "operator": "==", "value": "go"}
+```
+
+Boolean filters use `conditions`:
+
+```python
+{
+    "operator": "AND",
+    "conditions": [
+        {"field": "meta.repo", "operator": "==", "value": "snissn/gomap"},
+        {"field": "meta.start_line", "operator": ">=", "value": 100},
+    ],
+}
+```
+
+Supported operators are `AND`, `OR`, `NOT`, `==`, `!=`, `>`, `>=`, `<`, `<=`,
+`in`, and `not in`. The client also accepts common Haystack-style aliases such
+as `$eq`, `$gte`, `$in`, and `$nin`, then sends the documented service operator.
+Unsupported operators and the top-level `embedding` field filter raise
+`InvalidFilterError`; embedding-named metadata paths such as
+`meta.embedding.provider` are allowed. The client does not broaden unsupported
+filters into local document scans.
+
+## Error mapping
+
+Service error envelopes are mapped to typed exceptions:
+
+| Service code | Exception |
+| --- | --- |
+| `invalid_request` | `InvalidRequestError` |
+| `malformed_json` | `MalformedJSONError` |
+| `index_not_found` | `IndexNotFoundError` |
+| `index_unavailable` | `IndexUnavailableError` |
+| `index_stale` | `IndexStaleError` |
+| `conflict` | `ConflictError` |
+| `unsupported` | `UnsupportedError` |
+| `internal` | `InternalServiceError` |
+
+Network failures raise `TreeDBTransportError`, timeouts raise
+`TreeDBTimeoutError`, and malformed service responses raise
+`TreeDBProtocolError`.

--- a/clients/python/treedb_client/pyproject.toml
+++ b/clients/python/treedb_client/pyproject.toml
@@ -1,0 +1,26 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "treedb-client"
+version = "0.1.0"
+description = "Sync Python client for the pre-alpha TreeDB document service"
+readme = "README.md"
+requires-python = ">=3.9"
+authors = [{ name = "gomap contributors" }]
+license = { text = "See repository license" }
+classifiers = [
+  "Development Status :: 3 - Alpha",
+  "Intended Audience :: Developers",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3 :: Only",
+  "Typing :: Typed",
+]
+dependencies = []
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.setuptools.package-data]
+treedb_client = ["py.typed"]

--- a/clients/python/treedb_client/src/treedb_client/__init__.py
+++ b/clients/python/treedb_client/src/treedb_client/__init__.py
@@ -1,0 +1,59 @@
+"""Python client for TreeDB's pre-alpha document service."""
+
+from .client import TreeDBClient
+from .errors import (
+    ConflictError,
+    IndexNotFoundError,
+    IndexStaleError,
+    IndexUnavailableError,
+    InternalServiceError,
+    InvalidRequestError,
+    MalformedJSONError,
+    TreeDBClientError,
+    TreeDBConfigError,
+    TreeDBProtocolError,
+    TreeDBServiceError,
+    TreeDBTimeoutError,
+    TreeDBTransportError,
+    UnsupportedError,
+)
+from .filters import Filter, InvalidFilterError, normalize_filter
+from .models import (
+    CountDocumentsResponse,
+    DeleteDocumentsResponse,
+    DenseVectorSearchResponse,
+    Document,
+    FilterDocumentsResponse,
+    IndexCapabilities,
+    IndexInfo,
+    UpsertDocumentsResponse,
+)
+
+__all__ = [
+    "ConflictError",
+    "CountDocumentsResponse",
+    "DeleteDocumentsResponse",
+    "DenseVectorSearchResponse",
+    "Document",
+    "Filter",
+    "FilterDocumentsResponse",
+    "IndexCapabilities",
+    "IndexInfo",
+    "IndexNotFoundError",
+    "IndexStaleError",
+    "IndexUnavailableError",
+    "InternalServiceError",
+    "InvalidFilterError",
+    "InvalidRequestError",
+    "MalformedJSONError",
+    "TreeDBClient",
+    "TreeDBClientError",
+    "TreeDBConfigError",
+    "TreeDBProtocolError",
+    "TreeDBServiceError",
+    "TreeDBTimeoutError",
+    "TreeDBTransportError",
+    "UnsupportedError",
+    "UpsertDocumentsResponse",
+    "normalize_filter",
+]

--- a/clients/python/treedb_client/src/treedb_client/client.py
+++ b/clients/python/treedb_client/src/treedb_client/client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import http.client
 import json
 import socket
 import urllib.error
@@ -219,6 +220,8 @@ class TreeDBClient:
             raise TreeDBTransportError(f"TreeDB request to {url} failed: {exc.reason}") from exc
         except (socket.timeout, TimeoutError) as exc:
             raise TreeDBTimeoutError(f"TreeDB request to {url} timed out after {self.timeout} seconds") from exc
+        except (http.client.RemoteDisconnected, ConnectionResetError, ConnectionAbortedError, BrokenPipeError) as exc:
+            raise TreeDBTransportError(f"TreeDB request to {url} failed: {exc}") from exc
 
     def _decode_success(self, status_code: int, body: bytes) -> Any:
         decoded = _decode_json_body(body, status_code=status_code)

--- a/clients/python/treedb_client/src/treedb_client/client.py
+++ b/clients/python/treedb_client/src/treedb_client/client.py
@@ -1,0 +1,366 @@
+"""Synchronous HTTP client for the TreeDB document service."""
+
+from __future__ import annotations
+
+import json
+import socket
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections.abc import Callable, Mapping, Sequence
+from typing import Any, Optional, TypeVar, Union
+
+from .errors import (
+    InvalidRequestError,
+    TreeDBConfigError,
+    TreeDBProtocolError,
+    TreeDBTimeoutError,
+    TreeDBTransportError,
+    service_error_from_code,
+)
+from .filters import FilterLike, InvalidFilterError, normalize_filter
+from .models import (
+    CountDocumentsResponse,
+    DeleteDocumentsResponse,
+    DenseVectorSearchResponse,
+    Document,
+    FilterDocumentsResponse,
+    IndexInfo,
+    UpsertDocumentsResponse,
+)
+
+DocumentLike = Union[Document, Mapping[str, Any]]
+_ResponseT = TypeVar("_ResponseT")
+
+
+class TreeDBClient:
+    """Small sync client for the pre-alpha TreeDB document service.
+
+    The client uses only Python's standard library and has no Haystack runtime
+    dependency. All filtering/deletion/search behavior is delegated to the
+    service; unsupported filters raise locally or fail closed on the service.
+    """
+
+    def __init__(self, base_url: str, timeout: Optional[float] = 30.0) -> None:
+        self.base_url = _normalize_base_url(base_url)
+        self.timeout = _normalize_timeout(timeout)
+        self._opener = urllib.request.build_opener()
+
+    def health(self) -> Mapping[str, Any]:
+        """Return the service health payload from `GET /v1/health`."""
+
+        payload = self._request("GET", "/v1/health")
+        if not isinstance(payload, Mapping):
+            raise TreeDBProtocolError("health response must be a JSON object")
+        return payload
+
+    def create_index(self, name: str, dimension: int, metric: Optional[str] = "cosine") -> IndexInfo:
+        """Create or idempotently open a compatible document index."""
+
+        request: dict[str, Any] = {"name": name, "dimension": dimension}
+        if metric:
+            request["metric"] = metric
+        payload = self._request("POST", "/v1/indexes", request)
+        return _index_from_envelope(payload)
+
+    def ensure_index(self, name: str, dimension: int, metric: Optional[str] = "cosine") -> IndexInfo:
+        """Ensure a compatible index exists.
+
+        The service's create route is idempotent for compatible existing indexes
+        and returns `conflict` for incompatible schemas.
+        """
+
+        return self.create_index(name, dimension, metric)
+
+    def open_index(self, name: str) -> IndexInfo:
+        """Open/read metadata for an existing index."""
+
+        payload = self._request("GET", self._index_path(name))
+        return _index_from_envelope(payload)
+
+    def upsert_documents(
+        self,
+        index: str,
+        documents: Sequence[DocumentLike],
+        *,
+        expected_generation: Optional[int] = None,
+    ) -> UpsertDocumentsResponse:
+        """Write or replace documents in an index."""
+
+        request: dict[str, Any] = {"documents": [_document_for_write(doc) for doc in documents]}
+        _add_expected_generation(request, expected_generation)
+        payload = self._request("POST", self._index_path(index, "documents", "upsert"), request)
+        return _parse_response("upsert response", UpsertDocumentsResponse.from_dict, payload)
+
+    def delete_documents(
+        self,
+        index: str,
+        ids: Sequence[str],
+        *,
+        expected_generation: Optional[int] = None,
+    ) -> DeleteDocumentsResponse:
+        """Delete explicit document IDs.
+
+        This method only sends ID deletes. Use `delete_by_filter` for the
+        service-supported metadata-filter delete path.
+        """
+
+        request: dict[str, Any] = {"ids": _list_of_strings(ids, "ids")}
+        _add_expected_generation(request, expected_generation)
+        payload = self._request("POST", self._index_path(index, "documents", "delete"), request)
+        return _parse_response("delete response", DeleteDocumentsResponse.from_dict, payload)
+
+    def delete_by_filter(
+        self,
+        index: str,
+        filter: FilterLike,
+        *,
+        expected_generation: Optional[int] = None,
+    ) -> DeleteDocumentsResponse:
+        """Delete documents matching a server-side metadata filter.
+
+        The client never scans locally to emulate unsupported delete behavior.
+        """
+
+        normalized = normalize_filter(filter)
+        if normalized is None:
+            raise InvalidFilterError("delete_by_filter requires a filter")
+        request: dict[str, Any] = {"filter": normalized}
+        _add_expected_generation(request, expected_generation)
+        payload = self._request("POST", self._index_path(index, "documents", "delete"), request)
+        return _parse_response("delete response", DeleteDocumentsResponse.from_dict, payload)
+
+    def count_documents(
+        self,
+        index: str,
+        filter: Optional[FilterLike] = None,
+        *,
+        expected_generation: Optional[int] = None,
+    ) -> CountDocumentsResponse:
+        """Count documents matching a server-side filter, or all documents."""
+
+        request: dict[str, Any] = {}
+        _add_filter(request, filter)
+        _add_expected_generation(request, expected_generation)
+        payload = self._request("POST", self._index_path(index, "documents", "count"), request)
+        return _parse_response("count response", CountDocumentsResponse.from_dict, payload)
+
+    def filter_documents(
+        self,
+        index: str,
+        filter: Optional[FilterLike] = None,
+        *,
+        limit: int = 0,
+        offset: int = 0,
+        return_embedding: bool = False,
+        expected_generation: Optional[int] = None,
+    ) -> FilterDocumentsResponse:
+        """List documents matching a server-side filter in document-ID order."""
+
+        request: dict[str, Any] = {"limit": limit, "offset": offset, "return_embedding": return_embedding}
+        _add_filter(request, filter)
+        _add_expected_generation(request, expected_generation)
+        payload = self._request("POST", self._index_path(index, "documents", "filter"), request)
+        return _parse_response("filter response", FilterDocumentsResponse.from_dict, payload)
+
+    def query_by_embedding(
+        self,
+        index: str,
+        query_embedding: Sequence[float],
+        top_k: int,
+        filter: Optional[FilterLike] = None,
+        *,
+        return_embedding: bool = False,
+        expected_generation: Optional[int] = None,
+    ) -> DenseVectorSearchResponse:
+        """Run exact dense-vector search through the TreeDB service."""
+
+        request: dict[str, Any] = {
+            "query_embedding": [float(value) for value in query_embedding],
+            "top_k": top_k,
+            "return_embedding": return_embedding,
+        }
+        _add_filter(request, filter)
+        _add_expected_generation(request, expected_generation)
+        payload = self._request("POST", self._index_path(index, "search", "vector"), request)
+        return _parse_response("vector search response", DenseVectorSearchResponse.from_dict, payload)
+
+    def _index_path(self, index: str, *parts: str) -> str:
+        encoded = urllib.parse.quote(index, safe="")
+        suffix = "/".join(urllib.parse.quote(part, safe="") for part in parts)
+        if suffix:
+            return f"/v1/indexes/{encoded}/{suffix}"
+        return f"/v1/indexes/{encoded}"
+
+    def _request(self, method: str, path: str, body: Optional[Mapping[str, Any]] = None) -> Any:
+        url = self.base_url + path
+        data: Optional[bytes] = None
+        headers = {"Accept": "application/json"}
+        if body is not None:
+            try:
+                data = json.dumps(body, allow_nan=False, separators=(",", ":")).encode("utf-8")
+            except (TypeError, ValueError) as exc:
+                raise InvalidRequestError("invalid_request", f"request payload is not JSON-serializable: {exc}") from exc
+            headers["Content-Type"] = "application/json"
+        request = urllib.request.Request(url, data=data, headers=headers, method=method)
+        try:
+            with self._opener.open(request, timeout=self.timeout) as response:
+                response_body = response.read()
+                return self._decode_success(response.getcode(), response_body)
+        except urllib.error.HTTPError as exc:
+            try:
+                response_body = exc.read()
+            finally:
+                exc.close()
+            raise self._decode_error(exc.code, response_body) from None
+        except urllib.error.URLError as exc:
+            if _is_timeout(exc.reason):
+                raise TreeDBTimeoutError(f"TreeDB request to {url} timed out after {self.timeout} seconds") from exc
+            raise TreeDBTransportError(f"TreeDB request to {url} failed: {exc.reason}") from exc
+        except (socket.timeout, TimeoutError) as exc:
+            raise TreeDBTimeoutError(f"TreeDB request to {url} timed out after {self.timeout} seconds") from exc
+
+    def _decode_success(self, status_code: int, body: bytes) -> Any:
+        decoded = _decode_json_body(body, status_code=status_code)
+        if isinstance(decoded, Mapping) and "error" in decoded:
+            error = decoded.get("error")
+            if isinstance(error, Mapping):
+                code = str(error.get("code", "internal"))
+                message = str(error.get("message", ""))
+                raise service_error_from_code(code, message, status_code=status_code, response_body=_body_to_text(body))
+            raise TreeDBProtocolError("error envelope must contain an object", status_code=status_code, response_body=_body_to_text(body))
+        return decoded
+
+    def _decode_error(self, status_code: int, body: bytes) -> Exception:
+        decoded = _decode_json_body(body, status_code=status_code)
+        if not isinstance(decoded, Mapping):
+            return TreeDBProtocolError(
+                f"TreeDB service returned HTTP {status_code} with a non-object JSON body",
+                status_code=status_code,
+                response_body=_body_to_text(body),
+            )
+        error = decoded.get("error")
+        if not isinstance(error, Mapping):
+            return TreeDBProtocolError(
+                f"TreeDB service returned HTTP {status_code} without an error envelope",
+                status_code=status_code,
+                response_body=_body_to_text(body),
+            )
+        code = str(error.get("code", "internal"))
+        message = str(error.get("message", ""))
+        return service_error_from_code(code, message, status_code=status_code, response_body=_body_to_text(body))
+
+
+def _normalize_base_url(base_url: str) -> str:
+    if not isinstance(base_url, str) or not base_url.strip():
+        raise TreeDBConfigError("base_url must be a non-empty HTTP(S) URL")
+    trimmed = base_url.strip().rstrip("/")
+    parsed = urllib.parse.urlparse(trimmed)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise TreeDBConfigError("base_url must be an absolute HTTP(S) URL")
+    if parsed.query or parsed.fragment:
+        raise TreeDBConfigError("base_url must not include query parameters or fragments")
+    return trimmed
+
+
+def _normalize_timeout(timeout: Optional[float]) -> Optional[float]:
+    if timeout is None:
+        return None
+    if isinstance(timeout, bool) or not isinstance(timeout, (int, float)):
+        raise TreeDBConfigError("timeout must be a positive number of seconds or None")
+    value = float(timeout)
+    if value <= 0:
+        raise TreeDBConfigError("timeout must be positive")
+    return value
+
+
+def _add_expected_generation(request: dict[str, Any], expected_generation: Optional[int]) -> None:
+    if expected_generation is None:
+        return
+    if isinstance(expected_generation, bool) or not isinstance(expected_generation, int) or expected_generation <= 0:
+        raise InvalidRequestError("invalid_request", "expected_generation must be a positive integer")
+    request["expected_generation"] = expected_generation
+
+
+def _add_filter(request: dict[str, Any], filter_value: Optional[FilterLike]) -> None:
+    normalized = normalize_filter(filter_value)
+    if normalized is not None:
+        request["filter"] = normalized
+
+
+def _document_for_write(document: DocumentLike) -> Mapping[str, Any]:
+    if isinstance(document, Document):
+        return document.to_dict(include_score=False)
+    if isinstance(document, Mapping):
+        return Document.from_dict(document).to_dict(include_score=False)
+    raise InvalidRequestError("invalid_request", "documents must be Document instances or mappings")
+
+
+def _list_of_strings(values: Sequence[str], label: str) -> list[str]:
+    if isinstance(values, (str, bytes, bytearray)):
+        raise InvalidRequestError("invalid_request", f"{label} must be a sequence of strings, not a single string")
+    try:
+        out = list(values)
+    except TypeError as exc:
+        raise InvalidRequestError("invalid_request", f"{label} must be a sequence of strings") from exc
+    for i, value in enumerate(out):
+        if not isinstance(value, str):
+            raise InvalidRequestError("invalid_request", f"{label}[{i}] must be a string")
+    return out
+
+
+def _index_from_envelope(payload: Any) -> IndexInfo:
+    envelope = _expect_mapping(payload, "index response")
+    index = envelope.get("index")
+    if not isinstance(index, Mapping):
+        raise TreeDBProtocolError("index response is missing index object")
+    return _parse_mapping("index response", IndexInfo.from_dict, index)
+
+
+def _parse_response(
+    label: str,
+    parser: Callable[[Mapping[str, Any]], _ResponseT],
+    payload: Any,
+) -> _ResponseT:
+    return _parse_mapping(label, parser, _expect_mapping(payload, label))
+
+
+def _parse_mapping(
+    label: str,
+    parser: Callable[[Mapping[str, Any]], _ResponseT],
+    payload: Mapping[str, Any],
+) -> _ResponseT:
+    try:
+        return parser(payload)
+    except TreeDBProtocolError:
+        raise
+    except (KeyError, TypeError, ValueError) as exc:
+        raise TreeDBProtocolError(f"{label} is malformed: {exc}") from exc
+
+
+def _expect_mapping(payload: Any, label: str) -> Mapping[str, Any]:
+    if not isinstance(payload, Mapping):
+        raise TreeDBProtocolError(f"{label} must be a JSON object")
+    return payload
+
+
+def _decode_json_body(body: bytes, *, status_code: int) -> Any:
+    text = _body_to_text(body)
+    try:
+        return json.loads(text) if text else {}
+    except json.JSONDecodeError as exc:
+        raise TreeDBProtocolError(
+            f"TreeDB service returned malformed JSON for HTTP {status_code}: {exc}",
+            status_code=status_code,
+            response_body=text,
+        ) from exc
+
+
+def _body_to_text(body: bytes) -> str:
+    return body.decode("utf-8", errors="replace")
+
+
+def _is_timeout(reason: Any) -> bool:
+    if isinstance(reason, (socket.timeout, TimeoutError)):
+        return True
+    return "timed out" in str(reason).lower()

--- a/clients/python/treedb_client/src/treedb_client/errors.py
+++ b/clients/python/treedb_client/src/treedb_client/errors.py
@@ -1,0 +1,113 @@
+"""Exception hierarchy for the TreeDB document service client."""
+
+from __future__ import annotations
+
+from typing import Dict, Optional, Type
+
+
+class TreeDBClientError(Exception):
+    """Base class for all TreeDB Python client exceptions."""
+
+
+class TreeDBConfigError(TreeDBClientError, ValueError):
+    """Raised when client configuration is invalid."""
+
+
+class TreeDBTransportError(TreeDBClientError):
+    """Raised when the client cannot reach the TreeDB service."""
+
+
+class TreeDBTimeoutError(TreeDBTransportError, TimeoutError):
+    """Raised when a TreeDB service request times out."""
+
+
+class TreeDBProtocolError(TreeDBClientError):
+    """Raised when the service response does not match the HTTP/JSON contract."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: Optional[int] = None,
+        response_body: Optional[str] = None,
+    ) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.response_body = response_body
+
+
+class TreeDBServiceError(TreeDBClientError):
+    """Base class for structured errors returned by the TreeDB service."""
+
+    code = "internal"
+
+    def __init__(
+        self,
+        code: str,
+        message: str,
+        *,
+        status_code: Optional[int] = None,
+        response_body: Optional[str] = None,
+    ) -> None:
+        super().__init__(f"{code}: {message}" if message else code)
+        self.code = code
+        self.message = message
+        self.status_code = status_code
+        self.response_body = response_body
+
+
+class InvalidRequestError(TreeDBServiceError):
+    code = "invalid_request"
+
+
+class MalformedJSONError(TreeDBServiceError):
+    code = "malformed_json"
+
+
+class IndexNotFoundError(TreeDBServiceError):
+    code = "index_not_found"
+
+
+class IndexUnavailableError(TreeDBServiceError):
+    code = "index_unavailable"
+
+
+class IndexStaleError(TreeDBServiceError):
+    code = "index_stale"
+
+
+class ConflictError(TreeDBServiceError):
+    code = "conflict"
+
+
+class UnsupportedError(TreeDBServiceError):
+    code = "unsupported"
+
+
+class InternalServiceError(TreeDBServiceError):
+    code = "internal"
+
+
+ERROR_CLASS_BY_CODE: Dict[str, Type[TreeDBServiceError]] = {
+    InvalidRequestError.code: InvalidRequestError,
+    MalformedJSONError.code: MalformedJSONError,
+    IndexNotFoundError.code: IndexNotFoundError,
+    IndexUnavailableError.code: IndexUnavailableError,
+    IndexStaleError.code: IndexStaleError,
+    ConflictError.code: ConflictError,
+    UnsupportedError.code: UnsupportedError,
+    InternalServiceError.code: InternalServiceError,
+}
+
+
+def service_error_from_code(
+    code: str,
+    message: str,
+    *,
+    status_code: Optional[int] = None,
+    response_body: Optional[str] = None,
+) -> TreeDBServiceError:
+    """Build the narrowest exception class for a TreeDB service error code."""
+
+    cls = ERROR_CLASS_BY_CODE.get(code, TreeDBServiceError)
+    return cls(code, message, status_code=status_code, response_body=response_body)

--- a/clients/python/treedb_client/src/treedb_client/filters.py
+++ b/clients/python/treedb_client/src/treedb_client/filters.py
@@ -1,0 +1,161 @@
+"""Haystack-style filter normalization for the TreeDB document service."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Union
+
+from .errors import TreeDBClientError
+
+
+class InvalidFilterError(TreeDBClientError, ValueError):
+    """Raised when a filter cannot be represented safely by the service."""
+
+
+_BOOL_OPERATORS = {"and": "AND", "or": "OR", "not": "NOT"}
+_LEAF_OPERATORS = {
+    "==": "==",
+    "=": "==",
+    "eq": "==",
+    "$eq": "==",
+    "!=": "!=",
+    "ne": "!=",
+    "$ne": "!=",
+    ">": ">",
+    "gt": ">",
+    "$gt": ">",
+    ">=": ">=",
+    "gte": ">=",
+    "$gte": ">=",
+    "<": "<",
+    "lt": "<",
+    "$lt": "<",
+    "<=": "<=",
+    "lte": "<=",
+    "$lte": "<=",
+    "in": "in",
+    "$in": "in",
+    "not in": "not in",
+    "not_in": "not in",
+    "not-in": "not in",
+    "nin": "not in",
+    "$nin": "not in",
+}
+_ALLOWED_KEYS = {"operator", "field", "value", "conditions"}
+
+
+@dataclass(frozen=True)
+class Filter:
+    """Filter AST node accepted by the TreeDB document service.
+
+    Boolean nodes set `operator` to AND/OR/NOT and provide `conditions`. Leaf
+    nodes set `field`, `operator`, and `value`. The client validates only the
+    shapes the service can execute; it never rewrites unsupported filters into
+    broader client-side scans.
+    """
+
+    operator: str
+    field: Optional[str] = None
+    value: Any = None
+    conditions: Optional[Sequence["FilterLike"]] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return normalize_filter(self)
+
+
+FilterLike = Union[Filter, Mapping[str, Any]]
+
+
+def normalize_filter(filter_value: Optional[FilterLike]) -> Optional[Dict[str, Any]]:
+    """Return a service-compatible filter dictionary.
+
+    The accepted input shape intentionally matches Haystack v2 style filters and
+    the TreeDB service contract. Unsupported operators and malformed nodes raise
+    `InvalidFilterError` instead of falling back to a client-side document scan.
+    """
+
+    if filter_value is None:
+        return None
+    if isinstance(filter_value, Filter):
+        raw: Dict[str, Any] = {"operator": filter_value.operator}
+        if filter_value.field is not None:
+            raw["field"] = filter_value.field
+        if filter_value.conditions is not None:
+            raw["conditions"] = list(filter_value.conditions)
+        if filter_value.conditions is None or filter_value.field is not None:
+            raw["value"] = filter_value.value
+        return _normalize_mapping(raw, "filter")
+    if isinstance(filter_value, Mapping):
+        return _normalize_mapping(dict(filter_value), "filter")
+    raise InvalidFilterError("filter must be a mapping, Filter, or None")
+
+
+def _normalize_mapping(raw: Dict[str, Any], path: str) -> Dict[str, Any]:
+    unknown = sorted(str(key) for key in raw if key not in _ALLOWED_KEYS)
+    if unknown:
+        raise InvalidFilterError(f"{path}: unsupported field(s): {', '.join(unknown)}")
+    operator = raw.get("operator")
+    if not isinstance(operator, str) or not operator.strip():
+        raise InvalidFilterError(f"{path}: operator is required")
+    normalized = _normalize_operator(operator)
+    if normalized in _BOOL_OPERATORS.values():
+        return _normalize_boolean(raw, normalized, path)
+    return _normalize_leaf(raw, normalized, path)
+
+
+def _normalize_operator(operator: str) -> str:
+    key = " ".join(operator.strip().lower().replace("_", " ").split())
+    if key in _BOOL_OPERATORS:
+        return _BOOL_OPERATORS[key]
+    if key in _LEAF_OPERATORS:
+        return _LEAF_OPERATORS[key]
+    raise InvalidFilterError(f"unsupported filter operator {operator!r}")
+
+
+def _normalize_boolean(raw: Dict[str, Any], operator: str, path: str) -> Dict[str, Any]:
+    if raw.get("field") not in (None, ""):
+        raise InvalidFilterError(f"{path}: boolean operator {operator!r} cannot set field")
+    if "value" in raw and raw.get("value") is not None:
+        raise InvalidFilterError(f"{path}: boolean operator {operator!r} cannot set value")
+    conditions = raw.get("conditions")
+    if isinstance(conditions, (str, bytes, bytearray)) or not isinstance(conditions, Sequence):
+        raise InvalidFilterError(f"{path}: boolean operator {operator!r} requires conditions")
+    if operator in {"AND", "OR"} and len(conditions) == 0:
+        raise InvalidFilterError(f"{path}: operator {operator!r} requires at least one condition")
+    if operator == "NOT" and len(conditions) != 1:
+        raise InvalidFilterError(f"{path}: NOT requires exactly one condition")
+    return {
+        "operator": operator,
+        "conditions": [
+            _normalize_mapping(_coerce_mapping(condition, f"{path}.conditions[{i}]"), f"{path}.conditions[{i}]")
+            for i, condition in enumerate(conditions)
+        ],
+    }
+
+
+def _normalize_leaf(raw: Dict[str, Any], operator: str, path: str) -> Dict[str, Any]:
+    if "conditions" in raw and raw.get("conditions") not in (None, []):
+        raise InvalidFilterError(f"{path}: leaf operator {operator!r} cannot set conditions")
+    field = raw.get("field")
+    if not isinstance(field, str) or not field.strip():
+        raise InvalidFilterError(f"{path}: field is required for operator {operator!r}")
+    field = field.strip()
+    if field == "embedding":
+        raise InvalidFilterError(f"{path}: embedding filters are unsupported; filter metadata fields instead")
+    if "value" not in raw:
+        raise InvalidFilterError(f"{path}: value is required for operator {operator!r}")
+    value = raw.get("value")
+    if operator in {"in", "not in"}:
+        if isinstance(value, (str, bytes, bytearray)) or not isinstance(value, Sequence):
+            raise InvalidFilterError(f"{path}: operator {operator!r} requires an array value")
+        value = list(value)
+    return {"field": field, "operator": operator, "value": value}
+
+
+def _coerce_mapping(value: Any, path: str) -> Dict[str, Any]:
+    if isinstance(value, Filter):
+        return value.to_dict()
+    if isinstance(value, Mapping):
+        return dict(value)
+    raise InvalidFilterError(f"{path}: condition must be a filter mapping")

--- a/clients/python/treedb_client/src/treedb_client/models.py
+++ b/clients/python/treedb_client/src/treedb_client/models.py
@@ -1,0 +1,291 @@
+"""Typed dataclasses for the TreeDB document service contract."""
+
+from __future__ import annotations
+
+import copy
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional, TypeVar
+
+
+_T = TypeVar("_T")
+
+
+def _as_mapping(value: Mapping[str, Any], label: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise TypeError(f"{label} must be a mapping")
+    return value
+
+
+def _reject_unknown(data: Mapping[str, Any], allowed: Sequence[str], label: str) -> None:
+    allowed_set = set(allowed)
+    unknown = sorted(str(key) for key in data.keys() if key not in allowed_set)
+    if unknown:
+        raise ValueError(f"{label} has unsupported field(s): {', '.join(unknown)}")
+
+
+def _as_str(value: Any, label: str) -> str:
+    if not isinstance(value, str):
+        raise TypeError(f"{label} must be a string")
+    return value
+
+
+def _as_int(value: Any, label: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError(f"{label} must be an integer")
+    return value
+
+
+def _as_bool(value: Any, label: str) -> bool:
+    if not isinstance(value, bool):
+        raise TypeError(f"{label} must be a boolean")
+    return value
+
+
+def _optional_float(value: Any, label: str) -> Optional[float]:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise TypeError(f"{label} must be a number")
+    return float(value)
+
+
+def _optional_float_list(value: Any, label: str) -> Optional[list[float]]:
+    if value is None:
+        return None
+    if isinstance(value, (str, bytes, bytearray)) or not isinstance(value, Sequence):
+        raise TypeError(f"{label} must be a sequence of numbers")
+    out: list[float] = []
+    for i, item in enumerate(value):
+        if isinstance(item, bool) or not isinstance(item, (int, float)):
+            raise TypeError(f"{label}[{i}] must be a number")
+        out.append(float(item))
+    return out
+
+
+def _copy_meta(value: Any, label: str) -> Dict[str, Any]:
+    if value is None:
+        return {}
+    if not isinstance(value, Mapping):
+        raise TypeError(f"{label} must be a mapping")
+    return copy.deepcopy(dict(value))
+
+
+@dataclass
+class Document:
+    """Haystack-compatible document shape used by the TreeDB service.
+
+    The base client intentionally does not import Haystack. It mirrors the
+    fields (`id`, `content`, `embedding`, `meta`, `score`) that the service
+    accepts and returns. `score` is response-only and is omitted from write
+    payloads unless `include_score=True` is explicitly passed to `to_dict`.
+    """
+
+    id: str
+    content: str = ""
+    embedding: Optional[list[float]] = None
+    meta: Dict[str, Any] = field(default_factory=dict)
+    score: Optional[float] = None
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "Document":
+        data = _as_mapping(data, "document")
+        _reject_unknown(data, ["id", "content", "embedding", "meta", "score"], "document")
+        if "id" not in data:
+            raise ValueError("document.id is required")
+        return cls(
+            id=_as_str(data["id"], "document.id"),
+            content=_as_str(data.get("content", ""), "document.content"),
+            embedding=_optional_float_list(data.get("embedding"), "document.embedding"),
+            meta=_copy_meta(data.get("meta"), "document.meta"),
+            score=_optional_float(data.get("score"), "document.score"),
+        )
+
+    def to_dict(self, *, include_score: bool = False) -> Dict[str, Any]:
+        out: Dict[str, Any] = {"id": self.id}
+        if self.content:
+            out["content"] = self.content
+        if self.embedding is not None:
+            out["embedding"] = [float(value) for value in self.embedding]
+        if self.meta:
+            out["meta"] = copy.deepcopy(self.meta)
+        if include_score and self.score is not None:
+            out["score"] = float(self.score)
+        return out
+
+
+@dataclass(frozen=True)
+class IndexCapabilities:
+    dense_vector_search: bool
+    exact_dense_scoring: bool
+    metadata_filters: bool
+    keyword_search: bool
+    hybrid_search: bool
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "IndexCapabilities":
+        data = _as_mapping(data, "index.capabilities")
+        _reject_unknown(
+            data,
+            [
+                "dense_vector_search",
+                "exact_dense_scoring",
+                "metadata_filters",
+                "keyword_search",
+                "hybrid_search",
+            ],
+            "index.capabilities",
+        )
+        return cls(
+            dense_vector_search=_as_bool(data.get("dense_vector_search", False), "index.capabilities.dense_vector_search"),
+            exact_dense_scoring=_as_bool(data.get("exact_dense_scoring", False), "index.capabilities.exact_dense_scoring"),
+            metadata_filters=_as_bool(data.get("metadata_filters", False), "index.capabilities.metadata_filters"),
+            keyword_search=_as_bool(data.get("keyword_search", False), "index.capabilities.keyword_search"),
+            hybrid_search=_as_bool(data.get("hybrid_search", False), "index.capabilities.hybrid_search"),
+        )
+
+    def to_dict(self) -> Dict[str, bool]:
+        return {
+            "dense_vector_search": self.dense_vector_search,
+            "exact_dense_scoring": self.exact_dense_scoring,
+            "metadata_filters": self.metadata_filters,
+            "keyword_search": self.keyword_search,
+            "hybrid_search": self.hybrid_search,
+        }
+
+
+@dataclass(frozen=True)
+class IndexInfo:
+    name: str
+    dimension: int
+    metric: str
+    generation: int
+    contract_version: str
+    embedding_field: str
+    document_type: str
+    capabilities: IndexCapabilities
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "IndexInfo":
+        data = _as_mapping(data, "index")
+        _reject_unknown(
+            data,
+            [
+                "name",
+                "dimension",
+                "metric",
+                "generation",
+                "contract_version",
+                "embedding_field",
+                "document_type",
+                "capabilities",
+            ],
+            "index",
+        )
+        return cls(
+            name=_as_str(data["name"], "index.name"),
+            dimension=_as_int(data["dimension"], "index.dimension"),
+            metric=_as_str(data["metric"], "index.metric"),
+            generation=_as_int(data["generation"], "index.generation"),
+            contract_version=_as_str(data["contract_version"], "index.contract_version"),
+            embedding_field=_as_str(data["embedding_field"], "index.embedding_field"),
+            document_type=_as_str(data["document_type"], "index.document_type"),
+            capabilities=IndexCapabilities.from_dict(data.get("capabilities", {})),
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "dimension": self.dimension,
+            "metric": self.metric,
+            "generation": self.generation,
+            "contract_version": self.contract_version,
+            "embedding_field": self.embedding_field,
+            "document_type": self.document_type,
+            "capabilities": self.capabilities.to_dict(),
+        }
+
+
+@dataclass(frozen=True)
+class UpsertDocumentsResponse:
+    index: IndexInfo
+    upserted: int
+    inserted: int
+    updated: int
+    ids: list[str]
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "UpsertDocumentsResponse":
+        data = _as_mapping(data, "upsert response")
+        return cls(
+            index=IndexInfo.from_dict(data["index"]),
+            upserted=_as_int(data["upserted"], "upserted"),
+            inserted=_as_int(data["inserted"], "inserted"),
+            updated=_as_int(data["updated"], "updated"),
+            ids=[_as_str(item, "ids[]") for item in data.get("ids", [])],
+        )
+
+
+@dataclass(frozen=True)
+class DeleteDocumentsResponse:
+    index: IndexInfo
+    deleted: int
+    ids: list[str]
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "DeleteDocumentsResponse":
+        data = _as_mapping(data, "delete response")
+        return cls(
+            index=IndexInfo.from_dict(data["index"]),
+            deleted=_as_int(data["deleted"], "deleted"),
+            ids=[_as_str(item, "ids[]") for item in data.get("ids", [])],
+        )
+
+
+@dataclass(frozen=True)
+class CountDocumentsResponse:
+    index: IndexInfo
+    count: int
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "CountDocumentsResponse":
+        data = _as_mapping(data, "count response")
+        return cls(index=IndexInfo.from_dict(data["index"]), count=_as_int(data["count"], "count"))
+
+
+@dataclass(frozen=True)
+class FilterDocumentsResponse:
+    index: IndexInfo
+    documents: list[Document]
+    matched_count: int
+    truncated: bool = False
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "FilterDocumentsResponse":
+        data = _as_mapping(data, "filter response")
+        return cls(
+            index=IndexInfo.from_dict(data["index"]),
+            documents=[Document.from_dict(item) for item in data.get("documents", [])],
+            matched_count=_as_int(data["matched_count"], "matched_count"),
+            truncated=_as_bool(data.get("truncated", False), "truncated"),
+        )
+
+
+@dataclass(frozen=True)
+class DenseVectorSearchResponse:
+    index: IndexInfo
+    documents: list[Document]
+    metric: str
+    exact: bool
+    candidates: int
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "DenseVectorSearchResponse":
+        data = _as_mapping(data, "vector search response")
+        return cls(
+            index=IndexInfo.from_dict(data["index"]),
+            documents=[Document.from_dict(item) for item in data.get("documents", [])],
+            metric=_as_str(data["metric"], "metric"),
+            exact=_as_bool(data["exact"], "exact"),
+            candidates=_as_int(data["candidates"], "candidates"),
+        )

--- a/clients/python/treedb_client/tests/_support.py
+++ b/clients/python/treedb_client/tests/_support.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = PACKAGE_ROOT.parents[2]
+SRC = PACKAGE_ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))

--- a/clients/python/treedb_client/tests/test_client.py
+++ b/clients/python/treedb_client/tests/test_client.py
@@ -16,6 +16,7 @@ from treedb_client import (
     TreeDBConfigError,
     TreeDBProtocolError,
     TreeDBTimeoutError,
+    TreeDBTransportError,
     UnsupportedError,
 )
 
@@ -236,6 +237,17 @@ class TreeDBClientTests(unittest.TestCase):
 
             with self.assertRaises(TreeDBTimeoutError):
                 client.health()
+
+    def test_peer_reset_maps_to_transport_error(self) -> None:
+        class ResettingOpener:
+            def open(self, request: Any, timeout: float | None = None) -> Any:
+                raise ConnectionResetError("connection reset by peer")
+
+        client = TreeDBClient("http://127.0.0.1:9", timeout=1)
+        client._opener = ResettingOpener()  # type: ignore[attr-defined]
+
+        with self.assertRaisesRegex(TreeDBTransportError, "connection reset"):
+            client.health()
 
 
 if __name__ == "__main__":

--- a/clients/python/treedb_client/tests/test_client.py
+++ b/clients/python/treedb_client/tests/test_client.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+import json
+import threading
+import time
+import unittest
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any, Dict, Tuple
+
+import _support  # noqa: F401
+from treedb_client import (
+    Document,
+    IndexNotFoundError,
+    InvalidRequestError,
+    TreeDBClient,
+    TreeDBConfigError,
+    TreeDBProtocolError,
+    TreeDBTimeoutError,
+    UnsupportedError,
+)
+
+
+SAMPLE_INDEX = {
+    "name": "docs",
+    "dimension": 2,
+    "metric": "cosine",
+    "generation": 1,
+    "contract_version": "treedb-document-service/v1alpha1",
+    "embedding_field": "embedding",
+    "document_type": "treedb_document_service_v1",
+    "capabilities": {
+        "dense_vector_search": True,
+        "exact_dense_scoring": True,
+        "metadata_filters": True,
+        "keyword_search": False,
+        "hybrid_search": False,
+    },
+}
+
+
+class FixtureHandler(BaseHTTPRequestHandler):
+    server_version = "TreeDBClientFixture/1.0"
+
+    def do_GET(self) -> None:  # noqa: N802
+        self._serve()
+
+    def do_POST(self) -> None:  # noqa: N802
+        self._serve()
+
+    def log_message(self, format: str, *args: Any) -> None:
+        return
+
+    def _serve(self) -> None:
+        length = int(self.headers.get("Content-Length", "0"))
+        body = self.rfile.read(length) if length else b""
+        route = (self.command, self.path)
+        self.server.records.append(  # type: ignore[attr-defined]
+            {"method": self.command, "path": self.path, "body": body, "headers": dict(self.headers)}
+        )
+        status, payload, delay = self.server.routes.get(  # type: ignore[attr-defined]
+            route, (404, {"error": {"code": "index_not_found", "message": "missing route"}}, 0)
+        )
+        if delay:
+            time.sleep(delay)
+        raw = json.dumps(payload).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(raw)))
+        self.end_headers()
+        try:
+            self.wfile.write(raw)
+        except OSError:
+            pass
+
+
+class FixtureServer:
+    def __init__(self, routes: Dict[Tuple[str, str], Tuple[int, Any, float]], prefix: str = "") -> None:
+        self.routes = routes
+        self.prefix = prefix
+        self.httpd = ThreadingHTTPServer(("127.0.0.1", 0), FixtureHandler)
+        self.httpd.routes = routes  # type: ignore[attr-defined]
+        self.httpd.records = []  # type: ignore[attr-defined]
+        self.thread = threading.Thread(target=self.httpd.serve_forever, daemon=True)
+
+    def __enter__(self) -> "FixtureServer":
+        self.thread.start()
+        return self
+
+    def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+        self.httpd.shutdown()
+        self.httpd.server_close()
+        self.thread.join(timeout=2)
+
+    @property
+    def base_url(self) -> str:
+        host, port = self.httpd.server_address
+        return f"http://{host}:{port}{self.prefix}"
+
+    @property
+    def records(self) -> list[dict[str, Any]]:
+        return self.httpd.records  # type: ignore[attr-defined]
+
+
+def json_body(record: dict[str, Any]) -> Any:
+    return json.loads(record["body"].decode("utf-8"))
+
+
+class TreeDBClientTests(unittest.TestCase):
+    def test_create_index_posts_contract_payload(self) -> None:
+        with FixtureServer({("POST", "/v1/indexes"): (200, {"index": SAMPLE_INDEX}, 0)}) as server:
+            client = TreeDBClient(server.base_url, timeout=1)
+
+            info = client.create_index("docs", 2)
+
+            self.assertEqual(info.name, "docs")
+            self.assertEqual(json_body(server.records[0]), {"name": "docs", "dimension": 2, "metric": "cosine"})
+            self.assertEqual(server.records[0]["headers"]["Content-Type"], "application/json")
+
+    def test_malformed_index_response_maps_to_protocol_error(self) -> None:
+        malformed_index = dict(SAMPLE_INDEX)
+        del malformed_index["dimension"]
+        with FixtureServer({("POST", "/v1/indexes"): (200, {"index": malformed_index}, 0)}) as server:
+            client = TreeDBClient(server.base_url, timeout=1)
+
+            with self.assertRaisesRegex(TreeDBProtocolError, "index response is malformed"):
+                client.create_index("docs", 2)
+
+    def test_base_url_path_prefix_is_preserved(self) -> None:
+        with FixtureServer({("GET", "/api/v1/health"): (200, {"ok": True}, 0)}, prefix="/api") as server:
+            client = TreeDBClient(server.base_url + "/", timeout=1)
+
+            self.assertEqual(client.health()["ok"], True)
+            self.assertEqual(server.records[0]["path"], "/api/v1/health")
+
+    def test_upsert_documents_omits_response_score_from_write_payload(self) -> None:
+        route = "/v1/indexes/docs/documents/upsert"
+        response = {"index": SAMPLE_INDEX, "upserted": 1, "inserted": 1, "updated": 0, "ids": ["a"]}
+        with FixtureServer({("POST", route): (200, response, 0)}) as server:
+            client = TreeDBClient(server.base_url, timeout=1)
+
+            result = client.upsert_documents(
+                "docs",
+                [Document(id="a", content="alpha", embedding=[1, 0], meta={"repo": "gomap"}, score=0.5)],
+                expected_generation=1,
+            )
+
+            self.assertEqual(result.upserted, 1)
+            body = json_body(server.records[0])
+            self.assertEqual(body["expected_generation"], 1)
+            self.assertNotIn("score", body["documents"][0])
+            self.assertEqual(body["documents"][0]["embedding"], [1.0, 0.0])
+
+    def test_count_filter_search_and_delete_by_filter_parse_responses(self) -> None:
+        routes = {
+            ("POST", "/v1/indexes/docs/documents/count"): (200, {"index": SAMPLE_INDEX, "count": 2}, 0),
+            ("POST", "/v1/indexes/docs/documents/filter"): (
+                200,
+                {
+                    "index": SAMPLE_INDEX,
+                    "matched_count": 1,
+                    "documents": [{"id": "a", "content": "alpha", "meta": {"repo": "gomap"}}],
+                },
+                0,
+            ),
+            ("POST", "/v1/indexes/docs/search/vector"): (
+                200,
+                {
+                    "index": SAMPLE_INDEX,
+                    "metric": "cosine",
+                    "exact": True,
+                    "candidates": 1,
+                    "documents": [{"id": "a", "content": "alpha", "score": 1.0}],
+                },
+                0,
+            ),
+            ("POST", "/v1/indexes/docs/documents/delete"): (
+                200,
+                {"index": SAMPLE_INDEX, "deleted": 1, "ids": ["a"]},
+                0,
+            ),
+        }
+        with FixtureServer(routes) as server:
+            client = TreeDBClient(server.base_url, timeout=1)
+
+            self.assertEqual(client.count_documents("docs", {"field": "meta.repo", "operator": "==", "value": "gomap"}).count, 2)
+            self.assertEqual(client.filter_documents("docs", limit=10).documents[0].id, "a")
+            self.assertEqual(client.query_by_embedding("docs", [1, 0], 1).documents[0].score, 1.0)
+            self.assertEqual(client.delete_by_filter("docs", {"field": "meta.repo", "operator": "$eq", "value": "gomap"}).deleted, 1)
+
+            delete_body = json_body(server.records[-1])
+            self.assertEqual(delete_body["filter"], {"field": "meta.repo", "operator": "==", "value": "gomap"})
+
+    def test_delete_documents_rejects_bare_string_ids_before_http(self) -> None:
+        client = TreeDBClient("http://127.0.0.1:9", timeout=1)
+
+        with self.assertRaisesRegex(InvalidRequestError, "not a single string"):
+            client.delete_documents("docs", "doc-1")  # type: ignore[arg-type]
+
+    def test_expected_generation_zero_is_rejected_before_http(self) -> None:
+        client = TreeDBClient("http://127.0.0.1:9", timeout=1)
+
+        with self.assertRaisesRegex(InvalidRequestError, "positive integer"):
+            client.count_documents("docs", expected_generation=0)
+
+    def test_service_error_mapping(self) -> None:
+        route = "/v1/indexes/missing/documents/count"
+        with FixtureServer({("POST", route): (404, {"error": {"code": "index_not_found", "message": "missing"}}, 0)}) as server:
+            client = TreeDBClient(server.base_url, timeout=1)
+
+            with self.assertRaises(IndexNotFoundError) as caught:
+                client.count_documents("missing")
+
+            self.assertEqual(caught.exception.code, "index_not_found")
+            self.assertEqual(caught.exception.status_code, 404)
+            self.assertIn("missing", caught.exception.message)
+
+    def test_unsupported_error_mapping(self) -> None:
+        route = "/v1/indexes/docs/documents/count"
+        with FixtureServer({("POST", route): (501, {"error": {"code": "unsupported", "message": "not implemented"}}, 0)}) as server:
+            client = TreeDBClient(server.base_url, timeout=1)
+
+            with self.assertRaises(UnsupportedError):
+                client.count_documents("docs")
+
+    def test_config_validation(self) -> None:
+        for base_url in ("", "localhost:7120", "ftp://127.0.0.1:7120", "http://127.0.0.1:7120?x=1"):
+            with self.subTest(base_url=base_url):
+                with self.assertRaises(TreeDBConfigError):
+                    TreeDBClient(base_url)
+        with self.assertRaises(TreeDBConfigError):
+            TreeDBClient("http://127.0.0.1:7120", timeout=0)
+
+    def test_timeout_mapping(self) -> None:
+        with FixtureServer({("GET", "/v1/health"): (200, {"ok": True}, 0.25)}) as server:
+            client = TreeDBClient(server.base_url, timeout=0.01)
+
+            with self.assertRaises(TreeDBTimeoutError):
+                client.health()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/clients/python/treedb_client/tests/test_filters.py
+++ b/clients/python/treedb_client/tests/test_filters.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import unittest
+
+import _support  # noqa: F401
+from treedb_client import Filter, InvalidFilterError, TreeDBClientError, normalize_filter
+
+
+class FilterConversionTests(unittest.TestCase):
+    def test_leaf_filter_normalizes_operator_aliases(self) -> None:
+        self.assertEqual(
+            normalize_filter({"field": "meta.repo", "operator": "$eq", "value": "snissn/gomap"}),
+            {"field": "meta.repo", "operator": "==", "value": "snissn/gomap"},
+        )
+        self.assertEqual(
+            normalize_filter({"field": "language", "operator": "NOT_IN", "value": ("python", "ruby")}),
+            {"field": "language", "operator": "not in", "value": ["python", "ruby"]},
+        )
+
+    def test_boolean_filter_normalizes_conditions(self) -> None:
+        filt = Filter(
+            operator="AND",
+            conditions=[
+                Filter(field="meta.repo", operator="==", value="snissn/gomap"),
+                {"field": "meta.start_line", "operator": ">=", "value": 100},
+            ],
+        )
+
+        self.assertEqual(
+            normalize_filter(filt),
+            {
+                "operator": "AND",
+                "conditions": [
+                    {"field": "meta.repo", "operator": "==", "value": "snissn/gomap"},
+                    {"field": "meta.start_line", "operator": ">=", "value": 100},
+                ],
+            },
+        )
+
+    def test_not_requires_one_condition(self) -> None:
+        with self.assertRaisesRegex(InvalidFilterError, "exactly one"):
+            normalize_filter({"operator": "NOT", "conditions": []})
+
+    def test_unsupported_operator_fails_closed(self) -> None:
+        with self.assertRaisesRegex(InvalidFilterError, "unsupported filter operator"):
+            normalize_filter({"field": "meta.repo", "operator": "contains", "value": "gomap"})
+
+    def test_membership_requires_array(self) -> None:
+        with self.assertRaisesRegex(InvalidFilterError, "requires an array"):
+            normalize_filter({"field": "meta.repo", "operator": "in", "value": "gomap"})
+
+    def test_top_level_embedding_filter_is_rejected(self) -> None:
+        with self.assertRaisesRegex(InvalidFilterError, "embedding filters are unsupported"):
+            normalize_filter({"field": "embedding", "operator": "==", "value": [1.0, 0.0]})
+
+    def test_embedding_named_metadata_paths_are_allowed(self) -> None:
+        self.assertEqual(
+            normalize_filter({"field": "meta.embedding.provider", "operator": "==", "value": "openai"}),
+            {"field": "meta.embedding.provider", "operator": "==", "value": "openai"},
+        )
+        self.assertEqual(
+            normalize_filter({"field": "embedding.model", "operator": "==", "value": "text-embedding-3-small"}),
+            {"field": "embedding.model", "operator": "==", "value": "text-embedding-3-small"},
+        )
+
+    def test_unknown_filter_keys_are_rejected_before_http(self) -> None:
+        with self.assertRaisesRegex(InvalidFilterError, "unsupported field"):
+            normalize_filter({"field": "meta.repo", "operator": "==", "value": "gomap", "scan": True})
+
+    def test_invalid_filter_is_client_error(self) -> None:
+        self.assertTrue(issubclass(InvalidFilterError, TreeDBClientError))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/clients/python/treedb_client/tests/test_integration.py
+++ b/clients/python/treedb_client/tests/test_integration.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import os
+import shutil
+import signal
+import socket
+import subprocess
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from typing import Optional
+
+import _support
+from treedb_client import Document, TreeDBClient, TreeDBClientError
+
+
+def _free_addr() -> str:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        host, port = sock.getsockname()
+    return f"{host}:{port}"
+
+
+class TreeDBServiceProcess:
+    def __init__(self, repo_root: Path, data_dir: str) -> None:
+        self.repo_root = repo_root
+        self.data_dir = data_dir
+        self.addr = _free_addr()
+        self.log = tempfile.NamedTemporaryFile("w+", prefix="treedb_document_service_", suffix=".log", delete=False)
+        self.proc: Optional[subprocess.Popen[str]] = None
+
+    @property
+    def base_url(self) -> str:
+        return f"http://{self.addr}"
+
+    def start(self) -> None:
+        cmd = [
+            "go",
+            "run",
+            "./cmd/treedb-document-service",
+            "-dir",
+            self.data_dir,
+            "-addr",
+            self.addr,
+            "-profile",
+            "command_wal_durable",
+        ]
+        self.proc = subprocess.Popen(
+            cmd,
+            cwd=str(self.repo_root),
+            stdout=self.log,
+            stderr=subprocess.STDOUT,
+            text=True,
+            start_new_session=True,
+        )
+        client = TreeDBClient(self.base_url, timeout=1)
+        deadline = time.monotonic() + 90
+        last_error: Optional[BaseException] = None
+        while time.monotonic() < deadline:
+            if self.proc.poll() is not None:
+                raise AssertionError(f"service exited early with code {self.proc.returncode}: {self.read_log()}")
+            try:
+                health = client.health()
+                if health.get("ok"):
+                    return
+            except (TreeDBClientError, OSError) as exc:
+                last_error = exc
+            time.sleep(0.25)
+        raise AssertionError(f"service did not become healthy: {last_error}; log={self.read_log()}")
+
+    def stop(self) -> None:
+        if self.proc is None:
+            return
+        if self.proc.poll() is None:
+            try:
+                if hasattr(os, "killpg"):
+                    os.killpg(self.proc.pid, signal.SIGTERM)
+                else:
+                    self.proc.terminate()
+                self.proc.wait(timeout=15)
+            except subprocess.TimeoutExpired:
+                if hasattr(os, "killpg") and hasattr(signal, "SIGKILL"):
+                    os.killpg(self.proc.pid, signal.SIGKILL)
+                else:
+                    self.proc.kill()
+                self.proc.wait(timeout=5)
+        log_name = self.log.name
+        self.log.close()
+        try:
+            os.unlink(log_name)
+        except OSError:
+            pass
+
+    def read_log(self) -> str:
+        self.log.flush()
+        with open(self.log.name, "r", encoding="utf-8", errors="replace") as handle:
+            return handle.read()
+
+
+@unittest.skipUnless(
+    os.environ.get("TREEDB_CLIENT_RUN_INTEGRATION") == "1" and shutil.which("go"),
+    "set TREEDB_CLIENT_RUN_INTEGRATION=1 and install Go to run TreeDB service integration tests",
+)
+class TreeDBClientIntegrationTests(unittest.TestCase):
+    def test_service_round_trip_and_reopen_smoke(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="treedb_client_integration_") as data_dir:
+            service = TreeDBServiceProcess(_support.REPO_ROOT, data_dir)
+            try:
+                service.start()
+                client = TreeDBClient(service.base_url, timeout=5)
+                client.ensure_index("docs", dimension=2)
+                client.upsert_documents(
+                    "docs",
+                    [
+                        Document(id="a", content="alpha", embedding=[1, 0], meta={"repo": "gomap", "language": "go"}),
+                        Document(id="b", content="beta", embedding=[0, 1], meta={"repo": "other", "language": "python"}),
+                    ],
+                )
+                self.assertEqual(client.count_documents("docs", {"field": "meta.repo", "operator": "==", "value": "gomap"}).count, 1)
+                listed = client.filter_documents("docs", {"field": "meta.language", "operator": "in", "value": ["go"]})
+                self.assertEqual([doc.id for doc in listed.documents], ["a"])
+                self.assertIsNone(listed.documents[0].embedding)
+                searched = client.query_by_embedding("docs", [1, 0], 1, return_embedding=True)
+                self.assertEqual(searched.documents[0].id, "a")
+                self.assertEqual(searched.documents[0].embedding, [1.0, 0.0])
+                self.assertEqual(client.delete_by_filter("docs", {"field": "meta.repo", "operator": "==", "value": "other"}).deleted, 1)
+                self.assertEqual(client.count_documents("docs").count, 1)
+            finally:
+                service.stop()
+
+            reopened = TreeDBServiceProcess(_support.REPO_ROOT, data_dir)
+            try:
+                reopened.start()
+                client = TreeDBClient(reopened.base_url, timeout=5)
+                info = client.open_index("docs")
+                self.assertEqual(info.dimension, 2)
+                self.assertEqual(client.count_documents("docs").count, 1)
+                searched = client.query_by_embedding("docs", [1, 0], 1, return_embedding=True)
+                self.assertEqual(searched.documents[0].id, "a")
+                self.assertEqual(searched.documents[0].embedding, [1.0, 0.0])
+            finally:
+                reopened.stop()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/clients/python/treedb_client/tests/test_models.py
+++ b/clients/python/treedb_client/tests/test_models.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import unittest
+
+import _support  # noqa: F401
+from treedb_client import Document, IndexCapabilities, IndexInfo
+
+
+class DocumentModelTests(unittest.TestCase):
+    def test_document_write_serialization_omits_response_score(self) -> None:
+        doc = Document(
+            id="doc-1",
+            content="body",
+            embedding=[1, 2.5],
+            meta={"repo": "snissn/gomap", "nested": {"line": 7}},
+            score=0.99,
+        )
+
+        payload = doc.to_dict()
+
+        self.assertEqual(payload["id"], "doc-1")
+        self.assertEqual(payload["content"], "body")
+        self.assertEqual(payload["embedding"], [1.0, 2.5])
+        self.assertEqual(payload["meta"]["nested"]["line"], 7)
+        self.assertNotIn("score", payload)
+
+    def test_document_response_deserialization_preserves_score_and_defaults(self) -> None:
+        doc = Document.from_dict({"id": "doc-1", "score": 0.25})
+
+        self.assertEqual(doc.id, "doc-1")
+        self.assertEqual(doc.content, "")
+        self.assertIsNone(doc.embedding)
+        self.assertEqual(doc.meta, {})
+        self.assertEqual(doc.score, 0.25)
+        self.assertEqual(doc.to_dict(include_score=True), {"id": "doc-1", "score": 0.25})
+
+    def test_document_rejects_unknown_fields(self) -> None:
+        with self.assertRaisesRegex(ValueError, "unsupported field"):
+            Document.from_dict({"id": "doc-1", "metadata": {"repo": "gomap"}})
+
+
+class IndexModelTests(unittest.TestCase):
+    def test_index_info_round_trip(self) -> None:
+        info = IndexInfo.from_dict(
+            {
+                "name": "docs",
+                "dimension": 2,
+                "metric": "cosine",
+                "generation": 1,
+                "contract_version": "treedb-document-service/v1alpha1",
+                "embedding_field": "embedding",
+                "document_type": "treedb_document_service_v1",
+                "capabilities": {
+                    "dense_vector_search": True,
+                    "exact_dense_scoring": True,
+                    "metadata_filters": True,
+                    "keyword_search": False,
+                    "hybrid_search": False,
+                },
+            }
+        )
+
+        self.assertEqual(info.name, "docs")
+        self.assertEqual(info.dimension, 2)
+        self.assertIsInstance(info.capabilities, IndexCapabilities)
+        self.assertTrue(info.capabilities.metadata_filters)
+        self.assertFalse(info.capabilities.keyword_search)
+        self.assertEqual(info.to_dict()["capabilities"]["hybrid_search"], False)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,7 @@ TreeDB is a persistent B+Tree with a high-throughput cached write-back layer.
 - **[Tuning](TREEDB_TUNING.md)**: Configuration knobs for performance.
 - **[Typed-Storage Guides](../TreeDB/docs/guides/README.md)**: Collection layout quickstarts, typed-storage benchmark/profile guide, and vector typed-column guidance.
 - **[Document Service API](TREEDB_DOCUMENT_SERVICE_API.md)**: Pre-alpha Haystack-style HTTP/JSON contract for documents, metadata filters, and exact dense-vector search.
+- **[Python Document Service Client](../clients/python/treedb_client/README.md)**: Haystack-free sync Python client for the document service.
 
 ## ⚡ HashDB
 

--- a/docs/TREEDB_DOCUMENT_SERVICE_API.md
+++ b/docs/TREEDB_DOCUMENT_SERVICE_API.md
@@ -20,6 +20,15 @@ go run ./cmd/treedb-document-service \
 The command opens TreeDB with the selected public profile and serves the routes
 below. `GET /v1/health` returns the current `contract_version`.
 
+A Haystack-free sync Python client for this contract lives in
+[`clients/python/treedb_client`](../clients/python/treedb_client/README.md).
+Run its stdlib unit tests with:
+
+```sh
+cd clients/python/treedb_client
+PYTHONPATH=src python3 -m unittest discover -s tests
+```
+
 ## Scope and honesty
 
 Supported now:


### PR DESCRIPTION
## Objective

Closes #2532. Part of #2530.

Add a Haystack-free synchronous Python client for TreeDB's pre-alpha document service so downstream Python/Haystack integration work can reuse typed HTTP/JSON plumbing instead of duplicating it.

## Context

#2531 / PR #2537 is merged to `main` as `9f0de414629f0839c6e199731ba6871bb118f592`. This PR is the clean restack of the previous stacked PR #2546 onto current `main`; repository rules disallow force-pushing the original topic branch, so #2546 is superseded by this PR.

## Non-goals

- No Haystack dependency in the base client.
- No async client API.
- No keyword or hybrid search support.
- No client-side scans or fallback behavior for unsupported TreeDB/service features.

## Design

- Adds `clients/python/treedb_client`, distributed as `treedb-client` with module `treedb_client`.
- Uses only Python standard library runtime dependencies (`urllib.request`, `dataclasses`, `unittest` for tests).
- Exposes `TreeDBClient(base_url, timeout=...)` with create/open/ensure index, upsert, delete by IDs, delete by server-side filter, count/filter/list, and dense vector query methods.
- Adds typed dataclasses for documents, index metadata/capabilities, operation responses, and dense search responses.
- Adds Haystack-style filter normalization/validation for the service-supported AST and aliases (`$eq`, `$gte`, `$in`, `$nin`, etc.) while failing closed for unsupported operators and literal top-level `embedding` filters.
- Maps service error envelopes to typed exceptions and keeps transport/timeout/protocol errors distinct.

## Scope

Includes:

- `clients/python/treedb_client/README.md`
- `clients/python/treedb_client/pyproject.toml`
- `clients/python/treedb_client/src/treedb_client/*`
- `clients/python/treedb_client/tests/*`
- docs links from `docs/README.md` and `docs/TREEDB_DOCUMENT_SERVICE_API.md`

Excludes:

- TreeDB service contract changes.
- Haystack DocumentStore/Retriever implementation (#2533).
- Keyword/hybrid support (#2534 and TreeDB text/hybrid core work).

## Correctness

Tests run locally on clean head `3b1df1aa7`:

- `cd clients/python/treedb_client && PYTHONPATH=src python3 -m unittest discover -s tests` — pass, 25 tests, 1 optional integration skip.
- `go test ./TreeDB/documentservice ./cmd/treedb-document-service` — pass.

Prior stacked PR #2546 also ran optional service integration/reopen smoke and editable-install smoke after the same client fixes.

Coverage includes document serialization/deserialization, filter conversion/validation, error mapping, timeout/config behavior, HTTP request payloads, optional service round trip, and service restart/reopen smoke.

## Performance

No benchmarks run. This PR adds an opt-in Python client and docs/tests only; it does not change TreeDB storage/search hot paths.

## Rollout / Toggle Plan

- Default behavior: no runtime change unless users install/import `treedb-client`.
- Optional integration tests are gated by `TREEDB_CLIENT_RUN_INTEGRATION=1` because they start the Go service.
- Revert path: remove the `clients/python/treedb_client` package/docs link if the pre-alpha client surface needs replacement.

## Follow-ups

- #2533: build `treedb-haystack` DocumentStore + embedding retriever on this base client.
- #2534: keyword/hybrid retrievers only after TreeDB text/hybrid execution is ready.

## AI review status

- Codex/CodeRabbit will be requested on this clean restacked PR.
