### PR TITLE
TreeDB: skip eager ref tracker in outer leaf mode

### DIFF
--- a/TreeDB/db/db.go
+++ b/TreeDB/db/db.go
@@ -1429,7 +1429,7 @@ func openWithLock(opts Options, lock *lockfile.Lock) (*DB, error) {
 
 	db := &DB{
 		valueLogManager:                vm,
-		valueLogRefTracker:             newValueLogRefTracker(),
+		valueLogRefTracker:             newValueLogRefTrackerForOptions(opts),
 		lock:                           lock,
 		adaptive:                       adaptiveCtrl,
 		keepRecent:                     opts.KeepRecent,

--- a/TreeDB/db/vlog_gc_incremental.go
+++ b/TreeDB/db/vlog_gc_incremental.go
@@ -180,6 +180,18 @@ func newValueLogRefTracker() *valueLogRefTracker {
 	}
 }
 
+func newValueLogRefTrackerForOptions(opts Options) *valueLogRefTracker {
+	if opts.IndexOuterLeavesInValueLog {
+		// The incremental tracker currently follows logical value-pointer deltas.
+		// Outer-leaf mode also rewrites physical leaf-page references in the value
+		// log, so commits cannot keep these counts exact without a broader delta.
+		// Leave the tracker disabled and let GC/rewrite planning do explicit reachability
+		// scans instead of forcing every open to rebuild stale metadata.
+		return nil
+	}
+	return newValueLogRefTracker()
+}
+
 func (t *valueLogRefTracker) canTrack(baseSeq uint64) bool {
 	if t == nil {
 		return false

--- a/TreeDB/db/vlog_gc_test.go
+++ b/TreeDB/db/vlog_gc_test.go
@@ -32,6 +32,34 @@ func TestValueLogGC_EmptySet_NoValueLogSegments(t *testing.T) {
 	}
 }
 
+func TestValueLogRefTracker_DisabledForOuterLeavesSkipsStaleMetadata(t *testing.T) {
+	dir := t.TempDir()
+	stale := []byte("stale ref-count metadata from an older build")
+	metaPath := filepath.Join(dir, valueLogRefCountsFileName)
+	if err := os.WriteFile(metaPath, stale, 0o644); err != nil {
+		t.Fatalf("write stale metadata: %v", err)
+	}
+
+	db, err := Open(Options{Dir: dir, IndexOuterLeavesInValueLog: true})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if db.valueLogRefTracker != nil {
+		t.Fatal("outer-leaf value-log mode should leave incremental ref tracker disabled")
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	after, err := os.ReadFile(metaPath)
+	if err != nil {
+		t.Fatalf("read stale metadata: %v", err)
+	}
+	if !bytes.Equal(after, stale) {
+		t.Fatalf("stale metadata was unexpectedly rebuilt on open")
+	}
+}
+
 func TestValueOnlyValueLogFiles_KeepsReservedLaneInPrimaryValueLog(t *testing.T) {
 	dir := t.TempDir()
 	id, err := valuelog.EncodeFileID(rewriteLeafLogLaneID, 1)

--- a/TreeDB/db/vlog_rewrite_test.go
+++ b/TreeDB/db/vlog_rewrite_test.go
@@ -1029,8 +1029,10 @@ func TestValueLogRewriteOnline_CollectionRootCommitUsesCurrentStoragePolicy(t *t
 	if err := db.applyRewriteSwapBatchToCollectionRoot(target, []rewriteSwap{{key: []byte("doc/p"), oldPtr: oldPtr, newPtr: newPtr}}, false); err != nil {
 		t.Fatalf("apply collection rewrite swap with stale policy: %v", err)
 	}
-	if _, ok := db.valueLogRefTracker.referencedSet(db.currentCommitSeq()); ok {
-		t.Fatal("expected value-log-leaf collection rewrite to invalidate value-log ref tracker")
+	if db.valueLogRefTracker != nil {
+		if _, ok := db.valueLogRefTracker.referencedSet(db.currentCommitSeq()); ok {
+			t.Fatal("expected value-log-leaf collection rewrite to invalidate value-log ref tracker")
+		}
 	}
 
 	newRoot := readCollectionRootID(t, db, maintenanceTestCollectionRootKey)
@@ -5620,6 +5622,9 @@ func primeValueLogRefTracker(t *testing.T, db *DB) {
 	t.Helper()
 	if _, err := db.referencedValueLogSegments(context.Background()); err != nil {
 		t.Fatalf("prime value-log ref tracker: %v", err)
+	}
+	if db.valueLogRefTracker == nil {
+		return
 	}
 	requireValueLogRefTrackerValid(t, db)
 }


### PR DESCRIPTION
## Summary
- disable the eager incremental value-log ref tracker for `IndexOuterLeavesInValueLog` backends
- keep GC/rewrite correctness in that mode on explicit reachability scans instead of rebuilding stale `vlog_ref_counts.meta` during every open
- add coverage that stale ref-count metadata is ignored for outer-leaf value-log mode

## Context
Geth uses the command-WAL durable profile, which enables outer leaves in the value log. The incremental ref tracker currently tracks logical value-pointer deltas, but outer-leaf mode also changes physical leaf-page value-log references, so ordinary commits cannot keep the ref-count metadata exact. After PR #2611 fixed no-op AppliedLSN publishes, Sepolia reopen still rebuilt `vlog_ref_counts.meta` repeatedly because the geth profile invalidated the tracker on outer-leaf commits.

For this unsupported tracker mode, opening should not do a full `collectValueLogRefCounts` scan. GC/rewrite planning can still scan reachability when explicitly invoked.

## Tests
- `go test ./TreeDB/db -run 'TestValueLogRefTracker_DisabledForOuterLeavesSkipsStaleMetadata|TestValueLogGC_WithStandaloneValueLogSegmentsKeepsReferencedNonActiveSegment|TestValueLogGC_IncrementalTrackerPersistsOnClose|TestCommandWALAppliedLSNOnlyPublishPreservesValueLogRefTracker|TestPublishCommandWALNoopPreservesValueLogRefTracker' -count=1`
- `go test ./TreeDB/db -count=1`
- `go test ./TreeDB/... -count=1`
- `(cd TreeDB/integration/gethethdb && go test ./... -count=1)`
