### PR TITLE
Document service: defer vector-index rebuilds for benchmark bulk load

### DIFF
--- a/TreeDB/documentservice/service.go
+++ b/TreeDB/documentservice/service.go
@@ -175,7 +175,7 @@ func (s *Service) UpsertDocuments(ctx context.Context, index string, req UpsertD
 			updated++
 		}
 	}
-	if inserted > 0 && updated == 0 {
+	if inserted > 0 && updated == 0 && !req.DeferVectorIndexRebuild {
 		if err := rebuildServiceVectorIndex(ctx, col); err != nil {
 			return UpsertDocumentsResponse{}, err
 		}

--- a/TreeDB/documentservice/service_test.go
+++ b/TreeDB/documentservice/service_test.go
@@ -743,7 +743,12 @@ func TestServiceBenchmarkVectorFailClosed(t *testing.T) {
 	if _, err := svc.SearchBenchmarkVector(ctx, "bench", BenchmarkVectorSearchRequest{QueryEmbedding: []float32{1, 0}, TopK: 1, StatsMode: collections.VectorIndexSearchStatsMode("future")}); ErrorCodeOf(err) != CodeInvalidRequest {
 		t.Fatalf("unknown stats_mode err=%v code=%s", err, ErrorCodeOf(err))
 	}
-	loadBenchmarkDocs(t, svc, "bench", []Document{{ID: "a", Embedding: []float32{1, 0}}})
+	if _, err := svc.UpsertDocuments(ctx, "bench", UpsertDocumentsRequest{Documents: []Document{{ID: "a", Embedding: []float32{1, 0}}}, DeferVectorIndexRebuild: true}); err != nil {
+		t.Fatalf("deferred UpsertDocuments bench: %v", err)
+	}
+	if _, err := svc.SearchBenchmarkVector(ctx, "bench", BenchmarkVectorSearchRequest{QueryEmbedding: []float32{1, 0}, TopK: 1, EfSearch: 4}); ErrorCodeOf(err) != CodeIndexUnavailable {
+		t.Fatalf("pre-optimize benchmark vector search err=%v code=%s", err, ErrorCodeOf(err))
+	}
 	if _, err := svc.OptimizeIndex(ctx, "bench", OptimizeIndexRequest{}); err != nil {
 		t.Fatalf("OptimizeIndex bench: %v", err)
 	}

--- a/TreeDB/documentservice/types.go
+++ b/TreeDB/documentservice/types.go
@@ -110,6 +110,9 @@ type CreateIndexRequest struct {
 type UpsertDocumentsRequest struct {
 	ExpectedGeneration uint64     `json:"expected_generation,omitempty"`
 	Documents          []Document `json:"documents"`
+	// DeferVectorIndexRebuild lets benchmark loaders bulk-insert documents and
+	// rebuild service vector assets once via OptimizeIndex after the load phase.
+	DeferVectorIndexRebuild bool `json:"defer_vector_index_rebuild,omitempty"`
 }
 
 type UpsertDocumentsResponse struct {

--- a/clients/python/treedb_client/README.md
+++ b/clients/python/treedb_client/README.md
@@ -149,7 +149,11 @@ client.reset_index(
         quantized_indexes=[QuantizedIndexInfo(name="embedding.scalar_u8.fast")],
     ),
 )
-client.upsert_documents("bench_run_001", [Document(id="a", embedding=[0.1, 0.2, 0.3])])
+client.upsert_documents(
+    "bench_run_001",
+    [Document(id="a", embedding=[0.1, 0.2, 0.3])],
+    defer_vector_index_rebuild=True,
+)
 client.optimize_index("bench_run_001")
 bench = client.search_vector_index(
     "bench_run_001",

--- a/clients/python/treedb_client/src/treedb_client/client.py
+++ b/clients/python/treedb_client/src/treedb_client/client.py
@@ -149,11 +149,14 @@ class TreeDBClient:
         documents: Sequence[DocumentLike],
         *,
         expected_generation: Optional[int] = None,
+        defer_vector_index_rebuild: bool = False,
     ) -> UpsertDocumentsResponse:
         """Write or replace documents in an index."""
 
         request: dict[str, Any] = {"documents": [_document_for_write(doc) for doc in documents]}
         _add_expected_generation(request, expected_generation)
+        if defer_vector_index_rebuild:
+            request["defer_vector_index_rebuild"] = True
         payload = self._request("POST", self._index_path(index, "documents", "upsert"), request)
         return _parse_response("upsert response", UpsertDocumentsResponse.from_dict, payload)
 

--- a/clients/python/treedb_client/tests/test_client.py
+++ b/clients/python/treedb_client/tests/test_client.py
@@ -167,11 +167,13 @@ class TreeDBClientTests(unittest.TestCase):
                 "docs",
                 [Document(id="a", content="alpha", embedding=[1, 0], meta={"repo": "gomap"}, score=0.5)],
                 expected_generation=1,
+                defer_vector_index_rebuild=True,
             )
 
             self.assertEqual(result.upserted, 1)
             body = json_body(server.records[0])
             self.assertEqual(body["expected_generation"], 1)
+            self.assertEqual(body["defer_vector_index_rebuild"], True)
             self.assertNotIn("score", body["documents"][0])
             self.assertEqual(body["documents"][0]["embedding"], [1.0, 0.0])
 

--- a/docs/TREEDB_DOCUMENT_SERVICE_API.md
+++ b/docs/TREEDB_DOCUMENT_SERVICE_API.md
@@ -349,6 +349,12 @@ collection-truncate/WAL format just for benchmark reset and preserves TreeDB's
 insert-only graph rebuild boundary. Compatible non-`column_graph` indexes may be
 cleared with existing document deletes.
 
+Bulk loaders may pass `"defer_vector_index_rebuild": true` on document upserts
+to avoid rebuilding column-graph vector assets after every inserted batch.
+When rebuild is deferred, `/search/vector-index` fails closed until optimize has
+built the assets for the loaded documents. The exact document route
+`/search/vector` remains readable from stored documents before optimize.
+
 Optimize/rebuild after load:
 
 ```http


### PR DESCRIPTION
## Summary
- add `defer_vector_index_rebuild` to document upserts so benchmark loaders can bulk-insert and call `/optimize` once
- expose the flag in the Python TreeDB client and benchmark docs
- keep normal upsert behavior unchanged unless the flag is set

## Remote investigation evidence
- Host: `mikers@192.168.0.185`, `/mnt/fast4tb` 3.6T with ~1.7T free.
- Cause of previous TreeDB VDBBench load timeout: perf on the timed-out run showed `UpsertDocuments -> rebuildServiceVectorIndex -> RebuildVectorIndex` rebuilding column-graph assets after every 100-row VDBBench insert batch. Top samples were HNSW rebuild dot-products and value-log zstd reads.
- Patched exact FP32 VDBBench full row completed on the remote host:
  - artifact: `/mnt/fast4tb/tmp/treedb_vdbbench_remote_exact_defer_20260611_051433/artifact`
  - `Performance1536D50K`, cosine, k=10, concurrency `1,8,32`, label `:)`
  - insert `85.0383s`, optimize `152.0742s`, load `237.1126s`
  - QPS max `36.0825`; c1/c8/c32 `7.3992 / 33.8872 / 36.0825`
  - recall `0.9954`, NDCG `0.9961`, p95 `0.1455s`, p99 `0.1683s`

## Follow-up blocker found
- The scalar_u8 rerank32 full row no longer times out during load (insert ~84.6s, optimize ~156.1s) but the service OOMs during concurrent quantized search, producing an invalid `x` row. Artifact: `/mnt/fast4tb/tmp/treedb_vdbbench_remote_scalar_defer_20260611_052944/artifact`.
- This PR fixes the load-time O(n^2) rebuild issue; scalar concurrent-search memory is a separate follow-up.

## Tests
- `go test ./TreeDB/documentservice ./cmd/treedb-document-service`
- `uv run --project clients/python/treedb_client --with pytest pytest clients/python/treedb_client/tests/test_client.py -q`
- Remote: `go test ./TreeDB/documentservice ./cmd/treedb-document-service`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Added `defer_vector_index_rebuild` option to document upsert operations, enabling deferred vector index rebuilding during bulk document loading
* When enabled, vector search becomes unavailable until explicit index optimization is performed; document search remains functional
* Updated client libraries to support the new deferral parameter

<!-- end of auto-generated comment: release notes by coderabbit.ai -->