### PR TITLE
TreeDB: add prepared HNSW traversal score plane seam

### DIFF
--- a/TreeDB/collections/column_hnsw_prepared_traversal.go
+++ b/TreeDB/collections/column_hnsw_prepared_traversal.go
@@ -1,0 +1,412 @@
+package collections
+
+import (
+	"errors"
+	"fmt"
+	"math"
+)
+
+var errColumnHNSWPreparedTraversalScorePlaneUnavailable = errors.New("collections: hnsw prepared traversal score plane unavailable")
+
+type columnHNSWPreparedTraversalScorePlaneKind uint8
+
+const (
+	columnHNSWPreparedTraversalScorePlaneKindExactFP32 columnHNSWPreparedTraversalScorePlaneKind = iota + 1
+	columnHNSWPreparedTraversalScorePlaneKindQuantized
+)
+
+func (k columnHNSWPreparedTraversalScorePlaneKind) String() string {
+	switch k {
+	case columnHNSWPreparedTraversalScorePlaneKindExactFP32:
+		return "exact_fp32"
+	case columnHNSWPreparedTraversalScorePlaneKindQuantized:
+		return "quantized"
+	default:
+		return "unknown"
+	}
+}
+
+type columnHNSWPreparedTraversalOptions struct {
+	TopK     int
+	EfSearch int
+
+	// RetainedCandidateLimit optionally asks traversal to retain more score-plane
+	// candidates than the final TopK. Zero uses normalized ef_search. This keeps
+	// the seam usable by future quantized_rerank callers without adding rerank
+	// semantics to the traversal itself.
+	RetainedCandidateLimit int
+
+	ScoreBatchMode columnVectorGraphScoreBatchMode
+	StatsMode      columnVectorGraphNativeSearchStatsMode
+
+	// OmitResultMaterialization returns ordinal/score candidates without reading
+	// result IDs or row refs from the pack. Future quantized rerank callers can use
+	// this to collect an explicit score-plane shortlist before exact reranking.
+	OmitResultMaterialization bool
+}
+
+// columnHNSWPreparedTraversalScorePlane is the explicit scoring seam for the
+// pack-style HNSW traversal. Implementations are per-query/per-scratch objects:
+// exact FP32 owns a normalized-query scratch slice, and quantized score planes
+// own codec-prepared query state. Immutable pack adjacency/result identity stays
+// in columnHNSWSearchPackPreparedView and is not reinterpreted as quantized
+// storage.
+type columnHNSWPreparedTraversalScorePlane interface {
+	kind() columnHNSWPreparedTraversalScorePlaneKind
+	prepareForHNSWPreparedTraversal(pack *columnHNSWSearchPackPreparedView, query []float32, opts columnHNSWPreparedTraversalOptions, scratch *columnVectorGraphNativeSearchScratch) error
+	scoreOrdinal(ordinal int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) (float64, error)
+	scoreOrdinals(ordinals []int, dst []float64, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) ([]float64, error)
+}
+
+type columnHNSWPreparedExactFP32ScorePlane struct {
+	pack            *columnHNSWSearchPackPreparedView
+	normalizedQuery []float32
+	scoreBatchMode  columnVectorGraphScoreBatchMode
+}
+
+func (p *columnHNSWPreparedExactFP32ScorePlane) kind() columnHNSWPreparedTraversalScorePlaneKind {
+	return columnHNSWPreparedTraversalScorePlaneKindExactFP32
+}
+
+func (p *columnHNSWPreparedExactFP32ScorePlane) prepareForHNSWPreparedTraversal(pack *columnHNSWSearchPackPreparedView, query []float32, opts columnHNSWPreparedTraversalOptions, scratch *columnVectorGraphNativeSearchScratch) error {
+	if p == nil || pack == nil || scratch == nil {
+		return errColumnHNSWPreparedTraversalScorePlaneUnavailable
+	}
+	queryInvNorm, err := columnVectorGraphInvNorm(query)
+	if err != nil {
+		return fmt.Errorf("collections: hnsw_search_pack_v1 prepared traversal exact query norm: %w: %w", errColumnVectorGraphNativeSearchQueryNormInvalid, err)
+	}
+	if cap(scratch.scoreScratch.Float32Values) < pack.Header.VectorStride {
+		scratch.scoreScratch.Float32Values = ensureColumnVectorGraphNativeFloat32Scratch(scratch.scoreScratch.Float32Values, pack.Header.VectorStride)
+	}
+	normalizedQuery := scratch.scoreScratch.Float32Values[:pack.Header.VectorStride]
+	for i := 0; i < pack.Header.Dimensions; i++ {
+		normalizedQuery[i] = query[i] * queryInvNorm
+	}
+	if pack.Header.VectorStride > pack.Header.Dimensions {
+		clear(normalizedQuery[pack.Header.Dimensions:])
+	}
+	p.pack = pack
+	p.normalizedQuery = normalizedQuery
+	p.scoreBatchMode = opts.ScoreBatchMode
+	return nil
+}
+
+func (p *columnHNSWPreparedExactFP32ScorePlane) scoreOrdinal(ordinal int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) (float64, error) {
+	if p == nil || p.pack == nil || len(p.normalizedQuery) < p.pack.Header.VectorStride {
+		return 0, errColumnHNSWPreparedTraversalScorePlaneUnavailable
+	}
+	return p.pack.scoreOrdinal(p.normalizedQuery, ordinal, p.scoreBatchMode, scratch, stats)
+}
+
+func (p *columnHNSWPreparedExactFP32ScorePlane) scoreOrdinals(ordinals []int, dst []float64, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) ([]float64, error) {
+	if p == nil || p.pack == nil || len(p.normalizedQuery) < p.pack.Header.VectorStride {
+		return dst[:0], errColumnHNSWPreparedTraversalScorePlaneUnavailable
+	}
+	if scratch == nil {
+		return dst[:0], errColumnVectorGraphNativeSearchScratchRequired
+	}
+	if cap(dst) < len(ordinals) {
+		dst = make([]float64, len(ordinals))
+	} else {
+		dst = dst[:len(ordinals)]
+	}
+	if len(ordinals) == 0 {
+		return dst, nil
+	}
+	scratch.scoreTileRowIDs = ensureColumnVectorGraphNativeUint32Scratch(scratch.scoreTileRowIDs, len(ordinals))
+	rowIDs := scratch.scoreTileRowIDs[:len(ordinals)]
+	for i, ordinal := range ordinals {
+		if ordinal < 0 || ordinal >= p.pack.Header.Rows || uint64(ordinal) > uint64(^uint32(0)) {
+			return dst[:i], fmt.Errorf("collections: hnsw_search_pack_v1 prepared traversal exact ordinal=%d outside row_count=%d", ordinal, p.pack.Header.Rows)
+		}
+		rowIDs[i] = uint32(ordinal)
+	}
+	return p.pack.scoreRowIDs(p.normalizedQuery, rowIDs, dst, p.scoreBatchMode, scratch, stats)
+}
+
+type columnHNSWPreparedQuantizedScorePlane struct {
+	scorer *columnVectorGraphQuantizedScorer
+}
+
+func (p *columnHNSWPreparedQuantizedScorePlane) kind() columnHNSWPreparedTraversalScorePlaneKind {
+	return columnHNSWPreparedTraversalScorePlaneKindQuantized
+}
+
+func (p *columnHNSWPreparedQuantizedScorePlane) prepareForHNSWPreparedTraversal(pack *columnHNSWSearchPackPreparedView, query []float32, opts columnHNSWPreparedTraversalOptions, scratch *columnVectorGraphNativeSearchScratch) error {
+	_ = pack
+	_ = query
+	_ = opts
+	_ = scratch
+	if p == nil || p.scorer == nil || p.scorer.kind == columnVectorGraphQuantizedScorerKindNone {
+		return errColumnHNSWPreparedTraversalScorePlaneUnavailable
+	}
+	return nil
+}
+
+func (p *columnHNSWPreparedQuantizedScorePlane) scoreOrdinal(ordinal int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) (float64, error) {
+	if p == nil || p.scorer == nil {
+		return 0, errColumnHNSWPreparedTraversalScorePlaneUnavailable
+	}
+	return p.scorer.scoreOrdinal(ordinal, scratch, stats)
+}
+
+func (p *columnHNSWPreparedQuantizedScorePlane) scoreOrdinals(ordinals []int, dst []float64, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) ([]float64, error) {
+	if p == nil || p.scorer == nil {
+		return dst[:0], errColumnHNSWPreparedTraversalScorePlaneUnavailable
+	}
+	return p.scorer.scoreOrdinals(ordinals, dst, scratch, stats)
+}
+
+func (v *columnHNSWSearchPackPreparedView) searchCosinePreparedScorePlane(query []float32, opts columnHNSWPreparedTraversalOptions, scratch *columnVectorGraphNativeSearchScratch, scorePlane columnHNSWPreparedTraversalScorePlane) ([]columnVectorGraphNativeSearchResult, columnVectorGraphNativeSearchStats, error) {
+	var stats columnVectorGraphNativeSearchStats
+	if v == nil {
+		return nil, stats, errColumnHNSWSearchPackSearchUnavailable
+	}
+	switch status := v.fastStatus(""); status {
+	case columnHNSWSearchPackPreparedStatusDirect, columnHNSWSearchPackPreparedStatusHeap:
+	default:
+		return nil, stats, columnHNSWSearchPackStatusError(status)
+	}
+	if scratch == nil {
+		return nil, stats, errColumnVectorGraphNativeSearchScratchRequired
+	}
+	if scorePlane == nil {
+		return nil, stats, errColumnHNSWPreparedTraversalScorePlaneUnavailable
+	}
+	if len(query) != v.Header.Dimensions {
+		return nil, stats, fmt.Errorf("collections: hnsw_search_pack_v1 prepared traversal query dims=%d want %d: %w", len(query), v.Header.Dimensions, errColumnVectorGraphNativeSearchQueryDimensionMismatch)
+	}
+	statsMode := opts.StatsMode.normalized()
+	if !columnHNSWSearchPackStatsModeSupportedForSearch(statsMode) {
+		return nil, stats, errColumnHNSWSearchPackSearchUnsupportedMode
+	}
+	rowCount := v.Header.Rows
+	topK := opts.TopK
+	if topK < 0 {
+		return nil, stats, errColumnVectorGraphNativeSearchTopKNegative
+	}
+	efSearch := opts.EfSearch
+	if efSearch < 0 {
+		return nil, stats, errColumnVectorGraphNativeSearchEfSearchNegative
+	}
+	retainedCandidateLimit := opts.RetainedCandidateLimit
+	if retainedCandidateLimit < 0 {
+		return nil, stats, fmt.Errorf("collections: hnsw_search_pack_v1 prepared traversal retained candidates=%d cannot be negative", retainedCandidateLimit)
+	}
+	if topK == 0 || rowCount == 0 {
+		return nil, stats, nil
+	}
+	stats.CandidateRows = uint64(rowCount)
+	if topK > rowCount {
+		topK = rowCount
+	}
+	if efSearch == 0 {
+		efSearch = v.Header.EfSearch
+	}
+	if efSearch < topK {
+		efSearch = topK
+	}
+	if efSearch > rowCount {
+		efSearch = rowCount
+	}
+	if retainedCandidateLimit == 0 {
+		retainedCandidateLimit = efSearch
+	}
+	if retainedCandidateLimit < topK {
+		return nil, stats, fmt.Errorf("collections: hnsw_search_pack_v1 prepared traversal retained candidates=%d below normalized top_k=%d", retainedCandidateLimit, topK)
+	}
+	if retainedCandidateLimit > rowCount {
+		retainedCandidateLimit = rowCount
+	}
+	degree := v.Header.M
+	if degree < 1 {
+		degree = 1
+	}
+	if degree <= math.MaxInt/2 {
+		degree *= 2
+	}
+	if err := scratch.prepareHNSWSearchPack(rowCount, v.Header.VectorStride, degree, topK, retainedCandidateLimit); err != nil {
+		return nil, stats, fmt.Errorf("collections: hnsw_search_pack_v1 prepared traversal scratch prepare: %w", err)
+	}
+	if err := scorePlane.prepareForHNSWPreparedTraversal(v, query, opts, scratch); err != nil {
+		return nil, stats, fmt.Errorf("collections: hnsw_search_pack_v1 prepared traversal %s score plane: %w", scorePlane.kind(), err)
+	}
+	countLoopEdges := !statsMode.minimal()
+	var loopEdgeVisits uint64
+	var visitedCandidates uint64
+	entryOrdinal := v.Header.EntryOrdinal
+	if entryOrdinal < 0 || entryOrdinal >= rowCount {
+		return nil, stats, fmt.Errorf("collections: hnsw_search_pack_v1 prepared traversal entry ordinal=%d outside rows=%d", entryOrdinal, rowCount)
+	}
+	maxLayer, err := v.maxLayerForOrdinal(entryOrdinal)
+	if err != nil {
+		return nil, stats, err
+	}
+	for layer := maxLayer; layer > 0; layer-- {
+		entryOrdinal, err = v.greedyNearestAtLayerPreparedScorePlane(scorePlane, entryOrdinal, layer, scratch, &stats, countLoopEdges, &loopEdgeVisits)
+		if err != nil {
+			return nil, stats, err
+		}
+	}
+	visitMarks := scratch.visitMarks
+	visitEpoch := scratch.visitEpoch
+	visitMarks[entryOrdinal] = visitEpoch
+	if err := v.scoreAndPushFrontierVisitedPreparedScorePlane(scorePlane, entryOrdinal, retainedCandidateLimit, scratch, &stats, &visitedCandidates); err != nil {
+		return nil, stats, err
+	}
+	nextSeed := 0
+	rowCount64 := uint64(rowCount)
+	for {
+		candidate, ok := scratch.popFrontier()
+		if !ok {
+			if len(scratch.top) >= retainedCandidateLimit {
+				break
+			}
+			seed, seedOK := columnHNSWSearchPackNextCandidateSeed(nextSeed, rowCount, visitMarks, visitEpoch)
+			if !seedOK {
+				break
+			}
+			nextSeed = seed + 1
+			visitMarks[seed] = visitEpoch
+			if err := v.scoreAndPushFrontierVisitedPreparedScorePlane(scorePlane, seed, retainedCandidateLimit, scratch, &stats, &visitedCandidates); err != nil {
+				return nil, stats, err
+			}
+			continue
+		}
+		if columnVectorGraphLayer0SearchShouldStop(candidate, scratch.top, retainedCandidateLimit) {
+			break
+		}
+		adjacency, err := v.adjacencyLayerForOrdinal(candidate.ordinal, 0, &stats)
+		if err != nil {
+			return nil, stats, err
+		}
+		if len(adjacency) == 0 {
+			continue
+		}
+		scratch.scoreTileOrdinals = ensureColumnVectorGraphNativeIntScratch(scratch.scoreTileOrdinals, len(adjacency))
+		tile := scratch.scoreTileOrdinals[:0]
+		for i, neighbor := range adjacency {
+			if countLoopEdges {
+				loopEdgeVisits++
+			}
+			if uint64(neighbor) >= rowCount64 {
+				return nil, stats, fmt.Errorf("collections: hnsw_search_pack_v1 prepared traversal ordinal=%d adjacency[%d]=%d outside row_count=%d: %w", candidate.ordinal, i, neighbor, rowCount, errColumnVectorGraphAdjacencyOrdinalOutOfBounds)
+			}
+			neighborOrdinal := int(neighbor)
+			if visitMarks[neighborOrdinal] == visitEpoch {
+				continue
+			}
+			visitMarks[neighborOrdinal] = visitEpoch
+			tile = append(tile, neighborOrdinal)
+		}
+		if len(tile) != 0 {
+			if err := v.scoreAndPushFrontierVisitedTilePreparedScorePlane(scorePlane, tile, retainedCandidateLimit, scratch, &stats, &visitedCandidates); err != nil {
+				return nil, stats, err
+			}
+		}
+	}
+	if countLoopEdges {
+		stats.Edges = loopEdgeVisits
+		stats.VisitedEdges = loopEdgeVisits
+		stats.Candidates = visitedCandidates
+	}
+	if len(scratch.top) == 0 {
+		return scratch.results, stats, nil
+	}
+	if len(scratch.top) > topK {
+		scratch.top = scratch.top[:topK]
+	}
+	if opts.OmitResultMaterialization {
+		for _, candidate := range scratch.top {
+			scratch.results = append(scratch.results, columnVectorGraphNativeSearchResult{Ordinal: candidate.ordinal, Score: candidate.score})
+		}
+		return scratch.results, stats, nil
+	}
+	if err := v.fetchTopSearchResults(scratch, &stats); err != nil {
+		return nil, stats, err
+	}
+	return scratch.results, stats, nil
+}
+
+func (v *columnHNSWSearchPackPreparedView) greedyNearestAtLayerPreparedScorePlane(scorePlane columnHNSWPreparedTraversalScorePlane, entryOrdinal int, layer int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats, countLoopEdges bool, loopEdgeVisits *uint64) (int, error) {
+	best := entryOrdinal
+	bestScore, err := scorePlane.scoreOrdinal(best, scratch, stats)
+	if err != nil {
+		return 0, err
+	}
+	changed := true
+	for changed {
+		changed = false
+		adjacency, err := v.adjacencyLayerForOrdinal(best, layer, stats)
+		if err != nil {
+			return 0, err
+		}
+		if len(adjacency) == 0 {
+			continue
+		}
+		scratch.scoreTileOrdinals = ensureColumnVectorGraphNativeIntScratch(scratch.scoreTileOrdinals, len(adjacency))
+		tile := scratch.scoreTileOrdinals[:0]
+		for i, neighbor := range adjacency {
+			if countLoopEdges && loopEdgeVisits != nil {
+				(*loopEdgeVisits)++
+			}
+			if uint64(neighbor) >= uint64(v.Header.Rows) {
+				return 0, fmt.Errorf("collections: hnsw_search_pack_v1 prepared traversal ordinal=%d layer=%d adjacency[%d]=%d outside row_count=%d: %w", best, layer, i, neighbor, v.Header.Rows, errColumnVectorGraphAdjacencyOrdinalOutOfBounds)
+			}
+			tile = append(tile, int(neighbor))
+		}
+		scratch.scoreTileScores = ensureColumnVectorGraphNativeFloat64Scratch(scratch.scoreTileScores, len(tile))
+		scores, err := scorePlane.scoreOrdinals(tile, scratch.scoreTileScores, scratch, stats)
+		if err != nil {
+			return 0, err
+		}
+		for i, neighborOrdinal := range tile {
+			score := scores[i]
+			if score > bestScore || (score == bestScore && neighborOrdinal < best) {
+				best = neighborOrdinal
+				bestScore = score
+				changed = true
+			}
+		}
+	}
+	return best, nil
+}
+
+func (v *columnHNSWSearchPackPreparedView) scoreAndPushFrontierVisitedPreparedScorePlane(scorePlane columnHNSWPreparedTraversalScorePlane, ordinal, topK int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats, visitedCandidates *uint64) error {
+	_ = v
+	score, err := scorePlane.scoreOrdinal(ordinal, scratch, stats)
+	if err != nil {
+		return err
+	}
+	if visitedCandidates != nil {
+		(*visitedCandidates)++
+	}
+	candidate := columnVectorGraphSearchCandidate{ordinal: ordinal, score: score}
+	if scratch.insertTop(topK, candidate) {
+		scratch.pushFrontier(candidate)
+	}
+	return nil
+}
+
+func (v *columnHNSWSearchPackPreparedView) scoreAndPushFrontierVisitedTilePreparedScorePlane(scorePlane columnHNSWPreparedTraversalScorePlane, ordinals []int, topK int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats, visitedCandidates *uint64) error {
+	_ = v
+	if len(ordinals) == 0 {
+		return nil
+	}
+	scratch.scoreTileScores = ensureColumnVectorGraphNativeFloat64Scratch(scratch.scoreTileScores, len(ordinals))
+	scores, err := scorePlane.scoreOrdinals(ordinals, scratch.scoreTileScores, scratch, stats)
+	if err != nil {
+		return err
+	}
+	if visitedCandidates != nil {
+		*visitedCandidates += uint64(len(ordinals))
+	}
+	for i, ordinal := range ordinals {
+		candidate := columnVectorGraphSearchCandidate{ordinal: ordinal, score: scores[i]}
+		if scratch.insertTop(topK, candidate) {
+			scratch.pushFrontier(candidate)
+		}
+	}
+	return nil
+}

