### PR TITLE
TreeDB Haystack keyword and hybrid retrievers

### DIFF
--- a/clients/python/treedb_haystack/README.md
+++ b/clients/python/treedb_haystack/README.md
@@ -5,11 +5,13 @@ pre-alpha HTTP/JSON document service. It provides:
 
 - `haystack_integrations.document_stores.treedb.TreeDBDocumentStore`
 - `haystack_integrations.components.retrievers.treedb.TreeDBEmbeddingRetriever`
+- `haystack_integrations.components.retrievers.treedb.TreeDBKeywordRetriever`
+- `haystack_integrations.components.retrievers.treedb.TreeDBHybridRetriever`
 
-The MVP supports embedded Haystack `Document` writes and exact dense-vector
-retrieval through the TreeDB document service. It intentionally does **not**
-expose keyword or hybrid retrieval, and it never scans documents client-side to
-emulate unsupported filters or search modes.
+The integration supports embedded Haystack `Document` writes, exact dense-vector
+retrieval, ranked keyword retrieval, and TreeDB-native hybrid text/vector
+retrieval through the TreeDB document service. It never scans documents
+client-side to emulate unsupported filters or search modes.
 
 Service contract: [`docs/TREEDB_DOCUMENT_SERVICE_API.md`](../../../docs/TREEDB_DOCUMENT_SERVICE_API.md)
 
@@ -47,7 +49,11 @@ go run ./cmd/treedb-document-service \
 ```python
 from haystack import Document, Pipeline
 from haystack.document_stores.types import DuplicatePolicy
-from haystack_integrations.components.retrievers.treedb import TreeDBEmbeddingRetriever
+from haystack_integrations.components.retrievers.treedb import (
+    TreeDBEmbeddingRetriever,
+    TreeDBHybridRetriever,
+    TreeDBKeywordRetriever,
+)
 from haystack_integrations.document_stores.treedb import TreeDBDocumentStore
 
 store = TreeDBDocumentStore(
@@ -68,7 +74,7 @@ store.write_documents(
         ),
         Document(
             id="doc-b",
-            content="Keyword and hybrid retrieval are future work.",
+            content="Keyword and hybrid retrieval run through TreeDB service indexes.",
             embedding=[0.0, 1.0, 0.0],
             meta={"repo": "snissn/gomap", "language": "docs"},
         ),
@@ -76,23 +82,44 @@ store.write_documents(
     policy=DuplicatePolicy.OVERWRITE,
 )
 
-pipeline = Pipeline()
-pipeline.add_component("retriever", TreeDBEmbeddingRetriever(document_store=store, top_k=1))
-result = pipeline.run({"retriever": {"query_embedding": [1.0, 0.0, 0.0]}})
-print(result["retriever"]["documents"][0].id)
+embedding_pipeline = Pipeline()
+embedding_pipeline.add_component("retriever", TreeDBEmbeddingRetriever(document_store=store, top_k=1))
+embedding_result = embedding_pipeline.run({"retriever": {"query_embedding": [1.0, 0.0, 0.0]}})
+print(embedding_result["retriever"]["documents"][0].id)
+
+keyword_pipeline = Pipeline()
+keyword_pipeline.add_component("retriever", TreeDBKeywordRetriever(document_store=store, top_k=1))
+keyword_result = keyword_pipeline.run({"retriever": {"query": "TreeDB service indexes"}})
+print(keyword_result["retriever"]["documents"][0].id)
+
+hybrid_pipeline = Pipeline()
+hybrid_pipeline.add_component(
+    "retriever",
+    TreeDBHybridRetriever(
+        document_store=store,
+        top_k=1,
+        fusion={"method": "rrf", "rrf_k": 60, "source_order": ["text", "vector"]},
+    ),
+)
+hybrid_result = hybrid_pipeline.run(
+    {"retriever": {"query": "TreeDB service indexes", "query_embedding": [1.0, 0.0, 0.0]}}
+)
+print(hybrid_result["retriever"]["documents"][0].id)
 ```
 
 ## Runnable examples
 
 Example scripts live in [`examples/`](examples/):
 
-- [`basic_ingest_retrieve.py`](examples/basic_ingest_retrieve.py) writes two embedded Haystack documents and retrieves one through a `Pipeline`.
-- [`code_search_metadata.py`](examples/code_search_metadata.py) demonstrates code-search metadata fields such as `repo`, `path`, `language`, `symbol`, `start_line`, `end_line`, and `chunk_kind` with service-side filters.
+- [`basic_ingest_retrieve.py`](examples/basic_ingest_retrieve.py) writes two embedded Haystack documents and retrieves one through an embedding `Pipeline`.
+- [`keyword_hybrid_retrieve.py`](examples/keyword_hybrid_retrieve.py) demonstrates keyword and hybrid retrievers over the same TreeDB index.
+- [`code_search_metadata.py`](examples/code_search_metadata.py) demonstrates code-search metadata fields such as `repo`, `path`, `language`, `symbol`, `start_line`, `end_line`, and `chunk_kind` with service-side embedding filters.
 
 After starting `cmd/treedb-document-service`, run them from the repository root with the local packages installed:
 
 ```sh
 python clients/python/treedb_haystack/examples/basic_ingest_retrieve.py
+python clients/python/treedb_haystack/examples/keyword_hybrid_retrieve.py
 python clients/python/treedb_haystack/examples/code_search_metadata.py
 ```
 
@@ -110,6 +137,13 @@ Boolean filters use `conditions`. Supported operators are `AND`, `OR`, `NOT`,
 closed through the base `treedb-client`; this package does not broaden them into
 local scans.
 
+Metadata filters are currently supported by document count/filter/delete and
+exact dense-vector retrieval. If filters are supplied to `TreeDBKeywordRetriever`
+or `TreeDBHybridRetriever`, Haystack `FilterPolicy` is still honored and the
+filter is sent to TreeDB, but the current TreeDB keyword/hybrid routes fail
+closed with `unsupported` until TreeDB exposes bounded scalar filter mapping for
+those routes. The retrievers do not fetch and filter documents client-side.
+
 ## Duplicate and filter policies
 
 - `DuplicatePolicy.OVERWRITE` maps to TreeDB service upsert and is the default
@@ -120,7 +154,8 @@ local scans.
   current service has no create-if-absent endpoint. If TreeDB reports an
   unexpected update after the preflight, the store raises `DocumentStoreError`
   rather than silently reporting success.
-- `TreeDBEmbeddingRetriever` supports Haystack `FilterPolicy.REPLACE` and
+- `TreeDBEmbeddingRetriever`, `TreeDBKeywordRetriever`, and
+  `TreeDBHybridRetriever` support Haystack `FilterPolicy.REPLACE` and
   `FilterPolicy.MERGE` via Haystack's `apply_filter_policy` helper.
 
 ## Run tests
@@ -159,5 +194,7 @@ installation/release URLs are stable.
 ## Scope and non-goals
 
 TreeDB's service-backed dense-vector search is an exact correctness/MVP path. It
-is not advertised as ANN throughput work, and this package does not implement
-keyword, sparse, or hybrid retrievers.
+is not advertised as ANN throughput work. Keyword and hybrid retrievers delegate
+to TreeDB's service indexes; this package does not implement sparse retrieval,
+client-side keyword scans, client-side fusion fallbacks, or code-symbol graph
+retrieval.

--- a/clients/python/treedb_haystack/examples/README.md
+++ b/clients/python/treedb_haystack/examples/README.md
@@ -22,9 +22,14 @@ In another shell with the same virtual environment:
 
 ```sh
 python clients/python/treedb_haystack/examples/basic_ingest_retrieve.py
+python clients/python/treedb_haystack/examples/keyword_hybrid_retrieve.py
 python clients/python/treedb_haystack/examples/code_search_metadata.py
 ```
 
-Both scripts use small deterministic embeddings and exact TreeDB service-backed
-dense retrieval. They do not exercise or claim keyword/hybrid search support.
-Use `--base-url` and `--index` to point at a different service or isolate runs.
+The scripts use small deterministic embeddings and TreeDB service-backed
+retrieval. `basic_ingest_retrieve.py` and `code_search_metadata.py` use exact
+dense retrieval; `keyword_hybrid_retrieve.py` uses the TreeDB keyword and hybrid
+service routes. Keyword/hybrid metadata filters are intentionally not used
+because the current service fails those filters closed with `unsupported` until
+bounded scalar filter mapping is available. Use `--base-url` and `--index` to
+point at a different service or isolate runs.

--- a/clients/python/treedb_haystack/examples/code_search_metadata.py
+++ b/clients/python/treedb_haystack/examples/code_search_metadata.py
@@ -3,7 +3,8 @@
 
 This example stores code chunks with repository/path/symbol/line metadata and
 retrieves them with dense embeddings plus a service-side metadata filter.
