### PR TITLE
TreeDB VectorDBBench pgvector comparator setup

### DIFF
--- a/docs/benchmarks/treedb_vectordbbench_campaign_2026-06-11.md
+++ b/docs/benchmarks/treedb_vectordbbench_campaign_2026-06-11.md
@@ -8,13 +8,14 @@ Base for this closeout branch: `origin/main` at
 
 This campaign did **not** produce a claim-quality expanded VectorDBBench matrix.
 The full TreeDB `Performance1536D50K` durable baseline did not complete load on
-this host, and the pgvector comparator did not produce a valid row. This report
-therefore records the attempt, exact artifacts, blockers, and rerun guidance. It
-must not be used for README headline performance claims or TreeDB-vs-pgvector
-comparisons.
+this host, and the full Docker/pgvector comparator did not produce a valid row.
+This report therefore records the attempt, exact artifacts, blockers, and rerun
+guidance. It must not be used for README headline performance claims or
+TreeDB-vs-pgvector full-matrix comparisons.
 
-The only successful numbers below are from a small TreeDB custom smoke
-(`512 x 1536`) and are labeled as functional harness/route proof only.
+The only successful numbers below are from small `512 x 1536` custom smokes for
+TreeDB and local PostgreSQL/pgvector. They are labeled as functional
+harness/route/setup proof only.
 
 ## Issue / PR stack state
 
@@ -22,7 +23,7 @@ The only successful numbers below are from a small TreeDB custom smoke
 | --- | --- | --- | --- | --- |
 | `#2599` harness / route-proof sidecar | `#2605` merged as `7f66890467f96e7460ed6eeec29fdee81e61acac` | Complete. Harness contract merged. | `/tmp/treedb_vdbbench_2599_final_20260610_221336` | Foundation only: proves artifact capture and route-proof schema. |
 | `#2600` TreeDB-only baseline | `#2608` merged as `d8c2442adec53711fa2e69c78a4df06dc6512a17` | Full `Performance1536D50K` blocked by TreeDB durable load runtime; smaller custom smoke completed. | `/tmp/treedb_vdbbench_2600_serial_20260610_224155`; `/tmp/treedb_vdbbench_2600_custom_smoke_20260610_235005` | Blocker evidence plus smoke-only appendix. No full baseline row. |
-| `#2601` server comparator rows | `#2607` open/draft at `ad4090b89c2b483a448052cdce6812689e52b3df` | Blocked. pgvector setup/dry-run passed; full pgvector load failed with Docker/PostgreSQL `pg_wal` no-space. | `/tmp/treedb_vdbbench_2601_pgvector_setup_script_20260610_225302`; `/tmp/treedb_vdbbench_2601_pgvector_20260610_223212`; `/tmp/treedb_vdbbench_2601_pgvector_full_20260610_234701` | Setup/blocker evidence only. No comparator row. |
+| `#2601` server comparator rows | `#2607` updated after the blocked report | Docker pgvector setup/dry-run passed; full Docker pgvector load failed with `pg_wal` no-space; local PostgreSQL/pgvector custom smoke completed. | `/tmp/treedb_vdbbench_2601_pgvector_setup_script_20260610_225302`; `/tmp/treedb_vdbbench_2601_pgvector_20260610_223212`; `/tmp/treedb_vdbbench_2601_pgvector_full_20260610_234701`; `/tmp/treedb_vdbbench_2601_pgvector_local_custom_20260611_014219` | Full-row blocker evidence plus custom-smoke comparator row. No full comparator row. |
 | `#2602` final/expanded matrix report | `#2609` from `snissn/2602-manager` | Interim closeout for a blocked campaign. | `docs/benchmarks/treedb_vectordbbench_campaign_2026-06-11.md` | Documents incomplete status and rerun plan. |
 
 ## Matrix rows requested vs. captured
@@ -31,7 +32,8 @@ The only successful numbers below are from a small TreeDB custom smoke
 | --- | --- | --- | --- |
 | TreeDB exact FP32 | `Performance1536D50K`, COSINE, `k=10`, concurrency `1,8,32`, `30s`, `m=16`, `efConstruction=128`, `efSearch=128`, `command_wal_durable` | Exact row hit VDBBench's `3600s` load timeout. | No. |
 | TreeDB scalar_u8 rerank32 | Same case, `quantized_rerank_candidates=32` | Intentionally stopped after the exact row timed out. | No. |
-| pgvector HNSW | Same case and HNSW parameters through PostgreSQL/pgvector | Setup/dry-run passed; full load failed with `pg_wal/xlogtemp.156`: no space left on device. | No. |
+| pgvector HNSW | Same case and HNSW parameters through PostgreSQL/pgvector | Docker setup/dry-run passed; full Docker load failed with `pg_wal/xlogtemp.156`: no space left on device. | No. |
+| pgvector HNSW local custom smoke | `PerformanceCustomDataset`, `512 x 1536`, COSINE, `k=10`, concurrency `1,8`, `10s`, local PostgreSQL/pgvector | Completed with result label `:)`. | Smoke-only; not a full comparative row. |
 | Qdrant/server comparators | Optional after pgvector | Not run. | No. |
 | RaBitQ | Optional experimental TreeDB lane | Not run in this campaign. RaBitQ remains experimental-only. | No. |
 
@@ -272,6 +274,29 @@ are invalid as comparator evidence. Valid evidence from this artifact is limited
 to startup/version/health logs, VDBBench dry-run/full command shape, and the
 exact storage blocker.
 
+### Local pgvector custom smoke: functional only, not claim-quality
+
+Artifact root:
+
+- `/tmp/treedb_vdbbench_2601_pgvector_local_custom_20260611_014219`
+- marker: `/tmp/treedb_vdbbench_2601_pgvector_local_custom_20260611_014219/LOCAL_CUSTOM_SMOKE.md`
+- result summary: `/tmp/treedb_vdbbench_2601_pgvector_local_custom_20260611_014219/result_summary.json`
+- result JSON: `/tmp/treedb_vdbbench_2601_pgvector_local_custom_20260611_014219/vdbbench-results/PgVector/result_20260611_pgvector-hnsw-2601-local-custom_pgvector.json`
+
+This run used local Homebrew PostgreSQL `18.4` plus pgvector `0.8.2` on loopback
+instead of Docker, with the same custom `512 x 1536` dataset used by the #2600
+TreeDB custom smoke. It completed successfully and is useful as small server
+comparator setup proof only.
+
+| row | load_s | insert_s | optimize_s | recall | NDCG | serial p95_s | serial p99_s | conc | QPS | conc p95_s | conc p99_s |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| pgvector HNSW local custom | 2.0156 | 0.8104 | 1.2052 | 1.0 | 1.0 | 0.0018 | 0.0051 | 1 | 990.2530 | 0.001065 | 0.001239 |
+| pgvector HNSW local custom | 2.0156 | 0.8104 | 1.2052 | 1.0 | 1.0 | 0.0018 | 0.0051 | 8 | 4608.7741 | 0.002742 | 0.005455 |
+
+Do not compare this smoke row against full TreeDB `Performance1536D50K` rows,
+because those full TreeDB rows did not complete in #2600. It also does not
+replace the requested full `Performance1536D50K` pgvector comparator row.
+
 ## What this campaign proves vs. does not prove
 
 Proved:
