### PR TITLE
TreeDB: route RaBitQ search via HNSW pack

### DIFF
--- a/TreeDB/collections/column_hnsw_rabitq_prepared_search.go
+++ b/TreeDB/collections/column_hnsw_rabitq_prepared_search.go
@@ -77,19 +77,12 @@ func (r *columnVectorGraphPhysicalRowReader) searchRabitQCosinePreparedHNSWPack(
 	}
 	scratch.searchPlan.quantizedScorer = columnVectorGraphQuantizedScorer{kind: columnVectorGraphQuantizedScorerKindRabitQ1Bit, rabitq: scorer}
 	scratch.preparedQuantizedPlane.scorer = &scratch.searchPlan.quantizedScorer
-	traversalStatsMode := opts.StatsMode.normalized()
-	if traversalStatsMode == columnVectorGraphNativeSearchStatsModeMinimal {
-		// Preserve the existing quantized route counter contract in production mode:
-		// candidate/edge counters are part of the quantized traversal evidence even
-		// though exact FP32 pack search can omit them for minimal stats.
-		traversalStatsMode = columnVectorGraphNativeSearchStatsModeFullDiagnostics
-	}
 	traversalOpts := columnHNSWPreparedTraversalOptions{
 		TopK:                      opts.TopK,
 		EfSearch:                  opts.EfSearch,
 		RetainedCandidateLimit:    0,
 		ScoreBatchMode:            opts.ScoreBatchMode,
-		StatsMode:                 traversalStatsMode,
+		StatsMode:                 opts.StatsMode,
 		OmitResultMaterialization: opts.OmitResultMaterialization,
 	}
 	rerankCandidateLimit := 0

--- a/TreeDB/collections/column_hnsw_rabitq_prepared_search.go
+++ b/TreeDB/collections/column_hnsw_rabitq_prepared_search.go
@@ -94,6 +94,7 @@ func (r *columnVectorGraphPhysicalRowReader) searchRabitQCosinePreparedHNSWPack(
 	}
 	if queryMode == columnVectorGraphNativeSearchQueryModeQuantizedRerank {
 		traversalOpts.OmitResultMaterialization = true
+		traversalOpts.SuppressOmittedResultMaterialization = true
 	}
 	results, searchStats, err := pack.searchCosinePreparedScorePlane(query, traversalOpts, scratch, &scratch.preparedQuantizedPlane)
 	applyColumnVectorGraphQuantizedBaseStats(&searchStats, stats)

