### PR TITLE
TreeDB: add Haystack document store MVP

### DIFF
--- a/clients/python/treedb_haystack/.gitignore
+++ b/clients/python/treedb_haystack/.gitignore
@@ -1,0 +1,9 @@
+.venv/
+build/
+dist/
+__pycache__/
+*.py[cod]
+*.egg-info/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/

--- a/clients/python/treedb_haystack/README.md
+++ b/clients/python/treedb_haystack/README.md
@@ -1,0 +1,141 @@
+# treedb-haystack (pre-alpha)
+
+`treedb-haystack` is the first Haystack integration package for TreeDB's
+pre-alpha HTTP/JSON document service. It provides:
+
+- `haystack_integrations.document_stores.treedb.TreeDBDocumentStore`
+- `haystack_integrations.components.retrievers.treedb.TreeDBEmbeddingRetriever`
+
+The MVP supports embedded Haystack `Document` writes and exact dense-vector
+retrieval through the TreeDB document service. It intentionally does **not**
+expose keyword or hybrid retrieval, and it never scans documents client-side to
+emulate unsupported filters or search modes.
+
+Service contract: [`docs/TREEDB_DOCUMENT_SERVICE_API.md`](../../../docs/TREEDB_DOCUMENT_SERVICE_API.md)
+
+## Install for local development
+
+From the repository root, install the sibling TreeDB client first, then this
+package:
+
+```sh
+python3 -m venv .venv-treedb-haystack
+. .venv-treedb-haystack/bin/activate
+python -m pip install -U pip
+python -m pip install -e clients/python/treedb_client
+python -m pip install -e 'clients/python/treedb_haystack[dev]'
+```
+
+If your pip version does not support editable extras for local paths, install the
+test tools explicitly:
+
+```sh
+python -m pip install pytest mypy ruff
+```
+
+## Start TreeDB's document service
+
+```sh
+go run ./cmd/treedb-document-service \
+  -dir /tmp/treedb-document-service \
+  -addr 127.0.0.1:7120 \
+  -profile command_wal_durable
+```
+
+## Example
+
+```python
+from haystack import Document, Pipeline
+from haystack.document_stores.types import DuplicatePolicy
+from haystack_integrations.components.retrievers.treedb import TreeDBEmbeddingRetriever
+from haystack_integrations.document_stores.treedb import TreeDBDocumentStore
+
+store = TreeDBDocumentStore(
+    base_url="http://127.0.0.1:7120",
+    index="docs",
+    embedding_dimension=3,
+    similarity="cosine",
+    return_embedding=False,
+)
+
+store.write_documents(
+    [
+        Document(
+            id="doc-a",
+            content="TreeDB stores Haystack documents.",
+            embedding=[1.0, 0.0, 0.0],
+            meta={"repo": "snissn/gomap", "language": "python"},
+        ),
+        Document(
+            id="doc-b",
+            content="Keyword and hybrid retrieval are future work.",
+            embedding=[0.0, 1.0, 0.0],
+            meta={"repo": "snissn/gomap", "language": "docs"},
+        ),
+    ],
+    policy=DuplicatePolicy.OVERWRITE,
+)
+
+pipeline = Pipeline()
+pipeline.add_component("retriever", TreeDBEmbeddingRetriever(document_store=store, top_k=1))
+result = pipeline.run({"retriever": {"query_embedding": [1.0, 0.0, 0.0]}})
+print(result["retriever"]["documents"][0].id)
+```
+
+## Filters
+
+Filters use the TreeDB service/Haystack v2 filter AST and are executed by the
+TreeDB service:
+
+```python
+{"field": "meta.repo", "operator": "==", "value": "snissn/gomap"}
+```
+
+Boolean filters use `conditions`. Supported operators are `AND`, `OR`, `NOT`,
+`==`, `!=`, `>`, `>=`, `<`, `<=`, `in`, and `not in`. Unsupported operators fail
+closed through the base `treedb-client`; this package does not broaden them into
+local scans.
+
+## Duplicate and filter policies
+
+- `DuplicatePolicy.OVERWRITE` maps to TreeDB service upsert and is the default
+  because upsert is the only atomic write primitive in the MVP service.
+- `DuplicatePolicy.FAIL` and `DuplicatePolicy.SKIP` check existing IDs with a
+  server-side `id in [...]` filter before writing. They avoid client-side full
+  scans, but they are best-effort across separate concurrent clients because the
+  current service has no create-if-absent endpoint. If TreeDB reports an
+  unexpected update after the preflight, the store raises `DocumentStoreError`
+  rather than silently reporting success.
+- `TreeDBEmbeddingRetriever` supports Haystack `FilterPolicy.REPLACE` and
+  `FilterPolicy.MERGE` via Haystack's `apply_filter_policy` helper.
+
+## Run tests
+
+Unit tests require Haystack and pytest:
+
+```sh
+cd clients/python/treedb_haystack
+PYTHONPATH=src:../treedb_client/src python -m pytest -q
+```
+
+Optional integration tests start `go run ./cmd/treedb-document-service`, write to
+a temporary TreeDB directory, and restart the service for a persistence smoke:
+
+```sh
+cd clients/python/treedb_haystack
+TREEDB_HAYSTACK_RUN_INTEGRATION=1 PYTHONPATH=src:../treedb_client/src python -m pytest -q
+```
+
+Type/import checks used during local development:
+
+```sh
+cd clients/python/treedb_haystack
+PYTHONPATH=src:../treedb_client/src python -m compileall -q src tests
+python -m mypy -p haystack_integrations.document_stores.treedb -p haystack_integrations.components.retrievers.treedb
+```
+
+## Scope and non-goals
+
+TreeDB's service-backed dense-vector search is an exact correctness/MVP path. It
+is not advertised as ANN throughput work, and this package does not implement
+keyword, sparse, or hybrid retrievers.

--- a/clients/python/treedb_haystack/pyproject.toml
+++ b/clients/python/treedb_haystack/pyproject.toml
@@ -1,0 +1,56 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "treedb-haystack"
+version = "0.1.0"
+description = "Haystack DocumentStore and embedding retriever for TreeDB"
+readme = "README.md"
+requires-python = ">=3.10"
+authors = [{ name = "gomap contributors" }]
+license = { text = "See repository license" }
+classifiers = [
+  "Development Status :: 3 - Alpha",
+  "Intended Audience :: Developers",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3 :: Only",
+  "Typing :: Typed",
+]
+dependencies = [
+  "haystack-ai>=2.26.1",
+  "treedb-client>=0.1.0",
+]
+
+[project.optional-dependencies]
+dev = [
+  "pytest",
+  "mypy",
+  "ruff",
+]
+
+[project.urls]
+Source = "https://github.com/snissn/gomap"
+Issues = "https://github.com/snissn/gomap/issues"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+include = ["haystack_integrations*"]
+namespaces = true
+
+[tool.setuptools.package-data]
+haystack_integrations = ["py.typed"]
+
+[tool.pytest.ini_options]
+addopts = "--strict-markers"
+markers = [
+  "integration: tests that start a local TreeDB document service",
+]
+
+[tool.ruff]
+line-length = 120
+
+[tool.mypy]
+python_version = "3.10"
+check_untyped_defs = true
+warn_unused_ignores = true

--- a/clients/python/treedb_haystack/src/haystack_integrations/components/retrievers/treedb/__init__.py
+++ b/clients/python/treedb_haystack/src/haystack_integrations/components/retrievers/treedb/__init__.py
@@ -1,0 +1,5 @@
+"""TreeDB Haystack retriever integration."""
+
+from .embedding_retriever import TreeDBEmbeddingRetriever
+
+__all__ = ["TreeDBEmbeddingRetriever"]