@@ -282,13 +307,15 @@ Proved:
   custom dataset and can prove vector-index/no-document routes.
 - pgvector HNSW setup can start locally and VDBBench can resolve the intended
   `pgvectorhnsw` command in dry-run mode.
+- Local PostgreSQL/pgvector can complete a bounded `512 x 1536` custom
+  VDBBench smoke row.
 
 Not proved:
 
 - No full TreeDB `Performance1536D50K` exact or scalar_u8 baseline row exists.
-- No pgvector comparator row exists.
+- No full `Performance1536D50K` pgvector comparator row exists.
 - No TreeDB-vs-pgvector, TreeDB-vs-Qdrant, TreeDB-vs-USearch, or TreeDB-vs-RaBitQ
-  comparative performance claim is supported by this campaign.
+  full-matrix comparative performance claim is supported by this campaign.
 - No native Go allocation or per-operation benchmark conclusion follows from
   any VDBBench artifact here.
 

--- a/docs/benchmarks/treedb_vectordbbench_server_comparators_2026-06-11.md
+++ b/docs/benchmarks/treedb_vectordbbench_server_comparators_2026-06-11.md
@@ -1,7 +1,7 @@
 # TreeDB VectorDBBench Server Comparator Setup (2026-06-11)
 
-Issue: `snissn/gomap#2601`. Parent tracker: `#2598`. Stacked on
-`snissn/gomap#2605` / `snissn/2599-manager`.
+Issue: `snissn/gomap#2601`. Parent tracker: `#2598`. Built on the
+merged `snissn/gomap#2605` harness (`7f66890467f96e7460ed6eeec29fdee81e61acac`).
 
 This note is a **setup/runbook and abort record**, not a comparator result
 report. No pgvector/Qdrant latency, QPS, recall, load, or index-build number in

--- a/docs/benchmarks/treedb_vectordbbench_server_comparators_2026-06-11.md
+++ b/docs/benchmarks/treedb_vectordbbench_server_comparators_2026-06-11.md
@@ -15,7 +15,9 @@ these artifacts is public-claim quality.
   shape.
 - The first full pgvector attempt was aborted because it overlapped with the
   #2600 TreeDB-only full baseline. Treat that artifact as contention-tainted.
-- Wait for a no-concurrent-benchmark window before running a full comparator.
+- A later no-concurrent full pgvector attempt reached VDBBench but failed during
+  PostgreSQL insert with `pg_wal/xlogtemp.*: No space left on device`; no
+  comparator row is captured yet.
 
 ## Artifact roots
 
@@ -23,6 +25,7 @@ these artifacts is public-claim quality.
 | --- | --- | --- |
 | `/tmp/treedb_vdbbench_2601_pgvector_20260610_223212` | aborted/contention-tainted | Setup, versions, health, dry-run, and abort logs only. Do not report benchmark metrics. |
 | `/tmp/treedb_vdbbench_2601_pgvector_setup_script_20260610_225302` | setup smoke | Script validation: container health + VDBBench dry-run, no full benchmark. |
+| `/tmp/treedb_vdbbench_2601_pgvector_full_20260610_234701` | failed/no-space | Attempted full pgvector row; load failed with PostgreSQL `pg_wal` no-space error. Do not report metrics. |
 
 Key aborted-artifact marker:
 
@@ -69,14 +72,24 @@ process is visible unless `ALLOW_CONCURRENT_BENCHMARKS=true` is explicitly set.
 It records Docker/image/version context, health checks, VDBBench command output,
 results, and container logs under `OUT`.
 
-## Aborted full attempt caveat
+## Failed/aborted full-attempt caveats
 
 The aborted artifact loaded 50K vectors and began pgvector HNSW index creation,
 but the coordinator terminated it to avoid overlap with #2600. VDBBench then
 wrote a failed result JSON with zero metrics and `label = x`. That JSON is
 retained only as abort evidence.
 
-Do not compare it against TreeDB, Qdrant, USearch, Faiss, or any other lane.
+The later no-concurrent full attempt failed during pgvector load with:
+
+```text
+could not write to file "pg_wal/xlogtemp.156": No space left on device
+```
+
+It also wrote a failed result JSON with `label = x` and zero metrics. The
+artifact is useful for setup/blocker evidence only.
+
+Do not compare either failed artifact against TreeDB, Qdrant, USearch, Faiss,
+or any other lane.
 
 ## Next comparator
 

