### PR TITLE
Add TreeDB benchmark vector service contract

### DIFF
--- a/TreeDB/documentservice/http.go
+++ b/TreeDB/documentservice/http.go
@@ -81,6 +81,10 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			writeError(w, serviceErrorf(CodeInvalidRequest, "method %s is not allowed for %s", r.Method, r.URL.Path))
 			return
 		}
+		if len(parts) == 4 {
+			h.serveIndexOperation(w, r, index, parts[3], maxBodyBytes)
+			return
+		}
 		if len(parts) == 5 && parts[3] == "documents" {
 			h.serveDocumentOperation(w, r, index, parts[4], maxBodyBytes)
 			return
@@ -91,6 +95,35 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	writeError(w, serviceErrorf(CodeInvalidRequest, "unknown document service route %q", r.URL.Path))
+}
+
+func (h *Handler) serveIndexOperation(w http.ResponseWriter, r *http.Request, index, op string, maxBodyBytes int64) {
+	switch op {
+	case "reset":
+		var req ResetIndexRequest
+		if !h.decodeJSON(w, r, maxBodyBytes, &req) {
+			return
+		}
+		res, err := h.Service.ResetIndex(r.Context(), index, req)
+		if err != nil {
+			writeError(w, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, res)
+	case "optimize":
+		var req OptimizeIndexRequest
+		if !h.decodeJSON(w, r, maxBodyBytes, &req) {
+			return
+		}
+		res, err := h.Service.OptimizeIndex(r.Context(), index, req)
+		if err != nil {
+			writeError(w, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, res)
+	default:
+		writeError(w, serviceErrorf(CodeInvalidRequest, "unknown index operation %q", op))
+	}
 }
 
 func (h *Handler) serveDocumentOperation(w http.ResponseWriter, r *http.Request, index, op string, maxBodyBytes int64) {
@@ -174,6 +207,17 @@ func (h *Handler) serveSearchOperation(w http.ResponseWriter, r *http.Request, i
 			return
 		}
 		res, err := h.Service.SearchHybrid(r.Context(), index, req)
+		if err != nil {
+			writeError(w, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, res)
+	case "vector-index":
+		var req BenchmarkVectorSearchRequest
+		if !h.decodeJSON(w, r, maxBodyBytes, &req) {
+			return
+		}
+		res, err := h.Service.SearchBenchmarkVector(r.Context(), index, req)
 		if err != nil {
 			writeError(w, err)
 			return

--- a/TreeDB/documentservice/http_test.go
+++ b/TreeDB/documentservice/http_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/snissn/gomap/TreeDB/collections"
 )
 
 func TestHTTPMalformedJSONKeywordHybridAndErrorPayloads(t *testing.T) {
@@ -118,6 +120,55 @@ func TestHTTPDocumentVectorRoundTrip(t *testing.T) {
 	postJSON(t, handler, "/v1/indexes/docs/search/vector", DenseVectorSearchRequest{QueryEmbedding: []float32{1, 0}, TopK: 1, ReturnEmbedding: true}, http.StatusOK, &search)
 	if len(search.Documents) != 1 || search.Documents[0].ID != "a" || len(search.Documents[0].Embedding) != 2 || search.Documents[0].Score == nil {
 		t.Fatalf("search=%+v", search)
+	}
+}
+
+func TestHTTPBenchmarkLifecycleRoutesAndExactVectorShape(t *testing.T) {
+	svc, db := newTestService(t)
+	defer db.Close()
+	handler := NewHandler(svc)
+
+	var reset ResetIndexResponse
+	postJSON(t, handler, "/v1/indexes/bench/reset", ResetIndexRequest{
+		Dimension: 2,
+		DropOld:   true,
+		VectorIndexOptions: &BenchmarkVectorIndexOptions{
+			Strategy: collections.VectorIndexStrategyColumnGraph,
+			QuantizedIndexes: []QuantizedIndexInfo{{
+				Name:  "embedding.scalar_u8.fast",
+				Codec: collections.QuantizedVectorCodecScalarU8,
+			}},
+		},
+	}, http.StatusOK, &reset)
+	if !reset.Index.Capabilities.BenchmarkLifecycle || !reset.Index.Capabilities.NoDocumentVectorSearch || !reset.Index.Capabilities.ScalarU8QuantizedRerank {
+		t.Fatalf("reset capabilities=%+v", reset.Index.Capabilities)
+	}
+	postJSON(t, handler, "/v1/indexes/bench/documents/upsert", UpsertDocumentsRequest{Documents: []Document{
+		{ID: "a", Content: "alpha", Embedding: []float32{1, 0}},
+		{ID: "b", Content: "beta", Embedding: []float32{0, 1}},
+	}}, http.StatusOK, nil)
+	var optimize OptimizeIndexResponse
+	postJSON(t, handler, "/v1/indexes/bench/optimize", OptimizeIndexRequest{}, http.StatusOK, &optimize)
+	if !optimize.Status.Loaded || optimize.VectorIndexName != defaultVectorIndexName {
+		t.Fatalf("optimize=%+v", optimize)
+	}
+	var benchmark BenchmarkVectorSearchResponse
+	postJSON(t, handler, "/v1/indexes/bench/search/vector-index", BenchmarkVectorSearchRequest{QueryEmbedding: []float32{1, 0}, TopK: 1, EfSearch: 8}, http.StatusOK, &benchmark)
+	if !benchmark.NoDocuments || len(benchmark.Results) != 1 || benchmark.Results[0].ID != "a" || benchmark.Stats.DocumentsFetched != 0 {
+		t.Fatalf("benchmark vector response=%+v stats=%+v", benchmark, benchmark.Stats)
+	}
+
+	var exactShape map[string]any
+	postJSON(t, handler, "/v1/indexes/bench/search/vector", DenseVectorSearchRequest{QueryEmbedding: []float32{1, 0}, TopK: 1}, http.StatusOK, &exactShape)
+	for _, unexpected := range []string{"results", "stats", "diagnostics", "no_documents", "query_mode"} {
+		if _, ok := exactShape[unexpected]; ok {
+			t.Fatalf("exact /search/vector included benchmark field %q in shape=%+v", unexpected, exactShape)
+		}
+	}
+	for _, required := range []string{"index", "documents", "metric", "exact", "candidates"} {
+		if _, ok := exactShape[required]; !ok {
+			t.Fatalf("exact /search/vector missing field %q in shape=%+v", required, exactShape)
+		}
 	}
 }
 

--- a/TreeDB/documentservice/service.go
+++ b/TreeDB/documentservice/service.go
@@ -450,6 +450,9 @@ func (s *Service) SearchBenchmarkVector(ctx context.Context, index string, req B
 	if req.EfSearch < 0 || req.QuantizedRerankCandidates < 0 {
 		return BenchmarkVectorSearchResponse{}, serviceError(CodeInvalidRequest, "ef_search and quantized_rerank_candidates must be non-negative")
 	}
+	if err := validateBenchmarkVectorStatsMode(req.StatsMode); err != nil {
+		return BenchmarkVectorSearchResponse{}, err
+	}
 	if err := validateEmbedding("query_embedding", req.QueryEmbedding, info.Dimension, info.Metric); err != nil {
 		return BenchmarkVectorSearchResponse{}, err
 	}
@@ -1082,6 +1085,20 @@ func benchmarkVectorSearchResults(results []collections.VectorIndexSearchResult)
 		out[i] = BenchmarkVectorSearchResult{ID: string(result.ID), Ordinal: result.Ordinal, Score: result.Score}
 	}
 	return out
+}
+
+func validateBenchmarkVectorStatsMode(mode collections.VectorIndexSearchStatsMode) error {
+	switch mode {
+	case collections.VectorIndexSearchStatsModeDefault,
+		collections.VectorIndexSearchStatsModeMinimal,
+		collections.VectorIndexSearchStatsModeProduction,
+		collections.VectorIndexSearchStatsModeFullDiagnostics:
+		return nil
+	case collections.VectorIndexSearchStatsModeBenchmarkDebug:
+		return serviceError(CodeInvalidRequest, "benchmark vector search does not support benchmark_debug stats_mode")
+	default:
+		return serviceErrorf(CodeInvalidRequest, "unsupported benchmark vector stats_mode %q", mode)
+	}
 }
 
 func validateBenchmarkVectorSearchRequestShape(mode BenchmarkVectorQueryMode, req BenchmarkVectorSearchRequest) error {

--- a/TreeDB/documentservice/service.go
+++ b/TreeDB/documentservice/service.go
@@ -50,11 +50,13 @@ func (s *Service) CreateIndex(ctx context.Context, req CreateIndexRequest) (Inde
 	if err != nil {
 		return IndexInfo{}, err
 	}
+	vectorOptions, err := benchmarkVectorIndexOptionsForCreate(metric, req.VectorIndexOptions)
+	if err != nil {
+		return IndexInfo{}, err
+	}
 	options := collections.CollectionOptions{DocumentFormat: collections.DocumentFormatJSON}
-	vectorStrategy := collections.VectorIndexStrategyNativeRuntime
-	if metric == MetricCosine {
+	if vectorOptions.strategy == collections.VectorIndexStrategyColumnGraph {
 		options.ColumnStore = serviceColumnStoreConfig(req.Dimension)
-		vectorStrategy = collections.VectorIndexStrategyColumnGraph
 	}
 	meta := &collections.CollectionMeta{
 		Name:    req.Name,
@@ -64,9 +66,13 @@ func (s *Service) CreateIndex(ctx context.Context, req CreateIndexRequest) (Inde
 			Field:            defaultEmbeddingField,
 			Metric:           collectionMetric,
 			Dimensions:       req.Dimension,
+			M:                vectorOptions.m,
+			EfConstruction:   vectorOptions.efConstruction,
+			EfSearch:         vectorOptions.efSearch,
 			Encoding:         collections.VectorIndexEncodingFloat32,
-			Strategy:         vectorStrategy,
+			Strategy:         vectorOptions.strategy,
 			SchemaGeneration: 1,
+			QuantizedIndexes: vectorOptions.quantizedIndexes,
 		}},
 		TextIndexes: []collections.TextIndexDefinition{{
 			Name:             defaultTextIndexName,
@@ -345,6 +351,154 @@ func (s *Service) SearchDenseVector(ctx context.Context, index string, req Dense
 	return DenseVectorSearchResponse{Index: info, Documents: docs, Metric: info.Metric, Exact: true, Candidates: candidateCount}, nil
 }
 
+// ResetIndex creates a missing benchmark index or clears an existing compatible
+// non-column_graph index when drop_old is requested. Column_graph benchmark
+// indexes intentionally fail closed for in-place reset: rebuilding those assets
+// after delete/reinsert tombstones is not the fresh insert-only load boundary
+// VectorDBBench needs. Managed benchmark runs should use a fresh data directory;
+// external shared services should use a unique index name per run.
+func (s *Service) ResetIndex(ctx context.Context, index string, req ResetIndexRequest) (ResetIndexResponse, error) {
+	if err := ctxErr(ctx); err != nil {
+		return ResetIndexResponse{}, err
+	}
+	if err := collections.ValidateCollectionName(index); err != nil {
+		return ResetIndexResponse{}, wrapServiceError(CodeInvalidRequest, "invalid index name", err)
+	}
+	existingCol, existingInfo, err := s.openIndex(ctx, index, 0)
+	if err != nil {
+		if ErrorCodeOf(err) != CodeIndexNotFound {
+			return ResetIndexResponse{}, err
+		}
+		info, err := s.CreateIndex(ctx, CreateIndexRequest{Name: index, Dimension: req.Dimension, Metric: req.Metric, VectorIndexOptions: req.VectorIndexOptions})
+		if err != nil {
+			return ResetIndexResponse{}, err
+		}
+		return ResetIndexResponse{Index: info, Created: true, Reset: false, DropOld: req.DropOld, DroppedDocuments: 0}, nil
+	}
+	if !req.DropOld {
+		return ResetIndexResponse{}, serviceErrorf(CodeConflict, "index %q already exists and drop_old=false", index)
+	}
+	if req.Dimension == 0 {
+		req.Dimension = existingInfo.Dimension
+	}
+	if req.Metric == "" {
+		req.Metric = existingInfo.Metric
+	}
+	if existingInfo.Capabilities.ColumnGraphVectorSearch {
+		return ResetIndexResponse{}, serviceErrorf(CodeUnsupported, "drop_old reset for column_graph benchmark index %q requires a fresh data directory or unique index name", index)
+	}
+	if _, err := s.CreateIndex(ctx, CreateIndexRequest{Name: index, Dimension: req.Dimension, Metric: req.Metric, VectorIndexOptions: req.VectorIndexOptions}); err != nil {
+		return ResetIndexResponse{}, err
+	}
+
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	ids, err := s.collectMatchingIDs(ctx, existingCol, nil)
+	if err != nil {
+		return ResetIndexResponse{}, err
+	}
+	if len(ids) > 0 {
+		deleteIDs := make([][]byte, len(ids))
+		for i, id := range ids {
+			deleteIDs[i] = []byte(id)
+		}
+		if _, err := existingCol.DeleteBatch(deleteIDs); err != nil {
+			return ResetIndexResponse{}, mapCollectionMaintenanceError("reset index", err)
+		}
+	}
+	_, info, err := s.openIndex(ctx, index, 0)
+	if err != nil {
+		return ResetIndexResponse{}, err
+	}
+	return ResetIndexResponse{Index: info, Created: false, Reset: true, DropOld: req.DropOld, DroppedDocuments: len(ids)}, nil
+}
+
+// OptimizeIndex rebuilds service vector assets after a benchmark load phase.
+func (s *Service) OptimizeIndex(ctx context.Context, index string, req OptimizeIndexRequest) (OptimizeIndexResponse, error) {
+	col, info, err := s.openIndex(ctx, index, req.ExpectedGeneration)
+	if err != nil {
+		return OptimizeIndexResponse{}, err
+	}
+	vectorIndexName := strings.TrimSpace(req.VectorIndexName)
+	if vectorIndexName == "" {
+		vectorIndexName = info.VectorIndexName
+	}
+	if vectorIndexName != info.VectorIndexName {
+		return OptimizeIndexResponse{}, serviceErrorf(CodeInvalidRequest, "unsupported vector_index_name %q", req.VectorIndexName)
+	}
+	status, err := col.RebuildVectorIndex(vectorIndexName)
+	if err != nil {
+		return OptimizeIndexResponse{}, mapCollectionMaintenanceError("optimize vector index", err)
+	}
+	return OptimizeIndexResponse{Index: info, VectorIndexName: vectorIndexName, Status: vectorIndexMaintenanceStatus(status)}, nil
+}
+
+// SearchBenchmarkVector runs fail-closed no-document vector-index benchmark
+// search. It never materializes documents and never falls back to exact dense
+// document scanning.
+func (s *Service) SearchBenchmarkVector(ctx context.Context, index string, req BenchmarkVectorSearchRequest) (BenchmarkVectorSearchResponse, error) {
+	col, info, err := s.openIndex(ctx, index, req.ExpectedGeneration)
+	if err != nil {
+		return BenchmarkVectorSearchResponse{}, err
+	}
+	if !info.Capabilities.NoDocumentVectorSearch {
+		return BenchmarkVectorSearchResponse{}, serviceError(CodeIndexUnavailable, "no-document vector-index search requires a cosine column_graph index")
+	}
+	if req.TopK <= 0 {
+		return BenchmarkVectorSearchResponse{}, serviceError(CodeInvalidRequest, "top_k must be positive")
+	}
+	if req.EfSearch < 0 || req.QuantizedRerankCandidates < 0 {
+		return BenchmarkVectorSearchResponse{}, serviceError(CodeInvalidRequest, "ef_search and quantized_rerank_candidates must be non-negative")
+	}
+	if err := validateEmbedding("query_embedding", req.QueryEmbedding, info.Dimension, info.Metric); err != nil {
+		return BenchmarkVectorSearchResponse{}, err
+	}
+	vectorIndexName := strings.TrimSpace(req.VectorIndexName)
+	if vectorIndexName == "" {
+		vectorIndexName = info.VectorIndexName
+	}
+	if vectorIndexName != info.VectorIndexName {
+		return BenchmarkVectorSearchResponse{}, serviceErrorf(CodeInvalidRequest, "unsupported vector_index_name %q", req.VectorIndexName)
+	}
+	queryMode, collectionQueryMode, err := normalizeBenchmarkVectorQueryMode(req.QueryMode)
+	if err != nil {
+		return BenchmarkVectorSearchResponse{}, err
+	}
+	var buffer collections.VectorIndexSearchBuffer
+	search, err := col.SearchVectorIndexWithBuffer(collections.VectorIndexSearchOptions{
+		IndexName:                 vectorIndexName,
+		Query:                     append([]float32(nil), req.QueryEmbedding...),
+		QueryMode:                 collectionQueryMode,
+		QuantizedIndexName:        req.QuantizedIndexName,
+		QuantizedRerankCandidates: req.QuantizedRerankCandidates,
+		TopK:                      req.TopK,
+		EfSearch:                  req.EfSearch,
+		StatsMode:                 req.StatsMode,
+	}, &buffer)
+	if err != nil {
+		return BenchmarkVectorSearchResponse{}, mapVectorIndexSearchError("benchmark vector search", err)
+	}
+	if err := validateBenchmarkVectorSearchRoute(queryMode, req, search); err != nil {
+		return BenchmarkVectorSearchResponse{}, err
+	}
+	results := benchmarkVectorSearchResults(search.Results)
+	if results == nil {
+		results = []BenchmarkVectorSearchResult{}
+	}
+	return BenchmarkVectorSearchResponse{
+		Index:                     info,
+		Results:                   results,
+		Metric:                    info.Metric,
+		VectorIndexName:           vectorIndexName,
+		QueryMode:                 queryMode,
+		QuantizedIndexName:        req.QuantizedIndexName,
+		QuantizedRerankCandidates: req.QuantizedRerankCandidates,
+		NoDocuments:               true,
+		Stats:                     search.Stats,
+		Diagnostics:               search.Diagnostics(),
+	}, nil
+}
+
 // SearchKeyword runs ranked lexical search over the service content text index.
 func (s *Service) SearchKeyword(ctx context.Context, index string, req KeywordSearchRequest) (KeywordSearchResponse, error) {
 	col, info, err := s.openIndex(ctx, index, req.ExpectedGeneration)
@@ -519,17 +673,22 @@ func indexInfoFromMeta(meta collections.CollectionMeta) (IndexInfo, error) {
 	}
 	hybridSearch := vectorDef.Strategy == collections.VectorIndexStrategyColumnGraph && vectorDef.Metric == collections.VectorMetricCosine && vectorDef.Encoding == collections.VectorIndexEncodingFloat32
 	return IndexInfo{
-		Name:            meta.Name,
-		Dimension:       vectorDef.Dimensions,
-		Metric:          metric,
-		Generation:      generation,
-		ContractVersion: ContractVersion,
-		EmbeddingField:  defaultEmbeddingField,
-		VectorIndexName: vectorDef.Name,
-		TextField:       defaultTextField,
-		TextIndexName:   textDef.Name,
-		DocumentType:    defaultCollectionDocType,
-		Capabilities:    indexCapabilities(hybridSearch),
+		Name:                 meta.Name,
+		Dimension:            vectorDef.Dimensions,
+		Metric:               metric,
+		Generation:           generation,
+		ContractVersion:      ContractVersion,
+		EmbeddingField:       defaultEmbeddingField,
+		VectorIndexName:      vectorDef.Name,
+		VectorStrategy:       vectorDef.Strategy,
+		VectorM:              vectorDef.M,
+		VectorEfConstruction: vectorDef.EfConstruction,
+		VectorEfSearch:       vectorDef.EfSearch,
+		QuantizedIndexes:     quantizedIndexInfos(vectorDef),
+		TextField:            defaultTextField,
+		TextIndexName:        textDef.Name,
+		DocumentType:         defaultCollectionDocType,
+		Capabilities:         indexCapabilities(vectorDef, hybridSearch),
 	}, nil
 }
 
@@ -574,6 +733,78 @@ func serviceTextIndexDefinition(meta collections.CollectionMeta) (collections.Te
 		return candidate, nil
 	}
 	return collections.TextIndexDefinition{}, serviceErrorf(CodeIndexUnavailable, "collection %q does not expose the service text index %q", meta.Name, defaultTextIndexName)
+}
+
+type normalizedBenchmarkVectorIndexOptions struct {
+	strategy         collections.VectorIndexStrategy
+	m                int
+	efConstruction   int
+	efSearch         int
+	quantizedIndexes []collections.QuantizedVectorIndexDefinition
+}
+
+func benchmarkVectorIndexOptionsForCreate(metric Metric, opts *BenchmarkVectorIndexOptions) (normalizedBenchmarkVectorIndexOptions, error) {
+	out := normalizedBenchmarkVectorIndexOptions{strategy: collections.VectorIndexStrategyNativeRuntime}
+	if metric == MetricCosine {
+		out.strategy = collections.VectorIndexStrategyColumnGraph
+	}
+	if opts == nil {
+		return out, nil
+	}
+	if opts.M < 0 || opts.EfConstruction < 0 || opts.EfSearch < 0 {
+		return normalizedBenchmarkVectorIndexOptions{}, serviceError(CodeInvalidRequest, "vector index m, ef_construction, and ef_search must be non-negative")
+	}
+	out.m = opts.M
+	out.efConstruction = opts.EfConstruction
+	out.efSearch = opts.EfSearch
+	if opts.Strategy != "" {
+		switch opts.Strategy {
+		case collections.VectorIndexStrategyNativeRuntime, collections.VectorIndexStrategyColumnGraph:
+			out.strategy = opts.Strategy
+		default:
+			return normalizedBenchmarkVectorIndexOptions{}, serviceErrorf(CodeInvalidRequest, "unsupported vector index strategy %q", opts.Strategy)
+		}
+	} else if len(opts.QuantizedIndexes) > 0 {
+		out.strategy = collections.VectorIndexStrategyColumnGraph
+	}
+	if out.strategy == collections.VectorIndexStrategyColumnGraph && metric != MetricCosine {
+		return normalizedBenchmarkVectorIndexOptions{}, serviceErrorf(CodeInvalidRequest, "vector index strategy %q requires metric %q", out.strategy, MetricCosine)
+	}
+	if len(opts.QuantizedIndexes) > 0 && out.strategy != collections.VectorIndexStrategyColumnGraph {
+		return normalizedBenchmarkVectorIndexOptions{}, serviceErrorf(CodeInvalidRequest, "quantized vector indexes require strategy %q", collections.VectorIndexStrategyColumnGraph)
+	}
+	if len(opts.QuantizedIndexes) == 0 {
+		return out, nil
+	}
+	out.quantizedIndexes = make([]collections.QuantizedVectorIndexDefinition, len(opts.QuantizedIndexes))
+	seen := make(map[string]struct{}, len(opts.QuantizedIndexes))
+	for i, q := range opts.QuantizedIndexes {
+		if q.Name == "" {
+			return normalizedBenchmarkVectorIndexOptions{}, serviceErrorf(CodeInvalidRequest, "vector_index_options.quantized_indexes[%d].name is required", i)
+		}
+		if err := collections.ValidateIndexName(q.Name); err != nil {
+			return normalizedBenchmarkVectorIndexOptions{}, wrapServiceError(CodeInvalidRequest, fmt.Sprintf("vector_index_options.quantized_indexes[%d].name is invalid", i), err)
+		}
+		if _, ok := seen[q.Name]; ok {
+			return normalizedBenchmarkVectorIndexOptions{}, serviceErrorf(CodeInvalidRequest, "duplicate quantized index %q", q.Name)
+		}
+		seen[q.Name] = struct{}{}
+		switch q.Codec {
+		case "":
+			q.Codec = collections.QuantizedVectorCodecScalarU8
+		case collections.QuantizedVectorCodecScalarU8, "rabitq_1bit", "brq_1bit":
+		default:
+			return normalizedBenchmarkVectorIndexOptions{}, serviceErrorf(CodeInvalidRequest, "quantized index %q codec %q is unsupported", q.Name, q.Codec)
+		}
+		if q.Version == 0 {
+			q.Version = 1
+		}
+		if q.Version > 1 {
+			return normalizedBenchmarkVectorIndexOptions{}, serviceErrorf(CodeInvalidRequest, "quantized index %q version=%d is unsupported", q.Name, q.Version)
+		}
+		out.quantizedIndexes[i] = collections.QuantizedVectorIndexDefinition{Name: q.Name, Codec: q.Codec, Version: q.Version}
+	}
+	return out, nil
 }
 
 func serviceColumnStoreConfig(dimension int) *collections.ColumnStoreConfig {
@@ -811,6 +1042,106 @@ func serviceDocumentFetchOptions(returnEmbedding bool) collections.DocumentFetch
 	return opts
 }
 
+func vectorIndexMaintenanceStatus(status collections.VectorIndexStatus) VectorIndexMaintenanceStatus {
+	return VectorIndexMaintenanceStatus{
+		Name:             status.Name,
+		Strategy:         status.Strategy,
+		State:            status.State,
+		Reason:           status.Reason,
+		Loaded:           status.Loaded,
+		RebuildNeeded:    status.RebuildNeeded,
+		RootID:           status.RootID,
+		NativeRootLoaded: status.NativeRootLoaded,
+		NativeRootBytes:  status.NativeRootBytes,
+		DurationNanos:    status.Duration.Nanoseconds(),
+	}
+}
+
+func normalizeBenchmarkVectorQueryMode(mode BenchmarkVectorQueryMode) (BenchmarkVectorQueryMode, collections.VectorIndexQueryMode, error) {
+	switch mode {
+	case "", BenchmarkVectorQueryModeExact:
+		return BenchmarkVectorQueryModeExact, collections.VectorIndexQueryModeExact, nil
+	case BenchmarkVectorQueryModeQuantizedOnly:
+		return BenchmarkVectorQueryModeQuantizedOnly, collections.VectorIndexQueryModeQuantizedOnly, nil
+	case BenchmarkVectorQueryModeQuantizedRerank:
+		return BenchmarkVectorQueryModeQuantizedRerank, collections.VectorIndexQueryModeQuantizedRerank, nil
+	default:
+		return "", "", serviceErrorf(CodeInvalidRequest, "unsupported benchmark vector query_mode %q", mode)
+	}
+}
+
+func benchmarkVectorSearchResults(results []collections.VectorIndexSearchResult) []BenchmarkVectorSearchResult {
+	if len(results) == 0 {
+		return nil
+	}
+	out := make([]BenchmarkVectorSearchResult, len(results))
+	for i, result := range results {
+		out[i] = BenchmarkVectorSearchResult{ID: string(result.ID), Ordinal: result.Ordinal, Score: result.Score}
+	}
+	return out
+}
+
+func validateBenchmarkVectorSearchRoute(mode BenchmarkVectorQueryMode, req BenchmarkVectorSearchRequest, response collections.VectorIndexSearchResponse) error {
+	diag := response.Diagnostics()
+	stats := response.Stats
+	if !diag.NoDocumentGuardrailsOK || stats.DocumentsFetched != 0 || stats.DocumentBytes != 0 || stats.DocumentOutputBytes != 0 {
+		return serviceErrorf(CodeIndexUnavailable, "benchmark vector search left the no-document route: diagnostics=%+v", diag)
+	}
+	switch mode {
+	case BenchmarkVectorQueryModeExact:
+		if diag.Route != collections.VectorIndexSearchRouteExactHNSWSearchPackV1 || !diag.ExactHNSWSearchPackNoDocRoute || diag.FallbackReason != collections.VectorIndexSearchFallbackReasonNone {
+			return serviceErrorf(CodeIndexUnavailable, "exact benchmark vector search did not use the exact no-document hnsw_search_pack_v1 route: diagnostics=%+v", diag)
+		}
+	case BenchmarkVectorQueryModeQuantizedOnly, BenchmarkVectorQueryModeQuantizedRerank:
+		if err := validateBenchmarkQuantizedVectorSearchRoute(mode, req, response); err != nil {
+			return err
+		}
+	default:
+		return serviceErrorf(CodeInvalidRequest, "unsupported benchmark vector query_mode %q", mode)
+	}
+	return nil
+}
+
+func validateBenchmarkQuantizedVectorSearchRoute(mode BenchmarkVectorQueryMode, req BenchmarkVectorSearchRequest, response collections.VectorIndexSearchResponse) error {
+	diag := response.Diagnostics()
+	stats := response.Stats
+	emptySearch := len(response.Results) == 0 && stats.CandidateRows == 0
+	if stats.SearchRouteHNSWSearchPack != 0 || stats.HNSWSearchPackFallbacks != 0 {
+		return serviceErrorf(CodeIndexUnavailable, "quantized benchmark vector search touched exact hnsw_search_pack route counters: diagnostics=%+v", diag)
+	}
+	if stats.SearchRouteColumnGraphPrepared+stats.SearchRouteColumnGraphFallback != 1 {
+		return serviceErrorf(CodeIndexUnavailable, "quantized benchmark vector search did not use one column_graph route: diagnostics=%+v", diag)
+	}
+	if stats.QuantizedAssetUnavailable != 0 || stats.QuantizedAssetMissing != 0 || stats.QuantizedAssetInvalid != 0 || stats.QuantizedAssetStale != 0 || stats.QuantizedAssetClosed != 0 {
+		return serviceErrorf(CodeIndexUnavailable, "quantized benchmark vector asset is unavailable: diagnostics=%+v", diag)
+	}
+	if !emptySearch && stats.QuantizedScorerActive != 1 {
+		return serviceErrorf(CodeIndexUnavailable, "quantized benchmark vector search did not activate a quantized scorer: diagnostics=%+v", diag)
+	}
+	if !emptySearch && stats.QuantizedScoreCalls == 0 {
+		return serviceErrorf(CodeIndexUnavailable, "quantized benchmark vector search did not report quantized score calls: diagnostics=%+v", diag)
+	}
+	switch mode {
+	case BenchmarkVectorQueryModeQuantizedOnly:
+		if diag.Route != collections.VectorIndexSearchRouteQuantizedOnly || stats.SearchRouteQuantizedOnly != 1 || stats.SearchRouteQuantizedRerank != 0 || stats.QuantizedRerankCandidates != 0 || stats.QuantizedRerankExactScoreCalls != 0 || stats.PreparedScoreCalls != 0 {
+			return serviceErrorf(CodeIndexUnavailable, "quantized_only benchmark vector search did not stay on the quantized-only route: diagnostics=%+v", diag)
+		}
+	case BenchmarkVectorQueryModeQuantizedRerank:
+		if diag.Route != collections.VectorIndexSearchRouteQuantizedRerank || stats.SearchRouteQuantizedRerank != 1 || stats.SearchRouteQuantizedOnly != 0 {
+			return serviceErrorf(CodeIndexUnavailable, "quantized_rerank benchmark vector search did not use the quantized-rerank route: diagnostics=%+v", diag)
+		}
+		if !emptySearch {
+			if stats.QuantizedRerankCandidates == 0 || stats.QuantizedRerankExactScoreCalls != stats.QuantizedRerankCandidates || stats.VectorBytesRead == 0 || stats.NormBytesRead == 0 {
+				return serviceErrorf(CodeIndexUnavailable, "quantized_rerank benchmark vector search did not report exact rerank counters: diagnostics=%+v", diag)
+			}
+			if req.QuantizedRerankCandidates > 0 && stats.QuantizedRerankCandidates > uint64(req.QuantizedRerankCandidates) {
+				return serviceErrorf(CodeIndexUnavailable, "quantized_rerank benchmark vector search exceeded requested rerank candidates: got %d want <= %d", stats.QuantizedRerankCandidates, req.QuantizedRerankCandidates)
+			}
+		}
+	}
+	return nil
+}
+
 func normalizeKeywordSearchOperator(op collections.TextSearchOperator) (collections.TextSearchOperator, error) {
 	switch strings.TrimSpace(strings.ToLower(string(op))) {
 	case "", string(collections.TextSearchOperatorOR):
@@ -1024,6 +1355,23 @@ func mapHybridSearchError(err error) error {
 		return wrapServiceError(CodeIndexUnavailable, "TreeDB backend is closed", err)
 	}
 	return wrapServiceError(CodeInternal, "hybrid search failed", err)
+}
+
+func mapVectorIndexSearchError(operation string, err error) error {
+	if err == nil {
+		return nil
+	}
+	var serviceErr *Error
+	if errors.As(err, &serviceErr) {
+		return err
+	}
+	if errors.Is(err, collections.ErrVectorIndexSearchUnavailable) || errors.Is(err, collections.ErrIndexNotFound) {
+		return wrapServiceError(CodeIndexUnavailable, operation+" failed closed", err)
+	}
+	if errors.Is(err, backenddb.ErrClosed) {
+		return wrapServiceError(CodeIndexUnavailable, "TreeDB backend is closed", err)
+	}
+	return wrapServiceError(CodeInternal, operation+" failed", err)
 }
 
 func mapCollectionMaintenanceError(operation string, err error) error {

--- a/TreeDB/documentservice/service.go
+++ b/TreeDB/documentservice/service.go
@@ -464,6 +464,9 @@ func (s *Service) SearchBenchmarkVector(ctx context.Context, index string, req B
 	if err != nil {
 		return BenchmarkVectorSearchResponse{}, err
 	}
+	if err := validateBenchmarkVectorSearchRequestShape(queryMode, req); err != nil {
+		return BenchmarkVectorSearchResponse{}, err
+	}
 	var buffer collections.VectorIndexSearchBuffer
 	search, err := col.SearchVectorIndexWithBuffer(collections.VectorIndexSearchOptions{
 		IndexName:                 vectorIndexName,
@@ -1079,6 +1082,29 @@ func benchmarkVectorSearchResults(results []collections.VectorIndexSearchResult)
 		out[i] = BenchmarkVectorSearchResult{ID: string(result.ID), Ordinal: result.Ordinal, Score: result.Score}
 	}
 	return out
+}
+
+func validateBenchmarkVectorSearchRequestShape(mode BenchmarkVectorQueryMode, req BenchmarkVectorSearchRequest) error {
+	switch mode {
+	case BenchmarkVectorQueryModeExact:
+		if req.QuantizedIndexName != "" || req.QuantizedRerankCandidates != 0 {
+			return serviceError(CodeInvalidRequest, "exact benchmark vector search does not accept quantized_index_name or quantized_rerank_candidates")
+		}
+	case BenchmarkVectorQueryModeQuantizedOnly:
+		if req.QuantizedIndexName == "" {
+			return serviceError(CodeInvalidRequest, "quantized_only benchmark vector search requires quantized_index_name")
+		}
+		if req.QuantizedRerankCandidates != 0 {
+			return serviceError(CodeInvalidRequest, "quantized_only benchmark vector search does not accept quantized_rerank_candidates")
+		}
+	case BenchmarkVectorQueryModeQuantizedRerank:
+		if req.QuantizedIndexName == "" {
+			return serviceError(CodeInvalidRequest, "quantized_rerank benchmark vector search requires quantized_index_name")
+		}
+	default:
+		return serviceErrorf(CodeInvalidRequest, "unsupported benchmark vector query_mode %q", mode)
+	}
+	return nil
 }
 
 func validateBenchmarkVectorSearchRoute(mode BenchmarkVectorQueryMode, req BenchmarkVectorSearchRequest, response collections.VectorIndexSearchResponse) error {

--- a/TreeDB/documentservice/service.go
+++ b/TreeDB/documentservice/service.go
@@ -364,6 +364,9 @@ func (s *Service) ResetIndex(ctx context.Context, index string, req ResetIndexRe
 	if err := collections.ValidateCollectionName(index); err != nil {
 		return ResetIndexResponse{}, wrapServiceError(CodeInvalidRequest, "invalid index name", err)
 	}
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+
 	existingCol, existingInfo, err := s.openIndex(ctx, index, 0)
 	if err != nil {
 		if ErrorCodeOf(err) != CodeIndexNotFound {
@@ -384,15 +387,13 @@ func (s *Service) ResetIndex(ctx context.Context, index string, req ResetIndexRe
 	if req.Metric == "" {
 		req.Metric = existingInfo.Metric
 	}
-	if existingInfo.Capabilities.ColumnGraphVectorSearch {
+	if existingInfo.VectorStrategy == collections.VectorIndexStrategyColumnGraph {
 		return ResetIndexResponse{}, serviceErrorf(CodeUnsupported, "drop_old reset for column_graph benchmark index %q requires a fresh data directory or unique index name", index)
 	}
 	if _, err := s.CreateIndex(ctx, CreateIndexRequest{Name: index, Dimension: req.Dimension, Metric: req.Metric, VectorIndexOptions: req.VectorIndexOptions}); err != nil {
 		return ResetIndexResponse{}, err
 	}
 
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
 	ids, err := s.collectMatchingIDs(ctx, existingCol, nil)
 	if err != nil {
 		return ResetIndexResponse{}, err
@@ -798,7 +799,9 @@ func benchmarkVectorIndexOptionsForCreate(metric Metric, opts *BenchmarkVectorIn
 		switch q.Codec {
 		case "":
 			q.Codec = collections.QuantizedVectorCodecScalarU8
-		case collections.QuantizedVectorCodecScalarU8, "rabitq_1bit", "brq_1bit":
+		case collections.QuantizedVectorCodecScalarU8, "rabitq_1bit":
+		case "brq_1bit":
+			return normalizedBenchmarkVectorIndexOptions{}, serviceErrorf(CodeInvalidRequest, "vector index quantized_indexes[%d].codec %q is not supported by the document service benchmark contract", i, q.Codec)
 		default:
 			return normalizedBenchmarkVectorIndexOptions{}, serviceErrorf(CodeInvalidRequest, "quantized index %q codec %q is unsupported", q.Name, q.Codec)
 		}

--- a/TreeDB/documentservice/service_test.go
+++ b/TreeDB/documentservice/service_test.go
@@ -626,6 +626,131 @@ func TestServiceErrorCasesDimensionStaleUnavailable(t *testing.T) {
 	}
 }
 
+func TestServiceBenchmarkLifecycleResetOptimizeAndNoDocumentSearch(t *testing.T) {
+	svc, db := newTestService(t)
+	defer db.Close()
+	ctx := context.Background()
+	vectorOptions := &BenchmarkVectorIndexOptions{
+		Strategy: collections.VectorIndexStrategyColumnGraph,
+		M:        4,
+		EfSearch: 8,
+		QuantizedIndexes: []QuantizedIndexInfo{{
+			Name:  "embedding.scalar_u8.fast",
+			Codec: collections.QuantizedVectorCodecScalarU8,
+		}},
+	}
+
+	reset, err := svc.ResetIndex(ctx, "bench", ResetIndexRequest{Dimension: 2, Metric: MetricCosine, DropOld: true, VectorIndexOptions: vectorOptions})
+	if err != nil {
+		t.Fatalf("ResetIndex create: %v", err)
+	}
+	if !reset.Created || reset.Reset || reset.Index.VectorStrategy != collections.VectorIndexStrategyColumnGraph || !reset.Index.Capabilities.BenchmarkLifecycle || !reset.Index.Capabilities.ExactColumnGraphSearch || !reset.Index.Capabilities.ScalarU8QuantizedRerank {
+		t.Fatalf("reset create response=%+v capabilities=%+v", reset, reset.Index.Capabilities)
+	}
+	loadBenchmarkDocs(t, svc, "bench", []Document{
+		{ID: "old-a", Content: "old alpha", Embedding: []float32{1, 0}},
+		{ID: "old-b", Content: "old beta", Embedding: []float32{0, 1}},
+	})
+	optimize, err := svc.OptimizeIndex(ctx, "bench", OptimizeIndexRequest{})
+	if err != nil {
+		t.Fatalf("OptimizeIndex first: %v", err)
+	}
+	if !optimize.Status.Loaded || optimize.Status.RebuildNeeded {
+		t.Fatalf("optimize status=%+v", optimize.Status)
+	}
+	exact, err := svc.SearchBenchmarkVector(ctx, "bench", BenchmarkVectorSearchRequest{QueryEmbedding: []float32{1, 0}, TopK: 2, EfSearch: 8})
+	if err != nil {
+		t.Fatalf("SearchBenchmarkVector exact: %v", err)
+	}
+	if !exact.NoDocuments || exact.QueryMode != BenchmarkVectorQueryModeExact || len(exact.Results) != 2 || exact.Results[0].ID != "old-a" || exact.Stats.DocumentsFetched != 0 || exact.Diagnostics.Route != collections.VectorIndexSearchRouteExactHNSWSearchPackV1 || !exact.Diagnostics.NoDocumentGuardrailsOK {
+		t.Fatalf("exact benchmark response=%+v stats=%+v diagnostics=%+v", exact, exact.Stats, exact.Diagnostics)
+	}
+	reranked, err := svc.SearchBenchmarkVector(ctx, "bench", BenchmarkVectorSearchRequest{QueryEmbedding: []float32{1, 0}, TopK: 2, EfSearch: 8, QueryMode: BenchmarkVectorQueryModeQuantizedRerank, QuantizedIndexName: "embedding.scalar_u8.fast", QuantizedRerankCandidates: 32})
+	if err != nil {
+		t.Fatalf("SearchBenchmarkVector quantized_rerank: %v", err)
+	}
+	if reranked.Diagnostics.Route != collections.VectorIndexSearchRouteQuantizedRerank || reranked.Stats.QuantizedScorerActive != 1 || reranked.Stats.QuantizedRerankExactScoreCalls == 0 || reranked.Stats.DocumentsFetched != 0 {
+		t.Fatalf("quantized_rerank response=%+v stats=%+v diagnostics=%+v", reranked, reranked.Stats, reranked.Diagnostics)
+	}
+
+	if _, err := svc.ResetIndex(ctx, "bench", ResetIndexRequest{Dimension: 2, Metric: MetricCosine, DropOld: true, VectorIndexOptions: vectorOptions}); ErrorCodeOf(err) != CodeUnsupported {
+		t.Fatalf("ResetIndex existing column_graph err=%v code=%s", err, ErrorCodeOf(err))
+	}
+}
+
+func TestServiceBenchmarkResetDeletesCompatibleNativeIndex(t *testing.T) {
+	svc, db := newTestService(t)
+	defer db.Close()
+	ctx := context.Background()
+	vectorOptions := &BenchmarkVectorIndexOptions{Strategy: collections.VectorIndexStrategyNativeRuntime}
+	if _, err := svc.ResetIndex(ctx, "nativebench", ResetIndexRequest{Dimension: 2, Metric: MetricCosine, DropOld: true, VectorIndexOptions: vectorOptions}); err != nil {
+		t.Fatalf("ResetIndex create native: %v", err)
+	}
+	loadBenchmarkDocs(t, svc, "nativebench", []Document{
+		{ID: "old-a", Content: "old alpha", Embedding: []float32{1, 0}},
+		{ID: "old-b", Content: "old beta", Embedding: []float32{0, 1}},
+	})
+	reset, err := svc.ResetIndex(ctx, "nativebench", ResetIndexRequest{Dimension: 2, Metric: MetricCosine, DropOld: true, VectorIndexOptions: vectorOptions})
+	if err != nil {
+		t.Fatalf("ResetIndex existing native: %v", err)
+	}
+	if reset.Created || !reset.Reset || reset.DroppedDocuments != 2 {
+		t.Fatalf("reset existing native response=%+v", reset)
+	}
+	count, err := svc.CountDocuments(ctx, "nativebench", CountDocumentsRequest{})
+	if err != nil || count.Count != 0 {
+		t.Fatalf("count after native reset=%+v err=%v", count, err)
+	}
+}
+
+func TestServiceBenchmarkVectorFailClosed(t *testing.T) {
+	svc, db := newTestService(t)
+	defer db.Close()
+	ctx := context.Background()
+	info, err := svc.CreateIndex(ctx, CreateIndexRequest{Name: "bench", Dimension: 2, VectorIndexOptions: &BenchmarkVectorIndexOptions{Strategy: collections.VectorIndexStrategyColumnGraph}})
+	if err != nil {
+		t.Fatalf("CreateIndex bench: %v", err)
+	}
+	if _, err := svc.SearchBenchmarkVector(ctx, "bench", BenchmarkVectorSearchRequest{QueryEmbedding: []float32{1, 0}, TopK: 1, EfSearch: 4}); ErrorCodeOf(err) != CodeIndexUnavailable {
+		t.Fatalf("missing assets err=%v code=%s", err, ErrorCodeOf(err))
+	}
+	if _, err := svc.SearchBenchmarkVector(ctx, "bench", BenchmarkVectorSearchRequest{ExpectedGeneration: info.Generation + 1, QueryEmbedding: []float32{1, 0}, TopK: 1, EfSearch: 4}); ErrorCodeOf(err) != CodeIndexStale {
+		t.Fatalf("stale generation err=%v code=%s", err, ErrorCodeOf(err))
+	}
+	if _, err := svc.SearchBenchmarkVector(ctx, "bench", BenchmarkVectorSearchRequest{QueryEmbedding: []float32{1, 0}, TopK: 1, QueryMode: "future_mode"}); ErrorCodeOf(err) != CodeInvalidRequest {
+		t.Fatalf("unsupported query mode err=%v code=%s", err, ErrorCodeOf(err))
+	}
+	loadBenchmarkDocs(t, svc, "bench", []Document{{ID: "a", Embedding: []float32{1, 0}}})
+	if _, err := svc.OptimizeIndex(ctx, "bench", OptimizeIndexRequest{}); err != nil {
+		t.Fatalf("OptimizeIndex bench: %v", err)
+	}
+	if _, err := svc.SearchBenchmarkVector(ctx, "bench", BenchmarkVectorSearchRequest{QueryEmbedding: []float32{1, 0}, TopK: 1, QueryMode: BenchmarkVectorQueryModeQuantizedRerank, QuantizedIndexName: "embedding.scalar_u8.missing", QuantizedRerankCandidates: 32}); ErrorCodeOf(err) != CodeIndexUnavailable {
+		t.Fatalf("unsupported/missing quantized err=%v code=%s", err, ErrorCodeOf(err))
+	}
+	dense, err := svc.SearchDenseVector(ctx, "bench", DenseVectorSearchRequest{QueryEmbedding: []float32{1, 0}, TopK: 1})
+	if err != nil || !dense.Exact || len(dense.Documents) != 1 || dense.Documents[0].ID != "a" {
+		t.Fatalf("dense exact fallback contract changed dense=%+v err=%v", dense, err)
+	}
+
+	l2Info, err := svc.CreateIndex(ctx, CreateIndexRequest{Name: "l2bench", Dimension: 2, Metric: MetricL2, VectorIndexOptions: &BenchmarkVectorIndexOptions{Strategy: collections.VectorIndexStrategyNativeRuntime}})
+	if err != nil {
+		t.Fatalf("CreateIndex l2bench: %v", err)
+	}
+	if l2Info.Capabilities.NoDocumentVectorSearch {
+		t.Fatalf("l2 capabilities=%+v want no_document_vector_search=false", l2Info.Capabilities)
+	}
+	if _, err := svc.SearchBenchmarkVector(ctx, "l2bench", BenchmarkVectorSearchRequest{QueryEmbedding: []float32{1, 0}, TopK: 1}); ErrorCodeOf(err) != CodeIndexUnavailable {
+		t.Fatalf("unsupported metric/strategy err=%v code=%s", err, ErrorCodeOf(err))
+	}
+}
+
+func loadBenchmarkDocs(t *testing.T, svc *Service, index string, docs []Document) {
+	t.Helper()
+	if _, err := svc.UpsertDocuments(context.Background(), index, UpsertDocumentsRequest{Documents: docs}); err != nil {
+		t.Fatalf("UpsertDocuments %s: %v", index, err)
+	}
+}
+
 func documentIDs(docs []Document) []string {
 	ids := make([]string, len(docs))
 	for i := range docs {

--- a/TreeDB/documentservice/service_test.go
+++ b/TreeDB/documentservice/service_test.go
@@ -726,6 +726,12 @@ func TestServiceBenchmarkVectorFailClosed(t *testing.T) {
 	if _, err := svc.SearchBenchmarkVector(ctx, "bench", BenchmarkVectorSearchRequest{QueryEmbedding: []float32{1, 0}, TopK: 1, QueryMode: BenchmarkVectorQueryModeQuantizedOnly, QuantizedRerankCandidates: 32}); ErrorCodeOf(err) != CodeInvalidRequest {
 		t.Fatalf("quantized_only invalid shape err=%v code=%s", err, ErrorCodeOf(err))
 	}
+	if _, err := svc.SearchBenchmarkVector(ctx, "bench", BenchmarkVectorSearchRequest{QueryEmbedding: []float32{1, 0}, TopK: 1, StatsMode: collections.VectorIndexSearchStatsModeBenchmarkDebug}); ErrorCodeOf(err) != CodeInvalidRequest {
+		t.Fatalf("benchmark_debug stats_mode err=%v code=%s", err, ErrorCodeOf(err))
+	}
+	if _, err := svc.SearchBenchmarkVector(ctx, "bench", BenchmarkVectorSearchRequest{QueryEmbedding: []float32{1, 0}, TopK: 1, StatsMode: collections.VectorIndexSearchStatsMode("future")}); ErrorCodeOf(err) != CodeInvalidRequest {
+		t.Fatalf("unknown stats_mode err=%v code=%s", err, ErrorCodeOf(err))
+	}
 	loadBenchmarkDocs(t, svc, "bench", []Document{{ID: "a", Embedding: []float32{1, 0}}})
 	if _, err := svc.OptimizeIndex(ctx, "bench", OptimizeIndexRequest{}); err != nil {
 		t.Fatalf("OptimizeIndex bench: %v", err)

--- a/TreeDB/documentservice/service_test.go
+++ b/TreeDB/documentservice/service_test.go
@@ -720,6 +720,12 @@ func TestServiceBenchmarkVectorFailClosed(t *testing.T) {
 	if _, err := svc.SearchBenchmarkVector(ctx, "bench", BenchmarkVectorSearchRequest{QueryEmbedding: []float32{1, 0}, TopK: 1, QueryMode: "future_mode"}); ErrorCodeOf(err) != CodeInvalidRequest {
 		t.Fatalf("unsupported query mode err=%v code=%s", err, ErrorCodeOf(err))
 	}
+	if _, err := svc.SearchBenchmarkVector(ctx, "bench", BenchmarkVectorSearchRequest{QueryEmbedding: []float32{1, 0}, TopK: 1, QuantizedIndexName: "embedding.scalar_u8.fast"}); ErrorCodeOf(err) != CodeInvalidRequest {
+		t.Fatalf("exact with quantized index err=%v code=%s", err, ErrorCodeOf(err))
+	}
+	if _, err := svc.SearchBenchmarkVector(ctx, "bench", BenchmarkVectorSearchRequest{QueryEmbedding: []float32{1, 0}, TopK: 1, QueryMode: BenchmarkVectorQueryModeQuantizedOnly, QuantizedRerankCandidates: 32}); ErrorCodeOf(err) != CodeInvalidRequest {
+		t.Fatalf("quantized_only invalid shape err=%v code=%s", err, ErrorCodeOf(err))
+	}
 	loadBenchmarkDocs(t, svc, "bench", []Document{{ID: "a", Embedding: []float32{1, 0}}})
 	if _, err := svc.OptimizeIndex(ctx, "bench", OptimizeIndexRequest{}); err != nil {
 		t.Fatalf("OptimizeIndex bench: %v", err)

--- a/TreeDB/documentservice/service_test.go
+++ b/TreeDB/documentservice/service_test.go
@@ -640,6 +640,17 @@ func TestServiceBenchmarkLifecycleResetOptimizeAndNoDocumentSearch(t *testing.T)
 		}},
 	}
 
+	brqOptions := &BenchmarkVectorIndexOptions{
+		Strategy: collections.VectorIndexStrategyColumnGraph,
+		QuantizedIndexes: []QuantizedIndexInfo{{
+			Name:  "embedding.brq_1bit.experimental",
+			Codec: "brq_1bit",
+		}},
+	}
+	if _, err := svc.ResetIndex(ctx, "bench_brq", ResetIndexRequest{Dimension: 2, Metric: MetricCosine, DropOld: true, VectorIndexOptions: brqOptions}); ErrorCodeOf(err) != CodeInvalidRequest {
+		t.Fatalf("ResetIndex brq_1bit err=%v code=%s", err, ErrorCodeOf(err))
+	}
+
 	reset, err := svc.ResetIndex(ctx, "bench", ResetIndexRequest{Dimension: 2, Metric: MetricCosine, DropOld: true, VectorIndexOptions: vectorOptions})
 	if err != nil {
 		t.Fatalf("ResetIndex create: %v", err)

--- a/TreeDB/documentservice/types.go
+++ b/TreeDB/documentservice/types.go
@@ -40,36 +40,70 @@ type Document struct {
 
 // IndexCapabilities describes the supported operations for one service index.
 type IndexCapabilities struct {
-	DenseVectorSearch      bool `json:"dense_vector_search"`
-	ExactDenseScoring      bool `json:"exact_dense_scoring"`
-	MetadataFilters        bool `json:"metadata_filters"`
-	KeywordSearch          bool `json:"keyword_search"`
-	HybridSearch           bool `json:"hybrid_search"`
-	KeywordMetadataFilters bool `json:"keyword_metadata_filters"`
-	HybridMetadataFilters  bool `json:"hybrid_metadata_filters"`
+	DenseVectorSearch       bool `json:"dense_vector_search"`
+	ExactDenseScoring       bool `json:"exact_dense_scoring"`
+	MetadataFilters         bool `json:"metadata_filters"`
+	KeywordSearch           bool `json:"keyword_search"`
+	HybridSearch            bool `json:"hybrid_search"`
+	KeywordMetadataFilters  bool `json:"keyword_metadata_filters"`
+	HybridMetadataFilters   bool `json:"hybrid_metadata_filters"`
+	BenchmarkLifecycle      bool `json:"benchmark_lifecycle"`
+	VectorIndexMaintenance  bool `json:"vector_index_maintenance"`
+	NoDocumentVectorSearch  bool `json:"no_document_vector_search"`
+	ColumnGraphVectorSearch bool `json:"column_graph_vector_search"`
+	ExactColumnGraphSearch  bool `json:"exact_column_graph_search"`
+	QuantizedVectorSearch   bool `json:"quantized_vector_search"`
+	QuantizedRerank         bool `json:"quantized_rerank"`
+	ScalarU8QuantizedRerank bool `json:"scalar_u8_quantized_rerank"`
+	RabitQ1BitExperimental  bool `json:"rabitq_1bit_experimental"`
+}
+
+// QuantizedIndexInfo describes a declared quantized score plane attached to the
+// service vector index.
+type QuantizedIndexInfo struct {
+	Name    string `json:"name"`
+	Codec   string `json:"codec"`
+	Version uint32 `json:"version"`
 }
 
 // IndexInfo is returned by create/open and echoed by operation responses.
 type IndexInfo struct {
-	Name            string            `json:"name"`
-	Dimension       int               `json:"dimension"`
-	Metric          Metric            `json:"metric"`
-	Generation      uint64            `json:"generation"`
-	ContractVersion string            `json:"contract_version"`
-	EmbeddingField  string            `json:"embedding_field"`
-	VectorIndexName string            `json:"vector_index_name"`
-	TextField       string            `json:"text_field"`
-	TextIndexName   string            `json:"text_index_name"`
-	DocumentType    string            `json:"document_type"`
-	Capabilities    IndexCapabilities `json:"capabilities"`
+	Name                 string                          `json:"name"`
+	Dimension            int                             `json:"dimension"`
+	Metric               Metric                          `json:"metric"`
+	Generation           uint64                          `json:"generation"`
+	ContractVersion      string                          `json:"contract_version"`
+	EmbeddingField       string                          `json:"embedding_field"`
+	VectorIndexName      string                          `json:"vector_index_name"`
+	VectorStrategy       collections.VectorIndexStrategy `json:"vector_strategy"`
+	VectorM              int                             `json:"vector_m,omitempty"`
+	VectorEfConstruction int                             `json:"vector_ef_construction,omitempty"`
+	VectorEfSearch       int                             `json:"vector_ef_search,omitempty"`
+	QuantizedIndexes     []QuantizedIndexInfo            `json:"quantized_indexes,omitempty"`
+	TextField            string                          `json:"text_field"`
+	TextIndexName        string                          `json:"text_index_name"`
+	DocumentType         string                          `json:"document_type"`
+	Capabilities         IndexCapabilities               `json:"capabilities"`
+}
+
+// BenchmarkVectorIndexOptions configures the service-owned collection vector
+// index for benchmark lifecycle setups. Omitted fields preserve the legacy
+// create-index defaults used by treedb-client and treedb-haystack.
+type BenchmarkVectorIndexOptions struct {
+	Strategy         collections.VectorIndexStrategy `json:"strategy,omitempty"`
+	M                int                             `json:"m,omitempty"`
+	EfConstruction   int                             `json:"ef_construction,omitempty"`
+	EfSearch         int                             `json:"ef_search,omitempty"`
+	QuantizedIndexes []QuantizedIndexInfo            `json:"quantized_indexes,omitempty"`
 }
 
 // CreateIndexRequest creates or opens a service index. Existing compatible
 // indexes are returned idempotently; incompatible existing collections fail.
 type CreateIndexRequest struct {
-	Name      string `json:"name"`
-	Dimension int    `json:"dimension"`
-	Metric    Metric `json:"metric,omitempty"`
+	Name               string                       `json:"name"`
+	Dimension          int                          `json:"dimension"`
+	Metric             Metric                       `json:"metric,omitempty"`
+	VectorIndexOptions *BenchmarkVectorIndexOptions `json:"vector_index_options,omitempty"`
 }
 
 // UpsertDocumentsRequest writes or replaces service documents.
@@ -145,6 +179,96 @@ type DenseVectorSearchResponse struct {
 	Metric     Metric     `json:"metric"`
 	Exact      bool       `json:"exact"`
 	Candidates int        `json:"candidates"`
+}
+
+// ResetIndexRequest creates a missing benchmark index or clears an existing
+// compatible non-column_graph index when DropOld is true. Column_graph benchmark
+// reset fails closed for existing indexes; use a fresh data directory or unique
+// index name to preserve the insert-only load boundary required by graph assets.
+type ResetIndexRequest struct {
+	Dimension          int                          `json:"dimension"`
+	Metric             Metric                       `json:"metric,omitempty"`
+	DropOld            bool                         `json:"drop_old,omitempty"`
+	VectorIndexOptions *BenchmarkVectorIndexOptions `json:"vector_index_options,omitempty"`
+}
+
+type ResetIndexResponse struct {
+	Index            IndexInfo `json:"index"`
+	Created          bool      `json:"created"`
+	Reset            bool      `json:"reset"`
+	DropOld          bool      `json:"drop_old"`
+	DroppedDocuments int       `json:"dropped_documents"`
+}
+
+// OptimizeIndexRequest rebuilds service vector assets after benchmark load.
+type OptimizeIndexRequest struct {
+	ExpectedGeneration uint64 `json:"expected_generation,omitempty"`
+	VectorIndexName    string `json:"vector_index_name,omitempty"`
+}
+
+type VectorIndexMaintenanceStatus struct {
+	Name             string                          `json:"name"`
+	Strategy         collections.VectorIndexStrategy `json:"strategy"`
+	State            collections.VectorIndexState    `json:"state"`
+	Reason           collections.VectorIndexReason   `json:"reason"`
+	Loaded           bool                            `json:"loaded"`
+	RebuildNeeded    bool                            `json:"rebuild_needed"`
+	RootID           uint64                          `json:"root_id,omitempty"`
+	NativeRootLoaded bool                            `json:"native_root_loaded,omitempty"`
+	NativeRootBytes  int64                           `json:"native_root_bytes,omitempty"`
+	DurationNanos    int64                           `json:"duration_nanos,omitempty"`
+}
+
+type OptimizeIndexResponse struct {
+	Index           IndexInfo                    `json:"index"`
+	VectorIndexName string                       `json:"vector_index_name"`
+	Status          VectorIndexMaintenanceStatus `json:"status"`
+}
+
+// BenchmarkVectorQueryMode selects the no-document vector-index benchmark score
+// plane. The legacy /search/vector route does not accept these modes and remains
+// exact dense document scoring.
+type BenchmarkVectorQueryMode string
+
+const (
+	BenchmarkVectorQueryModeExact           BenchmarkVectorQueryMode = "exact"
+	BenchmarkVectorQueryModeQuantizedOnly   BenchmarkVectorQueryMode = "quantized_only"
+	BenchmarkVectorQueryModeQuantizedRerank BenchmarkVectorQueryMode = "quantized_rerank"
+)
+
+// BenchmarkVectorSearchRequest runs fail-closed no-document vector-index search
+// through Collection.SearchVectorIndexWithBuffer. Quantized modes require an
+// explicit quantized index name; quantized_rerank may bound exact rerank with
+// QuantizedRerankCandidates (rerank32 is the benchmark baseline when set to 32).
+type BenchmarkVectorSearchRequest struct {
+	ExpectedGeneration        uint64                                 `json:"expected_generation,omitempty"`
+	VectorIndexName           string                                 `json:"vector_index_name,omitempty"`
+	QueryEmbedding            []float32                              `json:"query_embedding"`
+	TopK                      int                                    `json:"top_k"`
+	EfSearch                  int                                    `json:"ef_search,omitempty"`
+	QueryMode                 BenchmarkVectorQueryMode               `json:"query_mode,omitempty"`
+	QuantizedIndexName        string                                 `json:"quantized_index_name,omitempty"`
+	QuantizedRerankCandidates int                                    `json:"quantized_rerank_candidates,omitempty"`
+	StatsMode                 collections.VectorIndexSearchStatsMode `json:"stats_mode,omitempty"`
+}
+
+type BenchmarkVectorSearchResult struct {
+	ID      string  `json:"id"`
+	Ordinal int     `json:"ordinal"`
+	Score   float64 `json:"score"`
+}
+
+type BenchmarkVectorSearchResponse struct {
+	Index                     IndexInfo                                `json:"index"`
+	Results                   []BenchmarkVectorSearchResult            `json:"results"`
+	Metric                    Metric                                   `json:"metric"`
+	VectorIndexName           string                                   `json:"vector_index_name"`
+	QueryMode                 BenchmarkVectorQueryMode                 `json:"query_mode"`
+	QuantizedIndexName        string                                   `json:"quantized_index_name,omitempty"`
+	QuantizedRerankCandidates int                                      `json:"quantized_rerank_candidates,omitempty"`
+	NoDocuments               bool                                     `json:"no_documents"`
+	Stats                     collections.VectorIndexSearchStats       `json:"stats"`
+	Diagnostics               collections.VectorIndexSearchDiagnostics `json:"diagnostics"`
 }
 
 // KeywordSearchRequest runs ranked lexical search over the service content text
@@ -257,16 +381,47 @@ func metricFromCollection(metric collections.VectorMetric) (Metric, error) {
 	}
 }
 
-func indexCapabilities(hybridSearch bool) IndexCapabilities {
+func indexCapabilities(vectorDef collections.VectorIndexDefinition, hybridSearch bool) IndexCapabilities {
+	columnGraph := vectorDef.Strategy == collections.VectorIndexStrategyColumnGraph && vectorDef.Metric == collections.VectorMetricCosine && vectorDef.Encoding == collections.VectorIndexEncodingFloat32
+	quantized := columnGraph && len(vectorDef.QuantizedIndexes) > 0
 	return IndexCapabilities{
-		DenseVectorSearch:      true,
-		ExactDenseScoring:      true,
-		MetadataFilters:        true,
-		KeywordSearch:          true,
-		HybridSearch:           hybridSearch,
-		KeywordMetadataFilters: false,
-		HybridMetadataFilters:  false,
+		DenseVectorSearch:       true,
+		ExactDenseScoring:       true,
+		MetadataFilters:         true,
+		KeywordSearch:           true,
+		HybridSearch:            hybridSearch,
+		KeywordMetadataFilters:  false,
+		HybridMetadataFilters:   false,
+		BenchmarkLifecycle:      true,
+		VectorIndexMaintenance:  true,
+		NoDocumentVectorSearch:  columnGraph,
+		ColumnGraphVectorSearch: columnGraph,
+		ExactColumnGraphSearch:  columnGraph,
+		QuantizedVectorSearch:   quantized,
+		QuantizedRerank:         quantized,
+		ScalarU8QuantizedRerank: columnGraph && quantizedIndexCodecDeclared(vectorDef, collections.QuantizedVectorCodecScalarU8),
+		RabitQ1BitExperimental:  columnGraph && quantizedIndexCodecDeclared(vectorDef, "rabitq_1bit"),
 	}
+}
+
+func quantizedIndexInfos(def collections.VectorIndexDefinition) []QuantizedIndexInfo {
+	if len(def.QuantizedIndexes) == 0 {
+		return nil
+	}
+	out := make([]QuantizedIndexInfo, len(def.QuantizedIndexes))
+	for i, q := range def.QuantizedIndexes {
+		out[i] = QuantizedIndexInfo{Name: q.Name, Codec: q.Codec, Version: q.Version}
+	}
+	return out
+}
+
+func quantizedIndexCodecDeclared(def collections.VectorIndexDefinition, codec string) bool {
+	for _, q := range def.QuantizedIndexes {
+		if q.Codec == codec {
+			return true
+		}
+	}
+	return false
 }
 
 func scorePtr(score float64) *float64 {

--- a/clients/python/treedb_client/README.md
+++ b/clients/python/treedb_client/README.md
@@ -137,6 +137,8 @@ for doc in results.documents:
 # VectorDBBench-style no-document vector-index route. This is separate from
 # query_by_embedding above; it fails closed rather than falling back to exact
 # document scans. Managed benchmark runs should use a fresh TreeDB data dir.
+# Omit metric when preserving an existing index's metric; pass it when creating
+# or enforcing a benchmark schema.
 client.reset_index(
     "bench_run_001",
     dimension=3,

--- a/clients/python/treedb_client/README.md
+++ b/clients/python/treedb_client/README.md
@@ -17,13 +17,17 @@ Supported by the base client:
 - delete by server-side metadata filter
 - count/filter/list documents
 - exact dense-vector search with optional metadata filters and embedding echo
+- benchmark lifecycle helpers for reset/create, vector-index optimize/rebuild, and fail-closed no-document vector-index search
+- explicit scalar_u8 + rerank benchmark request fields (`query_mode="quantized_rerank"`, quantized index name, rerank candidate count)
 - ranked keyword search over the service `content` text index
 - TreeDB-native hybrid text/vector search with deterministic RRF fusion options
-- typed dataclasses for documents, index metadata, keyword/hybrid requests and responses, stats, plan/snapshot, fusion options, and errors
+- typed dataclasses for documents, index metadata, benchmark vector options/responses, keyword/hybrid requests and responses, stats, plan/snapshot, fusion options, and errors
 - Haystack-style filter conversion/validation without a Haystack dependency
 
 Not supported:
 
+- using benchmark no-document vector-index routes as Haystack/exact dense-search evidence
+- in-place `drop_old` reset for existing `column_graph` benchmark indexes; use a fresh data directory or unique index name
 - metadata filters on keyword/hybrid routes (the service fails them closed with `unsupported`/HTTP 501)
 - async client APIs
 - client-side scans or text/vector fallbacks to emulate unsupported TreeDB behavior
@@ -82,7 +86,7 @@ go run ./cmd/treedb-document-service \
 ## Example
 
 ```python
-from treedb_client import Document, Filter, TreeDBClient
+from treedb_client import BenchmarkVectorIndexOptions, Document, Filter, QuantizedIndexInfo, TreeDBClient
 
 client = TreeDBClient("http://127.0.0.1:7120", timeout=5)
 
@@ -129,6 +133,31 @@ results = client.query_by_embedding(
 
 for doc in results.documents:
     print(doc.id, doc.score, doc.meta.get("path"))
+
+# VectorDBBench-style no-document vector-index route. This is separate from
+# query_by_embedding above; it fails closed rather than falling back to exact
+# document scans. Managed benchmark runs should use a fresh TreeDB data dir.
+client.reset_index(
+    "bench_run_001",
+    dimension=3,
+    metric="cosine",
+    drop_old=True,
+    vector_index_options=BenchmarkVectorIndexOptions(
+        strategy="column_graph",
+        quantized_indexes=[QuantizedIndexInfo(name="embedding.scalar_u8.fast")],
+    ),
+)
+client.upsert_documents("bench_run_001", [Document(id="a", embedding=[0.1, 0.2, 0.3])])
+client.optimize_index("bench_run_001")
+bench = client.search_vector_index(
+    "bench_run_001",
+    query_embedding=[0.1, 0.2, 0.3],
+    top_k=1,
+    query_mode="quantized_rerank",
+    quantized_index_name="embedding.scalar_u8.fast",
+    quantized_rerank_candidates=32,
+)
+print(bench.results[0].id, bench.no_documents, bench.diagnostics.get("route"))
 
 keyword = client.search_keyword(
     "docs",

--- a/clients/python/treedb_client/src/treedb_client/__init__.py
+++ b/clients/python/treedb_client/src/treedb_client/__init__.py
@@ -19,6 +19,9 @@ from .errors import (
 )
 from .filters import Filter, InvalidFilterError, normalize_filter
 from .models import (
+    BenchmarkVectorIndexOptions,
+    BenchmarkVectorSearchResponse,
+    BenchmarkVectorSearchResult,
     CountDocumentsResponse,
     DeleteDocumentsResponse,
     DenseVectorSearchResponse,
@@ -35,10 +38,17 @@ from .models import (
     KeywordSearchRequest,
     KeywordSearchResponse,
     KeywordSearchStats,
+    OptimizeIndexResponse,
+    QuantizedIndexInfo,
+    ResetIndexResponse,
     UpsertDocumentsResponse,
+    VectorIndexMaintenanceStatus,
 )
 
 __all__ = [
+    "BenchmarkVectorIndexOptions",
+    "BenchmarkVectorSearchResponse",
+    "BenchmarkVectorSearchResult",
     "ConflictError",
     "CountDocumentsResponse",
     "DeleteDocumentsResponse",
@@ -64,6 +74,9 @@ __all__ = [
     "KeywordSearchResponse",
     "KeywordSearchStats",
     "MalformedJSONError",
+    "OptimizeIndexResponse",
+    "QuantizedIndexInfo",
+    "ResetIndexResponse",
     "TreeDBClient",
     "TreeDBClientError",
     "TreeDBConfigError",
@@ -73,5 +86,6 @@ __all__ = [
     "TreeDBTransportError",
     "UnsupportedError",
     "UpsertDocumentsResponse",
+    "VectorIndexMaintenanceStatus",
     "normalize_filter",
 ]

--- a/clients/python/treedb_client/src/treedb_client/client.py
+++ b/clients/python/treedb_client/src/treedb_client/client.py
@@ -76,8 +76,7 @@ class TreeDBClient:
         """Create or idempotently open a compatible document index."""
 
         request: dict[str, Any] = {"name": name, "dimension": dimension}
-        if metric:
-            request["metric"] = metric
+        _add_optional_non_empty_string(request, "metric", metric, "metric")
         _add_vector_index_options(request, vector_index_options)
         payload = self._request("POST", "/v1/indexes", request)
         return _index_from_envelope(payload)
@@ -117,8 +116,7 @@ class TreeDBClient:
         """
 
         request: dict[str, Any] = {"dimension": dimension, "drop_old": bool(drop_old)}
-        if metric:
-            request["metric"] = metric
+        _add_optional_non_empty_string(request, "metric", metric, "metric")
         _add_vector_index_options(request, vector_index_options)
         payload = self._request("POST", self._index_path(index, "reset"), request)
         return _parse_response("reset index response", ResetIndexResponse.from_dict, payload)
@@ -282,14 +280,11 @@ class TreeDBClient:
             request["vector_index_name"] = vector_index_name
         if ef_search is not None:
             request["ef_search"] = int(ef_search)
-        if query_mode:
-            request["query_mode"] = query_mode
-        if quantized_index_name:
-            request["quantized_index_name"] = quantized_index_name
+        _add_optional_non_empty_string(request, "query_mode", query_mode, "query_mode")
+        _add_optional_non_empty_string(request, "quantized_index_name", quantized_index_name, "quantized_index_name")
         if quantized_rerank_candidates is not None:
             request["quantized_rerank_candidates"] = int(quantized_rerank_candidates)
-        if stats_mode:
-            request["stats_mode"] = stats_mode
+        _add_optional_non_empty_string(request, "stats_mode", stats_mode, "stats_mode")
         payload = self._request("POST", self._index_path(index, "search", "vector-index"), request)
         return _parse_response("benchmark vector search response", BenchmarkVectorSearchResponse.from_dict, payload)
 
@@ -471,6 +466,14 @@ def _add_expected_generation(request: dict[str, Any], expected_generation: Optio
     _validate_expected_generation(expected_generation)
     if expected_generation is not None:
         request["expected_generation"] = expected_generation
+
+
+def _add_optional_non_empty_string(request: dict[str, Any], key: str, value: Optional[str], label: str) -> None:
+    if value is None:
+        return
+    if not isinstance(value, str) or value.strip() == "":
+        raise InvalidRequestError("invalid_request", f"{label} must be a non-empty string when provided")
+    request[key] = value
 
 
 def _add_filter(request: dict[str, Any], filter_value: Optional[FilterLike]) -> None:

--- a/clients/python/treedb_client/src/treedb_client/client.py
+++ b/clients/python/treedb_client/src/treedb_client/client.py
@@ -21,6 +21,8 @@ from .errors import (
 )
 from .filters import FilterLike, InvalidFilterError, normalize_filter
 from .models import (
+    BenchmarkVectorIndexOptions,
+    BenchmarkVectorSearchResponse,
     CountDocumentsResponse,
     DeleteDocumentsResponse,
     DenseVectorSearchResponse,
@@ -32,10 +34,13 @@ from .models import (
     IndexInfo,
     KeywordSearchRequest,
     KeywordSearchResponse,
+    OptimizeIndexResponse,
+    ResetIndexResponse,
     UpsertDocumentsResponse,
 )
 
 DocumentLike = Union[Document, Mapping[str, Any]]
+VectorIndexOptionsLike = Union[BenchmarkVectorIndexOptions, Mapping[str, Any]]
 _ResponseT = TypeVar("_ResponseT")
 
 
@@ -60,23 +65,78 @@ class TreeDBClient:
             raise TreeDBProtocolError("health response must be a JSON object")
         return payload
 
-    def create_index(self, name: str, dimension: int, metric: Optional[str] = "cosine") -> IndexInfo:
+    def create_index(
+        self,
+        name: str,
+        dimension: int,
+        metric: Optional[str] = "cosine",
+        *,
+        vector_index_options: Optional[VectorIndexOptionsLike] = None,
+    ) -> IndexInfo:
         """Create or idempotently open a compatible document index."""
 
         request: dict[str, Any] = {"name": name, "dimension": dimension}
         if metric:
             request["metric"] = metric
+        _add_vector_index_options(request, vector_index_options)
         payload = self._request("POST", "/v1/indexes", request)
         return _index_from_envelope(payload)
 
-    def ensure_index(self, name: str, dimension: int, metric: Optional[str] = "cosine") -> IndexInfo:
+    def ensure_index(
+        self,
+        name: str,
+        dimension: int,
+        metric: Optional[str] = "cosine",
+        *,
+        vector_index_options: Optional[VectorIndexOptionsLike] = None,
+    ) -> IndexInfo:
         """Ensure a compatible index exists.
 
         The service's create route is idempotent for compatible existing indexes
         and returns `conflict` for incompatible schemas.
         """
 
-        return self.create_index(name, dimension, metric)
+        return self.create_index(name, dimension, metric, vector_index_options=vector_index_options)
+
+    def reset_index(
+        self,
+        index: str,
+        *,
+        dimension: int,
+        metric: Optional[str] = "cosine",
+        drop_old: bool = False,
+        vector_index_options: Optional[VectorIndexOptionsLike] = None,
+    ) -> ResetIndexResponse:
+        """Create or reset a benchmark index through the service lifecycle route.
+
+        Existing column_graph benchmark indexes fail closed on the service when
+        `drop_old=True`; managed benchmark runs should use a fresh data directory
+        or a unique index name to preserve TreeDB's insert-only graph rebuild
+        boundary.
+        """
+
+        request: dict[str, Any] = {"dimension": dimension, "drop_old": bool(drop_old)}
+        if metric:
+            request["metric"] = metric
+        _add_vector_index_options(request, vector_index_options)
+        payload = self._request("POST", self._index_path(index, "reset"), request)
+        return _parse_response("reset index response", ResetIndexResponse.from_dict, payload)
+
+    def optimize_index(
+        self,
+        index: str,
+        *,
+        vector_index_name: Optional[str] = None,
+        expected_generation: Optional[int] = None,
+    ) -> OptimizeIndexResponse:
+        """Rebuild service vector assets after a benchmark load phase."""
+
+        request: dict[str, Any] = {}
+        _add_expected_generation(request, expected_generation)
+        if vector_index_name:
+            request["vector_index_name"] = vector_index_name
+        payload = self._request("POST", self._index_path(index, "optimize"), request)
+        return _parse_response("optimize index response", OptimizeIndexResponse.from_dict, payload)
 
     def open_index(self, name: str) -> IndexInfo:
         """Open/read metadata for an existing index."""
@@ -190,6 +250,47 @@ class TreeDBClient:
         _add_expected_generation(request, expected_generation)
         payload = self._request("POST", self._index_path(index, "search", "vector"), request)
         return _parse_response("vector search response", DenseVectorSearchResponse.from_dict, payload)
+
+    def search_vector_index(
+        self,
+        index: str,
+        query_embedding: Sequence[float],
+        top_k: int,
+        *,
+        vector_index_name: Optional[str] = None,
+        ef_search: Optional[int] = None,
+        query_mode: Optional[str] = None,
+        quantized_index_name: Optional[str] = None,
+        quantized_rerank_candidates: Optional[int] = None,
+        stats_mode: Optional[str] = None,
+        expected_generation: Optional[int] = None,
+    ) -> BenchmarkVectorSearchResponse:
+        """Run fail-closed no-document vector-index benchmark search.
+
+        This calls `/search/vector-index`, not the exact dense `/search/vector`
+        route used by Haystack. Quantized modes must be explicit and are not
+        emulated by client-side or service-side exact fallback.
+        """
+
+        request: dict[str, Any] = {
+            "query_embedding": [float(value) for value in query_embedding],
+            "top_k": top_k,
+        }
+        _add_expected_generation(request, expected_generation)
+        if vector_index_name:
+            request["vector_index_name"] = vector_index_name
+        if ef_search is not None:
+            request["ef_search"] = int(ef_search)
+        if query_mode:
+            request["query_mode"] = query_mode
+        if quantized_index_name:
+            request["quantized_index_name"] = quantized_index_name
+        if quantized_rerank_candidates is not None:
+            request["quantized_rerank_candidates"] = int(quantized_rerank_candidates)
+        if stats_mode:
+            request["stats_mode"] = stats_mode
+        payload = self._request("POST", self._index_path(index, "search", "vector-index"), request)
+        return _parse_response("benchmark vector search response", BenchmarkVectorSearchResponse.from_dict, payload)
 
     def search_keyword(
         self,
@@ -375,6 +476,18 @@ def _add_filter(request: dict[str, Any], filter_value: Optional[FilterLike]) -> 
     normalized = normalize_filter(filter_value)
     if normalized is not None:
         request["filter"] = normalized
+
+
+def _add_vector_index_options(request: dict[str, Any], options: Optional[VectorIndexOptionsLike]) -> None:
+    if options is None:
+        return
+    if isinstance(options, BenchmarkVectorIndexOptions):
+        request["vector_index_options"] = options.to_dict()
+        return
+    if isinstance(options, Mapping):
+        request["vector_index_options"] = BenchmarkVectorIndexOptions.from_dict(options).to_dict()
+        return
+    raise InvalidRequestError("invalid_request", "vector_index_options must be BenchmarkVectorIndexOptions, mapping, or None")
 
 
 def _document_for_write(document: DocumentLike) -> Mapping[str, Any]:

--- a/clients/python/treedb_client/src/treedb_client/client.py
+++ b/clients/python/treedb_client/src/treedb_client/client.py
@@ -103,7 +103,7 @@ class TreeDBClient:
         index: str,
         *,
         dimension: int,
-        metric: Optional[str] = "cosine",
+        metric: Optional[str] = None,
         drop_old: bool = False,
         vector_index_options: Optional[VectorIndexOptionsLike] = None,
     ) -> ResetIndexResponse:
@@ -112,7 +112,8 @@ class TreeDBClient:
         Existing column_graph benchmark indexes fail closed on the service when
         `drop_old=True`; managed benchmark runs should use a fresh data directory
         or a unique index name to preserve TreeDB's insert-only graph rebuild
-        boundary.
+        boundary. Omit `metric` to preserve an existing index's metric; pass it
+        when creating a missing index or when compatibility should be enforced.
         """
 
         request: dict[str, Any] = {"dimension": dimension, "drop_old": bool(drop_old)}

--- a/clients/python/treedb_client/src/treedb_client/models.py
+++ b/clients/python/treedb_client/src/treedb_client/models.py
@@ -285,9 +285,9 @@ class QuantizedIndexInfo:
 @dataclass(frozen=True)
 class BenchmarkVectorIndexOptions:
     strategy: str = ""
-    m: int = 0
-    ef_construction: int = 0
-    ef_search: int = 0
+    m: Optional[int] = None
+    ef_construction: Optional[int] = None
+    ef_search: Optional[int] = None
     quantized_indexes: Sequence[QuantizedIndexInfo | Mapping[str, Any]] = field(default_factory=list)
 
     @classmethod
@@ -299,9 +299,13 @@ class BenchmarkVectorIndexOptions:
             raise TypeError("vector index options.quantized_indexes must be a sequence")
         return cls(
             strategy=_as_optional_str_default(data.get("strategy"), "vector index options.strategy"),
-            m=_as_optional_int_default(data.get("m"), "vector index options.m"),
-            ef_construction=_as_optional_int_default(data.get("ef_construction"), "vector index options.ef_construction"),
-            ef_search=_as_optional_int_default(data.get("ef_search"), "vector index options.ef_search"),
+            m=None if "m" not in data or data.get("m") is None else _as_int(data.get("m"), "vector index options.m"),
+            ef_construction=None
+            if "ef_construction" not in data or data.get("ef_construction") is None
+            else _as_int(data.get("ef_construction"), "vector index options.ef_construction"),
+            ef_search=None
+            if "ef_search" not in data or data.get("ef_search") is None
+            else _as_int(data.get("ef_search"), "vector index options.ef_search"),
             quantized_indexes=[QuantizedIndexInfo.from_dict(item) for item in raw_quantized],
         )
 
@@ -309,11 +313,11 @@ class BenchmarkVectorIndexOptions:
         out: Dict[str, Any] = {}
         if self.strategy:
             out["strategy"] = self.strategy
-        if self.m:
+        if self.m is not None:
             out["m"] = _as_int(self.m, "vector index options.m")
-        if self.ef_construction:
+        if self.ef_construction is not None:
             out["ef_construction"] = _as_int(self.ef_construction, "vector index options.ef_construction")
-        if self.ef_search:
+        if self.ef_search is not None:
             out["ef_search"] = _as_int(self.ef_search, "vector index options.ef_search")
         if self.quantized_indexes:
             out["quantized_indexes"] = [

--- a/clients/python/treedb_client/src/treedb_client/models.py
+++ b/clients/python/treedb_client/src/treedb_client/models.py
@@ -168,6 +168,15 @@ class IndexCapabilities:
     hybrid_search: bool
     keyword_metadata_filters: bool = False
     hybrid_metadata_filters: bool = False
+    benchmark_lifecycle: bool = False
+    vector_index_maintenance: bool = False
+    no_document_vector_search: bool = False
+    column_graph_vector_search: bool = False
+    exact_column_graph_search: bool = False
+    quantized_vector_search: bool = False
+    quantized_rerank: bool = False
+    scalar_u8_quantized_rerank: bool = False
+    rabitq_1bit_experimental: bool = False
     extra: Dict[str, Any] = field(default_factory=dict)
 
     @classmethod
@@ -181,6 +190,15 @@ class IndexCapabilities:
             "hybrid_search",
             "keyword_metadata_filters",
             "hybrid_metadata_filters",
+            "benchmark_lifecycle",
+            "vector_index_maintenance",
+            "no_document_vector_search",
+            "column_graph_vector_search",
+            "exact_column_graph_search",
+            "quantized_vector_search",
+            "quantized_rerank",
+            "scalar_u8_quantized_rerank",
+            "rabitq_1bit_experimental",
         ]
         return cls(
             dense_vector_search=_as_bool(data.get("dense_vector_search", False), "index.capabilities.dense_vector_search"),
@@ -193,6 +211,29 @@ class IndexCapabilities:
             ),
             hybrid_metadata_filters=_as_bool(
                 data.get("hybrid_metadata_filters", False), "index.capabilities.hybrid_metadata_filters"
+            ),
+            benchmark_lifecycle=_as_bool(data.get("benchmark_lifecycle", False), "index.capabilities.benchmark_lifecycle"),
+            vector_index_maintenance=_as_bool(
+                data.get("vector_index_maintenance", False), "index.capabilities.vector_index_maintenance"
+            ),
+            no_document_vector_search=_as_bool(
+                data.get("no_document_vector_search", False), "index.capabilities.no_document_vector_search"
+            ),
+            column_graph_vector_search=_as_bool(
+                data.get("column_graph_vector_search", False), "index.capabilities.column_graph_vector_search"
+            ),
+            exact_column_graph_search=_as_bool(
+                data.get("exact_column_graph_search", False), "index.capabilities.exact_column_graph_search"
+            ),
+            quantized_vector_search=_as_bool(
+                data.get("quantized_vector_search", False), "index.capabilities.quantized_vector_search"
+            ),
+            quantized_rerank=_as_bool(data.get("quantized_rerank", False), "index.capabilities.quantized_rerank"),
+            scalar_u8_quantized_rerank=_as_bool(
+                data.get("scalar_u8_quantized_rerank", False), "index.capabilities.scalar_u8_quantized_rerank"
+            ),
+            rabitq_1bit_experimental=_as_bool(
+                data.get("rabitq_1bit_experimental", False), "index.capabilities.rabitq_1bit_experimental"
             ),
             extra=_copy_extra(data, allowed),
         )
@@ -207,9 +248,79 @@ class IndexCapabilities:
                 "hybrid_search": self.hybrid_search,
                 "keyword_metadata_filters": self.keyword_metadata_filters,
                 "hybrid_metadata_filters": self.hybrid_metadata_filters,
+                "benchmark_lifecycle": self.benchmark_lifecycle,
+                "vector_index_maintenance": self.vector_index_maintenance,
+                "no_document_vector_search": self.no_document_vector_search,
+                "column_graph_vector_search": self.column_graph_vector_search,
+                "exact_column_graph_search": self.exact_column_graph_search,
+                "quantized_vector_search": self.quantized_vector_search,
+                "quantized_rerank": self.quantized_rerank,
+                "scalar_u8_quantized_rerank": self.scalar_u8_quantized_rerank,
+                "rabitq_1bit_experimental": self.rabitq_1bit_experimental,
             },
             self.extra,
         )
+
+
+@dataclass(frozen=True)
+class QuantizedIndexInfo:
+    name: str
+    codec: str = "scalar_u8"
+    version: int = 1
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "QuantizedIndexInfo":
+        data = _as_mapping(data, "quantized index")
+        _reject_unknown(data, ["name", "codec", "version"], "quantized index")
+        return cls(
+            name=_as_str(data["name"], "quantized index.name"),
+            codec=_as_optional_str_default(data.get("codec"), "quantized index.codec") or "scalar_u8",
+            version=_as_optional_int_default(data.get("version"), "quantized index.version") or 1,
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"name": self.name, "codec": self.codec, "version": self.version}
+
+
+@dataclass(frozen=True)
+class BenchmarkVectorIndexOptions:
+    strategy: str = ""
+    m: int = 0
+    ef_construction: int = 0
+    ef_search: int = 0
+    quantized_indexes: Sequence[QuantizedIndexInfo | Mapping[str, Any]] = field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "BenchmarkVectorIndexOptions":
+        data = _as_mapping(data, "vector index options")
+        _reject_unknown(data, ["strategy", "m", "ef_construction", "ef_search", "quantized_indexes"], "vector index options")
+        raw_quantized = data.get("quantized_indexes", [])
+        if isinstance(raw_quantized, (str, bytes, bytearray)) or not isinstance(raw_quantized, Sequence):
+            raise TypeError("vector index options.quantized_indexes must be a sequence")
+        return cls(
+            strategy=_as_optional_str_default(data.get("strategy"), "vector index options.strategy"),
+            m=_as_optional_int_default(data.get("m"), "vector index options.m"),
+            ef_construction=_as_optional_int_default(data.get("ef_construction"), "vector index options.ef_construction"),
+            ef_search=_as_optional_int_default(data.get("ef_search"), "vector index options.ef_search"),
+            quantized_indexes=[QuantizedIndexInfo.from_dict(item) for item in raw_quantized],
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        out: Dict[str, Any] = {}
+        if self.strategy:
+            out["strategy"] = self.strategy
+        if self.m:
+            out["m"] = _as_int(self.m, "vector index options.m")
+        if self.ef_construction:
+            out["ef_construction"] = _as_int(self.ef_construction, "vector index options.ef_construction")
+        if self.ef_search:
+            out["ef_search"] = _as_int(self.ef_search, "vector index options.ef_search")
+        if self.quantized_indexes:
+            out["quantized_indexes"] = [
+                item.to_dict() if isinstance(item, QuantizedIndexInfo) else QuantizedIndexInfo.from_dict(item).to_dict()
+                for item in self.quantized_indexes
+            ]
+        return out
 
 
 @dataclass(frozen=True)
@@ -223,6 +334,11 @@ class IndexInfo:
     document_type: str
     capabilities: IndexCapabilities
     vector_index_name: str = ""
+    vector_strategy: str = ""
+    vector_m: int = 0
+    vector_ef_construction: int = 0
+    vector_ef_search: int = 0
+    quantized_indexes: list[QuantizedIndexInfo] = field(default_factory=list)
     text_field: str = ""
     text_index_name: str = ""
     extra: Dict[str, Any] = field(default_factory=dict)
@@ -238,6 +354,11 @@ class IndexInfo:
             "contract_version",
             "embedding_field",
             "vector_index_name",
+            "vector_strategy",
+            "vector_m",
+            "vector_ef_construction",
+            "vector_ef_search",
+            "quantized_indexes",
             "text_field",
             "text_index_name",
             "document_type",
@@ -252,6 +373,13 @@ class IndexInfo:
             contract_version=_as_str(data["contract_version"], "index.contract_version"),
             embedding_field=embedding_field,
             vector_index_name=_as_optional_str_default(data.get("vector_index_name", embedding_field), "index.vector_index_name"),
+            vector_strategy=_as_optional_str_default(data.get("vector_strategy", ""), "index.vector_strategy"),
+            vector_m=_as_optional_int_default(data.get("vector_m"), "index.vector_m"),
+            vector_ef_construction=_as_optional_int_default(
+                data.get("vector_ef_construction"), "index.vector_ef_construction"
+            ),
+            vector_ef_search=_as_optional_int_default(data.get("vector_ef_search"), "index.vector_ef_search"),
+            quantized_indexes=[QuantizedIndexInfo.from_dict(item) for item in data.get("quantized_indexes", [])],
             text_field=_as_optional_str_default(data.get("text_field", ""), "index.text_field"),
             text_index_name=_as_optional_str_default(data.get("text_index_name", ""), "index.text_index_name"),
             document_type=_as_str(data["document_type"], "index.document_type"),
@@ -269,6 +397,11 @@ class IndexInfo:
                 "contract_version": self.contract_version,
                 "embedding_field": self.embedding_field,
                 "vector_index_name": self.vector_index_name,
+                "vector_strategy": self.vector_strategy,
+                "vector_m": self.vector_m,
+                "vector_ef_construction": self.vector_ef_construction,
+                "vector_ef_search": self.vector_ef_search,
+                "quantized_indexes": [item.to_dict() for item in self.quantized_indexes],
                 "text_field": self.text_field,
                 "text_index_name": self.text_index_name,
                 "document_type": self.document_type,
@@ -360,6 +493,156 @@ class DenseVectorSearchResponse:
             metric=_as_str(data["metric"], "metric"),
             exact=_as_bool(data["exact"], "exact"),
             candidates=_as_int(data["candidates"], "candidates"),
+        )
+
+
+@dataclass(frozen=True)
+class ResetIndexResponse:
+    index: IndexInfo
+    created: bool
+    reset: bool
+    drop_old: bool
+    dropped_documents: int
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "ResetIndexResponse":
+        data = _as_mapping(data, "reset index response")
+        return cls(
+            index=IndexInfo.from_dict(data["index"]),
+            created=_as_bool(data.get("created", False), "reset response.created"),
+            reset=_as_bool(data.get("reset", False), "reset response.reset"),
+            drop_old=_as_bool(data.get("drop_old", False), "reset response.drop_old"),
+            dropped_documents=_as_int(data.get("dropped_documents", 0), "reset response.dropped_documents"),
+        )
+
+
+@dataclass(frozen=True)
+class VectorIndexMaintenanceStatus:
+    name: str = ""
+    strategy: str = ""
+    state: str = ""
+    reason: str = ""
+    loaded: bool = False
+    rebuild_needed: bool = False
+    root_id: int = 0
+    native_root_loaded: bool = False
+    native_root_bytes: int = 0
+    duration_nanos: int = 0
+    extra: Dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "VectorIndexMaintenanceStatus":
+        data = _as_mapping(data, "vector index maintenance status")
+        allowed = [
+            "name",
+            "strategy",
+            "state",
+            "reason",
+            "loaded",
+            "rebuild_needed",
+            "root_id",
+            "native_root_loaded",
+            "native_root_bytes",
+            "duration_nanos",
+        ]
+        return cls(
+            name=_as_optional_str_default(data.get("name"), "maintenance status.name"),
+            strategy=_as_optional_str_default(data.get("strategy"), "maintenance status.strategy"),
+            state=_as_optional_str_default(data.get("state"), "maintenance status.state"),
+            reason=_as_optional_str_default(data.get("reason"), "maintenance status.reason"),
+            loaded=_as_optional_bool_default(data.get("loaded"), "maintenance status.loaded"),
+            rebuild_needed=_as_optional_bool_default(data.get("rebuild_needed"), "maintenance status.rebuild_needed"),
+            root_id=_as_optional_int_default(data.get("root_id"), "maintenance status.root_id"),
+            native_root_loaded=_as_optional_bool_default(
+                data.get("native_root_loaded"), "maintenance status.native_root_loaded"
+            ),
+            native_root_bytes=_as_optional_int_default(
+                data.get("native_root_bytes"), "maintenance status.native_root_bytes"
+            ),
+            duration_nanos=_as_optional_int_default(data.get("duration_nanos"), "maintenance status.duration_nanos"),
+            extra=_copy_extra(data, allowed),
+        )
+
+
+@dataclass(frozen=True)
+class OptimizeIndexResponse:
+    index: IndexInfo
+    vector_index_name: str
+    status: VectorIndexMaintenanceStatus
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "OptimizeIndexResponse":
+        data = _as_mapping(data, "optimize index response")
+        return cls(
+            index=IndexInfo.from_dict(data["index"]),
+            vector_index_name=_as_str(data["vector_index_name"], "optimize response.vector_index_name"),
+            status=VectorIndexMaintenanceStatus.from_dict(data.get("status", {})),
+        )
+
+
+@dataclass(frozen=True)
+class BenchmarkVectorSearchResult:
+    id: str
+    ordinal: int
+    score: float
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "BenchmarkVectorSearchResult":
+        data = _as_mapping(data, "benchmark vector search result")
+        return cls(
+            id=_as_str(data["id"], "benchmark result.id"),
+            ordinal=_as_int(data.get("ordinal", 0), "benchmark result.ordinal"),
+            score=_optional_float(data.get("score", 0.0), "benchmark result.score") or 0.0,
+        )
+
+
+@dataclass(frozen=True)
+class BenchmarkVectorSearchResponse:
+    index: IndexInfo
+    results: list[BenchmarkVectorSearchResult]
+    metric: str
+    vector_index_name: str
+    query_mode: str
+    quantized_index_name: str = ""
+    quantized_rerank_candidates: int = 0
+    no_documents: bool = False
+    stats: Dict[str, Any] = field(default_factory=dict)
+    diagnostics: Dict[str, Any] = field(default_factory=dict)
+    extra: Dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "BenchmarkVectorSearchResponse":
+        data = _as_mapping(data, "benchmark vector search response")
+        allowed = [
+            "index",
+            "results",
+            "metric",
+            "vector_index_name",
+            "query_mode",
+            "quantized_index_name",
+            "quantized_rerank_candidates",
+            "no_documents",
+            "stats",
+            "diagnostics",
+        ]
+        stats = data.get("stats", {})
+        diagnostics = data.get("diagnostics", {})
+        return cls(
+            index=IndexInfo.from_dict(data["index"]),
+            results=[BenchmarkVectorSearchResult.from_dict(item) for item in data.get("results", [])],
+            metric=_as_str(data["metric"], "benchmark response.metric"),
+            vector_index_name=_as_str(data["vector_index_name"], "benchmark response.vector_index_name"),
+            query_mode=_as_str(data["query_mode"], "benchmark response.query_mode"),
+            quantized_index_name=_as_optional_str_default(
+                data.get("quantized_index_name"), "benchmark response.quantized_index_name"
+            ),
+            quantized_rerank_candidates=_as_optional_int_default(
+                data.get("quantized_rerank_candidates"), "benchmark response.quantized_rerank_candidates"
+            ),
+            no_documents=_as_optional_bool_default(data.get("no_documents"), "benchmark response.no_documents"),
+            stats=dict(_as_mapping(stats, "benchmark response.stats")),
+            diagnostics=dict(_as_mapping(diagnostics, "benchmark response.diagnostics")),
+            extra=_copy_extra(data, allowed),
         )
 
 

--- a/clients/python/treedb_client/tests/test_client.py
+++ b/clients/python/treedb_client/tests/test_client.py
@@ -282,6 +282,7 @@ class TreeDBClientTests(unittest.TestCase):
             self.assertEqual(search.query_mode, "quantized_rerank")
             self.assertEqual(search.results[0].id, "doc-1")
             reset_body = json_body(server.records[0])
+            self.assertNotIn("metric", reset_body)
             self.assertEqual(reset_body["vector_index_options"]["strategy"], "column_graph")
             self.assertEqual(reset_body["vector_index_options"]["quantized_indexes"][0]["codec"], "scalar_u8")
             self.assertEqual(json_body(server.records[1]), {"expected_generation": 1})

--- a/clients/python/treedb_client/tests/test_client.py
+++ b/clients/python/treedb_client/tests/test_client.py
@@ -288,6 +288,18 @@ class TreeDBClientTests(unittest.TestCase):
             self.assertEqual(json_body(server.records[1]), {"expected_generation": 1})
             self.assertEqual(json_body(server.records[2])["quantized_rerank_candidates"], 32)
 
+    def test_empty_optional_benchmark_fields_fail_closed_locally(self) -> None:
+        client = TreeDBClient("http://127.0.0.1:1", timeout=1)
+
+        with self.assertRaisesRegex(InvalidRequestError, "metric"):
+            client.create_index("docs", 2, metric="")
+        with self.assertRaisesRegex(InvalidRequestError, "metric"):
+            client.reset_index("docs", dimension=2, metric="")
+        with self.assertRaisesRegex(InvalidRequestError, "query_mode"):
+            client.search_vector_index("docs", [1, 0], 1, query_mode="")
+        with self.assertRaisesRegex(InvalidRequestError, "stats_mode"):
+            client.search_vector_index("docs", [1, 0], 1, stats_mode="")
+
     def test_keyword_search_serializes_request_and_parses_response(self) -> None:
         route = "/v1/indexes/docs/search/keyword"
         response = {

--- a/clients/python/treedb_client/tests/test_client.py
+++ b/clients/python/treedb_client/tests/test_client.py
@@ -9,12 +9,14 @@ from typing import Any, Dict, Tuple
 
 import _support  # noqa: F401
 from treedb_client import (
+    BenchmarkVectorIndexOptions,
     Document,
     HybridFusionOptions,
     IndexNotFoundError,
     IndexStaleError,
     IndexUnavailableError,
     InvalidRequestError,
+    QuantizedIndexInfo,
     TreeDBClient,
     TreeDBConfigError,
     TreeDBProtocolError,
@@ -32,6 +34,11 @@ SAMPLE_INDEX = {
     "contract_version": "treedb-document-service/v1alpha1",
     "embedding_field": "embedding",
     "vector_index_name": "embedding",
+    "vector_strategy": "column_graph",
+    "vector_m": 16,
+    "vector_ef_construction": 128,
+    "vector_ef_search": 64,
+    "quantized_indexes": [{"name": "embedding.scalar_u8.fast", "codec": "scalar_u8", "version": 1}],
     "text_field": "content",
     "text_index_name": "content",
     "document_type": "treedb_document_service_v1",
@@ -43,6 +50,15 @@ SAMPLE_INDEX = {
         "hybrid_search": True,
         "keyword_metadata_filters": False,
         "hybrid_metadata_filters": False,
+        "benchmark_lifecycle": True,
+        "vector_index_maintenance": True,
+        "no_document_vector_search": True,
+        "column_graph_vector_search": True,
+        "exact_column_graph_search": True,
+        "quantized_vector_search": True,
+        "quantized_rerank": True,
+        "scalar_u8_quantized_rerank": True,
+        "rabitq_1bit_experimental": False,
     },
 }
 
@@ -198,6 +214,78 @@ class TreeDBClientTests(unittest.TestCase):
 
             delete_body = json_body(server.records[-1])
             self.assertEqual(delete_body["filter"], {"field": "meta.repo", "operator": "==", "value": "gomap"})
+
+
+    def test_benchmark_lifecycle_and_vector_index_search_methods(self) -> None:
+        reset_route = "/v1/indexes/bench/reset"
+        optimize_route = "/v1/indexes/bench/optimize"
+        search_route = "/v1/indexes/bench/search/vector-index"
+        routes = {
+            ("POST", reset_route): (
+                200,
+                {"index": SAMPLE_INDEX, "created": True, "reset": False, "drop_old": True, "dropped_documents": 0},
+                0,
+            ),
+            ("POST", optimize_route): (
+                200,
+                {
+                    "index": SAMPLE_INDEX,
+                    "vector_index_name": "embedding",
+                    "status": {"name": "embedding", "strategy": "column_graph", "state": "column_graph_loaded", "loaded": True},
+                },
+                0,
+            ),
+            ("POST", search_route): (
+                200,
+                {
+                    "index": SAMPLE_INDEX,
+                    "results": [{"id": "doc-1", "ordinal": 1, "score": 0.98}],
+                    "metric": "cosine",
+                    "vector_index_name": "embedding",
+                    "query_mode": "quantized_rerank",
+                    "quantized_index_name": "embedding.scalar_u8.fast",
+                    "quantized_rerank_candidates": 32,
+                    "no_documents": True,
+                    "stats": {"documents_fetched": 0, "quantized_rerank_exact_score_calls": 32},
+                    "diagnostics": {"route": "quantized_rerank"},
+                },
+                0,
+            ),
+        }
+        with FixtureServer(routes) as server:
+            client = TreeDBClient(server.base_url, timeout=1)
+
+            reset = client.reset_index(
+                "bench",
+                dimension=2,
+                drop_old=True,
+                vector_index_options=BenchmarkVectorIndexOptions(
+                    strategy="column_graph",
+                    m=16,
+                    ef_construction=128,
+                    ef_search=64,
+                    quantized_indexes=[QuantizedIndexInfo(name="embedding.scalar_u8.fast")],
+                ),
+            )
+            optimize = client.optimize_index("bench", expected_generation=1)
+            search = client.search_vector_index(
+                "bench",
+                [1, 0],
+                1,
+                query_mode="quantized_rerank",
+                quantized_index_name="embedding.scalar_u8.fast",
+                quantized_rerank_candidates=32,
+            )
+
+            self.assertTrue(reset.created)
+            self.assertTrue(optimize.status.loaded)
+            self.assertEqual(search.query_mode, "quantized_rerank")
+            self.assertEqual(search.results[0].id, "doc-1")
+            reset_body = json_body(server.records[0])
+            self.assertEqual(reset_body["vector_index_options"]["strategy"], "column_graph")
+            self.assertEqual(reset_body["vector_index_options"]["quantized_indexes"][0]["codec"], "scalar_u8")
+            self.assertEqual(json_body(server.records[1]), {"expected_generation": 1})
+            self.assertEqual(json_body(server.records[2])["quantized_rerank_candidates"], 32)
 
     def test_keyword_search_serializes_request_and_parses_response(self) -> None:
         route = "/v1/indexes/docs/search/keyword"

--- a/clients/python/treedb_client/tests/test_models.py
+++ b/clients/python/treedb_client/tests/test_models.py
@@ -162,6 +162,12 @@ class IndexModelTests(unittest.TestCase):
         self.assertTrue(response.index.capabilities.scalar_u8_quantized_rerank)
         self.assertEqual(response.index.quantized_indexes[0].name, "embedding.scalar_u8.fast")
 
+    def test_benchmark_vector_options_preserve_explicit_zero_values(self) -> None:
+        options = BenchmarkVectorIndexOptions.from_dict({"m": 0, "ef_construction": 0, "ef_search": 0})
+
+        self.assertEqual(options.to_dict(), {"m": 0, "ef_construction": 0, "ef_search": 0})
+        self.assertEqual(BenchmarkVectorIndexOptions().to_dict(), {})
+
 
 class KeywordHybridModelTests(unittest.TestCase):
     def test_keyword_request_serializes_supported_fields_and_filter(self) -> None:

--- a/clients/python/treedb_client/tests/test_models.py
+++ b/clients/python/treedb_client/tests/test_models.py
@@ -4,6 +4,8 @@ import unittest
 
 import _support  # noqa: F401
 from treedb_client import (
+    BenchmarkVectorIndexOptions,
+    BenchmarkVectorSearchResponse,
     Document,
     HybridFusionOptions,
     HybridSearchPlan,
@@ -13,6 +15,7 @@ from treedb_client import (
     IndexInfo,
     KeywordSearchRequest,
     KeywordSearchResponse,
+    QuantizedIndexInfo,
 )
 
 
@@ -105,6 +108,59 @@ class IndexModelTests(unittest.TestCase):
 
         self.assertEqual(capabilities.extra["future_capability"], "kept")
         self.assertEqual(capabilities.to_dict()["future_capability"], "kept")
+
+
+
+    def test_benchmark_vector_models_round_trip_scalar_u8_rerank(self) -> None:
+        options = BenchmarkVectorIndexOptions(
+            strategy="column_graph",
+            m=16,
+            ef_construction=128,
+            ef_search=64,
+            quantized_indexes=[QuantizedIndexInfo(name="embedding.scalar_u8.fast")],
+        )
+
+        self.assertEqual(
+            options.to_dict(),
+            {
+                "strategy": "column_graph",
+                "m": 16,
+                "ef_construction": 128,
+                "ef_search": 64,
+                "quantized_indexes": [{"name": "embedding.scalar_u8.fast", "codec": "scalar_u8", "version": 1}],
+            },
+        )
+
+        response = BenchmarkVectorSearchResponse.from_dict(
+            {
+                "index": {
+                    **_sample_index(),
+                    "vector_strategy": "column_graph",
+                    "quantized_indexes": [{"name": "embedding.scalar_u8.fast", "codec": "scalar_u8", "version": 1}],
+                    "capabilities": {
+                        **_sample_index()["capabilities"],
+                        "no_document_vector_search": True,
+                        "quantized_rerank": True,
+                        "scalar_u8_quantized_rerank": True,
+                    },
+                },
+                "results": [{"id": "doc-1", "ordinal": 7, "score": 0.99}],
+                "metric": "cosine",
+                "vector_index_name": "embedding",
+                "query_mode": "quantized_rerank",
+                "quantized_index_name": "embedding.scalar_u8.fast",
+                "quantized_rerank_candidates": 32,
+                "no_documents": True,
+                "stats": {"documents_fetched": 0, "quantized_rerank_exact_score_calls": 32},
+                "diagnostics": {"route": "quantized_rerank"},
+            }
+        )
+
+        self.assertEqual(response.query_mode, "quantized_rerank")
+        self.assertEqual(response.quantized_rerank_candidates, 32)
+        self.assertEqual(response.results[0].id, "doc-1")
+        self.assertTrue(response.index.capabilities.scalar_u8_quantized_rerank)
+        self.assertEqual(response.index.quantized_indexes[0].name, "embedding.scalar_u8.fast")
 
 
 class KeywordHybridModelTests(unittest.TestCase):

--- a/docs/TREEDB_DOCUMENT_SERVICE_API.md
+++ b/docs/TREEDB_DOCUMENT_SERVICE_API.md
@@ -144,6 +144,13 @@ Responses include:
     "contract_version": "treedb-document-service/v1alpha1",
     "embedding_field": "embedding",
     "vector_index_name": "embedding",
+    "vector_strategy": "column_graph",
+    "vector_m": 16,
+    "vector_ef_construction": 128,
+    "vector_ef_search": 64,
+    "quantized_indexes": [
+      {"name": "embedding.scalar_u8.fast", "codec": "scalar_u8", "version": 1}
+    ],
     "text_field": "content",
     "text_index_name": "content",
     "document_type": "treedb_document_service_v1",
@@ -154,7 +161,16 @@ Responses include:
       "keyword_search": true,
       "hybrid_search": true,
       "keyword_metadata_filters": false,
-      "hybrid_metadata_filters": false
+      "hybrid_metadata_filters": false,
+      "benchmark_lifecycle": true,
+      "vector_index_maintenance": true,
+      "no_document_vector_search": true,
+      "column_graph_vector_search": true,
+      "exact_column_graph_search": true,
+      "quantized_vector_search": true,
+      "quantized_rerank": true,
+      "scalar_u8_quantized_rerank": true,
+      "rabitq_1bit_experimental": false
     }
   }
 }
@@ -273,6 +289,101 @@ document count/filter/delete and exact dense-vector search. Keyword and hybrid
 requests validate the shape and then fail closed with `unsupported` when any
 filter is supplied.
 
+
+## Benchmark lifecycle and no-document vector-index search
+
+These routes exist for external benchmark adapters such as VectorDBBench. They
+are deliberately separate from Haystack's exact dense-vector route: they time the
+TreeDB service/vector-index boundary and never broaden unsupported ANN or
+quantized modes into exact document scans. VDBBench rows that use these routes
+include Python/client/service overhead and are not native Go `B/op` or
+`allocs/op` evidence.
+
+Create a benchmark-shaped index by passing `vector_index_options` to
+`POST /v1/indexes` or to the reset route when the index is missing:
+
+```json
+{
+  "name": "bench",
+  "dimension": 1536,
+  "metric": "cosine",
+  "vector_index_options": {
+    "strategy": "column_graph",
+    "m": 16,
+    "ef_construction": 128,
+    "ef_search": 64,
+    "quantized_indexes": [
+      {"name": "embedding.scalar_u8.fast", "codec": "scalar_u8", "version": 1}
+    ]
+  }
+}
+```
+
+`codec=scalar_u8` plus `query_mode=quantized_rerank` is the exact-like
+quantized benchmark lane; rerank32 is the baseline evidence target when
+`quantized_rerank_candidates` is set to `32`. `rabitq_1bit`/`brq_1bit` may be
+declared for experimental compact rows, but the v1 codec semantics and recall
+caveats are unchanged.
+
+Reset/create for benchmark harnesses:
+
+```http
+POST /v1/indexes/{index}/reset
+```
+
+```json
+{
+  "dimension": 1536,
+  "metric": "cosine",
+  "drop_old": true,
+  "vector_index_options": {"strategy": "column_graph"}
+}
+```
+
+If `{index}` is missing, the route creates it. If `{index}` already exists and
+`drop_old=false`, it returns `conflict`. Existing `column_graph` benchmark
+indexes fail closed with `unsupported` for in-place `drop_old` reset; managed
+benchmark runs should use a fresh data directory, and shared external services
+should use a unique index name per run. This avoids adding a broad durable
+collection-truncate/WAL format just for benchmark reset and preserves TreeDB's
+insert-only graph rebuild boundary. Compatible non-`column_graph` indexes may be
+cleared with existing document deletes.
+
+Optimize/rebuild after load:
+
+```http
+POST /v1/indexes/{index}/optimize
+```
+
+```json
+{"vector_index_name": "embedding", "expected_generation": 1}
+```
+
+No-document vector-index benchmark search:
+
+```http
+POST /v1/indexes/{index}/search/vector-index
+```
+
+```json
+{
+  "query_embedding": [0.1, 0.2, 0.3],
+  "top_k": 10,
+  "ef_search": 64,
+  "query_mode": "quantized_rerank",
+  "quantized_index_name": "embedding.scalar_u8.fast",
+  "quantized_rerank_candidates": 32
+}
+```
+
+Supported `query_mode` values are `exact`, `quantized_only`, and
+`quantized_rerank`. Quantized modes require a declared quantized index name and
+fail closed when assets are missing, invalid, stale, or unavailable. Responses
+include result IDs/scores plus TreeDB stats/diagnostics so benchmark adapters can
+assert no-document guardrails: no documents fetched, no exact fallback for
+quantized modes, quantized scorer active, and rerank exact reads bounded by the
+requested shortlist.
+
 ## Dense-vector search
 
 ```http
@@ -306,7 +417,7 @@ Response:
 }
 ```
 
-Tie order is deterministic: higher score first, then document ID ascending.
+Tie order is deterministic: higher score first, then document ID ascending. This route remains exact dense document scoring for TreeDB's Python and Haystack clients; it is not the `column_graph` ANN/no-document benchmark route.
 
 ## Keyword search
 

--- a/docs/TREEDB_DOCUMENT_SERVICE_API.md
+++ b/docs/TREEDB_DOCUMENT_SERVICE_API.md
@@ -321,9 +321,9 @@ Create a benchmark-shaped index by passing `vector_index_options` to
 
 `codec=scalar_u8` plus `query_mode=quantized_rerank` is the exact-like
 quantized benchmark lane; rerank32 is the baseline evidence target when
-`quantized_rerank_candidates` is set to `32`. `rabitq_1bit`/`brq_1bit` may be
-declared for experimental compact rows, but the v1 codec semantics and recall
-caveats are unchanged.
+`quantized_rerank_candidates` is set to `32`. `rabitq_1bit` may be declared
+for experimental compact rows, but the v1 codec semantics and recall caveats
+are unchanged.
 
 Reset/create for benchmark harnesses:
 


### PR DESCRIPTION
## Objective

Add the TreeDB document-service and `treedb-client` contract needed by VectorDBBench benchmark adapters: benchmark lifecycle setup, explicit vector-index optimize/rebuild, and fail-closed no-document vector-index search.

Closes #2570. Parent tracker: #2569.

## Context

VectorDBBench needs a Python/service boundary that is aligned with the existing `treedb-client` / `treedb-haystack` stack but does not redefine Haystack's exact dense-vector route as ANN. This PR adds separate benchmark routes and client helpers while preserving `/search/vector` as exact dense document scoring.

## Non-goals

- No Haystack ANN behavior change.
- No in-place durable `Collection.Truncate()` or command-WAL format change for benchmark reset.
- No silent exact fallback for ANN/quantized benchmark modes.
- No mutation of `rabitq_1bit` v1 semantics.
- No claim that Python/service VectorDBBench rows are native Go `B/op` / `allocs/op` evidence.

## Design

- Adds benchmark lifecycle route: `POST /v1/indexes/{index}/reset`.
  - Creates a missing benchmark index.
  - Existing `column_graph` benchmark indexes fail closed with `unsupported` for in-place `drop_old`; managed benchmark runs should use a fresh data directory, and shared services should use unique index names.
  - Compatible non-`column_graph` indexes can be cleared with existing document deletes.
- Adds vector asset maintenance route: `POST /v1/indexes/{index}/optimize`.
- Adds no-document vector-index benchmark route: `POST /v1/indexes/{index}/search/vector-index`.
  - Uses `Collection.SearchVectorIndexWithBuffer`.
  - Supports `exact`, `quantized_only`, and `quantized_rerank`.
  - Validates route diagnostics/counters so unsupported or fallback paths fail closed.
- Adds scalar_u8 + rerank contract fields:
  - `quantized_index_name`
  - `quantized_rerank_candidates`
  - `query_mode="quantized_rerank"`
  - docs call out rerank32 as the baseline evidence target.
- Extends `treedb-client` with typed options/responses and methods for these routes.

## Scope

Includes:

- `TreeDB/documentservice/*`
- `docs/TREEDB_DOCUMENT_SERVICE_API.md`
- `clients/python/treedb_client/*`

Excludes:

- `treedb-haystack` API changes.
- VDBBench adapter implementation (#2571/#2572).
- Durable collection truncate / command-WAL frame changes.

## Correctness

Tests run:

```sh
go test ./TreeDB/documentservice ./cmd/treedb-document-service
cd clients/python/treedb_client && PYTHONPATH=src python3 -m unittest discover -s tests
cd clients/python/treedb_client && python3 -m compileall -q src tests
git diff --check
```

Covered:

- benchmark index create/reset route;
- no-document exact vector-index route;
- scalar_u8 `quantized_rerank` route and rerank counters;
- unsupported/stale/missing-asset fail-closed cases;
- exact dense `/search/vector` remains exact document scoring;
- Python client serialization/parsing for benchmark lifecycle and scalar_u8 + rerank fields.

## Performance

No native vector hot path was intentionally changed. The new service route calls existing TreeDB buffered no-document vector search and validates counters/diagnostics at the service boundary.

Benchmarks are deferred to #2572/#2573 where the VDBBench rows will be run with explicit Python/service measurement boundaries. This PR's focused evidence is route/counter correctness rather than throughput improvement.

## Rollout / Toggle Plan

- Existing `/search/vector` exact dense route is unchanged for Haystack/client users.
- Benchmark routes are opt-in and separate.
- Existing `column_graph` reset fails closed; callers can use fresh dirs or unique index names.

## Follow-ups

- #2571: VDBBench Python benchmark client and CLI seam.
- #2572: exact FP32 and scalar_u8 + rerank VDBBench variants.
- #2573: docs/runbook/evidence.

## AI Review Loop

Not requested yet. This PR should request Codex/Copilot/CodeRabbit only after latest-head CI is running or green and the coordinator final review agrees the PR is mature.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added vector-index search mode supporting quantized vector search with reranking options
  * Added index reset and optimize operations for lifecycle management
  * Enhanced index metadata to expose vector strategy and quantized index configuration
  * Extended Python client with vector-index management and search methods

* **Documentation**
  * Updated API documentation with benchmark lifecycle and vector-index search details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->