### PR TITLE
Document TreeDB VectorDBBench runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,11 @@ USearch c=1/c=8 averages are from batch searches with `threads=1/8`, while
 TreeDB and pgvector report per-query latency samples. Source and caveats:
 [June 8 vector external comparison](docs/benchmarks/treedb_vector_external_compare_2026-06-08.md).
 
+TreeDB is also wired into `snissn/vectordbbench` through the document service.
+Those rows measure Python/client/HTTP/service overhead and are separate from
+native Go `0 B/op` no-document evidence; see the
+[TreeDB VectorDBBench runbook](docs/benchmarks/treedb_vectordbbench_runbook_2026-06-11.md).
+
 ### `application.db` Offline Density Workload
 
 Offline compacted-size comparison from the June 2 Celestia `application.db`

--- a/TreeDB/README.md
+++ b/TreeDB/README.md
@@ -281,6 +281,13 @@ Full context, commands, guardrails, and caveats are in
 row is an in-memory library comparator, not a persistent DB/server row, and its
 averages are from batch searches with `threads=1/8`.
 
+TreeDB's VectorDBBench integration uses the document service and the shared
+`treedb-client` Python package. It exposes separate exact FP32,
+scalar_u8-rerank32, and experimental RaBitQ rows while keeping Haystack's
+`/search/vector` route as exact dense document scoring. Those rows include
+Python/client/HTTP/service overhead and are not native Go allocation evidence;
+see `../docs/benchmarks/treedb_vectordbbench_runbook_2026-06-11.md`.
+
 The tiny BERT embedding demo in `../examples/vector_search/tiny_bert/` is a
 caller-side fixture/demo; TreeDB core does not generate embeddings. Export it
 with `--output-jsonl` and set `TREEDB_VECTOR_BENCH_JSONL` to run

--- a/docs/TREEDB_DOCUMENT_SERVICE_API.md
+++ b/docs/TREEDB_DOCUMENT_SERVICE_API.md
@@ -382,7 +382,9 @@ fail closed when assets are missing, invalid, stale, or unavailable. Responses
 include result IDs/scores plus TreeDB stats/diagnostics so benchmark adapters can
 assert no-document guardrails: no documents fetched, no exact fallback for
 quantized modes, quantized scorer active, and rerank exact reads bounded by the
-requested shortlist.
+requested shortlist. Reproducible VectorDBBench setup commands and smoke evidence
+are documented in
+[`docs/benchmarks/treedb_vectordbbench_runbook_2026-06-11.md`](benchmarks/treedb_vectordbbench_runbook_2026-06-11.md).
 
 ## Dense-vector search
 

