### PR TITLE
TreeDB: budget periodic rewrite planning scans

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -2064,6 +2064,8 @@ const (
 	envDisableVlogGenerationLoop                      = "TREEDB_DISABLE_VLOG_GENERATION_LOOP"
 	envDisableVlogGenerationCheckpointKick            = "TREEDB_DISABLE_VLOG_GENERATION_CHECKPOINT_KICK"
 	envDisableVlogGenerationCheckpointKickHotDebtOnly = "TREEDB_DISABLE_VLOG_GENERATION_CHECKPOINT_KICK_HOT_DEBT_ONLY"
+	envDisableVlogGenerationPeriodicRewritePlanBudget = "TREEDB_DISABLE_VLOG_GENERATION_PERIODIC_REWRITE_PLAN_BUDGET"
+	envVlogGenerationPeriodicRewritePlanBudgetMillis  = "TREEDB_VLOG_GENERATION_PERIODIC_REWRITE_PLAN_BUDGET_MS"
 	// Experimental immutable-leaf maintenance hook. Disabled by default until
 	// the cached scheduler policy and dwell behavior are validated.
 	envEnableLeafGenerationPackMaintenance                     = "TREEDB_ENABLE_LEAF_GENERATION_PACK_MAINTENANCE"
@@ -8352,6 +8354,11 @@ const (
 	// and should only run when the foreground has been quiet for a meaningfully
 	// longer window than lightweight maintenance.
 	vlogGenerationMaintenanceQuietWindow = 15 * time.Second
+	// Periodic rewrite planning is best-effort background maintenance. Keep its
+	// fresh-plan live-byte estimate bounded so a scheduled pass cannot monopolize
+	// foreground-heavy restore/sync windows. Explicit/checkpoint/deferred debt
+	// paths keep their existing wider contexts.
+	vlogGenerationPeriodicRewritePlanBudget = 2 * time.Second
 	// Retained-path prune performs a full live-ID scan and is pure best-effort
 	// reclaim. Require a meaningfully idle window before starting it so hot
 	// write workloads do not pay for a large scan between active phases.
@@ -11503,6 +11510,11 @@ func (db *DB) vlogGenerationRewritePlanContext(timeout time.Duration, opts vlogG
 			return context.WithTimeout(context.Background(), timeout)
 		}
 		return context.WithCancel(context.Background())
+	}
+	if vlogGenerationIsPeriodicSource(opts) {
+		if budget := vlogGenerationPeriodicRewritePlanBudgetDuration(); budget > 0 && (timeout <= 0 || timeout > budget) {
+			timeout = budget
+		}
 	}
 	return db.foregroundVlogMaintenanceContextWithResumeGrace(timeout, vlogGenerationRewritePlanResumeGrace)
 }
@@ -17671,6 +17683,21 @@ func vlogGenerationIsStageConfirmSource(opts vlogGenerationMaintenanceOptions) b
 
 func vlogGenerationIsQueueSource(opts vlogGenerationMaintenanceOptions) bool {
 	return opts.debugSource == "rewrite_queue_pending"
+}
+
+func vlogGenerationIsPeriodicSource(opts vlogGenerationMaintenanceOptions) bool {
+	return opts.debugSource == "" && !opts.bypassQuiet
+}
+
+func vlogGenerationPeriodicRewritePlanBudgetDuration() time.Duration {
+	if envBool(envDisableVlogGenerationPeriodicRewritePlanBudget) {
+		return 0
+	}
+	budgetMillis := envUint64(envVlogGenerationPeriodicRewritePlanBudgetMillis, uint64(vlogGenerationPeriodicRewritePlanBudget/time.Millisecond))
+	if budgetMillis == 0 {
+		return 0
+	}
+	return time.Duration(budgetMillis) * time.Millisecond
 }
 
 func vlogGenerationIsAgeBlockedSource(opts vlogGenerationMaintenanceOptions) bool {

--- a/TreeDB/caching/vlog_generation_scheduler_test.go
+++ b/TreeDB/caching/vlog_generation_scheduler_test.go
@@ -2408,6 +2408,102 @@ func TestLeafGenerationPackMaintenance_SkipsWithinMinInterval(t *testing.T) {
 	}
 }
 
