### PR TITLE
treedb: reduce text hybrid search allocations

### DIFF
--- a/TreeDB/collections/hybrid_text_candidates.go
+++ b/TreeDB/collections/hybrid_text_candidates.go
@@ -1,14 +1,13 @@
 package collections
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 )
 
 // SearchHybridTextCandidates adapts collection-native ranked text search into
 // the shared hybrid candidate shape. It is candidate-only: it requests no
-// documents from SearchText, copies stable result IDs into response-owned
+// documents from SearchText, reuses response-owned result IDs for response-owned
 // HybridSearchCandidate values, assigns one-based source ranks, preserves text
 // match attribution, and fails closed if the backing text path reports any full
 // document materialization or scan fallback.
@@ -27,12 +26,12 @@ func (c *Collection) SearchHybridTextCandidates(query HybridTextQuery) (HybridCa
 		return response, err
 	}
 
-	textResponse, err := c.SearchText(TextSearchOptions{
+	textResponse, err := c.searchText(TextSearchOptions{
 		IndexName:        query.IndexName,
 		Query:            query.Query,
 		TopK:             requested,
 		IncludeDocuments: false,
-	})
+	}, textSearchResultTextMatchesOnly)
 	if err != nil {
 		response := HybridCandidateResponse{Stats: hybridTextCandidateStatsFromSearch(requested, textResponse.Stats, 0)}
 		response.Stats.FailClosed = 1
@@ -64,7 +63,7 @@ func hybridTextCandidatesFromSearchResponse(requested int, textIndexName string,
 	}
 	candidates := make([]HybridSearchCandidate, len(textResponse.Results))
 	for i, result := range textResponse.Results {
-		id := bytes.Clone(result.DocumentID)
+		id := result.DocumentID
 		id = id[:len(id):len(id)]
 		rank := result.Rank
 		if rank <= 0 {
@@ -136,7 +135,10 @@ func hybridTextMatchesFromSearchResult(result TextSearchResult) []HybridTextMatc
 	}
 	matches := make([]HybridTextMatch, len(result.TextMatches))
 	for i, match := range result.TextMatches {
-		terms := append([]string(nil), match.Terms...)
+		terms := match.Terms
+		if len(terms) > 0 {
+			terms = terms[:len(terms):len(terms)]
+		}
 		matches[i] = HybridTextMatch{Field: match.Field, Terms: terms}
 	}
 	return matches

--- a/TreeDB/collections/text_search.go
+++ b/TreeDB/collections/text_search.go
@@ -106,16 +106,79 @@ type TextSearchResponse struct {
 	Stats     TextSearchStats
 }
 
+type textSearchCandidatePosting struct {
+	term    string
+	posting textSearchPostingValue
+}
+
 type textSearchCandidate struct {
-	documentID []byte
-	postings   map[string]textPostingValue
-	matches    map[string]map[string]struct{}
+	documentID string
+	postings   [2]textSearchCandidatePosting
+	overflow   []textSearchCandidatePosting
+	postingsN  int
 	score      float64
 }
+
+func (c *textSearchCandidate) postingCount() int {
+	if c == nil {
+		return 0
+	}
+	return c.postingsN
+}
+
+func (c *textSearchCandidate) postingForTerm(term string) (textSearchPostingValue, bool) {
+	if c == nil {
+		return textSearchPostingValue{}, false
+	}
+	for i := 0; i < c.postingsN; i++ {
+		entry := c.postingAt(i)
+		if entry.term == term {
+			return entry.posting, true
+		}
+	}
+	return textSearchPostingValue{}, false
+}
+
+func (c *textSearchCandidate) addPosting(term string, posting textSearchPostingValue) {
+	for i := 0; i < c.postingsN; i++ {
+		if c.postingAt(i).term == term {
+			if i < len(c.postings) {
+				c.postings[i].posting = posting
+			} else {
+				c.overflow[i-len(c.postings)].posting = posting
+			}
+			return
+		}
+	}
+	if c.postingsN < len(c.postings) {
+		c.postings[c.postingsN] = textSearchCandidatePosting{term: term, posting: posting}
+	} else {
+		c.overflow = append(c.overflow, textSearchCandidatePosting{term: term, posting: posting})
+	}
+	c.postingsN++
+}
+
+func (c *textSearchCandidate) postingAt(i int) textSearchCandidatePosting {
+	if i < len(c.postings) {
+		return c.postings[i]
+	}
+	return c.overflow[i-len(c.postings)]
+}
+
+type textSearchResultMode uint8
+
+const (
+	textSearchResultFull textSearchResultMode = iota
+	textSearchResultTextMatchesOnly
+)
 
 // SearchText executes a bounded postings-backed lexical search for a declared
 // collection text index. It never scans/ranks all collection documents.
 func (c *Collection) SearchText(opts TextSearchOptions) (TextSearchResponse, error) {
+	return c.searchText(opts, textSearchResultFull)
+}
+
+func (c *Collection) searchText(opts TextSearchOptions, resultMode textSearchResultMode) (TextSearchResponse, error) {
 	var response TextSearchResponse
 	if c == nil {
 		return response, errCollectionNil
@@ -174,7 +237,7 @@ func (c *Collection) SearchText(opts TextSearchOptions) (TextSearchResponse, err
 	maxPostingsScanned := normalizeTextSearchMaxPostingsScanned(candidateLimit, len(terms), opts.MaxPostingsScanned)
 	response.Stats.TextCandidatesRequested = uint64(candidateLimit)
 
-	return executeTextSearchAtSnapshot(c, snap, catalog, idx, opts, terms, operator, candidateLimit, maxPostingsScanned, response)
+	return executeTextSearchAtSnapshot(c, snap, catalog, idx, opts, terms, operator, candidateLimit, maxPostingsScanned, resultMode, response)
 }
 
 func executeTextSearchAtSnapshot(
@@ -186,6 +249,7 @@ func executeTextSearchAtSnapshot(
 	terms []string,
 	operator TextSearchOperator,
 	candidateLimit, maxPostingsScanned int,
+	resultMode textSearchResultMode,
 	response TextSearchResponse,
 ) (TextSearchResponse, error) {
 	statsRootName := collectionTextStatsRootName(catalog.meta.Name, idx.Name)
@@ -203,7 +267,9 @@ func executeTextSearchAtSnapshot(
 	}
 	fieldStats := make(map[string]textStatsFieldValue, len(idx.Fields))
 	fieldWeights := make(map[string]float64, len(idx.Fields))
+	fieldNames := make([]string, 0, len(idx.Fields))
 	for _, field := range idx.Fields {
+		fieldNames = append(fieldNames, field.Field)
 		statsValue, err := readTextStatsFieldAtRoot(snap, catalog, statsRootName, field.Field)
 		if err != nil {
 			return textSearchFailClosed(response, textSearchFailClosedStorageCorrupt, err)
@@ -222,7 +288,7 @@ func executeTextSearchAtSnapshot(
 	postingsRootName := collectionTextIndexRootName(catalog.meta.Name, idx.Name)
 	for i, term := range scanTerms {
 		allowNewCandidates := operator != TextSearchOperatorAND || i == 0
-		truncated, err := scanTextSearchPostingsTerm(snap, catalog, postingsRootName, term, termStats[term], candidates, allowNewCandidates, candidateLimit, maxPostingsScanned, &response.Stats)
+		truncated, err := scanTextSearchPostingsTerm(snap, catalog, postingsRootName, term, termStats[term], candidates, allowNewCandidates, candidateLimit, maxPostingsScanned, fieldNames, &response.Stats)
 		if err != nil {
 			return textSearchFailClosed(response, textSearchFailClosedStorageCorrupt, err)
 		}
@@ -242,7 +308,7 @@ func executeTextSearchAtSnapshot(
 
 	if operator == TextSearchOperatorAND {
 		for key, candidate := range candidates {
-			if len(candidate.postings) != len(terms) {
+			if candidate.postingCount() != len(terms) {
 				delete(candidates, key)
 			}
 		}
@@ -255,19 +321,22 @@ func executeTextSearchAtSnapshot(
 	scoreStart := time.Now()
 	scored := make([]*textSearchCandidate, 0, len(candidates))
 	stateRootName := collectionTextStateRootName(catalog.meta.Name, idx.Name)
+	var stateKeyScratch []byte
+	var fieldLengthScratch []textDocumentFieldLength
 	for _, candidate := range candidates {
-		stateRaw, found, err := collectionGetAppendAtCatalogRoot(snap, catalog, stateRootName, encodeTextStateKey(candidate.documentID), nil)
+		stateKeyScratch = appendTextStateKeyString(stateKeyScratch[:0], candidate.documentID)
+		stateRaw, found, err := collectionGetAppendAtCatalogRoot(snap, catalog, stateRootName, stateKeyScratch, nil)
 		if err != nil {
 			return textSearchFailClosed(response, textSearchFailClosedStorageCorrupt, err)
 		}
 		if !found {
-			return textSearchFailClosed(response, textSearchFailClosedStorageCorrupt, errMalformedTextStorage("missing text-state for collection %q index %q document %q", catalog.meta.Name, idx.Name, string(candidate.documentID)))
+			return textSearchFailClosed(response, textSearchFailClosedStorageCorrupt, errMalformedTextStorage("missing text-state for collection %q index %q document %q", catalog.meta.Name, idx.Name, candidate.documentID))
 		}
-		state, err := decodeTextDocumentStateValue(stateRaw)
+		fieldLengthScratch, err = decodeTextDocumentStateFieldLengths(stateRaw, fieldLengthScratch[:0], fieldNames)
 		if err != nil {
 			return textSearchFailClosed(response, textSearchFailClosedStorageCorrupt, err)
 		}
-		score, err := scoreTextSearchCandidate(candidate, terms, corpus, termStats, fieldStats, fieldWeights, state)
+		score, err := scoreTextSearchCandidate(candidate, terms, corpus, termStats, fieldStats, fieldWeights, fieldLengthScratch)
 		if err != nil {
 			return textSearchFailClosed(response, textSearchFailClosedStorageCorrupt, err)
 		}
@@ -282,7 +351,7 @@ func executeTextSearchAtSnapshot(
 		if scored[i].score != scored[j].score {
 			return scored[i].score > scored[j].score
 		}
-		return bytes.Compare(scored[i].documentID, scored[j].documentID) < 0
+		return scored[i].documentID < scored[j].documentID
 	})
 	if len(scored) > opts.TopK {
 		scored = scored[:opts.TopK]
@@ -290,9 +359,15 @@ func executeTextSearchAtSnapshot(
 	response.Stats.TextCandidatesReturned = uint64(len(scored))
 	response.Results = make([]TextSearchResult, len(scored))
 	for i, candidate := range scored {
-		matchedTerms, matchedFields, matches := textSearchCandidateMatches(candidate)
+		var matchedTerms, matchedFields []string
+		var matches []TextSearchMatch
+		if resultMode == textSearchResultTextMatchesOnly {
+			matches = textSearchCandidateTextMatches(candidate)
+		} else {
+			matchedTerms, matchedFields, matches = textSearchCandidateMatches(candidate)
+		}
 		response.Results[i] = TextSearchResult{
-			DocumentID:    bytes.Clone(candidate.documentID),
+			DocumentID:    []byte(candidate.documentID),
 			IndexName:     idx.Name,
 			Rank:          i + 1,
 			Score:         candidate.score,
@@ -313,7 +388,7 @@ func executeTextSearchAtSnapshot(
 
 func pruneTextSearchANDCandidates(candidates map[string]*textSearchCandidate, term string) {
 	for key, candidate := range candidates {
-		if _, ok := candidate.postings[term]; !ok {
+		if _, ok := candidate.postingForTerm(term); !ok {
 			delete(candidates, key)
 		}
 	}
@@ -327,6 +402,7 @@ func scanTextSearchPostingsTerm(
 	candidates map[string]*textSearchCandidate,
 	allowNewCandidates bool,
 	candidateLimit, maxPostingsScanned int,
+	fieldNames []string,
 	stats *TextSearchStats,
 ) (bool, error) {
 	prefix := encodeTextPostingTermPrefix(term)
@@ -357,14 +433,11 @@ func scanTextSearchPostingsTerm(
 			it.Next()
 			continue
 		}
-		decodedTerm, documentID, err := decodeTextPostingKey(key)
+		documentID, err := decodeTextPostingKeyDocumentIDForPrefix(key, prefix)
 		if err != nil {
 			return false, err
 		}
-		if decodedTerm != term {
-			return false, errMalformedTextStorage("postings key term %q outside scan term %q", decodedTerm, term)
-		}
-		posting, err := decodeTextPostingValue(it.ValueCopy(nil))
+		posting, err := decodeTextPostingValueForSearch(it.UnsafeValue(), fieldNames)
 		if err != nil {
 			return false, err
 		}
@@ -384,22 +457,10 @@ func scanTextSearchPostingsTerm(
 				stats.FailClosedReason = textSearchFailClosedCandidateLimit
 				return true, nil
 			}
-			candidate = &textSearchCandidate{
-				documentID: bytes.Clone(documentID),
-				postings:   make(map[string]textPostingValue),
-				matches:    make(map[string]map[string]struct{}),
-			}
+			candidate = &textSearchCandidate{documentID: keyString}
 			candidates[keyString] = candidate
 		}
-		candidate.postings[term] = posting
-		for _, field := range posting.Fields {
-			terms := candidate.matches[field.Field]
-			if terms == nil {
-				terms = make(map[string]struct{})
-				candidate.matches[field.Field] = terms
-			}
-			terms[term] = struct{}{}
-		}
+		candidate.addPosting(term, posting)
 		it.Next()
 	}
 	if err := it.Error(); err != nil {
@@ -411,18 +472,14 @@ func scanTextSearchPostingsTerm(
 	return false, nil
 }
 
-func scoreTextSearchCandidate(candidate *textSearchCandidate, terms []string, corpus textStatsCorpusValue, termStats map[string]textStatsTermValue, fieldStats map[string]textStatsFieldValue, fieldWeights map[string]float64, state textDocumentStateValue) (float64, error) {
+func scoreTextSearchCandidate(candidate *textSearchCandidate, terms []string, corpus textStatsCorpusValue, termStats map[string]textStatsTermValue, fieldStats map[string]textStatsFieldValue, fieldWeights map[string]float64, fieldLengths []textDocumentFieldLength) (float64, error) {
 	if corpus.DocumentCount == 0 {
 		return 0, errMalformedTextStorage("text-stats corpus document count is zero with search candidates")
-	}
-	fieldLengths := make(map[string]uint32, len(state.Fields))
-	for _, field := range state.Fields {
-		fieldLengths[field.Field] = field.Length
 	}
 	corpusDocuments := float64(corpus.DocumentCount)
 	var score float64
 	for _, term := range terms {
-		posting, ok := candidate.postings[term]
+		posting, ok := candidate.postingForTerm(term)
 		if !ok {
 			continue
 		}
@@ -433,7 +490,8 @@ func scoreTextSearchCandidate(candidate *textSearchCandidate, terms []string, co
 		df := float64(stats.DocumentFrequency)
 		idf := math.Log(1 + (corpusDocuments-df+0.5)/(df+0.5))
 		var combinedTF float64
-		for _, fieldPosting := range posting.Fields {
+		for fieldIdx := 0; fieldIdx < posting.fieldCount(); fieldIdx++ {
+			fieldPosting := posting.fieldAt(fieldIdx)
 			weight, ok := fieldWeights[fieldPosting.Field]
 			if !ok {
 				return 0, errMalformedTextStorage("posting references undeclared text field %q", fieldPosting.Field)
@@ -442,7 +500,7 @@ func scoreTextSearchCandidate(candidate *textSearchCandidate, terms []string, co
 			if statsValue.DocumentCount == 0 || statsValue.TotalTokenCount == 0 {
 				return 0, errMalformedTextStorage("missing text-stats field accounting for %q", fieldPosting.Field)
 			}
-			fieldLength, ok := fieldLengths[fieldPosting.Field]
+			fieldLength, ok := textDocumentFieldLengthByName(fieldLengths, fieldPosting.Field)
 			if !ok {
 				return 0, errMalformedTextStorage("missing text-state field length for %q", fieldPosting.Field)
 			}
@@ -494,31 +552,105 @@ func fetchTextSearchResultDocuments(c *Collection, snap *backenddb.Snapshot, cat
 	return nil
 }
 
+type textSearchMatchPair struct {
+	field string
+	term  string
+}
+
+func textSearchCandidateTextMatches(candidate *textSearchCandidate) []TextSearchMatch {
+	_, _, matches := textSearchCandidateMatchDetails(candidate, false)
+	return matches
+}
+
 func textSearchCandidateMatches(candidate *textSearchCandidate) ([]string, []string, []TextSearchMatch) {
-	fields := make([]string, 0, len(candidate.matches))
-	termSet := make(map[string]struct{})
-	for field, terms := range candidate.matches {
-		fields = append(fields, field)
-		for term := range terms {
-			termSet[term] = struct{}{}
+	return textSearchCandidateMatchDetails(candidate, true)
+}
+
+func textSearchCandidateMatchDetails(candidate *textSearchCandidate, includeLegacyLists bool) ([]string, []string, []TextSearchMatch) {
+	var inline [8]textSearchMatchPair
+	pairs := inline[:0]
+	for postingIdx := 0; postingIdx < candidate.postingCount(); postingIdx++ {
+		entry := candidate.postingAt(postingIdx)
+		for fieldIdx := 0; fieldIdx < entry.posting.fieldCount(); fieldIdx++ {
+			field := entry.posting.fieldAt(fieldIdx)
+			if len(pairs) == cap(pairs) {
+				grown := make([]textSearchMatchPair, len(pairs), len(pairs)*2)
+				copy(grown, pairs)
+				pairs = grown
+			}
+			pairs = append(pairs, textSearchMatchPair{field: field.Field, term: entry.term})
 		}
 	}
-	sort.Strings(fields)
-	matchedTerms := make([]string, 0, len(termSet))
-	for term := range termSet {
-		matchedTerms = append(matchedTerms, term)
+	if len(pairs) == 0 {
+		return nil, nil, nil
 	}
-	sort.Strings(matchedTerms)
-	matches := make([]TextSearchMatch, 0, len(fields))
-	for _, field := range fields {
-		terms := make([]string, 0, len(candidate.matches[field]))
-		for term := range candidate.matches[field] {
-			terms = append(terms, term)
+	sortTextSearchMatchPairs(pairs)
+	unique := pairs[:0]
+	for _, pair := range pairs {
+		if len(unique) > 0 && unique[len(unique)-1] == pair {
+			continue
 		}
-		sort.Strings(terms)
+		unique = append(unique, pair)
+	}
+
+	matches := make([]TextSearchMatch, 0, len(unique))
+	var matchedFields []string
+	var matchedTerms []string
+	if includeLegacyLists {
+		matchedFields = make([]string, 0, len(unique))
+		matchedTerms = make([]string, 0, len(unique))
+	}
+	for i := 0; i < len(unique); {
+		field := unique[i].field
+		j := i + 1
+		for j < len(unique) && unique[j].field == field {
+			j++
+		}
+		terms := make([]string, 0, j-i)
+		for _, pair := range unique[i:j] {
+			terms = append(terms, pair.term)
+			if includeLegacyLists && !textSearchStringSliceContains(matchedTerms, pair.term) {
+				matchedTerms = append(matchedTerms, pair.term)
+			}
+		}
 		matches = append(matches, TextSearchMatch{Field: field, Terms: terms})
+		if includeLegacyLists {
+			matchedFields = append(matchedFields, field)
+		}
+		i = j
 	}
-	return matchedTerms, fields, matches
+	if includeLegacyLists {
+		sort.Strings(matchedTerms)
+	}
+	return matchedTerms, matchedFields, matches
+}
+
+func sortTextSearchMatchPairs(pairs []textSearchMatchPair) {
+	for i := 1; i < len(pairs); i++ {
+		current := pairs[i]
+		j := i - 1
+		for j >= 0 && textSearchMatchPairLess(current, pairs[j]) {
+			pairs[j+1] = pairs[j]
+			j--
+		}
+		pairs[j+1] = current
+	}
+}
+
+func textSearchMatchPairLess(a, b textSearchMatchPair) bool {
+	if a.field != b.field {
+		return a.field < b.field
+	}
+	return a.term < b.term
+}
+
+func textSearchStringSliceContains(values []string, value string) bool {
+	for _, existing := range values {
+		if existing == value {
+			return true
+		}
+	}
+	return false
 }
 
 func textSearchFailClosed(response TextSearchResponse, reason string, err error) (TextSearchResponse, error) {

--- a/TreeDB/collections/text_storage.go
+++ b/TreeDB/collections/text_storage.go
@@ -35,6 +35,36 @@ type textPostingValue struct {
 	Fields        []textPostingFieldValue
 }
 
+type textSearchPostingValue struct {
+	TermFrequency uint32
+	fields        [2]textSearchPostingFieldValue
+	overflow      []textSearchPostingFieldValue
+	fieldsN       int
+}
+
+type textSearchPostingFieldValue struct {
+	Field     string
+	Frequency uint32
+}
+
+func (v *textSearchPostingValue) addField(field textSearchPostingFieldValue) {
+	if v.fieldsN < len(v.fields) {
+		v.fields[v.fieldsN] = field
+	} else {
+		v.overflow = append(v.overflow, field)
+	}
+	v.fieldsN++
+}
+
+func (v textSearchPostingValue) fieldCount() int { return v.fieldsN }
+
+func (v textSearchPostingValue) fieldAt(i int) textSearchPostingFieldValue {
+	if i < len(v.fields) {
+		return v.fields[i]
+	}
+	return v.overflow[i-len(v.fields)]
+}
+
 type textPostingFieldValue struct {
 	Field     string
 	Frequency uint32
@@ -108,11 +138,29 @@ func decodeTextPostingKey(raw []byte) (string, []byte, error) {
 	return string(termBytes), bytes.Clone(cur.buf[cur.pos:]), nil
 }
 
+func decodeTextPostingKeyDocumentIDForPrefix(raw, prefix []byte) ([]byte, error) {
+	if len(raw) == 0 {
+		return nil, errMalformedTextStorage("empty postings key")
+	}
+	if !bytes.HasPrefix(raw, prefix) {
+		return nil, errMalformedTextStorage("postings key outside requested term prefix")
+	}
+	if len(raw) == len(prefix) {
+		return nil, errMalformedTextStorage("postings key missing document id")
+	}
+	return raw[len(prefix):], nil
+}
+
 func encodeTextStateKey(documentID []byte) []byte {
 	out := make([]byte, 0, 1+len(documentID))
 	out = append(out, textStateKeyVersion)
 	out = append(out, documentID...)
 	return out
+}
+
+func appendTextStateKeyString(dst []byte, documentID string) []byte {
+	dst = append(dst, textStateKeyVersion)
+	return append(dst, documentID...)
 }
 
 func decodeTextStateKey(raw []byte) ([]byte, error) {
@@ -253,6 +301,60 @@ func decodeTextPostingValue(raw []byte) (textPostingValue, error) {
 	return value, nil
 }
 
+func decodeTextPostingValueForSearch(raw []byte, fieldNames []string) (textSearchPostingValue, error) {
+	if len(raw) == 0 {
+		return textSearchPostingValue{}, errMalformedTextStorage("empty postings value")
+	}
+	if raw[0] != textPostingValueVersion {
+		return textSearchPostingValue{}, errUnsupportedTextStorageVersion("postings value", raw[0])
+	}
+	cur := textCursor{buf: raw[1:]}
+	freq, err := cur.readUvarint()
+	if err != nil {
+		return textSearchPostingValue{}, errMalformedTextStorage("postings value frequency: %v", err)
+	}
+	fieldCount, err := cur.readUvarint()
+	if err != nil {
+		return textSearchPostingValue{}, errMalformedTextStorage("postings value field count: %v", err)
+	}
+	value := textSearchPostingValue{TermFrequency: checkedTextUint32(freq)}
+	if uint64(value.TermFrequency) != freq {
+		return textSearchPostingValue{}, errMalformedTextStorage("postings value frequency overflows uint32")
+	}
+	if fieldCount > uint64(cur.remaining()+1) {
+		return textSearchPostingValue{}, errMalformedTextStorage("postings value field count too large")
+	}
+	for i := uint64(0); i < fieldCount; i++ {
+		field, err := cur.readStringIntern(fieldNames)
+		if err != nil {
+			return textSearchPostingValue{}, errMalformedTextStorage("postings value field[%d] name: %v", i, err)
+		}
+		fieldFreq, err := cur.readUvarint()
+		if err != nil {
+			return textSearchPostingValue{}, errMalformedTextStorage("postings value field[%d] frequency: %v", i, err)
+		}
+		positions, err := cur.skipUint32Slice()
+		if err != nil {
+			return textSearchPostingValue{}, errMalformedTextStorage("postings value field[%d] positions: %v", i, err)
+		}
+		offsets, err := cur.skipOffsetSlice()
+		if err != nil {
+			return textSearchPostingValue{}, errMalformedTextStorage("postings value field[%d] offsets: %v", i, err)
+		}
+		if uint64(checkedTextUint32(fieldFreq)) != fieldFreq {
+			return textSearchPostingValue{}, errMalformedTextStorage("postings value field[%d] frequency overflows uint32", i)
+		}
+		if offsets != 0 && offsets != positions {
+			return textSearchPostingValue{}, errMalformedTextStorage("postings value field[%d] offsets/positions length mismatch", i)
+		}
+		value.addField(textSearchPostingFieldValue{Field: field, Frequency: uint32(fieldFreq)})
+	}
+	if cur.remaining() != 0 {
+		return textSearchPostingValue{}, errMalformedTextStorage("postings value trailing bytes")
+	}
+	return value, nil
+}
+
 func encodeTextDocumentStateValue(value textDocumentStateValue) []byte {
 	fields := append([]textDocumentFieldState(nil), value.Fields...)
 	sort.SliceStable(fields, func(i, j int) bool { return fields[i].Field < fields[j].Field })
@@ -346,6 +448,90 @@ func decodeTextDocumentStateValue(raw []byte) (textDocumentStateValue, error) {
 		return textDocumentStateValue{}, errMalformedTextStorage("text-state value trailing bytes")
 	}
 	return value, nil
+}
+
+type textDocumentFieldLength struct {
+	Field  string
+	Length uint32
+}
+
+func decodeTextDocumentStateFieldLengths(raw []byte, dst []textDocumentFieldLength, fieldNames []string) ([]textDocumentFieldLength, error) {
+	if len(raw) == 0 {
+		return nil, errMalformedTextStorage("empty text-state value")
+	}
+	if raw[0] != textStateValueVersion {
+		return nil, errUnsupportedTextStorageVersion("text-state value", raw[0])
+	}
+	cur := textCursor{buf: raw[1:]}
+	fieldCount, err := cur.readUvarint()
+	if err != nil {
+		return nil, errMalformedTextStorage("text-state field count: %v", err)
+	}
+	if fieldCount > uint64(cur.remaining()+1) {
+		return nil, errMalformedTextStorage("text-state field count too large")
+	}
+	if uint64(cap(dst)) < fieldCount {
+		dst = make([]textDocumentFieldLength, 0, fieldCount)
+	} else {
+		dst = dst[:0]
+	}
+	for i := uint64(0); i < fieldCount; i++ {
+		fieldName, err := cur.readStringIntern(fieldNames)
+		if err != nil {
+			return nil, errMalformedTextStorage("text-state field[%d] name: %v", i, err)
+		}
+		length, err := cur.readUvarint()
+		if err != nil {
+			return nil, errMalformedTextStorage("text-state field[%d] length: %v", i, err)
+		}
+		if uint64(checkedTextUint32(length)) != length {
+			return nil, errMalformedTextStorage("text-state field[%d] length overflows uint32", i)
+		}
+		termCount, err := cur.readUvarint()
+		if err != nil {
+			return nil, errMalformedTextStorage("text-state field[%d] term count: %v", i, err)
+		}
+		if termCount > uint64(cur.remaining()+1) {
+			return nil, errMalformedTextStorage("text-state field[%d] term count too large", i)
+		}
+		dst = append(dst, textDocumentFieldLength{Field: fieldName, Length: uint32(length)})
+		for j := uint64(0); j < termCount; j++ {
+			if _, err := cur.readBytes(); err != nil {
+				return nil, errMalformedTextStorage("text-state field[%d] term[%d] name: %v", i, j, err)
+			}
+			freq, err := cur.readUvarint()
+			if err != nil {
+				return nil, errMalformedTextStorage("text-state field[%d] term[%d] frequency: %v", i, j, err)
+			}
+			if uint64(checkedTextUint32(freq)) != freq {
+				return nil, errMalformedTextStorage("text-state field[%d] term[%d] frequency overflows uint32", i, j)
+			}
+			positions, err := cur.skipUint32Slice()
+			if err != nil {
+				return nil, errMalformedTextStorage("text-state field[%d] term[%d] positions: %v", i, j, err)
+			}
+			offsets, err := cur.skipOffsetSlice()
+			if err != nil {
+				return nil, errMalformedTextStorage("text-state field[%d] term[%d] offsets: %v", i, j, err)
+			}
+			if offsets != 0 && offsets != positions {
+				return nil, errMalformedTextStorage("text-state field[%d] term[%d] offsets/positions length mismatch", i, j)
+			}
+		}
+	}
+	if cur.remaining() != 0 {
+		return nil, errMalformedTextStorage("text-state value trailing bytes")
+	}
+	return dst, nil
+}
+
+func textDocumentFieldLengthByName(fields []textDocumentFieldLength, name string) (uint32, bool) {
+	for _, field := range fields {
+		if field.Field == name {
+			return field.Length, true
+		}
+	}
+	return 0, false
 }
 
 func encodeTextStatsCorpusValue(value textStatsCorpusValue) []byte {
@@ -511,6 +697,31 @@ func (c *textCursor) readString() (string, error) {
 	return string(value), nil
 }
 
+func (c *textCursor) readStringIntern(interns []string) (string, error) {
+	value, err := c.readBytes()
+	if err != nil {
+		return "", err
+	}
+	for _, intern := range interns {
+		if textBytesEqualString(value, intern) {
+			return intern, nil
+		}
+	}
+	return string(value), nil
+}
+
+func textBytesEqualString(value []byte, intern string) bool {
+	if len(value) != len(intern) {
+		return false
+	}
+	for i, b := range value {
+		if intern[i] != b {
+			return false
+		}
+	}
+	return true
+}
+
 func (c *textCursor) readUint32Slice() ([]uint32, error) {
 	count, err := c.readUvarint()
 	if err != nil {
@@ -531,6 +742,26 @@ func (c *textCursor) readUint32Slice() ([]uint32, error) {
 		out = append(out, uint32(value))
 	}
 	return out, nil
+}
+
+func (c *textCursor) skipUint32Slice() (uint64, error) {
+	count, err := c.readUvarint()
+	if err != nil {
+		return 0, err
+	}
+	if count > uint64(c.remaining()+1) {
+		return 0, errors.New("count too large")
+	}
+	for i := uint64(0); i < count; i++ {
+		value, err := c.readUvarint()
+		if err != nil {
+			return 0, err
+		}
+		if uint64(checkedTextUint32(value)) != value {
+			return 0, errors.New("uint32 overflow")
+		}
+	}
+	return count, nil
 }
 
 func (c *textCursor) readOffsetSlice() ([]textTokenOffset, error) {
@@ -560,6 +791,33 @@ func (c *textCursor) readOffsetSlice() ([]textTokenOffset, error) {
 		out = append(out, textTokenOffset{Start: uint32(start), End: uint32(end)})
 	}
 	return out, nil
+}
+
+func (c *textCursor) skipOffsetSlice() (uint64, error) {
+	count, err := c.readUvarint()
+	if err != nil {
+		return 0, err
+	}
+	if count > uint64(c.remaining()+1) {
+		return 0, errors.New("count too large")
+	}
+	for i := uint64(0); i < count; i++ {
+		start, err := c.readUvarint()
+		if err != nil {
+			return 0, err
+		}
+		end, err := c.readUvarint()
+		if err != nil {
+			return 0, err
+		}
+		if uint64(checkedTextUint32(start)) != start || uint64(checkedTextUint32(end)) != end {
+			return 0, errors.New("uint32 overflow")
+		}
+		if end < start {
+			return 0, errors.New("offset end before start")
+		}
+	}
+	return count, nil
 }
 
 func checkedTextUint32(value uint64) uint32 {

--- a/TreeDB/collections/text_storage_test.go
+++ b/TreeDB/collections/text_storage_test.go
@@ -34,12 +34,24 @@ func TestTextStorageCodecsRoundTripAndFailClosed(t *testing.T) {
 			Offsets:   []textTokenOffset{{Start: 0, End: 6}, {Start: 14, End: 20}, {Start: 30, End: 36}},
 		}},
 	}
-	decodedPosting, err := decodeTextPostingValue(encodeTextPostingValue(posting))
+	encodedPosting := encodeTextPostingValue(posting)
+	decodedPosting, err := decodeTextPostingValue(encodedPosting)
 	if err != nil {
 		t.Fatalf("decode postings value: %v", err)
 	}
 	if decodedPosting.TermFrequency != 3 || len(decodedPosting.Fields) != 1 || decodedPosting.Fields[0].Field != "body" || !slices.Equal(decodedPosting.Fields[0].Positions, []uint32{0, 2, 5}) {
 		t.Fatalf("decoded postings=%+v", decodedPosting)
+	}
+	searchPosting, err := decodeTextPostingValueForSearch(encodedPosting, []string{"body"})
+	if err != nil {
+		t.Fatalf("decode search postings value: %v", err)
+	}
+	if searchPosting.TermFrequency != decodedPosting.TermFrequency || searchPosting.fieldCount() != len(decodedPosting.Fields) {
+		t.Fatalf("search posting=%+v decoded=%+v", searchPosting, decodedPosting)
+	}
+	searchField := searchPosting.fieldAt(0)
+	if searchField.Field != decodedPosting.Fields[0].Field || searchField.Frequency != decodedPosting.Fields[0].Frequency {
+		t.Fatalf("search field=%+v decoded=%+v", searchField, decodedPosting.Fields[0])
 	}
 
 	state := textDocumentStateValue{Fields: []textDocumentFieldState{{
@@ -52,12 +64,43 @@ func TestTextStorageCodecsRoundTripAndFailClosed(t *testing.T) {
 			Offsets:   []textTokenOffset{{Start: 0, End: 6}, {Start: 21, End: 27}},
 		}},
 	}}}
-	decodedState, err := decodeTextDocumentStateValue(encodeTextDocumentStateValue(state))
+	encodedState := encodeTextDocumentStateValue(state)
+	decodedState, err := decodeTextDocumentStateValue(encodedState)
 	if err != nil {
 		t.Fatalf("decode text-state value: %v", err)
 	}
 	if len(decodedState.Fields) != 1 || decodedState.Fields[0].Terms[0].Term != "refund" || decodedState.Fields[0].Terms[0].Frequency != 2 {
 		t.Fatalf("decoded state=%+v", decodedState)
+	}
+	fieldLengths, err := decodeTextDocumentStateFieldLengths(encodedState, nil, []string{"body"})
+	if err != nil {
+		t.Fatalf("decode search text-state field lengths: %v", err)
+	}
+	if len(fieldLengths) != len(decodedState.Fields) || fieldLengths[0].Field != decodedState.Fields[0].Field || fieldLengths[0].Length != decodedState.Fields[0].Length {
+		t.Fatalf("field lengths=%+v decoded=%+v", fieldLengths, decodedState.Fields)
+	}
+
+	malformedPosting := textPostingValue{TermFrequency: 1, Fields: []textPostingFieldValue{{
+		Field:     "body",
+		Frequency: 1,
+		Positions: []uint32{1, 2},
+		Offsets:   []textTokenOffset{{Start: 0, End: 1}},
+	}}}
+	if _, err := decodeTextPostingValueForSearch(encodeTextPostingValue(malformedPosting), []string{"body"}); !errors.Is(err, ErrTextIndexStorageCorrupt) {
+		t.Fatalf("decode malformed search posting err=%v want ErrTextIndexStorageCorrupt", err)
+	}
+	malformedState := textDocumentStateValue{Fields: []textDocumentFieldState{{
+		Field:  "body",
+		Length: 2,
+		Terms: []textDocumentTermState{{
+			Term:      "refund",
+			Frequency: 1,
+			Positions: []uint32{1, 2},
+			Offsets:   []textTokenOffset{{Start: 0, End: 1}},
+		}},
+	}}}
+	if _, err := decodeTextDocumentStateFieldLengths(encodeTextDocumentStateValue(malformedState), nil, []string{"body"}); !errors.Is(err, ErrTextIndexStorageCorrupt) {
+		t.Fatalf("decode malformed search state err=%v want ErrTextIndexStorageCorrupt", err)
 	}
 
 	for _, tc := range []struct {


### PR DESCRIPTION
## Objective

Reduce TreeDB indexed text-candidate and hybrid-search allocation cost without changing retrieval semantics.

Refs #2589 (first focused PR: text/hybrid search path; insert/readiness follow-up remains). 

## Context

Baseline #2564 allocation rows were dominated by SearchText/SearchHybridTextCandidates materializing full text-state/posting structures and cloning candidate/match payloads on the candidate-only path.

## Non-goals

- No gateway syntax/analyzer/vector codec/reranking feature work.
- No change to candidate budgets, BM25/BM25F/vector score semantics, scalar filtering, or final fetch bounds.
- Indexed insert/readiness remains essentially unchanged in this PR and should be handled in a follow-up chunk.

## Design

- Add search-only text posting/text-state decoders that:
  - skip positions/offset payload allocation while still validating malformed counts and offset/position parity;
  - decode only text-state field lengths needed for BM25F scoring;
  - intern declared text field names to avoid per-posting/per-state string allocations.
- Replace per-candidate posting/match maps with small inline candidate/posting storage and deterministic compact match materialization.
- Use an internal SearchText result mode for hybrid candidate generation so it emits only the text match details needed by hybrid candidates.
- Reuse response-owned SearchText IDs/match term slices when adapting to HybridSearchCandidate, with cap isolation, instead of cloning already-owned candidate-only payloads.

Invariants preserved:

- Candidate generation still requests `IncludeDocuments=false` and fetches zero full documents.
- Final hybrid document fetch remains a separate top-k-bounded phase.
- Ranked text ordering remains score-descending then document-ID ascending.
- Text match attribution remains deterministic by field/term order.
- Fast decoders fail closed on malformed storage.

## Correctness

Tests run:

- `git diff --check`
- `GOWORK=off go test ./TreeDB/collections -count=1`
- Focused during development: `GOWORK=off go test ./TreeDB/collections -run 'TestTextStorageCodecsRoundTripAndFailClosed|TestSearchText|TestSearchHybridTextCandidates|TestIndexInsertSearchFixtureGuardrails2564|TestHybrid' -count=1`

Added coverage:

- Fast text posting decoder parity for term frequency/field frequency.
- Fast text-state field-length decoder parity.
- Fast decoder malformed offset/position parity fail-closed checks.

## Performance

Command:

```sh
GOWORK=off go test ./TreeDB/collections -run '^$' -bench '^BenchmarkIndexInsertSearch2564$' -benchmem -benchtime=5x -count=3
```

Artifacts:

- Baseline root: `/tmp/gomap_2589_alloc_baseline_20260610_143627`
- Final root: `/tmp/gomap_2589_alloc_final_search_20260610_145651`
- Summary: `/tmp/gomap_2589_alloc_final_search_20260610_145651/bench_before_after_summary.md`
- Allocation profiles/tops: `text_candidates.*`, `hybrid_no_docs.*`, `hybrid_fetch.*`, `insert_readiness.*` under final root.

Median-of-3 summary:

| row | before ns/op | after ns/op | before ops/s | after ops/s | before B/op | after B/op | before allocs/op | after allocs/op | Δ B/op | Δ allocs/op |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| indexed_insert_batch_flush_vector_rebuild | 78,394,592 | 68,614,933 | 12.8 | 14.6 | 11,001,843 | 11,030,268 | 113,175 | 113,177 | +0.3% | +0.0% |
| search_text_candidates_no_docs | 261,975 | 126,183 | 3,817.2 | 7,925.0 | 425,584 | 109,289 | 7,591 | 878 | -74.3% | -88.4% |
| search_vector_candidates_no_docs | 17,867 | 16,825 | 55,969.1 | 59,435.4 | 36,408 | 36,408 | 82 | 82 | +0.0% | +0.0% |
| search_hybrid_no_docs_scalar_filter | 273,908 | 155,075 | 3,650.9 | 6,448.5 | 514,720 | 198,425 | 7,791 | 1,078 | -61.4% | -86.2% |
| search_hybrid_fetch_topk_scalar_filter | 506,542 | 369,683 | 1,974.2 | 2,705.0 | 572,529 | 256,232 | 8,768 | 2,055 | -55.2% | -76.6% |

Counters stayed stable for the search rows: candidate counts, postings scanned, docs fetched/fallbacks, scalar/fusion counters, and vector candidate metrics are unchanged. Vector candidates do not regress in B/op or allocs/op.

## Caveats / follow-ups

- Insert/readiness allocations are not materially improved in this PR; this should be the next #2589 chunk.
- No on-disk format changes.
- AI reviews requested after PR maturity/CI start: Codex, Copilot, and CodeRabbit. Latest-head CI is running/pending at PR open time.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal text search processing to improve search performance and resource efficiency.
* **Tests**
  * Expanded test coverage for text storage codecs and search operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->