--- a/docs/benchmarks/treedb_vectordbbench_server_comparators_2026-06-11.md
+++ b/docs/benchmarks/treedb_vectordbbench_server_comparators_2026-06-11.md
@@ -1,0 +1,85 @@
+# TreeDB VectorDBBench Server Comparator Setup (2026-06-11)
+
+Issue: `snissn/gomap#2601`. Parent tracker: `#2598`. Stacked on
+`snissn/gomap#2605` / `snissn/2599-manager`.
+
+This note is a **setup/runbook and abort record**, not a comparator result
+report. No pgvector/Qdrant latency, QPS, recall, load, or index-build number in
+these artifacts is public-claim quality.
+
+## Current status
+
+- pgvector HNSW is the first comparator lane.
+- A local `pgvector/pgvector:pg16` container starts and passes health checks.
+- VDBBench `pgvectorhnsw` dry-run succeeds for the intended TreeDB baseline
+  shape.
+- The first full pgvector attempt was aborted because it overlapped with the
+  #2600 TreeDB-only full baseline. Treat that artifact as contention-tainted.
+- Wait for a no-concurrent-benchmark window before running a full comparator.
+
+## Artifact roots
+
+| artifact | status | use |
+| --- | --- | --- |
+| `/tmp/treedb_vdbbench_2601_pgvector_20260610_223212` | aborted/contention-tainted | Setup, versions, health, dry-run, and abort logs only. Do not report benchmark metrics. |
+| `/tmp/treedb_vdbbench_2601_pgvector_setup_script_20260610_225302` | setup smoke | Script validation: container health + VDBBench dry-run, no full benchmark. |
+
+Key aborted-artifact marker:
+
+- `/tmp/treedb_vdbbench_2601_pgvector_20260610_223212/ABORTED_CONTENTION_TAINTED.md`
+- `/tmp/treedb_vdbbench_2601_pgvector_20260610_223212/abort_manifest.json`
+
+## pgvector setup captured
+
+From the setup-smoke artifact:
+
+- Docker: `Docker version 27.5.1, build 9f9e405`.
+- Image: `pgvector/pgvector:pg16`.
+- PostgreSQL: `16.14 (Debian 16.14-1.pgdg12+1)`.
+- pgvector extension: `vector=0.8.2`.
+- VDBBench checkout: `snissn/vectordbbench` at
+  `c1c763c0dcd97c489c2b107fd7060374f76d09b8`.
+- Command shape: `pgvectorhnsw`, `Performance1536D50K`, COSINE, `k=10`,
+  concurrency `1,8,32`, `30s`, `m=16`, `ef_construction=128`, `ef_search=128`.
+- Dry-run exit: `0`.
+
+## Runbook
+
+Health + dry-run only (safe while another full benchmark is running):
+
+```sh
+OUT=/tmp/treedb_vdbbench_2601_pgvector_setup_$(date +%Y%m%d_%H%M%S) \
+VECTORDBBENCH_DIR=/path/to/snissn/vectordbbench \
+RUN_FULL=false \
+scripts/treedb_vdbbench_pgvector_comparator.sh
+```
+
+Full comparator run, only in a no-concurrent-benchmark window:
+
+```sh
+OUT=/tmp/treedb_vdbbench_2601_pgvector_full_$(date +%Y%m%d_%H%M%S) \
+VECTORDBBENCH_DIR=/path/to/snissn/vectordbbench \
+RUN_FULL=true \
+ALLOW_CONCURRENT_BENCHMARKS=false \
+scripts/treedb_vdbbench_pgvector_comparator.sh
+```
+
+The script refuses a full run when another `vectordb_bench.cli.vectordbbench`
+process is visible unless `ALLOW_CONCURRENT_BENCHMARKS=true` is explicitly set.
+It records Docker/image/version context, health checks, VDBBench command output,
+results, and container logs under `OUT`.
+
+## Aborted full attempt caveat
+
+The aborted artifact loaded 50K vectors and began pgvector HNSW index creation,
+but the coordinator terminated it to avoid overlap with #2600. VDBBench then
+wrote a failed result JSON with zero metrics and `label = x`. That JSON is
+retained only as abort evidence.
+
+Do not compare it against TreeDB, Qdrant, USearch, Faiss, or any other lane.
+
+## Next comparator
+
+Qdrant HNSW remains the next priority after pgvector once the full pgvector row
+has a clean no-contention window. Keep Qdrant evidence in the same
+server/database boundary lane and do not mix it with library-only rows.

--- a/docs/benchmarks/treedb_vectordbbench_server_comparators_2026-06-11.md
+++ b/docs/benchmarks/treedb_vectordbbench_server_comparators_2026-06-11.md
@@ -3,21 +3,25 @@
 Issue: `snissn/gomap#2601`. Parent tracker: `#2598`. Built on the
 merged `snissn/gomap#2605` harness (`7f66890467f96e7460ed6eeec29fdee81e61acac`).
 
-This note is a **setup/runbook and abort record**, not a comparator result
-report. No pgvector/Qdrant latency, QPS, recall, load, or index-build number in
-these artifacts is public-claim quality.
+This note is a **setup/runbook, blocker record, and custom-smoke comparator
+record**. The successful pgvector row below is a small `512 x 1536` functional
+smoke, not a full `Performance1536D50K` row and not public-claim quality.
 
 ## Current status
 
-- pgvector HNSW is the first comparator lane.
-- A local `pgvector/pgvector:pg16` container starts and passes health checks.
-- VDBBench `pgvectorhnsw` dry-run succeeds for the intended TreeDB baseline
-  shape.
-- The first full pgvector attempt was aborted because it overlapped with the
-  #2600 TreeDB-only full baseline. Treat that artifact as contention-tainted.
-- A later no-concurrent full pgvector attempt reached VDBBench but failed during
-  PostgreSQL insert with `pg_wal/xlogtemp.*: No space left on device`; no
-  comparator row is captured yet.
+- pgvector HNSW is the first server/database comparator lane.
+- A local `pgvector/pgvector:pg16` Docker container starts and passes health
+  checks; VDBBench `pgvectorhnsw` dry-run succeeds for the intended
+  `Performance1536D50K` shape.
+- The first full Docker/pgvector attempt was aborted because it overlapped with
+  the #2600 TreeDB-only full baseline. Treat that artifact as
+  contention-tainted.
+- A later no-concurrent Docker/pgvector full attempt reached VDBBench but failed
+  during PostgreSQL insert with `pg_wal/xlogtemp.*: No space left on device`.
+- A local Homebrew PostgreSQL + pgvector custom smoke completed successfully on
+  the same `512 x 1536` custom dataset used by #2600's TreeDB smoke. This is a
+  valid setup/custom-smoke comparator row only; it does not unblock full-matrix
+  comparative claims.
 
 ## Artifact roots
 
@@ -25,14 +29,19 @@ these artifacts is public-claim quality.
 | --- | --- | --- |
 | `/tmp/treedb_vdbbench_2601_pgvector_20260610_223212` | aborted/contention-tainted | Setup, versions, health, dry-run, and abort logs only. Do not report benchmark metrics. |
 | `/tmp/treedb_vdbbench_2601_pgvector_setup_script_20260610_225302` | setup smoke | Script validation: container health + VDBBench dry-run, no full benchmark. |
-| `/tmp/treedb_vdbbench_2601_pgvector_full_20260610_234701` | failed/no-space | Attempted full pgvector row; load failed with PostgreSQL `pg_wal` no-space error. Do not report metrics. |
+| `/tmp/treedb_vdbbench_2601_pgvector_full_20260610_234701` | failed/no-space | Attempted full Docker/pgvector row; load failed with PostgreSQL `pg_wal` no-space error. Do not report metrics. |
+| `/tmp/treedb_vdbbench_2601_pgvector_local_custom_20260611_014219` | complete local custom smoke | Local PostgreSQL/pgvector custom `512 x 1536` VDBBench row. Functional comparator smoke only, not claim-quality. |
 
-Key aborted-artifact marker:
+Key markers:
 
 - `/tmp/treedb_vdbbench_2601_pgvector_20260610_223212/ABORTED_CONTENTION_TAINTED.md`
 - `/tmp/treedb_vdbbench_2601_pgvector_20260610_223212/abort_manifest.json`