-It intentionally does not use keyword or hybrid retrieval.
+Keyword/hybrid metadata filters currently fail closed in the TreeDB service, so
+this metadata-filter example intentionally uses embedding retrieval.
 """
 
 from __future__ import annotations

--- a/clients/python/treedb_haystack/examples/keyword_hybrid_retrieve.py
+++ b/clients/python/treedb_haystack/examples/keyword_hybrid_retrieve.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""TreeDB Haystack keyword + hybrid retrieval example.
+
+Start the service first, for example:
+
+    go run ./cmd/treedb-document-service \
+      -dir /tmp/treedb-document-service \
+      -addr 127.0.0.1:7120 \
+      -profile command_wal_durable
+
+Keyword and hybrid metadata filters are intentionally not used here: the current
+TreeDB service fails those filters closed with `unsupported` until bounded scalar
+filter mapping is available for the keyword/hybrid routes.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from haystack import Document, Pipeline
+from haystack.document_stores.types import DuplicatePolicy
+from haystack_integrations.components.retrievers.treedb import TreeDBHybridRetriever, TreeDBKeywordRetriever
+from haystack_integrations.document_stores.treedb import TreeDBDocumentStore
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-url", default="http://127.0.0.1:7120", help="TreeDB document service base URL")
+    parser.add_argument("--index", default="haystack_keyword_hybrid_example", help="TreeDB document-service index name")
+    args = parser.parse_args()
+
+    store = TreeDBDocumentStore(
+        base_url=args.base_url,
+        index=args.index,
+        embedding_dimension=3,
+        similarity="cosine",
+        return_embedding=False,
+    )
+    store.write_documents(
+        [
+            Document(
+                id="treedb-search",
+                content="TreeDB service keyword search and hybrid retrieval use indexed document content.",
+                embedding=[1.0, 0.0, 0.0],
+                meta={"topic": "treedb", "kind": "search"},
+            ),
+            Document(
+                id="haystack-pipelines",
+                content="Haystack pipelines connect writers, embedders, retrievers, and readers.",
+                embedding=[0.0, 1.0, 0.0],
+                meta={"topic": "haystack", "kind": "pipeline"},
+            ),
+        ],
+        policy=DuplicatePolicy.OVERWRITE,
+    )
+
+    keyword_pipeline = Pipeline()
+    keyword_pipeline.add_component("retriever", TreeDBKeywordRetriever(document_store=store, top_k=1))
+    keyword_result = keyword_pipeline.run({"retriever": {"query": "TreeDB keyword search"}})
+    keyword_docs = keyword_result["retriever"]["documents"]
+    if not keyword_docs or keyword_docs[0].id != "treedb-search":
+        raise SystemExit(f"unexpected keyword result: {keyword_docs!r}")
+
+    hybrid_pipeline = Pipeline()
+    hybrid_pipeline.add_component(
+        "retriever",
+        TreeDBHybridRetriever(
+            document_store=store,
+            top_k=1,
+            fusion={"method": "rrf", "rrf_k": 60, "source_order": ["text", "vector"]},
+        ),
+    )
+    hybrid_result = hybrid_pipeline.run(
+        {"retriever": {"query": "TreeDB keyword search", "query_embedding": [1.0, 0.0, 0.0]}}
+    )
+    hybrid_docs = hybrid_result["retriever"]["documents"]
+    if not hybrid_docs or hybrid_docs[0].id != "treedb-search":
+        raise SystemExit(f"unexpected hybrid result: {hybrid_docs!r}")
+
+    keyword_meta = keyword_docs[0].meta.get("_treedb_search", {})
+    hybrid_meta = hybrid_docs[0].meta.get("_treedb_search", {})
+    print(
+        "keyword "
+        f"id={keyword_docs[0].id} score={keyword_docs[0].score:.6f} "
+        f"explanation_type={keyword_meta.get('type')}"
+    )
+    print(
+        "hybrid "
+        f"id={hybrid_docs[0].id} score={hybrid_docs[0].score:.6f} "
+        f"explanation_type={hybrid_meta.get('type')}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/clients/python/treedb_haystack/pyproject.toml
+++ b/clients/python/treedb_haystack/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "treedb-haystack"
 version = "0.1.0"
-description = "Haystack DocumentStore and embedding retriever for TreeDB"
+description = "Haystack DocumentStore and TreeDB retrievers"
 readme = "README.md"
 requires-python = ">=3.10"
 authors = [{ name = "gomap contributors" }]

--- a/clients/python/treedb_haystack/src/haystack_integrations/components/retrievers/treedb/__init__.py
+++ b/clients/python/treedb_haystack/src/haystack_integrations/components/retrievers/treedb/__init__.py
@@ -1,5 +1,7 @@
 """TreeDB Haystack retriever integration."""
 
 from .embedding_retriever import TreeDBEmbeddingRetriever
+from .hybrid_retriever import TreeDBHybridRetriever
+from .keyword_retriever import TreeDBKeywordRetriever
 
-__all__ = ["TreeDBEmbeddingRetriever"]
+__all__ = ["TreeDBEmbeddingRetriever", "TreeDBHybridRetriever", "TreeDBKeywordRetriever"]

--- a/clients/python/treedb_haystack/src/haystack_integrations/components/retrievers/treedb/hybrid_retriever.py
+++ b/clients/python/treedb_haystack/src/haystack_integrations/components/retrievers/treedb/hybrid_retriever.py
@@ -1,0 +1,216 @@
+"""Haystack hybrid retriever for TreeDB."""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+from collections.abc import Mapping
+from typing import Any, Optional, Union
+
+from haystack import component, default_from_dict, default_to_dict
+from haystack.dataclasses import Document
+from haystack.document_stores.types import FilterPolicy
+from haystack.document_stores.types.filter_policy import apply_filter_policy
+from treedb_client import HybridFusionOptions
+
+from haystack_integrations.document_stores.treedb import TreeDBDocumentStore
+
+FusionLike = Union[HybridFusionOptions, Mapping[str, Any]]
+
+
+@component
+class TreeDBHybridRetriever:
+    """Retrieve documents from a `TreeDBDocumentStore` with TreeDB hybrid text/vector search."""
+
+    def __init__(
+        self,
+        *,
+        document_store: TreeDBDocumentStore,
+        filters: Optional[dict[str, Any]] = None,
+        top_k: int = 10,
+        candidate_limit: Optional[int] = None,
+        text_candidate_limit: Optional[int] = None,
+        vector_candidate_limit: Optional[int] = None,
+        ef_search: Optional[int] = None,
+        fusion: Optional[FusionLike] = None,
+        return_embedding: Optional[bool] = None,
+        filter_policy: Union[str, FilterPolicy] = FilterPolicy.REPLACE,
+    ) -> None:
+        """Create the TreeDB hybrid retriever.
+
+        :param document_store: `TreeDBDocumentStore` instance to query.
+        :param filters: Init-time filters. Runtime filters are combined according to `filter_policy`.
+        :param top_k: Default maximum number of documents to return.
+        :param candidate_limit: Shared default candidate limit for omitted source-specific limits.
+        :param text_candidate_limit: Text-source candidate limit.
+        :param vector_candidate_limit: Vector-source candidate limit.
+        :param ef_search: Optional vector-source ef_search hint.
+        :param fusion: TreeDB fusion options (`HybridFusionOptions` or mapping).
+        :param return_embedding: Override document-store embedding echo for retrieved documents.
+        :param filter_policy: Haystack filter policy (`REPLACE` or `MERGE`).
+        :raises ValueError: If `document_store` is not a `TreeDBDocumentStore` or `top_k` is not positive.
+        """
+
+        if not isinstance(document_store, TreeDBDocumentStore):
+            msg = "document_store must be an instance of TreeDBDocumentStore"
+            raise ValueError(msg)
+        if top_k <= 0:
+            msg = "top_k must be positive"
+            raise ValueError(msg)
+
+        self.document_store = document_store
+        self.filters = copy.deepcopy(filters) if filters else None
+        self.top_k = int(top_k)
+        self.candidate_limit = _optional_positive_int(candidate_limit, "candidate_limit")
+        self.text_candidate_limit = _optional_positive_int(text_candidate_limit, "text_candidate_limit")
+        self.vector_candidate_limit = _optional_positive_int(vector_candidate_limit, "vector_candidate_limit")
+        self.ef_search = _optional_positive_int(ef_search, "ef_search")
+        self.fusion = _fusion_to_dict(fusion)
+        self.return_embedding = return_embedding
+        self.filter_policy = (
+            filter_policy if isinstance(filter_policy, FilterPolicy) else FilterPolicy.from_str(filter_policy)
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize this retriever for Haystack pipelines."""
+
+        return default_to_dict(
+            self,
+            document_store=self.document_store.to_dict(),
+            filters=self.filters,
+            top_k=self.top_k,
+            candidate_limit=self.candidate_limit,
+            text_candidate_limit=self.text_candidate_limit,
+            vector_candidate_limit=self.vector_candidate_limit,
+            ef_search=self.ef_search,
+            fusion=copy.deepcopy(self.fusion),
+            return_embedding=self.return_embedding,
+            filter_policy=self.filter_policy.value,
+        )
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "TreeDBHybridRetriever":
+        """Deserialize a retriever from `to_dict()` output."""
+
+        payload = copy.deepcopy(data)
+        init_parameters = payload["init_parameters"]
+        init_parameters["document_store"] = TreeDBDocumentStore.from_dict(init_parameters["document_store"])
+        if filter_policy := init_parameters.get("filter_policy"):
+            init_parameters["filter_policy"] = (
+                filter_policy if isinstance(filter_policy, FilterPolicy) else FilterPolicy.from_str(filter_policy)
+            )
+        return default_from_dict(cls, payload)
+
+    @component.output_types(documents=list[Document])
+    def run(
+        self,
+        query: Optional[str] = None,
+        query_embedding: Optional[list[float]] = None,
+        filters: Optional[dict[str, Any]] = None,
+        top_k: Optional[int] = None,
+        candidate_limit: Optional[int] = None,
+        text_candidate_limit: Optional[int] = None,
+        vector_candidate_limit: Optional[int] = None,
+        ef_search: Optional[int] = None,
+        fusion: Optional[FusionLike] = None,
+        return_embedding: Optional[bool] = None,
+    ) -> dict[str, list[Document]]:
+        """Retrieve documents with TreeDB hybrid text/vector search.
+
+        :param query: Optional text query for TreeDB text/keyword source.
+        :param query_embedding: Optional dense query embedding for TreeDB vector source.
+        :param filters: Runtime TreeDB/Haystack filter AST. Hybrid filters currently fail closed in the service.
+        :param top_k: Runtime maximum number of documents to return.
+        :param candidate_limit: Runtime shared candidate limit override.
+        :param text_candidate_limit: Runtime text-source candidate limit override.
+        :param vector_candidate_limit: Runtime vector-source candidate limit override.
+        :param ef_search: Runtime vector-source ef_search override.
+        :param fusion: Runtime TreeDB fusion options override.
+        :param return_embedding: Runtime embedding echo override.
+        :returns: `{"documents": [...]}` with Haystack `Document` results.
+        """
+
+        if not query and query_embedding is None:
+            msg = "query or query_embedding must be provided"
+            raise ValueError(msg)
+        effective_filters = apply_filter_policy(
+            filter_policy=self.filter_policy,
+            init_filters=copy.deepcopy(self.filters),
+            runtime_filters=copy.deepcopy(filters),
+        )
+        effective_top_k = self.top_k if top_k is None else int(top_k)
+        if effective_top_k <= 0:
+            msg = "top_k must be positive"
+            raise ValueError(msg)
+        docs = self.document_store._search_hybrid(
+            query=query,
+            query_embedding=query_embedding,
+            filters=effective_filters or None,
+            top_k=effective_top_k,
+            candidate_limit=self.candidate_limit if candidate_limit is None else _optional_positive_int(candidate_limit, "candidate_limit"),
+            text_candidate_limit=(
+                self.text_candidate_limit
+                if text_candidate_limit is None
+                else _optional_positive_int(text_candidate_limit, "text_candidate_limit")
+            ),
+            vector_candidate_limit=(
+                self.vector_candidate_limit
+                if vector_candidate_limit is None
+                else _optional_positive_int(vector_candidate_limit, "vector_candidate_limit")
+            ),
+            ef_search=self.ef_search if ef_search is None else _optional_positive_int(ef_search, "ef_search"),
+            fusion=copy.deepcopy(self.fusion) if fusion is None else _fusion_to_dict(fusion),
+            return_embedding=self.return_embedding if return_embedding is None else return_embedding,
+        )
+        return {"documents": docs}
+
+    @component.output_types(documents=list[Document])
+    async def run_async(
+        self,
+        query: Optional[str] = None,
+        query_embedding: Optional[list[float]] = None,
+        filters: Optional[dict[str, Any]] = None,
+        top_k: Optional[int] = None,
+        candidate_limit: Optional[int] = None,
+        text_candidate_limit: Optional[int] = None,
+        vector_candidate_limit: Optional[int] = None,
+        ef_search: Optional[int] = None,
+        fusion: Optional[FusionLike] = None,
+        return_embedding: Optional[bool] = None,
+    ) -> dict[str, list[Document]]:
+        """Asynchronously retrieve documents by hybrid search."""
+
+        return await asyncio.to_thread(
+            self.run,
+            query=query,
+            query_embedding=query_embedding,
+            filters=filters,
+            top_k=top_k,
+            candidate_limit=candidate_limit,
+            text_candidate_limit=text_candidate_limit,
+            vector_candidate_limit=vector_candidate_limit,
+            ef_search=ef_search,
+            fusion=fusion,
+            return_embedding=return_embedding,
+        )
+
+
+def _optional_positive_int(value: Optional[int], label: str) -> Optional[int]:
+    if value is None:
+        return None
+    parsed = int(value)
+    if parsed <= 0:
+        msg = f"{label} must be positive"
+        raise ValueError(msg)
+    return parsed
+
+
+def _fusion_to_dict(fusion: Optional[FusionLike]) -> Optional[dict[str, Any]]:
+    if fusion is None:
+        return None
+    if isinstance(fusion, HybridFusionOptions):
+        return fusion.to_dict()
+    if isinstance(fusion, Mapping):
+        return HybridFusionOptions.from_dict(fusion).to_dict()
+    msg = "fusion must be HybridFusionOptions or a mapping"
+    raise TypeError(msg)

