### PR TITLE
Route rabitq_1bit search through prepared HNSW pack traversal

### DIFF
--- a/TreeDB/collections/collection_vector_index_prepared_search_cache.go
+++ b/TreeDB/collections/collection_vector_index_prepared_search_cache.go
@@ -730,32 +730,36 @@ func (p *collectionVectorIndexPreparedSearch) SearchQuantizedWithBuffer(opts Vec
 		clear(previousResults)
 		return response, nil
 	}
+	searchOpts := columnVectorGraphNativeSearchOptions{
+		TopK:                      opts.TopK,
+		EfSearch:                  opts.EfSearch,
+		ScoreBatchMode:            opts.scoreBatchMode,
+		StatsMode:                 statsMode,
+		QueryMode:                 queryMode,
+		QuantizedIndexName:        opts.QuantizedIndexName,
+		QuantizedRerankCandidates: opts.QuantizedRerankCandidates,
+	}
 	var results []columnVectorGraphNativeSearchResult
 	var searchStats columnVectorGraphNativeSearchStats
 	var err error
 	if pack, ok := collectionScalarU8PreparedTraversalPackForReader(reader, queryMode, statsMode, opts.QuantizedIndexName); ok {
-		results, searchStats, err = reader.SearchCosineScalarU8PreparedTraversal(pack, opts.Query, columnVectorGraphNativeSearchOptions{
-			TopK:                      opts.TopK,
-			EfSearch:                  opts.EfSearch,
-			ScoreBatchMode:            opts.scoreBatchMode,
-			StatsMode:                 statsMode,
-			QueryMode:                 queryMode,
-			QuantizedIndexName:        opts.QuantizedIndexName,
-			QuantizedRerankCandidates: opts.QuantizedRerankCandidates,
-		}, &buffer.searchScratch)
+		results, searchStats, err = reader.SearchCosineScalarU8PreparedTraversal(pack, opts.Query, searchOpts, &buffer.searchScratch)
+		response.Stats = vectorIndexSearchStatsFromInternal(searchStats, columnPhysicalRowReaderStats{})
+		p.routeStats.apply(&response.Stats)
+	} else if reader.rabitqHNSWSearchPackPreparedRouteEligible(queryMode, opts.QuantizedIndexName, statsMode) {
+		results, searchStats, err = reader.searchRabitQCosinePreparedHNSWPack(opts.Query, searchOpts, &buffer.searchScratch)
+		response.Stats = vectorIndexSearchStatsFromInternal(searchStats, columnPhysicalRowReaderStats{})
+		if err != nil && searchStats.QuantizedScorerActive == 0 && searchStats.QuantizedScoreCalls == 0 {
+			p.routeStats.apply(&response.Stats)
+		} else {
+			vectorIndexSearchRouteStatsForHNSWSearchPackRoute(reader.hnswSearchPack.routeStats(reader.hnswSearchPackStatus, reader.hnswSearchPackOpenNanos)).apply(&response.Stats)
+		}
 	} else {
-		results, searchStats, err = reader.SearchCosine(opts.Query, columnVectorGraphNativeSearchOptions{
-			TopK:                      opts.TopK,
-			EfSearch:                  opts.EfSearch,
-			ScoreBatchMode:            opts.scoreBatchMode,
-			StatsMode:                 statsMode,
-			QueryMode:                 queryMode,
-			QuantizedIndexName:        opts.QuantizedIndexName,
-			QuantizedRerankCandidates: opts.QuantizedRerankCandidates,
-		}, &buffer.searchScratch)
+		results, searchStats, err = reader.SearchCosine(opts.Query, searchOpts, &buffer.searchScratch)
+		response.Stats = vectorIndexSearchStatsFromInternal(searchStats, columnPhysicalRowReaderStats{})
+		p.routeStats.apply(&response.Stats)
 	}