+- `/tmp/treedb_vdbbench_2601_pgvector_full_20260610_234701/FAILED_NO_SPACE.md`
+- `/tmp/treedb_vdbbench_2601_pgvector_full_20260610_234701/failure_manifest.json`
+- `/tmp/treedb_vdbbench_2601_pgvector_local_custom_20260611_014219/LOCAL_CUSTOM_SMOKE.md`
+- `/tmp/treedb_vdbbench_2601_pgvector_local_custom_20260611_014219/result_summary.json`
 
-## pgvector setup captured
+## Docker pgvector setup captured
 
 From the setup-smoke artifact:
 
@@ -46,7 +55,88 @@ From the setup-smoke artifact:
   concurrency `1,8,32`, `30s`, `m=16`, `ef_construction=128`, `ef_search=128`.
 - Dry-run exit: `0`.
 
-## Runbook
+## Local pgvector custom smoke captured
+
+Artifact root:
+
+- `/tmp/treedb_vdbbench_2601_pgvector_local_custom_20260611_014219`
+
+Sanitized context:
+
+| field | value |
+| --- | --- |
+| gomap commit at run start | `f68ae6813` (`snissn/2601-manager`) |
+| vectordbbench commit | `c1c763c0dcd97c489c2b107fd7060374f76d09b8` |
+| host class | Apple M3, macOS/Darwin arm64 |
+| PostgreSQL | Homebrew PostgreSQL `18.4` |
+| pgvector extension | `vector=0.8.2` |
+| Python / uv | Python `3.14.0`; `uv 0.9.18` |
+| VDBBench row | `pgvectorhnsw` |
+| HNSW | `m=16`, `ef_construction=128`, `ef_search=128` |
+
+Dataset and VDBBench shape:
+
+| field | value |
+| --- | --- |
+| case | `PerformanceCustomDataset` / `TreeDB2601PgvectorLocalSmoke` |
+| dataset | `treedb2600smoke/treedb2600_smoke_512x1536_20260610_234950` |
+| train rows | 512 |
+| test rows | 64 |
+| dimension | 1536 |
+| metric | COSINE |
+| topK | 10 |
+| concurrency | `1,8` for `10s` each |
+| result label | `:)` |
+
+Smoke results as emitted by VDBBench. Latencies are seconds in the artifact
+result file. These rows are **functional smoke only** and must not be used as
+public or full-matrix comparative throughput evidence.
+
+| row | load_s | insert_s | optimize_s | recall | NDCG | serial p95_s | serial p99_s | conc | QPS | conc p95_s | conc p99_s |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| pgvector HNSW local custom | 2.0156 | 0.8104 | 1.2052 | 1.0 | 1.0 | 0.0018 | 0.0051 | 1 | 990.2530 | 0.001065 | 0.001239 |
+| pgvector HNSW local custom | 2.0156 | 0.8104 | 1.2052 | 1.0 | 1.0 | 0.0018 | 0.0051 | 8 | 4608.7741 | 0.002742 | 0.005455 |
+
+Local custom-smoke command outline:
+
+```sh
+OUT=/tmp/treedb_vdbbench_2601_pgvector_local_custom_20260611_014219
+initdb -D "$OUT/pgdata" -A trust
+pg_ctl -D "$OUT/pgdata" -l "$OUT/logs/postgres.log" -w start
+createdb -h 127.0.0.1 -p "$PORT" vectordb
+psql -h 127.0.0.1 -p "$PORT" -d vectordb -c 'CREATE EXTENSION IF NOT EXISTS vector;'
+
+uv run --no-sync \
+  --with click --with pydantic --with pyyaml --with environs \
+  --with pandas --with polars --with pyarrow --with psutil --with pytz \
+  --with tqdm --with plotly --with ujson --with hdrhistogram \
+  --with scikit-learn --with s3fs --with oss2 \
+  --with psycopg --with psycopg-binary --with pgvector \
+  python -m vectordb_bench.cli.vectordbbench pgvectorhnsw \
+  --user-name "$USER" --password '' --host 127.0.0.1 --port "$PORT" \
+  --db-name vectordb \
+  --m 16 --ef-construction 128 --ef-search 128 \
+  --case-type PerformanceCustomDataset --k 10 \
+  --num-concurrency 1,8 --concurrency-duration 10 \
+  --db-label pgvector-hnsw-2601-local-custom \
+  --task-label pgvector-hnsw-2601-local-custom \
+  --custom-case-name TreeDB2601PgvectorLocalSmoke \
+  --custom-case-description TreeDB2601PgvectorLocalSmoke \
+  --custom-case-load-timeout 300 \
+  --custom-case-optimize-timeout 300 \
+  --custom-dataset-name treedb2600smoke \
+  --custom-dataset-dir treedb2600_smoke_512x1536_20260610_234950 \
+  --custom-dataset-size 512 \
+  --custom-dataset-dim 1536 \
+  --custom-dataset-metric-type COSINE \
+  --custom-dataset-file-count 1 \
+  --custom-dataset-with-gt
+```
+
+The complete captured command is in
+`/tmp/treedb_vdbbench_2601_pgvector_local_custom_20260611_014219/commands/vdbbench_pgvectorhnsw.command.txt`.
+
+## Runbook: Docker helper
 
 Health + dry-run only (safe while another full benchmark is running):
 
@@ -57,13 +147,23 @@ RUN_FULL=false \
 scripts/treedb_vdbbench_pgvector_comparator.sh
 ```
 
-Full comparator run, only in a no-concurrent-benchmark window:
+Full Docker comparator run, only in a no-concurrent-benchmark window:
 
 ```sh
 OUT=/tmp/treedb_vdbbench_2601_pgvector_full_$(date +%Y%m%d_%H%M%S) \
 VECTORDBBENCH_DIR=/path/to/snissn/vectordbbench \
 RUN_FULL=true \
 ALLOW_CONCURRENT_BENCHMARKS=false \
+scripts/treedb_vdbbench_pgvector_comparator.sh
+```
+
+Custom-case Docker runs can append VDBBench CLI arguments with
+`VDBBENCH_EXTRA_ARGS`, parsed with Python `shlex`, for example:
+
+```sh
+VDBBENCH_EXTRA_ARGS="--custom-case-name Smoke --custom-dataset-name treedb2600smoke ..." \
+CASE_TYPE=PerformanceCustomDataset \
+RUN_FULL=true \
 scripts/treedb_vdbbench_pgvector_comparator.sh
 ```
 
@@ -74,12 +174,12 @@ results, and container logs under `OUT`.
 
 ## Failed/aborted full-attempt caveats
 
-The aborted artifact loaded 50K vectors and began pgvector HNSW index creation,
-but the coordinator terminated it to avoid overlap with #2600. VDBBench then
-wrote a failed result JSON with zero metrics and `label = x`. That JSON is
-retained only as abort evidence.
+The aborted Docker artifact loaded 50K vectors and began pgvector HNSW index
+creation, but the coordinator terminated it to avoid overlap with #2600.
+VDBBench then wrote a failed result JSON with zero metrics and `label = x`.
+That JSON is retained only as abort evidence.
 
-The later no-concurrent full attempt failed during pgvector load with:
+The later no-concurrent Docker full attempt failed during pgvector load with:
 
 ```text
 could not write to file "pg_wal/xlogtemp.156": No space left on device
