### PR TITLE
Document vector external comparison snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,24 @@ semantics match.
 Source:
 [June 4 fast Mongo/native client-shape matrix](docs/benchmarks/mongo_gateway_fast_client_matrix_2026-06-04.md).
 
+### Vector Search External Snapshot
+
+Local Apple M3 snapshot for `10k x 1536` vectors, `topK=10`, `M=16`,
+`efConstruction=128`, and `efSearch=128`. TreeDB rows use DB-demo no-document
+search; USearch is an in-memory library comparator; pgvector is a PostgreSQL
+server HNSW comparator.
+
+| system | recall@10 | c=1 avg / QPS | c=8 avg / QPS |
+| --- | ---: | ---: | ---: |
+| TreeDB exact FP32 | 0.9859 | 418 µs / 2,391 | 852 µs / 9,386 |
+| TreeDB scalar_u8 rerank32 | 0.9828 | 165 µs / 6,072 | 511 µs / 15,571 |
+| USearch f32 HNSW | 0.8938 | 725 µs / 1,380 | 160 µs / 6,259 |
+| PostgreSQL+pgvector HNSW | 0.9859 | 2.67 ms / 374 | 4.29 ms / 1,864 |
+
+USearch c=1/c=8 averages are from batch searches with `threads=1/8`, while
+TreeDB and pgvector report per-query latency samples. Source and caveats:
+[June 8 vector external comparison](docs/benchmarks/treedb_vector_external_compare_2026-06-08.md).
+
 ### `application.db` Offline Density Workload
 
 Offline compacted-size comparison from the June 2 Celestia `application.db`

--- a/TreeDB/README.md
+++ b/TreeDB/README.md
@@ -265,6 +265,22 @@ currently trips Go's cgo pointer checks on this toolchain; set
 `RUN_UNSAFE_USEARCH_FILTERED=true` only when you explicitly want that benchmark
 with `GODEBUG=cgocheck=0`.
 
+Recent `10k x 1536` external snapshot, using TreeDB DB-demo no-document search,
+USearch f32 HNSW, and PostgreSQL+pgvector HNSW with `M=16`,
+`efConstruction=128`, `efSearch=128`, and `topK=10`:
+
+| system | recall@10 | c=1 avg / QPS | c=8 avg / QPS |
+| --- | ---: | ---: | ---: |
+| TreeDB exact FP32 | 0.9859 | 418 µs / 2,391 | 852 µs / 9,386 |
+| TreeDB scalar_u8 rerank32 | 0.9828 | 165 µs / 6,072 | 511 µs / 15,571 |
+| USearch f32 HNSW | 0.8938 | 725 µs / 1,380 | 160 µs / 6,259 |
+| PostgreSQL+pgvector HNSW | 0.9859 | 2.67 ms / 374 | 4.29 ms / 1,864 |
+
+Full context, commands, guardrails, and caveats are in
+`../docs/benchmarks/treedb_vector_external_compare_2026-06-08.md`. The USearch
+row is an in-memory library comparator, not a persistent DB/server row, and its
+averages are from batch searches with `threads=1/8`.
+
 The tiny BERT embedding demo in `../examples/vector_search/tiny_bert/` is a
 caller-side fixture/demo; TreeDB core does not generate embeddings. Export it
 with `--output-jsonl` and set `TREEDB_VECTOR_BENCH_JSONL` to run

