### PR TITLE
TreeDB: route scalar_u8 quantized search through prepared traversal

### DIFF
--- a/TreeDB/collections/collection_vector_index_prepared_search_cache.go
+++ b/TreeDB/collections/collection_vector_index_prepared_search_cache.go
@@ -730,15 +730,30 @@ func (p *collectionVectorIndexPreparedSearch) SearchQuantizedWithBuffer(opts Vec
 		clear(previousResults)
 		return response, nil
 	}
-	results, searchStats, err := reader.SearchCosine(opts.Query, columnVectorGraphNativeSearchOptions{
-		TopK:                      opts.TopK,
-		EfSearch:                  opts.EfSearch,
-		ScoreBatchMode:            opts.scoreBatchMode,
-		StatsMode:                 statsMode,
-		QueryMode:                 queryMode,
-		QuantizedIndexName:        opts.QuantizedIndexName,
-		QuantizedRerankCandidates: opts.QuantizedRerankCandidates,
-	}, &buffer.searchScratch)
+	var results []columnVectorGraphNativeSearchResult
+	var searchStats columnVectorGraphNativeSearchStats
+	var err error
+	if pack, ok := collectionScalarU8PreparedTraversalPackForReader(reader, queryMode, statsMode, opts.QuantizedIndexName); ok {
+		results, searchStats, err = reader.SearchCosineScalarU8PreparedTraversal(pack, opts.Query, columnVectorGraphNativeSearchOptions{
+			TopK:                      opts.TopK,
+			EfSearch:                  opts.EfSearch,
+			ScoreBatchMode:            opts.scoreBatchMode,
+			StatsMode:                 statsMode,
+			QueryMode:                 queryMode,
+			QuantizedIndexName:        opts.QuantizedIndexName,
+			QuantizedRerankCandidates: opts.QuantizedRerankCandidates,
+		}, &buffer.searchScratch)
+	} else {
+		results, searchStats, err = reader.SearchCosine(opts.Query, columnVectorGraphNativeSearchOptions{
+			TopK:                      opts.TopK,
+			EfSearch:                  opts.EfSearch,
+			ScoreBatchMode:            opts.scoreBatchMode,
+			StatsMode:                 statsMode,
+			QueryMode:                 queryMode,
+			QuantizedIndexName:        opts.QuantizedIndexName,
+			QuantizedRerankCandidates: opts.QuantizedRerankCandidates,
+		}, &buffer.searchScratch)
+	}
 	response.Stats = vectorIndexSearchStatsFromInternal(searchStats, columnPhysicalRowReaderStats{})
 	p.routeStats.apply(&response.Stats)
 	if err != nil {

--- a/TreeDB/collections/column_hnsw_prepared_quantized_search.go
+++ b/TreeDB/collections/column_hnsw_prepared_quantized_search.go
@@ -1,0 +1,219 @@
+package collections
+
+import "fmt"
+
+var errColumnHNSWPreparedQuantizedTraversalUnavailable = fmt.Errorf("%w: scalar_u8 hnsw prepared quantized traversal unavailable", ErrVectorIndexSearchUnavailable)
+
+func collectionScalarU8PreparedTraversalPackForReader(reader *columnVectorGraphPhysicalRowReader, queryMode columnVectorGraphNativeSearchQueryMode, statsMode columnVectorGraphNativeSearchStatsMode, quantizedIndexName string) (*columnHNSWSearchPackPreparedView, bool) {
+	if reader == nil || !queryMode.quantized() || !columnHNSWSearchPackStatsModeSupportedForSearch(statsMode) {
+		return nil, false
+	}
+	qdef, ok := findQuantizedVectorIndex(reader.def, quantizedIndexName)
+	if !ok || qdef.Codec != QuantizedVectorCodecScalarU8 || qdef.Version != 1 {
+		return nil, false
+	}
+	pack := reader.hnswSearchPack
+	switch status := pack.fastStatus(reader.hnswSearchPackStatus); status {
+	case columnHNSWSearchPackPreparedStatusDirect, columnHNSWSearchPackPreparedStatusHeap:
+		return pack, pack != nil
+	default:
+		return nil, false
+	}
+}
+
+func (r *columnVectorGraphPhysicalRowReader) SearchCosineScalarU8PreparedTraversal(pack *columnHNSWSearchPackPreparedView, query []float32, opts columnVectorGraphNativeSearchOptions, scratch *columnVectorGraphNativeSearchScratch) ([]columnVectorGraphNativeSearchResult, columnVectorGraphNativeSearchStats, error) {
+	var setupStats columnVectorGraphNativeSearchStats
+	if r == nil {
+		return nil, setupStats, errNilColumnVectorGraphPhysicalRowReader
+	}
+	queryMode, err := opts.QueryMode.normalized()
+	if err != nil {
+		return nil, setupStats, fmt.Errorf("collections: column_graph %q hnsw prepared quantized traversal query mode: %w", r.def.Name, err)
+	}
+	switch queryMode {
+	case columnVectorGraphNativeSearchQueryModeQuantizedOnly:
+		setupStats.SearchRouteQuantizedOnly = 1
+	case columnVectorGraphNativeSearchQueryModeQuantizedRerank:
+		setupStats.SearchRouteQuantizedRerank = 1
+	default:
+		return nil, setupStats, fmt.Errorf("%w: column_graph %q query_mode=%s is not quantized", errColumnHNSWPreparedQuantizedTraversalUnavailable, r.def.Name, queryMode.String())
+	}
+	r.populateQuantizedAssetSearchStats(opts.QuantizedIndexName, &setupStats)
+	if err := r.validateQuantizedNativeSearchOptions(queryMode, opts); err != nil {
+		return nil, setupStats, err
+	}
+	if opts.HasCandidateRows {
+		return nil, setupStats, errColumnHNSWSearchPackSearchCandidateRows
+	}
+	traversalMode, wavefrontWidth, err := columnVectorGraphNativeSearchTraversalOptions(opts)
+	if err != nil {
+		return nil, setupStats, fmt.Errorf("collections: column_graph %q hnsw prepared quantized traversal: %w", r.def.Name, err)
+	}
+	if traversalMode != columnVectorGraphNativeSearchTraversalModeExact || wavefrontWidth != 0 {
+		return nil, setupStats, fmt.Errorf("%w: column_graph %q traversal_mode=%s wavefront_width=%d", errColumnHNSWPreparedQuantizedTraversalUnavailable, r.def.Name, traversalMode.String(), wavefrontWidth)
+	}
+	qdef, ok := findQuantizedVectorIndex(r.def, opts.QuantizedIndexName)
+	if !ok || qdef.Codec != QuantizedVectorCodecScalarU8 || qdef.Version != 1 {
+		return nil, setupStats, fmt.Errorf("%w: column_graph %q quantized index %q codec/version=(%q,%d) is not scalar_u8 v1", errColumnHNSWPreparedQuantizedTraversalUnavailable, r.def.Name, opts.QuantizedIndexName, qdef.Codec, qdef.Version)
+	}
+	if pack == nil {
+		return nil, setupStats, errColumnHNSWPreparedQuantizedTraversalUnavailable
+	}
+	switch status := pack.fastStatus(r.hnswSearchPackStatus); status {
+	case columnHNSWSearchPackPreparedStatusDirect, columnHNSWSearchPackPreparedStatusHeap:
+	default:
+		return nil, setupStats, columnHNSWSearchPackStatusError(status)
+	}
+	rowCount := r.RowCount()
+	if pack.Header.Rows != rowCount || pack.Header.Dimensions != r.def.Dimensions {
+		return nil, setupStats, fmt.Errorf("%w: column_graph %q hnsw_search_pack_v1 shape rows/dims=(%d,%d) want (%d,%d)", errColumnHNSWPreparedQuantizedTraversalUnavailable, r.def.Name, pack.Header.Rows, pack.Header.Dimensions, rowCount, r.def.Dimensions)
+	}
+	topK := opts.TopK
+	if topK < 0 {
+		return nil, columnVectorGraphNativeSearchStats{}, fmt.Errorf("collections: column_graph %q native search top_k cannot be negative: %w", r.def.Name, errColumnVectorGraphNativeSearchTopKNegative)
+	}
+	efSearch := opts.EfSearch
+	if efSearch < 0 {
+		return nil, columnVectorGraphNativeSearchStats{}, fmt.Errorf("collections: column_graph %q native search ef_search cannot be negative: %w", r.def.Name, errColumnVectorGraphNativeSearchEfSearchNegative)
+	}
+	if topK == 0 || rowCount == 0 {
+		return nil, columnVectorGraphNativeSearchStats{}, nil
+	}
+	setupStats.CandidateRows = uint64(rowCount)
+	if scratch == nil {
+		return nil, columnVectorGraphNativeSearchStats{}, fmt.Errorf("collections: column_graph %q: %w", r.def.Name, errColumnVectorGraphNativeSearchScratchRequired)
+	}
+	queryInvNorm, err := columnVectorGraphInvNorm(query)
+	if err != nil {
+		return nil, columnVectorGraphNativeSearchStats{}, fmt.Errorf("collections: column_graph %q query norm: %w: %w", r.def.Name, errColumnVectorGraphNativeSearchQueryNormInvalid, err)
+	}
+	if topK > rowCount {
+		topK = rowCount
+	}
+	if efSearch == 0 {
+		efSearch = r.def.EfSearch
+	}
+	if efSearch < topK {
+		efSearch = topK
+	}
+	if efSearch > rowCount {
+		efSearch = rowCount
+	}
+	rerankCandidateLimit := 0
+	if queryMode == columnVectorGraphNativeSearchQueryModeQuantizedRerank {
+		rerankCandidateLimit = opts.QuantizedRerankCandidates
+		if rerankCandidateLimit == 0 {
+			rerankCandidateLimit = efSearch
+		}
+		if rerankCandidateLimit < topK {
+			return nil, columnVectorGraphNativeSearchStats{}, fmt.Errorf("collections: column_graph %q native search quantized rerank candidates=%d below normalized top_k=%d: %w", r.def.Name, rerankCandidateLimit, topK, errColumnVectorGraphNativeSearchQuantizedRerankLimit)
+		}
+		if rerankCandidateLimit > rowCount {
+			rerankCandidateLimit = rowCount
+		}
+	}
+	scorer, err := r.prepareQuantizedScorer(queryMode, opts.QuantizedIndexName, query, queryInvNorm, scratch)
+	if err != nil {
+		recordColumnVectorGraphQuantizedAssetErrorStats(&setupStats, err)
+		return nil, setupStats, err
+	}
+	scratch.searchPlan.quantizedScorer = scorer
+	scratch.preparedQuantizedPlane.scorer = &scratch.searchPlan.quantizedScorer
+	setupStats.QuantizedScorerActive = 1
+	if r.preparedSearch != nil && r.preparedSearch.ready() {
+		setupStats.PreparedGraphSearchViews = 1
+	}
+	traversalStatsMode := opts.StatsMode.normalized()
+	if traversalStatsMode == columnVectorGraphNativeSearchStatsModeMinimal {
+		// The existing quantized column_graph route keeps candidate/edge counters even
+		// for production/minimal stats because quantized traversal is the thing being
+		// measured. Preserve that counter contract while reusing the pack traversal.
+		traversalStatsMode = columnVectorGraphNativeSearchStatsModeFullDiagnostics
+	}
+	packOpts := columnHNSWPreparedTraversalOptions{
+		TopK:                                 opts.TopK,
+		EfSearch:                             opts.EfSearch,
+		RetainedCandidateLimit:               0,
+		ScoreBatchMode:                       opts.ScoreBatchMode,
+		StatsMode:                            traversalStatsMode,
+		OmitResultMaterialization:            opts.OmitResultMaterialization || queryMode == columnVectorGraphNativeSearchQueryModeQuantizedRerank,
+		SuppressOmittedResultMaterialization: queryMode == columnVectorGraphNativeSearchQueryModeQuantizedRerank,
+	}
+	results, stats, err := pack.searchCosinePreparedScorePlane(query, packOpts, scratch, &scratch.preparedQuantizedPlane)
+	columnVectorGraphApplyQuantizedPreparedTraversalSetupStats(&stats, setupStats)
+	r.populateScalarU8PreparedTraversalSearchStats(&stats)
+	if err != nil {
+		return nil, stats, err
+	}
+	if queryMode == columnVectorGraphNativeSearchQueryModeQuantizedOnly {
+		return results, stats, nil
+	}
+
+	// The pack traversal retained the quantized candidate set in scratch.top without
+	// reading result IDs/row refs. Rerank only the configured shortlist with the
+	// existing exact FP32 scorer so vector/norm read and exact-call counters stay
+	// bounded by QuantizedRerankCandidates.
+	scratch.results = scratch.results[:0]
+	plan, err := scratch.prepareSearchPlanForNativeSearch(r)
+	if err != nil {
+		return nil, stats, err
+	}
+	plan.scoreBatchMode = columnVectorGraphScoreBatchModeForSearchPlan(opts.ScoreBatchMode, plan)
+	var singleBlockView *columnVectorGraphBlockView
+	if plan.physicalReader != nil && len(plan.physicalReader.ranges) == 1 && (plan.scoreSource.vectorKind == columnVectorGraphSearchVectorSourceGraphRows || plan.scoreSource.normKind == columnVectorGraphSearchNormSourceGraphRows) {
+		singleBlockView, err = plan.blockViewForAssetOrdinal(0)
+		if err != nil {
+			return nil, stats, err
+		}
+	}
+	if err := r.exactRerankQuantizedCandidates(plan, singleBlockView, query, queryInvNorm, topK, rerankCandidateLimit, scratch, &stats); err != nil {
+		return nil, stats, err
+	}
+	if opts.OmitResultMaterialization {
+		for _, candidate := range scratch.top {
+			scratch.results = append(scratch.results, columnVectorGraphNativeSearchResult{Ordinal: candidate.ordinal, Score: candidate.score})
+		}
+		return scratch.results, stats, nil
+	}
+	if err := pack.fetchTopSearchResults(scratch, &stats); err != nil {
+		return nil, stats, err
+	}
+	return scratch.results, stats, nil
+}
+
+func columnVectorGraphApplyQuantizedPreparedTraversalSetupStats(dst *columnVectorGraphNativeSearchStats, src columnVectorGraphNativeSearchStats) {
+	if dst == nil {
+		return
+	}
+	dst.SearchRouteQuantizedOnly = src.SearchRouteQuantizedOnly
+	dst.SearchRouteQuantizedRerank = src.SearchRouteQuantizedRerank
+	dst.QuantizedScorerActive = src.QuantizedScorerActive
+	dst.QuantizedAssetMissing = src.QuantizedAssetMissing
+	dst.QuantizedAssetInvalid = src.QuantizedAssetInvalid
+	dst.QuantizedAssetStale = src.QuantizedAssetStale
+	dst.QuantizedAssetClosed = src.QuantizedAssetClosed
+	dst.QuantizedAssetUnavailable = src.QuantizedAssetUnavailable
+	dst.QuantizedAssetMmapDirect = src.QuantizedAssetMmapDirect
+	dst.QuantizedAssetHeapCopy = src.QuantizedAssetHeapCopy
+	dst.QuantizedAssetOpenNanos = src.QuantizedAssetOpenNanos
+	dst.QuantizedAssetMappedBytes = src.QuantizedAssetMappedBytes
+	dst.QuantizedAssetHeapCopyBytes = src.QuantizedAssetHeapCopyBytes
+	dst.QuantizedAssetActiveHandles = src.QuantizedAssetActiveHandles
+	if src.CandidateRows != 0 && dst.CandidateRows == 0 {
+		dst.CandidateRows = src.CandidateRows
+	}
+	if src.PreparedGraphSearchViews != 0 {
+		dst.PreparedGraphSearchViews = src.PreparedGraphSearchViews
+	}
+}
+
+func (r *columnVectorGraphPhysicalRowReader) populateScalarU8PreparedTraversalSearchStats(stats *columnVectorGraphNativeSearchStats) {
+	if r == nil || stats == nil {
+		return
+	}
+	r.populateTypedColumnVectorSearchStats(stats)
+	r.populateInvNormStateSearchStats(stats)
+	r.populateRowRefStateSearchStats(stats)
+	r.populateDocumentIDStateSearchStats(stats)
+	r.populateLayer0AdjacencySourceSearchStats(stats)
+}

--- a/TreeDB/collections/column_hnsw_prepared_quantized_search.go
+++ b/TreeDB/collections/column_hnsw_prepared_quantized_search.go
@@ -68,6 +68,9 @@ func (r *columnVectorGraphPhysicalRowReader) SearchCosineScalarU8PreparedTravers
 	if pack.Header.Rows != rowCount || pack.Header.Dimensions != r.def.Dimensions {
 		return nil, setupStats, fmt.Errorf("%w: column_graph %q hnsw_search_pack_v1 shape rows/dims=(%d,%d) want (%d,%d)", errColumnHNSWPreparedQuantizedTraversalUnavailable, r.def.Name, pack.Header.Rows, pack.Header.Dimensions, rowCount, r.def.Dimensions)
 	}
+	if len(query) != r.def.Dimensions {
+		return nil, setupStats, fmt.Errorf("collections: column_graph %q hnsw prepared quantized traversal query dims=%d want %d: %w", r.def.Name, len(query), r.def.Dimensions, errColumnVectorGraphNativeSearchQueryDimensionMismatch)
+	}
 	topK := opts.TopK
 	if topK < 0 {
 		return nil, columnVectorGraphNativeSearchStats{}, fmt.Errorf("collections: column_graph %q native search top_k cannot be negative: %w", r.def.Name, errColumnVectorGraphNativeSearchTopKNegative)

--- a/TreeDB/collections/column_hnsw_prepared_traversal.go
+++ b/TreeDB/collections/column_hnsw_prepared_traversal.go
@@ -239,7 +239,7 @@ func (v *columnHNSWSearchPackPreparedView) searchCosinePreparedScorePlane(query 
 	if opts.OmitResultMaterialization && !opts.SuppressOmittedResultMaterialization {
 		resultScratchK = retainedCandidateLimit
 	}
-	if err := scratch.prepareHNSWSearchPack(rowCount, v.Header.VectorStride, degree, resultScratchK, retainedCandidateLimit); err != nil {
+	if err := scratch.prepareHNSWSearchPack(rowCount, v.Header.VectorStride, degree, resultScratchK, retainedCandidateLimit, degree, degree); err != nil {
 		return nil, *stats, fmt.Errorf("collections: hnsw_search_pack_v1 prepared traversal scratch prepare: %w", err)
 	}
 	if err := scorePlane.prepareForHNSWPreparedTraversal(v, query, opts, scratch); err != nil {

--- a/TreeDB/collections/column_hnsw_prepared_traversal.go
+++ b/TreeDB/collections/column_hnsw_prepared_traversal.go
@@ -43,6 +43,10 @@ type columnHNSWPreparedTraversalOptions struct {
 	// result IDs or row refs from the pack. Future quantized rerank callers can use
 	// this to collect an explicit score-plane shortlist before exact reranking.
 	OmitResultMaterialization bool
+	// SuppressOmittedResultMaterialization keeps the retained candidates in
+	// scratch.top for internal rerank callers without also appending ordinal-only
+	// results that the caller will immediately discard.
+	SuppressOmittedResultMaterialization bool
 }
 
 // columnHNSWPreparedTraversalScorePlane is the explicit scoring seam for the
@@ -163,43 +167,44 @@ func (p *columnHNSWPreparedQuantizedScorePlane) scoreOrdinals(ordinals []int, ds
 }
 
 func (v *columnHNSWSearchPackPreparedView) searchCosinePreparedScorePlane(query []float32, opts columnHNSWPreparedTraversalOptions, scratch *columnVectorGraphNativeSearchScratch, scorePlane columnHNSWPreparedTraversalScorePlane) ([]columnVectorGraphNativeSearchResult, columnVectorGraphNativeSearchStats, error) {
-	var stats columnVectorGraphNativeSearchStats
 	if v == nil {
-		return nil, stats, errColumnHNSWSearchPackSearchUnavailable
+		return nil, columnVectorGraphNativeSearchStats{}, errColumnHNSWSearchPackSearchUnavailable
 	}
 	switch status := v.fastStatus(""); status {
 	case columnHNSWSearchPackPreparedStatusDirect, columnHNSWSearchPackPreparedStatusHeap:
 	default:
-		return nil, stats, columnHNSWSearchPackStatusError(status)
+		return nil, columnVectorGraphNativeSearchStats{}, columnHNSWSearchPackStatusError(status)
 	}
 	if scratch == nil {
-		return nil, stats, errColumnVectorGraphNativeSearchScratchRequired
+		return nil, columnVectorGraphNativeSearchStats{}, errColumnVectorGraphNativeSearchScratchRequired
 	}
+	stats := &scratch.preparedTraversalStats
+	*stats = columnVectorGraphNativeSearchStats{}
 	if scorePlane == nil {
-		return nil, stats, errColumnHNSWPreparedTraversalScorePlaneUnavailable
+		return nil, *stats, errColumnHNSWPreparedTraversalScorePlaneUnavailable
 	}
 	if len(query) != v.Header.Dimensions {
-		return nil, stats, fmt.Errorf("collections: hnsw_search_pack_v1 prepared traversal query dims=%d want %d: %w", len(query), v.Header.Dimensions, errColumnVectorGraphNativeSearchQueryDimensionMismatch)
+		return nil, *stats, fmt.Errorf("collections: hnsw_search_pack_v1 prepared traversal query dims=%d want %d: %w", len(query), v.Header.Dimensions, errColumnVectorGraphNativeSearchQueryDimensionMismatch)
 	}
 	statsMode := opts.StatsMode.normalized()
 	if !columnHNSWSearchPackStatsModeSupportedForSearch(statsMode) {
-		return nil, stats, errColumnHNSWSearchPackSearchUnsupportedMode
+		return nil, *stats, errColumnHNSWSearchPackSearchUnsupportedMode
 	}
 	rowCount := v.Header.Rows
 	topK := opts.TopK
 	if topK < 0 {
-		return nil, stats, errColumnVectorGraphNativeSearchTopKNegative
+		return nil, *stats, errColumnVectorGraphNativeSearchTopKNegative
 	}
 	efSearch := opts.EfSearch
 	if efSearch < 0 {
-		return nil, stats, errColumnVectorGraphNativeSearchEfSearchNegative
+		return nil, *stats, errColumnVectorGraphNativeSearchEfSearchNegative
 	}
 	retainedCandidateLimit := opts.RetainedCandidateLimit
 	if retainedCandidateLimit < 0 {
-		return nil, stats, fmt.Errorf("collections: hnsw_search_pack_v1 prepared traversal retained candidates=%d cannot be negative", retainedCandidateLimit)
+		return nil, *stats, fmt.Errorf("collections: hnsw_search_pack_v1 prepared traversal retained candidates=%d cannot be negative", retainedCandidateLimit)
 	}
 	if topK == 0 || rowCount == 0 {
-		return nil, stats, nil
+		return nil, *stats, nil
 	}
 	stats.CandidateRows = uint64(rowCount)
 	if topK > rowCount {
@@ -218,7 +223,7 @@ func (v *columnHNSWSearchPackPreparedView) searchCosinePreparedScorePlane(query 
 		retainedCandidateLimit = efSearch
 	}
 	if retainedCandidateLimit < topK {
-		return nil, stats, fmt.Errorf("collections: hnsw_search_pack_v1 prepared traversal retained candidates=%d below normalized top_k=%d", retainedCandidateLimit, topK)
+		return nil, *stats, fmt.Errorf("collections: hnsw_search_pack_v1 prepared traversal retained candidates=%d below normalized top_k=%d", retainedCandidateLimit, topK)
 	}
 	if retainedCandidateLimit > rowCount {
 		retainedCandidateLimit = rowCount
@@ -230,34 +235,38 @@ func (v *columnHNSWSearchPackPreparedView) searchCosinePreparedScorePlane(query 
 	if degree <= math.MaxInt/2 {
 		degree *= 2
 	}
-	if err := scratch.prepareHNSWSearchPack(rowCount, v.Header.VectorStride, degree, topK, retainedCandidateLimit); err != nil {
-		return nil, stats, fmt.Errorf("collections: hnsw_search_pack_v1 prepared traversal scratch prepare: %w", err)
+	resultScratchK := topK
+	if opts.OmitResultMaterialization && !opts.SuppressOmittedResultMaterialization {
+		resultScratchK = retainedCandidateLimit
+	}
+	if err := scratch.prepareHNSWSearchPack(rowCount, v.Header.VectorStride, degree, resultScratchK, retainedCandidateLimit); err != nil {
+		return nil, *stats, fmt.Errorf("collections: hnsw_search_pack_v1 prepared traversal scratch prepare: %w", err)
 	}
 	if err := scorePlane.prepareForHNSWPreparedTraversal(v, query, opts, scratch); err != nil {
-		return nil, stats, fmt.Errorf("collections: hnsw_search_pack_v1 prepared traversal %s score plane: %w", scorePlane.kind(), err)
+		return nil, *stats, fmt.Errorf("collections: hnsw_search_pack_v1 prepared traversal %s score plane: %w", scorePlane.kind(), err)
 	}
 	countLoopEdges := !statsMode.minimal()
 	var loopEdgeVisits uint64
 	var visitedCandidates uint64
 	entryOrdinal := v.Header.EntryOrdinal
 	if entryOrdinal < 0 || entryOrdinal >= rowCount {
-		return nil, stats, fmt.Errorf("collections: hnsw_search_pack_v1 prepared traversal entry ordinal=%d outside rows=%d", entryOrdinal, rowCount)
+		return nil, *stats, fmt.Errorf("collections: hnsw_search_pack_v1 prepared traversal entry ordinal=%d outside rows=%d", entryOrdinal, rowCount)
 	}
 	maxLayer, err := v.maxLayerForOrdinal(entryOrdinal)
 	if err != nil {
-		return nil, stats, err
+		return nil, *stats, err
 	}
 	for layer := maxLayer; layer > 0; layer-- {
-		entryOrdinal, err = v.greedyNearestAtLayerPreparedScorePlane(scorePlane, entryOrdinal, layer, scratch, &stats, countLoopEdges, &loopEdgeVisits)
+		entryOrdinal, err = v.greedyNearestAtLayerPreparedScorePlane(scorePlane, entryOrdinal, layer, scratch, stats, countLoopEdges, &loopEdgeVisits)
 		if err != nil {
-			return nil, stats, err
+			return nil, *stats, err
 		}
 	}
 	visitMarks := scratch.visitMarks
 	visitEpoch := scratch.visitEpoch
 	visitMarks[entryOrdinal] = visitEpoch
-	if err := v.scoreAndPushFrontierVisitedPreparedScorePlane(scorePlane, entryOrdinal, retainedCandidateLimit, scratch, &stats, &visitedCandidates); err != nil {
-		return nil, stats, err
+	if err := v.scoreAndPushFrontierVisitedPreparedScorePlane(scorePlane, entryOrdinal, retainedCandidateLimit, scratch, stats, &visitedCandidates); err != nil {
+		return nil, *stats, err
 	}
 	nextSeed := 0
 	rowCount64 := uint64(rowCount)
@@ -273,29 +282,29 @@ func (v *columnHNSWSearchPackPreparedView) searchCosinePreparedScorePlane(query 
 			}
 			nextSeed = seed + 1
 			visitMarks[seed] = visitEpoch
-			if err := v.scoreAndPushFrontierVisitedPreparedScorePlane(scorePlane, seed, retainedCandidateLimit, scratch, &stats, &visitedCandidates); err != nil {
-				return nil, stats, err
+			if err := v.scoreAndPushFrontierVisitedPreparedScorePlane(scorePlane, seed, retainedCandidateLimit, scratch, stats, &visitedCandidates); err != nil {
+				return nil, *stats, err
 			}
 			continue
 		}
 		if columnVectorGraphLayer0SearchShouldStop(candidate, scratch.top, retainedCandidateLimit) {
 			break
 		}
-		adjacency, err := v.adjacencyLayerForOrdinal(candidate.ordinal, 0, &stats)
+		adjacency, err := v.adjacencyLayerForOrdinal(candidate.ordinal, 0, stats)
 		if err != nil {
-			return nil, stats, err
+			return nil, *stats, err
 		}
 		if len(adjacency) == 0 {
 			continue
 		}
+		if countLoopEdges {
+			loopEdgeVisits += uint64(len(adjacency))
+		}
 		scratch.scoreTileOrdinals = ensureColumnVectorGraphNativeIntScratch(scratch.scoreTileOrdinals, len(adjacency))
 		tile := scratch.scoreTileOrdinals[:0]
 		for i, neighbor := range adjacency {
-			if countLoopEdges {
-				loopEdgeVisits++
-			}
 			if uint64(neighbor) >= rowCount64 {
-				return nil, stats, fmt.Errorf("collections: hnsw_search_pack_v1 prepared traversal ordinal=%d adjacency[%d]=%d outside row_count=%d: %w", candidate.ordinal, i, neighbor, rowCount, errColumnVectorGraphAdjacencyOrdinalOutOfBounds)
+				return nil, *stats, fmt.Errorf("collections: hnsw_search_pack_v1 prepared traversal ordinal=%d adjacency[%d]=%d outside row_count=%d: %w", candidate.ordinal, i, neighbor, rowCount, errColumnVectorGraphAdjacencyOrdinalOutOfBounds)
 			}
 			neighborOrdinal := int(neighbor)
 			if visitMarks[neighborOrdinal] == visitEpoch {
@@ -305,8 +314,8 @@ func (v *columnHNSWSearchPackPreparedView) searchCosinePreparedScorePlane(query 
 			tile = append(tile, neighborOrdinal)
 		}
 		if len(tile) != 0 {
-			if err := v.scoreAndPushFrontierVisitedTilePreparedScorePlane(scorePlane, tile, retainedCandidateLimit, scratch, &stats, &visitedCandidates); err != nil {
-				return nil, stats, err
+			if err := v.scoreAndPushFrontierVisitedTilePreparedScorePlane(scorePlane, tile, retainedCandidateLimit, scratch, stats, &visitedCandidates); err != nil {
+				return nil, *stats, err
 			}
 		}
 	}
@@ -316,24 +325,27 @@ func (v *columnHNSWSearchPackPreparedView) searchCosinePreparedScorePlane(query 
 		stats.Candidates = visitedCandidates
 	}
 	if len(scratch.top) == 0 {
-		return scratch.results, stats, nil
+		return scratch.results, *stats, nil
 	}
 	if opts.OmitResultMaterialization {
 		if len(scratch.top) > retainedCandidateLimit {
 			scratch.top = scratch.top[:retainedCandidateLimit]
 		}
+		if opts.SuppressOmittedResultMaterialization {
+			return scratch.results, *stats, nil
+		}
 		for _, candidate := range scratch.top {
 			scratch.results = append(scratch.results, columnVectorGraphNativeSearchResult{Ordinal: candidate.ordinal, Score: candidate.score})
 		}
-		return scratch.results, stats, nil
+		return scratch.results, *stats, nil
 	}
 	if len(scratch.top) > topK {
 		scratch.top = scratch.top[:topK]
 	}
-	if err := v.fetchTopSearchResults(scratch, &stats); err != nil {
-		return nil, stats, err
+	if err := v.fetchTopSearchResults(scratch, stats); err != nil {
+		return nil, *stats, err
 	}
-	return scratch.results, stats, nil
+	return scratch.results, *stats, nil
 }
 
 func (v *columnHNSWSearchPackPreparedView) greedyNearestAtLayerPreparedScorePlane(scorePlane columnHNSWPreparedTraversalScorePlane, entryOrdinal int, layer int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats, countLoopEdges bool, loopEdgeVisits *uint64) (int, error) {
@@ -352,12 +364,12 @@ func (v *columnHNSWSearchPackPreparedView) greedyNearestAtLayerPreparedScorePlan
 		if len(adjacency) == 0 {
 			continue
 		}
+		if countLoopEdges && loopEdgeVisits != nil {
+			*loopEdgeVisits += uint64(len(adjacency))
+		}
 		scratch.scoreTileOrdinals = ensureColumnVectorGraphNativeIntScratch(scratch.scoreTileOrdinals, len(adjacency))
 		tile := scratch.scoreTileOrdinals[:0]
 		for i, neighbor := range adjacency {
-			if countLoopEdges && loopEdgeVisits != nil {
-				(*loopEdgeVisits)++
-			}
 			if uint64(neighbor) >= uint64(v.Header.Rows) {
 				return 0, fmt.Errorf("collections: hnsw_search_pack_v1 prepared traversal ordinal=%d layer=%d adjacency[%d]=%d outside row_count=%d: %w", best, layer, i, neighbor, v.Header.Rows, errColumnVectorGraphAdjacencyOrdinalOutOfBounds)
 			}

--- a/TreeDB/collections/column_hnsw_search_pack_search.go
+++ b/TreeDB/collections/column_hnsw_search_pack_search.go
@@ -80,7 +80,7 @@ func (v *columnHNSWSearchPackPreparedView) searchCosine(query []float32, opts co
 	if degree <= math.MaxInt/2 {
 		degree *= 2
 	}
-	if err := scratch.prepareHNSWSearchPack(rowCount, v.Header.VectorStride, degree, topK, efSearch); err != nil {
+	if err := scratch.prepareHNSWSearchPack(rowCount, v.Header.VectorStride, degree, topK, efSearch, 0, 0); err != nil {
 		return nil, stats, fmt.Errorf("collections: hnsw_search_pack_v1 search scratch prepare: %w", err)
 	}
 	queryInvNorm, err := columnVectorGraphInvNorm(query)

--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -1002,6 +1002,8 @@ type columnVectorGraphNativeSearchScratch struct {
 	quantizedQueryCentered   []vectorops.ScalarU8CenteredCode
 	quantizedRabitQWorkspace rabitq.Workspace
 	quantizedBRQWorkspace    brq.Workspace
+	preparedQuantizedPlane   columnHNSWPreparedQuantizedScorePlane
+	preparedTraversalStats   columnVectorGraphNativeSearchStats
 	wavefrontCandidates      []columnVectorGraphSearchCandidate
 	searchPlan               columnVectorGraphSearchPlan
 }
@@ -1059,9 +1061,9 @@ func (s *columnVectorGraphNativeSearchScratch) prepareHNSWSearchPack(rowCount, v
 	s.scoreTileScores = resizeColumnVectorGraphNativeFloat64Scratch(s.scoreTileScores, degree)
 	s.scoreTileRowIDs = resizeColumnVectorGraphNativeUint32Scratch(s.scoreTileRowIDs, degree)
 	s.scoreTileDots = resizeColumnVectorGraphNativeFloat32Scratch(s.scoreTileDots, degree)
+	s.scoreTileOrdinals = resizeColumnVectorGraphNativeIntScratch(s.scoreTileOrdinals, degree)
+	s.scoreTileQuantizedDots = resizeColumnVectorGraphNativeInt64Scratch(s.scoreTileQuantizedDots, degree)
 	s.idBuffers = resizeColumnVectorGraphNativeIDBuffersScratch(s.idBuffers, 0)
-	s.scoreTileOrdinals = resizeColumnVectorGraphNativeIntScratch(s.scoreTileOrdinals, 0)
-	s.scoreTileQuantizedDots = resizeColumnVectorGraphNativeInt64Scratch(s.scoreTileQuantizedDots, 0)
 	s.wavefrontCandidates = resizeColumnVectorGraphNativeCandidateScratch(s.wavefrontCandidates, 0)
 	return nil
 }

--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -1039,12 +1039,12 @@ func (s *columnVectorGraphNativeSearchScratch) prepare(rowCount, dimensions, deg
 	return nil
 }
 
-func (s *columnVectorGraphNativeSearchScratch) prepareHNSWSearchPack(rowCount, vectorStride, degree, topK, efSearch int) error {
+func (s *columnVectorGraphNativeSearchScratch) prepareHNSWSearchPack(rowCount, vectorStride, degree, topK, efSearch, ordinalTileCapacity, quantizedDotCapacity int) error {
 	if s == nil {
 		return errColumnVectorGraphNativeSearchScratchRequired
 	}
-	if rowCount < 0 || vectorStride < 0 || degree < 0 || topK < 0 || efSearch < 0 {
-		return fmt.Errorf("collections: hnsw_search_pack_v1 search received negative sizing input: rowCount=%d vectorStride=%d degree=%d topK=%d efSearch=%d", rowCount, vectorStride, degree, topK, efSearch)
+	if rowCount < 0 || vectorStride < 0 || degree < 0 || topK < 0 || efSearch < 0 || ordinalTileCapacity < 0 || quantizedDotCapacity < 0 {
+		return fmt.Errorf("collections: hnsw_search_pack_v1 search received negative sizing input: rowCount=%d vectorStride=%d degree=%d topK=%d efSearch=%d ordinalTileCapacity=%d quantizedDotCapacity=%d", rowCount, vectorStride, degree, topK, efSearch, ordinalTileCapacity, quantizedDotCapacity)
 	}
 	clearColumnVectorGraphNativeRowScratchViews(&s.scoreScratch)
 	clearColumnVectorGraphNativeRowScratchViews(&s.expandScratch)
@@ -1061,9 +1061,9 @@ func (s *columnVectorGraphNativeSearchScratch) prepareHNSWSearchPack(rowCount, v
 	s.scoreTileScores = resizeColumnVectorGraphNativeFloat64Scratch(s.scoreTileScores, degree)
 	s.scoreTileRowIDs = resizeColumnVectorGraphNativeUint32Scratch(s.scoreTileRowIDs, degree)
 	s.scoreTileDots = resizeColumnVectorGraphNativeFloat32Scratch(s.scoreTileDots, degree)
-	s.scoreTileOrdinals = resizeColumnVectorGraphNativeIntScratch(s.scoreTileOrdinals, degree)
-	s.scoreTileQuantizedDots = resizeColumnVectorGraphNativeInt64Scratch(s.scoreTileQuantizedDots, degree)
 	s.idBuffers = resizeColumnVectorGraphNativeIDBuffersScratch(s.idBuffers, 0)
+	s.scoreTileOrdinals = resizeColumnVectorGraphNativeIntScratch(s.scoreTileOrdinals, ordinalTileCapacity)
+	s.scoreTileQuantizedDots = resizeColumnVectorGraphNativeInt64Scratch(s.scoreTileQuantizedDots, quantizedDotCapacity)
 	s.wavefrontCandidates = resizeColumnVectorGraphNativeCandidateScratch(s.wavefrontCandidates, 0)
 	return nil
 }

--- a/TreeDB/collections/vector_index_search.go
+++ b/TreeDB/collections/vector_index_search.go
@@ -961,6 +961,13 @@ func (s *VectorIndexSearcher) hnswSearchPackSearchWithBufferRoute(queryMode colu
 	return pack, vectorIndexSearchRouteStatsForHNSWSearchPackRoute(cached), true
 }
 
+func (s *VectorIndexSearcher) scalarU8PreparedTraversalSearchWithBufferRoute(queryMode columnVectorGraphNativeSearchQueryMode, statsMode columnVectorGraphNativeSearchStatsMode, quantizedIndexName string) (*columnHNSWSearchPackPreparedView, bool) {
+	if s == nil {
+		return nil, false
+	}
+	return collectionScalarU8PreparedTraversalPackForReader(s.reader, queryMode, statsMode, quantizedIndexName)
+}
+
 func (r vectorIndexSearchRouteStats) apply(stats *VectorIndexSearchStats) {
 	if stats == nil {
 		return
@@ -1764,6 +1771,29 @@ func (s *VectorIndexSearcher) SearchWithBuffer(opts VectorIndexSearcherSearchOpt
 	pack, routeStats, usePackRoute := s.hnswSearchPackSearchWithBufferRoute(queryMode, statsMode)
 	if usePackRoute {
 		results, searchStats, err := pack.searchCosine(opts.Query, columnVectorGraphNativeSearchOptions{
+			TopK:                      opts.TopK,
+			EfSearch:                  opts.EfSearch,
+			ScoreBatchMode:            opts.scoreBatchMode,
+			StatsMode:                 statsMode,
+			QueryMode:                 queryMode,
+			QuantizedIndexName:        opts.QuantizedIndexName,
+			QuantizedRerankCandidates: opts.QuantizedRerankCandidates,
+		}, &s.scratch)
+		response.Stats = vectorIndexSearchStatsFromInternal(searchStats, columnPhysicalRowReaderStats{})
+		routeStats.apply(&response.Stats)
+		if err != nil {
+			clear(previousResults)
+			return response, err
+		}
+		response.Results, err = copyVectorIndexSearchResultsToBuffer(results, buffer, previousResults)
+		if err != nil {
+			return response, err
+		}
+		return response, nil
+	}
+
+	if pack, ok := s.scalarU8PreparedTraversalSearchWithBufferRoute(queryMode, statsMode, opts.QuantizedIndexName); ok {
+		results, searchStats, err := s.reader.SearchCosineScalarU8PreparedTraversal(pack, opts.Query, columnVectorGraphNativeSearchOptions{
 			TopK:                      opts.TopK,
 			EfSearch:                  opts.EfSearch,
 			ScoreBatchMode:            opts.scoreBatchMode,

--- a/TreeDB/collections/vector_index_search_test.go
+++ b/TreeDB/collections/vector_index_search_test.go
@@ -779,6 +779,14 @@ func TestScalarU8QuantizedPreparedTraversalPackRouteWhenAdjacencyClosed2586(t *t
 	query := []float32{0.8, 0.2, 0}
 	qName := def.QuantizedIndexes[0].Name
 	var buffer VectorIndexSearchBuffer
+	badTopK0, err := searcher.SearchWithBuffer(VectorIndexSearcherSearchOptions{Query: []float32{0.8, 0.2}, QueryMode: VectorIndexQueryModeQuantizedOnly, QuantizedIndexName: qName, TopK: 0, EfSearch: len(rows), StatsMode: VectorIndexSearchStatsModeProduction}, &buffer)
+	if !errors.Is(err, errColumnVectorGraphNativeSearchQueryDimensionMismatch) {
+		t.Fatalf("quantized_only topK=0 bad dims response=%+v err=%v want dimension mismatch", badTopK0, err)
+	}
+	badRerankTopK0, err := searcher.SearchWithBuffer(VectorIndexSearcherSearchOptions{Query: []float32{0.8, 0.2}, QueryMode: VectorIndexQueryModeQuantizedRerank, QuantizedIndexName: qName, TopK: 0, EfSearch: len(rows), StatsMode: VectorIndexSearchStatsModeProduction}, &buffer)
+	if !errors.Is(err, errColumnVectorGraphNativeSearchQueryDimensionMismatch) {
+		t.Fatalf("quantized_rerank topK=0 bad dims response=%+v err=%v want dimension mismatch", badRerankTopK0, err)
+	}
 	quantizedOnly, err := searcher.SearchWithBuffer(VectorIndexSearcherSearchOptions{Query: query, QueryMode: VectorIndexQueryModeQuantizedOnly, QuantizedIndexName: qName, TopK: 3, EfSearch: len(rows), StatsMode: VectorIndexSearchStatsModeProduction}, &buffer)
 	if err != nil {
 		t.Fatalf("quantized_only SearchWithBuffer with closed prepared adjacency: %v", err)

--- a/TreeDB/collections/vector_index_search_test.go
+++ b/TreeDB/collections/vector_index_search_test.go
@@ -767,6 +767,10 @@ func TestScalarU8QuantizedPreparedTraversalPackRouteWhenAdjacencyClosed2586(t *t
 	if searcher.reader == nil || searcher.reader.hnswSearchPack == nil || searcher.reader.adjacencyLayerSources == nil {
 		t.Fatalf("searcher missing prepared pack or adjacency state")
 	}
+	packStatus := searcher.reader.hnswSearchPack.fastStatus(searcher.reader.hnswSearchPackStatus)
+	if packStatus != columnHNSWSearchPackPreparedStatusDirect && packStatus != columnHNSWSearchPackPreparedStatusHeap {
+		t.Fatalf("searcher prepared pack status=%s", packStatus)
+	}
 	if err := searcher.reader.adjacencyLayerSources.Close(); err != nil {
 		t.Fatalf("close adjacency sources: %v", err)
 	}
@@ -781,9 +785,7 @@ func TestScalarU8QuantizedPreparedTraversalPackRouteWhenAdjacencyClosed2586(t *t
 	}
 	assertVectorIndexSearchResultsV4(t, quantizedOnly.Results, scalarU8QuantizedTopKForTest1926(t, rows, query, 3), false)
 	assertQuantizedOnlyGuardrailStats2416(t, quantizedOnly.Stats, def.Dimensions)
-	if quantizedOnly.Stats.AdjacencyPreparedCSRDirectViews == 0 || quantizedOnly.Stats.AdjacencySourceFallbacks != 0 {
-		t.Fatalf("quantized_only stats=%+v want pack CSR adjacency with no source fallback", quantizedOnly.Stats)
-	}
+	assertScalarU8PreparedTraversalPackAdjacencyStats2586(t, quantizedOnly.Stats, packStatus, "quantized_only")
 
 	reranked, err := searcher.SearchWithBuffer(VectorIndexSearcherSearchOptions{Query: query, QueryMode: VectorIndexQueryModeQuantizedRerank, QuantizedIndexName: qName, QuantizedRerankCandidates: len(rows), TopK: 3, EfSearch: len(rows), StatsMode: VectorIndexSearchStatsModeProduction}, &buffer)
 	if err != nil {
@@ -791,8 +793,9 @@ func TestScalarU8QuantizedPreparedTraversalPackRouteWhenAdjacencyClosed2586(t *t
 	}
 	assertVectorIndexSearchResultsV4(t, reranked.Results, exactColumnGraphTopKForTest(t, rows, query, 3), false)
 	assertQuantizedRerankNoDocumentGuardrailStats2416(t, reranked.Stats, len(rows))
-	if reranked.Stats.AdjacencyPreparedCSRDirectViews == 0 || reranked.Stats.QuantizedRerankExactScoreCalls != uint64(len(rows)) {
-		t.Fatalf("quantized_rerank stats=%+v want pack CSR traversal and exact rerank shortlist", reranked.Stats)
+	assertScalarU8PreparedTraversalPackAdjacencyStats2586(t, reranked.Stats, packStatus, "quantized_rerank")
+	if reranked.Stats.QuantizedRerankExactScoreCalls != uint64(len(rows)) {
+		t.Fatalf("quantized_rerank stats=%+v want exact rerank shortlist", reranked.Stats)
 	}
 }
 
@@ -822,8 +825,8 @@ func TestScalarU8QuantizedPreparedTraversalRerankPreservesEfTraversal2586(t *tes
 		t.Fatalf("OpenVectorIndexSearcher fallback: %v", err)
 	}
 	defer func() { _ = fallbackSearcher.Close() }()
-	if fallbackSearcher.reader == nil || fallbackSearcher.reader.hnswSearchPack == nil || fallbackSearcher.reader.preparedSearch == nil {
-		t.Fatalf("fallback searcher missing prepared state")
+	if fallbackSearcher.reader == nil || fallbackSearcher.reader.hnswSearchPack == nil {
+		t.Fatalf("fallback searcher missing reader or prepared pack")
 	}
 	fallbackSearcher.reader.hnswSearchPack = nil
 
@@ -883,9 +886,14 @@ func TestSearchVectorIndexWithBufferScalarU8PreparedTraversalPackRouteWhenAdjace
 	if err != nil || len(warm.Results) != quantizedOnlyOpts.TopK {
 		t.Fatalf("warm SearchVectorIndexWithBuffer results=%d err=%v", len(warm.Results), err)
 	}
+	packStatus := columnHNSWSearchPackPreparedStatusMissing
 	mutateCachedCollectionQuantizedReader2586(t, col, quantizedOnlyOpts, func(reader *columnVectorGraphPhysicalRowReader) {
 		if reader.hnswSearchPack == nil || reader.adjacencyLayerSources == nil {
 			t.Fatalf("cached reader missing prepared pack or adjacency state")
+		}
+		packStatus = reader.hnswSearchPack.fastStatus(reader.hnswSearchPackStatus)
+		if packStatus != columnHNSWSearchPackPreparedStatusDirect && packStatus != columnHNSWSearchPackPreparedStatusHeap {
+			t.Fatalf("cached prepared pack status=%s", packStatus)
 		}
 		if err := reader.adjacencyLayerSources.Close(); err != nil {
 			t.Fatalf("close cached adjacency sources: %v", err)
@@ -900,9 +908,7 @@ func TestSearchVectorIndexWithBufferScalarU8PreparedTraversalPackRouteWhenAdjace
 	assertVectorIndexSearchResultsV4(t, quantizedOnly.Results, scalarU8QuantizedTopKForTest1926(t, rows, query, quantizedOnlyOpts.TopK), false)
 	assertQuantizedOnlyGuardrailStats2416(t, quantizedOnly.Stats, def.Dimensions)
 	assertCollectionBufferedQuantizedRouteStats2415(t, quantizedOnly.Stats, columnVectorGraphNativeSearchQueryModeQuantizedOnly, quantizedOnlyOpts, def.Dimensions)
-	if quantizedOnly.Stats.AdjacencyPreparedCSRDirectViews == 0 || quantizedOnly.Stats.AdjacencySourceFallbacks != 0 {
-		t.Fatalf("collection quantized_only stats=%+v want pack CSR adjacency with no source fallback", quantizedOnly.Stats)
-	}
+	assertScalarU8PreparedTraversalPackAdjacencyStats2586(t, quantizedOnly.Stats, packStatus, "collection quantized_only")
 
 	rerankOpts := quantizedOnlyOpts
 	rerankOpts.QueryMode = VectorIndexQueryModeQuantizedRerank
@@ -914,8 +920,9 @@ func TestSearchVectorIndexWithBufferScalarU8PreparedTraversalPackRouteWhenAdjace
 	assertVectorIndexSearchResultsV4(t, reranked.Results, exactColumnGraphTopKForTest(t, rows, query, rerankOpts.TopK), false)
 	assertQuantizedRerankNoDocumentGuardrailStats2416(t, reranked.Stats, rerankOpts.QuantizedRerankCandidates)
 	assertCollectionBufferedQuantizedRouteStats2415(t, reranked.Stats, columnVectorGraphNativeSearchQueryModeQuantizedRerank, rerankOpts, def.Dimensions)
-	if reranked.Stats.AdjacencyPreparedCSRDirectViews == 0 || reranked.Stats.QuantizedRerankExactScoreCalls != uint64(rerankOpts.QuantizedRerankCandidates) {
-		t.Fatalf("collection quantized_rerank stats=%+v want pack CSR traversal and exact rerank shortlist", reranked.Stats)
+	assertScalarU8PreparedTraversalPackAdjacencyStats2586(t, reranked.Stats, packStatus, "collection quantized_rerank")
+	if reranked.Stats.QuantizedRerankExactScoreCalls != uint64(rerankOpts.QuantizedRerankCandidates) {
+		t.Fatalf("collection quantized_rerank stats=%+v want exact rerank shortlist", reranked.Stats)
 	}
 }
 
@@ -1257,6 +1264,25 @@ func assertCollectionBufferedQuantizedRouteStats2415(tb testing.TB, stats Vector
 	tb.Helper()
 	if !vectorIndexSearchStatsAreBufferedNoDocumentQuantizedRoute(stats, mode, opts, dims) {
 		tb.Fatalf("collection buffered quantized stats=%+v want healthy no-document quantized route", stats)
+	}
+}
+
+func assertScalarU8PreparedTraversalPackAdjacencyStats2586(tb testing.TB, stats VectorIndexSearchStats, packStatus columnHNSWSearchPackPreparedStatus, label string) {
+	tb.Helper()
+	if stats.AdjacencySourceFallbacks != 0 {
+		tb.Fatalf("%s stats=%+v want pack traversal with no source fallback", label, stats)
+	}
+	switch packStatus {
+	case columnHNSWSearchPackPreparedStatusDirect:
+		if stats.AdjacencyPreparedCSRDirectViews == 0 {
+			tb.Fatalf("%s stats=%+v want direct pack CSR adjacency", label, stats)
+		}
+	case columnHNSWSearchPackPreparedStatusHeap:
+		if stats.AdjacencyHeapCopyTypedViews == 0 {
+			tb.Fatalf("%s stats=%+v want heap-copy pack adjacency", label, stats)
+		}
+	default:
+		tb.Fatalf("%s unexpected pack status=%s", label, packStatus)
 	}
 }
 

--- a/TreeDB/collections/vector_index_search_test.go
+++ b/TreeDB/collections/vector_index_search_test.go
@@ -746,6 +746,179 @@ func TestSearchVectorIndexWithBufferQuantizedOnlyAndRerank2415(t *testing.T) {
 	}
 }
 
+func TestScalarU8QuantizedPreparedTraversalPackRouteWhenAdjacencyClosed2586(t *testing.T) {
+	rows := []columnGraphRebuildInputRowV2A{
+		{id: "doc-a", vector: []float32{1, 0, 0}},
+		{id: "doc-b", vector: []float32{0.9, 0.1, 0}},
+		{id: "doc-c", vector: []float32{0, 1, 0}},
+		{id: "doc-d", vector: []float32{0, 0, 1}},
+		{id: "doc-e", vector: []float32{0.4, 0.6, 0}},
+	}
+	_, d, col, def := openColumnGraphQuantizedGuardrailTestCollection1926(t, rows)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	searcher, err := col.OpenVectorIndexSearcher(VectorIndexSearcherOptions{IndexName: def.Name, MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("OpenVectorIndexSearcher: %v", err)
+	}
+	defer func() { _ = searcher.Close() }()
+	if searcher.reader == nil || searcher.reader.hnswSearchPack == nil || searcher.reader.adjacencyLayerSources == nil {
+		t.Fatalf("searcher missing prepared pack or adjacency state")
+	}
+	if err := searcher.reader.adjacencyLayerSources.Close(); err != nil {
+		t.Fatalf("close adjacency sources: %v", err)
+	}
+	searcher.reader.preparedSearch = nil
+
+	query := []float32{0.8, 0.2, 0}
+	qName := def.QuantizedIndexes[0].Name
+	var buffer VectorIndexSearchBuffer
+	quantizedOnly, err := searcher.SearchWithBuffer(VectorIndexSearcherSearchOptions{Query: query, QueryMode: VectorIndexQueryModeQuantizedOnly, QuantizedIndexName: qName, TopK: 3, EfSearch: len(rows), StatsMode: VectorIndexSearchStatsModeProduction}, &buffer)
+	if err != nil {
+		t.Fatalf("quantized_only SearchWithBuffer with closed prepared adjacency: %v", err)
+	}
+	assertVectorIndexSearchResultsV4(t, quantizedOnly.Results, scalarU8QuantizedTopKForTest1926(t, rows, query, 3), false)
+	assertQuantizedOnlyGuardrailStats2416(t, quantizedOnly.Stats, def.Dimensions)
+	if quantizedOnly.Stats.AdjacencyPreparedCSRDirectViews == 0 || quantizedOnly.Stats.AdjacencySourceFallbacks != 0 {
+		t.Fatalf("quantized_only stats=%+v want pack CSR adjacency with no source fallback", quantizedOnly.Stats)
+	}
+
+	reranked, err := searcher.SearchWithBuffer(VectorIndexSearcherSearchOptions{Query: query, QueryMode: VectorIndexQueryModeQuantizedRerank, QuantizedIndexName: qName, QuantizedRerankCandidates: len(rows), TopK: 3, EfSearch: len(rows), StatsMode: VectorIndexSearchStatsModeProduction}, &buffer)
+	if err != nil {
+		t.Fatalf("quantized_rerank SearchWithBuffer with closed prepared adjacency: %v", err)
+	}
+	assertVectorIndexSearchResultsV4(t, reranked.Results, exactColumnGraphTopKForTest(t, rows, query, 3), false)
+	assertQuantizedRerankNoDocumentGuardrailStats2416(t, reranked.Stats, len(rows))
+	if reranked.Stats.AdjacencyPreparedCSRDirectViews == 0 || reranked.Stats.QuantizedRerankExactScoreCalls != uint64(len(rows)) {
+		t.Fatalf("quantized_rerank stats=%+v want pack CSR traversal and exact rerank shortlist", reranked.Stats)
+	}
+}
+
+func TestScalarU8QuantizedPreparedTraversalRerankPreservesEfTraversal2586(t *testing.T) {
+	rows := []columnGraphRebuildInputRowV2A{
+		{id: "doc-a", vector: []float32{1, 0, 0}},
+		{id: "doc-b", vector: []float32{0.95, 0.05, 0}},
+		{id: "doc-c", vector: []float32{0.85, 0.15, 0}},
+		{id: "doc-d", vector: []float32{0.75, 0.25, 0}},
+		{id: "doc-e", vector: []float32{0.65, 0.35, 0}},
+		{id: "doc-f", vector: []float32{0.55, 0.45, 0}},
+		{id: "doc-g", vector: []float32{0.45, 0.55, 0}},
+		{id: "doc-h", vector: []float32{0.35, 0.65, 0}},
+	}
+	_, d, col, def := openColumnGraphQuantizedGuardrailTestCollection1926(t, rows)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	packSearcher, err := col.OpenVectorIndexSearcher(VectorIndexSearcherOptions{IndexName: def.Name, MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("OpenVectorIndexSearcher pack: %v", err)
+	}
+	defer func() { _ = packSearcher.Close() }()
+	fallbackSearcher, err := col.OpenVectorIndexSearcher(VectorIndexSearcherOptions{IndexName: def.Name, MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("OpenVectorIndexSearcher fallback: %v", err)
+	}
+	defer func() { _ = fallbackSearcher.Close() }()
+	if fallbackSearcher.reader == nil || fallbackSearcher.reader.hnswSearchPack == nil || fallbackSearcher.reader.preparedSearch == nil {
+		t.Fatalf("fallback searcher missing prepared state")
+	}
+	fallbackSearcher.reader.hnswSearchPack = nil
+
+	opts := VectorIndexSearcherSearchOptions{
+		Query:                     []float32{0.7, 0.3, 0},
+		QueryMode:                 VectorIndexQueryModeQuantizedRerank,
+		QuantizedIndexName:        def.QuantizedIndexes[0].Name,
+		QuantizedRerankCandidates: 4,
+		TopK:                      3,
+		EfSearch:                  len(rows),
+		StatsMode:                 VectorIndexSearchStatsModeProduction,
+	}
+	var packBuffer, fallbackBuffer VectorIndexSearchBuffer
+	packResults, err := packSearcher.SearchWithBuffer(opts, &packBuffer)
+	if err != nil {
+		t.Fatalf("pack SearchWithBuffer: %v", err)
+	}
+	fallbackResults, err := fallbackSearcher.SearchWithBuffer(opts, &fallbackBuffer)
+	if err != nil {
+		t.Fatalf("fallback SearchWithBuffer: %v", err)
+	}
+	assertQuantizedRerankNoDocumentGuardrailStats2416(t, packResults.Stats, opts.QuantizedRerankCandidates)
+	assertQuantizedRerankNoDocumentGuardrailStats2416(t, fallbackResults.Stats, opts.QuantizedRerankCandidates)
+	if packResults.Stats.Candidates != fallbackResults.Stats.Candidates || packResults.Stats.VisitedEdges != fallbackResults.Stats.VisitedEdges || packResults.Stats.QuantizedScoreCalls != fallbackResults.Stats.QuantizedScoreCalls || packResults.Stats.QuantizedRerankExactScoreCalls != fallbackResults.Stats.QuantizedRerankExactScoreCalls {
+		t.Fatalf("pack stats=%+v fallback stats=%+v want same efSearch traversal and rerank counters", packResults.Stats, fallbackResults.Stats)
+	}
+	if len(packResults.Results) != len(fallbackResults.Results) {
+		t.Fatalf("pack results=%d fallback results=%d", len(packResults.Results), len(fallbackResults.Results))
+	}
+	for i := range packResults.Results {
+		got := packResults.Results[i]
+		want := fallbackResults.Results[i]
+		if string(got.ID) != string(want.ID) || got.Ordinal != want.Ordinal || got.Score != want.Score {
+			t.Fatalf("result[%d] pack=%+v fallback=%+v", i, got, want)
+		}
+	}
+}
+
+func TestSearchVectorIndexWithBufferScalarU8PreparedTraversalPackRouteWhenAdjacencyClosed2586(t *testing.T) {
+	rows := []columnGraphRebuildInputRowV2A{
+		{id: "doc-a", vector: []float32{1, 0, 0}},
+		{id: "doc-b", vector: []float32{0.9, 0.1, 0}},
+		{id: "doc-c", vector: []float32{0, 1, 0}},
+		{id: "doc-d", vector: []float32{0, 0, 1}},
+		{id: "doc-e", vector: []float32{0.4, 0.6, 0}},
+	}
+	_, d, col, def := openColumnGraphQuantizedGuardrailTestCollection1926(t, rows)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	query := []float32{0.8, 0.2, 0}
+	qName := def.QuantizedIndexes[0].Name
+	quantizedOnlyOpts := VectorIndexSearchOptions{IndexName: def.Name, Query: query, QueryMode: VectorIndexQueryModeQuantizedOnly, QuantizedIndexName: qName, TopK: 3, EfSearch: len(rows), MaxDecodedBlocks: 1, StatsMode: VectorIndexSearchStatsModeProduction}
+	var buffer VectorIndexSearchBuffer
+	warm, err := col.SearchVectorIndexWithBuffer(quantizedOnlyOpts, &buffer)
+	if err != nil || len(warm.Results) != quantizedOnlyOpts.TopK {
+		t.Fatalf("warm SearchVectorIndexWithBuffer results=%d err=%v", len(warm.Results), err)
+	}
+	mutateCachedCollectionQuantizedReader2586(t, col, quantizedOnlyOpts, func(reader *columnVectorGraphPhysicalRowReader) {
+		if reader.hnswSearchPack == nil || reader.adjacencyLayerSources == nil {
+			t.Fatalf("cached reader missing prepared pack or adjacency state")
+		}
+		if err := reader.adjacencyLayerSources.Close(); err != nil {
+			t.Fatalf("close cached adjacency sources: %v", err)
+		}
+		reader.preparedSearch = nil
+	})
+
+	quantizedOnly, err := col.SearchVectorIndexWithBuffer(quantizedOnlyOpts, &buffer)
+	if err != nil {
+		t.Fatalf("quantized_only SearchVectorIndexWithBuffer with closed prepared adjacency: %v", err)
+	}
+	assertVectorIndexSearchResultsV4(t, quantizedOnly.Results, scalarU8QuantizedTopKForTest1926(t, rows, query, quantizedOnlyOpts.TopK), false)
+	assertQuantizedOnlyGuardrailStats2416(t, quantizedOnly.Stats, def.Dimensions)
+	assertCollectionBufferedQuantizedRouteStats2415(t, quantizedOnly.Stats, columnVectorGraphNativeSearchQueryModeQuantizedOnly, quantizedOnlyOpts, def.Dimensions)
+	if quantizedOnly.Stats.AdjacencyPreparedCSRDirectViews == 0 || quantizedOnly.Stats.AdjacencySourceFallbacks != 0 {
+		t.Fatalf("collection quantized_only stats=%+v want pack CSR adjacency with no source fallback", quantizedOnly.Stats)
+	}
+
+	rerankOpts := quantizedOnlyOpts
+	rerankOpts.QueryMode = VectorIndexQueryModeQuantizedRerank
+	rerankOpts.QuantizedRerankCandidates = len(rows)
+	reranked, err := col.SearchVectorIndexWithBuffer(rerankOpts, &buffer)
+	if err != nil {
+		t.Fatalf("quantized_rerank SearchVectorIndexWithBuffer with closed prepared adjacency: %v", err)
+	}
+	assertVectorIndexSearchResultsV4(t, reranked.Results, exactColumnGraphTopKForTest(t, rows, query, rerankOpts.TopK), false)
+	assertQuantizedRerankNoDocumentGuardrailStats2416(t, reranked.Stats, rerankOpts.QuantizedRerankCandidates)
+	assertCollectionBufferedQuantizedRouteStats2415(t, reranked.Stats, columnVectorGraphNativeSearchQueryModeQuantizedRerank, rerankOpts, def.Dimensions)
+	if reranked.Stats.AdjacencyPreparedCSRDirectViews == 0 || reranked.Stats.QuantizedRerankExactScoreCalls != uint64(rerankOpts.QuantizedRerankCandidates) {
+		t.Fatalf("collection quantized_rerank stats=%+v want pack CSR traversal and exact rerank shortlist", reranked.Stats)
+	}
+}
+
 func TestSearchVectorIndexWithBufferQuantizedEmptyCollection2415(t *testing.T) {
 	_, d, col, def := openColumnGraphQuantizedGuardrailTestCollection1926(t, nil)
 	defer func() { _ = d.Close() }()
@@ -1085,6 +1258,33 @@ func assertCollectionBufferedQuantizedRouteStats2415(tb testing.TB, stats Vector
 	if !vectorIndexSearchStatsAreBufferedNoDocumentQuantizedRoute(stats, mode, opts, dims) {
 		tb.Fatalf("collection buffered quantized stats=%+v want healthy no-document quantized route", stats)
 	}
+}
+
+func mutateCachedCollectionQuantizedReader2586(tb testing.TB, col *Collection, opts VectorIndexSearchOptions, mutate func(*columnVectorGraphPhysicalRowReader)) {
+	tb.Helper()
+	queryMode, err := normalizeVectorIndexSearchQueryMode(opts.QueryMode, opts.QuantizedIndexName, opts.QuantizedRerankCandidates, opts.TopK)
+	if err != nil {
+		tb.Fatalf("normalize query mode: %v", err)
+	}
+	slot := collectionVectorIndexPreparedSearchCacheSlotForOptions(opts, queryMode)
+	col.vectorBufferedSearchMu.Lock()
+	entry := col.vectorBufferedSearch[slot]
+	col.vectorBufferedSearchMu.Unlock()
+	if entry == nil || entry.prepared == nil || entry.prepared.searcher == nil {
+		tb.Fatalf("missing cached prepared quantized entry for slot %+v", slot)
+	}
+	prepared := entry.prepared
+	prepared.mu.Lock()
+	defer prepared.mu.Unlock()
+	prepared.quantizedReadersMu.Lock()
+	defer prepared.quantizedReadersMu.Unlock()
+	for _, reader := range prepared.quantizedReaders {
+		if reader != nil {
+			mutate(reader)
+			return
+		}
+	}
+	tb.Fatalf("cached prepared quantized entry has no pooled reader for slot %+v", slot)
 }
 
 func mutateCachedCollectionQuantizedAssetStatus2415(tb testing.TB, col *Collection, opts VectorIndexSearchOptions, mutate func(map[string]columnVectorGraphQuantizedAssetLoadStatus, string, columnVectorGraphQuantizedAssetLoadStatus)) {


### PR DESCRIPTION
## Objective

Route TreeDB `scalar_u8` `quantized_only` and `quantized_rerank` searches through the #2585 prepared HNSW pack-style traversal seam while preserving scalar_u8 score identity, exact FP32 route behavior, quantized diagnostics, and hot-row `0 B/op`, `0 allocs/op`.

Closes #2586.  Downstream of #2584 / #2585; uses the #2591 10k x 768 quantized production-gate smoke as large-shape evidence.

## Context

The scalar_u8 scorer was already compact, but the old quantized path still paid the column-graph prepared adjacency/frontier traversal overhead. This PR adds an explicit scalar_u8 score plane for the prepared HNSW search-pack traversal and routes eligible lower-level and collection buffered quantized searches through that seam.

## Non-goals

- No scalar_u8 codec/storage/format changes.
- No exact FP32 route/semantics changes.
- No exact fallback for quantized modes.
- No RabitQ tuning; RabitQ rows are included only as #2591 smoke guardrails.

## Design

- Adds `SearchCosineScalarU8PreparedTraversal` for scalar_u8 v1 quantized-only/rerank traversal over `hnsw_search_pack_v1`.
- Wires both `VectorIndexSearcher.SearchWithBuffer` and collection `SearchVectorIndexWithBuffer` quantized paths to use the prepared traversal when a live pack is present.
- Preserves codec-generic quantized route counters (`search_route_quantized_only`, `search_route_quantized_rerank`, quantized scorer/asset counters) instead of claiming the exact-FP32 `hnsw_search_pack` route.
- Keeps rerank traversal breadth at normalized `efSearch`; `QuantizedRerankCandidates` only bounds the exact FP32 rerank shortlist.
- Reuses search scratch for the score plane/stats and avoids materializing discarded ordinal-only results in the internal rerank path.
- Shared seam cleanup: edge-visit accounting is batched per adjacency list instead of incrementing inside the neighbor loop.

## Scope

Includes:
- `TreeDB/collections/column_hnsw_prepared_quantized_search.go`
- `TreeDB/collections/column_hnsw_prepared_traversal.go`
- `TreeDB/collections/column_vector_graph_search.go`
- `TreeDB/collections/vector_index_search.go`
- `TreeDB/collections/collection_vector_index_prepared_search_cache.go`
- `TreeDB/collections/vector_index_search_test.go`

Excludes: format/storage migrations, scalar_u8 score semantics changes, exact route behavior changes, and RabitQ tuning.

## Correctness / route evidence

Added/updated tests cover:
- lower-level scalar_u8 qonly/rerank using the pack route while legacy adjacency sources are closed;
- collection `SearchVectorIndexWithBuffer` qonly/rerank using the pack route while cached legacy adjacency sources are closed;
- rerank preserving `efSearch` traversal counters while limiting exact rerank to the configured shortlist;
- existing quantized no-document guardrails for qonly/rerank counters, vector/norm reads, docs fetched, and fallback counters.

Fresh local validation on latest head (`05539577a`):

```sh
GOWORK=off go test ./TreeDB/collections \
  -run 'Test(ScalarU8QuantizedPreparedTraversalPackRouteWhenAdjacencyClosed2586|ScalarU8QuantizedPreparedTraversalRerankPreservesEfTraversal2586|SearchVectorIndexWithBufferScalarU8PreparedTraversalPackRouteWhenAdjacencyClosed2586|SearchVectorIndexWithBufferQuantizedOnlyAndRerank2415|VectorIndexSearcherColumnGraphTypedColumnNativeReaderReusableBuffer)' \
  -count=1
# ok github.com/snissn/gomap/TreeDB/collections 1.141s

GOWORK=off go test ./TreeDB/collections -count=1
# ok github.com/snissn/gomap/TreeDB/collections 47.444s
```

Artifacts:
- focused latest-head run: `/tmp/issue2586_focused_055395_20260610_222126.txt`
- full latest-head collections run: `/tmp/issue2586_coordinator_collections_codexfix_20260610_221335.txt`
- coordinator focused pre-PR check: `/tmp/issue2586_coordinator_focused_prepr_20260610_212449.txt`

Follow-up commits:
- `dfdf49378`: test-only Windows heap-view route assertion relaxation; still requires no source fallback.
- `b7a632b13`: exact FP32 scratch-shape preservation while scalar_u8 prepared traversal retains its no-allocation quantized tile scratch.
- `05539577a`: Codex finding fix; validates query dimensions before scalar_u8 prepared traversal can return empty results for `TopK == 0` / empty indexes.

## Benchmark artifacts

Baseline: `/tmp/gomap_2586_baseline_ca34466d_20260610_204223`
Original small-matrix candidate: `/tmp/gomap_2586_candidate_dfdf49378_20260610_214451`
Latest scalar_u8 before/after guardrail: `/tmp/issue2586_scalar_after_b7a632_20260610_215837`
Latest exact FP32 scratch guardrail: `/tmp/issue2586_exact_after_param_20260610_215553`
Original profile candidate: `/tmp/gomap_2586_candidate_ca34466d7_20260610_210014`

Small hot-cache matrix command shape used for baseline and candidate:

```sh
GOMAXPROCS=8 GOWORK=off go test ./TreeDB/collections \
  -run '^$' \
  -bench '^(BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderReusableBufferV4|BenchmarkOpenVectorIndexSearcherColumnGraphTypedColumnNativeReaderReusableBufferParallelV4|BenchmarkVectorIndexSearcherColumnGraphScalarU8QuantizedSearchWithBuffer2414|BenchmarkCollectionSearchVectorIndexWithBufferColumnGraphScalarU8Quantized2415)$' \
  -benchmem -benchtime=100000x -count=5
```

Original full quick benchstat: `/tmp/gomap_2586_candidate_dfdf49378_20260610_214451/benchstat_quick_time_allocs_latest.txt`
Latest scalar_u8 before/after benchstat: `/tmp/issue2586_scalar_after_b7a632_20260610_215837/benchstat_scalar.txt`
Latest exact FP32 before/after benchstat: `/tmp/issue2586_exact_after_param_20260610_215553/benchstat_exact.txt`

| row | original baseline | original/dfdf candidate | benchstat |
|---|---:|---:|---:|
| lower qonly c=1 | 10.081 us/op (~99.2k ops/s) | 9.541 us/op (~104.8k ops/s) | ~, p=0.151 |
| lower qonly c=8 | 2.116 us/op (~472.6k ops/s) | 1.923 us/op (~520.0k ops/s) | ~, p=0.310 |
| lower rerank32 c=1 | 10.30 us/op (~97.1k ops/s) | 10.05 us/op (~99.5k ops/s) | ~, p=0.421 |
| lower rerank32 c=8 | 2.812 us/op (~355.6k ops/s) | 2.182 us/op (~458.3k ops/s) | ~, p=0.056 |
| collection qonly c=1 | 10.61 us/op (~94.3k ops/s) | 10.42 us/op (~96.0k ops/s) | ~, p=0.421 |
| collection qonly c=8 | 2.856 us/op (~350.1k ops/s) | 2.523 us/op (~396.4k ops/s) | ~, p=0.690 |
| collection rerank32 c=1 | 11.54 us/op (~86.7k ops/s) | 11.41 us/op (~87.6k ops/s) | ~, p=1.000 |
| collection rerank32 c=8 | 2.700 us/op (~370.4k ops/s) | 2.665 us/op (~375.2k ops/s) | ~, p=0.548 |
| exact reusable c=1 | 11.42 us/op (~87.6k ops/s) | 11.75 us/op (~85.1k ops/s) | ~, p=0.151 |
| exact reusable parallel c=8 | 2.280 us/op (~438.6k ops/s) | 3.103 us/op (~322.3k ops/s) | ~, p=0.056 |

Allocation guardrail: every row above is `0 B/op`, `0 allocs/op` in original baseline and dfdf candidate. The latest-head addendum below covers the subsequent exact-scratch and query-dimension follow-up commits.

Counter/route guardrails from the same dfdf candidate rows:
- scalar_u8 qonly/rerank: `search_route_column_graph_prepared=1`, `search_route_hnsw_search_pack=0`, `quantized_scorer_active=1`;
- qonly: `quantized_score_calls=169`, vector/norm/docs reads remain zero;
- rerank32: `quantized_rerank_candidates=32`, `quantized_rerank_exact_score_calls=32`, exact vector/norm reads bounded to shortlist;
- no adjacency source fallback, graph-row fallback, typed-column fallback, or document fetch in hot rows.

## #2591 10k x 768 smoke

Command shape (same host, baseline and candidate):

```sh
TREEDB_VECTOR_BENCH_DOCS=10000 \
TREEDB_VECTOR_BENCH_DIMS=768 \
TREEDB_VECTOR_BENCH_M=16 \
TREEDB_VECTOR_BENCH_EF_CONSTRUCTION=128 \
TREEDB_VECTOR_BENCH_EF_SEARCH=128 \
TREEDB_VECTOR_BENCH_TOPK=10 \
TREEDB_VECTOR_BENCH_QUERIES=16 \
GOMAXPROCS=8 GOWORK=off go test ./TreeDB/collections \
  -run '^$' \
  -bench '^BenchmarkCollectionVectorQuantizedProductionGate2591$' \
  -benchmem -benchtime=1x -count=1
```

Original artifacts:
- baseline: `/tmp/gomap_2586_baseline_ca34466d_20260610_204223/production_10k_768_smoke_baseline.txt`
- candidate: `/tmp/gomap_2586_candidate_ca34466d7_20260610_210014/production_10k_768_smoke_candidate.txt`
- benchstat: `/tmp/gomap_2586_candidate_ca34466d7_20260610_210014/benchstat_production_10k_768_smoke_time_allocs.txt`

Latest-head smoke artifacts:
- b7a scratch addendum: `/tmp/issue2586_10k768_b7a632_rerun_20260610_220120.txt`
- 055 Codex-fix head: `/tmp/issue2586_10k768_055395_20260610_221555.txt`

This is intentionally a smoke (`n=1`), not a statistically significant promotion claim. It covers exact FP32, scalar_u8, and RabitQ production-gate rows at 10k docs x 768 dims. All rows stayed at `0 B/op`, `0 allocs/op`; exact FP32 stayed on `hnsw_search_pack`; scalar_u8 stayed on the quantized prepared column-graph route with quantized-only/rerank counters preserved.

## Profiles

Candidate profile artifacts: `/tmp/gomap_2586_candidate_ca34466d7_20260610_210014/profiles`
Baseline profile artifacts: `/tmp/gomap_2586_baseline_ca34466d_20260610_204223/profiles`

Promoted scalar rows captured for qonly/rerank c=1/c=8:
- `cpu_qonly_c1.pprof`, `cpu_qonly_c8.pprof`
- `cpu_rerank32_c1.pprof`, `cpu_rerank32_c8.pprof`
- matching alloc profiles and `*_top.txt` summaries

Profile summary:
- qonly c=1: `searchCosinePreparedScorePlane` is the main local cost (73.85% cum), followed by frontier heap work and `dotScalarU8CenteredIndexedARM64Int32`.
- qonly c=8: same shape; prepared traversal 77.60% cum, scalar_u8 kernel 10.80% flat.
- rerank32 c=1: prepared traversal 62.50% cum; exact rerank is bounded (`exactRerankQuantizedCandidates` 5.36% cum).
- rerank32 c=8: prepared traversal 71.09% cum; exact FP32 indexed dot appears only in the bounded rerank path.
- Allocation profiles show setup/build allocations; timed hot benchmark rows remain `0 B/op`, `0 allocs/op`.

## Regressions / caveats

No significant local regression in the median-of-5 small matrix; exact FP32 reusable-buffer rows remain statistically unchanged and allocation-free. The #2591 large-shape row is smoke-only (`n=1`) and noisy, so this PR does not make statistically significant large-shape speedup claims from that run.


Codex latest-head review follow-up: 05539577a adds query-dimension validation before the scalar_u8 prepared route can return empty results for `TopK == 0`/empty indexes, plus a reusable-searcher test covering qonly/rerank `TopK == 0` bad dimensions. Post-fix evidence: `/tmp/issue2586_focused_055395_20260610_222126.txt`, `/tmp/issue2586_coordinator_collections_codexfix_20260610_221335.txt`, and `/tmp/issue2586_10k768_055395_20260610_221555.txt` (all scalar hot rows remain `0 B/op`, `0 allocs/op`).

## AI review loop

- Codex latest-head review: requested after initial PR creation, after the Windows heap-view assertion fix, and again after the 05539577a Codex finding fix.
- Copilot latest-head review: requested after initial PR creation and after the Windows heap-view assertion fix; re-requested after the 05539577a fix once this body was updated.
- CodeRabbit: auto-attempted; review was skipped/rate-limited in this PR.

Latest-head CI is green and Codex latest-head review returned no issues; Copilot was re-requested. Leaving this PR unmerged per instruction.

## Coordinator latest-head addendum (05539577a)

A third commit parameterizes `prepareHNSWSearchPack` scratch sizing so exact FP32 HNSW-pack searches keep their prior ordinal/quantized scratch shape (`0,0`), while scalar_u8 prepared traversal preallocates the ordinal/quantized-dot tile scratch it needs to preserve `0 B/op`, `0 allocs/op`.

Latest local evidence on b7a632b13/05539577a:
- focused scalar_u8/#2585 seam tests: `/tmp/issue2586_coordinator_focused_dfdf_20260610_214543.txt` and `/tmp/issue2586_focused_055395_20260610_222126.txt` (passed)
- full collections package: `/tmp/issue2586_coordinator_collections_b7a632_20260610_215656.txt` (`ok github.com/snissn/gomap/TreeDB/collections 61.143s`)
- exact FP32 before/after guardrail: `/tmp/issue2586_exact_after_param_20260610_215553/benchstat_exact.txt` (exact rows statistically unchanged; both `0 B/op`, `0 allocs/op`; exact route/counters unchanged)
- scalar_u8 before/after guardrail: `/tmp/issue2586_scalar_after_b7a632_20260610_215837/benchstat_scalar.txt` (geomean -19.70%; all hot rows `0 B/op`, `0 allocs/op`)
- #2591 10k x 768 latest-head smoke: `/tmp/issue2586_10k768_b7a632_rerun_20260610_220120.txt` and latest `/tmp/issue2586_10k768_055395_20260610_221555.txt` (20 rows each; all `0 B/op`, `0 allocs/op`; scalar_u8 quantized rows use `search_route_column_graph_prepared=1` and preserve quantized counters)