@@ -91,8 +191,15 @@ artifact is useful for setup/blocker evidence only.
 Do not compare either failed artifact against TreeDB, Qdrant, USearch, Faiss,
 or any other lane.
 
-## Next comparator
+## Next comparator/full-row work
+
+The local custom pgvector smoke satisfies setup and small-row comparator proof,
+but it does **not** replace the requested full `Performance1536D50K` comparator
+row. To produce claim-quality comparator evidence, rerun pgvector on a quiet
+host with verified PostgreSQL/Docker storage (or a dedicated local PostgreSQL
+cluster) and capture the real `Performance1536D50K`, `k=10`, concurrency
+`1,8,32`, `30s` row.
 
 Qdrant HNSW remains the next priority after pgvector once the full pgvector row
-has a clean no-contention window. Keep Qdrant evidence in the same
+has a clean no-contention environment. Keep Qdrant evidence in the same
 server/database boundary lane and do not mix it with library-only rows.

--- a/scripts/treedb_vdbbench_pgvector_comparator.sh
+++ b/scripts/treedb_vdbbench_pgvector_comparator.sh
@@ -148,6 +148,43 @@ run_logged() {
   return "$rc"
 }
 
+validate_full_result() {
+  python3 - "$OUT" <<'PY'
+import json
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+out = Path(sys.argv[1])
+results = sorted((out / 'vdbbench-results' / 'PgVector').glob('result_*_pgvector.json'))
+if not results:
+    status = 'failed_missing_result_json'
+    reason = 'VDBBench command completed without a PgVector result JSON'
+else:
+    data = json.loads(results[-1].read_text())
+    failed = [item for item in data.get('results', []) if item.get('label') != ':)']
+    if not failed:
+        sys.exit(0)
+    first = failed[0]
+    metrics = first.get('metrics') or {}
+    status = 'failed_vdbbench_case'
+    reason = (
+        f"VDBBench result label={first.get('label')!r}; "
+        f"max_load_count={metrics.get('max_load_count')} qps={metrics.get('qps')}"
+    )
+manifest = {
+    'schema_version': 'treedb-vdbbench-pgvector-comparator/v1',
+    'status': status,
+    'reason': reason,
+    'generated_at': datetime.now(UTC).isoformat().replace('+00:00', 'Z'),
+    'artifact_root': str(out),
+    'claim_quality': 'none; failed VDBBench cases are not comparator evidence',
+}
+(out / 'status_manifest.json').write_text(json.dumps(manifest, indent=2, sort_keys=True) + '\n')
+print(reason, file=sys.stderr)
+sys.exit(1)
+PY
+}
+
 {
   echo "artifact_root=$OUT"
   echo "generated_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
@@ -283,6 +320,7 @@ assert_no_other_vdbbench
 
 docker logs "$CONTAINER_NAME" > "$OUT/logs/pgvector_container_after_vdbbench.log" 2>&1 || true
 docker exec "$CONTAINER_NAME" psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -Atc "select count(*) from vdbbench_table_test; select pg_size_pretty(pg_total_relation_size('vdbbench_table_test')); select pg_size_pretty(pg_indexes_size('vdbbench_table_test'));" > "$OUT/pgvector_postrun_table_stats.txt" 2> "$OUT/pgvector_postrun_table_stats.stderr.txt" || true
+validate_full_result
 write_status complete "full pgvectorhnsw VDBBench run completed"
 echo "artifact_root=$OUT"
 echo "status=complete"

--- a/scripts/treedb_vdbbench_pgvector_comparator.sh
+++ b/scripts/treedb_vdbbench_pgvector_comparator.sh
@@ -35,6 +35,9 @@ EF_SEARCH=${EF_SEARCH:-128}
 DB_LABEL=${DB_LABEL:-pgvector-hnsw-2601-${stamp}}
 TASK_LABEL=${TASK_LABEL:-$DB_LABEL}
 VDBBENCH_TIMEOUT=${VDBBENCH_TIMEOUT:-36000}
+# Optional additional VectorDBBench CLI args, parsed with Python shlex so
+# custom-case runs can pass quoted descriptions without changing this script.
+VDBBENCH_EXTRA_ARGS=${VDBBENCH_EXTRA_ARGS:-}
 
 if [[ -z "$VECTORDBBENCH_DIR" ]]; then
   echo "VECTORDBBENCH_DIR is required (path to snissn/vectordbbench checkout)" >&2
@@ -210,6 +213,7 @@ PY
   echo "ef_construction=$EF_CONSTRUCTION"
   echo "ef_search=$EF_SEARCH"
   echo "run_full=$RUN_FULL"
+  echo "vdbbench_extra_args=$VDBBENCH_EXTRA_ARGS"
 } > "$OUT/context.txt"
 
 docker image inspect "$IMAGE" > "$OUT/pgvector_image_inspect.json" 2>&1 || true
@@ -273,6 +277,17 @@ docker exec "$CONTAINER_NAME" psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -v ON_E
 docker exec "$CONTAINER_NAME" psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -Atc "select version(); select extname || '=' || extversion from pg_extension where extname='vector'; show shared_buffers; show maintenance_work_mem; show max_parallel_workers;" > "$OUT/pgvector_versions.txt" 2> "$OUT/pgvector_versions.stderr.txt"
 docker logs "$CONTAINER_NAME" > "$OUT/logs/pgvector_container_before_vdbbench.log" 2>&1 || true
 