--- a/docs/benchmarks/treedb_vectordbbench_runbook_2026-06-11.md
+++ b/docs/benchmarks/treedb_vectordbbench_runbook_2026-06-11.md
@@ -1,0 +1,218 @@
+# TreeDB VectorDBBench Runbook and Smoke Evidence (2026-06-11)
+
+This note documents the TreeDB VectorDBBench integration after the service and
+adapter stack merged. It is a reproducibility/runbook document plus a functional
+smoke artifact. It is **not** claim-quality latency/QPS evidence.
+
+## Merged Stack
+
+| issue | PR | merge commit | scope |
+| --- | --- | --- | --- |
+| #2570 | `snissn/gomap#2583` | `28fa5edda27b52dadf7cff060683f71666dd470a` | TreeDB document-service benchmark lifecycle, no-document vector-index route, and `treedb-client` support |
+| #2571 | `snissn/vectordbbench#1` | `b22d106df04b8cf7f903fafa49c99cea01a27848` | VectorDBBench TreeDB client/config/CLI seam |
+| #2572 | `snissn/vectordbbench#3` | `c1c763c0dcd97c489c2b107fd7060374f76d09b8` | named exact/scalar_u8/RaBitQ variants and route/counter guardrails |
+
+`snissn/vectordbbench#2` was the original stacked #2572 PR. It was auto-closed
+when its base branch merged and is superseded by `snissn/vectordbbench#3`.
+
+## Measurement Boundaries
+
+Keep these lanes separate:
+
+- **VDBBench TreeDB rows** measure Python + `treedb-client` + HTTP/JSON +
+  TreeDB document service + TreeDB vector-index work.
+- **Haystack route** remains exact dense document scoring through
+  `/v1/indexes/{index}/search/vector`; it is not ANN and should not be used for
+  TreeDB ANN claims.
+- **Native Go no-document rows** (`SearchWithBuffer` / reusable searcher) remain
+  the high-QPS `0 B/op`, `0 allocs/op` evidence lane when Go benchmarks emit
+  allocation metrics.
+- **USearch rows** are in-memory/library comparators.
+- **pgvector rows** are PostgreSQL/server comparators.
+- **RaBitQ v1 rows** are experimental/compact evidence. Do not present them as
+  exact-like recall.
+
+The current exact-like quantized TreeDB lane is scalar_u8 + exact rerank:
+`query_mode="quantized_rerank"`, an explicit `quantized_index_name`, and
+`quantized_rerank_candidates=32` for the rerank32 baseline.
+
+## Local Service Setup
+
+Use a fresh TreeDB data directory for managed VDBBench runs. Existing
+`column_graph` benchmark indexes fail closed for in-place `drop_old` reset, so
+shared services should use a unique `--index-name` per run.
+
+```sh
+RUN_DIR=/tmp/treedb_vdbbench_$(date +%Y%m%d_%H%M%S)
+mkdir -p "$RUN_DIR"
+
+go run ./cmd/treedb-document-service \
+  -dir "$RUN_DIR/treedb-data" \
+  -addr 127.0.0.1:7120 \
+  -profile command_wal_durable
+```
+
+Health check:
+
+```sh
+curl -fsS http://127.0.0.1:7120/v1/health
+```
+
+## Local Python Setup
+
+For local development from checkouts:
+
+```sh
+# gomap checkout provides treedb-client
+export TREEDB_CLIENT_SRC=/path/to/gomap/clients/python/treedb_client/src
+
+# vectordbbench checkout at or after c1c763c0dcd97c489c2b107fd7060374f76d09b8
+cd /path/to/vectordbbench
+export PYTHONPATH="$PWD:$TREEDB_CLIENT_SRC"
+```
+
+The packaged VDBBench extra also pins `treedb-client` to an immutable gomap
+commit containing the merged service/client contract.
+
+## VDBBench Commands
+
+List TreeDB commands:
+
+```sh
+python -m vectordb_bench.cli.vectordbbench --help | grep -i treedb
+```
+
+Dry-run exact FP32 no-document command:
+
+```sh
+PYTHONPATH="$PWD:$TREEDB_CLIENT_SRC" \
+python -m vectordb_bench.cli.vectordbbench treedbcolumngraphexact \
+  --base-url http://127.0.0.1:7120 \
+  --index-name treedb_exact_$(date +%s) \
+  --m 16 \
+  --ef-construction 128 \
+  --ef-search 128 \
+  --skip-load \
+  --skip-search-serial \
+  --skip-search-concurrent \
+  --dry-run
+```
+
+Dry-run scalar_u8 rerank32 command:
+
+```sh
+PYTHONPATH="$PWD:$TREEDB_CLIENT_SRC" \
+python -m vectordb_bench.cli.vectordbbench treedbscalaru8rerank \
+  --base-url http://127.0.0.1:7120 \
+  --index-name treedb_scalar_u8_$(date +%s) \
+  --m 16 \
+  --ef-construction 128 \
+  --ef-search 128 \
+  --quantized-index-name embedding.scalar_u8.fast \
+  --quantized-rerank-candidates 32 \
+  --skip-load \
+  --skip-search-serial \
+  --skip-search-concurrent \
+  --dry-run
+```
+
+For a full VDBBench run, remove the `--skip-*`/`--dry-run` flags and select the
+same dataset/case settings that you use for comparator databases. Record the
+case ID, dimensions, topK, metric, load concurrency, search concurrency list,
+duration, and service profile next to results. Do not compare full-run results
+to native Go allocation rows.
+
+Optional experimental RaBitQ v1 command:
+
+```sh
+PYTHONPATH="$PWD:$TREEDB_CLIENT_SRC" \
+python -m vectordb_bench.cli.vectordbbench treedbrabitq1bitexperimental \
+  --base-url http://127.0.0.1:7120 \
+  --index-name treedb_rabitq_v1_experimental_$(date +%s) \
+  --m 16 \
+  --ef-construction 128 \
+  --ef-search 128 \
+  --query-mode quantized_only
+```
+
+Keep this row labeled experimental and recall-limited unless a future versioned
+codec/design issue changes that contract.
+
+## Smoke Evidence
+
+Artifact root: `/tmp/gomap_2573_vdbbench_smoke_20260610_202907`
+
+Context:
+
+- gomap commit: `e30ac7384a579d301e8a384fab6977e8e8367879`
+- vectordbbench commit: `c1c763c0dcd97c489c2b107fd7060374f76d09b8`
+- Go: `go version go1.26.0 darwin/arm64`
+- Python: `Python 3.14.0`
+- OS/arch: `Darwin arm64`
+- Service profile: `command_wal_durable`
+- Service command used a fresh artifact-owned data directory.
+
+Validation commands captured in the artifact:
+
+```sh
+PYTHONPATH=. uv run --no-sync --with pytest --with click --with pydantic --with pyyaml --with environs --with pandas --with polars --with pyarrow --with psutil --with pytz --with tqdm --with plotly --with ujson --with hdrhistogram --with scikit-learn --with s3fs --with oss2 python -m pytest tests/test_treedb_cli.py tests/test_db_client_resolution.py -q
+```
+
+Result: `56 passed` (`vectordbbench_tests.txt`).
+
+The smoke script instantiated the merged VDBBench TreeDB client classes against
+a local TreeDB document service, loaded four 2-D vectors into fresh exact and
+scalar indexes, optimized, searched through the VDBBench client API, and then
+queried the service response counters directly.
+
+| row | result IDs | route | no docs | docs fetched | quantized scorer | quantized score calls | rerank exact calls |
+| --- | --- | --- | ---: | ---: | ---: | ---: | ---: |
+| exact FP32 smoke | `101,103` | `exact_hnsw_search_pack_v1` | true | 0 | 0 | 0 | 0 |
+| scalar_u8 rerank32 smoke | `101,103` | `quantized_rerank` | true | 0 | 1 | 7 | 4 |
+
+The scalar smoke loaded only four documents, so the route correctly reranked the
+available shortlist (`4`) rather than the configured upper bound (`32`). This
+proves the shortlist-bounded exact-read guardrail, not a production recall or
+throughput number.
+
+Additional artifacts:
+
+- `README.md`
+- `context.txt`
+- `health.json`
+- `service.log`
+- `vdbbench_treedb_smoke.py`
+- `vdbbench_treedb_smoke.json`
+- `vectordbbench_tests.txt`
+- `cli_exact_dry_run.txt`
+- `cli_scalar_dry_run.txt`
+
+## Result Reporting Template
+
+When publishing a full VDBBench run, include a table like this and keep exact,
+scalar_u8, and RaBitQ separate:
+
+| row | case/dims/docs | topK | metric | concurrency | recall/NDCG | avg | p95 | p99 | QPS | load | optimize | route proof |
+| --- | --- | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| TreeDB exact FP32 |  |  | cosine |  |  |  |  |  |  |  |  | `route=exact_hnsw_search_pack_v1`, `documents_fetched=0` |
+| TreeDB scalar_u8 rerank32 |  |  | cosine |  |  |  |  |  |  |  |  | `route=quantized_rerank`, `quantized_scorer_active=1`, exact reads `<=32` |
+| TreeDB RaBitQ v1 experimental |  |  | cosine |  |  |  |  |  |  |  |  | experimental; do not combine with scalar_u8 |
+
+Also state:
+
+- whether the service used a fresh data directory or a unique index name;
+- TreeDB service profile (`command_wal_durable`, `command_wal_relaxed`, or
+  benchmark-only `bench`);
+- Python, Go, OS/CPU context, and host-load caveats;
+- that VDBBench rows include Python/client/service overhead and do not emit Go
+  `B/op`/`allocs/op` metrics.
+
+## Relationship To Existing Evidence
+
+The June 8 external comparison remains the current same-host comparison snapshot
+for TreeDB exact FP32, scalar_u8 rerank32, USearch, and pgvector on `10k x 1536`:
+
+- [TreeDB Vector External Comparison Snapshot](treedb_vector_external_compare_2026-06-08.md)
+
+Use that report for current exact/scalar_u8 vs USearch/pgvector comparison
+context. Use this runbook to reproduce the new VDBBench service/client boundary.