--- a/TreeDB/collections/column_hnsw_prepared_traversal.go
+++ b/TreeDB/collections/column_hnsw_prepared_traversal.go
@@ -314,14 +314,17 @@ func (v *columnHNSWSearchPackPreparedView) searchCosinePreparedScorePlane(query 
 	if len(scratch.top) == 0 {
 		return scratch.results, stats, nil
 	}
-	if len(scratch.top) > topK {
-		scratch.top = scratch.top[:topK]
-	}
 	if opts.OmitResultMaterialization {
+		if len(scratch.top) > retainedCandidateLimit {
+			scratch.top = scratch.top[:retainedCandidateLimit]
+		}
 		for _, candidate := range scratch.top {
 			scratch.results = append(scratch.results, columnVectorGraphNativeSearchResult{Ordinal: candidate.ordinal, Score: candidate.score})
 		}
 		return scratch.results, stats, nil
+	}
+	if len(scratch.top) > topK {
+		scratch.top = scratch.top[:topK]
 	}
 	if err := v.fetchTopSearchResults(scratch, &stats); err != nil {
 		return nil, stats, err

--- a/TreeDB/collections/column_hnsw_prepared_traversal.go
+++ b/TreeDB/collections/column_hnsw_prepared_traversal.go
@@ -79,6 +79,10 @@ func (p *columnHNSWPreparedExactFP32ScorePlane) prepareForHNSWPreparedTraversal(
 	if cap(scratch.scoreScratch.Float32Values) < pack.Header.VectorStride {
 		scratch.scoreScratch.Float32Values = ensureColumnVectorGraphNativeFloat32Scratch(scratch.scoreScratch.Float32Values, pack.Header.VectorStride)
 	}
+	// The exact score plane intentionally borrows scoreScratch.Float32Values
+	// for the normalized query. Pack scoring methods must treat this slice as
+	// read-only while the plane is active and use scoreTile* fields for staging;
+	// allocating a per-query copy would violate the zero-allocation seam contract.
 	normalizedQuery := scratch.scoreScratch.Float32Values[:pack.Header.VectorStride]
 	for i := 0; i < pack.Header.Dimensions; i++ {
 		normalizedQuery[i] = query[i] * queryInvNorm
@@ -117,7 +121,7 @@ func (p *columnHNSWPreparedExactFP32ScorePlane) scoreOrdinals(ordinals []int, ds
 	scratch.scoreTileRowIDs = ensureColumnVectorGraphNativeUint32Scratch(scratch.scoreTileRowIDs, len(ordinals))
 	rowIDs := scratch.scoreTileRowIDs[:len(ordinals)]
 	for i, ordinal := range ordinals {
-		if ordinal < 0 || ordinal >= p.pack.Header.Rows || uint64(ordinal) > uint64(^uint32(0)) {
+		if ordinal < 0 || ordinal >= p.pack.Header.Rows || uint64(ordinal) > math.MaxUint32 {
 			return dst[:i], fmt.Errorf("collections: hnsw_search_pack_v1 prepared traversal exact ordinal=%d outside row_count=%d", ordinal, p.pack.Header.Rows)
 		}
 		rowIDs[i] = uint32(ordinal)
@@ -366,6 +370,7 @@ func (v *columnHNSWSearchPackPreparedView) greedyNearestAtLayerPreparedScorePlan
 		}
 		for i, neighborOrdinal := range tile {
 			score := scores[i]
+			// Keep exact-pack tie handling stable with the current route.
 			if score > bestScore || (score == bestScore && neighborOrdinal < best) {
 				best = neighborOrdinal
 				bestScore = score

--- a/TreeDB/collections/column_hnsw_search_pack_test.go
+++ b/TreeDB/collections/column_hnsw_search_pack_test.go
@@ -1,8 +1,10 @@
 package collections
 
 import (
+	"bytes"
 	"encoding/binary"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"os"
@@ -594,6 +596,136 @@ func TestColumnHNSWSearchPackRouteMatchesColumnGraph2315(t *testing.T) {
 		t.Fatalf("pack route stats=%+v", packResponse.Stats)
 	}
 	assertColumnHNSWSearchPackMatchesColumnGraphRoute2315(t, searcher, opts, packResponse)
+}
+
+func TestColumnHNSWPreparedTraversalScorePlaneSeam2585(t *testing.T) {
+	rows := []columnGraphRebuildInputRowV2A{
+		{id: "doc-a", vector: []float32{1, 0, 0}},
+		{id: "doc-b", vector: []float32{0.9, 0.1, 0}},
+		{id: "doc-c", vector: []float32{0, 1, 0}},
+		{id: "doc-d", vector: []float32{0, 0, 1}},
+		{id: "doc-e", vector: []float32{0.4, 0.6, 0}},
+	}
+	_, d, col, def := openColumnGraphQuantizedGuardrailTestCollection1926(t, rows)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	searcher, err := col.OpenVectorIndexSearcher(VectorIndexSearcherOptions{IndexName: def.Name, MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("OpenVectorIndexSearcher: %v", err)
+	}
+	defer func() { _ = searcher.Close() }()
+	if searcher.reader == nil || searcher.reader.hnswSearchPack == nil {
+		t.Fatal("searcher missing hnsw_search_pack_v1 prepared view")
+	}
+	pack := searcher.reader.hnswSearchPack
+	query := []float32{1, 0.05, 0}
+	nativeOpts := columnVectorGraphNativeSearchOptions{TopK: 3, EfSearch: len(rows), StatsMode: columnVectorGraphNativeSearchStatsModeFullDiagnostics, QueryMode: columnVectorGraphNativeSearchQueryModeExact}
+	var packScratch columnVectorGraphNativeSearchScratch
+	packResults, packStats, err := pack.searchCosine(query, nativeOpts, &packScratch)
+	if err != nil {
+		t.Fatalf("pack searchCosine exact: %v", err)
+	}
+	var exactScratch columnVectorGraphNativeSearchScratch
+	exactPlane := &columnHNSWPreparedExactFP32ScorePlane{}
+	exactResults, exactStats, err := pack.searchCosinePreparedScorePlane(query, columnHNSWPreparedTraversalOptions{TopK: 3, EfSearch: len(rows), StatsMode: columnVectorGraphNativeSearchStatsModeFullDiagnostics}, &exactScratch, exactPlane)
+	if err != nil {
+		t.Fatalf("prepared traversal exact score plane: %v", err)
+	}
+	assertColumnHNSWPreparedTraversalResultsMatch2585(t, exactResults, packResults)
+	if exactPlane.kind() != columnHNSWPreparedTraversalScorePlaneKindExactFP32 || exactStats.PreparedScoreCalls == 0 || exactStats.QuantizedScoreCalls != 0 || exactStats.Candidates != packStats.Candidates || exactStats.VisitedEdges != packStats.VisitedEdges {
+		t.Fatalf("exact seam stats=%+v pack=%+v kind=%s", exactStats, packStats, exactPlane.kind())
+	}
+
+	var quantizedScratch columnVectorGraphNativeSearchScratch
+	queryInvNorm, err := columnVectorGraphInvNorm(query)
+	if err != nil {
+		t.Fatalf("columnVectorGraphInvNorm query: %v", err)
+	}
+	scorer, err := searcher.reader.prepareQuantizedScorer(columnVectorGraphNativeSearchQueryModeQuantizedOnly, def.QuantizedIndexes[0].Name, query, queryInvNorm, &quantizedScratch)
+	if err != nil {
+		t.Fatalf("prepareQuantizedScorer: %v", err)
+	}
+	quantizedPlane := &columnHNSWPreparedQuantizedScorePlane{scorer: &scorer}
+	quantizedResults, quantizedStats, err := pack.searchCosinePreparedScorePlane(query, columnHNSWPreparedTraversalOptions{TopK: 3, EfSearch: len(rows), StatsMode: columnVectorGraphNativeSearchStatsModeFullDiagnostics}, &quantizedScratch, quantizedPlane)
+	if err != nil {
+		t.Fatalf("prepared traversal quantized score plane: %v", err)
+	}
+	if len(quantizedResults) != 3 {
+		t.Fatalf("quantized seam results=%d want 3: %+v", len(quantizedResults), quantizedResults)
+	}
+	if quantizedPlane.kind() != columnHNSWPreparedTraversalScorePlaneKindQuantized || quantizedStats.QuantizedScoreCalls == 0 || quantizedStats.PreparedScoreCalls != 0 || quantizedStats.VectorBytesRead != 0 || quantizedStats.NormBytesRead != 0 || quantizedStats.GraphRowFallbacks != 0 {
+		t.Fatalf("quantized seam stats=%+v kind=%s want explicit quantized scoring without exact fallback", quantizedStats, quantizedPlane.kind())
+	}
+	if _, _, err := pack.searchCosinePreparedScorePlane(query, columnHNSWPreparedTraversalOptions{TopK: 1, EfSearch: len(rows)}, &columnVectorGraphNativeSearchScratch{}, nil); !errors.Is(err, errColumnHNSWPreparedTraversalScorePlaneUnavailable) {
+		t.Fatalf("nil score plane err=%v want explicit score-plane failure", err)
+	}
+}
+
+func TestColumnHNSWSearchPackExactRouteAndQuantizedFailClosed2585(t *testing.T) {
+	rows := []columnGraphRebuildInputRowV2A{
+		{id: "doc-a", vector: []float32{1, 0, 0}},
+		{id: "doc-b", vector: []float32{0.9, 0.1, 0}},
+		{id: "doc-c", vector: []float32{0, 1, 0}},
+		{id: "doc-d", vector: []float32{0, 0, 1}},
+	}
+	_, d, col, def := openColumnGraphQuantizedGuardrailTestCollection1926(t, rows)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	searcher, err := col.OpenVectorIndexSearcher(VectorIndexSearcherOptions{IndexName: def.Name, MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("OpenVectorIndexSearcher: %v", err)
+	}
+	defer func() { _ = searcher.Close() }()
+	query := []float32{1, 0, 0}
+	var buffer VectorIndexSearchBuffer
+	exact, err := searcher.SearchWithBuffer(VectorIndexSearcherSearchOptions{Query: query, QueryMode: VectorIndexQueryModeExact, TopK: 2, EfSearch: len(rows), StatsMode: VectorIndexSearchStatsModeProduction}, &buffer)
+	if err != nil {
+		t.Fatalf("exact SearchWithBuffer: %v", err)
+	}
+	if exact.Stats.RouteKind() != VectorIndexSearchRouteExactHNSWSearchPackV1 || exact.Stats.SearchRouteHNSWSearchPack != 1 || exact.Stats.HNSWSearchPackActive != 1 || exact.Stats.SearchRouteQuantizedOnly+exact.Stats.SearchRouteQuantizedRerank != 0 || exact.Stats.QuantizedScorerActive != 0 {
+		t.Fatalf("exact route stats=%+v want unchanged hnsw_search_pack_v1 route", exact.Stats)
+	}
+	quantizedOpts := VectorIndexSearcherSearchOptions{Query: query, QueryMode: VectorIndexQueryModeQuantizedOnly, QuantizedIndexName: def.QuantizedIndexes[0].Name, TopK: 2, EfSearch: len(rows), StatsMode: VectorIndexSearchStatsModeProduction}
+	quantized, err := searcher.SearchWithBuffer(quantizedOpts, &buffer)
+	if err != nil {
+		t.Fatalf("quantized SearchWithBuffer: %v", err)
+	}
+	assertQuantizedOnlyGuardrailStats2416(t, quantized.Stats, def.Dimensions)
+
+	if searcher.reader == nil || searcher.reader.quantizedAssetStatus == nil {
+		t.Fatal("searcher missing quantized asset status")
+	}
+	qName := def.QuantizedIndexes[0].Name
+	originalStatus := searcher.reader.quantizedAssetStatus[qName]
+	delete(searcher.reader.quantizedAssetStatus, qName)
+	missingOnly, onlyErr := searcher.SearchWithBuffer(quantizedOpts, &buffer)
+	rerankOpts := VectorIndexSearcherSearchOptions{Query: query, QueryMode: VectorIndexQueryModeQuantizedRerank, QuantizedIndexName: qName, QuantizedRerankCandidates: 2, TopK: 2, EfSearch: len(rows), StatsMode: VectorIndexSearchStatsModeProduction}
+	missingRerank, rerankErr := searcher.SearchWithBuffer(rerankOpts, &buffer)
+	searcher.reader.quantizedAssetStatus[qName] = originalStatus
+	if !errors.Is(onlyErr, ErrVectorIndexSearchUnavailable) || len(missingOnly.Results) != 0 {
+		t.Fatalf("missing quantized_only asset response=%+v err=%v want fail-closed unavailable", missingOnly, onlyErr)
+	}
+	assertQuantizedUnavailableGuardrailStats2416(t, missingOnly.Stats, columnVectorGraphNativeSearchQueryModeQuantizedOnly, columnVectorGraphQuantizedAssetHealthMissing)
+	if !errors.Is(rerankErr, ErrVectorIndexSearchUnavailable) || len(missingRerank.Results) != 0 {
+		t.Fatalf("missing quantized_rerank asset response=%+v err=%v want fail-closed unavailable", missingRerank, rerankErr)
+	}
+	assertQuantizedUnavailableGuardrailStats2416(t, missingRerank.Stats, columnVectorGraphNativeSearchQueryModeQuantizedRerank, columnVectorGraphQuantizedAssetHealthMissing)
+}
+
+func assertColumnHNSWPreparedTraversalResultsMatch2585(tb testing.TB, got, want []columnVectorGraphNativeSearchResult) {
+	tb.Helper()
+	if len(got) != len(want) {
+		tb.Fatalf("results=%d want %d got=%+v want=%+v", len(got), len(want), got, want)
+	}
+	for i := range want {
+		if got[i].Ordinal != want[i].Ordinal || !bytes.Equal(got[i].ID, want[i].ID) || math.Abs(got[i].Score-want[i].Score) > 1e-6 {
+			tb.Fatalf("result[%d]=%+v want %+v", i, got[i], want[i])
+		}
+	}
 }
 
 func TestColumnHNSWSearchPackMissingAndStaleFallbackSearchWithBuffer2315(t *testing.T) {

--- a/TreeDB/collections/column_hnsw_search_pack_test.go
+++ b/TreeDB/collections/column_hnsw_search_pack_test.go
@@ -663,6 +663,71 @@ func TestColumnHNSWPreparedTraversalScorePlaneSeam2585(t *testing.T) {
 	}
 }
 
+func TestColumnHNSWPreparedTraversalOmitReturnsRetainedShortlist2585(t *testing.T) {
+	rows := []columnGraphRebuildInputRowV2A{
+		{id: "doc-a", vector: []float32{1, 0, 0}},
+		{id: "doc-b", vector: []float32{0.9, 0.1, 0}},
+		{id: "doc-c", vector: []float32{0.7, 0.3, 0}},
+		{id: "doc-d", vector: []float32{0.4, 0.6, 0}},
+		{id: "doc-e", vector: []float32{0, 1, 0}},
+	}
+	_, d, col, def := openColumnGraphQuantizedGuardrailTestCollection1926(t, rows)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	searcher, err := col.OpenVectorIndexSearcher(VectorIndexSearcherOptions{IndexName: def.Name, MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("OpenVectorIndexSearcher: %v", err)
+	}
+	defer func() { _ = searcher.Close() }()
+	if searcher.reader == nil || searcher.reader.hnswSearchPack == nil {
+		t.Fatal("searcher missing hnsw_search_pack_v1 prepared view")
+	}
+	pack := searcher.reader.hnswSearchPack
+	query := []float32{1, 0.05, 0}
+	const (
+		topK     = 2
+		retained = 4
+	)
+	opts := columnHNSWPreparedTraversalOptions{
+		TopK:                      topK,
+		EfSearch:                  len(rows),
+		RetainedCandidateLimit:    retained,
+		StatsMode:                 columnVectorGraphNativeSearchStatsModeFullDiagnostics,
+		OmitResultMaterialization: true,
+	}
+	var scratch columnVectorGraphNativeSearchScratch
+	shortlist, _, err := pack.searchCosinePreparedScorePlane(query, opts, &scratch, &columnHNSWPreparedExactFP32ScorePlane{})
+	if err != nil {
+		t.Fatalf("prepared traversal omitted shortlist: %v", err)
+	}
+	if len(shortlist) != retained {
+		t.Fatalf("omitted shortlist results=%d want retained=%d: %+v", len(shortlist), retained, shortlist)
+	}
+	for i, result := range shortlist {
+		if result.ID != nil || result.HasRowRef || len(result.RowRef.DocumentID) != 0 {
+			t.Fatalf("omitted shortlist result[%d]=%+v unexpectedly materialized ID/row ref", i, result)
+		}
+	}
+
+	var materializedScratch columnVectorGraphNativeSearchScratch
+	materializedOpts := opts
+	materializedOpts.OmitResultMaterialization = false
+	materialized, _, err := pack.searchCosinePreparedScorePlane(query, materializedOpts, &materializedScratch, &columnHNSWPreparedExactFP32ScorePlane{})
+	if err != nil {
+		t.Fatalf("prepared traversal materialized results: %v", err)
+	}
+	if len(materialized) != topK {
+		t.Fatalf("materialized results=%d want top_k=%d: %+v", len(materialized), topK, materialized)
+	}
+	for i, result := range materialized {
+		if len(result.ID) == 0 {
+			t.Fatalf("materialized result[%d]=%+v missing ID", i, result)
+		}
+	}
+}
+
 func TestColumnHNSWSearchPackExactRouteAndQuantizedFailClosed2585(t *testing.T) {
 	rows := []columnGraphRebuildInputRowV2A{
 		{id: "doc-a", vector: []float32{1, 0, 0}},


### PR DESCRIPTION
## Summary

- Add a prepared HNSW traversal/scoring seam with explicit score planes for exact FP32 and quantized scoring.
- Keep the public exact FP32 search route on the current `hnsw_search_pack_v1` hot path.
- Add tests for exact seam parity, retained shortlist behavior, explicit quantized scoring counters, unchanged exact route stats, and quantized fail-closed behavior.

## Scope notes

- This does **not** promote scalar_u8 or rabitq_1bit onto a new public route.
- Quantized traversal uses an explicit score plane in tests; there is no hidden exact fallback.
- Rebased/synced onto `origin/main` after #2591 / PR #2592 merged as `e30ac7384a579d301e8a384fab6977e8e8367879`.

Closes #2585.

## Validation

Tests:

- `GOWORK=off go test ./TreeDB/collections -run 'TestColumnHNSWPreparedTraversal(ScorePlaneSeam|OmitReturnsRetainedShortlist)2585|TestColumnHNSWSearchPackExactRouteAndQuantizedFailClosed2585|TestColumnHNSWSearchPackRouteMatchesColumnGraph2315|TestVectorIndexSearcherQuantizedSearchWithBufferSuccessAndErrorReset1926|TestSearchVectorIndexQuantizedOnlyAndRerankSupported1926|TestColumnGraphQuantizedProductionGateRouteAssertions2591|TestColumnGraphScalarU8QuantizedBenchQueriesHonorMultiQueryOrdinal2591' -count=1`
  - `/tmp/issue2585_focused_final_main_20260610_195819.txt`
- `GOWORK=off go test ./TreeDB/collections -count=1`
  - `/tmp/issue2585_collections_test_final_main_20260610_195835.txt`


Post-review focused checks:

- Coordinator shortlist/CodeRabbit follow-up: `GOWORK=off go test ./TreeDB/collections -run 'TestColumnHNSWPreparedTraversal(ScorePlaneSeam|OmitReturnsRetainedShortlist)2585|TestColumnHNSWSearchPackExactRouteAndQuantizedFailClosed2585|TestColumnHNSWSearchPackRouteMatchesColumnGraph2315' -count=1`
  - manager artifact: `/tmp/issue2585_focused_coderabbit_comment_20260610_201327.txt`
  - coordinator artifact: `/tmp/issue2585_coordinator_focused_latest_20260610_201606.txt`
- Full collections after retained-shortlist patch:
  - manager artifact: `/tmp/issue2585_collections_shortlist_fix_20260610_200734.txt`

Exact FP32 no-regression checks:

- c=1 exact route benchstat: `/tmp/issue2585_benchstat_exact_c1_final_main.txt`
  - `ReusableBufferV4`: ~, p=0.246
  - `ReusableBufferParallelV4`: ~, p=0.548
  - geomean -0.21%
  - hot rows stayed `0 B/op`, `0 allocs/op`
- c=8 exact route benchstat: `/tmp/issue2585_benchstat_exact_c8_final_main_rerun.txt`
  - `ReusableBufferV4-8`: ~, p=0.310
  - `ReusableBufferParallelV4-8`: ~, p=0.389
  - geomean +1.37% (not statistically significant)
  - hot rows stayed `0 B/op`, `0 allocs/op`

#2591 production-gate smoke on final main base:

- `TREEDB_VECTOR_BENCH_DOCS=10000 TREEDB_VECTOR_BENCH_DIMS=768 TREEDB_VECTOR_BENCH_M=16 TREEDB_VECTOR_BENCH_EF_CONSTRUCTION=128 TREEDB_VECTOR_BENCH_EF_SEARCH=128 TREEDB_VECTOR_BENCH_TOPK=10 TREEDB_VECTOR_BENCH_QUERIES=16 GOMAXPROCS=8 GOWORK=off go test ./TreeDB/collections -run '^$' -bench '^BenchmarkCollectionVectorQuantizedProductionGate2591' -benchmem -benchtime=1x -count=1`
  - `/tmp/issue2585_2591_smoke_final_main_20260610_200240.txt`

