### PR TITLE
TreeDB: lock RaBitQ v1 score identity

### DIFF
--- a/TreeDB/internal/rabitq/rabitq_test.go
+++ b/TreeDB/internal/rabitq/rabitq_test.go
@@ -130,6 +130,49 @@ func TestEncodeQueryScoreGolden2449(t *testing.T) {
 	}
 }
 
+func TestScoreCosineV1ScoringIdentity2560(t *testing.T) {
+	plan, err := NewPlan(9, Config{Seed: 0x2560}) // CodeDimensions=16, no packed-byte padding.
+	if err != nil {
+		t.Fatalf("NewPlan: %v", err)
+	}
+	query := Query{
+		SignBits:       []byte{0b1010_0101, 0b0011_1100},
+		AbsWeights:     []float32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
+		WeightSum:      136,
+		CodeDimensions: 16,
+	}
+	code := []byte{0b1010_0001, 0b0010_1101}
+	qdpInv := float32(0.5)
+
+	got, err := plan.ScoreCosine(query, code, plan.CountCodeBits(code), qdpInv)
+	if err != nil {
+		t.Fatalf("ScoreCosine: %v", err)
+	}
+	var weightedSignDot float64
+	for i, weight32 := range query.AbsWeights {
+		mask := byte(1 << uint(i&7))
+		if (code[i>>3]&mask != 0) == (query.SignBits[i>>3]&mask != 0) {
+			weightedSignDot += float64(weight32)
+		} else {
+			weightedSignDot -= float64(weight32)
+		}
+	}
+	want := weightedSignDot / (float64(qdpInv) * float64(query.CodeDimensions))
+	if math.Abs(got-want) > 1e-12 {
+		t.Fatalf("ScoreCosine=%0.17g want v1 weighted sign-dot formula %0.17g", got, want)
+	}
+	if math.Abs(got-10.75) > 1e-12 {
+		t.Fatalf("ScoreCosine=%0.17g want golden 10.75", got)
+	}
+
+	badQuery := query
+	badQuery.AbsWeights = append([]float32(nil), query.AbsWeights...)
+	badQuery.AbsWeights[0] *= 2
+	if _, err := plan.ScoreCosine(badQuery, code, plan.CountCodeBits(code), qdpInv); !errors.Is(err, ErrDimensionMismatch) {
+		t.Fatalf("ScoreCosine with calibrated weights but stale WeightSum err=%v want %v", err, ErrDimensionMismatch)
+	}
+}
+
 func TestPackedCodeBitOrderAndPadding2449(t *testing.T) {
 	plan, err := NewPlan(3, Config{Seed: 0x2449}) // CodeDimensions=4, one physical byte with four high padding bits.
 	if err != nil {


### PR DESCRIPTION
## Objective

Add a test-only RaBitQ v1 scoring oracle for #2560 before any calibration experiments, and record that no production calibration candidate was promoted.

Fixes/addresses: #2560
Parent tracker: #2556

## Context

#2560 requires locking current `rabitq_1bit` v1 behavior before evaluating calibration/preprocessing ideas. The hard guardrail is that v1 codec identity, storage schema, LSB0 bit order, score formula, and fail-closed behavior must not silently change.

## Non-goals

- No production scorer/quantizer changes.
- No `rabitq_1bit` v1 storage/schema/score/config mutation.
- No exact fallback or quantized route behavior changes.
- No new calibrated/versioned codec; those ideas stay gated by #2561/#2480-style design.

## Design

- Adds `TestScoreCosineV1ScoringIdentity2560` in `TreeDB/internal/rabitq/rabitq_test.go`.
- The test manually constructs LSB0 query/code bytes, query weights, `WeightSum`, and `quantized_dot_product_inv`, then checks `Plan.ScoreCosine` against the v1 weighted sign-dot formula:
  `sum_i AbsWeights[i] * (+1 match / -1 mismatch) / (quantizedDotProductInv * CodeDimensions)`.
- It also verifies calibrated/stale query weights fail closed with `ErrDimensionMismatch` rather than being accepted silently.

## Correctness

Tests run locally:

- `GOWORK=off go test ./TreeDB/internal/rabitq -run 'Test(ScoreCosineV1ScoringIdentity2560|EncodeQueryScoreGolden2449|ScoreCosineFailsClosedOnMalformedSideInputs2449|DegenerateInputsFailClosed2449)' -count=1`
- `GOWORK=off go test ./TreeDB/collections -run 'TestRabitQByte(Table|Mismatch)|Test(VectorIndexSearcherRabitQ|ColumnGraphRabitQ|CollectionSearchVectorIndexWithBufferRabitQ|ColumnGraphQuantizedAssetFailClosed)' -count=1`
- `GOWORK=off go test ./TreeDB/docs -run 'Test.*RabitQ|Test.*Quantized' -count=1`
- `GOWORK=off go test ./TreeDB/internal/rabitq ./TreeDB/collections -count=1`

Internal review: PASS (read-only Pi reviewer), including `go test ./TreeDB/internal/rabitq -count=1`.

## Performance / benchmark evidence

No production code changed, and no v1-preserving quality candidate was found. I still re-ran the parent exact/scalar/RaBitQ matrix to validate recall/storage/counters remain unchanged on the test-only branch.

- Artifact root: `/tmp/gomap_2560_nochange_quant_compare_20260607_133946`
- Baseline comparator: `/tmp/gomap_2556_quant_compare_20260607_132557` at `5caae285f7fc3e6d094fee7f447123976257b719`
- Host context (sanitized): Apple M3, macOS/Darwin arm64, Go 1.26.0; local laptop load, timing is not promotion evidence.
- Shape: docs=10,000, dims=1,536, queries=10,000, validate_queries=64, topK=10, M=16, efConstruction=128, efSearch=128, rerank candidates=32.

| mode | recall@10 | storage/doc | c=1 QPS | c=8 QPS | guardrails |
| --- | ---: | ---: | ---: | ---: | --- |
| exact FP32 | 0.9859 | 13303.5B | 1877.3 | 8232.3 | docs/fallback/scratch zero |
| scalar_u8 qonly | 0.8703 | 14879.9B | 4201.0 | 14919.5 | exact vector/norm reads zero |
| scalar_u8 rerank32 | 0.9828 | 14879.9B | 3802.3 | 15318.6 | exact calls=32, vector=196608B, norm=128B |
| RaBitQ qonly | 0.5031 | 13608.0B | 2206.5 | 3300.3 | exact vector/norm reads zero |
| RaBitQ rerank32 | 0.6359 | 13608.0B | 2352.3 | 5829.0 | exact calls=32, vector=196608B, norm=128B |

No-doc route counters were clean for every row: docs fetched=0, response-owned allocs=0, route fallback=0, graph fallback=0, typed-column fallback=0, scratch decode=0.

## Calibration inventory / recommendation

Inventory artifact: `/tmp/gomap_2560_nochange_quant_compare_20260607_133946/issue_2560_calibration_inventory.md`.

V1-preserving knobs found:

- Implementation parity changes that compute the exact same formula (already represented by #2477) preserve v1 but do not improve ordering.
- Per-query monotonic score rescaling does not improve candidate ordering; changing returned qonly scores would itself be a score-semantics change.
- efSearch/rerank/oversampling are sibling issues (#2557/#2558/#2559), not calibration.

Versioned-codec-only ideas:

- Query centering/weight clipping/power transforms, alternate thresholds, alternate rotations/seeds/preconditioners, per-vector/per-block calibration side arrays, residuals, or multi-bit schemes all change query encoding, stored bits, schema/config, or score semantics.

Recommendation: **no-promote for #2560 production code**. Any quality-improving calibration should go through #2561/#2480 as an explicit new codec/query-mode contract with oracle tests, storage schema, fail-closed behavior, score labels, and benchmark gates.

## CI / AI Review Loop

- Latest-head CI: all checks passing for `c6bca98b0f1ba03118a201cb5903ab9b22a5c19c` (`gh pr checks 2562`).
- Codex latest-head review: requested; no major issues.
- Copilot latest-head review: requested with `@copilot review`; no response surfaced yet.
- CodeRabbit latest-head review: auto-triggered but unavailable/rate-limited by org usage; no actionable findings.
- Review comments/threads resolved: no review threads.