--- a/TreeDB/collections/column_hnsw_rabitq_prepared_search.go
+++ b/TreeDB/collections/column_hnsw_rabitq_prepared_search.go
@@ -87,12 +87,14 @@ func (r *columnVectorGraphPhysicalRowReader) searchRabitQCosinePreparedHNSWPack(
 	traversalOpts := columnHNSWPreparedTraversalOptions{
 		TopK:                      opts.TopK,
 		EfSearch:                  opts.EfSearch,
-		RetainedCandidateLimit:    opts.QuantizedRerankCandidates,
+		RetainedCandidateLimit:    0,
 		ScoreBatchMode:            opts.ScoreBatchMode,
 		StatsMode:                 traversalStatsMode,
 		OmitResultMaterialization: opts.OmitResultMaterialization,
 	}
+	rerankCandidateLimit := 0
 	if queryMode == columnVectorGraphNativeSearchQueryModeQuantizedRerank {
+		rerankCandidateLimit = opts.QuantizedRerankCandidates
 		traversalOpts.OmitResultMaterialization = true
 		traversalOpts.SuppressOmittedResultMaterialization = true
 	}
@@ -104,6 +106,9 @@ func (r *columnVectorGraphPhysicalRowReader) searchRabitQCosinePreparedHNSWPack(
 	}
 	if queryMode != columnVectorGraphNativeSearchQueryModeQuantizedRerank {
 		return results, searchStats, nil
+	}
+	if rerankCandidateLimit > 0 && len(scratch.top) > rerankCandidateLimit {
+		scratch.top = scratch.top[:rerankCandidateLimit]
 	}
 	if err := pack.exactRerankPreparedTraversalCandidates(query, opts.TopK, opts.ScoreBatchMode, scratch, &searchStats); err != nil {
 		return nil, searchStats, err

--- a/TreeDB/collections/column_vector_graph_rabitq_quantized_asset_test.go
+++ b/TreeDB/collections/column_vector_graph_rabitq_quantized_asset_test.go
@@ -332,8 +332,11 @@ func TestRabitQPreparedHNSWSearchPackRerankPreservesEfTraversal2587(t *testing.T
 		if stats.DocumentsFetched != 0 || stats.GraphRowFallbacks != 0 || stats.TypedColumnFallbacks != 0 || stats.VectorScratchDecodes != 0 {
 			t.Fatalf("%s stats=%+v want no document/fallback guardrail counters", name, stats)
 		}
-		if stats.QuantizedRerankExactScoreCalls != uint64(opts.QuantizedRerankCandidates) || stats.PreparedScoreCalls != uint64(opts.QuantizedRerankCandidates) {
+		if stats.QuantizedRerankExactScoreCalls != uint64(opts.QuantizedRerankCandidates) {
 			t.Fatalf("%s stats=%+v want rerank shortlist=%d", name, stats, opts.QuantizedRerankCandidates)
+		}
+		if name == "pack" && stats.PreparedScoreCalls != uint64(opts.QuantizedRerankCandidates) {
+			t.Fatalf("%s stats=%+v want pack rerank prepared score calls=%d", name, stats, opts.QuantizedRerankCandidates)
 		}
 	}
 	if packResults.Stats.Candidates == 0 || packResults.Stats.VisitedEdges == 0 {

--- a/TreeDB/collections/column_vector_graph_rabitq_quantized_asset_test.go
+++ b/TreeDB/collections/column_vector_graph_rabitq_quantized_asset_test.go
@@ -279,6 +279,78 @@ func TestRabitQPreparedHNSWSearchPackRouteParity2587(t *testing.T) {
 	}
 }
 
+func TestRabitQPreparedHNSWSearchPackRerankPreservesEfTraversal2587(t *testing.T) {
+	rows := []columnGraphRebuildInputRowV2A{
+		{id: "doc-a", vector: []float32{1, 0, 0}},
+		{id: "doc-b", vector: []float32{0.95, 0.05, 0}},
+		{id: "doc-c", vector: []float32{0.85, 0.15, 0}},
+		{id: "doc-d", vector: []float32{0.75, 0.25, 0}},
+		{id: "doc-e", vector: []float32{0.65, 0.35, 0}},
+		{id: "doc-f", vector: []float32{0.55, 0.45, 0}},
+		{id: "doc-g", vector: []float32{0.45, 0.55, 0}},
+		{id: "doc-h", vector: []float32{0.35, 0.65, 0}},
+	}
+	_, d, col, def := openColumnGraphRabitQQuantizedTestCollection2450(t, rows)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	packSearcher, err := col.OpenVectorIndexSearcher(VectorIndexSearcherOptions{IndexName: def.Name, MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("OpenVectorIndexSearcher pack: %v", err)
+	}
+	defer func() { _ = packSearcher.Close() }()
+	fallbackSearcher, err := col.OpenVectorIndexSearcher(VectorIndexSearcherOptions{IndexName: def.Name, MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("OpenVectorIndexSearcher fallback: %v", err)
+	}
+	defer func() { _ = fallbackSearcher.Close() }()
+	if fallbackSearcher.reader == nil || fallbackSearcher.reader.hnswSearchPack == nil {
+		t.Fatalf("fallback searcher missing reader or prepared pack")
+	}
+	fallbackSearcher.reader.hnswSearchPack = nil
+
+	opts := VectorIndexSearcherSearchOptions{
+		Query:                     []float32{0.7, 0.3, 0},
+		QueryMode:                 VectorIndexQueryModeQuantizedRerank,
+		QuantizedIndexName:        def.QuantizedIndexes[0].Name,
+		QuantizedRerankCandidates: 4,
+		TopK:                      3,
+		EfSearch:                  len(rows),
+		StatsMode:                 VectorIndexSearchStatsModeProduction,
+	}
+	var packBuffer, fallbackBuffer VectorIndexSearchBuffer
+	packResults, err := packSearcher.SearchWithBuffer(opts, &packBuffer)
+	if err != nil {
+		t.Fatalf("pack SearchWithBuffer: %v", err)
+	}
+	fallbackResults, err := fallbackSearcher.SearchWithBuffer(opts, &fallbackBuffer)
+	if err != nil {
+		t.Fatalf("fallback SearchWithBuffer: %v", err)
+	}
+	for name, stats := range map[string]VectorIndexSearchStats{"pack": packResults.Stats, "fallback": fallbackResults.Stats} {
+		if stats.DocumentsFetched != 0 || stats.GraphRowFallbacks != 0 || stats.TypedColumnFallbacks != 0 || stats.VectorScratchDecodes != 0 {
+			t.Fatalf("%s stats=%+v want no document/fallback guardrail counters", name, stats)
+		}
+		if stats.QuantizedRerankExactScoreCalls != uint64(opts.QuantizedRerankCandidates) || stats.PreparedScoreCalls != uint64(opts.QuantizedRerankCandidates) {
+			t.Fatalf("%s stats=%+v want rerank shortlist=%d", name, stats, opts.QuantizedRerankCandidates)
+		}
+	}
+	if packResults.Stats.Candidates != fallbackResults.Stats.Candidates || packResults.Stats.VisitedEdges != fallbackResults.Stats.VisitedEdges || packResults.Stats.QuantizedScoreCalls != fallbackResults.Stats.QuantizedScoreCalls || packResults.Stats.QuantizedRerankExactScoreCalls != fallbackResults.Stats.QuantizedRerankExactScoreCalls {
+		t.Fatalf("pack stats=%+v fallback stats=%+v want same efSearch traversal and rerank counters", packResults.Stats, fallbackResults.Stats)
+	}
+	if len(packResults.Results) != len(fallbackResults.Results) {
+		t.Fatalf("pack results=%d fallback results=%d", len(packResults.Results), len(fallbackResults.Results))
+	}
+	for i := range packResults.Results {
+		got := packResults.Results[i]
+		want := fallbackResults.Results[i]
+		if got.Ordinal != want.Ordinal || !bytes.Equal(got.ID, want.ID) || math.Abs(got.Score-want.Score) > 1e-6 {
+			t.Fatalf("result[%d] pack=%+v fallback=%+v", i, got, want)
+		}
+	}
+}
+
 func TestCollectionSearchVectorIndexWithBufferRabitQConcurrentPreparedPack2587(t *testing.T) {
 	rows := make([]columnGraphRebuildInputRowV2A, 32)
 	for i := range rows {

--- a/TreeDB/collections/column_vector_graph_rabitq_quantized_asset_test.go
+++ b/TreeDB/collections/column_vector_graph_rabitq_quantized_asset_test.go
@@ -317,7 +317,7 @@ func TestRabitQPreparedHNSWSearchPackRerankPreservesEfTraversal2587(t *testing.T
 		QuantizedRerankCandidates: 4,
 		TopK:                      3,
 		EfSearch:                  len(rows),
-		StatsMode:                 VectorIndexSearchStatsModeProduction,
+		StatsMode:                 VectorIndexSearchStatsModeFullDiagnostics,
 	}
 	var packBuffer, fallbackBuffer VectorIndexSearchBuffer
 	packResults, err := packSearcher.SearchWithBuffer(opts, &packBuffer)
@@ -335,6 +335,9 @@ func TestRabitQPreparedHNSWSearchPackRerankPreservesEfTraversal2587(t *testing.T
 		if stats.QuantizedRerankExactScoreCalls != uint64(opts.QuantizedRerankCandidates) || stats.PreparedScoreCalls != uint64(opts.QuantizedRerankCandidates) {
 			t.Fatalf("%s stats=%+v want rerank shortlist=%d", name, stats, opts.QuantizedRerankCandidates)
 		}
+	}
+	if packResults.Stats.Candidates == 0 || packResults.Stats.VisitedEdges == 0 {
+		t.Fatalf("pack stats=%+v want production traversal counters", packResults.Stats)
 	}
 	if packResults.Stats.Candidates != fallbackResults.Stats.Candidates || packResults.Stats.VisitedEdges != fallbackResults.Stats.VisitedEdges || packResults.Stats.QuantizedScoreCalls != fallbackResults.Stats.QuantizedScoreCalls || packResults.Stats.QuantizedRerankExactScoreCalls != fallbackResults.Stats.QuantizedRerankExactScoreCalls {
 		t.Fatalf("pack stats=%+v fallback stats=%+v want same efSearch traversal and rerank counters", packResults.Stats, fallbackResults.Stats)


### PR DESCRIPTION
## Objective

Fixes #2587. Route eligible TreeDB `rabitq_1bit` `quantized_only` and `quantized_rerank` searches through the prepared `hnsw_search_pack_v1` traversal seam with a RaBitQ score plane.

## Context

RaBitQ was still using the quantized column-graph traversal path after the pack traversal seam landed. This PR reuses that seam for RaBitQ so traversal/scoring counters and exact-read guardrails line up with the prepared pack route while preserving existing RaBitQ v1 scorer semantics.


## Current delta against `origin/main`

`origin/main` moved during review and now contains the parallel RaBitQ pack-route implementation from #2606. After merging latest main (`ae23f683e`), this PR's remaining diff is intentionally small:

- remove production-mode full-diagnostics forcing from the RaBitQ pack traversal (`StatsMode: opts.StatsMode`);
- keep the traversal-breadth/rerank test in `VectorIndexSearchStatsModeFullDiagnostics`;
- keep the Windows heap-fallback-safe rerank counter assertion.

The design/evidence below documents the full #2587 route work and the guardrails this PR preserves.

## Non-goals

- No RaBitQ v2 / BRQ / multi-bit codec work.
- No durable format, codec identity, or stored asset migration.
- No scalar_u8 route change.
- No exact-FP32 route change.
- No speedup claim versus exact FP32 or scalar_u8 beyond same-host context rows below.

## Design

- Adds a RaBitQ-specific prepared-pack route in `column_hnsw_rabitq_prepared_search.go`.
- Selects the route only when the query mode is quantized, the selected quantized index is `rabitq_1bit` v1, stats mode is supported, and the `hnsw_search_pack_v1` asset is direct/heap healthy.
- `quantized_only` uses pack traversal with the RaBitQ quantized score plane and keeps exact vector/norm reads at zero.
- `quantized_rerank` traverses the full configured `efSearch` breadth with the RaBitQ score plane, trims only the retained shortlist, then exact-reranks that shortlist from prepared pack FP32 vectors.
- Scalar U8 remains on the existing column-graph prepared route; exact FP32 remains on the existing pack route.
- Production stats stay production-minimal; tests that assert traversal breadth request full diagnostics explicitly.

Hard invariant statement: this PR does **not** intentionally change the RaBitQ v1 durable layout, LSB-first bit order, padding semantics, weighted sign-dot score formula, codec name/version/config identity, durable asset identity, or fail-closed behavior for invalid/unavailable RaBitQ assets.

## Correctness / tests

Latest pushed head: `21f57662d` (merges latest `origin/main` `ae23f683e`; PR functional product code remains the `2cb1baee0` RaBitQ route plus the Windows heap-fallback test expectation fix).

Local checks on `21f57662d`:

```sh
git diff --check origin/main...HEAD
GOWORK=off go test ./TreeDB/collections -run '^TestRabitQPreparedHNSWSearchPackRerankPreservesEfTraversal2587$' -count=1
GOWORK=off go test ./TreeDB/internal/rabitq ./TreeDB/collections ./cmd/treedb_vector_search_demo ./TreeDB/documentservice -count=1
GOWORK=off go test ./TreeDB/collections -race -run '^TestCollectionSearchVectorIndexWithBufferRabitQConcurrentPreparedPack2587$' -count=1
```

GitHub status check rollup is green on `21f57662d` after merging latest `origin/main`.

Coverage added/updated:

- RaBitQ prepared-pack parity against the existing v1 `SearchCosine` scorer.
- Eligible RaBitQ reports `SearchRouteHNSWSearchPack=1` / `HNSWSearchPackActive=1` and avoids column-graph fallback counters.
- Scalar U8 stays on the column-graph prepared route.
- `quantized_only` exact vector/norm reads remain zero.
- `quantized_rerank` exact calls/read bytes are limited to the retained shortlist; pack rerank may report `NormBytesRead=0` because norms come from prepared pack vectors.
- Concurrent collection prepared-pack route race coverage.
- Documentservice benchmark validator accepts the quantized pack route stats.
- Demo expectations accept the RaBitQ prepared-pack route.

## Benchmark evidence

Baseline for collected route benchmarks: `origin/main` `7f6689046`. Candidate functional code: `2cb1baee0`; after #2606 reached `main`, the latest PR diff is the production-stats/test correction described above, so these benchmark rows are retained as route evidence rather than rerun for the now-small delta.

Clean hot-cache matrix (`-benchtime=100000x -count=5`, same Apple M3 host) showed RaBitQ pack-route counters active and hot rows at `0 B/op`, `0 allocs/op`:

- Direct RaBitQ `SearchWithBuffer`: `quantized_only` c=1/c=8 and `quantized_rerank` c=1 were statistically neutral; `quantized_rerank` c=8 improved `6.388µ -> 3.631µ` (`-43.16%`).
- Collection RaBitQ `SearchVectorIndexWithBuffer`: `quantized_only` improved c=1 `26.46µ -> 13.45µ` (`-49.16%`) and c=8 `7.251µ -> 3.989µ` (`-44.99%`); `quantized_rerank` c=1/c=8 were statistically neutral in that run.
- Route/resource guardrails: `hnsw_search_pack_active/search=1`, `hnsw_search_pack_fallbacks/search=0`, `quantized_only` `norm_B/search=0`, and rerank exact score calls stayed at the configured shortlist.

Production-gate matrix (`BenchmarkCollectionVectorQuantizedProductionGate2591`, `-benchtime=10000x -count=5`) also kept hot RaBitQ rows at `0 B/op`, `0 allocs/op`; production timings were mixed/noisy after restoring full `efSearch` traversal for rerank correctness, with collection `quantized_rerank` c=1 still improving `189.8µ -> 91.3µ` (`-51.9%`). Exact-FP32 code is unchanged; exact rows are treated as guardrail/CI coverage rather than promoted as a speedup.

## Risk notes

- Route is fail-closed: if the pack asset is missing/stale/invalid or stats mode is unsupported, existing fallback paths remain available.
- The Windows CI fix in the latest commit only relaxes a test assumption for heap-copy fallback prepared-score counters; it does not change product code.
- No migration/backward compatibility scaffolding is needed because no durable format changes are introduced.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected search statistics mode handling in vector index prepared search operations to respect user-configured settings directly.

* **Tests**
  * Updated test diagnostics to capture full statistics during vector search pack and fallback comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->