### PR TITLE
TreeDB: persist value-log ref counts on close

### DIFF
--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -1805,6 +1805,11 @@ func (db *DB) Close() error {
 	db.closing.Store(true)
 	db.stopCommitCombiner()
 	db.pruner.Stop()
+	if db.valueLogRefTracker != nil {
+		if err := db.persistValueLogRefTracker(); err != nil {
+			errs = append(errs, err)
+		}
+	}
 	if db.ghostManager != nil {
 		db.ghostManager.stop()
 	}

--- a/TreeDB/db/vlog_gc_test.go
+++ b/TreeDB/db/vlog_gc_test.go
@@ -664,6 +664,62 @@ func TestValueLogGC_IncrementalParityWithFullScan(t *testing.T) {
 	}
 }
 
+func TestValueLogGC_IncrementalTrackerPersistsOnClose(t *testing.T) {
+	dir := t.TempDir()
+
+	db, err := Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+
+	ptrs := appendPointersInNewSegment(t, dir, 0, 1, 25_000, 3, func(i int) []byte {
+		return bytes.Repeat([]byte{byte(i + 1)}, 256)
+	})
+	b := db.NewBatch().(*Batch)
+	for i := range ptrs {
+		if err := b.SetPointer([]byte(fmt.Sprintf("k%02d", i)), ptrs[i]); err != nil {
+			t.Fatalf("set pointer %d: %v", i, err)
+		}
+	}
+	if err := b.Write(); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	_ = b.Close()
+
+	seq := db.currentCommitSeq()
+	if _, ok := db.valueLogRefTracker.referencedSet(seq); !ok {
+		t.Fatalf("expected dirty incremental tracker for seq=%d", seq)
+	}
+	metaPath := db.valueLogRefCountsPath()
+	if err := db.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	data, err := os.ReadFile(metaPath)
+	if err != nil {
+		t.Fatalf("read metadata: %v", err)
+	}
+	disk, err := decodeValueLogRefCounts(data)
+	if err != nil {
+		t.Fatalf("decode metadata: %v", err)
+	}
+	if disk.commitSeq != seq {
+		t.Fatalf("metadata seq mismatch after close: got=%d want=%d", disk.commitSeq, seq)
+	}
+	if got := disk.counts[ptrs[0].FileID]; got != uint64(len(ptrs)) {
+		t.Fatalf("metadata file refcount mismatch: got=%d want=%d", got, len(ptrs))
+	}
+
+	db, err = Open(Options{Dir: dir})
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	if _, ok := db.valueLogRefTracker.referencedSet(db.currentCommitSeq()); !ok {
+		t.Fatalf("expected persisted tracker to load on reopen")
+	}
+}
+
 func TestValueLogGC_IncrementalCounterRollbackOnFailedCommit(t *testing.T) {
 	dir := t.TempDir()
 


### PR DESCRIPTION
## Summary

- persist the incremental value-log ref-count tracker during `DB.Close`
- prevents graceful restarts from discarding the latest ref-count metadata and forcing a full index/value-log pointer scan on the next open
- adds a regression test that writes value-log pointers, closes, verifies the persisted commit seq/counts, and reopens from the persisted tracker

## Why

During the merged geth/TreeDB Sepolia validation, a 3h run reached ~94% state / ~61% chain sync and shut down cleanly. Reopening that fresh DB then spent startup time in:

```text
TreeDB.Open -> db.initValueLogRefTracker -> scanValueLogRefCounts -> collectValueLogRefCounts
```

The captured startup CPU profile was ~99.6% in `collectValueLogRefCounts`, dominated by iterator value-log reads/LZ4 decode. The root cause is that the tracker is updated incrementally after commits but was not persisted on normal close, leaving stale on-disk metadata for the next open.

## Tests

```sh
go test ./TreeDB/db -run 'TestValueLogGC_IncrementalTrackerPersistsOnClose|TestValueLogGC_IncrementalParityWithFullScan|TestValueLogGC_IncrementalMode_RebuildOnCorruption' -count=1 -v
go test ./TreeDB/db ./TreeDB/tree ./TreeDB/zipper -count=1
go test ./TreeDB/... -count=1
```

## Caveats

- This optimizes graceful close/reopen. Ungraceful exits can still require rebuilding missing/stale metadata.
- TreeDB remains experimental for geth; Pebble/default behavior is unchanged.
