### PR TITLE
TreeDB/caching: scan tail segments for RID start

### DIFF
--- a/TreeDB/caching/db.go
+++ b/TreeDB/caching/db.go
@@ -10220,8 +10220,10 @@ func Open(dir string, backend BackendDB, opts Options) (*DB, error) {
 	segments, _ := listNonEmptySplitLogSegments(walDir, valueLogDir, leafLogDir)
 	reserveLeafLogLane := opts.IndexOuterLeavesInValueLog
 	// Cached value-log RIDs remain globally unique across reopen/rewrite cycles.
-	// Until we persist nextRID separately, opening must recover the max on-disk
-	// RID here rather than risk reusing low RIDs after a clean reopen.
+	// RID allocation is monotonic, so each lane's latest non-empty value-log
+	// segment contains that lane's high-watermark. Scanning only those tail
+	// segments avoids a full value-log pass during clean geth restarts while still
+	// seeding the allocator above every valid on-disk RID produced by this path.
 	maxExistingRID, err := maxValueLogRIDFromSegments(segments)
 	if err != nil {
 		return nil, err
@@ -31505,7 +31507,7 @@ func listNonEmptySplitLogSegments(walDir, valueLogDir, leafLogDir string) (segme
 
 func maxValueLogRIDFromSegments(segments []logSegmentInfo) (uint64, error) {
 	var maxRID uint64
-	for _, seg := range segments {
+	for _, seg := range tailValueLogSegmentsByLane(segments) {
 		if !seg.valueLog || seg.size <= 0 || seg.lane < 0 || seg.seq < 0 {
 			continue
 		}

--- a/TreeDB/caching/db_test.go
+++ b/TreeDB/caching/db_test.go
@@ -163,7 +163,7 @@ func TestTailValueLogSegmentsByLane(t *testing.T) {
 	}
 }
 
-func TestOpenSeedsRIDFromAllValueLogSegments(t *testing.T) {
+func TestOpenSeedsRIDFromTailValueLogSegments(t *testing.T) {
 	dir := t.TempDir()
 	valueDir := filepath.Join(dir, "value_vlog")
 	if err := os.MkdirAll(valueDir, 0o700); err != nil {
@@ -190,10 +190,11 @@ func TestOpenSeedsRIDFromAllValueLogSegments(t *testing.T) {
 		}
 	}
 
-	// Older segment contains a higher RID than the newest segment.
+	// RID allocation is monotonic, so Open only needs the newest non-empty
+	// segment in each lane to recover the allocator high-watermark.
 	const expectedMaxRID = uint64(100)
-	writeSegment(1, expectedMaxRID)
-	writeSegment(2, 10)
+	writeSegment(1, 10)
+	writeSegment(2, expectedMaxRID)
 
 	backend := NewMockBackend()
 	db, err := Open(dir, backend, Options{

--- a/TreeDB/caching/vlog_segment_scan_test.go
+++ b/TreeDB/caching/vlog_segment_scan_test.go
@@ -4,7 +4,36 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/snissn/gomap/TreeDB/internal/valuelog"
 )
+
+func TestMaxValueLogRIDFromSegmentsScansLatestSegmentPerLane(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	oldCorruptPath := filepath.Join(dir, valueLogName(0, 1))
+	if err := os.WriteFile(oldCorruptPath, []byte{0x01}, 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	lane0Tail := writeRIDValueLogSegment(t, dir, 0, 2, 22)
+	lane1Tail := writeRIDValueLogSegment(t, dir, 1, 1, 33)
+
+	segments := []logSegmentInfo{
+		{path: oldCorruptPath, size: 1, seq: 1, lane: 0, valueLog: true},
+		{path: lane0Tail, size: fileSize(t, lane0Tail), seq: 2, lane: 0, valueLog: true},
+		{path: lane1Tail, size: fileSize(t, lane1Tail), seq: 1, lane: 1, valueLog: true},
+		{path: filepath.Join(dir, commitLogName(9, 9)), size: 128, seq: 9, lane: 9, valueLog: false},
+	}
+
+	maxRID, err := maxValueLogRIDFromSegments(segments)
+	if err != nil {
+		t.Fatalf("maxValueLogRIDFromSegments: %v", err)
+	}
+	if maxRID != 33 {
+		t.Fatalf("maxRID=%d want 33", maxRID)
+	}
+}
 
 func TestMaxValueLogRIDFromSegments_IgnoresSegmentRemovedAfterScan(t *testing.T) {
 	t.Parallel()
@@ -30,4 +59,34 @@ func TestMaxValueLogRIDFromSegments_IgnoresSegmentRemovedAfterScan(t *testing.T)
 	if maxRID != 0 {
 		t.Fatalf("maxRID=%d want 0", maxRID)
 	}
+}
+
+func writeRIDValueLogSegment(t testing.TB, dir string, lane, seq int, rid uint64) string {
+	t.Helper()
+	fileID, err := valuelog.EncodeFileID(uint32(lane), uint32(seq))
+	if err != nil {
+		t.Fatalf("EncodeFileID: %v", err)
+	}
+	path := filepath.Join(dir, valueLogName(lane, seq))
+	w, err := valuelog.NewWriter(path, fileID)
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	if _, err := w.Append(0, nil, rid, []byte("value")); err != nil {
+		_ = w.Close()
+		t.Fatalf("Append: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	return path
+}
+
+func fileSize(t testing.TB, path string) int64 {
+	t.Helper()
+	st, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	return st.Size()
 }


### PR DESCRIPTION
## Summary

- Seed cached-mode value-log RID allocation by scanning only the latest non-empty value-log segment per lane.
- Add coverage that corrupt older segments are not read when a newer tail segment exists.
- Update the cached open RID-seeding test to match the monotonic RID allocation invariant.

## Why

After snissn/gomap#2614 removed the command-WAL appender's full RID-map scan, geth TreeDB reopen profiling still showed startup blocked in `caching.maxValueLogRIDFromSegments` reading every value-log segment before `Opened ancient database`.

Cached-mode RIDs are allocated monotonically from a shared high-watermark, including rewrite/leaf-log paths via `ReserveValueLogRIDs`, so each lane's latest non-empty segment carries that lane's high RID. Scanning only those tails avoids the clean-reopen full value-log pass while preserving the allocator high-watermark for DBs produced by the current cached path.

## Validation

- `go test ./TreeDB/caching -run 'Test(OpenSeedsRIDFromTailValueLogSegments|MaxValueLogRIDFromSegments|TailValueLogSegmentsByLane|ReserveValueLogRIDs)' -count=1`
- `go test ./TreeDB/caching -count=1`
- `go test ./TreeDB/collections -run TestColumnPhysicalQ4BTopKSortedLatestVisibleMutation1953 -count=1 -v` (reran after an unrelated one-off failure in the full suite)
- `go test ./TreeDB/... -count=1`
- `(cd TreeDB/integration/gethethdb && go test ./... -count=1)`

## Remote evidence motivating this PR

- go-ethereum PR #5 with gomap#2614: `/mnt/fast4tb/tmp/geth-treedb-exp/reopen_pr5_rid_start_pass1_20260611T173831Z`
- Result: `pprof_ready_seconds=1`, `rpc_ready_seconds=101`.
- Startup CPU profile: `caching.maxValueLogRIDFromSegments` / `valuelog.Reader.ReadNextMeta` accounted for ~92% cumulative CPU in the first 20s, confirming this is the remaining full value-log scan.