-	response.Stats = vectorIndexSearchStatsFromInternal(searchStats, columnPhysicalRowReaderStats{})
-	p.routeStats.apply(&response.Stats)
+
 	if err != nil {
 		clear(previousResults)
 		return response, err

--- a/TreeDB/collections/collection_vector_index_prepared_search_cache.go
+++ b/TreeDB/collections/collection_vector_index_prepared_search_cache.go
@@ -730,7 +730,7 @@ func (p *collectionVectorIndexPreparedSearch) SearchQuantizedWithBuffer(opts Vec
 		clear(previousResults)
 		return response, nil
 	}
-	results, searchStats, err := reader.SearchCosine(opts.Query, columnVectorGraphNativeSearchOptions{
+	searchOpts := columnVectorGraphNativeSearchOptions{
 		TopK:                      opts.TopK,
 		EfSearch:                  opts.EfSearch,
 		ScoreBatchMode:            opts.scoreBatchMode,
@@ -738,9 +738,23 @@ func (p *collectionVectorIndexPreparedSearch) SearchQuantizedWithBuffer(opts Vec
 		QueryMode:                 queryMode,
 		QuantizedIndexName:        opts.QuantizedIndexName,
 		QuantizedRerankCandidates: opts.QuantizedRerankCandidates,
-	}, &buffer.searchScratch)
-	response.Stats = vectorIndexSearchStatsFromInternal(searchStats, columnPhysicalRowReaderStats{})
-	p.routeStats.apply(&response.Stats)
+	}
+	var results []columnVectorGraphNativeSearchResult
+	var searchStats columnVectorGraphNativeSearchStats
+	var err error
+	if reader.rabitqHNSWSearchPackPreparedRouteEligible(queryMode, opts.QuantizedIndexName, statsMode) {
+		results, searchStats, err = reader.searchRabitQCosinePreparedHNSWPack(opts.Query, searchOpts, &buffer.searchScratch)
+		response.Stats = vectorIndexSearchStatsFromInternal(searchStats, columnPhysicalRowReaderStats{})
+		if err != nil && searchStats.QuantizedScorerActive == 0 && searchStats.QuantizedScoreCalls == 0 {
+			p.routeStats.apply(&response.Stats)
+		} else {
+			vectorIndexSearchRouteStatsForHNSWSearchPackRoute(reader.hnswSearchPack.routeStats(reader.hnswSearchPackStatus, reader.hnswSearchPackOpenNanos)).apply(&response.Stats)
+		}
+	} else {
+		results, searchStats, err = reader.SearchCosine(opts.Query, searchOpts, &buffer.searchScratch)
+		response.Stats = vectorIndexSearchStatsFromInternal(searchStats, columnPhysicalRowReaderStats{})
+		p.routeStats.apply(&response.Stats)
+	}
 	if err != nil {
 		clear(previousResults)
 		return response, err

--- a/TreeDB/collections/column_hnsw_prepared_traversal.go
+++ b/TreeDB/collections/column_hnsw_prepared_traversal.go
@@ -430,3 +430,47 @@ func (v *columnHNSWSearchPackPreparedView) scoreAndPushFrontierVisitedTilePrepar
 	}
 	return nil
 }
+
+func (v *columnHNSWSearchPackPreparedView) exactRerankPreparedTraversalCandidates(query []float32, topK int, scoreBatchMode columnVectorGraphScoreBatchMode, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) error {
+	if v == nil {
+		return errColumnHNSWSearchPackSearchUnavailable
+	}
+	if scratch == nil {
+		return errColumnVectorGraphNativeSearchScratchRequired
+	}
+	if len(scratch.top) == 0 || topK <= 0 {
+		scratch.top = scratch.top[:0]
+		return nil
+	}
+	if len(scratch.top) < topK {
+		topK = len(scratch.top)
+	}
+	n := len(scratch.top)
+	scratch.scoreTileOrdinals = ensureColumnVectorGraphNativeIntScratch(scratch.scoreTileOrdinals, n)
+	ordinals := scratch.scoreTileOrdinals[:0]
+	for _, candidate := range scratch.top {
+		ordinals = append(ordinals, candidate.ordinal)
+	}
+	var exactPlane columnHNSWPreparedExactFP32ScorePlane
+	if err := exactPlane.prepareForHNSWPreparedTraversal(v, query, columnHNSWPreparedTraversalOptions{ScoreBatchMode: scoreBatchMode}, scratch); err != nil {
+		return err
+	}
+	scratch.scoreTileScores = ensureColumnVectorGraphNativeFloat64Scratch(scratch.scoreTileScores, n)
+	exactScores, err := exactPlane.scoreOrdinals(ordinals, scratch.scoreTileScores, scratch, stats)
+	if err != nil {
+		return err
+	}
+	if len(exactScores) != n {
+		return fmt.Errorf("collections: hnsw_search_pack_v1 prepared traversal exact rerank scored %d candidates want %d", len(exactScores), n)
+	}
+	if stats != nil {
+		stats.QuantizedRerankCandidates += uint64(n)
+		stats.QuantizedRerankExactScoreCalls += uint64(n)
+	}
+	scratch.top = scratch.top[:0]
+	for i, ordinal := range ordinals {
+		candidate := columnVectorGraphSearchCandidate{ordinal: ordinal, score: exactScores[i]}
+		scratch.insertTop(topK, candidate)
+	}
+	return nil
+}

--- a/TreeDB/collections/column_hnsw_prepared_traversal.go
+++ b/TreeDB/collections/column_hnsw_prepared_traversal.go
@@ -163,43 +163,45 @@ func (p *columnHNSWPreparedQuantizedScorePlane) scoreOrdinals(ordinals []int, ds
 }
 
 func (v *columnHNSWSearchPackPreparedView) searchCosinePreparedScorePlane(query []float32, opts columnHNSWPreparedTraversalOptions, scratch *columnVectorGraphNativeSearchScratch, scorePlane columnHNSWPreparedTraversalScorePlane) ([]columnVectorGraphNativeSearchResult, columnVectorGraphNativeSearchStats, error) {
-	var stats columnVectorGraphNativeSearchStats
+	var zeroStats columnVectorGraphNativeSearchStats
 	if v == nil {
-		return nil, stats, errColumnHNSWSearchPackSearchUnavailable
+		return nil, zeroStats, errColumnHNSWSearchPackSearchUnavailable
 	}
 	switch status := v.fastStatus(""); status {
 	case columnHNSWSearchPackPreparedStatusDirect, columnHNSWSearchPackPreparedStatusHeap:
 	default:
-		return nil, stats, columnHNSWSearchPackStatusError(status)
+		return nil, zeroStats, columnHNSWSearchPackStatusError(status)
 	}
 	if scratch == nil {
-		return nil, stats, errColumnVectorGraphNativeSearchScratchRequired
+		return nil, zeroStats, errColumnVectorGraphNativeSearchScratchRequired
 	}
+	stats := &scratch.preparedTraversalStats
+	*stats = columnVectorGraphNativeSearchStats{}
 	if scorePlane == nil {
-		return nil, stats, errColumnHNSWPreparedTraversalScorePlaneUnavailable
+		return nil, *stats, errColumnHNSWPreparedTraversalScorePlaneUnavailable
 	}
 	if len(query) != v.Header.Dimensions {
-		return nil, stats, fmt.Errorf("collections: hnsw_search_pack_v1 prepared traversal query dims=%d want %d: %w", len(query), v.Header.Dimensions, errColumnVectorGraphNativeSearchQueryDimensionMismatch)
+		return nil, *stats, fmt.Errorf("collections: hnsw_search_pack_v1 prepared traversal query dims=%d want %d: %w", len(query), v.Header.Dimensions, errColumnVectorGraphNativeSearchQueryDimensionMismatch)
 	}
 	statsMode := opts.StatsMode.normalized()
 	if !columnHNSWSearchPackStatsModeSupportedForSearch(statsMode) {
-		return nil, stats, errColumnHNSWSearchPackSearchUnsupportedMode
+		return nil, *stats, errColumnHNSWSearchPackSearchUnsupportedMode
 	}
 	rowCount := v.Header.Rows
 	topK := opts.TopK
 	if topK < 0 {
-		return nil, stats, errColumnVectorGraphNativeSearchTopKNegative
+		return nil, *stats, errColumnVectorGraphNativeSearchTopKNegative
 	}
 	efSearch := opts.EfSearch
 	if efSearch < 0 {
-		return nil, stats, errColumnVectorGraphNativeSearchEfSearchNegative
+		return nil, *stats, errColumnVectorGraphNativeSearchEfSearchNegative
 	}
 	retainedCandidateLimit := opts.RetainedCandidateLimit
 	if retainedCandidateLimit < 0 {
-		return nil, stats, fmt.Errorf("collections: hnsw_search_pack_v1 prepared traversal retained candidates=%d cannot be negative", retainedCandidateLimit)
+		return nil, *stats, fmt.Errorf("collections: hnsw_search_pack_v1 prepared traversal retained candidates=%d cannot be negative", retainedCandidateLimit)
 	}
 	if topK == 0 || rowCount == 0 {
-		return nil, stats, nil
+		return nil, *stats, nil
 	}
 	stats.CandidateRows = uint64(rowCount)
 	if topK > rowCount {
@@ -218,7 +220,7 @@ func (v *columnHNSWSearchPackPreparedView) searchCosinePreparedScorePlane(query 
 		retainedCandidateLimit = efSearch
 	}
 	if retainedCandidateLimit < topK {
-		return nil, stats, fmt.Errorf("collections: hnsw_search_pack_v1 prepared traversal retained candidates=%d below normalized top_k=%d", retainedCandidateLimit, topK)
+		return nil, *stats, fmt.Errorf("collections: hnsw_search_pack_v1 prepared traversal retained candidates=%d below normalized top_k=%d", retainedCandidateLimit, topK)
 	}
 	if retainedCandidateLimit > rowCount {
 		retainedCandidateLimit = rowCount
@@ -230,34 +232,38 @@ func (v *columnHNSWSearchPackPreparedView) searchCosinePreparedScorePlane(query 
 	if degree <= math.MaxInt/2 {
 		degree *= 2
 	}
-	if err := scratch.prepareHNSWSearchPack(rowCount, v.Header.VectorStride, degree, topK, retainedCandidateLimit); err != nil {
-		return nil, stats, fmt.Errorf("collections: hnsw_search_pack_v1 prepared traversal scratch prepare: %w", err)
+	resultCapacity := topK
+	if opts.OmitResultMaterialization {
+		resultCapacity = retainedCandidateLimit
+	}
+	if err := scratch.prepareHNSWSearchPack(rowCount, v.Header.VectorStride, degree, resultCapacity, retainedCandidateLimit); err != nil {
+		return nil, *stats, fmt.Errorf("collections: hnsw_search_pack_v1 prepared traversal scratch prepare: %w", err)
 	}
 	if err := scorePlane.prepareForHNSWPreparedTraversal(v, query, opts, scratch); err != nil {
-		return nil, stats, fmt.Errorf("collections: hnsw_search_pack_v1 prepared traversal %s score plane: %w", scorePlane.kind(), err)
+		return nil, *stats, fmt.Errorf("collections: hnsw_search_pack_v1 prepared traversal %s score plane: %w", scorePlane.kind(), err)
 	}
 	countLoopEdges := !statsMode.minimal()
 	var loopEdgeVisits uint64
 	var visitedCandidates uint64
 	entryOrdinal := v.Header.EntryOrdinal
 	if entryOrdinal < 0 || entryOrdinal >= rowCount {
-		return nil, stats, fmt.Errorf("collections: hnsw_search_pack_v1 prepared traversal entry ordinal=%d outside rows=%d", entryOrdinal, rowCount)
+		return nil, *stats, fmt.Errorf("collections: hnsw_search_pack_v1 prepared traversal entry ordinal=%d outside rows=%d", entryOrdinal, rowCount)
 	}
 	maxLayer, err := v.maxLayerForOrdinal(entryOrdinal)
 	if err != nil {
-		return nil, stats, err
+		return nil, *stats, err
 	}
 	for layer := maxLayer; layer > 0; layer-- {
-		entryOrdinal, err = v.greedyNearestAtLayerPreparedScorePlane(scorePlane, entryOrdinal, layer, scratch, &stats, countLoopEdges, &loopEdgeVisits)
+		entryOrdinal, err = v.greedyNearestAtLayerPreparedScorePlane(scorePlane, entryOrdinal, layer, scratch, stats, countLoopEdges, &loopEdgeVisits)
 		if err != nil {
-			return nil, stats, err
+			return nil, *stats, err
 		}
 	}
 	visitMarks := scratch.visitMarks
 	visitEpoch := scratch.visitEpoch
 	visitMarks[entryOrdinal] = visitEpoch
-	if err := v.scoreAndPushFrontierVisitedPreparedScorePlane(scorePlane, entryOrdinal, retainedCandidateLimit, scratch, &stats, &visitedCandidates); err != nil {
-		return nil, stats, err
+	if err := v.scoreAndPushFrontierVisitedPreparedScorePlane(scorePlane, entryOrdinal, retainedCandidateLimit, scratch, stats, &visitedCandidates); err != nil {
+		return nil, *stats, err
 	}
 	nextSeed := 0
 	rowCount64 := uint64(rowCount)
@@ -273,17 +279,17 @@ func (v *columnHNSWSearchPackPreparedView) searchCosinePreparedScorePlane(query 
 			}
 			nextSeed = seed + 1
 			visitMarks[seed] = visitEpoch
-			if err := v.scoreAndPushFrontierVisitedPreparedScorePlane(scorePlane, seed, retainedCandidateLimit, scratch, &stats, &visitedCandidates); err != nil {
-				return nil, stats, err
+			if err := v.scoreAndPushFrontierVisitedPreparedScorePlane(scorePlane, seed, retainedCandidateLimit, scratch, stats, &visitedCandidates); err != nil {
+				return nil, *stats, err
 			}
 			continue
 		}
 		if columnVectorGraphLayer0SearchShouldStop(candidate, scratch.top, retainedCandidateLimit) {
 			break
 		}
-		adjacency, err := v.adjacencyLayerForOrdinal(candidate.ordinal, 0, &stats)
+		adjacency, err := v.adjacencyLayerForOrdinal(candidate.ordinal, 0, stats)
 		if err != nil {
-			return nil, stats, err
+			return nil, *stats, err
 		}
 		if len(adjacency) == 0 {
 			continue
@@ -295,7 +301,7 @@ func (v *columnHNSWSearchPackPreparedView) searchCosinePreparedScorePlane(query 
 				loopEdgeVisits++
 			}
 			if uint64(neighbor) >= rowCount64 {
-				return nil, stats, fmt.Errorf("collections: hnsw_search_pack_v1 prepared traversal ordinal=%d adjacency[%d]=%d outside row_count=%d: %w", candidate.ordinal, i, neighbor, rowCount, errColumnVectorGraphAdjacencyOrdinalOutOfBounds)
+				return nil, *stats, fmt.Errorf("collections: hnsw_search_pack_v1 prepared traversal ordinal=%d adjacency[%d]=%d outside row_count=%d: %w", candidate.ordinal, i, neighbor, rowCount, errColumnVectorGraphAdjacencyOrdinalOutOfBounds)
 			}
 			neighborOrdinal := int(neighbor)
 			if visitMarks[neighborOrdinal] == visitEpoch {
@@ -305,8 +311,8 @@ func (v *columnHNSWSearchPackPreparedView) searchCosinePreparedScorePlane(query 
 			tile = append(tile, neighborOrdinal)
 		}
 		if len(tile) != 0 {
-			if err := v.scoreAndPushFrontierVisitedTilePreparedScorePlane(scorePlane, tile, retainedCandidateLimit, scratch, &stats, &visitedCandidates); err != nil {
-				return nil, stats, err
+			if err := v.scoreAndPushFrontierVisitedTilePreparedScorePlane(scorePlane, tile, retainedCandidateLimit, scratch, stats, &visitedCandidates); err != nil {
+				return nil, *stats, err
 			}
 		}
 	}
@@ -316,7 +322,7 @@ func (v *columnHNSWSearchPackPreparedView) searchCosinePreparedScorePlane(query 
 		stats.Candidates = visitedCandidates
 	}
 	if len(scratch.top) == 0 {
-		return scratch.results, stats, nil
+		return scratch.results, *stats, nil
 	}
 	if opts.OmitResultMaterialization {
 		if len(scratch.top) > retainedCandidateLimit {
@@ -325,15 +331,15 @@ func (v *columnHNSWSearchPackPreparedView) searchCosinePreparedScorePlane(query 
 		for _, candidate := range scratch.top {
 			scratch.results = append(scratch.results, columnVectorGraphNativeSearchResult{Ordinal: candidate.ordinal, Score: candidate.score})
 		}
-		return scratch.results, stats, nil
+		return scratch.results, *stats, nil
 	}
 	if len(scratch.top) > topK {
 		scratch.top = scratch.top[:topK]
 	}
-	if err := v.fetchTopSearchResults(scratch, &stats); err != nil {
-		return nil, stats, err
+	if err := v.fetchTopSearchResults(scratch, stats); err != nil {
+		return nil, *stats, err
 	}
-	return scratch.results, stats, nil
+	return scratch.results, *stats, nil
 }
 
 func (v *columnHNSWSearchPackPreparedView) greedyNearestAtLayerPreparedScorePlane(scorePlane columnHNSWPreparedTraversalScorePlane, entryOrdinal int, layer int, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats, countLoopEdges bool, loopEdgeVisits *uint64) (int, error) {
@@ -415,6 +421,50 @@ func (v *columnHNSWSearchPackPreparedView) scoreAndPushFrontierVisitedTilePrepar
 		if scratch.insertTop(topK, candidate) {
 			scratch.pushFrontier(candidate)
 		}
+	}
+	return nil
+}
+
+func (v *columnHNSWSearchPackPreparedView) exactRerankPreparedTraversalCandidates(query []float32, topK int, scoreBatchMode columnVectorGraphScoreBatchMode, scratch *columnVectorGraphNativeSearchScratch, stats *columnVectorGraphNativeSearchStats) error {
+	if v == nil {
+		return errColumnHNSWSearchPackSearchUnavailable
+	}
+	if scratch == nil {
+		return errColumnVectorGraphNativeSearchScratchRequired
+	}
+	if len(scratch.top) == 0 || topK <= 0 {
+		scratch.top = scratch.top[:0]
+		return nil
+	}
+	if len(scratch.top) < topK {
+		topK = len(scratch.top)
+	}
+	n := len(scratch.top)
+	scratch.scoreTileOrdinals = ensureColumnVectorGraphNativeIntScratch(scratch.scoreTileOrdinals, n)
+	ordinals := scratch.scoreTileOrdinals[:0]
+	for _, candidate := range scratch.top {
+		ordinals = append(ordinals, candidate.ordinal)
+	}
+	var exactPlane columnHNSWPreparedExactFP32ScorePlane
+	if err := exactPlane.prepareForHNSWPreparedTraversal(v, query, columnHNSWPreparedTraversalOptions{ScoreBatchMode: scoreBatchMode}, scratch); err != nil {
+		return err
+	}
+	scratch.scoreTileScores = ensureColumnVectorGraphNativeFloat64Scratch(scratch.scoreTileScores, n)
+	exactScores, err := exactPlane.scoreOrdinals(ordinals, scratch.scoreTileScores, scratch, stats)
+	if err != nil {
+		return err
+	}
+	if len(exactScores) != n {
+		return fmt.Errorf("collections: hnsw_search_pack_v1 prepared traversal exact rerank scored %d candidates want %d", len(exactScores), n)
+	}
+	if stats != nil {
+		stats.QuantizedRerankCandidates += uint64(n)
+		stats.QuantizedRerankExactScoreCalls += uint64(n)
+	}
+	scratch.top = scratch.top[:0]
+	for i, ordinal := range ordinals {
+		candidate := columnVectorGraphSearchCandidate{ordinal: ordinal, score: exactScores[i]}
+		scratch.insertTop(topK, candidate)
 	}
 	return nil
 }

--- a/TreeDB/collections/column_hnsw_rabitq_prepared_search.go
+++ b/TreeDB/collections/column_hnsw_rabitq_prepared_search.go
@@ -1,0 +1,134 @@
+package collections
+
+import (
+	"fmt"
+
+	"github.com/snissn/gomap/TreeDB/internal/rabitq"
+)
+
+func columnVectorGraphQuantizedIndexIsRabitQ1Bit(def VectorIndexDefinition, name string) bool {
+	qdef, ok := findQuantizedVectorIndex(def, name)
+	return ok && qdef.Codec == rabitq.CodecName && qdef.Version == rabitq.CodecVersion
+}
+
+func (r *columnVectorGraphPhysicalRowReader) rabitqHNSWSearchPackPreparedRouteEligible(queryMode columnVectorGraphNativeSearchQueryMode, quantizedIndexName string, statsMode columnVectorGraphNativeSearchStatsMode) bool {
+	if r == nil || !queryMode.quantized() || !columnVectorGraphQuantizedIndexIsRabitQ1Bit(r.def, quantizedIndexName) {
+		return false
+	}
+	if !columnHNSWSearchPackStatsModeSupportedForSearch(statsMode) {
+		return false
+	}
+	pack := r.hnswSearchPack
+	if pack == nil {
+		return false
+	}
+	status := pack.fastStatus(r.hnswSearchPackStatus)
+	return status == columnHNSWSearchPackPreparedStatusDirect || status == columnHNSWSearchPackPreparedStatusHeap
+}
+
+func (r *columnVectorGraphPhysicalRowReader) searchRabitQCosinePreparedHNSWPack(query []float32, opts columnVectorGraphNativeSearchOptions, scratch *columnVectorGraphNativeSearchScratch) ([]columnVectorGraphNativeSearchResult, columnVectorGraphNativeSearchStats, error) {
+	var stats columnVectorGraphNativeSearchStats
+	if r == nil {
+		return nil, stats, errNilColumnVectorGraphPhysicalRowReader
+	}
+	queryMode, err := opts.QueryMode.normalized()
+	if err != nil {
+		return nil, stats, fmt.Errorf("collections: hnsw_search_pack_v1 rabitq_1bit prepared traversal query mode: %w", err)
+	}
+	if queryMode == columnVectorGraphNativeSearchQueryModeQuantizedOnly {
+		stats.SearchRouteQuantizedOnly = 1
+	} else if queryMode == columnVectorGraphNativeSearchQueryModeQuantizedRerank {
+		stats.SearchRouteQuantizedRerank = 1
+	} else {
+		return nil, stats, errColumnHNSWSearchPackSearchUnsupportedMode
+	}
+	if opts.HasCandidateRows {
+		return nil, stats, errColumnHNSWSearchPackSearchCandidateRows
+	}
+	if len(query) != r.def.Dimensions {
+		return nil, stats, fmt.Errorf("collections: column_graph %q query dims=%d want %d: %w", r.def.Name, len(query), r.def.Dimensions, errColumnVectorGraphNativeSearchQueryDimensionMismatch)
+	}
+	r.populateQuantizedAssetSearchStats(opts.QuantizedIndexName, &stats)
+	if err := r.validateQuantizedNativeSearchOptions(queryMode, opts); err != nil {
+		return nil, stats, err
+	}
+	if !columnVectorGraphQuantizedIndexIsRabitQ1Bit(r.def, opts.QuantizedIndexName) {
+		return nil, stats, fmt.Errorf("%w: column_graph %q quantized index %q is not rabitq_1bit v%d", ErrVectorIndexSearchUnavailable, r.def.Name, opts.QuantizedIndexName, rabitq.CodecVersion)
+	}
+	if scratch == nil {
+		return nil, stats, fmt.Errorf("collections: column_graph %q: %w", r.def.Name, errColumnVectorGraphNativeSearchScratchRequired)
+	}
+	pack := r.hnswSearchPack
+	status := columnHNSWSearchPackPreparedStatusMissing
+	if pack != nil {
+		status = pack.fastStatus(r.hnswSearchPackStatus)
+	}
+	if status != columnHNSWSearchPackPreparedStatusDirect && status != columnHNSWSearchPackPreparedStatusHeap {
+		return nil, stats, columnHNSWSearchPackStatusError(status)
+	}
+	if opts.TopK == 0 || r.RowCount() == 0 {
+		return nil, stats, nil
+	}
+
+	scorer, err := r.prepareRabitQQuantizedScorer(queryMode, opts.QuantizedIndexName, query, scratch)
+	if err != nil {
+		recordColumnVectorGraphQuantizedAssetErrorStats(&stats, err)
+		return nil, stats, err
+	}
+	scratch.preparedTraversalQuantizedScorer = columnVectorGraphQuantizedScorer{kind: columnVectorGraphQuantizedScorerKindRabitQ1Bit, rabitq: scorer}
+	scratch.preparedTraversalQuantizedScorePlane.scorer = &scratch.preparedTraversalQuantizedScorer
+	traversalOpts := columnHNSWPreparedTraversalOptions{
+		TopK:                      opts.TopK,
+		EfSearch:                  opts.EfSearch,
+		RetainedCandidateLimit:    opts.QuantizedRerankCandidates,
+		ScoreBatchMode:            opts.ScoreBatchMode,
+		StatsMode:                 opts.StatsMode,
+		OmitResultMaterialization: opts.OmitResultMaterialization,
+	}
+	if queryMode == columnVectorGraphNativeSearchQueryModeQuantizedRerank {
+		traversalOpts.OmitResultMaterialization = true
+	}
+	results, searchStats, err := pack.searchCosinePreparedScorePlane(query, traversalOpts, scratch, &scratch.preparedTraversalQuantizedScorePlane)
+	applyColumnVectorGraphQuantizedBaseStats(&searchStats, stats)
+	searchStats.QuantizedScorerActive = 1
+	if err != nil {
+		return results, searchStats, err
+	}
+	if queryMode != columnVectorGraphNativeSearchQueryModeQuantizedRerank {
+		return results, searchStats, nil
+	}
+	if err := pack.exactRerankPreparedTraversalCandidates(query, opts.TopK, opts.ScoreBatchMode, scratch, &searchStats); err != nil {
+		return nil, searchStats, err
+	}
+	if opts.OmitResultMaterialization {
+		scratch.results = scratch.results[:0]
+		for _, candidate := range scratch.top {
+			scratch.results = append(scratch.results, columnVectorGraphNativeSearchResult{Ordinal: candidate.ordinal, Score: candidate.score})
+		}
+		return scratch.results, searchStats, nil
+	}
+	scratch.results = scratch.results[:0]
+	if err := pack.fetchTopSearchResults(scratch, &searchStats); err != nil {
+		return nil, searchStats, err
+	}
+	return scratch.results, searchStats, nil
+}
+
+func applyColumnVectorGraphQuantizedBaseStats(dst *columnVectorGraphNativeSearchStats, base columnVectorGraphNativeSearchStats) {
+	if dst == nil {
+		return
+	}
+	dst.SearchRouteQuantizedOnly = base.SearchRouteQuantizedOnly
+	dst.SearchRouteQuantizedRerank = base.SearchRouteQuantizedRerank
+	dst.QuantizedAssetMissing = base.QuantizedAssetMissing
+	dst.QuantizedAssetInvalid = base.QuantizedAssetInvalid
+	dst.QuantizedAssetStale = base.QuantizedAssetStale
+	dst.QuantizedAssetClosed = base.QuantizedAssetClosed
+	dst.QuantizedAssetUnavailable = base.QuantizedAssetUnavailable
+	dst.QuantizedAssetMmapDirect = base.QuantizedAssetMmapDirect
+	dst.QuantizedAssetHeapCopy = base.QuantizedAssetHeapCopy
+	dst.QuantizedAssetOpenNanos = base.QuantizedAssetOpenNanos
+	dst.QuantizedAssetMappedBytes = base.QuantizedAssetMappedBytes
+	dst.QuantizedAssetHeapCopyBytes = base.QuantizedAssetHeapCopyBytes
+	dst.QuantizedAssetActiveHandles = base.QuantizedAssetActiveHandles
+}

--- a/TreeDB/collections/column_hnsw_rabitq_prepared_search.go
+++ b/TreeDB/collections/column_hnsw_rabitq_prepared_search.go
@@ -94,6 +94,7 @@ func (r *columnVectorGraphPhysicalRowReader) searchRabitQCosinePreparedHNSWPack(
 	}
 	if queryMode == columnVectorGraphNativeSearchQueryModeQuantizedRerank {
 		traversalOpts.OmitResultMaterialization = true
+		traversalOpts.SuppressOmittedResultMaterialization = true
 	}
 	results, searchStats, err := pack.searchCosinePreparedScorePlane(query, traversalOpts, scratch, &scratch.preparedQuantizedPlane)
 	applyColumnVectorGraphQuantizedBaseStats(&searchStats, stats)

--- a/TreeDB/collections/column_hnsw_rabitq_prepared_search.go
+++ b/TreeDB/collections/column_hnsw_rabitq_prepared_search.go
@@ -87,12 +87,14 @@ func (r *columnVectorGraphPhysicalRowReader) searchRabitQCosinePreparedHNSWPack(
 	traversalOpts := columnHNSWPreparedTraversalOptions{
 		TopK:                      opts.TopK,
 		EfSearch:                  opts.EfSearch,
-		RetainedCandidateLimit:    opts.QuantizedRerankCandidates,
+		RetainedCandidateLimit:    0,
 		ScoreBatchMode:            opts.ScoreBatchMode,
 		StatsMode:                 traversalStatsMode,
 		OmitResultMaterialization: opts.OmitResultMaterialization,
 	}
+	rerankCandidateLimit := 0
 	if queryMode == columnVectorGraphNativeSearchQueryModeQuantizedRerank {
+		rerankCandidateLimit = opts.QuantizedRerankCandidates
 		traversalOpts.OmitResultMaterialization = true
 		traversalOpts.SuppressOmittedResultMaterialization = true
 	}
@@ -104,6 +106,9 @@ func (r *columnVectorGraphPhysicalRowReader) searchRabitQCosinePreparedHNSWPack(
 	}
 	if queryMode != columnVectorGraphNativeSearchQueryModeQuantizedRerank {
 		return results, searchStats, nil
+	}
+	if rerankCandidateLimit > 0 && len(scratch.top) > rerankCandidateLimit {
+		scratch.top = scratch.top[:rerankCandidateLimit]
 	}
 	if err := pack.exactRerankPreparedTraversalCandidates(query, opts.TopK, opts.ScoreBatchMode, scratch, &searchStats); err != nil {
 		return nil, searchStats, err

--- a/TreeDB/collections/column_hnsw_rabitq_prepared_search.go
+++ b/TreeDB/collections/column_hnsw_rabitq_prepared_search.go
@@ -87,6 +87,7 @@ func (r *columnVectorGraphPhysicalRowReader) searchRabitQCosinePreparedHNSWPack(
 	}
 	if queryMode == columnVectorGraphNativeSearchQueryModeQuantizedRerank {
 		traversalOpts.OmitResultMaterialization = true
+		traversalOpts.SuppressOmittedResultMaterialization = true
 	}
 	results, searchStats, err := pack.searchCosinePreparedScorePlane(query, traversalOpts, scratch, &scratch.preparedQuantizedPlane)
 	applyColumnVectorGraphQuantizedBaseStats(&searchStats, stats)

--- a/TreeDB/collections/column_hnsw_rabitq_prepared_search.go
+++ b/TreeDB/collections/column_hnsw_rabitq_prepared_search.go
@@ -1,0 +1,134 @@
+package collections
+
+import (
+	"fmt"
+
+	"github.com/snissn/gomap/TreeDB/internal/rabitq"
+)
+
+func columnVectorGraphQuantizedIndexIsRabitQ1Bit(def VectorIndexDefinition, name string) bool {
+	qdef, ok := findQuantizedVectorIndex(def, name)
+	return ok && qdef.Codec == rabitq.CodecName && qdef.Version == rabitq.CodecVersion
+}
+
+func (r *columnVectorGraphPhysicalRowReader) rabitqHNSWSearchPackPreparedRouteEligible(queryMode columnVectorGraphNativeSearchQueryMode, quantizedIndexName string, statsMode columnVectorGraphNativeSearchStatsMode) bool {
+	if r == nil || !queryMode.quantized() || !columnVectorGraphQuantizedIndexIsRabitQ1Bit(r.def, quantizedIndexName) {
+		return false
+	}
+	if !columnHNSWSearchPackStatsModeSupportedForSearch(statsMode) {
+		return false
+	}
+	pack := r.hnswSearchPack
+	if pack == nil {
+		return false
+	}
+	status := pack.fastStatus(r.hnswSearchPackStatus)
+	return status == columnHNSWSearchPackPreparedStatusDirect || status == columnHNSWSearchPackPreparedStatusHeap
+}
+
+func (r *columnVectorGraphPhysicalRowReader) searchRabitQCosinePreparedHNSWPack(query []float32, opts columnVectorGraphNativeSearchOptions, scratch *columnVectorGraphNativeSearchScratch) ([]columnVectorGraphNativeSearchResult, columnVectorGraphNativeSearchStats, error) {
+	var stats columnVectorGraphNativeSearchStats
+	if r == nil {
+		return nil, stats, errNilColumnVectorGraphPhysicalRowReader
+	}
+	queryMode, err := opts.QueryMode.normalized()
+	if err != nil {
+		return nil, stats, fmt.Errorf("collections: hnsw_search_pack_v1 rabitq_1bit prepared traversal query mode: %w", err)
+	}
+	if queryMode == columnVectorGraphNativeSearchQueryModeQuantizedOnly {
+		stats.SearchRouteQuantizedOnly = 1
+	} else if queryMode == columnVectorGraphNativeSearchQueryModeQuantizedRerank {
+		stats.SearchRouteQuantizedRerank = 1
+	} else {
+		return nil, stats, errColumnHNSWSearchPackSearchUnsupportedMode
+	}
+	if opts.HasCandidateRows {
+		return nil, stats, errColumnHNSWSearchPackSearchCandidateRows
+	}
+	if len(query) != r.def.Dimensions {
+		return nil, stats, fmt.Errorf("collections: column_graph %q query dims=%d want %d: %w", r.def.Name, len(query), r.def.Dimensions, errColumnVectorGraphNativeSearchQueryDimensionMismatch)
+	}
+	r.populateQuantizedAssetSearchStats(opts.QuantizedIndexName, &stats)
+	if err := r.validateQuantizedNativeSearchOptions(queryMode, opts); err != nil {
+		return nil, stats, err
+	}
+	if !columnVectorGraphQuantizedIndexIsRabitQ1Bit(r.def, opts.QuantizedIndexName) {
+		return nil, stats, fmt.Errorf("%w: column_graph %q quantized index %q is not rabitq_1bit v%d", ErrVectorIndexSearchUnavailable, r.def.Name, opts.QuantizedIndexName, rabitq.CodecVersion)
+	}
+	if scratch == nil {
+		return nil, stats, fmt.Errorf("collections: column_graph %q: %w", r.def.Name, errColumnVectorGraphNativeSearchScratchRequired)
+	}
+	pack := r.hnswSearchPack
+	status := columnHNSWSearchPackPreparedStatusMissing
+	if pack != nil {
+		status = pack.fastStatus(r.hnswSearchPackStatus)
+	}
+	if status != columnHNSWSearchPackPreparedStatusDirect && status != columnHNSWSearchPackPreparedStatusHeap {
+		return nil, stats, columnHNSWSearchPackStatusError(status)
+	}
+	if opts.TopK == 0 || r.RowCount() == 0 {
+		return nil, stats, nil
+	}
+
+	scorer, err := r.prepareRabitQQuantizedScorer(queryMode, opts.QuantizedIndexName, query, scratch)
+	if err != nil {
+		recordColumnVectorGraphQuantizedAssetErrorStats(&stats, err)
+		return nil, stats, err
+	}
+	scratch.searchPlan.quantizedScorer = columnVectorGraphQuantizedScorer{kind: columnVectorGraphQuantizedScorerKindRabitQ1Bit, rabitq: scorer}
+	scratch.preparedQuantizedPlane.scorer = &scratch.searchPlan.quantizedScorer
+	traversalOpts := columnHNSWPreparedTraversalOptions{
+		TopK:                      opts.TopK,
+		EfSearch:                  opts.EfSearch,
+		RetainedCandidateLimit:    opts.QuantizedRerankCandidates,
+		ScoreBatchMode:            opts.ScoreBatchMode,
+		StatsMode:                 opts.StatsMode,
+		OmitResultMaterialization: opts.OmitResultMaterialization,
+	}
+	if queryMode == columnVectorGraphNativeSearchQueryModeQuantizedRerank {
+		traversalOpts.OmitResultMaterialization = true
+	}
+	results, searchStats, err := pack.searchCosinePreparedScorePlane(query, traversalOpts, scratch, &scratch.preparedQuantizedPlane)
+	applyColumnVectorGraphQuantizedBaseStats(&searchStats, stats)
+	searchStats.QuantizedScorerActive = 1
+	if err != nil {
+		return results, searchStats, err
+	}
+	if queryMode != columnVectorGraphNativeSearchQueryModeQuantizedRerank {
+		return results, searchStats, nil
+	}
+	if err := pack.exactRerankPreparedTraversalCandidates(query, opts.TopK, opts.ScoreBatchMode, scratch, &searchStats); err != nil {
+		return nil, searchStats, err
+	}
+	if opts.OmitResultMaterialization {
+		scratch.results = scratch.results[:0]
+		for _, candidate := range scratch.top {
+			scratch.results = append(scratch.results, columnVectorGraphNativeSearchResult{Ordinal: candidate.ordinal, Score: candidate.score})
+		}
+		return scratch.results, searchStats, nil
+	}
+	scratch.results = scratch.results[:0]
+	if err := pack.fetchTopSearchResults(scratch, &searchStats); err != nil {
+		return nil, searchStats, err
+	}
+	return scratch.results, searchStats, nil
+}
+
+func applyColumnVectorGraphQuantizedBaseStats(dst *columnVectorGraphNativeSearchStats, base columnVectorGraphNativeSearchStats) {
+	if dst == nil {
+		return
+	}
+	dst.SearchRouteQuantizedOnly = base.SearchRouteQuantizedOnly
+	dst.SearchRouteQuantizedRerank = base.SearchRouteQuantizedRerank
+	dst.QuantizedAssetMissing = base.QuantizedAssetMissing
+	dst.QuantizedAssetInvalid = base.QuantizedAssetInvalid
+	dst.QuantizedAssetStale = base.QuantizedAssetStale
+	dst.QuantizedAssetClosed = base.QuantizedAssetClosed
+	dst.QuantizedAssetUnavailable = base.QuantizedAssetUnavailable
+	dst.QuantizedAssetMmapDirect = base.QuantizedAssetMmapDirect
+	dst.QuantizedAssetHeapCopy = base.QuantizedAssetHeapCopy
+	dst.QuantizedAssetOpenNanos = base.QuantizedAssetOpenNanos
+	dst.QuantizedAssetMappedBytes = base.QuantizedAssetMappedBytes
+	dst.QuantizedAssetHeapCopyBytes = base.QuantizedAssetHeapCopyBytes
+	dst.QuantizedAssetActiveHandles = base.QuantizedAssetActiveHandles
+}

--- a/TreeDB/collections/column_vector_graph_quantized_bench_test.go
+++ b/TreeDB/collections/column_vector_graph_quantized_bench_test.go
@@ -1796,6 +1796,9 @@ func assertColumnGraphRabitQQuantizedSearchWithBufferGuardrails2451(tb testing.T
 		if stats.SearchRouteQuantizedOnly != 1 || stats.SearchRouteQuantizedRerank != 0 || stats.QuantizedScorerActive != 1 {
 			tb.Fatalf("rabitq quantized_only route stats=%+v", stats)
 		}
+		if stats.SearchRouteHNSWSearchPack != 1 || stats.HNSWSearchPackActive != 1 || stats.HNSWSearchPackFallbacks != 0 || stats.SearchRouteColumnGraphPrepared != 0 || stats.SearchRouteColumnGraphFallback != 0 {
+			tb.Fatalf("rabitq quantized_only route stats=%+v want prepared hnsw_search_pack_v1 score-plane traversal", stats)
+		}
 		if stats.PreparedScoreCalls != 0 || stats.QuantizedRerankExactScoreCalls != 0 || stats.VectorBytesRead != 0 || stats.NormBytesRead != 0 {
 			tb.Fatalf("rabitq quantized_only exact stats=%+v want none", stats)
 		}
@@ -1803,11 +1806,14 @@ func assertColumnGraphRabitQQuantizedSearchWithBufferGuardrails2451(tb testing.T
 		if stats.SearchRouteQuantizedOnly != 0 || stats.SearchRouteQuantizedRerank != 1 || stats.QuantizedScorerActive != 1 {
 			tb.Fatalf("rabitq quantized_rerank route stats=%+v", stats)
 		}
+		if stats.SearchRouteHNSWSearchPack != 1 || stats.HNSWSearchPackActive != 1 || stats.HNSWSearchPackFallbacks != 0 || stats.SearchRouteColumnGraphPrepared != 0 || stats.SearchRouteColumnGraphFallback != 0 {
+			tb.Fatalf("rabitq quantized_rerank route stats=%+v want prepared hnsw_search_pack_v1 score-plane traversal", stats)
+		}
 		if stats.QuantizedRerankCandidates != uint64(opts.QuantizedRerankCandidates) || stats.QuantizedRerankExactScoreCalls != uint64(opts.QuantizedRerankCandidates) {
 			tb.Fatalf("rabitq quantized_rerank stats=%+v want shortlist=%d", stats, opts.QuantizedRerankCandidates)
 		}
-		if stats.VectorBytesRead != uint64(opts.QuantizedRerankCandidates*dims*4) || stats.NormBytesRead != uint64(opts.QuantizedRerankCandidates*4) {
-			tb.Fatalf("rabitq quantized_rerank exact bytes stats=%+v want vector=%d norm=%d", stats, opts.QuantizedRerankCandidates*dims*4, opts.QuantizedRerankCandidates*4)
+		if stats.VectorBytesRead != uint64(opts.QuantizedRerankCandidates*dims*4) || stats.NormBytesRead != 0 {
+			tb.Fatalf("rabitq quantized_rerank exact bytes stats=%+v want prepared-pack vector=%d norm=0", stats, opts.QuantizedRerankCandidates*dims*4)
 		}
 	default:
 		tb.Fatalf("unexpected rabitq SearchWithBuffer benchmark query mode %q", opts.QueryMode)

--- a/TreeDB/collections/column_vector_graph_rabitq_quantized_asset_test.go
+++ b/TreeDB/collections/column_vector_graph_rabitq_quantized_asset_test.go
@@ -279,6 +279,78 @@ func TestRabitQPreparedHNSWSearchPackRouteParity2587(t *testing.T) {
 	}
 }
 
+func TestRabitQPreparedHNSWSearchPackRerankPreservesEfTraversal2587(t *testing.T) {
+	rows := []columnGraphRebuildInputRowV2A{
+		{id: "doc-a", vector: []float32{1, 0, 0}},
+		{id: "doc-b", vector: []float32{0.95, 0.05, 0}},
+		{id: "doc-c", vector: []float32{0.85, 0.15, 0}},
+		{id: "doc-d", vector: []float32{0.75, 0.25, 0}},
+		{id: "doc-e", vector: []float32{0.65, 0.35, 0}},
+		{id: "doc-f", vector: []float32{0.55, 0.45, 0}},
+		{id: "doc-g", vector: []float32{0.45, 0.55, 0}},
+		{id: "doc-h", vector: []float32{0.35, 0.65, 0}},
+	}
+	_, d, col, def := openColumnGraphRabitQQuantizedTestCollection2450(t, rows)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	packSearcher, err := col.OpenVectorIndexSearcher(VectorIndexSearcherOptions{IndexName: def.Name, MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("OpenVectorIndexSearcher pack: %v", err)
+	}
+	defer func() { _ = packSearcher.Close() }()
+	fallbackSearcher, err := col.OpenVectorIndexSearcher(VectorIndexSearcherOptions{IndexName: def.Name, MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("OpenVectorIndexSearcher fallback: %v", err)
+	}
+	defer func() { _ = fallbackSearcher.Close() }()
+	if fallbackSearcher.reader == nil || fallbackSearcher.reader.hnswSearchPack == nil {
+		t.Fatalf("fallback searcher missing reader or prepared pack")
+	}
+	fallbackSearcher.reader.hnswSearchPack = nil
+
+	opts := VectorIndexSearcherSearchOptions{
+		Query:                     []float32{0.7, 0.3, 0},
+		QueryMode:                 VectorIndexQueryModeQuantizedRerank,
+		QuantizedIndexName:        def.QuantizedIndexes[0].Name,
+		QuantizedRerankCandidates: 4,
+		TopK:                      3,
+		EfSearch:                  len(rows),
+		StatsMode:                 VectorIndexSearchStatsModeProduction,
+	}
+	var packBuffer, fallbackBuffer VectorIndexSearchBuffer
+	packResults, err := packSearcher.SearchWithBuffer(opts, &packBuffer)
+	if err != nil {
+		t.Fatalf("pack SearchWithBuffer: %v", err)
+	}
+	fallbackResults, err := fallbackSearcher.SearchWithBuffer(opts, &fallbackBuffer)
+	if err != nil {
+		t.Fatalf("fallback SearchWithBuffer: %v", err)
+	}
+	for name, stats := range map[string]VectorIndexSearchStats{"pack": packResults.Stats, "fallback": fallbackResults.Stats} {
+		if stats.DocumentsFetched != 0 || stats.GraphRowFallbacks != 0 || stats.TypedColumnFallbacks != 0 || stats.VectorScratchDecodes != 0 {
+			t.Fatalf("%s stats=%+v want no document/fallback guardrail counters", name, stats)
+		}
+		if stats.QuantizedRerankExactScoreCalls != uint64(opts.QuantizedRerankCandidates) || stats.PreparedScoreCalls != uint64(opts.QuantizedRerankCandidates) {
+			t.Fatalf("%s stats=%+v want rerank shortlist=%d", name, stats, opts.QuantizedRerankCandidates)
+		}
+	}
+	if packResults.Stats.Candidates != fallbackResults.Stats.Candidates || packResults.Stats.VisitedEdges != fallbackResults.Stats.VisitedEdges || packResults.Stats.QuantizedScoreCalls != fallbackResults.Stats.QuantizedScoreCalls || packResults.Stats.QuantizedRerankExactScoreCalls != fallbackResults.Stats.QuantizedRerankExactScoreCalls {
+		t.Fatalf("pack stats=%+v fallback stats=%+v want same efSearch traversal and rerank counters", packResults.Stats, fallbackResults.Stats)
+	}
+	if len(packResults.Results) != len(fallbackResults.Results) {
+		t.Fatalf("pack results=%d fallback results=%d", len(packResults.Results), len(fallbackResults.Results))
+	}
+	for i := range packResults.Results {
+		got := packResults.Results[i]
+		want := fallbackResults.Results[i]
+		if got.Ordinal != want.Ordinal || !bytes.Equal(got.ID, want.ID) || math.Abs(got.Score-want.Score) > 1e-6 {
+			t.Fatalf("result[%d] pack=%+v fallback=%+v", i, got, want)
+		}
+	}
+}
+
 func TestCollectionSearchVectorIndexWithBufferRabitQConcurrentPreparedPack2587(t *testing.T) {
 	rows := make([]columnGraphRebuildInputRowV2A, 32)
 	for i := range rows {

--- a/TreeDB/collections/column_vector_graph_rabitq_quantized_asset_test.go
+++ b/TreeDB/collections/column_vector_graph_rabitq_quantized_asset_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"strings"
+	"sync"
 	"testing"
 
 	backenddb "github.com/snissn/gomap/TreeDB/db"
@@ -211,6 +212,150 @@ func TestVectorIndexSearcherRabitQQuantizedSearchWithBuffer2451(t *testing.T) {
 		t.Fatalf("rabitq quantized_rerank short results=%d want 2", len(rerankedShort.Results))
 	}
 	assertRabitQQuantizedRerankStats2451(t, rerankedShort.Stats, shortlist, def.Dimensions, plan.BytesPerCode())
+}
+
+func TestRabitQPreparedHNSWSearchPackRouteParity2587(t *testing.T) {
+	rows := []columnGraphRebuildInputRowV2A{
+		{id: "doc-a", vector: []float32{1, 0, 0}},
+		{id: "doc-b", vector: []float32{0.7, 0.2, 0.1}},
+		{id: "doc-c", vector: []float32{0.1, 0.8, 0.2}},
+		{id: "doc-d", vector: []float32{0, 0.1, 0.9}},
+		{id: "doc-e", vector: []float32{-0.2, 0.4, 0.7}},
+		{id: "doc-f", vector: []float32{0.3, -0.4, 0.6}},
+		{id: "doc-g", vector: []float32{-0.5, 0.1, 0.7}},
+		{id: "doc-h", vector: []float32{0.2, 0.5, -0.4}},
+	}
+	query := []float32{0.25, 0.7, -0.1}
+	_, d, col, def := openColumnGraphRabitQQuantizedTestCollection2450(t, rows)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	searcher, err := col.OpenVectorIndexSearcher(VectorIndexSearcherOptions{IndexName: def.Name, MaxDecodedBlocks: 1})
+	if err != nil {
+		t.Fatalf("OpenVectorIndexSearcher: %v", err)
+	}
+	defer func() { _ = searcher.Close() }()
+	qName := def.QuantizedIndexes[0].Name
+	cases := []struct {
+		name      string
+		mode      VectorIndexQueryMode
+		topK      int
+		rerank    int
+		wantExact bool
+	}{
+		{name: "quantized_only", mode: VectorIndexQueryModeQuantizedOnly, topK: 4},
+		{name: "quantized_rerank_all", mode: VectorIndexQueryModeQuantizedRerank, topK: 3, rerank: len(rows), wantExact: true},
+		{name: "quantized_rerank_shortlist", mode: VectorIndexQueryModeQuantizedRerank, topK: 3, rerank: 5, wantExact: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			legacyOpts := columnVectorGraphNativeSearchOptions{TopK: tc.topK, EfSearch: len(rows), QueryMode: columnVectorGraphNativeSearchQueryModeFromPublic2415(tc.mode), QuantizedIndexName: qName, QuantizedRerankCandidates: tc.rerank}
+			var legacyScratch columnVectorGraphNativeSearchScratch
+			legacy, legacyStats, err := searcher.reader.SearchCosine(query, legacyOpts, &legacyScratch)
+			if err != nil {
+				t.Fatalf("legacy SearchCosine: %v", err)
+			}
+			var buffer VectorIndexSearchBuffer
+			got, err := searcher.SearchWithBuffer(VectorIndexSearcherSearchOptions{Query: query, QueryMode: tc.mode, QuantizedIndexName: qName, QuantizedRerankCandidates: tc.rerank, TopK: tc.topK, EfSearch: len(rows)}, &buffer)
+			if err != nil {
+				t.Fatalf("SearchWithBuffer prepared pack route: %v", err)
+			}
+			assertRabitQPreparedPackResultsMatch2587(t, got.Results, legacy)
+			if got.Stats.SearchRouteHNSWSearchPack != 1 || got.Stats.HNSWSearchPackActive != 1 || got.Stats.SearchRouteColumnGraphPrepared+got.Stats.SearchRouteColumnGraphFallback != 0 {
+				t.Fatalf("prepared pack route stats=%+v", got.Stats)
+			}
+			if got.Stats.QuantizedScoreCalls != legacyStats.QuantizedScoreCalls || got.Stats.QuantizedCodeBytesRead != legacyStats.QuantizedCodeBytesRead {
+				t.Fatalf("quantized scorer counters got=%+v legacy=%+v", got.Stats, legacyStats)
+			}
+			if tc.wantExact {
+				if got.Stats.QuantizedRerankCandidates != uint64(tc.rerank) || got.Stats.QuantizedRerankExactScoreCalls != uint64(tc.rerank) || got.Stats.PreparedScoreCalls != uint64(tc.rerank) {
+					t.Fatalf("rerank counters=%+v want shortlist=%d", got.Stats, tc.rerank)
+				}
+			} else if got.Stats.PreparedScoreCalls != 0 || got.Stats.VectorBytesRead != 0 || got.Stats.NormBytesRead != 0 {
+				t.Fatalf("quantized_only exact counters=%+v want zero", got.Stats)
+			}
+		})
+	}
+}
+
+func TestCollectionSearchVectorIndexWithBufferRabitQConcurrentPreparedPack2587(t *testing.T) {
+	rows := make([]columnGraphRebuildInputRowV2A, 32)
+	for i := range rows {
+		rows[i] = columnGraphRebuildInputRowV2A{id: fmt.Sprintf("doc-%02d", i), vector: rabitqTestVector2477(3, uint64(i+1))}
+	}
+	_, d, col, def := openColumnGraphRabitQQuantizedTestCollection2450(t, rows)
+	defer func() { _ = d.Close() }()
+	if _, err := col.RebuildVectorIndex(def.Name); err != nil {
+		t.Fatalf("RebuildVectorIndex: %v", err)
+	}
+	qName := def.QuantizedIndexes[0].Name
+	warmOpts := VectorIndexSearchOptions{IndexName: def.Name, Query: rabitqTestVector2477(3, 100), QueryMode: VectorIndexQueryModeQuantizedOnly, QuantizedIndexName: qName, TopK: 4, EfSearch: len(rows), MaxDecodedBlocks: 1, StatsMode: VectorIndexSearchStatsModeProduction}
+	var warmBuffer VectorIndexSearchBuffer
+	if _, err := col.SearchVectorIndexWithBuffer(warmOpts, &warmBuffer); err != nil {
+		t.Fatalf("warm SearchVectorIndexWithBuffer: %v", err)
+	}
+	const workers = 8
+	const iterations = 20
+	var wg sync.WaitGroup
+	errCh := make(chan error, workers)
+	for worker := 0; worker < workers; worker++ {
+		worker := worker
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			var buffer VectorIndexSearchBuffer
+			for iter := 0; iter < iterations; iter++ {
+				query := rabitqTestVector2477(3, uint64(1000+worker*iterations+iter))
+				opts := warmOpts
+				opts.Query = query
+				if iter%2 == 1 {
+					opts.QueryMode = VectorIndexQueryModeQuantizedRerank
+					opts.QuantizedRerankCandidates = 8
+				} else {
+					opts.QueryMode = VectorIndexQueryModeQuantizedOnly
+					opts.QuantizedRerankCandidates = 0
+				}
+				got, err := col.SearchVectorIndexWithBuffer(opts, &buffer)
+				if err != nil {
+					errCh <- fmt.Errorf("worker=%d iter=%d: %w", worker, iter, err)
+					return
+				}
+				if len(got.Results) != opts.TopK || got.Stats.SearchRouteHNSWSearchPack != 1 || got.Stats.HNSWSearchPackActive != 1 || got.Stats.QuantizedScorerActive != 1 || got.Stats.QuantizedScoreCalls == 0 {
+					errCh <- fmt.Errorf("worker=%d iter=%d stats=%+v results=%d", worker, iter, got.Stats, len(got.Results))
+					return
+				}
+				if opts.QueryMode == VectorIndexQueryModeQuantizedOnly {
+					if got.Stats.PreparedScoreCalls != 0 || got.Stats.VectorBytesRead != 0 || got.Stats.NormBytesRead != 0 {
+						errCh <- fmt.Errorf("worker=%d iter=%d quantized_only exact counters=%+v", worker, iter, got.Stats)
+						return
+					}
+				} else if got.Stats.QuantizedRerankExactScoreCalls != uint64(opts.QuantizedRerankCandidates) || got.Stats.PreparedScoreCalls != uint64(opts.QuantizedRerankCandidates) {
+					errCh <- fmt.Errorf("worker=%d iter=%d rerank counters=%+v", worker, iter, got.Stats)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func assertRabitQPreparedPackResultsMatch2587(tb testing.TB, got []VectorIndexSearchResult, want []columnVectorGraphNativeSearchResult) {
+	tb.Helper()
+	if len(got) != len(want) {
+		tb.Fatalf("results=%d want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i].Ordinal != want[i].Ordinal || !bytes.Equal(got[i].ID, want[i].ID) || math.Abs(got[i].Score-want[i].Score) > 1e-6 {
+			tb.Fatalf("result[%d]=%+v want ordinal=%d id=%q score=%v", i, got[i], want[i].Ordinal, want[i].ID, want[i].Score)
+		}
+	}
 }
 
 func TestCollectionSearchVectorIndexWithBufferRabitQQuantized2452(t *testing.T) {
@@ -657,6 +802,9 @@ func assertRabitQQuantizedOnlyStats2451(tb testing.TB, stats VectorIndexSearchSt
 	if stats.SearchRouteQuantizedOnly != 1 || stats.SearchRouteQuantizedRerank != 0 || stats.QuantizedScorerActive != 1 {
 		tb.Fatalf("rabitq quantized_only route stats=%+v", stats)
 	}
+	if stats.SearchRouteHNSWSearchPack != 1 || stats.HNSWSearchPackActive != 1 || stats.HNSWSearchPackFallbacks != 0 || stats.SearchRouteColumnGraphPrepared != 0 || stats.SearchRouteColumnGraphFallback != 0 {
+		tb.Fatalf("rabitq quantized_only route stats=%+v want prepared hnsw_search_pack_v1 score-plane traversal", stats)
+	}
 	if stats.QuantizedScoreCalls == 0 || stats.QuantizedCodeBytesRead != stats.QuantizedScoreCalls*uint64(bytesPerCode) {
 		tb.Fatalf("rabitq quantized_only code stats=%+v bytes_per_code=%d", stats, bytesPerCode)
 	}
@@ -670,14 +818,17 @@ func assertRabitQQuantizedRerankStats2451(tb testing.TB, stats VectorIndexSearch
 	if stats.SearchRouteQuantizedOnly != 0 || stats.SearchRouteQuantizedRerank != 1 || stats.QuantizedScorerActive != 1 {
 		tb.Fatalf("rabitq quantized_rerank route stats=%+v", stats)
 	}
+	if stats.SearchRouteHNSWSearchPack != 1 || stats.HNSWSearchPackActive != 1 || stats.HNSWSearchPackFallbacks != 0 || stats.SearchRouteColumnGraphPrepared != 0 || stats.SearchRouteColumnGraphFallback != 0 {
+		tb.Fatalf("rabitq quantized_rerank route stats=%+v want prepared hnsw_search_pack_v1 score-plane traversal", stats)
+	}
 	if stats.QuantizedScoreCalls == 0 || stats.QuantizedCodeBytesRead != stats.QuantizedScoreCalls*uint64(bytesPerCode) {
 		tb.Fatalf("rabitq quantized_rerank code stats=%+v bytes_per_code=%d", stats, bytesPerCode)
 	}
 	if stats.QuantizedRerankCandidates != uint64(shortlist) || stats.QuantizedRerankExactScoreCalls != uint64(shortlist) {
 		tb.Fatalf("rabitq quantized_rerank exact calls stats=%+v shortlist=%d", stats, shortlist)
 	}
-	if stats.VectorBytesRead != uint64(shortlist*dims*4) || stats.NormBytesRead != uint64(shortlist*4) {
-		tb.Fatalf("rabitq quantized_rerank exact bytes stats=%+v want vector=%d norm=%d", stats, shortlist*dims*4, shortlist*4)
+	if stats.VectorBytesRead != uint64(shortlist*dims*4) || stats.NormBytesRead != 0 {
+		tb.Fatalf("rabitq quantized_rerank exact bytes stats=%+v want prepared-pack vector=%d norm=0", stats, shortlist*dims*4)
 	}
 	if stats.DocumentsFetched != 0 {
 		tb.Fatalf("rabitq quantized_rerank stats=%+v want no documents", stats)

--- a/TreeDB/collections/column_vector_graph_rabitq_quantized_asset_test.go
+++ b/TreeDB/collections/column_vector_graph_rabitq_quantized_asset_test.go
@@ -332,8 +332,11 @@ func TestRabitQPreparedHNSWSearchPackRerankPreservesEfTraversal2587(t *testing.T
 		if stats.DocumentsFetched != 0 || stats.GraphRowFallbacks != 0 || stats.TypedColumnFallbacks != 0 || stats.VectorScratchDecodes != 0 {
 			t.Fatalf("%s stats=%+v want no document/fallback guardrail counters", name, stats)
 		}
-		if stats.QuantizedRerankExactScoreCalls != uint64(opts.QuantizedRerankCandidates) || stats.PreparedScoreCalls != uint64(opts.QuantizedRerankCandidates) {
+		if stats.QuantizedRerankExactScoreCalls != uint64(opts.QuantizedRerankCandidates) {
 			t.Fatalf("%s stats=%+v want rerank shortlist=%d", name, stats, opts.QuantizedRerankCandidates)
+		}
+		if name == "pack" && stats.PreparedScoreCalls != uint64(opts.QuantizedRerankCandidates) {
+			t.Fatalf("pack stats=%+v want prepared rerank shortlist=%d", stats, opts.QuantizedRerankCandidates)
 		}
 	}
 	if packResults.Stats.Candidates == 0 || packResults.Stats.VisitedEdges == 0 {

--- a/TreeDB/collections/column_vector_graph_rabitq_quantized_asset_test.go
+++ b/TreeDB/collections/column_vector_graph_rabitq_quantized_asset_test.go
@@ -336,6 +336,9 @@ func TestRabitQPreparedHNSWSearchPackRerankPreservesEfTraversal2587(t *testing.T
 			t.Fatalf("%s stats=%+v want rerank shortlist=%d", name, stats, opts.QuantizedRerankCandidates)
 		}
 	}
+	if packResults.Stats.Candidates == 0 || packResults.Stats.VisitedEdges == 0 {
+		t.Fatalf("pack stats=%+v want production traversal counters", packResults.Stats)
+	}
 	if packResults.Stats.Candidates != fallbackResults.Stats.Candidates || packResults.Stats.VisitedEdges != fallbackResults.Stats.VisitedEdges || packResults.Stats.QuantizedScoreCalls != fallbackResults.Stats.QuantizedScoreCalls || packResults.Stats.QuantizedRerankExactScoreCalls != fallbackResults.Stats.QuantizedRerankExactScoreCalls {
 		t.Fatalf("pack stats=%+v fallback stats=%+v want same efSearch traversal and rerank counters", packResults.Stats, fallbackResults.Stats)
 	}

--- a/TreeDB/collections/column_vector_graph_search.go
+++ b/TreeDB/collections/column_vector_graph_search.go
@@ -979,31 +979,34 @@ type columnVectorGraphSearchCandidate struct {
 // It is not concurrency-safe. Parallel searches over immutable graph assets are
 // valid with one reader and one scratch per worker.
 type columnVectorGraphNativeSearchScratch struct {
-	scoreScratch             columnPhysicalRowReaderScratch
-	expandScratch            columnPhysicalRowReaderScratch
-	resultScratch            columnPhysicalRowReaderScratch
-	visitMarks               []uint64
-	visitEpoch               uint64
-	frontier                 []columnVectorGraphSearchCandidate
-	top                      []columnVectorGraphSearchCandidate
-	results                  []columnVectorGraphNativeSearchResult
-	idBuffers                [][]byte
-	resultIDViews            [][]byte
-	resultOrder              []int
-	resultOrdinals           []int
-	resultRowRefs            []DocumentRowRef
-	resultHasRefs            []bool
-	scoreTileOrdinals        []int
-	scoreTileScores          []float64
-	scoreTileRowIDs          []uint32
-	scoreTileDots            []float32
-	scoreTileQuantizedDots   []int64
-	quantizedQueryCodes      []byte
-	quantizedQueryCentered   []vectorops.ScalarU8CenteredCode
-	quantizedRabitQWorkspace rabitq.Workspace
-	quantizedBRQWorkspace    brq.Workspace
-	wavefrontCandidates      []columnVectorGraphSearchCandidate
-	searchPlan               columnVectorGraphSearchPlan
+	scoreScratch                         columnPhysicalRowReaderScratch
+	expandScratch                        columnPhysicalRowReaderScratch
+	resultScratch                        columnPhysicalRowReaderScratch
+	visitMarks                           []uint64
+	visitEpoch                           uint64
+	frontier                             []columnVectorGraphSearchCandidate
+	top                                  []columnVectorGraphSearchCandidate
+	results                              []columnVectorGraphNativeSearchResult
+	idBuffers                            [][]byte
+	resultIDViews                        [][]byte
+	resultOrder                          []int
+	resultOrdinals                       []int
+	resultRowRefs                        []DocumentRowRef
+	resultHasRefs                        []bool
+	scoreTileOrdinals                    []int
+	scoreTileScores                      []float64
+	scoreTileRowIDs                      []uint32
+	scoreTileDots                        []float32
+	scoreTileQuantizedDots               []int64
+	quantizedQueryCodes                  []byte
+	quantizedQueryCentered               []vectorops.ScalarU8CenteredCode
+	quantizedRabitQWorkspace             rabitq.Workspace
+	quantizedBRQWorkspace                brq.Workspace
+	preparedTraversalQuantizedScorer     columnVectorGraphQuantizedScorer
+	preparedTraversalQuantizedScorePlane columnHNSWPreparedQuantizedScorePlane
+	preparedTraversalStats               columnVectorGraphNativeSearchStats
+	wavefrontCandidates                  []columnVectorGraphSearchCandidate
+	searchPlan                           columnVectorGraphSearchPlan
 }
 
 func (s *columnVectorGraphNativeSearchScratch) prepare(rowCount, dimensions, degree, topK, efSearch, scoreTileCapacity, wavefrontWidth int) error {
@@ -1060,7 +1063,7 @@ func (s *columnVectorGraphNativeSearchScratch) prepareHNSWSearchPack(rowCount, v
 	s.scoreTileRowIDs = resizeColumnVectorGraphNativeUint32Scratch(s.scoreTileRowIDs, degree)
 	s.scoreTileDots = resizeColumnVectorGraphNativeFloat32Scratch(s.scoreTileDots, degree)
 	s.idBuffers = resizeColumnVectorGraphNativeIDBuffersScratch(s.idBuffers, 0)
-	s.scoreTileOrdinals = resizeColumnVectorGraphNativeIntScratch(s.scoreTileOrdinals, 0)
+	s.scoreTileOrdinals = resizeColumnVectorGraphNativeIntScratch(s.scoreTileOrdinals, degree)
 	s.scoreTileQuantizedDots = resizeColumnVectorGraphNativeInt64Scratch(s.scoreTileQuantizedDots, 0)
 	s.wavefrontCandidates = resizeColumnVectorGraphNativeCandidateScratch(s.wavefrontCandidates, 0)
 	return nil

--- a/TreeDB/collections/vector_index_search.go
+++ b/TreeDB/collections/vector_index_search.go
@@ -1791,7 +1791,31 @@ func (s *VectorIndexSearcher) SearchWithBuffer(opts VectorIndexSearcherSearchOpt
 		clear(previousResults)
 		return response, err
 	}
-	if s.reader != nil && s.reader.rabitqHNSWSearchPackPreparedRouteEligible(queryMode, opts.QuantizedIndexName, statsMode) {
+	pack, routeStats, usePackRoute := s.hnswSearchPackSearchWithBufferRoute(queryMode, statsMode)
+	if usePackRoute {
+		results, searchStats, err := pack.searchCosine(opts.Query, columnVectorGraphNativeSearchOptions{
+			TopK:                      opts.TopK,
+			EfSearch:                  opts.EfSearch,
+			ScoreBatchMode:            opts.scoreBatchMode,
+			StatsMode:                 statsMode,
+			QueryMode:                 queryMode,
+			QuantizedIndexName:        opts.QuantizedIndexName,
+			QuantizedRerankCandidates: opts.QuantizedRerankCandidates,
+		}, &s.scratch)
+		response.Stats = vectorIndexSearchStatsFromInternal(searchStats, columnPhysicalRowReaderStats{})
+		routeStats.apply(&response.Stats)
+		if err != nil {
+			clear(previousResults)
+			return response, err
+		}
+		response.Results, err = copyVectorIndexSearchResultsToBuffer(results, buffer, previousResults)
+		if err != nil {
+			return response, err
+		}
+		return response, nil
+	}
+
+	if s.reader.rabitqHNSWSearchPackPreparedRouteEligible(queryMode, opts.QuantizedIndexName, statsMode) {
 		packRouteStats := vectorIndexSearchRouteStatsForHNSWSearchPackRoute(s.routeStats)
 		results, searchStats, err := s.reader.searchRabitQCosinePreparedHNSWPack(opts.Query, columnVectorGraphNativeSearchOptions{
 			TopK:                      opts.TopK,
@@ -1808,30 +1832,6 @@ func (s *VectorIndexSearcher) SearchWithBuffer(opts VectorIndexSearcherSearchOpt
 		} else {
 			packRouteStats.apply(&response.Stats)
 		}
-		if err != nil {
-			clear(previousResults)
-			return response, err
-		}
-		response.Results, err = copyVectorIndexSearchResultsToBuffer(results, buffer, previousResults)
-		if err != nil {
-			return response, err
-		}
-		return response, nil
-	}
-
-	pack, routeStats, usePackRoute := s.hnswSearchPackSearchWithBufferRoute(queryMode, statsMode)
-	if usePackRoute {
-		results, searchStats, err := pack.searchCosine(opts.Query, columnVectorGraphNativeSearchOptions{
-			TopK:                      opts.TopK,
-			EfSearch:                  opts.EfSearch,
-			ScoreBatchMode:            opts.scoreBatchMode,
-			StatsMode:                 statsMode,
-			QueryMode:                 queryMode,
-			QuantizedIndexName:        opts.QuantizedIndexName,
-			QuantizedRerankCandidates: opts.QuantizedRerankCandidates,
-		}, &s.scratch)
-		response.Stats = vectorIndexSearchStatsFromInternal(searchStats, columnPhysicalRowReaderStats{})
-		routeStats.apply(&response.Stats)
 		if err != nil {
 			clear(previousResults)
 			return response, err

--- a/TreeDB/collections/vector_index_search.go
+++ b/TreeDB/collections/vector_index_search.go
@@ -586,8 +586,9 @@ type VectorIndexSearchResponse struct {
 
 // VectorIndexSearchRouteKind is a compact route summary derived from public
 // search stats. The exact hnsw_search_pack_v1 route is intentionally distinct
-// from codec-generic quantized routes and must not be used for quantized route
-// claims.
+// from codec-generic quantized route kinds; a quantized search may still report
+// SearchRouteHNSWSearchPack when a codec-specific score plane uses pack
+// traversal, but RouteKind remains quantized.
 type VectorIndexSearchRouteKind string
 
 const (
@@ -605,9 +606,9 @@ const (
 	VectorIndexSearchRouteColumnGraphFallback VectorIndexSearchRouteKind = "column_graph_fallback"
 )
 
-// VectorIndexSearchHNSWSearchPackStatus summarizes exact hnsw_search_pack_v1
-// health from public search stats. It is exact FP32 pack state, not quantized
-// scorer or quantized asset state.
+// VectorIndexSearchHNSWSearchPackStatus summarizes hnsw_search_pack_v1 health
+// from public search stats. It describes the pack traversal asset itself; codec
+// route kind and quantized score-plane health remain separate counters.
 type VectorIndexSearchHNSWSearchPackStatus string
 
 const (
@@ -1168,13 +1169,14 @@ func (c *Collection) searchVectorIndexOneShot(opts VectorIndexSearchOptions) (Ve
 // This method supports exact/zero QueryMode through the exact
 // hnsw_search_pack_v1 route, and explicit quantized_only / quantized_rerank
 // modes through a collection-owned prepared quantized route selected by
-// QuantizedIndexName. It intentionally fails closed for document materialization,
-// projections, filters, benchmark-debug stats mode, missing or invalid prepared
-// assets, stale route identities, and legacy/fallback routes. Healthy prepared
-// state is opened once into the collection cache keyed by the current
-// collection/vector-index/score-plane manifest identity; steady-state searches
-// reuse that prepared state and caller-owned result buffer instead of opening a
-// VectorIndexSearcher per call.
+// QuantizedIndexName; rabitq_1bit uses the prepared hnsw_search_pack_v1
+// score-plane traversal when eligible. It intentionally fails closed for
+// document materialization, projections, filters, benchmark-debug stats mode,
+// missing or invalid prepared assets, stale route identities, and
+// legacy/fallback routes. Healthy prepared state is opened once into the
+// collection cache keyed by the current collection/vector-index/score-plane
+// manifest identity; steady-state searches reuse that prepared state and
+// caller-owned result buffer instead of opening a VectorIndexSearcher per call.
 func (c *Collection) SearchVectorIndexWithBuffer(opts VectorIndexSearchOptions, buffer *VectorIndexSearchBuffer) (VectorIndexSearchResponse, error) {
 	if err := validateCollectionVectorIndexSearchWithBufferOptions(opts, buffer); err != nil {
 		return VectorIndexSearchResponse{}, err
@@ -1359,7 +1361,10 @@ func vectorIndexDocumentFetchOptionsNonZero(opts DocumentFetchOptions) bool {
 }
 
 func vectorIndexSearchStatsAreBufferedNoDocumentPackRoute(stats VectorIndexSearchStats) bool {
-	return stats.SearchRouteHNSWSearchPack == 1 &&
+	return stats.SearchRouteQuantizedOnly == 0 &&
+		stats.SearchRouteQuantizedRerank == 0 &&
+		stats.QuantizedScorerActive == 0 &&
+		stats.SearchRouteHNSWSearchPack == 1 &&
 		stats.HNSWSearchPackActive == 1 &&
 		stats.HNSWSearchPackMissing == 0 &&
 		stats.HNSWSearchPackInvalid == 0 &&
@@ -1378,10 +1383,24 @@ func vectorIndexSearchStatsAreBufferedNoDocumentQuantizedRoute(stats VectorIndex
 	if !queryMode.quantized() {
 		return false
 	}
-	if stats.SearchRouteHNSWSearchPack != 0 || stats.HNSWSearchPackActive != 0 || stats.HNSWSearchPackMissing != 0 || stats.HNSWSearchPackInvalid != 0 || stats.HNSWSearchPackStale != 0 || stats.HNSWSearchPackClosed != 0 || stats.HNSWSearchPackFallbacks != 0 {
-		return false
-	}
-	if stats.SearchRouteColumnGraphPrepared+stats.SearchRouteColumnGraphFallback != 1 {
+	columnGraphRoute := stats.SearchRouteHNSWSearchPack == 0 &&
+		stats.HNSWSearchPackActive == 0 &&
+		stats.HNSWSearchPackMissing == 0 &&
+		stats.HNSWSearchPackInvalid == 0 &&
+		stats.HNSWSearchPackStale == 0 &&
+		stats.HNSWSearchPackClosed == 0 &&
+		stats.HNSWSearchPackFallbacks == 0 &&
+		stats.SearchRouteColumnGraphPrepared+stats.SearchRouteColumnGraphFallback == 1
+	packRoute := stats.SearchRouteHNSWSearchPack == 1 &&
+		stats.HNSWSearchPackActive == 1 &&
+		stats.HNSWSearchPackMissing == 0 &&
+		stats.HNSWSearchPackInvalid == 0 &&
+		stats.HNSWSearchPackStale == 0 &&
+		stats.HNSWSearchPackClosed == 0 &&
+		stats.HNSWSearchPackFallbacks == 0 &&
+		stats.SearchRouteColumnGraphPrepared == 0 &&
+		stats.SearchRouteColumnGraphFallback == 0
+	if !columnGraphRoute && !packRoute {
 		return false
 	}
 	emptySearch := opts.TopK == 0 || stats.CandidateRows == 0
@@ -1422,7 +1441,10 @@ func vectorIndexSearchStatsAreBufferedNoDocumentQuantizedRoute(stats VectorIndex
 		if opts.QuantizedRerankCandidates > 0 && stats.QuantizedRerankCandidates > uint64(opts.QuantizedRerankCandidates) {
 			return false
 		}
-		if stats.VectorBytesRead == 0 || stats.NormBytesRead == 0 {
+		if stats.VectorBytesRead == 0 {
+			return false
+		}
+		if stats.NormBytesRead == 0 && stats.SearchRouteHNSWSearchPack == 0 {
 			return false
 		}
 		if dimensions > 0 {
@@ -1711,7 +1733,8 @@ func (s *VectorIndexSearcher) Search(opts VectorIndexSearcherSearchOptions) (Vec
 // current-format evidence should show hnsw_search_pack_v1 active and selected,
 // zero document fetches, zero graph-row fallback, zero typed-column vector
 // fallback, and zero vector scratch decodes. Explicit quantized modes use the
-// column_graph quantized scorer route instead of hnsw_search_pack_v1 and must
+// column_graph quantized scorer route; rabitq_1bit uses the prepared
+// hnsw_search_pack_v1 score-plane traversal when eligible. Quantized modes must
 // fail closed with quantized_* asset counters when the selected score plane is
 // unavailable.
 //
@@ -1761,6 +1784,34 @@ func (s *VectorIndexSearcher) SearchWithBuffer(opts VectorIndexSearcherSearchOpt
 		clear(previousResults)
 		return response, err
 	}
+	if s.reader != nil && s.reader.rabitqHNSWSearchPackPreparedRouteEligible(queryMode, opts.QuantizedIndexName, statsMode) {
+		packRouteStats := vectorIndexSearchRouteStatsForHNSWSearchPackRoute(s.routeStats)
+		results, searchStats, err := s.reader.searchRabitQCosinePreparedHNSWPack(opts.Query, columnVectorGraphNativeSearchOptions{
+			TopK:                      opts.TopK,
+			EfSearch:                  opts.EfSearch,
+			ScoreBatchMode:            opts.scoreBatchMode,
+			StatsMode:                 statsMode,
+			QueryMode:                 queryMode,
+			QuantizedIndexName:        opts.QuantizedIndexName,
+			QuantizedRerankCandidates: opts.QuantizedRerankCandidates,
+		}, &s.scratch)
+		response.Stats = vectorIndexSearchStatsFromInternal(searchStats, columnPhysicalRowReaderStats{})
+		if err != nil && searchStats.QuantizedScorerActive == 0 && searchStats.QuantizedScoreCalls == 0 {
+			vectorIndexSearchRouteStatsForColumnGraphQuantized(s.routeStats).apply(&response.Stats)
+		} else {
+			packRouteStats.apply(&response.Stats)
+		}
+		if err != nil {
+			clear(previousResults)
+			return response, err
+		}
+		response.Results, err = copyVectorIndexSearchResultsToBuffer(results, buffer, previousResults)
+		if err != nil {
+			return response, err
+		}
+		return response, nil
+	}
+
 	pack, routeStats, usePackRoute := s.hnswSearchPackSearchWithBufferRoute(queryMode, statsMode)
 	if usePackRoute {
 		results, searchStats, err := pack.searchCosine(opts.Query, columnVectorGraphNativeSearchOptions{

--- a/TreeDB/collections/vector_index_search.go
+++ b/TreeDB/collections/vector_index_search.go
@@ -586,8 +586,9 @@ type VectorIndexSearchResponse struct {
 
 // VectorIndexSearchRouteKind is a compact route summary derived from public
 // search stats. The exact hnsw_search_pack_v1 route is intentionally distinct
-// from codec-generic quantized routes and must not be used for quantized route
-// claims.
+// from codec-generic quantized route kinds; a quantized search may still report
+// SearchRouteHNSWSearchPack when a codec-specific score plane uses pack
+// traversal, but RouteKind remains quantized.
 type VectorIndexSearchRouteKind string
 
 const (
@@ -605,9 +606,9 @@ const (
 	VectorIndexSearchRouteColumnGraphFallback VectorIndexSearchRouteKind = "column_graph_fallback"
 )
 
-// VectorIndexSearchHNSWSearchPackStatus summarizes exact hnsw_search_pack_v1
-// health from public search stats. It is exact FP32 pack state, not quantized
-// scorer or quantized asset state.
+// VectorIndexSearchHNSWSearchPackStatus summarizes hnsw_search_pack_v1 health
+// from public search stats. It describes the pack traversal asset itself; codec
+// route kind and quantized score-plane health remain separate counters.
 type VectorIndexSearchHNSWSearchPackStatus string
 
 const (
@@ -1175,13 +1176,14 @@ func (c *Collection) searchVectorIndexOneShot(opts VectorIndexSearchOptions) (Ve
 // This method supports exact/zero QueryMode through the exact
 // hnsw_search_pack_v1 route, and explicit quantized_only / quantized_rerank
 // modes through a collection-owned prepared quantized route selected by
-// QuantizedIndexName. It intentionally fails closed for document materialization,
-// projections, filters, benchmark-debug stats mode, missing or invalid prepared
-// assets, stale route identities, and legacy/fallback routes. Healthy prepared
-// state is opened once into the collection cache keyed by the current
-// collection/vector-index/score-plane manifest identity; steady-state searches
-// reuse that prepared state and caller-owned result buffer instead of opening a
-// VectorIndexSearcher per call.
+// QuantizedIndexName; rabitq_1bit uses the prepared hnsw_search_pack_v1
+// score-plane traversal when eligible. It intentionally fails closed for
+// document materialization, projections, filters, benchmark-debug stats mode,
+// missing or invalid prepared assets, stale route identities, and
+// legacy/fallback routes. Healthy prepared state is opened once into the
+// collection cache keyed by the current collection/vector-index/score-plane
+// manifest identity; steady-state searches reuse that prepared state and
+// caller-owned result buffer instead of opening a VectorIndexSearcher per call.
 func (c *Collection) SearchVectorIndexWithBuffer(opts VectorIndexSearchOptions, buffer *VectorIndexSearchBuffer) (VectorIndexSearchResponse, error) {
 	if err := validateCollectionVectorIndexSearchWithBufferOptions(opts, buffer); err != nil {
 		return VectorIndexSearchResponse{}, err
@@ -1366,7 +1368,10 @@ func vectorIndexDocumentFetchOptionsNonZero(opts DocumentFetchOptions) bool {
 }
 
 func vectorIndexSearchStatsAreBufferedNoDocumentPackRoute(stats VectorIndexSearchStats) bool {
-	return stats.SearchRouteHNSWSearchPack == 1 &&
+	return stats.SearchRouteQuantizedOnly == 0 &&
+		stats.SearchRouteQuantizedRerank == 0 &&
+		stats.QuantizedScorerActive == 0 &&
+		stats.SearchRouteHNSWSearchPack == 1 &&
 		stats.HNSWSearchPackActive == 1 &&
 		stats.HNSWSearchPackMissing == 0 &&
 		stats.HNSWSearchPackInvalid == 0 &&
@@ -1385,10 +1390,24 @@ func vectorIndexSearchStatsAreBufferedNoDocumentQuantizedRoute(stats VectorIndex
 	if !queryMode.quantized() {
 		return false
 	}
-	if stats.SearchRouteHNSWSearchPack != 0 || stats.HNSWSearchPackActive != 0 || stats.HNSWSearchPackMissing != 0 || stats.HNSWSearchPackInvalid != 0 || stats.HNSWSearchPackStale != 0 || stats.HNSWSearchPackClosed != 0 || stats.HNSWSearchPackFallbacks != 0 {
-		return false
-	}
-	if stats.SearchRouteColumnGraphPrepared+stats.SearchRouteColumnGraphFallback != 1 {
+	columnGraphRoute := stats.SearchRouteHNSWSearchPack == 0 &&
+		stats.HNSWSearchPackActive == 0 &&
+		stats.HNSWSearchPackMissing == 0 &&
+		stats.HNSWSearchPackInvalid == 0 &&
+		stats.HNSWSearchPackStale == 0 &&
+		stats.HNSWSearchPackClosed == 0 &&
+		stats.HNSWSearchPackFallbacks == 0 &&
+		stats.SearchRouteColumnGraphPrepared+stats.SearchRouteColumnGraphFallback == 1
+	packRoute := stats.SearchRouteHNSWSearchPack == 1 &&
+		stats.HNSWSearchPackActive == 1 &&
+		stats.HNSWSearchPackMissing == 0 &&
+		stats.HNSWSearchPackInvalid == 0 &&
+		stats.HNSWSearchPackStale == 0 &&
+		stats.HNSWSearchPackClosed == 0 &&
+		stats.HNSWSearchPackFallbacks == 0 &&
+		stats.SearchRouteColumnGraphPrepared == 0 &&
+		stats.SearchRouteColumnGraphFallback == 0
+	if !columnGraphRoute && !packRoute {
 		return false
 	}
 	emptySearch := opts.TopK == 0 || stats.CandidateRows == 0
@@ -1429,7 +1448,10 @@ func vectorIndexSearchStatsAreBufferedNoDocumentQuantizedRoute(stats VectorIndex
 		if opts.QuantizedRerankCandidates > 0 && stats.QuantizedRerankCandidates > uint64(opts.QuantizedRerankCandidates) {
 			return false
 		}
-		if stats.VectorBytesRead == 0 || stats.NormBytesRead == 0 {
+		if stats.VectorBytesRead == 0 {
+			return false
+		}
+		if stats.NormBytesRead == 0 && stats.SearchRouteHNSWSearchPack == 0 {
 			return false
 		}
 		if dimensions > 0 {
@@ -1718,7 +1740,8 @@ func (s *VectorIndexSearcher) Search(opts VectorIndexSearcherSearchOptions) (Vec
 // current-format evidence should show hnsw_search_pack_v1 active and selected,
 // zero document fetches, zero graph-row fallback, zero typed-column vector
 // fallback, and zero vector scratch decodes. Explicit quantized modes use the
-// column_graph quantized scorer route instead of hnsw_search_pack_v1 and must
+// column_graph quantized scorer route; rabitq_1bit uses the prepared
+// hnsw_search_pack_v1 score-plane traversal when eligible. Quantized modes must
 // fail closed with quantized_* asset counters when the selected score plane is
 // unavailable.
 //
@@ -1768,6 +1791,34 @@ func (s *VectorIndexSearcher) SearchWithBuffer(opts VectorIndexSearcherSearchOpt
 		clear(previousResults)
 		return response, err
 	}
+	if s.reader != nil && s.reader.rabitqHNSWSearchPackPreparedRouteEligible(queryMode, opts.QuantizedIndexName, statsMode) {
+		packRouteStats := vectorIndexSearchRouteStatsForHNSWSearchPackRoute(s.routeStats)
+		results, searchStats, err := s.reader.searchRabitQCosinePreparedHNSWPack(opts.Query, columnVectorGraphNativeSearchOptions{
+			TopK:                      opts.TopK,
+			EfSearch:                  opts.EfSearch,
+			ScoreBatchMode:            opts.scoreBatchMode,
+			StatsMode:                 statsMode,
+			QueryMode:                 queryMode,
+			QuantizedIndexName:        opts.QuantizedIndexName,
+			QuantizedRerankCandidates: opts.QuantizedRerankCandidates,
+		}, &s.scratch)
+		response.Stats = vectorIndexSearchStatsFromInternal(searchStats, columnPhysicalRowReaderStats{})
+		if err != nil && searchStats.QuantizedScorerActive == 0 && searchStats.QuantizedScoreCalls == 0 {
+			vectorIndexSearchRouteStatsForColumnGraphQuantized(s.routeStats).apply(&response.Stats)
+		} else {
+			packRouteStats.apply(&response.Stats)
+		}
+		if err != nil {
+			clear(previousResults)
+			return response, err
+		}
+		response.Results, err = copyVectorIndexSearchResultsToBuffer(results, buffer, previousResults)
+		if err != nil {
+			return response, err
+		}
+		return response, nil
+	}
+
 	pack, routeStats, usePackRoute := s.hnswSearchPackSearchWithBufferRoute(queryMode, statsMode)
 	if usePackRoute {
 		results, searchStats, err := pack.searchCosine(opts.Query, columnVectorGraphNativeSearchOptions{

--- a/TreeDB/documentservice/service.go
+++ b/TreeDB/documentservice/service.go
@@ -1152,11 +1152,25 @@ func validateBenchmarkQuantizedVectorSearchRoute(mode BenchmarkVectorQueryMode, 
 	diag := response.Diagnostics()
 	stats := response.Stats
 	emptySearch := len(response.Results) == 0 && stats.CandidateRows == 0
-	if stats.SearchRouteHNSWSearchPack != 0 || stats.HNSWSearchPackFallbacks != 0 {
-		return serviceErrorf(CodeIndexUnavailable, "quantized benchmark vector search touched exact hnsw_search_pack route counters: diagnostics=%+v", diag)
-	}
-	if stats.SearchRouteColumnGraphPrepared+stats.SearchRouteColumnGraphFallback != 1 {
-		return serviceErrorf(CodeIndexUnavailable, "quantized benchmark vector search did not use one column_graph route: diagnostics=%+v", diag)
+	columnGraphRoute := stats.SearchRouteHNSWSearchPack == 0 &&
+		stats.HNSWSearchPackActive == 0 &&
+		stats.HNSWSearchPackMissing == 0 &&
+		stats.HNSWSearchPackInvalid == 0 &&
+		stats.HNSWSearchPackStale == 0 &&
+		stats.HNSWSearchPackClosed == 0 &&
+		stats.HNSWSearchPackFallbacks == 0 &&
+		stats.SearchRouteColumnGraphPrepared+stats.SearchRouteColumnGraphFallback == 1
+	packRoute := stats.SearchRouteHNSWSearchPack == 1 &&
+		stats.HNSWSearchPackActive == 1 &&
+		stats.HNSWSearchPackMissing == 0 &&
+		stats.HNSWSearchPackInvalid == 0 &&
+		stats.HNSWSearchPackStale == 0 &&
+		stats.HNSWSearchPackClosed == 0 &&
+		stats.HNSWSearchPackFallbacks == 0 &&
+		stats.SearchRouteColumnGraphPrepared == 0 &&
+		stats.SearchRouteColumnGraphFallback == 0
+	if !columnGraphRoute && !packRoute {
+		return serviceErrorf(CodeIndexUnavailable, "quantized benchmark vector search did not use a prepared column_graph or quantized hnsw_search_pack route: diagnostics=%+v", diag)
 	}
 	if stats.QuantizedAssetUnavailable != 0 || stats.QuantizedAssetMissing != 0 || stats.QuantizedAssetInvalid != 0 || stats.QuantizedAssetStale != 0 || stats.QuantizedAssetClosed != 0 {
 		return serviceErrorf(CodeIndexUnavailable, "quantized benchmark vector asset is unavailable: diagnostics=%+v", diag)
@@ -1177,7 +1191,7 @@ func validateBenchmarkQuantizedVectorSearchRoute(mode BenchmarkVectorQueryMode, 
 			return serviceErrorf(CodeIndexUnavailable, "quantized_rerank benchmark vector search did not use the quantized-rerank route: diagnostics=%+v", diag)
 		}
 		if !emptySearch {
-			if stats.QuantizedRerankCandidates == 0 || stats.QuantizedRerankExactScoreCalls != stats.QuantizedRerankCandidates || stats.VectorBytesRead == 0 || stats.NormBytesRead == 0 {
+			if stats.QuantizedRerankCandidates == 0 || stats.QuantizedRerankExactScoreCalls != stats.QuantizedRerankCandidates || stats.VectorBytesRead == 0 || (!packRoute && stats.NormBytesRead == 0) {
 				return serviceErrorf(CodeIndexUnavailable, "quantized_rerank benchmark vector search did not report exact rerank counters: diagnostics=%+v", diag)
 			}
 			if req.QuantizedRerankCandidates > 0 && stats.QuantizedRerankCandidates > uint64(req.QuantizedRerankCandidates) {

--- a/cmd/treedb_vector_search_demo/main_test.go
+++ b/cmd/treedb_vector_search_demo/main_test.go
@@ -445,8 +445,17 @@ func TestExecuteColumnGraphQuantizedModes(t *testing.T) {
 				if res.Search.AvgVectorBytes != 0 || res.Search.AvgNormBytes != 0 {
 					t.Fatalf("quantized_only unexpectedly read exact vectors/norms: %+v", res.Search)
 				}
-				if requireFloat64Metric(t, res.Search.AvgSearchRouteQuantizedOnly, "avg_search_route_quantized_only") != 1 || requireFloat64Metric(t, res.Search.AvgSearchRouteQuantizedRerank, "avg_search_route_quantized_rerank") != 0 || requireFloat64Metric(t, res.Search.AvgSearchRouteHNSWSearchPack, "avg_search_route_hnsw_search_pack") != 0 {
-					t.Fatalf("quantized_only route counters not isolated: %+v", res.Search)
+				wantPackRoute := res.QuantizedCodec == quantizedVectorCodecRabitQ1Bit
+				if requireFloat64Metric(t, res.Search.AvgSearchRouteQuantizedOnly, "avg_search_route_quantized_only") != 1 || requireFloat64Metric(t, res.Search.AvgSearchRouteQuantizedRerank, "avg_search_route_quantized_rerank") != 0 {
+					t.Fatalf("quantized_only query-mode route counters not isolated: %+v", res.Search)
+				}
+				if got := requireFloat64Metric(t, res.Search.AvgSearchRouteHNSWSearchPack, "avg_search_route_hnsw_search_pack"); (got == 1) != wantPackRoute {
+					t.Fatalf("quantized_only pack route=%v want_pack=%v stats=%+v", got, wantPackRoute, res.Search)
+				}
+				if wantPackRoute {
+					if requireFloat64Metric(t, res.Search.AvgSearchRouteColumnGraphPrepared, "avg_search_route_column_graph_prepared") != 0 || requireFloat64Metric(t, res.Search.AvgSearchRouteColumnGraphFallback, "avg_search_route_column_graph_fallback") != 0 {
+						t.Fatalf("rabitq quantized_only should use pack route only: %+v", res.Search)
+					}
 				}
 			},
 		},
@@ -465,16 +474,35 @@ func TestExecuteColumnGraphQuantizedModes(t *testing.T) {
 				if res.Search.AvgQuantizedRerankExactScoreCalls > float64(res.QuantizedRerankCandidates) {
 					t.Fatalf("quantized_rerank exact score calls exceeded limit: %+v", res.Search)
 				}
-				if res.Search.AvgVectorBytes <= 0 || res.Search.AvgNormBytes <= 0 {
-					t.Fatalf("quantized_rerank stats missing exact vector/norm reads: %+v", res.Search)
+				if res.Search.AvgVectorBytes <= 0 {
+					t.Fatalf("quantized_rerank stats missing exact vector reads: %+v", res.Search)
+				}
+				wantPackRoute := res.QuantizedCodec == quantizedVectorCodecRabitQ1Bit
+				if wantPackRoute {
+					if res.Search.AvgNormBytes != 0 {
+						t.Fatalf("rabitq quantized_rerank should rerank from pack vectors without norm reads: %+v", res.Search)
+					}
+				} else if res.Search.AvgNormBytes <= 0 {
+					t.Fatalf("quantized_rerank stats missing exact norm reads: %+v", res.Search)
 				}
 				maxVectorBytes := float64(res.QuantizedRerankCandidates * res.Dimensions * 4)
 				maxNormBytes := float64(res.QuantizedRerankCandidates * 4)
+				if wantPackRoute {
+					maxNormBytes = 0
+				}
 				if res.Search.AvgVectorBytes > maxVectorBytes || res.Search.AvgNormBytes > maxNormBytes {
 					t.Fatalf("quantized_rerank exact reads exceeded rerank bound: %+v", res.Search)
 				}
-				if requireFloat64Metric(t, res.Search.AvgSearchRouteQuantizedOnly, "avg_search_route_quantized_only") != 0 || requireFloat64Metric(t, res.Search.AvgSearchRouteQuantizedRerank, "avg_search_route_quantized_rerank") != 1 || requireFloat64Metric(t, res.Search.AvgSearchRouteHNSWSearchPack, "avg_search_route_hnsw_search_pack") != 0 {
-					t.Fatalf("quantized_rerank route counters not isolated: %+v", res.Search)
+				if requireFloat64Metric(t, res.Search.AvgSearchRouteQuantizedOnly, "avg_search_route_quantized_only") != 0 || requireFloat64Metric(t, res.Search.AvgSearchRouteQuantizedRerank, "avg_search_route_quantized_rerank") != 1 {
+					t.Fatalf("quantized_rerank query-mode route counters not isolated: %+v", res.Search)
+				}
+				if got := requireFloat64Metric(t, res.Search.AvgSearchRouteHNSWSearchPack, "avg_search_route_hnsw_search_pack"); (got == 1) != wantPackRoute {
+					t.Fatalf("quantized_rerank pack route=%v want_pack=%v stats=%+v", got, wantPackRoute, res.Search)
+				}
+				if wantPackRoute {
+					if requireFloat64Metric(t, res.Search.AvgSearchRouteColumnGraphPrepared, "avg_search_route_column_graph_prepared") != 0 || requireFloat64Metric(t, res.Search.AvgSearchRouteColumnGraphFallback, "avg_search_route_column_graph_fallback") != 0 {
+						t.Fatalf("rabitq quantized_rerank should use pack route only: %+v", res.Search)
+					}
 				}
 			},
 		},


### PR DESCRIPTION
## Summary

Implements #2587 by routing eligible `rabitq_1bit` quantized searches through the prepared `hnsw_search_pack_v1` traversal seam while preserving RaBitQ score-plane identity and fail-closed behavior.

Latest PR head: `e55d90b0a9fda3ec95e5d15bb6d0632dd94f83f2` on `snissn/2587-manager-rebased2`.

## Changes

- Adds `column_hnsw_rabitq_prepared_search.go` and routes `rabitq_1bit` `quantized_only` / `quantized_rerank` through the prepared pack score-plane traversal when eligible.
- Keeps exact FP32 pack route first on the exact hot path; RaBitQ eligibility is checked only after exact pack route selection declines.
- Preserves quantized route counters (`search_route_quantized_only` / `search_route_quantized_rerank`) while also reporting `search_route_hnsw_search_pack=1` for RaBitQ pack traversal.
- Keeps production traversal counters (`candidates`, `edges`, `visited_edges`) populated for RaBitQ pack traversal.
- Fixes rerank breadth semantics: traversal keeps `ef_search`; `QuantizedRerankCandidates` only limits the exact rerank shortlist.
- Avoids discarded rerank materialization when the retained shortlist is sufficient.

## Tests

- `/tmp/issue2587_final3_collections_20260611_002546.txt`
  - `GOMAXPROCS=8 GOWORK=off go test ./TreeDB/collections -count=1`
- Targeted coverage includes:
  - `TestRabitQPreparedHNSWSearchPackRouteParity2587`
  - `TestRabitQPreparedHNSWSearchPackRerankPreservesEfTraversal2587`
  - scalar_u8 rerank breadth regression coverage remains green.

## Benchmarks

Same-host baseline (`origin/main` at `ab68056b`) vs candidate (`e55d90b0`):

- RaBitQ hot rows: `/tmp/issue2587_rabitq_bench_ab680_vs_final2_rerun_20260610_235811/benchstat.txt`
- Exact FP32 guardrail: `/tmp/issue2587_exact_gate_ab680_vs_final2_20260610_235353/benchstat.txt`
- Raw files are in the same directories.

Small 1024 x 128 hot-cache matrix (`-benchtime=100000x`, GOMAXPROCS=8):

| row | result |
|---|---:|
| lower RaBitQ qonly c=1 | -17.65% |
| lower RaBitQ qonly c=8 | -21.18% |
| lower RaBitQ rerank32 c=1 | -15.48% |
| lower RaBitQ rerank32 c=8 | -16.83% |
| collection RaBitQ qonly c=1 | -20.51% |
| collection RaBitQ qonly c=8 | -20.75% |
| collection RaBitQ rerank32 c=1 | -8.85% |
| collection RaBitQ rerank32 c=8 | -11.80% |
| exact FP32 gate rows | no significant regressions; geomean -21.63% |

All rows stayed `0 B/op`, `0 allocs/op`.

## #2591 10k x 768 smoke

- `/tmp/issue2587_10k768_final2_20260611_000046.txt`

All 20 rows stayed `0 B/op`, `0 allocs/op`. RaBitQ rows report the quantized query-mode counters plus `search_route_hnsw_search_pack=1`, nonzero `candidates/edges/visited_edges`, and no hidden exact fallback.

## Profiles

Final collection RaBitQ hot-row CPU/alloc profiles:

- `/tmp/issue2587_profiles_final2b_20260611_000238`
- rows: `qonly_c1`, `qonly_c8`, `rerank32_c1`, `rerank32_c8`
- includes `cpu_*.pprof`, `allocs_*.pprof`, `cpu_*_top.txt`, `allocs_*_top.txt`

CPU profiles remain dominated by prepared traversal/scoring (`searchCosinePreparedScorePlane`, RaBitQ byte-table scoring, frontier maintenance, exact rerank for rerank rows). Bench rows remain allocation-free.

Fixes #2587.

