### PR TITLE
TreeDB document service keyword and hybrid search

### DIFF
--- a/TreeDB/collections/typed_storage_naming_test.go
+++ b/TreeDB/collections/typed_storage_naming_test.go
@@ -389,6 +389,8 @@ var typedStorageLegacyNameAllowlist = []typedStorageLegacyNameAllowlistEntry{
 	{path: "TreeDB/collections/dense_numeric_vector_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 35, occurrences: 38},
 	{path: "TreeDB/collections/document_materializer.go", classification: typedStorageLegacyCompatibility, matchingLines: 13, occurrences: 13},
 	{path: "TreeDB/collections/document_materializer_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 32, occurrences: 32},
+	{path: "TreeDB/documentservice/service.go", classification: typedStorageLegacyCompatibility, matchingLines: 5, occurrences: 7},
+	{path: "TreeDB/documentservice/service_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 1, occurrences: 2},
 	{path: "TreeDB/collections/document_projection.go", classification: typedStorageLegacyCompatibility, matchingLines: 3, occurrences: 3},
 	{path: "TreeDB/collections/hybrid_search_closeout_bench_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 2, occurrences: 2},
 	{path: "TreeDB/collections/hybrid_search_executor_test.go", classification: typedStorageLegacyCompatibility, matchingLines: 2, occurrences: 2},

--- a/TreeDB/documentservice/doc.go
+++ b/TreeDB/documentservice/doc.go
@@ -4,12 +4,13 @@
 // The package is the Go implementation seam for the HTTP/JSON API documented in
 // docs/TREEDB_DOCUMENT_SERVICE_API.md. It maps Haystack-style documents
 // (id/content/embedding/meta/score) onto TreeDB collections, supports exact
-// dense-vector scoring with metadata filters, and intentionally fails closed for
-// keyword and hybrid retrieval until TreeDB's ranked text/hybrid executors are
-// implemented.
+// dense-vector scoring with metadata filters, and serves keyword/hybrid retrieval
+// through collection-native SearchText/SearchHybrid APIs. Keyword/hybrid filters
+// and unavailable indexes fail closed; the service does not scan documents as a
+// fallback.
 //
 // The contract is pre-alpha: request/response schemas may change before TreeDB
 // stabilizes. Exact dense scoring here is the correctness/MVP service path for
-// Python and Haystack clients; it is not TreeDB's high-QPS column_graph ANN
-// serving path.
+// Python and Haystack clients; hybrid vector sources use TreeDB's declared
+// collection vector index and fail closed when it is unavailable.
 package documentservice

--- a/TreeDB/documentservice/http.go
+++ b/TreeDB/documentservice/http.go
@@ -158,9 +158,27 @@ func (h *Handler) serveSearchOperation(w http.ResponseWriter, r *http.Request, i
 		}
 		writeJSON(w, http.StatusOK, res)
 	case "keyword":
-		writeError(w, h.Service.SearchKeyword(r.Context(), index, nil))
+		var req KeywordSearchRequest
+		if !h.decodeJSON(w, r, maxBodyBytes, &req) {
+			return
+		}
+		res, err := h.Service.SearchKeyword(r.Context(), index, req)
+		if err != nil {
+			writeError(w, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, res)
 	case "hybrid":
-		writeError(w, h.Service.SearchHybrid(r.Context(), index, nil))
+		var req HybridSearchRequest
+		if !h.decodeJSON(w, r, maxBodyBytes, &req) {
+			return
+		}
+		res, err := h.Service.SearchHybrid(r.Context(), index, req)
+		if err != nil {
+			writeError(w, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, res)
 	default:
 		writeError(w, serviceErrorf(CodeInvalidRequest, "unknown search operation %q", op))
 	}

--- a/TreeDB/documentservice/http_test.go
+++ b/TreeDB/documentservice/http_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 )
 
-func TestHTTPMalformedJSONAndUnsupportedSearchFailClosed(t *testing.T) {
+func TestHTTPMalformedJSONKeywordHybridAndErrorPayloads(t *testing.T) {
 	svc, db := newTestService(t)
 	defer db.Close()
 	handler := NewHandler(svc)
@@ -22,18 +22,38 @@ func TestHTTPMalformedJSONAndUnsupportedSearchFailClosed(t *testing.T) {
 	}
 	assertHTTPErrorCode(t, rr.Body.Bytes(), CodeMalformedJSON)
 
-	if _, err := svc.CreateIndex(req.Context(), CreateIndexRequest{Name: "docs", Dimension: 2}); err != nil {
-		t.Fatalf("CreateIndex: %v", err)
+	postJSON(t, handler, "/v1/indexes", CreateIndexRequest{Name: "docs", Dimension: 2}, http.StatusOK, nil)
+	postJSON(t, handler, "/v1/indexes/docs/documents/upsert", UpsertDocumentsRequest{Documents: []Document{
+		{ID: "shared", Content: "refund refund", Embedding: []float32{1, 0}, Meta: map[string]any{"repo": "gomap"}},
+		{ID: "vector", Content: "shipping", Embedding: []float32{0.99, 0.01}, Meta: map[string]any{"repo": "gomap"}},
+	}}, http.StatusOK, nil)
+
+	var keyword KeywordSearchResponse
+	postJSON(t, handler, "/v1/indexes/docs/search/keyword", KeywordSearchRequest{Query: "refund", TopK: 1}, http.StatusOK, &keyword)
+	if len(keyword.Documents) != 1 || keyword.Documents[0].ID != "shared" || keyword.Documents[0].Score == nil {
+		t.Fatalf("keyword response=%+v", keyword)
 	}
-	for _, path := range []string{"/v1/indexes/docs/search/keyword", "/v1/indexes/docs/search/hybrid"} {
-		req := httptest.NewRequest(http.MethodPost, path, bytes.NewBufferString(`{"query":"refund"}`))
-		rr := httptest.NewRecorder()
-		handler.ServeHTTP(rr, req)
-		if rr.Code != http.StatusNotImplemented {
-			t.Fatalf("%s status=%d body=%s", path, rr.Code, rr.Body.String())
-		}
-		assertHTTPErrorCode(t, rr.Body.Bytes(), CodeUnsupported)
+
+	var hybrid HybridSearchResponse
+	postJSON(t, handler, "/v1/indexes/docs/search/hybrid", HybridSearchRequest{Query: "refund", QueryEmbedding: []float32{1, 0}, TopK: 2, EfSearch: 4}, http.StatusOK, &hybrid)
+	if len(hybrid.Documents) == 0 || hybrid.Documents[0].ID != "shared" || hybrid.Documents[0].Score == nil {
+		t.Fatalf("hybrid response=%+v", hybrid)
 	}
+
+	req = httptest.NewRequest(http.MethodPost, "/v1/indexes/docs/search/keyword", bytes.NewBufferString(`{"query":"refund","top_k":1,"filter":{"field":"meta.repo","operator":"==","value":"gomap"}}`))
+	rr = httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	if rr.Code != http.StatusNotImplemented {
+		t.Fatalf("keyword filter status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	assertHTTPErrorCode(t, rr.Body.Bytes(), CodeUnsupported)
+	req = httptest.NewRequest(http.MethodPost, "/v1/indexes/docs/search/hybrid", bytes.NewBufferString(`{"query":"refund","top_k":1,"filter":{"field":"meta.repo","operator":"==","value":"gomap"}}`))
+	rr = httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	if rr.Code != http.StatusNotImplemented {
+		t.Fatalf("hybrid filter status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	assertHTTPErrorCode(t, rr.Body.Bytes(), CodeUnsupported)
 }
 
 func TestHTTPDefaultMaxBodyBytesDoesNotMutateHandler(t *testing.T) {

--- a/TreeDB/documentservice/service.go
+++ b/TreeDB/documentservice/service.go
@@ -50,18 +50,29 @@ func (s *Service) CreateIndex(ctx context.Context, req CreateIndexRequest) (Inde
 	if err != nil {
 		return IndexInfo{}, err
 	}
+	options := collections.CollectionOptions{DocumentFormat: collections.DocumentFormatJSON}
+	vectorStrategy := collections.VectorIndexStrategyNativeRuntime
+	if metric == MetricCosine {
+		options.ColumnStore = serviceColumnStoreConfig(req.Dimension)
+		vectorStrategy = collections.VectorIndexStrategyColumnGraph
+	}
 	meta := &collections.CollectionMeta{
-		Name: req.Name,
-		Options: collections.CollectionOptions{
-			DocumentFormat: collections.DocumentFormatJSON,
-		},
+		Name:    req.Name,
+		Options: options,
 		VectorIndexes: []collections.VectorIndexDefinition{{
 			Name:             defaultVectorIndexName,
 			Field:            defaultEmbeddingField,
 			Metric:           collectionMetric,
 			Dimensions:       req.Dimension,
 			Encoding:         collections.VectorIndexEncodingFloat32,
-			Strategy:         collections.VectorIndexStrategyNativeRuntime,
+			Strategy:         vectorStrategy,
+			SchemaGeneration: 1,
+		}},
+		TextIndexes: []collections.TextIndexDefinition{{
+			Name:             defaultTextIndexName,
+			Fields:           []collections.TextIndexField{{Field: defaultTextField}},
+			Analyzer:         collections.TextAnalyzerSimple,
+			StorePositions:   true,
 			SchemaGeneration: 1,
 		}},
 	}
@@ -156,6 +167,11 @@ func (s *Service) UpsertDocuments(ctx context.Context, index string, req UpsertD
 		}
 		if wasUpdated {
 			updated++
+		}
+	}
+	if inserted > 0 && updated == 0 {
+		if err := rebuildServiceVectorIndex(ctx, col); err != nil {
+			return UpsertDocumentsResponse{}, err
 		}
 	}
 	return UpsertDocumentsResponse{Index: info, Upserted: len(prepared), Inserted: inserted, Updated: updated, IDs: ids}, nil
@@ -329,14 +345,125 @@ func (s *Service) SearchDenseVector(ctx context.Context, index string, req Dense
 	return DenseVectorSearchResponse{Index: info, Documents: docs, Metric: info.Metric, Exact: true, Candidates: candidateCount}, nil
 }
 
-// SearchKeyword intentionally fails closed until TreeDB ranked text execution is implemented.
-func (s *Service) SearchKeyword(context.Context, string, json.RawMessage) error {
-	return serviceError(CodeUnsupported, "keyword search is not implemented; TreeDB text search currently fails closed and the service does not scan documents as a fallback")
+// SearchKeyword runs ranked lexical search over the service content text index.
+func (s *Service) SearchKeyword(ctx context.Context, index string, req KeywordSearchRequest) (KeywordSearchResponse, error) {
+	col, info, err := s.openIndex(ctx, index, req.ExpectedGeneration)
+	if err != nil {
+		return KeywordSearchResponse{}, err
+	}
+	if req.TopK <= 0 {
+		return KeywordSearchResponse{}, serviceError(CodeInvalidRequest, "top_k must be positive")
+	}
+	operator, err := normalizeKeywordSearchOperator(req.Operator)
+	if err != nil {
+		return KeywordSearchResponse{}, err
+	}
+	if req.CandidateLimit < 0 || req.MaxPostingsScanned < 0 {
+		return KeywordSearchResponse{}, serviceError(CodeInvalidRequest, "candidate_limit and max_postings_scanned must be non-negative")
+	}
+	if req.Filter != nil {
+		if err := req.Filter.Validate(); err != nil {
+			return KeywordSearchResponse{}, err
+		}
+		return KeywordSearchResponse{}, serviceError(CodeUnsupported, "metadata filters are not supported for keyword search yet; the service will not scan documents as a fallback")
+	}
+
+	textResponse, err := col.SearchText(collections.TextSearchOptions{
+		IndexName:            defaultTextIndexName,
+		Query:                req.Query,
+		Operator:             operator,
+		TopK:                 req.TopK,
+		CandidateLimit:       req.CandidateLimit,
+		MaxPostingsScanned:   req.MaxPostingsScanned,
+		IncludeDocuments:     true,
+		DocumentFetchOptions: serviceDocumentFetchOptions(req.ReturnEmbedding),
+	})
+	response := KeywordSearchResponse{Index: info, TextIndex: defaultTextIndexName, Stats: keywordStatsFromCollection(textResponse.Stats)}
+	if err != nil {
+		return response, mapKeywordSearchError(err)
+	}
+	docs, err := documentsFromTextSearchResults(textResponse.Results, req.ReturnEmbedding)
+	if err != nil {
+		return response, err
+	}
+	response.Documents = docs
+	return response, nil
 }
 
-// SearchHybrid intentionally fails closed until TreeDB hybrid execution is implemented.
-func (s *Service) SearchHybrid(context.Context, string, json.RawMessage) error {
-	return serviceError(CodeUnsupported, "hybrid search is not implemented; the service does not run text/hybrid document-scan fallbacks")
+// SearchHybrid runs collection-native hybrid retrieval with text and/or vector sources.
+func (s *Service) SearchHybrid(ctx context.Context, index string, req HybridSearchRequest) (HybridSearchResponse, error) {
+	col, info, err := s.openIndex(ctx, index, req.ExpectedGeneration)
+	if err != nil {
+		return HybridSearchResponse{}, err
+	}
+	if req.TopK <= 0 {
+		return HybridSearchResponse{}, serviceError(CodeInvalidRequest, "top_k must be positive")
+	}
+	if !info.Capabilities.HybridSearch {
+		return HybridSearchResponse{}, serviceError(CodeIndexUnavailable, "hybrid search requires a cosine column_graph vector index and content text index")
+	}
+	if req.CandidateLimit < 0 || req.TextCandidateLimit < 0 || req.VectorCandidateLimit < 0 || req.EfSearch < 0 {
+		return HybridSearchResponse{}, serviceError(CodeInvalidRequest, "candidate limits and ef_search must be non-negative")
+	}
+	if req.Filter != nil {
+		if err := req.Filter.Validate(); err != nil {
+			return HybridSearchResponse{}, err
+		}
+		return HybridSearchResponse{}, serviceError(CodeUnsupported, "metadata filters are not supported for hybrid search yet; the service will not scan documents as a fallback")
+	}
+
+	hasText := strings.TrimSpace(req.Query) != ""
+	hasVector := len(req.QueryEmbedding) > 0
+	if !hasText && !hasVector {
+		return HybridSearchResponse{}, serviceError(CodeInvalidRequest, "hybrid search requires query, query_embedding, or both")
+	}
+
+	opts := collections.HybridSearchOptions{
+		TopK:                 req.TopK,
+		Fusion:               req.Fusion,
+		IncludeDocuments:     true,
+		DocumentFetchOptions: serviceDocumentFetchOptions(req.ReturnEmbedding),
+	}
+	response := HybridSearchResponse{Index: info}
+	if hasText {
+		limit := req.TextCandidateLimit
+		if limit == 0 {
+			limit = req.CandidateLimit
+		}
+		opts.Text = &collections.HybridTextQuery{IndexName: defaultTextIndexName, Query: req.Query, CandidateLimit: limit}
+		response.TextIndex = defaultTextIndexName
+	}
+	if hasVector {
+		if err := validateEmbedding("query_embedding", req.QueryEmbedding, info.Dimension, info.Metric); err != nil {
+			return HybridSearchResponse{}, err
+		}
+		limit := req.VectorCandidateLimit
+		if limit == 0 {
+			limit = req.CandidateLimit
+		}
+		opts.Vector = &collections.HybridVectorQuery{
+			IndexName:      defaultVectorIndexName,
+			Query:          append([]float32(nil), req.QueryEmbedding...),
+			CandidateLimit: limit,
+			EfSearch:       req.EfSearch,
+			QueryMode:      collections.VectorIndexQueryModeExact,
+		}
+		response.VectorIndex = defaultVectorIndexName
+	}
+
+	hybridResponse, err := col.SearchHybrid(opts)
+	response.Plan = hybridResponse.Plan
+	response.Snapshot = hybridResponse.Snapshot
+	response.Stats = hybridResponse.Stats
+	if err != nil {
+		return response, mapHybridSearchError(err)
+	}
+	docs, err := documentsFromHybridSearchResults(hybridResponse.Results, hybridResponse.Plan, req.ReturnEmbedding)
+	if err != nil {
+		return response, err
+	}
+	response.Documents = docs
+	return response, nil
 }
 
 func (s *Service) openIndex(ctx context.Context, name string, expectedGeneration uint64) (*collections.Collection, IndexInfo, error) {
@@ -371,42 +498,97 @@ func indexInfoFromMeta(meta collections.CollectionMeta) (IndexInfo, error) {
 	if format != collections.DocumentFormatJSON {
 		return IndexInfo{}, serviceErrorf(CodeIndexUnavailable, "collection %q is not a document service JSON index", meta.Name)
 	}
-	var def collections.VectorIndexDefinition
-	found := false
-	for _, candidate := range meta.VectorIndexes {
-		if candidate.Name == defaultVectorIndexName || candidate.Field == defaultEmbeddingField {
-			def = candidate
-			found = true
-			break
-		}
-	}
-	if !found {
-		return IndexInfo{}, serviceErrorf(CodeIndexUnavailable, "collection %q does not expose the service embedding index", meta.Name)
-	}
-	if def.Field != defaultEmbeddingField {
-		return IndexInfo{}, serviceErrorf(CodeIndexUnavailable, "collection %q uses unsupported embedding field %q", meta.Name, def.Field)
-	}
-	if def.Dimensions <= 0 {
-		return IndexInfo{}, serviceErrorf(CodeIndexUnavailable, "collection %q has invalid embedding dimensions", meta.Name)
-	}
-	metric, err := metricFromCollection(def.Metric)
+	vectorDef, err := serviceVectorIndexDefinition(meta)
 	if err != nil {
 		return IndexInfo{}, err
 	}
-	generation := def.SchemaGeneration
+	textDef, err := serviceTextIndexDefinition(meta)
+	if err != nil {
+		return IndexInfo{}, err
+	}
+	metric, err := metricFromCollection(vectorDef.Metric)
+	if err != nil {
+		return IndexInfo{}, err
+	}
+	generation := vectorDef.SchemaGeneration
+	if textDef.SchemaGeneration > generation {
+		generation = textDef.SchemaGeneration
+	}
 	if generation == 0 {
 		generation = 1
 	}
+	hybridSearch := vectorDef.Strategy == collections.VectorIndexStrategyColumnGraph && vectorDef.Metric == collections.VectorMetricCosine && vectorDef.Encoding == collections.VectorIndexEncodingFloat32
 	return IndexInfo{
 		Name:            meta.Name,
-		Dimension:       def.Dimensions,
+		Dimension:       vectorDef.Dimensions,
 		Metric:          metric,
 		Generation:      generation,
 		ContractVersion: ContractVersion,
 		EmbeddingField:  defaultEmbeddingField,
+		VectorIndexName: vectorDef.Name,
+		TextField:       defaultTextField,
+		TextIndexName:   textDef.Name,
 		DocumentType:    defaultCollectionDocType,
-		Capabilities:    indexCapabilities(),
+		Capabilities:    indexCapabilities(hybridSearch),
 	}, nil
+}
+
+func serviceVectorIndexDefinition(meta collections.CollectionMeta) (collections.VectorIndexDefinition, error) {
+	for _, candidate := range meta.VectorIndexes {
+		if candidate.Name == defaultVectorIndexName {
+			if candidate.Field != defaultEmbeddingField {
+				return collections.VectorIndexDefinition{}, serviceErrorf(CodeIndexUnavailable, "collection %q uses unsupported embedding field %q", meta.Name, candidate.Field)
+			}
+			if candidate.Dimensions <= 0 {
+				return collections.VectorIndexDefinition{}, serviceErrorf(CodeIndexUnavailable, "collection %q has invalid embedding dimensions", meta.Name)
+			}
+			if candidate.Encoding != collections.VectorIndexEncodingFloat32 {
+				return collections.VectorIndexDefinition{}, serviceErrorf(CodeIndexUnavailable, "collection %q uses unsupported vector index encoding %s", meta.Name, candidate.Encoding.String())
+			}
+			if candidate.Strategy != collections.VectorIndexStrategyNativeRuntime && candidate.Strategy != collections.VectorIndexStrategyColumnGraph {
+				return collections.VectorIndexDefinition{}, serviceErrorf(CodeIndexUnavailable, "collection %q uses unsupported vector index strategy %q", meta.Name, candidate.Strategy)
+			}
+			return candidate, nil
+		}
+	}
+	return collections.VectorIndexDefinition{}, serviceErrorf(CodeIndexUnavailable, "collection %q does not expose the service vector index %q", meta.Name, defaultVectorIndexName)
+}
+
+func serviceTextIndexDefinition(meta collections.CollectionMeta) (collections.TextIndexDefinition, error) {
+	for _, candidate := range meta.TextIndexes {
+		if candidate.Name != defaultTextIndexName {
+			continue
+		}
+		if candidate.Analyzer != collections.TextAnalyzerSimple {
+			return collections.TextIndexDefinition{}, serviceErrorf(CodeIndexUnavailable, "collection %q text index %q uses unsupported analyzer %q", meta.Name, defaultTextIndexName, candidate.Analyzer)
+		}
+		if len(candidate.Fields) != 1 || candidate.Fields[0].Field != defaultTextField {
+			return collections.TextIndexDefinition{}, serviceErrorf(CodeIndexUnavailable, "collection %q text index %q must cover only field %q", meta.Name, defaultTextIndexName, defaultTextField)
+		}
+		if candidate.Fields[0].Weight != 1 {
+			return collections.TextIndexDefinition{}, serviceErrorf(CodeIndexUnavailable, "collection %q text index %q uses unsupported content weight %g", meta.Name, defaultTextIndexName, candidate.Fields[0].Weight)
+		}
+		if !candidate.StorePositions || candidate.StoreOffsets {
+			return collections.TextIndexDefinition{}, serviceErrorf(CodeIndexUnavailable, "collection %q text index %q uses unsupported position/offset storage", meta.Name, defaultTextIndexName)
+		}
+		return candidate, nil
+	}
+	return collections.TextIndexDefinition{}, serviceErrorf(CodeIndexUnavailable, "collection %q does not expose the service text index %q", meta.Name, defaultTextIndexName)
+}
+
+func serviceColumnStoreConfig(dimension int) *collections.ColumnStoreConfig {
+	return &collections.ColumnStoreConfig{
+		Enabled: true,
+		Columns: []collections.ColumnStoreColumn{{
+			Name:       defaultEmbeddingField,
+			Path:       defaultEmbeddingField,
+			Owner:      collections.TypedStorageOwnerColumnPart,
+			ValueType:  collections.ColumnStoreValueFloat32Vector,
+			VectorDims: dimension,
+		}},
+		RetainedPayload:         collections.ColumnRetainedPayloadFull,
+		RetainedPayloadEncoding: collections.ColumnRetainedPayloadEncodingJSON,
+	}
 }
 
 type preparedDocument struct {
@@ -619,6 +801,256 @@ func scoreEmbedding(query, document []float32, metric Metric) (float64, error) {
 type scoredDocument struct {
 	document Document
 	score    float64
+}
+
+func serviceDocumentFetchOptions(returnEmbedding bool) collections.DocumentFetchOptions {
+	opts := collections.DocumentFetchOptions{Format: collections.DocumentFormatJSON}
+	if !returnEmbedding {
+		opts.ExcludePaths = []string{defaultEmbeddingField}
+	}
+	return opts
+}
+
+func normalizeKeywordSearchOperator(op collections.TextSearchOperator) (collections.TextSearchOperator, error) {
+	switch strings.TrimSpace(strings.ToLower(string(op))) {
+	case "", string(collections.TextSearchOperatorOR):
+		return collections.TextSearchOperatorOR, nil
+	case string(collections.TextSearchOperatorAND):
+		return collections.TextSearchOperatorAND, nil
+	default:
+		return "", serviceErrorf(CodeInvalidRequest, "unsupported keyword operator %q", op)
+	}
+}
+
+func keywordStatsFromCollection(stats collections.TextSearchStats) KeywordSearchStats {
+	return KeywordSearchStats{
+		QueryTerms:                stats.QueryTerms,
+		CandidatesRequested:       stats.TextCandidatesRequested,
+		CandidatesReturned:        stats.TextCandidatesReturned,
+		PostingsScanned:           maxUint64(stats.TextPostingsScanned, stats.PostingsScanned),
+		CandidatesScored:          maxUint64(stats.TextCandidatesScored, stats.CandidatesScored),
+		DocumentsFetched:          stats.DocumentsFetched,
+		DocumentsMissing:          stats.DocumentsMissing,
+		FullDocumentScanFallbacks: stats.FullDocumentScanFallbacks,
+		PostingsScanNanos:         stats.PostingsScanNanos,
+		CandidateScoreNanos:       stats.CandidateScoreNanos,
+		DocumentFetchNanos:        stats.DocumentFetchNanos,
+		Truncated:                 stats.Truncated,
+		FailClosed:                stats.FailClosed,
+		FailClosedReason:          stats.FailClosedReason,
+		Unavailable:               stats.Unavailable,
+		UnavailableReason:         stats.UnavailableReason,
+	}
+}
+
+func documentsFromTextSearchResults(results []collections.TextSearchResult, returnEmbedding bool) ([]Document, error) {
+	docs := make([]Document, 0, len(results))
+	for _, result := range results {
+		if len(result.Document) == 0 {
+			return nil, serviceErrorf(CodeIndexUnavailable, "keyword result document %q was not fetched", string(result.DocumentID))
+		}
+		doc, err := decodeStoredDocument(result.DocumentID, result.Document)
+		if err != nil {
+			return nil, err
+		}
+		if !returnEmbedding {
+			doc.Embedding = nil
+		}
+		doc.Score = scorePtr(result.Score)
+		attachSearchMeta(&doc, keywordSearchMeta(result))
+		docs = append(docs, doc)
+	}
+	if docs == nil {
+		docs = []Document{}
+	}
+	return docs, nil
+}
+
+func documentsFromHybridSearchResults(results []collections.HybridSearchResult, plan collections.HybridSearchPlan, returnEmbedding bool) ([]Document, error) {
+	docs := make([]Document, 0, len(results))
+	for _, result := range results {
+		if !result.DocumentFound || len(result.Document) == 0 {
+			return nil, serviceErrorf(CodeIndexUnavailable, "hybrid result document %q was not fetched", string(result.ID))
+		}
+		doc, err := decodeStoredDocument(result.ID, result.Document)
+		if err != nil {
+			return nil, err
+		}
+		if !returnEmbedding {
+			doc.Embedding = nil
+		}
+		doc.Score = scorePtr(result.FusedScore)
+		attachSearchMeta(&doc, hybridSearchMeta(result, plan))
+		docs = append(docs, doc)
+	}
+	if docs == nil {
+		docs = []Document{}
+	}
+	return docs, nil
+}
+
+func keywordSearchMeta(result collections.TextSearchResult) map[string]any {
+	meta := map[string]any{
+		"type":           "keyword",
+		"text_index":     result.IndexName,
+		"rank":           result.Rank,
+		"score_kind":     string(result.ScoreKind),
+		"matched_terms":  append([]string(nil), result.MatchedTerms...),
+		"matched_fields": append([]string(nil), result.MatchedFields...),
+	}
+	if len(result.TextMatches) > 0 {
+		meta["text_matches"] = textSearchMatchesMeta(result.TextMatches)
+	}
+	return meta
+}
+
+func hybridSearchMeta(result collections.HybridSearchResult, plan collections.HybridSearchPlan) map[string]any {
+	meta := map[string]any{
+		"type":              "hybrid",
+		"rank":              result.Rank,
+		"fusion_method":     string(plan.FusionMethod),
+		"fusion_tie_policy": string(plan.FusionTiePolicy),
+		"fused_score":       result.FusedScore,
+	}
+	if len(result.Sources) > 0 {
+		sources := make([]map[string]any, len(result.Sources))
+		for i, source := range result.Sources {
+			sourceMeta := map[string]any{
+				"source":       string(source.Source),
+				"index_name":   source.IndexName,
+				"source_rank":  source.SourceRank,
+				"score":        source.Score,
+				"score_kind":   string(source.ScoreKind),
+				"fusion_score": source.FusionScore,
+			}
+			if len(source.TextMatches) > 0 {
+				sourceMeta["text_matches"] = hybridTextMatchesMeta(source.TextMatches)
+			}
+			sources[i] = sourceMeta
+		}
+		meta["sources"] = sources
+	}
+	return meta
+}
+
+func textSearchMatchesMeta(matches []collections.TextSearchMatch) []map[string]any {
+	out := make([]map[string]any, len(matches))
+	for i, match := range matches {
+		out[i] = map[string]any{"field": match.Field, "terms": append([]string(nil), match.Terms...)}
+	}
+	return out
+}
+
+func hybridTextMatchesMeta(matches []collections.HybridTextMatch) []map[string]any {
+	out := make([]map[string]any, len(matches))
+	for i, match := range matches {
+		out[i] = map[string]any{"field": match.Field, "terms": append([]string(nil), match.Terms...)}
+	}
+	return out
+}
+
+func attachSearchMeta(doc *Document, meta map[string]any) {
+	if doc.Meta == nil {
+		doc.Meta = map[string]any{}
+	}
+	doc.Meta[searchMetaKey] = meta
+}
+
+func rebuildServiceVectorIndex(ctx context.Context, col *collections.Collection) error {
+	if err := ctxErr(ctx); err != nil {
+		return err
+	}
+	if col == nil {
+		return serviceError(CodeIndexUnavailable, "index collection is unavailable")
+	}
+	def, err := serviceVectorIndexDefinition(col.Meta())
+	if err != nil {
+		return err
+	}
+	if def.Strategy != collections.VectorIndexStrategyColumnGraph {
+		return nil
+	}
+	if _, err := col.RebuildVectorIndex(defaultVectorIndexName); err != nil {
+		if serviceVectorRebuildUnsupportedAfterMutation(err) {
+			// Column-graph vector rebuild is currently insert-only for this row-ref
+			// state. Preserve write/upsert semantics and let subsequent hybrid vector
+			// searches fail closed as stale/unavailable instead of scanning.
+			return nil
+		}
+		return mapCollectionMaintenanceError("rebuild service vector index", err)
+	}
+	return nil
+}
+
+func serviceVectorRebuildUnsupportedAfterMutation(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "requires insert-only base physical refs")
+}
+
+func mapKeywordSearchError(err error) error {
+	if err == nil {
+		return nil
+	}
+	var serviceErr *Error
+	if errors.As(err, &serviceErr) {
+		return err
+	}
+	if errors.Is(err, collections.ErrTextIndexUnavailable) || errors.Is(err, collections.ErrIndexNotFound) {
+		return wrapServiceError(CodeIndexUnavailable, "keyword text index is unavailable", err)
+	}
+	if errors.Is(err, backenddb.ErrClosed) {
+		return wrapServiceError(CodeIndexUnavailable, "TreeDB backend is closed", err)
+	}
+	return wrapServiceError(CodeInvalidRequest, "keyword search request is invalid or unsupported", err)
+}
+
+func mapHybridSearchError(err error) error {
+	if err == nil {
+		return nil
+	}
+	var serviceErr *Error
+	if errors.As(err, &serviceErr) {
+		return err
+	}
+	if errors.Is(err, collections.ErrHybridSearchStaleIndex) {
+		return wrapServiceError(CodeIndexStale, "hybrid search index snapshot is stale", err)
+	}
+	if errors.Is(err, collections.ErrHybridSearchIndexUnavailable) || errors.Is(err, collections.ErrIndexNotFound) {
+		return wrapServiceError(CodeIndexUnavailable, "hybrid search index is unavailable", err)
+	}
+	if errors.Is(err, collections.ErrHybridSearchUnsupported) {
+		return wrapServiceError(CodeUnsupported, "hybrid search request is unsupported", err)
+	}
+	if errors.Is(err, backenddb.ErrClosed) {
+		return wrapServiceError(CodeIndexUnavailable, "TreeDB backend is closed", err)
+	}
+	return wrapServiceError(CodeInternal, "hybrid search failed", err)
+}
+
+func mapCollectionMaintenanceError(operation string, err error) error {
+	if err == nil {
+		return nil
+	}
+	var serviceErr *Error
+	if errors.As(err, &serviceErr) {
+		return err
+	}
+	if errors.Is(err, collections.ErrIndexNotFound) || errors.Is(err, collections.ErrHybridSearchIndexUnavailable) {
+		return wrapServiceError(CodeIndexUnavailable, operation+" failed", err)
+	}
+	if errors.Is(err, backenddb.ErrClosed) {
+		return wrapServiceError(CodeIndexUnavailable, "TreeDB backend is closed", err)
+	}
+	return wrapServiceError(CodeInternal, operation+" failed", err)
+}
+
+func maxUint64(values ...uint64) uint64 {
+	var max uint64
+	for _, value := range values {
+		if value > max {
+			max = value
+		}
+	}
+	return max
 }
 
 func cloneMeta(in map[string]any) map[string]any {

--- a/TreeDB/documentservice/service_test.go
+++ b/TreeDB/documentservice/service_test.go
@@ -311,10 +311,254 @@ func TestServiceDenseVectorSearchStableIDsScoresMetadataAndEmbeddingEcho(t *test
 	}
 }
 
+func TestServiceKeywordSearchRankedLexicalResultsAndTieOrder(t *testing.T) {
+	svc, db := newTestService(t)
+	defer db.Close()
+	ctx := context.Background()
+	info, err := svc.CreateIndex(ctx, CreateIndexRequest{Name: "docs", Dimension: 2})
+	if err != nil {
+		t.Fatalf("CreateIndex: %v", err)
+	}
+	if !info.Capabilities.KeywordSearch || !info.Capabilities.HybridSearch || info.TextIndexName != defaultTextIndexName || info.VectorIndexName != defaultVectorIndexName || info.Capabilities.KeywordMetadataFilters || info.Capabilities.HybridMetadataFilters {
+		t.Fatalf("index capabilities/info=%+v", info)
+	}
+	_, err = svc.UpsertDocuments(ctx, "docs", UpsertDocumentsRequest{Documents: []Document{
+		{ID: "doc-best", Content: "refund refund refund policy", Embedding: []float32{1, 0}, Meta: map[string]any{"repo": "gomap", "path": "best.go"}},
+		{ID: "doc-ok", Content: "refund shipping", Embedding: []float32{0, 1}, Meta: map[string]any{"repo": "gomap", "path": "ok.go"}},
+		{ID: "doc-other", Content: "shipping update", Embedding: []float32{0.5, 0.5}, Meta: map[string]any{"repo": "other"}},
+		{ID: "tie-a", Content: "tie term", Embedding: []float32{1, 1}},
+		{ID: "tie-b", Content: "tie term", Embedding: []float32{1, -1}},
+	}})
+	if err != nil {
+		t.Fatalf("UpsertDocuments: %v", err)
+	}
+	res, err := svc.SearchKeyword(ctx, "docs", KeywordSearchRequest{Query: "refund", TopK: 2})
+	if err != nil {
+		t.Fatalf("SearchKeyword: %v", err)
+	}
+	if len(res.Documents) != 2 || res.Documents[0].ID != "doc-best" || res.Documents[1].ID != "doc-ok" {
+		t.Fatalf("keyword ids=%v want doc-best/doc-ok response=%+v", documentIDs(res.Documents), res)
+	}
+	if res.Documents[0].Score == nil || res.Documents[1].Score == nil || *res.Documents[0].Score <= *res.Documents[1].Score {
+		t.Fatalf("keyword scores=%v %v want ranked lexical scores", res.Documents[0].Score, res.Documents[1].Score)
+	}
+	if res.Documents[0].Embedding != nil || res.Documents[0].Meta["path"] != "best.go" {
+		t.Fatalf("keyword document mapping=%+v", res.Documents[0])
+	}
+	meta := searchMeta(t, res.Documents[0])
+	if meta["type"] != "keyword" || meta["text_index"] != defaultTextIndexName || meta["rank"] != 1 {
+		t.Fatalf("keyword explanation meta=%+v", meta)
+	}
+	if res.Stats.CandidatesReturned != 2 || res.Stats.PostingsScanned == 0 || res.Stats.FullDocumentScanFallbacks != 0 || res.Stats.FailClosed != 0 {
+		t.Fatalf("keyword stats=%+v", res.Stats)
+	}
+
+	ties, err := svc.SearchKeyword(ctx, "docs", KeywordSearchRequest{Query: "tie", TopK: 2})
+	if err != nil {
+		t.Fatalf("SearchKeyword ties: %v", err)
+	}
+	if got := documentIDs(ties.Documents); !reflect.DeepEqual(got, []string{"tie-a", "tie-b"}) {
+		t.Fatalf("tie ids=%v want stable ID order", got)
+	}
+	if limited, err := svc.SearchKeyword(ctx, "docs", KeywordSearchRequest{Query: "refund", TopK: 2, CandidateLimit: 1}); ErrorCodeOf(err) != CodeIndexUnavailable || limited.Stats.FailClosed == 0 {
+		t.Fatalf("keyword candidate-limit response=%+v err=%v code=%s", limited, err, ErrorCodeOf(err))
+	}
+}
+
+func TestServiceHybridSearchTextVectorAndOverlap(t *testing.T) {
+	svc, db := newTestService(t)
+	defer db.Close()
+	ctx := context.Background()
+	if _, err := svc.CreateIndex(ctx, CreateIndexRequest{Name: "docs", Dimension: 2}); err != nil {
+		t.Fatalf("CreateIndex: %v", err)
+	}
+	_, err := svc.UpsertDocuments(ctx, "docs", UpsertDocumentsRequest{Documents: []Document{
+		{ID: "shared", Content: "refund refund", Embedding: []float32{1, 0}, Meta: map[string]any{"kind": "shared"}},
+		{ID: "text", Content: "refund policy", Embedding: []float32{0, 1}, Meta: map[string]any{"kind": "text"}},
+		{ID: "vector", Content: "shipping update", Embedding: []float32{0.99, 0.01}, Meta: map[string]any{"kind": "vector"}},
+		{ID: "background", Content: "other", Embedding: []float32{0, 1}, Meta: map[string]any{"kind": "background"}},
+	}})
+	if err != nil {
+		t.Fatalf("UpsertDocuments: %v", err)
+	}
+
+	textOnly, err := svc.SearchHybrid(ctx, "docs", HybridSearchRequest{Query: "refund", TopK: 2, TextCandidateLimit: 3})
+	if err != nil {
+		t.Fatalf("SearchHybrid text-only: %v", err)
+	}
+	if len(textOnly.Documents) != 2 || textOnly.Stats.VectorCandidatesReturned != 0 {
+		t.Fatalf("text-only response=%+v stats=%+v", textOnly, textOnly.Stats)
+	}
+	if !searchMetaHasOnlySource(t, textOnly.Documents[0], "text") {
+		t.Fatalf("text-only meta=%+v", searchMeta(t, textOnly.Documents[0]))
+	}
+
+	vectorOnly, err := svc.SearchHybrid(ctx, "docs", HybridSearchRequest{QueryEmbedding: []float32{1, 0}, TopK: 2, VectorCandidateLimit: 3, EfSearch: 8})
+	if err != nil {
+		t.Fatalf("SearchHybrid vector-only: %v", err)
+	}
+	if len(vectorOnly.Documents) != 2 || vectorOnly.Documents[0].ID != "shared" || vectorOnly.Stats.TextCandidatesReturned != 0 || vectorOnly.Stats.VectorCandidatesReturned == 0 {
+		t.Fatalf("vector-only response=%+v stats=%+v", vectorOnly, vectorOnly.Stats)
+	}
+	if !searchMetaHasOnlySource(t, vectorOnly.Documents[0], "vector") {
+		t.Fatalf("vector-only meta=%+v", searchMeta(t, vectorOnly.Documents[0]))
+	}
+
+	overlap, err := svc.SearchHybrid(ctx, "docs", HybridSearchRequest{Query: "refund", QueryEmbedding: []float32{1, 0}, TopK: 3, TextCandidateLimit: 3, VectorCandidateLimit: 3, EfSearch: 8})
+	if err != nil {
+		t.Fatalf("SearchHybrid overlap: %v", err)
+	}
+	if len(overlap.Documents) != 3 || overlap.Documents[0].ID != "shared" || overlap.Documents[0].Score == nil {
+		t.Fatalf("overlap response=%+v", overlap)
+	}
+	meta := searchMeta(t, overlap.Documents[0])
+	if meta["type"] != "hybrid" || meta["fusion_method"] != string(collections.HybridFusionMethodRRF) || !searchMetaHasSources(meta, "text", "vector") {
+		t.Fatalf("overlap explanation meta=%+v", meta)
+	}
+	if overlap.Stats.FusionBoth == 0 || overlap.Stats.FullDocumentScanFallbacks != 0 || overlap.Stats.FailClosed != 0 || overlap.Plan.FusionMethod != collections.HybridFusionMethodRRF {
+		t.Fatalf("overlap stats=%+v plan=%+v", overlap.Stats, overlap.Plan)
+	}
+}
+
+func TestServiceKeywordHybridFiltersAndMissingIndexesFailClosed(t *testing.T) {
+	svc, db := newTestService(t)
+	defer db.Close()
+	ctx := context.Background()
+	if _, err := svc.CreateIndex(ctx, CreateIndexRequest{Name: "docs", Dimension: 2}); err != nil {
+		t.Fatalf("CreateIndex: %v", err)
+	}
+	if _, err := svc.UpsertDocuments(ctx, "docs", UpsertDocumentsRequest{Documents: []Document{{ID: "a", Content: "refund", Embedding: []float32{1, 0}, Meta: map[string]any{"repo": "gomap"}}}}); err != nil {
+		t.Fatalf("UpsertDocuments: %v", err)
+	}
+	filter := &Filter{Field: "meta.repo", Operator: "==", Value: "gomap"}
+	if _, err := svc.SearchKeyword(ctx, "docs", KeywordSearchRequest{Query: "refund", TopK: 1, Filter: filter}); ErrorCodeOf(err) != CodeUnsupported {
+		t.Fatalf("keyword filter err=%v code=%s", err, ErrorCodeOf(err))
+	}
+	if _, err := svc.SearchHybrid(ctx, "docs", HybridSearchRequest{Query: "refund", TopK: 1, Filter: filter}); ErrorCodeOf(err) != CodeUnsupported {
+		t.Fatalf("hybrid filter err=%v code=%s", err, ErrorCodeOf(err))
+	}
+	if _, err := svc.UpsertDocuments(ctx, "docs", UpsertDocumentsRequest{Documents: []Document{{ID: "a", Content: "refund updated", Embedding: []float32{0, 1}, Meta: map[string]any{"repo": "gomap"}}}}); err != nil {
+		t.Fatalf("stale vector UpsertDocuments: %v", err)
+	}
+	if _, err := svc.SearchHybrid(ctx, "docs", HybridSearchRequest{QueryEmbedding: []float32{0, 1}, TopK: 1, EfSearch: 4}); ErrorCodeOf(err) != CodeIndexUnavailable && ErrorCodeOf(err) != CodeIndexStale {
+		t.Fatalf("stale vector err=%v code=%s", err, ErrorCodeOf(err))
+	}
+
+	mgr := collections.NewCollectionManager(db)
+	if _, err := mgr.CreateCollection(&collections.CollectionMeta{
+		Name: "notext",
+		Options: collections.CollectionOptions{
+			DocumentFormat: collections.DocumentFormatJSON,
+			ColumnStore:    serviceColumnStoreConfig(2),
+		},
+		VectorIndexes: []collections.VectorIndexDefinition{{
+			Name:       defaultVectorIndexName,
+			Field:      defaultEmbeddingField,
+			Metric:     collections.VectorMetricCosine,
+			Dimensions: 2,
+			Strategy:   collections.VectorIndexStrategyColumnGraph,
+		}},
+	}); err != nil {
+		t.Fatalf("CreateCollection notext: %v", err)
+	}
+	if _, err := svc.SearchKeyword(ctx, "notext", KeywordSearchRequest{Query: "refund", TopK: 1}); ErrorCodeOf(err) != CodeIndexUnavailable {
+		t.Fatalf("missing text err=%v code=%s", err, ErrorCodeOf(err))
+	}
+
+	if _, err := mgr.CreateCollection(&collections.CollectionMeta{
+		Name:    "novector",
+		Options: collections.CollectionOptions{DocumentFormat: collections.DocumentFormatJSON},
+		TextIndexes: []collections.TextIndexDefinition{{
+			Name:   defaultTextIndexName,
+			Fields: []collections.TextIndexField{{Field: defaultTextField}},
+		}},
+	}); err != nil {
+		t.Fatalf("CreateCollection novector: %v", err)
+	}
+	if _, err := svc.SearchHybrid(ctx, "novector", HybridSearchRequest{QueryEmbedding: []float32{1, 0}, TopK: 1}); ErrorCodeOf(err) != CodeIndexUnavailable {
+		t.Fatalf("missing vector err=%v code=%s", err, ErrorCodeOf(err))
+	}
+}
+
+func TestServiceNonCosineHybridCapabilityFailsClosedButDenseAndKeywordWork(t *testing.T) {
+	svc, db := newTestService(t)
+	defer db.Close()
+	ctx := context.Background()
+	info, err := svc.CreateIndex(ctx, CreateIndexRequest{Name: "l2docs", Dimension: 2, Metric: MetricL2})
+	if err != nil {
+		t.Fatalf("CreateIndex l2docs: %v", err)
+	}
+	if info.Capabilities.HybridSearch {
+		t.Fatalf("l2 capabilities=%+v want hybrid_search=false", info.Capabilities)
+	}
+	if _, err := svc.UpsertDocuments(ctx, "l2docs", UpsertDocumentsRequest{Documents: []Document{{ID: "a", Content: "refund", Embedding: []float32{1, 0}}}}); err != nil {
+		t.Fatalf("UpsertDocuments l2docs: %v", err)
+	}
+	keyword, err := svc.SearchKeyword(ctx, "l2docs", KeywordSearchRequest{Query: "refund", TopK: 1})
+	if err != nil || len(keyword.Documents) != 1 || keyword.Documents[0].ID != "a" {
+		t.Fatalf("SearchKeyword l2docs=%+v err=%v", keyword, err)
+	}
+	dense, err := svc.SearchDenseVector(ctx, "l2docs", DenseVectorSearchRequest{QueryEmbedding: []float32{1, 0}, TopK: 1})
+	if err != nil || len(dense.Documents) != 1 || dense.Documents[0].ID != "a" {
+		t.Fatalf("SearchDenseVector l2docs=%+v err=%v", dense, err)
+	}
+	if _, err := svc.SearchHybrid(ctx, "l2docs", HybridSearchRequest{Query: "refund", TopK: 1}); ErrorCodeOf(err) != CodeIndexUnavailable {
+		t.Fatalf("SearchHybrid l2 err=%v code=%s", err, ErrorCodeOf(err))
+	}
+}
+
+func TestServiceOpenedIncompatibleTextVectorSchemasFailClosed(t *testing.T) {
+	svc, db := newTestService(t)
+	defer db.Close()
+	ctx := context.Background()
+	mgr := collections.NewCollectionManager(db)
+	baseVector := collections.VectorIndexDefinition{
+		Name:       defaultVectorIndexName,
+		Field:      defaultEmbeddingField,
+		Metric:     collections.VectorMetricCosine,
+		Dimensions: 2,
+		Encoding:   collections.VectorIndexEncodingFloat32,
+		Strategy:   collections.VectorIndexStrategyNativeRuntime,
+	}
+	baseText := collections.TextIndexDefinition{
+		Name:           defaultTextIndexName,
+		Fields:         []collections.TextIndexField{{Field: defaultTextField}},
+		Analyzer:       collections.TextAnalyzerSimple,
+		StorePositions: true,
+	}
+	badText := baseText
+	badText.Fields = []collections.TextIndexField{{Field: defaultTextField}, {Field: "title"}}
+	if _, err := mgr.CreateCollection(&collections.CollectionMeta{
+		Name:          "badtext",
+		Options:       collections.CollectionOptions{DocumentFormat: collections.DocumentFormatJSON},
+		VectorIndexes: []collections.VectorIndexDefinition{baseVector},
+		TextIndexes:   []collections.TextIndexDefinition{badText},
+	}); err != nil {
+		t.Fatalf("CreateCollection badtext: %v", err)
+	}
+	if _, err := svc.OpenIndex(ctx, "badtext"); ErrorCodeOf(err) != CodeIndexUnavailable {
+		t.Fatalf("bad text schema err=%v code=%s", err, ErrorCodeOf(err))
+	}
+
+	badVector := baseVector
+	badVector.Encoding = collections.VectorIndexEncodingInt8
+	if _, err := mgr.CreateCollection(&collections.CollectionMeta{
+		Name:          "badvector",
+		Options:       collections.CollectionOptions{DocumentFormat: collections.DocumentFormatJSON},
+		VectorIndexes: []collections.VectorIndexDefinition{badVector},
+		TextIndexes:   []collections.TextIndexDefinition{baseText},
+	}); err != nil {
+		t.Fatalf("CreateCollection badvector: %v", err)
+	}
+	if _, err := svc.OpenIndex(ctx, "badvector"); ErrorCodeOf(err) != CodeIndexUnavailable {
+		t.Fatalf("bad vector schema err=%v code=%s", err, ErrorCodeOf(err))
+	}
+}
+
 func TestServicePersistenceReopenDocumentsAndEmbeddings(t *testing.T) {
 	dir := t.TempDir()
 	ctx := context.Background()
-	db, err := backenddb.Open(backenddb.Options{Dir: dir, DisableBackgroundPrune: true})
+	db, err := backenddb.Open(testBackendOptions(dir))
 	if err != nil {
 		t.Fatalf("open db: %v", err)
 	}
@@ -334,7 +578,7 @@ func TestServicePersistenceReopenDocumentsAndEmbeddings(t *testing.T) {
 	if err := db.Close(); err != nil {
 		t.Fatalf("close db: %v", err)
 	}
-	reopened, err := backenddb.Open(backenddb.Options{Dir: dir, DisableBackgroundPrune: true})
+	reopened, err := backenddb.Open(testBackendOptions(dir))
 	if err != nil {
 		t.Fatalf("reopen db: %v", err)
 	}
@@ -382,11 +626,67 @@ func TestServiceErrorCasesDimensionStaleUnavailable(t *testing.T) {
 	}
 }
 
+func documentIDs(docs []Document) []string {
+	ids := make([]string, len(docs))
+	for i := range docs {
+		ids[i] = docs[i].ID
+	}
+	return ids
+}
+
+func searchMeta(t *testing.T, doc Document) map[string]any {
+	t.Helper()
+	meta, ok := doc.Meta[searchMetaKey].(map[string]any)
+	if !ok {
+		t.Fatalf("document %q missing %s metadata: %+v", doc.ID, searchMetaKey, doc.Meta)
+	}
+	return meta
+}
+
+func searchMetaHasOnlySource(t *testing.T, doc Document, source string) bool {
+	t.Helper()
+	return searchMetaHasSources(searchMeta(t, doc), source)
+}
+
+func searchMetaHasSources(meta map[string]any, sources ...string) bool {
+	rawSources, ok := meta["sources"].([]map[string]any)
+	if !ok {
+		return false
+	}
+	if len(rawSources) != len(sources) {
+		return false
+	}
+	want := make(map[string]bool, len(sources))
+	for _, source := range sources {
+		want[source] = false
+	}
+	for _, raw := range rawSources {
+		source, ok := raw["source"].(string)
+		if !ok {
+			return false
+		}
+		if _, exists := want[source]; !exists {
+			return false
+		}
+		want[source] = true
+	}
+	for _, found := range want {
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
 func newTestService(t *testing.T) (*Service, *backenddb.DB) {
 	t.Helper()
-	db, err := backenddb.Open(backenddb.Options{Dir: t.TempDir(), DisableBackgroundPrune: true})
+	db, err := backenddb.Open(testBackendOptions(t.TempDir()))
 	if err != nil {
 		t.Fatalf("open db: %v", err)
 	}
 	return New(collections.NewCollectionManager(db)), db
+}
+
+func testBackendOptions(dir string) backenddb.Options {
+	return backenddb.Options{Dir: dir, CommandWAL: true, DisableBackgroundPrune: true}
 }

--- a/TreeDB/documentservice/types.go
+++ b/TreeDB/documentservice/types.go
@@ -13,7 +13,10 @@ const (
 
 	defaultEmbeddingField    = "embedding"
 	defaultVectorIndexName   = "embedding"
+	defaultTextField         = "content"
+	defaultTextIndexName     = "content"
 	defaultCollectionDocType = "treedb_document_service_v1"
+	searchMetaKey            = "_treedb_search"
 )
 
 // Metric selects the dense-vector score function. Scores returned by the
@@ -37,11 +40,13 @@ type Document struct {
 
 // IndexCapabilities describes the supported operations for one service index.
 type IndexCapabilities struct {
-	DenseVectorSearch bool `json:"dense_vector_search"`
-	ExactDenseScoring bool `json:"exact_dense_scoring"`
-	MetadataFilters   bool `json:"metadata_filters"`
-	KeywordSearch     bool `json:"keyword_search"`
-	HybridSearch      bool `json:"hybrid_search"`
+	DenseVectorSearch      bool `json:"dense_vector_search"`
+	ExactDenseScoring      bool `json:"exact_dense_scoring"`
+	MetadataFilters        bool `json:"metadata_filters"`
+	KeywordSearch          bool `json:"keyword_search"`
+	HybridSearch           bool `json:"hybrid_search"`
+	KeywordMetadataFilters bool `json:"keyword_metadata_filters"`
+	HybridMetadataFilters  bool `json:"hybrid_metadata_filters"`
 }
 
 // IndexInfo is returned by create/open and echoed by operation responses.
@@ -52,6 +57,9 @@ type IndexInfo struct {
 	Generation      uint64            `json:"generation"`
 	ContractVersion string            `json:"contract_version"`
 	EmbeddingField  string            `json:"embedding_field"`
+	VectorIndexName string            `json:"vector_index_name"`
+	TextField       string            `json:"text_field"`
+	TextIndexName   string            `json:"text_index_name"`
 	DocumentType    string            `json:"document_type"`
 	Capabilities    IndexCapabilities `json:"capabilities"`
 }
@@ -139,6 +147,73 @@ type DenseVectorSearchResponse struct {
 	Candidates int        `json:"candidates"`
 }
 
+// KeywordSearchRequest runs ranked lexical search over the service content text
+// index. Metadata filters intentionally fail closed for keyword search in this
+// pre-alpha contract; the service never scans documents as a fallback.
+type KeywordSearchRequest struct {
+	ExpectedGeneration uint64                         `json:"expected_generation,omitempty"`
+	Query              string                         `json:"query"`
+	TopK               int                            `json:"top_k"`
+	Operator           collections.TextSearchOperator `json:"operator,omitempty"`
+	CandidateLimit     int                            `json:"candidate_limit,omitempty"`
+	MaxPostingsScanned int                            `json:"max_postings_scanned,omitempty"`
+	Filter             *Filter                        `json:"filter,omitempty"`
+	ReturnEmbedding    bool                           `json:"return_embedding,omitempty"`
+}
+
+type KeywordSearchResponse struct {
+	Index     IndexInfo          `json:"index"`
+	Documents []Document         `json:"documents"`
+	TextIndex string             `json:"text_index"`
+	Stats     KeywordSearchStats `json:"stats"`
+}
+
+type KeywordSearchStats struct {
+	QueryTerms                int    `json:"query_terms,omitempty"`
+	CandidatesRequested       uint64 `json:"candidates_requested,omitempty"`
+	CandidatesReturned        uint64 `json:"candidates_returned,omitempty"`
+	PostingsScanned           uint64 `json:"postings_scanned,omitempty"`
+	CandidatesScored          uint64 `json:"candidates_scored,omitempty"`
+	DocumentsFetched          uint64 `json:"documents_fetched,omitempty"`
+	DocumentsMissing          uint64 `json:"documents_missing,omitempty"`
+	FullDocumentScanFallbacks uint64 `json:"full_document_scan_fallbacks,omitempty"`
+	PostingsScanNanos         uint64 `json:"postings_scan_nanos,omitempty"`
+	CandidateScoreNanos       uint64 `json:"candidate_score_nanos,omitempty"`
+	DocumentFetchNanos        uint64 `json:"document_fetch_nanos,omitempty"`
+	Truncated                 bool   `json:"truncated,omitempty"`
+	FailClosed                uint64 `json:"fail_closed,omitempty"`
+	FailClosedReason          string `json:"fail_closed_reason,omitempty"`
+	Unavailable               bool   `json:"unavailable,omitempty"`
+	UnavailableReason         string `json:"unavailable_reason,omitempty"`
+}
+
+// HybridSearchRequest runs collection-native text/vector hybrid retrieval. At
+// least one of Query or QueryEmbedding must be supplied. Metadata filters fail
+// closed for now unless the service grows a bounded scalar-index mapping.
+type HybridSearchRequest struct {
+	ExpectedGeneration   uint64                          `json:"expected_generation,omitempty"`
+	Query                string                          `json:"query,omitempty"`
+	QueryEmbedding       []float32                       `json:"query_embedding,omitempty"`
+	TopK                 int                             `json:"top_k"`
+	TextCandidateLimit   int                             `json:"text_candidate_limit,omitempty"`
+	VectorCandidateLimit int                             `json:"vector_candidate_limit,omitempty"`
+	CandidateLimit       int                             `json:"candidate_limit,omitempty"`
+	EfSearch             int                             `json:"ef_search,omitempty"`
+	Fusion               collections.HybridFusionOptions `json:"fusion,omitempty"`
+	Filter               *Filter                         `json:"filter,omitempty"`
+	ReturnEmbedding      bool                            `json:"return_embedding,omitempty"`
+}
+
+type HybridSearchResponse struct {
+	Index       IndexInfo                        `json:"index"`
+	Documents   []Document                       `json:"documents"`
+	TextIndex   string                           `json:"text_index,omitempty"`
+	VectorIndex string                           `json:"vector_index,omitempty"`
+	Plan        collections.HybridSearchPlan     `json:"plan,omitempty"`
+	Snapshot    collections.HybridSearchSnapshot `json:"snapshot,omitempty"`
+	Stats       collections.HybridSearchStats    `json:"stats,omitempty"`
+}
+
 func normalizeMetric(metric Metric) (Metric, error) {
 	switch strings.TrimSpace(strings.ToLower(string(metric))) {
 	case "", string(MetricCosine):
@@ -182,13 +257,15 @@ func metricFromCollection(metric collections.VectorMetric) (Metric, error) {
 	}
 }
 
-func indexCapabilities() IndexCapabilities {
+func indexCapabilities(hybridSearch bool) IndexCapabilities {
 	return IndexCapabilities{
-		DenseVectorSearch: true,
-		ExactDenseScoring: true,
-		MetadataFilters:   true,
-		KeywordSearch:     false,
-		HybridSearch:      false,
+		DenseVectorSearch:      true,
+		ExactDenseScoring:      true,
+		MetadataFilters:        true,
+		KeywordSearch:          true,
+		HybridSearch:           hybridSearch,
+		KeywordMetadataFilters: false,
+		HybridMetadataFilters:  false,
 	}
 }
 

--- a/docs/TREEDB_COLLECTION_QUICKSTART.md
+++ b/docs/TREEDB_COLLECTION_QUICKSTART.md
@@ -73,8 +73,9 @@ make that visible instead of implying the optimized path was used.
 See also `cmd/treedb_vector_demo/README.md` and the pre-alpha
 [TreeDB Document Service API](TREEDB_DOCUMENT_SERVICE_API.md) for the
 Haystack-style HTTP/JSON contract. The document service's filtered dense search
-uses exact scoring as a correctness/MVP path; it is not the high-QPS
-`column_graph` ANN route described below.
+uses exact scoring as a correctness/MVP path; keyword and hybrid routes call the
+collection text/hybrid APIs and fail closed rather than scanning when required
+indexes are unavailable.
 
 `cmd/treedb_vector_demo` creates a fresh TreeDB directory, declares a collection,
 loads deterministic JSON fixtures, publishes embeddings as typed-column dense

--- a/docs/TREEDB_DOCUMENT_SERVICE_API.md
+++ b/docs/TREEDB_DOCUMENT_SERVICE_API.md
@@ -1,6 +1,7 @@
 # TreeDB Document Service API (pre-alpha)
 
-Issue: [#2531](https://github.com/snissn/gomap/issues/2531). Parent tracker:
+Issues: [#2531](https://github.com/snissn/gomap/issues/2531),
+[#2534](https://github.com/snissn/gomap/issues/2534). Parent tracker:
 [#2530](https://github.com/snissn/gomap/issues/2530).
 
 This is the smallest TreeDB document/search service contract intended for the
@@ -38,18 +39,17 @@ Supported now:
 - delete by ID or metadata filter;
 - count/filter/list documents;
 - exact dense-vector search with metadata filters;
+- ranked keyword search over the declared `content` text index;
+- TreeDB collection-native hybrid search over text and/or vector sources;
 - optional embedding echo in returned documents.
 
 Not supported now:
 
-- keyword search;
-- hybrid search;
-- text ranking/BM25/BM25F;
-- client-side or service-side full-document scan fallbacks for keyword/hybrid.
-
-Keyword and hybrid routes return `unsupported`/HTTP 501. This matches current
-TreeDB core behavior: `SearchText` and `SearchHybrid` fail closed until ranked
-text and hybrid executors land.
+- metadata filters on keyword/hybrid routes (they fail closed with
+  `unsupported`/HTTP 501);
+- client-side or service-side full-document scan fallbacks for keyword/hybrid;
+- silent vector-only/text-only downgrade when a requested source/index is
+  missing, stale, corrupt, or unavailable.
 
 Dense-vector search in this service is an **exact scoring correctness/MVP path**.
 It scans service documents that match the metadata filter and scores their stored
@@ -78,8 +78,14 @@ Service documents use Haystack-compatible fields:
 }
 ```
 
-`score` is response-only. `embedding` is required on upsert for this dense-search
-MVP. Responses omit embeddings unless `return_embedding=true`.
+`score` is response-only. `embedding` is required on upsert for dense/vector
+retrieval. Responses omit embeddings unless `return_embedding=true`.
+
+Keyword and hybrid result documents add response-only explanation metadata under
+`meta._treedb_search`. For keyword results it includes the text index, rank,
+score kind, matched fields/terms, and text matches. For hybrid results it
+includes fused rank/score, fusion method/tie policy, and per-source text/vector
+contributions.
 
 TreeDB stores each service index as a JSON collection. The document ID is the
 TreeDB collection key and the JSON `id` field is kept for client compatibility.
@@ -109,6 +115,17 @@ Request:
 - l2: negative squared L2 distance;
 - inner_product: dot product.
 
+Service-created indexes declare these stable names:
+
+- vector field/index: `embedding`;
+- text field/index: `content`;
+- document type: `treedb_document_service_v1`.
+
+Cosine indexes are created with the collection `column_graph` vector strategy so
+hybrid vector sources can use `Collection.SearchHybrid`. Non-cosine indexes keep
+exact dense scoring available, but hybrid vector capability is reported false
+until the collection vector path can serve that metric safely.
+
 Open/read index metadata:
 
 ```http
@@ -126,13 +143,18 @@ Responses include:
     "generation": 1,
     "contract_version": "treedb-document-service/v1alpha1",
     "embedding_field": "embedding",
+    "vector_index_name": "embedding",
+    "text_field": "content",
+    "text_index_name": "content",
     "document_type": "treedb_document_service_v1",
     "capabilities": {
       "dense_vector_search": true,
       "exact_dense_scoring": true,
       "metadata_filters": true,
-      "keyword_search": false,
-      "hybrid_search": false
+      "keyword_search": true,
+      "hybrid_search": true,
+      "keyword_metadata_filters": false,
+      "hybrid_metadata_filters": false
     }
   }
 }
@@ -246,7 +268,10 @@ Fields may be `id`, `content`, `meta.<path>`, or a metadata path without the
 `not in`, so filters fail closed rather than broadening result sets. Comparison
 operators require numeric or string operands. Membership values must be arrays.
 Unsupported operators fail with `invalid_request`; the service does not rewrite
-unsupported filters into broader scans.
+unsupported filters into broader scans. This filter AST is currently supported by
+document count/filter/delete and exact dense-vector search. Keyword and hybrid
+requests validate the shape and then fail closed with `unsupported` when any
+filter is supplied.
 
 ## Dense-vector search
 
@@ -283,17 +308,162 @@ Response:
 
 Tie order is deterministic: higher score first, then document ID ascending.
 
-## Keyword and hybrid fail-closed routes
-
-These endpoints are reserved for downstream clients but are not implemented:
+## Keyword search
 
 ```http
 POST /v1/indexes/{index}/search/keyword
+```
+
+Request:
+
+```json
+{
+  "query": "refund policy",
+  "top_k": 10,
+  "operator": "or",
+  "candidate_limit": 1000,
+  "max_postings_scanned": 100000,
+  "return_embedding": false
+}
+```
+
+`operator` is `or` (default) or `and`; explicit `AND`/`OR` in the query string is
+also understood by TreeDB text search. `candidate_limit` and
+`max_postings_scanned` are optional guardrails. If a guardrail is exceeded, the
+route fails closed with `index_unavailable` rather than returning incomplete
+rankings. Metadata `filter` is not supported here and returns `unsupported`.
+
+Response (abridged; the actual payload also includes the top-level `index`
+object shown in the index metadata section):
+
+```json
+{
+  "text_index": "content",
+  "documents": [
+    {
+      "id": "doc-1",
+      "content": "refund policy text",
+      "meta": {
+        "repo": "snissn/gomap",
+        "_treedb_search": {
+          "type": "keyword",
+          "text_index": "content",
+          "rank": 1,
+          "score_kind": "bm25f",
+          "matched_terms": ["refund", "policy"],
+          "matched_fields": ["content"],
+          "text_matches": [{"field": "content", "terms": ["refund", "policy"]}]
+        }
+      },
+      "score": 3.12
+    }
+  ],
+  "stats": {
+    "query_terms": 2,
+    "candidates_requested": 1000,
+    "candidates_returned": 1,
+    "postings_scanned": 8,
+    "candidates_scored": 1,
+    "documents_fetched": 1
+  }
+}
+```
+
+Tie order is deterministic: higher BM25F score first, then document ID
+ascending.
+
+## Hybrid search
+
+```http
 POST /v1/indexes/{index}/search/hybrid
 ```
 
-They return HTTP 501 with `unsupported`. They do **not** scan all documents or
-silently downgrade to vector-only/text-only behavior.
+Request:
+
+```json
+{
+  "query": "refund policy",
+  "query_embedding": [0.1, 0.2, 0.3],
+  "top_k": 10,
+  "candidate_limit": 100,
+  "text_candidate_limit": 100,
+  "vector_candidate_limit": 100,
+  "ef_search": 64,
+  "fusion": {
+    "method": "rrf",
+    "rrf_k": 60,
+    "tie_policy": "fused_score_best_rank_source_order_id",
+    "source_order": ["text", "vector"]
+  },
+  "return_embedding": false
+}
+```
+
+Hybrid requests require `capabilities.hybrid_search=true` in the index metadata.
+At least one of `query` or `query_embedding` is required. Supplying only `query`
+runs TreeDB text-only hybrid execution; supplying only `query_embedding` runs the
+collection vector source; supplying both uses deterministic reciprocal-rank
+fusion. `candidate_limit` is a shared default for omitted source-specific limits.
+Metadata `filter` is not supported here and returns `unsupported`.
+
+Response (abridged; the actual payload also includes the top-level `index`
+object shown in the index metadata section):
+
+```json
+{
+  "text_index": "content",
+  "vector_index": "embedding",
+  "documents": [
+    {
+      "id": "doc-1",
+      "content": "refund policy text",
+      "meta": {
+        "repo": "snissn/gomap",
+        "_treedb_search": {
+          "type": "hybrid",
+          "rank": 1,
+          "fusion_method": "rrf",
+          "fusion_tie_policy": "fused_score_best_rank_source_order_id",
+          "fused_score": 0.0325,
+          "sources": [
+            {"source": "text", "index_name": "content", "source_rank": 1, "score": 3.12, "score_kind": "bm25f", "fusion_score": 0.0164},
+            {"source": "vector", "index_name": "embedding", "source_rank": 2, "score": 0.991, "score_kind": "vector_similarity", "fusion_score": 0.0161}
+          ]
+        }
+      },
+      "score": 0.0325
+    }
+  ],
+  "plan": {
+    "scalar_filter_strategy": "union_fusion",
+    "fusion_method": "rrf",
+    "fusion_tie_policy": "fused_score_best_rank_source_order_id",
+    "text_candidate_limit": 100,
+    "vector_candidate_limit": 100,
+    "final_top_k": 10
+  },
+  "stats": {
+    "text_candidates_requested": 100,
+    "text_candidates_returned": 10,
+    "vector_candidates_requested": 100,
+    "vector_candidates_returned": 10,
+    "candidates_fused": 20,
+    "fusion_both": 1,
+    "documents_fetched": 10
+  }
+}
+```
+
+Missing/stale/unavailable text or vector indexes, text postings/candidate budget
+exhaustion, corrupt index state, and bounded document-fetch failures return a
+service error (`index_unavailable`, `index_stale`, or `unsupported`) rather than
+empty success or a scan fallback.
+
+Pre-alpha caveat: cosine service indexes attempt to refresh the `column_graph`
+vector index after insert-only upserts. Updates/deletes can currently leave the
+vector graph rebuild-needed in collection core; hybrid requests that need the
+vector source then fail closed until that core mutation/rebuild path is available.
+Keyword search and exact dense scoring continue to use their safe paths.
 
 ## Error envelope
 


### PR DESCRIPTION
## Objective

Expose real TreeDB document-service keyword and hybrid search for #2534 by wiring the Go service/HTTP contract to collection `SearchText` and `SearchHybrid`.

## Context

Core TreeDB text/hybrid blockers are closed. This PR owns only the Go TreeDB document service API/HTTP/docs/tests layer for downstream Python client and Haystack retriever work.

## Non-goals

- No Python client or Haystack retriever implementation.
- No TreeDB core text/hybrid/vector hot-path changes.
- No client-side or service-side keyword/hybrid scan fallback.
- No metadata-filter support for keyword/hybrid yet; filters fail closed.

## Design

- Adds `KeywordSearchRequest/Response` and `HybridSearchRequest/Response` plus HTTP routes:
  - `POST /v1/indexes/{index}/search/keyword`
  - `POST /v1/indexes/{index}/search/hybrid`
- Service-created indexes now declare stable names:
  - text field/index: `content`
  - vector field/index: `embedding`
  - document type: `treedb_document_service_v1`
- Keyword calls `Collection.SearchText` with bounded candidate/postings options and bounded document fetch.
- Hybrid calls `Collection.SearchHybrid` with text and/or vector sources and RRF fusion options.
- Missing/stale/unavailable text/vector sources map to typed service errors (`index_unavailable`, `index_stale`, `unsupported`) rather than empty success.
- Keyword/hybrid metadata filters validate shape, then fail closed with `unsupported`; no scan fallback.
- Result documents include stable IDs, `score`, original metadata, and response-only `meta._treedb_search` explanation metadata.
- Existing exact dense-vector scan behavior is preserved. Non-cosine indexes keep dense/keyword support but report `hybrid_search=false` and hybrid fails closed.

## Scope

Includes:
- `TreeDB/documentservice` service/types/http/tests/docs comments.
- Document service API docs and quickstart wording.
- Typed-storage legacy-name allowlist update for new documentservice `ColumnStore` references.

Excludes:
- TreeDB collection/core search implementation changes.
- Python `treedb-client` / `treedb-haystack` changes.

## Correctness

Tests run:

- `go test ./TreeDB/documentservice -count=1`
- `go test ./TreeDB/docs -count=1`
- `go test ./TreeDB/collections -run 'TestSearchHybridExecutor|TestSearchHybridTextCandidates|TestSearchHybridVectorCandidates|TestTextSearch' -count=1`
- `go test ./TreeDB/documentservice ./TreeDB/docs ./cmd/treedb-document-service -count=1`
- `go test ./TreeDB/collections -count=1`
- `go test ./cmd/treedb-document-service -count=1`
- `go test ./TreeDB/... -count=1`

Coverage added/updated:
- keyword ranked lexical results and deterministic tie ordering;
- keyword candidate-limit fail-closed;
- hybrid text-only/vector-only/overlap fusion via service;
- unsupported metadata filters for keyword/hybrid;
- stale/missing text/vector index fail-closed behavior;
- non-cosine hybrid capability/fail-closed behavior while dense/keyword still work;
- incompatible opened text/vector schemas fail closed;
- HTTP keyword/hybrid routes and unsupported-filter error payloads;
- existing dense vector HTTP/service tests still pass.

## Performance

No TreeDB core text/hybrid/vector hot paths changed; this PR only wires service/API/HTTP/docs/tests over existing collection APIs, so before/after core benchmarks are not applicable. Focused and broad TreeDB tests above exercise the service and collection contracts. No material dense-vector regression observed in existing tests.

## Downstream API contract snapshot for 2534b/2534c

### Routes

- `POST /v1/indexes/{index}/search/keyword`
- `POST /v1/indexes/{index}/search/hybrid`

### Keyword request

```json
{
  "expected_generation": 1,
  "query": "refund policy",
  "top_k": 10,
  "operator": "or",
  "candidate_limit": 1000,
  "max_postings_scanned": 100000,
  "filter": null,
  "return_embedding": false
}
```

### Keyword response

```json
{
  "index": {"...": "IndexInfo"},
  "text_index": "content",
  "documents": [{"id": "doc-1", "content": "...", "meta": {"_treedb_search": {"type": "keyword"}}, "score": 1.23}],
  "stats": {"query_terms": 2, "candidates_requested": 1000, "candidates_returned": 1}
}
```

### Hybrid request

```json
{
  "expected_generation": 1,
  "query": "refund policy",
  "query_embedding": [0.1, 0.2, 0.3],
  "top_k": 10,
  "candidate_limit": 100,
  "text_candidate_limit": 100,
  "vector_candidate_limit": 100,
  "ef_search": 64,
  "fusion": {
    "method": "rrf",
    "rrf_k": 60,
    "tie_policy": "fused_score_best_rank_source_order_id",
    "source_order": ["text", "vector"]
  },
  "filter": null,
  "return_embedding": false
}
```

### Hybrid response

```json
{
  "index": {"...": "IndexInfo"},
  "text_index": "content",
  "vector_index": "embedding",
  "documents": [{"id": "doc-1", "content": "...", "meta": {"_treedb_search": {"type": "hybrid", "sources": []}}, "score": 0.0325}],
  "plan": {"fusion_method": "rrf", "fusion_tie_policy": "fused_score_best_rank_source_order_id"},
  "snapshot": {"consistency": "current_snapshot"},
  "stats": {"text_candidates_returned": 10, "vector_candidates_returned": 10, "documents_fetched": 10}
}
```

### Capabilities / names

- `IndexInfo.text_index_name`: `content`
- `IndexInfo.text_field`: `content`
- `IndexInfo.vector_index_name`: `embedding`
- `IndexInfo.embedding_field`: `embedding`
- `capabilities.keyword_search`: true for service-compatible indexes.
- `capabilities.hybrid_search`: true only when the stable content text index and cosine `column_graph` embedding vector index are configured.
- `capabilities.metadata_filters`: true for document operations and exact dense vector search.
- `capabilities.keyword_metadata_filters`: false.
- `capabilities.hybrid_metadata_filters`: false.

### Filter/fail-closed behavior

- Keyword/hybrid `filter` present: `unsupported` / HTTP 501 after shape validation.
- Missing index: `index_not_found` / HTTP 404 for missing service collection.
- Missing/incompatible text/vector schema or unavailable source: `index_unavailable` / HTTP 503.
- Stale generation/snapshot: `index_stale` / HTTP 409 where surfaced by service/core.
- Unsupported query/fusion/source shape: `unsupported` / HTTP 501 or `invalid_request` / HTTP 400 for request validation.

## AI review status

Internal high-thinking reviewer pass after fixes. Latest-head CI is green on head 1b73c0f264a18a7f6296d2b67a92fc4f9981e759. Codex and Copilot reviews requested after the PR reached mature state. CodeRabbit auto-review attempted but is currently rate-limited/usage-credit blocked; no CodeRabbit findings are available yet.

## Known caveats / risks

- Cosine service indexes attempt insert-only `column_graph` rebuild after insert-only upserts. Core currently fails closed for vector hybrid after update/delete mutation states; exact dense and keyword continue on safe paths.
- API is pre-alpha; downstream 2534b can start speculative client work from this snapshot, but should pin to this PR/head and expect possible review-driven naming/body adjustments.