### PR DESCRIPTION
## Objective

Document the merged TreeDB VectorDBBench integration and preserve reproducible smoke evidence with exact/scalar_u8/RaBitQ/Haystack/native-Go boundaries kept separate.

Closes #2573. Parent tracker: #2569.

## Context

The service/client and VectorDBBench adapter stack is now merged:

- #2570 / #2583: TreeDB document-service benchmark lifecycle and no-document vector-index contract
- #2571 / snissn/vectordbbench#1: TreeDB VectorDBBench client/CLI seam
- #2572 / snissn/vectordbbench#3: explicit exact/scalar_u8/RaBitQ variants and guardrails

This PR documents how to reproduce the service/client boundary and records the functional smoke evidence for the merged stack.

## Non-goals

- No new TreeDB service or VectorDBBench adapter code.
- No claim-quality public latency/QPS numbers from VDBBench.
- No change to Haystack exact dense-search semantics.
- No promotion of RaBitQ v1 as exact-like recall.
- No native Go allocation claim from Python/service rows.

## Design / Docs

Adds:

- `docs/benchmarks/treedb_vectordbbench_runbook_2026-06-11.md`
  - local TreeDB document-service startup;
  - local Python/VDBBench setup;
  - exact FP32, scalar_u8 rerank32, and experimental RaBitQ command examples;
  - smoke artifact and route/counter evidence;
  - result reporting template and boundary caveats.