+func TestVlogGenerationRewritePlanContext_BudgetsPeriodicFreshPlans(t *testing.T) {
+	prepareDirectSchedulerTest(t)
+	t.Setenv(envVlogGenerationPeriodicRewritePlanBudgetMillis, "25")
+	db := &DB{closeCh: make(chan struct{})}
+
+	ctx, cancel := db.vlogGenerationRewritePlanContext(30*time.Second, vlogGenerationMaintenanceOptions{})
+	deadline, ok := ctx.Deadline()
+	cancel()
+	if !ok {
+		t.Fatal("periodic rewrite plan context missing deadline")
+	}
+	if ttl := time.Until(deadline); ttl <= 0 || ttl > time.Second {
+		t.Fatalf("periodic rewrite plan ttl=%s want budgeted", ttl)
+	}
+
+	ctx, cancel = db.vlogGenerationRewritePlanContext(30*time.Second, vlogGenerationMaintenanceOptions{
+		bypassQuiet: true,
+	})
+	deadline, ok = ctx.Deadline()
+	cancel()
+	if !ok {
+		t.Fatal("bypass rewrite plan context missing deadline")
+	}
+	if ttl := time.Until(deadline); ttl < 20*time.Second {
+		t.Fatalf("bypass rewrite plan ttl=%s want unbudgeted 30s context", ttl)
+	}
+}
+
+func TestVlogGenerationMaintenance_PeriodicFreshPlanBudgetCancelsLongPlan(t *testing.T) {
+	prepareDirectSchedulerTest(t)
+	t.Setenv(envVlogGenerationPeriodicRewritePlanBudgetMillis, "25")
+
+	dir := t.TempDir()
+	backend, err := backenddb.Open(backenddb.Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open backend: %v", err)
+	}
+	planner := &timedRewritePlannerBackend{
+		DB:        backend,
+		planStart: make(chan struct{}),
+		planDelay: time.Second,
+	}
+	db, err := Open(dir, planner, Options{
+		AllowUnsafe:                      true,
+		DisableWAL:                       true,
+		JournalLanes:                     1,
+		ValueLogGenerationPolicy:         uint8(backenddb.ValueLogGenerationHotWarmCold),
+		ValueLogRewriteTriggerTotalBytes: 1,
+		ValueLogRewriteBudgetBytesPerSec: 1024,
+		ForceValueLogPointers:            true,
+	})
+	if err != nil {
+		t.Fatalf("open cachingdb: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	b := db.NewBatch()
+	if err := b.Set([]byte("k"), make([]byte, 2048)); err != nil {
+		_ = b.Close()
+		t.Fatalf("set: %v", err)
+	}
+	if err := b.Write(); err != nil {
+		_ = b.Close()
+		t.Fatalf("write: %v", err)
+	}
+	_ = b.Close()
+	if err := db.Checkpoint(); err != nil {
+		t.Fatalf("checkpoint: %v", err)
+	}
+	db.vlogGenerationRewriteBudgetTokensBytes.Store(1024)
+	forceVlogMaintenanceIdle(db)
+
+	done := make(chan struct{})
+	go func() {
+		db.maybeRunVlogGenerationMaintenance(false)
+		close(done)
+	}()
+	select {
+	case <-planner.planStart:
+	case <-time.After(schedulerTestWait(t)):
+		t.Fatal("timed out waiting for periodic rewrite plan")
+	}
+	select {
+	case <-done:
+	case <-time.After(schedulerTestWait(t)):
+		t.Fatal("periodic rewrite plan did not stop after budget")
+	}
+	completed, canceled := planner.recordedPlanOutcomes()
+	if completed != 0 || canceled != 1 {
+		t.Fatalf("plan outcomes completed=%d canceled=%d want 0/1", completed, canceled)
+	}
+	if got := db.Stats()["treedb.cache.vlog_generation.rewrite.plan_canceled"]; got != "1" {
+		t.Fatalf("plan_canceled=%q want 1", got)
+	}
+}
+
 func TestVlogGenerationMaintenance_PeriodicPassRunsLeafPackWhenEnabled(t *testing.T) {
 	prepareDirectSchedulerTest(t)
 	t.Setenv(envEnableLeafGenerationPackMaintenance, "1")

--- a/docs/TREEDB_VLOG_GENERATIONAL_RUNBOOK.md
+++ b/docs/TREEDB_VLOG_GENERATIONAL_RUNBOOK.md
@@ -214,6 +214,11 @@ Additional reporting:
   - By default, checkpoint-kick maintenance skips starting a fresh rewrite plan while foreground activity is hot and rewrite queue debt is empty.
   - Queued rewrite debt and deferred-due passes still run.
   - Set this disable knob only for controlled rollback experiments that need the legacy checkpoint-kick fresh-plan behavior.
+- Periodic rewrite-plan scan budget:
+  - By default, periodic/background fresh rewrite planning is bounded by a short internal deadline so scheduled live-byte scans cannot monopolize foreground-heavy restore/sync windows.
+  - Explicit/checkpoint/deferred rewrite debt paths keep their wider planning contexts.
+  - `TREEDB_DISABLE_VLOG_GENERATION_PERIODIC_REWRITE_PLAN_BUDGET=1` disables the budget for controlled rollback experiments.
+  - `TREEDB_VLOG_GENERATION_PERIODIC_REWRITE_PLAN_BUDGET_MS` overrides the internal budget in milliseconds for diagnostics.
 - Optional debt-drain cap overrides (for controlled experiments):
   - `TREEDB_VLOG_GENERATION_REWRITE_RESUME_MAX_SEGMENTS`
   - `TREEDB_VLOG_GENERATION_REWRITE_DEBT_DRAIN_MAX_SEGMENTS`


### PR DESCRIPTION
## Objective

Bound best-effort periodic value-log rewrite planning so a scheduled/background maintenance tick cannot spend tens of seconds in `ValueLogRewritePlan -> collectValueLogLiveBytes` during geth/Sepolia restore/sync windows.

This is a follow-up to #2545: that PR guarded the checkpoint-kick fresh-planning path, while the latest Sepolia profile showed the periodic loop can still enter the same full live-byte scan after progress resets/stalls.

## Changes

- Add a short internal deadline for periodic/background fresh rewrite planning.
- Keep checkpoint-kick, deferred, and queued rewrite-debt planning on the existing wider contexts.
- Add rollback/diagnostic env knobs:
  - `TREEDB_DISABLE_VLOG_GENERATION_PERIODIC_REWRITE_PLAN_BUDGET=1`
  - `TREEDB_VLOG_GENERATION_PERIODIC_REWRITE_PLAN_BUDGET_MS=<ms>`
- Add scheduler tests for:
  - periodic plan contexts being budgeted while bypass/debt contexts remain wider;
  - long periodic fresh plans canceling instead of continuing unbounded.
- Update the generational value-log runbook.

## Evidence

Sepolia profile motivating this PR:

- Run: `/mnt/fast4tb/tmp/geth-treedb-exp/r_skelguard2_20260607T225629Z`
- 85m profile: `vlogGenerationLoop -> maybeRunPeriodicVlogGenerationMaintenance -> maybeRunVlogGenerationMaintenanceWithOptions -> ValueLogRewritePlan -> estimateValueLogLiveBytesBySegment -> collectValueLogLiveBytes`
- `collectValueLogLiveBytes`: `22.16s` / `43.55%` cumulative in the 30s CPU profile.

Validation:

```sh
go test ./TreeDB/caching -run 'TestVlogGenerationRewritePlanContext_BudgetsPeriodicFreshPlans|TestVlogGenerationMaintenance_PeriodicFreshPlanBudgetCancelsLongPlan' -count=1
go test ./TreeDB/caching -run 'TestVlogGeneration' -count=1
go test ./TreeDB/caching -count=1
```

All passed locally.

## Caveats

This mitigates the periodic rewrite-planning scan source. It does not claim full Sepolia readiness and does not resolve the remaining geth skeleton reset/missing-head behavior by itself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configuration options: `TREEDB_VLOG_GENERATION_PERIODIC_REWRITE_PLAN_BUDGET_MS` (customize rewrite-plan deadline in milliseconds) and `TREEDB_DISABLE_VLOG_GENERATION_PERIODIC_REWRITE_PLAN_BUDGET` (disable the budget).

* **Documentation**
  * Updated vlog generational runbook documenting periodic rewrite-plan budget behavior and new configuration knobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->