+extra_args=()
+if [[ -n "$VDBBENCH_EXTRA_ARGS" ]]; then
+  mapfile -t extra_args < <(python3 - "$VDBBENCH_EXTRA_ARGS" <<'PY'
+import shlex
+import sys
+for arg in shlex.split(sys.argv[1]):
+    print(arg)
+PY
+)
+fi
+
 common_cmd=(
   uv run --no-sync
   --with click --with pydantic --with pyyaml --with environs
@@ -295,6 +310,7 @@ common_cmd=(
   --concurrency-duration "$CONCURRENCY_DURATION"
   --db-label "$DB_LABEL"
   --task-label "$TASK_LABEL"
+  "${extra_args[@]}"
 )
 export PYTHONPATH="$VECTORDBBENCH_DIR${PYTHONPATH:+:$PYTHONPATH}"
 export RESULTS_LOCAL_DIR="$OUT/vdbbench-results"

--- a/scripts/treedb_vdbbench_pgvector_comparator.sh
+++ b/scripts/treedb_vdbbench_pgvector_comparator.sh
@@ -1,0 +1,288 @@
+#!/usr/bin/env bash
+# Capture a pgvector HNSW VectorDBBench setup/benchmark artifact for issue #2601.
+#
+# Defaults are intentionally safe: the script starts pgvector, captures health
+# and a VDBBench dry-run, then stops the container without running the full
+# benchmark. Set RUN_FULL=true only in a no-concurrent-benchmark window.
+
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+stamp=$(date +%Y%m%d_%H%M%S)
+OUT=${OUT:-/tmp/treedb_vdbbench_2601_pgvector_${stamp}}
+VECTORDBBENCH_DIR=${VECTORDBBENCH_DIR:-}
+IMAGE=${PGVECTOR_IMAGE:-pgvector/pgvector:pg16}
+CONTAINER_NAME=${CONTAINER_NAME:-gomap2601-pgvector-${stamp}}
+POSTGRES_DB=${POSTGRES_DB:-vectordb}
+POSTGRES_USER=${POSTGRES_USER:-postgres}
+POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-$(python3 - <<'PY'
+import secrets
+print(secrets.token_urlsafe(18))
+PY
+)}
+HOST=${HOST:-127.0.0.1}
+PORT=${PORT:-0}
+RUN_FULL=${RUN_FULL:-false}
+KEEP_CONTAINER=${KEEP_CONTAINER:-false}
+ALLOW_CONCURRENT_BENCHMARKS=${ALLOW_CONCURRENT_BENCHMARKS:-false}
+CASE_TYPE=${CASE_TYPE:-Performance1536D50K}
+K=${K:-10}
+NUM_CONCURRENCY=${NUM_CONCURRENCY:-1,8,32}
+CONCURRENCY_DURATION=${CONCURRENCY_DURATION:-30}
+HNSW_M=${HNSW_M:-16}
+EF_CONSTRUCTION=${EF_CONSTRUCTION:-128}
+EF_SEARCH=${EF_SEARCH:-128}
+DB_LABEL=${DB_LABEL:-pgvector-hnsw-2601-${stamp}}
+TASK_LABEL=${TASK_LABEL:-$DB_LABEL}
+VDBBENCH_TIMEOUT=${VDBBENCH_TIMEOUT:-36000}
+
+if [[ -z "$VECTORDBBENCH_DIR" ]]; then
+  echo "VECTORDBBENCH_DIR is required (path to snissn/vectordbbench checkout)" >&2
+  exit 2
+fi
+if [[ ! -d "$VECTORDBBENCH_DIR" ]]; then
+  echo "VECTORDBBENCH_DIR does not exist: $VECTORDBBENCH_DIR" >&2
+  exit 2
+fi
+if [[ -e "$OUT" && -n "$(find "$OUT" -mindepth 1 -maxdepth 1 -print -quit 2>/dev/null)" ]]; then
+  echo "OUT must be new or empty: $OUT" >&2
+  exit 2
+fi
+mkdir -p "$OUT"/{commands,logs,vdbbench-results,pgdata}
+
+if [[ "$PORT" == "0" ]]; then
+  PORT=$(python3 - <<'PY'
+import socket
+sock = socket.socket()
+sock.bind(('127.0.0.1', 0))
+print(sock.getsockname()[1])
+sock.close()
+PY
+)
+fi
+
+redact_artifact_password() {
+  find "$OUT" -path "$OUT/pgdata" -prune -o -type f -print0 \
+    | xargs -0 grep -Il -- "$POSTGRES_PASSWORD" 2>/dev/null \
+    | while IFS= read -r file; do
+        perl -0pi -e "s/\Q$POSTGRES_PASSWORD\E/<redacted-artifact-local-password>/g" "$file"
+      done
+}
+
+write_status() {
+  local status=$1
+  local reason=${2:-}
+  python3 - "$OUT" "$status" "$reason" <<'PY'
+import json
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+out = Path(sys.argv[1])
+status = sys.argv[2]
+reason = sys.argv[3]
+files = []
+for path in sorted(out.rglob('*')):
+    if not path.is_file():
+        continue
+    rel = path.relative_to(out)
+    if rel.parts and rel.parts[0] == 'pgdata':
+        continue
+    files.append(str(rel))
+manifest = {
+    'schema_version': 'treedb-vdbbench-pgvector-comparator/v1',
+    'status': status,
+    'reason': reason,
+    'generated_at': datetime.now(UTC).isoformat().replace('+00:00', 'Z'),
+    'artifact_root': str(out),
+    'files': files[:500],
+    'files_truncated': len(files) > 500,
+}
+(out / 'status_manifest.json').write_text(json.dumps(manifest, indent=2, sort_keys=True) + '\n')
+PY
+}
+
+cleanup() {
+  local exit_code=$?
+  set +e
+  if docker ps --format '{{.Names}}' | grep -qx "$CONTAINER_NAME"; then
+    docker logs "$CONTAINER_NAME" > "$OUT/logs/pgvector_container_cleanup.log" 2>&1
+    if [[ "$KEEP_CONTAINER" != "true" ]]; then
+      docker stop "$CONTAINER_NAME" > "$OUT/commands/pgvector_stop.stdout.txt" 2> "$OUT/commands/pgvector_stop.stderr.txt"
+    fi
+  fi
+  docker ps -a --filter "name=$CONTAINER_NAME" --format 'table {{.Names}}\t{{.Image}}\t{{.Status}}\t{{.Ports}}' > "$OUT/health_docker_ps_after_cleanup.txt" 2>&1
+  find "$OUT/vdbbench-results" -maxdepth 5 -type f 2>/dev/null | sort > "$OUT/vdbbench_results_files.txt"
+  redact_artifact_password
+  if [[ $exit_code -ne 0 && ! -f "$OUT/status_manifest.json" ]]; then
+    write_status "failed_or_aborted" "script exited $exit_code; see command logs"
+  fi
+  exit $exit_code
+}
+trap cleanup EXIT
+trap 'write_status aborted_by_signal "received TERM/INT"; exit 130' INT TERM
+
+assert_no_other_vdbbench() {
+  if [[ "$ALLOW_CONCURRENT_BENCHMARKS" == "true" ]]; then
+    return 0
+  fi
+  local matches
+  matches=$(ps -axo pid,command | grep -F -- '-m vectordb_bench.cli.vectordbbench' | grep -v grep | grep -v "pgvector-hnsw-2601-${stamp}" || true)
+  if [[ -n "$matches" ]]; then
+    printf '%s\n' "$matches" > "$OUT/concurrent_vdbbench_processes_blocker.txt"
+    echo "Refusing full pgvector run while another VDBBench process exists; see $OUT/concurrent_vdbbench_processes_blocker.txt" >&2
+    return 1
+  fi
+}
+
+run_logged() {
+  local name=$1
+  shift
+  local rc
+  printf '%q ' "$@" > "$OUT/commands/${name}.command.txt"
+  printf '\n' >> "$OUT/commands/${name}.command.txt"
+  set +e
+  "$@" > "$OUT/commands/${name}.stdout.txt" 2> "$OUT/commands/${name}.stderr.txt"
+  rc=$?
+  set -e
+  printf '%s\n' "$rc" > "$OUT/commands/${name}.exit_code"
+  return "$rc"
+}
+
+{
+  echo "artifact_root=$OUT"
+  echo "generated_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  echo "gomap_commit=$(git -C "$repo_root" rev-parse HEAD)"
+  echo "gomap_branch=$(git -C "$repo_root" branch --show-current)"
+  echo "vectordbbench_dir=$VECTORDBBENCH_DIR"
+  echo "vectordbbench_commit=$(git -C "$VECTORDBBENCH_DIR" rev-parse HEAD 2>/dev/null || true)"
+  echo "vectordbbench_branch=$(git -C "$VECTORDBBENCH_DIR" branch --show-current 2>/dev/null || true)"
+  echo "docker_version=$(docker --version)"
+  echo "python3_version=$(python3 --version)"
+  echo "uv_version=$(uv --version 2>/dev/null || true)"
+  uname -a | sed 's/^/uname=/'
+  sysctl -n machdep.cpu.brand_string 2>/dev/null | sed 's/^/cpu_brand=/' || true
+  echo "image=$IMAGE"
+  echo "container=$CONTAINER_NAME"
+  echo "host=$HOST"
+  echo "port=$PORT"
+  echo "case_type=$CASE_TYPE"
+  echo "k=$K"
+  echo "num_concurrency=$NUM_CONCURRENCY"
+  echo "concurrency_duration=$CONCURRENCY_DURATION"
+  echo "hnsw_m=$HNSW_M"
+  echo "ef_construction=$EF_CONSTRUCTION"
+  echo "ef_search=$EF_SEARCH"
+  echo "run_full=$RUN_FULL"
+} > "$OUT/context.txt"
+
+docker image inspect "$IMAGE" > "$OUT/pgvector_image_inspect.json" 2>&1 || true
+docker info > "$OUT/docker_info.txt" 2>&1 || true
+
+printf 'docker run -d --name %q -e POSTGRES_PASSWORD=<redacted> -e POSTGRES_DB=%q -p %q:%q:5432 -v %q:/var/lib/postgresql/data %q\n' \
+  "$CONTAINER_NAME" "$POSTGRES_DB" "$HOST" "$PORT" "$OUT/pgdata" "$IMAGE" > "$OUT/commands/pgvector_start.command.txt"
+docker run -d \
+  --name "$CONTAINER_NAME" \
+  -e POSTGRES_PASSWORD="$POSTGRES_PASSWORD" \
+  -e POSTGRES_DB="$POSTGRES_DB" \
+  -p "$HOST:$PORT:5432" \
+  -v "$OUT/pgdata:/var/lib/postgresql/data" \
+  "$IMAGE" \
+  > "$OUT/commands/pgvector_start.stdout.txt" \
+  2> "$OUT/commands/pgvector_start.stderr.txt"
+echo "$CONTAINER_NAME" > "$OUT/container_name.txt"
+
+for _ in $(seq 1 120); do
+  if docker exec "$CONTAINER_NAME" pg_isready -U "$POSTGRES_USER" -d postgres > "$OUT/health_pg_isready_postgres.txt" 2>&1; then
+    # The postgres entrypoint briefly starts a temporary server, shuts it down,
+    # then starts the final server. Require readiness to remain true across a
+    # short delay so we do not race the temporary shutdown.
+    sleep 2
+    if docker exec "$CONTAINER_NAME" pg_isready -U "$POSTGRES_USER" -d postgres > "$OUT/health_pg_isready_postgres.txt" 2>&1; then
+      break
+    fi
+  fi
+  sleep 1
+done
+if ! docker exec "$CONTAINER_NAME" pg_isready -U "$POSTGRES_USER" -d postgres > "$OUT/health_pg_isready_postgres.txt" 2>&1; then
+  docker logs "$CONTAINER_NAME" > "$OUT/logs/pgvector_container_startup_failure.log" 2>&1 || true
+  echo "pgvector container did not become healthy" >&2
+  exit 1
+fi
+# Wait for SQL execution, not only socket readiness. pg_isready can report
+# accepting connections while the postgres entrypoint is still finalizing.
+for _ in $(seq 1 120); do
+  if docker exec "$CONTAINER_NAME" psql -U "$POSTGRES_USER" -d postgres -Atc 'select 1;' > "$OUT/health_postgres_sql.txt" 2> "$OUT/health_postgres_sql.stderr.txt"; then
+    break
+  fi
+  sleep 1
+done
+if ! grep -qx '1' "$OUT/health_postgres_sql.txt"; then
+  docker logs "$CONTAINER_NAME" > "$OUT/logs/pgvector_container_sql_ready_failure.log" 2>&1 || true
+  echo "pgvector container did not become SQL-ready" >&2
+  exit 1
+fi
+
+docker ps --filter "name=$CONTAINER_NAME" --format 'table {{.Names}}\t{{.Image}}\t{{.Status}}\t{{.Ports}}' > "$OUT/health_docker_ps.txt"
+# Make database creation explicit and logged; tolerate a race where POSTGRES_DB
+# appears between the check and createdb.
+docker exec "$CONTAINER_NAME" psql -U "$POSTGRES_USER" -d postgres -Atc "select 1 from pg_database where datname = '$POSTGRES_DB';" > "$OUT/commands/check_database.stdout.txt" 2> "$OUT/commands/check_database.stderr.txt" || true
+if ! grep -qx '1' "$OUT/commands/check_database.stdout.txt"; then
+  docker exec "$CONTAINER_NAME" createdb -U "$POSTGRES_USER" "$POSTGRES_DB" > "$OUT/commands/create_database.stdout.txt" 2> "$OUT/commands/create_database.stderr.txt" || true
+  docker exec "$CONTAINER_NAME" psql -U "$POSTGRES_USER" -d postgres -Atc "select 1 from pg_database where datname = '$POSTGRES_DB';" > "$OUT/commands/check_database_after_create.stdout.txt" 2> "$OUT/commands/check_database_after_create.stderr.txt"
+  grep -qx '1' "$OUT/commands/check_database_after_create.stdout.txt"
+fi
+docker exec "$CONTAINER_NAME" pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB" > "$OUT/health_pg_isready.txt" 2>&1 || true
+docker exec "$CONTAINER_NAME" psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -c 'CREATE EXTENSION IF NOT EXISTS vector;' > "$OUT/commands/create_extension.stdout.txt" 2> "$OUT/commands/create_extension.stderr.txt"
+docker exec "$CONTAINER_NAME" psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 -Atc "select version(); select extname || '=' || extversion from pg_extension where extname='vector'; show shared_buffers; show maintenance_work_mem; show max_parallel_workers;" > "$OUT/pgvector_versions.txt" 2> "$OUT/pgvector_versions.stderr.txt"
+docker logs "$CONTAINER_NAME" > "$OUT/logs/pgvector_container_before_vdbbench.log" 2>&1 || true
+
+common_cmd=(
+  uv run --no-sync
+  --with click --with pydantic --with pyyaml --with environs
+  --with pandas --with polars --with pyarrow --with psutil --with pytz
+  --with tqdm --with plotly --with ujson --with hdrhistogram
+  --with scikit-learn --with s3fs --with oss2
+  --with psycopg --with psycopg-binary --with pgvector
+  python -m vectordb_bench.cli.vectordbbench pgvectorhnsw
+  --user-name "$POSTGRES_USER"
+  --password "$POSTGRES_PASSWORD"
+  --host "$HOST"
+  --port "$PORT"
+  --db-name "$POSTGRES_DB"
+  --m "$HNSW_M"
+  --ef-construction "$EF_CONSTRUCTION"
+  --ef-search "$EF_SEARCH"
+  --case-type "$CASE_TYPE"
+  --k "$K"
+  --num-concurrency "$NUM_CONCURRENCY"
+  --concurrency-duration "$CONCURRENCY_DURATION"
+  --db-label "$DB_LABEL"
+  --task-label "$TASK_LABEL"
+)
+export PYTHONPATH="$VECTORDBBENCH_DIR${PYTHONPATH:+:$PYTHONPATH}"
+export RESULTS_LOCAL_DIR="$OUT/vdbbench-results"
+export LOG_FILE="$OUT/vdbbench_pgvectorhnsw.log"
+
+(
+  cd "$VECTORDBBENCH_DIR"
+  run_logged vdbbench_pgvectorhnsw_dry_run "${common_cmd[@]}" --skip-load --skip-search-serial --skip-search-concurrent --dry-run
+)
+
+if [[ "$RUN_FULL" != "true" ]]; then
+  write_status setup_smoke_complete "RUN_FULL=false; only health checks and dry-run were executed"
+  echo "artifact_root=$OUT"
+  echo "status=setup_smoke_complete"
+  exit 0
+fi
+
+assert_no_other_vdbbench
+(
+  cd "$VECTORDBBENCH_DIR"
+  run_logged vdbbench_pgvectorhnsw "${common_cmd[@]}"
+)
+
+docker logs "$CONTAINER_NAME" > "$OUT/logs/pgvector_container_after_vdbbench.log" 2>&1 || true
+docker exec "$CONTAINER_NAME" psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -Atc "select count(*) from vdbbench_table_test; select pg_size_pretty(pg_total_relation_size('vdbbench_table_test')); select pg_size_pretty(pg_indexes_size('vdbbench_table_test'));" > "$OUT/pgvector_postrun_table_stats.txt" 2> "$OUT/pgvector_postrun_table_stats.stderr.txt" || true
+write_status complete "full pgvectorhnsw VDBBench run completed"
+echo "artifact_root=$OUT"
+echo "status=complete"