--- a/docs/benchmarks/treedb_vector_external_compare_2026-06-08.md
+++ b/docs/benchmarks/treedb_vector_external_compare_2026-06-08.md
@@ -1,0 +1,91 @@
+# TreeDB Vector External Comparison Snapshot (10k x 1536)
+
+This is a scoped local benchmark snapshot comparing TreeDB exact FP32,
+TreeDB scalar_u8 rerank32, USearch f32 HNSW, and PostgreSQL+pgvector HNSW on
+one synthetic `10k x 1536` vector-search shape.
+
+Treat these rows as same-host comparison evidence, not isolated public latency
+claims. The run used a local developer laptop with non-zero background load.
+
+## Context
+
+- Artifact root: `/tmp/gomap_exact_scalar_usearch_pgvector_20260607_160605`
+- Commit: `840bff52062e3b2c1c2818cde7d94efe3b9a45ce`
+- Host: Apple M3, 8 CPUs, macOS/Darwin arm64
+- Go: `go version go1.26.0 darwin/arm64`
+- Shape: `docs=10000`, `dims=1536`, `queries=10000`, `validate_queries=64`, `topK=10`
+- HNSW knobs: `M=16`, `efConstruction=128`, `efSearch=128`
+- TreeDB scalar rerank: `scalar_u8`, `quantized_rerank`, `rerank_candidates=32`
+- Benchmark lock: `/tmp/gomap_2556_benchmark.lock`
+- Load averages:
+  - DB/pgvector start: `3.38 2.87 2.37`
+  - DB/pgvector end: `5.90 3.82 2.81`
+  - USearch start: `3.72 3.58 2.80`
+  - USearch end: `4.23 3.72 2.88`
+
+## Search Results
+
+| system | recall@10 | c=1 avg / p95 / QPS | c=8 avg / p95 / QPS |
+| --- | ---: | ---: | ---: |
+| TreeDB exact FP32 | `0.9859` (`631/640`) | `418µs` / `562µs` / `2,391.1` | `852µs` / `1.77ms` / `9,386.0` |
+| TreeDB scalar_u8 rerank32 | `0.9828` (`629/640`) | `165µs` / `235µs` / `6,071.9` | `511µs` / `833µs` / `15,571.3` |
+| USearch f32 HNSW | `0.8938` (`572/640`) | `725µs` / `1.38ms`* / `1,380.0` | `160µs` / n/a / `6,258.8` |
+| PostgreSQL+pgvector HNSW | `0.9859` (`631/640`) | `2.67ms` / `5.08ms` / `373.9` | `4.29ms` / `8.25ms` / `1,864.2` |
+
+`*` USearch p95 is from per-query Python calls. USearch c=1/c=8 QPS and
+avg/query are from batch searches with `threads=1/8`, so the p95 row is not
+fully comparable to the batch QPS rows. USearch is an in-memory library HNSW
+comparator, not a persistent DB/server row.
+
+## Build / Storage Context
+
+| system | insert/load | index build | storage/index |
+| --- | ---: | ---: | ---: |
+| TreeDB exact FP32 | `5.106s` | `16.362s` | `126.87MiB` |
+| TreeDB scalar_u8 rerank32 | `5.025s` | `16.687s` | `141.91MiB` |
+| USearch f32 HNSW | n/a | `4.055s` | `60.01MiB` |
+| PostgreSQL+pgvector HNSW | `4.092s` | `12.298s` | `158.31MiB` |
+
+## TreeDB Guardrails
+
+TreeDB DB-demo rows used the no-document search boundary:
+
+- documents fetched: `0`
+- response-owned result allocations: `0`
+- route/fallback/scratch counters: `0`
+- scalar_u8 rerank exact score calls/search: `32`
+- scalar_u8 rerank vector bytes/search: `196,608`
+- scalar_u8 rerank norm bytes/search: `128`
+
+pgvector and USearch are full-vector HNSW comparators and do not expose TreeDB's
+quantized-route guardrail counters.
+
+## Commands
+
+TreeDB exact/scalar and pgvector used the DB comparator harness:
+
+```sh
+RUN_DIR=/tmp/gomap_exact_scalar_usearch_pgvector_20260607_160605 \
+BACKENDS=treedb_column_graph,treedb_column_graph_scalar_u8_quantized_rerank,pgvector \
+DOCS=10000 DIMS=1536 QUERIES=10000 VALIDATE_QUERIES=64 VALIDATE_DOCS=16 TOP_K=10 \
+SEARCH_CONCURRENCY=1,8 M=16 EF_CONSTRUCTION=128 EF_SEARCH=128 TREEDB_COLUMN_GRAPH_EF_SEARCH=128 \
+MIN_RECALL=0 TREEDB_QUANTIZED_MIN_RECALL=0 TREEDB_QUANTIZED_RERANK_MIN_RECALL=0 \
+TREEDB_QUANTIZED_RERANK_CANDIDATES=32 TREEDB_VALIDATION_EXACT_SOURCE=dataset \
+PGVECTOR_DOCKER=auto PGVECTOR_DROP_SCHEMA_AFTER=true PGVECTOR_ALLOW_DROP_SCHEMA=true \
+NUMPY_PACKAGE=numpy==2.3.5 \
+lockf /tmp/gomap_2556_benchmark.lock scripts/bench_vector_db_compare.sh
+```
+
+USearch used the same exported dataset from the DB comparator artifact, the
+Python `usearch` package, `metric=cos`, `dtype=f32`, `connectivity=16`,
+`expansion_add=128`, and `expansion_search=128`. Raw files in the artifact root:
+
+- `selected_summary.md`
+- `comparison.md`
+- `treedb_column_graph.json`
+- `treedb_column_graph_scalar_u8_quantized_rerank.json`
+- `pgvector.json`
+- `usearch.json`
+- `usearch_batch.json`
+- `usearch_dataset_bench.py`
+- `usearch_batch_probe.py`


### PR DESCRIPTION
## Summary

- Add the `10k x 1536` exact/scalar_u8 vs USearch/pgvector snapshot to the root README benchmark highlights.
- Add the same quick table to `TreeDB/README.md` near vector-search comparison guidance.
- Add a detailed benchmark report with commands, artifact paths, host/load caveats, TreeDB guardrails, and raw artifact filenames.

## Evidence / benchmark source

Artifact root: `/tmp/gomap_exact_scalar_usearch_pgvector_20260607_160605`

Shape: `docs=10000`, `dims=1536`, `queries=10000`, `validate_queries=64`, `topK=10`, `M=16`, `efConstruction=128`, `efSearch=128`.

| system | recall@10 | c=1 avg / QPS | c=8 avg / QPS |
| --- | ---: | ---: | ---: |
| TreeDB exact FP32 | `0.9859` | `418µs` / `2,391` | `852µs` / `9,386` |
| TreeDB scalar_u8 rerank32 | `0.9828` | `165µs` / `6,072` | `511µs` / `15,571` |
| USearch f32 HNSW | `0.8938` | `725µs` / `1,380` | `160µs` / `6,259` |
| PostgreSQL+pgvector HNSW | `0.9859` | `2.67ms` / `374` | `4.29ms` / `1,864` |

Caveats are documented in the new report, especially that USearch is an in-memory library comparator and its averages are from batch searches.

## Tests

- `git diff --cached --check`
- pre-commit `go-fmt` hook passed during commit

No Go test run; docs-only change.
