### PR TITLE
TreeDB Haystack: add examples and listing plan

### DIFF
--- a/clients/python/treedb_haystack/README.md
+++ b/clients/python/treedb_haystack/README.md
@@ -82,6 +82,20 @@ result = pipeline.run({"retriever": {"query_embedding": [1.0, 0.0, 0.0]}})
 print(result["retriever"]["documents"][0].id)
 ```
 
+## Runnable examples
+
+Example scripts live in [`examples/`](examples/):
+
+- [`basic_ingest_retrieve.py`](examples/basic_ingest_retrieve.py) writes two embedded Haystack documents and retrieves one through a `Pipeline`.
+- [`code_search_metadata.py`](examples/code_search_metadata.py) demonstrates code-search metadata fields such as `repo`, `path`, `language`, `symbol`, `start_line`, `end_line`, and `chunk_kind` with service-side filters.
+
+After starting `cmd/treedb-document-service`, run them from the repository root with the local packages installed:
+
+```sh
+python clients/python/treedb_haystack/examples/basic_ingest_retrieve.py
+python clients/python/treedb_haystack/examples/code_search_metadata.py
+```
+
 ## Filters
 
 Filters use the TreeDB service/Haystack v2 filter AST and are executed by the
@@ -133,6 +147,14 @@ cd clients/python/treedb_haystack
 PYTHONPATH=src:../treedb_client/src python -m compileall -q src tests
 python -m mypy -p haystack_integrations.document_stores.treedb -p haystack_integrations.components.retrievers.treedb
 ```
+
+## Haystack integrations listing
+
+A listing draft for the Haystack integrations index is prepared in the
+`snissn/haystack-integrations` fork on branch `treedb-listing` as
+`integrations/treedb.md`. It uses the gomap repository URL instead of a PyPI URL
+until package publication is finalized. Open the upstream listing PR after the
+installation/release URLs are stable.
 
 ## Scope and non-goals
 

--- a/clients/python/treedb_haystack/examples/README.md
+++ b/clients/python/treedb_haystack/examples/README.md
@@ -1,0 +1,30 @@
+# TreeDB Haystack examples
+
+These examples require a running TreeDB document service and the local Python
+packages installed in a virtual environment.
+
+From the repository root:
+
+```sh
+python3 -m venv .venv-treedb-haystack
+. .venv-treedb-haystack/bin/activate
+python -m pip install -U pip
+python -m pip install -e clients/python/treedb_client
+python -m pip install -e clients/python/treedb_haystack
+
+go run ./cmd/treedb-document-service \
+  -dir /tmp/treedb-document-service \
+  -addr 127.0.0.1:7120 \
+  -profile command_wal_durable
+```
+
+In another shell with the same virtual environment:
+
+```sh
+python clients/python/treedb_haystack/examples/basic_ingest_retrieve.py
+python clients/python/treedb_haystack/examples/code_search_metadata.py
+```
+
+Both scripts use small deterministic embeddings and exact TreeDB service-backed
+dense retrieval. They do not exercise or claim keyword/hybrid search support.
+Use `--base-url` and `--index` to point at a different service or isolate runs.