### PR DESCRIPTION
## Summary

- Adds/updates the #2601 pgvector HNSW VectorDBBench comparator runbook and evidence report.
- Keeps the full Docker `Performance1536D50K` attempt as blocked/no-space evidence, not a comparator row.
- Adds a completed local PostgreSQL/pgvector `512 x 1536` custom VDBBench smoke row so the server-comparator lane has functional setup evidence.
- Updates the campaign report with the new pgvector local custom-smoke addendum while preserving the full-matrix blocker caveat.

Closes #2601.

## Boundary / blockers

- No full `Performance1536D50K` pgvector row was captured.
- The local custom row is a server/database comparator smoke only; it is not claim-quality and must not be compared as a full TreeDB-vs-pgvector matrix.
- Docker/pgvector full run remains blocked by PostgreSQL/Docker storage: `pg_wal/xlogtemp.156: No space left on device`.
- VDBBench rows include Python/client/service/database overhead and are not native Go allocation evidence.

## Artifacts

- Setup-smoke artifact: `/tmp/treedb_vdbbench_2601_pgvector_setup_script_20260610_225302`
- Aborted/contention-tainted Docker attempt: `/tmp/treedb_vdbbench_2601_pgvector_20260610_223212`
- Failed Docker no-space full attempt: `/tmp/treedb_vdbbench_2601_pgvector_full_20260610_234701`
- Completed local PostgreSQL/pgvector custom smoke: `/tmp/treedb_vdbbench_2601_pgvector_local_custom_20260611_014219`
  - `LOCAL_CUSTOM_SMOKE.md`
  - `result_summary.json`
  - VDBBench result JSON under `vdbbench-results/PgVector/`

## Local custom smoke result

Dataset: `512 x 1536`, cosine, `k=10`, concurrency `1,8` for `10s`, HNSW `m=16`, `ef_construction=128`, `ef_search=128`.

- load: `2.0156s`
- recall/NDCG: `1.0` / `1.0`
- concurrency 1: `990.2530 QPS`, p95 `0.001065s`, p99 `0.001239s`
- concurrency 8: `4608.7741 QPS`, p95 `0.002742s`, p99 `0.005455s`

Functional smoke only; not public claim-quality.

## Validation

- `PYTHONPATH=scripts python3 scripts/treedb_vectordbbench_artifact_test.py` — pass
- `bash -n scripts/treedb_vdbbench_pgvector_comparator.sh` — pass
- `git diff --check` — pass
- Local PostgreSQL/pgvector custom VDBBench smoke completed with result label `:)`
- `go test ./TreeDB/documentservice ./cmd/treedb-document-service` skipped: benchmark docs/script only; no service/API/Go code changed.

## AI review / CI

- Latest-head CI: pending for head `53c94e2bbc7d87665394acd8f61b998220aeae84`.
- AI review can focus on benchmark honesty, artifact boundaries, and whether the custom smoke is clearly separated from full comparator claims.