--- a/clients/python/treedb_haystack/src/haystack_integrations/components/retrievers/treedb/embedding_retriever.py
+++ b/clients/python/treedb_haystack/src/haystack_integrations/components/retrievers/treedb/embedding_retriever.py
@@ -1,0 +1,135 @@
+"""Haystack embedding retriever for TreeDB."""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+from typing import Any, Optional, Union
+
+from haystack import component, default_from_dict, default_to_dict
+from haystack.dataclasses import Document
+from haystack.document_stores.types import FilterPolicy
+from haystack.document_stores.types.filter_policy import apply_filter_policy
+
+from haystack_integrations.document_stores.treedb import TreeDBDocumentStore
+
+
+@component
+class TreeDBEmbeddingRetriever:
+    """Retrieve documents from a `TreeDBDocumentStore` by dense query embedding."""
+
+    def __init__(
+        self,
+        *,
+        document_store: TreeDBDocumentStore,
+        filters: Optional[dict[str, Any]] = None,
+        top_k: int = 10,
+        return_embedding: Optional[bool] = None,
+        filter_policy: Union[str, FilterPolicy] = FilterPolicy.REPLACE,
+    ) -> None:
+        """Create the TreeDB embedding retriever.
+
+        :param document_store: `TreeDBDocumentStore` instance to query.
+        :param filters: Init-time filters. Runtime filters are combined according to `filter_policy`.
+        :param top_k: Default maximum number of documents to return.
+        :param return_embedding: Override document-store embedding echo for retrieved documents.
+        :param filter_policy: Haystack filter policy (`REPLACE` or `MERGE`).
+        :raises ValueError: If `document_store` is not a `TreeDBDocumentStore`.
+        """
+
+        if not isinstance(document_store, TreeDBDocumentStore):
+            msg = "document_store must be an instance of TreeDBDocumentStore"
+            raise ValueError(msg)
+        if top_k <= 0:
+            msg = "top_k must be positive"
+            raise ValueError(msg)
+
+        self.document_store = document_store
+        self.filters = copy.deepcopy(filters) if filters else None
+        self.top_k = int(top_k)
+        self.return_embedding = return_embedding
+        self.filter_policy = (
+            filter_policy if isinstance(filter_policy, FilterPolicy) else FilterPolicy.from_str(filter_policy)
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize this retriever for Haystack pipelines."""
+
+        return default_to_dict(
+            self,
+            document_store=self.document_store.to_dict(),
+            filters=self.filters,
+            top_k=self.top_k,
+            return_embedding=self.return_embedding,
+            filter_policy=self.filter_policy.value,
+        )
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "TreeDBEmbeddingRetriever":
+        """Deserialize a retriever from `to_dict()` output."""
+
+        payload = copy.deepcopy(data)
+        init_parameters = payload["init_parameters"]
+        init_parameters["document_store"] = TreeDBDocumentStore.from_dict(init_parameters["document_store"])
+        if filter_policy := init_parameters.get("filter_policy"):
+            init_parameters["filter_policy"] = (
+                filter_policy if isinstance(filter_policy, FilterPolicy) else FilterPolicy.from_str(filter_policy)
+            )
+        return default_from_dict(cls, payload)
+
+    @component.output_types(documents=list[Document])
+    def run(
+        self,
+        query_embedding: list[float],
+        filters: Optional[dict[str, Any]] = None,
+        top_k: Optional[int] = None,
+        return_embedding: Optional[bool] = None,
+    ) -> dict[str, list[Document]]:
+        """Retrieve documents similar to `query_embedding`.
+
+        :param query_embedding: Dense query embedding.
+        :param filters: Runtime TreeDB/Haystack filter AST.
+        :param top_k: Runtime maximum number of documents to return.
+        :param return_embedding: Runtime embedding echo override.
+        :returns: `{"documents": [...]}` with Haystack `Document` results.
+        """
+
+        effective_filters = apply_filter_policy(
+            filter_policy=self.filter_policy,
+            init_filters=copy.deepcopy(self.filters),
+            runtime_filters=copy.deepcopy(filters),
+        )
+        effective_top_k = self.top_k if top_k is None else int(top_k)
+        if effective_top_k <= 0:
+            msg = "top_k must be positive"
+            raise ValueError(msg)
+        effective_return_embedding = self.return_embedding if return_embedding is None else return_embedding
+        docs = self.document_store._query_by_embedding(
+            query_embedding=query_embedding,
+            filters=effective_filters or None,
+            top_k=effective_top_k,
+            return_embedding=effective_return_embedding,
+        )
+        return {"documents": docs}
+
+    @component.output_types(documents=list[Document])
+    async def run_async(
+        self,
+        query_embedding: list[float],
+        filters: Optional[dict[str, Any]] = None,
+        top_k: Optional[int] = None,
+        return_embedding: Optional[bool] = None,
+    ) -> dict[str, list[Document]]:
+        """Asynchronously retrieve documents.
+
+        The TreeDB client MVP is synchronous, so this runs `run()` in a worker
+        thread rather than blocking the asyncio event loop.
+        """
+
+        return await asyncio.to_thread(
+            self.run,
+            query_embedding=query_embedding,
+            filters=filters,
+            top_k=top_k,
+            return_embedding=return_embedding,
+        )

--- a/clients/python/treedb_haystack/src/haystack_integrations/document_stores/treedb/__init__.py
+++ b/clients/python/treedb_haystack/src/haystack_integrations/document_stores/treedb/__init__.py
@@ -1,0 +1,13 @@
+"""TreeDB Haystack DocumentStore integration."""
+
+from .document_store import (
+    TreeDBDocumentStore,
+    haystack_document_to_treedb_document,
+    treedb_document_to_haystack_document,
+)
+
+__all__ = [
+    "TreeDBDocumentStore",
+    "haystack_document_to_treedb_document",
+    "treedb_document_to_haystack_document",
+]

--- a/clients/python/treedb_haystack/src/haystack_integrations/document_stores/treedb/document_store.py
+++ b/clients/python/treedb_haystack/src/haystack_integrations/document_stores/treedb/document_store.py
@@ -140,6 +140,7 @@ class TreeDBDocumentStore:
             return 0
 
         with self._write_lock:
+            input_count = len(docs)
             docs = _deduplicate_input_documents(docs, policy)
             if policy in {DuplicatePolicy.FAIL, DuplicatePolicy.SKIP}:
                 existing_ids = self._existing_document_ids([doc.id for doc in docs])
@@ -167,6 +168,8 @@ class TreeDBDocumentStore:
                     "the MVP service does not provide atomic create-if-absent writes"
                 )
                 raise DocumentStoreError(msg)
+            if policy == DuplicatePolicy.OVERWRITE:
+                return input_count
             return response.upserted
 
     def delete_documents(self, document_ids: Sequence[str]) -> None:

--- a/clients/python/treedb_haystack/src/haystack_integrations/document_stores/treedb/document_store.py
+++ b/clients/python/treedb_haystack/src/haystack_integrations/document_stores/treedb/document_store.py
@@ -1,0 +1,464 @@
+"""Haystack DocumentStore backed by TreeDB's document service."""
+
+from __future__ import annotations
+
+import copy
+import math
+import threading
+from collections import OrderedDict
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from typing import Any, Optional, TypeVar, Union
+
+from haystack import default_from_dict, default_to_dict
+from haystack.dataclasses import Document as HaystackDocument
+from haystack.document_stores.errors import DocumentStoreError, DuplicateDocumentError
+from haystack.document_stores.types import DuplicatePolicy
+from haystack.errors import FilterError
+from treedb_client import Document as TreeDBDocument
+from treedb_client import IndexInfo, TreeDBClient, TreeDBClientError, normalize_filter
+from treedb_client import InvalidFilterError as TreeDBInvalidFilterError
+from treedb_client import InvalidRequestError as TreeDBInvalidRequestError
+
+FilterLike = Mapping[str, Any]
+_T = TypeVar("_T")
+
+
+class TreeDBDocumentStore:
+    """A Haystack DocumentStore backed by the TreeDB document service.
+
+    The store delegates filtering, deletion, and dense-vector search to TreeDB's
+    HTTP service through `treedb-client`. It intentionally exposes only the dense
+    embedding MVP: no keyword, sparse, or hybrid retrievers are implemented here,
+    and unsupported filters are not emulated with client-side document scans.
+    """
+
+    def __init__(
+        self,
+        *,
+        base_url: Optional[str] = None,
+        index: str = "docs",
+        embedding_dimension: int = 768,
+        similarity: str = "cosine",
+        return_embedding: bool = False,
+        ensure_index: bool = True,
+        recreate_index: bool = False,
+        timeout: Optional[float] = 30.0,
+        client: Optional[TreeDBClient] = None,
+    ) -> None:
+        """Create a TreeDB-backed Haystack document store.
+
+        :param base_url: Base URL for the TreeDB document service. Required unless `client` is supplied.
+        :param index: TreeDB document-service index name.
+        :param embedding_dimension: Dense embedding dimension for index creation/validation.
+        :param similarity: TreeDB vector metric: `cosine`, `l2`, or `inner_product` (`dot_product` alias).
+        :param return_embedding: Whether filter/search responses should include stored embeddings by default.
+        :param ensure_index: Create/open a compatible service index during construction. If false, operations are lazy.
+        :param recreate_index: Unsupported by the current TreeDB service because there is no safe drop/recreate route.
+        :param timeout: HTTP timeout in seconds for the default `TreeDBClient`.
+        :param client: Optional preconfigured TreeDB client, useful for tests and custom transports.
+        :raises DocumentStoreError: If `recreate_index` is requested or index setup fails.
+        :raises ValueError: If `base_url` is missing and no client is supplied.
+        """
+
+        if recreate_index:
+            msg = "recreate_index is not supported by the TreeDB document service MVP"
+            raise DocumentStoreError(msg)
+        if isinstance(embedding_dimension, bool) or not isinstance(embedding_dimension, int) or embedding_dimension <= 0:
+            msg = "embedding_dimension must be a positive integer"
+            raise ValueError(msg)
+        if client is None and not base_url:
+            msg = "base_url is required when client is not supplied"
+            raise ValueError(msg)
+
+        self.index = index
+        self.embedding_dimension = embedding_dimension
+        self.similarity = _normalize_similarity(similarity)
+        self.return_embedding = bool(return_embedding)
+        self.ensure_index = bool(ensure_index)
+        self.recreate_index = False
+        self.timeout = timeout
+        self.client = client if client is not None else TreeDBClient(str(base_url), timeout=timeout)
+        self.base_url = str(base_url or getattr(self.client, "base_url", ""))
+        self.index_info: Optional[IndexInfo] = None
+        self._write_lock = threading.Lock()
+
+        if self.ensure_index:
+            self.index_info = self._client_call(
+                "ensure index",
+                lambda: self.client.ensure_index(self.index, self.embedding_dimension, self.similarity),
+            )
+            self._validate_index_info(self.index_info)
+
+    def count_documents(self, filters: Optional[FilterLike] = None) -> int:
+        """Return the number of documents matching `filters`, or all documents."""
+
+        prepared_filter = _prepare_filter(filters)
+        response = self._client_call(
+            "count documents",
+            lambda: self.client.count_documents(
+                self.index,
+                prepared_filter,
+                expected_generation=self._expected_generation(),
+            ),
+        )
+        return response.count
+
+    def filter_documents(self, filters: Optional[FilterLike] = None) -> list[HaystackDocument]:
+        """Return documents matching `filters` using TreeDB service-side filtering."""
+
+        prepared_filter = _prepare_filter(filters)
+        response = self._client_call(
+            "filter documents",
+            lambda: self.client.filter_documents(
+                self.index,
+                prepared_filter,
+                return_embedding=self.return_embedding,
+                expected_generation=self._expected_generation(),
+            ),
+        )
+        return [treedb_document_to_haystack_document(doc) for doc in response.documents]
+
+    def write_documents(
+        self,
+        documents: Iterable[HaystackDocument],
+        policy: Union[DuplicatePolicy, str] = DuplicatePolicy.OVERWRITE,
+    ) -> int:
+        """Write embedded Haystack documents to TreeDB.
+
+        `DuplicatePolicy.OVERWRITE` maps directly to TreeDB's atomic upsert endpoint.
+        `DuplicatePolicy.FAIL` and `DuplicatePolicy.SKIP` first ask the service
+        for existing IDs with an `id in [...]` filter; they do not scan all
+        documents client-side. TreeDB's MVP service has no create-only write,
+        so these two policies are best-effort under separate concurrent clients;
+        if a race is detected via an unexpected update response, the store raises
+        `DocumentStoreError` instead of silently reporting success.
+        """
+
+        docs = _validate_haystack_documents(documents)
+        policy = _normalize_duplicate_policy(policy)
+        if not docs:
+            return 0
+
+        with self._write_lock:
+            docs = _deduplicate_input_documents(docs, policy)
+            if policy in {DuplicatePolicy.FAIL, DuplicatePolicy.SKIP}:
+                existing_ids = self._existing_document_ids([doc.id for doc in docs])
+                if existing_ids and policy == DuplicatePolicy.FAIL:
+                    ids = ", ".join(sorted(existing_ids))
+                    msg = f"Document(s) with id(s) already exist in TreeDB index {self.index!r}: {ids}"
+                    raise DuplicateDocumentError(msg)
+                if existing_ids and policy == DuplicatePolicy.SKIP:
+                    docs = [doc for doc in docs if doc.id not in existing_ids]
+                    if not docs:
+                        return 0
+
+            treedb_docs = [haystack_document_to_treedb_document(doc) for doc in docs]
+            response = self._client_call(
+                "upsert documents",
+                lambda: self.client.upsert_documents(
+                    self.index,
+                    treedb_docs,
+                    expected_generation=self._expected_generation(),
+                ),
+            )
+            if policy in {DuplicatePolicy.FAIL, DuplicatePolicy.SKIP} and response.updated:
+                msg = (
+                    f"TreeDB duplicate policy {policy.value!r} detected a concurrent update after preflight; "
+                    "the MVP service does not provide atomic create-if-absent writes"
+                )
+                raise DocumentStoreError(msg)
+            return response.upserted
+
+    def delete_documents(self, document_ids: Sequence[str]) -> None:
+        """Delete explicit document IDs through the TreeDB service."""
+
+        ids = _validate_document_ids(document_ids)
+        if not ids:
+            return
+        self._client_call(
+            "delete documents",
+            lambda: self.client.delete_documents(
+                self.index,
+                ids,
+                expected_generation=self._expected_generation(),
+            ),
+        )
+
+    def delete_by_filter(self, filters: FilterLike) -> int:
+        """Delete documents matching a TreeDB/Haystack filter and return the delete count."""
+
+        if not filters:
+            msg = "delete_by_filter requires a non-empty filter; delete-all is not supported by this MVP"
+            raise FilterError(msg)
+        prepared_filter = _prepare_filter(filters)
+        if prepared_filter is None:
+            msg = "delete_by_filter requires a non-empty filter; delete-all is not supported by this MVP"
+            raise FilterError(msg)
+        response = self._client_call(
+            "delete documents by filter",
+            lambda: self.client.delete_by_filter(
+                self.index,
+                prepared_filter,
+                expected_generation=self._expected_generation(),
+            ),
+        )
+        return response.deleted
+
+    def count_documents_by_filter(self, filters: FilterLike) -> int:
+        """Return the number of documents matching `filters`."""
+
+        return self.count_documents(filters=filters)
+
+    def _query_by_embedding(
+        self,
+        *,
+        query_embedding: Sequence[float],
+        filters: Optional[FilterLike] = None,
+        top_k: int = 10,
+        return_embedding: Optional[bool] = None,
+    ) -> list[HaystackDocument]:
+        """Run dense-vector search through the TreeDB service."""
+
+        prepared_filter = _prepare_filter(filters)
+        response = self._client_call(
+            "query by embedding",
+            lambda: self.client.query_by_embedding(
+                self.index,
+                query_embedding=query_embedding,
+                top_k=top_k,
+                filter=prepared_filter,
+                return_embedding=self.return_embedding if return_embedding is None else bool(return_embedding),
+                expected_generation=self._expected_generation(),
+            ),
+        )
+        return [treedb_document_to_haystack_document(doc) for doc in response.documents]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize this document store for Haystack pipelines."""
+
+        return default_to_dict(
+            self,
+            base_url=self.base_url,
+            index=self.index,
+            embedding_dimension=self.embedding_dimension,
+            similarity=self.similarity,
+            return_embedding=self.return_embedding,
+            ensure_index=self.ensure_index,
+            recreate_index=False,
+            timeout=self.timeout,
+        )
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "TreeDBDocumentStore":
+        """Deserialize a document store from `to_dict()` output."""
+
+        return default_from_dict(cls, data)
+
+    def _existing_document_ids(self, ids: Sequence[str]) -> set[str]:
+        unique_ids = list(OrderedDict((doc_id, None) for doc_id in ids).keys())
+        if not unique_ids:
+            return set()
+        response = self._client_call(
+            "check duplicate IDs",
+            lambda: self.client.filter_documents(
+                self.index,
+                {"field": "id", "operator": "in", "value": unique_ids},
+                limit=len(unique_ids),
+                return_embedding=False,
+                expected_generation=self._expected_generation(),
+            ),
+        )
+        return {doc.id for doc in response.documents}
+
+    def _expected_generation(self) -> Optional[int]:
+        if self.index_info is None:
+            return None
+        return self.index_info.generation
+
+    def _validate_index_info(self, info: IndexInfo) -> None:
+        if info.dimension != self.embedding_dimension:
+            msg = (
+                f"TreeDB index {self.index!r} has dimension {info.dimension}, "
+                f"expected {self.embedding_dimension}"
+            )
+            raise DocumentStoreError(msg)
+        if info.metric != self.similarity:
+            msg = f"TreeDB index {self.index!r} uses metric {info.metric!r}, expected {self.similarity!r}"
+            raise DocumentStoreError(msg)
+        if not info.capabilities.dense_vector_search:
+            msg = f"TreeDB index {self.index!r} does not advertise dense vector search"
+            raise DocumentStoreError(msg)
+        if not info.capabilities.metadata_filters:
+            msg = f"TreeDB index {self.index!r} does not advertise metadata filters"
+            raise DocumentStoreError(msg)
+
+    @staticmethod
+    def _client_call(label: str, fn: Callable[[], _T]) -> _T:
+        try:
+            return fn()
+        except TreeDBInvalidFilterError as exc:
+            raise FilterError(str(exc)) from exc
+        except TreeDBInvalidRequestError as exc:
+            if _looks_like_filter_error(exc):
+                raise FilterError(str(exc)) from exc
+            msg = f"TreeDB {label} failed: {exc}"
+            raise DocumentStoreError(msg) from exc
+        except TreeDBClientError as exc:
+            msg = f"TreeDB {label} failed: {exc}"
+            raise DocumentStoreError(msg) from exc
+
+
+def haystack_document_to_treedb_document(document: HaystackDocument) -> TreeDBDocument:
+    """Convert a Haystack `Document` into the base TreeDB client document model."""
+
+    if document.embedding is None:
+        msg = f"Document {document.id!r} has no embedding; TreeDBDocumentStore requires embedded documents"
+        raise DocumentStoreError(msg)
+    if getattr(document, "sparse_embedding", None) is not None:
+        msg = "TreeDBDocumentStore MVP does not support sparse embeddings"
+        raise DocumentStoreError(msg)
+    if getattr(document, "blob", None) is not None:
+        msg = "TreeDBDocumentStore MVP does not support blob-only Haystack documents"
+        raise DocumentStoreError(msg)
+    return TreeDBDocument(
+        id=document.id,
+        content=document.content or "",
+        embedding=[float(value) for value in document.embedding],
+        meta=copy.deepcopy(document.meta),
+        score=document.score,
+    )
+
+
+def treedb_document_to_haystack_document(document: TreeDBDocument) -> HaystackDocument:
+    """Convert a base TreeDB client document into a Haystack `Document`."""
+
+    return HaystackDocument(
+        id=document.id,
+        content=document.content,
+        embedding=None if document.embedding is None else [float(value) for value in document.embedding],
+        meta=copy.deepcopy(document.meta),
+        score=document.score,
+    )
+
+
+def _validate_haystack_documents(documents: Iterable[HaystackDocument]) -> list[HaystackDocument]:
+    if isinstance(documents, (str, bytes, bytearray)) or not isinstance(documents, Iterable):
+        msg = "param 'documents' must contain an iterable of Haystack Document objects"
+        raise ValueError(msg)
+    docs = list(documents)
+    if any(not isinstance(doc, HaystackDocument) for doc in docs):
+        msg = "param 'documents' must contain an iterable of Haystack Document objects"
+        raise ValueError(msg)
+    return docs
+
+
+def _validate_document_ids(document_ids: Sequence[str]) -> list[str]:
+    if isinstance(document_ids, (str, bytes, bytearray)):
+        msg = "document_ids must be a sequence of strings, not a single string"
+        raise ValueError(msg)
+    ids = list(document_ids)
+    if any(not isinstance(doc_id, str) for doc_id in ids):
+        msg = "document_ids must be a sequence of strings"
+        raise ValueError(msg)
+    return ids
+
+
+def _normalize_duplicate_policy(policy: Union[DuplicatePolicy, str]) -> DuplicatePolicy:
+    if isinstance(policy, DuplicatePolicy):
+        return DuplicatePolicy.OVERWRITE if policy == DuplicatePolicy.NONE else policy
+    if isinstance(policy, str):
+        lowered = policy.strip().lower()
+        for candidate in DuplicatePolicy:
+            if candidate.value == lowered:
+                return DuplicatePolicy.OVERWRITE if candidate == DuplicatePolicy.NONE else candidate
+    msg = f"unsupported duplicate policy {policy!r}"
+    raise ValueError(msg)
+
+
+def _deduplicate_input_documents(
+    documents: list[HaystackDocument],
+    policy: DuplicatePolicy,
+) -> list[HaystackDocument]:
+    seen: set[str] = set()
+    if policy == DuplicatePolicy.FAIL:
+        duplicates: set[str] = set()
+        for doc in documents:
+            if doc.id in seen:
+                duplicates.add(doc.id)
+            seen.add(doc.id)
+        if duplicates:
+            ids = ", ".join(sorted(duplicates))
+            msg = f"Duplicate document id(s) in write batch: {ids}"
+            raise DuplicateDocumentError(msg)
+        return documents
+
+    if policy == DuplicatePolicy.SKIP:
+        out: list[HaystackDocument] = []
+        for doc in documents:
+            if doc.id in seen:
+                continue
+            seen.add(doc.id)
+            out.append(doc)
+        return out
+
+    by_id: "OrderedDict[str, HaystackDocument]" = OrderedDict()
+    for doc in documents:
+        if doc.id in by_id:
+            del by_id[doc.id]
+        by_id[doc.id] = doc
+    return list(by_id.values())
+
+
+def _prepare_filter(filters: Optional[FilterLike]) -> Optional[dict[str, Any]]:
+    if isinstance(filters, Mapping) and len(filters) == 0:
+        return None
+    try:
+        normalized = normalize_filter(filters)
+    except TreeDBInvalidFilterError as exc:
+        raise FilterError(str(exc)) from exc
+    if normalized is not None:
+        _validate_filter_semantics(normalized, "filter")
+    return normalized
+
+
+def _validate_filter_semantics(filter_node: Mapping[str, Any], path: str) -> None:
+    operator = str(filter_node.get("operator", "")).upper()
+    if operator in {"AND", "OR", "NOT"}:
+        conditions = filter_node.get("conditions", [])
+        for i, condition in enumerate(conditions):
+            if isinstance(condition, Mapping):
+                _validate_filter_semantics(condition, f"{path}.conditions[{i}]")
+        return
+    if operator in {">", ">=", "<", "<="} and not _is_filter_comparison_value(filter_node.get("value")):
+        msg = f"{path}: operator {operator!r} requires a numeric or string value"
+        raise FilterError(msg)
+
+
+def _is_filter_comparison_value(value: Any) -> bool:
+    if isinstance(value, bool):
+        return False
+    if isinstance(value, (int, float)):
+        return math.isfinite(float(value))
+    return isinstance(value, str)
+
+
+def _looks_like_filter_error(exc: TreeDBInvalidRequestError) -> bool:
+    message = str(exc).lower()
+    return any(token in message for token in ("filter", "operator", "conditions", "field is required"))
+
+
+def _normalize_similarity(similarity: str) -> str:
+    normalized = similarity.strip().lower().replace("-", "_").replace(" ", "_")
+    aliases = {
+        "cosine": "cosine",
+        "l2": "l2",
+        "euclidean": "l2",
+        "inner_product": "inner_product",
+        "innerproduct": "inner_product",
+        "dot_product": "inner_product",
+        "dotproduct": "inner_product",
+    }
+    if normalized in aliases:
+        return aliases[normalized]
+    msg = "similarity must be one of 'cosine', 'l2', or 'inner_product'"
+    raise ValueError(msg)

--- a/clients/python/treedb_haystack/tests/_support.py
+++ b/clients/python/treedb_haystack/tests/_support.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[1]
+CLIENT_ROOT = PACKAGE_ROOT.parent / "treedb_client"
+REPO_ROOT = PACKAGE_ROOT.parents[2]
+for path in (PACKAGE_ROOT / "src", CLIENT_ROOT / "src"):
+    if str(path) not in sys.path:
+        sys.path.insert(0, str(path))

--- a/clients/python/treedb_haystack/tests/fakes.py
+++ b/clients/python/treedb_haystack/tests/fakes.py
@@ -1,0 +1,258 @@
+from __future__ import annotations
+
+import math
+from copy import deepcopy
+from typing import Any, Optional
+
+import _support  # noqa: F401
+from treedb_client import (
+    CountDocumentsResponse,
+    DeleteDocumentsResponse,
+    DenseVectorSearchResponse,
+    Document,
+    FilterDocumentsResponse,
+    IndexCapabilities,
+    IndexInfo,
+    UpsertDocumentsResponse,
+)
+
+
+CAPABILITIES = IndexCapabilities(
+    dense_vector_search=True,
+    exact_dense_scoring=True,
+    metadata_filters=True,
+    keyword_search=False,
+    hybrid_search=False,
+)
+
+
+def sample_index(name: str = "docs", dimension: int = 3, metric: str = "cosine") -> IndexInfo:
+    return IndexInfo(
+        name=name,
+        dimension=dimension,
+        metric=metric,
+        generation=1,
+        contract_version="treedb-document-service/v1alpha1",
+        embedding_field="embedding",
+        document_type="treedb_document_service_v1",
+        capabilities=CAPABILITIES,
+    )
+
+
+class FakeTreeDBClient:
+    def __init__(self, *, index_name: str = "docs", dimension: int = 3, metric: str = "cosine") -> None:
+        self.base_url = "http://fake-treedb"
+        self.index_info = sample_index(index_name, dimension, metric)
+        self.documents: dict[str, Document] = {}
+        self.ensure_calls: list[tuple[str, int, Optional[str]]] = []
+        self.upsert_calls: list[list[str]] = []
+        self.filter_calls: list[dict[str, Any]] = []
+        self.count_calls: list[dict[str, Any]] = []
+        self.delete_id_calls: list[list[str]] = []
+        self.delete_filter_calls: list[dict[str, Any]] = []
+        self.query_calls: list[dict[str, Any]] = []
+
+    def ensure_index(self, name: str, dimension: int, metric: Optional[str] = "cosine") -> IndexInfo:
+        self.ensure_calls.append((name, dimension, metric))
+        return self.index_info
+
+    def count_documents(
+        self,
+        index: str,
+        filter: Optional[dict[str, Any]] = None,
+        *,
+        expected_generation: Optional[int] = None,
+    ) -> CountDocumentsResponse:
+        self.count_calls.append({"filter": deepcopy(filter), "expected_generation": expected_generation})
+        docs = self._matching_documents(filter)
+        return CountDocumentsResponse(index=self.index_info, count=len(docs))
+
+    def filter_documents(
+        self,
+        index: str,
+        filter: Optional[dict[str, Any]] = None,
+        *,
+        limit: int = 0,
+        offset: int = 0,
+        return_embedding: bool = False,
+        expected_generation: Optional[int] = None,
+    ) -> FilterDocumentsResponse:
+        self.filter_calls.append(
+            {
+                "filter": deepcopy(filter),
+                "limit": limit,
+                "offset": offset,
+                "return_embedding": return_embedding,
+                "expected_generation": expected_generation,
+            }
+        )
+        docs = self._matching_documents(filter)
+        matched_count = len(docs)
+        docs = docs[offset:]
+        if limit:
+            docs = docs[:limit]
+        out = [self._copy_doc(doc, return_embedding=return_embedding) for doc in docs]
+        return FilterDocumentsResponse(index=self.index_info, documents=out, matched_count=matched_count)
+
+    def upsert_documents(
+        self,
+        index: str,
+        documents: list[Document],
+        *,
+        expected_generation: Optional[int] = None,
+    ) -> UpsertDocumentsResponse:
+        self.upsert_calls.append([doc.id for doc in documents])
+        inserted = 0
+        updated = 0
+        for doc in documents:
+            if doc.id in self.documents:
+                updated += 1
+            else:
+                inserted += 1
+            self.documents[doc.id] = self._copy_doc(doc, return_embedding=True)
+        return UpsertDocumentsResponse(
+            index=self.index_info,
+            upserted=len(documents),
+            inserted=inserted,
+            updated=updated,
+            ids=[doc.id for doc in documents],
+        )
+
+    def delete_documents(
+        self,
+        index: str,
+        ids: list[str],
+        *,
+        expected_generation: Optional[int] = None,
+    ) -> DeleteDocumentsResponse:
+        self.delete_id_calls.append(list(ids))
+        deleted = 0
+        for doc_id in ids:
+            if doc_id in self.documents:
+                deleted += 1
+                del self.documents[doc_id]
+        return DeleteDocumentsResponse(index=self.index_info, deleted=deleted, ids=list(ids))
+
+    def delete_by_filter(
+        self,
+        index: str,
+        filter: dict[str, Any],
+        *,
+        expected_generation: Optional[int] = None,
+    ) -> DeleteDocumentsResponse:
+        self.delete_filter_calls.append(deepcopy(filter))
+        ids = [doc.id for doc in self._matching_documents(filter)]
+        for doc_id in ids:
+            del self.documents[doc_id]
+        return DeleteDocumentsResponse(index=self.index_info, deleted=len(ids), ids=ids)
+
+    def query_by_embedding(
+        self,
+        index: str,
+        query_embedding: list[float],
+        top_k: int,
+        filter: Optional[dict[str, Any]] = None,
+        *,
+        return_embedding: bool = False,
+        expected_generation: Optional[int] = None,
+    ) -> DenseVectorSearchResponse:
+        self.query_calls.append(
+            {
+                "query_embedding": list(query_embedding),
+                "top_k": top_k,
+                "filter": deepcopy(filter),
+                "return_embedding": return_embedding,
+                "expected_generation": expected_generation,
+            }
+        )
+        scored: list[tuple[float, Document]] = []
+        for doc in self._matching_documents(filter):
+            if doc.embedding is None:
+                continue
+            score = _cosine(query_embedding, doc.embedding)
+            scored.append((score, doc))
+        scored.sort(key=lambda item: (-item[0], item[1].id))
+        docs = []
+        for score, doc in scored[:top_k]:
+            out = self._copy_doc(doc, return_embedding=return_embedding)
+            out.score = score
+            docs.append(out)
+        return DenseVectorSearchResponse(
+            index=self.index_info,
+            documents=docs,
+            metric=self.index_info.metric,
+            exact=True,
+            candidates=len(scored),
+        )
+
+    def _matching_documents(self, filter: Optional[dict[str, Any]]) -> list[Document]:
+        return [doc for doc in sorted(self.documents.values(), key=lambda item: item.id) if _matches_filter(filter, doc)]
+
+    @staticmethod
+    def _copy_doc(doc: Document, *, return_embedding: bool) -> Document:
+        return Document(
+            id=doc.id,
+            content=doc.content,
+            embedding=None if not return_embedding else (None if doc.embedding is None else list(doc.embedding)),
+            meta=deepcopy(doc.meta),
+            score=doc.score,
+        )
+
+
+def _matches_filter(filter: Optional[dict[str, Any]], doc: Document) -> bool:
+    if not filter:
+        return True
+    op = str(filter.get("operator", "")).upper()
+    if op == "AND":
+        return all(_matches_filter(condition, doc) for condition in filter.get("conditions", []))
+    if op == "OR":
+        return any(_matches_filter(condition, doc) for condition in filter.get("conditions", []))
+    if op == "NOT":
+        return not _matches_filter(filter.get("conditions", [None])[0], doc)
+
+    field = filter["field"]
+    left = _field_value(doc, field)
+    right = filter.get("value")
+    if left is None:
+        return False
+    if op == "==":
+        return left == right
+    if op == "!=":
+        return left != right
+    if op == "IN":
+        return left in right
+    if op == "NOT IN":
+        return left not in right
+    if op == ">=":
+        return left >= right
+    if op == ">":
+        return left > right
+    if op == "<=":
+        return left <= right
+    if op == "<":
+        return left < right
+    raise AssertionError(f"unsupported fake filter operator {op!r}")
+
+
+def _field_value(doc: Document, field: str) -> Any:
+    if field == "id":
+        return doc.id
+    if field == "content":
+        return doc.content
+    if field.startswith("meta."):
+        field = field[5:]
+    current: Any = doc.meta
+    for part in field.split("."):
+        if not isinstance(current, dict) or part not in current:
+            return None
+        current = current[part]
+    return current
+
+
+def _cosine(query: list[float], embedding: list[float]) -> float:
+    dot = sum(float(q) * float(e) for q, e in zip(query, embedding, strict=True))
+    q_norm = math.sqrt(sum(float(q) * float(q) for q in query))
+    e_norm = math.sqrt(sum(float(e) * float(e) for e in embedding))
+    if q_norm == 0.0 or e_norm == 0.0:
+        return 0.0
+    return dot / (q_norm * e_norm)

--- a/clients/python/treedb_haystack/tests/test_document_store.py
+++ b/clients/python/treedb_haystack/tests/test_document_store.py
@@ -103,6 +103,19 @@ def test_write_documents_overwrite_policy_does_not_preflight_duplicates() -> Non
     assert client.upsert_calls[-1] == ["same"]
 
 
+def test_overwrite_policy_reports_input_count_for_duplicate_batch_ids() -> None:
+    store, client = make_store()
+
+    written = store.write_documents(
+        [haystack_doc("same", [1, 0, 0], version=1), haystack_doc("same", [0, 1, 0], version=2)],
+        policy=DuplicatePolicy.OVERWRITE,
+    )
+
+    assert written == 2
+    assert client.upsert_calls[-1] == ["same"]
+    assert store.filter_documents({"field": "id", "operator": "==", "value": "same"})[0].meta["version"] == 2
+
+
 def test_default_duplicate_policy_uses_service_upsert() -> None:
     store, client = make_store()
 

--- a/clients/python/treedb_haystack/tests/test_document_store.py
+++ b/clients/python/treedb_haystack/tests/test_document_store.py
@@ -1,0 +1,272 @@
+from __future__ import annotations
+
+import pytest
+from haystack import Document as HaystackDocument
+from haystack.dataclasses import ByteStream
+from haystack.dataclasses.sparse_embedding import SparseEmbedding
+from haystack.document_stores.errors import DocumentStoreError, DuplicateDocumentError
+from haystack.document_stores.types import DuplicatePolicy
+from haystack.errors import FilterError
+from treedb_client import Document as TreeDBDocument
+from treedb_client import InvalidFilterError as TreeDBInvalidFilterError
+from treedb_client import InvalidRequestError as TreeDBInvalidRequestError
+
+import _support  # noqa: F401
+from fakes import FakeTreeDBClient
+from haystack_integrations.document_stores.treedb import (
+    TreeDBDocumentStore,
+    haystack_document_to_treedb_document,
+    treedb_document_to_haystack_document,
+)
+
+
+def make_store(*, return_embedding: bool = False, ensure_index: bool = True) -> tuple[TreeDBDocumentStore, FakeTreeDBClient]:
+    client = FakeTreeDBClient()
+    store = TreeDBDocumentStore(
+        base_url="http://fake-treedb",
+        index="docs",
+        embedding_dimension=3,
+        similarity="cosine",
+        return_embedding=return_embedding,
+        ensure_index=ensure_index,
+        client=client,  # type: ignore[arg-type]
+    )
+    return store, client
+
+
+def haystack_doc(doc_id: str, embedding: list[float], **meta: object) -> HaystackDocument:
+    return HaystackDocument(id=doc_id, content=f"content {doc_id}", embedding=embedding, meta=dict(meta))
+
+
+def test_constructor_ensures_index_and_count_write_filter_delete_round_trip() -> None:
+    store, client = make_store(return_embedding=True)
+
+    assert client.ensure_calls == [("docs", 3, "cosine")]
+    assert store.write_documents(
+        [
+            haystack_doc("a", [1, 0, 0], repo="gomap", language="go"),
+            haystack_doc("b", [0, 1, 0], repo="gomap", language="python"),
+            haystack_doc("c", [0, 0, 1], repo="other", language="go"),
+        ],
+        policy=DuplicatePolicy.OVERWRITE,
+    ) == 3
+
+    assert store.count_documents() == 3
+    assert store.count_documents(filters={"field": "meta.repo", "operator": "==", "value": "gomap"}) == 2
+
+    filtered = store.filter_documents({"field": "meta.language", "operator": "==", "value": "go"})
+    assert [doc.id for doc in filtered] == ["a", "c"]
+    assert filtered[0].embedding == [1.0, 0.0, 0.0]
+
+    store.delete_documents(["c"])
+    assert store.count_documents() == 2
+    deleted = store.delete_by_filter({"field": "meta.language", "operator": "==", "value": "python"})
+    assert deleted == 1
+    assert store.count_documents() == 1
+
+
+def test_write_documents_fail_policy_uses_server_side_id_filter() -> None:
+    store, client = make_store()
+    store.write_documents([haystack_doc("dup", [1, 0, 0])], policy=DuplicatePolicy.OVERWRITE)
+
+    with pytest.raises(DuplicateDocumentError, match="dup"):
+        store.write_documents([haystack_doc("dup", [0, 1, 0])], policy=DuplicatePolicy.FAIL)
+
+    assert client.filter_calls[-1]["filter"] == {"field": "id", "operator": "in", "value": ["dup"]}
+    assert client.upsert_calls == [["dup"]]
+
+
+def test_write_documents_skip_policy_writes_only_new_ids() -> None:
+    store, client = make_store()
+    store.write_documents([haystack_doc("existing", [1, 0, 0])], policy=DuplicatePolicy.OVERWRITE)
+
+    written = store.write_documents(
+        [haystack_doc("existing", [0, 1, 0]), haystack_doc("new", [0, 0, 1])],
+        policy=DuplicatePolicy.SKIP,
+    )
+
+    assert written == 1
+    assert client.filter_calls[-1]["filter"] == {"field": "id", "operator": "in", "value": ["existing", "new"]}
+    assert client.upsert_calls[-1] == ["new"]
+    assert store.filter_documents({"field": "id", "operator": "==", "value": "existing"})[0].embedding is None
+
+
+def test_write_documents_overwrite_policy_does_not_preflight_duplicates() -> None:
+    store, client = make_store()
+    store.write_documents([haystack_doc("same", [1, 0, 0])], policy=DuplicatePolicy.OVERWRITE)
+    client.filter_calls.clear()
+
+    written = store.write_documents([haystack_doc("same", [0, 1, 0])], policy="overwrite")
+
+    assert written == 1
+    assert client.filter_calls == []
+    assert client.upsert_calls[-1] == ["same"]
+
+
+def test_default_duplicate_policy_uses_service_upsert() -> None:
+    store, client = make_store()
+
+    assert store.write_documents([haystack_doc("default", [1, 0, 0])]) == 1
+
+    assert client.filter_calls == []
+    assert client.upsert_calls[-1] == ["default"]
+
+
+def test_fail_and_skip_detect_concurrent_update_race() -> None:
+    class RacingClient(FakeTreeDBClient):
+        def upsert_documents(self, index: str, documents: list[TreeDBDocument], **kwargs: object) -> object:
+            self.documents[documents[0].id] = TreeDBDocument(
+                id=documents[0].id,
+                content="racing writer",
+                embedding=[0.0, 1.0, 0.0],
+            )
+            return super().upsert_documents(index, documents, **kwargs)
+
+    for policy in (DuplicatePolicy.FAIL, DuplicatePolicy.SKIP):
+        store = TreeDBDocumentStore(
+            base_url="http://fake-treedb",
+            index="docs",
+            embedding_dimension=3,
+            client=RacingClient(),  # type: ignore[arg-type]
+        )
+
+        with pytest.raises(DocumentStoreError, match="concurrent update"):
+            store.write_documents([haystack_doc(f"race-{policy.value}", [1, 0, 0])], policy=policy)
+
+
+def test_write_documents_rejects_unembedded_sparse_or_blob_documents() -> None:
+    store, _ = make_store()
+
+    with pytest.raises(DocumentStoreError, match="no embedding"):
+        store.write_documents([HaystackDocument(id="missing", content="missing")], policy=DuplicatePolicy.OVERWRITE)
+    with pytest.raises(DocumentStoreError, match="sparse embeddings"):
+        store.write_documents(
+            [
+                HaystackDocument(
+                    id="sparse",
+                    content="sparse",
+                    embedding=[1.0, 0.0, 0.0],
+                    sparse_embedding=SparseEmbedding(indices=[0], values=[1.0]),
+                )
+            ],
+            policy=DuplicatePolicy.OVERWRITE,
+        )
+    with pytest.raises(DocumentStoreError, match="blob"):
+        store.write_documents(
+            [
+                HaystackDocument(
+                    id="blob",
+                    content="blob",
+                    embedding=[1.0, 0.0, 0.0],
+                    blob=ByteStream(data=b"blob"),
+                )
+            ],
+            policy=DuplicatePolicy.OVERWRITE,
+        )
+
+
+def test_conversion_functions_preserve_haystack_fields_without_aliasing_meta() -> None:
+    haystack = HaystackDocument(
+        id="doc-1",
+        content="body",
+        embedding=[0.1, 0.2, 0.3],
+        meta={"repo": "gomap", "nested": {"line": 7}},
+        score=0.75,
+    )
+
+    treedb = haystack_document_to_treedb_document(haystack)
+    assert treedb == TreeDBDocument(
+        id="doc-1",
+        content="body",
+        embedding=[0.1, 0.2, 0.3],
+        meta={"repo": "gomap", "nested": {"line": 7}},
+        score=0.75,
+    )
+    treedb.meta["nested"]["line"] = 8
+    assert haystack.meta["nested"]["line"] == 7
+
+    back = treedb_document_to_haystack_document(treedb)
+    assert back.id == "doc-1"
+    assert back.content == "body"
+    assert back.embedding == [0.1, 0.2, 0.3]
+    assert back.meta["nested"]["line"] == 8
+    assert back.score == 0.75
+
+
+@pytest.mark.parametrize("bad_dimension", [0, -1, True, 3.5, "3"])
+def test_constructor_rejects_non_positive_or_non_integer_embedding_dimension(bad_dimension: object) -> None:
+    with pytest.raises(ValueError, match="positive integer"):
+        TreeDBDocumentStore(
+            base_url="http://127.0.0.1:7120",
+            embedding_dimension=bad_dimension,  # type: ignore[arg-type]
+            ensure_index=False,
+        )
+
+
+def test_to_dict_from_dict_round_trip_without_network() -> None:
+    store = TreeDBDocumentStore(
+        base_url="http://127.0.0.1:7120",
+        index="serialized",
+        embedding_dimension=128,
+        similarity="dot_product",
+        return_embedding=True,
+        ensure_index=False,
+        timeout=7,
+    )
+
+    data = store.to_dict()
+
+    assert data["type"] == "haystack_integrations.document_stores.treedb.document_store.TreeDBDocumentStore"
+    assert data["init_parameters"]["similarity"] == "inner_product"
+    restored = TreeDBDocumentStore.from_dict(data)
+    assert restored.base_url == "http://127.0.0.1:7120"
+    assert restored.index == "serialized"
+    assert restored.embedding_dimension == 128
+    assert restored.similarity == "inner_product"
+    assert restored.return_embedding is True
+    assert restored.ensure_index is False
+
+
+def test_invalid_filters_map_to_haystack_filter_error_without_scan_fallback() -> None:
+    store, client = make_store()
+
+    with pytest.raises(FilterError, match="numeric or string"):
+        store.count_documents({"field": "meta.version", "operator": ">", "value": []})
+    assert client.count_calls == []
+
+    class InvalidFilterClient(FakeTreeDBClient):
+        def filter_documents(self, *args: object, **kwargs: object) -> object:
+            raise TreeDBInvalidFilterError("unsupported filter operator 'contains'")
+
+    invalid_filter_store = TreeDBDocumentStore(
+        base_url="http://fake-treedb",
+        index="docs",
+        embedding_dimension=3,
+        ensure_index=False,
+        client=InvalidFilterClient(),  # type: ignore[arg-type]
+    )
+    with pytest.raises(FilterError, match="unsupported filter operator"):
+        invalid_filter_store.filter_documents({"field": "meta.repo", "operator": "==", "value": "gomap"})
+
+    class ServiceRejectedFilterClient(FakeTreeDBClient):
+        def delete_by_filter(self, *args: object, **kwargs: object) -> object:
+            raise TreeDBInvalidRequestError("invalid_request", "filter comparisons require numeric operands")
+
+    service_rejected_filter_store = TreeDBDocumentStore(
+        base_url="http://fake-treedb",
+        index="docs",
+        embedding_dimension=3,
+        ensure_index=False,
+        client=ServiceRejectedFilterClient(),  # type: ignore[arg-type]
+    )
+    with pytest.raises(FilterError, match="filter comparisons"):
+        service_rejected_filter_store.delete_by_filter({"field": "meta.version", "operator": "==", "value": 1})
+
+
+def test_recreate_index_and_delete_empty_filter_fail_honestly() -> None:
+    with pytest.raises(DocumentStoreError, match="recreate_index"):
+        TreeDBDocumentStore(base_url="http://127.0.0.1:7120", recreate_index=True)
+
+    store, _ = make_store()
+    with pytest.raises(FilterError, match="requires a non-empty filter"):
+        store.delete_by_filter({})

--- a/clients/python/treedb_haystack/tests/test_embedding_retriever.py
+++ b/clients/python/treedb_haystack/tests/test_embedding_retriever.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+import asyncio
+import copy
+
+import pytest
+from haystack import Document as HaystackDocument
+from haystack import Pipeline
+from haystack.document_stores.types import DuplicatePolicy, FilterPolicy
+
+import _support  # noqa: F401
+from fakes import FakeTreeDBClient
+from haystack_integrations.components.retrievers.treedb import TreeDBEmbeddingRetriever
+from haystack_integrations.document_stores.treedb import TreeDBDocumentStore
+
+
+def make_populated_store(*, return_embedding: bool = False) -> tuple[TreeDBDocumentStore, FakeTreeDBClient]:
+    client = FakeTreeDBClient()
+    store = TreeDBDocumentStore(
+        base_url="http://fake-treedb",
+        index="docs",
+        embedding_dimension=3,
+        similarity="cosine",
+        return_embedding=return_embedding,
+        client=client,  # type: ignore[arg-type]
+    )
+    store.write_documents(
+        [
+            HaystackDocument(id="alpha", content="alpha", embedding=[1.0, 0.0, 0.0], meta={"category": "A", "rank": 1}),
+            HaystackDocument(id="beta", content="beta", embedding=[0.0, 1.0, 0.0], meta={"category": "B", "rank": 2}),
+            HaystackDocument(id="gamma", content="gamma", embedding=[0.8, 0.2, 0.0], meta={"category": "A", "rank": 3}),
+        ],
+        policy=DuplicatePolicy.OVERWRITE,
+    )
+    return store, client
+
+
+def test_invalid_document_store_type() -> None:
+    with pytest.raises(ValueError, match="TreeDBDocumentStore"):
+        TreeDBEmbeddingRetriever(document_store="not-a-store")  # type: ignore[arg-type]
+
+
+def test_run_top_k_and_return_embedding_override() -> None:
+    store, client = make_populated_store(return_embedding=False)
+    retriever = TreeDBEmbeddingRetriever(document_store=store, top_k=2, return_embedding=True)
+
+    result = retriever.run(query_embedding=[1.0, 0.0, 0.0])
+
+    assert [doc.id for doc in result["documents"]] == ["alpha", "gamma"]
+    assert all(isinstance(doc, HaystackDocument) for doc in result["documents"])
+    assert result["documents"][0].embedding == [1.0, 0.0, 0.0]
+    assert client.query_calls[-1]["top_k"] == 2
+    assert client.query_calls[-1]["return_embedding"] is True
+
+
+def test_run_filters_and_top_k_override() -> None:
+    store, client = make_populated_store()
+    retriever = TreeDBEmbeddingRetriever(document_store=store, top_k=3)
+
+    result = retriever.run(
+        query_embedding=[1.0, 0.0, 0.0],
+        filters={"field": "meta.category", "operator": "==", "value": "B"},
+        top_k=1,
+    )
+
+    assert [doc.id for doc in result["documents"]] == ["beta"]
+    assert client.query_calls[-1]["top_k"] == 1
+    assert client.query_calls[-1]["filter"] == {"field": "meta.category", "operator": "==", "value": "B"}
+
+
+def test_filter_policy_replace_uses_runtime_filter() -> None:
+    store, client = make_populated_store()
+    retriever = TreeDBEmbeddingRetriever(
+        document_store=store,
+        filters={"field": "meta.category", "operator": "==", "value": "A"},
+        top_k=3,
+        filter_policy=FilterPolicy.REPLACE,
+    )
+
+    result = retriever.run(
+        query_embedding=[0.0, 1.0, 0.0],
+        filters={"field": "meta.category", "operator": "==", "value": "B"},
+    )
+
+    assert [doc.id for doc in result["documents"]] == ["beta"]
+    assert client.query_calls[-1]["filter"] == {"field": "meta.category", "operator": "==", "value": "B"}
+
+
+def test_filter_policy_merge_combines_init_and_runtime_filters() -> None:
+    store, client = make_populated_store()
+    retriever = TreeDBEmbeddingRetriever(
+        document_store=store,
+        filters={"field": "meta.category", "operator": "==", "value": "A"},
+        top_k=3,
+        filter_policy="merge",
+    )
+
+    result = retriever.run(
+        query_embedding=[1.0, 0.0, 0.0],
+        filters={"field": "meta.rank", "operator": ">=", "value": 3},
+    )
+
+    assert [doc.id for doc in result["documents"]] == ["gamma"]
+    assert client.query_calls[-1]["filter"] == {
+        "operator": "AND",
+        "conditions": [
+            {"field": "meta.category", "operator": "==", "value": "A"},
+            {"field": "meta.rank", "operator": ">=", "value": 3},
+        ],
+    }
+
+
+def test_filter_policy_merge_does_not_mutate_init_filters() -> None:
+    store, client = make_populated_store()
+    init_filters = {
+        "operator": "AND",
+        "conditions": [{"field": "meta.category", "operator": "==", "value": "A"}],
+    }
+    retriever = TreeDBEmbeddingRetriever(
+        document_store=store,
+        filters=init_filters,
+        top_k=3,
+        filter_policy=FilterPolicy.MERGE,
+    )
+
+    first = retriever.run(
+        query_embedding=[1.0, 0.0, 0.0],
+        filters={"field": "meta.rank", "operator": ">=", "value": 3},
+    )
+    second = retriever.run(query_embedding=[1.0, 0.0, 0.0])
+
+    assert [doc.id for doc in first["documents"]] == ["gamma"]
+    assert [doc.id for doc in second["documents"]] == ["alpha", "gamma"]
+    assert retriever.filters == init_filters
+    assert client.query_calls[-1]["filter"] == init_filters
+
+
+def test_to_dict_from_dict_round_trip() -> None:
+    client = FakeTreeDBClient()
+    store = TreeDBDocumentStore(
+        base_url="http://fake-treedb",
+        index="serialized",
+        embedding_dimension=3,
+        ensure_index=False,
+        client=client,  # type: ignore[arg-type]
+    )
+    retriever = TreeDBEmbeddingRetriever(
+        document_store=store,
+        filters={"field": "meta.category", "operator": "==", "value": "A"},
+        top_k=5,
+        return_embedding=True,
+        filter_policy=FilterPolicy.MERGE,
+    )
+
+    serialized = retriever.to_dict()
+    original = copy.deepcopy(serialized)
+
+    assert serialized["type"] == (
+        "haystack_integrations.components.retrievers.treedb.embedding_retriever.TreeDBEmbeddingRetriever"
+    )
+    assert serialized["init_parameters"]["filter_policy"] == "merge"
+    restored = TreeDBEmbeddingRetriever.from_dict(serialized)
+    assert serialized == original
+    assert restored.top_k == 5
+    assert restored.filter_policy == FilterPolicy.MERGE
+    assert restored.return_embedding is True
+    assert isinstance(restored.document_store, TreeDBDocumentStore)
+    assert restored.document_store.ensure_index is False
+
+
+def test_pipeline_wiring_runs_retriever_component() -> None:
+    store, _ = make_populated_store()
+    pipeline = Pipeline()
+    pipeline.add_component("retriever", TreeDBEmbeddingRetriever(document_store=store, top_k=1))
+
+    result = pipeline.run({"retriever": {"query_embedding": [1.0, 0.0, 0.0]}})
+
+    assert [doc.id for doc in result["retriever"]["documents"]] == ["alpha"]
+
+
+def test_run_async_returns_documents_without_calling_sync_path_on_event_loop() -> None:
+    store, _ = make_populated_store()
+    retriever = TreeDBEmbeddingRetriever(document_store=store, top_k=1)
+
+    result = asyncio.run(retriever.run_async(query_embedding=[1.0, 0.0, 0.0]))
+
+    assert [doc.id for doc in result["documents"]] == ["alpha"]
+
+
+def test_fake_cosine_handles_zero_norm_vectors_for_tests() -> None:
+    store, _ = make_populated_store()
+    retriever = TreeDBEmbeddingRetriever(document_store=store, top_k=3)
+
+    result = retriever.run(query_embedding=[0.0, 0.0, 0.0])
+
+    assert [doc.score for doc in result["documents"]] == [0.0, 0.0, 0.0]
+
+
+def test_run_rejects_non_positive_top_k() -> None:
+    store, _ = make_populated_store()
+    retriever = TreeDBEmbeddingRetriever(document_store=store)
+
+    with pytest.raises(ValueError, match="top_k"):
+        retriever.run(query_embedding=[1.0, 0.0, 0.0], top_k=0)

--- a/clients/python/treedb_haystack/tests/test_integration.py
+++ b/clients/python/treedb_haystack/tests/test_integration.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import os
+import shutil
+import signal
+import socket
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+from typing import Optional
+
+import pytest
+from haystack import Document as HaystackDocument
+from haystack import Pipeline
+from haystack.document_stores.types import DuplicatePolicy
+from treedb_client import TreeDBClient, TreeDBClientError
+
+import _support
+from haystack_integrations.components.retrievers.treedb import TreeDBEmbeddingRetriever
+from haystack_integrations.document_stores.treedb import TreeDBDocumentStore
+
+
+def _free_addr() -> str:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        host, port = sock.getsockname()
+    return f"{host}:{port}"
+
+
+class TreeDBServiceProcess:
+    def __init__(self, repo_root: Path, data_dir: str) -> None:
+        self.repo_root = repo_root
+        self.data_dir = data_dir
+        self.addr = ""
+        self.log = tempfile.NamedTemporaryFile("w+", prefix="treedb_haystack_service_", suffix=".log", delete=False)
+        self.proc: Optional[subprocess.Popen[str]] = None
+
+    @property
+    def base_url(self) -> str:
+        return f"http://{self.addr}"
+
+    def start(self) -> None:
+        last_error: Optional[AssertionError] = None
+        for attempt in range(5):
+            self.addr = _free_addr()
+            log_before = self.read_log()
+            try:
+                self._start_once()
+                return
+            except AssertionError as exc:
+                last_error = exc
+                attempt_log = self.read_log()[len(log_before) :].lower()
+                if "address already in use" not in attempt_log or attempt == 4:
+                    raise
+                self._terminate_process()
+        raise AssertionError(f"service did not start after retrying address allocation: {last_error}")
+
+    def _start_once(self) -> None:
+        cmd = [
+            "go",
+            "run",
+            "./cmd/treedb-document-service",
+            "-dir",
+            self.data_dir,
+            "-addr",
+            self.addr,
+            "-profile",
+            "command_wal_durable",
+        ]
+        self.proc = subprocess.Popen(
+            cmd,
+            cwd=str(self.repo_root),
+            stdout=self.log,
+            stderr=subprocess.STDOUT,
+            text=True,
+            start_new_session=True,
+        )
+        client = TreeDBClient(self.base_url, timeout=1)
+        deadline = time.monotonic() + 90
+        last_error: Optional[BaseException] = None
+        while time.monotonic() < deadline:
+            if self.proc.poll() is not None:
+                raise AssertionError(f"service exited early with code {self.proc.returncode}: {self.read_log()}")
+            try:
+                if client.health().get("ok"):
+                    return
+            except (TreeDBClientError, OSError) as exc:
+                last_error = exc
+            time.sleep(0.25)
+        raise AssertionError(f"service did not become healthy: {last_error}; log={self.read_log()}")
+
+    def stop(self) -> None:
+        self._terminate_process()
+        log_name = self.log.name
+        self.log.close()
+        try:
+            os.unlink(log_name)
+        except OSError:
+            pass
+
+    def _terminate_process(self) -> None:
+        if self.proc is not None and self.proc.poll() is None:
+            try:
+                if hasattr(os, "killpg"):
+                    os.killpg(self.proc.pid, signal.SIGTERM)
+                else:
+                    self.proc.terminate()
+                self.proc.wait(timeout=15)
+            except subprocess.TimeoutExpired:
+                if hasattr(os, "killpg") and hasattr(signal, "SIGKILL"):
+                    os.killpg(self.proc.pid, signal.SIGKILL)
+                else:
+                    self.proc.kill()
+                self.proc.wait(timeout=5)
+
+    def read_log(self) -> str:
+        self.log.flush()
+        with open(self.log.name, "r", encoding="utf-8", errors="replace") as handle:
+            return handle.read()
+
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("TREEDB_HAYSTACK_RUN_INTEGRATION") != "1" or not shutil.which("go"),
+    reason="set TREEDB_HAYSTACK_RUN_INTEGRATION=1 and install Go to run TreeDB service integration tests",
+)
+
+
+@pytest.mark.integration
+def test_haystack_store_retriever_pipeline_and_reopen_smoke() -> None:
+    with tempfile.TemporaryDirectory(prefix="treedb_haystack_integration_") as data_dir:
+        service = TreeDBServiceProcess(_support.REPO_ROOT, data_dir)
+        try:
+            service.start()
+            store = TreeDBDocumentStore(
+                base_url=service.base_url,
+                index="docs",
+                embedding_dimension=3,
+                similarity="cosine",
+                return_embedding=False,
+                timeout=5,
+            )
+            docs = [
+                HaystackDocument(
+                    id="a",
+                    content="alpha TreeDB document",
+                    embedding=[1.0, 0.0, 0.0],
+                    meta={"repo": "snissn/gomap", "language": "go"},
+                ),
+                HaystackDocument(
+                    id="b",
+                    content="beta Haystack document",
+                    embedding=[0.0, 1.0, 0.0],
+                    meta={"repo": "snissn/gomap", "language": "python"},
+                ),
+            ]
+            start = time.perf_counter()
+            written = store.write_documents(docs, policy=DuplicatePolicy.OVERWRITE)
+            ingest_seconds = time.perf_counter() - start
+            assert written == 2
+            assert store.count_documents({"field": "meta.repo", "operator": "==", "value": "snissn/gomap"}) == 2
+            assert [doc.id for doc in store.filter_documents({"field": "meta.language", "operator": "==", "value": "go"})] == ["a"]
+
+            pipeline = Pipeline()
+            pipeline.add_component("retriever", TreeDBEmbeddingRetriever(document_store=store, top_k=1, return_embedding=True))
+            start = time.perf_counter()
+            result = pipeline.run({"retriever": {"query_embedding": [1.0, 0.0, 0.0]}})
+            query_seconds = time.perf_counter() - start
+            assert result["retriever"]["documents"][0].id == "a"
+            assert result["retriever"]["documents"][0].embedding == [1.0, 0.0, 0.0]
+            # Smoke metrics are printed for PR evidence; this is not an ANN throughput benchmark.
+            print(f"treedb_haystack_smoke docs=2 ingest_seconds={ingest_seconds:.6f} query_seconds={query_seconds:.6f}")
+        finally:
+            service.stop()
+
+        reopened = TreeDBServiceProcess(_support.REPO_ROOT, data_dir)
+        try:
+            reopened.start()
+            store = TreeDBDocumentStore(
+                base_url=reopened.base_url,
+                index="docs",
+                embedding_dimension=3,
+                similarity="cosine",
+                return_embedding=True,
+                timeout=5,
+            )
+            assert store.count_documents({"field": "meta.repo", "operator": "==", "value": "snissn/gomap"}) == 2
+            assert [doc.id for doc in store.filter_documents({"field": "meta.language", "operator": "==", "value": "go"})] == ["a"]
+            result = TreeDBEmbeddingRetriever(document_store=store, top_k=1).run(query_embedding=[1.0, 0.0, 0.0])
+            assert result["documents"][0].id == "a"
+            assert result["documents"][0].embedding == [1.0, 0.0, 0.0]
+        finally:
+            reopened.stop()


### PR DESCRIPTION
## Objective

Closes #2533. Part of #2530.

Ship the TreeDB Haystack embedding MVP: a `treedb-haystack` package exposing `TreeDBDocumentStore` and `TreeDBEmbeddingRetriever` backed by the TreeDB Python client from #2532.

## Context

- #2531 document service API is merged to `main` as `9f0de414`.
- #2532 Python client is merged to `main` as `691863a`.
- This PR is the clean restack of superseded stacked PR #2553 onto current `main`; repository rules disallow force-pushing the original stacked branch.
- Downstream #2535 can start using this package/API shape for examples/listing once this PR is accepted.

## Non-goals

- No keyword retriever.
- No hybrid retriever.
- No sparse embedding support.
- No upstream Haystack integration listing/docs changes (owned by #2535).
- No client-side full-document scan fallback for unsupported filters/search.
- No TreeDB Go service hot-path changes.

## Design

- Adds `clients/python/treedb_haystack` package target named `treedb-haystack`.
- Module shape:
  - `haystack_integrations.document_stores.treedb.TreeDBDocumentStore`
  - `haystack_integrations.components.retrievers.treedb.TreeDBEmbeddingRetriever`
- `TreeDBDocumentStore` delegates all storage, filtering, deletion, and dense-vector search to `treedb-client` / the TreeDB document service.
- Constructor supports `base_url`, `index`, `embedding_dimension`, `similarity`, `return_embedding`, `ensure_index`, `timeout`, and optional client injection.
- Duplicate policy handling:
  - `OVERWRITE` maps to service upsert and is the default atomic policy.
  - `FAIL` / `SKIP` use a server-side `id in [...]` filter preflight; no local full scan. Because the service MVP has no create-if-absent endpoint, these policies are documented as best-effort across separate concurrent clients and raise `DocumentStoreError` if an unexpected update race is detected.
- Retriever supports Haystack `FilterPolicy.REPLACE` and `MERGE` via Haystack's `apply_filter_policy` helper.
- Conversion helpers preserve Haystack/TreeDB `id`, `content`, `embedding`, `meta`, and `score` fields.
- `recreate_index` fails honestly because the current service has no safe drop/recreate endpoint.

## Scope

Includes:

- `clients/python/treedb_haystack/pyproject.toml`
- `clients/python/treedb_haystack/README.md`
- `clients/python/treedb_haystack/src/haystack_integrations/document_stores/treedb/*`
- `clients/python/treedb_haystack/src/haystack_integrations/components/retrievers/treedb/*`
- `clients/python/treedb_haystack/tests/*`

Excludes:

- Go TreeDB service/core changes.
- Base `treedb-client` changes.
- Haystack integrations listing/example work (#2535).
- Keyword/hybrid retrievers (#2534, blocked on TreeDB text/hybrid core readiness).

## Correctness

Tests run locally on clean head `0595ace83`:

```sh
cd clients/python/treedb_haystack
PYTHONPATH=src:../treedb_client/src /tmp/treedb_haystack_inspect/bin/python -m pytest -q
# 27 passed, 1 skipped

PYTHONPATH=src:../treedb_client/src /tmp/treedb_haystack_inspect/bin/python -m compileall -q src tests
PYTHONPATH=src:../treedb_client/src /tmp/treedb_haystack_inspect/bin/python -m mypy -p haystack_integrations.document_stores.treedb -p haystack_integrations.components.retrievers.treedb
# Success: no issues found in 4 source files

PYTHONPATH=src:../treedb_client/src /tmp/treedb_haystack_inspect/bin/python -m ruff check src tests
# All checks passed

TREEDB_HAYSTACK_RUN_INTEGRATION=1 PYTHONPATH=src:../treedb_client/src /tmp/treedb_haystack_inspect/bin/python -m pytest -q tests/test_integration.py -s
# 1 passed; includes service restart/persistence smoke
```

Covered behavior:

- document count/write/filter/delete;
- duplicate policies `FAIL`, `SKIP`, `OVERWRITE`;
- serialization/deserialization;
- Haystack ↔ TreeDB document conversion;
- embedding retriever top-k, filters, filter-policy replace/merge;
- Haystack `Pipeline` wiring;
- invalid filter mapping to Haystack `FilterError`;
- optional local TreeDB service restart/persistence smoke.

## Performance

No TreeDB Go hot paths are changed in this PR, so before/after TreeDB benchmarks are not applicable.

Integration smoke metric from the optional local service test on a 2-document / 3-dimensional corpus:

```text
treedb_haystack_smoke docs=2 ingest_seconds=0.009361 query_seconds=0.174611
```

This is only a functional smoke metric for the exact dense-search MVP, not an ANN throughput claim.

## Rollout / Toggle Plan

- New package is opt-in under `clients/python/treedb_haystack`; existing Go and Python-client users are unaffected.
- Runtime dependency on the TreeDB document service remains explicit through `base_url` / `TreeDBClient` injection.
- To disable/revert, stop installing/importing `treedb-haystack` or revert this package directory.

## Follow-ups

- #2535: examples, packaging polish, and Haystack integrations listing once this API is accepted.
- #2534: keyword/hybrid retrievers only after TreeDB text/hybrid core is ready.

## AI review status

- Codex/CodeRabbit will be requested on this clean restacked PR.
