### PR TITLE
TreeDB: avoid full RID map scan for command WAL appender

### DIFF
--- a/TreeDB/db/value_log_appender.go
+++ b/TreeDB/db/value_log_appender.go
@@ -95,11 +95,11 @@ func (db *DB) installCommandWALValueLogAppender() error {
 	if err != nil {
 		return err
 	}
-	ridMap, err := scanValueLogSegments(segments, db.valueLogDictLookup)
+	nextRID, err := nextReplayAppenderRIDStart(segments)
 	if err != nil {
 		return err
 	}
-	appender, err := newReplayInlineAppender(db, segments, ridMap)
+	appender, err := newReplayInlineAppenderWithNextRID(db, segments, nextRID)
 	if err != nil {
 		return err
 	}

--- a/TreeDB/db/wal_recovery.go
+++ b/TreeDB/db/wal_recovery.go
@@ -728,8 +728,24 @@ type replayInlineAppender struct {
 }
 
 func newReplayInlineAppender(db *DB, segments []logSegment, ridMap map[uint64]page.ValuePtr) (*replayInlineAppender, error) {
+	var maxRID uint64
+	for rid := range ridMap {
+		if rid > maxRID {
+			maxRID = rid
+		}
+	}
+	if maxRID == ^uint64(0) {
+		return nil, fmt.Errorf("value-log rid space exhausted")
+	}
+	return newReplayInlineAppenderWithNextRID(db, segments, maxRID+1)
+}
+
+func newReplayInlineAppenderWithNextRID(db *DB, segments []logSegment, nextRID uint64) (*replayInlineAppender, error) {
 	if db == nil {
 		return nil, fmt.Errorf("missing db")
+	}
+	if nextRID == 0 {
+		return nil, fmt.Errorf("value-log rid space exhausted")
 	}
 	var maxLane0Seq uint32
 	for _, seg := range segments {
@@ -742,15 +758,6 @@ func newReplayInlineAppender(db *DB, segments []logSegment, ridMap map[uint64]pa
 			}
 			maxLane0Seq = uint32(seg.seq)
 		}
-	}
-	var maxRID uint64
-	for rid := range ridMap {
-		if rid > maxRID {
-			maxRID = rid
-		}
-	}
-	if maxRID == ^uint64(0) {
-		return nil, fmt.Errorf("value-log rid space exhausted")
 	}
 	maxSegmentBytes := int64(0)
 	if db.indexPackedValuePtr || db.indexOuterLeavesInValueLog {
@@ -767,8 +774,57 @@ func newReplayInlineAppender(db *DB, segments []logSegment, ridMap map[uint64]pa
 	return &replayInlineAppender{
 		db:      db,
 		writer:  writer,
-		nextRID: maxRID + 1,
+		nextRID: nextRID,
 	}, nil
+}
+
+func nextReplayAppenderRIDStart(segments []logSegment) (uint64, error) {
+	// RIDs are allocated from one monotonically increasing namespace. The appender
+	// only needs the high-water mark, so scan the latest value-log segment in each
+	// lane instead of rebuilding a full RID->pointer map from every segment.
+	latest := latestValueLogSegmentsByLane(segments)
+	if len(latest) == 0 {
+		return 1, nil
+	}
+	maxRID := uint64(0)
+	for i := range latest {
+		seg := &latest[i]
+		segMaxRID, err := scanValueLogFileMaxRID(&valuelog.File{ID: seg.fileID, Path: seg.path})
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			return 0, err
+		}
+		if segMaxRID > maxRID {
+			maxRID = segMaxRID
+		}
+	}
+	if maxRID == ^uint64(0) {
+		return 0, fmt.Errorf("value-log rid space exhausted")
+	}
+	return maxRID + 1, nil
+}
+
+func latestValueLogSegmentsByLane(segments []logSegment) []logSegment {
+	latestByLane := make(map[int]logSegment)
+	for _, seg := range segments {
+		if !seg.valueLog {
+			continue
+		}
+		cur, ok := latestByLane[seg.lane]
+		if !ok || seg.seq > cur.seq {
+			latestByLane[seg.lane] = seg
+		}
+	}
+	latest := make([]logSegment, 0, len(latestByLane))
+	for _, seg := range latestByLane {
+		latest = append(latest, seg)
+	}
+	sort.Slice(latest, func(i, j int) bool {
+		return latest[i].lane < latest[j].lane
+	})
+	return latest
 }
 
 func (a *replayInlineAppender) append(value []byte) (page.ValuePtr, error) {

--- a/TreeDB/db/wal_recovery_test.go
+++ b/TreeDB/db/wal_recovery_test.go
@@ -12,6 +12,62 @@ import (
 	"github.com/snissn/gomap/TreeDB/page"
 )
 
+func TestNextReplayAppenderRIDStartScansLatestValueLogSegmentPerLane(t *testing.T) {
+	dir := t.TempDir()
+	older := writeRIDStartValueLogSegment(t, dir, 2, 1, 10)
+	latest := writeRIDStartValueLogSegment(t, dir, 2, 2, 200)
+	leafLatest := writeRIDStartValueLogSegment(t, dir, rewriteLeafLogLaneID, 1, 150)
+	ignoredCommit := logSegment{lane: 2, seq: 99, path: filepath.Join(dir, "commit.log")}
+
+	gotLatest := latestValueLogSegmentsByLane([]logSegment{older, latest, leafLatest, ignoredCommit})
+	if len(gotLatest) != 2 {
+		t.Fatalf("latest segments len=%d want 2", len(gotLatest))
+	}
+	if gotLatest[0].lane != 2 || gotLatest[0].seq != 2 {
+		t.Fatalf("lane 2 latest=%+v want seq 2", gotLatest[0])
+	}
+	if gotLatest[1].lane != int(rewriteLeafLogLaneID) || gotLatest[1].seq != 1 {
+		t.Fatalf("leaf lane latest=%+v want seq 1", gotLatest[1])
+	}
+
+	next, err := nextReplayAppenderRIDStart([]logSegment{older, latest, leafLatest, ignoredCommit})
+	if err != nil {
+		t.Fatalf("nextReplayAppenderRIDStart: %v", err)
+	}
+	if next != 201 {
+		t.Fatalf("next RID=%d want 201", next)
+	}
+}
+
+func writeRIDStartValueLogSegment(t *testing.T, dir string, lane uint32, seq uint32, maxRID uint64) logSegment {
+	t.Helper()
+	fileID, err := valuelog.EncodeFileID(lane, seq)
+	if err != nil {
+		t.Fatalf("fileID: %v", err)
+	}
+	path := valueLogSegmentPath(t, dir, fileID)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir segment dir: %v", err)
+	}
+	w, err := valuelog.NewWriter(path, fileID)
+	if err != nil {
+		t.Fatalf("writer: %v", err)
+	}
+	for _, rid := range []uint64{maxRID - 1, maxRID} {
+		if _, err := w.Append(0, nil, rid, []byte("value")); err != nil {
+			t.Fatalf("append rid %d: %v", rid, err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close writer: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat segment: %v", err)
+	}
+	return logSegment{lane: int(lane), seq: uint64(seq), path: path, size: info.Size(), valueLog: true, fileID: fileID}
+}
+
 func TestNewReplayInlineAppender_PackedValuePtrCapsSegmentSize(t *testing.T) {
 	db := &DB{
 		dir:                 t.TempDir(),


### PR DESCRIPTION
## Summary
- avoid building a full value-log RID map when installing the command-WAL value-log appender
- seed the appender RID allocator by scanning only the latest value-log segment in each lane
- keep full RID-map scans for actual WAL replay/fence resolution where the map is required

## Context
After disabling the eager outer-leaf ref tracker, Sepolia reopen profiling moved the remaining startup cost to `db.scanValueLogSegments` from `installCommandWALValueLogAppender`. At that point no RID map is needed; the appender only needs a safe next RID and segment sequence high-water marks. RIDs are allocated from a monotonic namespace, so the high-water mark can be obtained from the newest segment per lane instead of scanning every value-log segment.

## Tests
- `go test ./TreeDB/db -run 'TestNextReplayAppenderRIDStartScansLatestValueLogSegmentPerLane|TestNewReplayInlineAppender|TestValueLogRefTracker_DisabledForOuterLeavesSkipsStaleMetadata' -count=1`
- `go test ./TreeDB/db -count=1`
- `go test ./TreeDB/... -count=1`
- `(cd TreeDB/integration/gethethdb && go test ./... -count=1)`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized database recovery initialization for improved efficiency.

* **Tests**
  * Added test coverage for database recovery validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->