- README/TreeDB README links to the new runbook.
- Document-service API link to the VectorDBBench runbook.

## Correctness / Evidence

Local validation:

```sh
go test ./TreeDB/documentservice ./cmd/treedb-document-service
git diff --check
```

VectorDBBench merged-checkout validation captured in `/tmp/gomap_2573_vdbbench_smoke_20260610_202907`:

```sh
PYTHONPATH=. uv run --no-sync --with pytest --with click --with pydantic --with pyyaml --with environs --with pandas --with polars --with pyarrow --with psutil --with pytz --with tqdm --with plotly --with ujson --with hdrhistogram --with scikit-learn --with s3fs --with oss2 python -m pytest tests/test_treedb_cli.py tests/test_db_client_resolution.py -q
```

Result: `56 passed`.

Functional smoke against local TreeDB document service:

| row | result IDs | route | no docs | docs fetched | quantized scorer | quantized score calls | rerank exact calls |
| --- | --- | --- | ---: | ---: | ---: | ---: | ---: |
| exact FP32 smoke | `101,103` | `exact_hnsw_search_pack_v1` | true | 0 | 0 | 0 | 0 |
| scalar_u8 rerank32 smoke | `101,103` | `quantized_rerank` | true | 0 | 1 | 7 | 4 |

The scalar smoke used four documents, so rerank exact calls are `4` and remain below the configured rerank32 upper bound.

## Performance

No performance improvement claimed. The artifact is a functional smoke and route/counter proof only. Full VDBBench throughput/latency evidence remains a follow-up run using the documented command template and a quiet/dedicated host if public numbers are needed.

## AI Review Loop

Requested after this PR was opened with docs/evidence complete. Resolve any review findings before merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive VectorDBBench integration documentation including a detailed runbook with complete setup instructions, local service configuration, available test commands, dry-run examples, and smoke test validation results.
  * Updated API and README documentation to clarify benchmark measurement boundaries between different test lanes and reference the new external runbook for reproducible benchmarking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->