--- a/clients/python/treedb_haystack/src/haystack_integrations/components/retrievers/treedb/keyword_retriever.py
+++ b/clients/python/treedb_haystack/src/haystack_integrations/components/retrievers/treedb/keyword_retriever.py
@@ -1,0 +1,146 @@
+"""Haystack keyword retriever for TreeDB."""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+from typing import Any, Optional, Union
+
+from haystack import component, default_from_dict, default_to_dict
+from haystack.dataclasses import Document
+from haystack.document_stores.types import FilterPolicy
+from haystack.document_stores.types.filter_policy import apply_filter_policy
+
+from haystack_integrations.document_stores.treedb import TreeDBDocumentStore
+
+
+@component
+class TreeDBKeywordRetriever:
+    """Retrieve documents from a `TreeDBDocumentStore` by TreeDB ranked keyword search."""
+
+    def __init__(
+        self,
+        *,
+        document_store: TreeDBDocumentStore,
+        filters: Optional[dict[str, Any]] = None,
+        top_k: int = 10,
+        operator: Optional[str] = None,
+        candidate_limit: Optional[int] = None,
+        max_postings_scanned: Optional[int] = None,
+        return_embedding: Optional[bool] = None,
+        filter_policy: Union[str, FilterPolicy] = FilterPolicy.REPLACE,
+    ) -> None:
+        """Create the TreeDB keyword retriever.
+
+        :param document_store: `TreeDBDocumentStore` instance to query.
+        :param filters: Init-time filters. Runtime filters are combined according to `filter_policy`.
+        :param top_k: Default maximum number of documents to return.
+        :param operator: Optional TreeDB keyword operator (`or` default or `and`).
+        :param candidate_limit: Optional keyword candidate guardrail.
+        :param max_postings_scanned: Optional postings-scan guardrail.
+        :param return_embedding: Override document-store embedding echo for retrieved documents.
+        :param filter_policy: Haystack filter policy (`REPLACE` or `MERGE`).
+        :raises ValueError: If `document_store` is not a `TreeDBDocumentStore` or `top_k` is not positive.
+        """
+
+        if not isinstance(document_store, TreeDBDocumentStore):
+            msg = "document_store must be an instance of TreeDBDocumentStore"
+            raise ValueError(msg)
+        if top_k <= 0:
+            msg = "top_k must be positive"
+            raise ValueError(msg)
+
+        self.document_store = document_store
+        self.filters = copy.deepcopy(filters) if filters else None
+        self.top_k = int(top_k)
+        self.operator = operator
+        self.candidate_limit = _optional_positive_int(candidate_limit, "candidate_limit")
+        self.max_postings_scanned = _optional_positive_int(max_postings_scanned, "max_postings_scanned")
+        self.return_embedding = return_embedding
+        self.filter_policy = (
+            filter_policy if isinstance(filter_policy, FilterPolicy) else FilterPolicy.from_str(filter_policy)
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize this retriever for Haystack pipelines."""
+
+        return default_to_dict(
+            self,
+            document_store=self.document_store.to_dict(),
+            filters=self.filters,
+            top_k=self.top_k,
+            operator=self.operator,
+            candidate_limit=self.candidate_limit,
+            max_postings_scanned=self.max_postings_scanned,
+            return_embedding=self.return_embedding,
+            filter_policy=self.filter_policy.value,
+        )
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "TreeDBKeywordRetriever":
+        """Deserialize a retriever from `to_dict()` output."""
+
+        payload = copy.deepcopy(data)
+        init_parameters = payload["init_parameters"]
+        init_parameters["document_store"] = TreeDBDocumentStore.from_dict(init_parameters["document_store"])
+        if filter_policy := init_parameters.get("filter_policy"):
+            init_parameters["filter_policy"] = (
+                filter_policy if isinstance(filter_policy, FilterPolicy) else FilterPolicy.from_str(filter_policy)
+            )
+        return default_from_dict(cls, payload)
+
+    @component.output_types(documents=list[Document])
+    def run(
+        self,
+        query: str,
+        filters: Optional[dict[str, Any]] = None,
+        top_k: Optional[int] = None,
+    ) -> dict[str, list[Document]]:
+        """Retrieve documents matching `query` with TreeDB ranked keyword search.
+
+        :param query: Text query to send to TreeDB keyword search.
+        :param filters: Runtime TreeDB/Haystack filter AST. Keyword filters currently fail closed in the service.
+        :param top_k: Runtime maximum number of documents to return.
+        :returns: `{"documents": [...]}` with Haystack `Document` results.
+        """
+
+        effective_filters = apply_filter_policy(
+            filter_policy=self.filter_policy,
+            init_filters=copy.deepcopy(self.filters),
+            runtime_filters=copy.deepcopy(filters),
+        )
+        effective_top_k = self.top_k if top_k is None else int(top_k)
+        if effective_top_k <= 0:
+            msg = "top_k must be positive"
+            raise ValueError(msg)
+        docs = self.document_store._search_keyword(
+            query=query,
+            filters=effective_filters or None,
+            top_k=effective_top_k,
+            operator=self.operator,
+            candidate_limit=self.candidate_limit,
+            max_postings_scanned=self.max_postings_scanned,
+            return_embedding=self.return_embedding,
+        )
+        return {"documents": docs}
+
+    @component.output_types(documents=list[Document])
+    async def run_async(
+        self,
+        query: str,
+        filters: Optional[dict[str, Any]] = None,
+        top_k: Optional[int] = None,
+    ) -> dict[str, list[Document]]:
+        """Asynchronously retrieve documents by keyword search."""
+
+        return await asyncio.to_thread(self.run, query=query, filters=filters, top_k=top_k)
+
+
+def _optional_positive_int(value: Optional[int], label: str) -> Optional[int]:
+    if value is None:
+        return None
+    parsed = int(value)
+    if parsed <= 0:
+        msg = f"{label} must be positive"
+        raise ValueError(msg)
+    return parsed

--- a/clients/python/treedb_haystack/src/haystack_integrations/document_stores/treedb/document_store.py
+++ b/clients/python/treedb_haystack/src/haystack_integrations/document_stores/treedb/document_store.py
@@ -26,10 +26,10 @@ _T = TypeVar("_T")
 class TreeDBDocumentStore:
     """A Haystack DocumentStore backed by the TreeDB document service.
 
-    The store delegates filtering, deletion, and dense-vector search to TreeDB's
-    HTTP service through `treedb-client`. It intentionally exposes only the dense
-    embedding MVP: no keyword, sparse, or hybrid retrievers are implemented here,
-    and unsupported filters are not emulated with client-side document scans.
+    The store delegates filtering, deletion, dense-vector search, keyword search,
+    and hybrid search to TreeDB's HTTP service through `treedb-client`.
+    Unsupported filters and search modes are not emulated with client-side
+    document scans.
     """
 
     def __init__(
@@ -229,6 +229,72 @@ class TreeDBDocumentStore:
                 self.index,
                 query_embedding=query_embedding,
                 top_k=top_k,
+                filter=prepared_filter,
+                return_embedding=self.return_embedding if return_embedding is None else bool(return_embedding),
+                expected_generation=self._expected_generation(),
+            ),
+        )
+        return [treedb_document_to_haystack_document(doc) for doc in response.documents]
+
+    def _search_keyword(
+        self,
+        *,
+        query: str,
+        filters: Optional[FilterLike] = None,
+        top_k: int = 10,
+        operator: Optional[str] = None,
+        candidate_limit: Optional[int] = None,
+        max_postings_scanned: Optional[int] = None,
+        return_embedding: Optional[bool] = None,
+    ) -> list[HaystackDocument]:
+        """Run TreeDB ranked keyword search through the service."""
+
+        prepared_filter = _prepare_filter(filters)
+        response = self._client_call(
+            "keyword search",
+            lambda: self.client.search_keyword(
+                self.index,
+                query,
+                top_k,
+                operator=operator,
+                candidate_limit=candidate_limit,
+                max_postings_scanned=max_postings_scanned,
+                filter=prepared_filter,
+                return_embedding=self.return_embedding if return_embedding is None else bool(return_embedding),
+                expected_generation=self._expected_generation(),
+            ),
+        )
+        return [treedb_document_to_haystack_document(doc) for doc in response.documents]
+
+    def _search_hybrid(
+        self,
+        *,
+        query: Optional[str] = None,
+        query_embedding: Optional[Sequence[float]] = None,
+        filters: Optional[FilterLike] = None,
+        top_k: int = 10,
+        candidate_limit: Optional[int] = None,
+        text_candidate_limit: Optional[int] = None,
+        vector_candidate_limit: Optional[int] = None,
+        ef_search: Optional[int] = None,
+        fusion: Optional[Any] = None,
+        return_embedding: Optional[bool] = None,
+    ) -> list[HaystackDocument]:
+        """Run TreeDB hybrid text/vector search through the service."""
+
+        prepared_filter = _prepare_filter(filters)
+        response = self._client_call(
+            "hybrid search",
+            lambda: self.client.search_hybrid(
+                self.index,
+                query=query,
+                query_embedding=query_embedding,
+                top_k=top_k,
+                candidate_limit=candidate_limit,
+                text_candidate_limit=text_candidate_limit,
+                vector_candidate_limit=vector_candidate_limit,
+                ef_search=ef_search,
+                fusion=fusion,
                 filter=prepared_filter,
                 return_embedding=self.return_embedding if return_embedding is None else bool(return_embedding),
                 expected_generation=self._expected_generation(),

--- a/clients/python/treedb_haystack/tests/fakes.py
+++ b/clients/python/treedb_haystack/tests/fakes.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import math
+import re
 from copy import deepcopy
 from typing import Any, Optional
 
@@ -11,8 +12,15 @@ from treedb_client import (
     DenseVectorSearchResponse,
     Document,
     FilterDocumentsResponse,
+    HybridFusionOptions,
+    HybridSearchPlan,
+    HybridSearchResponse,
+    HybridSearchSnapshot,
+    HybridSearchStats,
     IndexCapabilities,
     IndexInfo,
+    KeywordSearchResponse,
+    KeywordSearchStats,
     UpsertDocumentsResponse,
 )
 
@@ -21,8 +29,10 @@ CAPABILITIES = IndexCapabilities(
     dense_vector_search=True,
     exact_dense_scoring=True,
     metadata_filters=True,
-    keyword_search=False,
-    hybrid_search=False,
+    keyword_search=True,
+    hybrid_search=True,
+    keyword_metadata_filters=False,
+    hybrid_metadata_filters=False,
 )
 
 
@@ -34,6 +44,9 @@ def sample_index(name: str = "docs", dimension: int = 3, metric: str = "cosine")
         generation=1,
         contract_version="treedb-document-service/v1alpha1",
         embedding_field="embedding",
+        vector_index_name="embedding",
+        text_field="content",
+        text_index_name="content",
         document_type="treedb_document_service_v1",
         capabilities=CAPABILITIES,
     )
@@ -51,6 +64,8 @@ class FakeTreeDBClient:
         self.delete_id_calls: list[list[str]] = []
         self.delete_filter_calls: list[dict[str, Any]] = []
         self.query_calls: list[dict[str, Any]] = []
+        self.keyword_calls: list[dict[str, Any]] = []
+        self.hybrid_calls: list[dict[str, Any]] = []
 
     def ensure_index(self, name: str, dimension: int, metric: Optional[str] = "cosine") -> IndexInfo:
         self.ensure_calls.append((name, dimension, metric))
@@ -185,6 +200,224 @@ class FakeTreeDBClient:
             candidates=len(scored),
         )
 
+    def search_keyword(
+        self,
+        index: str,
+        query: str,
+        top_k: int,
+        *,
+        operator: Optional[str] = None,
+        candidate_limit: Optional[int] = None,
+        max_postings_scanned: Optional[int] = None,
+        filter: Optional[dict[str, Any]] = None,
+        return_embedding: bool = False,
+        expected_generation: Optional[int] = None,
+    ) -> KeywordSearchResponse:
+        self.keyword_calls.append(
+            {
+                "query": query,
+                "top_k": top_k,
+                "operator": operator,
+                "candidate_limit": candidate_limit,
+                "max_postings_scanned": max_postings_scanned,
+                "filter": deepcopy(filter),
+                "return_embedding": return_embedding,
+                "expected_generation": expected_generation,
+            }
+        )
+        ranked = self._keyword_ranked(query, filter=filter, operator=operator)
+        if candidate_limit is not None:
+            ranked = ranked[:candidate_limit]
+        docs = []
+        for rank, (score, matched_terms, doc) in enumerate(ranked[:top_k], start=1):
+            out = self._copy_doc(doc, return_embedding=return_embedding)
+            out.score = score
+            out.meta.setdefault(
+                "_treedb_search",
+                {
+                    "type": "keyword",
+                    "text_index": self.index_info.text_index_name,
+                    "rank": rank,
+                    "score_kind": "fake_bm25f",
+                    "matched_terms": matched_terms,
+                    "matched_fields": [self.index_info.text_field],
+                    "text_matches": [{"field": self.index_info.text_field, "terms": matched_terms}],
+                },
+            )
+            docs.append(out)
+        return KeywordSearchResponse(
+            index=self.index_info,
+            documents=docs,
+            text_index=self.index_info.text_index_name,
+            stats=KeywordSearchStats(
+                query_terms=len(_terms(query)),
+                candidates_requested=candidate_limit or top_k,
+                candidates_returned=len(docs),
+                postings_scanned=sum(len(_terms(doc.content)) for _, _, doc in ranked),
+                candidates_scored=len(ranked),
+                documents_fetched=len(docs),
+            ),
+        )
+
+    def search_hybrid(
+        self,
+        index: str,
+        *,
+        query: Optional[str] = None,
+        query_embedding: Optional[list[float]] = None,
+        top_k: int,
+        candidate_limit: Optional[int] = None,
+        text_candidate_limit: Optional[int] = None,
+        vector_candidate_limit: Optional[int] = None,
+        ef_search: Optional[int] = None,
+        fusion: Optional[HybridFusionOptions | dict[str, Any]] = None,
+        filter: Optional[dict[str, Any]] = None,
+        return_embedding: bool = False,
+        expected_generation: Optional[int] = None,
+    ) -> HybridSearchResponse:
+        fusion_payload = _fusion_to_dict(fusion)
+        self.hybrid_calls.append(
+            {
+                "query": query,
+                "query_embedding": None if query_embedding is None else list(query_embedding),
+                "top_k": top_k,
+                "candidate_limit": candidate_limit,
+                "text_candidate_limit": text_candidate_limit,
+                "vector_candidate_limit": vector_candidate_limit,
+                "ef_search": ef_search,
+                "fusion": deepcopy(fusion_payload),
+                "filter": deepcopy(filter),
+                "return_embedding": return_embedding,
+                "expected_generation": expected_generation,
+            }
+        )
+        text_limit = text_candidate_limit or candidate_limit or top_k
+        vector_limit = vector_candidate_limit or candidate_limit or top_k
+        text_ranked = [] if query is None else self._keyword_ranked(query, filter=filter)[:text_limit]
+        vector_ranked = [] if query_embedding is None else self._vector_ranked(query_embedding, filter=filter)[:vector_limit]
+
+        rrf_k = int(fusion_payload.get("rrf_k", 60))
+        fusion_method = str(fusion_payload.get("method", "rrf"))
+        tie_policy = str(fusion_payload.get("tie_policy", "fused_score_best_rank_source_order_id"))
+        source_order = [str(item) for item in fusion_payload.get("source_order", ["text", "vector"])]
+        source_preference = {source: i for i, source in enumerate(source_order)}
+        fused: dict[str, dict[str, Any]] = {}
+
+        for rank, (score, _matched_terms, doc) in enumerate(text_ranked, start=1):
+            _add_hybrid_source(
+                fused,
+                doc,
+                source="text",
+                index_name=self.index_info.text_index_name,
+                rank=rank,
+                score=score,
+                score_kind="fake_bm25f",
+                fusion_score=1.0 / (rrf_k + rank),
+            )
+        for rank, (score, doc) in enumerate(vector_ranked, start=1):
+            _add_hybrid_source(
+                fused,
+                doc,
+                source="vector",
+                index_name=self.index_info.vector_index_name,
+                rank=rank,
+                score=score,
+                score_kind="vector_similarity",
+                fusion_score=1.0 / (rrf_k + rank),
+            )
+
+        ordered = sorted(
+            fused.values(),
+            key=lambda item: (
+                -float(item["fused_score"]),
+                int(item["best_rank"]),
+                min(source_preference.get(source["source"], len(source_preference)) for source in item["sources"]),
+                item["doc"].id,
+            ),
+        )
+        docs = []
+        for rank, item in enumerate(ordered[:top_k], start=1):
+            out = self._copy_doc(item["doc"], return_embedding=return_embedding)
+            out.score = float(item["fused_score"])
+            out.meta.setdefault(
+                "_treedb_search",
+                {
+                    "type": "hybrid",
+                    "rank": rank,
+                    "fusion_method": fusion_method,
+                    "fusion_tie_policy": tie_policy,
+                    "fused_score": float(item["fused_score"]),
+                    "sources": deepcopy(item["sources"]),
+                },
+            )
+            docs.append(out)
+
+        text_ids = {doc.id for _, _, doc in text_ranked}
+        vector_ids = {doc.id for _, doc in vector_ranked}
+        return HybridSearchResponse(
+            index=self.index_info,
+            documents=docs,
+            text_index=self.index_info.text_index_name if query is not None else "",
+            vector_index=self.index_info.vector_index_name if query_embedding is not None else "",
+            plan=HybridSearchPlan(
+                scalar_filter_strategy="none" if not filter else "service_filter",
+                fusion_method=fusion_method,
+                fusion_tie_policy=tie_policy,
+                text_candidate_limit=0 if query is None else text_limit,
+                vector_candidate_limit=0 if query_embedding is None else vector_limit,
+                final_top_k=top_k,
+            ),
+            snapshot=HybridSearchSnapshot(consistency="fake_current_snapshot", collection_generation=self.index_info.generation),
+            stats=HybridSearchStats(
+                text_candidates_requested=0 if query is None else text_limit,
+                text_candidates_returned=len(text_ranked),
+                text_postings_scanned=sum(len(_terms(doc.content)) for _, _, doc in text_ranked),
+                text_candidates_scored=len(text_ranked),
+                vector_candidates_requested=0 if query_embedding is None else vector_limit,
+                vector_candidates_returned=len(vector_ranked),
+                vector_candidates_examined=len(vector_ranked),
+                candidates_fused=len(text_ranked) + len(vector_ranked),
+                candidates_after_fusion=len(ordered),
+                fusion_text_only=len(text_ids - vector_ids),
+                fusion_vector_only=len(vector_ids - text_ids),
+                fusion_both=len(text_ids & vector_ids),
+                fusion_duplicate_candidates=len(text_ids & vector_ids),
+                candidates_after_filter=len(ordered),
+                documents_fetched=len(docs),
+            ),
+        )
+
+    def _keyword_ranked(
+        self,
+        query: str,
+        *,
+        filter: Optional[dict[str, Any]],
+        operator: Optional[str] = None,
+    ) -> list[tuple[float, list[str], Document]]:
+        query_terms = _terms(query)
+        if not query_terms:
+            return []
+        require_all = str(operator or "or").lower() == "and"
+        ranked: list[tuple[float, list[str], Document]] = []
+        for doc in self._matching_documents(filter):
+            content_terms = _terms(doc.content)
+            matched_terms = [term for term in query_terms if term in content_terms]
+            if not matched_terms or (require_all and len(set(matched_terms)) != len(set(query_terms))):
+                continue
+            score = float(sum(content_terms.count(term) for term in query_terms))
+            ranked.append((score, sorted(set(matched_terms)), doc))
+        ranked.sort(key=lambda item: (-item[0], item[2].id))
+        return ranked
+
+    def _vector_ranked(self, query_embedding: list[float], *, filter: Optional[dict[str, Any]]) -> list[tuple[float, Document]]:
+        ranked: list[tuple[float, Document]] = []
+        for doc in self._matching_documents(filter):
+            if doc.embedding is None:
+                continue
+            ranked.append((_cosine(query_embedding, doc.embedding), doc))
+        ranked.sort(key=lambda item: (-item[0], item[1].id))
+        return ranked
+
     def _matching_documents(self, filter: Optional[dict[str, Any]]) -> list[Document]:
         return [doc for doc in sorted(self.documents.values(), key=lambda item: item.id) if _matches_filter(filter, doc)]
 
@@ -197,6 +430,32 @@ class FakeTreeDBClient:
             meta=deepcopy(doc.meta),
             score=doc.score,
         )
+
+
+def _add_hybrid_source(
+    fused: dict[str, dict[str, Any]],
+    doc: Document,
+    *,
+    source: str,
+    index_name: str,
+    rank: int,
+    score: float,
+    score_kind: str,
+    fusion_score: float,
+) -> None:
+    item = fused.setdefault(doc.id, {"doc": doc, "fused_score": 0.0, "best_rank": rank, "sources": []})
+    item["fused_score"] = float(item["fused_score"]) + fusion_score
+    item["best_rank"] = min(int(item["best_rank"]), rank)
+    item["sources"].append(
+        {
+            "source": source,
+            "index_name": index_name,
+            "source_rank": rank,
+            "score": score,
+            "score_kind": score_kind,
+            "fusion_score": fusion_score,
+        }
+    )
 
 
 def _matches_filter(filter: Optional[dict[str, Any]], doc: Document) -> bool:
@@ -256,3 +515,15 @@ def _cosine(query: list[float], embedding: list[float]) -> float:
     if q_norm == 0.0 or e_norm == 0.0:
         return 0.0
     return dot / (q_norm * e_norm)
+
+
+def _terms(text: str) -> list[str]:
+    return re.findall(r"[a-z0-9_]+", text.lower())
+
+
+def _fusion_to_dict(fusion: Optional[HybridFusionOptions | dict[str, Any]]) -> dict[str, Any]:
+    if fusion is None:
+        return {}
+    if isinstance(fusion, HybridFusionOptions):
+        return fusion.to_dict()
+    return HybridFusionOptions.from_dict(fusion).to_dict()

--- a/clients/python/treedb_haystack/tests/test_hybrid_retriever.py
+++ b/clients/python/treedb_haystack/tests/test_hybrid_retriever.py
@@ -197,14 +197,17 @@ def test_hybrid_filters_fail_closed_through_service_without_scan_fallback() -> N
 
 
 @pytest.mark.parametrize(
-    "error",
+    ("error", "run_kwargs"),
     [
-        IndexNotFoundError("index_not_found", "missing vector index"),
-        IndexStaleError("index_stale", "stale hybrid snapshot"),
-        IndexUnavailableError("index_unavailable", "vector index unavailable"),
+        (IndexNotFoundError("index_not_found", "missing text index"), {"query": "policy"}),
+        (IndexNotFoundError("index_not_found", "missing vector index"), {"query_embedding": [1.0, 0.0, 0.0]}),
+        (IndexStaleError("index_stale", "stale hybrid snapshot"), {"query": "policy"}),
+        (IndexUnavailableError("index_unavailable", "vector index unavailable"), {"query_embedding": [1.0, 0.0, 0.0]}),
     ],
 )
-def test_hybrid_service_index_errors_fail_closed_without_empty_success(error: Exception) -> None:
+def test_hybrid_service_index_errors_fail_closed_without_empty_success(
+    error: Exception, run_kwargs: dict[str, object]
+) -> None:
     class ErrorClient(FakeTreeDBClient):
         def search_hybrid(self, *args: object, **kwargs: object) -> object:
             raise error
@@ -218,7 +221,7 @@ def test_hybrid_service_index_errors_fail_closed_without_empty_success(error: Ex
     retriever = TreeDBHybridRetriever(document_store=store)
 
     with pytest.raises(DocumentStoreError, match=str(error).split(": ", 1)[-1]):
-        retriever.run(query_embedding=[1.0, 0.0, 0.0])
+        retriever.run(**run_kwargs)  # type: ignore[arg-type]
 
 
 def test_hybrid_to_dict_from_dict_round_trip() -> None:

--- a/clients/python/treedb_haystack/tests/test_hybrid_retriever.py
+++ b/clients/python/treedb_haystack/tests/test_hybrid_retriever.py
@@ -1,0 +1,282 @@
+from __future__ import annotations
+
+import copy
+
+import pytest
+from haystack import Document as HaystackDocument
+from haystack import Pipeline
+from haystack.document_stores.errors import DocumentStoreError
+from haystack.document_stores.types import DuplicatePolicy, FilterPolicy
+from treedb_client import HybridFusionOptions, IndexNotFoundError, IndexStaleError, IndexUnavailableError, UnsupportedError
+
+import _support  # noqa: F401
+from fakes import FakeTreeDBClient
+from haystack_integrations.components.retrievers.treedb import TreeDBHybridRetriever
+from haystack_integrations.document_stores.treedb import TreeDBDocumentStore
+
+
+def make_populated_store() -> tuple[TreeDBDocumentStore, FakeTreeDBClient]:
+    client = FakeTreeDBClient()
+    store = TreeDBDocumentStore(
+        base_url="http://fake-treedb",
+        index="docs",
+        embedding_dimension=3,
+        similarity="cosine",
+        return_embedding=False,
+        client=client,  # type: ignore[arg-type]
+    )
+    store.write_documents(
+        [
+            HaystackDocument(
+                id="alpha",
+                content="refund refund policy details",
+                embedding=[0.9, 0.1, 0.0],
+                meta={"category": "A", "rank": 1},
+            ),
+            HaystackDocument(
+                id="beta",
+                content="policy handbook",
+                embedding=[0.0, 1.0, 0.0],
+                meta={"category": "B", "rank": 2},
+            ),
+            HaystackDocument(
+                id="gamma",
+                content="refund shipping notes",
+                embedding=[1.0, 0.0, 0.0],
+                meta={"category": "A", "rank": 3},
+            ),
+        ],
+        policy=DuplicatePolicy.OVERWRITE,
+    )
+    return store, client
+
+
+def test_invalid_document_store_type() -> None:
+    with pytest.raises(ValueError, match="TreeDBDocumentStore"):
+        TreeDBHybridRetriever(document_store="not-a-store")  # type: ignore[arg-type]
+
+
+def test_hybrid_text_only_uses_tree_text_source_and_preserves_metadata() -> None:
+    store, client = make_populated_store()
+    retriever = TreeDBHybridRetriever(document_store=store, top_k=2, candidate_limit=10)
+
+    result = retriever.run(query="refund policy")
+
+    documents = result["documents"]
+    assert [doc.id for doc in documents] == ["alpha", "beta"]
+    assert documents[0].meta["_treedb_search"]["type"] == "hybrid"
+    assert documents[0].meta["_treedb_search"]["sources"][0]["source"] == "text"
+    assert client.hybrid_calls[-1]["query"] == "refund policy"
+    assert client.hybrid_calls[-1]["query_embedding"] is None
+    assert client.hybrid_calls[-1]["candidate_limit"] == 10
+
+
+def test_hybrid_vector_only_uses_tree_vector_source_and_return_embedding_override() -> None:
+    store, client = make_populated_store()
+    retriever = TreeDBHybridRetriever(document_store=store, top_k=2, return_embedding=True)
+
+    result = retriever.run(query_embedding=[1.0, 0.0, 0.0])
+
+    documents = result["documents"]
+    assert [doc.id for doc in documents] == ["gamma", "alpha"]
+    assert documents[0].embedding == [1.0, 0.0, 0.0]
+    assert documents[0].meta["_treedb_search"]["sources"][0]["source"] == "vector"
+    assert client.hybrid_calls[-1]["query"] is None
+    assert client.hybrid_calls[-1]["query_embedding"] == [1.0, 0.0, 0.0]
+    assert client.hybrid_calls[-1]["return_embedding"] is True
+
+
+def test_hybrid_overlapping_candidates_are_fused_and_fusion_options_pass_through() -> None:
+    store, client = make_populated_store()
+    fusion = HybridFusionOptions(
+        method="rrf",
+        rrf_k=10,
+        tie_policy="fused_score_best_rank_source_order_id",
+        source_order=["text", "vector"],
+    )
+    retriever = TreeDBHybridRetriever(
+        document_store=store,
+        top_k=3,
+        text_candidate_limit=3,
+        vector_candidate_limit=3,
+        ef_search=64,
+        fusion=fusion,
+    )
+
+    result = retriever.run(query="refund", query_embedding=[1.0, 0.0, 0.0])
+
+    documents = result["documents"]
+    assert documents[0].id in {"alpha", "gamma"}
+    assert documents[0].meta["_treedb_search"]["fusion_method"] == "rrf"
+    assert len(documents[0].meta["_treedb_search"]["sources"]) == 2
+    assert client.hybrid_calls[-1]["fusion"] == {
+        "method": "rrf",
+        "rrf_k": 10,
+        "tie_policy": "fused_score_best_rank_source_order_id",
+        "source_order": ["text", "vector"],
+    }
+    assert client.hybrid_calls[-1]["text_candidate_limit"] == 3
+    assert client.hybrid_calls[-1]["vector_candidate_limit"] == 3
+    assert client.hybrid_calls[-1]["ef_search"] == 64
+
+
+def test_hybrid_runtime_fusion_options_override_init_options() -> None:
+    store, client = make_populated_store()
+    retriever = TreeDBHybridRetriever(
+        document_store=store,
+        fusion={"method": "rrf", "rrf_k": 60, "source_order": ["text", "vector"]},
+    )
+
+    retriever.run(
+        query="refund",
+        query_embedding=[1.0, 0.0, 0.0],
+        fusion={"method": "rrf", "rrf_k": 5, "source_order": ["vector", "text"]},
+    )
+
+    assert client.hybrid_calls[-1]["fusion"] == {"method": "rrf", "rrf_k": 5, "source_order": ["vector", "text"]}
+
+
+def test_hybrid_filter_policy_replace_uses_runtime_filters_without_mutating_init_filters() -> None:
+    store, client = make_populated_store()
+    init_filters = {"field": "meta.category", "operator": "==", "value": "A"}
+    retriever = TreeDBHybridRetriever(
+        document_store=store,
+        filters=init_filters,
+        top_k=3,
+        filter_policy=FilterPolicy.REPLACE,
+    )
+
+    result = retriever.run(query="policy", filters={"field": "meta.category", "operator": "==", "value": "B"})
+
+    assert [doc.id for doc in result["documents"]] == ["beta"]
+    assert client.hybrid_calls[-1]["filter"] == {"field": "meta.category", "operator": "==", "value": "B"}
+    assert retriever.filters == init_filters
+
+
+def test_hybrid_filter_policy_merge_passes_combined_runtime_and_init_filters() -> None:
+    store, client = make_populated_store()
+    retriever = TreeDBHybridRetriever(
+        document_store=store,
+        filters={"field": "meta.category", "operator": "==", "value": "A"},
+        top_k=3,
+        filter_policy="merge",
+    )
+
+    result = retriever.run(query="refund", filters={"field": "meta.rank", "operator": ">=", "value": 3})
+
+    assert [doc.id for doc in result["documents"]] == ["gamma"]
+    assert client.hybrid_calls[-1]["filter"] == {
+        "operator": "AND",
+        "conditions": [
+            {"field": "meta.category", "operator": "==", "value": "A"},
+            {"field": "meta.rank", "operator": ">=", "value": 3},
+        ],
+    }
+
+
+def test_hybrid_filters_fail_closed_through_service_without_scan_fallback() -> None:
+    class UnsupportedFilterClient(FakeTreeDBClient):
+        def search_hybrid(self, *args: object, **kwargs: object) -> object:
+            self.hybrid_calls.append({"filter": copy.deepcopy(kwargs.get("filter"))})
+            raise UnsupportedError("unsupported", "hybrid filters unsupported")
+
+    client = UnsupportedFilterClient()
+    store = TreeDBDocumentStore(
+        base_url="http://fake-treedb",
+        index="docs",
+        embedding_dimension=3,
+        client=client,  # type: ignore[arg-type]
+    )
+    retriever = TreeDBHybridRetriever(document_store=store)
+
+    with pytest.raises(DocumentStoreError, match="hybrid filters unsupported"):
+        retriever.run(query="policy", filters={"field": "meta.category", "operator": "==", "value": "A"})
+
+    assert client.hybrid_calls[-1]["filter"] == {"field": "meta.category", "operator": "==", "value": "A"}
+    assert client.filter_calls == []
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        IndexNotFoundError("index_not_found", "missing vector index"),
+        IndexStaleError("index_stale", "stale hybrid snapshot"),
+        IndexUnavailableError("index_unavailable", "vector index unavailable"),
+    ],
+)
+def test_hybrid_service_index_errors_fail_closed_without_empty_success(error: Exception) -> None:
+    class ErrorClient(FakeTreeDBClient):
+        def search_hybrid(self, *args: object, **kwargs: object) -> object:
+            raise error
+
+    store = TreeDBDocumentStore(
+        base_url="http://fake-treedb",
+        index="docs",
+        embedding_dimension=3,
+        client=ErrorClient(),  # type: ignore[arg-type]
+    )
+    retriever = TreeDBHybridRetriever(document_store=store)
+
+    with pytest.raises(DocumentStoreError, match=str(error).split(": ", 1)[-1]):
+        retriever.run(query_embedding=[1.0, 0.0, 0.0])
+
+
+def test_hybrid_to_dict_from_dict_round_trip() -> None:
+    store = TreeDBDocumentStore(
+        base_url="http://fake-treedb",
+        index="serialized",
+        embedding_dimension=3,
+        ensure_index=False,
+        client=FakeTreeDBClient(),  # type: ignore[arg-type]
+    )
+    retriever = TreeDBHybridRetriever(
+        document_store=store,
+        filters={"field": "meta.category", "operator": "==", "value": "A"},
+        top_k=5,
+        candidate_limit=50,
+        text_candidate_limit=25,
+        vector_candidate_limit=30,
+        ef_search=64,
+        fusion={"method": "rrf", "rrf_k": 60, "tie_policy": "fused_score_best_rank_source_order_id"},
+        return_embedding=True,
+        filter_policy=FilterPolicy.MERGE,
+    )
+
+    serialized = retriever.to_dict()
+    original = copy.deepcopy(serialized)
+
+    assert serialized["type"] == "haystack_integrations.components.retrievers.treedb.hybrid_retriever.TreeDBHybridRetriever"
+    restored = TreeDBHybridRetriever.from_dict(serialized)
+    assert serialized == original
+    assert restored.top_k == 5
+    assert restored.candidate_limit == 50
+    assert restored.text_candidate_limit == 25
+    assert restored.vector_candidate_limit == 30
+    assert restored.ef_search == 64
+    assert restored.fusion == {"method": "rrf", "rrf_k": 60, "tie_policy": "fused_score_best_rank_source_order_id"}
+    assert restored.return_embedding is True
+    assert restored.filter_policy == FilterPolicy.MERGE
+    assert isinstance(restored.document_store, TreeDBDocumentStore)
+
+
+def test_hybrid_pipeline_wiring_runs_retriever_component() -> None:
+    store, _ = make_populated_store()
+    pipeline = Pipeline()
+    pipeline.add_component("retriever", TreeDBHybridRetriever(document_store=store, top_k=1))
+
+    result = pipeline.run({"retriever": {"query": "refund", "query_embedding": [1.0, 0.0, 0.0]}})
+
+    assert result["retriever"]["documents"]
+
+
+def test_hybrid_run_rejects_missing_query_sources_and_non_positive_top_k() -> None:
+    store, client = make_populated_store()
+    retriever = TreeDBHybridRetriever(document_store=store)
+
+    with pytest.raises(ValueError, match="query or query_embedding"):
+        retriever.run()
+    with pytest.raises(ValueError, match="query or query_embedding"):
+        retriever.run(query="")
+    assert client.hybrid_calls == []
+    with pytest.raises(ValueError, match="top_k"):
+        retriever.run(query="policy", top_k=0)

--- a/clients/python/treedb_haystack/tests/test_keyword_retriever.py
+++ b/clients/python/treedb_haystack/tests/test_keyword_retriever.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+import copy
+
+import pytest
+from haystack import Document as HaystackDocument
+from haystack import Pipeline
+from haystack.document_stores.errors import DocumentStoreError
+from haystack.document_stores.types import DuplicatePolicy, FilterPolicy
+from treedb_client import IndexNotFoundError, IndexStaleError, IndexUnavailableError, UnsupportedError
+
+import _support  # noqa: F401
+from fakes import FakeTreeDBClient
+from haystack_integrations.components.retrievers.treedb import TreeDBKeywordRetriever
+from haystack_integrations.document_stores.treedb import TreeDBDocumentStore
+
+
+def make_populated_store() -> tuple[TreeDBDocumentStore, FakeTreeDBClient]:
+    client = FakeTreeDBClient()
+    store = TreeDBDocumentStore(
+        base_url="http://fake-treedb",
+        index="docs",
+        embedding_dimension=3,
+        similarity="cosine",
+        return_embedding=False,
+        client=client,  # type: ignore[arg-type]
+    )
+    store.write_documents(
+        [
+            HaystackDocument(
+                id="alpha",
+                content="refund refund policy details",
+                embedding=[1.0, 0.0, 0.0],
+                meta={"category": "A", "rank": 1},
+            ),
+            HaystackDocument(
+                id="beta",
+                content="policy handbook",
+                embedding=[0.0, 1.0, 0.0],
+                meta={"category": "B", "rank": 2},
+            ),
+            HaystackDocument(
+                id="gamma",
+                content="shipping notes",
+                embedding=[0.0, 0.0, 1.0],
+                meta={"category": "A", "rank": 3},
+            ),
+        ],
+        policy=DuplicatePolicy.OVERWRITE,
+    )
+    return store, client
+
+
+def test_invalid_document_store_type() -> None:
+    with pytest.raises(ValueError, match="TreeDBDocumentStore"):
+        TreeDBKeywordRetriever(document_store="not-a-store")  # type: ignore[arg-type]
+
+
+def test_keyword_retriever_returns_ranked_lexical_results_and_search_metadata() -> None:
+    store, client = make_populated_store()
+    retriever = TreeDBKeywordRetriever(
+        document_store=store,
+        top_k=2,
+        operator="or",
+        candidate_limit=10,
+        max_postings_scanned=1000,
+        return_embedding=True,
+    )
+
+    result = retriever.run(query="refund policy")
+
+    documents = result["documents"]
+    assert [doc.id for doc in documents] == ["alpha", "beta"]
+    assert documents[0].score == 3.0
+    assert documents[0].embedding == [1.0, 0.0, 0.0]
+    assert documents[0].meta["_treedb_search"]["type"] == "keyword"
+    assert documents[0].meta["_treedb_search"]["matched_terms"] == ["policy", "refund"]
+    assert client.keyword_calls[-1] == {
+        "query": "refund policy",
+        "top_k": 2,
+        "operator": "or",
+        "candidate_limit": 10,
+        "max_postings_scanned": 1000,
+        "filter": None,
+        "return_embedding": True,
+        "expected_generation": 1,
+    }
+
+
+def test_keyword_filter_policy_replace_uses_runtime_filters_without_mutating_init_filters() -> None:
+    store, client = make_populated_store()
+    init_filters = {"field": "meta.category", "operator": "==", "value": "A"}
+    retriever = TreeDBKeywordRetriever(
+        document_store=store,
+        filters=init_filters,
+        top_k=3,
+        filter_policy=FilterPolicy.REPLACE,
+    )
+
+    result = retriever.run(query="policy", filters={"field": "meta.category", "operator": "==", "value": "B"})
+
+    assert [doc.id for doc in result["documents"]] == ["beta"]
+    assert client.keyword_calls[-1]["filter"] == {"field": "meta.category", "operator": "==", "value": "B"}
+    assert retriever.filters == init_filters
+
+
+def test_keyword_filter_policy_merge_passes_combined_runtime_and_init_filters() -> None:
+    store, client = make_populated_store()
+    retriever = TreeDBKeywordRetriever(
+        document_store=store,
+        filters={"field": "meta.category", "operator": "==", "value": "A"},
+        top_k=3,
+        filter_policy="merge",
+    )
+
+    result = retriever.run(query="refund policy", filters={"field": "meta.rank", "operator": "<", "value": 3})
+
+    assert [doc.id for doc in result["documents"]] == ["alpha"]
+    assert client.keyword_calls[-1]["filter"] == {
+        "operator": "AND",
+        "conditions": [
+            {"field": "meta.category", "operator": "==", "value": "A"},
+            {"field": "meta.rank", "operator": "<", "value": 3},
+        ],
+    }
+
+
+def test_keyword_filter_policy_replace_uses_init_filters_when_runtime_filters_are_absent() -> None:
+    store, client = make_populated_store()
+    retriever = TreeDBKeywordRetriever(
+        document_store=store,
+        filters={"field": "meta.category", "operator": "==", "value": "A"},
+        top_k=3,
+    )
+
+    result = retriever.run(query="policy")
+
+    assert [doc.id for doc in result["documents"]] == ["alpha"]
+    assert client.keyword_calls[-1]["filter"] == {"field": "meta.category", "operator": "==", "value": "A"}
+
+
+def test_keyword_filters_fail_closed_through_service_without_scan_fallback() -> None:
+    class UnsupportedFilterClient(FakeTreeDBClient):
+        def search_keyword(self, *args: object, **kwargs: object) -> object:
+            self.keyword_calls.append({"filter": copy.deepcopy(kwargs.get("filter"))})
+            raise UnsupportedError("unsupported", "keyword filters unsupported")
+
+    client = UnsupportedFilterClient()
+    store = TreeDBDocumentStore(
+        base_url="http://fake-treedb",
+        index="docs",
+        embedding_dimension=3,
+        client=client,  # type: ignore[arg-type]
+    )
+    retriever = TreeDBKeywordRetriever(document_store=store)
+
+    with pytest.raises(DocumentStoreError, match="keyword filters unsupported"):
+        retriever.run(query="policy", filters={"field": "meta.category", "operator": "==", "value": "A"})
+
+    assert client.keyword_calls[-1]["filter"] == {"field": "meta.category", "operator": "==", "value": "A"}
+    assert client.filter_calls == []
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        IndexNotFoundError("index_not_found", "missing text index"),
+        IndexStaleError("index_stale", "stale text index"),
+        IndexUnavailableError("index_unavailable", "text index unavailable"),
+    ],
+)
+def test_keyword_service_index_errors_fail_closed_without_empty_success(error: Exception) -> None:
+    class ErrorClient(FakeTreeDBClient):
+        def search_keyword(self, *args: object, **kwargs: object) -> object:
+            raise error
+
+    store = TreeDBDocumentStore(
+        base_url="http://fake-treedb",
+        index="docs",
+        embedding_dimension=3,
+        client=ErrorClient(),  # type: ignore[arg-type]
+    )
+    retriever = TreeDBKeywordRetriever(document_store=store)
+
+    with pytest.raises(DocumentStoreError, match=str(error).split(": ", 1)[-1]):
+        retriever.run(query="policy")
+
+
+def test_keyword_to_dict_from_dict_round_trip() -> None:
+    store = TreeDBDocumentStore(
+        base_url="http://fake-treedb",
+        index="serialized",
+        embedding_dimension=3,
+        ensure_index=False,
+        client=FakeTreeDBClient(),  # type: ignore[arg-type]
+    )
+    retriever = TreeDBKeywordRetriever(
+        document_store=store,
+        filters={"field": "meta.category", "operator": "==", "value": "A"},
+        top_k=5,
+        operator="and",
+        candidate_limit=50,
+        max_postings_scanned=500,
+        return_embedding=True,
+        filter_policy=FilterPolicy.MERGE,
+    )
+
+    serialized = retriever.to_dict()
+    original = copy.deepcopy(serialized)
+
+    assert serialized["type"] == "haystack_integrations.components.retrievers.treedb.keyword_retriever.TreeDBKeywordRetriever"
+    restored = TreeDBKeywordRetriever.from_dict(serialized)
+    assert serialized == original
+    assert restored.top_k == 5
+    assert restored.operator == "and"
+    assert restored.candidate_limit == 50
+    assert restored.max_postings_scanned == 500
+    assert restored.return_embedding is True
+    assert restored.filter_policy == FilterPolicy.MERGE
+    assert isinstance(restored.document_store, TreeDBDocumentStore)
+
+
+def test_keyword_pipeline_wiring_runs_retriever_component() -> None:
+    store, _ = make_populated_store()
+    pipeline = Pipeline()
+    pipeline.add_component("retriever", TreeDBKeywordRetriever(document_store=store, top_k=1))
+
+    result = pipeline.run({"retriever": {"query": "refund policy"}})
+
+    assert [doc.id for doc in result["retriever"]["documents"]] == ["alpha"]
+
+
+def test_keyword_run_rejects_non_positive_top_k() -> None:
+    store, _ = make_populated_store()
+    retriever = TreeDBKeywordRetriever(document_store=store)
+
+    with pytest.raises(ValueError, match="top_k"):
+        retriever.run(query="policy", top_k=0)


### PR DESCRIPTION
## Objective

Add TreeDB Haystack keyword and hybrid retrievers for #2534 on top of the merged TreeDB Python client keyword/hybrid contract from #2575.

## Base / scope

- Base: `main` after #2575 merged as `c44c0ea4be5e17f1f308d4ff458b0162fca31e1a`.
- Head: `0b8c3ee1d2b0763d51c85fdca7d800e171dbf144`.
- Diff is Haystack-package only under `clients/python/treedb_haystack`.
- No TreeDB Go service/core changes and no Python client contract changes.

## What changed

- Adds `TreeDBKeywordRetriever` in `haystack_integrations.components.retrievers.treedb.keyword_retriever` with:
  - `run(query, filters=None, top_k=None)`
  - init-time `operator`, `candidate_limit`, `max_postings_scanned`, `return_embedding`, and Haystack `FilterPolicy` support.
- Adds `TreeDBHybridRetriever` in `haystack_integrations.components.retrievers.treedb.hybrid_retriever` with:
  - `run(query=None, query_embedding=None, filters=None, top_k=None, candidate_limit=None, text_candidate_limit=None, vector_candidate_limit=None, ef_search=None, fusion=None, return_embedding=None)`
  - init/runtime candidate limits, `ef_search`, TreeDB fusion options, return-embedding controls, and Haystack `FilterPolicy` support.
- Exports keyword/hybrid retrievers alongside `TreeDBEmbeddingRetriever`.
- Extends `TreeDBDocumentStore` service delegation helpers for keyword/hybrid search without client-side scans or fallback fusion.
- Updates fakes, unit tests, README, and examples to cover embedding vs keyword vs hybrid usage.

## Contract notes

The merged #2575 client contract is used unchanged:

- `TreeDBClient.search_keyword(...)`
- `TreeDBClient.search_hybrid(...)`
- `search_hybrid` raises `InvalidRequestError` before HTTP when neither `query` nor `query_embedding` is supplied.

The Haystack hybrid retriever rejects missing/empty text-only input when no embedding is supplied, so it does not call the client with both sources absent.

## Filter behavior / caveat

- Haystack `FilterPolicy.REPLACE` and `FilterPolicy.MERGE` are preserved.
- If keyword/hybrid filters are effective after policy application, the retrievers pass them to the TreeDB client/service.
- Current TreeDB keyword/hybrid metadata filters fail closed with service `unsupported` until TreeDB exposes bounded scalar filter mapping for those routes.
- This package does **not** fetch/filter documents locally and does **not** silently drop user filters except according to Haystack filter-policy semantics.

## Tests run on final `main` base

- `cd clients/python/treedb_haystack && PYTHONPATH=src:../treedb_client/src python3.12 -m compileall -q src tests examples`
- `cd clients/python/treedb_haystack && PYTHONPATH=src:../treedb_client/src uv run --no-project --python 3.12 --with pytest --with 'haystack-ai>=2.26.1' python -m pytest -q` — 55 passed, 1 skipped
- `cd clients/python/treedb_haystack && PYTHONPATH=src:../treedb_client/src uv run --no-project --python 3.12 --with mypy --with 'haystack-ai>=2.26.1' python -m mypy -p haystack_integrations.document_stores.treedb -p haystack_integrations.components.retrievers.treedb`
- `cd clients/python/treedb_haystack && uv run --no-project --python 3.12 --with ruff ruff check .`
- `cd clients/python/treedb_client && PYTHONPATH=src python3.12 -m unittest discover -s tests` — 35 ran, 1 skipped
- `git diff --check`

## Performance

Haystack wrapper only: this PR delegates to existing TreeDB service/client calls and adds no TreeDB Go service/core hot-path changes. No TreeDB benchmark is required; performance risk is limited to Python wrapper serialization/filter-policy application outside TreeDB query execution.

## CI / review status

- Latest-head CI for `0b8c3ee1d2b0763d51c85fdca7d800e171dbf144`: green.
- Merge state: clean against `main`.
- Codex review: requested; no major issues found.
- Copilot review: requested; acknowledged with eyes reaction; no Copilot review comments or review threads observed.
- CodeRabbit review: requested; status check is passing but currently labeled review skipped, and the later review-command response says review finished; no review findings surfaced.
- Review threads: 0 unresolved.

## Non-goals

- No TreeDB service/core changes.
- No Python client changes beyond the merged #2575 base.
- No client-side keyword scans, metadata filtering fallbacks, or client-side hybrid fusion fallbacks.
- No code-symbol graph retrieval.