--- a/clients/python/treedb_haystack/examples/basic_ingest_retrieve.py
+++ b/clients/python/treedb_haystack/examples/basic_ingest_retrieve.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Basic TreeDB Haystack document ingest + embedding retrieval example.
+
+Start the service first, for example:
+
+    go run ./cmd/treedb-document-service \
+      -dir /tmp/treedb-document-service \
+      -addr 127.0.0.1:7120 \
+      -profile command_wal_durable
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from haystack import Document, Pipeline
+from haystack.document_stores.types import DuplicatePolicy
+from haystack_integrations.components.retrievers.treedb import TreeDBEmbeddingRetriever
+from haystack_integrations.document_stores.treedb import TreeDBDocumentStore
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-url", default="http://127.0.0.1:7120", help="TreeDB document service base URL")
+    parser.add_argument("--index", default="haystack_basic_example", help="TreeDB document-service index name")
+    args = parser.parse_args()
+
+    store = TreeDBDocumentStore(
+        base_url=args.base_url,
+        index=args.index,
+        embedding_dimension=3,
+        similarity="cosine",
+        return_embedding=False,
+    )
+    store.write_documents(
+        [
+            Document(
+                id="treedb-overview",
+                content="TreeDB stores Haystack documents behind a service API.",
+                embedding=[1.0, 0.0, 0.0],
+                meta={"topic": "treedb", "kind": "overview"},
+            ),
+            Document(
+                id="haystack-overview",
+                content="Haystack pipelines connect components such as retrievers.",
+                embedding=[0.0, 1.0, 0.0],
+                meta={"topic": "haystack", "kind": "overview"},
+            ),
+        ],
+        policy=DuplicatePolicy.OVERWRITE,
+    )
+
+    pipeline = Pipeline()
+    pipeline.add_component("retriever", TreeDBEmbeddingRetriever(document_store=store, top_k=1))
+    result = pipeline.run({"retriever": {"query_embedding": [1.0, 0.0, 0.0]}})
+    documents = result["retriever"]["documents"]
+    if not documents or documents[0].id != "treedb-overview":
+        raise SystemExit(f"unexpected result: {documents!r}")
+
+    print(f"retrieved id={documents[0].id} score={documents[0].score:.6f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/clients/python/treedb_haystack/examples/code_search_metadata.py
+++ b/clients/python/treedb_haystack/examples/code_search_metadata.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""TreeDB Haystack code-search metadata example.
+
+This example stores code chunks with repository/path/symbol/line metadata and
+retrieves them with dense embeddings plus a service-side metadata filter.
+It intentionally does not use keyword or hybrid retrieval.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from haystack import Document, Pipeline
+from haystack.document_stores.types import DuplicatePolicy, FilterPolicy
+from haystack_integrations.components.retrievers.treedb import TreeDBEmbeddingRetriever
+from haystack_integrations.document_stores.treedb import TreeDBDocumentStore
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-url", default="http://127.0.0.1:7120", help="TreeDB document service base URL")
+    parser.add_argument("--index", default="haystack_code_search_example", help="TreeDB document-service index name")
+    args = parser.parse_args()
+
+    store = TreeDBDocumentStore(
+        base_url=args.base_url,
+        index=args.index,
+        embedding_dimension=4,
+        similarity="cosine",
+        return_embedding=False,
+    )
+    store.write_documents(
+        [
+            Document(
+                id="TreeDB/documentservice/service.go:SearchDenseVector",
+                content="SearchDenseVector scores stored embeddings exactly with optional metadata filters.",
+                embedding=[1.0, 0.0, 0.0, 0.0],
+                meta={
+                    "repo": "snissn/gomap",
+                    "path": "TreeDB/documentservice/service.go",
+                    "language": "go",
+                    "symbol": "SearchDenseVector",
+                    "start_line": 250,
+                    "end_line": 320,
+                    "chunk_kind": "function",
+                },
+            ),
+            Document(
+                id="clients/python/treedb_haystack/README.md:filters",
+                content="TreeDB Haystack filters are executed by the TreeDB document service.",
+                embedding=[0.0, 1.0, 0.0, 0.0],
+                meta={
+                    "repo": "snissn/gomap",
+                    "path": "clients/python/treedb_haystack/README.md",
+                    "language": "markdown",
+                    "symbol": "Filters",
+                    "start_line": 70,
+                    "end_line": 90,
+                    "chunk_kind": "section",
+                },
+            ),
+        ],
+        policy=DuplicatePolicy.OVERWRITE,
+    )
+
+    filters = {"field": "meta.language", "operator": "==", "value": "go"}
+    pipeline = Pipeline()
+    pipeline.add_component(
+        "retriever",
+        TreeDBEmbeddingRetriever(
+            document_store=store,
+            filters={"field": "meta.repo", "operator": "==", "value": "snissn/gomap"},
+            filter_policy=FilterPolicy.MERGE,
+            top_k=2,
+        ),
+    )
+    result = pipeline.run({"retriever": {"query_embedding": [1.0, 0.0, 0.0, 0.0], "filters": filters}})
+    documents = result["retriever"]["documents"]
+    if not documents or documents[0].meta.get("symbol") != "SearchDenseVector":
+        raise SystemExit(f"unexpected result: {documents!r}")
+
+    doc = documents[0]
+    print(
+        "retrieved "
+        f"symbol={doc.meta['symbol']} path={doc.meta['path']} "
+        f"lines={doc.meta['start_line']}-{doc.meta['end_line']} score={doc.score:.6f}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/clients/python/treedb_haystack/pyproject.toml
+++ b/clients/python/treedb_haystack/pyproject.toml
@@ -31,6 +31,7 @@ dev = [
 
 [project.urls]
 Source = "https://github.com/snissn/gomap"
+Documentation = "https://github.com/snissn/gomap/tree/main/clients/python/treedb_haystack"
 Issues = "https://github.com/snissn/gomap/issues"
 
 [tool.setuptools.packages.find]

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,7 @@ TreeDB is a persistent B+Tree with a high-throughput cached write-back layer.
 - **[Typed-Storage Guides](../TreeDB/docs/guides/README.md)**: Collection layout quickstarts, typed-storage benchmark/profile guide, and vector typed-column guidance.
 - **[Document Service API](TREEDB_DOCUMENT_SERVICE_API.md)**: Pre-alpha Haystack-style HTTP/JSON contract for documents, metadata filters, and exact dense-vector search.
 - **[Python Document Service Client](../clients/python/treedb_client/README.md)**: Haystack-free sync Python client for the document service.
+- **[TreeDB Haystack Integration](../clients/python/treedb_haystack/README.md)**: DocumentStore/retriever package and runnable examples for Haystack pipelines.
 
 ## ⚡ HashDB
 


### PR DESCRIPTION
## Objective

Closes #2535. Part of #2530.

Add runnable TreeDB Haystack examples, package metadata/docs, and prepare the Haystack integrations listing draft.

## Context

- #2531 document service API is merged.
- #2532 Python client is merged.
- #2533 `treedb-haystack` MVP is merged.
- Keyword/hybrid retrievers remain blocked by TreeDB text/hybrid execution readiness and are not documented as available.

## Non-goals

- No keyword or hybrid examples.
- No benchmark/ANN throughput claims.
- No TreeDB Go service/core changes.
- No upstream Haystack listing PR submission from this gomap PR; the listing draft is prepared in the local fork for a follow-up publication step.

## Design / Scope

Gomap changes:

- Adds `clients/python/treedb_haystack/examples/basic_ingest_retrieve.py`.
- Adds `clients/python/treedb_haystack/examples/code_search_metadata.py` with `repo`, `path`, `language`, `symbol`, `start_line`, `end_line`, and `chunk_kind` metadata.
- Adds `clients/python/treedb_haystack/examples/README.md` with install/service/run commands.
- Adds a `Documentation` URL to `clients/python/treedb_haystack/pyproject.toml`.
- Links the Haystack integration package from `docs/README.md`.
- Documents the Haystack integrations listing branch in `clients/python/treedb_haystack/README.md`.

External listing draft:

- Prepared and pushed `integrations/treedb.md` in `/Users/michaelseiler/dev/snissn/haystack-integrations`.
- Branch: `treedb-listing`.
- Commit: `356e52e` (`Add TreeDB integration listing`).
- Uses repo URL `https://github.com/snissn/gomap/tree/main/clients/python/treedb_haystack`; no PyPI URL is claimed.
- Upstream PR should be opened after package/release URLs are stable.

## Correctness

Local validation:

```sh
cd clients/python/treedb_haystack
PYTHONPATH=src:../treedb_client/src /tmp/treedb_haystack_inspect/bin/python -m compileall -q examples
PYTHONPATH=src:../treedb_client/src /tmp/treedb_haystack_inspect/bin/python -m pytest -q
# 28 passed, 1 skipped
```

Example smoke against a local TreeDB document service:

```sh
python clients/python/treedb_haystack/examples/basic_ingest_retrieve.py --base-url http://127.0.0.1:<port> --index smoke_basic
# retrieved id=treedb-overview score=1.000000

python clients/python/treedb_haystack/examples/code_search_metadata.py --base-url http://127.0.0.1:<port> --index smoke_code
# retrieved symbol=SearchDenseVector path=TreeDB/documentservice/service.go lines=250-320 score=1.000000
```

Clean install/import smoke:

```sh
python3 -m venv /tmp/treedb_haystack_example_venv_...
python -m pip install -e clients/python/treedb_client -e clients/python/treedb_haystack
python - <<'PY'
from haystack_integrations.document_stores.treedb import TreeDBDocumentStore
from haystack_integrations.components.retrievers.treedb import TreeDBEmbeddingRetriever
print(TreeDBDocumentStore.__name__, TreeDBEmbeddingRetriever.__name__)
PY
# TreeDBDocumentStore TreeDBEmbeddingRetriever
```

Listing frontmatter smoke: parsed required frontmatter fields from `integrations/treedb.md` in the local fork.

## Performance

No benchmarks run. Examples use a 2-document toy corpus with deterministic embeddings and make no throughput claims.

## Rollout / Toggle Plan

Docs/examples only. Users opt in by installing the Python packages and running the scripts against a TreeDB document service.

## Follow-ups

- Open the upstream Haystack integrations listing PR from `snissn/haystack-integrations:treedb-listing` after package/release URLs are finalized.
- #2534 remains blocked on real TreeDB text/hybrid execution before keyword/hybrid examples are added.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Added complete TreeDB Haystack integration guide with prerequisites and local setup instructions
* Added executable examples for document ingestion/retrieval using embeddings
* Added executable example for code search featuring metadata filtering and vector similarity
* Updated documentation index

<!-- end of auto-generated comment: release notes by coderabbit.ai -->